### PR TITLE
容器中设置了CARGO_HOME以留下依赖包的缓存

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -19,7 +19,7 @@ RUN sed -i "s@http://\(deb\|security\).debian.org@http://mirrors.ustc.edu.cn@g" 
     gnupg \
     lsb-release \
     llvm-dev libclang-dev clang gcc-multilib \
-    gcc build-essential fdisk dosfstools qemu-kvm \
+    gcc build-essential fdisk dosfstools \
     sudo wget
 
 # 安装Rust
@@ -49,5 +49,6 @@ RUN apt-get autoremove -q -y && \
     rm -rf /build-image
 
 ENV DragonOS_GCC=/root/opt/dragonos-gcc/gcc-x86_64-unknown-none/bin/
+ENV CARGO_HOME=/data/.cargo
 # 设置容器启动后执行的命令
 CMD ["/bin/bash"]


### PR DESCRIPTION
主要的修改：

- 容器中设置 `CARGO_HOME` 默认为 `/data/.cargo`。
  - 因为源代码挂载在 `/data`，所以这样可以将下载的依赖保存下来。
- 去掉 `qemu-kvm` 包，减少 docker 镜像约 700M 体积。
  - 因为看起来并不支持容器中使用qemu，且其附带下载 `X11` 组件，占用比较大

PS：`sudo` 实际上也有些多余，因为容器中已经是 root 权限了。不过它占用空间很小，脚本中多次使用它，修改麻烦就留着了。