### PR TITLE
feat(net): 为UDP和Raw socket添加IPv4组播支持

### DIFF
--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -3,6 +3,8 @@ use alloc::sync::Arc;
 
 pub mod port;
 pub use port::PortManager;
+pub mod multicast;
+pub use multicast::{apply_ipv4_membership, apply_ipv4_multicast_if, Ipv4MulticastMembership};
 use system_error::SystemError;
 
 #[allow(dead_code)]

--- a/kernel/src/net/socket/inet/common/multicast.rs
+++ b/kernel/src/net/socket/inet/common/multicast.rs
@@ -1,0 +1,224 @@
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use core::sync::atomic::{AtomicI32, AtomicU32, Ordering};
+use smoltcp::wire::{IpAddress, Ipv4Address};
+use system_error::SystemError;
+
+use crate::libs::mutex::Mutex;
+use crate::net::socket::IpOption;
+use crate::net::Iface;
+use crate::process::namespace::net_namespace::NetNamespace;
+
+pub const IP_MREQ_SIZE: usize = 8;
+pub const IP_MREQN_SIZE: usize = 12;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Ipv4MulticastMembership {
+    pub multiaddr: u32,
+    pub ifindex: i32,
+    pub ifaddr: u32,
+}
+
+#[inline]
+pub fn is_ipv4_multicast(addr_be: u32) -> bool {
+    let b = addr_be.to_ne_bytes();
+    (224..=239).contains(&b[0])
+}
+
+pub fn find_iface_by_ifindex(netns: &Arc<NetNamespace>, ifindex: i32) -> Option<Arc<dyn Iface>> {
+    if ifindex <= 0 {
+        return None;
+    }
+    let ifindex = ifindex as usize;
+    if let Some(iface) = netns.device_list().get(&ifindex) {
+        return Some(iface.clone());
+    }
+    netns
+        .loopback_iface()
+        .and_then(|lo| {
+            if lo.nic_id() == ifindex {
+                Some(lo)
+            } else {
+                None
+            }
+        })
+        .map(|lo| lo as Arc<dyn Iface>)
+}
+
+pub fn find_iface_by_ipv4(netns: &Arc<NetNamespace>, addr_be: u32) -> Option<Arc<dyn Iface>> {
+    let b = addr_be.to_ne_bytes();
+    let target = Ipv4Address::new(b[0], b[1], b[2], b[3]);
+
+    for (_id, iface) in netns.device_list().iter() {
+        let smol_iface = iface.smol_iface().lock();
+        if smol_iface
+            .ip_addrs()
+            .iter()
+            .any(|cidr| match cidr.address() {
+                IpAddress::Ipv4(v4) => v4 == target,
+                _ => false,
+            })
+        {
+            return Some(iface.clone());
+        }
+    }
+
+    netns.loopback_iface().and_then(|lo| {
+        let found = {
+            let smol_iface = lo.smol_iface().lock();
+            smol_iface
+                .ip_addrs()
+                .iter()
+                .any(|cidr| match cidr.address() {
+                    IpAddress::Ipv4(v4) => v4 == target,
+                    _ => false,
+                })
+        };
+        if found {
+            Some(lo as Arc<dyn Iface>)
+        } else {
+            None
+        }
+    })
+}
+
+pub fn choose_default_ipv4_iface(netns: &Arc<NetNamespace>) -> Option<Arc<dyn Iface>> {
+    if let Some(iface) = netns.default_iface() {
+        return Some(iface);
+    }
+    if let Some(iface) = netns.device_list().values().next() {
+        return Some(iface.clone());
+    }
+    netns.loopback_iface().map(|lo| lo as Arc<dyn Iface>)
+}
+
+pub fn parse_mreqn_for_multicast_if(val: &[u8]) -> Result<(u32, i32), SystemError> {
+    if val.len() < core::mem::size_of::<u32>() {
+        return Err(SystemError::EINVAL);
+    }
+    // Default: in_addr only.
+    let mut ifaddr = u32::from_ne_bytes([val[0], val[1], val[2], val[3]]);
+    let mut ifindex = 0i32;
+
+    if val.len() >= IP_MREQN_SIZE {
+        ifaddr = u32::from_ne_bytes([val[4], val[5], val[6], val[7]]);
+        ifindex = i32::from_ne_bytes([val[8], val[9], val[10], val[11]]);
+    } else if val.len() >= IP_MREQ_SIZE {
+        ifaddr = u32::from_ne_bytes([val[4], val[5], val[6], val[7]]);
+    }
+
+    Ok((ifaddr, ifindex))
+}
+
+pub fn parse_mreqn_for_membership(val: &[u8]) -> Result<(u32, u32, i32), SystemError> {
+    if val.len() < IP_MREQ_SIZE {
+        return Err(SystemError::EINVAL);
+    }
+    let multiaddr = u32::from_ne_bytes([val[0], val[1], val[2], val[3]]);
+    let ifaddr = u32::from_ne_bytes([val[4], val[5], val[6], val[7]]);
+    let mut ifindex = 0i32;
+    if val.len() >= IP_MREQN_SIZE {
+        ifindex = i32::from_ne_bytes([val[8], val[9], val[10], val[11]]);
+    }
+    Ok((multiaddr, ifaddr, ifindex))
+}
+
+pub fn apply_ipv4_multicast_if(
+    netns: &Arc<NetNamespace>,
+    val: &[u8],
+    ifindex: &AtomicI32,
+    ifaddr: &AtomicU32,
+) -> Result<(), SystemError> {
+    let (addr, index) = parse_mreqn_for_multicast_if(val)?;
+    if index < 0 {
+        return Err(SystemError::EADDRNOTAVAIL);
+    }
+    if index == 0 && addr == 0 {
+        ifindex.store(0, Ordering::Relaxed);
+        ifaddr.store(0, Ordering::Relaxed);
+        return Ok(());
+    }
+    let iface = if index != 0 {
+        find_iface_by_ifindex(netns, index)
+    } else {
+        find_iface_by_ipv4(netns, addr)
+    }
+    .ok_or(SystemError::EADDRNOTAVAIL)?;
+    ifindex.store(iface.nic_id() as i32, Ordering::Relaxed);
+    ifaddr.store(addr, Ordering::Relaxed);
+    Ok(())
+}
+
+pub fn apply_ipv4_membership(
+    netns: &Arc<NetNamespace>,
+    opt: IpOption,
+    val: &[u8],
+    groups: &Mutex<Vec<Ipv4MulticastMembership>>,
+) -> Result<(), SystemError> {
+    let (multi, ifaddr, ifindex) = parse_mreqn_for_membership(val)?;
+    if !is_ipv4_multicast(multi) {
+        return Err(SystemError::EINVAL);
+    }
+    if ifindex < 0 {
+        return Err(SystemError::ENODEV);
+    }
+    let iface = if ifindex != 0 {
+        find_iface_by_ifindex(netns, ifindex)
+    } else if ifaddr != 0 {
+        find_iface_by_ipv4(netns, ifaddr)
+    } else {
+        choose_default_ipv4_iface(netns)
+    };
+
+    if iface.is_none() {
+        if opt == IpOption::DROP_MEMBERSHIP && ifindex == 0 && ifaddr == 0 {
+            return Err(SystemError::ENODEV);
+        }
+        return Err(if opt == IpOption::DROP_MEMBERSHIP {
+            SystemError::EADDRNOTAVAIL
+        } else {
+            SystemError::ENODEV
+        });
+    }
+
+    let resolved_ifindex = iface.unwrap().nic_id() as i32;
+    let mut groups = groups.lock();
+    match opt {
+        IpOption::ADD_MEMBERSHIP => {
+            if groups
+                .iter()
+                .any(|g| g.multiaddr == multi && g.ifindex == resolved_ifindex)
+            {
+                return Err(SystemError::EADDRINUSE);
+            }
+            groups.push(Ipv4MulticastMembership {
+                multiaddr: multi,
+                ifindex: resolved_ifindex,
+                ifaddr,
+            });
+            Ok(())
+        }
+        IpOption::DROP_MEMBERSHIP => {
+            let pos = groups.iter().position(|g| {
+                if g.multiaddr != multi {
+                    return false;
+                }
+                if ifindex != 0 {
+                    return g.ifindex == resolved_ifindex;
+                }
+                if ifaddr != 0 {
+                    return g.ifaddr == ifaddr;
+                }
+                true
+            });
+            if let Some(idx) = pos {
+                groups.swap_remove(idx);
+                Ok(())
+            } else {
+                Err(SystemError::EADDRNOTAVAIL)
+            }
+        }
+        _ => Err(SystemError::ENOPROTOOPT),
+    }
+}

