### PR TITLE
Revert "fix cputime, sys_rt_sigtimedwait and sys_rt_sigreturn"

### DIFF
--- a/kernel/src/arch/x86_64/asm/entry.S
+++ b/kernel/src/arch/x86_64/asm/entry.S
@@ -407,11 +407,6 @@ ENTRY(syscall_64)
     popq %rax
     addq $0x10, %rsp    // 弹出变量FUNC和errcode
 
-    cmpq (%rsp), %rcx
-    jne .L_syscall_must_use_iret
-    cmpq 0x10(%rsp), %r11
-    jne .L_syscall_must_use_iret
-
     popq %rcx           // pop rip到rcx
 
     addq $0x8, %rsp     // 弹出cs
@@ -420,9 +415,3 @@ ENTRY(syscall_64)
 
     swapgs
     sysretq
-
-// 适用于 sigreturn, ptrace, 或任何修改了上下文的情况
-// 此时栈结构完美符合 iretq 要求: [RIP, CS, RFLAGS, RSP, SS]
-.L_syscall_must_use_iret: 
-    swapgs
-    iretq

--- a/kernel/src/sched/cputime.rs
+++ b/kernel/src/sched/cputime.rs
@@ -88,15 +88,15 @@ impl CpuTimeFunc {
             return;
         }
 
-        let accounted_cputime = cputime - other;
-
         if user_tick {
-            pcb.account_utime(accounted_cputime);
+            pcb.account_utime(cputime);
         } else {
-            pcb.account_stime(accounted_cputime);
+            pcb.account_stime(cputime);
         }
-        pcb.add_sum_exec_runtime(accounted_cputime);
+        pcb.add_sum_exec_runtime(cputime);
 
+        let cputime_ns = TICK_NESC as u64 * ticks;
+        let accounted_cputime = cputime_ns - other;
         // 检查并处理CPU时间定时器
         let mut itimers = pcb.itimers_irqsave();
         // 处理 ITIMER_VIRTUAL (仅在用户态tick时消耗时间)

--- a/user/apps/tests/syscall/gvisor/blocklists/sigreturn_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/sigreturn_test
@@ -1,0 +1,2 @@
+# 还在修复中
+SigIretTest.CheckRcxR11

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -55,7 +55,6 @@ sigaction_test
 sigprocmask_test
 sigaltstack_test
 sigreturn_test
-sigtimedwait_test
 
 # 其他测试
 itimer_test


### PR DESCRIPTION
Reverts DragonOS-Community/DragonOS#1394

由于这个pr的测例 SigtimedwaitTest.SIGKILLUncaught 会卡死，因此撤回。