### PR TITLE
fix(ntty): 修复读取缓冲区索引计算错误

### DIFF
--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -312,7 +312,7 @@ impl NTtyData {
             }
 
             if likely(flag == 1) {
-                self.read_buf[self.read_head] = buf[c_offset];
+                self.read_buf[ntty_buf_mask(self.read_head)] = buf[c_offset];
                 c_offset += 1;
                 self.read_head += 1;
             } else {


### PR DESCRIPTION
这是一个环形缓冲区索引计算错误的经典bug。                                                     
                                                                                                
数据结构关键点：                                                                              
- read_buf 是固定大小的环形缓冲区，大小为 NTTY_BUFSIZE = 4096                                 
- read_head 是逻辑索引，会不断递增，不会回绕                                                  
- ntty_buf_mask() 函数通过 idx & (NTTY_BUFSIZE - 1) 将逻辑索引转换为物理索引                  
                                                                                              
修改前（Bug）                                                                                 
```rust
self.read_buf[self.read_head] = buf[c_offset];
```
当 read_head >= 4096 时，直接使用会导致数组越界访问（panic 或内存损坏）。                     
                                                                                              
修改后（正确）                                                                                
```rust
self.read_buf[ntty_buf_mask(self.read_head)] = buf[c_offset];                                 
```
通过掩码运算实现环形缓冲区的回绕：4096 & 0xFFF = 0，4097 & 0xFFF = 1，以此类推。