### PR TITLE
feat(tty): 引入中断下半部机制并重构TTY输入处理

### DIFF
--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         tty::{
             console::ConsoleSwitch,
-            kthread::send_to_tty_refresh_thread,
+            kthread::enqueue_tty_rx_from_irq,
             termios::{WindowSize, TTY_STD_TERMIOS},
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyDriverType, TtyOperation},
@@ -326,7 +326,7 @@ impl VirtIODevice for VirtIOConsoleDevice {
             }
         }
 
-        send_to_tty_refresh_thread(&buf[0..index]);
+        enqueue_tty_rx_from_irq(&buf[0..index]);
         Ok(IrqReturn::Handled)
     }
 

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -20,7 +20,7 @@ use crate::{
         serial::{AtomicBaudRate, BaudRate, DivisorFraction, UartPort},
         tty::{
             console::ConsoleSwitch,
-            kthread::send_to_tty_refresh_thread,
+            kthread::enqueue_tty_rx_from_irq,
             termios::WindowSize,
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyOperation},
@@ -280,7 +280,7 @@ impl UartPort for Serial8250PIOPort {
             }
         }
 
-        send_to_tty_refresh_thread(&buf[0..index]);
+        enqueue_tty_rx_from_irq(&buf[0..index]);
         Ok(())
     }
 

--- a/kernel/src/exception/bottom_half.rs
+++ b/kernel/src/exception/bottom_half.rs
@@ -1,0 +1,110 @@
+//! Bottom-half (softirq/tasklet) 屏蔽机制（BH）
+//!
+//! 目标：提供类似 Linux `local_bh_disable/enable` 与 `*_bh` 锁语义的最小实现。
+//!
+//! ## 设计要点（对齐 Linux，适配 DragonOS 现状）
+//! - DragonOS 当前在硬中断退出路径无条件调用 `do_softirq()`，且 softirq 回调期间会重新打开本地中断。
+//! - 如果进程上下文持有普通自旋锁/读写锁时被中断打断，硬中断退出触发 softirq 再取同一把锁，会发生经典死锁。
+//! - 因此，我们引入"本 CPU 的 BH 禁用计数"，在 IRQ 退出路径检测到 BH disabled 时跳过 softirq 执行；
+//!   在 BH enable（计数归零）且处于 task context 时补跑 pending softirq。
+//!
+//! ## 重要边界
+//! - `lock_bh` 只解决"进程态 vs softirq/tasklet"并发。
+//! - 若同一把锁也会在 hardirq 中获取，仍必须使用 `*_irqsave`（`lock_bh` 不关硬中断）。
+//! - `local_bh_disable()` **不禁止抢占**，与 Linux 行为一致。`lock_bh()` 会额外禁用抢占。
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use system_error::SystemError;
+
+use alloc::vec::Vec;
+
+use crate::{
+    arch::CurrentIrqArch,
+    exception::{softirq, tasklet, InterruptArch},
+    mm::percpu::{PerCpu, PerCpuVar},
+};
+
+lazy_static! {
+    /// 每个 CPU 的 BH 禁用计数
+    static ref BH_DISABLE_COUNT: PerCpuVar<AtomicUsize> = {
+        let mut v = Vec::with_capacity(PerCpu::MAX_CPU_NUM as usize);
+        v.resize_with(PerCpu::MAX_CPU_NUM as usize, || AtomicUsize::new(0));
+        PerCpuVar::new(v).expect("PerCpuVar length mismatch")
+    };
+}
+
+#[inline(always)]
+fn local_cnt() -> &'static AtomicUsize {
+    BH_DISABLE_COUNT.get()
+}
+
+/// 返回本 CPU 是否允许执行 softirq/tasklet（bottom half）。
+#[inline(always)]
+pub fn is_local_bh_disabled() -> bool {
+    local_cnt().load(Ordering::SeqCst) != 0
+}
+
+/// 初始化中断下半部（bottom half）子系统。
+///
+/// 该函数按正确顺序依次初始化：
+/// 1. softirq：软中断核心机制
+/// 3. tasklet：基于 softirq 的 tasklet 机制
+///
+/// # Returns
+///
+/// 成功返回 `Ok(())`，失败返回相应错误。
+#[inline(never)]
+pub fn irq_bottom_half_init() -> Result<(), SystemError> {
+    softirq::softirq_init()?;
+    tasklet::tasklet_init()?;
+    Ok(())
+}
+
+/// 一个"禁用本 CPU bottom half"的 RAII 守卫
+///
+/// - 构造时：`bh_disable_cnt++`
+/// - Drop 时：`bh_disable_cnt--`；若归零且处于 task context（当前约束为：本地 IRQ enabled），则补跑 pending softirq。
+///
+/// ## 注意
+/// 与 Linux 行为一致，`local_bh_disable()` **不禁止抢占**。如果需要同时禁用抢占，
+/// 应使用 `lock_bh()` 或显式调用 `preempt_disable()`。
+pub struct LocalBhDisableGuard;
+
+/// 禁用本 CPU bottom half，返回 RAII 守卫。
+///
+/// 注意：该接口只屏蔽本 CPU 的 softirq/tasklet 执行，不关硬中断，也不禁止抢占。
+#[inline(always)]
+pub fn local_bh_disable() -> LocalBhDisableGuard {
+    local_cnt().fetch_add(1, Ordering::SeqCst);
+    LocalBhDisableGuard
+}
+
+impl Drop for LocalBhDisableGuard {
+    fn drop(&mut self) {
+        // 计数归零时，尝试在当前线程上下文补跑 pending softirq。
+        //
+        // 约束：只有在本地 IRQ enabled 时才做补跑；若此时 IRQ disabled（例如持有 irqsave 锁），
+        // 则只负责降低计数，pending 会在之后的 IRQ 退出点或未来某次 enable 点处理。
+        // 注意：
+        // - 必须在 IRQ-off 区间完成“递减 + 是否归零”的判定，避免硬中断退出路径观察到中间态。
+        // - 不能允许计数下溢；release 下也必须安全，因此用 checked decrement。
+        let irq_was_enabled = CurrentIrqArch::is_irq_enabled();
+        let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+
+        let prev =
+            local_cnt().fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| x.checked_sub(1));
+
+        match prev {
+            Ok(1) if irq_was_enabled => {
+                // 本次 drop 让计数归零，且来自 task context（IRQ was enabled）=> 补跑 softirq。
+                softirq::do_softirq();
+            }
+            Ok(_) => {}
+            Err(_old /* == 0 */) => {
+                // 发生了 enable 次数多于 disable 的逻辑错误；保持计数为 0，避免 wrap 下溢。
+                debug_assert!(false, "local_bh_enable underflow");
+            }
+        }
+    }
+}

