### PR TITLE
fix(driver/apic_timer): 修复local apic timer初始化顺序导致的在某些云服务器上无法收到中断的bug

### DIFF
--- a/kernel/src/arch/x86_64/driver/apic/apic_timer.rs
+++ b/kernel/src/arch/x86_64/driver/apic/apic_timer.rs
@@ -228,12 +228,12 @@ impl LocalApicTimer {
         );
         self.mode = LocalApicTimerMode::Periodic;
         self.set_divisor(divisor);
-        self.set_initial_cnt(initial_count);
         self.setup_lvt(
             APIC_TIMER_IRQ_NUM.data() as u8,
             true,
             LocalApicTimerMode::Periodic,
         );
+        self.set_initial_cnt(initial_count);
     }
 
     fn setup_lvt(&mut self, vector: u8, mask: bool, mode: LocalApicTimerMode) {


### PR DESCRIPTION
由于原先apic timer初始化的时候，先设置初始计数，然后才设置lvt，这导致在某些处理器上收不到apic timer的中断，从而没法调度。



经测试，本PR使得DragonOS在腾讯云的以下机型能够正常执行调度：
- SA2 (本PR之前，无法收到apic timer中断）
- S5 (本PR之前，无法收到apic timer中断）
- SA3 (本PR之前，无法收到apic timer中断）
- S6 (本PR之前，可以正常收到apic timer中断）
- SA4 (本PR之前，可以正常收到apic timer中断）
- S8 (本PR之前，可以正常收到apic timer中断）

![image](https://github.com/DragonOS-Community/DragonOS/assets/63215266/49ee6368-c826-4187-a708-94b08f41bb33)

注：由于云服务器上面pci驱动找不到mcfg表，导致无法正常初始化pci，因此上述截图是把pci初始化、磁盘驱动初始化注释掉，并且loop{}死循环在pid=1的内核线程的结果。符合预期。