### PR TITLE
refactor(sched): optimize remote wakeup preemption logic

### DIFF
--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -297,11 +297,14 @@ impl ProcessManager {
                 // avoid deadlock
                 drop(writer);
 
-                let rq =
-                    cpu_rq(pcb.sched_info().on_cpu().unwrap_or(current_cpu_id()).data() as usize);
+                let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+                let update_clock = target_cpu == smp_get_processor_id();
+                let rq = cpu_rq(target_cpu.data() as usize);
 
                 let (rq, _guard) = rq.self_lock();
-                rq.update_rq_clock();
+                if update_clock {
+                    rq.update_rq_clock();
+                }
                 if was_uninterruptible {
                     rq.dec_nr_uninterruptible();
                 }
@@ -310,7 +313,11 @@ impl ProcessManager {
                     EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
                 );
 
-                rq.check_preempt_currnet(pcb, WakeupFlags::empty());
+                if update_clock {
+                    rq.check_preempt_currnet(pcb, WakeupFlags::empty());
+                } else {
+                    rq.check_preempt_remote(pcb, WakeupFlags::empty());
+                }
 
                 // sched_enqueue(pcb.clone(), true);
                 return Ok(());
@@ -340,11 +347,13 @@ impl ProcessManager {
 
         let on_rq = *pcb.sched_info().on_rq.lock_irqsave();
         if on_rq == crate::sched::OnRq::Queued {
-            let rq = crate::sched::cpu_rq(
-                pcb.sched_info().on_cpu().unwrap_or(current_cpu_id()).data() as usize,
-            );
+            let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+            let update_clock = target_cpu == smp_get_processor_id();
+            let rq = crate::sched::cpu_rq(target_cpu.data() as usize);
             let (rq, _guard) = rq.self_lock();
-            rq.update_rq_clock();
+            if update_clock {
+                rq.update_rq_clock();
+            }
 
             let old_policy = pcb.sched_info().policy();
             if old_policy != crate::sched::SchedPolicy::FIFO {
@@ -371,7 +380,11 @@ impl ProcessManager {
                 );
             }
 
-            rq.check_preempt_currnet(pcb, crate::sched::WakeupFlags::empty());
+            if update_clock {
+                rq.check_preempt_currnet(pcb, crate::sched::WakeupFlags::empty());
+            } else {
+                rq.check_preempt_remote(pcb, crate::sched::WakeupFlags::empty());
+            }
         } else {
             *pcb.sched_info().sched_policy.write_irqsave() = crate::sched::SchedPolicy::FIFO;
             let mut prio_data = pcb.sched_info().prio_data.write_irqsave();
@@ -397,21 +410,24 @@ impl ProcessManager {
                 // avoid deadlock
                 drop(writer);
 
-                let rq = cpu_rq(
-                    pcb.sched_info()
-                        .on_cpu()
-                        .unwrap_or(smp_get_processor_id())
-                        .data() as usize,
-                );
+                let target_cpu = pcb.sched_info().on_cpu().unwrap_or(smp_get_processor_id());
+                let update_clock = target_cpu == smp_get_processor_id();
+                let rq = cpu_rq(target_cpu.data() as usize);
 
                 let (rq, _guard) = rq.self_lock();
-                rq.update_rq_clock();
+                if update_clock {
+                    rq.update_rq_clock();
+                }
                 rq.activate_task(
                     pcb,
                     EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
                 );
 
-                rq.check_preempt_currnet(pcb, WakeupFlags::empty());
+                if update_clock {
+                    rq.check_preempt_currnet(pcb, WakeupFlags::empty());
+                } else {
+                    rq.check_preempt_remote(pcb, WakeupFlags::empty());
+                }
 
                 // sched_enqueue(pcb.clone(), true);
                 return Ok(());
@@ -448,9 +464,13 @@ impl ProcessManager {
         drop(writer);
 
         if on_rq == OnRq::Queued {
-            let rq = cpu_rq(pcb.sched_info().on_cpu().unwrap_or(current_cpu_id()).data() as usize);
+            let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+            let update_clock = target_cpu == smp_get_processor_id();
+            let rq = cpu_rq(target_cpu.data() as usize);
             let (rq, _guard) = rq.self_lock();
-            rq.update_rq_clock();
+            if update_clock {
+                rq.update_rq_clock();
+            }
             // STOP 使任务不可运行：应从 rq 移除，但这不是 CPU 迁移。
             // 使用 DEQUEUE_STOPPED 让 OnRq 进入 None，避免后续 activate_task() 走 ENQUEUE_MIGRATED 分支。
             rq.deactivate_task(

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -504,6 +504,46 @@ impl CpuRunQueue {
         }
     }
 
+    /// 远端 wakeup/策略调整场景下的保守抢占检查。
+    ///
+    /// Linux 会在持有目标 rq 锁且目标 rq 时钟已更新后执行完整的 wakeup-preempt 检查。
+    /// 当前明确禁止跨核 `update_rq_clock()`，因此远端路径只能保留那些不依赖
+    /// `rq.clock_task` 最新值的抢占决策：
+    /// - 更高调度类抢占；
+    /// - FIFO 优先级抢占；
+    /// - idle 被非 idle 任务抢占。
+    ///
+    /// CFS 的 wakeup-preempt 需要像 Linux `check_preempt_wakeup()` 一样先更新当前实体，
+    /// 这在远端场景会重新引入“错误 CPU 更新目标 rq 时钟”的问题，因此这里故意跳过。
+    #[allow(clippy::comparison_chain)]
+    pub fn check_preempt_remote(&mut self, pcb: &Arc<ProcessControlBlock>, flags: WakeupFlags) {
+        let current = self.current();
+        let current_policy = current.sched_info().policy();
+        let next_policy = pcb.sched_info().policy();
+
+        if current.flags().contains(ProcessFlags::NEED_SCHEDULE) {
+            return;
+        }
+
+        if next_policy < current_policy {
+            self.resched_current();
+        } else if next_policy == current_policy {
+            match current_policy {
+                SchedPolicy::CFS => {}
+                SchedPolicy::FIFO => FifoScheduler::check_preempt_currnet(self, pcb, flags),
+                SchedPolicy::RT => todo!(),
+                SchedPolicy::IDLE => IdleScheduler::check_preempt_currnet(self, pcb, flags),
+            }
+        }
+
+        if *self.current().sched_info().on_rq.lock_irqsave() == OnRq::Queued
+            && self.current().flags().contains(ProcessFlags::NEED_SCHEDULE)
+        {
+            self.clock_updata_flags
+                .insert(ClockUpdataFlag::RQCF_REQ_SKIP);
+        }
+    }
+
     /// 禁用一个任务，将离开队列
     pub fn deactivate_task(&mut self, pcb: Arc<ProcessControlBlock>, flags: DequeueFlag) {
         if flags.contains(DequeueFlag::DEQUEUE_SLEEP)
@@ -546,6 +586,12 @@ impl CpuRunQueue {
 
     /// 更新rq时钟
     pub fn update_rq_clock(&mut self) {
+        debug_assert_eq!(
+            self.cpu,
+            smp_get_processor_id(),
+            "update_rq_clock must run on its own cpu"
+        );
+
         // 需要跳过这次时钟更新
         if self
             .clock_updata_flags


### PR DESCRIPTION
- Introduce`check_preempt_remote` for conservative preemption checks in remote CPU scenarios
- Add`update_clock` flag to conditionally update runqueue clock and choose preemption method
- Add debug assertion to ensure`update_rq_clock`runs on its own CPU