### PR TITLE
refactor(arch/x86_64): improve APIC ID handling and SMP initialization

### DIFF
--- a/kernel/src/arch/x86_64/cpu.rs
+++ b/kernel/src/arch/x86_64/cpu.rs
@@ -1,15 +1,80 @@
 use core::hint::spin_loop;
 
-use x86::cpuid::{cpuid, CpuIdResult};
+use raw_cpuid::CpuId;
+use x86::msr::{rdmsr, IA32_APIC_BASE, IA32_X2APIC_APICID};
 
-use crate::smp::cpu::ProcessorId;
+use crate::{arch::smp::SMP_BOOT_DATA, smp::cpu::ProcessorId};
 
-/// 获取当前cpu的apic id
+/// 获取当前CPU的逻辑编号
 #[inline]
 pub fn current_cpu_id() -> ProcessorId {
-    let cpuid_res: CpuIdResult = cpuid!(0x1);
-    let cpu_id = (cpuid_res.ebx >> 24) & 0xff;
-    return ProcessorId::new(cpu_id);
+    if !SMP_BOOT_DATA.is_initialized() {
+        return ProcessorId::new(0);
+    }
+
+    let x2apic_id = current_x2apic_physical_id();
+    if let Some(apic_id) = x2apic_id {
+        if let Some(cpu_id) = phys_apic_id_to_cpu_id(apic_id) {
+            return cpu_id;
+        }
+    }
+
+    let cpuid_apic_id = current_apic_physical_id();
+    if let Some(cpu_id) = phys_apic_id_to_cpu_id(cpuid_apic_id) {
+        return cpu_id;
+    }
+
+    panic!(
+        "current cpu apic id is not present in SMP_BOOT_DATA: x2apic={x2apic_id:?}, cpuid={cpuid_apic_id}, bsp_phys_id={}",
+        SMP_BOOT_DATA.bsp_phys_id()
+    );
+}
+
+/// 获取当前CPU的物理APIC ID
+#[inline]
+pub fn current_apic_physical_id() -> usize {
+    let cpuid = CpuId::new();
+
+    if let Some(topology) = cpuid.get_extended_topology_info() {
+        if let Some(apic_id) = topology.map(|level| level.x2apic_id()).next() {
+            return apic_id as usize;
+        }
+    }
+
+    if let Some(topology) = cpuid.get_processor_topology_info() {
+        return topology.x2apic_id() as usize;
+    }
+
+    if let Some(feature_info) = cpuid.get_feature_info() {
+        return feature_info.initial_local_apic_id() as usize;
+    }
+
+    return 0;
+}
+
+#[inline]
+fn current_x2apic_physical_id() -> Option<usize> {
+    let apic_base = unsafe { rdmsr(IA32_APIC_BASE) };
+    if (apic_base & (1 << 10)) == 0 {
+        return None;
+    }
+
+    Some(unsafe { rdmsr(IA32_X2APIC_APICID) as usize })
+}
+
+#[inline]
+pub fn phys_apic_id_to_cpu_id(apic_id: usize) -> Option<ProcessorId> {
+    if !SMP_BOOT_DATA.is_initialized() {
+        return Some(ProcessorId::new(apic_id as u32));
+    }
+
+    for cpu in 0..SMP_BOOT_DATA.cpu_count() {
+        if SMP_BOOT_DATA.phys_id(cpu) == apic_id {
+            return Some(ProcessorId::new(cpu as u32));
+        }
+    }
+
+    None
 }
 
 /// 重置cpu

--- a/kernel/src/arch/x86_64/driver/apic/x2apic.rs
+++ b/kernel/src/arch/x86_64/driver/apic/x2apic.rs
@@ -1,9 +1,12 @@
-use core::sync::atomic::{fence, Ordering};
+use core::{
+    hint::spin_loop,
+    sync::atomic::{fence, Ordering},
+};
 
 use log::info;
 use x86::msr::{
-    rdmsr, wrmsr, IA32_APIC_BASE, IA32_X2APIC_APICID, IA32_X2APIC_EOI, IA32_X2APIC_SIVR,
-    IA32_X2APIC_VERSION,
+    rdmsr, wrmsr, IA32_APIC_BASE, IA32_X2APIC_APICID, IA32_X2APIC_EOI, IA32_X2APIC_ICR,
+    IA32_X2APIC_SIVR, IA32_X2APIC_VERSION,
 };
 
 use super::{hw_irq::ApicId, LVTRegister, LocalAPIC, LVT};
