### PR TITLE
fix: 在插入新的timer时,边界条件判断不正确的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cppcheck.xml
 Cargo.lock
 .cache
 compile_commands.json
+/logs/

--- a/kernel/src/time/timer.rs
+++ b/kernel/src/time/timer.rs
@@ -157,7 +157,7 @@ impl Timer {
         let expire_jiffies = inner_guard.expire_jiffies;
         let self_arc = inner_guard.self_ref.upgrade().unwrap();
         drop(inner_guard);
-        let mut split_pos: usize = 0;
+        let mut split_pos: usize = timer_list.len();
         for (pos, elt) in timer_list.iter().enumerate() {
             if Arc::ptr_eq(&self_arc, &elt.1) {
                 warn!("Timer already in list");


### PR DESCRIPTION
修复split_pos 初始值错误导致原本应该被插入到链表末尾的定时器,插入到了链表头