### PR TITLE
feat(sysfs): implement group_remove_files to complete attribute group removal

### DIFF
--- a/kernel/src/filesystem/sysfs/dir.rs
+++ b/kernel/src/filesystem/sysfs/dir.rs
@@ -120,8 +120,7 @@ impl SysFS {
         kobj.set_inode(None);
 
         if let Some(inode) = kobj_inode {
-            let parent = inode.parent().unwrap();
-            parent.remove_recursive()
+            inode.remove_inode_include_self()
         }
     }
 }

--- a/kernel/src/filesystem/sysfs/group.rs
+++ b/kernel/src/filesystem/sysfs/group.rs
@@ -214,7 +214,18 @@ impl SysFS {
         return Ok(());
     }
 
-    fn group_remove_files(&self, _parent: &Arc<KernFSInode>, _group: &'static dyn AttributeGroup) {
-        todo!("group_remove_files")
+    fn group_remove_files(&self, parent: &Arc<KernFSInode>, group: &'static dyn AttributeGroup) {
+        // visibility的正确性需要依赖is_visible的实现，为保证文件被彻底删除，这里跳过了对visibility的判断
+        for attr in group.attrs() {
+            if let Err(e) = parent.remove(attr.name()) {
+                if e != SystemError::ENOENT {
+                    warn!(
+                        "sysfs failed to remove attr '{}' in group '{}': {e:?}",
+                        attr.name(),
+                        group.name().unwrap_or("")
+                    );
+                }
+            }
+        }
     }
 }

--- a/kernel/src/filesystem/sysfs/group.rs
+++ b/kernel/src/filesystem/sysfs/group.rs
@@ -97,7 +97,7 @@ impl SysFS {
 
         if let Err(e) = self.group_create_files(parent_inode.clone(), kobj, group, update) {
             if group.name().is_some() {
-                parent_inode.remove_recursive();
+                parent_inode.remove_inode_include_self();
             }
             return Err(e);
         }
@@ -148,7 +148,7 @@ impl SysFS {
         self.group_remove_files(&parent_inode, group);
 
         if group.name().is_some() {
-            parent_inode.remove_recursive();
+            parent_inode.remove_inode_include_self();
         }
 
         return Ok(());


### PR DESCRIPTION
Fixed #1835

This PR implement the group_remove_files function, complete sysfs attribute group removal, and fix attribute group lifecycle management issues.

## Main Changes

- Implemented the removal logic for each attribute file in the attribute group
  - skipped to check the visibility of attribute file to ensure proper removal

- Fix the removal logic in `remove_dir(&self, kobj: &Arc<dyn KObject>)` and `kernel/src/filesystem/sysfs/group.rs` to avoid accidental removal and directory leak

- About dunitest: due to unimpletement of init_module syscall, user-space test is not added in this PR
