### PR TITLE
refactor(kernel): 重构rwsem和waitqueue实现，解决并发错误

### DIFF
--- a/docs/kernel/locking/rwsem.md
+++ b/docs/kernel/locking/rwsem.md
@@ -1,4 +1,4 @@
-# RwSem读写信号量
+# RwSem 读写信号量
 
 ## 1. 简介
 
@@ -17,269 +17,671 @@ RwSem (Read-Write Semaphore) 是一种可睡眠的读写锁，用于保护进程
 
 ## 2. 核心设计
 
-### 2.1 写者优先策略
+### 2.1 锁状态表示
 
-RwSem 采用**写者优先**的公平性策略，目的是防止写者被连续的读者饿死：
-
-- 当有写者在等待时，**阻塞新的读者**获取锁
-- 最后一个读者释放锁时，优先唤醒等待的写者
-- 所有写者完成后，才唤醒等待的读者
-
-### 2.2 状态位设计
-
-RwSem 使用一个 64 位原子整数 (`AtomicU64`) 维护所有状态：
+RwSem 使用一个原子整数 (`AtomicUsize`) 维护锁状态，通过位域编码实现高效的状态管理：
 
 ```
-+--------+------------------+-----------+--------+
-| 63..33 |      32          |    31     | 30..0  |
-+--------+------------------+-----------+--------+
-|   ?    | WRITER_BIT       |  保留     | 读者计数 |
-| 写者   | 写者激活标志     |           | (32位)  |
-| 等待数 |                 |           |         |
-+--------+------------------+-----------+--------+
+64位系统状态位布局:
++--------+--------------+------------+----------+------------------+
+| Bit 63 |   Bit 62     |  Bit 61    | Bit 60   |   Bits 59..0     |
++--------+--------------+------------+----------+------------------+
+| WRITER | UPGRADEABLE  |  BEING     | OVERFLOW |  READER COUNT    |
+|        |   READER     | UPGRADED   | DETECT   |   (读者计数)      |
++--------+--------------+------------+----------+------------------+
 ```
 
 | 字段 | 位置 | 说明 |
 |------|------|------|
-| `READER_MASK` | Bits 0..31 | 当前激活的读者数量 |
-| `WRITER_BIT` | Bit 32 | 是否有写者正在持有锁 |
-| `WRITER_WAITER_MASK` | Bits 33..63 | 等待中的写者数量 |
-
-### 2.3 快速路径与慢速路径
-
-RwSem 的获取操作分为两个阶段：
-
-#### 快速路径
-- 使用原子 CAS (Compare-And-Swap) 操作尝试获取锁
-- 无需加锁，无系统调用开销
-- 成功时直接返回 Guard
-
-#### 慢速路径
-- 快速路径失败时进入
-- 使用 `WaitQueue` 将当前线程加入等待队列并睡眠
-- 被唤醒时重试快速路径
-
-### 2.4 双等待队列设计
-
-RwSem 维护两个独立的等待队列：
+| `WRITER` | Bit 63 | 写者锁，1 表示有写者持有锁 |
+| `UPGRADEABLE_READER` | Bit 62 | 可升级读者锁，1 表示有可升级读者持有锁 |
+| `BEING_UPGRADED` | Bit 61 | 升级进行中标志，1 表示正在从可升级读者升级到写者 |
+| `MAX_READER` | Bit 60 | 读者溢出检测位，当读者数量达到 2^60 时置位 |
+| `READER_COUNT` | Bits 59..0 | 当前激活的读者数量 |
 
 ```rust
-pub struct RwSem<T> {
-    wq_read:  WaitQueue,  // 读者等待队列
-    wq_write: WaitQueue,  // 写者等待队列
+const READER: usize = 1;
+const WRITER: usize = 1 << (usize::BITS - 1);              // Bit 63
+const UPGRADEABLE_READER: usize = 1 << (usize::BITS - 2);  // Bit 62
+const BEING_UPGRADED: usize = 1 << (usize::BITS - 3);      // Bit 61
+const MAX_READER: usize = 1 << (usize::BITS - 4);          // Bit 60
+```
+
+### 2.2 三种锁模式
+
+RwSem 支持三种锁模式，提供不同级别的访问权限：
+
+1. **读锁（Read Lock）**
+   - 多个读者可以并发持有读锁
+   - 提供对数据的只读访问（`&T`）
+   - 与写者和正在升级的可升级读者互斥
+
+2. **写锁（Write Lock）**
+   - 只有一个写者可以持有写锁
+   - 提供对数据的可变访问（`&mut T`）
+   - 与所有其他锁模式互斥
+
+3. **可升级读锁（Upgradeable Read Lock）**
+   - 只有一个可升级读者可以持有可升级读锁
+   - 初始提供只读访问（`&T`）
+   - 可以原子地升级到写锁
+   - 与写者和其他可升级读者互斥，但可与普通读者共存
+
+### 2.3 等待队列设计
+
+```rust
+pub struct RwSem<T: ?Sized> {
+    lock: AtomicUsize,      // 锁状态
+    queue: WaitQueue,       // 单一等待队列
+    val: UnsafeCell<T>,     // 被保护的数据
 }
 ```
 
-**设计原因**：
-- 写者释放时，只唤醒一个写者（`wq_write.wakeup()`）
-- 写者释放且无写者等待时，唤醒**所有**读者（`wq_read.wakeup_all()`）
-- 分离队列可避免不必要的线程唤醒
+**设计特点**：
+- 使用单一 `WaitQueue` 管理所有等待者（读者、写者、可升级读者）
+- 利用 `WaitQueue.wait_until()` 的原子语义确保正确性
+- 通过不同的唤醒策略实现公平性和性能平衡
 
-## 3. 锁获取流程
+## 3. 锁获取机制
 
 ### 3.1 读锁获取
 
-```
-┌─────────────────┐
-│ 尝试快速路径     │
-│ (CAS递增读者数)  │
-└────────┬────────┘
-         │
-    成功 / 失败
-      /     \
-     ↓       ↓
-  ┌───┐   ┌─────────────┐
-  │返回│   │无写者激活/等待?│
-  └───┘   └──────┬──────┘
-                 │ 是/否
-            是 /     \
-           ↓         ↓
-      ┌───────┐  ┌─────────┐
-      │加入读者│  │阻塞并等待│
-      │等待队列│  └────┬────┘
-      └───────┘       │
-                   被唤醒时重试
+```rust
+pub fn read(&self) -> RwSemReadGuard<'_, T> {
+    self.queue.wait_until(|| self.try_read())
+}
+
+pub fn try_read(&self) -> Option<RwSemReadGuard<'_, T>> {
+    let lock = self.lock.fetch_add(READER, Acquire);
+    if lock & (WRITER | BEING_UPGRADED | MAX_READER) == 0 {
+        // 无写者、无升级中的可升级读者、未溢出 → 成功
+        Some(RwSemReadGuard {
+            inner: self,
+            _nosend: PhantomData,
+        })
+    } else {
+        // 有阻塞因素，回滚计数
+        self.lock.fetch_sub(READER, Release);
+        None
+    }
+}
 ```
 
-**关键点**: 检查 `WRITER_BIT` 和 `WRITER_WAITER_MASK`，任一非零则不能获取读锁。
+**获取条件**：
+- 无写者（`WRITER` 位为 0）
+- 无正在升级的可升级读者（`BEING_UPGRADED` 位为 0）
+- 读者数量未溢出（`MAX_READER` 位为 0）
+
+**关键设计**：
+- 先乐观地递增读者计数（`fetch_add`）
+- 再检查阻塞条件
+- 失败则回滚计数（`fetch_sub`）
+- 这种"先递增后检查"的方式在无竞争场景下性能更优
 
 ### 3.2 写锁获取
 
-```
-┌─────────────────┐
-│ 尝试快速路径     │
-│ (CAS设置写者位)  │
-└────────┬────────┘
-         │
-    成功 / 失败
-      /     \
-     ↓       ↓
-  ┌───┐   ┌─────────────────────┐
-  │返回│   │原子递增写者等待计数  │
-  └───┘   └──────────┬──────────┘
-                     │
-                     ↓
-              ┌───────────────┐
-              │ 无读者/写者?   │
-              └───────┬───────┘
-                      │ 是/否
-                 是 /     \
-                ↓         ↓
-            ┌───────┐  ┌─────────┐
-            │成功： │  │阻塞并等待│
-            │设置   │  └────┬────┘
-            │写者位 │       │
-            └───┬───┘   被唤醒时重试
-                │
-                ↓
-            ┌─────┐
-            │返回 │
-            └─────┘
+```rust
+pub fn write(&self) -> RwSemWriteGuard<'_, T> {
+    self.queue.wait_until(|| self.try_write())
+}
+
+pub fn try_write(&self) -> Option<RwSemWriteGuard<'_, T>> {
+    if self.lock.compare_exchange(0, WRITER, Acquire, Relaxed).is_ok() {
+        Some(RwSemWriteGuard {
+            inner: self,
+            _nosend: PhantomData,
+        })
+    } else {
+        None
+    }
+}
 ```
 
-**关键点**: 通过 `WRITER_WAITER_UNIT` 预先"占位"，阻止新读者进入。
+**获取条件**：
+- 锁状态必须为 0（无读者、无写者、无可升级读者）
+- 使用 CAS 操作保证原子性
+
+### 3.3 可升级读锁获取
+
+```rust
+pub fn upread(&self) -> RwSemUpgradeableGuard<'_, T> {
+    self.queue.wait_until(|| self.try_upread())
+}
+
+pub fn try_upread(&self) -> Option<RwSemUpgradeableGuard<'_, T>> {
+    let lock = self.lock.fetch_or(UPGRADEABLE_READER, Acquire)
+                 & (WRITER | UPGRADEABLE_READER);
+    if lock == 0 {
+        // 无写者且无其他可升级读者 → 成功
+        return Some(RwSemUpgradeableGuard {
+            inner: self,
+            _nosend: PhantomData,
+        });
+    } else if lock == WRITER {
+        // 有写者，需要回滚
+        self.lock.fetch_sub(UPGRADEABLE_READER, Release);
+    }
+    // lock == UPGRADEABLE_READER 表示已有其他可升级读者，
+    // fetch_or 没有改变状态，无需回滚
+    None
+}
+```
+
+**获取条件**：
+- 无写者（`WRITER` 位为 0）
+- 无其他可升级读者（`UPGRADEABLE_READER` 位为 0）
+- 可与普通读者共存
+
+**关键设计**：
+- 使用 `fetch_or` 原子设置可升级读者位
+- 通过检查返回的旧值判断是否成功
+- 只在设置了 `WRITER` 位但失败时才需要回滚
+
+### 3.4 wait_until 核心机制
+
+所有阻塞式的锁获取都依赖 `WaitQueue.wait_until()` 方法：
+
+```rust
+pub fn wait_until<F, R>(&self, cond: F) -> R
+where
+    F: FnMut() -> Option<R>,
+{
+    // 1. 快速路径：先检查条件
+    if let Some(res) = cond() {
+        return res;
+    }
+
+    // 2. 创建一对 Waiter/Waker
+    let (waiter, waker) = Waiter::new_pair();
+
+    loop {
+        // 3. 先注册 waker 到等待队列
+        self.register_waker(waker.clone());
+
+        // 4. 再检查条件（防止唤醒丢失）
+        if let Some(res) = cond() {
+            self.remove_waker(&waker);
+            return res;
+        }
+
+        // 5. 睡眠等待被唤醒
+        waiter.wait();
+
+        // 6. 被唤醒后循环继续（可能是伪唤醒）
+    }
+}
+```
+
+**关键点**：
+- 先注册 waker，再检查条件，确保不会错过任何唤醒信号
+- 即使被唤醒，也可能获取锁失败（公平竞争），需要继续循环
+- 这种设计避免了复杂的唤醒丢失问题
 
 ## 4. 锁释放与唤醒策略
 
 ### 4.1 读锁释放
 
 ```rust
-fn read_unlock(&self) {
-    // 原子递减读者计数
-    let prev = self.count.fetch_sub(1, Ordering::Release);
-    let current = prev - 1;
-
-    // 最后一个读者 + 有写者等待 → 唤醒一个写者
-    if (current & READER_MASK) == 0 && (current & WRITER_WAITER_MASK) > 0 {
-        self.wq_write.wakeup(None);
+impl<T: ?Sized> Drop for RwSemReadGuard<'_, T> {
+    fn drop(&mut self) {
+        // 原子递减读者计数
+        if self.inner.lock.fetch_sub(READER, Release) == READER {
+            // 这是最后一个读者，唤醒一个等待者
+            self.inner.queue.wake_one();
+        }
     }
 }
 ```
