### PR TITLE
feat(procfs): 新增/proc/<pid>/stat和/proc/<pid>/task支持

### DIFF
--- a/kernel/src/filesystem/procfs/proc_pid_stat.rs
+++ b/kernel/src/filesystem/procfs/proc_pid_stat.rs
@@ -1,0 +1,146 @@
+use alloc::{
+    format,
+    string::{String, ToString},
+    sync::Arc,
+};
+use system_error::SystemError;
+
+use crate::{
+    arch::MMArch,
+    mm::MemoryManagementArch,
+    process::{pid::PidType, ProcessControlBlock, ProcessManager, ProcessState, RawPid},
+};
+
+use super::{ProcFSInode, ProcfsFilePrivateData};
+
+fn state_to_linux_char(state: ProcessState) -> char {
+    match state {
+        ProcessState::Runnable => 'R',
+        ProcessState::Blocked(interruptable) => {
+            if interruptable {
+                'S'
+            } else {
+                'D'
+            }
+        }
+        ProcessState::Stopped => 'T',
+        ProcessState::Exited(_) => 'Z',
+    }
+}
+
+fn sanitize_comm_for_proc_stat(comm: &str) -> String {
+    // BusyBox/procps 使用 strrchr(')') 定位 comm 结束位置。
+    // 若 comm 中包含 ')' 会破坏解析，先做最小替换。
+    comm.chars()
+        .map(|c| if c == ')' { '_' } else { c })
+        .collect()
+}
+
+fn generate_linux_proc_stat_line(
+    pid: RawPid,
+    comm: &str,
+    state: ProcessState,
+    ppid: RawPid,
+    pcb: &Arc<ProcessControlBlock>,
+) -> String {
+    // Linux /proc/[pid]/stat 字段：
+    // pid (comm) state ppid pgrp session tty_nr tpgid flags minflt cminflt majflt cmajflt
+    // utime stime cutime cstime priority nice num_threads itrealvalue starttime vsize rss ...
+    //
+    // BusyBox 1.35.0 只强依赖到 rss 字段位置，且字段顺序必须对齐。
+    let comm = sanitize_comm_for_proc_stat(comm);
+    let state_ch = state_to_linux_char(state);
+
+    // 尽量填真实值；拿不到的先填 0，不影响 BusyBox 解析，只影响输出质量。
+    let pgrp: usize = 0;
+    let session: usize = 0;
+    let tty_nr: i32 = 0;
+    let tpgid: i32 = 0;
+    let flags: u64 = 0;
+    let minflt: u64 = 0;
+    let cminflt: u64 = 0;
+    let majflt: u64 = 0;
+    let cmajflt: u64 = 0;
+    let utime: u64 = 0;
+    let stime: u64 = 0;
+    let cutime: i64 = 0;
+    let cstime: i64 = 0;
+    let priority: i64 = 0;
+    let nice: i64 = 0;
+    // Linux 语义：进程线程组中的线程数量（包含主线程）。
+    // 线程组成员由 Pid(TGID)->tasks[PidType::TGID] 维护；用它计数比本地缓存更可靠。
+    let num_threads: i64 = pcb
+        .task_pid_ptr(PidType::TGID)
+        .map(|tgid_pid| tgid_pid.tasks_iter(PidType::TGID).count() as i64)
+        .unwrap_or(1);
+    let itrealvalue: i64 = 0;
+    let starttime: u64 = 0;
+
+    // vsize: bytes, rss: pages
+    // 使用传入的 pcb，避免重复查找
+    let (vsize_bytes, rss_pages) = pcb
+        .basic()
+        .user_vm()
+        .map(|vm| {
+            let guard = vm.read();
+            let bytes = guard.vma_usage_bytes();
+            let pages = (bytes.saturating_add(MMArch::PAGE_SIZE - 1)) >> MMArch::PAGE_SHIFT;
+            (bytes as u64, pages as u64)
+        })
+        .unwrap_or((0, 0));
+
+    // rsslim 及后续字段给足占位，避免对方 parser 依赖更多字段时出问题
+    format!(
+        "{pid} ({comm}) {state_ch} {ppid} {pgrp} {session} {tty_nr} {tpgid} {flags} \
+{minflt} {cminflt} {majflt} {cmajflt} {utime} {stime} {cutime} {cstime} {priority} {nice} \
+{num_threads} {itrealvalue} {starttime} {vsize_bytes} {rss_pages} 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n",
+        pid = pid.data(),
+        ppid = ppid.data(),
+    )
+}
+
+impl ProcFSInode {
+    /// 生成进程 stat 信息的公共逻辑
+    fn generate_pid_stat_data(pid: RawPid) -> Result<String, SystemError> {
+        let pcb = ProcessManager::find_task_by_vpid(pid).ok_or(SystemError::ESRCH)?;
+
+        let comm = pcb.basic().name().to_string();
+        let sched = pcb.sched_info();
+        let state = sched.inner_lock_read_irqsave().state();
+
+        let ppid = pcb
+            .parent_pcb()
+            .map(|p| p.raw_pid())
+            .unwrap_or(RawPid::new(0));
+
+        Ok(generate_linux_proc_stat_line(pid, &comm, state, ppid, &pcb))
+    }
+
+    /// /proc/<pid>/stat
+    #[inline(never)]
+    pub(super) fn open_pid_stat(
+        &self,
+        pdata: &mut ProcfsFilePrivateData,
+    ) -> Result<i64, SystemError> {
+        let pid = self.fdata.pid.ok_or(SystemError::EINVAL)?;
+
+        let s = Self::generate_pid_stat_data(pid)?;
+        pdata.data = s.into_bytes();
+        Ok(pdata.data.len() as i64)
+    }
+
+    /// /proc/<pid>/task/<tid>/stat（最小实现：先按进程视图输出）
+    #[inline(never)]
+    pub(super) fn open_pid_task_tid_stat(
+        &self,
+        pdata: &mut ProcfsFilePrivateData,
+    ) -> Result<i64, SystemError> {
+        let pid = self.fdata.pid.ok_or(SystemError::EINVAL)?;
+        // 目前内核线程/用户线程还没有独立的 tid 视图，这里先占位：tid 仅用于路径匹配。
+        let _tid = self.fdata.tid.ok_or(SystemError::EINVAL)?;
+
+        let s = Self::generate_pid_stat_data(pid)?;
+        pdata.data = s.into_bytes();
+        Ok(pdata.data.len() as i64)
+    }
+}

