### PR TITLE
修复读取stdin时，无法正常读取的问题。

### DIFF
--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -12,7 +12,7 @@ use crate::{
     include::bindings::bindings::{textui_putchar, BLACK, WHITE},
     kerror,
     libs::rwlock::RwLock,
-    syscall::SystemError,
+    syscall::SystemError, kdebug, arch::asm::current::current_pcb,
 };
 
 use super::{TtyCore, TtyError, TtyFileFlag, TtyFilePrivateData};
@@ -263,6 +263,7 @@ impl IndexNode for TtyDevice {
         }
         return Ok(());
     }
+
 }
 
 impl TtyDevicePrivateData {

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -173,9 +173,14 @@ impl File {
     ///
     /// @param origin 调整的起始位置
     pub fn lseek(&mut self, origin: SeekFrom) -> Result<usize, SystemError> {
-        if self.inode.metadata().unwrap().file_type == FileType::Pipe {
-            return Err(SystemError::ESPIPE);
+        let file_type = self.inode.metadata().unwrap().file_type;
+        match file_type {
+            FileType::Pipe | FileType::CharDevice => {
+                return Err(SystemError::ESPIPE);
+            }
+            _ => {}
         }
+        
         let pos: i64;
         match origin {
             SeekFrom::SeekSet(offset) => {


### PR DESCRIPTION
解决了以下两个问题：
- 读取stdin的时候，遇到回车、EOF不会自动返回
- 对字符设备进行seek操作，没有返回`ESPIPE`的bug