### PR TITLE
refactor(bitmap): 重构静态位图实现，移除incomplete_features依赖

### DIFF
--- a/kernel/crates/bitmap/src/lib.rs
+++ b/kernel/crates/bitmap/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(core_intrinsics)]
-#![allow(incomplete_features)] // for const generics
-#![feature(generic_const_exprs)]
 #![deny(clippy::all)]
 #![allow(internal_features)]
 #![allow(clippy::needless_return)]
@@ -15,4 +13,5 @@ mod static_bitmap;
 pub mod traits;
 pub use alloc_bitmap::AllocBitmap;
 pub use bitmap_core::BitMapCore;
+pub use static_bitmap::static_bitmap_size;
 pub use static_bitmap::StaticBitmap;

--- a/kernel/crates/bitmap/src/static_bitmap.rs
+++ b/kernel/crates/bitmap/src/static_bitmap.rs
@@ -2,44 +2,54 @@ use core::mem::size_of;
 
 use crate::{bitmap_core::BitMapCore, traits::BitMapOps};
 
+pub const fn static_bitmap_size<const N: usize>() -> usize {
+    N.div_ceil(usize::BITS as usize)
+}
+
 /// 静态位图
 ///
 /// 该位图的大小在编译时确定，不可变
 #[derive(Debug, Clone)]
