### PR TITLE
Patch fix sched

### DIFF
--- a/kernel/src/driver/net/e1000e/e1000e_driver.rs
+++ b/kernel/src/driver/net/e1000e/e1000e_driver.rs
@@ -88,6 +88,7 @@ impl phy::TxToken for E1000ETxToken {
         let result = f(buffer.as_mut_slice());
         let mut device = self.driver.inner.lock();
         device.e1000e_transmit(buffer);
+        buffer.free_buffer();
         return result;
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -130,5 +130,4 @@ pub fn panic(info: &PanicInfo) -> ! {
 
     println!("Current PCB:\n\t{:?}", *(ProcessManager::current_pcb()));
     ProcessManager::exit(usize::MAX);
-    unreachable!();
 }

--- a/kernel/src/libs/rwlock.rs
+++ b/kernel/src/libs/rwlock.rs
@@ -44,6 +44,7 @@ pub struct RwLock<T> {
 pub struct RwLockReadGuard<'a, T: 'a> {
     data: *const T,
     lock: &'a AtomicU32,
+    irq_guard: Option<IrqFlagsGuard>,
 }
 
 /// @brief UPGRADED是介于READER和WRITER之间的一种锁,它可以升级为WRITER,
@@ -53,6 +54,7 @@ pub struct RwLockReadGuard<'a, T: 'a> {
 pub struct RwLockUpgradableGuard<'a, T: 'a> {
     data: *const T,
     inner: &'a RwLock<T>,
+    irq_guard: Option<IrqFlagsGuard>,
 }
 
 /// @brief WRITER守卫的数据结构
@@ -144,6 +146,7 @@ impl<T> RwLock<T> {
             return Some(RwLockReadGuard {
                 data: unsafe { &*self.data.get() },
                 lock: &self.lock,
+                irq_guard: None,
             });
         }
     }
@@ -158,6 +161,19 @@ impl<T> RwLock<T> {
                 None => spin_loop(),
             }
         } //忙等待
+    }
+
+    pub fn read_irqsave(&self) -> RwLockReadGuard<T> {
+        loop {
+            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+            match self.try_read() {
+                Some(mut guard) => {
+                    guard.irq_guard = Some(irq_guard);
+                    return guard;
+                }
+                None => spin_loop(),
+            }
+        }
     }
 
     #[allow(dead_code)]
