### PR TITLE
 替换 local_irq_save 为 IrqFlagsGuard 实现

### DIFF
--- a/kernel/src/arch/x86_64/fpu.rs
+++ b/kernel/src/arch/x86_64/fpu.rs
@@ -9,9 +9,10 @@ use core::{
 
 use alloc::boxed::Box;
 
-use crate::include::bindings::bindings::process_control_block;
+use crate::{exception::InterruptArch, include::bindings::bindings::process_control_block};
 
-use super::asm::irqflags::{local_irq_restore, local_irq_save};
+use crate::arch::CurrentIrqArch;
+
 /// https://www.felixcloutier.com/x86/fxsave#tbl-3-47
 #[repr(C, align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -79,7 +80,7 @@ impl FpState {
 /// @brief 从用户态进入内核时，保存浮点寄存器，并关闭浮点功能
 pub fn fp_state_save(pcb: &mut process_control_block) {
     // 该过程中不允许中断
-    let rflags: usize = local_irq_save();
+    let guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
 
     let fp: &mut FpState = if pcb.fp_state == null_mut() {
         let f = Box::leak(Box::new(FpState::default()));
@@ -111,13 +112,13 @@ pub fn fp_state_save(pcb: &mut process_control_block) {
                                 "mov cr4, rax" */
         )
     }
-    local_irq_restore(rflags);
+    drop(guard);
 }
 
 /// @brief 从内核态返回用户态时，恢复浮点寄存器，并开启浮点功能
 pub fn fp_state_restore(pcb: &mut process_control_block) {
     // 该过程中不允许中断
-    let rflags = local_irq_save();
+    let guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
 
     if pcb.fp_state == null_mut() {
         panic!("fp_state_restore: fp_state is null. pid={}", pcb.pid);
@@ -141,5 +142,5 @@ pub fn fp_state_restore(pcb: &mut process_control_block) {
     fp.restore();
     fp.clear();
 
-    local_irq_restore(rflags);
+    drop(guard);
 }

--- a/kernel/src/exception/softirq.rs
+++ b/kernel/src/exception/softirq.rs
@@ -10,13 +10,12 @@ use alloc::{boxed::Box, sync::Arc};
 use num_traits::FromPrimitive;
 
 use crate::{
+    arch::CurrentIrqArch,
     arch::{
-        asm::{
-            current::current_pcb,
-            irqflags::{local_irq_restore, local_irq_save},
-        },
+        asm::current::current_pcb,
         interrupt::{cli, sti},
     },
+    exception::InterruptArch,
     include::bindings::bindings::MAX_CPU_NUM,
     kdebug, kinfo,
     libs::rwlock::RwLock,
@@ -226,14 +225,14 @@ impl Softirq {
     }
 
     pub fn raise_softirq(&self, softirq_num: SoftirqNumber) {
-        let flags = local_irq_save();
+        let guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let processor_id = smp_get_processor_id() as usize;
 
         cpu_pending(processor_id).insert(VecStatus::from(softirq_num));
 
         compiler_fence(Ordering::SeqCst);
 
-        local_irq_restore(flags);
+        drop(guard);
         // kdebug!("raise_softirq exited");
     }
     pub unsafe fn clear_softirq_pending(&self, softirq_num: SoftirqNumber) {

--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -1118,7 +1118,8 @@ impl VMA {
         // kdebug!("VMA::zeroed: flusher dropped");
 
         // 清空这些内存
-        let virt_iter: VirtPageFrameIter = VirtPageFrameIter::new(destination, destination.add(page_count));
+        let virt_iter: VirtPageFrameIter =
+            VirtPageFrameIter::new(destination, destination.add(page_count));
         for frame in virt_iter {
             let paddr = mapper.translate(frame.virt_address()).unwrap().0;
 


### PR DESCRIPTION
把除了自旋锁中的 local_irq_save 替换为了 IrqFlagsGuard。自旋锁和 _do_irqsoft 中的cli、sti没有替换