@@ -121,6 +124,14 @@ impl LocalAPIC for X2Apic {
     }
 
     fn write_icr(&self, icr: x86::apic::Icr) {
-        unsafe { wrmsr(0x830, ((icr.upper() as u64) << 32) | icr.lower() as u64) };
+        unsafe {
+            wrmsr(
+                IA32_X2APIC_ICR,
+                ((icr.upper() as u64) << 32) | icr.lower() as u64,
+            );
+            while ((rdmsr(IA32_X2APIC_ICR) >> 12) & 0x1) != 0 {
+                spin_loop();
+            }
+        };
     }
 }

--- a/kernel/src/arch/x86_64/interrupt/ipi.rs
+++ b/kernel/src/arch/x86_64/interrupt/ipi.rs
@@ -101,10 +101,11 @@ impl ArchIpiTarget {
 
     #[inline(always)]
     fn cpu_id_to_apic_id(cpu_id: ProcessorId) -> x86::apic::ApicId {
+        let apic_id = SMP_BOOT_DATA.phys_id(cpu_id.data() as usize) as u32;
         if CurrentApic.x2apic_enabled() {
-            x86::apic::ApicId::X2Apic(cpu_id.data())
+            x86::apic::ApicId::X2Apic(apic_id)
         } else {
-            x86::apic::ApicId::XApic(cpu_id.data() as u8)
+            x86::apic::ApicId::XApic(apic_id as u8)
         }
     }
 }
@@ -157,33 +158,70 @@ pub fn send_ipi(kind: IpiKind, target: IpiTarget) {
     CurrentApic.write_icr(icr);
 }
 
-/// 发送smp初始化IPI
-pub fn ipi_send_smp_init() {
-    let target = ArchIpiTarget::Other;
+/// 向目标CPU发送smp初始化IPI
+pub fn ipi_send_smp_init(target_cpu: ProcessorId) -> Result<(), SystemError> {
+    if target_cpu.data() as usize >= SMP_BOOT_DATA.cpu_count() {
+        return Err(SystemError::EINVAL);
+    }
+    let target: ArchIpiTarget = IpiTarget::Specified(target_cpu).into();
     let icr = if CurrentApic.x2apic_enabled() {
         x86::apic::Icr::for_x2apic(
             0,
             target.into(),
-            x86::apic::DestinationShorthand::AllExcludingSelf,
+            x86::apic::DestinationShorthand::NoShorthand,
             x86::apic::DeliveryMode::Init,
             x86::apic::DestinationMode::Physical,
             x86::apic::DeliveryStatus::Idle,
-            x86::apic::Level::Deassert,
-            x86::apic::TriggerMode::Edge,
+            x86::apic::Level::Assert,
+            x86::apic::TriggerMode::Level,
         )
     } else {
         x86::apic::Icr::for_xapic(
             0,
             target.into(),
-            x86::apic::DestinationShorthand::AllExcludingSelf,
+            x86::apic::DestinationShorthand::NoShorthand,
+            x86::apic::DeliveryMode::Init,
+            x86::apic::DestinationMode::Physical,
+            x86::apic::DeliveryStatus::Idle,
+            x86::apic::Level::Assert,
+            x86::apic::TriggerMode::Level,
+        )
+    };
+    CurrentApic.write_icr(icr);
+    return Ok(());
+}
+
+/// 向目标CPU发送smp初始化IPI的deassert阶段
+pub fn ipi_send_smp_init_deassert(target_cpu: ProcessorId) -> Result<(), SystemError> {
+    if target_cpu.data() as usize >= SMP_BOOT_DATA.cpu_count() {
+        return Err(SystemError::EINVAL);
+    }
+    let target: ArchIpiTarget = IpiTarget::Specified(target_cpu).into();
+    let icr = if CurrentApic.x2apic_enabled() {
+        x86::apic::Icr::for_x2apic(
+            0,
+            target.into(),
+            x86::apic::DestinationShorthand::NoShorthand,
             x86::apic::DeliveryMode::Init,
             x86::apic::DestinationMode::Physical,
             x86::apic::DeliveryStatus::Idle,
             x86::apic::Level::Deassert,
-            x86::apic::TriggerMode::Edge,
+            x86::apic::TriggerMode::Level,
+        )
+    } else {
+        x86::apic::Icr::for_xapic(
+            0,
+            target.into(),
+            x86::apic::DestinationShorthand::NoShorthand,
+            x86::apic::DeliveryMode::Init,
+            x86::apic::DestinationMode::Physical,
+            x86::apic::DeliveryStatus::Idle,
+            x86::apic::Level::Deassert,
+            x86::apic::TriggerMode::Level,
         )
     };
     CurrentApic.write_icr(icr);
+    return Ok(());
 }
 
 /// 发送smp启动IPI
@@ -205,7 +243,7 @@ pub fn ipi_send_smp_startup(target_cpu: ProcessorId) -> Result<(), SystemError> 
             x86::apic::DeliveryMode::StartUp,
             x86::apic::DestinationMode::Physical,
             x86::apic::DeliveryStatus::Idle,
-            x86::apic::Level::Deassert,
+            x86::apic::Level::Assert,
             x86::apic::TriggerMode::Edge,
         )
     } else {
@@ -216,7 +254,7 @@ pub fn ipi_send_smp_startup(target_cpu: ProcessorId) -> Result<(), SystemError> 
             x86::apic::DeliveryMode::StartUp,
             x86::apic::DestinationMode::Physical,
             x86::apic::DeliveryStatus::Idle,
-            x86::apic::Level::Deassert,
+            x86::apic::Level::Assert,
             x86::apic::TriggerMode::Edge,
         )
     };

