### PR TITLE
ci: 添加rust-slabmalloc的主机测试工作流和属性测试

### DIFF
--- a/.github/workflows/test-mm.yaml
+++ b/.github/workflows/test-mm.yaml
@@ -1,0 +1,88 @@
+name: Test MM (Host)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master", "feat-*", "fix-*"]
+  pull_request:
+    branches: ["master", "feat-*", "fix-*"]
+
+env:
+  HOME: /root
+  RUSTUP_DIST_SERVER: "https://rsproxy.cn"
+  RUSTUP_UPDATE_ROOT: "https://rsproxy.cn/rustup"
+
+jobs:
+  build:
+    name: Build slab_stress (host)
+    runs-on: ubuntu-latest
+    container:
+      image: dragonos/dragonos-dev:v1.19
+      options: --privileged -v /dev:/dev
+    steps:
+      - name: Checkout DragonOS code
+        uses: actions/checkout@v4
+
+      - name: Build slab_stress (host)
+        shell: bash -ileo pipefail {0}
+        run: |
+          cd kernel/crates/rust-slabmalloc
+          cargo build --release --features host --bin slab_stress
+
+      - name: Upload slab_stress binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: slab_stress-binary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: kernel/crates/rust-slabmalloc/../../target/release/slab_stress
+          retention-days: 1
+
+  slab-valgrind-stress:
+    name: Slab allocator long-run (valgrind) - size=${{ matrix.size }}, seed=${{ matrix.seed }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    strategy:
+      matrix:
+        size: [64, 128, 255, 256]
+        seed: [1, 2, 3]
+    container:
+      image: dragonos/dragonos-dev:v1.19
+      options: --privileged -v /dev:/dev
+    steps:
+      - name: Checkout DragonOS code
+        uses: actions/checkout@v4
+
+      - name: Install valgrind
+        shell: bash -ileo pipefail {0}
+        run: |
+          apt-get update
+          apt-get install -y valgrind
+
+      - name: Download slab_stress binary
+        uses: actions/download-artifact@v4
+        with:
+          name: slab_stress-binary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp
+
+      - name: Run slab_stress under valgrind
+        shell: bash -ileo pipefail {0}
+        env:
+          SLAB_STRESS_ITERS: "2000000"
+          SLAB_STRESS_SIZE: "${{ matrix.size }}"
+          SLAB_STRESS_SEED: "${{ matrix.seed }}"
+        run: |
+          chmod +x /tmp/slab_stress
+          valgrind \
+            -s \
+            --error-exitcode=1 \
+            --track-origins=yes \
+            --leak-check=full \
+            --show-leak-kinds=all \
+            --malloc-fill=0xAA --free-fill=0xDD \
+            /tmp/slab_stress \
+              --iters "${SLAB_STRESS_ITERS}" \
+              --max-live 4096 \
+              --size "${SLAB_STRESS_SIZE}" \
+              --seed "${SLAB_STRESS_SEED}"
+
+

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -117,6 +117,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdt"
 version = "0.2.0-alpha1"
 source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/fdt?rev=9862813020#98628130200086c2e55dae0d997ac4daeb590e90"
@@ -549,6 +570,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -850,6 +883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1160,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.9.1",
+ "num-traits 0.2.19",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,14 +1214,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1167,7 +1247,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1176,7 +1266,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1267,7 +1375,20 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
  "windows-sys",
 ]
 
@@ -1276,6 +1397,18 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1357,7 +1490,8 @@ version = "0.11.0"
 dependencies = [
  "env_logger",
  "log",
- "rand",
+ "proptest",
+ "rand 0.8.5",
  "spin 0.9.8",
 ]
 
@@ -1466,6 +1600,19 @@ name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.2",
+ "windows-sys",
+]
 
 [[package]]
 name = "termcolor"
@@ -1607,6 +1754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab14ea9660d240e7865ce9d54ecdbd1cd9fa5802ae6f4512f093c7907e921533"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,7 +1802,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1675,6 +1828,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wait_queue_macros"
 version = "0.1.0"
 
