### PR TITLE
修正文件open和写入的错误

### DIFF
--- a/kernel/src/driver/base/block/block_device.rs
+++ b/kernel/src/driver/base/block/block_device.rs
@@ -261,7 +261,7 @@ pub trait BlockDevice: Device {
                 let mut temp = Vec::new();
                 temp.resize(1usize << self.blk_size_log2(), 0);
                 // 由于块设备每次读写都是整块的，在不完整写入之前，必须把不完整的地方补全
-                self.write_at(range.lba_start, 1, &mut temp[..])?;
+                self.read_at(range.lba_start, 1, &mut temp[..])?;
                 // 把数据从临时buffer复制到目标buffer
                 temp[range.begin..range.end].copy_from_slice(&buf_slice);
                 self.write_at(range.lba_start, 1, &temp[..])?;

--- a/kernel/src/filesystem/fat/entry.rs
+++ b/kernel/src/filesystem/fat/entry.rs
@@ -198,7 +198,7 @@ impl FATFile {
             // 计算本次写入位置在磁盘上的偏移量
             let offset = fs.cluster_bytes_offset(current_cluster) + in_cluster_bytes_offset;
             // 写入磁盘
-            let w: usize = fs.partition.disk().write_at(
+            let w: usize = fs.partition.disk().write_at_bytes(
                 offset as usize,
                 end_len,
                 &buf[start..start + end_len],

--- a/kernel/src/filesystem/vfs/syscall.rs
+++ b/kernel/src/filesystem/vfs/syscall.rs
@@ -191,14 +191,6 @@ impl Syscall {
             return Err(SystemError::ENOTDIR);
         }
 
-        // 如果O_TRUNC，并且，打开模式包含O_RDWR或O_WRONLY，清空文件
-        if mode.contains(FileMode::O_TRUNC)
-            && (mode.contains(FileMode::O_RDWR) || mode.contains(FileMode::O_WRONLY))
-            && file_type == FileType::File
-        {
-            inode.truncate(0)?;
-        }
-
         // 创建文件对象
 
         let mut file: File = File::new(inode, mode)?;
@@ -206,6 +198,14 @@ impl Syscall {
         // 打开模式为“追加”
         if mode.contains(FileMode::O_APPEND) {
             file.lseek(SeekFrom::SeekEnd(0))?;
+        }
+
+        // 如果O_TRUNC，并且，打开模式包含O_RDWR或O_WRONLY，清空文件
+        if mode.contains(FileMode::O_TRUNC)
+            && (mode.contains(FileMode::O_RDWR) || mode.contains(FileMode::O_WRONLY))
+            && file_type == FileType::File
+        {
+            file.ftruncate(0)?;
         }
         // 把文件对象存入pcb
         let r = ProcessManager::current_pcb()


### PR DESCRIPTION
1. 修正文件open的时候可能错误的把inode清空的问题(如果当前inode是mknod创建的)
2. 修正fat和block device中,对文件写入部分的错误问题