### PR TITLE
feat(procfs): 添加/proc/<pid>/ns/目录支持及cgroup命名空间实现

### DIFF
--- a/kernel/src/filesystem/procfs/proc_thread_self_ns.rs
+++ b/kernel/src/filesystem/procfs/proc_thread_self_ns.rs
@@ -6,6 +6,8 @@
 //! In Linux, these files are typically symlinks that point to strings like "ipc:[4026531839]",
 //! where the number is a namespace ID. Opening these files returns a file descriptor
 //! that can be used to reference the namespace.
+//!
+//! Reference: https://man7.org/linux/man-pages/man7/namespaces.7.html
 
 use core::convert::TryFrom;
 
@@ -14,11 +16,75 @@ use alloc::string::String;
 use system_error::SystemError;
 
 use crate::process::{
+    fork::CloneFlags,
     namespace::{nsproxy::NamespaceId, NamespaceOps},
-    ProcessManager,
+    ProcessManager, RawPid,
 };
 
 use super::ProcfsFilePrivateData;
+
+// ============================================================================
+// Namespace ioctl commands (Linux nsfs.h)
+// ============================================================================
+
+/// Namespace ioctl command definitions.
+///
+/// These commands are used with ioctl() on namespace file descriptors
+/// obtained by opening /proc/[pid]/ns/* files.
+///
+/// The magic number 0xb7 is defined in Linux's include/uapi/linux/nsfs.h
+/// Command format: _IO(0xb7, N) = (0xb7 << 8) | N
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+pub enum NsIoctlCmd {
+    /// Get a file descriptor for the owning user namespace.
+    /// Returns a new fd referring to the user namespace that owns
+    /// the namespace referred to by the fd on which ioctl() is performed.
+    GetUserns,
+
+    /// Get a file descriptor for the parent namespace.
+    /// Only valid for hierarchical namespace types (PID, user).
+    /// Returns EINVAL for non-hierarchical namespaces.
+    GetParent,
+
+    /// Get the namespace type.
+    /// Returns the CLONE_NEW* flag value that identifies the namespace type.
+    GetNstype,
+
+    /// Get the owner UID of a user namespace.
+    /// Only valid for user namespaces.
+    /// Returns EINVAL for other namespace types.
+    GetOwnerUid,
+}
+
+impl From<NsIoctlCmd> for u32 {
+    fn from(cmd: NsIoctlCmd) -> Self {
+        match cmd {
+            NsIoctlCmd::GetUserns => 0xb701,
+            NsIoctlCmd::GetParent => 0xb702,
+            NsIoctlCmd::GetNstype => 0xb703,
+            NsIoctlCmd::GetOwnerUid => 0xb704,
+        }
+    }
+}
+
+impl TryFrom<u32> for NsIoctlCmd {
+    type Error = SystemError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0xb701 => Ok(NsIoctlCmd::GetUserns),
+            0xb702 => Ok(NsIoctlCmd::GetParent),
+            0xb703 => Ok(NsIoctlCmd::GetNstype),
+            0xb704 => Ok(NsIoctlCmd::GetOwnerUid),
+            _ => Err(SystemError::ENOTTY),
+        }
+    }
+}
+
+// ============================================================================
+// Namespace file types
+// ============================================================================
 
 /// Namespace file types for /proc/thread-self/ns/
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -48,6 +114,7 @@ impl ThreadSelfNsFileType {
         Self::User.name(),
         Self::Cgroup.name(),
     ];
