### PR TITLE
fix(gvisor): 修复gvisor测试套件安装流程

### DIFF
--- a/user/apps/tests/syscall/gvisor/Makefile
+++ b/user/apps/tests/syscall/gvisor/Makefile
@@ -54,21 +54,19 @@ build:
 # 下载测试套件
 download:
 	@echo "下载gvisor测试套件..."
-	@./download_tests.sh
+	@./download_tests.sh --skip-if-exists
 
 # 安装到目标目录
-install: build
+install: build download
 	@echo "安装gvisor测试套件到 $(INSTALL_DIR)"
 	@mkdir -p $(INSTALL_DIR)
 	# 安装Rust测试运行器二进制文件
 	@cp -f runner/target/$(RUST_TARGET)/release/runner $(INSTALL_DIR)/gvisor-test-runner
+	@chmod +x $(INSTALL_DIR)/gvisor-test-runner
 	# 安装测试配置文件
 	@cp -f whitelist.txt $(INSTALL_DIR)/
 	@cp -rf blocklists $(INSTALL_DIR)/
-	# 安装下载脚本（用于目标系统上下载测试）
-	@cp -f download_tests.sh $(INSTALL_DIR)/
-	@chmod +x $(INSTALL_DIR)/download_tests.sh
-	@chmod +x $(INSTALL_DIR)/gvisor-test-runner
+	@cp -rf tests $(INSTALL_DIR)/
 	@echo "安装完成"
 
 # 运行测试


### PR DESCRIPTION
- 添加download作为install目标的依赖
- 为download脚本添加--skip-if-exists参数
- 将tests目录复制到安装目录
- 移除不必要的download_tests.sh脚本安装