### PR TITLE
ci: Add checkout step in nightly build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -72,6 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Checkout DragonOS code
+        uses: actions/checkout@v4
+
       - name: Prepare directory
         run: |
           mkdir -p bin


### PR DESCRIPTION
- Introduced a step to checkout the DragonOS code in the nightly build workflow, ensuring the latest code is available for the build process.