### PR TITLE
refactor(syscall): 重构系统调用处理为独立模块

### DIFF
--- a/kernel/src/bpf/mod.rs
+++ b/kernel/src/bpf/mod.rs
@@ -1,23 +1,12 @@
 pub mod helper;
 pub mod map;
 pub mod prog;
+mod sys_bpf;
 use crate::include::bindings::linux_bpf::{bpf_attr, bpf_cmd};
-use crate::syscall::user_access::UserBufferReader;
-use crate::syscall::Syscall;
 use log::error;
-use num_traits::FromPrimitive;
 use system_error::SystemError;
 
 type Result<T> = core::result::Result<T, SystemError>;
-
-impl Syscall {
-    pub fn sys_bpf(cmd: u32, attr: *mut u8, size: u32) -> Result<usize> {
-        let buf = UserBufferReader::new(attr, size as usize, true)?;
-        let attr = buf.read_one_from_user::<bpf_attr>(0)?;
-        let cmd = bpf_cmd::from_u32(cmd).ok_or(SystemError::EINVAL)?;
-        bpf(cmd, attr)
-    }
-}
 
 pub fn bpf(cmd: bpf_cmd, attr: &bpf_attr) -> Result<usize> {
     let res = match cmd {

--- a/kernel/src/bpf/sys_bpf.rs
+++ b/kernel/src/bpf/sys_bpf.rs
@@ -1,0 +1,83 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_BPF;
+use crate::bpf::bpf;
+use crate::include::bindings::linux_bpf::{bpf_attr, bpf_cmd};
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferReader;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use num_traits::FromPrimitive;
+use system_error::SystemError;
+
+/// System call handler for the `bpf` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// Berkeley Packet Filter (eBPF) operations.
+pub struct SysBpfHandle;
+
+impl SysBpfHandle {
+    /// Extracts the command from syscall arguments
+    fn cmd(args: &[usize]) -> u32 {
+        args[0] as u32
+    }
+
+    /// Extracts the attribute pointer from syscall arguments
+    fn attr(args: &[usize]) -> *mut u8 {
+        args[1] as *mut u8
+    }
+
+    /// Extracts the attribute size from syscall arguments
+    fn size(args: &[usize]) -> u32 {
+        args[2] as u32
+    }
+}
+
+impl Syscall for SysBpfHandle {
+    /// Returns the number of arguments expected by the `bpf` syscall
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    /// Handles the `bpf` system call
+    ///
+    /// Performs various eBPF operations based on the command.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Command (u32)
+    ///   - args[1]: Pointer to bpf_attr structure (*mut u8)
+    ///   - args[2]: Size of bpf_attr structure (u32)
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - Result value on success
+    /// * `Err(SystemError)` - Error code if operation fails
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let cmd = Self::cmd(args);
+        let attr = Self::attr(args);
+        let size = Self::size(args);
+
+        let buf = UserBufferReader::new(attr, size as usize, true)?;
+        let attr_value = buf.buffer_protected(0)?.read_one::<bpf_attr>(0)?;
+        let cmd = bpf_cmd::from_u32(cmd).ok_or(SystemError::EINVAL)?;
+        bpf(cmd, &attr_value)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("cmd", Self::cmd(args).to_string()),
+            FormattedSyscallParam::new("attr", format!("{:#x}", Self::attr(args) as usize)),
+            FormattedSyscallParam::new("size", Self::size(args).to_string()),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_BPF, SysBpfHandle);

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -14,6 +14,9 @@ mod sys_chroot;
 mod sys_close;
 mod sys_dup;
 mod sys_dup3;
+#[cfg(target_arch = "x86_64")]
+mod sys_eventfd;
+mod sys_eventfd2;
 mod sys_faccessat;
 mod sys_faccessat2;
 mod sys_fchdir;
@@ -32,6 +35,9 @@ mod sys_lseek;
 mod sys_mkdirat;
 pub mod sys_mknodat;
 mod sys_openat;
+#[cfg(target_arch = "x86_64")]
+mod sys_poll;
+mod sys_ppoll;
 mod sys_pread64;
 mod sys_preadv;
 mod sys_preadv2;

--- a/kernel/src/filesystem/vfs/syscall/sys_eventfd.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_eventfd.rs
@@ -1,0 +1,62 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_EVENTFD;
+use crate::filesystem::vfs::syscall::sys_eventfd2::do_eventfd;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+/// System call handler for the `eventfd` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// creating an eventfd file descriptor (legacy version without flags).
+pub struct SysEventFdHandle;
+
+impl SysEventFdHandle {
+    /// Extracts the initial value from syscall arguments
+    fn initval(args: &[usize]) -> u32 {
+        args[0] as u32
+    }
+}
+
+impl Syscall for SysEventFdHandle {
+    /// Returns the number of arguments expected by the `eventfd` syscall
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    /// Handles the `eventfd` system call (legacy version)
+    ///
+    /// Creates an eventfd file descriptor with the specified initial value.
+    /// This is the legacy version that doesn't support flags (flags default to 0).
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Initial value (u32)
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - File descriptor on success
+    /// * `Err(SystemError)` - Error code if operation fails
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let initval = Self::initval(args);
+        do_eventfd(initval, 0)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "initval",
+            Self::initval(args).to_string(),
+        )]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_EVENTFD, SysEventFdHandle);

