### PR TITLE
fix(futex): 修复futex定时器激活逻辑导致唤醒丢失的问题&复FUTEX_WAKE_OP操作中的Linux兼容性问题

### DIFF
--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -476,6 +476,7 @@ impl Futex {
         nr_wake2: i32,
         op: i32,
     ) -> Result<usize, SystemError> {
+        // Linux 语义：对于私有 futex，允许 uaddr1 为 NULL，此时只执行 op，不从 uaddr1 唤醒任何等待者。
         let key1 = Futex::get_futex_key(
             uaddr1,
             flags.contains(FutexFlag::FLAGS_SHARED),
@@ -488,11 +489,13 @@ impl Futex {
         )?;
 
         let mut futex_data_guard = FutexData::futex_map();
-        let bucket1 = futex_data_guard.get_mut(&key1).ok_or(SystemError::EINVAL)?;
         let mut wake_count = 0;
 
-        // 唤醒uaddr1中的进程
-        wake_count += bucket1.wake_up(key1, None, nr_wake as u32)?;
+        // 若 uaddr1 没有关联任何等待者，则按照 Linux 行为返回 0 而不是 EINVAL。
+        if let Some(bucket1) = futex_data_guard.get_mut(&key1) {
+            // 唤醒uaddr1中的进程
+            wake_count += bucket1.wake_up(key1, None, nr_wake as u32)?;
+        }
 
         match Self::futex_atomic_op_inuser(op as u32, uaddr2) {
             Ok(ret) => {
@@ -687,8 +690,9 @@ impl Futex {
             FutexOP::FUTEX_OP_OR => unsafe {
                 *((*ptr) as *mut u32) |= oparg;
             },
+            // ANDN 语义：new = old & ~oparg
             FutexOP::FUTEX_OP_ANDN => unsafe {
-                *((*ptr) as *mut u32) &= oparg;
+                *((*ptr) as *mut u32) &= !oparg;
             },
             FutexOP::FUTEX_OP_XOR => unsafe {
                 *((*ptr) as *mut u32) ^= oparg;

--- a/user/apps/tests/syscall/gvisor/blocklists/futex_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/futex_test
@@ -1,5 +1,4 @@
 # PrivateFutexTest needs FUTEX_WAKE_OP
-PrivateFutexTest.*
 RobustFutexTest.*
 SharedFutexTest.WakeInterprocessFile_NoRandomSave
 


### PR DESCRIPTION
```
commit 46fb53164d134899bd9a2e76858c69124cb308e1 (HEAD -> fix-futex-251019, longjin/fix-futex-251019)
Author: longjin <longjin@DragonOS.org>
Date:   Sun Oct 19 17:03:51 2025 +0800

    fix(futex): 修复FUTEX_WAKE_OP操作中的Linux兼容性问题
    
    - 修复FUTEX_OP_ANDN操作的位运算逻辑错误
    - 支持私有futex中uaddr为NULL时的Linux兼容行为
    - futex_test启用PrivateFutex的测例
    
    Signed-off-by: longjin <longjin@DragonOS.org>

commit 4383ca592d2cb1003806599cd25b482e0e060b9e
Author: longjin <longjin@DragonOS.org>
Date:   Sun Oct 19 16:51:25 2025 +0800

    fix(futex): 修复定时器激活逻辑以避免唤醒丢失
    
    - 在阻塞进程时，确保定时器在中断关闭后被激活，以防止短超时导致的唤醒丢失
    - 移除不必要的定时器激活调用，优化代码结构
    
    Signed-off-by: longjin <longjin@DragonOS.org>
```