### PR TITLE
fix(sbrk): 将sbrk移出syscall_table

### DIFF
--- a/kernel/src/mm/syscall/mod.rs
+++ b/kernel/src/mm/syscall/mod.rs
@@ -12,7 +12,7 @@ mod sys_mprotect;
 mod sys_mremap;
 mod sys_msync;
 mod sys_munmap;
-mod sys_sbrk;
+pub mod sys_sbrk;
 
 bitflags! {
     /// Memory protection flags

--- a/kernel/src/mm/syscall/sys_sbrk.rs
+++ b/kernel/src/mm/syscall/sys_sbrk.rs
@@ -1,53 +1,64 @@
 //! System call handler for the sbrk system call.
 
-use crate::arch::interrupt::TrapFrame;
 use crate::mm::ucontext::AddressSpace;
-use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::SYS_SBRK;
 use system_error::SystemError;
 
-use alloc::vec::Vec;
+// /// Handler for the sbrk system call, which increments the program's data space (heap).
+// pub struct SysSbrkHandle;
 
-/// Handler for the sbrk system call, which increments the program's data space (heap).
-pub struct SysSbrkHandle;
+// impl Syscall for SysSbrkHandle {
+//     /// Returns the number of arguments this syscall takes.
+//     fn num_args(&self) -> usize {
+//         1
+//     }
 
-impl Syscall for SysSbrkHandle {
-    /// Returns the number of arguments this syscall takes.
-    fn num_args(&self) -> usize {
-        1
-    }
+//     /// Handles the sbrk system call.
+//     ///
+//     /// # Arguments
+//     /// * `args` - The syscall arguments, where args[0] is the increment value (isize).
+//     ///
+//     /// # Returns
+//     /// * On success, returns the previous program break (heap end) as usize.
+//     /// * On failure, returns a SystemError.
+//     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+//         let incr = Self::incr(args);
+//         let address_space = AddressSpace::current()?;
+//         assert!(address_space.read().user_mapper.utable.is_current());
+//         let mut address_space = address_space.write();
+//         let r = unsafe { address_space.sbrk(incr) }?;
+//         return Ok(r.data());
+//     }
 
-    /// Handles the sbrk system call.
-    ///
-    /// # Arguments
-    /// * `args` - The syscall arguments, where args[0] is the increment value (isize).
-    ///
-    /// # Returns
-    /// * On success, returns the previous program break (heap end) as usize.
-    /// * On failure, returns a SystemError.
-    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
-        let incr = Self::incr(args);
-        let address_space = AddressSpace::current()?;
-        assert!(address_space.read().user_mapper.utable.is_current());
-        let mut address_space = address_space.write();
-        let r = unsafe { address_space.sbrk(incr) }?;
-        return Ok(r.data());
-    }
+//     /// Formats the syscall arguments for display/debugging purposes.
+//     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+//         vec![FormattedSyscallParam::new(
+//             "incr",
+//             format!("{}", Self::incr(args)),
+//         )]
+//     }
+// }
 
-    /// Formats the syscall arguments for display/debugging purposes.
-    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
-        vec![FormattedSyscallParam::new(
-            "incr",
-            format!("{}", Self::incr(args)),
-        )]
-    }
+// impl SysSbrkHandle {
+//     /// Extracts the increment argument from syscall parameters.
+//     fn incr(args: &[usize]) -> isize {
+//         args[0] as isize
+//     }
+// }
+
+// syscall_table_macros::declare_syscall!(SYS_SBRK, SysSbrkHandle);
+
+/// Handles the sbrk system call.
+///
+/// # Arguments
+/// * `args` - The syscall arguments, where args[0] is the increment value (isize).
+///
+/// # Returns
+/// * On success, returns the previous program break (heap end) as usize.
+/// * On failure, returns a SystemError.
+pub fn sys_sbrk(incr: isize) -> Result<usize, SystemError> {
+    let address_space = AddressSpace::current()?;
+    assert!(address_space.read().user_mapper.utable.is_current());
+    let mut address_space = address_space.write();
+    let r = unsafe { address_space.sbrk(incr) }?;
+    return Ok(r.data());
 }
-
-impl SysSbrkHandle {
-    /// Extracts the increment argument from syscall parameters.
-    fn incr(args: &[usize]) -> isize {
-        args[0] as isize
-    }
-}
-
-syscall_table_macros::declare_syscall!(SYS_SBRK, SysSbrkHandle);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -187,6 +187,11 @@ impl Syscall {
                 Self::pwrite(fd, buf, len, offset)
             }
 
+            SYS_SBRK => {
+                let incr = args[0] as isize;
+                crate::mm::syscall::sys_sbrk::sys_sbrk(incr)
+            }
+
             SYS_REBOOT => {
                 let magic1 = args[0] as u32;
                 let magic2 = args[1] as u32;


### PR DESCRIPTION
srbk的系统调用号为100001，不支持注册到系统调用表中