### PR TITLE
新增系统调用，并对照linux-6.1.9改写sys_wait4

### DIFF
--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -277,6 +277,42 @@ bitflags! {
     }
 }
 
+/// SIGCHLD si_codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToPrimitive)]
+#[allow(dead_code)]
+pub enum SigChildCode {
+    /// child has exited
+    ///
+    /// CLD_EXITED
+    Exited = 1,
+    /// child was killed
+    ///
+    /// CLD_KILLED
+    Killed = 2,
+    /// child terminated abnormally
+    ///
+    /// CLD_DUMPED
+    Dumped = 3,
+    /// traced child has trapped
+    ///
+    /// CLD_TRAPPED
+    Trapped = 4,
+    /// child has stopped
+    ///
+    /// CLD_STOPPED
+    Stopped = 5,
+    /// stopped child has continued
+    ///
+    /// CLD_CONTINUED
+    Continued = 6,
+}
+
+impl Into<i32> for SigChildCode {
+    fn into(self) -> i32 {
+        self as i32
+    }
+}
+
 #[repr(C, align(16))]
 #[derive(Debug, Clone, Copy)]
 pub struct SigFrame {

--- a/kernel/src/arch/x86_64/process/syscall.rs
+++ b/kernel/src/arch/x86_64/process/syscall.rs
@@ -25,13 +25,13 @@ impl Syscall {
         // 关中断，防止在设置地址空间的时候，发生中断，然后进调度器，出现错误。
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let pcb = ProcessManager::current_pcb();
-        crate::kdebug!(
-            "pid: {:?}  do_execve: path: {:?}, argv: {:?}, envp: {:?}\n",
-            pcb.pid(),
-            path,
-            argv,
-            envp
-        );
+        // crate::kdebug!(
+        //     "pid: {:?}  do_execve: path: {:?}, argv: {:?}, envp: {:?}\n",
+        //     pcb.pid(),
+        //     path,
+        //     argv,
+        //     envp
+        // );
 
         let mut basic_info = pcb.basic_mut();
         // 暂存原本的用户地址空间的引用(因为如果在切换页表之前释放了它，可能会造成内存use after free)
@@ -110,10 +110,10 @@ impl Syscall {
 
         // kdebug!("regs: {:?}\n", regs);
 
-        crate::kdebug!(
-            "tmp_rs_execve: done, load_result.entry_point()={:?}",
-            load_result.entry_point()
-        );
+        // crate::kdebug!(
+        //     "tmp_rs_execve: done, load_result.entry_point()={:?}",
+        //     load_result.entry_point()
+        // );
 
         return Ok(());
     }

--- a/kernel/src/arch/x86_64/process/syscall.rs
+++ b/kernel/src/arch/x86_64/process/syscall.rs
@@ -22,15 +22,16 @@ impl Syscall {
         envp: Vec<String>,
         regs: &mut TrapFrame,
     ) -> Result<(), SystemError> {
-        // kdebug!(
-        //     "tmp_rs_execve: path: {:?}, argv: {:?}, envp: {:?}\n",
-        //     path,
-        //     argv,
-        //     envp
-        // );
         // 关中断，防止在设置地址空间的时候，发生中断，然后进调度器，出现错误。
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let pcb = ProcessManager::current_pcb();
+        crate::kdebug!(
+            "pid: {:?}  do_execve: path: {:?}, argv: {:?}, envp: {:?}\n",
+            pcb.pid(),
+            path,
+            argv,
+            envp
+        );
 
         let mut basic_info = pcb.basic_mut();
         // 暂存原本的用户地址空间的引用(因为如果在切换页表之前释放了它，可能会造成内存use after free)
@@ -109,10 +110,10 @@ impl Syscall {
 
         // kdebug!("regs: {:?}\n", regs);
 
-        // kdebug!(
-        //     "tmp_rs_execve: done, load_result.entry_point()={:?}",
-        //     load_result.entry_point()
-        // );
+        crate::kdebug!(
+            "tmp_rs_execve: done, load_result.entry_point()={:?}",
+            load_result.entry_point()
+        );
 
         return Ok(());
     }

--- a/kernel/src/arch/x86_64/syscall.rs
+++ b/kernel/src/arch/x86_64/syscall.rs
@@ -7,15 +7,25 @@ use crate::{
     ipc::signal_types::SignalArch,
     libs::align::SafeForZero,
     mm::VirtAddr,
+    process::ProcessManager,
     syscall::{Syscall, SystemError, SYS_RT_SIGRETURN},
 };
 use alloc::string::String;
 
 use super::{interrupt::TrapFrame, mm::barrier::mfence};
 
+pub const SYS_LSTAT: usize = 6;
+pub const SYS_READV: usize = 19;
 pub const SYS_ACCESS: usize = 21;
-pub const SYS_PRLIMIT64: usize = 302;
+pub const SYS_UNLINK: usize = 87;
+pub const SYS_CHMOD: usize = 90;
+pub const SYS_FCHMOD: usize = 91;
+pub const SYS_UMASK: usize = 95;
+pub const SYS_SYSINFO: usize = 99;
+pub const SYS_CLOCK_GETTIME: usize = 228;
+pub const SYS_FCHMODAT: usize = 268;
 pub const SYS_FACCESSAT: usize = 269;
+pub const SYS_PRLIMIT64: usize = 302;
 pub const SYS_FACCESSAT2: usize = 439;
 
 /// ### 存储PCB系统调用栈以及在syscall过程中暂存用户态rsp的结构体
@@ -44,9 +54,15 @@ extern "C" {
 }
 
 macro_rules! syscall_return {
-    ($val:expr, $regs:expr) => {{
+    ($val:expr, $regs:expr, $show:expr) => {{
         let ret = $val;
         $regs.rax = ret as u64;
+
+        if $show {
+            let pid = ProcessManager::current_pcb().pid();
+            crate::kdebug!("syscall return:pid={:?},ret= {:?}\n", pid, ret as isize);
+        }
+
         unsafe {
             CurrentIrqArch::interrupt_disable();
         }
@@ -69,18 +85,34 @@ pub extern "sysv64" fn syscall_handler(frame: &mut TrapFrame) -> () {
         frame.r9 as usize,
     ];
     mfence();
+    let pid = ProcessManager::current_pcb().pid();
+    let show = false;
+    // let show = if syscall_num != SYS_SCHED && pid.data() > 3 {
+    //     true
+    // } else {
+    //     false
+    // };
+
+    if show {
+        crate::kdebug!("syscall: pid: {:?}, num={:?}\n", pid, syscall_num);
+    }
 
     // Arch specific syscall
     match syscall_num {
         SYS_RT_SIGRETURN => {
-            syscall_return!(X86_64SignalArch::sys_rt_sigreturn(frame) as usize, frame);
+            syscall_return!(
+                X86_64SignalArch::sys_rt_sigreturn(frame) as usize,
+                frame,
+                show
+            );
         }
         _ => {}
     }
     syscall_return!(
         Syscall::handle(syscall_num, &args, frame).unwrap_or_else(|e| e.to_posix_errno() as usize)
             as u64,
-        frame
+        frame,
+        show
     );
 }
 

--- a/kernel/src/filesystem/vfs/core.rs
+++ b/kernel/src/filesystem/vfs/core.rs
@@ -16,10 +16,15 @@ use crate::{
         vfs::{mount::MountFS, syscall::ModeType, AtomicInodeId, FileSystem, FileType},
     },
     kdebug, kerror, kinfo,
+    process::ProcessManager,
     syscall::SystemError,
 };
 
-use super::{file::FileMode, utils::rsplit_path, IndexNode, InodeId, MAX_PATHLEN};
+use super::{
+    file::FileMode,
+    utils::{rsplit_path, user_path_at},
+    IndexNode, InodeId, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
+};
 
 /// @brief 原子地生成新的Inode号。
 /// 请注意，所有的inode号都需要通过该函数来生成.全局的inode号，除了以下两个特殊的以外，都是唯一的
@@ -206,13 +211,17 @@ pub fn do_mkdir(path: &str, _mode: FileMode) -> Result<u64, SystemError> {
 }
 
 /// @brief 删除文件夹
-pub fn do_remove_dir(path: &str) -> Result<u64, SystemError> {
+pub fn do_remove_dir(dirfd: i32, path: &str) -> Result<u64, SystemError> {
     // 文件名过长
     if path.len() > MAX_PATHLEN as usize {
         return Err(SystemError::ENAMETOOLONG);
     }
 
-    let inode: Result<Arc<dyn IndexNode>, SystemError> = ROOT_INODE().lookup(path);
+    let pcb = ProcessManager::current_pcb();
+    let (inode_begin, remain_path) = user_path_at(&pcb, dirfd, path.to_string())?;
+
+    let inode: Result<Arc<dyn IndexNode>, SystemError> =
+        inode_begin.lookup_follow_symlink(remain_path.as_str(), VFS_MAX_FOLLOW_SYMLINK_TIMES);
 
     if inode.is_err() {
         let errno = inode.unwrap_err();
@@ -222,9 +231,10 @@ pub fn do_remove_dir(path: &str) -> Result<u64, SystemError> {
         }
     }
 
-    let (filename, parent_path) = rsplit_path(path);
+    let (filename, parent_path) = rsplit_path(&remain_path);
     // 查找父目录
-    let parent_inode: Arc<dyn IndexNode> = ROOT_INODE().lookup(parent_path.unwrap_or("/"))?;
+    let parent_inode: Arc<dyn IndexNode> = inode_begin
+        .lookup_follow_symlink(parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
 
     if parent_inode.metadata()?.file_type != FileType::Dir {
         return Err(SystemError::ENOTDIR);
@@ -242,13 +252,16 @@ pub fn do_remove_dir(path: &str) -> Result<u64, SystemError> {
 }
 
 /// @brief 删除文件
-pub fn do_unlink_at(path: &str, _mode: FileMode) -> Result<u64, SystemError> {
+pub fn do_unlink_at(dirfd: i32, path: &str) -> Result<u64, SystemError> {
     // 文件名过长
     if path.len() > MAX_PATHLEN as usize {
         return Err(SystemError::ENAMETOOLONG);
     }
+    let pcb = ProcessManager::current_pcb();
+    let (inode_begin, remain_path) = user_path_at(&pcb, dirfd, path.to_string())?;
 
-    let inode: Result<Arc<dyn IndexNode>, SystemError> = ROOT_INODE().lookup(path);
+    let inode: Result<Arc<dyn IndexNode>, SystemError> =
+        inode_begin.lookup_follow_symlink(&remain_path, VFS_MAX_FOLLOW_SYMLINK_TIMES);
 
     if inode.is_err() {
         let errno = inode.clone().unwrap_err();
@@ -264,7 +277,8 @@ pub fn do_unlink_at(path: &str, _mode: FileMode) -> Result<u64, SystemError> {
 
     let (filename, parent_path) = rsplit_path(path);
     // 查找父目录
-    let parent_inode: Arc<dyn IndexNode> = ROOT_INODE().lookup(parent_path.unwrap_or("/"))?;
+    let parent_inode: Arc<dyn IndexNode> = inode_begin
+        .lookup_follow_symlink(parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
 
     if parent_inode.metadata()?.file_type != FileType::Dir {
         return Err(SystemError::ENOTDIR);

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -19,6 +19,7 @@ use super::{Dirent, FileType, IndexNode, InodeId, Metadata, SpecialNodeData};
 
 /// 文件私有信息的枚举类型
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum FilePrivateData {
     /// 管道文件私有信息
     Pipefs(PipeFsPrivateData),
@@ -198,6 +199,7 @@ impl File {
     }
 
     /// @brief 根据inode号获取子目录项的名字
+    #[allow(dead_code)]
     pub fn get_entry_name(&self, ino: InodeId) -> Result<String, SystemError> {
         return self.inode.get_entry_name(ino);
     }
@@ -535,6 +537,7 @@ impl FileDescriptorVec {
         return Ok(());
     }
 
+    #[allow(dead_code)]
     pub fn iter(&self) -> FileDescriptorIterator {
         return FileDescriptorIterator::new(self);
     }

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 pub mod core;
 pub mod fcntl;
 pub mod file;
@@ -50,6 +48,7 @@ pub enum FileType {
     Socket,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum SpecialNodeData {
     /// 管道文件
@@ -62,6 +61,7 @@ pub enum SpecialNodeData {
 
 /* these are defined by POSIX and also present in glibc's dirent.h */
 /// 完整含义请见 http://www.gnu.org/software/libc/manual/html_node/Directory-Entries.html
+#[allow(dead_code)]
 pub const DT_UNKNOWN: u16 = 0;
 /// 命名管道，或者FIFO
 pub const DT_FIFO: u16 = 1;
@@ -78,7 +78,9 @@ pub const DT_LNK: u16 = 10;
 // 是一个socket
 pub const DT_SOCK: u16 = 12;
 // 这个是抄Linux的，还不知道含义
+#[allow(dead_code)]
 pub const DT_WHT: u16 = 14;
+#[allow(dead_code)]
 pub const DT_MAX: u16 = 16;
 
 /// vfs容许的最大的符号链接跳转次数

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -1,14 +1,20 @@
-use crate::syscall::SystemError;
+use crate::{
+    process::ProcessManager,
+    syscall::{user_access::check_and_clone_cstr, SystemError},
+};
 
-use super::{fcntl::AtFlags, syscall::ModeType};
+use super::{
+    fcntl::AtFlags, syscall::ModeType, utils::user_path_at, MAX_PATHLEN,
+    VFS_MAX_FOLLOW_SYMLINK_TIMES,
+};
 
 pub(super) fn do_faccessat(
-    _dirfd: i32,
-    _pathname: *const u8,
+    dirfd: i32,
+    path: *const u8,
     mode: ModeType,
     flags: u32,
 ) -> Result<usize, SystemError> {
-    if (mode.bits() & (!ModeType::S_IXUGO.bits())) != 0 {
+    if (mode.bits() & (!ModeType::S_IRWXO.bits())) != 0 {
         return Err(SystemError::EINVAL);
     }
 
@@ -22,6 +28,35 @@ pub(super) fn do_faccessat(
 
     // let follow_symlink = flags & AtFlags::AT_SYMLINK_NOFOLLOW.bits() as u32 == 0;
 
+    let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
+
+    if path.len() == 0 {
+        return Err(SystemError::EINVAL);
+    }
+
+    let (inode, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
+
+    // 如果找不到文件，则返回错误码ENOENT
+    let _inode = inode.lookup_follow_symlink(path.as_str(), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+
     // todo: 接着完善（可以借鉴linux 6.1.9的do_faccessat）
+    return Ok(0);
+}
+
+pub fn do_fchmodat(dirfd: i32, path: *const u8, _mode: ModeType) -> Result<usize, SystemError> {
+    let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
+
+    if path.len() == 0 {
+        return Err(SystemError::EINVAL);
+    }
+
+    let (inode, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
+
+    // 如果找不到文件，则返回错误码ENOENT
+    let _inode = inode.lookup_follow_symlink(path.as_str(), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+
+    kwarn!("do_fchmodat: not implemented yet\n");
+    // todo: 真正去改变文件的权限
+
     return Ok(0);
 }

--- a/kernel/src/filesystem/vfs/utils.rs
+++ b/kernel/src/filesystem/vfs/utils.rs
@@ -7,6 +7,7 @@ use super::{fcntl::AtFlags, FileType, IndexNode, ROOT_INODE};
 /// @brief 切分路径字符串，返回最左侧那一级的目录名和剩余的部分。
 ///
 /// 举例：对于 /123/456/789/   本函数返回的第一个值为123, 第二个值为456/789
+#[allow(dead_code)]
 pub fn split_path(path: &str) -> (&str, Option<&str>) {
     let mut path_split: core::str::SplitN<&str> = path.trim_matches('/').splitn(2, "/");
     let comp = path_split.next().unwrap_or("");
@@ -30,7 +31,7 @@ pub fn rsplit_path(path: &str) -> (&str, Option<&str>) {
 ///
 /// ## 返回值
 ///
-/// 返回值为(需要lookup的inode, 剩余的path)
+/// 返回值为(需要执行lookup的inode, 剩余的path)
 pub fn user_path_at(
     pcb: &Arc<ProcessControlBlock>,
     dirfd: i32,

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -6,7 +6,7 @@ use crate::{
         FileType, IndexNode, Metadata, PollStatus,
     },
     libs::{spinlock::SpinLock, wait_queue::WaitQueue},
-    process::{ProcessManager, ProcessState},
+    process::ProcessState,
     syscall::SystemError,
     time::TimeSpec,
 };
@@ -94,14 +94,6 @@ impl IndexNode for LockedPipeInode {
         buf: &mut [u8],
         data: &mut FilePrivateData,
     ) -> Result<usize, crate::syscall::SystemError> {
-        let pcb = ProcessManager::current_pcb();
-        let show = if pcb.pid().data() > 3 { true } else { false };
-        if show {
-            kdebug!(
-                "locked_pipe_inode begin read_at: preempt={}",
-                ProcessManager::current_pcb().preempt_count()
-            );
-        }
         // 获取mode
         let mode: FileMode;
         if let FilePrivateData::Pipefs(pdata) = data {
@@ -136,12 +128,7 @@ impl IndexNode for LockedPipeInode {
             // 否则在读等待队列中睡眠，并释放锁
             unsafe {
                 let irq_guard = CurrentIrqArch::save_and_disable_irq();
-                if show {
-                    kdebug!(
-                        "locked_pipe_inode begin to sleep without sched: preempt={}",
-                        ProcessManager::current_pcb().preempt_count()
-                    );
-                }
+
                 inode.read_wait_queue.sleep_without_schedule();
                 drop(inode);
 

--- a/kernel/src/ipc/signal_types.rs
+++ b/kernel/src/ipc/signal_types.rs
@@ -335,6 +335,11 @@ impl Default for SigPending {
 }
 
 impl SigPending {
+    /// 判断是否有待处理的信号
+    pub fn has_pending(&self) -> bool {
+        return !self.signal.is_empty();
+    }
+
     pub fn signal(&self) -> SigSet {
         self.signal
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(const_trait_impl)]
 #![feature(const_refs_to_cell)]
 #![feature(core_intrinsics)]
+#![feature(cstr_from_bytes_until_nul)]
 #![feature(c_void_variant)]
 #![feature(drain_filter)]
 #![feature(inline_const)]

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -224,7 +224,7 @@ fn do_waitpid(
         }
         ProcessState::Exited(status) => {
             let pid = child_pcb.pid();
-            kdebug!("wait4: child exited, pid: {:?}, status: {status}\n", pid);
+            // kdebug!("wait4: child exited, pid: {:?}, status: {status}\n", pid);
 
             if likely(!kwo.options.contains(WaitOption::WEXITED)) {
                 return None;

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -1,0 +1,253 @@
+use core::intrinsics::likely;
+
+use alloc::sync::Arc;
+
+use crate::{
+    arch::{
+        ipc::signal::{SigChildCode, Signal},
+        sched::sched,
+        CurrentIrqArch,
+    },
+    exception::InterruptArch,
+    syscall::{user_access::UserBufferWriter, SystemError},
+};
+
+use super::{
+    abi::WaitOption, pid::PidType, resource::RUsage, Pid, ProcessControlBlock, ProcessManager,
+    ProcessState,
+};
+
+/// 内核wait4时的参数
+#[derive(Debug)]
+pub struct KernelWaitOption<'a> {
+    pub pid_type: PidType,
+    pub pid: Pid,
+    pub options: WaitOption,
+    pub ret_status: i32,
+    pub ret_info: Option<WaitIdInfo>,
+    pub ret_rusage: Option<&'a mut RUsage>,
+    pub no_task_error: Option<SystemError>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WaitIdInfo {
+    pub pid: Pid,
+    pub status: i32,
+    pub cause: i32,
+}
+
+impl<'a> KernelWaitOption<'a> {
+    pub fn new(pid_type: PidType, pid: Pid, options: WaitOption) -> Self {
+        Self {
+            pid_type,
+            pid,
+            options,
+            ret_status: 0,
+            ret_info: None,
+            ret_rusage: None,
+            no_task_error: None,
+        }
+    }
+}
+
+pub fn kernel_wait4(
+    mut pid: i64,
+    wstatus_buf: Option<UserBufferWriter<'_>>,
+    options: WaitOption,
+    rusage_buf: Option<&mut RUsage>,
+) -> Result<usize, SystemError> {
+    // i64::MIN is not defined
+    if pid == i64::MIN {
+        return Err(SystemError::ESRCH);
+    }
+
+    // 判断pid类型
+    let pidtype: PidType;
+
+    if pid == -1 {
+        pidtype = PidType::MAX;
+    } else if pid < 0 {
+        pidtype = PidType::PGID;
+        kwarn!("kernel_wait4: currently not support pgid, default to wait for pid\n");
+        pid = -pid;
+    } else if pid == 0 {
+        pidtype = PidType::PGID;
+        kwarn!("kernel_wait4: currently not support pgid, default to wait for pid\n");
+        pid = ProcessManager::current_pcb().pid().data() as i64;
+    } else {
+        pidtype = PidType::PID;
+    }
+
+    let pid = Pid(pid as usize);
+
+    // 构造参数
+    let mut kwo = KernelWaitOption::new(pidtype, pid, options);
+
+    kwo.options.insert(WaitOption::WEXITED);
+    kwo.ret_rusage = rusage_buf;
+
+    // 调用do_wait，执行等待
+    let r = do_wait(&mut kwo)?;
+
+    // 如果有wstatus_buf，则将wstatus写入用户空间
+    if let Some(mut wstatus_buf) = wstatus_buf {
+        let wstatus = if let Some(ret_info) = &kwo.ret_info {
+            ret_info.status
+        } else {
+            kwo.ret_status
+        };
+        wstatus_buf.copy_one_to_user(&wstatus, 0)?;
+    }
+
+    return Ok(r);
+}
+
+/// 参考 https://opengrok.ringotek.cn/xref/linux-6.1.9/kernel/exit.c#1573
+fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
+    let mut retval: Result<usize, SystemError>;
+    // todo: 在signal struct里面增加等待队列，并在这里初始化子进程退出的回调，使得子进程退出时，能唤醒当前进程。
+
+    loop {
+        kwo.no_task_error = Some(SystemError::ECHILD);
+        let child_pcb = ProcessManager::find(kwo.pid).ok_or(SystemError::ECHILD);
+        if kwo.pid_type != PidType::MAX && child_pcb.is_err() {
+            if let Some(err) = &kwo.no_task_error {
+                retval = Err(err.clone());
+            } else {
+                retval = Ok(0);
+            }
+
+            if !kwo.options.contains(WaitOption::WNOHANG) {
+                retval = Err(SystemError::ERESTARTSYS);
+                if ProcessManager::current_pcb()
+                    .sig_info_irqsave()
+                    .sig_pending()
+                    .has_pending()
+                    == false
+                {
+                    // todo: 增加子进程退出的回调后，这里可以直接等待在自身的child_wait等待队列上。
+                    continue;
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        if kwo.pid_type == PidType::PID {
+            let child_pcb = child_pcb.unwrap();
+            // 获取weak引用，以便于在do_waitpid中能正常drop pcb
+            let child_weak = Arc::downgrade(&child_pcb);
+            let r = do_waitpid(child_pcb, kwo);
+            if r.is_some() {
+                return r.unwrap();
+            } else {
+                child_weak.upgrade().unwrap().wait_queue.sleep();
+            }
+        } else if kwo.pid_type == PidType::MAX {
+            // 等待任意子进程
+            // todo: 这里有问题！如果正在for循环的过程中，子进程退出了，可能会导致父进程永远等待。
+            let current_pcb = ProcessManager::current_pcb();
+            let rd_childen = current_pcb.children.read();
+            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+            for pid in rd_childen.iter() {
+                let pcb = ProcessManager::find(*pid).ok_or(SystemError::ECHILD)?;
+                if pcb.sched_info().state().is_exited() {
+                    kwo.ret_status = pcb.sched_info().state().exit_code().unwrap() as i32;
+                    drop(pcb);
+                    unsafe { ProcessManager::release(pid.clone()) };
+                    return Ok(pid.clone().into());
+                } else {
+                    unsafe { pcb.wait_queue.sleep_without_schedule() };
+                }
+            }
+            drop(irq_guard);
+            sched();
+        } else {
+            // todo: 对于pgid的处理
+            kwarn!("kernel_wait4: currently not support {:?}", kwo.pid_type);
+            return Err(SystemError::EINVAL);
+        }
+    }
+
+    return retval;
+}
+
+fn do_waitpid(
+    child_pcb: Arc<ProcessControlBlock>,
+    kwo: &mut KernelWaitOption,
+) -> Option<Result<usize, SystemError>> {
+    let state = child_pcb.sched_info().state();
+    // 获取退出码
+    match state {
+        ProcessState::Runnable => {
+            if kwo.options.contains(WaitOption::WNOHANG)
+                || kwo.options.contains(WaitOption::WNOWAIT)
+            {
+                if let Some(info) = &mut kwo.ret_info {
+                    *info = WaitIdInfo {
+                        pid: child_pcb.pid(),
+                        status: Signal::SIGCONT as i32,
+                        cause: SigChildCode::Continued.into(),
+                    };
+                } else {
+                    kwo.ret_status = 0xffff;
+                }
+
+                return Some(Ok(0));
+            }
+        }
+        ProcessState::Blocked(_) | ProcessState::Stopped => {
+            // todo: 在stopped里面，添加code字段，表示停止的原因
+            let exitcode = 0;
+            // 由于目前不支持ptrace，因此这个值为false
+            let ptrace = false;
+
+            if (!ptrace) && (!kwo.options.contains(WaitOption::WUNTRACED)) {
+                kwo.ret_status = 0;
+                return Some(Ok(0));
+            }
+
+            if likely(!(kwo.options.contains(WaitOption::WNOWAIT))) {
+                kwo.ret_status = (exitcode << 8) | 0x7f;
+            }
+            if let Some(infop) = &mut kwo.ret_info {
+                *infop = WaitIdInfo {
+                    pid: child_pcb.pid(),
+                    status: exitcode,
+                    cause: SigChildCode::Stopped.into(),
+                };
+            }
+
+            return Some(Ok(child_pcb.pid().data()));
+        }
+        ProcessState::Exited(status) => {
+            let pid = child_pcb.pid();
+            kdebug!("wait4: child exited, pid: {:?}, status: {status}\n", pid);
+
+            if likely(!kwo.options.contains(WaitOption::WEXITED)) {
+                return None;
+            }
+
+            // todo: 增加对线程组的group leader的处理
+
+            if let Some(infop) = &mut kwo.ret_info {
+                *infop = WaitIdInfo {
+                    pid,
+                    status: status as i32,
+                    cause: SigChildCode::Exited.into(),
+                };
+            }
+
+            kwo.ret_status = status as i32;
+
+            drop(child_pcb);
+            // kdebug!("wait4: to release {pid:?}");
+            unsafe { ProcessManager::release(pid) };
+            return Some(Ok(pid.into()));
+        }
+    };
+
+    return None;
+}

--- a/kernel/src/process/syscall.rs
+++ b/kernel/src/process/syscall.rs
@@ -8,13 +8,13 @@ use alloc::{
 
 use super::{
     abi::WaitOption,
+    exit::kernel_wait4,
     fork::{CloneFlags, KernelCloneArgs},
     resource::{RLimit64, RLimitID, RUsage, RUsageWho},
-    KernelStack, Pid, ProcessManager, ProcessState,
+    KernelStack, Pid, ProcessManager,
 };
 use crate::{
-    arch::{interrupt::TrapFrame, sched::sched, CurrentIrqArch, MMArch},
-    exception::InterruptArch,
+    arch::{interrupt::TrapFrame, MMArch},
     filesystem::{
         procfs::procfs_register_pid,
         vfs::{file::FileDescriptorVec, MAX_PATHLEN},
@@ -24,9 +24,7 @@ use crate::{
     process::ProcessControlBlock,
     sched::completion::Completion,
     syscall::{
-        user_access::{
-            check_and_clone_cstr, check_and_clone_cstr_array, UserBufferReader, UserBufferWriter,
-        },
+        user_access::{check_and_clone_cstr, check_and_clone_cstr_array, UserBufferWriter},
         Syscall, SystemError,
     },
 };
@@ -34,15 +32,25 @@ use crate::{
 impl Syscall {
     pub fn fork(frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let r = ProcessManager::fork(frame, CloneFlags::empty()).map(|pid| pid.into());
+        kdebug!(
+            "fork: current pid: {:?}, return: {:?}\n",
+            ProcessManager::current_pcb().pid(),
+            r
+        );
         return r;
     }
 
     pub fn vfork(frame: &mut TrapFrame) -> Result<usize, SystemError> {
-        ProcessManager::fork(
-            frame,
-            CloneFlags::CLONE_VM | CloneFlags::CLONE_FS | CloneFlags::CLONE_SIGNAL,
-        )
-        .map(|pid| pid.into())
+        // 由于Linux vfork需要保证子进程先运行（除非子进程调用execve或者exit），
+        // 而我们目前没有实现这个特性，所以暂时使用fork代替vfork（linux文档表示这样也是也可以的）
+        Self::fork(frame)
+
+        // 下面是以前的实现，除非我们实现了子进程先运行的特性，否则不要使用，不然会导致父进程数据损坏
+        // ProcessManager::fork(
+        //     frame,
+        //     CloneFlags::CLONE_VM | CloneFlags::CLONE_FS | CloneFlags::CLONE_SIGNAL,
+        // )
+        // .map(|pid| pid.into())
     }
 
     pub fn execve(
@@ -100,98 +108,35 @@ impl Syscall {
         options: i32,
         rusage: *mut c_void,
     ) -> Result<usize, SystemError> {
-        let ret = WaitOption::from_bits(options as u32);
-        let options = match ret {
-            Some(options) => options,
-            None => {
-                return Err(SystemError::EINVAL);
-            }
+        let options = WaitOption::from_bits(options as u32).ok_or(SystemError::EINVAL)?;
+
+        let wstatus_buf = if wstatus.is_null() {
+            None
+        } else {
+            Some(UserBufferWriter::new(
+                wstatus,
+                core::mem::size_of::<i32>(),
+                true,
+            )?)
         };
 
-        let mut _rusage_buf =
-            UserBufferReader::new::<c_void>(rusage, core::mem::size_of::<c_void>(), true)?;
-
-        let mut wstatus_buf =
-            UserBufferWriter::new::<i32>(wstatus, core::mem::size_of::<i32>(), true)?;
-
-        let cur_pcb = ProcessManager::current_pcb();
-        let rd_childen = cur_pcb.children.read();
-
-        if pid > 0 {
-            let pid = Pid(pid as usize);
-            let child_pcb = ProcessManager::find(pid).ok_or(SystemError::ECHILD)?;
-            drop(rd_childen);
-
-            loop {
-                let state = child_pcb.sched_info().state();
-                // 获取退出码
-                match state {
-                    ProcessState::Runnable => {
-                        if options.contains(WaitOption::WNOHANG)
-                            || options.contains(WaitOption::WNOWAIT)
-                        {
-                            if !wstatus.is_null() {
-                                wstatus_buf.copy_one_to_user(&WaitOption::WCONTINUED.bits(), 0)?;
-                            }
-                            return Ok(0);
-                        }
-                    }
-                    ProcessState::Blocked(_) | ProcessState::Stopped => {
-                        // 指定WUNTRACED则等待暂停的进程，不指定则返回0
-                        if !options.contains(WaitOption::WUNTRACED)
-                            || options.contains(WaitOption::WNOWAIT)
-                        {
-                            if !wstatus.is_null() {
-                                wstatus_buf.copy_one_to_user(&WaitOption::WSTOPPED.bits(), 0)?;
-                            }
-                            return Ok(0);
-                        }
-                    }
-                    ProcessState::Exited(status) => {
-                        // kdebug!("wait4: child exited, pid: {:?}, status: {status}\n", pid);
-                        if !wstatus.is_null() {
-                            wstatus_buf.copy_one_to_user(
-                                &(status as u32 | WaitOption::WEXITED.bits()),
-                                0,
-                            )?;
-                        }
-                        drop(child_pcb);
-                        // kdebug!("wait4: to release {pid:?}");
-                        unsafe { ProcessManager::release(pid) };
-                        return Ok(pid.into());
-                    }
-                };
-
-                // 等待指定进程
-                child_pcb.wait_queue.sleep();
-            }
-        } else if pid < -1 {
-            // TODO 判断是否pgid == -pid（等待指定组任意进程）
-            // 暂时不支持
-            return Err(SystemError::EINVAL);
-        } else if pid == 0 {
-            // TODO 判断是否pgid == current_pgid（等待当前组任意进程）
-            // 暂时不支持
-            return Err(SystemError::EINVAL);
+        let mut tmp_rusage = if rusage.is_null() {
+            None
         } else {
-            // 等待任意子进程(这两)
-            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-            for pid in rd_childen.iter() {
-                let pcb = ProcessManager::find(*pid).ok_or(SystemError::ECHILD)?;
-                if pcb.sched_info().state().is_exited() {
-                    if !wstatus.is_null() {
-                        wstatus_buf.copy_one_to_user(&0, 0)?;
-                    }
-                    return Ok(pid.clone().into());
-                } else {
-                    unsafe { pcb.wait_queue.sleep_without_schedule() };
-                }
-            }
-            drop(irq_guard);
-            sched();
-        }
+            Some(RUsage::default())
+        };
 
-        return Ok(0);
+        let r = kernel_wait4(pid, wstatus_buf, options, tmp_rusage.as_mut())?;
+
+        if !rusage.is_null() {
+            let mut rusage_buf = UserBufferWriter::new::<RUsage>(
+                rusage as *mut RUsage,
+                core::mem::size_of::<RUsage>(),
+                true,
+            )?;
+            rusage_buf.copy_one_to_user(&tmp_rusage.unwrap(), 0)?;
+        }
+        return Ok(r);
     }
 
     /// # 退出进程
@@ -356,15 +301,11 @@ impl Syscall {
     pub fn prlimit64(
         _pid: Pid,
         resource: usize,
-        new_limit: *const RLimit64,
+        _new_limit: *const RLimit64,
         old_limit: *mut RLimit64,
     ) -> Result<usize, SystemError> {
         let resource = RLimitID::try_from(resource)?;
         let mut writer = None;
-
-        if new_limit.is_null() {
-            return Err(SystemError::EINVAL);
-        }
 
         if !old_limit.is_null() {
             writer = Some(UserBufferWriter::new(
@@ -373,8 +314,6 @@ impl Syscall {
                 true,
             )?);
         }
-
-        let _reader = UserBufferReader::new(new_limit, core::mem::size_of::<RLimit64>(), true)?;
 
         match resource {
             RLimitID::Stack => {

--- a/kernel/src/process/syscall.rs
+++ b/kernel/src/process/syscall.rs
@@ -32,11 +32,6 @@ use crate::{
 impl Syscall {
     pub fn fork(frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let r = ProcessManager::fork(frame, CloneFlags::empty()).map(|pid| pid.into());
-        kdebug!(
-            "fork: current pid: {:?}, return: {:?}\n",
-            ProcessManager::current_pcb().pid(),
-            r
-        );
         return r;
     }
 

--- a/kernel/src/syscall/misc.rs
+++ b/kernel/src/syscall/misc.rs
@@ -1,0 +1,57 @@
+use crate::arch::mm::LockedFrameAllocator;
+
+use super::{user_access::UserBufferWriter, Syscall, SystemError};
+
+#[repr(C)]
+
+/// 系统信息
+///
+/// 参考 https://opengrok.ringotek.cn/xref/linux-6.1.9/include/uapi/linux/sysinfo.h#8
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SysInfo {
+    uptime: u64,
+    loads: [u64; 3],
+    totalram: u64,
+    freeram: u64,
+    sharedram: u64,
+    bufferram: u64,
+    totalswap: u64,
+    freeswap: u64,
+    procs: u16,
+    pad: u16,
+    totalhigh: u64,
+    freehigh: u64,
+    mem_unit: u32,
+    // 这后面还有一小段，但是我们不需要
+}
+
+impl Syscall {
+    pub fn sysinfo(info: *mut SysInfo) -> Result<usize, SystemError> {
+        let mut writer = UserBufferWriter::new(info, core::mem::size_of::<SysInfo>(), true)?;
+        let mut sysinfo = SysInfo::default();
+
+        let mem = LockedFrameAllocator.get_usage();
+        sysinfo.uptime = 0;
+        sysinfo.loads = [0; 3];
+        sysinfo.totalram = mem.total().bytes() as u64;
+        sysinfo.freeram = mem.free().bytes() as u64;
+        sysinfo.sharedram = 0;
+        sysinfo.bufferram = 0;
+        sysinfo.totalswap = 0;
+        sysinfo.freeswap = 0;
+        sysinfo.procs = 0;
+        sysinfo.pad = 0;
+        sysinfo.totalhigh = 0;
+        sysinfo.freehigh = 0;
+        sysinfo.mem_unit = 0;
+
+        writer.copy_one_to_user(&sysinfo, 0)?;
+
+        return Ok(0);
+    }
+
+    pub fn umask(_mask: u32) -> Result<usize, SystemError> {
+        kwarn!("SYS_UMASK has not yet been implemented\n");
+        return Ok(0o777);
+    }
+}

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -223,6 +223,17 @@ impl<'a> UserBufferReader<'a> {
         return Ok(());
     }
 
+    /// 把用户空间的数据转换成指定类型的切片
+    ///
+    /// ## 参数
+    ///
+    /// - `offset`：字节偏移量
+    pub fn buffer<T>(&self, offset: usize) -> Result<&[T], SystemError> {
+        Ok(self
+            .convert_with_offset::<T>(self.buffer, offset)
+            .map_err(|_| SystemError::EINVAL)?)
+    }
+
     fn convert_with_offset<T>(&self, src: &[u8], offset: usize) -> Result<&[T], SystemError> {
         if offset >= src.len() {
             return Err(SystemError::EINVAL);


### PR DESCRIPTION
1. 新增以下系统调用
            - SYS_LSTAT
            - SYS_READV
            - SYS_ACCESS
            - SYS_UNLINK
            - SYS_CHMOD
            - SYS_FCHMOD
            - SYS_UMASK
            - SYS_SYSINFO
            - SYS_CLOCK_GETTIME
            - SYS_FCHMODAT
            - SYS_FACCESSAT

2. 修改sys_wait4,使得其部分符合Linux的行为(还是有些地方不符合的,详情请对比linux-6.1.9的sys_wait4接口)