### PR TITLE
fix(dog): 添加CC环境变量，解决编译时找不到musl-gcc的问题

### DIFF
--- a/user/apps/test-backlog/Makefile
+++ b/user/apps/test-backlog/Makefile
@@ -11,6 +11,7 @@ endif
 
 ifeq ($(ARCH), x86_64)
 	export RUST_TARGET=x86_64-unknown-linux-musl
+	export CC=x86_64-linux-musl-gcc
 else ifeq ($(ARCH), riscv64)
 	export RUST_TARGET=riscv64gc-unknown-linux-gnu
 else 


### PR DESCRIPTION
解决了编译时找不到musl-gcc的问题 #742 