### PR TITLE
fix(epoll): 修复事件处理逻辑并优化poll系统调用

### DIFF
--- a/kernel/src/filesystem/poll.rs
+++ b/kernel/src/filesystem/poll.rs
@@ -6,8 +6,9 @@ use crate::{
     ipc::signal::{
         restore_saved_sigmask_unless, set_user_sigmask, RestartBlock, RestartBlockData, RestartFn,
     },
+    libs::wait_queue::TimeoutWaiter,
     mm::VirtAddr,
-    process::ProcessManager,
+    process::{resource::RLimitID, ProcessManager},
     syscall::{
         user_access::{UserBufferReader, UserBufferWriter},
         Syscall,
@@ -16,7 +17,10 @@ use crate::{
 };
 
 use super::vfs::file::{File, FileFlags};
+use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 use system_error::SystemError;
 
 #[repr(C)]
@@ -30,23 +34,44 @@ pub struct PollFd {
 struct PollAdapter<'a> {
     ep_file: Arc<File>,
     poll_fds: &'a mut [PollFd],
+    /// Maps fd to all indices in poll_fds array that reference this fd
+    fd_to_indices: BTreeMap<i32, Vec<usize>>,
 }
 
 impl<'a> PollAdapter<'a> {
     pub fn new(ep_file: Arc<File>, poll_fds: &'a mut [PollFd]) -> Self {
-        Self { ep_file, poll_fds }
+        Self {
+            ep_file,
+            poll_fds,
+            fd_to_indices: BTreeMap::new(),
+        }
     }
 
-    fn add_pollfds(&self) -> Result<(), SystemError> {
+    fn add_pollfds(&mut self) -> Result<(), SystemError> {
         for (i, pollfd) in self.poll_fds.iter().enumerate() {
             if pollfd.fd < 0 {
                 continue;
             }
+
+            // Track all indices for this fd
+            let indices = self.fd_to_indices.entry(pollfd.fd).or_default();
+            let is_first = indices.is_empty();
+            indices.push(i);
+
+            // Only add to epoll if this is the first occurrence of this fd
+            if !is_first {
+                continue;
+            }
+
             let mut epoll_event = EPollEvent::default();
             let poll_flags = PollFlags::from_bits_truncate(pollfd.events);
-            let ep_events: EPollEventType = poll_flags.into();
+            let mut ep_events: EPollEventType = poll_flags.into();
+            // POLLERR and POLLHUP are always reported, regardless of what events were requested
+            // This matches Linux's behavior: filter = demangle_poll(pollfd->events) | EPOLLERR | EPOLLHUP;
+            ep_events |= EPollEventType::EPOLLERR | EPollEventType::EPOLLHUP;
             epoll_event.set_events(ep_events.bits());
-            epoll_event.set_data(i as u64);
+            // Store the fd as data so we can look up all indices later
+            epoll_event.set_data(pollfd.fd as u64);
 
             EventPoll::epoll_ctl_with_epfile(
                 self.ep_file.clone(),
@@ -62,7 +87,9 @@ impl<'a> PollAdapter<'a> {
     }
 
     fn poll_all_fds(&mut self, timeout: Option<Instant>) -> Result<usize, SystemError> {
-        let mut epoll_events = vec![EPollEvent::default(); self.poll_fds.len()];
+        // Number of unique fds (not total poll_fds)
+        let unique_fds = self.fd_to_indices.len();
+        let mut epoll_events = vec![EPollEvent::default(); unique_fds];
         let len = epoll_events.len() as i32;
         let remain_timeout = timeout.map(|t| {
             t.duration_since(Instant::now())
@@ -75,15 +102,39 @@ impl<'a> PollAdapter<'a> {
             len,
             remain_timeout,
         )?;
+
+        let mut total_ready = 0usize;
+
         for event in epoll_events.iter().take(events) {
-            let index = event.data() as usize;
-            if index >= self.poll_fds.len() {
-                log::warn!("poll_all_fds: Invalid index in epoll event: {}", index);
-                continue;
+            // data contains the fd
+            let fd = event.data() as i32;
+            let actual_events = event.events();
+
+            // Get all indices for this fd
+            let indices = match self.fd_to_indices.get(&fd) {
+                Some(indices) => indices,
+                None => continue,
+            };
+
+            // Update all poll_fds entries for this fd
+            for &index in indices {
+                if index >= self.poll_fds.len() {
+                    continue;
+                }
+
+                // Apply the correct filter for this specific entry
+                let requested = self.poll_fds[index].events as u32;
+                let filter =
+                    requested | EPollEventType::EPOLLERR.bits() | EPollEventType::EPOLLHUP.bits();
+                let filtered_events = actual_events & filter;
+
+                if filtered_events != 0 {
+                    self.poll_fds[index].revents = (filtered_events & 0xffff) as u16;
+                    total_ready += 1;
+                }
             }
-            self.poll_fds[index].revents = (event.events() & 0xffff) as u16;
         }
-        Ok(events)
+        Ok(total_ready)
     }
 }
 
@@ -91,15 +142,41 @@ impl Syscall {
     /// https://code.dragonos.org.cn/xref/linux-6.6.21/fs/select.c#1068
     #[inline(never)]
     pub fn poll(pollfd_ptr: usize, nfds: u32, timeout_ms: i32) -> Result<usize, SystemError> {
-        let pollfd_ptr = VirtAddr::new(pollfd_ptr);
-        let len = nfds as usize * core::mem::size_of::<PollFd>();
+        // Check nfds against RLIMIT_NOFILE first (like Linux does)
+        // This catches negative nfds values that become large positive values when cast to u32
+        let nofile_limit = ProcessManager::current_pcb()
+            .get_rlimit(RLimitID::Nofile)
+            .rlim_cur as usize;
+        if nfds as usize > nofile_limit {
+            return Err(SystemError::EINVAL);
+        }
 
         let mut timeout: Option<Instant> = None;
         if timeout_ms >= 0 {
             timeout = poll_select_set_timeout(timeout_ms as u64);
         }
+
+        // Handle nfds=0 as a special case - no buffer needed
+        // This handles poll(nullptr, 0, timeout) correctly
+        if nfds == 0 {
+            let mut r = poll_no_fds(timeout);
+            if let Err(SystemError::ERESTARTNOHAND) = r {
+                let pollfd_ptr = VirtAddr::new(pollfd_ptr);
+                let restart_block_data = RestartBlockData::new_poll(pollfd_ptr, nfds, timeout);
+                let restart_block = RestartBlock::new(&RestartFnPoll, restart_block_data);
+                r = ProcessManager::current_pcb().set_restart_fn(Some(restart_block));
+            }
+            return r;
+        }
+
+        let pollfd_ptr = VirtAddr::new(pollfd_ptr);
+        let len = nfds as usize * core::mem::size_of::<PollFd>();
+
         let mut poll_fds_writer = UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), len, true)?;
-        let mut r = do_sys_poll(poll_fds_writer.buffer(0)?, timeout);
+        let poll_fds = poll_fds_writer.buffer(0)?;
+
+        let mut r = do_sys_poll(poll_fds, timeout);
+
         if let Err(SystemError::ERESTARTNOHAND) = r {
             let restart_block_data = RestartBlockData::new_poll(pollfd_ptr, nfds, timeout);
             let restart_block = RestartBlock::new(&RestartFnPoll, restart_block_data);
@@ -117,19 +194,25 @@ impl Syscall {
         timespec_ptr: usize,
         sigmask_ptr: usize,
     ) -> Result<usize, SystemError> {
+        // Check nfds against RLIMIT_NOFILE first (like Linux does)
+        let nofile_limit = ProcessManager::current_pcb()
+            .get_rlimit(RLimitID::Nofile)
+            .rlim_cur as usize;
+        if nfds as usize > nofile_limit {
+            return Err(SystemError::EINVAL);
+        }
+
         let mut timeout_ts: Option<Instant> = None;
         let mut sigmask: Option<SigSet> = None;
-        let pollfd_ptr = VirtAddr::new(pollfd_ptr);
-        let pollfds_len = nfds as usize * core::mem::size_of::<PollFd>();
-        let mut poll_fds_writer =
-            UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), pollfds_len, true)?;
-        let poll_fds = poll_fds_writer.buffer(0)?;
+
+        // Read sigmask first (before any potential blocking)
         if sigmask_ptr != 0 {
             let sigmask_reader =
                 UserBufferReader::new(sigmask_ptr as *const SigSet, size_of::<SigSet>(), true)?;
             sigmask = Some(*sigmask_reader.read_one_from_user(0)?);
         }
 
+        // Read timeout
         if timespec_ptr != 0 {
             let tsreader = UserBufferReader::new(
                 timespec_ptr as *const PosixTimeSpec,
@@ -145,16 +228,22 @@ impl Syscall {
             }
         }
 
+        // Set sigmask before blocking
         if let Some(mut sigmask) = sigmask {
             set_user_sigmask(&mut sigmask);
         }
-        // log::debug!(
-        //     "ppoll: poll_fds: {:?}, nfds: {}, timeout_ts: {:?}，sigmask: {:?}",
-        //     poll_fds,
-        //     nfds,
-        //     timeout_ts,
-        //     sigmask
-        // );
+
+        // Handle nfds=0 as a special case - no buffer needed
+        if nfds == 0 {
+            let r: Result<usize, SystemError> = poll_no_fds(timeout_ts);
+            return poll_select_finish(timeout_ts, timespec_ptr, PollTimeType::TimeSpec, r);
+        }
+
+        let pollfd_ptr = VirtAddr::new(pollfd_ptr);
+        let pollfds_len = nfds as usize * core::mem::size_of::<PollFd>();
+        let mut poll_fds_writer =
+            UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), pollfds_len, true)?;
+        let poll_fds = poll_fds_writer.buffer(0)?;
 
         let r: Result<usize, SystemError> = do_sys_poll(poll_fds, timeout_ts);
 
@@ -166,6 +255,12 @@ pub fn do_sys_poll(
     poll_fds: &mut [PollFd],
     timeout: Option<Instant>,
 ) -> Result<usize, SystemError> {
+    // Handle the case of no file descriptors to poll
+    // This is a special case where we just need to wait for signals or timeout
+    if poll_fds.is_empty() {
+        return poll_no_fds(timeout);
+    }
+
     let ep_file = EventPoll::create_epoll_file(FileFlags::empty())?;
 
     let ep_file = Arc::new(ep_file);
@@ -175,6 +270,75 @@ pub fn do_sys_poll(
     let nevents = adapter.poll_all_fds(timeout)?;
 
     Ok(nevents)
+}
+
+/// Handle poll with no file descriptors - wait for signals or timeout
+fn poll_no_fds(timeout: Option<Instant>) -> Result<usize, SystemError> {
+    let current_pcb = ProcessManager::current_pcb();
+
+    // Check for pending signals first
+    if current_pcb.has_pending_signal_fast() && current_pcb.has_pending_not_masked_signal() {
+        return Err(SystemError::ERESTARTNOHAND);
+    }
+
+    // Handle immediate timeout (timeout == Some(instant_in_past) or timeout == Some(now))
+    if let Some(end_time) = timeout {
+        if Instant::now() >= end_time {
+            return Ok(0);
+        }
+    }
+
+    // Calculate remaining timeout in microseconds
+    let timeout_us = timeout.map(|end_time| {
+        let now = Instant::now();
+        if now >= end_time {
+            0u64
+        } else {
+            end_time
+                .duration_since(now)
+                .unwrap_or(Duration::ZERO)
+                .micros()
+        }
+    });
+
+    // If zero timeout, return immediately
+    if timeout_us == Some(0) {
+        return Ok(0);
+    }
+
+    // Use safe TimeoutWaiter pattern
+    let timeout_waiter = TimeoutWaiter::new(timeout_us);
+
+    loop {
+        // Check for signals before waiting
+        if current_pcb.has_pending_signal_fast() && current_pcb.has_pending_not_masked_signal() {
+            return Err(SystemError::ERESTARTNOHAND);
+        }
+
+        // Wait with timeout using the safe Waiter/Waker pattern
+        match timeout_waiter.wait(true) {
+            Ok(true) => return Ok(0), // Timed out
+            Ok(false) => {
+                // Woken up - check if by signal
+                if current_pcb.has_pending_signal_fast()
+                    && current_pcb.has_pending_not_masked_signal()
+                {
+                    return Err(SystemError::ERESTARTNOHAND);
+                }
+                // For infinite timeout (None), continue waiting
+                if timeout.is_none() {
+                    continue;
+                }
+                // For finite timeout, check if expired
+                if let Some(end_time) = timeout {
+                    if Instant::now() >= end_time {
+                        return Ok(0);
+                    }
+                }
+            }
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 /// 计算超时的时刻

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -26,6 +26,7 @@ stat_test
 statfs_test
 #chmod_test
 #chown_test
+poll_test
 chdir_test
 fchdir_test
 pread64_test


### PR DESCRIPTION
- 修复epoll事件处理中EPOLLONESHOT和EPOLLET标志检查逻辑，使用注册事件而非实际事件
- 优化poll系统调用，支持nfds=0的特殊情况处理，添加RLIMIT_NOFILE检查
- 修复Unix流套接字recv和recv_from方法的阻塞行为
- 重构超时等待机制，使用安全的TimeoutWaiter模式替代不安全代码
- 修复管道关闭时的epoll通知机制，确保正确唤醒等待者
- 添加对"始终就绪"文件类型（目录、普通文件）的poll支持