### PR TITLE
fix(riscv64 platform):Fix several bugs on the VF2 platform and existing on riscv64

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -157,12 +157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "byte-slice-cast"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,7 +425,6 @@ dependencies = [
  "bitfield-struct",
  "bitflags 1.3.2",
  "bitmap",
- "byte-slice-cast",
  "cfg-if",
  "cpio_reader",
  "defer",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -108,7 +108,6 @@ uefi-raw = "=0.5.0"
 riscv = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/riscv.git", rev = "4241a97", features = [
     "s-mode",
 ] }
-byte-slice-cast = { version = "1.2.2", default-features = false }
 sbi-rt = { version = "=0.0.3", features = ["legacy"] }
 uefi = { version = "=0.26.0", features = ["alloc"] }
 uefi-raw = "=0.5.0"

--- a/kernel/src/arch/riscv64/driver/vf2/dw_mshc/dma.rs
+++ b/kernel/src/arch/riscv64/driver/vf2/dw_mshc/dma.rs
@@ -4,7 +4,7 @@ use bitfield_struct::bitfield;
 pub struct DES0 {
     _reserved0: bool,
     disable_interrupt_on_completion: bool,
-    last_decriptor: bool,
+    last_descriptor: bool,
     first_descriptor: bool,
     second_address_chained: bool,
     end_of_ring: bool,

--- a/kernel/src/arch/riscv64/driver/vf2/dw_mshc/mmc.rs
+++ b/kernel/src/arch/riscv64/driver/vf2/dw_mshc/mmc.rs
@@ -41,7 +41,6 @@ use crate::libs::{
 use crate::mm::allocator::page_frame::PhysPageFrame;
 use crate::mm::mmio_buddy::{mmio_pool, MMIOSpaceGuard};
 use crate::mm::{MemoryManagementArch, PhysAddr};
-use byte_slice_cast::*;
 use log::{debug, info, warn};
 use system_error::SystemError;
 
@@ -216,7 +215,7 @@ impl MMC {
             info!("CID: {:x?}", cid);
             info!(
                 "Card Name: {}",
-                core::str::from_utf8(cid.name().to_be_bytes().as_byte_slice()).unwrap()
+                core::str::from_utf8(&cid.name().to_be_bytes()).unwrap()
             );
         }
 

--- a/kernel/src/arch/riscv64/init/dragonstub.rs
+++ b/kernel/src/arch/riscv64/init/dragonstub.rs
@@ -41,6 +41,7 @@ impl BootCallbacks for DragonStubCallBack {
 
     fn init_memmap_sysfs(&self) -> Result<(), SystemError> {
         log::error!("riscv64, init_memmap_sysfs is not impled");
+        crate::mm::sysfs::early_memmap_init();
         Ok(())
     }
 


### PR DESCRIPTION
…ng bugs in the RISCV architecture

- Fix several bugs on the VF2 platform
- Fix some riscv bugs because of kexec codes.