### PR TITLE
Patch fix clippy 0315evening

### DIFF
--- a/kernel/src/exception/irqdomain.rs
+++ b/kernel/src/exception/irqdomain.rs
@@ -249,7 +249,7 @@ impl IrqDomainManager {
             r = self.do_activate_irq(Some(irq_data.clone()), reserve);
         }
 
-        if !r.is_ok() {
+        if r.is_err() {
             irq_data.common_data().status().set_activated();
         }
 
@@ -385,7 +385,7 @@ impl IrqDomainManager {
             if dt.domain().is_some() && Arc::ptr_eq(dt.domain().as_ref().unwrap(), domain) {
                 return Some(dt);
             }
-            irq_data = dt.parent_data().map(|x| x.upgrade()).flatten();
+            irq_data = dt.parent_data().and_then(|x| x.upgrade());
         }
 
         return None;

--- a/kernel/src/exception/manage.rs
+++ b/kernel/src/exception/manage.rs
@@ -399,7 +399,7 @@ impl IrqManager {
             // todo: oneshot
         } else if action_guard.handler().is_some_and(|h| {
             h.type_id() == (&DefaultPrimaryIrqHandler as &dyn IrqHandler).type_id()
-        }) && desc_inner_guard
+        }) && !desc_inner_guard
             .irq_data()
             .chip_info_read_irqsave()
             .chip()

