### PR TITLE
fix(procfs): 修复进程名称显示问题

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -8,7 +8,6 @@ use core::{
 };
 
 use alloc::{
-    ffi::CString,
     string::{String, ToString},
     sync::{Arc, Weak},
     vec::Vec,
@@ -1095,7 +1094,7 @@ impl ProcessControlBlock {
     }
 
     /// 生成进程的名字
-    pub fn generate_name(program_path: &str, args: &Vec<CString>) -> String {
+    pub fn generate_name(program_path: &str) -> String {
         // Extract just the basename from the program path
         let name = program_path.split('/').last().unwrap_or(program_path);
         name.to_string()

--- a/kernel/src/process/syscall/sys_execve.rs
+++ b/kernel/src/process/syscall/sys_execve.rs
@@ -73,7 +73,7 @@ impl SysExecve {
     ) -> Result<(), SystemError> {
         ProcessManager::current_pcb()
             .basic_mut()
-            .set_name(ProcessControlBlock::generate_name(&path, &argv));
+            .set_name(ProcessControlBlock::generate_name(&path));
 
         do_execve(inode, argv, envp, frame)?;
 


### PR DESCRIPTION
修改ProcessControlBlock::generate_name函数，使其只返回可执行文件的basename， 而不是完整的路径和所有参数。这样/proc/*/status中显示的进程名称将符合
Linux的行为规范。

例如：/bin/busybox 进程将显示为 "busybox" 而不是 "/bin/busybox -/bin/busybox sh --login"