### PR TITLE
fix: 修复信号处理和fork时的FP状态管理问题

### DIFF
--- a/user/apps/tests/syscall/gvisor/blocklists/futex_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/futex_test
@@ -1,6 +1,5 @@
 # PrivateFutexTest needs FUTEX_WAKE_OP
 RobustFutexTest.*
-SharedFutexTest.WakeInterprocessFile_NoRandomSave
 
 SharedPrivate/PrivateAndSharedFutexTest.NoWakeInterprocessPrivateAnon_NoRandomSave/*
 

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -21,6 +21,8 @@ lseek_test
 
 # 进程相关测试
 fork_test
+fpsig_fork_test
+fpsig_nested_test
 #exec_test
 #wait_test
 futex_test


### PR DESCRIPTION
- 在信号处理前保存FP状态并加载标准FP环境
- 在fork时确保保存当前FP寄存器状态
- 更新测试用例白名单以包含FP信号fork测试