### PR TITLE
feat(process): 实现prctl系统调用支持PR_SET_PDEATHSIG和PR_SET_NAME选项

### DIFF
--- a/kernel/src/process/syscall/mod.rs
+++ b/kernel/src/process/syscall/mod.rs
@@ -18,6 +18,7 @@ mod sys_gettid;
 mod sys_getuid;
 mod sys_groups;
 mod sys_pidfdopen;
+mod sys_prctl;
 pub mod sys_prlimit64;
 mod sys_set_tid_address;
 mod sys_setdomainname;

--- a/kernel/src/process/syscall/sys_prctl.rs
+++ b/kernel/src/process/syscall/sys_prctl.rs
@@ -1,0 +1,158 @@
+use alloc::string::ToString;
+use core::{cmp, ffi::c_int, mem};
+use num_traits::FromPrimitive;
+
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
+use system_error::SystemError;
+
+use crate::{
+    arch::{interrupt::TrapFrame, ipc::signal::Signal, syscall::nr::SYS_PRCTL},
+    process::ProcessManager,
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access::{UserBufferReader, UserBufferWriter},
+    },
+};
+
+const TASK_COMM_LEN: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, FromPrimitive)]
+#[repr(usize)]
+enum PrctlOption {
+    SetPDeathSig = 1,
+    GetPDeathSig = 2,
+    SetName = 15,
+    GetName = 16,
+}
+
+impl TryFrom<usize> for PrctlOption {
+    type Error = SystemError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        PrctlOption::from_usize(value).ok_or(SystemError::EINVAL)
+    }
+}
+
+pub struct SysPrctl;
+
+impl Syscall for SysPrctl {
+    fn num_args(&self) -> usize {
+        5
+    }
+
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        if args.len() < 5 {
+            return Err(SystemError::EINVAL);
+        }
+
+        let option = PrctlOption::try_from(args[0])?;
+        let arg2 = args[1];
+        let from_user = frame.is_from_user();
+        let current = ProcessManager::current_pcb();
+
+        match option {
+            PrctlOption::SetPDeathSig => {
+                let signal = parse_pdeathsig(arg2)?;
+                current.set_pdeath_signal(signal);
+                Ok(0)
+            }
+            PrctlOption::GetPDeathSig => {
+                let dest = arg2 as *mut c_int;
+                if dest.is_null() {
+                    return Err(SystemError::EFAULT);
+                }
+                let mut writer = UserBufferWriter::new(dest, mem::size_of::<c_int>(), from_user)?;
+                let sig = current.pdeath_signal();
+                let value: c_int = if sig == Signal::INVALID {
+                    0
+                } else {
+                    sig as c_int
+                };
+                writer.copy_one_to_user(&value, 0)?;
+                Ok(0)
+            }
+            PrctlOption::SetName => {
+                let name_ptr = arg2 as *const u8;
+                if name_ptr.is_null() {
+                    return Err(SystemError::EFAULT);
+                }
+                let comm = read_comm_buffer(name_ptr, from_user)?;
+                let name = comm_buffer_to_string(&comm);
+                current.set_name(name);
+                Ok(0)
+            }
+            PrctlOption::GetName => {
+                let dest = arg2 as *mut u8;
+                if dest.is_null() {
+                    return Err(SystemError::EFAULT);
+                }
+                let name = current.basic().name().to_string();
+                write_comm_buffer(dest, from_user, name.as_bytes())?;
+                Ok(0)
+            }
+        }
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        let option_val = args.first().copied().unwrap_or(0);
+        let option_str = if let Ok(option) = PrctlOption::try_from(option_val) {
+            format!("{:#x} ({:?})", option_val, option)
+        } else {
+            format!("{:#x}", option_val)
+        };
+
+        vec![
+            FormattedSyscallParam::new("option", option_str),
+            FormattedSyscallParam::new("arg2", format!("{:#x}", args.get(1).copied().unwrap_or(0))),
+            FormattedSyscallParam::new("arg3", format!("{:#x}", args.get(2).copied().unwrap_or(0))),
+            FormattedSyscallParam::new("arg4", format!("{:#x}", args.get(3).copied().unwrap_or(0))),
+            FormattedSyscallParam::new("arg5", format!("{:#x}", args.get(4).copied().unwrap_or(0))),
+        ]
+    }
+}
+
+fn parse_pdeathsig(value: usize) -> Result<Signal, SystemError> {
+    if value == 0 {
+        return Ok(Signal::INVALID);
+    }
+    let sig = Signal::from(value);
+    if sig.is_valid() {
+        Ok(sig)
+    } else {
+        Err(SystemError::EINVAL)
+    }
+}
+
+fn read_comm_buffer(
+    ptr_src: *const u8,
+    from_user: bool,
+) -> Result<[u8; TASK_COMM_LEN], SystemError> {
+    let mut comm = [0u8; TASK_COMM_LEN];
+    let reader = UserBufferReader::new(ptr_src, TASK_COMM_LEN, from_user)?;
+    reader.copy_from_user_protected(&mut comm, 0)?;
+    comm[TASK_COMM_LEN - 1] = 0;
+    Ok(comm)
+}
+
+fn comm_buffer_to_string(buffer: &[u8; TASK_COMM_LEN]) -> String {
+    let len = buffer
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(TASK_COMM_LEN - 1);
+    let slice = &buffer[..len];
+    match core::str::from_utf8(slice) {
+        Ok(s) => s.to_owned(),
+        Err(_) => String::from_utf8_lossy(slice).into_owned(),
+    }
+}
+
+fn write_comm_buffer(dest: *mut u8, from_user: bool, name_bytes: &[u8]) -> Result<(), SystemError> {
+    let mut comm = [0u8; TASK_COMM_LEN];
+    let copy_len = cmp::min(name_bytes.len(), TASK_COMM_LEN - 1);
+    comm[..copy_len].copy_from_slice(&name_bytes[..copy_len]);
+    let mut writer = UserBufferWriter::new(dest, TASK_COMM_LEN, from_user)?;
+    writer.copy_to_user_protected(&comm, 0)?;
+    Ok(())
+}
+
+syscall_table_macros::declare_syscall!(SYS_PRCTL, SysPrctl);

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -350,13 +350,6 @@ impl Syscall {
                 Err(SystemError::ENOSYS)
             }
 
