### PR TITLE
fix(mm/buddy): correct page zeroing size and add boundary checks

### DIFF
--- a/kernel/src/mm/allocator/buddy.rs
+++ b/kernel/src/mm/allocator/buddy.rs
@@ -521,7 +521,8 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
                             .0
                     };
 
-                    // 清空这个页面
+                    // 清空这个页面：注意这里只分配了1页作为page_list元数据页，
+                    // 因此清零长度应固定为一页大小，而非按当前order的块大小。
                     core::ptr::write_bytes(
                         A::phys_2_virt(new_page_list_addr)
                             .expect(
@@ -529,7 +530,7 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
                             )
                             .as_ptr::<u8>(),
                         0,
-                        1 << order,
+                        A::PAGE_SIZE,
                     );
                     assert!(
                         first_page_list_paddr == self.free_area[Self::order2index(order as u8)]


### PR DESCRIPTION
![img_v3_02pv_574a5a51-2fcb-407f-aa8b-b012b13082ag](https://github.com/user-attachments/assets/d92b1a22-f20f-437c-86d2-018fc14b56fa)
把base分配为新的存空闲块的page_list后，没有立即退出，还把base当成空闲块扔进page_list里面了。

![img_v3_02pv_4e5d4e89-b397-46fa-b68f-b0455c452c8g](https://github.com/user-attachments/assets/0a47df22-f6bc-4a15-a3d3-dacaba56649a)
这里是想检查是否用second_page_list里面的空闲块分配为新的page_list，结果写成了检查second_page_list 是否存在

```
fix(mm/buddy): correct page zeroing size and add boundary checks

- Fix incorrect page zeroing size by using PAGE_SIZE instead of block size (1 <<
order)
- Add boundary check to return early when new_page_list_addr equals base
- Add validation to ensure second page list has sufficient capacity before use
- Improve code comments to clarify page metadata handling
 ```