### PR TITLE
factor(clone, mempolicy, cpuinfo): 实现clone3和get_mempolicy系统调用，并实现`/proc/cpuinfo`文件

### DIFF
--- a/kernel/src/arch/x86_64/smp/mod.rs
+++ b/kernel/src/arch/x86_64/smp/mod.rs
@@ -138,7 +138,7 @@ impl SmpBootData {
     }
 }
 
-pub(super) static SMP_BOOT_DATA: SmpBootData = SmpBootData {
+pub static SMP_BOOT_DATA: SmpBootData = SmpBootData {
     initialized: AtomicBool::new(false),
     cpu_count: 0,
     phys_id: [0; PerCpu::MAX_CPU_NUM as usize],

--- a/kernel/src/filesystem/procfs/proc_cpuinfo.rs
+++ b/kernel/src/filesystem/procfs/proc_cpuinfo.rs
@@ -1,0 +1,204 @@
+use system_error::SystemError;
+use alloc::{string::String, vec::Vec, format};
+use crate::{
+    smp::cpu::smp_cpu_manager,
+};
+
+use super::{ProcFSInode, ProcfsFilePrivateData};
+
+impl ProcFSInode {
+    #[inline(never)]
+    pub(super) fn open_cpuinfo(
+        &self,
+        pdata: &mut ProcfsFilePrivateData,
+    ) -> Result<i64, SystemError> {
+        let cpu_manager = smp_cpu_manager();
+        
+        // 遍历所有present的CPU
+        for cpu_id in cpu_manager.present_cpus().iter_cpu() {
+            // 生成每个 CPU 的信息
+            let cpu_info = self.generate_cpu_info(cpu_id);
+            pdata.data.extend_from_slice(cpu_info.as_bytes());
+            
+            // 在每个CPU信息之间添加空行分隔
+            pdata.data.push(b'\n');
+        }
+
+        Ok(pdata.data.len() as i64)
+    }
+
+    /// 生成单个 CPU 的信息字符串
+    /// 当前使用的 raw_cpuid 库仅支持 x86_64 架构
+    /// 当在某个线程或核心上执行 CPUID 指令时，它返回的是 当前核心视角下的 CPU 信息。
+    /// 所以需要通过 sched_setaffinity() 把线程绑定到不同核心，然后在该线程执行 CPUID。
+    /// 但是目前还没实现sched_setaffinity系统调用
+    fn generate_cpu_info(&self, cpu_id: crate::smp::cpu::ProcessorId) -> String {
+        let mut info = String::new();
+        
+        #[cfg(target_arch = "x86_64")]
+        {
+            use raw_cpuid::CpuId;
+            
+            info.push_str(&format!("processor\t: {}\n", cpu_id.data()));
+            
+            let cpuid = CpuId::new();
+            
+            // 获取厂商信息
+            if let Some(vendor_info) = cpuid.get_vendor_info() {
+                let vendor_string = vendor_info.as_str();
+                if vendor_string != "GenuineIntel" && vendor_string != "AuthenticAMD" {
+                    info.push_str("vendor_id\t: Unknown\n");
+                    return info;
+                }
+                info.push_str(&format!("vendor_id\t: {}\n", vendor_string));
+            }
+            else {
+                info.push_str("vendor_id\t: Unknown\n");
+                return info;
+            }
+            
+            // 获取 CPU 特性信息
+            if let Some(feature_info) = cpuid.get_feature_info() {
+                info.push_str(&format!("cpu family\t: {}\n", feature_info.family_id()));
+                info.push_str(&format!("model\t\t: {}\n", feature_info.model_id()));
+                info.push_str(&format!("stepping\t: {}\n", feature_info.stepping_id()));
+            }
+            
+            // 获取处理器品牌字符串
+            if let Some(brand_string) = cpuid.get_processor_brand_string() {
+                info.push_str(&format!("model name\t: {}\n", brand_string.as_str()));
+            } else {
+                info.push_str("model name\t: Unknown\n");
+            }
+            
+            // 微代码版本（在虚拟化环境中通常无法获取真实值 && raw_cpuid 库只支持amd cpu获取microcode）
+            // info.push_str("microcode\t: 0xffffffff\n");
+            
+            // CPU 频率
+            if let Some(cpu_fre) = cpuid.get_processor_frequency_info() {
+                let cpu_mhz = cpu_fre.processor_base_frequency() as f64;
+                info.push_str(&format!("cpu MHz\t\t: {}\n", cpu_mhz));
+            }
+            else {
+                let tsc_khz = crate::arch::driver::tsc::TSCManager::cpu_khz();
+                if tsc_khz > 0 {
+                    let cpu_mhz = tsc_khz as f64 / 1000.0;
+                    info.push_str(&format!("cpu MHz\t\t: {:.3}\n", cpu_mhz));
+                } else {
+                    info.push_str("cpu MHz\t\t: unknown\n");
+                }
+            }
+            
+            // L3缓存大小
+            if let Some(cache_params) = cpuid.get_cache_parameters() {
+                for cache in cache_params {
+                    if cache.level() == 3 {
+                        let cache_size = cache.sets() 
+                                       * cache.associativity() 
+                                       * cache.coherency_line_size();
+                        info.push_str(&format!("cache size\t: {} KB\n", cache_size / 1024));
+                        break;
+                    }
+                }
+            }
+            else {
+                info.push_str("cache size\t: unknown\n");
+            }
+
+            let boot_data = &crate::arch::x86_64::smp::SMP_BOOT_DATA;
+
+            // // 物理 CPU 封装 ID
+            
+
+            // siblings - 同一个物理cpu中的逻辑处理器数量
+            let siblings = smp_cpu_manager().present_cpus_count();
+            info.push_str(&format!("siblings\t: {}\n", siblings));
+            
+            // // core id - 在同一个物理cpu内的核心ID
+            
+
+            // // cpu cores - 每个物理cpu中的核心数
+            
+
+            // APIC ID // 不确定是哪个
+            let apic_id = boot_data.phys_id(cpu_id.data() as usize);
+            info.push_str(&format!("apicid\t\t: {}\n", apic_id));
+            info.push_str(&format!("initial apicid\t: {}\n", apic_id));
+            
+            // FPU 和其他特性
+            if let Some(feature_info) = cpuid.get_feature_info() {
+                info.push_str(&format!("fpu\t\t: {}\n", if feature_info.has_fpu() { "yes" } else { "no" }));
+                // info.push_str("fpu_exception\t: yes\n");
+                
+                // CPUID level
+                // if let Some(vendor_info) = cpuid.get_extended_feature_info() {
+                //     info.push_str(&format!("cpuid level\t: {}\n", vendor_info.));
+                // }
+                
+                // wp 标志 
+                let cr0: u64;
+                unsafe {
+                    core::arch::asm!("mov {}, cr0", out(reg) cr0);
+                }
+                let wp_enabled = (cr0 >> 16) & 1 != 0;
+                info.push_str(&format!("wp\t\t: {}\n", if wp_enabled { "yes" } else { "no" }));
+
+                // CPU 特性标志 - 只包含真实检测到的特性
+                info.push_str("flags\t\t: ");
+                let mut flags = Vec::new();
+                
+                if feature_info.has_fpu() { flags.push("fpu"); }
+                if feature_info.has_vme() { flags.push("vme"); }
+                if feature_info.has_de() { flags.push("de"); }
+                if feature_info.has_pse() { flags.push("pse"); }
+                if feature_info.has_tsc() { flags.push("tsc"); }
+                if feature_info.has_msr() { flags.push("msr"); }
+                if feature_info.has_pae() { flags.push("pae"); }
+                if feature_info.has_mce() { flags.push("mce"); }
+                if feature_info.has_cmpxchg8b() { flags.push("cx8"); }
+                if feature_info.has_apic() { flags.push("apic"); }
+                if feature_info.has_sysenter_sysexit() { flags.push("sep"); }
+                if feature_info.has_mtrr() { flags.push("mtrr"); }
+                if feature_info.has_pge() { flags.push("pge"); }
+                if feature_info.has_mca() { flags.push("mca"); }
+                if feature_info.has_cmov() { flags.push("cmov"); }
+                if feature_info.has_pat() { flags.push("pat"); }
+                if feature_info.has_pse36() { flags.push("pse36"); }
+                if feature_info.has_clflush() { flags.push("clflush"); }
+                if feature_info.has_mmx() { flags.push("mmx"); }
+                if feature_info.has_fxsave_fxstor() { flags.push("fxsr"); }
+                if feature_info.has_sse() { flags.push("sse"); }
+                if feature_info.has_sse2() { flags.push("sse2"); }
+                if feature_info.has_ss() { flags.push("ss"); }
+                if feature_info.has_htt() { flags.push("ht"); }
+                
+                info.push_str(&flags.join(" "));
+                info.push('\n');
+
+                // bugs 内核根据 CPUID、微码版本以及已知漏洞列表汇总出来
+                // 这里暂时不实现
+
+                info.push_str(&format!("clflush size\t: {}\n", feature_info.cflush_cache_line_size()));
+                info.push_str(&format!("cache_alignment\t: {}\n", feature_info.cflush_cache_line_size()));
+            }
+            
+            // BogoMIPS（基于TSC频率的简化计算）在虚拟机中无意义 暂时不实现
+            // let tsc_khz = crate::arch::driver::tsc::TSCManager::cpu_khz();
+            // if tsc_khz > 0 {
+            //     let bogomips = (tsc_khz as f64 / 1000.0) * 2.0;
+            //     info.push_str(&format!("bogomips\t: {:.2}\n", bogomips));
+            // }
+
+            // info.push_str("cache_alignment\t: 64\n");
+            if let Some(processor_capacity_feature_info) = cpuid.get_processor_capacity_feature_info(){
+                info.push_str(&format!("address sizes\t: {} bits physical, {} bits virtual\n", 
+                    processor_capacity_feature_info.physical_address_bits(), 
+                    processor_capacity_feature_info.linear_address_bits())
+                );
+            }
+            // info.push_str("power management:\n");
+        }
+        
+        info
+    }
+}

--- a/kernel/src/mm/syscall/mempolice_utils.rs
+++ b/kernel/src/mm/syscall/mempolice_utils.rs
@@ -1,0 +1,148 @@
+//! 内存策略工具和定义
+
+use system_error::SystemError;
+use crate::syscall::user_access::{UserBufferReader, UserBufferWriter};
+use crate::mm::VirtAddr;
+
+/// NUMA内存策略类型
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MempolicyMode {
+    /// 默认策略 - 本地分配
+    Default = 0,
+    /// 绑定到特定节点
+    Bind = 1,
+    /// 跨节点交错分配
+    Interleave = 2,
+    /// 首选节点分配
+    Preferred = 3,
+    /// 本地节点分配
+    Local = 4,
+}
+
+impl TryFrom<u32> for MempolicyMode {
+    type Error = SystemError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(MempolicyMode::Default),
+            1 => Ok(MempolicyMode::Bind),
+            2 => Ok(MempolicyMode::Interleave),
+            3 => Ok(MempolicyMode::Preferred),
+            4 => Ok(MempolicyMode::Local),
+            _ => Err(SystemError::EINVAL),
+        }
+    }
+}
+
+bitflags::bitflags! {
+    /// get_mempolicy系统调用的标志
+    pub struct MempolicyFlags: u32 {
+        /// 获取有效策略
+        const MPOL_F_NODE = 1 << 0;
+        /// 获取特定地址的策略
+        const MPOL_F_ADDR = 1 << 1;
+        /// 获取特定内存区域的策略
+        const MPOL_F_MEMS_ALLOWED = 1 << 2;
+    }
+}
+
+/// 内存策略结构
+#[derive(Debug, Clone)]
+pub struct Mempolicy {
+    /// 策略模式
+    pub mode: MempolicyMode,
+    /// 策略的节点掩码
+    pub nodemask: u64,
+    /// 首选节点（用于PREFERRED模式）
+    pub preferred_node: Option<u32>,
+}
+
+impl Default for Mempolicy {
+    fn default() -> Self {
+        Self {
+            mode: MempolicyMode::Default,
+            nodemask: 0,
+            preferred_node: None,
+        }
+    }
+}
+
+impl Mempolicy {
+    /// 创建新的默认内存策略
+    pub fn new_default() -> Self {
+        Self::default()
+    }
+
+    /// 获取策略模式的u32值
+    pub fn mode_as_u32(&self) -> u32 {
+        self.mode as u32
+    }
+
+    /// 检查策略是否针对特定节点
+    pub fn is_node_policy(&self) -> bool {
+        matches!(self.mode, MempolicyMode::Bind | MempolicyMode::Preferred)
+    }
+}
+
+/// 将策略信息写入用户空间
+pub fn write_policy_to_user(
+    policy_ptr: VirtAddr,
+    mode: u32,
+) -> Result<(), SystemError> {
+    if !policy_ptr.is_null() {
+        let mut writer = UserBufferWriter::new(
+            policy_ptr.data() as *mut u32,
+            core::mem::size_of::<u32>(),
+            true,
+        )?;
+        writer.copy_one_to_user(&mode, 0)?;
+    }
+    Ok(())
+}
+
+/// 将节点掩码写入用户空间
+pub fn write_nodemask_to_user(
+    nmask_ptr: VirtAddr,
+    nodemask: u64,
+    maxnode: usize,
+) -> Result<(), SystemError> {
+    if !nmask_ptr.is_null() && maxnode > 0 {
+        let bytes_to_write = (maxnode + 7) / 8; // 将位转换为字节
+        let bytes_to_write = bytes_to_write.min(8); // 限制为u64大小
+        
+        let mut writer = UserBufferWriter::new(
+            nmask_ptr.data() as *mut u8,
+            bytes_to_write,
+            true,
+        )?;
+        
+        let mask_bytes = nodemask.to_ne_bytes();
+        writer.copy_to_user(&mask_bytes[..bytes_to_write], 0)?;
+    }
+    Ok(())
+}
+
+/// 从用户空间读取节点掩码
+pub fn _read_nodemask_from_user(
+    nmask_ptr: VirtAddr,
+    maxnode: usize,
+) -> Result<u64, SystemError> {
+    if nmask_ptr.is_null() || maxnode == 0 {
+        return Ok(0);
+    }
+
+    let bytes_to_read = (maxnode + 7) / 8; // 将位转换为字节
+    let bytes_to_read = bytes_to_read.min(8); // 限制为u64大小
+    
+    let reader = UserBufferReader::new(
+        nmask_ptr.data() as *const u8,
+        bytes_to_read,
+        true,
+    )?;
+    
+    let mut mask_bytes = [0u8; 8];
+    reader.copy_from_user(&mut mask_bytes[..bytes_to_read], 0)?;
+    
+    Ok(u64::from_ne_bytes(mask_bytes))
+}

