### PR TITLE
feat(page_cache): add file reverse mapping and truncation support

### DIFF
--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 
 use alloc::{
     collections::BTreeSet,
@@ -11,17 +11,21 @@ use system_error::SystemError;
 use super::vfs::{FilePrivateData, IndexNode};
 use crate::exception::workqueue::{schedule_work, Work, WorkQueue};
 use crate::libs::mutex::MutexGuard;
+use crate::libs::rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard};
 use crate::libs::spinlock::SpinLock;
 use crate::libs::wait_queue::WaitQueue;
 use crate::mm::page::FileMapInfo;
 use crate::mm::page_cache_stats as pc_stats;
+use crate::mm::ucontext::LockedVMA;
 use crate::sched::completion::Completion;
 use crate::{arch::mm::LockedFrameAllocator, libs::lazy_init::Lazy};
 use crate::{
     arch::MMArch,
     libs::mutex::Mutex,
     mm::{
+        mmu_gather::MmuGather,
         page::{page_manager_lock, page_reclaimer_lock, Page, PageFlags},
+        ucontext::AddressSpace,
         MemoryManagementArch,
     },
 };
@@ -32,6 +36,62 @@ static PAGE_CACHE_ID: AtomicUsize = AtomicUsize::new(0);
 
 const PAGECACHE_IO_WORKERS: usize = 4;
 static PAGECACHE_IO_RR: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug, Default)]
