### PR TITLE
fix(process): 修复子进程退出时父进程唤醒逻辑

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -409,24 +409,27 @@ impl ProcessManager {
                         e
                     );
                 }
-                // 额外唤醒：父进程可能阻塞在 wait 系列调用上
-                parent_pcb
-                    .wait_queue
-                    .wakeup_all(Some(ProcessState::Blocked(true)));
+            }
 
-                // 根据 Linux wait 语义，线程组中的任何线程都可以等待同一线程组中任何线程创建的子进程。
-                // 由于子进程被添加到线程组 leader 的 children 列表中，
-                // 因此还需要唤醒线程组 leader 的 wait_queue（如果 leader 不是 parent_pcb 本身）。
-                let parent_group_leader = {
-                    let ti = parent_pcb.thread.read_irqsave();
-                    ti.group_leader()
-                };
-                if let Some(leader) = parent_group_leader {
-                    if !Arc::ptr_eq(&leader, &parent_pcb) {
-                        leader
-                            .wait_queue
-                            .wakeup_all(Some(ProcessState::Blocked(true)));
-                    }
+            // 无论exit_signal是什么值，都要唤醒父进程的wait_queue
+            // 因为父进程可能使用__WALL选项等待任何类型的子进程（包括exit_signal=0的clone子进程）
+            // 根据Linux语义，exit_signal只决定发送什么信号，不决定是否唤醒父进程
+            parent_pcb
+                .wait_queue
+                .wakeup_all(Some(ProcessState::Blocked(true)));
+
+            // 根据 Linux wait 语义，线程组中的任何线程都可以等待同一线程组中任何线程创建的子进程。
+            // 由于子进程被添加到线程组 leader 的 children 列表中，
+            // 因此还需要唤醒线程组 leader 的 wait_queue（如果 leader 不是 parent_pcb 本身）。
+            let parent_group_leader = {
+                let ti = parent_pcb.thread.read_irqsave();
+                ti.group_leader()
+            };
+            if let Some(leader) = parent_group_leader {
+                if !Arc::ptr_eq(&leader, &parent_pcb) {
+                    leader
+                        .wait_queue
+                        .wakeup_all(Some(ProcessState::Blocked(true)));
                 }
             }
             // todo: 这里还需要根据线程组的信息，决定信号的发送


### PR DESCRIPTION
- 修正父进程唤醒条件，确保无论exit_signal为何值都唤醒父进程
- 修复线程组leader唤醒逻辑的位置错误


解决wait_test里面`Waiters/WaitSpecificChildTest.WALL/0`概率性的超时1min都没返回的问题