### PR TITLE
fix: 解决进程退出时没有主动释放fdtable的问题

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -426,6 +426,7 @@ impl ProcessManager {
         }
         drop(thread);
         unsafe { pcb.basic_mut().set_user_vm(None) };
+        pcb.exit_files();
 
         // TODO 由于未实现进程组，tty记录的前台进程组等于当前进程，故退出前要置空
         // 后续相关逻辑需要在SYS_EXIT_GROUP系统调用中实现
@@ -1054,6 +1055,11 @@ impl ProcessControlBlock {
 
     pub fn set_nsproxy(&self, nsprsy: NsProxy) {
         *self.nsproxy.write() = nsprsy;
+    }
+
+    /// Exit fd table when process exit
+    fn exit_files(&self) {
+        self.basic.write_irqsave().set_fd_table(None);
     }
 }
 


### PR DESCRIPTION
会导致http server被kill时,pcb没有drop