### PR TITLE
feat(sysfs): implement group_remove_files to complete attribute group…

### DIFF
--- a/kernel/src/driver/base/mod.rs
+++ b/kernel/src/driver/base/mod.rs
@@ -12,3 +12,4 @@ pub mod map;
 pub mod platform;
 pub mod subsys;
 pub mod swnode;
+pub mod test;

--- a/kernel/src/driver/base/test/mod.rs
+++ b/kernel/src/driver/base/test/mod.rs
@@ -1,0 +1,1 @@
+pub mod sysfs_group_test;

--- a/kernel/src/driver/base/test/sysfs_group_test.rs
+++ b/kernel/src/driver/base/test/sysfs_group_test.rs
@@ -1,0 +1,470 @@
+use alloc::{string::ToString, sync::Arc, sync::Weak};
+use log::info;
+use system_error::SystemError;
+
+use crate::{
+    driver::base::{
+        device::{device_register, Device, DeviceType, IdTable},
+        kobject::{
+            CommonKobj, KObjType, KObject, KObjectCommonData, KObjectManager, KObjectState,
+            LockedKObjectState,
+        },
+    },
+    filesystem::{
+        kernfs::KernFSInode,
+        sysfs::{
+            Attribute, AttributeGroup, SysFSOps, SysFSOpsSupport, SYSFS_ATTR_MODE_RW,
+            SYSFS_ATTR_MODE_WO,
+        },
+        vfs::InodeMode,
+    },
+    init::initcall::INITCALL_FS,
+    libs::{
+        rwsem::{RwSemReadGuard, RwSemWriteGuard},
+        spinlock::{SpinLock, SpinLockGuard},
+    },
+    misc::ksysfs::sys_kernel_kobj,
+};
+
+static mut TEST_DEVICE: Option<Arc<TestDevice>> = None;
+static mut TEST_CONTROL: Option<Arc<CommonKobj>> = None;
+
+#[derive(Debug)]
+struct TestDeviceInner {
+    kobj_common: KObjectCommonData,
+    registered: bool,
+    fail_on_create: bool,
+}
+
+#[derive(Debug)]
+#[cast_to([sync] Device)]
+
+// 这是一个测试用的设备，仅为用户态暴露文件，以进行attribute_group的测试
+// 会创建/sys/kernel/sysfs_group_test，通过写入文件动态在/sys/devices创建测试设备
+struct TestDevice {
+    inner: SpinLock<TestDeviceInner>,
+    kobj_state: LockedKObjectState,
+}
+
+fn get_test_device() -> Arc<TestDevice> {
+    unsafe { TEST_DEVICE.clone().unwrap() }
+}
+
+impl TestDevice {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: SpinLock::new(TestDeviceInner {
+                kobj_common: KObjectCommonData::default(),
+                registered: false,
+                fail_on_create: false,
+            }),
+            kobj_state: LockedKObjectState::new(None),
+        })
+    }
+
+    fn inner(&self) -> SpinLockGuard<'_, TestDeviceInner> {
+        self.inner.lock()
+    }
+
+    fn register(self: &Arc<Self>) -> Result<(), SystemError> {
+        let inner = self.inner();
+        if inner.registered {
+            return Err(SystemError::EEXIST);
+        }
+        drop(inner);
+
+        let device = get_test_device();
+        let result = device_register(device.clone());
+        if let Err(e) = result {
+            info!("Test device registration failed: {:?}", e);
+            return Err(e);
+        }
+
+        device.set_kobj_type(Some(&TEST_KOBJ_TYPE));
+        self.inner().registered = true;
+        info!("Test device registered");
+        Ok(())
+    }
+
+    fn unregister(self: &Arc<Self>) {
+        if !self.inner().registered {
+            return;
+        }
+
+        let device = get_test_device();
+
+        let kobj = device.clone() as Arc<dyn KObject>;
+
+        KObjectManager::remove_kobj(kobj);
+
+        self.inner().registered = false;
+        info!("Test device unregistered");
+    }
+
+    fn set_fail_on_create(&self, fail: bool) {
+        self.inner().fail_on_create = fail;
+        if fail {
+            unsafe { TEST_ATTR_GROUPS = [&Group1, &Group3] }
+        } else {
+            unsafe { TEST_ATTR_GROUPS = [&Group1, &Group2] }
+        }
+    }
+
+    fn fail_on_create(&self) -> bool {
+        self.inner().fail_on_create
+    }
+}
+
+impl KObject for TestDevice {
+    fn as_any_ref(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
+        self.inner().kobj_common.kern_inode = inode;
+    }
+
+    fn inode(&self) -> Option<Arc<KernFSInode>> {
+        self.inner().kobj_common.kern_inode.clone()
+    }
+
+    fn parent(&self) -> Option<Weak<dyn KObject>> {
+        self.inner().kobj_common.parent.clone()
+    }
+
+    fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
+        self.inner().kobj_common.parent = parent;
+    }
+
+    fn kset(&self) -> Option<Arc<crate::driver::base::kset::KSet>> {
+        self.inner().kobj_common.kset.clone()
+    }
+
+    fn set_kset(&self, kset: Option<Arc<crate::driver::base::kset::KSet>>) {
+        self.inner().kobj_common.kset = kset;
+    }
+
+    fn kobj_type(&self) -> Option<&'static dyn KObjType> {
+        self.inner().kobj_common.kobj_type
+    }
+
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.inner().kobj_common.kobj_type = ktype;
+    }
+
+    fn name(&self) -> alloc::string::String {
+        "sysfs_group_test".to_string()
+    }
+
+    fn set_name(&self, _name: alloc::string::String) {}
+
+    fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {
+        self.kobj_state.read()
+    }
+
+    fn kobj_state_mut(&self) -> RwSemWriteGuard<'_, KObjectState> {
+        self.kobj_state.write()
+    }
+
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.kobj_state.write() = state;
+    }
+}
+
+impl Device for TestDevice {
+    fn dev_type(&self) -> DeviceType {
+        DeviceType::Other
+    }
+
+    fn id_table(&self) -> IdTable {
+        IdTable::new("sysfs_group_test".to_string(), None)
+    }
+
+    fn set_bus(&self, _bus: Option<Weak<dyn crate::driver::base::device::bus::Bus>>) {}
+
+    fn set_class(&self, _class: Option<Weak<dyn crate::driver::base::class::Class>>) {}
+
+    fn driver(&self) -> Option<Arc<dyn crate::driver::base::device::driver::Driver>> {
+        None
+    }
+
+    fn set_driver(&self, _driver: Option<Weak<dyn crate::driver::base::device::driver::Driver>>) {}
+
+    fn is_dead(&self) -> bool {
+        false
+    }
+
+    fn can_match(&self) -> bool {
+        true
+    }
+
+    fn set_can_match(&self, _can_match: bool) {}
+
+    fn state_synced(&self) -> bool {
+        false
+    }
+
+    fn attribute_groups(&self) -> Option<&'static [&'static dyn AttributeGroup]> {
+        unsafe { Some(&TEST_ATTR_GROUPS) }
+    }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        None
+    }
+
+    fn set_dev_parent(&self, _parent: Option<Weak<dyn Device>>) {}
+}
+
+#[derive(Debug)]
+struct TestKObjType;
+
+impl KObjType for TestKObjType {
+    fn release(&self, _kobj: Arc<dyn KObject>) {}
+    fn sysfs_ops(&self) -> Option<&dyn SysFSOps> {
+        Some(&TEST_SYSFS_OPS)
+    }
+    fn attribute_groups(&self) -> Option<&'static [&'static dyn AttributeGroup]> {
+        unsafe { Some(&TEST_ATTR_GROUPS) }
+    }
+}
+
+#[derive(Debug)]
+struct ControlKObjType;
+
+impl KObjType for ControlKObjType {
+    fn release(&self, _kobj: Arc<dyn KObject>) {}
+    fn sysfs_ops(&self) -> Option<&dyn SysFSOps> {
+        Some(&TEST_SYSFS_OPS)
+    }
+    fn attribute_groups(&self) -> Option<&'static [&'static dyn AttributeGroup]> {
+        Some(&CONTROL_ATTR_GROUPS)
+    }
+}
+
+static TEST_KOBJ_TYPE: TestKObjType = TestKObjType;
+static CONTROL_KOBJ_TYPE: ControlKObjType = ControlKObjType;
+
+#[derive(Debug)]
+struct TestSysFSOps;
+
+impl SysFSOps for TestSysFSOps {
+    fn show(
+        &self,
+        kobj: Arc<dyn KObject>,
+        attr: &dyn Attribute,
+        buf: &mut [u8],
+    ) -> Result<usize, SystemError> {
+        attr.show(kobj, buf)
+    }
+
+    fn store(
+        &self,
+        kobj: Arc<dyn KObject>,
+        attr: &dyn Attribute,
+        buf: &[u8],
+    ) -> Result<usize, SystemError> {
+        attr.store(kobj, buf)
+    }
+}
+
+static TEST_SYSFS_OPS: TestSysFSOps = TestSysFSOps;
+
+static CONTROL_ATTR_GROUPS: [&'static dyn AttributeGroup; 1] = [&ControlGroup];
+static mut TEST_ATTR_GROUPS: [&'static dyn AttributeGroup; 2] = [&Group1, &Group2];
+#[derive(Debug)]
+struct Group1;
+
+impl AttributeGroup for Group1 {
+    fn name(&self) -> Option<&str> {
+        Some("test_group1")
+    }
+
+    fn attrs(&self) -> &[&'static dyn Attribute] {
+        &ATTRS
+    }
+}
+
+#[derive(Debug)]
+struct Group2;
+
+impl AttributeGroup for Group2 {
+    fn name(&self) -> Option<&str> {
+        Some("test_group2")
+    }
+
+    fn attrs(&self) -> &[&'static dyn Attribute] {
+        &ATTRS
+    }
+}
+
+#[derive(Debug)]
+struct Group3;
+
+// 创建同名group，触发回滚
+impl AttributeGroup for Group3 {
+    fn name(&self) -> Option<&str> {
+        Some("test_group1")
+    }
+
+    fn attrs(&self) -> &[&'static dyn Attribute] {
+        &ATTRS
+    }
+}
+
+static ATTRS: [&'static dyn Attribute; 1] = [&AttrStatus];
+
+#[derive(Debug)]
+struct AttrStatus;
+
+impl Attribute for AttrStatus {
+    fn name(&self) -> &str {
+        "status"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_RW
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW | SysFSOpsSupport::ATTR_STORE
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        Ok(0)
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, _buf: &[u8]) -> Result<usize, SystemError> {
+        Ok(0)
+    }
+}
+
+#[derive(Debug)]
+struct ControlGroup;
+
+impl AttributeGroup for ControlGroup {
+    fn name(&self) -> Option<&str> {
+        None
+    }
+
+    fn attrs(&self) -> &[&'static dyn Attribute] {
+        &CONTROL_ATTRS
+    }
+}
+
+static CONTROL_ATTRS: [&'static dyn Attribute; 3] =
+    [&AttrRegister, &AttrUnregister, &AttrFailOnCreate];
+
+#[derive(Debug)]
+struct AttrRegister;
+
+#[derive(Debug)]
+struct AttrUnregister;
+
+#[derive(Debug)]
+struct AttrFailOnCreate;
+
+impl Attribute for AttrRegister {
+    fn name(&self) -> &str {
+        "register"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_WO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_STORE
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, buf: &[u8]) -> Result<usize, SystemError> {
+        let device = get_test_device();
+        device.register()?;
+        Ok(buf.len())
+    }
+}
+
+impl Attribute for AttrUnregister {
+    fn name(&self) -> &str {
+        "unregister"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_WO
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_STORE
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, buf: &[u8]) -> Result<usize, SystemError> {
+        let device = get_test_device();
+        device.unregister();
+        Ok(buf.len())
+    }
+}
+
+impl Attribute for AttrFailOnCreate {
+    fn name(&self) -> &str {
+        "fail_on_create"
+    }
+
+    fn mode(&self) -> InodeMode {
+        SYSFS_ATTR_MODE_RW
+    }
+
+    fn support(&self) -> SysFSOpsSupport {
+        SysFSOpsSupport::ATTR_SHOW | SysFSOpsSupport::ATTR_STORE
+    }
+
+    fn show(&self, _kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let device = get_test_device();
+        let fail = device.fail_on_create();
+        let s = alloc::format!("{}\n", if fail { 1 } else { 0 });
+        let bytes = s.as_bytes();
+        let len = bytes.len().min(buf.len());
+        buf[..len].copy_from_slice(&bytes[..len]);
+        Ok(len)
+    }
+
+    fn store(&self, _kobj: Arc<dyn KObject>, buf: &[u8]) -> Result<usize, SystemError> {
+        let device = get_test_device();
+        let s = core::str::from_utf8(buf).map_err(|_| SystemError::EINVAL)?;
+        let s = s.trim();
+        let fail = match s {
+            "1" | "true" => true,
+            "0" | "false" => false,
+            _ => return Err(SystemError::EINVAL),
+        };
+        device.set_fail_on_create(fail);
+        Ok(buf.len())
+    }
+}
+
+#[unified_init::macros::unified_init(INITCALL_FS)]
+fn test_init() -> Result<(), SystemError> {
+    info!("Initializing sysfs group test device");
+
+    let device = TestDevice::new();
+
+    unsafe {
+        TEST_DEVICE = Some(device.clone());
+    }
+
+    let control = crate::driver::base::kobject::CommonKobj::new("sysfs_group_test".to_string());
+    control.set_kobj_type(Some(&CONTROL_KOBJ_TYPE));
+
+    let kernel_kobj = sys_kernel_kobj();
+    control.set_parent(Some(Arc::downgrade(&(kernel_kobj as Arc<dyn KObject>))));
+
+    crate::driver::base::kobject::KObjectManager::init_and_add_kobj(
+        control.clone() as Arc<dyn KObject>,
+        Some(&CONTROL_KOBJ_TYPE),
+    )?;
+
+    unsafe {
+        TEST_CONTROL = Some(control);
+    }
+
+    info!("Sysfs group test device initialized");
+    Ok(())
+}

--- a/kernel/src/filesystem/sysfs/dir.rs
+++ b/kernel/src/filesystem/sysfs/dir.rs
@@ -120,8 +120,7 @@ impl SysFS {
         kobj.set_inode(None);
 
         if let Some(inode) = kobj_inode {
-            let parent = inode.parent().unwrap();
-            parent.remove_recursive()
+            inode.remove_inode_include_self()
         }
     }
 }

--- a/kernel/src/filesystem/sysfs/group.rs
+++ b/kernel/src/filesystem/sysfs/group.rs
@@ -214,7 +214,18 @@ impl SysFS {
         return Ok(());
     }
 
-    fn group_remove_files(&self, _parent: &Arc<KernFSInode>, _group: &'static dyn AttributeGroup) {
-        todo!("group_remove_files")
+    fn group_remove_files(&self, parent: &Arc<KernFSInode>, group: &'static dyn AttributeGroup) {
+        // visibility的正确性需要依赖is_visible的实现，为保证文件被彻底删除，这里跳过了对visibility的判断
+        for attr in group.attrs() {
+            if let Err(e) = parent.remove(attr.name()) {
+                if e != SystemError::ENOENT {
+                    warn!(
+                        "sysfs failed to remove attr '{}' in group '{}': {e:?}",
+                        attr.name(),
+                        group.name().unwrap_or("")
+                    );
+                }
+            }
+        }
     }
 }

--- a/kernel/src/filesystem/sysfs/group.rs
+++ b/kernel/src/filesystem/sysfs/group.rs
@@ -97,7 +97,7 @@ impl SysFS {
 
         if let Err(e) = self.group_create_files(parent_inode.clone(), kobj, group, update) {
             if group.name().is_some() {
-                parent_inode.remove_recursive();
+                parent_inode.remove_inode_include_self();
             }
             return Err(e);
         }
@@ -148,7 +148,7 @@ impl SysFS {
         self.group_remove_files(&parent_inode, group);
 
         if group.name().is_some() {
-            parent_inode.remove_recursive();
+            parent_inode.remove_inode_include_self();
         }
 
         return Ok(());

--- a/user/apps/tests/dunitest/suites/normal/sysfs_group_test.cc
+++ b/user/apps/tests/dunitest/suites/normal/sysfs_group_test.cc
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+namespace {
+    
+const char* control_path = "/sys/kernel/sysfs_group_test";
+const char* register_path = "/sys/kernel/sysfs_group_test/register";
+const char* unregister_path = "/sys/kernel/sysfs_group_test/unregister";
+const char* device_path = "/sys/devices/sysfs_group_test";
+const char* group1_path = "/sys/devices/sysfs_group_test/test_group1";
+const char* group2_path = "/sys/devices/sysfs_group_test/test_group2";
+    
+bool file_exists(const char *path) {
+    struct stat st;
+    return stat(path, &st) == 0;
+}
+
+int write_file(const char *path, const char *buf, size_t size) {
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) return -1;
+    ssize_t n = write(fd, buf, size);
+    close(fd);
+    return n == (ssize_t)size ? 0 : -1;
+}
+
+void ensure_device_unregistered(void) {
+    if (file_exists(device_path)) {
+        write_file(unregister_path, "1\n", 2);
+        usleep(10000);
+    }
+    if (file_exists(device_path)) {
+        FAIL() << "Fail to remove device";
+    }
+}
+
+} // namespace
+
+TEST(SysfsGroupTest, CreateGroups) {
+    if (!file_exists(control_path)) {
+        GTEST_SKIP() << "sysfs_group_test kernel module not loaded";
+    }
+    ensure_device_unregistered();    
+
+    const char* group1_path_status = "/sys/devices/sysfs_group_test/test_group1/status";
+    const char* group2_path_status = "/sys/devices/sysfs_group_test/test_group2/status";
+
+    EXPECT_TRUE(file_exists(control_path)) << "Control interface not exists";
+    EXPECT_FALSE(file_exists(device_path)) << "Device registered initially as unexpected";
+
+    EXPECT_EQ(0, write_file(register_path, "1\n", 2)) << "Register device fails";
+    EXPECT_TRUE(file_exists(device_path)) << "Device directory not created";
+    EXPECT_TRUE(file_exists(group1_path)) << "group1 not created";
+    EXPECT_TRUE(file_exists(group2_path)) << "group2 not created";
+    EXPECT_TRUE(file_exists(group1_path_status)) << "group1 attributes not created";
+    EXPECT_TRUE(file_exists(group2_path_status)) << "group2 attributes not created";
+
+    ensure_device_unregistered();
+}
+
+TEST(SysfsGroupTest, RemoveGroups) {
+    if (!file_exists(control_path)) {
+        GTEST_SKIP() << "sysfs_group_test kernel module not loaded";
+    }
+    ensure_device_unregistered();    
+
+    EXPECT_EQ(0, write_file(register_path, "1\n", 2)) << "Register device fail";
+    EXPECT_EQ(0, write_file(unregister_path, "1\n", 2)) << "Unregister device fail";
+    EXPECT_FALSE(file_exists(device_path)) << "Device directory not removed";
+    EXPECT_FALSE(file_exists(group1_path)) << "group1 not removed";
+    EXPECT_FALSE(file_exists(group2_path)) << "group2 not removed";
+
+    ensure_device_unregistered();
+}
+
+TEST(SysfsGroupTest, Lifecycle) {
+    if (!file_exists(control_path)) {
+        GTEST_SKIP() << "sysfs_group_test kernel module not loaded";
+    }
+    ensure_device_unregistered();    
+    
+    for (int i = 0; i < 3; i++) {
+        EXPECT_EQ(0, write_file(register_path, "1\n", 2)) << "Register device fails" << i;
+        EXPECT_TRUE(file_exists(device_path)) << "Device not exists" << i;
+        EXPECT_EQ(0, write_file(unregister_path, "1\n", 2)) << "Unregister device fails" << i;
+        EXPECT_FALSE(file_exists(device_path)) << "Device not removed" << i;
+    }
+
+    ensure_device_unregistered();
+}
+
+TEST(SysfsGroupTest, FailureRollback) {
+    if (!file_exists(control_path)) {
+        GTEST_SKIP() << "sysfs_group_test kernel module not loaded";
+    }
+    ensure_device_unregistered();    
+    
+    const char* set_fail_path = "/sys/kernel/sysfs_group_test/fail_on_create";
+
+    EXPECT_EQ(0, write_file(set_fail_path, "1\n", 2)) << "Set fail flag fails";
+    EXPECT_FALSE(file_exists(group1_path)) << "Group1 created as unexpected";
+
+    ensure_device_unregistered();
+    EXPECT_EQ(0, write_file(set_fail_path, "0\n", 2)) << "Clear fail flag fails";
+}
+
+TEST(SysfsGroupTest, ErrorHandling) {
+    if (!file_exists(control_path)) {
+        GTEST_SKIP() << "sysfs_group_test kernel module not loaded";
+    }
+    ensure_device_unregistered();    
+    
+    EXPECT_EQ(0, write_file(register_path, "1\n", 2)) << "First registration fails";
+    EXPECT_NE(0, write_file(register_path, "1\n", 2)) << "Double registration success as unexpected";
+    EXPECT_TRUE(file_exists(device_path)) << "Device not exists after error";
+
+    EXPECT_EQ(0, write_file(unregister_path, "1\n", 2)) << "First unregister fails";
+    EXPECT_EQ(0, write_file(unregister_path, "1\n", 2)) << "Double unregister fails";
+    EXPECT_FALSE(file_exists(device_path)) << "Device not removed";
+
+    ensure_device_unregistered();
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -8,6 +8,7 @@ normal/devpts_dir_read
 normal/test_pivot_root
 normal/test_mount_reconfigure
 normal/proc_self_limits
+normal/sysfs_group_test
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link


### PR DESCRIPTION
Fixed #1835

This PR implement the group_remove_files function, complete sysfs attribute group removal, and fix attribute group lifecycle management issues.

## Main Changes

- Implemented the removal logic for each attribute file in the attribute group
  - skipped to check the visibility of attribute file to ensure proper removal

- Fix the removal logic in `remove_dir(&self, kobj: &Arc<dyn KObject>)` and `kernel/src/filesystem/sysfs/group.rs` to avoid accidental removal and directory leak

- Add `kernel/src/driver/base/test` to create control interface in `/sys/kernel/sysfs_group_test control interface` for user-space dunitest
  - There are `register`, `unregister`, `fail_on_create` attribute file in the control interface
  - the test device will be created/removed in `/sys/devices`
- Add sysfs_group_test.cc test file in dunitest, including:
  - attribute group create
  - attribute group removal
  - rollback when fail to create attribute group
  