### PR TITLE
refactor(mm): 重命名 verify_area 为 access_ok 并改进文档

### DIFF
--- a/kernel/src/arch/x86_64/process/syscall.rs
+++ b/kernel/src/arch/x86_64/process/syscall.rs
@@ -7,7 +7,7 @@ use crate::{
         process::table::{USER_CS, USER_DS},
         MMArch,
     },
-    mm::{verify_area, MemoryManagementArch, VirtAddr},
+    mm::{access_ok, MemoryManagementArch, VirtAddr},
     process::{
         exec::{BinaryLoaderResult, ExecParam},
         ProcessControlBlock, ProcessManager,
@@ -107,7 +107,7 @@ impl Syscall {
             ARCH_SET_FS => {
                 // 验证FS地址是否为有效的用户空间地址
                 let fs_addr = VirtAddr::new(arg2);
-                verify_area(fs_addr, MMArch::PAGE_SIZE).map_err(|_| SystemError::EPERM)?;
+                access_ok(fs_addr, MMArch::PAGE_SIZE).map_err(|_| SystemError::EPERM)?;
                 arch_info.fsbase = arg2;
                 // 如果是当前进程则直接写入寄存器
                 if pcb.raw_pid() == ProcessManager::current_pcb().raw_pid() {
@@ -117,7 +117,7 @@ impl Syscall {
             ARCH_SET_GS => {
                 // 验证GS地址是否为有效的用户空间地址
                 let gs_addr = VirtAddr::new(arg2);
-                verify_area(gs_addr, MMArch::PAGE_SIZE).map_err(|_| SystemError::EPERM)?;
+                access_ok(gs_addr, MMArch::PAGE_SIZE).map_err(|_| SystemError::EPERM)?;
                 arch_info.gsbase = arg2;
                 if pcb.raw_pid() == ProcessManager::current_pcb().raw_pid() {
                     unsafe { arch_info.restore_gsbase() }

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -23,7 +23,7 @@ use crate::driver::disk::ahci::hba::{
 };
 use crate::libs::rwsem::{RwSemReadGuard, RwSemWriteGuard};
 use crate::libs::spinlock::{SpinLock, SpinLockGuard};
-use crate::mm::{verify_area, MemoryManagementArch, PhysAddr, VirtAddr};
+use crate::mm::{access_ok, MemoryManagementArch, PhysAddr, VirtAddr};
 use log::error;
 use system_error::SystemError;
 
@@ -114,7 +114,7 @@ impl AhciDisk {
         // 由于目前的内存管理机制无法把用户空间的内存地址转换为物理地址，所以只能先把数据拷贝到内核空间
         // TODO：在内存管理重构后，可以直接使用用户空间的内存地址
 
-        let user_buf = verify_area(VirtAddr::new(buf_ptr), buf.len()).is_ok();
+        let user_buf = access_ok(VirtAddr::new(buf_ptr), buf.len()).is_ok();
         let mut kbuf = if user_buf {
             let x: Vec<u8> = vec![0; buf.len()];
             Some(x)
@@ -276,7 +276,7 @@ impl AhciDisk {
 
         // 由于目前的内存管理机制无法把用户空间的内存地址转换为物理地址，所以只能先把数据拷贝到内核空间
         // TODO：在内存管理重构后，可以直接使用用户空间的内存地址
-        let user_buf = verify_area(VirtAddr::new(buf_ptr), buf.len()).is_ok();
+        let user_buf = access_ok(VirtAddr::new(buf_ptr), buf.len()).is_ok();
         let mut kbuf = if user_buf {
             let mut x: Vec<u8> = vec![0; buf.len()];
             x.resize(buf.len(), 0);

--- a/kernel/src/filesystem/vfs/iov.rs
+++ b/kernel/src/filesystem/vfs/iov.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use system_error::SystemError;
 
 use crate::{
-    mm::verify_area,
+    mm::access_ok,
     mm::VirtAddr,
     syscall::user_access::{
         copy_from_user_protected, user_accessible_len, UserBufferReader, UserBufferWriter,
@@ -93,7 +93,7 @@ impl IoVecs {
             // This checks that the address range is within user space limits,
             // but does NOT traverse page tables or check actual mappings.
             // Actual page mapping/permission checks happen during copy operations.
-            verify_area(base, one.iov_len)?;
+            access_ok(base, one.iov_len)?;
 
             // Skip zero-length iovecs after validation
             if one.iov_len == 0 {

--- a/kernel/src/filesystem/vfs/syscall/sys_getcwd.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_getcwd.rs
@@ -6,7 +6,7 @@ use crate::alloc::string::ToString;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_GETCWD;
 use crate::filesystem::vfs::utils::is_ancestor;
-use crate::mm::verify_area;
+use crate::mm::access_ok;
 use crate::mm::VirtAddr;
 use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
@@ -36,7 +36,7 @@ impl Syscall for SysGetcwdHandle {
         let size = Self::size(args);
 
         let security_check = || {
-            verify_area(VirtAddr::new(buf_vaddr as usize), size)?;
+            access_ok(VirtAddr::new(buf_vaddr as usize), size)?;
             return Ok(());
         };
         let r = security_check();

--- a/kernel/src/libs/futex/syscall/sys_futex.rs
+++ b/kernel/src/libs/futex/syscall/sys_futex.rs
@@ -6,7 +6,7 @@ use crate::libs::futex::{constant::*, futex::Futex};
 
 use crate::{
     arch::{interrupt::TrapFrame, syscall::nr::SYS_FUTEX},
-    mm::{verify_area, VirtAddr},
+    mm::{access_ok, VirtAddr},
     syscall::{
         table::{FormattedSyscallParam, Syscall},
         user_access::UserBufferReader,
@@ -165,7 +165,7 @@ pub(super) fn do_futex(
         | FutexArg::FUTEX_WAKE_OP
         | FutexArg::FUTEX_WAIT_REQUEUE_PI
         | FutexArg::FUTEX_CMP_REQUEUE_PI => {
-            verify_area(uaddr2, core::mem::size_of::<u32>())?;
+            access_ok(uaddr2, core::mem::size_of::<u32>())?;
         }
         _ => {}
     }
@@ -193,7 +193,7 @@ pub(super) fn do_futex(
         && uaddr.data() == 0;
 
     if !skip_uaddr_check {
-        verify_area(uaddr, core::mem::size_of::<u32>())?;
+        access_ok(uaddr, core::mem::size_of::<u32>())?;
     }
 
     match cmd {

--- a/kernel/src/libs/futex/syscall/sys_robust_futex.rs
+++ b/kernel/src/libs/futex/syscall/sys_robust_futex.rs
@@ -3,7 +3,7 @@ use system_error::SystemError;
 use crate::{
     arch::interrupt::TrapFrame,
     arch::syscall::nr::{SYS_GET_ROBUST_LIST, SYS_SET_ROBUST_LIST},
-    mm::{verify_area, VirtAddr},
+    mm::{access_ok, VirtAddr},
     syscall::table::{FormattedSyscallParam, Syscall},
 };
 use alloc::{string::ToString, vec::Vec};
@@ -39,7 +39,7 @@ impl Syscall for SysSetRobustListHandle {
         let len = Self::len(args);
 
         // 判断用户空间地址的合法性
-        verify_area(head, core::mem::size_of::<u32>())?;
+        access_ok(head, core::mem::size_of::<u32>())?;
 
         let result = crate::libs::futex::futex::RobustListHead::set_robust_list(head, len);
 
@@ -99,8 +99,8 @@ impl Syscall for SysGetRobustListHandle {
         let len_ptr = Self::len_ptr(args);
 
         // 判断用户空间地址的合法性
-        verify_area(head, core::mem::size_of::<u32>())?;
-        verify_area(len_ptr, core::mem::size_of::<u32>())?;
+        access_ok(head, core::mem::size_of::<u32>())?;
+        access_ok(len_ptr, core::mem::size_of::<u32>())?;
 
         crate::libs::futex::futex::RobustListHead::get_robust_list(pid, head, len_ptr)
     }

--- a/kernel/src/mm/syscall/sys_madvise.rs
+++ b/kernel/src/mm/syscall/sys_madvise.rs
@@ -5,7 +5,7 @@ use crate::libs::align::page_align_up;
 use crate::mm::{
     syscall::{MadvFlags, PageFrameCount},
     ucontext::AddressSpace,
-    MemoryManagementArch, VirtPageFrame, {verify_area, VirtAddr},
+    MemoryManagementArch, VirtPageFrame, {access_ok, VirtAddr},
 };
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use system_error::SystemError;
@@ -62,7 +62,7 @@ impl Syscall for SysMadviseHandle {
         }
 
         // 验证地址范围的有效性
-        if verify_area(start_vaddr, aligned_len).is_err() {
+        if access_ok(start_vaddr, aligned_len).is_err() {
             return Err(SystemError::EINVAL);
         }
 

--- a/kernel/src/mm/syscall/sys_mincore.rs
+++ b/kernel/src/mm/syscall/sys_mincore.rs
@@ -4,7 +4,7 @@ use crate::arch::MMArch;
 use crate::libs::align::page_align_up;
 use crate::mm::allocator::page_frame::{PageFrameCount, VirtPageFrame};
 use crate::mm::ucontext::AddressSpace;
-use crate::mm::{verify_area, MemoryManagementArch};
+use crate::mm::{access_ok, MemoryManagementArch};
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::UserBufferWriter;
 use system_error::SystemError;
@@ -35,7 +35,7 @@ impl Syscall for SysMincoreHandle {
             return Err(SystemError::EINVAL);
         }
 
-        if verify_area(start_vaddr, len).is_err() {
+        if access_ok(start_vaddr, len).is_err() {
             return Err(SystemError::ENOMEM);
         }
         if len == 0 {

--- a/kernel/src/mm/syscall/sys_mmap.rs
+++ b/kernel/src/mm/syscall/sys_mmap.rs
@@ -7,7 +7,7 @@ use crate::mm::syscall::MapFlags;
 use crate::mm::ucontext::DEFAULT_MMAP_MIN_ADDR;
 use crate::mm::AddressSpace;
 use crate::mm::VirtAddr;
-use crate::mm::{verify_area, MemoryManagementArch};
+use crate::mm::{access_ok, MemoryManagementArch};
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use log::error;
 use system_error::SystemError;
@@ -60,7 +60,7 @@ impl Syscall for SysMmapHandle {
         }
         let offset = offset_raw as usize;
         // 基础参数校验
-        if verify_area(start_vaddr, len).is_err() {
+        if access_ok(start_vaddr, len).is_err() {
             return Err(SystemError::EFAULT);
         }
 

--- a/kernel/src/mm/syscall/sys_mprotect.rs
+++ b/kernel/src/mm/syscall/sys_mprotect.rs
@@ -4,7 +4,7 @@ use crate::arch::{interrupt::TrapFrame, syscall::nr::SYS_MPROTECT, MMArch};
 use crate::mm::{
     syscall::{page_align_up, PageFrameCount, ProtFlags},
     ucontext::AddressSpace,
-    MemoryManagementArch, VirtPageFrame, {verify_area, VirtAddr},
+    MemoryManagementArch, VirtPageFrame, {access_ok, VirtAddr},
 };
 
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
@@ -53,7 +53,7 @@ impl Syscall for SysMprotectHandle {
             return Err(SystemError::ENOMEM);
         }
 
-        if verify_area(start_vaddr, len_aligned).is_err() {
+        if access_ok(start_vaddr, len_aligned).is_err() {
             return Err(SystemError::EFAULT);
         }
 

--- a/kernel/src/mm/syscall/sys_munmap.rs
+++ b/kernel/src/mm/syscall/sys_munmap.rs
@@ -7,7 +7,7 @@ use crate::mm::syscall::PageFrameCount;
 use crate::mm::ucontext::AddressSpace;
 use crate::mm::unlikely;
 use crate::mm::MemoryManagementArch;
-use crate::mm::{verify_area, MMArch, VirtAddr, VirtPageFrame};
+use crate::mm::{access_ok, MMArch, VirtAddr, VirtPageFrame};
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -69,7 +69,7 @@ pub(super) fn do_munmap(start_vaddr: VirtAddr, len: usize) -> Result<usize, Syst
     assert!(start_vaddr.check_aligned(MMArch::PAGE_SIZE));
     assert!(check_aligned(len, MMArch::PAGE_SIZE));
 
-    if unlikely(verify_area(start_vaddr, len).is_err()) {
+    if unlikely(access_ok(start_vaddr, len).is_err()) {
         return Err(SystemError::EINVAL);
     }
     if unlikely(len == 0) {

--- a/kernel/src/mm/syscall/sys_process_vm.rs
+++ b/kernel/src/mm/syscall/sys_process_vm.rs
@@ -12,7 +12,7 @@ use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::{SYS_PROCESS_VM_READV, SYS_PROCESS_VM_WRITEV};
 use crate::arch::MMArch;
 use crate::filesystem::vfs::iov::IoVec;
-use crate::mm::{verify_area, KernelWpGuard, MemoryManagementArch, PhysAddr, VirtAddr};
+use crate::mm::{access_ok, KernelWpGuard, MemoryManagementArch, PhysAddr, VirtAddr};
 use crate::process::cred::CAPFlags;
 use crate::process::{ProcessControlBlock, ProcessManager, RawPid};
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
@@ -293,7 +293,7 @@ fn do_process_vm_readv(
         let remote_addr = VirtAddr::new(remote_iov.iov_base as usize + remote_offset);
 
         // Verify local buffer is writable
-        if verify_area(local_addr, chunk_len).is_err() {
+        if access_ok(local_addr, chunk_len).is_err() {
             if bytes_copied > 0 {
                 return Ok(bytes_copied);
             }
@@ -455,7 +455,7 @@ fn do_process_vm_writev(
         let remote_addr = VirtAddr::new(remote_iov.iov_base as usize + remote_offset);
 
         // Verify local buffer is readable
-        if verify_area(local_addr, chunk_len).is_err() {
+        if access_ok(local_addr, chunk_len).is_err() {
             if bytes_copied > 0 {
                 return Ok(bytes_copied);
             }

--- a/kernel/src/net/syscall/sys_bind.rs
+++ b/kernel/src/net/syscall/sys_bind.rs
@@ -43,7 +43,7 @@ impl Syscall for SysBindHandle {
         // Verify address validity if from user space
         if frame.is_from_user() {
             let virt_addr = VirtAddr::new(addr as usize);
-            if crate::mm::verify_area(virt_addr, addrlen).is_err() {
+            if crate::mm::access_ok(virt_addr, addrlen).is_err() {
                 return Err(SystemError::EFAULT);
             }
         }

--- a/kernel/src/net/syscall/sys_connect.rs
+++ b/kernel/src/net/syscall/sys_connect.rs
@@ -43,7 +43,7 @@ impl Syscall for SysConnectHandle {
         // Verify address validity if from user space
         if frame.is_from_user() {
             let virt_addr = VirtAddr::new(addr as usize);
-            if crate::mm::verify_area(virt_addr, addrlen).is_err() {
+            if crate::mm::access_ok(virt_addr, addrlen).is_err() {
                 return Err(SystemError::EFAULT);
             }
         }

--- a/kernel/src/net/syscall/sys_recvfrom.rs
+++ b/kernel/src/net/syscall/sys_recvfrom.rs
@@ -50,20 +50,20 @@ impl Syscall for SysRecvfromHandle {
         // Verify buffer and address validity if from user space
         if frame.is_from_user() {
             let virt_buf = VirtAddr::new(buf as usize);
-            if crate::mm::verify_area(virt_buf, len).is_err() {
+            if crate::mm::access_ok(virt_buf, len).is_err() {
                 return Err(SystemError::EFAULT);
             }
 
             if !addrlen.is_null() {
                 let virt_addrlen = VirtAddr::new(addrlen as usize);
-                if crate::mm::verify_area(virt_addrlen, core::mem::size_of::<u32>()).is_err() {
+                if crate::mm::access_ok(virt_addrlen, core::mem::size_of::<u32>()).is_err() {
                     return Err(SystemError::EFAULT);
                 }
             }
 
             if !addr.is_null() {
                 let virt_addr = VirtAddr::new(addr as usize);
-                if crate::mm::verify_area(virt_addr, core::mem::size_of::<SockAddr>()).is_err() {
+                if crate::mm::access_ok(virt_addr, core::mem::size_of::<SockAddr>()).is_err() {
                     return Err(SystemError::EFAULT);
                 }
             }

--- a/kernel/src/net/syscall/sys_sendto.rs
+++ b/kernel/src/net/syscall/sys_sendto.rs
@@ -51,13 +51,13 @@ impl Syscall for SysSendtoHandle {
         // Verify buffer and address validity if from user space
         if frame.is_from_user() {
             let virt_buf = VirtAddr::new(buf as usize);
-            if crate::mm::verify_area(virt_buf, len).is_err() {
+            if crate::mm::access_ok(virt_buf, len).is_err() {
                 return Err(SystemError::EFAULT);
             }
 
             if !addr.is_null() {
                 let virt_addr = VirtAddr::new(addr as usize);
-                if crate::mm::verify_area(virt_addr, addrlen).is_err() {
+                if crate::mm::access_ok(virt_addr, addrlen).is_err() {
                     return Err(SystemError::EFAULT);
                 }
             }

--- a/kernel/src/net/syscall/sys_setsockopt.rs
+++ b/kernel/src/net/syscall/sys_setsockopt.rs
@@ -55,7 +55,7 @@ impl Syscall for SysSetsockoptHandle {
         // Verify optval address validity if from user space
         if frame.is_from_user() {
             let virt_optval = VirtAddr::new(optval as usize);
-            if crate::mm::verify_area(virt_optval, optlen_to_read).is_err() {
+            if crate::mm::access_ok(virt_optval, optlen_to_read).is_err() {
                 return Err(SystemError::EFAULT);
             }
         }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -7,7 +7,7 @@ use crate::filesystem::vfs::file::FileFlags;
 use crate::filesystem::vfs::file::FilePrivateData;
 use crate::filesystem::vfs::FileType;
 use crate::filesystem::vfs::InodeMode;
-use crate::mm::verify_area;
+use crate::mm::access_ok;
 use crate::mm::MemoryManagementArch;
 use crate::process::pid::PidPrivateData;
 use alloc::{string::ToString, sync::Arc};
@@ -152,7 +152,7 @@ impl KernelCloneArgs {
 
     pub fn verify(&self) -> Result<(), SystemError> {
         if self.flags.contains(CloneFlags::CLONE_SETTLS) {
-            verify_area(VirtAddr::new(self.tls), MMArch::PAGE_SIZE)
+            access_ok(VirtAddr::new(self.tls), MMArch::PAGE_SIZE)
                 .map_err(|_| SystemError::EPERM)?;
         }
         Ok(())

--- a/kernel/src/process/syscall/sys_clone.rs
+++ b/kernel/src/process/syscall/sys_clone.rs
@@ -1,6 +1,6 @@
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_CLONE;
-use crate::mm::{verify_area, VirtAddr};
+use crate::mm::{access_ok, VirtAddr};
 use crate::process::fork::{CloneFlags, KernelCloneArgs};
 use crate::process::syscall::clone_utils::do_clone;
 use crate::process::Signal;
@@ -41,8 +41,8 @@ impl Syscall for SysClone {
         let child_tid = Self::child_tid(args);
 
         // 地址校验
-        verify_area(parent_tid, core::mem::size_of::<i32>())?;
-        verify_area(child_tid, core::mem::size_of::<i32>())?;
+        access_ok(parent_tid, core::mem::size_of::<i32>())?;
+        access_ok(child_tid, core::mem::size_of::<i32>())?;
 
         let flags = Self::flags(args);
         let stack = Self::stack(args);

--- a/kernel/src/process/syscall/sys_execve.rs
+++ b/kernel/src/process/syscall/sys_execve.rs
@@ -7,7 +7,7 @@ use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_EXECVE;
 use crate::filesystem::vfs::{IndexNode, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES};
 use crate::mm::page::PAGE_4K_SIZE;
-use crate::mm::{verify_area, VirtAddr};
+use crate::mm::{access_ok, VirtAddr};
 use crate::process::execve::do_execve;
 use crate::process::{ProcessControlBlock, ProcessManager};
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
@@ -46,9 +46,9 @@ impl SysExecve {
 
         // 权限校验
         if frame.is_from_user()
-            && (verify_area(virt_path_ptr, MAX_PATHLEN).is_err()
-                || verify_area(virt_argv_ptr, PAGE_4K_SIZE).is_err())
-            || verify_area(virt_env_ptr, PAGE_4K_SIZE).is_err()
+            && (access_ok(virt_path_ptr, MAX_PATHLEN).is_err()
+                || access_ok(virt_argv_ptr, PAGE_4K_SIZE).is_err())
+            || access_ok(virt_env_ptr, PAGE_4K_SIZE).is_err()
         {
             return Err(SystemError::EFAULT);
         }


### PR DESCRIPTION
重命名理由：
- 修改前 DragonOS 中的 verify_area() 函数实际上与 Linux Kernal 中 access_ok() 的行为一致。
- verify_area 暗示"已验证可访问"，具有误导性
- access_ok 强调"快速范围检查"，符合实际行为

文档改进：
- 明确说明这只是第一层检查，不保证真正可访问
- 添加粗体警告，防止误用为"已验证可访问"
- 补充典型用法示例，展示配合 copy_to_user 的正确模式

这将函数语义从"验证已完成"纠正为"可以尝试访问"，
避免开发者误认为 Ok(()) 代表地址已映射或真正可访问。