### PR TITLE
fix(tty): 修复tty对tab进行处理时产生数组越界panic的问题

### DIFF
--- a/kernel/src/libs/font/mod.rs
+++ b/kernel/src/libs/font/mod.rs
@@ -40,7 +40,7 @@ impl FontDesc {
         }
 
         for (first, last) in Self::DOUBLE_WIDTH_RANGE {
-            if ch > *first && ch < *last {
+            if ch >= *first && ch < *last {
                 return true;
             }
         }


### PR DESCRIPTION
bug复现方法:

在commit [37c2359](https://github.com/DragonOS-Community/DragonOS/commit/37c2359ac400be9a77c26542bd60ef8267aa5ee6) 下，
x86_64，调整head.S，把图形窗口设置成640*400,然后启动dragonos.
接着shell自动补全（按tab键）：
![UYlRf7Ckwl](https://github.com/user-attachments/assets/2ff5f81a-9b8d-46cb-9d53-6c0d57282825)

在这里已经卡了，backtrace会发现内核已经panic。

