### PR TITLE
feat(mm): 新增页缓存统计与监控功能

### DIFF
--- a/kernel/src/filesystem/procfs/meminfo.rs
+++ b/kernel/src/filesystem/procfs/meminfo.rs
@@ -3,6 +3,7 @@
 //! 这个文件展示了系统的内存使用情况
 
 use crate::libs::mutex::MutexGuard;
+use crate::mm::MemoryManagementArch;
 use crate::{
     filesystem::{
         procfs::{
@@ -12,6 +13,7 @@ use crate::{
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     mm::allocator::page_frame::FrameAllocator,
+    mm::page_cache_stats,
 };
 use alloc::{
     borrow::ToOwned,
@@ -35,8 +37,12 @@ impl MeminfoFileOps {
 
     fn generate_meminfo_content() -> Vec<u8> {
         use crate::arch::mm::LockedFrameAllocator;
+        use crate::arch::MMArch;
 
         let usage = unsafe { LockedFrameAllocator.usage() };
+        let stats = page_cache_stats::snapshot();
+        let page_kb = (MMArch::PAGE_SIZE >> 10) as u64;
+        let cached_pages = stats.file_pages.saturating_sub(stats.shmem_pages);
 
         let mut data: Vec<u8> = vec![];
 
@@ -51,6 +57,40 @@ impl MeminfoFileOps {
                 .as_bytes()
                 .to_owned(),
         );
+
+        data.append(&mut format!("Buffers:\t{} kB\n", 0u64).as_bytes().to_owned());
+        data.append(
+            &mut format!("Cached:\t\t{} kB\n", cached_pages * page_kb)
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(
+            &mut format!("Dirty:\t\t{} kB\n", stats.file_dirty * page_kb)
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(
+            &mut format!("Writeback:\t{} kB\n", stats.file_writeback * page_kb)
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(
+            &mut format!("Mapped:\t\t{} kB\n", stats.file_mapped * page_kb)
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(
+            &mut format!("Shmem:\t\t{} kB\n", stats.shmem_pages * page_kb)
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(&mut format!("Slab:\t\t{} kB\n", 0u64).as_bytes().to_owned());
+        data.append(
+            &mut format!("SReclaimable:\t{} kB\n", 0u64)
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(&mut format!("SUnreclaim:\t{} kB\n", 0u64).as_bytes().to_owned());
 
         // 去除多余的 \0 并在结尾添加 \0
         trim_string(&mut data);

--- a/kernel/src/filesystem/procfs/mod.rs
+++ b/kernel/src/filesystem/procfs/mod.rs
@@ -29,6 +29,7 @@ mod thread_self;
 mod utils;
 mod version;
 mod version_signature;
+mod vmstat;
 
 // 重新导出 ProcFS
 pub use root::ProcFS;

--- a/kernel/src/filesystem/procfs/root.rs
+++ b/kernel/src/filesystem/procfs/root.rs
@@ -22,6 +22,7 @@ use crate::{
             thread_self::ThreadSelfDirOps,
             version::VersionFileOps,
             version_signature::VersionSignatureFileOps,
+            vmstat::VmstatFileOps,
             Builder, PROCFS_BLOCK_SIZE, PROCFS_MAX_NAMELEN,
         },
         vfs::{FileSystemMakerData, IndexNode, InodeMode, FSMAKER},
@@ -70,6 +71,7 @@ impl RootDirOps {
         ("thread-self", ThreadSelfDirOps::new_inode),
         ("version", VersionFileOps::new_inode),
         ("version_signature", VersionSignatureFileOps::new_inode),
+        ("vmstat", VmstatFileOps::new_inode),
     ];
 }
 

--- a/kernel/src/filesystem/procfs/sys/vm.rs
+++ b/kernel/src/filesystem/procfs/sys/vm.rs
@@ -1,0 +1,129 @@
+//! /proc/sys/vm - 虚拟内存参数目录
+
+use crate::libs::mutex::MutexGuard;
+use crate::{
+    filesystem::{
+        procfs::template::{Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder},
+        vfs::{FilePrivateData, IndexNode, InodeMode},
+    },
+    mm::{page::PageReclaimer, page_cache_stats},
+};
+use alloc::{
+    string::ToString,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::sync::atomic::{AtomicBool, Ordering};
+use system_error::SystemError;
+
+static DROP_CACHES_QUIET: AtomicBool = AtomicBool::new(false);
+
+/// /proc/sys/vm 目录的 DirOps 实现
+#[derive(Debug)]
+pub struct VmDirOps;
+
+impl VmDirOps {
+    pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl DirOps for VmDirOps {
+    fn lookup_child(
+        &self,
+        dir: &ProcDir<Self>,
+        name: &str,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        if name == "drop_caches" {
+            let mut cached_children = dir.cached_children().write();
+            if let Some(child) = cached_children.get(name) {
+                return Ok(child.clone());
+            }
+
+            let inode = DropCachesFileOps::new_inode(dir.self_ref_weak().clone());
+            cached_children.insert(name.to_string(), inode.clone());
+            return Ok(inode);
+        }
+
+        Err(SystemError::ENOENT)
+    }
+
+    fn populate_children(&self, dir: &ProcDir<Self>) {
+        let mut cached_children = dir.cached_children().write();
+        cached_children
+            .entry("drop_caches".to_string())
+            .or_insert_with(|| DropCachesFileOps::new_inode(dir.self_ref_weak().clone()));
+    }
+}
+
+/// /proc/sys/vm/drop_caches 文件的 FileOps 实现
+#[derive(Debug)]
+pub struct DropCachesFileOps;
+
+impl DropCachesFileOps {
+    pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o200))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    fn write_config(data: &[u8]) -> Result<usize, SystemError> {
+        let input = core::str::from_utf8(data).map_err(|_| SystemError::EINVAL)?;
+        let parts: Vec<&str> = input.split_whitespace().collect();
+        if parts.is_empty() {
+            return Err(SystemError::EINVAL);
+        }
+
+        let value: u32 = parts[0].parse().map_err(|_| SystemError::EINVAL)?;
+        if !(1..=4).contains(&value) {
+            return Err(SystemError::EINVAL);
+        }
+
+        let quiet = (value & 4) != 0;
+        let drop_pagecache = (value & 1) != 0;
+        let drop_slab = (value & 2) != 0;
+
+        if drop_pagecache {
+            PageReclaimer::drop_pagecache(true);
+            page_cache_stats::inc_drop_pagecache();
+        }
+
+        if drop_slab {
+            log::warn!("drop_caches: drop_slab not supported");
+        }
+
+        if quiet {
+            DROP_CACHES_QUIET.store(true, Ordering::Relaxed);
+        } else if !DROP_CACHES_QUIET.load(Ordering::Relaxed) {
+            log::info!("drop_caches: {}", value);
+        }
+
+        Ok(data.len())
+    }
+}
+
+impl FileOps for DropCachesFileOps {
+    fn read_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        _buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EACCES)
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        Self::write_config(buf)
+    }
+}

--- a/kernel/src/filesystem/procfs/template/file.rs
+++ b/kernel/src/filesystem/procfs/template/file.rs
@@ -158,4 +158,9 @@ impl<F: FileOps + 'static> IndexNode for ProcFile<F> {
     fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         return Ok(());
     }
+
+    fn resize(&self, _len: usize) -> Result<(), SystemError> {
+        // Linux procfs allows O_TRUNC; treat it as a no-op for pseudo files.
+        Ok(())
+    }
 }

--- a/kernel/src/filesystem/procfs/vmstat.rs
+++ b/kernel/src/filesystem/procfs/vmstat.rs
@@ -1,0 +1,494 @@
+//! /proc/vmstat - 虚拟内存统计信息
+
+use crate::libs::mutex::MutexGuard;
+use crate::{
+    filesystem::{
+        procfs::{
+            template::{Builder, FileOps, ProcFileBuilder},
+            utils::{proc_read, trim_string},
+        },
+        vfs::{FilePrivateData, IndexNode, InodeMode},
+    },
+    mm::page_cache_stats,
+};
+use alloc::{borrow::ToOwned, format, sync::Arc, sync::Weak, vec::Vec};
+use system_error::SystemError;
+
+#[derive(Clone, Copy, Debug)]
+enum VmstatSource {
+    Zero,
+    FilePages,
+    FileMapped,
+    FileDirty,
+    FileWriteback,
+    Shmem,
+    Unevictable,
+    DropPagecache,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct VmstatField {
+    name: &'static str,
+    source: VmstatSource,
+}
+
+// Match Linux 6.6 vmstat_text ordering with minimal features enabled.
+const VMSTAT_FIELDS: &[VmstatField] = &[
+    // enum zone_stat_item counters
+    VmstatField {
+        name: "nr_free_pages",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_zone_inactive_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_zone_active_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_zone_inactive_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_zone_active_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_zone_unevictable",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_zone_write_pending",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_mlock",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_bounce",
+        source: VmstatSource::Zero,
+    },
+    // enum node_stat_item counters
+    VmstatField {
+        name: "nr_inactive_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_active_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_inactive_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_active_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_unevictable",
+        source: VmstatSource::Unevictable,
+    },
+    VmstatField {
+        name: "nr_slab_reclaimable",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_slab_unreclaimable",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_isolated_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_isolated_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_nodes",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_refault_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_refault_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_activate_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_activate_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_restore_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_restore_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "workingset_nodereclaim",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_anon_pages",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_mapped",
+        source: VmstatSource::FileMapped,
+    },
+    VmstatField {
+        name: "nr_file_pages",
+        source: VmstatSource::FilePages,
+    },
+    VmstatField {
+        name: "nr_dirty",
+        source: VmstatSource::FileDirty,
+    },
+    VmstatField {
+        name: "nr_writeback",
+        source: VmstatSource::FileWriteback,
+    },
+    VmstatField {
+        name: "nr_writeback_temp",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_shmem",
+        source: VmstatSource::Shmem,
+    },
+    VmstatField {
+        name: "nr_shmem_hugepages",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_shmem_pmdmapped",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_file_hugepages",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_file_pmdmapped",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_anon_transparent_hugepages",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_vmscan_write",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_vmscan_immediate_reclaim",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_dirtied",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_written",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_throttled_written",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_kernel_misc_reclaimable",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_foll_pin_acquired",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_foll_pin_released",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_kernel_stack",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_page_table_pages",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_sec_page_table_pages",
+        source: VmstatSource::Zero,
+    },
+    // enum writeback_stat_item counters
+    VmstatField {
+        name: "nr_dirty_threshold",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "nr_dirty_background_threshold",
+        source: VmstatSource::Zero,
+    },
+    // enum vm_event_item counters (CONFIG_VM_EVENT_COUNTERS)
+    VmstatField {
+        name: "pgpgin",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgpgout",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pswpin",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pswpout",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgalloc_normal",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgalloc_movable",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "allocstall_normal",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "allocstall_movable",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgskip_normal",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgskip_movable",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgfree",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgactivate",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgdeactivate",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pglazyfree",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgfault",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgmajfault",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pglazyfreed",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgrefill",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgreuse",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgsteal_kswapd",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgsteal_direct",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgsteal_khugepaged",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgdemote_kswapd",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgdemote_direct",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgdemote_khugepaged",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgscan_kswapd",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgscan_direct",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgscan_khugepaged",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgscan_direct_throttle",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgscan_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgscan_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgsteal_anon",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgsteal_file",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pginodesteal",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "slabs_scanned",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "kswapd_inodesteal",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "kswapd_low_wmark_hit_quickly",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "kswapd_high_wmark_hit_quickly",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pageoutrun",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "pgrotated",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "drop_pagecache",
+        source: VmstatSource::DropPagecache,
+    },
+    VmstatField {
+        name: "drop_slab",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "oom_kill",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "unevictable_pgs_culled",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "unevictable_pgs_scanned",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "unevictable_pgs_rescued",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "unevictable_pgs_mlocked",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "unevictable_pgs_munlocked",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "unevictable_pgs_cleared",
+        source: VmstatSource::Zero,
+    },
+    VmstatField {
+        name: "unevictable_pgs_stranded",
+        source: VmstatSource::Zero,
+    },
+];
+
+/// /proc/vmstat 文件的 FileOps 实现
+#[derive(Debug)]
+pub struct VmstatFileOps;
+
+impl VmstatFileOps {
+    pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self, InodeMode::S_IRUGO)
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    fn generate_vmstat_content() -> Vec<u8> {
+        let stats = page_cache_stats::snapshot();
+        let mut data: Vec<u8> = Vec::new();
+
+        for field in VMSTAT_FIELDS {
+            let value = match field.source {
+                VmstatSource::Zero => 0,
+                VmstatSource::FilePages => stats.file_pages,
+                VmstatSource::FileMapped => stats.file_mapped,
+                VmstatSource::FileDirty => stats.file_dirty,
+                VmstatSource::FileWriteback => stats.file_writeback,
+                VmstatSource::Shmem => stats.shmem_pages,
+                VmstatSource::Unevictable => stats.unevictable,
+                VmstatSource::DropPagecache => stats.drop_pagecache,
+            };
+            data.append(&mut format!("{} {}\n", field.name, value).as_bytes().to_owned());
+        }
+
+        data.append(&mut b"nr_unstable 0\n".to_vec());
+        trim_string(&mut data);
+        data
+    }
+}
+
+impl FileOps for VmstatFileOps {
+    fn read_at(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        let content = Self::generate_vmstat_content();
+        proc_read(offset, len, buf, &content)
+    }
+}

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -791,6 +791,7 @@ impl IndexNode for LockedTmpfsInode {
                 Some(backend),
             );
             pc.set_unevictable(true);
+            pc.set_shmem(true);
             result.0.lock().page_cache = Some(pc);
         }
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -32,6 +32,7 @@ pub mod mincore;
 pub mod mmio_buddy;
 pub mod no_init;
 pub mod page;
+pub mod page_cache_stats;
 pub mod percpu;
 pub mod readahead;
 pub mod syscall;

--- a/kernel/src/mm/page_cache_stats.rs
+++ b/kernel/src/mm/page_cache_stats.rs
@@ -1,0 +1,98 @@
+use core::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PageCacheStatsSnapshot {
+    pub file_pages: u64,
+    pub file_mapped: u64,
+    pub file_dirty: u64,
+    pub file_writeback: u64,
+    pub shmem_pages: u64,
+    pub unevictable: u64,
+    pub drop_pagecache: u64,
+}
+
+static FILE_PAGES: AtomicU64 = AtomicU64::new(0);
+static FILE_MAPPED: AtomicU64 = AtomicU64::new(0);
+static FILE_DIRTY: AtomicU64 = AtomicU64::new(0);
+static FILE_WRITEBACK: AtomicU64 = AtomicU64::new(0);
+static SHMEM_PAGES: AtomicU64 = AtomicU64::new(0);
+static UNEVICTABLE: AtomicU64 = AtomicU64::new(0);
+static DROP_PAGECACHE: AtomicU64 = AtomicU64::new(0);
+
+#[inline]
+pub fn inc_file_pages() {
+    FILE_PAGES.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn dec_file_pages() {
+    FILE_PAGES.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_file_mapped() {
+    FILE_MAPPED.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn dec_file_mapped() {
+    FILE_MAPPED.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_file_dirty() {
+    FILE_DIRTY.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn dec_file_dirty() {
+    FILE_DIRTY.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_file_writeback() {
+    FILE_WRITEBACK.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn dec_file_writeback() {
+    FILE_WRITEBACK.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_shmem_pages() {
+    SHMEM_PAGES.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn dec_shmem_pages() {
+    SHMEM_PAGES.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_unevictable() {
+    UNEVICTABLE.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn dec_unevictable() {
+    UNEVICTABLE.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn inc_drop_pagecache() {
+    DROP_PAGECACHE.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn snapshot() -> PageCacheStatsSnapshot {
+    PageCacheStatsSnapshot {
+        file_pages: FILE_PAGES.load(Ordering::Relaxed),
+        file_mapped: FILE_MAPPED.load(Ordering::Relaxed),
+        file_dirty: FILE_DIRTY.load(Ordering::Relaxed),
+        file_writeback: FILE_WRITEBACK.load(Ordering::Relaxed),
+        shmem_pages: SHMEM_PAGES.load(Ordering::Relaxed),
+        unevictable: UNEVICTABLE.load(Ordering::Relaxed),
+        drop_pagecache: DROP_PAGECACHE.load(Ordering::Relaxed),
+    }
+}

--- a/kernel/src/mm/sysfs.rs
+++ b/kernel/src/mm/sysfs.rs
@@ -1,18 +1,24 @@
 use alloc::{string::ToString, sync::Arc};
 use unified_init::macros::unified_init;
 
+use crate::arch::MMArch;
 use crate::{
-    driver::base::firmware::sys_firmware_kobj,
     driver::base::{
-        kobject::{KObjType, KObject, KObjectManager, KObjectSysFSOps},
+        firmware::sys_firmware_kobj,
+        kobject::{DynamicKObjKType, KObjType, KObject, KObjectManager, KObjectSysFSOps},
         kset::KSet,
     },
     filesystem::{
-        sysfs::{Attribute, AttributeGroup, SysFSOps, SysFSOpsSupport, SYSFS_ATTR_MODE_RO},
+        sysfs::{
+            file::sysfs_emit_str, Attribute, AttributeGroup, SysFSOps, SysFSOpsSupport,
+            SYSFS_ATTR_MODE_RO,
+        },
         vfs::InodeMode,
     },
     init::initcall::INITCALL_POSTCORE,
     libs::casting::DowncastArc,
+    misc::ksysfs::sys_kernel_kobj,
+    mm::{page_cache_stats, MemoryManagementArch},
 };
 
 use crate::driver::base::kobject::CommonKobj;
@@ -344,4 +350,182 @@ fn memmap_sysfs_add(index: &usize, desc: &Arc<MemmapDesc>) {
     KObjectManager::add_kobj(desc.clone() as Arc<dyn KObject>).unwrap_or_else(|e| {
         log::warn!("Failed to add memmap({index:?}) kobject to sysfs: {:?}", e);
     });
+}
+
+#[derive(Debug)]
+struct PagecacheAttrGroup;
+
+impl AttributeGroup for PagecacheAttrGroup {
+    fn name(&self) -> Option<&str> {
+        None
+    }
+
+    fn attrs(&self) -> &[&'static dyn Attribute] {
+        &[
+            &AttrCachedKb,
+            &AttrDirtyKb,
+            &AttrWritebackKb,
+            &AttrMappedKb,
+            &AttrShmemKb,
+        ]
+    }
+
+    fn is_visible(
+        &self,
+        _kobj: Arc<dyn KObject>,
+        attr: &'static dyn Attribute,
+    ) -> Option<InodeMode> {
+        Some(attr.mode())
+    }
+}
+
+#[derive(Debug)]
+struct AttrCachedKb;
+
+impl Attribute for AttrCachedKb {
+    fn name(&self) -> &str {
+        "cached_kb"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let stats = page_cache_stats::snapshot();
+        let page_kb = (MMArch::PAGE_SIZE >> 10) as u64;
+        let cached = stats.file_pages.saturating_sub(stats.shmem_pages) * page_kb;
+        sysfs_emit_str(buf, &format!("{cached}\n"))
+    }
+}
+
+#[derive(Debug)]
+struct AttrDirtyKb;
+
+impl Attribute for AttrDirtyKb {
+    fn name(&self) -> &str {
+        "dirty_kb"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let stats = page_cache_stats::snapshot();
+        let page_kb = (MMArch::PAGE_SIZE >> 10) as u64;
+        let dirty = stats.file_dirty * page_kb;
+        sysfs_emit_str(buf, &format!("{dirty}\n"))
+    }
+}
+
+#[derive(Debug)]
+struct AttrWritebackKb;
+
+impl Attribute for AttrWritebackKb {
+    fn name(&self) -> &str {
+        "writeback_kb"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let stats = page_cache_stats::snapshot();
+        let page_kb = (MMArch::PAGE_SIZE >> 10) as u64;
+        let writeback = stats.file_writeback * page_kb;
+        sysfs_emit_str(buf, &format!("{writeback}\n"))
+    }
+}
+
+#[derive(Debug)]
+struct AttrMappedKb;
+
+impl Attribute for AttrMappedKb {
+    fn name(&self) -> &str {
+        "mapped_kb"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let stats = page_cache_stats::snapshot();
+        let page_kb = (MMArch::PAGE_SIZE >> 10) as u64;
+        let mapped = stats.file_mapped * page_kb;
+        sysfs_emit_str(buf, &format!("{mapped}\n"))
+    }
+}
+
+#[derive(Debug)]
+struct AttrShmemKb;
+
+impl Attribute for AttrShmemKb {
+    fn name(&self) -> &str {
+        "shmem_kb"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_RO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let stats = page_cache_stats::snapshot();
+        let page_kb = (MMArch::PAGE_SIZE >> 10) as u64;
+        let shmem = stats.shmem_pages * page_kb;
+        sysfs_emit_str(buf, &format!("{shmem}\n"))
+    }
+}
+
+#[unified_init(INITCALL_POSTCORE)]
+fn pagecache_sysfs_init() -> Result<(), SystemError> {
+    let kernel_kobj = sys_kernel_kobj();
+    let mm_kobj = CommonKobj::new("mm".to_string());
+    mm_kobj.set_parent(Some(Arc::downgrade(&(kernel_kobj as Arc<dyn KObject>))));
+    KObjectManager::init_and_add_kobj(mm_kobj.clone(), Some(&DynamicKObjKType)).unwrap_or_else(
+        |e| {
+            log::warn!("Failed to add mm kobject to sysfs: {:?}", e);
+        },
+    );
+
+    let pagecache_kobj = CommonKobj::new("pagecache".to_string());
+    pagecache_kobj.set_parent(Some(Arc::downgrade(&(mm_kobj as Arc<dyn KObject>))));
+    KObjectManager::init_and_add_kobj(pagecache_kobj.clone(), Some(&DynamicKObjKType))
+        .unwrap_or_else(|e| {
+            log::warn!("Failed to add pagecache kobject to sysfs: {:?}", e);
+        });
+
+    crate::filesystem::sysfs::sysfs_instance()
+        .create_groups(
+            &(pagecache_kobj as Arc<dyn KObject>),
+            &[&PagecacheAttrGroup],
+        )
+        .map_err(|e| {
+            log::warn!("Failed to create pagecache sysfs groups: {:?}", e);
+            SystemError::ENOMEM
+        })?;
+
+    Ok(())
 }


### PR DESCRIPTION
- 新增页缓存统计模块，跟踪文件页、脏页、回写页、映射页、共享内存页等状态
- 在/proc/meminfo中新增Cached、Dirty、Writeback、Mapped、Shmem等统计信息
- 新增/proc/vmstat文件，提供完整的虚拟内存统计信息
- 新增/proc/sys/vm/drop_caches接口，支持清理页缓存
- 在/sys/kernel/mm/pagecache下新增sysfs属性，提供页缓存统计信息
- 重构页缓存驱逐逻辑，支持更灵活的驱逐策略
- 为tmpfs共享内存页缓存添加统计支持