### PR TITLE
refactor(vfs): 统一使用vfs_check_and_clone_cstr函数进行路径检查

### DIFF
--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -153,10 +153,7 @@ impl InnerPageCache {
 
             let page = page_manager_guard.create_one_page(
                 PageType::File(FileMapInfo {
-                    page_cache: self
-                        .page_cache_ref
-                        .upgrade()
-                        .expect("failed to get self_arc of pagecache"),
+                    page_cache: self.page_cache_ref.clone(),
                     index: page_index,
                 }),
                 page_flags,

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -15,7 +15,7 @@ use crate::{
     process::cred::GroupInfo,
     time::{syscall::PosixTimeval, PosixTimeSpec},
 };
-use crate::{process::ProcessManager, syscall::user_access::check_and_clone_cstr};
+use crate::{process::ProcessManager, syscall::user_access::vfs_check_and_clone_cstr};
 use alloc::string::String;
 
 pub(super) fn do_faccessat(
@@ -38,7 +38,7 @@ pub(super) fn do_faccessat(
 
     // let follow_symlink = flags & AtFlags::AT_SYMLINK_NOFOLLOW.bits() as u32 == 0;
 
-    let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
+    let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
     let path = path.to_str().map_err(|_| SystemError::EINVAL)?;
     // log::debug!("do_faccessat path: {:?}", path);
 
@@ -52,7 +52,7 @@ pub(super) fn do_faccessat(
 }
 
 pub fn do_fchmodat(dirfd: i32, path: *const u8, mode: InodeMode) -> Result<usize, SystemError> {
-    let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
+    let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
     let path = path.to_str().map_err(|_| SystemError::EINVAL)?;
 
     let (inode, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -1,4 +1,4 @@
-use crate::{syscall::user_access::check_and_clone_cstr, time::PosixTimeSpec};
+use crate::time::PosixTimeSpec;
 
 use super::{fcntl::AtFlags, file::FileFlags, InodeMode, SuperBlock};
 mod dup2;

--- a/kernel/src/filesystem/vfs/syscall/rename_utils.rs
+++ b/kernel/src/filesystem/vfs/syscall/rename_utils.rs
@@ -6,7 +6,7 @@ use crate::filesystem::vfs::SystemError;
 use crate::filesystem::vfs::VFS_MAX_FOLLOW_SYMLINK_TIMES;
 use crate::filesystem::vfs::{MAX_PATHLEN, NAME_MAX};
 use crate::process::ProcessManager;
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 /// # 修改文件名
 ///
 ///
@@ -31,18 +31,12 @@ pub fn do_renameat2(
     filename_to: *const u8,
     flags: u32,
 ) -> Result<usize, SystemError> {
-    let filename_from = check_and_clone_cstr(filename_from, Some(MAX_PATHLEN))
-        .unwrap()
+    let filename_from = vfs_check_and_clone_cstr(filename_from, Some(MAX_PATHLEN))?
         .into_string()
         .map_err(|_| SystemError::EINVAL)?;
-    let filename_to = check_and_clone_cstr(filename_to, Some(MAX_PATHLEN))
-        .unwrap()
+    let filename_to = vfs_check_and_clone_cstr(filename_to, Some(MAX_PATHLEN))?
         .into_string()
         .map_err(|_| SystemError::EINVAL)?;
-    // 文件名过长
-    if filename_from.len() > MAX_PATHLEN || filename_to.len() > MAX_PATHLEN {
-        return Err(SystemError::ENAMETOOLONG);
-    }
 
     if filename_from == "/" || filename_to == "/" {
         return Err(SystemError::EBUSY);

--- a/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
@@ -11,7 +11,7 @@ use crate::filesystem::vfs::{fcntl::AtFlags, FileType, MAX_PATHLEN, VFS_MAX_FOLL
 use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 
 /// System call handler for the `chdir` syscall
 ///
@@ -53,7 +53,7 @@ impl Syscall for SysChdirHandle {
             return Err(SystemError::EFAULT);
         }
 
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         let path = path.trim();

--- a/kernel/src/filesystem/vfs/syscall/sys_chown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chown.rs
@@ -22,7 +22,7 @@ impl Syscall for SyschownHandle {
         let uid = Self::uid(args);
         let gid = Self::gid(args);
 
-        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+        let pathname = user_access::vfs_check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         return do_fchownat(

--- a/kernel/src/filesystem/vfs/syscall/sys_chroot.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chroot.rs
@@ -18,7 +18,7 @@ use crate::filesystem::vfs::{
 use crate::process::cred::CAPFlags;
 use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 
 pub struct SysChrootHandle;
 
@@ -33,7 +33,7 @@ impl Syscall for SysChrootHandle {
             return Err(SystemError::EFAULT);
         }
 
-        let path = check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?
+        let path = vfs_check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         let path = path.trim();

--- a/kernel/src/filesystem/vfs/syscall/sys_fchownat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchownat.rs
@@ -25,7 +25,7 @@ impl Syscall for SysFchownatHandle {
         let gid = Self::gid(args);
         let flags = Self::flags(args);
 
-        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+        let pathname = user_access::vfs_check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         let pathname = pathname.as_str().trim();

--- a/kernel/src/filesystem/vfs/syscall/sys_lchown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_lchown.rs
@@ -22,7 +22,7 @@ impl Syscall for SysLchownHandle {
         let uid = Self::uid(args);
         let gid = Self::gid(args);
 
-        let pathname = user_access::check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+        let pathname = user_access::vfs_check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         return do_fchownat(

--- a/kernel/src/filesystem/vfs/syscall/sys_link.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_link.rs
@@ -5,7 +5,7 @@ use crate::arch::syscall::nr::SYS_LINK;
 use crate::filesystem::vfs::syscall::AtFlags;
 use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::string::String;
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -24,7 +24,7 @@ impl Syscall for SysLinkHandle {
         let new = Self::new_path(args);
 
         let get_path = |cstr: *const u8| -> Result<String, SystemError> {
-            let res = check_and_clone_cstr(cstr, Some(MAX_PATHLEN))?
+            let res = vfs_check_and_clone_cstr(cstr, Some(MAX_PATHLEN))?
                 .into_string()
                 .map_err(|_| SystemError::EINVAL)?;
             if res.len() >= MAX_PATHLEN {

--- a/kernel/src/filesystem/vfs/syscall/sys_linkat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_linkat.rs
@@ -5,7 +5,7 @@ use crate::arch::syscall::nr::SYS_LINKAT;
 use crate::filesystem::vfs::syscall::AtFlags;
 use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -25,10 +25,10 @@ impl Syscall for SysLinkAtHandle {
         let new = Self::new_path(args);
         let flags = Self::flags(args);
 
-        let old = check_and_clone_cstr(old, Some(MAX_PATHLEN))?
+        let old = vfs_check_and_clone_cstr(old, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
-        let new = check_and_clone_cstr(new, Some(MAX_PATHLEN))?
+        let new = vfs_check_and_clone_cstr(new, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         if old.len() >= MAX_PATHLEN || new.len() >= MAX_PATHLEN {

--- a/kernel/src/filesystem/vfs/syscall/sys_mkdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mkdir.rs
@@ -5,6 +5,7 @@ use crate::filesystem::vfs::vcore::do_mkdir_at;
 use crate::filesystem::vfs::InodeMode;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -25,12 +26,9 @@ impl Syscall for SysMkdirHandle {
         let path = Self::path(args);
         let mode = Self::mode(args);
 
-        let path = crate::filesystem::vfs::syscall::check_and_clone_cstr(
-            path,
-            Some(crate::filesystem::vfs::MAX_PATHLEN),
-        )?
-        .into_string()
-        .map_err(|_| SystemError::EINVAL)?;
+        let path = vfs_check_and_clone_cstr(path, Some(crate::filesystem::vfs::MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
 
         do_mkdir_at(
             AtFlags::AT_FDCWD.bits(),

--- a/kernel/src/filesystem/vfs/syscall/sys_mkdirat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mkdirat.rs
@@ -5,6 +5,7 @@ use crate::arch::syscall::nr::SYS_MKDIRAT;
 use crate::filesystem::vfs::vcore::do_mkdir_at;
 use crate::filesystem::vfs::InodeMode;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -22,12 +23,9 @@ impl Syscall for SysMkdirAtHandle {
         let path = Self::path(args);
         let mode = Self::mode(args);
 
-        let path = crate::filesystem::vfs::syscall::check_and_clone_cstr(
-            path,
-            Some(crate::filesystem::vfs::MAX_PATHLEN),
-        )?
-        .into_string()
-        .map_err(|_| SystemError::EINVAL)?;
+        let path = vfs_check_and_clone_cstr(path, Some(crate::filesystem::vfs::MAX_PATHLEN))?
+            .into_string()
+            .map_err(|_| SystemError::EINVAL)?;
         do_mkdir_at(dirfd, &path, InodeMode::from_bits_truncate(mode as u32))?;
         Ok(0)
     }

--- a/kernel/src/filesystem/vfs/syscall/sys_mknod.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mknod.rs
@@ -12,7 +12,7 @@ use crate::{
     process::ProcessManager,
     syscall::{
         table::{FormattedSyscallParam, Syscall},
-        user_access::check_and_clone_cstr,
+        user_access::vfs_check_and_clone_cstr,
     },
 };
 use alloc::sync::Arc;
@@ -34,7 +34,7 @@ impl Syscall for SysMknodHandle {
         let flags: InodeMode = InodeMode::from_bits_truncate(flags as u32);
         let dev_t = DeviceNumber::from(dev_t as u32);
 
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         let path = path.as_str().trim();

--- a/kernel/src/filesystem/vfs/syscall/sys_mknodat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mknodat.rs
@@ -14,7 +14,7 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 
 pub struct SysMknodatHandle;
 
@@ -30,7 +30,7 @@ impl Syscall for SysMknodatHandle {
         let path = Self::path(args);
         let mode_val = Self::mode(args);
         let dev = DeviceNumber::from(Self::dev(args));
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
 

--- a/kernel/src/filesystem/vfs/syscall/sys_newfstatat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_newfstatat.rs
@@ -6,7 +6,7 @@ use crate::{
     filesystem::vfs::{stat::do_newfstatat, MAX_PATHLEN},
     syscall::{
         table::{FormattedSyscallParam, Syscall},
-        user_access::check_and_clone_cstr,
+        user_access::vfs_check_and_clone_cstr,
     },
 };
 use alloc::vec::Vec;
@@ -67,7 +67,7 @@ impl SysNewFstatatHandle {
             return Err(SystemError::EFAULT);
         }
 
-        let filename = check_and_clone_cstr(filename_ptr as *const u8, Some(MAX_PATHLEN))?;
+        let filename = vfs_check_and_clone_cstr(filename_ptr as *const u8, Some(MAX_PATHLEN))?;
         let filename_str = filename.to_str().map_err(|_| SystemError::EINVAL)?;
 
         do_newfstatat(dfd, filename_str, user_stat_buf_ptr, flags).map(|_| 0)

--- a/kernel/src/filesystem/vfs/syscall/sys_rmdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_rmdir.rs
@@ -6,7 +6,7 @@ use crate::filesystem::vfs::syscall::AtFlags;
 use crate::filesystem::vfs::vcore::do_remove_dir;
 use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -21,7 +21,7 @@ impl Syscall for SysRmdirHandle {
     /// Handles the rmdir syscall.
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let path = Self::path(args);
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         return do_remove_dir(AtFlags::AT_FDCWD.bits(), &path).map(|v| v as usize);

--- a/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
@@ -9,7 +9,7 @@ use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use crate::syscall::user_access::UserBufferWriter;
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -26,7 +26,7 @@ impl Syscall for SysStatfsHandle {
         let user_statfs = Self::statfs(args);
         let mut writer = UserBufferWriter::new(user_statfs, size_of::<PosixStatfs>(), true)?;
         let fd = open_utils::do_open(path, FileFlags::O_RDONLY.bits(), InodeMode::empty().bits())?;
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))
             .unwrap()
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;

--- a/kernel/src/filesystem/vfs/syscall/sys_statx.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statx.rs
@@ -4,7 +4,7 @@ use crate::filesystem::vfs::stat::do_statx;
 use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -51,7 +51,7 @@ impl SysStatxHandle {
             return Err(SystemError::EFAULT);
         }
 
-        let filename = check_and_clone_cstr(filename_ptr as *const u8, Some(MAX_PATHLEN))?;
+        let filename = vfs_check_and_clone_cstr(filename_ptr as *const u8, Some(MAX_PATHLEN))?;
         let filename_str = filename.to_str().map_err(|_| SystemError::EINVAL)?;
 
         do_statx(dfd, filename_str, flags, mask, user_kstat_ptr).map(|_| 0)

--- a/kernel/src/filesystem/vfs/syscall/sys_symlinkat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_symlinkat.rs
@@ -5,7 +5,7 @@ use crate::{
     filesystem::vfs::MAX_PATHLEN,
     syscall::{
         table::{FormattedSyscallParam, Syscall},
-        user_access::check_and_clone_cstr,
+        user_access::vfs_check_and_clone_cstr,
     },
 };
 use alloc::string::{String, ToString};
@@ -22,8 +22,8 @@ impl Syscall for SysSymlinkAtHandle {
     }
 
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
-        let from = Self::from(args);
-        let to = Self::to(args);
+        let from = Self::from(args)?;
+        let to = Self::to(args)?;
         let newdfd = Self::newdfd(args);
 
         do_symlinkat(from.as_str(), Some(newdfd), to.as_str())
@@ -31,36 +31,36 @@ impl Syscall for SysSymlinkAtHandle {
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("from", Self::from(args)),
+            FormattedSyscallParam::new(
+                "from",
+                Self::from(args).unwrap_or_else(|_| "<invalid>".to_string()),
+            ),
             FormattedSyscallParam::new("newdfd", Self::newdfd(args).to_string()),
-            FormattedSyscallParam::new("to", Self::to(args)),
+            FormattedSyscallParam::new(
+                "to",
+                Self::to(args).unwrap_or_else(|_| "<invalid>".to_string()),
+            ),
         ]
     }
 }
 
 impl SysSymlinkAtHandle {
-    fn from(args: &[usize]) -> String {
-        check_and_clone_cstr(args[0] as *const u8, Some(MAX_PATHLEN))
-            .unwrap()
+    fn from(args: &[usize]) -> Result<String, SystemError> {
+        let s = vfs_check_and_clone_cstr(args[0] as *const u8, Some(MAX_PATHLEN))?
             .into_string()
-            .map_err(|_| SystemError::EINVAL)
-            .unwrap()
-            .trim()
-            .to_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        Ok(s.trim().to_string())
     }
 
     fn newdfd(args: &[usize]) -> i32 {
         args[1] as i32
     }
 
-    fn to(args: &[usize]) -> String {
-        check_and_clone_cstr(args[2] as *const u8, Some(MAX_PATHLEN))
-            .unwrap()
+    fn to(args: &[usize]) -> Result<String, SystemError> {
+        let s = vfs_check_and_clone_cstr(args[2] as *const u8, Some(MAX_PATHLEN))?
             .into_string()
-            .map_err(|_| SystemError::EINVAL)
-            .unwrap()
-            .trim()
-            .to_string()
+            .map_err(|_| SystemError::EINVAL)?;
+        Ok(s.trim().to_string())
     }
 }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_truncate.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_truncate.rs
@@ -9,7 +9,7 @@ use crate::{
     process::{resource::RLimitID, ProcessManager},
     syscall::{
         table::{FormattedSyscallParam, Syscall},
-        user_access::check_and_clone_cstr,
+        user_access::vfs_check_and_clone_cstr,
     },
 };
 
@@ -37,7 +37,7 @@ impl Syscall for SysTruncateHandle {
         let path_ptr = args[0] as *const u8;
         let length = Self::len(args)?;
         // 复制并校验用户态路径
-        let path = check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?;
+        let path = vfs_check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?;
         let path = path.to_str().map_err(|_| SystemError::EINVAL)?;
 
         // 解析起始 inode 与剩余路径

--- a/kernel/src/filesystem/vfs/syscall/sys_umount2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_umount2.rs
@@ -26,7 +26,7 @@ impl Syscall for SysUmount2Handle {
         let target = Self::target(args);
         let flags = Self::flags(args);
 
-        let target = user_access::check_and_clone_cstr(target, Some(MAX_PATHLEN))?
+        let target = user_access::vfs_check_and_clone_cstr(target, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         do_umount2(

--- a/kernel/src/filesystem/vfs/syscall/sys_unlink.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_unlink.rs
@@ -6,7 +6,7 @@ use crate::filesystem::vfs::syscall::AtFlags;
 use crate::filesystem::vfs::vcore::do_unlink_at;
 use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -21,7 +21,7 @@ impl Syscall for SysUnlinkHandle {
     /// Handles the unlink syscall.
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let path = Self::path(args);
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         return do_unlink_at(AtFlags::AT_FDCWD.bits(), &path).map(|v| v as usize);

--- a/kernel/src/filesystem/vfs/syscall/sys_unlinkat.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_unlinkat.rs
@@ -8,7 +8,7 @@ use crate::filesystem::vfs::fcntl::AtFlags;
 use crate::filesystem::vfs::vcore::{do_remove_dir, do_unlink_at};
 use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use alloc::vec::Vec;
 
 pub struct SysUnlinkAtHandle;
@@ -34,7 +34,7 @@ impl Syscall for SysUnlinkAtHandle {
         let flags = Self::flags(args);
 
         let flags = AtFlags::from_bits(flags as i32).ok_or(SystemError::EINVAL)?;
-        let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
 

--- a/kernel/src/filesystem/vfs/syscall/sys_utimes.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_utimes.rs
@@ -6,7 +6,7 @@ use crate::filesystem::vfs::open::do_utimes;
 use crate::filesystem::vfs::MAX_PATHLEN;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::vfs_check_and_clone_cstr;
 use crate::syscall::user_access::UserBufferReader;
 use crate::time::syscall::PosixTimeval;
 use alloc::vec::Vec;
@@ -22,7 +22,7 @@ impl Syscall for SysUtimesHandle {
         let pathname = Self::pathname(args);
         let times = Self::times(args);
 
-        let pathname = check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
+        let pathname = vfs_check_and_clone_cstr(pathname, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         let times = if times.is_null() {

--- a/kernel/src/filesystem/vfs/syscall/xattr_utils.rs
+++ b/kernel/src/filesystem/vfs/syscall/xattr_utils.rs
@@ -2,7 +2,9 @@ use super::{XATTR_CREATE, XATTR_REPLACE};
 use crate::{
     filesystem::vfs::{syscall::AtFlags, utils::user_path_at, IndexNode, MAX_PATHLEN},
     process::ProcessManager,
-    syscall::user_access::{check_and_clone_cstr, UserBufferReader, UserBufferWriter},
+    syscall::user_access::{
+        check_and_clone_cstr, vfs_check_and_clone_cstr, UserBufferReader, UserBufferWriter,
+    },
 };
 use alloc::{sync::Arc, vec::Vec};
 use system_error::SystemError;
@@ -15,7 +17,7 @@ pub(super) fn path_getxattr(
     size: usize,
     lookup_flags: usize,
 ) -> Result<usize, SystemError> {
-    let path = check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?
+    let path = vfs_check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?
         .into_string()
         .map_err(|_| SystemError::EINVAL)?;
 
@@ -79,7 +81,7 @@ pub(super) fn path_setxattr(
     lookup_flags: usize,
     flags: i32,
 ) -> Result<usize, SystemError> {
-    let path = check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?
+    let path = vfs_check_and_clone_cstr(path_ptr, Some(MAX_PATHLEN))?
         .into_string()
         .map_err(|_| SystemError::EINVAL)?;
 

--- a/kernel/src/process/syscall/sys_execve.rs
+++ b/kernel/src/process/syscall/sys_execve.rs
@@ -11,7 +11,7 @@ use crate::mm::{verify_area, VirtAddr};
 use crate::process::execve::do_execve;
 use crate::process::{ProcessControlBlock, ProcessManager};
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::{check_and_clone_cstr, check_and_clone_cstr_array};
+use crate::syscall::user_access::{check_and_clone_cstr_array, vfs_check_and_clone_cstr};
 use alloc::{ffi::CString, vec::Vec};
 use log::error;
 use system_error::SystemError;
@@ -60,7 +60,7 @@ impl SysExecve {
         argv: *const *const u8,
         envp: *const *const u8,
     ) -> Result<(CString, Vec<CString>, Vec<CString>), SystemError> {
-        let path: CString = check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
+        let path: CString = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?;
         let mut argv: Vec<CString> = check_and_clone_cstr_array(argv)?;
         let envp: Vec<CString> = check_and_clone_cstr_array(envp)?;
 


### PR DESCRIPTION
- 将多个VFS系统调用中的check_and_clone_cstr替换为vfs_check_and_clone_cstr
- 在page_cache.rs中简化page_cache引用获取方式
- 在sys_mount.rs中新增copy_mount_path_string函数专门处理挂载路径
- 移除rename_utils.rs中冗余的路径长度检查