### PR TITLE
fix(net): address family错误返回错误导致的redis跑不起来

### DIFF
--- a/kernel/src/net/socket/family.rs
+++ b/kernel/src/net/socket/family.rs
@@ -102,14 +102,14 @@ pub enum AddressFamily {
     Max = 46,
 }
 
-use system_error::SystemError;
-
 impl core::convert::TryFrom<u16> for AddressFamily {
     type Error = system_error::SystemError;
     fn try_from(x: u16) -> Result<Self, Self::Error> {
         use num_traits::FromPrimitive;
-        use SystemError::*;
-        return <Self as FromPrimitive>::from_u16(x).ok_or(EINVAL);
+        return <Self as FromPrimitive>::from_u16(x).ok_or({
+            log::debug!("AddressFamily::try_from failed: x={}", x);
+            Self::Error::EINVAL
+        });
     }
 }
 
@@ -117,5 +117,5 @@ use crate::net::socket;
 use alloc::sync::Arc;
 
 pub trait Family {
-    fn socket(stype: socket::PSOCK, protocol: u32) -> Result<Arc<socket::Inode>, SystemError>;
+    fn socket(stype: socket::PSOCK, protocol: u32) -> Result<Arc<socket::Inode>, system_error::SystemError>;
 }

--- a/kernel/src/net/socket/inet/mod.rs
+++ b/kernel/src/net/socket/inet/mod.rs
@@ -22,8 +22,10 @@ use smoltcp::wire::*;
 /// According to the Linux man pages and the Linux implementation, `getsockname()` will _not_ fail
 /// even if the socket is unbound. Instead, it will return an unspecified socket address. This
 /// unspecified endpoint helps with that.
-const UNSPECIFIED_LOCAL_ENDPOINT: IpEndpoint =
+const UNSPECIFIED_LOCAL_ENDPOINT_V4: IpEndpoint =
     IpEndpoint::new(IpAddress::Ipv4(Ipv4Address::UNSPECIFIED), 0);
+const UNSPECIFIED_LOCAL_ENDPOINT_V6: IpEndpoint =
+    IpEndpoint::new(IpAddress::Ipv6(Ipv6Address::UNSPECIFIED), 0);
 
 pub trait InetSocket: Socket {
     /// `on_iface_events`

--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use smoltcp;
 use system_error::SystemError::{self, *};
 
-use super::inet::UNSPECIFIED_LOCAL_ENDPOINT;
+use super::inet::UNSPECIFIED_LOCAL_ENDPOINT_V4;
 
 // pub const DEFAULT_METADATA_BUF_SIZE: usize = 1024;
 pub const DEFAULT_RX_BUF_SIZE: usize = 512 * 1024;
@@ -31,13 +31,13 @@ where
 
 #[derive(Debug)]
 pub enum Init {
-    Unbound(Box<smoltcp::socket::tcp::Socket<'static>>),
+    Unbound((Box<smoltcp::socket::tcp::Socket<'static>>, bool)),
     Bound((socket::inet::BoundInner, smoltcp::wire::IpEndpoint)),
 }
 
 impl Init {
-    pub(super) fn new() -> Self {
-        Init::Unbound(Box::new(new_smoltcp_socket()))
+    pub(super) fn new(v4: bool) -> Self {
+        Init::Unbound((Box::new(new_smoltcp_socket()), v4))
     }
 
     /// 传入一个已经绑定的socket
@@ -55,7 +55,7 @@ impl Init {
         local_endpoint: smoltcp::wire::IpEndpoint,
     ) -> Result<Self, SystemError> {
         match self {
-            Init::Unbound(socket) => {
+            Init::Unbound((socket, _)) => {
                 let bound = socket::inet::BoundInner::bind(*socket, &local_endpoint.addr)?;
                 bound
                     .port_manager()
@@ -63,7 +63,10 @@ impl Init {
                 // bound.iface().common().bind_socket()
                 Ok(Init::Bound((bound, local_endpoint)))
             }
-            Init::Bound(_) => Err(EINVAL),
+            Init::Bound(_) => {
+                log::debug!("Already Bound");
+                Err(EINVAL)
+            },
         }
     }
 
@@ -72,14 +75,14 @@ impl Init {
         remote_endpoint: smoltcp::wire::IpEndpoint,
     ) -> Result<(socket::inet::BoundInner, smoltcp::wire::IpEndpoint), (Self, SystemError)> {
         match self {
-            Init::Unbound(socket) => {
+            Init::Unbound((socket, v4)) => {
                 let (bound, address) =
                     socket::inet::BoundInner::bind_ephemeral(*socket, remote_endpoint.addr)
-                        .map_err(|err| (Self::new(), err))?;
+                        .map_err(|err| (Self::new(v4), err))?;
                 let bound_port = bound
                     .port_manager()
                     .bind_ephemeral_port(Types::Tcp)
-                    .map_err(|err| (Self::new(), err))?;
+                    .map_err(|err| (Self::new(v4), err))?;
                 let endpoint = smoltcp::wire::IpEndpoint::new(address, bound_port);
                 Ok((bound, endpoint))
             }
@@ -308,7 +311,8 @@ impl Listening {
             if let Some(name) = socket.local_endpoint() {
                 return name;
             } else {
-                return UNSPECIFIED_LOCAL_ENDPOINT;
+                // TODO: IPV6
+                return UNSPECIFIED_LOCAL_ENDPOINT_V4;
             }
         })
     }

--- a/kernel/src/net/socket/utils.rs
+++ b/kernel/src/net/socket/utils.rs
@@ -13,12 +13,11 @@ pub fn create_socket(
     type AF = socket::AddressFamily;
     let inode = match family {
         AF::INet => socket::inet::Inet::socket(socket_type, protocol)?,
-        AF::INet6 => {
-            todo!("AF_INET6 unimplemented");
-        }
+        // AF::INet6 => socket::inet::Inet6::socket(socket_type, protocol)?,
         AF::Unix => socket::unix::Unix::socket(socket_type, protocol)?,
         _ => {
-            todo!("unsupport address family");
+            log::warn!("unsupport address family");
+            return Err(SystemError::EAFNOSUPPORT);
         }
     };
     inode.set_nonblock(is_nonblock);


### PR DESCRIPTION
新增发现BUG：
- [ ] Address Family在转换到已有地址时，from_u16在2与10（INET6）上会返回None