### PR TITLE
feat(vfs): 改进pread/pwrite和getdents的用户缓冲区处理

### DIFF
--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -6,6 +6,7 @@ mod faccessat2;
 mod link_utils;
 mod newfstat;
 mod open_utils;
+mod pread_pwrite_common;
 mod readlink_at;
 mod rename_utils;
 mod sys_chdir;

--- a/kernel/src/filesystem/vfs/syscall/pread_pwrite_common.rs
+++ b/kernel/src/filesystem/vfs/syscall/pread_pwrite_common.rs
@@ -1,0 +1,137 @@
+use alloc::vec;
+use system_error::SystemError;
+
+use crate::{
+    filesystem::vfs::file::File,
+    mm::VirtAddr,
+    syscall::user_access::{copy_from_user_protected, copy_to_user_protected, user_accessible_len},
+};
+
+pub(super) enum PreadPwriteDir {
+    Read,
+    Write,
+}
+
+/// Common implementation for pread64/pwrite64 with Linux-compatible "partial bad buffer" semantics.
+///
+/// Key rules:
+/// - If `len == 0`, must not touch user memory.
+/// - If the user buffer is partially inaccessible, return the number of bytes successfully
+///   transferred; only return `EFAULT` if **0 bytes** were transferred.
+///
+/// `from_user` controls whether the pointer should be treated as a userspace pointer.
+pub(super) fn do_pread_pwrite_at(
+    file: &File,
+    offset: usize,
+    user_ptr: usize,
+    len: usize,
+    from_user: bool,
+    dir: PreadPwriteDir,
+) -> Result<usize, SystemError> {
+    if len == 0 {
+        return match dir {
+            PreadPwriteDir::Read => {
+                let mut empty: [u8; 0] = [];
+                file.pread(offset, 0, &mut empty)
+            }
+            PreadPwriteDir::Write => file.pwrite(offset, 0, &[]),
+        };
+    }
+
+    if from_user && user_ptr == 0 {
+        return Err(SystemError::EFAULT);
+    }
+
+    const CHUNK: usize = 64 * 1024;
+    let mut total: usize = 0;
+    let mut cur_off: usize = offset;
+
+    while total < len {
+        let remain = len - total;
+        let want = core::cmp::min(CHUNK, remain);
+
+        let user_addr = VirtAddr::new(user_ptr.saturating_add(total));
+        let check_write = matches!(dir, PreadPwriteDir::Read);
+
+        let accessible = if from_user {
+            user_accessible_len(user_addr, want, check_write)
+        } else {
+            want
+        };
+
+        if accessible == 0 {
+            if total == 0 {
+                return Err(SystemError::EFAULT);
+            }
+            break;
+        }
+
+        let mut kbuf = vec![0u8; accessible];
+
+        match dir {
+            PreadPwriteDir::Read => {
+                let n = file.pread(cur_off, accessible, &mut kbuf)?;
+                if n == 0 {
+                    break;
+                }
+
+                if from_user {
+                    match unsafe { copy_to_user_protected(user_addr, &kbuf[..n]) } {
+                        Ok(_) => {
+                            total = total.saturating_add(n);
+                            cur_off = cur_off.saturating_add(n);
+                        }
+                        Err(SystemError::EFAULT) => {
+                            if total == 0 {
+                                return Err(SystemError::EFAULT);
+                            }
+                            break;
+                        }
+                        Err(e) => return Err(e),
+                    }
+                } else {
+                    let dst =
+                        unsafe { core::slice::from_raw_parts_mut(user_addr.data() as *mut u8, n) };
+                    dst.copy_from_slice(&kbuf[..n]);
+                    total = total.saturating_add(n);
+                    cur_off = cur_off.saturating_add(n);
+                }
+
+                // Stop on short file read (EOF) or when we intentionally clipped to accessible area.
+                if n < accessible || accessible < want {
+                    break;
+                }
+            }
+            PreadPwriteDir::Write => {
+                if from_user {
+                    match unsafe { copy_from_user_protected(&mut kbuf, user_addr) } {
+                        Ok(_) => {}
+                        Err(SystemError::EFAULT) => {
+                            if total == 0 {
+                                return Err(SystemError::EFAULT);
+                            }
+                            break;
+                        }
+                        Err(e) => return Err(e),
+                    }
+                } else {
+                    let src = unsafe {
+                        core::slice::from_raw_parts(user_addr.data() as *const u8, accessible)
+                    };
+                    kbuf.copy_from_slice(src);
+                }
+
+                let n = file.pwrite(cur_off, accessible, &kbuf)?;
+                total = total.saturating_add(n);
+                cur_off = cur_off.saturating_add(n);
+
+                // Stop on short write or when we intentionally clipped to accessible area.
+                if n < accessible || accessible < want {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(total)
+}

--- a/kernel/src/filesystem/vfs/syscall/sys_pread64.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_pread64.rs
@@ -7,9 +7,10 @@ use crate::arch::syscall::nr::SYS_PREAD64;
 use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
-use crate::syscall::user_access::UserBufferWriter;
 use alloc::string::ToString;
 use alloc::vec::Vec;
+
+use super::pread_pwrite_common::{do_pread_pwrite_at, PreadPwriteDir};
 
 /// System call handler for the `pread64` syscall
 ///
@@ -42,10 +43,6 @@ impl Syscall for SysPread64Handle {
             return Err(SystemError::EINVAL);
         }
 
-        let mut user_buffer_writer =
-            UserBufferWriter::new_checked(buf_vaddr, len, frame.is_from_user())?;
-        let user_buf = user_buffer_writer.buffer(0)?;
-
         let binding = ProcessManager::current_pcb().fd_table();
         let fd_table_guard = binding.read();
 
@@ -56,7 +53,14 @@ impl Syscall for SysPread64Handle {
         // Drop guard to avoid scheduling issues
         drop(fd_table_guard);
 
-        return file.pread(offset, len, user_buf);
+        do_pread_pwrite_at(
+            file.as_ref(),
+            offset,
+            buf_vaddr as usize,
+            len,
+            frame.is_from_user(),
+            PreadPwriteDir::Read,
+        )
     }
 
     /// Formats the syscall parameters for display/debug purposes

--- a/kernel/src/filesystem/vfs/syscall/sys_preadv.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_preadv.rs
@@ -79,9 +79,9 @@ pub fn do_preadv(fd: i32, iovecs: &IoVecs, offset: usize) -> Result<usize, Syste
     let read_len = file.pread(offset, data.len(), &mut data)?;
 
     // Scatter the read data back to user buffers.
-    iovecs.scatter(&data[..read_len])?;
+    let copied = iovecs.scatter(&data[..read_len])?;
 
-    Ok(read_len)
+    Ok(copied)
 }
 
 syscall_table_macros::declare_syscall!(SYS_PREADV, SysPreadVHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_preadv2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_preadv2.rs
@@ -133,8 +133,8 @@ pub fn do_preadv2(
 
         let mut data = vec![0; iovecs.total_len()];
         let read_len = file.read(data.len(), &mut data)?;
-        iovecs.scatter(&data[..read_len])?;
-        return Ok(read_len);
+        let copied = iovecs.scatter(&data[..read_len])?;
+        return Ok(copied);
     }
 
     // offset 为非负时，直接复用现有的 preadv 实现，保持语义一致

--- a/user/apps/tests/syscall/gvisor/blocklists/partitial_bad_buffer_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/partitial_bad_buffer_test
@@ -1,0 +1,1 @@
+PartialBadBufferTest.SendMsgTCP

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -111,3 +111,5 @@ clock_nanosleep_test
 clock_getres_test
 clock_gettime_test
 setgid_test
+partitial_bad_buffer_test
+


### PR DESCRIPTION
- 新增pread_pwrite_common模块，实现Linux兼容的部分缓冲区访问语义
- 修改IoVecs::scatter方法返回实际写入字节数
- 修复getdents错误处理逻辑，遵循Linux语义返回已写入字节数
- 优化UserBuffer清零操作，临时关闭内核写保护
- 更新测试配置，添加部分坏缓冲区测试