### PR TITLE
fix(net): 修复Unix流套接字SCM记录边界处理

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,8 @@ run-vnc: check_arch
 
 run-nographic: check_arch
 	$(MAKE) kernel
-	# SKIP_GRUB=1 $(MAKE) write_diskimage || exit 1
-	$(MAKE) rootfs
+	SKIP_GRUB=1 $(MAKE) write_diskimage || exit 1
+	# $(MAKE) rootfs
 	$(MAKE) qemu-nographic
 
 # 在docker中编译，并启动QEMU

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -84,9 +84,9 @@ socket_unix_seqpacket_local_test
 socket_unix_unbound_seqpacket_test
 socket_unix_stream_test
 socket_unix_unbound_abstract_test
-# socket_unix_unbound_dgram_test
-# socket_unix_unbound_filesystem_test
-# socket_unix_unbound_stream_test
+socket_unix_unbound_dgram_test
+socket_unix_unbound_filesystem_test
+socket_unix_unbound_stream_test
 
 # 信号处理测试
 sigaction_test


### PR DESCRIPTION
- 修复Unix流套接字SCM记录边界处理，确保recvmsg正确合并数据
- 修复write系统调用零长度写入的语义
- 修复open系统调用对socket文件的处理
- 更新Makefile构建配置
- 启用gVisor Unix套接字测试