### PR TITLE
fix(driver/virtio): 修改pci transport中断初始化的位置

### DIFF
--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -30,11 +30,7 @@ use crate::{
             kset::KSet,
         },
         virtio::{
-            sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager},
-            transport::VirtIOTransport,
-            virtio_impl::HalImpl,
-            VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId,
-            VIRTIO_VENDOR_ID,
+            sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager}, transport::VirtIOTransport, virtio_impl::HalImpl, VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId, VIRTIO_VENDOR_ID
         },
     },
     exception::{irqdesc::IrqReturn, IrqNumber},
@@ -163,8 +159,14 @@ unsafe impl Sync for VirtIOBlkDevice {}
 
 impl VirtIOBlkDevice {
     pub fn new(transport: VirtIOTransport, dev_id: Arc<DeviceId>) -> Option<Arc<Self>> {
+        // 设置中断
+        if let Err(err) = transport.setup_irq(dev_id.clone()) {
+            error!("VirtIOBlkDevice '{dev_id:?}' setup_irq failed: {:?}", err);
+            return None;
+        }
+
         let devname = virtioblk_manager().alloc_id()?;
-        let irq = transport.irq().map(|irq| IrqNumber::new(irq.data()));
+        let irq = Some(transport.irq());
         let device_inner = VirtIOBlk::<HalImpl, VirtIOTransport>::new(transport);
         if let Err(e) = device_inner {
             error!("VirtIOBlkDevice '{dev_id:?}' create failed: {:?}", e);

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -30,7 +30,11 @@ use crate::{
             kset::KSet,
         },
         virtio::{
-            sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager}, transport::VirtIOTransport, virtio_impl::HalImpl, VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId, VIRTIO_VENDOR_ID
+            sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager},
+            transport::VirtIOTransport,
+            virtio_impl::HalImpl,
+            VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId,
+            VIRTIO_VENDOR_ID,
         },
     },
     exception::{irqdesc::IrqReturn, IrqNumber},

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -91,6 +91,12 @@ impl Debug for InnerVirtIONetDevice {
 
 impl VirtIONetDevice {
     pub fn new(transport: VirtIOTransport, dev_id: Arc<DeviceId>) -> Option<Arc<Self>> {
+        // 设置中断
+        if let Err(err) = transport.setup_irq(dev_id.clone()) {
+            error!("VirtIONetDevice '{dev_id:?}' setup_irq failed: {:?}", err);
+            return None;
+        }
+
         let driver_net: VirtIONet<HalImpl, VirtIOTransport, 2> =
             match VirtIONet::<HalImpl, VirtIOTransport, 2>::new(transport, 4096) {
                 Ok(net) => net,

--- a/kernel/src/driver/virtio/transport.rs
+++ b/kernel/src/driver/virtio/transport.rs
@@ -2,9 +2,20 @@ use alloc::{string::ToString, sync::Arc};
 
 use virtio_drivers::transport::Transport;
 
-use crate::{driver::{base::device::DeviceId, pci::{pci::{PciDeviceStructure, PciError}, pci_irq::{IrqCommonMsg, IrqSpecificMsg, PciInterrupt, PciIrqError, PciIrqMsg, IRQ}}}, exception::IrqNumber};
+use crate::{
+    driver::{
+        base::device::DeviceId,
+        pci::{
+            pci::{PciDeviceStructure, PciError},
+            pci_irq::{IrqCommonMsg, IrqSpecificMsg, PciInterrupt, PciIrqError, PciIrqMsg, IRQ},
+        },
+    },
+    exception::IrqNumber,
+};
 
-use super::{irq::DefaultVirtioIrqHandler, transport_mmio::VirtIOMmioTransport, transport_pci::PciTransport};
+use super::{
+    irq::DefaultVirtioIrqHandler, transport_mmio::VirtIOMmioTransport, transport_pci::PciTransport,
+};
 
 pub enum VirtIOTransport {
     Pci(PciTransport),
@@ -25,7 +36,8 @@ impl VirtIOTransport {
             let mut pci_device_guard = transport.pci_device();
             let standard_device = pci_device_guard.as_standard_device_mut().unwrap();
             standard_device
-                .irq_init(IRQ::PCI_IRQ_MSIX | IRQ::PCI_IRQ_MSI).ok_or(PciError::PciIrqError(PciIrqError::IrqNotInited))?;
+                .irq_init(IRQ::PCI_IRQ_MSIX | IRQ::PCI_IRQ_MSI)
+                .ok_or(PciError::PciIrqError(PciIrqError::IrqNotInited))?;
             // 中断相关信息
             let msg = PciIrqMsg {
                 irq_common_message: IrqCommonMsg::init_from(
@@ -36,10 +48,8 @@ impl VirtIOTransport {
                 ),
                 irq_specific_message: IrqSpecificMsg::msi_default(),
             };
-            standard_device
-                .irq_install(msg)?;
-            standard_device
-                .irq_enable(true)?;
+            standard_device.irq_install(msg)?;
+            standard_device.irq_enable(true)?;
         }
         return Ok(());
     }

--- a/kernel/src/driver/virtio/transport.rs
+++ b/kernel/src/driver/virtio/transport.rs
@@ -1,8 +1,10 @@
+use alloc::{string::ToString, sync::Arc};
+
 use virtio_drivers::transport::Transport;
 
-use crate::exception::HardwareIrqNumber;
+use crate::{driver::{base::device::DeviceId, pci::{pci::{PciDeviceStructure, PciError}, pci_irq::{IrqCommonMsg, IrqSpecificMsg, PciInterrupt, PciIrqError, PciIrqMsg, IRQ}}}, exception::IrqNumber};
 
-use super::{transport_mmio::VirtIOMmioTransport, transport_pci::PciTransport};
+use super::{irq::DefaultVirtioIrqHandler, transport_mmio::VirtIOMmioTransport, transport_pci::PciTransport};
 
 pub enum VirtIOTransport {
     Pci(PciTransport),
@@ -10,11 +12,36 @@ pub enum VirtIOTransport {
 }
 
 impl VirtIOTransport {
-    pub fn irq(&self) -> Option<HardwareIrqNumber> {
+    pub fn irq(&self) -> IrqNumber {
         match self {
-            VirtIOTransport::Mmio(transport) => Some(transport.irq()),
-            _ => None,
+            VirtIOTransport::Pci(transport) => transport.irq(),
+            VirtIOTransport::Mmio(transport) => IrqNumber::new(transport.irq().data()),
         }
+    }
+
+    /// 设置中断
+    pub fn setup_irq(&self, dev_id: Arc<DeviceId>) -> Result<(), PciError> {
+        if let VirtIOTransport::Pci(transport) = self {
+            let mut pci_device_guard = transport.pci_device();
+            let standard_device = pci_device_guard.as_standard_device_mut().unwrap();
+            standard_device
+                .irq_init(IRQ::PCI_IRQ_MSIX | IRQ::PCI_IRQ_MSI).ok_or(PciError::PciIrqError(PciIrqError::IrqNotInited))?;
+            // 中断相关信息
+            let msg = PciIrqMsg {
+                irq_common_message: IrqCommonMsg::init_from(
+                    0,
+                    "Virtio_IRQ".to_string(),
+                    &DefaultVirtioIrqHandler,
+                    dev_id,
+                ),
+                irq_specific_message: IrqSpecificMsg::msi_default(),
+            };
+            standard_device
+                .irq_install(msg)?;
+            standard_device
+                .irq_enable(true)?;
+        }
+        return Ok(());
     }
 }
 

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -7,7 +7,11 @@ use crate::{
     driver::net::{NetDevice, Operstate},
     libs::rwlock::RwLockReadGuard,
     net::{socket::SocketPollMethod, NET_DEVICES},
-    time::timer::{next_n_ms_timer_jiffies, Timer, TimerFunction},
+    time::{
+        sleep::nanosleep,
+        timer::{next_n_ms_timer_jiffies, Timer, TimerFunction},
+        PosixTimeSpec,
+    },
 };
 
 use super::{
@@ -118,6 +122,14 @@ fn dhcp_query() -> Result<(), SystemError> {
                     .remove_default_ipv4_route();
             }
         }
+        // 在睡眠前释放锁
+        drop(binding);
+
+        let sleep_time = PosixTimeSpec {
+            tv_sec: 5,
+            tv_nsec: 0,
+        };
+        let _ = nanosleep(sleep_time)?;
     }
 
     return Err(SystemError::ETIMEDOUT);


### PR DESCRIPTION
**PR描述**
- 修改了pci transport的中断初始化位置
- 在dhcp请求之间加入适当的睡眠

相关issue：#1007