@@ -1683,6 +1845,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1751,7 +1922,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2063,6 +2234,12 @@ checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "x86"

--- a/kernel/crates/rust-slabmalloc/Cargo.toml
+++ b/kernel/crates/rust-slabmalloc/Cargo.toml
@@ -6,11 +6,19 @@ edition = "2018"
 [features]
 unstable = []
 default = [ "unstable" ]
+host = ["rand"]
 
 [dependencies]
 log = "0.4"
+rand = { version = "0.8", optional = true, features = ["std", "small_rng"] }
 
 [target.'cfg(unix)'.dev-dependencies]
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 env_logger = "0.9"
 spin = "0.9.8"
+proptest = "1.6"
+
+[[bin]]
+name = "slab_stress"
+path = "src/bin/slab_stress.rs"
+required-features = ["host"]

--- a/kernel/crates/rust-slabmalloc/README.host-tests.md
+++ b/kernel/crates/rust-slabmalloc/README.host-tests.md
@@ -1,0 +1,74 @@
+## rust-slabmalloc：Linux 主机测试体系
+
+该目录下的 `slabmalloc` 是 **no_std** 库，但在 Linux 主机上我们可以用 `cargo test` 跑单元测试/属性测试，并用一个独立的压力工具配合 Valgrind/Miri 做长稳与 UB 检查。
+
+### 快速开始
+
+在本 crate 目录运行：
+
+```bash
+cd /home/jinlong/code/DragonOS/kernel/crates/rust-slabmalloc
+cargo test
+```
+
+### 单元测试（Unit tests）
+
+单元测试位于 `src/tests.rs`，覆盖：
+
+- 基础分配/释放正确性
+- `ObjectPage` 布局与位图行为
+- 页链表迁移不变量（full/partial/empty 即时迁移）
+
+### 属性/随机测试（proptest）
+
+属性测试位于 `src/prop_tests.rs`，使用 `proptest` 生成随机 alloc/free 序列，验证：
+
+- 反复 alloc/free 不崩溃
+- 最终可回收所有 empty 页到 pager（不泄漏）
+
+运行：
+
+```bash
+cargo test prop_
+```
+
+如需更“啰嗦”的 proptest 输出：
+
+```bash
+PROPTEST_VERBOSE=1 cargo test prop_
+```
+
+### 压测/长稳（slab_stress）
+
+该工具是一个 host 可执行程序：`src/bin/slab_stress.rs`
+
+编译并运行（release）：
+
+```bash
+cargo run --release --features host --bin slab_stress -- --iters 500000 --max-live 4096 --size 64 --seed 1
+```
+
+### Valgrind
+
+先编译 release：
+
+```bash
+cargo build --release --features host --bin slab_stress
+```
+
+再用 Valgrind 跑：
+
+```bash
+valgrind \
+  -s \
+  --error-exitcode=1 \
+  --track-origins=yes \
+  --leak-check=full \
+  --show-leak-kinds=all \
+  --malloc-fill=0xAA --free-fill=0xDD \
+  ../../target/release/slab_stress --iters 200000 --size 64 --seed 1
+```
+
+说明：如果你看到 `still reachable`（比如来自 Rust std 的线程信息），这通常不是越界/泄漏错误；真正的越界会体现在 `ERROR SUMMARY` 或 `Invalid read/write` 报告里。
+
+

