### PR TITLE
feat(fs): implement umask and improve permission handling

### DIFF
--- a/kernel/src/filesystem/fs.rs
+++ b/kernel/src/filesystem/fs.rs
@@ -46,7 +46,9 @@ impl Default for FsStruct {
 impl FsStruct {
     pub fn new() -> Self {
         Self {
-            umask: AtomicU32::new(InodeMode::S_IWUGO.bits()),
+            // Linux 常见默认 umask：0022（屏蔽 group/other 的写权限）。
+            // 这能保证新建文件默认不对组/其他可写，同时不把所有写权限都屏蔽掉。
+            umask: AtomicU32::new((InodeMode::S_IWGRP | InodeMode::S_IWOTH).bits()),
             path_context: RwLock::new(PathContext::new()),
         }
     }

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -38,6 +38,7 @@ utimes_test
 truncate_test
 fadvise_test
 open_test
+open_create_test
 
 # 进程相关测试
 fork_test


### PR DESCRIPTION
- Set default umask to 0022 for new filesystem instances
- Add apply_umask_for_create() and chmod_preserve_type() helper functions
- Implement proper permission checks for file creation and chmod operations
- Fix fchmod syscall to work correctly and reject O_PATH file descriptors
- Add open_create_test to gvisor test suite