### PR TITLE
feat(process): implement user namespace support for rootless containers

### DIFF
--- a/kernel/src/filesystem/procfs/mod.rs
+++ b/kernel/src/filesystem/procfs/mod.rs
@@ -5,7 +5,10 @@
 use alloc::{sync::Arc, vec::Vec};
 use system_error::SystemError;
 
-use crate::{libs::once::Once, process::ProcessManager};
+use crate::{
+    libs::once::Once,
+    process::{cred::Cred, ProcessManager},
+};
 
 use super::vfs::mount::{MountFlags, MountPath};
 use super::vfs::InodeMode;
@@ -47,11 +50,15 @@ pub(super) use template::Builder;
 #[derive(Debug, Clone)]
 pub struct ProcfsFilePrivateData {
     pub data: Vec<u8>,
+    pub open_cred: Arc<Cred>,
 }
 
 impl ProcfsFilePrivateData {
     pub fn new() -> Self {
-        ProcfsFilePrivateData { data: Vec::new() }
+        ProcfsFilePrivateData {
+            data: Vec::new(),
+            open_cred: ProcessManager::current_pcb().cred(),
+        }
     }
 }
 

--- a/kernel/src/filesystem/procfs/pid/id_map.rs
+++ b/kernel/src/filesystem/procfs/pid/id_map.rs
@@ -123,9 +123,7 @@ impl IdMapFileOps {
         Ok(pcb.cred().user_ns.clone())
     }
 
