### PR TITLE
refactor(kernel): 优化UTS命名空间字符串处理

### DIFF
--- a/kernel/src/process/syscall/sys_sethostname.rs
+++ b/kernel/src/process/syscall/sys_sethostname.rs
@@ -5,7 +5,7 @@ use crate::arch::syscall::nr::SYS_SETHOSTNAME;
 use crate::process::namespace::uts_namespace::NewUtsName;
 use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
-use crate::syscall::user_access::check_and_clone_cstr;
+use crate::syscall::user_access::UserBufferReader;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -43,15 +43,11 @@ impl Syscall for SysSethostname {
             return Err(SystemError::EINVAL);
         }
 
-        // 使用check_and_clone_cstr安全地从用户空间读取字符串，但限制长度为len
-        let s = check_and_clone_cstr(name_ptr, Some(core::cmp::min(len, NewUtsName::MAXLEN) + 1))?;
-        let ss = s.to_str().map_err(|_| SystemError::EINVAL)?;
+        let reader = UserBufferReader::new_checked(name_ptr, len, true)?;
+        let mut buf = vec![0u8; len];
+        reader.copy_from_user_protected(&mut buf, 0)?;
 
-        // 截断到指定长度
-        let truncated = if ss.len() > len { &ss[..len] } else { ss };
-
-        // 设置主机名
-        uts_ns.set_hostname(truncated)?;
+        uts_ns.set_hostname(&buf)?;
 
         Ok(0)
     }

--- a/user/apps/c_unitest/test_setdomainname.c
+++ b/user/apps/c_unitest/test_setdomainname.c
@@ -78,6 +78,18 @@ int main() {
         perror("✗ setdomainname failed");
     }
     printf("\n");
+
+    printf("Test 3.1: UTF-8 boundary cut\n");
+    char utf8_domain[] = "测试domain";
+    size_t utf8_len = 4;
+    printf("Setting domainname to: '%s' with len=%zu\n", utf8_domain, utf8_len);
+    long ret = sys_setdomainname(utf8_domain, utf8_len);
+    if (ret == 0) {
+        printf("✓ setdomainname succeeded (unexpected)\n");
+    } else {
+        printf("setdomainname failed with error: %s\n", strerror(errno));
+    }
+    printf("\n");
     
     // Test 4: Test with zero length
     printf("Test 4: Test with zero length\n");


### PR DESCRIPTION
- 将NewUtsName内部字段从String类型改为[u8; 65]数组，减少内存分配
- 重构copy_string_to_array为copy_bytes_to_array，支持字节数组直接复制
- 修改set_hostname和set_domainname方法，直接接受字节数组参数
- 更新sys_setdomainname和sys_sethostname系统调用，使用UserBufferReader读取用户空 间数据
- 添加UTF-8边界切割测试用例