### PR TITLE
fix(mm): 修复riscv64启动时的PageFault

### DIFF
--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -807,13 +807,15 @@ impl<Arch: MemoryManagementArch> EntryFlags<Arch> {
     /// - prot_flags: 页的保护标志
     /// - user: 用户空间是否可访问
     pub fn from_prot_flags(prot_flags: ProtFlags, user: bool) -> Self {
-        let vm_flags = super::VmFlags::from(prot_flags);
-        // let flags: EntryFlags<Arch> = EntryFlags::new()
-        //     .set_user(user)
-        //     .set_execute(prot_flags.contains(ProtFlags::PROT_EXEC))
-        //     .set_write(prot_flags.contains(ProtFlags::PROT_WRITE));
-        let flags = Arch::vm_get_page_prot(vm_flags).set_user(user);
-        return flags;
+        if Arch::PAGE_FAULT_ENABLED {
+            let vm_flags = super::VmFlags::from(prot_flags);
+            Arch::vm_get_page_prot(vm_flags).set_user(user)
+        } else {
+            EntryFlags::new()
+                .set_user(user)
+                .set_execute(prot_flags.contains(ProtFlags::PROT_EXEC))
+                .set_write(prot_flags.contains(ProtFlags::PROT_WRITE))
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
## 错误原因
文件映射的pr中完善了页表项保护位`EntryFlags`的生成机制，添加了保护位映射表，导致进行匿名可写映射时页表项的保护位为只读造成PageFault，但riscv64暂不支持缺页异常处理

## 修复方法
在`from_prot_flags`方法中判断当前架构是否支持缺页异常，如果不支持就使用旧版的转换方法