### PR TITLE
fix(process): 修复waitpid在处理Blocked状态时的逻辑错误

### DIFF
--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -221,7 +221,12 @@ fn do_waitpid(
                 return Some(Ok(0));
             }
         }
-        ProcessState::Blocked(_) | ProcessState::Stopped => {
+        ProcessState::Blocked(_) => {
+            // 对于被阻塞的子进程（如正在sleep），waitpid应该继续等待
+            // 而不是立即返回0。只有当子进程真正退出时才应该返回。
+            return None;
+        }
+        ProcessState::Stopped => {
             // todo: 在stopped里面，添加code字段，表示停止的原因
             let exitcode = 0;
             // 由于目前不支持ptrace，因此这个值为false


### PR DESCRIPTION
在处理Blocked状态的子进程时，waitpid应继续等待而不是立即返回0。只有当子进程真正退出时才应返回。

问题详述：
错误行为：当子进程处于ProcessState::Blocked(_)状态时（比如正在执行sleep），waitpid错误地返回0，表示"没有可等待的子进程"
正确行为：根据POSIX标准，waitpid应该继续等待直到子进程退出，而不是因为子进程暂时阻塞就返回0
竞争条件：
如果父进程先调用waitpid，子进程后sleep → 正常等待 ✅
如果子进程先sleep，父进程后调用waitpid → 错误返回0 ❌

解决了issue的“情况1”   https://github.com/DragonOS-Community/DragonOS/issues/1231