### PR TITLE
refactor(gvisor): 优化测试输出配置并移除冗余日志

### DIFF
--- a/user/apps/tests/syscall/gvisor/monitor_test_results.sh
+++ b/user/apps/tests/syscall/gvisor/monitor_test_results.sh
@@ -108,8 +108,6 @@ show_diagnostic_info() {
     fi
 
     echo "[监控] 串口文件大小: $(du -h "$SERIAL_FILE" 2>/dev/null | cut -f1 || echo "未知")"
-    echo "[监控] 最近100行输出:"
-    tail -n 100 "$SERIAL_FILE" 2>/dev/null | sed 's/^/  /'
     echo "[监控] ================================"
 }
 

--- a/user/apps/tests/syscall/gvisor/run_tests.sh
+++ b/user/apps/tests/syscall/gvisor/run_tests.sh
@@ -54,4 +54,4 @@ adjust_readv_blocklist() {
 adjust_readv_blocklist
 
 cd "$SYSCALL_TEST_DIR" || exit 1
-./gvisor-test-runner --stdout
+./gvisor-test-runner

--- a/user/apps/tests/syscall/gvisor/runner/src/lib_sync.rs
+++ b/user/apps/tests/syscall/gvisor/runner/src/lib_sync.rs
@@ -65,7 +65,7 @@ pub struct Config {
     pub temp_dir: PathBuf,
     pub extra_blocklist_dirs: Vec<PathBuf>,
     pub test_patterns: Vec<String>,
-    pub output_to_stdout: bool,  // 是否输出到控制台而不是文件
+    pub output_to_stdout: bool, // 是否输出到控制台而不是文件
 }
 
 impl Default for Config {
@@ -87,7 +87,7 @@ impl Default for Config {
             ),
             extra_blocklist_dirs: Vec::new(),
             test_patterns: Vec::new(),
-            output_to_stdout: false,
+            output_to_stdout: true,
         }
     }
 }
@@ -333,7 +333,10 @@ impl TestRunner {
         // 根据配置决定输出方式
         let (stdout, stderr) = if self.config.output_to_stdout {
             // 单个测例：直接输出到控制台
-            (std::process::Stdio::inherit(), std::process::Stdio::inherit())
+            (
+                std::process::Stdio::inherit(),
+                std::process::Stdio::inherit(),
+            )
         } else {
             // 批量测试：输出到文件
             // 确保结果目录存在
@@ -354,7 +357,10 @@ impl TestRunner {
             }
             let out = out?;
             let err = out.try_clone()?;
-            (std::process::Stdio::from(out), std::process::Stdio::from(err))
+            (
+                std::process::Stdio::from(out),
+                std::process::Stdio::from(err),
+            )
         };
 
         // 构造并执行命令（不使用 shell，不捕获输出，不创建管道）

--- a/user/apps/tests/syscall/gvisor/runner/src/main.rs
+++ b/user/apps/tests/syscall/gvisor/runner/src/main.rs
@@ -81,10 +81,10 @@ fn main() -> Result<()> {
                 .help("测试名称模式"),
         )
         .arg(
-            Arg::new("stdout")
-                .long("stdout")
+            Arg::new("no-stdout")
+                .long("no-stdout")
                 .action(clap::ArgAction::SetTrue)
-                .help("将测试输出直接显示到控制台，而不是保存到文件"),
+                .help("将测试输出保存到文件，而不是直接显示到控制台"),
         );
 
     let matches = app.get_matches();
@@ -117,8 +117,8 @@ fn main() -> Result<()> {
         config.test_patterns = patterns.cloned().collect();
     }
 
-    // 设置输出方式
-    config.output_to_stdout = matches.get_flag("stdout");
+    // 设置输出方式（默认为true，--no-stdout 设为 false）
+    config.output_to_stdout = !matches.get_flag("no-stdout");
 
     // 创建测试运行器
     let runner = TestRunner::new(config);


### PR DESCRIPTION
- 将测试运行器默认输出方式改为控制台，并添加`--no-stdout`选项以保存到文件
- 移除监控脚本中显示最近100行串口输出的冗余日志
- 清理代码格式和注释