### PR TITLE
fix(net/tcp): fix close abort semantics and add dunitest coverage

### DIFF
--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -8,7 +8,162 @@ use super::inner;
 use super::poll_util;
 use super::TcpSocket;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CloseObservation {
+    state: smoltcp::socket::tcp::State,
+    unread: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EstablishedCloseDisposition {
+    Abort,
+    GracefulPendingDecision,
+    PreserveGracefulState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EstablishedCloseStateClass {
+    PendingDecision,
+    GracefulInProgress,
+    Closed,
+}
+
 impl TcpSocket {
+    #[inline]
+    fn observe_established_close(established: &inner::Established) -> CloseObservation {
+        established.with(|socket| CloseObservation {
+            state: socket.state(),
+            unread: socket.recv_queue(),
+        })
+    }
+
+    fn decide_established_close(
+        &self,
+        established: &inner::Established,
+    ) -> EstablishedCloseDisposition {
+        let initial = Self::observe_established_close(established);
+
+        if initial.unread > 0 {
+            return EstablishedCloseDisposition::Abort;
+        }
+
+        if self.should_abort_established_zero_linger(initial.state) {
+            return EstablishedCloseDisposition::Abort;
+        }
+
+        if matches!(
+            Self::classify_established_close_state(initial.state),
+            EstablishedCloseStateClass::GracefulInProgress | EstablishedCloseStateClass::Closed
+        ) {
+            return EstablishedCloseDisposition::PreserveGracefulState;
+        }
+
+        // Linux `__tcp_close()` decides between FIN and active reset based on whether unread
+        // data is discarded. DragonOS loopback can race with in-flight protocol progress around
+        // close time, so a single `recv_queue()` snapshot is too weak. Require two consecutive
+        // identical zero-unread observations after quiescent polls; otherwise fall back to abort.
+        // Only apply this when `close(fd)` is still deciding whether to initiate graceful close
+        // or abort. If the socket is already in graceful-closing states, preserve that path.
+        let iface = established.iface().clone();
+        let mut last: Option<CloseObservation> = Some(initial);
+        let mut stable_zero_observations = 0usize;
+        const MAX_CLOSE_SAMPLING_ROUNDS: usize = 4;
+
+        for round in 0..MAX_CLOSE_SAMPLING_ROUNDS {
+            if let Some(netns) = iface.common().net_namespace() {
+                netns.wakeup_poll_thread();
+            }
+            poll_util::poll_iface_until_quiescent(iface.as_ref());
+
+            let observation = Self::observe_established_close(established);
+            if observation.unread > 0 {
+                return EstablishedCloseDisposition::Abort;
+            }
+
+            if self.should_abort_established_zero_linger(observation.state) {
+                return EstablishedCloseDisposition::Abort;
+            }
+
+            match Self::classify_established_close_state(observation.state) {
+                EstablishedCloseStateClass::GracefulInProgress
+                | EstablishedCloseStateClass::Closed => {
+                    return EstablishedCloseDisposition::PreserveGracefulState;
+                }
+                EstablishedCloseStateClass::PendingDecision => {}
+            }
+
+            if last == Some(observation) {
+                stable_zero_observations += 1;
+                if stable_zero_observations >= 1 {
+                    return EstablishedCloseDisposition::GracefulPendingDecision;
+                }
+            } else {
+                stable_zero_observations = 0;
+            }
+            last = Some(observation);
+
+            if round + 1 < MAX_CLOSE_SAMPLING_ROUNDS {
+                crate::sched::sched_yield();
+            }
+        }
+
+        EstablishedCloseDisposition::Abort
+    }
+
+    #[inline]
+    fn is_zero_linger_close(&self) -> bool {
+        self.linger_onoff()
+            .load(core::sync::atomic::Ordering::Relaxed)
+            != 0
+            && self
+                .linger_linger()
+                .load(core::sync::atomic::Ordering::Relaxed)
+                == 0
+    }
+
+    #[inline]
+    fn should_abort_established_zero_linger(&self, state: smoltcp::socket::tcp::State) -> bool {
+        if !self.is_zero_linger_close() {
+            return false;
+        }
+
+        matches!(
+            state,
+            smoltcp::socket::tcp::State::SynReceived
+                | smoltcp::socket::tcp::State::Established
+                | smoltcp::socket::tcp::State::CloseWait
+                | smoltcp::socket::tcp::State::FinWait1
+                | smoltcp::socket::tcp::State::FinWait2
+        )
+    }
+
+    #[inline]
+    fn classify_established_close_state(
+        state: smoltcp::socket::tcp::State,
+    ) -> EstablishedCloseStateClass {
+        match state {
+            smoltcp::socket::tcp::State::FinWait1
+            | smoltcp::socket::tcp::State::FinWait2
+            | smoltcp::socket::tcp::State::Closing
+            | smoltcp::socket::tcp::State::LastAck
+            | smoltcp::socket::tcp::State::TimeWait => {
+                EstablishedCloseStateClass::GracefulInProgress
+            }
+            smoltcp::socket::tcp::State::Closed => EstablishedCloseStateClass::Closed,
+            smoltcp::socket::tcp::State::SynReceived
+            | smoltcp::socket::tcp::State::Established
+            | smoltcp::socket::tcp::State::CloseWait => EstablishedCloseStateClass::PendingDecision,
+            unexpected => {
+                debug_assert!(
+                    false,
+                    "unexpected established close state: {:?}",
+                    unexpected
+                );
+                EstablishedCloseStateClass::PendingDecision
+            }
+        }
+    }
+
     pub fn do_bind(&self, local_endpoint: smoltcp::wire::IpEndpoint) -> Result<(), SystemError> {
         let mut writer = self.inner.write();
         match writer.take().expect("Tcp inner::Inner is None") {
@@ -526,19 +681,22 @@ impl TcpSocket {
                 let local_port = es.get_name().port;
                 let iface = es.iface().clone();
                 let me: alloc::sync::Weak<dyn InetSocket> = self.self_ref.clone();
-                let linger_abort = self
-                    .linger_onoff()
-                    .load(core::sync::atomic::Ordering::Relaxed)
-                    != 0
-                    && self
-                        .linger_linger()
-                        .load(core::sync::atomic::Ordering::Relaxed)
-                        == 0;
-                let unread = es.with(|socket| socket.recv_queue());
-                if linger_abort || unread > 0 {
-                    es.with_mut(|socket| socket.abort());
-                } else {
-                    es.with_mut(|socket| socket.close());
+                let close_disposition = self.decide_established_close(&es);
+                match close_disposition {
+                    EstablishedCloseDisposition::Abort => {
+                        es.with_mut(|socket| socket.abort());
+                    }
+                    EstablishedCloseDisposition::GracefulPendingDecision
+                    | EstablishedCloseDisposition::PreserveGracefulState => {
+                        let final_observation = Self::observe_established_close(&es);
+                        if final_observation.unread > 0
+                            || self.should_abort_established_zero_linger(final_observation.state)
+                        {
+                            es.with_mut(|socket| socket.abort());
+                        } else {
+                            es.with_mut(|socket| socket.close());
+                        }
+                    }
                 }
                 if es.owns_port() {
                     iface.port_manager().unbind_port(Types::Tcp, local_port);

--- a/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
@@ -1,0 +1,307 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace {
+
+class FdGuard {
+  public:
+    FdGuard() = default;
+    explicit FdGuard(int fd) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+
+    FdGuard(FdGuard&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+
+    FdGuard& operator=(FdGuard&& other) noexcept {
+        if (this != &other) {
+            Reset();
+            fd_ = other.fd_;
+            other.fd_ = -1;
+        }
+        return *this;
+    }
+
+    ~FdGuard() { Reset(); }
+
+    int Get() const { return fd_; }
+
+    int Release() {
+        int fd = fd_;
+        fd_ = -1;
+        return fd;
+    }
+
+    void Reset(int fd = -1) {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        fd_ = fd;
+    }
+
+  private:
+    int fd_ = -1;
+};
+
+struct TcpPair {
+    FdGuard listen_fd;
+    FdGuard client_fd;
+    FdGuard server_fd;
+};
+
+std::string ErrnoString(int err) {
+    return std::to_string(err) + " (" + std::strerror(err) + ")";
+}
+
+bool InitTcpPair(TcpPair* pair) {
+    pair->listen_fd.Reset();
+    pair->client_fd.Reset();
+    pair->server_fd.Reset();
+
+    int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        ADD_FAILURE() << "socket(listen) failed: " << ErrnoString(errno);
+        return false;
+    }
+    pair->listen_fd.Reset(listen_fd);
+
+    int reuse = 1;
+    if (setsockopt(pair->listen_fd.Get(), SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0) {
+        ADD_FAILURE() << "setsockopt(SO_REUSEADDR) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    sockaddr_in addr {};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(0);
+
+    if (bind(pair->listen_fd.Get(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ADD_FAILURE() << "bind(listen) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    socklen_t addr_len = sizeof(addr);
+    if (getsockname(pair->listen_fd.Get(), reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+        ADD_FAILURE() << "getsockname(listen) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    if (listen(pair->listen_fd.Get(), 1) != 0) {
+        ADD_FAILURE() << "listen failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    int client_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (client_fd < 0) {
+        ADD_FAILURE() << "socket(client) failed: " << ErrnoString(errno);
+        return false;
+    }
+    pair->client_fd.Reset(client_fd);
+
+    if (connect(pair->client_fd.Get(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ADD_FAILURE() << "connect failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    int server_fd = accept(pair->listen_fd.Get(), nullptr, nullptr);
+    if (server_fd < 0) {
+        ADD_FAILURE() << "accept failed: " << ErrnoString(errno);
+        return false;
+    }
+    pair->server_fd.Reset(server_fd);
+
+    return true;
+}
+
+void ExpectPeerEofAfterShutdownWr(int fd) {
+    char byte = '\0';
+    errno = 0;
+    const ssize_t n = recv(fd, &byte, sizeof(byte), 0);
+    const int saved_errno = errno;
+    ASSERT_GE(n, 0) << "recv failed: " << ErrnoString(saved_errno);
+    ASSERT_EQ(0, n) << "expected EOF after SHUT_WR, got " << n;
+}
+
+struct WriteResult {
+    ssize_t first_ret = -1;
+    int first_errno = 0;
+    ssize_t second_ret = -1;
+    int second_errno = 0;
+};
+
+struct WriterArgs {
+    int fd = -1;
+    size_t len = 0;
+    WriteResult* result = nullptr;
+};
+
+void* WriterThread(void* arg) {
+    auto* args = reinterpret_cast<WriterArgs*>(arg);
+    char* buf = static_cast<char*>(std::malloc(args->len));
+    if (buf == nullptr) {
+        return nullptr;
+    }
+    std::memset(buf, 'a', args->len);
+
+    errno = 0;
+    args->result->first_ret = write(args->fd, buf, args->len);
+    args->result->first_errno = errno;
+
+    errno = 0;
+    args->result->second_ret = write(args->fd, buf, args->len);
+    args->result->second_errno = errno;
+
+    std::free(buf);
+    return nullptr;
+}
+
+TEST(TcpCloseSemantics, BlockPartialWriteClosedReturnsReset) {
+    signal(SIGPIPE, SIG_IGN);
+    TcpPair pair;
+    ASSERT_TRUE(InitTcpPair(&pair));
+
+    int sndbuf_req = INT_MAX;
+    ASSERT_EQ(0,
+              setsockopt(
+                  pair.client_fd.Get(), SOL_SOCKET, SO_SNDBUF, &sndbuf_req, sizeof(sndbuf_req)))
+        << "setsockopt(SO_SNDBUF) failed: " << ErrnoString(errno);
+
+    int actual_sndbuf = 0;
+    socklen_t optlen = sizeof(actual_sndbuf);
+    ASSERT_EQ(0,
+              getsockopt(
+                  pair.client_fd.Get(), SOL_SOCKET, SO_SNDBUF, &actual_sndbuf, &optlen))
+        << "getsockopt(SO_SNDBUF) failed: " << ErrnoString(errno);
+    ASSERT_GT(actual_sndbuf, 0);
+
+    WriteResult result {};
+    WriterArgs args {
+        .fd = pair.client_fd.Get(),
+        .len = static_cast<size_t>(actual_sndbuf) * 2,
+        .result = &result,
+    };
+
+    pthread_t writer {};
+    ASSERT_EQ(0, pthread_create(&writer, nullptr, WriterThread, &args))
+        << "pthread_create failed: " << ErrnoString(errno);
+
+    sleep(1);
+
+    pair.server_fd.Reset();
+
+    ASSERT_EQ(0, pthread_join(writer, nullptr))
+        << "pthread_join failed: " << ErrnoString(errno);
+
+    EXPECT_GT(result.first_ret, 0) << "first write should partially succeed";
+    EXPECT_EQ(-1, result.second_ret) << "second write should fail";
+    EXPECT_TRUE(result.second_errno == EPIPE || result.second_errno == ECONNRESET)
+        << "expected EPIPE/ECONNRESET, got " << ErrnoString(result.second_errno);
+}
+
+TEST(TcpCloseSemantics, ShutdownWrThenClosePreservesGracefulClose) {
+    signal(SIGPIPE, SIG_IGN);
+    TcpPair pair;
+    ASSERT_TRUE(InitTcpPair(&pair));
+
+    ASSERT_EQ(0, shutdown(pair.client_fd.Get(), SHUT_WR))
+        << "shutdown(SHUT_WR) failed: " << ErrnoString(errno);
+    ExpectPeerEofAfterShutdownWr(pair.server_fd.Get());
+
+    sleep(1);
+
+    pair.client_fd.Reset();
+
+    sleep(1);
+
+    char byte = 'x';
+    errno = 0;
+    const ssize_t wr = send(pair.server_fd.Get(), &byte, sizeof(byte), 0);
+    EXPECT_EQ(static_cast<ssize_t>(sizeof(byte)), wr)
+        << "send after peer graceful close failed: " << ErrnoString(errno);
+}
+
+TEST(TcpCloseSemantics, ShutdownWrThenZeroLingerCloseAborts) {
+    signal(SIGPIPE, SIG_IGN);
+    TcpPair pair;
+    ASSERT_TRUE(InitTcpPair(&pair));
+
+    linger linger_opt {
+        .l_onoff = 1,
+        .l_linger = 0,
+    };
+    ASSERT_EQ(0,
+              setsockopt(pair.client_fd.Get(),
+                         SOL_SOCKET,
+                         SO_LINGER,
+                         &linger_opt,
+                         sizeof(linger_opt)))
+        << "setsockopt(SO_LINGER) failed: " << ErrnoString(errno);
+
+    ASSERT_EQ(0, shutdown(pair.client_fd.Get(), SHUT_WR))
+        << "shutdown(SHUT_WR) failed: " << ErrnoString(errno);
+    ExpectPeerEofAfterShutdownWr(pair.server_fd.Get());
+
+    sleep(1);
+
+    pair.client_fd.Reset();
+
+    sleep(1);
+
+    char byte = 'z';
+    errno = 0;
+    const ssize_t wr = send(pair.server_fd.Get(), &byte, sizeof(byte), 0);
+    const int saved_errno = errno;
+    EXPECT_EQ(-1, wr) << "zero-linger close should abort the peer";
+    EXPECT_TRUE(saved_errno == EPIPE || saved_errno == ECONNRESET)
+        << "expected EPIPE/ECONNRESET, got " << ErrnoString(saved_errno);
+}
+
+TEST(TcpCloseSemantics, ShutdownWrThenUnreadDataCloseAborts) {
+    signal(SIGPIPE, SIG_IGN);
+    TcpPair pair;
+    ASSERT_TRUE(InitTcpPair(&pair));
+
+    ASSERT_EQ(0, shutdown(pair.client_fd.Get(), SHUT_WR))
+        << "shutdown(SHUT_WR) failed: " << ErrnoString(errno);
+    ExpectPeerEofAfterShutdownWr(pair.server_fd.Get());
+
+    char byte = 'a';
+    errno = 0;
+    const ssize_t first_send = send(pair.server_fd.Get(), &byte, sizeof(byte), 0);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(byte)), first_send)
+        << "first send before peer close failed: " << ErrnoString(errno);
+
+    sleep(1);
+
+    pair.client_fd.Reset();
+
+    sleep(1);
+
+    byte = 'b';
+    errno = 0;
+    const ssize_t second_send = send(pair.server_fd.Get(), &byte, sizeof(byte), 0);
+    const int saved_errno = errno;
+    EXPECT_EQ(-1, second_send) << "peer close with unread data should abort";
+    EXPECT_TRUE(saved_errno == EPIPE || saved_errno == ECONNRESET)
+        << "expected EPIPE/ECONNRESET, got " << ErrnoString(saved_errno);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -8,8 +8,9 @@ normal/devpts_dir_read
 normal/test_pivot_root
 normal/test_mount_reconfigure
 normal/proc_self_limits
+normal/sched_affinity
 normal/test_tlb_shootdown
+normal/tcp_close_semantics
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
-normal/sched_affinity


### PR DESCRIPTION
Align DragonOS TCP close(fd) behavior with Linux for established sockets.

- add bounded close-time observation for established sockets so close() can distinguish between graceful close-in-progress and cases that must abort
- preserve abort semantics when unread data exists at close time
- preserve zero-linger abort semantics for FIN_WAIT1/FIN_WAIT2 as well as established-style states
- recheck final close-time state before choosing abort vs close to avoid losing late-arriving unread data
- add dunitest coverage for block-partial-write reset, graceful half-close, zero-linger abort, and unread-data abort paths

This fixes the DragonOS side close semantics needed by the flaky gVisor BlockingTCPSockets BlockPartialWriteClosed coverage while keeping Linux-like TCP behavior for half-close and SO_LINGER edge cases.