### PR TITLE
feat(filesystem): 完善 rename 系统调用实现

### DIFF
--- a/user/apps/tests/syscall/gvisor/blocklists/rename_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/rename_test
@@ -1,9 +1,0 @@
-RenameTest.DirectoryOverwritesDirectoryLinkCount
-# 权限相关未实现
-RenameTest.FailsWhenOldParentNotWritable
-RenameTest.FailsWhenNewParentNotWritable
-RenameTest.OverwriteFailsWhenNewParentNotWritable
-RenameTest.FileDoesNotExistWhenNewParentNotExecutable
-# 相关系统调用未实现
-RenameTest.SysfsFileToSelf
-RenameTest.SysfsDirectoryToSelf

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -63,6 +63,7 @@ prctl_test
 
 # 内存管理测试
 mmap_test
+munmap_test
 brk_test
 mincore_test
 madvise_test


### PR DESCRIPTION
- 在 kernfs 中处理重命名到自身的特殊情况
- 在 renameat2 系统调用中添加权限检查
- 从测试黑名单中移除已实现的测试项
- 在测试白名单中添加 munmap_test