### PR TITLE
refactor(vfs): 将ioctl方法的private_data参数类型改为MutexGuard

### DIFF
--- a/kernel/src/driver/base/block/gendisk/mod.rs
+++ b/kernel/src/driver/base/block/gendisk/mod.rs
@@ -302,7 +302,7 @@ impl IndexNode for GenDisk {
         &self,
         cmd: u32,
         data: usize,
-        private_data: &crate::filesystem::vfs::FilePrivateData,
+        private_data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let bdev = self.block_device();
         if let Some(loop_dev) = BlockDevice::as_any_ref(&*bdev).downcast_ref::<LoopDevice>() {

--- a/kernel/src/driver/block/loop_device/loop_control.rs
+++ b/kernel/src/driver/block/loop_device/loop_control.rs
@@ -168,7 +168,7 @@ impl IndexNode for LoopControlDevice {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match LoopControlIoctl::from_u32(cmd) {
             Some(LoopControlIoctl::Add) => {

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -1072,7 +1072,7 @@ impl IndexNode for LoopDevice {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let ioctl_cmd = LoopIoctl::from_u32(cmd).ok_or(SystemError::ENOSYS)?;
 

--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -618,7 +618,7 @@ impl IndexNode for LockedDevFSInode {
         &self,
         _cmd: u32,
         _data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/filesystem/kernfs/mod.rs
+++ b/kernel/src/filesystem/kernfs/mod.rs
@@ -319,7 +319,7 @@ impl IndexNode for KernFSInode {
         &self,
         _cmd: u32,
         _data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         // 若文件系统没有实现此方法，则返回“不支持”
         return Err(SystemError::ENOSYS);

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -637,9 +637,9 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         &self,
         _cmd: u32,
         _data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        // 若文件系统没有实现此方法，则返回“不支持”
+        // 若文件系统没有实现此方法，则返回"不支持"
         return Err(SystemError::ENOSYS);
     }
 

--- a/kernel/src/filesystem/vfs/mount.rs
+++ b/kernel/src/filesystem/vfs/mount.rs
@@ -880,7 +880,7 @@ impl IndexNode for MountFSInode {
         &self,
         cmd: u32,
         data: usize,
-        private_data: &FilePrivateData,
+        private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return self.inner_inode.ioctl(cmd, data, private_data);
     }

--- a/kernel/src/filesystem/vfs/syscall/sys_ioctl.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_ioctl.rs
@@ -92,7 +92,7 @@ impl Syscall for SysIoctlHandle {
                 // 其他命令转发给inode处理
                 let r = file
                     .inode()
-                    .ioctl(cmd, data, &file.private_data.lock())
+                    .ioctl(cmd, data, file.private_data.lock())
                     .map_err(|e| {
                         // 将内部错误码 ENOIOCTLCMD 转换为用户空间错误码 ENOTTY
                         if e == SystemError::ENOIOCTLCMD {

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -1577,7 +1577,7 @@ impl IndexNode for LockedPipeInode {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
             FIONREAD => {

--- a/kernel/src/net/socket/inode.rs
+++ b/kernel/src/net/socket/inode.rs
@@ -379,7 +379,7 @@ impl<T: Socket + 'static> IndexNode for T {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: &FilePrivateData,
+        private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
             SIOCGIFCONF => handle_siocgifconf(data),
@@ -404,7 +404,7 @@ impl<T: Socket + 'static> IndexNode for T {
             }
             _ => {
                 // 透穿调用子协议栈的ioctl
-                Socket::ioctl(self, cmd, data, _private_data)
+                Socket::ioctl(self, cmd, data, &private_data)
             }
         }
     }

--- a/kernel/src/perf/mod.rs
+++ b/kernel/src/perf/mod.rs
@@ -236,7 +236,12 @@ impl IndexNode for PerfEventInode {
         Ok(())
     }
 
-    fn ioctl(&self, cmd: u32, data: usize, _private_data: &FilePrivateData) -> Result<usize> {
+    fn ioctl(
+        &self,
+        cmd: u32,
+        data: usize,
+        _private_data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize> {
         let req = PerfEventIoc::from_u32(cmd).ok_or(SystemError::EINVAL)?;
         info!("perf_event_ioctl: request: {:?}, arg: {}", req, data);
         match req {

--- a/kernel/src/virt/kvm/kvm_dev.rs
+++ b/kernel/src/virt/kvm/kvm_dev.rs
@@ -141,7 +141,7 @@ impl IndexNode for LockedKvmInode {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
             0xdeadbeef => {

--- a/kernel/src/virt/kvm/vcpu_dev.rs
+++ b/kernel/src/virt/kvm/vcpu_dev.rs
@@ -148,7 +148,7 @@ impl IndexNode for LockedVcpuInode {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
             0xdeadbeef => {

--- a/kernel/src/virt/kvm/vm_dev.rs
+++ b/kernel/src/virt/kvm/vm_dev.rs
@@ -146,7 +146,7 @@ impl IndexNode for LockedVmInode {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: &FilePrivateData,
+        _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
             0xdeadbeef => {

--- a/kernel/src/virt/vm/kvm_dev.rs
+++ b/kernel/src/virt/vm/kvm_dev.rs
@@ -18,7 +18,7 @@ use crate::{
             FileType, IndexNode, InodeFlags, InodeMode, Metadata,
         },
     },
-    libs::spinlock::SpinLock,
+    libs::{mutex::MutexGuard, spinlock::SpinLock},
     mm::MemoryManagementArch,
     process::ProcessManager,
     syscall::user_access::{UserBufferReader, UserBufferWriter},
@@ -152,7 +152,7 @@ impl IndexNode for LockedKvmInode {
         &self,
         cmd: u32,
         arg: usize,
-        _private_data: &crate::filesystem::vfs::FilePrivateData,
+        _private_data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
             Self::KVM_CREATE_VM => {
@@ -233,7 +233,7 @@ impl KvmInstance {
 impl IndexNode for KvmInstance {
     fn open(
         &self,
-        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
         _mode: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -244,7 +244,7 @@ impl IndexNode for KvmInstance {
         &self,
         cmd: u32,
         arg: usize,
-        _private_data: &crate::filesystem::vfs::FilePrivateData,
+        _private_data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         debug!("kvm instance ioctl cmd {cmd:x}");
         match cmd {
@@ -284,7 +284,7 @@ impl IndexNode for KvmInstance {
         _offset: usize,
         _len: usize,
         _buf: &mut [u8],
-        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         todo!()
     }
@@ -294,7 +294,7 @@ impl IndexNode for KvmInstance {
         _offset: usize,
         _len: usize,
         _buf: &[u8],
-        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         todo!()
     }
@@ -317,7 +317,7 @@ impl IndexNode for KvmInstance {
 
     fn close(
         &self,
-        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
         Ok(())
     }
@@ -365,7 +365,7 @@ impl KvmVcpuDev {
 impl IndexNode for KvmVcpuDev {
     fn open(
         &self,
-        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
         Ok(())
@@ -373,7 +373,7 @@ impl IndexNode for KvmVcpuDev {
 
     fn close(
         &self,
-        _data: crate::libs::mutex::MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
         Ok(())
     }
@@ -382,7 +382,7 @@ impl IndexNode for KvmVcpuDev {
         &self,
         cmd: u32,
         arg: usize,
-        _private_data: &crate::filesystem::vfs::FilePrivateData,
+        _private_data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
             Self::KVM_RUN => {


### PR DESCRIPTION
- 统一将IndexNode trait的ioctl方法参数从&FilePrivateData改为MutexGuard<FilePrivateData>
- 在TtyDevice中提前释放锁以避免死锁
- 更新所有相关实现以适配新的参数类型