### PR TITLE
fix: correct fcntl signal owner handling

### DIFF
--- a/kernel/src/filesystem/vfs/fcntl.rs
+++ b/kernel/src/filesystem/vfs/fcntl.rs
@@ -23,10 +23,14 @@ pub enum FcntlCommand {
     SetLock = 6,
     /// set record locking info (blocking)
     SetLockWait = 7,
-    /// set owner
+        /// set owner
     SetOwn = 8,
     /// get owner
     GetOwn = 9,
+    /// set signal to send on asynchronous I/O (0 means SIGIO)
+    SetSig = 10,
+    /// get signal to send on asynchronous I/O (0 means SIGIO)
+    GetSig = 11,
 
     SetLease = F_LINUX_SPECIFIC_BASE,
     GetLease = F_LINUX_SPECIFIC_BASE + 1,

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1,6 +1,6 @@
 use core::{
     fmt,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicI32, AtomicUsize, Ordering},
 };
 
 use alloc::{string::String, sync::Arc, vec::Vec};
@@ -428,6 +428,11 @@ pub struct File {
     posix_lock_key: (usize, InodeId),
     /// 预读状态
     ra_state: Mutex<FileReadaheadState>,
+        /// 预读状态
+    ra_state: Mutex<FileReadaheadState>,
+    /// 异步 I/O 通知信号编号（F_SETSIG/F_GETSIG）。
+    /// 0 表示默认 SIGIO；范围 [0, SIGRTMAX]。
+    fasync_signum: AtomicI32,
 }
 
 impl File {
@@ -652,6 +657,7 @@ impl File {
             pid: Mutex::new(None),
             posix_lock_key,
             ra_state: Mutex::new(FileReadaheadState::new()),
+            fasync_signum: AtomicI32::new(0),
         };
 
         return Ok(f);
@@ -1181,6 +1187,7 @@ impl File {
             pid: Mutex::new(None),
             posix_lock_key: self.posix_lock_key,
             ra_state: Mutex::new(self.ra_state.lock().clone()),
+            fasync_signum: AtomicI32::new(self.fasync_signum.load(Ordering::Relaxed)),
         };
         // 调用inode的open方法，让inode知道有新的文件打开了这个inode
         // TODO: reopen is not a good idea for some inodes, need a better design
@@ -1378,7 +1385,21 @@ impl File {
         // todo: update inode owner
         Ok(())
     }
+        /// 获取异步 I/O 通知信号编号（F_GETSIG）。
+    ///
+    /// 返回 `0` 表示尚未设置，应默认为 `SIGIO`。
+    #[inline]
+    pub fn fasync_signum(&self) -> i32 {
+        self.fasync_signum.load(Ordering::Relaxed)
+    }
 
+    /// 设置异步 I/O 通知信号编号（F_SETSIG）。
+    ///
+    /// 调用方负责校验 `signum` 的合法性（`[0, SIGRTMAX]`）。
+    #[inline]
+    pub fn set_fasync_signum(&self, signum: i32) {
+        self.fasync_signum.store(signum, Ordering::Relaxed);
+    }
     pub fn get_inode_flags(&self) -> Result<InodeFlags, SystemError> {
         let metadata = self.inode.metadata()?;
         Ok(metadata.flags)

--- a/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
@@ -1,3 +1,4 @@
+use crate::arch::ipc::signal::Signal;
 use crate::arch::syscall::nr::SYS_FCNTL;
 use crate::filesystem::vfs::FileType;
 use crate::filesystem::vfs::InodeFlags;
@@ -284,6 +285,32 @@ impl SysFcntlHandle {
                 let owner = file.owner().unwrap_or(RawPid::from(0));
 
                 return Ok(owner.data());
+            }
+            FcntlCommand::SetSig => {
+                // F_SETSIG: 设置异步 I/O 通知信号。
+                // arg == 0 表示使用默认 SIGIO。Linux 6.6 在 fs/fcntl.c 中对原始
+                // `unsigned long arg` 调用 `valid_signal`（即 `arg <= _NSIG`），
+                // 所以这里也必须在未截断的 `usize` 上做上界比较，避免 64 位
+                // 值低 32 位恰好落入 [0, SIGRTMAX] 时被错误接受。
+                if arg > Signal::SIGRTMAX as usize {
+                    return Err(SystemError::EINVAL);
+                }
+                let binding = ProcessManager::current_pcb().fd_table();
+                let file = binding
+                    .read()
+                    .get_file_by_fd(fd)
+                    .ok_or(SystemError::EBADF)?;
+                file.set_fasync_signum(arg as i32);
+                return Ok(0);
+            }
+            FcntlCommand::GetSig => {
+                // F_GETSIG: 获取异步 I/O 通知信号；0 表示默认 SIGIO。
+                let binding = ProcessManager::current_pcb().fd_table();
+                let file = binding
+                    .read()
+                    .get_file_by_fd(fd)
+                    .ok_or(SystemError::EBADF)?;
+                return Ok(file.fasync_signum() as usize);
             }
             FcntlCommand::GetPipeSize => {
                 // F_GETPIPE_SZ: 获取管道缓冲区大小

--- a/user/apps/tests/dunitest/suites/normal/fcntl_signal.cc
+++ b/user/apps/tests/dunitest/suites/normal/fcntl_signal.cc
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+namespace {
+
+// Linux kernel definition: __SIGRTMAX is 64. Keep a local constant so this
+// test does not rely on the libc SIGRTMAX macro (which is typically 64 but
+// exposed as an adjusted value by glibc).
+constexpr int kKernelSigrtmax = 64;
+
+int fd_pair() {
+    int fds[2] = {-1, -1};
+    if (pipe(fds) != 0) {
+        return -1;
+    }
+    close(fds[1]);
+    return fds[0];
+}
+
+}  // namespace
+
+// 默认值应为 0，表示使用 SIGIO。
+TEST(FcntlSignal, GetSigDefaultsToZero) {
+    int fd = fd_pair();
+    ASSERT_GE(fd, 0);
+
+    int sig = fcntl(fd, F_GETSIG);
+    EXPECT_EQ(0, sig) << "errno=" << errno << " (" << strerror(errno) << ")";
+
+    close(fd);
+}
+
+// F_SETSIG 后 F_GETSIG 应返回同一值。
+TEST(FcntlSignal, SetSigThenGetSigRoundTrip) {
+    int fd = fd_pair();
+    ASSERT_GE(fd, 0);
+
+    ASSERT_EQ(0, fcntl(fd, F_SETSIG, SIGUSR1));
+    EXPECT_EQ(SIGUSR1, fcntl(fd, F_GETSIG));
+
+    ASSERT_EQ(0, fcntl(fd, F_SETSIG, SIGUSR2));
+    EXPECT_EQ(SIGUSR2, fcntl(fd, F_GETSIG));
+
+    // 0 表示恢复默认 SIGIO。
+    ASSERT_EQ(0, fcntl(fd, F_SETSIG, 0));
+    EXPECT_EQ(0, fcntl(fd, F_GETSIG));
+
+    close(fd);
+}
+
+// 边界：SIGRTMAX 必须被接受。
+TEST(FcntlSignal, SetSigAcceptsSigrtmaxBoundary) {
+    int fd = fd_pair();
+    ASSERT_GE(fd, 0);
+
+    ASSERT_EQ(0, fcntl(fd, F_SETSIG, kKernelSigrtmax));
+    EXPECT_EQ(kKernelSigrtmax, fcntl(fd, F_GETSIG));
+
+    close(fd);
+}
+
+// 负值与超过 SIGRTMAX 的值应返回 EINVAL。
+TEST(FcntlSignal, SetSigRejectsInvalidValues) {
+    int fd = fd_pair();
+    ASSERT_GE(fd, 0);
+
+    errno = 0;
+    EXPECT_EQ(-1, fcntl(fd, F_SETSIG, -1));
+    EXPECT_EQ(EINVAL, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, fcntl(fd, F_SETSIG, kKernelSigrtmax + 1));
+    EXPECT_EQ(EINVAL, errno);
+
+    // 校验失败不应修改现有值。
+    EXPECT_EQ(0, fcntl(fd, F_GETSIG));
+
+    close(fd);
+}
+
+// 对非法 fd 的 F_GETSIG/F_SETSIG 应返回 EBADF。
+TEST(FcntlSignal, InvalidFdReturnsEBADF) {
+    errno = 0;
+    EXPECT_EQ(-1, fcntl(-1, F_GETSIG));
+    EXPECT_EQ(EBADF, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, fcntl(-1, F_SETSIG, SIGUSR1));
+    EXPECT_EQ(EBADF, errno);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -3,6 +3,7 @@
 demo/gtest_demo
 normal/capability
 normal/fcntl_lock
+normal/fcntl_signal
 normal/epoll_timeout_budget
 normal/devpts_dir_read
 normal/test_pivot_root


### PR DESCRIPTION
## Summary

Fix fcntl signal owner handling and add dunitest coverage for the related behavior.

## Changes

- Correct fcntl signal owner handling logic in VFS/fcntl code.
- Update related fcntl syscall handling.
- Add a new `fcntl_signal` dunitest case.
- Add the new test case to the dunitest whitelist.

## Testing

- Added `user/apps/tests/dunitest/suites/normal/fcntl_signal.cc`.
- Not fully verified locally because the PR CI workflow is currently awaiting maintainer approval.