### PR TITLE
feat(signal): 完善信号发送者信息传递与rt_sigqueueinfo实现

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -278,7 +278,13 @@ impl X86_64MMArch {
 
         let send_segv = || {
             let pid = ProcessManager::current_pid();
-            let mut info = SigInfo::new(Signal::SIGSEGV, 0, SigCode::User, SigType::Kill(pid));
+            let uid = ProcessManager::current_pcb().cred().uid.data() as u32;
+            let mut info = SigInfo::new(
+                Signal::SIGSEGV,
+                0,
+                SigCode::User,
+                SigType::Kill { pid, uid },
+            );
             Signal::SIGSEGV
                 .send_signal_info(Some(&mut info), pid)
                 .expect("failed to send SIGSEGV to process");
@@ -446,7 +452,10 @@ impl X86_64MMArch {
                 sig,
                 0,
                 SigCode::User,
-                SigType::Kill(ProcessManager::current_pid()),
+                SigType::Kill {
+                    pid: ProcessManager::current_pid(),
+                    uid: ProcessManager::current_pcb().cred().uid.data() as u32,
+                },
             );
             let _ = sig.send_signal_info(Some(&mut info), ProcessManager::current_pid());
             return;

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -740,7 +740,10 @@ impl IndexNode for LockedPipeInode {
                             sig,
                             0,
                             SigCode::Kernel,
-                            SigType::Kill(ProcessManager::current_pcb().task_pid_vnr()),
+                            SigType::Kill {
+                                pid: ProcessManager::current_pcb().task_pid_vnr(),
+                                uid: ProcessManager::current_pcb().cred().uid.data() as u32,
+                            },
                         );
                         compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
@@ -812,7 +815,10 @@ impl IndexNode for LockedPipeInode {
                             sig,
                             0,
                             SigCode::Kernel,
-                            SigType::Kill(ProcessManager::current_pcb().task_pid_vnr()),
+                            SigType::Kill {
+                                pid: ProcessManager::current_pcb().task_pid_vnr(),
+                                uid: ProcessManager::current_pcb().cred().uid.data() as u32,
+                            },
                         );
                         compiler_fence(core::sync::atomic::Ordering::SeqCst);
 

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -163,11 +163,17 @@ impl Signal {
                 }
                 None => {
                     // 不需要显示指定siginfo，因此设置为默认值
+                    let current_pcb = ProcessManager::current_pcb();
+                    let sender_pid = current_pcb.raw_pid();
+                    let sender_uid = current_pcb.cred().uid.data() as u32;
                     SigInfo::new(
                         *self,
                         0,
                         SigCode::User,
-                        SigType::Kill(ProcessManager::current_pcb().raw_pid()),
+                        SigType::Kill {
+                            pid: sender_pid,
+                            uid: sender_uid,
+                        },
                     )
                 }
             };

--- a/kernel/src/ipc/syscall/sys_pidfd_sendsignal.rs
+++ b/kernel/src/ipc/syscall/sys_pidfd_sendsignal.rs
@@ -62,12 +62,18 @@ impl Syscall for SysPidfdSendSignalHandle {
             return Ok(0);
         }
 
-        // 应该从参数获取
+        let current_pcb = ProcessManager::current_pcb();
+        let sender_pid = current_pcb.raw_pid();
+        let sender_uid = current_pcb.cred().uid.data() as u32;
+
         let mut info = SigInfo::new(
             sig,
             0,
             SigCode::User,
-            SigType::Kill(RawPid::new(pid as usize)),
+            SigType::Kill {
+                pid: sender_pid,
+                uid: sender_uid,
+            },
         );
 
         let ret = sig

--- a/kernel/src/ipc/syscall/sys_restart.rs
+++ b/kernel/src/ipc/syscall/sys_restart.rs
@@ -25,7 +25,7 @@ pub(super) fn do_kernel_restart_syscall() -> Result<usize, SystemError> {
         // 不应该走到这里，因此kill掉当前进程及同组的进程
         let pid = RawPid::new(0);
         let sig = Signal::SIGKILL;
-        let mut info = SigInfo::new(sig, 0, SigCode::Kernel, SigType::Kill(pid));
+        let mut info = SigInfo::new(sig, 0, SigCode::Kernel, SigType::Kill { pid, uid: 0 });
 
         sig.send_signal_info(Some(&mut info), pid)
             .expect("Failed to kill ");

--- a/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
+++ b/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
@@ -1,19 +1,25 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::ffi::c_int;
+use core::mem::size_of;
 
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_RT_SIGQUEUEINFO;
-use crate::ipc::kill::send_signal_to_pid;
+use crate::ipc::signal_types::{PosixSigInfo, SigCode, SigInfo, SigType};
+use crate::ipc::syscall::sys_kill::check_signal_permission_pcb_with_sig;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::{arch::ipc::signal::Signal, process::RawPid};
+use crate::syscall::user_access::UserBufferReader;
+use crate::{arch::ipc::signal::Signal, process::ProcessManager, process::RawPid};
 use system_error::SystemError;
 
 /// rt_sigqueueinfo 系统调用（最小兼容实现）
 ///
 /// 语义上与 kill(pid, sig) 类似，但允许用户态携带一个 siginfo_t。
-/// 当前实现仅用于权限与错误码兼容：忽略用户态 siginfo 内容，
-/// 直接复用 kill_process 的权限检查与投递逻辑。
+/// 参考 Linux 6.6：
+/// - 从用户态拷贝 siginfo（并强制以参数 sig 作为 si_signo）
+/// - 若向“非自身 pid”发送，禁止伪造内核/kill/tkill 的 si_code：
+///   `(si_code >= 0 || si_code == SI_TKILL) && current_pid != pid` => EPERM
+/// - 将 si_errno 等字段随信号投递给目标。
 struct SysRtSigqueueinfoHandle;
 
 impl SysRtSigqueueinfoHandle {
@@ -29,8 +35,6 @@ impl SysRtSigqueueinfoHandle {
 
     #[inline(always)]
     fn _uinfo(args: &[usize]) -> usize {
-        // 第三个参数是用户态 siginfo_t 指针，当前实现仅校验存在性，
-        // 不解析其中内容。
         args[2]
     }
 }
@@ -43,10 +47,23 @@ impl Syscall for SysRtSigqueueinfoHandle {
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let pid = Self::pid(args);
         let sig = Self::sig(args);
-        let _uinfo = Self::_uinfo(args);
+        let uinfo = Self::_uinfo(args) as *const PosixSigInfo;
 
         if pid <= 0 {
             return Err(SystemError::EINVAL);
+        }
+
+        if uinfo.is_null() {
+            return Err(SystemError::EFAULT);
+        }
+
+        // sig==0 探测模式：只做存在性与权限检查（与 kill(2) 语义一致）
+        if sig == 0 {
+            let target_pid = RawPid::from(pid as usize);
+            let target = ProcessManager::find_task_by_vpid(target_pid).ok_or(SystemError::ESRCH)?;
+            // 传入 Signal::INVALID/0 在权限检查里无特殊含义，这里用 None 即可
+            check_signal_permission_pcb_with_sig(&target, None)?;
+            return Ok(0);
         }
 
         let signal = Signal::from(sig);
@@ -54,9 +71,65 @@ impl Syscall for SysRtSigqueueinfoHandle {
             return Err(SystemError::EINVAL);
         }
 
-        // 复用 kill(2) 的权限与投递逻辑。
-        let raw = RawPid::from(pid as usize);
-        send_signal_to_pid(raw, signal)
+        // 从用户空间读取 siginfo_t
+        let reader = UserBufferReader::new(uinfo, size_of::<PosixSigInfo>(), true)?;
+        let user_info = reader.read_one_from_user::<PosixSigInfo>(0)?;
+
+        let target_pid = RawPid::from(pid as usize);
+        let current_pcb = ProcessManager::current_pcb();
+        let current_pid = current_pcb.raw_pid();
+
+        // Linux 6.6: do_rt_sigqueueinfo 权限校验
+        let si_code = user_info.si_code;
+        if (si_code >= 0 || si_code == (SigCode::Tkill as i32)) && current_pid != target_pid {
+            return Err(SystemError::EPERM);
+        }
+
+        // 解析 si_code（未知 code：尽量保持“来自用户态(负值)”的语义，不 panic）
+        let code_enum = SigCode::try_from_i32(si_code).unwrap_or({
+            if si_code < 0 {
+                SigCode::Queue
+            } else {
+                SigCode::User
+            }
+        });
+
+        let sender_uid = current_pcb.cred().uid.data() as u32;
+        let sender_pid = current_pid;
+
+        // 根据信号来源/布局构造内核 SigInfo
+        let sig_type = match code_enum {
+            SigCode::Queue => {
+                let sigval = unsafe { user_info._sifields._rt.si_sigval };
+                SigType::Rt {
+                    pid: sender_pid,
+                    uid: sender_uid,
+                    sigval,
+                }
+            }
+            SigCode::Timer => {
+                let timer = unsafe { user_info._sifields._timer };
+                SigType::PosixTimer {
+                    timerid: timer.si_tid,
+                    overrun: timer.si_overrun,
+                    sigval: timer.si_sigval,
+                }
+            }
+            _ => SigType::Kill {
+                pid: sender_pid,
+                uid: sender_uid,
+            },
+        };
+
+        let mut info = SigInfo::new(signal, user_info.si_errno, code_enum, sig_type);
+
+        // 查找目标进程并检查权限
+        let target = ProcessManager::find_task_by_vpid(target_pid).ok_or(SystemError::ESRCH)?;
+        check_signal_permission_pcb_with_sig(&target, Some(signal))?;
+
+        signal
+            .send_signal_info_to_pcb(Some(&mut info), target)
+            .map(|x| x as usize)
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/ipc/syscall/sys_tkill.rs
+++ b/kernel/src/ipc/syscall/sys_tkill.rs
@@ -165,12 +165,16 @@ fn send_signal_to_thread(
     // 构造SigInfo，使用SI_TKILL语义
     let current_pcb = ProcessManager::current_pcb();
     let current_tgid = current_pcb.task_tgid_vnr().unwrap_or(RawPid::from(0));
+    let sender_uid = current_pcb.cred().uid.data() as u32;
 
     let mut info = SigInfo::new(
         sig,
         0,
         SigCode::Tkill, // 使用SI_TKILL语义
-        SigType::Kill(current_tgid),
+        SigType::Kill {
+            pid: current_tgid,
+            uid: sender_uid,
+        },
     );
 
     // 发送信号

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -94,6 +94,7 @@ sigprocmask_test
 sigaltstack_test
 sigreturn_test
 sigtimedwait_test
+rtsignal_test
 
 # 其他测试
 itimer_test


### PR DESCRIPTION
- 修改SigType枚举，为Kill类型添加uid字段，并新增Rt类型以支持rt_sigqueueinfo
- 在所有信号发送路径中传递发送者的pid和uid信息
- 实现rt_sigqueueinfo系统调用，支持用户态传递siginfo信息
- 更新SigCode::try_from_i32方法以支持错误处理
- 添加rtsignal_test到测试白名单