### PR TITLE
refactor(mm): 优化地址空间切换与锁机制

### DIFF
--- a/kernel/src/arch/riscv64/process/mod.rs
+++ b/kernel/src/arch/riscv64/process/mod.rs
@@ -172,12 +172,11 @@ impl ProcessManager {
         Self::switch_process_fpu(&prev, &next);
         Self::switch_local_context(&prev, &next);
 
-        // 切换地址空间
-        let next_addr_space = next.basic().user_vm().as_ref().unwrap().clone();
+        // 切换地址空间（无锁快速路径）
+        let next_addr_space = next.basic().user_vm().unwrap();
         compiler_fence(Ordering::SeqCst);
 
-        next_addr_space.read().user_mapper.utable.make_current();
-        drop(next_addr_space);
+        next_addr_space.make_current();
         compiler_fence(Ordering::SeqCst);
 
         // debug!("current sum={}, prev sum={}, next_sum={}", riscv::register::sstatus::read().sum(), prev.arch_info_irqsave().sstatus.sum(), next.arch_info_irqsave().sstatus.sum());

--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -310,7 +310,7 @@ impl X86_64MMArch {
         };
 
         let current_address_space: Arc<AddressSpace> = AddressSpace::current().unwrap();
-        let mut space_guard = current_address_space.write_irqsave();
+        let mut space_guard = current_address_space.write();
         let mut fault;
         loop {
             let vma = space_guard.mappings.find_nearest(address);

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -395,12 +395,11 @@ impl ProcessManager {
         // 切换gsbase
         Self::switch_gsbase(&prev, &next);
 
-        // 切换地址空间
-        let next_addr_space = next.basic().user_vm().as_ref().unwrap().clone();
+        // 切换地址空间（无锁快速路径）
+        let next_addr_space = next.basic().user_vm().unwrap();
         compiler_fence(Ordering::SeqCst);
 
-        next_addr_space.read().user_mapper.utable.make_current();
-        drop(next_addr_space);
+        next_addr_space.make_current();
         compiler_fence(Ordering::SeqCst);
         // 切换内核栈
 

--- a/kernel/src/libs/elf.rs
+++ b/kernel/src/libs/elf.rs
@@ -36,7 +36,7 @@ use crate::{
     syscall::user_access::{clear_user, copy_to_user},
 };
 
-use super::rwlock::RwLockWriteGuard;
+use crate::libs::rwsem::RwSemWriteGuard;
 
 // 存放跟架构相关的Elf属性，
 pub trait ElfArch: Clone + Copy + Debug {
@@ -131,7 +131,7 @@ impl ElfLoader {
     /// - `prot_flags` - 本次映射的权限
     fn set_elf_brk(
         &self,
-        user_vm_guard: &mut RwLockWriteGuard<'_, InnerAddressSpace>,
+        user_vm_guard: &mut RwSemWriteGuard<'_, InnerAddressSpace>,
         start: VirtAddr,
         end: VirtAddr,
         prot_flags: ProtFlags,
@@ -199,7 +199,7 @@ impl ElfLoader {
     /// 返回映射的虚拟地址和成功标志
     #[allow(clippy::too_many_arguments)]
     fn map_readonly_segment(
-        user_vm_guard: &mut RwLockWriteGuard<'_, InnerAddressSpace>,
+        user_vm_guard: &mut RwSemWriteGuard<'_, InnerAddressSpace>,
         param: &ExecParam,
         addr_to_map: VirtAddr,
         prot: ProtFlags,
@@ -297,7 +297,7 @@ impl ElfLoader {
     /// - `Ok((VirtAddr, bool))`：如果成功加载，则bool值为true，否则为false. VirtAddr为加载的地址
     #[allow(clippy::too_many_arguments)]
     fn load_elf_segment(
-        user_vm_guard: &mut RwLockWriteGuard<'_, InnerAddressSpace>,
+        user_vm_guard: &mut RwSemWriteGuard<'_, InnerAddressSpace>,
         param: &mut ExecParam,
         phent: &ProgramHeader,
         mut addr_to_map: VirtAddr,

--- a/kernel/src/mm/syscall/sys_process_vm.rs
+++ b/kernel/src/mm/syscall/sys_process_vm.rs
@@ -301,7 +301,7 @@ fn do_process_vm_readv(
         }
 
         // Read from remote process's address space
-        let target_vm_guard = target_vm.read_irqsave();
+        let target_vm_guard = target_vm.read();
 
         // Check if remote address is valid in target's address space
         if target_vm_guard.mappings.contains(remote_addr).is_none() {
@@ -463,7 +463,7 @@ fn do_process_vm_writev(
         }
 
         // Write to remote process's address space
-        let target_vm_guard = target_vm.read_irqsave();
+        let target_vm_guard = target_vm.read();
 
         // Check if remote address is valid in target's address space
         if target_vm_guard.mappings.contains(remote_addr).is_none() {

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -199,7 +199,7 @@ fn do_execve_switch_user_vm(new_vm: Arc<AddressSpace>) -> Option<Arc<AddressSpac
     );
 
     // 切换到新的用户地址空间
-    unsafe { new_vm.read().user_mapper.utable.make_current() };
+    unsafe { new_vm.make_current() };
 
     drop(irq_guard);
 

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -291,7 +291,7 @@ impl ProcessManager {
             unsafe { new_pcb.basic_mut().set_user_vm(Some(old_address_space)) };
             return Ok(());
         }
-        let new_address_space = old_address_space.write_irqsave().try_clone().unwrap_or_else(|e| {
+        let new_address_space = old_address_space.write().try_clone().unwrap_or_else(|e| {
             panic!(
                 "copy_mm: Failed to clone address space of current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.raw_pid(), new_pcb.raw_pid(), e

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -913,7 +913,7 @@ fn check_user_access_by_page_table(addr: VirtAddr, size: usize, check_write: boo
     // Calculate number of pages to check (rounded up)
     let pages = aligned_size / MMArch::PAGE_SIZE;
 
-    let guard = vm.read_irqsave();
+    let guard = vm.read();
     for i in 0..pages {
         let page_addr = aligned_addr + i * MMArch::PAGE_SIZE;
         let flags = match guard.user_mapper.utable.translate(VirtAddr::new(page_addr)) {
@@ -1032,7 +1032,7 @@ pub fn user_accessible_len(addr: VirtAddr, size: usize, check_write: bool) -> us
         None => return 0,
     };
 
-    let vma_read_guard = vm.read_irqsave();
+    let vma_read_guard = vm.read();
     let mappings = &vma_read_guard.mappings;
 
     let mut checked = 0usize;


### PR DESCRIPTION
- 在进程切换时使用无锁快速路径切换地址空间，提升调度性能
- 将地址空间内部锁从RwLock替换为RwSem，支持I/O操作时的等待
- 为AddressSpace添加table_paddr字段和make_current方法，支持无锁页表切换
- 统一将read_irqsave/write_irqsave替换为read/write，简化锁使用