### PR TITLE
fix: 解决syscall_table处理结束后,忘记执行调度的bug

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -282,7 +282,8 @@ impl X86_64MMArch {
                     if !space_guard.can_extend_stack(region.start() - address) {
                         // exceeds stack limit
                         log::error!(
-                            "stack limit exceeded, error_code: {:?}, address: {:#x}",
+                            "pid {} stack limit exceeded, error_code: {:?}, address: {:#x}",
+                            ProcessManager::current_pid().data(),
                             error_code,
                             address.data(),
                         );

--- a/kernel/src/process/syscall/sys_fork.rs
+++ b/kernel/src/process/syscall/sys_fork.rs
@@ -1,5 +1,5 @@
 use crate::arch::interrupt::TrapFrame;
-//use crate::arch::syscall::nr::SYS_FORK;
+use crate::arch::syscall::nr::SYS_FORK;
 use crate::process::fork::CloneFlags;
 use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
@@ -14,7 +14,6 @@ impl Syscall for SysFork {
     }
 
     fn handle(&self, _args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
-        log::debug!("fork");
         ProcessManager::fork(frame, CloneFlags::empty()).map(|pid| pid.into())
     }
 
@@ -23,4 +22,4 @@ impl Syscall for SysFork {
     }
 }
 
-//syscall_table_macros::declare_syscall!(SYS_FORK, SysFork);
+syscall_table_macros::declare_syscall!(SYS_FORK, SysFork);

--- a/kernel/src/process/syscall/sys_vfork.rs
+++ b/kernel/src/process/syscall/sys_vfork.rs
@@ -1,5 +1,5 @@
 use crate::arch::interrupt::TrapFrame;
-//use crate::arch::syscall::nr::SYS_VFORK;
+use crate::arch::syscall::nr::SYS_VFORK;
 use crate::process::fork::CloneFlags;
 use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
@@ -16,7 +16,6 @@ impl Syscall for SysVfork {
     fn handle(&self, _args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
         // 由于Linux vfork需要保证子进程先运行（除非子进程调用execve或者exit），
         // 而我们目前没有实现这个特性，所以暂时使用fork代替vfork（linux文档表示这样也是也可以的）
-        log::debug!("vfork");
         ProcessManager::fork(frame, CloneFlags::empty()).map(|pid| pid.into())
 
         // 下面是以前的实现，除非我们实现了子进程先运行的特性，否则不要使用，不然会导致父进程数据损坏
@@ -32,4 +31,4 @@ impl Syscall for SysVfork {
     }
 }
 
-//syscall_table_macros::declare_syscall!(SYS_VFORK, SysVfork);
+syscall_table_macros::declare_syscall!(SYS_VFORK, SysVfork);


### PR DESCRIPTION
同时,将sys_fork\sys_vfork调整为使用syscall table机制来实现

解决了 https://github.com/DragonOS-Community/DragonOS/issues/1191
cc @sparkzky  @dolzhuying 