### PR TITLE
feat(mm): 实现 mm-aware TLB shootdown 基础设施

### DIFF
--- a/kernel/src/arch/riscv64/interrupt/ipi.rs
+++ b/kernel/src/arch/riscv64/interrupt/ipi.rs
@@ -6,6 +6,17 @@ use crate::{
     smp::core::smp_get_processor_id,
 };
 
+/// IPI delivery on RISC-V:
+///
+/// - `FlushTLB` broadcasts TLB invalidation synchronously via SBI `remote_sfence_vma`;
+///   when the call returns, all target CPUs have completed invalidation. No per-CPU CSD
+///   ack protocol is needed (unlike x86_64).
+/// - Therefore `crate::mm::tlb::flush_tlb_multi` on RISC-V goes directly here without
+///   requiring the initiator to poll for ack before returning to userspace.
+///
+/// Other direct-send paths for `IpiKind::FlushTLB` (e.g. the old `InactiveFlusher` /
+/// `PageFlushAll`) have been removed on x86_64; the RISC-V implementation is kept here
+/// to facilitate future integration with the new `mm::tlb::flush_tlb_multi` flow.
 #[inline(always)]
 pub fn send_ipi(kind: IpiKind, target: IpiTarget) {
     let mask = Into::into(target);

--- a/kernel/src/arch/riscv64/process/mod.rs
+++ b/kernel/src/arch/riscv64/process/mod.rs
@@ -173,10 +173,35 @@ impl ProcessManager {
         Self::switch_local_context(&prev, &next);
 
         // 切换地址空间（无锁快速路径）
+        // 必须同时维护 mm-aware shootdown 的前置状态：
+        //   - 被切出的 mm：从 active_cpus 里摘掉当前 CPU；
+        //   - 被切入的 mm：在加载 satp 后写入 active_cpus 并更新 per-CPU TlbState.loaded_mm，
+        //     这样后续 `flush_tlb_mm_range` / `flush_tlb_multi` 才能正确把本 CPU 当成目标。
+        // 顺序：clear(prev) -> make_current(next) -> set(next) -> tlb_state_set_loaded_mm(next)
+        // 与 x86_64 switch_process 保持一致 (见 kernel/src/arch/x86_64/process/mod.rs:switch_process)。
         let next_addr_space = next.basic().user_vm().unwrap();
+        let prev_addr_space = prev.basic().user_vm();
+        let cpu = crate::smp::core::smp_get_processor_id();
         compiler_fence(Ordering::SeqCst);
 
+        let same_mm = match prev_addr_space.as_ref() {
+            Some(p) => Arc::ptr_eq(p, &next_addr_space),
+            None => false,
+        };
+
+        if !same_mm {
+            if let Some(prev_mm) = prev_addr_space.as_ref() {
+                prev_mm.active_cpus_clear(cpu);
+            }
+        }
+
         next_addr_space.make_current();
+        compiler_fence(Ordering::SeqCst);
+
+        if !same_mm {
+            next_addr_space.active_cpus_set(cpu);
+        }
+        unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(next_addr_space.clone()) };
         compiler_fence(Ordering::SeqCst);
 
         // debug!("current sum={}, prev sum={}, next_sum={}", riscv::register::sstatus::read().sum(), prev.arch_info_irqsave().sstatus.sum(), next.arch_info_irqsave().sstatus.sum());

--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -426,7 +426,13 @@ impl X86_64MMArch {
                 return;
             }
             let mapper = &mut space_guard.user_mapper.utable;
-            let message = PageFaultMessage::new(vma.clone(), address, flags, mapper);
+            let message = PageFaultMessage::new(
+                vma.clone(),
+                address,
+                flags,
+                mapper,
+                current_address_space.clone(),
+            );
 
             fault = PageFaultHandler::handle_mm_fault(message);
 

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -399,9 +399,34 @@ impl ProcessManager {
 
         // 切换地址空间（无锁快速路径）
         let next_addr_space = next.basic().user_vm().unwrap();
+        let prev_addr_space = prev.basic().user_vm();
+        let cpu = crate::smp::core::smp_get_processor_id();
         compiler_fence(Ordering::SeqCst);
 
+        // INV-1: clear prev mm's bit before switching hardware page table (if prev/next differ),
+        // set next mm's bit after switching.
+        // Order: clear(prev) → set CR3 → set(next) → update per-CPU TlbState.
+        //
+        // Note: if prev and next point to the same mm (same-address-space thread switch), keep the bit unchanged.
+        let same_mm = match prev_addr_space.as_ref() {
+            Some(p) => Arc::ptr_eq(p, &next_addr_space),
+            None => false,
+        };
+
+        if !same_mm {
+            if let Some(prev_mm) = prev_addr_space.as_ref() {
+                prev_mm.active_cpus_clear(cpu);
+            }
+        }
+
         next_addr_space.make_current();
+        compiler_fence(Ordering::SeqCst);
+
+        if !same_mm {
+            next_addr_space.active_cpus_set(cpu);
+        }
+        // Update per-CPU TlbState: hardware-loaded mm and generation
+        crate::mm::tlb::tlb_state_set_loaded_mm(next_addr_space.clone());
         compiler_fence(Ordering::SeqCst);
         // 切换内核栈
 

--- a/kernel/src/exception/ipi.rs
+++ b/kernel/src/exception/ipi.rs
@@ -5,8 +5,6 @@ use system_error::SystemError;
 use crate::arch::driver::apic::{CurrentApic, LocalAPIC};
 
 use crate::{
-    arch::MMArch,
-    mm::MemoryManagementArch,
     sched::{SchedMode, __schedule},
     smp::cpu::ProcessorId,
 };
@@ -21,6 +19,21 @@ use super::{
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum IpiKind {
     KickCpu,
+    /// TLB shootdown IPI.
+    ///
+    /// Do NOT directly `send_ipi(IpiKind::FlushTLB, ..)` in new code:
+    ///
+    /// - On x86_64 this IPI is issued by [`crate::mm::tlb::flush_tlb_multi`] via the per-CPU CSD
+    ///   protocol; the receiving end [`FlushTLBIpiHandler`] reads `FlushTlbInfo` from the CSD
+    ///   and performs a synchronous ack. A bare send provides no context and won't be waited
+    ///   on by the initiator, inevitably breaking the "shootdown before free" ordering.
+    /// - On RISC-V `send_ipi(IpiKind::FlushTLB, ..)` is completed synchronously via SBI
+    ///   `remote_sfence_vma` without going through `FlushTLBIpiHandler`; it is still
+    ///   restricted to be called only from the `mm::tlb` layer to keep the interface
+    ///   consistent with future per-mm range flush support.
+    ///
+    /// All subsystems (mmap/munmap/mprotect/mremap/madvise/zap_file_mappings/...) must go
+    /// through [`crate::mm::mmu_gather::MmuGather`] + [`crate::mm::ucontext::AddressSpace::flush_tlb_range`].
     FlushTLB,
     /// 指定中断向量号
     SpecVector(HardwareIrqNumber),
@@ -60,7 +73,10 @@ impl IrqHandler for KickCpuIpiHandler {
     }
 }
 
-/// 处理TLB刷新的IPI
+/// IPI handler for TLB flushing.
+///
+/// This handler is only invoked via the per-CPU CSD protocol by `crate::mm::tlb::flush_tlb_multi`.
+/// Direct bare sends of `IpiKind::FlushTLB` are forbidden.
 #[derive(Debug)]
 pub struct FlushTLBIpiHandler;
 
@@ -71,7 +87,10 @@ impl IrqHandler for FlushTLBIpiHandler {
         _static_data: Option<&dyn IrqHandlerData>,
         _dynamic_data: Option<Arc<dyn IrqHandlerData>>,
     ) -> Result<IrqReturn, SystemError> {
-        unsafe { MMArch::invalidate_all() };
+        // Read the FlushTlbInfo context written by the initiator from the per-CPU CSD slot,
+        // perform TLB invalidation for the corresponding range, and finally set `done` so
+        // the initiator can synchronously wait.
+        crate::mm::tlb::remote_flush_tlb_on_ipi();
 
         Ok(IrqReturn::Handled)
     }

--- a/kernel/src/ipc/syscall/sys_shmat.rs
+++ b/kernel/src/ipc/syscall/sys_shmat.rs
@@ -8,7 +8,8 @@ use crate::{
     libs::align::page_align_up,
     mm::{
         allocator::page_frame::{PageFrameCount, PhysPageFrame, VirtPageFrame},
-        page::{page_manager_lock, EntryFlags, PageFlushAll},
+        mmu_gather::MmuGather,
+        page::{page_manager_lock, DeferredFlusher, EntryFlags},
         syscall::ProtFlags,
         ucontext::{AddressSpace, PhysmapParams, VMA},
         VirtAddr, VmFlags,
@@ -58,7 +59,9 @@ pub(super) fn do_kernel_shmat(
             let destination = VirtPageFrame::new(region.start());
             let page_flags: EntryFlags<MMArch> =
                 EntryFlags::from_prot_flags(ProtFlags::from(vm_flags), true);
-            let flusher: PageFlushAll<MMArch> = PageFlushAll::new();
+            // New region mapping: no prior PTE, no TLB shootdown needed;
+            // use DeferredFlusher to silently consume internal PageFlush tokens.
+            let flusher = DeferredFlusher::new();
 
             // 将共享内存映射到对应虚拟区域
             let params = PhysmapParams {
@@ -98,9 +101,12 @@ pub(super) fn do_kernel_shmat(
                 .ok_or(SystemError::EINVAL)?
                 .1;
 
-            // 取消原映射
-            let flusher: PageFlushAll<MMArch> = PageFlushAll::new();
-            vma.unmap(&mut address_write_guard.user_mapper.utable, flusher);
+            // Unmap the old mapping via MmuGather: cross-core shootdown first, then free physical pages (INV-3).
+            {
+                let mut tlb = MmuGather::gather(&current_address_space);
+                vma.unmap(&mut address_write_guard.user_mapper.utable, &mut tlb);
+                tlb.finish();
+            }
 
             // 将该虚拟内存区域映射到共享内存区域
             let mut page_manager_guard = page_manager_lock();

--- a/kernel/src/ipc/syscall/sys_shmdt.rs
+++ b/kernel/src/ipc/syscall/sys_shmdt.rs
@@ -1,9 +1,8 @@
 use crate::arch::interrupt::TrapFrame;
-use crate::mm::page::PageFlushAll;
+use crate::mm::mmu_gather::MmuGather;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::{
     arch::syscall::nr::SYS_SHMDT,
-    arch::MMArch,
     mm::{ucontext::AddressSpace, VirtAddr},
     syscall::table::Syscall,
 };
@@ -56,9 +55,12 @@ impl Syscall for SysShmdtHandle {
             return Err(SystemError::EINVAL);
         }
 
-        // 取消映射
-        let flusher: PageFlushAll<MMArch> = PageFlushAll::new();
-        vma.unmap(&mut address_write_guard.user_mapper.utable, flusher);
+        // Unmap via MmuGather: shootdown first, then free physical pages (INV-3).
+        {
+            let mut tlb = MmuGather::gather(&current_address_space);
+            vma.unmap(&mut address_write_guard.user_mapper.utable, &mut tlb);
+            tlb.finish();
+        }
 
         return Ok(0);
     }

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -12,7 +12,7 @@ use crate::{
     libs::align::align_down,
     mm::{
         page::{page_manager_lock, EntryFlags},
-        ucontext::LockedVMA,
+        ucontext::{AddressSpace, LockedVMA},
         VirtAddr, VmFaultReason, VmFlags,
     },
     process::{ProcessManager, ProcessState},
@@ -58,6 +58,10 @@ pub struct PageFaultMessage<'a> {
     page: Option<Arc<Page>>,
     /// 写时拷贝需要的页面
     cow_page: Option<Arc<Page>>,
+    /// 缺页所属的地址空间。
+    ///
+    /// do_wp_page 等在修改 PTE 后需要走 mm-aware shootdown 的路径要依赖它（`AddressSpace::flush_tlb_range`）。
+    mm: Arc<AddressSpace>,
 }
 
 impl<'a> PageFaultMessage<'a> {
@@ -66,6 +70,7 @@ impl<'a> PageFaultMessage<'a> {
         address: VirtAddr,
         flags: FaultFlags,
         mapper: &'a mut PageMapper,
+        mm: Arc<AddressSpace>,
     ) -> Self {
         let guard = vma.lock();
         let backing_pgoff = guard.backing_page_offset().map(|backing_page_offset| {
@@ -80,6 +85,7 @@ impl<'a> PageFaultMessage<'a> {
             page: None,
             mapper,
             cow_page: None,
+            mm,
         }
     }
 
@@ -105,6 +111,12 @@ impl<'a> PageFaultMessage<'a> {
     #[allow(dead_code)]
     pub fn flags(&self) -> FaultFlags {
         self.flags
+    }
+
+    /// 缺页所属的地址空间。
+    #[inline(always)]
+    pub fn mm(&self) -> &Arc<AddressSpace> {
+        &self.mm
     }
 }
 
@@ -470,6 +482,7 @@ impl PageFaultHandler {
     pub unsafe fn do_wp_page(pfm: &mut PageFaultMessage) -> VmFaultReason {
         let address = pfm.address_aligned_down();
         let vma = pfm.vma.clone();
+        let mm = pfm.mm().clone();
         let mapper = &mut pfm.mapper;
 
         let old_paddr = mapper.translate(address).unwrap().0;
@@ -481,8 +494,15 @@ impl PageFaultHandler {
         let mut entry = mapper.get_entry(address, 0).unwrap();
         let new_flags = entry.flags().set_write(true).set_dirty(true);
 
+        // 统一为 do_wp_page 所有分支做 mm-aware shootdown：
+        // 这里的 `mm` 可能被多个线程/CPU 共享（CLONE_VM / CLONE_THREAD），
+        // 任何修改 PTE（RO -> RW 或替换物理页）的分支都必须让远端 CPU 同步失效旧 TLB。
+        // 旧的本地 `invlpg` / 无 flush 写法会让其他 CPU 继续持有旧翻译，
+        // 导致错误的重复写保护 fault 或访问到已被替换的旧物理页（风险 4 残留）。
+        let end = VirtAddr::new(address.data() + MMArch::PAGE_SIZE);
+
         if vma.lock().vm_flags().contains(VmFlags::VM_SHARED) {
-            // 共享映射，直接修改页表项保护位，标记为脏页
+            // 共享映射：原地升级 PTE 为可写，并标记脏。
             let table = mapper.get_table(address, 0).unwrap();
             let i = table.index_of(address).unwrap();
             entry.set_flags(new_flags);
@@ -495,24 +515,33 @@ impl PageFaultHandler {
                 }
             }
 
+            // PTE 从 RO 升级为 RW：其他 CPU 持有的 RO 缓存会导致它们访问时触发虚假写保护 fault，
+            // 必须 mm-aware shootdown 让其它 CPU 重新 walk 最新 PTE。
+            mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
             VmFaultReason::VM_FAULT_COMPLETED
         } else if vma.is_anonymous() {
             // 私有匿名映射，根据引用计数判断是否拷贝页面
             if map_count == 1 {
+                // 只剩当前 mm 引用该页：直接原地升级为可写。
+                // 注意：这里 `map_count == 1` 仅代表“只有一个 VMA 在 rmap 链上映射到该物理页”，
+                // 不代表“只有一个 CPU 在运行这个 mm”，所以仍然需要 mm-aware shootdown。
                 let table = mapper.get_table(address, 0).unwrap();
                 let i = table.index_of(address).unwrap();
                 entry.set_flags(new_flags);
                 table.set_entry(i, entry);
+
+                mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
                 VmFaultReason::VM_FAULT_COMPLETED
             } else if let Some(flush) = mapper.map(address, new_flags) {
                 let mut page_manager_guard = page_manager_lock();
                 let old_page = page_manager_guard.get_unwrap(&old_paddr);
                 old_page.write().remove_vma(&vma);
-                // drop(page_manager_guard);
 
-                flush.flush();
+                // 替换为新的物理页：必须先让其他 CPU 的 TLB 失效，
+                // 才能保证它们不会再通过旧 TLB 访问旧物理页。
+                // SAFETY: 后续 mm.flush_tlb_range 会做 mm-aware 远端 + 本地 shootdown。
+                unsafe { flush.ignore() };
                 let paddr = mapper.translate(address).unwrap().0;
-                // let mut page_manager_guard = page_manager_lock();
                 let page = page_manager_guard.get_unwrap(&paddr);
                 page.write().insert_vma(vma.clone());
 
@@ -521,6 +550,8 @@ impl PageFaultHandler {
                     MMArch::PAGE_SIZE,
                 );
 
+                drop(page_manager_guard);
+                mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
                 VmFaultReason::VM_FAULT_COMPLETED
             } else {
                 VmFaultReason::VM_FAULT_OOM
@@ -531,11 +562,10 @@ impl PageFaultHandler {
                 let mut page_manager_guard = page_manager_lock();
                 let old_page = page_manager_guard.get_unwrap(&old_paddr);
                 old_page.write().remove_vma(&vma);
-                // drop(page_manager_guard);
 
-                flush.flush();
+                // SAFETY: 后续 mm.flush_tlb_range 会做 mm-aware 远端 + 本地 shootdown。
+                unsafe { flush.ignore() };
                 let paddr = mapper.translate(address).unwrap().0;
-                // let mut page_manager_guard = page_manager_lock();
                 let page = page_manager_guard.get_unwrap(&paddr);
                 page.write().insert_vma(vma.clone());
 
@@ -544,6 +574,8 @@ impl PageFaultHandler {
                     MMArch::PAGE_SIZE,
                 );
 
+                drop(page_manager_guard);
+                mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
                 VmFaultReason::VM_FAULT_COMPLETED
             } else {
                 VmFaultReason::VM_FAULT_OOM

--- a/kernel/src/mm/init.rs
+++ b/kernel/src/mm/init.rs
@@ -60,6 +60,8 @@ pub unsafe fn mm_init() {
     page_manager_init();
     // enable PAGE_RECLAIMER
     page_reclaimer_init();
+    // init per-CPU TLB state / CSD slots
+    crate::mm::tlb::tlb_init();
 
     MM_INIT
         .compare_exchange(

--- a/kernel/src/mm/madvise.rs
+++ b/kernel/src/mm/madvise.rs
@@ -3,7 +3,8 @@ use system_error::SystemError;
 use crate::arch::{mm::PageMapper, MMArch};
 
 use super::{
-    page::Flusher, syscall::MadvFlags, ucontext::LockedVMA, MemoryManagementArch, VirtAddr, VmFlags,
+    mmu_gather::MmuGather, syscall::MadvFlags, ucontext::LockedVMA, MemoryManagementArch, VirtAddr,
+    VmFlags,
 };
 
 impl LockedVMA {
@@ -11,7 +12,7 @@ impl LockedVMA {
         &self,
         behavior: MadvFlags,
         mapper: &mut PageMapper,
-        mut flusher: impl Flusher<MMArch>,
+        tlb: &mut MmuGather<'_>,
     ) -> Result<(), SystemError> {
         //TODO https://code.dragonos.org.cn/xref/linux-6.6.21/mm/madvise.c?fi=madvise#do_madvise
         let mut vma = self.lock();
@@ -32,12 +33,16 @@ impl LockedVMA {
 
                 while current_page < end_page {
                     let virt_addr = VirtAddr::new(current_page.data());
-                    if let Some((_phys_addr, _)) = mapper.translate(virt_addr) {
+                    if let Some((_paddr, _)) = mapper.translate(virt_addr) {
                         // 只有当页面已经映射时才需要解除映射
                         unsafe {
                             if let Some((_, _, flush)) = mapper.unmap_phys(virt_addr, false) {
-                                // 刷新TLB
-                                flusher.consume(flush);
+                                // Local PTE cleared; actual TLB invalidation is performed uniformly by MmuGather.
+                                // Note: the current implementation does not reclaim physical pages (keeping legacy
+                                // behavior). To support real reclamation of anon pages in the future, call
+                                // `tlb.stash_paddr(_paddr)` here.
+                                flush.ignore();
+                                tlb.accumulate_range(virt_addr);
                             }
                         }
                     }

--- a/kernel/src/mm/mmu_gather.rs
+++ b/kernel/src/mm/mmu_gather.rs
@@ -1,0 +1,184 @@
+//! Simplified `mmu_gather` for DragonOS (cf. Linux 6.6 `include/asm-generic/tlb.h`)
+//!
+//! Enforces the ordering: shootdown first, then free physical pages / page-table pages (INV-3):
+//!
+//! 1) Page table entries are cleared by PageMapper.
+//! 2) Arc references to physical pages are stashed in `pending_pages` instead of being dropped immediately.
+//! 3) `flush_mmu_tlbonly()` performs remote + local TLB invalidation via `AddressSpace::flush_tlb_range` (synchronous ack).
+//! 4) `flush_mmu_free()` finally drops pending_pages, triggering `deallocate_page_frames`.
+//!
+//! This guarantees that no matter how many other CPUs share the mm, they cannot hit a freed
+//! physical page through a stale TLB entry.
+
+use alloc::{sync::Arc, vec::Vec};
+
+use crate::{
+    arch::MMArch,
+    mm::{
+        page::{page_manager_lock, Page},
+        tlb::TLB_FLUSH_ALL,
+        ucontext::AddressSpace,
+        MemoryManagementArch, PhysAddr, VirtAddr,
+    },
+};
+
+/// Batch processor for a single mmu modification session.
+///
+/// Usage:
+///
+/// ```ignore
+/// let mut tlb = MmuGather::gather(mm, start, end);
+/// // ... call PageMapper to unmap, pass the returned PhysAddr to tlb.remove_page(paddr) ...
+/// tlb.finish(); // flush TLB first, then free pages
+/// ```
+pub struct MmuGather<'mm> {
+    /// Target mm for shootdown.
+    ///
+    /// `None` means "no shootdown needed" — used on the teardown path (`Drop for InnerAddressSpace`)
+    /// where the `Arc<AddressSpace>` itself is being dropped, so its strong-count has already hit 0,
+    /// `Weak::upgrade` can no longer obtain the Arc, and `active_cpus` has already been cleared by
+    /// all process-exit paths. In this case there is literally no CPU holding a TLB entry for this mm,
+    /// so `flush_mmu_tlbonly` becomes a no-op while the page-free bookkeeping still runs.
+    mm: Option<&'mm Arc<AddressSpace>>,
+    /// Range start (to be accumulated)
+    start: VirtAddr,
+    /// Range end (to be accumulated, exclusive)
+    end: VirtAddr,
+    /// Whether to perform a full-mm flush (common for large munmap)
+    fullmm: bool,
+    /// Whether page-table pages were freed (Linux freed_tables)
+    freed_tables: bool,
+    /// Accumulated physical pages pending release (dropped after flush_mmu_tlbonly)
+    pending_pages: Vec<Arc<Page>>,
+    /// Stride shift (typically PAGE_SHIFT)
+    stride_shift: u8,
+    /// Whether finish() has been called, preventing double free
+    finished: bool,
+}
+
+impl<'mm> MmuGather<'mm> {
+    /// Start a gather. Initial range is empty; expand via `accumulate_range` later.
+    pub fn gather(mm: &'mm Arc<AddressSpace>) -> Self {
+        Self {
+            mm: Some(mm),
+            start: VirtAddr::new(usize::MAX),
+            end: VirtAddr::new(0),
+            fullmm: false,
+            freed_tables: false,
+            pending_pages: Vec::new(),
+            stride_shift: MMArch::PAGE_SHIFT as u8,
+            finished: false,
+        }
+    }
+
+    /// Gather without a shootdown target. Used only from the mm-teardown path
+    /// (`InnerAddressSpace::drop`), where the `Arc<AddressSpace>` is already being dropped
+    /// and `active_cpus` is guaranteed empty.
+    ///
+    /// `flush_mmu_tlbonly` is a no-op on this variant; `finish()` still drops stashed pages.
+    pub fn gather_teardown() -> Self {
+        Self {
+            mm: None,
+            start: VirtAddr::new(usize::MAX),
+            end: VirtAddr::new(0),
+            fullmm: false,
+            freed_tables: false,
+            pending_pages: Vec::new(),
+            stride_shift: MMArch::PAGE_SHIFT as u8,
+            finished: false,
+        }
+    }
+
+    /// Mark the entire mm as needing a flush (full-segment munmap or exit path).
+    pub fn set_fullmm(&mut self) {
+        self.fullmm = true;
+    }
+
+    /// Mark that this gather also freed page-table pages.
+    pub fn note_pt_table_freed(&mut self) {
+        self.freed_tables = true;
+    }
+
+    /// Merge a `[vaddr, vaddr + (1 << stride_shift))` interval into the flush range.
+    pub fn accumulate_range(&mut self, vaddr: VirtAddr) {
+        let stride = 1usize << self.stride_shift;
+        let page_end = VirtAddr::new(vaddr.data().saturating_add(stride));
+
+        if vaddr < self.start {
+            self.start = vaddr;
+        }
+        if page_end > self.end {
+            self.end = page_end;
+        }
+    }
+
+    /// Add a physical page pending release to the pending list; actual release happens after TLB flush.
+    ///
+    /// `paddr` points to a physical page already unmapped from the page table. The caller must ensure
+    /// that the anon_vma reverse mapping for this page has been cleaned up (e.g. by obtaining the
+    /// `Arc<Page>` via `PageManagerRef::remove_page` before passing it in).
+    pub fn stash_page(&mut self, page: Arc<Page>) {
+        self.pending_pages.push(page);
+    }
+
+    /// Convenience: remove the `Arc<Page>` for `paddr` from the global page_manager and stash it.
+    ///
+    /// If `paddr` does not exist in the page_manager (e.g. a file page no longer in cache), this is a no-op.
+    pub fn stash_paddr(&mut self, paddr: PhysAddr) {
+        let mut guard = page_manager_lock();
+        if let Some(p) = guard.remove_page(&paddr) {
+            self.pending_pages.push(p);
+        }
+    }
+
+    /// Perform TLB flush only (without freeing pending_pages).
+    ///
+    /// After this call, `start/end/freed_tables` are reset, allowing a second round of accumulation
+    /// within the same gather.
+    pub fn flush_mmu_tlbonly(&mut self) {
+        if let Some(mm) = self.mm {
+            if self.fullmm || self.start == VirtAddr::new(usize::MAX) {
+                mm.flush_tlb_range(
+                    VirtAddr::new(0),
+                    TLB_FLUSH_ALL,
+                    self.stride_shift,
+                    self.freed_tables || self.fullmm,
+                );
+            } else if self.start < self.end {
+                mm.flush_tlb_range(self.start, self.end, self.stride_shift, self.freed_tables);
+            }
+        }
+        // else: teardown path -- no CPU holds a TLB entry for this mm anymore, skip shootdown.
+
+        self.start = VirtAddr::new(usize::MAX);
+        self.end = VirtAddr::new(0);
+        self.freed_tables = false;
+        self.fullmm = false;
+    }
+
+    /// Free pending_pages (triggers deallocate_page_frames).
+    ///
+    /// The caller must guarantee that TLB shootdown has already completed before calling this.
+    pub fn flush_mmu_free(&mut self) {
+        // Drop all Arc<Page>, letting InnerPage::drop reach deallocate_page_frames
+        self.pending_pages.clear();
+    }
+
+    /// Finish the gather: flush TLB first, then free pages.
+    pub fn finish(mut self) {
+        self.flush_mmu_tlbonly();
+        self.flush_mmu_free();
+        self.finished = true;
+    }
+}
+
+impl Drop for MmuGather<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            // Normal path must call finish() explicitly; this is a fallback to avoid
+            // missing a flush during panic unwind.
+            self.flush_mmu_tlbonly();
+            self.flush_mmu_free();
+        }
+    }
+}

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -31,6 +31,7 @@ pub mod madvise;
 pub mod memblock;
 pub mod mincore;
 pub mod mmio_buddy;
+pub mod mmu_gather;
 pub mod no_init;
 pub mod page;
 pub mod page_cache_stats;
@@ -38,6 +39,7 @@ pub mod percpu;
 pub mod readahead;
 pub mod syscall;
 pub mod sysfs;
+pub mod tlb;
 pub mod truncate;
 pub mod ucontext;
 

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -15,8 +15,7 @@ use log::{error, info};
 use lru::LruCache;
 
 use crate::{
-    arch::{interrupt::ipi::send_ipi, mm::LockedFrameAllocator, MMArch},
-    exception::ipi::{IpiKind, IpiTarget},
+    arch::{mm::LockedFrameAllocator, MMArch},
     filesystem::{
         page_cache::{list_page_caches, PageCache},
         vfs::FilePrivateData,
@@ -112,8 +111,8 @@ impl PageManager {
         }
     }
 
-    pub fn remove_page(&mut self, paddr: &PhysAddr) {
-        self.phys2page.remove(paddr);
+    pub fn remove_page(&mut self, paddr: &PhysAddr) -> Option<Arc<Page>> {
+        self.phys2page.remove(paddr)
     }
 
     /// # 创建一个新页面并加入管理器
@@ -1854,14 +1853,39 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
         virt: VirtAddr,
         unmap_parents: bool,
     ) -> Option<(PhysAddr, EntryFlags<Arch>, PageFlush<Arch>)> {
+        self.unmap_phys_with_freed_tables(virt, unmap_parents)
+            .map(|(paddr, flags, flush, _freed)| (paddr, flags, flush))
+    }
+
+    /// Same as `unmap_phys`, but also returns whether intermediate page-table pages were freed during unmapping.
+    ///
+    /// Freed intermediate page-table pages (i.e. this unmap caused a page table level to become empty and
+    /// be returned to the allocator) means that other CPUs' TLBs may still cache intermediate-level translation
+    /// entries pointing to those pages (corresponding to `tlb->freed_tables` in Linux). The caller should
+    /// pass this information to [`MmuGather`] so that shootdown triggers a full-mm invalidation instead of
+    /// per-page invlpg, preventing Paging-Structure Cache from retaining stale entries.
+    ///
+    /// [`MmuGather`]: crate::mm::mmu_gather::MmuGather
+    pub unsafe fn unmap_phys_with_freed_tables(
+        &mut self,
+        virt: VirtAddr,
+        unmap_parents: bool,
+    ) -> Option<(PhysAddr, EntryFlags<Arch>, PageFlush<Arch>, bool)> {
         if !virt.check_aligned(Arch::PAGE_SIZE) {
             error!("Try to unmap unaligned page: virt={:?}", virt);
             return None;
         }
 
         let table = self.table();
-        return unmap_phys_inner(virt, &table, unmap_parents, self.allocator_mut())
-            .map(|(paddr, flags)| (paddr, flags, PageFlush::<Arch>::new(virt)));
+        let mut freed_tables = false;
+        unmap_phys_inner(
+            virt,
+            &table,
+            unmap_parents,
+            self.allocator_mut(),
+            &mut freed_tables,
+        )
+        .map(|(paddr, flags)| (paddr, flags, PageFlush::<Arch>::new(virt), freed_tables))
     }
 
     /// 在页表中，访问虚拟地址对应的页表项，并调用传入的函数F
@@ -1901,6 +1925,7 @@ unsafe fn unmap_phys_inner<Arch: MemoryManagementArch>(
     table: &PageTable<Arch>,
     unmap_parents: bool,
     allocator: &mut impl FrameAllocator,
+    freed_tables: &mut bool,
 ) -> Option<(PhysAddr, EntryFlags<Arch>)> {
     // 获取页表项的索引
     let i = table.index_of(vaddr)?;
@@ -1914,7 +1939,7 @@ unsafe fn unmap_phys_inner<Arch: MemoryManagementArch>(
 
     let subtable = table.next_level_table(i)?;
     // 递归地取消映射
-    let result = unmap_phys_inner(vaddr, &subtable, unmap_parents, allocator)?;
+    let result = unmap_phys_inner(vaddr, &subtable, unmap_parents, allocator, freed_tables)?;
 
     // TODO: This is a bad idea for architectures where the kernel mappings are done in the process tables,
     // as these mappings may become out of sync
@@ -1930,6 +1955,8 @@ unsafe fn unmap_phys_inner<Arch: MemoryManagementArch>(
             table.set_entry(i, PageEntry::from_usize(0));
             // 释放子页表
             allocator.free_one(subtable.phys());
+            // Mark: intermediate page-table pages were freed; upper layer needs a heavier shootdown for this mm (`freed_tables`).
+            *freed_tables = true;
         }
     }
 
@@ -1985,8 +2012,25 @@ impl<Arch: MemoryManagementArch> Drop for PageFlush<Arch> {
     }
 }
 
-/// 用于刷新整个页表的刷新器。这个刷新器一经产生，就必须调用flush()方法，
-/// 否则会造成对页表的更改被忽略，这是不安全的
+/// A flusher for the entire page table. Once created, its `flush()` method must be called;
+/// otherwise, page table changes will be silently ignored, which is unsafe.
+///
+/// # Usage Constraints
+///
+/// **Only allowed for mappings not attached to any user `AddressSpace`**, for example:
+///
+/// - Kernel-mode fixed mappings (kernel mapper)
+/// - DMA / IO remap regions that are never loaded as a user mm by another CPU
+///
+/// Any user-mm PTE modification must go through [`MmuGather`] + [`AddressSpace::flush_tlb_range`],
+/// which perform synchronous shootdown on all `active_cpus`, preventing stale TLB hits on freed physical pages.
+///
+/// A flush initiated with `PageFlushAll` only takes effect on the current CPU (`invalidate_all`)
+/// and does not perform cross-core shootdown; using it in a user-mm scenario would break TLB
+/// consistency (risk 4).
+///
+/// [`MmuGather`]: crate::mm::mmu_gather::MmuGather
+/// [`AddressSpace::flush_tlb_range`]: crate::mm::ucontext::AddressSpace::flush_tlb_range
 #[must_use = "The flusher must call the 'flush()', or the changes to page table will be unsafely ignored."]
 pub struct PageFlushAll<Arch: MemoryManagementArch> {
     phantom: PhantomData<fn() -> Arch>,
@@ -2028,40 +2072,34 @@ impl<Arch: MemoryManagementArch> Flusher<Arch> for () {
     fn consume(&mut self, _flush: PageFlush<Arch>) {}
 }
 
+/// "Deferred" flusher: silently forgets `PageFlush` on consume;
+/// the caller is responsible for performing a unified mm-aware `AddressSpace::flush_tlb_range` flush later.
+///
+/// This kind of flusher performs no TLB invalidation; suitable for mprotect/mremap/madvise/munmap etc.
+/// where the pattern is "modify PTEs + unified shootdown afterwards".
+#[derive(Debug, Default)]
+pub struct DeferredFlusher;
+
+impl DeferredFlusher {
+    #[inline]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl<Arch: MemoryManagementArch> Flusher<Arch> for DeferredFlusher {
+    #[inline]
+    fn consume(&mut self, flush: PageFlush<Arch>) {
+        // SAFETY: caller guarantees that AddressSpace::flush_tlb_range will be called later for unified TLB flush.
+        unsafe { flush.ignore() };
+    }
+}
+
 impl<Arch: MemoryManagementArch> Drop for PageFlushAll<Arch> {
     fn drop(&mut self) {
         unsafe {
             Arch::invalidate_all();
         }
-    }
-}
-
-/// 未在当前CPU上激活的页表的刷新器
-///
-/// 如果页表没有在当前cpu上激活，那么需要发送ipi到其他核心，尝试在其他核心上刷新页表
-///
-/// TODO: 这个方式很暴力，也许把它改成在指定的核心上刷新页表会更好。（可以测试一下开销）
-#[derive(Debug)]
-pub struct InactiveFlusher;
-
-impl InactiveFlusher {
-    pub fn new() -> Self {
-        return Self {};
-    }
-}
-
-impl Flusher<MMArch> for InactiveFlusher {
-    fn consume(&mut self, flush: PageFlush<MMArch>) {
-        unsafe {
-            flush.ignore();
-        }
-    }
-}
-
-impl Drop for InactiveFlusher {
-    fn drop(&mut self) {
-        // 发送刷新页表的IPI
-        send_ipi(IpiKind::FlushTLB, IpiTarget::Other);
     }
 }
 

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -1,0 +1,492 @@
+//! mm-aware TLB shootdown infrastructure (Linux 6.6 style)
+//!
+//! This module unifies DragonOS TLB flushing around:
+//! - `mm_cpumask` (`AddressSpace::active_cpus`): the set of CPUs that may currently hold TLB entries for this mm.
+//! - `tlb_gen` (`AddressSpace::tlb_gen`): monotonically increasing generation counter for page table modifications.
+//! - per-CPU `TlbState`: records the mm currently loaded on this CPU and the latest tlb_gen it has caught up to.
+//! - `FlushTlbInfo`: cross-CPU shootdown context.
+//! - `flush_tlb_multi`: synchronous cross-CPU broadcast with ack, using `CsdFlushTlb` for polling.
+//!
+//! Design invariants:
+//! - INV-1: At any point, if CPU `c`'s hardware page table equals `mm.table_paddr`, then bit `c` in `mm.active_cpus` is 1.
+//! - INV-2: `flush_tlb_*` must publish page table writes first, then `inc_mm_tlb_gen`, then read `active_cpus`.
+//! - INV-3: Freeing physical pages / page-table pages must happen after shootdown completion (guaranteed by `MmuGather`).
+//! - INV-4: When `flush_tlb_multi` returns, all target CPUs have finished executing `local_flush_tlb_func`.
+//! - INV-5: When `freed_tables == true`, the receiving end must handle it (simplified: in this iteration the sender
+//!   sends to all active CPUs regardless, and the receiver unconditionally executes).
+
+use core::sync::atomic::{compiler_fence, Ordering};
+
+#[cfg(target_arch = "x86_64")]
+use core::{hint::spin_loop, sync::atomic::AtomicBool};
+
+use alloc::sync::Arc;
+#[allow(unused_imports)]
+use alloc::vec::Vec;
+
+use crate::{
+    arch::{interrupt::ipi::send_ipi, CurrentIrqArch, MMArch},
+    exception::{
+        ipi::{IpiKind, IpiTarget},
+        InterruptArch,
+    },
+    libs::cpumask::CpuMask,
+    mm::{percpu::PerCpuVar, ucontext::AddressSpace, MemoryManagementArch, VirtAddr},
+    smp::{
+        core::smp_get_processor_id,
+        cpu::{smp_cpu_manager, ProcessorId},
+    },
+};
+
+#[cfg(target_arch = "x86_64")]
+use crate::libs::spinlock::SpinLock;
+
+/// Sentinel end value meaning "flush the entire mm"; combined with start=0 it means "do not use range-based flush".
+pub const TLB_FLUSH_ALL: VirtAddr = VirtAddr::new(usize::MAX);
+
+/// Cf. Linux `tlb_single_page_flush_ceiling`: above this threshold, fall back to full-mm flush.
+pub const TLB_SINGLE_PAGE_FLUSH_CEILING: usize = 33;
+
+/// Context for a single shootdown. Lives on the initiator's stack, spanning the entire IPI wait window.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct FlushTlbInfo {
+    /// Target address space
+    pub mm: Arc<AddressSpace>,
+    /// Start virtual address (inclusive, aligned to stride)
+    pub start: VirtAddr,
+    /// End virtual address (exclusive). If `TLB_FLUSH_ALL`, invalidate the entire mm.
+    pub end: VirtAddr,
+    /// New generation number after increment
+    pub new_tlb_gen: u64,
+    /// Page size shift (currently fixed at `PAGE_SHIFT`; huge-page stride not yet supported)
+    pub stride_shift: u8,
+    /// Whether page-table pages were also freed.
+    /// Current simplified policy: the sender sends IPI to all CPUs in `active_cpus`
+    /// regardless of the `freed_tables` value, and the receiver always performs the flush.
+    /// This field is retained for future lazy TLB decision-making.
+    pub freed_tables: bool,
+    /// Initiating CPU
+    pub initiating_cpu: ProcessorId,
+}
+
+impl FlushTlbInfo {
+    /// Check whether this is a full-mm flush
+    #[inline]
+    pub fn is_flush_all(&self) -> bool {
+        self.end == TLB_FLUSH_ALL
+    }
+
+    /// Number of pages in the flush range (in stride units), used to decide whether to degrade to full-mm flush
+    #[inline]
+    pub fn range_pages(&self) -> usize {
+        if self.is_flush_all() {
+            usize::MAX
+        } else {
+            let stride = 1usize << self.stride_shift;
+            let len = self.end.data().saturating_sub(self.start.data());
+            len.div_ceil(stride)
+        }
+    }
+}
+
+/// Per-CPU TLB state
+#[derive(Debug)]
+pub struct TlbState {
+    /// The mm currently loaded in hardware on this CPU (weak reference; drop does not prevent mm release)
+    loaded_mm: Option<Arc<AddressSpace>>,
+    /// The mm tlb_gen this CPU has caught up to
+    loaded_tlb_gen: u64,
+}
+
+impl TlbState {
+    const fn new() -> Self {
+        Self {
+            loaded_mm: None,
+            loaded_tlb_gen: 0,
+        }
+    }
+
+    /// Get the currently loaded mm (clones the Arc)
+    #[allow(dead_code)]
+    pub fn loaded_mm(&self) -> Option<Arc<AddressSpace>> {
+        self.loaded_mm.clone()
+    }
+
+    /// Check whether this CPU currently has the given mm loaded.
+    ///
+    /// Compares Arc pointer equality.
+    pub fn loaded_is(&self, mm: &Arc<AddressSpace>) -> bool {
+        match &self.loaded_mm {
+            Some(cur) => Arc::ptr_eq(cur, mm),
+            None => false,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn loaded_tlb_gen(&self) -> u64 {
+        self.loaded_tlb_gen
+    }
+}
+
+/// Per-CPU CSD (Call Single Data) for synchronous ack during TLB shootdown.
+///
+/// Currently only serves FlushTLB; not abstracted into a generic `smp_call_function`.
+///
+/// x86_64 only; RISC-V's `send_ipi(FlushTLB, ..)` uses synchronous SBI `remote_sfence_vma`
+/// and does not need CSD.
+#[cfg(target_arch = "x86_64")]
+pub struct CsdFlushTlb {
+    /// Pointer to `FlushTlbInfo` written by the initiator; read by the receiver.
+    info: SpinLock<Option<*const FlushTlbInfo>>,
+    /// Set to true by the target CPU upon completion.
+    done: AtomicBool,
+}
+
+// SAFETY: The pointer itself is unsafe, but it points to an object on the initiator's stack,
+// synchronized via the done flag.
+#[cfg(target_arch = "x86_64")]
+unsafe impl Sync for CsdFlushTlb {}
+#[cfg(target_arch = "x86_64")]
+unsafe impl Send for CsdFlushTlb {}
+
+#[cfg(target_arch = "x86_64")]
+impl CsdFlushTlb {
+    const fn new() -> Self {
+        Self {
+            info: SpinLock::new(None),
+            done: AtomicBool::new(true),
+        }
+    }
+}
+
+/// Per-CPU TLB state (currently loaded mm and latest generation per CPU)
+static mut TLB_STATE: Option<PerCpuVar<TlbState>> = None;
+
+/// Per-CPU CSD slot; each CPU allows at most one in-flight TLB shootdown at a time
+#[cfg(target_arch = "x86_64")]
+static mut CSD_FLUSH_TLB: Option<PerCpuVar<CsdFlushTlb>> = None;
+
+/// Serialize cross-core shootdown.
+///
+/// Currently uses a single global lock to ensure initiators don't share CSD slots;
+/// can be upgraded to per-initiator CSD pools in the future.
+#[cfg(target_arch = "x86_64")]
+static FLUSH_TLB_GLOBAL_LOCK: SpinLock<()> = SpinLock::new(());
+
+/// Initialize this module. Must be called after `PerCpu::init()`.
+pub fn tlb_init() {
+    let cpu_num = crate::mm::percpu::PerCpu::MAX_CPU_NUM as usize;
+
+    let mut states: Vec<TlbState> = Vec::with_capacity(cpu_num);
+    for _ in 0..cpu_num {
+        states.push(TlbState::new());
+    }
+    unsafe {
+        TLB_STATE = Some(PerCpuVar::new(states).expect("PerCpuVar length mismatch"));
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        let mut csds: Vec<CsdFlushTlb> = Vec::with_capacity(cpu_num);
+        for _ in 0..cpu_num {
+            csds.push(CsdFlushTlb::new());
+        }
+        unsafe {
+            CSD_FLUSH_TLB = Some(PerCpuVar::new(csds).expect("PerCpuVar length mismatch"));
+        }
+    }
+}
+
+#[inline]
+fn tlb_state() -> &'static PerCpuVar<TlbState> {
+    // Must not be called before initialization (tlb_init runs before idle first enters)
+    unsafe { TLB_STATE.as_ref().expect("tlb_state not initialized") }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn csd_flush_tlb() -> &'static PerCpuVar<CsdFlushTlb> {
+    unsafe {
+        CSD_FLUSH_TLB
+            .as_ref()
+            .expect("csd_flush_tlb not initialized")
+    }
+}
+
+/// Get the TlbState (mutable) for a specified CPU. Only use when interrupts are disabled or other synchronization guarantees exist.
+#[allow(dead_code)]
+#[inline]
+pub fn tlb_state_force_mut(cpu: ProcessorId) -> &'static mut TlbState {
+    unsafe { tlb_state().force_get_mut(cpu) }
+}
+
+/// Get the TlbState (mutable) for the current CPU. The caller must ensure preemption/interrupts won't cause concurrent access from another CPU.
+#[inline]
+pub fn tlb_state_local_mut() -> &'static mut TlbState {
+    tlb_state().get_mut()
+}
+
+/// Get the TlbState (read-only) for a specified CPU.
+#[inline]
+pub fn tlb_state_force(cpu: ProcessorId) -> &'static TlbState {
+    unsafe { tlb_state().force_get(cpu) }
+}
+
+/// After context switch, update this CPU's TlbState to the new mm.
+///
+/// # Safety
+///
+/// - The caller must execute this with interrupts disabled (to ensure per-CPU data is not preempted).
+/// - `mm.active_cpus` must already include this CPU (set the bit before calling this function during switch).
+pub unsafe fn tlb_state_set_loaded_mm(mm: Arc<AddressSpace>) {
+    let st = tlb_state_local_mut();
+    let new_gen = mm.tlb_gen.load(Ordering::SeqCst);
+    st.loaded_mm = Some(mm);
+    st.loaded_tlb_gen = new_gen;
+}
+
+/// Clear this CPU's loaded_mm (used for the final state when a process exits and user_vm is set to None).
+///
+/// # Safety
+///
+/// - The caller must execute this with interrupts disabled.
+#[allow(dead_code)]
+pub unsafe fn tlb_state_clear_loaded_mm() {
+    let st = tlb_state_local_mut();
+    st.loaded_mm = None;
+    st.loaded_tlb_gen = 0;
+}
+
+/// Context-aware local TLB flush.
+///
+/// Policy:
+/// - Full mm or range exceeding `TLB_SINGLE_PAGE_FLUSH_CEILING` pages → `invalidate_all`.
+/// - Otherwise, invalidate page by page via `invalidate_page`.
+///
+/// Only updates `loaded_tlb_gen` when this CPU's loaded_mm matches `info.mm`.
+pub fn local_flush_tlb_func(info: &FlushTlbInfo) {
+    let loaded_matches = {
+        let st = tlb_state_force(smp_get_processor_id());
+        st.loaded_is(&info.mm)
+    };
+
+    if !loaded_matches {
+        // This CPU has already switched to a different mm; the previous CR3 write implicitly
+        // invalidated the entire TLB, no further flush needed.
+        return;
+    }
+
+    // When intermediate page-table pages have been freed, per-page invlpg cannot clear
+    // Paging-Structure Cache (PSC) entries pointing to the reclaimed intermediate PT;
+    // a full-mm invalidation is required, matching Linux `tlb->freed_tables` semantics.
+    let must_full = info.is_flush_all()
+        || info.freed_tables
+        || info.range_pages() > TLB_SINGLE_PAGE_FLUSH_CEILING;
+
+    if must_full {
+        unsafe { MMArch::invalidate_all() };
+    } else {
+        let stride = 1usize << info.stride_shift;
+        let mut addr = info.start.data();
+        let end = info.end.data();
+        while addr < end {
+            unsafe { MMArch::invalidate_page(VirtAddr::new(addr)) };
+            addr = addr.saturating_add(stride);
+        }
+    }
+
+    let st = tlb_state_local_mut();
+    if st.loaded_tlb_gen < info.new_tlb_gen {
+        st.loaded_tlb_gen = info.new_tlb_gen;
+    }
+}
+
+/// Remote IPI handler entry point.
+///
+/// Called by `FlushTLBIpiHandler::handle`; reads `&FlushTlbInfo` from the per-CPU CSD,
+/// executes `local_flush_tlb_func`, and atomically sets `done`.
+///
+/// x86_64 only; RISC-V's `send_ipi(FlushTLB, ..)` uses SBI `remote_sfence_vma` and does not go through here.
+pub fn remote_flush_tlb_on_ipi() {
+    #[cfg(target_arch = "x86_64")]
+    {
+        let cpu = smp_get_processor_id();
+        let csd = unsafe { csd_flush_tlb().force_get(cpu) };
+        let info_ptr: *const FlushTlbInfo = {
+            let guard = csd.info.lock();
+            match *guard {
+                Some(p) => p,
+                None => {
+                    // Should not happen; defensively set done to avoid initiator deadlock
+                    csd.done.store(true, Ordering::Release);
+                    return;
+                }
+            }
+        };
+
+        // SAFETY: the initiator's stack frame remains valid throughout the polling window in `flush_tlb_multi`;
+        // it will not be freed before done=true.
+        let info = unsafe { &*info_ptr };
+
+        local_flush_tlb_func(info);
+
+        compiler_fence(Ordering::SeqCst);
+        csd.done.store(true, Ordering::Release);
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        // Other architectures should not reach this function via IPI handler;
+        // if called by mistake, perform a conservative full-mm invalidation as a fallback.
+        unsafe { MMArch::invalidate_all() };
+    }
+}
+
+/// Issue a synchronous TLB shootdown to a set of target CPUs.
+///
+/// Initiator requirements:
+/// 1. Page table writes are complete and `inc_mm_tlb_gen` has been called.
+/// 2. `target_cpus` must not include this CPU (local flush is done by the caller after sending IPIs).
+///
+/// Upon return, all CPUs in `target_cpus` have completed this shootdown (INV-4).
+fn flush_tlb_multi(target_cpus: &CpuMask, info: &FlushTlbInfo) {
+    // Filter out offline CPUs to avoid sending IPIs to not-yet-started / offline APICs.
+    let online = smp_cpu_manager().present_cpus();
+    let active: CpuMask = target_cpus & online;
+
+    let my_cpu = smp_get_processor_id();
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Global lock serialization: ensures only one shootdown uses per-CPU CSD slots at a time.
+        // Can be refined to per-target dedicated channels in the future.
+        let _g = FLUSH_TLB_GLOBAL_LOCK.lock();
+
+        // Prepare CSD slots for each target CPU
+        for cpu in active.iter_cpu() {
+            if cpu == my_cpu {
+                continue;
+            }
+            let csd = unsafe { csd_flush_tlb().force_get(cpu) };
+            {
+                let mut g = csd.info.lock();
+                *g = Some(info as *const FlushTlbInfo);
+            }
+            csd.done.store(false, Ordering::SeqCst);
+        }
+
+        compiler_fence(Ordering::SeqCst);
+
+        // Send IPIs (one Specified per CPU, avoiding "Other" broadcast that would cause unrelated CPUs to take extra paths)
+        for cpu in active.iter_cpu() {
+            if cpu == my_cpu {
+                continue;
+            }
+            send_ipi(IpiKind::FlushTLB, IpiTarget::Specified(cpu));
+        }
+
+        // Poll for done
+        for cpu in active.iter_cpu() {
+            if cpu == my_cpu {
+                continue;
+            }
+            let csd = unsafe { csd_flush_tlb().force_get(cpu) };
+            while !csd.done.load(Ordering::Acquire) {
+                spin_loop();
+            }
+            // Clean up CSD slot to prevent misuse
+            let mut g = csd.info.lock();
+            *g = None;
+        }
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        // RISC-V and similar: leverage the underlying synchronous SBI implementation of `send_ipi`
+        // (e.g. `remote_sfence_vma`). This path is blocking; return means the target has completed
+        // full-mm invalidation, no CSD protocol needed.
+        // Note: this path performs a full-mm invalidation without range discrimination,
+        // matching the current semantics for this iteration.
+        let _ = info; // unused
+        for cpu in active.iter_cpu() {
+            if cpu == my_cpu {
+                continue;
+            }
+            send_ipi(IpiKind::FlushTLB, IpiTarget::Specified(cpu));
+        }
+    }
+}
+
+/// Range-based TLB flush for the specified mm.
+///
+/// - `start`: start virtual address
+/// - `end`: end virtual address (exclusive). If equal to `TLB_FLUSH_ALL`, flush the entire mm.
+/// - `stride_shift`: page size shift (typically `MMArch::PAGE_SHIFT`)
+/// - `freed_tables`: whether page-table pages were also freed
+pub fn flush_tlb_mm_range(
+    mm: &Arc<AddressSpace>,
+    start: VirtAddr,
+    end: VirtAddr,
+    stride_shift: u8,
+    freed_tables: bool,
+) {
+    // Disable interrupts to protect the entire initiation process:
+    // - Prevent migration during inc_tlb_gen and snapshot of active_cpus;
+    // - Prevent being scheduled out while waiting for IPI ack.
+    let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+
+    // Publish barrier: ensure page table writes are visible to other CPUs before the generation increment.
+    compiler_fence(Ordering::SeqCst);
+    let new_gen = mm.tlb_gen.fetch_add(1, Ordering::SeqCst) + 1;
+    compiler_fence(Ordering::SeqCst);
+
+    let this_cpu = smp_get_processor_id();
+
+    let info = FlushTlbInfo {
+        mm: mm.clone(),
+        start,
+        end,
+        new_tlb_gen: new_gen,
+        stride_shift,
+        freed_tables,
+        initiating_cpu: this_cpu,
+    };
+
+    // Snapshot the remote target set.
+    let remote_mask: CpuMask = {
+        let g = mm.active_cpus.lock();
+        let mut m = g.clone();
+        // Exclude this CPU; local flush is handled separately
+        m.set(this_cpu, false);
+        m
+    };
+
+    if !remote_mask.is_empty() {
+        flush_tlb_multi(&remote_mask, &info);
+    }
+
+    // If this CPU is currently using this mm, perform local flush
+    let loaded_local = {
+        let st = tlb_state_force(this_cpu);
+        st.loaded_is(mm)
+    };
+    if loaded_local {
+        local_flush_tlb_func(&info);
+    }
+
+    compiler_fence(Ordering::SeqCst);
+    drop(irq_guard);
+}
+
+/// Convenience wrapper for full-mm flush
+#[inline]
+pub fn flush_tlb_mm(mm: &Arc<AddressSpace>) {
+    flush_tlb_mm_range(
+        mm,
+        VirtAddr::new(0),
+        TLB_FLUSH_ALL,
+        MMArch::PAGE_SHIFT as u8,
+        false,
+    );
+}

--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -30,11 +30,12 @@ use crate::{
     ipc::shm::{ShmFlags, ShmId},
     libs::{
         align::page_align_up,
+        cpumask::CpuMask,
         mutex::{Mutex, MutexGuard},
         rwsem::RwSem,
         spinlock::SpinLock,
     },
-    mm::{page::page_manager_lock, PhysAddr},
+    mm::{mmu_gather::MmuGather, page::page_manager_lock, PhysAddr},
     process::{resource::RLimitID, ProcessManager},
 };
 
@@ -42,7 +43,7 @@ use super::{
     allocator::page_frame::{
         deallocate_page_frames, PageFrameCount, PhysPageFrame, VirtPageFrame, VirtPageFrameIter,
     },
-    page::{EntryFlags, Flusher, InactiveFlusher, Page, PageFlags, PageFlushAll, PageType},
+    page::{EntryFlags, Flusher, Page, PageFlags, PageType},
     syscall::{MadvFlags, MapFlags, MremapFlags, ProtFlags},
     MemoryManagementArch, PageTableKind, VirtAddr, VirtRegion, VmFlags,
 };
@@ -77,6 +78,16 @@ pub struct AddressSpace {
     /// 页表物理地址（创建后不变，可无锁访问）
     /// 用于在调度器上下文中快速切换页表，无需获取RwSem锁
     table_paddr: PhysAddr,
+    /// The set of CPUs that may currently hold TLB entries for this mm.
+    ///
+    /// Maintained by context switch / exec / process exit paths; `flush_tlb_mm_range` uses this to determine shootdown targets.
+    /// Cf. Linux 6.6 `struct mm_struct::cpu_bitmap` semantics.
+    pub active_cpus: SpinLock<CpuMask>,
+    /// Monotonically increasing count of page table modifications for this mm.
+    ///
+    /// `flush_tlb_*` must increment this after publishing page table writes and before snapshotting `active_cpus`;
+    /// remote CPUs receiving IPI write this to per-CPU `TlbState::loaded_tlb_gen` as a "caught-up generation" marker.
+    pub tlb_gen: AtomicU64,
     /// 使用RwSem而非RwLock，因为地址空间操作可能需要进行I/O（如页缺失时的文件读取）
     inner: RwSem<InnerAddressSpace>,
 }
@@ -86,12 +97,20 @@ impl AddressSpace {
         let inner = InnerAddressSpace::new(create_stack)?;
         let table_paddr = inner.user_mapper.utable.table().phys();
         let id = ADDRESS_SPACE_ID_ALLOCATOR.fetch_add(1, Ordering::Relaxed);
-        let result = Self {
+        let result = Arc::new(Self {
             id,
             table_paddr,
+            active_cpus: SpinLock::new(CpuMask::new()),
+            tlb_gen: AtomicU64::new(0),
             inner: RwSem::new(inner),
-        };
-        return Ok(Arc::new(result));
+        });
+        // Back-fill the Weak<AddressSpace> so that InnerAddressSpace methods can obtain
+        // the outer Arc to construct MmuGather / initiate TLB shootdown.
+        {
+            let mut g = result.inner.write();
+            g.outer = Arc::downgrade(&result);
+        }
+        return Ok(result);
     }
 
     /// 获取地址空间的全局唯一ID
@@ -134,6 +153,62 @@ impl AddressSpace {
     pub unsafe fn make_current(&self) {
         MMArch::set_table(PageTableKind::User, self.table_paddr);
     }
+
+    /// Add the specified CPU to this mm's `active_cpus`.
+    ///
+    /// The caller should invoke this after the hardware has loaded this mm's page table, or immediately before loading,
+    /// so that `flush_tlb_mm_range` can see this CPU after inc_tlb_gen.
+    #[inline]
+    pub fn active_cpus_set(&self, cpu: crate::smp::cpu::ProcessorId) {
+        let mut g = self.active_cpus.lock();
+        g.set(cpu, true);
+    }
+
+    /// Remove the specified CPU from `active_cpus`.
+    ///
+    /// The caller should invoke this before switching the hardware page table to a different mm,
+    /// ensuring that any subsequent shootdown will no longer consider this CPU a target.
+    #[inline]
+    pub fn active_cpus_clear(&self, cpu: crate::smp::cpu::ProcessorId) {
+        let mut g = self.active_cpus.lock();
+        g.set(cpu, false);
+    }
+
+    /// Issue a range-based TLB flush for this mm (including remote shootdown + local).
+    ///
+    /// See `crate::mm::tlb::flush_tlb_mm_range` for constraints.
+    #[inline]
+    pub fn flush_tlb_range(
+        self: &Arc<Self>,
+        start: VirtAddr,
+        end: VirtAddr,
+        stride_shift: u8,
+        freed_tables: bool,
+    ) {
+        crate::mm::tlb::flush_tlb_mm_range(self, start, end, stride_shift, freed_tables);
+    }
+
+    /// Issue a full-mm TLB flush.
+    #[inline]
+    pub fn flush_tlb_all(self: &Arc<Self>) {
+        crate::mm::tlb::flush_tlb_mm(self);
+    }
+}
+
+impl Drop for AddressSpace {
+    fn drop(&mut self) {
+        // Assert that no CPUs still reference this mm when it is dropped in debug builds.
+        // In release builds, degrade gracefully to avoid false positives (a leak is better than a panic).
+        #[cfg(debug_assertions)]
+        {
+            let g = self.active_cpus.lock();
+            debug_assert!(
+                g.is_empty(),
+                "AddressSpace dropped with non-empty active_cpus; id={}",
+                self.id
+            );
+        }
+    }
 }
 
 impl core::ops::Deref for AddressSpace {
@@ -171,6 +246,13 @@ pub struct InnerAddressSpace {
     pub end_code: VirtAddr,
     pub start_data: VirtAddr,
     pub end_data: VirtAddr,
+
+    /// Weak reference back to the outer `AddressSpace`.
+    ///
+    /// Back-filled by `AddressSpace::new` after constructing the Arc; used by internal
+    /// `munmap`/`mprotect`/... to obtain `Arc<AddressSpace>` for constructing `MmuGather`
+    /// and initiating TLB shootdown.
+    outer: Weak<AddressSpace>,
 }
 
 impl InnerAddressSpace {
@@ -199,6 +281,7 @@ impl InnerAddressSpace {
             end_code: VirtAddr(0),
             start_data: VirtAddr(0),
             end_data: VirtAddr(0),
+            outer: Weak::new(),
         };
         if create_stack {
             // debug!("to create user stack.");
@@ -218,6 +301,17 @@ impl InnerAddressSpace {
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let new_addr_space = AddressSpace::new(false)?;
         let mut new_guard = new_addr_space.write();
+
+        // 父 mm 可能是多线程共享的 mm（CLONE_VM / CLONE_THREAD），此时正在其他 CPU 上跑的线程
+        // 也可能在父页表上缓存了 writable 的 TLB。下面 COW 写保护父进程 PTE 时，
+        // 必须走 mm-aware shootdown：只做本地 invlpg 的话，远端 CPU 仍可能用旧的可写 TLB 写进去，
+        // 破坏 COW 语义（风险 4 残留）。这里用 MmuGather 累积整个被改写的范围，
+        // 循环结束后由 tlb.finish() 统一触发 flush_tlb_mm_range，对父 mm 的所有活跃 CPU 同步 shootdown。
+        let parent_mm = self
+            .outer
+            .upgrade()
+            .expect("InnerAddressSpace::try_clone called before AddressSpace::new finished");
+        let mut parent_tlb = MmuGather::gather(&parent_mm);
 
         // 仅拷贝用户栈的结构体信息（元数据），实际的用户栈页面内容会在下面的 VMA 循环中处理
         unsafe {
@@ -313,9 +407,14 @@ impl InnerAddressSpace {
                             let cow_flags = page_flags.set_write(false);
 
                             // 更新父进程的页表项为只读
+                            // 不在此处做本地 invlpg；而是把被改写的地址累积到 parent_tlb，
+                            // 最后由 parent_tlb.finish() 统一做 mm-aware 远端 + 本地 shootdown，
+                            // 确保父 mm 的所有活跃 CPU 都刷新 TLB。
                             if old_flags.has_write() {
                                 if let Some(flush) = old_mapper.remap(current_page, cow_flags) {
-                                    flush.flush();
+                                    // SAFETY: later parent_tlb.finish() issues a unified flush_tlb_mm_range on the parent mm.
+                                    flush.ignore();
+                                    parent_tlb.accumulate_range(current_page);
                                 }
                             }
 
@@ -340,6 +439,9 @@ impl InnerAddressSpace {
         }
 
         drop(new_guard);
+        // 完成父 mm 的 mm-aware shootdown：INV-3 要求 TLB 生效完成后再继续后续逻辑，
+        // 此处没有 page 进入 pending_pages，因此实际只触发 flush_tlb_mm_range。
+        parent_tlb.finish();
         drop(irq_guard);
         return Ok(new_addr_space);
     }
@@ -396,6 +498,15 @@ impl InnerAddressSpace {
     #[inline]
     pub fn is_current(&self) -> bool {
         return self.user_mapper.utable.is_current();
+    }
+
+    /// Obtain the outer `Arc<AddressSpace>`.
+    ///
+    /// Back-filled during `AddressSpace::new` construction; upgrade should always succeed on normal paths.
+    /// Returns `None` only in extreme scenarios (Weak not yet assigned / mm already destroyed).
+    #[inline]
+    pub fn outer_addr_space(&self) -> Option<Arc<AddressSpace>> {
+        self.outer.upgrade()
     }
 
     /// 进行匿名页映射
@@ -735,14 +846,11 @@ impl InnerAddressSpace {
         // debug!("mmap: page: {:?}, region={region:?}", page.virt_address());
 
         compiler_fence(Ordering::SeqCst);
-        let (mut active, mut inactive);
-        let flusher = if self.is_current() {
-            active = PageFlushAll::new();
-            &mut active as &mut dyn Flusher<MMArch>
-        } else {
-            inactive = InactiveFlusher::new();
-            &mut inactive as &mut dyn Flusher<MMArch>
-        };
+        // New mapping: the new region had no prior PTE, no TLB invalidation needed.
+        // Use DeferredFlusher to silently consume internal PageFlush tokens.
+        // If MAP_FIXED support for overwriting existing mappings is added in the future,
+        // the caller should first munmap via MmuGather to release old mappings.
+        let mut flusher = crate::mm::page::DeferredFlusher::new();
         compiler_fence(Ordering::SeqCst);
         // 映射页面，并将VMA插入到地址空间的VMA列表中
         self.mappings.insert_vma(map_func(
@@ -751,7 +859,7 @@ impl InnerAddressSpace {
             vm_flags,
             EntryFlags::from_prot_flags(prot_flags, true),
             &mut self.user_mapper.utable,
-            flusher,
+            &mut flusher,
         )?);
 
         return Ok(page);
@@ -928,15 +1036,10 @@ impl InnerAddressSpace {
 
         let move_len = core::cmp::min(old_len, new_len);
 
-        // 选择合适的 flusher（与 mmap/munmap 的策略一致）。
-        let (mut active, mut inactive);
-        let flusher: &mut dyn Flusher<MMArch> = if self.is_current() {
-            active = PageFlushAll::new();
-            &mut active as &mut dyn Flusher<MMArch>
-        } else {
-            inactive = InactiveFlusher::new();
-            &mut inactive as &mut dyn Flusher<MMArch>
-        };
+        // mremap does not free physical pages (old VMA pages are moved to the new VMA, or dual-mapped under DONTUNMAP);
+        // using MmuGather here is solely for a unified cross-core TLB shootdown at the end.
+        let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
+        let mut tlb = MmuGather::gather(&mm);
 
         // 迁移/复制已存在的页表映射。
         // - DONTUNMAP：复制映射（旧映射仍保留）
@@ -952,14 +1055,20 @@ impl InnerAddressSpace {
             let dst = new_region.start() + off;
             if let Some((paddr, src_flags)) = mapper.translate(src) {
                 if !dontunmap {
-                    if let Some((_paddr2, _flags2, flush)) = unsafe { mapper.unmap_phys(src, true) }
+                    if let Some((_paddr2, _flags2, flush, freed_tables)) =
+                        unsafe { mapper.unmap_phys_with_freed_tables(src, true) }
                     {
-                        flusher.consume(flush);
+                        unsafe { flush.ignore() };
+                        tlb.accumulate_range(src);
+                        if freed_tables {
+                            tlb.note_pt_table_freed();
+                        }
                     }
                 }
 
                 if let Some(flush) = unsafe { mapper.map_phys(dst, paddr, src_flags) } {
-                    flusher.consume(flush);
+                    unsafe { flush.ignore() };
+                    tlb.accumulate_range(dst);
                 } else {
                     return Err(SystemError::ENOMEM);
                 }
@@ -974,6 +1083,9 @@ impl InnerAddressSpace {
             }
             off += MMArch::PAGE_SIZE;
         }
+
+        drop(page_manager_guard);
+        tlb.finish();
 
         Ok(new_region.start())
     }
@@ -1003,7 +1115,10 @@ impl InnerAddressSpace {
         let region_to_unmap = VirtRegion::new(start_page.virt_address(), page_count.bytes());
         let vmas_related: Vec<Arc<LockedVMA>> =
             self.mappings.conflicts(region_to_unmap).collect::<Vec<_>>();
-        let mut flusher: PageFlushAll<MMArch> = PageFlushAll::new();
+
+        // Use MmuGather: clear PTEs + stash pages first, then unified shootdown, and finally free physical pages (INV-3)
+        let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
+        let mut tlb = MmuGather::gather(&mm);
 
         // 遍历每个相关的 VMA，将当前的 VMA 拆分为可能的三块 VMA，然后删除与需要删除的区域相交的部分。
         // 示意图：对每个与 region_to_unmap 相交的 VMA，按交集拆分成三段（before / intersection / after），
@@ -1044,8 +1159,11 @@ impl InnerAddressSpace {
                 self.mappings.insert_vma(after);
             }
 
-            cur_vma.unmap(&mut self.user_mapper.utable, &mut flusher);
+            cur_vma.unmap(&mut self.user_mapper.utable, &mut tlb);
         }
+
+        // Shootdown first, then free physical pages
+        tlb.finish();
 
         // TODO: 当引入后备页映射后，这里需要增加通知文件的逻辑
 
@@ -1063,14 +1181,8 @@ impl InnerAddressSpace {
         //     start_page,
         //     page_count
         // );
-        let (mut active, mut inactive);
-        let flusher = if self.is_current() {
-            active = PageFlushAll::new();
-            &mut active as &mut dyn Flusher<MMArch>
-        } else {
-            inactive = InactiveFlusher::new();
-            &mut inactive as &mut dyn Flusher<MMArch>
-        };
+        let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
+        let mut tlb = MmuGather::gather(&mm);
 
         let mapper = &mut self.user_mapper.utable;
         let region = VirtRegion::new(start_page.virt_address(), page_count.bytes());
@@ -1110,11 +1222,13 @@ impl InnerAddressSpace {
                 .set_execute(prot_flags.contains(ProtFlags::PROT_EXEC))
                 .set_write(prot_flags.contains(ProtFlags::PROT_WRITE));
 
-            r_guard.remap(new_flags, mapper, &mut *flusher)?;
+            r_guard.remap(new_flags, mapper, &mut tlb)?;
             drop(r_guard);
             self.mappings.insert_vma(r);
         }
 
+        // Unified shootdown. mprotect does not free physical pages; tlb.finish() mainly flushes the TLB.
+        tlb.finish();
         return Ok(());
     }
 
@@ -1163,14 +1277,8 @@ impl InnerAddressSpace {
         page_count: PageFrameCount,
         behavior: MadvFlags,
     ) -> Result<(), SystemError> {
-        let (mut active, mut inactive);
-        let flusher = if self.is_current() {
-            active = PageFlushAll::new();
-            &mut active as &mut dyn Flusher<MMArch>
-        } else {
-            inactive = InactiveFlusher::new();
-            &mut inactive as &mut dyn Flusher<MMArch>
-        };
+        let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
+        let mut tlb = MmuGather::gather(&mm);
 
         let mapper = &mut self.user_mapper.utable;
 
@@ -1192,9 +1300,10 @@ impl InnerAddressSpace {
             if let Some(after) = split_result.after {
                 self.mappings.insert_vma(after);
             }
-            r.do_madvise(behavior, mapper, &mut *flusher)?;
+            r.do_madvise(behavior, mapper, &mut tlb)?;
             self.mappings.insert_vma(r);
         }
+        tlb.finish();
         Ok(())
     }
 
@@ -1210,10 +1319,12 @@ impl InnerAddressSpace {
             }
         }
 
-        let mut flusher: PageFlushAll<MMArch> = PageFlushAll::new();
+        let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
+        let mut tlb = MmuGather::gather(&mm);
         for vma in targets {
-            vma.unmap(&mut self.user_mapper.utable, &mut flusher);
+            vma.unmap(&mut self.user_mapper.utable, &mut tlb);
         }
+        tlb.finish();
         Ok(())
     }
 
@@ -1236,12 +1347,27 @@ impl InnerAddressSpace {
 
     /// 取消用户空间内的所有映射
     pub unsafe fn unmap_all(&mut self) {
-        let mut flusher: PageFlushAll<MMArch> = PageFlushAll::new();
+        // 两种调用场景：
+        // 1) 显式调用（仍有 `Arc<AddressSpace>` 外部引用）：`outer.upgrade()` 返回 `Some`，
+        //    走正常的 mm-aware shootdown + 释放路径。
+        // 2) `Drop for InnerAddressSpace`：此时 `Arc<AddressSpace>` 正处于 `drop_slow`，
+        //    strong-count 已经是 0，`Weak::upgrade()` 必然返回 `None`。此路径下我们已经在
+        //    exit/switch_process 里清理过 `active_cpus`，不会有任何 CPU 还持有这个 mm 的 TLB，
+        //    因此使用 `MmuGather::gather_teardown()`，跳过跨核 shootdown，只把 PTE 拆掉、
+        //    按 INV-3 的 "先 flush，后释放" 顺序释放物理页。
+        let mm_arc = self.outer_addr_space();
+        let mut tlb = match mm_arc.as_ref() {
+            Some(mm) => MmuGather::gather(mm),
+            None => MmuGather::gather_teardown(),
+        };
+        // Full-mm flush (fullmm); no need to accumulate ranges.
+        tlb.set_fullmm();
         for vma in self.mappings.iter_vmas() {
             if vma.mapped() {
-                vma.unmap(&mut self.user_mapper.utable, &mut flusher);
+                vma.unmap(&mut self.user_mapper.utable, &mut tlb);
             }
         }
+        tlb.finish();
     }
 
     /// 设置进程的堆的内存空间
@@ -1685,7 +1811,11 @@ impl LockedVMA {
         return Ok(());
     }
 
-    pub fn unmap(&self, mapper: &mut PageMapper, mut flusher: impl Flusher<MMArch>) {
+    /// Unmap the entire VMA, stashing physical pages pending release into `tlb` and accumulating the TLB flush range.
+    ///
+    /// The caller must complete all PTE clears before calling `tlb.finish()`, which uniformly
+    /// performs cross-core TLB shootdown first and then frees physical pages (INV-3).
+    pub fn unmap(&self, mapper: &mut PageMapper, tlb: &mut MmuGather<'_>) {
         // todo: 如果当前vma与文件相关，完善文件相关的逻辑
         let mut self_guard = self.lock();
 
@@ -1720,21 +1850,34 @@ impl LockedVMA {
             if mapper.translate(page.virt_address()).is_none() {
                 continue;
             }
-            let (paddr, _, flush) = unsafe { mapper.unmap_phys(page.virt_address(), true) }
-                .expect("Failed to unmap, beacuse of some page is not mapped");
+            let (paddr, _, flush, freed_tables) =
+                unsafe { mapper.unmap_phys_with_freed_tables(page.virt_address(), true) }
+                    .expect("Failed to unmap, beacuse of some page is not mapped");
 
             // 从anon_vma中删除当前VMA
-            let page = page_manager_guard.get_unwrap(&paddr);
-            let mut page_guard = page.write();
-            page_guard.remove_vma(self);
+            let page_arc = page_manager_guard.get_unwrap(&paddr);
+            let can_dealloc = {
+                let mut page_guard = page_arc.write();
+                page_guard.remove_vma(self);
+                // The physical page's VMA list length is 0 and it is not marked as non-reclaimable, so it can be freed.
+                // TODO: LRU-based physical page reclamation in the future
+                page_guard.can_deallocate()
+            };
 
-            // 如果物理页的vma链表长度为0并且未标记为不可回收，则释放物理页.
-            // TODO 后续由lru释放物理页面
-            if page_guard.can_deallocate() {
-                page_manager_guard.remove_page(&paddr);
+            if can_dealloc {
+                // Remove this `Arc<Page>` from page_manager, deferring the drop until after TLB shootdown.
+                // This guarantees INV-3: other cores can no longer reach the returned-to-buddy physical page via stale TLB.
+                if let Some(p) = page_manager_guard.remove_page(&paddr) {
+                    tlb.stash_page(p);
+                }
             }
 
-            flusher.consume(flush);
+            // Local PTE cleared; no immediate invlpg. Final TLB invalidation is performed uniformly by MmuGather.
+            unsafe { flush.ignore() };
+            tlb.accumulate_range(page.virt_address());
+            if freed_tables {
+                tlb.note_pt_table_freed();
+            }
         }
         self_guard.mapped = false;
 
@@ -2186,11 +2329,16 @@ impl VMA {
         );
     }
 
+    /// Modify the flags of all existing PTEs covered by this VMA (without changing physical page ownership).
+    ///
+    /// Does not immediately perform TLB invalidation; the range is accumulated into the passed `MmuGather`,
+    /// and the upper layer performs unified shootdown after all modifications are complete
+    /// (TLB first, then free/modify, guaranteeing INV-3).
     pub fn remap(
         &mut self,
         flags: EntryFlags<MMArch>,
         mapper: &mut PageMapper,
-        mut flusher: impl Flusher<MMArch>,
+        tlb: &mut MmuGather<'_>,
     ) -> Result<(), SystemError> {
         for page in self.region.pages() {
             // debug!("remap page {:?}", page.virt_address());
@@ -2200,7 +2348,8 @@ impl VMA {
                         .remap(page.virt_address(), flags)
                         .expect("Failed to remap")
                 };
-                flusher.consume(r);
+                unsafe { r.ignore() };
+                tlb.accumulate_range(page.virt_address());
             }
             // debug!("consume page {:?}", page.virt_address());
             // debug!("remap page {:?} done", page.virt_address());

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -181,9 +181,20 @@ fn do_execve_switch_user_vm(new_vm: Arc<AddressSpace>) -> Option<Arc<AddressSpac
     let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
     let pcb = ProcessManager::current_pcb();
 
+    let cpu = crate::smp::core::smp_get_processor_id();
+
     let mut basic_info = pcb.basic_mut();
     // 暂存原本的用户地址空间的引用(因为如果在切换页表之前释放了它，可能会造成内存use after free)
     let old_address_space = basic_info.user_vm();
+
+    // INV-1: when execve switches mm, first clear this CPU from the old mm's active_cpus,
+    // then switch the hardware page table, then add this CPU to the new mm's active_cpus,
+    // and finally update per-CPU TlbState.
+    // Note: on the execve path the old/new mm are always different (the new mm is a freshly
+    // created AddressSpace::new result).
+    if let Some(old_vm) = old_address_space.as_ref() {
+        old_vm.active_cpus_clear(cpu);
+    }
 
     // 在pcb中原来的用户地址空间
     unsafe {
@@ -204,6 +215,9 @@ fn do_execve_switch_user_vm(new_vm: Arc<AddressSpace>) -> Option<Arc<AddressSpac
 
     // 切换到新的用户地址空间
     unsafe { new_vm.make_current() };
+
+    new_vm.active_cpus_set(cpu);
+    unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(new_vm.clone()) };
 
     drop(irq_guard);
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -712,6 +712,23 @@ impl ProcessManager {
 
             // 注意：exit_files() 可能会触发阻塞（例如关闭 FUSE fd 需要等待 daemon 回复），
             // 因此不能在它之前清空 user_vm，否则后续调度切换会遇到 user_vm==None 的普通进程并崩溃。
+            //
+            // INV-1: Before releasing the hold on user_vm, clear this CPU from the mm's active_cpus,
+            // otherwise after the mm is freed (Arc count reaches zero) a stale per-CPU cpumask bit
+            // will remain, and subsequent flushes by other threads on the same mm would still target
+            // this CPU and send spurious IPIs.
+            //
+            // Note that this CPU's hardware page table still points to this mm, but __schedule will
+            // immediately switch to idle, whose IDLE_PROCESS_ADDRESS_SPACE will re-set this CPU's
+            // active_cpus bit and write the correct per-CPU TlbState. So clearing the old mm's bit
+            // here is sufficient.
+            {
+                let cpu = smp_get_processor_id();
+                if let Some(old_vm) = pcb.basic().user_vm() {
+                    old_vm.active_cpus_clear(cpu);
+                }
+            }
+
             unsafe { pcb.basic_mut().set_user_vm(None) };
 
             drop(pcb);

--- a/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
@@ -1,0 +1,380 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <atomic>
+
+namespace {
+
+constexpr size_t kPageSize = 4096;
+constexpr size_t kNrPages = 64;
+constexpr int kNrThreads = 4;
+constexpr int kIters = 2000;
+constexpr int kMunmapRounds = 16;
+
+thread_local sigjmp_buf g_segv_jmp;
+thread_local volatile sig_atomic_t g_segv_active = 0;
+
+void sigsegv_handler(int sig, siginfo_t* si, void* uc) {
+    (void)sig;
+    (void)si;
+    (void)uc;
+    if (g_segv_active) {
+        siglongjmp(g_segv_jmp, 1);
+    }
+    _exit(99);
+}
+
+int install_segv_handler() {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_flags = SA_SIGINFO | SA_NODEFER;
+    sa.sa_sigaction = sigsegv_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSEGV, &sa, nullptr) < 0) {
+        return -1;
+    }
+    if (sigaction(SIGBUS, &sa, nullptr) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+struct ThreadCtx {
+    volatile uint8_t* base;
+    size_t len;
+    std::atomic<int>* run;
+};
+
+void* hammer_writer(void* arg) {
+    auto* ctx = static_cast<ThreadCtx*>(arg);
+    size_t off = 0;
+
+    g_segv_active = 1;
+    (void)sigsetjmp(g_segv_jmp, 1);
+
+    while (ctx->run->load(std::memory_order_acquire)) {
+        ctx->base[off] = static_cast<uint8_t>(off);
+        off += 13;
+        if (off >= ctx->len) {
+            off = 0;
+        }
+    }
+
+    g_segv_active = 0;
+    return nullptr;
+}
+
+int start_workers(uint8_t* buf, size_t len, std::atomic<int>* run, pthread_t* threads,
+                  ThreadCtx* ctxs) {
+    int created = 0;
+    for (; created < kNrThreads; ++created) {
+        ctxs[created].base = buf + created * kPageSize;
+        ctxs[created].len = len / kNrPages;
+        ctxs[created].run = run;
+        if (pthread_create(&threads[created], nullptr, hammer_writer, &ctxs[created]) != 0) {
+            fprintf(stderr, "pthread_create failed\n");
+            run->store(0, std::memory_order_release);
+            for (int i = 0; i < created; ++i) {
+                pthread_join(threads[i], nullptr);
+            }
+            return -1;
+        }
+    }
+    return 0;
+}
+
+void stop_workers(std::atomic<int>* run, pthread_t* threads) {
+    run->store(0, std::memory_order_release);
+    for (int i = 0; i < kNrThreads; ++i) {
+        pthread_join(threads[i], nullptr);
+    }
+}
+
+int case_mprotect_downgrade() {
+    const size_t len = kNrPages * kPageSize;
+    auto* buf = static_cast<uint8_t*>(
+        mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (buf == MAP_FAILED) {
+        perror("mmap");
+        return -1;
+    }
+    memset(buf, 0, len);
+
+    std::atomic<int> run{1};
+    pthread_t threads[kNrThreads];
+    ThreadCtx ctxs[kNrThreads];
+    if (start_workers(buf, len, &run, threads, ctxs) != 0) {
+        munmap(buf, len);
+        return -1;
+    }
+
+    int rc = 0;
+    g_segv_active = 1;
+
+    for (int i = 0; i < kIters; ++i) {
+        if (mprotect(buf, len, PROT_READ) < 0) {
+            perror("mprotect(R)");
+            rc = -1;
+            break;
+        }
+
+        if (sigsetjmp(g_segv_jmp, 1) == 0) {
+            *reinterpret_cast<volatile uint8_t*>(buf) = 0xAA;
+            fprintf(stderr, "FAIL: write to RO buf succeeded at iter %d\n", i);
+            rc = -1;
+            break;
+        }
+
+        if (mprotect(buf, len, PROT_READ | PROT_WRITE) < 0) {
+            perror("mprotect(RW)");
+            rc = -1;
+            break;
+        }
+    }
+
+    g_segv_active = 0;
+    stop_workers(&run, threads);
+    munmap(buf, len);
+    return rc;
+}
+
+int case_munmap_while_writing() {
+    const size_t len = kNrPages * kPageSize;
+
+    for (volatile int i = 0; i < kMunmapRounds; ++i) {
+        auto* buf = static_cast<uint8_t*>(
+            mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        if (buf == MAP_FAILED) {
+            perror("mmap");
+            return -1;
+        }
+        memset(buf, 0, len);
+
+        std::atomic<int> run{1};
+        pthread_t threads[kNrThreads];
+        ThreadCtx ctxs[kNrThreads];
+        if (start_workers(buf, len, &run, threads, ctxs) != 0) {
+            munmap(buf, len);
+            return -1;
+        }
+
+        usleep(2000);
+        stop_workers(&run, threads);
+
+        if (munmap(buf, len) < 0) {
+            perror("munmap");
+            return -1;
+        }
+
+        g_segv_active = 1;
+        int ok = 0;
+        if (sigsetjmp(g_segv_jmp, 1) == 0) {
+            *reinterpret_cast<volatile uint8_t*>(buf) = 0xBB;
+            fprintf(stderr, "FAIL: write to unmapped buf succeeded (iter %d)\n", i);
+        } else {
+            ok = 1;
+        }
+        g_segv_active = 0;
+
+        if (!ok) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+// Hammer writer that writes a monotonically increasing per-thread counter
+// across the entire buffer.
+//
+// Used by `case_fork_cow_stale_tlb` to make every CPU in the parent mm cache a
+// writable TLB entry for the whole buffer. Unlike `hammer_writer`, this writes
+// all pages (not just a per-thread slice) so any writable-TLB leak in the
+// parent post-fork will flip bytes anywhere in `buf`.
+struct HammerCtx {
+    volatile uint8_t* base;
+    size_t len;
+    std::atomic<int>* run;
+    uint8_t mark;
+};
+
+void* hammer_writer_whole(void* arg) {
+    auto* ctx = static_cast<HammerCtx*>(arg);
+    size_t off = 0;
+    uint8_t v = ctx->mark;
+
+    g_segv_active = 1;
+    (void)sigsetjmp(g_segv_jmp, 1);
+
+    while (ctx->run->load(std::memory_order_acquire)) {
+        ctx->base[off] = v++;
+        off += 13;
+        if (off >= ctx->len) {
+            off = 0;
+        }
+    }
+
+    g_segv_active = 0;
+    return nullptr;
+}
+
+// Regression test for the parent-side COW shootdown in `AddressSpace::try_clone`
+// and the mm-aware flush in `do_wp_page` (private-anonymous, map_count > 1).
+//
+// The parent:
+//   1. mmaps a private-anon buffer (all-zero after mmap).
+//   2. Spawns `kNrThreads` hammer workers that continuously overwrite the whole
+//      buffer. On a multi-CPU system this makes every CPU running the parent
+//      mm cache a writable TLB entry covering `buf`.
+//   3. Forks. `try_clone` writes-protects the parent's PTEs and must
+//      synchronously shoot down the parent mm's TLB on *all* active CPUs.
+//
+// Immediately after fork, the child snapshots `buf` (whatever the hammers
+// happened to have left in it) and then repeatedly verifies that no byte has
+// changed. Since the child only contains the main thread, any byte flipping
+// between the snapshot and a subsequent read must come from a parent CPU
+// writing through a stale writable TLB into the physical page that is still
+// shared (COW-wise) with the child.
+//
+// When the fix is in place:
+//   - `try_clone` issues a mm-aware `flush_tlb_mm_range` on the parent mm so
+//     every CPU invalidates its writable TLB of `buf` before fork returns.
+//   - The hammer workers' subsequent writes fault into `do_wp_page` which,
+//     in the private-anon map_count > 1 branch, allocates fresh physical
+//     pages for the parent mm. The child's physical pages stay pristine.
+int case_fork_cow_stale_tlb() {
+    const size_t len = kNrPages * kPageSize;
+    auto* buf = static_cast<uint8_t*>(
+        mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (buf == MAP_FAILED) {
+        perror("mmap");
+        return -1;
+    }
+    memset(buf, 0, len);
+
+    std::atomic<int> run{1};
+    pthread_t threads[kNrThreads];
+    HammerCtx ctxs[kNrThreads];
+    int created = 0;
+    for (; created < kNrThreads; ++created) {
+        ctxs[created].base = buf;
+        ctxs[created].len = len;
+        ctxs[created].run = &run;
+        ctxs[created].mark = static_cast<uint8_t>(0x10 + created);
+        if (pthread_create(&threads[created], nullptr, hammer_writer_whole, &ctxs[created]) != 0) {
+            fprintf(stderr, "pthread_create failed\n");
+            run.store(0, std::memory_order_release);
+            for (int i = 0; i < created; ++i) {
+                pthread_join(threads[i], nullptr);
+            }
+            munmap(buf, len);
+            return -1;
+        }
+    }
+
+    // Give the hammer threads a chance to spread across multiple CPUs so they
+    // really populate writable TLB entries everywhere.
+    usleep(5000);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        run.store(0, std::memory_order_release);
+        for (int i = 0; i < kNrThreads; ++i) {
+            pthread_join(threads[i], nullptr);
+        }
+        munmap(buf, len);
+        return -1;
+    }
+
+    if (pid == 0) {
+        // Child. Snapshot `buf` immediately so we know what the post-fork
+        // COW-shared physical pages look like from our point of view. Any
+        // subsequent divergence in a sampled byte must be a stale-TLB leak
+        // from the parent mm: the child has only one thread and it never
+        // writes `buf` itself.
+        //
+        // Sample every 256 bytes (16 samples/page). That's 1 KiB per page of
+        // buf state captured, which is more than enough to notice a leak.
+        constexpr size_t kSnapStride = 256;
+        const size_t snap_count = len / kSnapStride;
+        uint8_t* snap = new uint8_t[snap_count];
+        for (size_t i = 0; i < snap_count; ++i) {
+            snap[i] = buf[i * kSnapStride];
+        }
+
+        constexpr int kRounds = 400;
+        for (int r = 0; r < kRounds; ++r) {
+            for (size_t i = 0; i < snap_count; ++i) {
+                const uint8_t v = buf[i * kSnapStride];
+                if (v != snap[i]) {
+                    fprintf(stderr,
+                            "FAIL: child observed parent's stale-TLB write: "
+                            "buf[%zu]: 0x%02x -> 0x%02x (round %d)\n",
+                            i * kSnapStride, snap[i], v, r);
+                    delete[] snap;
+                    _exit(10);
+                }
+            }
+            usleep(500);
+        }
+        delete[] snap;
+        _exit(0);
+    }
+
+    int status = 0;
+    const pid_t wp = waitpid(pid, &status, 0);
+    run.store(0, std::memory_order_release);
+    for (int i = 0; i < kNrThreads; ++i) {
+        pthread_join(threads[i], nullptr);
+    }
+    munmap(buf, len);
+
+    if (wp != pid) {
+        perror("waitpid");
+        return -1;
+    }
+    if (!WIFEXITED(status)) {
+        fprintf(stderr, "child did not exit normally: status=0x%x\n", status);
+        return -1;
+    }
+    if (WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "child exit status=%d\n", WEXITSTATUS(status));
+        return -1;
+    }
+    return 0;
+}
+
+TEST(TlbShootdown, MprotectDowngradeInvalidatesRemoteWriters) {
+    EXPECT_EQ(0, case_mprotect_downgrade());
+}
+
+TEST(TlbShootdown, MunmapAccessFaultsAfterUnmap) {
+    EXPECT_EQ(0, case_munmap_while_writing());
+}
+
+TEST(TlbShootdown, ForkCowNoStaleTlbLeak) {
+    EXPECT_EQ(0, case_fork_cow_stale_tlb());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (install_segv_handler() < 0) {
+        perror("sigaction");
+        return 1;
+    }
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -8,6 +8,7 @@ normal/devpts_dir_read
 normal/test_pivot_root
 normal/test_mount_reconfigure
 normal/proc_self_limits
+normal/test_tlb_shootdown
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link

--- a/user/dadk/config/sets/ubuntu2404/gvisor_syscall_tests-1.0.0.toml
+++ b/user/dadk/config/sets/ubuntu2404/gvisor_syscall_tests-1.0.0.toml
@@ -1,0 +1,1 @@
+../../all/gvisor_syscall_tests-1.0.0.toml


### PR DESCRIPTION
- 新增`mmu_gather`模块，强制执行 shootdown 先于物理页释放的顺序
- 新增`tlb`模块，实现`mm_cpumask`、`tlb_gen`、per-CPU`TlbState` 和同步 CSD 握手协议
- 重构 x86_64/riscv64 进程切换、execve、exit 路径，维护`active_cpus`位图
- 重构 mmap/munmap/mprotect/mremap/madvise/shmat/shmdt 使用`MmuGather` 统一 shootdown
- 重构`do_wp_page`对所有 COW 场景执行 mm-aware TLB 刷新
- 新增用户态 TLB shootdown 回归测试用例