-    fn open_cred_from_data(
-        data: &MutexGuard<FilePrivateData>,
-    ) -> Result<Arc<Cred>, SystemError> {
+    fn open_cred_from_data(data: &MutexGuard<FilePrivateData>) -> Result<Arc<Cred>, SystemError> {
         let FilePrivateData::Procfs(ProcfsFilePrivateData { open_cred, .. }) = &**data else {
             return Err(SystemError::EPERM);
         };

--- a/kernel/src/filesystem/procfs/pid/id_map.rs
+++ b/kernel/src/filesystem/procfs/pid/id_map.rs
@@ -8,14 +8,15 @@ use crate::{
         procfs::{
             pid::find_process_by_vpid,
             template::{Builder, FileOps, ProcFileBuilder},
+            ProcfsFilePrivateData,
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     process::{
-        cred::{ns_capable, CAPFlags},
+        cred::{cap_capable, CAPFlags, Cred},
         namespace::user_namespace::{
-            map_id_range_down, UidGidExtent, UidGidMap, UID_GID_MAP_MAX_BASE_EXTENTS,
-            UID_GID_MAP_MAX_EXTENTS, USERNS_SETGROUPS_ALLOWED,
+            map_id_down, map_id_range_down, map_id_up, UidGidExtent, UidGidMap, UserNamespace,
+            UID_GID_MAP_MAX_BASE_EXTENTS, UID_GID_MAP_MAX_EXTENTS, USERNS_SETGROUPS_ALLOWED,
         },
         RawPid,
     },
@@ -29,11 +30,56 @@ use alloc::{
 use core::sync::atomic::{AtomicU32, Ordering};
 use system_error::SystemError;
 
+const PROC_ID_MAP_MAX_WRITE: usize = 4096;
+
 /// 映射文件类型
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MapType {
     Uid,
     Gid,
+}
+
+impl MapType {
+    fn parent_cap(self) -> CAPFlags {
+        match self {
+            MapType::Uid => CAPFlags::CAP_SETUID,
+            MapType::Gid => CAPFlags::CAP_SETGID,
+        }
+    }
+
+    fn is_uid(self) -> bool {
+        matches!(self, MapType::Uid)
+    }
+}
+
+#[derive(Clone)]
+struct IdMapWriteContext {
+    map_type: MapType,
+    target_ns: Arc<UserNamespace>,
+    opener_cred: Arc<Cred>,
+    target_owner: usize,
+    target_flags: u32,
+    target_parent_could_setfcap: bool,
+}
+
+impl IdMapWriteContext {
+    fn opener_has_cap(&self, ns: &Arc<UserNamespace>, cap: CAPFlags) -> bool {
+        cap_capable(&self.opener_cred, ns, cap)
+    }
+
+    fn target_parent_ns(&self) -> Result<Arc<UserNamespace>, SystemError> {
+        self.target_ns.parent_ns().ok_or(SystemError::EPERM)
+    }
+
+    fn lower_ns_for_display(&self) -> Arc<UserNamespace> {
+        if Arc::ptr_eq(&self.opener_cred.user_ns, &self.target_ns) {
+            self.target_ns
+                .parent_ns()
+                .unwrap_or_else(|| self.target_ns.clone())
+        } else {
+            self.opener_cred.user_ns.clone()
+        }
+    }
 }
 
 /// /proc/[pid]/uid_map 和 /proc/[pid]/gid_map 的 FileOps
@@ -72,70 +118,54 @@ impl IdMapFileOps {
             .unwrap()
     }
 
-    fn get_user_ns(
-        &self,
-    ) -> Result<Arc<crate::process::namespace::user_namespace::UserNamespace>, SystemError> {
+    fn get_user_ns(&self) -> Result<Arc<UserNamespace>, SystemError> {
         let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
         Ok(pcb.cred().user_ns.clone())
     }
 
-    fn generate_content(
-        &self,
-        map: &UidGidMap,
-        user_ns: &crate::process::namespace::user_namespace::UserNamespace,
-    ) -> String {
+    fn open_cred_from_data(
+        data: &MutexGuard<FilePrivateData>,
+    ) -> Result<Arc<Cred>, SystemError> {
+        let FilePrivateData::Procfs(ProcfsFilePrivateData { open_cred, .. }) = &**data else {
+            return Err(SystemError::EPERM);
+        };
+        Ok(open_cred.clone())
+    }
+
+    fn generate_content(&self, map: &UidGidMap, ctx: &IdMapWriteContext) -> String {
         let nr = map.get_nr_extents() as usize;
         if nr == 0 {
             return String::new();
         }
 
-        let mut output = String::new();
         let extents = if nr <= UID_GID_MAP_MAX_BASE_EXTENTS {
             &map.extent[..nr]
         } else {
             map.forward.as_deref().unwrap_or(&[])
         };
 
-        for e in extents {
-            // lower_first 显示为对读者可见的值
-            let visible_lower = if let Some(parent) = user_ns.parent_ns() {
-                let parent_inner = parent.inner.lock();
-                let parent_map = match self.map_type {
-                    MapType::Uid => &parent_inner.uid_map,
-                    MapType::Gid => &parent_inner.gid_map,
-                };
-                crate::process::namespace::user_namespace::map_id_up(parent_map, e.lower_first)
-                    .unwrap_or(e.lower_first)
-            } else {
-                e.lower_first
-            };
+        let lower_ns = ctx.lower_ns_for_display();
+        let lower_map = {
+            let inner = lower_ns.inner.lock();
+            match self.map_type {
+                MapType::Uid => inner.uid_map.clone(),
+                MapType::Gid => inner.gid_map.clone(),
+            }
+        };
+
+        let mut output = String::new();
+        for extent in extents {
+            let visible_lower = map_id_up(&lower_map, extent.lower_first).unwrap_or(u32::MAX);
             output.push_str(&format!(
                 "{:10} {:10} {:10}\n",
-                e.first, visible_lower, e.count
+                extent.first, visible_lower, extent.count
             ));
         }
+
         output
     }
 
-    fn write_map(
-        &self,
-        buf: &[u8],
-        map: &mut UidGidMap,
-        parent_map: &UidGidMap,
-        cap_setid: CAPFlags,
-        user_ns: &Arc<crate::process::namespace::user_namespace::UserNamespace>,
-    ) -> Result<usize, SystemError> {
-        // 1. 只写一次检查
-        if map.is_written() {
-            return Err(SystemError::EPERM);
-        }
-
-        // 2. 权限检查：需要 CAP_SYS_ADMIN 在目标 ns
-        if !ns_capable(user_ns, CAPFlags::CAP_SYS_ADMIN) {
-            return Err(SystemError::EPERM);
-        }
-
-        // 3. 解析输入
+    fn parse_map(&self, buf: &[u8]) -> Result<Vec<UidGidExtent>, SystemError> {
         let input = core::str::from_utf8(buf).map_err(|_| SystemError::EINVAL)?;
         let mut new_extents: Vec<UidGidExtent> = Vec::new();
 
@@ -150,76 +180,184 @@ impl IdMapFileOps {
                 return Err(SystemError::EINVAL);
             }
 
-            let first = parts[0].parse::<u32>().map_err(|_| SystemError::EINVAL)?;
-            let lower_first = parts[1].parse::<u32>().map_err(|_| SystemError::EINVAL)?;
-            let count = parts[2].parse::<u32>().map_err(|_| SystemError::EINVAL)?;
+            let extent = UidGidExtent {
+                first: parts[0].parse::<u32>().map_err(|_| SystemError::EINVAL)?,
+                lower_first: parts[1].parse::<u32>().map_err(|_| SystemError::EINVAL)?,
+                count: parts[2].parse::<u32>().map_err(|_| SystemError::EINVAL)?,
+            };
 
-            if first == u32::MAX || lower_first == u32::MAX || count == 0 {
-                return Err(SystemError::EINVAL);
-            }
-
-            // 检查溢出
-            if first.checked_add(count).is_none() || lower_first.checked_add(count).is_none() {
-                return Err(SystemError::EINVAL);
-            }
-
-            // 检查 overlap
-            for e in &new_extents {
-                if (first >= e.first && first < e.first + e.count)
-                    || (e.first >= first && e.first < first + count)
-                {
-                    return Err(SystemError::EINVAL);
-                }
-            }
-
-            new_extents.push(UidGidExtent {
-                first,
-                lower_first,
-                count,
-            });
+            self.validate_new_extent(&new_extents, &extent)?;
+            new_extents.push(extent);
         }
 
-        if new_extents.is_empty() {
-            return Ok(buf.len());
-        }
-
-        if new_extents.len() > UID_GID_MAP_MAX_EXTENTS {
+        if new_extents.is_empty() || new_extents.len() > UID_GID_MAP_MAX_EXTENTS {
             return Err(SystemError::EINVAL);
         }
 
-        // 4. 验证 parent map
-        for e in &new_extents {
-            if map_id_range_down(parent_map, e.lower_first, e.count).is_none() {
+        Ok(new_extents)
+    }
+
+    fn validate_new_extent(
+        &self,
+        new_extents: &[UidGidExtent],
+        extent: &UidGidExtent,
+    ) -> Result<(), SystemError> {
+        if extent.first == u32::MAX || extent.lower_first == u32::MAX || extent.count == 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        let upper_last = extent
+            .first
+            .checked_add(extent.count - 1)
+            .ok_or(SystemError::EINVAL)?;
+        let lower_last = extent
+            .lower_first
+            .checked_add(extent.count - 1)
+            .ok_or(SystemError::EINVAL)?;
+
+        for prev in new_extents {
+            let prev_upper_last = prev.first + prev.count - 1;
+            let prev_lower_last = prev.lower_first + prev.count - 1;
+
+            if prev.first <= upper_last && prev_upper_last >= extent.first {
+                return Err(SystemError::EINVAL);
+            }
+
+            if prev.lower_first <= lower_last && prev_lower_last >= extent.lower_first {
+                return Err(SystemError::EINVAL);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn verify_root_map(
+        &self,
+        ctx: &IdMapWriteContext,
+        new_extents: &[UidGidExtent],
+    ) -> Result<(), SystemError> {
+        if !ctx.map_type.is_uid() {
+            return Ok(());
+        }
+
+        if !new_extents.iter().any(|extent| extent.lower_first == 0) {
+            return Ok(());
+        }
+
+        if Arc::ptr_eq(&ctx.opener_cred.user_ns, &ctx.target_ns) {
+            if !ctx.target_parent_could_setfcap {
+                return Err(SystemError::EPERM);
+            }
+        } else {
+            let parent_ns = ctx.target_parent_ns()?;
+            if !ctx.opener_has_cap(&parent_ns, CAPFlags::CAP_SETFCAP) {
                 return Err(SystemError::EPERM);
             }
         }
 
-        // 5. 对非特权的 multi-extent 映射，需要 parent ns 的 CAP_SETUID/CAP_SETGID
-        if let Some(parent_ns) = user_ns.parent_ns() {
-            if !ns_capable(&parent_ns, cap_setid) {
-                return Err(SystemError::EPERM);
-            }
+        Ok(())
+    }
+
+    fn restricted_single_extent_permitted(
+        &self,
+        ctx: &IdMapWriteContext,
+        new_extents: &[UidGidExtent],
+    ) -> Result<bool, SystemError> {
+        if new_extents.len() != 1 || new_extents[0].count != 1 {
+            return Ok(false);
         }
 
-        // 5. 安装映射
-        let nr = new_extents.len();
-        for (i, e) in new_extents.iter().enumerate() {
-            if i < UID_GID_MAP_MAX_BASE_EXTENTS {
-                map.extent[i] = *e;
-            }
+        if ctx.target_owner != ctx.opener_cred.euid.data() {
+            return Ok(false);
         }
 
-        if nr > UID_GID_MAP_MAX_BASE_EXTENTS {
-            // 排序并分配 forward/reverse 数组
-            let mut forward = new_extents.clone();
-            forward.sort_by_key(|a| a.first);
-            let mut reverse = new_extents.clone();
-            reverse.sort_by_key(|a| a.lower_first);
+        let parent_ns = ctx.target_parent_ns()?;
+        let lower_id = new_extents[0].lower_first;
+
+        match ctx.map_type {
+            MapType::Uid => {
+                let parent_uid = map_id_down(&parent_ns.inner.lock().uid_map, lower_id)
+                    .ok_or(SystemError::EPERM)?;
+                Ok(parent_uid as usize == ctx.opener_cred.euid.data())
+            }
+            MapType::Gid => {
+                let parent_gid = map_id_down(&parent_ns.inner.lock().gid_map, lower_id)
+                    .ok_or(SystemError::EPERM)?;
+                Ok((ctx.target_flags & USERNS_SETGROUPS_ALLOWED) == 0
+                    && parent_gid as usize == ctx.opener_cred.egid.data())
+            }
+        }
+    }
+
+    fn new_idmap_permitted(
+        &self,
+        ctx: &IdMapWriteContext,
+        new_extents: &[UidGidExtent],
+    ) -> Result<(), SystemError> {
+        self.verify_root_map(ctx, new_extents)?;
+
+        if self.restricted_single_extent_permitted(ctx, new_extents)? {
+            return Ok(());
+        }
+
+        let parent_ns = ctx.target_parent_ns()?;
+        let parent_cap = ctx.map_type.parent_cap();
+        if ctx.opener_has_cap(&parent_ns, parent_cap) {
+            return Ok(());
+        }
+
+        Err(SystemError::EPERM)
+    }
+
+    fn install_map(&self, map: &mut UidGidMap, mut extents: Vec<UidGidExtent>) {
+        map.forward = None;
+        map.reverse = None;
+        map.extent = [UidGidExtent {
+            first: 0,
+            lower_first: 0,
+            count: 0,
+        }; UID_GID_MAP_MAX_BASE_EXTENTS];
+
+        let nr = extents.len();
+        if nr <= UID_GID_MAP_MAX_BASE_EXTENTS {
+            extents.sort_by_key(|extent| extent.first);
+            for (index, extent) in extents.iter().enumerate() {
+                map.extent[index] = *extent;
+            }
+        } else {
+            let mut forward = extents.clone();
+            forward.sort_by_key(|extent| extent.first);
+            let mut reverse = extents;
+            reverse.sort_by_key(|extent| extent.lower_first);
             map.forward = Some(forward);
             map.reverse = Some(reverse);
         }
 
         map.nr_extents.store(nr as u32, Ordering::Release);
+    }
+
+    fn write_map(
+        &self,
+        offset: usize,
+        buf: &[u8],
+        map: &mut UidGidMap,
+        parent_map: &UidGidMap,
+        ctx: &IdMapWriteContext,
+    ) -> Result<usize, SystemError> {
+        if offset != 0 || buf.len() >= PROC_ID_MAP_MAX_WRITE {
+            return Err(SystemError::EINVAL);
+        }
+
+        let mut new_extents = self.parse_map(buf)?;
+        self.new_idmap_permitted(ctx, &new_extents)?;
+
+        for extent in &mut new_extents {
+            let mapped_lower = map_id_range_down(parent_map, extent.lower_first, extent.count)
+                .ok_or(SystemError::EPERM)?;
+            extent.lower_first = mapped_lower;
+        }
+
+        self.install_map(map, new_extents);
         Ok(buf.len())
     }
 }
@@ -230,21 +368,30 @@ impl FileOps for IdMapFileOps {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: MutexGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
-        let user_ns = pcb.cred().user_ns.clone();
+        let user_ns = self.get_user_ns()?;
+        let opener_cred = Self::open_cred_from_data(&data)?;
         let inner = user_ns.inner.lock();
+        let ctx = IdMapWriteContext {
+            map_type: self.map_type,
+            target_ns: user_ns.clone(),
+            opener_cred,
+            target_owner: inner.owner,
+            target_flags: inner.flags,
+            target_parent_could_setfcap: inner.parent_could_setfcap,
+        };
 
         let content = match self.map_type {
-            MapType::Uid => self.generate_content(&inner.uid_map, &user_ns),
-            MapType::Gid => self.generate_content(&inner.gid_map, &user_ns),
+            MapType::Uid => self.generate_content(&inner.uid_map, &ctx),
+            MapType::Gid => self.generate_content(&inner.gid_map, &ctx),
         };
 
         let content_bytes = content.as_bytes();
         if offset >= content_bytes.len() {
             return Ok(0);
         }
+
         let end = (offset + len).min(content_bytes.len());
         let to_copy = end - offset;
         buf[..to_copy].copy_from_slice(&content_bytes[offset..end]);
@@ -253,51 +400,50 @@ impl FileOps for IdMapFileOps {
 
     fn write_at(
         &self,
-        _offset: usize,
+        offset: usize,
         _len: usize,
         buf: &[u8],
-        _data: MutexGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
-        let user_ns = pcb.cred().user_ns.clone();
+        let opener_cred = Self::open_cred_from_data(&data)?;
+        let user_ns = self.get_user_ns()?;
+
+        if !cap_capable(&opener_cred, &user_ns, CAPFlags::CAP_SYS_ADMIN) {
+            return Err(SystemError::EPERM);
+        }
+
         let mut inner = user_ns.inner.lock();
+        let ctx = IdMapWriteContext {
+            map_type: self.map_type,
+            target_ns: user_ns.clone(),
+            opener_cred,
+            target_owner: inner.owner,
+            target_flags: inner.flags,
+            target_parent_could_setfcap: inner.parent_could_setfcap,
+        };
 
         match self.map_type {
             MapType::Uid => {
-                let parent_map = if let Some(ref parent) = user_ns.parent {
-                    if let Some(parent_ns) = parent.upgrade() {
-                        parent_ns.inner.lock().uid_map.clone()
-                    } else {
-                        return Err(SystemError::EPERM);
-                    }
-                } else {
+                if inner.uid_map.is_written() {
                     return Err(SystemError::EPERM);
+                }
+                let parent_map = {
+                    let parent_ns = ctx.target_parent_ns()?;
+                    let map = parent_ns.inner.lock().uid_map.clone();
+                    map
                 };
-                self.write_map(
-                    buf,
-                    &mut inner.uid_map,
-                    &parent_map,
-                    CAPFlags::CAP_SETUID,
-                    &user_ns,
-                )
+                self.write_map(offset, buf, &mut inner.uid_map, &parent_map, &ctx)
             }
             MapType::Gid => {
-                let parent_map = if let Some(ref parent) = user_ns.parent {
-                    if let Some(parent_ns) = parent.upgrade() {
-                        parent_ns.inner.lock().gid_map.clone()
-                    } else {
-                        return Err(SystemError::EPERM);
-                    }
-                } else {
+                if inner.gid_map.is_written() {
                     return Err(SystemError::EPERM);
+                }
+                let parent_map = {
+                    let parent_ns = ctx.target_parent_ns()?;
+                    let map = parent_ns.inner.lock().gid_map.clone();
+                    map
                 };
-                self.write_map(
-                    buf,
-                    &mut inner.gid_map,
-                    &parent_map,
-                    CAPFlags::CAP_SETGID,
-                    &user_ns,
-                )
+                self.write_map(offset, buf, &mut inner.gid_map, &parent_map, &ctx)
             }
         }
     }
@@ -352,28 +498,29 @@ impl FileOps for SetgroupsFileOps {
 
     fn write_at(
         &self,
-        _offset: usize,
+        offset: usize,
         _len: usize,
         buf: &[u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
+        if offset != 0 || buf.len() >= PROC_ID_MAP_MAX_WRITE {
+            return Err(SystemError::EINVAL);
+        }
+
         let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
         let user_ns = pcb.cred().user_ns.clone();
         let mut inner = user_ns.inner.lock();
 
-        // 只能写入 "allow" 或 "deny"
         let input = core::str::from_utf8(buf).map_err(|_| SystemError::EINVAL)?;
         let input = input.trim();
 
         match input {
             "allow" => {
-                // 只能允许已经允许的情况（不能重新启用）
                 if (inner.flags & USERNS_SETGROUPS_ALLOWED) == 0 {
                     return Err(SystemError::EPERM);
                 }
             }
             "deny" => {
-                // 只能在 gid_map 未写入时拒绝
                 if inner.gid_map.is_written() {
                     return Err(SystemError::EPERM);
                 }
@@ -386,7 +533,6 @@ impl FileOps for SetgroupsFileOps {
     }
 }
 
-// UidGidMap 需要实现 Clone 以支持 parent_map 的复制
 impl Clone for UidGidMap {
     fn clone(&self) -> Self {
         Self {

--- a/kernel/src/filesystem/procfs/pid/id_map.rs
+++ b/kernel/src/filesystem/procfs/pid/id_map.rs
@@ -1,0 +1,392 @@
+//! /proc/[pid]/uid_map, /proc/[pid]/gid_map, /proc/[pid]/setgroups
+//!
+//! 实现 User Namespace 的 UID/GID 映射和 setgroups 控制文件。
+
+use crate::libs::mutex::MutexGuard;
+use crate::{
+    filesystem::{
+        procfs::{
+            pid::find_process_by_vpid,
+            template::{Builder, FileOps, ProcFileBuilder},
+        },
+        vfs::{FilePrivateData, IndexNode, InodeMode},
+    },
+    process::{
+        cred::{ns_capable, CAPFlags},
+        namespace::user_namespace::{
+            map_id_range_down, UidGidExtent, UidGidMap, UID_GID_MAP_MAX_BASE_EXTENTS,
+            UID_GID_MAP_MAX_EXTENTS, USERNS_SETGROUPS_ALLOWED,
+        },
+        RawPid,
+    },
+};
+use alloc::{
+    format,
+    string::String,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::sync::atomic::{AtomicU32, Ordering};
+use system_error::SystemError;
+
+/// 映射文件类型
+#[derive(Debug, Clone, Copy)]
+enum MapType {
+    Uid,
+    Gid,
+}
+
+/// /proc/[pid]/uid_map 和 /proc/[pid]/gid_map 的 FileOps
+#[derive(Debug)]
+pub struct IdMapFileOps {
+    pid: RawPid,
+    map_type: MapType,
+}
+
+impl IdMapFileOps {
+    pub fn new_uid(pid: RawPid) -> Self {
+        Self {
+            pid,
+            map_type: MapType::Uid,
+        }
+    }
+
+    pub fn new_gid(pid: RawPid) -> Self {
+        Self {
+            pid,
+            map_type: MapType::Gid,
+        }
+    }
+
+    pub fn new_uid_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new_uid(pid), InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    pub fn new_gid_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new_gid(pid), InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    fn get_user_ns(
+        &self,
+    ) -> Result<Arc<crate::process::namespace::user_namespace::UserNamespace>, SystemError> {
+        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        Ok(pcb.cred().user_ns.clone())
+    }
+
+    fn generate_content(
+        &self,
+        map: &UidGidMap,
+        user_ns: &crate::process::namespace::user_namespace::UserNamespace,
+    ) -> String {
+        let nr = map.get_nr_extents() as usize;
+        if nr == 0 {
+            return String::new();
+        }
+
+        let mut output = String::new();
+        let extents = if nr <= UID_GID_MAP_MAX_BASE_EXTENTS {
+            &map.extent[..nr]
+        } else {
+            map.forward.as_deref().unwrap_or(&[])
+        };
+
+        for e in extents {
+            // lower_first 显示为对读者可见的值
+            let visible_lower = if let Some(parent) = user_ns.parent_ns() {
+                crate::process::namespace::user_namespace::map_id_up(
+                    &parent.inner.lock().uid_map,
+                    e.lower_first,
+                )
+                .unwrap_or(e.lower_first)
+            } else {
+                e.lower_first
+            };
+            output.push_str(&format!(
+                "{:10} {:10} {:10}\n",
+                e.first, visible_lower, e.count
+            ));
+        }
+        output
+    }
+
+    fn write_map(
+        &self,
+        buf: &[u8],
+        map: &mut UidGidMap,
+        parent_map: &UidGidMap,
+        _cap_setid: CAPFlags,
+        user_ns: &Arc<crate::process::namespace::user_namespace::UserNamespace>,
+    ) -> Result<usize, SystemError> {
+        // 1. 只写一次检查
+        if map.is_written() {
+            return Err(SystemError::EPERM);
+        }
+
+        // 2. 权限检查：需要 CAP_SYS_ADMIN 在目标 ns
+        if !ns_capable(user_ns, CAPFlags::CAP_SYS_ADMIN) {
+            return Err(SystemError::EPERM);
+        }
+
+        // 3. 解析输入
+        let input = core::str::from_utf8(buf).map_err(|_| SystemError::EINVAL)?;
+        let mut new_extents: Vec<UidGidExtent> = Vec::new();
+
+        for line in input.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() != 3 {
+                return Err(SystemError::EINVAL);
+            }
+
+            let first = parts[0].parse::<u32>().map_err(|_| SystemError::EINVAL)?;
+            let lower_first = parts[1].parse::<u32>().map_err(|_| SystemError::EINVAL)?;
+            let count = parts[2].parse::<u32>().map_err(|_| SystemError::EINVAL)?;
+
+            if first == u32::MAX || lower_first == u32::MAX || count == 0 {
+                return Err(SystemError::EINVAL);
+            }
+
+            // 检查溢出
+            if first.saturating_add(count) < first
+                || lower_first.saturating_add(count) < lower_first
+            {
+                return Err(SystemError::EINVAL);
+            }
+
+            // 检查 overlap
+            for e in &new_extents {
+                if (first >= e.first && first < e.first + e.count)
+                    || (e.first >= first && e.first < first + count)
+                {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+
+            new_extents.push(UidGidExtent {
+                first,
+                lower_first,
+                count,
+            });
+        }
+
+        if new_extents.is_empty() {
+            return Ok(buf.len());
+        }
+
+        if new_extents.len() > UID_GID_MAP_MAX_EXTENTS {
+            return Err(SystemError::EINVAL);
+        }
+
+        // 4. 验证 parent map
+        for e in &new_extents {
+            if map_id_range_down(parent_map, e.lower_first, e.count).is_none() {
+                return Err(SystemError::EPERM);
+            }
+        }
+
+        // 5. 安装映射
+        let nr = new_extents.len();
+        for (i, e) in new_extents.iter().enumerate() {
+            if i < UID_GID_MAP_MAX_BASE_EXTENTS {
+                map.extent[i] = *e;
+            }
+        }
+
+        if nr > UID_GID_MAP_MAX_BASE_EXTENTS {
+            // 排序并分配 forward/reverse 数组
+            let mut forward = new_extents.clone();
+            forward.sort_by_key(|a| a.first);
+            let mut reverse = new_extents.clone();
+            reverse.sort_by_key(|a| a.lower_first);
+            map.forward = Some(forward);
+            map.reverse = Some(reverse);
+        }
+
+        map.nr_extents.store(nr as u32, Ordering::Release);
+        Ok(buf.len())
+    }
+}
+
+impl FileOps for IdMapFileOps {
+    fn read_at(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let user_ns = pcb.cred().user_ns.clone();
+        let inner = user_ns.inner.lock();
+
+        let content = match self.map_type {
+            MapType::Uid => self.generate_content(&inner.uid_map, &user_ns),
+            MapType::Gid => self.generate_content(&inner.gid_map, &user_ns),
+        };
+
+        let content_bytes = content.as_bytes();
+        if offset >= content_bytes.len() {
+            return Ok(0);
+        }
+        let end = (offset + len).min(content_bytes.len());
+        let to_copy = end - offset;
+        buf[..to_copy].copy_from_slice(&content_bytes[offset..end]);
+        Ok(to_copy)
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let user_ns = pcb.cred().user_ns.clone();
+        let mut inner = user_ns.inner.lock();
+
+        match self.map_type {
+            MapType::Uid => {
+                let parent_map = if let Some(ref parent) = user_ns.parent {
+                    if let Some(parent_ns) = parent.upgrade() {
+                        parent_ns.inner.lock().uid_map.clone()
+                    } else {
+                        return Err(SystemError::EPERM);
+                    }
+                } else {
+                    return Err(SystemError::EPERM);
+                };
+                self.write_map(
+                    buf,
+                    &mut inner.uid_map,
+                    &parent_map,
+                    CAPFlags::CAP_SETUID,
+                    &user_ns,
+                )
+            }
+            MapType::Gid => {
+                let parent_map = if let Some(ref parent) = user_ns.parent {
+                    if let Some(parent_ns) = parent.upgrade() {
+                        parent_ns.inner.lock().gid_map.clone()
+                    } else {
+                        return Err(SystemError::EPERM);
+                    }
+                } else {
+                    return Err(SystemError::EPERM);
+                };
+                self.write_map(
+                    buf,
+                    &mut inner.gid_map,
+                    &parent_map,
+                    CAPFlags::CAP_SETGID,
+                    &user_ns,
+                )
+            }
+        }
+    }
+}
+
+/// /proc/[pid]/setgroups 的 FileOps
+#[derive(Debug)]
+pub struct SetgroupsFileOps {
+    pid: RawPid,
+}
+
+impl SetgroupsFileOps {
+    pub fn new(pid: RawPid) -> Self {
+        Self { pid }
+    }
+
+    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new(pid), InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl FileOps for SetgroupsFileOps {
+    fn read_at(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let user_ns = pcb.cred().user_ns.clone();
+        let inner = user_ns.inner.lock();
+
+        let content = if (inner.flags & USERNS_SETGROUPS_ALLOWED) != 0 {
+            "allow\n"
+        } else {
+            "deny\n"
+        };
+
+        let content_bytes = content.as_bytes();
+        if offset >= content_bytes.len() {
+            return Ok(0);
+        }
+        let end = (offset + len).min(content_bytes.len());
+        let to_copy = end - offset;
+        buf[..to_copy].copy_from_slice(&content_bytes[offset..end]);
+        Ok(to_copy)
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let user_ns = pcb.cred().user_ns.clone();
+        let mut inner = user_ns.inner.lock();
+
+        // 只能写入 "allow" 或 "deny"
+        let input = core::str::from_utf8(buf).map_err(|_| SystemError::EINVAL)?;
+        let input = input.trim();
+
+        match input {
+            "allow" => {
+                // 只能允许已经允许的情况（不能重新启用）
+                if (inner.flags & USERNS_SETGROUPS_ALLOWED) == 0 {
+                    return Err(SystemError::EPERM);
+                }
+            }
+            "deny" => {
+                // 只能在 gid_map 未写入时拒绝
+                if inner.gid_map.is_written() {
+                    return Err(SystemError::EPERM);
+                }
+                inner.flags &= !USERNS_SETGROUPS_ALLOWED;
+            }
+            _ => return Err(SystemError::EINVAL),
+        }
+
+        Ok(buf.len())
+    }
+}
+
+// UidGidMap 需要实现 Clone 以支持 parent_map 的复制
+impl Clone for UidGidMap {
+    fn clone(&self) -> Self {
+        Self {
+            nr_extents: AtomicU32::new(self.get_nr_extents()),
+            extent: self.extent,
+            forward: self.forward.clone(),
+            reverse: self.reverse.clone(),
+        }
+    }
+}

--- a/kernel/src/filesystem/procfs/pid/id_map.rs
+++ b/kernel/src/filesystem/procfs/pid/id_map.rs
@@ -99,11 +99,13 @@ impl IdMapFileOps {
         for e in extents {
             // lower_first 显示为对读者可见的值
             let visible_lower = if let Some(parent) = user_ns.parent_ns() {
-                crate::process::namespace::user_namespace::map_id_up(
-                    &parent.inner.lock().uid_map,
-                    e.lower_first,
-                )
-                .unwrap_or(e.lower_first)
+                let parent_inner = parent.inner.lock();
+                let parent_map = match self.map_type {
+                    MapType::Uid => &parent_inner.uid_map,
+                    MapType::Gid => &parent_inner.gid_map,
+                };
+                crate::process::namespace::user_namespace::map_id_up(parent_map, e.lower_first)
+                    .unwrap_or(e.lower_first)
             } else {
                 e.lower_first
             };
@@ -120,7 +122,7 @@ impl IdMapFileOps {
         buf: &[u8],
         map: &mut UidGidMap,
         parent_map: &UidGidMap,
-        _cap_setid: CAPFlags,
+        cap_setid: CAPFlags,
         user_ns: &Arc<crate::process::namespace::user_namespace::UserNamespace>,
     ) -> Result<usize, SystemError> {
         // 1. 只写一次检查
@@ -157,9 +159,7 @@ impl IdMapFileOps {
             }
 
             // 检查溢出
-            if first.saturating_add(count) < first
-                || lower_first.saturating_add(count) < lower_first
-            {
+            if first.checked_add(count).is_none() || lower_first.checked_add(count).is_none() {
                 return Err(SystemError::EINVAL);
             }
 
@@ -190,6 +190,13 @@ impl IdMapFileOps {
         // 4. 验证 parent map
         for e in &new_extents {
             if map_id_range_down(parent_map, e.lower_first, e.count).is_none() {
+                return Err(SystemError::EPERM);
+            }
+        }
+
+        // 5. 对非特权的 multi-extent 映射，需要 parent ns 的 CAP_SETUID/CAP_SETGID
+        if let Some(parent_ns) = user_ns.parent_ns() {
+            if !ns_capable(&parent_ns, cap_setid) {
                 return Err(SystemError::EPERM);
             }
         }

--- a/kernel/src/filesystem/procfs/pid/mod.rs
+++ b/kernel/src/filesystem/procfs/pid/mod.rs
@@ -18,6 +18,7 @@ mod cmdline;
 mod exe;
 mod fd;
 mod fdinfo;
+mod id_map;
 mod limits;
 mod maps;
 mod mountinfo;
@@ -32,6 +33,7 @@ use cmdline::CmdlineFileOps;
 use exe::ExeSymOps;
 use fd::FdDirOps;
 use fdinfo::FdInfoDirOps;
+use id_map::{IdMapFileOps, SetgroupsFileOps};
 use limits::LimitsFile;
 use maps::MapsFileOps;
 use mountinfo::MountInfoFileOps;
@@ -98,6 +100,15 @@ impl PidDirOps {
         }),
         ("status", |ops, parent| {
             StatusFileOps::new_inode(ops.pid, parent)
+        }),
+        ("uid_map", |ops, parent| {
+            IdMapFileOps::new_uid_inode(ops.pid, parent)
+        }),
+        ("gid_map", |ops, parent| {
+            IdMapFileOps::new_gid_inode(ops.pid, parent)
+        }),
+        ("setgroups", |ops, parent| {
+            SetgroupsFileOps::new_inode(ops.pid, parent)
         }),
         ("task", |ops, parent| TaskDirOps::new_inode(ops.pid, parent)),
         ("exe", |ops, parent| ExeSymOps::new_inode(ops.pid, parent)),

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -431,6 +431,11 @@ pub struct File {
 }
 
 impl File {
+    #[inline]
+    pub fn cred(&self) -> Arc<Cred> {
+        self.cred.clone()
+    }
+
     fn maybe_kill_suid_sgid_after_write(&self) -> Result<(), SystemError> {
         // 仅对普通文件生效。
         if self.file_type != FileType::File {

--- a/kernel/src/process/cred.rs
+++ b/kernel/src/process/cred.rs
@@ -4,6 +4,7 @@ use core::sync::atomic::AtomicUsize;
 use alloc::vec::Vec;
 
 use super::namespace::user_namespace::{UserNamespace, INIT_USER_NAMESPACE};
+use crate::process::ProcessManager;
 
 const GLOBAL_ROOT_UID: Kuid = Kuid(0);
 const GLOBAL_ROOT_GID: Kgid = Kgid(0);
@@ -242,16 +243,75 @@ impl Cred {
         &self.groups
     }
 
-    /// 检查当前进程是否具有指定的capability
+    /// 检查当前进程是否具有指定的capability（在当前 user_ns 中）
     pub fn has_capability(&self, cap: CAPFlags) -> bool {
-        // 检查effective capability set中是否包含指定的capability
-        self.cap_effective.contains(cap)
+        cap_capable(self, &self.user_ns, cap)
     }
 
     /// 检查当前进程是否具有CAP_SYS_ADMIN权限
     pub fn has_cap_sys_admin(&self) -> bool {
         self.has_capability(CAPFlags::CAP_SYS_ADMIN)
     }
+}
+
+/// 检查 cred 在目标 user namespace 中是否具有指定 capability
+///
+/// 遵循 Linux cap_capable 的层次遍历规则：
+/// 1. 如果 cred 就在目标 ns 中，检查 effective cap
+/// 2. 如果 cred 的 ns 比目标更浅，返回 false
+/// 3. 如果 cred 的用户是目标 ns 的直接 owner，返回 true
+/// 4. 否则向上遍历 parent chain
+pub fn cap_capable(cred: &Cred, targ_ns: &Arc<UserNamespace>, cap: CAPFlags) -> bool {
+    let mut ns = targ_ns.clone();
+    loop {
+        if Arc::ptr_eq(&cred.user_ns, &ns) {
+            return cred.cap_effective.contains(cap);
+        }
+
+        if cred.user_ns.level() >= ns.level() {
+            return false;
+        }
+
+        let ns_owner = ns.inner.lock().owner;
+        if let Some(ref parent_weak) = ns.parent {
+            if let Some(parent_ns) = parent_weak.upgrade() {
+                if Arc::ptr_eq(&parent_ns, &cred.user_ns) && ns_owner == cred.euid.data() {
+                    return true;
+                }
+                ns = parent_ns;
+                continue;
+            }
+        }
+
+        return false;
+    }
+}
+
+/// 检查当前进程在指定 ns 中是否有某 capability
+pub fn ns_capable(ns: &Arc<UserNamespace>, cap: CAPFlags) -> bool {
+    let pcb = ProcessManager::current_pcb();
+    cap_capable(&pcb.cred(), ns, cap)
+}
+
+/// 检查当前进程在指定 ns 中是否有某 capability（setid 上下文）
+pub fn ns_capable_setid(ns: &Arc<UserNamespace>, cap: CAPFlags) -> bool {
+    ns_capable(ns, cap)
+}
+
+/// 当进程进入新的 user namespace 时重置 credentials
+///
+/// 遵循 Linux 语义：
+/// - 能力集重置为 FULL（在新 ns 中有全部能力）
+/// - securebits 重置为默认值
+/// - uid/gid/euid/egid/fsuid/fsgid **不改变**
+/// - user_ns 指向新的 namespace
+pub fn set_cred_user_ns(cred: &mut Cred, user_ns: Arc<UserNamespace>) {
+    cred.cap_inheritable = CAPFlags::CAP_EMPTY_SET;
+    cred.cap_permitted = CAPFlags::CAP_FULL_SET;
+    cred.cap_effective = CAPFlags::CAP_FULL_SET;
+    cred.cap_ambient = CAPFlags::CAP_EMPTY_SET;
+    cred.cap_bset = CAPFlags::CAP_FULL_SET;
+    cred.user_ns = user_ns;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -529,7 +529,7 @@ impl ProcessManager {
 
         if (clone_flags & (CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_FS)
             == (CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_FS))
-            || (clone_flags & (CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_FS))
+            || (clone_flags & (CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_FS))
                 == (CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_FS)
         {
             return Err(SystemError::EINVAL);

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1697,6 +1697,18 @@ impl ProcessControlBlock {
         self.fs.write()
     }
 
+    #[inline(always)]
+    pub fn fs_struct_is_shared(&self) -> bool {
+        Arc::strong_count(&*self.fs.read()) > 1
+    }
+
+    pub fn set_fs_struct(&self, fs: Arc<FsStruct>) -> Arc<FsStruct> {
+        let mut guard = self.fs.write();
+        let old = guard.clone();
+        *guard = fs;
+        old
+    }
+
     pub fn pwd_inode(&self) -> Arc<dyn IndexNode> {
         self.fs.read().pwd()
     }

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -5,6 +5,7 @@ use system_error::SystemError;
 use crate::{
     filesystem::vfs::{IndexNode, VFS_MAX_FOLLOW_SYMLINK_TIMES},
     process::{
+        cred::Cred,
         fork::CloneFlags,
         namespace::{
             cgroup_namespace::{CgroupNamespace, INIT_CGROUP_NAMESPACE},
@@ -148,8 +149,18 @@ impl ProcessManager {
             return Ok(());
         }
 
-        // todo: 这里要添加一个对user_namespace的处理
-        // https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/nsproxy.c?r=&mo=3770&fi=151#165
+        let user_ns = if clone_flags.contains(CloneFlags::CLONE_NEWUSER) {
+            let mut new_cred = (*child_pcb.cred()).clone();
+            let new_user_ns =
+                crate::process::namespace::user_namespace::UserNamespace::create_user_ns(
+                    &new_cred,
+                )?;
+            crate::process::cred::set_cred_user_ns(&mut new_cred, new_user_ns.clone());
+            child_pcb.set_cred(Cred::new_arc(new_cred))?;
+            new_user_ns
+        } else {
+            child_pcb.cred().user_ns.clone()
+        };
 
         /*
          * CLONE_NEWIPC must detach from the undolist: after switching
@@ -164,7 +175,6 @@ impl ProcessManager {
         {
             return Err(SystemError::EINVAL);
         }
-        let user_ns = child_pcb.cred().user_ns.clone();
         let new_ns = create_new_namespaces(clone_flags, child_pcb, user_ns)?;
         // 设置新的nsproxy
 

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -3,7 +3,10 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use system_error::SystemError;
 
 use crate::{
-    filesystem::vfs::{IndexNode, VFS_MAX_FOLLOW_SYMLINK_TIMES},
+    filesystem::{
+        fs::FsStruct,
+        vfs::{IndexNode, VFS_MAX_FOLLOW_SYMLINK_TIMES},
+    },
     process::{
         cred::Cred,
         fork::CloneFlags,
@@ -291,33 +294,41 @@ pub fn switch_task_namespaces(
     tsk: &Arc<ProcessControlBlock>,
     new_nsproxy: Arc<NsProxy>,
 ) -> Result<(), SystemError> {
-    let rebound_paths = if Arc::ptr_eq(tsk.nsproxy().mnt_namespace(), &new_nsproxy.mnt_ns) {
-        None
-    } else {
-        Some(resolve_fs_paths_for_new_mntns(tsk, &new_nsproxy.mnt_ns)?)
-    };
+    let fs = tsk.fs_struct();
+    switch_task_namespaces_with_fs(tsk, &fs, new_nsproxy)
+}
 
-    tsk.set_nsproxy(new_nsproxy);
-
-    if let Some((new_root, new_pwd)) = rebound_paths {
-        let fs = tsk.fs_struct_mut();
-        fs.set_root(new_root);
-        fs.set_pwd(new_pwd);
+pub(crate) fn switch_task_namespaces_with_fs(
+    tsk: &Arc<ProcessControlBlock>,
+    fs: &Arc<FsStruct>,
+    new_nsproxy: Arc<NsProxy>,
+) -> Result<(), SystemError> {
+    if !Arc::ptr_eq(tsk.nsproxy().mnt_namespace(), &new_nsproxy.mnt_ns) {
+        prepare_fs_for_new_mntns(fs, &new_nsproxy.mnt_ns)?;
     }
 
+    tsk.set_nsproxy(new_nsproxy);
+    Ok(())
+}
+
+pub(crate) fn prepare_fs_for_new_mntns(
+    fs: &Arc<FsStruct>,
+    new_mntns: &Arc<MntNamespace>,
+) -> Result<(), SystemError> {
+    let (new_root, new_pwd) = resolve_fs_paths_for_new_mntns(fs, new_mntns)?;
+    fs.set_root(new_root);
+    fs.set_pwd(new_pwd);
     Ok(())
 }
 
 type ReboundFsPaths = (Arc<dyn IndexNode>, Arc<dyn IndexNode>);
 
 fn resolve_fs_paths_for_new_mntns(
-    tsk: &Arc<ProcessControlBlock>,
+    fs: &Arc<FsStruct>,
     new_mntns: &Arc<MntNamespace>,
 ) -> Result<ReboundFsPaths, SystemError> {
-    let fs = tsk.fs_struct();
     let old_root_path = fs.root().absolute_path()?;
     let old_pwd_path = fs.pwd().absolute_path()?;
-    drop(fs);
 
     let new_root = resolve_from_namespace_root(new_mntns, &old_root_path)?;
     let new_pwd = resolve_from_namespace_root(new_mntns, &old_pwd_path)?;

--- a/kernel/src/process/namespace/setns.rs
+++ b/kernel/src/process/namespace/setns.rs
@@ -4,7 +4,7 @@ use system_error::SystemError;
 
 use crate::{
     filesystem::vfs::file::{FilePrivateData, NamespaceFilePrivateData},
-    process::{fork::CloneFlags, ProcessManager, RawPid},
+    process::{cred::Cred, fork::CloneFlags, ProcessManager, RawPid},
 };
 
 use super::nsproxy::{switch_task_namespaces, NsProxy};
@@ -143,9 +143,12 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
             // 仅影响子进程 PID namespace，保持与 Linux 语义一致
             new_inner.pid_ns_for_children = ns;
         }
-        NamespaceFilePrivateData::User(_ns) => {
-            // 暂未实现 user namespace 切换
-            return Err(SystemError::EINVAL);
+        NamespaceFilePrivateData::User(ns) => {
+            if !flags.is_empty() && !flags.contains(CloneFlags::CLONE_NEWUSER) {
+                return Err(SystemError::EINVAL);
+            }
+            userns_install(&current, ns)?;
+            return Ok(());
         }
         NamespaceFilePrivateData::Cgroup(ns) => {
             if !flags.is_empty() && !flags.contains(CloneFlags::CLONE_NEWCGROUP) {
@@ -159,6 +162,35 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
 
     // 5. 原子切换当前任务的 namespace 代理
     switch_task_namespaces(&current, new_nsproxy)?;
+
+    Ok(())
+}
+
+/// 安装（切换）user namespace（对应 Linux userns_install）
+fn userns_install(
+    current: &Arc<crate::process::ProcessControlBlock>,
+    user_ns: Arc<super::user_namespace::UserNamespace>,
+) -> Result<(), SystemError> {
+    // 1. 不能与当前 ns 相同（防止重复获得能力）
+    if Arc::ptr_eq(&current.cred().user_ns, &user_ns) {
+        return Err(SystemError::EINVAL);
+    }
+
+    // 2. 不能共享线程组
+    if !current.threads_read_irqsave().thread_group_empty() {
+        return Err(SystemError::EINVAL);
+    }
+
+    // 3. 需要 CAP_SYS_ADMIN 在目标 ns
+    // TODO: 实现 ns_capable 后启用
+    // if !ns_capable(&user_ns, CAPFlags::CAP_SYS_ADMIN) {
+    //     return Err(SystemError::EPERM);
+    // }
+
+    // 4. 重置 credentials
+    let mut new_cred = (*current.cred()).clone();
+    crate::process::cred::set_cred_user_ns(&mut new_cred, user_ns);
+    current.set_cred(Cred::new_arc(new_cred))?;
 
     Ok(())
 }

--- a/kernel/src/process/namespace/setns.rs
+++ b/kernel/src/process/namespace/setns.rs
@@ -16,14 +16,14 @@ use super::nsproxy::{switch_task_namespaces, NsProxy};
 /// 内核态 setns 实现（当前仅支持 pidfd + namespace flag 形式）
 ///
 /// - `fd`：必须是通过 `pidfd_open` 或 `clone(CLONE_PIDFD)` 获得的 pidfd
-/// - `nstype`：命名空间 flag 组合，仅允许 CLONE_NEWNS/CLONE_NEWUTS/CLONE_NEWIPC/
-///   CLONE_NEWNET/CLONE_NEWPID/CLONE_NEWCGROUP，且不能为空
+/// - `nstype`：命名空间 flag 组合。pidfd 路径当前仅支持 CLONE_NEWNS/CLONE_NEWUTS/
+///   CLONE_NEWIPC/CLONE_NEWNET/CLONE_NEWPID/CLONE_NEWCGROUP；namespace fd 路径额外支持 CLONE_NEWUSER
 ///
 /// 语义（与 Linux setns(pidfd, flags) 对齐的子集）：
 /// - 针对指定 flag，从目标任务的 `NsProxy` 中拷贝对应 namespace 引用，
 ///   在当前任务上构造新的 `NsProxy` 并通过 `switch_task_namespaces` 原子替换
 /// - CLONE_NEWPID 仅影响 `pid_ns_for_children`（与 DragonOS/ Linux 一致）
-/// - 不支持 USER/TIME namespace 以及 `/proc/<pid>/ns/*` 路径
+/// - user namespace 当前仅支持通过 `/proc/<pid>/ns/user` 这类 namespace fd 进入
 #[inline(never)]
 pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
     // 1. 解析并校验 flag
@@ -34,6 +34,7 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
             | CloneFlags::CLONE_NEWUTS.bits()
             | CloneFlags::CLONE_NEWIPC.bits()
             | CloneFlags::CLONE_NEWNET.bits()
+            | CloneFlags::CLONE_NEWUSER.bits()
             | CloneFlags::CLONE_NEWPID.bits()
             | CloneFlags::CLONE_NEWCGROUP.bits(),
     );
@@ -67,6 +68,9 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
             return Err(SystemError::EBADF);
         }
         if flags.is_empty() {
+            return Err(SystemError::EINVAL);
+        }
+        if flags.contains(CloneFlags::CLONE_NEWUSER) {
             return Err(SystemError::EINVAL);
         }
 
@@ -185,12 +189,17 @@ fn userns_install(
         return Err(SystemError::EINVAL);
     }
 
-    // 3. 需要 CAP_SYS_ADMIN 在目标 ns
+    // 3. 不能共享 fs_struct
+    if current.fs_struct_is_shared() {
+        return Err(SystemError::EINVAL);
+    }
+
+    // 4. 需要 CAP_SYS_ADMIN 在目标 ns
     if !ns_capable(&user_ns, CAPFlags::CAP_SYS_ADMIN) {
         return Err(SystemError::EPERM);
     }
 
-    // 4. 重置 credentials
+    // 5. 先准备新的 cred，全部校验通过后再提交
     let mut new_cred = (*current.cred()).clone();
     crate::process::cred::set_cred_user_ns(&mut new_cred, user_ns);
     current.set_cred(Cred::new_arc(new_cred))?;

--- a/kernel/src/process/namespace/setns.rs
+++ b/kernel/src/process/namespace/setns.rs
@@ -4,7 +4,11 @@ use system_error::SystemError;
 
 use crate::{
     filesystem::vfs::file::{FilePrivateData, NamespaceFilePrivateData},
-    process::{cred::Cred, fork::CloneFlags, ProcessManager, RawPid},
+    process::{
+        cred::{ns_capable, CAPFlags, Cred},
+        fork::CloneFlags,
+        ProcessManager, RawPid,
+    },
 };
 
 use super::nsproxy::{switch_task_namespaces, NsProxy};
@@ -182,10 +186,9 @@ fn userns_install(
     }
 
     // 3. 需要 CAP_SYS_ADMIN 在目标 ns
-    // TODO: 实现 ns_capable 后启用
-    // if !ns_capable(&user_ns, CAPFlags::CAP_SYS_ADMIN) {
-    //     return Err(SystemError::EPERM);
-    // }
+    if !ns_capable(&user_ns, CAPFlags::CAP_SYS_ADMIN) {
+        return Err(SystemError::EPERM);
+    }
 
     // 4. 重置 credentials
     let mut new_cred = (*current.cred()).clone();

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -2,25 +2,47 @@ use alloc::sync::Arc;
 
 use system_error::SystemError;
 
-use crate::process::{
-    cred::Cred,
-    fork::CloneFlags,
-    namespace::nsproxy::{switch_task_namespaces, NsProxy},
-    ProcessManager,
+use crate::{
+    filesystem::fs::FsStruct,
+    process::{
+        cred::Cred,
+        fork::CloneFlags,
+        namespace::nsproxy::{
+            create_new_namespaces, switch_task_namespaces, switch_task_namespaces_with_fs,
+            NsProxy,
+        },
+        ProcessManager,
+    },
 };
 
 /// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/fork.c#3385
 pub fn ksys_unshare(flags: CloneFlags) -> Result<(), SystemError> {
+    let flags = normalize_unshare_flags(flags);
+
     // 检查 unshare 标志位
     check_unshare_flags(flags)?;
 
-    let new_nsproxy = unshare_nsproxy_namespaces(flags)?;
+    let current_pcb = ProcessManager::current_pcb();
+    let mut new_cred = unshare_user_cred(flags, &current_pcb)?;
+    let new_fs = unshare_fs_struct(flags, &current_pcb)?;
+    let new_nsproxy = unshare_nsproxy_namespaces(flags, &current_pcb, new_cred.as_ref(), new_fs.as_ref())?;
 
     if let Some(new_nsproxy) = new_nsproxy {
-        // 更新当前进程的 Namespace 代理
-        let current_pcb = ProcessManager::current_pcb();
-        switch_task_namespaces(&current_pcb, new_nsproxy)?;
+        if let Some(new_fs) = new_fs.as_ref() {
+            switch_task_namespaces_with_fs(&current_pcb, new_fs, new_nsproxy)?;
+        } else {
+            switch_task_namespaces(&current_pcb, new_nsproxy)?;
+        }
     }
+
+    if let Some(new_fs) = new_fs {
+        current_pcb.set_fs_struct(new_fs);
+    }
+
+    if let Some(new_cred) = new_cred.take() {
+        current_pcb.set_cred(Cred::new_arc(new_cred))?;
+    }
+
     // TODO: 处理其他命名空间的 unshare 操作
     // CLONE_FS, CLONE_FILES, CLONE_SIGHAND, CLONE_VM, CLONE_THREAD, CLONE_SYSVSEM,
     // CLONE_NEWUTS, CLONE_NEWIPC, CLONE_NEWUSER, CLONE_NEWNET, CLONE_NEWCGROUP, CLONE_NEWTIME
@@ -28,9 +50,62 @@ pub fn ksys_unshare(flags: CloneFlags) -> Result<(), SystemError> {
     Ok(())
 }
 
+#[inline(always)]
+fn normalize_unshare_flags(mut flags: CloneFlags) -> CloneFlags {
+    if flags.contains(CloneFlags::CLONE_NEWUSER) {
+        flags |= CloneFlags::CLONE_THREAD | CloneFlags::CLONE_FS;
+    }
+    if flags.contains(CloneFlags::CLONE_VM) {
+        flags |= CloneFlags::CLONE_SIGHAND;
+    }
+    if flags.contains(CloneFlags::CLONE_SIGHAND) {
+        flags |= CloneFlags::CLONE_THREAD;
+    }
+    if flags.contains(CloneFlags::CLONE_NEWNS) {
+        flags |= CloneFlags::CLONE_FS;
+    }
+    flags
+}
+
+#[inline(never)]
+fn unshare_user_cred(
+    unshare_flags: CloneFlags,
+    current_pcb: &Arc<crate::process::ProcessControlBlock>,
+) -> Result<Option<Cred>, SystemError> {
+    if !unshare_flags.contains(CloneFlags::CLONE_NEWUSER) {
+        return Ok(None);
+    }
+
+    let mut new_cred = (*current_pcb.cred()).clone();
+    let new_user_ns =
+        crate::process::namespace::user_namespace::UserNamespace::create_user_ns(&new_cred)?;
+    crate::process::cred::set_cred_user_ns(&mut new_cred, new_user_ns);
+    Ok(Some(new_cred))
+}
+
+#[inline(never)]
+fn unshare_fs_struct(
+    unshare_flags: CloneFlags,
+    current_pcb: &Arc<crate::process::ProcessControlBlock>,
+) -> Result<Option<Arc<FsStruct>>, SystemError> {
+    if !unshare_flags.contains(CloneFlags::CLONE_FS) {
+        return Ok(None);
+    }
+
+    if !current_pcb.fs_struct_is_shared() {
+        return Ok(None);
+    }
+
+    let current_fs = current_pcb.fs_struct();
+    Ok(Some(Arc::new((*current_fs).clone())))
+}
+
 #[inline(never)]
 fn unshare_nsproxy_namespaces(
     unshare_flags: CloneFlags,
+    current_pcb: &Arc<crate::process::ProcessControlBlock>,
+    new_cred: Option<&Cred>,
+    _new_fs: Option<&Arc<FsStruct>>,
 ) -> Result<Option<Arc<NsProxy>>, SystemError> {
     const ALL_VALID_FLAGS: CloneFlags = CloneFlags::from_bits_truncate(
         CloneFlags::CLONE_NEWNS.bits()
@@ -45,21 +120,13 @@ fn unshare_nsproxy_namespaces(
         return Ok(None);
     }
 
-    let current_pcb = ProcessManager::current_pcb();
+    let user_ns = new_cred
+        .map(|cred| cred.user_ns.clone())
+        .unwrap_or_else(ProcessManager::current_user_ns);
 
-    let user_ns = if unshare_flags.contains(CloneFlags::CLONE_NEWUSER) {
-        let mut new_cred = (*current_pcb.cred()).clone();
-        let new_user_ns =
-            crate::process::namespace::user_namespace::UserNamespace::create_user_ns(&new_cred)?;
-        crate::process::cred::set_cred_user_ns(&mut new_cred, new_user_ns.clone());
-        current_pcb.set_cred(Cred::new_arc(new_cred))?;
-        new_user_ns
-    } else {
-        ProcessManager::current_user_ns()
-    };
+    let nsproxy = create_new_namespaces(&unshare_flags, current_pcb, user_ns)?;
 
-    let nsproxy = super::nsproxy::create_new_namespaces(&unshare_flags, &current_pcb, user_ns)?;
-    return Ok(Some(nsproxy));
+    Ok(Some(nsproxy))
 }
 
 #[inline(never)]

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -3,6 +3,7 @@ use alloc::sync::Arc;
 use system_error::SystemError;
 
 use crate::process::{
+    cred::Cred,
     fork::CloneFlags,
     namespace::nsproxy::{switch_task_namespaces, NsProxy},
     ProcessManager,
@@ -44,9 +45,18 @@ fn unshare_nsproxy_namespaces(
         return Ok(None);
     }
 
-    // 获取当前进程的 PCB
     let current_pcb = ProcessManager::current_pcb();
-    let user_ns = ProcessManager::current_user_ns();
+
+    let user_ns = if unshare_flags.contains(CloneFlags::CLONE_NEWUSER) {
+        let mut new_cred = (*current_pcb.cred()).clone();
+        let new_user_ns =
+            crate::process::namespace::user_namespace::UserNamespace::create_user_ns(&new_cred)?;
+        crate::process::cred::set_cred_user_ns(&mut new_cred, new_user_ns.clone());
+        current_pcb.set_cred(Cred::new_arc(new_cred))?;
+        new_user_ns
+    } else {
+        ProcessManager::current_user_ns()
+    };
 
     let nsproxy = super::nsproxy::create_new_namespaces(&unshare_flags, &current_pcb, user_ns)?;
     return Ok(Some(nsproxy));

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -8,8 +8,7 @@ use crate::{
         cred::Cred,
         fork::CloneFlags,
         namespace::nsproxy::{
-            create_new_namespaces, switch_task_namespaces, switch_task_namespaces_with_fs,
-            NsProxy,
+            create_new_namespaces, switch_task_namespaces, switch_task_namespaces_with_fs, NsProxy,
         },
         ProcessManager,
     },
@@ -25,7 +24,8 @@ pub fn ksys_unshare(flags: CloneFlags) -> Result<(), SystemError> {
     let current_pcb = ProcessManager::current_pcb();
     let mut new_cred = unshare_user_cred(flags, &current_pcb)?;
     let new_fs = unshare_fs_struct(flags, &current_pcb)?;
-    let new_nsproxy = unshare_nsproxy_namespaces(flags, &current_pcb, new_cred.as_ref(), new_fs.as_ref())?;
+    let new_nsproxy =
+        unshare_nsproxy_namespaces(flags, &current_pcb, new_cred.as_ref(), new_fs.as_ref())?;
 
     if let Some(new_nsproxy) = new_nsproxy {
         if let Some(new_fs) = new_fs.as_ref() {

--- a/kernel/src/process/namespace/user_namespace.rs
+++ b/kernel/src/process/namespace/user_namespace.rs
@@ -348,3 +348,205 @@ impl ProcessManager {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn make_extent(first: u32, lower_first: u32, count: u32) -> UidGidExtent {
+        UidGidExtent {
+            first,
+            lower_first,
+            count,
+        }
+    }
+
+    fn make_map_inline(extents: &[UidGidExtent]) -> UidGidMap {
+        let mut map = UidGidMap::default();
+        for (i, e) in extents.iter().enumerate() {
+            map.extent[i] = *e;
+        }
+        map.nr_extents
+            .store(extents.len() as u32, core::sync::atomic::Ordering::Release);
+        map
+    }
+
+    fn make_map_heap(extents: &[UidGidExtent]) -> UidGidMap {
+        let mut map = UidGidMap::default();
+        let mut forward = extents.to_vec();
+        forward.sort_by_key(|e| e.first);
+        let mut reverse = extents.to_vec();
+        reverse.sort_by_key(|e| e.lower_first);
+        map.forward = Some(forward);
+        map.reverse = Some(reverse);
+        map.nr_extents
+            .store(extents.len() as u32, core::sync::atomic::Ordering::Release);
+        map
+    }
+
+    // ── map_id_down ──
+
+    #[test]
+    fn test_map_id_down_empty() {
+        let map = UidGidMap::default();
+        assert_eq!(map_id_down(&map, 0), None);
+        assert_eq!(map_id_down(&map, 1000), None);
+    }
+
+    #[test]
+    fn test_map_id_down_single_extent() {
+        let map = make_map_inline(&[make_extent(0, 1000, 10)]);
+        assert_eq!(map_id_down(&map, 0), Some(1000));
+        assert_eq!(map_id_down(&map, 5), Some(1005));
+        assert_eq!(map_id_down(&map, 9), Some(1009));
+        assert_eq!(map_id_down(&map, 10), None);
+    }
+
+    #[test]
+    fn test_map_id_down_offset_extent() {
+        let map = make_map_inline(&[make_extent(100, 200, 50)]);
+        assert_eq!(map_id_down(&map, 99), None);
+        assert_eq!(map_id_down(&map, 100), Some(200));
+        assert_eq!(map_id_down(&map, 149), Some(349));
+        assert_eq!(map_id_down(&map, 150), None);
+    }
+
+    #[test]
+    fn test_map_id_down_multiple_inline() {
+        let map = make_map_inline(&[make_extent(0, 100, 10), make_extent(1000, 5000, 20)]);
+        assert_eq!(map_id_down(&map, 5), Some(105));
+        assert_eq!(map_id_down(&map, 1005), Some(5005));
+        assert_eq!(map_id_down(&map, 500), None);
+    }
+
+    #[test]
+    fn test_map_id_down_identity() {
+        let map = UidGidMap::new_identity();
+        assert_eq!(map_id_down(&map, 0), Some(0));
+        assert_eq!(map_id_down(&map, 1000), Some(1000));
+        assert_eq!(map_id_down(&map, u32::MAX - 1), Some(u32::MAX - 1));
+    }
+
+    #[test]
+    fn test_map_id_down_heap_binary_search() {
+        let extents: Vec<UidGidExtent> = (0..10)
+            .map(|i| make_extent(i * 100, i * 1000, 50))
+            .collect();
+        let map = make_map_heap(&extents);
+        assert_eq!(map_id_down(&map, 0), Some(0));
+        assert_eq!(map_id_down(&map, 250), Some(2500));
+        assert_eq!(map_id_down(&map, 949), Some(9400));
+        assert_eq!(map_id_down(&map, 950), None);
+        assert_eq!(map_id_down(&map, 5000), None);
+    }
+
+    // ── map_id_up ──
+
+    #[test]
+    fn test_map_id_up_empty() {
+        let map = UidGidMap::default();
+        assert_eq!(map_id_up(&map, 0), None);
+    }
+
+    #[test]
+    fn test_map_id_up_single_extent() {
+        let map = make_map_inline(&[make_extent(100, 500, 10)]);
+        assert_eq!(map_id_up(&map, 500), Some(100));
+        assert_eq!(map_id_up(&map, 509), Some(109));
+        assert_eq!(map_id_up(&map, 499), None);
+        assert_eq!(map_id_up(&map, 510), None);
+    }
+
+    #[test]
+    fn test_map_id_up_identity() {
+        let map = UidGidMap::new_identity();
+        assert_eq!(map_id_up(&map, 0), Some(0));
+        assert_eq!(map_id_up(&map, u32::MAX - 1), Some(u32::MAX - 1));
+    }
+
+    #[test]
+    fn test_map_id_up_heap_binary_search() {
+        let extents: Vec<UidGidExtent> = (0..10)
+            .map(|i| make_extent(i * 100, i * 1000, 50))
+            .collect();
+        let map = make_map_heap(&extents);
+        assert_eq!(map_id_up(&map, 0), Some(0));
+        assert_eq!(map_id_up(&map, 2500), Some(250));
+        assert_eq!(map_id_up(&map, 9400), Some(940));
+        assert_eq!(map_id_up(&map, 9450), None);
+    }
+
+    // ── map_id_range_down ──
+
+    #[test]
+    fn test_map_id_range_down_zero_count() {
+        let map = UidGidMap::default();
+        assert_eq!(map_id_range_down(&map, 42, 0), Some(42));
+    }
+
+    #[test]
+    fn test_map_id_range_down_within_extent() {
+        let map = make_map_inline(&[make_extent(0, 100, 50)]);
+        assert_eq!(map_id_range_down(&map, 0, 10), Some(100));
+        assert_eq!(map_id_range_down(&map, 5, 20), Some(105));
+    }
+
+    #[test]
+    fn test_map_id_range_down_cross_extent_fails() {
+        let map = make_map_inline(&[make_extent(0, 100, 10), make_extent(100, 200, 10)]);
+        // 跨越两个不连续的 extent，映射不连续
+        assert_eq!(map_id_range_down(&map, 0, 20), None);
+    }
+
+    #[test]
+    fn test_map_id_range_down_out_of_range() {
+        let map = make_map_inline(&[make_extent(0, 100, 10)]);
+        assert_eq!(map_id_range_down(&map, 0, 11), None);
+        assert_eq!(map_id_range_down(&map, 10, 1), None);
+    }
+
+    // ── UidGidMap constructors ──
+
+    #[test]
+    fn test_default_map_not_written() {
+        let map = UidGidMap::default();
+        assert!(!map.is_written());
+        assert_eq!(map.get_nr_extents(), 0);
+    }
+
+    #[test]
+    fn test_identity_map_written() {
+        let map = UidGidMap::new_identity();
+        assert!(map.is_written());
+        assert_eq!(map.get_nr_extents(), 1);
+    }
+
+    #[test]
+    fn test_roundtrip_inline() {
+        let map = make_map_inline(&[make_extent(0, 1000, 100)]);
+        for id in 0..100u32 {
+            let down = map_id_down(&map, id).unwrap();
+            assert_eq!(down, id + 1000);
+            let up = map_id_up(&map, down).unwrap();
+            assert_eq!(up, id);
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_heap() {
+        let extents: Vec<UidGidExtent> = (0..8)
+            .map(|i| make_extent(i * 100, i * 1000 + 500, 50))
+            .collect();
+        let map = make_map_heap(&extents);
+        for i in 0..8u32 {
+            for offset in [0, 25, 49] {
+                let child_id = i * 100 + offset;
+                let parent_id = map_id_down(&map, child_id).unwrap();
+                assert_eq!(parent_id, i * 1000 + 500 + offset);
+                let back = map_id_up(&map, parent_id).unwrap();
+                assert_eq!(back, child_id);
+            }
+        }
+    }
+}

--- a/kernel/src/process/namespace/user_namespace.rs
+++ b/kernel/src/process/namespace/user_namespace.rs
@@ -1,27 +1,213 @@
 use alloc::sync::{Arc, Weak};
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt::Debug;
+use core::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
 use crate::libs::spinlock::SpinLock;
-use crate::process::ProcessManager;
+use crate::process::{cred::CAPFlags, Cred, ProcessManager};
+use system_error::SystemError;
 
 use super::nsproxy::NsCommon;
 use super::{NamespaceOps, NamespaceType};
-use alloc::vec::Vec;
+
+/// UID/GID 映射区间
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UidGidExtent {
+    /// 子命名空间中的起始 ID
+    pub first: u32,
+    /// 父命名空间中的起始 ID（写入后会被转换为 kernel-global ID）
+    pub lower_first: u32,
+    /// 映射数量
+    pub count: u32,
+}
+
+/// 内联 extent 最大数量
+pub const UID_GID_MAP_MAX_BASE_EXTENTS: usize = 5;
+/// 最大 extent 数量（与 Linux 一致）
+pub const UID_GID_MAP_MAX_EXTENTS: usize = 340;
+/// 默认 overflow UID
+pub const DEFAULT_OVERFLOWUID: u32 = 65534;
+/// 默认 overflow GID
+pub const DEFAULT_OVERFLOWGID: u32 = 65534;
+/// 允许 setgroups 的标志位
+pub const USERNS_SETGROUPS_ALLOWED: u32 = 1;
+
+/// UID/GID 映射表
+/// 采用小映射优化：≤5 个 extent 使用内联数组，否则堆分配
+pub struct UidGidMap {
+    /// 当前 extent 数量（使用原子操作保证并发可见性）
+    pub nr_extents: AtomicU32,
+    /// 内联存储（≤5 extents）
+    pub extent: [UidGidExtent; UID_GID_MAP_MAX_BASE_EXTENTS],
+    /// 堆分配的前向排序数组（按 first 排序，用于 map_id_down）
+    pub forward: Option<Vec<UidGidExtent>>,
+    /// 堆分配的反向排序数组（按 lower_first 排序，用于 map_id_up）
+    pub reverse: Option<Vec<UidGidExtent>>,
+}
+
+impl Default for UidGidMap {
+    fn default() -> Self {
+        Self {
+            nr_extents: AtomicU32::new(0),
+            extent: [UidGidExtent {
+                first: 0,
+                lower_first: 0,
+                count: 0,
+            }; UID_GID_MAP_MAX_BASE_EXTENTS],
+            forward: None,
+            reverse: None,
+        }
+    }
+}
+
+impl UidGidMap {
+    /// 创建 identity mapping（用于 init_user_ns）
+    pub fn new_identity() -> Self {
+        let mut map = Self::default();
+        map.extent[0] = UidGidExtent {
+            first: 0,
+            lower_first: 0,
+            count: u32::MAX,
+        };
+        map.nr_extents.store(1, AtomicOrdering::Release);
+        map
+    }
+
+    /// 检查映射是否已写入（只写一次）
+    pub fn is_written(&self) -> bool {
+        self.nr_extents.load(AtomicOrdering::Acquire) != 0
+    }
+
+    /// 获取 extent 数量
+    pub fn get_nr_extents(&self) -> u32 {
+        self.nr_extents.load(AtomicOrdering::Acquire)
+    }
+}
+
+/// 将 id 从 child namespace 映射到 parent namespace（map_id_down）
+/// 在 map 的 extent 中查找，child id 匹配 extent.first
+pub fn map_id_down(map: &UidGidMap, id: u32) -> Option<u32> {
+    let nr = map.get_nr_extents() as usize;
+    if nr == 0 {
+        return None;
+    }
+
+    let extents: &[UidGidExtent] = if nr <= UID_GID_MAP_MAX_BASE_EXTENTS {
+        &map.extent[..nr]
+    } else {
+        map.forward.as_deref().unwrap_or(&[])
+    };
+
+    // 线性扫描或二分查找
+    let idx = if nr <= UID_GID_MAP_MAX_BASE_EXTENTS {
+        extents
+            .iter()
+            .position(|e| id >= e.first && id < e.first.saturating_add(e.count))?
+    } else {
+        // 二分查找（forward 按 first 排序）
+        match extents.binary_search_by(|e| e.first.cmp(&id)) {
+            Ok(i) => i,
+            Err(i) => {
+                if i == 0 {
+                    return None;
+                }
+                // 检查前一个 extent 是否包含 id
+                let e = &extents[i - 1];
+                if id >= e.first && id < e.first.saturating_add(e.count) {
+                    i - 1
+                } else {
+                    return None;
+                }
+            }
+        }
+    };
+
+    let e = &extents[idx];
+    Some((id - e.first) + e.lower_first)
+}
+
+/// 将 id 从 parent namespace 映射到 child namespace（map_id_up）
+/// 在 map 的 extent 中查找，parent id 匹配 extent.lower_first
+pub fn map_id_up(map: &UidGidMap, id: u32) -> Option<u32> {
+    let nr = map.get_nr_extents() as usize;
+    if nr == 0 {
+        return None;
+    }
+
+    let extents: &[UidGidExtent] = if nr <= UID_GID_MAP_MAX_BASE_EXTENTS {
+        &map.extent[..nr]
+    } else {
+        map.reverse.as_deref().unwrap_or(&[])
+    };
+
+    let idx = if nr <= UID_GID_MAP_MAX_BASE_EXTENTS {
+        extents
+            .iter()
+            .position(|e| id >= e.lower_first && id < e.lower_first.saturating_add(e.count))?
+    } else {
+        match extents.binary_search_by(|e| e.lower_first.cmp(&id)) {
+            Ok(i) => i,
+            Err(i) => {
+                if i == 0 {
+                    return None;
+                }
+                let e = &extents[i - 1];
+                if id >= e.lower_first && id < e.lower_first.saturating_add(e.count) {
+                    i - 1
+                } else {
+                    return None;
+                }
+            }
+        }
+    };
+
+    let e = &extents[idx];
+    Some((id - e.lower_first) + e.first)
+}
+
+/// 范围 down 映射：验证 [id, id+count) 都能被映射
+pub fn map_id_range_down(map: &UidGidMap, id: u32, count: u32) -> Option<u32> {
+    if count == 0 {
+        return Some(id);
+    }
+    let end = id.saturating_add(count - 1);
+    let mapped_start = map_id_down(map, id)?;
+    let mapped_end = map_id_down(map, end)?;
+    // 验证映射是连续的
+    if mapped_end != mapped_start.saturating_add(count - 1) {
+        return None;
+    }
+    Some(mapped_start)
+}
 
 lazy_static! {
     pub static ref INIT_USER_NAMESPACE: Arc<UserNamespace> = UserNamespace::new_root();
 }
 
 pub struct UserNamespace {
-    parent: Option<Weak<UserNamespace>>,
+    pub parent: Option<Weak<UserNamespace>>,
     nscommon: NsCommon,
     self_ref: Weak<UserNamespace>,
-    _inner: SpinLock<InnerUserNamespace>,
+    pub inner: SpinLock<InnerUserNamespace>,
 }
 
 pub struct InnerUserNamespace {
-    _children: Vec<Arc<UserNamespace>>,
+    pub children: Vec<Arc<UserNamespace>>,
+    /// UID 映射表
+    pub uid_map: UidGidMap,
+    /// GID 映射表
+    pub gid_map: UidGidMap,
+    /// Project ID 映射表（预留）
+    pub projid_map: UidGidMap,
+    /// 所有者 UID（在父命名空间中的 kernel-global ID，用 usize 存储 Kuid）
+    pub owner: usize,
+    /// 所有者 GID
+    pub group: usize,
+    /// 标志位 (USERNS_SETGROUPS_ALLOWED)
+    pub flags: u32,
+    /// 创建时父进程是否有 CAP_SETFCAP
+    pub parent_could_setfcap: bool,
 }
 
 impl NamespaceOps for UserNamespace {
@@ -31,14 +217,21 @@ impl NamespaceOps for UserNamespace {
 }
 
 impl UserNamespace {
-    /// 创建root user namespace
+    /// 创建 root user namespace
     fn new_root() -> Arc<Self> {
         Arc::new_cyclic(|self_ref| Self {
             self_ref: self_ref.clone(),
             nscommon: NsCommon::new(0, NamespaceType::User),
             parent: None,
-            _inner: SpinLock::new(InnerUserNamespace {
-                _children: Vec::new(),
+            inner: SpinLock::new(InnerUserNamespace {
+                children: Vec::new(),
+                uid_map: UidGidMap::new_identity(),
+                gid_map: UidGidMap::new_identity(),
+                projid_map: UidGidMap::default(),
+                owner: 0,
+                group: 0,
+                flags: USERNS_SETGROUPS_ALLOWED,
+                parent_could_setfcap: true,
             }),
         })
     }
@@ -48,19 +241,12 @@ impl UserNamespace {
         self.nscommon.level
     }
 
+    /// 获取父命名空间
+    pub fn parent_ns(&self) -> Option<Arc<UserNamespace>> {
+        self.parent.as_ref().and_then(|p| p.upgrade())
+    }
+
     /// 检查当前用户命名空间是否是另一个用户命名空间的祖先
-    ///
-    /// # 参数
-    /// * `other` - 要检查的目标用户命名空间
-    ///
-    /// # 返回值
-    /// * `true` - 如果当前命名空间是 `other` 的祖先
-    /// * `false` - 如果当前命名空间不是 `other` 的祖先
-    ///
-    /// # 说明
-    /// 该方法通过遍历 `other` 的父命名空间链来判断当前命名空间是否为其祖先。
-    /// 如果两个命名空间处于同一层级且指向同一个对象，则认为是祖先关系。
-    /// 如果当前命名空间的层级大于目标命名空间，则不可能是祖先关系。
     pub fn is_ancestor_of(&self, other: &Arc<Self>) -> bool {
         let mut current = other.clone();
         let self_level = self.level();
@@ -80,11 +266,75 @@ impl UserNamespace {
             }
         }
     }
+
+    /// 创建新的 user namespace（对应 Linux create_user_ns）
+    ///
+    /// 调用者提供当前进程的 cred，函数会基于 cred 的 user_ns 作为父 namespace
+    /// 创建新的 user namespace，并返回新 namespace 的 Arc。
+    ///
+    /// 注意：此函数**不**修改 cred，调用者需要自行调用 set_cred_user_ns。
+    pub fn create_user_ns(cred: &Cred) -> Result<Arc<Self>, SystemError> {
+        let parent_ns = cred.user_ns.clone();
+
+        // 1. 嵌套深度检查
+        if parent_ns.level() >= 32 {
+            return Err(SystemError::ENOSPC);
+        }
+
+        // 2. chroot 检查（简化版：检查当前 fs.root 是否与 init 不同）
+        // TODO: 实现更严格的 chroot 检查
+
+        // 3. 创建者的 euid/egid 在父 ns 中必须有有效映射
+        // 对于 init_user_ns，这总是成立的（identity mapping）
+        // 对于子 ns，需要验证映射存在
+
+        // 4. 创建新的 UserNamespace
+        let new_ns = Arc::new_cyclic(|self_ref| {
+            let ns = Self {
+                self_ref: self_ref.clone(),
+                nscommon: NsCommon::new(parent_ns.level() + 1, NamespaceType::User),
+                parent: Some(Arc::downgrade(&parent_ns)),
+                inner: SpinLock::new(InnerUserNamespace {
+                    children: Vec::new(),
+                    uid_map: UidGidMap::default(),
+                    gid_map: UidGidMap::default(),
+                    projid_map: UidGidMap::default(),
+                    owner: cred.euid.data(),
+                    group: cred.egid.data(),
+                    flags: USERNS_SETGROUPS_ALLOWED,
+                    parent_could_setfcap: cred
+                        .cap_effective
+                        .contains(crate::process::cred::CAPFlags::CAP_SETFCAP),
+                }),
+            };
+            ns
+        });
+
+        // 5. 将新 ns 添加到父 ns 的 children 列表
+        {
+            let mut parent_inner = parent_ns.inner.lock();
+            parent_inner.children.push(new_ns.clone());
+        }
+
+        Ok(new_ns)
+    }
+}
+
+/// 检查 user namespace 中是否允许 setgroups
+///
+/// 需要同时满足：
+/// 1. gid_map 已写入（有有效的 GID 映射）
+/// 2. setgroups 未被拒绝（USERNS_SETGROUPS_ALLOWED 标志）
+pub fn userns_may_setgroups(ns: &Arc<UserNamespace>) -> bool {
+    let inner = ns.inner.lock();
+    inner.gid_map.is_written() && (inner.flags & USERNS_SETGROUPS_ALLOWED) != 0
 }
 
 impl Debug for UserNamespace {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UserNamespace").finish()
+        f.debug_struct("UserNamespace")
+            .field("level", &self.level())
+            .finish()
     }
 }
 

--- a/kernel/src/process/namespace/user_namespace.rs
+++ b/kernel/src/process/namespace/user_namespace.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 use core::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
 use crate::libs::spinlock::SpinLock;
-use crate::process::{cred::CAPFlags, Cred, ProcessManager};
+use crate::process::{Cred, ProcessManager};
 use system_error::SystemError;
 
 use super::nsproxy::NsCommon;
@@ -26,10 +26,7 @@ pub struct UidGidExtent {
 pub const UID_GID_MAP_MAX_BASE_EXTENTS: usize = 5;
 /// 最大 extent 数量（与 Linux 一致）
 pub const UID_GID_MAP_MAX_EXTENTS: usize = 340;
-/// 默认 overflow UID
-pub const DEFAULT_OVERFLOWUID: u32 = 65534;
-/// 默认 overflow GID
-pub const DEFAULT_OVERFLOWGID: u32 = 65534;
+
 /// 允许 setgroups 的标志位
 pub const USERNS_SETGROUPS_ALLOWED: u32 = 1;
 

--- a/kernel/src/process/syscall/sys_groups.rs
+++ b/kernel/src/process/syscall/sys_groups.rs
@@ -71,9 +71,14 @@ impl Syscall for SysSetGroups {
         let pcb = ProcessManager::current_pcb();
 
         // Linux: requires CAP_SETGID in the current user namespace.
-        // For now we treat "root" or CAP_SETGID in effective set as privileged.
         let current_cred = pcb.cred();
-        if current_cred.euid.data() != 0 && !current_cred.has_capability(CAPFlags::CAP_SETGID) {
+        let user_ns = current_cred.user_ns.clone();
+        if !crate::process::cred::ns_capable_setid(&user_ns, CAPFlags::CAP_SETGID) {
+            return Err(SystemError::EPERM);
+        }
+
+        // 在 user namespace 中，setgroups 还受 gid_map 和 setgroups flag 限制
+        if !crate::process::namespace::user_namespace::userns_may_setgroups(&user_ns) {
             return Err(SystemError::EPERM);
         }
 

--- a/user/apps/tests/dunitest/suites/normal/user_namespace_id_map.cc
+++ b/user/apps/tests/dunitest/suites/normal/user_namespace_id_map.cc
@@ -1,0 +1,706 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#ifndef CLONE_FS
+#define CLONE_FS 0x00000200
+#endif
+
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER 0x10000000
+#endif
+
+#ifndef SYS_setns
+#ifdef __NR_setns
+#define SYS_setns __NR_setns
+#endif
+#endif
+
+namespace {
+
+constexpr size_t kCloneStackSize = 1 << 20;
+constexpr int kChildWaitTimeoutSec = 5;
+
+std::string errno_detail(const char* step, int err) {
+    std::string detail(step);
+    detail += ": errno=";
+    detail += std::to_string(err);
+    detail += " (";
+    detail += strerror(err);
+    detail += ")";
+    return detail;
+}
+
+std::string expected_map_line(unsigned first, unsigned lower, unsigned count) {
+    char buf[128] = {};
+    snprintf(buf, sizeof(buf), "%10u %10u %10u\n", first, lower, count);
+    return std::string(buf);
+}
+
+int write_text_file(const char* path, const std::string& content) {
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        return errno;
+    }
+
+    size_t written = 0;
+    while (written < content.size()) {
+        ssize_t n = write(fd, content.data() + written, content.size() - written);
+        if (n < 0) {
+            int err = errno;
+            close(fd);
+            return err;
+        }
+        written += static_cast<size_t>(n);
+    }
+
+    close(fd);
+    return 0;
+}
+
+int read_text_file(const char* path, std::string* out) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return errno;
+    }
+
+    out->clear();
+    char buf[128];
+    for (;;) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n < 0) {
+            int err = errno;
+            close(fd);
+            return err;
+        }
+        if (n == 0) {
+            break;
+        }
+        out->append(buf, static_cast<size_t>(n));
+    }
+
+    close(fd);
+    return 0;
+}
+
+int read_link_text(const char* path, std::string* out) {
+    char buf[256] = {};
+    ssize_t n = readlink(path, buf, sizeof(buf) - 1);
+    if (n < 0) {
+        return errno;
+    }
+
+    buf[n] = '\0';
+    *out = std::string(buf, static_cast<size_t>(n));
+    return 0;
+}
+
+void send_detail(int fd, const std::string& detail) {
+    if (fd < 0 || detail.empty()) {
+        return;
+    }
+
+    size_t written = 0;
+    while (written < detail.size()) {
+        ssize_t n = write(fd, detail.data() + written, detail.size() - written);
+        if (n <= 0) {
+            return;
+        }
+        written += static_cast<size_t>(n);
+    }
+}
+
+std::string read_pipe_detail(int fd) {
+    std::string out;
+    char buf[256];
+
+    for (;;) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n <= 0) {
+            break;
+        }
+        out.append(buf, static_cast<size_t>(n));
+    }
+
+    return out;
+}
+
+bool wait_for_child_exit(pid_t child, int* status, int timeout_sec, bool kill_on_timeout,
+                         std::string* detail) {
+    constexpr useconds_t kPollIntervalUs = 100000;
+    const int max_polls = timeout_sec * 1000000 / kPollIntervalUs;
+
+    for (int i = 0; i < max_polls; ++i) {
+        pid_t ret = waitpid(child, status, WNOHANG);
+        if (ret == child) {
+            return true;
+        }
+        if (ret < 0) {
+            if (detail != nullptr) {
+                *detail = errno_detail("waitpid", errno);
+            }
+            return false;
+        }
+        usleep(kPollIntervalUs);
+    }
+
+    if (kill_on_timeout) {
+        kill(child, SIGKILL);
+        waitpid(child, status, 0);
+    }
+    if (detail != nullptr) {
+        *detail = "timed out waiting for child";
+    }
+    return false;
+}
+
+using UserNsRunner = int (*)(void*, std::string*);
+
+struct CloneContext {
+    UserNsRunner runner;
+    void* arg;
+    int status_fd;
+};
+
+struct FirstLevelArgs {
+    unsigned uid;
+    unsigned gid;
+};
+
+struct NestedLevelArgs {
+    unsigned expected_visible_uid;
+};
+
+struct HeldClone {
+    pid_t pid = -1;
+    int release_fd = -1;
+    std::vector<char> stack = std::vector<char>(kCloneStackSize);
+};
+
+struct HoldCloneContext {
+    int ready_fd;
+    int wait_fd;
+};
+
+int clone_runner_entry(void* opaque) {
+    CloneContext* ctx = static_cast<CloneContext*>(opaque);
+    std::string detail;
+    int rc = ctx->runner(ctx->arg, &detail);
+    send_detail(ctx->status_fd, detail);
+    close(ctx->status_fd);
+    return rc;
+}
+
+int hold_clone_entry(void* opaque) {
+    HoldCloneContext* ctx = static_cast<HoldCloneContext*>(opaque);
+    char ready = '1';
+    if (write(ctx->ready_fd, &ready, 1) != 1) {
+        close(ctx->ready_fd);
+        close(ctx->wait_fd);
+        return 1;
+    }
+
+    close(ctx->ready_fd);
+    char byte = 0;
+    while (read(ctx->wait_fd, &byte, 1) < 0) {
+        if (errno != EINTR) {
+            close(ctx->wait_fd);
+            return 1;
+        }
+    }
+
+    close(ctx->wait_fd);
+    return 0;
+}
+
+int run_in_new_userns(UserNsRunner runner, void* arg, std::string* detail) {
+    int pipefd[2] = {-1, -1};
+    if (pipe(pipefd) != 0) {
+        *detail = errno_detail("pipe", errno);
+        return 1;
+    }
+
+    std::vector<char> stack(kCloneStackSize);
+    CloneContext ctx = {
+        .runner = runner,
+        .arg = arg,
+        .status_fd = pipefd[1],
+    };
+
+    pid_t child = clone(clone_runner_entry, stack.data() + stack.size(), CLONE_NEWUSER | SIGCHLD,
+                        &ctx);
+    if (child < 0) {
+        int err = errno;
+        close(pipefd[0]);
+        close(pipefd[1]);
+        *detail = errno_detail("clone(CLONE_NEWUSER)", err);
+        return 1;
+    }
+
+    close(pipefd[1]);
+
+    int status = 0;
+    std::string wait_detail;
+    if (!wait_for_child_exit(child, &status, kChildWaitTimeoutSec, true, &wait_detail)) {
+        *detail = "clone child wait failed: " + wait_detail;
+        std::string child_detail = read_pipe_detail(pipefd[0]);
+        if (!child_detail.empty()) {
+            *detail += "; child detail: " + child_detail;
+        }
+        close(pipefd[0]);
+        return 1;
+    }
+
+    *detail = read_pipe_detail(pipefd[0]);
+    close(pipefd[0]);
+
+    if (!WIFEXITED(status)) {
+        if (detail->empty()) {
+            *detail = "child terminated abnormally";
+        }
+        return 1;
+    }
+
+    return WEXITSTATUS(status);
+}
+
+bool spawn_held_clone(int clone_flags, HeldClone* held, std::string* detail) {
+    int ready_pipe[2] = {-1, -1};
+    int release_pipe[2] = {-1, -1};
+    if (pipe(ready_pipe) != 0) {
+        *detail = errno_detail("pipe(ready)", errno);
+        return false;
+    }
+    if (pipe(release_pipe) != 0) {
+        int err = errno;
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+        *detail = errno_detail("pipe(release)", err);
+        return false;
+    }
+
+    HoldCloneContext ctx = {
+        .ready_fd = ready_pipe[1],
+        .wait_fd = release_pipe[0],
+    };
+
+    pid_t child = clone(hold_clone_entry, held->stack.data() + held->stack.size(),
+                        clone_flags | SIGCHLD, &ctx);
+    if (child < 0) {
+        int err = errno;
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+        close(release_pipe[0]);
+        close(release_pipe[1]);
+        *detail = errno_detail("clone(held child)", err);
+        return false;
+    }
+
+    close(ready_pipe[1]);
+    close(release_pipe[0]);
+
+    char ready = 0;
+    ssize_t n = read(ready_pipe[0], &ready, 1);
+    close(ready_pipe[0]);
+    if (n != 1) {
+        int status = 0;
+        std::string wait_detail;
+        wait_for_child_exit(child, &status, kChildWaitTimeoutSec, true, &wait_detail);
+        close(release_pipe[1]);
+        *detail = "held child did not reach ready state";
+        return false;
+    }
+
+    held->pid = child;
+    held->release_fd = release_pipe[1];
+    return true;
+}
+
+void cleanup_held_clone(HeldClone* held) {
+    if (held->pid < 0) {
+        return;
+    }
+
+    if (held->release_fd >= 0) {
+        char byte = 'x';
+        ssize_t ignored = write(held->release_fd, &byte, 1);
+        (void)ignored;
+        close(held->release_fd);
+        held->release_fd = -1;
+    }
+
+    int status = 0;
+    std::string detail;
+    if (!wait_for_child_exit(held->pid, &status, kChildWaitTimeoutSec, true, &detail)) {
+        // best effort cleanup; test process will report the original failure path
+    }
+    held->pid = -1;
+}
+
+int open_userns_fd(pid_t pid, std::string* detail) {
+    char path[64] = {};
+    snprintf(path, sizeof(path), "/proc/%d/ns/user", pid);
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        *detail = errno_detail("open target user ns fd", errno);
+        return -1;
+    }
+    return fd;
+}
+
+int read_userns_link_for_pid(pid_t pid, std::string* out) {
+    char path[64] = {};
+    snprintf(path, sizeof(path), "/proc/%d/ns/user", pid);
+    return read_link_text(path, out);
+}
+
+int run_second_level_userns(void* opaque, std::string* detail) {
+    const NestedLevelArgs& args = *static_cast<const NestedLevelArgs*>(opaque);
+
+    int err = write_text_file("/proc/self/uid_map", "0 0 1\n");
+    if (err != 0) {
+        *detail = errno_detail("write nested uid_map", err);
+        return 1;
+    }
+
+    err = write_text_file("/proc/self/setgroups", "deny\n");
+    if (err != 0) {
+        *detail = errno_detail("write nested setgroups=deny", err);
+        return 1;
+    }
+
+    err = write_text_file("/proc/self/gid_map", "0 0 1\n");
+    if (err != 0) {
+        *detail = errno_detail("write nested gid_map", err);
+        return 1;
+    }
+
+    std::string content;
+    err = read_text_file("/proc/self/uid_map", &content);
+    if (err != 0) {
+        *detail = errno_detail("read nested uid_map", err);
+        return 1;
+    }
+
+    if (content != expected_map_line(0, args.expected_visible_uid, 1)) {
+        *detail = "nested uid_map content mismatch: got='" + content + "' expected='"
+            + expected_map_line(0, args.expected_visible_uid, 1) + "'";
+        return 1;
+    }
+
+    return 0;
+}
+
+int run_first_level_userns(void* opaque, std::string* detail) {
+    const FirstLevelArgs& args = *static_cast<const FirstLevelArgs*>(opaque);
+    const std::string first_uid_map = "0 " + std::to_string(args.uid) + " 1\n";
+    const std::string first_gid_map = "0 " + std::to_string(args.gid) + " 1\n";
+
+    int err = write_text_file("/proc/self/uid_map", first_uid_map);
+    if (err != 0) {
+        *detail = errno_detail("write first uid_map", err);
+        return 1;
+    }
+
+    err = write_text_file("/proc/self/gid_map", first_gid_map);
+    if (err != EPERM) {
+        *detail = "first gid_map before setgroups deny returned ";
+        *detail += std::to_string(err);
+        *detail += ", expected EPERM(";
+        *detail += std::to_string(EPERM);
+        *detail += ")";
+        return 1;
+    }
+
+    err = write_text_file("/proc/self/setgroups", "deny\n");
+    if (err != 0) {
+        *detail = errno_detail("write first setgroups=deny", err);
+        return 1;
+    }
+
+    err = write_text_file("/proc/self/gid_map", first_gid_map);
+    if (err != 0) {
+        *detail = errno_detail("write first gid_map after deny", err);
+        return 1;
+    }
+
+    std::string content;
+    err = read_text_file("/proc/self/uid_map", &content);
+    if (err != 0) {
+        *detail = errno_detail("read first uid_map", err);
+        return 1;
+    }
+
+    if (content != expected_map_line(0, args.uid, 1)) {
+        *detail = "first uid_map content mismatch: got='" + content + "' expected='"
+            + expected_map_line(0, args.uid, 1) + "'";
+        return 1;
+    }
+
+    NestedLevelArgs nested = {
+        .expected_visible_uid = 0,
+    };
+    std::string nested_detail;
+    int rc = run_in_new_userns(run_second_level_userns, &nested, &nested_detail);
+    if (rc != 0) {
+        *detail = "nested userns failed: " + nested_detail;
+        return 1;
+    }
+
+    return 0;
+}
+
+int run_rootless_nested_id_map_flow(std::string* detail) {
+    unsigned uid = static_cast<unsigned>(geteuid());
+    unsigned gid = static_cast<unsigned>(getegid());
+
+    if (uid == 0) {
+        if (setgid(1000) != 0) {
+            *detail = errno_detail("setgid(1000)", errno);
+            return 1;
+        }
+        if (setuid(1000) != 0) {
+            *detail = errno_detail("setuid(1000)", errno);
+            return 1;
+        }
+        uid = static_cast<unsigned>(geteuid());
+        gid = static_cast<unsigned>(getegid());
+    }
+
+    FirstLevelArgs args = {
+        .uid = uid,
+        .gid = gid,
+    };
+    return run_in_new_userns(run_first_level_userns, &args, detail);
+}
+
+int run_unshare_newuser_changes_namespace(std::string* detail) {
+    std::string before;
+    int err = read_link_text("/proc/self/ns/user", &before);
+    if (err != 0) {
+        *detail = errno_detail("readlink before unshare userns", err);
+        return 1;
+    }
+
+    if (unshare(CLONE_NEWUSER) != 0) {
+        *detail = errno_detail("unshare(CLONE_NEWUSER)", errno);
+        return 1;
+    }
+
+    std::string after;
+    err = read_link_text("/proc/self/ns/user", &after);
+    if (err != 0) {
+        *detail = errno_detail("readlink after unshare userns", err);
+        return 1;
+    }
+
+    if (after == before) {
+        *detail = "user namespace did not change after unshare: before='" + before + "' after='"
+            + after + "'";
+        return 1;
+    }
+
+    return 0;
+}
+
+int run_setns_userns_namespace_fd_success(std::string* detail) {
+#ifndef SYS_setns
+    *detail = "SYS_setns is not available";
+    return 1;
+#else
+    std::string before;
+    int err = read_link_text("/proc/self/ns/user", &before);
+    if (err != 0) {
+        *detail = errno_detail("readlink before setns userns", err);
+        return 1;
+    }
+
+    HeldClone target;
+    if (!spawn_held_clone(CLONE_NEWUSER, &target, detail)) {
+        return 1;
+    }
+
+    int target_fd = open_userns_fd(target.pid, detail);
+    if (target_fd < 0) {
+        cleanup_held_clone(&target);
+        return 1;
+    }
+
+    std::string target_ns;
+    err = read_userns_link_for_pid(target.pid, &target_ns);
+    if (err != 0) {
+        close(target_fd);
+        cleanup_held_clone(&target);
+        *detail = errno_detail("readlink target userns", err);
+        return 1;
+    }
+
+    if (syscall(SYS_setns, target_fd, CLONE_NEWUSER) != 0) {
+        int sys_err = errno;
+        close(target_fd);
+        cleanup_held_clone(&target);
+        *detail = errno_detail("setns(CLONE_NEWUSER)", sys_err);
+        return 1;
+    }
+
+    std::string after;
+    err = read_link_text("/proc/self/ns/user", &after);
+    close(target_fd);
+    cleanup_held_clone(&target);
+    if (err != 0) {
+        *detail = errno_detail("readlink after setns userns", err);
+        return 1;
+    }
+
+    if (after != target_ns) {
+        *detail = "setns entered unexpected user namespace: got='" + after + "' expected='"
+            + target_ns + "'";
+        return 1;
+    }
+
+    if (after == before) {
+        *detail = "setns left user namespace unchanged: before='" + before + "' after='" + after
+            + "'";
+        return 1;
+    }
+
+    return 0;
+#endif
+}
+
+int run_setns_userns_rejects_shared_fs(std::string* detail) {
+#ifndef SYS_setns
+    *detail = "SYS_setns is not available";
+    return 1;
+#else
+    std::string before;
+    int err = read_link_text("/proc/self/ns/user", &before);
+    if (err != 0) {
+        *detail = errno_detail("readlink before shared-fs setns", err);
+        return 1;
+    }
+
+    HeldClone target;
+    if (!spawn_held_clone(CLONE_NEWUSER, &target, detail)) {
+        return 1;
+    }
+
+    int target_fd = open_userns_fd(target.pid, detail);
+    if (target_fd < 0) {
+        cleanup_held_clone(&target);
+        return 1;
+    }
+
+    HeldClone shared_fs_holder;
+    if (!spawn_held_clone(CLONE_FS, &shared_fs_holder, detail)) {
+        close(target_fd);
+        cleanup_held_clone(&target);
+        return 1;
+    }
+
+    errno = 0;
+    long ret = syscall(SYS_setns, target_fd, CLONE_NEWUSER);
+    int setns_err = errno;
+
+    std::string after;
+    err = read_link_text("/proc/self/ns/user", &after);
+
+    close(target_fd);
+    cleanup_held_clone(&shared_fs_holder);
+    cleanup_held_clone(&target);
+
+    if (ret == 0) {
+        *detail = "setns(CLONE_NEWUSER) unexpectedly succeeded while fs_struct was shared";
+        return 1;
+    }
+
+    if (setns_err != EINVAL) {
+        *detail = "setns(CLONE_NEWUSER) with shared fs returned errno=";
+        *detail += std::to_string(setns_err);
+        *detail += ", expected EINVAL(";
+        *detail += std::to_string(EINVAL);
+        *detail += ")";
+        return 1;
+    }
+
+    if (err != 0) {
+        *detail = errno_detail("readlink after shared-fs setns", err);
+        return 1;
+    }
+
+    if (after != before) {
+        *detail = "user namespace changed despite shared-fs rejection: before='" + before
+            + "' after='" + after + "'";
+        return 1;
+    }
+
+    return 0;
+#endif
+}
+
+void expect_child_success(const char* case_name, int (*fn)(std::string*)) {
+    int pipefd[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(pipefd)) << case_name << ": pipe failed: errno=" << errno << " ("
+                               << strerror(errno) << ")";
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << case_name << ": fork failed: errno=" << errno << " ("
+                        << strerror(errno) << ")";
+
+    if (child == 0) {
+        close(pipefd[0]);
+        std::string detail;
+        int rc = fn(&detail);
+        send_detail(pipefd[1], detail);
+        close(pipefd[1]);
+        _exit(rc);
+    }
+
+    close(pipefd[1]);
+
+    int status = 0;
+    std::string wait_detail;
+    ASSERT_TRUE(wait_for_child_exit(child, &status, kChildWaitTimeoutSec, true, &wait_detail))
+        << case_name << ": " << wait_detail;
+
+    std::string detail = read_pipe_detail(pipefd[0]);
+    close(pipefd[0]);
+
+    ASSERT_TRUE(WIFEXITED(status)) << case_name << ": child terminated abnormally";
+    EXPECT_EQ(0, WEXITSTATUS(status)) << case_name << ": " << detail;
+}
+
+TEST(UserNamespaceIdMap, RootlessSingleAndNestedSelfMaps) {
+    expect_child_success("rootless_nested_id_map_flow", run_rootless_nested_id_map_flow);
+}
+
+TEST(UserNamespaceControl, UnshareNewUserChangesNamespace) {
+    expect_child_success("unshare_newuser_changes_namespace", run_unshare_newuser_changes_namespace);
+}
+
+TEST(UserNamespaceControl, NamespaceFdSetnsSucceedsWhenFsExclusive) {
+    expect_child_success("setns_userns_namespace_fd_success", run_setns_userns_namespace_fd_success);
+}
+
+TEST(UserNamespaceControl, NamespaceFdSetnsRejectsSharedFs) {
+    expect_child_success("setns_userns_rejects_shared_fs", run_setns_userns_rejects_shared_fs);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -15,3 +15,4 @@ normal/tcp_close_semantics
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
+normal/user_namespace_id_map


### PR DESCRIPTION
Implement core user namespace infrastructure referencing Linux 6.6.21:

- UidGidExtent/UidGidMap data structures with inline (<=5 extents) and heap-allocated (>5 extents) mapping, plus map_id_down/up binary search for UID/GID translation
- create_user_ns() with credential reset (full caps in new ns) and 32-level nesting limit
- CLONE_NEWUSER integration in fork (nsproxy), unshare, and setns (with userns_install)
- cap_capable/ns_capable/ns_capable_setid with Linux-style hierarchy traversal (4-case model)
- /proc/[pid]/uid_map, gid_map, setgroups procfs files with extent parsing, permission checks, and sorted reverse map generation
- setgroups namespace-aware check via userns_may_setgroups