### PR TITLE
ci: 推送文档到s3时，不同步`p/*`目录下的文件

### DIFF
--- a/.github/workflows/docs-multiversion.yml
+++ b/.github/workflows/docs-multiversion.yml
@@ -44,4 +44,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_DEPLOY_S3_SECRET_KEY }}
       
       run: |
-        aws s3 sync ./_build/html s3://dragonos-docs --delete
+        aws s3 sync ./_build/html s3://dragonos-docs --delete --exclude "p/*"


### PR DESCRIPTION
这些文件夹被用于其他子项目的文档