### PR TITLE
fix: 修复拷贝线程的时候,错误的设置用户栈指针的bug

### DIFF
--- a/kernel/src/arch/riscv64/process/mod.rs
+++ b/kernel/src/arch/riscv64/process/mod.rs
@@ -119,9 +119,10 @@ impl ProcessManager {
 
         // 拷贝栈帧
         unsafe {
-            let usp = clone_args.stack;
-            if usp != 0 {
-                child_trapframe.sp = usp;
+            if clone_args.stack != 0 {
+                // stack 是栈的顶部（低地址），栈底需要加上 stack_size
+                // 注意：栈向下增长，所以 sp 应该指向高地址
+                child_trapframe.sp = clone_args.stack + clone_args.stack_size;
             }
             let trap_frame_ptr = trap_frame_vaddr.data() as *mut TrapFrame;
             *trap_frame_ptr = child_trapframe;

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -325,9 +325,11 @@ impl ProcessManager {
 
         // 拷贝栈帧
         unsafe {
-            let usp = clone_args.stack;
-            if usp != 0 {
-                child_trapframe.rsp = usp as u64;
+            if clone_args.stack != 0 {
+                // stack 是栈的顶部（低地址），栈底需要加上 stack_size
+                // 注意：x86_64 栈向下增长，所以 rsp 应该指向高地址
+                let stack_top = clone_args.stack + clone_args.stack_size;
+                child_trapframe.rsp = stack_top as u64;
             }
             let trap_frame_ptr = trap_frame_vaddr.data() as *mut TrapFrame;
             *trap_frame_ptr = child_trapframe;

--- a/user/apps/tests/syscall/gvisor/blocklists/uname_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/uname_test
@@ -1,3 +1,0 @@
-# 需要添加SYS_CLONE3之后，才能开始验证这个测试，否则内核会panic
-UnameTest.UnshareUTS
-


### PR DESCRIPTION
原本内核把clone时，用户指定的用户栈的rsp设置错了...导致内存写坏，用户程序随机跑飞。

glibc在pthread_join的时候有个assert,检测到了这个问题:
子线程退出的时候，有可能报错`Fatal glibc error: allocatestack.c:192 (advise_stack_range): assertion failed: freesize < size`

对着glibc-2.39的代码分析之后，发现这里的bug.
