### PR TITLE
fix(syscall): 修复mincore系统调用

### DIFF
--- a/kernel/src/mm/syscall/sys_mincore.rs
+++ b/kernel/src/mm/syscall/sys_mincore.rs
@@ -39,7 +39,7 @@ impl Syscall for SysMincoreHandle {
             return Err(SystemError::ENOMEM);
         }
         if len == 0 {
-            return Err(SystemError::EINVAL);
+            return Ok(0);
         }
         let len = page_align_up(len);
         let current_address_space = AddressSpace::current()?;

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -21,6 +21,7 @@ uname_test
 # 内存管理测试
 #mmap_test
 brk_test
+mincore_test
 
 # 网络相关测试
 #bind_test


### PR DESCRIPTION
当传入 length=0 时 mincore 应立刻返回 0 而不是 -EINVAL
确保mincore test通过