### PR TITLE
refactor(vfs/syscall): 重构部分vfs下的系统调用

### DIFF
--- a/kernel/src/filesystem/vfs/syscall/dup2.rs
+++ b/kernel/src/filesystem/vfs/syscall/dup2.rs
@@ -1,6 +1,9 @@
 use system_error::SystemError;
 
-use crate::{filesystem::vfs::file::{FileDescriptorVec, FileMode}, libs::rwlock::RwLockWriteGuard};
+use crate::{
+    filesystem::vfs::file::{FileDescriptorVec, FileMode},
+    libs::rwlock::RwLockWriteGuard,
+};
 
 pub fn do_dup2(
     oldfd: i32,

--- a/kernel/src/filesystem/vfs/syscall/dup2.rs
+++ b/kernel/src/filesystem/vfs/syscall/dup2.rs
@@ -1,0 +1,52 @@
+use system_error::SystemError;
+
+use crate::{filesystem::vfs::file::{FileDescriptorVec, FileMode}, libs::rwlock::RwLockWriteGuard};
+
+pub fn do_dup2(
+    oldfd: i32,
+    newfd: i32,
+    fd_table_guard: &mut RwLockWriteGuard<'_, FileDescriptorVec>,
+) -> Result<usize, SystemError> {
+    do_dup3(oldfd, newfd, FileMode::empty(), fd_table_guard)
+}
+
+pub fn do_dup3(
+    oldfd: i32,
+    newfd: i32,
+    flags: FileMode,
+    fd_table_guard: &mut RwLockWriteGuard<'_, FileDescriptorVec>,
+) -> Result<usize, SystemError> {
+    // 确认oldfd, newid是否有效
+    if !(FileDescriptorVec::validate_fd(oldfd) && FileDescriptorVec::validate_fd(newfd)) {
+        return Err(SystemError::EBADF);
+    }
+
+    if oldfd == newfd {
+        // 若oldfd与newfd相等
+        return Ok(newfd as usize);
+    }
+    let new_exists = fd_table_guard.get_file_by_fd(newfd).is_some();
+    if new_exists {
+        // close newfd
+        if fd_table_guard.drop_fd(newfd).is_err() {
+            // An I/O error occurred while attempting to close fildes2.
+            return Err(SystemError::EIO);
+        }
+    }
+
+    let old_file = fd_table_guard
+        .get_file_by_fd(oldfd)
+        .ok_or(SystemError::EBADF)?;
+    let new_file = old_file.try_clone().ok_or(SystemError::EBADF)?;
+
+    if flags.contains(FileMode::O_CLOEXEC) {
+        new_file.set_close_on_exec(true);
+    } else {
+        new_file.set_close_on_exec(false);
+    }
+    // 申请文件描述符，并把文件对象存入其中
+    let res = fd_table_guard
+        .alloc_fd(new_file, Some(newfd))
+        .map(|x| x as usize);
+    return res;
+}

--- a/kernel/src/filesystem/vfs/syscall/faccessat2.rs
+++ b/kernel/src/filesystem/vfs/syscall/faccessat2.rs
@@ -2,16 +2,16 @@ use system_error::SystemError;
 
 use crate::filesystem::vfs::{open::do_faccessat, syscall::ModeType};
 
- pub fn do_faccessat2(
-        dirfd: i32,
-        pathname: *const u8,
-        mode: u32,
-        flags: u32,
-    ) -> Result<usize, SystemError> {
-        return do_faccessat(
-            dirfd,
-            pathname,
-            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
-            flags,
-        );
-    }
+pub fn do_faccessat2(
+    dirfd: i32,
+    pathname: *const u8,
+    mode: u32,
+    flags: u32,
+) -> Result<usize, SystemError> {
+    return do_faccessat(
+        dirfd,
+        pathname,
+        ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
+        flags,
+    );
+}

--- a/kernel/src/filesystem/vfs/syscall/faccessat2.rs
+++ b/kernel/src/filesystem/vfs/syscall/faccessat2.rs
@@ -1,0 +1,17 @@
+use system_error::SystemError;
+
+use crate::filesystem::vfs::{open::do_faccessat, syscall::ModeType};
+
+ pub fn do_faccessat2(
+        dirfd: i32,
+        pathname: *const u8,
+        mode: u32,
+        flags: u32,
+    ) -> Result<usize, SystemError> {
+        return do_faccessat(
+            dirfd,
+            pathname,
+            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
+            flags,
+        );
+    }

--- a/kernel/src/filesystem/vfs/syscall/link_utils.rs
+++ b/kernel/src/filesystem/vfs/syscall/link_utils.rs
@@ -1,0 +1,72 @@
+use crate::filesystem::vfs::syscall::AtFlags;
+use crate::filesystem::vfs::utils::rsplit_path;
+use crate::filesystem::vfs::utils::user_path_at;
+use crate::filesystem::vfs::FileType;
+use crate::filesystem::vfs::IndexNode;
+use crate::filesystem::vfs::SystemError;
+use crate::filesystem::vfs::VFS_MAX_FOLLOW_SYMLINK_TIMES;
+use crate::process::ProcessManager;
+use alloc::sync::Arc;
+/// **创建硬连接的系统调用**
+///    
+/// ## 参数
+///
+/// - 'oldfd': 用于解析源文件路径的文件描述符
+/// - 'old': 源文件路径
+/// - 'newfd': 用于解析新文件路径的文件描述符
+/// - 'new': 新文件将创建的路径
+/// - 'flags': 标志位，仅以位或方式包含AT_EMPTY_PATH和AT_SYMLINK_FOLLOW
+///
+///
+pub fn do_linkat(
+    oldfd: i32,
+    old: &str,
+    newfd: i32,
+    new: &str,
+    flags: AtFlags,
+) -> Result<usize, SystemError> {
+    // flag包含其他未规定值时返回EINVAL
+    if !(AtFlags::AT_EMPTY_PATH | AtFlags::AT_SYMLINK_FOLLOW).contains(flags) {
+        return Err(SystemError::EINVAL);
+    }
+    // TODO AT_EMPTY_PATH标志启用时，进行调用者CAP_DAC_READ_SEARCH或相似的检查
+    let symlink_times = if flags.contains(AtFlags::AT_SYMLINK_FOLLOW) {
+        0_usize
+    } else {
+        VFS_MAX_FOLLOW_SYMLINK_TIMES
+    };
+    let pcb = ProcessManager::current_pcb();
+
+    // 得到源路径的inode
+    let old_inode: Arc<dyn IndexNode> = if old.is_empty() {
+        if flags.contains(AtFlags::AT_EMPTY_PATH) {
+            // 在AT_EMPTY_PATH启用时，old可以为空，old_inode实际为oldfd所指文件，但该文件不能为目录。
+            let binding = pcb.fd_table();
+            let fd_table_guard = binding.read();
+            let file = fd_table_guard
+                .get_file_by_fd(oldfd)
+                .ok_or(SystemError::EBADF)?;
+            let old_inode = file.inode();
+            old_inode
+        } else {
+            return Err(SystemError::ENONET);
+        }
+    } else {
+        let (old_begin_inode, old_remain_path) = user_path_at(&pcb, oldfd, old)?;
+        old_begin_inode.lookup_follow_symlink(&old_remain_path, symlink_times)?
+    };
+
+    // old_inode为目录时返回EPERM
+    if old_inode.metadata().unwrap().file_type == FileType::Dir {
+        return Err(SystemError::EPERM);
+    }
+
+    // 得到新创建节点的父节点
+    let (new_begin_inode, new_remain_path) = user_path_at(&pcb, newfd, new)?;
+    let (new_name, new_parent_path) = rsplit_path(&new_remain_path);
+    let new_parent =
+        new_begin_inode.lookup_follow_symlink(new_parent_path.unwrap_or("/"), symlink_times)?;
+
+    // 被调用者利用downcast_ref判断两inode是否为同一文件系统
+    return new_parent.link(new_name, &old_inode).map(|_| 0);
+}

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -21,7 +21,7 @@ use super::stat::{do_newfstatat, do_statx, vfs_fstat};
 use super::{
     fcntl::{AtFlags, FcntlCommand, FD_CLOEXEC},
     file::{File, FileMode},
-    open::{do_faccessat, do_fchmodat},
+    open::do_faccessat,
     utils::{rsplit_path, user_path_at},
     FileType, IndexNode, SuperBlock, MAX_PATHLEN, ROOT_INODE, VFS_MAX_FOLLOW_SYMLINK_TIMES,
 };
@@ -100,6 +100,8 @@ mod sys_futimesat;
 mod sys_lchown;
 #[cfg(target_arch = "x86_64")]
 mod sys_chown;
+#[cfg(target_arch = "x86_64")]
+mod sys_chmod;
 
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
@@ -875,14 +877,6 @@ impl Syscall {
             pathname,
             ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
             flags,
-        );
-    }
-
-    pub fn chmod(pathname: *const u8, mode: u32) -> Result<usize, SystemError> {
-        return do_fchmodat(
-            AtFlags::AT_FDCWD.bits(),
-            pathname,
-            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
         );
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -54,6 +54,7 @@ mod sys_utimensat;
 mod sys_fchown;
 mod sys_fchownat;
 mod sys_fchmod;
+mod sys_fchmodat;
 
 mod epoll_utils;
 mod sys_epoll_create1;
@@ -880,14 +881,6 @@ impl Syscall {
     pub fn chmod(pathname: *const u8, mode: u32) -> Result<usize, SystemError> {
         return do_fchmodat(
             AtFlags::AT_FDCWD.bits(),
-            pathname,
-            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
-        );
-    }
-
-    pub fn fchmodat(dirfd: i32, pathname: *const u8, mode: u32) -> Result<usize, SystemError> {
-        return do_fchmodat(
-            dirfd,
             pathname,
             ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
         );

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -94,7 +94,8 @@ mod sys_unlink;
 mod sys_utimes;
 #[cfg(target_arch = "x86_64")]
 mod sys_futimesat;
-
+#[cfg(target_arch = "x86_64")]
+mod sys_lchown;
 
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
@@ -913,19 +914,6 @@ impl Syscall {
             uid,
             gid,
             AtFlags::AT_STATX_SYNC_AS_STAT,
-        );
-    }
-
-    pub fn lchown(pathname: *const u8, uid: usize, gid: usize) -> Result<usize, SystemError> {
-        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
-            .into_string()
-            .map_err(|_| SystemError::EINVAL)?;
-        return do_fchownat(
-            AtFlags::AT_FDCWD.bits(),
-            &pathname,
-            uid,
-            gid,
-            AtFlags::AT_SYMLINK_NOFOLLOW,
         );
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -21,7 +21,6 @@ use super::stat::{do_newfstatat, do_statx, vfs_fstat};
 use super::{
     fcntl::{AtFlags, FcntlCommand, FD_CLOEXEC},
     file::{File, FileMode},
-    open::do_faccessat,
     utils::{rsplit_path, user_path_at},
     FileType, IndexNode, SuperBlock, MAX_PATHLEN, ROOT_INODE, VFS_MAX_FOLLOW_SYMLINK_TIMES,
 };
@@ -105,6 +104,8 @@ mod sys_lchown;
 mod sys_chown;
 #[cfg(target_arch = "x86_64")]
 mod sys_chmod;
+#[cfg(target_arch = "x86_64")]
+mod sys_access;
 
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
@@ -858,14 +859,5 @@ impl Syscall {
         buf_size: usize,
     ) -> Result<usize, SystemError> {
         return Self::readlink_at(AtFlags::AT_FDCWD.bits(), path, user_buf, buf_size);
-    }
-
-    pub fn access(pathname: *const u8, mode: u32) -> Result<usize, SystemError> {
-        return do_faccessat(
-            AtFlags::AT_FDCWD.bits(),
-            pathname,
-            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
-            0,
-        );
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -1,14 +1,10 @@
-use system_error::SystemError;
-
 use crate::{
     syscall::{
         user_access::check_and_clone_cstr,
-        Syscall,
     },
     time:: PosixTimeSpec,
 };
 
-use super::stat::vfs_fstat;
 use super::{
     fcntl::AtFlags,
     file::FileMode,
@@ -21,6 +17,7 @@ mod utimensat;
 mod faccessat2;
 mod readlink_at;
 mod dup2;
+mod newfstat;
 mod sys_chdir;
 mod sys_close;
 mod sys_fchdir;
@@ -486,17 +483,5 @@ bitflags! {
         // 			return -EAGAIN if that's not
         // 			possible.
         const RESOLVE_CACHED = 0x20;
-    }
-}
-
-impl Syscall {
-    #[inline(never)]
-    pub fn newfstat(fd: i32, user_stat_buf_ptr: usize) -> Result<usize, SystemError> {
-        if user_stat_buf_ptr == 0 {
-            return Err(SystemError::EFAULT);
-        }
-        let stat = vfs_fstat(fd)?;
-        // log::debug!("newfstat fd: {}, stat.size: {:?}",fd,stat.size);
-        super::stat::cp_new_stat(stat, user_stat_buf_ptr).map(|_| 0)
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -21,7 +21,7 @@ use super::stat::{do_newfstatat, do_statx, vfs_fstat};
 use super::{
     fcntl::{AtFlags, FcntlCommand, FD_CLOEXEC},
     file::{File, FileMode},
-    open::{do_faccessat, do_fchmodat, do_fchownat,ksys_fchown},
+    open::{do_faccessat, do_fchmodat, do_fchownat},
     utils::{rsplit_path, user_path_at},
     FileType, IndexNode, SuperBlock, MAX_PATHLEN, ROOT_INODE, VFS_MAX_FOLLOW_SYMLINK_TIMES,
 };
@@ -51,6 +51,7 @@ mod sys_unlinkat;
 mod sys_write;
 mod sys_writev;
 mod sys_utimensat;
+mod sys_fchown;
 
 mod epoll_utils;
 mod sys_epoll_create1;
@@ -940,9 +941,5 @@ impl Syscall {
         let pathname = pathname.as_str().trim();
         let flags = AtFlags::from_bits_truncate(flags);
         return do_fchownat(dirfd, pathname, uid, gid, flags);
-    }
-
-    pub fn fchown(fd: i32, uid: usize, gid: usize) -> Result<usize, SystemError> {
-        return ksys_fchown(fd, uid, gid);
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -1,26 +1,27 @@
-use crate::{
-    syscall::{
-        user_access::check_and_clone_cstr,
-    },
-    time:: PosixTimeSpec,
-};
+use crate::{syscall::user_access::check_and_clone_cstr, time::PosixTimeSpec};
 
-use super::{
-    fcntl::AtFlags,
-    file::FileMode,
-    SuperBlock,
-};
-mod link_utils;
-mod open_utils;
-mod rename_utils;
-mod utimensat;
-mod faccessat2;
-mod readlink_at;
+use super::{fcntl::AtFlags, file::FileMode, SuperBlock};
 mod dup2;
+mod faccessat2;
+mod link_utils;
 mod newfstat;
+mod open_utils;
+mod readlink_at;
+mod rename_utils;
 mod sys_chdir;
 mod sys_close;
+mod sys_dup;
+mod sys_dup3;
+mod sys_faccessat;
+mod sys_faccessat2;
 mod sys_fchdir;
+mod sys_fchmod;
+mod sys_fchmodat;
+mod sys_fchown;
+mod sys_fchownat;
+mod sys_fcntl;
+mod sys_fstatfs;
+mod sys_ftruncate;
 mod sys_getcwd;
 mod sys_getdents;
 mod sys_ioctl;
@@ -32,28 +33,18 @@ mod sys_pread64;
 mod sys_pselect6;
 mod sys_pwrite64;
 mod sys_read;
+mod sys_readlinkat;
 mod sys_readv;
 mod sys_renameat2;
 mod sys_select;
+mod sys_statfs;
+mod sys_statx;
 mod sys_symlinkat;
 mod sys_unlinkat;
+mod sys_utimensat;
 mod sys_write;
 mod sys_writev;
-mod sys_utimensat;
-mod sys_fchown;
-mod sys_fchownat;
-mod sys_fchmod;
-mod sys_fchmodat;
-mod sys_faccessat;
-mod sys_faccessat2;
-mod sys_readlinkat;
-mod sys_dup;
-mod sys_dup3;
-mod sys_fcntl;
-mod sys_ftruncate;
-mod sys_statx;
-mod sys_statfs;
-mod sys_fstatfs;
+mod utimensat;
 
 mod epoll_utils;
 mod sys_epoll_create1;
@@ -68,9 +59,21 @@ pub mod sys_umount2;
 mod sys_fstat;
 
 #[cfg(target_arch = "x86_64")]
+mod sys_access;
+#[cfg(target_arch = "x86_64")]
+mod sys_chmod;
+#[cfg(target_arch = "x86_64")]
+mod sys_chown;
+#[cfg(target_arch = "x86_64")]
+mod sys_dup2;
+#[cfg(target_arch = "x86_64")]
 mod sys_epoll_create;
 #[cfg(target_arch = "x86_64")]
 mod sys_epoll_wait;
+#[cfg(target_arch = "x86_64")]
+mod sys_futimesat;
+#[cfg(target_arch = "x86_64")]
+mod sys_lchown;
 #[cfg(target_arch = "x86_64")]
 mod sys_link;
 #[cfg(target_arch = "x86_64")]
@@ -78,7 +81,13 @@ mod sys_lstat;
 #[cfg(target_arch = "x86_64")]
 mod sys_mkdir;
 #[cfg(target_arch = "x86_64")]
+mod sys_mknod;
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+mod sys_newfstatat;
+#[cfg(target_arch = "x86_64")]
 mod sys_open;
+#[cfg(target_arch = "x86_64")]
+mod sys_readlink;
 #[cfg(target_arch = "x86_64")]
 mod sys_rename;
 #[cfg(target_arch = "x86_64")]
@@ -93,24 +102,6 @@ mod sys_symlink;
 mod sys_unlink;
 #[cfg(target_arch = "x86_64")]
 mod sys_utimes;
-#[cfg(target_arch = "x86_64")]
-mod sys_futimesat;
-#[cfg(target_arch = "x86_64")]
-mod sys_lchown;
-#[cfg(target_arch = "x86_64")]
-mod sys_chown;
-#[cfg(target_arch = "x86_64")]
-mod sys_chmod;
-#[cfg(target_arch = "x86_64")]
-mod sys_access;
-#[cfg(target_arch = "x86_64")]
-mod sys_readlink;
-#[cfg(target_arch = "x86_64")]
-mod sys_dup2;
-#[cfg(target_arch = "x86_64")]
-mod sys_mknod;
-#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
-mod sys_newfstatat;
 
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -29,6 +29,7 @@ mod link_utils;
 mod open_utils;
 mod rename_utils;
 mod utimensat;
+mod faccessat2;
 mod sys_chdir;
 mod sys_close;
 mod sys_fchdir;
@@ -55,6 +56,8 @@ mod sys_fchown;
 mod sys_fchownat;
 mod sys_fchmod;
 mod sys_fchmodat;
+mod sys_faccessat;
+mod sys_faccessat2;
 
 mod epoll_utils;
 mod sys_epoll_create1;
@@ -863,20 +866,6 @@ impl Syscall {
             pathname,
             ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
             0,
-        );
-    }
-
-    pub fn faccessat2(
-        dirfd: i32,
-        pathname: *const u8,
-        mode: u32,
-        flags: u32,
-    ) -> Result<usize, SystemError> {
-        return do_faccessat(
-            dirfd,
-            pathname,
-            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
-            flags,
         );
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -53,6 +53,7 @@ mod sys_writev;
 mod sys_utimensat;
 mod sys_fchown;
 mod sys_fchownat;
+mod sys_fchmod;
 
 mod epoll_utils;
 mod sys_epoll_create1;
@@ -890,19 +891,5 @@ impl Syscall {
             pathname,
             ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
         );
-    }
-
-    pub fn fchmod(fd: i32, mode: u32) -> Result<usize, SystemError> {
-        let _mode = ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?;
-        let binding = ProcessManager::current_pcb().fd_table();
-        let fd_table_guard = binding.read();
-        let _file = fd_table_guard
-            .get_file_by_fd(fd)
-            .ok_or(SystemError::EBADF)?;
-
-        // fchmod没完全实现，因此不修改文件的权限
-        // todo: 实现fchmod
-        warn!("fchmod not fully implemented");
-        return Ok(0);
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -52,6 +52,7 @@ mod sys_write;
 mod sys_writev;
 mod sys_utimensat;
 mod sys_fchown;
+mod sys_fchownat;
 
 mod epoll_utils;
 mod sys_epoll_create1;
@@ -926,20 +927,5 @@ impl Syscall {
             gid,
             AtFlags::AT_SYMLINK_NOFOLLOW,
         );
-    }
-
-    pub fn fchownat(
-        dirfd: i32,
-        pathname: *const u8,
-        uid: usize,
-        gid: usize,
-        flags: i32,
-    ) -> Result<usize, SystemError> {
-        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
-            .into_string()
-            .map_err(|_| SystemError::EINVAL)?;
-        let pathname = pathname.as_str().trim();
-        let flags = AtFlags::from_bits_truncate(flags);
-        return do_fchownat(dirfd, pathname, uid, gid, flags);
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/newfstat.rs
+++ b/kernel/src/filesystem/vfs/syscall/newfstat.rs
@@ -1,0 +1,13 @@
+use system_error::SystemError;
+
+use crate::filesystem::vfs::stat;
+
+#[inline(never)]
+pub fn do_newfstat(fd: i32, user_stat_buf_ptr: usize) -> Result<usize, SystemError> {
+    if user_stat_buf_ptr == 0 {
+        return Err(SystemError::EFAULT);
+    }
+    let stat = stat::vfs_fstat(fd)?;
+    // log::debug!("newfstat fd: {}, stat.size: {:?}",fd,stat.size);
+    stat::cp_new_stat(stat, user_stat_buf_ptr).map(|_| 0)
+}

--- a/kernel/src/filesystem/vfs/syscall/readlink_at.rs
+++ b/kernel/src/filesystem/vfs/syscall/readlink_at.rs
@@ -1,31 +1,39 @@
 use system_error::SystemError;
 
-use crate::{filesystem::vfs::{file::{File, FileMode}, utils::user_path_at, FileType, MAX_PATHLEN}, process::ProcessManager, syscall::user_access::{check_and_clone_cstr, UserBufferWriter}};
+use crate::{
+    filesystem::vfs::{
+        file::{File, FileMode},
+        utils::user_path_at,
+        FileType, MAX_PATHLEN,
+    },
+    process::ProcessManager,
+    syscall::user_access::{check_and_clone_cstr, UserBufferWriter},
+};
 
 pub fn do_readlink_at(
-        dirfd: i32,
-        path: *const u8,
-        user_buf: *mut u8,
-        buf_size: usize,
-    ) -> Result<usize, SystemError> {
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
-            .into_string()
-            .map_err(|_| SystemError::EINVAL)?;
-        let path = path.as_str().trim();
-        let mut user_buf = UserBufferWriter::new(user_buf, buf_size, true)?;
+    dirfd: i32,
+    path: *const u8,
+    user_buf: *mut u8,
+    buf_size: usize,
+) -> Result<usize, SystemError> {
+    let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+        .into_string()
+        .map_err(|_| SystemError::EINVAL)?;
+    let path = path.as_str().trim();
+    let mut user_buf = UserBufferWriter::new(user_buf, buf_size, true)?;
 
-        let (inode, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
+    let (inode, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
 
-        let inode = inode.lookup(path.as_str())?;
-        if inode.metadata()?.file_type != FileType::SymLink {
-            return Err(SystemError::EINVAL);
-        }
-
-        let ubuf = user_buf.buffer::<u8>(0).unwrap();
-
-        let file = File::new(inode, FileMode::O_RDONLY)?;
-
-        let len = file.read(buf_size, ubuf)?;
-
-        return Ok(len);
+    let inode = inode.lookup(path.as_str())?;
+    if inode.metadata()?.file_type != FileType::SymLink {
+        return Err(SystemError::EINVAL);
     }
+
+    let ubuf = user_buf.buffer::<u8>(0).unwrap();
+
+    let file = File::new(inode, FileMode::O_RDONLY)?;
+
+    let len = file.read(buf_size, ubuf)?;
+
+    return Ok(len);
+}

--- a/kernel/src/filesystem/vfs/syscall/readlink_at.rs
+++ b/kernel/src/filesystem/vfs/syscall/readlink_at.rs
@@ -1,0 +1,31 @@
+use system_error::SystemError;
+
+use crate::{filesystem::vfs::{file::{File, FileMode}, utils::user_path_at, FileType, MAX_PATHLEN}, process::ProcessManager, syscall::user_access::{check_and_clone_cstr, UserBufferWriter}};
+
+pub fn do_readlink_at(
+        dirfd: i32,
+        path: *const u8,
+        user_buf: *mut u8,
+        buf_size: usize,
+    ) -> Result<usize, SystemError> {
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        let path = path.as_str().trim();
+        let mut user_buf = UserBufferWriter::new(user_buf, buf_size, true)?;
+
+        let (inode, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
+
+        let inode = inode.lookup(path.as_str())?;
+        if inode.metadata()?.file_type != FileType::SymLink {
+            return Err(SystemError::EINVAL);
+        }
+
+        let ubuf = user_buf.buffer::<u8>(0).unwrap();
+
+        let file = File::new(inode, FileMode::O_RDONLY)?;
+
+        let len = file.read(buf_size, ubuf)?;
+
+        return Ok(len);
+    }

--- a/kernel/src/filesystem/vfs/syscall/rename_utils.rs
+++ b/kernel/src/filesystem/vfs/syscall/rename_utils.rs
@@ -2,7 +2,6 @@ use crate::filesystem::vfs::utils::rsplit_path;
 use crate::filesystem::vfs::utils::user_path_at;
 use crate::filesystem::vfs::SystemError;
 use crate::filesystem::vfs::MAX_PATHLEN;
-use crate::filesystem::vfs::ROOT_INODE;
 use crate::filesystem::vfs::VFS_MAX_FOLLOW_SYMLINK_TIMES;
 use crate::process::ProcessManager;
 use crate::syscall::user_access::check_and_clone_cstr;
@@ -47,11 +46,12 @@ pub fn do_renameat2(
     let (_old_inode_begin, old_remain_path) = user_path_at(&pcb, oldfd, &filename_from)?;
     let (_new_inode_begin, new_remain_path) = user_path_at(&pcb, newfd, &filename_to)?;
     //获取父目录
+    let root_inode = ProcessManager::current_mntns().root_inode();
     let (old_filename, old_parent_path) = rsplit_path(&old_remain_path);
-    let old_parent_inode = ROOT_INODE()
+    let old_parent_inode = root_inode
         .lookup_follow_symlink(old_parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
     let (new_filename, new_parent_path) = rsplit_path(&new_remain_path);
-    let new_parent_inode = ROOT_INODE()
+    let new_parent_inode = root_inode
         .lookup_follow_symlink(new_parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
     old_parent_inode.move_to(old_filename, &new_parent_inode, new_filename)?;
     return Ok(0);

--- a/kernel/src/filesystem/vfs/syscall/rename_utils.rs
+++ b/kernel/src/filesystem/vfs/syscall/rename_utils.rs
@@ -1,0 +1,58 @@
+use crate::filesystem::vfs::utils::rsplit_path;
+use crate::filesystem::vfs::utils::user_path_at;
+use crate::filesystem::vfs::SystemError;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::filesystem::vfs::ROOT_INODE;
+use crate::filesystem::vfs::VFS_MAX_FOLLOW_SYMLINK_TIMES;
+use crate::process::ProcessManager;
+use crate::syscall::user_access::check_and_clone_cstr;
+/// # 修改文件名
+///
+///
+/// ## 参数
+///
+/// - oldfd: 源文件夹文件描述符
+/// - filename_from: 源文件路径
+/// - newfd: 目标文件夹文件描述符
+/// - filename_to: 目标文件路径
+/// - flags: 标志位
+///
+///
+/// ## 返回值
+/// - Ok(返回值类型): 返回值的说明
+/// - Err(错误值类型): 错误的说明
+///
+pub fn do_renameat2(
+    oldfd: i32,
+    filename_from: *const u8,
+    newfd: i32,
+    filename_to: *const u8,
+    _flags: u32,
+) -> Result<usize, SystemError> {
+    let filename_from = check_and_clone_cstr(filename_from, Some(MAX_PATHLEN))
+        .unwrap()
+        .into_string()
+        .map_err(|_| SystemError::EINVAL)?;
+    let filename_to = check_and_clone_cstr(filename_to, Some(MAX_PATHLEN))
+        .unwrap()
+        .into_string()
+        .map_err(|_| SystemError::EINVAL)?;
+    // 文件名过长
+    if filename_from.len() > MAX_PATHLEN || filename_to.len() > MAX_PATHLEN {
+        return Err(SystemError::ENAMETOOLONG);
+    }
+
+    //获取pcb，文件节点
+    let pcb = ProcessManager::current_pcb();
+    let (_old_inode_begin, old_remain_path) = user_path_at(&pcb, oldfd, &filename_from)?;
+    let (_new_inode_begin, new_remain_path) = user_path_at(&pcb, newfd, &filename_to)?;
+    //获取父目录
+    let (old_filename, old_parent_path) = rsplit_path(&old_remain_path);
+    let old_parent_inode = ROOT_INODE()
+        .lookup_follow_symlink(old_parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+    let (new_filename, new_parent_path) = rsplit_path(&new_remain_path);
+    let new_parent_inode = ROOT_INODE()
+        .lookup_follow_symlink(new_parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+    old_parent_inode.move_to(old_filename, &new_parent_inode, new_filename)?;
+    return Ok(0);
+}

--- a/kernel/src/filesystem/vfs/syscall/sys_access.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_access.rs
@@ -1,0 +1,43 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_faccessat, syscall::ModeType},syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_ACCESS;
+
+pub struct SysAccessHandle;
+
+impl Syscall for SysAccessHandle {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pathname = Self::pathname(args);
+        let mode = Self::mode(args);
+        return do_faccessat(
+            AtFlags::AT_FDCWD.bits(),
+            pathname,
+            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
+            0,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pathname",format!("{:#x}",Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}",Self::mode(args))),
+        ]
+    }
+}
+
+impl SysAccessHandle{
+    fn pathname(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+
+    fn mode(args: &[usize]) -> u32 {
+        args[1] as u32
+    }
+} 
+
+syscall_table_macros::declare_syscall!(SYS_ACCESS,SysAccessHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_access.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_access.rs
@@ -1,8 +1,12 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_faccessat, syscall::ModeType},syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_ACCESS;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{fcntl::AtFlags, open::do_faccessat, syscall::ModeType},
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysAccessHandle;
 
@@ -24,13 +28,13 @@ impl Syscall for SysAccessHandle {
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("pathname",format!("{:#x}",Self::pathname(args) as usize)),
-            FormattedSyscallParam::new("mode", format!("{:#x}",Self::mode(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
         ]
     }
 }
 
-impl SysAccessHandle{
+impl SysAccessHandle {
     fn pathname(args: &[usize]) -> *const u8 {
         args[0] as *const u8
     }
@@ -38,6 +42,6 @@ impl SysAccessHandle{
     fn mode(args: &[usize]) -> u32 {
         args[1] as u32
     }
-} 
+}
 
-syscall_table_macros::declare_syscall!(SYS_ACCESS,SysAccessHandle);
+syscall_table_macros::declare_syscall!(SYS_ACCESS, SysAccessHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
@@ -1,0 +1,119 @@
+//! System call handler for changing current working directory.
+
+use system_error::SystemError;
+
+use alloc::{string::String, vec::Vec};
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_CHDIR;
+use crate::filesystem::vfs::{FileType, MAX_PATHLEN, ROOT_INODE, VFS_MAX_FOLLOW_SYMLINK_TIMES};
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::check_and_clone_cstr;
+
+/// System call handler for the `chdir` syscall
+///
+/// Changes the current working directory of the calling process.
+pub struct SysChdirHandle;
+
+impl Syscall for SysChdirHandle {
+    /// Returns the number of arguments expected by the `chdir` syscall
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    /// @brief 切换工作目录
+    ///
+    /// @param dest_path 目标路径
+    ///
+    /// @return   返回码  描述  
+    ///      0       |          成功  
+    ///         
+    ///   EACCESS    |        权限不足        
+    ///
+    ///    ELOOP     | 解析path时遇到路径循环
+    ///
+    /// ENAMETOOLONG |       路径名过长       
+    ///
+    ///    ENOENT    |  目标文件或目录不存在  
+    ///
+    ///    ENODIR    |  检索期间发现非目录项  
+    ///
+    ///    ENOMEM    |      系统内存不足      
+    ///
+    ///    EFAULT    |       错误的地址      
+    ///  
+    /// ENAMETOOLONG |        路径过长  
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let path = Self::path(args);
+
+        if path.is_null() {
+            return Err(SystemError::EFAULT);
+        }
+
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+
+        let proc = ProcessManager::current_pcb();
+        // Copy path to kernel space to avoid some security issues
+        let mut new_path = String::from("");
+        if !path.is_empty() {
+            let cwd = match path.as_bytes()[0] {
+                b'/' => String::from("/"),
+                _ => proc.basic().cwd(),
+            };
+            let mut cwd_vec: Vec<_> = cwd.split('/').filter(|&x| !x.is_empty()).collect();
+            let path_split = path.split('/').filter(|&x| !x.is_empty());
+            for seg in path_split {
+                if seg == ".." {
+                    cwd_vec.pop();
+                } else if seg == "." {
+                    // 当前目录
+                } else {
+                    cwd_vec.push(seg);
+                }
+            }
+            for seg in cwd_vec {
+                new_path.push('/');
+                new_path.push_str(seg);
+            }
+            if new_path.is_empty() {
+                new_path = String::from("/");
+            }
+        }
+        let inode =
+            match ROOT_INODE().lookup_follow_symlink(&new_path, VFS_MAX_FOLLOW_SYMLINK_TIMES) {
+                Err(_) => {
+                    return Err(SystemError::ENOENT);
+                }
+                Ok(i) => i,
+            };
+        let metadata = inode.metadata()?;
+        if metadata.file_type == FileType::Dir {
+            proc.basic_mut().set_cwd(new_path);
+            proc.fs_struct_mut().set_pwd(inode);
+            return Ok(0);
+        } else {
+            return Err(SystemError::ENOTDIR);
+        }
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "path",
+            format!("{:#x}", Self::path(args) as usize),
+        )]
+    }
+}
+
+impl SysChdirHandle {
+    /// Extracts the path argument from syscall parameters
+    fn path(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_CHDIR, SysChdirHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_chmod.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chmod.rs
@@ -1,12 +1,16 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchmodat, syscall::ModeType},syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_CHMOD;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{fcntl::AtFlags, open::do_fchmodat, syscall::ModeType},
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysChmodHandle;
 
-impl Syscall for SysChmodHandle{
+impl Syscall for SysChmodHandle {
     fn num_args(&self) -> usize {
         2
     }
@@ -23,18 +27,18 @@ impl Syscall for SysChmodHandle{
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),    
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
             FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
         ]
     }
 }
 
-impl SysChmodHandle{
-    fn pathname(args:&[usize])->*const u8{
+impl SysChmodHandle {
+    fn pathname(args: &[usize]) -> *const u8 {
         args[0] as *const u8
     }
 
-    fn mode(args:&[usize])->u32{
+    fn mode(args: &[usize]) -> u32 {
         args[1] as u32
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_chmod.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chmod.rs
@@ -1,0 +1,42 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchmodat, syscall::ModeType},syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_CHMOD;
+
+pub struct SysChmodHandle;
+
+impl Syscall for SysChmodHandle{
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pathname = Self::pathname(args);
+        let mode = Self::mode(args);
+        return do_fchmodat(
+            AtFlags::AT_FDCWD.bits(),
+            pathname,
+            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),    
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
+        ]
+    }
+}
+
+impl SysChmodHandle{
+    fn pathname(args:&[usize])->*const u8{
+        args[0] as *const u8
+    }
+
+    fn mode(args:&[usize])->u32{
+        args[1] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_CHMOD, SysChmodHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_chown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chown.rs
@@ -1,0 +1,53 @@
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchownat,  MAX_PATHLEN}, syscall::{table::{FormattedSyscallParam, Syscall}, user_access}};
+use alloc::vec::Vec;
+use system_error::SystemError;
+use crate::arch::syscall::nr::SYS_CHOWN;
+
+pub struct SyschownHandle;
+
+impl Syscall for SyschownHandle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pathname = Self::pathname(args);
+        let uid = Self::uid(args);
+        let gid = Self::gid(args);
+
+        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        return do_fchownat(
+            AtFlags::AT_FDCWD.bits(),
+            &pathname,
+            uid,
+            gid,
+            AtFlags::AT_STATX_SYNC_AS_STAT,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),    
+            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args) as usize)),    
+            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args) as usize)),    
+        ]
+    }
+}
+
+impl SyschownHandle{
+    fn pathname(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+
+    fn uid(args: &[usize]) -> usize {
+        args[1] as usize
+    }
+
+    fn gid(args: &[usize]) -> usize {
+        args[2] as usize
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_CHOWN, SyschownHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_chown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chown.rs
@@ -1,7 +1,14 @@
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchownat,  MAX_PATHLEN}, syscall::{table::{FormattedSyscallParam, Syscall}, user_access}};
+use crate::arch::syscall::nr::SYS_CHOWN;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{fcntl::AtFlags, open::do_fchownat, MAX_PATHLEN},
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access,
+    },
+};
 use alloc::vec::Vec;
 use system_error::SystemError;
-use crate::arch::syscall::nr::SYS_CHOWN;
 
 pub struct SyschownHandle;
 
@@ -29,24 +36,24 @@ impl Syscall for SyschownHandle {
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),    
-            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args) as usize)),    
-            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args) as usize)),    
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args))),
+            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args))),
         ]
     }
 }
 
