### PR TITLE
feat(PS1): use colorful PS1 to better locate the command line position

### DIFF
--- a/user/sysconfig/etc/profile
+++ b/user/sysconfig/etc/profile
@@ -1,3 +1,7 @@
 #!/bin/sh
 export PATH=/bin:/usr/bin:/usr/local/bin
+# 设置 PS1 环境变量，定义彩色命令行提示符
+# \\e[32m 设置绿色，\\e[34m 设置蓝色，\\e[0m 重置颜色，不可见字符必须用 \[ ... \] 包裹
+# \\u 用户名，\\h 主机名，\\w 当前工作目录
+export PS1='\[\e[32m\]\u\[\e[0m\]@\h:\[\e[34m\]\w\[\e[0m\]\$ '
 trap ' ' INT


### PR DESCRIPTION
- 添加 PS1 环境变量，实现更美观的sh并且可以更好地定位之前键入的命令行的位置。（大量输出时尤为重要）

```sh
# user/sysconfig/etc/profile
# 设置 PS1 环境变量，定义彩色命令行提示符
# \e[32m 设置绿色，\e[34m 设置蓝色，\e[0m 重置颜色，不可见字符必须用 \[ ... \] 包裹
# \u 用户名，\h 主机名，\w 当前工作目录
export PS1='\[\e[32m\]\u\[\e[0m\]@\h:\[\e[34m\]\w\[\e[0m\]\$ '
```

<img width="1188" height="1421" alt="image" src="https://github.com/user-attachments/assets/9eab173f-b815-432c-a8ef-2adc7be8ddb7" />
