### PR TITLE
perf(spinlock): narrow SpinLock atomic memory orderings

### DIFF
--- a/kernel/src/libs/spinlock.rs
+++ b/kernel/src/libs/spinlock.rs
@@ -120,7 +120,7 @@ impl<T> SpinLock<T> {
     fn inner_try_lock(&self) -> bool {
         let res = self
             .lock
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_ok();
         return res;
     }
@@ -147,16 +147,16 @@ impl<T> SpinLock<T> {
     /// 由于这样做可能导致preempt count不正确，因此必须小心的手动维护好preempt count。
     /// 如非必要，请不要使用这个函数。
     pub unsafe fn force_unlock(&self) {
-        self.lock.store(false, Ordering::SeqCst);
+        self.lock.store(false, Ordering::Release);
     }
 
     fn unlock(&self) {
-        self.lock.store(false, Ordering::SeqCst);
+        self.lock.store(false, Ordering::Release);
         ProcessManager::preempt_enable();
     }
 
     pub fn is_locked(&self) -> bool {
-        self.lock.load(Ordering::SeqCst)
+        self.lock.load(Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
* compare_exchange: use `Ordering::Acquire` on success and `Ordering::Relaxed` on failure
* use `Ordering::Release` when releasing the lock
* use `Ordering::Relaxed` for is_locked()