### PR TITLE
fix(sched): harden CPU placement and wakeup invariants

### DIFF
--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -20,10 +20,10 @@ use crate::{
     libs::{cpumask::CpuMask, rwsem::RwSem},
     mm::VirtAddr,
     process::ProcessFlags,
-    sched::{sched_cgroup_fork, sched_fork, sched_set_new_task_cpu},
+    sched::{cpu_is_online, sched_cgroup_fork, sched_fork, sched_set_new_task_cpu},
     smp::{
         core::smp_get_processor_id,
-        cpu::{smp_cpu_manager, smp_cpu_manager_initialized, ProcessorId},
+        cpu::{smp_cpu_manager_initialized, ProcessorId},
     },
     syscall::user_access::UserBufferWriter,
 };
@@ -165,7 +165,7 @@ impl KernelCloneArgs {
 
     #[inline]
     fn target_cpu_is_online(cpu: ProcessorId) -> bool {
-        !smp_cpu_manager_initialized() || smp_cpu_manager().is_online_cpu(cpu)
+        !smp_cpu_manager_initialized() || cpu_is_online(cpu)
     }
 
     #[inline]

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -305,6 +305,11 @@ impl ProcessManager {
                 let rq = cpu_rq(target_cpu.data() as usize);
 
                 let (rq, _guard) = rq.self_lock();
+                debug_assert_eq!(
+                    pcb.sched_info().on_cpu(),
+                    Some(rq.cpu()),
+                    "wakeup: on_cpu mismatch with rq.cpu"
+                );
                 if update_clock {
                     rq.update_rq_clock();
                 }
@@ -418,6 +423,11 @@ impl ProcessManager {
                 let rq = cpu_rq(target_cpu.data() as usize);
 
                 let (rq, _guard) = rq.self_lock();
+                debug_assert_eq!(
+                    pcb.sched_info().on_cpu(),
+                    Some(rq.cpu()),
+                    "wakeup_stop: on_cpu mismatch with rq.cpu"
+                );
                 if update_clock {
                     rq.update_rq_clock();
                 }

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -1416,6 +1416,10 @@ impl Scheduler for CompletelyFairScheduler {
         mut flags: EnqueueFlag,
     ) {
         let mut se = pcb.sched_info().sched_entity();
+        debug_assert!(
+            Arc::ptr_eq(&se.cfs_rq(), &rq.cfs_rq()),
+            "enqueue: SE's cfs_rq must match target rq's cfs_rq"
+        );
         let mut idle_h_nr_running = pcb.sched_info().policy() == SchedPolicy::IDLE;
         let (should_continue, se) = FairSchedEntity::for_each_in_group(&mut se, |se| {
             if se.on_rq() {

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -31,6 +31,7 @@ use crate::{
         ipi::{IpiKind, IpiTarget},
         InterruptArch,
     },
+    init::initial_kthread::{get_system_state, SystemState},
     libs::{
         cpumask::{AtomicCpuMask, CpuMask},
         lazy_init::Lazy,
@@ -97,6 +98,19 @@ fn rq_is_idle_cpu(rq: &CpuRunQueue) -> bool {
     task_is_idle(&rq.current()) && rq.nr_running == 0
 }
 
+#[inline]
+pub fn cpu_is_online(cpu: ProcessorId) -> bool {
+    smp_cpu_manager().is_online_cpu(cpu)
+}
+
+#[inline]
+fn boot_in_progress() -> bool {
+    matches!(
+        get_system_state(),
+        SystemState::Booting | SystemState::Scheduling | SystemState::FreeingInitMem
+    )
+}
+
 pub fn pick_idle_cpu(allowed: &CpuMask) -> Option<ProcessorId> {
     if !smp_cpu_manager_initialized() {
         return IDLE_CPUS.first_and(allowed);
@@ -104,7 +118,7 @@ pub fn pick_idle_cpu(allowed: &CpuMask) -> Option<ProcessorId> {
 
     allowed
         .iter_cpu()
-        .find(|&cpu| IDLE_CPUS.get(cpu) && smp_cpu_manager().is_online_cpu(cpu))
+        .find(|&cpu| IDLE_CPUS.get(cpu) && cpu_is_online(cpu))
 }
 
 lazy_static! {
@@ -512,6 +526,10 @@ impl CpuRunQueue {
         if was_idle_cpu && !rq_is_idle_cpu(self) {
             IDLE_CPUS.clear(self.cpu);
         }
+
+        debug_assert_eq!(*pcb.sched_info().on_rq.lock_irqsave(), OnRq::Queued);
+        debug_assert_eq!(pcb.sched_info().on_cpu(), Some(self.cpu));
+        pcb.debug_assert_fork_cpu_binding();
     }
 
     /// 检查对应的task是否可以抢占当前运行的task
@@ -770,6 +788,8 @@ impl CpuRunQueue {
 
     /// 选择下一个task
     pub fn pick_next_task(&mut self, prev: Arc<ProcessControlBlock>) -> Arc<ProcessControlBlock> {
+        debug_assert_eq!(prev.sched_info().on_cpu(), Some(self.cpu));
+
         let mut next: Option<Arc<ProcessControlBlock>> = None;
 
         if self.fifo.nr_running() > 0 {
@@ -1134,6 +1154,12 @@ pub fn sched_set_new_task_cpu(pcb: &Arc<ProcessControlBlock>, target_cpu: Proces
 }
 
 fn __set_task_cpu(pcb: &Arc<ProcessControlBlock>, cpu: ProcessorId) {
+    debug_assert!(
+        cpu_is_online(cpu) || boot_in_progress(),
+        "__set_task_cpu target cpu {:?} must be online outside boot",
+        cpu
+    );
+
     // TODO: Fixme There is not implement group sched;
     let se = pcb.sched_info().sched_entity();
     let rq = cpu_rq(cpu.data() as usize);

--- a/kernel/src/smp/cpu/mod.rs
+++ b/kernel/src/smp/cpu/mod.rs
@@ -74,6 +74,12 @@ impl CpuHpCpuState {
     pub const fn thread(&self) -> &Option<Arc<ProcessControlBlock>> {
         &self.thread
     }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub const fn state(&self) -> CpuHpState {
+        self.state
+    }
 }
 
 pub struct SmpCpuManager {


### PR DESCRIPTION
Harden scheduler CPU selection and task placement by filtering idle CPU candidates through online state and by asserting that post-boot task binding does not target offline CPUs.

Also add debug-only invariants to wakeup, wakeup_stop, activate_task, pick_next_task, and CFS enqueue paths so mismatched CPU/runqueue/entity bindings are detected immediately.

This change is intended as defensive hardening only and does not change release behavior.