### PR TITLE
exec: Align execve/execveat with Linux fd-path semantics and fix exec stack/vfork regressions

### DIFF
--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -140,6 +140,10 @@ impl DevFS {
             .expect("DevFS: Failed to create /dev/block");
         // 预创建 /dev/ptmx 符号链接指向 devpts 内部节点，避免早期 ENOENT
         let _ = root.add_dev_symlink("pts/ptmx", "ptmx");
+        // Linux 用户态会通过 /dev/fd/N[/path] 重新访问 fd 派生的可见路径。
+        // DragonOS 的真实对象解析能力在 /proc/self/fd，因此这里补兼容入口。
+        root.add_dev_symlink("/proc/self/fd", "fd")
+            .expect("DevFS: Failed to create /dev/fd");
         devfs.register_bultinin_device();
 
         // debug!("ls /dev: {:?}", root.list());

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -411,13 +411,43 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
 /// - `Ok((Arc<File>, i32))`: 成功打开的文件和分配的文件描述符
 /// - `Err(SystemError)`: 错误
 pub fn do_open_execat(dirfd: i32, path: &str) -> Result<Arc<File>, SystemError> {
-    let path = path.trim();
-    if path.is_empty() {
+    do_open_execat_with_flags(dirfd, path, AtFlags::empty())
+}
+
+/// 为 execve/execveat 打开可执行文件，保留 `AT_EMPTY_PATH` / `AT_SYMLINK_NOFOLLOW` 语义。
+pub fn do_open_execat_with_flags(
+    dirfd: i32,
+    path: &str,
+    flags: AtFlags,
+) -> Result<Arc<File>, SystemError> {
+    if flags.contains(!(AtFlags::AT_SYMLINK_NOFOLLOW | AtFlags::AT_EMPTY_PATH)) {
+        return Err(SystemError::EINVAL);
+    }
+
+    if path.is_empty() && !flags.contains(AtFlags::AT_EMPTY_PATH) {
         return Err(SystemError::ENOENT);
     }
 
-    let (inode_begin, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
-    let inode = inode_begin.lookup_follow_symlink(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+    let inode = if path.is_empty() {
+        ProcessManager::current_pcb()
+            .fd_table()
+            .read()
+            .get_file_by_fd(dirfd)
+            .ok_or(SystemError::EBADF)?
+            .inode()
+    } else {
+        let (inode_begin, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
+        if flags.contains(AtFlags::AT_SYMLINK_NOFOLLOW) {
+            let inode =
+                inode_begin.lookup_follow_symlink2(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES, false)?;
+            if inode.metadata()?.file_type == FileType::SymLink {
+                return Err(SystemError::ELOOP);
+            }
+            inode
+        } else {
+            inode_begin.lookup_follow_symlink(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?
+        }
+    };
 
     let metadata = inode.metadata()?;
     let file_type = metadata.file_type;

--- a/kernel/src/libs/elf.rs
+++ b/kernel/src/libs/elf.rs
@@ -5,7 +5,7 @@ use core::{
     ops::Range,
 };
 
-use alloc::vec::Vec;
+use alloc::{ffi::CString, vec::Vec};
 use elf::{
     abi::{ET_DYN, ET_EXEC, PT_GNU_PROPERTY, PT_INTERP, PT_LOAD},
     endian::AnyEndian,
@@ -29,7 +29,8 @@ use crate::{
     process::{
         abi::AtType,
         exec::{
-            BinaryLoader, BinaryLoaderResult, ExecError, ExecLoadMode, ExecParam, ExecParamFlags,
+            BinaryLoader, BinaryLoaderResult, ExecError, ExecInterpFlags, ExecLoadMode, ExecParam,
+            ExecParamFlags,
         },
         ProcessFlags, ProcessManager,
     },
@@ -920,6 +921,9 @@ impl BinaryLoader for ElfLoader {
                 interpreter_file,
                 param.vm().clone(),
                 ExecParamFlags::EXEC,
+                CString::new(interpreter_path).map_err(|_| ExecError::InvalidParemeter)?,
+                param.execfn().clone(),
+                ExecInterpFlags::empty(),
             ));
         }
         //TODO 缺少一部分逻辑 https://code.dragonos.org.cn/xref/linux-6.1.9/fs/binfmt_elf.c#931

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -62,11 +62,57 @@ pub enum LoadBinaryResult {
     Loaded(BinaryLoaderResult),
     /// 需要重新执行解释器 (shebang场景)
     NeedReexec {
-        /// 解释器文件（通过do_open_execat打开）
-        interpreter_file: Arc<File>,
+        /// 下一轮 exec 的启动信息
+        next: ExecStartInfo,
         /// 新的argv (解释器路径 + [可选参数] + 脚本路径 + 原始参数)
         new_argv: Vec<CString>,
     },
+}
+
+bitflags! {
+    pub struct ExecInterpFlags: u32 {
+        const PATH_INACCESSIBLE = 1 << 0;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecStartInfo {
+    file: Arc<File>,
+    filename: String,
+    execfn: String,
+    interp_flags: ExecInterpFlags,
+}
+
+impl ExecStartInfo {
+    pub fn new(
+        file: Arc<File>,
+        filename: String,
+        execfn: String,
+        interp_flags: ExecInterpFlags,
+    ) -> Self {
+        Self {
+            file,
+            filename,
+            execfn,
+            interp_flags,
+        }
+    }
+
+    pub fn file(&self) -> Arc<File> {
+        self.file.clone()
+    }
+
+    pub fn filename(&self) -> &str {
+        &self.filename
+    }
+
+    pub fn execfn(&self) -> &str {
+        &self.execfn
+    }
+
+    pub fn interp_flags(&self) -> ExecInterpFlags {
+        self.interp_flags
+    }
 }
 
 /// 执行上下文，用于跟踪递归执行状态
@@ -74,8 +120,6 @@ pub enum LoadBinaryResult {
 pub struct ExecContext {
     /// 当前递归深度
     pub recursion_depth: usize,
-    /// 原始脚本路径 (用于argv)
-    pub original_path: Option<String>,
 }
 
 impl Default for ExecContext {
@@ -86,10 +130,7 @@ impl Default for ExecContext {
 
 impl ExecContext {
     pub fn new() -> Self {
-        Self {
-            recursion_depth: 0,
-            original_path: None,
-        }
+        Self { recursion_depth: 0 }
     }
 
     /// 检查是否超过最大递归深度
@@ -159,6 +200,9 @@ pub struct ExecParam {
     vm: Arc<AddressSpace>,
     /// 一些标志位
     flags: ExecParamFlags,
+    filename: CString,
+    execfn: CString,
+    interp_flags: ExecInterpFlags,
     /// 用来初始化进程的一些信息。这些信息由二进制加载器和exec机制来共同填充
     init_info: ProcInitInfo,
 }
@@ -179,12 +223,24 @@ impl ExecParam {
     /// - `file`: 通过do_open_execat打开的可执行文件
     /// - `vm`: 地址空间
     /// - `flags`: 执行标志
-    pub fn new(file: Arc<File>, vm: Arc<AddressSpace>, flags: ExecParamFlags) -> Self {
+    pub fn new(
+        file: Arc<File>,
+        vm: Arc<AddressSpace>,
+        flags: ExecParamFlags,
+        filename: CString,
+        execfn: CString,
+        interp_flags: ExecInterpFlags,
+    ) -> Self {
+        let mut init_info = ProcInitInfo::new(execfn.to_string_lossy().as_ref());
+        init_info.execfn = Some(execfn.clone());
         Self {
             file,
             vm,
             flags,
-            init_info: ProcInitInfo::new(ProcessManager::current_pcb().basic().name()),
+            filename,
+            execfn,
+            interp_flags,
+            init_info,
         }
     }
 
@@ -220,6 +276,18 @@ impl ExecParam {
     /// 获取File的Arc引用
     pub fn file(&self) -> Arc<File> {
         self.file.clone()
+    }
+
+    pub fn filename(&self) -> &CString {
+        &self.filename
+    }
+
+    pub fn execfn(&self) -> &CString {
+        &self.execfn
+    }
+
+    pub fn interp_flags(&self) -> ExecInterpFlags {
+        self.interp_flags
     }
 
     /// 消费ExecParam并获取File的所有权（用于将文件加入文件描述符表）
@@ -460,6 +528,13 @@ pub fn load_binary_file_with_context(
         let shebang_info =
             ShebangLoader::parse_shebang_line(&head_buf).map_err(|_| SystemError::ENOEXEC)?;
 
+        if param
+            .interp_flags()
+            .contains(ExecInterpFlags::PATH_INACCESSIBLE)
+        {
+            return Err(SystemError::ENOENT);
+        }
+
         // 通过正常的open流程打开解释器文件
         let interpreter_file =
             do_open_execat(AtFlags::AT_FDCWD.bits(), &shebang_info.interpreter_path).inspect_err(
@@ -473,11 +548,7 @@ pub fn load_binary_file_with_context(
             )?;
 
         // 获取脚本路径
-        let script_path = param
-            .file_ref()
-            .inode()
-            .absolute_path()
-            .unwrap_or_else(|_| ctx.original_path.clone().unwrap_or_default());
+        let script_path = param.filename().to_string_lossy().into_owned();
 
         // 构建新的argv
         // Linux语义: [interpreter, optional_arg, script_path, original_args[1:]...]
@@ -503,7 +574,12 @@ pub fn load_binary_file_with_context(
         }
 
         return Ok(LoadBinaryResult::NeedReexec {
-            interpreter_file,
+            next: ExecStartInfo::new(
+                interpreter_file,
+                shebang_info.interpreter_path.clone(),
+                param.execfn().to_string_lossy().into_owned(),
+                ExecInterpFlags::empty(),
+            ),
             new_argv,
         });
     }
@@ -537,6 +613,7 @@ pub struct ProcInitInfo {
     pub args: Vec<CString>,
     pub envs: Vec<CString>,
     pub auxv: BTreeMap<u8, usize>,
+    pub execfn: Option<CString>,
     pub rand_num: [u8; 16],
 }
 
@@ -547,6 +624,7 @@ impl ProcInitInfo {
             args: Vec::new(),
             envs: Vec::new(),
             auxv: BTreeMap::new(),
+            execfn: None,
             rand_num: [0u8; 16],
         }
     }
@@ -589,10 +667,23 @@ impl ProcInitInfo {
         self.auxv
             .insert(super::abi::AtType::Random as u8, ustack.sp().data());
 
+        if let Some(execfn) = self.execfn.as_ref() {
+            self.push_str(ustack, execfn)?;
+            self.auxv
+                .insert(super::abi::AtType::ExecFn as u8, ustack.sp().data());
+        }
+
         // 实现栈的16字节对齐
-        // 用当前栈顶地址减去后续要压栈的长度，得到的压栈后的栈顶地址与0xF按位与操作得到对齐要填充的字节数
-        let length_to_push = (self.auxv.len() + envps.len() + 1 + argps.len() + 1 + 1)
-            * core::mem::align_of::<usize>();
+        // 后续要压入的内容都是 `usize` 宽度：
+        // - auxv 终止项: 2 words
+        // - auxv 条目: 2 words / entry
+        // - envp NULL: 1 word
+        // - envp 指针数组: envps.len() words
+        // - argv NULL: 1 word
+        // - argv 指针数组: argps.len() words
+        // - argc: 1 word
+        let length_to_push =
+            self.remaining_stack_words(envps.len(), argps.len()) * core::mem::size_of::<usize>();
         self.push_slice(
             ustack,
             &vec![0u8; (ustack.sp().data() - length_to_push) & 0xF],
@@ -617,6 +708,14 @@ impl ProcInitInfo {
         self.push_slice(ustack, &[self.args.len()])?;
 
         return Ok((ustack.sp(), argv_ptr));
+    }
+
+    fn remaining_stack_words(&self, envc: usize, argc: usize) -> usize {
+        let aux_words = 2 + self.auxv.len() * 2;
+        let env_words = 1 + envc;
+        let argv_words = 1 + argc;
+        let argc_words = 1;
+        aux_words + env_words + argv_words + argc_words
     }
 
     fn push_slice<T: Copy>(&self, ustack: &mut UserStack, slice: &[T]) -> Result<(), SystemError> {

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -1,18 +1,18 @@
 use crate::arch::CurrentIrqArch;
 use crate::exception::InterruptArch;
 use crate::filesystem::vfs::fcntl::AtFlags;
-use crate::filesystem::vfs::file::File;
-use crate::filesystem::vfs::open::do_open_execat;
+use crate::filesystem::vfs::open::{do_open_execat, do_open_execat_with_flags};
 use crate::libs::rwsem::RwSem;
 use crate::process::exec::{
-    load_binary_file_with_context, ExecContext, ExecParam, ExecParamFlags, LoadBinaryResult,
+    load_binary_file_with_context, ExecContext, ExecInterpFlags, ExecParam, ExecParamFlags,
+    ExecStartInfo, LoadBinaryResult,
 };
-use crate::process::ProcessManager;
+use crate::process::{ProcessControlBlock, ProcessManager};
 use crate::syscall::Syscall;
 use crate::{libs::rand::rand_bytes, mm::ucontext::AddressSpace};
 
 use crate::arch::interrupt::TrapFrame;
-use alloc::{ffi::CString, sync::Arc, vec::Vec};
+use alloc::{ffi::CString, string::String, sync::Arc, vec::Vec};
 use system_error::SystemError;
 
 /// 执行execve系统调用
@@ -31,16 +31,68 @@ pub fn do_execve(
     envp: Vec<CString>,
     regs: &mut TrapFrame,
 ) -> Result<(), SystemError> {
-    // 创建初始执行上下文
-    let mut ctx = ExecContext::new();
-
-    // 保存原始脚本路径（用于shebang场景）
-    ctx.original_path = Some(path.into());
-
-    // 通过正常的open流程打开文件
     let file = do_open_execat(AtFlags::AT_FDCWD.bits(), path)?;
+    let start = ExecStartInfo::new(file, path.into(), path.into(), ExecInterpFlags::empty());
 
-    do_execve_internal(file, argv, envp, regs, ctx)
+    do_execve_with_info(start, argv, envp, regs)
+}
+
+pub fn do_execveat(
+    dirfd: i32,
+    path: &str,
+    argv: Vec<CString>,
+    envp: Vec<CString>,
+    flags: AtFlags,
+    regs: &mut TrapFrame,
+) -> Result<(), SystemError> {
+    let file = do_open_execat_with_flags(dirfd, path, flags)?;
+    let start = ExecStartInfo::new(
+        file,
+        exec_visible_name(dirfd, path),
+        exec_initial_execfn(dirfd, path),
+        exec_path_interp_flags(dirfd, path),
+    );
+
+    do_execve_with_info(start, argv, envp, regs)
+}
+
+pub fn do_execve_with_info(
+    start: ExecStartInfo,
+    argv: Vec<CString>,
+    envp: Vec<CString>,
+    regs: &mut TrapFrame,
+) -> Result<(), SystemError> {
+    do_execve_internal(start, argv, envp, regs, ExecContext::new())
+}
+
+pub fn exec_visible_name(dirfd: i32, path: &str) -> String {
+    if dirfd == AtFlags::AT_FDCWD.bits() || path.starts_with('/') {
+        path.into()
+    } else if path.is_empty() {
+        alloc::format!("/dev/fd/{dirfd}")
+    } else {
+        alloc::format!("/dev/fd/{dirfd}/{path}")
+    }
+}
+
+pub fn exec_initial_execfn(dirfd: i32, path: &str) -> String {
+    exec_visible_name(dirfd, path)
+}
+
+fn exec_path_interp_flags(dirfd: i32, path: &str) -> ExecInterpFlags {
+    if dirfd == AtFlags::AT_FDCWD.bits() || path.starts_with('/') {
+        return ExecInterpFlags::empty();
+    }
+
+    let cloexec = ProcessManager::current_pcb()
+        .fd_table()
+        .read()
+        .get_cloexec(dirfd);
+    if cloexec {
+        ExecInterpFlags::PATH_INACCESSIBLE
+    } else {
+        ExecInterpFlags::empty()
+    }
 }
 
 /// execve的内部实现，支持递归执行（用于shebang）
@@ -53,7 +105,7 @@ pub fn do_execve(
 /// - `ctx`: 执行上下文，用于跟踪递归深度
 #[inline(never)]
 fn do_execve_internal(
-    file: Arc<File>,
+    start: ExecStartInfo,
     argv: Vec<CString>,
     envp: Vec<CString>,
     regs: &mut TrapFrame,
@@ -61,9 +113,14 @@ fn do_execve_internal(
 ) -> Result<(), SystemError> {
     let address_space = AddressSpace::new(true).expect("Failed to create new address space");
 
-    let mut param = ExecParam::new(file, address_space.clone(), ExecParamFlags::EXEC);
-
-    param.begin_new_exec().map_err(SystemError::from)?;
+    let mut param = ExecParam::new(
+        start.file(),
+        address_space.clone(),
+        ExecParamFlags::EXEC,
+        CString::new(start.filename()).map_err(|_| SystemError::EINVAL)?,
+        CString::new(start.execfn()).map_err(|_| SystemError::EINVAL)?,
+        start.interp_flags(),
+    );
 
     // 预先设置args，以便shebang处理时可以访问原始参数
     param.init_info_mut().args = argv.clone();
@@ -96,14 +153,7 @@ fn do_execve_internal(
             };
             address_space.write().user_stack = Some(ustack_message);
 
-            // execve 成功后，如果是 vfork 创建的子进程，需要通知父进程继续执行
-            // 在通知父进程之前，必须先清除 vfork_done，防止子进程退出时再次通知
             let pcb = ProcessManager::current_pcb();
-            let vfork_done = pcb.thread.write_irqsave().vfork_done.take();
-
-            if let Some(completion) = vfork_done {
-                completion.complete_all();
-            }
 
             // unshare fd_table if it's shared (CLONE_FILES case)
             // 参考 Linux: https://elixir.bootlin.com/linux/v6.1.9/source/fs/exec.c#L1857
@@ -121,6 +171,9 @@ fn do_execve_internal(
                 }
             }
 
+            // close-on-exec 必须属于成功 exec 的 commit 过程，不能留在 syscall wrapper 尾部。
+            pcb.fd_table().write().close_on_exec();
+
             if pcb.sighand().is_shared() {
                 // Linux出于进程和线程隔离，要确保在execve时，对共享的 SigHand 进行深拷贝
                 // 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/fs/exec.c#1187
@@ -135,13 +188,29 @@ fn do_execve_internal(
             // 清除 rseq 状态（execve 后需要重新注册）
             crate::process::rseq::rseq_execve(&pcb);
 
-            Syscall::arch_do_execve(regs, &param, &result, user_sp, argv_ptr)
+            let executable_path = param
+                .file_ref()
+                .inode()
+                .absolute_path()
+                .unwrap_or_else(|_| param.filename().to_string_lossy().into_owned());
+            pcb.basic_mut()
+                .set_name(ProcessControlBlock::generate_name(&executable_path));
+            pcb.set_execute_path(executable_path);
+            pcb.set_cmdline_from_argv(&param.init_info().args);
+
+            // vfork 父进程必须在 child 完成 exec commit 后再恢复。
+            // 否则父子仍可能共享 files_struct，child 的 close_on_exec() 会污染父进程。
+            let vfork_done = pcb.thread.write_irqsave().vfork_done.take();
+            let exec_ret = Syscall::arch_do_execve(regs, &param, &result, user_sp, argv_ptr);
+            if exec_ret.is_ok() {
+                if let Some(completion) = vfork_done {
+                    completion.complete_all();
+                }
+            }
+            exec_ret
         }
 
-        Ok(LoadBinaryResult::NeedReexec {
-            interpreter_file,
-            new_argv,
-        }) => {
+        Ok(LoadBinaryResult::NeedReexec { next, new_argv }) => {
             // Shebang场景：需要递归执行解释器
             // 恢复旧的地址空间
             if let Some(old_vm) = old_vm {
@@ -151,7 +220,7 @@ fn do_execve_internal(
             // 增加递归深度并递归调用
             let new_ctx = ctx.increment_depth();
 
-            do_execve_internal(interpreter_file, new_argv, envp, regs, new_ctx)
+            do_execve_internal(next, new_argv, envp, regs, new_ctx)
         }
 
         Err(e) => {

--- a/kernel/src/process/shebang.rs
+++ b/kernel/src/process/shebang.rs
@@ -82,7 +82,7 @@ impl ShebangLoader {
         // 5. 提取解释器路径 (到第一个空白字符)
         let interp_end = line
             .iter()
-            .position(|&c| c == b' ' || c == b'\t')
+            .position(|&c| c == b' ' || c == b'\t' || c == b'\0')
             .unwrap_or(line.len());
 
         let interpreter_path = core::str::from_utf8(&line[..interp_end])
@@ -101,13 +101,18 @@ impl ShebangLoader {
 
             if let Some(start) = arg_start {
                 let arg_line = &remaining[start..];
-                // 提取参数 (到下一个空白或行尾)
-                let arg_end = arg_line
+                // Linux/gVisor 语义：解释器路径后的其余内容是一个完整参数，内部空格需要保留。
+                let arg_line = &arg_line[..arg_line
                     .iter()
-                    .position(|&c| c == b' ' || c == b'\t')
-                    .unwrap_or(arg_line.len());
+                    .position(|&c| c == b'\0')
+                    .unwrap_or(arg_line.len())];
+                let arg_line = &arg_line[..arg_line
+                    .iter()
+                    .rposition(|&c| c != b' ' && c != b'\t')
+                    .map(|idx| idx + 1)
+                    .unwrap_or(0)];
 
-                let arg = core::str::from_utf8(&arg_line[..arg_end])
+                let arg = core::str::from_utf8(arg_line)
                     .map_err(|_| ExecError::ParseError)?
                     .to_string();
 

--- a/kernel/src/process/syscall/sys_execve.rs
+++ b/kernel/src/process/syscall/sys_execve.rs
@@ -7,7 +7,7 @@ use crate::filesystem::vfs::{MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES};
 use crate::mm::page::PAGE_4K_SIZE;
 use crate::mm::{access_ok, VirtAddr};
 use crate::process::execve::do_execve;
-use crate::process::{ProcessControlBlock, ProcessManager};
+use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::{check_and_clone_cstr_array, vfs_check_and_clone_cstr};
 use alloc::{ffi::CString, vec::Vec};
@@ -93,21 +93,7 @@ impl SysExecve {
         envp: Vec<CString>,
         frame: &mut TrapFrame,
     ) -> Result<(), SystemError> {
-        ProcessManager::current_pcb()
-            .basic_mut()
-            .set_name(ProcessControlBlock::generate_name(path));
-
-        // 仅在 execve 成功后再写入 cmdline，避免失败时污染当前进程信息
-        let argv_for_cmdline = argv.clone();
         do_execve(path, argv, envp, frame)?;
-
-        let pcb = ProcessManager::current_pcb();
-        // 关闭设置了O_CLOEXEC的文件描述符
-        let fd_table = pcb.fd_table();
-        fd_table.write().close_on_exec();
-
-        pcb.set_execute_path(path.to_string());
-        pcb.set_cmdline_from_argv(&argv_for_cmdline);
         Ok(())
     }
 }
@@ -140,12 +126,7 @@ impl Syscall for SysExecve {
             return Err(SystemError::ENOENT);
         }
 
-        // 获取解析符号链接后的绝对路径（用于set_execute_path）
-        let pwd = ProcessManager::current_pcb().pwd_inode();
-        let inode = pwd.lookup_follow_symlink(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
-        let resolved_path = inode.absolute_path().unwrap_or(path.clone());
-
-        Self::execve(&resolved_path, argv, envp, frame)?;
+        Self::execve(&path, argv, envp, frame)?;
         return Ok(0);
     }
 

--- a/kernel/src/process/syscall/sys_execveat.rs
+++ b/kernel/src/process/syscall/sys_execveat.rs
@@ -3,8 +3,8 @@ use system_error::SystemError;
 
 use crate::{
     arch::{interrupt::TrapFrame, syscall::nr::SYS_EXECVEAT},
-    filesystem::vfs::{utils::user_path_at, FileType, VFS_MAX_FOLLOW_SYMLINK_TIMES},
-    process::{syscall::sys_execve::SysExecve, ProcessManager},
+    filesystem::vfs::fcntl::AtFlags,
+    process::{execve::do_execveat, syscall::sys_execve::SysExecve},
     syscall::table::{FormattedSyscallParam, Syscall},
 };
 
@@ -48,52 +48,8 @@ impl Syscall for SysExecveAt {
             return Err(SystemError::ENOENT);
         }
 
-        let resolved_path = if flags.contains(OpenFlags::AT_EMPTY_PATH) && path.is_empty() {
-            let binding = ProcessManager::current_pcb().fd_table();
-            let fd_table_guard = binding.read();
-
-            let file = fd_table_guard
-                .get_file_by_fd(dirfd as _)
-                .ok_or(SystemError::EBADF)?;
-
-            // 无法执行目录
-            if file.file_type() == FileType::Dir {
-                return Err(SystemError::EACCES);
-            }
-
-            // 获取文件的绝对路径
-            file.inode()
-                .absolute_path()
-                .map_err(|_| SystemError::ENOENT)?
-        } else {
-            let (inode_begin, path) =
-                user_path_at(&ProcessManager::current_pcb(), dirfd as _, &path)?;
-
-            let inode = if flags.contains(OpenFlags::AT_SYMLINK_NOFOLLOW) {
-                // AT_SYMLINK_NOFOLLOW: 不跟随最终的符号链接
-                // 使用 lookup_follow_symlink2 以便控制 follow_final_symlink 参数
-                let result_inode = inode_begin.lookup_follow_symlink2(
-                    &path,
-                    VFS_MAX_FOLLOW_SYMLINK_TIMES,
-                    false, // 不跟随最终符号链接
-                )?;
-
-                // Linux 语义：如果最终路径是符号链接且设置了 AT_SYMLINK_NOFOLLOW，返回 ELOOP
-                if result_inode.metadata()?.file_type == FileType::SymLink {
-                    return Err(SystemError::ELOOP);
-                }
-
-                result_inode
-            } else {
-                // AT_SYMLINK_NOFOLLOW 未设置：跟随所有符号链接
-                inode_begin.lookup_follow_symlink(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?
-            };
-
-            // 获取解析后的绝对路径
-            inode.absolute_path().unwrap_or(path)
-        };
-
-        SysExecve::execve(&resolved_path, argv, envp, frame)?;
+        let at_flags = AtFlags::from_bits(flags.bits() as i32).ok_or(SystemError::EINVAL)?;
+        do_execveat(dirfd as i32, &path, argv, envp, at_flags, frame)?;
 
         Ok(0)
     }


### PR DESCRIPTION




## Summary

This change reworks DragonOS exec input handling to preserve Linux-compatible `execveat` semantics, especially for fd-based execution and shebang scripts, and fixes two regressions discovered during boot validation:

- preserve fd-derived visible filenames such as `/dev/fd/<fd>` and `/dev/fd/<fd>/<path>`
- honor `AT_EMPTY_PATH` and `AT_SYMLINK_NOFOLLOW` in the exec open path
- return `ENOENT` for shebang `execveat(..., AT_EMPTY_PATH)` when the script path becomes inaccessible after `FD_CLOEXEC`
- keep `AT_EXECFN` and shebang script argv path aligned with the user-visible exec path instead of inode absolute paths
- fix shebang optional-arg parsing to match Linux/gVisor behavior
- move `close_on_exec()` into the real exec commit path
- add `/dev/fd -> /proc/self/fd` so fd-based visible names can actually be reopened in DragonOS
- fix exec user stack initialization and `vfork` completion timing regressions introduced during the refactor

## Problem

DragonOS previously flattened `execveat` inputs into absolute paths too early, which lost the distinction between:

- the opened executable file
- the user-visible filename used by shebang, `AT_EXECFN`, and fd-based exec flows

That caused Linux semantic mismatches in gVisor tests, especially for:

- `execveat(fd, "", ..., AT_EMPTY_PATH)`
- shebang scripts executed through `execveat`
- `FD_CLOEXEC` interactions
- relative `execveat(dirfd, "path", ...)`

During follow-up validation, boot-time execution of `busybox sh /etc/init.d/rcS` exposed two additional regressions introduced by the refactor:

- the new exec stack setup undercounted auxv stack words after adding `AT_EXECFN`, corrupting initial user stack layout
- `vfork` parents could resume before the child finished exec commit, allowing `close_on_exec()` to run against a shared file table

## Root Cause

1. `sys_execveat` resolved fd-based execution to absolute paths before entering the exec engine, so DragonOS lost Linux's fd-derived visible filename semantics.
2. shebang recursion used inode absolute paths instead of the visible filename carried through exec.
3. DragonOS exposed `/proc/self/fd/*` magic links but did not provide the `/dev/fd` compatibility path expected by Linux user space.
4. exec pathname handling incorrectly trimmed user input in the exec open helper.
5. after adding `AT_EXECFN`, exec stack alignment logic still assumed the old auxv layout.
6. `vfork_done` completion was issued before exec commit had fully isolated the child from the parent's shared file table.

## Solution

### Exec semantic alignment

- add `do_open_execat_with_flags()` to preserve `AT_EMPTY_PATH` and `AT_SYMLINK_NOFOLLOW` behavior in the exec open path
- route `execveat` directly into a dedicated exec path instead of converting to an absolute pathname in the syscall layer
- introduce `ExecStartInfo` and `ExecInterpFlags` so the exec engine can explicitly carry:
  - opened file
  - visible filename
  - original execfn
  - path-inaccessible state
- use the visible filename for shebang recursion
- return `ENOENT` before invoking the interpreter when `PATH_INACCESSIBLE` is set
- propagate `AT_EXECFN` through `ProcInitInfo`
- parse shebang optional arguments as one full trailing argument, matching Linux/gVisor

### Runtime compatibility fixes

- add `/dev/fd -> /proc/self/fd` during devfs initialization so `/dev/fd/N[/path]` works as a reopen path in DragonOS
- stop trimming exec pathnames in the exec open helper
- initialize `ProcInitInfo.proc_name` from the new exec path instead of the old process name
- recompute user stack alignment from the real auxv/envp/argv layout after adding `AT_EXECFN`
- delay `vfork_done` completion until exec commit has succeeded
