### PR TITLE
refactor(mm): 优化内存管理模块代码结构

### DIFF
--- a/kernel/src/mm/memblock.rs
+++ b/kernel/src/mm/memblock.rs
@@ -40,6 +40,9 @@ impl MemBlockManager {
     pub const MIN_MEMBLOCK_ADDR: PhysAddr = PhysAddr::new(0);
     #[allow(dead_code)]
     pub const MAX_MEMBLOCK_ADDR: PhysAddr = PhysAddr::new(usize::MAX);
+
+    /// 由于这个函数只在全局调用，因此不需要担心栈上溢出问题
+    #[allow(clippy::large_stack_frames)]
     const fn new() -> Self {
         Self {
             inner: SpinLock::new(InnerMemBlockManager {


### PR DESCRIPTION
- 将 `MmioBuddyMemPool` 中的 `free_regions` 从数组改为 `Vec`, 降低初始化的栈内存使用
- 移除不必要的 `LinkedList` 依赖，使用 `Vec` 替代