+
+**唤醒策略**：
+- 只有最后一个读者释放时才唤醒
+- 唤醒一个等待者（可能是写者或可升级读者）
+- 避免不必要的唤醒开销
 
 ### 4.2 写锁释放
 
 ```rust
-fn write_unlock(&self) {
-    // 清除写者位
-    let prev = self.count.fetch_and(!WRITER_BIT, Ordering::Release);
+impl<T: ?Sized> Drop for RwSemWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        // 清除写者位
+        self.inner.lock.fetch_and(!WRITER, Release);
 
-    if 有写者等待 {
-        唤醒一个写者
-    } else {
-        唤醒所有读者
+        // 唤醒所有等待者
+        self.inner.queue.wake_all();
     }
 }
 ```
 
-**唤醒策略**:
-1. 有写者等待 → 唤醒一个写者（保持写者优先）
-2. 无写者等待 → 唤醒所有读者（并发读）
+**唤醒策略**：
+- 唤醒所有等待者
+- 允许多个读者并发获取锁
+- 只有一个写者能成功（通过 CAS 竞争）
 
-## 5. 主要 API
-
-### 5.1 创建
-
-```rust
-pub const fn new(value: T) -> Self
-```
-
-### 5.2 读锁获取
+### 4.3 可升级读锁释放
 
 ```rust
-// 阻塞获取 (不可中断)
-pub fn read(&self) -> RwSemReadGuard<'_, T>
-
-// 阻塞获取 (可被信号中断)
-pub fn read_interruptible(&self) -> Result<RwSemReadGuard<'_, T>, SystemError>
-
-// 非阻塞尝试获取
-pub fn try_read(&self) -> Option<RwSemReadGuard<'_, T>
-```
-
-### 5.3 写锁获取
-
-```rust
-// 阻塞获取 (不可中断)
-pub fn write(&self) -> RwSemWriteGuard<'_, T>
-
-// 阻塞获取 (可被信号中断)
-pub fn write_interruptible(&self) -> Result<RwSemWriteGuard<'_, T>, SystemError>
-
-// 非阻塞尝试获取
-pub fn try_write(&self) -> Option<RwSemWriteGuard<'_, T>
-```
-
-### 5.4 写锁降级
-
-```rust
-impl<'a, T> RwSemWriteGuard<'a, T> {
-    /// 将写锁降级为读锁，不释放锁
-    pub fn downgrade(self) -> RwSemReadGuard<'a, T>
+impl<T: ?Sized> Drop for RwSemUpgradeableGuard<'_, T> {
+    fn drop(&mut self) {
+        let res = self.inner.lock.fetch_sub(UPGRADEABLE_READER, Release);
+        if res == UPGRADEABLE_READER {
+            // 没有其他读者，唤醒所有等待者
+            self.inner.queue.wake_all();
+        }
+    }
 }
 ```
 
-**降级操作**：原子地将状态从 "1个写者" 转换为 "1个读者"，并在无写者等待时唤醒其他读者。
+**唤醒策略**：
+- 如果没有其他读者（`res == UPGRADEABLE_READER`），唤醒所有等待者
+- 如果还有其他读者，不唤醒（等待最后一个读者唤醒）
 
-## 6. 用法示例
+## 5. 高级特性
+
+### 5.1 写锁降级
+
+将写锁原子地降级为可升级读锁，允许其他读者并发访问：
 
 ```rust
-use kernel::libs::rwsem::RwSem;
+impl<'a, T> RwSemWriteGuard<'a, T> {
+    pub fn downgrade(mut self) -> RwSemUpgradeableGuard<'a, T> {
+        loop {
+            self = match self.try_downgrade() {
+                Ok(guard) => return guard,
+                Err(e) => e,
+            };
+        }
+    }
+
+    fn try_downgrade(self) -> Result<RwSemUpgradeableGuard<'a, T>, Self> {
+        let inner = self.inner;
+        let res = self.inner.lock.compare_exchange(
+            WRITER,
+            UPGRADEABLE_READER,
+            AcqRel,
+            Relaxed,
+        );
+        if res.is_ok() {
+            core::mem::forget(self);
+            Ok(RwSemUpgradeableGuard {
+                inner,
+                _nosend: PhantomData,
+            })
+        } else {
+            Err(self)
+        }
+    }
+}
+```
+
+**使用场景**：
+- 写入数据后，需要长时间持有锁进行只读操作
+- 通过降级允许其他读者并发访问，提高并发性
+
+**注意事项**：
+- 降级过程中使用 CAS 操作保证原子性
+- 使用循环重试处理 CAS 失败（通常是由于 ABA 问题）
+- 降级后不会唤醒等待者（由可升级读锁释放时处理）
+
+### 5.2 可升级读锁升级
+
+将可升级读锁原子地升级为写锁：
+
+```rust
+impl<'a, T> RwSemUpgradeableGuard<'a, T> {
+    pub fn upgrade(mut self) -> RwSemWriteGuard<'a, T> {
+        // 先设置升级标志，阻塞新的读者
+        self.inner.lock.fetch_or(BEING_UPGRADED, Acquire);
+        loop {
+            self = match self.try_upgrade() {
+                Ok(guard) => return guard,
+                Err(e) => e,
+            };
+        }
+    }
+
+    pub fn try_upgrade(self) -> Result<RwSemWriteGuard<'a, T>, Self> {
+        let res = self.inner.lock.compare_exchange(
+            UPGRADEABLE_READER | BEING_UPGRADED,
+            WRITER | UPGRADEABLE_READER,
+            AcqRel,
+            Relaxed,
+        );
+        if res.is_ok() {
+            let inner = self.inner;
+            core::mem::forget(self);
+            Ok(RwSemWriteGuard {
+                inner,
+                _nosend: PhantomData,
+            })
+        } else {
+            Err(self)
+        }
+    }
+}
+```
+
+**升级机制**：
+1. 先设置 `BEING_UPGRADED` 标志，阻塞新的读者
+2. 自旋等待现有读者全部释放（读者计数降为 0）
+3. 使用 CAS 将状态从"可升级读者+升级中"转换为"写者"
+
+**关键设计**：
+- 升级过程中不会睡眠，而是自旋等待
+- `BEING_UPGRADED` 标志确保不会有新的读者进入
+- 保持 `UPGRADEABLE_READER` 位直到升级完成，防止其他线程获取可升级读锁
+
+### 5.3 可中断的锁获取
+
+支持被信号中断的锁获取操作：
+
+```rust
+// 可中断的读锁获取
+pub fn read_interruptible(&self) -> Result<RwSemReadGuard<'_, T>, SystemError> {
+    self.queue.wait_until_interruptible(|| self.try_read())
+}
+
+// 可中断的写锁获取
+pub fn write_interruptible(&self) -> Result<RwSemWriteGuard<'_, T>, SystemError> {
+    self.queue.wait_until_interruptible(|| self.try_write())
+}
+```
+
+**使用场景**：
+- 用户态进程获取锁时，需要响应信号（如 Ctrl+C）
+- 避免进程无限期阻塞
+
+**错误处理**：
+- 返回 `Err(SystemError::ERESTARTSYS)` 表示被信号中断
+- 调用者需要适当处理错误（通常是返回到用户态）
+
+## 6. API 参考
+
+### 6.1 创建
+
+```rust
+// 编译期常量初始化
+pub const fn new(value: T) -> Self
+
+// 运行时初始化
+let rwsem = RwSem::new(data);
+```
+
+### 6.2 读锁操作
+
+```rust
+// 阻塞获取（不可中断）
+pub fn read(&self) -> RwSemReadGuard<'_, T>
+
+// 阻塞获取（可被信号中断）
+pub fn read_interruptible(&self) -> Result<RwSemReadGuard<'_, T>, SystemError>
+
+// 非阻塞尝试获取
+pub fn try_read(&self) -> Option<RwSemReadGuard<'_, T>>
+```
+
+### 6.3 写锁操作
+
+```rust
+// 阻塞获取（不可中断）
+pub fn write(&self) -> RwSemWriteGuard<'_, T>
+
+// 阻塞获取（可被信号中断）
+pub fn write_interruptible(&self) -> Result<RwSemWriteGuard<'_, T>, SystemError>
+
+// 非阻塞尝试获取
+pub fn try_write(&self) -> Option<RwSemWriteGuard<'_, T>>
+```
+
+### 6.4 可升级读锁操作
+
+```rust
+// 阻塞获取（不可中断）
+pub fn upread(&self) -> RwSemUpgradeableGuard<'_, T>
+
+// 非阻塞尝试获取
+pub fn try_upread(&self) -> Option<RwSemUpgradeableGuard<'_, T>>
+```
+
+### 6.5 锁转换操作
+
+```rust
+impl<'a, T> RwSemWriteGuard<'a, T> {
+    // 写锁降级为可升级读锁
+    pub fn downgrade(self) -> RwSemUpgradeableGuard<'a, T>
+}
+
+impl<'a, T> RwSemUpgradeableGuard<'a, T> {
+    // 可升级读锁升级为写锁
+    pub fn upgrade(self) -> RwSemWriteGuard<'a, T>
+
+    // 非阻塞尝试升级
+    pub fn try_upgrade(self) -> Result<RwSemWriteGuard<'a, T>, Self>
+}
+```
+
+### 6.6 直接访问
+
+```rust
+// 获取可变引用（需要独占的 &mut self）
+pub fn get_mut(&mut self) -> &mut T
+```
+
+## 7. 使用示例
+
+### 7.1 基本读写
+
+```rust
+use crate::libs::rwsem::RwSem;
 
 static DATA: RwSem<Vec<u32>> = RwSem::new(Vec::new());
 
-// 读取数据
+// 多个读者可并发访问
 fn reader() {
     let guard = DATA.read();
     println!("Data: {:?}", *guard);
     // guard 离开作用域时自动释放读锁
 }
 
-// 写入数据
+// 写者独占访问
 fn writer() {
     let mut guard = DATA.write();
     guard.push(42);
     // guard 离开作用域时自动释放写锁
 }
+```
 
