### PR TITLE
fix(poll) : 实现poll测试

### DIFF
--- a/kernel/src/filesystem/epoll/mod.rs
+++ b/kernel/src/filesystem/epoll/mod.rs
@@ -1,5 +1,8 @@
 use super::vfs::file::File;
-use crate::libs::{rwlock::RwLock, spinlock::SpinLock};
+use crate::{
+    filesystem::vfs::FileType,
+    libs::{rwlock::RwLock, spinlock::SpinLock},
+};
 use alloc::sync::Weak;
 use core::fmt::Debug;
 use event_poll::EventPoll;
@@ -94,16 +97,65 @@ impl EPollItem {
     }
 
     /// ## 通过epoll_item来执行绑定文件的poll方法，并获取到感兴趣的事件
-    fn ep_item_poll(&self) -> EPollEventType {
-        let file = self.file.upgrade();
-        if file.is_none() {
+    ///
+    /// 返回与用户注册的事件掩码相交的就绪事件
+    pub(super) fn ep_item_poll(&self) -> EPollEventType {
+        let Some(file) = self.file.upgrade() else {
             return EPollEventType::empty();
+        };
+
+        // 对于不支持poll的普通文件/目录，返回默认掩码（总是就绪）
+        // 需要与用户注册的事件掩码相交，保持与普通文件路径的一致性
+        if Self::is_always_ready_file(&file) {
+            let interested = self.event.read().events;
+            return EPollEventType::from_bits_truncate(
+                Self::default_poll_mask().bits() & interested,
+            );
         }
-        if let Ok(events) = file.unwrap().poll() {
-            let events = events as u32 & self.event.read().events;
-            return EPollEventType::from_bits_truncate(events);
+
+        match file.poll() {
+            Ok(events) => {
+                let interested = self.event.read().events;
+                EPollEventType::from_bits_truncate(events as u32 & interested)
+            }
+            Err(_) => EPollEventType::empty(),
         }
-        return EPollEventType::empty();
+    }
+
+    /// 检查文件是否为"总是就绪"类型
+    ///
+    /// 满足以下条件的文件总是就绪：
+    /// 1. 文件类型为普通文件或目录
+    /// 2. 文件不支持poll操作
+    ///
+    /// Linux语义：普通文件和目录的I/O操作不会阻塞，因此它们总是可读/可写的
+    /// 参考 Linux 内核的 DEFAULT_POLLMASK
+    #[inline]
+    pub(super) fn is_always_ready_file(file: &File) -> bool {
+        // 先检查是否支持poll，支持的话就不是"总是就绪"
+        if file.supports_poll() {
+            return false;
+        }
+
+        // 不支持poll的普通文件和目录总是就绪
+        let file_type = file
+            .inode()
+            .metadata()
+            .map(|m| m.file_type)
+            .unwrap_or(FileType::File);
+
+        matches!(file_type, FileType::File | FileType::Dir)
+    }
+
+    /// 返回默认的poll掩码，用于不支持poll的普通文件
+    ///
+    /// 对应Linux内核的 DEFAULT_POLLMASK (POLLIN | POLLOUT | POLLRDNORM | POLLWRNORM)
+    #[inline]
+    pub(super) fn default_poll_mask() -> EPollEventType {
+        EPollEventType::EPOLLIN
+            | EPollEventType::EPOLLOUT
+            | EPollEventType::EPOLLRDNORM
+            | EPollEventType::EPOLLWRNORM
     }
 }
 

--- a/kernel/src/filesystem/poll.rs
+++ b/kernel/src/filesystem/poll.rs
@@ -1,21 +1,27 @@
 use core::ffi::c_int;
 
 use crate::{
-    arch::ipc::signal::SigSet,
+    arch::ipc::signal::{SigSet, Signal},
     filesystem::epoll::{event_poll::EventPoll, EPollCtlOption, EPollEvent, EPollEventType},
     ipc::signal::{
         restore_saved_sigmask_unless, set_user_sigmask, RestartBlock, RestartBlockData, RestartFn,
     },
+    libs::wait_queue::{TimeoutWaker, Waiter},
     mm::VirtAddr,
     process::ProcessManager,
     syscall::{
         user_access::{UserBufferReader, UserBufferWriter},
         Syscall,
     },
-    time::{syscall::PosixTimeval, Duration, Instant, PosixTimeSpec},
+    time::{
+        syscall::PosixTimeval,
+        timer::{next_n_us_timer_jiffies, Timer},
+        Duration, Instant, PosixTimeSpec,
+    },
 };
 
 use super::vfs::file::{File, FileFlags};
+use crate::process::resource::RLimitID;
 use alloc::sync::Arc;
 use system_error::SystemError;
 
@@ -30,60 +36,140 @@ pub struct PollFd {
 struct PollAdapter<'a> {
     ep_file: Arc<File>,
     poll_fds: &'a mut [PollFd],
+    /// 记录已添加到 epoll 的 fd 以及合并后的事件掩码
+    added_fds: alloc::collections::BTreeMap<i32, u16>,
 }
 
 impl<'a> PollAdapter<'a> {
     pub fn new(ep_file: Arc<File>, poll_fds: &'a mut [PollFd]) -> Self {
-        Self { ep_file, poll_fds }
+        Self {
+            ep_file,
+            poll_fds,
+            added_fds: alloc::collections::BTreeMap::new(),
+        }
     }
 
-    fn add_pollfds(&self) -> Result<(), SystemError> {
-        for (i, pollfd) in self.poll_fds.iter().enumerate() {
+    fn add_pollfds(&mut self) -> Result<(), SystemError> {
+        // 首先清除所有 revents（revents 是 output-only 字段）
+        // 这确保每次 poll 调用都从干净状态开始，不受之前调用的影响
+        for pollfd in self.poll_fds.iter_mut() {
+            pollfd.revents = 0;
+        }
+
+        // 第一遍：收集每个唯一 fd 的合并事件掩码
+        for i in 0..self.poll_fds.len() {
+            let pollfd = &self.poll_fds[i];
             if pollfd.fd < 0 {
                 continue;
             }
+
+            // 合并同一 fd 的所有事件
+            let entry = self.added_fds.entry(pollfd.fd).or_insert(0);
+            *entry |= pollfd.events;
+        }
+
+        // 第二遍：将每个唯一 fd 添加到 epoll
+        let fds_to_add: alloc::vec::Vec<_> = self
+            .added_fds
+            .iter()
+            .map(|(&fd, &events)| (fd, events))
+            .collect();
+
+        for (fd, merged_events) in fds_to_add {
             let mut epoll_event = EPollEvent::default();
-            let poll_flags = PollFlags::from_bits_truncate(pollfd.events);
+            let mut poll_flags = PollFlags::from_bits_truncate(merged_events);
+            poll_flags |= PollFlags::POLLERR | PollFlags::POLLHUP;
             let ep_events: EPollEventType = poll_flags.into();
             epoll_event.set_events(ep_events.bits());
-            epoll_event.set_data(i as u64);
+            epoll_event.set_data(fd as u64);
 
-            EventPoll::epoll_ctl_with_epfile(
+            let result = EventPoll::epoll_ctl_with_epfile(
                 self.ep_file.clone(),
                 EPollCtlOption::Add,
-                pollfd.fd,
+                fd,
                 epoll_event,
                 false,
-            )
-            .map(|_| ())?;
+            );
+
+            match result {
+                Ok(_) => {}
+                Err(_) => {
+                    // 根据 POSIX 语义，无效的 fd 应该设置 POLLNVAL 并继续处理其他 fd
+                    // 从 added_fds 中移除此 fd，并设置对应的所有 pollfd 条目的 revents
+                    // 注意：同一个 fd 可能在 poll_fds 数组中出现多次，每个条目都应独立处理
+                    self.added_fds.remove(&fd);
+                    for pollfd in self.poll_fds.iter_mut() {
+                        if pollfd.fd == fd {
+                            pollfd.revents = PollFlags::POLLNVAL.bits();
+                            // 不能 break，需要为所有匹配的条目设置 POLLNVAL
+                        }
+                    }
+                }
+            }
         }
 
         Ok(())
     }
 
     fn poll_all_fds(&mut self, timeout: Option<Instant>) -> Result<usize, SystemError> {
-        let mut epoll_events = vec![EPollEvent::default(); self.poll_fds.len()];
+        // 如果没有添加任何有效 fd 到 epoll，直接计算已有 revents 的数量并返回
+        // 这处理了所有 fd 都无效（POLLNVAL）的情况
+        if self.added_fds.is_empty() {
+            let count = self.poll_fds.iter().filter(|pfd| pfd.revents != 0).count();
+            return Ok(count);
+        }
+
+        // 检查是否已经有无效 fd（POLLNVAL）
+        let has_invalid_fds = self.poll_fds.iter().any(|pfd| pfd.revents != 0);
+
+        // 即使某些 fd 已经有 POLLNVAL，仍需检查有效 fd 的事件
+        // Linux 语义：poll 检查所有 fd 并在单次调用中报告所有就绪事件
+        let mut epoll_events = vec![EPollEvent::default(); self.added_fds.len()];
         let len = epoll_events.len() as i32;
-        let remain_timeout = timeout.map(|t| {
-            t.duration_since(Instant::now())
-                .unwrap_or(Duration::ZERO)
-                .into()
-        });
+
+        // 如果已经有无效 fd，使用非阻塞模式检查有效 fd
+        // 这样可以立即返回所有结果，而不会因等待有效 fd 而延迟报告无效 fd
+        let remain_timeout = if has_invalid_fds {
+            Some(PosixTimeSpec::default()) // timeout=0，非阻塞
+        } else {
+            timeout.map(|t| {
+                t.duration_since(Instant::now())
+                    .unwrap_or(Duration::ZERO)
+                    .into()
+            })
+        };
+
         let events = EventPoll::epoll_wait_with_file(
             self.ep_file.clone(),
             &mut epoll_events,
             len,
             remain_timeout,
         )?;
+
+        // 处理返回的事件，将它们映射回所有相关的 pollfd 条目
         for event in epoll_events.iter().take(events) {
-            let index = event.data() as usize;
-            if index >= self.poll_fds.len() {
-                log::warn!("poll_all_fds: Invalid index in epoll event: {}", index);
-                continue;
+            let event_fd = event.data() as i32;
+            let revents = event.events();
+
+            // 找到所有匹配这个 fd 的 pollfd 条目
+            for pollfd in self.poll_fds.iter_mut() {
+                if pollfd.fd == event_fd {
+                    // 只设置用户请求的事件 + 强制事件
+                    let requested = (pollfd.events as u32)
+                        | PollFlags::POLLERR.bits() as u32
+                        | PollFlags::POLLHUP.bits() as u32
+                        | PollFlags::POLLNVAL.bits() as u32;
+                    let filtered_revents = revents & requested;
+                    if filtered_revents != 0 {
+                        pollfd.revents = (filtered_revents & 0xffff) as u16;
+                    }
+                }
             }
-            self.poll_fds[index].revents = (event.events() & 0xffff) as u16;
         }
-        Ok(events)
+
+        // 计算有事件的 pollfd 数量
+        let count = self.poll_fds.iter().filter(|pfd| pfd.revents != 0).count();
+        Ok(count)
     }
 }
 
@@ -91,13 +177,42 @@ impl Syscall {
     /// https://code.dragonos.org.cn/xref/linux-6.6.21/fs/select.c#1068
     #[inline(never)]
     pub fn poll(pollfd_ptr: usize, nfds: u32, timeout_ms: i32) -> Result<usize, SystemError> {
+        // 检查 nfds 是否超过 RLIMIT_NOFILE
+        let rlimit_nofile = ProcessManager::current_pcb()
+            .get_rlimit(RLimitID::Nofile)
+            .rlim_cur as u32;
+        if nfds > rlimit_nofile {
+            return Err(SystemError::EINVAL);
+        }
+
+        // 检查长度溢出
+        let len = (nfds as usize)
+            .checked_mul(core::mem::size_of::<PollFd>())
+            .ok_or(SystemError::EINVAL)?;
+
+        // 当 nfds > 0 但 pollfd_ptr 为空指针时，返回 EFAULT
+        if nfds > 0 && pollfd_ptr == 0 {
+            return Err(SystemError::EFAULT);
+        }
+
         let pollfd_ptr = VirtAddr::new(pollfd_ptr);
-        let len = nfds as usize * core::mem::size_of::<PollFd>();
 
         let mut timeout: Option<Instant> = None;
         if timeout_ms >= 0 {
             timeout = poll_select_set_timeout(timeout_ms as u64);
         }
+
+        // nfds == 0 时，直接进入等待逻辑，不需要用户缓冲区
+        if nfds == 0 {
+            let mut r = do_sys_poll(&mut [], timeout);
+            if let Err(SystemError::ERESTARTNOHAND) = r {
+                let restart_block_data = RestartBlockData::new_poll(pollfd_ptr, nfds, timeout);
+                let restart_block = RestartBlock::new(&RestartFnPoll, restart_block_data);
+                r = ProcessManager::current_pcb().set_restart_fn(Some(restart_block));
+            }
+            return r;
+        }
+
         let mut poll_fds_writer = UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), len, true)?;
         let mut r = do_sys_poll(poll_fds_writer.buffer(0)?, timeout);
         if let Err(SystemError::ERESTARTNOHAND) = r {
@@ -117,13 +232,28 @@ impl Syscall {
         timespec_ptr: usize,
         sigmask_ptr: usize,
     ) -> Result<usize, SystemError> {
+        // 检查 nfds 是否超过 RLIMIT_NOFILE
+        let rlimit_nofile = ProcessManager::current_pcb()
+            .get_rlimit(RLimitID::Nofile)
+            .rlim_cur as u32;
+        if nfds > rlimit_nofile {
+            return Err(SystemError::EINVAL);
+        }
+
+        // 检查长度溢出
+        let pollfds_len = (nfds as usize)
+            .checked_mul(core::mem::size_of::<PollFd>())
+            .ok_or(SystemError::EINVAL)?;
+
+        // 当 nfds > 0 但 pollfd_ptr 为空指针时，返回 EFAULT
+        if nfds > 0 && pollfd_ptr == 0 {
+            return Err(SystemError::EFAULT);
+        }
+
         let mut timeout_ts: Option<Instant> = None;
         let mut sigmask: Option<SigSet> = None;
         let pollfd_ptr = VirtAddr::new(pollfd_ptr);
-        let pollfds_len = nfds as usize * core::mem::size_of::<PollFd>();
-        let mut poll_fds_writer =
-            UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), pollfds_len, true)?;
-        let poll_fds = poll_fds_writer.buffer(0)?;
+
         if sigmask_ptr != 0 {
             let sigmask_reader =
                 UserBufferReader::new(sigmask_ptr as *const SigSet, size_of::<SigSet>(), true)?;
@@ -148,15 +278,23 @@ impl Syscall {
         if let Some(mut sigmask) = sigmask {
             set_user_sigmask(&mut sigmask);
         }
-        // log::debug!(
-        //     "ppoll: poll_fds: {:?}, nfds: {}, timeout_ts: {:?}，sigmask: {:?}",
-        //     poll_fds,
-        //     nfds,
-        //     timeout_ts,
-        //     sigmask
-        // );
 
-        let r: Result<usize, SystemError> = do_sys_poll(poll_fds, timeout_ts);
+        // nfds == 0 时，直接进入等待逻辑，不需要用户缓冲区
+        let mut r: Result<usize, SystemError> = if nfds == 0 {
+            do_sys_poll(&mut [], timeout_ts)
+        } else {
+            let mut poll_fds_writer =
+                UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), pollfds_len, true)?;
+            let poll_fds = poll_fds_writer.buffer(0)?;
+            do_sys_poll(poll_fds, timeout_ts)
+        };
+
+        // 处理信号中断，设置restart block使ppoll可重启
+        if let Err(SystemError::ERESTARTNOHAND) = r {
+            let restart_block_data = RestartBlockData::new_poll(pollfd_ptr, nfds, timeout_ts);
+            let restart_block = RestartBlock::new(&RestartFnPoll, restart_block_data);
+            r = ProcessManager::current_pcb().set_restart_fn(Some(restart_block));
+        }
 
         return poll_select_finish(timeout_ts, timespec_ptr, PollTimeType::TimeSpec, r);
     }
@@ -166,6 +304,12 @@ pub fn do_sys_poll(
     poll_fds: &mut [PollFd],
     timeout: Option<Instant>,
 ) -> Result<usize, SystemError> {
+    // 特殊处理: nfds=0 时，直接进入可中断等待
+    // 这种情况下只等待超时或信号，不需要创建 epoll
+    if poll_fds.is_empty() {
+        return poll_wait_timeout_only(timeout);
+    }
+
     let ep_file = EventPoll::create_epoll_file(FileFlags::empty())?;
 
     let ep_file = Arc::new(ep_file);
@@ -175,6 +319,97 @@ pub fn do_sys_poll(
     let nevents = adapter.poll_all_fds(timeout)?;
 
     Ok(nevents)
+}
+
+/// 处理 nfds=0 的情况：纯等待超时或信号
+///
+/// 根据 Linux 语义：
+/// - 如果 timeout=0，立即返回 0
+/// - 如果 timeout>0，等待指定时间后返回 0
+/// - 如果 timeout=-1(None)，无限等待直到被信号中断，返回 ERESTARTNOHAND
+fn poll_wait_timeout_only(timeout: Option<Instant>) -> Result<usize, SystemError> {
+    // 如果有超时时间且已过期，直接返回
+    if let Some(end_time) = timeout {
+        if Instant::now() >= end_time {
+            return Ok(0);
+        }
+    }
+
+    loop {
+        // 检查是否有待处理的信号
+        let current_pcb = ProcessManager::current_pcb();
+        if current_pcb.has_pending_signal_fast()
+            && Signal::signal_pending_state(true, false, &current_pcb)
+        {
+            return Err(SystemError::ERESTARTNOHAND);
+        }
+
+        // 检查超时
+        if let Some(end_time) = timeout {
+            if Instant::now() >= end_time {
+                return Ok(0);
+            }
+        }
+
+        // 计算剩余等待时间
+        let sleep_duration = if let Some(end_time) = timeout {
+            let remain = end_time
+                .duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+            if remain == Duration::ZERO {
+                return Ok(0);
+            }
+            remain
+        } else {
+            // 无限等待时，设置一个较长的时间（比如1秒），然后循环检查信号
+            Duration::from_secs(1)
+        };
+
+        // 创建 Waiter/Waker 对
+        let (waiter, waker) = Waiter::new_pair();
+
+        // 创建定时器唤醒
+        let sleep_us = sleep_duration.total_micros();
+        let timer: Arc<Timer> = Timer::new(
+            TimeoutWaker::new(waker.clone()),
+            next_n_us_timer_jiffies(sleep_us),
+        );
+
+        // 激活定时器
+        timer.activate();
+
+        // 使用标准的 Waiter.wait() - 它内部已经正确处理了中断禁用等逻辑
+        let wait_res = waiter.wait(true);
+
+        // 醒来后检查原因
+        let was_timeout = timer.timeout();
+        if !was_timeout {
+            timer.cancel();
+        }
+
+        // 处理等待结果（可能是信号中断）
+        // 注意：waiter.wait() 返回 ERESTARTSYS，但 poll 需要 ERESTARTNOHAND
+        // 以便正确设置 restart block
+        if let Err(SystemError::ERESTARTSYS) = wait_res {
+            return Err(SystemError::ERESTARTNOHAND);
+        }
+        wait_res?;
+
+        // 检查是否因信号而醒来
+        let current_pcb = ProcessManager::current_pcb();
+        if current_pcb.has_pending_signal_fast()
+            && Signal::signal_pending_state(true, false, &current_pcb)
+        {
+            return Err(SystemError::ERESTARTNOHAND);
+        }
+
+        // 如果超时且有超时设置，返回 0
+        if was_timeout && timeout.is_some() {
+            return Ok(0);
+        }
+
+        // 无限等待时继续循环（重新检查信号）
+    }
 }
 
 /// 计算超时的时刻

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1206,6 +1206,12 @@ impl File {
         self.inode.as_pollable_inode()?.poll(&private_data)
     }
 
+    /// 检查文件是否支持 poll 操作
+    #[inline]
+    pub fn supports_poll(&self) -> bool {
+        self.inode.as_pollable_inode().is_ok()
+    }
+
     pub fn owner(&self) -> Option<RawPid> {
         self.pid.lock().as_ref().map(|pcb| pcb.pid().pid_vnr())
     }

--- a/kernel/src/sched/completion.rs
+++ b/kernel/src/sched/completion.rs
@@ -5,10 +5,10 @@ use system_error::SystemError;
 use crate::{
     libs::{
         spinlock::SpinLock,
-        wait_queue::{WaitQueue, Waiter},
+        wait_queue::{TimeoutWaker, WaitQueue, Waiter},
     },
     process::ProcessManager,
-    time::timer::{Timer, WakeUpHelper},
+    time::timer::Timer,
 };
 
 const COMPLETE_ALL: u32 = u32::MAX;
@@ -92,7 +92,7 @@ impl Completion {
             let mut timer = None;
             if let Some(r) = remaining {
                 let jiffies = r as u64;
-                let t = Timer::new(WakeUpHelper::new(pcb.clone()), jiffies);
+                let t = Timer::new(TimeoutWaker::new(waker.clone()), jiffies);
                 t.activate();
                 timer = Some(t);
             }

--- a/kernel/src/time/syscall/sys_clock_gettime.rs
+++ b/kernel/src/time/syscall/sys_clock_gettime.rs
@@ -39,7 +39,7 @@ impl Syscall for SysClockGettime {
 
         let timespec = posix_clock_now(clock_id);
 
-        tp_buf.copy_one_to_user(&timespec, 0)?;
+        tp_buf.buffer_protected(0)?.write_one(0, &timespec)?;
 
         return Ok(0);
     }

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -59,7 +59,7 @@ prctl_test
 exit_test
 setns_test
 eventfd_test
-prctl_test
+poll_test
 
 # 内存管理测试
 mmap_test


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Overview**
> - Implemented `poll`/`ppoll` via an epoll-backed adapter, with RLIMIT_NOFILE checks, robust user buffer validation, nfds=0 timeout-only wait path, restartable semantics, and correct mapping of revents (including POLLNVAL for bad fds).
> 
> **Epoll/Wait infrastructure**
> - Added `TimeoutWaker` in `wait_queue` and used it across epoll waits and completions for timer-driven wakeups.
> - Epoll: skip items with `revents=0`, preserve user private bits (e.g., `EPOLLET`/`EPOLLONESHOT`), disallow `EPOLLWAKEUP`, and treat non-pollable regular files/dirs as always-ready with a default mask. Added `File::supports_poll`.
> 
> **I/O subsystems**
> - Pipe: make epoll wakeups best-effort and ensure readers get `POLLHUP` when writers close; wake appropriate wait queues.
> - Unix stream socket: implemented `recv_from` to return data and peer endpoint.
> 
> **Misc**
> - `clock_gettime`: switch to protected buffer write API.
> - Test: enable `poll_test` in gVisor whitelist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 884cf3ea3d2c17d5f6f9b5d9c28416251dd5ce9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->