### PR TITLE
添加初始化DragonOS的Rust-Musl工具链的脚本.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,8 @@
 .. toctree::
    :maxdepth: 1
    :caption: 应用层
-
+   
+   userland/appdev/index
    userland/libc/index
 
 .. toctree::

--- a/docs/userland/appdev/c-cpp-quick-start.md
+++ b/docs/userland/appdev/c-cpp-quick-start.md
@@ -1,0 +1,15 @@
+# 为DragonOS开发C/C++应用
+
+## 编译环境
+
+&emsp;&emsp;DragonOS与Linux具有部分二进制兼容性，因此可以使用Linux的musl-gcc进行编译。但是由于DragonOS还不支持动态链接，
+因此要增加编译参数`-static`
+
+比如，您可以使用
+```shell
+musl-gcc -static -o hello hello.c
+```
+来编译一个hello.c文件。
+
+在移植现有程序时，可能需要配置`CFLAGS`和`LDFLAGS`，以及`CPPFLAGS`，以便正确地编译，具体请以实际为准。
+

--- a/docs/userland/appdev/index.rst
+++ b/docs/userland/appdev/index.rst
@@ -1,0 +1,10 @@
+应用程序开发文档
+====================================
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: 目录
+
+   rust-quick-start
+   c-cpp-quick-start

--- a/docs/userland/appdev/rust-quick-start.md
+++ b/docs/userland/appdev/rust-quick-start.md
@@ -1,0 +1,42 @@
+# Rust应用开发快速入门
+
+## 编译环境
+
+&emsp;&emsp;DragonOS与Linux具有部分二进制兼容性，因此可以使用Linux的Rust编译器进行编译，但是需要进行一些配置：
+
+您可以参考DragonOS的`tools/bootstrap.sh`中，`initialize_userland_musl_toolchain()`函数的实现，进行配置。
+或者，只要运行一下bootstrap.sh就可以了。
+
+主要是因为DragonOS还不支持动态链接，但是默认的工具链里面，包含了动态链接解释器相关的代码，因此像脚本内那样，进行替换就能运行。
+
+## 配置项目
+
+### 从模板创建
+
+:::{note}
+该功能需要dadk 0.1.4及以上版本方能支持
+:::
+
+1. 使用DragonOS的tools目录下的`bootstrap.sh`脚本初始化环境
+2. 在终端输入`cargo install cargo-generate`
+3. 在终端输入
+
+```shell
+cargo generate --git https://github.com/DragonOS-Community/Rust-App-Template
+```
+即可创建项目。如果您的网络较慢，请使用镜像站
+```shell
+cargo generate --git https://git.mirrors.dragonos.org/DragonOS-Community/Rust-App-Template
+```
+
+4. 使用`cargo run`来运行项目
+5. 在DragonOS的`user/dadk/config`目录下，使用`dadk new`命令，创建编译配置,安装到DragonOS的`/`目录下。 
+(在dadk的编译命令选项处，请使用Makefile里面的`make install`配置进行编译、安装)
+6. 编译DragonOS即可安装
+
+### 手动配置
+
+如果您需要移植别的库/程序到DragonOS，请参考模板内的配置。
+
+由于DragonOS目前不支持动态链接，因此目前需要在RUSTFLAGS里面指定`-C target-feature=+crt-static -C link-arg=-no-pie`
+并且需要使用上文提到的工具链`nightly-2023-08-15-x86_64-unknown-linux_dragonos-gnu`

--- a/user/Makefile
+++ b/user/Makefile
@@ -14,7 +14,7 @@ current_CFLAGS := $(CFLAGS)
 
 DADK_VERSION=$(shell dadk -V | awk 'END {print $$2}')
 # 最小的DADK版本
-MIN_DADK_VERSION = 0.1.3
+MIN_DADK_VERSION = 0.1.4
 DADK_CACHE_DIR = $(ROOT_PATH)/bin/dadk_cache
 
 # 旧版的libc安装路径


### PR DESCRIPTION
添加初始化DragonOS的Rust-Musl工具链的脚本.

## 注意
- 之后DragonOS的默认应用程序将逐步切换到musl工具链上面，如果编译运行的时候出错，那么请重新运行bootstrap.sh即可
- 如果由于DADK版本升级导致无法编译的，这种情况是因为您使用的crates-io镜像站没有更新导致的。请直接使用`cargo install --git https://git.mirrors.dragonos.org/DragonOS-Community/DADK.git`更新dadk版本即可。