### PR TITLE
refactor(kernel): 增加内核栈大小从0x4000到0x8000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,6 @@ log-monitor:
 update-submodules:
 	@echo "更新子模块"
 	@git submodule update --recursive --init
-	@git submodule foreach git pull origin master
 
 .PHONY: update-submodules-by-mirror
 update-submodules-by-mirror:

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1688,8 +1688,8 @@ unsafe fn dealloc_from_kernel_space(vaddr: VirtAddr, paddr: PhysAddr) {
 }
 
 impl KernelStack {
-    pub const SIZE: usize = 0x4000;
-    pub const ALIGN: usize = 0x4000;
+    pub const SIZE: usize = 0x8000;
+    pub const ALIGN: usize = 0x8000;
 
     pub fn new() -> Result<Self, SystemError> {
         if cfg!(feature = "kstack_protect") {


### PR DESCRIPTION
修改KernelStack的SIZE和ALIGN常量值，将内核栈大小从16KB增加到32KB。

因为内核有些地方16k会爆栈，尤其是rv64