### PR TITLE
feat(filesystem): Enhance pwrite and pwritev syscall validation

### DIFF
--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -639,6 +639,8 @@ impl File {
         let md = self.inode.metadata()?;
         let file_type = md.file_type;
 
+        // 按 Linux 语义，带 O_APPEND 的文件写入（包括 pwrite）都会强制在文件末尾进行，
+        // 但偏移有效性检查仍在更上层进行。
         let actual_offset =
             if flags.contains(FileFlags::O_APPEND) && matches!(file_type, FileType::File) {
                 md.size as usize

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -29,6 +29,7 @@ pread64_test
 rename_test
 getdents_test
 preadv_test
+pwrite64_test
 utimes_test
 fadvise_test
 


### PR DESCRIPTION
- Added validation for pwrite and pwritev syscalls to ensure offset and length conform to Linux semantics, returning EINVAL for negative offsets and invalid ranges.
- Updated offset extraction in sys_pwrite64 and sys_pwritev to use i64 for better compatibility.
- Included a new test case for pwrite64 in the gvisor whitelist to ensure proper functionality.

This change improves the robustness of file writing operations in the VFS layer.