### PR TITLE
feat(procfs): 添加 /proc/cmdline 和 /proc/<pid>/cmdline 文件支持

### DIFF
--- a/kernel/src/filesystem/procfs/proc_pid_cmdline.rs
+++ b/kernel/src/filesystem/procfs/proc_pid_cmdline.rs
@@ -1,0 +1,42 @@
+use alloc::string::ToString;
+use system_error::SystemError;
+
+use crate::{init::boot_params, process::ProcessManager};
+
+use super::{ProcFSInode, ProcfsFilePrivateData};
+
+impl ProcFSInode {
+    /// /proc/cmdline
+    ///
+    /// Linux 语义：输出启动时的 kernel command line，末尾带 '\n'。
+    #[inline(never)]
+    pub(super) fn open_cmdline(
+        &self,
+        pdata: &mut ProcfsFilePrivateData,
+    ) -> Result<i64, SystemError> {
+        let cmdline = boot_params().read().boot_cmdline_str().to_string();
+        pdata.data = cmdline.into_bytes();
+        if !pdata.data.ends_with(b"\n") {
+            pdata.data.push(b'\n');
+        }
+        Ok(pdata.data.len() as i64)
+    }
+
+    /// /proc/<pid>/cmdline（也覆盖 /proc/self/cmdline）
+    ///
+    /// Linux 语义：以 '\0' 分隔 argv，通常末尾带一个额外的 '\0'。
+    #[inline(never)]
+    pub(super) fn open_pid_cmdline(
+        &self,
+        pdata: &mut ProcfsFilePrivateData,
+    ) -> Result<i64, SystemError> {
+        let pid = self
+            .fdata
+            .pid
+            .expect("ProcFS: pid is None when opening 'cmdline' file.");
+        let pcb = ProcessManager::find_task_by_vpid(pid).ok_or(SystemError::ESRCH)?;
+
+        pdata.data = pcb.cmdline_bytes();
+        Ok(pdata.data.len() as i64)
+    }
+}

--- a/kernel/src/filesystem/procfs/procfs_setup.rs
+++ b/kernel/src/filesystem/procfs/procfs_setup.rs
@@ -10,6 +10,7 @@ impl ProcFS {
         self.create_kmsg_file();
         self.create_version_signature_file();
         self.create_mounts_file();
+        self.create_cmdline_file();
         self.create_version_file();
         self.create_cpuinfo_file();
         self.create_self_file();
@@ -84,6 +85,21 @@ impl ProcFS {
             .unwrap();
         self.create_proc_file(mounts_params)
             .unwrap_or_else(|_| panic!("create mounts error"));
+    }
+
+    /// @brief 创建 /proc/cmdline 文件
+    #[inline(never)]
+    fn create_cmdline_file(&self) {
+        let cmdline_params = ProcFileCreationParams::builder()
+            .parent(self.root_inode())
+            .name("cmdline")
+            .file_type(FileType::File)
+            .mode(InodeMode::from_bits_truncate(0o444))
+            .ftype(ProcFileType::ProcCmdline)
+            .build()
+            .unwrap();
+        self.create_proc_file(cmdline_params)
+            .unwrap_or_else(|_| panic!("create cmdline error"));
     }
 
     /// @brief 创建 /proc/version 文件

--- a/kernel/src/init/initial_kthread.rs
+++ b/kernel/src/init/initial_kthread.rs
@@ -213,12 +213,14 @@ fn run_init_process(
 
     let pwd = ProcessManager::current_pcb().pwd_inode();
     let inode = pwd.lookup_follow_symlink(path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+
     do_execve(
         inode,
         proc_init_info.args.clone(),
         proc_init_info.envs.clone(),
         trap_frame,
     )?;
-
+    // 初始化阶段直接调用 do_execve（绕过 sys_execve），因此这里补齐 cmdline 存储
+    ProcessManager::current_pcb().set_cmdline_from_argv(&proc_init_info.args);
     Ok(())
 }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -569,6 +569,9 @@ impl ProcessManager {
         // 这样才能正确支持通过/proc/self/exe重新执行程序
         pcb.set_execute_path(current_pcb.execute_path());
 
+        // 继承 cmdline（/proc/<pid>/cmdline 语义）
+        pcb.set_cmdline_bytes(current_pcb.cmdline_bytes());
+
         // alloc_pid
         if pcb.raw_pid() == RawPid::UNASSIGNED {
             // 分层PID分配：在父进程的子PID namespace中为新任务分配PID

--- a/kernel/src/process/syscall/sys_execve.rs
+++ b/kernel/src/process/syscall/sys_execve.rs
@@ -90,6 +90,8 @@ impl SysExecve {
             .basic_mut()
             .set_name(ProcessControlBlock::generate_name(&path));
 
+        // 仅在 execve 成功后再写入 cmdline，避免失败时污染当前进程信息
+        let argv_for_cmdline = argv.clone();
         do_execve(inode, argv, envp, frame)?;
 
         let pcb = ProcessManager::current_pcb();
@@ -98,6 +100,7 @@ impl SysExecve {
         fd_table.write().close_on_exec();
 
         pcb.set_execute_path(path);
+        pcb.set_cmdline_from_argv(&argv_for_cmdline);
         Ok(())
     }
 }


### PR DESCRIPTION
- 新增 proc_pid_cmdline 模块，实现 /proc/cmdline 和 /proc/<pid>/cmdline 文件的读取逻辑
- 在进程控制块中增加 cmdline 字段，用于存储进程的命令行参数
- 在 execve、fork 和初始进程启动时正确设置和继承 cmdline 数据
- 在 procfs 中创建对应的文件节点并集成到文件类型枚举和打开逻辑中