-impl SyschownHandle{
+impl SyschownHandle {
     fn pathname(args: &[usize]) -> *const u8 {
         args[0] as *const u8
     }
 
     fn uid(args: &[usize]) -> usize {
-        args[1] as usize
+        args[1]
     }
 
     fn gid(args: &[usize]) -> usize {
-        args[2] as usize
+        args[2]
     }
 }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_dup.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_dup.rs
@@ -1,24 +1,28 @@
 use core::ffi::c_int;
 
-use crate::{arch::interrupt::TrapFrame,  process::ProcessManager, syscall::{table::{FormattedSyscallParam, Syscall}}};
+use crate::arch::syscall::nr::SYS_DUP;
+use crate::{
+    arch::interrupt::TrapFrame,
+    process::ProcessManager,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
 use alloc::vec::Vec;
 use system_error::SystemError;
-use crate::arch::syscall::nr::SYS_DUP;
 
 /// @brief 根据提供的文件描述符的fd，复制对应的文件结构体，并返回新复制的文件结构体对应的fd
 pub struct SysDupHandle;
 
 impl Syscall for SysDupHandle {
-   fn num_args(&self) -> usize {
-       1
-   }
+    fn num_args(&self) -> usize {
+        1
+    }
 
-   fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
-       let oldfd = Self::oldfd(args);
-       let binding = ProcessManager::current_pcb().fd_table();
-       let mut fd_table_guard = binding.write();
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let oldfd = Self::oldfd(args);
+        let binding = ProcessManager::current_pcb().fd_table();
+        let mut fd_table_guard = binding.write();
 
-       let old_file = fd_table_guard
+        let old_file = fd_table_guard
             .get_file_by_fd(oldfd)
             .ok_or(SystemError::EBADF)?;
 
@@ -28,17 +32,18 @@ impl Syscall for SysDupHandle {
         // 申请文件描述符，并把文件对象存入其中
         let res = fd_table_guard.alloc_fd(new_file, None).map(|x| x as usize);
         return res;
-   }
+    }
 
-   fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
-       vec![
-           FormattedSyscallParam::new("oldfd", format!("{:#x}", Self::oldfd(args))),
-       ]
-   }
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "oldfd",
+            format!("{:#x}", Self::oldfd(args)),
+        )]
+    }
 }
 
 impl SysDupHandle {
-    fn oldfd(args:&[usize])->c_int{
+    fn oldfd(args: &[usize]) -> c_int {
         args[0] as c_int
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_dup.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_dup.rs
@@ -1,0 +1,46 @@
+use core::ffi::c_int;
+
+use crate::{arch::interrupt::TrapFrame,  process::ProcessManager, syscall::{table::{FormattedSyscallParam, Syscall}}};
+use alloc::vec::Vec;
+use system_error::SystemError;
+use crate::arch::syscall::nr::SYS_DUP;
+
+/// @brief 根据提供的文件描述符的fd，复制对应的文件结构体，并返回新复制的文件结构体对应的fd
+pub struct SysDupHandle;
+
+impl Syscall for SysDupHandle {
+   fn num_args(&self) -> usize {
+       1
+   }
+
+   fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+       let oldfd = Self::oldfd(args);
+       let binding = ProcessManager::current_pcb().fd_table();
+       let mut fd_table_guard = binding.write();
+
+       let old_file = fd_table_guard
+            .get_file_by_fd(oldfd)
+            .ok_or(SystemError::EBADF)?;
+
+        let new_file = old_file.try_clone().ok_or(SystemError::EBADF)?;
+        // dup默认非cloexec
+        new_file.set_close_on_exec(false);
+        // 申请文件描述符，并把文件对象存入其中
+        let res = fd_table_guard.alloc_fd(new_file, None).map(|x| x as usize);
+        return res;
+   }
+
+   fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+       vec![
+           FormattedSyscallParam::new("oldfd", format!("{:#x}", Self::oldfd(args))),
+       ]
+   }
+}
+
+impl SysDupHandle {
+    fn oldfd(args:&[usize])->c_int{
+        args[0] as c_int
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_DUP, SysDupHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_dup2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_dup2.rs
@@ -1,0 +1,59 @@
+use core::ffi::c_int;
+
+use crate::arch::syscall::nr::SYS_DUP2;
+use crate::filesystem::vfs::syscall::dup2::do_dup2;
+use crate::{
+    arch::interrupt::TrapFrame,
+    process::ProcessManager,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+/// 根据提供的文件描述符的fd，和指定新fd，复制对应的文件结构体，
+/// 并返回新复制的文件结构体对应的fd.
+/// 如果新fd已经打开，则会先关闭新fd.
+///
+/// ## 参数
+///
+/// - `oldfd`：旧文件描述符
+/// - `newfd`：新文件描述符
+///
+/// ## 返回值
+///
+/// - 成功：新文件描述符
+/// - 失败：错误码
+pub struct SysDup2Handle;
+
+impl Syscall for SysDup2Handle {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let oldfd = Self::oldfd(args);
+        let newfd = Self::newfd(args);
+        let binding = ProcessManager::current_pcb().fd_table();
+        let mut fd_table_guard = binding.write();
+        return do_dup2(oldfd, newfd, &mut fd_table_guard);
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("oldfd",format!("{:#x}", Self::oldfd(args))),
+            FormattedSyscallParam::new("newfd",format!("{:#x}", Self::newfd(args)))
+        ]
+    }
+}
+
+impl SysDup2Handle {
+    fn oldfd(args: &[usize]) -> c_int {
+        args[0] as c_int
+    }
+
+    fn newfd(args: &[usize]) -> c_int {
+        args[1] as c_int
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_DUP2, SysDup2Handle);

--- a/kernel/src/filesystem/vfs/syscall/sys_dup2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_dup2.rs
@@ -40,8 +40,8 @@ impl Syscall for SysDup2Handle {
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("oldfd",format!("{:#x}", Self::oldfd(args))),
-            FormattedSyscallParam::new("newfd",format!("{:#x}", Self::newfd(args)))
+            FormattedSyscallParam::new("oldfd", format!("{:#x}", Self::oldfd(args))),
+            FormattedSyscallParam::new("newfd", format!("{:#x}", Self::newfd(args))),
         ]
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_dup3.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_dup3.rs
@@ -1,0 +1,61 @@
+use core::ffi::c_int;
+
+use crate::arch::syscall::nr::SYS_DUP3;
+use crate::filesystem::vfs::file::FileMode;
+use crate::filesystem::vfs::syscall::dup2::do_dup3;
+use crate::{
+    arch::interrupt::TrapFrame,
+    process::ProcessManager,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
+use system_error::SystemError;
+pub struct SysDup3Handle;
+
+impl Syscall for SysDup3Handle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let oldfd = Self::oldfd(args);
+        let newfd = Self::newfd(args);
+        let flags = Self::flags(args);
+        let flags = FileMode::from_bits_truncate(flags);
+        if (flags.bits() & !FileMode::O_CLOEXEC.bits()) != 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        if oldfd == newfd {
+            return Err(SystemError::EINVAL);
+        }
+
+        let binding = ProcessManager::current_pcb().fd_table();
+        let mut fd_table_guard = binding.write();
+        return do_dup3(oldfd, newfd, flags, &mut fd_table_guard);
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("oldfd", format!("{:#x}", Self::oldfd(args))),
+            FormattedSyscallParam::new("newfd", format!("{:#x}", Self::newfd(args))),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysDup3Handle {
+    fn oldfd(args: &[usize]) -> c_int {
+        args[0] as c_int
+    }
+
+    fn newfd(args: &[usize]) -> c_int {
+        args[1] as c_int
+    }
+
+    fn flags(args: &[usize]) -> u32 {
+        args[2] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_DUP3, SysDup3Handle);

--- a/kernel/src/filesystem/vfs/syscall/sys_faccessat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_faccessat.rs
@@ -1,0 +1,50 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::faccessat2::do_faccessat2},syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_FACCESSAT;
+
+pub struct SysFaccessatHandle;
+
+impl Syscall for SysFaccessatHandle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let pathname = Self::pathname(args);
+        let mode = Self::mode(args);
+
+        return do_faccessat2(
+            dirfd,
+            pathname,
+            mode,
+            0,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
+        ]
+    }
+}
+
+impl SysFaccessatHandle {
+    fn dirfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    fn pathname(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+
+    fn mode(args: &[usize]) -> u32 {
+        args[2] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FACCESSAT, SysFaccessatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_faccessat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_faccessat.rs
@@ -1,8 +1,12 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::faccessat2::do_faccessat2},syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_FACCESSAT;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::syscall::faccessat2::do_faccessat2,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysFaccessatHandle;
 
@@ -16,12 +20,7 @@ impl Syscall for SysFaccessatHandle {
         let pathname = Self::pathname(args);
         let mode = Self::mode(args);
 
-        return do_faccessat2(
-            dirfd,
-            pathname,
-            mode,
-            0,
-        );
+        return do_faccessat2(dirfd, pathname, mode, 0);
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/filesystem/vfs/syscall/sys_faccessat2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_faccessat2.rs
@@ -1,0 +1,56 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::faccessat2::do_faccessat2},syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_FACCESSAT2;
+
+pub struct SysFaccessat2Handle;
+
+impl Syscall for SysFaccessat2Handle {
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let pathname = Self::pathname(args);
+        let mode = Self::mode(args);
+        let flags = Self::flags(args);
+
+        return do_faccessat2(
+            dirfd,
+            pathname,
+            mode,
+            flags,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysFaccessat2Handle {
+    fn dirfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    fn pathname(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+
+    fn mode(args: &[usize]) -> u32 {
+        args[2] as u32
+    }
+
+    fn flags(args: &[usize]) -> u32 {
+        args[3] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FACCESSAT2, SysFaccessat2Handle);

--- a/kernel/src/filesystem/vfs/syscall/sys_faccessat2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_faccessat2.rs
@@ -1,8 +1,12 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::faccessat2::do_faccessat2},syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_FACCESSAT2;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::syscall::faccessat2::do_faccessat2,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysFaccessat2Handle;
 
@@ -17,12 +21,7 @@ impl Syscall for SysFaccessat2Handle {
         let mode = Self::mode(args);
         let flags = Self::flags(args);
 
-        return do_faccessat2(
-            dirfd,
-            pathname,
-            mode,
-            flags,
-        );
+        return do_faccessat2(dirfd, pathname, mode, flags);
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/filesystem/vfs/syscall/sys_fchdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchdir.rs
@@ -1,0 +1,65 @@
+//! System call handler for changing current working directory using file descriptor.
+
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_FCHDIR;
+use crate::filesystem::vfs::FileType;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+/// System call handler for the `fchdir` syscall
+///
+/// Changes the current working directory to the directory referenced by the file descriptor.
+pub struct SysFchdirHandle;
+
+impl Syscall for SysFchdirHandle {
+    /// Returns the number of arguments expected by the `fchdir` syscall
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    /// Changes the current working directory using a file descriptor
+    ///
+    /// ## Arguments
+    /// - `fd`: File descriptor referring to a directory
+    ///
+    /// ## Returns
+    /// - `Ok(0)`: Success
+    /// - `Err(SystemError)`: Various error conditions (EBADF, ENOTDIR, etc.)
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+
+        let pcb = ProcessManager::current_pcb();
+        let file = pcb
+            .fd_table()
+            .read()
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?;
+        let inode = file.inode();
+        if inode.metadata()?.file_type != FileType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+        let path = inode.absolute_path()?;
+        pcb.basic_mut().set_cwd(path);
+        pcb.fs_struct_mut().set_pwd(inode);
+        return Ok(0);
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new("fd", Self::fd(args).to_string())]
+    }
+}
+
+impl SysFchdirHandle {
+    /// Extracts the file descriptor argument from syscall parameters
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FCHDIR, SysFchdirHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fchmod.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchmod.rs
@@ -1,0 +1,49 @@
+use log::warn;
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::ModeType}, process::ProcessManager, syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_FCHMOD;
+
+pub struct SysFchmodHandle;
+
+impl Syscall for SysFchmodHandle {
+    fn num_args(&self) -> usize {
+        2
+    }
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let mode = Self::mode(args);
+
+        let _mode = ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?;
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+        let _file = fd_table_guard
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?;
+
+        // fchmod没完全实现，因此不修改文件的权限
+        // todo: 实现fchmod
+        warn!("fchmod not fully implemented");
+        return Ok(0);
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", format!("{:#x}",Self::fd(args))),
+            FormattedSyscallParam::new("mode", format!("{:#x}",Self::mode(args))),
+        ]
+    }
+}
+
+impl SysFchmodHandle {
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    fn mode(args: &[usize]) -> u32 {
+        args[1] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FCHMOD, SysFchmodHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fchmod.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchmod.rs
@@ -1,9 +1,14 @@
 use log::warn;
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::ModeType}, process::ProcessManager, syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_FCHMOD;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::syscall::ModeType,
+    process::ProcessManager,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysFchmodHandle;
 
@@ -30,8 +35,8 @@ impl Syscall for SysFchmodHandle {
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("fd", format!("{:#x}",Self::fd(args))),
-            FormattedSyscallParam::new("mode", format!("{:#x}",Self::mode(args))),
+            FormattedSyscallParam::new("fd", format!("{:#x}", Self::fd(args))),
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
         ]
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_fchmodat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchmodat.rs
@@ -1,0 +1,49 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame,filesystem::vfs::{open::do_fchmodat, syscall::ModeType}, syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_FCHMODAT;
+
+pub struct SysFchmodatHandle;
+
+impl Syscall for SysFchmodatHandle{
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let pathname = Self::pathname(args);
+        let mode = Self::mode(args);
+
+        return do_fchmodat(
+            dirfd,
+            pathname,
+            ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}",Self::dirfd(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}",Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}",Self::mode(args))),
+        ]
+    }
+}
+
+impl SysFchmodatHandle   {
+    fn dirfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    fn pathname(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+
+    fn mode(args: &[usize]) ->u32 {
+        args[2] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FCHMODAT, SysFchmodatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fchmodat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchmodat.rs
@@ -1,12 +1,16 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame,filesystem::vfs::{open::do_fchmodat, syscall::ModeType}, syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_FCHMODAT;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{open::do_fchmodat, syscall::ModeType},
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysFchmodatHandle;
 
-impl Syscall for SysFchmodatHandle{
+impl Syscall for SysFchmodatHandle {
     fn num_args(&self) -> usize {
         3
     }
@@ -25,14 +29,14 @@ impl Syscall for SysFchmodatHandle{
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("dirfd", format!("{:#x}",Self::dirfd(args))),
-            FormattedSyscallParam::new("pathname", format!("{:#x}",Self::pathname(args) as usize)),
-            FormattedSyscallParam::new("mode", format!("{:#x}",Self::mode(args))),
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
         ]
     }
 }
 
-impl SysFchmodatHandle   {
+impl SysFchmodatHandle {
     fn dirfd(args: &[usize]) -> i32 {
         args[0] as i32
     }
@@ -41,7 +45,7 @@ impl SysFchmodatHandle   {
         args[1] as *const u8
     }
 
-    fn mode(args: &[usize]) ->u32 {
+    fn mode(args: &[usize]) -> u32 {
         args[2] as u32
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_fchown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchown.rs
@@ -1,0 +1,43 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::open::ksys_fchown, syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_FCHOWN;
+
+pub struct SysFchownHandle;
+
+impl Syscall for SysFchownHandle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let uid = Self::uid(args);
+        let gid = Self::gid(args);
+        ksys_fchown(fd, uid, gid)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", format!("{:#x}", Self::fd(args))),
+            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args))),
+            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args))),
+        ]
+    }
+}
+
+impl SysFchownHandle{
+    fn fd(args:&[usize])->i32{
+        args[0] as i32
+    }
+     fn uid (args:&[usize])->usize{
+        args[1] as usize
+     }
+
+     fn gid (args:&[usize])->usize{
+        args[2] as usize
+     }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FCHOWN, SysFchownHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fchown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchown.rs
@@ -1,8 +1,12 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::open::ksys_fchown, syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_FCHOWN;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::open::ksys_fchown,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysFchownHandle;
 
@@ -27,17 +31,17 @@ impl Syscall for SysFchownHandle {
     }
 }
 
-impl SysFchownHandle{
-    fn fd(args:&[usize])->i32{
+impl SysFchownHandle {
+    fn fd(args: &[usize]) -> i32 {
         args[0] as i32
     }
-     fn uid (args:&[usize])->usize{
-        args[1] as usize
-     }
+    fn uid(args: &[usize]) -> usize {
+        args[1]
+    }
 
-     fn gid (args:&[usize])->usize{
-        args[2] as usize
-     }
+    fn gid(args: &[usize]) -> usize {
+        args[2]
+    }
 }
 
 syscall_table_macros::declare_syscall!(SYS_FCHOWN, SysFchownHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fchownat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchownat.rs
@@ -1,0 +1,63 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchownat, MAX_PATHLEN}, syscall::{table::{FormattedSyscallParam, Syscall}, user_access}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_FCHOWNAT;
+
+pub struct SysFchownatHandle;
+
+impl Syscall for SysFchownatHandle {
+    fn num_args(&self) -> usize {
+        5
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let pathname = Self::pathname(args);
+        let uid = Self::uid(args);
+        let gid = Self::gid(args);
+        let flags = Self::flags(args);
+
+        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        let pathname = pathname.as_str().trim();
+        let flags = AtFlags::from_bits_truncate(flags);
+        return do_fchownat(dirfd, pathname, uid, gid, flags);
+
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args))),
+            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args))),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysFchownatHandle {
+    fn dirfd(args:&[usize])->i32{
+        args[0] as i32
+    }
+
+    fn pathname(args:&[usize])->*const u8{
+        args[1] as *const u8
+    }
+
+    fn uid(args:&[usize])->usize{
+        args[2] as usize
+    }
+
+    fn gid(args:&[usize])->usize{
+        args[3] as usize
+    }
+
+    fn flags(args:&[usize])->i32{
+        args[4] as i32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FCHOWNAT, SysFchownatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fchownat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchownat.rs
@@ -1,8 +1,15 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchownat, MAX_PATHLEN}, syscall::{table::{FormattedSyscallParam, Syscall}, user_access}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_FCHOWNAT;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{fcntl::AtFlags, open::do_fchownat, MAX_PATHLEN},
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access,
+    },
+};
+use alloc::vec::Vec;
 
 pub struct SysFchownatHandle;
 
