### PR TITLE
feat(filesystem): 完善文件系统统计信息支持

### DIFF
--- a/kernel/src/filesystem/vfs/stat.rs
+++ b/kernel/src/filesystem/vfs/stat.rs
@@ -302,15 +302,14 @@ pub fn vfs_getattr(
         kstat.btime.tv_nsec = metadata.btime.tv_nsec;
     }
 
-    // 对于字符/块设备，st_rdev 在基础属性中也应被返回。
-    // 即便调用者未显式请求 STATX_ALL，也填充 rdev 以符合 Linux 语义。
+    // 即便调用者未显式请求 STATX_ALL，也填充 rdev、dev 以符合 Linux 语义。
     kstat.rdev = metadata.raw_dev;
+    kstat.dev = DeviceNumber::from(metadata.dev_id as u32);
 
     if request_mask.contains(PosixStatxMask::STATX_ALL) {
         kstat.attributes = StxAttributes::STATX_ATTR_APPEND;
         kstat.attributes_mask |=
             StxAttributes::STATX_ATTR_AUTOMOUNT | StxAttributes::STATX_ATTR_DAX;
-        kstat.dev = DeviceNumber::from(metadata.dev_id as u32);
     }
 
     // 把文件类型加入mode里面 （todo: 在具体的文件系统里面去实现这个操作。这里只是权宜之计）


### PR DESCRIPTION
- 为 FAT 文件系统实现 statfs 所需的 SuperBlock 字段（f_blocks、f_bfree、f_bavail、f_frsize）
- 为 tmpfs 添加默认容量策略（物理内存一半）并同步更新 SuperBlock 统计信息
- 修复 FAT32 FSInfo 空闲簇计数更新时的溢出问题
- 为挂载点提供稳定的 st_dev 标识符

经过该pr， `df -h`以及`busybox df -h`可以运行