### PR TITLE
fix(mm): 修复madvise和msync系统调用中的边界处理问题

### DIFF
--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -1033,10 +1033,10 @@ impl UserMappings {
             if guard.region.contains(vaddr) {
                 return Some(v.clone());
             }
-            // 选择起始地址不大于 vaddr 的 VMA 中，起始地址最大的一个
-            if guard.region.start <= vaddr
+            // 向下寻找：选择起始地址大于 vaddr 的 VMA 中，起始地址最小的一个（最近的下一个VMA）
+            if guard.region.start > vaddr
                 && if let Some(ref current) = nearest {
-                    guard.region.start > current.lock_irqsave().region.start
+                    guard.region.start < current.lock_irqsave().region.start
                 } else {
                     true
                 }

--- a/user/apps/tests/syscall/gvisor/blocklists/fork_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/fork_test
@@ -1,3 +1,7 @@
+# 这个测例，pipe读到的是正确的，但是很奇怪，用户程序glibc会报错：
+# Fatal glibc error: allocatestack.c:192 (advise_stack_range): assertion failed: freesize < size
+# 接着内核panic,然后才会看到错误，说不结果匹配。感觉是哪里写坏内存了，或者对cow/dirty page的处理不对。
+# 已经排除了child进程退出的影响。
 ForkTest.COWSegment
 ForkTest.SigAltStack
 ForkTest.Affinity

--- a/user/apps/tests/syscall/gvisor/blocklists/madvise_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/madvise_test
@@ -1,0 +1,2 @@
+MadviseDontforkTest.DontforkShared
+MadviseDontforkTest.DontforkAnonPrivate

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -26,6 +26,7 @@ futex_test
 #mmap_test
 brk_test
 mincore_test
+madvise_test
 
 # 网络相关测试
 #bind_test


### PR DESCRIPTION
- 修复madvise长度参数未对齐时的处理逻辑，添加长度向上舍入和溢出检查
- 优化msync系统调用中的VMA查找逻辑，修复锁竞争和边界条件问题
- 修复UserMappings::find_nearest中的VMA查找逻辑错误
- 启用madvise测试