+
     /// Get the namespace type name (e.g., "ipc", "uts")
     pub const fn name(&self) -> &'static str {
         match self {
@@ -62,6 +129,40 @@ impl ThreadSelfNsFileType {
             ThreadSelfNsFileType::User => "user",
             ThreadSelfNsFileType::Cgroup => "cgroup",
         }
+    }
+
+    /// Get the CLONE_NEW* flag corresponding to this namespace type.
+    ///
+    /// This is used by NS_GET_NSTYPE ioctl to return the namespace type.
+    pub const fn clone_flag(&self) -> CloneFlags {
+        match self {
+            ThreadSelfNsFileType::Ipc => CloneFlags::CLONE_NEWIPC,
+            ThreadSelfNsFileType::Uts => CloneFlags::CLONE_NEWUTS,
+            ThreadSelfNsFileType::Mnt => CloneFlags::CLONE_NEWNS,
+            ThreadSelfNsFileType::Net => CloneFlags::CLONE_NEWNET,
+            ThreadSelfNsFileType::Pid | ThreadSelfNsFileType::PidForChildren => {
+                CloneFlags::CLONE_NEWPID
+            }
+            ThreadSelfNsFileType::Time | ThreadSelfNsFileType::TimeForChildren => {
+                CloneFlags::CLONE_NEWTIME
+            }
+            ThreadSelfNsFileType::User => CloneFlags::CLONE_NEWUSER,
+            ThreadSelfNsFileType::Cgroup => CloneFlags::CLONE_NEWCGROUP,
+        }
+    }
+
+    /// Check if this namespace type supports NS_GET_PARENT ioctl.
+    ///
+    /// Only hierarchical namespace types (PID, user) support get_parent.
+    /// Cgroup, network, mount, IPC, UTS namespaces are not hierarchical
+    /// in the sense that NS_GET_PARENT would return a parent.
+    pub const fn supports_get_parent(&self) -> bool {
+        matches!(
+            self,
+            ThreadSelfNsFileType::Pid
+                | ThreadSelfNsFileType::PidForChildren
+                | ThreadSelfNsFileType::User
+        )
     }
 }
 
@@ -135,8 +236,9 @@ pub fn current_thread_self_ns_ino(ns_type: ThreadSelfNsFileType) -> usize {
             ns.ns_common().nsid
         }
         ThreadSelfNsFileType::Cgroup => {
-            // Cgroup namespace is not yet implemented
-            NamespaceId::new(0)
+            // Cgroup namespace
+            let ns = nsproxy.cgroup_ns.clone();
+            ns.ns_common().nsid
         }
     };
 