--- a/kernel/src/net/socket/inet/raw/mod.rs
+++ b/kernel/src/net/socket/inet/raw/mod.rs
@@ -3,7 +3,8 @@
 //! 提供 IP 层原始套接字支持，用于 ping、traceroute 等工具
 
 use alloc::sync::{Arc, Weak};
-use core::sync::atomic::{AtomicBool, AtomicUsize};
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicUsize};
 
 use smoltcp::wire::{IpProtocol, IpVersion};
 
@@ -76,4 +77,11 @@ pub struct RawSocket {
 
     /// 回环快速路径：用于保留 TOS/TCLASS 等字段且实现 SO_RCVBUF 行为。
     loopback_rx: Mutex<LoopbackRxQueue>,
+
+    /// IP_MULTICAST_IF: interface index
+    ip_multicast_ifindex: AtomicI32,
+    /// IP_MULTICAST_IF: interface address (network byte order)
+    ip_multicast_addr: AtomicU32,
+    /// IP_ADD_MEMBERSHIP/IP_DROP_MEMBERSHIP state (best-effort, no actual IGMP)
+    ip_multicast_groups: Mutex<Vec<crate::net::socket::inet::common::Ipv4MulticastMembership>>,
 }

--- a/kernel/src/net/socket/inet/raw/socket.rs
+++ b/kernel/src/net/socket/inet/raw/socket.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 use smoltcp::wire::{IpAddress, IpProtocol, IpVersion};
 use system_error::SystemError;
