### PR TITLE
fix syscall_ebpf compile fail

### DIFF
--- a/user/apps/syscall_ebpf/syscall_ebpf-ebpf/rust-toolchain.toml
+++ b/user/apps/syscall_ebpf/syscall_ebpf-ebpf/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-11-05"
 components = ["rust-src"]


### PR DESCRIPTION
【问题描述】
修复在工具链老旧导致的syscall_ebpf应用程序编译报错问题
其中编译报错如下：
  --- stderr
  thread 'main' panicked at syscall_ebpf/build.rs:131:9:
  assertion `left == right` failed

【具体修复】
指定syscall_ebpf应用程序编译时的工具链为特定版本

【自测结果】
syscall_ebpf应用程序编译成功