### PR TITLE
feat(sched): Add per-task CPU affinity state and minimal `sched_{set,get}affinity` support

### DIFF
--- a/kernel/crates/bitmap/src/alloc_bitmap.rs
+++ b/kernel/crates/bitmap/src/alloc_bitmap.rs
@@ -112,7 +112,7 @@ impl BitMapOps<usize> for AllocBitmap {
     unsafe fn as_bytes(&self) -> &[u8] {
         core::slice::from_raw_parts(
             self.data.as_ptr() as *const u8,
-            core::mem::size_of::<Self>(),
+            self.data.len() * core::mem::size_of::<usize>(),
         )
     }
 

--- a/kernel/crates/bitmap/src/static_bitmap.rs
+++ b/kernel/crates/bitmap/src/static_bitmap.rs
@@ -129,7 +129,7 @@ impl<const N: usize, const M: usize> BitMapOps<usize> for StaticBitmap<N, M> {
     unsafe fn as_bytes(&self) -> &[u8] {
         core::slice::from_raw_parts(
             self.data.as_ptr() as *const u8,
-            core::mem::size_of::<Self>(),
+            self.data.len() * core::mem::size_of::<usize>(),
         )
     }
 

--- a/kernel/crates/bitmap/tests/alloc-bitmap.rs
+++ b/kernel/crates/bitmap/tests/alloc-bitmap.rs
@@ -2,6 +2,22 @@
 
 use bitmap::{traits::BitMapOps, AllocBitmap};
 
+#[test]
+fn test_alloc_bitmap_as_bytes_matches_bitmap_payload() {
+    let mut bitmap = AllocBitmap::new(128);
+    bitmap.set(0, true);
+    bitmap.set(63, true);
+    bitmap.set(64, true);
+    bitmap.set(127, true);
+
+    let bytes = unsafe { bitmap.as_bytes() };
+    assert_eq!(bytes.len(), bitmap.size());
+    assert_eq!(bytes[0], 0x01);
+    assert_eq!(bytes[7], 0x80);
+    assert_eq!(bytes[8], 0x01);
+    assert_eq!(bytes[15], 0x80);
+}
+
 /// 测试空的位图
 ///
 /// 这是一个测试空的位图的例子

--- a/kernel/src/arch/riscv64/process/kthread.rs
+++ b/kernel/src/arch/riscv64/process/kthread.rs
@@ -43,9 +43,9 @@ impl KernelThreadMechanism {
             e
         })?;
 
-        ProcessManager::find(pid)
-            .unwrap()
-            .set_name(info.name().clone());
+        let pcb = ProcessManager::find(pid).unwrap();
+        pcb.set_name(info.name().clone());
+        info.setup_pcb(&pcb);
 
         return Ok(pid);
     }

--- a/kernel/src/arch/x86_64/process/kthread.rs
+++ b/kernel/src/arch/x86_64/process/kthread.rs
@@ -44,9 +44,9 @@ impl KernelThreadMechanism {
             unsafe { KernelThreadCreateInfo::parse_unsafe_arc_ptr(create_info) };
         })?;
 
-        ProcessManager::find_task_by_vpid(pid)
-            .unwrap()
-            .set_name(info.name().clone());
+        let pcb = ProcessManager::find_task_by_vpid(pid).unwrap();
+        pcb.set_name(info.name().clone());
+        info.setup_pcb(&pcb);
 
         return Ok(pid);
     }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -547,6 +547,12 @@ impl ProcessManager {
                 current_pcb.raw_pid(), pcb.raw_pid(), e
             )
         });