--- a/kernel/src/filesystem/vfs/syscall/sys_eventfd2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_eventfd2.rs
@@ -1,0 +1,102 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_EVENTFD2;
+use crate::filesystem::eventfd::{EventFd, EventFdFlags, EventFdInode, EVENTFD_ID_ALLOCATOR};
+use crate::filesystem::vfs::file::{File, FileFlags};
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+/// System call handler for the `eventfd2` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// creating an eventfd file descriptor with flags support.
+pub struct SysEventFd2Handle;
+
+impl SysEventFd2Handle {
+    /// Extracts the initial value from syscall arguments
+    fn initval(args: &[usize]) -> u32 {
+        args[0] as u32
+    }
+
+    /// Extracts the flags from syscall arguments
+    fn flags(args: &[usize]) -> u32 {
+        args[1] as u32
+    }
+}
+
+impl Syscall for SysEventFd2Handle {
+    /// Returns the number of arguments expected by the `eventfd2` syscall
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    /// Handles the `eventfd2` system call
+    ///
+    /// Creates an eventfd file descriptor with the specified initial value and flags.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Initial value (u32)
+    ///   - args[1]: Flags (u32): EFD_SEMAPHORE, EFD_CLOEXEC, EFD_NONBLOCK
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - File descriptor on success
+    /// * `Err(SystemError)` - Error code if operation fails
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let initval = Self::initval(args);
+        let flags = Self::flags(args);
+        do_eventfd(initval, flags)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("initval", Self::initval(args).to_string()),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_EVENTFD2, SysEventFd2Handle);
+
+/// Internal implementation of the eventfd operation
+///
+/// # Arguments
+/// * `init_val` - Initial value for the eventfd
+/// * `flags` - Flags for the eventfd (EFD_SEMAPHORE, EFD_CLOEXEC, EFD_NONBLOCK)
+///
+/// # Returns
+/// * `Ok(usize)` - File descriptor on success
+/// * `Err(SystemError)` - Error code if operation fails
+///
+/// See: https://man7.org/linux/man-pages/man2/eventfd2.2.html
+pub fn do_eventfd(init_val: u32, flags: u32) -> Result<usize, SystemError> {
+    let flags = EventFdFlags::from_bits(flags).ok_or(SystemError::EINVAL)?;
+    let id = EVENTFD_ID_ALLOCATOR
+        .lock()
+        .alloc()
+        .ok_or(SystemError::ENOMEM)? as u32;
+    let eventfd = EventFd::new(init_val as u64, flags, id);
+    let inode = Arc::new(EventFdInode::new(eventfd));
+    let filemode = if flags.contains(EventFdFlags::EFD_CLOEXEC) {
+        FileFlags::O_RDWR | FileFlags::O_CLOEXEC
+    } else {
+        FileFlags::O_RDWR
+    };
+    let file = File::new(inode, filemode)?;
+    let binding = ProcessManager::current_pcb().fd_table();
+    let mut fd_table_guard = binding.write();
+    let fd = fd_table_guard.alloc_fd(file, None).map(|x| x as usize);
+    return fd;
+}

