### PR TITLE
chore: Update NovaShell to cb835e03e4

### DIFF
--- a/user/dadk/config/nova_shell-0.1.0.dadk
+++ b/user/dadk/config/nova_shell-0.1.0.dadk
@@ -6,7 +6,7 @@
     "BuildFromSource": {
       "Git": {
         "url": "https://git.mirrors.dragonos.org.cn/DragonOS-Community/NovaShell.git",
-        "revision": "7bb802ad1e"
+        "revision": "cb835e03e4"
       }
     }
   },


### PR DESCRIPTION
[修复执行前台命令时未设置前台进程的错误 #51](https://github.com/DragonOS-Community/NovaShell/pull/51)