@@ -256,6 +272,7 @@ impl<T> RwLock<T> {
             return Some(RwLockUpgradableGuard {
                 inner: self,
                 data: unsafe { &mut *self.data.get() },
+                irq_guard: None,
             });
         } else {
             return None;
@@ -269,6 +286,21 @@ impl<T> RwLock<T> {
         loop {
             match self.try_upgradeable_read() {
                 Some(guard) => return guard,
+                None => spin_loop(),
+            }
+        }
+    }
+
+    #[inline]
+    /// @brief 获得UPGRADER守卫
+    pub fn upgradeable_read_irqsave(&self) -> RwLockUpgradableGuard<T> {
+        loop {
+            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+            match self.try_upgradeable_read() {
+                Some(mut guard) => {
+                    guard.irq_guard = Some(irq_guard);
+                    return guard;
+                }
                 None => spin_loop(),
             }
         }
@@ -332,7 +364,7 @@ impl<'rwlock, T> RwLockUpgradableGuard<'rwlock, T> {
     #[allow(dead_code)]
     #[inline]
     /// @brief 尝试将UPGRADER守卫升级为WRITER守卫
-    pub fn try_upgrade(self) -> Result<RwLockWriteGuard<'rwlock, T>, Self> {
+    pub fn try_upgrade(mut self) -> Result<RwLockWriteGuard<'rwlock, T>, Self> {
         let res = self.inner.lock.compare_exchange(
             UPGRADED,
             WRITER,
@@ -343,13 +375,13 @@ impl<'rwlock, T> RwLockUpgradableGuard<'rwlock, T> {
 
         if res.is_ok() {
             let inner = self.inner;
-
+            let irq_guard = self.irq_guard.take();
             mem::forget(self);
 
             Ok(RwLockWriteGuard {
                 data: unsafe { &mut *inner.data.get() },
                 inner,
-                irq_guard: None,
+                irq_guard,
             })
         } else {
             Err(self)
@@ -373,19 +405,20 @@ impl<'rwlock, T> RwLockUpgradableGuard<'rwlock, T> {
     #[allow(dead_code)]
     #[inline]
     /// @brief UPGRADER降级为READER
-    pub fn downgrade(self) -> RwLockReadGuard<'rwlock, T> {
+    pub fn downgrade(mut self) -> RwLockReadGuard<'rwlock, T> {
         while self.inner.current_reader().is_err() {
             spin_loop();
         }
 
         let inner: &RwLock<T> = self.inner;
-
+        let irq_guard = self.irq_guard.take();
         // 自动移去UPGRADED比特位
         mem::drop(self);
 
         RwLockReadGuard {
             data: unsafe { &*inner.data.get() },
             lock: &inner.lock,
+            irq_guard,
         }
     }
 
@@ -426,26 +459,27 @@ impl<'rwlock, T> RwLockWriteGuard<'rwlock, T> {
     #[allow(dead_code)]
     #[inline]
     /// @brief 将WRITER降级为READER
-    pub fn downgrade(self) -> RwLockReadGuard<'rwlock, T> {
+    pub fn downgrade(mut self) -> RwLockReadGuard<'rwlock, T> {
         while self.inner.current_reader().is_err() {
             spin_loop();
         }
         //本质上来说绝对保证没有任何读者
 
         let inner = self.inner;
-
+        let irq_guard = self.irq_guard.take();
         mem::drop(self);
 
         return RwLockReadGuard {
             data: unsafe { &*inner.data.get() },
             lock: &inner.lock,
+            irq_guard,
         };
     }
 
     #[allow(dead_code)]
     #[inline]
     /// @brief 将WRITER降级为UPGRADER
-    pub fn downgrade_to_upgradeable(self) -> RwLockUpgradableGuard<'rwlock, T> {
+    pub fn downgrade_to_upgradeable(mut self) -> RwLockUpgradableGuard<'rwlock, T> {
         debug_assert_eq!(
             self.inner.lock.load(Ordering::Acquire) & (WRITER | UPGRADED),
             WRITER
@@ -455,11 +489,13 @@ impl<'rwlock, T> RwLockWriteGuard<'rwlock, T> {
 
         let inner = self.inner;
 
+        let irq_guard = self.irq_guard.take();
         mem::forget(self);
 
         return RwLockUpgradableGuard {
             inner,
             data: unsafe { &*inner.data.get() },
+            irq_guard,
         };
     }
 }

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -1144,6 +1144,10 @@ impl SocketInode {
     pub fn inner(&self) -> SpinLockGuard<Box<dyn Socket>> {
         return self.0.lock();
     }
+
+    pub unsafe fn inner_no_preempt(&self) -> SpinLockGuard<Box<dyn Socket>> {
+        return self.0.lock_no_preempt();
+    }
 }
 
 impl IndexNode for SocketInode {

--- a/kernel/src/net/socket.rs
+++ b/kernel/src/net/socket.rs
@@ -1177,7 +1177,7 @@ impl IndexNode for SocketInode {
         buf: &mut [u8],
         _data: &mut crate::filesystem::vfs::FilePrivateData,
     ) -> Result<usize, SystemError> {
-        return self.0.lock().read(&mut buf[0..len]).0;
+        return self.0.lock_no_preempt().read(&mut buf[0..len]).0;
     }
 
     fn write_at(
@@ -1187,7 +1187,7 @@ impl IndexNode for SocketInode {
         buf: &[u8],
         _data: &mut crate::filesystem::vfs::FilePrivateData,
     ) -> Result<usize, SystemError> {
-        return self.0.lock().write(&buf[0..len], None);
+        return self.0.lock_no_preempt().write(&buf[0..len], None);
     }
 
     fn poll(&self) -> Result<crate::filesystem::vfs::PollStatus, SystemError> {

--- a/kernel/src/net/syscall.rs
+++ b/kernel/src/net/syscall.rs
@@ -173,7 +173,7 @@ impl Syscall {
         let socket: Arc<SocketInode> = ProcessManager::current_pcb()
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
-        let mut socket = socket.inner();
+        let mut socket = unsafe { socket.inner_no_preempt() };
         // kdebug!("connect to {:?}...", endpoint);
         socket.connect(endpoint)?;
         return Ok(0);
@@ -191,7 +191,7 @@ impl Syscall {
         let socket: Arc<SocketInode> = ProcessManager::current_pcb()
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
-        let mut socket = socket.inner();
+        let mut socket = unsafe { socket.inner_no_preempt() };
         socket.bind(endpoint)?;
         return Ok(0);
     }
@@ -221,7 +221,7 @@ impl Syscall {
         let socket: Arc<SocketInode> = ProcessManager::current_pcb()
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
-        let socket = socket.inner();
+        let socket = unsafe { socket.inner_no_preempt() };
         return socket.write(buf, endpoint);
     }
 
@@ -244,7 +244,7 @@ impl Syscall {
         let socket: Arc<SocketInode> = ProcessManager::current_pcb()
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
-        let socket = socket.inner();
+        let socket = unsafe { socket.inner_no_preempt() };
 
         let (n, endpoint) = socket.read(buf);
         drop(socket);
@@ -275,7 +275,7 @@ impl Syscall {
         let socket: Arc<SocketInode> = ProcessManager::current_pcb()
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
-        let socket = socket.inner();
+        let socket = unsafe { socket.inner_no_preempt() };
 
         let mut buf = iovs.new_buf(true);
         // 从socket中读取数据

--- a/kernel/src/net/syscall.rs
+++ b/kernel/src/net/syscall.rs
@@ -336,7 +336,7 @@ impl Syscall {
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
         // kdebug!("accept: socket={:?}", socket);
-        let mut socket = socket.inner();
+        let mut socket = unsafe { socket.inner_no_preempt() };
         // 从socket中接收连接
         let (new_socket, remote_endpoint) = socket.accept()?;
         drop(socket);

--- a/kernel/src/net/syscall.rs
+++ b/kernel/src/net/syscall.rs
@@ -304,7 +304,7 @@ impl Syscall {
         let socket: Arc<SocketInode> = ProcessManager::current_pcb()
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
-        let mut socket = socket.inner();
+        let mut socket = unsafe { socket.inner_no_preempt() };
         socket.listen(backlog)?;
         return Ok(0);
     }
@@ -319,7 +319,7 @@ impl Syscall {
         let socket: Arc<SocketInode> = ProcessManager::current_pcb()
             .get_socket(fd as i32)
             .ok_or(SystemError::EBADF)?;
-        let socket = socket.inner();
+        let socket = unsafe { socket.inner_no_preempt() };
         socket.shutdown(ShutdownType::try_from(how as i32)?)?;
         return Ok(0);
     }

--- a/kernel/src/process/idle.rs
+++ b/kernel/src/process/idle.rs
@@ -37,8 +37,10 @@ impl ProcessManager {
                 let stack_ptr =
                     VirtAddr::new(Self::stack_ptr().data() & (!(KernelStack::ALIGN - 1)));
                 // 初始化bsp的idle进程
-                unsafe { KernelStack::from_existed(stack_ptr) }
-                    .expect("Failed to create kernel stack struct for BSP.")
+                let mut ks = unsafe { KernelStack::from_existed(stack_ptr) }
+                    .expect("Failed to create kernel stack struct for BSP.");
+                unsafe { ks.clear_pcb(true) };
+                ks
             } else {
                 KernelStack::new().unwrap_or_else(|e| {
                     panic!("Failed to create kernel stack struct for AP {}: {:?}", i, e)

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1093,9 +1093,9 @@ impl KernelStack {
     }
 
     /// 清除内核栈的pcb指针
-    /// 
+    ///
     /// ## 参数
-    /// 
+    ///
     /// - `force` : 如果为true,那么，即使该内核栈的pcb指针不为null，也会被强制清除而不处理Weak指针问题
     pub unsafe fn clear_pcb(&mut self, force: bool) {
         let stack_bottom_ptr = self.start_address().data() as *mut *const ProcessControlBlock;

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -693,6 +693,7 @@ impl ProcessControlBlock {
         return self.sched_info.read();
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub fn sched_info_irqsave(&self) -> RwLockReadGuard<ProcessSchedulerInfo> {
         return self.sched_info.read_irqsave();

--- a/kernel/src/sched/core.rs
+++ b/kernel/src/sched/core.rs
@@ -5,7 +5,6 @@ use alloc::{sync::Arc, vec::Vec};
 use crate::{
     include::bindings::bindings::smp_get_total_cpu,
     kinfo,
-    libs::rwlock::RwLockReadGuard,
     mm::percpu::PerCpu,
     process::{AtomicPid, Pid, ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState},
     smp::core::smp_get_processor_id,

--- a/kernel/src/sched/core.rs
+++ b/kernel/src/sched/core.rs
@@ -106,6 +106,7 @@ pub fn do_sched() -> Option<Arc<ProcessControlBlock>> {
             for _ in 0..50 {
                 match guard.try_upgrade() {
                     Ok(mut writer) => {
+                        // 被mark_sleep但是还在临界区的进程将其设置为Runnable
                         writer.set_state(ProcessState::Runnable);
                         break;
                     }

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -6,3 +6,4 @@ arch/x86_64/efi/grub/*
 
 *.tar.gz
 build/*
+target/

--- a/tools/create_hdd_image.sh
+++ b/tools/create_hdd_image.sh
@@ -48,8 +48,8 @@ EOF
 
 echo "Creating virtual disk image..."
 ARGS=`getopt -o P: -- "$@"`
-# 创建一至少为64MB磁盘镜像（类型选择raw）
-qemu-img create -f raw disk.img 64M
+# 创建一至少为256MB磁盘镜像（类型选择raw）
+qemu-img create -f raw disk.img 256M
 #将规范化后的命令行参数分配至位置参数（$1,$2,...)
 eval set -- "${ARGS}"
 #echo formatted parameters=[$@]

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -62,9 +62,9 @@ QEMU_DRIVE="id=disk,file=${QEMU_DISK_IMAGE},if=none"
 
 # ps: 下面这条使用tap的方式，无法dhcp获取到ip，暂时不知道为什么
 # QEMU_DEVICES="-device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 -net nic,netdev=nic0 -netdev tap,id=nic0,model=virtio-net-pci,script=qemu/ifup-nat,downscript=qemu/ifdown-nat -usb -device qemu-xhci,id=xhci,p2=8,p3=4 -machine accel=${qemu_accel} -machine q35 "
-# QEMU_DEVICES="-device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 -netdev user,id=hostnet0,hostfwd=tcp::12580-:12580 -device virtio-net-pci,vectors=5,netdev=hostnet0,id=net0 -usb -device qemu-xhci,id=xhci,p2=8,p3=4 -machine accel=${qemu_accel} -machine q35 " 
+QEMU_DEVICES="-device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 -netdev user,id=hostnet0,hostfwd=tcp::12580-:12580 -device virtio-net-pci,vectors=5,netdev=hostnet0,id=net0 -usb -device qemu-xhci,id=xhci,p2=8,p3=4 -machine accel=${qemu_accel} -machine q35 " 
 # E1000E
-QEMU_DEVICES="-device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 -netdev user,id=hostnet0,hostfwd=tcp::12580-:12580 -net nic,model=e1000e,netdev=hostnet0,id=net0 -netdev user,id=hostnet1,hostfwd=tcp::12581-:12581 -device virtio-net-pci,vectors=5,netdev=hostnet1,id=net1 -usb -device qemu-xhci,id=xhci,p2=8,p3=4 -machine accel=${qemu_accel} -machine q35 " 
+#QEMU_DEVICES="-device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 -netdev user,id=hostnet0,hostfwd=tcp::12580-:12580 -net nic,model=e1000e,netdev=hostnet0,id=net0 -netdev user,id=hostnet1,hostfwd=tcp::12581-:12581 -device virtio-net-pci,vectors=5,netdev=hostnet1,id=net1 -usb -device qemu-xhci,id=xhci,p2=8,p3=4 -machine accel=${qemu_accel} -machine q35 " 
 QEMU_ARGUMENT="-d ${QEMU_DISK_IMAGE} -m ${QEMU_MEMORY} -smp ${QEMU_SMP} -boot order=d -monitor ${QEMU_MONITOR} -d ${qemu_trace_std} "
 
 QEMU_ARGUMENT+="-s -S -enable-kvm -cpu ${QEMU_CPU_FEATURES} -rtc ${QEMU_RTC_CLOCK} -serial ${QEMU_SERIAL} -drive ${QEMU_DRIVE} ${QEMU_DEVICES}"


### PR DESCRIPTION
解决waitqueue sleep的时候,由于preempt count不为0,导致sched失败,从而导致该waitqueue下一次wakeup时,会把pcb多次加入调度队列的bug