### PR TITLE
docs: 新增发布助手能力说明文档和V0.4.0发行日志

### DIFF
--- a/docs/agents/release_agent_capability.md
+++ b/docs/agents/release_agent_capability.md
@@ -1,0 +1,123 @@
+# DragonOS 发布助手能力说明（可复用模版）
+
+面向未来版本发布的通用“发布助手”能力，帮助 Agent 自动调研自上个 Tag 以来的变更并产出可直接使用的发行日志。
+
+---
+
+## 目标
+- 自动收集 `<PREV_TAG>..HEAD` 的提交，按模块分类梳理。
+- 生成结构化发行日志（核心亮点 / 版本概览 / 详细变更 / 已知关注点 / 致谢）。
+- 更新 ChangeLog 索引，准备好后续推文的要点。
+
+## 输入
+- 上一版本 Tag（例：`V0.3.0`）。如无 Tag，则需要明确基线提交。
+- 目标版本号（例：`0.4.0`）和发布日期。
+
+## 输出
+- 提交快照：`dragonos_<VER>_commits_formatted.txt`、`dragonos_<VER>_commits_oneline.txt`
+- 发行日志：`docs/community/ChangeLog/V0.<X>.x/V0.<X>.0.md`
+- ChangeLog 索引更新：`docs/community/ChangeLog/index.rst`
+- （可选）推文要点草稿
+
+## 路径约定
+- 发行日志目录：`docs/community/ChangeLog/V0.<X>.x/`
+- 新增条目在 `index.rst` 的 toctree 中追加：
+  ```
+  V0.<X>.x/V0.<X>.0
+  ```
+
+## 工作流步骤
+1) 确定基线  
+   - `PREV_TAG=$(git tag | sort -V | grep -E "0\\.3\\.0|V0\\.3\\.0" | tail -1)`（示例）  
+   - 差分范围：`$PREV_TAG..HEAD`
+
+2) 导出提交  
+   ```
+   git log $PREV_TAG..HEAD --no-merges \
+     --format="%H%nAuthor: %an <%ae>%nDate: %ad%nSubject: %s%n%n%b%n---" \
+     > ./dragonos_<VER>_commits_formatted.txt
+
+   git log $PREV_TAG..HEAD --no-merges --oneline \
+     > ./dragonos_<VER>_commits_oneline.txt
+   ```
+   - 保存在仓库根目录，便于复查和附录。
+
+3) 分类梳理（关键词/目录双管）  
+   - I/O 多路复用/时间：`pselect|poll|epoll|timer|clock|nanosleep`  
+   - 文件系统/VFS：`tmpfs|ext4|fat|vfs|symlink|truncate|preadv|pwritev|fadvise|copy_file_range|creat|umask`  
+   - procfs/观测性：`/proc|stat|cmdline|maps|ns|printk`  
+   - 进程/信号/执行：`exec|fork|wait|shebang|sig|rt_|tgkill|setresuid`  
+   - 内存/页面：`slab|page_cache|mmap|reclaim|user_access|iovec`  
+   - IPC/管道：`pipe|fifo|F_GETPIPE_SZ|F_SETPIPE_SZ`  
+   - 网络/设备：`napi|udp|tty|ptmx|random`  
+   - 工程/CI：`ci|workflow|container|devcontainer|build container|nightly`  
+   - 文档/社区：`docs|README|Playground|translation`  
+   - 测试/gVisor：`gvisor|whitelist|blocklist`
+
+4) 生成发行日志草稿（套用当前 0.4.0 结构）  
+   - 章节：核心亮点 → 版本概览 → 详细变更（分模块） → 已知关注点 → 贡献者鸣谢 → 参考资料  
+   - 详细变更按上一步的分类填充，每条写“做了什么 + 为什么重要/影响”，附 PR/提交号。
+
+5) 更新索引  
+   - 在 `docs/community/ChangeLog/index.rst` toctree 中追加新版本路径。
+
+6) 版本号与对外可见信息检查  
+   - DragonOS 版本源：`kernel/Cargo.toml` 的 `version`（影响 uname / /proc/version / about）。  
+   - 构建脚本：`build-scripts/kernel_build/src/version_gen.rs` 自动生成 `kernel/src/init/version_info.rs`。  
+   - 校验：构建后在系统内执行 `uname -a`、`cat /proc/version`、`about`，确认 `dragonos-<VER>`。
+
+7) 验证与质量  
+   - 格式/静态检查：`make fmt`（或 `read_lints`）。  
+   - 编译：`make kernel`。  
+   - 重点回归：I/O 多路复用+信号；tmpfs/chroot/mount 传播；等待队列；POSIX timer/CPU time；gVisor 用例。
+
+8) 推文要点（可选）  
+   - 从“核心亮点”和“详细变更”摘取 3–5 条能力/场景化描述，避免罗列 commit。
+
+## 发行日志写作要点（缩略模板）
+```
+# V0.<X>.0
+> 发布日期: YYYY-MM-DD
+
+## 核心亮点
+- 3–6 条面向用户/场景的升级点
+
+## 版本概览
+- 按模块列一行概览（I/O、时间、文件系统、procfs、进程/信号、内存、IPC、网络、工程、文档/社区、gVisor…）
+
+## 详细变更
+- 模块 A：若干条（含 PR/提交号）
+- 模块 B：…
+
+## 已知关注点
+- 升级/测试建议与潜在风险
+
+## 贡献者鸣谢
+- 可列主要作者，或指向 Contributors 页面
+
+## 参考资料
+- CI Dashboard / Playground / Repo / Docs 等链接
+```
+
+## 快速命令汇总（示例）
+```
+PREV_TAG=V0.3.0
+VER=0.4.0
+
+git log $PREV_TAG..HEAD --no-merges \
+  --format="%H%nAuthor: %an <%ae>%nDate: %ad%nSubject: %s%n%n%b%n---" \
+  > ./dragonos_${VER}_commits_formatted.txt
+
+git log $PREV_TAG..HEAD --no-merges --oneline \
+  > ./dragonos_${VER}_commits_oneline.txt
+```
+
+## 最小执行清单（复用时照抄即可）
+1. 确认 PREV_TAG → 导出提交文件（formatted/oneline）。
+2. 按关键词/目录分类，形成“模块 → 要点 + PR号”表。
+3. 套模板写 `docs/community/ChangeLog/V0.<X>.x/V0.<X>.0.md`。
+4. 更新 `docs/community/ChangeLog/index.rst` toctree。
+5. 若发布：`kernel/Cargo.toml` 版本改为 `<VER>` → `make kernel` → 运行时用 `uname /proc/about` 校验。
+6. 跑必要的 fmt/编译/回归测试。
+
+

