### PR TITLE
feat(sched): implement POSIX scheduling system calls

### DIFF
--- a/kernel/src/sched/syscall/mod.rs
+++ b/kernel/src/sched/syscall/mod.rs
@@ -1,40 +1,7 @@
-use system_error::SystemError;
-
-use crate::arch::cpu::current_cpu_id;
-use crate::exception::InterruptArch;
-use crate::process::ProcessManager;
-use crate::sched::CurrentIrqArch;
-use crate::sched::Scheduler;
-use crate::syscall::Syscall;
-
-use super::fair::CompletelyFairScheduler;
-use super::{cpu_rq, schedule, SchedMode};
-
 #[cfg(target_arch = "x86_64")]
 mod sys_pause;
 
-impl Syscall {
-    pub fn do_sched_yield() -> Result<usize, SystemError> {
-        // 禁用中断
-        let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-
-        let pcb = ProcessManager::current_pcb();
-        let rq = cpu_rq(pcb.sched_info().on_cpu().unwrap_or(current_cpu_id()).data() as usize);
-        let (rq, guard) = rq.self_lock();
-
-        // TODO: schedstat_inc(rq->yld_count);
-
-        CompletelyFairScheduler::yield_task(rq);
-
-        pcb.preempt_disable();
-
-        drop(guard);
-        drop(irq_guard);
-
-        pcb.preempt_enable(); // sched_preempt_enable_no_resched();
-
-        schedule(SchedMode::SM_NONE);
-
-        Ok(0)
-    }
-}
+mod sys_sched_getparam;
+mod sys_sched_getscheduler;
+mod sys_sched_yield;
+mod util;

