### PR TITLE
ci: Refactor nightly build workflow to separate build and publish steps

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -13,17 +13,13 @@ env:
   RUSTUP_UPDATE_ROOT: "https://rsproxy.cn/rustup"
 
 jobs:
-  build-and-publish:
-    name: Build DragonOS and Publish Artifacts
+  build:
+    name: Build DragonOS
     runs-on: ubuntu-latest
     timeout-minutes: 120
     container:
       image: dragonos/dragonos-dev:v1.19
       options: --privileged -v /dev:/dev
-    services:
-      docker:
-        image: docker:dind
-        options: --privileged
     steps:
       - name: Checkout DragonOS code
         uses: actions/checkout@v4
@@ -52,12 +48,41 @@ jobs:
           echo "构建产物验证成功"
           ls -lh bin/kernel/kernel.elf bin/disk-image-x86_64.img
 
+      - name: Compress build artifacts
+        shell: bash -ileo pipefail {0}
+        run: |
+          cd bin
+          tar -czf dragonos-artifacts.tar.gz kernel/kernel.elf disk-image-x86_64.img
+          ls -lh dragonos-artifacts.tar.gz
+          echo "压缩完成，压缩包大小:"
+          du -h dragonos-artifacts.tar.gz
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: bin/dragonos-artifacts.tar.gz
+          retention-days: 1
+
+  publish:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout DragonOS code
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: bin/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Generate image tag
         id: image-tag
-        shell: bash -ileo pipefail {0}
         run: |
           DATE_TAG=$(date +%Y%m%d)
           COMMIT_SHORT=$(git rev-parse --short HEAD)

--- a/tools/Dockerfile.artifacts
+++ b/tools/Dockerfile.artifacts
@@ -3,13 +3,12 @@
 
 FROM scratch
 
-# 复制构建产物到镜像中
-COPY bin/kernel/kernel.elf /artifacts/kernel.elf
-COPY bin/disk-image-x86_64.img /artifacts/disk-image-x86_64.img
+# 复制压缩的构建产物到镜像中
+COPY bin/dragonos-artifacts.tar.gz /artifacts/dragonos-artifacts.tar.gz
 
 # 添加元数据标签
 LABEL org.opencontainers.image.title="DragonOS Build Artifacts"
-LABEL org.opencontainers.image.description="DragonOS nightly build artifacts: kernel.elf and disk-image-x86_64.img"
+LABEL org.opencontainers.image.description="DragonOS nightly build artifacts: compressed archive containing kernel.elf and disk-image-x86_64.img"
 LABEL org.opencontainers.image.source="https://github.com/DragonOS-Community/DragonOS"
 
 # 设置工作目录（虽然 scratch 镜像没有 shell，但保留这个信息用于文档）


### PR DESCRIPTION
- Updated the nightly build workflow to include distinct build and publish jobs.
- Added steps to compress build artifacts into a tarball and upload them for later use.
- Modified the Dockerfile to copy the compressed artifacts instead of individual files, enhancing efficiency and organization.