--- a/kernel/src/filesystem/vfs/syscall/sys_poll.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_poll.rs
@@ -1,0 +1,144 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_POLL;
+use crate::filesystem::poll::{do_sys_poll, poll_select_set_timeout, PollFd, RestartFnPoll};
+use crate::ipc::signal::{RestartBlock, RestartBlockData};
+use crate::mm::VirtAddr;
+use crate::process::resource::RLimitID;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferWriter;
+use crate::time::Instant;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+/// System call handler for the `poll` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// polling file descriptors for events.
+pub struct SysPollHandle;
+
+impl SysPollHandle {
+    /// Extracts the pollfd pointer from syscall arguments
+    fn pollfd_ptr(args: &[usize]) -> usize {
+        args[0]
+    }
+
+    /// Extracts the number of file descriptors from syscall arguments
+    fn nfds(args: &[usize]) -> u32 {
+        args[1] as u32
+    }
+
+    /// Extracts the timeout from syscall arguments
+    fn timeout_ms(args: &[usize]) -> i32 {
+        args[2] as i32
+    }
+}
+
+impl Syscall for SysPollHandle {
+    /// Returns the number of arguments expected by the `poll` syscall
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    /// Handles the `poll` system call
+    ///
+    /// Polls file descriptors for events.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Pointer to pollfd array (usize)
+    ///   - args[1]: Number of file descriptors (u32)
+    ///   - args[2]: Timeout in milliseconds (i32)
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - Number of file descriptors with events
+    /// * `Err(SystemError)` - Error code if operation fails
+    ///
+    /// Reference: https://code.dragonos.org.cn/xref/linux-6.6.21/fs/select.c#1068
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pollfd_ptr = Self::pollfd_ptr(args);
+        let nfds = Self::nfds(args);
+        let timeout_ms = Self::timeout_ms(args);
+
+        do_poll(pollfd_ptr, nfds, timeout_ms)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pollfd_ptr", format!("{:#x}", Self::pollfd_ptr(args))),
+            FormattedSyscallParam::new("nfds", Self::nfds(args).to_string()),
+            FormattedSyscallParam::new("timeout_ms", Self::timeout_ms(args).to_string()),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_POLL, SysPollHandle);
+
+/// Internal implementation of the poll operation
+///
+/// # Arguments
+/// * `pollfd_ptr` - Pointer to pollfd array
+/// * `nfds` - Number of file descriptors
+/// * `timeout_ms` - Timeout in milliseconds
+///
+/// # Returns
+/// * `Ok(usize)` - Number of file descriptors with events
+/// * `Err(SystemError)` - Error code if operation fails
+#[inline(never)]
+pub fn do_poll(pollfd_ptr: usize, nfds: u32, timeout_ms: i32) -> Result<usize, SystemError> {
+    // 检查 nfds 是否超过 RLIMIT_NOFILE
+    let rlimit_nofile = ProcessManager::current_pcb()
+        .get_rlimit(RLimitID::Nofile)
+        .rlim_cur as u32;
+    if nfds > rlimit_nofile {
+        return Err(SystemError::EINVAL);
+    }
+
+    // 检查长度溢出
+    let len = (nfds as usize)
+        .checked_mul(core::mem::size_of::<PollFd>())
+        .ok_or(SystemError::EINVAL)?;
+
+    // 当 nfds > 0 但 pollfd_ptr 为空指针时，返回 EFAULT
+    if nfds > 0 && pollfd_ptr == 0 {
+        return Err(SystemError::EFAULT);
+    }
+
+    let pollfd_ptr = VirtAddr::new(pollfd_ptr);
+
+    let mut timeout: Option<Instant> = None;
+    if timeout_ms >= 0 {
+        timeout = poll_select_set_timeout(timeout_ms as u64);
+    }
+
+    // nfds == 0 时，直接进入等待逻辑，不需要用户缓冲区
+    if nfds == 0 {
+        let mut r = do_sys_poll(&mut [], timeout);
+        if let Err(SystemError::ERESTARTNOHAND) = r {
+            let restart_block_data = RestartBlockData::new_poll(pollfd_ptr, nfds, timeout);
+            let restart_block = RestartBlock::new(&RestartFnPoll, restart_block_data);
+            r = ProcessManager::current_pcb().set_restart_fn(Some(restart_block));
+        }
+        return r;
+    }
+
+    let mut poll_fds_writer = UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), len, true)?;
+    let mut r = do_sys_poll(poll_fds_writer.buffer(0)?, timeout);
+    if let Err(SystemError::ERESTARTNOHAND) = r {
+        let restart_block_data = RestartBlockData::new_poll(pollfd_ptr, nfds, timeout);
+        let restart_block = RestartBlock::new(&RestartFnPoll, restart_block_data);
+        r = ProcessManager::current_pcb().set_restart_fn(Some(restart_block));
+    }
+
+    return r;
+}

