### PR TITLE
Path-fix-clippy-240311new

### DIFF
--- a/kernel/crates/bitmap/src/bitmap_core.rs
+++ b/kernel/crates/bitmap/src/bitmap_core.rs
@@ -61,8 +61,8 @@ impl<T: BitOps> BitMapCore<T> {
     pub(crate) fn first_index(&self, data: &[T]) -> Option<usize> {
         for (i, element) in data.iter().enumerate() {
             let bit = <T as BitOps>::first_index(element);
-            if bit.is_some() {
-                return Some(i * T::bit_size() + bit.unwrap());
+            if let Some(b) = bit {
+                return Some(i * T::bit_size() + b);
             }
         }
 
@@ -237,10 +237,8 @@ impl<T: BitOps> BitMapCore<T> {
                 if element == mask {
                     return true;
                 }
-            } else {
-                if element != &T::make_mask(T::bit_size()) {
+            } else if element != &T::make_mask(T::bit_size()) {
                     return false;
-                }
             }
         }
 

--- a/kernel/crates/bitmap/src/traits.rs
+++ b/kernel/crates/bitmap/src/traits.rs
@@ -309,7 +309,8 @@ pub trait BitMapOps<T: BitOps> {
     /// 判断bitmap是否为空
     fn is_empty(&self) -> bool;
 
-    /// # Safety
+    /// # Unsafe
+    /// *不应直接修改字节数组*
     /// 
     /// 将bitmap转换为字节数组
     unsafe fn as_bytes(&self) -> &[u8];

--- a/kernel/crates/bitmap/src/traits.rs
+++ b/kernel/crates/bitmap/src/traits.rs
@@ -309,6 +309,8 @@ pub trait BitMapOps<T: BitOps> {
     /// 判断bitmap是否为空
     fn is_empty(&self) -> bool;
 
+    /// # Safety
+    /// 
     /// 将bitmap转换为字节数组
     unsafe fn as_bytes(&self) -> &[u8];
 }

--- a/kernel/crates/unified-init/macros/src/lib.rs
+++ b/kernel/crates/unified-init/macros/src/lib.rs
@@ -42,7 +42,7 @@ use uuid::Uuid;
 #[proc_macro_attribute]
 pub fn unified_init(args: TokenStream, input: TokenStream) -> TokenStream {
     do_unified_init(args, input)
-        .unwrap_or_else(|e| e.to_compile_error().into())
+        .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }
 
@@ -59,7 +59,7 @@ fn do_unified_init(args: TokenStream, input: TokenStream) -> syn::Result<proc_ma
 
     // 在旁边添加一个UnifiedInitializer
     let initializer =
-        generate_unified_initializer(&function, &target_slice, function.sig.ident.to_string())?;
+        generate_unified_initializer(&function, target_slice, function.sig.ident.to_string())?;
 
     // 拼接
     let mut output = proc_macro2::TokenStream::new();
@@ -111,7 +111,7 @@ fn check_function_signature(function: &ItemFn) -> syn::Result<()> {
                     if let syn::GenericArgument::Type(type_arg) = generic_args.args.first().unwrap()
                     {
                         if let syn::Type::Tuple(tuple) = type_arg {
-                            if tuple.elems.len() != 0 {
+                            if !tuple.elems.is_empty() {
                                 return Err(syn::Error::new(tuple.span(), "Expected empty tuple"));
                             }
                         } else {
@@ -166,7 +166,7 @@ fn generate_unified_initializer(
     let initializer_name = format!(
         "unified_initializer_{}_{}",
         raw_initializer_name,
-        Uuid::new_v4().to_simple().to_string().to_ascii_uppercase()[..8].to_string()
+        &Uuid::new_v4().to_simple().to_string().to_ascii_uppercase()[..8]
     )
     .to_ascii_uppercase();
 

--- a/kernel/src/arch/x86_64/driver/apic/lapic_vector.rs
+++ b/kernel/src/arch/x86_64/driver/apic/lapic_vector.rs
@@ -205,14 +205,13 @@ pub(super) fn irq_msi_compose_msg(cfg: &HardwareIrqConfig, msg: &mut MsiMsg, dma
         // todo: 判断vmx是否支持 extended destination mode
         // 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/arch/x86/kernel/apic/apic.c?fi=__irq_msi_compose_msg#2580
         address_lo.set_virt_destid_8_14(cfg.apic_id.data() >> 8);
-    } else {
-        if unlikely(cfg.apic_id.data() > 0xff) {
-            kwarn!(
-                "irq_msi_compose_msg: Invalid APIC ID: {}",
-                cfg.apic_id.data()
-            );
-        }
+    } else if unlikely(cfg.apic_id.data() > 0xff) {
+        kwarn!(
+            "irq_msi_compose_msg: Invalid APIC ID: {}",
+            cfg.apic_id.data()
+        );
     }
+    
     msg.address_hi = address_hi.into();
     msg.address_lo = address_lo.into();
     msg.data = arch_data.into();

--- a/kernel/src/arch/x86_64/interrupt/ipi.rs
+++ b/kernel/src/arch/x86_64/interrupt/ipi.rs
@@ -80,13 +80,12 @@ impl Into<ApicId> for ArchIpiTarget {
     fn into(self) -> ApicId {
         if let ArchIpiTarget::Specified(id) = self {
             return id;
+        } else if CurrentApic.x2apic_enabled() {
+            return x86::apic::ApicId::X2Apic(0);
         } else {
-            if CurrentApic.x2apic_enabled() {
-                return x86::apic::ApicId::X2Apic(0);
-            } else {
-                return x86::apic::ApicId::XApic(0);
-            }
+            return x86::apic::ApicId::XApic(0);
         }
+        
     }
 }
 

--- a/kernel/src/arch/x86_64/interrupt/trap.rs
+++ b/kernel/src/arch/x86_64/interrupt/trap.rs
@@ -224,13 +224,12 @@ unsafe extern "C" fn do_invalid_TSS(regs: &'static TrapFrame, error_code: u64) {
     let msg2: &str;
     if (error_code & 0x02) != 0 {
         msg2 = ERR_MSG_2;
+    } else if (error_code & 0x04) != 0 {
+        msg2 = ERR_MSG_3;
     } else {
-        if (error_code & 0x04) != 0 {
-            msg2 = ERR_MSG_3;
-        } else {
-            msg2 = ERR_MSG_4;
-        }
+        msg2 = ERR_MSG_4;
     }
+    
     kerror!(
         "do_invalid_TSS(10), \tError code: {:#x},\trsp: {:#x},\trip: {:#x},\t CPU: {}, \tpid: {:?}\n{}{}",
         error_code,

--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -275,7 +275,7 @@ bitflags! {
         const SIGSYS   =  1<<30;
         const SIGRTMIN =  1<<31;
         // TODO 写上实时信号
-        const SIGRTMAX =  1<<MAX_SIG_NUM-1;
+        const SIGRTMAX =  1 << (MAX_SIG_NUM-1);
     }
 }
 

--- a/kernel/src/arch/x86_64/syscall/mod.rs
+++ b/kernel/src/arch/x86_64/syscall/mod.rs
@@ -64,7 +64,7 @@ macro_rules! syscall_return {
 }
 
 #[no_mangle]
-pub extern "sysv64" fn syscall_handler(frame: &mut TrapFrame) -> () {
+pub extern "sysv64" fn syscall_handler(frame: &mut TrapFrame) {
     let syscall_num = frame.rax as usize;
     // 防止sys_sched由于超时无法退出导致的死锁
     if syscall_num == SYS_SCHED {

--- a/kernel/src/driver/base/block/block_device.rs
+++ b/kernel/src/driver/base/block/block_device.rs
@@ -62,7 +62,7 @@ impl BlockIter {
         return BlockIter {
             begin: start_addr,
             end: end_addr,
-            blk_size_log2: blk_size_log2,
+            blk_size_log2,
             multiblock: false,
         };
     }
@@ -92,9 +92,9 @@ impl BlockIter {
         return BlockRange {
             lba_start: lba_id,
             lba_end: lba_id + 1,
-            begin: begin,
-            end: end,
-            blk_size_log2: blk_size_log2,
+            begin,
+            end,
+            blk_size_log2,
         };
     }
 
@@ -119,11 +119,11 @@ impl BlockIter {
         self.begin += end - begin;
 
         return BlockRange {
-            lba_start: lba_start,
-            lba_end: lba_end,
-            begin: begin,
-            end: end,
-            blk_size_log2: blk_size_log2,
+            lba_start,
+            lba_end,
+            begin,
+            end,
+            blk_size_log2,
         };
     }
 }

--- a/kernel/src/driver/base/device/dd.rs
+++ b/kernel/src/driver/base/device/dd.rs
@@ -94,11 +94,9 @@ impl DeviceManager {
                 if unlikely(r.is_err()) {
                     flag = false;
                     break;
-                } else {
-                    if r.unwrap() == true {
-                        flag = true;
-                        break;
-                    }
+                } else if r.unwrap() == true {
+                    flag = true;
+                    break;
                 }
             }
 
@@ -158,10 +156,8 @@ impl DeviceManager {
                     );
                     return Err(e);
                 }
-            } else {
-                if r.unwrap() == false {
-                    return Ok(false);
-                }
+            } else if r.unwrap() == false {
+                return Ok(false);
             }
         }
 
@@ -211,14 +207,12 @@ impl DeviceManager {
             self.device_links_force_bind(dev);
             driver_manager().driver_bound(dev);
             return Err(e);
-        } else {
-            if let Some(bus) = dev.bus().map(|bus| bus.upgrade()).flatten() {
-                bus.subsystem().bus_notifier().call_chain(
-                    BusNotifyEvent::DriverNotBound,
-                    Some(dev),
-                    None,
-                );
-            }
+        } else if let Some(bus) = dev.bus().map(|bus| bus.upgrade()).flatten() {
+            bus.subsystem().bus_notifier().call_chain(
+                BusNotifyEvent::DriverNotBound,
+                Some(dev),
+                None,
+            );
         }
         return r;
     }

--- a/kernel/src/driver/base/device/device_number.rs
+++ b/kernel/src/driver/base/device/device_number.rs
@@ -33,7 +33,7 @@ pub struct DeviceNumber {
 
 impl DeviceNumber {
     pub const MINOR_BITS: u32 = 20;
-    pub const MINOR_MASK: u32 = 1 << Self::MINOR_BITS - 1;
+    pub const MINOR_MASK: u32 = 1 << (Self::MINOR_BITS - 1);
 
     pub const fn new(major: Major, minor: u32) -> Self {
         Self {

--- a/kernel/src/driver/base/device/driver.rs
+++ b/kernel/src/driver/base/device/driver.rs
@@ -287,9 +287,9 @@ impl DriverMatcher<&str> for DriverMatchName {
 }
 
 /// enum probe_type - device driver probe type to try
-///	Device drivers may opt in for special handling of their
-///	respective probe routines. This tells the core what to
-///	expect and prefer.
+/// Device drivers may opt in for special handling of their
+/// respective probe routines. This tells the core what to
+/// expect and prefer.
 ///
 /// Note that the end goal is to switch the kernel to use asynchronous
 /// probing by default, so annotating drivers with
@@ -300,18 +300,18 @@ impl DriverMatcher<&str> for DriverMatchName {
 #[derive(Debug)]
 pub enum DriverProbeType {
     /// Used by drivers that work equally well
-    ///	whether probed synchronously or asynchronously.
+    /// whether probed synchronously or asynchronously.
     DefaultStrategy,
 
     /// Drivers for "slow" devices which
-    ///	probing order is not essential for booting the system may
-    ///	opt into executing their probes asynchronously.
+    /// probing order is not essential for booting the system may
+    /// opt into executing their probes asynchronously.
     PreferAsync,
 
     /// Use this to annotate drivers that need
-    ///	their probe routines to run synchronously with driver and
-    ///	device registration (with the exception of -EPROBE_DEFER
-    ///	handling - re-probing always ends up being done asynchronously).
+    /// their probe routines to run synchronously with driver and
+    /// device registration (with the exception of -EPROBE_DEFER
+    /// handling - re-probing always ends up being done asynchronously).
     ForceSync,
 }
 

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -98,11 +98,11 @@ pub fn sys_dev_char_kset() -> Arc<KSet> {
     unsafe { DEV_CHAR_KSET_INSTANCE.as_ref().unwrap().clone() }
 }
 
-pub(self) unsafe fn set_sys_dev_block_kset(kset: Arc<KSet>) {
+unsafe fn set_sys_dev_block_kset(kset: Arc<KSet>) {
     DEV_BLOCK_KSET_INSTANCE = Some(kset);
 }
 
-pub(self) unsafe fn set_sys_dev_char_kset(kset: Arc<KSet>) {
+unsafe fn set_sys_dev_char_kset(kset: Arc<KSet>) {
     DEV_CHAR_KSET_INSTANCE = Some(kset);
 }
 
@@ -111,7 +111,7 @@ pub fn sys_devices_virtual_kset() -> Arc<KSet> {
     unsafe { DEVICES_VIRTUAL_KSET_INSTANCE.as_ref().unwrap().clone() }
 }
 
-pub(self) unsafe fn set_sys_devices_virtual_kset(kset: Arc<KSet>) {
+unsafe fn set_sys_devices_virtual_kset(kset: Arc<KSet>) {
     DEVICES_VIRTUAL_KSET_INSTANCE = Some(kset);
 }
 

--- a/kernel/src/driver/disk/ahci/ahci_inode.rs
+++ b/kernel/src/driver/disk/ahci/ahci_inode.rs
@@ -39,7 +39,7 @@ impl LockedAhciInode {
             // uuid: Uuid::new_v5(),
             self_ref: Weak::default(),
             fs: Weak::default(),
-            disk: disk,
+            disk,
             metadata: Metadata {
                 dev_id: 1,
                 inode_id: generate_inode_id(),

--- a/kernel/src/driver/firmware/efi/tables.rs
+++ b/kernel/src/driver/firmware/efi/tables.rs
@@ -25,7 +25,7 @@ use super::{
 };
 
 /// 所有的要解析的表格的解析器
-static TABLE_PARSERS: &'static [&'static TableMatcher] = &[
+static TABLE_PARSERS: &[&TableMatcher] = &[
     &TableMatcher::new(&MatchTableDragonStubPayloadEFI),
     &TableMatcher::new(&MatchTableMemoryAttributes),
     &TableMatcher::new(&MatchTableMemReserve),

--- a/kernel/src/driver/net/e1000e/e1000e.rs
+++ b/kernel/src/driver/net/e1000e/e1000e.rs
@@ -155,7 +155,7 @@ impl E1000EBuffer {
         return self.length;
     }
     // 释放buffer内部的dma_pages，需要小心使用
-    pub fn free_buffer(self) -> () {
+    pub fn free_buffer(self) {
         if self.length != 0 {
             unsafe { dma_dealloc(self.paddr, self.buffer, E1000E_DMA_PAGES) };
         }
@@ -593,7 +593,7 @@ pub extern "C" fn rs_e1000e_init() {
     e1000e_init();
 }
 
-pub fn e1000e_init() -> () {
+pub fn e1000e_init() {
     match e1000e_probe() {
         Ok(_code) => {
             kinfo!("Successfully init e1000e device!");

--- a/kernel/src/driver/open_firmware/fdt.rs
+++ b/kernel/src/driver/open_firmware/fdt.rs
@@ -92,10 +92,10 @@ impl OpenFirmwareFdtDriver {
 
     /// 扫描 `/chosen` 节点
     fn early_init_scan_chosen(&self, fdt: &Fdt) -> Result<(), SystemError> {
-        const CHOSEN_NAME1: &'static str = "/chosen";
+        const CHOSEN_NAME1: &str = "/chosen";
         let mut node = fdt.find_node(CHOSEN_NAME1);
         if node.is_none() {
-            const CHOSEN_NAME2: &'static str = "/chosen@0";
+            const CHOSEN_NAME2: &str = "/chosen@0";
             node = fdt.find_node(CHOSEN_NAME2);
             if node.is_some() {
                 FDT_GLOBAL_DATA.write().chosen_node_name = Some(CHOSEN_NAME2);

--- a/kernel/src/driver/tty/tty_driver.rs
+++ b/kernel/src/driver/tty/tty_driver.rs
@@ -236,10 +236,8 @@ impl TtyDriver {
                 // TODO: 暂时这么写，因为还没写TtyPort
                 if tty.core().port().is_none() {
                     kwarn!("{} port is None", tty.core().name());
-                } else {
-                    if tty.core().port().unwrap().state() == TtyPortState::KOPENED {
-                        return Err(SystemError::EBUSY);
-                    }
+                } else if tty.core().port().unwrap().state() == TtyPortState::KOPENED {
+                    return Err(SystemError::EBUSY);
                 }
 
                 tty.reopen()?;

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1447,18 +1447,16 @@ impl NTtyData {
             '\t' => {
                 // 计算输出一个\t需要的空间
                 let spaces = 8 - (self.cursor_column & 7) as usize;
-                if termios.output_mode.contains(OutputMode::TABDLY) {
-                    if OutputMode::TABDLY.bits() == OutputMode::XTABS.bits() {
-                        // 配置的tab选项是真正输出空格到驱动
-                        if space < spaces {
-                            // 空间不够
-                            return Err(SystemError::ENOBUFS);
-                        }
-                        self.cursor_column += spaces as u32;
-                        // 写入sapces个空格
-                        tty.write(core, "        ".as_bytes(), spaces)?;
-                        return Ok(spaces);
+                if termios.output_mode.contains(OutputMode::TABDLY) && OutputMode::TABDLY.bits() == OutputMode::XTABS.bits() {
+                    // 配置的tab选项是真正输出空格到驱动
+                    if space < spaces {
+                    // 空间不够
+                        return Err(SystemError::ENOBUFS);
                     }
+                    self.cursor_column += spaces as u32;
+                    // 写入sapces个空格
+                    tty.write(core, "        ".as_bytes(), spaces)?;
+                    return Ok(spaces);
                 }
                 self.cursor_column += spaces as u32;
             }

--- a/kernel/src/libs/elf.rs
+++ b/kernel/src/libs/elf.rs
@@ -501,7 +501,7 @@ impl ElfLoader {
 }
 
 impl BinaryLoader for ElfLoader {
-    fn probe(self: &'static Self, param: &ExecParam, buf: &[u8]) -> Result<(), ExecError> {
+    fn probe(&'static self, param: &ExecParam, buf: &[u8]) -> Result<(), ExecError> {
         // let elf_bytes =
         //     ElfBytes::<AnyEndian>::minimal_parse(buf).map_err(|_| ExecError::NotExecutable)?;
 
@@ -518,7 +518,7 @@ impl BinaryLoader for ElfLoader {
     }
 
     fn load(
-        self: &'static Self,
+        &'static self,
         param: &mut ExecParam,
         head_buf: &[u8],
     ) -> Result<BinaryLoaderResult, ExecError> {
@@ -743,10 +743,9 @@ impl BinaryLoader for ElfLoader {
             }
 
             let p_vaddr = VirtAddr::new(seg_to_load.p_vaddr as usize);
-            if (seg_to_load.p_flags & elf::abi::PF_X) != 0 {
-                if start_code.is_none() || start_code.as_ref().unwrap() > &p_vaddr {
-                    start_code = Some(p_vaddr);
-                }
+            if (seg_to_load.p_flags & elf::abi::PF_X) != 0 && 
+                (start_code.is_none() || start_code.as_ref().unwrap() > &p_vaddr) {
+                start_code = Some(p_vaddr);
             }
 
             if start_data.is_none()

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -553,7 +553,7 @@ impl Futex {
         let mut oparg = sign_extend32((encoded_op & 0x00fff000) >> 12, 11);
         let cmparg = sign_extend32(encoded_op & 0x00000fff, 11);
 
-        if encoded_op & (FutexOP::FUTEX_OP_OPARG_SHIFT.bits() << 28) != 0 && oparg > 31 {
+        if (encoded_op & (FutexOP::FUTEX_OP_OPARG_SHIFT.bits() << 28) != 0) && oparg > 31 {
             kwarn!(
                 "futex_wake_op: pid:{} tries to shift op by {}; fix this program",
                 ProcessManager::current_pcb().pid().data(),

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -317,12 +317,10 @@ impl Futex {
         };
 
         // 如果是超时唤醒，则返回错误
-        if timer.is_some() {
-            if timer.clone().unwrap().timeout() {
-                bucket_mut.remove(futex_q);
+        if timer.is_some() && timer.clone().unwrap().timeout() {
+            bucket_mut.remove(futex_q);
 
-                return Err(SystemError::ETIMEDOUT);
-            }
+            return Err(SystemError::ETIMEDOUT);
         }
 
         // TODO: 如果没有挂起的信号，则重新判断是否满足wait要求，重新进入wait
@@ -555,16 +553,14 @@ impl Futex {
         let mut oparg = sign_extend32((encoded_op & 0x00fff000) >> 12, 11);
         let cmparg = sign_extend32(encoded_op & 0x00000fff, 11);
 
-        if encoded_op & (FutexOP::FUTEX_OP_OPARG_SHIFT.bits() << 28) != 0 {
-            if oparg > 31 {
-                kwarn!(
-                    "futex_wake_op: pid:{} tries to shift op by {}; fix this program",
-                    ProcessManager::current_pcb().pid().data(),
-                    oparg
-                );
+        if encoded_op & (FutexOP::FUTEX_OP_OPARG_SHIFT.bits() << 28) != 0 && oparg > 31 {
+            kwarn!(
+                "futex_wake_op: pid:{} tries to shift op by {}; fix this program",
+                ProcessManager::current_pcb().pid().data(),
+                oparg
+            );
 
-                oparg &= 31;
-            }
+            oparg &= 31;
         }
 
         // TODO: 这个汇编似乎是有问题的，目前不好测试

--- a/kernel/src/libs/keyboard_parser.rs
+++ b/kernel/src/libs/keyboard_parser.rs
@@ -124,14 +124,12 @@ impl TypeOneFSMState {
         };
         if scancode != PAUSE_BREAK_SCAN_CODE[i as usize] {
             return self.handle_type3(scancode, scancode_status);
+        } else if i == 5 {
+            // 所有Pause Break扫描码都被清除
+            return TypeOneFSMState::Start;
         } else {
-            if i == 5 {
-                // 所有Pause Break扫描码都被清除
-                return TypeOneFSMState::Start;
-            } else {
-                return TypeOneFSMState::PauseBreak(i + 1);
-            }
-        }
+            return TypeOneFSMState::PauseBreak(i + 1);
+        } 
     }
 
     fn handle_func0(&self, scancode: u8, scancode_status: &mut ScanCodeStatus) -> TypeOneFSMState {
@@ -385,14 +383,12 @@ impl TypeOneFSMState {
         }
         if scancode != PRTSC_SCAN_CODE[i as usize] {
             return self.handle_type3(scancode, scancode_status);
+        } else if i == 3 {
+            // 成功解析出PrtscPress
+            return TypeOneFSMState::Start;
         } else {
-            if i == 3 {
-                // 成功解析出PrtscPress
-                return TypeOneFSMState::Start;
-            } else {
-                // 继续解析
-                return TypeOneFSMState::PrtscPress(i + 1);
-            }
+            // 继续解析
+            return TypeOneFSMState::PrtscPress(i + 1);
         }
     }
 
@@ -412,14 +408,12 @@ impl TypeOneFSMState {
         }
         if scancode != PRTSC_SCAN_CODE[i as usize] {
             return self.handle_type3(scancode, scancode_status);
+        } else if i == 3 {
+            // 成功解析出PrtscRelease
+            return TypeOneFSMState::Start;
         } else {
-            if i == 3 {
-                // 成功解析出PrtscRelease
-                return TypeOneFSMState::Start;
-            } else {
-                // 继续解析
-                return TypeOneFSMState::PrtscRelease(i + 1);
-            }
+            // 继续解析
+            return TypeOneFSMState::PrtscRelease(i + 1);
         }
     }
 }

--- a/kernel/src/libs/lib_ui/textui.rs
+++ b/kernel/src/libs/lib_ui/textui.rs
@@ -853,19 +853,18 @@ impl TextuiWindow {
                     self.textui_refresh_vlines(self.top_vline, actual_line_sum)?;
                 }
             }
-        } else {
-            if is_enable_window == true {
-                if let TextuiVline::Chromatic(vline) =
-                    &self.vlines[<LineId as Into<usize>>::into(self.vline_operating)]
-                {
-                    if !vline.index.check(self.chars_per_line) {
-                        self.textui_new_line()?;
-                    }
-
-                    return self.true_textui_putchar_window(character, frcolor, bkcolor);
+        } else if is_enable_window == true {
+            if let TextuiVline::Chromatic(vline) =
+                &self.vlines[<LineId as Into<usize>>::into(self.vline_operating)]
+            {
+                if !vline.index.check(self.chars_per_line) {
+                    self.textui_new_line()?;
                 }
+
+                return self.true_textui_putchar_window(character, frcolor, bkcolor);
             }
         }
+        
 
         return Ok(());
     }

--- a/kernel/src/libs/lib_ui/textui_no_alloc.rs
+++ b/kernel/src/libs/lib_ui/textui_no_alloc.rs
@@ -98,24 +98,22 @@ pub fn no_init_textui_putchar_window(
                 }
             }
         }
-    } else {
-        if is_put_to_window == true {
-            // 输出其他字符
-            let char = TextuiCharChromatic::new(Some(character), frcolor, bkcolor);
+    } else if is_put_to_window == true {
+        // 输出其他字符
+        let char = TextuiCharChromatic::new(Some(character), frcolor, bkcolor);
 
-            if NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)
-                == CHAR_PER_LINE.load(Ordering::SeqCst)
-            {
-                NO_ALLOC_OPERATIONS_INDEX.store(0, Ordering::SeqCst);
-                NO_ALLOC_OPERATIONS_LINE.fetch_add(1, Ordering::SeqCst);
-            }
-            char.no_init_textui_render_chromatic(
-                LineId::new(NO_ALLOC_OPERATIONS_LINE.load(Ordering::SeqCst)),
-                LineIndex::new(NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)),
-            );
-
-            NO_ALLOC_OPERATIONS_INDEX.fetch_add(1, Ordering::SeqCst);
+        if NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)
+            == CHAR_PER_LINE.load(Ordering::SeqCst)
+        {
+            NO_ALLOC_OPERATIONS_INDEX.store(0, Ordering::SeqCst);
+            NO_ALLOC_OPERATIONS_LINE.fetch_add(1, Ordering::SeqCst);
         }
+        char.no_init_textui_render_chromatic(
+            LineId::new(NO_ALLOC_OPERATIONS_LINE.load(Ordering::SeqCst)),
+            LineIndex::new(NO_ALLOC_OPERATIONS_INDEX.load(Ordering::SeqCst)),
+        );
+
+        NO_ALLOC_OPERATIONS_INDEX.fetch_add(1, Ordering::SeqCst);
     }
 
     return Ok(());

--- a/kernel/src/libs/rbtree.rs
+++ b/kernel/src/libs/rbtree.rs
@@ -1309,12 +1309,10 @@ impl<K: Ord, V> RBTree<K, V> {
             let mut replace = node.right().min_node();
             if node == self.root {
                 self.root = replace;
+            } else if node.parent().left() == node {
+                node.parent().set_left(replace);
             } else {
-                if node.parent().left() == node {
-                    node.parent().set_left(replace);
-                } else {
-                    node.parent().set_right(replace);
-                }
+                node.parent().set_right(replace);
             }
 
             // child是"取代节点"的右孩子，也是需要"调整的节点"。
@@ -1360,12 +1358,10 @@ impl<K: Ord, V> RBTree<K, V> {
 
         if self.root == node {
             self.root = child
+        } else if parent.left() == node {
+            parent.set_left(child);
         } else {
-            if parent.left() == node {
-                parent.set_left(child);
-            } else {
-                parent.set_right(child);
-            }
+            parent.set_right(child);
         }
 
         if color == Color::Black {

--- a/kernel/src/libs/vec_cursor.rs
+++ b/kernel/src/libs/vec_cursor.rs
@@ -19,7 +19,7 @@ pub struct VecCursor {
 impl VecCursor {
     /// @brief 新建一个游标
     pub fn new(data: Vec<u8>) -> Self {
-        return Self { data: data, pos: 0 };
+        return Self { data, pos: 0 };
     }
 
     /// @brief 创建一个全0的cursor


### PR DESCRIPTION
## **User description**
Fix 41 clippy errors or warnings.

240311 Afternoon

应该没有再混杂master的内容，刚刚手贱更新了分支orz


___

## **Type**
Bug fix, Enhancement


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>keyboard_parser.rs
</strong><dd><code>Improved FSM state handling and error checking for keyboard keys</code>&nbsp; </dd></summary>
<hr>

kernel/src/libs/keyboard_parser.rs
- Simplified the FSM state handling for Pause Break and Prtsc keys.
- Improved error handling for invalid scancodes.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-733a4f1094f36233bda42595f64f390b6ed74fb656d5dcc3862c8b260dfe1b0e"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>futex.rs
</strong><dd><code>Improved error handling and panic prevention in futex operations</code>&nbsp; </dd></summary>
<hr>

kernel/src/libs/futex/futex.rs
- Improved error handling for futex operations with timers.
- Fixed a potential panic in futex wake operations.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-0d4196d7a75c64795a1f9e9a4ac781c2a1b99fa2427950befe274916f3f5aeb6"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>elf.rs
</strong><dd><code>Fixed bugs and enhanced error handling in ElfLoader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/libs/elf.rs
- Fixed a bug in the ElfLoader's probe method.
- Improved error handling in the ElfLoader's load method.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-5b6ab37fc3bf49ed5867e2b5408f77d27bd7c978effef9d9ee651aaa53f8dbcb"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dd.rs
</strong><dd><code>Enhanced error handling and prevented panic in DeviceManager's 

 device_open</code></dd></summary>
<hr>

kernel/src/driver/base/device/dd.rs
- Improved error handling in DeviceManager's device_open method.
- Fixed a potential panic in DeviceManager's device_open method.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-b2c5f6a3b77e7b3ce9331c65454b0bc7238cbaee03c9617694876c173df2f56a"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_device.rs
</strong><dd><code>Fixed bugs and enhanced error handling in BlockIter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/driver/base/block/block_device.rs
- Fixed a bug in BlockIter's constructor.
- Improved error handling in BlockIter's methods.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-ae173e4da6e09fc509841d8d36af9eb2f62064ed3fc211692bc7e033f5ee1374"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>textui_no_alloc.rs
</strong><dd><code>Enhanced error handling and prevented panic in textui_no_alloc</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/libs/lib_ui/textui_no_alloc.rs
- Improved the no_init_textui_putchar_window method for better error <br>  handling.
- Fixed a potential panic in no_init_textui_putchar_window method.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-9eb082671c0f1db29d7a6b02a84fda7ac80d9b9ebc42eade52935bfdba85c974"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rbtree.rs
</strong><dd><code>Improved node replacement logic and prevented panic in RBTree</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/libs/rbtree.rs
- Improved the RBTree's node replacement logic.
- Fixed a potential panic in the RBTree's node replacement logic.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-fb27a4b028bd81834db9046a8e5dab52f289ec69ed7a29ef0060c46ace10bdba"></a></td>
</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs
</strong><dd><code>Enhanced unified_init proc_macro for better error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/crates/unified-init/macros/src/lib.rs
- Simplified the unified_init proc_macro attribute.
- Fixed a potential panic in the unified_init proc_macro.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-3dbf0722782d7628fb7ee58286670b471cedfc92912a226c0c1354641a2e42ce"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>driver.rs
</strong><dd><code>Documented DriverProbeType enum for clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/driver/base/device/driver.rs
- Added documentation for the DriverProbeType enum.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/582/files#diff-061c2fc69e37fcc6f5f89a25d6eb60a0bfff001676dc382cb29255ad4fb3d323"></a></td>
</tr>                    
</table></details></td></tr><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