@@ -180,4 +282,153 @@ pub fn read_thread_self_ns_link(
     let len = buf.len().min(target_bytes.len() - offset);
     buf[..len].copy_from_slice(&target_bytes[offset..offset + len]);
     Ok(len)
+}
+
+// ============================================================================
+// PID-specific namespace file functions (for /proc/<pid>/ns/)
+// ============================================================================
+
+/// Get namespace "inode number" (nsid) for a specific PID.
+///
+/// Similar to `current_thread_self_ns_ino` but for a specific process.
+/// Returns ESRCH if the process doesn't exist.
+#[inline(never)]
+pub fn pid_ns_ino(pid: RawPid, ns_type: ThreadSelfNsFileType) -> Result<usize, SystemError> {
+    let pcb = ProcessManager::find_task_by_vpid(pid).ok_or(SystemError::ESRCH)?;
+    let nsproxy = pcb.nsproxy();
+
+    let ino = match ns_type {
+        ThreadSelfNsFileType::Ipc => nsproxy.ipc_ns.ns_common().nsid,
+        ThreadSelfNsFileType::Uts => nsproxy.uts_ns.ns_common().nsid,
+        ThreadSelfNsFileType::Mnt => nsproxy.mnt_ns.ns_common().nsid,
+        ThreadSelfNsFileType::Net => nsproxy.net_ns.ns_common().nsid,
+        ThreadSelfNsFileType::Pid => pcb.active_pid_ns().ns_common().nsid,
+        ThreadSelfNsFileType::PidForChildren => nsproxy.pid_ns_for_children.ns_common().nsid,
+        ThreadSelfNsFileType::Time | ThreadSelfNsFileType::TimeForChildren => {
+            // Time namespace is not yet implemented
+            NamespaceId::new(0)
+        }
+        ThreadSelfNsFileType::User => pcb.cred().user_ns.ns_common().nsid,
+        ThreadSelfNsFileType::Cgroup => nsproxy.cgroup_ns.ns_common().nsid,
+    };
+
+    Ok(ino.data())
+}
+
+/// Generate namespace ID string for a specific PID in the format "namespace_type:[id]"
+fn generate_pid_namespace_id(
+    pid: RawPid,
+    ns_type: ThreadSelfNsFileType,
+) -> Result<String, SystemError> {
+    let ino = pid_ns_ino(pid, ns_type)?;
+    Ok(format!("{}:[{}]", ns_type.name(), ino))
+}
+
+/// Open a namespace file for a specific PID (returns the target length)
+#[inline(never)]
+pub fn open_pid_ns_file(
+    pid: RawPid,
+    ns_type: ThreadSelfNsFileType,
+    _pdata: &mut ProcfsFilePrivateData,
+) -> Result<i64, SystemError> {
+    let target = generate_pid_namespace_id(pid, ns_type)?;
+    Ok(target.len() as i64)
+}
+
+/// Read a namespace symlink target for a specific PID
+#[inline(never)]
+pub fn read_pid_ns_link(
+    pid: RawPid,
+    ns_type: ThreadSelfNsFileType,
+    buf: &mut [u8],
+    offset: usize,
+) -> Result<usize, SystemError> {
+    let target = generate_pid_namespace_id(pid, ns_type)?;
+    let target_bytes = target.as_bytes();
+
+    if offset >= target_bytes.len() {
+        return Ok(0);
+    }
+
+    let len = buf.len().min(target_bytes.len() - offset);
+    buf[..len].copy_from_slice(&target_bytes[offset..offset + len]);
+    Ok(len)
+}
+
+// ============================================================================
+// Namespace file ioctl handling
+// ============================================================================
+
+/// Handle ioctl operations for /proc/[pid]/ns/* files.
+///
+/// This function processes namespace-specific ioctl commands as defined
+/// in Linux's nsfs.h. Only namespace files under /proc should call this.
+///
+/// # Arguments
+/// * `ns_type` - The type of namespace file being operated on
+/// * `cmd` - The ioctl command (NS_GET_NSTYPE, NS_GET_USERNS, etc.)
+/// * `_data` - Additional data for the ioctl (unused for current commands)
+///
+/// # Returns
+/// * `Ok(usize)` - Command-specific return value
+/// * `Err(SystemError)` - Error if command fails or is unsupported
+///
+/// # Supported Commands
+/// * `NS_GET_NSTYPE` - Returns the CLONE_NEW* flag for this namespace type
+/// * `NS_GET_USERNS` - Returns fd to owning user namespace (not yet implemented)
+/// * `NS_GET_PARENT` - Returns fd to parent namespace (only for hierarchical ns)
+#[inline(never)]
+pub fn ns_file_ioctl(
+    ns_type: ThreadSelfNsFileType,
+    cmd: u32,
+    _data: usize,
+) -> Result<usize, SystemError> {
+    let cmd = NsIoctlCmd::try_from(cmd)?;
+
+    match cmd {
+        NsIoctlCmd::GetNstype => {
+            // Return the namespace type as CLONE_NEW* flag value
+            Ok(ns_type.clone_flag().bits() as usize)
+        }
+
+        NsIoctlCmd::GetUserns => {
+            // TODO: Return fd to owning user namespace
+            // This requires:
+            // 1. Getting the user namespace that owns this namespace
+            // 2. Creating a new file descriptor pointing to that user namespace
+            // 3. Installing the fd in the current process's fd table
+            //
+            // For now, return ENOSYS as this is not yet fully implemented.
+            // This is acceptable for most container runtimes which primarily
+            // need NS_GET_NSTYPE.
+            Err(SystemError::ENOSYS)
+        }
+
+        NsIoctlCmd::GetParent => {
+            // Only hierarchical namespace types support get_parent
+            if !ns_type.supports_get_parent() {
+                return Err(SystemError::EINVAL);
+            }
+
+            // TODO: Return fd to parent namespace
+            // This requires similar work as NS_GET_USERNS:
+            // 1. Getting the parent namespace
+            // 2. Creating a new file descriptor
+            // 3. Installing the fd
+            //
+            // For now, return ENOSYS
+            Err(SystemError::ENOSYS)
+        }
+
+        NsIoctlCmd::GetOwnerUid => {
+            // Only valid for user namespaces
+            if ns_type != ThreadSelfNsFileType::User {
+                return Err(SystemError::EINVAL);
+            }
+
+            // TODO: Return the owner UID of the user namespace
+            // This requires writing the UID to the user-provided buffer at _data
+            Err(SystemError::ENOSYS)
+        }
+    }
 }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -32,9 +32,9 @@ use crate::{
     process::{
         cred::Cred,
         namespace::{
-            ipc_namespace::IpcNamespace, mnt::MntNamespace, net_namespace::NetNamespace,
-            pid_namespace::PidNamespace, user_namespace::UserNamespace,
-            uts_namespace::UtsNamespace,
+            cgroup_namespace::CgroupNamespace, ipc_namespace::IpcNamespace, mnt::MntNamespace,
+            net_namespace::NetNamespace, pid_namespace::PidNamespace,
+            user_namespace::UserNamespace, uts_namespace::UtsNamespace,
         },
         resource::RLimitID,
         ProcessControlBlock, ProcessManager, RawPid,
@@ -76,7 +76,9 @@ pub enum NamespaceFilePrivateData {
     /// PID namespace for children.
     PidForChildren(Arc<PidNamespace>),
     User(Arc<UserNamespace>),
-    // Time/cgroup namespaces are not implemented yet.
+    /// Cgroup namespace.
+    Cgroup(Arc<CgroupNamespace>),
+    // Time namespace is not implemented yet.
 }
 
 impl fmt::Debug for NamespaceFilePrivateData {
@@ -91,6 +93,9 @@ impl fmt::Debug for NamespaceFilePrivateData {
                 f.write_str("NamespaceFilePrivateData::PidForChildren(..)")
             }
             NamespaceFilePrivateData::User(_) => f.write_str("NamespaceFilePrivateData::User(..)"),
+            NamespaceFilePrivateData::Cgroup(_) => {
+                f.write_str("NamespaceFilePrivateData::Cgroup(..)")
+            }
         }
     }
 }