--- a/kernel/src/filesystem/vfs/syscall/sys_ppoll.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_ppoll.rs
@@ -1,0 +1,184 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::ipc::signal::SigSet;
+use crate::arch::syscall::nr::SYS_PPOLL;
+use crate::filesystem::poll::{
+    do_sys_poll, poll_select_finish, poll_select_set_timeout, PollFd, PollTimeType, RestartFnPoll,
+};
+use crate::ipc::signal::set_user_sigmask;
+use crate::ipc::signal::{RestartBlock, RestartBlockData};
+use crate::mm::VirtAddr;
+use crate::process::resource::RLimitID;
+use crate::process::ProcessManager;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferReader;
+use crate::time::{Instant, PosixTimeSpec};
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::mem::size_of;
+use system_error::SystemError;
+
+/// System call handler for the `ppoll` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// polling file descriptors for events with a timespec timeout and signal mask.
+pub struct SysPpollHandle;
+
+impl SysPpollHandle {
+    /// Extracts the pollfd pointer from syscall arguments
+    fn pollfd_ptr(args: &[usize]) -> usize {
+        args[0]
+    }
+
+    /// Extracts the number of file descriptors from syscall arguments
+    fn nfds(args: &[usize]) -> u32 {
+        args[1] as u32
+    }
+
+    /// Extracts the timespec pointer from syscall arguments
+    fn timespec_ptr(args: &[usize]) -> usize {
+        args[2]
+    }
+
+    /// Extracts the sigmask pointer from syscall arguments
+    fn sigmask_ptr(args: &[usize]) -> usize {
+        args[3]
+    }
+}
+
+impl Syscall for SysPpollHandle {
+    /// Returns the number of arguments expected by the `ppoll` syscall
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    /// Handles the `ppoll` system call
+    ///
+    /// Polls file descriptors for events with a timespec timeout and signal mask.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Pointer to pollfd array (usize)
+    ///   - args[1]: Number of file descriptors (u32)
+    ///   - args[2]: Pointer to timespec structure (usize)
+    ///   - args[3]: Pointer to sigset_t structure (usize)
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - Number of file descriptors with events
+    /// * `Err(SystemError)` - Error code if operation fails
+    ///
+    /// Reference: https://code.dragonos.org.cn/xref/linux-6.1.9/fs/select.c#1101
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pollfd_ptr = Self::pollfd_ptr(args);
+        let nfds = Self::nfds(args);
+        let timespec_ptr = Self::timespec_ptr(args);
+        let sigmask_ptr = Self::sigmask_ptr(args);
+
+        do_ppoll(pollfd_ptr, nfds, timespec_ptr, sigmask_ptr)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pollfd_ptr", format!("{:#x}", Self::pollfd_ptr(args))),
+            FormattedSyscallParam::new("nfds", Self::nfds(args).to_string()),
+            FormattedSyscallParam::new("timespec_ptr", format!("{:#x}", Self::timespec_ptr(args))),
+            FormattedSyscallParam::new("sigmask_ptr", format!("{:#x}", Self::sigmask_ptr(args))),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_PPOLL, SysPpollHandle);
+
+/// Internal implementation of the ppoll operation
+///
+/// # Arguments
+/// * `pollfd_ptr` - Pointer to pollfd array
+/// * `nfds` - Number of file descriptors
+/// * `timespec_ptr` - Pointer to timespec structure
+/// * `sigmask_ptr` - Pointer to sigset_t structure
+///
+/// # Returns
+/// * `Ok(usize)` - Number of file descriptors with events
+/// * `Err(SystemError)` - Error code if operation fails
+#[inline(never)]
+pub fn do_ppoll(
+    pollfd_ptr: usize,
+    nfds: u32,
+    timespec_ptr: usize,
+    sigmask_ptr: usize,
+) -> Result<usize, SystemError> {
+    // 检查 nfds 是否超过 RLIMIT_NOFILE
+    let rlimit_nofile = ProcessManager::current_pcb()
+        .get_rlimit(RLimitID::Nofile)
+        .rlim_cur as u32;
+    if nfds > rlimit_nofile {
+        return Err(SystemError::EINVAL);
+    }
+
+    // 检查长度溢出
+    let pollfds_len = (nfds as usize)
+        .checked_mul(core::mem::size_of::<PollFd>())
+        .ok_or(SystemError::EINVAL)?;
+
+    // 当 nfds > 0 但 pollfd_ptr 为空指针时，返回 EFAULT
+    if nfds > 0 && pollfd_ptr == 0 {
+        return Err(SystemError::EFAULT);
+    }
+
+    let mut timeout_ts: Option<Instant> = None;
+    let mut sigmask: Option<SigSet> = None;
+    let pollfd_ptr = VirtAddr::new(pollfd_ptr);
+
+    if sigmask_ptr != 0 {
+        let sigmask_reader =
+            UserBufferReader::new(sigmask_ptr as *const SigSet, size_of::<SigSet>(), true)?;
+        sigmask = Some(sigmask_reader.buffer_protected(0)?.read_one::<SigSet>(0)?);
+    }
+
+    if timespec_ptr != 0 {
+        let tsreader = UserBufferReader::new(
+            timespec_ptr as *const PosixTimeSpec,
+            size_of::<PosixTimeSpec>(),
+            true,
+        )?;
+        let ts: PosixTimeSpec = tsreader.buffer_protected(0)?.read_one::<PosixTimeSpec>(0)?;
+        let timeout_ms = ts.tv_sec * 1000 + ts.tv_nsec / 1_000_000;
+
+        if timeout_ms >= 0 {
+            timeout_ts =
+                Some(poll_select_set_timeout(timeout_ms as u64).ok_or(SystemError::EINVAL)?);
+        }
+    }
+
+    if let Some(mut sigmask) = sigmask {
+        set_user_sigmask(&mut sigmask);
+    }
+
+    // nfds == 0 时，直接进入等待逻辑，不需要用户缓冲区
+    let mut r: Result<usize, SystemError> = if nfds == 0 {
+        do_sys_poll(&mut [], timeout_ts)
+    } else {
+        use crate::syscall::user_access::UserBufferWriter;
+        let mut poll_fds_writer =
+            UserBufferWriter::new(pollfd_ptr.as_ptr::<PollFd>(), pollfds_len, true)?;
+        let poll_fds = poll_fds_writer.buffer(0)?;
+        do_sys_poll(poll_fds, timeout_ts)
+    };
+
+    // 处理信号中断，设置restart block使ppoll可重启
+    if let Err(SystemError::ERESTARTNOHAND) = r {
+        let restart_block_data = RestartBlockData::new_poll(pollfd_ptr, nfds, timeout_ts);
+        let restart_block = RestartBlock::new(&RestartFnPoll, restart_block_data);
+        r = ProcessManager::current_pcb().set_restart_fn(Some(restart_block));
+    }
+
+    return poll_select_finish(timeout_ts, timespec_ptr, PollTimeType::TimeSpec, r);
+}

--- a/kernel/src/perf/mod.rs
+++ b/kernel/src/perf/mod.rs
@@ -1,5 +1,6 @@
 mod bpf;
 mod kprobe;
+mod sys_perf_event_open;
 mod tracepoint;
 mod util;
 
@@ -26,8 +27,6 @@ use crate::mm::{MemoryManagementArch, VirtAddr, VmFaultReason};
 use crate::perf::bpf::BpfPerfEvent;
 use crate::perf::util::{PerfEventIoc, PerfEventOpenFlags, PerfProbeArgs, PerfProbeConfig};
 use crate::process::ProcessManager;
-use crate::syscall::user_access::UserBufferReader;
-use crate::syscall::Syscall;
 use alloc::boxed::Box;
 use alloc::collections::LinkedList;
 use alloc::string::String;
@@ -348,24 +347,6 @@ impl FileSystem for PerfFakeFs {
         end_pgoff: usize,
     ) -> VmFaultReason {
         PageFaultHandler::filemap_map_pages(pfm, start_pgoff, end_pgoff)
-    }
-}
-
-impl Syscall {
-    pub fn sys_perf_event_open(
-        attr: *const u8,
-        pid: i32,
-        cpu: i32,
-        group_fd: i32,
-        flags: u32,
-    ) -> Result<usize> {
-        let buf = UserBufferReader::new(
-            attr as *const perf_event_attr,
-            size_of::<perf_event_attr>(),
-            true,
-        )?;
-        let attr = buf.read_one_from_user(0)?;
-        perf_event_open(attr, pid, cpu, group_fd, flags)
     }
 }
 

