### PR TITLE
fix: `page_align_up` overflow

### DIFF
--- a/kernel/src/libs/align.rs
+++ b/kernel/src/libs/align.rs
@@ -132,7 +132,7 @@ unsafe impl<const NUM: usize> SafeForZero for [u8; NUM] {}
 /// 返回值：对齐后的地址。
 pub const fn page_align_up(addr: usize) -> usize {
     let page_size = MMArch::PAGE_SIZE;
-    return (addr + page_size - 1) & (!(page_size - 1));
+    return addr.wrapping_add(page_size - 1) & (!(page_size - 1));
 }
 
 pub const fn page_align_down(addr: usize) -> usize {


### PR DESCRIPTION
Fix #1077 by using `wrapping_add`.

However, RedoxOS and Asterinas use `checked_add`.
But change to `checked_add` in DragonOS will lead to a lot of code changes.

https://gitlab.redox-os.org/redox-os/relibc/-/merge_requests/569

https://github.com/asterinas/asterinas/blob/c0e572becdac63d814b460875dccb9d833d2b06d/ostd/libs/align_ext/src/lib.rs#L51-L54