--- a/kernel/src/exception/manage.rs
+++ b/kernel/src/exception/manage.rs
@@ -320,7 +320,7 @@ impl IrqManager {
 
         // 标记当前irq是否是共享的
         let mut irq_shared = false;
-        if desc_inner_guard.actions().is_empty() == false {
+        if !desc_inner_guard.actions().is_empty() {
             // 除非双方都同意并且是相同类型（级别、边沿、极性），否则不能共享中断。
             // 因此，两个标志字段都必须设置IRQF_SHARED，并且设置触发类型的位必须匹配。
             // 另外，所有各方都必须就ONESHOT达成一致。
@@ -362,11 +362,10 @@ impl IrqManager {
             let old = &desc_inner_guard.actions()[0].clone();
             let old_guard = old.inner();
 
-            if ((old_guard
+            if (!(old_guard
                 .flags()
                 .intersection(*action_guard.flags())
-                .contains(IrqHandleFlags::IRQF_SHARED))
-                == false)
+                .contains(IrqHandleFlags::IRQF_SHARED)))
                 || (old_trigger_type != (action_guard.flags().trigger_type()))
                 || ((old_guard.flags().bitxor(*action_guard.flags()))
                     .contains(IrqHandleFlags::IRQF_ONESHOT))
@@ -406,7 +405,6 @@ impl IrqManager {
             .chip()
             .flags()
             .contains(IrqChipFlags::IRQCHIP_ONESHOT_SAFE)
-            == false
         {
             // 请求中断时 hander = NULL，因此我们为其使用默认的主处理程序。
             // 但它没有设置ONESHOT标志。与电平触发中断结合时，

--- a/kernel/src/filesystem/fat/bpb.rs
+++ b/kernel/src/filesystem/fat/bpb.rs
@@ -221,7 +221,6 @@ impl BiosParameterBlockFAT32 {
 impl BiosParameterBlock {
     pub fn new(partition: Arc<Partition>) -> Result<BiosParameterBlock, SystemError> {
         let mut v = vec![0; LBA_SIZE];
-        v.resize(LBA_SIZE, 0);
 
         // 读取分区的引导扇区
         partition

--- a/kernel/src/filesystem/fat/bpb.rs
+++ b/kernel/src/filesystem/fat/bpb.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
 use system_error::SystemError;
 
 use crate::{
@@ -220,7 +220,7 @@ impl BiosParameterBlockFAT32 {
 
 impl BiosParameterBlock {
     pub fn new(partition: Arc<Partition>) -> Result<BiosParameterBlock, SystemError> {
-        let mut v = Vec::with_capacity(LBA_SIZE);
+        let mut v = vec![0; LBA_SIZE];
         v.resize(LBA_SIZE, 0);
 
         // 读取分区的引导扇区
@@ -248,19 +248,20 @@ impl BiosParameterBlock {
         bpb.hidden_sectors = cursor.read_u32()?;
         bpb.total_sectors_32 = cursor.read_u32()?;
 
-        let mut bpb32 = BiosParameterBlockFAT32::default();
-        bpb32.fat_size_32 = cursor.read_u32()?;
-        bpb32.ext_flags = cursor.read_u16()?;
-        bpb32.fs_version = cursor.read_u16()?;
-        bpb32.root_cluster = cursor.read_u32()?;
-        bpb32.fs_info = cursor.read_u16()?;
-        bpb32.backup_boot_sec = cursor.read_u16()?;
-
+        let mut bpb32 = BiosParameterBlockFAT32 {
+            fat_size_32: cursor.read_u32()?,
+            ext_flags: cursor.read_u16()?,
+            fs_version: cursor.read_u16()?,
+            root_cluster: cursor.read_u32()?,
+            fs_info: cursor.read_u16()?,
+            backup_boot_sec: cursor.read_u16()?,
+            drive_num: cursor.read_u8()?,
+            reserved1: cursor.read_u8()?,
+            boot_sig: cursor.read_u8()?,
+            volume_id: cursor.read_u32()?,
+            ..Default::default()
+        };
         cursor.read_exact(&mut bpb32.reserved0)?;
-        bpb32.drive_num = cursor.read_u8()?;
-        bpb32.reserved1 = cursor.read_u8()?;
-        bpb32.boot_sig = cursor.read_u8()?;
-        bpb32.volume_id = cursor.read_u32()?;
         cursor.read_exact(&mut bpb32.volume_label)?;
         cursor.read_exact(&mut bpb32.filesystem_type)?;
 

--- a/kernel/src/filesystem/fat/entry.rs
+++ b/kernel/src/filesystem/fat/entry.rs
@@ -1207,7 +1207,7 @@ impl ShortDirEntry {
 
         // 当前是文件或卷号
         if self.is_file() || self.is_volume_id() {
-            let mut file: FATFile = FATFile {
+            let file: FATFile = FATFile {
                 file_name: self.name_to_string(),
                 first_cluster,
                 short_dir_entry: *self,

--- a/kernel/src/filesystem/fat/entry.rs
+++ b/kernel/src/filesystem/fat/entry.rs
@@ -555,7 +555,7 @@ impl FATDir {
         let r: Result<FATDirEntryOrShortName, SystemError> =
             self.check_existence(name, Some(false), fs.clone());
         // 检查错误码，如果能够表明目录项已经存在，则返回-EEXIST
-        if let Err(err_val) = r { 
+        if let Err(err_val) = r {
             if err_val == (SystemError::EISDIR) || err_val == (SystemError::ENOTDIR) {
                 return Err(SystemError::EEXIST);
             } else {
@@ -617,7 +617,7 @@ impl FATDir {
                 // '.'目录项
                 let mut dot_entry = ShortDirEntry {
                     name: ShortNameGenerator::new(".").generate().unwrap(),
-                    attributes:  FileAttributes::new(FileAttributes::DIRECTORY),
+                    attributes: FileAttributes::new(FileAttributes::DIRECTORY),
                     ..Default::default()
                 };
                 dot_entry.set_first_cluster(first_cluster);
@@ -758,7 +758,9 @@ impl FATDir {
         let offset = fs.cluster_bytes_offset(end.0) + end.1;
         short_dentry.flush(&fs, offset)?;
 
-        return Ok(short_dentry.convert_to_dir_entry_with_long_name(long_name.to_string(), (start, end)));
+        return Ok(
+            short_dentry.convert_to_dir_entry_with_long_name(long_name.to_string(), (start, end))
+        );
     }
 
     /// @brief 判断当前目录是否为空
@@ -1223,7 +1225,7 @@ impl ShortDirEntry {
             }
         } else {
             // 当前是文件夹
-            let mut dir = FATDir {
+            let dir = FATDir {
                 dir_name: self.name_to_string(),
                 first_cluster,
                 root_offset: None,
@@ -1266,7 +1268,7 @@ impl ShortDirEntry {
                 return FATDirEntry::VolId(file);
             }
         } else {
-            let mut dir = FATDir {
+            let dir = FATDir {
                 first_cluster: first_cluster,
                 dir_name: name,
                 loc: Some(loc),
@@ -1735,7 +1737,7 @@ impl FATDirEntry {
 
     /// @brief 判断目录项是否为文件
     pub fn is_file(&self) -> bool {
-        matches!(self,&FATDirEntry::File(_) | &FATDirEntry::VolId(_))
+        matches!(self, &FATDirEntry::File(_) | &FATDirEntry::VolId(_))
     }
 
     /// @brief 判断目录项是否为文件夹
@@ -1988,6 +1990,7 @@ impl ShortNameGenerator {
                 .map(|s| u16::from_str_radix(s, 16));
             // 如果校验码相同
             if checksum_result == Ok(Ok(self.checksum)) {
+                // 置位checksum_bitmask中，基础名末尾数字的对应位
                 if let Some(num) = num_suffix {
                     self.checksum_bitmask |= 1 << num;
                 }


### PR DESCRIPTION
## **Type**
Bug fix, Enhancement


___

## **Description**
This PR fixes issues with cluster handling in the FAT filesystem, including the FATFile, FATDir, and FATDirEntry structs. It improves error handling and code readability in FATDirEntry and enhances the ShortDirEntry and LongDirEntry structs with more initializers. Additionally, it fixes a memory allocation issue in the BiosParameterBlock and enhances the BiosParameterBlockFAT32 struct with more fields and initializers.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entry.rs</strong><dd><code>Fixed Cluster Handling and Improved Error Handling in FAT Filesystem</code></dd></summary>
<hr>

kernel/src/filesystem/fat/entry.rs
- Fixed issues with cluster handling in FATFile, FATDir, and <br>  FATDirEntry.
- Improved error handling and code readability in FATDirEntry.
- Enhanced the ShortDirEntry and LongDirEntry structs with more <br>  initializers.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/609/files#diff-6ea50326a43c3c4462be44250bfeab02ca5538283a7a348d2eeafaf1666e5c8a">+78/-78</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bpb.rs</strong><dd><code>Memory Allocation Fix and Struct Enhancement in BiosParameterBlock</code></dd></summary>
<hr>

kernel/src/filesystem/fat/bpb.rs
- Fixed memory allocation issue in BiosParameterBlock.
- Enhanced BiosParameterBlockFAT32 struct with more fields and <br>  initializers.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/DragonOS/pull/609/files#diff-1baf50937f9cbc77bf309131bfb38475dd3b997359c11c86a399c7fe0ea9d142">+15/-14</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
