### PR TITLE
heyicong 3-12

### DIFF
--- a/kernel/src/filesystem/procfs/mod.rs
+++ b/kernel/src/filesystem/procfs/mod.rs
@@ -4,7 +4,7 @@ use alloc::{
     borrow::ToOwned,
     collections::BTreeMap,
     format,
-    string::String,
+    string::{String, ToString},
     sync::{Arc, Weak},
     vec::Vec,
 };

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -275,8 +275,7 @@ impl ProcessManager {
         }
 
         if clone_flags.contains(CloneFlags::CLONE_SIGHAND) {
-            (*new_pcb.sig_struct_irqsave()).handlers =
-                current_pcb.sig_struct_irqsave().handlers.clone();
+            new_pcb.sig_struct_irqsave().handlers = current_pcb.sig_struct_irqsave().handlers;
         }
         return Ok(());
     }
@@ -383,7 +382,7 @@ impl ProcessManager {
         }
 
         // 拷贝标志位
-        Self::copy_flags(&clone_flags, &pcb).unwrap_or_else(|e| {
+        Self::copy_flags(&clone_flags, pcb).unwrap_or_else(|e| {
             panic!(
                 "fork: Failed to copy flags from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.pid(), pcb.pid(), e
@@ -391,7 +390,7 @@ impl ProcessManager {
         });
 
         // 拷贝用户地址空间
-        Self::copy_mm(&clone_flags, &current_pcb, &pcb).unwrap_or_else(|e| {
+        Self::copy_mm(&clone_flags, current_pcb, pcb).unwrap_or_else(|e| {
             panic!(
                 "fork: Failed to copy mm from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.pid(), pcb.pid(), e
@@ -399,7 +398,7 @@ impl ProcessManager {
         });
 
         // 拷贝文件描述符表
-        Self::copy_files(&clone_flags, &current_pcb, &pcb).unwrap_or_else(|e| {
+        Self::copy_files(&clone_flags, current_pcb, pcb).unwrap_or_else(|e| {
             panic!(
                 "fork: Failed to copy files from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.pid(), pcb.pid(), e
@@ -407,7 +406,7 @@ impl ProcessManager {
         });
 
         // 拷贝信号相关数据
-        Self::copy_sighand(&clone_flags, &current_pcb, pcb).map_err(|e| {
+        Self::copy_sighand(&clone_flags, current_pcb, pcb).map_err(|e| {
             panic!(
                 "fork: Failed to copy sighand from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.pid(), pcb.pid(), e

--- a/kernel/src/process/kthread.rs
+++ b/kernel/src/process/kthread.rs
@@ -355,7 +355,7 @@ impl KernelThreadMechanism {
     ) -> Option<Arc<ProcessControlBlock>> {
         let pcb = Self::create(func, name)?;
         ProcessManager::wakeup(&pcb)
-            .expect(format!("Failed to wakeup kthread: {:?}", pcb.pid()).as_str());
+            .unwrap_or_else(|_| panic!("Failed to wakeup kthread: {:?}", pcb.pid()));
         return Some(pcb);
     }
 

--- a/kernel/src/sched/cfs.rs
+++ b/kernel/src/sched/cfs.rs
@@ -210,7 +210,7 @@ impl Scheduler for SchedulerCFS {
     /// @brief 在当前cpu上进行调度。
     /// 请注意，进入该函数之前，需要关中断
     fn sched(&mut self) -> Option<Arc<ProcessControlBlock>> {
-        assert!(CurrentIrqArch::is_irq_enabled() == false);
+        assert!(!CurrentIrqArch::is_irq_enabled());
 
         ProcessManager::current_pcb()
             .flags()

--- a/kernel/src/sched/rt.rs
+++ b/kernel/src/sched/rt.rs
@@ -115,9 +115,7 @@ impl SchedulerRT {
         }
         // 为每个cpu核心创建负载统计队列
         for _ in 0..MAX_CPU_NUM {
-            result
-                .load_list
-                .push(Box::leak(Box::new(LinkedList::new())));
+            result.load_list.push(Box::leak(Box::default()));
         }
         return result;
     }

--- a/kernel/src/sched/syscall.rs
+++ b/kernel/src/sched/syscall.rs
@@ -21,8 +21,7 @@ impl Syscall {
         // 根据调度结果统一进行切换
         let pcb = do_sched();
 
-        if pcb.is_some() {
-            let next_pcb = pcb.unwrap();
+        if let Some(next_pcb) = pcb {
             let current_pcb = ProcessManager::current_pcb();
             // kdebug!("sched: current_pcb: {:?}, next_pcb: {:?}\n", current_pcb, next_pcb);
             if current_pcb.pid() != next_pcb.pid() {

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -95,7 +95,7 @@ pub fn check_and_clone_cstr(
         }
         buffer.push(c[0]);
     }
-    return Ok(String::from_utf8(buffer).map_err(|_| SystemError::EFAULT)?);
+    String::from_utf8(buffer).map_err(|_| SystemError::EFAULT)
 }
 
 /// 检查并从用户态拷贝一个 C 字符串数组
@@ -229,9 +229,8 @@ impl<'a> UserBufferReader<'a> {
     ///
     /// - `offset`：字节偏移量
     pub fn buffer<T>(&self, offset: usize) -> Result<&[T], SystemError> {
-        Ok(self
-            .convert_with_offset::<T>(self.buffer, offset)
-            .map_err(|_| SystemError::EINVAL)?)
+        self.convert_with_offset::<T>(self.buffer, offset)
+            .map_err(|_| SystemError::EINVAL)
     }
 
     fn convert_with_offset<T>(&self, src: &[u8], offset: usize) -> Result<&[T], SystemError> {
@@ -318,7 +317,7 @@ impl<'a> UserBufferWriter<'a> {
     }
 
     pub fn buffer<T>(&'a mut self, offset: usize) -> Result<&mut [T], SystemError> {
-        Ok(Self::convert_with_offset::<T>(self.buffer, offset).map_err(|_| SystemError::EINVAL)?)
+        Self::convert_with_offset::<T>(self.buffer, offset).map_err(|_| SystemError::EINVAL)
     }
 
     fn convert_with_offset<T>(src: &mut [u8], offset: usize) -> Result<&mut [T], SystemError> {


### PR DESCRIPTION
## **Type**
Bug fix, Enhancement


___

## **Description**
This pull request includes several changes:
- Fixed a bug in signal handler cloning in the fork process.
- Updated the procfs module for type safety improvements.
- Improved error handling in kthread creation and syscall implementations.
- Added assertions for process state changes and irq state in the CFS scheduler.
- Fixed a bug in syscall handling for the RT scheduler and improved initialization of RT scheduler data structures.
- Fixed a bug in C string conversion in the user_access module.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs
</strong><dd><code>Update procfs module for type safety improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/filesystem/procfs/mod.rs
- Updated `String` to `ToString` for type safety.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-589a38e78558c15904667b709707a91c1f64f9d8b8e0fd6845b12a9addaf2b83"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fork.rs
</strong><dd><code>Fix signal handler cloning issue in fork process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/process/fork.rs
- Fixed a bug in signal handler cloning.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-b2f615e3d0b045115723f77e903b757da6f0901f91a2416316fb4216c2480803"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>syscall.rs
</strong><dd><code>Fix syscall handling for RT scheduler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/sched/syscall.rs
- Fixed a bug in syscall handling for RT scheduler.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-d2329b87b6b6b9b23afcd86073a9e99889d2ccb9a1899aedc445e13feb2228a9"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>user_access.rs
</strong><dd><code>Fix C string conversion issue in user_access module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/syscall/user_access.rs
- Fixed a bug in C string conversion.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-cc08884cf047a000057574cee98e2361d6834937f8f34b0ba4087a5451c99b4f"></a></td>
</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>kthread.rs
</strong><dd><code>Improve error handling for kthread creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/process/kthread.rs
- Improved error handling in kthread creation.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-41b144c220bda3e45c053f5bd28f5f7e8e8e4f7bcab8fb7048e6fe2f6896f559"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs
</strong><dd><code>Add assertions for process state changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/process/mod.rs
- Added assertions for process state changes.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-d213de2455287d29c4cb751bbf5b55b2cd59a9f5ba90b981d2b6807e38c8762c"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cfs.rs
</strong><dd><code>Add assertions for irq state in CFS scheduler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/sched/cfs.rs
- Added assertions for irq state in scheduler.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-c9c8e5524939f370e3606afe12e9cddbf838ec74b2d7a62c86253297f3cf8ec3"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rt.rs
</strong><dd><code>Improve RT scheduler data structures initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/sched/rt.rs
- Improved initialization of RT scheduler data structures.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-be882840b5b6ce415234216ac0284645a89101ca6bf828d968bbbb53eccfd7b3"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs
</strong><dd><code>Improve error handling in syscall implementations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/syscall/mod.rs
- Improved error handling in syscall implementations.

    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/595/files#diff-c6157a4f8c5e089bf48e6dfaf58ad40b92661fb0e7224723b2c8db9696c01e73"></a></td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
