### PR TITLE
fix: 修正IfaceCommon的bounds字段的锁使用问题&调度问题

### DIFF
--- a/kernel/src/arch/x86_64/interrupt/handle.rs
+++ b/kernel/src/arch/x86_64/interrupt/handle.rs
@@ -43,7 +43,7 @@ unsafe extern "C" fn x86_64_do_irq(trap_frame: &mut TrapFrame, vector: u32) {
     }
     // 检测当前进程是否可被调度
     if (current_pcb_flags().contains(ProcessFlags::NEED_SCHEDULE))
-        && vector == APIC_TIMER_IRQ_NUM.data()
+        || vector == APIC_TIMER_IRQ_NUM.data()
     {
         __schedule(SchedMode::SM_PREEMPT);
     }

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -244,11 +244,11 @@ impl IfaceCommon {
             self.poll_at_ms.store(0, Ordering::Relaxed);
         }
 
-        self.bounds.read().iter().for_each(|bound_socket| {
+        self.bounds.read_irqsave().iter().for_each(|bound_socket| {
             // incase our inet socket missed the event, we manually notify it each time we poll
             if has_events {
                 bound_socket.on_iface_events();
-                bound_socket
+                let _woke = bound_socket
                     .wait_queue()
                     .wakeup(Some(ProcessState::Blocked(true)));
             }

--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -212,7 +212,10 @@ impl Connecting {
         let result = *self.result.read_irqsave();
         match result {
             Connecting => (Inner::Connecting(self), Err(EAGAIN_OR_EWOULDBLOCK)),
-            Connected => (Inner::Established(Established { inner: self.inner }), Ok(())),
+            Connected => (
+                Inner::Established(Established { inner: self.inner }),
+                Ok(()),
+            ),
             Refused => (Inner::Init(Init::new_bound(self.inner)), Err(ECONNREFUSED)),
         }
     }

--- a/user/apps/http_server/main.c
+++ b/user/apps/http_server/main.c
@@ -17,6 +17,8 @@
 
 #define DEFAULT_PAGE "/index.html"
 
+static int request_counter = 0;
+
 int security_check(char *path)
 {
     // 检查路径是否包含 ..
@@ -214,7 +216,7 @@ int main(int argc, char const *argv[])
 
     while (1)
     {
-        printf("Waiting for a client...\n");
+        printf("[#%d] Waiting for a client...\n", request_counter++);
 
         // 等待并接受客户端连接
         if ((new_socket = accept(server_fd, (struct sockaddr *)&address, (socklen_t *)&addrlen)) < 0)


### PR DESCRIPTION
- 中断上下文内用到的锁,在外面要irqsave.
- 把主线调度的pr应用到当前分支: https://github.com/DragonOS-Community/DragonOS/pull/1063