### PR TITLE
bugfix: 修复无法sleep的问题以及进程处于block(true)状态时无法被信号唤醒&唤醒后不处理信号的问题

### DIFF
--- a/kernel/src/arch/x86_64/asm/entry.S
+++ b/kernel/src/arch/x86_64/asm/entry.S
@@ -374,6 +374,10 @@ ENTRY(syscall_64)
 
     callq *%rdx //调用服务程序
 
+    // 将原本要返回的栈帧的栈指针传入do_signal的第一个参数
+    movq %rsp, %rdi
+    callq do_signal
+
     cli
     
     // === 恢复调用现场 ===

--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -495,7 +495,7 @@ impl SignalArch for X86_64SignalArch {
     }
 
     fn sys_rt_sigreturn(trap_frame: &mut TrapFrame) -> u64 {
-        let frame = (trap_frame.rsp as usize) as *mut SigFrame;
+        let frame = (trap_frame.rsp as usize - size_of::<u64>()) as *mut SigFrame;
 
         // 如果当前的rsp不来自用户态，则认为产生了错误（或被SROP攻击）
         if UserBufferWriter::new(frame, size_of::<SigFrame>(), true).is_err() {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -702,12 +702,6 @@ impl Syscall {
                 Self::sigaction(sig, act, old_act, frame.from_user())
             }
 
-            SYS_RT_SIGRETURN => {
-                // 由于目前signal机制的实现，与x86_64强关联，因此暂时在arch/x86_64/syscall.rs中调用
-                // todo: 未来需要将signal机制与平台解耦
-                todo!()
-            }
-
             SYS_GETPID => Self::getpid().map(|pid| pid.into()),
 
             SYS_SCHED => Self::sched(frame.from_user()),

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -1,4 +1,7 @@
-use core::{fmt, ops};
+use core::{
+    fmt,
+    ops::{self, Sub},
+};
 
 use self::timekeep::ktime_get_real_ns;
 
@@ -51,6 +54,30 @@ impl TimeSpec {
             tv_sec: sec,
             tv_nsec: nsec,
         };
+    }
+}
+
+impl Sub for TimeSpec {
+    type Output = Duration;
+    fn sub(self, rhs: Self) -> Self::Output {
+        let sec = self.tv_sec.checked_sub(rhs.tv_sec).unwrap_or(0);
+        let nsec = self.tv_nsec.checked_sub(rhs.tv_nsec).unwrap_or(0);
+        Duration::from_micros((sec * 1000000 + nsec / 1000) as u64)
+    }
+}
+
+impl From<Duration> for TimeSpec {
+    fn from(dur: Duration) -> Self {
+        TimeSpec {
+            tv_sec: dur.total_micros() as i64 / 1000000,
+            tv_nsec: (dur.total_micros() as i64 % 1000000) * 1000,
+        }
+    }
+}
+
+impl Into<Duration> for TimeSpec {
+    fn into(self) -> Duration {
+        Duration::from_micros(self.tv_sec as u64 * 1000000 + self.tv_nsec as u64 / 1000)
     }
 }
 

--- a/kernel/src/time/sleep.rs
+++ b/kernel/src/time/sleep.rs
@@ -8,6 +8,7 @@ use crate::{
     include::bindings::bindings::{useconds_t, Cpu_tsc_freq},
     process::ProcessManager,
     syscall::SystemError,
+    time::timekeeping::getnstimeofday,
 };
 
 use super::{
@@ -27,8 +28,7 @@ pub fn nanosleep(sleep_time: TimeSpec) -> Result<TimeSpec, SystemError> {
         return Err(SystemError::EINVAL);
     }
     // 对于小于500us的时间，使用spin/rdtsc来进行定时
-
-    if sleep_time.tv_nsec < 500000 {
+    if sleep_time.tv_nsec < 500000 && sleep_time.tv_sec == 0 {
         let expired_tsc: u64 = unsafe {
             CurrentTimeArch::get_cycles() as u64
                 + (sleep_time.tv_nsec as u64 * Cpu_tsc_freq) / 1000000000
@@ -41,28 +41,29 @@ pub fn nanosleep(sleep_time: TimeSpec) -> Result<TimeSpec, SystemError> {
             tv_nsec: 0,
         });
     }
+
+    let total_sleep_time_us: u64 =
+        sleep_time.tv_sec as u64 * 1000000 + sleep_time.tv_nsec as u64 / 1000;
     // 创建定时器
     let handler: Box<WakeUpHelper> = WakeUpHelper::new(ProcessManager::current_pcb());
-    let timer: Arc<Timer> = Timer::new(
-        handler,
-        next_n_us_timer_jiffies((sleep_time.tv_nsec / 1000) as u64),
-    );
+    let timer: Arc<Timer> = Timer::new(handler, next_n_us_timer_jiffies(total_sleep_time_us));
 
     let irq_guard: crate::exception::IrqFlagsGuard =
         unsafe { CurrentIrqArch::save_and_disable_irq() };
     ProcessManager::mark_sleep(true).ok();
+
+    let start_time = getnstimeofday();
     timer.activate();
 
     drop(irq_guard);
-
     sched();
 
-    // TODO: 增加信号唤醒的功能后，返回正确的剩余时间
+    let end_time = getnstimeofday();
+    // 返回正确的剩余时间
+    let real_sleep_time = end_time - start_time;
+    let rm_time: TimeSpec = (sleep_time - real_sleep_time.into()).into();
 
-    return Ok(TimeSpec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    });
+    return Ok(rm_time);
 }
 
 /// @brief 休眠指定时间（单位：微秒）

--- a/user/dadk/config/nova_shell-0.1.0.dadk
+++ b/user/dadk/config/nova_shell-0.1.0.dadk
@@ -6,7 +6,7 @@
     "BuildFromSource": {
       "Git": {
         "url": "https://git.mirrors.dragonos.org.cn/DragonOS-Community/NovaShell.git",
-        "revision": "95738b235f"
+        "revision": "4160a0a0de"
       }
     }
   },

--- a/user/dadk/config/relibc-0.1.0.dadk
+++ b/user/dadk/config/relibc-0.1.0.dadk
@@ -5,8 +5,8 @@
   "task_type": {
     "BuildFromSource": {
       "Git": {
-        "url": "https://git.mirrors.dragonos.org/DragonOS-Community/relibc.git",
-        "revision": "3ef630632f"
+        "url": "https://git.mirrors.dragonos.org.cn/DragonOS-Community/relibc.git",
+        "revision": "27e779dc23"
       }
     }
   },


### PR DESCRIPTION
# bugfix: 修复无法sleep的问题以及进程处于block(true)状态时无法被信号唤醒&唤醒后不处理信号的问题

## 无法sleep的问题

原因是：
1. nanosleep函数对“spin/wait"方式等待的判断有误
2. nanosleep函数对定时器过期时间的计算有误，导致定时器过期过快，sleep失败

## 无法被信号唤醒的问题

信号发送函数内，过早的把信号加入sigpending，应改为判断是否wants_signal之后再加入

## 唤醒后不处理信号的问题

syscall指令进入的系统调用，返回的时候没有do_signal导致的

## sys_rt_sigreturn调用没有正确的获取到sigframe的问题
原因是sigframe内的返回地址已经被弹出了，导致rsp加了8,而原来的relibc是在发起调用之前先push了一个u64到栈上，导致“刚好能跑”。现已修正relibc，使得这块的行为跟linux一致