### PR TITLE
refactor(page_cache): 引入PageCacheBackend抽象层并重构相关文件系统

### DIFF
--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1,6 +1,6 @@
 use crate::{
     filesystem::{
-        page_cache::PageCache,
+        page_cache::{PageCache, SyncPageCacheBackend},
         vfs::{
             self, utils::DName, vcore::generate_inode_id, FilePrivateData, IndexNode, InodeFlags,
             InodeId, InodeMode,
@@ -523,7 +523,13 @@ impl LockedExt4Inode {
         // 设置self_ref
         guard.self_ref = Arc::downgrade(&inode);
 
-        let page_cache = PageCache::new(Some(Arc::downgrade(&inode) as Weak<dyn IndexNode>));
+        let backend = Arc::new(SyncPageCacheBackend::new(
+            Arc::downgrade(&inode) as Weak<dyn IndexNode>
+        ));
+        let page_cache = PageCache::new(
+            Some(Arc::downgrade(&inode) as Weak<dyn IndexNode>),
+            Some(backend),
+        );
         guard.page_cache = Some(page_cache);
 
         drop(guard);

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -398,6 +398,7 @@ impl PageReclaimer {
         };
         let paddr = guard.phys_address();
         let inode = page_cache.inode().clone().unwrap().upgrade().unwrap();
+        let backend = page_cache.backend();
 
         for vma in guard.vma_set() {
             let address_space = vma.lock().address_space().and_then(|x| x.upgrade());
@@ -437,17 +438,22 @@ impl PageReclaimer {
         };
 
         if len > 0 {
-            let r = inode.write_direct(
-                page_start,
-                len,
-                unsafe {
-                    core::slice::from_raw_parts(
-                        MMArch::phys_2_virt(paddr).unwrap().data() as *const u8,
-                        len,
-                    )
-                },
-                Mutex::new(FilePrivateData::Unused).lock(),
-            );
+            let data = unsafe {
+                core::slice::from_raw_parts(
+                    MMArch::phys_2_virt(paddr).unwrap().data() as *const u8,
+                    len,
+                )
+            };
+            let r = if let Some(backend) = backend {
+                backend.write_page(page_index, data)
+            } else {
+                inode.write_direct(
+                    page_start,
+                    len,
+                    data,
+                    Mutex::new(FilePrivateData::Unused).lock(),
+                )
+            };
             if let Err(e) = r {
                 log::error!(
                     "page writeback failed: offset={}, len={}, err={:?}",

--- a/kernel/src/perf/bpf.rs
+++ b/kernel/src/perf/bpf.rs
@@ -235,7 +235,7 @@ impl BpfPerfEvent {
             data: SpinLock::new(BpfPerfEventData {
                 enabled: false,
                 mmap_page: RingPage::empty(),
-                page_cache: PageCache::new(None),
+                page_cache: PageCache::new(None, None),
                 offset: 0,
             }),
         }


### PR DESCRIPTION
- 新增PageCacheBackend trait和SyncPageCacheBackend实现，用于抽象页面缓存后端操作
- 修改PageCache构造函数，支持传入自定义后端
- 重构ext4、fat、tmpfs文件系统使用新的PageCache后端机制
- 优化页面回收和预读逻辑，使用后端接口进行读写操作
- 修复页面错误处理逻辑，移除直接文件读取改用page_cache.read_pages()