### PR TITLE
feat(netlink): add kobject uevent support and socket options

### DIFF
--- a/kernel/src/net/posix.rs
+++ b/kernel/src/net/posix.rs
@@ -101,7 +101,7 @@ pub struct SockAddrLl {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SockAddrNl {
-    pub nl_family: AddressFamily,
+    pub nl_family: u16,
     pub nl_pad: u16,
     pub nl_pid: u32,
     pub nl_groups: u32,
@@ -189,7 +189,7 @@ impl From<NetlinkSocketAddr> for SockAddr {
     fn from(value: NetlinkSocketAddr) -> Self {
         SockAddr {
             addr_nl: SockAddrNl {
-                nl_family: AddressFamily::Netlink,
+                nl_family: AddressFamily::Netlink as u16,
                 nl_pad: 0,
                 nl_pid: value.port(),
                 nl_groups: value.groups().as_u32(),

--- a/kernel/src/net/socket/netlink/kobject/bound.rs
+++ b/kernel/src/net/socket/netlink/kobject/bound.rs
@@ -1,0 +1,88 @@
+use crate::{
+    filesystem::epoll::EPollEventType,
+    net::socket::{
+        netlink::{
+            addr::NetlinkSocketAddr,
+            common::bound::BoundNetlink,
+            kobject::message::KobjectUeventMessage,
+            table::{NetlinkKobjectUeventProtocol, SupportedNetlinkProtocol},
+        },
+        utils::datagram_common,
+        PMSG,
+    },
+};
+use system_error::SystemError;
+
+impl datagram_common::Bound for BoundNetlink<KobjectUeventMessage> {
+    type Endpoint = NetlinkSocketAddr;
+
+    fn bind(&mut self, endpoint: &Self::Endpoint) -> Result<(), SystemError> {
+        self.bind_common(endpoint)
+    }
+
+    fn local_endpoint(&self) -> Self::Endpoint {
+        self.handle.addr()
+    }
+
+    fn remote_endpoint(&self) -> Option<Self::Endpoint> {
+        Some(self.remote_addr)
+    }
+
+    fn set_remote_endpoint(&mut self, endpoint: &Self::Endpoint) {
+        self.remote_addr = *endpoint;
+    }
+
+    fn try_send(
+        &self,
+        buf: &[u8],
+        to: &Self::Endpoint,
+        _flags: PMSG,
+    ) -> Result<usize, SystemError> {
+        let sent_len = buf.len();
+        let message = KobjectUeventMessage::new(buf);
+
+        if to.port() != 0 {
+            <NetlinkKobjectUeventProtocol as SupportedNetlinkProtocol>::unicast(
+                to.port(),
+                message.clone(),
+                self.netns(),
+            )?;
+        }
+
+        if !to.groups().is_empty() {
+            <NetlinkKobjectUeventProtocol as SupportedNetlinkProtocol>::multicast(
+                to.groups(),
+                message,
+                self.netns(),
+            )?;
+        }
+
+        Ok(sent_len)
+    }
+
+    fn try_recv(
+        &self,
+        writer: &mut [u8],
+        flags: PMSG,
+    ) -> Result<(usize, Self::Endpoint), SystemError> {
+        let mut receive_queue = self.receive_queue.0.lock();
+        let Some(message) = receive_queue.front() else {
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        };
+
+        let copied = writer.len().min(message.as_bytes().len());
+        if copied > 0 {
+            writer[..copied].copy_from_slice(&message.as_bytes()[..copied]);
+        }
+
+        if !flags.contains(PMSG::PEEK) {
+            receive_queue.pop_front();
+        }
+
+        Ok((copied, NetlinkSocketAddr::new_unspecified()))
+    }
+
+    fn check_io_events(&self) -> EPollEventType {
+        self.check_io_events_common()
+    }
+}

--- a/kernel/src/net/socket/netlink/kobject/message.rs
+++ b/kernel/src/net/socket/netlink/kobject/message.rs
@@ -1,0 +1,22 @@
+use alloc::vec::Vec;
+
+use crate::net::socket::netlink::table::MulticastMessage;
+
+#[derive(Debug, Clone)]
+pub struct KobjectUeventMessage {
+    bytes: Vec<u8>,
+}
+
+impl KobjectUeventMessage {
+    pub fn new(payload: &[u8]) -> Self {
+        Self {
+            bytes: payload.to_vec(),
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl MulticastMessage for KobjectUeventMessage {}

--- a/kernel/src/net/socket/netlink/kobject/mod.rs
+++ b/kernel/src/net/socket/netlink/kobject/mod.rs
@@ -1,0 +1,6 @@
+use crate::net::socket::netlink::{common::NetlinkSocket, table::NetlinkKobjectUeventProtocol};
+
+mod bound;
+pub mod message;
+
+pub(super) type NetlinkKobjectUeventSocket = NetlinkSocket<NetlinkKobjectUeventProtocol>;

--- a/kernel/src/net/socket/netlink/mod.rs
+++ b/kernel/src/net/socket/netlink/mod.rs
@@ -1,5 +1,6 @@
 use crate::net::socket::{
     netlink::{
+        kobject::NetlinkKobjectUeventSocket,
         route::NetlinkRouteSocket,
         table::{is_valid_protocol, StandardNetlinkProtocol},
     },
@@ -10,6 +11,7 @@ use system_error::SystemError;
 
 pub mod addr;
 mod common;
+mod kobject;
 mod message;
 mod receiver;
 mod route;
@@ -18,35 +20,36 @@ pub mod table;
 pub fn create_netlink_socket(
     socket_type: PSOCK,
     protocol: u32,
-    _is_nonblock: bool,
+    is_nonblock: bool,
 ) -> Result<Arc<dyn Socket>, SystemError> {
-    match socket_type {
-        super::PSOCK::Raw | super::PSOCK::Datagram => {
-            let nl_protocol = StandardNetlinkProtocol::try_from(protocol);
-            let inode = match nl_protocol {
-                Ok(StandardNetlinkProtocol::ROUTE) => NetlinkRouteSocket::new(false),
-                Ok(_) => {
-                    log::warn!(
-                        "standard netlink families {} is not supported yet",
-                        protocol
-                    );
-                    return Err(SystemError::EAFNOSUPPORT);
-                }
-                Err(_) => {
-                    if is_valid_protocol(protocol) {
-                        log::error!("user-provided netlink family is not supported");
-                        return Err(SystemError::EPROTONOSUPPORT);
-                    }
-                    log::error!("invalid netlink protocol: {}", protocol);
-                    return Err(SystemError::EAFNOSUPPORT);
-                }
-            };
-
-            Ok(inode)
-        }
-        _ => {
-            log::warn!("unsupported socket type for Netlink");
-            Err(SystemError::EPROTONOSUPPORT)
-        }
+    if !matches!(socket_type, super::PSOCK::Raw | super::PSOCK::Datagram) {
+        log::warn!("unsupported socket type for Netlink");
+        return Err(SystemError::ESOCKTNOSUPPORT);
     }
+
+    let inode: Arc<dyn Socket> = match StandardNetlinkProtocol::try_from(protocol) {
+        Ok(StandardNetlinkProtocol::ROUTE) => {
+            NetlinkRouteSocket::new(is_nonblock, socket_type, protocol)
+        }
+        Ok(StandardNetlinkProtocol::KOBJECT_UEVENT) => {
+            NetlinkKobjectUeventSocket::new(is_nonblock, socket_type, protocol)
+        }
+        Ok(_) => {
+            log::warn!(
+                "standard netlink families {} is not supported yet",
+                protocol
+            );
+            return Err(SystemError::EPROTONOSUPPORT);
+        }
+        Err(_) => {
+            if !is_valid_protocol(protocol) {
+                log::error!("invalid netlink protocol: {}", protocol);
+            } else {
+                log::error!("user-provided netlink family is not supported");
+            }
+            return Err(SystemError::EPROTONOSUPPORT);
+        }
+    };
+
+    Ok(inode)
 }

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -108,6 +108,7 @@ socket_ip_tcp_udp_generic_loopback_test
 socket_ipv4_datagram_based_socket_unbound_loopback_test
 socket_ipv4_udp_unbound_loopback_test
 socket_ipv4_udp_unbound_loopback_nogotsan_test
+socket_netlink_test
 
 # 信号处理测试
 sigaction_test


### PR DESCRIPTION
- Add kobject uevent netlink protocol support with new socket type
- Implement socket options (SO_TYPE, SO_DOMAIN, SO_PROTOCOL, SO_SNDTIMEO, SO_RCVTIMEO) for netlink sockets
- Fix SockAddrNl nl_family field type from AddressFamily to u16
- Add timeout handling for send and receive operations
- Improve error handling in remote_endpoint() method