### PR TITLE
fix: setgroups(size=0) does not commit cleared groups back to the PCB

### DIFF
--- a/kernel/src/process/syscall/sys_groups.rs
+++ b/kernel/src/process/syscall/sys_groups.rs
@@ -82,6 +82,7 @@ impl Syscall for SysSetGroups {
         if size == 0 {
             // clear all supplementary groups
             cred.setgroups(Vec::new());
+            *pcb.cred.lock() = Cred::new_arc(cred);
             return Ok(0);
         }
         if size > NGROUPS_MAX {


### PR DESCRIPTION
Fixes #1838

Calling setgroups(0, NULL) was modifying a local copy of credentials but not writing them back to the PCB. This fix ensures the updated credentials are persisted.