### PR TITLE
feat(fs): implement FileSystem::info() for FAT and ext4 to unblock statfs(2)

### DIFF
--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -39,7 +39,10 @@ impl FileSystem for Ext4FileSystem {
     }
 
     fn info(&self) -> vfs::FsInfo {
-        todo!()
+        vfs::FsInfo {
+            blk_dev_id: self.raw_dev.data() as usize,
+            max_name_len: 255,
+        }
     }
 
     fn as_any_ref(&self) -> &dyn core::any::Any {

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -425,7 +425,10 @@ impl FileSystem for FATFileSystem {
     }
 
     fn info(&self) -> crate::filesystem::vfs::FsInfo {
-        todo!()
+        crate::filesystem::vfs::FsInfo {
+            blk_dev_id: self.gendisk.device_num().data() as usize,
+            max_name_len: 255,
+        }
     }
 
     /// @brief 本函数用于实现动态转换。


### PR DESCRIPTION
Fixes #1842

Implemented `FileSystem::info()` for both FAT and ext4 filesystems to populate the `FsInfo` struct. This resolves the kernel panics encountered when `statfs(2)` or `fstatfs(2)` is called on these mounts, enabling proper metadata querying.