-// 写锁降级
+### 7.2 可升级读锁
+
+```rust
+fn reader_that_may_write() {
+    // 先以可升级读者身份获取锁
+    let guard = DATA.upread();
+
+    // 读取数据判断是否需要修改
+    if guard.is_empty() {
+        // 需要修改，升级到写锁
+        let mut write_guard = guard.upgrade();
+        write_guard.push(1);
+    }
+    // 不需要修改，直接释放
+}
+```
+
+### 7.3 写锁降级
+
+```rust
 fn writer_with_downgrade() {
+    // 先获取写锁进行修改
     let mut guard = DATA.write();
     guard.clear();
     guard.push(1);
 
-    // 降级为读锁，允许其他读者并发访问
+    // 修改完成，降级为可升级读锁
     let read_guard = guard.downgrade();
+
+    // 现在允许其他读者并发访问
     println!("After write: {:?}", *read_guard);
 }
+```
 
-// 可中断的获取
+### 7.4 可中断的获取
+
+```rust
 fn interruptible_reader() -> Result<(), SystemError> {
+    // 可被信号中断
     let guard = DATA.read_interruptible()?;
     println!("Data: {:?}", *guard);
     Ok(())
 }
+```
 
-// 非阻塞尝试
-fn try_read() -> Option<()> {
+### 7.5 非阻塞尝试
+
+```rust
+fn try_reader() -> Option<()> {
+    // 立即返回，不会睡眠
     let guard = DATA.try_read()?;
     println!("Data: {:?}", *guard);
     Some(())
 }
 ```
 
-## 7. 与 Linux 内核 rw_semaphore 的对比
+## 8. 内存序与正确性
 
-| 特性 | Linux rw_semaphore | DragonOS RwSem |
-|------|-------------------|----------------|
-| 状态存储 | atomic_long_t | AtomicU64 |
-| 写者优先 | 是 | 是 |
-| 双等待队列 | 是 | 是 |
-| 锁降级 | 支持 | 支持 |
-| 可中断等待 | 支持 | 支持 |
+### 8.1 内存序保证
 
-## 8. 注意事项
+RwSem 使用以下内存序保证正确性：
 
-1. **不可在中断上下文使用** - RwSem 可能会睡眠，中断上下文不允许睡眠
+- **Acquire**：获取锁时使用，确保锁保护的数据可见
+- **Release**：释放锁时使用，确保临界区内的修改对后续获取者可见
+- **AcqRel**：同时需要 Acquire 和 Release 语义的操作（如降级、升级）
+- **Relaxed**：CAS 失败路径，不需要同步
+
+### 8.2 happens-before 关系
+
+```
+写者释放 (Release) ────┐
+                      │ happens-before
+读者获取 (Acquire) ←──┘
+```
+
+**保证**：
+- 写者在释放前的所有修改，对后续读者可见
+- 多个读者之间没有 happens-before 关系（并发读）
+
+## 9. 与其他实现的对比
+
+| 特性 | Linux rw_semaphore | Rust parking_lot::RwLock | DragonOS RwSem |
+|------|-------------------|--------------------------|----------------|
+| 状态存储 | atomic_long_t | AtomicUsize | AtomicUsize |
+| 等待队列 | 单队列 + 类型标记 | 单队列 + parking | 单队列 + WaitQueue |
+| 可升级锁 | 不支持 | 支持 | **支持** |
+| 锁降级 | 支持（down_write_to_read） | 支持 | **支持** |
+| 公平策略 | 写者优先 + HANDOFF | FIFO + 反饥饿 | FIFO 公平竞争 |
+| 可中断等待 | 支持 | 不支持 | **支持** |
+| 中断上下文 | 不支持 | 不支持 | 不支持 |
+
+## 10. 性能特性
+
+### 10.1 快速路径优化
+
+- **无竞争读取**：单次原子操作（`fetch_add`）
+- **无竞争写入**：单次 CAS 操作
+- **读者释放**：单次原子操作，只有最后一个读者才唤醒
+
+### 10.2 可扩展性
+
+- **并发读**：读者之间完全并发，无额外同步开销
+- **写者唤醒**：`wake_all()` 允许多个读者并发唤醒
+- **队列开销**：只在有等待者时才操作队列
+
+### 10.3 性能建议
+
+- 优先使用 `try_*` 方法避免睡眠（在能够快速重试的场景下）
+- 使用可升级读锁避免读锁升级导致的死锁
+- 读密集场景下性能优于写密集场景
+
+## 11. 注意事项
+
+### 11.1 使用限制
+
+1. **不可在中断上下文使用** - RwSem 可能会睡眠
 2. **避免嵌套锁** - 同一线程递归获取同一 RwSem 会导致死锁
-3. **写者优先可能导致读者饿死** - 在写者密集的场景下，读者可能长时间等待
-4. **内存序要求** - 使用 Acquire/Release 语义确保 happens-before 关系
+3. **避免读锁升级** - 不支持将普通读锁升级为写锁（会导致死锁）
+4. **Guard 不可跨线程** - Guard 类型标记为 `!Send`，不能跨线程传递
+
+### 11.2 死锁场景
+
+```rust
+// ❌ 错误：嵌套获取同一锁
+let guard1 = rwsem.read();
+let guard2 = rwsem.write();  // 死锁！
+
+// ❌ 错误：尝试升级普通读锁
+let guard = rwsem.read();
+drop(guard);
+let guard = rwsem.write();  // 不是原子升级，可能有竞态
+
+// ✅ 正确：使用可升级读锁
+let guard = rwsem.upread();
+let guard = guard.upgrade();  // 原子升级
+```
+
+### 11.3 最佳实践
+
+1. 优先使用可升级读锁而非普通读锁（当可能需要写入时）
+2. 使用降级而非释放+重新获取（保持原子性）
+3. 在用户态进程中使用 `*_interruptible` 变体
+4. 尽量减少临界区大小，避免长时间持有锁
+
+## 12. 实现原理总结
+
+```
+                    ┌─────────────────────────────────────┐
+                    │             RwSem<T>                │
+                    │                                     │
+                    │  ┌───────────────────────────────┐  │
+                    │  │  lock: AtomicUsize            │  │
+                    │  │  [W|U|B|O|READER_COUNT]       │  │
+                    │  │  W: Writer                    │  │
+                    │  │  U: Upgradeable Reader        │  │
+                    │  │  B: Being Upgraded            │  │
+                    │  │  O: Overflow Detect           │  │
+                    │  └───────────────────────────────┘  │
+                    │  ┌───────────────────────────────┐  │
+                    │  │  queue: WaitQueue             │  │
+                    │  │  (all waiters in FIFO order)  │  │
+                    │  └───────────────────────────────┘  │
+                    │  ┌───────────────────────────────┐  │
+                    │  │  val: UnsafeCell<T>           │  │
+                    │  └───────────────────────────────┘  │
+                    └─────────────────────────────────────┘
+
+锁获取流程（以读锁为例）:
+    read() → wait_until(try_read)
+                  │
+                  ↓
+           ┌──────────────┐
+           │ 注册 waker    │ ← 先入队（防止唤醒丢失）
+           └──────┬───────┘
+                  │
+                  ↓
+           ┌──────────────┐
+           │ 调用 cond()  │ ← 再检查条件
+           │ = try_read() │
+           └──────┬───────┘
+                  │
+            成功 ←┴─→ 失败
+              │         │
+              ↓         ↓
+         返回 Guard   睡眠等待
+                         │
+                    被唤醒后循环
+
+锁释放与唤醒:
+    读锁: 最后一个读者 → wake_one()
+    写锁: 总是 → wake_all()
+    可升级读锁: 无其他读者时 → wake_all()
+```
+
+这个设计通过巧妙利用位域编码、wait_until 原子等待机制和差异化的唤醒策略，实现了一个高效、正确且功能丰富的读写信号量。

--- a/docs/kernel/sched/wait_queue.md
+++ b/docs/kernel/sched/wait_queue.md
@@ -1,109 +1,330 @@
 # DragonOS 等待队列机制
 
-## 概述
+## 1. 概述
 
-DragonOS 等待队列是基于 Waiter/Waker 模式的同步原语，用于进程阻塞等待和唤醒。通过原子操作解决"唤醒丢失"问题。
+DragonOS 等待队列（WaitQueue）是基于 Waiter/Waker 模式的进程同步原语，用于进程阻塞等待和唤醒。它通过原子操作和精心设计的等待-唤醒协议，彻底解决了"唤醒丢失"问题。
 
-## 核心设计
+### 1.1 核心特性
 
-### Waiter/Waker 模式
+- **零唤醒丢失**：通过"先注册后检查"的机制确保不会错过任何唤醒信号
+- **一次性 Waiter/Waker**：每次等待创建一对对象，避免状态复用问题
+- **wait_until 为核心**：以返回资源的 `wait_until` 为基础 API，其他 API 基于此实现
+- **原子等待与获取**：支持原子地"等待条件并获取资源"（如锁的 Guard）
+- **多核友好**：Waker 可跨 CPU 共享，支持并发唤醒
+- **信号感知**：支持可中断和不可中断的等待模式
 
-每次等待操作创建一对对象：
+## 2. 核心设计
 
-- **Waiter**：线程本地持有（!Send/!Sync），用于等待
-- **Waker**：跨 CPU 共享（Arc），用于唤醒
+### 2.1 Waiter/Waker 模式
 
-### 关键结构
+等待队列采用生产者-消费者模式，将等待方和唤醒方分离：
 
 ```rust
-struct WaitQueue {
-    inner: SpinLock<VecDeque<Arc<Waker>>>,
-    num_waiters: AtomicU32,  // 快速路径检查
+pub struct Waiter {
+    waker: Arc<Waker>,
+    _nosend: PhantomData<Rc<()>>,  // 标记为 !Send
 }
 
-struct Waker {
-    has_woken: AtomicBool,    // 唤醒标记
+pub struct Waker {
+    has_woken: AtomicBool,    // 唤醒标志
     target: Weak<PCB>,        // 目标进程
 }
 ```
 
-## 等待与唤醒流程
+**关键特性**：
+- **Waiter**：线程本地持有（`!Send`/`!Sync`），只能在创建它的线程上等待
+- **Waker**：通过 `Arc` 共享，可以跨 CPU/线程传递和唤醒
+- **一次性设计**：每次等待创建新的 Waiter/Waker 对，避免状态污染
 
-### 等待流程
-
-1. 检查条件，满足则直接返回
-2. 创建 Waiter/Waker 对，加锁将 Waker 加入队列
-3. 再次检查条件（处理竞态）
-4. 执行 before_sleep 钩子（通常释放锁）
-5. 调用 Waiter::wait() 阻塞当前进程
+### 2.2 等待队列结构
 
 ```rust
-// 等待条件满足
-wait_queue.wait_event_interruptible(
-    || condition_is_met(),
-    Some(|| unlock_mutex()),
-)?;
-```
+pub struct WaitQueue {
+    inner: SpinLock<InnerWaitQueue>,
+    num_waiters: AtomicU32,  // 快速路径检查
+}
 
-### 唤醒流程
-
-```
-┌─────────────────┐
-│  wake_one()     │
-└─────────────────┘
-         │
-         ▼
-┌─────────────────┐
-│ 检查队列是否空  │ (快速路径)
-└─────────────────┘
-         │
-    空  │ │ 非空
-        ▼ ▼
-   返回  加锁队列
-         │
-         ▼
-┌─────────────────┐
-│ 取出一个 Waker  │
-└─────────────────┘
-         │
-         ▼
-┌─────────────────┐
-│ 释放锁后唤醒    │
-└─────────────────┘
-         │
-         ▼
-┌─────────────────┐
-│设置 has_woken   │
-│并唤醒进程       │
-└─────────────────┘
-```
-
-### 内存序保证
-
-- **唤醒方**：使用 Release 语义设置 `has_woken`
-- **等待方**：使用 Acquire 语义读取 `has_woken`
-- 保证唤醒前的所有操作对等待方可见
-
-## 核心实现
-
-### Waker::wake
-
-```rust
-pub fn wake(&self) -> bool {
-    // 原子设置唤醒标记
-    if self.has_woken.swap(true, Ordering::Release) {
-        return false;  // 已被唤醒
-    }
-
-    // 唤醒目标进程
-    if let Some(pcb) = self.target.upgrade() {
-        ProcessManager::wakeup(&pcb);
-    }
-    true
+struct InnerWaitQueue {
+    dead: bool,                    // 队列失效标志
+    waiters: VecDeque<Arc<Waker>>, // 等待者队列（FIFO）
 }
 ```
 
-### block_current
+**设计亮点**：
+- **快速路径优化**：`num_waiters` 原子计数器允许无锁检查队列是否为空
+- **FIFO 顺序**：使用 `VecDeque` 保证公平性
+- **死亡标记**：`dead` 标志用于资源销毁时的清理
+- **自旋锁保护**：使用 `SpinLock` 而非 `Mutex`，避免递归依赖
+
+## 3. 核心 API：wait_until 家族
+
+### 3.1 wait_until：核心等待原语
+
+`wait_until` 是整个等待队列机制的核心，所有其他等待方法都基于它实现：
+
+```rust
+pub fn wait_until<F, R>(&self, cond: F) -> R
+where
+    F: FnMut() -> Option<R>,
+{
+    // 1. 快速路径：先检查条件
+    if let Some(res) = cond() {
+        return res;
+    }
+
+    // 2. 创建唯一的 Waiter/Waker 对
+    let (waiter, waker) = Waiter::new_pair();
+
+    loop {
+        // 3. 先注册 waker 到队列（关键！）
+        self.register_waker(waker.clone());
+
+        // 4. 再检查条件（防止唤醒丢失）
+        if let Some(res) = cond() {
+            self.remove_waker(&waker);
+            return res;
+        }
+
+        // 5. 睡眠等待被唤醒
+        waiter.wait();
+
+        // 6. 被唤醒后循环继续（可能是伪唤醒或竞争失败）
+    }
+}
+```
+
+**关键设计思想**：
+1. **先入队，再检查**：确保在检查条件和睡眠之间，任何唤醒都能被正确处理
+2. **返回资源而非布尔值**：`Option<R>` 而非 `bool`，允许直接返回获取的资源（如锁 Guard）
+3. **循环重试**：被唤醒后可能因竞争失败，需要重新入队并检查
+4. **唯一 Waiter/Waker**：整个等待过程只创建一对对象，简化生命周期管理
+
+### 3.2 wait_until 变体
+
+```rust
+// 不可中断等待
+pub fn wait_until<F, R>(&self, cond: F) -> R
+
+// 可中断等待（可被信号中断）
+pub fn wait_until_interruptible<F, R>(&self, cond: F)
+    -> Result<R, SystemError>
+
+// 带超时的可中断等待
+pub fn wait_until_timeout<F, R>(&self, cond: F, timeout: Duration)
+    -> Result<R, SystemError>
+```
+
+**返回值语义**：
+- `Ok(R)`：条件满足，返回获取的资源
+- `Err(ERESTARTSYS)`：被信号中断
+- `Err(EAGAIN_OR_EWOULDBLOCK)`：超时
+
+### 3.3 为什么 wait_until 优于 wait_event
+
+传统的 `wait_event` 系列 API 只返回布尔值：
+
+```rust
+// 传统方式（存在竞态）
+wait_event(|| lock.is_available());
+let guard = lock.acquire();  // ❌ 可能失败！另一个线程可能抢先获取
+```
+
+而 `wait_until` 可以原子地"等待并获取"：
+
+```rust
+// wait_until 方式（无竞态）
+let guard = wait_until(|| lock.try_acquire());  // ✅ 原子获取
+```
+
+**关键优势**：
+- 消除"检查-获取"之间的竞态窗口
+- 代码更简洁，语义更清晰
+- 性能更好（减少一次原子操作）
+
+## 4. 等待与唤醒流程
+
+### 4.1 详细等待流程
+
+```
+┌─────────────────────┐
+│  调用 wait_until    │
+└──────────┬──────────┘
+           │
+           ↓
+    ┌──────────────┐
+    │ 快速路径：    │
+    │ 检查条件      │
+    └──────┬───────┘
+           │
+      满足? ────────┐
+        │ 否       │ 是
+        ↓          ↓
+  ┌──────────┐  返回结果
+  │ 创建      │
+  │ Waiter/  │
+  │ Waker    │
+  └────┬─────┘
+       │
+       ↓ [循环开始]
+  ┌──────────────┐
+  │ 1. 注册 waker │ ← 关键：先入队
+  │    到队列     │
+  └──────┬───────┘
+         │
+         ↓
+  ┌──────────────┐
+  │ 2. 再次检查  │ ← 防止唤醒丢失
+  │    条件       │
+  └──────┬───────┘
+         │
+    满足? ────────┐
+      │ 否       │ 是
+      ↓          ↓
+  ┌──────────┐ ┌──────────┐
+  │ 检查信号 │ │ 移除      │
+  │ (可中断) │ │ waker    │
+  └────┬─────┘ └────┬─────┘
+       │            │
+  有信号? ──┐       ↓
+    │ 否  │ 是   返回结果
+    ↓     ↓
+  ┌────┐ 返回
+  │睡眠│ ERESTARTSYS
+  └─┬──┘
+    │
+    ↓ [被唤醒]
+  ┌──────────────┐
+  │ 检查信号     │
+  │ (可中断)     │
+  └──────┬───────┘
+         │
+         ↓ [循环继续]
+```
+
+**关键点解释**：
+
+1. **先入队再检查**：
+   - 如果先检查再入队，可能在检查返回 false 之后、入队之前，条件变为 true 并发生唤醒
+   - 此时唤醒信号会丢失，因为 waker 还未入队
+   - 先入队保证了任何后续的唤醒都能找到我们的 waker
+
+2. **循环重试的必要性**：
+   - 被唤醒并不保证条件满足（可能是伪唤醒）
+   - 即使条件曾经满足，也可能因为竞争而再次变为不满足
+   - 因此需要重新入队并检查
+
+3. **一次性 Waker 的优势**：
+   - 避免了复杂的状态管理
+   - 被唤醒后不会再次被唤醒（`has_woken` 标志）
+   - 循环中会重新注册新的 waker，但使用同一个 `Arc<Waker>`
+
+### 4.2 唤醒流程
+
+#### wake_one：唤醒一个等待者
+
+```rust
+pub fn wake_one(&self) -> bool {
+    // 快速路径：队列为空
+    if self.is_empty() {
+        return false;
+    }
+
+    loop {
+        // 从队列头部取出一个 waker
+        let next = {
+            let mut guard = self.inner.lock_irqsave();
+            let waker = guard.waiters.pop_front();
+            if waker.is_some() {
+                self.num_waiters.fetch_sub(1, Ordering::Release);
+            }
+            waker
+        };
+
+        let Some(waker) = next else { return false };
+
+        // 释放锁后再唤醒（减少锁持有时间）
+        if waker.wake() {
+            return true;  // 成功唤醒
+        }
+        // waker 已失效（进程已退出），继续尝试下一个
+    }
+}
+```
+
+**设计要点**：
+- **FIFO 顺序**：从队列头部取出，保证公平性
+- **锁外唤醒**：释放锁后再调用 `waker.wake()`，减少锁竞争
+- **自动跳过失效 waker**：如果目标进程已退出，自动尝试下一个
+
+#### wake_all：唤醒所有等待者
+
+```rust
+pub fn wake_all(&self) -> usize {
+    // 快速路径：队列为空
+    if self.is_empty() {
+        return 0;
+    }
+
+    // 一次性取出所有 waker（减少锁持有时间）
+    let wakers = {
+        let mut guard = self.inner.lock_irqsave();
+        let mut drained = VecDeque::new();
+        mem::swap(&mut guard.waiters, &mut drained);
+        self.num_waiters.store(0, Ordering::Release);
+        drained
+    };
+
+    // 释放锁后逐个唤醒
+    let mut woken = 0;
+    for waker in wakers {
+        if waker.wake() {
+            woken += 1;
+        }
+    }
+    woken
+}
+```
+
+**设计要点**：
+- **批量取出**：一次性将队列清空，最小化锁持有时间
+- **锁外唤醒**：在释放锁后逐个唤醒，允许被唤醒的进程立即竞争
+- **返回实际唤醒数**：区分"唤醒请求"和"实际唤醒"
+
+### 4.3 Waker 唤醒机制
+
+```rust
+impl Waker {
+    pub fn wake(&self) -> bool {
+        // 原子设置唤醒标志
+        if self.has_woken.swap(true, Ordering::Release) {
+            return false;  // 已被唤醒过
+        }
+
+        // 唤醒目标进程
+        if let Some(pcb) = self.target.upgrade() {
+            ProcessManager::wakeup(&pcb);
+        }
+        true
+    }
+
+    pub fn close(&self) {
+        // 关闭 waker，防止后续唤醒
+        self.has_woken.store(true, Ordering::Acquire);
+    }
+
+    fn consume_wake(&self) -> bool {
+        // 消费唤醒标志（用于 block_current）
+        self.has_woken.swap(false, Ordering::Acquire)
+    }
+}
+```
+
+**关键特性**：
+- **原子唤醒标志**：`has_woken` 使用 `AtomicBool` 确保只唤醒一次
+- **弱引用目标进程**：使用 `Weak<PCB>` 避免循环引用，进程退出时自动清理
+- **内存序保证**：Release/Acquire 语义确保唤醒前的修改对被唤醒进程可见
+
+### 4.4 阻塞当前进程
 
 ```rust
 fn block_current(waiter: &Waiter, interruptible: bool) -> Result<(), SystemError> {
@@ -113,15 +334,23 @@ fn block_current(waiter: &Waiter, interruptible: bool) -> Result<(), SystemError
             return Ok(());
         }
 
-        // 禁用中断，标记进程为睡眠状态
+        // 禁用中断，进入临界区
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-        ProcessManager::mark_sleep(interruptible)?;
-        drop(irq_guard);
 
-        // 调度出去
+        // 再次检查唤醒标志（处理"先唤后睡"竞态）
+        if waiter.waker.consume_wake() {
+            drop(irq_guard);
+            return Ok(());
+        }
+
+        // 标记进程为睡眠状态
+        ProcessManager::mark_sleep(interruptible)?;
+        drop(irq_guard);  // 恢复中断
+
+        // 调度到其他进程
         schedule(SchedMode::SM_NONE);
 
-        // 检查信号（可中断等待）
+        // 被唤醒后，检查信号（可中断模式）
         if interruptible && Signal::signal_pending_state(...) {
             return Err(SystemError::ERESTARTSYS);
         }
@@ -129,23 +358,272 @@ fn block_current(waiter: &Waiter, interruptible: bool) -> Result<(), SystemError
 }
 ```
 
-## 主要 API
+**关键设计**：
+- **双重检查**：在禁用中断前后都检查唤醒标志，防止"先唤后睡"
+- **中断保护**：`mark_sleep` 必须在禁用中断的情况下执行
+- **信号检查**：被调度回来后检查是否有信号需要处理
 
-```rust
-// 等待事件
-wait_queue.wait_event_interruptible(|| condition_met, Some(|| unlock()))?;
+## 5. 内存序与正确性
 
-// 唤醒
-wait_queue.wakeup(None);     // 唤醒一个
-wait_queue.wake_all();       // 唤醒所有
+### 5.1 内存序保证
 
-// 便利方法
-wait_queue.sleep_unlock_spinlock(guard)?;  // 睡眠并释放锁
+等待队列使用以下内存序确保正确性：
+
+| 操作 | 内存序 | 作用 |
+|------|--------|------|
+| `waker.wake()` | Release | 确保唤醒前的修改对被唤醒者可见 |
+| `waiter.wait()` | Acquire | 确保能看到唤醒前的所有修改 |
+| `register_waker` | Release | 确保入队操作的可见性 |
+| `num_waiters` | Acquire/Release | 同步计数器的修改 |
+
+### 5.2 happens-before 关系
+
+```
+线程 A（唤醒方）              线程 B（等待方）
+    │                           │
+    │ 修改共享数据               │
+    │                           │
+    ↓                           ↓
+wake() (Release)          register_waker()
+    │                           │
+    │ happens-before             │
+    │ ─────────────────────────→ │
+    │                           ↓
+    │                      wait() (Acquire)
+    │                           │
+    │                           ↓
+    │                      观察到共享数据修改
 ```
 
-## 使用示例
+**保证**：
+- 唤醒方在调用 `wake()` 之前的所有修改，对等待方可见
+- 这是实现正确同步的基础
 
-### 信号量
+### 5.3 无竞态的证明
+
+**情况 1：先入队后唤醒（正常流程）**
+```
+时间轴：
+T1: 等待方 register_waker()
+T2: 等待方检查条件，返回 false
+T3: 等待方准备睡眠
+T4: 唤醒方 wake_one()          ← waker 在队列中，正常唤醒
+T5: 等待方被唤醒
+```
+
+**情况 2：先唤醒后入队（需要处理的竞态）**
+```
+时间轴：
+T1: 等待方检查条件，返回 false
+T2: 唤醒方修改条件为 true
+T3: 唤醒方 wake_one()          ← waker 还未入队，唤醒失败
+T4: 等待方 register_waker()
+T5: 等待方再次检查条件         ← 检测到 true，不会睡眠！
+```
+
+**关键点**：通过"入队后再检查"，即使唤醒发生在入队前，也能通过第二次检查发现条件已满足。
+
+## 6. 兼容 API：wait_event 家族
+
+为了向后兼容，提供了基于 `wait_until` 实现的 `wait_event` 系列 API：
+
+```rust
+// 可中断等待，返回 Result<(), SystemError>
+pub fn wait_event_interruptible<F, B>(
+    &self,
+    mut cond: F,
+    before_sleep: Option<B>,
+) -> Result<(), SystemError>
+where
+    F: FnMut() -> bool,
+    B: FnMut(),
+{
+    self.wait_until_impl(
+        || if cond() { Some(()) } else { None },
+        true,
+        None,
+        before_sleep,
+    )
+}
+
+// 不可中断等待
+pub fn wait_event_uninterruptible<F, B>(
+    &self,
+    mut cond: F,
+    before_sleep: Option<B>,
+) -> Result<(), SystemError>
+where
+    F: FnMut() -> bool,
+    B: FnMut(),
+{
+    self.wait_until_impl(
+        || if cond() { Some(()) } else { None },
+        false,
+        None,
+        before_sleep,
+    )
+}
+
+// 带超时的可中断等待
+pub fn wait_event_interruptible_timeout<F>(
+    &self,
+    mut cond: F,
+    timeout: Option<Duration>,
+) -> Result<(), SystemError>
+where
+    F: FnMut() -> bool,
+{
+    self.wait_until_impl(
+        || if cond() { Some(()) } else { None },
+        true,
+        timeout,
+        None::<fn()>,
+    )
+}
+```
+
+**before_sleep 钩子**：
+- 在入队后、睡眠前执行
+- 典型用途：释放锁，避免持锁睡眠
+- 例如：`wait_event_interruptible(|| cond(), Some(|| drop(guard)))`
+
+## 7. 便利方法
+
+### 7.1 睡眠并释放锁
+
+```rust
+// 释放 SpinLock 并睡眠（可中断）
+pub fn sleep_unlock_spinlock<T>(&self, to_unlock: SpinLockGuard<T>)
+    -> Result<(), SystemError>
+
+// 释放 Mutex 并睡眠（可中断）
+pub fn sleep_unlock_mutex<T>(&self, to_unlock: MutexGuard<T>)
+    -> Result<(), SystemError>
+
+// 释放 SpinLock 并睡眠（不可中断）
+pub fn sleep_uninterruptible_unlock_spinlock<T>(&self, to_unlock: SpinLockGuard<T>)
+
+// 释放 Mutex 并睡眠（不可中断）
+pub fn sleep_uninterruptible_unlock_mutex<T>(&self, to_unlock: MutexGuard<T>)
+```
+
+**使用示例**：
+```rust
+let guard = lock.lock();
+// 检查条件
+if !condition_met() {
+    // 需要等待，释放锁并睡眠
+    wait_queue.sleep_unlock_spinlock(guard)?;
+    // 被唤醒后需要重新获取锁
+}
+```
+
+### 7.2 队列生命周期管理
+
+```rust
+// 标记队列失效，唤醒并清空所有等待者
+pub fn mark_dead(&self) {
+    let mut drained = VecDeque::new();
+    {
+        let mut guard = self.inner.lock_irqsave();
+        guard.dead = true;
+        mem::swap(&mut guard.waiters, &mut drained);
+        self.num_waiters.store(0, Ordering::Release);
+    }
+    for w in drained {
+        w.wake();
+        w.close();
+    }
+}
+
+// 检查队列是否为空
+pub fn is_empty(&self) -> bool {
+    self.num_waiters.load(Ordering::Acquire) == 0
+}
+
+// 获取等待者数量
+pub fn len(&self) -> usize {
+    self.num_waiters.load(Ordering::Acquire) as usize
+}
+```
+
+## 8. 事件等待队列
+
+除了普通等待队列，还提供了基于事件掩码的等待队列：
+
+```rust
+pub struct EventWaitQueue {
+    wait_list: SpinLock<Vec<(u64, Arc<Waker>)>>,
+}
+
+impl EventWaitQueue {
+    // 等待特定事件
+    pub fn sleep(&self, events: u64)
+
+    // 等待特定事件并释放锁
+    pub fn sleep_unlock_spinlock<T>(&self, events: u64, to_unlock: SpinLockGuard<T>)
+
+    // 唤醒等待任意匹配事件的线程（位掩码 AND）
+    pub fn wakeup_any(&self, events: u64) -> usize
+
+    // 唤醒等待精确匹配事件的线程（相等比较）
+    pub fn wakeup(&self, events: u64) -> usize
+
+    // 唤醒所有等待者
+    pub fn wakeup_all(&self)
+}
+```
+
+**使用场景**：
+- 多种事件类型的等待（如 `READABLE | WRITABLE`）
+- 按事件类型唤醒特定等待者
+- 例如：socket 的 poll/select 实现
+
+## 9. 超时支持
+
+### 9.1 超时机制
+
+```rust
+pub fn wait_until_timeout<F, R>(&self, cond: F, timeout: Duration)
+    -> Result<R, SystemError>
+where
+    F: FnMut() -> Option<R>,
+{
+    self.wait_until_impl(cond, true, Some(timeout), None::<fn()>)
+}
+```
+
+**实现原理**：
+1. 计算截止时间：`deadline = now + timeout`
+2. 创建定时器，到期时唤醒 waiter
+3. 被唤醒后检查是否超时：
+   - 如果定时器触发，返回 `EAGAIN_OR_EWOULDBLOCK`
+   - 如果条件满足，取消定时器并返回结果
+
+### 9.2 TimeoutWaker
+
+```rust
+pub struct TimeoutWaker {
+    waker: Arc<Waker>,
+}
+
+impl TimerFunction for TimeoutWaker {
+    fn run(&mut self) -> Result<(), SystemError> {
+        // 定时器到期，唤醒等待者
+        self.waker.wake();
+        Ok(())
+    }
+}
+```
+
+**关键设计**：
+- 定时器通过 `Waker::wake()` 唤醒，而非直接唤醒 PCB
+- 这样 `Waiter::wait()` 可以正确观察到唤醒状态
+- 与正常唤醒使用相同的机制，保持一致性
+
+## 10. 使用示例
+
+### 10.1 信号量实现
 
 ```rust
 struct Semaphore {
@@ -155,32 +633,261 @@ struct Semaphore {
 
 impl Semaphore {
     fn down(&self) -> Result<(), SystemError> {
-        loop {
-            // 尝试获取
-            if self.counter.fetch_sub(1, Acquire) > 0 {
-                return Ok(());
+        // 使用 wait_until 直接获取信号量
+        self.wait_queue.wait_until(|| {
+            let old = self.counter.load(Acquire);
+            if old > 0 {
+                // 尝试原子递减
+                if self.counter.compare_exchange(
+                    old, old - 1, Acquire, Relaxed
+                ).is_ok() {
+                    return Some(());  // 成功获取
+                }
             }
-            // 失败，等待
-            self.counter.fetch_add(1, Release);
-            self.wait_queue.wait_event_interruptible(
-                || self.counter.load(Acquire) > 0,
-                None,
-            )?;
-        }
+            None  // 获取失败，继续等待
+        });
+        Ok(())
     }
 
     fn up(&self) {
         self.counter.fetch_add(1, Release);
-        self.wait_queue.wakeup(None);
+        self.wait_queue.wake_one();
     }
 }
 ```
 
-## 关键优势
+**优势**：
+- 使用 `wait_until` 确保原子地"等待并获取"
+- 避免了"检查-获取"之间的竞态窗口
+- 代码简洁清晰
 
-1. **无唤醒丢失**：原子 `has_woken` 标记确保
-2. **简单易用**：统一的 API，无需手动管理状态
-3. **高性能**：快速路径优化，最小化锁持有时间
-4. **多核友好**：支持并发唤醒，减少锁竞争
+### 10.2 条件变量实现
 
-这套机制为 DragonOS 的同步原语（信号量、条件变量、futex 等）提供了基础支撑。
+```rust
+struct CondVar {
+    wait_queue: WaitQueue,
+}
+
+impl CondVar {
+    fn wait<T>(&self, guard: MutexGuard<T>) -> Result<MutexGuard<T>, SystemError> {
+        let mutex = guard.mutex();
+
+        // 使用 before_sleep 钩子释放锁
+        let mut guard = Some(guard);
+        self.wait_queue.wait_event_interruptible(
+            || false,  // 等待 notify
+            Some(|| {
+                if let Some(g) = guard.take() {
+                    drop(g);  // 释放锁
+                }
+            }),
+        )?;
+
+        // 重新获取锁
+        mutex.lock_interruptible()
+    }
+
+    fn notify_one(&self) {
+        self.wait_queue.wake_one();
+    }
+
+    fn notify_all(&self) {
+        self.wait_queue.wake_all();
+    }
+}
+```
+
+### 10.3 RwSem 集成
+
+```rust
+impl<T: ?Sized> RwSem<T> {
+    pub fn read(&self) -> RwSemReadGuard<'_, T> {
+        // 直接返回 Guard，无竞态
+        self.queue.wait_until(|| self.try_read())
+    }
+
+    pub fn write(&self) -> RwSemWriteGuard<'_, T> {
+        self.queue.wait_until(|| self.try_write())
+    }
+
+    pub fn read_interruptible(&self) -> Result<RwSemReadGuard<'_, T>, SystemError> {
+        self.queue.wait_until_interruptible(|| self.try_read())
+    }
+}
+```
+
+**为什么这样设计**：
+- `try_read()` 返回 `Option<Guard>`，正好匹配 `wait_until` 的要求
+- 一行代码实现完整的"等待并获取"逻辑
+- 编译器保证类型安全，不会出现忘记检查的问题
+
+### 10.4 带超时的等待
+
+```rust
+fn wait_with_timeout(queue: &WaitQueue, timeout_ms: u64) -> Result<(), SystemError> {
+    let timeout = Duration::from_millis(timeout_ms);
+    queue.wait_event_interruptible_timeout(
+        || condition_met(),
+        Some(timeout),
+    )
+}
+```
+
+## 11. 性能特性
+
+### 11.1 快速路径优化
+
+- **无等待者时**：`is_empty()` 仅需一次原子读取，无锁竞争
+- **快速检查**：`wait_until` 首先检查条件，避免不必要的入队
+- **锁外唤醒**：唤醒操作在释放队列锁之后进行，减少锁持有时间
+
+### 11.2 可扩展性
+
+- **FIFO 队列**：保证公平性，避免饥饿
+- **批量唤醒**：`wake_all()` 一次性取出所有 waker，最小化锁竞争
+- **跨 CPU 唤醒**：Waker 可以在不同 CPU 上唤醒，无需锁同步
+
+### 11.3 内存开销
+
+- **Waiter**：栈上分配，不涉及堆
+- **Waker**：通过 `Arc` 共享，每个等待者一个
+- **队列**：只在有等待者时占用空间，空队列开销最小
+
+## 12. 对比与演进
+
+### 12.1 与传统实现的对比
+
+| 特性 | 传统 wait_event | DragonOS wait_until |
+|------|----------------|---------------------|
+| API 返回值 | `bool` | `Option<R>` |
+| 原子获取 | 不支持（需手动） | **原生支持** |
+| 唤醒丢失 | 需小心处理 | **设计保证无丢失** |
+| 竞态窗口 | 检查-获取有窗口 | **无窗口** |
+| 代码复杂度 | 高（需手动管理状态） | **低（编译器保证）** |
+| 性能 | 可能需要多次原子操作 | **最小化原子操作** |
+
+### 12.2 设计演进
+
+**旧设计（存在问题）**：
+```rust
+// ❌ 可能存在唤醒丢失
+loop {
+    if condition() {
+        return;
+    }
+    register_waker();
+    sleep();
+}
+```
+
+**当前设计（正确）**：
+```rust
+// ✅ 无唤醒丢失
+loop {
+    register_waker();  // 先入队
+    if condition() {   // 再检查
+        remove_waker();
+        return;
+    }
+    sleep();
+}
+```
+
+## 13. 最佳实践
+
+### 13.1 使用建议
+
+1. **优先使用 wait_until**：相比 `wait_event`，它提供更强的保证和更简洁的代码
+2. **利用 Option 返回值**：直接返回获取的资源，避免二次获取
+3. **合理使用可中断版本**：用户态进程应使用 `*_interruptible` 避免无法终止
+4. **正确处理超时**：区分 `ERESTARTSYS`（信号）和 `EAGAIN_OR_EWOULDBLOCK`（超时）
+
+### 13.2 避免的陷阱
+
+```rust
+// ❌ 错误：分离检查和获取
+if condition() {
+    let guard = acquire();  // 可能失败！
+}
+
+// ✅ 正确：原子等待并获取
+let guard = wait_until(|| try_acquire());
+
+// ❌ 错误：忘记处理信号
+let result = wait_queue.wait_event_interruptible(|| cond(), None);
+// 未检查 result
+
+// ✅ 正确：正确处理错误
+let result = wait_queue.wait_event_interruptible(|| cond(), None)?;
+```
+
+### 13.3 调试建议
+
+- 使用 `wait_queue.len()` 检查等待者数量
+- 注意 `has_woken` 标志的状态（通过日志）
+- 检查是否有进程长期阻塞（可能是唤醒逻辑错误）
+
+## 14. 实现原理总结
+
+```
+                    ┌─────────────────────────────────────┐
+                    │           WaitQueue                 │
+                    │  ┌───────────────────────────────┐  │
+                    │  │ inner: SpinLock<InnerQueue>  │  │
+                    │  │   ├─ dead: bool              │  │
+                    │  │   └─ waiters: VecDeque       │  │
+                    │  └───────────────────────────────┘  │
+                    │  ┌───────────────────────────────┐  │
+                    │  │ num_waiters: AtomicU32       │  │
+                    │  └───────────────────────────────┘  │
+                    └─────────────────────────────────────┘
+                                    │
+                        ┌───────────┴───────────┐
+                        ↓                       ↓
+            ┌────────────────────┐  ┌────────────────────┐
+            │      Waiter        │  │       Waker        │
+            │  ┌──────────────┐  │  │  ┌──────────────┐  │
+            │  │ waker: Arc   │──┼──┼─→│ has_woken:   │  │
+            │  │              │  │  │  │  AtomicBool  │  │
+            │  └──────────────┘  │  │  └──────────────┘  │
+            │  ┌──────────────┐  │  │  ┌──────────────┐  │
+            │  │ _nosend      │  │  │  │ target:      │  │
+            │  │  PhantomData │  │  │  │  Weak<PCB>   │  │
+            │  └──────────────┘  │  │  └──────────────┘  │
+            └────────────────────┘  └────────────────────┘
+                 (!Send)                   (Send+Sync)
+
+核心流程：
+┌──────────────────────────────────────────────────────────┐
+│                   wait_until(cond)                       │
+│                                                          │
+│  1. 快速路径: if cond() → return                        │
+│                                                          │
+│  2. 创建 (waiter, waker) 对                             │
+│                                                          │
+│  3. loop {                                               │
+│       ├─ register_waker(waker)      ← 先入队            │
+│       ├─ if cond() → return         ← 再检查            │
+│       ├─ waiter.wait()              ← 睡眠等待          │
+│       └─ [被唤醒，循环继续]                             │
+│     }                                                    │
+└──────────────────────────────────────────────────────────┘
+
+唤醒策略：
+┌────────────────────┐
+│    wake_one()      │  → 取出队首 waker → 唤醒一个进程
+└────────────────────┘
+
+┌────────────────────┐
+│    wake_all()      │  → 取出所有 waker → 唤醒所有进程
+└────────────────────┘
+
+内存序保证：
+    唤醒方: wake() (Release)
+                │
+                │ happens-before
+                ↓
+    等待方: wait() (Acquire)
+```
+
+这个设计通过"先入队后检查"的核心机制、一次性 Waiter/Waker 模式和原子内存序保证，实现了一个零唤醒丢失、高性能、易用的等待队列机制，为 DragonOS 的各种同步原语提供了坚实的基础。

--- a/kernel/src/libs/rwsem.rs
+++ b/kernel/src/libs/rwsem.rs
@@ -1,349 +1,331 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Sleepable Read-Write Semaphore (RwSem)
+
 use core::{
     cell::UnsafeCell,
-    mem::ManuallyDrop,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{
+        AtomicUsize,
+        Ordering::{AcqRel, Acquire, Relaxed, Release},
+    },
 };
 
+use alloc::rc::Rc;
 use system_error::SystemError;
 
 use super::wait_queue::WaitQueue;
 
-/// Sleepable read-write semaphore (rwsem): a blocking read/write lock.
+/// A mutex that provides data access to either one writer or many readers.
 ///
-/// - Intended for **process context** (may sleep).
-/// - DO NOT use in interrupt context.
+/// # Overview
 ///
-/// Fairness (v2): writer-preference.
+/// This mutex allows for multiple readers, or at most one writer to access
+/// at any point in time. The writer of this mutex has exclusive access to
+/// modify the underlying data, while the readers are allowed shared and
+/// read-only access.
+///
+/// The writing and reading portions cannot be active simultaneously, when
+/// one portion is in progress, the other portion will sleep. This is
+/// suitable for scenarios where the mutex is expected to be held for a
+/// period of time, which can avoid wasting CPU resources.
 ///
 /// # Implementation Details
 ///
-/// - **State**: Managed by a single `AtomicU64` (`count`).
-///   - Bits 0..32: Reader count (u32).
-///   - Bit 32: Writer active flag.
-///   - Bits 33..63: Writer waiters count (31 bits).
-/// - **Fast Path**: Uses atomic CAS/fetch operations to acquire lock without spinlocks.
-/// - **Slow Path**: Uses `WaitQueue` to block threads.
+/// The internal representation of the mutex state is as follows:
+/// - **Bit 63:** Writer mutex.
+/// - **Bit 62:** Upgradeable reader mutex.
+/// - **Bit 61:** Indicates if an upgradeable reader is being upgraded.
+/// - **Bit 60:** Reader overflow detection (set when count reaches 2^60).
+/// - **Bits 59-0:** Reader mutex count.
+///
+/// # Safety
+///
+/// Avoid using `RwSem` in an interrupt context, as it may result in sleeping
+/// and never being awakened.
 #[derive(Debug)]
-pub struct RwSem<T> {
-    data: UnsafeCell<T>,
-    count: AtomicU64,
-    wq_read: WaitQueue,
-    wq_write: WaitQueue,
+pub struct RwSem<T: ?Sized> {
+    lock: AtomicUsize,
+    queue: WaitQueue,
+    val: UnsafeCell<T>,
 }
 
-// Constants for bit manipulation
-const READER_MASK: u64 = 0x0000_0000_FFFF_FFFF;
-const WRITER_BIT: u64 = 1 << 32;
-const WRITER_WAITER_SHIFT: u32 = 33;
-const WRITER_WAITER_UNIT: u64 = 1 << WRITER_WAITER_SHIFT;
-const WRITER_WAITER_MASK: u64 = 0xFFFF_FFFE_0000_0000;
+const READER: usize = 1;
+const WRITER: usize = 1 << (usize::BITS - 1);
+const UPGRADEABLE_READER: usize = 1 << (usize::BITS - 2);
+const BEING_UPGRADED: usize = 1 << (usize::BITS - 3);
+const MAX_READER: usize = 1 << (usize::BITS - 4);
 
 /// Read guard for [`RwSem`].
 #[derive(Debug)]
-pub struct RwSemReadGuard<'a, T: 'a> {
-    lock: &'a RwSem<T>,
+pub struct RwSemReadGuard<'a, T: ?Sized + 'a> {
+    inner: &'a RwSem<T>,
+    // Mark as !Send
+    _nosend: PhantomData<Rc<()>>,
 }
 
 /// Write guard for [`RwSem`].
 #[derive(Debug)]
-pub struct RwSemWriteGuard<'a, T: 'a> {
-    lock: &'a RwSem<T>,
+pub struct RwSemWriteGuard<'a, T: ?Sized + 'a> {
+    inner: &'a RwSem<T>,
+    // Mark as !Send
+    _nosend: PhantomData<Rc<()>>,
+}
+
+/// Upgradeable read guard for [`RwSem`].
+#[derive(Debug)]
+pub struct RwSemUpgradeableGuard<'a, T: ?Sized + 'a> {
+    inner: &'a RwSem<T>,
+    // Mark as !Send
+    _nosend: PhantomData<Rc<()>>,
 }
 
 // SAFETY: T must be Sync because multiple readers can access &T concurrently.
-unsafe impl<T> Sync for RwSem<T> where T: Send + Sync {}
-unsafe impl<T> Send for RwSem<T> where T: Send {}
+unsafe impl<T: ?Sized + Send> Send for RwSem<T> {}
+unsafe impl<T: ?Sized + Send + Sync> Sync for RwSem<T> {}
+
+unsafe impl<T: ?Sized + Sync> Sync for RwSemWriteGuard<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RwSemReadGuard<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RwSemUpgradeableGuard<'_, T> {}
 
 impl<T> RwSem<T> {
-    pub const fn new(value: T) -> Self {
+    /// Creates a new read-write semaphore with an initial value.
+    pub const fn new(val: T) -> Self {
         Self {
-            data: UnsafeCell::new(value),
-            count: AtomicU64::new(0),
-            wq_read: WaitQueue::default(),
-            wq_write: WaitQueue::default(),
+            val: UnsafeCell::new(val),
+            lock: AtomicUsize::new(0),
+            queue: WaitQueue::default(),
         }
     }
+}
 
-    fn try_acquire_read(&self) -> bool {
-        let mut current = self.count.load(Ordering::Relaxed);
-        loop {
-            // Fail if writer active or writer waiting (Writer Preference)
-            if (current & (WRITER_BIT | WRITER_WAITER_MASK)) != 0 {
-                return false;
-            }
-            // Try to increment reader count
-            let new = current + 1;
-            match self.count.compare_exchange_weak(
-                current,
-                new,
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return true,
-                Err(x) => current = x,
-            }
-        }
-    }
-
-    fn try_acquire_write(&self) -> bool {
-        let mut current = self.count.load(Ordering::Relaxed);
-        loop {
-            // Fail if any readers or writer active
-            if (current & (READER_MASK | WRITER_BIT)) != 0 {
-                return false;
-            }
-            // Try to set writer bit
-            let new = current | WRITER_BIT;
-            match self.count.compare_exchange_weak(
-                current,
-                new,
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return true,
-                Err(x) => current = x,
-            }
-        }
-    }
-
-    /// Like `try_acquire_write()`, but also consumes one pending-writer reservation.
-    fn try_acquire_write_from_waiter(&self) -> bool {
-        let mut current = self.count.load(Ordering::Relaxed);
-        loop {
-            // Fail if any readers or writer active
-            if (current & (READER_MASK | WRITER_BIT)) != 0 {
-                return false;
-            }
-
-            // We assume caller has already incremented writer_waiters, so we decrement it here.
-            // Note: In rare race conditions (e.g. wakeup rollback), we might need to handle
-            // the case where WRITER_WAITER_MASK is 0, but logical flow should prevent this
-            // in the happy path. However, safely, we should just assume we consume one unit.
-
-            let new = (current.saturating_sub(WRITER_WAITER_UNIT)) | WRITER_BIT;
-
-            match self.count.compare_exchange_weak(
-                current,
-                new,
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return true,
-                Err(x) => current = x,
-            }
-        }
-    }
-
-    /// Non-blocking read acquire.
-    pub fn try_read(&self) -> Option<RwSemReadGuard<'_, T>> {
-        if self.try_acquire_read() {
-            Some(RwSemReadGuard { lock: self })
-        } else {
-            None
-        }
-    }
-
-    /// Non-blocking write acquire.
-    pub fn try_write(&self) -> Option<RwSemWriteGuard<'_, T>> {
-        if self.try_acquire_write() {
-            Some(RwSemWriteGuard { lock: self })
-        } else {
-            None
-        }
-    }
-
-    /// Blocking read acquire (uninterruptible).
+impl<T: ?Sized> RwSem<T> {
+    /// Acquires a read mutex and sleep until it can be acquired.
+    ///
+    /// The calling thread will sleep until there are no writers or upgrading
+    /// upreaders present.
+    #[track_caller]
     pub fn read(&self) -> RwSemReadGuard<'_, T> {
-        if self.try_acquire_read() {
-            return RwSemReadGuard { lock: self };
-        }
-
-        loop {
-            match self
-                .wq_read
-                .wait_event_uninterruptible(|| self.try_acquire_read(), None::<fn()>)
-            {
-                Ok(()) => return RwSemReadGuard { lock: self },
-                Err(_) => continue,
-            }
-        }
+        self.queue.wait_until(|| self.try_read())
     }
 
-    /// Blocking write acquire (uninterruptible).
+    /// Acquires a write mutex and sleep until it can be acquired.
+    ///
+    /// The calling thread will sleep until there are no writers, upreaders,
+    /// or readers present.
+    #[track_caller]
     pub fn write(&self) -> RwSemWriteGuard<'_, T> {
-        if self.try_acquire_write() {
-            return RwSemWriteGuard { lock: self };
-        }
+        self.queue.wait_until(|| self.try_write())
+    }
 
-        // Reserve a writer slot (blocks new readers)
-        self.count.fetch_add(WRITER_WAITER_UNIT, Ordering::Acquire);
-
-        loop {
-            let res = self
-                .wq_write
-                .wait_event_uninterruptible(|| self.try_acquire_write_from_waiter(), None::<fn()>);
-
-            match res {
-                Ok(()) => return RwSemWriteGuard { lock: self },
-                Err(_) => {
-                    // This branch usually shouldn't happen for uninterruptible wait unless queue is dead.
-                    // But if it does, we must rollback.
-                    let prev = self.count.fetch_sub(WRITER_WAITER_UNIT, Ordering::Release);
-                    let current = prev - WRITER_WAITER_UNIT;
-
-                    // If we were the last waiter and no writer is active, wake readers
-                    if (current & WRITER_WAITER_MASK) == 0 && (current & WRITER_BIT) == 0 {
-                        self.wq_read.wakeup_all(None);
-                    }
-                    continue; // Or return error? The original code retries?
-                              // Original code for `wait_event_uninterruptible` loops on Err?
-                              // No, original code:
-                              /*
-                              match res {
-                                  Ok(()) => return ...,
-                                  Err(_) => {
-                                      // rollback...
-                                  }
-                              }
-                              */
-                    // Actually, wait_event_uninterruptible returning Err is weird.
-                    // But let's assume we should retry or just return (but we can't return error here).
-                    // The original code looped on `wq_read` failure, but for `wq_write` failure it rolled back and... looped?
-                    // Wait, original `write`:
-                    /*
-                    match res {
-                        Ok(()) => return ...,
-                        Err(_) => {
-                             // rollback
-                             // wake readers
-                        }
-                    }
-                    */
-                    // And the loop continues. So it retries.
-                    // But we just decremented waiter count. We need to increment it again if we retry?
-                    // Yes, the loop starts with `if self.try_acquire_write()`.
-                    // Then reserves slot.
-                    // So rollback is correct.
-                }
-            }
-        }
+    /// Acquires a upread mutex and sleep until it can be acquired.
+    ///
+    /// The calling thread will sleep until there are no writers or upreaders present.
+    #[track_caller]
+    pub fn upread(&self) -> RwSemUpgradeableGuard<'_, T> {
+        self.queue.wait_until(|| self.try_upread())
     }
 
     /// Blocking read acquire (interruptible).
     pub fn read_interruptible(&self) -> Result<RwSemReadGuard<'_, T>, SystemError> {
-        if self.try_acquire_read() {
-            return Ok(RwSemReadGuard { lock: self });
-        }
-
-        self.wq_read
-            .wait_event_interruptible(|| self.try_acquire_read(), None::<fn()>)?;
-
-        Ok(RwSemReadGuard { lock: self })
+        self.queue.wait_until_interruptible(|| self.try_read())
     }
 
     /// Blocking write acquire (interruptible).
     pub fn write_interruptible(&self) -> Result<RwSemWriteGuard<'_, T>, SystemError> {
-        if self.try_acquire_write() {
-            return Ok(RwSemWriteGuard { lock: self });
-        }
-
-        self.count.fetch_add(WRITER_WAITER_UNIT, Ordering::Acquire);
-
-        let res = self
-            .wq_write
-            .wait_event_interruptible(|| self.try_acquire_write_from_waiter(), None::<fn()>);
-
-        match res {
-            Ok(()) => Ok(RwSemWriteGuard { lock: self }),
-            Err(e) => {
-                // Rollback reservation
-                let prev = self.count.fetch_sub(WRITER_WAITER_UNIT, Ordering::Release);
-                let current = prev - WRITER_WAITER_UNIT;
-
-                if (current & WRITER_WAITER_MASK) == 0 && (current & WRITER_BIT) == 0 {
-                    self.wq_read.wakeup_all(None);
-                }
-                Err(e)
-            }
-        }
+        self.queue.wait_until_interruptible(|| self.try_write())
     }
 
-    fn read_unlock(&self) {
-        let prev = self.count.fetch_sub(1, Ordering::Release);
-        let current = prev - 1;
-
-        // If last reader and writers are waiting, wake one writer
-        if (current & READER_MASK) == 0 && (current & WRITER_WAITER_MASK) > 0 {
-            self.wq_write.wakeup(None);
-        }
-    }
-
-    fn write_unlock(&self) {
-        let prev = self.count.fetch_and(!WRITER_BIT, Ordering::Release);
-        let current = prev & !WRITER_BIT;
-
-        if (current & WRITER_WAITER_MASK) > 0 {
-            // Wake one writer
-            self.wq_write.wakeup(None);
+    /// Attempts to acquire a read lock.
+    ///
+    /// This function will never sleep and will return immediately.
+    pub fn try_read(&self) -> Option<RwSemReadGuard<'_, T>> {
+        let lock = self.lock.fetch_add(READER, Acquire);
+        if lock & (WRITER | BEING_UPGRADED | MAX_READER) == 0 {
+            Some(RwSemReadGuard {
+                inner: self,
+                _nosend: PhantomData,
+            })
         } else {
-            // Wake all readers
-            self.wq_read.wakeup_all(None);
+            self.lock.fetch_sub(READER, Release);
+            None
+        }
+    }
+
+    /// Attempts to acquire a write lock.
+    ///
+    /// This function will never sleep and will return immediately.
+    pub fn try_write(&self) -> Option<RwSemWriteGuard<'_, T>> {
+        if self
+            .lock
+            .compare_exchange(0, WRITER, Acquire, Relaxed)
+            .is_ok()
+        {
+            Some(RwSemWriteGuard {
+                inner: self,
+                _nosend: PhantomData,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to acquire a upread mutex.
+    ///
+    /// This function will never sleep and will return immediately.
+    pub fn try_upread(&self) -> Option<RwSemUpgradeableGuard<'_, T>> {
+        let lock = self.lock.fetch_or(UPGRADEABLE_READER, Acquire) & (WRITER | UPGRADEABLE_READER);
+        if lock == 0 {
+            return Some(RwSemUpgradeableGuard {
+                inner: self,
+                _nosend: PhantomData,
+            });
+        } else if lock == WRITER {
+            self.lock.fetch_sub(UPGRADEABLE_READER, Release);
+        }
+        None
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// This method is zero-cost: By holding a mutable reference to the lock, the compiler has
+    /// already statically guaranteed that access to the data is exclusive.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.val.get_mut()
+    }
+}
+
+impl<T: ?Sized> Deref for RwSemReadGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.inner.val.get() }
+    }
+}
+
+impl<T: ?Sized> Drop for RwSemReadGuard<'_, T> {
+    fn drop(&mut self) {
+        // When there are no readers, wake up a waiting writer.
+        if self.inner.lock.fetch_sub(READER, Release) == READER {
+            self.inner.queue.wake_one();
         }
     }
 }
 
-impl<T> Deref for RwSemReadGuard<'_, T> {
+impl<T: ?Sized> Deref for RwSemWriteGuard<'_, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.lock.data.get() }
+    fn deref(&self) -> &T {
+        unsafe { &*self.inner.val.get() }
     }
 }
 
-impl<T> Deref for RwSemWriteGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.lock.data.get() }
-    }
-}
-
-impl<T> DerefMut for RwSemWriteGuard<'_, T> {
+impl<T: ?Sized> DerefMut for RwSemWriteGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.lock.data.get() }
+        unsafe { &mut *self.inner.val.get() }
     }
 }
 
 impl<'a, T> RwSemWriteGuard<'a, T> {
-    /// Downgrade a write guard into a read guard without releasing the lock.
-    pub fn downgrade(self) -> RwSemReadGuard<'a, T> {
-        let this = ManuallyDrop::new(self);
-        let sem = this.lock;
-
-        // Atomically transition from Writer to 1 Reader.
-        // writer bit is 1<<32. reader is +1.
-        // We want to subtract (WRITER_BIT - 1).
-        let prev = sem.count.fetch_sub(WRITER_BIT - 1, Ordering::Release);
-        let current = prev - (WRITER_BIT - 1);
-
-        // If no writer waiters, wake other readers
-        if (current & WRITER_WAITER_MASK) == 0 {
-            sem.wq_read.wakeup_all(None);
+    /// Atomically downgrades a write guard to an upgradeable reader guard.
+    ///
+    /// This method always succeeds because the lock is exclusively held by the writer.
+    pub fn downgrade(mut self) -> RwSemUpgradeableGuard<'a, T> {
+        loop {
+            self = match self.try_downgrade() {
+                Ok(guard) => return guard,
+                Err(e) => e,
+            };
         }
+    }
 
-        RwSemReadGuard { lock: sem }
+    /// This is not exposed as a public method to prevent intermediate lock states from affecting the
+    /// downgrade process.
+    fn try_downgrade(self) -> Result<RwSemUpgradeableGuard<'a, T>, Self> {
+        let inner = self.inner;
+        let res = self
+            .inner
+            .lock
+            .compare_exchange(WRITER, UPGRADEABLE_READER, AcqRel, Relaxed);
+        if res.is_ok() {
+            core::mem::forget(self);
+            Ok(RwSemUpgradeableGuard {
+                inner,
+                _nosend: PhantomData,
+            })
+        } else {
+            Err(self)
+        }
     }
 }
 
-impl<T> Drop for RwSemReadGuard<'_, T> {
+impl<T: ?Sized> Drop for RwSemWriteGuard<'_, T> {
     fn drop(&mut self) {
-        self.lock.read_unlock();
+        self.inner.lock.fetch_and(!WRITER, Release);
+
+        // When the current writer releases, wake up all the sleeping threads.
+        // All awakened threads may include readers and writers.
+        // Thanks to the `wait_until` method, either all readers
+        // continue to execute or one writer continues to execute.
+        self.inner.queue.wake_all();
     }
 }
 
-impl<T> Drop for RwSemWriteGuard<'_, T> {
+impl<T: ?Sized> Deref for RwSemUpgradeableGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.inner.val.get() }
+    }
+}
+
+impl<'a, T> RwSemUpgradeableGuard<'a, T> {
+    /// Upgrades this upread guard to a write guard atomically.
+    ///
+    /// After calling this method, subsequent readers will be blocked
+    /// while previous readers remain unaffected.
+    ///
+    /// The calling thread will not sleep, but spin to wait for the existing
+    /// reader to be released.
+    pub fn upgrade(mut self) -> RwSemWriteGuard<'a, T> {
+        self.inner.lock.fetch_or(BEING_UPGRADED, Acquire);
+        loop {
+            self = match self.try_upgrade() {
+                Ok(guard) => return guard,
+                Err(e) => e,
+            };
+        }
+    }
+
+    /// Attempts to upgrade this upread guard to a write guard atomically.
+    ///
+    /// This function will return immediately.
+    pub fn try_upgrade(self) -> Result<RwSemWriteGuard<'a, T>, Self> {
+        let res = self.inner.lock.compare_exchange(
+            UPGRADEABLE_READER | BEING_UPGRADED,
+            WRITER | UPGRADEABLE_READER,
+            AcqRel,
+            Relaxed,
+        );
+        if res.is_ok() {
+            let inner = self.inner;
+            core::mem::forget(self);
+            Ok(RwSemWriteGuard {
+                inner,
+                _nosend: PhantomData,
+            })
+        } else {
+            Err(self)
+        }
+    }
+}
+
+impl<T: ?Sized> Drop for RwSemUpgradeableGuard<'_, T> {
     fn drop(&mut self) {
-        self.lock.write_unlock();
+        let res = self.inner.lock.fetch_sub(UPGRADEABLE_READER, Release);
+        if res == UPGRADEABLE_READER {
+            self.inner.queue.wake_all();
+        }
     }
 }


### PR DESCRIPTION
- 重构 RwSem 状态表示，使用 64 位原子整数和位域编码
- 新增可升级读锁支持，提供原子升级/降级功能
- 重构 WaitQueue 核心机制，以 wait_until 为基础 API 消除唤醒丢失
- 统一等待队列设计，使用单一队列管理所有等待者
- 优化锁获取性能，实现快速路径和慢速路径分离

---

# 之前实现的rwsem的问题


### Bug 1: `try_acquire_read` 过于激进的拒绝

```rust
// rwsem.rs:72
if (current & (WRITER_BIT | WRITER_WAITER_MASK)) != 0 {
    return false;
}
```

即使没有活跃写者，只要有写者**等待**，所有读者都被拒绝。这在高并发读场景会导致读者饥饿。

**修复建议**：只在有活跃写者时拒绝读者，对于写者等待的情况，采用更公平的策略。

### Bug 2: `write()` 方法的错误恢复逻辑

```rust
// rwsem.rs:179-230
pub fn write(&self) -> RwSemWriteGuard<'_, T> {
    // ...
    self.count.fetch_add(WRITER_WAITER_UNIT, Ordering::Acquire);  // 增加 waiter 计数

    loop {
        let res = self.wq_write.wait_event_uninterruptible(...);
        match res {
            Ok(()) => return RwSemWriteGuard { lock: self },
            Err(_) => {
                // 回滚 waiter 计数
                let prev = self.count.fetch_sub(WRITER_WAITER_UNIT, Ordering::Release);
                // ...
                continue;  // 重新循环，但没有重新增加 waiter 计数！
            }
        }
    }
}
```

当 `wait_event_uninterruptible` 返回错误并重试时，`writer_waiter` 计数已经被减少，但循环继续时没有重新增加。这可能导致 `writer_waiter_mask` 计数不正确。

### Bug 3: 唤醒时机和原子性问题

```rust
// rwsem.rs:282-293
fn write_unlock(&self) {
    let prev = self.count.fetch_and(!WRITER_BIT, Ordering::Release);
    let current = prev & !WRITER_BIT;

    // 窗口期：锁已释放，但唤醒还未发生

    if (current & WRITER_WAITER_MASK) > 0 {
        self.wq_write.wakeup(None);  // 只唤醒一个写者
    } else {
        self.wq_read.wakeup_all(None);
    }
}
```

在 `fetch_and` 和 `wakeup` 之间，其他线程可能：
1. 看到锁已释放
2. 尝试获取锁但因为看到 waiter 而失败
3. 进入等待队列
4. 但 `wakeup` 已经执行完毕

### Bug 4: `read_unlock` 的唤醒条件

```rust
// rwsem.rs:272-279
fn read_unlock(&self) {
    let prev = self.count.fetch_sub(1, Ordering::Release);
    let current = prev - 1;

    // 只在最后一个读者退出且有写者等待时唤醒
    if (current & READER_MASK) == 0 && (current & WRITER_WAITER_MASK) > 0 {
        self.wq_write.wakeup(None);
    }
}
```

如果最后一个读者退出时，有写者**和**读者都在等待：
- 只唤醒了写者
- 但写者可能因为某种原因获取失败
- 此时读者仍在等待，但不会被唤醒

## 5. 与 Linux 实现的对比

| 特性 | Linux rwsem | DragonOS RwSem | 问题 |
|------|-------------|----------------|------|
| 等待队列 | 单一链表，按顺序 | 两个独立队列 | 可能导致顺序问题 |
| 唤醒机制 | wake_q 批量唤醒 | 直接唤醒 | 可能有原子性问题 |
| 写者等待标记 | FLAG_WAITERS 独立位 | 嵌入计数器高位 | 语义不同 |
| 公平性 | HANDOFF 机制 | 无 | 可能饥饿 |
| 快速路径读 | 有写者等待仍可获取（特定条件下） | 有写者等待必定失败 | 读者饥饿 |