### PR TITLE
fix(mm/pagecache): track vma on filemap prefault

### DIFF
--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -110,7 +110,11 @@ impl InnerPageCache {
             unsafe {
                 let dst = page_guard.as_slice_mut();
                 dst[..page_len].copy_from_slice(&buf[buf_offset..buf_offset + page_len]);
+                if page_len < MMArch::PAGE_SIZE {
+                    dst[page_len..].fill(0);
+                }
             }
+            page_guard.add_flags(PageFlags::PG_UPTODATE);
 
             self.add_page(start_page_index + i, &page);
         }
@@ -164,6 +168,7 @@ impl InnerPageCache {
             unsafe {
                 page_guard.as_slice_mut().fill(0);
             }
+            page_guard.add_flags(PageFlags::PG_UPTODATE);
 
             self.add_page(page_index, &page);
         }

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -21,7 +21,7 @@ use crate::{
     init::initcall::INITCALL_CORE,
     libs::{
         mutex::{Mutex, MutexGuard},
-        rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
+        rwsem::{RwSem, RwSemReadGuard, RwSemUpgradeableGuard, RwSemWriteGuard},
     },
     process::{ProcessControlBlock, ProcessManager},
     time::{sleep::nanosleep, PosixTimeSpec},
@@ -569,6 +569,10 @@ impl Page {
 
     pub fn read(&self) -> RwSemReadGuard<'_, InnerPage> {
         self.inner.read()
+    }
+
+    pub fn upread(&self) -> RwSemUpgradeableGuard<'_, InnerPage> {
+        self.inner.upread()
     }
 
     pub fn write(&self) -> RwSemWriteGuard<'_, InnerPage> {


### PR DESCRIPTION
- Mark filemap prefaulted pages with insert_vma to keep map_count consistent with mappings.
- Avoid redundant mapping in filemap_map_pages when a PTE already exists.
- Ensure page-cache created pages are fully initialized and UPTODATE.

**Motivation**

Setting PG_UPTODATE enables prefault mapping via filemap_map_pages. Those pages were mapped without updating vma_set, causing map_count to stay at 0 and enabling reclaim/writeback paths to treat mapped pages as unmapped, leading to mmap hangs. The fix aligns VMA tracking with prefault mappings and adds diagnostics to validate mapping correctness.