### PR TITLE
riscv: 更新sbi-rt至0.0.3版本

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -63,7 +63,7 @@ x86_64 = "0.14.10"
 # target为riscv64时，使用下面的依赖
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 riscv = { version = "0.11.0", features = [ "s-mode" ] }
-sbi-rt = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/rustsbi.git", rev = "80478bc417", features = ["legacy"] }
+sbi-rt = { version = "0.0.3", features = ["legacy"] }
 
 
 # 构建时依赖项


### PR DESCRIPTION
先前使用git仓库链接，现在由于sbi-rt包的新版本已发布至crates.io网站，使用crates提供的版本。本次只修改了Cargo.toml文件，Rust代码未被更改。