### PR TITLE
fix: 临时修复线程退出时处理tty前台进程组产生panic的bug

### DIFF
--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -166,6 +166,8 @@ impl ProcessManager {
 
         let pcb = ProcessControlBlock::new(name, new_kstack);
 
+        // TODO: 注意！这里设置tty的操作不符合Linux的行为！（毕竟创建进程不一定要fork，也可以用clone来创建）
+        // 正确做法应该是在实现进程组之后去管理前台进程组。
         pcb.sig_info_mut()
             .set_tty(current_pcb.sig_info_irqsave().tty());
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -425,12 +425,9 @@ impl ProcessManager {
 
         // TODO 由于未实现进程组，tty记录的前台进程组等于当前进程，故退出前要置空
         // 后续相关逻辑需要在SYS_EXIT_GROUP系统调用中实现
-        pcb.sig_info_irqsave()
-            .tty()
-            .unwrap()
-            .core()
-            .contorl_info_irqsave()
-            .pgid = None;
+        if let Some(tty) = pcb.sig_info_irqsave().tty() {
+            tty.core().contorl_info_irqsave().pgid = None;
+        }
         pcb.sig_info_mut().set_tty(None);
 
         drop(pcb);


### PR DESCRIPTION
临时解决了：https://github.com/DragonOS-Community/DragonOS/issues/981

@smallcjy @1037827920 
