### PR TITLE
修复tcsetpgrp函数设置进程组不正确的问题

### DIFF
--- a/kernel/src/driver/tty/tty_job_control.rs
+++ b/kernel/src/driver/tty/tty_job_control.rs
@@ -5,7 +5,10 @@ use crate::{
     arch::ipc::signal::{SigSet, Signal},
     mm::VirtAddr,
     process::{Pid, ProcessManager},
-    syscall::{user_access::UserBufferWriter, Syscall},
+    syscall::{
+        user_access::{UserBufferReader, UserBufferWriter},
+        Syscall,
+    },
 };
 
 use super::tty_core::{TtyCore, TtyIoctlCmd};
@@ -81,13 +84,13 @@ impl TtyJobCtrlManager {
                     }
                 };
 
-                // let user_reader = UserBufferReader::new(
-                //     VirtAddr::new(arg).as_ptr::<usize>(),
-                //     core::mem::size_of::<usize>(),
-                //     true,
-                // )?;
+                let user_reader = UserBufferReader::new(
+                    VirtAddr::new(arg).as_ptr::<i32>(),
+                    core::mem::size_of::<i32>(),
+                    true,
+                )?;
 
-                // let pgrp = user_reader.read_one_from_user::<usize>(0)?;
+                let pgrp = user_reader.read_one_from_user::<i32>(0)?;
 
                 let current = ProcessManager::current_pcb();
 
@@ -101,7 +104,7 @@ impl TtyJobCtrlManager {
                     return Err(SystemError::ENOTTY);
                 }
 
-                ctrl.pgid = Some(Pid::new(arg));
+                ctrl.pgid = Some(Pid::new(*pgrp as usize));
 
                 return Ok(0);
             }


### PR DESCRIPTION
## 前提
https://bbs.dragonos.org.cn/t/topic/333/3 记录了NovaShell中使用tcsetpgrp（底层为ioctl）无法设置前台进程的问题，推测是切换前台进程的操作必须由当前前台进程发起，但dragonreach在进入NovaShell之前未正确设置前台进程为NovaShell，导致tty记录的前台进程一直为dragonreach，因此NovaShell无法设置前台进程
因此，将init程序替换为NovaShell，使NovaShell成为初始的前台进程，查看是否能成功设置前台进程
![image](https://github.com/user-attachments/assets/9fc37167-e349-4dac-8508-e595af2e756b)
![image](https://github.com/user-attachments/assets/ba24754a-46b7-4cbb-aa4a-9b7894c48eea)
![image](https://github.com/user-attachments/assets/966fd88e-8796-4280-a70e-66440f840aa3)


## 问题描述
根据日志可以看出，成功设置前台进程，但进程号不正确
![image](https://github.com/user-attachments/assets/eee7afb6-8031-4c32-bd9c-b73a5bdd0a5b)

参考linux源码中[`tty_jobctrl_ioctl`](https://code.dragonos.org.cn/xref/linux-6.6.21/drivers/tty/tty_jobctrl.c#572)函数定义发现，当cmd参数为`TIOCSPGRP`时，arg会被解析为pid_t*（i32）类型从用户空间读取pid（https://code.dragonos.org.cn/xref/linux-6.6.21/drivers/tty/tty_jobctrl.c#504），但DragonOS中错误地直接将指针设置为pid

## 修改方法
将arg构造为UserBufferReader对象，读取一个i32类型作为pid
![image](https://github.com/user-attachments/assets/78d6d82e-9c14-48b0-ba97-29e12257e22d)
![image](https://github.com/user-attachments/assets/644cde6c-ebfe-4cf8-8dd6-51c96c32eeca)

成功设置正确的pid，并成功传递终止信号：
![image](https://github.com/user-attachments/assets/82ae2f5a-45e2-457f-b3f7-c1c632335891)
