### PR TITLE
feat(tty): 为TTY设备添加page_cache方法并处理无页面缓存的情况

### DIFF
--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -408,6 +408,11 @@ impl IndexNode for TtyDevice {
         Ok(())
     }
 
+    fn page_cache(&self) -> Option<Arc<crate::filesystem::page_cache::PageCache>> {
+        // TTY设备是字符设备，不需要页面缓存
+        None
+    }
+
     fn close(&self, data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
         let (tty, _flags) = if let FilePrivateData::Tty(tty_priv) = &*data {
             (tty_priv.tty(), tty_priv.flags)


### PR DESCRIPTION
- 在TTY设备中实现page_cache方法，返回None以表明字符设备不需要页面缓存
- 在页面错误处理中增加对无页面缓存情况的处理，避免panic并返回VM_FAULT_SIGBUS