### PR TITLE
修正了FAT32判断逻辑，解决了文件系统为FAT12/16时系统无法正常启动的问题。

### DIFF
--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -244,6 +244,13 @@ impl FileSystem for FATFileSystem {
 }
 
 impl FATFileSystem {
+    /// FAT12允许的最大簇号
+    pub const FAT12_MAX_CLUSTER: u32 = 0xFF5;
+    /// FAT16允许的最大簇号
+    pub const FAT16_MAX_CLUSTER: u32 = 0xFFF5;
+    /// FAT32允许的最大簇号
+    pub const FAT32_MAX_CLUSTER: u32 = 0x0FFFFFF7;
+
     pub fn new(partition: Arc<Partition>) -> Result<Arc<FATFileSystem>, i32> {
         let bpb = BiosParameterBlock::new(partition.clone())?;
 


### PR DESCRIPTION
# Crash

https://github.com/DragonOS-Community/DragonOS/blob/45b8371173b070028457f7ee64be33f68b4f9ada/kernel/src/filesystem/fat/bpb.rs#L366

此处条件判断并不能有效区分FAT32和FAT12/16，导致了如果文件系统是FAT12/16的话， `validate()` 中的判断会走到 `kerror()`。

# Fix

- 我所知的使用广泛的FAT类型的判断方法是根据簇的数量确定的。所以这里改成通过簇数确定FAT32还是FAT12/16。
- 另外将 `validate()` 往后移了，等到所有字段加载好了、FAT类型也判断好后再检查FAT32的BPB是否正确。

# Reference

- [FAT Filesystem](http://elm-chan.org/docs/fat_e.html#fat_determination)
- [Microsoft FAT Specification](https://academy.cba.mit.edu/classes/networking_communications/SD/FAT.pdf)