### PR TITLE
fix: TCP socket miss activation after close

### DIFF
--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -285,6 +285,14 @@ impl IfaceCommon {
         self.bounds.write().push(socket);
     }
 
+    pub fn unbind_socket(&self, socket: Arc<dyn InetSocket>) {
+        let mut bounds = self.bounds.write();
+        if let Some(index) = bounds.iter().position(|s| Arc::ptr_eq(s, &socket)) {
+            bounds.remove(index);
+            log::debug!("unbind socket success");
+        }
+    }
+
     // TODO: 需要在inet实现多网卡监听或路由子系统实现后移除
     pub fn is_default_iface(&self) -> bool {
         self.default_iface

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -60,8 +60,10 @@ fn dhcp_query() -> Result<(), SystemError> {
 
     let sockets = || net_face.sockets().lock_irqsave();
 
-    // let dhcp_handle = SOCKET_SET.lock_irqsave().add(dhcp_socket);
     let dhcp_handle = sockets().add(dhcp_socket);
+    defer::defer!({
+        sockets().remove(dhcp_handle);
+    });
 
     const DHCP_TRY_ROUND: u8 = 100;
     for i in 0..DHCP_TRY_ROUND {

--- a/kernel/src/net/socket/common/shutdown.rs
+++ b/kernel/src/net/socket/common/shutdown.rs
@@ -124,7 +124,7 @@ impl TryFrom<usize> for ShutdownTemp {
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
         match value {
-            0 | 1 | 2 => Ok(ShutdownTemp {
+            0..2 => Ok(ShutdownTemp {
                 bit: value as u8 + 1,
             }),
             _ => Err(SystemError::EINVAL),

--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -53,11 +53,11 @@ impl BoundInner {
                 })
                 .expect("No default interface");
 
-            let handle = iface.sockets().lock_no_preempt().add(socket);
+            let handle = iface.sockets().lock_irqsave().add(socket);
             return Ok(Self { handle, iface });
         } else {
             let iface = get_iface_to_bind(address).ok_or(ENODEV)?;
-            let handle = iface.sockets().lock_no_preempt().add(socket);
+            let handle = iface.sockets().lock_irqsave().add(socket);
             return Ok(Self { handle, iface });
         }
     }

--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -355,6 +355,13 @@ impl Listening {
             .port_manager()
             .unbind_port(Types::Tcp, port);
     }
+
+    pub fn release(&self) {
+        // log::debug!("Release Listening Socket");
+        for inner in self.inners.iter() {
+            inner.release();
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The miss activation after close of TCP cause system panic at network interupt arrive, though which should be ignored.

Now the behavior still kind of weird, the first query to the virtio "reset" after a short period of time, but the following query after the first one is immediate reset. Also, the default "reset" behavior seems not the correct behavior when you access a "non exist" server. Need further investegation.

The UDP socket seems not correctly closed.

TCP socket still couldn't connect a remote socket.

The test case "test-backlog" with actix-web runtime is still unable to run.