### PR TITLE
feat(driver/net): 将网络设备注册到sysfs, 添加设备类属性文件

### DIFF
--- a/kernel/src/arch/x86_64/driver/rtc.rs
+++ b/kernel/src/arch/x86_64/driver/rtc.rs
@@ -163,6 +163,14 @@ impl Device for CmosRtcDevice {
     fn bus(&self) -> Option<Weak<dyn Bus>> {
         self.inner().device_common.get_bus_weak_or_clear()
     }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = parent;
+    }
 }
 
 impl KObject for CmosRtcDevice {

--- a/kernel/src/driver/base/device/bus.rs
+++ b/kernel/src/driver/base/device/bus.rs
@@ -299,9 +299,14 @@ impl BusManager {
             .ok_or(SystemError::EINVAL)?;
         debug!("bus '{}' add driver '{}'", bus.name(), driver.name());
 
-        driver.set_kobj_type(Some(&BusDriverKType));
+        // driver.set_kobj_type(Some(&BusDriverKType));
         let kobj = driver.clone() as Arc<dyn KObject>;
-        KObjectManager::add_kobj(kobj, bus.subsystem().drivers_kset())?;
+        // KObjectManager::add_kobj(kobj, bus.subsystem().drivers_kset())?;
+        KObjectManager::init_and_add_kobj(
+            kobj,
+            bus.subsystem().drivers_kset(),
+            Some(&BusDriverKType),
+        )?;
 
         bus.subsystem().add_driver_to_vec(driver)?;
         if bus.subsystem().drivers_autoprobe() {
@@ -451,6 +456,7 @@ impl BusManager {
         }
         let bus = bus.unwrap();
         if bus.subsystem().drivers_autoprobe() {
+            log::info!("MT bus '{}' autoprobe driver", bus.name());
             device_manager().device_initial_probe(dev).ok();
         }
         for interface in bus.subsystem().interfaces() {

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -1,4 +1,5 @@
 use alloc::{
+    collections::BTreeMap,
     string::{String, ToString},
     sync::{Arc, Weak},
 };
@@ -12,16 +13,21 @@ use crate::{
     },
     exception::irqdata::IrqHandlerData,
     filesystem::{
+        kernfs::KernFSInode,
         sysfs::{
             file::sysfs_emit_str, sysfs_instance, Attribute, AttributeGroup, SysFSOps,
             SysFSOpsSupport,
         },
         vfs::syscall::ModeType,
     },
+    libs::{
+        rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+        spinlock::{SpinLock, SpinLockGuard},
+    },
 };
 
-use core::fmt::Debug;
 use core::intrinsics::unlikely;
+use core::{any::Any, fmt::Debug};
 use system_error::SystemError;
 
 use self::{
@@ -31,8 +37,10 @@ use self::{
 };
 
 use super::{
-    class::Class,
-    kobject::{KObjType, KObject, KObjectManager, KObjectState},
+    class::{Class, ClassKObjbectType},
+    kobject::{
+        KObjType, KObject, KObjectCommonData, KObjectManager, KObjectState, LockedKObjectState,
+    },
     kset::KSet,
     swnode::software_node_notify,
 };
@@ -193,6 +201,10 @@ pub trait Device: KObject {
     fn attribute_groups(&self) -> Option<&'static [&'static dyn AttributeGroup]> {
         None
     }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>>;
+
+    fn set_dev_parent(&self, parent: Option<Weak<dyn Device>>);
 }
 
 impl dyn Device {
@@ -210,6 +222,7 @@ pub struct DeviceCommonData {
     pub driver: Option<Weak<dyn Driver>>,
     pub dead: bool,
     pub can_match: bool,
+    pub parent: Option<Weak<dyn Device>>,
 }
 
 impl Default for DeviceCommonData {
@@ -220,6 +233,7 @@ impl Default for DeviceCommonData {
             driver: None,
             dead: false,
             can_match: true,
+            parent: None,
         }
     }
 }
@@ -244,6 +258,13 @@ impl DeviceCommonData {
     /// 当weak指针的strong count为0的时候，清除弱引用
     pub fn get_driver_weak_or_clear(&mut self) -> Option<Weak<dyn Driver>> {
         driver_base_macros::get_weak_or_clear!(self.driver)
+    }
+
+    /// 获取parent字段
+    ///
+    /// 当weak指针的strong count为0的时候，清除弱引用
+    pub fn get_parent_weak_or_clear(&mut self) -> Option<Weak<dyn Device>> {
+        driver_base_macros::get_weak_or_clear!(self.parent)
     }
 }
 
@@ -475,21 +496,26 @@ impl DeviceManager {
     #[allow(dead_code)]
     pub fn add_device(&self, device: Arc<dyn Device>) -> Result<(), SystemError> {
         // 在这里处理与parent相关的逻辑
-
-        let current_parent = device
-            .parent()
-            .and_then(|x| x.upgrade())
-            .and_then(|x| x.arc_any().cast::<dyn Device>().ok());
-
-        let actual_parent = self.get_device_parent(&device, current_parent)?;
-        if let Some(actual_parent) = actual_parent {
+        let deivce_parent = device.dev_parent().and_then(|x| x.upgrade());
+        if let Some(ref dev) = deivce_parent {
+            log::info!(
+                "deivce: {:?}  dev parent: {:?}",
+                device.name().to_string(),
+                dev.name()
+            );
+        }
+        let kobject_parent = self.get_device_parent(&device, deivce_parent)?;
+        if let Some(ref kobj) = kobject_parent {
+            log::info!("kobject parent: {:?}", kobj.name());
+        }
+        if let Some(kobject_parent) = kobject_parent {
             // debug!(
             //     "device '{}' parent is '{}', strong_count: {}",
             //     device.name().to_string(),
             //     actual_parent.name(),
             //     Arc::strong_count(&actual_parent)
             // );
-            device.set_parent(Some(Arc::downgrade(&actual_parent)));
+            device.set_parent(Some(Arc::downgrade(&kobject_parent)));
         }
 
         KObjectManager::add_kobj(device.clone() as Arc<dyn KObject>, None).map_err(|e| {
@@ -536,12 +562,43 @@ impl DeviceManager {
         return Ok(());
     }
 
+    /// 用于创建并添加一个新的kset，表示一个设备类目录
+    /// 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/drivers/base/core.c#3159
+    fn class_dir_create_and_add(
+        &self,
+        class: Arc<dyn Class>,
+        kobject_parent: Arc<dyn KObject>,
+    ) -> Arc<dyn KObject> {
+        let mut guard = CLASS_DIR_KSET_INSTANCE.write();
+        let class_name: String = class.name().to_string();
+        let kobject_parent_name = kobject_parent.name();
+        let key = format!("{}-{}", class_name, kobject_parent_name);
+
+        // 检查设备类目录是否已经存在
+        if let Some(class_dir) = guard.get(&key) {
+            return class_dir.clone();
+        }
+
+        let class_dir: Arc<ClassDir> = ClassDir::new();
+
+        class_dir.set_name(class_name.clone());
+        class_dir.set_kobj_type(Some(&ClassKObjbectType));
+        class_dir.set_parent(Some(Arc::downgrade(&kobject_parent)));
+
+        KObjectManager::add_kobj(class_dir.clone() as Arc<dyn KObject>, None)
+            .expect("add class dir failed");
+
+        guard.insert(key, class_dir.clone());
+
+        return class_dir;
+    }
+
     /// 获取设备真实的parent kobject
     ///
     /// ## 参数
     ///
     /// - `device`: 设备
-    /// - `current_parent`: 当前的parent kobject
+    /// - `device_parent`: 父设备
     ///
     /// ## 返回值
     ///
@@ -551,29 +608,31 @@ impl DeviceManager {
     fn get_device_parent(
         &self,
         device: &Arc<dyn Device>,
-        current_parent: Option<Arc<dyn Device>>,
+        device_parent: Option<Arc<dyn Device>>,
     ) -> Result<Option<Arc<dyn KObject>>, SystemError> {
         // debug!("get_device_parent() device:{:?}", device.name());
         if device.class().is_some() {
-            let parent_kobj: Arc<dyn KObject>;
-            // debug!("current_parent:{:?}", current_parent);
-            if let Some(cp) = current_parent {
-                if cp.class().is_some() {
-                    return Ok(Some(cp.clone() as Arc<dyn KObject>));
+            let kobject_parent: Arc<dyn KObject>;
+            if let Some(dp) = device_parent {
+                if dp.class().is_some() {
+                    return Ok(Some(dp.clone() as Arc<dyn KObject>));
                 } else {
-                    parent_kobj = cp.clone() as Arc<dyn KObject>;
+                    kobject_parent = dp.clone() as Arc<dyn KObject>;
                 }
             } else {
-                parent_kobj = sys_devices_virtual_kset() as Arc<dyn KObject>;
+                kobject_parent = sys_devices_virtual_kset() as Arc<dyn KObject>;
             }
 
             // 是否需要glue dir?
 
-            return Ok(Some(parent_kobj));
+            let kobject_parent =
+                self.class_dir_create_and_add(device.class().unwrap(), kobject_parent.clone());
+
+            return Ok(Some(kobject_parent));
         }
 
         // subsystems can specify a default root directory for their devices
-        if current_parent.is_none() {
+        if device_parent.is_none() {
             if let Some(bus) = device.bus().and_then(|bus| bus.upgrade()) {
                 if let Some(root) = bus.root_device().and_then(|x| x.upgrade()) {
                     return Ok(Some(root as Arc<dyn KObject>));
@@ -581,8 +640,8 @@ impl DeviceManager {
             }
         }
 
-        if let Some(current_parent) = current_parent {
-            return Ok(Some(current_parent as Arc<dyn KObject>));
+        if let Some(device_parent) = device_parent {
+            return Ok(Some(device_parent as Arc<dyn KObject>));
         }
 
         return Ok(None);
@@ -641,9 +700,8 @@ impl DeviceManager {
         let subsys_kobj = class.subsystem().subsys() as Arc<dyn KObject>;
         sysfs_instance().create_link(Some(&dev_kobj), &subsys_kobj, "subsystem".to_string())?;
 
-        // todo: 这里需要处理class的parent逻辑, 添加device链接
-        if let Some(parent) = dev.parent().and_then(|x| x.upgrade()) {
-            let parent_kobj = parent.clone() as Arc<dyn KObject>;
+        if let Some(dev_parent) = dev.dev_parent().and_then(|x| x.upgrade()) {
+            let parent_kobj = dev_parent.clone() as Arc<dyn KObject>;
             sysfs_instance()
                 .create_link(Some(&dev_kobj), &parent_kobj, "device".to_string())
                 .inspect_err(|_e| {
@@ -966,3 +1024,93 @@ impl core::hash::Hash for DeviceId {
 impl Eq for DeviceId {}
 
 impl IrqHandlerData for DeviceId {}
+
+lazy_static! {
+    /// class_dir列表，通过parent kobject的name和class_dir的name来索引class_dir实例
+    static ref CLASS_DIR_KSET_INSTANCE: RwLock<BTreeMap<String, Arc<ClassDir>>> = RwLock::new(BTreeMap::new());
+}
+
+#[derive(Debug)]
+struct ClassDir {
+    inner: SpinLock<InnerClassDir>,
+    locked_kobj_state: LockedKObjectState,
+}
+#[derive(Debug)]
+struct InnerClassDir {
+    name: Option<String>,
+    kobject_common: KObjectCommonData,
+}
+
+impl ClassDir {
+    fn new() -> Arc<Self> {
+        return Arc::new(Self {
+            inner: SpinLock::new(InnerClassDir {
+                name: None,
+                kobject_common: KObjectCommonData::default(),
+            }),
+            locked_kobj_state: LockedKObjectState::default(),
+        });
+    }
+
+    fn inner(&self) -> SpinLockGuard<InnerClassDir> {
+        return self.inner.lock();
+    }
+}
+
+impl KObject for ClassDir {
+    fn as_any_ref(&self) -> &dyn Any {
+        return self;
+    }
+
+    fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
+        self.inner().kobject_common.kern_inode = inode;
+    }
+
+    fn inode(&self) -> Option<Arc<KernFSInode>> {
+        return self.inner().kobject_common.kern_inode.clone();
+    }
+
+    fn parent(&self) -> Option<Weak<dyn KObject>> {
+        return self.inner().kobject_common.parent.clone();
+    }
+
+    fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
+        self.inner().kobject_common.parent = parent;
+    }
+
+    fn kset(&self) -> Option<Arc<KSet>> {
+        return self.inner().kobject_common.kset.clone();
+    }
+
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+        self.inner().kobject_common.kset = kset;
+    }
+
+    fn kobj_type(&self) -> Option<&'static dyn KObjType> {
+        return self.inner().kobject_common.kobj_type;
+    }
+
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.inner().kobject_common.kobj_type = ktype;
+    }
+
+    fn name(&self) -> String {
+        return self.inner().name.clone().unwrap_or_default();
+    }
+
+    fn set_name(&self, name: String) {
+        self.inner().name = Some(name);
+    }
+
+    fn kobj_state(&self) -> RwLockReadGuard<KObjectState> {
+        self.locked_kobj_state.read()
+    }
+
+    fn kobj_state_mut(&self) -> RwLockWriteGuard<KObjectState> {
+        self.locked_kobj_state.write()
+    }
+
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.locked_kobj_state.write() = state;
+    }
+}

--- a/kernel/src/driver/base/kobject.rs
+++ b/kernel/src/driver/base/kobject.rs
@@ -178,18 +178,17 @@ impl SysFSOps for KObjectSysFSOps {
 pub struct KObjectManager;
 
 impl KObjectManager {
-    #[allow(dead_code)]
     pub fn init_and_add_kobj(
         kobj: Arc<dyn KObject>,
         join_kset: Option<Arc<KSet>>,
+        kobj_type: Option<&'static dyn KObjType>,
     ) -> Result<(), SystemError> {
-        Self::kobj_init(&kobj);
+        Self::kobj_init(&kobj, kobj_type);
         Self::add_kobj(kobj, join_kset)
     }
 
-    #[allow(dead_code)]
-    pub fn kobj_init(kobj: &Arc<dyn KObject>) {
-        kobj.set_kobj_type(Some(&DynamicKObjKType));
+    pub fn kobj_init(kobj: &Arc<dyn KObject>, kobj_type: Option<&'static dyn KObjType>) {
+        kobj.set_kobj_type(kobj_type);
     }
 
     pub fn add_kobj(

--- a/kernel/src/driver/base/platform/platform_device.rs
+++ b/kernel/src/driver/base/platform/platform_device.rs
@@ -11,15 +11,15 @@ use crate::{
             bus::{Bus, BusState},
             device_manager,
             driver::Driver,
-            Device, DevicePrivateData, DeviceType, IdTable,
+            Device, DeviceCommonData, DevicePrivateData, DeviceType, IdTable,
         },
-        kobject::{KObjType, KObject, KObjectState, LockedKObjectState},
+        kobject::{KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState},
         kset::KSet,
     },
     filesystem::kernfs::KernFSInode,
     libs::{
         rwlock::{RwLockReadGuard, RwLockWriteGuard},
-        spinlock::SpinLock,
+        spinlock::{SpinLock, SpinLockGuard},
     },
 };
 use system_error::SystemError;
@@ -79,9 +79,9 @@ pub struct PlatformDeviceManager;
 impl PlatformDeviceManager {
     /// platform_device_add - add a platform device to device hierarchy
     pub fn device_add(&self, pdev: Arc<dyn PlatformDevice>) -> Result<(), SystemError> {
-        if pdev.parent().is_none() {
-            pdev.set_parent(Some(Arc::downgrade(
-                &(platform_bus_device() as Arc<dyn KObject>),
+        if pdev.dev_parent().is_none() {
+            pdev.set_dev_parent(Some(Arc::downgrade(
+                &(platform_bus_device() as Arc<dyn Device>),
             )));
         }
 
@@ -136,10 +136,12 @@ impl PlatformBusDevice {
         data: DevicePrivateData,
         parent: Option<Weak<dyn KObject>>,
     ) -> Arc<PlatformBusDevice> {
-        return Arc::new(PlatformBusDevice {
-            inner: SpinLock::new(InnerPlatformBusDevice::new(data, parent)),
+        let platform_bus_device = Self {
+            inner: SpinLock::new(InnerPlatformBusDevice::new(data)),
             kobj_state: LockedKObjectState::new(None),
-        });
+        };
+        platform_bus_device.set_parent(parent);
+        return Arc::new(platform_bus_device);
     }
 
     /// @brief: 获取总线的匹配表
@@ -180,38 +182,30 @@ impl PlatformBusDevice {
         let state = self.inner.lock().state;
         return state;
     }
+
+    fn inner(&self) -> SpinLockGuard<InnerPlatformBusDevice> {
+        self.inner.lock()
+    }
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct InnerPlatformBusDevice {
     name: String,
     data: DevicePrivateData,
-    state: BusState,                   // 总线状态
-    parent: Option<Weak<dyn KObject>>, // 总线的父对象
-
-    kernfs_inode: Option<Arc<KernFSInode>>,
-    /// 当前设备挂载到的总线
-    bus: Option<Weak<dyn Bus>>,
-    /// 当前设备已经匹配的驱动
-    driver: Option<Weak<dyn Driver>>,
-
-    ktype: Option<&'static dyn KObjType>,
-    kset: Option<Arc<KSet>>,
+    state: BusState, // 总线状态
+    kobject_common: KObjectCommonData,
+    device_common: DeviceCommonData,
 }
 
 impl InnerPlatformBusDevice {
-    pub fn new(data: DevicePrivateData, parent: Option<Weak<dyn KObject>>) -> Self {
+    pub fn new(data: DevicePrivateData) -> Self {
         Self {
             data,
             name: "platform".to_string(),
             state: BusState::NotInitialized,
-            parent,
-            kernfs_inode: None,
-            bus: None,
-            driver: None,
-            ktype: None,
-            kset: None,
+            kobject_common: KObjectCommonData::default(),
+            device_common: DeviceCommonData::default(),
         }
     }
 }
@@ -222,27 +216,27 @@ impl KObject for PlatformBusDevice {
     }
 
     fn parent(&self) -> Option<Weak<dyn KObject>> {
-        self.inner.lock().parent.clone()
+        self.inner().kobject_common.parent.clone()
     }
 
     fn inode(&self) -> Option<Arc<KernFSInode>> {
-        self.inner.lock().kernfs_inode.clone()
+        self.inner().kobject_common.kern_inode.clone()
     }
 
     fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
-        self.inner.lock().kernfs_inode = inode;
+        self.inner().kobject_common.kern_inode = inode;
     }
 
     fn kobj_type(&self) -> Option<&'static dyn KObjType> {
-        self.inner.lock().ktype
+        self.inner().kobject_common.kobj_type
     }
 
     fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
-        self.inner.lock().ktype = ktype;
+        self.inner().kobject_common.kobj_type = ktype;
     }
 
     fn kset(&self) -> Option<Arc<KSet>> {
-        self.inner.lock().kset.clone()
+        self.inner().kobject_common.kset.clone()
     }
 
     fn kobj_state(&self) -> RwLockReadGuard<KObjectState> {
@@ -258,19 +252,19 @@ impl KObject for PlatformBusDevice {
     }
 
     fn name(&self) -> String {
-        self.inner.lock().name.clone()
+        self.inner().name.clone()
     }
 
     fn set_name(&self, name: String) {
-        self.inner.lock().name = name;
+        self.inner().name = name;
     }
 
     fn set_kset(&self, kset: Option<Arc<KSet>>) {
-        self.inner.lock().kset = kset;
+        self.inner().kobject_common.kset = kset;
     }
 
     fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
-        self.inner.lock().parent = parent;
+        self.inner().kobject_common.parent = parent;
     }
 }
 
@@ -288,15 +282,15 @@ impl Device for PlatformBusDevice {
     }
 
     fn bus(&self) -> Option<Weak<dyn Bus>> {
-        self.inner.lock().bus.clone()
+        self.inner().device_common.bus.clone()
     }
 
     fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
-        self.inner.lock().bus = bus;
+        self.inner().device_common.bus = bus;
     }
 
     fn driver(&self) -> Option<Arc<dyn Driver>> {
-        self.inner.lock().driver.clone()?.upgrade()
+        self.inner().device_common.driver.clone()?.upgrade()
     }
 
     #[inline]
@@ -305,7 +299,7 @@ impl Device for PlatformBusDevice {
     }
 
     fn set_driver(&self, driver: Option<Weak<dyn Driver>>) {
-        self.inner.lock().driver = driver;
+        self.inner().device_common.driver = driver;
     }
 
     fn can_match(&self) -> bool {
@@ -320,7 +314,15 @@ impl Device for PlatformBusDevice {
         todo!()
     }
 
-    fn set_class(&self, _class: Option<Weak<dyn Class>>) {
-        todo!()
+    fn set_class(&self, class: Option<Weak<dyn Class>>) {
+        self.inner().device_common.class = class;
+    }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, dev_parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = dev_parent;
     }
 }

--- a/kernel/src/driver/base/platform/subsys.rs
+++ b/kernel/src/driver/base/platform/subsys.rs
@@ -5,7 +5,9 @@ use alloc::{
 use intertrait::cast::CastArc;
 use log::error;
 
-use super::{platform_device::PlatformDevice, platform_driver::PlatformDriver};
+use super::{
+    platform_bus_device, platform_device::PlatformDevice, platform_driver::PlatformDriver,
+};
 use crate::{
     driver::{
         acpi::acpi_manager,
@@ -140,6 +142,11 @@ impl Bus for PlatformBus {
 
         // 尝试根据设备名称匹配
         return Ok(device.name().eq(&driver.name()));
+    }
+
+    fn root_device(&self) -> Option<Weak<dyn Device>> {
+        let root_device = platform_bus_device() as Arc<dyn Device>;
+        return Some(Arc::downgrade(&root_device));
     }
 }
 

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -509,6 +509,14 @@ impl Device for LockedAhciDisk {
     fn set_class(&self, _class: Option<Weak<dyn Class>>) {
         todo!()
     }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        None
+    }
+
+    fn set_dev_parent(&self, _dev_parent: Option<Weak<dyn Device>>) {
+        todo!()
+    }
 }
 
 impl BlockDevice for LockedAhciDisk {

--- a/kernel/src/driver/input/ps2_mouse/ps_mouse_device.rs
+++ b/kernel/src/driver/input/ps2_mouse/ps_mouse_device.rs
@@ -16,9 +16,9 @@ use crate::{
             class::Class,
             device::{
                 bus::Bus, device_manager, device_number::DeviceNumber, driver::Driver, Device,
-                DeviceType, IdTable,
+                DeviceCommonData, DeviceType, IdTable,
             },
-            kobject::{KObjType, KObject, KObjectState, LockedKObjectState},
+            kobject::{KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState},
             kset::KSet,
         },
         input::{
@@ -184,13 +184,8 @@ impl Ps2MouseDevice {
     pub fn new() -> Self {
         let r = Self {
             inner: SpinLock::new(InnerPs2MouseDevice {
-                bus: None,
-                class: None,
-                driver: None,
-                kern_inode: None,
-                parent: None,
-                kset: None,
-                kobj_type: None,
+                device_common: DeviceCommonData::default(),
+                kobject_common: KObjectCommonData::default(),
                 current_packet: 0,
                 current_state: MouseState::new(),
                 buf: AllocRingBuffer::new(MOUSE_BUFFER_CAPACITY),
@@ -409,17 +404,16 @@ impl Ps2MouseDevice {
         }
         Err(SystemError::ETIMEDOUT)
     }
+
+    fn inner(&self) -> SpinLockGuard<InnerPs2MouseDevice> {
+        self.inner.lock_irqsave()
+    }
 }
 
 #[derive(Debug)]
 struct InnerPs2MouseDevice {
-    bus: Option<Weak<dyn Bus>>,
-    class: Option<Weak<dyn Class>>,
-    driver: Option<Weak<dyn Driver>>,
-    kern_inode: Option<Arc<KernFSInode>>,
-    parent: Option<Weak<dyn KObject>>,
-    kset: Option<Arc<KSet>>,
-    kobj_type: Option<&'static dyn KObjType>,
+    device_common: DeviceCommonData,
+    kobject_common: KObjectCommonData,
 
     /// 鼠标数据
     current_state: MouseState,
@@ -446,19 +440,19 @@ impl Device for Ps2MouseDevice {
     }
 
     fn set_bus(&self, bus: Option<alloc::sync::Weak<dyn Bus>>) {
-        self.inner.lock_irqsave().bus = bus;
+        self.inner().device_common.bus = bus;
     }
 
     fn set_class(&self, class: Option<alloc::sync::Weak<dyn Class>>) {
-        self.inner.lock_irqsave().class = class;
+        self.inner().device_common.class = class;
     }
 
     fn driver(&self) -> Option<alloc::sync::Arc<dyn Driver>> {
-        self.inner.lock_irqsave().driver.clone()?.upgrade()
+        self.inner().device_common.driver.clone()?.upgrade()
     }
 
     fn set_driver(&self, driver: Option<alloc::sync::Weak<dyn Driver>>) {
-        self.inner.lock_irqsave().driver = driver;
+        self.inner().device_common.driver = driver;
     }
 
     fn can_match(&self) -> bool {
@@ -472,17 +466,25 @@ impl Device for Ps2MouseDevice {
     }
 
     fn bus(&self) -> Option<alloc::sync::Weak<dyn Bus>> {
-        self.inner.lock_irqsave().bus.clone()
+        self.inner().device_common.bus.clone()
     }
 
     fn class(&self) -> Option<Arc<dyn Class>> {
-        let mut guard = self.inner.lock_irqsave();
-        let r = guard.class.clone()?.upgrade();
+        let mut guard = self.inner();
+        let r = guard.device_common.class.clone()?.upgrade();
         if r.is_none() {
-            guard.class = None;
+            guard.device_common.class = None;
         }
 
         return r;
+    }
+
+    fn dev_parent(&self) -> Option<alloc::sync::Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, dev_parent: Option<alloc::sync::Weak<dyn Device>>) {
+        self.inner().device_common.parent = dev_parent;
     }
 }
 
@@ -530,35 +532,35 @@ impl KObject for Ps2MouseDevice {
     }
 
     fn set_inode(&self, inode: Option<alloc::sync::Arc<KernFSInode>>) {
-        self.inner.lock_irqsave().kern_inode = inode;
+        self.inner().kobject_common.kern_inode = inode;
     }
 
     fn inode(&self) -> Option<alloc::sync::Arc<KernFSInode>> {
-        self.inner.lock_irqsave().kern_inode.clone()
+        self.inner().kobject_common.kern_inode.clone()
     }
 
     fn parent(&self) -> Option<alloc::sync::Weak<dyn KObject>> {
-        self.inner.lock_irqsave().parent.clone()
+        self.inner().kobject_common.parent.clone()
     }
 
     fn set_parent(&self, parent: Option<alloc::sync::Weak<dyn KObject>>) {
-        self.inner.lock_irqsave().parent = parent
+        self.inner().kobject_common.parent = parent
     }
 
     fn kset(&self) -> Option<alloc::sync::Arc<KSet>> {
-        self.inner.lock_irqsave().kset.clone()
+        self.inner().kobject_common.kset.clone()
     }
 
     fn set_kset(&self, kset: Option<alloc::sync::Arc<KSet>>) {
-        self.inner.lock_irqsave().kset = kset;
+        self.inner().kobject_common.kset = kset;
     }
 
     fn kobj_type(&self) -> Option<&'static dyn KObjType> {
-        self.inner.lock_irqsave().kobj_type
+        self.inner().kobject_common.kobj_type
     }
 
     fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
-        self.inner.lock_irqsave().kobj_type = ktype;
+        self.inner().kobject_common.kobj_type = ktype;
     }
 
     fn name(&self) -> alloc::string::String {
@@ -665,12 +667,12 @@ impl IndexNode for Ps2MouseDevice {
 
 impl Ps2Device for Ps2MouseDevice {}
 
-pub fn rs_ps2_mouse_device_init(parent: Arc<dyn KObject>) -> Result<(), SystemError> {
+pub fn rs_ps2_mouse_device_init(dev_parent: Arc<dyn Device>) -> Result<(), SystemError> {
     debug!("ps2_mouse_device initializing...");
     let psmouse = Arc::new(Ps2MouseDevice::new());
 
     device_manager().device_default_initialize(&(psmouse.clone() as Arc<dyn Device>));
-    psmouse.set_parent(Some(Arc::downgrade(&parent)));
+    psmouse.set_dev_parent(Some(Arc::downgrade(&dev_parent)));
     serio_device_manager().register_port(psmouse.clone() as Arc<dyn SerioDevice>)?;
 
     devfs_register(&psmouse.name(), psmouse.clone()).map_err(|e| {

--- a/kernel/src/driver/input/serio/i8042/mod.rs
+++ b/kernel/src/driver/input/serio/i8042/mod.rs
@@ -6,7 +6,6 @@ use unified_init::macros::unified_init;
 use crate::{
     driver::base::{
         device::{device_manager, Device},
-        kobject::KObject,
         platform::{
             platform_device::{platform_device_manager, PlatformDevice},
             platform_driver::{platform_driver_manager, PlatformDriver},
@@ -65,14 +64,14 @@ pub fn i8042_stop(_serio: &Arc<dyn SerioDevice>) -> Result<(), SystemError> {
 /// 参考: https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/input/serio/i8042.c#i8042_setup_aux
 pub fn i8042_setup_aux() -> Result<(), SystemError> {
     let aux_port = Arc::new(I8042AuxPort::new());
-    aux_port.set_parent(Some(Arc::downgrade(
-        &(i8042_platform_device() as Arc<dyn KObject>),
+    aux_port.set_dev_parent(Some(Arc::downgrade(
+        &(i8042_platform_device() as Arc<dyn Device>),
     )));
     serio_device_manager().register_port(aux_port.clone() as Arc<dyn SerioDevice>)?;
 
     #[cfg(target_arch = "x86_64")]
     crate::driver::input::ps2_mouse::ps_mouse_device::rs_ps2_mouse_device_init(
-        aux_port.clone() as Arc<dyn KObject>
+        aux_port.clone() as Arc<dyn Device>
     )?;
     Ok(())
 }

--- a/kernel/src/driver/net/class.rs
+++ b/kernel/src/driver/net/class.rs
@@ -1,0 +1,83 @@
+use crate::{
+    driver::base::{
+        class::{class_manager, Class},
+        device::sys_dev_char_kset,
+        kobject::KObject,
+        subsys::SubSysPrivate,
+    },
+    filesystem::sysfs::AttributeGroup,
+    init::initcall::INITCALL_SUBSYS,
+};
+use alloc::{
+    string::ToString,
+    sync::{Arc, Weak},
+};
+use system_error::SystemError;
+use unified_init::macros::unified_init;
+
+use super::sysfs::NetAttrGroup;
+
+/// `/sys/class/net` 的 class 实例
+static mut CLASS_NET_INSTANCE: Option<Arc<NetClass>> = None;
+
+/// 获取 `/sys/class/net` 的 class 实例
+#[inline(always)]
+#[allow(dead_code)]
+pub fn sys_class_net_instance() -> Option<&'static Arc<NetClass>> {
+    unsafe { CLASS_NET_INSTANCE.as_ref() }
+}
+
+/// 初始化net子系统
+#[unified_init(INITCALL_SUBSYS)]
+pub fn net_init() -> Result<(), SystemError> {
+    let net_class: Arc<NetClass> = NetClass::new();
+    class_manager().class_register(&(net_class.clone() as Arc<dyn Class>))?;
+
+    unsafe {
+        CLASS_NET_INSTANCE = Some(net_class);
+    }
+
+    return Ok(());
+}
+
+/// '/sys/class/net' 类
+#[derive(Debug)]
+pub struct NetClass {
+    subsystem: SubSysPrivate,
+}
+
+impl NetClass {
+    const NAME: &'static str = "net";
+    pub fn new() -> Arc<Self> {
+        let net_class = Arc::new(Self {
+            subsystem: SubSysPrivate::new(Self::NAME.to_string(), None, None, &[]),
+        });
+        net_class
+            .subsystem()
+            .set_class(Some(Arc::downgrade(&net_class) as Weak<dyn Class>));
+
+        return net_class;
+    }
+}
+
+impl Class for NetClass {
+    fn name(&self) -> &'static str {
+        return Self::NAME;
+    }
+
+    fn dev_kobj(&self) -> Option<Arc<dyn KObject>> {
+        Some(sys_dev_char_kset() as Arc<dyn KObject>)
+    }
+
+    fn set_dev_kobj(&self, _kobj: Arc<dyn KObject>) {
+        unimplemented!("NetClass::set_dev_kobj");
+    }
+
+    fn subsystem(&self) -> &SubSysPrivate {
+        return &self.subsystem;
+    }
+
+    fn dev_groups(&self) -> &'static [&'static dyn AttributeGroup] {
+        return &[&NetAttrGroup];
+    }
+}

--- a/kernel/src/driver/net/e1000e/e1000e_driver.rs
+++ b/kernel/src/driver/net/e1000e/e1000e_driver.rs
@@ -5,17 +5,20 @@ use crate::{
     driver::{
         base::{
             class::Class,
-            device::{bus::Bus, driver::Driver, Device, DeviceType, IdTable},
-            kobject::{KObjType, KObject, KObjectState},
+            device::{bus::Bus, driver::Driver, Device, DeviceCommonData, DeviceType, IdTable},
+            kobject::{KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState},
         },
-        net::NetDevice,
+        net::{register_netdevice, NetDeivceState, NetDevice, NetDeviceCommonData, Operstate},
     },
-    libs::spinlock::SpinLock,
+    libs::{
+        rwlock::{RwLockReadGuard, RwLockWriteGuard},
+        spinlock::{SpinLock, SpinLockGuard},
+    },
     net::{generate_iface_id, NET_DEVICES},
     time::Instant,
 };
 use alloc::{
-    string::String,
+    string::{String, ToString},
     sync::{Arc, Weak},
 };
 use core::{
@@ -31,6 +34,8 @@ use smoltcp::{
 use system_error::SystemError;
 
 use super::e1000e::{E1000EBuffer, E1000EDevice};
+
+const DEVICE_NAME: &str = "e1000e";
 
 pub struct E1000ERxToken(E1000EBuffer);
 pub struct E1000ETxToken {
@@ -73,12 +78,24 @@ impl Debug for E1000EDriverWrapper {
     }
 }
 
+#[cast_to([sync] NetDevice)]
+#[cast_to([sync] Device)]
 pub struct E1000EInterface {
     driver: E1000EDriverWrapper,
     iface_id: usize,
     iface: SpinLock<smoltcp::iface::Interface>,
     name: String,
+    inner: SpinLock<InnerE1000EInterface>,
+    locked_kobj_state: LockedKObjectState,
 }
+
+#[derive(Debug)]
+pub struct InnerE1000EInterface {
+    netdevice_common: NetDeviceCommonData,
+    device_common: DeviceCommonData,
+    kobj_common: KObjectCommonData,
+}
+
 impl phy::RxToken for E1000ERxToken {
     fn consume<R, F>(mut self, f: F) -> R
     where
@@ -190,9 +207,19 @@ impl E1000EInterface {
             iface_id,
             iface: SpinLock::new(iface),
             name: format!("eth{}", iface_id),
+            inner: SpinLock::new(InnerE1000EInterface {
+                netdevice_common: NetDeviceCommonData::default(),
+                device_common: DeviceCommonData::default(),
+                kobj_common: KObjectCommonData::default(),
+            }),
+            locked_kobj_state: LockedKObjectState::default(),
         });
 
         return result;
+    }
+
+    pub fn inner(&self) -> SpinLockGuard<InnerE1000EInterface> {
+        return self.inner.lock();
     }
 }
 
@@ -208,43 +235,70 @@ impl Debug for E1000EInterface {
 
 impl Device for E1000EInterface {
     fn dev_type(&self) -> DeviceType {
-        todo!()
+        DeviceType::Net
     }
 
     fn id_table(&self) -> IdTable {
-        todo!()
+        IdTable::new(DEVICE_NAME.to_string(), None)
     }
 
-    fn set_bus(&self, _bus: Option<Weak<dyn Bus>>) {
-        todo!()
+    fn bus(&self) -> Option<Weak<dyn Bus>> {
+        self.inner().device_common.bus.clone()
     }
 
-    fn set_class(&self, _class: Option<Weak<dyn Class>>) {
-        todo!()
+    fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
+        self.inner().device_common.bus = bus;
+    }
+
+    fn class(&self) -> Option<Arc<dyn Class>> {
+        let mut guard = self.inner();
+        let r = guard.device_common.class.clone()?.upgrade();
+        if r.is_none() {
+            guard.device_common.class = None;
+        }
+
+        return r;
+    }
+
+    fn set_class(&self, class: Option<Weak<dyn Class>>) {
+        self.inner().device_common.class = class;
     }
 
     fn driver(&self) -> Option<Arc<dyn Driver>> {
-        todo!()
+        let r = self.inner().device_common.driver.clone()?.upgrade();
+        if r.is_none() {
+            self.inner().device_common.driver = None;
+        }
+
+        return r;
     }
 
-    fn set_driver(&self, _driver: Option<Weak<dyn Driver>>) {
-        todo!()
+    fn set_driver(&self, driver: Option<Weak<dyn Driver>>) {
+        self.inner().device_common.driver = driver;
     }
 
     fn is_dead(&self) -> bool {
-        todo!()
+        false
     }
 
     fn can_match(&self) -> bool {
-        todo!()
+        self.inner().device_common.can_match
     }
 
-    fn set_can_match(&self, _can_match: bool) {
-        todo!()
+    fn set_can_match(&self, can_match: bool) {
+        self.inner().device_common.can_match = can_match;
     }
 
     fn state_synced(&self) -> bool {
-        todo!()
+        true
+    }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = parent;
     }
 }
 
@@ -260,7 +314,7 @@ impl NetDevice for E1000EInterface {
     }
 
     #[inline]
-    fn name(&self) -> String {
+    fn iface_name(&self) -> String {
         return self.name.clone();
     }
 
@@ -295,6 +349,31 @@ impl NetDevice for E1000EInterface {
     fn inner_iface(&self) -> &SpinLock<smoltcp::iface::Interface> {
         return &self.iface;
     }
+
+    fn addr_assign_type(&self) -> u8 {
+        return self.inner().netdevice_common.addr_assign_type;
+    }
+
+    fn net_device_type(&self) -> u16 {
+        self.inner().netdevice_common.net_device_type = 1; // 以太网设备
+        return self.inner().netdevice_common.net_device_type;
+    }
+
+    fn net_state(&self) -> NetDeivceState {
+        return self.inner().netdevice_common.state;
+    }
+
+    fn set_net_state(&self, state: NetDeivceState) {
+        self.inner().netdevice_common.state |= state;
+    }
+
+    fn operstate(&self) -> Operstate {
+        return self.inner().netdevice_common.operstate;
+    }
+
+    fn set_operstate(&self, state: Operstate) {
+        self.inner().netdevice_common.operstate = state;
+    }
 }
 
 impl KObject for E1000EInterface {
@@ -302,32 +381,32 @@ impl KObject for E1000EInterface {
         self
     }
 
-    fn set_inode(&self, _inode: Option<Arc<crate::filesystem::kernfs::KernFSInode>>) {
-        todo!()
+    fn set_inode(&self, inode: Option<Arc<crate::filesystem::kernfs::KernFSInode>>) {
+        self.inner().kobj_common.kern_inode = inode;
     }
 
     fn inode(&self) -> Option<Arc<crate::filesystem::kernfs::KernFSInode>> {
-        todo!()
+        self.inner().kobj_common.kern_inode.clone()
     }
 
     fn parent(&self) -> Option<alloc::sync::Weak<dyn KObject>> {
-        todo!()
+        self.inner().kobj_common.parent.clone()
     }
 
-    fn set_parent(&self, _parent: Option<alloc::sync::Weak<dyn KObject>>) {
-        todo!()
+    fn set_parent(&self, parent: Option<alloc::sync::Weak<dyn KObject>>) {
+        self.inner().kobj_common.parent = parent;
     }
 
     fn kset(&self) -> Option<Arc<crate::driver::base::kset::KSet>> {
-        todo!()
+        self.inner().kobj_common.kset.clone()
     }
 
-    fn set_kset(&self, _kset: Option<Arc<crate::driver::base::kset::KSet>>) {
-        todo!()
+    fn set_kset(&self, kset: Option<Arc<crate::driver::base::kset::KSet>>) {
+        self.inner().kobj_common.kset = kset;
     }
 
     fn kobj_type(&self) -> Option<&'static dyn crate::driver::base::kobject::KObjType> {
-        todo!()
+        self.inner().kobj_common.kobj_type
     }
 
     fn name(&self) -> String {
@@ -335,27 +414,23 @@ impl KObject for E1000EInterface {
     }
 
     fn set_name(&self, _name: String) {
-        todo!()
+        // do nothing
     }
 
-    fn kobj_state(
-        &self,
-    ) -> crate::libs::rwlock::RwLockReadGuard<crate::driver::base::kobject::KObjectState> {
-        todo!()
+    fn kobj_state(&self) -> RwLockReadGuard<KObjectState> {
+        self.locked_kobj_state.read()
     }
 
-    fn kobj_state_mut(
-        &self,
-    ) -> crate::libs::rwlock::RwLockWriteGuard<crate::driver::base::kobject::KObjectState> {
-        todo!()
+    fn kobj_state_mut(&self) -> RwLockWriteGuard<KObjectState> {
+        self.locked_kobj_state.write()
     }
 
-    fn set_kobj_state(&self, _state: KObjectState) {
-        todo!()
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.locked_kobj_state.write() = state;
     }
 
-    fn set_kobj_type(&self, _ktype: Option<&'static dyn KObjType>) {
-        todo!()
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.inner().kobj_common.kobj_type = ktype;
     }
 }
 
@@ -363,9 +438,14 @@ pub fn e1000e_driver_init(device: E1000EDevice) {
     let mac = smoltcp::wire::EthernetAddress::from_bytes(&device.mac_address());
     let driver = E1000EDriver::new(device);
     let iface = E1000EInterface::new(driver);
+    // 标识网络设备已经启动
+    iface.set_net_state(NetDeivceState::__LINK_STATE_START);
+
     // 将网卡的接口信息注册到全局的网卡接口信息表中
     NET_DEVICES
         .write_irqsave()
         .insert(iface.nic_id(), iface.clone());
     info!("e1000e driver init successfully!\tMAC: [{}]", mac);
+
+    register_netdevice(iface.clone()).expect("register lo device failed");
 }

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -2,10 +2,15 @@ use crate::arch::rand::rand;
 use crate::driver::base::class::Class;
 use crate::driver::base::device::bus::Bus;
 use crate::driver::base::device::driver::Driver;
-use crate::driver::base::device::{Device, DeviceType, IdTable};
-use crate::driver::base::kobject::{KObjType, KObject, KObjectState};
+use crate::driver::base::device::{Device, DeviceCommonData, DeviceType, IdTable};
+use crate::driver::base::kobject::{
+    KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState,
+};
+use crate::driver::base::kset::KSet;
+use crate::filesystem::kernfs::KernFSInode;
 use crate::init::initcall::INITCALL_DEVICE;
-use crate::libs::spinlock::SpinLock;
+use crate::libs::rwlock::{RwLockReadGuard, RwLockWriteGuard};
+use crate::libs::spinlock::{SpinLock, SpinLockGuard};
 use crate::net::{generate_iface_id, NET_DEVICES};
 use crate::time::Instant;
 use alloc::collections::VecDeque;
@@ -23,7 +28,7 @@ use smoltcp::{
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
-use super::NetDevice;
+use super::{register_netdevice, NetDeivceState, NetDevice, NetDeviceCommonData, Operstate};
 
 const DEVICE_NAME: &str = "loopback";
 
@@ -235,11 +240,22 @@ impl phy::Device for LoopbackDriver {
 
 /// ## LoopbackInterface结构
 /// 封装驱动包裹器和iface，设置接口名称
+#[cast_to([sync] NetDevice)]
+#[cast_to([sync] Device)]
 pub struct LoopbackInterface {
     driver: LoopbackDriverWapper,
     iface_id: usize,
     iface: SpinLock<smoltcp::iface::Interface>,
     name: String,
+    inner: SpinLock<InnerLoopbackInterface>,
+    locked_kobj_state: LockedKObjectState,
+}
+
+#[derive(Debug)]
+pub struct InnerLoopbackInterface {
+    netdevice_common: NetDeviceCommonData,
+    device_common: DeviceCommonData,
+    kobj_common: KObjectCommonData,
 }
 
 impl LoopbackInterface {
@@ -274,7 +290,17 @@ impl LoopbackInterface {
             iface_id,
             iface: SpinLock::new(iface),
             name: "lo".to_string(),
+            inner: SpinLock::new(InnerLoopbackInterface {
+                netdevice_common: NetDeviceCommonData::default(),
+                device_common: DeviceCommonData::default(),
+                kobj_common: KObjectCommonData::default(),
+            }),
+            locked_kobj_state: LockedKObjectState::default(),
         })
+    }
+
+    fn inner(&self) -> SpinLockGuard<InnerLoopbackInterface> {
+        return self.inner.lock();
     }
 }
 
@@ -287,38 +313,38 @@ impl Debug for LoopbackInterface {
             .finish()
     }
 }
-//TODO: 向sysfs注册lo设备
+
 impl KObject for LoopbackInterface {
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
     }
 
-    fn set_inode(&self, _inode: Option<Arc<crate::filesystem::kernfs::KernFSInode>>) {
-        todo!()
+    fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
+        self.inner().kobj_common.kern_inode = inode;
     }
 
-    fn inode(&self) -> Option<Arc<crate::filesystem::kernfs::KernFSInode>> {
-        todo!()
+    fn inode(&self) -> Option<Arc<KernFSInode>> {
+        self.inner().kobj_common.kern_inode.clone()
     }
 
-    fn parent(&self) -> Option<alloc::sync::Weak<dyn KObject>> {
-        todo!()
+    fn parent(&self) -> Option<Weak<dyn KObject>> {
+        self.inner().kobj_common.parent.clone()
     }
 
-    fn set_parent(&self, _parent: Option<alloc::sync::Weak<dyn KObject>>) {
-        todo!()
+    fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
+        self.inner().kobj_common.parent = parent;
     }
 
-    fn kset(&self) -> Option<Arc<crate::driver::base::kset::KSet>> {
-        todo!()
+    fn kset(&self) -> Option<Arc<KSet>> {
+        self.inner().kobj_common.kset.clone()
     }
 
-    fn set_kset(&self, _kset: Option<Arc<crate::driver::base::kset::KSet>>) {
-        todo!()
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+        self.inner().kobj_common.kset = kset;
     }
 
-    fn kobj_type(&self) -> Option<&'static dyn crate::driver::base::kobject::KObjType> {
-        todo!()
+    fn kobj_type(&self) -> Option<&'static dyn KObjType> {
+        self.inner().kobj_common.kobj_type
     }
 
     fn name(&self) -> String {
@@ -326,27 +352,23 @@ impl KObject for LoopbackInterface {
     }
 
     fn set_name(&self, _name: String) {
-        todo!()
+        // do nothing
     }
 
-    fn kobj_state(
-        &self,
-    ) -> crate::libs::rwlock::RwLockReadGuard<crate::driver::base::kobject::KObjectState> {
-        todo!()
+    fn kobj_state(&self) -> RwLockReadGuard<KObjectState> {
+        self.locked_kobj_state.read()
     }
 
-    fn kobj_state_mut(
-        &self,
-    ) -> crate::libs::rwlock::RwLockWriteGuard<crate::driver::base::kobject::KObjectState> {
-        todo!()
+    fn kobj_state_mut(&self) -> RwLockWriteGuard<KObjectState> {
+        self.locked_kobj_state.write()
     }
 
-    fn set_kobj_state(&self, _state: KObjectState) {
-        todo!()
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.locked_kobj_state.write() = state;
     }
 
-    fn set_kobj_type(&self, _ktype: Option<&'static dyn KObjType>) {
-        todo!()
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.inner().kobj_common.kobj_type = ktype;
     }
 }
 
@@ -359,43 +381,70 @@ impl Device for LoopbackInterface {
         IdTable::new(DEVICE_NAME.to_string(), None)
     }
 
-    fn set_bus(&self, _bus: Option<Weak<dyn Bus>>) {
-        todo!()
+    fn bus(&self) -> Option<Weak<dyn Bus>> {
+        self.inner().device_common.bus.clone()
     }
 
-    fn set_class(&self, _class: Option<Weak<dyn Class>>) {
-        todo!()
+    fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
+        self.inner().device_common.bus = bus;
+    }
+
+    fn class(&self) -> Option<Arc<dyn Class>> {
+        let mut guard = self.inner();
+        let r = guard.device_common.class.clone()?.upgrade();
+        if r.is_none() {
+            guard.device_common.class = None;
+        }
+
+        return r;
+    }
+
+    fn set_class(&self, class: Option<Weak<dyn Class>>) {
+        self.inner().device_common.class = class;
     }
 
     fn driver(&self) -> Option<Arc<dyn Driver>> {
-        todo!()
+        let r = self.inner().device_common.driver.clone()?.upgrade();
+        if r.is_none() {
+            self.inner().device_common.driver = None;
+        }
+
+        return r;
     }
 
-    fn set_driver(&self, _driver: Option<Weak<dyn Driver>>) {
-        todo!()
+    fn set_driver(&self, driver: Option<Weak<dyn Driver>>) {
+        self.inner().device_common.driver = driver;
     }
 
     fn is_dead(&self) -> bool {
-        todo!()
+        false
     }
 
     fn can_match(&self) -> bool {
-        todo!()
+        self.inner().device_common.can_match
     }
 
-    fn set_can_match(&self, _can_match: bool) {
-        todo!()
+    fn set_can_match(&self, can_match: bool) {
+        self.inner().device_common.can_match = can_match;
     }
 
     fn state_synced(&self) -> bool {
         true
     }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = parent;
+    }
 }
 
 impl NetDevice for LoopbackInterface {
-    /// 由于lo网卡设备不是实际的物理设备，其mac地址需要手动设置为一个默认值，这里默认为0200000001
+    /// 由于lo网卡设备不是实际的物理设备，其mac地址需要手动设置为一个默认值，这里默认为00:00:00:00:00
     fn mac(&self) -> smoltcp::wire::EthernetAddress {
-        let mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let mac = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         smoltcp::wire::EthernetAddress(mac)
     }
 
@@ -405,7 +454,7 @@ impl NetDevice for LoopbackInterface {
     }
 
     #[inline]
-    fn name(&self) -> String {
+    fn iface_name(&self) -> String {
         self.name.clone()
     }
     /// ## `update_ip_addrs` 用于更新接口的 IP 地址。
@@ -459,6 +508,31 @@ impl NetDevice for LoopbackInterface {
     fn inner_iface(&self) -> &SpinLock<smoltcp::iface::Interface> {
         return &self.iface;
     }
+
+    fn addr_assign_type(&self) -> u8 {
+        return self.inner().netdevice_common.addr_assign_type;
+    }
+
+    fn net_device_type(&self) -> u16 {
+        self.inner().netdevice_common.net_device_type = 24; // 环回设备
+        return self.inner().netdevice_common.net_device_type;
+    }
+
+    fn net_state(&self) -> NetDeivceState {
+        return self.inner().netdevice_common.state;
+    }
+
+    fn set_net_state(&self, state: NetDeivceState) {
+        self.inner().netdevice_common.state |= state;
+    }
+
+    fn operstate(&self) -> Operstate {
+        return self.inner().netdevice_common.operstate;
+    }
+
+    fn set_operstate(&self, state: Operstate) {
+        self.inner().netdevice_common.operstate = state;
+    }
 }
 
 pub fn loopback_probe() {
@@ -469,10 +543,14 @@ pub fn loopback_probe() {
 pub fn loopback_driver_init() {
     let driver = LoopbackDriver::new();
     let iface = LoopbackInterface::new(driver);
+    // 标识网络设备已经启动
+    iface.set_net_state(NetDeivceState::__LINK_STATE_START);
 
     NET_DEVICES
         .write_irqsave()
         .insert(iface.iface_id, iface.clone());
+
+    register_netdevice(iface.clone()).expect("register lo device failed");
 }
 
 /// ## lo网卡设备的注册函数

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -1,24 +1,62 @@
-use alloc::string::String;
+use alloc::{string::String, sync::Arc};
 use smoltcp::{
     iface,
     wire::{self, EthernetAddress},
 };
+use sysfs::netdev_register_kobject;
 
 use super::base::device::Device;
 use crate::libs::spinlock::SpinLock;
 use system_error::SystemError;
 
+pub mod class;
 mod dma;
 pub mod e1000e;
 pub mod irq_handle;
 pub mod loopback;
+pub mod sysfs;
 pub mod virtio_net;
+
+bitflags! {
+    pub struct NetDeivceState: u16 {
+        /// 表示网络设备已经启动
+        const __LINK_STATE_START = 1 << 0;
+        /// 表示网络设备在系统中存在，即注册到sysfs中
+        const __LINK_STATE_PRESENT = 1 << 1;
+        /// 表示网络设备没有检测到载波信号
+        const __LINK_STATE_NOCARRIER = 1 << 2;
+        /// 表示设备的链路监视操作处于挂起状态
+        const __LINK_STATE_LINKWATCH_PENDING = 1 << 3;
+        /// 表示设备处于休眠状态
+        const __LINK_STATE_DORMANT = 1 << 4;
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+#[allow(dead_code, non_camel_case_types)]
+pub enum Operstate {
+    /// 网络接口的状态未知
+    IF_OPER_UNKNOWN = 0,
+    /// 网络接口不存在
+    IF_OPER_NOTPRESENT = 1,
+    /// 网络接口已禁用或未连接
+    IF_OPER_DOWN = 2,
+    /// 网络接口的下层接口已关闭
+    IF_OPER_LOWERLAYERDOWN = 3,
+    /// 网络接口正在测试
+    IF_OPER_TESTING = 4,
+    /// 网络接口处于休眠状态
+    IF_OPER_DORMANT = 5,
+    /// 网络接口已启用
+    IF_OPER_UP = 6,
+}
+
 #[allow(dead_code)]
 pub trait NetDevice: Device {
     /// @brief 获取网卡的MAC地址
     fn mac(&self) -> EthernetAddress;
 
-    fn name(&self) -> String;
+    fn iface_name(&self) -> String;
 
     /// @brief 获取网卡的id
     fn nic_id(&self) -> usize;
@@ -30,4 +68,52 @@ pub trait NetDevice: Device {
     /// @brief 获取smoltcp的网卡接口类型
     fn inner_iface(&self) -> &SpinLock<smoltcp::iface::Interface>;
     // fn as_any_ref(&'static self) -> &'static dyn core::any::Any;
+
+    fn addr_assign_type(&self) -> u8;
+
+    fn net_device_type(&self) -> u16;
+
+    fn net_state(&self) -> NetDeivceState;
+
+    fn set_net_state(&self, state: NetDeivceState);
+
+    fn operstate(&self) -> Operstate;
+
+    fn set_operstate(&self, state: Operstate);
+}
+
+/// 网络设备的公共数据
+#[derive(Debug)]
+pub struct NetDeviceCommonData {
+    /// 表示网络接口的地址分配类型
+    pub addr_assign_type: u8,
+    /// 表示网络接口的类型
+    pub net_device_type: u16,
+    /// 表示网络接口的状态
+    pub state: NetDeivceState,
+    /// 表示网络接口的操作状态
+    pub operstate: Operstate,
+}
+
+impl Default for NetDeviceCommonData {
+    fn default() -> Self {
+        Self {
+            addr_assign_type: 0,
+            net_device_type: 1,
+            state: NetDeivceState::empty(),
+            operstate: Operstate::IF_OPER_UNKNOWN,
+        }
+    }
+}
+
+/// 将网络设备注册到sysfs中
+/// 参考：https://code.dragonos.org.cn/xref/linux-2.6.39/net/core/dev.c?fi=register_netdev#5373
+fn register_netdevice(dev: Arc<dyn NetDevice>) -> Result<(), SystemError> {
+    // 在sysfs中注册设备
+    netdev_register_kobject(dev.clone())?;
+
+    // 标识网络设备在系统中存在
+    dev.set_net_state(NetDeivceState::__LINK_STATE_PRESENT);
+
+    return Ok(());
 }

--- a/kernel/src/driver/net/sysfs.rs
+++ b/kernel/src/driver/net/sysfs.rs
@@ -1,0 +1,635 @@
+use crate::{
+    driver::base::{
+        class::Class,
+        device::{device_manager, Device},
+        kobject::KObject,
+    },
+    filesystem::{
+        sysfs::{
+            file::sysfs_emit_str, Attribute, AttributeGroup, SysFSOpsSupport, SYSFS_ATTR_MODE_RO,
+            SYSFS_ATTR_MODE_RW,
+        },
+        vfs::syscall::ModeType,
+    },
+};
+use alloc::sync::Arc;
+use intertrait::cast::CastArc;
+use log::error;
+use system_error::SystemError;
+
+use super::{class::sys_class_net_instance, NetDeivceState, NetDevice, Operstate};
+
+/// 将设备注册到`/sys/class/net`目录下
+/// 参考：https://code.dragonos.org.cn/xref/linux-2.6.39/net/core/net-sysfs.c?fi=netdev_register_kobject#1311
+pub fn netdev_register_kobject(dev: Arc<dyn NetDevice>) -> Result<(), SystemError> {
+    // 初始化设备
+    device_manager().device_default_initialize(&(dev.clone() as Arc<dyn Device>));
+
+    // 设置dev的class为net
+    dev.set_class(Some(Arc::downgrade(
+        &(sys_class_net_instance().cloned().unwrap() as Arc<dyn Class>),
+    )));
+
+    // 设置设备的kobject名
+    dev.set_name(dev.iface_name().clone());
+
+    device_manager().add_device(dev.clone() as Arc<dyn Device>)?;
+
+    return Ok(());
+}
+
+// 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/net/core/net-sysfs.c
+#[derive(Debug)]
+pub struct NetAttrGroup;
+
+impl AttributeGroup for NetAttrGroup {
+    fn name(&self) -> Option<&str> {
+        None
+    }
+
+    fn attrs(&self) -> &[&'static dyn Attribute] {
+        &[
+            &AttrAddrAssignType,
+            &AttrAddrLen,
+            &AttrDevId,
+            &AttrIfalias,
+            &AttrIflink,
+            &AttrIfindex,
+            &AttrFeatrues,
+            &AttrType,
+            &AttrLinkMode,
+            &AttrAddress,
+            &AttrBroadcast,
+            &AttrCarrier,
+            &AttrSpeed,
+            &AttrDuplex,
+            &AttrDormant,
+            &AttrOperstate,
+            &AttrMtu,
+            &AttrFlags,
+            &AttrTxQueueLen,
+            &AttrNetdevGroup,
+        ]
+    }
+
+    fn is_visible(
+        &self,
+        _kobj: Arc<dyn KObject>,
+        attr: &'static dyn Attribute,
+    ) -> Option<ModeType> {
+        return Some(attr.mode());
+    }
+}
+
+/// # 表示网络接口的MAC地址是如何分配的
+/// - 0(NET_ADDR_PERM): 永久的MAC地址（默认值）
+/// - 1(NET_ADDR_RANDOM): 随机生成的MAC地址
+/// - 2(NET_ADDR_STOLEN): 从其他设备中获取的MAC地址
+/// - 3(NET_ADDR_SET): 由用户设置的MAC地址
+#[derive(Debug)]
+struct AttrAddrAssignType;
+
+impl Attribute for AttrAddrAssignType {
+    fn name(&self) -> &str {
+        "addr_assign_type"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let net_device = kobj.cast::<dyn NetDevice>().map_err(|_| {
+            error!("AttrAddrAssignType::show() failed: kobj is not a NetDevice");
+            SystemError::EINVAL
+        })?;
+        let addr_assign_type = net_device.addr_assign_type();
+        sysfs_emit_str(buf, &format!("{}\n", addr_assign_type))
+    }
+}
+
+/// # 表示网络接口的MAC地址的长度，以字节为单位
+#[derive(Debug)]
+struct AttrAddrLen;
+
+impl Attribute for AttrAddrLen {
+    fn name(&self) -> &str {
+        "addr_len"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrAddrLen::show")
+    }
+}
+
+/// # 表示网络接口的设备ID，是一个十六进制数
+#[derive(Debug)]
+struct AttrDevId;
+
+impl Attribute for AttrDevId {
+    fn name(&self) -> &str {
+        "dev_id"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrDevId::show")
+    }
+}
+
+/// # 表示网络接口的别名，可以设置
+#[derive(Debug)]
+struct AttrIfalias;
+
+impl Attribute for AttrIfalias {
+    fn name(&self) -> &str {
+        "ifalias"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RW
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW | SysFSOpsSupport::ATTR_STORE
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrIfalias::show")
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, _buf: &[u8]) -> Result<usize, SystemError> {
+        todo!("AttrIfalias::store")
+    }
+}
+
+/// # 表示网络接口的链路索引，用于表示网络接口在系统中的位置
+#[derive(Debug)]
+struct AttrIflink;
+
+impl Attribute for AttrIflink {
+    fn name(&self) -> &str {
+        "iflink"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrIflink::show")
+    }
+}
+
+/// # 标识网络接口的索引
+#[derive(Debug)]
+struct AttrIfindex;
+
+impl Attribute for AttrIfindex {
+    fn name(&self) -> &str {
+        "ifindex"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrIfindex::show")
+    }
+}
+
+/// # 用于显示网络接口支持的特性，这些特性通常由网络驱动程序和硬件能力决定
+#[derive(Debug)]
+struct AttrFeatrues;
+
+impl Attribute for AttrFeatrues {
+    fn name(&self) -> &str {
+        "features"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrFeatrues::show")
+    }
+}
+
+/// # 用于表示网络接口的类型
+/// - 1：ARPHRD_ETHER 以太网接口
+/// - 24：ARPHRD_LOOPBACK 回环接口
+/// - 512：ARPHRD_IEEE80211_RADIOTAP IEEE 802.11 无线接口
+/// - 768：ARPHRD_IEEE802154 IEEE 802.15.4 无线接口
+/// - 769：ARPHRD_6LOWPAN 6LoWPAN接口
+#[derive(Debug)]
+struct AttrType;
+
+impl Attribute for AttrType {
+    fn name(&self) -> &str {
+        "type"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let net_deive = kobj.cast::<dyn NetDevice>().map_err(|_| {
+            error!("AttrType::show() failed: kobj is not a NetDevice");
+            SystemError::EINVAL
+        })?;
+        let net_type = net_deive.net_device_type();
+        sysfs_emit_str(buf, &format!("{}\n", net_type))
+    }
+}
+
+/// # 表示网络接口的链路模式，用于指示网络接口是否处于自动协商模式
+/// - 0：表示网络接口处于自动协商模式
+/// - 1：表示网络接口处于强制模式，即链路参数（如速度和双工模式）是手动配置的，而不是通过自动协商确定的
+#[derive(Debug)]
+struct AttrLinkMode;
+
+impl Attribute for AttrLinkMode {
+    fn name(&self) -> &str {
+        "link_mode"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrLinkMode::show")
+    }
+}
+
+/// # 表示网络接口的MAC地址
+#[derive(Debug)]
+struct AttrAddress;
+
+impl Attribute for AttrAddress {
+    fn name(&self) -> &str {
+        "address"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let net_device = kobj.cast::<dyn NetDevice>().map_err(|_| {
+            error!("AttrAddress::show() failed: kobj is not a NetDevice");
+            SystemError::EINVAL
+        })?;
+        let mac_addr = net_device.mac();
+        sysfs_emit_str(buf, &format!("{}\n", mac_addr))
+    }
+}
+
+/// # 表示网络接口的广播地址
+#[derive(Debug)]
+struct AttrBroadcast;
+
+impl Attribute for AttrBroadcast {
+    fn name(&self) -> &str {
+        "broadcast"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrBroadcast::show")
+    }
+}
+
+/// # 表示网络接口的物理链路状态
+/// - 0：表示网络接口处于关闭状态
+/// - 1：表示网络接口处于打开状态
+#[derive(Debug)]
+struct AttrCarrier;
+
+impl Attribute for AttrCarrier {
+    fn name(&self) -> &str {
+        "carrier"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let net_device = kobj.cast::<dyn NetDevice>().map_err(|_| {
+            error!("AttrCarrier::show() failed: kobj is not a NetDevice");
+            SystemError::EINVAL
+        })?;
+        if net_device
+            .net_state()
+            .contains(NetDeivceState::__LINK_STATE_START)
+            && !net_device
+                .net_state()
+                .contains(NetDeivceState::__LINK_STATE_NOCARRIER)
+        {
+            sysfs_emit_str(buf, "1\n")
+        } else {
+            sysfs_emit_str(buf, "0\n")
+        }
+    }
+}
+
+/// # 表示网络接口的当前连接速度，单位为Mbps
+/// - 特殊值：-1，表示无法确定，通常是因为接口不支持查询速度或接口未连接
+#[derive(Debug)]
+struct AttrSpeed;
+
+impl Attribute for AttrSpeed {
+    fn name(&self) -> &str {
+        "speed"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrSpeed::show")
+    }
+}
+
+/// # 表示网络接口的双工模式
+/// - half：半双工，网络接口不能同时发送和接收数据
+/// - full：全双工，网络接口可以同时发送和接收数据
+/// - unknown：未知，通常表示接口未连接或无法确定双工模式
+#[derive(Debug)]
+struct AttrDuplex;
+
+impl Attribute for AttrDuplex {
+    fn name(&self) -> &str {
+        "duplex"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrDuplex::show")
+    }
+}
+
+/// 表示网络接口是否处于休眠状态
+/// - 0：表示网络接口未处于休眠状态
+/// - 1：表示网络接口处于休眠状态
+#[derive(Debug)]
+struct AttrDormant;
+
+impl Attribute for AttrDormant {
+    fn name(&self) -> &str {
+        "dormant"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrDormant::show")
+    }
+}
+
+/// # 表示网络接口的操作状态
+/// - up：网络接口已启用并且正在运行
+/// - down：网络接口已禁用或未连接
+/// - dormant：网络接口处于休眠状态，等待某些条件满足后激活
+/// - testing：网络接口正在测试中
+/// - unknown：网络接口的状态未知
+/// - notpresent：网络接口硬件不存在
+/// - lowerlayerdown：网络接口的底层设备未启用
+/// - inactive：网络接口未激活
+#[derive(Debug)]
+struct AttrOperstate;
+
+impl Attribute for AttrOperstate {
+    fn name(&self) -> &str {
+        "operstate"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        let net_device = _kobj.cast::<dyn NetDevice>().map_err(|_| {
+            error!("AttrOperstate::show() failed: kobj is not a NetDevice");
+            SystemError::EINVAL
+        })?;
+        if !net_device
+            .net_state()
+            .contains(NetDeivceState::__LINK_STATE_START)
+        {
+            net_device.set_operstate(Operstate::IF_OPER_DOWN);
+        }
+
+        let operstate_str = match net_device.operstate() {
+            Operstate::IF_OPER_UP => "up",
+            Operstate::IF_OPER_DOWN => "down",
+            Operstate::IF_OPER_DORMANT => "dormant",
+            Operstate::IF_OPER_TESTING => "testing",
+            Operstate::IF_OPER_UNKNOWN => "unknown",
+            Operstate::IF_OPER_NOTPRESENT => "notpresent",
+            Operstate::IF_OPER_LOWERLAYERDOWN => "lowerlayerdown",
+        };
+
+        sysfs_emit_str(_buf, &format!("{}\n", operstate_str))
+    }
+}
+
+/// # 表示网络接口的最大传输单元
+#[derive(Debug)]
+struct AttrMtu;
+
+impl Attribute for AttrMtu {
+    fn name(&self) -> &str {
+        "mtu"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrMtu::show")
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, _buf: &[u8]) -> Result<usize, SystemError> {
+        todo!("AttrMtu::store")
+    }
+}
+
+/// # 表示网络接口的标志，这些标志提供了关于网络接口状态和配置的详细信息
+/// - IFF_UP(0x1)：接口已启用
+/// - IFF_BROADCAST(0x2)：支持广播
+/// - IFF_DEBUG(0x4)：调试模式
+/// - IFF_LOOPBACK(0x8)：环回接口
+/// - IFF_POINTOPOINT(0x10)：点对点链路
+/// - IFF_NOTRAILERS(0x20)：禁用拖尾
+/// - IFF_RUNNING(0x40)：资源已分配
+/// - IFF_NOARP(0x80)：无ARP协议
+/// - IFF_PROMISC(0x100)：混杂模式
+/// - IFF_ALLMULTI(0x200)：接收所有多播放数据包
+/// - IFF_ MASTER(0x400)：主设备
+/// - IFF_SLAVE(0x800)：从设备
+/// - IFF_MULTICAST(0x1000)：支持多播
+/// - IFF_PORTSEL(0x2000)：可以选择媒体类型
+/// - IFF_AUTOMEDIA(0x4000)：自动选择媒体类型
+/// - IFF_DYNAMIC(0x8000)：动态接口
+#[derive(Debug)]
+struct AttrFlags;
+
+impl Attribute for AttrFlags {
+    fn name(&self) -> &str {
+        "flags"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrFlags::show")
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, _buf: &[u8]) -> Result<usize, SystemError> {
+        todo!("AttrFlags::store")
+    }
+}
+
+/// # 表示网络接口的传输队列长度
+#[derive(Debug)]
+struct AttrTxQueueLen;
+
+impl Attribute for AttrTxQueueLen {
+    fn name(&self) -> &str {
+        "tx_queue_len"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrTxQueueLen::show")
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, _buf: &[u8]) -> Result<usize, SystemError> {
+        todo!("AttrTxQueueLen::store")
+    }
+}
+
+/// # 表示网络设备所属的设备组
+#[derive(Debug)]
+struct AttrNetdevGroup;
+
+impl Attribute for AttrNetdevGroup {
+    fn name(&self) -> &str {
+        "netdev_group"
+    }
+
+    fn mode(&self) -> ModeType {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        todo!("AttrNetdevGroup::show")
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, _buf: &[u8]) -> Result<usize, SystemError> {
+        todo!("AttrNetdevGroup::store")
+    }
+}

--- a/kernel/src/driver/pci/subsys.rs
+++ b/kernel/src/driver/pci/subsys.rs
@@ -151,6 +151,11 @@ impl Bus for PciBus {
         };
         return Ok(pci_dev.name().eq(&pci_driver.name()));
     }
+
+    fn root_device(&self) -> Option<Weak<dyn Device>> {
+        let root_device = pci_bus_device() as Arc<dyn Device>;
+        return Some(Arc::downgrade(&root_device));
+    }
 }
 
 #[derive(Debug)]

--- a/kernel/src/driver/pci/test/pt_device.rs
+++ b/kernel/src/driver/pci/test/pt_device.rs
@@ -130,6 +130,14 @@ impl Device for TestDevice {
     fn state_synced(&self) -> bool {
         true
     }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.device_data.read().parent.clone()
+    }
+
+    fn set_dev_parent(&self, dev_parent: Option<Weak<dyn Device>>) {
+        self.device_data.write().parent = dev_parent
+    }
 }
 
 impl KObject for TestDevice {

--- a/kernel/src/driver/rtc/sysfs.rs
+++ b/kernel/src/driver/rtc/sysfs.rs
@@ -173,6 +173,14 @@ impl Device for RtcGeneralDevice {
     fn attribute_groups(&self) -> Option<&'static [&'static dyn AttributeGroup]> {
         Some(&[&RtcAttrGroup])
     }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, dev_parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = dev_parent;
+    }
 }
 
 impl KObject for RtcGeneralDevice {
@@ -245,7 +253,7 @@ pub fn rtc_general_device_create(
 ) -> Arc<RtcGeneralDevice> {
     let dev = RtcGeneralDevice::new(priority.unwrap_or_default());
     device_manager().device_default_initialize(&(dev.clone() as Arc<dyn Device>));
-    dev.set_parent(Some(Arc::downgrade(real_dev) as Weak<dyn KObject>));
+    dev.set_dev_parent(Some(Arc::downgrade(real_dev) as Weak<dyn Device>));
     dev.set_class(Some(Arc::downgrade(
         &(sys_class_rtc_instance().cloned().unwrap() as Arc<dyn Class>),
     )));

--- a/kernel/src/driver/serial/serial8250/mod.rs
+++ b/kernel/src/driver/serial/serial8250/mod.rs
@@ -16,9 +16,9 @@ use crate::{
         class::Class,
         device::{
             bus::Bus, device_manager, device_number::DeviceNumber, driver::Driver, Device,
-            DeviceKObjType, DeviceState, DeviceType, IdTable,
+            DeviceCommonData, DeviceKObjType, DeviceState, DeviceType, IdTable,
         },
-        kobject::{KObjType, KObject, KObjectState, LockedKObjectState},
+        kobject::{KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState},
         kset::KSet,
         platform::{
             platform_device::{platform_device_manager, PlatformDevice},
@@ -212,11 +212,11 @@ impl Device for Serial8250ISADevices {
         false
     }
     fn bus(&self) -> Option<Weak<dyn Bus>> {
-        self.inner.read().bus.clone()
+        self.inner.read().device_common.bus.clone()
     }
 
     fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
-        self.inner.write().bus = bus;
+        self.inner.write().device_common.bus = bus;
     }
 
     fn dev_type(&self) -> DeviceType {
@@ -228,19 +228,19 @@ impl Device for Serial8250ISADevices {
     }
 
     fn driver(&self) -> Option<Arc<dyn Driver>> {
-        self.inner.read().driver.clone()?.upgrade()
+        self.inner.read().device_common.driver.clone()?.upgrade()
     }
 
     fn set_driver(&self, driver: Option<Weak<dyn Driver>>) {
-        self.inner.write().driver = driver;
+        self.inner.write().device_common.driver = driver;
     }
 
     fn can_match(&self) -> bool {
-        self.inner.read().can_match
+        self.inner.read().device_common.can_match
     }
 
     fn set_can_match(&self, can_match: bool) {
-        self.inner.write().can_match = can_match;
+        self.inner.write().device_common.can_match = can_match;
     }
 
     fn state_synced(&self) -> bool {
@@ -250,6 +250,14 @@ impl Device for Serial8250ISADevices {
     fn set_class(&self, _class: Option<Weak<dyn Class>>) {
         todo!()
     }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner.read().device_common.parent.clone()
+    }
+
+    fn set_dev_parent(&self, dev_parent: Option<Weak<dyn Device>>) {
+        self.inner.write().device_common.parent = dev_parent;
+    }
 }
 
 impl KObject for Serial8250ISADevices {
@@ -258,27 +266,27 @@ impl KObject for Serial8250ISADevices {
     }
 
     fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
-        self.inner.write().inode = inode;
+        self.inner.write().kobject_common.kern_inode = inode;
     }
 
     fn inode(&self) -> Option<Arc<KernFSInode>> {
-        self.inner.read().inode.clone()
+        self.inner.read().kobject_common.kern_inode.clone()
     }
 
     fn parent(&self) -> Option<Weak<dyn KObject>> {
-        self.inner.read().parent_kobj.clone()
+        self.inner.read().kobject_common.parent.clone()
     }
 
     fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
-        self.inner.write().parent_kobj = parent;
+        self.inner.write().kobject_common.parent = parent;
     }
 
     fn kset(&self) -> Option<Arc<KSet>> {
-        self.inner.read().kset.clone()
+        self.inner.read().kobject_common.kset.clone()
     }
 
     fn set_kset(&self, kset: Option<Arc<KSet>>) {
-        self.inner.write().kset = kset;
+        self.inner.write().kobject_common.kset = kset;
     }
 
     fn kobj_type(&self) -> Option<&'static dyn KObjType> {
@@ -310,27 +318,17 @@ impl KObject for Serial8250ISADevices {
 
 #[derive(Debug)]
 struct InnerSerial8250ISADevices {
-    /// 当前设备所述的kset
-    kset: Option<Arc<KSet>>,
-    parent_kobj: Option<Weak<dyn KObject>>,
-    /// 当前设备所述的总线
-    bus: Option<Weak<dyn Bus>>,
-    inode: Option<Arc<KernFSInode>>,
-    driver: Option<Weak<dyn Driver>>,
+    kobject_common: KObjectCommonData,
+    device_common: DeviceCommonData,
     device_state: DeviceState,
-    can_match: bool,
 }
 
 impl InnerSerial8250ISADevices {
     fn new() -> Self {
         Self {
-            kset: None,
-            parent_kobj: None,
-            bus: None,
-            inode: None,
-            driver: None,
+            kobject_common: KObjectCommonData::default(),
+            device_common: DeviceCommonData::default(),
             device_state: DeviceState::NotInitialized,
-            can_match: false,
         }
     }
 }

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -549,6 +549,17 @@ impl Device for TtyDevice {
     fn state_synced(&self) -> bool {
         true
     }
+
+    fn dev_parent(&self) -> Option<alloc::sync::Weak<dyn crate::driver::base::device::Device>> {
+        None
+    }
+
+    fn set_dev_parent(
+        &self,
+        _dev_parent: Option<alloc::sync::Weak<dyn crate::driver::base::device::Device>>,
+    ) {
+        todo!()
+    }
 }
 
 impl CharDevice for TtyDevice {

--- a/kernel/src/driver/video/fbdev/base/fbcon/mod.rs
+++ b/kernel/src/driver/video/fbdev/base/fbcon/mod.rs
@@ -10,8 +10,11 @@ use crate::{
     driver::{
         base::{
             class::Class,
-            device::{bus::Bus, device_manager, driver::Driver, Device, DeviceType, IdTable},
-            kobject::{KObjType, KObject, KObjectState, LockedKObjectState},
+            device::{
+                bus::Bus, device_manager, driver::Driver, Device, DeviceCommonData, DeviceType,
+                IdTable,
+            },
+            kobject::{KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState},
             kset::KSet,
         },
         tty::virtual_terminal::virtual_console::{CursorOperation, VcCursor, VirtualConsoleData},
@@ -89,12 +92,8 @@ struct InnerFbConsoleManager {}
 
 #[derive(Debug)]
 struct InnerFbConsoleDevice {
-    kernfs_inode: Option<Arc<KernFSInode>>,
-    parent: Option<Weak<dyn KObject>>,
-    kset: Option<Arc<KSet>>,
-    bus: Option<Weak<dyn Bus>>,
-    driver: Option<Weak<dyn Driver>>,
-    ktype: Option<&'static dyn KObjType>,
+    device_common: DeviceCommonData,
+    kobject_common: KObjectCommonData,
 }
 
 /// `/sys/class/graphics/fbcon`代表的 framebuffer console 设备
@@ -111,15 +110,15 @@ impl FbConsoleDevice {
     pub fn new() -> Arc<Self> {
         return Arc::new(Self {
             inner: SpinLock::new(InnerFbConsoleDevice {
-                kernfs_inode: None,
-                parent: None,
-                kset: None,
-                bus: None,
-                ktype: None,
-                driver: None,
+                device_common: DeviceCommonData::default(),
+                kobject_common: KObjectCommonData::default(),
             }),
             kobj_state: LockedKObjectState::new(None),
         });
+    }
+
+    fn inner(&self) -> SpinLockGuard<InnerFbConsoleDevice> {
+        self.inner.lock()
     }
 }
 
@@ -129,35 +128,35 @@ impl KObject for FbConsoleDevice {
     }
 
     fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
-        self.inner.lock().kernfs_inode = inode;
+        self.inner().kobject_common.kern_inode = inode;
     }
 
     fn inode(&self) -> Option<Arc<KernFSInode>> {
-        self.inner.lock().kernfs_inode.clone()
+        self.inner().kobject_common.kern_inode.clone()
     }
 
     fn parent(&self) -> Option<Weak<dyn KObject>> {
-        self.inner.lock().parent.clone()
+        self.inner().kobject_common.parent.clone()
     }
 
     fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
-        self.inner.lock().parent = parent;
+        self.inner().kobject_common.parent = parent;
     }
 
     fn kset(&self) -> Option<Arc<KSet>> {
-        self.inner.lock().kset.clone()
+        self.inner().kobject_common.kset.clone()
     }
 
     fn set_kset(&self, kset: Option<Arc<KSet>>) {
-        self.inner.lock().kset = kset;
+        self.inner().kobject_common.kset = kset;
     }
 
     fn kobj_type(&self) -> Option<&'static dyn KObjType> {
-        self.inner.lock().ktype
+        self.inner().kobject_common.kobj_type
     }
 
     fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
-        self.inner.lock().ktype = ktype;
+        self.inner().kobject_common.kobj_type = ktype;
     }
 
     fn name(&self) -> String {
@@ -191,11 +190,11 @@ impl Device for FbConsoleDevice {
     }
 
     fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
-        self.inner.lock().bus = bus;
+        self.inner().device_common.bus = bus;
     }
 
     fn bus(&self) -> Option<Weak<dyn Bus>> {
-        self.inner.lock().bus.clone()
+        self.inner().device_common.bus.clone()
     }
 
     fn set_class(&self, _class: Option<Weak<dyn Class>>) {
@@ -208,27 +207,27 @@ impl Device for FbConsoleDevice {
     }
 
     fn driver(&self) -> Option<Arc<dyn Driver>> {
-        self.inner
-            .lock()
+        self.inner()
+            .device_common
             .driver
             .clone()
             .and_then(|driver| driver.upgrade())
     }
 
     fn set_driver(&self, driver: Option<Weak<dyn Driver>>) {
-        self.inner.lock().driver = driver;
+        self.inner().device_common.driver = driver;
     }
 
     fn is_dead(&self) -> bool {
-        todo!()
+        self.inner().device_common.dead
     }
 
     fn can_match(&self) -> bool {
-        todo!()
+        self.inner().device_common.can_match
     }
 
-    fn set_can_match(&self, _can_match: bool) {
-        todo!()
+    fn set_can_match(&self, can_match: bool) {
+        self.inner().device_common.can_match = can_match;
     }
 
     fn state_synced(&self) -> bool {
@@ -237,6 +236,14 @@ impl Device for FbConsoleDevice {
 
     fn attribute_groups(&self) -> Option<&'static [&'static dyn AttributeGroup]> {
         return Some(&[&AnonymousAttributeGroup]);
+    }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, dev_parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = dev_parent;
     }
 }
 

--- a/kernel/src/driver/virtio/mmio.rs
+++ b/kernel/src/driver/virtio/mmio.rs
@@ -20,7 +20,7 @@ fn do_probe_virtio_mmio() -> Result<(), SystemError> {
     let do_check = |node: FdtNode| -> Result<(), SystemError> {
         let mmio_transport = VirtIOMmioTransport::new(node)?;
         let device_id = mmio_transport.device_id();
-        virtio_device_init(VirtIOTransport::Mmio(mmio_transport), device_id);
+        virtio_device_init(VirtIOTransport::Mmio(mmio_transport), device_id, None);
         Ok(())
     };
 

--- a/kernel/src/driver/virtio/mod.rs
+++ b/kernel/src/driver/virtio/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc};
+use alloc::{collections::LinkedList, string::String, sync::Arc};
 use system_error::SystemError;
 
 use crate::exception::{irqdesc::IrqReturn, IrqNumber};
@@ -17,6 +17,8 @@ pub mod virtio_impl;
 
 /// virtio 设备厂商ID
 pub const VIRTIO_VENDOR_ID: u16 = 0x1af4;
+// 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/include/linux/mod_devicetable.h?fi=VIRTIO_DEV_ANY_ID#453
+pub const VIRTIO_DEV_ANY_ID: u32 = 0xffffffff;
 
 #[allow(dead_code)]
 pub trait VirtIODevice: Device {
@@ -48,6 +50,28 @@ pub trait VirtIODevice: Device {
 
 pub trait VirtIODriver: Driver {
     fn probe(&self, device: &Arc<dyn VirtIODevice>) -> Result<(), SystemError>;
+
+    fn virtio_id_table(&self) -> LinkedList<VirtioDeviceId>;
+
+    fn add_virtio_id(&self, id: VirtioDeviceId);
 }
 
 int_like!(VirtIODeviceIndex, usize);
+
+#[derive(Debug, Default)]
+pub struct VirtIODriverCommonData {
+    pub id_table: LinkedList<VirtioDeviceId>,
+}
+
+/// 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/include/linux/mod_devicetable.h#449
+#[derive(Debug, Default, Clone)]
+pub struct VirtioDeviceId {
+    pub device: u32,
+    pub vendor: u32,
+}
+
+impl VirtioDeviceId {
+    pub fn new(device: u32, vendor: u32) -> Self {
+        Self { device, vendor }
+    }
+}

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -4,7 +4,7 @@ use smoltcp::{socket::dhcpv4, wire};
 use system_error::SystemError;
 
 use crate::{
-    driver::net::NetDevice,
+    driver::net::{NetDevice, Operstate},
     libs::rwlock::RwLockReadGuard,
     net::{socket::SocketPollMethod, NET_DEVICES},
     time::timer::{next_n_ms_timer_jiffies, Timer, TimerFunction},
@@ -89,6 +89,8 @@ fn dhcp_query() -> Result<(), SystemError> {
                         .unwrap();
                     let cidr = net_face.inner_iface().lock().ip_addrs().first().cloned();
                     if let Some(cidr) = cidr {
+                        // 这里先在这里将网卡设置为up，后面等netlink实现了再修改
+                        net_face.set_operstate(Operstate::IF_OPER_UP);
                         info!("Successfully allocated ip by Dhcpv4! Ip:{}", cidr);
                         return Ok(());
                     }


### PR DESCRIPTION
**本次PR的主要修改：**

- 全部设备相关：

  - 增加Device trait的dev_parent()和set_dev_parent()方法，以及在DeviceCommonData中添加了parent字段。这个跟kobject的parent还是不一样的，这个parent主要是指设备的父设备，而kobject的parent指的是设备在sysfs中的类似父目录这样的。原先的代码是将父设备设置到了kobject的parent，然后在add_device时才通过get_device_parent获取实际kobject的parent，但是这样没有相关的字段来存储device的parent了。
  - 给大部分设备的结构体添加了类型为DeviceCommonData和KObjectCommonData的字段，我觉得这样比较好，就是给设备添加共有的字段时不用去每个实现的设备结构体添加，有点麻烦

- virtio设备相关

  - 给通过pci probe出来的virtio设备设置了父设备，在pci设备下创建其对应的virtio设备符号链接。如在0000:00:03.0下创建了virtio0的符号链接
![image-20240908214330657](https://github.com/user-attachments/assets/33c001c2-f3e1-4f7b-9276-97da3110a579)
但是我不知道mmio probe出来的virtio设备父设备怎么设置，所以给了None值，即不设置其父设备

  - 修改了virtio_net.rs一部分的代码，主要是关于VirtioInterface这个结构体，原先是为其实现了VirtIODevice trait和NetDevice trait。我将其分成两个结构体，分别为VirtIONetDevice实现了VirtIODevice trait以及为VirtioInterface实现了NetDevice trait。参考linux先完成了VirtIONetDevice设备的注册，然后通过VirtIONetDriver的probe()去注册VirtioInterface设备。再将VirtioInterface的父设备设置为将其probe出来的VirtIODevice

    - 注册VirtIONetDevice设备：[[virtio.c - OpenGrok cross reference for /linux-6.1.9/drivers/virtio/virtio.c (dragonos.org.cn)](https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/virtio/virtio.c?r=&mo=11848&fi=457#418)](https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/virtio/virtio.c?r=&mo=11848&fi=457#418) 
    - 注册VirtioInterface设备：[[virtio_net.c - OpenGrok cross reference for /linux-6.1.9/drivers/net/virtio_net.c (dragonos.org.cn)](https://github.com/DragonOS-Community/DragonOS/compare/%5Bvirtio_net.c%20-%20OpenGrok%20cross%20reference%20for%20/linux-6.1.9/drivers/net/virtio_net.c%20(dragonos.org.cn)%5D(https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/net/virtio_net.c#3712))]([virtio_net.c - OpenGrok cross reference for /linux-6.1.9/drivers/net/virtio_net.c (dragonos.org.cn)](https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/net/virtio_net.c#3712))

  - 实现了VirtIOBus的match_device()方法，这样就不用在virtio设备注册的时候直接手动调用驱动的probe()，而是通过bus_probe_device()，匹配对应的驱动，设置设备驱动并自动调用其probe()

- net设备相关：

  - 创建了/sys/class/net的实例并初始化了net子系统，主要文件：driver/net/class.rs
  - 实现了register_netdevice()，将网络设备注册到sysfs中
  - 创建了net设备的属性文件，目前实现了addr_assign_type/type/address/carrier/operstate

- kobjec相关：主要是DeviceManager，添加了class_dir_create_and_add，在get_device_parent()中被调用，主要是为了判断该设备是否为设备类，然后在其父设备下创建对应的类目录，在该类目录中创建目标为设备的符号链接。如virtio0下的net类目录创建了eth1的符号链接：
![image-20240908222024905](https://github.com/user-attachments/assets/1654e2b4-389f-4281-8efe-dd2be89a3283)
  对于没有父设备的设备，比如lo，fbcon，tty0等在/sys/devices/virtual下创建类目录，然后链接到设备：
![image-20240908222235570](https://github.com/user-attachments/assets/30a1ea60-0e8d-410c-8793-2bbbb8fa8615)
