### PR TITLE
feat: 打开clippy的stack overflow静态检查

### DIFF
--- a/kernel/.clippy.toml
+++ b/kernel/.clippy.toml
@@ -1,2 +1,4 @@
 # 这是clippy的配置文件，详情请见：
 # https://doc.rust-lang.org/clippy/lint_configuration.html
+stack-size-threshold = 4096
+array-size-threshold = 1024

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -24,6 +24,8 @@
 #![allow(static_mut_refs, non_local_definitions, internal_features)]
 // clippy的配置
 #![deny(clippy::all)]
+#![deny(clippy::large_stack_frames)]
+#![deny(clippy::large_const_arrays)]
 // DragonOS允许在函数中使用return语句（尤其是长函数时，我们推荐这么做）
 #![allow(
     clippy::macro_metavars_in_unsafe,


### PR DESCRIPTION
*限制栈大小最大为4096字节
*限制栈中的数组最大为1024字节