@@ -82,6 +83,9 @@ impl RawSocket {
             ip_version,
             protocol,
             loopback_rx: crate::libs::mutex::Mutex::new(super::loopback::LoopbackRxQueue::default()),
+            ip_multicast_ifindex: core::sync::atomic::AtomicI32::new(0),
+            ip_multicast_addr: core::sync::atomic::AtomicU32::new(0),
+            ip_multicast_groups: crate::libs::mutex::Mutex::new(Vec::new()),
         });
 
         // Linux 语义：raw socket 未 bind 也应能被 poll/epoll 正确唤醒。

--- a/kernel/src/net/socket/posix/ip_option.rs
+++ b/kernel/src/net/socket/posix/ip_option.rs
@@ -15,6 +15,7 @@ pub enum IpOption {
     RECVTTL = 12,
     RECVTOS = 13,
     ORIGDSTADDR = 20,
+    MULTICAST_IF = 32,
     MULTICAST_TTL = 33,
     MULTICAST_LOOP = 34,
     ADD_MEMBERSHIP = 35,

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -82,6 +82,7 @@ bind_test
 socket_test
 udp_socket_test
 socket_ip_udp_loopback_test
+socket_ip_udp_loopback_non_blocking_test
 
 # unix socket相关的测试
 socket_unix_dgram_local_test
@@ -101,6 +102,8 @@ tcp_socket_test
 socket_ip_tcp_generic_loopback_test
 socket_ip_tcp_loopback_non_blocking_test
 socket_ip_tcp_loopback_test
+socket_ip_tcp_udp_generic_loopback_test
+socket_ipv4_datagram_based_socket_unbound_loopback_test
 
 # 信号处理测试
 sigaction_test


### PR DESCRIPTION
- 新增multicast模块，包含IPv4组播成员管理相关函数
- 为UDP socket实现IP_MULTICAST_IF、IP_ADD_MEMBERSHIP和IP_DROP_MEMBERSHIP选项
- 为Raw socket实现IP_MULTICAST_IF、IP_ADD_MEMBERSHIP和IP_DROP_MEMBERSHIP选项
- 在IpOption枚举中添加MULTICAST_IF选项
- 更新gvisor测试白名单，添加相关socket测试