--- a/kernel/src/perf/sys_perf_event_open.rs
+++ b/kernel/src/perf/sys_perf_event_open.rs
@@ -1,0 +1,102 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_PERF_EVENT_OPEN;
+use crate::include::bindings::linux_bpf::perf_event_attr;
+use crate::perf::perf_event_open;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferReader;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::mem::size_of;
+use system_error::SystemError;
+
+/// System call handler for the `perf_event_open` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// performance event monitoring.
+pub struct SysPerfEventOpenHandle;
+
+impl SysPerfEventOpenHandle {
+    /// Extracts the attribute pointer from syscall arguments
+    fn attr(args: &[usize]) -> *const u8 {
+        args[0] as *const u8
+    }
+
+    /// Extracts the pid from syscall arguments
+    fn pid(args: &[usize]) -> i32 {
+        args[1] as i32
+    }
+
+    /// Extracts the cpu from syscall arguments
+    fn cpu(args: &[usize]) -> i32 {
+        args[2] as i32
+    }
+
+    /// Extracts the group_fd from syscall arguments
+    fn group_fd(args: &[usize]) -> i32 {
+        args[3] as i32
+    }
+
+    /// Extracts the flags from syscall arguments
+    fn flags(args: &[usize]) -> u32 {
+        args[4] as u32
+    }
+}
+
+impl Syscall for SysPerfEventOpenHandle {
+    /// Returns the number of arguments expected by the `perf_event_open` syscall
+    fn num_args(&self) -> usize {
+        5
+    }
+
+    /// Handles the `perf_event_open` system call
+    ///
+    /// Opens a performance event file descriptor.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Pointer to perf_event_attr structure (*const u8)
+    ///   - args[1]: Process ID (i32)
+    ///   - args[2]: CPU ID (i32)
+    ///   - args[3]: Group file descriptor (i32)
+    ///   - args[4]: Flags (u32)
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - File descriptor on success
+    /// * `Err(SystemError)` - Error code if operation fails
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let attr = Self::attr(args);
+        let pid = Self::pid(args);
+        let cpu = Self::cpu(args);
+        let group_fd = Self::group_fd(args);
+        let flags = Self::flags(args);
+
+        let buf = UserBufferReader::new(
+            attr as *const perf_event_attr,
+            size_of::<perf_event_attr>(),
+            true,
+        )?;
+        let attr = buf.buffer_protected(0)?.read_one::<perf_event_attr>(0)?;
+        perf_event_open(&attr, pid, cpu, group_fd, flags)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("attr", format!("{:#x}", Self::attr(args) as usize)),
+            FormattedSyscallParam::new("pid", Self::pid(args).to_string()),
+            FormattedSyscallParam::new("cpu", Self::cpu(args).to_string()),
+            FormattedSyscallParam::new("group_fd", Self::group_fd(args).to_string()),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_PERF_EVENT_OPEN, SysPerfEventOpenHandle);

