### PR TITLE
feat(arch/x86_64): 添加AVX支持和XSAVE指令集优化

### DIFF
--- a/kernel/src/arch/x86_64/asm/head.S
+++ b/kernel/src/arch/x86_64/asm/head.S
@@ -291,6 +291,50 @@ switch_to_start64:
 
 .code64
 halt:
+
+// Enable FPU/SSE and optionally XSAVE/XCR0.
+// - Always enables CR0.MP and clears CR0.EM
+// - Always enables CR4.OSFXSR/CR4.OSXMMEXCPT
+// - Enables CR4.OSXSAVE and sets XCR0 only if CPUID reports XSAVE support
+//   (and sets XCR0 to 0x7 only if AVX is also supported)
+.macro ENABLE_FPU_SSE_XSAVE_XCR0
+    // Enable legacy x87 + SSE usage
+    movq %cr0, %rax
+    and $0xFFFB, %ax		// clear coprocessor emulation CR0.EM
+    or $0x2, %ax			// set coprocessor monitoring CR0.MP
+    movq %rax, %cr0
+
+    // Always enable OSFXSR/OSXMMEXCPT (x86_64 baseline has SSE/SSE2)
+    movq %cr4, %rax
+    or $(3 << 9), %ax		// set CR4.OSFXSR and CR4.OSXMMEXCPT
+    movq %rax, %cr4
+
+    // Conditionally enable XSAVE and set XCR0.
+    // On CPUs without XSAVE/AVX, unguarded CR4.OSXSAVE/xsetbv would #GP and crash early boot.
+    pushq %rbx
+    mov $0x1, %eax
+    cpuid
+    bt $26, %ecx			// CPUID.01H:ECX.XSAVE[26]
+    jnc .Lno_xsave\@
+
+    // XSAVE is supported: enable CR4.OSXSAVE so XGETBV/XSETBV are usable
+    movq %cr4, %rax
+    or $(1 << 18), %rax		// CR4.OSXSAVE
+    movq %rax, %cr4
+
+    // Default to x87 + SSE state (XCR0=0x3). If AVX is supported, include YMM (XCR0=0x7).
+    mov $0x3, %eax			// x87 + SSE
+    bt $28, %ecx			// CPUID.01H:ECX.AVX[28]
+    jnc .Lxcr0_set\@
+    mov $0x7, %eax			// x87 + SSE + AVX
+.Lxcr0_set\@:
+    xor %ecx, %ecx			// XCR0
+    xor %edx, %edx			// high 32 bits = 0
+    xsetbv					// Set XCR0
+.Lno_xsave\@:
+    popq %rbx
+.endm
+
     cli
     hlt
     jmp halt
@@ -485,15 +529,8 @@ repeat_set_idt:
     dec %rcx
     jne repeat_set_idt
 
-    
-    //now enable SSE and the like
-    movq %cr0, %rax
-    and $0xFFFB, %ax		//clear coprocessor emulation CR0.EM
-    or $0x2, %ax			//set coprocessor monitoring  CR0.MP
-    movq %rax, %cr0
-    movq %cr4, %rax
-    or $(3 << 9), %ax		//set CR4.OSFXSR and CR4.OSXMMEXCPT at the same time
-    movq %rax, %cr4
+
+    ENABLE_FPU_SSE_XSAVE_XCR0
 
 
     movq	go_to_kernel(%rip),	%rax		/* movq address */
@@ -516,14 +553,7 @@ go_to_kernel:
 start_smp:
 
 
-    //now enable SSE and the like
-    movq %cr0, %rax
-    and $0xFFFB, %ax		//clear coprocessor emulation CR0.EM
-    or $0x2, %ax			//set coprocessor monitoring  CR0.MP
-    movq %rax, %cr0
-    movq %cr4, %rax
-    or $(3 << 9), %ax		//set CR4.OSFXSR and CR4.OSXMMEXCPT at the same time
-    movq %rax, %cr4
+    ENABLE_FPU_SSE_XSAVE_XCR0
 
 
 	movq	go_to_smp_kernel(%rip),	%rax		/* movq address */

