### PR TITLE
fix: tty刷新线程初始化之前，键盘产生数据导致崩溃的问题

### DIFF
--- a/kernel/src/driver/tty/kthread.rs
+++ b/kernel/src/driver/tty/kthread.rs
@@ -62,6 +62,10 @@ fn tty_refresh_thread() -> i32 {
 
 /// 发送数据到tty刷新线程
 pub fn send_to_tty_refresh_thread(data: &[u8]) {
+    if unsafe { TTY_REFRESH_THREAD.is_none() } {
+        return;
+    }
+
     for item in data {
         KEYBUF.push(*item).ok();
     }


### PR DESCRIPTION
增加了对TTY_REFRESH_THREAD是否为空的判断