--- a/kernel/crates/rust-slabmalloc/src/bin/slab_stress.rs
+++ b/kernel/crates/rust-slabmalloc/src/bin/slab_stress.rs
@@ -1,0 +1,175 @@
+//! Linux host 压测/长稳工具：对 slabmalloc 的 SCAllocator<ObjectPage> 执行随机 alloc/free 序列。
+//!
+//! 典型用法：
+//! - `cargo run --release --bin slab_stress -- --iters 500000 --max-live 4096 --size 64 --seed 1`
+//! - `valgrind --leak-check=full --show-leak-kinds=all target/release/slab_stress --iters 200000`
+//!
+//! 说明：该工具只依赖 std + crate 本身，方便在 Linux 主机上跑 valgrind/miri/stress。
+
+use slabmalloc::*;
+
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::alloc::Layout;
+use std::collections::HashSet;
+use std::env;
+use std::mem::transmute;
+use std::ptr::NonNull;
+use std::time::Instant;
+
+struct Pager {
+    base_pages: HashSet<*mut u8>,
+}
+
+impl Pager {
+    fn new() -> Self {
+        Self {
+            base_pages: HashSet::with_capacity(1 << 14),
+        }
+    }
+
+    fn currently_allocated(&self) -> usize {
+        self.base_pages.len()
+    }
+
+    fn alloc_page(&mut self, page_size: usize) -> *mut u8 {
+        let p =
+            unsafe { std::alloc::alloc(Layout::from_size_align(page_size, page_size).unwrap()) };
+        if p.is_null() {
+            panic!("alloc_page({}) failed", page_size);
+        }
+        match page_size {
+            ObjectPage::SIZE => {
+                self.base_pages.insert(p);
+            }
+            _ => panic!("unsupported page size {}", page_size),
+        }
+        p
+    }
+
+    fn dealloc_page(&mut self, ptr: *mut u8, page_size: usize) {
+        let layout = Layout::from_size_align(page_size, page_size).unwrap();
+        match page_size {
+            ObjectPage::SIZE => {
+                assert!(
+                    self.base_pages.remove(&ptr),
+                    "freeing unknown page {:p}",
+                    ptr
+                );
+            }
+            _ => panic!("unsupported page size {}", page_size),
+        }
+        unsafe { std::alloc::dealloc(ptr, layout) };
+    }
+
+    fn allocate_page<'a>(&mut self) -> &'a mut ObjectPage<'a> {
+        let raw = self.alloc_page(ObjectPage::SIZE);
+        unsafe { transmute(raw as usize) }
+    }
+
+    fn release_page<'a>(&mut self, p: &'a mut ObjectPage<'a>) {
+        self.dealloc_page(p as *const ObjectPage as *mut u8, ObjectPage::SIZE);
+    }
+}
+
+fn arg_u64(name: &str, default: u64) -> u64 {
+    let mut it = env::args().skip(1);
+    while let Some(a) = it.next() {
+        if a == name {
+            return it
+                .next()
+                .unwrap_or_else(|| panic!("missing value for {}", name))
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("invalid u64 for {}", name));
+        }
+    }
+    default
+}
+
+fn arg_usize(name: &str, default: usize) -> usize {
+    arg_u64(name, default as u64) as usize
+}
+
+fn main() {
+    let iters = arg_u64("--iters", 200_000) as usize;
+    let max_live = arg_usize("--max-live", 4096);
+    let size = arg_usize("--size", 64);
+    let seed = arg_u64("--seed", 1);
+
+    assert!(size > 0 && size <= ZoneAllocator::MAX_BASE_ALLOC_SIZE);
+    let layout = Layout::from_size_align(size, 1).unwrap();
+
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut pager = Pager::new();
+    let mut sa: SCAllocator<ObjectPage> = SCAllocator::new(size);
+
+    // 预先给一页，避免一开始就 OOM
+    let page = pager.allocate_page();
+    unsafe { sa.refill(page) };
+
+    let mut live: Vec<NonNull<u8>> = Vec::with_capacity(max_live);
+    let start = Instant::now();
+    let mut allocs = 0usize;
+    let mut frees = 0usize;
+    let mut refills = 1usize;
+    let mut reclaims = 0usize;
+
+    for i in 0..iters {
+        let do_alloc = live.is_empty() || (live.len() < max_live && rng.gen_bool(0.60));
+        if do_alloc {
+            loop {
+                match sa.allocate(layout) {
+                    Ok(p) => {
+                        live.push(p);
+                        allocs += 1;
+                        break;
+                    }
+                    Err(AllocationError::OutOfMemory) => {
+                        let page = pager.allocate_page();
+                        unsafe { sa.refill(page) };
+                        refills += 1;
+                    }
+                    Err(AllocationError::InvalidLayout) => unreachable!(),
+                }
+            }
+        } else {
+            let idx = rng.gen_range(0..live.len());
+            let p = live.swap_remove(idx);
+            unsafe { sa.deallocate(p, layout).expect("dealloc failed") };
+            frees += 1;
+        }
+
+        // 偶尔回收空页
+        if (i & 0x3fff) == 0x3fff {
+            let reclaimed = sa.try_reclaim_pages(1, &mut |p: *mut ObjectPage| unsafe {
+                pager.release_page(&mut *p)
+            });
+            if reclaimed > 0 {
+                reclaims += reclaimed;
+            }
+        }
+    }
+
+    for p in live.drain(..) {
+        unsafe { sa.deallocate(p, layout).expect("dealloc failed") };
+        frees += 1;
+    }
+
+    sa.try_reclaim_pages(usize::MAX, &mut |p: *mut ObjectPage| unsafe {
+        pager.release_page(&mut *p)
+    });
+
+    let dur = start.elapsed();
+    println!(
+        "slab_stress done: iters={} size={} allocs={} frees={} refills={} reclaims={} pages_left={} elapsed={:?}",
+        iters,
+        size,
+        allocs,
+        frees,
+        refills,
+        reclaims,
+        pager.currently_allocated(),
+        dur
+    );
+
+    assert_eq!(pager.currently_allocated(), 0, "leaked pages");
+}

