### PR TITLE
refactor: 删除过时的va-pa转换函数，改为统一使用MMArch

### DIFF
--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -1,4 +1,5 @@
-use super::{_port, hba::HbaCmdTable, virt_2_phys};
+use super::{_port, hba::HbaCmdTable};
+use crate::arch::MMArch;
 use crate::driver::base::block::block_device::{BlockDevice, BlockId};
 use crate::driver::base::block::disk_info::Partition;
 use crate::driver::base::class::Class;
@@ -19,7 +20,7 @@ use crate::driver::disk::ahci::hba::{
 };
 use crate::libs::rwlock::{RwLockReadGuard, RwLockWriteGuard};
 use crate::libs::spinlock::SpinLock;
-use crate::mm::{phys_2_virt, verify_area, VirtAddr};
+use crate::mm::{verify_area, MemoryManagementArch, PhysAddr, VirtAddr};
 use log::error;
 use system_error::SystemError;
 
@@ -86,9 +87,11 @@ impl AhciDisk {
 
         #[allow(unused_unsafe)]
         let cmdheader: &mut HbaCmdHeader = unsafe {
-            (phys_2_virt(
+            (MMArch::phys_2_virt(PhysAddr::new(
                 volatile_read!(port.clb) as usize + slot as usize * size_of::<HbaCmdHeader>(),
-            ) as *mut HbaCmdHeader)
+            ))
+            .unwrap()
+            .data() as *mut HbaCmdHeader)
                 .as_mut()
                 .unwrap()
         };
@@ -118,7 +121,9 @@ impl AhciDisk {
 
         #[allow(unused_unsafe)]
         let cmdtbl = unsafe {
-            (phys_2_virt(volatile_read!(cmdheader.ctba) as usize) as *mut HbaCmdTable)
+            (MMArch::phys_2_virt(PhysAddr::new(volatile_read!(cmdheader.ctba) as usize))
+                .unwrap()
+                .data() as *mut HbaCmdTable)
                 .as_mut()
                 .unwrap() // 必须使用 as_mut ，得到的才是原来的变量
         };
@@ -132,7 +137,10 @@ impl AhciDisk {
 
         // 8K bytes (16 sectors) per PRDT
         for i in 0..((volatile_read!(cmdheader.prdtl) - 1) as usize) {
-            volatile_write!(cmdtbl.prdt_entry[i].dba, virt_2_phys(buf_ptr) as u64);
+            volatile_write!(
+                cmdtbl.prdt_entry[i].dba,
+                MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
+            );
             cmdtbl.prdt_entry[i].dbc = 8 * 1024 - 1;
             volatile_set_bit!(cmdtbl.prdt_entry[i].dbc, 1 << 31, true); // 允许中断 prdt_entry.i
             buf_ptr += 8 * 1024;
@@ -141,7 +149,10 @@ impl AhciDisk {
 
         // Last entry
         let las = (volatile_read!(cmdheader.prdtl) - 1) as usize;
-        volatile_write!(cmdtbl.prdt_entry[las].dba, virt_2_phys(buf_ptr) as u64);
+        volatile_write!(
+            cmdtbl.prdt_entry[las].dba,
+            MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
+        );
         cmdtbl.prdt_entry[las].dbc = ((tmp_count << 9) - 1) as u32; // 数据长度
 
         volatile_set_bit!(cmdtbl.prdt_entry[las].dbc, 1 << 31, true); // 允许中断
@@ -234,9 +245,11 @@ impl AhciDisk {
         compiler_fence(Ordering::SeqCst);
         #[allow(unused_unsafe)]
         let cmdheader: &mut HbaCmdHeader = unsafe {
-            (phys_2_virt(
+            (MMArch::phys_2_virt(PhysAddr::new(
                 volatile_read!(port.clb) as usize + slot as usize * size_of::<HbaCmdHeader>(),
-            ) as *mut HbaCmdHeader)
+            ))
+            .unwrap()
+            .data() as *mut HbaCmdHeader)
                 .as_mut()
                 .unwrap()
         };
@@ -273,7 +286,9 @@ impl AhciDisk {
 
         #[allow(unused_unsafe)]
         let cmdtbl = unsafe {
-            (phys_2_virt(volatile_read!(cmdheader.ctba) as usize) as *mut HbaCmdTable)
+            (MMArch::phys_2_virt(PhysAddr::new(volatile_read!(cmdheader.ctba) as usize))
+                .unwrap()
+                .data() as *mut HbaCmdTable)
                 .as_mut()
                 .unwrap()
         };
@@ -287,7 +302,10 @@ impl AhciDisk {
 
         // 8K bytes (16 sectors) per PRDT
         for i in 0..((volatile_read!(cmdheader.prdtl) - 1) as usize) {
-            volatile_write!(cmdtbl.prdt_entry[i].dba, virt_2_phys(buf_ptr) as u64);
+            volatile_write!(
+                cmdtbl.prdt_entry[i].dba,
+                MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
+            );
             volatile_write_bit!(cmdtbl.prdt_entry[i].dbc, (1 << 22) - 1, 8 * 1024 - 1); // 数据长度
             volatile_set_bit!(cmdtbl.prdt_entry[i].dbc, 1 << 31, true); // 允许中断
             buf_ptr += 8 * 1024;
@@ -296,7 +314,10 @@ impl AhciDisk {
 
         // Last entry
         let las = (volatile_read!(cmdheader.prdtl) - 1) as usize;
-        volatile_write!(cmdtbl.prdt_entry[las].dba, virt_2_phys(buf_ptr) as u64);
+        volatile_write!(
+            cmdtbl.prdt_entry[las].dba,
+            MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
+        );
         volatile_set_bit!(cmdtbl.prdt_entry[las].dbc, 1 << 31, true); // 允许中断
         volatile_write_bit!(
             cmdtbl.prdt_entry[las].dbc,

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -15,7 +15,6 @@ use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
 use core::ops::{Deref, DerefMut};
-use log::debug;
 use smoltcp::wire::HardwareAddress;
 use smoltcp::{
     phy::{self},

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 use system_error::SystemError;
 
-use crate::{arch::MMArch, include::bindings::bindings::PAGE_OFFSET};
+use crate::arch::MMArch;
 
 use core::{
     cmp,
@@ -119,18 +119,6 @@ pub unsafe fn set_IDLE_PROCESS_ADDRESS_SPACE(address_space: Arc<AddressSpace>) {
         panic!("IDLE_PROCESS_ADDRESS_SPACE is already initialized");
     }
     __IDLE_PROCESS_ADDRESS_SPACE = Some(address_space);
-}
-
-/// @brief 将内核空间的虚拟地址转换为物理地址
-#[inline(always)]
-pub fn virt_2_phys(addr: usize) -> usize {
-    addr - PAGE_OFFSET as usize
-}
-
-/// @brief 将物理地址转换为内核空间的虚拟地址
-#[inline(always)]
-pub fn phys_2_virt(addr: usize) -> usize {
-    addr + PAGE_OFFSET as usize
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]

--- a/tools/debugging/logmonitor/src/backend/monitor/mm.rs
+++ b/tools/debugging/logmonitor/src/backend/monitor/mm.rs
@@ -154,7 +154,7 @@ impl MMMonitorThread {
         info!("MMMonitorThread::run(): kmem_path: {:?}", self.kmem_path);
 
         let mut kmem_file = {
-            let mut file: File;
+            let file: File;
             loop {
                 let f = self.open_kmem_file();
                 if f.is_ok() {


### PR DESCRIPTION
refactor: 删除过时的va-pa转换函数，改为统一使用MMArch