### PR TITLE
添加dadk支持

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -44,7 +44,7 @@ jobs:
     - if: ${{ steps.cache-build-tools.outputs.cache-hit != 'true' }}
       name: Install toolchain
       continue-on-error: true
-      run:  sudo apt install -y llvm-dev libclang-dev clang gcc-multilib && cargo install cargo-binutils && rustup toolchain install nightly && rustup default nightly && rustup component add rust-src && rustup component add llvm-tools-preview && rustup target add x86_64-unknown-none && rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+      run:  sudo apt install -y llvm-dev libclang-dev clang gcc-multilib && cargo install cargo-binutils && rustup toolchain install nightly && rustup default nightly && rustup component add rust-src && rustup component add llvm-tools-preview && rustup target add x86_64-unknown-none && rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu && cargo install --git https://github.com/DragonOS-Community/DADK.git
     
     - name: build the DragonOS
       run: bash -c "source ~/.cargo/env && export DragonOS_GCC=$HOME/opt/dragonos-gcc/gcc-x86_64-unknown-none/bin && make -j $(nproc) "

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -123,7 +123,7 @@ rustInstall() {
 		echo "curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly"
 		exit
 	else
-        echo "是否为Rust换源为Gitee镜像源？"
+        echo "是否为Rust换源为国内镜像源？(Tuna)"
 		echo "如果您在国内，我们推荐您这样做，以提升网络速度。"
 		echo "*WARNING* 这将会替换原有的镜像源设置。"
 		printf "(y/N): "
@@ -141,6 +141,7 @@ rustInstall() {
         rustup component add rust-src
         rustup component add llvm-tools-preview
 		rustup target add x86_64-unknown-none
+		cargo install dadk
 		echo "Rust已经成功的在您的计算机上安装！请运行 source ~/.cargo/env 以使rust在当前窗口生效！"
 	fi
 }

--- a/tools/change_rust_src.sh
+++ b/tools/change_rust_src.sh
@@ -2,7 +2,7 @@
 echo -e "[source.crates-io]   \n \
 registry = \"https://github.com/rust-lang/crates.io-index\"  \n \
 \n \
-replace-with = 'dragonos-gitee' \n \
-[source.dragonos-gitee] \n \
-registry = \"https://gitee.com/DragonOS/crates.io-index.git\"	 \n \
+replace-with = 'tuna' \n \
+[source.tuna] \n \
+registry = \"https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git\"	 \n \
 " > ~/.cargo/config

--- a/tools/write_disk_image.sh
+++ b/tools/write_disk_image.sh
@@ -90,7 +90,7 @@ mkdir -p ${root_folder}/bin/disk_mount/proc
 mkdir -p ${root_folder}/bin/disk_mount/usr
 cp -r ${root_folder}/bin/user/* ${root_folder}/bin/disk_mount/bin
 touch ${root_folder}/bin/disk_mount/dev/keyboard.dev
-cp -r ${root_folder}/bin/sysroot/usr/* ${root_folder}/bin/disk_mount/usr/ 
+cp -r ${root_folder}/bin/sysroot/* ${root_folder}/bin/disk_mount/
 
 # 设置 grub 相关数据
 if [ ${ARCH} == "i386" ] || [ ${ARCH} == "x86_64" ]; then

--- a/user/Makefile
+++ b/user/Makefile
@@ -2,7 +2,7 @@ user_sub_dirs = apps
 
 SUBDIR_ROOTS := . 
 DIRS := . $(shell find $(SUBDIR_ROOTS) -type d)
-GARBAGE_PATTERNS := *.o *.s~ *.s *.S~ *.c~ *.h~ sys_api_lib *.a
+GARBAGE_PATTERNS := *.o sys_api_lib *.a
 GARBAGE := $(foreach DIR,$(DIRS),$(addprefix $(DIR)/,$(GARBAGE_PATTERNS)))
 
 

--- a/user/Makefile
+++ b/user/Makefile
@@ -12,16 +12,50 @@ output_dir=$(ROOT_PATH)/bin/user
 CFLAGS := $(GLOBAL_CFLAGS) -I $(shell pwd)/libs -I $(shell pwd)/libs/libc/src/include -I $(shell pwd)/libs/libc/src/include/export
 current_CFLAGS := $(CFLAGS)
 
+DADK_VERSION = $(shell dadk -V | awk 'END {print $2}')
+# 最小的DADK版本
+MIN_DADK_VERSION = 0.1.1
+DADK_CACHE_DIR = $(ROOT_PATH)/bin/dadk_cache
+
+# 旧版的libc安装路径
+OLD_LIBC_INSTALL_PATH=$(ROOT_PATH)/bin/sysroot/usr/old_libc
+
 ECHO:
 	@echo "$@"
 
-$(user_sub_dirs): ECHO sys_api_lib
+
+install_dadk:
+# 如果未安装
+ifeq ("$(DADK_VERSION)", "")
+	@echo "\ndadk is not installed."
+	@echo "Please install dadk $(MIN_DADK_VERSION) or higher version"
+	@echo "\nYou can install dadk by running the following command:"
+	@echo "\n\tcargo install dadk"
+	@echo "\nOr you can install dadk from source by running the following command:"
+	@echo "\n\tcargo install --git https://github.com/DragonOS-Community/DADK.git"
+	@echo "\n"
+	@exit 1
+else
+	@echo "dadk version $(DADK_VERSION) installed"
+endif
+
+dadk_run: install_dadk
+	mkdir -p $(DADK_CACHE_DIR)
+# 之所以在这里临时设置ARCH为空，是因为如果要设置这个环境变量，应当在DADK的配置文件中设置
+	ARCH= dadk --config-dir dadk/config --cache-dir $(DADK_CACHE_DIR) --dragonos-dir $(ROOT_PATH)/bin/sysroot build
+	ARCH= dadk --config-dir dadk/config --cache-dir $(DADK_CACHE_DIR) --dragonos-dir $(ROOT_PATH)/bin/sysroot install
+
+dadk_clean: install_dadk
+	dadk --config-dir dadk/config --cache-dir $(DADK_CACHE_DIR) --dragonos-dir $(ROOT_PATH)/bin/sysroot clean
+
+$(user_sub_dirs): ECHO sys_api_lib 
 
 	$(MAKE) -C $@ all CFLAGS="$(CFLAGS)" tmp_output_dir="$(tmp_output_dir)" output_dir="$(output_dir)" sys_libs_dir="$(shell pwd)/libs"
-	
-app: $(user_sub_dirs)
 
-all: app
+app: $(user_sub_dirs)
+	$(MAKE) dadk_run 
+
+all: install_dadk app
 
 	$(shell if [ ! -e $(tmp_output_dir) ];then mkdir -p $(tmp_output_dir); fi)
 	$(shell if [ ! -e $(output_dir) ];then mkdir -p $(output_dir); fi)
@@ -47,15 +81,18 @@ sys_api_lib: sys_api_lib_stage_1
 
 # 打包系统库
 	mkdir -p $(ROOT_PATH)/bin/tmp/user/sys_api_lib_build_tmp
+	mkdir -p $(OLD_LIBC_INSTALL_PATH)/include
+	mkdir -p $(OLD_LIBC_INSTALL_PATH)/lib
 	$(AR) x $(ROOT_PATH)/user/libs/libc/target/x86_64-unknown-none/release/liblibc.a --output=$(ROOT_PATH)/bin/tmp/user/sys_api_lib_build_tmp 
-	$(AR) crvs $(ROOT_PATH)/bin/sysroot/usr/lib/libc.a $(shell find ./libs/* -name "*.o") $(shell find $(ROOT_PATH)/bin/tmp/user/sys_api_lib_build_tmp/* -name "*.o")
+	$(AR) crvs $(OLD_LIBC_INSTALL_PATH)/lib/libc.a $(shell find ./libs/* -name "*.o") $(shell find $(ROOT_PATH)/bin/tmp/user/sys_api_lib_build_tmp/* -name "*.o")
 	rm -rf $(ROOT_PATH)/bin/tmp/user/sys_api_lib_build_tmp
 # $(shell find ./libs/* -name "*.o" | xargs -I {} cp {} $(ROOT_PATH)/bin/sysroot/usr/lib/)
-	$(shell cp -r $(ROOT_PATH)/user/libs/libc/src/include/export/* $(ROOT_PATH)/bin/sysroot/usr/include/)
-	$(shell cp -r $(ROOT_PATH)/user/libs/libc/src/arch/x86_64/c*.o $(ROOT_PATH)/bin/sysroot/usr/lib/)
+	$(shell cp -r $(ROOT_PATH)/user/libs/libc/src/include/export/* $(OLD_LIBC_INSTALL_PATH)/include/)
+	$(shell cp -r $(ROOT_PATH)/user/libs/libc/src/arch/x86_64/c*.o $(OLD_LIBC_INSTALL_PATH)/lib/)
 
 clean: 
 	rm -rf $(GARBAGE)
+	$(MAKE) dadk_clean
 	$(MAKE) clean -C libs
 	@list='$(user_sub_dirs)'; for subdir in $$list; do \
 		echo "Clean in dir: $$subdir";\

--- a/user/apps/about/Makefile
+++ b/user/apps/about/Makefile
@@ -1,9 +1,11 @@
+OLD_LIBC_INSTALL_PATH=$(ROOT_PATH)/bin/sysroot/usr/old_libc
+
 # 获得当前git提交的sha1,并截取前8位
 GIT_COMMIT_SHA1=$(shell git log -n 1 | head -n 1 | cut -d ' ' -f 2 | cut -c1-8)
 
 all: about.o
 
-	$(LD) -b elf64-x86-64 -z muldefs -o $(tmp_output_dir)/about  $(shell find . -name "*.o") $(ROOT_PATH)/bin/sysroot/usr/lib/libc.a -T about.lds
+	$(LD) -b elf64-x86-64 -z muldefs -o $(tmp_output_dir)/about  $(shell find . -name "*.o") $(OLD_LIBC_INSTALL_PATH)/lib/libc.a -T about.lds
 
 	$(OBJCOPY) -I elf64-x86-64 -R ".eh_frame" -R ".comment" -O elf64-x86-64 $(tmp_output_dir)/about $(output_dir)/about.elf
 

--- a/user/apps/shell/Makefile
+++ b/user/apps/shell/Makefile
@@ -1,6 +1,8 @@
+OLD_LIBC_INSTALL_PATH=$(ROOT_PATH)/bin/sysroot/usr/old_libc
+
 all: shell.o cmd.o cmd_help.o cmd_test.o
 
-	$(LD) -b elf64-x86-64 -z muldefs -o $(tmp_output_dir)/shell  $(shell find . -name "*.o") $(ROOT_PATH)/bin/sysroot/usr/lib/libc.a -T shell.lds
+	$(LD) -b elf64-x86-64 -z muldefs -o $(tmp_output_dir)/shell  $(shell find . -name "*.o") $(OLD_LIBC_INSTALL_PATH)/lib/libc.a -T shell.lds
 
 	$(OBJCOPY) -I elf64-x86-64 -R ".eh_frame" -R ".comment" -O elf64-x86-64 $(tmp_output_dir)/shell $(output_dir)/shell.elf
 shell.o: shell.c

--- a/user/apps/test_relibc/Makefile
+++ b/user/apps/test_relibc/Makefile
@@ -1,6 +1,6 @@
-CC=x86_64-elf-gcc
-LD=x86_64-elf-ld
-OBJCOPY=x86_64-dragonos-objcopy
+CC=$(DragonOS_GCC)/x86_64-elf-gcc
+LD=ld
+OBJCOPY=objcopy
 # 修改这里，把它改为你的relibc的sysroot路径
 RELIBC_OPT=$(DADK_BUILD_CACHE_DIR_RELIBC_0_1_0)
 CFLAGS=-I $(RELIBC_OPT)/include

--- a/user/apps/test_relibc/Makefile
+++ b/user/apps/test_relibc/Makefile
@@ -2,20 +2,23 @@ CC=x86_64-elf-gcc
 LD=x86_64-elf-ld
 OBJCOPY=x86_64-dragonos-objcopy
 # 修改这里，把它改为你的relibc的sysroot路径
-RELIBC_SYSROOT=/home/longjin/relibc/sysroot
-CFLAGS=-I $(RELIBC_SYSROOT)/usr/include
-# 修改这里，把它改为你的DragonOS的根目录
-ROOT_PATH=/home/longjin/code/DragonOS
-tmp_output_dir=$(ROOT_PATH)/bin/tmp/user
-output_dir=$(ROOT_PATH)/bin/user
+RELIBC_OPT=$(DADK_BUILD_CACHE_DIR_RELIBC_0_1_0)
+CFLAGS=-I $(RELIBC_OPT)/include
 
-LIBC_OBJS:=$(shell find $(RELIBC_SYSROOT)/usr/lib -name "*.o")
-LIBC_OBJS+=$(RELIBC_SYSROOT)/usr/lib/libc.a
+tmp_output_dir=$(ROOT_PATH)/bin/tmp/user
+output_dir=$(DADK_BUILD_CACHE_DIR_TEST_RELIBC_0_1_0)
+
+LIBC_OBJS:=$(shell find $(RELIBC_OPT)/lib -name "*.o")
+LIBC_OBJS+=$(RELIBC_OPT)/lib/libc.a
 
 all: main.o
-
+	mkdir -p $(tmp_output_dir)
+	
 	$(LD) -b elf64-x86-64 -z muldefs -o $(tmp_output_dir)/test  $(shell find . -name "*.o") $(LIBC_OBJS) -T link.lds
 
 	$(OBJCOPY) -I elf64-x86-64 -R ".eh_frame" -R ".comment" -O elf64-x86-64 $(tmp_output_dir)/test $(output_dir)/test.elf
 main.o: main.c
 	$(CC) $(CFLAGS) -c main.c  -o main.o
+
+clean:
+	rm -f *.o

--- a/user/apps/test_signal/Makefile
+++ b/user/apps/test_signal/Makefile
@@ -1,6 +1,8 @@
+OLD_LIBC_INSTALL_PATH=$(ROOT_PATH)/bin/sysroot/usr/old_libc
+
 all: main.o
 
-	$(LD) -b elf64-x86-64 -z muldefs -o $(tmp_output_dir)/test_signal  $(shell find . -name "*.o") $(ROOT_PATH)/bin/sysroot/usr/lib/libc.a -T link.lds
+	$(LD) -b elf64-x86-64 -z muldefs -o $(tmp_output_dir)/test_signal  $(shell find . -name "*.o") $(OLD_LIBC_INSTALL_PATH)/lib/libc.a -T link.lds
 
 	$(OBJCOPY) -I elf64-x86-64 -R ".eh_frame" -R ".comment" -O elf64-x86-64 $(tmp_output_dir)/test_signal $(output_dir)/test_signal.elf
 main.o: main.c

--- a/user/dadk/config/relibc-0.1.0.dadk
+++ b/user/dadk/config/relibc-0.1.0.dadk
@@ -13,7 +13,7 @@
   },
   "depends": [],
   "build": {
-    "build_command": "DESTDIR=$DADK_BUILD_CACHE_DIR_RELIBC_0_1_0 make install -j $(nproc)"
+    "build_command": "bash init_dragonos_toolchain.sh && DESTDIR=$DADK_BUILD_CACHE_DIR_RELIBC_0_1_0 make install -j $(nproc)"
   },
   "install": {
     "in_dragonos_path": "/usr"

--- a/user/dadk/config/relibc-0.1.0.dadk
+++ b/user/dadk/config/relibc-0.1.0.dadk
@@ -1,0 +1,30 @@
+{
+  "name": "relibc",
+  "version": "0.1.0",
+  "description": "从GitHub克隆最新的relibc来编译",
+  "task_type": {
+    "BuildFromSource": {
+      "Git": {
+        "url": "https://github.com/DragonOS-Community/relibc.git",
+        "branch": "dragonos-relibc",
+        "revision": null
+      }
+    }
+  },
+  "depends": [],
+  "build": {
+    "build_command": "DESTDIR=$DADK_BUILD_CACHE_DIR_RELIBC_0_1_0 make install -j $(nproc)"
+  },
+  "install": {
+    "in_dragonos_path": "/usr"
+  },
+  "clean": {
+    "clean_command": "make clean"
+  },
+  "envs": [    
+    {
+      "key": "TARGET",
+      "value": "x86_64-unknown-dragonos"
+    }
+  ]
+}

--- a/user/dadk/config/test_relibc-0.1.0.dadk
+++ b/user/dadk/config/test_relibc-0.1.0.dadk
@@ -1,0 +1,28 @@
+{
+  "name": "test_relibc",
+  "version": "0.1.0",
+  "description": "一个用来测试relibc能够正常运行的app",
+  "task_type": {
+    "BuildFromSource": {
+      "Local": {
+        "path": "apps/test_relibc"
+      }
+    }
+  },
+  "depends": [
+    {
+      "name": "relibc",
+      "version": "0.1.0"
+    }
+  ],
+  "build": {
+    "build_command": "make"
+  },
+  "install": {
+    "in_dragonos_path": "/bin"
+  },
+  "clean": {
+    "clean_command": "make clean"
+  },
+  "envs": []
+}


### PR DESCRIPTION
- 引入dadk，使用dadk0.1.1来编译test-relibc程序
- 由于gitee仓库体积限制导致无法继续使用gitee上的rust索引，因此更换为清华源

**编译之前，需要手动删除`bin/sysroot`文件夹，否则会由于之前的数据存在，导致冲突**

编译之前，需要先运行`cargo install dadk`安装DragonOS应用开发工具，否则编译时会报错。