### PR TITLE
syscall: fix setgroups(0) failing to persist changes

### DIFF
--- a/kernel/src/process/syscall/sys_groups.rs
+++ b/kernel/src/process/syscall/sys_groups.rs
@@ -82,6 +82,7 @@ impl Syscall for SysSetGroups {
         if size == 0 {
             // clear all supplementary groups
             cred.setgroups(Vec::new());
+            *pcb.cred.lock() = Cred::new_arc(cred);
             return Ok(0);
         }
         if size > NGROUPS_MAX {


### PR DESCRIPTION
Fixes #1838: fix setgroups(0) failing to persist changes.