-            // SYS_SCHED_YIELD => Self::sched_yield(),
-            SYS_PRCTL => {
-                // todo: 这个系统调用还没有实现
-
-                Err(SystemError::EINVAL)
-            }
-
             #[cfg(target_arch = "x86_64")]
             SYS_EVENTFD => {
                 let initval = args[0] as u32;

--- a/user/apps/tests/syscall/gvisor/blocklists/prctl_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/prctl_test
@@ -1,0 +1,11 @@
+# 缺少 SYS_PTRACE
+PrctlTest.NoNewPrivsPreservedAcrossCloneForkAndExecve
+PrctlTest.PDeathSig
+# 暂不支持
+PrctlTest.InvalidPrSetMM
+PrctlTest.SetGetDumpability
+
+PrctlTest.SimpleSetGetChildSubreaper
+PrctlTest.ThreadsInheritChildSubreaperBit
+PrctlTest.ProcessesDoNotInheritChildSubreaperBit
+PrctlTest.OrphansReparentedToSubreaper

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -35,6 +35,7 @@ fpsig_nested_test
 wait_test
 tkill_test
 tgkill_test
+prctl_test
 
 # 内存管理测试
 #mmap_test


### PR DESCRIPTION
- 新增pdeath_signal字段到ProcessControlBlock，支持父进程退出信号设置
- 实现prctl系统调用，支持设置/获取进程名和父进程退出信号
- 在进程退出时向设置了pdeath_signal的子进程发送相应信号
- 添加prctl测试用例到gvisor测试白名单