### PR TITLE
feat(ipc/signal): 重构 nanosleep 重启函数以支持进程/线程 CPU 时间等待

### DIFF
--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -319,6 +319,10 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
 
         sighand.set_group_exec_notify_count(kill_list.len() as isize);
 
+        for task in kill_list.iter() {
+            task.exit_signal.store(Signal::INVALID, Ordering::SeqCst);
+        }
+
         for task in kill_list {
             let _ = Signal::SIGKILL.send_signal_info_to_pcb(None, task, PidType::PID);
         }


### PR DESCRIPTION
- 新增`ktime_now`和`calc_remaining`辅助函数
- 在`RestartFnNanosleep`中为`ProcessCPUTimeID`和`ThreadCPUTimeID` 实现基于等待队列的精确等待
- 在`de_thread`中清除待终止线程的退出信号，避免信号误传