### PR TITLE
fix(sched): align EEVDF yield picking

### DIFF
--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -4,11 +4,11 @@ use core::mem::swap;
 use core::sync::atomic::fence;
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use crate::libs::rbtree::RBTree;
 use crate::libs::spinlock::SpinLock;
 use crate::process::ProcessControlBlock;
 use crate::process::ProcessFlags;
 use crate::sched::clock::ClockUpdataFlag;
+use crate::sched::fair_tree::FairTimeline;
 use crate::sched::{SchedFeature, SCHED_FEATURES};
 use crate::time::jiffies::TICK_NESC;
 use crate::time::timer::clock;
@@ -317,8 +317,8 @@ pub struct CfsRunQueue {
     /// remain runtime
     runtime_remaining: u64,
 
-    /// 存放调度实体的红黑树
-    pub(super) entities: RBTree<u64, Arc<FairSchedEntity>>,
+    /// 按 vruntime 排序并维护子树最小 deadline 的 EEVDF timeline。
+    pub(super) entities: FairTimeline,
 
     /// IDLE
     idle: usize,
@@ -377,7 +377,7 @@ impl CfsRunQueue {
             h_nr_running: 0,
             exec_clock: 0,
             min_vruntime: 1 << 20,
-            entities: RBTree::new(),
+            entities: FairTimeline::default(),
             idle: 0,
             idle_nr_running: 0,
             idle_h_nr_running: 0,
@@ -651,10 +651,7 @@ impl CfsRunQueue {
         }
 
         // 找到最小虚拟运行时间的调度实体
-        let leftmost = self.entities.get_first();
-        if let Some(leftmost) = leftmost {
-            let se = leftmost.1;
-
+        if let Some(se) = self.entities.leftmost() {
             if curr.is_none() {
                 vruntime = se.vruntime;
             } else {
@@ -1133,8 +1130,7 @@ impl CfsRunQueue {
 
     pub fn inner_enqueue_entity(&mut self, se: &Arc<FairSchedEntity>) {
         self.avg_vruntime_add(se);
-        se.force_mut().min_deadline = se.deadline;
-        self.entities.insert(se.vruntime, se.clone());
+        self.entities.insert(se.clone());
         // warn!(
         //     "enqueue pcb {:?} cfsrq {:?}",
         //     se.pcb().pid(),
@@ -1178,16 +1174,7 @@ impl CfsRunQueue {
         //     .as_bytes(),
         // );
 
-        let mut i = 1;
-        while let Some(rm) = self.entities.remove(&se.vruntime) {
-            if Arc::ptr_eq(&rm, se) {
-                break;
-            }
-            rm.force_mut().vruntime += i;
-            self.entities.insert(rm.vruntime, rm);
-
-            i += 1;
-        }
+        self.entities.remove(se);
         // send_to_default_serial8250_port(
         //     format!(
         //         "after dequeue pcb {:?}(real: {:?}) cfsrq {:?}\n",
@@ -1341,15 +1328,27 @@ impl CfsRunQueue {
             .max((self.avg.load_avg * PELT_MIN_DIVIDER) as u64);
     }
 
+    fn pick_eevdf_entity(
+        &self,
+        curr: Option<&Arc<FairSchedEntity>>,
+    ) -> Option<Arc<FairSchedEntity>> {
+        self.entities
+            .pick_eevdf(curr.filter(|se| se.on_rq()), |se| self.entity_eligible(se))
+    }
+
     /// pick下一个运行的task
     pub fn pick_next_entity(&self) -> Option<Arc<FairSchedEntity>> {
-        if SCHED_FEATURES.contains(SchedFeature::NEXT_BUDDY)
-            && self.next().is_some()
-            && self.entity_eligible(&self.next().unwrap())
-        {
-            return self.next();
+        if SCHED_FEATURES.contains(SchedFeature::NEXT_BUDDY) {
+            if let Some(next) = self.next() {
+                if self.entity_eligible(&next) {
+                    return Some(next);
+                }
+            }
         }
-        self.entities.get_first().map(|val| val.1.clone())
+
+        let curr = self.current();
+        self.pick_eevdf_entity(curr.as_ref())
+            .or_else(|| self.entities.leftmost())
     }
 
     pub fn entity_eligible(&self, se: &Arc<FairSchedEntity>) -> bool {
@@ -1638,10 +1637,11 @@ impl Scheduler for CompletelyFairScheduler {
         }
 
         let cfs_rq = se.cfs_rq();
-        cfs_rq.force_mut().update_current();
+        let cfs_rq = cfs_rq.force_mut();
+        cfs_rq.update_current();
 
-        if let Some((_, pick_se)) = cfs_rq.entities.get_first() {
-            if Arc::ptr_eq(pick_se, &pse) {
+        if let Some(pick_se) = cfs_rq.pick_eevdf_entity(Some(&se)) {
+            if Arc::ptr_eq(&pick_se, &pse) {
                 rq.resched_current();
                 return;
             }
@@ -1716,51 +1716,16 @@ impl Scheduler for CompletelyFairScheduler {
 
     fn pick_next_task(
         rq: &mut CpuRunQueue,
-        prev: Option<Arc<ProcessControlBlock>>,
+        _prev: Option<Arc<ProcessControlBlock>>,
     ) -> Option<Arc<ProcessControlBlock>> {
         let mut cfs_rq = rq.cfs_rq();
         if rq.nr_running == 0 {
             return None;
         }
 
-        let prev_cfs_valid = if let Some(p) = &prev {
-            if p.sched_info().policy() == SchedPolicy::CFS {
-                // Check if prev is still running (not blocked)
-                let state = p.sched_info().inner_lock_read_irqsave().state();
-                state.is_runnable()
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-
         loop {
             let curr = cfs_rq.current();
-            let next = cfs_rq.pick_next_entity();
-
-            // Determine winner between curr (if valid) and next (from tree)
-            let winner = if let Some(c) = curr.clone() {
-                // If curr is valid (prev is running CFS), we compare.
-                // Note: c is an ancestor of prev.
-                if prev_cfs_valid {
-                    if let Some(n) = &next {
-                        // Simple vruntime comparison
-                        if n.vruntime < c.vruntime {
-                            n.clone()
-                        } else {
-                            c
-                        }
-                    } else {
-                        c
-                    }
-                } else {
-                    // curr is invalid (blocked or not CFS), must pick next
-                    next?
-                }
-            } else {
-                next?
-            };
+            let winner = cfs_rq.pick_next_entity()?;
 
             // If winner is curr, descend into curr's group
             if let Some(c) = curr {

--- a/kernel/src/sched/fair_tree.rs
+++ b/kernel/src/sched/fair_tree.rs
@@ -1,0 +1,327 @@
+use alloc::{boxed::Box, sync::Arc};
+use core::cmp::{max, Ordering};
+
+use crate::sched::fair::FairSchedEntity;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct EntityKey {
+    vruntime: u64,
+    id: usize,
+}
+
+impl EntityKey {
+    fn new(entity: &Arc<FairSchedEntity>) -> Self {
+        Self {
+            vruntime: entity.vruntime,
+            id: Arc::as_ptr(entity) as usize,
+        }
+    }
+
+    #[inline]
+    fn vruntime_before(left: u64, right: u64) -> bool {
+        (left.wrapping_sub(right) as i64) < 0
+    }
+}
+
+impl Ord for EntityKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.vruntime == other.vruntime {
+            self.id.cmp(&other.id)
+        } else if Self::vruntime_before(self.vruntime, other.vruntime) {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        }
+    }
+}
+
+impl PartialOrd for EntityKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug)]
+struct FairTreeNode {
+    key: EntityKey,
+    entity: Arc<FairSchedEntity>,
+    left: Option<Box<FairTreeNode>>,
+    right: Option<Box<FairTreeNode>>,
+    height: i32,
+    min_deadline: u64,
+}
+
+impl FairTreeNode {
+    fn new(entity: Arc<FairSchedEntity>) -> Box<Self> {
+        let key = EntityKey::new(&entity);
+        let min_deadline = entity.deadline;
+        entity.force_mut().min_deadline = min_deadline;
+
+        Box::new(Self {
+            key,
+            entity,
+            left: None,
+            right: None,
+            height: 1,
+            min_deadline,
+        })
+    }
+
+    #[inline]
+    fn height(node: &Option<Box<Self>>) -> i32 {
+        node.as_ref().map_or(0, |node| node.height)
+    }
+
+    #[inline]
+    fn deadline_gt(left: u64, right: u64) -> bool {
+        (left.wrapping_sub(right) as i64) > 0
+    }
+
+    fn refresh(&mut self) {
+        self.height = 1 + max(Self::height(&self.left), Self::height(&self.right));
+
+        let mut min_deadline = self.entity.deadline;
+        if let Some(left) = self.left.as_ref() {
+            if Self::deadline_gt(min_deadline, left.min_deadline) {
+                min_deadline = left.min_deadline;
+            }
+        }
+        if let Some(right) = self.right.as_ref() {
+            if Self::deadline_gt(min_deadline, right.min_deadline) {
+                min_deadline = right.min_deadline;
+            }
+        }
+
+        self.min_deadline = min_deadline;
+        self.entity.force_mut().min_deadline = min_deadline;
+    }
+
+    fn balance_factor(&self) -> i32 {
+        Self::height(&self.left) - Self::height(&self.right)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FairTimeline {
+    root: Option<Box<FairTreeNode>>,
+    len: usize,
+}
+
+impl FairTimeline {
+    pub fn insert(&mut self, entity: Arc<FairSchedEntity>) {
+        let key = EntityKey::new(&entity);
+        self.root = Some(Self::insert_node(self.root.take(), key, entity));
+        self.len += 1;
+    }
+
+    pub fn remove(&mut self, entity: &Arc<FairSchedEntity>) -> Option<Arc<FairSchedEntity>> {
+        let key = EntityKey::new(entity);
+        let (root, removed) = Self::remove_node(self.root.take(), key);
+        self.root = root;
+        if removed.is_some() {
+            self.len -= 1;
+        }
+        removed
+    }
+
+    pub fn leftmost(&self) -> Option<Arc<FairSchedEntity>> {
+        let mut node = self.root.as_ref()?;
+        while let Some(left) = node.left.as_ref() {
+            node = left;
+        }
+        Some(node.entity.clone())
+    }
+
+    pub fn pick_eevdf(
+        &self,
+        curr: Option<&Arc<FairSchedEntity>>,
+        mut eligible: impl FnMut(&Arc<FairSchedEntity>) -> bool,
+    ) -> Option<Arc<FairSchedEntity>> {
+        let mut best = curr.filter(|entity| eligible(entity)).cloned();
+        let mut best_left: Option<&FairTreeNode> = None;
+        let mut node = self.root.as_deref();
+
+        while let Some(se_node) = node {
+            if !eligible(&se_node.entity) {
+                node = se_node.left.as_deref();
+                continue;
+            }
+
+            if best
+                .as_ref()
+                .is_none_or(|best| Self::deadline_gt(best.deadline, se_node.entity.deadline))
+            {
+                best = Some(se_node.entity.clone());
+            }
+
+            if let Some(left) = se_node.left.as_deref() {
+                if best_left.is_none_or(|best_left| {
+                    Self::deadline_gt(best_left.min_deadline, left.min_deadline)
+                }) {
+                    best_left = Some(left);
+                }
+
+                if left.min_deadline == se_node.min_deadline {
+                    break;
+                }
+            }
+
+            if se_node.entity.deadline == se_node.min_deadline {
+                break;
+            }
+
+            node = se_node.right.as_deref();
+        }
+
+        match (best, best_left) {
+            (Some(best), Some(left)) if Self::deadline_gt(best.deadline, left.min_deadline) => {
+                Self::pick_min_deadline(left)
+            }
+            (None, Some(left)) => Self::pick_min_deadline(left),
+            (best, _) => best,
+        }
+    }
+
+    #[inline]
+    fn deadline_gt(left: u64, right: u64) -> bool {
+        FairTreeNode::deadline_gt(left, right)
+    }
+
+    fn pick_min_deadline(node: &FairTreeNode) -> Option<Arc<FairSchedEntity>> {
+        if node.entity.deadline == node.min_deadline {
+            return Some(node.entity.clone());
+        }
+
+        if let Some(left) = node.left.as_deref() {
+            if left.min_deadline == node.min_deadline {
+                return Self::pick_min_deadline(left);
+            }
+        }
+
+        node.right.as_deref().and_then(Self::pick_min_deadline)
+    }
+
+    fn insert_node(
+        node: Option<Box<FairTreeNode>>,
+        key: EntityKey,
+        entity: Arc<FairSchedEntity>,
+    ) -> Box<FairTreeNode> {
+        let Some(mut node) = node else {
+            return FairTreeNode::new(entity);
+        };
+
+        if key < node.key {
+            node.left = Some(Self::insert_node(node.left.take(), key, entity));
+        } else {
+            node.right = Some(Self::insert_node(node.right.take(), key, entity));
+        }
+
+        Self::rebalance(node)
+    }
+
+    fn remove_node(
+        node: Option<Box<FairTreeNode>>,
+        key: EntityKey,
+    ) -> (Option<Box<FairTreeNode>>, Option<Arc<FairSchedEntity>>) {
+        let Some(mut node) = node else {
+            return (None, None);
+        };
+
+        match key.cmp(&node.key) {
+            Ordering::Less => {
+                let (left, removed) = Self::remove_node(node.left.take(), key);
+                node.left = left;
+                (Some(Self::rebalance(node)), removed)
+            }
+            Ordering::Greater => {
+                let (right, removed) = Self::remove_node(node.right.take(), key);
+                node.right = right;
+                (Some(Self::rebalance(node)), removed)
+            }
+            Ordering::Equal => {
+                let removed = Some(node.entity.clone());
+                (Self::merge(node.left.take(), node.right.take()), removed)
+            }
+        }
+    }
+
+    fn merge(
+        left: Option<Box<FairTreeNode>>,
+        right: Option<Box<FairTreeNode>>,
+    ) -> Option<Box<FairTreeNode>> {
+        match (left, right) {
+            (None, right) => right,
+            (left, None) => left,
+            (left, Some(right)) => {
+                let (right, mut min) = Self::remove_min(right);
+                min.left = left;
+                min.right = right;
+                Some(Self::rebalance(min))
+            }
+        }
+    }
+
+    fn remove_min(mut node: Box<FairTreeNode>) -> (Option<Box<FairTreeNode>>, Box<FairTreeNode>) {
+        let Some(left) = node.left.take() else {
+            return (node.right.take(), node);
+        };
+
+        let (left, min) = Self::remove_min(left);
+        node.left = left;
+        (Some(Self::rebalance(node)), min)
+    }
+
+    fn rebalance(mut node: Box<FairTreeNode>) -> Box<FairTreeNode> {
+        node.refresh();
+        let balance = node.balance_factor();
+
+        if balance > 1 {
+            if node.left.as_ref().map_or(0, |left| left.balance_factor()) < 0 {
+                let left = node.left.take().map(Self::rotate_left);
+                node.left = left;
+            }
+            return Self::rotate_right(node);
+        }
+
+        if balance < -1 {
+            if node
+                .right
+                .as_ref()
+                .map_or(0, |right| right.balance_factor())
+                > 0
+            {
+                let right = node.right.take().map(Self::rotate_right);
+                node.right = right;
+            }
+            return Self::rotate_left(node);
+        }
+
+        node
+    }
+
+    fn rotate_left(mut root: Box<FairTreeNode>) -> Box<FairTreeNode> {
+        let mut new_root = root
+            .right
+            .take()
+            .expect("rotate_left requires a right child");
+        root.right = new_root.left.take();
+        root.refresh();
+
+        new_root.left = Some(root);
+        new_root.refresh();
+        new_root
+    }
+
+    fn rotate_right(mut root: Box<FairTreeNode>) -> Box<FairTreeNode> {
+        let mut new_root = root
+            .left
+            .take()
+            .expect("rotate_right requires a left child");
+        root.left = new_root.right.take();
+        root.refresh();
+
+        new_root.right = Some(root);
+        new_root.refresh();
+        new_root
+    }
+}

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -2,6 +2,7 @@ pub mod clock;
 pub mod completion;
 pub mod cputime;
 pub mod fair;
+pub mod fair_tree;
 pub mod fifo;
 #[cfg(feature = "fifo_demo")]
 pub mod fifo_demo;

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -7,6 +7,8 @@
 #   0: EMERG   1: ALERT   2: CRIT   3: ERR
 #   4: WARN    5: NOTICE  6: INFO   7: DEBUG
 #   示例: export DRAGONOS_LOGLEVEL=4  # 只显示WARN及以上级别的日志
+# - DRAGONOS_QEMU_ACCEL: 覆盖 QEMU 加速器选择，可选 kvm/tcg/hvf
+#   示例: DRAGONOS_QEMU_ACCEL=tcg make run-nographic
 #
 # - AUTO_TEST: 自动测试选项
 # - SYSCALL_TEST_DIR: 系统调用测试目录
@@ -88,6 +90,19 @@ if [ ${ARCH} == "i386" ] || [ ${ARCH} == "x86_64" ]; then
     fi
   fi
 fi
+
+if [ -n "${DRAGONOS_QEMU_ACCEL:-}" ]; then
+  case "${DRAGONOS_QEMU_ACCEL}" in
+    kvm|tcg|hvf)
+      qemu_accel="${DRAGONOS_QEMU_ACCEL}"
+      ;;
+    *)
+      echo "[错误] 不支持的 DRAGONOS_QEMU_ACCEL=${DRAGONOS_QEMU_ACCEL}，可选值: kvm/tcg/hvf"
+      exit 1
+      ;;
+  esac
+fi
+echo "QEMU accel=${qemu_accel}"
 
 # uboot版本
 UBOOT_VERSION="v2023.10"


### PR DESCRIPTION
Implement a scheduler-local EEVDF timeline so sched_yield() can follow Linux deadline semantics without penalizing vruntime.