--- a/kernel/src/mm/syscall/mod.rs
+++ b/kernel/src/mm/syscall/mod.rs
@@ -14,6 +14,8 @@ mod sys_mremap;
 mod sys_msync;
 mod sys_munmap;
 pub mod sys_sbrk;
+mod sys_get_mempolicy;
+mod mempolice_utils;
 
 bitflags! {
     /// Memory protection flags

--- a/kernel/src/mm/syscall/sys_get_mempolicy.rs
+++ b/kernel/src/mm/syscall/sys_get_mempolicy.rs
@@ -1,0 +1,160 @@
+//! System call handler for the get_mempolicy system call.
+
+use crate::arch::{interrupt::TrapFrame, syscall::nr::SYS_GET_MEMPOLICY};
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::mm::{
+    VirtAddr, ucontext::AddressSpace,
+};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+use super::mempolice_utils::{
+    Mempolicy, MempolicyFlags,
+    write_policy_to_user, write_nodemask_to_user
+};
+
+/// ## get_mempolicy系统调用
+///
+/// 获取进程的NUMA内存策略
+///
+/// ## 参数
+///
+/// - `policy`: 用于返回内存策略模式的用户空间指针
+/// - `nmask`: 用于返回节点掩码的用户空间指针  
+/// - `maxnode`: nmask指向的位图中的最大节点数
+/// - `addr`: 要查询策略的内存地址（当flags包含MPOL_F_ADDR时使用）
+/// - `flags`: 控制行为的标志位
+///
+/// ## 返回值
+///
+/// 成功时返回0，失败时返回错误码 
+pub struct SysGetMempolicy;
+
+impl Syscall for SysGetMempolicy {
+    /// Returns the number of arguments this syscall takes.
+    fn num_args(&self) -> usize {
+        5
+    }
+
+    /// Handles the get_mempolicy system call.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let policy_ptr = VirtAddr::new(Self::policy(args));
+        let nmask_ptr = VirtAddr::new(Self::nmask(args));
+        let maxnode = Self::maxnode(args);
+        let addr = VirtAddr::new(Self::addr(args));
+        let flags = Self::flags(args) as u32;
+
+        if flags &
+		    !((MempolicyFlags::MPOL_F_NODE.bits())
+			| (MempolicyFlags::MPOL_F_ADDR.bits())
+			| (MempolicyFlags::MPOL_F_MEMS_ALLOWED.bits())) > 0
+		{ return Err(SystemError::EINVAL); }
+
+        if flags & MempolicyFlags::MPOL_F_MEMS_ALLOWED.bits() > 0 {
+            if (flags & (MempolicyFlags::MPOL_F_NODE.bits() | MempolicyFlags::MPOL_F_ADDR.bits())) > 0 {
+                return Err(SystemError::EINVAL);
+            }
+        }
+        
+        // 验证参数
+        if maxnode > 1024 {
+            return Err(SystemError::EINVAL);
+        }
+
+        // 获取当前进程的内存策略
+        let mempolicy = Self::get_process_mempolicy(addr, flags)?;
+
+        // 根据flags决定返回的内容
+        if flags & MempolicyFlags::MPOL_F_NODE.bits() > 0 {
+            // 返回首选节点或有效节点
+            let node = mempolicy.preferred_node.unwrap_or(0);
+            write_policy_to_user(policy_ptr, node)?;
+        } else if flags & MempolicyFlags::MPOL_F_MEMS_ALLOWED.bits() > 0 {
+            // 返回允许的内存节点掩码
+            let allowed_mask = Self::get_allowed_nodes()?;
+            write_nodemask_to_user(nmask_ptr, allowed_mask, maxnode)?;
+        } else {
+            // 返回策略模式
+            write_policy_to_user(policy_ptr, mempolicy.mode_as_u32())?;
+            
+            // 返回节点掩码
+            if mempolicy.is_node_policy() {
+                write_nodemask_to_user(nmask_ptr, mempolicy.nodemask, maxnode)?;
+            }
+        }
+
+        Ok(0)
+    }
+
+    /// Formats the syscall arguments for display/debugging purposes.
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("policy", format!("{:#x}", Self::policy(args))),
+            FormattedSyscallParam::new("nmask", format!("{:#x}", Self::nmask(args))),
+            FormattedSyscallParam::new("maxnode", format!("{}", Self::maxnode(args))),
+            FormattedSyscallParam::new("addr", format!("{:#x}", Self::addr(args))),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+impl SysGetMempolicy {
+    fn policy(args: &[usize]) -> usize {
+        args[0]
+    }
+    fn nmask(args: &[usize]) -> usize {
+        args[1]
+    }
+    fn maxnode(args: &[usize]) -> usize {
+        args[2]
+    }
+    fn addr(args: &[usize]) -> usize {
+        args[3]
+    }
+    fn flags(args: &[usize]) -> usize {
+        args[4]
+    }
+
+    /// 获取进程的内存策略
+    fn get_process_mempolicy(
+        addr: VirtAddr, 
+        flags: u32
+    ) -> Result<Mempolicy, SystemError> {
+        if flags & MempolicyFlags::MPOL_F_ADDR.bits() > 0 {
+            // 查询特定地址的策略
+            Self::get_vma_mempolicy(addr)
+        } else {
+            // 查询进程默认策略
+            Self::get_default_mempolicy()
+        }
+    }
+
+    /// 获取VMA的内存策略
+    fn get_vma_mempolicy(addr: VirtAddr) -> Result<Mempolicy, SystemError> {
+        let current_as = AddressSpace::current()?;
+        let as_guard = current_as.read();
+        
+        // 检查地址是否在有效的VMA中
+        if let Some(_vma) = as_guard.mappings.contains(addr) {
+            // 目前DragonOS还没有实现per-VMA的内存策略
+            // 返回默认策略
+            Ok(Mempolicy::new_default())
+        } else {
+            Err(SystemError::EFAULT)
+        }
+    }
+
+    /// 获取默认内存策略
+    fn get_default_mempolicy() -> Result<Mempolicy, SystemError> {
+        // 目前DragonOS是单节点系统，返回默认策略
+        Ok(Mempolicy::new_default())
+    }
+
+    /// 获取允许的NUMA节点掩码
+    fn get_allowed_nodes() -> Result<u64, SystemError> {
+        // 目前DragonOS是单节点系统，只有节点0可用
+        Ok(1u64) // 只有第0位设置，表示只有节点0
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_GET_MEMPOLICY, SysGetMempolicy);

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -1,0 +1,106 @@
+use crate::arch::ipc::signal::MAX_SIG_NUM;
+use crate::filesystem::procfs::procfs_register_pid;
+use crate::process::fork::{CloneFlags, KernelCloneArgs, MAX_PID_NS_LEVEL};
+use crate::process::{KernelStack, ProcessControlBlock, ProcessManager};
+use crate::sched::completion::Completion;
+use crate::syscall::user_access::UserBufferWriter;
+use crate::arch::interrupt::TrapFrame;
+use alloc::{string::ToString, sync::Arc};
+use system_error::SystemError;
+
+pub const CLONE_ARGS_SIZE_VER0: usize = 64; /* sizeof first published struct */
+pub const CLONE_ARGS_SIZE_VER1: usize = 80; /* sizeof second published struct */
+pub const CLONE_ARGS_SIZE_VER2: usize = 88; /* sizeof third published struct */
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct CloneArgs {
+    pub flags: u64,
+	pub pidfd: u64,
+	pub child_tid: u64,
+	pub parent_tid: u64, 
+	pub exit_signal: u64,
+	pub stack: u64,
+	pub stack_size: u64,
+	pub tls: u64,
+	pub set_tid: u64,
+	pub set_tid_size: u64,
+	pub cgroup: u64,
+}
+
+impl CloneArgs {
+    pub fn check_valid(&self, size: usize) -> Result<(), SystemError> {
+        if self.set_tid_size > MAX_PID_NS_LEVEL as u64 {
+            return Err(SystemError::EINVAL);
+        }
+        if self.set_tid == 0 && self.set_tid_size > 0 {
+            return Err(SystemError::EINVAL);
+        }
+        if self.set_tid > 0 && self.set_tid_size == 0 {
+            return Err(SystemError::EINVAL);
+        }
+        if self.exit_signal > 0xFF || self.exit_signal <= MAX_SIG_NUM as u64 {
+            return Err(SystemError::EINVAL);
+        }
+        if self.flags & CloneFlags::CLONE_INTO_CGROUP.bits() != 0 &&
+           (self.cgroup > i32::MAX as u64 || size < CLONE_ARGS_SIZE_VER2) {
+            return Err(SystemError::EINVAL);
+        }
+        Ok(())
+    } 
+}
+
+pub fn do_clone(clone_args: KernelCloneArgs, frame: &mut TrapFrame) -> Result<usize, SystemError> {
+    let flags = clone_args.flags;
+
+    let vfork = Arc::new(Completion::new());
+
+        if flags.contains(CloneFlags::CLONE_PIDFD)
+            && flags.contains(CloneFlags::CLONE_PARENT_SETTID)
+        {
+            return Err(SystemError::EINVAL);
+        }
+
+        let current_pcb = ProcessManager::current_pcb();
+        let new_kstack = KernelStack::new()?;
+        let name = current_pcb.basic().name().to_string();
+
+        let pcb = ProcessControlBlock::new(name, new_kstack);
+        // 克隆pcb
+        ProcessManager::copy_process(&current_pcb, &pcb, clone_args, frame)?;
+
+        // 向procfs注册进程
+        procfs_register_pid(pcb.raw_pid()).unwrap_or_else(|e| {
+            panic!(
+                "fork: Failed to register pid to procfs, pid: [{:?}]. Error: {:?}",
+                pcb.raw_pid(),
+                e
+            )
+        });
+
+        if flags.contains(CloneFlags::CLONE_VFORK) {
+            pcb.thread.write_irqsave().vfork_done = Some(vfork.clone());
+        }
+
+        if pcb.thread.read_irqsave().set_child_tid.is_some() {
+            let addr = pcb.thread.read_irqsave().set_child_tid.unwrap();
+            let mut writer =
+                UserBufferWriter::new(addr.as_ptr::<i32>(), core::mem::size_of::<i32>(), true)?;
+            writer.copy_one_to_user(&(pcb.raw_pid().data() as i32), 0)?;
+        }
+
+        ProcessManager::wakeup(&pcb).unwrap_or_else(|e| {
+            panic!(
+                "fork: Failed to wakeup new process, pid: [{:?}]. Error: {:?}",
+                pcb.raw_pid(),
+                e
+            )
+        });
+
+        if flags.contains(CloneFlags::CLONE_VFORK) {
+            // 等待子进程结束或者exec;
+            vfork.wait_for_completion_interruptible()?;
+        }
+
+        return Ok(pcb.raw_pid().0);
+}

--- a/kernel/src/process/syscall/mod.rs
+++ b/kernel/src/process/syscall/mod.rs
@@ -1,5 +1,7 @@
 mod sys_cap_get_set;
 mod sys_clone;
+mod sys_clone3;
+pub mod clone_utils;
 mod sys_execve;
 mod sys_execveat;
 mod sys_exit;

--- a/kernel/src/process/syscall/sys_clone.rs
+++ b/kernel/src/process/syscall/sys_clone.rs
@@ -1,14 +1,10 @@
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_CLONE;
-use crate::filesystem::procfs::procfs_register_pid;
+use crate::process::syscall::clone_utils::do_clone;
 use crate::mm::{verify_area, VirtAddr};
 use crate::process::fork::{CloneFlags, KernelCloneArgs};
-use crate::process::{KernelStack, ProcessControlBlock, ProcessManager};
-use crate::sched::completion::Completion;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::UserBufferWriter;
 use alloc::vec::Vec;
-use alloc::{string::ToString, sync::Arc};
 use system_error::SystemError;
 
 pub struct SysClone;
@@ -59,56 +55,7 @@ impl Syscall for SysClone {
         clone_args.child_tid = child_tid;
         clone_args.tls = tls;
 
-        let vfork = Arc::new(Completion::new());
-
-        if flags.contains(CloneFlags::CLONE_PIDFD)
-            && flags.contains(CloneFlags::CLONE_PARENT_SETTID)
-        {
-            return Err(SystemError::EINVAL);
-        }
-
-        let current_pcb = ProcessManager::current_pcb();
-        let new_kstack = KernelStack::new()?;
-        let name = current_pcb.basic().name().to_string();
-
-        let pcb = ProcessControlBlock::new(name, new_kstack);
-        // 克隆pcb
-        ProcessManager::copy_process(&current_pcb, &pcb, clone_args, frame)?;
-
-        // 向procfs注册进程
-        procfs_register_pid(pcb.raw_pid()).unwrap_or_else(|e| {
-            panic!(
-                "fork: Failed to register pid to procfs, pid: [{:?}]. Error: {:?}",
-                pcb.raw_pid(),
-                e
-            )
-        });
-
-        if flags.contains(CloneFlags::CLONE_VFORK) {
-            pcb.thread.write_irqsave().vfork_done = Some(vfork.clone());
-        }
-
-        if pcb.thread.read_irqsave().set_child_tid.is_some() {
-            let addr = pcb.thread.read_irqsave().set_child_tid.unwrap();
-            let mut writer =
-                UserBufferWriter::new(addr.as_ptr::<i32>(), core::mem::size_of::<i32>(), true)?;
-            writer.copy_one_to_user(&(pcb.raw_pid().data() as i32), 0)?;
-        }
-
-        ProcessManager::wakeup(&pcb).unwrap_or_else(|e| {
-            panic!(
-                "fork: Failed to wakeup new process, pid: [{:?}]. Error: {:?}",
-                pcb.raw_pid(),
-                e
-            )
-        });
-
-        if flags.contains(CloneFlags::CLONE_VFORK) {
-            // 等待子进程结束或者exec;
-            vfork.wait_for_completion_interruptible()?;
-        }
-
-        return Ok(pcb.raw_pid().0);
+        do_clone(clone_args, frame)
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/process/syscall/sys_clone3.rs
+++ b/kernel/src/process/syscall/sys_clone3.rs
@@ -1,0 +1,44 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_CLONE3;
+use crate::process::fork::KernelCloneArgs;
+use crate::process::syscall::clone_utils::do_clone;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub struct SysClone3;
+
+impl Syscall for SysClone3 {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let uarg_ptr = Self::uargs(args);
+        let size = Self::size(args);
+
+        let mut kargs = KernelCloneArgs::new();
+        kargs.copy_clone_args_from_user(uarg_ptr, size)?;
+
+        do_clone(kargs, frame)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("uargs", format!("{:#x}", Self::uargs(args))),
+            FormattedSyscallParam::new("size", format!("{:#x}", Self::size(args))),
+        ]
+    }
+}
+
+impl SysClone3 {
+    fn uargs(args: &[usize]) -> usize { 
+        args[0] as usize
+    }
+
+    fn size(args: &[usize]) -> usize {
+        args[1]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_CLONE3, SysClone3);

--- a/kernel/src/time/syscall/sys_nanosleep.rs
+++ b/kernel/src/time/syscall/sys_nanosleep.rs
@@ -21,7 +21,7 @@ impl SysNanosleep {
 
 impl Syscall for SysNanosleep {
     fn num_args(&self) -> usize {
-        1
+        2
     }
 
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {


### PR DESCRIPTION
feat(procfs): 添加/proc/cpuinfo

- 新增/proc/cpuinfo文件支持，提供CPU硬件信息查询功能
- 实现x86_64架构下的CPU信息采集逻辑，包括：
- 厂商信息、型号、步进版本
- CPU频率、缓存大小
- APIC ID和CPU特性标志
- 将SMP_BOOT_DATA的可见性从pub(super)改为pub，以便cpuinfo模块访问
- 在ProcFS中注册cpuinfo文件并添加相关文件类型定义
- 实现open_cpuinfo方法处理文件打开请求
- 添加generate_cpu_info方法生成各CPU核心的详细信息

refactor(clone): 重构clone系统调用实现并添加clone3支持

- 将clone系统调用的核心逻辑提取到clone_utils模块
- 新增clone3系统调用实现，支持更现代的进程创建方式
- 添加CloneArgs结构体处理clone3的用户空间参数
- 实现从用户空间复制clone参数的验证和转换逻辑
- 扩展CloneFlags支持CLONE_INTO_CGROUP标志

feat(memory): 实现get_mempolicy系统调用

- 添加get_mempolicy系统调用处理NUMA内存策略查询
- 实现Mempolicy结构体和相关枚举类型
- 提供用户空间与内核空间的内存策略数据转换方法
- 支持查询默认内存策略和特定地址的策略
- 添加mempolice_utils模块处理内存策略相关逻辑