### PR TITLE
feat(block_cache): Enhance CacheBlock and BlockCache functionality

### DIFF
--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -84,10 +84,7 @@ impl InnerPageCache {
 
             let page = page_manager_guard.create_one_page(
                 PageType::File(FileMapInfo {
-                    page_cache: self
-                        .page_cache_ref
-                        .upgrade()
-                        .expect("failed to get self_arc of pagecache"),
+                    page_cache: self.page_cache_ref.clone(),
                     index: page_index,
                 }),
                 PageFlags::PG_LRU,


### PR DESCRIPTION
- Added `from_slice` method to `CacheBlock` for creating instances directly from slices, avoiding unnecessary allocations.
- Introduced `write_data` method in `CacheBlock` to allow in-place updates of block data.
- Updated `insert_one_block` and `immediate_write` methods in `BlockCache` to accept slices instead of vectors, improving performance and memory usage.
- Implemented error handling for block size validation in multiple locations to ensure data integrity.
- Change `FileMapInfo::page_cache` to `Weak<PageCache>` to fix a memory leak caused by reference cycles.