### PR TITLE
refactor: 将 SpinLockGuard 替换为 MutexGuard

### DIFF
--- a/kernel/src/arch/riscv64/driver/vf2/dw_mshc/mmc.rs
+++ b/kernel/src/arch/riscv64/driver/vf2/dw_mshc/mmc.rs
@@ -944,7 +944,7 @@ impl IndexNode for MMC {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -953,7 +953,7 @@ impl IndexNode for MMC {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/arch/riscv64/process/mod.rs
+++ b/kernel/src/arch/riscv64/process/mod.rs
@@ -16,7 +16,6 @@ use crate::{
         CurrentIrqArch,
     },
     exception::InterruptArch,
-    libs::spinlock::SpinLockGuard,
     mm::VirtAddr,
     process::{
         fork::{CloneFlags, KernelCloneArgs},

--- a/kernel/src/bpf/map/mod.rs
+++ b/kernel/src/bpf/map/mod.rs
@@ -13,7 +13,9 @@ use crate::filesystem::vfs::InodeMode;
 use crate::filesystem::vfs::{FilePrivateData, FileSystem, FileType, IndexNode, Metadata};
 use crate::include::bindings::linux_bpf::{bpf_attr, bpf_map_type};
 use crate::libs::casting::DowncastArc;
-use crate::libs::spinlock::{SpinLock, SpinLockGuard};
+use crate::libs::mutex::MutexGuard;
+use crate::libs::spinlock::SpinLock;
+
 use crate::process::ProcessManager;
 use crate::syscall::user_access::{UserBufferReader, UserBufferWriter};
 use alloc::boxed::Box;
@@ -132,10 +134,10 @@ impl BpfMap {
 }
 
 impl IndexNode for BpfMap {
-    fn open(&self, _data: SpinLockGuard<FilePrivateData>, _flags: &FileFlags) -> Result<()> {
+    fn open(&self, _data: MutexGuard<FilePrivateData>, _flags: &FileFlags) -> Result<()> {
         Ok(())
     }
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<()> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<()> {
         Ok(())
     }
     fn read_at(
@@ -143,7 +145,7 @@ impl IndexNode for BpfMap {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         Err(SystemError::ENOSYS)
     }
@@ -153,7 +155,7 @@ impl IndexNode for BpfMap {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/bpf/prog/mod.rs
+++ b/kernel/src/bpf/prog/mod.rs
@@ -9,7 +9,7 @@ use crate::filesystem::vfs::file::{File, FileFlags};
 use crate::filesystem::vfs::InodeMode;
 use crate::filesystem::vfs::{FilePrivateData, FileSystem, FileType, IndexNode, Metadata};
 use crate::include::bindings::linux_bpf::bpf_attr;
-use crate::libs::spinlock::SpinLockGuard;
+use crate::libs::mutex::MutexGuard;
 use crate::process::ProcessManager;
 use alloc::string::String;
 use alloc::sync::Arc;
@@ -45,10 +45,10 @@ impl BpfProg {
 }
 
 impl IndexNode for BpfProg {
-    fn open(&self, _data: SpinLockGuard<FilePrivateData>, _flags: &FileFlags) -> Result<()> {
+    fn open(&self, _data: MutexGuard<FilePrivateData>, _flags: &FileFlags) -> Result<()> {
         Ok(())
     }
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<()> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<()> {
         Ok(())
     }
     fn read_at(
@@ -56,7 +56,7 @@ impl IndexNode for BpfProg {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         Err(SystemError::ENOSYS)
     }
@@ -66,7 +66,7 @@ impl IndexNode for BpfProg {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/driver/base/block/gendisk/mod.rs
+++ b/kernel/src/driver/base/block/gendisk/mod.rs
@@ -13,13 +13,12 @@ use system_error::SystemError;
 
 use super::block_device::{BlockDevice, BlockId, GeneralBlockRange, LBA_SIZE};
 use crate::{
-    driver::base::device::device_number::DeviceNumber,
-    driver::block::loop_device::LoopDevice,
+    driver::{base::device::device_number::DeviceNumber, block::loop_device::LoopDevice},
     filesystem::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
         vfs::{utils::DName, IndexNode, InodeMode, Metadata},
     },
-    libs::{rwlock::RwLock, spinlock::SpinLockGuard},
+    libs::{mutex::MutexGuard, rwlock::RwLock},
 };
 
 const MINORS_PER_DISK: u32 = 256;
@@ -225,7 +224,7 @@ impl IndexNode for GenDisk {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if len == 0 {
             return Ok(0);
@@ -241,7 +240,7 @@ impl IndexNode for GenDisk {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if len == 0 {
             return Ok(0);
@@ -286,14 +285,14 @@ impl IndexNode for GenDisk {
 
     fn close(
         &self,
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
         Ok(())
     }
 
     fn open(
         &self,
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
         _mode: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())

--- a/kernel/src/driver/block/loop_device/loop_control.rs
+++ b/kernel/src/driver/block/loop_device/loop_control.rs
@@ -19,6 +19,7 @@ use crate::{
         },
     },
     libs::{
+        mutex::MutexGuard,
         rwlock::RwLock,
         rwsem::{RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
@@ -102,13 +103,13 @@ impl Debug for LoopControlDevice {
 impl IndexNode for LoopControlDevice {
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         Ok(())
     }
 
@@ -211,7 +212,7 @@ impl IndexNode for LoopControlDevice {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -221,7 +222,7 @@ impl IndexNode for LoopControlDevice {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -25,6 +25,7 @@ use crate::{
         vfs::{FilePrivateData, FileType, IndexNode, InodeFlags, InodeId, InodeMode, Metadata},
     },
     libs::{
+        mutex::{Mutex, MutexGuard},
         rwlock::RwLock,
         rwsem::{RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
@@ -1013,7 +1014,7 @@ impl IndexNode for LoopDevice {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if len > buf.len() {
             return Err(SystemError::ENOBUFS);
@@ -1026,7 +1027,7 @@ impl IndexNode for LoopDevice {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if len > buf.len() {
             return Err(SystemError::E2BIG);
@@ -1267,7 +1268,7 @@ impl BlockDevice for LoopDevice {
             return Err(SystemError::ENOSPC);
         }
 
-        let data = SpinLock::new(FilePrivateData::Unused);
+        let data = Mutex::new(FilePrivateData::Unused);
         let data_guard = data.lock();
 
         file_inode.read_at(file_offset, len, &mut buf[..len], data_guard)
@@ -1315,7 +1316,7 @@ impl BlockDevice for LoopDevice {
             return Err(SystemError::ENOSPC);
         }
 
-        let data = SpinLock::new(FilePrivateData::Unused);
+        let data = Mutex::new(FilePrivateData::Unused);
         let data_guard = data.lock();
 
         let written = file_inode.write_at(file_offset, len, &buf[..len], data_guard)?;

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -49,6 +49,7 @@ use crate::{
     },
     init::initcall::INITCALL_POSTCORE,
     libs::{
+        mutex::MutexGuard,
         rwlock::RwLock,
         rwsem::{RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
@@ -244,7 +245,7 @@ impl IndexNode for VirtIOBlkDevice {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -253,7 +254,7 @@ impl IndexNode for VirtIOBlkDevice {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -274,7 +275,7 @@ impl IndexNode for VirtIOBlkDevice {
 
     fn close(
         &self,
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
         Ok(())
     }
@@ -286,7 +287,7 @@ impl IndexNode for VirtIOBlkDevice {
 
     fn open(
         &self,
-        _data: SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
         _mode: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())

--- a/kernel/src/driver/input/ps2_mouse/ps_mouse_device.rs
+++ b/kernel/src/driver/input/ps2_mouse/ps_mouse_device.rs
@@ -9,6 +9,7 @@ use kdepends::ringbuffer::{AllocRingBuffer, RingBuffer};
 use log::{debug, error};
 use system_error::SystemError;
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     arch::{io::PortIOArch, CurrentIrqArch, CurrentPortIOArch},
     driver::{
@@ -599,7 +600,7 @@ impl DeviceINode for Ps2MouseDevice {
 impl IndexNode for Ps2MouseDevice {
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         let mut guard = self.inner.lock_irqsave();
@@ -607,7 +608,7 @@ impl IndexNode for Ps2MouseDevice {
         Ok(())
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         let mut guard = self.inner.lock_irqsave();
         guard.buf.clear();
         Ok(())
@@ -618,7 +619,7 @@ impl IndexNode for Ps2MouseDevice {
         _offset: usize,
         _len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let mut guard = self.inner.lock_irqsave();
 
@@ -637,7 +638,7 @@ impl IndexNode for Ps2MouseDevice {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return Err(SystemError::ENOSYS);
     }

--- a/kernel/src/driver/keyboard/ps2_keyboard.rs
+++ b/kernel/src/driver/keyboard/ps2_keyboard.rs
@@ -7,6 +7,7 @@ use alloc::{
 
 use unified_init::macros::unified_init;
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     arch::{io::PortIOArch, CurrentIrqArch, CurrentPortIOArch},
     driver::{
@@ -27,11 +28,7 @@ use crate::{
         },
     },
     init::initcall::INITCALL_DEVICE,
-    libs::{
-        keyboard_parser::TypeOneFSM,
-        rwlock::RwLock,
-        spinlock::{SpinLock, SpinLockGuard},
-    },
+    libs::{keyboard_parser::TypeOneFSM, rwlock::RwLock, spinlock::SpinLock},
     time::PosixTimeSpec,
 };
 use system_error::SystemError;
@@ -128,7 +125,7 @@ impl IndexNode for LockedPS2KeyBoardInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return Err(SystemError::ENOSYS);
     }
@@ -138,20 +135,20 @@ impl IndexNode for LockedPS2KeyBoardInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return Err(SystemError::ENOSYS);
     }
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 

--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -17,7 +17,7 @@ use crate::{
         epoll::{event_poll::EventPoll, EPollEventType},
         vfs::{file::FileFlags, FilePrivateData, FileSystem, FileType, IndexNode, InodeMode},
     },
-    libs::{casting::DowncastArc, spinlock::SpinLockGuard},
+    libs::{casting::DowncastArc, mutex::MutexGuard},
     mm::VirtAddr,
     syscall::user_access::UserBufferWriter,
 };
@@ -356,7 +356,7 @@ impl TtyOperation for Unix98PtyDriverInner {
 
 pub fn ptmx_open(
     this: &TtyDevice,
-    mut data: SpinLockGuard<FilePrivateData>,
+    mut data: MutexGuard<FilePrivateData>,
     flags: &FileFlags,
 ) -> Result<(), SystemError> {
     if let FilePrivateData::Tty(data) = &*data {

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -36,7 +36,7 @@ use crate::{
         },
     },
     init::initcall::INITCALL_DEVICE,
-    libs::{rwlock::RwLock, spinlock::SpinLockGuard},
+    libs::{mutex::MutexGuard, rwlock::RwLock},
     mm::VirtAddr,
     process::ProcessManager,
     syscall::user_access::{UserBufferReader, UserBufferWriter},
@@ -221,7 +221,7 @@ impl PollableInode for TtyDevice {
 impl IndexNode for TtyDevice {
     fn open(
         &self,
-        mut data: SpinLockGuard<FilePrivateData>,
+        mut data: MutexGuard<FilePrivateData>,
         mode: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         if self.tty_type == TtyType::Pty(PtyType::Ptm) {
@@ -298,7 +298,7 @@ impl IndexNode for TtyDevice {
         _offset: usize,
         len: usize,
         buf: &mut [u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         let (tty, flags) = if let FilePrivateData::Tty(tty_priv) = &*data {
             (tty_priv.tty(), tty_priv.flags)
@@ -340,7 +340,7 @@ impl IndexNode for TtyDevice {
         _offset: usize,
         len: usize,
         buf: &[u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         let mut count = len;
         let (tty, flags) = if let FilePrivateData::Tty(tty_priv) = &*data {
@@ -424,7 +424,7 @@ impl IndexNode for TtyDevice {
         None
     }
 
-    fn close(&self, data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         let (tty, _flags) = if let FilePrivateData::Tty(tty_priv) = &*data {
             (tty_priv.tty(), tty_priv.flags)
         } else {

--- a/kernel/src/driver/video/fbdev/base/fbmem.rs
+++ b/kernel/src/driver/video/fbdev/base/fbmem.rs
@@ -10,6 +10,7 @@ use log::error;
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     driver::base::{
         class::{class_manager, Class},
@@ -405,13 +406,13 @@ impl DeviceINode for FbDevice {
 impl IndexNode for FbDevice {
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         Ok(())
     }
     fn read_at(
@@ -419,7 +420,7 @@ impl IndexNode for FbDevice {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let fb = self.inner.lock().fb.upgrade().unwrap();
         return fb.fb_read(&mut buf[0..len], offset);
@@ -430,7 +431,7 @@ impl IndexNode for FbDevice {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let fb = self.inner.lock().fb.upgrade().unwrap();
         return fb.fb_write(&buf[0..len], offset);

--- a/kernel/src/filesystem/devfs/null_dev.rs
+++ b/kernel/src/filesystem/devfs/null_dev.rs
@@ -6,7 +6,7 @@ use crate::filesystem::vfs::{
     vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags,
     Metadata,
 };
-use crate::libs::spinlock::SpinLockGuard;
+use crate::libs::mutex::MutexGuard;
 use crate::{libs::spinlock::SpinLock, time::PosixTimeSpec};
 use alloc::{
     string::String,
@@ -84,13 +84,13 @@ impl IndexNode for LockedNullInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 
@@ -125,7 +125,7 @@ impl IndexNode for LockedNullInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return Ok(0);
     }
@@ -136,7 +136,7 @@ impl IndexNode for LockedNullInode {
         _offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);

--- a/kernel/src/filesystem/devfs/random_dev.rs
+++ b/kernel/src/filesystem/devfs/random_dev.rs
@@ -5,8 +5,8 @@ use crate::filesystem::vfs::{
     vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags,
     InodeMode, Metadata,
 };
+use crate::libs::mutex::MutexGuard;
 use crate::libs::rand::rand_bytes;
-use crate::libs::spinlock::SpinLockGuard;
 use crate::{filesystem::devfs::DevFS, libs::spinlock::SpinLock, time::PosixTimeSpec};
 use alloc::{
     string::String,
@@ -78,13 +78,13 @@ impl IndexNode for LockedRandomInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         Ok(())
     }
 
@@ -121,7 +121,7 @@ impl IndexNode for LockedRandomInode {
         _offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);
@@ -143,7 +143,7 @@ impl IndexNode for LockedRandomInode {
         _offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);

--- a/kernel/src/filesystem/devfs/zero_dev.rs
+++ b/kernel/src/filesystem/devfs/zero_dev.rs
@@ -6,7 +6,7 @@ use crate::filesystem::vfs::{
     vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags,
     Metadata,
 };
-use crate::libs::spinlock::SpinLockGuard;
+use crate::libs::mutex::MutexGuard;
 use crate::{libs::spinlock::SpinLock, time::PosixTimeSpec};
 use alloc::{
     string::String,
@@ -84,13 +84,13 @@ impl IndexNode for LockedZeroInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 
@@ -125,7 +125,7 @@ impl IndexNode for LockedZeroInode {
         _offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);
@@ -144,7 +144,7 @@ impl IndexNode for LockedZeroInode {
         _offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);

--- a/kernel/src/filesystem/devpts/mod.rs
+++ b/kernel/src/filesystem/devpts/mod.rs
@@ -3,6 +3,7 @@ use core::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     driver::{
         base::device::{
@@ -18,7 +19,7 @@ use crate::{
         mount::{do_mount_mkdir, MountFlags},
         FileSystem, FileType, FsInfo, InodeMode, MountableFileSystem, SuperBlock, FSMAKER,
     },
-    libs::spinlock::{SpinLock, SpinLockGuard},
+    libs::spinlock::SpinLock,
     time::PosixTimeSpec,
 };
 use alloc::{
@@ -255,7 +256,7 @@ impl PtsDevInode {
 impl IndexNode for LockedDevPtsFSInode {
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &super::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -268,7 +269,7 @@ impl IndexNode for LockedDevPtsFSInode {
         return Ok(metadata);
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         // TODO: 回收
         Ok(())
     }
@@ -278,7 +279,7 @@ impl IndexNode for LockedDevPtsFSInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         todo!()
     }
@@ -288,7 +289,7 @@ impl IndexNode for LockedDevPtsFSInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         todo!()
     }

--- a/kernel/src/filesystem/epoll/mod.rs
+++ b/kernel/src/filesystem/epoll/mod.rs
@@ -1,5 +1,5 @@
 use super::{poll::PollFlags, vfs::file::File};
-use crate::libs::{rwlock::RwLock, spinlock::SpinLock};
+use crate::libs::{mutex::Mutex, rwsem::RwSem};
 use alloc::sync::Weak;
 use core::fmt::Debug;
 use event_poll::EventPoll;
@@ -53,9 +53,9 @@ impl EPollEvent {
 #[derive(Debug)]
 pub struct EPollItem {
     /// 对应的Epoll
-    epoll: Weak<SpinLock<EventPoll>>,
+    epoll: Weak<Mutex<EventPoll>>,
     /// 用户注册的事件
-    event: RwLock<EPollEvent>,
+    event: RwSem<EPollEvent>,
     /// 监听的描述符
     fd: i32,
     /// 对应的文件
@@ -64,24 +64,24 @@ pub struct EPollItem {
 
 impl EPollItem {
     pub fn new(
-        epoll: Weak<SpinLock<EventPoll>>,
+        epoll: Weak<Mutex<EventPoll>>,
         events: EPollEvent,
         fd: i32,
         file: Weak<File>,
     ) -> Self {
         Self {
             epoll,
-            event: RwLock::new(events),
+            event: RwSem::new(events),
             fd,
             file,
         }
     }
 
-    pub fn epoll(&self) -> Weak<SpinLock<EventPoll>> {
+    pub fn epoll(&self) -> Weak<Mutex<EventPoll>> {
         self.epoll.clone()
     }
 
-    pub fn event(&self) -> &RwLock<EPollEvent> {
+    pub fn event(&self) -> &RwSem<EPollEvent> {
         &self.event
     }
 

--- a/kernel/src/filesystem/eventfd.rs
+++ b/kernel/src/filesystem/eventfd.rs
@@ -7,6 +7,7 @@ use crate::filesystem::{
     epoll::{event_poll::EventPoll, EPollEventType, EPollItem},
     vfs::{FilePrivateData, FileSystem, FileType, FsInfo, IndexNode, Magic, Metadata, SuperBlock},
 };
+use crate::libs::mutex::MutexGuard;
 use crate::libs::spinlock::{SpinLock, SpinLockGuard};
 use crate::libs::wait_queue::WaitQueue;
 use crate::mm::MemoryManagementArch;
@@ -175,13 +176,13 @@ impl IndexNode for EventFdInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         Ok(())
     }
 
@@ -198,7 +199,7 @@ impl IndexNode for EventFdInode {
         _offset: usize,
         len: usize,
         buf: &mut [u8],
-        data_guard: SpinLockGuard<FilePrivateData>,
+        data_guard: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let data = data_guard.clone();
         drop(data_guard);
@@ -262,7 +263,7 @@ impl IndexNode for EventFdInode {
         _offset: usize,
         len: usize,
         buf: &[u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if len < 8 {
             return Err(SystemError::EINVAL);

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -6,10 +6,7 @@ use crate::{
             InodeId, InodeMode,
         },
     },
-    libs::{
-        casting::DowncastArc,
-        spinlock::{SpinLock, SpinLockGuard},
-    },
+    libs::{casting::DowncastArc, mutex::MutexGuard, spinlock::SpinLock},
     time::PosixTimeSpec,
 };
 use alloc::{
@@ -25,7 +22,7 @@ use system_error::SystemError;
 
 use super::filesystem::Ext4FileSystem;
 
-type PrivateData<'a> = crate::libs::spinlock::SpinLockGuard<'a, vfs::FilePrivateData>;
+type PrivateData<'a> = crate::libs::mutex::MutexGuard<'a, vfs::FilePrivateData>;
 
 pub struct Ext4Inode {
     // 对应another_ext4里面的inode号，用于在ext4文件系统中查找相应的inode
@@ -55,7 +52,7 @@ impl IndexNode for LockedExt4Inode {
 
     fn open(
         &self,
-        _data: crate::libs::spinlock::SpinLockGuard<vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
         _mode: &vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -173,7 +170,7 @@ impl IndexNode for LockedExt4Inode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let len = core::cmp::min(len, buf.len());
         self.read_sync(offset, &mut buf[0..len])
@@ -245,7 +242,7 @@ impl IndexNode for LockedExt4Inode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let len = core::cmp::min(len, buf.len());
         self.write_sync(offset, &buf[0..len])

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -1,5 +1,6 @@
 use crate::arch::MMArch;
 use crate::filesystem::vfs::syscall::RenameFlags;
+use crate::libs::mutex::MutexGuard;
 use crate::mm::truncate::truncate_inode_pages;
 use crate::mm::MemoryManagementArch;
 use alloc::string::ToString;
@@ -1745,7 +1746,7 @@ impl IndexNode for LockedFATInode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let len = core::cmp::min(len, buf.len());
         let buf = &mut buf[0..len];
@@ -1757,7 +1758,7 @@ impl IndexNode for LockedFATInode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let len = core::cmp::min(len, buf.len());
         let buf = &buf[0..len];
@@ -1769,7 +1770,7 @@ impl IndexNode for LockedFATInode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let len = core::cmp::min(len, buf.len());
         let r = self.read_sync(offset, &mut buf[0..len]);
@@ -1782,7 +1783,7 @@ impl IndexNode for LockedFATInode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let len = core::cmp::min(len, buf.len());
         let r = self.write_sync(offset, &buf[0..len]);
@@ -2010,13 +2011,13 @@ impl IndexNode for LockedFATInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 

--- a/kernel/src/filesystem/kernfs/callback.rs
+++ b/kernel/src/filesystem/kernfs/callback.rs
@@ -1,9 +1,7 @@
 use super::KernFSInode;
+use crate::filesystem::{sysfs::SysFSKernPrivateData, vfs::PollStatus};
+use crate::libs::mutex::MutexGuard;
 use crate::tracepoint::{TraceCmdLineCacheSnapshot, TracePipeSnapshot, TracePointInfo};
-use crate::{
-    filesystem::{sysfs::SysFSKernPrivateData, vfs::PollStatus},
-    libs::spinlock::SpinLockGuard,
-};
 use alloc::sync::Arc;
 use core::fmt::Debug;
 use system_error::SystemError;
@@ -35,14 +33,14 @@ pub trait KernFSCallback: Send + Sync + Debug {
 #[derive(Debug)]
 pub struct KernCallbackData<'a> {
     kern_inode: Arc<KernFSInode>,
-    private_data: SpinLockGuard<'a, Option<KernInodePrivateData>>,
+    private_data: MutexGuard<'a, Option<KernInodePrivateData>>,
 }
 
 #[allow(dead_code)]
 impl<'a> KernCallbackData<'a> {
     pub fn new(
         kern_inode: Arc<KernFSInode>,
-        private_data: SpinLockGuard<'a, Option<KernInodePrivateData>>,
+        private_data: MutexGuard<'a, Option<KernInodePrivateData>>,
     ) -> Self {
         Self {
             kern_inode,

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -1,7 +1,7 @@
 use super::OvlInode;
 use crate::{
     filesystem::vfs::{IndexNode, Metadata},
-    libs::spinlock::SpinLock,
+    libs::mutex::Mutex,
 };
 use alloc::sync::Arc;
 use system_error::SystemError;
@@ -19,7 +19,7 @@ impl OvlInode {
         let new_upper_inode = self.create_upper_inode(metadata.clone())?;
 
         let mut buffer = vec![0u8; metadata.size as usize];
-        let lock = SpinLock::new(crate::filesystem::vfs::FilePrivateData::Unused);
+        let lock = Mutex::new(crate::filesystem::vfs::FilePrivateData::Unused);
         lower_inode.read_at(0, metadata.size as usize, &mut buffer, lock.lock())?;
 
         new_upper_inode.write_at(0, metadata.size as usize, &buffer, lock.lock())?;

--- a/kernel/src/filesystem/overlayfs/mod.rs
+++ b/kernel/src/filesystem/overlayfs/mod.rs
@@ -269,7 +269,7 @@ impl IndexNode for OvlInode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        data: crate::libs::spinlock::SpinLockGuard<vfs::FilePrivateData>,
+        data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         if let Some(ref upper_inode) = *self.upper_inode.lock() {
             return upper_inode.read_at(offset, len, buf, data);
@@ -287,7 +287,7 @@ impl IndexNode for OvlInode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        data: crate::libs::spinlock::SpinLockGuard<vfs::FilePrivateData>,
+        data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if (*self.upper_inode.lock()).is_none() {
             self.copy_up()?;

--- a/kernel/src/filesystem/procfs/cmdline.rs
+++ b/kernel/src/filesystem/procfs/cmdline.rs
@@ -4,6 +4,7 @@
 
 use alloc::string::ToString;
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -52,7 +53,7 @@ impl FileOps for CmdlineFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = Self::generate_cmdline_content();
 

--- a/kernel/src/filesystem/procfs/cpuinfo.rs
+++ b/kernel/src/filesystem/procfs/cpuinfo.rs
@@ -34,7 +34,7 @@ impl FileOps for CpuInfoFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let mut data: Vec<u8> = vec![];
         let cpu_manager = smp_cpu_manager();

--- a/kernel/src/filesystem/procfs/kmsg_file.rs
+++ b/kernel/src/filesystem/procfs/kmsg_file.rs
@@ -2,16 +2,14 @@
 //!
 //! 这个文件提供对内核日志消息的访问
 
-use crate::{
-    filesystem::{
-        procfs::{
-            kmsg::KMSG,
-            template::{Builder, FileOps, ProcFileBuilder},
-        },
-        vfs::{FilePrivateData, IndexNode, InodeMode},
+use crate::filesystem::{
+    procfs::{
+        kmsg::KMSG,
+        template::{Builder, FileOps, ProcFileBuilder},
     },
-    libs::spinlock::SpinLockGuard,
+    vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
 
@@ -34,7 +32,7 @@ impl FileOps for KmsgFileOps {
         _offset: usize,
         _len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // 访问全局 KMSG 缓冲区
         let kmsg = unsafe { KMSG.as_ref().ok_or(SystemError::ENODEV)? };

--- a/kernel/src/filesystem/procfs/meminfo.rs
+++ b/kernel/src/filesystem/procfs/meminfo.rs
@@ -2,6 +2,7 @@
 //!
 //! 这个文件展示了系统的内存使用情况
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -64,7 +65,7 @@ impl FileOps for MeminfoFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = Self::generate_meminfo_content();
         proc_read(offset, len, buf, &content)

--- a/kernel/src/filesystem/procfs/mounts.rs
+++ b/kernel/src/filesystem/procfs/mounts.rs
@@ -2,6 +2,7 @@
 //!
 //! 这个文件展示了系统当前的所有挂载点
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -138,7 +139,7 @@ impl FileOps for MountsFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let mounts_content = generate_mounts_like_content(MountsFormat::Mounts);
         let bytes = mounts_content.as_bytes();

--- a/kernel/src/filesystem/procfs/net/arp.rs
+++ b/kernel/src/filesystem/procfs/net/arp.rs
@@ -12,6 +12,7 @@ use crate::filesystem::{
     },
     vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use crate::net::neighbor;
 use alloc::string::ToString;
 use alloc::{string::String, sync::Arc, sync::Weak, vec::Vec};
@@ -80,7 +81,7 @@ impl FileOps for ArpFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = Self::generate_arp_content();
         proc_read(offset, len, buf, &content)

--- a/kernel/src/filesystem/procfs/net/protocols.rs
+++ b/kernel/src/filesystem/procfs/net/protocols.rs
@@ -12,6 +12,7 @@ use crate::filesystem::{
     },
     vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use alloc::{format, sync::Arc, sync::Weak, vec::Vec};
 use system_error::SystemError;
 
@@ -154,7 +155,7 @@ impl FileOps for ProtocolsFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = Self::generate_protocols_content();
         proc_read(offset, len, buf, &content)

--- a/kernel/src/filesystem/procfs/pid/cmdline.rs
+++ b/kernel/src/filesystem/procfs/pid/cmdline.rs
@@ -2,6 +2,7 @@
 //!
 //! 返回进程的完整命令行，各参数之间以 \0 分隔
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -10,7 +11,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     process::{ProcessManager, RawPid},
 };
 use alloc::sync::{Arc, Weak};
@@ -37,7 +37,7 @@ impl FileOps for CmdlineFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // 查找进程
         let pcb = ProcessManager::find(self.pid).ok_or(SystemError::ESRCH)?;

--- a/kernel/src/filesystem/procfs/pid/fdinfo.rs
+++ b/kernel/src/filesystem/procfs/pid/fdinfo.rs
@@ -2,12 +2,12 @@
 //!
 //! 这个目录包含了进程打开的所有文件描述符的详细信息
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::template::{Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder},
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     process::{ProcessControlBlock, ProcessManager, RawPid},
 };
 use alloc::{
@@ -133,7 +133,7 @@ impl FileOps for FdInfoFileOps {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // // 动态查找进程
         // let process = ProcessManager::find(self.pid).ok_or(SystemError::ESRCH)?;

--- a/kernel/src/filesystem/procfs/pid/maps.rs
+++ b/kernel/src/filesystem/procfs/pid/maps.rs
@@ -2,6 +2,7 @@
 //!
 //! 返回进程的内存映射信息，格式兼容 Linux procfs
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     arch::MMArch,
     filesystem::{
@@ -11,7 +12,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     mm::{ucontext::LockedVMA, MemoryManagementArch, VmFlags},
     process::{ProcessManager, RawPid},
 };
@@ -168,7 +168,7 @@ impl FileOps for MapsFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = generate_maps_content(self.pid)?;
         proc_read(offset, len, buf, &content)

--- a/kernel/src/filesystem/procfs/pid/mountinfo.rs
+++ b/kernel/src/filesystem/procfs/pid/mountinfo.rs
@@ -2,6 +2,7 @@
 //!
 //! 显示进程的挂载点详细信息
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -11,7 +12,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     process::RawPid,
 };
 use alloc::sync::{Arc, Weak};
@@ -39,7 +39,7 @@ impl FileOps for MountInfoFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = generate_mountinfo_content();
         proc_read(offset, len, buf, content.as_bytes())

--- a/kernel/src/filesystem/procfs/pid/mounts.rs
+++ b/kernel/src/filesystem/procfs/pid/mounts.rs
@@ -2,6 +2,7 @@
 //!
 //! 显示进程的挂载点信息
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -11,7 +12,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     process::RawPid,
 };
 use alloc::sync::{Arc, Weak};
@@ -39,7 +39,7 @@ impl FileOps for PidMountsFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = generate_mounts_content();
         proc_read(offset, len, buf, content.as_bytes())

--- a/kernel/src/filesystem/procfs/pid/ns.rs
+++ b/kernel/src/filesystem/procfs/pid/ns.rs
@@ -2,6 +2,7 @@
 //!
 //! 提供进程的命名空间符号链接，每个链接指向对应的命名空间标识符
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -13,7 +14,6 @@ use crate::{
             IndexNode, InodeId, InodeMode,
         },
     },
-    libs::spinlock::SpinLockGuard,
     process::{
         namespace::{nsproxy::NamespaceId, NamespaceOps},
         ProcessManager, RawPid,
@@ -151,7 +151,7 @@ impl SymOps for NsSymOps {
             .map(InodeId::new)
     }
 
-    fn open(&self, data: &mut SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         // 当打开命名空间文件时，设置命名空间私有数据
         // 这使得 setns() 可以使用这个 fd
         let pcb = ProcessManager::find(self.pid).ok_or(SystemError::ESRCH)?;

--- a/kernel/src/filesystem/procfs/pid/stat.rs
+++ b/kernel/src/filesystem/procfs/pid/stat.rs
@@ -2,6 +2,7 @@
 //!
 //! 以单行格式返回进程的状态信息，兼容 Linux procfs 格式
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     arch::MMArch,
     filesystem::{
@@ -11,7 +12,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     mm::MemoryManagementArch,
     process::{pid::PidType, ProcessControlBlock, ProcessManager, ProcessState, RawPid},
 };
@@ -123,7 +123,7 @@ impl FileOps for StatFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let pcb = ProcessManager::find(self.pid).ok_or(SystemError::ESRCH)?;
 

--- a/kernel/src/filesystem/procfs/pid/statm.rs
+++ b/kernel/src/filesystem/procfs/pid/statm.rs
@@ -2,6 +2,7 @@
 //!
 //! 显示进程的内存使用统计（以页为单位）
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     arch::MMArch,
     filesystem::{
@@ -11,7 +12,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     mm::MemoryManagementArch,
     process::{ProcessManager, RawPid},
 };
@@ -42,7 +42,7 @@ impl FileOps for StatmFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // 查找进程
         let pcb = ProcessManager::find(self.pid).ok_or(SystemError::ESRCH)?;

--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -2,6 +2,7 @@
 //!
 //! 显示进程的详细状态信息
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -10,7 +11,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
     process::{ProcessManager, RawPid},
 };
 use alloc::{
@@ -169,7 +169,7 @@ impl FileOps for StatusFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = self.generate_status_content()?;
         // log::info!("Generated /proc/[pid]/status content");

--- a/kernel/src/filesystem/procfs/sys/kernel.rs
+++ b/kernel/src/filesystem/procfs/sys/kernel.rs
@@ -2,6 +2,7 @@
 //!
 //! 提供内核参数配置接口
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     debug::klog::loglevel::KERNEL_LOG_LEVEL,
     filesystem::{
@@ -11,7 +12,6 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    libs::spinlock::SpinLockGuard,
 };
 use alloc::{
     format,
@@ -113,7 +113,7 @@ impl FileOps for PrintkFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = Self::read_config();
         proc_read(offset, len, buf, content.as_bytes())
@@ -124,7 +124,7 @@ impl FileOps for PrintkFileOps {
         _offset: usize,
         _len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Self::write_config(buf)
     }

--- a/kernel/src/filesystem/procfs/template/dir.rs
+++ b/kernel/src/filesystem/procfs/template/dir.rs
@@ -1,3 +1,4 @@
+use crate::libs::mutex::MutexGuard;
 use crate::{
     driver::base::device::device_number::DeviceNumber,
     filesystem::{
@@ -7,7 +8,7 @@ use crate::{
             FileType, IndexNode, InodeFlags, InodeId, InodeMode, Metadata,
         },
     },
-    libs::{rwlock::RwLock, spinlock::SpinLockGuard},
+    libs::rwlock::RwLock,
     time::PosixTimeSpec,
 };
 use alloc::collections::BTreeMap;
@@ -101,7 +102,7 @@ impl<Ops: DirOps + 'static> IndexNode for ProcDir<Ops> {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::EISDIR)
     }
@@ -111,7 +112,7 @@ impl<Ops: DirOps + 'static> IndexNode for ProcDir<Ops> {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::EISDIR)
     }
@@ -210,13 +211,13 @@ impl<Ops: DirOps + 'static> IndexNode for ProcDir<Ops> {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 

--- a/kernel/src/filesystem/procfs/thread_self.rs
+++ b/kernel/src/filesystem/procfs/thread_self.rs
@@ -3,6 +3,7 @@
 //! 这个模块实现了 /proc/thread-self 目录，它包含当前线程的信息。
 //! 主要提供 /proc/thread-self/ns/ 子目录用于访问当前线程的命名空间。
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::template::{Builder, DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
@@ -11,7 +12,6 @@ use crate::{
             IndexNode, InodeId, InodeMode,
         },
     },
-    libs::spinlock::SpinLockGuard,
     process::{
         namespace::{nsproxy::NamespaceId, NamespaceOps},
         ProcessManager,
@@ -249,7 +249,7 @@ impl SymOps for ThreadSelfNsSymOps {
         Some(InodeId::new(current_thread_self_ns_ino(self.ns_type)))
     }
 
-    fn open(&self, data: &mut SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         // 当打开命名空间文件时，设置命名空间私有数据
         // 这使得 setns() 可以使用这个 fd
         let pcb = ProcessManager::current_pcb();

--- a/kernel/src/filesystem/procfs/version.rs
+++ b/kernel/src/filesystem/procfs/version.rs
@@ -2,6 +2,7 @@
 //!
 //! 这个文件展示了内核版本、编译信息等
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
@@ -56,7 +57,7 @@ impl FileOps for VersionFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let content = Self::generate_version_content();
         proc_read(offset, len, buf, &content)

--- a/kernel/src/filesystem/procfs/version_signature.rs
+++ b/kernel/src/filesystem/procfs/version_signature.rs
@@ -3,16 +3,14 @@
 //! 这个文件用于兼容 Aya 框架的内核版本识别
 //! 格式: DragonOS 6.0.0-generic 6.0.0
 
-use crate::{
-    filesystem::{
-        procfs::{
-            template::{Builder, FileOps, ProcFileBuilder},
-            utils::proc_read,
-        },
-        vfs::{FilePrivateData, IndexNode, InodeMode},
+use crate::filesystem::{
+    procfs::{
+        template::{Builder, FileOps, ProcFileBuilder},
+        utils::proc_read,
     },
-    libs::spinlock::SpinLockGuard,
+    vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
 
@@ -37,7 +35,7 @@ impl FileOps for VersionSignatureFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         proc_read(offset, len, buf, Self::VERSION_SIGNATURE)
     }

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -3,6 +3,7 @@ use core::intrinsics::unlikely;
 
 use crate::filesystem::vfs::syscall::RenameFlags;
 use crate::filesystem::vfs::{FileSystemMakerData, FSMAKER};
+use crate::libs::mutex::MutexGuard;
 use crate::libs::rwlock::RwLock;
 use crate::register_mountable_fs;
 use crate::{
@@ -197,13 +198,13 @@ impl IndexNode for LockedRamFSInode {
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &super::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         return Ok(());
@@ -214,7 +215,7 @@ impl IndexNode for LockedRamFSInode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);
@@ -246,7 +247,7 @@ impl IndexNode for LockedRamFSInode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -5,6 +5,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use crate::filesystem::page_cache::PageCache;
 use crate::filesystem::vfs::syscall::RenameFlags;
 use crate::filesystem::vfs::{FileSystemMakerData, FSMAKER};
+use crate::libs::mutex::MutexGuard;
 use crate::libs::rwlock::RwLock;
 use crate::mm::allocator::page_frame::FrameAllocator;
 use crate::mm::fault::PageFaultHandler;
@@ -433,13 +434,13 @@ impl IndexNode for LockedTmpfsInode {
         self.resize(len)
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         Ok(())
     }
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &super::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -450,7 +451,7 @@ impl IndexNode for LockedTmpfsInode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);
@@ -546,7 +547,7 @@ impl IndexNode for LockedTmpfsInode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.len() < len {
             return Err(SystemError::EINVAL);

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     ipc::pipe::LockedPipeInode,
     libs::{
         casting::DowncastArc,
-        spinlock::{SpinLock, SpinLockGuard},
+        mutex::{Mutex, MutexGuard},
     },
     mm::{fault::PageFaultMessage, VmFaultReason},
     net::socket::Socket,
@@ -378,10 +378,10 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     ///         失败：Err(错误码)
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
-        // 若文件系统没有实现此方法，则返回“不支持”
+        // 若文件系统没有实现此方法，则返回"不支持"
         return Err(SystemError::ENOSYS);
     }
 
@@ -389,8 +389,8 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     ///
     /// @return 成功：Ok()
     ///         失败：Err(错误码)
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
-        // 若文件系统没有实现此方法，则返回“不支持”
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        // 若文件系统没有实现此方法，则返回"不支持"
         return Err(SystemError::ENOSYS);
     }
 
@@ -409,7 +409,7 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError>;
 
     /// @brief 在inode的指定偏移量开始，写入指定大小的数据（从buf的第0byte开始写入）
@@ -426,7 +426,7 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         offset: usize,
         len: usize,
         buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError>;
 
     /// # 在inode的指定偏移量开始，读取指定大小的数据，忽略PageCache
@@ -447,7 +447,7 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return Err(SystemError::ENOSYS);
     }
@@ -470,7 +470,7 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return Err(SystemError::ENOSYS);
     }
@@ -1111,7 +1111,7 @@ impl dyn IndexNode {
                     0,
                     256,
                     &mut content,
-                    SpinLock::new(FilePrivateData::Unused).lock(),
+                    Mutex::new(FilePrivateData::Unused).lock(),
                 )?;
 
                 // 将读到的数据转换为utf8字符串（先转为str，再转为String）

--- a/kernel/src/filesystem/vfs/mount.rs
+++ b/kernel/src/filesystem/vfs/mount.rs
@@ -15,6 +15,7 @@ use hashbrown::HashMap;
 use ida::IdAllocator;
 use system_error::SystemError;
 
+use crate::libs::mutex::MutexGuard;
 use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
     filesystem::{
@@ -644,7 +645,7 @@ impl MountFSInode {
 impl IndexNode for MountFSInode {
     fn open(
         &self,
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
         flags: &FileFlags,
     ) -> Result<(), SystemError> {
         return self.inner_inode.open(data, flags);
@@ -668,7 +669,7 @@ impl IndexNode for MountFSInode {
         return self.inner_inode.fadvise(file, offset, len, advise);
     }
 
-    fn close(&self, data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         self.inner_inode.close(data)
     }
 
@@ -698,7 +699,7 @@ impl IndexNode for MountFSInode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return self.inner_inode.read_at(offset, len, buf, data);
     }
@@ -708,7 +709,7 @@ impl IndexNode for MountFSInode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return self.inner_inode.write_at(offset, len, buf, data);
     }
@@ -718,7 +719,7 @@ impl IndexNode for MountFSInode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         self.inner_inode.read_direct(offset, len, buf, data)
     }
@@ -728,7 +729,7 @@ impl IndexNode for MountFSInode {
         offset: usize,
         len: usize,
         buf: &[u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         self.inner_inode.write_direct(offset, len, buf, data)
     }

--- a/kernel/src/filesystem/vfs/syscall/symlink_utils.rs
+++ b/kernel/src/filesystem/vfs/syscall/symlink_utils.rs
@@ -6,7 +6,7 @@ use crate::{
         utils::{rsplit_path, user_path_at},
         FilePrivateData, FileType, NAME_MAX, VFS_MAX_FOLLOW_SYMLINK_TIMES,
     },
-    libs::spinlock::SpinLock,
+    libs::mutex::Mutex,
     process::ProcessManager,
 };
 
@@ -57,7 +57,7 @@ pub fn do_symlinkat(from: &str, newdfd: Option<i32>, to: &str) -> Result<usize, 
 
     let buf = from.as_bytes();
     let len = buf.len();
-    new_inode.write_at(0, len, buf, SpinLock::new(FilePrivateData::Unused).lock())?;
+    new_inode.write_at(0, len, buf, Mutex::new(FilePrivateData::Unused).lock())?;
 
     return Ok(0);
 }

--- a/kernel/src/init/initram.rs
+++ b/kernel/src/init/initram.rs
@@ -11,7 +11,7 @@ use crate::filesystem::vfs::MountFS;
 use crate::init::boot::boot_callbacks;
 use crate::init::initcall::INITCALL_ROOTFS;
 use crate::libs::decompress::xz_decompress;
-use crate::libs::spinlock::SpinLock;
+use crate::libs::mutex::Mutex;
 use crate::process::namespace::propagation::MountPropagation;
 use cpio_reader::Mode;
 use system_error::SystemError;
@@ -177,7 +177,7 @@ pub fn initramfs_init() -> Result<(), SystemError> {
                     0,
                     entry.file.len(),
                     &entry.file,
-                    SpinLock::new(crate::filesystem::vfs::FilePrivateData::Unused).lock(),
+                    Mutex::new(crate::filesystem::vfs::FilePrivateData::Unused).lock(),
                 )?;
             }
             FileType::CharDevice => {
@@ -210,7 +210,7 @@ pub fn initramfs_init() -> Result<(), SystemError> {
             parent_inode.create_with_data(filename, FileType::SymLink, InodeMode::S_IRWXUGO, 0)?;
         let buf = other_name.as_bytes();
         let len = buf.len();
-        new_inode.write_at(0, len, buf, SpinLock::new(FilePrivateData::Unused).lock())?;
+        new_inode.write_at(0, len, buf, Mutex::new(FilePrivateData::Unused).lock())?;
     }
 
     // 下面的方式是查看外置 initramfs, 例如使用 qemu 的 -initrd 参数加载的

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -1,3 +1,4 @@
+use crate::libs::mutex::MutexGuard;
 use crate::{
     arch::{ipc::signal::Signal, MMArch},
     filesystem::{
@@ -11,10 +12,7 @@ use crate::{
         },
     },
     ipc::signal_types::SigCode,
-    libs::{
-        spinlock::{SpinLock, SpinLockGuard},
-        wait_queue::WaitQueue,
-    },
+    libs::{spinlock::SpinLock, wait_queue::WaitQueue},
     mm::MemoryManagementArch,
     process::{ProcessFlags, ProcessManager, ProcessState},
     syscall::user_access::UserBufferWriter,
@@ -414,7 +412,7 @@ impl IndexNode for LockedPipeInode {
         _offset: usize,
         len: usize,
         buf: &mut [u8],
-        data_guard: SpinLockGuard<FilePrivateData>,
+        data_guard: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let data = data_guard.clone();
         drop(data_guard);
@@ -504,7 +502,7 @@ impl IndexNode for LockedPipeInode {
 
     fn open(
         &self,
-        mut data: SpinLockGuard<FilePrivateData>,
+        mut data: MutexGuard<FilePrivateData>,
         flags: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         let accflags = flags.access_flags();
@@ -640,7 +638,7 @@ impl IndexNode for LockedPipeInode {
         return Ok(inode.metadata.clone());
     }
 
-    fn close(&self, data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         let flags: FileFlags;
         if let FilePrivateData::Pipefs(pipe_data) = &*data {
             flags = pipe_data.flags;
@@ -731,7 +729,7 @@ impl IndexNode for LockedPipeInode {
         _offset: usize,
         len: usize,
         buf: &[u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // 获取flags
         let flags: FileFlags;

--- a/kernel/src/ipc/signalfd.rs
+++ b/kernel/src/ipc/signalfd.rs
@@ -15,6 +15,7 @@ use crate::filesystem::vfs::{
     vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, FsInfo, IndexNode, InodeFlags,
     InodeMode, Magic, Metadata, PollableInode, SuperBlock,
 };
+use crate::libs::mutex::MutexGuard;
 use crate::libs::spinlock::{SpinLock, SpinLockGuard};
 use crate::libs::wait_queue::WaitQueue;
 use crate::mm::MemoryManagementArch;
@@ -229,13 +230,13 @@ impl IndexNode for SignalFdInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         Ok(())
     }
 
@@ -244,7 +245,7 @@ impl IndexNode for SignalFdInode {
         _offset: usize,
         len: usize,
         buf: &mut [u8],
-        data_guard: SpinLockGuard<FilePrivateData>,
+        data_guard: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // 释放 FilePrivateData 锁，避免在阻塞时持有锁导致 panic
         drop(data_guard);
@@ -279,7 +280,7 @@ impl IndexNode for SignalFdInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::EINVAL)
     }

--- a/kernel/src/libs/mutex.rs
+++ b/kernel/src/libs/mutex.rs
@@ -9,12 +9,11 @@ use system_error::SystemError;
 use crate::{
     arch::CurrentIrqArch,
     exception::InterruptArch,
-    libs::spinlock::SpinLockGuard,
     process::{ProcessControlBlock, ProcessManager, RawPid},
     sched::{schedule, SchedMode},
 };
 
-use super::spinlock::SpinLock;
+use super::spinlock::{SpinLock, SpinLockGuard};
 
 #[derive(Debug)]
 struct MutexInner {

--- a/kernel/src/libs/wait_queue.rs
+++ b/kernel/src/libs/wait_queue.rs
@@ -19,16 +19,16 @@ use system_error::SystemError;
 use crate::{
     arch::{ipc::signal::Signal, CurrentIrqArch},
     exception::InterruptArch,
+    libs::mutex::MutexGuard,
     process::{ProcessControlBlock, ProcessManager, ProcessState},
     sched::{schedule, SchedMode},
-    time::timer::{next_n_us_timer_jiffies, Timer},
-    time::{Duration, Instant},
+    time::{
+        timer::{next_n_us_timer_jiffies, Timer},
+        Duration, Instant,
+    },
 };
 
-use super::{
-    mutex::MutexGuard,
-    spinlock::{SpinLock, SpinLockGuard},
-};
+use super::spinlock::{SpinLock, SpinLockGuard};
 
 #[derive(Debug)]
 struct InnerWaitQueue {

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -20,6 +20,7 @@ use crate::{
     filesystem::{page_cache::PageCache, vfs::FilePrivateData},
     init::initcall::INITCALL_CORE,
     libs::{
+        mutex::Mutex,
         rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
     },
@@ -437,7 +438,7 @@ impl PageReclaimer {
                             len,
                         )
                     },
-                    SpinLock::new(FilePrivateData::Unused).lock(),
+                    Mutex::new(FilePrivateData::Unused).lock(),
                 )
                 .unwrap();
         }

--- a/kernel/src/net/socket/inode.rs
+++ b/kernel/src/net/socket/inode.rs
@@ -4,7 +4,7 @@ use crate::{
         fasync::FAsyncItem, file::File, FilePrivateData, FileType, IndexNode, InodeMode, Metadata,
         PollableInode,
     },
-    libs::spinlock::SpinLockGuard,
+    libs::mutex::MutexGuard,
     net::posix::SockAddrIn,
     process::ProcessManager,
     syscall::user_access::{UserBufferReader, UserBufferWriter},
@@ -285,7 +285,7 @@ fn handle_siocgifconf(data: usize) -> Result<usize, SystemError> {
 impl<T: Socket + 'static> IndexNode for T {
     fn open(
         &self,
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
         _: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         match &*data {
@@ -297,7 +297,7 @@ impl<T: Socket + 'static> IndexNode for T {
         }
     }
 
-    fn close(&self, _: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         // Only tear down the socket on the final close.
         if self.open_file_counter().fetch_sub(1, Ordering::AcqRel) == 1 {
             self.do_close()
@@ -311,7 +311,7 @@ impl<T: Socket + 'static> IndexNode for T {
         _: usize,
         _: usize,
         buf: &mut [u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // Drop the lock guard before calling self.read() to avoid holding the lock
         // across a potentially blocking or reentrant operation. This prevents deadlocks
@@ -325,7 +325,7 @@ impl<T: Socket + 'static> IndexNode for T {
         _offset: usize,
         _len: usize,
         buf: &[u8],
-        data: SpinLockGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         if buf.is_empty() {
             log::debug!(

--- a/kernel/src/perf/bpf.rs
+++ b/kernel/src/perf/bpf.rs
@@ -7,7 +7,8 @@ use crate::include::bindings::linux_bpf::{
     perf_event_header, perf_event_mmap_page, perf_event_type,
 };
 use crate::libs::align::page_align_up;
-use crate::libs::spinlock::{SpinLock, SpinLockGuard};
+use crate::libs::mutex::MutexGuard;
+use crate::libs::spinlock::SpinLock;
 use crate::mm::allocator::page_frame::{PageFrameCount, PhysPageFrame};
 use crate::mm::page::{page_manager_lock_irqsave, PageFlags, PageType};
 use crate::mm::{MemoryManagementArch, PhysAddr};
@@ -293,7 +294,7 @@ impl IndexNode for BpfPerfEvent {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("PerfEventInode does not support read")
     }
@@ -303,7 +304,7 @@ impl IndexNode for BpfPerfEvent {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("PerfEventInode does not support write")
     }

--- a/kernel/src/perf/kprobe.rs
+++ b/kernel/src/perf/kprobe.rs
@@ -9,7 +9,7 @@ use crate::filesystem::page_cache::PageCache;
 use crate::filesystem::vfs::file::File;
 use crate::filesystem::vfs::{FilePrivateData, FileSystem, IndexNode};
 use crate::libs::casting::DowncastArc;
-use crate::libs::spinlock::SpinLockGuard;
+use crate::libs::mutex::MutexGuard;
 use crate::perf::util::PerfProbeArgs;
 use crate::perf::{BasicPerfEbpfCallBack, PerfEventOps};
 use alloc::boxed::Box;
@@ -104,7 +104,7 @@ impl IndexNode for KprobePerfEvent {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("read_at not implemented for PerfEvent");
     }
@@ -114,7 +114,7 @@ impl IndexNode for KprobePerfEvent {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("write_at not implemented for PerfEvent");
     }

--- a/kernel/src/perf/mod.rs
+++ b/kernel/src/perf/mod.rs
@@ -18,7 +18,7 @@ use crate::include::bindings::linux_bpf::{
     perf_event_attr, perf_event_sample_format, perf_sw_ids, perf_type_id,
 };
 use crate::libs::casting::DowncastArc;
-use crate::libs::spinlock::{SpinLock, SpinLockGuard};
+use crate::libs::mutex::{Mutex, MutexGuard};
 use crate::mm::allocator::page_frame::{
     allocate_page_frames, deallocate_page_frames, PageFrameCount, PhysPageFrame,
 };
@@ -168,7 +168,7 @@ impl PerfEventInode {
     pub fn new(event: Box<dyn PerfEventOps>) -> Self {
         Self {
             event,
-            epitems: SpinLock::new(LinkedList::new()),
+            epitems: Mutex::new(LinkedList::new()),
         }
     }
     fn do_poll(&self) -> Result<usize> {
@@ -197,10 +197,10 @@ impl IndexNode for PerfEventInode {
     fn mmap(&self, start: usize, len: usize, offset: usize) -> Result<()> {
         self.event.mmap(start, len, offset)
     }
-    fn open(&self, _data: SpinLockGuard<FilePrivateData>, _flags: &FileFlags) -> Result<()> {
+    fn open(&self, _data: MutexGuard<FilePrivateData>, _flags: &FileFlags) -> Result<()> {
         Ok(())
     }
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<()> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<()> {
         Ok(())
     }
     fn read_at(
@@ -208,7 +208,7 @@ impl IndexNode for PerfEventInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("read_at not implemented for PerfEvent");
     }
@@ -218,7 +218,7 @@ impl IndexNode for PerfEventInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("write_at not implemented for PerfEvent");
     }

--- a/kernel/src/perf/tracepoint.rs
+++ b/kernel/src/perf/tracepoint.rs
@@ -3,13 +3,13 @@ use crate::bpf::helper::BPF_HELPER_FUN_SET;
 use crate::bpf::prog::BpfProg;
 use crate::filesystem::page_cache::PageCache;
 use crate::libs::casting::DowncastArc;
+use crate::libs::mutex::MutexGuard;
 use crate::libs::spinlock::SpinLock;
 use crate::perf::util::PerfProbeConfig;
 use crate::perf::{BasicPerfEbpfCallBack, JITMem};
 use crate::tracepoint::{TracePoint, TracePointCallBackFunc};
 use crate::{
     filesystem::vfs::{file::File, FilePrivateData, FileSystem, IndexNode},
-    libs::spinlock::SpinLockGuard,
     perf::{util::PerfProbeArgs, PerfEventOps},
 };
 use alloc::boxed::Box;
@@ -43,7 +43,7 @@ impl IndexNode for TracepointPerfEvent {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("read_at not implemented for TracepointPerfEvent");
     }
@@ -53,7 +53,7 @@ impl IndexNode for TracepointPerfEvent {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize> {
         panic!("write_at not implemented for TracepointPerfEvent");
     }

--- a/kernel/src/virt/kvm/kvm_dev.rs
+++ b/kernel/src/virt/kvm/kvm_dev.rs
@@ -1,4 +1,6 @@
+use crate::libs::mutex::MutexGuard;
 use crate::driver::base::device::device_number::DeviceNumber;
+use crate::libs::mutex::MutexGuard;
 use crate::filesystem;
 use crate::filesystem::devfs::{DevFS, DeviceINode};
 use crate::filesystem::vfs::{
@@ -93,14 +95,14 @@ impl IndexNode for LockedKvmInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &FileMode,
     ) -> Result<(), SystemError> {
         debug!("file private data:{:?}", _data);
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 
@@ -165,7 +167,7 @@ impl IndexNode for LockedKvmInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -176,7 +178,7 @@ impl IndexNode for LockedKvmInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/virt/kvm/vcpu_dev.rs
+++ b/kernel/src/virt/kvm/vcpu_dev.rs
@@ -1,4 +1,6 @@
+use crate::libs::mutex::MutexGuard;
 use crate::arch::kvm::vmx::vcpu::VcpuContextFrame;
+use crate::libs::mutex::MutexGuard;
 use crate::arch::KVMArch;
 use crate::driver::base::device::device_number::DeviceNumber;
 use crate::filesystem;
@@ -100,14 +102,14 @@ impl IndexNode for LockedVcpuInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &FileMode,
     ) -> Result<(), SystemError> {
         debug!("file private data:{:?}", _data);
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 
@@ -200,7 +202,7 @@ impl IndexNode for LockedVcpuInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -211,7 +213,7 @@ impl IndexNode for LockedVcpuInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/virt/kvm/vm_dev.rs
+++ b/kernel/src/virt/kvm/vm_dev.rs
@@ -1,4 +1,6 @@
+use crate::libs::mutex::MutexGuard;
 use crate::driver::base::device::device_number::DeviceNumber;
+use crate::libs::mutex::MutexGuard;
 use crate::filesystem;
 use crate::filesystem::devfs::DevFS;
 use crate::filesystem::vfs::{
@@ -98,14 +100,14 @@ impl IndexNode for LockedVmInode {
 
     fn open(
         &self,
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
         _mode: &FileMode,
     ) -> Result<(), SystemError> {
         debug!("file private data:{:?}", _data);
         return Ok(());
     }
 
-    fn close(&self, _data: SpinLockGuard<FilePrivateData>) -> Result<(), SystemError> {
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
 
@@ -196,7 +198,7 @@ impl IndexNode for LockedVmInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -207,7 +209,7 @@ impl IndexNode for LockedVmInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: SpinLockGuard<FilePrivateData>,
+        _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/virt/vm/kvm_dev.rs
+++ b/kernel/src/virt/vm/kvm_dev.rs
@@ -107,7 +107,7 @@ impl DeviceINode for LockedKvmInode {
 impl IndexNode for LockedKvmInode {
     fn open(
         &self,
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -117,7 +117,7 @@ impl IndexNode for LockedKvmInode {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -127,7 +127,7 @@ impl IndexNode for LockedKvmInode {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -181,7 +181,7 @@ impl IndexNode for LockedKvmInode {
 
     fn close(
         &self,
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
         Ok(())
     }
@@ -233,7 +233,7 @@ impl KvmInstance {
 impl IndexNode for KvmInstance {
     fn open(
         &self,
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
         _mode: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -284,7 +284,7 @@ impl IndexNode for KvmInstance {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         todo!()
     }
@@ -294,7 +294,7 @@ impl IndexNode for KvmInstance {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         todo!()
     }
@@ -317,7 +317,7 @@ impl IndexNode for KvmInstance {
 
     fn close(
         &self,
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
         Ok(())
     }
@@ -365,7 +365,7 @@ impl KvmVcpuDev {
 impl IndexNode for KvmVcpuDev {
     fn open(
         &self,
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -373,7 +373,7 @@ impl IndexNode for KvmVcpuDev {
 
     fn close(
         &self,
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
         Ok(())
     }
@@ -473,7 +473,7 @@ impl IndexNode for KvmVcpuDev {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         todo!()
     }
@@ -483,7 +483,7 @@ impl IndexNode for KvmVcpuDev {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: crate::libs::spinlock::SpinLockGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         todo!()
     }


### PR DESCRIPTION
- 在多个文件系统的 IndexNode 实现中，将 SpinLockGuard<FilePrivateData> 替换为 MutexGuard<FilePrivateData>
- 更新了 epoll 模块中的锁类型，将 SpinLock 替换为 Mutex，并调整了相关锁的使用方式
- 修改了网络模块中 EPollItems 的锁类型，将 SpinLock 替换为 Mutex
- 调整了文件系统、驱动、IPC 等模块中相关代码的锁使用方式