### PR TITLE
修改RamFS目前存在的BUG

### DIFF
--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -114,6 +114,29 @@ impl RamFS {
 }
 
 impl IndexNode for LockedRamFSInode {
+    fn truncate(&self, _len: usize) -> Result<(), SystemError> {
+        let mut inode = self.0.lock();
+
+        //如果是文件夹，则报错
+        if inode.metadata.file_type == FileType::Dir {
+            return Err(SystemError::EINVAL);
+        }
+
+        //当前文件长度大于_len才进行截断，否则不操作
+        if inode.data.len() > _len {
+            inode.data.resize(_len, 0);
+        }
+        return Ok(());
+    }
+
+    fn close(&self, _data: &mut FilePrivateData) -> Result<(), SystemError> {
+        return Ok(());
+    }
+
+    fn open(&self, _data: &mut FilePrivateData, _mode: &super::vfs::file::FileMode) -> Result<(), SystemError> {
+        return Ok(());
+    }
+
     fn read_at(
         &self,
         offset: usize,

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -114,7 +114,7 @@ impl RamFS {
 }
 
 impl IndexNode for LockedRamFSInode {
-    fn truncate(&self, _len: usize) -> Result<(), SystemError> {
+    fn truncate(&self, len: usize) -> Result<(), SystemError> {
         let mut inode = self.0.lock();
 
         //如果是文件夹，则报错
@@ -123,8 +123,8 @@ impl IndexNode for LockedRamFSInode {
         }
 
         //当前文件长度大于_len才进行截断，否则不操作
-        if inode.data.len() > _len {
-            inode.data.resize(_len, 0);
+        if inode.data.len() > len {
+            inode.data.resize(len, 0);
         }
         return Ok(());
     }
@@ -133,7 +133,11 @@ impl IndexNode for LockedRamFSInode {
         return Ok(());
     }
 
-    fn open(&self, _data: &mut FilePrivateData, _mode: &super::vfs::file::FileMode) -> Result<(), SystemError> {
+    fn open(
+        &self,
+        _data: &mut FilePrivateData,
+        _mode: &super::vfs::file::FileMode,
+    ) -> Result<(), SystemError> {
         return Ok(());
     }
 


### PR DESCRIPTION
为LockedRamFSInode实现了IndexNode中的相应方法：

- close方法：解决使用shell中的ls命令时报错
- open方法：解决在内存文件系统中打开或者创建文件时报错；
- truncate方法：解决使用fopen函数创建或者打开文件时返回空指针；