--- a/kernel/crates/rust-slabmalloc/src/lib.rs
+++ b/kernel/crates/rust-slabmalloc/src/lib.rs
@@ -44,6 +44,9 @@ extern crate test;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod prop_tests;
+
 use core::alloc::Layout;
 use core::fmt;
 use core::mem;

--- a/kernel/crates/rust-slabmalloc/src/prop_tests.rs
+++ b/kernel/crates/rust-slabmalloc/src/prop_tests.rs
@@ -1,0 +1,141 @@
+use proptest::prelude::*;
+
+use crate::*;
+
+/// 随机序列/属性测试：在“可按需 refill 页面”的模型下，反复 alloc/free 不应崩溃，
+/// 且最终可把所有页面回收到 pager（无泄漏）。
+///
+/// 说明：
+/// - 这里用的是 SCAllocator<ObjectPage>，避开 ZoneAllocator 的回调复杂度，聚焦页状态迁移与位图正确性。
+/// - 该测试只在 Linux host 上作为 dev/test 运行（cargo test）。
+mod prop {
+    use super::*;
+    use rand::{rngs::SmallRng, Rng, SeedableRng};
+    use std::alloc::Layout;
+    use std::collections::HashSet;
+    use std::mem::transmute;
+    use std::ptr::NonNull;
+    use std::vec::Vec;
+
+    struct Pager {
+        base_pages: HashSet<*mut u8>,
+    }
+
+    impl Pager {
+        fn new() -> Self {
+            Self {
+                base_pages: HashSet::with_capacity(4096),
+            }
+        }
+
+        fn currently_allocated(&self) -> usize {
+            self.base_pages.len()
+        }
+
+        fn alloc_page(&mut self, page_size: usize) -> Option<*mut u8> {
+            let r = unsafe {
+                std::alloc::alloc(Layout::from_size_align(page_size, page_size).unwrap())
+            };
+            if r.is_null() {
+                return None;
+            }
+            match page_size {
+                OBJECT_PAGE_SIZE => {
+                    self.base_pages.insert(r);
+                }
+                _ => unreachable!("invalid page-size supplied"),
+            }
+            Some(r)
+        }
+
+        fn dealloc_page(&mut self, ptr: *mut u8, page_size: usize) {
+            let layout = match page_size {
+                OBJECT_PAGE_SIZE => {
+                    assert!(
+                        self.base_pages.contains(&ptr),
+                        "Trying to deallocate invalid base-page"
+                    );
+                    self.base_pages.remove(&ptr);
+                    Layout::from_size_align(OBJECT_PAGE_SIZE, OBJECT_PAGE_SIZE).unwrap()
+                }
+                _ => unreachable!("invalid page-size supplied"),
+            };
+            unsafe { std::alloc::dealloc(ptr, layout) };
+        }
+
+        fn allocate_page<'a>(&mut self) -> Option<&'a mut ObjectPage<'a>> {
+            self.alloc_page(OBJECT_PAGE_SIZE)
+                .map(|r| unsafe { transmute(r as usize) })
+        }
+
+        fn release_page<'a>(&mut self, p: &'a mut ObjectPage<'a>) {
+            self.dealloc_page(p as *const ObjectPage as *mut u8, OBJECT_PAGE_SIZE);
+        }
+    }
+
+    proptest! {
+        // 控制规模：避免 CI / 本机跑太久
+        #![proptest_config(ProptestConfig { cases: 64, .. ProptestConfig::default() })]
+
+        #[test]
+        fn prop_random_alloc_free_sequence(seed in any::<u64>(), ops in 200usize..2000usize) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mut pager = Pager::new();
+
+            // 在多个 size class 上覆盖（只测 base page 范围）
+            let sizes = [8usize, 16, 32, 64, 128, 256, 512, 1024, 2048];
+            let size = sizes[rng.gen_range(0..sizes.len())];
+            let mut sa: SCAllocator<ObjectPage> = SCAllocator::new(size);
+            let layout = Layout::from_size_align(size, 1).unwrap();
+
+            // live objects
+            let mut live: Vec<NonNull<u8>> = Vec::new();
+
+            // 确保至少有一页可用
+            let page = pager.allocate_page().expect("Can't allocate a page");
+            unsafe { sa.refill(page) };
+
+            for _ in 0..ops {
+                let do_alloc = live.is_empty() || rng.gen_bool(0.60);
+                if do_alloc {
+                    loop {
+                        match sa.allocate(layout) {
+                            Ok(p) => {
+                                live.push(p);
+                                break;
+                            }
+                            Err(AllocationError::OutOfMemory) => {
+                                let page = pager.allocate_page().expect("Can't allocate a page");
+                                unsafe { sa.refill(page) };
+                                continue;
+                            }
+                            Err(AllocationError::InvalidLayout) => unreachable!("Unexpected error"),
+                        }
+                    }
+                } else {
+                    let idx = rng.gen_range(0..live.len());
+                    let p = live.swap_remove(idx);
+                    unsafe { sa.deallocate(p, layout).expect("Can't deallocate") };
+                }
+
+                // 偶尔尝试回收空页（模拟内存压力路径）
+                if rng.gen_bool(0.05) {
+                    sa.try_reclaim_pages(1, &mut |p: *mut ObjectPage| unsafe {
+                        pager.release_page(&mut *p)
+                    });
+                }
+            }
+
+            // 全部释放，确保可以回收到 pager
+            for p in live.drain(..) {
+                unsafe { sa.deallocate(p, layout).expect("Can't deallocate") };
+            }
+
+            sa.try_reclaim_pages(usize::MAX, &mut |p: *mut ObjectPage| unsafe {
+                pager.release_page(&mut *p)
+            });
+
+            prop_assert_eq!(pager.currently_allocated(), 0);
+        }
+    }
+}


### PR DESCRIPTION
- 新增GitHub Actions工作流，用于在主机上构建并运行slab_stress压力测试
- 添加proptest依赖，实现随机分配/释放序列的属性测试
- 新增slab_stress二进制工具，支持Valgrind内存检查
- 完善测试文档，说明主机测试的使用方法
- 修复页面状态迁移测试，确保Full/Partial/Empty列表转换正确