### PR TITLE
feat(filesystem): improve mknod support for devfs and tmpfs

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -82,7 +82,7 @@ impl Syscall {
         if let Some(handler) = syscall_table().get(syscall_num) {
             // 使用以下代码可以打印系统调用号和参数，方便调试
 
-            // let show = ProcessManager::current_pid().data() >= 12;
+            // let show = ProcessManager::current_pid().data() > 13;
             let show = false;
             if show {
                 log::debug!(


### PR DESCRIPTION
  Implement proper mknod syscall support in DevFS and TmpFS by adding
  logic to create character devices, block devices, and FIFO pipes
  based on the mode parameter.

  - DevFS: Add mknod method to create device nodes
  - TmpFS: Enhance mknod to correctly set file type and device number
  - Remove ENOSYS error for block/char device creation in TmpFS