### PR TITLE
refactor(futex): 优化futex唤醒逻辑和共享键生成机制

### DIFF
--- a/user/apps/tests/syscall/gvisor/blocklists/futex_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/futex_test
@@ -1,2 +1,1 @@
 SharedPrivate/PrivateAndSharedFutexTest.WakeOpCondSuccess/*
-SharedPrivate/PrivateAndSharedFutexTest.WakeWrongKind*


### PR DESCRIPTION
- 重构futex等待唤醒逻辑，明确区分正常唤醒、超时和信号唤醒
- 引入SharedKeyKind枚举，改进共享futex键的生成方式
- 为AddressSpace添加全局唯一ID，支持私有匿名映射的跨线程同步
- 修复clear_child_tid唤醒逻辑，使用FUTEX_SHARED标志
- 更新测试用例，移除不再适用的阻塞项