### PR TITLE
feat: 添加SYS_MKDIRAT系统调用

### DIFF
--- a/kernel/src/filesystem/vfs/core.rs
+++ b/kernel/src/filesystem/vfs/core.rs
@@ -172,7 +172,8 @@ pub fn do_mkdir_at(
         user_path_at(&ProcessManager::current_pcb(), dirfd, path.trim())?;
     let (name, parent) = rsplit_path(&path);
     if let Some(parent) = parent {
-        current_inode = current_inode.lookup(parent)?;
+        current_inode =
+            current_inode.lookup_follow_symlink(parent, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
     }
     // debug!("mkdir at {:?}", current_inode.metadata()?.inode_id);
     return current_inode.mkdir(name, ModeType::from_bits_truncate(mode.bits()));

--- a/kernel/src/filesystem/vfs/syscall.rs
+++ b/kernel/src/filesystem/vfs/syscall.rs
@@ -807,6 +807,14 @@ impl Syscall {
         return Ok(0);
     }
 
+    pub fn mkdir_at(dirfd: i32, path: *const u8, mode: usize) -> Result<usize, SystemError> {
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        do_mkdir_at(dirfd, &path, FileMode::from_bits_truncate(mode as u32))?;
+        return Ok(0);
+    }
+
     /// **创建硬连接的系统调用**
     ///    
     /// ## 参数

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -295,6 +295,13 @@ impl Syscall {
                 Self::mkdir(path, mode)
             }
 
+            SYS_MKDIRAT => {
+                let dirfd = args[0] as i32;
+                let path = args[1] as *const u8;
+                let mode = args[2];
+                Self::mkdir_at(dirfd, path, mode)
+            }
+
             SYS_NANOSLEEP => {
                 let req = args[0] as *const PosixTimeSpec;
                 let rem = args[1] as *mut PosixTimeSpec;


### PR DESCRIPTION
将内核原本实现的do_mkdir_at暴露出来,实现SYS_MKDIRAT

解决了：https://github.com/DragonOS-Community/DragonOS/issues/983
在添加这个系统调用后，`cp -r`已经能正常工作
r? @val213 