--- a/kernel/src/exception/mod.rs
+++ b/kernel/src/exception/mod.rs
@@ -4,6 +4,7 @@ use system_error::SystemError;
 
 use crate::arch::CurrentIrqArch;
 
+pub mod bottom_half;
 pub mod debug;
 pub mod dummychip;
 pub mod ebreak;
@@ -21,6 +22,7 @@ pub mod msi;
 mod resend;
 pub mod softirq;
 pub mod sysfs;
+pub mod tasklet;
 
 /// 中断的架构相关的trait
 pub trait InterruptArch: Send + Sync {

--- a/kernel/src/exception/tasklet.rs
+++ b/kernel/src/exception/tasklet.rs
@@ -1,0 +1,111 @@
+//! Tasklet：一种基于 softirq 的 bottom-half 机制（Linux 风格，Rust 友好）
+//!
+//! 语义（MVP）：
+//! - 可以在 hardirq/task context 调用 `tasklet_schedule()`。
+//! - 同一个 tasklet 在同一时间不会并发执行（自串行）。
+//! - 重复 schedule 不会导致无限入队（使用 `is_scheduled` 去重）。
+//! - tasklet 在 softirq 上下文执行：不允许睡眠。
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use alloc::{sync::Arc, vec::Vec};
+use system_error::SystemError;
+
+use crate::{
+    exception::softirq::{softirq_vectors, SoftirqNumber, SoftirqVec},
+    libs::spinlock::SpinLock,
+    mm::percpu::{PerCpu, PerCpuVar},
+};
+
+#[derive(Debug)]
+pub struct Tasklet {
+    is_scheduled: AtomicBool,
+    is_running: AtomicBool,
+    callback: fn(usize),
+    data: usize,
+}
+
+impl Tasklet {
+    pub fn new(callback: fn(usize), data: usize) -> Arc<Self> {
+        Arc::new(Self {
+            is_scheduled: AtomicBool::new(false),
+            is_running: AtomicBool::new(false),
+            callback,
+            data,
+        })
+    }
+}
+
+lazy_static! {
+    /// 每个 CPU 的 tasklet 队列
+    static ref TASKLET_QUEUE: PerCpuVar<SpinLock<Vec<Arc<Tasklet>>>> = {
+        let mut v = Vec::with_capacity(PerCpu::MAX_CPU_NUM as usize);
+        v.resize_with(PerCpu::MAX_CPU_NUM as usize, || SpinLock::new(Vec::new()));
+        PerCpuVar::new(v).expect("PerCpuVar length mismatch")
+    };
+}
+
+#[inline(always)]
+fn local_queue() -> &'static SpinLock<Vec<Arc<Tasklet>>> {
+    TASKLET_QUEUE.get()
+}
+
+/// 调度一个 tasklet（去重）。
+///
+/// 允许在 hardirq/softirq/task context 调用；不会睡眠。
+pub fn tasklet_schedule(t: &Arc<Tasklet>) {
+    if t.is_scheduled
+        .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
+
+    // 入队时关本地中断，避免与 softirq handler 并发访问队列。
+    local_queue().lock_irqsave().push(t.clone());
+    softirq_vectors().raise_softirq(SoftirqNumber::TASKLET);
+}
+
+#[derive(Debug, Default)]
+struct TaskletSoftirq;
+
+impl SoftirqVec for TaskletSoftirq {
+    fn run(&self) {
+        // 将队列快速取出到本地，缩短关中断时间。
+        let mut processing = {
+            let mut q = local_queue().lock_irqsave();
+            core::mem::take(&mut *q)
+        };
+
+        while let Some(t) = processing.pop() {
+            // 若正在运行，则把它丢回队列并重新 raise（保证"自串行"，但允许再次被调度）。
+            if t.is_running
+                .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+                .is_err()
+            {
+                local_queue().lock_irqsave().push(t);
+                softirq_vectors().raise_softirq(SoftirqNumber::TASKLET);
+                continue;
+            }
+
+            // 允许回调里再次 schedule（此时可重新入队）。
+            // 注意：即使 tasklet 被 disable，已经入队的 tasklet 仍然会执行
+            // （符合 Linux 语义：disable 只阻止新的 schedule，不阻止已入队的执行）。
+            t.is_scheduled.store(false, Ordering::Release);
+
+            (t.callback)(t.data);
+
+            t.is_running.store(false, Ordering::Release);
+        }
+    }
+}
+
+/// 初始化 tasklet 子系统：注册 TASKLET softirq handler。
+///
+/// TASKLET_QUEUE 使用 lazy_static 自动初始化，无需手动初始化。
+#[inline(never)]
+pub fn tasklet_init() -> Result<(), SystemError> {
+    let handler = Arc::new(TaskletSoftirq);
+    softirq_vectors().register_softirq(SoftirqNumber::TASKLET, handler)?;
+    Ok(())
+}

