### PR TITLE
fix: 修复键盘码解析器没能正确处理类似ctrl C的控制字符的问题

### DIFF
--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -388,9 +388,9 @@ impl NTtyData {
                 continue;
             }
 
-            if self.char_map.get(c as usize).unwrap() {
+            if ((c as usize) < self.char_map.size()) && self.char_map.get(c as usize).unwrap() {
                 // 特殊字符
-                self.receive_special_char(c, tty.clone(), lookahead_done)
+                self.receive_special_char(c, tty.clone(), lookahead_done);
             } else {
                 self.receive_char(c, tty.clone());
             }

--- a/kernel/src/libs/keyboard_parser.rs
+++ b/kernel/src/libs/keyboard_parser.rs
@@ -313,7 +313,8 @@ impl TypeOneFSMState {
         }
 
         // shift被按下
-        if scancode_status.shift_l || scancode_status.shift_r {
+        let shift = scancode_status.shift_l || scancode_status.shift_r;
+        if shift {
             col = true;
         }
 
@@ -327,9 +328,8 @@ impl TypeOneFSMState {
 
         let mut ch = TYPE1_KEY_CODE_MAPTABLE[col as usize + 2 * index as usize];
         if key != KeyFlag::NoneFlag {
-            // debug!("EMIT: ch is '{}', keyflag is {:?}\n", ch as char, key);
             if scancode_status.ctrl_l || scancode_status.ctrl_r {
-                ch = Self::to_ctrl(ch);
+                ch = Self::to_ctrl(ch, shift);
             }
             Self::emit(ch);
         }
@@ -337,10 +337,16 @@ impl TypeOneFSMState {
     }
 
     #[inline]
-    fn to_ctrl(ch: u8) -> u8 {
+    fn to_ctrl(ch: u8, shift: bool) -> u8 {
         return match ch as char {
-            'a'..='z' => ch - 0x40,
-            'A'..='Z' => ch - 0x40,
+            'a'..='z' => ch - 0x60,
+            'A'..='Z' => {
+                if shift {
+                    ch
+                } else {
+                    ch - 0x40
+                }
+            }
             '@'..='_' => ch - 0x40,
             _ => ch,
         };


### PR DESCRIPTION
原本的代码里面，

- 当按下`Ctrl+c`的时候，输出的是`#`而不是`ETX`控制字。
- 当shift按下时，再按`Ctrl+c`，输出的是ETX，这也是不对的。（如果capslock激活，然后`ctrl+c`的话,那就无问题）
![image](https://github.com/user-attachments/assets/0b8fd067-2385-4238-a7ff-ba25a37615db)
