### PR TITLE
feat(la64): 实现了较为早期的la64的异常处理的注册

### DIFF
--- a/kernel/crates/asm_macros/src/lib.rs
+++ b/kernel/crates/asm_macros/src/lib.rs
@@ -5,3 +5,6 @@ pub mod x86_64;
 
 #[cfg(target_arch = "riscv64")]
 pub mod riscv64;
+
+#[cfg(target_arch = "loongarch64")]
+pub mod loongarch64;

--- a/kernel/crates/asm_macros/src/loongarch64/context.rs
+++ b/kernel/crates/asm_macros/src/loongarch64/context.rs
@@ -1,0 +1,280 @@
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#48
+#[macro_export]
+macro_rules! backup_t0t1 {
+    () => {
+        concat!(
+            "
+            csrwr $t0, {exception_ks0}
+            csrwr $t1, {exception_ks1}
+        "
+        )
+    };
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#53
+#[macro_export]
+macro_rules! reload_t0t1 {
+    () => {
+        concat!(
+            "
+            csrrd $t0, {exception_ks0}
+            csrrd $t1, {exception_ks1}
+        "
+        )
+    };
+}
+
+/// get_saved_sp returns the SP for the current CPU by looking in the
+/// kernelsp array for it. It stores the current sp in t0 and loads the
+/// new value in sp.
+///
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h?r=&mo=2487&fi=119#88
+#[macro_export]
+macro_rules! get_saved_sp {
+    () => {
+        concat!(
+            "
+            la.abs $t1, KERNEL_SP
+            csrrd $t0, {percpu_base_ks}
+            add.d $t1, $t1, $t0
+
+            move $t0, $sp
+            ld.d $sp, $t1, 0
+        "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h?r=&mo=2487&fi=119#101
+#[macro_export]
+macro_rules! set_saved_sp {
+    ($stackp:tt, $temp:tt) => {
+        concat!(
+            "la.pcrel ",
+            stringify!($temp),
+            ", KERNEL_SP\n",
+            "add.d ",
+            stringify!($temp),
+            ", ",
+            stringify!($temp),
+            ", $r21\n",
+            "st.d ",
+            stringify!($stackp),
+            ", ",
+            stringify!($temp),
+            ", 0\n"
+        )
+    };
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#109
+#[macro_export]
+macro_rules! save_some {
+    () => {
+        concat!(
+            "
+            csrrd $t1, {loongarch_csr_prmd}
+            andi	$t1, $t1, 0x3
+            move $t0, $sp
+            beqz $t1, 3f
+
+        ",
+            get_saved_sp!(),
+        "
+        3:
+            addi.d $sp, $sp, -{pt_size}
+        
+
+            st.d $t0, $sp, {off_usp} // 等价于 cfi_st	t0, PT_R3, docfi=0
+
+            st.d $zero, $sp, {off_r0}
+            csrrd $t0, {loongarch_csr_prmd}
+            st.d $t0, $sp, {off_csr_prmd}
+            csrrd $t0, {loongarch_csr_crmd}
+            st.d $t0, $sp, {off_csr_crmd}
+            csrrd $t0, {loongarch_csr_euen}
+            st.d $t0, $sp, {off_csr_euen}
+            csrrd $t0, {loongarch_csr_ecfg}
+            st.d $t0, $sp, {off_csr_ecfg}
+            csrrd $t0, {loongarch_csr_estat}
+            st.d $t0, $sp, {off_csr_estat}
+
+            st.d $ra, $sp, {off_ra}
+            st.d $a0, $sp, {off_a0}
+            st.d $a1, $sp, {off_a1}
+            st.d $a2, $sp, {off_a2}
+            st.d $a3, $sp, {off_a3}
+            st.d $a4, $sp, {off_a4}
+            st.d $a5, $sp, {off_a5}
+            st.d $a6, $sp, {off_a6}
+            st.d $a7, $sp, {off_a7}
+
+            csrrd $ra, {loongarch_csr_era}
+            st.d $ra, $sp, {off_csr_era}
+
+            st.d $tp, $sp, {off_tp}
+            st.d $fp, $sp, {off_fp}
+
+            /* Set thread_info if we're coming from user mode */
+            csrrd $t0, {loongarch_csr_prmd}
+            andi $t0, $t0, 0x3
+            beqz $t0, 9f
+
+            li.d $tp, ~{thread_mask}
+            and $tp, $tp, $sp
+            st.d $r21, $sp, {off_r21}
+            csrrd $r21, {percpu_base_ks}
+            9:
+        "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#197
+#[macro_export]
+macro_rules! restore_some {
+    () => {
+        concat!(
+            "
+            ld.d $a0, $sp, {off_csr_prmd}
+            // extract pplv bit
+            andi $a0, $a0, 0x3
+            beqz $a0, 4f
+            ld.d $r21, $sp, {off_r21}
+
+            4:
+            ld.d $a0, $sp, {off_csr_era}
+            csrwr $a0, {loongarch_csr_era}
+            ld.d $a0, $sp, {off_csr_prmd}
+            csrwr $a0, {loongarch_csr_prmd}
+            ld.d $ra, $sp, {off_ra}
+            ld.d $a0, $sp, {off_a0}
+            ld.d $a1, $sp, {off_a1}
+            ld.d $a2, $sp, {off_a2}
+            ld.d $a3, $sp, {off_a3}
+            ld.d $a4, $sp, {off_a4}
+            ld.d $a5, $sp, {off_a5}
+            ld.d $a6, $sp, {off_a6}
+            ld.d $a7, $sp, {off_a7}
+            ld.d $tp, $sp, {off_tp}
+            ld.d $fp, $sp, {off_fp}
+            "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#58
+#[macro_export]
+macro_rules! save_temp {
+    () => {
+        concat!(
+            reload_t0t1!(),
+            "
+            st.d $t0, $sp, {off_t0}
+            st.d $t1, $sp, {off_t1}
+            st.d $t2, $sp, {off_t2}
+            st.d $t3, $sp, {off_t3}
+            st.d $t4, $sp, {off_t4}
+            st.d $t5, $sp, {off_t5}
+            st.d $t6, $sp, {off_t6}
+            st.d $t7, $sp, {off_t7}
+            st.d $t8, $sp, {off_t8}
+            "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#173
+#[macro_export]
+macro_rules! restore_temp {
+    () => {
+        concat!(
+            reload_t0t1!(),
+            "
+            ld.d $t0, $sp, {off_t0}
+            ld.d $t1, $sp, {off_t1}
+            ld.d $t2, $sp, {off_t2}
+            ld.d $t3, $sp, {off_t3}
+            ld.d $t4, $sp, {off_t4}
+            ld.d $t5, $sp, {off_t5}
+            ld.d $t6, $sp, {off_t6}
+            ld.d $t7, $sp, {off_t7}
+            ld.d $t8, $sp, {off_t8}
+            "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#71
+#[macro_export]
+macro_rules! save_static {
+    () => {
+        concat!(
+            "
+            st.d $s0, $sp, {off_s0}
+            st.d $s1, $sp, {off_s1}
+            st.d $s2, $sp, {off_s2}
+            st.d $s3, $sp, {off_s3}
+            st.d $s4, $sp, {off_s4}
+            st.d $s5, $sp, {off_s5}
+            st.d $s6, $sp, {off_s6}
+            st.d $s7, $sp, {off_s7}
+            st.d $s8, $sp, {off_s8}
+            "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#185
+#[macro_export]
+macro_rules! restore_static {
+    () => {
+        concat!(
+            "
+            ld.d $s0, $sp, {off_s0}
+            ld.d $s1, $sp, {off_s1}
+            ld.d $s2, $sp, {off_s2}
+            ld.d $s3, $sp, {off_s3}
+            ld.d $s4, $sp, {off_s4}
+            ld.d $s5, $sp, {off_s5}
+            ld.d $s6, $sp, {off_s6}
+            ld.d $s7, $sp, {off_s7}
+            ld.d $s8, $sp, {off_s8}
+            "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#167
+#[macro_export]
+macro_rules! save_all {
+    () => {
+        concat!(save_some!(), "\n", save_temp!(), "\n", save_static!(),)
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#220
+#[macro_export]
+macro_rules! restore_sp_and_ret {
+    () => {
+        concat!(
+            "
+            ld.d $sp, $sp, {off_usp}
+            ertn
+            "
+        )
+    };
+}
+
+/// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/include/asm/stackframe.h#225
+#[macro_export]
+macro_rules! restore_all_and_ret {
+    () => {
+        concat!(
+            restore_static!(),
+            restore_temp!(),
+            restore_some!(),
+            restore_sp_and_ret!()
+        )
+    };
+}

--- a/kernel/crates/asm_macros/src/loongarch64/mod.rs
+++ b/kernel/crates/asm_macros/src/loongarch64/mod.rs
@@ -1,0 +1,1 @@
+pub mod context;

--- a/kernel/src/arch/loongarch64/asm/mod.rs
+++ b/kernel/src/arch/loongarch64/asm/mod.rs
@@ -1,2 +1,44 @@
+use crate::process::KernelStack;
+
 pub mod bitops;
 pub mod boot;
+
+/* KSave registers */
+pub const LOONGARCH_CSR_KS0: usize = 0x30;
+pub const LOONGARCH_CSR_KS1: usize = 0x31;
+pub const LOONGARCH_CSR_KS2: usize = 0x32;
+pub const LOONGARCH_CSR_KS3: usize = 0x33;
+pub const LOONGARCH_CSR_KS4: usize = 0x34;
+pub const LOONGARCH_CSR_KS5: usize = 0x35;
+pub const LOONGARCH_CSR_KS6: usize = 0x36;
+pub const LOONGARCH_CSR_KS7: usize = 0x37;
+pub const LOONGARCH_CSR_KS8: usize = 0x38;
+
+/// Current mode info
+pub const LOONGARCH_CSR_CRMD: usize = 0x0;
+/// Prev-exception mode info
+pub const LOONGARCH_CSR_PRMD: usize = 0x1;
+
+/// Extended unit enable
+pub const LOONGARCH_CSR_EUEN: usize = 0x2;
+
+/// Exception config
+pub const LOONGARCH_CSR_ECFG: usize = 0x4;
+/// Exception status
+pub const LOONGARCH_CSR_ESTAT: usize = 0x5;
+
+/// Exception return address.
+pub const LOONGARCH_CSR_ERA: usize = 0x6;
+
+/// Bad virtual address.
+pub const LOONGARCH_CSR_BADV: usize = 0x7;
+
+/* Exception allocated KS0, KS1 and KS2 statically */
+pub const EXCEPTION_KS0: usize = LOONGARCH_CSR_KS0;
+pub const EXCEPTION_KS1: usize = LOONGARCH_CSR_KS1;
+
+/* Percpu-data base allocated KS3 statically */
+pub const PERCPU_BASE_KS: usize = LOONGARCH_CSR_KS3;
+pub const PERCPU_KSAVE_MASK: usize = 1 << 3;
+
+pub const _THREAD_MASK: usize = KernelStack::SIZE - 1;

--- a/kernel/src/arch/loongarch64/cpu.rs
+++ b/kernel/src/arch/loongarch64/cpu.rs
@@ -1,4 +1,4 @@
-use crate::smp::cpu::ProcessorId;
+use crate::{mm::percpu::PerCpu, smp::cpu::ProcessorId};
 
 /// 重置cpu
 pub unsafe fn cpu_reset() -> ! {
@@ -13,3 +13,6 @@ pub unsafe fn cpu_reset() -> ! {
 pub fn current_cpu_id() -> ProcessorId {
     ProcessorId::new(loongArch64::register::cpuid::read().core_id() as u32)
 }
+
+#[no_mangle]
+pub static mut KERNEL_SP: [usize; PerCpu::MAX_CPU_NUM as usize] = [0; PerCpu::MAX_CPU_NUM as usize];

--- a/kernel/src/arch/loongarch64/init/boot.rs
+++ b/kernel/src/arch/loongarch64/init/boot.rs
@@ -1,6 +1,6 @@
 use loongArch64::register::{ecfg, eentry};
 
-use crate::{init::init::start_kernel, mm::PhysAddr};
+use crate::{arch::interrupt::entry::handle_reserved_, init::init::start_kernel, mm::PhysAddr};
 
 static mut BOOT_HARTID: u32 = 0;
 static mut BOOT_FDT_PADDR: PhysAddr = PhysAddr::new(0);
@@ -15,16 +15,19 @@ pub unsafe extern "C" fn kernel_main(hartid: usize, fdt_paddr: usize) -> ! {
         BOOT_HARTID = hartid as u32;
         BOOT_FDT_PADDR = fdt_paddr;
     }
-    setup_trap_vector();
+    boot_tmp_setup_trap_vector();
+
     start_kernel();
 }
 
-/// 设置中断、异常处理函数
-fn setup_trap_vector() {
-    // todo!();
-    // let ptr = handle_exception as *const () as usize;
-    // ecfg::set_vs(0);
-    // eentry::set_eentry(handle_exception as usize);
+/// 临时设置中断、异常处理函数
+///
+/// 后续需要通过 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#1085
+/// 这里的这个函数来重新设置中断、异常处理函数
+fn boot_tmp_setup_trap_vector() {
+    let ptr = handle_reserved_ as *const () as usize;
+    ecfg::set_vs(0);
+    eentry::set_eentry(ptr);
 }
 
 /// Clear the bss section

--- a/kernel/src/arch/loongarch64/init/mod.rs
+++ b/kernel/src/arch/loongarch64/init/mod.rs
@@ -1,4 +1,6 @@
 use system_error::SystemError;
+
+use crate::driver::serial::serial8250::send_to_default_serial8250_port;
 pub mod boot;
 
 #[derive(Debug)]
@@ -10,6 +12,8 @@ impl ArchBootParams {
 
 #[inline(never)]
 pub fn early_setup_arch() -> Result<(), SystemError> {
+    send_to_default_serial8250_port(b"la64:early_setup_arch");
+    loop {}
     todo!("la64:early_setup_arch");
 }
 

--- a/kernel/src/arch/loongarch64/interrupt/entry.rs
+++ b/kernel/src/arch/loongarch64/interrupt/entry.rs
@@ -1,0 +1,145 @@
+use asm_macros::{
+    backup_t0t1, get_saved_sp, reload_t0t1, restore_all_and_ret, restore_some, restore_sp_and_ret,
+    restore_static, restore_temp, save_all, save_some, save_static, save_temp,
+};
+use kdepends::memoffset::offset_of;
+
+use crate::{
+    arch::{
+        asm::{
+            EXCEPTION_KS0, EXCEPTION_KS1, LOONGARCH_CSR_BADV, LOONGARCH_CSR_CRMD,
+            LOONGARCH_CSR_ECFG, LOONGARCH_CSR_ERA, LOONGARCH_CSR_ESTAT, LOONGARCH_CSR_EUEN,
+            LOONGARCH_CSR_PRMD, PERCPU_BASE_KS, _THREAD_MASK,
+        },
+        interrupt::TrapFrame,
+    },
+    driver::serial::serial8250::send_to_default_serial8250_port,
+};
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/genex.S#55
+macro_rules! build_prep_badv_ {
+    () => {
+        concat!(
+            "
+        csrrd $t0, {loongarch_csr_badv}
+        st.d $t0, $sp, {off_csr_badvaddr}
+        "
+        )
+    };
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/genex.S#60
+macro_rules! build_prep_fcsr_ {
+    () => {
+        concat!(
+            "
+        movfcsr2gr	$a1, $fcsr0
+        "
+        )
+    };
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/genex.S#64
+macro_rules! build_prep_none_ {
+    () => {
+        ""
+    };
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/genex.S#67
+macro_rules! build_handler {
+    ($exception:expr, $handler:expr, $prep:ident) => {
+        paste::paste! {
+            /// handle exception的实现请参考 https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/genex.S#69
+            #[naked]
+            #[no_mangle]
+            #[repr(align(8))]
+            pub unsafe extern "C" fn [<handle_ $exception _>]() -> ! {
+                core::arch::naked_asm!(concat!(
+                    backup_t0t1!(),
+                    save_all!(),
+                    [<build_prep_ $prep _>]!(),
+                    "
+                    move $a0, $sp
+                    la.abs $t0, ", stringify!([<do_ $handler _>]),
+                    "
+                    jirl $ra, $t0, 0
+                    ",
+                    restore_all_and_ret!(),
+                    "
+                    // 以下是为了编译器不报错说变量未使用，才保留的代码
+                        /* {off_csr_badvaddr} */
+                        /* {loongarch_csr_badv} */
+                    "
+                ),
+                exception_ks0 = const EXCEPTION_KS0,
+                exception_ks1 = const EXCEPTION_KS1,
+                loongarch_csr_prmd = const LOONGARCH_CSR_PRMD,
+                loongarch_csr_crmd = const LOONGARCH_CSR_CRMD,
+                loongarch_csr_euen = const LOONGARCH_CSR_EUEN,
+                loongarch_csr_ecfg = const LOONGARCH_CSR_ECFG,
+                loongarch_csr_estat = const LOONGARCH_CSR_ESTAT,
+                loongarch_csr_era = const LOONGARCH_CSR_ERA,
+                loongarch_csr_badv = const LOONGARCH_CSR_BADV,
+                percpu_base_ks = const PERCPU_BASE_KS,
+                thread_mask = const _THREAD_MASK,
+                pt_size = const core::mem::size_of::<TrapFrame>(),
+                off_r0 = const offset_of!(TrapFrame, r0),
+                off_ra = const offset_of!(TrapFrame, ra),
+                off_tp = const offset_of!(TrapFrame, tp),
+                off_usp = const offset_of!(TrapFrame, usp),
+                off_a0 = const offset_of!(TrapFrame, a0),
+                off_a1 = const offset_of!(TrapFrame, a1),
+                off_a2 = const offset_of!(TrapFrame, a2),
+                off_a3 = const offset_of!(TrapFrame, a3),
+                off_a4 = const offset_of!(TrapFrame, a4),
+                off_a5 = const offset_of!(TrapFrame, a5),
+                off_a6 = const offset_of!(TrapFrame, a6),
+                off_a7 = const offset_of!(TrapFrame, a7),
+                off_t0 = const offset_of!(TrapFrame, t0),
+                off_t1 = const offset_of!(TrapFrame, t1),
+                off_t2 = const offset_of!(TrapFrame, t2),
+                off_t3 = const offset_of!(TrapFrame, t3),
+                off_t4 = const offset_of!(TrapFrame, t4),
+                off_t5 = const offset_of!(TrapFrame, t5),
+                off_t6 = const offset_of!(TrapFrame, t6),
+                off_t7 = const offset_of!(TrapFrame, t7),
+                off_t8 = const offset_of!(TrapFrame, t8),
+                off_r21 = const offset_of!(TrapFrame, r21),
+                off_fp = const offset_of!(TrapFrame, fp),
+                off_s0 = const offset_of!(TrapFrame, s0),
+                off_s1 = const offset_of!(TrapFrame, s1),
+                off_s2 = const offset_of!(TrapFrame, s2),
+                off_s3 = const offset_of!(TrapFrame, s3),
+                off_s4 = const offset_of!(TrapFrame, s4),
+                off_s5 = const offset_of!(TrapFrame, s5),
+                off_s6 = const offset_of!(TrapFrame, s6),
+                off_s7 = const offset_of!(TrapFrame, s7),
+                off_s8 = const offset_of!(TrapFrame, s8),
+                // off_orig_a0 = const offset_of!(TrapFrame, orig_a0),
+                off_csr_era = const offset_of!(TrapFrame, csr_era),
+                off_csr_badvaddr = const offset_of!(TrapFrame, csr_badvaddr),
+                off_csr_crmd = const offset_of!(TrapFrame, csr_crmd),
+                off_csr_prmd = const offset_of!(TrapFrame, csr_prmd),
+                off_csr_euen = const offset_of!(TrapFrame, csr_euen),
+                off_csr_ecfg = const offset_of!(TrapFrame, csr_ecfg),
+                off_csr_estat = const offset_of!(TrapFrame, csr_estat),
+                )
+            }
+
+        }
+    };
+}
+
+build_handler!(ade, ade, badv);
+build_handler!(ale, ale, badv);
+build_handler!(bce, bce, none);
+build_handler!(bp, bp, none);
+build_handler!(fpe, fpe, fcsr);
+build_handler!(fpu, fpu, none);
+build_handler!(lsx, lsx, none);
+build_handler!(lasx, lasx, none);
+build_handler!(lbt, lbt, none);
+build_handler!(ri, ri, none);
+build_handler!(watch, watch, none);
+build_handler!(reserved, reserved, none); /* others */

--- a/kernel/src/arch/loongarch64/interrupt/entry.rs
+++ b/kernel/src/arch/loongarch64/interrupt/entry.rs
@@ -1,20 +1,7 @@
-use asm_macros::{
-    backup_t0t1, get_saved_sp, reload_t0t1, restore_all_and_ret, restore_some, restore_sp_and_ret,
-    restore_static, restore_temp, save_all, save_some, save_static, save_temp,
-};
+use asm_macros::*;
 use kdepends::memoffset::offset_of;
 
-use crate::{
-    arch::{
-        asm::{
-            EXCEPTION_KS0, EXCEPTION_KS1, LOONGARCH_CSR_BADV, LOONGARCH_CSR_CRMD,
-            LOONGARCH_CSR_ECFG, LOONGARCH_CSR_ERA, LOONGARCH_CSR_ESTAT, LOONGARCH_CSR_EUEN,
-            LOONGARCH_CSR_PRMD, PERCPU_BASE_KS, _THREAD_MASK,
-        },
-        interrupt::TrapFrame,
-    },
-    driver::serial::serial8250::send_to_default_serial8250_port,
-};
+use crate::arch::{asm::*, interrupt::TrapFrame};
 
 /// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/genex.S#55
 macro_rules! build_prep_badv_ {

--- a/kernel/src/arch/loongarch64/interrupt/handle.rs
+++ b/kernel/src/arch/loongarch64/interrupt/handle.rs
@@ -1,0 +1,87 @@
+use crate::driver::serial::serial8250::send_to_default_serial8250_port;
+
+use super::TrapFrame;
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#508
+#[no_mangle]
+unsafe extern "C" fn do_ade_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_ade_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#522
+#[no_mangle]
+unsafe extern "C" fn do_ale_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_ale_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#583
+#[no_mangle]
+unsafe extern "C" fn do_bce_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_bce_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#672
+#[no_mangle]
+unsafe extern "C" fn do_bp_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_bp_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#481
+#[no_mangle]
+unsafe extern "C" fn do_fpe_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_fpe_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#904
+#[no_mangle]
+unsafe extern "C" fn do_fpu_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_fpu_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#921
+#[no_mangle]
+unsafe extern "C" fn do_lsx_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_lsx_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#943
+#[no_mangle]
+unsafe extern "C" fn do_lasx_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_lasx_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#978
+#[no_mangle]
+unsafe extern "C" fn do_lbt_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_lbt_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#809
+#[no_mangle]
+unsafe extern "C" fn do_ri_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_ri_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#756
+#[no_mangle]
+unsafe extern "C" fn do_watch_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_watch_()\n");
+    loop {}
+}
+
+/// https://code.dragonos.org.cn/xref/linux-6.6.21/arch/loongarch/kernel/traps.c#1009
+#[no_mangle]
+unsafe extern "C" fn do_reserved_(frame: *mut TrapFrame) {
+    send_to_default_serial8250_port(b"la64: do_reserved_()\n");
+    // loop {}
+}

--- a/kernel/src/arch/loongarch64/interrupt/mod.rs
+++ b/kernel/src/arch/loongarch64/interrupt/mod.rs
@@ -1,3 +1,5 @@
+pub mod entry;
+mod handle;
 pub mod ipi;
 
 use core::any::Any;

--- a/kernel/src/arch/loongarch64/link.ld
+++ b/kernel/src/arch/loongarch64/link.ld
@@ -21,7 +21,6 @@ SECTIONS
 		*(.bootstrap.*)
 		. = ALIGN(4096);
 		*(.initial_pgtable_section)
-		. = ALIGN(4096);
 	}
 
 
@@ -68,7 +67,7 @@ SECTIONS
 	. = ALIGN(32768);
 	
 	trace_point_start_pa = .;
-	.tracepoint (trace_point_start_pa): AT(trace_point_start_pa - KERNEL_VMA)
+	.tracepoint (trace_point_start_pa):
     {
         _tracepoint = .;
         *(.tracepoint)


### PR DESCRIPTION
- 栈保存&恢复
- 开机时临时设置异常处理程序,并验证可进入异常处理程序 (通过临时编写break 0 的asm是可以验证能进入do_reserved_())

汇编代码借鉴了linux 6.6.21的。

todo: 接下来会在后续的pr逐步完善la64启动时的异常、中断处理功能（与linux保持一致）
