### PR TITLE
feat(elf): 实现只读段文件映射与BSS处理优化

### DIFF
--- a/kernel/src/libs/elf.rs
+++ b/kernel/src/libs/elf.rs
@@ -175,6 +175,90 @@ impl ElfLoader {
         )
     }
 
+    /// 映射只读ELF段（文件映射）
+    ///
+    /// 对"非写段"(PF_W=0，包括代码段与只读段)改为文件映射：
+    /// - 通过 pagecache + 用户态缺页同步读盘实现按需加载
+    /// - 最终用户态权限严格按 make_prot() 生成（无 PF_W -> 不含 PROT_WRITE）
+    ///
+    /// ## 参数
+    ///
+    /// - `user_vm_guard`：用户空间地址空间
+    /// - `param`：执行参数
+    /// - `addr_to_map`：映射的虚拟地址
+    /// - `prot`：保护标志
+    /// - `map_flags`：映射标志
+    /// - `file_offset`：段在文件中的偏移
+    /// - `beginning_page_offset`：页内偏移
+    /// - `map_size`：映射大小
+    /// - `total_size`：ELF文件总大小
+    /// - `map_err_handler`：错误处理函数
+    ///
+    /// ## 返回值
+    ///
+    /// 返回映射的虚拟地址和成功标志
+    #[allow(clippy::too_many_arguments)]
+    fn map_readonly_segment(
+        user_vm_guard: &mut RwLockWriteGuard<'_, InnerAddressSpace>,
+        param: &ExecParam,
+        addr_to_map: VirtAddr,
+        prot: ProtFlags,
+        map_flags: MapFlags,
+        file_offset: usize,
+        beginning_page_offset: usize,
+        map_size: usize,
+        total_size: usize,
+        map_err_handler: impl FnOnce(SystemError) -> SystemError,
+    ) -> Result<(VirtAddr, bool), SystemError> {
+        // Linux: off = p_offset - ELF_PAGEOFFSET(p_vaddr)
+        let file_page_offset = file_offset
+            .checked_sub(beginning_page_offset)
+            .ok_or(SystemError::ENOEXEC)?;
+
+        // ELF 约束：p_offset % PAGE == p_vaddr % PAGE，保证 off 页对齐
+        if (file_page_offset & (CurrentElfArch::ELF_PAGE_SIZE - 1)) != 0 {
+            return Err(SystemError::ENOEXEC);
+        }
+
+        // total_size 逻辑保持与原实现一致：首段先映射 total_size 再 munmap 空洞尾部
+        let map_len = if total_size != 0 {
+            Self::elf_page_align_up(VirtAddr::new(total_size)).data()
+        } else {
+            map_size
+        };
+        if map_len < map_size {
+            return Err(SystemError::EINVAL);
+        }
+
+        let file = param.file();
+        let start_page = user_vm_guard
+            .file_mapping_with_file(
+                file,
+                addr_to_map,
+                map_len,
+                prot,
+                map_flags,
+                file_page_offset,
+                false,
+                false,
+            )
+            .map_err(map_err_handler)?;
+        let mapped = start_page.virt_address();
+
+        if total_size != 0 {
+            let to_unmap = mapped + map_size;
+            let to_unmap_size = map_len - map_size;
+            if to_unmap_size > 0 {
+                user_vm_guard.munmap(
+                    VirtPageFrame::new(to_unmap),
+                    PageFrameCount::from_bytes(to_unmap_size).unwrap(),
+                )?;
+            }
+        }
+
+        Ok((mapped, true))
+    }
+
     /// 根据ELF的p_flags生成对应的ProtFlags
     fn make_prot(p_flags: u32, _has_interpreter: bool, _is_interpreter: bool) -> ProtFlags {
         let mut prot = ProtFlags::empty();
@@ -227,7 +311,8 @@ impl ElfLoader {
         // });
 
         // 映射位置的偏移量（页内偏移）
-        let beginning_page_offset = Self::elf_page_offset(addr_to_map);
+        // 按 Linux 语义：使用 p_vaddr 的页内偏移（ELF_PAGEOFFSET(p_vaddr)）
+        let beginning_page_offset = (phent.p_vaddr as usize) & (CurrentElfArch::ELF_PAGE_SIZE - 1);
         addr_to_map = Self::elf_page_start(addr_to_map);
         // 计算要映射的内存的大小
         let map_size = phent.p_filesz as usize + beginning_page_offset;
@@ -253,6 +338,27 @@ impl ElfLoader {
             }
             err
         };
+
+        // 对"非写段"(PF_W=0，包括代码段与只读段)改为文件映射
+        // - 通过 pagecache + 用户态缺页同步读盘实现按需加载
+        // - 最终用户态权限严格按 make_prot() 生成（无 PF_W -> 不含 PROT_WRITE）
+        // 解释器(PT_INTERP 对应 ld.so)也同样适用：其只读段可安全走 filemap
+        let is_readonly_load = (phent.p_flags & elf::abi::PF_W) == 0;
+        if is_readonly_load {
+            return Self::map_readonly_segment(
+                user_vm_guard,
+                param,
+                addr_to_map,
+                *prot,
+                *map_flags,
+                file_offset,
+                beginning_page_offset,
+                map_size,
+                total_size,
+                map_err_handler,
+            );
+        }
+
         // 由于后面需要把ELF文件的内容加载到内存，因此暂时把当前段的权限设置为可写
         let tmp_prot = if !prot.contains(ProtFlags::PROT_WRITE) {
             *prot | ProtFlags::PROT_WRITE
@@ -829,6 +935,12 @@ impl BinaryLoader for ElfLoader {
         // todo: 补充逻辑：https://code.dragonos.org.cn/xref/linux-6.6.21/fs/binfmt_elf.c#1007
         param.setup_new_exec();
 
+        // Linux 语义：elf_bss/elf_brk 以“字节端点”记录：
+        // - elf_bss: max(p_vaddr + p_filesz)
+        // - elf_brk: max(p_vaddr + p_memsz)
+        // 之后再做：
+        // 1) pad_zero(elf_bss) 清零最后一个文件页的尾部
+        // 2) page-align 后，为 [align_up(elf_bss), align_up(elf_brk)) 建立匿名 BSS 映射
         let mut elf_brk = VirtAddr::new(0);
         let mut elf_bss = VirtAddr::new(0);
         let mut start_code: Option<VirtAddr> = None;
@@ -858,20 +970,30 @@ impl BinaryLoader for ElfLoader {
                 //     elf_brk,
                 //     elf_bss
                 // );
-                self.set_elf_brk(
-                    &mut user_vm,
-                    elf_bss + load_bias,
-                    elf_brk + load_bias,
-                    bss_prot_flags,
-                )?;
+                // 仅在页粒度上需要扩展 BSS 时才去映射，避免覆盖段的最后一页
+                let bss_start_page = Self::elf_page_align_up(elf_bss);
+                let brk_end_page = Self::elf_page_align_up(elf_brk);
+                if brk_end_page > bss_start_page {
+                    self.set_elf_brk(
+                        &mut user_vm,
+                        bss_start_page + load_bias,
+                        brk_end_page + load_bias,
+                        bss_prot_flags,
+                    )?;
+                }
+
+                // 处理“BSS 落在最后一个文件页内”的尾部清零（Linux: padzero）
                 let nbyte = Self::elf_page_offset(elf_bss);
                 if nbyte > 0 {
                     let nbyte = min(CurrentElfArch::ELF_PAGE_SIZE - nbyte, elf_brk - elf_bss);
+                    // 重要：clear_user 会触发用户态缺页，缺页路径会获取 AddressSpace 写锁。
+                    // 因此必须在释放 user_vm 写锁后再清零，避免死锁。
+                    drop(user_vm);
                     unsafe {
-                        // This bss-zeroing can fail if the ELF file specifies odd protections.
-                        // So we don't check the return value.
+                        // 这里清零理论上不应失败：BSS 所属段应为可写；失败时忽略以兼容 Linux 行为
                         clear_user(elf_bss + load_bias, nbyte).ok();
                     }
+                    user_vm = binding.write();
                 }
             }
 
@@ -986,14 +1108,14 @@ impl BinaryLoader for ElfLoader {
                 return Err(ExecError::InvalidParemeter);
             }
 
-            // end vaddr of this segment(code+data+bss)
-            let seg_end_vaddr_f = Self::elf_page_align_up(VirtAddr::new(
-                (seg_to_load.p_vaddr + seg_to_load.p_filesz) as usize,
-            ));
-
-            if seg_end_vaddr_f > elf_bss {
-                elf_bss = seg_end_vaddr_f;
+            // 文件部分结束的“字节端点”（用于 BSS/padzero 语义）
+            let seg_file_end = VirtAddr::new((seg_to_load.p_vaddr + seg_to_load.p_filesz) as usize);
+            if seg_file_end > elf_bss {
+                elf_bss = seg_file_end;
             }
+
+            // 统计 end_code/end_data 使用页对齐后的文件端点（更贴近 /proc/maps 的 VMA 粒度）
+            let seg_end_vaddr_f = Self::elf_page_align_up(seg_file_end);
 
             if ((seg_to_load.p_flags & elf::abi::PF_X) != 0)
                 && (end_code.is_none()
@@ -1032,11 +1154,18 @@ impl BinaryLoader for ElfLoader {
         //     elf_brk,
         //     bss_prot_flags
         // );
-        self.set_elf_brk(&mut user_vm, elf_bss, elf_brk, bss_prot_flags)?;
-
+        // 先释放 AddressSpace 写锁，再对最后一个文件页做 padzero（padzero 会写用户地址，可能触发缺页）
+        drop(user_vm);
         if likely(elf_bss != elf_brk) && unlikely(Self::pad_zero(elf_bss).is_err()) {
-            // debug!("elf_bss = {elf_bss:?}, elf_brk = {elf_brk:?}");
             return Err(ExecError::BadAddress(Some(elf_bss)));
+        }
+
+        // 再重新获取写锁，对齐后映射剩余的 BSS 页（避免覆盖最后一页）
+        let mut user_vm = binding.write();
+        let bss_start_page = Self::elf_page_align_up(elf_bss);
+        let brk_end_page = Self::elf_page_align_up(elf_brk);
+        if brk_end_page > bss_start_page {
+            self.set_elf_brk(&mut user_vm, bss_start_page, brk_end_page, bss_prot_flags)?;
         }
         drop(user_vm);
         if let Some(mut interpreter) = interpreter {


### PR DESCRIPTION
- 为只读ELF段（PF_W=0）添加文件映射支持，通过pagecache实现按需加载
- 重构BSS处理逻辑，避免死锁并遵循Linux padzero语义
- 新增file_mapping_with_file接口，优化文件映射参数传递

bugbot run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Linux-like ELF segment mapping and BSS semantics with safer locking, plus a clearer mmap API.
> 
> - ELF loader: use `p_vaddr` pageoffset; map `PF_W=0` segments via file-backed `file_mapping_with_file` (pagecache, demand paging); honor `total_size` by mapping/unmapping tail; applies to interpreter too
> - BSS: track `elf_bss/elf_brk` as byte endpoints; perform `pad_zero` after dropping the address space write lock; only map page-aligned remainder `[align_up(elf_bss), align_up(elf_brk))`; update `end_code/end_data` using aligned file endpoints
> - mm/ucontext: add `file_mapping_with_file(file, ...)` with Linux-style permission/type checks and `inode.mmap` hook; refactor `file_mapping(fd, ...)` to delegate; improved docs/comments
> - Minor: open interpreter errors propagate `ENOENT`; fix beginning-page offset computation to Linux semantics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2490a1257a46640768d6743991165c36024bbe60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->