### PR TITLE
ci: Update nightly build workflow with new environment variables

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   ARCH: x86_64
+  HOME: /root
+  RUSTUP_DIST_SERVER: "https://rsproxy.cn"
+  RUSTUP_UPDATE_ROOT: "https://rsproxy.cn/rustup"
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
- Added HOME, RUSTUP_DIST_SERVER, and RUSTUP_UPDATE_ROOT environment variables to the nightly build workflow to enhance Rust toolchain management and configuration.