--- a/kernel/src/process/rseq.rs
+++ b/kernel/src/process/rseq.rs
@@ -734,17 +734,3 @@ pub fn rseq_execve(pcb: &ProcessControlBlock) {
     pcb.rseq_state_mut().registration = None;
     pcb.rseq_state_mut().event_mask.store(0, Ordering::SeqCst);
 }
-
-// ============================================================================
-// 系统调用入口
-// ============================================================================
-
-/// sys_rseq 系统调用
-pub fn sys_rseq(
-    rseq_ptr: VirtAddr,
-    rseq_len: u32,
-    flags: i32,
-    sig: u32,
-) -> Result<usize, SystemError> {
-    Rseq::syscall(rseq_ptr, rseq_len, flags, sig)
-}

--- a/kernel/src/process/syscall/mod.rs
+++ b/kernel/src/process/syscall/mod.rs
@@ -24,6 +24,7 @@ mod sys_init_module;
 mod sys_pidfdopen;
 mod sys_prctl;
 pub mod sys_prlimit64;
+mod sys_rseq;
 mod sys_set_tid_address;
 mod sys_setdomainname;
 mod sys_setfsgid;

--- a/kernel/src/process/syscall/sys_rseq.rs
+++ b/kernel/src/process/syscall/sys_rseq.rs
@@ -1,0 +1,86 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_RSEQ;
+use crate::mm::VirtAddr;
+use crate::process::rseq::Rseq;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+/// System call handler for the `rseq` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// registering/unregistering restartable sequences (rseq).
+pub struct SysRseqHandle;
+
+impl SysRseqHandle {
+    /// Extracts the rseq pointer from syscall arguments
+    fn rseq_ptr(args: &[usize]) -> VirtAddr {
+        VirtAddr::new(args[0])
+    }
+
+    /// Extracts the rseq length from syscall arguments
+    fn rseq_len(args: &[usize]) -> u32 {
+        args[1] as u32
+    }
+
+    /// Extracts the flags from syscall arguments
+    fn flags(args: &[usize]) -> i32 {
+        args[2] as i32
+    }
+
+    /// Extracts the signature from syscall arguments
+    fn sig(args: &[usize]) -> u32 {
+        args[3] as u32
+    }
+}
+
+impl Syscall for SysRseqHandle {
+    /// Returns the number of arguments expected by the `rseq` syscall
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    /// Handles the `rseq` system call
+    ///
+    /// Registers or unregisters a restartable sequence (rseq) for the current process.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Pointer to rseq structure (VirtAddr)
+    ///   - args[1]: Length of rseq structure (u32)
+    ///   - args[2]: Flags (i32): 0 for register, RSEQ_FLAG_UNREGISTER for unregister
+    ///   - args[3]: Signature value (u32)
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - 0 on success
+    /// * `Err(SystemError)` - Error code if operation fails
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let rseq_ptr = Self::rseq_ptr(args);
+        let rseq_len = Self::rseq_len(args);
+        let flags = Self::flags(args);
+        let sig = Self::sig(args);
+
+        Rseq::syscall(rseq_ptr, rseq_len, flags, sig)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("rseq_ptr", format!("{:#x}", Self::rseq_ptr(args).data())),
+            FormattedSyscallParam::new("rseq_len", Self::rseq_len(args).to_string()),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+            FormattedSyscallParam::new("sig", format!("{:#x}", Self::sig(args))),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_RSEQ, SysRseqHandle);