--- a/kernel/src/arch/x86_64/smp/mod.rs
+++ b/kernel/src/arch/x86_64/smp/mod.rs
@@ -7,12 +7,13 @@ use core::{
 
 use kdepends::memoffset::offset_of;
 use log::debug;
+use raw_cpuid::CpuId;
 use system_error::SystemError;
 
 use crate::{
-    arch::{mm::LowAddressRemapping, process::table::TSSManager, MMArch},
+    arch::{mm::LowAddressRemapping, process::table::TSSManager, CurrentTimeArch, MMArch},
     exception::InterruptArch,
-    libs::{cpumask::CpuMask, rwlock::RwLock},
+    libs::cpumask::CpuMask,
     mm::{percpu::PerCpu, MemoryManagementArch, PhysAddr, VirtAddr, IDLE_PROCESS_ADDRESS_SPACE},
     process::ProcessManager,
     smp::{
@@ -25,9 +26,10 @@ use crate::{
 
 use super::{
     acpi::early_acpi_boot_init,
-    interrupt::ipi::{ipi_send_smp_init, ipi_send_smp_startup},
+    interrupt::ipi::{ipi_send_smp_init, ipi_send_smp_init_deassert, ipi_send_smp_startup},
     CurrentIrqArch,
 };
+use crate::time::TimeArch;
 
 extern "C" {
     /// AP处理器启动时，会将CR3设置为这个值
@@ -37,6 +39,10 @@ extern "C" {
 }
 
 pub(super) static X86_64_SMP_MANAGER: X86_64SmpManager = X86_64SmpManager::new();
+
+const AP_INIT_ASSERT_DELAY_NS_LEGACY: usize = 10_000_000;
+const AP_STARTUP_RETRY_DELAY_NS_MODERN: usize = 20_000;
+const AP_STARTUP_RETRY_DELAY_NS_LEGACY: usize = 500_000;
 
 #[repr(C)]
 struct ApStartStackInfo {
@@ -110,6 +116,10 @@ impl SmpBootData {
         self.cpu_count
     }
 
+    pub fn is_initialized(&self) -> bool {
+        self.initialized.load(Ordering::SeqCst)
+    }
+
     /// 获取CPU的物理ID
     pub fn phys_id(&self, cpu_id: usize) -> usize {
         self.phys_id[cpu_id]
@@ -149,7 +159,7 @@ pub static SMP_BOOT_DATA: SmpBootData = SmpBootData {
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct X86_64SmpManager {
-    ia64_cpu_to_sapicid: RwLock<[Option<usize>; PerCpu::MAX_CPU_NUM as usize]>,
+    _reserved: (),
 }
 
 impl X86_64SmpManager {
@@ -158,15 +168,11 @@ impl X86_64SmpManager {
     /// 注：由于该函数只在编译时被调用，因此 `#[allow(clippy::large_stack_frames)]` 是安全的。
     #[allow(clippy::large_stack_frames)]
     const fn new() -> Self {
-        return Self {
-            ia64_cpu_to_sapicid: RwLock::new([None; PerCpu::MAX_CPU_NUM as usize]),
-        };
+        return Self { _reserved: () };
     }
 
     /// initialize the logical cpu number to APIC ID mapping
     pub fn build_cpu_map(&self) -> Result<(), SystemError> {
-        // 参考：https://code.dragonos.org.cn/xref/linux-6.1.9/arch/ia64/kernel/smpboot.c?fi=smp_build_cpu_map#496
-        // todo!("build_cpu_map")
         unsafe {
             smp_cpu_manager().set_possible_cpu(ProcessorId::new(0), true);
             smp_cpu_manager().set_present_cpu(ProcessorId::new(0), true);
@@ -218,12 +224,17 @@ impl SMPArch for X86_64SMPArch {
 
     fn start_cpu(cpu_id: ProcessorId, _cpu_hpstate: &CpuHpCpuState) -> Result<(), SystemError> {
         Self::copy_smp_start_code();
+        let init_assert_delay_ns = Self::ap_init_assert_delay_ns();
 
         fence(Ordering::SeqCst);
-        ipi_send_smp_init();
+        ipi_send_smp_init(cpu_id)?;
+        Self::busy_wait_ns(init_assert_delay_ns);
+        fence(Ordering::SeqCst);
+        ipi_send_smp_init_deassert(cpu_id)?;
         fence(Ordering::SeqCst);
         ipi_send_smp_startup(cpu_id)?;
 
+        Self::busy_wait_ns(Self::startup_retry_delay_ns(init_assert_delay_ns));
         fence(Ordering::SeqCst);
         ipi_send_smp_startup(cpu_id)?;
 
@@ -235,6 +246,49 @@ impl SMPArch for X86_64SMPArch {
 
 impl X86_64SMPArch {
     const SMP_CODE_START: usize = 0x20000;
+
+    #[inline(always)]
+    fn ap_init_assert_delay_ns() -> usize {
+        let cpuid = CpuId::new();
+        let Some(feature_info) = cpuid.get_feature_info() else {
+            return AP_INIT_ASSERT_DELAY_NS_LEGACY;
+        };
+        let Some(vendor_info) = cpuid.get_vendor_info() else {
+            return AP_INIT_ASSERT_DELAY_NS_LEGACY;
+        };
+
+        let family_id = feature_info.family_id() as u32;
+        let display_family = if family_id == 0x0f {
+            family_id + feature_info.extended_family_id() as u32
+        } else {
+            family_id
+        };
+
+        match vendor_info.as_str() {
+            "GenuineIntel" if display_family == 0x06 => 0,
+            "AuthenticAMD" if display_family >= 0x0f => 0,
+            "HygonGenuine" if display_family >= 0x18 => 0,
+            _ => AP_INIT_ASSERT_DELAY_NS_LEGACY,
+        }
+    }
+
+    #[inline(always)]
+    fn startup_retry_delay_ns(init_assert_delay_ns: usize) -> usize {
+        if init_assert_delay_ns == 0 {
+            AP_STARTUP_RETRY_DELAY_NS_MODERN
+        } else {
+            AP_STARTUP_RETRY_DELAY_NS_LEGACY
+        }
+    }
+
+    #[inline(always)]
+    fn busy_wait_ns(ns: usize) {
+        let expire = CurrentTimeArch::cal_expire_cycles(ns);
+        while CurrentTimeArch::get_cycles() < expire {
+            spin_loop();
+        }
+    }
+
     /// 复制SMP启动代码到0x20000处
     fn copy_smp_start_code() -> (VirtAddr, usize) {
         let apu_boot_size = Self::start_code_size();

--- a/kernel/src/process/rseq.rs
+++ b/kernel/src/process/rseq.rs
@@ -17,9 +17,9 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use system_error::SystemError;
 
 use crate::{
-    arch::cpu::current_cpu_id,
     mm::VirtAddr,
     process::{ProcessControlBlock, ProcessFlags, ProcessManager},
+    smp::core::smp_get_processor_id,
 };
 
 // ============================================================================
@@ -582,7 +582,7 @@ impl Rseq {
         }
 
         // 更新 cpu_id 等字段
-        let cpu_id = current_cpu_id().data() as u32;
+        let cpu_id = smp_get_processor_id().data() as u32;
         if let Err(_e) = unsafe { access.update_cpu_node_id(cpu_id, 0, 0) } {
             // log::debug!("rseq update_cpu_node_id failed: {:?}", e);
             Self::disable_current_rseq_after_fault(&pcb);

--- a/kernel/src/tracepoint/trace_pipe.rs
+++ b/kernel/src/tracepoint/trace_pipe.rs
@@ -1,4 +1,7 @@
-use crate::tracepoint::{TraceEntry, TracePointMap};
+use crate::{
+    smp::core::smp_get_processor_id,
+    tracepoint::{TraceEntry, TracePointMap},
+};
 use alloc::{format, string::String, vec::Vec};
 
 pub trait TracePipeOps {
@@ -227,7 +230,7 @@ impl TraceEntryParser {
         let str = fmt_func(&entry[offset..]);
 
         let time = crate::time::Instant::now().total_micros() * 1000; // Convert to nanoseconds
-        let cpu_id = crate::arch::cpu::current_cpu_id().data();
+        let cpu_id = smp_get_processor_id().data();
 
         // Copy the packed field to a local variable to avoid unaligned reference
         let pid = trace_entry.pid;


### PR DESCRIPTION
- Refactor`current_cpu_id()`to use SMP boot data for APIC ID mapping
- Add support for x2APIC ID retrieval and conversion to logical CPU ID
- Implement proper SMP initialization IPI sequence with timing delays
- Fix IPI target mapping to use physical APIC IDs from SMP boot data
- Replace direct CPU ID calls with`smp_get_processor_id()` in trace and rseq modules