### PR TITLE
fix(net): start iface id at 1 to match Linux ifindex semantics

### DIFF
--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -17,6 +17,6 @@ pub mod tcp_listener_backlog;
 
 /// 生成网络接口的id (全局自增)
 pub fn generate_iface_id() -> usize {
-    static IFACE_ID: AtomicUsize = AtomicUsize::new(0);
+    static IFACE_ID: AtomicUsize = AtomicUsize::new(1);
     return IFACE_ID.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
 }


### PR DESCRIPTION
Linux ifindex must be non-zero. Make generate_iface_id() start from 1 so loopback and other devices never get ifindex 0, fixing raw socket tests relying on if_nametoindex("lo") returning a valid index.