--- a/kernel/src/syscall/misc.rs
+++ b/kernel/src/syscall/misc.rs
@@ -1,10 +1,7 @@
 use crate::{
-    arch::{mm::LockedFrameAllocator, rand::rand},
-    libs::rand::GRandFlags,
+    arch::mm::LockedFrameAllocator,
     mm::allocator::{page_frame::FrameAllocator, slab::slab_usage},
 };
-use alloc::vec::Vec;
-use core::cmp;
 use system_error::SystemError;
 
 use super::{user_access::UserBufferWriter, Syscall};
@@ -55,31 +52,5 @@ impl Syscall {
         writer.copy_one_to_user(&sysinfo, 0)?;
 
         return Ok(0);
-    }
-
-    /// ## 将随机字节填入buf
-    /// ### 该系统调用与linux不一致，因为目前没有其他随机源
-    pub fn get_random(buf: *mut u8, len: usize, flags: GRandFlags) -> Result<usize, SystemError> {
-        if flags.bits() == (GRandFlags::GRND_INSECURE.bits() | GRandFlags::GRND_RANDOM.bits()) {
-            return Err(SystemError::EINVAL);
-        }
-
-        let mut writer = UserBufferWriter::new(buf, len, true)?;
-
-        let mut ret = Vec::new();
-        let mut count = 0;
-        while count < len {
-            // 对 len - count 的长度进行判断，remain_len 小于4则循环次数和 remain_len 相等
-            let remain_len = len - count;
-            let step = cmp::min(remain_len, 4);
-            let rand = rand();
-            for offset in 0..step {
-                ret.push((rand >> (offset * 2)) as u8);
-                count += 1;
-            }
-        }
-
-        writer.copy_to_user(&ret, 0)?;
-        Ok(len)
     }
 }

