### PR TITLE
fix: 修复无唤醒事件时,核心卡死在idle进程的问题

### DIFF
--- a/kernel/src/arch/x86_64/interrupt/handle.rs
+++ b/kernel/src/arch/x86_64/interrupt/handle.rs
@@ -43,7 +43,7 @@ unsafe extern "C" fn x86_64_do_irq(trap_frame: &mut TrapFrame, vector: u32) {
     }
     // 检测当前进程是否可被调度
     if (current_pcb_flags().contains(ProcessFlags::NEED_SCHEDULE))
-        && vector == APIC_TIMER_IRQ_NUM.data()
+        || vector == APIC_TIMER_IRQ_NUM.data()
     {
         __schedule(SchedMode::SM_PREEMPT);
     }


### PR DESCRIPTION
卡死原因是apic timer中断来的时候，未能执行调度导致卡死在idle.  如果某个中断（比如键盘）会触发process wakeup的，则会设置idle进程的need schedule位，于是就能调度了。

r? @xiaolin2004 @Samuka007 @GnoCiYeH 