### PR TITLE
refactor(process): 调整arch_switch_to_user函数，把riscv和x86_64的共用逻辑抽取出来。

### DIFF
--- a/kernel/src/arch/riscv64/mm/mod.rs
+++ b/kernel/src/arch/riscv64/mm/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     smp::cpu::ProcessorId,
 };
 
-use self::init::riscv_mm_init;
+use self::init::{riscv_mm_init, INITIAL_PGTABLE_VALUE};
 
 pub mod bump;
 pub(super) mod init;
@@ -185,7 +185,7 @@ impl MemoryManagementArch for RiscV64MMArch {
     }
 
     fn initial_page_table() -> PhysAddr {
-        todo!()
+        unsafe { INITIAL_PGTABLE_VALUE }
     }
 
     fn setup_new_usermapper() -> Result<UserMapper, SystemError> {

--- a/kernel/src/arch/riscv64/process/idle.rs
+++ b/kernel/src/arch/riscv64/process/idle.rs
@@ -1,8 +1,6 @@
 use core::hint::spin_loop;
 
-use crate::{
-    arch::CurrentIrqArch, exception::InterruptArch, kBUG, kdebug, process::ProcessManager,
-};
+use crate::{arch::CurrentIrqArch, exception::InterruptArch, kBUG, process::ProcessManager};
 
 impl ProcessManager {
     /// 每个核的idle进程

--- a/kernel/src/arch/riscv64/process/syscall.rs
+++ b/kernel/src/arch/riscv64/process/syscall.rs
@@ -1,11 +1,10 @@
 use alloc::{string::String, vec::Vec};
-use riscv::register::sstatus::{Sstatus, FS, SPP};
+use riscv::register::sstatus::{FS, SPP};
 use system_error::SystemError;
 
 use crate::{
     arch::{interrupt::TrapFrame, CurrentIrqArch},
     exception::InterruptArch,
-    kdebug,
     mm::ucontext::AddressSpace,
     process::{
         exec::{load_binary_file, ExecParam, ExecParamFlags},
@@ -64,8 +63,7 @@ impl Syscall {
         let mut param = ExecParam::new(path.as_str(), address_space.clone(), ExecParamFlags::EXEC)?;
 
         // 加载可执行文件
-        let load_result = load_binary_file(&mut param)
-            .unwrap_or_else(|e| panic!("Failed to load binary file: {:?}, path: {:?}", e, path));
+        let load_result = load_binary_file(&mut param)?;
         // kdebug!("load binary file done");
         // kdebug!("argv: {:?}, envp: {:?}", argv, envp);
         param.init_info_mut().args = argv;

--- a/kernel/src/arch/riscv64/syscall/mod.rs
+++ b/kernel/src/arch/riscv64/syscall/mod.rs
@@ -2,7 +2,7 @@
 pub mod nr;
 use system_error::SystemError;
 
-use crate::{exception::InterruptArch, kdebug, process::ProcessManager, syscall::Syscall};
+use crate::{exception::InterruptArch, process::ProcessManager, syscall::Syscall};
 
 use super::{interrupt::TrapFrame, CurrentIrqArch};
 

--- a/kernel/src/arch/x86_64/process/syscall.rs
+++ b/kernel/src/arch/x86_64/process/syscall.rs
@@ -66,8 +66,7 @@ impl Syscall {
         let mut param = ExecParam::new(path.as_str(), address_space.clone(), ExecParamFlags::EXEC)?;
 
         // 加载可执行文件
-        let load_result = load_binary_file(&mut param)
-            .unwrap_or_else(|e| panic!("Failed to load binary file: {:?}, path: {:?}", e, path));
+        let load_result = load_binary_file(&mut param)?;
         // kdebug!("load binary file done");
         // kdebug!("argv: {:?}, envp: {:?}", argv, envp);
         param.init_info_mut().args = argv;

--- a/kernel/src/arch/x86_64/syscall/mod.rs
+++ b/kernel/src/arch/x86_64/syscall/mod.rs
@@ -11,7 +11,6 @@ use crate::{
     process::ProcessManager,
     syscall::{Syscall, SYS_SCHED},
 };
-use alloc::string::String;
 use system_error::SystemError;
 
 use super::{
@@ -131,19 +130,6 @@ pub fn arch_syscall_init() -> Result<(), SystemError> {
     unsafe { set_system_trap_gate(0x80, 0, VirtAddr::new(syscall_int as usize)) }; // 系统调用门
     unsafe { init_syscall_64() };
     return Ok(());
-}
-
-/// 执行第一个用户进程的函数（只应该被调用一次）
-///
-/// 当进程管理重构完成后，这个函数应该被删除。调整为别的函数。
-#[no_mangle]
-pub extern "C" fn rs_exec_init_process(frame: &mut TrapFrame) -> usize {
-    let path = String::from("/bin/shell.elf");
-    let argv = vec![String::from("/bin/shell.elf")];
-    let envp = vec![String::from("PATH=/bin")];
-    let r = Syscall::do_execve(path, argv, envp, frame);
-    // kdebug!("rs_exec_init_process: r: {:?}\n", r);
-    return r.map(|_| 0).unwrap_or_else(|e| e.to_posix_errno() as usize);
 }
 
 /// syscall指令初始化函数

--- a/kernel/src/init/initial_kthread.rs
+++ b/kernel/src/init/initial_kthread.rs
@@ -1,16 +1,19 @@
 //! 这个文件内放置初始内核线程的代码。
 
-use alloc::string::String;
+use core::sync::atomic::{compiler_fence, Ordering};
+
+use alloc::string::{String, ToString};
 use system_error::SystemError;
 
 use crate::{
-    arch::process::arch_switch_to_user,
+    arch::{interrupt::TrapFrame, process::arch_switch_to_user},
     driver::{net::e1000e::e1000e::e1000e_init, virtio::virtio::virtio_probe},
     filesystem::vfs::core::mount_root_fs,
     kdebug, kerror,
     net::net_core::net_init,
-    process::{kthread::KernelThreadMechanism, stdio::stdio_init},
+    process::{kthread::KernelThreadMechanism, stdio::stdio_init, ProcessFlags, ProcessManager},
     smp::smp_init,
+    syscall::Syscall,
 };
 
 use super::initcall::do_initcalls;
@@ -61,10 +64,49 @@ fn kenrel_init_freeable() -> Result<(), SystemError> {
 
 /// 切换到用户态
 fn switch_to_user() {
-    const INIT_PROGRAM: &str = "/bin/dragonreach";
-    let path = String::from(INIT_PROGRAM);
+    let current_pcb = ProcessManager::current_pcb();
+
+    // 删除kthread的标志
+    current_pcb.flags().remove(ProcessFlags::KTHREAD);
+    current_pcb.worker_private().take();
+
+    *current_pcb.sched_info().sched_policy.write_irqsave() = crate::sched::SchedPolicy::CFS;
+    drop(current_pcb);
+
+    // 逐个尝试运行init进程
+
+    if try_to_run_init_process("/bin/dragonreach").is_err()
+        && try_to_run_init_process("/bin/init").is_err()
+        && try_to_run_init_process("/bin/sh").is_err()
+    {
+        panic!("Failed to run init process: No working init found.");
+    }
+}
+
+fn try_to_run_init_process(path: &str) -> Result<(), SystemError> {
+    if let Err(e) = run_init_process(path.to_string()) {
+        if e != SystemError::ENOENT {
+            kerror!(
+                "Failed to run init process: {path} exists but couldn't execute it (error {:?})",
+                e
+            );
+        }
+        return Err(e);
+    }
+
+    unreachable!();
+}
+
+#[inline(never)]
+fn run_init_process(path: String) -> Result<(), SystemError> {
     let argv = vec![path.clone()];
     let envp = vec![String::from("PATH=/")];
+    let mut trap_frame = TrapFrame::new();
 
-    unsafe { arch_switch_to_user(path, argv, envp) };
+    compiler_fence(Ordering::SeqCst);
+    Syscall::do_execve(path, argv, envp, &mut trap_frame)?;
+
+    // 需要确保执行到这里之后，上面所有的资源都已经释放（比如arc之类的）
+
+    unsafe { arch_switch_to_user(trap_frame) };
 }


### PR DESCRIPTION
refactor(process): Extract common logic for riscv and x86_64 in arch_switch_to_user to run_init_process

调整arch_switch_to_user函数，把riscv和x86_64的共用逻辑抽取出来。写成run_init_process函数，并且能够尝试运行多个不同的init程序，直到某个运行成功