### PR TITLE
fix:命名管道读行为不符合posix规范问题

### DIFF
--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -288,18 +288,16 @@ impl IndexNode for LockedPipeInode {
         let accmode = mode.accmode();
         let mut guard = self.inner.lock();
         // 不能以读写方式打开管道
-        if accmode==FileMode::O_RDWR.bits() {
+        if accmode == FileMode::O_RDWR.bits() {
             return Err(SystemError::EACCES);
-        }
-        else if accmode==FileMode::O_RDONLY.bits() {
+        } else if accmode == FileMode::O_RDONLY.bits() {
             guard.reader += 1;
             guard.had_reader = true;
             println!(
                 "FIFO:     pipe try open in read mode with reader pid:{:?}",
                 ProcessManager::current_pid()
             );
-        }
-        else if accmode==FileMode::O_WRONLY.bits() {
+        } else if accmode == FileMode::O_WRONLY.bits() {
             println!(
                 "FIFO:     pipe try open in write mode with {} reader, writer pid:{:?}",
                 guard.reader,
@@ -338,7 +336,7 @@ impl IndexNode for LockedPipeInode {
         let mut guard = self.inner.lock();
 
         // 写端关闭
-        if accmode==FileMode::O_WRONLY.bits() {
+        if accmode == FileMode::O_WRONLY.bits() {
             assert!(guard.writer > 0);
             guard.writer -= 1;
             // 如果已经没有写端了，则唤醒读端
@@ -349,7 +347,7 @@ impl IndexNode for LockedPipeInode {
         }
 
         // 读端关闭
-        if accmode==FileMode::O_RDONLY.bits() {
+        if accmode == FileMode::O_RDONLY.bits() {
             assert!(guard.reader > 0);
             guard.reader -= 1;
             // 如果已经没有写端了，则唤醒读端

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -293,16 +293,16 @@ impl IndexNode for LockedPipeInode {
         } else if accmode == FileMode::O_RDONLY.bits() {
             guard.reader += 1;
             guard.had_reader = true;
-            println!(
-                "FIFO:     pipe try open in read mode with reader pid:{:?}",
-                ProcessManager::current_pid()
-            );
+            // println!(
+            //     "FIFO:     pipe try open in read mode with reader pid:{:?}",
+            //     ProcessManager::current_pid()
+            // );
         } else if accmode == FileMode::O_WRONLY.bits() {
-            println!(
-                "FIFO:     pipe try open in write mode with {} reader, writer pid:{:?}",
-                guard.reader,
-                ProcessManager::current_pid()
-            );
+            // println!(
+            //     "FIFO:     pipe try open in write mode with {} reader, writer pid:{:?}",
+            //     guard.reader,
+            //     ProcessManager::current_pid()
+            // );
             if guard.reader == 0 {
                 if mode.contains(FileMode::O_NONBLOCK) {
                     return Err(SystemError::ENXIO);

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -1,4 +1,7 @@
+use core::sync::atomic::compiler_fence;
+
 use crate::{
+    arch::ipc::signal::{SigCode, Signal},
     filesystem::vfs::{
         core::generate_inode_id, file::FileMode, syscall::ModeType, FilePrivateData, FileSystem,
         FileType, IndexNode, Metadata,
@@ -8,7 +11,7 @@ use crate::{
         wait_queue::WaitQueue,
     },
     net::event_poll::{EPollEventType, EPollItem, EventPoll},
-    process::ProcessState,
+    process::{ProcessManager, ProcessState},
     sched::SchedMode,
     time::PosixTimeSpec,
 };
@@ -19,6 +22,8 @@ use alloc::{
     vec::Vec,
 };
 use system_error::SystemError;
+
+use super::signal_types::{SigInfo, SigType};
 
 /// 我们设定pipe_buff的总大小为1024字节
 const PIPE_BUFF_SIZE: usize = 1024;
@@ -59,6 +64,7 @@ pub struct InnerPipeInode {
     metadata: Metadata,
     reader: u32,
     writer: u32,
+    had_reader: bool,
     epitems: SpinLock<LinkedList<Arc<EPollItem>>>,
 }
 
@@ -131,6 +137,7 @@ impl LockedPipeInode {
             valid_cnt: 0,
             read_pos: 0,
             write_pos: 0,
+            had_reader: false,
             data: [0; PIPE_BUFF_SIZE],
 
             metadata: Metadata {
@@ -278,15 +285,31 @@ impl IndexNode for LockedPipeInode {
         mut data: SpinLockGuard<FilePrivateData>,
         mode: &crate::filesystem::vfs::file::FileMode,
     ) -> Result<(), SystemError> {
+        let accmode = mode.accmode();
         let mut guard = self.inner.lock();
         // 不能以读写方式打开管道
-        if mode.contains(FileMode::O_RDWR) {
+        if accmode==FileMode::O_RDWR.bits() {
             return Err(SystemError::EACCES);
         }
-        if mode.contains(FileMode::O_RDONLY) {
+        else if accmode==FileMode::O_RDONLY.bits() {
             guard.reader += 1;
+            guard.had_reader = true;
+            println!(
+                "FIFO:     pipe try open in read mode with reader pid:{:?}",
+                ProcessManager::current_pid()
+            );
         }
-        if mode.contains(FileMode::O_WRONLY) {
+        else if accmode==FileMode::O_WRONLY.bits() {
+            println!(
+                "FIFO:     pipe try open in write mode with {} reader, writer pid:{:?}",
+                guard.reader,
+                ProcessManager::current_pid()
+            );
+            if guard.reader == 0 {
+                if mode.contains(FileMode::O_NONBLOCK) {
+                    return Err(SystemError::ENXIO);
+                }
+            }
             guard.writer += 1;
         }
 
@@ -311,10 +334,11 @@ impl IndexNode for LockedPipeInode {
         } else {
             return Err(SystemError::EBADF);
         }
+        let accmode = mode.accmode();
         let mut guard = self.inner.lock();
 
         // 写端关闭
-        if mode.contains(FileMode::O_WRONLY) {
+        if accmode==FileMode::O_WRONLY.bits() {
             assert!(guard.writer > 0);
             guard.writer -= 1;
             // 如果已经没有写端了，则唤醒读端
@@ -325,7 +349,7 @@ impl IndexNode for LockedPipeInode {
         }
 
         // 读端关闭
-        if mode.contains(FileMode::O_RDONLY) {
+        if accmode==FileMode::O_RDONLY.bits() {
             assert!(guard.reader > 0);
             guard.reader -= 1;
             // 如果已经没有写端了，则唤醒读端
@@ -361,7 +385,35 @@ impl IndexNode for LockedPipeInode {
         let mut inode = self.inner.lock();
 
         if inode.reader == 0 {
-            // TODO: 如果已经没有读端存在了，则向写端进程发送SIGPIPE信号
+            if !inode.had_reader {
+                // 如果从未有读端，直接返回 ENXIO，无论是否阻塞模式
+                return Err(SystemError::ENXIO);
+            } else {
+                // 如果曾经有读端，现在已关闭
+                match mode.contains(FileMode::O_NONBLOCK) {
+                    true => {
+                        // 非阻塞模式，直接返回 EPIPE
+                        return Err(SystemError::EPIPE);
+                    }
+                    false => {
+                        let sig = Signal::SIGPIPE;
+                        let mut info = SigInfo::new(
+                            sig,
+                            0,
+                            SigCode::Kernel,
+                            SigType::Kill(ProcessManager::current_pid()),
+                        );
+                        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+
+                        let _retval = sig
+                            .send_signal_info(Some(&mut info), ProcessManager::current_pid())
+                            .map(|x| x as usize);
+
+                        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+                        return Err(SystemError::EPIPE);
+                    }
+                }
+            }
         }
 
         // 如果管道空间不够

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -303,10 +303,8 @@ impl IndexNode for LockedPipeInode {
             //     guard.reader,
             //     ProcessManager::current_pid()
             // );
-            if guard.reader == 0 {
-                if mode.contains(FileMode::O_NONBLOCK) {
-                    return Err(SystemError::ENXIO);
-                }
+            if guard.reader == 0 && mode.contains(FileMode::O_NONBLOCK) {
+                return Err(SystemError::ENXIO);
             }
             guard.writer += 1;
         }

--- a/user/apps/test_fifo_write/Makefile
+++ b/user/apps/test_fifo_write/Makefile
@@ -1,0 +1,20 @@
+ifeq ($(ARCH), x86_64)
+	CROSS_COMPILE=x86_64-linux-musl-
+else ifeq ($(ARCH), riscv64)
+	CROSS_COMPILE=riscv64-linux-musl-
+endif
+
+CC=$(CROSS_COMPILE)gcc
+
+.PHONY: all
+all: main.c
+	$(CC) -static -o test_fifo_write main.c
+
+.PHONY: install clean
+install: all
+	mv test_fifo_write $(DADK_CURRENT_BUILD_DIR)/test_fifo_write
+
+clean:
+	rm test_fifo_write *.o
+
+fmt:

--- a/user/apps/test_fifo_write/main.c
+++ b/user/apps/test_fifo_write/main.c
@@ -3,35 +3,118 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <signal.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 
 #define FIFO_PATH "/bin/test_fifo"
 
+// 信号处理函数
+void sigpipe_handler(int signo) {
+    if (signo == SIGPIPE) {
+        printf("Received SIGPIPE signal. Write operation failed.\n");
+    }
+}
+
+void test_fifo_write(const char *scenario_desc, int nonblocking) {
+    int fd;
+    char *data = "Hello, FIFO!";
+    printf("\n--- Testing: %s ---\n", scenario_desc);
+
+    // 设置 O_NONBLOCK 标志
+    int flags = O_WRONLY;
+    if (nonblocking) {
+        flags |= O_NONBLOCK;
+    }
+
+    // 打开 FIFO 写端
+    fd = open(FIFO_PATH, flags);
+    if (fd == -1) {
+        if (errno == ENXIO) {
+            printf("Result: Failed to open FIFO for writing (ENXIO: No readers).\n");
+        } else {
+            perror("Failed to open FIFO for writing");
+        }
+        return;
+    }
+
+    // 写入数据
+    ssize_t bytes_written = write(fd, data, sizeof(data));
+    if (bytes_written == -1) {
+        if (errno == EPIPE) {
+            printf("Result: Write failed with EPIPE (no readers available).\n");
+        } else if (errno == ENXIO) {
+            printf("Result: Write failed with ENXIO (FIFO never had readers).\n");
+        } else {
+            perror("Write failed with an unexpected error");
+        }
+    } else {
+        printf("Result: Write succeeded. Bytes written: %zd\n", bytes_written);
+    }
+
+    // 关闭 FIFO 写端
+    close(fd);
+}
+
+void run_tests() {
+    pid_t reader_pid;
+
+    // Case 1: Test with no readers (FIFO never had readers)
+    test_fifo_write("No readers (FIFO never had readers)", 1);
+
+    // Case 2: Test with a reader that disconnects
+    reader_pid = fork();
+    if (reader_pid == 0) {
+        // 子进程充当读端
+        int reader_fd = open(FIFO_PATH, O_RDONLY);
+        if (reader_fd == -1) {
+            perror("Reader failed to open FIFO");
+            exit(EXIT_FAILURE);
+        }
+        sleep(1); // 模拟读端短暂存在
+        close(reader_fd);
+        exit(EXIT_SUCCESS);
+    }
+
+    sleep(5); // 确保读端已打开
+    test_fifo_write("Reader exists but disconnects", 0);
+    waitpid(reader_pid, NULL, 0); // 等待读端子进程退出
+
+    // Case 3: Test with an active reader
+    reader_pid = fork();
+    if (reader_pid == 0) {
+        // 子进程充当读端
+        int reader_fd = open(FIFO_PATH, O_RDONLY);
+        if (reader_fd == -1) {
+            perror("Reader failed to open FIFO");
+            exit(EXIT_FAILURE);
+        }
+        sleep(5); // 保持读端存在
+        close(reader_fd);
+        exit(EXIT_SUCCESS);
+    }
+
+    sleep(1); // 确保读端已打开
+    test_fifo_write("Active reader exists", 0);
+    waitpid(reader_pid, NULL, 0); // 等待读端子进程退出
+}
+
 int main() {
+    // 设置 SIGPIPE 信号处理
+    signal(SIGPIPE, sigpipe_handler);
+
     // 创建 FIFO
     if (mkfifo(FIFO_PATH, 0666) == -1 && errno != EEXIST) {
         perror("mkfifo failed");
         exit(EXIT_FAILURE);
     }
 
-    printf("Opening FIFO in write mode...\n");
-
-    // 尝试以非阻塞模式打开 FIFO 的写端
-    int fd = open(FIFO_PATH, O_WRONLY|O_NONBLOCK);
-    printf("fd: %d\n",fd);
-    if (fd == -1) {
-        if (errno == ENXIO) {
-            printf("Error: No readers (ENXIO).\n");
-        } else {
-            perror("Failed to open FIFO");
-        }
-    } else {
-        printf("FIFO opened successfully in write mode.\n");
-        close(fd);
-    }
+    // 运行测试
+    run_tests();
 
     // 删除 FIFO
     unlink(FIFO_PATH);
 
+    printf("\nAll tests completed.\n");
     return 0;
 }

--- a/user/apps/test_fifo_write/main.c
+++ b/user/apps/test_fifo_write/main.c
@@ -118,16 +118,16 @@ int main() {
     }
 
     // 测试阻塞模式下的三种情况
-    printf("========== Testing Blocking Mode ==========\n");
-    test_case1(0); // 阻塞模式下没有读端
-    test_case2(0); // 阻塞模式下读端断开
-    test_case3(0); // 阻塞模式下读端存在
+    // printf("========== Testing Blocking Mode ==========\n");
+    // test_case1(0); // 阻塞模式下没有读端
+    // test_case2(0); // 阻塞模式下读端断开
+    // test_case3(0); // 阻塞模式下读端存在
 
     // 测试非阻塞模式下的三种情况
-    // printf("\n========== Testing Nonblocking Mode ==========\n");
-    // test_case1(1); // 非阻塞模式下没有读端
-    // test_case2(1); // 非阻塞模式下读端断开
-    // test_case3(1); // 非阻塞模式下读端存在
+    printf("\n========== Testing Nonblocking Mode ==========\n");
+    test_case1(1); // 非阻塞模式下没有读端
+    test_case2(1); // 非阻塞模式下读端断开
+    test_case3(1); // 非阻塞模式下读端存在
 
     // 删除 FIFO
     unlink(FIFO_PATH);

--- a/user/apps/test_fifo_write/main.c
+++ b/user/apps/test_fifo_write/main.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+#define FIFO_PATH "/bin/test_fifo"
+
+int main() {
+    // 创建 FIFO
+    if (mkfifo(FIFO_PATH, 0666) == -1 && errno != EEXIST) {
+        perror("mkfifo failed");
+        exit(EXIT_FAILURE);
+    }
+
+    printf("Opening FIFO in write mode...\n");
+
+    // 尝试以非阻塞模式打开 FIFO 的写端
+    int fd = open(FIFO_PATH, O_WRONLY|O_NONBLOCK);
+    printf("fd: %d\n",fd);
+    if (fd == -1) {
+        if (errno == ENXIO) {
+            printf("Error: No readers (ENXIO).\n");
+        } else {
+            perror("Failed to open FIFO");
+        }
+    } else {
+        printf("FIFO opened successfully in write mode.\n");
+        close(fd);
+    }
+
+    // 删除 FIFO
+    unlink(FIFO_PATH);
+
+    return 0;
+}

--- a/user/apps/test_fifo_write/main.c
+++ b/user/apps/test_fifo_write/main.c
@@ -1,137 +1,195 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
-#include <signal.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <unistd.h>
+
+#define TEST_ASSERT(left, right, success_msg, fail_msg)                        \
+  do {                                                                         \
+    if ((left) == (right)) {                                                   \
+      printf("[PASS] %s\n", success_msg);                                      \
+    } else {                                                                   \
+      printf("[FAIL] %s: Expected %d, but got %d\n", fail_msg, (right),        \
+             (left));                                                          \
+    }                                                                          \
+  } while (0)
 
 #define FIFO_PATH "/bin/test_fifo" // 使用 /tmp 目录避免权限问题
 
+typedef struct {
+  int fd;
+  int error_code;
+} FifoWriteResult;
+
 // 信号处理函数
 void sigpipe_handler(int signo) {
-    if (signo == SIGPIPE) {
-        printf("Received SIGPIPE signal. Write operation failed.\n");
-    }
+  if (signo == SIGPIPE) {
+    printf("Received SIGPIPE signal. Write operation failed.\n");
+  }
 }
 
-void test_fifo_write(const char *scenario_desc, int nonblocking) {
-    int fd;
-    char *data = "Hello, FIFO!";
-    printf("\n--- Testing: %s (nonblocking=%d) ---\n", scenario_desc, nonblocking);
+const char *scenarios[] = {"No readers (FIFO never had readers)",
+                           "Reader exists but disconnects",
+                           "Active reader exists"};
 
-    // 设置写模式和非阻塞模式标志
-    int flags = O_WRONLY;
-    if (nonblocking) {
-        flags |= O_NONBLOCK;
-    }
+FifoWriteResult test_fifo_write(int scenario_index, int nonblocking) {
+  FifoWriteResult result = {.fd = -1, .error_code = 0};
+  int fd;
+  const char *data = "Hello, FIFO!";
 
-    // 打开 FIFO 写端
-    fd = open(FIFO_PATH, flags);
-    if (fd == -1) {
-        if (errno == ENXIO) {
-            printf("Result: Failed to open FIFO for writing (ENXIO: No readers).\n");
-        } else {
-            perror("Failed to open FIFO for writing");
-        }
-        return;
-    }
+  // Set write mode and non-blocking flag
+  int flags = O_WRONLY;
+  if (nonblocking) {
+    flags |= O_NONBLOCK;
+  }
 
-    // 写入数据
-    ssize_t bytes_written = write(fd, data, sizeof(data));
-    if (bytes_written == -1) {
-        if (errno == EPIPE) {
-            printf("Result: Write failed with EPIPE (no readers available).\n");
-        } else if (errno == ENXIO) {
-            printf("Result: Write failed with ENXIO (FIFO never had readers).\n");
-        } else if (errno == EAGAIN) {
-            printf("Result: Write failed with EAGAIN (nonblocking write, pipe full or no readers).\n");
-        } else {
-            perror("Write failed with an unexpected error");
-        }
+  // Open the FIFO write end
+  fd = open(FIFO_PATH, flags);
+  if (fd == -1) {
+    result.fd = fd;
+    result.error_code = errno;
+
+    if (errno == ENXIO) {
+      printf("Result: Failed to open FIFO for writing (ENXIO: No readers).\n");
     } else {
-        printf("Result: Write succeeded. Bytes written: %zd\n", bytes_written);
+      perror("Failed to open FIFO for writing");
+    }
+    return result; // Return early with error details
+  }
+
+  // Write data
+  ssize_t bytes_written = write(fd, data, strlen(data));
+  if (bytes_written == -1) {
+    result.error_code = errno;
+
+    if (bytes_written == -1) {
+      if (errno == EPIPE) {
+        printf("Result: Write failed with EPIPE (no readers available).\n");
+      } else if (errno == ENXIO) {
+        printf("Result: Write failed with ENXIO (FIFO never had readers).\n");
+      } else if (errno == EAGAIN) {
+        printf("Result: Write failed with EAGAIN (nonblocking write, pipe full "
+               "or no readers).\n");
+      } else {
+        perror("Write failed with an unexpected error");
+      }
+    } else {
+      printf("Result: Write succeeded. Bytes written: %zd\n", bytes_written);
     }
 
-    // 关闭 FIFO 写端
+    result.fd = fd;
     close(fd);
+    return result; // Return with fd and error_code
+  }
 }
 
 void test_case1(int nonblocking) {
-    // Case 1: No readers (FIFO never had readers)
-    test_fifo_write("No readers (FIFO never had readers)", nonblocking);
+  // Case 1: No readers (FIFO never had readers)
+  FifoWriteResult result = test_fifo_write(0, nonblocking);
+
+  char buffer[100];
+  sprintf(buffer,"Fail with unexpected error %d",result.error_code);
+  TEST_ASSERT(result.error_code, ENXIO,
+              "write(2) fails with the error ENXIO",
+              buffer);
 }
 
 void test_case2(int nonblocking) {
-    pid_t reader_pid;
+  pid_t reader_pid;
 
-    // Case 2: Reader exists but disconnects
-    reader_pid = fork();
-    if (reader_pid == 0) {
-        // 子进程充当读端
-        int reader_fd = open(FIFO_PATH, O_RDONLY);
-        if (reader_fd == -1) {
-            perror("Reader failed to open FIFO");
-            exit(EXIT_FAILURE);
-        }
-        sleep(1); // 模拟读端短暂存在
-        close(reader_fd);
-        exit(EXIT_SUCCESS);
+  // Case 2: Reader exists but disconnects
+  reader_pid = fork();
+  if (reader_pid == 0) {
+    // Child process acts as a reader
+    int reader_fd = open(FIFO_PATH, O_RDONLY);
+    if (reader_fd == -1) {
+      perror("Reader failed to open FIFO");
+      exit(EXIT_FAILURE);
     }
+    sleep(1); // Simulate a brief existence of the reader
+    close(reader_fd);
+    exit(EXIT_SUCCESS);
+  }
 
-    sleep(5); // 确保读端已打开
-    test_fifo_write("Reader exists but disconnects", nonblocking);
-    waitpid(reader_pid, NULL, 0); // 等待读端子进程退出
+  sleep(5); // Ensure the reader has opened the FIFO
+  FifoWriteResult result = test_fifo_write(1, nonblocking);
+  waitpid(reader_pid, NULL, 0); // Wait for the reader process to exit
+
+  if (nonblocking) {
+    TEST_ASSERT(result.fd != -1 && result.error_code == EPIPE, 1, "Non-Blocking Write failed with EPIPE", "Non-Blocking Write failed with wrong error type");
+  } else {
+    TEST_ASSERT(result.fd != -1 && result.error_code == EPIPE, 1, "Blocking Write failed with EPIPE", "Blocking Write failed with wrong error type");
+  }
 }
 
 void test_case3(int nonblocking) {
-    pid_t reader_pid;
+  pid_t reader_pid;
 
-    // Case 3: Active reader exists
-    reader_pid = fork();
-    if (reader_pid == 0) {
-        // 子进程充当读端
-        int reader_fd = open(FIFO_PATH, O_RDONLY);
-        if (reader_fd == -1) {
-            perror("Reader failed to open FIFO");
-            exit(EXIT_FAILURE);
-        }
-        sleep(5); // 保持读端存在
-        close(reader_fd);
-        exit(EXIT_SUCCESS);
+  // Case 3: Active reader exists
+  reader_pid = fork();
+  if (reader_pid == 0) {
+    // Child process acts as a reader
+    int reader_fd = open(FIFO_PATH, O_RDONLY);
+    if (reader_fd == -1) {
+      perror("Reader failed to open FIFO");
+      exit(EXIT_FAILURE);
     }
+    sleep(5); // Keep the reader active
+    close(reader_fd);
+    exit(EXIT_SUCCESS);
+  }
 
-    sleep(1); // 确保读端已打开
-    test_fifo_write("Active reader exists", nonblocking);
-    waitpid(reader_pid, NULL, 0); // 等待读端子进程退出
+  sleep(1); // Ensure the reader has opened the FIFO
+  FifoWriteResult result = test_fifo_write(2, nonblocking);
+
+  waitpid(reader_pid, NULL, 0); // Wait for the reader process to exit
+
+  TEST_ASSERT(result.error_code, 0, "write succeed", "write failed");
+}
+
+void run_tests(int nonblocking) {
+  for (int i = 0; i < 3; i++) {
+    printf("\n--- Testing: %s (nonblocking=%d) ---\n", scenarios[i],
+           nonblocking);
+    switch (i) {
+    case 0:
+      test_case1(nonblocking);
+      break;
+    case 1:
+      test_case2(nonblocking);
+      break;
+    case 2:
+      test_case3(nonblocking);
+      break;
+    }
+  }
 }
 
 int main() {
-    // 设置 SIGPIPE 信号处理
-    signal(SIGPIPE, sigpipe_handler);
+  // 设置 SIGPIPE 信号处理
+  signal(SIGPIPE, sigpipe_handler);
 
-    // 创建 FIFO
-    if (mkfifo(FIFO_PATH, 0666) == -1 && errno != EEXIST) {
-        perror("mkfifo failed");
-        exit(EXIT_FAILURE);
-    }
+  // 创建 FIFO
+  if (mkfifo(FIFO_PATH, 0666) == -1 && errno != EEXIST) {
+    perror("mkfifo failed");
+    exit(EXIT_FAILURE);
+  }
 
-    // 测试阻塞模式下的三种情况
-    // printf("========== Testing Blocking Mode ==========\n");
-    // test_case1(0); // 阻塞模式下没有读端
-    // test_case2(0); // 阻塞模式下读端断开
-    // test_case3(0); // 阻塞模式下读端存在
+  // 测试阻塞模式下的三种情况
+//   printf("========== Testing Blocking Mode ==========\n");
+//   run_tests(0); // 阻塞模式
 
-    // 测试非阻塞模式下的三种情况
-    printf("\n========== Testing Nonblocking Mode ==========\n");
-    test_case1(1); // 非阻塞模式下没有读端
-    test_case2(1); // 非阻塞模式下读端断开
-    test_case3(1); // 非阻塞模式下读端存在
+  // 测试非阻塞模式下的三种情况
+  printf("\n========== Testing Nonblocking Mode ==========\n");
+  run_tests(1); // 非阻塞模式
 
-    // 删除 FIFO
-    unlink(FIFO_PATH);
+  // 删除 FIFO
+  unlink(FIFO_PATH);
 
-    printf("\nAll tests completed.\n");
-    return 0;
+  printf("\nAll tests completed.\n");
+  return 0;
 }

--- a/user/dadk/config/test_fifo_write_0_1_0.toml
+++ b/user/dadk/config/test_fifo_write_0_1_0.toml
@@ -1,0 +1,41 @@
+# 用户程序名称
+name = "test_fifo_write"
+# 版本号
+version = "0.1.0"
+# 用户程序描述信息
+description = "一个用来测试fifo_write行为的app"
+
+# （可选）默认: false 是否只构建一次，如果为true，DADK会在构建成功后，将构建结果缓存起来，下次构建时，直接使用缓存的构建结果
+build-once = false
+#  (可选) 默认: false 是否只安装一次，如果为true，DADK会在安装成功后，不再重复安装
+install-once = false
+# 目标架构
+# 可选值："x86_64", "aarch64", "riscv64"
+target-arch = ["x86_64"]
+
+# 任务源
+[task-source]
+# 构建类型
+# 可选值："build-from_source", "install-from-prebuilt"
+type = "build-from-source"
+# 构建来源
+# "build_from_source" 可选值："git", "local", "archive"
+# "install_from_prebuilt" 可选值："local", "archive"
+source = "local"
+# 路径或URL
+source-path = "user/apps/test_fifo_write"
+
+# 构建相关信息
+[build]
+# （可选）构建命令
+build-command = "make install"
+
+# 安装相关信息
+[install]
+# （可选）安装到DragonOS的路径
+in-dragonos-path = "/"
+
+# clean相关信息
+[clean]
+# （可选）清除命令
+clean-command = "make clean"

--- a/user/dadk/config/test_fifo_write_0_1_0.toml
+++ b/user/dadk/config/test_fifo_write_0_1_0.toml
@@ -33,7 +33,7 @@ build-command = "make install"
 # 安装相关信息
 [install]
 # （可选）安装到DragonOS的路径
-in-dragonos-path = "/"
+in-dragonos-path = "/bin"
 
 # clean相关信息
 [clean]


### PR DESCRIPTION
测试结果：
**期望情况**
非阻塞模式下
```
========== Testing Nonblocking Mode ==========

--- Testing: No readers (FIFO never had readers) (nonblocking=1) ---
Result: Failed to open FIFO for writing (ENXIO: No readers).

--- Testing: Reader exists but disconnects (nonblocking=1) ---
Result: Write failed with EPIPE (no readers available).

--- Testing: Active reader exists (nonblocking=1) ---
Result: Write succeeded. Bytes written: 13
```
阻塞模式下
```
========== Testing Blocking Mode ==========

--- Testing: No readers (FIFO never had readers) (nonblocking=0) ---
Result: Failed to open FIFO for writing (ENXIO: No readers).

--- Testing: Reader exists but disconnects (nonblocking=0) ---
Result: Write failed with EPIPE (no readers available).

--- Testing: Active reader exists (nonblocking=0) ---
Result: Write succeeded. Bytes written: 13
```

**测试结果（截图）**
![image](https://github.com/user-attachments/assets/37f5de4f-703b-40ef-8331-602cb271cc06)
![image](https://github.com/user-attachments/assets/8210cec5-3729-4e28-a2ee-bcbe5d458168)
