### PR TITLE
fix(page_cache): 修复pagecache无法直接mmap然后读写文件的bug

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -272,6 +272,8 @@ impl X86_64MMArch {
                         address.data(),
                         flags
                     );
+                    log::error!("fault rip: {:#x}", regs.rip);
+
                     let pid = ProcessManager::current_pid();
                     let mut info =
                         SigInfo::new(Signal::SIGSEGV, 0, SigCode::User, SigType::Kill(pid));

--- a/kernel/src/driver/base/device/driver.rs
+++ b/kernel/src/driver/base/device/driver.rs
@@ -171,6 +171,7 @@ impl dyn Driver {
     /// ## 注意
     ///
     /// 这里的默认实现很低效，请为特定的驱动自行实现高效的查询
+    #[inline(never)]
     pub fn find_device_by_name(&self, name: &str) -> Option<Arc<dyn Device>> {
         if let Some(r) = self.__find_device_by_name_fast(name) {
             return Some(r);

--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -72,7 +72,7 @@ pub fn virtio_console(
     log::debug!(
         "virtio_console: dev_id: {:?}, parent: {:?}",
         dev_id,
-        dev_parent
+        dev_parent.as_ref().map(|x| x.name())
     );
     let device = VirtIOConsoleDevice::new(transport, dev_id.clone());
     if device.is_none() {
@@ -576,9 +576,7 @@ impl Driver for VirtIOConsoleDriver {
             virtio_con_dev.dev_id(),
         );
         }
-        log::debug!("virtio console: add_device: to lock inner");
         let mut inner = self.inner();
-        log::debug!("virtio console: add_device: inner.locked");
         let dev_name = inner.alloc_id();
         if dev_name.is_none() {
             panic!("Failed to allocate ID for VirtIO console device: '{:?}', virtio console device limit exceeded.", virtio_con_dev.dev_id())

--- a/kernel/src/driver/pci/pci.rs
+++ b/kernel/src/driver/pci/pci.rs
@@ -1063,7 +1063,12 @@ pub fn pci_init() {
         let common_header = box_pci_device.common_header();
         match box_pci_device.header_type() {
             HeaderType::Standard if common_header.status & 0x10 != 0 => {
-                info!("Found pci standard device with class code ={} subclass={} status={:#x} cap_pointer={:#x}  vendor={:#x}, device id={:#x},bdf={}", common_header.class_code, common_header.subclass, common_header.status, box_pci_device.as_standard_device().unwrap().capabilities_pointer,common_header.vendor_id, common_header.device_id,common_header.bus_device_function);
+                info!(
+                    "Found pci standard device with class code ={} subclass={}, bdf={}",
+                    common_header.class_code,
+                    common_header.subclass,
+                    common_header.bus_device_function
+                );
             }
             HeaderType::Standard => {
                 info!(

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -99,6 +99,7 @@ impl TtyLdiscManager {
     /// ### 参数
     /// - tty：需要设置的tty
     /// - o_tty: other tty 用于pty pair
+    #[inline(never)]
     pub fn ldisc_setup(tty: Arc<TtyCore>, o_tty: Option<Arc<TtyCore>>) -> Result<(), SystemError> {
         let ld = tty.ldisc();
 

--- a/kernel/src/driver/virtio/sysfs.rs
+++ b/kernel/src/driver/virtio/sysfs.rs
@@ -196,7 +196,7 @@ impl VirtIODeviceManager {
         dev.set_virtio_device_index(virtio_index);
         dev.set_device_name(format!("virtio{}", virtio_index.data()));
 
-        log::debug!("virtio_device_add: dev: {:?}", dev);
+        log::debug!("virtio_device_add: dev: {:?}", dev.name());
         // 添加设备到设备管理器
         device_manager().add_device(dev.clone() as Arc<dyn Device>)?;
         let r = device_manager()

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -268,6 +268,7 @@ impl PageFaultHandler {
     ///
     /// ## 返回值
     /// - VmFaultReason: 页面错误处理信息标志
+    #[inline(never)]
     pub unsafe fn do_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
         if !pfm.flags().contains(FaultFlags::FAULT_FLAG_WRITE) {
             Self::do_read_fault(pfm)
@@ -291,6 +292,7 @@ impl PageFaultHandler {
     ///
     /// ## 返回值
     /// - VmFaultReason: 页面错误处理信息标志
+    #[inline(never)]
     pub unsafe fn do_cow_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
         let mut ret = Self::filemap_fault(pfm);
 
@@ -351,6 +353,7 @@ impl PageFaultHandler {
     ///
     /// ## 返回值
     /// - VmFaultReason: 页面错误处理信息标志
+    #[inline(never)]
     pub unsafe fn do_shared_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
         let mut ret = Self::filemap_fault(pfm);
 
@@ -411,6 +414,7 @@ impl PageFaultHandler {
     ///
     /// ## 返回值
     /// - VmFaultReason: 页面错误处理信息标志
+    #[inline(never)]
     pub unsafe fn do_wp_page(pfm: &mut PageFaultMessage) -> VmFaultReason {
         let address = pfm.address_aligned_down();
         let vma = pfm.vma.clone();
@@ -538,7 +542,7 @@ impl PageFaultHandler {
         let to_pte = min(
             from_pte + fault_around_page_number,
             min(
-                1 << MMArch::PAGE_SHIFT,
+                MMArch::PAGE_ENTRY_NUM,
                 pte_pgoff + (vma_pages_count - vm_pgoff),
             ),
         );
@@ -587,7 +591,7 @@ impl PageFaultHandler {
                     .expect("file_page_offset is none"))
                 << MMArch::PAGE_SHIFT);
 
-        for pgoff in start_pgoff..=end_pgoff {
+        for pgoff in start_pgoff..end_pgoff {
             if let Some(page) = page_cache.lock_irqsave().get_page(pgoff) {
                 let page_guard = page.read_irqsave();
                 if page_guard.flags().contains(PageFlags::PG_UPTODATE) {

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -380,19 +380,21 @@ impl PageReclaimer {
             MMArch::PAGE_SIZE
         };
 
-        inode
-            .write_direct(
-                page_index * MMArch::PAGE_SIZE,
-                len,
-                unsafe {
-                    core::slice::from_raw_parts(
-                        MMArch::phys_2_virt(paddr).unwrap().data() as *mut u8,
-                        len,
-                    )
-                },
-                SpinLock::new(FilePrivateData::Unused).lock(),
-            )
-            .unwrap();
+        if len > 0 {
+            inode
+                .write_direct(
+                    page_index * MMArch::PAGE_SIZE,
+                    len,
+                    unsafe {
+                        core::slice::from_raw_parts(
+                            MMArch::phys_2_virt(paddr).unwrap().data() as *mut u8,
+                            len,
+                        )
+                    },
+                    SpinLock::new(FilePrivateData::Unused).lock(),
+                )
+                .unwrap();
+        }
 
         // 清除标记
         guard.remove_flags(PageFlags::PG_DIRTY);


### PR DESCRIPTION
# 简介
经过此commit,用户程序可以直接mmap文件然后读写（无需通过read/write去读取）

# 存在的问题

~~目前这个pr仍然有bug：对同一文件的第二次filemap，会在读取的时候直接panic掉。~~
25.5.10： 已经解决： https://github.com/DragonOS-Community/DragonOS/pull/1158/commits/20cdd279a50c5e4d7d6a25e9430aac6df2660351

## 测试程序

`test_filemap.c`

```c
#include <ctype.h>
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/mman.h>
#include <sys/stat.h>
#include <unistd.h>

#define EXPECTED_LEN 6 // "hello"的长度 + \0

int main() {
  printf("Program started\n");
  const char *filename = "testfile";
  int fd;
  struct stat st;
  char *mapped;

  printf("Attempting to open file: %s\n", filename);
  fd = open(filename, O_RDWR);
  if (fd == -1) {
    perror("open failed");
    exit(EXIT_FAILURE);
  }
  printf("File opened successfully\n");

  printf("Getting file stats\n");
  if (fstat(fd, &st) == -1) {
    perror("fstat failed");
    close(fd);
    exit(EXIT_FAILURE);
  }
  printf("File size: %ld bytes\n", st.st_size);

  printf("Checking file size against expected length (%d)\n", EXPECTED_LEN);
  if (st.st_size < EXPECTED_LEN) {
    fprintf(stderr, "Error: File size is less than %d bytes\n", EXPECTED_LEN);
    close(fd);
    exit(EXIT_FAILURE);
  }
  printf("File size matches expected length\n");

  printf("Mapping file to memory\n");
  mapped = mmap(NULL, st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
  if (mapped == MAP_FAILED) {
    perror("mmap failed");
    close(fd);
    exit(EXIT_FAILURE);
  }
  printf("File mapped successfully at address: %p\n", mapped);

  printf("Checking file content\n");
  if (strncmp(mapped, "hello", EXPECTED_LEN - 1) != 0 &&
      strncmp(mapped, "HELLO", EXPECTED_LEN - 1) != 0) {
    fprintf(stderr, "Error: File content is neither 'hello' nor 'HELLO'\n");
    munmap(mapped, st.st_size);
    close(fd);
    exit(EXIT_FAILURE);
  }
  printf("File content verified: %.*s\n", EXPECTED_LEN, mapped);

  printf("Converting case of each character\n");
  for (int i = 0; i < EXPECTED_LEN; i++) {
    if (islower(mapped[i])) {
      mapped[i] = toupper(mapped[i]);
    } else if (isupper(mapped[i])) {
      mapped[i] = tolower(mapped[i]);
    }
  }
  printf("Case conversion complete. New content: %.*s\n", EXPECTED_LEN, mapped);

  printf("Syncing changes to disk\n");
  if (msync(mapped, st.st_size, MS_SYNC) == -1) {
    perror("msync failed");
  } else {
    printf("Changes synced successfully\n");
  }

  printf("Cleaning up resources\n");
  munmap(mapped, st.st_size);
  close(fd);
  printf("Resources released\n");

  printf("Program completed successfully\n");
  return EXIT_SUCCESS;
}

```
## 测试方法

```shell
musl-gcc  -static -o tfm test_filemap.c
```
然后把tfm拷贝到bin/sysroot下面。并且在bin/sysroot目录下执行：
```shell
echo hello > testfile
```

接着执行
```
make write_disk_image
```

### 错误1：两次执行测试程序，第二次内核panic

然后进入dragonos之后直接执行`./tfm`，可以看到成功的。并且cat testfile也变成了大写。

接着再次执行`./tfm`，内核就会在转换字符串大小写，写入page的地方panic。此处就是内核在处理pagefault的时候panic的。
如果重启dragonos再次执行，也是第一次成功，第二次失败。稳定复现。

panic的地方在这里:
![image](https://github.com/user-attachments/assets/5ca3fcd2-ef17-4090-892c-9a75690f0772)

错误现象：
```shell
root@DragonOS:/$ ./tfm
Program started
Attempting to open file: testfile
File opened successfully
Getting file stats
File size: 4096 bytes
Checking file size against expected length (6)
File size matches expected length
Mapping file to memory
File mapped successfully at address: 0x10000
Checking file content
File content verified: hello

Converting case of each character
Case conversion complete. New content: HELLO

Syncing changes to disk
Changes synced successfully
Cleaning up resources
Resources released
Program completed successfully
[ WARN ] (src/syscall/mod.rs:916)        SYS_EXIT_GROUP has not yet been implemented
root@DragonOS:/$ ./tfm
Program started
Attempting to open file: testfile
File opened successfully
Getting file stats
File size: 4096 bytes
Checking file size against expected length (6)
File size matches expected length
Mapping file to memory
File mapped successfully at address: 0x10000
Checking file content
File content verified: HELLO

Converting case of each character
[ ERROR ] (src/debug/panic/mod.rs:42)    Kernel Panic Occurred.
Location:
        File: src/mm/page.rs
        Line: 93, Column: 32
Message:
        Phys Page not found, PhysAddr(0x1cd04000)
Rust Panic Backtrace:
[1] function:_Unwind_Backtrace()        (+) 0051 address:0xffff80000049bdc3
[2] function:dragonos_kernel::debug::panic::hook::print_stack_trace()   (+) 0232 address:0xffff800000451b98
[3] function:rust_begin_unwind()        (+) 0689 address:0xffff800000258691
[4] function:core::panicking::panic_fmt()       (+) 0028 address:0xffff80000054381c
[5] function:dragonos_kernel::mm::page::PageManager::get_unwrap()       (+) 0554 address:0xffff800000321b4a
[6] function:dragonos_kernel::mm::fault::PageFaultHandler::handle_pte_fault()   (+) 0757 address:0xffff80000031d6f5
[7] function:dragonos_kernel::mm::fault::PageFaultHandler::handle_mm_fault()    (+) 1115 address:0xffff80000031d11b
[8] function:dragonos_kernel::arch::x86_64::mm::fault::<impl dragonos_kernel::arch::x86_64::mm::X86_64MMArch>::do_user_addr_fault()     (+) 1320 address:0xfff8
[9] function:do_page_fault()    (+) 0031 address:0xffff80000015cc7f
[10] function:__entry_err_code_after_gs_check_1()       (+) 0003 address:0xffff80000014759e
[ ERROR ] (src/debug/panic/mod.rs:42)    Kernel Panic Occurred.
Location:
        File: /home/longjin/.rustup/toolchains/nightly-2024-11-05-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs
        Line: 227, Column: 5
Message:
        panic in a function that cannot unwind
Current PCB:
        ProcessControlBlock { pid: Pid(11), tgid: Pid(11), thread_pid: RwLock { lock: 0, data: UnsafeCell { .. } }, basic: RwLock { lock: 0, data: UnsafeCell }
[ ERROR ] (src/debug/panic/mod.rs:42)    Kernel Panic Occurred.
Location:
        File: src/mm/ucontext.rs
        Line: 1174, Column: 55
Message:
        called `Option::unwrap()` on a `None` value
Rust Panic Backtrace:
[1] function:_Unwind_Backtrace()        (+) 0051 address:0xffff80000049bdc3
[2] function:dragonos_kernel::debug::panic::hook::print_stack_trace()   (+) 0232 address:0xffff800000451b98
[3] function:rust_begin_unwind()        (+) 0689 address:0xffff800000258691
[4] function:core::panicking::panic_fmt()       (+) 0028 address:0xffff80000054381c
[5] function:core::panicking::panic()   (+) 0073 address:0xffff8000005438c9
[6] function:core::option::unwrap_failed()      (+) 0021 address:0xffff80000054acf5
[7] function:_ZN15dragonos_kernel2mm8ucontext9LockedVMA5unmap17hb91611dff5bccc10E.llvm.13113641246671491073()   (+) 1532 address:0xffff80000032cacc
[8] function:<dragonos_kernel::mm::ucontext::InnerAddressSpace as core::ops::drop::Drop>::drop()        (+) 0311 address:0xffff80000032ad67
[9] function:alloc::sync::Arc<T,A>::drop_slow()         (+) 0023 address:0xffff80000043e117
[10] function:dragonos_kernel::process::ProcessManager::exit()  (+) 1464 address:0xffff8000002c4858
[11] function:rust_begin_unwind()       (+) 0815 address:0xffff80000025870f
[12] function:core::panicking::panic_nounwind_fmt()     (+) 0089 address:0xffff800000543879
[13] function:core::panicking::panic_nounwind()         (+) 0079 address:0xffff80000054391f
[14] function:core::panicking::panic_cannot_unwind()    (+) 0016 address:0xffff800000543ae2
[15] function:do_page_fault()   (+) 0046 address:0xffff80000015cc8e
[16] function:__entry_err_code_after_gs_check_1()       (+) 0003 address:0xffff80000014759e
./tfm: Process terminated
root@DragonOS:/$ 
```

### 错误2：先cat testfile，那么第一次执行测试程序就会panic

错误信息：

```shell
root@DragonOS:/$ cat testfile
HELLO
[ WARN ] (src/syscall/mod.rs:916)        SYS_EXIT_GROUP has not yet been implemented
root@DragonOS:/$ ./tfm       
Program started
Attempting to open file: testfile
File opened successfully
Getting file stats
File size: 4096 bytes
Checking file size against expected length (6)
File size matches expected length
Mapping file to memory
File mapped successfully at address: 0x10000
Checking file content
File content verified: HELLO

Converting case of each character
Case conversion complete. New content: hello

Syncing changes to disk
Changes synced successfully
Cleaning up resources
[ ERROR ] (src/debug/panic/mod.rs:42)    Kernel Panic Occurred.
Location:
        File: src/mm/page.rs
        Line: 351, Column: 68
Message:
        called `Option::unwrap()` on a `None` value
Rust Panic Backtrace:
[1] function:_Unwind_Backtrace()        (+) 0051 address:0xffff80000049cac3
[2] function:dragonos_kernel::debug::panic::hook::print_stack_trace()   (+) 0232 address:0xffff800000269de8
[3] function:rust_begin_unwind()        (+) 0689 address:0xffff8000002f0ad1
[4] function:core::panicking::panic_fmt()       (+) 0028 address:0xffff80000054451c
[5] function:core::panicking::panic()   (+) 0073 address:0xffff8000005445c9
[6] function:core::option::unwrap_failed()      (+) 0021 address:0xffff80000054b9f5
[7] function:dragonos_kernel::mm::page::PageReclaimer::page_writeback()         (+) 3304 address:0xffff80000044c138
[8] function:dragonos_kernel::mm::page::page_reclaim_thread()   (+) 0319 address:0xffff80000044a76f
[9] function:dragonos_kernel::process::kthread::kernel_thread_bootstrap_stage2()        (+) 0882 address:0xffff8000002d4062
[ ERROR ] (src/arch/x86_64/interrupt/trap.rs:347)        do_general_protection(13),     Error code: 0x0,        rsp: 0xffff80001fb66cc0,        rip: 0xffff800)
Refers to a descriptor in the GDT or the current LDT;
Refers to a descriptor in the current GDT;

Segment Selector Index: 0x0


[ ERROR ] (src/debug/panic/mod.rs:42)    Kernel Panic Occurred.
Location:
        File: src/arch/x86_64/interrupt/trap.rs
        Line: 361, Column: 5
Message:
        General Protection
```