### PR TITLE
fix: 临时修复键盘驱动与鼠标驱动冲突导致键盘无响应

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -23,6 +23,7 @@ kvm = []
 
 fatfs = []
 fatfs-secure = ["fatfs"]
+driver_ps2_mouse = []
 
 # kprobe
 kprobe_test = []

--- a/kernel/src/arch/x86_64/asm/entry.S
+++ b/kernel/src/arch/x86_64/asm/entry.S
@@ -54,7 +54,6 @@ Restore_all:
     popq %rax
     addq $0x10, %rsp // 弹出变量FUNC和errcode
     
-    sti
     iretq
 
 ret_from_exception:

--- a/kernel/src/driver/input/mod.rs
+++ b/kernel/src/driver/input/mod.rs
@@ -1,4 +1,4 @@
 pub mod ps2_dev;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "driver_ps2_mouse"))]
 pub mod ps2_mouse;
 pub mod serio;

--- a/kernel/src/driver/input/serio/i8042/mod.rs
+++ b/kernel/src/driver/input/serio/i8042/mod.rs
@@ -69,7 +69,7 @@ pub fn i8042_setup_aux() -> Result<(), SystemError> {
     )));
     serio_device_manager().register_port(aux_port.clone() as Arc<dyn SerioDevice>)?;
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "driver_ps2_mouse"))]
     crate::driver::input::ps2_mouse::ps_mouse_device::rs_ps2_mouse_device_init(
         aux_port.clone() as Arc<dyn Device>
     )?;


### PR DESCRIPTION
开机的时候，在初始化完成之前，连续一直敲键盘，然后移动了一下鼠标，就能触发原本的bug：开机之后shell输入不了东西，但cpu中断是开的。

暂时通过条件编译的方式解决. 目前认为是鼠标驱动问题,没有正确判断是不是自己的数据...
但是因为我们场景下,鼠标驱动几乎用不到,因此先条件编译屏蔽.