--- a/kernel/src/syscall/sys_getrandom.rs
+++ b/kernel/src/syscall/sys_getrandom.rs
@@ -1,0 +1,124 @@
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::rand::rand;
+use crate::arch::syscall::nr::SYS_GETRANDOM;
+use crate::libs::rand::GRandFlags;
+use crate::syscall::table::FormattedSyscallParam;
+use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferWriter;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::cmp;
+use system_error::SystemError;
+
+/// System call handler for the `getrandom` syscall
+///
+/// This handler implements the `Syscall` trait to provide functionality for
+/// generating random bytes.
+pub struct SysGetRandomHandle;
+
+impl SysGetRandomHandle {
+    /// Extracts the buffer pointer from syscall arguments
+    fn buf(args: &[usize]) -> *mut u8 {
+        args[0] as *mut u8
+    }
+
+    /// Extracts the buffer length from syscall arguments
+    fn len(args: &[usize]) -> usize {
+        args[1]
+    }
+
+    /// Extracts the flags from syscall arguments
+    fn flags(args: &[usize]) -> u8 {
+        args[2] as u8
+    }
+}
+
+impl Syscall for SysGetRandomHandle {
+    /// Returns the number of arguments expected by the `getrandom` syscall
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    /// Handles the `getrandom` system call
+    ///
+    /// Fills a buffer with random bytes.
+    ///
+    /// # Arguments
+    /// * `args` - Array containing:
+    ///   - args[0]: Buffer pointer (*mut u8)
+    ///   - args[1]: Buffer length (usize)
+    ///   - args[2]: Flags (u8): GRND_NONBLOCK, GRND_RANDOM, GRND_INSECURE
+    /// * `_frame` - Trap frame (unused)
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - Number of bytes written on success
+    /// * `Err(SystemError)` - Error code if operation fails
+    ///
+    /// Note: This syscall implementation differs from Linux as there is currently
+    /// no other random source available.
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let buf = Self::buf(args);
+        let len = Self::len(args);
+        let flags = GRandFlags::from_bits(Self::flags(args)).ok_or(SystemError::EINVAL)?;
+
+        do_get_random(buf, len, flags)
+    }
+
+    /// Formats the syscall parameters for display/debug purposes
+    ///
+    /// # Arguments
+    /// * `args` - The raw syscall arguments
+    ///
+    /// # Returns
+    /// Vector of formatted parameters with descriptive names
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("buf", format!("{:#x}", Self::buf(args) as usize)),
+            FormattedSyscallParam::new("len", Self::len(args).to_string()),
+            FormattedSyscallParam::new("flags", format!("{:#x}", Self::flags(args))),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_GETRANDOM, SysGetRandomHandle);
+
+/// Internal implementation of the getrandom operation
+///
+/// # Arguments
+/// * `buf` - Buffer to fill with random bytes
+/// * `len` - Length of buffer
+/// * `flags` - Flags (GRND_NONBLOCK, GRND_RANDOM, GRND_INSECURE)
+///
+/// # Returns
+/// * `Ok(usize)` - Number of bytes written
+/// * `Err(SystemError)` - Error code if operation fails
+///
+/// Note: This implementation differs from Linux as there is currently no other random source.
+pub fn do_get_random(buf: *mut u8, len: usize, flags: GRandFlags) -> Result<usize, SystemError> {
+    if flags.bits() == (GRandFlags::GRND_INSECURE.bits() | GRandFlags::GRND_RANDOM.bits()) {
+        return Err(SystemError::EINVAL);
+    }
+
+    let mut writer = UserBufferWriter::new(buf, len, true)?;
+    let mut buffer = writer.buffer_protected(0)?;
+
+    let mut count = 0;
+    while count < len {
+        // 对 len - count 的长度进行判断，remain_len 小于4则循环次数和 remain_len 相等
+        let remain_len = len - count;
+        let step = cmp::min(remain_len, 4);
+        let rand_value = rand();
+
+        // 生成随机字节并直接写入用户缓冲区
+        let mut random_bytes = [0u8; 4];
+        for (offset, byte) in random_bytes.iter_mut().enumerate().take(step) {
+            *byte = (rand_value >> (offset * 2)) as u8;
+        }
+
+        // 使用异常表保护的方式写入用户缓冲区
+        buffer.write_to_user(count, &random_bytes[..step])?;
+        count += step;
+    }
+
+    Ok(len)
+}


### PR DESCRIPTION
- 将bpf、eventfd、poll、ppoll、perf_event_open、rseq、getrandom系统调用从Syscall trait移至独立模块