### PR TITLE
chore: move setup_arch_post timepoint to before clocksource_boot_finish

### DIFF
--- a/kernel/src/driver/acpi/pmtmr.rs
+++ b/kernel/src/driver/acpi/pmtmr.rs
@@ -12,7 +12,7 @@ pub const ACPI_PM_MASK: u64 = 0xffffff;
 pub fn acpi_pm_read_early() -> u32 {
     use crate::driver::clocksource::acpi_pm::{acpi_pm_read_verified, PMTMR_IO_PORT};
     use core::sync::atomic::Ordering;
-    let port = unsafe { PMTMR_IO_PORT.load(Ordering::SeqCst) };
+    let port = PMTMR_IO_PORT.load(Ordering::SeqCst);
 
     // 如果端口为零直接返回
     if port == 0 {

--- a/kernel/src/driver/clocksource/acpi_pm.rs
+++ b/kernel/src/driver/clocksource/acpi_pm.rs
@@ -20,7 +20,7 @@ use system_error::SystemError;
 // 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/drivers/clocksource/acpi_pm.c
 
 /// acpi_pmtmr所在的I/O端口
-pub static mut PMTMR_IO_PORT: AtomicU32 = AtomicU32::new(0);
+pub static PMTMR_IO_PORT: AtomicU32 = AtomicU32::new(0);
 
 /// # 读取acpi_pmtmr当前值，并对齐进行掩码操作
 #[inline(always)]
@@ -206,12 +206,13 @@ fn find_acpi_pm_clock() -> Result<(), SystemError> {
     let pm_timer_block = fadt.pm_timer_block().map_err(|_| SystemError::ENODEV)?;
     let pm_timer_block = pm_timer_block.ok_or(SystemError::ENODEV)?;
     let pmtmr_addr = pm_timer_block.address;
-    unsafe {
-        PMTMR_IO_PORT.store(pmtmr_addr as u32, Ordering::SeqCst);
-    }
-    kinfo!("apic_pmtmr I/O port: {}", unsafe {
+
+    PMTMR_IO_PORT.store(pmtmr_addr as u32, Ordering::SeqCst);
+
+    kinfo!(
+        "apic_pmtmr I/O port: {}",
         PMTMR_IO_PORT.load(Ordering::SeqCst)
-    });
+    );
 
     return Ok(());
 }
@@ -222,16 +223,17 @@ fn find_acpi_pm_clock() -> Result<(), SystemError> {
 #[allow(dead_code)]
 pub fn init_acpi_pm_clocksource() -> Result<(), SystemError> {
     let acpi_pm = Acpipm::new();
-    unsafe {
-        CLOCKSOURCE_ACPI_PM = Some(acpi_pm);
-    }
 
     // 解析fadt
     find_acpi_pm_clock()?;
 
     // 检查pmtmr_io_port是否被设置
-    if unsafe { PMTMR_IO_PORT.load(Ordering::SeqCst) } == 0 {
+    if PMTMR_IO_PORT.load(Ordering::SeqCst) == 0 {
         return Err(SystemError::ENODEV);
+    }
+
+    unsafe {
+        CLOCKSOURCE_ACPI_PM = Some(acpi_pm);
     }
 
     // 验证ACPI PM Timer作为时钟源的稳定性和一致性
@@ -256,25 +258,23 @@ pub fn init_acpi_pm_clocksource() -> Result<(), SystemError> {
                 break;
             }
             kinfo!("PM Timer had inconsistens results: {} {}", value1, value2);
-            unsafe {
-                PMTMR_IO_PORT.store(0, Ordering::SeqCst);
-            }
+
+            PMTMR_IO_PORT.store(0, Ordering::SeqCst);
+
             return Err(SystemError::EINVAL);
         }
         if i == ACPI_PM_READ_CHECKS {
             kinfo!("PM Timer failed consistency check: {}", value1);
-            unsafe {
-                PMTMR_IO_PORT.store(0, Ordering::SeqCst);
-            }
+
+            PMTMR_IO_PORT.store(0, Ordering::SeqCst);
+
             return Err(SystemError::EINVAL);
         }
     }
 
     // 检查ACPI PM Timer的频率是否正确
     if !verify_pmtmr_rate() {
-        unsafe {
-            PMTMR_IO_PORT.store(0, Ordering::SeqCst);
-        }
+        PMTMR_IO_PORT.store(0, Ordering::SeqCst);
     }
 
     // 检查TSC时钟源的监视器是否被禁用，如果被禁用则将时钟源的标志设置为CLOCK_SOURCE_MUST_VERIFY

--- a/kernel/src/init/init.rs
+++ b/kernel/src/init/init.rs
@@ -75,11 +75,10 @@ fn do_start_kernel() {
     time_init();
     timer_init();
     kthread_init();
+    setup_arch_post().expect("setup_arch_post failed");
     clocksource_boot_finish();
 
     Futex::init();
-
-    setup_arch_post().expect("setup_arch_post failed");
 
     #[cfg(all(target_arch = "x86_64", feature = "kvm"))]
     crate::virt::kvm::kvm_init();


### PR DESCRIPTION
This commit adjusts the timing of the setup_arch_post event to occur before the clocksource_boot_finish event, allowing the time subsystem to properly register architecture-specific clock sources.