### PR TITLE
fix: 修复getdents系统调用实现

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -199,12 +199,12 @@ impl X86_64MMArch {
 
         // 在异常表中查找修复代码
         if let Some(fixup_addr) = ExceptionTableManager::search_exception_table(regs.rip as usize) {
-            log::debug!(
-                "Page fault at {:#x} accessing user address {:#x}, fixed up to {:#x}",
-                regs.rip,
-                address.data(),
-                fixup_addr
-            );
+            // log::debug!(
+            //     "Page fault at {:#x} accessing user address {:#x}, fixed up to {:#x}",
+            //     regs.rip,
+            //     address.data(),
+            //     fixup_addr
+            // );
 
             // 修改trap frame的RIP到修复代码
             regs.rip = fixup_addr as u64;
@@ -385,16 +385,16 @@ impl X86_64MMArch {
             }
 
             if unlikely(Self::vma_access_error(vma.clone(), error_code)) {
+                // VMA权限错误，检查是否需要异常表修复
+                if handle_kernel_access_failed(regs) {
+                    return; // 已通过异常表修复
+                }
+
                 log::error!(
                     "vma access error, error_code: {:?}, address: {:#x}",
                     error_code,
                     address.data(),
                 );
-
-                // VMA权限错误，检查是否需要异常表修复
-                if handle_kernel_access_failed(regs) {
-                    return; // 已通过异常表修复
-                }
 
                 send_segv();
             }

--- a/kernel/src/filesystem/procfs/mod.rs
+++ b/kernel/src/filesystem/procfs/mod.rs
@@ -1174,7 +1174,10 @@ impl IndexNode for LockedProcFSInode {
         keys.push(String::from(".."));
 
         if self.0.lock().fdata.ftype == ProcFileType::ProcFdDir {
-            return self.dynamical_list_fd();
+            // 对于 /proc/self/fd 目录，需要包含 "." 和 ".."，然后添加所有fd
+            let mut fd_list = self.dynamical_list_fd()?;
+            keys.append(&mut fd_list);
+            return Ok(keys);
         }
 
         keys.append(

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -438,6 +438,17 @@ impl File {
     /// ## 参数
     /// - ctx 填充目录项的上下文
     pub fn read_dir(&self, ctx: &mut FilldirContext) -> Result<(), SystemError> {
+        // O_PATH 文件描述符只能用于有限的操作，getdents/getdents64
+        // 在 Linux 中会返回 EBADF。提前检测并返回相同语义。
+        if self.mode().contains(FileMode::O_PATH) {
+            return Err(SystemError::EBADF);
+        }
+
+        // 仅目录允许读取目录项，其它类型遵循 POSIX 语义返回 ENOTDIR。
+        if self.file_type() != FileType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+
         let inode: &Arc<dyn IndexNode> = &self.inode;
         let mut current_pos = self.offset.load(Ordering::SeqCst);
 
@@ -445,7 +456,15 @@ impl File {
         // 但是观察到在现有的子目录中已经包含，不做处理也能正常返回. 和 .. 这里先不做处理
 
         // 迭代读取目录项
-        let readdir_subdirs_name = inode.list()?;
+        // 为了保证在目录内容动态变化（例如 /proc/self/fd）时不会因为重新
+        // 创建列表而丢失尚未读取的目录项，这里缓存第一次生成的列表，在
+        // 文件偏移被 seek 到 0 之前复用该缓存。
+        let mut cached_names = self.readdir_subdirs_name.lock();
+        if current_pos == 0 || cached_names.is_empty() {
+            *cached_names = inode.list()?;
+        }
+        let readdir_subdirs_name = cached_names.clone();
+        drop(cached_names);
 
         let subdirs_name_len = readdir_subdirs_name.len();
         while current_pos < subdirs_name_len {
@@ -453,6 +472,12 @@ impl File {
             let sub_inode: Arc<dyn IndexNode> = match inode.find(name) {
                 Ok(i) => i,
                 Err(e) => {
+                    if e == SystemError::ENOENT {
+                        // 目录项在本次读取过程中被移除，跳过它，继续读取后续条目
+                        self.offset.fetch_add(1, Ordering::SeqCst);
+                        current_pos += 1;
+                        continue;
+                    }
                     error!("Readdir error: Failed to find sub inode");
                     return Err(e);
                 }

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     mm::{fault::PageFaultMessage, VmFaultReason},
     net::socket::Socket,
     process::ProcessManager,
+    syscall::user_buffer::UserBuffer,
     time::PosixTimeSpec,
 };
 
@@ -1121,17 +1122,6 @@ pub struct FsInfo {
     pub max_name_len: usize,
 }
 
-/// @brief
-#[repr(C)]
-#[derive(Debug)]
-pub struct Dirent {
-    d_ino: u64,    // 文件序列号
-    d_off: i64,    // dir偏移量
-    d_reclen: u16, // 目录下的记录数
-    d_type: u8,    // entry的类型
-    d_name: u8,    // 文件entry的名字(是一个零长数组)， 本字段仅用于占位
-}
-
 impl Metadata {
     pub fn new(file_type: FileType, mode: ModeType) -> Self {
         Metadata {
@@ -1238,22 +1228,34 @@ pub fn produce_fs(
 
 define_filesystem_maker_slice!(FSMAKER);
 
+/// Dirent 格式类型
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirentFormat {
+    /// 旧格式 getdents (linux_dirent)，不包含 d_type 字段
+    Getdents,
+    /// 新格式 getdents64 (linux_dirent64)，包含 d_type 字段
+    Getdents64,
+}
+
 /// # 批量填充Dirent时的上下文Add commentMore actions
 /// linux语义是通过getdents_callback *类型来实现类似链表的迭代填充，这里考虑通过填充传入的缓冲区来实现
 pub struct FilldirContext<'a> {
-    buf: &'a mut [u8],
+    user_buf: UserBuffer<'a>,
     current_pos: usize,
     remain_size: usize,
     error: Option<SystemError>,
+    format: DirentFormat,
 }
 
 impl<'a> FilldirContext<'a> {
-    pub fn new(user_buf: &'a mut [u8]) -> Self {
+    pub fn new(user_buf: UserBuffer<'a>, format: DirentFormat) -> Self {
+        let len = user_buf.len();
         Self {
-            remain_size: user_buf.len(),
-            buf: user_buf,
+            remain_size: len,
+            user_buf,
             current_pos: 0,
             error: None,
+            format,
         }
     }
 
@@ -1264,7 +1266,7 @@ impl<'a> FilldirContext<'a> {
     /// - offset 当前目录项偏移量
     /// - ino 目录项的inode的inode_id
     /// - d_type 目录项的inode的file_type_num
-    fn fill_dir(
+    pub(crate) fn fill_dir(
         &mut self,
         name: &str,
         offset: usize,
@@ -1272,40 +1274,104 @@ impl<'a> FilldirContext<'a> {
         d_type: u8,
     ) -> Result<(), SystemError> {
         let name_len = name.len();
-        let dirent_size = ::core::mem::size_of::<Dirent>() - ::core::mem::size_of::<u8>();
-        let reclen = name_len + dirent_size + 1;
+        let name_bytes = name.as_bytes();
 
-        // 将reclen向上对齐usize大小
-        let align_up = |len: usize, align: usize| -> usize { (len + align - 1) & !(align - 1) };
-        let align_up_reclen = align_up(reclen, ::core::mem::size_of::<usize>());
+        // 根据格式计算基础结构大小
+        // linux_dirent (旧格式): d_ino(8) + d_off(8) + d_reclen(2) = 18 bytes
+        // linux_dirent64 (新格式): d_ino(8) + d_off(8) + d_reclen(2) + d_type(1) = 19 bytes
+        let base_size = match self.format {
+            DirentFormat::Getdents => 18,   // d_ino + d_off + d_reclen
+            DirentFormat::Getdents64 => 19, // d_ino + d_off + d_reclen + d_type
+        };
 
-        // 当前缓冲区空间已不足，返回EINVAL
+        // 计算总长度：基础结构 + 文件名 + null terminator
+        let total_size = base_size + name_len + 1;
+
+        // 对齐到 8 字节（Linux 要求 d_reclen 必须是 8 的倍数）
+        const ALIGN: usize = 8;
+        let align_up = |len: usize| -> usize { (len + ALIGN - 1) & !(ALIGN - 1) };
+        let align_up_reclen = align_up(total_size);
+
+        // 检查缓冲区空间是否足够
         if align_up_reclen > self.remain_size {
             self.error = Some(SystemError::EINVAL);
             return Err(SystemError::EINVAL);
         }
 
-        // 获取剩余缓冲区
-        let current_dirent_slice = &mut self.buf[self.current_pos..];
-        let dirent = unsafe { (current_dirent_slice.as_mut_ptr() as *mut Dirent).as_mut() }
-            .ok_or(SystemError::EFAULT)?;
-
-        // 填充dirent
-        dirent.d_ino = ino;
-        dirent.d_type = d_type;
-        dirent.d_reclen = align_up_reclen as u16;
-        dirent.d_off = offset as i64;
-        unsafe {
-            let ptr = &mut dirent.d_name as *mut u8;
-            let buf: &mut [u8] =
-                ::core::slice::from_raw_parts_mut::<'static, u8>(ptr, name_len + 1);
-            buf[0..name_len].copy_from_slice(name.as_bytes());
-            buf[name_len] = 0;
+        // 获取当前写入位置的偏移量
+        let buf_start = self.current_pos;
+        // 清零缓冲区（确保对齐部分为0）
+        // 如果清零失败（例如访问不可写页面），视为缓冲区空间不足
+        if let Err(_e) = self.user_buf.clear_range(buf_start, align_up_reclen) {
+            // 将 EFAULT 或其他写入错误转换为 EINVAL，表示缓冲区空间不足
+            // 这样 read_dir 会正常返回，而不是传播错误
+            self.error = Some(SystemError::EINVAL);
+            return Err(SystemError::EINVAL);
         }
+        // 在内核空间构建完整的 dirent 数据
+        let mut dirent_data = vec![0u8; align_up_reclen];
 
+        // 根据格式填充结构
+        match self.format {
+            DirentFormat::Getdents => {
+                // linux_dirent 格式：
+                // d_ino: unsigned long (8 bytes)
+                // d_off: unsigned long (8 bytes)
+                // d_reclen: unsigned short (2 bytes)
+                // d_name[0]: char[] (可变长度)
+
+                // 写入 d_ino (offset 0, 8 bytes)
+                dirent_data[0..8].copy_from_slice(&ino.to_le_bytes());
+
+                // 写入 d_off (offset 8, 8 bytes) - 注意：旧格式使用 unsigned long
+                let d_off = offset as u64;
+                dirent_data[8..16].copy_from_slice(&d_off.to_le_bytes());
+
+                // 写入 d_reclen (offset 16, 2 bytes)
+                dirent_data[16..18].copy_from_slice(&(align_up_reclen as u16).to_le_bytes());
+
+                // 写入 d_name (offset 18)
+                dirent_data[18..18 + name_len].copy_from_slice(name_bytes);
+                dirent_data[18 + name_len] = 0; // null terminator
+            }
+            DirentFormat::Getdents64 => {
+                // linux_dirent64 格式：
+                // d_ino: uint64_t (8 bytes)
+                // d_off: int64_t (8 bytes)
+                // d_reclen: unsigned short (2 bytes)
+                // d_type: unsigned char (1 byte)
+                // d_name[0]: char[] (可变长度)
+
+                // 写入 d_ino (offset 0, 8 bytes)
+                dirent_data[0..8].copy_from_slice(&ino.to_le_bytes());
+
+                // 写入 d_off (offset 8, 8 bytes) - 注意：新格式使用 int64_t
+                let d_off = offset as i64;
+                dirent_data[8..16].copy_from_slice(&d_off.to_le_bytes());
+
+                // 写入 d_reclen (offset 16, 2 bytes)
+                dirent_data[16..18].copy_from_slice(&(align_up_reclen as u16).to_le_bytes());
+
+                // 写入 d_type (offset 18, 1 byte)
+                dirent_data[18] = d_type;
+
+                // 写入 d_name (offset 19)
+                dirent_data[19..19 + name_len].copy_from_slice(name_bytes);
+                dirent_data[19 + name_len] = 0; // null terminator
+            }
+        }
+        // 使用受保护的方法写入用户缓冲区
+        // 如果写入失败（例如访问不可写页面），视为缓冲区空间不足
+        if let Err(_e) = self.user_buf.write_to_user(buf_start, &dirent_data) {
+            // 将 EFAULT 或其他写入错误转换为 EINVAL，表示缓冲区空间不足
+            // 这样 read_dir 会正常返回，而不是传播错误
+            self.error = Some(SystemError::EINVAL);
+            return Err(SystemError::EINVAL);
+        }
+        // 更新位置
         self.current_pos += align_up_reclen;
         self.remain_size -= align_up_reclen;
 
-        return Ok(());
+        Ok(())
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_getdents.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_getdents.rs
@@ -4,18 +4,83 @@ use system_error::SystemError;
 
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::{SYS_GETDENTS, SYS_GETDENTS64};
-use crate::filesystem::vfs::FilldirContext;
-use crate::mm::{verify_area, VirtAddr};
+use crate::filesystem::vfs::{DirentFormat, FilldirContext};
 use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferWriter;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
-/// System call handler for the `getdents` syscall
+/// System call handler for the `getdents` syscall (旧格式)
 ///
-/// Reads directory entries from a directory file descriptor.
+/// Reads directory entries from a directory file descriptor using linux_dirent format.
 pub struct SysGetdentsHandle;
+
+/// System call handler for the `getdents64` syscall (新格式)
+///
+/// Reads directory entries from a directory file descriptor using linux_dirent64 format.
+pub struct SysGetdents64Handle;
+
+const MAX_GETDENTS_COUNT: usize = i32::MAX as usize;
+
+fn do_getdents(
+    args: &[usize],
+    frame: &mut TrapFrame,
+    format: DirentFormat,
+) -> Result<usize, SystemError> {
+    let fd = args[0] as i32;
+    let buf_vaddr = args[1];
+    let len = args[2];
+
+    if buf_vaddr == 0 {
+        return Err(SystemError::EFAULT);
+    }
+
+    if len == 0 {
+        return Err(SystemError::EINVAL);
+    }
+
+    if len > MAX_GETDENTS_COUNT {
+        return Err(SystemError::EINVAL);
+    }
+
+    if fd < 0 {
+        return Err(SystemError::EBADF);
+    }
+
+    // 使用 UserBufferWriter 和 buffer_protected 创建受保护的用户缓冲区
+    let from_user = frame.is_from_user();
+    let mut writer = UserBufferWriter::new(buf_vaddr as *mut u8, len, from_user)?;
+    let user_buf = writer.buffer_protected(0)?;
+
+    // 获取fd
+    let binding = ProcessManager::current_pcb().fd_table();
+    let fd_table_guard = binding.read();
+    let file = fd_table_guard
+        .get_file_by_fd(fd)
+        .ok_or(SystemError::EBADF)?;
+
+    // drop guard 以避免无法调度的问题
+    drop(fd_table_guard);
+
+    let mut ctx = FilldirContext::new(user_buf, format);
+    match file.read_dir(&mut ctx) {
+        Ok(_) => {
+            if ctx.error.is_some() {
+                if ctx.error == Some(SystemError::EINVAL) {
+                    return Ok(ctx.current_pos);
+                } else {
+                    return Err(ctx.error.unwrap());
+                }
+            }
+            return Ok(ctx.current_pos);
+        }
+        Err(e) => {
+            return Err(e);
+        }
+    }
+}
 
 impl Syscall for SysGetdentsHandle {
     /// Returns the number of arguments expected by the `getdents` syscall
@@ -23,7 +88,7 @@ impl Syscall for SysGetdentsHandle {
         3
     }
 
-    /// # 获取目录中的数据
+    /// # 获取目录中的数据 (旧格式 linux_dirent)
     ///
     /// ## 参数
     /// - fd 文件描述符号
@@ -33,80 +98,47 @@ impl Syscall for SysGetdentsHandle {
     /// - Ok(ctx.current_pos) 填充缓冲区当前指针位置
     /// - Err(ctx.error.unwrap()) 填充缓冲区时返回的错误
     fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
-        let fd = Self::fd(args);
-        let buf_vaddr = Self::buf(args);
-        let len = Self::len(args);
-        let virt_addr: VirtAddr = VirtAddr::new(buf_vaddr);
-        // 判断缓冲区是否来自用户态，进行权限校验
-        let res = if frame.is_from_user() && verify_area(virt_addr, len).is_err() {
-            // 来自用户态，而buffer在内核态，这样的操作不被允许
-            Err(SystemError::EPERM)
-        } else if buf_vaddr == 0 {
-            Err(SystemError::EFAULT)
-        } else {
-            let buf: &mut [u8] = unsafe {
-                core::slice::from_raw_parts_mut::<'static, u8>(buf_vaddr as *mut u8, len)
-            };
-            if fd < 0 {
-                return Err(SystemError::EBADF);
-            }
-
-            // 获取fd
-            let binding = ProcessManager::current_pcb().fd_table();
-            let fd_table_guard = binding.read();
-            let file = fd_table_guard
-                .get_file_by_fd(fd)
-                .ok_or(SystemError::EBADF)?;
-
-            // drop guard 以避免无法调度的问题
-            drop(fd_table_guard);
-
-            let mut ctx = FilldirContext::new(buf);
-            match file.read_dir(&mut ctx) {
-                Ok(_) => {
-                    if ctx.error.is_some() {
-                        if ctx.error == Some(SystemError::EINVAL) {
-                            return Ok(ctx.current_pos);
-                        } else {
-                            return Err(ctx.error.unwrap());
-                        }
-                    }
-                    return Ok(ctx.current_pos);
-                }
-                Err(e) => {
-                    return Err(e);
-                }
-            }
-        };
-        return res;
+        do_getdents(args, frame, DirentFormat::Getdents)
     }
 
     /// Formats the syscall parameters for display/debug purposes
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("fd", Self::fd(args).to_string()),
-            FormattedSyscallParam::new("buf", format!("{:#x}", Self::buf(args))),
-            FormattedSyscallParam::new("count", Self::len(args).to_string()),
+            FormattedSyscallParam::new("fd", args[0].to_string()),
+            FormattedSyscallParam::new("buf", format!("{:#x}", args[1])),
+            FormattedSyscallParam::new("count", args[2].to_string()),
         ]
     }
 }
 
-impl SysGetdentsHandle {
-    /// Extracts the file descriptor from syscall parameters
-    fn fd(args: &[usize]) -> i32 {
-        args[0] as i32
+impl Syscall for SysGetdents64Handle {
+    /// Returns the number of arguments expected by the `getdents64` syscall
+    fn num_args(&self) -> usize {
+        3
     }
 
-    /// Extracts the buffer pointer from syscall parameters
-    fn buf(args: &[usize]) -> usize {
-        args[1]
+    /// # 获取目录中的数据 (新格式 linux_dirent64)
+    ///
+    /// ## 参数
+    /// - fd 文件描述符号
+    /// - buf 输出缓冲区
+    ///
+    /// ## 返回值
+    /// - Ok(ctx.current_pos) 填充缓冲区当前指针位置
+    /// - Err(ctx.error.unwrap()) 填充缓冲区时返回的错误
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        do_getdents(args, frame, DirentFormat::Getdents64)
     }
 
-    /// Extracts the buffer size from syscall parameters
-    fn len(args: &[usize]) -> usize {
-        args[2]
+    /// Formats the syscall parameters for display/debug purposes
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", args[0].to_string()),
+            FormattedSyscallParam::new("buf", format!("{:#x}", args[1])),
+            FormattedSyscallParam::new("count", args[2].to_string()),
+        ]
     }
 }
 
 syscall_table_macros::declare_syscall!(SYS_GETDENTS, SysGetdentsHandle);
-syscall_table_macros::declare_syscall!(SYS_GETDENTS64, SysGetdentsHandle);
+syscall_table_macros::declare_syscall!(SYS_GETDENTS64, SysGetdents64Handle);

--- a/tools/write_disk_image.sh
+++ b/tools/write_disk_image.sh
@@ -99,6 +99,7 @@ fi
 
 # 拷贝用户程序到磁盘镜像
 mkdir -p ${mount_folder}/bin
+mkdir -p ${mount_folder}/sbin
 mkdir -p ${mount_folder}/dev
 mkdir -p ${mount_folder}/proc
 mkdir -p ${mount_folder}/usr

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -23,6 +23,7 @@ sync_test
 #chown_test
 chdir_test
 fchdir_test
+getdents_test
 
 # 进程相关测试
 fork_test


### PR DESCRIPTION
- 修复目录项缓存逻辑，避免动态目录读取时丢失条目
- 添加O_PATH文件描述符和文件类型检查
- 支持getdents和getdents64两种格式
- 改进用户缓冲区写入安全性和错误处理
- 修复/proc/self/fd目录列表包含"."和".."