--- a/kernel/src/arch/x86_64/fpu.rs
+++ b/kernel/src/arch/x86_64/fpu.rs
@@ -1,69 +1,263 @@
-use core::arch::x86_64::{_fxrstor64, _fxsave64};
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
-/// https://www.felixcloutier.com/x86/fxsave#tbl-3-47
-#[repr(C, align(16))]
-#[derive(Debug, Copy, Clone)]
+/// XSAVE area 的最大大小
+/// 对于 AVX: 约 832 字节 (512 + 64 header + 256 YMM)
+/// 对于 AVX-512: 可能超过 2KB
+/// 我们目前只支持到 AVX，因此使用 1024 字节足够
+/// 这样可以减少每个进程的内存占用
+const MAX_XSAVE_SIZE: usize = 1024;
+
+/// 全局变量：是否使用 XSAVE（而不是 FXSAVE）
+static USE_XSAVE: AtomicBool = AtomicBool::new(false);
+
+/// 全局变量：XSAVE 特性掩码
+static XSAVE_FEATURE_MASK: AtomicU64 = AtomicU64::new(0);
+
+/// 全局变量：XSAVE area 大小
+static XSAVE_AREA_SIZE: AtomicUsize = AtomicUsize::new(512);
+
+/// XSAVE 特性位
+pub const XFEATURE_X87: u64 = 1 << 0;
+pub const XFEATURE_SSE: u64 = 1 << 1;
+pub const XFEATURE_AVX: u64 = 1 << 2;
+
+/// FPU/SSE/AVX 状态保存结构
+/// 使用 XSAVE 指令保存时需要 64 字节对齐
+#[repr(C, align(64))]
+#[derive(Debug)]
 pub struct FpState {
-    //0
-    fcw: u16,
-    fsw: u16,
-    ftw: u16,
-    fop: u16,
-    word2: u64,
-    //16
-    word3: u64,
-    mxcsr: u32,
-    mxcsr_mask: u32,
-    //32
-    mm: [u64; 16],
-    //160
-    xmm: [u64; 32],
-    //416
-    rest: [u64; 12],
+    /// XSAVE/FXSAVE area
+    /// 前 512 字节是 FXSAVE 兼容的格式
+    /// 512 字节之后是扩展状态组件（AVX 等）
+    data: [u8; MAX_XSAVE_SIZE],
 }
