### PR TITLE
fix: 修复进程创建时 CLONE_PARENT_SETTID 标志处理时机

### DIFF
--- a/user/apps/tests/syscall/gvisor/blocklists/fork_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/fork_test
@@ -2,4 +2,3 @@ ForkTest.COWSegment
 ForkTest.SigAltStack
 ForkTest.Affinity
 CloneTest.Clone3UnknownFlag
-CloneTest.Clone3Basic


### PR DESCRIPTION
- 将 CLONE_PARENT_SETTID 处理逻辑移至进程创建完成后的正确位置