--- a/docs/community/ChangeLog/V0.4.x/V0.4.0.md
+++ b/docs/community/ChangeLog/V0.4.x/V0.4.0.md
@@ -1,0 +1,754 @@
+# V0.4.0
+
+> 前言：本次版本聚焦“Linux 语义对齐 + 工程可用性”。I/O 多路复用、POSIX 定时器/CPU 时间、文件系统与 procfs 获得大幅补强；tmpfs、mount 传播、等待队列重构等为容器/云原生场景铺路；CI/夜构与 Playground 让体验和回归更顺畅。
+
+> 发布日期: 2025-12-22
+
+## 核心亮点
+
+### I/O 多路复用与时间语义：向 Linux 6.6 对齐
+
+- **poll/pselect6 系统调用完善**：修复信号掩码恢复逻辑，优化 `pselect6` 实现，正确处理 sigmask 参数和 timeout 验证，移除零超时提前返回的逻辑，确保在等待 I/O 时正确保存和恢复信号掩码 (#1531)
+- **epoll 事件处理增强**：正确处理普通文件的 epoll 事件，避免添加不必要的 epitem；修复 epoll 超时唤醒机制，确保定时器通过 Waker 唤醒等待队列；改进 poll_select_finish 函数以支持更多时间类型 (#1528, #1492)
+- **POSIX interval timer 完整实现**：实现 timer_create、timer_settime、timer_gettime、timer_getoverrun、timer_delete 系统调用，支持 SIGEV_NONE/SIGEV_SIGNAL/SIGEV_THREAD_ID 信号投递模式，修复 gVisor timers_test (#1501, #1521)
+- **进程与线程 CPU 时间统计**：实现 ProcessCpuTime 结构体，支持用户态、内核态及总执行时间统计；为 PCB 添加 cputime_wait_queue，支持 CLOCK_PROCESS/THREAD_CPUTIME_ID 的 clock_nanosleep；扩展 clock_gettime 和 clock_nanosleep 系统调用支持进程和线程 CPU 时间时钟 (#1517)
+- **POSIX 调度系统调用**：实现 sched_getparam、sched_getscheduler 系统调用，重构 sched_yield 到独立模块 (#1416)
+
+### 文件系统与 VFS：功能扩展与稳定性提升
+
+- **tmpfs 文件系统支持**：新增 tmpfs 支持并与 devfs 集成，提供内存文件系统能力；实现原子大小管理、零页创建、页缓存管理等功能；支持 /dev/shm 挂载，完善 chroot 和挂载传播机制 (#1459, #1480, #1410)
+- **新系统调用实现**：
+  - `copy_file_range`：实现高效的文件范围复制系统调用 (#1513)
+  - `creat`：新增 creat 系统调用支持，遵循 Linux 语义（创建新文件或截断现有文件并打开为只写模式）(#1482)
+  - `preadv2/pwritev2`：实现带偏移量和标志位的向量化 I/O 系统调用，支持 RWF 标志位验证 (#1451, #1461)
+  - `fadvise64`：实现文件访问建议系统调用，支持页面缓存范围写回和驱逐，改进预读机制支持随机访问模式 (#1439)
+  - `umask`：实现 umask 系统调用，改进权限处理，设置默认 umask 为 0022 (#1500, #1419)
+- **文件操作改进**：
+  - 修复 truncate 系统调用的页缓存截断逻辑，修复边界条件，添加长度检查 (#1444)
+  - 增强符号链接处理，将最大符号链接跟随次数提升至 40（符合 Linux 6.6 标准），改进 VFS 行为 (#1507)
+  - 修复 symlinkat 中父目录路径为 None 时的处理逻辑 (#1512)
+  - 修复 sys_rename 逻辑并支持 RENAME_NOREPLACE 标志 (#1393)
+  - 修复 pread64 系统调用的兼容性和错误处理，验证 offset 参数和用户缓冲区 (#1398)
+- **append 锁机制**：实现文件追加操作的锁管理器，使用 jhash 算法保障并发写入的正确性，支持强制追加语义 (#1483)
+- **EventFd 文件系统**：实现 EventFd 文件系统并增强 VFS inode 能力，支持事件通知机制；为 IndexNode trait 添加 is_stream、supports_seek、supports_pread、supports_pwrite 方法 (#1486)
+- **文件系统标志重构**：重构文件系统标志体系，区分打开标志与访问模式，提升代码清晰度 (#1414)
+- **路径检查统一**：统一使用 vfs_check_and_clone_cstr 函数进行路径检查，减少代码重复 (#1481)
+- **文件预读功能**：添加文件预读功能支持，新增 readahead 模块实现文件预读算法，提升顺序读取性能 (#1391)
+- **挂载传播机制**：实现挂载传播机制，支持 Shared、Private、Slave、Unbindable 传播类型，实现递归绑定挂载支持 (#1410)
+
+### procfs 与系统信息：可观测性大幅提升
+
+- **进程信息文件完善**：
+  - `/proc/<pid>/stat`：提供进程状态信息，支持 BusyBox ps/pstree/top 等工具 (#1490)
+  - `/proc/<pid>/task`：实现线程目录结构，支持主线程 tid=pid 的展示 (#1490)
+  - `/proc/<pid>/cmdline` 和 `/proc/cmdline`：提供进程和内核命令行参数 (#1489)
+  - `/proc/<pid>/maps`：提供进程内存映射信息，改进缺页异常处理 (#1468)
+  - `/proc/<pid>/statm`：提供进程内存统计信息 (#1455)
+- **命名空间支持**：
+  - `/proc/<pid>/ns/` 目录：支持动态创建命名空间文件，实现 cgroup 命名空间基础结构 (#1515)
+  - `/proc/thread-self/ns`：支持查看线程的命名空间，实现 setns 系统调用用于命名空间管理 (#1412, #1515)
+  - 修复命名空间文件创建时的竞态条件 (#1413)
+- **内核日志管理**：实现内核日志级别管理和 procfs 接口（/proc/sys/kernel/printk），支持动态调整日志级别 (#1415)
+- **文件描述符信息**：在 procfs 中新增文件描述符相关支持，支持 /proc/self/fd/N 魔法链接，实现管道 FIONREAD ioctl 命令，添加 /proc/<pid>/fdinfo 目录支持 (#1426)
+
+### 进程管理与执行：更接近 Linux 行为
+
+- **shebang 脚本支持**：添加 shebang 脚本执行支持，实现脚本解析和递归执行，可直接运行脚本文件，支持多种解释器 (#1511)
+- **进程等待语义修复**：
+  - 修复线程组中子进程的等待语义 (#1427)
+  - 修复子进程退出时父进程唤醒逻辑，确保无论 exit_signal 为何值都唤醒父进程 (#1516)
+- **进程执行改进**：
+  - 修复 sys_exec 相关测试，修复 execve 系统调用中空路径和空参数处理问题 (#1518)
+  - 改进 execve 和 execveat 系统调用的实现，增强执行文件权限检查与信号处理
+  - 实现 fd_table 在 execve 进程中的 unsharing，确保隔离性
+  - 改进路径解析逻辑，修复 shebang 解释器未找到时的错误日志
+- **信号处理增强**：
+  - 修正 POSIX 定时器信号投递逻辑，支持 SIGEV_THREAD 模式，放宽 SIGEV_THREAD_ID 限制 (#1521)
+  - 修复信号忽略逻辑，实现信号忽略检查逻辑 (#1434)
+  - 实现增强的信号处理和 IPC 机制，添加 rt_sigqueueinfo 和 rt_tgsigqueueinfo 系统调用 (#1423)
+  - 修复 kill 进程组的 bug (#1424)
+  - 修复 sys_rt_sigtimedwait 和 sys_rt_sigreturn 相关问题 (#1406, #1394, #1400)
+
+### 内存管理与 I/O：性能与稳定性优化
+
+- **用户空间内存访问修复**：
+  - 修复 IoVecs 构造时对零长度缓冲区的验证，确保符合 Linux 语义
+  - 修复 scatter 方法在遇到不可访问内存时的错误处理，避免部分写入后返回错误
+  - 修复 readv/preadv 等系统调用，使其支持分块读取和部分成功写入
+  - 修复页面回收逻辑，避免回收仍被映射的文件页
+  - 修复 UserBufferReader/Writer 对空指针的检查，防止未定义行为
+  - 优化 IoVecs 的用户空间内存访问检查与拷贝逻辑，统一使用 user_accessible_len 进行访问性验证 (#1522)
+- **块缓存增强**：增强 CacheBlock 和 BlockCache 功能，添加 from_slice 和 write_data 方法，改进 insert_one_block 和 immediate_write 方法接受切片而非向量，修复 FileMapInfo::page_cache 的内存泄漏问题（改为 Weak<PageCache>）(#1465)
+- **页面缓存改进**：
+  - 修复 truncate 时的页缓存截断，修复边界条件 (#1444)
+  - 改进页面缓存管理，重构页缓存读写以解决死锁问题 (#1455)
+- **内存管理优化**：
+  - 修复 slab 分配器迭代器越界访问和并发安全问题，将 SLABALLOCATOR 改为 SpinLock 保护 (#1464)
+  - 修复异常表安全拷贝的错误处理返回值 (#1395)
+  - 优化页面回收过程，分离为两阶段以避免死锁 (#1455)
+- **mmap 支持增强**：为多个文件系统节点实现 mmap 方法，改进 mmap 错误处理和验证，增强内存保护处理和验证 (#1455)
+
+### IPC 与管道：阻塞语义与竞态修复
+
+- **FIFO 阻塞打开语义**：实现 FIFO 的阻塞打开语义，为 LockedPipeInode 添加 open_wait_queue 用于 FIFO 打开时的阻塞等待，实现 Linux FIFO 的阻塞/非阻塞打开语义（O_RDONLY/O_WRONLY/O_RDWR）(#1429)
+- **管道行为完善**：
+  - 修复并完善 pipe 的行为，新增管道文件系统（PipeFS）并注册 PIPEFS_MAGIC
+  - 扩展管道缓冲区至 65536 字节，支持原子写入
+  - 实现命名管道（FIFO）支持，允许 O_RDWR 模式打开
+  - 修复阻塞模式下写端唤醒的竞态条件，在阻塞模式下先增加 writer 计数再等待读端 (#1529, #1426)
+  - 为 fcntl 系统调用添加管道缓冲区大小查询功能（F_GETPIPE_SZ 和 F_SETPIPE_SZ）
+  - 在 procfs 中新增文件描述符相关支持
+
+### 网络与设备：稳定性提升
+
+- **网络栈优化**：
+  - 将 NapiManager 的锁机制改为 lock_irqsave，修复在中断上下文中调用 napi_schedule 可能导致的死锁问题 (#1525)
+  - 修复 UDP getsockname/getpeername 系统调用 (#1460)
+- **TTY 驱动增强**：
+  - 增强 TTY 驱动和设备管理，改进 master 和 slave 类型的处理 (#1462)
+  - 修复 TTY 和会话的权限检查逻辑，添加 TIOCNOTTY 命令支持 (#1430)
+  - 为 TTY 设备添加 page_cache 方法并处理无页面缓存的情况 (#1428)
+  - 改进 PTY 设备管理，添加 /dev/ptmx 符号链接指向内部 devpts 节点 (#1462)
+- **异步 I/O 通知**：实现异步 I/O 通知机制和 ioctl 系统调用增强 (#1425)
+
+### 文件系统实现：ext4 与 FAT 改进
+
+- **ext4 文件系统**：
+  - 修复 ext4 inode 读写操作中的自旋锁死锁问题
+  - 添加父目录指针支持，实现 parent() 方法
+  - 改进块设备寻址逻辑，统一使用 512 字节 LBA
+  - 增强根文件系统探测机制，支持 ext4 和 FAT 自动识别
+  - 修复 ELF 加载器中解释器路径查找问题
+  - 为 ext4 和 fat 文件系统添加探测方法并优化代码 (#1509)
+- **FAT 文件系统**：
+  - 更新目录链接计数管理，确保目录链接计数从 2 开始（自引用和父目录链接）(#1454)
+  - 完善文件系统统计信息支持，实现 statfs 所需的 SuperBlock 字段 (#1491)
+  - 修复 FAT32 FSInfo 空闲簇计数更新时的溢出问题 (#1491)
+- **文件系统统计**：完善 FAT 和 tmpfs 的文件系统统计信息支持，为 tmpfs 添加默认容量策略（物理内存一半）(#1491)
+
+### 等待队列重构：引入 Waiter/Waker 模式
+
+- **等待队列机制重构**：重构等待队列机制，引入 Waiter/Waker 模式避免唤醒丢失，统一等待接口，提供 wait_event_interruptible/uninterruptible 方法，重构 futex、epoll、eventfd、semaphore、completion 等模块使用新等待队列，优化进程等待子进程退出逻辑 (#1452)
+- **信号处理修复**：在 sys_rt_sigtimedwait 中消费信号后及时刷新 HAS_PENDING_SIGNAL 状态，将 futex 可中断唤醒的错误码从 ERESTARTSYS 改为 EINTR，以符合 Linux 语义 (#1452)
+
+### 工程效率与 CI：自动化与工具链改进
+
+- **夜间构建工作流**：新增夜间构建与发布工作流，支持自动化构建和发布，分离构建和发布步骤，压缩构建产物为 tarball (#1469, #1471, #1472, #1473, #1474, #1475, #1476, #1477)
+- **构建容器升级**：构建容器版本升级至 v1.19，修复 CI 相关问题，添加 riscv64 libc 支持，更新 CI 工作流中的 Docker 镜像仓库地址 (#1442)
+- **CI 流程修复**：
+  - 修复 CI 流程中测试失败但返回成功状态的问题 (#1403)
+  - 修复 gVisor 测试自动化脚本，修复自动化开启/关闭 gVisor syscall 测例打包的脚本 (#1405)
+  - 添加 open_test 测试 (#1458)
+- **代码审查自动化**：添加 Claude 代码审查工作流，优化代码审查流程和配置，启用进度跟踪功能 (#1435, #1436, #1437, #1438, #1440, #1445, #1446, #1447)
+- **开发容器支持**：添加基于 CNB 镜像的 devcontainer 支持，设置非 root 用户为默认 devcontainer 用户 (#1449, #1457)
+
+### 文档与社区：体验与可访问性提升
+
+- **DragonOS Playground**：更新 README 和构建文档，添加 DragonOS Playground 体验方式，在 README 中新增云原生开发体验方式，提供 CNB 平台一键启动链接，更新社区新闻添加 Playground 上线信息 (#1484)
+- **文档翻译更新**：多轮文档翻译更新，提升国际化支持 (#1485, #1453, #1411, #1408, #1402, #1396)
+- **用户环境改进**：
+  - 修正 PS1 环境变量使其与 bash 默认高亮一致 (#1432)
+  - 使用彩色 PS1，提升用户体验 (#1422)
+
+### gVisor 测试：兼容性持续提升
+
+- **测试用例扩展**：删除 gVisor 测试中的 fifo_test blocklist 文件，扩展测试覆盖范围 (#1524)
+- **系统调用修复**：
+  - 修复 open 系统调用在 gVisor 下的异常表现，修复多个 open 相关测试 (#1417)
+  - 修复 utimensat/futimesat 系统调用边界情况以兼容 gVisor 测试 (#1431)
+  - 修复 pread64 系统调用的兼容性和错误处理 (#1398)
+  - 修复 sys_rename 逻辑并支持 RENAME_NOREPLACE (#1393)
+  - 修复 getdents 系统调用实现 (#1397)
+  - 修复 syscall/vfs 中写入部分可读缓冲区时的 SIG 衍生问题 (#1375)
+  - 修复 cputime、sys_rt_sigtimedwait 和 sys_rt_sigreturn 相关问题 (#1406, #1394, #1400)
+
+### 其他改进
+
+- **符号表查询修复**：修复符号表查询问题，使用二分查找符号替代原有逻辑 (#1443)
+- **设备驱动改进**：添加随机设备支持（/dev/random），提供随机字节生成能力 (#1455)
+- **文件系统改进**：改进目录链接计数管理，更新 FAT 和 RAM 文件系统中的目录链接计数管理 (#1454)
+
+## 版本概览
+
+- **I/O 多路复用**：poll/pselect6 信号掩码恢复逻辑修复，epoll 事件处理增强，超时唤醒机制完善
+- **时间与定时器**：POSIX interval timer 完整实现，CPU 时间统计，clock_nanosleep 完善，POSIX 调度系统调用
+- **文件系统**：tmpfs 支持，copy_file_range、creat、preadv2、pwritev2、fadvise64、umask 等新系统调用，append 锁机制，EventFd 文件系统，挂载传播机制
+- **procfs 增强**：/proc/<pid>/stat、/proc/<pid>/task、/proc/<pid>/cmdline、/proc/<pid>/maps、/proc/<pid>/ns/、/proc/thread-self/ns 等文件支持，内核日志管理
+- **进程管理**：shebang 脚本支持，进程等待语义修复，信号处理增强，进程执行改进
+- **内存与 I/O**：用户空间内存访问修复，块缓存增强，页面缓存改进，slab 分配器并发安全修复，mmap 支持增强
+- **IPC 与管道**：FIFO 阻塞打开语义，管道竞态条件修复，管道缓冲区动态调整
+- **网络与设备**：网络栈锁机制优化，UDP 套接字修复，TTY 驱动增强，随机设备支持
+- **文件系统实现**：ext4 死锁修复，FAT 文件系统改进，文件系统统计信息完善
+- **等待队列重构**：Waiter/Waker 模式，统一等待接口
+- **工程效率**：夜间构建工作流，构建容器升级至 v1.19，CI 流程修复，代码审查自动化，开发容器支持
+- **文档与社区**：DragonOS Playground 推广，文档翻译更新，用户环境改进
+- **gVisor 测试**：测试用例扩展，多个系统调用修复以通过 gVisor 测试
+
+## 详细变更
+
+### 1. I/O 多路复用与时间语义：对齐 Linux 6.6
+
+#### poll/pselect6 优化 (#1531)
+- 修复 poll_select_finish 中信号掩码恢复逻辑，避免在 ERESTARTSYS 时错误恢复
+- 重构 pselect6 系统调用，正确处理 sigmask 参数和 timeout 验证
+- 移除 poll_select_finish 中零超时提前返回的逻辑
+- 为 PosixTimeSpec 添加 as_millis 方法
+- 将 select 相关测试加入白名单
+
+#### epoll 事件处理 (#1528, #1492)
+- 修复普通文件在 epoll 中总是就绪的逻辑，避免添加不必要的 epitem
+- 改进 poll_select_finish 函数以支持更多时间类型
+- 修复 select 系统调用中 timeout 负值检查
+- 重构定时器创建逻辑，使用 EpollTimeoutWaker 结构体实现 TimerFunction
+- 将超时唤醒方式从直接唤醒 PCB 改为通过 Waker::wake() 触发
+
+#### POSIX interval timer (#1501, #1521)
+- 新增 timer_create/timer_settime/timer_gettime/timer_getoverrun/timer_delete 系统调用处理，并接入 syscall table
+- 实现进程级 POSIX interval timer：基于 CLOCK_MONOTONIC 的创建/删除/设置/查询、周期性重装与到期调度
+- 完整实现 SIGEV_NONE/SIGEV_SIGNAL/SIGEV_THREAD_ID（放宽 SIGEV_THREAD_ID 限制，允许向同线程组的任意线程投递信号）与 SI_TIMER siginfo（含 si_timerid/si_overrun/si_value）
+- 修复 overrun 语义与信号合并：按线程 pending 队列合并并累积 overrun，避免重复入队导致进程被信号杀死
+- 修复周期性 timer 的 gettime 剩余时间计算与回调窗口返回 0 的问题
+- 修复定时器回调中信号锁/队列访问导致的自锁死
+- 修复 ProcessControlBlock::raw_tgid() 返回错误字段的问题
+
+#### CPU 时间统计 (#1517)
+- 新增 ProcessCpuTime 结构体，用于统计用户态、内核态及总执行时间
+- 为 PCB 添加 cputime_wait_queue，支持 CLOCK_PROCESS/THREAD_CPUTIME_ID 的 clock_nanosleep
+- 在调度器 CPU 时间统计中增加 CPU-time 等待队列唤醒逻辑
+- 扩展 clock_gettime 和 clock_nanosleep 系统调用，支持进程和线程 CPU 时间时钟
+- 添加 PosixTimeSpec::from_ns 方法，便于从纳秒创建时间规格
+- 在 process_cputime_ns 中添加对无效线程组关系的防御性回退和日志记录
+- 为 thread_cputime_ns 添加原子操作顺序的注释说明
+- 新增多线程 CPU 时间测试程序，验证进程 CPU 时间累加线程时间的功能
+
+#### POSIX 调度系统调用 (#1416)
+- 添加 sched_getparam 系统调用以获取进程调度参数
+- 添加 sched_getscheduler 系统调用以获取进程调度策略
+- 重构 sched_yield 到独立模块，提供适当的系统调用处理程序
+- 添加调度权限检查的实用函数
+- 从主系统调用模块中移除旧的 do_sched_yield 实现
+
+### 2. 文件系统与 VFS：功能扩展与稳定性提升
+
+#### tmpfs 文件系统 (#1459, #1480, #1410)
+- 引入新的 tmpfs 模块用于内存中的临时文件存储
+- 更新 devfs 以将 /dev/shm 挂载为 tmpfs，符合 Linux 语义
+- 增强 vfs 模块以包含 TMPFS_MAGIC 用于 tmpfs 识别
+- 添加 tmpfs 功能所需的方法和结构，包括 inode 管理和文件操作
+- 实现原子大小管理，添加原子操作以管理 tmpfs 文件系统的当前大小
+- 将大小管理集成到 inode 操作中，确保大小更新是线程安全的并遵循指定的限制
+- 增强 resize 和 truncate 方法以在文件修改期间相应调整文件系统大小
+- 实现零页创建，添加 create_zero_pages 方法到 InnerPageCache 以高效创建零页
+- 更新 Tmpfs 以在读写操作期间利用新的零页创建，确保无缝处理页面错误
+- 增强 PageFaultHandler，添加 pagecache_fault_zero 以专门管理 tmpfs 的页面错误
+- 修复 chroot 相关问题，实现挂载传播机制
+
+#### 新系统调用实现
+
+**copy_file_range (#1513)**
+- 实现 copy_file_range 系统调用，支持文件间高效数据拷贝
+- 添加完整的测试用例，覆盖基本功能、边界条件和错误处理
+
+**creat (#1482)**
+- 实现 creat 系统调用处理器，遵循 Linux 语义：创建新文件或截断现有文件并打开为只写模式
+- 在 x86_64 架构下注册 creat 系统调用到系统调用表
+- 在 gvisor 测试白名单中添加 creat 测试项
+
+**preadv2/pwritev2 (#1451, #1461)**
+- 实现 preadv2 系统调用，支持带偏移量和标志位的向量化读取
+- 处理 offset 为 -1 时使用当前文件偏移量，其他情况复用 preadv 逻辑
+- 添加 RWF 标志位验证，遵循 Linux 兼容性要求
+- 实现 pwritev2 系统调用，允许带偏移量和标志的向量化写入
+- 实现文件描述符和偏移量的验证，确保健壮的错误处理
+- 为新系统调用重用 pwritev 的核心逻辑，保持文件写入操作的一致性
+
+**fadvise64 (#1439)**
+- 新增 fadvise64 系统调用实现
+- 添加页面缓存范围写回和驱逐功能
+- 改进预读机制，支持随机访问模式
+- 扩展文件访问模式标志管理
+- 封装文件预读状态访问并优化 fadvise64 实现
+- 修复 fadvise64 中页边界检查逻辑
+
+**umask (#1500, #1419)**
+- 为新文件系统实例设置默认 umask 为 0022
+- 添加 apply_umask_for_create() 和 chmod_preserve_type() 辅助函数
+- 实现文件创建和 chmod 操作的适当权限检查
+- 修复 fchmod 系统调用以正确工作并拒绝 O_PATH 文件描述符
+- 将 open_create_test 添加到 gvisor 测试套件
+
+#### 文件操作改进
+
+**truncate 修复 (#1444)**
+- 限制缓冲区大小为 512KB，避免分配过大内存导致容量溢出
+- 为 resize 加上页缓存截断
+- 增加对 len 的检查，检查截断后的长度是否超过限度
+- 检查 filemode
+- 改进长度参数的类型转换逻辑；统一使用限制大小的缓冲区策略
+- 在 fat 的 resize 中加入最大容量检查
+- 统一定义 ZERO_BUF_SIZE；增加对零写入的检查；在 vfs 层统一拒绝超出 isize::MAX 的长度
+
+**符号链接处理增强 (#1507)**
+- 更新 tmpfs 以要求常规文件和符号链接都使用页缓存，确保正确的读写操作
+- 将最大符号链接跟随次数增加到 40，符合 Linux 6.6 标准
+- 改进 VFS 中的符号链接处理，根据路径条件和尾随斜杠正确跟随符号链接
+- 在 vfs_statx 中添加冲突标志的验证，防止无效操作
+- 改进符号链接和 lstat 的系统调用实现以遵循 Linux 语义，确保符号链接创建和路径解析的正确行为
+- 修正符号链接跟随次数的处理逻辑，将 VFS_MAX_FOLLOW_SYMLINK_TIMES 从 40 调整为 41
+
+**其他文件操作修复**
+- 修复 symlinkat 中父目录路径为 None 时的处理逻辑 (#1512)
+- 修复 sys_rename 逻辑并支持 RENAME_NOREPLACE 标志 (#1393)
+- 修复 pread64 系统调用的兼容性和错误处理，验证 offset 参数和用户缓冲区 (#1398)
+
+#### append 锁机制 (#1483)
+- 引入 AppendLockManager 以确保跨文件系统的追加操作的原子性，防止并发写入场景中的数据损坏
+- 更新文件写入方法以利用新的追加锁机制，确保追加到文件时尊重最新的文件结束位置
+- 增强 write_append 和 pwrite_append 方法以支持强制追加语义，符合 Linux 行为
+- 在 VFS 初始化期间初始化追加锁管理器，确保在任何文件写入操作之前准备就绪
+- 添加 jhash 库并用于 append_lock 的哈希计算
+
+#### EventFd 文件系统 (#1486)
+- 引入 EventFdFs 作为新的伪文件系统以支持 eventfd 文件描述符，包括根 inode 检索和文件系统信息的方法
+- 增强 IndexNode trait，添加 is_stream、supports_seek、supports_pread 和 supports_pwrite 方法，以简化流式文件的操作语义
+- 更新 VFS 中的文件处理以利用新的 inode 能力，确保 pread、pwrite 和 lseek 操作的正确行为
+- 将 eventfd_test 添加到系统调用白名单用于测试
+- 修复 pread/pwrite 中 O_PATH 和流式对象的错误处理顺序
+
+#### 文件系统标志重构 (#1414)
+- 重构文件系统标志体系，区分打开标志与访问模式
+- 提升代码清晰度和可维护性
+
+#### 路径检查统一 (#1481)
+- 将多个 VFS 系统调用中的 check_and_clone_cstr 替换为 vfs_check_and_clone_cstr
+- 在 page_cache.rs 中简化 page_cache 引用获取方式
+- 在 sys_mount.rs 中新增 copy_mount_path_string 函数专门处理挂载路径
+- 移除 rename_utils.rs 中冗余的路径长度检查
+
+#### 文件预读功能 (#1391)
+- 新增 readahead 模块实现文件预读算法
+- 修改 page_cache 模块支持预读标记
+- 在 File 结构体中添加预读状态管理
+- 为 PageFlags 添加 PG_READAHEAD 标志位
+
+#### 挂载传播机制 (#1410)
+- 添加对挂载传播类型的支持：Shared、Private、Slave 和 Unbindable
+- 引入新模块用于管理挂载传播语义，包括对等组注册和事件传播
+- 更新现有挂载函数以在挂载和卸载操作期间处理传播逻辑
+- 增强文档以包含新挂载传播功能的详细信息及其用法
+- 添加单元测试以验证不同场景下挂载传播行为的正确性
+- 实现递归绑定挂载支持，添加递归绑定挂载功能，支持 MS_BIND | MS_REC 标志
+- 实现 BFS 遍历以在 do_recursive_bind_mount 中复制子挂载
+- 修复挂载注册顺序以防止失败时的悬空注册
+
+### 3. procfs 与系统信息：可观测性大幅提升
+
+#### 进程信息文件
+
+**/proc/<pid>/stat 和 /proc/<pid>/task (#1490)**
+- 添加 /proc/<pid>/stat 文件生成，支持 BusyBox ps/pstree/top 等工具
+- 实现 /proc/<pid>/task 目录结构，支持主线程 tid=pid 的展示
+- 新增 proc_pid_stat 和 proc_pid_task 模块处理相关逻辑
+- 扩展 ProcFileType 枚举，添加 ProcPidStat、ProcPidTaskDir 等类型
+- 在 InodeInfo 中新增 tid 字段以支持线程信息
+
+**/proc/cmdline 和 /proc/<pid>/cmdline (#1489)**
+- 新增 proc_pid_cmdline 模块，实现 /proc/cmdline 和 /proc/<pid>/cmdline 文件的读取逻辑
+- 在进程控制块中增加 cmdline 字段，用于存储进程的命令行参数
+- 在 execve、fork 和初始进程启动时正确设置和继承 cmdline 数据
+- 在 procfs 中创建对应的文件节点并集成到文件类型枚举和打开逻辑中
+
+**/proc/<pid>/maps (#1468)**
+- 新增 proc_maps 模块，实现 /proc/<pid>/maps 文件的生成逻辑
+- 在 ProcFS 中注册 maps 文件，支持进程文件夹的创建和清理
+- 更新 gvisor 测试白名单，添加 time_test
+- 修正缺页异常处理中的用户态判断逻辑，优先使用 TrapFrame 和错误码判断访问发起者
+
+**/proc/<pid>/statm (#1455)**
+- 将 ProcStatm 文件类型引入 ProcFileType 枚举
+- 实现 open_statm 函数以返回 statm 文件的占位符响应
+- 更新 ProcFS inode 创建以包含每个进程的 statm 文件
+- 增强 IndexNode 实现以处理新的 ProcStatm 文件类型
+- 优化 statm 文件打开逻辑，增加虚拟内存页数计算
+
+#### 命名空间支持
+
+**/proc/<pid>/ns/ 目录 (#1515)**
+- 新增 /proc/<pid>/ns/ 目录，支持动态创建命名空间文件
+- 实现 cgroup 命名空间基础结构，支持 CLONE_NEWCGROUP 标志
+- 为命名空间文件添加 ioctl 支持（NS_GET_NSTYPE 等命令）
+- 扩展 setns 系统调用以支持 cgroup 命名空间切换
+
+**/proc/thread-self/ns (#1412)**
+- 引入新模块用于处理 /proc/thread-self/ns 下的命名空间文件，允许应用程序通过符号链接引用命名空间
+- 实现命名空间文件及其对应 ID 的动态创建，确保与 Linux 行为兼容
+- 更新 ProcFS 以为线程特定命名空间创建必要的目录结构和文件
+- 增强现有 ProcFileType 枚举以包含线程自身命名空间的新类型
+- 实现 setns 系统调用用于命名空间管理，允许进程使用文件描述符加入现有命名空间
+
+**命名空间文件竞态修复 (#1413)**
+- 为并发命名空间文件创建添加适当的错误处理
+- 在创建过程中更早地移动命名空间类型验证
+- 确保子 inode 在 children map 中可见之前完全初始化
+- 通过重新检查 children map 处理 EEXIST 竞态条件
+
+#### 内核日志管理 (#1415)
+- 引入新模块用于管理内核日志级别，模仿 Linux 行为
+- 添加通过命令行和 procfs 接口动态配置日志级别的支持
+- 创建新的 /proc/sys/kernel/printk 文件用于读取和写入日志级别设置
+- 更新现有日志机制以利用新的日志级别管理系统
+- 增强 QEMU 启动脚本以允许通过环境变量设置日志级别
+
+#### 文件描述符信息 (#1426)
+- 在 procfs 中新增文件描述符相关支持
+- 为 procfs 的 InodeInfo 添加 target_inode 字段，用于存储魔法链接的原始文件 inode
+- 实现 IndexNode::special_node 方法，使 /proc/self/fd/N 能返回原始文件的引用
+- 在 VFS 中处理 SpecialNodeData::Reference，支持魔法链接的路径解析
+- 为管道文件实现 ioctl 的 FIONREAD 命令，获取可读字节数
+- 添加 /proc/<pid>/fdinfo 目录支持并实现管道缓冲区动态调整
+
+### 4. 进程管理与执行：更接近 Linux 行为
+
+#### shebang 脚本支持 (#1511)
+- 新增 shebang 模块，实现脚本解析和递归执行
+- 重构 exec 模块，支持递归加载和上下文跟踪
+- 添加测试程序验证 shebang 功能
+- 为 parse_shebang_line 函数添加 inline 属性以优化
+
+#### 进程等待语义修复
+
+**线程组等待语义 (#1427)**
+- 修复线程组中子进程的等待语义
+
+**父进程唤醒逻辑 (#1516)**
+- 修正父进程唤醒条件，确保无论 exit_signal 为何值都唤醒父进程
+- 修复线程组 leader 唤醒逻辑的位置错误
+
+#### 进程执行改进 (#1518)
+- 修复 execve 系统调用中空路径和空参数处理问题，在解析符号链接前检查 argv 是否为空，避免空指针访问
+- 添加对空路径字符串的检查，返回 ENOENT 错误码
+- 为 gvisor 测试套件添加版本管理功能，引入版本变量和版本文件以支持自动检测和升级
+- 增强执行文件权限检查与信号处理，在 execve 系统调用中增加文件类型和执行权限检查
+- 移除 shebang 处理中冗余的 interpreter_path 字段
+- 修复 fork 时信号掩码复制问题，确保 POSIX 合规性
+- 完善 execveat 系统调用对 AT_EMPTY_PATH 和 AT_SYMLINK_NOFOLLOW 标志的处理
+- 实现 fd_table 在 execve 进程中的 unsharing，确保隔离性
+- 更新路径解析逻辑，仅在 absolute_path() 成功时替换 argv[0]，在失败时保持原始路径
+- 改进 shebang 解释器未找到时的错误日志
+
+#### 信号处理增强
+
+**POSIX 定时器信号投递 (#1521)**
+- 修复 ProcessControlBlock::raw_tgid() 返回错误字段的问题
+- 为 POSIX 定时器添加 SIGEV_THREAD 支持，兼容 gVisor 测试
+- 放宽 SIGEV_THREAD_ID 限制，允许向同线程组的任意线程投递信号
+
+**信号忽略逻辑 (#1434)**
+- 实现信号忽略检查逻辑
+- 修复 getpid 在命名空间中返回正确的 tgid
+- 修复 fork 时的 copy_process 顺序
+- 修复 init 进程中的 CloneFlags::CLONE_SIGHAND 标志
+
+**增强的信号处理和 IPC 机制 (#1423)**
+- 添加 rt_sigqueueinfo 和 rt_tgsigqueueinfo 系统调用，用于符合 POSIX 的信号投递
+- 增强 kill 进程功能，提供适当的信号验证和权限检查
+- 改进进程退出处理，包括信号清理和父进程通知
+- 更新 fork 实现以正确处理信号继承
+- 实现 setresuid 系统调用，提供适当的权限管理
+- 添加信号相关系统调用的全面测试覆盖
+
+**kill 进程组修复 (#1424)**
+- 修复 kill 进程组的 bug，使得 KillTest.ProcessGroups 通过
+
+**sys_rt_sigtimedwait 和 sys_rt_sigreturn 修复 (#1406, #1394, #1400)**
+- 修复进程 CPU 时间统计精度，将统计基准调整为扣除 IRQ 和 Steal 时间后的净时间（accounted_cputime）
+- 修复 sys_rt_sigtimedwait 的信号等待逻辑，确保即使等待信号集为空也能正确进入 do_kernel_rt_sigtimedwait
+- 修复潜在的无限睡眠问题：当线程被非目标信号或非超时事件唤醒时，将正确返回 EINTR
+- 修复 bitflags 错误移除的 bug，应该使用 remove()
+- 修复 sys_rt_sigreturn：当从信号处理函数返回用户态时，如果待恢复的 %rcx / %r11 与 sysretq 的行为冲突，则强制跳转到 .L_syscall_must_use_iret 分支，使用 iretq 指令精确恢复完整的上下文
+
+### 5. 内存管理与 I/O：性能与稳定性优化
+
+#### 用户空间内存访问修复 (#1522)
+- 修复 IoVecs 构造时对零长度缓冲区的验证，确保符合 Linux 语义
+- 修复 scatter 方法在遇到不可访问内存时的错误处理，避免部分写入后返回错误
+- 修复 readv/preadv 等系统调用，使其支持分块读取和部分成功写入
+- 修复页面回收逻辑，避免回收仍被映射的文件页
+- 修复 UserBufferReader/Writer 对空指针的检查，防止未定义行为
+- 调整缓存阈值并添加 gVisor 测试的内存检测逻辑
+- 优化 IoVecs 的用户空间内存访问检查与拷贝逻辑，移除冗余的 verify_area 和 UserBufferReader/Writer 检查，统一使用 user_accessible_len 进行访问性验证
+- 在 gather 方法中使用 copy_from_user_protected 进行异常保护的拷贝，与 scatter 方法保持一致
+- 改进错误处理逻辑，当部分数据已成功读取时返回已读取的数据，否则返回 EFAULT
+
+#### 块缓存增强 (#1465)
+- 为 CacheBlock 添加 from_slice 方法，用于直接从切片创建实例，避免不必要的分配
+- 在 CacheBlock 中引入 write_data 方法，允许就地更新块数据
+- 更新 BlockCache 中的 insert_one_block 和 immediate_write 方法以接受切片而非向量，提高性能和内存使用
+- 在多个位置实现块大小验证的错误处理，确保数据完整性
+- 将 FileMapInfo::page_cache 更改为 Weak<PageCache> 以修复由引用循环引起的内存泄漏
+
+#### 页面缓存改进 (#1444, #1455)
+- 修复 truncate 时的页缓存截断，修复边界条件
+- 重构页缓存读写以解决死锁问题并改进错误处理，将页缓存读写拆分为两阶段以避免用户缺页时持有锁
+- 改进文件系统缺页处理，返回 SIGBUS 而非 panic
+- 优化 sys_read/sys_write 的用户缓冲区访问检查
+- 修复 mprotect 参数对齐检查
+
+#### 内存管理优化
+
+**slab 分配器修复 (#1464)**
+- 为 ObjectPageIterMut 添加 remaining 字段，防止迭代越界
+- 将 SLABALLOCATOR 改为 SpinLock 保护，修复并发访问问题
+- 在 kernel_allocator 中正确使用锁保护 slab 分配器操作
+
+**异常表安全拷贝 (#1395)**
+- 修改异常表安全拷贝的错误处理返回值
+
+**页面回收优化 (#1455)**
+- 优化页面回收过程以防止死锁，将页面回收分为两阶段以避免长时间持有回收器锁，降低与 page_manager/page_cache 的锁顺序反转风险
+- 更新 shrink_list 方法以在不持有回收器锁的情况下处理受害者页驱逐，确保更安全的内存管理
+- 改进 drain_lru 方法以高效检索用于回收的受害者页
+
+#### mmap 支持增强 (#1455)
+- 为 LockedZeroInode、LockedExt4Inode、LockedFATInode 和 LockedRamFSInode 实现 mmap 方法，允许内存映射操作
+- 改进 mmap 错误处理和验证，增强错误处理以返回不支持操作的适当错误
+- 添加 MAP_PRIVATE 和 MAP_SHARED 标志的检查，确保只设置一个
+- 实现 MAP_FIXED 的页面对齐验证
+- 增强内存保护处理和验证，更新 init_xd_rsvd 函数以确保启用 NX 支持并正确处理硬件限制
+- 改进 sys_mprotect 中的对齐检查以防止溢出并确保适当的内存区域验证
+- 增强 mmap 系统调用的偏移量检查和内存分配逻辑
+
+### 6. IPC 与管道：阻塞语义与竞态修复
+
+#### FIFO 阻塞打开语义 (#1429)
+- 为 LockedPipeInode 添加 open_wait_queue 用于 FIFO 打开时的阻塞等待
+- 实现 Linux FIFO 的阻塞/非阻塞打开语义（O_RDONLY/O_WRONLY/O_RDWR）
+- 添加 has_reader/has_writer 辅助方法检查管道状态
+- 更新测试配置，将 fifo_test 加入白名单
+
+#### 管道行为完善 (#1529, #1426)
+- 修复并完善 pipe 的行为，新增管道文件系统（PipeFS）并注册 PIPEFS_MAGIC
+- 扩展管道缓冲区至 65536 字节，支持原子写入
+- 实现命名管道（FIFO）支持，允许 O_RDWR 模式打开
+- 改进 fcntl 的 F_SETFL 实现，仅允许修改特定标志位
+- 修复写入只读文件描述符的错误码为 EBADF
+- 为命名管道自动添加 O_LARGEFILE 标志
+- 优化管道读写逻辑，支持循环写入和部分写入
+- 修复阻塞模式下写端唤醒的竞态条件：在阻塞模式下先增加 writer 计数再等待读端，避免竞态条件；在增加 writer 计数后立即唤醒等待的读者；处理信号中断时回滚 writer 计数；确保非阻塞模式下也正确唤醒读者
+- 在 preadv/pwrite64/pwritev 系统调用中增加对管道、Socket 和字符设备的 ESPIPE 错误检查
+- 为 fcntl 系统调用添加管道缓冲区大小查询功能（F_GETPIPE_SZ 和 F_SETPIPE_SZ）
+- 优化管道关闭逻辑，避免潜在死锁问题
+- 在 procfs 中新增文件描述符相关支持，支持 /proc/self/fd/N 魔法链接并实现管道 FIONREAD
+- 添加 /proc/<pid>/fdinfo 目录支持并实现管道缓冲区动态调整
+
+### 7. 网络与设备：稳定性提升
+
+#### 网络栈优化
+
+**NapiManager 锁机制 (#1525)**
+- 将 NapiManager 的锁机制改为 lock_irqsave
+- 修复在中断上下文中调用 napi_schedule 可能导致的死锁问题
+
+**UDP 套接字修复 (#1460)**
+- 修复 UDP getsockname/getpeername 系统调用
+- 添加测试白名单以支持新的可用 inet 系统调用
+
+#### TTY 驱动增强
+
+**TTY 驱动和设备管理 (#1462)**
+- 更新 TTY 驱动以在关闭操作期间更有效地处理 master 和 slave 类型，确保正确清理 /dev/pts 中的设备条目
+- 改进控制 TTY 分离的处理，添加对 TIOCNOTTY 命令的支持
+- 重构 PTY 设备初始化以确保正确的元数据设置和设备注册
+- 为 /dev/ptmx 添加符号链接指向内部 devpts 节点，防止早期访问期间的 ENOENT 错误
+- 改进 PTY 设备管理和清理逻辑，增强 PtyDevPtsLink 结构以更有效地管理 PTY 设备的生命周期
+
+**TTY 权限检查 (#1430)**
+- 修复 TTY 和会话的权限检查逻辑，通过 pty_root_test
+
+**TTY page_cache 支持 (#1428)**
+- 在 TTY 设备中实现 page_cache 方法，返回 None 以表明字符设备不需要页面缓存
+- 在页面错误处理中增加对无页面缓存情况的处理，避免 panic 并返回 VM_FAULT_SIGBUS
+
+#### 异步 I/O 通知 (#1425)
+- 实现异步 I/O 通知机制和 ioctl 系统调用增强
+
+#### 随机设备支持 (#1455)
+- 新增随机设备模块 random_dev，提供随机字节生成能力
+- 在 DevFS 中注册 /dev/random 设备，确保系统能够访问随机数据
+
+### 8. 文件系统实现：ext4 与 FAT 改进
+
+#### ext4 文件系统 (#1509)
+- 修复 ext4 inode 读写操作中的自旋锁死锁问题
+- 添加父目录指针支持，实现 parent() 方法
+- 改进块设备寻址逻辑，统一使用 512 字节 LBA
+- 增强根文件系统探测机制，支持 ext4 和 FAT 自动识别
+- 修复 ELF 加载器中解释器路径查找问题
+- 更新 another_ext4 依赖版本
+- 为 ext4 和 fat 文件系统添加探测方法并优化代码，在 Ext4FileSystem 和 FATFileSystem 中新增 probe 方法
+- 重构 vcore.rs 中的文件系统探测逻辑，使用新的 probe 方法替代原有的独立探测函数
+- 优化 Ext4Inode 构造函数中 parent 字段的默认值设置，使用 unwrap_or_default 替代 unwrap_or_else
+- 在 rcS 启动脚本中添加 PATH 环境变量设置
+
+#### FAT 文件系统 (#1454, #1491)
+- 更新目录链接计数管理，调整目录的链接计数以确保从 2 开始，考虑自引用和父目录链接
+- 更新创建和删除目录时递增和递减链接计数的逻辑
+- 增强 VFS 层中目录链接计数的动态计算，确保在元数据不可靠时的准确性
+- 为 FAT 文件系统实现 statfs 所需的 SuperBlock 字段（f_blocks、f_bfree、f_bavail、f_frsize）
+- 修复 FAT32 FSInfo 空闲簇计数更新时的溢出问题
+- 为挂载点提供稳定的 st_dev 标识符
+
+#### 文件系统统计 (#1491)
+- 完善 FAT 和 tmpfs 的文件系统统计信息支持
+- 为 tmpfs 添加默认容量策略（物理内存一半）并同步更新 SuperBlock 统计信息
+
+### 9. 等待队列重构：引入 Waiter/Waker 模式
+
+#### 等待队列机制重构 (#1452)
+- 重构 WaitQueue，引入 Waiter/Waker 模式避免唤醒丢失
+- 统一等待接口，提供 wait_event_interruptible/uninterruptible 方法
+- 重构 futex、epoll、eventfd、semaphore、completion 等模块使用新等待队列
+- 优化进程等待子进程退出逻辑，使用新等待队列接口
+- 添加等待队列设计文档说明新机制
+- 添加 SKIP_GRUB 选项以支持在 CI 或无图形界面环境中跳过 GRUB 安装
+
+#### 信号处理修复 (#1452)
+- 在 sys_rt_sigtimedwait 中消费信号后及时刷新 HAS_PENDING_SIGNAL 状态，避免后续等待路径误判
+- 将 futex 可中断唤醒的错误码从 ERESTARTSYS 改为 EINTR，以符合 Linux 语义
+
+### 10. 工程效率与 CI：自动化与工具链改进
+
+#### 夜间构建工作流 (#1469, #1471, #1472, #1473, #1474, #1475, #1476, #1477)
+- 新增夜间构建与发布工作流
+- 支持自动化构建和发布，分离构建和发布步骤
+- 压缩构建产物为 tarball 并上传以供后续使用
+- 修改 Dockerfile 以复制压缩的产物而非单个文件，提高效率和组织性
+- 添加步骤以在夜间构建工作流中创建 'bin' 目录以更有效地组织构建产物
+- 在夜间构建工作流中恢复 HOME 环境变量以确保构建过程的适当目录上下文
+- 更新夜间构建工作流以有条件地运行构建和发布作业
+- 在夜间构建工作流中添加步骤以 checkout DragonOS 代码
+
+#### 构建容器升级 (#1442)
+- 构建容器版本升级至 v1.19
+- 添加 --ci 安装模式和 APT_FLAG（--no-install-recommends）到 bootstrap.sh
+- 在 CI 上跳过 grub/docs，移除旧的 RUST_VERSION_OLD 安装步骤
+- 在 Dockerfile 中使用 --no-install-recommends
+- 调整构建脚本和 BUILD_CONTAINER_VERSION
+- 更新 DADK 版本至 v0.5.1 并调整构建脚本
+- 更新 CI 工作流中的 Docker 镜像源
+- 添加 linux-libc-dev-riscv64-cross 到 Ubuntu/Debian bootstrap 安装列表，为交叉编译提供 riscv64 交叉 libc 头文件
+- 更新 CI 工作流中的 Docker 镜像仓库地址
+
+#### CI 流程修复
+
+**测试状态修复 (#1403)**
+- 修复 CI 流程中测试失败但返回成功状态的问题
+
+**gVisor 测试脚本修复 (#1405)**
+- 修复自动化开启/关闭 gVisor syscall 测例打包的脚本
+
+**测试添加 (#1458)**
+- 添加 open_test 测试
+
+#### 代码审查自动化 (#1435, #1436, #1437, #1438, #1440, #1445, #1446, #1447)
+- 添加 Claude 代码审查工作流
+- 优化代码审查流程和配置
+- 启用进度跟踪功能
+- 扩展 Claude 参数以支持更多工具
+- 重构提示词结构，明确代码审查的五个重点领域
+- 移除重复的注释更新指令，简化工作流逻辑
+- 明确使用特定工具进行内联评论和状态更新
+- 提供单行和多行评论的具体操作指导
+- 简化 PR 状态总结的要求
+
+#### 开发容器支持 (#1449, #1457)
+- 添加基于 CNB 镜像的 devcontainer 支持
+- 设置非 root 用户为默认 devcontainer 用户
+- 修复 devcontainer：将容器用户从 'dragonos' 更改为 'root'，然后更新为使用 'dragonos' 作为默认用户
+- 修复 CI：将源更改为从默认镜像服务器改为 github
+
+### 11. 文档与社区：体验与可访问性提升
+
+#### DragonOS Playground (#1484)
+- 更新 README 和构建文档，添加 DragonOS Playground 体验方式
+- 在 README 中新增云原生开发体验方式，提供 CNB 平台一键启动链接
+- 更新社区新闻，添加 Playground 上线信息
+- 在构建文档开头添加快速体验章节，推荐使用 Playground
+
+#### 文档翻译更新 (#1485, #1453, #1411, #1408, #1402, #1396)
+- 多轮文档翻译更新，提升国际化支持
+
+#### 用户环境改进
+
+**PS1 环境变量 (#1432, #1422)**
+- 修正 PS1 环境变量使其与 bash 默认高亮一致
+- 使用彩色 PS1，提升用户体验
+
+### 12. gVisor 测试：兼容性持续提升
+
+#### 测试用例扩展 (#1524)
+- 删除 gVisor 测试中的 fifo_test blocklist 文件
+- 扩展测试覆盖范围，持续提升 Linux 兼容性
+
+#### 系统调用修复
+
+**open 系统调用 (#1417)**
+- 调整 readable 和 writable 返回的错误码类型
+- 修复以下测试：OpenTest.OTrunc、OpenTest.OTruncAndReadOnlyDir、OpenTest.OCreateDirectory、OpenTest.MustCreateExisting、OpenTest.CreateWithAppend、OpenTest.AppendOnly、OpenTest.AppendConcurrentWrite、OpenTest.DirectoryWritableFails、OpenTest.DirectoryDirectFails、OpenTest.Null、OpenTest.CanTruncateReadOnly、OpenTest.OpenNonDirectoryWithTrailingSlash、OpenTest.OpenWithStrangeFlags
+- 添加 open_test 的 block
+
+**utimensat/futimesat (#1431)**
+- 修复 utimensat/futimesat 系统调用边界情况以兼容 gVisor 测试
+
+**pread64 (#1398)**
+- 修复 pread64 系统调用的兼容性和错误处理
+- 验证 offset 参数：当偏移量为负数或发生溢出时返回 EINVAL
+- 验证用户缓冲区：使用 new_checked 确保内存已映射，从而正确返回 EFAULT
+- 检查文件类型：对不可定位的文件（如管道、Socket）返回 ESPIPE
+- 修复 File::readable() 中的权限检查
+- 修复了 gVisor pread64 测试集中的多个失败项
+
+**sys_rename (#1393)**
+- 修复 sys_rename 逻辑并支持 RENAME_NOREPLACE
+
+**getdents (#1397)**
+- 修复 getdents 系统调用实现
+
+**其他修复**
+- 修复 syscall/vfs 中写入部分可读缓冲区时的 SIG 衍生问题 (#1375)
+- 修复 cputime、sys_rt_sigtimedwait 和 sys_rt_sigreturn 相关问题 (#1406, #1394, #1400)
+
+### 13. 其他改进
+
+#### 符号表查询修复 (#1443)
+- 修复符号表查询问题，原有逻辑 addr 刚好等于 kallsyms_adress_list[i+1] 时，索引 index 值会是 i，但是实际上是 i+1
+- 现在修改为通过二分查找符号
+
+#### Cargo.lock 清理 (#1530)
+- 修复 Cargo.lock 中 another_ext4 包的重复条目问题
+- 统一 lockfile 格式，避免不同开发者使用不同 Cargo 版本时产生冲突
+
+## 已知关注点
+
+- I/O 多路复用与信号结合的路径较为复杂，建议在升级到 0.4.0 后重点执行高并发网络服务/事件循环框架的回归测试。
+- tmpfs 和 chroot 相关改动涉及文件系统挂载和路径解析，建议验证容器化场景下的行为。
+- 等待队列机制重构涉及并发控制，建议重点测试多线程场景下的稳定性和性能。
+- POSIX interval timer 和 CPU 时间统计为新增功能，建议在实际应用中验证定时器精度和性能开销。
+- 挂载传播机制为新增功能，建议在容器化场景下验证不同传播类型的行为。
+
+## 贡献者鸣谢
+
+感谢所有为 DragonOS 0.4.0 贡献代码、测试、文档和反馈的社区伙伴！
+
+本版本共包含 105 个提交，涉及内核核心、文件系统、进程管理、内存管理、网络、设备驱动、工程工具等多个模块的改进和修复。
+
+主要贡献者包括（按提交时间顺序）：LoGin、Vitus、kaleidoscope416、Samuel Dai、aLinChe、xboHodx、Yuming Jiang、kado、goldwind-ting、sparkzky 等。
+
+详细贡献者列表可参考 GitHub 仓库的 [Contributors 页面](https://github.com/DragonOS-Community/DragonOS/graphs/contributors)。
+
+## 参考资料
+
+- **Linux 兼容性测试看板**：[ci-dashboard.dragonos.org](https://ci-dashboard.dragonos.org)
+- **DragonOS Playground**：[cnb.cool/DragonOS-Community/playground](https://cnb.cool/DragonOS-Community/playground)
+- **社区仓库**：[github.com/DragonOS-Community/DragonOS](https://github.com/DragonOS-Community/DragonOS)
+- **官方文档**：[docs.dragonos.org](https://docs.dragonos.org)

--- a/docs/community/ChangeLog/index.rst
+++ b/docs/community/ChangeLog/index.rst
@@ -6,6 +6,7 @@
 ..  toctree::
     :maxdepth: 1
 
+    V0.4.x/V0.4.0
     V0.3.x/V0.3.0
     V0.2.x/V0.2.0
     V0.1.x/V0.1.10

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -422,7 +422,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dragonos_kernel"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "acpi",
  "asm_macros",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dragonos_kernel"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/user/apps/about/about.c
+++ b/user/apps/about/about.c
@@ -14,8 +14,8 @@ void print_ascii_logo()
 
 void print_copyright()
 {
-    printf(" DragonOS - An opensource operating system.\n");
-    printf(" Copyright: DragonOS Community. 2022-2025, All rights reserved.\n");
+    printf(" DragonOS - Lightweight Cloud-Native Kernel\n");
+    printf(" Copyright: DragonOS Community. 2022-2026, All rights reserved.\n");
     
     // 使用 uname 获取版本信息
     struct utsname buf;
@@ -35,8 +35,7 @@ void print_copyright()
     printf(" Maintainer: longjin <longjin@DragonOS.org>\n");
     printf(" Get contact with the community: <contact@DragonOS.org>\n");
     printf("\n");
-    printf(" Join our development community:\n");
-    printf("\x1B[1;33m%s\x1B[0m", "    https://bbs.dragonos.org.cn\n");
+    printf("\x1B[1;33m%s\x1B[0m", " Welcome to join our development community on GitHub!\n");
     printf("\n");
 }
 


### PR DESCRIPTION
- 新增`docs/agents/release_agent_capability.md` 文档，提供面向未来版本发布的通用“发布助手”能力说明和可复用模板
- 新增`docs/community/ChangeLog/V0.4.x/V0.4.0.md` 发行日志，详细记录V0.4.0版本的各项改进和变更
- 更新`docs/community/ChangeLog/index.rst`索引文件，添加V0.4.0版本条目
- 更新内核版本号至0.4.0（`kernel/Cargo.toml`和`kernel/Cargo.lock`）
- 更新`about`应用程序的版权信息和版本显示