### PR TITLE
ci: Update nightly build workflow to prepare directory for artifacts

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -69,8 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout DragonOS code
-        uses: actions/checkout@v4
+      - name: Prepare directory
+        run: |
+          mkdir -p bin
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
- Added a step to create a 'bin' directory in the nightly build workflow to organize build artifacts more effectively.