### PR TITLE
test(gvisor): add chdir_test and fix test runner filter formatting

### DIFF
--- a/user/apps/tests/syscall/gvisor/blocklists/chdir_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/chdir_test
@@ -1,0 +1,1 @@
+ChdirTest.PermissionDenied

--- a/user/apps/tests/syscall/gvisor/runner/src/lib_sync.rs
+++ b/user/apps/tests/syscall/gvisor/runner/src/lib_sync.rs
@@ -351,9 +351,9 @@ impl TestRunner {
         let start_time = Instant::now();
         let mut cmd = Command::new(&test_path);
         if !blocked_subtests.is_empty() {
-            cmd.arg("--gtest_filter")
-                .arg(format!("-{}", blocked_subtests.join(":")));
+            cmd.arg(format!("--gtest_filter=-{}", blocked_subtests.join(":")));
         }
+
         let status = cmd
             .current_dir(&self.config.tests_dir)
             .env("TEST_TMPDIR", &self.config.temp_dir)

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -4,7 +4,7 @@
 
 # 基础系统调用测试
 read_test
-#chdir_test
+chdir_test
 
 # 文件系统相关测试
 #stat_test


### PR DESCRIPTION
- Add chdir_test to blocklists
- Fix formatting of gtest_filter argument in test runner
- Enable chdir_test in whitelist