### PR TITLE
feat(process): 完善进程等待和克隆的语义实现

### DIFF
--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -158,6 +158,21 @@ impl KernelCloneArgs {
         }
         Ok(())
     }
+
+    /// 规范化 exit_signal 字段，根据 Linux clone 语义处理
+    ///
+    /// ## 规则
+    ///
+    /// 1. 如果设置了 CLONE_THREAD，进程是线程组成员，不应发送 exit_signal（设为 INVALID）
+    /// 2. 其他情况保持 exit_signal 不变
+    ///
+    /// 这个方法应该在 do_clone() 之前调用，确保 exit_signal 的语义正确。
+    pub fn normalize_exit_signal(&mut self) {
+        if self.flags.contains(CloneFlags::CLONE_THREAD) {
+            // 线程组成员不发送 exit_signal
+            self.exit_signal = Signal::INVALID;
+        }
+    }
 }
 
 impl ProcessManager {

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -56,7 +56,11 @@ impl PosixCloneArgs {
     }
 }
 
-pub fn do_clone(clone_args: KernelCloneArgs, frame: &mut TrapFrame) -> Result<usize, SystemError> {
+pub fn do_clone(
+    mut clone_args: KernelCloneArgs,
+    frame: &mut TrapFrame,
+) -> Result<usize, SystemError> {
+    clone_args.normalize_exit_signal();
     clone_args.verify()?;
     let flags = clone_args.flags;
 

--- a/kernel/src/process/syscall/sys_clone.rs
+++ b/kernel/src/process/syscall/sys_clone.rs
@@ -3,6 +3,7 @@ use crate::arch::syscall::nr::SYS_CLONE;
 use crate::mm::{verify_area, VirtAddr};
 use crate::process::fork::{CloneFlags, KernelCloneArgs};
 use crate::process::syscall::clone_utils::do_clone;
+use crate::process::Signal;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -53,6 +54,10 @@ impl Syscall for SysClone {
         clone_args.parent_tid = parent_tid;
         clone_args.child_tid = child_tid;
         clone_args.tls = tls;
+
+        // 旧版 clone() 系统调用中，flags 的低 8 位用于指定 exit_signal
+        let exit_signal_num = (args[0] & 0xFF) as i32;
+        clone_args.exit_signal = Signal::from(exit_signal_num);
 
         do_clone(clone_args, frame)
     }

--- a/user/apps/tests/syscall/gvisor/blocklists/wait_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/wait_test
@@ -10,7 +10,7 @@ Waiters/WaitAnyChildTest.IgnoredChildRusage/*
 # 缺少 SYS_SCHED_GETPARAM SYS_SCHED_GETSCHEDULER
 Waiters/WaitSpecificChildTest.SiblingChildrenWNOTHREAD/*
 
-Waiters/WaitSpecificChildTest.CloneNoSIGCHLD/*
 Waiters/WaitSpecificChildTest.CloneThread/*
 Waiters/WaitSpecificChildTest.ForkWCLONE/*
+# 缺少 /bin/true
 Waiters/WaitSpecificChildTest.AfterChildExecve/*


### PR DESCRIPTION
feat(process): 完善进程等待和克隆的语义实现

- 实现子进程退出信号匹配检查，支持 __WALL 和 __WCLONE 等待选项
- 规范化克隆操作的 exit_signal 处理，线程组成员不发送退出信号
- 修复 wait4 系统调用中进程关系验证和错误码返回逻辑
- 更新旧版 clone 系统调用以正确处理 exit_signal 参数