### PR TITLE
fix(vfs): 修复syncfs系统调用中文件描述符验证问题

### DIFF
--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -15,6 +15,7 @@ write_test
 mknod_test
 unlink_test
 lseek_test
+sync_test
 #stat_test
 #chmod_test
 #chown_test


### PR DESCRIPTION
- 在syncfs系统调用中添加文件描述符验证逻辑
- 检查文件描述符是否存在以及是否以O_PATH模式打开
- 当文件描述符无效或为O_PATH模式时返回EBADF错误
- 添加sync_test到gvisor测试白名单中