### PR TITLE
1. 修复bootstrap.sh在安装libssl-dev之前，安装dadk，从而导致错误的问题

### DIFF
--- a/docs/introduction/build_system.md
+++ b/docs/introduction/build_system.md
@@ -241,4 +241,6 @@ make run-docker
 
 :::{note}
 如果您需要在vnc中运行DragonOS，请在上述命令后加上`-vnc`后缀。如：`make run-vnc`
+
+qemu虚拟机将在5900端口监听vnc连接。您可以使用vnc viewer或者Remmina连接至qemu虚拟机。
 :::

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -142,7 +142,7 @@ rustInstall() {
 		rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
         rustup component add llvm-tools-preview
 		rustup target add x86_64-unknown-none
-		cargo install dadk
+		
 		echo "Rust已经成功的在您的计算机上安装！请运行 source ~/.cargo/env 以使rust在当前窗口生效！"
 	fi
 }
@@ -205,6 +205,9 @@ else
     	printf "\e[31;1mFatal error: \e[0;31mUnsupported platform, please open an issue\[0m" || exit 1
 	fi
 fi
+
+# 安装dadk
+cargo install dadk || exit 1
 
 # 创建磁盘镜像
 bash create_hdd_image.sh


### PR DESCRIPTION
1. 修复bootstrap.sh在安装libssl-dev之前，安装dadk，从而导致错误的问题
2. 构建系统的文档，补充对vnc端口的说明