### PR TITLE
Patch fix clippy 202403132007

### DIFF
--- a/kernel/src/filesystem/procfs/mod.rs
+++ b/kernel/src/filesystem/procfs/mod.rs
@@ -99,6 +99,12 @@ impl ProcfsFilePrivateData {
     }
 }
 
+impl Default for ProcfsFilePrivateData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// @brief procfs文件系统的Inode结构体(不包含锁)
 #[derive(Debug)]
 pub struct ProcFSInode {
@@ -135,14 +141,14 @@ impl ProcFSInode {
         // 获取该pid对应的pcb结构体
         let pid = self.fdata.pid;
         let pcb = ProcessManager::find(pid);
-        let pcb = if pcb.is_none() {
+        let pcb = if let Some(pcb) = pcb {
+            pcb
+        } else {
             kerror!(
                 "ProcFS: Cannot find pcb for pid {:?} when opening its 'status' file.",
                 pid
             );
             return Err(SystemError::ESRCH);
-        } else {
-            pcb.unwrap()
         };
         // 传入数据
         let pdata: &mut Vec<u8> = &mut pdata.data;

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -486,7 +486,7 @@ impl IndexNode for LockedRamFSInode {
         // 判断需要创建的类型
         if unlikely(mode.contains(ModeType::S_IFREG)) {
             // 普通文件
-            return Ok(self.create(filename, FileType::File, mode)?);
+            return self.create(filename, FileType::File, mode);
         }
 
         let nod = Arc::new(LockedRamFSInode(SpinLock::new(RamFSInode {

--- a/kernel/src/filesystem/sysfs/file.rs
+++ b/kernel/src/filesystem/sysfs/file.rs
@@ -412,12 +412,11 @@ impl KernFSCallback for PreallocKFOpsEmpty {
 }
 
 pub fn sysfs_emit_str(buf: &mut [u8], s: &str) -> Result<usize, SystemError> {
-    let len;
-    if buf.len() > s.len() {
-        len = s.len();
+    let len = if buf.len() > s.len() {
+        s.len()
     } else {
-        len = buf.len() - 1;
-    }
+        buf.len() - 1
+    };
     buf[..len].copy_from_slice(&s.as_bytes()[..len]);
     buf[len] = b'\0';
     return Ok(len);

--- a/kernel/src/filesystem/vfs/fcntl.rs
+++ b/kernel/src/filesystem/vfs/fcntl.rs
@@ -24,7 +24,7 @@ pub enum FcntlCommand {
     /// set record locking info (blocking)
     SetLockWait = 7,
 
-    SetLease = F_LINUX_SPECIFIC_BASE + 0,
+    SetLease = F_LINUX_SPECIFIC_BASE,
     GetLease = F_LINUX_SPECIFIC_BASE + 1,
 
     /// Request nofications on a directory.

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -289,22 +289,17 @@ impl File {
             _ => {}
         }
 
-        let pos: i64;
-        match origin {
-            SeekFrom::SeekSet(offset) => {
-                pos = offset;
-            }
-            SeekFrom::SeekCurrent(offset) => {
-                pos = self.offset as i64 + offset;
-            }
+        let pos: i64 = match origin {
+            SeekFrom::SeekSet(offset) => offset,
+            SeekFrom::SeekCurrent(offset) => self.offset as i64 + offset,
             SeekFrom::SeekEnd(offset) => {
                 let metadata = self.metadata()?;
-                pos = metadata.size + offset;
+                metadata.size + offset
             }
             SeekFrom::Invalid => {
                 return Err(SystemError::EINVAL);
             }
-        }
+        };
         // 根据linux man page, lseek允许超出文件末尾，并且不改变文件大小
         // 当pos超出文件末尾时，read返回0。直到开始写入数据时，才会改变文件大小
         if pos < 0 {
@@ -355,7 +350,7 @@ impl File {
             return Ok(0);
         }
         let name = &self.readdir_subdirs_name[self.offset];
-        let sub_inode: Arc<dyn IndexNode> = match inode.find(&name) {
+        let sub_inode: Arc<dyn IndexNode> = match inode.find(name) {
             Ok(i) => i,
             Err(e) => {
                 kerror!(
@@ -401,9 +396,9 @@ impl File {
     pub fn try_clone(&self) -> Option<File> {
         let mut res = Self {
             inode: self.inode.clone(),
-            offset: self.offset.clone(),
-            mode: self.mode.clone(),
-            file_type: self.file_type.clone(),
+            offset: self.offset,
+            mode: self.mode,
+            file_type: self.file_type,
             readdir_subdirs_name: self.readdir_subdirs_name.clone(),
             private_data: self.private_data.clone(),
         };
@@ -573,11 +568,7 @@ impl FileDescriptorVec {
     /// @return false 不合法
     #[inline]
     pub fn validate_fd(fd: i32) -> bool {
-        if fd < 0 || fd as usize > FileDescriptorVec::PROCESS_MAX_FD {
-            return false;
-        } else {
-            return true;
-        }
+        return !(fd < 0 || fd as usize > FileDescriptorVec::PROCESS_MAX_FD);
     }
 
     /// 申请文件描述符，并把文件对象存入其中。
@@ -592,9 +583,7 @@ impl FileDescriptorVec {
     /// - `Ok(i32)` 申请成功，返回申请到的文件描述符
     /// - `Err(SystemError)` 申请失败，返回错误码，并且，file对象将被drop掉
     pub fn alloc_fd(&mut self, file: File, fd: Option<i32>) -> Result<i32, SystemError> {
-        if fd.is_some() {
-            // 指定了要申请的文件描述符编号
-            let new_fd = fd.unwrap();
+        if let Some(new_fd) = fd {
             let x = &mut self.fds[new_fd as usize];
             if x.is_none() {
                 *x = Some(Arc::new(SpinLock::new(file)));

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -36,7 +36,7 @@ pub(super) fn do_faccessat(
 
     let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
 
-    if path.len() == 0 {
+    if path.is_empty() {
         return Err(SystemError::EINVAL);
     }
 
@@ -52,7 +52,7 @@ pub(super) fn do_faccessat(
 pub fn do_fchmodat(dirfd: i32, path: *const u8, _mode: ModeType) -> Result<usize, SystemError> {
     let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
 
-    if path.len() == 0 {
+    if path.is_empty() {
         return Err(SystemError::EINVAL);
     }
 
@@ -86,7 +86,7 @@ fn do_sys_openat2(
 ) -> Result<usize, SystemError> {
     // kdebug!("open: path: {}, mode: {:?}", path, mode);
     // 文件名过长
-    if path.len() > MAX_PATHLEN as usize {
+    if path.len() > MAX_PATHLEN {
         return Err(SystemError::ENAMETOOLONG);
     }
     let (inode_begin, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
@@ -99,30 +99,30 @@ fn do_sys_openat2(
         },
     );
 
-    let inode: Arc<dyn IndexNode> = if inode.is_err() {
-        let errno = inode.unwrap_err();
-        // 文件不存在，且需要创建
-        if how.o_flags.contains(FileMode::O_CREAT)
-            && !how.o_flags.contains(FileMode::O_DIRECTORY)
-            && errno == SystemError::ENOENT
-        {
-            let (filename, parent_path) = rsplit_path(&path);
-            // 查找父目录
-            let parent_inode: Arc<dyn IndexNode> =
-                ROOT_INODE().lookup(parent_path.unwrap_or("/"))?;
-            // 创建文件
-            let inode: Arc<dyn IndexNode> = parent_inode.create(
-                filename,
-                FileType::File,
-                ModeType::from_bits_truncate(0o755),
-            )?;
-            inode
-        } else {
-            // 不需要创建文件，因此返回错误码
-            return Err(errno);
+    let inode: Arc<dyn IndexNode> = match inode {
+        Ok(inode) => inode,
+        Err(errno) => {
+            // 文件不存在，且需要创建
+            if how.o_flags.contains(FileMode::O_CREAT)
+                && !how.o_flags.contains(FileMode::O_DIRECTORY)
+                && errno == SystemError::ENOENT
+            {
+                let (filename, parent_path) = rsplit_path(&path);
+                // 查找父目录
+                let parent_inode: Arc<dyn IndexNode> =
+                    ROOT_INODE().lookup(parent_path.unwrap_or("/"))?;
+                // 创建文件
+                let inode: Arc<dyn IndexNode> = parent_inode.create(
+                    filename,
+                    FileType::File,
+                    ModeType::from_bits_truncate(0o755),
+                )?;
+                inode
+            } else {
+                // 不需要创建文件，因此返回错误码
+                return Err(errno);
+            }
         }
-    } else {
-        inode.unwrap()
     };
 
     let file_type: FileType = inode.metadata()?.file_type;

--- a/kernel/src/init/init.rs
+++ b/kernel/src/init/init.rs
@@ -30,7 +30,7 @@ use crate::{
 /// 前面可能会有一个架构相关的函数
 pub fn start_kernel() -> ! {
     // 进入内核后，中断应该是关闭的
-    assert_eq!(CurrentIrqArch::is_irq_enabled(), false);
+    assert!(!CurrentIrqArch::is_irq_enabled());
 
     do_start_kernel();
 
@@ -76,7 +76,7 @@ fn do_start_kernel() {
 
     CurrentSMPArch::init().expect("smp init failed");
     // SMP初始化有可能会开中断，所以这里再次检查中断是否关闭
-    assert_eq!(CurrentIrqArch::is_irq_enabled(), false);
+    assert!(!CurrentIrqArch::is_irq_enabled());
     Futex::init();
 
     setup_arch_post().expect("setup_arch_post failed");

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -108,12 +108,12 @@ impl Signal {
             let new_sig_info = match info {
                 Some(siginfo) => {
                     // 已经显式指定了siginfo，则直接使用它。
-                    (*siginfo).clone()
+                    *siginfo
                 }
                 None => {
                     // 不需要显示指定siginfo，因此设置为默认值
                     SigInfo::new(
-                        self.clone(),
+                        *self,
                         0,
                         SigCode::User,
                         SigType::Kill(ProcessManager::current_pcb().pid()),
@@ -127,7 +127,7 @@ impl Signal {
                 .q
                 .push(new_sig_info);
 
-            if pt == PidType::PGID || pt == PidType::SID {}
+            // if pt == PidType::PGID || pt == PidType::SID {}
             self.complete_signal(pcb.clone(), pt);
         }
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
@@ -213,11 +213,7 @@ impl Signal {
         // todo: 检查目标进程是否正在一个cpu上执行，如果是，则返回true，否则继续检查下一项
 
         // 检查目标进程是否有信号正在等待处理，如果是，则返回false，否则返回true
-        if pcb.sig_info_irqsave().sig_pending().signal().bits() == 0 {
-            return true;
-        } else {
-            return false;
-        }
+        return pcb.sig_info_irqsave().sig_pending().signal().bits() == 0;
     }
 
     /// @brief 判断signal的处理是否可能使得整个进程组退出
@@ -374,8 +370,7 @@ pub(super) fn do_sigaction(
 
     // 保存原有的 sigaction
     let old_act: Option<&mut Sigaction> = {
-        if old_act.is_some() {
-            let oa = old_act.unwrap();
+        if let Some(oa) = old_act {
             *(oa) = (*action).clone();
             Some(oa)
         } else {
@@ -384,8 +379,7 @@ pub(super) fn do_sigaction(
     };
     // 清除所有的脏的sa_flags位（也就是清除那些未使用的）
     let act = {
-        if act.is_some() {
-            let ac = act.unwrap();
+        if let Some(ac) = act {
             *ac.flags_mut() &= SigFlags::SA_ALL;
             Some(ac)
         } else {
@@ -397,8 +391,7 @@ pub(super) fn do_sigaction(
         *old_act.unwrap().flags_mut() &= SigFlags::SA_ALL;
     }
 
-    if act.is_some() {
-        let ac = act.unwrap();
+    if let Some(ac) = act {
         // 将act.sa_mask的SIGKILL SIGSTOP的屏蔽清除
         ac.mask_mut()
             .remove(SigSet::from(Signal::SIGKILL.into()) | SigSet::from(Signal::SIGSTOP.into()));

--- a/kernel/src/ipc/syscall.rs
+++ b/kernel/src/ipc/syscall.rs
@@ -130,13 +130,13 @@ impl Syscall {
             let input_sighandler = unsafe { (*act).handler as u64 };
             match input_sighandler {
                 USER_SIG_DFL => {
-                    new_ka = Sigaction::DEFAULT_SIGACTION.clone();
+                    new_ka = Sigaction::DEFAULT_SIGACTION;
                     *new_ka.flags_mut() = unsafe { (*act).flags };
                     new_ka.set_restorer(None);
                 }
 
                 USER_SIG_IGN => {
-                    new_ka = Sigaction::DEFAULT_SIGACTION_IGNORE.clone();
+                    new_ka = Sigaction::DEFAULT_SIGACTION_IGNORE;
                     *new_ka.flags_mut() = unsafe { (*act).flags };
 
                     new_ka.set_restorer(None);
@@ -171,7 +171,7 @@ impl Syscall {
             *new_ka.mask_mut() = mask;
         }
 
-        let sig = Signal::from(sig as i32);
+        let sig = Signal::from(sig);
         // 如果给出的信号值不合法
         if sig == Signal::INVALID {
             return Err(SystemError::EINVAL);
@@ -199,8 +199,7 @@ impl Syscall {
                 return Err(SystemError::EFAULT);
             }
 
-            let sigaction_handler: VirtAddr;
-            sigaction_handler = match old_sigaction.action() {
+            let sigaction_handler = match old_sigaction.action() {
                 SigactionType::SaHandler(handler) => {
                     if let SaHandlerType::SigCustomized(hand) = handler {
                         hand

--- a/kernel/src/mm/allocator/buddy.rs
+++ b/kernel/src/mm/allocator/buddy.rs
@@ -64,7 +64,7 @@ impl<A> PageList<A> {
 #[derive(Debug)]
 pub struct BuddyAllocator<A> {
     // 存放每个阶的空闲“链表”的头部地址
-    free_area: [PhysAddr; (MAX_ORDER - MIN_ORDER) as usize],
+    free_area: [PhysAddr; MAX_ORDER - MIN_ORDER],
     /// 总页数
     total: PageFrameCount,
     phantom: PhantomData<A>,
@@ -81,8 +81,8 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
         kdebug!("Free pages before init buddy: {:?}", initial_free_pages);
         kdebug!("Buddy entries: {}", Self::BUDDY_ENTRIES);
 
-        let mut free_area: [PhysAddr; (MAX_ORDER - MIN_ORDER) as usize] =
-            [PhysAddr::new(0); (MAX_ORDER - MIN_ORDER) as usize];
+        let mut free_area: [PhysAddr; MAX_ORDER - MIN_ORDER] =
+            [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
 
         // Buddy初始占用的空间从bump分配
         for f in free_area.iter_mut() {
@@ -213,7 +213,7 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
     /// free_area的下标
     #[inline]
     fn order2index(order: u8) -> usize {
-        (order as usize - MIN_ORDER) as usize
+        order as usize - MIN_ORDER
     }
 
     /// 从空闲链表的开头，取出1个指定阶数的伙伴块，如果没有，则返回None
@@ -302,7 +302,7 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
             }
             return None;
         };
-        let result: Option<PhysAddr> = alloc_in_specific_order(order as u8);
+        let result: Option<PhysAddr> = alloc_in_specific_order(order);
         // kdebug!("result={:?}", result);
         if result.is_some() {
             return result;
@@ -351,7 +351,7 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
     fn buddy_alloc(&mut self, count: PageFrameCount) -> Option<(PhysAddr, PageFrameCount)> {
         assert!(count.data().is_power_of_two());
         // 计算需要分配的阶数
-        let mut order = log2(count.data() as usize);
+        let mut order = log2(count.data());
         if count.data() & ((1 << order) - 1) != 0 {
             order += 1;
         }
@@ -425,79 +425,9 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
             }
 
             // 如果没有找到伙伴块
-            if buddy_entry_virt_vaddr.is_none() {
-                assert!(
-                    page_list.entry_num <= Self::BUDDY_ENTRIES,
-                    "buddy_free: page_list.entry_num > Self::BUDDY_ENTRIES"
-                );
-
-                // 当前第一个page_list没有空间了
-                if first_page_list.entry_num == Self::BUDDY_ENTRIES {
-                    // 如果当前order是最小的，那么就把这个块当作新的page_list使用
-                    let new_page_list_addr = if order == MIN_ORDER {
-                        base
-                    } else {
-                        // 否则分配新的page_list
-                        // 请注意，分配之后，有可能当前的entry_num会减1（伙伴块分裂），造成出现整个链表为null的entry数量为Self::BUDDY_ENTRIES+1的情况
-                        // 但是不影响，我们在后面插入链表项的时候，会处理这种情况，检查链表中的第2个页是否有空位
-                        self.buddy_alloc(PageFrameCount::new(1))
-                            .expect("buddy_alloc failed: no enough memory")
-                            .0
-                    };
-
-                    // 清空这个页面
-                    core::ptr::write_bytes(
-                        A::phys_2_virt(new_page_list_addr)
-                            .expect(
-                                "Buddy free: failed to get virt address of [new_page_list_addr]",
-                            )
-                            .as_ptr::<u8>(),
-                        0,
-                        1 << order,
-                    );
-                    assert!(
-                        first_page_list_paddr == self.free_area[Self::order2index(order as u8)]
-                    );
-                    // 初始化新的page_list
-                    let new_page_list = PageList::new(0, first_page_list_paddr);
-                    Self::write_page(new_page_list_addr, new_page_list);
-                    self.free_area[Self::order2index(order as u8)] = new_page_list_addr;
-                }
-
-                // 由于上面可能更新了第一个链表页，因此需要重新获取这个值
-                let first_page_list_paddr = self.free_area[Self::order2index(order as u8)];
-                let first_page_list: PageList<A> = Self::read_page(first_page_list_paddr);
-
-                // 检查第二个page_list是否有空位
-                let second_page_list = if first_page_list.next_page.is_null() {
-                    None
-                } else {
-                    Some(Self::read_page::<PageList<A>>(first_page_list.next_page))
-                };
-
-                let (paddr, mut page_list) = if let Some(second) = second_page_list {
-                    // 第二个page_list有空位
-                    // 应当符合之前的假设：还有1个空位
-                    assert!(second.entry_num == Self::BUDDY_ENTRIES - 1);
-
-                    (first_page_list.next_page, second)
-                } else {
-                    // 在第一个page list中分配
-                    (first_page_list_paddr, first_page_list)
-                };
-
-                // kdebug!("to write entry, page_list_base={paddr:?}, page_list.entry_num={}, value={base:?}", page_list.entry_num);
-                assert!(page_list.entry_num < Self::BUDDY_ENTRIES);
-                // 把要归还的块，写入到链表项中
-                unsafe { A::write(Self::entry_virt_addr(paddr, page_list.entry_num), base) }
-                page_list.entry_num += 1;
-                Self::write_page(paddr, page_list);
-                return;
-            } else {
+            if let Some(buddy_entry_virt_addr) = buddy_entry_virt_vaddr {
                 // 如果找到了伙伴块，合并，向上递归
 
-                // 伙伴块所在的表项的虚拟地址
-                let buddy_entry_virt_addr = buddy_entry_virt_vaddr.unwrap();
                 // 伙伴块所在的page_list的物理地址
                 let buddy_entry_page_list_paddr = buddy_entry_page_list_paddr.unwrap();
 
@@ -567,6 +497,74 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
                     page_list.entry_num -= 1;
                     Self::write_page(page_list_paddr, page_list);
                 }
+            } else {
+                assert!(
+                    page_list.entry_num <= Self::BUDDY_ENTRIES,
+                    "buddy_free: page_list.entry_num > Self::BUDDY_ENTRIES"
+                );
+
+                // 当前第一个page_list没有空间了
+                if first_page_list.entry_num == Self::BUDDY_ENTRIES {
+                    // 如果当前order是最小的，那么就把这个块当作新的page_list使用
+                    let new_page_list_addr = if order == MIN_ORDER {
+                        base
+                    } else {
+                        // 否则分配新的page_list
+                        // 请注意，分配之后，有可能当前的entry_num会减1（伙伴块分裂），造成出现整个链表为null的entry数量为Self::BUDDY_ENTRIES+1的情况
+                        // 但是不影响，我们在后面插入链表项的时候，会处理这种情况，检查链表中的第2个页是否有空位
+                        self.buddy_alloc(PageFrameCount::new(1))
+                            .expect("buddy_alloc failed: no enough memory")
+                            .0
+                    };
+
+                    // 清空这个页面
+                    core::ptr::write_bytes(
+                        A::phys_2_virt(new_page_list_addr)
+                            .expect(
+                                "Buddy free: failed to get virt address of [new_page_list_addr]",
+                            )
+                            .as_ptr::<u8>(),
+                        0,
+                        1 << order,
+                    );
+                    assert!(
+                        first_page_list_paddr == self.free_area[Self::order2index(order as u8)]
+                    );
+                    // 初始化新的page_list
+                    let new_page_list = PageList::new(0, first_page_list_paddr);
+                    Self::write_page(new_page_list_addr, new_page_list);
+                    self.free_area[Self::order2index(order as u8)] = new_page_list_addr;
+                }
+
+                // 由于上面可能更新了第一个链表页，因此需要重新获取这个值
+                let first_page_list_paddr = self.free_area[Self::order2index(order as u8)];
+                let first_page_list: PageList<A> = Self::read_page(first_page_list_paddr);
+
+                // 检查第二个page_list是否有空位
+                let second_page_list = if first_page_list.next_page.is_null() {
+                    None
+                } else {
+                    Some(Self::read_page::<PageList<A>>(first_page_list.next_page))
+                };
+
+                let (paddr, mut page_list) = if let Some(second) = second_page_list {
+                    // 第二个page_list有空位
+                    // 应当符合之前的假设：还有1个空位
+                    assert!(second.entry_num == Self::BUDDY_ENTRIES - 1);
+
+                    (first_page_list.next_page, second)
+                } else {
+                    // 在第一个page list中分配
+                    (first_page_list_paddr, first_page_list)
+                };
+
+                // kdebug!("to write entry, page_list_base={paddr:?}, page_list.entry_num={}, value={base:?}", page_list.entry_num);
+                assert!(page_list.entry_num < Self::BUDDY_ENTRIES);
+                // 把要归还的块，写入到链表项中
+                unsafe { A::write(Self::entry_virt_addr(paddr, page_list.entry_num), base) }
+                page_list.entry_num += 1;
+                Self::write_page(paddr, page_list);
+                return;
             }
             base = min(base, buddy_addr);
             order += 1;
@@ -596,7 +594,7 @@ impl<A: MemoryManagementArch> FrameAllocator for BuddyAllocator<A> {
         if unlikely(!count.data().is_power_of_two()) {
             kwarn!("buddy free: count is not power of two");
         }
-        let mut order = log2(count.data() as usize);
+        let mut order = log2(count.data());
         if count.data() & ((1 << order) - 1) != 0 {
             order += 1;
         }

--- a/kernel/src/mm/allocator/bump.rs
+++ b/kernel/src/mm/allocator/bump.rs
@@ -57,7 +57,7 @@ impl<MMA: MemoryManagementArch> BumpAllocator<MMA> {
         let mut found_start = false;
         // 遍历所有的物理内存区域
         for area in iter {
-            if found_start == false {
+            if !found_start {
                 // 将area的base地址与PAGE_SIZE对齐，对齐时向上取整
                 // let area_base = (area.base.data() + MMA::PAGE_SHIFT) & !(MMA::PAGE_SHIFT);
                 let area_base = area.area_base_aligned().data();
@@ -78,7 +78,7 @@ impl<MMA: MemoryManagementArch> BumpAllocator<MMA> {
                     offset = (offset + (MMA::PAGE_SIZE - 1)) & !(MMA::PAGE_SIZE - 1);
                 }
                 // found
-                if offset + 1 * MMA::PAGE_SIZE <= area_end {
+                if offset + MMA::PAGE_SIZE <= area_end {
                     ret_offset_aligned = offset - area.area_base_aligned().data();
                     found_start = true;
                 }
@@ -112,7 +112,10 @@ impl<MMA: MemoryManagementArch> BumpAllocator<MMA> {
                 PageMapper::<MMA, _>::current(PageTableKind::Kernel, BumpAllocator::<MMA>::new(0));
 
             for p in iter {
-                if let None = mapper.translate(MMA::phys_2_virt(p.phys_address()).unwrap()) {
+                if mapper
+                    .translate(MMA::phys_2_virt(p.phys_address()).unwrap())
+                    .is_none()
+                {
                     let vaddr = MMA::phys_2_virt(p.phys_address()).unwrap();
                     pseudo_map_phys(vaddr, p.phys_address(), PageFrameCount::new(1));
                 }

--- a/kernel/src/mm/allocator/kernel_allocator.rs
+++ b/kernel/src/mm/allocator/kernel_allocator.rs
@@ -61,8 +61,8 @@ impl LocalAlloc for KernelAllocator {
     unsafe fn local_alloc(&self, layout: Layout) -> *mut u8 {
         return self
             .alloc_in_buddy(layout)
-            .map(|x| x.as_mut_ptr() as *mut u8)
-            .unwrap_or(core::ptr::null_mut() as *mut u8);
+            .map(|x| x.as_mut_ptr())
+            .unwrap_or(core::ptr::null_mut());
     }
 
     unsafe fn local_alloc_zeroed(&self, layout: Layout) -> *mut u8 {
@@ -73,7 +73,7 @@ impl LocalAlloc for KernelAllocator {
                 core::ptr::write_bytes(ptr, 0, x.len());
                 ptr
             })
-            .unwrap_or(core::ptr::null_mut() as *mut u8);
+            .unwrap_or(core::ptr::null_mut());
     }
 
     unsafe fn local_dealloc(&self, ptr: *mut u8, layout: Layout) {
@@ -86,11 +86,7 @@ unsafe impl GlobalAlloc for KernelAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let r = self.local_alloc_zeroed(layout);
         mm_debug_log(
-            klog_types::AllocatorLogType::Alloc(AllocLogItem::new(
-                layout.clone(),
-                Some(r as usize),
-                None,
-            )),
+            klog_types::AllocatorLogType::Alloc(AllocLogItem::new(layout, Some(r as usize), None)),
             klog_types::LogSource::Buddy,
         );
 
@@ -104,7 +100,7 @@ unsafe impl GlobalAlloc for KernelAllocator {
 
         mm_debug_log(
             klog_types::AllocatorLogType::AllocZeroed(AllocLogItem::new(
-                layout.clone(),
+                layout,
                 Some(r as usize),
                 None,
             )),
@@ -116,11 +112,7 @@ unsafe impl GlobalAlloc for KernelAllocator {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         mm_debug_log(
-            klog_types::AllocatorLogType::Free(AllocLogItem::new(
-                layout.clone(),
-                Some(ptr as usize),
-                None,
-            )),
+            klog_types::AllocatorLogType::Free(AllocLogItem::new(layout, Some(ptr as usize), None)),
             klog_types::LogSource::Buddy,
         );
 

--- a/kernel/src/mm/allocator/slab.rs
+++ b/kernel/src/mm/allocator/slab.rs
@@ -106,7 +106,7 @@ impl FreeBlockList {
 
 impl Drop for FreeBlockList {
     fn drop(&mut self) {
-        while let Some(_) = self.pop() {}
+        while self.pop().is_some() {}
     }
 }
 

--- a/kernel/src/mm/c_adapter.rs
+++ b/kernel/src/mm/c_adapter.rs
@@ -82,8 +82,6 @@ fn do_kmalloc(size: usize, _zero: bool) -> usize {
     let (ptr, len, cap) = space.into_raw_parts();
     if !ptr.is_null() {
         let vaddr = VirtAddr::new(ptr as usize);
-        let len = len as usize;
-        let cap = cap as usize;
         let mut guard = C_ALLOCATION_MAP.lock();
         if unlikely(guard.contains_key(&vaddr)) {
             drop(guard);
@@ -139,8 +137,8 @@ unsafe extern "C" fn rs_mmio_create(
 ) -> i32 {
     // kdebug!("mmio_create");
     let r = mmio_pool().create_mmio(size as usize);
-    if r.is_err() {
-        return r.unwrap_err().to_posix_errno();
+    if let Err(e) = r {
+        return e.to_posix_errno();
     }
     let space_guard = r.unwrap();
     *res_vaddr = space_guard.vaddr().data() as u64;

--- a/kernel/src/mm/early_ioremap.rs
+++ b/kernel/src/mm/early_ioremap.rs
@@ -78,7 +78,7 @@ impl EarlyIoRemap {
         size: usize,
         read_only: bool,
     ) -> Result<(VirtAddr, usize), SystemError> {
-        if phys.check_aligned(MMArch::PAGE_SIZE) == false {
+        if !phys.check_aligned(MMArch::PAGE_SIZE) {
             return Err(SystemError::EINVAL);
         }
 
@@ -175,7 +175,7 @@ impl EarlyIoRemap {
 
         let idx = idx.ok_or(SystemError::EINVAL)?;
 
-        let vaddr = Self::idx_to_virt(idx as usize);
+        let vaddr = Self::idx_to_virt(idx);
         let count = PageFrameCount::from_bytes(slot_guard[idx].size as usize).unwrap();
 
         // 取消映射

--- a/kernel/src/mm/memblock.rs
+++ b/kernel/src/mm/memblock.rs
@@ -360,7 +360,7 @@ impl MemBlockManager {
         flags: MemoryAreaAttr,
     ) -> Result<(), SystemError> {
         let rsvd_base = PhysAddr::new(page_align_down(base.data()));
-        size = page_align_up((size as usize) + base.data() - rsvd_base.data());
+        size = page_align_up(size + base.data() - rsvd_base.data());
         base = rsvd_base;
 
         let mut inner = self.inner.lock();
@@ -490,10 +490,9 @@ impl<'a> Iterator for MemBlockIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         while self.index < self.inner.initial_memory_regions_num {
             if self.usable_only
-                && self.inner.initial_memory_regions[self.index]
+                && !self.inner.initial_memory_regions[self.index]
                     .flags
                     .is_empty()
-                    == false
             {
                 self.index += 1;
                 if self.index >= self.inner.initial_memory_regions_num {

--- a/kernel/src/mm/mmio_buddy.rs
+++ b/kernel/src/mm/mmio_buddy.rs
@@ -164,7 +164,7 @@ impl MmioBuddyMemPool {
         list_guard: &mut SpinLockGuard<MmioFreeRegionList>,
     ) -> Result<MmioBuddyAddrRegion, MmioResult> {
         // 申请范围错误
-        if exp < MMIO_BUDDY_MIN_EXP || exp > MMIO_BUDDY_MAX_EXP {
+        if !(MMIO_BUDDY_MIN_EXP..=MMIO_BUDDY_MAX_EXP).contains(&exp) {
             kdebug!("query_addr_region: exp wrong");
             return Err(MmioResult::WRONGEXP);
         }
@@ -175,7 +175,7 @@ impl MmioBuddyMemPool {
             // 将大的内存块依次分成小块内存，直到能够满足exp大小，即将exp+1分成两块exp
             for e in exp + 1..MMIO_BUDDY_MAX_EXP + 1 {
                 let pop_list: &mut SpinLockGuard<MmioFreeRegionList> =
-                    &mut self.free_regions[exp2index(e) as usize].lock();
+                    &mut self.free_regions[exp2index(e)].lock();
                 if pop_list.num_free == 0 {
                     continue;
                 }
@@ -187,7 +187,7 @@ impl MmioBuddyMemPool {
                                 if e2 != exp + 1 {
                                     // 要将分裂后的内存块插入到更小的链表中
                                     let low_list_guard: &mut SpinLockGuard<MmioFreeRegionList> =
-                                        &mut self.free_regions[exp2index(e2 - 1) as usize].lock();
+                                        &mut self.free_regions[exp2index(e2 - 1)].lock();
                                     self.split_block(region, e2, low_list_guard);
                                 } else {
                                     // 由于exp对应的链表list_guard已经被锁住了 不能再加锁
@@ -201,13 +201,12 @@ impl MmioBuddyMemPool {
                             }
                         }
                     } else {
-                        match self.pop_block(&mut self.free_regions[exp2index(e2) as usize].lock())
-                        {
+                        match self.pop_block(&mut self.free_regions[exp2index(e2)].lock()) {
                             Ok(region) => {
                                 if e2 != exp + 1 {
                                     // 要将分裂后的内存块插入到更小的链表中
                                     let low_list_guard: &mut SpinLockGuard<MmioFreeRegionList> =
-                                        &mut self.free_regions[exp2index(e2 - 1) as usize].lock();
+                                        &mut self.free_regions[exp2index(e2 - 1)].lock();
                                     self.split_block(region, e2, low_list_guard);
                                 } else {
                                     // 由于exp对应的链表list_guard已经被锁住了 不能再加锁
@@ -251,7 +250,7 @@ impl MmioBuddyMemPool {
                 if e != exp - 1 {
                     match self.merge_all_exp(
                         exp,
-                        &mut self.free_regions[exp2index(exp) as usize].lock(),
+                        &mut self.free_regions[exp2index(exp)].lock(),
                         &mut self.free_regions[exp2index(exp + 1)].lock(),
                     ) {
                         Ok(_) => continue,
@@ -263,7 +262,7 @@ impl MmioBuddyMemPool {
                 } else {
                     match self.merge_all_exp(
                         exp,
-                        &mut self.free_regions[exp2index(exp) as usize].lock(),
+                        &mut self.free_regions[exp2index(exp)].lock(),
                         list_guard,
                     ) {
                         Ok(_) => continue,
@@ -346,7 +345,7 @@ impl MmioBuddyMemPool {
         exp: u32,
         list_guard: &mut SpinLockGuard<MmioFreeRegionList>,
     ) -> Result<MmioBuddyAddrRegion, MmioResult> {
-        if list_guard.list.len() == 0 {
+        if list_guard.list.is_empty() {
             return Err(MmioResult::ISEMPTY);
         } else {
             //计算伙伴块的地址
@@ -559,7 +558,7 @@ impl MmioBuddyMemPool {
 
         // 归还到buddy
         mmio_pool()
-            .give_back_block(vaddr, length.trailing_zeros() as u32)
+            .give_back_block(vaddr, length.trailing_zeros())
             .unwrap_or_else(|err| {
                 panic!("MMIO release failed: self: {self:?}, err msg: {:?}", err);
             });
@@ -585,7 +584,7 @@ impl MmioBuddyAddrRegion {
 }
 
 /// @brief 空闲页数组结构体
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MmioFreeRegionList {
     /// 存储mmio_buddy的地址链表
     list: LinkedList<MmioBuddyAddrRegion>,
@@ -598,14 +597,6 @@ impl MmioFreeRegionList {
         return MmioFreeRegionList {
             ..Default::default()
         };
-    }
-}
-impl Default for MmioFreeRegionList {
-    fn default() -> Self {
-        MmioFreeRegionList {
-            list: Default::default(),
-            num_free: 0,
-        }
     }
 }
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -280,11 +280,7 @@ impl VirtAddr {
     /// @brief 判断虚拟地址是否在用户空间
     #[inline(always)]
     pub fn check_user(&self) -> bool {
-        if self < &MMArch::USER_END_VADDR {
-            return true;
-        } else {
-            return false;
-        }
+        return self < &MMArch::USER_END_VADDR;
     }
 
     #[inline(always)]
@@ -720,7 +716,7 @@ impl VirtRegion {
 
 impl PartialOrd for VirtRegion {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        return self.start.partial_cmp(&other.start);
+        Some(self.cmp(other))
     }
 }
 

--- a/kernel/src/mm/no_init.rs
+++ b/kernel/src/mm/no_init.rs
@@ -86,7 +86,7 @@ impl EarlyIoRemapPages {
         let offset = addr.data() - start_vaddr;
         let index = offset / MMArch::PAGE_SIZE;
         if index < Self::EARLY_REMAP_PAGES_NUM {
-            assert_eq!(self.bmp.get(index).unwrap(), true);
+            assert!(self.bmp.get(index).unwrap());
             self.bmp.set(index, false);
         }
     }
@@ -203,9 +203,9 @@ pub unsafe fn pseudo_unmap_phys(vaddr: VirtAddr, count: PageFrameCount) {
 
     for i in 0..count.data() {
         let vaddr = vaddr + i * MMArch::PAGE_SIZE;
-        mapper.unmap_phys(vaddr, true).map(|(_, _, flusher)| {
+        if let Some((_, _, flusher)) = mapper.unmap_phys(vaddr, true) {
             flusher.ignore();
-        });
+        };
     }
 
     mapper.make_current();

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -624,7 +624,7 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             if table.level() == 0 {
                 // todo: 检查是否已经映射
                 // 现在不检查的原因是，刚刚启动系统时，内核会映射一些页。
-                if table.entry_mapped(i)? == true {
+                if table.entry_mapped(i)? {
                     kwarn!("Page {:?} already mapped", virt);
                 }
 
@@ -752,8 +752,8 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             return None;
         }
 
-        let mut table = self.table();
-        return unmap_phys_inner(virt, &mut table, unmap_parents, self.allocator_mut())
+        let table = self.table();
+        return unmap_phys_inner(virt, &table, unmap_parents, self.allocator_mut())
             .map(|(paddr, flags)| (paddr, flags, PageFlush::<Arch>::new(virt)));
     }
 
@@ -805,9 +805,9 @@ unsafe fn unmap_phys_inner<Arch: MemoryManagementArch>(
         return Some((entry.address().ok()?, entry.flags()));
     }
 
-    let mut subtable = table.next_level_table(i)?;
+    let subtable = table.next_level_table(i)?;
     // 递归地取消映射
-    let result = unmap_phys_inner(vaddr, &mut subtable, unmap_parents, allocator)?;
+    let result = unmap_phys_inner(vaddr, &subtable, unmap_parents, allocator)?;
 
     // TODO: This is a bad idea for architectures where the kernel mappings are done in the process tables,
     // as these mappings may become out of sync

--- a/kernel/src/mm/syscall.rs
+++ b/kernel/src/mm/syscall.rs
@@ -113,23 +113,23 @@ impl From<ProtFlags> for VmFlags {
     }
 }
 
-impl Into<MapFlags> for VmFlags {
-    fn into(self) -> MapFlags {
+impl From<VmFlags> for MapFlags {
+    fn from(value: VmFlags) -> Self {
         let mut map_flags = MapFlags::MAP_NONE;
 
-        if self.contains(VmFlags::VM_GROWSDOWN) {
+        if value.contains(VmFlags::VM_GROWSDOWN) {
             map_flags |= MapFlags::MAP_GROWSDOWN;
         }
 
-        if self.contains(VmFlags::VM_LOCKED) {
+        if value.contains(VmFlags::VM_LOCKED) {
             map_flags |= MapFlags::MAP_LOCKED;
         }
 
-        if self.contains(VmFlags::VM_SYNC) {
+        if value.contains(VmFlags::VM_SYNC) {
             map_flags |= MapFlags::MAP_SYNC;
         }
 
-        if self.contains(VmFlags::VM_MAYSHARE) {
+        if value.contains(VmFlags::VM_MAYSHARE) {
             map_flags |= MapFlags::MAP_SHARED;
         }
 
@@ -137,19 +137,19 @@ impl Into<MapFlags> for VmFlags {
     }
 }
 
-impl Into<ProtFlags> for VmFlags {
-    fn into(self) -> ProtFlags {
+impl From<VmFlags> for ProtFlags {
+    fn from(value: VmFlags) -> Self {
         let mut prot_flags = ProtFlags::PROT_NONE;
 
-        if self.contains(VmFlags::VM_READ) {
+        if value.contains(VmFlags::VM_READ) {
             prot_flags |= ProtFlags::PROT_READ;
         }
 
-        if self.contains(VmFlags::VM_WRITE) {
+        if value.contains(VmFlags::VM_WRITE) {
             prot_flags |= ProtFlags::PROT_WRITE;
         }
 
-        if self.contains(VmFlags::VM_EXEC) {
+        if value.contains(VmFlags::VM_EXEC) {
             prot_flags |= ProtFlags::PROT_EXEC;
         }
 
@@ -302,7 +302,7 @@ impl Syscall {
             return Err(SystemError::EINVAL);
         }
         let vma = vma.unwrap();
-        let vm_flags = vma.lock().vm_flags().clone();
+        let vm_flags = *vma.lock().vm_flags();
 
         // 暂时不支持巨页映射
         if vm_flags.contains(VmFlags::VM_HUGETLB) {

--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -178,7 +178,7 @@ impl InnerAddressSpace {
             let new_vma = VMA::zeroed(
                 VirtPageFrame::new(vma_guard.region.start()),
                 PageFrameCount::new(vma_guard.region.size() / MMArch::PAGE_SIZE),
-                vma_guard.vm_flags().clone(),
+                *vma_guard.vm_flags(),
                 tmp_flags,
                 &mut new_guard.user_mapper.utable,
                 (),
@@ -287,7 +287,7 @@ impl InnerAddressSpace {
             prot_flags,
             map_flags,
             move |page, count, flags, mapper, flusher| {
-                Ok(VMA::zeroed(page, count, vm_flags, flags, mapper, flusher)?)
+                VMA::zeroed(page, count, vm_flags, flags, mapper, flusher)
             },
         )?;
 
@@ -515,7 +515,7 @@ impl InnerAddressSpace {
 
         for r in regions {
             // kdebug!("mprotect: r: {:?}", r);
-            let r = r.lock().region().clone();
+            let r = *r.lock().region();
             let r = self.mappings.remove_vma(&r).unwrap();
 
             let intersection = r.lock().region().intersect(&region).unwrap();
@@ -623,7 +623,7 @@ impl InnerAddressSpace {
         let new_brk = if incr > 0 {
             self.brk + incr as usize
         } else {
-            self.brk - (incr.abs()) as usize
+            self.brk - incr.unsigned_abs()
         };
 
         let new_brk = VirtAddr::new(page_align_up(new_brk.data()));
@@ -705,7 +705,7 @@ impl UserMappings {
         let r = self
             .vmas
             .iter()
-            .filter(move |v| !v.lock().region.intersect(&request).is_none())
+            .filter(move |v| v.lock().region.intersect(&request).is_some())
             .cloned();
         return r;
     }
@@ -827,7 +827,7 @@ impl UserMappings {
 
     /// 在当前进程的映射关系中，插入一个新的VMA。
     pub fn insert_vma(&mut self, vma: Arc<LockedVMA>) {
-        let region = vma.lock().region.clone();
+        let region = vma.lock().region;
         // 要求插入的地址范围必须是空闲的，也就是说，当前进程的地址空间中，不能有任何与之重叠的VMA。
         assert!(self.conflicts(region).next().is_none());
         self.reserve_hole(&region);
@@ -1291,7 +1291,7 @@ impl Eq for VMA {}
 
 impl PartialOrd for VMA {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        return self.region.partial_cmp(&other.region);
+        Some(self.cmp(other))
     }
 }
 

--- a/kernel/src/net/event_poll/syscall.rs
+++ b/kernel/src/net/event_poll/syscall.rs
@@ -93,7 +93,7 @@ impl Syscall {
         epoll_event: VirtAddr,
         max_events: i32,
         timespec: i32,
-        mut sigmask: &mut SigSet,
+        sigmask: &mut SigSet,
     ) -> Result<usize, SystemError> {
         // 设置屏蔽的信号
         set_current_sig_blocked(sigmask);

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -124,9 +124,9 @@ impl From<u8> for Protocol {
     }
 }
 
-impl Into<u8> for Protocol {
-    fn into(self) -> u8 {
-        match self {
+impl From<Protocol> for u8 {
+    fn from(value: Protocol) -> Self {
+        match value {
             Protocol::HopByHop => 0x00,
             Protocol::Icmp => 0x01,
             Protocol::Igmp => 0x02,

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -85,8 +85,7 @@ fn dhcp_query() -> Result<(), SystemError> {
                         .add_default_ipv4_route(router)
                         .unwrap();
                     let cidr = net_face.inner_iface().lock().ip_addrs().first().cloned();
-                    if cidr.is_some() {
-                        let cidr = cidr.unwrap();
+                    if let Some(cidr) = cidr {
                         kinfo!("Successfully allocated ip by Dhcpv4! Ip:{}", cidr);
                         return Ok(());
                     }
@@ -231,7 +230,7 @@ fn send_event(sockets: &smoltcp::iface::SocketSet) -> Result<(), SystemError> {
         let mut handle_guard = HANDLE_MAP.write_irqsave();
         let handle_item = handle_guard.get_mut(&handle).unwrap();
         EventPoll::wakeup_epoll(
-            &mut handle_item.epitems,
+            &handle_item.epitems,
             EPollEventType::from_bits_truncate(events as u32),
         )?;
         // crate::kdebug!(

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -434,7 +434,7 @@ impl SocketHandleItem {
     }
 
     pub fn shutdown_type(&self) -> ShutdownType {
-        self.shutdown_type.read().clone()
+        *self.shutdown_type.read()
     }
 
     pub fn shutdown_type_writer(&mut self) -> RwLockWriteGuard<ShutdownType> {
@@ -496,7 +496,7 @@ impl PortManager {
                 if EPHEMERAL_PORT == 65535 {
                     EPHEMERAL_PORT = 49152;
                 } else {
-                    EPHEMERAL_PORT = EPHEMERAL_PORT + 1;
+                    EPHEMERAL_PORT += 1;
                 }
                 port = EPHEMERAL_PORT;
             }
@@ -750,7 +750,7 @@ impl TryFrom<u16> for AddressFamily {
     type Error = SystemError;
     fn try_from(x: u16) -> Result<Self, Self::Error> {
         use num_traits::FromPrimitive;
-        return <Self as FromPrimitive>::from_u16(x).ok_or_else(|| SystemError::EINVAL);
+        return <Self as FromPrimitive>::from_u16(x).ok_or(SystemError::EINVAL);
     }
 }
 
@@ -770,7 +770,7 @@ impl TryFrom<u8> for PosixSocketType {
     type Error = SystemError;
     fn try_from(x: u8) -> Result<Self, Self::Error> {
         use num_traits::FromPrimitive;
-        return <Self as FromPrimitive>::from_u8(x).ok_or_else(|| SystemError::EINVAL);
+        return <Self as FromPrimitive>::from_u8(x).ok_or(SystemError::EINVAL);
     }
 }
 

--- a/kernel/src/net/syscall.rs
+++ b/kernel/src/net/syscall.rs
@@ -156,7 +156,6 @@ impl Syscall {
                     return Ok(0);
                 }
                 PosixSocketOption::SO_RCVBUF => {
-                    let optval = optval;
                     // 返回默认的接收缓冲区大小
                     unsafe {
                         *optval = socket.metadata()?.rx_buf_size as u32;
@@ -802,9 +801,9 @@ impl TryFrom<u16> for PosixIpProtocol {
     }
 }
 
-impl Into<u16> for PosixIpProtocol {
-    fn into(self) -> u16 {
-        <Self as ToPrimitive>::to_u16(&self).unwrap()
+impl From<PosixIpProtocol> for u16 {
+    fn from(value: PosixIpProtocol) -> Self {
+        <PosixIpProtocol as ToPrimitive>::to_u16(&value).unwrap()
     }
 }
 
@@ -923,9 +922,9 @@ impl TryFrom<i32> for PosixSocketOption {
     }
 }
 
-impl Into<i32> for PosixSocketOption {
-    fn into(self) -> i32 {
-        <Self as ToPrimitive>::to_i32(&self).unwrap()
+impl From<PosixSocketOption> for i32 {
+    fn from(value: PosixSocketOption) -> Self {
+        <PosixSocketOption as ToPrimitive>::to_i32(&value).unwrap()
     }
 }
 

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -140,8 +140,8 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
             // 获取weak引用，以便于在do_waitpid中能正常drop pcb
             let child_weak = Arc::downgrade(&child_pcb);
             let r = do_waitpid(child_pcb, kwo);
-            if r.is_some() {
-                return r.unwrap();
+            if let Some(r) = r {
+                return r;
             } else {
                 child_weak.upgrade().unwrap().wait_queue.sleep();
             }
@@ -157,8 +157,8 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                 if state.is_exited() {
                     kwo.ret_status = state.exit_code().unwrap() as i32;
                     drop(pcb);
-                    unsafe { ProcessManager::release(pid.clone()) };
-                    return Ok(pid.clone().into());
+                    unsafe { ProcessManager::release(*pid) };
+                    return Ok((*pid).into());
                 } else {
                     unsafe { pcb.wait_queue.sleep_without_schedule() };
                 }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -196,7 +196,7 @@ impl ProcessManager {
         if clone_flags.contains(CloneFlags::CLONE_VM) {
             new_pcb.flags().insert(ProcessFlags::VFORK);
         }
-        *new_pcb.flags.get_mut() = ProcessManager::current_pcb().flags().clone();
+        *new_pcb.flags.get_mut() = *ProcessManager::current_pcb().flags();
         return Ok(());
     }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1,5 +1,4 @@
 use core::{
-    fmt::Display,
     hash::Hash,
     hint::spin_loop,
     intrinsics::{likely, unlikely},

--- a/kernel/src/sched/completion.rs
+++ b/kernel/src/sched/completion.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-use core::intrinsics::saturating_add;
 
 use system_error::SystemError;
 


### PR DESCRIPTION
## **Type**
Bug fix, Enhancement


___

## **Description**
This PR includes several bug fixes and enhancements across different kernel modules. Notable changes include:
- Refactoring and bug fixes in the BuddyAllocator, including correcting the size of the `free_area` array and simplifying allocation and deallocation logic.
- Enhancements and bug fixes in the MmioBuddyMemPool, such as fixing the range check for memory block sizes and optimizing the splitting and merging of memory blocks.
- Improvements and bug fixes in the VFS syscalls, including fixing type conversion issues and improving error handling in file removal and opening operations.
- Enhancements and bug fixes in the signal types module, including fixing the default value initialization and improving the conversion between `SaHandlerType` and `usize`.
- Improvements and bug fixes in the kernel allocator, including fixing the allocation and deallocation logging and error handling.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>buddy.rs</strong><dd><code>BuddyAllocator refactoring and bug fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/mm/allocator/buddy.rs
- Corrected the size of the `free_area` array.
- Simplified the initialization of the `free_area` array.
- Fixed the calculation of the index in the `free_area` array.
- Simplified the allocation and deallocation logic in the <br>  `BuddyAllocator`.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/601/files#diff-3c60c1864c5f7fd88e22a3e78694c3e6d0cd4aabf88c043ed8284d2096494557">+76/-78</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>syscall.rs</strong><dd><code>VFS syscall improvements and bug fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/filesystem/vfs/syscall.rs
- Fixed type conversion issues in the `From<PosixOpenHow> for OpenHow` <br>  implementation.
- Improved error handling in the `do_remove_dir` and `do_unlink_at` <br>  functions.
- Fixed issues with path handling in the `do_openat` function.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/601/files#diff-6fe6fcd191fbf6df065e13c64053d037af35d49fd3339e05b10e81bf6460f926">+13/-13</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>signal_types.rs</strong><dd><code>Signal types improvements and bug fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/ipc/signal_types.rs
- Fixed the default value initialization for the `InnerSignalStruct`.
- Improved the conversion between `SaHandlerType` and `usize`.
- Added default implementations for `Debug` and `Default` for structs.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/601/files#diff-752bba3d3859c2fe97e3604fd6050a4842787a5d0701ced69e3d9657a35e0db4">+16/-34</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kernel_allocator.rs</strong><dd><code>Kernel allocator improvements and bug fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/mm/allocator/kernel_allocator.rs
- Fixed the allocation and deallocation logging.
- Improved the allocation and deallocation error handling.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/601/files#diff-43d8cc1d28a19a8a32b44057e5060ddf29aef87640c03cf07548e39481685e8a">+6/-14</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mmio_buddy.rs</strong><dd><code>MmioBuddyMemPool enhancements and bug fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/src/mm/mmio_buddy.rs
- Fixed the range check for memory block sizes.
- Improved error handling in the `query_addr_region` function.
- Optimized the splitting and merging of memory blocks.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/601/files#diff-6d81eca686a2877722df4bcbd606b75ed0091ebdb66b57ab164e84db28666e90">+10/-19</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
