### PR TITLE
fix(ipc/signalfd): eliminate hardirq deadlock in signal notification path

### DIFF
--- a/kernel/src/ipc/sighand.rs
+++ b/kernel/src/ipc/sighand.rs
@@ -21,6 +21,12 @@ use super::signal_types::Sigaction;
 pub struct SigHand {
     inner: RwLock<InnerSigHand>,
     group_exec_wait_queue: WaitQueue,
+    /// signalfd 共享等待队列，对标 Linux `sighand_struct::signalfd_wqh`。
+    ///
+    /// 信号投递路径（包括 hardirq 上下文）调用 `signalfd_wqh.wakeup_all()`
+    /// 唤醒所有阻塞在 signalfd `read()` 的线程。
+    /// `WaitQueue` 内部使用 `SpinLock` + `lock_irqsave`，hardirq 安全。
+    signalfd_wqh: WaitQueue,
 }
 
 impl Debug for SigHand {
@@ -51,6 +57,7 @@ impl SigHand {
         Arc::new(Self {
             inner: RwLock::new(InnerSigHand::default()),
             group_exec_wait_queue: WaitQueue::default(),
+            signalfd_wqh: WaitQueue::default(),
         })
     }
 
@@ -68,6 +75,14 @@ impl SigHand {
 
     fn group_exec_wait_queue(&self) -> &WaitQueue {
         &self.group_exec_wait_queue
+    }
+
+    /// 获取 signalfd 共享等待队列引用。
+    ///
+    /// signalfd 的 `read()` 路径在此队列上注册等待者，
+    /// 信号投递路径通过 `wakeup_all()` 唤醒它们。
+    pub fn signalfd_wqh(&self) -> &WaitQueue {
+        &self.signalfd_wqh
     }
 
     pub fn wait_group_exec_event_interruptible<F, B>(

--- a/kernel/src/ipc/signalfd.rs
+++ b/kernel/src/ipc/signalfd.rs
@@ -7,7 +7,9 @@ use core::mem::size_of;
 use bitflags::bitflags;
 
 use crate::arch::ipc::signal::{SigSet, Signal};
+use crate::arch::CurrentIrqArch;
 use crate::arch::MMArch;
+use crate::exception::InterruptArch;
 use crate::filesystem::epoll::event_poll::{EventPoll, LockedEPItemLinkedList};
 use crate::filesystem::epoll::{EPollEventType, EPollItem};
 use crate::filesystem::vfs::file::FileFlags;
@@ -17,7 +19,6 @@ use crate::filesystem::vfs::{
 };
 use crate::libs::mutex::MutexGuard;
 use crate::libs::spinlock::{SpinLock, SpinLockGuard};
-use crate::libs::wait_queue::WaitQueue;
 use crate::mm::MemoryManagementArch;
 use crate::process::ProcessManager;
 use crate::syscall::user_access::UserBufferReader;
@@ -100,7 +101,6 @@ struct SignalFdState {
 #[derive(Debug)]
 pub struct SignalFdInode {
     state: SpinLock<SignalFdState>,
-    wait_queue: WaitQueue,
     epitems: LockedEPItemLinkedList,
 }
 
@@ -130,7 +130,6 @@ impl SignalFdInode {
                 flags,
                 metadata,
             }),
-            wait_queue: WaitQueue::default(),
             epitems: LockedEPItemLinkedList::default(),
         }
     }
@@ -145,18 +144,16 @@ impl SignalFdInode {
     }
 
     fn readable(&self) -> bool {
-        let mask = self.state.lock().mask;
+        let mask = self.state.lock_irqsave().mask;
         self.has_pending_for_mask(&mask)
     }
 
-    pub fn notify_signal(&self, sig: Signal) {
-        let mask = self.state.lock().mask;
+    /// 仅通知 epoll 等待者。仅在进程上下文中调用（`Mutex` 安全）。
+    fn notify_epoll_only(&self, sig: Signal) {
+        let mask = self.state.lock_irqsave().mask;
         if !mask.contains(sig.into()) {
             return;
         }
-        // 唤醒阻塞 read() 的等待者
-        self.wait_queue.wakeup_all(None);
-        // 唤醒 epoll 等待者
         let _ = EventPoll::wakeup_epoll(
             &self.epitems,
             EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
@@ -165,7 +162,7 @@ impl SignalFdInode {
 
     fn dequeue_one(&self) -> Option<Signal> {
         let pcb = ProcessManager::current_pcb();
-        let mask = self.state.lock().mask;
+        let mask = self.state.lock_irqsave().mask;
         let ignore_mask = mask.complement();
         let (sig, _info) = pcb.dequeue_pending_signal(&ignore_mask);
         if sig == Signal::INVALID {
@@ -180,7 +177,7 @@ impl SignalFdInode {
     }
 
     pub(super) fn set_mask_and_flags(&self, mask: SigSet, flags: SignalFdFlags) {
-        let mut guard = self.state.lock();
+        let mut guard = self.state.lock_irqsave();
         guard.mask = mask;
         guard.flags = flags;
     }
@@ -188,7 +185,7 @@ impl SignalFdInode {
 
 impl PollableInode for SignalFdInode {
     fn poll(&self, _private_data: &FilePrivateData) -> Result<usize, SystemError> {
-        let mask = self.state.lock().mask;
+        let mask = self.state.lock_irqsave().mask;
         if self.has_pending_for_mask(&mask) {
             Ok((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as usize)
         } else {
@@ -259,14 +256,17 @@ impl IndexNode for SignalFdInode {
                 return Ok(size_of::<SignalFdSigInfo>());
             }
 
-            let state_guard = self.state.lock();
+            let state_guard = self.state.lock_irqsave();
             if self.nonblock(&state_guard) {
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
             drop(state_guard);
 
-            // 阻塞等待：由 notify_signal() 唤醒
-            let r = wq_wait_event_interruptible!(self.wait_queue, self.readable(), {});
+            // 阻塞等待：在 sighand 的共享 signalfd_wqh 上睡眠。
+            // 信号投递路径（含 hardirq）通过 signalfd_wqh.wakeup_all() 唤醒。
+            let pcb = ProcessManager::current_pcb();
+            let sighand = pcb.sighand();
+            let r = wq_wait_event_interruptible!(sighand.signalfd_wqh(), self.readable(), {});
             if r.is_err() {
                 return Err(SystemError::ERESTARTSYS);
             }
@@ -296,7 +296,7 @@ impl IndexNode for SignalFdInode {
     }
 
     fn metadata(&self) -> Result<Metadata, SystemError> {
-        Ok(self.state.lock().metadata.clone())
+        Ok(self.state.lock_irqsave().metadata.clone())
     }
 
     fn as_pollable_inode(&self) -> Result<&dyn PollableInode, SystemError> {
@@ -320,21 +320,44 @@ pub(super) fn read_user_sigset(mask_ptr: usize, mask_size: usize) -> Result<SigS
     Ok(SigSet::from_bits_truncate(bits))
 }
 
-/// 在向 pcb 投递信号后，唤醒该 pcb 中所有匹配 mask 的 signalfd。
+/// 在向 pcb 投递信号后，唤醒该 pcb 中所有 signalfd 等待者。
+///
+/// 此函数可能在 hardirq 上下文中调用（例如 timer IRQ → ITIMER_PROF → SIGPROF），
+/// 因此通知路径必须完全 hardirq-safe：
+///
+/// 1. **共享等待队列唤醒**（始终执行）：通过 `sighand.signalfd_wqh().wakeup_all()`
+///    唤醒所有阻塞在 signalfd `read()` 的线程。`WaitQueue` 内部使用
+///    `SpinLock` + `lock_irqsave`，hardirq 安全。
+///
+/// 2. **epoll 通知**（仅在进程上下文执行）：`EventPoll::wakeup_epoll` 依赖
+///    `Mutex`（可睡眠），不能在 hardirq 中调用。因此仅当 IRQ 开启（进程上下文）
+///    时才遍历 fd_table 做 epoll 通知。hardirq 场景下 epoll 用户将在下次
+///    `epoll_wait` re-poll 时感知就绪状态。
 pub fn notify_signalfd_for_pcb(pcb: &Arc<crate::process::ProcessControlBlock>, sig: Signal) {
+    // 始终安全：WaitQueue 内部使用 SpinLock + lock_irqsave
+    pcb.sighand().signalfd_wqh().wakeup_all(None);
+
+    // epoll 通知：仅在进程上下文中安全（IRQ enabled 表示非 hardirq）
+    if !CurrentIrqArch::is_irq_enabled() {
+        return;
+    }
+
+    // 进程上下文：走完整 epoll 通知路径
     let fd_table = {
         let basic = pcb.basic();
         basic.try_fd_table()
     };
     let Some(fd_table) = fd_table else {
-        // 该任务可能正在退出或是内核线程，没有 fd_table。
         return;
     };
-    let guard = fd_table.read();
+    // 使用 try_read 避免在信号投递路径上阻塞等锁
+    let Some(guard) = fd_table.try_read() else {
+        return;
+    };
     for (_fd, file) in guard.iter() {
         let inode = file.inode();
         if let Some(sfd) = inode.as_any_ref().downcast_ref::<SignalFdInode>() {
-            sfd.notify_signal(sig);
+            sfd.notify_epoll_only(sig);
         }
     }
 }

--- a/user/apps/c_unitest/test_signalfd_itimer.c
+++ b/user/apps/c_unitest/test_signalfd_itimer.c
@@ -1,0 +1,312 @@
+/**
+ * test_signalfd_itimer.c — 验证 SIGPROF + signalfd 不产生死锁
+ *
+ * 背景（Issue #1820）：
+ *   timer hardirq → ITIMER_PROF 到期 → send_signal(SIGPROF)
+ *   → complete_signal → notify_signalfd_for_pcb
+ *   该路径在 hardirq 上下文中执行。如果此时进程上下文正持有
+ *   SignalFdInode.state 的 SpinLock（比如在 read/poll 中），
+ *   hardirq 重入同一把锁就会自旋死锁。
+ *
+ * 本测试通过高频 ITIMER_PROF 触发 SIGPROF，同时在循环中
+ * 反复 read/poll signalfd，制造 hardirq 与进程上下文的竞争窗口。
+ * 如果存在死锁，内核会挂死（测试超时 = 失败）。
+ * 能跑完所有迭代即为 PASS。
+ *
+ * 测试矩阵：
+ *   Test 1: signalfd nonblock read  + ITIMER_PROF 高频
+ *   Test 2: signalfd blocking read  + ITIMER_PROF（线程发 kill 解除阻塞）
+ *   Test 3: signalfd + poll         + ITIMER_PROF 高频
+ *   Test 4: signalfd + epoll        + ITIMER_PROF 高频
+ */
+
+#include <errno.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/signalfd.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+/* ---------- 辅助 ---------- */
+
+#define ITERATIONS 50000
+#define TIMER_INTERVAL_US 500 /* 500µs，非常激进的 ITIMER_PROF 频率 */
+
+static void fail(const char *msg) {
+    perror(msg);
+    exit(EXIT_FAILURE);
+}
+
+/* 设置 ITIMER_PROF，高频产生 SIGPROF */
+static void start_itimer_prof(void) {
+    struct itimerval itv;
+    memset(&itv, 0, sizeof(itv));
+    itv.it_interval.tv_usec = TIMER_INTERVAL_US;
+    itv.it_value.tv_usec = TIMER_INTERVAL_US;
+    if (setitimer(ITIMER_PROF, &itv, NULL) < 0)
+        fail("setitimer(ITIMER_PROF)");
+}
+
+static void stop_itimer_prof(void) {
+    struct itimerval itv;
+    memset(&itv, 0, sizeof(itv));
+    setitimer(ITIMER_PROF, &itv, NULL);
+}
+
+/* 创建 signalfd 监听 SIGPROF，返回 fd */
+static int make_signalfd(int flags) {
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGPROF);
+    int fd = signalfd(-1, &mask, flags);
+    if (fd < 0)
+        fail("signalfd");
+    return fd;
+}
+
+/* 阻塞 SIGPROF（signalfd 要求信号被阻塞） */
+static void block_sigprof(void) {
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGPROF);
+    if (sigprocmask(SIG_BLOCK, &mask, NULL) < 0)
+        fail("sigprocmask(SIG_BLOCK, SIGPROF)");
+}
+
+/* CPU 密集小循环，消耗 prof-time 让 ITIMER_PROF 有机会 fire */
+static void burn_cpu(void) {
+    volatile int x = 0;
+    for (int j = 0; j < 200; j++)
+        x += j;
+    (void)x;
+}
+
+/* ---------- Test 1: nonblock read ---------- */
+
+static void test_nonblock_read(void) {
+    printf("[Test 1] signalfd nonblock read + ITIMER_PROF ... ");
+    fflush(stdout);
+
+    int sfd = make_signalfd(SFD_NONBLOCK);
+    start_itimer_prof();
+
+    struct signalfd_siginfo si;
+    int read_ok = 0;
+    for (int i = 0; i < ITERATIONS; i++) {
+        ssize_t n = read(sfd, &si, sizeof(si));
+        if (n == (ssize_t)sizeof(si))
+            read_ok++;
+        burn_cpu();
+    }
+
+    stop_itimer_prof();
+    close(sfd);
+    printf("PASS (read_ok=%d/%d)\n", read_ok, ITERATIONS);
+}
+
+/* ---------- Test 2: blocking read ---------- */
+
+struct blocking_ctx {
+    int sfd;
+    int ready; /* 简单栅栏 */
+};
+
+static void *blocking_reader(void *arg) {
+    struct blocking_ctx *ctx = arg;
+    struct signalfd_siginfo si;
+
+    __atomic_store_n(&ctx->ready, 1, __ATOMIC_RELEASE);
+
+    /* 阻塞 read：等待 SIGPROF 到达 */
+    ssize_t n = read(ctx->sfd, &si, sizeof(si));
+    if (n != (ssize_t)sizeof(si)) {
+        /* EINTR 也可以接受 */
+        if (errno != EINTR) {
+            perror("blocking read");
+            return (void *)1;
+        }
+    }
+    return NULL;
+}
+
+static void test_blocking_read(void) {
+    printf("[Test 2] signalfd blocking read + ITIMER_PROF ... ");
+    fflush(stdout);
+
+    int sfd = make_signalfd(0); /* 阻塞模式 */
+
+    struct blocking_ctx ctx = {.sfd = sfd, .ready = 0};
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, blocking_reader, &ctx) != 0)
+        fail("pthread_create");
+
+    /* 等读线程就位 */
+    while (!__atomic_load_n(&ctx.ready, __ATOMIC_ACQUIRE))
+        usleep(100);
+    usleep(1000); /* 让读线程真正进入 read 阻塞 */
+
+    /* 启动 ITIMER_PROF，SIGPROF 会唤醒 signalfd read */
+    start_itimer_prof();
+    burn_cpu(); /* 确保 timer 有 CPU time 可计量 */
+    usleep(50000); /* 50ms，给 ITIMER_PROF 充分触发时间 */
+
+    /* 如果 read 还没返回，发一个 SIGPROF 确保唤醒 */
+    kill(getpid(), SIGPROF);
+
+    void *ret;
+    pthread_join(tid, &ret);
+    stop_itimer_prof();
+    close(sfd);
+
+    if (ret != NULL) {
+        printf("FAIL\n");
+        exit(EXIT_FAILURE);
+    }
+    printf("PASS\n");
+}
+
+/* ---------- Test 3: poll ---------- */
+
+static void test_poll(void) {
+    printf("[Test 3] signalfd + poll + ITIMER_PROF ... ");
+    fflush(stdout);
+
+    int sfd = make_signalfd(SFD_NONBLOCK);
+    start_itimer_prof();
+
+    int poll_ready = 0;
+    for (int i = 0; i < ITERATIONS; i++) {
+        struct pollfd pfd = {.fd = sfd, .events = POLLIN};
+        int r = poll(&pfd, 1, 0); /* timeout=0，立即返回 */
+        if (r > 0 && (pfd.revents & POLLIN)) {
+            poll_ready++;
+            /* 消费掉信号 */
+            struct signalfd_siginfo si;
+            read(sfd, &si, sizeof(si));
+        }
+        burn_cpu();
+    }
+
+    stop_itimer_prof();
+    close(sfd);
+    printf("PASS (poll_ready=%d/%d)\n", poll_ready, ITERATIONS);
+}
+
+/* ---------- Test 4: epoll ---------- */
+
+static void test_epoll(void) {
+    printf("[Test 4] signalfd + epoll + ITIMER_PROF ... ");
+    fflush(stdout);
+
+    int sfd = make_signalfd(SFD_NONBLOCK);
+    int efd = epoll_create1(0);
+    if (efd < 0)
+        fail("epoll_create1");
+
+    struct epoll_event ev;
+    ev.events = EPOLLIN;
+    ev.data.fd = sfd;
+    if (epoll_ctl(efd, EPOLL_CTL_ADD, sfd, &ev) < 0)
+        fail("epoll_ctl ADD signalfd");
+
+    start_itimer_prof();
+
+    int epoll_ready = 0;
+    struct epoll_event revents[4];
+    for (int i = 0; i < ITERATIONS; i++) {
+        int n = epoll_wait(efd, revents, 4, 0); /* timeout=0 */
+        if (n > 0) {
+            epoll_ready++;
+            struct signalfd_siginfo si;
+            read(sfd, &si, sizeof(si));
+        }
+        burn_cpu();
+    }
+
+    stop_itimer_prof();
+    close(efd);
+    close(sfd);
+    printf("PASS (epoll_ready=%d/%d)\n", epoll_ready, ITERATIONS);
+}
+
+/* ---------- Test 5: 多 signalfd 并发 ---------- */
+
+struct mt_ctx {
+    int id;
+    int sfd;
+    int ok;
+};
+
+static void *mt_worker(void *arg) {
+    struct mt_ctx *ctx = arg;
+    struct signalfd_siginfo si;
+    int count = 0;
+    for (int i = 0; i < ITERATIONS / 4; i++) {
+        ssize_t n = read(ctx->sfd, &si, sizeof(si));
+        if (n == (ssize_t)sizeof(si))
+            count++;
+        burn_cpu();
+    }
+    ctx->ok = count;
+    return NULL;
+}
+
+static void test_multithread(void) {
+    printf("[Test 5] multi-thread signalfd + ITIMER_PROF ... ");
+    fflush(stdout);
+
+    /* 每个线程各自创建独立的 signalfd */
+    const int NTHREADS = 4;
+    pthread_t tids[4];
+    struct mt_ctx ctxs[4];
+
+    for (int i = 0; i < NTHREADS; i++) {
+        ctxs[i].id = i;
+        ctxs[i].sfd = make_signalfd(SFD_NONBLOCK);
+        ctxs[i].ok = 0;
+    }
+
+    start_itimer_prof();
+
+    for (int i = 0; i < NTHREADS; i++) {
+        if (pthread_create(&tids[i], NULL, mt_worker, &ctxs[i]) != 0)
+            fail("pthread_create mt");
+    }
+
+    for (int i = 0; i < NTHREADS; i++)
+        pthread_join(tids[i], NULL);
+
+    stop_itimer_prof();
+
+    int total = 0;
+    for (int i = 0; i < NTHREADS; i++) {
+        total += ctxs[i].ok;
+        close(ctxs[i].sfd);
+    }
+
+    printf("PASS (total_read=%d)\n", total);
+}
+
+/* ---------- main ---------- */
+
+int main(void) {
+    printf("=== test_signalfd_itimer (Issue #1820 deadlock verification) ===\n");
+    printf("ITERATIONS=%d  TIMER_INTERVAL=%dµs\n\n", ITERATIONS, TIMER_INTERVAL_US);
+
+    block_sigprof();
+
+    test_nonblock_read(); /* Test 1 */
+    test_blocking_read(); /* Test 2 */
+    test_poll();          /* Test 3 */
+    test_epoll();         /* Test 4 */
+    test_multithread();   /* Test 5 */
+
+    printf("\n=== ALL TESTS PASSED (no deadlock) ===\n");
+    return 0;
+}


### PR DESCRIPTION
### Summary

Fix a hardirq-context deadlock in the signalfd notification path, reported in #1820.

When `ITIMER_PROF` fires in a timer hardirq and delivers `SIGPROF`, the signal completion path calls `notify_signalfd_for_pcb()`. The previous implementation acquired three locks that are unsafe in hardirq context: a sleepable `RwSem` (fd_table), a non-irqsave `SpinLock` (SignalFdInode.state), and a sleepable `Mutex` (epoll epitems). This could cause a same-CPU reentrant deadlock when the hardirq interrupted a process-context path already holding `SignalFdInode.state`.

This patch adopts the proven Linux 6.6 `signalfd_wqh` design to make the notification path fully hardirq-safe.

### Root Cause

The deadlock scenario:

1. Thread enters signalfd `read()`/`poll()` → acquires `SignalFdInode.state.lock()` (SpinLock, IRQs still enabled)
2. Timer hardirq fires on the same CPU
3. `ITIMER_PROF` expires → `send_signal_to_pcb(SIGPROF)` → `complete_signal()` → `notify_signalfd_for_pcb()`
4. `notify_signalfd_for_pcb()` calls `fd_table.read()` (sleepable — illegal) and then `SignalFdInode.state.lock()` (reentrant on same CPU — deadlock)

### What Changed

#### `kernel/src/ipc/sighand.rs`
- Add `signalfd_wqh: WaitQueue` field to `SigHand`, mirroring Linux's `sighand_struct::signalfd_wqh`
- Add `signalfd_wqh()` public accessor

#### `kernel/src/ipc/signalfd.rs`
- **Rewrite `notify_signalfd_for_pcb()`**: hardirq path only does `signalfd_wqh.wakeup_all()` (O(1), hardirq-safe). Epoll notification is conditionally deferred to process context only, using `try_read()` instead of blocking `read()` on fd_table.
- **`read_at()`**: block on `sighand.signalfd_wqh()` instead of per-inode `wait_queue`
- **All `state.lock()` → `state.lock_irqsave()`**: 7 call sites converted as defence-in-depth
- Remove unused per-inode `wait_queue` field and `notify_signal()` method

#### `user/apps/c_unitest/test_signalfd_itimer.c` *(new file)*
- Targeted stress test that exercises the exact deadlock scenario: high-frequency `ITIMER_PROF` (500µs interval) generating `SIGPROF` while concurrently performing signalfd `read()`/`poll()`/`epoll_wait()` in tight loops
- 5 sub-tests: nonblock read, blocking read, poll, epoll, multi-thread (4 threads)
- 50,000 iterations per test — if the deadlock existed, the kernel would hang

### Design Rationale (Linux 6.6 Reference)

Linux solves this by embedding a `signalfd_wqh` wait queue directly in `sighand_struct`. Signal delivery (always under `sighand->siglock` with IRQs disabled) simply calls `wake_up(&tsk->sighand->signalfd_wqh)`. No fd_table iteration, no per-fd locks. signalfd's `read()` and `poll()` paths register on this shared queue. We adopt the same approach.

### Known Limitation

When signals are delivered from hardirq context (e.g., `SIGPROF` via `ITIMER_PROF`), epoll users monitoring a signalfd may experience slightly delayed notification since `EventPoll::wakeup_epoll()` depends on a `Mutex` and cannot be called from hardirq. The epoll user will pick up the ready state on the next `epoll_wait` timeout or re-poll. A follow-up improvement would be to make epoll's `LockedEPItemLinkedList` use an irq-safe `SpinLock` instead of `Mutex`, which is a broader epoll subsystem change.

Closes: #1820