### PR TITLE
tools/bootstrap.sh: 修复 archlinux and zsh 用户执行脚本时的报错

### DIFF
--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,4 +1,19 @@
-CURRENT_SHELL=$(basename $SHELL)
+#!/bin/bash
+
+if test -n "$ZSH_VERSION"; then
+  CURRENT_SHELL=zsh
+elif test -n "$BASH_VERSION"; then
+  CURRENT_SHELL=bash
+elif test -n "$KSH_VERSION"; then
+  CURRENT_SHELL=ksh
+elif test -n "$FCEDIT"; then
+  CURRENT_SHELL=ksh
+elif test -n "$PS3"; then
+  CURRENT_SHELL=unknown
+else
+  CURRENT_SHELL=sh
+fi
+
 source "$HOME/.$CURRENT_SHELL"rc
 
 emulator="qemu"
@@ -90,7 +105,7 @@ install_archlinux_pkg()
 	curl wget bridge-utils dnsmasq \
         diffutils pkgconf which unzip util-linux dosfstools \
         gcc make flex texinfo gmp mpfr qemu-base \
-        libmpc libssl-dev
+        libmpc openssl
 
 }
 
@@ -289,14 +304,16 @@ install_python_pkg
 # 安装dadk
 cargo install dadk || exit 1
 
+bashpath=$(cd `dirname $0`; pwd)
+
 # 创建磁盘镜像
-bash create_hdd_image.sh
+bash ${bashpath}/create_hdd_image.sh
 # 编译安装GCC交叉编译工具链
-bash build_gcc_toolchain.sh -cs -kb -kg || (echo "GCC交叉编译工具链安装失败" && exit 1)
+bash ${bashpath}/build_gcc_toolchain.sh -cs -kb -kg || (echo "GCC交叉编译工具链安装失败" && exit 1)
 # 编译安装musl交叉编译工具链
-bash install_musl_gcc.sh || (echo "musl交叉编译工具链安装失败" && exit 1)
+bash ${bashpath}/install_musl_gcc.sh || (echo "musl交叉编译工具链安装失败" && exit 1)
 # 编译安装grub
-bash grub_auto_install.sh || (echo "grub安装失败" && exit 1)
+bash ${bashpath}/grub_auto_install.sh || (echo "grub安装失败" && exit 1)
 
 # 解决kvm权限问题
 USR=$USER

--- a/tools/build_gcc_toolchain.sh
+++ b/tools/build_gcc_toolchain.sh
@@ -1,4 +1,19 @@
-CURRENT_SHELL=$(basename $SHELL)
+#!/bin/bash
+
+if test -n "$ZSH_VERSION"; then
+  CURRENT_SHELL=zsh
+elif test -n "$BASH_VERSION"; then
+  CURRENT_SHELL=bash
+elif test -n "$KSH_VERSION"; then
+  CURRENT_SHELL=ksh
+elif test -n "$FCEDIT"; then
+  CURRENT_SHELL=ksh
+elif test -n "$PS3"; then
+  CURRENT_SHELL=unknown
+else
+  CURRENT_SHELL=sh
+fi
+
 source "$HOME/.$CURRENT_SHELL"rc
 
 # init something here
@@ -101,9 +116,9 @@ case `cat /etc/os-release | grep '^NAME=' | cut -d'"' -f2` in
 esac
 
 # build the workspace
-mkdir $HOME/opt
-mkdir $INSTALL_POS
-mkdir $PREFIX
+mkdir -p $HOME/opt
+mkdir -p $INSTALL_POS
+mkdir -p $PREFIX
 cd $INSTALL_POS
 
 
@@ -145,7 +160,7 @@ GCC_FILE_TAR="${GCC_FILE}.tar.gz"
 if [ ! -n "$(find $PREFIX/bin/* -name $TARGET_GCC)" ] || [ ${KEEP_GCC} -ne 1 ]; then
     if [ $KEEP_GCC -eq 1 ]; then
         echo -e "\033[35m 没有检测到 $TARGET_GCC, -kg参数无效 \033[0m"
-        echo -e "\033[35m 开始安装binutils \033[0m"
+        echo -e "\033[35m 开始安装gcc \033[0m"
         sleep 1s
     fi
     if [ ! -d "$GCC_FILE" ]; then

--- a/tools/grub_auto_install.sh
+++ b/tools/grub_auto_install.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-CURRENT_SHELL=$(basename $SHELL)
+
+if test -n "$ZSH_VERSION"; then
+  CURRENT_SHELL=zsh
+elif test -n "$BASH_VERSION"; then
+  CURRENT_SHELL=bash
+elif test -n "$KSH_VERSION"; then
+  CURRENT_SHELL=ksh
+elif test -n "$FCEDIT"; then
+  CURRENT_SHELL=ksh
+elif test -n "$PS3"; then
+  CURRENT_SHELL=unknown
+else
+  CURRENT_SHELL=sh
+fi
+
 source "$HOME/.$CURRENT_SHELL"rc
 
 ABS_PREFIX=/opt/dragonos-grub


### PR DESCRIPTION
1. archlinux上没有libssl-dev包，相对应的包名是openssl
2. zsh用户使用bootstrap.sh 会因为 source ~/.zshrc
   导致bash执行很多zsh built-in 指令出现非常多错误
3. mkdir命令加-p选项避免对象目录存在时（反复执行脚本）报错
4. 修复简单错误(typo gcc 为 binutils)
5. 修复bootstrap.sh等脚本无法在非tools/目录执行的错误