--- a/kernel/src/filesystem/procfs/proc_pid_task.rs
+++ b/kernel/src/filesystem/procfs/proc_pid_task.rs
@@ -1,0 +1,153 @@
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use system_error::SystemError;
+
+use crate::{
+    filesystem::vfs::{utils::DName, FileType, IndexNode, InodeMode},
+    process::{ProcessManager, RawPid},
+};
+
+use super::{LockedProcFSInode, ProcFileType};
+
+impl LockedProcFSInode {
+    /// 动态列出 `/proc/<pid>/task` 下的 tid 列表。
+    ///
+    /// 最小实现：仅返回主线程 tid=pid，满足 BusyBox 的 PSSCAN_TASKS 逻辑。
+    pub(super) fn dynamical_list_task_tids(&self) -> Result<Vec<String>, SystemError> {
+        let pid = self.0.lock().fdata.pid.ok_or(SystemError::EINVAL)?;
+        // 尝试确认进程存在；不存在则返回 ESRCH
+        let _ = ProcessManager::find_task_by_vpid(pid).ok_or(SystemError::ESRCH)?;
+        Ok(vec![pid.to_string()])
+    }
+
+    /// 动态创建 `/proc/<pid>/task/<tid>` 目录，并在其中创建 `stat` 文件。
+    pub(super) fn dynamical_find_task_tid(
+        &self,
+        tid: &str,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let pid = self.0.lock().fdata.pid.ok_or(SystemError::EINVAL)?;
+        let tid_u = tid.parse::<usize>().map_err(|_| SystemError::EINVAL)?;
+        let tid_pid = RawPid::new(tid_u);
+
+        // 最小实现：只允许 tid==pid（主线程）。
+        if tid_pid != pid {
+            return Err(SystemError::ENOENT);
+        }
+
+        let name = DName::from(tid);
+
+        // Fast-path: 检查目录是否已存在
+        {
+            let guard = self.0.lock();
+            if let Some(existing) = guard.children.get(&name) {
+                return Ok(existing.clone());
+            }
+        }
+
+        // Slow-path: 尝试创建目录，处理并发竞争
+        let tid_dir = match self.create(tid, FileType::Dir, InodeMode::from_bits_truncate(0o555)) {
+            Ok(dir) => dir,
+            Err(SystemError::EEXIST) => {
+                // 并发竞争：其他线程已经创建了目录，重新查找并返回
+                let guard = self.0.lock();
+                if let Some(existing) = guard.children.get(&name) {
+                    return Ok(existing.clone());
+                } else {
+                    // 极不可能的情况：文件系统报告 EEXIST 但内存映射中不存在
+                    return Err(SystemError::ENOENT);
+                }
+            }
+            Err(e) => return Err(e),
+        };
+
+        let tid_dir_proc = tid_dir
+            .as_any_ref()
+            .downcast_ref::<LockedProcFSInode>()
+            .ok_or(SystemError::EPERM)?;
+        {
+            let mut guard = tid_dir_proc.0.lock();
+            guard.fdata.pid = Some(pid);
+            guard.fdata.tid = Some(tid_pid);
+            guard.fdata.ftype = ProcFileType::ProcPidTaskTidDir;
+        }
+
+        // 预创建 stat 文件，减少后续 find 分支复杂度
+        // 同样需要处理并发竞争
+        match tid_dir.create("stat", FileType::File, InodeMode::S_IRUGO) {
+            Ok(stat) => {
+                // 成功创建 stat 文件，配置其元数据
+                let stat_proc = stat
+                    .as_any_ref()
+                    .downcast_ref::<LockedProcFSInode>()
+                    .ok_or(SystemError::EPERM)?;
+                {
+                    let mut guard = stat_proc.0.lock();
+                    guard.fdata.pid = Some(pid);
+                    guard.fdata.tid = Some(tid_pid);
+                    guard.fdata.ftype = ProcFileType::ProcPidTaskTidStat;
+                }
+            }
+            Err(SystemError::EEXIST) => {
+                // 并发竞争：其他线程已经创建了 stat 文件
+                // 假设其他线程已经正确配置了 fdata，直接返回 tid_dir
+            }
+            Err(e) => return Err(e),
+        }
+
+        Ok(tid_dir)
+    }
+
+    /// 在 `/proc/<pid>/task/<tid>` 目录下动态查找子节点（目前只支持 `stat`）。
+    pub(super) fn dynamical_find_task_tid_child(
+        &self,
+        name: &str,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        if name != "stat" {
+            return Err(SystemError::ENOENT);
+        }
+
+        let dname = DName::from(name);
+
+        // Fast-path: 若已存在，直接返回（避免递归调用 find）
+        {
+            let guard = self.0.lock();
+            if let Some(existing) = guard.children.get(&dname) {
+                return Ok(existing.clone());
+            }
+        }
+
+        let pid = self.0.lock().fdata.pid.ok_or(SystemError::EINVAL)?;
+        let tid = self.0.lock().fdata.tid.ok_or(SystemError::EINVAL)?;
+
+        // Slow-path: 尝试创建文件，处理并发竞争
+        let stat = match self.create("stat", FileType::File, InodeMode::S_IRUGO) {
+            Ok(file) => file,
+            Err(SystemError::EEXIST) => {
+                // 并发竞争：其他线程已经创建了文件，重新查找并返回
+                let guard = self.0.lock();
+                if let Some(existing) = guard.children.get(&dname) {
+                    return Ok(existing.clone());
+                } else {
+                    // 极不可能的情况：文件系统报告 EEXIST 但内存映射中不存在
+                    return Err(SystemError::ENOENT);
+                }
+            }
+            Err(e) => return Err(e),
+        };
+
+        let stat_proc = stat
+            .as_any_ref()
+            .downcast_ref::<LockedProcFSInode>()
+            .ok_or(SystemError::EPERM)?;
+        {
+            let mut guard = stat_proc.0.lock();
+            guard.fdata.pid = Some(pid);
+            guard.fdata.tid = Some(tid);
+            guard.fdata.ftype = ProcFileType::ProcPidTaskTidStat;
+        }
+        Ok(stat)
+    }
+}


### PR DESCRIPTION
- 添加/proc/<pid>/stat文件生成，支持BusyBox ps/pstree/top等工具
- 实现/proc/<pid>/task目录结构，支持主线程tid=pid的展示
- 新增proc_pid_stat和proc_pid_task模块处理相关逻辑
- 扩展ProcFileType枚举，添加ProcPidStat、ProcPidTaskDir等类型
- 在InodeInfo中新增tid字段以支持线程信息

<img width="628" height="668" alt="image" src="https://github.com/user-attachments/assets/556549b3-8aff-4c50-a971-6284dcd35d4b" />
