### PR TITLE
fix: fchown on O_PATH fd should return EBADF

### DIFF
--- a/kernel/src/filesystem/vfs/syscall/sys_fchown.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchown.rs
@@ -1,9 +1,11 @@
 use system_error::SystemError;
 
 use crate::arch::syscall::nr::SYS_FCHOWN;
+use crate::filesystem::vfs::file::FileFlags;
 use crate::{
     arch::interrupt::TrapFrame,
     filesystem::vfs::open::ksys_fchown,
+    process::ProcessManager,
     syscall::table::{FormattedSyscallParam, Syscall},
 };
 use alloc::vec::Vec;
@@ -19,6 +21,19 @@ impl Syscall for SysFchownHandle {
         let fd = Self::fd(args);
         let uid = Self::uid(args);
         let gid = Self::gid(args);
+
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+        let file = fd_table_guard
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?;
+
+        // Linux 语义：对 O_PATH fd 执行 fchown 应返回 EBADF
+        if file.flags().contains(FileFlags::O_PATH) {
+            return Err(SystemError::EBADF);
+        }
+        drop(fd_table_guard);
+
         ksys_fchown(fd, uid, gid)
     }
 


### PR DESCRIPTION
Fixes #1839

Linux semantics require that fchown(2) on a file descriptor opened with O_PATH must fail with EBADF. This check was missing in sys_fchown.rs.