### PR TITLE
fix(syscall):修复syslog的bug

### DIFF
--- a/kernel/src/filesystem/procfs/kmsg.rs
+++ b/kernel/src/filesystem/procfs/kmsg.rs
@@ -67,7 +67,7 @@ impl Kmsg {
     }
 
     /// 读取缓冲区所有日志消息
-    fn read_all(&mut self, buf: &mut [u8]) -> Result<usize, SystemError> {
+    pub fn read_all(&mut self, buf: &mut [u8]) -> Result<usize, SystemError> {
         let len = self.data.len().min(buf.len());
 
         // 拷贝数据

--- a/kernel/src/filesystem/procfs/syscall.rs
+++ b/kernel/src/filesystem/procfs/syscall.rs
@@ -12,6 +12,8 @@ enum SyslogAction {
     Open = 1,
     /// Read from the log.
     Read = 2,
+    ///  Read all messages from the ring buffer.
+    ReadAll = 3,
     /// Read and clear all messages remaining in the ring buffer.
     ReadClear = 4,
     /// Clear ring buffer.
@@ -30,6 +32,7 @@ impl From<usize> for SyslogAction {
             0 => SyslogAction::Close,
             1 => SyslogAction::Open,
             2 => SyslogAction::Read,
+            3 => SyslogAction::ReadAll,
             4 => SyslogAction::ReadClear,
             5 => SyslogAction::Clear,
             8 => SyslogAction::ConsoleLevel,
@@ -64,6 +67,7 @@ impl Syscall {
             SyslogAction::Close => Ok(0),
             SyslogAction::Open => Ok(0),
             SyslogAction::Read => kmsg_guard.read(buf),
+            SyslogAction::ReadAll => kmsg_guard.read_all(buf),
             SyslogAction::ReadClear => kmsg_guard.read_clear(buf),
             SyslogAction::Clear => kmsg_guard.clear(),
             SyslogAction::SizeBuffer => kmsg_guard.data_size(),

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -7,6 +7,7 @@ read_test
 chdir_test
 bad_test
 uname_test
+syslog_test
 
 # 文件系统相关测试
 dup_test


### PR DESCRIPTION
- 在 procfs 的 syslog syscall 处理路径中增加对 SYSLOG_ACTION_READ_ALL (action = 3) 的分发。
- 直接调用现有的 Kmsg::read_all 接口，未修改 Kmsg 的实现逻辑。
- 修复了 gvisor 测试中 Syslog.ReadAll 因未分发而返回 EINVAL 的问题。