--- a/kernel/src/process/namespace/cgroup_namespace.rs
+++ b/kernel/src/process/namespace/cgroup_namespace.rs
@@ -1,0 +1,150 @@
+//! Cgroup Namespace Implementation
+//!
+//! This module provides cgroup namespace support for process isolation.
+//! Currently implemented as a bypass/stub to allow container runtimes (like runcell)
+//! to function, with extensibility for future full cgroup implementation.
+//!
+//! In Linux, cgroup namespaces virtualize the view of a process's cgroups.
+//! When a process creates a new cgroup namespace, its current cgroups directories
+//! become the cgroup root directories of the new namespace.
+//!
+//! Reference: https://man7.org/linux/man-pages/man7/cgroup_namespaces.7.html
+
+use alloc::sync::{Arc, Weak};
+use system_error::SystemError;
+
+use crate::process::fork::CloneFlags;
+use crate::process::namespace::nsproxy::NsCommon;
+use crate::process::namespace::user_namespace::INIT_USER_NAMESPACE;
+use crate::process::namespace::{NamespaceOps, NamespaceType};
+
+use super::user_namespace::UserNamespace;
+
+lazy_static! {
+    /// Initial cgroup namespace for the root process.
+    /// All processes start in this namespace unless they create a new one.
+    pub static ref INIT_CGROUP_NAMESPACE: Arc<CgroupNamespace> = CgroupNamespace::new_root();
+}
+
+/// Cgroup Namespace structure.
+///
+/// This provides isolation for the cgroup filesystem view.
+/// Currently implemented as a stub for bypass purposes, but designed
+/// for extensibility when full cgroup support is added.
+///
+/// Future extensions should add:
+/// - `root_cset`: CSS set representing the root cgroup in this namespace
+/// - Integration with actual cgroup controllers
+pub struct CgroupNamespace {
+    /// Common namespace fields (level, type, nsid)
+    ns_common: NsCommon,
+
+    /// Self reference for Arc::new_cyclic pattern
+    self_ref: Weak<CgroupNamespace>,
+
+    /// Associated user namespace for permission checks.
+    /// Required for CAP_SYS_ADMIN validation when creating/joining namespaces.
+    user_ns: Arc<UserNamespace>,
+    // Future fields for full cgroup implementation:
+    // /// Root CSS set for this namespace
+    // root_cset: Option<Arc<CssSet>>,
+}
+
+impl NamespaceOps for CgroupNamespace {
+    fn ns_common(&self) -> &NsCommon {
+        &self.ns_common
+    }
+}
+
+impl CgroupNamespace {
+    /// Create the root (initial) cgroup namespace.
+    /// This is used for the init process and serves as the ancestor
+    /// of all other cgroup namespaces.
+    fn new_root() -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
+            ns_common: NsCommon::new(0, NamespaceType::Cgroup),
+            self_ref: weak_self.clone(),
+            user_ns: INIT_USER_NAMESPACE.clone(),
+        })
+    }
+
+    /// Copy/create a cgroup namespace based on clone flags.
+    ///
+    /// If CLONE_NEWCGROUP is set, creates a new cgroup namespace.
+    /// Otherwise, returns a reference to the current namespace.
+    ///
+    /// # Arguments
+    /// * `clone_flags` - Clone flags indicating whether to create new namespace
+    /// * `user_ns` - User namespace for permission checks
+    ///
+    /// # Returns
+    /// * `Ok(Arc<CgroupNamespace>)` - The (possibly new) cgroup namespace
+    /// * `Err(SystemError)` - If namespace creation fails
+    ///
+    /// Reference: https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/cgroup/namespace.c#50
+    pub fn copy_cgroup_ns(
+        &self,
+        clone_flags: &CloneFlags,
+        user_ns: Arc<UserNamespace>,
+    ) -> Result<Arc<CgroupNamespace>, SystemError> {
+        // If CLONE_NEWCGROUP is not set, share the parent's namespace
+        if !clone_flags.contains(CloneFlags::CLONE_NEWCGROUP) {
+            return Ok(self.self_ref.upgrade().unwrap());
+        }
+
+        // Create a new cgroup namespace
+        // In Linux, this would:
+        // 1. Check CAP_SYS_ADMIN capability
+        // 2. Get current process's css_set as the root
+        // 3. Allocate new namespace structure
+        //
+        // For now, we create a stub namespace that allows container
+        // runtimes to function while maintaining the interface for
+        // future full implementation.
+
+        // TODO: Add capability check when capability system is more complete
+        // if !ns_capable(user_ns, CAP_SYS_ADMIN) {
+        //     return Err(SystemError::EPERM);
+        // }
+
+        let new_ns = Arc::new_cyclic(|weak_self| CgroupNamespace {
+            ns_common: NsCommon::new(self.ns_common.level + 1, NamespaceType::Cgroup),
+            self_ref: weak_self.clone(),
+            user_ns,
+        });
+
+        Ok(new_ns)
+    }
+
+    /// Get the owning user namespace.
+    /// Used for permission checks in setns operations.
+    pub fn user_ns(&self) -> &Arc<UserNamespace> {
+        &self.user_ns
+    }
+
+    /// Get the namespace level (depth in hierarchy).
+    /// Root namespace has level 0.
+    pub fn level(&self) -> u32 {
+        self.ns_common.level
+    }
+}
+
+// Implement Send and Sync for CgroupNamespace
+// This is safe because:
+// - NsCommon contains only primitive types and Arc
+// - Weak<CgroupNamespace> is Send + Sync
+// - Arc<UserNamespace> is Send + Sync
+unsafe impl Send for CgroupNamespace {}
+unsafe impl Sync for CgroupNamespace {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_cgroup_namespace() {
+        let ns = INIT_CGROUP_NAMESPACE.clone();
+        assert_eq!(ns.level(), 0);
+        assert_eq!(ns.ns_common().ty(), NamespaceType::Cgroup);
+    }
+}

--- a/kernel/src/process/namespace/mod.rs
+++ b/kernel/src/process/namespace/mod.rs
@@ -1,3 +1,4 @@
+pub mod cgroup_namespace;
 pub mod ipc_namespace;
 pub mod mnt;
 pub mod net_namespace;


### PR DESCRIPTION
- 新增/proc/<pid>/ns/目录，支持动态创建命名空间文件
- 实现cgroup命名空间基础结构，支持CLONE_NEWCGROUP标志
- 为命名空间文件添加ioctl支持（NS_GET_NSTYPE等命令）
- 扩展setns系统调用以支持cgroup命名空间切换