--- a/kernel/src/filesystem/vfs/syscall/sys_select.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_select.rs
@@ -1,4 +1,3 @@
-//! Reference https://github.com/asterinas/asterinas/blob/main/kernel/src/syscall/select.rs
 use alloc::vec::Vec;
 use system_error::SystemError;
 

--- a/kernel/src/init/init.rs
+++ b/kernel/src/init/init.rs
@@ -8,7 +8,7 @@ use crate::{
         acpi::acpi_init, base::init::driver_init, serial::serial_early_init,
         video::VideoRefreshManager,
     },
-    exception::{init::irq_init, softirq::softirq_init, InterruptArch},
+    exception::{bottom_half::irq_bottom_half_init, init::irq_init, InterruptArch},
     filesystem::vfs::vcore::vfs_init,
     init::init_intertrait,
     libs::{
@@ -90,7 +90,8 @@ fn do_start_kernel() {
     CurrentSMPArch::prepare_cpus().expect("prepare_cpus failed");
 
     // sched_init();
-    softirq_init().expect("softirq init failed");
+    // 初始化中断下半部（softirq、bottom_half、tasklet）
+    irq_bottom_half_init().expect("bottom half subsystem init failed");
     Syscall::init().expect("syscall init failed");
     timekeeping_init();
     time_init();

--- a/kernel/src/libs/keyboard_parser.rs
+++ b/kernel/src/libs/keyboard_parser.rs
@@ -1,4 +1,4 @@
-use crate::driver::tty::kthread::send_to_tty_refresh_thread;
+use crate::driver::tty::kthread::enqueue_tty_rx_from_irq;
 
 #[allow(dead_code)]
 pub const NUM_SCAN_CODES: u8 = 0x80;
@@ -368,7 +368,7 @@ impl TypeOneFSMState {
     #[inline(always)]
     fn emit(ch: u8) {
         // 发送到tty
-        send_to_tty_refresh_thread(&[ch]);
+        enqueue_tty_rx_from_irq(&[ch]);
     }
 
     /// @brief 处理Prtsc按下事件


### PR DESCRIPTION
- 新增bottom_half模块，实现local_bh_disable/enable和lock_bh语义
- 新增tasklet模块，提供基于softirq的bottom-half机制
- 重构TTY输入处理：将send_to_tty_refresh_thread改为enqueue_tty_rx_from_irq，在硬 中断中只入队并调度tasklet
- 为spinlock和rwlock添加*_bh接口，支持在持锁时屏蔽softirq/tasklet
- 修改softirq执行逻辑，在BH禁用时跳过执行以避免死锁
- 更新初始化流程，统一初始化bottom-half子系统