### PR TITLE
refactor(epoll): optimize nested epoll notification and fix TCP packet parsing

### DIFF
--- a/kernel/src/filesystem/epoll/event_poll.rs
+++ b/kernel/src/filesystem/epoll/event_poll.rs
@@ -76,7 +76,7 @@ pub struct EventPoll {
     /// 就绪状态（由内层 irqsave SpinLock 保护）
     ready_state: Arc<SpinLock<ReadyState>>,
     /// 监听本 epollfd 的 epitems（用于支持 epoll 嵌套：epollfd 被加入另一个 epoll）
-    pub(super) poll_epitems: LockedEPItemLinkedList,
+    pub(super) poll_epitems: Arc<LockedEPItemLinkedList>,
     /// 是否已经关闭
     shutdown: AtomicBool,
     self_ref: Option<Weak<Mutex<EventPoll>>>,
@@ -95,7 +95,7 @@ impl EventPoll {
                 ovflist: None,
                 epoll_wq: WaitQueue::default(),
             })),
-            poll_epitems: LockedEPItemLinkedList::default(),
+            poll_epitems: Arc::new(LockedEPItemLinkedList::default()),
             shutdown: AtomicBool::new(false),
             self_ref: None,
         }
@@ -251,7 +251,7 @@ impl EventPoll {
             Self::ep_loop_check(&src_epoll, &dst_epoll)?;
         }
 
