### PR TITLE
refactor(sched): simplify runqueue locking mechanism

### DIFF
--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -1105,7 +1105,7 @@ impl CfsRunQueue {
 
         if se.is_task() {
             let rq = self.rq();
-            let (rq, _guard) = rq.self_lock();
+            let rq = rq.force_mut_locked();
             // TODO:numa
             rq.cfs_tasks.push_back(se.clone());
         }
@@ -1120,7 +1120,7 @@ impl CfsRunQueue {
 
         if se.is_task() {
             let rq = self.rq();
-            let (rq, _guard) = rq.self_lock();
+            let rq = rq.force_mut_locked();
 
             // TODO:numa
             let _ = rq.cfs_tasks.extract_if(|x| Arc::ptr_eq(x, se));

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -13,6 +13,7 @@ pub mod syscall;
 
 use core::{
     intrinsics::{likely, unlikely},
+    panic::Location,
     sync::atomic::{compiler_fence, fence, AtomicUsize, Ordering},
 };
 
@@ -290,7 +291,6 @@ pub trait SchedArch {
 #[derive(Debug)]
 pub struct CpuRunQueue {
     lock: SpinLock<()>,
-    lock_on_who: AtomicUsize,
 
     cpu: ProcessorId,
     clock_task: u64,
@@ -340,7 +340,6 @@ impl CpuRunQueue {
     pub fn new(cpu: ProcessorId) -> Self {
         Self {
             lock: SpinLock::new(()),
-            lock_on_who: AtomicUsize::new(usize::MAX),
             cpu,
             clock_task: 0,
             clock: 0,
@@ -366,45 +365,49 @@ impl CpuRunQueue {
     }
 
     /// 此函数只能在关中断的情况下使用！！！
-    /// 获取到rq的可变引用，需要注意的是返回的第二个值需要确保其生命周期
-    /// 所以可以说这个函数是unsafe的，需要确保正确性
-    /// 在中断上下文，关中断的情况下，此函数是安全的
+    /// 获取到 rq 的可变引用，并显式持有 rq 锁。
     #[allow(clippy::mut_from_ref)]
-    pub fn self_lock(&self) -> (&mut Self, Option<SpinLockGuard<'_, ()>>) {
-        if self.lock.is_locked()
-            && smp_get_processor_id().data() as usize == self.lock_on_who.load(Ordering::SeqCst)
-        {
-            // 在本cpu已上锁则可以直接拿
-            (
-                unsafe {
-                    (self as *const Self as usize as *mut Self)
-                        .as_mut()
-                        .unwrap()
-                },
-                None,
-            )
-        } else {
-            // 否则先上锁再拿
-            let guard = self.lock();
-            (
-                unsafe {
-                    (self as *const Self as usize as *mut Self)
-                        .as_mut()
-                        .unwrap()
-                },
-                Some(guard),
-            )
-        }
+    #[track_caller]
+    pub fn self_lock(&self) -> (&mut Self, SpinLockGuard<'_, ()>) {
+        let mut spins = 0usize;
+        let guard = loop {
+            if let Ok(guard) = self.lock.try_lock_irqsave() {
+                break guard;
+            }
+
+            spins += 1;
+            if spins >= 1_000_000 {
+                let caller = Location::caller();
+                panic!(
+                    "CpuRunQueue::self_lock spinout on cpu {:?}, caller {}:{}",
+                    self.cpu,
+                    caller.file(),
+                    caller.line()
+                );
+            }
+
+            core::hint::spin_loop();
+        };
+        (self.force_mut_locked(), guard)
     }
 
     fn lock(&self) -> SpinLockGuard<'_, ()> {
-        let guard = self.lock.lock_irqsave();
+        self.lock.lock_irqsave()
+    }
 
-        // 更新在哪一个cpu上锁
-        self.lock_on_who
-            .store(smp_get_processor_id().data() as usize, Ordering::SeqCst);
+    #[allow(clippy::mut_from_ref)]
+    fn force_mut(&self) -> &mut Self {
+        unsafe { (self as *const Self as *mut Self).as_mut().unwrap() }
+    }
 
-        guard
+    /// 仅允许在已经持有 rq 锁的路径中使用。
+    #[allow(clippy::mut_from_ref)]
+    pub fn force_mut_locked(&self) -> &mut Self {
+        assert!(
+            self.lock.is_locked(),
+            "rq must be locked before mutable access"
+        );
+        self.force_mut()
     }
 
     pub fn enqueue_task(&mut self, pcb: Arc<ProcessControlBlock>, flags: EnqueueFlag) {
@@ -884,7 +887,7 @@ pub fn __schedule(sched_mod: SchedMode) {
 
     // TODO: hrtick_clear(rq);
 
-    let (rq, _guard) = rq.self_lock();
+    let (rq, guard) = rq.self_lock();
 
     rq.clock_updata_flags = ClockUpdataFlag::from_bits_truncate(rq.clock_updata_flags.bits() << 1);
 
@@ -975,8 +978,14 @@ pub fn __schedule(sched_mod: SchedMode) {
         // CurrentApic.send_eoi();
         compiler_fence(Ordering::SeqCst);
 
+        // This kernel does not hand off rq lock ownership across context switch.
+        // Drop it before switching so the incoming task's first tick/wakeup path
+        // can acquire the local rq lock normally.
+        drop(guard);
+
         unsafe { ProcessManager::switch_process(prev, next) };
     } else {
+        drop(guard);
         assert!(
             Arc::ptr_eq(&ProcessManager::current_pcb(), &prev),
             "{}",

--- a/kernel/src/sched/pelt.rs
+++ b/kernel/src/sched/pelt.rs
@@ -208,7 +208,7 @@ impl CfsRunQueue {
         }
 
         let rq = self.rq();
-        let (rq, _guard) = rq.self_lock();
+        let rq = rq.force_mut_locked();
 
         return rq.rq_clock_pelt() - self.throttled_clock_pelt_time;
     }


### PR DESCRIPTION

This PR rewrites `CpuRunQueue::self_lock` to remove the same-CPU reentry fast path based on `is_locked() + lock_on_who`.

The old design had a TOCTOU window:

- `is_locked()` and `lock_on_who` were observed separately
- lock ownership was published later than actual lock acquisition
- under higher scheduler concurrency, another CPU could incorrectly conclude that it already owned the runqueue lock

To eliminate that class of bugs, `self_lock()` now always acquires the real runqueue spinlock and returns an explicit `SpinLockGuard`.

## Root Cause

While implementing the lock rewrite, boot-time validation exposed an older hidden scheduling bug:

- `__schedule()` acquired the local rq lock
- the lock remained held across `switch_process(prev, next)`
- the next local APIC timer tick entered `scheduler_tick()`
- `scheduler_tick()` tried to lock the same rq again on the same CPU and spun forever

Previously, the same-CPU lock bypass masked this behavior. Once that bypass was removed, the bug became visible immediately.

## Changes

### 1. Remove the unsafe owner-tracking fast path

- deleted `lock_on_who` from `CpuRunQueue`
- removed the same-CPU "already locked, return mutable ref directly" path
- changed `self_lock()` to always return:

```rust
(&mut CpuRunQueue, SpinLockGuard<'_, ()>)
```

### 2. Make lock ownership explicit at all call sites

All `self_lock()` call sites now hold a real guard explicitly instead of relying on implicit same-CPU reentry behavior.

Affected areas include:

- scheduler core
- fair scheduler
- PELT helpers
- process wakeup / stop / exit paths
- idle task setup

### 3. Fix nested rq access in CFS internals

Some CFS paths previously re-entered `rq.self_lock()` indirectly while already operating under the rq lock.

To avoid self-deadlock after removing the bypass:

- added a locked-only helper for rq mutable access
- converted nested CFS rq access paths to use the already-held rq lock contract
- added assertions to fail fast if mutable rq access happens without the lock

### 4. Fix rq lock lifetime across context switch

This PR also fixes the scheduler bug uncovered during boot testing:

- `__schedule()` now drops the rq lock guard before `switch_process(prev, next)`
- rq lock ownership is no longer carried across context switch
- the incoming task can safely execute local timer tick / wakeup paths

## Why this approach

This PR intentionally chooses the simpler and more auditable direction:

- no custom owned-spinlock primitive
- no owner metadata coupled into the spinlock implementation
- one consistent rule: mutable rq access requires holding the real rq lock

That makes the behavior easier to reason about and avoids subtle lock ownership races.
