### PR TITLE
fix: 修复/proc/self/exe符号链接处理问题

### DIFF
--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -845,7 +845,13 @@ impl dyn IndexNode {
                 let link_path = String::from(
                     ::core::str::from_utf8(&content[..len]).map_err(|_| SystemError::EINVAL)?,
                 );
-                let new_path = link_path + "/" + &rest_path;
+
+                // 拼接路径时，如果rest_path为空，则不添加斜杠
+                let new_path = if rest_path.is_empty() {
+                    link_path
+                } else {
+                    link_path + "/" + &rest_path
+                };
 
                 // 继续查找符号链接
                 return result.lookup_follow_symlink2(

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -524,6 +524,11 @@ impl ProcessManager {
         // 继承 rlimit
         pcb.inherit_rlimits_from(current_pcb);
 
+        // 继承 executable_path
+        // 修复：fork时需要复制父进程的可执行文件路径，而不是使用进程名
+        // 这样才能正确支持通过/proc/self/exe重新执行程序
+        pcb.set_execute_path(current_pcb.execute_path());
+
         // log::debug!("fork: clone_flags: {:?}", clone_flags);
         // 设置线程组id、组长
         if clone_flags.contains(CloneFlags::CLONE_THREAD) {

--- a/kernel/src/process/syscall/sys_execve.rs
+++ b/kernel/src/process/syscall/sys_execve.rs
@@ -128,7 +128,11 @@ impl Syscall for SysExecve {
         let pwd = ProcessManager::current_pcb().pwd_inode();
         let inode = pwd.lookup_follow_symlink(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
 
-        Self::execve(inode, path, argv, envp, frame)?;
+        // 获取inode的绝对路径，而不是使用用户传入的原始路径
+        // 这样可以正确处理符号链接（如/proc/self/exe）
+        let resolved_path = inode.absolute_path().unwrap_or(path.clone());
+
+        Self::execve(inode, resolved_path, argv, envp, frame)?;
         return Ok(0);
     }
 

--- a/user/apps/c_unitest/test_proc_self_exe.c
+++ b/user/apps/c_unitest/test_proc_self_exe.c
@@ -1,0 +1,87 @@
+/**
+ * @file test_proc_self_exe.c
+ * @brief 测试通过 /proc/self/exe 来执行进程
+ * 
+ * 这个测试用例验证以下内容：
+ * 1. 能够通过readlink读取/proc/self/exe
+ * 2. 能够通过/proc/self/exe来执行程序
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/wait.h>
+
+#define BUF_SIZE 4096
+
+int main(int argc, char *argv[])
+{
+    // 如果有参数，说明是被重新执行的
+    if (argc > 1 && strcmp(argv[1], "reexec") == 0) {
+        printf("[Child] Successfully re-executed via /proc/self/exe\n");
+        printf("[Child] My PID: %d\n", getpid());
+        return 0;
+    }
+
+    printf("[Parent] Testing /proc/self/exe functionality\n");
+    printf("[Parent] My PID: %d\n", getpid());
+
+    // 测试1: 使用readlink读取/proc/self/exe
+    char exe_path[BUF_SIZE];
+    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+    if (len == -1) {
+        perror("[Parent] readlink(/proc/self/exe) failed");
+        return 1;
+    }
+    exe_path[len] = '\0';
+    printf("[Parent] /proc/self/exe -> %s\n", exe_path);
+
+    // 测试2: 尝试通过/proc/self/exe来执行程序
+    printf("[Parent] Attempting to execute /proc/self/exe...\n");
+    
+    pid_t pid = fork();
+    if (pid == -1) {
+        perror("[Parent] fork failed");
+        return 1;
+    }
+
+    if (pid == 0) {
+        // 子进程：通过/proc/self/exe执行
+        char *new_argv[] = {"/proc/self/exe", "reexec", NULL};
+        char *new_envp[] = {NULL};
+        
+        printf("[Child] About to execve(/proc/self/exe, ...)\n");
+        execve("/proc/self/exe", new_argv, new_envp);
+        
+        // 如果执行到这里，说明execve失败了
+        perror("[Child] execve(/proc/self/exe) failed");
+        printf("[Child] Error code: %d (%s)\n", errno, strerror(errno));
+        exit(1);
+    } else {
+        // 父进程：等待子进程结束
+        int status;
+        if (waitpid(pid, &status, 0) == -1) {
+            perror("[Parent] waitpid failed");
+            return 1;
+        }
+
+        if (WIFEXITED(status)) {
+            int exit_code = WEXITSTATUS(status);
+            printf("[Parent] Child exited with code: %d\n", exit_code);
+            if (exit_code == 0) {
+                printf("[Parent] Test PASSED!\n");
+                return 0;
+            } else {
+                printf("[Parent] Test FAILED - child returned error\n");
+                return 1;
+            }
+        } else {
+            printf("[Parent] Child did not exit normally\n");
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/user/apps/tests/syscall/gvisor/blocklists/vfork_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/vfork_test
@@ -1,2 +1,0 @@
-VforkTest.ParentStopsUntilChildExecves
-VforkTest.ExecedChildExitDoesntUnstopParent


### PR DESCRIPTION
- 修复符号链接路径拼接时rest_path为空的情况
- 在fork时正确继承父进程的可执行文件路径
- 在execve中解析符号链接的绝对路径
- 添加/proc/self/exe功能测试用例