### PR TITLE
chore: 更新NovaShell的git revision版本为25dce88

### DIFF
--- a/user/dadk/config/nova_shell-0.1.0.toml
+++ b/user/dadk/config/nova_shell-0.1.0.toml
@@ -24,7 +24,7 @@ source = "git"
 source-path = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/NovaShell.git"
 # git标签或分支
 # 注意： branch和revision只能二选一，且source要设置为"git"
-revision = "d7d2136c5a"
+revision = "25dce88"
 # 构建相关信息
 [build]
 # （可选）构建命令


### PR DESCRIPTION
将NovaShell的git revision从d7d2136c5a更新为25dce88