@@ -24,7 +31,6 @@ impl Syscall for SysFchownatHandle {
         let pathname = pathname.as_str().trim();
         let flags = AtFlags::from_bits_truncate(flags);
         return do_fchownat(dirfd, pathname, uid, gid, flags);
-
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
@@ -39,23 +45,23 @@ impl Syscall for SysFchownatHandle {
 }
 
 impl SysFchownatHandle {
-    fn dirfd(args:&[usize])->i32{
+    fn dirfd(args: &[usize]) -> i32 {
         args[0] as i32
     }
 
-    fn pathname(args:&[usize])->*const u8{
+    fn pathname(args: &[usize]) -> *const u8 {
         args[1] as *const u8
     }
 
-    fn uid(args:&[usize])->usize{
-        args[2] as usize
+    fn uid(args: &[usize]) -> usize {
+        args[2]
     }
 
-    fn gid(args:&[usize])->usize{
-        args[3] as usize
+    fn gid(args: &[usize]) -> usize {
+        args[3]
     }
 
-    fn flags(args:&[usize])->i32{
+    fn flags(args: &[usize]) -> i32 {
         args[4] as i32
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
@@ -1,0 +1,166 @@
+use crate::arch::syscall::nr::SYS_FCNTL;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{
+        fcntl::{FcntlCommand, FD_CLOEXEC},
+        file::{FileDescriptorVec, FileMode},
+        syscall::dup2::{do_dup2, do_dup3},
+    },
+    process::ProcessManager,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
+use log::warn;
+use num_traits::FromPrimitive;
+use system_error::SystemError;
+
+pub struct SysFcntlHandle;
+
+impl Syscall for SysFcntlHandle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let cmd = Self::cmd(args);
+        let arg = Self::arg(args);
+
+        let cmd: Option<FcntlCommand> = <FcntlCommand as FromPrimitive>::from_u32(cmd);
+        let res = if let Some(cmd) = cmd {
+            Self::do_fcntl(fd, cmd, arg)
+        } else {
+            Err(SystemError::EINVAL)
+        };
+
+        // debug!("FCNTL: fd: {}, cmd: {:?}, arg: {}, res: {:?}", fd, cmd, arg, res);
+        res
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", format!("{:#x}", Self::fd(args))),
+            FormattedSyscallParam::new("cmd", format!("{:#x}", Self::cmd(args))),
+            FormattedSyscallParam::new("arg", format!("{:#x}", Self::arg(args))),
+        ]
+    }
+}
+
+impl SysFcntlHandle {
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    fn cmd(args: &[usize]) -> u32 {
+        args[1] as u32
+    }
+
+    fn arg(args: &[usize]) -> i32 {
+        args[2] as i32
+    }
+
+    /// # fcntl
+    ///
+    /// ## 参数
+    ///
+    /// - `fd`：文件描述符
+    /// - `cmd`：命令
+    /// - `arg`：参数
+    pub fn do_fcntl(fd: i32, cmd: FcntlCommand, arg: i32) -> Result<usize, SystemError> {
+        // debug!("fcntl ({cmd:?}) fd: {fd}, arg={arg}");
+        match cmd {
+            FcntlCommand::DupFd | FcntlCommand::DupFdCloexec => {
+                if arg < 0 || arg as usize >= FileDescriptorVec::PROCESS_MAX_FD {
+                    return Err(SystemError::EBADF);
+                }
+                let arg = arg as usize;
+                for i in arg..FileDescriptorVec::PROCESS_MAX_FD {
+                    let binding = ProcessManager::current_pcb().fd_table();
+                    let mut fd_table_guard = binding.write();
+                    if fd_table_guard.get_file_by_fd(i as i32).is_none() {
+                        if cmd == FcntlCommand::DupFd {
+                            return do_dup2(fd, i as i32, &mut fd_table_guard);
+                        } else {
+                            return do_dup3(fd, i as i32, FileMode::O_CLOEXEC, &mut fd_table_guard);
+                        }
+                    }
+                }
+                return Err(SystemError::EMFILE);
+            }
+            FcntlCommand::GetFd => {
+                // Get file descriptor flags.
+                let binding = ProcessManager::current_pcb().fd_table();
+                let fd_table_guard = binding.read();
+
+                if let Some(file) = fd_table_guard.get_file_by_fd(fd) {
+                    // drop guard 以避免无法调度的问题
+                    drop(fd_table_guard);
+
+                    if file.close_on_exec() {
+                        return Ok(FD_CLOEXEC as usize);
+                    } else {
+                        return Ok(0);
+                    }
+                }
+                return Err(SystemError::EBADF);
+            }
+            FcntlCommand::SetFd => {
+                // Set file descriptor flags.
+                let binding = ProcessManager::current_pcb().fd_table();
+                let fd_table_guard = binding.write();
+
+                if let Some(file) = fd_table_guard.get_file_by_fd(fd) {
+                    // drop guard 以避免无法调度的问题
+                    drop(fd_table_guard);
+                    let arg = arg as u32;
+                    if arg & FD_CLOEXEC != 0 {
+                        file.set_close_on_exec(true);
+                    } else {
+                        file.set_close_on_exec(false);
+                    }
+                    return Ok(0);
+                }
+                return Err(SystemError::EBADF);
+            }
+
+            FcntlCommand::GetFlags => {
+                // Get file status flags.
+                let binding = ProcessManager::current_pcb().fd_table();
+                let fd_table_guard = binding.read();
+
+                if let Some(file) = fd_table_guard.get_file_by_fd(fd) {
+                    // drop guard 以避免无法调度的问题
+                    drop(fd_table_guard);
+                    return Ok(file.mode().bits() as usize);
+                }
+
+                return Err(SystemError::EBADF);
+            }
+            FcntlCommand::SetFlags => {
+                // Set file status flags.
+                let binding = ProcessManager::current_pcb().fd_table();
+                let fd_table_guard = binding.write();
+
+                if let Some(file) = fd_table_guard.get_file_by_fd(fd) {
+                    let arg = arg as u32;
+                    let mode = FileMode::from_bits(arg).ok_or(SystemError::EINVAL)?;
+                    // drop guard 以避免无法调度的问题
+                    drop(fd_table_guard);
+                    file.set_mode(mode)?;
+                    return Ok(0);
+                }
+
+                return Err(SystemError::EBADF);
+            }
+            _ => {
+                // TODO: unimplemented
+                // 未实现的命令，返回0，不报错。
+
+                warn!("fcntl: unimplemented command: {:?}, defaults to 0.", cmd);
+                return Err(SystemError::ENOSYS);
+            }
+        }
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FCNTL, SysFcntlHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fstat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fstat.rs
@@ -3,6 +3,7 @@
 use system_error::SystemError;
 
 use crate::arch::syscall::nr::SYS_FSTAT;
+use crate::filesystem::vfs::syscall::newfstat::do_newfstat;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
 
@@ -20,7 +21,7 @@ impl Syscall for SysFstatHandle {
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let fd = Self::fd(args);
         let usr_kstat = Self::usr_kstat(args);
-        crate::syscall::Syscall::newfstat(fd, usr_kstat)
+        do_newfstat(fd, usr_kstat)
     }
 
     /// Formats the syscall arguments for display/debugging purposes.

--- a/kernel/src/filesystem/vfs/syscall/sys_fstatfs.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fstatfs.rs
@@ -1,0 +1,50 @@
+use system_error::SystemError;
+use alloc::vec::Vec;
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_FSTATFS;
+use crate::filesystem::vfs::syscall::PosixStatfs;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferWriter;
+
+pub struct SysFstatfsHandle;
+
+impl Syscall for SysFstatfsHandle{
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let user_statfs = Self::statfs(args);
+        let mut writer = UserBufferWriter::new(user_statfs, size_of::<PosixStatfs>(), true)?;
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+        let file = fd_table_guard
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?;
+        drop(fd_table_guard);
+        let statfs = PosixStatfs::from(file.inode().fs().super_block());
+        writer.copy_one_to_user(&statfs, 0)?;
+        return Ok(0);
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dfd", format!("{:#x}", Self::fd(args) as usize)),
+            FormattedSyscallParam::new("statfs", format!("{:#x}", Self::statfs(args) as usize)),
+        ]
+    }
+}
+
+impl SysFstatfsHandle{
+    fn fd(args:&[usize])->i32{
+        args[0] as i32
+    }
+    fn statfs(args:&[usize])->*mut PosixStatfs{
+        args[1] as *mut PosixStatfs
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FSTATFS,SysFstatfsHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_fstatfs.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fstatfs.rs
@@ -1,5 +1,3 @@
-use system_error::SystemError;
-use alloc::vec::Vec;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_FSTATFS;
 use crate::filesystem::vfs::syscall::PosixStatfs;
@@ -7,10 +5,12 @@ use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
 use crate::syscall::user_access::UserBufferWriter;
+use alloc::vec::Vec;
+use system_error::SystemError;
 
 pub struct SysFstatfsHandle;
 
-impl Syscall for SysFstatfsHandle{
+impl Syscall for SysFstatfsHandle {
     fn num_args(&self) -> usize {
         2
     }
@@ -38,13 +38,13 @@ impl Syscall for SysFstatfsHandle{
     }
 }
 
-impl SysFstatfsHandle{
-    fn fd(args:&[usize])->i32{
+impl SysFstatfsHandle {
+    fn fd(args: &[usize]) -> i32 {
         args[0] as i32
     }
-    fn statfs(args:&[usize])->*mut PosixStatfs{
+    fn statfs(args: &[usize]) -> *mut PosixStatfs {
         args[1] as *mut PosixStatfs
     }
 }
 
-syscall_table_macros::declare_syscall!(SYS_FSTATFS,SysFstatfsHandle);
+syscall_table_macros::declare_syscall!(SYS_FSTATFS, SysFstatfsHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_ftruncate.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_ftruncate.rs
@@ -1,0 +1,67 @@
+use crate::arch::syscall::nr::SYS_FTRUNCATE;
+use crate::{
+    arch::interrupt::TrapFrame,
+    process::ProcessManager,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+/// # ftruncate
+///
+/// ## 描述
+///
+/// 改变文件大小.
+/// 如果文件大小大于原来的大小，那么文件的内容将会被扩展到指定的大小，新的空间将会用0填充.
+/// 如果文件大小小于原来的大小，那么文件的内容将会被截断到指定的大小.
+///
+/// ## 参数
+///
+/// - `fd`：文件描述符
+/// - `len`：文件大小
+///
+/// ## 返回值
+///
+/// 如果成功，返回0，否则返回错误码.
+pub struct SysFtruncateHandle;
+
+impl Syscall for SysFtruncateHandle {
+    fn num_args(&self) -> usize {
+        2
+    }
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let len = Self::len(args);
+
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+
+        if let Some(file) = fd_table_guard.get_file_by_fd(fd) {
+            // drop guard 以避免无法调度的问题
+            drop(fd_table_guard);
+            let r = file.ftruncate(len).map(|_| 0);
+            return r;
+        }
+
+        return Err(SystemError::EBADF);
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", format!("{:#x}", Self::fd(args))),
+            FormattedSyscallParam::new("len", format!("{:#x}", Self::len(args))),
+        ]
+    }
+}
+
+impl SysFtruncateHandle {
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    fn len(args: &[usize]) -> usize {
+        args[1]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FTRUNCATE,SysFtruncateHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_ftruncate.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_ftruncate.rs
@@ -64,4 +64,4 @@ impl SysFtruncateHandle {
     }
 }
 
-syscall_table_macros::declare_syscall!(SYS_FTRUNCATE,SysFtruncateHandle);
+syscall_table_macros::declare_syscall!(SYS_FTRUNCATE, SysFtruncateHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_futimesat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_futimesat.rs
@@ -1,0 +1,44 @@
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::syscall::UtimensFlags, syscall::table::{FormattedSyscallParam, Syscall}, time::PosixTimeSpec};
+use alloc::vec::Vec;
+use system_error::SystemError;
+use crate::arch::syscall::nr::SYS_FUTIMESAT;
+pub struct SysFutimesatHandle;
+
+impl Syscall for SysFutimesatHandle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let pathname = Self::pathname(args);
+        let times = Self::times(args);
+        let flags = UtimensFlags::empty();
+        super::utimensat::do_sys_utimensat(dirfd, pathname, times, flags.bits())
+
+    }
+       
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("times", format!("{:#x}", Self::times(args) as usize)),
+        ]
+    }
+}
+
+impl SysFutimesatHandle{
+   fn dirfd(args:&[usize])->i32{
+        args[0] as i32
+    }
+
+    fn pathname(args:&[usize])->*const u8{
+        args[1] as *const u8
+    }
+
+    fn times(args:&[usize])->*const PosixTimeSpec{
+        args[2] as *const PosixTimeSpec
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_FUTIMESAT, SysFutimesatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_futimesat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_futimesat.rs
@@ -1,7 +1,12 @@
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::syscall::UtimensFlags, syscall::table::{FormattedSyscallParam, Syscall}, time::PosixTimeSpec};
+use crate::arch::syscall::nr::SYS_FUTIMESAT;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::syscall::UtimensFlags,
+    syscall::table::{FormattedSyscallParam, Syscall},
+    time::PosixTimeSpec,
+};
 use alloc::vec::Vec;
 use system_error::SystemError;
-use crate::arch::syscall::nr::SYS_FUTIMESAT;
 pub struct SysFutimesatHandle;
 
 impl Syscall for SysFutimesatHandle {
@@ -15,9 +20,8 @@ impl Syscall for SysFutimesatHandle {
         let times = Self::times(args);
         let flags = UtimensFlags::empty();
         super::utimensat::do_sys_utimensat(dirfd, pathname, times, flags.bits())
-
     }
-       
+
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
             FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
@@ -27,16 +31,16 @@ impl Syscall for SysFutimesatHandle {
     }
 }
 
-impl SysFutimesatHandle{
-   fn dirfd(args:&[usize])->i32{
+impl SysFutimesatHandle {
+    fn dirfd(args: &[usize]) -> i32 {
         args[0] as i32
     }
 
-    fn pathname(args:&[usize])->*const u8{
+    fn pathname(args: &[usize]) -> *const u8 {
         args[1] as *const u8
     }
 
-    fn times(args:&[usize])->*const PosixTimeSpec{
+    fn times(args: &[usize]) -> *const PosixTimeSpec {
         args[2] as *const PosixTimeSpec
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_getcwd.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_getcwd.rs
@@ -1,0 +1,82 @@
+//! System call handler for getting current working directory.
+
+use system_error::SystemError;
+
+use crate::alloc::string::ToString;
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_GETCWD;
+use crate::mm::verify_area;
+use crate::mm::VirtAddr;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::vec::Vec;
+
+/// System call handler for the `getcwd` syscall
+///
+/// Gets the current working directory path and copies it to user buffer.
+pub struct SysGetcwdHandle;
+
+impl Syscall for SysGetcwdHandle {
+    /// Returns the number of arguments expected by the `getcwd` syscall
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    /// @brief 获取当前进程的工作目录路径
+    ///
+    /// @param buf 指向缓冲区的指针
+    /// @param size 缓冲区的大小
+    ///
+    /// @return 成功，返回的指针指向包含工作目录路径的字符串
+    /// @return 错误，没有足够的空间
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let buf_vaddr = Self::buf(args);
+        let size = Self::size(args);
+
+        let security_check = || {
+            verify_area(VirtAddr::new(buf_vaddr as usize), size)?;
+            return Ok(());
+        };
+        let r = security_check();
+        if let Err(e) = r {
+            Err(e)
+        } else {
+            let buf = unsafe { core::slice::from_raw_parts_mut(buf_vaddr, size) };
+            let proc = ProcessManager::current_pcb();
+            let cwd = proc.basic().cwd();
+
+            let cwd_bytes = cwd.as_bytes();
+            let cwd_len = cwd_bytes.len();
+            if cwd_len + 1 > buf.len() {
+                return Err(SystemError::ENOMEM);
+            }
+            buf[..cwd_len].copy_from_slice(cwd_bytes);
+            buf[cwd_len] = 0;
+
+            return Ok(cwd_len + 1);
+        }
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("buf", format!("{:#x}", Self::buf(args) as usize)),
+            FormattedSyscallParam::new("size", Self::size(args).to_string()),
+        ]
+    }
+}
+
+impl SysGetcwdHandle {
+    /// Extracts the buffer pointer from syscall parameters
+    fn buf(args: &[usize]) -> *mut u8 {
+        args[0] as *mut u8
+    }
+
+    /// Extracts the buffer size from syscall parameters
+    fn size(args: &[usize]) -> usize {
+        args[1]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_GETCWD, SysGetcwdHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_getdents.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_getdents.rs
@@ -1,0 +1,113 @@
+//! System call handler for getting directory entries.
+
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::{SYS_GETDENTS, SYS_GETDENTS64};
+use crate::filesystem::vfs::file::FileDescriptorVec;
+use crate::filesystem::vfs::FilldirContext;
+use crate::mm::{verify_area, VirtAddr};
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+/// System call handler for the `getdents` syscall
+///
+/// Reads directory entries from a directory file descriptor.
+pub struct SysGetdentsHandle;
+
+impl Syscall for SysGetdentsHandle {
+    /// Returns the number of arguments expected by the `getdents` syscall
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    /// # 获取目录中的数据
+    ///
+    /// ## 参数
+    /// - fd 文件描述符号
+    /// - buf 输出缓冲区
+    ///
+    /// ## 返回值
+    /// - Ok(ctx.current_pos) 填充缓冲区当前指针位置
+    /// - Err(ctx.error.unwrap()) 填充缓冲区时返回的错误
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let buf_vaddr = Self::buf(args);
+        let len = Self::len(args);
+        let virt_addr: VirtAddr = VirtAddr::new(buf_vaddr);
+        // 判断缓冲区是否来自用户态，进行权限校验
+        let res = if frame.is_from_user() && verify_area(virt_addr, len).is_err() {
+            // 来自用户态，而buffer在内核态，这样的操作不被允许
+            Err(SystemError::EPERM)
+        } else if buf_vaddr == 0 {
+            Err(SystemError::EFAULT)
+        } else {
+            let buf: &mut [u8] = unsafe {
+                core::slice::from_raw_parts_mut::<'static, u8>(buf_vaddr as *mut u8, len)
+            };
+            if fd < 0 || fd as usize > FileDescriptorVec::PROCESS_MAX_FD {
+                return Err(SystemError::EBADF);
+            }
+
+            // 获取fd
+            let binding = ProcessManager::current_pcb().fd_table();
+            let fd_table_guard = binding.read();
+            let file = fd_table_guard
+                .get_file_by_fd(fd)
+                .ok_or(SystemError::EBADF)?;
+
+            // drop guard 以避免无法调度的问题
+            drop(fd_table_guard);
+
+            let mut ctx = FilldirContext::new(buf);
+            match file.read_dir(&mut ctx) {
+                Ok(_) => {
+                    if ctx.error.is_some() {
+                        if ctx.error == Some(SystemError::EINVAL) {
+                            return Ok(ctx.current_pos);
+                        } else {
+                            return Err(ctx.error.unwrap());
+                        }
+                    }
+                    return Ok(ctx.current_pos);
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        };
+        return res;
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", Self::fd(args).to_string()),
+            FormattedSyscallParam::new("buf", format!("{:#x}", Self::buf(args))),
+            FormattedSyscallParam::new("count", Self::len(args).to_string()),
+        ]
+    }
+}
+
+impl SysGetdentsHandle {
+    /// Extracts the file descriptor from syscall parameters
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    /// Extracts the buffer pointer from syscall parameters
+    fn buf(args: &[usize]) -> usize {
+        args[1]
+    }
+
+    /// Extracts the buffer size from syscall parameters
+    fn len(args: &[usize]) -> usize {
+        args[2]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_GETDENTS, SysGetdentsHandle);
+syscall_table_macros::declare_syscall!(SYS_GETDENTS64, SysGetdentsHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_lchown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_lchown.rs
@@ -1,7 +1,14 @@
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchownat,  MAX_PATHLEN}, syscall::{table::{FormattedSyscallParam, Syscall}, user_access}};
+use crate::arch::syscall::nr::SYS_LCHOWN;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{fcntl::AtFlags, open::do_fchownat, MAX_PATHLEN},
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access,
+    },
+};
 use alloc::vec::Vec;
 use system_error::SystemError;
-use crate::arch::syscall::nr::SYS_LCHOWN;
 
 pub struct SysLchownHandle;
 
@@ -15,7 +22,7 @@ impl Syscall for SysLchownHandle {
         let uid = Self::uid(args);
         let gid = Self::gid(args);
 
-         let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         return do_fchownat(
@@ -29,24 +36,24 @@ impl Syscall for SysLchownHandle {
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),    
-            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args) as usize)),    
-            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args) as usize)),    
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args))),
+            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args))),
         ]
     }
 }
 
-impl SysLchownHandle{
+impl SysLchownHandle {
     fn pathname(args: &[usize]) -> *const u8 {
         args[0] as *const u8
     }
 
     fn uid(args: &[usize]) -> usize {
-        args[1] as usize
+        args[1]
     }
 
     fn gid(args: &[usize]) -> usize {
-        args[2] as usize
+        args[2]
     }
 }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_lchown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_lchown.rs
@@ -1,0 +1,53 @@
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, open::do_fchownat,  MAX_PATHLEN}, syscall::{table::{FormattedSyscallParam, Syscall}, user_access}};
+use alloc::vec::Vec;
+use system_error::SystemError;
+use crate::arch::syscall::nr::SYS_LCHOWN;
+
+pub struct SysLchownHandle;
+
+impl Syscall for SysLchownHandle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pathname = Self::pathname(args);
+        let uid = Self::uid(args);
+        let gid = Self::gid(args);
+
+         let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        return do_fchownat(
+            AtFlags::AT_FDCWD.bits(),
+            &pathname,
+            uid,
+            gid,
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),    
+            FormattedSyscallParam::new("uid", format!("{:#x}", Self::uid(args) as usize)),    
+            FormattedSyscallParam::new("gid", format!("{:#x}", Self::gid(args) as usize)),    
+        ]
+    }
+}
+
+impl SysLchownHandle{
+    fn pathname(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+
+    fn uid(args: &[usize]) -> usize {
+        args[1] as usize
+    }
+
+    fn gid(args: &[usize]) -> usize {
+        args[2] as usize
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_LCHOWN, SysLchownHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_link.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_link.rs
@@ -1,0 +1,70 @@
+//! System call handler for creating hard links (link).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_LINK;
+use crate::filesystem::vfs::syscall::AtFlags;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::syscall::user_access::check_and_clone_cstr;
+use alloc::string::String;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysLinkHandle;
+
+impl Syscall for SysLinkHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    /// Handles the link syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let old = Self::old_path(args);
+        let new = Self::new_path(args);
+
+        let get_path = |cstr: *const u8| -> Result<String, SystemError> {
+            let res = check_and_clone_cstr(cstr, Some(MAX_PATHLEN))?
+                .into_string()
+                .map_err(|_| SystemError::EINVAL)?;
+            if res.len() >= MAX_PATHLEN {
+                return Err(SystemError::ENAMETOOLONG);
+            }
+            if res.is_empty() {
+                return Err(SystemError::ENOENT);
+            }
+            Ok(res)
+        };
+
+        let old = get_path(old)?;
+        let new = get_path(new)?;
+        super::link_utils::do_linkat(
+            AtFlags::AT_FDCWD.bits(),
+            &old,
+            AtFlags::AT_FDCWD.bits(),
+            &new,
+            AtFlags::empty(),
+        )
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("old", format!("{:#x}", Self::old_path(args) as usize)),
+            FormattedSyscallParam::new("new", format!("{:#x}", Self::new_path(args) as usize)),
+        ]
+    }
+}
+
+impl SysLinkHandle {
+    /// Extracts the old path argument from syscall parameters.
+    fn old_path(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+    /// Extracts the new path argument from syscall parameters.
+    fn new_path(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_LINK, SysLinkHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_linkat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_linkat.rs
@@ -1,0 +1,79 @@
+//! System call handler for creating hard links (linkat).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_LINKAT;
+use crate::filesystem::vfs::syscall::AtFlags;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::syscall::user_access::check_and_clone_cstr;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysLinkAtHandle;
+
+impl Syscall for SysLinkAtHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        5
+    }
+
+    /// Handles the linkat syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let oldfd = Self::oldfd(args);
+        let old = Self::old_path(args);
+        let newfd = Self::newfd(args);
+        let new = Self::new_path(args);
+        let flags = Self::flags(args);
+
+        let old = check_and_clone_cstr(old, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        let new = check_and_clone_cstr(new, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        if old.len() >= MAX_PATHLEN || new.len() >= MAX_PATHLEN {
+            return Err(SystemError::ENAMETOOLONG);
+        }
+        if new.is_empty() {
+            return Err(SystemError::ENOENT);
+        }
+        let flags = AtFlags::from_bits(flags).ok_or(SystemError::EINVAL)?;
+        super::link_utils::do_linkat(oldfd, &old, newfd, &new, flags)
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("oldfd", format!("{:#x}", Self::oldfd(args))),
+            FormattedSyscallParam::new("old", format!("{:#x}", Self::old_path(args) as usize)),
+            FormattedSyscallParam::new("newfd", format!("{:#x}", Self::newfd(args))),
+            FormattedSyscallParam::new("new", format!("{:#x}", Self::new_path(args) as usize)),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysLinkAtHandle {
+    /// Extracts the oldfd argument from syscall parameters.
+    fn oldfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+    /// Extracts the old path argument from syscall parameters.
+    fn old_path(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+    /// Extracts the newfd argument from syscall parameters.
+    fn newfd(args: &[usize]) -> i32 {
+        args[2] as i32
+    }
+    /// Extracts the new path argument from syscall parameters.
+    fn new_path(args: &[usize]) -> *const u8 {
+        args[3] as *const u8
+    }
+    /// Extracts the flags argument from syscall parameters.
+    fn flags(args: &[usize]) -> i32 {
+        args[4] as i32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_LINKAT, SysLinkAtHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_lseek.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_lseek.rs
@@ -1,0 +1,132 @@
+//! System call handler for seeking to a position in a file.
+
+use system_error::SystemError;
+
+use super::SEEK_MAX;
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_LSEEK;
+use crate::driver::base::block::SeekFrom;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use super::{SEEK_CUR, SEEK_END, SEEK_SET};
+
+/// System call handler for the `lseek` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for seeking
+/// to a specific position in a file.
+pub struct SysLseekHandle;
+
+impl Syscall for SysLseekHandle {
+    /// Returns the number of arguments expected by the `lseek` syscall
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    /// @brief 调整文件操作指针的位置
+    ///
+    /// @param fd 文件描述符编号
+    /// @param seek 调整的方式
+    ///
+    /// @return Ok(usize) 调整后，文件访问指针相对于文件头部的偏移量
+    /// @return Err(SystemError) 调整失败，返回posix错误码
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let offset = Self::offset(args);
+        let whence = Self::whence(args);
+
+        // Convert seek type to SeekFrom enum
+        let seek = match whence {
+            SEEK_SET => Ok(SeekFrom::SeekSet(offset)),
+            SEEK_CUR => Ok(SeekFrom::SeekCurrent(offset)),
+            SEEK_END => Ok(SeekFrom::SeekEnd(offset)),
+            SEEK_MAX => Ok(SeekFrom::SeekEnd(0)),
+            _ => Err(SystemError::EINVAL),
+        }?;
+
+        // Get file from file descriptor table
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+        let file = fd_table_guard
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?;
+
+        // Drop guard to avoid scheduling issues
+        drop(fd_table_guard);
+
+        // Perform the seek operation
+        return file.lseek(seek);
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", Self::fd(args).to_string()),
+            FormattedSyscallParam::new("offset", Self::offset(args).to_string()),
+            FormattedSyscallParam::new("whence", Self::whence_name(Self::whence(args))),
+        ]
+    }
+}
+
+impl SysLseekHandle {
+    /// Extracts the file descriptor from syscall arguments
+    ///
+    /// # Arguments
+    /// * `args` - The syscall arguments array
+    ///
+    /// # Returns
+    /// The file descriptor as i32
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    /// Extracts the offset value from syscall arguments
+    ///
+    /// # Arguments
+    /// * `args` - The syscall arguments array
+    ///
+    /// # Returns
+    /// The offset value as i64
+    fn offset(args: &[usize]) -> i64 {
+        args[1] as i64
+    }
+
+    /// Extracts the whence parameter from syscall arguments
+    ///
+    /// # Arguments
+    /// * `args` - The syscall arguments array
+    ///
+    /// # Returns
+    /// The whence parameter as u32
+    fn whence(args: &[usize]) -> u32 {
+        args[2] as u32
+    }
+
+    /// Converts whence value to human-readable name for debugging
+    ///
+    /// # Arguments
+    /// * `whence` - The whence parameter value
+    ///
+    /// # Returns
+    /// String representation of the whence parameter
+    fn whence_name(whence: u32) -> String {
+        match whence {
+            SEEK_SET => "SEEK_SET".to_string(),
+            SEEK_CUR => "SEEK_CUR".to_string(),
+            SEEK_END => "SEEK_END".to_string(),
+            SEEK_MAX => "SEEK_MAX".to_string(),
+            _ => format!("UNKNOWN({})", whence),
+        }
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_LSEEK, SysLseekHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_lstat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_lstat.rs
@@ -7,6 +7,7 @@ use defer::defer;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_LSTAT;
 use crate::filesystem::vfs::file::FileMode;
+use crate::filesystem::vfs::syscall::newfstat::do_newfstat;
 use crate::filesystem::vfs::syscall::sys_close::do_close;
 use crate::filesystem::vfs::ModeType;
 use crate::syscall::table::FormattedSyscallParam;
@@ -35,7 +36,7 @@ impl Syscall for SysLstatHandle {
         defer!({
             do_close(fd as i32).ok();
         });
-        crate::syscall::Syscall::newfstat(fd as i32, usr_kstat)?;
+        do_newfstat(fd as i32, usr_kstat)?;
 
         return Ok(0);
     }

--- a/kernel/src/filesystem/vfs/syscall/sys_mkdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mkdir.rs
@@ -1,0 +1,64 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_MKDIR;
+use crate::filesystem::vfs::fcntl::AtFlags;
+use crate::filesystem::vfs::file::FileMode;
+use crate::filesystem::vfs::vcore::do_mkdir_at;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysMkdirHandle;
+
+impl Syscall for SysMkdirHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    /// @brief 创建文件夹
+    ///
+    /// @param path(r8) 路径 / mode(r9) 模式
+    ///
+    /// @return uint64_t 负数错误码 / 0表示成功
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let path = Self::path(args);
+        let mode = Self::mode(args);
+
+        let path = crate::filesystem::vfs::syscall::check_and_clone_cstr(
+            path,
+            Some(crate::filesystem::vfs::MAX_PATHLEN),
+        )?
+        .into_string()
+        .map_err(|_| SystemError::EINVAL)?;
+
+        do_mkdir_at(
+            AtFlags::AT_FDCWD.bits(),
+            &path,
+            FileMode::from_bits_truncate(mode as u32),
+        )?;
+        return Ok(0);
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("path", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
+        ]
+    }
+}
+
+impl SysMkdirHandle {
+    /// Extracts the path argument from syscall parameters.
+    fn path(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+
+    /// Extracts the mode argument from syscall parameters.
+    fn mode(args: &[usize]) -> usize {
+        args[1]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_MKDIR, SysMkdirHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_mkdirat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mkdirat.rs
@@ -1,0 +1,60 @@
+//! System call handler for creating directories (mkdirat).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_MKDIRAT;
+use crate::filesystem::vfs::file::FileMode;
+use crate::filesystem::vfs::vcore::do_mkdir_at;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysMkdirAtHandle;
+
+impl Syscall for SysMkdirAtHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    /// Handles the mkdirat syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let path = Self::path(args);
+        let mode = Self::mode(args);
+
+        let path = crate::filesystem::vfs::syscall::check_and_clone_cstr(
+            path,
+            Some(crate::filesystem::vfs::MAX_PATHLEN),
+        )?
+        .into_string()
+        .map_err(|_| SystemError::EINVAL)?;
+        do_mkdir_at(dirfd, &path, FileMode::from_bits_truncate(mode as u32))?;
+        Ok(0)
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("path", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("mode", format!("{:#x}", Self::mode(args))),
+        ]
+    }
+}
+
+impl SysMkdirAtHandle {
+    /// Extracts the dirfd argument from syscall parameters.
+    fn dirfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+    /// Extracts the path argument from syscall parameters.
+    fn path(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+    /// Extracts the mode argument from syscall parameters.
+    fn mode(args: &[usize]) -> usize {
+        args[2]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_MKDIRAT, SysMkdirAtHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_mknod.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mknod.rs
@@ -1,0 +1,80 @@
+use system_error::SystemError;
+
+use crate::{
+    arch::interrupt::TrapFrame,
+    driver::base::device::device_number::DeviceNumber,
+    filesystem::vfs::{
+        syscall::ModeType, utils::rsplit_path, IndexNode, MAX_PATHLEN, ROOT_INODE,
+        VFS_MAX_FOLLOW_SYMLINK_TIMES,
+    },
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access::check_and_clone_cstr,
+    },
+};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use crate::arch::syscall::nr::SYS_MKNOD;
+
+pub struct SysMknodHandle;
+
+impl Syscall for SysMknodHandle {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let path = Self::path(args);
+        let flags = Self::flags(args);
+        let dev_t = Self::dev_t(args);
+        let flags: ModeType = ModeType::from_bits_truncate(flags as u32);
+        let dev_t = DeviceNumber::from(dev_t as u32);
+
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        let path = path.as_str().trim();
+
+        let inode: Result<Arc<dyn IndexNode>, SystemError> =
+            ROOT_INODE().lookup_follow_symlink(path, VFS_MAX_FOLLOW_SYMLINK_TIMES);
+
+        if inode.is_ok() {
+            return Err(SystemError::EEXIST);
+        }
+
+        let (filename, parent_path) = rsplit_path(path);
+
+        // 查找父目录
+        let parent_inode: Arc<dyn IndexNode> = ROOT_INODE()
+            .lookup_follow_symlink(parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+        // 创建nod
+        parent_inode.mknod(filename, flags, dev_t)?;
+
+        return Ok(0);
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("path", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+            FormattedSyscallParam::new("dev_t", format!("{:#x}", Self::dev_t(args))),
+        ]
+    }
+}
+
+impl SysMknodHandle {
+    fn path(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+
+    fn flags(args: &[usize]) -> usize {
+        args[1]
+    }
+
+    fn dev_t(args: &[usize]) -> usize {
+        args[2]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_MKNOD, SysMknodHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_newfstatat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_newfstatat.rs
@@ -1,0 +1,67 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{stat::do_newfstatat,MAX_PATHLEN},syscall::{table::{FormattedSyscallParam, Syscall}, user_access::check_and_clone_cstr}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_NEWFSTATAT;
+
+pub struct SysNewFstatatHandle;
+
+impl Syscall for SysNewFstatatHandle{
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dfd = Self::dfd(args);
+        let filename_ptr = Self::filename_ptr(args);
+        let user_stat_buf_ptr = Self::user_stat_buf_ptr(args);
+        let flags = Self::flags(args);
+        Self::newfstatat(dfd, filename_ptr, user_stat_buf_ptr, flags)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dfd", format!("{:#x}", Self::dfd(args))),
+            FormattedSyscallParam::new("filename", format!("{:#x}", Self::filename_ptr(args))),
+            FormattedSyscallParam::new("user_stat_buf_ptr", format!("{:#x}", Self::user_stat_buf_ptr(args))),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysNewFstatatHandle{
+    fn dfd(args:&[usize])->i32{
+        args[0] as i32
+    }
+
+    fn filename_ptr(args:&[usize])->usize{
+        args[1]
+    }
+
+    fn user_stat_buf_ptr(args:&[usize])->usize{
+        args[2]
+    }
+
+    fn flags(args:&[usize])->u32{
+        args[3] as u32
+    }
+
+    #[inline(never)]
+    fn newfstatat(
+        dfd: i32,
+        filename_ptr: usize,
+        user_stat_buf_ptr: usize,
+        flags: u32,
+    ) -> Result<usize, SystemError> {
+        if user_stat_buf_ptr == 0 {
+            return Err(SystemError::EFAULT);
+        }
+
+        let filename = check_and_clone_cstr(filename_ptr as *const u8, Some(MAX_PATHLEN))?;
+        let filename_str = filename.to_str().map_err(|_| SystemError::EINVAL)?;
+
+        do_newfstatat(dfd, filename_str, user_stat_buf_ptr, flags).map(|_| 0)
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_NEWFSTATAT, SysNewFstatatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_newfstatat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_newfstatat.rs
@@ -1,12 +1,19 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{stat::do_newfstatat,MAX_PATHLEN},syscall::{table::{FormattedSyscallParam, Syscall}, user_access::check_and_clone_cstr}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_NEWFSTATAT;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{stat::do_newfstatat, MAX_PATHLEN},
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access::check_and_clone_cstr,
+    },
+};
+use alloc::vec::Vec;
 
 pub struct SysNewFstatatHandle;
 
-impl Syscall for SysNewFstatatHandle{
+impl Syscall for SysNewFstatatHandle {
     fn num_args(&self) -> usize {
         4
     }
@@ -23,26 +30,29 @@ impl Syscall for SysNewFstatatHandle{
         vec![
             FormattedSyscallParam::new("dfd", format!("{:#x}", Self::dfd(args))),
             FormattedSyscallParam::new("filename", format!("{:#x}", Self::filename_ptr(args))),
-            FormattedSyscallParam::new("user_stat_buf_ptr", format!("{:#x}", Self::user_stat_buf_ptr(args))),
+            FormattedSyscallParam::new(
+                "user_stat_buf_ptr",
+                format!("{:#x}", Self::user_stat_buf_ptr(args)),
+            ),
             FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
         ]
     }
 }
 
-impl SysNewFstatatHandle{
-    fn dfd(args:&[usize])->i32{
+impl SysNewFstatatHandle {
+    fn dfd(args: &[usize]) -> i32 {
         args[0] as i32
     }
 
-    fn filename_ptr(args:&[usize])->usize{
+    fn filename_ptr(args: &[usize]) -> usize {
         args[1]
     }
 
-    fn user_stat_buf_ptr(args:&[usize])->usize{
+    fn user_stat_buf_ptr(args: &[usize]) -> usize {
         args[2]
     }
 
-    fn flags(args:&[usize])->u32{
+    fn flags(args: &[usize]) -> u32 {
         args[3] as u32
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_openat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_openat.rs
@@ -1,0 +1,90 @@
+//! System call handler for opening files relative to a directory.
+
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_OPENAT;
+use crate::filesystem::vfs::file::FileMode;
+use crate::filesystem::vfs::open::do_sys_open;
+use crate::filesystem::vfs::ModeType;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::check_and_clone_cstr;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+/// System call handler for the `openat` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for opening files
+/// relative to a directory file descriptor.
+pub struct SysOpenatHandle;
+
+impl Syscall for SysOpenatHandle {
+    /// Returns the number of arguments expected by the `openat` syscall
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    /// Handles the `openat` system call
+    ///
+    /// Opens a file relative to a directory file descriptor.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Directory file descriptor (i32)
+    ///   - args[1]: Pointer to path string (*const u8)
+    ///   - args[2]: Open flags (u32)
+    ///   - args[3]: File mode/permissions (u32)
+    /// * `frame` - Trap frame containing context information
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - File descriptor of the opened file
+    /// * `Err(SystemError)` - Error code if operation fails
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let path_ptr = Self::path(args);
+        let o_flags = Self::o_flags(args);
+        let mode = Self::mode(args);
+        let path = check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        let open_flags = FileMode::from_bits(o_flags).ok_or(SystemError::EINVAL)?;
+        let mode_type = ModeType::from_bits(mode).ok_or(SystemError::EINVAL)?;
+        return do_sys_open(dirfd, &path, open_flags, mode_type, true);
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", Self::dirfd(args).to_string()),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::o_flags(args))),
+            FormattedSyscallParam::new("mode", format!("{:#o}", Self::mode(args))),
+        ]
+    }
+}
+
+impl SysOpenatHandle {
+    /// Extracts the directory file descriptor from syscall arguments
+    fn dirfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    /// Extracts the path pointer from syscall arguments
+    fn path(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+
+    /// Extracts the open flags from syscall arguments
+    fn o_flags(args: &[usize]) -> u32 {
+        args[2] as u32
+    }
+
+    /// Extracts the file mode/permissions from syscall arguments
+    fn mode(args: &[usize]) -> u32 {
+        args[3] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_OPENAT, SysOpenatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_pread64.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_pread64.rs
@@ -1,0 +1,87 @@
+//! System call handler for reading data at a specific offset.
+
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_PREAD64;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferWriter;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+/// System call handler for the `pread64` syscall
+///
+/// Reads data from a file at a specific offset without changing the file position.
+pub struct SysPread64Handle;
+
+impl Syscall for SysPread64Handle {
+    /// Returns the number of arguments expected by the `pread64` syscall
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    /// # sys_pread64 系统调用的实际执行函数
+    ///
+    /// ## 参数
+    /// - `fd`: 文件描述符
+    /// - `buf`: 读出缓冲区
+    /// - `len`: 要读取的字节数
+    /// - `offset`: 文件偏移量
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let buf_vaddr = Self::buf(args);
+        let len = Self::len(args);
+        let offset = Self::offset(args);
+
+        let mut user_buffer_writer = UserBufferWriter::new(buf_vaddr, len, frame.is_from_user())?;
+        let user_buf = user_buffer_writer.buffer(0)?;
+
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+
+        let file = fd_table_guard
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?;
+
+        // Drop guard to avoid scheduling issues
+        drop(fd_table_guard);
+
+        return file.pread(offset, len, user_buf);
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", Self::fd(args).to_string()),
+            FormattedSyscallParam::new("buf", format!("{:#x}", Self::buf(args) as usize)),
+            FormattedSyscallParam::new("count", Self::len(args).to_string()),
+            FormattedSyscallParam::new("offset", Self::offset(args).to_string()),
+        ]
+    }
+}
+
+impl SysPread64Handle {
+    /// Extracts the file descriptor from syscall arguments
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    /// Extracts the buffer pointer from syscall arguments
+    fn buf(args: &[usize]) -> *mut u8 {
+        args[1] as *mut u8
+    }
+
+    /// Extracts the buffer length from syscall arguments
+    fn len(args: &[usize]) -> usize {
+        args[2]
+    }
+
+    /// Extracts the file offset from syscall arguments
+    fn offset(args: &[usize]) -> usize {
+        args[3]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_PREAD64, SysPread64Handle);

--- a/kernel/src/filesystem/vfs/syscall/sys_pwrite64.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_pwrite64.rs
@@ -1,0 +1,88 @@
+//! System call handler for writing data at a specific offset.
+
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_PWRITE64;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferReader;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+/// System call handler for the `pwrite64` syscall
+///
+/// Writes data to a file at a specific offset without changing the file position.
+pub struct SysPwrite64Handle;
+
+impl Syscall for SysPwrite64Handle {
+    /// Returns the number of arguments expected by the `pwrite64` syscall
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    /// # sys_pwrite64 系统调用的实际执行函数
+    ///
+    /// ## 参数
+    /// - `fd`: 文件描述符
+    /// - `buf`: 写入缓冲区
+    /// - `len`: 要写入的字节数
+    /// - `offset`: 文件偏移量
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = Self::fd(args);
+        let buf_vaddr = Self::buf(args);
+        let len = Self::len(args);
+        let offset = Self::offset(args);
+
+        let user_buffer_reader = UserBufferReader::new(buf_vaddr, len, frame.is_from_user())?;
+        let user_buf = user_buffer_reader.read_from_user(0)?;
+
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+
+        let file = fd_table_guard.get_file_by_fd(fd);
+        if file.is_none() {
+            return Err(SystemError::EBADF);
+        }
+        // drop guard 以避免无法调度的问题
+        drop(fd_table_guard);
+        let file = file.unwrap();
+
+        return file.pwrite(offset, len, user_buf);
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", Self::fd(args).to_string()),
+            FormattedSyscallParam::new("buf", format!("{:#x}", Self::buf(args) as usize)),
+            FormattedSyscallParam::new("count", Self::len(args).to_string()),
+            FormattedSyscallParam::new("offset", Self::offset(args).to_string()),
+        ]
+    }
+}
+
+impl SysPwrite64Handle {
+    /// Extracts the file descriptor from syscall arguments
+    fn fd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+
+    /// Extracts the buffer pointer from syscall arguments
+    fn buf(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+
+    /// Extracts the buffer length from syscall arguments
+    fn len(args: &[usize]) -> usize {
+        args[2]
+    }
+
+    /// Extracts the file offset from syscall arguments
+    fn offset(args: &[usize]) -> usize {
+        args[3]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_PWRITE64, SysPwrite64Handle);

--- a/kernel/src/filesystem/vfs/syscall/sys_readlink.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_readlink.rs
@@ -1,12 +1,16 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, syscall::{readlink_at::do_readlink_at}},syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_READLINK;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::{fcntl::AtFlags, syscall::readlink_at::do_readlink_at},
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysReadlinkHandle;
 
-impl Syscall for SysReadlinkHandle{
+impl Syscall for SysReadlinkHandle {
     fn num_args(&self) -> usize {
         3
     }
@@ -16,12 +20,7 @@ impl Syscall for SysReadlinkHandle{
         let user_buf = Self::user_buf(args);
         let buf_size = Self::buf_size(args);
 
-        return do_readlink_at(
-            AtFlags::AT_FDCWD.bits(),
-            path,
-            user_buf,
-            buf_size,
-        );
+        return do_readlink_at(AtFlags::AT_FDCWD.bits(), path, user_buf, buf_size);
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
@@ -34,14 +33,14 @@ impl Syscall for SysReadlinkHandle{
 }
 
 impl SysReadlinkHandle {
-    fn path(args:&[usize])->*const u8{
+    fn path(args: &[usize]) -> *const u8 {
         args[0] as *const u8
     }
 
-    fn user_buf(args:&[usize])->*mut u8{
+    fn user_buf(args: &[usize]) -> *mut u8 {
         args[1] as *mut u8
     }
-    fn buf_size(args:&[usize])->usize{
+    fn buf_size(args: &[usize]) -> usize {
         args[2]
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_readlink.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_readlink.rs
@@ -1,0 +1,49 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{fcntl::AtFlags, syscall::{readlink_at::do_readlink_at}},syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_READLINK;
+
+pub struct SysReadlinkHandle;
+
+impl Syscall for SysReadlinkHandle{
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let path = Self::path(args);
+        let user_buf = Self::user_buf(args);
+        let buf_size = Self::buf_size(args);
+
+        return do_readlink_at(
+            AtFlags::AT_FDCWD.bits(),
+            path,
+            user_buf,
+            buf_size,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("path", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("buf", format!("{:#x}", Self::user_buf(args) as usize)),
+            FormattedSyscallParam::new("buf_size", format!("{:#x}", Self::buf_size(args))),
+        ]
+    }
+}
+
+impl SysReadlinkHandle {
+    fn path(args:&[usize])->*const u8{
+        args[0] as *const u8
+    }
+
+    fn user_buf(args:&[usize])->*mut u8{
+        args[1] as *mut u8
+    }
+    fn buf_size(args:&[usize])->usize{
+        args[2]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_READLINK, SysReadlinkHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_readlinkat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_readlinkat.rs
@@ -1,0 +1,55 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::{readlink_at::do_readlink_at}},syscall::table::{FormattedSyscallParam, Syscall}};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_READLINKAT;
+
+pub struct SysReadlinkatHandle;
+
+impl Syscall for SysReadlinkatHandle{
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let path = Self::path(args);
+        let user_buf = Self::user_buf(args);
+        let buf_size = Self::buf_size(args);
+
+        return do_readlink_at(
+            dirfd,
+            path,
+            user_buf,
+            buf_size,
+        );
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("path", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("buf", format!("{:#x}", Self::user_buf(args) as usize)),
+            FormattedSyscallParam::new("buf_size", format!("{:#x}", Self::buf_size(args))),
+        ]
+    }
+}
+
+impl SysReadlinkatHandle {
+    fn dirfd(args:&[usize])->i32{
+        args[0] as i32
+    }
+
+    fn path(args:&[usize])->*const u8{
+        args[1] as *const u8
+    }
+
+    fn user_buf(args:&[usize])->*mut u8{
+        args[2] as *mut u8
+    }
+    fn buf_size(args:&[usize])->usize{
+        args[3]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_READLINKAT, SysReadlinkatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_readlinkat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_readlinkat.rs
@@ -1,12 +1,16 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, filesystem::vfs::{syscall::{readlink_at::do_readlink_at}},syscall::table::{FormattedSyscallParam, Syscall}};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_READLINKAT;
+use crate::{
+    arch::interrupt::TrapFrame,
+    filesystem::vfs::syscall::readlink_at::do_readlink_at,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+use alloc::vec::Vec;
 
 pub struct SysReadlinkatHandle;
 
-impl Syscall for SysReadlinkatHandle{
+impl Syscall for SysReadlinkatHandle {
     fn num_args(&self) -> usize {
         4
     }
@@ -17,12 +21,7 @@ impl Syscall for SysReadlinkatHandle{
         let user_buf = Self::user_buf(args);
         let buf_size = Self::buf_size(args);
 
-        return do_readlink_at(
-            dirfd,
-            path,
-            user_buf,
-            buf_size,
-        );
+        return do_readlink_at(dirfd, path, user_buf, buf_size);
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
@@ -36,18 +35,18 @@ impl Syscall for SysReadlinkatHandle{
 }
 
 impl SysReadlinkatHandle {
-    fn dirfd(args:&[usize])->i32{
+    fn dirfd(args: &[usize]) -> i32 {
         args[0] as i32
     }
 
-    fn path(args:&[usize])->*const u8{
+    fn path(args: &[usize]) -> *const u8 {
         args[1] as *const u8
     }
 
-    fn user_buf(args:&[usize])->*mut u8{
+    fn user_buf(args: &[usize]) -> *mut u8 {
         args[2] as *mut u8
     }
-    fn buf_size(args:&[usize])->usize{
+    fn buf_size(args: &[usize]) -> usize {
         args[3]
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_rename.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_rename.rs
@@ -1,0 +1,51 @@
+//! System call handler for renaming files or directories (rename).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_RENAME;
+use crate::filesystem::vfs::syscall::AtFlags;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysRenameHandle;
+
+impl Syscall for SysRenameHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    /// Handles the rename syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let oldname = Self::oldname(args);
+        let newname = Self::newname(args);
+        super::rename_utils::do_renameat2(
+            AtFlags::AT_FDCWD.bits(),
+            oldname,
+            AtFlags::AT_FDCWD.bits(),
+            newname,
+            0,
+        )
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("oldname", format!("{:#x}", Self::oldname(args) as usize)),
+            FormattedSyscallParam::new("newname", format!("{:#x}", Self::newname(args) as usize)),
+        ]
+    }
+}
+
+impl SysRenameHandle {
+    /// Extracts the oldname argument from syscall parameters.
+    fn oldname(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+    /// Extracts the newname argument from syscall parameters.
+    fn newname(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_RENAME, SysRenameHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_renameat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_renameat.rs
@@ -1,0 +1,56 @@
+//! System call handler for renaming files or directories (renameat).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_RENAMEAT;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysRenameAtHandle;
+
+impl Syscall for SysRenameAtHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    /// Handles the renameat syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let oldfd = Self::oldfd(args);
+        let oldname = Self::oldname(args);
+        let newfd = Self::newfd(args);
+        let newname = Self::newname(args);
+        super::rename_utils::do_renameat2(oldfd, oldname, newfd, newname, 0)
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("oldfd", format!("{:#x}", Self::oldfd(args))),
+            FormattedSyscallParam::new("oldname", format!("{:#x}", Self::oldname(args) as usize)),
+            FormattedSyscallParam::new("newfd", format!("{:#x}", Self::newfd(args))),
+            FormattedSyscallParam::new("newname", format!("{:#x}", Self::newname(args) as usize)),
+        ]
+    }
+}
+
+impl SysRenameAtHandle {
+    /// Extracts the oldfd argument from syscall parameters.
+    fn oldfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+    /// Extracts the oldname argument from syscall parameters.
+    fn oldname(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+    /// Extracts the newfd argument from syscall parameters.
+    fn newfd(args: &[usize]) -> i32 {
+        args[2] as i32
+    }
+    /// Extracts the newname argument from syscall parameters.
+    fn newname(args: &[usize]) -> *const u8 {
+        args[3] as *const u8
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_RENAMEAT, SysRenameAtHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_renameat2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_renameat2.rs
@@ -1,0 +1,62 @@
+//! System call handler for renaming files or directories (renameat2).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_RENAMEAT2;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysRenameAt2Handle;
+
+impl Syscall for SysRenameAt2Handle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        5
+    }
+
+    /// Handles the renameat2 syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let oldfd = Self::oldfd(args);
+        let oldname = Self::oldname(args);
+        let newfd = Self::newfd(args);
+        let newname = Self::newname(args);
+        let flags = Self::flags(args);
+        super::rename_utils::do_renameat2(oldfd, oldname, newfd, newname, flags)
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("oldfd", format!("{:#x}", Self::oldfd(args))),
+            FormattedSyscallParam::new("oldname", format!("{:#x}", Self::oldname(args) as usize)),
+            FormattedSyscallParam::new("newfd", format!("{:#x}", Self::newfd(args))),
+            FormattedSyscallParam::new("newname", format!("{:#x}", Self::newname(args) as usize)),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysRenameAt2Handle {
+    /// Extracts the oldfd argument from syscall parameters.
+    fn oldfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+    /// Extracts the oldname argument from syscall parameters.
+    fn oldname(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+    /// Extracts the newfd argument from syscall parameters.
+    fn newfd(args: &[usize]) -> i32 {
+        args[2] as i32
+    }
+    /// Extracts the newname argument from syscall parameters.
+    fn newname(args: &[usize]) -> *const u8 {
+        args[3] as *const u8
+    }
+    /// Extracts the flags argument from syscall parameters.
+    fn flags(args: &[usize]) -> u32 {
+        args[4] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_RENAMEAT2, SysRenameAt2Handle);

--- a/kernel/src/filesystem/vfs/syscall/sys_rmdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_rmdir.rs
@@ -1,0 +1,46 @@
+//! System call handler for removing directories (rmdir).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_RMDIR;
+use crate::filesystem::vfs::syscall::AtFlags;
+use crate::filesystem::vfs::vcore::do_remove_dir;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::syscall::user_access::check_and_clone_cstr;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysRmdirHandle;
+
+impl Syscall for SysRmdirHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    /// Handles the rmdir syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let path = Self::path(args);
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        return do_remove_dir(AtFlags::AT_FDCWD.bits(), &path).map(|v| v as usize);
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "path",
+            format!("{:#x}", Self::path(args) as usize),
+        )]
+    }
+}
+
+impl SysRmdirHandle {
+    /// Extracts the path argument from syscall parameters.
+    fn path(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_RMDIR, SysRmdirHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_stat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_stat.rs
@@ -5,6 +5,7 @@ use system_error::SystemError;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_STAT;
 use crate::filesystem::vfs::file::FileMode;
+use crate::filesystem::vfs::syscall::newfstat::do_newfstat;
 use crate::filesystem::vfs::syscall::sys_close::do_close;
 use crate::filesystem::vfs::ModeType;
 use crate::syscall::table::FormattedSyscallParam;
@@ -36,7 +37,7 @@ impl Syscall for SysStatHandle {
             do_close(fd as i32).ok();
         });
 
-        crate::syscall::Syscall::newfstat(fd as i32, usr_kstat)?;
+        do_newfstat(fd as i32, usr_kstat)?;
 
         return Ok(0);
     }

--- a/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
@@ -1,0 +1,64 @@
+use system_error::SystemError;
+use alloc::vec::Vec;
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_STATFS;
+use crate::filesystem::vfs::file::FileMode;
+use crate::filesystem::vfs::syscall::open_utils;
+use crate::filesystem::vfs::syscall::ModeType;
+use crate::filesystem::vfs::syscall::PosixStatfs;
+use crate::filesystem::vfs::utils::user_path_at;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::filesystem::vfs::ROOT_INODE;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::UserBufferWriter;
+
+pub struct SysStatfsHandle;
+
+impl Syscall for SysStatfsHandle{
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let path = Self::path(args);
+        let user_statfs = Self::statfs(args);
+        let mut writer = UserBufferWriter::new(user_statfs, size_of::<PosixStatfs>(), true)?;
+        let fd = open_utils::do_open(
+            path,
+            FileMode::O_RDONLY.bits(),
+            ModeType::empty().bits(),
+            true,
+        )?;
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))
+            .unwrap()
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        let pcb = ProcessManager::current_pcb();
+        let (_inode_begin, remain_path) = user_path_at(&pcb, fd as i32, &path)?;
+        let inode = ROOT_INODE().lookup_follow_symlink(&remain_path, MAX_PATHLEN)?;
+        let statfs = PosixStatfs::from(inode.fs().super_block());
+        writer.copy_one_to_user(&statfs, 0)?;
+        return Ok(0);
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dfd", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("statfs", format!("{:#x}", Self::statfs(args) as usize)),
+        ]
+    }
+}
+
+impl SysStatfsHandle{
+    fn path(args:&[usize])->*const u8{
+        args[0] as *const u8
+    }
+    fn statfs(args:&[usize])->*mut PosixStatfs{
+        args[1] as *mut PosixStatfs
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_STATFS,SysStatfsHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
@@ -1,5 +1,3 @@
-use system_error::SystemError;
-use alloc::vec::Vec;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_STATFS;
 use crate::filesystem::vfs::file::FileMode;
@@ -14,10 +12,12 @@ use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
 use crate::syscall::user_access::check_and_clone_cstr;
 use crate::syscall::user_access::UserBufferWriter;
+use alloc::vec::Vec;
+use system_error::SystemError;
 
 pub struct SysStatfsHandle;
 
-impl Syscall for SysStatfsHandle{
+impl Syscall for SysStatfsHandle {
     fn num_args(&self) -> usize {
         2
     }
@@ -52,13 +52,13 @@ impl Syscall for SysStatfsHandle{
     }
 }
 
-impl SysStatfsHandle{
-    fn path(args:&[usize])->*const u8{
+impl SysStatfsHandle {
+    fn path(args: &[usize]) -> *const u8 {
         args[0] as *const u8
     }
-    fn statfs(args:&[usize])->*mut PosixStatfs{
+    fn statfs(args: &[usize]) -> *mut PosixStatfs {
         args[1] as *mut PosixStatfs
     }
 }
 
-syscall_table_macros::declare_syscall!(SYS_STATFS,SysStatfsHandle);
+syscall_table_macros::declare_syscall!(SYS_STATFS, SysStatfsHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_statx.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statx.rs
@@ -1,5 +1,3 @@
-use system_error::SystemError;
-use alloc::vec::Vec;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_STATX;
 use crate::filesystem::vfs::stat::do_statx;
@@ -7,6 +5,8 @@ use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
 use crate::syscall::user_access::check_and_clone_cstr;
+use alloc::vec::Vec;
+use system_error::SystemError;
 
 pub struct SysStatxHandle;
 
@@ -30,14 +30,15 @@ impl Syscall for SysStatxHandle {
             FormattedSyscallParam::new("filename_ptr", format!("{:#x}", Self::filename_ptr(args))),
             FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
             FormattedSyscallParam::new("mask", format!("{:#x}", Self::mask(args))),
-            FormattedSyscallParam::new("user_kstat_ptr", format!("{:#x}", Self::user_kstat_ptr(args))),
+            FormattedSyscallParam::new(
+                "user_kstat_ptr",
+                format!("{:#x}", Self::user_kstat_ptr(args)),
+            ),
         ]
     }
-
-    
 }
 
-impl SysStatxHandle{
+impl SysStatxHandle {
     #[inline(never)]
     fn statx(
         dfd: i32,
@@ -56,23 +57,22 @@ impl SysStatxHandle{
         do_statx(dfd, filename_str, flags, mask, user_kstat_ptr).map(|_| 0)
     }
 
-    fn dfd(args:&[usize])->i32{
+    fn dfd(args: &[usize]) -> i32 {
         args[0] as i32
     }
 
-    fn filename_ptr(args:&[usize])->usize{
+    fn filename_ptr(args: &[usize]) -> usize {
         args[1]
     }
-    fn flags(args:&[usize])->u32{
+    fn flags(args: &[usize]) -> u32 {
         args[2] as u32
     }
-    fn mask(args:&[usize])->u32{
+    fn mask(args: &[usize]) -> u32 {
         args[3] as u32
     }
-    fn user_kstat_ptr(args:&[usize])->usize{
+    fn user_kstat_ptr(args: &[usize]) -> usize {
         args[4]
     }
 }
 
 syscall_table_macros::declare_syscall!(SYS_STATX, SysStatxHandle);
-   

--- a/kernel/src/filesystem/vfs/syscall/sys_statx.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statx.rs
@@ -1,0 +1,78 @@
+use system_error::SystemError;
+use alloc::vec::Vec;
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_STATX;
+use crate::filesystem::vfs::stat::do_statx;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::check_and_clone_cstr;
+
+pub struct SysStatxHandle;
+
+impl Syscall for SysStatxHandle {
+    fn num_args(&self) -> usize {
+        5
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dfd = SysStatxHandle::dfd(args);
+        let filename_ptr = SysStatxHandle::filename_ptr(args);
+        let flags = SysStatxHandle::flags(args);
+        let mask = SysStatxHandle::mask(args);
+        let user_kstat_ptr = SysStatxHandle::user_kstat_ptr(args);
+        Self::statx(dfd, filename_ptr, flags, mask, user_kstat_ptr)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dfd", format!("{:#x}", Self::dfd(args))),
+            FormattedSyscallParam::new("filename_ptr", format!("{:#x}", Self::filename_ptr(args))),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+            FormattedSyscallParam::new("mask", format!("{:#x}", Self::mask(args))),
+            FormattedSyscallParam::new("user_kstat_ptr", format!("{:#x}", Self::user_kstat_ptr(args))),
+        ]
+    }
+
+    
+}
+
+impl SysStatxHandle{
+    #[inline(never)]
+    fn statx(
+        dfd: i32,
+        filename_ptr: usize,
+        flags: u32,
+        mask: u32,
+        user_kstat_ptr: usize,
+    ) -> Result<usize, SystemError> {
+        if user_kstat_ptr == 0 {
+            return Err(SystemError::EFAULT);
+        }
+
+        let filename = check_and_clone_cstr(filename_ptr as *const u8, Some(MAX_PATHLEN))?;
+        let filename_str = filename.to_str().map_err(|_| SystemError::EINVAL)?;
+
+        do_statx(dfd, filename_str, flags, mask, user_kstat_ptr).map(|_| 0)
+    }
+
+    fn dfd(args:&[usize])->i32{
+        args[0] as i32
+    }
+
+    fn filename_ptr(args:&[usize])->usize{
+        args[1]
+    }
+    fn flags(args:&[usize])->u32{
+        args[2] as u32
+    }
+    fn mask(args:&[usize])->u32{
+        args[3] as u32
+    }
+    fn user_kstat_ptr(args:&[usize])->usize{
+        args[4]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_STATX, SysStatxHandle);
+   

--- a/kernel/src/filesystem/vfs/syscall/sys_unlink.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_unlink.rs
@@ -1,0 +1,46 @@
+//! System call handler for unlinking files (unlink).
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_UNLINK;
+use crate::filesystem::vfs::syscall::AtFlags;
+use crate::filesystem::vfs::vcore::do_unlink_at;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::syscall::user_access::check_and_clone_cstr;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysUnlinkHandle;
+
+impl Syscall for SysUnlinkHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    /// Handles the unlink syscall.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let path = Self::path(args);
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        return do_unlink_at(AtFlags::AT_FDCWD.bits(), &path).map(|v| v as usize);
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "path",
+            format!("{:#x}", Self::path(args) as usize),
+        )]
+    }
+}
+
+impl SysUnlinkHandle {
+    /// Extracts the path argument from syscall parameters.
+    fn path(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_UNLINK, SysUnlinkHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_unlinkat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_unlinkat.rs
@@ -1,0 +1,88 @@
+//! System call handler for removing files or directories (unlinkat).
+
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_UNLINKAT;
+use crate::filesystem::vfs::fcntl::AtFlags;
+use crate::filesystem::vfs::vcore::{do_remove_dir, do_unlink_at};
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::syscall::user_access::check_and_clone_cstr;
+use alloc::vec::Vec;
+
+pub struct SysUnlinkAtHandle;
+
+impl Syscall for SysUnlinkAtHandle {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    /// **删除文件夹、取消文件的链接、删除文件的系统调用**
+    ///
+    /// ## 参数
+    ///
+    /// - `dirfd`：文件夹的文件描述符.目前暂未实现
+    /// - `pathname`：文件夹的路径
+    /// - `flags`：标志位
+    ///
+    ///
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let path = Self::path(args);
+        let flags = Self::flags(args);
+
+        let flags = AtFlags::from_bits(flags as i32).ok_or(SystemError::EINVAL)?;
+        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+
+        if flags.contains(AtFlags::AT_REMOVEDIR) {
+            // debug!("rmdir");
+            match do_remove_dir(dirfd, &path) {
+                Err(err) => {
+                    return Err(err);
+                }
+                Ok(_) => {
+                    return Ok(0);
+                }
+            }
+        }
+
+        match do_unlink_at(dirfd, &path) {
+            Err(err) => {
+                return Err(err);
+            }
+            Ok(_) => {
+                return Ok(0);
+            }
+        }
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("path", format!("{:#x}", Self::path(args) as usize)),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysUnlinkAtHandle {
+    /// Extracts the dirfd argument from syscall parameters.
+    fn dirfd(args: &[usize]) -> i32 {
+        args[0] as i32
+    }
+    /// Extracts the path argument from syscall parameters.
+    fn path(args: &[usize]) -> *const u8 {
+        args[1] as *const u8
+    }
+    /// Extracts the flags argument from syscall parameters.
+    fn flags(args: &[usize]) -> u32 {
+        args[2] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_UNLINKAT, SysUnlinkAtHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_utimensat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_utimensat.rs
@@ -1,8 +1,12 @@
 use system_error::SystemError;
 
-use crate::{arch::interrupt::TrapFrame, syscall::table::{FormattedSyscallParam, Syscall}, time::PosixTimeSpec};
-use alloc::vec::Vec;
 use crate::arch::syscall::nr::SYS_UTIMENSAT;
+use crate::{
+    arch::interrupt::TrapFrame,
+    syscall::table::{FormattedSyscallParam, Syscall},
+    time::PosixTimeSpec,
+};
+use alloc::vec::Vec;
 pub struct SysUtimensatHandle;
 
 impl Syscall for SysUtimensatHandle {
@@ -29,19 +33,19 @@ impl Syscall for SysUtimensatHandle {
 }
 
 impl SysUtimensatHandle {
-    fn dirfd(args:&[usize])->i32{
+    fn dirfd(args: &[usize]) -> i32 {
         args[0] as i32
     }
 
-    fn pathname(args:&[usize])->*const u8{
+    fn pathname(args: &[usize]) -> *const u8 {
         args[1] as *const u8
     }
 
-    fn times(args:&[usize])->*const PosixTimeSpec{
+    fn times(args: &[usize]) -> *const PosixTimeSpec {
         args[2] as *const PosixTimeSpec
     }
 
-    fn flags(args:&[usize])->u32{
+    fn flags(args: &[usize]) -> u32 {
         args[3] as u32
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_utimensat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_utimensat.rs
@@ -1,0 +1,49 @@
+use system_error::SystemError;
+
+use crate::{arch::interrupt::TrapFrame, syscall::table::{FormattedSyscallParam, Syscall}, time::PosixTimeSpec};
+use alloc::vec::Vec;
+use crate::arch::syscall::nr::SYS_UTIMENSAT;
+pub struct SysUtimensatHandle;
+
+impl Syscall for SysUtimensatHandle {
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let dirfd = Self::dirfd(args);
+        let pathname = Self::pathname(args);
+        let times = Self::times(args);
+        let flags = Self::flags(args);
+        super::utimensat::do_sys_utimensat(dirfd, pathname, times, flags)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("dirfd", format!("{:#x}", Self::dirfd(args))),
+            FormattedSyscallParam::new("pathname", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("times", format!("{:#x}", Self::times(args) as usize)),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysUtimensatHandle {
+    fn dirfd(args:&[usize])->i32{
+        args[0] as i32
+    }
+
+    fn pathname(args:&[usize])->*const u8{
+        args[1] as *const u8
+    }
+
+    fn times(args:&[usize])->*const PosixTimeSpec{
+        args[2] as *const PosixTimeSpec
+    }
+
+    fn flags(args:&[usize])->u32{
+        args[3] as u32
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_UTIMENSAT, SysUtimensatHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_utimes.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_utimes.rs
@@ -20,7 +20,7 @@ impl Syscall for SysUtimesHandle {
 
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let pathname = Self::pathname(args);
-        let times=Self::times(args);
+        let times = Self::times(args);
 
         let pathname = check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
             .into_string()
@@ -33,10 +33,9 @@ impl Syscall for SysUtimesHandle {
             Some([times[0], times[1]])
         };
         do_utimes(&pathname, times)
-
     }
 
-     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
             FormattedSyscallParam::new("path", format!("{:#x}", Self::pathname(args) as usize)),
             FormattedSyscallParam::new("times", format!("{:#x}", Self::times(args) as usize)),
@@ -49,10 +48,9 @@ impl SysUtimesHandle {
         args[0] as *const u8
     }
 
-    fn times(args:&[usize])-> *const PosixTimeval{
+    fn times(args: &[usize]) -> *const PosixTimeval {
         args[1] as *const PosixTimeval
     }
 }
 
 syscall_table_macros::declare_syscall!(SYS_UTIMES, SysUtimesHandle);
-

--- a/kernel/src/filesystem/vfs/syscall/sys_utimes.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_utimes.rs
@@ -1,0 +1,58 @@
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_UTIMES;
+use crate::filesystem::vfs::open::do_utimes;
+use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::UserBufferReader;
+use crate::time::syscall::PosixTimeval;
+use alloc::vec::Vec;
+
+pub struct SysUtimesHandle;
+
+impl Syscall for SysUtimesHandle {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pathname = Self::pathname(args);
+        let times=Self::times(args);
+
+        let pathname = check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        let times = if times.is_null() {
+            None
+        } else {
+            let times_reader = UserBufferReader::new(times, size_of::<PosixTimeval>() * 2, true)?;
+            let times = times_reader.read_from_user::<PosixTimeval>(0)?;
+            Some([times[0], times[1]])
+        };
+        do_utimes(&pathname, times)
+
+    }
+
+     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("path", format!("{:#x}", Self::pathname(args) as usize)),
+            FormattedSyscallParam::new("times", format!("{:#x}", Self::times(args) as usize)),
+        ]
+    }
+}
+
+impl SysUtimesHandle {
+    fn pathname(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+
+    fn times(args:&[usize])-> *const PosixTimeval{
+        args[1] as *const PosixTimeval
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_UTIMES, SysUtimesHandle);
+

--- a/kernel/src/filesystem/vfs/syscall/utimensat.rs
+++ b/kernel/src/filesystem/vfs/syscall/utimensat.rs
@@ -1,28 +1,32 @@
 use system_error::SystemError;
 
-use crate::{filesystem::vfs::{open::do_utimensat, syscall::UtimensFlags, MAX_PATHLEN}, syscall::user_access::{check_and_clone_cstr, UserBufferReader}, time::PosixTimeSpec};
+use crate::{
+    filesystem::vfs::{open::do_utimensat, syscall::UtimensFlags, MAX_PATHLEN},
+    syscall::user_access::{check_and_clone_cstr, UserBufferReader},
+    time::PosixTimeSpec,
+};
 
 pub fn do_sys_utimensat(
-        dirfd: i32,
-        pathname: *const u8,
-        times: *const PosixTimeSpec,
-        flags: u32,
-    ) -> Result<usize, SystemError> {
-        let pathname = if pathname.is_null() {
-            None
-        } else {
-            let pathname = check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
-                .into_string()
-                .map_err(|_| SystemError::EINVAL)?;
-            Some(pathname)
-        };
-        let flags = UtimensFlags::from_bits(flags).ok_or(SystemError::EINVAL)?;
-        let times = if times.is_null() {
-            None
-        } else {
-            let times_reader = UserBufferReader::new(times, size_of::<PosixTimeSpec>() * 2, true)?;
-            let times = times_reader.read_from_user::<PosixTimeSpec>(0)?;
-            Some([times[0], times[1]])
-        };
-        do_utimensat(dirfd, pathname, times, flags)
-    }
+    dirfd: i32,
+    pathname: *const u8,
+    times: *const PosixTimeSpec,
+    flags: u32,
+) -> Result<usize, SystemError> {
+    let pathname = if pathname.is_null() {
+        None
+    } else {
+        let pathname = check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        Some(pathname)
+    };
+    let flags = UtimensFlags::from_bits(flags).ok_or(SystemError::EINVAL)?;
+    let times = if times.is_null() {
+        None
+    } else {
+        let times_reader = UserBufferReader::new(times, size_of::<PosixTimeSpec>() * 2, true)?;
+        let times = times_reader.read_from_user::<PosixTimeSpec>(0)?;
+        Some([times[0], times[1]])
+    };
+    do_utimensat(dirfd, pathname, times, flags)
+}

--- a/kernel/src/filesystem/vfs/syscall/utimensat.rs
+++ b/kernel/src/filesystem/vfs/syscall/utimensat.rs
@@ -1,0 +1,28 @@
+use system_error::SystemError;
+
+use crate::{filesystem::vfs::{open::do_utimensat, syscall::UtimensFlags, MAX_PATHLEN}, syscall::user_access::{check_and_clone_cstr, UserBufferReader}, time::PosixTimeSpec};
+
+pub fn do_sys_utimensat(
+        dirfd: i32,
+        pathname: *const u8,
+        times: *const PosixTimeSpec,
+        flags: u32,
+    ) -> Result<usize, SystemError> {
+        let pathname = if pathname.is_null() {
+            None
+        } else {
+            let pathname = check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+                .into_string()
+                .map_err(|_| SystemError::EINVAL)?;
+            Some(pathname)
+        };
+        let flags = UtimensFlags::from_bits(flags).ok_or(SystemError::EINVAL)?;
+        let times = if times.is_null() {
+            None
+        } else {
+            let times_reader = UserBufferReader::new(times, size_of::<PosixTimeSpec>() * 2, true)?;
+            let times = times_reader.read_from_user::<PosixTimeSpec>(0)?;
+            Some([times[0], times[1]])
+        };
+        do_utimensat(dirfd, pathname, times, flags)
+    }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -496,21 +496,6 @@ impl Syscall {
                 Self::access(pathname, mode)
             }
 
-            SYS_FACCESSAT => {
-                let dirfd = args[0] as i32;
-                let pathname = args[1] as *const u8;
-                let mode = args[2] as u32;
-                Self::faccessat2(dirfd, pathname, mode, 0)
-            }
-
-            SYS_FACCESSAT2 => {
-                let dirfd = args[0] as i32;
-                let pathname = args[1] as *const u8;
-                let mode = args[2] as u32;
-                let flags = args[3] as u32;
-                Self::faccessat2(dirfd, pathname, mode, flags)
-            }
-
             SYS_CLOCK_GETTIME => {
                 let clockid = args[0] as i32;
                 let timespec = args[1] as *mut PosixTimeSpec;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -489,13 +489,6 @@ impl Syscall {
                 Self::readlink_at(dirfd, path, buf, bufsiz)
             }
 
-            #[cfg(target_arch = "x86_64")]
-            SYS_ACCESS => {
-                let pathname = args[0] as *const u8;
-                let mode = args[1] as u32;
-                Self::access(pathname, mode)
-            }
-
             SYS_CLOCK_GETTIME => {
                 let clockid = args[0] as i32;
                 let timespec = args[1] as *mut PosixTimeSpec;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -534,13 +534,6 @@ impl Syscall {
                 let gid = args[2];
                 Self::chown(pathname, uid, gid)
             }
-            #[cfg(target_arch = "x86_64")]
-            SYS_LCHOWN => {
-                let pathname = args[0] as *const u8;
-                let uid = args[1];
-                let gid = args[2];
-                Self::lchown(pathname, uid, gid)
-            }
 
             SYS_FSYNC => {
                 warn!("SYS_FSYNC has not yet been implemented");

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -527,14 +527,6 @@ impl Syscall {
                 Self::umask(mask)
             }
 
-            #[cfg(target_arch = "x86_64")]
-            SYS_CHOWN => {
-                let pathname = args[0] as *const u8;
-                let uid = args[1];
-                let gid = args[2];
-                Self::chown(pathname, uid, gid)
-            }
-
             SYS_FSYNC => {
                 warn!("SYS_FSYNC has not yet been implemented");
                 Ok(0)

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -543,12 +543,6 @@ impl Syscall {
                 let mode = args[1] as u32;
                 Self::chmod(pathname, mode)
             }
-            SYS_FCHMODAT => {
-                let dirfd = args[0] as i32;
-                let pathname = args[1] as *const u8;
-                let mode = args[2] as u32;
-                Self::fchmodat(dirfd, pathname, mode)
-            }
 
             SYS_SCHED_YIELD => Self::do_sched_yield(),
 

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -537,13 +537,6 @@ impl Syscall {
                 Err(SystemError::ENOSYS)
             }
 
-            #[cfg(target_arch = "x86_64")]
-            SYS_CHMOD => {
-                let pathname = args[0] as *const u8;
-                let mode = args[1] as u32;
-                Self::chmod(pathname, mode)
-            }
-
             SYS_SCHED_YIELD => Self::do_sched_yield(),
 
             SYS_SCHED_GETAFFINITY => {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -358,14 +358,6 @@ impl Syscall {
                 Self::fstatfs(fd, statfs)
             }
 
-            SYS_STATX => Self::statx(
-                args[0] as i32,
-                args[1],
-                args[2] as u32,
-                args[3] as u32,
-                args[4],
-            ),
-
             // 目前为了适配musl-libc,以下系统调用先这样写着
             SYS_GETRANDOM => {
                 let flags = GRandFlags::from_bits(args[2] as u8).ok_or(SystemError::EINVAL)?;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -307,14 +307,6 @@ impl Syscall {
                 Self::gettimeofday(timeval, timezone_ptr)
             }
 
-            SYS_FTRUNCATE => {
-                let fd = args[0] as i32;
-                let len = args[1];
-                let res = Self::ftruncate(fd, len);
-                // debug!("FTRUNCATE: fd: {}, len: {}, res: {:?}", fd, len, res);
-                res
-            }
-
             #[cfg(target_arch = "x86_64")]
             SYS_MKNOD => {
                 let path = args[0];

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -20,9 +20,6 @@ use table::{syscall_table, syscall_table_init};
 
 use crate::{
     arch::interrupt::TrapFrame,
-    filesystem::vfs::{
-        syscall::ModeType,
-    },
     mm::{verify_area, VirtAddr},
     net::syscall::SockAddr,
     time::{
@@ -305,19 +302,6 @@ impl Syscall {
                 let timeval = args[0] as *mut PosixTimeval;
                 let timezone_ptr = args[1] as *mut PosixTimeZone;
                 Self::gettimeofday(timeval, timezone_ptr)
-            }
-
-            #[cfg(target_arch = "x86_64")]
-            SYS_MKNOD => {
-                let path = args[0];
-                let flags = args[1];
-                let dev_t = args[2];
-                let flags: ModeType = ModeType::from_bits_truncate(flags as u32);
-                Self::mknod(
-                    path as *const u8,
-                    flags,
-                    crate::driver::base::device::device_number::DeviceNumber::from(dev_t as u32),
-                )
             }
 
             SYS_FUTEX => {

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     arch::interrupt::TrapFrame,
     filesystem::vfs::{
         fcntl::FcntlCommand,
-        syscall::{ModeType, UtimensFlags},
+        syscall::ModeType,
     },
     mm::{verify_area, VirtAddr},
     net::syscall::SockAddr,
@@ -620,22 +620,6 @@ impl Syscall {
                 Self::alarm(second)
             }
 
-            SYS_UTIMENSAT => Self::sys_utimensat(
-                args[0] as i32,
-                args[1] as *const u8,
-                args[2] as *const PosixTimeSpec,
-                args[3] as u32,
-            ),
-            #[cfg(target_arch = "x86_64")]
-            SYS_FUTIMESAT => {
-                let flags = UtimensFlags::empty();
-                Self::sys_utimensat(
-                    args[0] as i32,
-                    args[1] as *const u8,
-                    args[2] as *const PosixTimeSpec,
-                    flags.bits(),
-                )
-            }
             #[cfg(target_arch = "x86_64")]
             SYS_EVENTFD => {
                 let initval = args[0] as u32;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -473,22 +473,6 @@ impl Syscall {
                 Self::do_syslog(syslog_action_type, user_buf, len)
             }
 
-            #[cfg(target_arch = "x86_64")]
-            SYS_READLINK => {
-                let path = args[0] as *const u8;
-                let buf = args[1] as *mut u8;
-                let bufsiz = args[2];
-                Self::readlink(path, buf, bufsiz)
-            }
-
-            SYS_READLINKAT => {
-                let dirfd = args[0] as i32;
-                let path = args[1] as *const u8;
-                let buf = args[2] as *mut u8;
-                let bufsiz = args[3];
-                Self::readlink_at(dirfd, path, buf, bufsiz)
-            }
-
             SYS_CLOCK_GETTIME => {
                 let clockid = args[0] as i32;
                 let timespec = args[1] as *mut PosixTimeSpec;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -460,9 +460,6 @@ impl Syscall {
                 Err(SystemError::ENOSYS)
             }
 
-            #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
-            SYS_NEWFSTATAT => Self::newfstatat(args[0] as i32, args[1], args[2], args[3] as u32),
-
             // SYS_SCHED_YIELD => Self::sched_yield(),
             SYS_PRCTL => {
                 // todo: 这个系统调用还没有实现

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -527,12 +527,6 @@ impl Syscall {
                 Self::umask(mask)
             }
 
-            SYS_FCHOWN => {
-                let dirfd = args[0] as i32;
-                let uid = args[1];
-                let gid = args[2];
-                Self::fchown(dirfd, uid, gid)
-            }
             #[cfg(target_arch = "x86_64")]
             SYS_CHOWN => {
                 let pathname = args[0] as *const u8;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -346,12 +346,6 @@ impl Syscall {
                 return ret;
             }
 
-            SYS_STATFS => {
-                let path = args[0] as *const u8;
-                let statfs = args[1] as *mut PosixStatfs;
-                Self::statfs(path, statfs)
-            }
-
             SYS_FSTATFS => {
                 let fd = args[0] as i32;
                 let statfs = args[1] as *mut PosixStatfs;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -637,8 +637,6 @@ impl Syscall {
                 )
             }
             #[cfg(target_arch = "x86_64")]
-            SYS_UTIMES => Self::sys_utimes(args[0] as *const u8, args[1] as *const PosixTimeval),
-            #[cfg(target_arch = "x86_64")]
             SYS_EVENTFD => {
                 let initval = args[0] as u32;
                 Self::sys_eventfd(initval, 0)

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -543,11 +543,6 @@ impl Syscall {
                 let mode = args[1] as u32;
                 Self::chmod(pathname, mode)
             }
-            SYS_FCHMOD => {
-                let fd = args[0] as i32;
-                let mode = args[1] as u32;
-                Self::fchmod(fd, mode)
-            }
             SYS_FCHMODAT => {
                 let dirfd = args[0] as i32;
                 let pathname = args[1] as *const u8;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -541,14 +541,6 @@ impl Syscall {
                 let gid = args[2];
                 Self::lchown(pathname, uid, gid)
             }
-            SYS_FCHOWNAT => {
-                let dirfd = args[0] as i32;
-                let pathname = args[1] as *const u8;
-                let uid = args[2];
-                let gid = args[3];
-                let flag = args[4] as i32;
-                Self::fchownat(dirfd, pathname, uid, gid, flag)
-            }
 
             SYS_FSYNC => {
                 warn!("SYS_FSYNC has not yet been implemented");

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -5,7 +5,6 @@ use core::{
 
 use crate::{
     arch::syscall::nr::*,
-    filesystem::vfs::syscall::PosixStatfs,
     libs::{futex::constant::FutexFlag, rand::GRandFlags},
     mm::page::PAGE_4K_SIZE,
     net::syscall::MsgHdr,
@@ -344,12 +343,6 @@ impl Syscall {
 
                 let ret = Self::get_robust_list(pid, head_uaddr, len_ptr_uaddr);
                 return ret;
-            }
-
-            SYS_FSTATFS => {
-                let fd = args[0] as i32;
-                let statfs = args[1] as *mut PosixStatfs;
-                Self::fstatfs(fd, statfs)
             }
 
             // 目前为了适配musl-libc,以下系统调用先这样写着


### PR DESCRIPTION
* refactor(vfs/syscall): 把 chdir 添加到调用表
* refactor(vfs/syscall): 把 fchdir 添加到调用表
* refactor(vfs/syscall): 把 getcwd 添加到调用表
* refactor(vfs/syscall): 把 getdents|gendents64 添加到调用表
* refactor(vfs/syscall): 把 lseek 添加到调用表
* refactor(vfs/syscall): 把 openat 添加到调用表
* refactor(vfs/syscall): 把 pread64 添加到调用表
* refactor(vfs/syscall): 把 pwrite64 添加到调用表