+struct FileVmaIndex {
+    vmas: HashMap<usize, Weak<LockedVMA>>,
+}
+
+impl FileVmaIndex {
+    fn register(&mut self, vma: &Arc<LockedVMA>) {
+        self.vmas.insert(vma.id(), Arc::downgrade(vma));
+    }
+
+    fn unregister(&mut self, vma_id: usize) {
+        self.vmas.remove(&vma_id);
+    }
+
+    fn collect_all(&mut self) -> Vec<Arc<LockedVMA>> {
+        let mut result = Vec::new();
+        self.vmas.retain(|_, weak| {
+            if let Some(vma) = weak.upgrade() {
+                result.push(vma);
+                true
+            } else {
+                false
+            }
+        });
+        result
+    }
+}
+
+struct MmFileRangeGroup {
+    mm: Arc<AddressSpace>,
+    ranges: Vec<(Arc<LockedVMA>, crate::mm::VirtRegion)>,
+}
+
+impl MmFileRangeGroup {
+    fn new(mm: Arc<AddressSpace>) -> Self {
+        Self {
+            mm,
+            ranges: Vec::new(),
+        }
+    }
+}
+
+struct MmFilePageGroup {
+    mm: Arc<AddressSpace>,
+    items: Vec<(Arc<LockedVMA>, crate::mm::VirtAddr)>,
+}
+
+impl MmFilePageGroup {
+    fn new(mm: Arc<AddressSpace>) -> Self {
+        Self {
+            mm,
+            items: Vec::new(),
+        }
+    }
+}
 
 lazy_static! {
     static ref PAGECACHE_IO_WQS: Vec<Arc<WorkQueue>> = {
@@ -194,6 +254,10 @@ pub struct PageCache {
     inner: Mutex<InnerPageCache>,
     inode: Lazy<Weak<dyn IndexNode>>,
     backend: Lazy<Arc<dyn PageCacheBackend>>,
+    i_mmap_rwsem: RwSem<()>,
+    invalidate_lock: RwSem<()>,
+    file_vma_seq: AtomicU64,
+    file_vmas: SpinLock<FileVmaIndex>,
     unevictable: AtomicBool,
     is_shmem: AtomicBool,
     manager: PageCacheManager,
@@ -512,6 +576,7 @@ impl PageCacheManager {
         };
 
         if len > 0 {
+            let _ = cache.mkclean_page(page_index, false);
             {
                 let mut guard = page.write();
                 guard.remove_flags(PageFlags::PG_DIRTY);
@@ -773,6 +838,10 @@ impl PageCache {
                 }
                 v
             },
+            i_mmap_rwsem: RwSem::new(()),
+            invalidate_lock: RwSem::new(()),
+            file_vma_seq: AtomicU64::new(0),
+            file_vmas: SpinLock::new(FileVmaIndex::default()),
             unevictable: AtomicBool::new(false),
             is_shmem: AtomicBool::new(false),
             manager: PageCacheManager::new(weak.clone()),
@@ -818,6 +887,289 @@ impl PageCache {
 
     pub fn manager(&self) -> &PageCacheManager {
         &self.manager
+    }
+
+    pub fn i_mmap_read(&self) -> RwSemReadGuard<'_, ()> {
+        self.i_mmap_rwsem.read()
+    }
+
+    pub fn i_mmap_write(&self) -> RwSemWriteGuard<'_, ()> {
+        self.i_mmap_rwsem.write()
+    }
+
+    pub fn invalidate_read(&self) -> RwSemReadGuard<'_, ()> {
+        self.invalidate_lock.read()
+    }
+
+    pub fn invalidate_write(&self) -> RwSemWriteGuard<'_, ()> {
+        self.invalidate_lock.write()
+    }
+
+    fn note_file_vma_mutation(&self) {
+        self.file_vma_seq.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub fn file_vma_seq(&self) -> u64 {
+        self.file_vma_seq.load(Ordering::Acquire)
+    }
+
+    pub fn register_file_vma(&self, vma: &Arc<LockedVMA>) {
+        let _guard = self.i_mmap_write();
+        self.file_vmas.lock_irqsave().register(vma);
+        self.note_file_vma_mutation();
+    }
+
+    pub fn unregister_file_vma(&self, vma_id: usize) {
+        let _guard = self.i_mmap_write();
+        self.file_vmas.lock_irqsave().unregister(vma_id);
+        self.note_file_vma_mutation();
+    }
+
+    pub fn collect_file_vmas(&self) -> Vec<Arc<LockedVMA>> {
+        let _guard = self.i_mmap_read();
+        self.file_vmas.lock_irqsave().collect_all()
+    }
+
+    pub fn collect_file_vmas_in_page_range(
+        &self,
+        start_page_index: usize,
+        end_page_index: usize,
+    ) -> Vec<Arc<LockedVMA>> {
+        let _guard = self.i_mmap_read();
+        self.file_vmas
+            .lock_irqsave()
+            .collect_all()
+            .into_iter()
+            .filter(|vma| {
+                let guard = vma.lock();
+                let Some(vma_pgoff) = guard.backing_page_offset() else {
+                    return false;
+                };
+                let vma_pages = guard.region().size() >> MMArch::PAGE_SHIFT;
+                let vma_end = vma_pgoff.saturating_add(vma_pages);
+                start_page_index < vma_end && vma_pgoff <= end_page_index
+            })
+            .collect()
+    }
+
+    fn collect_file_vmas_snapshot(
+        &self,
+        page_range: Option<(usize, Option<usize>)>,
+    ) -> (u64, Vec<Arc<LockedVMA>>) {
+        let _guard = self.i_mmap_read();
+        let seq = self.file_vma_seq();
+        let mut vmas = self.file_vmas.lock_irqsave().collect_all();
+        if let Some((start_page_index, end_page_index_exclusive)) = page_range {
+            vmas.retain(|vma| {
+                vma.file_pgoff_intersection(start_page_index, end_page_index_exclusive)
+                    .is_some()
+            });
+        }
+        (seq, vmas)
+    }
+
+    pub fn collect_mapped_vmas_for_page(&self, page_index: usize) -> Vec<Arc<LockedVMA>> {
+        self.collect_file_vmas_in_page_range(page_index, page_index)
+    }
+
+    pub fn unmap_mapping_pages(
+        &self,
+        start_page_index: usize,
+        end_page_index_exclusive: Option<usize>,
+    ) -> Result<(), SystemError> {
+        loop {
+            let (seq, snapshot) =
+                self.collect_file_vmas_snapshot(Some((start_page_index, end_page_index_exclusive)));
+            let mut mm_groups: HashMap<u64, MmFileRangeGroup> = HashMap::new();
+
+            for vma in snapshot {
+                let Some(region) =
+                    vma.file_pgoff_intersection(start_page_index, end_page_index_exclusive)
+                else {
+                    continue;
+                };
+                let Some(mm) = vma.lock().address_space().and_then(|space| space.upgrade()) else {
+                    continue;
+                };
+                mm_groups
+                    .entry(mm.id())
+                    .or_insert_with(|| MmFileRangeGroup::new(mm.clone()))
+                    .ranges
+                    .push((vma, region));
+            }
+
+            for (_id, group) in mm_groups {
+                let mm_guard = group.mm.read();
+                let _pt_edit = group.mm.page_table_edit();
+                let mut tlb = MmuGather::gather(&group.mm);
+                for (vma, region) in group.ranges {
+                    vma.unmap_range(region, &mm_guard.user_mapper.utable, &mut tlb);
+                }
+                tlb.finish();
+            }
+
+            if self.file_vma_seq() == seq {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn truncate(&self, new_size: usize) -> Result<(), SystemError> {
+        let _invalidate = self.invalidate_write();
+        self.truncate_locked(new_size)
+    }
+
+    fn truncate_locked(&self, new_size: usize) -> Result<(), SystemError> {
+        let hole_start_page = page_align_up(new_size) >> MMArch::PAGE_SHIFT;
+        self.unmap_mapping_pages(hole_start_page, None)?;
+
+        let first_full_truncate_page = page_align_up(new_size) >> MMArch::PAGE_SHIFT;
+        let truncate_indices: Vec<usize> = {
+            let guard = self.inner.lock();
+            guard
+                .pages
+                .keys()
+                .copied()
+                .filter(|index| *index >= first_full_truncate_page)
+                .collect()
+        };
+
+        for page_index in truncate_indices {
+            loop {
+                let entry = {
+                    let guard = self.inner.lock();
+                    guard.get_entry(page_index)
+                };
+                let Some(entry) = entry else {
+                    break;
+                };
+                match entry.state() {
+                    PageState::Loading => {
+                        let _ = entry.wait_ready();
+                        continue;
+                    }
+                    PageState::Writeback => {
+                        let _ = entry.wait_queue.wait_until(|| match entry.state() {
+                            PageState::Writeback => None,
+                            PageState::Error => Some(Err(SystemError::EIO)),
+                            _ => Some(Ok(())),
+                        });
+                        continue;
+                    }
+                    _ => {}
+                }
+
+                if let Some(page) = self.inner.lock().remove_page(page_index) {
+                    let paddr = page.phys_address();
+                    page_manager_lock().remove_page(&paddr);
+                    let _ = page_reclaimer_lock().remove_page(&paddr);
+                }
+                break;
+            }
+        }
+
+        if new_size > 0 && !new_size.is_multiple_of(MMArch::PAGE_SIZE) {
+            let last_page_index = (new_size - 1) >> MMArch::PAGE_SHIFT;
+            let last_len = new_size - (last_page_index << MMArch::PAGE_SHIFT);
+            let entry = {
+                let guard = self.inner.lock();
+                guard.get_entry(last_page_index)
+            };
+            if let Some(entry) = entry {
+                match entry.state() {
+                    PageState::Loading => {
+                        let _ = entry.wait_ready();
+                    }
+                    PageState::Writeback => {
+                        let _ = entry.wait_queue.wait_until(|| match entry.state() {
+                            PageState::Writeback => None,
+                            PageState::Error => Some(Err(SystemError::EIO)),
+                            _ => Some(Ok(())),
+                        });
+                    }
+                    _ => {}
+                }
+                unsafe {
+                    entry.page.write().truncate(last_len);
+                }
+            }
+        }
+
+        self.unmap_mapping_pages(hole_start_page, None)?;
+
+        Ok(())
+    }
+
+    pub fn mkclean_page(
+        &self,
+        page_index: usize,
+        unmap: bool,
+    ) -> Result<Vec<Arc<LockedVMA>>, SystemError> {
+        loop {
+            let (seq, snapshot) =
+                self.collect_file_vmas_snapshot(Some((page_index, Some(page_index + 1))));
+            let mut mm_groups: HashMap<u64, MmFilePageGroup> = HashMap::new();
+
+            for vma in snapshot {
+                let (Some(mm), Ok(virt)) = ({
+                    let guard = vma.lock();
+                    (
+                        guard.address_space().and_then(|space| space.upgrade()),
+                        guard.page_address(page_index),
+                    )
+                }) else {
+                    continue;
+                };
+
+                mm_groups
+                    .entry(mm.id())
+                    .or_insert_with(|| MmFilePageGroup::new(mm.clone()))
+                    .items
+                    .push((vma, virt));
+            }
+
+            let mut unmapped = Vec::new();
+            for (_id, group) in mm_groups {
+                let mm_guard = group.mm.read();
+                let _pt_edit = group.mm.page_table_edit();
+                let mut tlb = MmuGather::gather(&group.mm);
+                for (vma, virt) in group.items {
+                    if unmap {
+                        if let Some((_paddr, _flags, flush)) =
+                            unsafe { mm_guard.user_mapper.utable.unmap_phys_preserve_tables(virt) }
+                        {
+                            unsafe { flush.ignore() };
+                            tlb.accumulate_range(virt);
+                            unmapped.push(vma);
+                        }
+                        continue;
+                    }
+
+                    let Some((_paddr, flags)) = mm_guard.user_mapper.utable.translate(virt) else {
+                        continue;
+                    };
+                    if !flags.has_write() {
+                        continue;
+                    }
+                    if let Some(flush) = unsafe {
+                        mm_guard
+                            .user_mapper
+                            .utable
+                            .remap_present(virt, flags.set_write(false).set_dirty(false))
+                    } {
+                        unsafe { flush.ignore() };
+                        tlb.accumulate_range(virt);
+                    }
+                }
+                tlb.finish();
+            }
+
+            if self.file_vma_seq() == seq {
+                return Ok(unmapped);
+            }
+        }
     }
 
     pub fn drop_clean_pages(&self) -> usize {
@@ -1288,7 +1640,10 @@ impl PageCache {
                 continue;
             }
 
-            let entry = self.get_or_create_entry(page_index, false)?;
+            let full_page_overwrite =
+                write_start == page_start && page_write_len == MMArch::PAGE_SIZE;
+            let populate_backend = !self.is_shmem() && !full_page_overwrite;
+            let entry = self.get_or_create_entry(page_index, populate_backend)?;
             copies.push(CopyItem {
                 entry,
                 page_index,

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -717,7 +717,7 @@ impl IndexNode for LockedTmpfsInode {
 
             // 调整页缓存（会释放多余页，并截断最后一页）
             if let Some(pc) = inode.page_cache.clone() {
-                pc.lock().resize(len)?;
+                pc.manager().resize(len)?;
             }
 
             // 如果缩小，减少current_size

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -534,11 +534,9 @@ pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemE
         }
     }
 
-    if result.is_ok() {
-        let vm_opt: Option<Arc<crate::mm::ucontext::AddressSpace>> =
-            ProcessManager::current_pcb().basic().user_vm();
-        if let Some(vm) = vm_opt {
-            let _ = vm.write().zap_file_mappings(md.inode_id);
+    if result.is_ok() && len < old_size as usize {
+        if let Some(page_cache) = inode.page_cache() {
+            page_cache.truncate(len)?;
         }
     }
 

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -124,6 +124,15 @@ impl<'a> PageFaultMessage<'a> {
 pub struct PageFaultHandler;
 
 impl PageFaultHandler {
+    fn file_page_cache(
+        pfm: &PageFaultMessage<'_>,
+    ) -> Option<Arc<crate::filesystem::page_cache::PageCache>> {
+        let vma = pfm.vma();
+        let vma_guard = vma.lock();
+        let file = vma_guard.vm_file()?;
+        file.inode().page_cache()
+    }
+
     /// 处理缺页异常
     /// ## 参数
     ///
@@ -174,23 +183,31 @@ impl PageFaultHandler {
     pub unsafe fn handle_normal_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
         let address = pfm.address_aligned_down();
         let vma = pfm.vma();
-        let mapper = &mut pfm.mapper;
-        if mapper.get_entry(address, 3).is_none() {
-            mapper
-                .allocate_table(address, 2)
-                .expect("failed to allocate PUD table");
+        let mm = pfm.mm().clone();
+        {
+            let _pt_edit = mm.page_table_edit();
+            let mapper = &mut pfm.mapper;
+            if mapper.get_entry(address, 3).is_none() {
+                mapper
+                    .allocate_table(address, 2)
+                    .expect("failed to allocate PUD table");
+            }
         }
         let page_flags = vma.lock().flags();
 
         for level in 2..=3 {
             let level = MMArch::PAGE_LEVELS - level;
-            if mapper.get_entry(address, level).is_none() {
-                if vma.is_hugepage() {
-                    if vma.is_anonymous() {
-                        mapper.map_huge_page(address, page_flags);
+            {
+                let _pt_edit = mm.page_table_edit();
+                let mapper = &mut pfm.mapper;
+                if mapper.get_entry(address, level).is_none() {
+                    if vma.is_hugepage() {
+                        if vma.is_anonymous() {
+                            mapper.map_huge_page(address, page_flags);
+                        }
+                    } else if mapper.allocate_table(address, level - 1).is_none() {
+                        return VmFaultReason::VM_FAULT_OOM;
                     }
-                } else if mapper.allocate_table(address, level - 1).is_none() {
-                    return VmFaultReason::VM_FAULT_OOM;
                 }
             }
         }
@@ -250,6 +267,8 @@ impl PageFaultHandler {
     pub unsafe fn do_anonymous_page(pfm: &mut PageFaultMessage) -> VmFaultReason {
         let address = pfm.address_aligned_down();
         let vma = pfm.vma.clone();
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
 
         // If this is an anonymous shared mapping, use a shared backing so pages are visible across fork
@@ -341,6 +360,10 @@ impl PageFaultHandler {
     /// - VmFaultReason: 页面错误处理信息标志
     #[inline(never)]
     pub unsafe fn do_cow_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
+        let page_cache = Self::file_page_cache(pfm);
+        let _invalidate = page_cache
+            .as_ref()
+            .map(|page_cache| page_cache.invalidate_read());
         let mut ret = Self::filemap_fault(pfm);
 
         if unlikely(ret.intersects(
@@ -377,6 +400,10 @@ impl PageFaultHandler {
     /// ## 返回值
     /// - VmFaultReason: 页面错误处理信息标志
     pub unsafe fn do_read_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
+        let page_cache = Self::file_page_cache(pfm);
+        let _invalidate = page_cache
+            .as_ref()
+            .map(|page_cache| page_cache.invalidate_read());
         let fs = pfm.vma().lock().vm_file().unwrap().inode().fs();
 
         let mut ret = Self::do_fault_around(pfm);
@@ -410,6 +437,10 @@ impl PageFaultHandler {
     /// - VmFaultReason: 页面错误处理信息标志
     #[inline(never)]
     pub unsafe fn do_shared_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
+        let page_cache = Self::file_page_cache(pfm);
+        let _invalidate = page_cache
+            .as_ref()
+            .map(|page_cache| page_cache.invalidate_read());
         let mut ret = Self::filemap_fault(pfm);
 
         if ret.intersects(VmFaultReason::VM_FAULT_ERROR) {
@@ -483,6 +514,7 @@ impl PageFaultHandler {
         let address = pfm.address_aligned_down();
         let vma = pfm.vma.clone();
         let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
 
         let old_paddr = mapper.translate(address).unwrap().0;
@@ -594,12 +626,15 @@ impl PageFaultHandler {
     pub unsafe fn do_fault_around(pfm: &mut PageFaultMessage) -> VmFaultReason {
         let vma = pfm.vma();
         let address = pfm.address();
-        let mapper = &mut pfm.mapper;
-
-        if mapper.get_table(address, 0).is_none() {
-            mapper
-                .allocate_table(address, 0)
-                .expect("failed to allocate pte table");
+        let mm = pfm.mm().clone();
+        {
+            let _pt_edit = mm.page_table_edit();
+            let mapper = &mut pfm.mapper;
+            if mapper.get_table(address, 0).is_none() {
+                mapper
+                    .allocate_table(address, 0)
+                    .expect("failed to allocate pte table");
+            }
         }
         let vma_guard = vma.lock();
         let vma_region = *vma_guard.region();
@@ -637,8 +672,13 @@ impl PageFaultHandler {
         );
 
         // 预先分配pte页表（如果不存在）
-        if mapper.get_table(address, 0).is_none() && mapper.allocate_table(address, 0).is_none() {
-            return VmFaultReason::VM_FAULT_OOM;
+        {
+            let _pt_edit = mm.page_table_edit();
+            let mapper = &mut pfm.mapper;
+            if mapper.get_table(address, 0).is_none() && mapper.allocate_table(address, 0).is_none()
+            {
+                return VmFaultReason::VM_FAULT_OOM;
+            }
         }
 
         let fs = pfm.vma().lock().vm_file().unwrap().inode().fs();
@@ -677,6 +717,8 @@ impl PageFaultHandler {
                 return VmFaultReason::VM_FAULT_SIGBUS;
             }
         };
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
 
         // 起始页地址
@@ -812,6 +854,8 @@ impl PageFaultHandler {
         let cache_page = pfm.page.clone();
         let cow_page = pfm.cow_page.clone();
         let address = pfm.address();
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
 
         let page_to_map = if flags.contains(FaultFlags::FAULT_FLAG_WRITE)
@@ -836,6 +880,8 @@ impl PageFaultHandler {
         let address = pfm.address_aligned_down();
         let vma = pfm.vma();
         let flags = vma.lock().flags();
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
 
         if let Some(flush) = mapper.map(address, flags) {
@@ -866,6 +912,8 @@ impl PageFaultHandler {
         let flags = vma_guard.flags();
         drop(vma_guard);
 
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
         for pgoff in start_pgoff..end_pgoff {
             let addr = VirtAddr::new(base.data() + ((pgoff - backing_pgoff) << MMArch::PAGE_SHIFT));

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -422,28 +422,9 @@ impl PageReclaimer {
         let inode = page_cache.inode().clone().unwrap().upgrade().unwrap();
         let backend = page_cache.backend();
 
-        for vma in guard.vma_set() {
-            let address_space = vma.lock().address_space().and_then(|x| x.upgrade());
-            if address_space.is_none() {
-                continue;
-            }
-            let address_space = address_space.unwrap();
-            let mut guard = address_space.write();
-            let mapper = &mut guard.user_mapper.utable;
-            let virt = vma.lock().page_address(page_index).unwrap();
-            if unmap {
-                unsafe {
-                    // 取消页表映射
-                    mapper.unmap(virt, false).unwrap().flush();
-                }
-            } else {
-                unsafe {
-                    // 保护位设为只读
-                    mapper.remap(
-                        virt,
-                        mapper.get_entry(virt, 0).unwrap().flags().set_write(false),
-                    )
-                };
+        if let Ok(unmapped_vmas) = page_cache.mkclean_page(page_index, unmap) {
+            for vma in unmapped_vmas {
+                guard.remove_vma(vma.as_ref());
             }
         }
 
@@ -1804,6 +1785,29 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             .flatten();
     }
 
+    /// Modify the leaf PTE flags of an existing mapping without allocating or freeing any page-table pages.
+    ///
+    /// This variant only touches an already present leaf entry and therefore works with `&self`.
+    /// It is intended for reverse-mapping walkers such as `mkclean` / file truncate zap, which
+    /// run under a separate page-table edit lock and must not require `&mut PageMapper`.
+    pub unsafe fn remap_present(
+        &self,
+        virt: VirtAddr,
+        flags: EntryFlags<Arch>,
+    ) -> Option<PageFlush<Arch>> {
+        self.visit(virt, |p1, i| {
+            let mut entry = p1.entry(i)?;
+            if entry.empty() {
+                return None;
+            }
+
+            entry.set_flags(flags);
+            p1.set_entry(i, entry);
+            Some(PageFlush::new(virt))
+        })
+        .flatten()
+    }
+
     /// 根据虚拟地址，查找页表，获取对应的物理地址和页表项的flags
     ///
     /// ## 参数
@@ -1886,6 +1890,36 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             &mut freed_tables,
         )
         .map(|(paddr, flags)| (paddr, flags, PageFlush::<Arch>::new(virt), freed_tables))
+    }
+
+    /// Clear an existing leaf PTE without freeing intermediate page-table pages.
+    ///
+    /// This is the non-allocating / non-freeing counterpart used by cross-mm file-rmap walkers.
+    /// Keeping parent page tables intact avoids needing access to the frame allocator and mirrors
+    /// Linux's `zap_pte_range()` style leaf-only invalidation.
+    pub unsafe fn unmap_phys_preserve_tables(
+        &self,
+        virt: VirtAddr,
+    ) -> Option<(PhysAddr, EntryFlags<Arch>, PageFlush<Arch>)> {
+        if !virt.check_aligned(Arch::PAGE_SIZE) {
+            error!("Try to unmap unaligned page: virt={:?}", virt);
+            return None;
+        }
+
+        self.visit(virt, |p1, i| {
+            let entry = p1.entry(i)?;
+            if entry.empty() {
+                return None;
+            }
+
+            p1.set_entry(i, PageEntry::from_usize(0));
+            Some((
+                entry.address().ok()?,
+                entry.flags(),
+                PageFlush::<Arch>::new(virt),
+            ))
+        })
+        .flatten()
     }
 
     /// 在页表中，访问虚拟地址对应的页表项，并调用传入的函数F

--- a/kernel/src/mm/truncate.rs
+++ b/kernel/src/mm/truncate.rs
@@ -1,33 +1,17 @@
-use super::page::{Page, PageFlags};
 use crate::filesystem::page_cache::PageCache;
+use crate::mm::MemoryManagementArch;
 use alloc::sync::Arc;
 
 /// # 功能
 ///
-/// 从指定偏移量开始，截断与当前文件的所有页缓存，目前仅是将文件相关的页缓存页的dirty位去除
+/// 从指定页索引开始，截断与当前文件相关的所有页缓存页。
 ///
 /// # 参数
 ///
 /// - page_cache: 与文件inode关联的页缓存
-/// - start: 偏移量
+/// - start: 起始页索引
 pub fn truncate_inode_pages(page_cache: Arc<PageCache>, start: usize) {
-    let pages_count = page_cache.manager().pages_count().unwrap_or(0);
-
-    for i in start..pages_count {
-        let page = page_cache.manager().get_page_any(i);
-        let page = if let Some(page) = page {
-            page
-        } else {
-            log::warn!("try to truncate page from different page cache");
-            return;
-        };
-        truncate_complete_page(page_cache.clone(), i, page.clone());
+    if let Err(err) = page_cache.truncate(start << crate::arch::MMArch::PAGE_SHIFT) {
+        log::warn!("truncate_inode_pages failed: start_page={start}, err={err:?}");
     }
-}
-
-fn truncate_complete_page(page_cache: Arc<PageCache>, page_index: usize, page: Arc<Page>) {
-    let mut guard = page.write();
-    guard.remove_flags(PageFlags::PG_DIRTY);
-    drop(guard);
-    page_cache.mark_page_uptodate(page_index);
 }

--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -88,13 +88,20 @@ pub struct AddressSpace {
     /// `flush_tlb_*` must increment this after publishing page table writes and before snapshotting `active_cpus`;
     /// remote CPUs receiving IPI write this to per-CPU `TlbState::loaded_tlb_gen` as a "caught-up generation" marker.
     pub tlb_gen: AtomicU64,
+    /// Serialize all user page-table edits for this mm.
+    ///
+    /// This is intentionally separate from `inner: RwSem<InnerAddressSpace>`:
+    /// file-rmap walkers need to edit remote PTEs under `mapping->i_mmap.read()`
+    /// without taking `mm.write()`, while fault/munmap/mprotect/mremap paths must
+    /// still synchronize with those edits.
+    page_table_edit_lock: Mutex<()>,
     /// 使用RwSem而非RwLock，因为地址空间操作可能需要进行I/O（如页缺失时的文件读取）
     inner: RwSem<InnerAddressSpace>,
 }
 
 impl AddressSpace {
     pub fn new(create_stack: bool) -> Result<Arc<Self>, SystemError> {
-        let inner = InnerAddressSpace::new(create_stack)?;
+        let inner = InnerAddressSpace::new(false)?;
         let table_paddr = inner.user_mapper.utable.table().phys();
         let id = ADDRESS_SPACE_ID_ALLOCATOR.fetch_add(1, Ordering::Relaxed);
         let result = Arc::new(Self {
@@ -102,6 +109,7 @@ impl AddressSpace {
             table_paddr,
             active_cpus: SpinLock::new(CpuMask::new()),
             tlb_gen: AtomicU64::new(0),
+            page_table_edit_lock: Mutex::new(()),
             inner: RwSem::new(inner),
         });
         // Back-fill the Weak<AddressSpace> so that InnerAddressSpace methods can obtain
@@ -109,6 +117,10 @@ impl AddressSpace {
         {
             let mut g = result.inner.write();
             g.outer = Arc::downgrade(&result);
+            g.mappings.set_owner(Arc::downgrade(&result));
+            if create_stack {
+                g.new_user_stack(UserStack::DEFAULT_USER_STACK_SIZE)?;
+            }
         }
         return Ok(result);
     }
@@ -193,6 +205,15 @@ impl AddressSpace {
     pub fn flush_tlb_all(self: &Arc<Self>) {
         crate::mm::tlb::flush_tlb_mm(self);
     }
+
+    #[inline]
+    pub fn page_table_edit(&self) -> MutexGuard<'_, ()> {
+        debug_assert!(
+            CurrentIrqArch::is_irq_enabled(),
+            "page_table_edit_lock must not be taken with interrupts disabled"
+        );
+        self.page_table_edit_lock.lock()
+    }
 }
 
 impl Drop for AddressSpace {
@@ -267,8 +288,8 @@ impl InnerAddressSpace {
             .sum()
     }
 
-    pub fn new(create_stack: bool) -> Result<Self, SystemError> {
-        let mut result = Self {
+    pub fn new(_create_stack: bool) -> Result<Self, SystemError> {
+        let result = Self {
             user_mapper: MMArch::setup_new_usermapper()?,
             mappings: UserMappings::new(),
             mmap_min: VirtAddr(DEFAULT_MMAP_MIN_ADDR),
@@ -283,10 +304,6 @@ impl InnerAddressSpace {
             end_data: VirtAddr(0),
             outer: Weak::new(),
         };
-        if create_stack {
-            // debug!("to create user stack.");
-            result.new_user_stack(UserStack::DEFAULT_USER_STACK_SIZE)?;
-        }
 
         return Ok(result);
     }
@@ -298,7 +315,6 @@ impl InnerAddressSpace {
     /// 返回克隆后的，新的地址空间的Arc指针
     #[inline(never)]
     pub fn try_clone(&mut self) -> Result<Arc<AddressSpace>, SystemError> {
-        let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let new_addr_space = AddressSpace::new(false)?;
         let mut new_guard = new_addr_space.write();
 
@@ -352,6 +368,7 @@ impl InnerAddressSpace {
 
             // 创建新的VMA
             let new_vma = LockedVMA::new(vma_guard.clone_info_only());
+            new_guard.mappings.attach_vma(&new_vma);
             new_guard.mappings.vmas.insert(new_vma.clone());
             drop(vma_guard);
 
@@ -384,65 +401,55 @@ impl InnerAddressSpace {
             let end_page = region.end();
             let mut current_page = start_page;
 
-            let old_mapper = &mut self.user_mapper.utable;
-            let new_mapper = &mut new_guard.user_mapper.utable;
-            let mut page_manager_guard = page_manager_lock();
+            {
+                let _parent_pt_edit = parent_mm.page_table_edit();
+                let old_mapper = &mut self.user_mapper.utable;
+                let new_mapper = &mut new_guard.user_mapper.utable;
+                let mut page_manager_guard = page_manager_lock();
 
-            while current_page < end_page {
-                if let Some((phys_addr, old_flags)) = old_mapper.translate(current_page) {
-                    unsafe {
-                        if is_shared {
-                            // 共享映射：直接映射到相同的物理页，不使用COW
-                            // 保持原有的flags
-                            if new_mapper
-                                .map_phys(current_page, phys_addr, page_flags)
-                                .is_none()
-                            {
-                                warn!("Failed to map shared page at {:?} to phys {:?} in child process (current_pid: {:?})",
-                                      current_page, phys_addr, ProcessManager::current_pcb().raw_pid());
-                            }
-                        } else {
-                            // 私有映射：使用COW机制
-                            // 将父进程和子进程的页表项都设置为只读
-                            let cow_flags = page_flags.set_write(false);
+                while current_page < end_page {
+                    if let Some((phys_addr, old_flags)) = old_mapper.translate(current_page) {
+                        unsafe {
+                            if is_shared {
+                                if new_mapper
+                                    .map_phys(current_page, phys_addr, page_flags)
+                                    .is_none()
+                                {
+                                    warn!("Failed to map shared page at {:?} to phys {:?} in child process (current_pid: {:?})",
+                                          current_page, phys_addr, ProcessManager::current_pcb().raw_pid());
+                                }
+                            } else {
+                                let cow_flags = page_flags.set_write(false);
 
-                            // 更新父进程的页表项为只读
-                            // 不在此处做本地 invlpg；而是把被改写的地址累积到 parent_tlb，
-                            // 最后由 parent_tlb.finish() 统一做 mm-aware 远端 + 本地 shootdown，
-                            // 确保父 mm 的所有活跃 CPU 都刷新 TLB。
-                            if old_flags.has_write() {
-                                if let Some(flush) = old_mapper.remap(current_page, cow_flags) {
-                                    // SAFETY: later parent_tlb.finish() issues a unified flush_tlb_mm_range on the parent mm.
-                                    flush.ignore();
-                                    parent_tlb.accumulate_range(current_page);
+                                if old_flags.has_write() {
+                                    if let Some(flush) = old_mapper.remap(current_page, cow_flags) {
+                                        flush.ignore();
+                                        parent_tlb.accumulate_range(current_page);
+                                    }
+                                }
+
+                                if new_mapper
+                                    .map_phys(current_page, phys_addr, cow_flags)
+                                    .is_none()
+                                {
+                                    warn!("Failed to map COW page at {:?} to phys {:?} in child process (current_pid: {:?})",
+                                          current_page, phys_addr, ProcessManager::current_pcb().raw_pid());
                                 }
                             }
-
-                            // 子进程也映射为只读
-                            if new_mapper
-                                .map_phys(current_page, phys_addr, cow_flags)
-                                .is_none()
-                            {
-                                warn!("Failed to map COW page at {:?} to phys {:?} in child process (current_pid: {:?})",
-                                      current_page, phys_addr, ProcessManager::current_pcb().raw_pid());
+                            if let Some(page) = page_manager_guard.get(&phys_addr) {
+                                page.write().insert_vma(new_vma.clone());
                             }
                         }
-                        // 为新进程的VMA添加反向映射
-                        if let Some(page) = page_manager_guard.get(&phys_addr) {
-                            page.write().insert_vma(new_vma.clone());
-                        }
                     }
+                    current_page = VirtAddr::new(current_page.data() + MMArch::PAGE_SIZE);
                 }
-                current_page = VirtAddr::new(current_page.data() + MMArch::PAGE_SIZE);
             }
-            drop(page_manager_guard);
         }
 
         drop(new_guard);
         // 完成父 mm 的 mm-aware shootdown：INV-3 要求 TLB 生效完成后再继续后续逻辑，
         // 此处没有 page 进入 pending_pages，因此实际只触发 flush_tlb_mm_range。
         parent_tlb.finish();
-        drop(irq_guard);
         return Ok(new_addr_space);
     }
 
@@ -853,14 +860,19 @@ impl InnerAddressSpace {
         let mut flusher = crate::mm::page::DeferredFlusher::new();
         compiler_fence(Ordering::SeqCst);
         // 映射页面，并将VMA插入到地址空间的VMA列表中
-        self.mappings.insert_vma(map_func(
-            page,
-            page_count,
-            vm_flags,
-            EntryFlags::from_prot_flags(prot_flags, true),
-            &mut self.user_mapper.utable,
-            &mut flusher,
-        )?);
+        let new_vma = {
+            let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
+            let _pt_edit = mm.page_table_edit();
+            map_func(
+                page,
+                page_count,
+                vm_flags,
+                EntryFlags::from_prot_flags(prot_flags, true),
+                &mut self.user_mapper.utable,
+                &mut flusher,
+            )?
+        };
+        self.mappings.insert_vma(new_vma);
 
         return Ok(page);
     }
@@ -1048,43 +1060,44 @@ impl InnerAddressSpace {
         let mapper = &mut self.user_mapper.utable;
         let old_vma = old_vma.clone();
 
-        let mut page_manager_guard = page_manager_lock();
-        let mut off = 0usize;
-        while off < move_len {
-            let src = old_vaddr + off;
-            let dst = new_region.start() + off;
-            if let Some((paddr, src_flags)) = mapper.translate(src) {
-                if !dontunmap {
-                    if let Some((_paddr2, _flags2, flush, freed_tables)) =
-                        unsafe { mapper.unmap_phys_with_freed_tables(src, true) }
-                    {
-                        unsafe { flush.ignore() };
-                        tlb.accumulate_range(src);
-                        if freed_tables {
-                            tlb.note_pt_table_freed();
+        {
+            let _pt_edit = mm.page_table_edit();
+            let mut page_manager_guard = page_manager_lock();
+            let mut off = 0usize;
+            while off < move_len {
+                let src = old_vaddr + off;
+                let dst = new_region.start() + off;
+                if let Some((paddr, src_flags)) = mapper.translate(src) {
+                    if !dontunmap {
+                        if let Some((_paddr2, _flags2, flush, freed_tables)) =
+                            unsafe { mapper.unmap_phys_with_freed_tables(src, true) }
+                        {
+                            unsafe { flush.ignore() };
+                            tlb.accumulate_range(src);
+                            if freed_tables {
+                                tlb.note_pt_table_freed();
+                            }
                         }
                     }
-                }
 
-                if let Some(flush) = unsafe { mapper.map_phys(dst, paddr, src_flags) } {
-                    unsafe { flush.ignore() };
-                    tlb.accumulate_range(dst);
-                } else {
-                    return Err(SystemError::ENOMEM);
-                }
+                    if let Some(flush) = unsafe { mapper.map_phys(dst, paddr, src_flags) } {
+                        unsafe { flush.ignore() };
+                        tlb.accumulate_range(dst);
+                    } else {
+                        return Err(SystemError::ENOMEM);
+                    }
 
-                // 更新物理页的 vma_set
-                let page = page_manager_guard.get_unwrap(&paddr);
-                let mut pg = page.write();
-                if !dontunmap {
-                    pg.remove_vma(old_vma.as_ref());
+                    // 更新物理页的 vma_set
+                    let page = page_manager_guard.get_unwrap(&paddr);
+                    let mut pg = page.write();
+                    if !dontunmap {
+                        pg.remove_vma(old_vma.as_ref());
+                    }
+                    pg.insert_vma(new_vma.clone());
                 }
-                pg.insert_vma(new_vma.clone());
+                off += MMArch::PAGE_SIZE;
             }
-            off += MMArch::PAGE_SIZE;
         }
-
-        drop(page_manager_guard);
         tlb.finish();
 
         Ok(new_region.start())
@@ -1143,23 +1156,24 @@ impl InnerAddressSpace {
                 .region()
                 .intersect(&region_to_unmap)
                 .ok_or(SystemError::EFAULT)?;
-            let split_result = cur_vma
-                .extract(intersection, &self.user_mapper.utable)
-                .ok_or(SystemError::EFAULT)?;
+            let (before, after) = {
+                let _pt_edit = mm.page_table_edit();
+                let split_result = cur_vma
+                    .extract(intersection, &self.user_mapper.utable)
+                    .ok_or(SystemError::EFAULT)?;
+                cur_vma.unmap(&mut self.user_mapper.utable, &mut tlb);
+                (split_result.prev, split_result.after)
+            };
 
             // TODO: 当引入后备页映射后，这里需要增加通知文件的逻辑
 
-            // 如果前面有VMA，则需要将前面的VMA重新插入到地址空间的VMA列表中
-            if let Some(before) = split_result.prev {
+            if let Some(before) = before {
                 self.mappings.insert_vma(before);
             }
 
-            // 如果后面有VMA，则需要将后面的VMA重新插入到地址空间的VMA列表中
-            if let Some(after) = split_result.after {
+            if let Some(after) = after {
                 self.mappings.insert_vma(after);
             }
-
-            cur_vma.unmap(&mut self.user_mapper.utable, &mut tlb);
         }
 
         // Shootdown first, then free physical pages
@@ -1197,33 +1211,41 @@ impl InnerAddressSpace {
             let r = self.mappings.remove_vma(&r).unwrap();
 
             let intersection = r.lock().region().intersect(&region).unwrap();
-            let split_result = r
-                .extract(intersection, mapper)
-                .expect("Failed to extract VMA");
+            let remap_result: Result<VmaSplitSides, SystemError> = {
+                let _pt_edit = mm.page_table_edit();
+                let split_result = r
+                    .extract(intersection, mapper)
+                    .expect("Failed to extract VMA");
 
-            if let Some(before) = split_result.prev {
+                let mut r_guard = r.lock();
+                if !r_guard.can_have_flags(prot_flags) {
+                    Err(SystemError::EACCES)
+                } else {
+                    r_guard.set_vm_flags(VmFlags::from(prot_flags));
+
+                    let new_flags: EntryFlags<MMArch> = r_guard
+                        .flags()
+                        .set_execute(prot_flags.contains(ProtFlags::PROT_EXEC))
+                        .set_write(prot_flags.contains(ProtFlags::PROT_WRITE));
+
+                    r_guard.remap(new_flags, mapper, &mut tlb)?;
+                    Ok((split_result.prev, split_result.after))
+                }
+            };
+            let (before, after) = match remap_result {
+                Ok(result) => result,
+                Err(err) => {
+                    self.mappings.insert_vma(r);
+                    return Err(err);
+                }
+            };
+
+            if let Some(before) = before {
                 self.mappings.insert_vma(before);
             }
-            if let Some(after) = split_result.after {
+            if let Some(after) = after {
                 self.mappings.insert_vma(after);
             }
-
-            let mut r_guard = r.lock();
-            // 如果VMA的保护标志不允许指定的修改，则返回错误
-            if !r_guard.can_have_flags(prot_flags) {
-                drop(r_guard);
-                self.mappings.insert_vma(r.clone());
-                return Err(SystemError::EACCES);
-            }
-            r_guard.set_vm_flags(VmFlags::from(prot_flags));
-
-            let new_flags: EntryFlags<MMArch> = r_guard
-                .flags()
-                .set_execute(prot_flags.contains(ProtFlags::PROT_EXEC))
-                .set_write(prot_flags.contains(ProtFlags::PROT_WRITE));
-
-            r_guard.remap(new_flags, mapper, &mut tlb)?;
-            drop(r_guard);
             self.mappings.insert_vma(r);
         }
 
@@ -1290,17 +1312,20 @@ impl InnerAddressSpace {
             let r = self.mappings.remove_vma(&r).unwrap();
 
             let intersection = r.lock().region().intersect(&region).unwrap();
-            let split_result = r
-                .extract(intersection, mapper)
-                .expect("Failed to extract VMA");
-
-            if let Some(before) = split_result.prev {
+            let (before, after) = {
+                let _pt_edit = mm.page_table_edit();
+                let split_result = r
+                    .extract(intersection, mapper)
+                    .expect("Failed to extract VMA");
+                r.do_madvise(behavior, mapper, &mut tlb)?;
+                (split_result.prev, split_result.after)
+            };
+            if let Some(before) = before {
                 self.mappings.insert_vma(before);
             }
-            if let Some(after) = split_result.after {
+            if let Some(after) = after {
                 self.mappings.insert_vma(after);
             }
-            r.do_madvise(behavior, mapper, &mut tlb)?;
             self.mappings.insert_vma(r);
         }
         tlb.finish();
@@ -1320,6 +1345,7 @@ impl InnerAddressSpace {
         }
 
         let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
+        let _pt_edit = mm.page_table_edit();
         let mut tlb = MmuGather::gather(&mm);
         for vma in targets {
             vma.unmap(&mut self.user_mapper.utable, &mut tlb);
@@ -1356,6 +1382,7 @@ impl InnerAddressSpace {
         //    因此使用 `MmuGather::gather_teardown()`，跳过跨核 shootdown，只把 PTE 拆掉、
         //    按 INV-3 的 "先 flush，后释放" 顺序释放物理页。
         let mm_arc = self.outer_addr_space();
+        let _pt_edit = mm_arc.as_ref().map(|mm| mm.page_table_edit());
         let mut tlb = match mm_arc.as_ref() {
             Some(mm) => MmuGather::gather(mm),
             None => MmuGather::gather_teardown(),
@@ -1552,6 +1579,8 @@ pub struct UserMappings {
     vmas: HashSet<Arc<LockedVMA>>,
     /// 当前用户空间的VMA空洞
     vm_holes: BTreeMap<VirtAddr, usize>,
+    /// 所属地址空间，用于在 VMA 生命周期变更时回填反向引用
+    owner: Weak<AddressSpace>,
 }
 
 impl UserMappings {
@@ -1560,7 +1589,39 @@ impl UserMappings {
             vmas: HashSet::new(),
             vm_holes: core::iter::once((VirtAddr::new(0), MMArch::USER_END_VADDR.data()))
                 .collect::<BTreeMap<_, _>>(),
+            owner: Weak::new(),
         };
+    }
+
+    pub fn set_owner(&mut self, owner: Weak<AddressSpace>) {
+        self.owner = owner;
+        for vma in self.vmas.iter() {
+            self.attach_vma(vma);
+        }
+    }
+
+    fn attach_vma(&self, vma: &Arc<LockedVMA>) {
+        let vm_file = {
+            let mut guard = vma.lock();
+            if guard.user_address_space.is_none() {
+                guard.user_address_space = Some(self.owner.clone());
+            }
+            guard.vm_file.clone()
+        };
+        if let Some(file) = vm_file {
+            if let Some(page_cache) = file.inode().page_cache() {
+                page_cache.register_file_vma(vma);
+            }
+        }
+    }
+
+    fn detach_vma(&self, vma: &Arc<LockedVMA>) {
+        let vm_file = { vma.lock().vm_file.clone() };
+        if let Some(file) = vm_file {
+            if let Some(page_cache) = file.inode().page_cache() {
+                page_cache.unregister_file_vma(vma.id());
+            }
+        }
     }
 
     /// 判断当前进程的VMA内，是否有包含指定的虚拟地址的VMA。
@@ -1699,6 +1760,7 @@ impl UserMappings {
         assert!(self.conflicts(region).next().is_none());
         self.reserve_hole(&region);
 
+        self.attach_vma(&vma);
         self.vmas.insert(vma);
     }
 
@@ -1723,6 +1785,7 @@ impl UserMappings {
             .drain_filter(|vma| vma.lock().region == *region)
             .next()?;
         self.unreserve_hole(region);
+        self.detach_vma(&vma);
 
         return Some(vma);
     }
@@ -1888,6 +1951,46 @@ impl LockedVMA {
                 .contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE)
         {
             crate::mm::page::PageReclaimer::wakeup_claim_thread();
+        }
+    }
+
+    /// Unmap an intersecting sub-range of this VMA while keeping the VMA metadata itself alive.
+    ///
+    /// This is used by file truncate/invalidate paths: future access should fault back in against
+    /// the updated file size/content instead of tearing down the VMA object.
+    pub fn unmap_range(&self, region: VirtRegion, mapper: &PageMapper, tlb: &mut MmuGather<'_>) {
+        let self_guard = self.lock();
+        let Some(intersection) = self_guard.region().intersect(&region) else {
+            return;
+        };
+        drop(self_guard);
+
+        let mut page_manager_guard = page_manager_lock();
+        for page in intersection.pages() {
+            if mapper.translate(page.virt_address()).is_none() {
+                continue;
+            }
+
+            let Some((paddr, _, flush)) =
+                (unsafe { mapper.unmap_phys_preserve_tables(page.virt_address()) })
+            else {
+                continue;
+            };
+
+            let page_arc = page_manager_guard.get_unwrap(&paddr);
+            let can_dealloc = {
+                let mut page_guard = page_arc.write();
+                page_guard.remove_vma(self);
+                page_guard.can_deallocate()
+            };
+            if can_dealloc {
+                if let Some(p) = page_manager_guard.remove_page(&paddr) {
+                    tlb.stash_page(p);
+                }
+            }
+
+            unsafe { flush.ignore() };
+            tlb.accumulate_range(page.virt_address());
         }
     }
 
@@ -2059,6 +2162,32 @@ impl LockedVMA {
         //TODO: 实现巨页映射判断逻辑，目前不支持巨页映射
         false
     }
+
+    pub fn file_pgoff_intersection(
+        &self,
+        start_page_index: usize,
+        end_page_index_exclusive: Option<usize>,
+    ) -> Option<VirtRegion> {
+        let guard = self.lock();
+        let vma_pgoff = guard.backing_page_offset()?;
+        let vma_pages = guard.region().size() >> MMArch::PAGE_SHIFT;
+        let vma_end = vma_pgoff.saturating_add(vma_pages);
+        let intersect_start = core::cmp::max(start_page_index, vma_pgoff);
+        let intersect_end = match end_page_index_exclusive {
+            Some(end) => core::cmp::min(end, vma_end),
+            None => vma_end,
+        };
+        if intersect_start >= intersect_end {
+            return None;
+        }
+
+        let offset_pages = intersect_start - vma_pgoff;
+        let start = guard.region().start() + (offset_pages << MMArch::PAGE_SHIFT);
+        Some(VirtRegion::new(
+            start,
+            (intersect_end - intersect_start) << MMArch::PAGE_SHIFT,
+        ))
+    }
 }
 
 impl Drop for LockedVMA {
@@ -2074,6 +2203,8 @@ pub struct VMASplitResult {
     pub middle: Arc<LockedVMA>,
     pub after: Option<Arc<LockedVMA>>,
 }
+
+type VmaSplitSides = (Option<Arc<LockedVMA>>, Option<Arc<LockedVMA>>);
 
 impl VMASplitResult {
     pub fn new(


### PR DESCRIPTION
- Add file VMA tracking with i_mmap_rwsem and invalidate_lock synchronization
- Implement file truncation with page unmapping and cleanup
- Add mkclean_page for page write protection and unmapping
- Extend PageMapper with remap_present and unmap_phys_preserve_tables for rmap operations
- Integrate file rmap into page fault handling with proper locking
- Update tmpfs and vfs truncation to use new page_cache truncate method
- Refactor address space cloning and VMA management to support file rmap
- Add page_table_edit lock for synchronized page table modifications