### PR TITLE
refactor(driver/hpet): 调整 HPET 驱动代码中函数声明顺序，优化部分函数命名

### DIFF
--- a/kernel/src/arch/x86_64/driver/hpet.rs
+++ b/kernel/src/arch/x86_64/driver/hpet.rs
@@ -57,7 +57,7 @@ pub fn hpet_instance() -> &'static Hpet {
 #[inline(always)]
 pub fn is_hpet_enabled() -> bool {
     if unsafe { HPET_INSTANCE.as_ref().is_some() } {
-        return unsafe { HPET_INSTANCE.as_ref().unwrap().enabled() };
+        return unsafe { HPET_INSTANCE.as_ref().unwrap().is_enabled() };
     }
     return false;
 }
@@ -230,7 +230,7 @@ impl Hpet {
         }
     }
 
-    pub fn enabled(&self) -> bool {
+    pub fn is_enabled(&self) -> bool {
         self.enabled.load(Ordering::SeqCst)
     }
 


### PR DESCRIPTION
# 调整 HPET_INSTANTS 初始化函数位置和 Hpet 方法声明顺序,优化函数命名

- HPET 单例相关方法位置调整：
    - 调整 hpet_init() 函数声明位置,将其前置到紧跟 HPET_INSTANCE 后面
- Hpet 结构体方法顺序调整：
    - 整理为公有方法在前，私有方法在后
    - 整体组织结构为:
        - 构造/初始化: new
        - 生命周期控制: hpet_enable / hpet_disable / is_enabled
        - 对外核心能力: main_counter_value / period
        - 对外查询辅助: enabled / timer (如果需要)
        - 内部辅助: is_counting / restart_counter / stop_counter / reset_counter / start_counter
        - 纯内部访问器: inner / inner_mut / timer_mut / hpet_regs / hpet_regs_mut
- Hpet 辅助函数命名优化：
    -  重命名 `Hpet::enabled()` 方法为 `Hpet::is_enabled()`