### PR TITLE
fix: 修正进程pcb的`on_cpu`字段未设置导致的panic问题

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -275,7 +275,12 @@ impl ProcessManager {
                 // avoid deadlock
                 drop(writer);
 
-                let rq = cpu_rq(pcb.sched_info().on_cpu().unwrap().data() as usize);
+                let rq = cpu_rq(
+                    pcb.sched_info()
+                        .on_cpu()
+                        .unwrap_or(smp_get_processor_id())
+                        .data() as usize,
+                );
 
                 let (rq, _guard) = rq.self_lock();
                 rq.update_rq_clock();

--- a/kernel/src/sched/clock.rs
+++ b/kernel/src/sched/clock.rs
@@ -1,12 +1,12 @@
 //! 这个文件实现的是调度过程中涉及到的时钟
 //!
-use crate::{arch::CurrentTimeArch, time::TimeArch};
+use crate::{arch::CurrentTimeArch, smp::cpu::ProcessorId, time::TimeArch};
 
 pub struct SchedClock;
 
 impl SchedClock {
     #[inline]
-    pub fn sched_clock_cpu(_cpu: usize) -> u64 {
+    pub fn sched_clock_cpu(_cpu: ProcessorId) -> u64 {
         #[cfg(target_arch = "x86_64")]
         {
             if crate::arch::driver::tsc::TSCManager::cpu_khz() == 0 {


### PR DESCRIPTION
解决了 https://github.com/DragonOS-Community/DragonOS/issues/1047 发生panic的问题。

但是，仍然存在问题：

按照 https://github.com/DragonOS-Community/DragonOS/issues/1047 的方法尝试，当问题复现时，可以注意到，是卡了一下子，然后输出panic信息。

本pr改完之后，按照 https://github.com/DragonOS-Community/DragonOS/issues/1047 进行尝试，不会panic，但是问题触发时，会卡一下，然后完全卡死。gdb看到在idle进程。

因此怀疑是调度有点问题？

@GnoCiYeH @val213 