### PR TITLE
fix(time): 处理信号中断导致的定时器唤醒

### DIFF
--- a/kernel/src/time/timer.rs
+++ b/kernel/src/time/timer.rs
@@ -325,6 +325,12 @@ pub fn schedule_timeout(mut timeout: i64) -> Result<i64, SystemError> {
         drop(irq_guard);
 
         schedule(SchedMode::SM_NONE);
+
+        // 如果定时器没有超时（被信号中断或其他原因唤醒），则取消定时器
+        if !timer.timeout() {
+            timer.cancel();
+        }
+
         let time_remaining: i64 = timeout - TIMER_JIFFIES.load(Ordering::SeqCst) as i64;
         if time_remaining >= 0 {
             // 被提前唤醒，返回剩余时间


### PR DESCRIPTION
在sleep和schedule_timeout模块中增加信号中断检查，当定时器被信号中断时取消定时器并返回ERESTARTSYS错误。

解决了 https://github.com/DragonOS-Community/DragonOS/issues/1163