### PR TITLE
默认安装gnu tar到dragonos的/usr/bin目录下

### DIFF
--- a/tools/create_hdd_image.sh
+++ b/tools/create_hdd_image.sh
@@ -49,7 +49,7 @@ EOF
 echo "Creating virtual disk image..."
 ARGS=`getopt -o P: -- "$@"`
 # 创建一至少为256MB磁盘镜像（类型选择raw）
-qemu-img create -f raw disk.img 256M
+qemu-img create -f raw disk.img 2048M
 #将规范化后的命令行参数分配至位置参数（$1,$2,...)
 eval set -- "${ARGS}"
 #echo formatted parameters=[$@]

--- a/user/Makefile
+++ b/user/Makefile
@@ -14,7 +14,7 @@ current_CFLAGS := $(CFLAGS)
 
 DADK_VERSION=$(shell dadk -V | awk 'END {print $$2}')
 # 最小的DADK版本
-MIN_DADK_VERSION = 0.1.4
+MIN_DADK_VERSION = 0.1.5
 DADK_CACHE_DIR = $(ROOT_PATH)/bin/dadk_cache
 
 # 旧版的libc安装路径

--- a/user/dadk/config/tar_1_35.dadk
+++ b/user/dadk/config/tar_1_35.dadk
@@ -1,0 +1,24 @@
+{
+  "name": "tar",
+  "version": "1.35",
+  "description": "gnu tar",
+  "rust_target": null,
+  "task_type": {
+    "InstallFromPrebuilt": {
+      "Archive": {
+        "url": "https://mirrors.dragonos.org/pub/third_party/gnu/tar/tar-1.35-x86_64-linux-gnu.tar.xz"
+      }
+    }
+  },
+  "depends": [],
+  "build": {
+    
+  },
+  "install": {
+    "in_dragonos_path": "/usr"
+  },
+  "clean": {
+    "clean_command": null
+  },
+  "envs": []
+}


### PR DESCRIPTION
## 内容
默认安装gnu tar到dragonos的/usr/bin目录下

## 注意
该PR把最小的dadk版本提升到了0.1.5，默认情况下，应当会自动更新。
如果由于您使用的crates-io镜像更新的不够及时，导致编译失败，请使用以下命令安装：
```shell
cargo install --git https://git.mirrors.dragonos.org/DragonOS-Community/DADK.git --tag v0.1.5
```