+
+impl Clone for FpState {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl Copy for FpState {}
 
 impl Default for FpState {
     fn default() -> Self {
-        Self {
-            fcw: 0x037f,
-            fsw: Default::default(),
-            ftw: Default::default(),
-            fop: Default::default(),
-            word2: Default::default(),
-            word3: Default::default(),
-            mxcsr: 0x1f80,
-            mxcsr_mask: Default::default(),
-            mm: Default::default(),
-            xmm: Default::default(),
-            rest: Default::default(),
-        }
+        let mut state = Self {
+            data: [0u8; MAX_XSAVE_SIZE],
+        };
+        state.init_default();
+        state
     }
 }
+
 impl FpState {
+    /// 初始化 XSAVE 支持检测（在内核启动时调用一次）
+    pub fn init_xsave_support() {
+        use raw_cpuid::CpuId;
+
+        let cpuid = CpuId::new();
+
+        // 检查 XSAVE 支持
+        let has_xsave = cpuid
+            .get_feature_info()
+            .map(|f| f.has_xsave())
+            .unwrap_or(false);
+
+        let has_osxsave = cpuid
+            .get_feature_info()
+            .map(|f| f.has_oxsave())
+            .unwrap_or(false);
+
+        if !has_xsave || !has_osxsave {
+            log::info!(
+                "XSAVE not available, using FXSAVE (xsave={}, osxsave={})",
+                has_xsave,
+                has_osxsave
+            );
+            USE_XSAVE.store(false, Ordering::SeqCst);
+            XSAVE_AREA_SIZE.store(512, Ordering::SeqCst);
+            return;
+        }
+
+        // 获取 XCR0 当前值（head.S 会在支持 XSAVE 时设置；通常为 0x3 或 0x7，取决于 AVX 支持）
+        let xcr0: u64;
+        unsafe {
+            let lo: u32;
+            let hi: u32;
+            core::arch::asm!(
+                "xgetbv",
+                in("ecx") 0u32,
+                out("eax") lo,
+                out("edx") hi,
+                options(nomem, nostack)
+            );
+            xcr0 = ((hi as u64) << 32) | (lo as u64);
+        }
+
+        // 使用 raw_cpuid 获取 XSAVE area 大小
+        let xsave_size = cpuid
+            .get_extended_state_info()
+            .map(|info| info.xsave_area_size_enabled_features() as usize)
+            .unwrap_or(576); // 默认 AVX 最小需求
+
+        let actual_size = xsave_size.clamp(512, MAX_XSAVE_SIZE);
+
+        USE_XSAVE.store(true, Ordering::SeqCst);
+        XSAVE_FEATURE_MASK.store(xcr0, Ordering::SeqCst);
+        XSAVE_AREA_SIZE.store(actual_size, Ordering::SeqCst);
+
+        log::info!(
+            "XSAVE enabled: XCR0=0x{:x}, area_size={} bytes, features: x87={}, SSE={}, AVX={}",
+            xcr0,
+            actual_size,
+            (xcr0 & XFEATURE_X87) != 0,
+            (xcr0 & XFEATURE_SSE) != 0,
+            (xcr0 & XFEATURE_AVX) != 0,
+        );
+    }
+
+    /// 创建新的 FpState
     #[inline]
     pub fn new() -> Self {
-        assert!(core::mem::size_of::<Self>() == 512);
-        return Self::default();
+        Self::default()
     }
 
+    /// 初始化为默认的 FPU 状态
+    fn init_default(&mut self) {
+        // FCW (FPU Control Word) = 0x037F
+        self.data[0] = 0x7F;
+        self.data[1] = 0x03;
+
+        // MXCSR = 0x1F80 (SSE control register) - 位于偏移 24
+        self.data[24] = 0x80;
+        self.data[25] = 0x1F;
+
+        // 如果使用 XSAVE，需要设置 XSTATE_BV header
+        if USE_XSAVE.load(Ordering::Relaxed) {
+            let mask = XSAVE_FEATURE_MASK.load(Ordering::Relaxed);
+            // XSTATE_BV 在偏移 512 处
+            self.data[512..520].copy_from_slice(&mask.to_le_bytes());
+        }
+    }
+
+    /// 保存当前 CPU 的 FPU/SSE/AVX 状态
     #[inline]
     pub fn save(&mut self) {
-        unsafe {
-            _fxsave64(self as *mut FpState as *mut u8);
+        if USE_XSAVE.load(Ordering::Relaxed) {
+            self.xsave();
+        } else {
+            self.fxsave();
         }
     }
 
+    /// 恢复 FPU/SSE/AVX 状态到当前 CPU
     #[inline]
     pub fn restore(&self) {
-        unsafe {
-            _fxrstor64(self as *const FpState as *const u8);
+        if USE_XSAVE.load(Ordering::Relaxed) {
+            self.xrstor();
+        } else {
+            self.fxrstor();
         }
     }
 
-    /// 清空浮点寄存器
+    /// 使用 FXSAVE64 指令保存（仅 SSE）
+    #[inline]
+    fn fxsave(&mut self) {
+        unsafe {
+            core::arch::asm!(
+                "fxsave64 [{}]",
+                in(reg) self.data.as_mut_ptr(),
+                options(nostack)
+            );
+        }
+    }
+
+    /// 使用 FXRSTOR64 指令恢复（仅 SSE）
+    #[inline(never)]
+    fn fxrstor(&self) {
+        unsafe {
+            core::arch::asm!(
+                "fxrstor64 [{}]",
+                in(reg) self.data.as_ptr(),
+                // FXRSTOR 会修改 x87/SSE 状态（含 XMM 寄存器等）。
+                // 声明 ABI clobber 以防止编译器假设向量寄存器值在该 asm 前后保持不变。
+                clobber_abi("C"),
+                options(nostack, preserves_flags, readonly)
+            );
+        }
+    }
+
+    /// 使用 XSAVE64 指令保存扩展状态（包括 AVX）
+    #[inline]
+    fn xsave(&mut self) {
+        let mask = XSAVE_FEATURE_MASK.load(Ordering::Relaxed);
+        unsafe {
+            core::arch::asm!(
+                "xsave64 [{}]",
+                in(reg) self.data.as_mut_ptr(),
+                in("eax") mask as u32,
+                in("edx") (mask >> 32) as u32,
+                options(nostack)
+            );
+        }
+    }
+
+    /// 使用 XRSTOR64 指令恢复扩展状态（包括 AVX）
+    #[inline(never)]
+    fn xrstor(&self) {
+        let mask = XSAVE_FEATURE_MASK.load(Ordering::Relaxed);
+        unsafe {
+            core::arch::asm!(
+                "xrstor64 [{}]",
+                in(reg) self.data.as_ptr(),
+                in("eax") mask as u32,
+                in("edx") (mask >> 32) as u32,
+                // XRSTOR 会修改 x87/SSE/AVX 状态（含 XMM/YMM 寄存器等）。
+                // 声明 ABI clobber 以防止编译器假设向量寄存器值在该 asm 前后保持不变。
+                clobber_abi("C"),
+                options(nostack, preserves_flags, readonly)
+            );
+        }
+    }
+
+    /// 清空浮点寄存器并恢复默认状态
     #[allow(dead_code)]
     pub fn clear(&mut self) {
-        *self = Self::default();
+        self.data.fill(0);
+        self.init_default();
         self.restore();
+    }
+
+    /// 获取底层数据的引用（用于信号处理等）
+    pub fn as_bytes(&self) -> &[u8] {
+        let size = XSAVE_AREA_SIZE.load(Ordering::Relaxed);
+        &self.data[..size]
+    }
+
+    /// 获取底层数据的可变引用（用于信号处理等）
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        let size = XSAVE_AREA_SIZE.load(Ordering::Relaxed);
+        &mut self.data[..size]
+    }
+
+    /// 获取 FXSAVE 兼容区域（前 512 字节）的引用
+    /// 用于与旧代码兼容
+    pub fn legacy_region(&self) -> &[u8; 512] {
+        self.data[..512].try_into().unwrap()
+    }
+
+    /// 获取 FXSAVE 兼容区域的可变引用
+    pub fn legacy_region_mut(&mut self) -> &mut [u8; 512] {
+        (&mut self.data[..512]).try_into().unwrap()
+    }
+
+    /// 返回是否使用 XSAVE
+    pub fn is_xsave_enabled() -> bool {
+        USE_XSAVE.load(Ordering::Relaxed)
+    }
+
+    /// 返回 XSAVE area 大小
+    pub fn xsave_area_size() -> usize {
+        XSAVE_AREA_SIZE.load(Ordering::Relaxed)
     }
 }

--- a/kernel/src/arch/x86_64/init/mod.rs
+++ b/kernel/src/arch/x86_64/init/mod.rs
@@ -8,7 +8,7 @@ use system_error::SystemError;
 use x86::dtables::DescriptorTablePointer;
 
 use crate::{
-    arch::{interrupt::trap::arch_trap_init, process::table::TSSManager},
+    arch::{fpu::FpState, interrupt::trap::arch_trap_init, process::table::TSSManager},
     driver::clocksource::acpi_pm::init_acpi_pm_clocksource,
     init::init::start_kernel,
     mm::{MemoryManagementArch, PhysAddr},
@@ -79,6 +79,9 @@ unsafe extern "C" fn kernel_main(
 #[inline(never)]
 #[allow(static_mut_refs)]
 pub fn early_setup_arch() -> Result<(), SystemError> {
+    // 初始化 XSAVE 支持（必须在任何 FPU 状态保存/恢复之前）
+    FpState::init_xsave_support();
+
     let stack_start = unsafe { *(head_stack_start as *const u64) } as usize;
     debug!("head_stack_start={:#x}\n", stack_start);
     unsafe {

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -149,7 +149,9 @@ fi
 
 if [ ${ARCH} == "i386" ] || [ ${ARCH} == "x86_64" ]; then
     QEMU_MACHINE=" -machine q35,memory-backend=${QEMU_MEMORY_BACKEND} "
-    QEMU_CPU_FEATURES+="-cpu IvyBridge,apic,x2apic,+fpu,check,+vmx,${allflags}"
+    # 根据加速方式选择CPU型号：KVM使用host，TCG使用IvyBridge
+    cpu_model=$([ "${qemu_accel}" == "kvm" ] && echo "host" || echo "IvyBridge")
+    QEMU_CPU_FEATURES+="-cpu ${cpu_model},apic,x2apic,+fpu,check,+vmx,${allflags}"
     QEMU_RTC_CLOCK+=" -rtc clock=host,base=localtime"
     if [ ${VIRTIO_BLK_DEVICE} == false ]; then
       QEMU_DEVICES_DISK+="-device ahci,id=ahci -device ide-hd,drive=disk,bus=ahci.0 "


### PR DESCRIPTION
- 在启动代码中启用CR4.OSXSAVE位和XCR0寄存器以支持AVX指令集
- 重构FPU状态管理模块，支持XSAVE/XRSTOR指令并自动检测硬件能力
- 扩展信号处理框架以支持AVX寄存器状态的保存和恢复
- 修复进程切换时FPU状态恢复的时序问题，确保首次进入用户态前正确初始化
- 优化QEMU启动脚本，使用host CPU模式以支持更多现代指令集特性

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **AVX/XSAVE enablement and FPU state overhaul**
> 
> - Add `ENABLE_FPU_SSE_XSAVE_XCR0` in `head.S` to safely enable CR0.MP/CR4.OSFXSR|OSXMMEXCPT and conditionally CR4.OSXSAVE + `XCR0` (x87|SSE or x87|SSE|AVX), used in BSP/AP paths
> - Replace ad‑hoc SSE setup with the macro; call `FpState::init_xsave_support()` in early boot
> - Rework `FpState` to auto-detect XSAVE via CPUID/XGETBV, select FX(SAVE|RSTOR) or X(SAVE|RSTOR), and expose aligned XSAVE area views
> 
> **Signal frame AVX support**
> 
> - Introduce `UserXState` (FXSAVE 512B + XSAVE header 64B + AVX 256B) and conversions to/from kernel `FpState`
> - Point `ucontext.mcontext.fpstate` at the FXSAVE-compatible region; keep SROP checks; save/restore full XSAVE on signal entry/return
> 
> **Scheduling and user entry**
> 
> - Ensure FPU state is initialized/restored before first return to userspace; keep per-task default state on first use
> 
> **mmap semantics**
> 
> - Only pre-populate pages for anonymous mappings when `MAP_POPULATE`/`MAP_LOCKED`; file mappings remain demand-paged to avoid zero-filled data
> 
> **QEMU**
> 
> - On x86, select `-cpu host` under KVM (else `IvyBridge`) to expose modern features
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0288599509786eb1920ee17c3145ae86253cfcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->