### PR TITLE
实现SYS_RMDIR

### DIFF
--- a/kernel/src/filesystem/vfs/syscall.rs
+++ b/kernel/src/filesystem/vfs/syscall.rs
@@ -574,6 +574,15 @@ impl Syscall {
         }
     }
 
+    pub fn rmdir(pathname: *const u8) -> Result<usize, SystemError> {
+        let pathname: String = check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?;
+        if pathname.len() >= MAX_PATHLEN {
+            return Err(SystemError::ENAMETOOLONG);
+        }
+        let pathname = pathname.as_str().trim();
+        return do_remove_dir(AtFlags::AT_FDCWD.bits(), pathname).map(|v| v as usize);
+    }
+
     pub fn unlink(pathname: *const u8) -> Result<usize, SystemError> {
         if pathname.is_null() {
             return Err(SystemError::EFAULT);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -407,6 +407,12 @@ impl Syscall {
                     }
                 }
             }
+            
+            #[cfg(target_arch = "x86_64")]
+            SYS_RMDIR => {
+                let pathname = args[0] as *const u8;
+                Self::rmdir(pathname)
+            }
 
             #[cfg(target_arch = "x86_64")]
             SYS_UNLINK => {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -407,7 +407,7 @@ impl Syscall {
                     }
                 }
             }
-            
+
             #[cfg(target_arch = "x86_64")]
             SYS_RMDIR => {
                 let pathname = args[0] as *const u8;

--- a/kernel/src/syscall/syscall_num.h
+++ b/kernel/src/syscall/syscall_num.h
@@ -65,6 +65,8 @@
 
 #define SYS_MKDIR 83
 
+#define SYS_RMDIR 84
+
 #define SYS_GETTIMEOFDAY 96
 
 #define SYS_ARCH_PRCTL 158


### PR DESCRIPTION
# 在vfs/syscall添加rmdir实现

## 没有复用unlink的原因：
1.模仿linux调用do_rmdir，同层不相互调用；2.unlink和rmdir的行为有差异；3.下层实现了do_remove_dir；
### unlink和rmdir的行为差异：
1.rmdir要判断空目录；2.rmdir在路径最后的成员为.时EINVAL，unlink在unlinkat的flag错误时EINVAL；

## 对do_remove_dir的修改：
### 1.先查找parent_path，再查找其子项，而非先直接从inode_begin查找子项
理由：1. 修改后逻辑差别是将对inode子项的错误判断交给find；2.子项为symlink时rmdir会ENOTDIR，不需要再跳转，故可以使用find；3.路径长时可以提高性能；
### 2.在此函数实现对尾随.项的判断，而非在下层的rmdir
理由：不需要查找inode即可返回，同时功能一致。

## 可以继续的工作：
1.统一unlinkat和unlink甚至mkdir等在vfs/syscall中的功能重复的代码；2. ramfs的rmdir中添加判空；3. shell中的rmdirbu不应可以删除/file/path/.

## 功能测试
![image](https://github.com/DragonOS-Community/DragonOS/assets/109664121/30882927-f9f4-48d1-8d92-c28fa5158b03)