--- a/kernel/src/sched/syscall/sys_sched_getparam.rs
+++ b/kernel/src/sched/syscall/sys_sched_getparam.rs
@@ -1,0 +1,163 @@
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_SCHED_GETPARAM;
+use crate::process::ProcessManager;
+use crate::process::RawPid;
+use crate::sched::prio::PrioUtil;
+use crate::sched::prio::MAX_RT_PRIO;
+use crate::sched::SchedPolicy;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferWriter;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+/// Linux sched_param 结构体
+/// 与 musl-libc 中的定义保持一致
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PosixSchedParam {
+    sched_priority: i32,
+    __reserved1: i32,
+    __reserved2: [i64; 4],
+    __reserved3: i32,
+}
+
+/// System call handler for the `sched_getparam` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for getting
+/// scheduling parameters of a process.
+struct SysSchedGetparam;
+
+impl Syscall for SysSchedGetparam {
+    /// Returns the number of arguments expected by the `sched_getparam` syscall
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    /// Handles the `sched_getparam` system call
+    ///
+    /// Gets the scheduling parameters of the specified process.
+    /// If pid is 0, gets the scheduling parameters of the current process.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Process ID (pid_t), 0 for current process
+    ///   - args[1]: Pointer to sched_param structure (*mut SchedParam)
+    /// * `frame` - Trap frame, used to determine if call originates from user space
+    ///
+    /// # Returns
+    /// * `Ok(0)`: Success
+    /// * `Err(SystemError::ESRCH)`: Process not found
+    /// * `Err(SystemError::EFAULT)`: Invalid user space pointer
+    /// * `Err(SystemError::EPERM)`: Permission denied
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pid = Self::pid(args);
+        let param = Self::param(args);
+
+        // 验证用户空间指针
+        if param.is_null() {
+            return Err(SystemError::EFAULT);
+        }
+
+        // 获取目标进程
+        let target_pcb = if pid == 0 {
+            // pid 为 0 表示当前进程
+            ProcessManager::current_pcb()
+        } else {
+            // 查找指定进程
+            let raw_pid = RawPid::from(pid);
+            ProcessManager::find_task_by_vpid(raw_pid).ok_or(SystemError::ESRCH)?
+        };
+
+        // 权限检查：只有进程自己或具有 CAP_SYS_NICE 权限的进程可以查询
+        let current_pcb = ProcessManager::current_pcb();
+        if !super::util::has_sched_permission(&current_pcb, &target_pcb) {
+            return Err(SystemError::EPERM);
+        }
+
+        // 获取调度策略和优先级
+        let policy = *target_pcb.sched_info().sched_policy.read_irqsave();
+        let prio_data = target_pcb.sched_info().prio_data.read_irqsave();
+        let prio = prio_data.prio;
+
+        // 根据调度策略计算 sched_priority
+        // Linux 行为：
+        // - 对于普通进程（SCHED_OTHER/CFS/IDLE），sched_priority 始终为 0
+        // - 对于实时进程（SCHED_FIFO/SCHED_RR），sched_priority 范围是 1-99
+        //   其中 1 是最低优先级，99 是最高优先级
+        // - 内部优先级 prio 范围是 0-99（对于实时进程），其中 0 是最高优先级
+        // - 转换公式：sched_priority = MAX_RT_PRIO (100) - prio
+        //   但需要限制在 1-99 范围内（因为 prio=0 时 sched_priority=100，需要限制为 99）
+        let sched_priority = match policy {
+            SchedPolicy::CFS | SchedPolicy::IDLE => {
+                // 普通进程的 sched_priority 始终为 0
+                0
+            }
+            SchedPolicy::RT | SchedPolicy::FIFO => {
+                // 检查是否为有效的实时优先级
+                // 实时进程的 prio 应该在 0-99 范围内（prio < MAX_RT_PRIO）
+                if !PrioUtil::rt_prio(prio) {
+                    // 如果优先级不在实时范围内，返回 0（表示普通进程）
+                    // 这通常不应该发生，但为了健壮性，我们处理这种情况
+                    0
+                } else {
+                    // 实时优先级转换：sched_priority = MAX_RT_PRIO - prio
+                    // prio = 0（最高）→ sched_priority = 100，限制为 99
+                    // prio = 99（最低）→ sched_priority = 1
+                    let rt_prio = MAX_RT_PRIO - prio;
+                    // 确保结果在 1-99 范围内
+                    rt_prio.clamp(1, 99)
+                }
+            }
+        };
+
+        // 构造 sched_param 结构
+        let sched_param = PosixSchedParam {
+            sched_priority,
+            __reserved1: 0,
+            __reserved2: [0; 4],
+            __reserved3: 0,
+        };
+
+        // 将结果写入用户空间
+        let mut writer = UserBufferWriter::new(
+            param,
+            core::mem::size_of::<PosixSchedParam>(),
+            frame.is_from_user(),
+        )?;
+
+        writer.buffer_protected(0)?.write_one(0, &sched_param)?;
+
+        Ok(0)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pid", Self::pid(args).to_string()),
+            FormattedSyscallParam::new("param", format!("{:#x}", Self::param(args) as usize)),
+        ]
+    }
+}
+
+impl SysSchedGetparam {
+    /// Extracts the process ID from syscall arguments
+    fn pid(args: &[usize]) -> usize {
+        args[0]
+    }
+
+    /// Extracts the sched_param pointer from syscall arguments
+    fn param(args: &[usize]) -> *mut PosixSchedParam {
+        args[1] as *mut PosixSchedParam
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SCHED_GETPARAM, SysSchedGetparam);

--- a/kernel/src/sched/syscall/sys_sched_getscheduler.rs
+++ b/kernel/src/sched/syscall/sys_sched_getscheduler.rs
@@ -1,0 +1,122 @@
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_SCHED_GETSCHEDULER;
+use crate::process::ProcessManager;
+use crate::process::RawPid;
+use crate::sched::SchedPolicy;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+/// Linux 调度策略枚举
+/// 与 musl-libc 和 Linux 内核保持一致
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PosixLinuxSchedPolicy {
+    /// 普通调度策略（对应 CFS）
+    Other = 0,
+    /// 先进先出实时调度
+    Fifo = 1,
+    /// 轮转实时调度
+    Rr = 2,
+    /// 批处理调度（DragonOS 暂不支持）
+    #[allow(dead_code)]
+    Batch = 3,
+    /// IDLE 调度
+    Idle = 5,
+    /// 截止时间调度（DragonOS 暂不支持）
+    #[allow(dead_code)]
+    Deadline = 6,
+}
+
+/// System call handler for the `sched_getscheduler` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for getting
+/// the scheduling policy of a process.
+struct SysSchedGetscheduler;
+
+impl Syscall for SysSchedGetscheduler {
+    /// Returns the number of arguments expected by the `sched_getscheduler` syscall
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    /// Handles the `sched_getscheduler` system call
+    ///
+    /// Gets the scheduling policy of the specified process.
+    /// If pid is 0, gets the scheduling policy of the current process.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Process ID (pid_t), 0 for current process
+    /// * `_frame` - Trap frame (unused in this implementation)
+    ///
+    /// # Returns
+    /// * `Ok(policy)`: Success, returns the scheduling policy value
+    /// * `Err(SystemError::ESRCH)`: Process not found
+    /// * `Err(SystemError::EPERM)`: Permission denied
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pid = Self::pid(args);
+
+        // 获取目标进程
+        let target_pcb = if pid == 0 {
+            // pid 为 0 表示当前进程
+            ProcessManager::current_pcb()
+        } else {
+            // 查找指定进程
+            let raw_pid = RawPid::from(pid);
+            ProcessManager::find_task_by_vpid(raw_pid).ok_or(SystemError::ESRCH)?
+        };
+
+        // 权限检查：只有进程自己或具有 CAP_SYS_NICE 权限的进程可以查询
+        let current_pcb = ProcessManager::current_pcb();
+        if !super::util::has_sched_permission(&current_pcb, &target_pcb) {
+            return Err(SystemError::EPERM);
+        }
+
+        // 获取调度策略
+        let policy = *target_pcb.sched_info().sched_policy.read_irqsave();
+
+        // 将 DragonOS 的 SchedPolicy 映射到 Linux 的调度策略值
+        // Linux 调度策略值：
+        // - SCHED_OTHER = 0 (对应 CFS)
+        // - SCHED_FIFO = 1
+        // - SCHED_RR = 2 (实时轮转调度)
+        // - SCHED_BATCH = 3 (DragonOS 暂不支持)
+        // - SCHED_IDLE = 5
+        // - SCHED_DEADLINE = 6 (DragonOS 暂不支持)
+        let linux_policy = match policy {
+            SchedPolicy::CFS => PosixLinuxSchedPolicy::Other,
+            SchedPolicy::FIFO => PosixLinuxSchedPolicy::Fifo,
+            SchedPolicy::RT => PosixLinuxSchedPolicy::Rr, // RT 策略映射到 SCHED_RR
+            SchedPolicy::IDLE => PosixLinuxSchedPolicy::Idle,
+        };
+
+        Ok(linux_policy as i32 as usize)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "pid",
+            Self::pid(args).to_string(),
+        )]
+    }
+}
+
+impl SysSchedGetscheduler {
+    /// Extracts the process ID from syscall arguments
+    fn pid(args: &[usize]) -> usize {
+        args[0]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SCHED_GETSCHEDULER, SysSchedGetscheduler);

--- a/kernel/src/sched/syscall/sys_sched_yield.rs
+++ b/kernel/src/sched/syscall/sys_sched_yield.rs
@@ -1,0 +1,74 @@
+use system_error::SystemError;
+
+use crate::arch::cpu::current_cpu_id;
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_SCHED_YIELD;
+use crate::exception::InterruptArch;
+use crate::process::ProcessManager;
+use crate::sched::fair::CompletelyFairScheduler;
+use crate::sched::CurrentIrqArch;
+use crate::sched::{cpu_rq, schedule, SchedMode, Scheduler};
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::vec::Vec;
+
+/// System call handler for the `sched_yield` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// voluntarily yielding the CPU to other processes.
+struct SysSchedYield;
+
+impl Syscall for SysSchedYield {
+    /// Returns the number of arguments expected by the `sched_yield` syscall
+    fn num_args(&self) -> usize {
+        0
+    }
+
+    /// Handles the `sched_yield` system call
+    ///
+    /// Voluntarily yields the CPU to other processes. The current process
+    /// will be moved to the end of the run queue for its priority level.
+    ///
+    /// # Arguments
+    /// * `_args` - Array containing no arguments (unused)
+    /// * `_frame` - Trap frame (unused in this implementation)
+    ///
+    /// # Returns
+    /// * `Ok(0)`: Success
+    fn handle(&self, _args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        // 禁用中断
+        let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+
+        let pcb = ProcessManager::current_pcb();
+        let rq = cpu_rq(pcb.sched_info().on_cpu().unwrap_or(current_cpu_id()).data() as usize);
+        let (rq, guard) = rq.self_lock();
+
+        // TODO: schedstat_inc(rq->yld_count);
+
+        CompletelyFairScheduler::yield_task(rq);
+
+        pcb.preempt_disable();
+
+        drop(guard);
+        drop(irq_guard);
+
+        pcb.preempt_enable(); // sched_preempt_enable_no_resched();
+
+        schedule(SchedMode::SM_NONE);
+
+        Ok(0)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `_args` - The raw syscall arguments (unused, as sched_yield takes no arguments)
+    ///
+    /// # Returns
+    /// Empty vector (sched_yield takes no arguments)
+    fn entry_format(&self, _args: &[usize]) -> Vec<FormattedSyscallParam> {
+        Vec::new()
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SCHED_YIELD, SysSchedYield);

--- a/kernel/src/sched/syscall/util.rs
+++ b/kernel/src/sched/syscall/util.rs
@@ -1,0 +1,36 @@
+/// 调度系统调用相关的工具函数
+use crate::process::ProcessControlBlock;
+
+/// 检查当前进程是否有权限查询目标进程的调度信息
+///
+/// 权限规则（与 Linux 一致）：
+/// - 进程自己可以查询
+/// - 具有 CAP_SYS_NICE 权限的进程可以查询
+/// - root 用户（uid == 0）可以查询
+///
+/// # Arguments
+/// * `current_pcb` - 当前进程的 PCB
+/// * `target_pcb` - 目标进程的 PCB
+///
+/// # Returns
+/// * `true` - 有权限
+/// * `false` - 无权限
+pub fn has_sched_permission(
+    current_pcb: &ProcessControlBlock,
+    target_pcb: &ProcessControlBlock,
+) -> bool {
+    // 进程自己
+    if current_pcb.raw_pid() == target_pcb.raw_pid() {
+        return true;
+    }
+
+    let current_cred = current_pcb.cred();
+
+    // 具有 CAP_SYS_NICE 权限
+    if current_cred.has_capability(crate::process::cred::CAPFlags::CAP_SYS_NICE) {
+        return true;
+    }
+
+    // root 用户（uid == 0）
+    current_cred.uid.data() == 0
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -342,8 +342,6 @@ impl Syscall {
                 Err(SystemError::ENOSYS)
             }
 
-            SYS_SCHED_YIELD => Self::do_sched_yield(),
-
             SYS_FADVISE64 => {
                 // todo: 这个系统调用还没有实现
 


### PR DESCRIPTION
- Add sched_getparam syscall to retrieve process scheduling parameters
- Add sched_getscheduler syscall to get process scheduling policy
- Refactor sched_yield into separate module with proper syscall handler
- Add utility functions for scheduling permission checks
- Remove old do_sched_yield implementation from main syscall module