### PR TITLE
refactor(procfs): align pid-scoped proc entries with pid and mount namespace semantics

### DIFF
--- a/kernel/src/filesystem/procfs/loadavg.rs
+++ b/kernel/src/filesystem/procfs/loadavg.rs
@@ -7,6 +7,7 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
+    process::{nr_threads, ProcessManager},
     sched::loadavg,
 };
 use alloc::{borrow::ToOwned, format, sync::Arc, sync::Weak, vec::Vec};
@@ -35,12 +36,9 @@ impl LoadavgFileOps {
         let loads = loadavg::get_avenrun(loadavg::FIXED_1 / 200, 0);
 
         let running = loadavg::nr_running();
-        let total = crate::process::all_process()
-            .lock_irqsave()
-            .as_ref()
-            .map(|m| m.len() as u32)
-            .unwrap_or(0);
-        let last_pid = crate::process::ProcessManager::current_pidns()
+        let total = nr_threads();
+        let last_pid = ProcessManager::current_pcb()
+            .active_pid_ns()
             .last_pid()
             .data() as u32;
 

--- a/kernel/src/filesystem/procfs/mod.rs
+++ b/kernel/src/filesystem/procfs/mod.rs
@@ -7,7 +7,7 @@ use system_error::SystemError;
 
 use crate::{
     libs::once::Once,
-    process::{cred::Cred, ProcessManager},
+    process::{cred::Cred, namespace::pid_namespace::INIT_PID_NAMESPACE, ProcessManager},
 };
 
 use super::vfs::mount::{MountFlags, MountPath};
@@ -75,7 +75,7 @@ pub fn procfs_init() -> Result<(), SystemError> {
     INIT.call_once(|| {
         ::log::info!("Initializing ProcFS...");
         // 创建 procfs 实例
-        let procfs: Arc<ProcFS> = ProcFS::new();
+        let procfs: Arc<ProcFS> = ProcFS::new(INIT_PID_NAMESPACE.clone());
         let root_inode = ProcessManager::current_mntns().root_inode();
         // procfs 挂载
         let mntfs = root_inode

--- a/kernel/src/filesystem/procfs/mounts.rs
+++ b/kernel/src/filesystem/procfs/mounts.rs
@@ -4,16 +4,18 @@
 
 use crate::libs::mutex::MutexGuard;
 use crate::{
+    driver::base::device::device_number::DeviceNumber,
     filesystem::{
         procfs::{
             template::{Builder, FileOps, ProcFileBuilder},
             utils::proc_read,
         },
-        vfs::{FilePrivateData, IndexNode, InodeMode},
+        vfs::{mount::MountFS, FilePrivateData, IndexNode, InodeMode},
     },
-    process::ProcessManager,
+    process::{namespace::mnt::MntNamespace, ProcessControlBlock, ProcessManager},
 };
 use alloc::{
+    format,
     string::{String, ToString},
     sync::{Arc, Weak},
     vec::Vec,
@@ -26,112 +28,10 @@ pub struct MountsFileOps;
 
 impl MountsFileOps {
     pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self, InodeMode::S_IRUGO) // 0444 - 所有用户可读
+        ProcFileBuilder::new(Self, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
-    }
-}
-
-/// 生成 mounts 内容
-#[inline(never)]
-fn generate_mounts_like_content(fmt: MountsFormat) -> String {
-    let mntns = ProcessManager::current_mntns();
-    let mounts = mntns.mount_list().clone_inner();
-
-    // 以进程 fs root 为基准做 chroot 视图裁剪/重写
-    let pcb = ProcessManager::current_pcb();
-    let root_inode = pcb.fs_struct().root();
-    let root_prefix = root_inode
-        .absolute_path()
-        .unwrap_or_else(|_| "/".to_string());
-    let is_chrooted = root_prefix != "/";
-    let root_prefix_with_slash = if root_prefix.ends_with('/') {
-        root_prefix.clone()
-    } else {
-        root_prefix.clone() + "/"
-    };
-
-    let mut lines = Vec::with_capacity(mounts.len());
-    let mut cap = 0;
-    let mut mid: usize = 1;
-
-    for (mp, mfs) in mounts {
-        let mut line = String::new();
-        let fs_type = mfs.fs_type();
-        let source = mfs.mount_source().unwrap_or_else(|| match fs_type {
-            // 特殊文件系统，直接显示文件系统名称
-            "devfs" | "devpts" | "sysfs" | "procfs" | "tmpfs" | "ramfs" | "rootfs" | "debugfs"
-            | "configfs" => fs_type.to_string(),
-            // 其他文件系统：source 元数据缺失时回退为 fs type，避免错误显示挂载点名
-            _ => fs_type.to_string(),
-        });
-
-        // 过滤/改写 mountpoint（chroot 后应只暴露 root 下的挂载点，并重写为 chroot 视角）
-        let mut mountpoint = mp.as_str().to_string();
-        if is_chrooted {
-            if mountpoint == root_prefix {
-                mountpoint = "/".to_string();
-            } else if mountpoint.starts_with(&root_prefix_with_slash) {
-                // strip_prefix 会得到 "child/.."；保持以 '/' 开头
-                let stripped = &mountpoint[root_prefix.len()..];
-                mountpoint = if stripped.is_empty() {
-                    "/".to_string()
-                } else {
-                    stripped.to_string()
-                };
-            } else {
-                continue;
-            }
-        }
-
-        match fmt {
-            MountsFormat::Mounts => {
-                line.push_str(&format!("{source} {m} {fs_type}", m = mountpoint));
-                line.push(' ');
-                line.push_str(&mfs.mount_flags().options_string());
-                line.push_str(" 0 0\n");
-            }
-            MountsFormat::MountInfo => {
-                // 极简 mountinfo：只保证 mountpoint 字段正确且不泄露 chroot 前缀
-                // mount ID / parent ID / major:minor / root / mountpoint / options / - / fstype / source / superopts
-                line.push_str(&format!(
-                    "{id} {pid} 0:0 / {mp} {opts} - {fst} {src} {opts}\n",
-                    id = mid,
-                    pid = if mid == 1 { 0 } else { 1 },
-                    mp = mountpoint,
-                    opts = mfs.mount_flags().options_string(),
-                    fst = fs_type,
-                    src = source
-                ));
-            }
-        }
-
-        cap += line.len();
-        lines.push(line);
-        mid += 1;
-    }
-
-    let mut content = String::with_capacity(cap);
-    for line in lines {
-        content.push_str(&line);
-    }
-
-    return content;
-}
-
-impl FileOps for MountsFileOps {
-    fn read_at(
-        &self,
-        offset: usize,
-        len: usize,
-        buf: &mut [u8],
-        _data: MutexGuard<FilePrivateData>,
-    ) -> Result<usize, SystemError> {
-        let mounts_content = generate_mounts_like_content(MountsFormat::Mounts);
-        let bytes = mounts_content.as_bytes();
-
-        proc_read(offset, len, buf, bytes)
     }
 }
 
@@ -141,12 +41,229 @@ enum MountsFormat {
     MountInfo,
 }
 
-/// 为 /proc/<pid>/mountinfo 生成内容（极简版，满足 gVisor chroot_test）。
-pub(super) fn generate_mountinfo_content() -> String {
-    generate_mounts_like_content(MountsFormat::MountInfo)
+fn escape_mount_field(raw: &str) -> String {
+    let mut escaped = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        match ch {
+            ' ' => escaped.push_str("\\040"),
+            '\t' => escaped.push_str("\\011"),
+            '\n' => escaped.push_str("\\012"),
+            '\\' => escaped.push_str("\\\\"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn mount_source_display(mfs: &Arc<MountFS>, fs_type: &str) -> String {
+    mfs.mount_source().unwrap_or_else(|| match fs_type {
+        "devfs" | "devpts" | "sysfs" | "procfs" | "tmpfs" | "ramfs" | "rootfs" | "debugfs"
+        | "configfs" => fs_type.to_string(),
+        _ => fs_type.to_string(),
+    })
+}
+
+fn mount_root_display(mfs: &Arc<MountFS>) -> String {
+    let root = mfs
+        .root_inner_inode()
+        .absolute_path()
+        .unwrap_or_else(|_| "/".to_string());
+
+    if root.is_empty() {
+        "/".to_string()
+    } else {
+        root
+    }
+}
+
+fn mount_dev_display(mfs: &Arc<MountFS>) -> DeviceNumber {
+    mfs.mountpoint_root_inode()
+        .metadata()
+        .map(|md| DeviceNumber::from(md.dev_id as u32))
+        .unwrap_or_default()
+}
+
+fn rewrite_mountpoint_for_root(mountpoint: &str, root_prefix: &str) -> Option<String> {
+    if root_prefix == "/" {
+        return Some(mountpoint.to_string());
+    }
+
+    let root_prefix_with_slash = if root_prefix.ends_with('/') {
+        root_prefix.to_string()
+    } else {
+        format!("{root_prefix}/")
+    };
+
+    if mountpoint == root_prefix {
+        Some("/".to_string())
+    } else if let Some(stripped) = mountpoint.strip_prefix(&root_prefix_with_slash) {
+        if stripped.is_empty() {
+            Some("/".to_string())
+        } else {
+            Some(format!("/{stripped}"))
+        }
+    } else {
+        None
+    }
+}
+
+fn mountinfo_optional_fields(mfs: &Arc<MountFS>) -> String {
+    let propagation = mfs.propagation();
+    let mut fields = Vec::new();
+    let info = propagation.info_string();
+
+    if !info.is_empty() {
+        fields.push(info);
+    }
+    if propagation.is_unbindable() {
+        fields.push("unbindable".to_string());
+    }
+
+    if fields.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", fields.join(" "))
+    }
+}
+
+fn collect_mounts(mntns: &Arc<MntNamespace>) -> Vec<(String, Arc<MountFS>)> {
+    let mut mounts = mntns
+        .mount_list()
+        .clone_inner()
+        .into_iter()
+        .map(|(path, mfs)| (path.as_str().to_string(), mfs))
+        .collect::<Vec<_>>();
+
+    mounts.sort_by_key(|(_, mfs)| {
+        let mount_id: usize = mfs.mount_id().into();
+        mount_id
+    });
+    mounts
+}
+
+#[inline(never)]
+fn generate_mounts_like_content_for_view(
+    mntns: &Arc<MntNamespace>,
+    root_inode: Arc<dyn IndexNode>,
+    fmt: MountsFormat,
+) -> String {
+    let mounts = collect_mounts(mntns);
+    let root_prefix = root_inode
+        .absolute_path()
+        .unwrap_or_else(|_| "/".to_string());
+
+    let mut lines = Vec::with_capacity(mounts.len());
+    let mut cap = 0;
+
+    for (mount_path, mfs) in mounts {
+        let Some(mountpoint) = rewrite_mountpoint_for_root(&mount_path, &root_prefix) else {
+            continue;
+        };
+
+        let fs_type = mfs.fs_type();
+        let source = escape_mount_field(&mount_source_display(&mfs, fs_type));
+        let fs_type = escape_mount_field(fs_type);
+        let mountpoint = escape_mount_field(&mountpoint);
+        let mount_opts = mfs.mount_flags().options_string();
+
+        let line = match fmt {
+            MountsFormat::Mounts => {
+                format!("{source} {mountpoint} {fs_type} {mount_opts} 0 0\n")
+            }
+            MountsFormat::MountInfo => {
+                let mount_id: usize = mfs.mount_id().into();
+                let parent_id: usize = mfs
+                    .self_mountpoint()
+                    .map(|mountpoint_inode| {
+                        let parent_id: usize = mountpoint_inode.mount_fs().mount_id().into();
+                        parent_id
+                    })
+                    .unwrap_or(mount_id);
+                let dev = mount_dev_display(&mfs);
+                let root = escape_mount_field(&mount_root_display(&mfs));
+                let optional_fields = mountinfo_optional_fields(&mfs);
+
+                format!(
+                    "{mount_id} {parent_id} {}:{} {root} {mountpoint} {mount_opts}{optional_fields} - {fs_type} {source} {mount_opts}\n",
+                    dev.major().data(),
+                    dev.minor()
+                )
+            }
+        };
+
+        cap += line.len();
+        lines.push(line);
+    }
+
+    let mut content = String::with_capacity(cap);
+    for line in lines {
+        content.push_str(&line);
+    }
+    content
+}
+
+fn generate_mounts_like_content_for_task(
+    task: &Arc<ProcessControlBlock>,
+    fmt: MountsFormat,
+) -> String {
+    let nsproxy = task.nsproxy();
+    let fs = task.fs_struct();
+    generate_mounts_like_content_for_view(nsproxy.mnt_namespace(), fs.root(), fmt)
+}
+
+pub(super) fn cache_procfs_file_content(
+    data: &mut MutexGuard<FilePrivateData>,
+    content: String,
+) -> Result<(), SystemError> {
+    let FilePrivateData::Procfs(pdata) = &mut **data else {
+        return Err(SystemError::EIO);
+    };
+    pdata.data = content.into_bytes();
+    Ok(())
+}
+
+pub(super) fn read_cached_procfs_file_content(
+    offset: usize,
+    len: usize,
+    buf: &mut [u8],
+    data: MutexGuard<FilePrivateData>,
+) -> Result<usize, SystemError> {
+    let bytes = match &*data {
+        FilePrivateData::Procfs(pdata) => pdata.data.as_slice(),
+        _ => return Err(SystemError::EIO),
+    };
+
+    proc_read(offset, len, buf, bytes)
+}
+
+impl FileOps for MountsFileOps {
+    fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        cache_procfs_file_content(data, generate_mounts_content())
+    }
+
+    fn read_at(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        read_cached_procfs_file_content(offset, len, buf, data)
+    }
+}
+
+/// 为 /proc/<pid>/mountinfo 生成内容（目标任务视角）。
+pub(super) fn generate_mountinfo_content_for_task(task: &Arc<ProcessControlBlock>) -> String {
+    generate_mounts_like_content_for_task(task, MountsFormat::MountInfo)
 }
 
 /// 为 /proc/<pid>/mounts 生成内容。
 pub(super) fn generate_mounts_content() -> String {
-    generate_mounts_like_content(MountsFormat::Mounts)
+    let current = ProcessManager::current_pcb();
+    generate_mounts_like_content_for_task(&current, MountsFormat::Mounts)
+}
+
+/// 为 /proc/<pid>/mounts 生成内容（目标任务视角）。
+pub(super) fn generate_mounts_content_for_task(task: &Arc<ProcessControlBlock>) -> String {
+    generate_mounts_like_content_for_task(task, MountsFormat::Mounts)
 }

--- a/kernel/src/filesystem/procfs/pid/cgroup.rs
+++ b/kernel/src/filesystem/procfs/pid/cgroup.rs
@@ -5,12 +5,13 @@ use crate::{
     cgroup::cgroup_path_from_view,
     filesystem::{
         procfs::{
+            pid::ProcPidTarget,
             template::{Builder, FileOps, ProcFileBuilder},
             utils::proc_read,
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    process::{ProcessManager, RawPid},
+    process::ProcessManager,
 };
 use alloc::{
     format,
@@ -21,19 +22,22 @@ use system_error::SystemError;
 
 #[derive(Debug)]
 pub struct CgroupFileOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl CgroupFileOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
     }
 
     fn generate_content(&self) -> Result<Vec<u8>, SystemError> {
-        let target = ProcessManager::find(self.pid).ok_or(SystemError::ESRCH)?;
+        let target = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
         let viewer = ProcessManager::current_pcb();
 
         let target_cg = target.task_cgroup_node();

--- a/kernel/src/filesystem/procfs/pid/cmdline.rs
+++ b/kernel/src/filesystem/procfs/pid/cmdline.rs
@@ -47,7 +47,10 @@ impl FileOps for CmdlineFileOps {
 
         // 如果 cmdline 为空，返回进程名
         let mut content = if cmdline_bytes.is_empty() {
-            let name = pcb.basic().name().as_bytes().to_vec();
+            let name = {
+                let basic = pcb.basic();
+                basic.name().as_bytes().to_vec()
+            };
             let mut result = name;
             result.push(0); // 以 \0 结尾
             result

--- a/kernel/src/filesystem/procfs/pid/cmdline.rs
+++ b/kernel/src/filesystem/procfs/pid/cmdline.rs
@@ -2,30 +2,27 @@
 //!
 //! 返回进程的完整命令行，各参数之间以 \0 分隔
 
-use crate::libs::mutex::MutexGuard;
-use crate::{
-    filesystem::{
-        procfs::{
-            pid::find_process_by_vpid,
-            template::{Builder, FileOps, ProcFileBuilder},
-            utils::proc_read,
-        },
-        vfs::{FilePrivateData, IndexNode, InodeMode},
+use crate::filesystem::{
+    procfs::{
+        pid::ProcPidTarget,
+        template::{Builder, FileOps, ProcFileBuilder},
+        utils::proc_read,
     },
-    process::RawPid,
+    vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
 
 /// /proc/[pid]/cmdline 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct CmdlineFileOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl CmdlineFileOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -40,8 +37,10 @@ impl FileOps for CmdlineFileOps {
         buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        // 查找进程
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
 
         // 获取 cmdline 字节
         let cmdline_bytes = pcb.cmdline_bytes();

--- a/kernel/src/filesystem/procfs/pid/cmdline.rs
+++ b/kernel/src/filesystem/procfs/pid/cmdline.rs
@@ -37,10 +37,7 @@ impl FileOps for CmdlineFileOps {
         buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let pcb = self
-            .target
-            .thread_group_leader()
-            .ok_or(SystemError::ESRCH)?;
+        let pcb = self.target.task().ok_or(SystemError::ESRCH)?;
 
         // 获取 cmdline 字节
         let cmdline_bytes = pcb.cmdline_bytes();

--- a/kernel/src/filesystem/procfs/pid/exe.rs
+++ b/kernel/src/filesystem/procfs/pid/exe.rs
@@ -2,15 +2,12 @@
 //!
 //! 这个符号链接指向进程的可执行文件路径
 
-use crate::{
-    filesystem::{
-        procfs::{
-            pid::find_process_by_vpid,
-            template::{Builder, ProcSymBuilder, SymOps},
-        },
-        vfs::{IndexNode, InodeMode},
+use crate::filesystem::{
+    procfs::{
+        pid::ProcPidTarget,
+        template::{Builder, ProcSymBuilder, SymOps},
     },
-    process::RawPid,
+    vfs::{IndexNode, InodeMode},
 };
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
@@ -18,17 +15,12 @@ use system_error::SystemError;
 /// /proc/[pid]/exe 符号链接的 SymOps 实现
 #[derive(Debug)]
 pub struct ExeSymOps {
-    /// 存储 PID，在读取时动态查找进程
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl ExeSymOps {
-    pub fn new(pid: RawPid) -> Self {
-        Self { pid }
-    }
-
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcSymBuilder::new(Self::new(pid), InodeMode::S_IRWXUGO) // 0777 - 符号链接权限
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcSymBuilder::new(Self { target }, InodeMode::S_IRWXUGO) // 0777 - 符号链接权限
             .parent(parent)
             .build()
             .unwrap()
@@ -37,8 +29,10 @@ impl ExeSymOps {
 
 impl SymOps for ExeSymOps {
     fn read_link(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
-        // 动态查找进程，获取目标进程的可执行文件路径
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
         let exe = pcb.execute_path();
         let exe_bytes = exe.as_bytes();
         let len = exe_bytes.len().min(buf.len());

--- a/kernel/src/filesystem/procfs/pid/exe.rs
+++ b/kernel/src/filesystem/procfs/pid/exe.rs
@@ -29,10 +29,7 @@ impl ExeSymOps {
 
 impl SymOps for ExeSymOps {
     fn read_link(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
-        let pcb = self
-            .target
-            .thread_group_leader()
-            .ok_or(SystemError::ESRCH)?;
+        let pcb = self.target.task().ok_or(SystemError::ESRCH)?;
         let exe = pcb.execute_path();
         let exe_bytes = exe.as_bytes();
         let len = exe_bytes.len().min(buf.len());

--- a/kernel/src/filesystem/procfs/pid/fd.rs
+++ b/kernel/src/filesystem/procfs/pid/fd.rs
@@ -2,15 +2,12 @@
 //!
 //! 这个目录包含了进程打开的所有文件描述符的符号链接
 
-use crate::{
-    filesystem::{
-        procfs::{
-            pid::find_process_by_vpid,
-            template::{Builder, DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
-        },
-        vfs::{IndexNode, InodeMode, SpecialNodeData},
+use crate::filesystem::{
+    procfs::{
+        pid::ProcPidTarget,
+        template::{Builder, DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
     },
-    process::RawPid,
+    vfs::{IndexNode, InodeMode, SpecialNodeData},
 };
 use alloc::{
     format,
@@ -23,22 +20,20 @@ use system_error::SystemError;
 /// /proc/[pid]/fd 目录的 DirOps 实现
 #[derive(Debug)]
 pub struct FdDirOps {
-    /// 存储 PID，在需要时动态查找进程
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl FdDirOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self { pid }, InodeMode::from_bits_truncate(0o500)) // dr-x------
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self { target }, InodeMode::from_bits_truncate(0o500)) // dr-x------
             .parent(parent)
             .volatile() // fd 是易失的，因为它们与特定进程关联
             .build()
             .unwrap()
     }
 
-    /// 获取进程引用
     fn get_process(&self) -> Option<Arc<crate::process::ProcessControlBlock>> {
-        find_process_by_vpid(self.pid)
+        self.target.thread_group_leader()
     }
 }
 
@@ -72,7 +67,7 @@ impl DirOps for FdDirOps {
         }
 
         // 创建新的符号链接（传递 PID 和 fd）
-        let inode = FdSymOps::new_inode(self.pid, fd, dir.self_ref_weak().clone());
+        let inode = FdSymOps::new_inode(self.target.clone(), fd, dir.self_ref_weak().clone());
         cached_children.insert(name.to_string(), inode.clone());
 
         Ok(inode)
@@ -99,7 +94,7 @@ impl DirOps for FdDirOps {
 
                 // 创建或获取缓存的符号链接（传递 PID 和 fd）
                 cached_children.entry(fd_str.clone()).or_insert_with(|| {
-                    FdSymOps::new_inode(self.pid, fd, dir.self_ref_weak().clone())
+                    FdSymOps::new_inode(self.target.clone(), fd, dir.self_ref_weak().clone())
                 });
             }
         }
@@ -110,14 +105,17 @@ impl DirOps for FdDirOps {
 /// /proc/[pid]/fd/[fd] 符号链接的 SymOps 实现
 #[derive(Debug)]
 pub struct FdSymOps {
-    /// 存储 PID，在需要时动态查找进程
-    pid: RawPid,
+    target: ProcPidTarget,
     fd: i32,
 }
 
 impl FdSymOps {
-    pub fn new_inode(pid: RawPid, fd: i32, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcSymBuilder::new(Self { pid, fd }, InodeMode::from_bits_truncate(0o700)) // lrwx------
+    pub fn new_inode(
+        target: ProcPidTarget,
+        fd: i32,
+        parent: Weak<dyn IndexNode>,
+    ) -> Arc<dyn IndexNode> {
+        ProcSymBuilder::new(Self { target, fd }, InodeMode::from_bits_truncate(0o700)) // lrwx------
             .parent(parent)
             .volatile()
             .build()
@@ -127,8 +125,10 @@ impl FdSymOps {
 
 impl SymOps for FdSymOps {
     fn read_link(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
-        // 动态查找进程
-        let process = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let process = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
 
         // 先获取文件对象的 clone，然后立即释放 fd_table 锁
         // 避免在持有锁时调用可能获取其他锁的方法（如 absolute_path）
@@ -179,8 +179,7 @@ impl SymOps for FdSymOps {
     }
 
     fn special_node(&self) -> Option<SpecialNodeData> {
-        // 动态查找进程
-        let process = find_process_by_vpid(self.pid)?;
+        let process = self.target.thread_group_leader()?;
 
         // 获取文件对象
         let file = {

--- a/kernel/src/filesystem/procfs/pid/fdinfo.rs
+++ b/kernel/src/filesystem/procfs/pid/fdinfo.rs
@@ -2,17 +2,14 @@
 //!
 //! 这个目录包含了进程打开的所有文件描述符的详细信息
 
-use crate::libs::mutex::MutexGuard;
-use crate::{
-    filesystem::{
-        procfs::{
-            pid::find_process_by_vpid,
-            template::{Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder},
-        },
-        vfs::{FilePrivateData, IndexNode, InodeMode},
+use crate::filesystem::{
+    procfs::{
+        pid::ProcPidTarget,
+        template::{Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder},
     },
-    process::RawPid,
+    vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use alloc::{
     string::ToString,
     sync::{Arc, Weak},
@@ -23,22 +20,20 @@ use system_error::SystemError;
 /// /proc/[pid]/fdinfo 目录的 DirOps 实现
 #[derive(Debug)]
 pub struct FdInfoDirOps {
-    /// 存储 PID，在需要时动态查找进程
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl FdInfoDirOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self { pid }, InodeMode::from_bits_truncate(0o555))
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self { target }, InodeMode::from_bits_truncate(0o555))
             .parent(parent)
             .volatile()
             .build()
             .unwrap()
     }
 
-    /// 获取进程引用
     fn get_process(&self) -> Option<Arc<crate::process::ProcessControlBlock>> {
-        find_process_by_vpid(self.pid)
+        self.target.thread_group_leader()
     }
 }
 
@@ -72,7 +67,7 @@ impl DirOps for FdInfoDirOps {
         }
 
         // 创建新的 fdinfo 文件
-        let inode = FdInfoFileOps::new_inode(self.pid, fd, dir.self_ref_weak().clone());
+        let inode = FdInfoFileOps::new_inode(self.target.clone(), fd, dir.self_ref_weak().clone());
         cached_children.insert(name.to_string(), inode.clone());
 
         Ok(inode)
@@ -95,7 +90,7 @@ impl DirOps for FdInfoDirOps {
             for fd in fds {
                 let fd_str = fd.to_string();
                 cached_children.entry(fd_str.clone()).or_insert_with(|| {
-                    FdInfoFileOps::new_inode(self.pid, fd, dir.self_ref_weak().clone())
+                    FdInfoFileOps::new_inode(self.target.clone(), fd, dir.self_ref_weak().clone())
                 });
             }
         }
@@ -113,7 +108,11 @@ pub struct FdInfoFileOps {
 }
 
 impl FdInfoFileOps {
-    pub fn new_inode(_pid: RawPid, _fd: i32, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+    pub fn new_inode(
+        _target: ProcPidTarget,
+        _fd: i32,
+        parent: Weak<dyn IndexNode>,
+    ) -> Arc<dyn IndexNode> {
         ProcFileBuilder::new(
             Self {
                 phantom: core::marker::PhantomData,
@@ -134,33 +133,6 @@ impl FileOps for FdInfoFileOps {
         _buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        // // 动态查找进程
-        // let process = ProcessManager::find(self.pid).ok_or(SystemError::ESRCH)?;
-
-        // // 获取文件信息
-        // let file = {
-        //     let fd_table = process.fd_table();
-        //     let fd_table_guard = fd_table.read();
-        //     fd_table_guard
-        //         .get_file_by_fd(self.fd)
-        //         .ok_or(SystemError::EBADF)?
-        // };
-
-        // // 生成 fdinfo 内容
-        // let mut content = Vec::new();
-
-        // // pos: 当前文件偏移量
-        // let pos = file.offset;
-        // content.extend_from_slice(format!("pos:\t{}\n", pos).as_bytes());
-
-        // // flags: 文件打开标志（八进制）
-        // let flags = file.mode().bits();
-        // content.extend_from_slice(format!("flags:\t{:#o}\n", flags).as_bytes());
-
-        // // mnt_id: 挂载点 ID（简化实现，返回 0）
-        // content.extend_from_slice(b"mnt_id:\t0\n");
-
-        // proc_read(offset, len, buf, &content)
         Ok(0)
     }
 }

--- a/kernel/src/filesystem/procfs/pid/id_map.rs
+++ b/kernel/src/filesystem/procfs/pid/id_map.rs
@@ -6,7 +6,7 @@ use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
-            pid::find_process_by_vpid,
+            pid::ProcPidTarget,
             template::{Builder, FileOps, ProcFileBuilder},
             ProcfsFilePrivateData,
         },
@@ -18,7 +18,6 @@ use crate::{
             map_id_down, map_id_range_down, map_id_up, UidGidExtent, UidGidMap, UserNamespace,
             UID_GID_MAP_MAX_BASE_EXTENTS, UID_GID_MAP_MAX_EXTENTS, USERNS_SETGROUPS_ALLOWED,
         },
-        RawPid,
     },
 };
 use alloc::{
@@ -85,41 +84,44 @@ impl IdMapWriteContext {
 /// /proc/[pid]/uid_map 和 /proc/[pid]/gid_map 的 FileOps
 #[derive(Debug)]
 pub struct IdMapFileOps {
-    pid: RawPid,
+    target: ProcPidTarget,
     map_type: MapType,
 }
 
 impl IdMapFileOps {
-    pub fn new_uid(pid: RawPid) -> Self {
+    pub fn new_uid(target: ProcPidTarget) -> Self {
         Self {
-            pid,
+            target,
             map_type: MapType::Uid,
         }
     }
 
-    pub fn new_gid(pid: RawPid) -> Self {
+    pub fn new_gid(target: ProcPidTarget) -> Self {
         Self {
-            pid,
+            target,
             map_type: MapType::Gid,
         }
     }
 
-    pub fn new_uid_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self::new_uid(pid), InodeMode::from_bits_truncate(0o644))
+    pub fn new_uid_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new_uid(target), InodeMode::from_bits_truncate(0o644))
             .parent(parent)
             .build()
             .unwrap()
     }
 
-    pub fn new_gid_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self::new_gid(pid), InodeMode::from_bits_truncate(0o644))
+    pub fn new_gid_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new_gid(target), InodeMode::from_bits_truncate(0o644))
             .parent(parent)
             .build()
             .unwrap()
     }
 
     fn get_user_ns(&self) -> Result<Arc<UserNamespace>, SystemError> {
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
         Ok(pcb.cred().user_ns.clone())
     }
 
@@ -450,16 +452,16 @@ impl FileOps for IdMapFileOps {
 /// /proc/[pid]/setgroups 的 FileOps
 #[derive(Debug)]
 pub struct SetgroupsFileOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl SetgroupsFileOps {
-    pub fn new(pid: RawPid) -> Self {
-        Self { pid }
+    pub fn new(target: ProcPidTarget) -> Self {
+        Self { target }
     }
 
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self::new(pid), InodeMode::from_bits_truncate(0o644))
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new(target), InodeMode::from_bits_truncate(0o644))
             .parent(parent)
             .build()
             .unwrap()
@@ -474,7 +476,10 @@ impl FileOps for SetgroupsFileOps {
         buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
         let user_ns = pcb.cred().user_ns.clone();
         let inner = user_ns.inner.lock();
 
@@ -505,7 +510,10 @@ impl FileOps for SetgroupsFileOps {
             return Err(SystemError::EINVAL);
         }
 
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
         let user_ns = pcb.cred().user_ns.clone();
         let mut inner = user_ns.inner.lock();
 

--- a/kernel/src/filesystem/procfs/pid/limits.rs
+++ b/kernel/src/filesystem/procfs/pid/limits.rs
@@ -8,13 +8,13 @@ use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
-            pid::find_process_by_vpid,
+            pid::ProcPidTarget,
             template::{Builder, FileOps, ProcFileBuilder},
             utils::proc_read,
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    process::{resource::RLimitID, RawPid},
+    process::resource::RLimitID,
 };
 use alloc::{
     string::{String, ToString},
@@ -25,7 +25,7 @@ use system_error::SystemError;
 /// /proc/[pid]/limits 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct LimitsFile {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 #[derive(Clone, Copy)]
@@ -102,8 +102,8 @@ impl LimitsFile {
         },
     ];
 
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -119,7 +119,10 @@ impl LimitsFile {
     }
 
     fn generate_limits_content(&self) -> Result<String, SystemError> {
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
 
         // 与 Linux fs/proc/base.c 的表头保持一致。
         let mut content = String::from(

--- a/kernel/src/filesystem/procfs/pid/maps.rs
+++ b/kernel/src/filesystem/procfs/pid/maps.rs
@@ -7,14 +7,13 @@ use crate::{
     arch::MMArch,
     filesystem::{
         procfs::{
-            pid::find_process_by_vpid,
+            pid::ProcPidTarget,
             template::{Builder, FileOps, ProcFileBuilder},
             utils::proc_read,
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     mm::{ucontext::LockedVMA, MemoryManagementArch, VmFlags},
-    process::RawPid,
 };
 use alloc::{
     format,
@@ -27,12 +26,12 @@ use system_error::SystemError;
 /// /proc/[pid]/maps 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct MapsFileOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl MapsFileOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -104,8 +103,8 @@ fn format_dev_inode_and_path(
 }
 
 /// 生成 /proc/[pid]/maps 内容
-fn generate_maps_content(pid: RawPid) -> Result<Vec<u8>, SystemError> {
-    let target_pcb = find_process_by_vpid(pid).ok_or(SystemError::ESRCH)?;
+fn generate_maps_content(target: &ProcPidTarget) -> Result<Vec<u8>, SystemError> {
+    let target_pcb = target.thread_group_leader().ok_or(SystemError::ESRCH)?;
 
     let vm = target_pcb.basic().user_vm().ok_or(SystemError::EINVAL)?;
     let root_prefix = target_pcb
@@ -171,7 +170,7 @@ impl FileOps for MapsFileOps {
         buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let content = generate_maps_content(self.pid)?;
+        let content = generate_maps_content(&self.target)?;
         proc_read(offset, len, buf, &content)
     }
 }

--- a/kernel/src/filesystem/procfs/pid/maps.rs
+++ b/kernel/src/filesystem/procfs/pid/maps.rs
@@ -106,7 +106,11 @@ fn format_dev_inode_and_path(
 fn generate_maps_content(target: &ProcPidTarget) -> Result<Vec<u8>, SystemError> {
     let target_pcb = target.thread_group_leader().ok_or(SystemError::ESRCH)?;
 
-    let vm = target_pcb.basic().user_vm().ok_or(SystemError::EINVAL)?;
+    let vm = {
+        let basic = target_pcb.basic();
+        basic.user_vm()
+    }
+    .ok_or(SystemError::EINVAL)?;
     let root_prefix = target_pcb
         .fs_struct()
         .root()

--- a/kernel/src/filesystem/procfs/pid/mod.rs
+++ b/kernel/src/filesystem/procfs/pid/mod.rs
@@ -116,6 +116,10 @@ impl ProcPidTarget {
             .map(|pid| pid.pid_nr_ns(&self.view_pid_ns))
             .unwrap_or(RawPid::new(0))
     }
+
+    fn same_pid_object(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.pid, &other.pid) && Arc::ptr_eq(&self.view_pid_ns, &other.view_pid_ns)
+    }
 }
 
 /// /proc/[pid] 目录的 DirOps 实现
@@ -135,6 +139,12 @@ impl PidDirOps {
 
     fn get_process(&self) -> Option<Arc<ProcessControlBlock>> {
         self.target.thread_group_leader()
+    }
+
+    pub(super) fn is_current_target(&self) -> bool {
+        ProcPidTarget::from_tgid_in_ns(self.target.view_pid_ns().clone(), self.target.vpid())
+            .map(|target| self.target.same_pid_object(&target))
+            .unwrap_or(false)
     }
 
     #[expect(clippy::type_complexity)]

--- a/kernel/src/filesystem/procfs/pid/mod.rs
+++ b/kernel/src/filesystem/procfs/pid/mod.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::{
     filesystem::{
         procfs::{
@@ -9,7 +11,11 @@ use crate::{
         },
         vfs::{IndexNode, InodeMode},
     },
-    process::{ProcessControlBlock, ProcessManager, RawPid},
+    process::{
+        namespace::pid_namespace::PidNamespace,
+        pid::{Pid, PidType},
+        ProcessControlBlock, RawPid,
+    },
 };
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
@@ -46,83 +52,145 @@ use statm::StatmFileOps;
 use status::StatusFileOps;
 use task::TaskDirOps;
 
-pub(super) fn find_process_by_vpid(pid: RawPid) -> Option<Arc<ProcessControlBlock>> {
-    ProcessManager::find_task_by_vpid(pid)
+#[derive(Clone)]
+pub(super) struct ProcPidTarget {
+    view_pid_ns: Arc<PidNamespace>,
+    pid: Arc<Pid>,
+}
+
+impl fmt::Debug for ProcPidTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcPidTarget")
+            .field("vpid", &self.vpid())
+            .field("tgid", &self.tgid())
+            .finish()
+    }
+}
+
+impl ProcPidTarget {
+    pub fn new(view_pid_ns: Arc<PidNamespace>, pid: Arc<Pid>) -> Self {
+        Self { view_pid_ns, pid }
+    }
+
+    pub fn from_tgid_in_ns(view_pid_ns: Arc<PidNamespace>, pid: RawPid) -> Option<Self> {
+        let target_pid = view_pid_ns.find_pid_in_ns(pid)?;
+        target_pid.pid_task(PidType::TGID)?;
+        Some(Self::new(view_pid_ns, target_pid))
+    }
+
+    pub fn from_task(
+        view_pid_ns: Arc<PidNamespace>,
+        task: Arc<ProcessControlBlock>,
+    ) -> Option<Self> {
+        let pid = task.task_pid_ptr(PidType::PID)?;
+        if pid.pid_nr_ns(&view_pid_ns).data() == 0 {
+            return None;
+        }
+        Some(Self::new(view_pid_ns, pid))
+    }
+
+    pub fn view_pid_ns(&self) -> &Arc<PidNamespace> {
+        &self.view_pid_ns
+    }
+
+    pub fn vpid(&self) -> RawPid {
+        self.pid.pid_nr_ns(&self.view_pid_ns)
+    }
+
+    pub fn task(&self) -> Option<Arc<ProcessControlBlock>> {
+        self.pid.pid_task(PidType::PID)
+    }
+
+    pub fn thread_group_leader(&self) -> Option<Arc<ProcessControlBlock>> {
+        let task = self.task()?;
+        let tgid = task.task_pid_ptr(PidType::TGID)?;
+        tgid.pid_task(PidType::TGID)
+    }
+
+    pub fn thread_group_pid(&self) -> Option<Arc<Pid>> {
+        self.thread_group_leader()?.task_pid_ptr(PidType::TGID)
+    }
+
+    pub fn tgid(&self) -> RawPid {
+        self.thread_group_pid()
+            .map(|pid| pid.pid_nr_ns(&self.view_pid_ns))
+            .unwrap_or(RawPid::new(0))
+    }
 }
 
 /// /proc/[pid] 目录的 DirOps 实现
 #[derive(Debug)]
 pub struct PidDirOps {
-    // 存储 PID，用于在需要时查找进程
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl PidDirOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self { pid }, InodeMode::from_bits_truncate(0o555))
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self { target }, InodeMode::from_bits_truncate(0o555))
             .parent(parent)
-            .volatile() // PID 目录是易失的，因为它们与特定进程关联
+            .volatile()
             .build()
             .unwrap()
     }
 
-    /// 获取进程引用
     fn get_process(&self) -> Option<Arc<ProcessControlBlock>> {
-        find_process_by_vpid(self.pid)
+        self.target.thread_group_leader()
     }
 
-    /// 静态条目表
-    /// 包含 /proc/[pid] 目录下的所有静态文件和目录
     #[expect(clippy::type_complexity)]
     const STATIC_ENTRIES: &'static [(
         &'static str,
         fn(&PidDirOps, Weak<dyn IndexNode>) -> Arc<dyn IndexNode>,
     )] = &[
         ("cmdline", |ops, parent| {
-            CmdlineFileOps::new_inode(ops.pid, parent)
+            CmdlineFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("cgroup", |ops, parent| {
-            CgroupFileOps::new_inode(ops.pid, parent)
+            CgroupFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("maps", |ops, parent| {
-            MapsFileOps::new_inode(ops.pid, parent)
+            MapsFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("limits", |ops, parent| {
-            LimitsFile::new_inode(ops.pid, parent)
+            LimitsFile::new_inode(ops.target.clone(), parent)
         }),
         ("mountinfo", |ops, parent| {
-            MountInfoFileOps::new_inode(ops.pid, parent)
+            MountInfoFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("mounts", |ops, parent| {
-            PidMountsFileOps::new_inode(ops.pid, parent)
+            PidMountsFileOps::new_inode(ops.target.clone(), parent)
         }),
-        ("ns", |ops, parent| NsDirOps::new_inode(ops.pid, parent)),
+        ("ns", |ops, parent| {
+            NsDirOps::new_inode(ops.target.clone(), parent)
+        }),
         ("stat", |ops, parent| {
-            StatFileOps::new_inode(ops.pid, parent)
+            StatFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("statm", |ops, parent| {
-            StatmFileOps::new_inode(ops.pid, parent)
+            StatmFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("status", |ops, parent| {
-            StatusFileOps::new_inode(ops.pid, parent)
+            StatusFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("uid_map", |ops, parent| {
-            IdMapFileOps::new_uid_inode(ops.pid, parent)
+            IdMapFileOps::new_uid_inode(ops.target.clone(), parent)
         }),
         ("gid_map", |ops, parent| {
-            IdMapFileOps::new_gid_inode(ops.pid, parent)
+            IdMapFileOps::new_gid_inode(ops.target.clone(), parent)
         }),
         ("setgroups", |ops, parent| {
-            SetgroupsFileOps::new_inode(ops.pid, parent)
+            SetgroupsFileOps::new_inode(ops.target.clone(), parent)
         }),
-        ("task", |ops, parent| TaskDirOps::new_inode(ops.pid, parent)),
-        ("exe", |ops, parent| ExeSymOps::new_inode(ops.pid, parent)),
+        ("task", |ops, parent| {
+            TaskDirOps::new_inode(ops.target.clone(), parent)
+        }),
+        ("exe", |ops, parent| {
+            ExeSymOps::new_inode(ops.target.clone(), parent)
+        }),
         ("fd", |ops, parent| {
-            // fd 目录仍然需要进程引用来列出文件描述符
             if ops.get_process().is_some() {
-                FdDirOps::new_inode(ops.pid, parent)
+                FdDirOps::new_inode(ops.target.clone(), parent)
             } else {
-                // 进程已退出，创建空目录
                 use crate::filesystem::procfs::template::ProcDirBuilder;
 
                 #[derive(Debug)]
@@ -136,9 +204,7 @@ impl PidDirOps {
                         Err(SystemError::ENOENT)
                     }
 
-                    fn populate_children(&self, _dir: &ProcDir<Self>) {
-                        // 空目录，无需填充
-                    }
+                    fn populate_children(&self, _dir: &ProcDir<Self>) {}
                 }
 
                 ProcDirBuilder::new(EmptyDirOps, InodeMode::from_bits_truncate(0o500))
@@ -148,11 +214,9 @@ impl PidDirOps {
             }
         }),
         ("fdinfo", |ops, parent| {
-            // fdinfo 目录也需要进程引用来列出文件描述符
             if ops.get_process().is_some() {
-                FdInfoDirOps::new_inode(ops.pid, parent)
+                FdInfoDirOps::new_inode(ops.target.clone(), parent)
             } else {
-                // 进程已退出，创建空目录
                 use crate::filesystem::procfs::template::ProcDirBuilder;
 
                 #[derive(Debug)]
@@ -166,9 +230,7 @@ impl PidDirOps {
                         Err(SystemError::ENOENT)
                     }
 
-                    fn populate_children(&self, _dir: &ProcDir<Self>) {
-                        // 空目录，无需填充
-                    }
+                    fn populate_children(&self, _dir: &ProcDir<Self>) {}
                 }
 
                 ProcDirBuilder::new(EmptyDirOps, InodeMode::from_bits_truncate(0o500))
@@ -182,7 +244,7 @@ impl PidDirOps {
 
 impl DirOps for PidDirOps {
     fn owner(&self) -> Option<(usize, usize)> {
-        let pcb = find_process_by_vpid(self.pid)?;
+        let pcb = self.target.thread_group_leader()?;
         if pcb.is_kthread() {
             return Some((0, 0));
         }
@@ -197,7 +259,6 @@ impl DirOps for PidDirOps {
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         let mut cached_children = dir.cached_children().write();
 
-        // 处理静态条目（包括 fd）
         if let Some(child) =
             lookup_child_from_table(name, &mut cached_children, Self::STATIC_ENTRIES, |f| {
                 (f)(self, dir.self_ref_weak().clone())
@@ -211,11 +272,8 @@ impl DirOps for PidDirOps {
 
     fn populate_children(&self, dir: &ProcDir<Self>) {
         let mut cached_children = dir.cached_children().write();
-
-        // 填充静态条目（包括 fd）
         populate_children_from_table(&mut cached_children, Self::STATIC_ENTRIES, |f| {
             (f)(self, dir.self_ref_weak().clone())
         });
-        // 写锁在这里自动释放
     }
 }

--- a/kernel/src/filesystem/procfs/pid/mountinfo.rs
+++ b/kernel/src/filesystem/procfs/pid/mountinfo.rs
@@ -2,31 +2,30 @@
 //!
 //! 显示进程的挂载点详细信息
 
-use crate::libs::mutex::MutexGuard;
-use crate::{
-    filesystem::{
-        procfs::{
-            mounts::generate_mountinfo_content,
-            template::{Builder, FileOps, ProcFileBuilder},
-            utils::proc_read,
+use crate::filesystem::{
+    procfs::{
+        mounts::{
+            cache_procfs_file_content, generate_mountinfo_content_for_task,
+            read_cached_procfs_file_content,
         },
-        vfs::{FilePrivateData, IndexNode, InodeMode},
+        pid::ProcPidTarget,
+        template::{Builder, FileOps, ProcFileBuilder},
     },
-    process::RawPid,
+    vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
 
 /// /proc/[pid]/mountinfo 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct MountInfoFileOps {
-    #[allow(dead_code)]
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl MountInfoFileOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -34,14 +33,24 @@ impl MountInfoFileOps {
 }
 
 impl FileOps for MountInfoFileOps {
+    fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        let target = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
+        cache_procfs_file_content(data, generate_mountinfo_content_for_task(&target))
+    }
+
     fn read_at(
         &self,
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: MutexGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let content = generate_mountinfo_content();
-        proc_read(offset, len, buf, content.as_bytes())
+        self.target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
+        read_cached_procfs_file_content(offset, len, buf, data)
     }
 }

--- a/kernel/src/filesystem/procfs/pid/mounts.rs
+++ b/kernel/src/filesystem/procfs/pid/mounts.rs
@@ -2,31 +2,30 @@
 //!
 //! 显示进程的挂载点信息
 
-use crate::libs::mutex::MutexGuard;
-use crate::{
-    filesystem::{
-        procfs::{
-            mounts::generate_mounts_content,
-            template::{Builder, FileOps, ProcFileBuilder},
-            utils::proc_read,
+use crate::filesystem::{
+    procfs::{
+        mounts::{
+            cache_procfs_file_content, generate_mounts_content_for_task,
+            read_cached_procfs_file_content,
         },
-        vfs::{FilePrivateData, IndexNode, InodeMode},
+        pid::ProcPidTarget,
+        template::{Builder, FileOps, ProcFileBuilder},
     },
-    process::RawPid,
+    vfs::{FilePrivateData, IndexNode, InodeMode},
 };
+use crate::libs::mutex::MutexGuard;
 use alloc::sync::{Arc, Weak};
 use system_error::SystemError;
 
 /// /proc/[pid]/mounts 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct PidMountsFileOps {
-    #[allow(dead_code)]
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl PidMountsFileOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -34,14 +33,24 @@ impl PidMountsFileOps {
 }
 
 impl FileOps for PidMountsFileOps {
+    fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        let target = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
+        cache_procfs_file_content(data, generate_mounts_content_for_task(&target))
+    }
+
     fn read_at(
         &self,
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        _data: MutexGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let content = generate_mounts_content();
-        proc_read(offset, len, buf, content.as_bytes())
+        self.target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
+        read_cached_procfs_file_content(offset, len, buf, data)
     }
 }

--- a/kernel/src/filesystem/procfs/pid/ns.rs
+++ b/kernel/src/filesystem/procfs/pid/ns.rs
@@ -6,7 +6,7 @@ use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
-            pid::find_process_by_vpid,
+            pid::ProcPidTarget,
             template::{Builder, DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
             thread_self::NsFileType,
         },
@@ -15,10 +15,7 @@ use crate::{
             IndexNode, InodeId, InodeMode,
         },
     },
-    process::{
-        namespace::{nsproxy::NamespaceId, NamespaceOps},
-        RawPid,
-    },
+    process::namespace::{nsproxy::NamespaceId, NamespaceOps},
 };
 use alloc::{
     format,
@@ -29,8 +26,8 @@ use core::convert::TryFrom;
 use system_error::SystemError;
 
 /// 获取指定进程的命名空间 ID
-fn get_pid_ns_ino(pid: RawPid, ns_type: NsFileType) -> Result<usize, SystemError> {
-    let pcb = find_process_by_vpid(pid).ok_or(SystemError::ESRCH)?;
+fn get_ns_ino(target: &ProcPidTarget, ns_type: NsFileType) -> Result<usize, SystemError> {
+    let pcb = target.task().ok_or(SystemError::ESRCH)?;
     let nsproxy = pcb.nsproxy();
 
     let ino: NamespaceId = match ns_type {
@@ -51,15 +48,41 @@ fn get_pid_ns_ino(pid: RawPid, ns_type: NsFileType) -> Result<usize, SystemError
     Ok(ino.data())
 }
 
+fn namespace_private_data(
+    target: &ProcPidTarget,
+    ns_type: NsFileType,
+) -> Result<NamespaceFilePrivateData, SystemError> {
+    let pcb = target.task().ok_or(SystemError::ESRCH)?;
+    let nsproxy = pcb.nsproxy();
+
+    let ns_data = match ns_type {
+        NsFileType::Ipc => NamespaceFilePrivateData::Ipc(nsproxy.ipc_ns.clone()),
+        NsFileType::Uts => NamespaceFilePrivateData::Uts(nsproxy.uts_ns.clone()),
+        NsFileType::Mnt => NamespaceFilePrivateData::Mnt(nsproxy.mnt_ns.clone()),
+        NsFileType::Net => NamespaceFilePrivateData::Net(nsproxy.net_ns.clone()),
+        NsFileType::Pid => NamespaceFilePrivateData::Pid(pcb.active_pid_ns()),
+        NsFileType::PidForChildren => {
+            NamespaceFilePrivateData::PidForChildren(nsproxy.pid_ns_for_children.clone())
+        }
+        NsFileType::Time | NsFileType::TimeForChildren => {
+            return Err(SystemError::ENOSYS);
+        }
+        NsFileType::User => NamespaceFilePrivateData::User(pcb.cred().user_ns.clone()),
+        NsFileType::Cgroup => NamespaceFilePrivateData::Cgroup(nsproxy.cgroup_ns.clone()),
+    };
+
+    Ok(ns_data)
+}
+
 /// /proc/[pid]/ns 目录的 DirOps 实现
 #[derive(Debug)]
 pub struct NsDirOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl NsDirOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self { pid }, InodeMode::from_bits_truncate(0o555))
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self { target }, InodeMode::from_bits_truncate(0o555))
             .parent(parent)
             .volatile()
             .build()
@@ -77,7 +100,7 @@ impl DirOps for NsDirOps {
         let ns_type = NsFileType::try_from(name)?;
 
         // 检查进程是否存在
-        if find_process_by_vpid(self.pid).is_none() {
+        if self.target.task().is_none() {
             return Err(SystemError::ESRCH);
         }
 
@@ -87,14 +110,13 @@ impl DirOps for NsDirOps {
         }
 
         // 创建命名空间符号链接
-        let inode = NsSymOps::new_inode(self.pid, ns_type, dir.self_ref_weak().clone());
+        let inode = NsSymOps::new_inode(self.target.clone(), ns_type, dir.self_ref_weak().clone());
         cached_children.insert(name.to_string(), inode.clone());
         Ok(inode)
     }
 
     fn populate_children(&self, dir: &ProcDir<Self>) {
-        // 检查进程是否存在
-        if find_process_by_vpid(self.pid).is_none() {
+        if self.target.task().is_none() {
             return;
         }
 
@@ -103,7 +125,7 @@ impl DirOps for NsDirOps {
         for name in NsFileType::ALL_NAMES {
             if let Ok(ns_type) = NsFileType::try_from(name) {
                 cached_children.entry(name.to_string()).or_insert_with(|| {
-                    NsSymOps::new_inode(self.pid, ns_type, dir.self_ref_weak().clone())
+                    NsSymOps::new_inode(self.target.clone(), ns_type, dir.self_ref_weak().clone())
                 });
             }
         }
@@ -113,17 +135,17 @@ impl DirOps for NsDirOps {
 /// /proc/[pid]/ns/[type] 符号链接的 SymOps 实现
 #[derive(Debug)]
 pub struct NsSymOps {
-    pid: RawPid,
+    target: ProcPidTarget,
     ns_type: NsFileType,
 }
 
 impl NsSymOps {
     pub fn new_inode(
-        pid: RawPid,
+        target: ProcPidTarget,
         ns_type: NsFileType,
         parent: Weak<dyn IndexNode>,
     ) -> Arc<dyn IndexNode> {
-        ProcSymBuilder::new(Self { pid, ns_type }, InodeMode::S_IRWXUGO)
+        ProcSymBuilder::new(Self { target, ns_type }, InodeMode::S_IRWXUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -132,7 +154,7 @@ impl NsSymOps {
 
 impl SymOps for NsSymOps {
     fn read_link(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
-        let ino = get_pid_ns_ino(self.pid, self.ns_type)?;
+        let ino = get_ns_ino(&self.target, self.ns_type)?;
         let target = format!("{}:[{}]", self.ns_type.name(), ino);
         let len = target.len().min(buf.len());
         buf[..len].copy_from_slice(&target.as_bytes()[..len]);
@@ -145,37 +167,13 @@ impl SymOps for NsSymOps {
     }
 
     fn dynamic_inode_id(&self) -> Option<InodeId> {
-        // 命名空间文件的 inode ID 应该是命名空间的 ID
-        // 这样 stat() 返回的 st_ino 就是命名空间 ID
-        get_pid_ns_ino(self.pid, self.ns_type)
+        get_ns_ino(&self.target, self.ns_type)
             .ok()
             .map(InodeId::new)
     }
 
     fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
-        // 当打开命名空间文件时，设置命名空间私有数据
-        // 这使得 setns() 可以使用这个 fd
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
-        let nsproxy = pcb.nsproxy();
-
-        let ns_data = match self.ns_type {
-            NsFileType::Ipc => NamespaceFilePrivateData::Ipc(nsproxy.ipc_ns.clone()),
-            NsFileType::Uts => NamespaceFilePrivateData::Uts(nsproxy.uts_ns.clone()),
-            NsFileType::Mnt => NamespaceFilePrivateData::Mnt(nsproxy.mnt_ns.clone()),
-            NsFileType::Net => NamespaceFilePrivateData::Net(nsproxy.net_ns.clone()),
-            NsFileType::Pid => NamespaceFilePrivateData::Pid(pcb.active_pid_ns()),
-            NsFileType::PidForChildren => {
-                NamespaceFilePrivateData::PidForChildren(nsproxy.pid_ns_for_children.clone())
-            }
-            NsFileType::Time | NsFileType::TimeForChildren => {
-                // Time namespace 尚未实现
-                return Err(SystemError::ENOSYS);
-            }
-            NsFileType::User => NamespaceFilePrivateData::User(pcb.cred().user_ns.clone()),
-            NsFileType::Cgroup => NamespaceFilePrivateData::Cgroup(nsproxy.cgroup_ns.clone()),
-        };
-
-        **data = FilePrivateData::Namespace(ns_data);
+        **data = FilePrivateData::Namespace(namespace_private_data(&self.target, self.ns_type)?);
         Ok(())
     }
 }

--- a/kernel/src/filesystem/procfs/pid/stat.rs
+++ b/kernel/src/filesystem/procfs/pid/stat.rs
@@ -9,7 +9,7 @@ use crate::{
     arch::MMArch,
     filesystem::{
         procfs::{
-            pid::find_process_by_vpid,
+            pid::ProcPidTarget,
             template::{Builder, FileOps, ProcFileBuilder},
             utils::proc_read,
         },
@@ -29,12 +29,12 @@ use system_error::SystemError;
 /// /proc/[pid]/stat 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct StatFileOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl StatFileOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -150,7 +150,7 @@ impl FileOps for StatFileOps {
         buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self.target.task().ok_or(SystemError::ESRCH)?;
 
         let comm = pcb.basic().name().to_string();
         let sched = pcb.sched_info();
@@ -158,10 +158,11 @@ impl FileOps for StatFileOps {
 
         let ppid = pcb
             .parent_pcb()
-            .map(|p| p.raw_pid())
+            .and_then(|p| p.task_pid_ptr(PidType::TGID))
+            .map(|pid| pid.pid_nr_ns(self.target.view_pid_ns()))
             .unwrap_or(RawPid::new(0));
 
-        let content = generate_linux_proc_stat_line(self.pid, &comm, state, ppid, &pcb);
+        let content = generate_linux_proc_stat_line(self.target.vpid(), &comm, state, ppid, &pcb);
         proc_read(offset, len, buf, content.as_bytes())
     }
 }

--- a/kernel/src/filesystem/procfs/pid/stat.rs
+++ b/kernel/src/filesystem/procfs/pid/stat.rs
@@ -64,10 +64,9 @@ fn sanitize_comm_for_proc_stat(comm: &str) -> String {
         .collect()
 }
 
-/// 生成 Linux 风格的 /proc/[pid]/stat 行
-fn generate_linux_proc_stat_line(
+struct ProcStatSnapshot {
     pid: RawPid,
-    comm: &str,
+    comm: String,
     state: ProcessState,
     ppid: RawPid,
     tty_nr: i32,
@@ -79,9 +78,12 @@ fn generate_linux_proc_stat_line(
     processor: i32,
     utime: u64,
     stime: u64,
-) -> String {
-    let comm = sanitize_comm_for_proc_stat(comm);
-    let state_ch = state_to_linux_char(state);
+}
+
+/// 生成 Linux 风格的 /proc/[pid]/stat 行
+fn generate_linux_proc_stat_line(snapshot: ProcStatSnapshot) -> String {
+    let comm = sanitize_comm_for_proc_stat(&snapshot.comm);
+    let state_ch = state_to_linux_char(snapshot.state);
 
     // 尽量填真实值；拿不到的先填 0
     let pgrp: usize = 0;
@@ -105,8 +107,17 @@ fn generate_linux_proc_stat_line(
         "{pid} ({comm}) {state_ch} {ppid} {pgrp} {session} {tty_nr} {tpgid} {flags} \
 {minflt} {cminflt} {majflt} {cmajflt} {utime} {stime} {cutime} {cstime} {priority} {nice} \
 {num_threads} {itrealvalue} {starttime} {vsize_bytes} {rss_pages} 0 0 0 0 0 0 0 0 0 0 0 0 0 {processor} 0 0 0 0 0\n",
-        pid = pid.data(),
-        ppid = ppid.data(),
+        pid = snapshot.pid.data(),
+        ppid = snapshot.ppid.data(),
+        tty_nr = snapshot.tty_nr,
+        utime = snapshot.utime,
+        stime = snapshot.stime,
+        priority = snapshot.priority,
+        nice = snapshot.nice,
+        num_threads = snapshot.num_threads,
+        vsize_bytes = snapshot.vsize_bytes,
+        rss_pages = snapshot.rss_pages,
+        processor = snapshot.processor,
     )
 }
 
@@ -152,8 +163,7 @@ impl FileOps for StatFileOps {
             .map(|vm| {
                 let guard = vm.read();
                 let bytes = guard.vma_usage_bytes();
-                let pages =
-                    (bytes.saturating_add(MMArch::PAGE_SIZE - 1)) >> MMArch::PAGE_SHIFT;
+                let pages = (bytes.saturating_add(MMArch::PAGE_SIZE - 1)) >> MMArch::PAGE_SHIFT;
                 (bytes as u64, pages as u64)
             })
             .unwrap_or((0, 0));
@@ -169,9 +179,9 @@ impl FileOps for StatFileOps {
             .map(|pid| pid.pid_nr_ns(self.target.view_pid_ns()))
             .unwrap_or(RawPid::new(0));
 
-        let content = generate_linux_proc_stat_line(
-            self.target.vpid(),
-            &comm,
+        let content = generate_linux_proc_stat_line(ProcStatSnapshot {
+            pid: self.target.vpid(),
+            comm,
             state,
             ppid,
             tty_nr,
@@ -183,7 +193,7 @@ impl FileOps for StatFileOps {
             processor,
             utime,
             stime,
-        );
+        });
         proc_read(offset, len, buf, content.as_bytes())
     }
 }

--- a/kernel/src/filesystem/procfs/pid/stat.rs
+++ b/kernel/src/filesystem/procfs/pid/stat.rs
@@ -16,7 +16,7 @@ use crate::{
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     mm::MemoryManagementArch,
-    process::{pid::PidType, ProcessControlBlock, ProcessState, RawPid},
+    process::{pid::PidType, ProcessState, RawPid},
     sched::{cputime::ns_to_clock_t, prio::PrioUtil},
 };
 use alloc::{
@@ -70,7 +70,15 @@ fn generate_linux_proc_stat_line(
     comm: &str,
     state: ProcessState,
     ppid: RawPid,
-    pcb: &Arc<ProcessControlBlock>,
+    tty_nr: i32,
+    priority: i64,
+    nice: i64,
+    num_threads: i64,
+    vsize_bytes: u64,
+    rss_pages: u64,
+    processor: i32,
+    utime: u64,
+    stime: u64,
 ) -> String {
     let comm = sanitize_comm_for_proc_stat(comm);
     let state_ch = state_to_linux_char(state);
@@ -78,11 +86,6 @@ fn generate_linux_proc_stat_line(
     // 尽量填真实值；拿不到的先填 0
     let pgrp: usize = 0;
     let session: usize = 0;
-    let tty_nr: i32 = pcb
-        .sig_info_irqsave()
-        .tty()
-        .map(|tty| tty.core().device_number().new_encode_dev() as i32)
-        .unwrap_or(0);
     let tpgid: i32 = 0;
     let flags: u64 = 0;
     let minflt: u64 = 0;
@@ -90,48 +93,13 @@ fn generate_linux_proc_stat_line(
     let majflt: u64 = 0;
     let cmajflt: u64 = 0;
 
-    // === 读取真实的 CPU 时间 ===
-    let cpu_time = pcb.cputime();
-    let utime = ns_to_clock_t(cpu_time.utime.load(Ordering::Relaxed));
-    let stime = ns_to_clock_t(cpu_time.stime.load(Ordering::Relaxed));
-
     let cutime: i64 = 0;
     let cstime: i64 = 0;
 
-    // === 读取真实的 priority 和 nice 值 ===
-    let prio_data = pcb.sched_info().prio_data();
-    let priority: i64 = prio_data.prio as i64;
-    let nice: i64 = PrioUtil::prio_to_nice(prio_data.static_prio) as i64;
-    drop(prio_data);
-
-    // 线程组中的线程数量
-    let num_threads: i64 = pcb
-        .task_pid_ptr(PidType::TGID)
-        .map(|tgid_pid| tgid_pid.tasks_iter(PidType::TGID).count() as i64)
-        .unwrap_or(1);
     let itrealvalue: i64 = 0;
 
     // starttime: 进程启动时间（暂时为 0，需要 PCB 添加 start_time 字段）
     let starttime: u64 = 0;
-
-    // vsize: bytes, rss: pages
-    let (vsize_bytes, rss_pages) = pcb
-        .basic()
-        .user_vm()
-        .map(|vm| {
-            let guard = vm.read();
-            let bytes = guard.vma_usage_bytes();
-            let pages = (bytes.saturating_add(MMArch::PAGE_SIZE - 1)) >> MMArch::PAGE_SHIFT;
-            (bytes as u64, pages as u64)
-        })
-        .unwrap_or((0, 0));
-
-    // processor: 进程最后运行的 CPU ID
-    let processor: i32 = pcb
-        .sched_info()
-        .on_cpu()
-        .map(|cpu| cpu.data() as i32)
-        .unwrap_or(0);
 
     format!(
         "{pid} ({comm}) {state_ch} {ppid} {pgrp} {session} {tty_nr} {tpgid} {flags} \
@@ -152,9 +120,48 @@ impl FileOps for StatFileOps {
     ) -> Result<usize, SystemError> {
         let pcb = self.target.task().ok_or(SystemError::ESRCH)?;
 
-        let comm = pcb.basic().name().to_string();
-        let sched = pcb.sched_info();
-        let state = sched.inner_lock_read_irqsave().state();
+        let (comm, user_vm) = {
+            let basic = pcb.basic();
+            (basic.name().to_string(), basic.user_vm())
+        };
+        let state = {
+            let sched = pcb.sched_info();
+            sched.inner_lock_read_irqsave().state()
+        };
+        let tty_nr = {
+            pcb.sig_info_irqsave()
+                .tty()
+                .map(|tty| tty.core().device_number().new_encode_dev() as i32)
+                .unwrap_or(0)
+        };
+        let cpu_time = pcb.cputime();
+        let utime = ns_to_clock_t(cpu_time.utime.load(Ordering::Relaxed));
+        let stime = ns_to_clock_t(cpu_time.stime.load(Ordering::Relaxed));
+        let (priority, nice) = {
+            let prio_data = pcb.sched_info().prio_data();
+            (
+                prio_data.prio as i64,
+                PrioUtil::prio_to_nice(prio_data.static_prio) as i64,
+            )
+        };
+        let num_threads = pcb
+            .task_pid_ptr(PidType::TGID)
+            .map(|tgid_pid| tgid_pid.tasks_iter(PidType::TGID).count() as i64)
+            .unwrap_or(1);
+        let (vsize_bytes, rss_pages) = user_vm
+            .map(|vm| {
+                let guard = vm.read();
+                let bytes = guard.vma_usage_bytes();
+                let pages =
+                    (bytes.saturating_add(MMArch::PAGE_SIZE - 1)) >> MMArch::PAGE_SHIFT;
+                (bytes as u64, pages as u64)
+            })
+            .unwrap_or((0, 0));
+        let processor = pcb
+            .sched_info()
+            .on_cpu()
+            .map(|cpu| cpu.data() as i32)
+            .unwrap_or(0);
 
         let ppid = pcb
             .parent_pcb()
@@ -162,7 +169,21 @@ impl FileOps for StatFileOps {
             .map(|pid| pid.pid_nr_ns(self.target.view_pid_ns()))
             .unwrap_or(RawPid::new(0));
 
-        let content = generate_linux_proc_stat_line(self.target.vpid(), &comm, state, ppid, &pcb);
+        let content = generate_linux_proc_stat_line(
+            self.target.vpid(),
+            &comm,
+            state,
+            ppid,
+            tty_nr,
+            priority,
+            nice,
+            num_threads,
+            vsize_bytes,
+            rss_pages,
+            processor,
+            utime,
+            stime,
+        );
         proc_read(offset, len, buf, content.as_bytes())
     }
 }

--- a/kernel/src/filesystem/procfs/pid/statm.rs
+++ b/kernel/src/filesystem/procfs/pid/statm.rs
@@ -49,10 +49,13 @@ impl FileOps for StatmFileOps {
             .thread_group_leader()
             .ok_or(SystemError::ESRCH)?;
 
+        let user_vm = {
+            let basic = pcb.basic();
+            basic.user_vm()
+        };
+
         // 获取进程内存信息（简化实现）
-        let size_pages = pcb
-            .basic()
-            .user_vm()
+        let size_pages = user_vm
             .map(|vm| {
                 let guard = vm.read();
                 // statm 第一列为总虚拟内存页数

--- a/kernel/src/filesystem/procfs/pid/statm.rs
+++ b/kernel/src/filesystem/procfs/pid/statm.rs
@@ -7,14 +7,13 @@ use crate::{
     arch::MMArch,
     filesystem::{
         procfs::{
-            pid::find_process_by_vpid,
+            pid::ProcPidTarget,
             template::{Builder, FileOps, ProcFileBuilder},
             utils::proc_read,
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     mm::MemoryManagementArch,
-    process::RawPid,
 };
 use alloc::{
     format,
@@ -25,12 +24,12 @@ use system_error::SystemError;
 /// /proc/[pid]/statm 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct StatmFileOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl StatmFileOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { pid }, InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -45,8 +44,10 @@ impl FileOps for StatmFileOps {
         buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        // 查找进程
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
 
         // 获取进程内存信息（简化实现）
         let size_pages = pcb

--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -50,24 +50,32 @@ impl StatusFileOps {
         let view_pid_ns = self.target.view_pid_ns();
         let mut pdata = Vec::new();
 
-        // Name
-        pdata.append(
-            &mut format!("Name:\t{}", pcb.basic().name())
-                .as_bytes()
-                .to_owned(),
-        );
+        let (name, user_vm, fd_table) = {
+            let basic = pcb.basic();
+            (
+                basic.name().to_string(),
+                basic.user_vm(),
+                basic.try_fd_table(),
+            )
+        };
 
-        let sched_info_guard = pcb.sched_info();
-        let state = sched_info_guard.inner_lock_read_irqsave().state();
-        let cpu_id = sched_info_guard
+        let state = {
+            let sched_info = pcb.sched_info();
+            sched_info.inner_lock_read_irqsave().state()
+        };
+        let cpu_id = pcb
+            .sched_info()
             .on_cpu()
             .map(|cpu| cpu.data() as i32)
             .unwrap_or(-1);
+        let priority = pcb.sched_info().policy();
+        let vrtime = pcb.sched_info().sched_entity.vruntime;
+        let time = pcb.sched_info().sched_entity.sum_exec_runtime;
+        let start_time = pcb.sched_info().sched_entity.exec_start;
+        let tty = { pcb.sig_info_irqsave().tty() };
 
-        let priority = sched_info_guard.policy();
-        let vrtime = sched_info_guard.sched_entity.vruntime;
-        let time = sched_info_guard.sched_entity.sum_exec_runtime;
-        let start_time = sched_info_guard.sched_entity.exec_start;
+        // Name
+        pdata.append(&mut format!("Name:\t{}", name).as_bytes().to_owned());
 
         // State
         pdata.append(&mut format!("\nState:\t{:?}", state).as_bytes().to_owned());
@@ -100,12 +108,18 @@ impl StatusFileOps {
             pdata.append(&mut format!("\nFDSize:\t{}", 0).into());
         } else {
             pdata.append(
-                &mut format!("\nFDSize:\t{}", pcb.fd_table().read().fd_open_count()).into(),
+                &mut format!(
+                    "\nFDSize:\t{}",
+                    fd_table
+                        .map(|fd_table| fd_table.read().fd_open_count())
+                        .unwrap_or(0)
+                )
+                .into(),
             );
         }
 
         // Tty
-        let name = if let Some(tty) = pcb.sig_info_irqsave().tty() {
+        let name = if let Some(tty) = tty {
             tty.core().name().clone()
         } else {
             "none".to_string()
@@ -128,7 +142,7 @@ impl StatusFileOps {
 
         pdata.append(&mut format!("\nvrtime:\t{}", vrtime).as_bytes().to_owned());
 
-        if let Some(user_vm) = pcb.basic().user_vm() {
+        if let Some(user_vm) = user_vm {
             let address_space_guard = user_vm.read();
             // todo: 当前进程运行过程中占用内存的峰值
             let hiwater_vm: u64 = 0;

--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -6,13 +6,13 @@ use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
         procfs::{
-            pid::find_process_by_vpid,
+            pid::ProcPidTarget,
             template::{Builder, FileOps, ProcFileBuilder},
             utils::{proc_read, trim_string},
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    process::RawPid,
+    process::pid::PidType,
 };
 use alloc::{
     borrow::ToOwned,
@@ -26,17 +26,16 @@ use system_error::SystemError;
 /// /proc/[pid]/status 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct StatusFileOps {
-    /// 存储 PID，在读取时动态查找进程
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl StatusFileOps {
-    pub fn new(pid: RawPid) -> Self {
-        Self { pid }
+    pub fn new(target: ProcPidTarget) -> Self {
+        Self { target }
     }
 
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self::new(pid), InodeMode::S_IRUGO)
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new(target), InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -44,8 +43,11 @@ impl StatusFileOps {
 
     /// 生成 status 文件内容
     fn generate_status_content(&self) -> Result<Vec<u8>, SystemError> {
-        // 动态查找进程，确保获取最新状态
-        let pcb = find_process_by_vpid(self.pid).ok_or(SystemError::ESRCH)?;
+        let pcb = self
+            .target
+            .thread_group_leader()
+            .ok_or(SystemError::ESRCH)?;
+        let view_pid_ns = self.target.view_pid_ns();
         let mut pdata = Vec::new();
 
         // Name
@@ -71,19 +73,11 @@ impl StatusFileOps {
         pdata.append(&mut format!("\nState:\t{:?}", state).as_bytes().to_owned());
 
         // Tgid
-        pdata.append(
-            &mut format!(
-                "\nTgid:\t{}",
-                pcb.task_tgid_vnr()
-                    .unwrap_or(crate::process::RawPid::new(0))
-                    .into()
-            )
-            .into(),
-        );
+        pdata.append(&mut format!("\nTgid:\t{}", self.target.tgid().data()).into());
 
         // Pid
         pdata.append(
-            &mut format!("\nPid:\t{}", pcb.task_pid_vnr().data())
+            &mut format!("\nPid:\t{}", self.target.vpid().data())
                 .as_bytes()
                 .to_owned(),
         );
@@ -93,8 +87,9 @@ impl StatusFileOps {
             &mut format!(
                 "\nPpid:\t{}",
                 pcb.parent_pcb()
-                    .map(|p| p.task_pid_vnr().data() as isize)
-                    .unwrap_or(-1)
+                    .and_then(|p| p.task_pid_ptr(PidType::TGID))
+                    .map(|pid| pid.pid_nr_ns(view_pid_ns).data() as isize)
+                    .unwrap_or(0)
             )
             .as_bytes()
             .to_owned(),

--- a/kernel/src/filesystem/procfs/pid/task.rs
+++ b/kernel/src/filesystem/procfs/pid/task.rs
@@ -5,7 +5,7 @@
 use crate::{
     filesystem::{
         procfs::{
-            pid::{find_process_by_vpid, stat::StatFileOps},
+            pid::{ns::NsDirOps, stat::StatFileOps, ProcPidTarget},
             template::{
                 lookup_child_from_table, populate_children_from_table, DirOps, ProcDir,
                 ProcDirBuilder,
@@ -14,27 +14,60 @@ use crate::{
         },
         vfs::{IndexNode, InodeMode},
     },
-    process::RawPid,
+    process::ProcessControlBlock,
 };
 use alloc::{
     string::ToString,
     sync::{Arc, Weak},
+    vec::Vec,
 };
 use system_error::SystemError;
 
 /// /proc/[pid]/task 目录的 DirOps 实现
 #[derive(Debug)]
 pub struct TaskDirOps {
-    pid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl TaskDirOps {
-    pub fn new_inode(pid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self { pid }, InodeMode::from_bits_truncate(0o555))
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self { target }, InodeMode::from_bits_truncate(0o555))
             .parent(parent)
             .volatile()
             .build()
             .unwrap()
+    }
+
+    fn thread_group_leader(&self) -> Option<Arc<ProcessControlBlock>> {
+        self.target.thread_group_leader()
+    }
+
+    fn thread_targets(&self) -> Vec<ProcPidTarget> {
+        let Some(leader) = self.thread_group_leader() else {
+            return Vec::new();
+        };
+
+        let mut targets = Vec::new();
+        if let Some(target) =
+            ProcPidTarget::from_task(self.target.view_pid_ns().clone(), leader.clone())
+        {
+            targets.push(target);
+        }
+
+        let group_tasks = leader.threads_read_irqsave().group_tasks_clone();
+        for weak in group_tasks {
+            if let Some(task) = weak.upgrade() {
+                if let Some(target) =
+                    ProcPidTarget::from_task(self.target.view_pid_ns().clone(), task)
+                {
+                    targets.push(target);
+                }
+            }
+        }
+
+        targets.sort_by_key(|target| target.vpid().data());
+        targets.dedup_by_key(|target| target.vpid().data());
+        targets
     }
 }
 
@@ -45,58 +78,51 @@ impl DirOps for TaskDirOps {
         name: &str,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         // 解析 tid
-        let tid = name.parse::<usize>().map_err(|_| SystemError::ENOENT)?;
-        let tid_pid = RawPid::new(tid);
-
-        // 目前简化实现：只支持 tid == pid（主线程）
-        // TODO: 支持真正的多线程
-        if tid_pid != self.pid {
-            return Err(SystemError::ENOENT);
-        }
-
-        // 检查进程是否存在
-        if find_process_by_vpid(self.pid).is_none() {
+        if self.thread_group_leader().is_none() {
             return Err(SystemError::ESRCH);
         }
+
+        let tid = name.parse::<usize>().map_err(|_| SystemError::ENOENT)?;
+        let target = self
+            .thread_targets()
+            .into_iter()
+            .find(|target| target.vpid().data() == tid)
+            .ok_or(SystemError::ENOENT)?;
 
         let mut cached_children = dir.cached_children().write();
         if let Some(child) = cached_children.get(name) {
             return Ok(child.clone());
         }
 
-        // 创建 tid 目录
-        let inode = TidDirOps::new_inode(self.pid, tid_pid, dir.self_ref_weak().clone());
+        let inode = TidDirOps::new_inode(target, dir.self_ref_weak().clone());
         cached_children.insert(name.to_string(), inode.clone());
         Ok(inode)
     }
 
     fn populate_children(&self, dir: &ProcDir<Self>) {
-        // 检查进程是否存在
-        if find_process_by_vpid(self.pid).is_none() {
+        if self.thread_group_leader().is_none() {
             return;
         }
 
         let mut cached_children = dir.cached_children().write();
-        let tid_str = self.pid.to_string();
-
-        // 目前只添加主线程
-        cached_children.entry(tid_str).or_insert_with(|| {
-            TidDirOps::new_inode(self.pid, self.pid, dir.self_ref_weak().clone())
-        });
+        for target in self.thread_targets() {
+            let tid_str = target.vpid().to_string();
+            cached_children.entry(tid_str).or_insert_with(|| {
+                TidDirOps::new_inode(target.clone(), dir.self_ref_weak().clone())
+            });
+        }
     }
 }
 
 /// /proc/[pid]/task/[tid] 目录的 DirOps 实现
 #[derive(Debug)]
 pub struct TidDirOps {
-    pid: RawPid,
-    #[allow(dead_code)]
-    tid: RawPid,
+    target: ProcPidTarget,
 }
 
 impl TidDirOps {
-    pub fn new_inode(pid: RawPid, tid: RawPid, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self { pid, tid }, InodeMode::from_bits_truncate(0o555))
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self { target }, InodeMode::from_bits_truncate(0o555))
             .parent(parent)
             .volatile()
             .build()
@@ -108,9 +134,14 @@ impl TidDirOps {
     const STATIC_ENTRIES: &'static [(
         &'static str,
         fn(&TidDirOps, Weak<dyn IndexNode>) -> Arc<dyn IndexNode>,
-    )] = &[("stat", |ops, parent| {
-        StatFileOps::new_inode(ops.pid, parent)
-    })];
+    )] = &[
+        ("stat", |ops, parent| {
+            StatFileOps::new_inode(ops.target.clone(), parent)
+        }),
+        ("ns", |ops, parent| {
+            NsDirOps::new_inode(ops.target.clone(), parent)
+        }),
+    ];
 }
 
 impl DirOps for TidDirOps {

--- a/kernel/src/filesystem/procfs/root.rs
+++ b/kernel/src/filesystem/procfs/root.rs
@@ -2,6 +2,8 @@
 //!
 //! 这个文件实现了 /proc 的根目录，包含静态条目和动态的进程目录
 
+use core::{any::Any, fmt};
+
 use crate::{
     filesystem::{
         procfs::{
@@ -20,7 +22,7 @@ use crate::{
                 lookup_child_from_table, populate_children_from_table, DirOps, ProcDir,
                 ProcDirBuilder,
             },
-            thread_self::ThreadSelfDirOps,
+            thread_self::ThreadSelfSymOps,
             version::VersionFileOps,
             version_signature::VersionSignatureFileOps,
             vmstat::VmstatFileOps,
@@ -28,7 +30,7 @@ use crate::{
         },
         vfs::{FileSystemMakerData, IndexNode, InodeMode, FSMAKER},
     },
-    process::{pid::PidType, ProcessManager, RawPid},
+    process::{namespace::pid_namespace::PidNamespace, ProcessManager, RawPid},
     register_mountable_fs,
 };
 use alloc::{
@@ -39,15 +41,38 @@ use alloc::{
 use system_error::SystemError;
 
 /// /proc 根目录的 DirOps 实现
-#[derive(Debug)]
-pub struct RootDirOps;
+pub struct RootDirOps {
+    pid_ns: Arc<PidNamespace>,
+}
+
+impl fmt::Debug for RootDirOps {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RootDirOps").finish()
+    }
+}
+
+struct ProcMountData {
+    pid_ns: Arc<PidNamespace>,
+}
+
+impl fmt::Debug for ProcMountData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcMountData").finish()
+    }
+}
+
+impl FileSystemMakerData for ProcMountData {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
 //  drop 的时候把对应pid的文件夹删除
 impl RootDirOps {
-    pub fn new_inode(fs: Weak<ProcFS>) -> Arc<dyn IndexNode> {
+    pub fn new_inode(fs: Weak<ProcFS>, pid_ns: Arc<PidNamespace>) -> Arc<dyn IndexNode> {
         //todo 这里要注册一个observer，用于动态创建进程目录
 
-        ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
+        ProcDirBuilder::new(Self { pid_ns }, InodeMode::from_bits_truncate(0o555))
             .fs(fs)
             .build()
             .expect("Failed to create RootDirOps")
@@ -70,7 +95,7 @@ impl RootDirOps {
         ("self", SelfSymOps::new_inode),
         ("stat", StatFileOps::new_inode),
         ("sys", SysDirOps::new_inode),
-        ("thread-self", ThreadSelfDirOps::new_inode),
+        ("thread-self", ThreadSelfSymOps::new_inode),
         ("version", VersionFileOps::new_inode),
         ("version_signature", VersionSignatureFileOps::new_inode),
         ("vmstat", VmstatFileOps::new_inode),
@@ -86,7 +111,10 @@ impl DirOps for RootDirOps {
         // 首先检查是否是 PID 目录
         if let Ok(pid) = name.parse::<RawPid>() {
             // 检查进程是否存在
-            if ProcessManager::find_task_by_vpid(pid).is_some() {
+            if let Some(target) = crate::filesystem::procfs::pid::ProcPidTarget::from_tgid_in_ns(
+                self.pid_ns.clone(),
+                pid,
+            ) {
                 let mut cached_children = dir.cached_children().write();
 
                 // 检查缓存中是否已存在
@@ -95,7 +123,7 @@ impl DirOps for RootDirOps {
                 }
 
                 // 创建新的 PID 目录（只传递 PID，不传递进程引用）
-                let inode = PidDirOps::new_inode(pid, dir.self_ref_weak().clone());
+                let inode = PidDirOps::new_inode(target, dir.self_ref_weak().clone());
                 cached_children.insert(name.to_string(), inode.clone());
                 return Ok(inode);
             } else {
@@ -118,23 +146,28 @@ impl DirOps for RootDirOps {
     }
 
     fn populate_children(&self, dir: &ProcDir<Self>) {
-        let active_pid_ns = ProcessManager::current_pcb().active_pid_ns();
-        let pid_list = active_pid_ns
+        let pid_targets = self
+            .pid_ns
             .collect_pids()
             .into_iter()
-            .filter(|pid| pid.pid_task(PidType::PID).is_some())
-            .map(|pid| pid.pid_nr_ns(&active_pid_ns))
-            .filter(|pid| pid.data() != 0)
+            .filter_map(|pid| {
+                crate::filesystem::procfs::pid::ProcPidTarget::from_tgid_in_ns(
+                    self.pid_ns.clone(),
+                    pid.pid_nr_ns(&self.pid_ns),
+                )
+            })
             .collect::<Vec<_>>();
 
         // 获取缓存写锁并填充
         let mut cached_children = dir.cached_children().write();
 
         // 填充进程目录（只传递 PID）
-        for pid in pid_list {
+        for target in pid_targets {
             cached_children
-                .entry(pid.to_string())
-                .or_insert_with(|| PidDirOps::new_inode(pid, dir.self_ref_weak().clone()));
+                .entry(target.vpid().to_string())
+                .or_insert_with(|| {
+                    PidDirOps::new_inode(target.clone(), dir.self_ref_weak().clone())
+                });
         }
 
         // 填充静态条目
@@ -150,15 +183,21 @@ use crate::libs::rwsem::RwSem;
 use linkme::distributed_slice;
 
 /// ProcFS 文件系统
-#[derive(Debug)]
 pub struct ProcFS {
+    pid_ns: Arc<PidNamespace>,
     /// procfs 的 root inode
     root_inode: Arc<dyn IndexNode>,
     super_block: RwSem<SuperBlock>,
 }
 
+impl fmt::Debug for ProcFS {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcFS").finish()
+    }
+}
+
 impl ProcFS {
-    pub fn new() -> Arc<Self> {
+    pub fn new(pid_ns: Arc<PidNamespace>) -> Arc<Self> {
         let super_block = SuperBlock::new(
             Magic::PROC_MAGIC,
             PROCFS_BLOCK_SIZE,
@@ -166,11 +205,16 @@ impl ProcFS {
         );
 
         let fs: Arc<ProcFS> = Arc::new_cyclic(|weak_fs| ProcFS {
+            pid_ns: pid_ns.clone(),
             super_block: RwSem::new(super_block),
-            root_inode: RootDirOps::new_inode(weak_fs.clone()),
+            root_inode: RootDirOps::new_inode(weak_fs.clone(), pid_ns.clone()),
         });
 
         fs
+    }
+
+    pub fn pid_ns(&self) -> &Arc<PidNamespace> {
+        &self.pid_ns
     }
 }
 
@@ -210,14 +254,18 @@ impl MountableFileSystem for ProcFS {
         _source: &str,
     ) -> Result<Option<Arc<dyn crate::filesystem::vfs::FileSystemMakerData + 'static>>, SystemError>
     {
-        // procfs 不需要任何额外的挂载数据
-        Ok(None)
+        Ok(Some(Arc::new(ProcMountData {
+            pid_ns: ProcessManager::current_pcb().active_pid_ns(),
+        })))
     }
 
     fn make_fs(
-        _data: Option<&dyn crate::filesystem::vfs::FileSystemMakerData>,
+        data: Option<&dyn crate::filesystem::vfs::FileSystemMakerData>,
     ) -> Result<Arc<dyn FileSystem + 'static>, SystemError> {
-        let fs = ProcFS::new();
+        let mount_data = data
+            .and_then(|d| d.as_any().downcast_ref::<ProcMountData>())
+            .ok_or(SystemError::EINVAL)?;
+        let fs = ProcFS::new(mount_data.pid_ns.clone());
         Ok(fs)
     }
 }

--- a/kernel/src/filesystem/procfs/root.rs
+++ b/kernel/src/filesystem/procfs/root.rs
@@ -117,12 +117,12 @@ impl DirOps for RootDirOps {
             ) {
                 let mut cached_children = dir.cached_children().write();
 
-                // 检查缓存中是否已存在
                 if let Some(child) = cached_children.get(name) {
-                    return Ok(child.clone());
+                    if self.validate_child(child.as_ref()) {
+                        return Ok(child.clone());
+                    }
                 }
 
-                // 创建新的 PID 目录（只传递 PID，不传递进程引用）
                 let inode = PidDirOps::new_inode(target, dir.self_ref_weak().clone());
                 cached_children.insert(name.to_string(), inode.clone());
                 return Ok(inode);
@@ -161,13 +161,23 @@ impl DirOps for RootDirOps {
         // 获取缓存写锁并填充
         let mut cached_children = dir.cached_children().write();
 
+        cached_children.retain(|name, child| {
+            name.parse::<RawPid>().is_err() || self.validate_child(child.as_ref())
+        });
+
         // 填充进程目录（只传递 PID）
         for target in pid_targets {
-            cached_children
-                .entry(target.vpid().to_string())
-                .or_insert_with(|| {
-                    PidDirOps::new_inode(target.clone(), dir.self_ref_weak().clone())
-                });
+            let name = target.vpid().to_string();
+            let needs_refresh = cached_children
+                .get(&name)
+                .map(|child| !self.validate_child(child.as_ref()))
+                .unwrap_or(true);
+            if needs_refresh {
+                cached_children.insert(
+                    name,
+                    PidDirOps::new_inode(target.clone(), dir.self_ref_weak().clone()),
+                );
+            }
         }
 
         // 填充静态条目
@@ -175,6 +185,13 @@ impl DirOps for RootDirOps {
             (f)(dir.self_ref_weak().clone())
         });
         // 写锁在这里自动释放
+    }
+
+    fn validate_child(&self, child: &dyn IndexNode) -> bool {
+        if let Some(pid_dir) = child.downcast_ref::<ProcDir<PidDirOps>>() {
+            return pid_dir.ops().is_current_target();
+        }
+        true
     }
 }
 

--- a/kernel/src/filesystem/procfs/self_.rs
+++ b/kernel/src/filesystem/procfs/self_.rs
@@ -4,24 +4,45 @@
 
 use crate::{
     filesystem::{
-        procfs::template::{Builder, ProcSymBuilder, SymOps},
+        procfs::{
+            root::ProcFS,
+            template::{Builder, ProcSymBuilder, SymOps},
+        },
         vfs::{IndexNode, InodeMode},
     },
-    process::ProcessManager,
+    process::{namespace::pid_namespace::PidNamespace, pid::PidType, ProcessManager},
 };
 use alloc::{
     string::ToString,
     sync::{Arc, Weak},
 };
+use core::fmt;
 use system_error::SystemError;
 
 /// /proc/self 符号链接的 SymOps 实现
-#[derive(Debug)]
-pub struct SelfSymOps;
+pub struct SelfSymOps {
+    view_pid_ns: Arc<PidNamespace>,
+}
+
+impl fmt::Debug for SelfSymOps {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SelfSymOps").finish()
+    }
+}
 
 impl SelfSymOps {
     pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcSymBuilder::new(Self, InodeMode::S_IRWXUGO) // 0777 - 符号链接权限
+        let view_pid_ns = parent
+            .upgrade()
+            .expect("proc self parent should exist")
+            .fs()
+            .as_any_ref()
+            .downcast_ref::<ProcFS>()
+            .expect("/proc/self must belong to procfs")
+            .pid_ns()
+            .clone();
+
+        ProcSymBuilder::new(Self { view_pid_ns }, InodeMode::S_IRWXUGO) // 0777 - 符号链接权限
             .parent(parent)
             .build()
             .unwrap()
@@ -30,11 +51,14 @@ impl SelfSymOps {
 
 impl SymOps for SelfSymOps {
     fn read_link(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
-        // 返回当前线程组的 TGID（与 Linux /proc/self 语义一致）
         let current_pcb = ProcessManager::current_pcb();
         let tgid = current_pcb
-            .task_tgid_vnr()
-            .unwrap_or_else(ProcessManager::current_pid);
+            .task_pid_ptr(PidType::TGID)
+            .map(|pid| pid.pid_nr_ns(&self.view_pid_ns))
+            .ok_or(SystemError::ESRCH)?;
+        if tgid.data() == 0 {
+            return Err(SystemError::ENOENT);
+        }
         let pid_bytes = tgid.data().to_string();
         let len = pid_bytes.len().min(buf.len());
         buf[..len].copy_from_slice(&pid_bytes.as_bytes()[..len]);

--- a/kernel/src/filesystem/procfs/stat.rs
+++ b/kernel/src/filesystem/procfs/stat.rs
@@ -9,9 +9,13 @@ use crate::{
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     libs::mutex::MutexGuard,
-    process::{pid::PidType, ProcessManager, ProcessState},
-    sched::cputime::{kcpustat_cpu, ns_to_clock_t, CpuUsageStat, NR_CPU_STATS},
-    smp::cpu::{smp_cpu_manager, ProcessorId},
+    process::{nr_context_switches, total_forks},
+    sched::{
+        cputime::{kcpustat_cpu, ns_to_clock_t, CpuUsageStat, NR_CPU_STATS},
+        loadavg, nr_iowait,
+    },
+    smp::cpu::smp_cpu_manager,
+    time::timekeeping::boottime_seconds,
 };
 use alloc::{borrow::ToOwned, format, sync::Arc, sync::Weak, vec::Vec};
 use system_error::SystemError;
@@ -31,24 +35,27 @@ impl StatFileOps {
     fn generate_stat_content() -> Vec<u8> {
         let mut data: Vec<u8> = Vec::new();
 
-        // 获取 CPU 数量
-        let cpu_count = smp_cpu_manager().present_cpus_count() as usize;
-        let cpu_count = if cpu_count == 0 { 1 } else { cpu_count };
+        let present_cpus = smp_cpu_manager()
+            .present_cpus()
+            .iter_cpu()
+            .collect::<Vec<_>>();
+        let cpu_ids = if present_cpus.is_empty() {
+            vec![crate::smp::cpu::ProcessorId::new(0)]
+        } else {
+            present_cpus
+        };
 
-        // 汇总所有 CPU 的统计
         let mut total_stats = [0u64; NR_CPU_STATS];
-        for cpu_id in 0..cpu_count {
-            let stat = kcpustat_cpu(ProcessorId::new(cpu_id as u32));
-            let snapshot = stat.snapshot();
+        for cpu_id in &cpu_ids {
+            let snapshot = kcpustat_cpu(*cpu_id).snapshot();
             for i in 0..NR_CPU_STATS {
                 total_stats[i] += snapshot[i];
             }
         }
 
-        // 输出总 CPU 行（8 个字段：user nice system idle iowait irq softirq steal）
         data.append(
             &mut format!(
-                "cpu {} {} {} {} {} {} {} {}\n",
+                "cpu {} {} {} {} {} {} {} {} {} {}\n",
                 ns_to_clock_t(total_stats[CpuUsageStat::User as usize]),
                 ns_to_clock_t(total_stats[CpuUsageStat::Nice as usize]),
                 ns_to_clock_t(total_stats[CpuUsageStat::System as usize]),
@@ -57,19 +64,19 @@ impl StatFileOps {
                 ns_to_clock_t(total_stats[CpuUsageStat::Irq as usize]),
                 ns_to_clock_t(total_stats[CpuUsageStat::Softirq as usize]),
                 ns_to_clock_t(total_stats[CpuUsageStat::Steal as usize]),
+                ns_to_clock_t(total_stats[CpuUsageStat::Guest as usize]),
+                ns_to_clock_t(total_stats[CpuUsageStat::GuestNice as usize]),
             )
             .as_bytes()
             .to_owned(),
         );
 
-        // 输出每个 CPU 的统计行
-        for cpu_id in 0..cpu_count {
-            let stat = kcpustat_cpu(ProcessorId::new(cpu_id as u32));
-            let snapshot = stat.snapshot();
+        for cpu_id in &cpu_ids {
+            let snapshot = kcpustat_cpu(*cpu_id).snapshot();
             data.append(
                 &mut format!(
-                    "cpu{} {} {} {} {} {} {} {} {}\n",
-                    cpu_id,
+                    "cpu{} {} {} {} {} {} {} {} {} {} {}\n",
+                    cpu_id.data(),
                     ns_to_clock_t(snapshot[CpuUsageStat::User as usize]),
                     ns_to_clock_t(snapshot[CpuUsageStat::Nice as usize]),
                     ns_to_clock_t(snapshot[CpuUsageStat::System as usize]),
@@ -78,46 +85,44 @@ impl StatFileOps {
                     ns_to_clock_t(snapshot[CpuUsageStat::Irq as usize]),
                     ns_to_clock_t(snapshot[CpuUsageStat::Softirq as usize]),
                     ns_to_clock_t(snapshot[CpuUsageStat::Steal as usize]),
+                    ns_to_clock_t(snapshot[CpuUsageStat::Guest as usize]),
+                    ns_to_clock_t(snapshot[CpuUsageStat::GuestNice as usize]),
                 )
                 .as_bytes()
                 .to_owned(),
             );
         }
 
-        data.append(&mut b"intr 0\n".to_vec());
-        data.append(&mut b"ctxt 0\n".to_vec());
-        data.append(&mut b"btime 0\n".to_vec());
-
-        let pidns = ProcessManager::current_pcb().active_pid_ns();
-        let processes = pidns.processes_created();
-        let pids = pidns.collect_pids();
-
-        let mut procs_running = 0u64;
-        let mut procs_blocked = 0u64;
-        for pid in pids {
-            if let Some(pcb) = pid.pid_task(PidType::PID) {
-                let state = pcb.sched_info().inner_lock_read_irqsave().state();
-                if state.is_runnable() {
-                    procs_running += 1;
-                } else if matches!(state, ProcessState::Blocked(false)) {
-                    procs_blocked += 1;
-                }
-            }
-        }
-
-        data.append(&mut format!("processes {}\n", processes).as_bytes().to_owned());
+        let intr_total = 0u64;
+        data.append(&mut format!("intr {}\n", intr_total).as_bytes().to_owned());
         data.append(
-            &mut format!("procs_running {}\n", procs_running)
+            &mut format!("ctxt {}\n", nr_context_switches())
                 .as_bytes()
                 .to_owned(),
         );
         data.append(
-            &mut format!("procs_blocked {}\n", procs_blocked)
+            &mut format!("btime {}\n", boottime_seconds())
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(
+            &mut format!("processes {}\n", total_forks())
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(
+            &mut format!("procs_running {}\n", loadavg::nr_running())
+                .as_bytes()
+                .to_owned(),
+        );
+        data.append(
+            &mut format!("procs_blocked {}\n", nr_iowait())
                 .as_bytes()
                 .to_owned(),
         );
 
-        data.append(&mut b"softirq 0\n".to_vec());
+        let softirq_total = 0u64;
+        data.append(&mut format!("softirq {}\n", softirq_total).as_bytes().to_owned());
 
         trim_string(&mut data);
         data

--- a/kernel/src/filesystem/procfs/template/dir.rs
+++ b/kernel/src/filesystem/procfs/template/dir.rs
@@ -88,13 +88,20 @@ impl<Ops: DirOps> ProcDir<Ops> {
     pub fn cached_children(&self) -> &RwSem<BTreeMap<String, Arc<dyn IndexNode>>> {
         &self.cached_children
     }
+
+    pub(crate) fn ops(&self) -> &Ops {
+        &self.inner
+    }
 }
 
 #[inherit_methods(from = "self.common")]
 impl<Ops: DirOps + 'static> IndexNode for ProcDir<Ops> {
     fn fs(&self) -> Arc<dyn FileSystem>;
-    fn as_any_ref(&self) -> &dyn core::any::Any;
     fn set_metadata(&self, metadata: &Metadata) -> Result<(), SystemError>;
+
+    fn as_any_ref(&self) -> &dyn core::any::Any {
+        self
+    }
 
     fn metadata(&self) -> Result<Metadata, SystemError> {
         let mut metadata = self.common.metadata()?;

--- a/kernel/src/filesystem/procfs/template/file.rs
+++ b/kernel/src/filesystem/procfs/template/file.rs
@@ -106,6 +106,11 @@ pub trait FileOps: Sync + Send + Sized + Debug {
         Err(SystemError::EPERM)
     }
 
+    /// 打开文件时调用，可用于按 open 时上下文初始化 procfs 私有数据
+    fn open(&self, _data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        Ok(())
+    }
+
     /// 返回动态 owner（用于 /proc/<pid> 等需要实时 UID/GID 的场景）
     fn owner(&self) -> Option<(usize, usize)> {
         None
@@ -165,7 +170,7 @@ impl<F: FileOps + 'static> IndexNode for ProcFile<F> {
     ) -> Result<(), SystemError> {
         // 设置 procfs 私有数据，使得 lseek(SEEK_END) 返回 EINVAL
         *data = FilePrivateData::Procfs(ProcfsFilePrivateData::new());
-        Ok(())
+        self.inner.open(&mut data)
     }
 
     fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/procfs/thread_self.rs
+++ b/kernel/src/filesystem/procfs/thread_self.rs
@@ -1,28 +1,24 @@
-//! /proc/thread-self 目录
+//! /proc/thread-self - 指向当前线程目录的符号链接
 //!
-//! 这个模块实现了 /proc/thread-self 目录，它包含当前线程的信息。
-//! 主要提供 /proc/thread-self/ns/ 子目录用于访问当前线程的命名空间。
+//! Linux 中 /proc/thread-self 是一个魔法符号链接，目标为
+//! /proc/<tgid>/task/<tid>，其中数字必须按当前 proc mount 绑定的 pid namespace
+//! 生成。真正的命名空间文件语义则由 /proc/<tgid>/task/<tid>/ns/* 提供。
 
-use crate::libs::mutex::MutexGuard;
 use crate::{
     filesystem::{
-        procfs::template::{Builder, DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
-        vfs::{
-            file::{FilePrivateData, NamespaceFilePrivateData},
-            IndexNode, InodeId, InodeMode,
+        procfs::{
+            root::ProcFS,
+            template::{Builder, ProcSymBuilder, SymOps},
         },
+        vfs::{IndexNode, InodeMode},
     },
-    process::{
-        namespace::{nsproxy::NamespaceId, NamespaceOps},
-        ProcessManager,
-    },
+    process::{namespace::pid_namespace::PidNamespace, pid::PidType, ProcessManager},
 };
 use alloc::{
     format,
-    string::ToString,
     sync::{Arc, Weak},
 };
-use core::convert::TryFrom;
+use core::{convert::TryFrom, fmt};
 use system_error::SystemError;
 
 /// 命名空间文件类型
@@ -92,187 +88,55 @@ impl TryFrom<&str> for NsFileType {
     }
 }
 
-/// 获取当前线程的命名空间 ID
-fn current_thread_self_ns_ino(ns_type: NsFileType) -> usize {
-    let pcb = ProcessManager::current_pcb();
-    let nsproxy = pcb.nsproxy();
-
-    let ino: NamespaceId = match ns_type {
-        NsFileType::Ipc => nsproxy.ipc_ns.ns_common().nsid,
-        NsFileType::Uts => nsproxy.uts_ns.ns_common().nsid,
-        NsFileType::Mnt => nsproxy.mnt_ns.ns_common().nsid,
-        NsFileType::Net => nsproxy.net_ns.ns_common().nsid,
-        NsFileType::Pid => pcb.active_pid_ns().ns_common().nsid,
-        NsFileType::PidForChildren => nsproxy.pid_ns_for_children.ns_common().nsid,
-        NsFileType::Time | NsFileType::TimeForChildren => {
-            // Time namespace 尚未实现
-            NamespaceId::new(0)
-        }
-        NsFileType::User => pcb.cred().user_ns.ns_common().nsid,
-        NsFileType::Cgroup => nsproxy.cgroup_ns.ns_common().nsid,
-    };
-
-    ino.data()
+/// /proc/thread-self 符号链接的 SymOps 实现
+pub struct ThreadSelfSymOps {
+    view_pid_ns: Arc<PidNamespace>,
 }
 
-// ============================================================================
-// /proc/thread-self 目录
-// ============================================================================
+impl fmt::Debug for ThreadSelfSymOps {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ThreadSelfSymOps").finish()
+    }
+}
 
-/// /proc/thread-self 目录的 DirOps 实现
-#[derive(Debug)]
-pub struct ThreadSelfDirOps;
-
-impl ThreadSelfDirOps {
+impl ThreadSelfSymOps {
     pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
+        let view_pid_ns = parent
+            .upgrade()
+            .expect("proc thread-self parent should exist")
+            .fs()
+            .as_any_ref()
+            .downcast_ref::<ProcFS>()
+            .expect("/proc/thread-self must belong to procfs")
+            .pid_ns()
+            .clone();
+
+        ProcSymBuilder::new(Self { view_pid_ns }, InodeMode::S_IRWXUGO)
             .parent(parent)
             .build()
             .unwrap()
     }
 }
 
-impl DirOps for ThreadSelfDirOps {
-    fn lookup_child(
-        &self,
-        dir: &ProcDir<Self>,
-        name: &str,
-    ) -> Result<Arc<dyn IndexNode>, SystemError> {
-        if name == "ns" {
-            let mut cached_children = dir.cached_children().write();
-            if let Some(child) = cached_children.get(name) {
-                return Ok(child.clone());
-            }
-
-            let inode = ThreadSelfNsDirOps::new_inode(dir.self_ref_weak().clone());
-            cached_children.insert(name.to_string(), inode.clone());
-            return Ok(inode);
-        }
-
-        Err(SystemError::ENOENT)
-    }
-
-    fn populate_children(&self, dir: &ProcDir<Self>) {
-        let mut cached_children = dir.cached_children().write();
-        cached_children
-            .entry("ns".to_string())
-            .or_insert_with(|| ThreadSelfNsDirOps::new_inode(dir.self_ref_weak().clone()));
-    }
-}
-
-// ============================================================================
-// /proc/thread-self/ns 目录
-// ============================================================================
-
-/// /proc/thread-self/ns 目录的 DirOps 实现
-#[derive(Debug)]
-pub struct ThreadSelfNsDirOps;
-
-impl ThreadSelfNsDirOps {
-    pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
-            .parent(parent)
-            .build()
-            .unwrap()
-    }
-}
-
-impl DirOps for ThreadSelfNsDirOps {
-    fn lookup_child(
-        &self,
-        dir: &ProcDir<Self>,
-        name: &str,
-    ) -> Result<Arc<dyn IndexNode>, SystemError> {
-        // 解析命名空间类型
-        let ns_type = NsFileType::try_from(name)?;
-
-        let mut cached_children = dir.cached_children().write();
-        if let Some(child) = cached_children.get(name) {
-            return Ok(child.clone());
-        }
-
-        // 创建命名空间符号链接
-        let inode = ThreadSelfNsSymOps::new_inode(ns_type, dir.self_ref_weak().clone());
-        cached_children.insert(name.to_string(), inode.clone());
-        Ok(inode)
-    }
-
-    fn populate_children(&self, dir: &ProcDir<Self>) {
-        let mut cached_children = dir.cached_children().write();
-
-        for name in NsFileType::ALL_NAMES {
-            if let Ok(ns_type) = NsFileType::try_from(name) {
-                cached_children.entry(name.to_string()).or_insert_with(|| {
-                    ThreadSelfNsSymOps::new_inode(ns_type, dir.self_ref_weak().clone())
-                });
-            }
-        }
-    }
-}
-
-// ============================================================================
-// /proc/thread-self/ns/* 符号链接
-// ============================================================================
-
-/// /proc/thread-self/ns/[type] 符号链接的 SymOps 实现
-#[derive(Debug)]
-pub struct ThreadSelfNsSymOps {
-    ns_type: NsFileType,
-}
-
-impl ThreadSelfNsSymOps {
-    pub fn new_inode(ns_type: NsFileType, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcSymBuilder::new(Self { ns_type }, InodeMode::S_IRWXUGO)
-            .parent(parent)
-            .build()
-            .unwrap()
-    }
-}
-
-impl SymOps for ThreadSelfNsSymOps {
+impl SymOps for ThreadSelfSymOps {
     fn read_link(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
-        let ino = current_thread_self_ns_ino(self.ns_type);
-        let target = format!("{}:[{}]", self.ns_type.name(), ino);
+        let current_pcb = ProcessManager::current_pcb();
+        let tgid = current_pcb
+            .task_pid_ptr(PidType::TGID)
+            .map(|pid| pid.pid_nr_ns(&self.view_pid_ns))
+            .ok_or(SystemError::ESRCH)?;
+        let tid = current_pcb
+            .task_pid_ptr(PidType::PID)
+            .map(|pid| pid.pid_nr_ns(&self.view_pid_ns))
+            .ok_or(SystemError::ESRCH)?;
+
+        if tgid.data() == 0 || tid.data() == 0 {
+            return Err(SystemError::ENOENT);
+        }
+
+        let target = format!("{}/task/{}", tgid.data(), tid.data());
         let len = target.len().min(buf.len());
         buf[..len].copy_from_slice(&target.as_bytes()[..len]);
         Ok(len)
-    }
-
-    fn is_self_reference(&self) -> bool {
-        // 命名空间符号链接是自引用的魔法链接
-        true
-    }
-
-    fn dynamic_inode_id(&self) -> Option<InodeId> {
-        // 命名空间文件的 inode ID 应该是命名空间的 ID
-        // 这样 stat() 返回的 st_ino 就是命名空间 ID
-        Some(InodeId::new(current_thread_self_ns_ino(self.ns_type)))
-    }
-
-    fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
-        // 当打开命名空间文件时，设置命名空间私有数据
-        // 这使得 setns() 可以使用这个 fd
-        let pcb = ProcessManager::current_pcb();
-        let nsproxy = pcb.nsproxy();
-
-        let ns_data = match self.ns_type {
-            NsFileType::Ipc => NamespaceFilePrivateData::Ipc(nsproxy.ipc_ns.clone()),
-            NsFileType::Uts => NamespaceFilePrivateData::Uts(nsproxy.uts_ns.clone()),
-            NsFileType::Mnt => NamespaceFilePrivateData::Mnt(nsproxy.mnt_ns.clone()),
-            NsFileType::Net => NamespaceFilePrivateData::Net(nsproxy.net_ns.clone()),
-            NsFileType::Pid => NamespaceFilePrivateData::Pid(pcb.active_pid_ns()),
-            NsFileType::PidForChildren => {
-                NamespaceFilePrivateData::PidForChildren(nsproxy.pid_ns_for_children.clone())
-            }
-            NsFileType::Time | NsFileType::TimeForChildren => {
-                // Time namespace 尚未实现
-                return Err(SystemError::ENOSYS);
-            }
-            NsFileType::User => NamespaceFilePrivateData::User(pcb.cred().user_ns.clone()),
-            NsFileType::Cgroup => NamespaceFilePrivateData::Cgroup(nsproxy.cgroup_ns.clone()),
-        };
-
-        **data = FilePrivateData::Namespace(ns_data);
-        Ok(())
     }
 }

--- a/kernel/src/ipc/sighand.rs
+++ b/kernel/src/ipc/sighand.rs
@@ -164,6 +164,16 @@ impl SigHand {
         self_guard.handlers = other_guard.handlers.clone();
     }
 
+    pub fn copy_process_state_from(&self, other: &Arc<SigHand>) {
+        let other_guard = other.inner();
+        let mut self_guard = self.inner_mut();
+        self_guard.flags = other_guard.flags;
+        self_guard.group_exit_code = other_guard.group_exit_code;
+        self_guard.group_exec_task = other_guard.group_exec_task.clone();
+        self_guard.group_exec_notify_count = other_guard.group_exec_notify_count;
+        self_guard.pids = other_guard.pids.clone();
+    }
+
     // ===== Shared pending helpers =====
     pub fn shared_pending_signal(&self) -> SigSet {
         let g = self.inner();

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -8,8 +8,9 @@ use alloc::sync::Arc;
 use system_error::SystemError;
 
 use super::inner;
-use super::poll_util;
 use super::TcpSocket;
+
+const TCP_CLOSE_POST_POLL_ROUNDS: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CloseObservation {
@@ -575,22 +576,6 @@ impl TcpSocket {
     }
 
     pub fn close_socket(&self) -> Result<(), SystemError> {
-        // 先把 iface 推进到稳定态，再决定 close(2) 是走 FIN 还是 RST。
-        // 否则 loopback 上尚未被 poll 到接收队列的数据会让 unread 误判为 0，
-        // 导致本应 abort(RST) 的场景被错误地当成 graceful close(FIN)。
-        if let Some(iface) = self
-            .inner
-            .read()
-            .as_ref()
-            .and_then(|inner| inner.iface())
-            .cloned()
-        {
-            if let Some(netns) = iface.common().net_namespace() {
-                netns.wakeup_poll_thread();
-            }
-            poll_util::poll_iface_until_quiescent(iface.as_ref());
-        }
-
         let mut writer = self.inner.write();
         let Some(inner) = writer.take() else {
             log::warn!("TcpSocket::close: already closed, unexpected");
@@ -734,7 +719,13 @@ impl TcpSocket {
             if let Some(netns) = iface.common().net_namespace() {
                 netns.wakeup_poll_thread();
             }
-            poll_util::poll_iface_until_quiescent(iface.as_ref());
+            // close(2) must not drain unrelated sockets on the whole interface. Linux
+            // queues FIN/RST work and returns without waiting for global TCP quiescence.
+            // A small bounded push is enough to expose the close to smoltcp/loopback
+            // immediately while keeping syscall latency independent of orphan backlog.
+            for _ in 0..TCP_CLOSE_POST_POLL_ROUNDS {
+                iface.poll();
+            }
             iface.common().notify_all_bound_sockets();
         }
         self.notify();

--- a/kernel/src/net/tcp_close_defer.rs
+++ b/kernel/src/net/tcp_close_defer.rs
@@ -191,7 +191,8 @@ impl TcpCloseDefer {
                     .get::<smoltcp::socket::tcp::Socket>(handle)
                     .remote_endpoint()
                     .is_some();
-                if rst_pending && !orphan_timed_out {
+                let is_reset_close = closing[i]._kind == DeferredTcpCloseKind::Reset;
+                if rst_pending && !is_reset_close && !orphan_timed_out {
                     i += 1;
                     continue;
                 }

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -414,21 +414,21 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
 
         // 非 leader exec：等待 leader 进入 zombie 后再交换 tid/raw_pid
         if !Arc::ptr_eq(&leader, &current) {
-            // 标记等待 leader 退出（notify_count < 0），由 exit_notify 唤醒
-            if !leader.is_zombie() && !leader.is_dead() {
-                sighand.set_group_exec_notify_count(-1);
-                let wait_res = sighand.wait_group_exec_event_killable(
-                    || {
-                        if Signal::fatal_signal_pending(&current) {
-                            return true;
-                        }
-                        leader.is_zombie() || leader.is_dead()
-                    },
-                    None::<fn()>,
-                );
-                if wait_res.is_err() || Signal::fatal_signal_pending(&current) {
-                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-                }
+            // 标记等待 leader 退出（notify_count < 0），由 exit_notify 唤醒。
+            // 必须先发布等待状态再检查 leader，否则 leader 可能在检查与设置之间
+            // 退出，导致 exit_notify 看不到 notify_count < 0 而丢失唤醒。
+            sighand.set_group_exec_notify_count(-1);
+            let wait_res = sighand.wait_group_exec_event_killable(
+                || {
+                    if Signal::fatal_signal_pending(&current) {
+                        return true;
+                    }
+                    leader.is_zombie() || leader.is_dead()
+                },
+                None::<fn()>,
+            );
+            if wait_res.is_err() || Signal::fatal_signal_pending(&current) {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
 
             ProcessManager::exchange_tid_and_raw_pids(&current, &leader)?;
@@ -492,7 +492,6 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
             current.exit_signal.store(Signal::SIGCHLD, Ordering::SeqCst);
         }
 
-        // log::info!("de_thread: done pid={:?}", current.raw_pid());
         Ok(())
     })();
 

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -177,8 +177,10 @@ fn do_execve_internal(
             if pcb.sighand().is_shared() {
                 // Linux出于进程和线程隔离，要确保在execve时，对共享的 SigHand 进行深拷贝
                 // 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/fs/exec.c#1187
+                let old_sighand = pcb.sighand();
                 let new_sighand = crate::ipc::sighand::SigHand::new();
-                new_sighand.copy_handlers_from(&pcb.sighand());
+                new_sighand.copy_handlers_from(&old_sighand);
+                new_sighand.copy_process_state_from(&old_sighand);
                 pcb.replace_sighand(new_sighand);
             }
             // 重置所有信号处理器为默认行为(SIG_DFL)，禁用并清空备用信号栈。

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -293,31 +293,35 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                 return Err(SystemError::ECHILD);
             }
 
-            let child_pcb = pid.pid_task(PidType::PID).ok_or(SystemError::ECHILD)?;
-
             let current = ProcessManager::current_pcb();
-
-            // 检查子进程是否可以被当前线程等待
-            // 根据 Linux 语义：
-            // - 默认情况下，线程组中的任何线程都可以等待同一线程组中任何线程 fork 的子进程
-            // - 如果指定了 __WNOTHREAD，则只能等待当前线程自己创建的子进程
-            if !is_eligible_child(&child_pcb, kwo.options) {
-                return Err(SystemError::ECHILD);
-            }
-
-            // 检查子进程是否匹配等待选项（__WALL/__WCLONE）
-            if !child_matches_wait_options(&child_pcb, kwo.options) {
-                return Err(SystemError::ECHILD);
-            }
-
             // 获取用于等待的 PCB（线程组 leader 或当前线程，取决于 WNOTHREAD）
             let parent = get_thread_group_leader(&current);
+            let check_child = |kwo: &mut KernelWaitOption| -> Option<Result<usize, SystemError>> {
+                let child_pcb = match pid.pid_task(PidType::PID) {
+                    Some(child_pcb) => child_pcb,
+                    None => return Some(Err(SystemError::ECHILD)),
+                };
+                // 检查子进程是否可以被当前线程等待
+                // 根据 Linux 语义：
+                // - 默认情况下，线程组中的任何线程可以等待同一线程组中任何线程 fork 的子进程
+                // - 如果指定了 __WNOTHREAD，则只能等待当前线程自己创建的子进程
+                if !is_eligible_child(&child_pcb, kwo.options) {
+                    return Some(Err(SystemError::ECHILD));
+                }
+
+                // 检查子进程是否匹配等待选项（__WALL/__WCLONE）
+                if !child_matches_wait_options(&child_pcb, kwo.options) {
+                    return Some(Err(SystemError::ECHILD));
+                }
+
+                do_waitpid(child_pcb, kwo)
+            };
 
             // 等待指定子进程：睡眠在父进程自己的 wait_queue 上
             // 子进程退出时会发送信号并唤醒父进程的 wait_queue
             loop {
                 // Fast path: check without sleeping
-                if let Some(r) = do_waitpid(child_pcb.clone(), kwo) {
+                if let Some(r) = check_child(kwo) {
                     break r;
                 }
                 if kwo.options.contains(WaitOption::WNOHANG) {
@@ -327,7 +331,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                 let mut ready: Option<Result<usize, SystemError>> = None;
                 let wait_res = parent.wait_queue.wait_event_interruptible(
                     || {
-                        if let Some(r) = do_waitpid(child_pcb.clone(), kwo) {
+                        if let Some(r) = check_child(kwo) {
                             ready = Some(r);
                             true
                         } else {

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -13,6 +13,7 @@ use crate::{
 
 use super::{
     abi::WaitOption,
+    dec_visible_thread_count,
     resource::{RUsage, RUsageWho},
     ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState, RawPid,
 };
@@ -1084,6 +1085,9 @@ impl ProcessControlBlock {
         if should_defer_unhash_for_group_exec(self, group_dead) {
             self.flags().insert(ProcessFlags::DEFER_UNHASH);
         } else {
+            if self.raw_pid() > RawPid(0) {
+                dec_visible_thread_count();
+            }
             self.detach_pid(PidType::PID);
             if group_dead {
                 self.detach_pid(PidType::TGID);
@@ -1113,6 +1117,9 @@ impl ProcessControlBlock {
             return;
         }
         self.flags().remove(ProcessFlags::DEFER_UNHASH);
+        if self.raw_pid() > RawPid(0) {
+            dec_visible_thread_count();
+        }
         self.detach_pid(PidType::PID);
         if self.is_thread_group_leader() {
             self.detach_pid(PidType::TGID);

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -1045,6 +1045,12 @@ fn do_waitpid(
 }
 
 impl ProcessControlBlock {
+    fn dec_visible_thread_count_if_accounted(&self) {
+        if self.take_visible_thread_accounted() {
+            dec_visible_thread_count();
+        }
+    }
+
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/exit.c#143
     pub(super) fn __exit_signal(&mut self) {
         let sighand = self.sighand();
@@ -1085,9 +1091,7 @@ impl ProcessControlBlock {
         if should_defer_unhash_for_group_exec(self, group_dead) {
             self.flags().insert(ProcessFlags::DEFER_UNHASH);
         } else {
-            if self.raw_pid() > RawPid(0) {
-                dec_visible_thread_count();
-            }
+            self.dec_visible_thread_count_if_accounted();
             self.detach_pid(PidType::PID);
             if group_dead {
                 self.detach_pid(PidType::TGID);
@@ -1117,9 +1121,7 @@ impl ProcessControlBlock {
             return;
         }
         self.flags().remove(ProcessFlags::DEFER_UNHASH);
-        if self.raw_pid() > RawPid(0) {
-            dec_visible_thread_count();
-        }
+        self.dec_visible_thread_count_if_accounted();
         self.detach_pid(PidType::PID);
         if self.is_thread_group_leader() {
             self.detach_pid(PidType::TGID);

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 use super::{
-    alloc_pid,
+    account_successful_fork, alloc_pid, inc_visible_thread_count,
     kthread::{KernelThreadPcbPrivate, WorkerPrivate},
     pid::{Pid, PidType},
     KernelStack, ProcessControlBlock, ProcessManager, RawPid,
@@ -923,6 +923,8 @@ impl ProcessManager {
             cgroup.charge_pids(1);
             cgroup.add_task(pcb.raw_pid());
             ProcessManager::add_pcb(pcb.clone());
+            inc_visible_thread_count();
+            account_successful_fork();
         }
 
         // 设置child_tid，意味着子线程能够知道自己的id。

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -923,6 +923,7 @@ impl ProcessManager {
             cgroup.charge_pids(1);
             cgroup.add_task(pcb.raw_pid());
             ProcessManager::add_pcb(pcb.clone());
+            pcb.mark_visible_thread_accounted();
             inc_visible_thread_count();
             account_successful_fork();
         }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -5,7 +5,7 @@ use core::{
     intrinsics::unlikely,
     mem::ManuallyDrop,
     str::FromStr,
-    sync::atomic::{compiler_fence, fence, AtomicBool, AtomicU8, AtomicUsize, Ordering},
+    sync::atomic::{compiler_fence, fence, AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
 };
 
 use alloc::{
@@ -108,10 +108,48 @@ pub use cputime::ProcessCpuTime;
 /// 系统中所有进程的pcb
 static ALL_PROCESS: SpinLock<Option<HashMap<RawPid, Arc<ProcessControlBlock>>>> =
     SpinLock::new(None);
+static NR_VISIBLE_THREADS: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_FORKS: AtomicU64 = AtomicU64::new(0);
+static TOTAL_CONTEXT_SWITCHES: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn all_process() -> &'static SpinLock<Option<HashMap<RawPid, Arc<ProcessControlBlock>>>>
 {
     &ALL_PROCESS
+}
+
+#[inline]
+pub(crate) fn inc_visible_thread_count() {
+    NR_VISIBLE_THREADS.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub(crate) fn dec_visible_thread_count() {
+    NR_VISIBLE_THREADS.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub(crate) fn account_successful_fork() {
+    TOTAL_FORKS.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn nr_threads() -> u32 {
+    NR_VISIBLE_THREADS.load(Ordering::Relaxed) as u32
+}
+
+#[inline]
+pub fn total_forks() -> u64 {
+    TOTAL_FORKS.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub(crate) fn account_context_switch() {
+    TOTAL_CONTEXT_SWITCHES.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn nr_context_switches() -> u64 {
+    TOTAL_CONTEXT_SWITCHES.load(Ordering::Relaxed)
 }
 
 fn exchange_raw_pids_locked(

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1324,6 +1324,8 @@ pub struct ProcessControlBlock {
     rcu_read_depth: AtomicUsize,
 
     flags: LockFreeFlags<ProcessFlags>,
+    /// 当前任务是否已经计入全局可见线程数。
+    visible_thread_accounted: AtomicBool,
     /// Serializes task-local pointer publication for RCU-protected metadata
     /// such as `cred`, `nsproxy`, and `sighand`.
     task_lock: SpinLock<()>,
@@ -1517,6 +1519,7 @@ impl ProcessControlBlock {
                 preempt_count,
                 rcu_read_depth,
                 flags,
+                visible_thread_accounted: AtomicBool::new(false),
                 task_lock: SpinLock::new(()),
                 kernel_stack: RwLock::new(kstack),
                 syscall_stack: RwLock::new(KernelStack::new().unwrap()),
@@ -1778,6 +1781,16 @@ impl ProcessControlBlock {
     #[inline(always)]
     pub fn flags(&self) -> &mut ProcessFlags {
         return self.flags.get_mut();
+    }
+
+    #[inline(always)]
+    pub(crate) fn mark_visible_thread_accounted(&self) {
+        self.visible_thread_accounted.store(true, Ordering::Release);
+    }
+
+    #[inline(always)]
+    pub(crate) fn take_visible_thread_accounted(&self) -> bool {
+        self.visible_thread_accounted.swap(false, Ordering::AcqRel)
     }
 
     /// 请注意，这个值能在中断上下文中读取，但不能被中断上下文修改

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -40,8 +40,8 @@ use crate::{
     },
     mm::percpu::{PerCpu, PerCpuVar},
     process::{
-        preempt::PreemptGuard, ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState,
-        SchedInfo,
+        account_context_switch, preempt::PreemptGuard, ProcessControlBlock, ProcessFlags,
+        ProcessManager, ProcessState, SchedInfo,
     },
     sched::idle::IdleScheduler,
     smp::{
@@ -102,6 +102,14 @@ fn rq_is_idle_cpu(rq: &CpuRunQueue) -> bool {
 #[inline]
 pub fn cpu_is_online(cpu: ProcessorId) -> bool {
     smp_cpu_manager().is_online_cpu(cpu)
+}
+
+pub fn nr_iowait() -> u32 {
+    smp_cpu_manager()
+        .present_cpus()
+        .iter_cpu()
+        .map(|cpu| cpu_rq(cpu.data() as usize).nr_iowait() as u32)
+        .sum()
 }
 
 #[inline]
@@ -1204,6 +1212,7 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
 
         rq.set_current(Arc::downgrade(&next));
         compiler_fence(Ordering::SeqCst);
+        account_context_switch();
         if let Some(dest_cpu) = migrate_prev_to {
             unsafe {
                 crate::process::PROCESS_SWITCH_RESULT

--- a/kernel/src/time/timekeeping.rs
+++ b/kernel/src/time/timekeeping.rs
@@ -296,6 +296,19 @@ pub fn timekeeper() -> &'static Timekeeper {
     return r;
 }
 
+pub fn boottime_seconds() -> i64 {
+    let tk = timekeeper().inner.read_irqsave();
+    let nsec_per_sec = NSEC_PER_SEC as i128;
+    let boottime_ns = (tk.xtime.tv_sec as i128) * nsec_per_sec
+        + (tk.xtime.tv_nsec as i128)
+        + (tk.wall_to_monotonic.tv_sec as i128) * nsec_per_sec
+        + (tk.wall_to_monotonic.tv_nsec as i128)
+        + (tk.total_sleep_time.tv_sec as i128) * nsec_per_sec
+        + (tk.total_sleep_time.tv_nsec as i128);
+
+    boottime_ns.div_euclid(nsec_per_sec) as i64
+}
+
 pub fn timekeeping_is_initialized() -> bool {
     unsafe { __TIMEKEEPER.is_some() }
 }

--- a/user/apps/tests/dunitest/suites/normal/proc_pid_mounts_target_view.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_pid_mounts_target_view.cc
@@ -1,0 +1,282 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+
+#ifndef CLONE_NEWNS
+#define CLONE_NEWNS 0x00020000
+#endif
+
+namespace {
+
+struct ChildProcessGuard {
+    pid_t pid = -1;
+    int quit_fd = -1;
+    int detail_fd = -1;
+
+    ~ChildProcessGuard() {
+        if (quit_fd >= 0) {
+            char quit = 'Q';
+            const ssize_t ignored = write(quit_fd, &quit, 1);
+            (void)ignored;
+            close(quit_fd);
+        }
+
+        if (detail_fd >= 0) {
+            close(detail_fd);
+        }
+
+        if (pid > 0) {
+            int status = 0;
+            while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+            }
+        }
+    }
+};
+
+int ensure_dir(const char* path) {
+    struct stat st = {};
+
+    if (stat(path, &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+
+    return mkdir(path, 0755);
+}
+
+void best_effort_rmdir(const char* path) {
+    if (rmdir(path) != 0 && errno != ENOENT && errno != ENOTEMPTY) {
+        ADD_FAILURE() << "rmdir failed for " << path << ": errno=" << errno << " ("
+                      << strerror(errno) << ")";
+    }
+}
+
+std::string read_all_from_fd(int fd) {
+    std::string out;
+    char buf[512];
+    ssize_t n = 0;
+
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out.append(buf, static_cast<size_t>(n));
+    }
+
+    return out;
+}
+
+bool read_text_file(const char* path, std::string* out) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    out->clear();
+    char buf[1024];
+    ssize_t n = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out->append(buf, static_cast<size_t>(n));
+    }
+
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return n >= 0;
+}
+
+void expect_contains(const char* path, const std::string& content, const char* needle) {
+    EXPECT_NE(std::string::npos, content.find(needle)) << path << " missing substring\nneedle="
+                                                       << needle << "\ncontent=" << content;
+}
+
+void expect_not_contains(const char* path, const std::string& content, const char* needle) {
+    EXPECT_EQ(std::string::npos, content.find(needle))
+        << path << " unexpectedly contains substring\nneedle=" << needle << "\ncontent="
+        << content;
+}
+
+[[noreturn]] void child_fail(int detail_fd, const char* step) {
+    dprintf(detail_fd,
+            "%s: errno=%d (%s)",
+            step,
+            errno,
+            errno == 0 ? "no error information" : strerror(errno));
+    _exit(1);
+}
+
+}  // namespace
+
+TEST(ProcPidMounts, UsesTargetTaskRootAndMountNamespace) {
+    char base[256] = {};
+    char rootfs[256] = {};
+    char inside_name[64] = {};
+    char inside[256] = {};
+    char outside[256] = {};
+    char proc_mounts_path[64] = {};
+    char proc_mountinfo_path[64] = {};
+    int ready_pipe[2] = {-1, -1};
+    int quit_pipe[2] = {-1, -1};
+    int detail_pipe[2] = {-1, -1};
+    std::string proc_mounts;
+    std::string proc_mountinfo;
+    std::string self_mounts;
+    std::string self_mountinfo;
+    char inside_mounts_needle[96] = {};
+    char inside_mountinfo_needle[96] = {};
+
+    ASSERT_EQ(0, ensure_dir("/tmp")) << "mkdir /tmp failed: errno=" << errno << " ("
+                                      << strerror(errno) << ")";
+
+    snprintf(base, sizeof(base), "/tmp/proc_pid_mounts_target_view_%d", getpid());
+    snprintf(rootfs, sizeof(rootfs), "%s/rootfs", base);
+    snprintf(inside_name, sizeof(inside_name), "inside_%d", getpid());
+    snprintf(inside, sizeof(inside), "%s/%s", rootfs, inside_name);
+    snprintf(outside, sizeof(outside), "%s/outside", base);
+    snprintf(inside_mounts_needle, sizeof(inside_mounts_needle), " /%s ramfs ", inside_name);
+    snprintf(inside_mountinfo_needle, sizeof(inside_mountinfo_needle), " /%s ", inside_name);
+
+    ASSERT_EQ(0, ensure_dir(base)) << "mkdir base failed: errno=" << errno << " ("
+                                   << strerror(errno) << ")";
+    ASSERT_EQ(0, ensure_dir(rootfs)) << "mkdir rootfs failed: errno=" << errno << " ("
+                                     << strerror(errno) << ")";
+    ASSERT_EQ(0, ensure_dir(outside)) << "mkdir outside failed: errno=" << errno << " ("
+                                      << strerror(errno) << ")";
+
+    ASSERT_EQ(0, pipe(ready_pipe)) << "pipe ready failed: errno=" << errno << " ("
+                                   << strerror(errno) << ")";
+    ASSERT_EQ(0, pipe(quit_pipe)) << "pipe quit failed: errno=" << errno << " ("
+                                  << strerror(errno) << ")";
+    ASSERT_EQ(0, pipe(detail_pipe)) << "pipe detail failed: errno=" << errno << " ("
+                                    << strerror(errno) << ")";
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (child == 0) {
+        close(ready_pipe[0]);
+        close(quit_pipe[1]);
+        close(detail_pipe[0]);
+
+        if (unshare(CLONE_NEWNS) != 0) {
+            child_fail(detail_pipe[1], "unshare(CLONE_NEWNS)");
+        }
+        if (mount("", "/", nullptr, MS_REC | MS_PRIVATE, nullptr) != 0) {
+            child_fail(detail_pipe[1], "mount(/, MS_PRIVATE)");
+        }
+        if (mount("", rootfs, "ramfs", 0, nullptr) != 0) {
+            child_fail(detail_pipe[1], "mount(rootfs, ramfs)");
+        }
+        if (ensure_dir(inside) != 0) {
+            child_fail(detail_pipe[1], "mkdir(inside)");
+        }
+        if (mount("", inside, "ramfs", 0, nullptr) != 0) {
+            child_fail(detail_pipe[1], "mount(inside, ramfs)");
+        }
+        if (mount("", outside, "ramfs", 0, nullptr) != 0) {
+            child_fail(detail_pipe[1], "mount(outside, ramfs)");
+        }
+        if (chdir(rootfs) != 0) {
+            child_fail(detail_pipe[1], "chdir(rootfs)");
+        }
+        if (chroot(rootfs) != 0) {
+            child_fail(detail_pipe[1], "chroot(rootfs)");
+        }
+        if (chdir("/") != 0) {
+            child_fail(detail_pipe[1], "chdir(/)");
+        }
+
+        const char ready = 'R';
+        if (write(ready_pipe[1], &ready, 1) != 1) {
+            child_fail(detail_pipe[1], "notify parent ready");
+        }
+
+        char quit = 0;
+        if (read(quit_pipe[0], &quit, 1) != 1) {
+            child_fail(detail_pipe[1], "wait parent quit");
+        }
+
+        close(ready_pipe[1]);
+        close(quit_pipe[0]);
+        close(detail_pipe[1]);
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+    close(quit_pipe[0]);
+    close(detail_pipe[1]);
+
+    ChildProcessGuard guard;
+    guard.pid = child;
+    guard.quit_fd = quit_pipe[1];
+    guard.detail_fd = detail_pipe[0];
+
+    char ready = 0;
+    ASSERT_EQ(1, read(ready_pipe[0], &ready, 1)) << "read child ready failed: errno=" << errno
+                                                 << " (" << strerror(errno) << ")";
+    EXPECT_EQ('R', ready);
+    close(ready_pipe[0]);
+
+    snprintf(proc_mounts_path, sizeof(proc_mounts_path), "/proc/%d/mounts", child);
+    ASSERT_TRUE(read_text_file(proc_mounts_path, &proc_mounts))
+        << "read " << proc_mounts_path << " failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+    expect_contains(proc_mounts_path, proc_mounts, " / ramfs ");
+    expect_contains(proc_mounts_path, proc_mounts, inside_mounts_needle);
+    expect_not_contains(proc_mounts_path, proc_mounts, "/outside");
+
+    snprintf(proc_mountinfo_path, sizeof(proc_mountinfo_path), "/proc/%d/mountinfo", child);
+    ASSERT_TRUE(read_text_file(proc_mountinfo_path, &proc_mountinfo))
+        << "read " << proc_mountinfo_path << " failed: errno=" << errno << " ("
+        << strerror(errno) << ")";
+    expect_contains(proc_mountinfo_path, proc_mountinfo, inside_mountinfo_needle);
+    expect_not_contains(proc_mountinfo_path, proc_mountinfo, outside);
+
+    ASSERT_TRUE(read_text_file("/proc/self/mounts", &self_mounts))
+        << "read /proc/self/mounts failed: errno=" << errno << " (" << strerror(errno) << ")";
+    expect_not_contains("/proc/self/mounts", self_mounts, inside_mountinfo_needle);
+    expect_not_contains("/proc/self/mounts", self_mounts, outside);
+
+    ASSERT_TRUE(read_text_file("/proc/self/mountinfo", &self_mountinfo))
+        << "read /proc/self/mountinfo failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+    expect_not_contains("/proc/self/mountinfo", self_mountinfo, inside_mountinfo_needle);
+    expect_not_contains("/proc/self/mountinfo", self_mountinfo, outside);
+
+    char quit = 'Q';
+    ASSERT_EQ(1, write(guard.quit_fd, &quit, 1)) << "write child quit failed: errno=" << errno
+                                                 << " (" << strerror(errno) << ")";
+    close(guard.quit_fd);
+    guard.quit_fd = -1;
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: errno=" << errno << " ("
+                                                 << strerror(errno) << ")";
+
+    const std::string detail = read_all_from_fd(guard.detail_fd);
+    close(guard.detail_fd);
+    guard.detail_fd = -1;
+
+    ASSERT_TRUE(WIFEXITED(status)) << "child terminated abnormally, status=0x" << std::hex
+                                   << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << detail;
+
+    guard.pid = -1;
+
+    best_effort_rmdir(inside);
+    best_effort_rmdir(rootfs);
+    best_effort_rmdir(outside);
+    best_effort_rmdir(base);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+bool read_text_file(const char* path, std::string* out) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    out->clear();
+    char buf[512];
+    ssize_t n = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out->append(buf, static_cast<size_t>(n));
+    }
+
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return n >= 0;
+}
+
+pid_t fork_waiting_child(int* release_fd) {
+    int pipefd[2] = {-1, -1};
+    if (pipe(pipefd) != 0) {
+        return -1;
+    }
+
+    pid_t child = fork();
+    if (child == 0) {
+        close(pipefd[1]);
+        char byte = 0;
+        while (read(pipefd[0], &byte, 1) > 0) {
+        }
+        close(pipefd[0]);
+        _exit(0);
+    }
+
+    close(pipefd[0]);
+    if (child < 0) {
+        close(pipefd[1]);
+        return -1;
+    }
+
+    *release_fd = pipefd[1];
+    return child;
+}
+
+void release_child(pid_t child, int release_fd) {
+    if (release_fd >= 0) {
+        close(release_fd);
+    }
+
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+    }
+}
+
+}  // namespace
+
+TEST(ProcPidReuseCache, NumericProcDirRefreshesAfterPidReuse) {
+    int first_release = -1;
+    const pid_t first = fork_waiting_child(&first_release);
+    ASSERT_GT(first, 0) << "fork first child failed: errno=" << errno << " (" << strerror(errno)
+                        << ")";
+
+    char status_path[64] = {};
+    snprintf(status_path, sizeof(status_path), "/proc/%d/status", first);
+
+    std::string status;
+    ASSERT_TRUE(read_text_file(status_path, &status))
+        << "initial read of " << status_path << " failed: errno=" << errno << " ("
+        << strerror(errno) << ")";
+
+    release_child(first, first_release);
+
+    pid_t reused = -1;
+    int reused_release = -1;
+    for (int i = 0; i < 128; ++i) {
+        int release_fd = -1;
+        pid_t child = fork_waiting_child(&release_fd);
+        ASSERT_GT(child, 0) << "fork replacement child failed: errno=" << errno << " ("
+                            << strerror(errno) << ")";
+
+        if (child == first) {
+            reused = child;
+            reused_release = release_fd;
+            break;
+        }
+
+        release_child(child, release_fd);
+    }
+
+    ASSERT_EQ(first, reused) << "test requires PID reuse to exercise cached /proc/<pid> inode";
+
+    status.clear();
+    ASSERT_TRUE(read_text_file(status_path, &status))
+        << "read after PID reuse should refresh stale /proc/<pid> cache: errno=" << errno << " ("
+        << strerror(errno) << ")";
+
+    char pid_line[32] = {};
+    snprintf(pid_line, sizeof(pid_line), "Pid:\t%d", reused);
+    EXPECT_NE(std::string::npos, status.find(pid_line)) << status_path << " content:\n" << status;
+
+    release_child(reused, reused_release);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/proc_self_exec_cmdline.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_self_exec_cmdline.cc
@@ -1,0 +1,160 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr char kExecExit42[] = "--proc-self-exec-cmdline-exit42";
+constexpr char kLeaderExec[] = "--proc-self-exec-cmdline-leader";
+constexpr char kSiblingExec[] = "--proc-self-exec-cmdline-sibling";
+
+bool read_all(int fd, std::string* out) {
+    out->clear();
+    char buf[256];
+    ssize_t n = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out->append(buf, static_cast<size_t>(n));
+    }
+    return n == 0;
+}
+
+std::string expected_cmdline(int argc, char** argv) {
+    std::string expected;
+    for (int i = 0; i < argc; ++i) {
+        expected.append(argv[i]);
+        expected.push_back('\0');
+    }
+    return expected;
+}
+
+int validate_cmdline_and_exit42(int argc, char** argv) {
+    int fd = open("/proc/self/cmdline", O_RDONLY);
+    if (fd < 0) {
+        dprintf(STDERR_FILENO,
+                "open /proc/self/cmdline failed: errno=%d (%s)\n",
+                errno,
+                strerror(errno));
+        return 1;
+    }
+
+    std::string actual;
+    const bool ok = read_all(fd, &actual);
+    const int saved_errno = errno;
+    close(fd);
+    if (!ok) {
+        dprintf(STDERR_FILENO,
+                "read /proc/self/cmdline failed: errno=%d (%s)\n",
+                saved_errno,
+                strerror(saved_errno));
+        return 1;
+    }
+
+    const std::string expected = expected_cmdline(argc, argv);
+    if (actual != expected) {
+        dprintf(STDERR_FILENO,
+                "/proc/self/cmdline mismatch: actual_size=%zu expected_size=%zu\n",
+                actual.size(),
+                expected.size());
+        return 1;
+    }
+
+    return 42;
+}
+
+void exec_exit42() {
+    char arg0[] = "/proc/self/exe";
+    char arg1[] = "--proc-self-exec-cmdline-exit42";
+    char* const argv[] = {arg0, arg1, nullptr};
+    char* const envp[] = {nullptr};
+    execve("/proc/self/exe", argv, envp);
+    _exit(errno);
+}
+
+void* pause_thread(void*) {
+    for (;;) {
+        pause();
+    }
+    return nullptr;
+}
+
+void run_leader_exec_helper() {
+    pthread_t thread;
+    if (pthread_create(&thread, nullptr, pause_thread, nullptr) != 0) {
+        _exit(1);
+    }
+
+    exec_exit42();
+}
+
+void* sibling_exec_thread(void*) {
+    exec_exit42();
+    return nullptr;
+}
+
+void run_sibling_exec_helper() {
+    pthread_t thread;
+    if (pthread_create(&thread, nullptr, sibling_exec_thread, nullptr) != 0) {
+        _exit(1);
+    }
+
+    for (;;) {
+        pause();
+    }
+}
+
+void expect_helper_exits_42(const char* mode) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (child == 0) {
+        char arg0[] = "/proc/self/exe";
+        char* const argv[] = {arg0, const_cast<char*>(mode), nullptr};
+        char* const envp[] = {nullptr};
+        execve("/proc/self/exe", argv, envp);
+        _exit(errno);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0))
+        << "waitpid failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    EXPECT_EQ(42, WEXITSTATUS(status));
+}
+
+}  // namespace
+
+TEST(ProcSelfExecCmdline, LeaderThreadExecKeepsProcSelfCmdlineCurrent) {
+    expect_helper_exits_42(kLeaderExec);
+}
+
+TEST(ProcSelfExecCmdline, SiblingThreadExecKeepsProcSelfCmdlineCurrent) {
+    expect_helper_exits_42(kSiblingExec);
+}
+
+int main(int argc, char** argv) {
+    if (argc >= 2 && strcmp(argv[1], kExecExit42) == 0) {
+        return validate_cmdline_and_exit42(argc, argv);
+    }
+    if (argc >= 2 && strcmp(argv[1], kLeaderExec) == 0) {
+        run_leader_exec_helper();
+        return 1;
+    }
+    if (argc >= 2 && strcmp(argv[1], kSiblingExec) == 0) {
+        run_sibling_exec_helper();
+        return 1;
+    }
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/proc_thread_accounting.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_thread_accounting.cc
@@ -1,0 +1,149 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+bool read_text_file(const char* path, std::string* out) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    out->clear();
+    char buf[256];
+    ssize_t n = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out->append(buf, static_cast<size_t>(n));
+    }
+
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return n >= 0;
+}
+
+void write_text_or_die(const char* path, const char* text) {
+    const int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        dprintf(STDERR_FILENO,
+                "open(%s) failed: errno=%d (%s)\n",
+                path,
+                errno,
+                strerror(errno));
+        _exit(1);
+    }
+
+    const size_t len = strlen(text);
+    const ssize_t n = write(fd, text, len);
+    const int saved_errno = errno;
+    close(fd);
+    if (n != static_cast<ssize_t>(len)) {
+        dprintf(STDERR_FILENO,
+                "write(%s) failed: n=%zd errno=%d (%s)\n",
+                path,
+                n,
+                saved_errno,
+                strerror(saved_errno));
+        _exit(1);
+    }
+}
+
+unsigned long read_loadavg_thread_total() {
+    std::string loadavg;
+    if (!read_text_file("/proc/loadavg", &loadavg)) {
+        ADD_FAILURE() << "read /proc/loadavg failed: errno=" << errno << " (" << strerror(errno)
+                      << ")";
+        return 0;
+    }
+
+    unsigned long running = 0;
+    unsigned long total = 0;
+    if (sscanf(loadavg.c_str(), "%*s %*s %*s %lu/%lu", &running, &total) != 2) {
+        ADD_FAILURE() << "failed to parse /proc/loadavg: " << loadavg;
+        return 0;
+    }
+
+    return total;
+}
+
+}  // namespace
+
+TEST(ProcThreadAccounting, RejectedForkDoesNotDecrementVisibleThreads) {
+    const unsigned long before_total = read_loadavg_thread_total();
+    ASSERT_GT(before_total, 0UL);
+
+    char cgroup_dir[128] = {};
+    char cgroup_procs[160] = {};
+    char pids_max[160] = {};
+    snprintf(cgroup_dir, sizeof(cgroup_dir), "/sys/fs/cgroup/proc_thread_accounting_%d", getpid());
+    snprintf(cgroup_procs, sizeof(cgroup_procs), "%s/cgroup.procs", cgroup_dir);
+    snprintf(pids_max, sizeof(pids_max), "%s/pids.max", cgroup_dir);
+
+    ASSERT_EQ(0, mkdir(cgroup_dir, 0755)) << "mkdir cgroup failed: errno=" << errno << " ("
+                                          << strerror(errno) << ")";
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork child failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (child == 0) {
+        write_text_or_die(cgroup_procs, "0\n");
+        write_text_or_die(pids_max, "1\n");
+
+        for (int i = 0; i < 64; ++i) {
+            errno = 0;
+            const pid_t failed = fork();
+            if (failed == 0) {
+                _exit(2);
+            }
+            if (failed > 0) {
+                int status = 0;
+                waitpid(failed, &status, 0);
+                dprintf(STDERR_FILENO, "fork unexpectedly succeeded under pids.max=1\n");
+                _exit(1);
+            }
+            if (errno != EAGAIN) {
+                dprintf(STDERR_FILENO,
+                        "fork failed with unexpected errno=%d (%s)\n",
+                        errno,
+                        strerror(errno));
+                _exit(1);
+            }
+        }
+
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: errno=" << errno << " ("
+                                                << strerror(errno) << ")";
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    const unsigned long after_total = read_loadavg_thread_total();
+    EXPECT_LT(after_total, 100000UL)
+        << "rejected fork polluted visible thread accounting: before=" << before_total
+        << " after=" << after_total;
+    EXPECT_LE(after_total, before_total + 16)
+        << "rejected fork should not inflate visible thread total: before=" << before_total
+        << " after=" << after_total;
+
+    if (rmdir(cgroup_dir) != 0 && errno != ENOENT) {
+        ADD_FAILURE() << "rmdir cgroup failed: errno=" << errno << " (" << strerror(errno) << ")";
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <netinet/in.h>
 #include <pthread.h>
+#include <poll.h>
 #include <signal.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -12,6 +13,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 #include <string>
 
 namespace {
@@ -168,6 +170,68 @@ void* WriterThread(void* arg) {
     return nullptr;
 }
 
+void* ResetDuringCloseWorker(void*) {
+    TcpPair pair;
+    if (!InitTcpPair(&pair)) {
+        return reinterpret_cast<void*>(1);
+    }
+
+    struct PollCloseArgs {
+        int fd = -1;
+        int result = 0;
+    } poll_args {
+        .fd = pair.client_fd.Get(),
+        .result = 0,
+    };
+
+    auto poll_and_close = [](void* arg) -> void* {
+        auto* args = reinterpret_cast<PollCloseArgs*>(arg);
+        pollfd pfd {
+            .fd = args->fd,
+            .events = POLLIN | POLLHUP,
+            .revents = 0,
+        };
+        const int poll_ret = poll(&pfd, 1, 5000);
+        if (poll_ret != 1) {
+            args->result = 1;
+            return nullptr;
+        }
+        if (close(args->fd) != 0) {
+            args->result = 2;
+            return nullptr;
+        }
+        args->fd = -1;
+        return nullptr;
+    };
+
+    pthread_t closer {};
+    if (pthread_create(&closer, nullptr, poll_and_close, &poll_args) != 0) {
+        return reinterpret_cast<void*>(2);
+    }
+
+    constexpr char kData[] = "abc";
+    if (write(pair.server_fd.Get(), kData, 3) != 3) {
+        pthread_join(closer, nullptr);
+        return reinterpret_cast<void*>(3);
+    }
+
+    usleep(10000);
+
+    if (close(pair.server_fd.Release()) != 0) {
+        pthread_join(closer, nullptr);
+        return reinterpret_cast<void*>(4);
+    }
+
+    if (pthread_join(closer, nullptr) != 0) {
+        return reinterpret_cast<void*>(5);
+    }
+    if (poll_args.result != 0) {
+        return reinterpret_cast<void*>(6 + poll_args.result);
+    }
+    pair.client_fd.Release();
+    return nullptr;
+}
+
 TEST(TcpCloseSemantics, BlockPartialWriteClosedReturnsReset) {
     signal(SIGPIPE, SIG_IGN);
     TcpPair pair;
@@ -297,6 +361,25 @@ TEST(TcpCloseSemantics, ShutdownWrThenUnreadDataCloseAborts) {
     EXPECT_EQ(-1, second_send) << "peer close with unread data should abort";
     EXPECT_TRUE(saved_errno == EPIPE || saved_errno == ECONNRESET)
         << "expected EPIPE/ECONNRESET, got " << ErrnoString(saved_errno);
+}
+
+TEST(TcpCloseSemantics, ConcurrentResetDuringCloseDoesNotStall) {
+    signal(SIGPIPE, SIG_IGN);
+
+    constexpr int kThreadCount = 100;
+    std::vector<pthread_t> threads(kThreadCount);
+
+    for (int i = 0; i < kThreadCount; ++i) {
+        ASSERT_EQ(0, pthread_create(&threads[i], nullptr, ResetDuringCloseWorker, nullptr))
+            << "pthread_create failed: " << ErrnoString(errno);
+    }
+
+    for (int i = 0; i < kThreadCount; ++i) {
+        void* result = nullptr;
+        ASSERT_EQ(0, pthread_join(threads[i], &result))
+            << "pthread_join failed: " << ErrnoString(errno);
+        EXPECT_EQ(nullptr, result) << "worker " << i << " failed";
+    }
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -27,6 +27,7 @@ fuse/fuse_extended
 normal/test_procfs_link
 normal/proc_pid_mounts_target_view
 normal/proc_pid_reuse_cache
+normal/proc_self_exec_cmdline
 normal/proc_thread_accounting
 normal/user_namespace_id_map
 normal/tty_tcflush

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -26,6 +26,7 @@ fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
 normal/proc_pid_mounts_target_view
+normal/proc_thread_accounting
 normal/user_namespace_id_map
 normal/tty_tcflush
 normal/signal_fpstate_sigreturn

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -26,6 +26,7 @@ fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
 normal/proc_pid_mounts_target_view
+normal/proc_pid_reuse_cache
 normal/proc_thread_accounting
 normal/user_namespace_id_map
 normal/tty_tcflush

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -25,6 +25,7 @@ normal/udp_ipv6_send_semantics
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
+normal/proc_pid_mounts_target_view
 normal/user_namespace_id_map
 normal/tty_tcflush
 normal/signal_fpstate_sigreturn


### PR DESCRIPTION
## Summary

This PR reworks procfs so pid-scoped entries are resolved in the pid namespace
bound to each procfs mount and are rendered from the target task's state rather
than from the reader's current context.

The main user-visible fixes are:
- `/proc/self` and `/proc/thread-self` now resolve using the procfs mount's pid namespace.
- `/proc/<pid>` and `/proc/<pid>/task/<tid>` now use namespace-visible IDs consistently.
- `/proc/<pid>/ns/*` now exposes namespace links and `setns()` targets for the actual target task.
- `/proc/<pid>/mounts` and `/proc/<pid>/mountinfo` now use the target task's mount namespace and fs root, including chroot-relative mountpoint rewriting.
- `/proc/stat` and `/proc/loadavg` now use tracked counters for thread count, forks, context switches, iowait, and boot time.

## Motivation

The previous procfs implementation mixed three different views:
- the pid namespace attached to the procfs mount,
- the current reader task,
- and the target task referenced by `/proc/<pid>`.

That led to incorrect behavior in several places, especially for procfs mounts
observed from different pid namespaces and for `/proc/<pid>/mounts` style files,
which should reflect the target task's `mnt_ns` and `fs_struct.root()` instead of
the reader's view.

This change fixes the model at the procfs architecture level instead of adding
per-file workarounds.

## What Changed

### 1. Procfs mount context is now explicit
- Added mount-specific procfs data so each procfs instance carries the pid namespace bound at mount time.
- Reworked procfs root construction to avoid depending on `current_pcb()` before process management is fully initialized.

### 2. PID-scoped procfs lookup now uses a stable target abstraction
- Introduced `ProcPidTarget` to store both the procfs view pid namespace and the referenced pid object.
- Updated `/proc/<pid>` lookup and child inode creation to use `ProcPidTarget` instead of resolving by raw vpid on demand.
- Extended `/proc/<pid>/task/<tid>` to enumerate real thread-group members in the correct pid namespace.

### 3. Per-task procfs files and symlinks now use the correct target task
- Updated `cmdline`, `exe`, `fd`, `fdinfo`, `id_map`, `limits`, `maps`, `stat`, `statm`, `status`, `cgroup`, and namespace entries to resolve against the target task consistently.
- Fixed `/proc/self` and `/proc/thread-self` to generate mount-relative pid/tid links instead of using the caller's raw global IDs.

### 4. Mount reporting now follows Linux-style target-task semantics
- Reworked mount rendering helpers so mount lists are generated from an explicit `(mnt_ns, fs root)` view.
- `/proc/<pid>/mounts` and `/proc/<pid>/mountinfo` now use the target task's mount namespace and root directory.
- Mountpoints are rewritten relative to the target task's root, so chrooted tasks do not leak paths outside their view.
- Procfs file content for mount listings is cached at open time so repeated reads observe a stable snapshot.

### 5. `/proc/stat` and `/proc/loadavg` reporting was tightened up
- Added global accounting for visible threads, successful forks, and context switches.
- Exported iowait and boot-time helpers and used them to populate `/proc/stat` and `/proc/loadavg` with more Linux-compatible values.

### 6. Added regression coverage
- Added a dunitest that validates `/proc/<pid>/mounts` and `/proc/<pid>/mountinfo` are rendered from the target task's namespace/root view rather than the reader's own view.
- Whitelisted the new test in dunitest.

## Why This Approach

This design keeps the procfs view model explicit and consistent:
- procfs mount binds the pid namespace,
- pid-scoped entries carry that view together with the referenced task,
- and content generators read the target task's own namespace/root state.

That matches Linux 6.6 semantics much more closely and avoids fragile special
cases across individual procfs files.
