### PR TITLE
fix(fat): resolve directory entry flush race condition causing file loss

### DIFF
--- a/kernel/src/filesystem/fat/entry.rs
+++ b/kernel/src/filesystem/fat/entry.rs
@@ -1161,6 +1161,11 @@ impl LongDirEntry {
         fs: Arc<FATFileSystem>,
         gendisk_bytes_offset: u64,
     ) -> Result<(), SystemError> {
+        // 目录项扇区 RMW 必须串行化，否则与并发的短/长目录项 flush 交错时，
+        // 后写入者会以自己先前读到的旧扇区覆盖对方的新目录项。详见
+        // `FATFileSystem::dirent_io_lock` 的注释。
+        let _dirent_guard = fs.lock_dirent_io();
+
         // 从磁盘读取数据
         let blk_offset = fs.get_in_block_offset(gendisk_bytes_offset);
         let lba = fs.gendisk_lba_from_offset(fs.bytes_to_sector(gendisk_bytes_offset));
@@ -1374,6 +1379,12 @@ impl ShortDirEntry {
         fs: &Arc<FATFileSystem>,
         gendisk_bytes_offset: u64,
     ) -> Result<(), SystemError> {
+        // 目录项扇区 RMW 必须串行化。典型 race：`FATFile::ensure_len` 触发的 pagecache
+        // 异步回写在扇区 S 上做 RMW；同时主线程在同扇区 S 里新建文件写入长/短目录项。
+        // 若不加锁，后写入者会用自己 read 阶段读到的旧扇区覆盖对方的新目录项，
+        // 导致新建的文件立刻“消失”，后续 `find` 返回 `ENOENT`。
+        let _dirent_guard = fs.lock_dirent_io();
+
         // 从磁盘读取数据
         let blk_offset = fs.get_in_block_offset(gendisk_bytes_offset);
         let lba = fs.gendisk_lba_from_offset(fs.bytes_to_sector(gendisk_bytes_offset));

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -103,6 +103,24 @@ pub struct FATFileSystem {
     root_inode: Arc<LockedFATInode>,
     /// FAT表查询缓存（LRU）
     fat_cache: Mutex<LruCache<ClusterID, ClusterID>>,
+    /// 目录项扇区读-改-写串行化锁。
+    ///
+    /// FAT 的 `ShortDirEntry`/`LongDirEntry` 只占 32 字节，而底层 gendisk 的写入粒度是
+    /// 一个 LBA 扇区（典型 512B，可容纳 16 个目录项）。`flush` 的实现是先把整扇区读入
+    /// 内存，修改其中 32 字节，再把整扇区写回磁盘。
+    ///
+    /// 在多线程 / 多 CPU 环境下，若下列两条路径并发触发：
+    /// - 主线程在父目录中新建文件（写入新的 long/short 目录项到扇区 S）
+    /// - 另一文件的 pagecache 异步回写 worker 触发 `ensure_len`，更新该文件短目录项
+    ///   (同样是扇区 S 的 RMW)
+    ///
+    /// 二者的 RMW 窗口若交错，后写入者会用自己先前读到的"旧扇区 + 自己的 32 字节"
+    /// 覆盖对方刚写入的新目录项，导致新文件的目录项在磁盘上被静默抹掉，后续 `find`
+    /// 返回 `ENOENT`。该问题在慢速 TCG 仿真下极易复现，在 KVM 下时序紧凑难以触发。
+    ///
+    /// 本锁用于把所有目录项扇区的 RMW 串行化，消除上述竞争。所有持锁位置都已确认
+    /// 不会同时持有 inode 锁的反向依赖，不存在死锁风险。
+    dirent_io_lock: Mutex<()>,
 }
 
 /// FAT文件系统的Inode
@@ -684,6 +702,7 @@ impl FATFileSystem {
             fat_cache: Mutex::new(LruCache::new(
                 NonZeroUsize::new(FAT_LRU_CACHE_SIZE).unwrap(),
             )),
+            dirent_io_lock: Mutex::new(()),
         });
 
         // 对root inode加锁，并继续完成初始化工作
@@ -702,6 +721,16 @@ impl FATFileSystem {
     #[inline]
     pub fn bytes_per_cluster(&self) -> u64 {
         return (self.bpb.bytes_per_sector as u64) * (self.bpb.sector_per_cluster as u64);
+    }
+
+    /// 锁定目录项扇区 RMW 串行化互斥量。
+    ///
+    /// 详见 `FATFileSystem::dirent_io_lock` 字段的注释。所有会触发
+    /// `ShortDirEntry::flush` / `LongDirEntry::flush` 的代码路径都必须在执行
+    /// "read sector -> modify 32B -> write sector" 前先持有该锁，直到 `write_at` 完成。
+    #[inline]
+    pub(super) fn lock_dirent_io(&self) -> MutexGuard<'_, ()> {
+        self.dirent_io_lock.lock()
     }
 
     #[inline]


### PR DESCRIPTION
# fs/fat: serialize directory-entry sector RMW to fix `ENOENT` race under slow I/O

## Summary

Fixes a silent data-corruption race in the FAT driver where a newly-created
file's directory entry can be overwritten by a concurrent page-cache
write-back, causing the following `find()` on the parent directory to return
`ENOENT`.

The race has been reliably reproduced in CI (FAT32 rootfs under QEMU TCG
emulation) as:

```
[RUNNER] END:   fuse/fuse_core      status=PASSED
[RUNNER] START: fuse/fuse_extended
Error: 创建日志文件失败: /opt/tests/dunitest/results/fuse_fuse_extended.log
Caused by: No such file or directory (os error 2)
```

It does not reproduce locally under KVM because the racing RMW window is
orders of magnitude shorter than one scheduler tick.

## Root cause

`ShortDirEntry::flush` and `LongDirEntry::flush` are the only paths that
mutate on-disk directory entries in the FAT driver. A FAT dirent is 32 bytes,
but the block device writes in whole LBA sectors (typically 512B, so one
sector holds 16 dirents). Both flush methods therefore implement a
read-modify-write:

```text
read(sector) -> modify 32 bytes in memory -> write(sector) -> sync
```

None of this is protected by any lock. Concurrent paths into dirent RMW exist
naturally:

- Path A — VFS create/unlink/rename acquires the *parent directory inode*
  mutex and writes new long/short dirents through `create_dir_entries` /
  `remove_dir_entries`.
- Path B — the page-cache writeback worker runs
  `FATFile::write -> FATFile::ensure_len -> ShortDirEntry::flush` while
  holding only the *file's own* inode mutex (a different mutex from the
  parent directory's).

Because the two paths touch the same parent directory sector but hold
different inode locks, their RMW windows can overlap:

| time | writeback worker (W)                         | create thread (M)                                |
|------|----------------------------------------------|--------------------------------------------------|
| t0   | `read(sector)` into `bufW` (no new dirent)   | —                                                |
| t1   | modify size field of `fuse_core.log` in bufW | `read(sector)` into `bufM` (no new dirent)       |
| t2   | —                                            | write `fuse_extended.log` long+short into bufM   |
| t3   | —                                            | `write(sector) <- bufM` (dirent now on disk)     |
| t4   | `write(sector) <- bufW`                      | — (bufW silently overwrites the new dirent)      |

After t4 the new dirent is gone from disk; the follow-up `guard.find(name)`
issued inside `FATInode::create` re-reads the directory, does not see the
entry, and returns `ENOENT` all the way up to userspace.


## Fix

Introduce a single filesystem-level `Mutex<()>` — `dirent_io_lock` — on
`FATFileSystem`, taken at the top of `ShortDirEntry::flush` and
`LongDirEntry::flush` and held across the `read -> modify -> write -> sync`
sequence. This is the minimum change that makes every dirent-sector RMW
atomic with respect to every other dirent-sector RMW.

This covers all dirent writers in the driver (verified by grep over
`*.flush(` in `kernel/src/filesystem/fat/`):

- `FATFile::ensure_len` / `FATFile::truncate` (extending writes, truncation)
- `FATDir::create_dir_entries` (VFS `create` / `mkdir`, long + short entries)
- `FATDir::create_dir` (`.` and `..` of a new subdirectory)
- `FATDir::remove_dir_entries` (VFS `unlink` / `rmdir`)

### Why it is sufficient

With the lock, any two concurrent RMWs on the same sector are totally
ordered. Whichever goes second reads the sector after the first's write and
therefore preserves the first's modifications. The sequence in the table
above can no longer happen; one of the two flushes always observes the other
one's update.

Readers (directory iteration during `find_entry`, `check_existence`, etc.) do
not need the lock: individual block-device reads are sector-atomic, and
readers only need to observe a consistent point-in-time state of each
sector, not a consistent view across multiple sectors.

### Lock ordering / deadlock analysis

Two paths acquire the new lock:

- `parent_inode.mutex` → `dirent_io_lock`  (VFS create/unlink/rename/mkdir/rmdir)
- `file_inode.mutex`   → `dirent_io_lock`  (page-cache writeback via `write_sync`)

Both orderings are one-way; nothing inside the `dirent_io_lock` critical
section reacquires any inode mutex. The two inode mutexes are different
objects (parent dir vs. child file), so they cannot form a cycle either.

## What this patch does *not* fix (known follow-ups)

- FAT-table `set_entry` has the same RMW-without-locking shape (a FAT32
  sector contains 128 entries), so concurrent cluster allocate/deallocate on
  different files can theoretically corrupt each other's chain heads. Not
  observed in practice yet and out of scope for this fix; tracked separately.
- `LockedFATInode::close` is still a no-op. Synchronously flushing dirty
  pages on close would narrow the window further as an optimization, but is
  no longer required for correctness once the RMW is serialized.
