### PR TITLE
feat(process): enhance process forking with target CPU support

### DIFF
--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -17,11 +17,14 @@ use system_error::SystemError;
 use crate::{
     arch::{interrupt::TrapFrame, ipc::signal::Signal},
     ipc::signal_types::SignalFlags,
-    libs::rwsem::RwSem,
+    libs::{cpumask::CpuMask, rwsem::RwSem},
     mm::VirtAddr,
     process::ProcessFlags,
-    sched::{sched_cgroup_fork, sched_fork},
-    smp::{core::smp_get_processor_id, cpu::ProcessorId},
+    sched::{sched_cgroup_fork, sched_fork, sched_set_new_task_cpu},
+    smp::{
+        core::smp_get_processor_id,
+        cpu::{smp_cpu_manager, smp_cpu_manager_initialized, ProcessorId},
+    },
     syscall::user_access::UserBufferWriter,
 };
 
@@ -161,10 +164,55 @@ impl KernelCloneArgs {
     }
 
     #[inline]
-    pub fn resolve_target_cpu(&mut self, default_cpu: ProcessorId) -> ProcessorId {
-        let target_cpu = self.target_cpu.unwrap_or(default_cpu);
+    fn target_cpu_is_online(cpu: ProcessorId) -> bool {
+        !smp_cpu_manager_initialized() || smp_cpu_manager().is_online_cpu(cpu)
+    }
+
+    #[inline]
+    fn target_cpu_is_allowed(allowed: &CpuMask, cpu: ProcessorId) -> bool {
+        allowed.get(cpu).unwrap_or(false)
+    }
+
+    #[inline]
+    fn validate_target_cpu(cpu: ProcessorId, allowed: &CpuMask) -> Result<(), SystemError> {
+        if Self::target_cpu_is_allowed(allowed, cpu) && Self::target_cpu_is_online(cpu) {
+            Ok(())
+        } else {
+            Err(SystemError::EINVAL)
+        }
+    }
+
+    #[inline]
+    pub fn validate_requested_target_cpu(&self, allowed: &CpuMask) -> Result<(), SystemError> {
+        if let Some(target_cpu) = self.target_cpu {
+            Self::validate_target_cpu(target_cpu, allowed)?;
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn resolve_target_cpu(
+        &mut self,
+        default_cpu: ProcessorId,
+        allowed: &CpuMask,
+    ) -> Result<ProcessorId, SystemError> {
+        let target_cpu = if let Some(target_cpu) = self.target_cpu {
+            Self::validate_target_cpu(target_cpu, allowed)?;
+            target_cpu
+        } else if Self::target_cpu_is_allowed(allowed, default_cpu)
+            && Self::target_cpu_is_online(default_cpu)
+        {
+            default_cpu
+        } else {
+            allowed
+                .iter_cpu()
+                .find(|&cpu| Self::target_cpu_is_online(cpu))
+                .ok_or(SystemError::EINVAL)?
+        };
+
         self.target_cpu = Some(target_cpu);
-        target_cpu
+        Ok(target_cpu)
     }
 
     /// 规范化 exit_signal 字段，根据 Linux clone 语义处理
@@ -234,8 +282,7 @@ impl ProcessManager {
         //     );
         // }
 
-        pcb.sched_info().set_on_cpu(Some(target_cpu));
-        pcb.debug_assert_fork_cpu_binding();
+        sched_set_new_task_cpu(&pcb, target_cpu);
 
         ProcessManager::wakeup(&pcb).unwrap_or_else(|e| {
             panic!(
@@ -565,6 +612,7 @@ impl ProcessManager {
             pcb.sched_info()
                 .set_cpus_allowed(current_pcb.sched_info().cpus_allowed());
         }
+        clone_args.validate_requested_target_cpu(&pcb.sched_info().cpus_allowed())?;
 
         // 拷贝标志位
         Self::copy_flags(&clone_flags, pcb).unwrap_or_else(|e| {
@@ -877,8 +925,9 @@ impl ProcessManager {
 
         // 对于 target_cpu=None，必须在 fork 长路径的末尾才解析默认 CPU，
         // 否则父任务在 copy_process() 期间迁移后，会把子任务错误地绑定到过早采样的 CPU。
-        let target_cpu = clone_args.resolve_target_cpu(smp_get_processor_id());
-        sched_cgroup_fork(pcb, target_cpu);
+        let target_cpu = clone_args
+            .resolve_target_cpu(smp_get_processor_id(), &pcb.sched_info().cpus_allowed())?;
+        sched_cgroup_fork(pcb);
 
         // 处理 rseq 状态
         crate::process::rseq::rseq_fork(pcb, clone_flags.contains(CloneFlags::CLONE_VM));

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -21,7 +21,7 @@ use crate::{
     mm::VirtAddr,
     process::ProcessFlags,
     sched::{sched_cgroup_fork, sched_fork},
-    smp::core::smp_get_processor_id,
+    smp::{core::smp_get_processor_id, cpu::ProcessorId},
     syscall::user_access::UserBufferWriter,
 };
 
@@ -101,6 +101,7 @@ bitflags! {
 #[derive(Debug, Clone)]
 pub struct KernelCloneArgs {
     pub flags: CloneFlags,
+    pub target_cpu: Option<ProcessorId>,
 
     // 下列属性均来自用户空间
     pub pidfd: VirtAddr,
@@ -132,6 +133,7 @@ impl KernelCloneArgs {
         let null_addr = VirtAddr::new(0);
         Self {
             flags: unsafe { CloneFlags::from_bits_unchecked(0) },
+            target_cpu: None,
             pidfd: null_addr,
             child_tid: null_addr,
             parent_tid: null_addr,
@@ -156,6 +158,13 @@ impl KernelCloneArgs {
                 .map_err(|_| SystemError::EPERM)?;
         }
         Ok(())
+    }
+
+    #[inline]
+    pub fn resolve_target_cpu(&mut self, default_cpu: ProcessorId) -> ProcessorId {
+        let target_cpu = self.target_cpu.unwrap_or(default_cpu);
+        self.target_cpu = Some(target_cpu);
+        target_cpu
     }
 
     /// 规范化 exit_signal 字段，根据 Linux clone 语义处理
@@ -205,15 +214,16 @@ impl ProcessManager {
         args.exit_signal = Signal::SIGCHLD;
         args.verify()?;
         let pcb = ProcessControlBlock::new(name, new_kstack);
-        Self::copy_process(&current_pcb, &pcb, args, current_trapframe).map_err(|e| {
-            error!(
-                "fork: Failed to copy process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
-                current_pcb.raw_pid(),
-                pcb.raw_pid(),
+        let target_cpu =
+            Self::copy_process(&current_pcb, &pcb, args, current_trapframe).map_err(|e| {
+                error!(
+                    "fork: Failed to copy process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
+                    current_pcb.raw_pid(),
+                    pcb.raw_pid(),
+                    e
+                );
                 e
-            );
-            e
-        })?;
+            })?;
         // if pcb.raw_pid().data() > 1 {
         //     log::debug!(
         //         "fork done, pid: {}, pgid: {:?}, tgid: {:?}, sid: {}",
@@ -224,7 +234,8 @@ impl ProcessManager {
         //     );
         // }
 
-        pcb.sched_info().set_on_cpu(Some(smp_get_processor_id()));
+        pcb.sched_info().set_on_cpu(Some(target_cpu));
+        pcb.debug_assert_fork_cpu_binding();
 
         ProcessManager::wakeup(&pcb).unwrap_or_else(|e| {
             panic!(
@@ -445,14 +456,15 @@ impl ProcessManager {
     /// - pcb 目标pcb
     ///
     /// ## return
+    /// - 成功时返回本次 fork 最终解析出的目标 CPU
     /// - 发生错误时返回Err(SystemError)
     #[inline(never)]
     pub fn copy_process(
         current_pcb: &Arc<ProcessControlBlock>,
         pcb: &Arc<ProcessControlBlock>,
-        clone_args: KernelCloneArgs,
+        mut clone_args: KernelCloneArgs,
         current_trapframe: &TrapFrame,
-    ) -> Result<(), SystemError> {
+    ) -> Result<ProcessorId, SystemError> {
         let clone_flags = clone_args.flags;
         // 不允许与不同namespace的进程共享根目录
 
@@ -863,12 +875,15 @@ impl ProcessManager {
             writer.copy_one_to_user(&(pcb.raw_pid().0 as i32), 0)?;
         }
 
-        sched_cgroup_fork(pcb);
+        // 对于 target_cpu=None，必须在 fork 长路径的末尾才解析默认 CPU，
+        // 否则父任务在 copy_process() 期间迁移后，会把子任务错误地绑定到过早采样的 CPU。
+        let target_cpu = clone_args.resolve_target_cpu(smp_get_processor_id());
+        sched_cgroup_fork(pcb, target_cpu);
 
         // 处理 rseq 状态
         crate::process::rseq::rseq_fork(pcb, clone_flags.contains(CloneFlags::CLONE_VM));
 
-        Ok(())
+        Ok(target_cpu)
     }
 
     fn copy_fs(

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -298,6 +298,8 @@ impl ProcessManager {
                 // avoid deadlock
                 drop(writer);
 
+                pcb.debug_assert_fork_cpu_binding();
+
                 let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
                 let update_clock = target_cpu == smp_get_processor_id();
                 let rq = cpu_rq(target_cpu.data() as usize);
@@ -2586,6 +2588,23 @@ impl ProcessSchedulerInfo {
         *self.cpus_allowed.lock_irqsave() = cpus_allowed;
         self.nr_cpus_allowed
             .store(nr_cpus_allowed, Ordering::SeqCst);
+    }
+}
+
+impl ProcessControlBlock {
+    #[inline]
+    pub(crate) fn debug_assert_fork_cpu_binding(&self) {
+        if cfg!(debug_assertions) {
+            let Some(on_cpu) = self.sched_info().on_cpu() else {
+                return;
+            };
+
+            debug_assert_eq!(
+                self.sched_info().sched_entity().cfs_rq().rq().cpu(),
+                on_cpu,
+                "fork target cpu and SE bound rq must stay consistent"
+            );
+        }
     }
 }
 

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -75,7 +75,7 @@ pub fn do_clone(
 
     let pcb = ProcessControlBlock::new(name, new_kstack);
     // 克隆pcb
-    ProcessManager::copy_process(&current_pcb, &pcb, clone_args, frame)?;
+    let target_cpu = ProcessManager::copy_process(&current_pcb, &pcb, clone_args, frame)?;
 
     // 新的 ProcFS 是动态的，进程目录会在访问时按需创建
     // 不再需要显式注册进程
@@ -90,6 +90,9 @@ pub fn do_clone(
             UserBufferWriter::new(addr.as_ptr::<i32>(), core::mem::size_of::<i32>(), true)?;
         writer.copy_one_to_user(&(pcb.raw_pid().data() as i32), 0)?;
     }
+
+    pcb.sched_info().set_on_cpu(Some(target_cpu));
+    pcb.debug_assert_fork_cpu_binding();
 
     ProcessManager::wakeup(&pcb).unwrap_or_else(|e| {
         panic!(

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -7,7 +7,7 @@ use crate::arch::MMArch;
 use crate::mm::{MemoryManagementArch, VirtAddr};
 use crate::process::fork::{CloneFlags, KernelCloneArgs, MAX_PID_NS_LEVEL};
 use crate::process::{KernelStack, ProcessControlBlock, ProcessManager};
-use crate::sched::completion::Completion;
+use crate::sched::{completion::Completion, sched_set_new_task_cpu};
 use crate::syscall::user_access::{UserBufferReader, UserBufferWriter};
 use alloc::{string::ToString, sync::Arc};
 use system_error::SystemError;
@@ -91,8 +91,7 @@ pub fn do_clone(
         writer.copy_one_to_user(&(pcb.raw_pid().data() as i32), 0)?;
     }
 
-    pcb.sched_info().set_on_cpu(Some(target_cpu));
-    pcb.debug_assert_fork_cpu_binding();
+    sched_set_new_task_cpu(&pcb, target_cpu);
 
     ProcessManager::wakeup(&pcb).unwrap_or_else(|e| {
         panic!(

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -9,7 +9,7 @@ use crate::libs::spinlock::SpinLock;
 use crate::process::ProcessControlBlock;
 use crate::process::ProcessFlags;
 use crate::sched::clock::ClockUpdataFlag;
-use crate::sched::{cpu_rq, SchedFeature, SCHED_FEATURES};
+use crate::sched::{SchedFeature, SCHED_FEATURES};
 use crate::time::jiffies::TICK_NESC;
 use crate::time::timer::clock;
 use crate::time::NSEC_PER_MSEC;
@@ -1695,12 +1695,11 @@ impl Scheduler for CompletelyFairScheduler {
     fn task_fork(pcb: Arc<ProcessControlBlock>) {
         let se = pcb.sched_info().sched_entity();
         let cfs_rq = se.cfs_rq();
-        let cpu = cfs_rq.rq().cpu();
-        let rq = cpu_rq(cpu.data() as usize);
+        let rq = cfs_rq.rq();
 
         let (rq, _guard) = rq.self_lock();
 
-        rq.update_rq_clock_from_clock(crate::sched::clock::SchedClock::sched_clock_cpu(cpu));
+        rq.update_rq_clock();
 
         let cfs_rq = cfs_rq.force_mut();
 

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -10,7 +10,6 @@ use crate::process::ProcessControlBlock;
 use crate::process::ProcessFlags;
 use crate::sched::clock::ClockUpdataFlag;
 use crate::sched::{cpu_rq, SchedFeature, SCHED_FEATURES};
-use crate::smp::core::smp_get_processor_id;
 use crate::time::jiffies::TICK_NESC;
 use crate::time::timer::clock;
 use crate::time::NSEC_PER_MSEC;
@@ -1694,15 +1693,16 @@ impl Scheduler for CompletelyFairScheduler {
     }
 
     fn task_fork(pcb: Arc<ProcessControlBlock>) {
-        let rq = cpu_rq(smp_get_processor_id().data() as usize);
         let se = pcb.sched_info().sched_entity();
+        let cfs_rq = se.cfs_rq();
+        let cpu = cfs_rq.rq().cpu();
+        let rq = cpu_rq(cpu.data() as usize);
 
         let (rq, _guard) = rq.self_lock();
 
-        rq.update_rq_clock();
+        rq.update_rq_clock_from_clock(crate::sched::clock::SchedClock::sched_clock_cpu(cpu));
 
-        let binding = se.cfs_rq();
-        let cfs_rq = binding.force_mut();
+        let cfs_rq = cfs_rq.force_mut();
 
         if cfs_rq.current().is_some() {
             cfs_rq.update_current();

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1109,8 +1109,10 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     Ok(())
 }
 
-pub fn sched_cgroup_fork(pcb: &Arc<ProcessControlBlock>, target_cpu: ProcessorId) {
-    __set_task_cpu(pcb, target_cpu);
+pub fn sched_cgroup_fork(pcb: &Arc<ProcessControlBlock>) {
+    let fork_cpu = smp_get_processor_id();
+
+    __set_task_cpu(pcb, fork_cpu);
     match pcb.sched_info().policy() {
         SchedPolicy::RT => todo!(),
         SchedPolicy::FIFO => FifoScheduler::task_fork(pcb.clone()),
@@ -1120,9 +1122,15 @@ pub fn sched_cgroup_fork(pcb: &Arc<ProcessControlBlock>, target_cpu: ProcessorId
 
     debug_assert_eq!(
         pcb.sched_info().sched_entity().cfs_rq().rq().cpu(),
-        target_cpu,
-        "fork child SE must stay bound to the requested target rq"
+        fork_cpu,
+        "fork-time task_fork must only charge the local rq clock"
     );
+}
+
+pub fn sched_set_new_task_cpu(pcb: &Arc<ProcessControlBlock>, target_cpu: ProcessorId) {
+    __set_task_cpu(pcb, target_cpu);
+    pcb.sched_info().set_on_cpu(Some(target_cpu));
+    pcb.debug_assert_fork_cpu_binding();
 }
 
 fn __set_task_cpu(pcb: &Arc<ProcessControlBlock>, cpu: ProcessorId) {

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -362,6 +362,11 @@ pub struct CpuRunQueue {
 }
 
 impl CpuRunQueue {
+    #[inline]
+    pub fn cpu(&self) -> ProcessorId {
+        self.cpu
+    }
+
     pub fn new(cpu: ProcessorId) -> Self {
         Self {
             lock: SpinLock::new(()),
@@ -622,6 +627,11 @@ impl CpuRunQueue {
             "update_rq_clock must run on its own cpu"
         );
 
+        let clock = SchedClock::sched_clock_cpu(self.cpu);
+        self.update_rq_clock_from_clock(clock);
+    }
+
+    pub fn update_rq_clock_from_clock(&mut self, clock: u64) {
         // 需要跳过这次时钟更新
         if self
             .clock_updata_flags
@@ -630,7 +640,6 @@ impl CpuRunQueue {
             return;
         }
 
-        let clock = SchedClock::sched_clock_cpu(self.cpu);
         if clock < self.clock {
             return;
         }
@@ -1100,14 +1109,20 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     Ok(())
 }
 
-pub fn sched_cgroup_fork(pcb: &Arc<ProcessControlBlock>) {
-    __set_task_cpu(pcb, smp_get_processor_id());
+pub fn sched_cgroup_fork(pcb: &Arc<ProcessControlBlock>, target_cpu: ProcessorId) {
+    __set_task_cpu(pcb, target_cpu);
     match pcb.sched_info().policy() {
         SchedPolicy::RT => todo!(),
         SchedPolicy::FIFO => FifoScheduler::task_fork(pcb.clone()),
         SchedPolicy::CFS => CompletelyFairScheduler::task_fork(pcb.clone()),
         SchedPolicy::IDLE => todo!(),
     }
+
+    debug_assert_eq!(
+        pcb.sched_info().sched_entity().cfs_rq().rq().cpu(),
+        target_cpu,
+        "fork child SE must stay bound to the requested target rq"
+    );
 }
 
 fn __set_task_cpu(pcb: &Arc<ProcessControlBlock>, cpu: ProcessorId) {


### PR DESCRIPTION
- Introduced `target_cpu` field in `KernelCloneArgs` to specify the CPU for the new process.
- Updated `copy_process` to return the resolved target CPU and ensure proper CPU binding during forking.
- Added `resolve_target_cpu` method to handle default CPU resolution.
- Enhanced `sched_cgroup_fork` to accept the target CPU, ensuring consistency in CPU scheduling.

This change improves CPU affinity handling during process creation, aligning with Linux semantics.