### PR TITLE
chore: cleanup duplicate another_ext4 entry in Cargo.lock

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -57,14 +57,6 @@ dependencies = [
 [[package]]
 name = "another_ext4"
 version = "0.1.0"
-dependencies = [
- "bitflags 2.9.1",
- "log",
-]
-
-[[package]]
-name = "another_ext4"
-version = "0.1.0"
 source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/another_ext4.git?rev=8bc384254c#8bc384254c7b7464afcdc312fb0c0aa622e2467e"
 dependencies = [
  "bitflags 2.9.1",
@@ -771,7 +763,7 @@ version = "0.1.0"
 name = "kdepends"
 version = "0.1.0"
 dependencies = [
- "another_ext4 0.1.0 (git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/another_ext4.git?rev=8bc384254c)",
+ "another_ext4",
  "crc",
  "memoffset",
  "ringbuffer",


### PR DESCRIPTION
修复 Cargo.lock 中 another_ext4 包的重复条目问题。新版本的 Cargo
会自动清理这种重复条目并使用简化的依赖引用格式，这个提交统一了
lockfile 格式，避免不同开发者使用不同 Cargo 版本时产生冲突。