### PR TITLE
fix(kbd): 修复键盘命令解析器生成的字节码与Linux不一致的问题

### DIFF
--- a/kernel/src/libs/keyboard_parser.rs
+++ b/kernel/src/libs/keyboard_parser.rs
@@ -176,6 +176,9 @@ impl TypeOneFSMState {
             }
             0x47 => {
                 scancode_status.home = true;
+                Self::emit(0x1b);
+                Self::emit(0x5b);
+                Self::emit(0x48);
             }
             0xc7 => {
                 scancode_status.home = false;
@@ -188,13 +191,19 @@ impl TypeOneFSMState {
             }
             0x53 => {
                 scancode_status.del = true;
-                Self::emit(127);
+                Self::emit(0x1b);
+                Self::emit(0x5b);
+                Self::emit(0x33);
+                Self::emit(0x7e);
             }
             0xd3 => {
                 scancode_status.del = false;
             }
             0x4f => {
                 scancode_status.end = true;
+                Self::emit(0x1b);
+                Self::emit(0x5b);
+                Self::emit(0x46);
             }
             0xcf => {
                 scancode_status.end = false;
@@ -207,32 +216,36 @@ impl TypeOneFSMState {
             }
             0x48 => {
                 scancode_status.arrow_u = true;
-                Self::emit(224);
-                Self::emit(72);
+                Self::emit(0x1b);
+                Self::emit(0x5b);
+                Self::emit(0x41);
             }
             0xc8 => {
                 scancode_status.arrow_u = false;
             }
             0x4b => {
                 scancode_status.arrow_l = true;
-                Self::emit(224);
-                Self::emit(75);
+                Self::emit(0x1b);
+                Self::emit(0x5b);
+                Self::emit(0x44);
             }
             0xcb => {
                 scancode_status.arrow_l = false;
             }
             0x50 => {
                 scancode_status.arrow_d = true;
-                Self::emit(224);
-                Self::emit(80);
+                Self::emit(0x1b);
+                Self::emit(0x5b);
+                Self::emit(0x42);
             }
             0xd0 => {
                 scancode_status.arrow_d = false;
             }
             0x4d => {
                 scancode_status.arrow_r = true;
-                Self::emit(224);
-                Self::emit(77);
+                Self::emit(0x1b);
+                Self::emit(0x5b);
+                Self::emit(0x43);
             }
             0xcd => {
                 scancode_status.arrow_r = false;
@@ -481,7 +494,7 @@ const TYPE1_KEY_CODE_MAPTABLE: [u8; 256] = [
     /*0x05*/ b'4', b'$', /*0x06*/ b'5', b'%', /*0x07*/ b'6', b'^',
     /*0x08*/ b'7', b'&', /*0x09*/ b'8', b'*', /*0x0a*/ b'9', b'(',
     /*0x0b*/ b'0', b')', /*0x0c*/ b'-', b'_', /*0x0d*/ b'=', b'+',
-    /*0x0e  \b */ 8, 8, // BACKSPACE
+    /*0x0e  \b */ 0x7f, 0x7f, // BACKSPACE
     /*0x0f*/ b'\t', b'\t', // TAB
     ////////////////////////character///////////////////////////
     /*0x10*/ b'q', b'Q',

--- a/user/dadk/config/nova_shell-0.1.0.dadk
+++ b/user/dadk/config/nova_shell-0.1.0.dadk
@@ -6,7 +6,7 @@
     "BuildFromSource": {
       "Git": {
         "url": "https://git.mirrors.dragonos.org.cn/DragonOS-Community/NovaShell.git",
-        "revision": "dcf45035c1"
+        "revision": "6c1ca14da7"
       }
     }
   },


### PR DESCRIPTION
修改了以下几个按键的字节码为xterm的字节码
- 上下左右
- home
- end
- del
- backspace


cc @GnoCiYeH 这个PR合并之后，https://github.com/DragonOS-Community/Held 需要做更改，不然跑不了。
更改的内容参考novashell的更改：

- https://github.com/DragonOS-Community/NovaShell/pull/46
- https://github.com/DragonOS-Community/NovaShell/pull/47