-pub struct StaticBitmap<const N: usize>
-where
-    [(); N.div_ceil(usize::BITS as usize)]:,
-{
-    pub data: [usize; N.div_ceil(usize::BITS as usize)],
+pub struct StaticBitmap<const N: usize, const M: usize> {
+    pub data: [usize; M],
     core: BitMapCore<usize>,
 }
 
-impl<const N: usize> Default for StaticBitmap<N>
-where
-    [(); N.div_ceil(usize::BITS as usize)]:,
-{
+/// 创建静态位图的宏
+///
+/// 使用方式：static_bitmap!(items_count) 创建一个能容纳 items_count 个位的静态位图
+///
+/// 示例：
+/// ```rust
+/// use bitmap::static_bitmap;
+/// use bitmap::StaticBitmap;
+///
+/// let bmp: static_bitmap!(100) = StaticBitmap::new();
+/// ```
+#[macro_export]
+macro_rules! static_bitmap {
+    ($count:expr) => {
+        $crate::StaticBitmap<{ $count }, { $crate::static_bitmap_size::<{ $count }>() }>
+    };
+}
+
+impl<const N: usize, const M: usize> Default for StaticBitmap<N, M> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const N: usize> StaticBitmap<N>
-where
-    [(); N.div_ceil(usize::BITS as usize)]:,
-{
+impl<const N: usize, const M: usize> StaticBitmap<N, M> {
     /// 创建一个新的静态位图
     pub const fn new() -> Self {
         Self {
-            data: [0; N.div_ceil(usize::BITS as usize)],
+            data: [0; M],
             core: BitMapCore::new(),
         }
     }
 }
 
-impl<const N: usize> BitMapOps<usize> for StaticBitmap<N>
-where
-    [(); N.div_ceil(usize::BITS as usize)]:,
-{
+impl<const N: usize, const M: usize> BitMapOps<usize> for StaticBitmap<N, M> {
     #[inline]
     fn get(&self, index: usize) -> Option<bool> {
         return self.core.get(N, &self.data, index);

--- a/kernel/crates/bitmap/src/traits.rs
+++ b/kernel/crates/bitmap/src/traits.rs
@@ -241,9 +241,10 @@ pub trait BitMapOps<T: BitOps> {
     ///
     /// ```
     /// use bitmap::StaticBitmap;
+    /// use bitmap::static_bitmap;
     /// use bitmap::traits::BitMapOps;
     ///
-    /// let mut bitmap = StaticBitmap::<34>::new();
+    /// let mut bitmap: static_bitmap!(34) = StaticBitmap::new();
     /// assert_eq!(bitmap.len(), 34);
     /// ```
     ///

--- a/kernel/crates/bitmap/tests/static-bitmap.rs
+++ b/kernel/crates/bitmap/tests/static-bitmap.rs
@@ -1,6 +1,6 @@
 //! 静态位图的集成测试
 
-use bitmap::{traits::BitMapOps, StaticBitmap};
+use bitmap::{static_bitmap, traits::BitMapOps, StaticBitmap};
 
 /// 测试空的位图
 ///
@@ -10,7 +10,7 @@ use bitmap::{traits::BitMapOps, StaticBitmap};
 /// 测试空的位图
 #[test]
 fn test_empty_bitmap_32() {
-    let mut bitmap = StaticBitmap::<32>::new();
+    let mut bitmap: static_bitmap!(32) = StaticBitmap::new();
     assert_eq!(bitmap.len(), 32);
     assert_eq!(bitmap.size(), 8);
     assert_eq!(bitmap.first_index(), None);
@@ -40,7 +40,7 @@ fn test_empty_bitmap_32() {
 
 #[test]
 fn test_empty_bitmap_64() {
-    let mut bitmap = StaticBitmap::<64>::new();
+    let mut bitmap: static_bitmap!(64) = StaticBitmap::new();
     assert_eq!(bitmap.len(), 64);
     assert_eq!(bitmap.size(), 8);
     assert_eq!(bitmap.first_index(), None);
@@ -71,7 +71,7 @@ fn test_empty_bitmap_64() {
 /// 测试长度为32的bmp，其中第一个元素为1
 #[test]
 fn test_static_bitmap_32_first_1() {
-    let mut bitmap = StaticBitmap::<32>::new();
+    let mut bitmap: static_bitmap!(32) = StaticBitmap::new();
     bitmap.set(0, true);
     assert_eq!(bitmap.len(), 32);
     assert_eq!(bitmap.size(), 8);
@@ -112,7 +112,7 @@ fn test_static_bitmap_32_first_1() {
 /// 测试长度为32的bmp，其中中间某个元素为1
 #[test]
 fn test_static_bitmap_32_middle_1() {
-    let mut bitmap = StaticBitmap::<32>::new();
+    let mut bitmap: static_bitmap!(32) = StaticBitmap::new();
     bitmap.set(15, true);
     assert_eq!(bitmap.len(), 32);
     assert_eq!(bitmap.size(), 8);
@@ -154,7 +154,7 @@ fn test_static_bitmap_32_middle_1() {
 /// 测试长度为32的bmp，其中最后一个元素为1
 #[test]
 fn test_static_bitmap_32_last_1() {
-    let mut bitmap = StaticBitmap::<32>::new();
+    let mut bitmap: static_bitmap!(32) = StaticBitmap::new();
     bitmap.set(31, true);
     assert_eq!(bitmap.len(), 32);
     assert_eq!(bitmap.size(), 8);
@@ -196,7 +196,7 @@ fn test_static_bitmap_32_last_1() {
 /// 测试长度为64的bmp，其中第一个元素为1
 #[test]
 fn test_static_bitmap_64_first_1() {
-    let mut bitmap = StaticBitmap::<64>::new();
+    let mut bitmap: static_bitmap!(64) = StaticBitmap::new();
     bitmap.set(0, true);
     assert_eq!(bitmap.len(), 64);
     assert_eq!(bitmap.size(), 8);
@@ -237,7 +237,7 @@ fn test_static_bitmap_64_first_1() {
 /// 测试长度为64的bmp，其中中间某个元素为1
 #[test]
 fn test_static_bitmap_64_middle_1() {
-    let mut bitmap = StaticBitmap::<64>::new();
+    let mut bitmap: static_bitmap!(64) = StaticBitmap::new();
     bitmap.set(15, true);
     assert_eq!(bitmap.len(), 64);
     assert_eq!(bitmap.size(), 8);
@@ -279,7 +279,7 @@ fn test_static_bitmap_64_middle_1() {
 /// 测试长度为64的bmp，其中最后一个元素为1
 #[test]
 fn test_static_bitmap_64_last_1() {
-    let mut bitmap = StaticBitmap::<64>::new();
+    let mut bitmap: static_bitmap!(64) = StaticBitmap::new();
     bitmap.set(63, true);
     assert_eq!(bitmap.len(), 64);
     assert_eq!(bitmap.size(), 8);
@@ -321,7 +321,7 @@ fn test_static_bitmap_64_last_1() {
 /// 测试长度为64的bmp，其中第一个和最后一个元素为1
 #[test]
 fn test_static_bitmap_64_two_1_first() {
-    let mut bitmap = StaticBitmap::<64>::new();
+    let mut bitmap: static_bitmap!(64) = StaticBitmap::new();
     bitmap.set(0, true);
     bitmap.set(63, true);
 
@@ -362,7 +362,7 @@ fn test_static_bitmap_64_two_1_first() {
 /// 测试长度为64的bmp，中间两个不相邻的元素为1
 #[test]
 fn test_static_bitmap_64_two_1_middle() {
-    let mut bitmap = StaticBitmap::<64>::new();
+    let mut bitmap: static_bitmap!(64) = StaticBitmap::new();
     bitmap.set(15, true);
     bitmap.set(63, true);
 
@@ -404,7 +404,7 @@ fn test_static_bitmap_64_two_1_middle() {
 
 #[test]
 fn test_static_bitmap_128_two_1_seperate_first() {
-    let mut bitmap = StaticBitmap::<128>::new();
+    let mut bitmap: static_bitmap!(128) = StaticBitmap::new();
 
     bitmap.set(0, true);
     bitmap.set(127, true);
@@ -444,7 +444,7 @@ fn test_static_bitmap_128_two_1_seperate_first() {
 /// 长度128, 第63、64bit为1
 #[test]
 fn test_static_bitmap_128_two_1_nearby_middle() {
-    let mut bitmap = StaticBitmap::<128>::new();
+    let mut bitmap: static_bitmap!(128) = StaticBitmap::new();
 
     bitmap.set(63, true);
     bitmap.set(64, true);
@@ -494,7 +494,7 @@ fn test_static_bitmap_128_two_1_nearby_middle() {
 
 #[test]
 fn test_static_bitmap_full_32() {
-    let mut bitmap = StaticBitmap::<32>::new();
+    let mut bitmap: static_bitmap!(32) = StaticBitmap::new();
     bitmap.set_all(true);
 
     assert_eq!(bitmap.len(), 32);
@@ -532,7 +532,7 @@ fn test_static_bitmap_full_32() {
 
 #[test]
 fn test_static_bitmap_full_64() {
-    let mut bitmap = StaticBitmap::<64>::new();
+    let mut bitmap: static_bitmap!(64) = StaticBitmap::new();
     bitmap.set_all(true);
 
     assert_eq!(bitmap.len(), 64);
@@ -570,7 +570,7 @@ fn test_static_bitmap_full_64() {
 
 #[test]
 fn test_static_bitmap_full_100() {
-    let mut bitmap = StaticBitmap::<100>::new();
+    let mut bitmap: static_bitmap!(100) = StaticBitmap::new();
     bitmap.set_all(true);
 
     assert_eq!(bitmap.len(), 100);
@@ -608,7 +608,7 @@ fn test_static_bitmap_full_100() {
 
 #[test]
 fn test_static_bitmap_full_128() {
-    let mut bitmap = StaticBitmap::<128>::new();
+    let mut bitmap: static_bitmap!(128) = StaticBitmap::new();
     bitmap.set_all(true);
 
     assert_eq!(bitmap.len(), 128);

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -8,7 +8,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use bitmap::traits::BitMapOps;
+use bitmap::{static_bitmap, traits::BitMapOps};
 use log::error;
 use system_error::SystemError;
 use unified_init::macros::unified_init;
@@ -110,7 +110,7 @@ pub struct VirtIOBlkManager {
 }
 
 struct InnerVirtIOBlkManager {
-    id_bmp: bitmap::StaticBitmap<{ VirtIOBlkManager::MAX_DEVICES }>,
+    id_bmp: static_bitmap!(VirtIOBlkManager::MAX_DEVICES),
     devname: [Option<DevName>; VirtIOBlkManager::MAX_DEVICES],
 }
 

--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -42,7 +42,7 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
-use bitmap::traits::BitMapOps;
+use bitmap::{static_bitmap, traits::BitMapOps};
 use core::fmt::Debug;
 use core::fmt::Formatter;
 use core::{
@@ -422,7 +422,7 @@ impl VirtIOConsoleDriver {
 
 #[derive(Debug)]
 struct InnerVirtIOConsoleDriver {
-    id_bmp: bitmap::StaticBitmap<{ VirtIOConsoleDriver::MAX_DEVICES }>,
+    id_bmp: static_bitmap!(VirtIOConsoleDriver::MAX_DEVICES),
     devname: [Option<DevName>; VirtIOConsoleDriver::MAX_DEVICES],
     virtio_driver_common: VirtIODriverCommonData,
     driver_common: DriverCommonData,

--- a/kernel/src/driver/clocksource/timer_riscv.rs
+++ b/kernel/src/driver/clocksource/timer_riscv.rs
@@ -29,7 +29,7 @@ use crate::{
 
 pub struct RiscVSbiTimer;
 
-static SBI_TIMER_INIT_BMP: SpinLock<StaticBitmap<{ PerCpu::MAX_CPU_NUM as usize }>> =
+static SBI_TIMER_INIT_BMP: SpinLock<static_bitmap!(PerCpu::MAX_CPU_NUM as usize)> =
     SpinLock::new(StaticBitmap::new());
 
 static mut INTERVAL_CNT: usize = 0;

--- a/kernel/src/driver/clocksource/timer_riscv.rs
+++ b/kernel/src/driver/clocksource/timer_riscv.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::{compiler_fence, fence, Ordering};
 
 use alloc::{string::ToString, sync::Arc};
-use bitmap::{traits::BitMapOps, StaticBitmap};
+use bitmap::{static_bitmap, traits::BitMapOps, StaticBitmap};
 use system_error::SystemError;
 
 use crate::{

--- a/kernel/src/driver/scsi/mod.rs
+++ b/kernel/src/driver/scsi/mod.rs
@@ -1,4 +1,4 @@
-use bitmap::traits::BitMapOps;
+use bitmap::{static_bitmap, traits::BitMapOps};
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
@@ -29,7 +29,7 @@ pub struct ScsiManager {
 }
 
 struct InnerScsiManager {
-    id_bmp: bitmap::StaticBitmap<{ ScsiManager::MAX_DEVICES }>,
+    id_bmp: static_bitmap!(ScsiManager::MAX_DEVICES),
     devname: [Option<DevName>; ScsiManager::MAX_DEVICES],
 }
 

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use core::intrinsics::likely;
 use core::ops::BitXor;
 
-use bitmap::{traits::BitMapOps, StaticBitmap};
+use bitmap::{static_bitmap, traits::BitMapOps, StaticBitmap};
 
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
@@ -119,8 +119,8 @@ pub struct NTtyData {
     read_buf: Box<[u8; NTTY_BUFSIZE]>,
     echo_buf: Box<[u8; NTTY_BUFSIZE]>,
 
-    read_flags: StaticBitmap<NTTY_BUFSIZE>,
-    char_map: StaticBitmap<256>,
+    read_flags: static_bitmap!(NTTY_BUFSIZE),
+    char_map: static_bitmap!(256),
 
     tty: Weak<TtyCore>,
 }

--- a/kernel/src/driver/tty/virtual_terminal/virtual_console.rs
+++ b/kernel/src/driver/tty/virtual_terminal/virtual_console.rs
@@ -4,7 +4,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use bitmap::{traits::BitMapOps, StaticBitmap};
+use bitmap::{static_bitmap, traits::BitMapOps, StaticBitmap};
 use log::warn;
 
 use crate::{
@@ -132,7 +132,7 @@ pub struct VirtualConsoleData {
     /// 字符转换表 用于将输入字符映射到特定的字符
     pub translate: TranslationMap,
 
-    pub tab_stop: StaticBitmap<256>,
+    pub tab_stop: static_bitmap!(256),
 
     pub attr: u8,
 

--- a/kernel/src/mm/no_init.rs
+++ b/kernel/src/mm/no_init.rs
@@ -8,7 +8,7 @@
 //! 对于x86:
 //! 这里假设在内核引导文件中，已经填写了前100M的页表，其中，前50M是真实映射到内存的，后面的仅仅创建了页表，表项全部为0。
 
-use bitmap::{traits::BitMapOps, StaticBitmap};
+use bitmap::{static_bitmap, traits::BitMapOps, StaticBitmap};
 
 use crate::{
     libs::spinlock::SpinLock,
@@ -45,7 +45,7 @@ impl EarlyRemapPage {
 #[repr(C)]
 pub struct EarlyIoRemapPages {
     pages: [EarlyRemapPage; Self::EARLY_REMAP_PAGES_NUM],
-    bmp: StaticBitmap<{ Self::EARLY_REMAP_PAGES_NUM }>,
+    bmp: static_bitmap!(Self::EARLY_REMAP_PAGES_NUM),
 }
 
 impl EarlyIoRemapPages {

--- a/tools/debugging/logmonitor/src/lib.rs
+++ b/tools/debugging/logmonitor/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
-
 extern crate clap;
 
 extern crate lazy_static;


### PR DESCRIPTION
- 移除generic_const_exprs特性依赖
- 引入static_bitmap_size常量函数和static_bitmap!宏
- 修改StaticBitmap结构体定义
- 更新相关测试和使用代码


修改的原因是这个特性在rust编译器里面是未完成的状态，并且升级dragonos的工具链的时候卡到这个bug了
https://github.com/rust-lang/rust/issues/76560