+        // pid 0 是 bootstrap idle 线程。它的 affinity 可能是“当前 CPU only”，
+        // 但普通任务不能把这份临时/per-cpu mask 当作默认继承下来。
+        if current_pcb.raw_pid() != RawPid(0) {
+            pcb.sched_info()
+                .set_cpus_allowed(current_pcb.sched_info().cpus_allowed());
+        }
 
         // 拷贝标志位
         Self::copy_flags(&clone_flags, pcb).unwrap_or_else(|e| {

--- a/kernel/src/process/idle.rs
+++ b/kernel/src/process/idle.rs
@@ -6,6 +6,7 @@ use core::{
 use alloc::{sync::Arc, vec::Vec};
 
 use crate::{
+    libs::cpumask::CpuMask,
     mm::{percpu::PerCpu, VirtAddr, IDLE_PROCESS_ADDRESS_SPACE},
     process::KernelStack,
     sched::{cpu_rq, OnRq},
@@ -61,6 +62,9 @@ impl ProcessManager {
 
             assert!(idle_pcb.sched_info().on_cpu().is_none());
             idle_pcb.sched_info().set_on_cpu(Some(ProcessorId::new(i)));
+            idle_pcb
+                .sched_info()
+                .set_cpus_allowed(CpuMask::from_cpu(ProcessorId::new(i)));
             *idle_pcb.sched_info().sched_policy.write_irqsave() = crate::sched::SchedPolicy::IDLE;
 
             let rq = cpu_rq(i as usize);

--- a/kernel/src/process/kthread.rs
+++ b/kernel/src/process/kthread.rs
@@ -17,9 +17,10 @@ use crate::{
     arch::CurrentIrqArch,
     exception::{irqdesc::IrqAction, InterruptArch},
     init::initial_kthread::{initial_kernel_thread, set_system_state, SystemState},
-    libs::{once::Once, spinlock::SpinLock},
+    libs::{cpumask::CpuMask, once::Once, spinlock::SpinLock},
     process::{ProcessManager, ProcessState},
     sched::{schedule, SchedMode},
+    smp::cpu::ProcessorId,
 };
 
 use super::{fork::CloneFlags, ProcessControlBlock, ProcessFlags, RawPid};
@@ -137,6 +138,8 @@ pub struct KernelThreadCreateInfo {
     self_ref: Weak<Self>,
     /// 如果该值为true在进入bootstrap stage2之后，就会进入睡眠状态
     to_mark_sleep: AtomicBool,
+    flags: SpinLock<KernelThreadFlags>,
+    bound_cpu: SpinLock<Option<ProcessorId>>,
 }
 
 #[atomic_enum]
@@ -158,6 +161,8 @@ impl KernelThreadCreateInfo {
             has_unsafe_arc_instance: AtomicBool::new(false),
             self_ref: Weak::new(),
             to_mark_sleep: AtomicBool::new(true),
+            flags: SpinLock::new(KernelThreadFlags::empty()),
+            bound_cpu: SpinLock::new(None),
         });
         let tmp = result.clone();
         unsafe {
@@ -256,6 +261,39 @@ impl KernelThreadCreateInfo {
 
     pub fn to_mark_sleep(&self) -> bool {
         self.to_mark_sleep.load(Ordering::SeqCst)
+    }
+
+    pub fn set_per_cpu(&self, cpu: ProcessorId) -> Result<(), SystemError> {
+        let result_guard = self.result_pcb.lock();
+        if result_guard.is_some() {
+            return Err(SystemError::EINVAL);
+        }
+        drop(result_guard);
+
+        self.flags.lock().insert(KernelThreadFlags::IS_PER_CPU);
+        *self.bound_cpu.lock() = Some(cpu);
+        Ok(())
+    }
+
+    pub fn setup_pcb(&self, pcb: &Arc<ProcessControlBlock>) {
+        let flags = *self.flags.lock();
+        if flags.is_empty() {
+            return;
+        }
+
+        let mut worker_private_guard = pcb.worker_private();
+        let worker_private = worker_private_guard
+            .as_mut()
+            .and_then(|x| x.kernel_thread_mut())
+            .expect("kthread create: missing worker_private");
+        worker_private.flags |= flags;
+        drop(worker_private_guard);
+
+        if flags.contains(KernelThreadFlags::IS_PER_CPU) {
+            let cpu = (*self.bound_cpu.lock())
+                .expect("kthread create: per-cpu thread missing target cpu");
+            pcb.sched_info().set_cpus_allowed(CpuMask::from_cpu(cpu));
+        }
     }
 }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -41,6 +41,7 @@ use crate::{
     },
     libs::{
         align::AlignedBox,
+        cpumask::CpuMask,
         futex::{
             constant::{FutexFlag, FUTEX_BITSET_MATCH_ANY},
             futex::{Futex, RobustListHead},
@@ -2364,6 +2365,8 @@ pub struct ProcessSchedulerInfo {
     /// cfs调度实体
     pub sched_entity: Arc<FairSchedEntity>,
     pub on_rq: SpinLock<OnRq>,
+    pub cpus_allowed: SpinLock<CpuMask>,
+    pub nr_cpus_allowed: AtomicUsize,
 
     pub prio_data: RwLock<PrioData>,
 }
@@ -2430,9 +2433,21 @@ impl InnerSchedInfo {
 }
 
 impl ProcessSchedulerInfo {
+    fn default_cpus_allowed() -> CpuMask {
+        if crate::smp::cpu::smp_cpu_manager_initialized() {
+            return crate::smp::cpu::smp_cpu_manager().possible_cpus().clone();
+        }
+
+        // 进程管理初始化早于 SMP 拓扑初始化。此时先退化为“当前引导 CPU 可运行”，
+        // 待后续显式初始化（如 idle/per-cpu kthread）再收敛到更精确的 mask。
+        CpuMask::from_cpu(current_cpu_id())
+    }
+
     #[inline(never)]
     pub fn new(on_cpu: Option<ProcessorId>) -> Self {
         let cpu_id = on_cpu.unwrap_or(ProcessorId::INVALID);
+        let cpus_allowed = Self::default_cpus_allowed();
+        let nr_cpus_allowed = cpus_allowed.iter_cpu().count();
         return Self {
             on_cpu: AtomicProcessorId::new(cpu_id),
             // migrate_to: AtomicProcessorId::new(ProcessorId::INVALID),
@@ -2447,6 +2462,8 @@ impl ProcessSchedulerInfo {
             sched_policy: RwLock::new(crate::sched::SchedPolicy::CFS),
             sched_entity: FairSchedEntity::new(),
             on_rq: SpinLock::new(OnRq::None),
+            cpus_allowed: SpinLock::new(cpus_allowed),
+            nr_cpus_allowed: AtomicUsize::new(nr_cpus_allowed),
             prio_data: RwLock::new(PrioData::default()),
         };
     }
@@ -2554,6 +2571,21 @@ impl ProcessSchedulerInfo {
 
     pub fn prio_data(&self) -> RwLockReadGuard<'_, PrioData> {
         return self.prio_data.read_irqsave();
+    }
+
+    pub fn cpus_allowed(&self) -> CpuMask {
+        return self.cpus_allowed.lock_irqsave().clone();
+    }
+
+    pub fn nr_cpus_allowed(&self) -> usize {
+        return self.nr_cpus_allowed.load(Ordering::SeqCst);
+    }
+
+    pub fn set_cpus_allowed(&self, cpus_allowed: CpuMask) {
+        let nr_cpus_allowed = cpus_allowed.iter_cpu().count();
+        *self.cpus_allowed.lock_irqsave() = cpus_allowed;
+        self.nr_cpus_allowed
+            .store(nr_cpus_allowed, Ordering::SeqCst);
     }
 }
 

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -391,10 +391,6 @@ impl CpuRunQueue {
         (self.force_mut_locked(), guard)
     }
 
-    fn lock(&self) -> SpinLockGuard<'_, ()> {
-        self.lock.lock_irqsave()
-    }
-
     #[allow(clippy::mut_from_ref)]
     fn force_mut(&self) -> &mut Self {
         unsafe { (self as *const Self as *mut Self).as_mut().unwrap() }
@@ -664,6 +660,9 @@ impl CpuRunQueue {
     pub fn sub_nr_running(&mut self, count: usize) {
         self.nr_running -= count;
         loadavg::dec_nr_running(count);
+        if self.nr_running < 2 && self.overload {
+            self.overload = false;
+        }
     }
 
     pub fn dec_nr_uninterruptible(&mut self) {
@@ -1135,4 +1134,31 @@ pub fn sched_yield() {
     drop(preempt_guard);
 
     schedule(SchedMode::SM_NONE);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::loadavg;
+    use crate::sched::CpuRunQueue;
+    use crate::smp::cpu::ProcessorId;
+
+    #[test]
+    fn rq_overload_clears_after_nr_running_drops_below_two() {
+        let mut rq = CpuRunQueue::new(ProcessorId::new(0));
+        let global_before = loadavg::nr_running();
+
+        rq.add_nr_running(2);
+        assert!(rq.overload);
+        assert_eq!(rq.nr_running, 2);
+
+        rq.sub_nr_running(1);
+        assert!(!rq.overload);
+        assert_eq!(rq.nr_running, 1);
+
+        assert_eq!(loadavg::nr_running(), global_before + 1);
+
+        rq.sub_nr_running(1);
+        assert_eq!(rq.nr_running, 0);
+        assert_eq!(loadavg::nr_running(), global_before);
+    }
 }

--- a/kernel/src/sched/syscall/mod.rs
+++ b/kernel/src/sched/syscall/mod.rs
@@ -4,4 +4,4 @@ mod sys_pause;
 mod sys_sched_getparam;
 mod sys_sched_getscheduler;
 mod sys_sched_yield;
-mod util;
+pub(crate) mod util;

--- a/kernel/src/sched/syscall/util.rs
+++ b/kernel/src/sched/syscall/util.rs
@@ -1,4 +1,5 @@
 /// 调度系统调用相关的工具函数
+use crate::process::cred::CAPFlags;
 use crate::process::ProcessControlBlock;
 
 /// 检查当前进程是否有权限查询目标进程的调度信息
@@ -27,10 +28,41 @@ pub fn has_sched_permission(
     let current_cred = current_pcb.cred();
 
     // 具有 CAP_SYS_NICE 权限
-    if current_cred.has_capability(crate::process::cred::CAPFlags::CAP_SYS_NICE) {
+    if current_cred.has_capability(CAPFlags::CAP_SYS_NICE) {
         return true;
     }
 
     // root 用户（uid == 0）
     current_cred.uid.data() == 0
+}
+
+/// 检查当前进程是否有权限修改目标进程的 CPU affinity。
+///
+/// Linux 兼容语义：
+/// - 进程自己总是允许
+/// - 具有 CAP_SYS_NICE 的进程允许
+/// - root（euid == 0）允许
+/// - 同一用户（real/effective uid 匹配）允许
+pub fn has_sched_setaffinity_permission(
+    current_pcb: &ProcessControlBlock,
+    target_pcb: &ProcessControlBlock,
+) -> bool {
+    if current_pcb.raw_pid() == target_pcb.raw_pid() {
+        return true;
+    }
+
+    let current_cred = current_pcb.cred();
+    if current_cred.has_capability(CAPFlags::CAP_SYS_NICE) {
+        return true;
+    }
+
+    if current_cred.euid.data() == 0 {
+        return true;
+    }
+
+    let target_cred = target_pcb.cred();
+    current_cred.euid == target_cred.euid
+        || current_cred.euid == target_cred.uid
+        || current_cred.uid == target_cred.euid
+        || current_cred.uid == target_cred.uid
 }

--- a/kernel/src/smp/cpu/mod.rs
+++ b/kernel/src/smp/cpu/mod.rs
@@ -23,6 +23,11 @@ impl ProcessorId {
 static mut SMP_CPU_MANAGER: Option<SmpCpuManager> = None;
 
 #[inline]
+pub fn smp_cpu_manager_initialized() -> bool {
+    unsafe { SMP_CPU_MANAGER.is_some() }
+}
+
+#[inline]
 pub fn smp_cpu_manager() -> &'static SmpCpuManager {
     unsafe { SMP_CPU_MANAGER.as_ref().unwrap() }
 }

--- a/kernel/src/smp/syscall/mod.rs
+++ b/kernel/src/smp/syscall/mod.rs
@@ -1,2 +1,3 @@
 mod sys_getcpu;
 mod sys_sched_getaffinity;
+mod sys_sched_setaffinity;

--- a/kernel/src/smp/syscall/sys_sched_getaffinity.rs
+++ b/kernel/src/smp/syscall/sys_sched_getaffinity.rs
@@ -5,7 +5,8 @@ use system_error::SystemError;
 
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_SCHED_GETAFFINITY;
-use crate::smp::cpu::smp_cpu_manager;
+use crate::process::{ProcessManager, RawPid};
+use crate::sched::syscall::util::has_sched_permission;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::UserBufferWriter;
 
@@ -17,29 +18,41 @@ impl Syscall for SysSchedGetaffinity {
     }
 
     fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
-        let _pid = args[0] as i32;
+        let pid = args[0] as i32;
         let size = args[1];
         let set_vaddr = args[2];
 
-        // 验证用户空间地址
+        if size == 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        let target_pcb = if pid == 0 {
+            ProcessManager::current_pcb()
+        } else {
+            ProcessManager::find_task_by_vpid(RawPid::from(pid as usize))
+                .ok_or(SystemError::ESRCH)?
+        };
+
+        let current_pcb = ProcessManager::current_pcb();
+        if !has_sched_permission(&current_pcb, &target_pcb) {
+            return Err(SystemError::EPERM);
+        }
+
+        let mask = target_pcb.sched_info().cpus_allowed();
+        let src = unsafe { mask.inner().as_bytes() };
+        let copy_len = core::cmp::min(size, src.len());
+
         let mut user_buffer_writer =
             UserBufferWriter::new(set_vaddr as *mut u8, size, frame.is_from_user())?;
         let set: &mut [u8] = user_buffer_writer.buffer(0)?;
-
-        // 获取CPU亲和性掩码
-        let cpu_manager = smp_cpu_manager();
-        let src = unsafe { cpu_manager.possible_cpus().inner().as_bytes() };
-
-        // 确保不会越界
-        let copy_len = core::cmp::min(size, src.len());
         set[..copy_len].copy_from_slice(&src[..copy_len]);
 
-        Ok(0)
+        Ok(copy_len)
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
         vec![
-            FormattedSyscallParam::new("pid", args[0].to_string()),
+            FormattedSyscallParam::new("pid", (args[0] as i32).to_string()),
             FormattedSyscallParam::new("size", args[1].to_string()),
             FormattedSyscallParam::new("set", format!("0x{:x}", args[2])),
         ]

--- a/kernel/src/smp/syscall/sys_sched_setaffinity.rs
+++ b/kernel/src/smp/syscall/sys_sched_setaffinity.rs
@@ -1,0 +1,103 @@
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use bitmap::traits::BitMapOps;
+use system_error::SystemError;
+
+use crate::arch::interrupt::TrapFrame;
+use crate::arch::syscall::nr::SYS_SCHED_SETAFFINITY;
+use crate::libs::cpumask::CpuMask;
+use crate::process::{ProcessManager, RawPid};
+use crate::sched::syscall::util::has_sched_setaffinity_permission;
+use crate::smp::cpu::smp_cpu_manager;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+use crate::syscall::user_access::UserBufferReader;
+
+pub struct SysSchedSetaffinity;
+
+impl Syscall for SysSchedSetaffinity {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pid = args[0] as i32;
+        let size = args[1];
+        let set_vaddr = args[2];
+
+        if size == 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        let target_pcb = if pid == 0 {
+            ProcessManager::current_pcb()
+        } else {
+            ProcessManager::find_task_by_vpid(RawPid::from(pid as usize))
+                .ok_or(SystemError::ESRCH)?
+        };
+
+        let current_pcb = ProcessManager::current_pcb();
+        if !has_sched_setaffinity_permission(&current_pcb, &target_pcb) {
+            return Err(SystemError::EPERM);
+        }
+
+        let reader = UserBufferReader::new(set_vaddr as *const u8, size, frame.is_from_user())?;
+        let user_set = reader.buffer(0)?;
+        let mask = Self::parse_user_mask(user_set)?;
+
+        if mask.is_empty() {
+            return Err(SystemError::EINVAL);
+        }
+
+        let possible_cpus = smp_cpu_manager().possible_cpus();
+        for cpu in mask.iter_cpu() {
+            if possible_cpus.get(cpu) != Some(true) {
+                return Err(SystemError::EINVAL);
+            }
+        }
+
+        target_pcb.sched_info().set_cpus_allowed(mask);
+        Ok(0)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pid", (args[0] as i32).to_string()),
+            FormattedSyscallParam::new("size", args[1].to_string()),
+            FormattedSyscallParam::new("set", format!("0x{:x}", args[2])),
+        ]
+    }
+}
+
+impl SysSchedSetaffinity {
+    fn parse_user_mask(user_set: &[u8]) -> Result<CpuMask, SystemError> {
+        let mut mask = CpuMask::new();
+        let kernel_mask_bytes = unsafe { mask.inner().as_bytes().len() };
+        let parse_len = core::cmp::min(user_set.len(), kernel_mask_bytes);
+
+        for (byte_index, byte) in user_set[..parse_len].iter().enumerate() {
+            if *byte == 0 {
+                continue;
+            }
+
+            for bit in 0..8 {
+                if (byte & (1 << bit)) == 0 {
+                    continue;
+                }
+
+                let cpu_index = byte_index * 8 + bit;
+                let cpu_id = crate::smp::cpu::ProcessorId::new(cpu_index as u32);
+                if mask.set(cpu_id, true).is_none() {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+        }
+
+        if user_set[parse_len..].iter().any(|byte| *byte != 0) {
+            return Err(SystemError::EINVAL);
+        }
+
+        Ok(mask)
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SCHED_SETAFFINITY, SysSchedSetaffinity);

--- a/user/apps/tests/dunitest/suites/normal/sched_affinity.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_affinity.cc
@@ -1,0 +1,277 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+int FirstCpu(const cpu_set_t& set) {
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (CPU_ISSET(cpu, &set)) {
+            return cpu;
+        }
+    }
+    return -1;
+}
+
+int NextCpu(const cpu_set_t& set, int after) {
+    for (int cpu = after + 1; cpu < CPU_SETSIZE; ++cpu) {
+        if (CPU_ISSET(cpu, &set)) {
+            return cpu;
+        }
+    }
+    return -1;
+}
+
+std::string CpuSetToString(const cpu_set_t& set) {
+    std::string out = "{";
+    bool first = true;
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (!CPU_ISSET(cpu, &set)) {
+            continue;
+        }
+        if (!first) {
+            out += ",";
+        }
+        first = false;
+        out += std::to_string(cpu);
+    }
+    out += "}";
+    return out;
+}
+
+void ExpectCpuSetEq(const cpu_set_t& expected, const cpu_set_t& actual) {
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        EXPECT_EQ(CPU_ISSET(cpu, &expected), CPU_ISSET(cpu, &actual))
+            << "cpu=" << cpu << " expected=" << CpuSetToString(expected)
+            << " actual=" << CpuSetToString(actual);
+    }
+}
+
+class SchedAffinityFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        CPU_ZERO(&original_);
+        ASSERT_EQ(0, sched_getaffinity(0, sizeof(original_), &original_))
+            << "sched_getaffinity failed: errno=" << errno << " (" << strerror(errno) << ")";
+        ASSERT_GE(FirstCpu(original_), 0) << "initial affinity is empty";
+    }
+
+    void TearDown() override {
+        if (sched_setaffinity(0, sizeof(original_), &original_) != 0) {
+            ADD_FAILURE() << "restore sched_setaffinity failed: errno=" << errno << " ("
+                          << strerror(errno) << ")";
+        }
+    }
+
+    cpu_set_t SingleCpuMask(int cpu) const {
+        cpu_set_t set;
+        CPU_ZERO(&set);
+        CPU_SET(cpu, &set);
+        return set;
+    }
+
+    cpu_set_t original_ {};
+};
+
+}  // namespace
+
+TEST_F(SchedAffinityFixture, SetGetRoundTripSingleCpu) {
+    const int cpu = FirstCpu(original_);
+    ASSERT_GE(cpu, 0);
+
+    cpu_set_t target = SingleCpuMask(cpu);
+    ASSERT_EQ(0, sched_setaffinity(0, sizeof(target), &target))
+        << "sched_setaffinity failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    cpu_set_t current;
+    CPU_ZERO(&current);
+    ASSERT_EQ(0, sched_getaffinity(0, sizeof(current), &current))
+        << "sched_getaffinity failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    ExpectCpuSetEq(target, current);
+}
+
+TEST_F(SchedAffinityFixture, ForkChildInheritsAffinity) {
+    const int cpu = FirstCpu(original_);
+    ASSERT_GE(cpu, 0);
+
+    cpu_set_t target = SingleCpuMask(cpu);
+    ASSERT_EQ(0, sched_setaffinity(0, sizeof(target), &target))
+        << "sched_setaffinity failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (pid == 0) {
+        cpu_set_t child;
+        CPU_ZERO(&child);
+        if (sched_getaffinity(0, sizeof(child), &child) != 0) {
+            _exit(10);
+        }
+
+        for (int i = 0; i < CPU_SETSIZE; ++i) {
+            if (CPU_ISSET(i, &child) != CPU_ISSET(i, &target)) {
+                _exit(11);
+            }
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(pid, waitpid(pid, &status, 0))
+        << "waitpid failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "child exit status=" << WEXITSTATUS(status);
+}
+
+TEST_F(SchedAffinityFixture, EmptyMaskRejected) {
+    cpu_set_t empty;
+    CPU_ZERO(&empty);
+
+    errno = 0;
+    EXPECT_EQ(-1, sched_setaffinity(0, sizeof(empty), &empty));
+    EXPECT_EQ(EINVAL, errno);
+}
+
+TEST_F(SchedAffinityFixture, ChildCanUpdateOwnAffinityRoundTrip) {
+    const int cpu0 = FirstCpu(original_);
+    ASSERT_GE(cpu0, 0);
+    const int cpu1 = NextCpu(original_, cpu0);
+    const int target_cpu = (cpu1 >= 0) ? cpu1 : cpu0;
+
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (pid == 0) {
+        cpu_set_t target;
+        cpu_set_t current;
+        CPU_ZERO(&target);
+        CPU_ZERO(&current);
+        CPU_SET(target_cpu, &target);
+
+        if (sched_setaffinity(0, sizeof(target), &target) != 0) {
+            _exit(20);
+        }
+        if (sched_getaffinity(0, sizeof(current), &current) != 0) {
+            _exit(21);
+        }
+
+        for (int i = 0; i < CPU_SETSIZE; ++i) {
+            if (CPU_ISSET(i, &current) != CPU_ISSET(i, &target)) {
+                _exit(22);
+            }
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(pid, waitpid(pid, &status, 0))
+        << "waitpid failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "child exit status=" << WEXITSTATUS(status);
+}
+
+TEST_F(SchedAffinityFixture, SameUidParentCanUpdateChildAffinity) {
+    int ready_pipe[2];
+    ASSERT_EQ(0, pipe(ready_pipe)) << "pipe failed: errno=" << errno << " (" << strerror(errno)
+                                   << ")";
+
+    pid_t helper = fork();
+    ASSERT_GE(helper, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (helper == 0) {
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+
+        const uid_t test_uid = (geteuid() == 0) ? static_cast<uid_t>(1000) : geteuid();
+        if (setresuid(test_uid, test_uid, test_uid) != 0) {
+            _exit(30);
+        }
+
+        cpu_set_t available;
+        CPU_ZERO(&available);
+        if (sched_getaffinity(0, sizeof(available), &available) != 0) {
+            _exit(31);
+        }
+
+        const int cpu = FirstCpu(available);
+        if (cpu < 0) {
+            _exit(32);
+        }
+
+        cpu_set_t target;
+        CPU_ZERO(&target);
+        CPU_SET(cpu, &target);
+
+        int sync_pipe[2];
+        if (pipe(sync_pipe) != 0) {
+            _exit(33);
+        }
+
+        pid_t child = fork();
+        if (child < 0) {
+            _exit(34);
+        }
+
+        if (child == 0) {
+            close(sync_pipe[1]);
+            char token = 0;
+            if (read(sync_pipe[0], &token, sizeof(token)) != sizeof(token)) {
+                _exit(40);
+            }
+            close(sync_pipe[0]);
+
+            cpu_set_t current;
+            CPU_ZERO(&current);
+            if (sched_getaffinity(0, sizeof(current), &current) != 0) {
+                _exit(41);
+            }
+
+            for (int i = 0; i < CPU_SETSIZE; ++i) {
+                if (CPU_ISSET(i, &current) != CPU_ISSET(i, &target)) {
+                    _exit(42);
+                }
+            }
+            _exit(0);
+        }
+
+        close(sync_pipe[0]);
+        if (sched_setaffinity(child, sizeof(target), &target) != 0) {
+            _exit(35);
+        }
+
+        const char token = 'x';
+        if (write(sync_pipe[1], &token, sizeof(token)) != sizeof(token)) {
+            _exit(36);
+        }
+        close(sync_pipe[1]);
+
+        int child_status = 0;
+        if (waitpid(child, &child_status, 0) != child) {
+            _exit(37);
+        }
+        if (!WIFEXITED(child_status)) {
+            _exit(38);
+        }
+        _exit(WEXITSTATUS(child_status));
+    }
+
+    close(ready_pipe[0]);
+    close(ready_pipe[1]);
+
+    int status = 0;
+    ASSERT_EQ(helper, waitpid(helper, &status, 0))
+        << "waitpid failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(WIFEXITED(status)) << "helper did not exit normally, status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "helper exit status=" << WEXITSTATUS(status);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -12,3 +12,4 @@ normal/test_tlb_shootdown
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
+normal/sched_affinity

--- a/user/apps/tests/syscall/gvisor/blocklists/getcpu_host_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/getcpu_host_test
@@ -1,0 +1,5 @@
+# Temporary blocklist for cross-CPU affinity/getcpu consistency.
+# DragonOS currently stores affinity masks but does not yet enforce task
+# migration onto an allowed CPU, so sched_getcpu() can still observe a CPU
+# outside the post-setaffinity mask.
+GetcpuTest.IsValidCpu

--- a/user/apps/tests/syscall/gvisor/blocklists/getcpu_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/getcpu_test
@@ -1,0 +1,5 @@
+# Temporary blocklist for cross-CPU affinity/getcpu consistency.
+# DragonOS currently stores affinity masks but does not yet enforce task
+# migration onto an allowed CPU, so sched_getcpu() can still observe a CPU
+# outside the post-setaffinity mask.
+GetcpuTest.IsValidCpu


### PR DESCRIPTION

## Summary

This PR adds per-task CPU affinity state to the PCB and exposes a minimal Linux-compatible `sched_setaffinity(2)` / `sched_getaffinity(2)` path.

The implementation keeps the scope intentionally small:

- affinity is stored on each task as scheduler state
- `fork` / `clone` inherit affinity from the parent
- kernel threads keep the default "all possible CPUs" behavior unless explicitly marked per-CPU
- `sched_setaffinity` validates and stores the requested mask, but does not trigger active migration yet
- `sched_getaffinity` now returns the target task's actual affinity instead of the global `possible_cpus` mask

This closes the basic state-management and syscall round-trip needed before later CPU placement work can rely on affinity semantics.

## What changed

### 1. Add affinity state to `ProcessSchedulerInfo`

`ProcessSchedulerInfo` now carries:

- `cpus_allowed`
- `nr_cpus_allowed`

and exposes helpers to read and update that state.

For normal tasks, the default affinity is initialized from the current `possible_cpus` snapshot. During very early boot, when the SMP CPU manager is not ready yet, initialization safely falls back to the current bootstrap CPU to avoid startup-time panics.

### 2. Preserve correct affinity across process creation

`fork` / `clone` now copy the parent's affinity into the child so affinity state does not silently reset during task creation.

There is one special-case fix for bootstrapping: the bootstrap idle task (`pid 0`) may temporarily carry a per-CPU mask, but ordinary tasks created from that path must not inherit a CPU0-only default. The inheritance path is therefore cut for `pid 0`, while per-CPU idle semantics remain intact.

### 3. Add minimal `sched_setaffinity(2)` support

A new syscall handler is added for `sched_setaffinity(2)`.

Current behavior:

- rejects zero-sized buffers
- rejects empty masks
- rejects bits outside the kernel mask width
- rejects CPUs outside `possible_cpus`
- updates the target task's stored affinity mask
- does **not** force immediate migration in this PR

Permission checks for `sched_setaffinity` are implemented separately from the read-only scheduler query helpers so same-UID processes can update each other's affinity, matching expected Linux behavior.

### 4. Fix `sched_getaffinity(2)` semantics

`sched_getaffinity(2)` is changed to:

- resolve the target task by PID
- apply permission checks
- return the task's actual `cpus_allowed` mask
- return the number of bytes copied back to userspace

This fixes the previous behavior where the syscall returned the global CPU mask instead of task-local affinity, and also aligns the return value with userspace expectations.

### 5. Support per-CPU kernel thread setup

The PR also wires up the previously defined `IS_PER_CPU` kernel-thread flag so that per-CPU kthreads can receive a single-CPU affinity mask during creation.

This keeps default kthread behavior unchanged while making the existing per-CPU flag meaningful for future users.

### 6. Fix bitmap byte export used by affinity syscalls

While validating the syscall round-trip, this PR also fixes a bug in the bitmap crate: `as_bytes()` previously returned the size of the bitmap object rather than the size of the underlying bitmap payload.

This produced corrupted affinity masks when copying bitmap data to userspace. The implementation now returns the actual payload byte length, and a dedicated bitmap test was added to lock this behavior down.

## Tests

Added / updated tests include:

- bitmap unit test for exported bitmap byte layout
- dunitest coverage for:
  - set/get round-trip
  - `fork` inheritance
  - rejecting an empty affinity mask
  - child updating its own affinity
  - same-UID parent updating a child task's affinity

## Current limitations

- `sched_setaffinity` only updates the stored mask; it does not migrate a currently running task yet
- affinity defaults are based on the current `possible_cpus` snapshot rather than future CPU hotplug expansion
- this PR provides the prerequisite affinity state and syscall semantics for later initial CPU placement work; it does not implement placement policy itself