-        {
+        let notify_nested = {
             let mut epoll_guard = {
                 if nonblock {
                     // 如果设置非阻塞，则尝试获取一次锁
@@ -266,7 +266,7 @@ impl EventPoll {
             };
 
             let ep_item = epoll_guard.ep_items.get(&dstfd).cloned();
-            match op {
+            let notify_nested = match op {
                 EPollCtlOption::Add => {
                     // 如果已经存在，则返回错误
                     if ep_item.is_some() {
@@ -277,24 +277,24 @@ impl EventPoll {
                     let epitem = Arc::new(EPollItem::new(
                         Arc::downgrade(&epoll_data.epoll.0),
                         Arc::downgrade(&epoll_guard.ready_state),
+                        Arc::downgrade(&epoll_guard.poll_epitems),
                         epds,
                         dstfd,
                         Arc::downgrade(&dst_file),
                     ));
-                    Self::ep_insert(&mut epoll_guard, dst_file, epitem)?;
+                    Self::ep_insert(&mut epoll_guard, dst_file, epitem)?
                 }
-                EPollCtlOption::Del => {
-                    match ep_item {
-                        Some(ref ep_item) => {
-                            // 删除
-                            Self::ep_remove(&mut epoll_guard, dstfd, Some(dst_file), ep_item)?;
-                        }
-                        None => {
-                            // 不存在则返回错误
-                            return Err(SystemError::ENOENT);
-                        }
+                EPollCtlOption::Del => match ep_item {
+                    Some(ref ep_item) => {
+                        // 删除
+                        Self::ep_remove(&mut epoll_guard, dstfd, Some(dst_file), ep_item)?;
+                        false
                     }
-                }
+                    None => {
+                        // 不存在则返回错误
+                        return Err(SystemError::ENOENT);
+                    }
+                },
                 EPollCtlOption::Mod => {
                     // 不存在则返回错误
                     if ep_item.is_none() {
@@ -309,9 +309,22 @@ impl EventPoll {
                         epds.events |= EPollEventType::EPOLLEXCLUSIVE.bits();
                     }
 
-                    Self::ep_modify(&mut epoll_guard, ep_item, &epds)?;
+                    Self::ep_modify(&mut epoll_guard, ep_item, &epds)?
                 }
+            };
+
+            if notify_nested {
+                Some(epoll_guard.poll_epitems.clone())
+            } else {
+                None
             }
+        };
+
+        if let Some(poll_epitems) = notify_nested {
+            let _ = Self::wakeup_epoll(
+                poll_epitems.as_ref(),
+                EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
+            );
         }
 
         Ok(0)
@@ -511,7 +524,9 @@ impl EventPoll {
                 {
                     // 注册前再次检查，避免错过事件（仅需 SpinLock）
                     let rs = rs_arc.lock_irqsave();
-                    if !rs.ready_list.is_empty() || epoll.0.lock().shutdown.load(Ordering::SeqCst) {
+                    if Self::ready_state_has_events(&rs)
+                        || epoll.0.lock().shutdown.load(Ordering::SeqCst)
+                    {
                         available = true;
                         // 不注册，直接继续
                     } else {
@@ -539,7 +554,7 @@ impl EventPoll {
                     // 清理 waker（仅需 SpinLock）
                     let rs = rs_arc.lock_irqsave();
                     rs.epoll_wq.remove_waker(&waker);
-                    available = !rs.ready_list.is_empty();
+                    available = Self::ready_state_has_events(&rs);
                     if epoll.0.lock().shutdown.load(Ordering::SeqCst) {
                         // epoll 被关闭，直接退出
                         return Err(SystemError::EINVAL);
@@ -564,7 +579,12 @@ impl EventPoll {
     /// 通过 ready_state Arc 检查是否有就绪事件（不需要外层 Mutex）
     fn ep_events_available_rs(rs_arc: &Arc<SpinLock<ReadyState>>) -> bool {
         let rs = rs_arc.lock_irqsave();
-        !rs.ready_list.is_empty()
+        Self::ready_state_has_events(&rs)
+    }
+
+    #[inline]
+    fn ready_state_has_events(rs: &ReadyState) -> bool {
+        !rs.ready_list.is_empty() || rs.ovflist.is_some()
     }
 
     /// 开始就绪列表扫描：偷取 ready_list 到返回的 Vec 中，
@@ -684,7 +704,7 @@ impl EventPoll {
         epoll_guard: &mut MutexGuard<EventPoll>,
         dst_file: Arc<File>,
         epitem: Arc<EPollItem>,
-    ) -> Result<(), SystemError> {
+    ) -> Result<bool, SystemError> {
         // 检查文件是否为"总是就绪"类型（不支持poll的普通文件/目录）
         let is_always_ready = dst_file.is_always_ready();
 
@@ -716,27 +736,18 @@ impl EventPoll {
 
         // 现在检查文件是否已经有事件发生。
         let event = epitem.ep_item_poll();
+        let mut notify_nested = false;
         if !event.is_empty() {
             let mut rs = epoll_guard.ready_state.lock_irqsave();
             if !rs.ready_list.iter().any(|e| Arc::ptr_eq(e, &epitem)) {
                 let was_empty = rs.ready_list.is_empty();
                 rs.ready_list.push_back(epitem.clone());
-                // 通知嵌套 epoll（如果 ready_list 从空变非空）
-                if was_empty {
-                    drop(rs);
-                    let _ = Self::wakeup_epoll(
-                        &epoll_guard.poll_epitems,
-                        EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
-                    );
-                    let rs2 = epoll_guard.ready_state.lock_irqsave();
-                    rs2.epoll_wq.wakeup(None);
-                } else {
-                    rs.epoll_wq.wakeup(None);
-                }
+                notify_nested = was_empty;
+                rs.epoll_wq.wakeup(None);
             }
         }
 
-        Ok(())
+        Ok(notify_nested)
     }
 
     pub fn ep_remove(
@@ -767,7 +778,7 @@ impl EventPoll {
         epoll_guard: &mut MutexGuard<EventPoll>,
         epitem: Arc<EPollItem>,
         event: &EPollEvent,
-    ) -> Result<(), SystemError> {
+    ) -> Result<bool, SystemError> {
         let mut epi_event_guard = epitem.event.lock_irqsave();
 
         // 修改epitem
@@ -777,33 +788,25 @@ impl EventPoll {
         drop(epi_event_guard);
         // 修改后检查文件是否已经有感兴趣事件发生
         let event = epitem.ep_item_poll();
+        let mut notify_nested = false;
         if !event.is_empty() {
             let mut rs = epoll_guard.ready_state.lock_irqsave();
             if !rs.ready_list.iter().any(|e| Arc::ptr_eq(e, &epitem)) {
                 let was_empty = rs.ready_list.is_empty();
                 rs.ready_list.push_back(epitem.clone());
-                if was_empty {
-                    drop(rs);
-                    let _ = Self::wakeup_epoll(
-                        &epoll_guard.poll_epitems,
-                        EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
-                    );
-                    let rs2 = epoll_guard.ready_state.lock_irqsave();
-                    rs2.epoll_wq.wakeup(None);
-                } else {
-                    rs.epoll_wq.wakeup(None);
-                }
+                notify_nested = was_empty;
+                rs.epoll_wq.wakeup(None);
             }
         }
         // TODO:处理EPOLLWAKEUP，目前不支持
 
-        Ok(())
+        Ok(notify_nested)
     }
 
     /// ### 判断epoll是否有就绪item（由外层 Mutex 保护的调用路径使用）
     pub fn ep_events_available(&self) -> bool {
         let rs = self.ready_state.lock_irqsave();
-        !rs.ready_list.is_empty()
+        Self::ready_state_has_events(&rs)
     }
 
     /// Linux 语义：epoll 嵌套需要进行 loop/depth 检查（失败返回 ELOOP）。
@@ -897,28 +900,37 @@ impl EventPoll {
                 continue;
             }
 
-            // 仅获取 SpinLock（irqsave）— hardirq-safe
-            let mut rs = rs_arc.lock_irqsave();
+            {
+                // 仅获取 SpinLock（irqsave）— hardirq-safe
+                let mut rs = rs_arc.lock_irqsave();
 
-            if let Some(ref mut ovflist) = rs.ovflist {
-                // 扫描进行中 — 推入溢出列表
-                if !ovflist.iter().any(|e| Arc::ptr_eq(e, epitem)) {
-                    ovflist.push(epitem.clone());
+                if let Some(ref mut ovflist) = rs.ovflist {
+                    // 扫描进行中 — 推入溢出列表
+                    if !ovflist.iter().any(|e| Arc::ptr_eq(e, epitem)) {
+                        ovflist.push(epitem.clone());
+                    }
+                } else {
+                    // 正常模式 — 推入 ready_list
+                    if !rs.ready_list.iter().any(|e| Arc::ptr_eq(e, epitem)) {
+                        rs.ready_list.push_back(epitem.clone());
+                    }
                 }
-            } else {
-                // 正常模式 — 推入 ready_list
-                if !rs.ready_list.iter().any(|e| Arc::ptr_eq(e, epitem)) {
-                    rs.ready_list.push_back(epitem.clone());
+
+                if ep_events.contains(EPollEventType::EPOLLEXCLUSIVE)
+                    && !pollflags.contains(EPollEventType::POLLFREE)
+                {
+                    // 避免惊群
+                    rs.epoll_wq.wakeup(None);
+                } else {
+                    rs.epoll_wq.wakeup_all(None);
                 }
             }
 
-            if ep_events.contains(EPollEventType::EPOLLEXCLUSIVE)
-                && !pollflags.contains(EPollEventType::POLLFREE)
-            {
-                // 避免惊群
-                rs.epoll_wq.wakeup(None);
-            } else {
-                rs.epoll_wq.wakeup_all(None);
+            if let Some(poll_epitems) = epitem.poll_epitems().upgrade() {
+                let _ = Self::wakeup_epoll(
+                    poll_epitems.as_ref(),
+                    EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
+                );
             }
         }
         Ok(())

--- a/kernel/src/filesystem/epoll/fs.rs
+++ b/kernel/src/filesystem/epoll/fs.rs
@@ -109,12 +109,8 @@ impl PollableInode for EPollInode {
         epitem: Arc<super::EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        self.epoll
-            .0
-            .lock()
-            .poll_epitems
-            .lock_irqsave()
-            .push_back(epitem);
+        let poll_epitems = { self.epoll.0.lock().poll_epitems.clone() };
+        poll_epitems.lock_irqsave().push_back(epitem);
         Ok(())
     }
 
@@ -123,8 +119,8 @@ impl PollableInode for EPollInode {
         epitem: &Arc<super::EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let ep = self.epoll.0.lock();
-        let mut guard = ep.poll_epitems.lock_irqsave();
+        let poll_epitems = { self.epoll.0.lock().poll_epitems.clone() };
+        let mut guard = poll_epitems.lock_irqsave();
         let len = guard.len();
         guard.retain(|x| !Arc::ptr_eq(x, epitem));
         if guard.len() != len {

--- a/kernel/src/filesystem/epoll/mod.rs
+++ b/kernel/src/filesystem/epoll/mod.rs
@@ -2,7 +2,7 @@ use super::{poll::PollFlags, vfs::file::File};
 use crate::libs::{mutex::Mutex, spinlock::SpinLock};
 use alloc::sync::Weak;
 use core::fmt::Debug;
-use event_poll::{EventPoll, ReadyState};
+use event_poll::{EventPoll, LockedEPItemLinkedList, ReadyState};
 use system_error::SystemError;
 
 pub mod event_poll;
@@ -57,6 +57,8 @@ pub struct EPollItem {
     /// 直接引用 EventPoll 的 ready_state，使回调路径绕过外层 Mutex。
     /// 对标 Linux 中 ep_poll_callback 仅获取 ep->lock 而不获取 ep->mtx 的设计。
     ready_state: Weak<SpinLock<ReadyState>>,
+    /// 直接引用 EventPoll 的 poll_epitems，使嵌套 epoll 的向上传播无需获取外层 Mutex。
+    poll_epitems: Weak<LockedEPItemLinkedList>,
     /// 用户注册的事件
     /// 使用 irqsave SpinLock 而非 RwSem，因为 wakeup_epoll 回调路径可能在
     /// hardirq 上下文中执行（例如 timer IRQ → signal → signalfd → epoll），
@@ -74,6 +76,7 @@ impl EPollItem {
     pub(super) fn new(
         epoll: Weak<Mutex<EventPoll>>,
         ready_state: Weak<SpinLock<ReadyState>>,
+        poll_epitems: Weak<LockedEPItemLinkedList>,
         events: EPollEvent,
         fd: i32,
         file: Weak<File>,
@@ -81,6 +84,7 @@ impl EPollItem {
         Self {
             epoll,
             ready_state,
+            poll_epitems,
             event: SpinLock::new(events),
             fd,
             file,
@@ -95,6 +99,12 @@ impl EPollItem {
     #[allow(dead_code)]
     pub(crate) fn ready_state(&self) -> Weak<SpinLock<ReadyState>> {
         self.ready_state.clone()
+    }
+
+    /// 获取 poll_epitems 的 Weak 引用，用于嵌套 epoll 的向上传播。
+    #[allow(dead_code)]
+    pub(crate) fn poll_epitems(&self) -> Weak<LockedEPItemLinkedList> {
+        self.poll_epitems.clone()
     }
 
     pub fn event(&self) -> &SpinLock<EPollEvent> {

--- a/kernel/src/net/socket/inet/stream/events.rs
+++ b/kernel/src/net/socket/inet/stream/events.rs
@@ -82,7 +82,7 @@ impl TcpSocket {
                 // Self-connect is modeled by an internal receive queue. Readable becomes true
                 // when the queue has data OR after SHUT_WR (EOF). Writable depends on queue
                 // free space unless SHUT_WR (then send() returns EPIPE).
-                sc.update_io_events(&self.pollee, self.is_send_shutdown());
+                sc.update_io_events(&self.pollee);
 
                 // Match established behavior for shutdown bits.
                 if self.is_send_shutdown() {

--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -916,6 +916,9 @@ pub struct SelfConnected {
     /// Effective receive capacity for the loopback queue (bytes).
     rx_cap: AtomicUsize,
     buf: Mutex<VecDeque<u8>>,
+    /// SHUT_WR flag for this self-connected socket. Stored here to avoid TOCTOU
+    /// race between checking shutdown and checking queue emptiness.
+    send_shutdown: AtomicBool,
 }
 
 impl SelfConnected {
@@ -929,6 +932,7 @@ impl SelfConnected {
             local,
             rx_cap: AtomicUsize::new(rx_cap),
             buf: Mutex::new(VecDeque::new()),
+            send_shutdown: AtomicBool::new(false),
         }
     }
 
@@ -993,20 +997,27 @@ impl SelfConnected {
         Ok(n)
     }
 
-    pub fn recv_into(
-        &self,
-        out: &mut [u8],
-        peek: bool,
-        trunc: bool,
-        send_shutdown: bool,
-    ) -> Result<usize, SystemError> {
+    /// Set the send_shutdown flag (called when SHUT_WR is performed).
+    pub fn set_send_shutdown(&self) {
+        self.send_shutdown.store(true, Ordering::Release);
+    }
+
+    /// Check if send_shutdown flag is set.
+    #[inline]
+    #[allow(dead_code)]
+    pub fn is_send_shutdown(&self) -> bool {
+        self.send_shutdown.load(Ordering::Acquire)
+    }
+
+    pub fn recv_into(&self, out: &mut [u8], peek: bool, trunc: bool) -> Result<usize, SystemError> {
         if out.is_empty() {
             return Ok(0);
         }
         let mut q = self.buf.lock();
         if q.is_empty() {
             // EOF after SHUT_WR once all queued data is drained.
-            if send_shutdown {
+            // Check send_shutdown inside the lock to avoid TOCTOU race.
+            if self.send_shutdown.load(Ordering::Acquire) {
                 return Ok(0);
             }
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -1032,7 +1043,6 @@ impl SelfConnected {
         out: &mut UserBuffer<'_>,
         offset: usize,
         max_len: usize,
-        send_shutdown: bool,
     ) -> Result<usize, SystemError> {
         if offset > out.len() {
             return Err(SystemError::EINVAL);
@@ -1044,7 +1054,8 @@ impl SelfConnected {
 
         let mut q = self.buf.lock();
         if q.is_empty() {
-            if send_shutdown {
+            // Check send_shutdown inside the lock to avoid TOCTOU race.
+            if self.send_shutdown.load(Ordering::Acquire) {
                 return Ok(0);
             }
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -1066,7 +1077,8 @@ impl SelfConnected {
         }
     }
 
-    pub fn update_io_events(&self, pollee: &AtomicUsize, send_shutdown: bool) {
+    pub fn update_io_events(&self, pollee: &AtomicUsize) {
+        let send_shutdown = self.send_shutdown.load(Ordering::Acquire);
         let queued = self.recv_queue();
         let cap = self.rx_cap.load(Ordering::Relaxed);
         let writable = !send_shutdown && queued < cap;

--- a/kernel/src/net/socket/inet/stream/io.rs
+++ b/kernel/src/net/socket/inet/stream/io.rs
@@ -398,8 +398,7 @@ impl TcpSocket {
                     }
                     let peek = flags.contains(PMSG::PEEK);
                     let trunc = flags.contains(PMSG::TRUNC);
-                    let send_shutdown = self.is_send_shutdown();
-                    let n = sc.recv_into(current_buf, peek, trunc, send_shutdown)?;
+                    let n = sc.recv_into(current_buf, peek, trunc)?;
                     if self.is_recv_shutdown() && !peek && self.recv_shutdown.record_read(n) {
                         sc.discard_all();
                     }
@@ -504,8 +503,7 @@ impl TcpSocket {
                         }
                         limit = core::cmp::min(limit, remaining);
                     }
-                    let n =
-                        sc.recv_to_user(user_buffer, total_read, limit, self.is_send_shutdown())?;
+                    let n = sc.recv_to_user(user_buffer, total_read, limit)?;
                     if self.is_recv_shutdown() && self.recv_shutdown.record_read(n) {
                         sc.discard_all();
                     }

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -413,6 +413,9 @@ impl TcpSocket {
                 // - SHUT_WR: subsequent send() returns EPIPE; recv() returns EOF once queue drains.
                 // - SHUT_RD: subsequent recv() returns 0.
                 // No smoltcp close/abort is needed.
+                if how.contains(ShutdownBit::SHUT_WR) {
+                    sc.set_send_shutdown();
+                }
                 if how.contains(ShutdownBit::SHUT_RD) {
                     let queued = sc.recv_queue();
                     self.recv_shutdown.init(queued);

--- a/kernel/src/net/socket/inet/stream/stream_core.rs
+++ b/kernel/src/net/socket/inet/stream/stream_core.rs
@@ -435,7 +435,7 @@ impl TcpSocket {
             }
             Some(inner::Inner::SelfConnected(sc)) => {
                 sc.set_recv_buffer_size(rx_size);
-                sc.update_io_events(&self.pollee, self.is_send_shutdown());
+                sc.update_io_events(&self.pollee);
             }
             Some(inner::Inner::Connecting(connecting)) => {
                 connecting.with_mut(|socket| {

--- a/kernel/src/net/tcp_listener_backlog.rs
+++ b/kernel/src/net/tcp_listener_backlog.rs
@@ -121,17 +121,23 @@ impl TcpListenerBacklog {
             }
         }
 
-        if let Ok(pkt4) = Ipv4Packet::new_checked(maybe_ip) {
-            if pkt4.next_header() != IpProtocol::Tcp {
-                return false;
+        // 先检查 IP 版本，再解析，避免 smoltcp::Ipv4Packet::new_checked 不校验版本字段
+        // 导致 IPv6 包误走 IPv4 解析路径。
+        let version = maybe_ip.first().map(|b| b >> 4).unwrap_or(0);
+
+        if version == 4 {
+            if let Ok(pkt4) = Ipv4Packet::new_checked(maybe_ip) {
+                if pkt4.next_header() != IpProtocol::Tcp {
+                    return false;
+                }
+                if let Ok(tcp) = TcpPacket::new_checked(pkt4.payload()) {
+                    dst_port = Some(tcp.dst_port());
+                    is_pure_syn = tcp.syn() && !tcp.ack();
+                }
             }
-            if let Ok(tcp) = TcpPacket::new_checked(pkt4.payload()) {
-                dst_port = Some(tcp.dst_port());
-                is_pure_syn = tcp.syn() && !tcp.ack();
-            }
-        } else if let Ok(pkt6) = Ipv6Packet::new_checked(maybe_ip) {
+        } else if version == 6 {
             // IPv6 可能包含扩展头，这里做一个保守跳过：能到 TCP 则解析，否则不丢。
-            let data = pkt6.as_ref();
+            let data = maybe_ip;
             if data.len() < 40 {
                 return false;
             }

--- a/user/apps/tests/syscall/gvisor/blocklists/tcp_socket_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/tcp_socket_test
@@ -1,1 +1,0 @@
-*SimpleTcpSocketTest.OnlyAcknowledgeBacklogConnections/1


### PR DESCRIPTION


- Change`poll_epitems`to`Arc<LockedEPItemLinkedList>` for lock-free nested epoll notification
- Add`poll_epitems`reference to`EPollItem` to propagate events without outer mutex
- Return`notify_nested`flag from`ep_insert`and`ep_modify` to conditionally wake up parent epolls
- Fix TCP packet parsing by checking IP version before IPv4/IPv6 validation
- Remove obsolete test file`tcp_socket_test`