### PR TITLE
fix: validate clone flags and update test blocklist

### DIFF
--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -162,7 +162,7 @@ impl KernelCloneArgs {
 
         args.check_valid(size)?;
 
-        self.flags = CloneFlags::from_bits_truncate(args.flags);
+        self.flags = CloneFlags::from_bits(args.flags).ok_or(SystemError::EINVAL)?;
         self.pidfd = VirtAddr::new(args.pidfd as usize);
         self.child_tid = VirtAddr::new(args.child_tid as usize);
         self.parent_tid = VirtAddr::new(args.parent_tid as usize);

--- a/user/apps/tests/syscall/gvisor/blocklists/fork_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/fork_test
@@ -1,4 +1,3 @@
 ForkTest.COWSegment
 ForkTest.SigAltStack
 ForkTest.Affinity
-CloneTest.Clone3UnknownFlag


### PR DESCRIPTION
- Replace from_bits_truncate with from_bits to properly validate clone flags
- Remove CloneTest.Clone3UnknownFlag from test blocklist as it's now handled



经过这个pr, gvisor syscall test的以下测例可以通过
```c
// Checks that clone fails for any unsupported flag.
TEST(CloneTest, Clone3UnknownFlag) {
  clone_args ca = {};
  ca.flags = (1ULL << 63);
  ca.exit_signal = SIGCHLD;
  EXPECT_THAT(clone3(&ca, sizeof(ca)), SyscallFailsWithErrno(EINVAL));
}
```