### PR TITLE
Patch-fix-clippy-240311

### DIFF
--- a/kernel/crates/bitmap/src/bitmap_core.rs
+++ b/kernel/crates/bitmap/src/bitmap_core.rs
@@ -61,8 +61,8 @@ impl<T: BitOps> BitMapCore<T> {
     pub(crate) fn first_index(&self, data: &[T]) -> Option<usize> {
         for (i, element) in data.iter().enumerate() {
             let bit = <T as BitOps>::first_index(element);
-            if bit.is_some() {
-                return Some(i * T::bit_size() + bit.unwrap());
+            if let Some(b) = bit {
+                return Some(i * T::bit_size() + b);
             }
         }
 
@@ -237,10 +237,8 @@ impl<T: BitOps> BitMapCore<T> {
                 if element == mask {
                     return true;
                 }
-            } else {
-                if element != &T::make_mask(T::bit_size()) {
+            } else if element != &T::make_mask(T::bit_size()) {
                     return false;
-                }
             }
         }
 

--- a/kernel/crates/bitmap/src/traits.rs
+++ b/kernel/crates/bitmap/src/traits.rs
@@ -309,6 +309,8 @@ pub trait BitMapOps<T: BitOps> {
     /// 判断bitmap是否为空
     fn is_empty(&self) -> bool;
 
+    /// # Safety
+    /// 
     /// 将bitmap转换为字节数组
     unsafe fn as_bytes(&self) -> &[u8];
 }

--- a/kernel/crates/unified-init/macros/src/lib.rs
+++ b/kernel/crates/unified-init/macros/src/lib.rs
@@ -42,7 +42,7 @@ use uuid::Uuid;
 #[proc_macro_attribute]
 pub fn unified_init(args: TokenStream, input: TokenStream) -> TokenStream {
     do_unified_init(args, input)
-        .unwrap_or_else(|e| e.to_compile_error().into())
+        .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }
 
@@ -59,7 +59,7 @@ fn do_unified_init(args: TokenStream, input: TokenStream) -> syn::Result<proc_ma
 
     // 在旁边添加一个UnifiedInitializer
     let initializer =
-        generate_unified_initializer(&function, &target_slice, function.sig.ident.to_string())?;
+        generate_unified_initializer(&function, target_slice, function.sig.ident.to_string())?;
 
     // 拼接
     let mut output = proc_macro2::TokenStream::new();
@@ -111,7 +111,7 @@ fn check_function_signature(function: &ItemFn) -> syn::Result<()> {
                     if let syn::GenericArgument::Type(type_arg) = generic_args.args.first().unwrap()
                     {
                         if let syn::Type::Tuple(tuple) = type_arg {
-                            if tuple.elems.len() != 0 {
+                            if !tuple.elems.is_empty() {
                                 return Err(syn::Error::new(tuple.span(), "Expected empty tuple"));
                             }
                         } else {
@@ -166,7 +166,7 @@ fn generate_unified_initializer(
     let initializer_name = format!(
         "unified_initializer_{}_{}",
         raw_initializer_name,
-        Uuid::new_v4().to_simple().to_string().to_ascii_uppercase()[..8].to_string()
+        &Uuid::new_v4().to_simple().to_string().to_ascii_uppercase()[..8]
     )
     .to_ascii_uppercase();
 

--- a/kernel/src/arch/x86_64/asm/entry.S
+++ b/kernel/src/arch/x86_64/asm/entry.S
@@ -327,6 +327,7 @@ ENTRY(ignore_int)
 
 ENTRY(syscall_64)
     // 切换用户栈和内核栈
+    cli
     swapgs
     movq %rsp, %gs:0x8
     movq %gs:0x0, %rsp
@@ -372,10 +373,12 @@ ENTRY(syscall_64)
 
     movq %rsp, %rdi // 把栈指针装入rdi，作为函数的第一个的参数
 
+    sti
     callq *%rdx //调用服务程序
 
     // 将原本要返回的栈帧的栈指针传入do_signal的第一个参数
     movq %rsp, %rdi
+
     callq do_signal
 
     cli

--- a/kernel/src/arch/x86_64/driver/apic/lapic_vector.rs
+++ b/kernel/src/arch/x86_64/driver/apic/lapic_vector.rs
@@ -205,14 +205,13 @@ pub(super) fn irq_msi_compose_msg(cfg: &HardwareIrqConfig, msg: &mut MsiMsg, dma
         // todo: 判断vmx是否支持 extended destination mode
         // 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/arch/x86/kernel/apic/apic.c?fi=__irq_msi_compose_msg#2580
         address_lo.set_virt_destid_8_14(cfg.apic_id.data() >> 8);
-    } else {
-        if unlikely(cfg.apic_id.data() > 0xff) {
-            kwarn!(
-                "irq_msi_compose_msg: Invalid APIC ID: {}",
-                cfg.apic_id.data()
-            );
-        }
+    } else if unlikely(cfg.apic_id.data() > 0xff) {
+        kwarn!(
+            "irq_msi_compose_msg: Invalid APIC ID: {}",
+            cfg.apic_id.data()
+        );
     }
+    
     msg.address_hi = address_hi.into();
     msg.address_lo = address_lo.into();
     msg.data = arch_data.into();

--- a/kernel/src/arch/x86_64/interrupt/ipi.rs
+++ b/kernel/src/arch/x86_64/interrupt/ipi.rs
@@ -80,13 +80,12 @@ impl Into<ApicId> for ArchIpiTarget {
     fn into(self) -> ApicId {
         if let ArchIpiTarget::Specified(id) = self {
             return id;
+        } else if CurrentApic.x2apic_enabled() {
+            return x86::apic::ApicId::X2Apic(0);
         } else {
-            if CurrentApic.x2apic_enabled() {
-                return x86::apic::ApicId::X2Apic(0);
-            } else {
-                return x86::apic::ApicId::XApic(0);
-            }
+            return x86::apic::ApicId::XApic(0);
         }
+        
     }
 }
 

--- a/kernel/src/arch/x86_64/interrupt/trap.rs
+++ b/kernel/src/arch/x86_64/interrupt/trap.rs
@@ -224,13 +224,12 @@ unsafe extern "C" fn do_invalid_TSS(regs: &'static TrapFrame, error_code: u64) {
     let msg2: &str;
     if (error_code & 0x02) != 0 {
         msg2 = ERR_MSG_2;
+    } else if (error_code & 0x04) != 0 {
+        msg2 = ERR_MSG_3;
     } else {
-        if (error_code & 0x04) != 0 {
-            msg2 = ERR_MSG_3;
-        } else {
-            msg2 = ERR_MSG_4;
-        }
+        msg2 = ERR_MSG_4;
     }
+    
     kerror!(
         "do_invalid_TSS(10), \tError code: {:#x},\trsp: {:#x},\trip: {:#x},\t CPU: {}, \tpid: {:?}\n{}{}",
         error_code,

--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -415,7 +415,8 @@ pub struct X86_64SignalArch;
 impl SignalArch for X86_64SignalArch {
     unsafe fn do_signal(frame: &mut TrapFrame) {
         let pcb = ProcessManager::current_pcb();
-        let siginfo = pcb.try_siginfo(5);
+
+        let siginfo = pcb.try_siginfo_irqsave(5);
 
         if unlikely(siginfo.is_none()) {
             return;
@@ -437,7 +438,7 @@ impl SignalArch for X86_64SignalArch {
         let sig_block: SigSet = siginfo_read_guard.sig_block().clone();
         drop(siginfo_read_guard);
 
-        let sig_guard = pcb.try_sig_struct_irq(5);
+        let sig_guard = pcb.try_sig_struct_irqsave(5);
         if unlikely(sig_guard.is_none()) {
             return;
         }

--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -275,7 +275,7 @@ bitflags! {
         const SIGSYS   =  1<<30;
         const SIGRTMIN =  1<<31;
         // TODO 写上实时信号
-        const SIGRTMAX =  1<<MAX_SIG_NUM-1;
+        const SIGRTMAX =  1 << (MAX_SIG_NUM-1);
     }
 }
 

--- a/kernel/src/arch/x86_64/syscall/mod.rs
+++ b/kernel/src/arch/x86_64/syscall/mod.rs
@@ -64,7 +64,7 @@ macro_rules! syscall_return {
 }
 
 #[no_mangle]
-pub extern "sysv64" fn syscall_handler(frame: &mut TrapFrame) -> () {
+pub extern "sysv64" fn syscall_handler(frame: &mut TrapFrame) {
     let syscall_num = frame.rax as usize;
     // 防止sys_sched由于超时无法退出导致的死锁
     if syscall_num == SYS_SCHED {

--- a/kernel/src/driver/base/block/block_device.rs
+++ b/kernel/src/driver/base/block/block_device.rs
@@ -62,7 +62,7 @@ impl BlockIter {
         return BlockIter {
             begin: start_addr,
             end: end_addr,
-            blk_size_log2: blk_size_log2,
+            blk_size_log2,
             multiblock: false,
         };
     }
@@ -92,9 +92,9 @@ impl BlockIter {
         return BlockRange {
             lba_start: lba_id,
             lba_end: lba_id + 1,
-            begin: begin,
-            end: end,
-            blk_size_log2: blk_size_log2,
+            begin,
+            end,
+            blk_size_log2,
         };
     }
 
@@ -119,11 +119,11 @@ impl BlockIter {
         self.begin += end - begin;
 
         return BlockRange {
-            lba_start: lba_start,
-            lba_end: lba_end,
-            begin: begin,
-            end: end,
-            blk_size_log2: blk_size_log2,
+            lba_start,
+            lba_end,
+            begin,
+            end,
+            blk_size_log2,
         };
     }
 }

--- a/kernel/src/driver/base/device/dd.rs
+++ b/kernel/src/driver/base/device/dd.rs
@@ -94,11 +94,9 @@ impl DeviceManager {
                 if unlikely(r.is_err()) {
                     flag = false;
                     break;
-                } else {
-                    if r.unwrap() == true {
-                        flag = true;
-                        break;
-                    }
+                } else if r.unwrap() == true {
+                    flag = true;
+                    break;
                 }
             }
 
@@ -158,10 +156,8 @@ impl DeviceManager {
                     );
                     return Err(e);
                 }
-            } else {
-                if r.unwrap() == false {
-                    return Ok(false);
-                }
+            } else if r.unwrap() == false {
+                return Ok(false);
             }
         }
 
@@ -211,14 +207,12 @@ impl DeviceManager {
             self.device_links_force_bind(dev);
             driver_manager().driver_bound(dev);
             return Err(e);
-        } else {
-            if let Some(bus) = dev.bus().map(|bus| bus.upgrade()).flatten() {
-                bus.subsystem().bus_notifier().call_chain(
-                    BusNotifyEvent::DriverNotBound,
-                    Some(dev),
-                    None,
-                );
-            }
+        } else if let Some(bus) = dev.bus().map(|bus| bus.upgrade()).flatten() {
+            bus.subsystem().bus_notifier().call_chain(
+                BusNotifyEvent::DriverNotBound,
+                Some(dev),
+                None,
+            );
         }
         return r;
     }

--- a/kernel/src/driver/base/device/device_number.rs
+++ b/kernel/src/driver/base/device/device_number.rs
@@ -33,7 +33,7 @@ pub struct DeviceNumber {
 
 impl DeviceNumber {
     pub const MINOR_BITS: u32 = 20;
-    pub const MINOR_MASK: u32 = 1 << Self::MINOR_BITS - 1;
+    pub const MINOR_MASK: u32 = 1 << (Self::MINOR_BITS - 1);
 
     pub const fn new(major: Major, minor: u32) -> Self {
         Self {

--- a/kernel/src/driver/base/device/driver.rs
+++ b/kernel/src/driver/base/device/driver.rs
@@ -287,9 +287,9 @@ impl DriverMatcher<&str> for DriverMatchName {
 }
 
 /// enum probe_type - device driver probe type to try
-///	Device drivers may opt in for special handling of their
-///	respective probe routines. This tells the core what to
-///	expect and prefer.
+/// Device drivers may opt in for special handling of their
+/// respective probe routines. This tells the core what to
+/// expect and prefer.
 ///
 /// Note that the end goal is to switch the kernel to use asynchronous
 /// probing by default, so annotating drivers with
@@ -300,18 +300,18 @@ impl DriverMatcher<&str> for DriverMatchName {
 #[derive(Debug)]
 pub enum DriverProbeType {
     /// Used by drivers that work equally well
-    ///	whether probed synchronously or asynchronously.
+    /// whether probed synchronously or asynchronously.
     DefaultStrategy,
 
     /// Drivers for "slow" devices which
-    ///	probing order is not essential for booting the system may
-    ///	opt into executing their probes asynchronously.
+    /// probing order is not essential for booting the system may
+    /// opt into executing their probes asynchronously.
     PreferAsync,
 
     /// Use this to annotate drivers that need
-    ///	their probe routines to run synchronously with driver and
-    ///	device registration (with the exception of -EPROBE_DEFER
-    ///	handling - re-probing always ends up being done asynchronously).
+    /// their probe routines to run synchronously with driver and
+    /// device registration (with the exception of -EPROBE_DEFER
+    /// handling - re-probing always ends up being done asynchronously).
     ForceSync,
 }
 

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -98,11 +98,11 @@ pub fn sys_dev_char_kset() -> Arc<KSet> {
     unsafe { DEV_CHAR_KSET_INSTANCE.as_ref().unwrap().clone() }
 }
 
-pub(self) unsafe fn set_sys_dev_block_kset(kset: Arc<KSet>) {
+unsafe fn set_sys_dev_block_kset(kset: Arc<KSet>) {
     DEV_BLOCK_KSET_INSTANCE = Some(kset);
 }
 
-pub(self) unsafe fn set_sys_dev_char_kset(kset: Arc<KSet>) {
+unsafe fn set_sys_dev_char_kset(kset: Arc<KSet>) {
     DEV_CHAR_KSET_INSTANCE = Some(kset);
 }
 
@@ -111,7 +111,7 @@ pub fn sys_devices_virtual_kset() -> Arc<KSet> {
     unsafe { DEVICES_VIRTUAL_KSET_INSTANCE.as_ref().unwrap().clone() }
 }
 
-pub(self) unsafe fn set_sys_devices_virtual_kset(kset: Arc<KSet>) {
+unsafe fn set_sys_devices_virtual_kset(kset: Arc<KSet>) {
     DEVICES_VIRTUAL_KSET_INSTANCE = Some(kset);
 }
 

--- a/kernel/src/driver/disk/ahci/ahci_inode.rs
+++ b/kernel/src/driver/disk/ahci/ahci_inode.rs
@@ -39,7 +39,7 @@ impl LockedAhciInode {
             // uuid: Uuid::new_v5(),
             self_ref: Weak::default(),
             fs: Weak::default(),
-            disk: disk,
+            disk,
             metadata: Metadata {
                 dev_id: 1,
                 inode_id: generate_inode_id(),

--- a/kernel/src/driver/firmware/efi/tables.rs
+++ b/kernel/src/driver/firmware/efi/tables.rs
@@ -25,7 +25,7 @@ use super::{
 };
 
 /// 所有的要解析的表格的解析器
-static TABLE_PARSERS: &'static [&'static TableMatcher] = &[
+static TABLE_PARSERS: &[&TableMatcher] = &[
     &TableMatcher::new(&MatchTableDragonStubPayloadEFI),
     &TableMatcher::new(&MatchTableMemoryAttributes),
     &TableMatcher::new(&MatchTableMemReserve),

--- a/kernel/src/driver/net/e1000e/e1000e.rs
+++ b/kernel/src/driver/net/e1000e/e1000e.rs
@@ -155,7 +155,7 @@ impl E1000EBuffer {
         return self.length;
     }
     // 释放buffer内部的dma_pages，需要小心使用
-    pub fn free_buffer(self) -> () {
+    pub fn free_buffer(self) {
         if self.length != 0 {
             unsafe { dma_dealloc(self.paddr, self.buffer, E1000E_DMA_PAGES) };
         }
@@ -593,7 +593,7 @@ pub extern "C" fn rs_e1000e_init() {
     e1000e_init();
 }
 
-pub fn e1000e_init() -> () {
+pub fn e1000e_init() {
     match e1000e_probe() {
         Ok(_code) => {
             kinfo!("Successfully init e1000e device!");

--- a/kernel/src/driver/open_firmware/fdt.rs
+++ b/kernel/src/driver/open_firmware/fdt.rs
@@ -92,10 +92,10 @@ impl OpenFirmwareFdtDriver {
 
     /// 扫描 `/chosen` 节点
     fn early_init_scan_chosen(&self, fdt: &Fdt) -> Result<(), SystemError> {
-        const CHOSEN_NAME1: &'static str = "/chosen";
+        const CHOSEN_NAME1: &str = "/chosen";
         let mut node = fdt.find_node(CHOSEN_NAME1);
         if node.is_none() {
-            const CHOSEN_NAME2: &'static str = "/chosen@0";
+            const CHOSEN_NAME2: &str = "/chosen@0";
             node = fdt.find_node(CHOSEN_NAME2);
             if node.is_some() {
                 FDT_GLOBAL_DATA.write().chosen_node_name = Some(CHOSEN_NAME2);

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -140,12 +140,12 @@ bitflags! {
     /// termios输入特性
     pub struct InputMode: u32 {
         /// 如果设置了该标志，表示启用软件流控制。
-        const IXON = 0x0200;
+        const IXON = 0x0400;
         /// 如果设置了该标志，表示启用输入流控制。
-        const IXOFF = 0x0400;
+        const IXOFF = 0x1000;
         /// Map Uppercase to Lowercase on Input 将大写转换为小写
         /// 表示不区分大小写
-        const IUCLC = 0x1000;
+        const IUCLC = 0x0200;
         /// 如果设置了该标志，表示当输入队列满时，产生一个响铃信号。
         const IMAXBEL = 0x2000;
         /// 如果设置了该标志，表示输入数据被视为 UTF-8 编码。
@@ -176,46 +176,44 @@ bitflags! {
     /// termios输出特性
     pub struct OutputMode: u32 {
         /// 在输出时将换行符替换\r\n
-        const ONLCR	= 0x00002;
+        const ONLCR	= 0x00004;
         /// Map Lowercase to Uppercase on Output 输出字符时将小写字母映射为大写字母
-        const OLCUC	= 0x00004;
+        const OLCUC	= 0x00002;
 
         /// 与NL协同 配置换行符的处理方式
-        const NLDLY	= 0x00300;
+        const NLDLY	= 0x00100;
         const   NL0	= 0x00000;  // 不延迟换行
         const   NL1	= 0x00100;  // 延迟换行（输出回车后等待一段时间再输出换行）
-        const   NL2	= 0x00200;  // NL2 和 NL3保留，暂未使用
-        const   NL3	= 0x00300;
 
         /// 配置水平制表符的处理方式
-        const TABDLY = 0x00c00;
+        const TABDLY = 0x01800;
         const  TAB0 = 0x00000;  // 不延迟水平制表符
-        const  TAB1 = 0x00400;  // 在输出水平制表符时，延迟到下一个设置的水平制表符位置
-        const  TAB2 = 0x00800;  // 在输出水平制表符时，延迟到下一个设置的 8 的倍数的位置
-        const  TAB3 = 0x00c00;  // TAB3 和 XTABS（与 TAB3 等效）保留，暂未使用
-        const XTABS = 0x00c00;
+        const  TAB1 = 0x00800;  // 在输出水平制表符时，延迟到下一个设置的水平制表符位置
+        const  TAB2 = 0x01000;  // 在输出水平制表符时，延迟到下一个设置的 8 的倍数的位置
+        const  TAB3 = 0x01800;  // TAB3 和 XTABS（与 TAB3 等效）保留，暂未使用
+        const XTABS = 0x01800;
 
         /// 配置回车符的处理方式
-        const CRDLY	= 0x03000;
+        const CRDLY	= 0x00600;
         const   CR0	= 0x00000;  // 不延迟回车
-        const   CR1	= 0x01000;  //  延迟回车（输出回车后等待一段时间再输出换行）
-        const   CR2	= 0x02000;  // CR2 和 CR3保留，暂未使用
-        const   CR3	= 0x03000;
+        const   CR1	= 0x02000;  //  延迟回车（输出回车后等待一段时间再输出换行）
+        const   CR2	= 0x04000;  // CR2 和 CR3保留，暂未使用
+        const   CR3	= 0x06000;
 
         /// 配置换页符（form feed）的处理方式
-        const FFDLY	= 0x04000;
+        const FFDLY	= 0x08000;
         const   FF0	= 0x00000;  // 不延迟换页
-        const   FF1	= 0x04000;  // 延迟换页
+        const   FF1	= 0x08000;  // 延迟换页
 
         /// 配置退格符（backspace）的处理方式
-        const BSDLY	= 0x08000;
+        const BSDLY	= 0x02000;
         const   BS0	= 0x00000;  // 不延迟退格
-        const   BS1	= 0x08000;  // 延迟退格
+        const   BS1	= 0x02000;  // 延迟退格
 
         /// 配置垂直制表符（vertical tab）的处理方式
-        const VTDLY	= 0x10000;
+        const VTDLY	= 0x04000;
         const   VT0	= 0x00000;  // 不延迟垂直制表符
-        const   VT1	= 0x10000;  // 延迟垂直制表符
+        const   VT1	= 0x04000;  // 延迟垂直制表符
 
         /// 表示执行输出处理，即启用输出处理函数
         const OPOST	= 0x01;
@@ -234,13 +232,14 @@ bitflags! {
     /// 配置终端设备的基本特性和控制参数
     pub struct ControlMode: u32 {
         /// Baud Rate Mask 指定波特率的掩码
-        const CBAUD		= 0x000000ff;
+        const CBAUD		= 0x0000100f;
         /// Extra Baud Bits 指定更高的波特率位
-        const CBAUDEX	= 0x00000000;
+        const CBAUDEX	= 0x00001000;
         /// Custom Baud Rate 指定自定义波特率 如果设置了 BOTHER，则通过以下位来设置自定义的波特率值
-        const BOTHER	= 0x0000001f;
+        const BOTHER	= 0x00001000;
 
-        const     B0	= 0x00000000;
+        /* Common CBAUD rates */
+        const     B0	= 0x00000000;	/* hang up */
         const    B50	= 0x00000001;
         const    B75	= 0x00000002;
         const   B110	= 0x00000003;
@@ -257,43 +256,43 @@ bitflags! {
         const B19200	= 0x0000000e;
         const B38400	= 0x0000000f;
 
-        const    B57600	= 0x00000010;
-        const   B115200	= 0x00000011;
-        const   B230400	= 0x00000012;
-        const   B460800	= 0x00000013;
-        const   B500000	= 0x00000014;
-        const   B576000	= 0x00000015;
-        const   B921600	= 0x00000016;
-        const  B1000000	= 0x00000017;
-        const  B1152000	= 0x00000018;
-        const  B1500000	= 0x00000019;
-        const  B2000000	= 0x0000001a;
-        const  B2500000	= 0x0000001b;
-        const  B3000000	= 0x0000001c;
-        const  B3500000	= 0x0000001d;
-        const  B4000000	= 0x0000001e;
+        const     B57600 = 0x00001001;
+        const    B115200 = 0x00001002;
+        const    B230400 = 0x00001003;
+        const    B460800 = 0x00001004;
+        const    B500000 = 0x00001005;
+        const    B576000 = 0x00001006;
+        const    B921600 = 0x00001007;
+        const   B1000000 = 0x00001008;
+        const   B1152000 = 0x00001009;
+        const   B1500000 = 0x0000100a;
+        const   B2000000 = 0x0000100b;
+        const   B2500000 = 0x0000100c;
+        const   B3000000 = 0x0000100d;
+        const   B3500000 = 0x0000100e;
+        const   B4000000 = 0x0000100f;
 
         /// 指定字符大小的掩码 以下位为特定字符大小
-        const CSIZE		= 0x00000300;
+        const CSIZE		= 0x00000030;
         const   CS5		= 0x00000000;
-        const   CS6		= 0x00000100;
-        const   CS7		= 0x00000200;
-        const   CS8		= 0x00000300;
+        const   CS6		= 0x00000010;
+        const   CS7		= 0x00000020;
+        const   CS8		= 0x00000030;
 
         /// Stop Bit Select 表示使用两个停止位；否则，表示使用一个停止位
-        const CSTOPB	= 0x00000400;
+        const CSTOPB	= 0x00000040;
         /// 表示启用接收器。如果未设置，则禁用接收器。
-        const CREAD		= 0x00000800;
+        const CREAD		= 0x00000080;
         /// 表示启用奇偶校验。如果未设置，则禁用奇偶校验。
-        const PARENB	= 0x00001000;
+        const PARENB	= 0x00000100;
         /// 表示启用奇校验。如果未设置，则表示启用偶校验。
-        const PARODD	= 0x00002000;
+        const PARODD	= 0x00000200;
         /// 表示在终端设备被关闭时挂断线路（执行挂断操作）
-        const HUPCL		= 0x00004000;
+        const HUPCL		= 0x00000400;
         /// 表示忽略调制解调器的状态（DCD、DSR、CTS 等）
-        const CLOCAL	= 0x00008000;
+        const CLOCAL	= 0x00000800;
         /// 指定输入波特率的掩码
-        const CIBAUD	= 0x00ff0000;
+        const CIBAUD	= 0x100f0000;
 
         const ADDRB = 0x20000000;
     }
@@ -301,37 +300,37 @@ bitflags! {
     /// 配置终端设备的本地模式（local mode）或控制输入处理的行为
     pub struct LocalMode: u32 {
         /// 启用中断字符（Ctrl-C、Ctrl-Z）
-        const ISIG	 = 0x00000080;
+        const ISIG	 = 0x00001;
         /// 表示启用规范模式，即启用行缓冲和回显。在规范模式下，输入被缓冲，并且只有在输入回车符时才会传递给应用程序。
-        const ICANON = 0x00000100;
+        const ICANON = 0x00002;
         /// 表示启用大写模式，即输入输出都将被转换为大写。
-        const XCASE	 = 0x00004000;
+        const XCASE	 = 0x00004;
         /// 表示启用回显（显示用户输入的字符）
-        const ECHO	 = 0x00000008;
+        const ECHO	 = 0x00008;
         /// 表示在回显时将擦除的字符用 backspace 和空格字符显示。
-        const ECHOE	 = 0x00000002;
+        const ECHOE	 = 0x00010;
         /// 表示在回显时将换行符后的字符用空格字符显示。
-        const ECHOK	 = 0x00000004;
+        const ECHOK	 = 0x00020;
         /// 表示在回显时将换行符显示为换行和回车符。
-        const ECHONL = 0x00000010;
+        const ECHONL = 0x00040;
         /// 表示在收到中断（Ctrl-C）和退出（Ctrl-\）字符后，不清空输入和输出缓冲区。
-        const NOFLSH = 0x80000000;
+        const NOFLSH = 0x00080;
         /// 表示在后台进程尝试写入终端时，发送停止信号（Ctrl-S）
-        const TOSTOP = 0x00400000;
+        const TOSTOP = 0x00100;
         /// 表示在回显时，显示控制字符为 ^ 加字符。
-        const ECHOCTL= 0x00000040;
+        const ECHOCTL= 0x00200;
         /// 表示在回显时显示带有 # 的换行符（为了与 echo -n 命令兼容）。
-        const ECHOPRT= 0x00000020;
+        const ECHOPRT= 0x00400;
         /// 表示在回显时将 KILL 字符（Ctrl-U）用空格字符显示。
-        const ECHOKE = 0x00000001;
+        const ECHOKE = 0x00800;
         /// 表示输出正在被冲刷（flush），通常是由于输入/输出流的状态变化。
-        const FLUSHO = 0x00800000;
+        const FLUSHO = 0x01000;
         /// 表示在规范模式下，存在需要重新打印的字符。
-        const PENDIN = 0x20000000;
+        const PENDIN = 0x04000;
         /// 表示启用实现定义的输入处理。
-        const IEXTEN = 0x00000400;
+        const IEXTEN = 0x08000;
         /// 表示启用扩展的处理函数
-        const EXTPROC= 0x10000000;
+        const EXTPROC= 0x10000;
     }
 
     pub struct TtySetTermiosOpt: u8 {

--- a/kernel/src/driver/tty/tty_driver.rs
+++ b/kernel/src/driver/tty/tty_driver.rs
@@ -236,10 +236,8 @@ impl TtyDriver {
                 // TODO: 暂时这么写，因为还没写TtyPort
                 if tty.core().port().is_none() {
                     kwarn!("{} port is None", tty.core().name());
-                } else {
-                    if tty.core().port().unwrap().state() == TtyPortState::KOPENED {
-                        return Err(SystemError::EBUSY);
-                    }
+                } else if tty.core().port().unwrap().state() == TtyPortState::KOPENED {
+                    return Err(SystemError::EBUSY);
                 }
 
                 tty.reopen()?;

--- a/kernel/src/driver/tty/tty_job_control.rs
+++ b/kernel/src/driver/tty/tty_job_control.rs
@@ -34,7 +34,9 @@ impl TtyJobCtrlManager {
     pub fn tty_check_change(tty: Arc<TtyCore>, sig: Signal) -> Result<(), SystemError> {
         let pcb = ProcessManager::current_pcb();
 
-        if pcb.sig_info().tty().is_none() || !Arc::ptr_eq(&pcb.sig_info().tty().unwrap(), &tty) {
+        if pcb.sig_info_irqsave().tty().is_none()
+            || !Arc::ptr_eq(&pcb.sig_info_irqsave().tty().unwrap(), &tty)
+        {
             return Ok(());
         }
 
@@ -91,8 +93,8 @@ impl TtyJobCtrlManager {
 
                 let mut ctrl = tty.core().contorl_info_irqsave();
 
-                if current.sig_info().tty().is_none()
-                    || !Arc::ptr_eq(&current.sig_info().tty().clone().unwrap(), &tty)
+                if current.sig_info_irqsave().tty().is_none()
+                    || !Arc::ptr_eq(&current.sig_info_irqsave().tty().clone().unwrap(), &tty)
                     || ctrl.session.is_none()
                     || ctrl.session.unwrap() != current.pid()
                 {
@@ -106,8 +108,8 @@ impl TtyJobCtrlManager {
 
             TtyIoctlCmd::TIOCGPGRP => {
                 let current = ProcessManager::current_pcb();
-                if current.sig_info().tty().is_some()
-                    && !Arc::ptr_eq(&current.sig_info().tty().unwrap(), &tty)
+                if current.sig_info_irqsave().tty().is_some()
+                    && !Arc::ptr_eq(&current.sig_info_irqsave().tty().unwrap(), &tty)
                 {
                     return Err(SystemError::ENOTTY);
                 }

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -48,7 +48,7 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
     /// - old: 之前的termios，如果为None则表示第一次设置
     fn set_termios(&self, tty: Arc<TtyCore>, old: Option<Termios>) -> Result<(), SystemError>;
 
-    fn poll(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
+    fn poll(&self, tty: Arc<TtyCore>) -> Result<usize, SystemError>;
     fn hangup(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
 
     /// ## 接收数据

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1447,18 +1447,16 @@ impl NTtyData {
             '\t' => {
                 // 计算输出一个\t需要的空间
                 let spaces = 8 - (self.cursor_column & 7) as usize;
-                if termios.output_mode.contains(OutputMode::TABDLY) {
-                    if OutputMode::TABDLY.bits() == OutputMode::XTABS.bits() {
-                        // 配置的tab选项是真正输出空格到驱动
-                        if space < spaces {
-                            // 空间不够
-                            return Err(SystemError::ENOBUFS);
-                        }
-                        self.cursor_column += spaces as u32;
-                        // 写入sapces个空格
-                        tty.write(core, "        ".as_bytes(), spaces)?;
-                        return Ok(spaces);
+                if termios.output_mode.contains(OutputMode::TABDLY) && OutputMode::TABDLY.bits() == OutputMode::XTABS.bits() {
+                    // 配置的tab选项是真正输出空格到驱动
+                    if space < spaces {
+                    // 空间不够
+                        return Err(SystemError::ENOBUFS);
                     }
+                    self.cursor_column += spaces as u32;
+                    // 写入sapces个空格
+                    tty.write(core, "        ".as_bytes(), spaces)?;
+                    return Ok(spaces);
                 }
                 self.cursor_column += spaces as u32;
             }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1,3 +1,4 @@
+use core::intrinsics::likely;
 use core::ops::BitXor;
 
 use bitmap::{traits::BitMapOps, StaticBitmap};
@@ -249,11 +250,10 @@ impl NTtyData {
             || termios.local_mode.contains(LocalMode::IEXTEN);
 
         let look_ahead = self.lookahead_count.min(count);
-
         if self.real_raw {
-            todo!("tty real raw mode todo");
+            self.receive_buf_real_raw(buf, count);
         } else if self.raw || (termios.local_mode.contains(LocalMode::EXTPROC) && !preops) {
-            todo!("tty raw mode todo");
+            self.receive_buf_raw(buf, flags, count);
         } else if tty.core().is_closing() && !termios.local_mode.contains(LocalMode::EXTPROC) {
             todo!()
         } else {
@@ -282,7 +282,47 @@ impl NTtyData {
         if self.read_cnt() > 0 {
             tty.core()
                 .read_wq()
-                .wakeup((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDBAND).bits() as u64);
+                .wakeup_any((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDBAND).bits() as u64);
+        }
+    }
+
+    fn receive_buf_real_raw(&mut self, buf: &[u8], mut count: usize) {
+        let mut head = ntty_buf_mask(self.read_head);
+        let mut n = count.min(NTTY_BUFSIZE - head);
+
+        // 假如有一部分在队列头部，则这部分是拷贝尾部部分
+        self.read_buf[head..(head + n)].copy_from_slice(&buf[0..n]);
+        self.read_head += n;
+        count -= n;
+        let offset = n;
+
+        // 假如有一部分在队列头部，则这部分是拷贝头部部分
+        head = ntty_buf_mask(self.read_head);
+        n = count.min(NTTY_BUFSIZE - head);
+        self.read_buf[head..(head + n)].copy_from_slice(&buf[offset..(offset + n)]);
+        self.read_head += n;
+    }
+
+    fn receive_buf_raw(&mut self, buf: &[u8], flags: Option<&[u8]>, mut count: usize) {
+        // TTY_NORMAL 目前这部分未做，所以先占位置而不做抽象
+        let mut flag = 1;
+        let mut f_offset = 0;
+        let mut c_offset = 0;
+        while count != 0 {
+            if flags.is_some() {
+                flag = flags.as_ref().unwrap()[f_offset];
+                f_offset += 1;
+            }
+
+            if likely(flag == 1) {
+                self.read_buf[self.read_head] = buf[c_offset];
+                c_offset += 1;
+                self.read_head += 1;
+            } else {
+                todo!()
+            }
+
+            count -= 1;
         }
     }
 
@@ -364,6 +404,7 @@ impl NTtyData {
         }
     }
 
+    #[inline(never)]
     pub fn receive_special_char(&mut self, mut c: u8, tty: Arc<TtyCore>, lookahead_done: bool) {
         let is_flow_ctrl = self.is_flow_ctrl_char(tty.clone(), c, lookahead_done);
         let termios = tty.core().termios();
@@ -467,9 +508,9 @@ impl NTtyData {
                 self.read_buf[ntty_buf_mask(self.read_head)] = c;
                 self.read_head += 1;
                 self.canon_head = self.read_head;
-                tty.core()
-                    .read_wq()
-                    .wakeup((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64);
+                tty.core().read_wq().wakeup_any(
+                    (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64,
+                );
                 return;
             }
 
@@ -480,9 +521,9 @@ impl NTtyData {
                 self.read_buf[ntty_buf_mask(self.read_head)] = c;
                 self.read_head += 1;
                 self.canon_head = self.read_head;
-                tty.core()
-                    .read_wq()
-                    .wakeup((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64);
+                tty.core().read_wq().wakeup_any(
+                    (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64,
+                );
                 return;
             }
 
@@ -508,9 +549,9 @@ impl NTtyData {
                 self.read_buf[ntty_buf_mask(self.read_head)] = c;
                 self.read_head += 1;
                 self.canon_head = self.read_head;
-                tty.core()
-                    .read_wq()
-                    .wakeup((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64);
+                tty.core().read_wq().wakeup_any(
+                    (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64,
+                );
                 return;
             }
         }
@@ -540,6 +581,7 @@ impl NTtyData {
     }
 
     /// ## ntty默认eraser function
+    #[inline(never)]
     fn eraser(&mut self, mut c: u8, termios: &RwLockReadGuard<Termios>) {
         if self.read_head == self.canon_head {
             return;
@@ -907,7 +949,7 @@ impl NTtyData {
             // 有一部分数据在头部,则先拷贝后面部分，再拷贝头部
             // TODO: tty审计？
             to[0..size].copy_from_slice(&self.read_buf[tail..(tail + size)]);
-            to[size..].copy_from_slice(&self.read_buf[(tail + size)..(*n + tail)]);
+            to[size..(*n)].copy_from_slice(&self.read_buf[0..(*n - size)]);
         } else {
             to[..*n].copy_from_slice(&self.read_buf[tail..(tail + *n)])
         }
@@ -975,7 +1017,7 @@ impl NTtyData {
         let size = if tail + n > NTTY_BUFSIZE {
             NTTY_BUFSIZE
         } else {
-            tail + *nr
+            tail + n
         };
 
         // 找到eol的坐标
@@ -1088,7 +1130,7 @@ impl NTtyData {
         let tail = self.read_tail & (NTTY_BUFSIZE - 1);
 
         // 计算出可读的字符数
-        let mut n = (NTTY_BUFSIZE - tail).min(self.read_tail);
+        let mut n = (NTTY_BUFSIZE - tail).min(head - self.read_tail);
         n = n.min(*nr);
 
         if n > 0 {
@@ -1209,6 +1251,7 @@ impl NTtyData {
         }
     }
 
+    #[inline(never)]
     pub fn echoes(&mut self, tty: Arc<TtyCore>) -> Result<usize, SystemError> {
         let mut space = tty.write_room(tty.core());
         let ospace = space;
@@ -1517,6 +1560,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         Ok(())
     }
 
+    #[inline(never)]
     fn read(
         &self,
         tty: Arc<TtyCore>,
@@ -1553,7 +1597,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                     return Ok(len - nr);
                 }
             } else {
-                if ldata.canon_copy_from_read_buf(buf, &mut nr, &mut offset)? {
+                if ldata.copy_from_read_buf(termios, buf, &mut nr, &mut offset)? {
                     return Ok(len - nr);
                 }
             }
@@ -1608,7 +1652,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 }
 
                 if ProcessManager::current_pcb()
-                    .sig_info()
+                    .sig_info_irqsave()
                     .sig_pending()
                     .has_pending()
                 {
@@ -1664,6 +1708,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         ret
     }
 
+    #[inline(never)]
     fn write(
         &self,
         tty: Arc<TtyCore>,
@@ -1685,7 +1730,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         // drop(ldata);
         let mut offset = 0;
         loop {
-            if pcb.sig_info().sig_pending().has_pending() {
+            if pcb.sig_info_irqsave().sig_pending().has_pending() {
                 return Err(SystemError::ERESTARTSYS);
             }
             if core.flags().contains(TtyFlag::HUPPED) {
@@ -1816,6 +1861,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         }
     }
 
+    #[inline(never)]
     fn set_termios(
         &self,
         tty: Arc<TtyCore>,
@@ -1827,14 +1873,13 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let contorl_chars = termios.control_characters;
 
         // 第一次设置或者规范模式 (ICANON) 或者扩展处理 (EXTPROC) 标志发生变化
-        if old.is_none()
-            || (old.is_some()
-                && old
-                    .unwrap()
-                    .local_mode
-                    .bitxor(termios.local_mode)
-                    .contains(LocalMode::ICANON | LocalMode::EXTPROC))
-        {
+        let mut spec_mode_changed = false;
+        if old.is_some() {
+            let local_mode = old.clone().unwrap().local_mode.bitxor(termios.local_mode);
+            spec_mode_changed =
+                local_mode.contains(LocalMode::ICANON) || local_mode.contains(LocalMode::EXTPROC);
+        }
+        if old.is_none() || spec_mode_changed {
             // 重置read_flags
             ldata.read_flags.set_all(false);
 
@@ -1857,10 +1902,8 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             ldata.lnext = false;
         }
 
-        // 设置规范模式
-        if termios.local_mode.contains(LocalMode::ICANON) {
-            ldata.icanon = true;
-        }
+        // 设置模式
+        ldata.icanon = termios.local_mode.contains(LocalMode::ICANON);
 
         // 设置回显
         if termios.local_mode.contains(LocalMode::ECHO) {
@@ -1982,8 +2025,37 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         Ok(())
     }
 
-    fn poll(&self, _tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {
-        todo!()
+    fn poll(&self, tty: Arc<TtyCore>) -> Result<usize, system_error::SystemError> {
+        let core = tty.core();
+        let ldata = self.disc_data();
+
+        let mut event = EPollEventType::empty();
+        if ldata.input_available(core.termios(), true) {
+            event.insert(EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM)
+        }
+
+        if core.contorl_info_irqsave().packet {
+            let link = core.link();
+            if link.is_some() && link.unwrap().core().contorl_info_irqsave().pktstatus != 0 {
+                event.insert(
+                    EPollEventType::EPOLLPRI
+                        | EPollEventType::EPOLLIN
+                        | EPollEventType::EPOLLRDNORM,
+                );
+            }
+        }
+
+        if core.flags().contains(TtyFlag::OTHER_CLOSED) {
+            event.insert(EPollEventType::EPOLLHUP);
+        }
+
+        if core.driver().driver_funcs().chars_in_buffer() < 256
+            && core.driver().driver_funcs().write_room(core) > 0
+        {
+            event.insert(EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM);
+        }
+
+        Ok(event.bits() as usize)
     }
 
     fn hangup(&self, _tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {

--- a/kernel/src/driver/tty/virtual_terminal/mod.rs
+++ b/kernel/src/driver/tty/virtual_terminal/mod.rs
@@ -102,62 +102,8 @@ impl TtyConsoleDriverInner {
             console: Arc::new(BlittingFbConsole::new()?),
         })
     }
-}
 
-impl TtyOperation for TtyConsoleDriverInner {
-    fn install(&self, _driver: Arc<TtyDriver>, tty: Arc<TtyCore>) -> Result<(), SystemError> {
-        let tty_core = tty.core();
-        let mut vc_data = VIRT_CONSOLES[tty_core.index()].lock();
-
-        self.console.con_init(&mut vc_data, true)?;
-        if vc_data.complement_mask == 0 {
-            vc_data.complement_mask = if vc_data.color_mode { 0x7700 } else { 0x0800 };
-        }
-        vc_data.s_complement_mask = vc_data.complement_mask;
-        // vc_data.bytes_per_row = vc_data.cols << 1;
-        vc_data.index = tty_core.index();
-        vc_data.bottom = vc_data.rows;
-        vc_data.set_driver_funcs(Arc::downgrade(
-            &(self.console.clone() as Arc<dyn ConsoleSwitch>),
-        ));
-
-        // todo: unicode字符集处理？
-
-        if vc_data.cols > VC_MAXCOL || vc_data.rows > VC_MAXROW {
-            return Err(SystemError::EINVAL);
-        }
-
-        vc_data.init(None, None, true);
-        vc_data.update_attr();
-
-        let window_size = tty_core.window_size_upgradeable();
-        if window_size.col == 0 && window_size.row == 0 {
-            let mut window_size = window_size.upgrade();
-            window_size.col = vc_data.cols as u16;
-            window_size.row = vc_data.rows as u16;
-        }
-
-        if vc_data.utf {
-            tty_core.termios_write().input_mode.insert(InputMode::IUTF8);
-        } else {
-            tty_core.termios_write().input_mode.remove(InputMode::IUTF8);
-        }
-
-        // 加入sysfs？
-
-        Ok(())
-    }
-
-    fn open(&self, _tty: &TtyCoreData) -> Result<(), SystemError> {
-        Ok(())
-    }
-
-    fn write_room(&self, _tty: &TtyCoreData) -> usize {
-        32768
-    }
-
-    /// 参考： https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/tty/vt/vt.c#2894
-    fn write(&self, tty: &TtyCoreData, buf: &[u8], mut nr: usize) -> Result<usize, SystemError> {
+    fn do_write(&self, tty: &TtyCoreData, buf: &[u8], mut nr: usize) -> Result<usize, SystemError> {
         // 关闭中断
         let mut vc_data = tty.vc_data_irqsave();
 
@@ -204,7 +150,70 @@ impl TtyOperation for TtyConsoleDriverInner {
         // TODO: notify update
         return Ok(offset);
     }
+}
 
+impl TtyOperation for TtyConsoleDriverInner {
+    fn install(&self, _driver: Arc<TtyDriver>, tty: Arc<TtyCore>) -> Result<(), SystemError> {
+        let tty_core = tty.core();
+        let mut vc_data = VIRT_CONSOLES[tty_core.index()].lock();
+
+        self.console.con_init(&mut vc_data, true)?;
+        if vc_data.complement_mask == 0 {
+            vc_data.complement_mask = if vc_data.color_mode { 0x7700 } else { 0x0800 };
+        }
+        vc_data.s_complement_mask = vc_data.complement_mask;
+        // vc_data.bytes_per_row = vc_data.cols << 1;
+        vc_data.index = tty_core.index();
+        vc_data.bottom = vc_data.rows;
+        vc_data.set_driver_funcs(Arc::downgrade(
+            &(self.console.clone() as Arc<dyn ConsoleSwitch>),
+        ));
+
+        // todo: unicode字符集处理？
+
+        if vc_data.cols > VC_MAXCOL || vc_data.rows > VC_MAXROW {
+            return Err(SystemError::EINVAL);
+        }
+
+        vc_data.init(None, None, true);
+        vc_data.update_attr();
+
+        let window_size = tty_core.window_size_upgradeable();
+        if window_size.col == 0 && window_size.row == 0 {
+            let mut window_size = window_size.upgrade();
+            window_size.col = vc_data.cols as u16;
+            window_size.row = vc_data.rows as u16;
+            kerror!("window_size {:?}", *window_size);
+        }
+
+        if vc_data.utf {
+            tty_core.termios_write().input_mode.insert(InputMode::IUTF8);
+        } else {
+            tty_core.termios_write().input_mode.remove(InputMode::IUTF8);
+        }
+
+        // 加入sysfs？
+
+        Ok(())
+    }
+
+    fn open(&self, _tty: &TtyCoreData) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    fn write_room(&self, _tty: &TtyCoreData) -> usize {
+        32768
+    }
+
+    /// 参考： https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/tty/vt/vt.c#2894
+    #[inline(never)]
+    fn write(&self, tty: &TtyCoreData, buf: &[u8], nr: usize) -> Result<usize, SystemError> {
+        let ret = self.do_write(tty, buf, nr);
+        self.flush_chars(tty);
+        ret
+    }
+
+    #[inline(never)]
     fn flush_chars(&self, tty: &TtyCoreData) {
         let mut vc_data = tty.vc_data_irqsave();
         vc_data.set_cursor();

--- a/kernel/src/driver/video/fbdev/base/mod.rs
+++ b/kernel/src/driver/video/fbdev/base/mod.rs
@@ -408,9 +408,7 @@ pub trait FrameBufferOps {
     }
 
     /// 将数据从一处复制到另一处。
-    fn fb_copyarea(&self, _data: CopyAreaData) -> Result<(), SystemError> {
-        Err(SystemError::ENOSYS)
-    }
+    fn fb_copyarea(&self, _data: CopyAreaData);
 
     /// 将帧缓冲区的内容映射到用户空间。
     fn fb_mmap(&self, _vma: &Arc<LockedVMA>) -> Result<(), SystemError> {

--- a/kernel/src/driver/video/fbdev/vesafb.rs
+++ b/kernel/src/driver/video/fbdev/vesafb.rs
@@ -418,86 +418,138 @@ impl FrameBufferOps for VesaFb {
         Ok(())
     }
 
-    fn fb_copyarea(&self, data: super::base::CopyAreaData) -> Result<(), SystemError> {
+    #[inline(never)]
+    fn fb_copyarea(&self, data: super::base::CopyAreaData) {
         let bp = boot_params().read();
-        let base = bp.screen_info.lfb_virt_base.ok_or(SystemError::ENODEV)?;
+        let base = bp.screen_info.lfb_virt_base.unwrap();
         let var = self.current_fb_var();
 
-        if data.sx < 0
-            || data.sy < 0
-            || data.sx as u32 > var.xres
-            || data.sx as u32 + data.width > var.xres
-            || data.sy as u32 > var.yres
-            || data.sy as u32 + data.height > var.yres
+        // 原区域或者目标区域全在屏幕外，则直接返回
+        if data.sx > var.xres as i32
+            || data.sy > var.yres as i32
+            || data.dx > var.xres as i32
+            || data.dy > var.yres as i32
+            || (data.sx + data.width as i32) < 0
+            || (data.sy + data.height as i32) < 0
+            || (data.dx + data.width as i32) < 0
+            || (data.dy + data.height as i32) < 0
         {
-            return Err(SystemError::EINVAL);
+            return;
         }
+
+        // 求两个矩形可视范围交集
+        let (s_visiable_x, s_w) = if data.sx < 0 {
+            (0, (data.width - ((-data.sx) as u32)).min(var.xres))
+        } else {
+            let w = if data.sx as u32 + data.width > var.xres {
+                var.xres - data.sx as u32
+            } else {
+                data.width
+            };
+
+            (data.sx, w)
+        };
+        let (s_visiable_y, s_h) = if data.sy < 0 {
+            (0, (data.height - ((-data.sy) as u32).min(var.yres)))
+        } else {
+            let h = if data.sy as u32 + data.height > var.yres {
+                var.yres - data.sy as u32
+            } else {
+                data.height
+            };
+
+            (data.sy, h)
+        };
+
+        let (d_visiable_x, d_w) = if data.dx < 0 {
+            (0, (data.width - ((-data.dx) as u32)).min(var.xres))
+        } else {
+            let w = if data.dx as u32 + data.width > var.xres {
+                var.xres - data.dx as u32
+            } else {
+                data.width
+            };
+
+            (data.dx, w)
+        };
+        let (d_visiable_y, d_h) = if data.dy < 0 {
+            (0, (data.height - ((-data.dy) as u32).min(var.yres)))
+        } else {
+            let h = if data.dy as u32 + data.height > var.yres {
+                var.yres - data.dy as u32
+            } else {
+                data.height
+            };
+
+            (data.dy, h)
+        };
+
+        // 可视范围无交集
+        if !(d_h + s_h > data.height && s_w + d_w > data.width) {
+            return;
+        }
+
+        // 可视区域左上角相对于矩形的坐标
+        let s_relative_x = s_visiable_x - data.sx;
+        let s_relative_y = s_visiable_y - data.sy;
+        let d_relative_x = d_visiable_x - data.dx;
+        let d_relative_y = d_visiable_y - data.dy;
+
+        let visiable_x = s_relative_x.max(d_relative_x);
+        let visiable_y = s_relative_y.max(d_relative_y);
+        let visiable_h = d_h + s_h - data.height;
+        let visiable_w = d_w + s_w - data.width;
+
+        let s_real_x = (visiable_x + data.sx) as u32;
+        let s_real_y = (visiable_y + data.sy) as u32;
+        let d_real_x = (visiable_x + data.dx) as u32;
+        let d_real_y = (visiable_y + data.dy) as u32;
 
         let bytes_per_pixel = var.bits_per_pixel >> 3;
         let bytes_per_line = var.xres * bytes_per_pixel;
 
-        let sy = data.sy as u32;
-        let sx = data.sx as u32;
+        let src =
+            base + VirtAddr::new((s_real_y * bytes_per_line + s_real_x * bytes_per_pixel) as usize);
 
-        let dst = {
-            let mut dst = base;
-            if data.dy < 0 {
-                dst -= VirtAddr::new((((-data.dy) as u32) * bytes_per_line) as usize);
-            } else {
-                dst += VirtAddr::new(((data.dy as u32) * bytes_per_line) as usize);
-            }
+        let dst =
+            base + VirtAddr::new((d_real_y * bytes_per_line + d_real_x * bytes_per_pixel) as usize);
 
-            if data.dx > 0 && (data.dx as u32) < var.xres {
-                dst += VirtAddr::new(((data.dx as u32) * bytes_per_pixel) as usize);
-            }
-
-            dst
-        };
-        let src = base + VirtAddr::new((sy * bytes_per_line + sx * bytes_per_pixel) as usize);
+        let size = (visiable_h * visiable_w) as usize;
 
         match bytes_per_pixel {
             4 => {
                 // 32bpp
                 let mut dst = dst.as_ptr::<u32>();
                 let mut src = src.as_ptr::<u32>();
+                let line_offset = var.xres as usize;
 
-                for y in 0..data.height as usize {
-                    if (data.dy + y as i32) < 0 || (data.dy + y as i32) > var.yres as i32 {
-                        unsafe {
-                            // core::ptr::copy(src, dst, data.width as usize);
-                            src = src.add(var.xres as usize);
-                            dst = dst.add(var.xres as usize);
+                if s_real_x > d_real_x {
+                    // 如果src在dst下方，则可以直接拷贝不会出现指针覆盖
+                    unsafe {
+                        for _ in 0..visiable_h {
+                            core::ptr::copy(src, dst, visiable_w as usize);
+                            src = src.add(line_offset);
+                            dst = dst.add(visiable_w as usize);
                         }
-                        continue;
                     }
-                    if data.dx < 0 {
-                        if ((-data.dx) as u32) < data.width {
-                            unsafe {
-                                core::ptr::copy(
-                                    src.add((-data.dx) as usize),
-                                    dst,
-                                    (data.width as usize) - (-data.dx) as usize,
-                                );
-                                src = src.add(var.xres as usize);
-                                dst = dst.add(var.xres as usize);
-                            }
+                } else {
+                    let mut tmp: Vec<u32> = Vec::with_capacity(size);
+                    tmp.resize(size, 0);
+                    let mut tmp_ptr = tmp.as_mut_ptr();
+
+                    // 这里是一个可以优化的点，现在为了避免指针拷贝时覆盖，统一先拷贝进入buf再拷贝到dst
+                    unsafe {
+                        for _ in 0..visiable_h {
+                            core::ptr::copy(src, tmp_ptr, visiable_w as usize);
+                            src = src.add(line_offset);
+                            tmp_ptr = tmp_ptr.add(visiable_w as usize);
                         }
-                    } else if data.dx as u32 + data.width > var.xres {
-                        if (data.dx as u32) < var.xres {
-                            unsafe {
-                                core::ptr::copy(src, dst, (var.xres - data.dx as u32) as usize);
-                                src = src.add(var.xres as usize);
-                                dst = dst.add(var.xres as usize);
-                            }
-                        }
-                    } else {
-                        for i in 0..data.width as usize {
-                            unsafe { *(dst.add(i)) = *(src.add(i)) }
-                        }
-                        unsafe {
-                            // core::ptr::copy(src, dst, data.width as usize);
-                            src = src.add(var.xres as usize);
-                            dst = dst.add(var.xres as usize);
+
+                        tmp_ptr = tmp_ptr.sub(size);
+                        for _ in 0..visiable_h {
+                            core::ptr::copy(tmp_ptr, dst, visiable_w as usize);
+                            dst = dst.add(line_offset);
+                            tmp_ptr = tmp_ptr.add(visiable_w as usize);
                         }
                     }
                 }
@@ -506,7 +558,6 @@ impl FrameBufferOps for VesaFb {
                 todo!()
             }
         }
-        Ok(())
     }
 }
 

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -484,7 +484,18 @@ impl File {
                 let inode = self.inode.downcast_ref::<LockedPipeInode>().unwrap();
                 return inode.inner().lock().add_epoll(epitem);
             }
-            _ => return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
+            _ => {
+                let r = self.inode.ioctl(
+                    EventPoll::ADD_EPOLLITEM,
+                    &epitem as *const Arc<EPollItem> as usize,
+                    &self.private_data,
+                );
+                if r.is_err() {
+                    return Err(SystemError::ENOSYS);
+                }
+
+                Ok(())
+            }
         }
     }
 

--- a/kernel/src/filesystem/vfs/mount.rs
+++ b/kernel/src/filesystem/vfs/mount.rs
@@ -369,6 +369,11 @@ impl IndexNode for MountFSInode {
     fn special_node(&self) -> Option<super::SpecialNodeData> {
         self.inner_inode.special_node()
     }
+
+    #[inline]
+    fn poll(&self, private_data: &FilePrivateData) -> Result<usize, SystemError> {
+        self.inner_inode.poll(private_data)
+    }
 }
 
 impl FileSystem for MountFS {

--- a/kernel/src/libs/elf.rs
+++ b/kernel/src/libs/elf.rs
@@ -501,7 +501,7 @@ impl ElfLoader {
 }
 
 impl BinaryLoader for ElfLoader {
-    fn probe(self: &'static Self, param: &ExecParam, buf: &[u8]) -> Result<(), ExecError> {
+    fn probe(&'static self, param: &ExecParam, buf: &[u8]) -> Result<(), ExecError> {
         // let elf_bytes =
         //     ElfBytes::<AnyEndian>::minimal_parse(buf).map_err(|_| ExecError::NotExecutable)?;
 
@@ -518,7 +518,7 @@ impl BinaryLoader for ElfLoader {
     }
 
     fn load(
-        self: &'static Self,
+        &'static self,
         param: &mut ExecParam,
         head_buf: &[u8],
     ) -> Result<BinaryLoaderResult, ExecError> {
@@ -743,10 +743,9 @@ impl BinaryLoader for ElfLoader {
             }
 
             let p_vaddr = VirtAddr::new(seg_to_load.p_vaddr as usize);
-            if (seg_to_load.p_flags & elf::abi::PF_X) != 0 {
-                if start_code.is_none() || start_code.as_ref().unwrap() > &p_vaddr {
-                    start_code = Some(p_vaddr);
-                }
+            if (seg_to_load.p_flags & elf::abi::PF_X) != 0 && 
+                (start_code.is_none() || start_code.as_ref().unwrap() > &p_vaddr) {
+                start_code = Some(p_vaddr);
             }
 
             if start_data.is_none()

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -317,12 +317,10 @@ impl Futex {
         };
 
         // 如果是超时唤醒，则返回错误
-        if timer.is_some() {
-            if timer.clone().unwrap().timeout() {
-                bucket_mut.remove(futex_q);
+        if timer.is_some() && timer.clone().unwrap().timeout() {
+            bucket_mut.remove(futex_q);
 
-                return Err(SystemError::ETIMEDOUT);
-            }
+            return Err(SystemError::ETIMEDOUT);
         }
 
         // TODO: 如果没有挂起的信号，则重新判断是否满足wait要求，重新进入wait
@@ -555,16 +553,14 @@ impl Futex {
         let mut oparg = sign_extend32((encoded_op & 0x00fff000) >> 12, 11);
         let cmparg = sign_extend32(encoded_op & 0x00000fff, 11);
 
-        if encoded_op & (FutexOP::FUTEX_OP_OPARG_SHIFT.bits() << 28) != 0 {
-            if oparg > 31 {
-                kwarn!(
-                    "futex_wake_op: pid:{} tries to shift op by {}; fix this program",
-                    ProcessManager::current_pcb().pid().data(),
-                    oparg
-                );
+        if encoded_op & (FutexOP::FUTEX_OP_OPARG_SHIFT.bits() << 28) != 0 && oparg > 31 {
+            kwarn!(
+                "futex_wake_op: pid:{} tries to shift op by {}; fix this program",
+                ProcessManager::current_pcb().pid().data(),
+                oparg
+            );
 
-                oparg &= 31;
-            }
+            oparg &= 31;
         }
 
         // TODO: 这个汇编似乎是有问题的，目前不好测试

--- a/kernel/src/libs/keyboard_parser.rs
+++ b/kernel/src/libs/keyboard_parser.rs
@@ -124,14 +124,12 @@ impl TypeOneFSMState {
         };
         if scancode != PAUSE_BREAK_SCAN_CODE[i as usize] {
             return self.handle_type3(scancode, scancode_status);
+        } else if i == 5 {
+            // 所有Pause Break扫描码都被清除
+            return TypeOneFSMState::Start;
         } else {
-            if i == 5 {
-                // 所有Pause Break扫描码都被清除
-                return TypeOneFSMState::Start;
-            } else {
-                return TypeOneFSMState::PauseBreak(i + 1);
-            }
-        }
+            return TypeOneFSMState::PauseBreak(i + 1);
+        } 
     }
 
     fn handle_func0(&self, scancode: u8, scancode_status: &mut ScanCodeStatus) -> TypeOneFSMState {
@@ -385,14 +383,12 @@ impl TypeOneFSMState {
         }
         if scancode != PRTSC_SCAN_CODE[i as usize] {
             return self.handle_type3(scancode, scancode_status);
+        } else if i == 3 {
+            // 成功解析出PrtscPress
+            return TypeOneFSMState::Start;
         } else {
-            if i == 3 {
-                // 成功解析出PrtscPress
-                return TypeOneFSMState::Start;
-            } else {
-                // 继续解析
-                return TypeOneFSMState::PrtscPress(i + 1);
-            }
+            // 继续解析
+            return TypeOneFSMState::PrtscPress(i + 1);
         }
     }
 
@@ -412,14 +408,12 @@ impl TypeOneFSMState {
         }
         if scancode != PRTSC_SCAN_CODE[i as usize] {
             return self.handle_type3(scancode, scancode_status);
+        } else if i == 3 {
+            // 成功解析出PrtscRelease
+            return TypeOneFSMState::Start;
         } else {
-            if i == 3 {
-                // 成功解析出PrtscRelease
-                return TypeOneFSMState::Start;
-            } else {
-                // 继续解析
-                return TypeOneFSMState::PrtscRelease(i + 1);
-            }
+            // 继续解析
+            return TypeOneFSMState::PrtscRelease(i + 1);
         }
     }
 }

--- a/kernel/src/libs/lib_ui/textui.rs
+++ b/kernel/src/libs/lib_ui/textui.rs
@@ -853,19 +853,18 @@ impl TextuiWindow {
                     self.textui_refresh_vlines(self.top_vline, actual_line_sum)?;
                 }
             }
-        } else {
-            if is_enable_window == true {
-                if let TextuiVline::Chromatic(vline) =
-                    &self.vlines[<LineId as Into<usize>>::into(self.vline_operating)]
-                {
-                    if !vline.index.check(self.chars_per_line) {
-                        self.textui_new_line()?;
-                    }
-
-                    return self.true_textui_putchar_window(character, frcolor, bkcolor);
+        } else if is_enable_window == true {
+            if let TextuiVline::Chromatic(vline) =
+                &self.vlines[<LineId as Into<usize>>::into(self.vline_operating)]
+            {
+                if !vline.index.check(self.chars_per_line) {
+                    self.textui_new_line()?;
                 }
+
+                return self.true_textui_putchar_window(character, frcolor, bkcolor);
             }
         }
+        
 
         return Ok(());
     }

--- a/kernel/src/libs/lib_ui/textui_no_alloc.rs
+++ b/kernel/src/libs/lib_ui/textui_no_alloc.rs
@@ -98,24 +98,22 @@ pub fn no_init_textui_putchar_window(
                 }
             }
         }
-    } else {
-        if is_put_to_window == true {
-            // 输出其他字符
-            let char = TextuiCharChromatic::new(Some(character), frcolor, bkcolor);
+    } else if is_put_to_window == true {
+        // 输出其他字符
+        let char = TextuiCharChromatic::new(Some(character), frcolor, bkcolor);
 
-            if NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)
-                == CHAR_PER_LINE.load(Ordering::SeqCst)
-            {
-                NO_ALLOC_OPERATIONS_INDEX.store(0, Ordering::SeqCst);
-                NO_ALLOC_OPERATIONS_LINE.fetch_add(1, Ordering::SeqCst);
-            }
-            char.no_init_textui_render_chromatic(
-                LineId::new(NO_ALLOC_OPERATIONS_LINE.load(Ordering::SeqCst)),
-                LineIndex::new(NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)),
-            );
-
-            NO_ALLOC_OPERATIONS_INDEX.fetch_add(1, Ordering::SeqCst);
+        if NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)
+            == CHAR_PER_LINE.load(Ordering::SeqCst)
+        {
+            NO_ALLOC_OPERATIONS_INDEX.store(0, Ordering::SeqCst);
+            NO_ALLOC_OPERATIONS_LINE.fetch_add(1, Ordering::SeqCst);
         }
+        char.no_init_textui_render_chromatic(
+            LineId::new(NO_ALLOC_OPERATIONS_LINE.load(Ordering::SeqCst)),
+            LineIndex::new(NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)),
+        );
+
+        NO_ALLOC_OPERATIONS_INDEX.fetch_add(1, Ordering::SeqCst);
     }
 
     return Ok(());

--- a/kernel/src/libs/printk.c
+++ b/kernel/src/libs/printk.c
@@ -599,7 +599,7 @@ int printk_color(unsigned int FRcolor, unsigned int BKcolor, const char *fmt, ..
     io_mfence();
     va_list args;
     va_start(args, fmt);
-    char buf[4096]; // vsprintf()的缓冲区
+    static char buf[4096]; // vsprintf()的缓冲区
     int len = vsprintf(buf, fmt, args);
 
     va_end(args);

--- a/kernel/src/libs/rbtree.rs
+++ b/kernel/src/libs/rbtree.rs
@@ -1309,12 +1309,10 @@ impl<K: Ord, V> RBTree<K, V> {
             let mut replace = node.right().min_node();
             if node == self.root {
                 self.root = replace;
+            } else if node.parent().left() == node {
+                node.parent().set_left(replace);
             } else {
-                if node.parent().left() == node {
-                    node.parent().set_left(replace);
-                } else {
-                    node.parent().set_right(replace);
-                }
+                node.parent().set_right(replace);
             }
 
             // child是"取代节点"的右孩子，也是需要"调整的节点"。
@@ -1360,12 +1358,10 @@ impl<K: Ord, V> RBTree<K, V> {
 
         if self.root == node {
             self.root = child
+        } else if parent.left() == node {
+            parent.set_left(child);
         } else {
-            if parent.left() == node {
-                parent.set_left(child);
-            } else {
-                parent.set_right(child);
-            }
+            parent.set_right(child);
         }
 
         if color == Color::Black {

--- a/kernel/src/libs/vec_cursor.rs
+++ b/kernel/src/libs/vec_cursor.rs
@@ -19,7 +19,7 @@ pub struct VecCursor {
 impl VecCursor {
     /// @brief 新建一个游标
     pub fn new(data: Vec<u8>) -> Self {
-        return Self { data: data, pos: 0 };
+        return Self { data, pos: 0 };
     }
 
     /// @brief 创建一个全0的cursor

--- a/kernel/src/net/event_poll/mod.rs
+++ b/kernel/src/net/event_poll/mod.rs
@@ -52,6 +52,8 @@ pub struct EventPoll {
 
 impl EventPoll {
     pub const EP_MAX_EVENTS: u32 = INT32_MAX / (core::mem::size_of::<EPollEvent>() as u32);
+    /// 用于获取inode中的epitem队列
+    pub const ADD_EPOLLITEM: u32 = 0x7965;
     pub fn new() -> Self {
         Self {
             epoll_wq: WaitQueue::INIT,
@@ -462,7 +464,7 @@ impl EventPoll {
                 }
 
                 // 如果有未处理的信号则返回错误
-                if current_pcb.sig_info().sig_pending().signal().bits() != 0 {
+                if current_pcb.sig_info_irqsave().sig_pending().signal().bits() != 0 {
                     return Err(SystemError::EINTR);
                 }
 

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -363,12 +363,12 @@ impl ProcessManager {
 
         // 设置clear_child_tid，在线程结束时将其置0以通知父进程
         if clone_flags.contains(CloneFlags::CLONE_CHILD_CLEARTID) {
-            pcb.thread.write().clear_child_tid = Some(clone_args.child_tid);
+            pcb.thread.write_irqsave().clear_child_tid = Some(clone_args.child_tid);
         }
 
         // 设置child_tid，意味着子线程能够知道自己的id
         if clone_flags.contains(CloneFlags::CLONE_CHILD_SETTID) {
-            pcb.thread.write().set_child_tid = Some(clone_args.child_tid);
+            pcb.thread.write_irqsave().set_child_tid = Some(clone_args.child_tid);
         }
 
         // 将子进程/线程的id存储在用户态传进的地址中
@@ -424,13 +424,14 @@ impl ProcessManager {
 
         // 设置线程组id、组长
         if clone_flags.contains(CloneFlags::CLONE_THREAD) {
-            pcb.thread.write().group_leader = current_pcb.thread.read().group_leader.clone();
+            pcb.thread.write_irqsave().group_leader =
+                current_pcb.thread.read_irqsave().group_leader.clone();
             unsafe {
                 let ptr = pcb.as_ref() as *const ProcessControlBlock as *mut ProcessControlBlock;
                 (*ptr).tgid = current_pcb.tgid;
             }
         } else {
-            pcb.thread.write().group_leader = Arc::downgrade(&pcb);
+            pcb.thread.write_irqsave().group_leader = Arc::downgrade(&pcb);
             unsafe {
                 let ptr = pcb.as_ref() as *const ProcessControlBlock as *mut ProcessControlBlock;
                 (*ptr).tgid = pcb.tgid;
@@ -439,12 +440,13 @@ impl ProcessManager {
 
         // CLONE_PARENT re-uses the old parent
         if clone_flags.contains(CloneFlags::CLONE_PARENT | CloneFlags::CLONE_THREAD) {
-            *pcb.real_parent_pcb.write() = current_pcb.real_parent_pcb.read().clone();
+            *pcb.real_parent_pcb.write_irqsave() =
+                current_pcb.real_parent_pcb.read_irqsave().clone();
 
             if clone_flags.contains(CloneFlags::CLONE_THREAD) {
                 pcb.exit_signal.store(Signal::INVALID, Ordering::SeqCst);
             } else {
-                let leader = current_pcb.thread.read().group_leader();
+                let leader = current_pcb.thread.read_irqsave().group_leader();
                 if unlikely(leader.is_none()) {
                     panic!(
                         "fork: Failed to get leader of current process, current pid: [{:?}]",
@@ -459,7 +461,7 @@ impl ProcessManager {
             }
         } else {
             // 新创建的进程，设置其父进程为当前进程
-            *pcb.real_parent_pcb.write() = Arc::downgrade(&current_pcb);
+            *pcb.real_parent_pcb.write_irqsave() = Arc::downgrade(&current_pcb);
             pcb.exit_signal
                 .store(clone_args.exit_signal, Ordering::SeqCst);
         }

--- a/kernel/src/process/syscall.rs
+++ b/kernel/src/process/syscall.rs
@@ -202,11 +202,11 @@ impl Syscall {
         });
 
         if flags.contains(CloneFlags::CLONE_VFORK) {
-            pcb.thread.write().vfork_done = Some(vfork.clone());
+            pcb.thread.write_irqsave().vfork_done = Some(vfork.clone());
         }
 
-        if pcb.thread.read().set_child_tid.is_some() {
-            let addr = pcb.thread.read().set_child_tid.unwrap();
+        if pcb.thread.read_irqsave().set_child_tid.is_some() {
+            let addr = pcb.thread.read_irqsave().set_child_tid.unwrap();
             let mut writer =
                 UserBufferWriter::new(addr.as_ptr::<i32>(), core::mem::size_of::<i32>(), true)?;
             writer.copy_one_to_user(&(pcb.pid().data() as i32), 0)?;
@@ -234,7 +234,7 @@ impl Syscall {
             .map_err(|_| SystemError::EFAULT)?;
 
         let pcb = ProcessManager::current_pcb();
-        pcb.thread.write().clear_child_tid = Some(VirtAddr::new(ptr));
+        pcb.thread.write_irqsave().clear_child_tid = Some(VirtAddr::new(ptr));
         Ok(pcb.pid.0)
     }
 


### PR DESCRIPTION
## **User description**
Fix 41 clippy error or warnings.

240311 afternoon.


___

## **Type**
Bug fix, Enhancement


___

## **Description**
This PR includes several improvements and bug fixes. In `kernel/src/driver/tty/tty_ldisc/ntty.rs`, the `receive_buf_real_raw` and `receive_buf_raw` functions have been optimized for better buffer handling. Additionally, bugs in the `eraser` and `echoes` functions have been fixed, and the `poll` function now returns an event mask instead of an error. The `set_termios` function has also been updated to handle changes in local mode more effectively.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ntty.rs
</strong><dd><code>Optimize buffer handling and fix bugs in NTtyData</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/driver/tty/tty_ldisc/ntty.rs
- Improved the `receive_buf_real_raw` and `receive_buf_raw` functions to <br>  handle buffer copying more efficiently.
- Added `likely` intrinsic for better optimization.
- Fixed bugs in `eraser` and `echoes` functions.
- Updated `poll` function to return an event mask instead of an error.
- Modified `set_termios` to handle changes in local mode more <br>  effectively.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/579/files#diff-754b6701855cfcb51e63c76cfaa0ccbb68e678b16c741488ddaf79c81765400c"></a></td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vesafb.rs
</strong><dd><code>Improve framebuffer copyarea function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/driver/video/fbdev/vesafb.rs
- Enhanced the `fb_copyarea` function to handle out-of-bounds copying <br>  more robustly.
- Added checks to ensure that the source and destination regions are <br>  within the framebuffer bounds.
- Optimized the copying process by avoiding unnecessary copying and <br>  using unsafe blocks for performance.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/579/files#diff-4832b1d798c22b9216534aca438ff20977257732af09d99f6b3c30db2cd48e84"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tty_device.rs
</strong><dd><code>Enhance TtyDevice with EventPoll and EPollItem support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/driver/tty/tty_device.rs
- Updated the `poll` function to use `EventPoll` for better event <br>  handling.
- Added support for adding `EPollItem` to the event poll.
- Modified the `write` function to handle partial writes more <br>  effectively.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/579/files#diff-b2cc8570e27c96688591c7d80d6363ec8aab3ef031041b84719ca9474f5694a1"></a></td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
