### PR TITLE
修复Archlinux下的bootstrap脚本问题，

### DIFF
--- a/env.mk
+++ b/env.mk
@@ -12,6 +12,8 @@ endif
 # 设置编译器
 ifeq ($(ARCH), x86_64)
 
+export PATH := ${PATH}:${HOME}/opt/x86_64-linux-musl-cross-gcc-9.4.0/bin
+
 # 如果 x86_64时，DragonOS_GCC 为空，那么设置为默认值
 export DragonOS_GCC?=$(HOME)/opt/dragonos-gcc/gcc-x86_64-unknown-none/bin
 
@@ -23,6 +25,8 @@ export AR=$(DragonOS_GCC)/x86_64-elf-ar
 export OBJCOPY=$(DragonOS_GCC)/x86_64-elf-objcopy
 
 else ifeq ($(ARCH), riscv64)
+
+export PATH := ${PATH}:${HOME}/opt/riscv64-linux-musl-cross-gcc-9.4.0/bin
 
 export CC=riscv64-unknown-elf-gcc
 # binutils版本需要>=2.38

--- a/env.mk
+++ b/env.mk
@@ -12,8 +12,6 @@ endif
 # 设置编译器
 ifeq ($(ARCH), x86_64)
 
-export PATH := ${PATH}:${HOME}/opt/x86_64-linux-musl-cross-gcc-9.4.0/bin
-
 # 如果 x86_64时，DragonOS_GCC 为空，那么设置为默认值
 export DragonOS_GCC?=$(HOME)/opt/dragonos-gcc/gcc-x86_64-unknown-none/bin
 
@@ -25,8 +23,6 @@ export AR=$(DragonOS_GCC)/x86_64-elf-ar
 export OBJCOPY=$(DragonOS_GCC)/x86_64-elf-objcopy
 
 else ifeq ($(ARCH), riscv64)
-
-export PATH := ${PATH}:${HOME}/opt/riscv64-linux-musl-cross-gcc-9.4.0/bin
 
 export CC=riscv64-unknown-elf-gcc
 # binutils版本需要>=2.38

--- a/tools/build_gcc_toolchain.sh
+++ b/tools/build_gcc_toolchain.sh
@@ -180,10 +180,10 @@ if [ ! -n "$(find $PREFIX/bin/* -name $TARGET_GCC)" ] || [ ${KEEP_GCC} -ne 1 ]; 
     mkdir build-gcc
     cd build-gcc
     ../${GCC_FILE}/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers
-    make all-gcc -j $(nproc) || exit 1
-    make all-target-libgcc -j $(nproc)  || exit 1
-    make install-gcc -j $(nproc)  || exit 1
-    make install-target-libgcc -j $(nproc)  || exit 1
+    make MAKEINFO=true all-gcc -j $(nproc) || exit 1
+    make MAKEINFO=true all-target-libgcc -j $(nproc)  || exit 1
+    make MAKEINFO=true install-gcc -j $(nproc)  || exit 1
+    make MAKEINFO=true install-target-libgcc -j $(nproc)  || exit 1
     cd ..
 fi
 
@@ -196,7 +196,7 @@ else
 	echo 'export PATH="$DragonOS_GCC:$PATH"'	>> "$HOME/.$(basename $SHELL)rc"
 	echo "[info] Add DragonOS_GCC into PATH successfully."
 fi
-source "$HOME/.$(basename $SHELL)rc"
+source "$HOME/.$CURRENT_SHELL"rc
 
 # final check
 if [ -n "$(find $PREFIX/bin/* -name $TARGET_GCC)" ] &&


### PR DESCRIPTION
由于archlinux 的 texinfo版本太新导致的gcc  #docs构建失败
使用 MAKEINFO=true 的make环境变量跳过gcc docs构建，绕过问题

修复make run时候遇到的编译user/apps时找不到指定工具链的问题

修复问题 #536 