### PR TITLE
feat(net): 新增TCP/IP套接字选项支持与Cork缓冲区超时机制

### DIFF
--- a/kernel/src/net/socket/inet/stream/constants.rs
+++ b/kernel/src/net/socket/inet/stream/constants.rs
@@ -21,6 +21,23 @@ pub const DEFAULT_TCP_MSS: usize = 536;
 /// 默认SYN重传次数
 pub const DEFAULT_TCP_SYNCNT: i32 = 6;
 
+/// TCP_FIN_TIMEOUT 默认值（秒）
+/// 来自Linux内核: include/net/tcp.h (TCP_TIMEWAIT_LEN)
+pub const TCP_FIN_TIMEOUT_DEFAULT: i32 = 60;
+
+/// TCP_LINGER2 最大值（秒）
+/// 来自Linux内核: include/net/tcp.h (TCP_FIN_TIMEOUT_MAX)
+pub const TCP_FIN_TIMEOUT_MAX: i32 = 120;
+
+/// TCP_CORK flush timeout (microseconds). Linux uses ~200ms.
+pub const TCP_CORK_FLUSH_TIMEOUT_US: u64 = 200_000;
+
+/// Default IPv4 multicast TTL for sockets.
+pub const IP_MULTICAST_TTL_DEFAULT: i32 = 1;
+
+/// Default IPv4 multicast loopback behavior (enabled).
+pub const IP_MULTICAST_LOOP_DEFAULT: bool = true;
+
 // ========== Socket缓冲区常量 - 参考Linux内核 include/net/sock.h ==========
 
 /// 最小socket缓冲区基本单位（用于SO_SNDBUF/SO_RCVBUF的clamp下限）

--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -712,8 +712,8 @@ impl Established {
                         .map_err(|_| SystemError::ECONNABORTED)
                 } else {
                     match socket.state() {
-                        smoltcp::socket::tcp::State::Closed
-                        | smoltcp::socket::tcp::State::TimeWait
+                        smoltcp::socket::tcp::State::Closed => Err(SystemError::ECONNRESET),
+                        smoltcp::socket::tcp::State::TimeWait
                         | smoltcp::socket::tcp::State::Closing
                         | smoltcp::socket::tcp::State::LastAck => Err(SystemError::EPIPE),
                         _ => Err(SystemError::EAGAIN_OR_EWOULDBLOCK),

--- a/kernel/src/net/socket/inet/stream/stream_core.rs
+++ b/kernel/src/net/socket/inet/stream/stream_core.rs
@@ -66,6 +66,16 @@ pub struct TcpSocketOptions {
     /// SO_LINGER
     pub(crate) linger_onoff: AtomicI32,
     pub(crate) linger_linger: AtomicI32,
+
+    /// IP_MULTICAST_TTL
+    pub(crate) ip_multicast_ttl: AtomicI32,
+    /// IP_MULTICAST_LOOP
+    pub(crate) ip_multicast_loop: AtomicBool,
+
+    /// SO_OOBINLINE
+    pub(crate) so_oobinline: AtomicBool,
+    /// TCP_LINGER2 (seconds; 0 means default)
+    pub(crate) tcp_linger2_secs: AtomicI32,
 }
 
 impl TcpSocketOptions {
@@ -97,6 +107,12 @@ impl TcpSocketOptions {
 
             linger_onoff: AtomicI32::new(0),
             linger_linger: AtomicI32::new(0),
+
+            so_oobinline: AtomicBool::new(false),
+            tcp_linger2_secs: AtomicI32::new(0),
+
+            ip_multicast_ttl: AtomicI32::new(constants::IP_MULTICAST_TTL_DEFAULT),
+            ip_multicast_loop: AtomicBool::new(constants::IP_MULTICAST_LOOP_DEFAULT),
         }
     }
 }
@@ -121,6 +137,7 @@ pub struct TcpSocket {
     pub(crate) options: TcpSocketOptions,
     pub(crate) cork_buf: Mutex<Vec<u8>>,
     pub(crate) cork_flush_in_progress: AtomicBool,
+    pub(crate) cork_timer_active: AtomicBool,
     pub(crate) recv_shutdown: ShutdownRecvTracker,
 }
 
@@ -148,6 +165,7 @@ impl TcpSocket {
             options: TcpSocketOptions::new(),
             cork_buf: Mutex::new(Vec::new()),
             cork_flush_in_progress: AtomicBool::new(false),
+            cork_timer_active: AtomicBool::new(false),
             recv_shutdown: ShutdownRecvTracker::new(),
         }
     }
@@ -315,6 +333,26 @@ impl TcpSocket {
     #[inline]
     pub(crate) fn linger_linger(&self) -> &AtomicI32 {
         &self.options.linger_linger
+    }
+
+    #[inline]
+    pub(crate) fn ip_multicast_ttl(&self) -> &AtomicI32 {
+        &self.options.ip_multicast_ttl
+    }
+
+    #[inline]
+    pub(crate) fn ip_multicast_loop(&self) -> &AtomicBool {
+        &self.options.ip_multicast_loop
+    }
+
+    #[inline]
+    pub(crate) fn so_oobinline_enabled(&self) -> &AtomicBool {
+        &self.options.so_oobinline
+    }
+
+    #[inline]
+    pub(crate) fn tcp_linger2_secs(&self) -> &AtomicI32 {
+        &self.options.tcp_linger2_secs
     }
 
     #[inline]

--- a/kernel/src/net/socket/posix/ip_option.rs
+++ b/kernel/src/net/socket/posix/ip_option.rs
@@ -13,6 +13,8 @@ pub enum IpOption {
     MTU_DISCOVER = 10,
     RECVTTL = 12,
     RECVTOS = 13,
+    MULTICAST_TTL = 33,
+    MULTICAST_LOOP = 34,
 }
 
 impl TryFrom<u32> for IpOption {

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -97,6 +97,7 @@ raw_socket_test
 raw_socket_icmp_test
 raw_socket_hdrincl_test
 tcp_socket_test
+socket_ip_tcp_generic_loopback_test
 
 # 信号处理测试
 sigaction_test


### PR DESCRIPTION
- 新增TCP_LINGER2、IP_MULTICAST_TTL、IP_MULTICAST_LOOP、SO_OOBINLINE等套接字选项 的读写支持
- 为TCP_CORK选项实现自动超时刷新机制，防止数据在缓冲区中滞留过久
- 在TCP状态处理中区分Closed与TimeWait状态，返回更精确的错误码
- 新增相关网络常量定义，提升与Linux内核的兼容性
- 更新gvisor测试白名单，添加socket_ip_tcp_generic_loopback_test