### PR TITLE
fix(procfs): replace todo!() in ProcDir::link() with EPERM

### DIFF
--- a/kernel/src/filesystem/procfs/template/dir.rs
+++ b/kernel/src/filesystem/procfs/template/dir.rs
@@ -230,7 +230,7 @@ impl<Ops: DirOps + 'static> IndexNode for ProcDir<Ops> {
     }
 
     fn link(&self, _name: &str, _other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
-        todo!("procfs dir link not implemented");
+        Err(SystemError::EPERM)
     }
 }
 

--- a/user/apps/c_unitest/test_procfs_link.c
+++ b/user/apps/c_unitest/test_procfs_link.c
@@ -1,0 +1,41 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/**
+ * Test that link(2) on procfs entries returns EPERM.
+ *
+ * procfs is a virtual filesystem that does not support hard links.
+ * Attempting to create a hard link targeting a procfs entry should
+ * fail with EPERM, matching Linux kernel behavior.
+ */
+
+#define TEST_PROCFS_PATH "/proc/self/status"
+#define TEST_LINK_PATH "/tmp/procfs_link_test"
+
+int main(void) {
+    int ret;
+
+    /* Attempt to create a hard link from a procfs entry */
+    ret = link(TEST_PROCFS_PATH, TEST_LINK_PATH);
+
+    if (ret == 0) {
+        fprintf(stderr,
+                "FAIL: link(\"%s\", \"%s\") succeeded unexpectedly\n",
+                TEST_PROCFS_PATH, TEST_LINK_PATH);
+        unlink(TEST_LINK_PATH);
+        return EXIT_FAILURE;
+    }
+
+    if (errno != EPERM && errno != EXDEV) {
+        fprintf(stderr,
+                "FAIL: link() returned errno %d (%m), expected EPERM (%d) "
+                "or EXDEV (%d)\n",
+                errno, EPERM, EXDEV);
+        return EXIT_FAILURE;
+    }
+
+    printf("PASS: link() on procfs correctly returned errno %d (%m)\n", errno);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Replaced `todo!("procfs dir link not implemented")` with `Err(SystemError::EPERM)` in `ProcDir`'s `IndexNode::link()` implementation (`kernel/src/filesystem/procfs/template/dir.rs:232`).

procfs is a virtual filesystem that does not support hard links. The `todo!()` caused a kernel panic if any code path reached this method. On Linux, `link(2)` against a procfs entry returns `EPERM` since procfs inodes don't implement `i_op->link`.

Fixes #1836

---

This contribution was developed with AI assistance (Claude Code).

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)