### PR TITLE
feat(net): refactor network namespace with RCU-protected interface slots

### DIFF
--- a/docs/kernel/locking/container_rcu_design.md
+++ b/docs/kernel/locking/container_rcu_design.md
@@ -1,0 +1,551 @@
+# DragonOS 容器级 RCU 设计文档
+
+## 文档目的
+
+本文是 RCU 分阶段方案中 **PR4：容器级 RCU 设计专项** 的输出物。
+
+PR4 不实现具体容器，不改运行时代码，而是把 DragonOS 后续要迁移的容器类对象按语义分类，明确每类对象应该采用的 RCU 模型、生命周期规则、写侧同步方式、读侧收益与禁止事项。
+
+本文的设计结论基于：
+
+- DragonOS 当前通用非抢占式 RCU 实现：`kernel/src/rcu/mod.rs`
+- DragonOS 当前进程、PID、procfs、mount、notifier、事件链等容器形态
+- Linux 6.6.21 中 PID、RCU list/hlist、IDR/XArray 的语义约束
+- Asterinas 中 Rust RCU pointer、COW Vec、XArray 的抽象边界
+
+本文不是 RCU 原理说明，而是后续 PR5 及之后实现容器级 RCU 时必须遵守的工程设计。
+
+---
+
+## 总体结论
+
+DragonOS 当前已经具备通用非抢占式 RCU 骨架，但这只解决一件事：
+
+> 已经从发布点摘除的旧对象，不能在仍可能被旧读者访问时释放。
+
+它 **不能** 让 `HashMap`、`BTreeMap`、`Vec`、`LinkedList` 的原地修改自动变成无锁安全。
+
+因此容器级 RCU 必须满足以下原则：
+
+- 读侧通过 `rcu_read_lock()` 保护对象生命周期。
+- 写侧仍必须有独立锁串行化。
+- 容器内部节点不能在读者可能遍历时原地释放、搬迁或重平衡。
+- 删除必须先从 RCU 可见发布点摘除，再经过 grace period，最后释放旧对象。
+- 读侧不能把裸引用带出 RCU 读侧临界区，除非先获取了 owned 引用，例如 `Arc<T>`。
+
+后续不允许出现这类伪 RCU：
+
+```rust
+// 错误模型：写侧仍原地修改 HashMap，读侧只套 rcu_read_lock。
+let _guard = rcu_read_lock();
+let value = raw_hash_map.get(&key);
+```
+
+原因是 RCU 只能延迟释放对象，不能保护 `HashMap` 的桶数组 resize、元素搬迁、迭代器失效和内部元数据并发修改。
+
+---
+
+## 基础模型
+
+### 1. Snapshot COW 容器
+
+适用对象：
+
+- 小表
+- 读多写少
+- 需要一致快照
+- 写侧可以接受 O(n) clone
+
+典型形式：
+
+- `Arc<Vec<T>>`
+- `Arc<BTreeMap<K, V>>`
+- `Arc<HashMap<K, V>>`
+
+写侧流程：
+
+1. 获取 writer lock。
+2. clone 当前快照。
+3. 在新快照上插入、删除或替换。
+4. 通过 RCU pointer 发布新快照。
+5. 旧快照通过 RCU 延迟 drop。
+
+读侧语义：
+
+- 读者看到某个完整快照。
+- 读者可能看到旧版本，但不会看到半更新状态。
+- 迭代是快照一致的。
+
+限制：
+
+- 不适合大表高频写。
+- 不适合 PID 数字索引这类 fork/exit 热路径。
+- 不适合需要就地修改单个节点状态的大对象图。
+
+### 2. RCU ID table / XArray 类索引
+
+适用对象：
+
+- 整数 ID 到对象的映射
+- 查找频繁
+- 插入/删除需要保持 O(log n) 或接近 O(1)
+- 不希望每次写都 clone 整表
+
+典型对象：
+
+- `PidNamespace::pid_map`
+- 未来文件描述符表、设备号表等可按整数索引的对象
+
+写侧规则：
+
+- 由一个 writer lock 串行化结构修改。
+- 分配 ID 与发布对象分两步完成。
+- slot 指针使用 RCU pointer 发布和清空。
+- 删除 slot 后，旧对象的 slot-owned 引用延迟到 GP 后释放。
+
+读侧规则：
+
+- `rcu_read_lock()` 下按 ID 查 slot。
+- 成功后必须获得 owned 引用，例如 `Arc<T>`，再离开读侧。
+- 不允许把 slot 内裸引用带出 guard。
+
+与 Linux 对照：
+
+- Linux PID 使用 namespace 内 IDR 保存 `struct pid *`。
+- `find_pid_ns()` 可在 `tasklist_lock` 或 RCU read-side 下调用。
+- `free_pid()` 从 IDR 删除后通过 `call_rcu()` 延迟释放 `struct pid`。
+
+DragonOS 不应照搬 C 版 IDR 指针细节，但必须保留同样的发布、删除和延迟回收语义。
+
+### 3. Intrusive RCU list / hlist
+
+适用对象：
+
+- 节点天然属于对象本体。
+- 删除后读者仍可能沿 next 指针走到旧节点。
+- 需要弱一致遍历，不需要快照一致。
+
+典型对象：
+
+- Linux `struct pid::tasks[]`
+- 未来高频事件链、设备链表
+
+写侧规则：
+
+- 通过 writer lock 串行化 list 修改。
+- `add` 使用 release 发布 next 指针。
+- `del` 不能立即清空读者仍可能使用的 next 指针。
+- 节点释放必须延迟到 GP 后。
+
+读侧语义：
+
+- 允许看到并发删除前的节点。
+- 允许漏掉并发插入的新节点。
+- 不承诺快照一致。
+
+DragonOS 当前不建议 PR5 第一刀实现 intrusive list。Rust 里要安全表达 intrusive 节点、pin、所有权和延迟析构，复杂度高于 C，需要专门设计。
+
+### 4. 保留现有锁
+
+适用对象：
+
+- 写侧复杂且并非性能瓶颈。
+- 读侧可能睡眠。
+- 容器不只是索引，还维护多结构一致性。
+- 当前缺少 SRCU 或完整 VFS RCU pathwalk。
+
+保留锁不是退让，而是正确的边界。RCU 不能为了“无锁读”破坏 Linux 语义和对象生命周期。
+
+---
+
+## 目标容器决策
+
+## 1. `ALL_PROCESS`
+
+当前形态：
+
+- `static ALL_PROCESS: SpinLock<Option<HashMap<RawPid, Arc<ProcessControlBlock>>>>`
+- `ProcessManager::find()` 加锁查表并 clone `Arc<PCB>`
+- `add_pcb()`、`release()`、`exchange_tid_and_raw_pids()` 原地修改表
+
+设计结论：
+
+**PR4 结论为保留现有锁，不做 RCU 化。**
+
+原因：
+
+- 它是全局 root pid 辅助索引，不是 Linux 语义里的 namespace PID 主索引。
+- 它与 `exchange_tid_and_raw_pids()`、cgroup 记账、父子关系移除、退出释放路径耦合。
+- 若改成 snapshot COW，全系统 fork/exit 都要 clone 全表，成本不可控。
+- 若原地改 `HashMap` 并让读侧 RCU 查表，是错误模型。
+
+后续方向：
+
+- 保持 `ALL_PROCESS` 作为全局管理表。
+- 用户可见 PID 查找应逐步收敛到 `PidNamespace::pid_map` / 未来 `RcuIdTable`。
+- 若未来需要 lockless all-task iteration，应另设专用 task list，而不是复用 `HashMap`。
+
+## 2. `PidNamespace::pid_map`
+
+当前形态：
+
+- `InnerPidNamespace::pid_map: HashMap<RawPid, Arc<Pid>>`
+- 与 `IdAllocator`、`last_pid`、`dead`、`child_reaper` 同在 `SpinLock<InnerPidNamespace>` 下
+- `find_pid_in_ns()` 加锁 get + clone
+- `free_pid()` 释放各 namespace 的 pid number，并从 `pid_map` 删除
+
+设计结论：
+
+**后续采用专用 `RcuIdTable<Arc<Pid>>`，不采用 COW HashMap。**
+
+原因：
+
+- PID 查找是高频路径，fork/exit 也是热路径，整表 clone 不合适。
+- Linux 6.6 的对应模型是 namespace IDR + RCU，而不是整表 COW。
+- `RawPid` 是整数索引，适合做 slot/radix/xarray 类结构。
+
+目标语义：
+
+- `alloc_pid_in_ns()` 在 namespace writer lock 下分配 ID。
+- 分配成功后，将 `Arc<Pid>` 通过 RCU slot 发布。
+- `find_pid_in_ns()` 在 RCU read-side 下读取 slot，并 clone `Arc<Pid>` 后返回。
+- `release_pid_in_ns()` 在 writer lock 下清空 slot，并将 slot-owned `Arc<Pid>` 延迟 drop。
+- `Pid` 内部的 `numbers` 与 namespace 的循环引用问题应在 PID 生命周期设计中解决，不能靠提前 drop 或弱化 RCU 语义绕过。
+
+接口方向：
+
+```rust
+pub struct RcuIdTable<T> {
+    // 内部结构后续实现，可选择 radix/xarray/分层数组。
+}
+
+impl<T: Send + Sync + 'static> RcuIdTable<Arc<T>> {
+    pub fn load(&self, id: usize) -> Option<Arc<T>>;
+    pub fn store_locked(&self, id: usize, value: Arc<T>);
+    pub fn remove_locked(&self, id: usize) -> Option<Arc<T>>;
+}
+```
+
+约束：
+
+- `store_locked/remove_locked` 的调用者必须持有上层 writer lock。
+- `load()` 自己进入 RCU read-side，并返回 owned `Arc`。
+- 不暴露裸 slot 指针。
+
+## 3. `Pid::tasks`
+
+当前形态：
+
+- `tasks: [SpinLock<Vec<Weak<ProcessControlBlock>>>; PidType::PIDTYPE_MAX]`
+- `pid_task()` 加锁读取第一个可升级任务
+- `tasks_iter()` 持锁迭代
+- `attach_pid()` push weak
+- `detach_pid()` retain 删除 weak
+
+Linux 对照：
+
+- Linux 使用 `struct pid::tasks[PIDTYPE_MAX]` 的 RCU hlist。
+- `attach_pid()` 在 `tasklist_lock` 下 `hlist_add_head_rcu()`。
+- `detach_pid()` 用 `hlist_del_rcu()`。
+- `pid_task()` 在 RCU 下取 hlist first。
+
+DragonOS 设计结论：
+
+**第一阶段采用 snapshot COW Vec，不立即做 intrusive hlist。**
+
+原因：
+
+- 每个 PID 对应的 task 列表通常很小。
+- Rust intrusive RCU hlist 需要额外解决 pin、节点嵌入、重复入链、延迟析构和 `Weak` 清理问题。
+- COW Vec 足够表达当前 PIDTYPE 的查找和遍历语义，风险更低。
+
+目标语义：
+
+- 每个 `PidType` 对应一个 RCU 发布的 `Arc<Vec<Weak<PCB>>>`。
+- `attach_pid()`/`detach_pid()` 在 writer lock 下 clone 小 Vec 后发布。
+- `pid_task()` 读快照并 upgrade 第一个存活任务。
+- `tasks_iter()` 不返回持锁 iterator，而是返回 owned `Vec<Arc<PCB>>` 或 snapshot iterator。
+
+限制：
+
+- 旧快照中可能包含已经退出的 Weak，读侧必须 upgrade 过滤。
+- unregister/detach 后，已经开始的读者仍可能看到旧 Weak，但 upgrade 失败或状态检查会过滤。
+- 如果未来 PGID/SID 大组遍历出现性能问题，再单独设计 intrusive RCU hlist。
+
+## 4. procfs `cached_children`
+
+当前形态：
+
+- `ProcDir<Ops>::cached_children: RwSem<BTreeMap<String, Arc<dyn IndexNode>>>`
+- `list()` 先 `populate_children()`，再读锁收集 key
+- `find()` 先读缓存，validate 后返回；未命中调用 `lookup_child()`
+
+设计结论：
+
+**适合作为 PR5 首个落地候选之一，模型为 snapshot COW map。**
+
+原因：
+
+- 子项数量通常较小。
+- 写侧低频，主要是懒加载。
+- 读侧高频，查找和 list 可以从快照获益。
+- 返回值本身是 `Arc<dyn IndexNode>`，天然适合读侧获取 owned 引用。
+
+目标语义：
+
+- `cached_children` 替换为 `RcuCowMap<String, Arc<dyn IndexNode>>` 或等价封装。
+- `populate_children_from_table()` 在写侧构造新快照并一次发布。
+- `lookup_child_from_table()` miss 后构造 inode，再通过写侧锁发布新快照。
+- `validate_child()` 必须保留，尤其是动态 `/proc/<pid>`、`/proc/<pid>/fd` 等目录。
+
+禁止事项：
+
+- 不允许把动态 PID 目录永久缓存为不可失效节点。
+- 不允许在 RCU read-side 中创建 inode、申请复杂资源或执行可能睡眠的路径。
+- 动态目录若创建过程可能睡眠，应在 RCU read-side 外执行，发布阶段再加写锁。
+
+## 5. mount namespace / mount tree
+
+当前形态：
+
+- `MountFS::mountpoints: Mutex<BTreeMap<InodeId, Arc<MountFS>>>`
+- `MountList` 内有 `mounts`、`mfs2ino`、`ino2mp` 三个 map
+- mount、umount、bind mount、propagation、rewrite_paths 会同时维护多个结构
+
+设计结论：
+
+**当前阶段保留现有锁，不做 RCU 化。**
+
+原因：
+
+- mount pathwalk 与 filesystem lookup 可能睡眠，不适合当前非抢占式 RCU。
+- mount propagation 需要多结构一致性，不是单个指针发布问题。
+- Linux 的 mount RCU pathwalk 依赖 seqlock、mount ref、dentry/inode/path 多层协议和失败回退。
+- DragonOS 当前没有完整 `LOOKUP_RCU` 和 SRCU 支撑。
+
+后续条件：
+
+- 先实现 VFS pathwalk 的 RCU/ref-walk 双模式。
+- 明确 mount 读侧遇到 rename/umount/propagation 冲突时如何退回加锁模式。
+- 引入必要的 sequence counter 或等价版本校验。
+
+在这些条件满足前，不应把 `MountList` 或 `mountpoints` 改成 RCU 容器。
+
+## 6. notifier / 订阅链 / 事件链
+
+当前形态：
+
+- `NotifierChain` 内部是按优先级排序的 `Vec<Arc<dyn NotifierBlock<...>>>`
+- `AtomicNotifierChain` 用 `SpinLock`
+- `BlockingNotifierChain` 用 `RwLock`
+
+设计结论：
+
+**`AtomicNotifierChain` 适合 COW Vec + RCU；`BlockingNotifierChain` 暂不迁移。**
+
+原因：
+
+- atomic notifier 的读侧调用不应睡眠，符合非抢占式 RCU。
+- notifier 注册/注销低频，call_chain 高频。
+- Asterinas 的 console callback / timer softirq callback 使用 RCU COW Vec，适合作为 Rust 参考模型。
+- blocking notifier 允许睡眠，应该等待 SRCU 或继续使用锁。
+
+目标语义：
+
+- `register()` clone 当前 Vec，按 priority 插入并发布。
+- `unregister()` clone 当前 Vec，删除并发布。
+- `call_chain()` 在 RCU read-side 中遍历快照。
+- unregister 不保证取消已经开始的 `call_chain()`；它只保证后续新读者不再看到该 block。
+
+约束：
+
+- `AtomicNotifierChain::call_chain()` 中的 callback 不得睡眠。
+- 如果 callback 可能注册/注销同一条 chain，需要明确是否允许重入；默认不承诺重入安全。
+- `nr_to_call` 对当前快照生效，不跨快照计数。
+
+## 7. epoll / fasync / poll 事件链
+
+当前形态：
+
+- epoll ready list、poll epitems 使用 `SpinLock<LinkedList<Arc<EPollItem>>>`
+- fasync 使用 `Mutex<Vec<Arc<FAsyncItem>>>`
+- 多数路径涉及 signal、file owner、socket 状态和 wakeup
+
+设计结论：
+
+**默认保留现有锁，不作为 PR5 首选。**
+
+原因：
+
+- 事件回调路径比普通 notifier 更容易与锁顺序、唤醒、文件生命周期交叉。
+- fasync 当前使用 `Mutex`，读侧可能不满足 atomic RCU callback 条件。
+- epoll 已有针对 hardirq-safe 的内层 spinlock 设计，不能为 RCU 化破坏现有 Linux 对齐语义。
+
+后续只有在确认读侧不睡眠、回调不需要持外层阻塞锁、删除语义可弱一致后，才考虑 COW snapshot 事件订阅表。
+
+---
+
+## 推荐 PR5 候选
+
+PR5 应选择风险低、收益明确、语义闭合的容器。
+
+推荐优先级：
+
+1. `AtomicNotifierChain` 的 COW Vec + RCU。
+2. procfs 静态 `cached_children` 的 COW map。
+3. `Pid::tasks` 的 COW Vec。
+
+不建议 PR5 直接做：
+
+- `ALL_PROCESS`
+- `PidNamespace::pid_map`
+- mount namespace / mount tree
+- epoll ready list
+
+原因是这些对象要么语义复杂，要么需要额外基础设施，要么收益不足以覆盖风险。
+
+---
+
+## 未来公共接口草案
+
+PR4 不实现接口，但后续实现应按下面边界收敛。
+
+### `RcuCowVec<T>`
+
+适用：
+
+- notifier
+- 小型订阅表
+- 小规模 task list
+
+必要接口：
+
+```rust
+pub struct RcuCowVec<T> {
+    // RCU-published Arc<Vec<T>>
+}
+
+impl<T: Clone + Send + Sync + 'static> RcuCowVec<T> {
+    pub fn snapshot(&self) -> Arc<Vec<T>>;
+    pub fn update_locked<F>(&self, f: F)
+    where
+        F: FnOnce(&mut Vec<T>);
+}
+```
+
+语义：
+
+- `snapshot()` 返回 owned `Arc<Vec<T>>`。
+- `update_locked()` 要求调用者已经持有写侧锁。
+- 旧 Vec 延迟到 GP 后 drop。
+
+### `RcuCowMap<K, V>`
+
+适用：
+
+- procfs cached children
+- 小型只读多、写少目录表
+
+必要接口：
+
+```rust
+pub struct RcuCowMap<K, V> {
+    // RCU-published Arc<BTreeMap<K, V>> or Arc<HashMap<K, V>>
+}
+
+impl<K, V> RcuCowMap<K, V>
+where
+    K: Clone + Ord + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    pub fn get(&self, key: &K) -> Option<V>;
+    pub fn snapshot(&self) -> Arc<BTreeMap<K, V>>;
+    pub fn update_locked<F>(&self, f: F)
+    where
+        F: FnOnce(&mut BTreeMap<K, V>);
+}
+```
+
+语义：
+
+- `get()` 返回 clone/owned 值，不返回借用。
+- `snapshot()` 用于 list 这类一致迭代。
+- 动态项仍由上层 validate。
+
+### `RcuIdTable<T>`
+
+适用：
+
+- PID namespace ID 表
+- 未来整数索引对象表
+
+必要接口：
+
+```rust
+pub struct RcuIdTable<T> {
+    // 分层数组、radix 或 xarray 形态由实现 PR 决定。
+}
+
+impl<T: Send + Sync + 'static> RcuIdTable<Arc<T>> {
+    pub fn load(&self, id: usize) -> Option<Arc<T>>;
+    pub fn store_locked(&self, id: usize, value: Arc<T>);
+    pub fn remove_locked(&self, id: usize) -> Option<Arc<T>>;
+}
+```
+
+语义：
+
+- `load()` 读侧自行进入 RCU，并返回 owned `Arc`。
+- `store_locked/remove_locked` 要求上层 writer lock。
+- 删除后的 slot-owned 引用必须延迟释放。
+
+---
+
+## 测试要求
+
+每个容器落地 PR 必须至少覆盖以下测试类别。
+
+### 基础语义
+
+- 插入后可查找。
+- 删除后新读者不可见。
+- 已开始读者可安全使用旧对象。
+- 旧对象在 GP 后释放。
+- 重复删除、空删除、重复注册返回正确错误。
+
+### 并发压力
+
+- 多 CPU 高频读。
+- writer 周期性插入、删除、替换。
+- 读者持续迭代时 writer 删除对象。
+- `rcu_barrier()` 后确认旧对象 drop 完成。
+
+### 子系统回归
+
+- PID：fork/exit、PID 复用、PID namespace 销毁、PGID/SID 遍历。
+- procfs：`/proc` list/find、`/proc/<pid>` 退出后失效、`/proc/net` 静态项。
+- notifier：register/unregister/call_chain 顺序、priority、`nr_to_call`。
+- mount：若未来触碰，必须覆盖 bind mount、umount、propagation、pivot_root、mountinfo。
+
+### 调试断言
+
+- RCU read-side 中不得调用可能睡眠接口。
+- container API 不暴露可逃逸裸引用。
+- 写侧更新 API 在调试模式下尽量检查 writer lock 前置条件。
+
+---
+
+## 明确禁止事项
+
+- 禁止把标准库或 `hashbrown` 的原地修改 map 直接暴露给 RCU reader。
+- 禁止在 RCU read-side 内执行可能阻塞的 inode 创建、内存回收等待、用户内存拷贝或文件系统 IO。
+- 禁止为了绕过循环引用而提前释放仍可能被读者看到的对象。
+- 禁止让 `synchronize_rcu()` 出现在 RCU read-side 内。
+- 禁止把 `Arc` clone 当成容器结构本身的并发保护。
+- 禁止在没有完整 pathwalk 回退协议前实现 `LOOKUP_RCU`。
+
+---
+
+## 一句话结论
+
+DragonOS 的容器级 RCU 应先从 COW 小容器和专用 ID 索引开始，保留写侧锁，读侧返回 owned 引用；`ALL_PROCESS` 和 mount 树暂不 RCU 化，`PidNamespace::pid_map` 等到专用 `RcuIdTable` 设计落地后再迁移。

--- a/docs/kernel/locking/index.rst
+++ b/docs/kernel/locking/index.rst
@@ -12,5 +12,6 @@
    rwlock
    mutex
    rwsem
-
+   rcu_implementation_plan
+   container_rcu_design
 

--- a/docs/kernel/locking/rcu_implementation_plan.md
+++ b/docs/kernel/locking/rcu_implementation_plan.md
@@ -1,0 +1,771 @@
+# DragonOS RCU 实现与分阶段落地方案
+
+## 文档目的
+
+这份文档用于把 DragonOS 的 RCU 设计、当前实现状态、后续 PR 拆分方案、测试策略与风险边界沉淀为一份可执行的工程计划。
+
+这不是一份“RCU 原理科普”，而是一份面向 DragonOS 当前代码形态的实现方案说明。
+
+## 当前状态
+
+截至当前提交，**PR1 已经落地**，也就是：
+
+- 已新增通用非抢占式 RCU 基础设施：`kernel/src/rcu/mod.rs`
+- 已把 `ProcessControlBlock` 扩展为区分：
+  - `preempt_count`
+  - `rcu_read_depth`
+- 已接入 quiescent state（QS）推进点：
+  - `__schedule()`
+  - 从内核返回用户态前
+  - x86/riscv idle 扩展静默态
+  - x86 CPU 下线路径
+- 已实现：
+  - `rcu_read_lock()` / `rcu_read_unlock()`
+  - `rcu_dereference()`
+  - `rcu_assign_pointer()`
+  - `call_rcu()`
+  - `synchronize_rcu()`
+  - `rcu_barrier()`
+  - `rcu_defer_drop()`
+- 已实现独立的 RCU worker 内核线程 `rcu_gp`
+
+**还没有落地**的是：
+
+- 具体子系统的 RCU 化迁移
+- 容器级 RCU 结构改造
+- `SRCU`
+- `Tasks RCU`
+- `LOOKUP_RCU` pathwalk
+
+也就是说，当前内核已经具备“正确的通用 RCU 骨架”，但还没有把具体对象读路径大规模切换到 RCU。
+
+---
+
+## 为什么 DragonOS 现在不能直接照搬 Linux Tree RCU
+
+DragonOS 当前具备：
+
+- `preempt_disable/enable`
+- 调度入口 `__schedule()`
+- idle 线程
+- 中断返回用户态公共出口
+- per-cpu 基础设施
+- 内核线程机制
+
+但 DragonOS **还不具备** Linux Tree RCU 所依赖的一整套成熟环境：
+
+- 完整的上下文跟踪（context tracking）
+- 完整的 RCU softirq / nocb / callback segmentation 体系
+- 完整的 lockdep / PROVE_RCU / stall detector 配套
+- 已经 RCU 化的任务、PID、VFS、网络核心容器
+
+所以当前最合理的落点不是直接复制 Linux 6.6 Tree RCU，而是：
+
+1. 先落地**通用非抢占式 RCU**
+2. 用它支撑单指针发布类对象
+3. 再逐步设计容器级 RCU 方案
+4. 最后再考虑 `SRCU` 或更强的 RCU flavor
+
+这也是为什么方案拆分成多个 PR，而不是一次性把所有“看起来能用 RCU 的地方”全改掉。
+
+---
+
+## 设计目标
+
+### 目标
+
+- 符合 Linux 非抢占式通用 RCU 的基本语义
+- 不引入 workaround 式“伪 RCU”
+- 不把对象生命周期安全建立在侥幸时序上
+- 优先保证正确性，再逐步追求读路径性能收益
+- 为后续 `SRCU`、容器级 RCU、VFS/网络迁移预留清晰接口
+
+### 非目标
+
+- 当前阶段不实现完整 Linux Tree RCU
+- 当前阶段不实现 `SRCU`
+- 当前阶段不实现 `Tasks RCU`
+- 当前阶段不实现 `LOOKUP_RCU`
+- 当前阶段不把 `HashMap/BTreeMap/Vec` 强行改成“看起来像无锁”的结构
+
+---
+
+## 参考基线
+
+### Linux 6.6.21
+
+本方案在语义上参考 Linux 6.6.21 的以下原则：
+
+- 非抢占式 RCU 读侧可以绑定 `preempt_disable()`
+- quiescent state 可以由上下文切换、返回用户态、idle 静默态推进
+- `call_rcu()` 与 `synchronize_rcu()` 必须由真正的 GP 保障
+- 指针发布和读侧解引用必须通过明确的内存序原语
+
+### Asterinas
+
+Asterinas 对 DragonOS 有两个可借鉴点：
+
+- RCU 读侧与“禁止抢占”绑定
+- 以单独监视器推进 grace period
+
+但 Asterinas 当前做法里“在 GP 完成点直接执行 callback”的思路不适合 DragonOS 主路径，所以 DragonOS 采用了独立 worker 来执行 callback，避免把析构/回调尾延迟压进调度路径。
+
+---
+
+## 核心设计
+
+## 1. RCU flavor 选择
+
+DragonOS 当前采用：
+
+- **通用非抢占式 RCU（non-preemptible RCU）**
+
+基本语义：
+
+- `rcu_read_lock()` 进入读侧临界区
+- 读侧临界区禁止抢占
+- 读侧不允许睡眠
+- writer 通过 GP 等待所有旧读者离开
+
+为什么不是 preemptible RCU：
+
+- DragonOS 当前的 `preempt_count`、调度、等待队列、锁语义都更接近“禁止抢占式读侧”
+- 如果现在强上 preemptible RCU，必须同步改造任务状态跟踪、blocked readers 管理与更多调度细节，风险过高
+
+---
+
+## 2. 读侧状态与 `preempt_count` 分离
+
+当前实现中，`ProcessControlBlock` 同时维护：
+
+- `preempt_count`
+- `rcu_read_depth`
+
+这样做是必须的。
+
+不能只用 `preempt_count` 的原因：
+
+- `preempt_count` 同时被 spinlock/rwlock/irqsave 使用
+- 仅凭 `preempt_count > 0` 无法判断是否真处于 RCU 读侧
+- `synchronize_rcu()`、调试断言、未来 `PROVE_RCU` 风格检查都需要明确的 RCU 嵌套层数
+
+当前规则：
+
+- `rcu_read_lock()`：
+  - `preempt_disable()`
+  - `rcu_read_depth += 1`
+- `rcu_read_unlock()`：
+  - `rcu_read_depth -= 1`
+  - `preempt_enable()`
+
+这保证：
+
+- 读侧不会被调度出去
+- 同时仍能区分“只是拿了自旋锁”和“确实在 RCU 读侧”
+
+---
+
+## 3. Grace Period 设计
+
+DragonOS 当前的 GP 设计是：
+
+- 全局 `gp_seq`
+- 全局 `completed_gp_seq`
+- 全局 `requested_gp_seq`
+- 每 CPU 一个 `RcuCpuState`
+- 每轮 GP 维护一个 `waiting_cpus` 集合
+
+### GP 启动
+
+当发生以下事件时，会请求未来 GP：
+
+- `call_rcu()`
+- `synchronize_rcu()`
+- `rcu_defer_drop()`
+
+若当前没有活动 GP，则启动新 GP：
+
+1. `gp_seq += 1`
+2. 构造等待 CPU 集合
+3. 等待所有需要参与本轮 GP 的 CPU 报告 QS
+
+### 哪些 CPU 要参与本轮 GP
+
+当前规则：
+
+- 仅 online CPU 参与
+- 已处于 idle 扩展静默态的 CPU 不进入等待集
+- 已 offline 的 CPU 不进入等待集
+
+### GP 完成
+
+当 `waiting_cpus` 为空时：
+
+- 当前 GP 完成
+- `completed_gp_seq = gp_seq`
+- 将 `target_gp <= completed_gp_seq` 的 callback 转移到 ready 队列
+
+---
+
+## 4. Quiescent State（QS）推进点
+
+当前已接入的 QS 推进点如下。
+
+### 4.1 调度路径
+
+位置：
+
+- `kernel/src/sched/mod.rs::__schedule()`
+
+语义：
+
+- 能执行到 `__schedule()`，说明当前任务不处于 RCU 读侧
+- 因为读侧绑定了 `preempt_disable()`，调度本身就意味着一个真实 QS
+
+这是当前最稳定、最核心的 QS 来源。
+
+### 4.2 返回用户态
+
+位置：
+
+- `kernel/src/exception/entry.rs`
+- `arch_switch_to_user()` 的架构路径
+
+语义：
+
+- 从内核回到用户态前，当前 CPU 已结束本轮内核读侧活动
+- 这与 Linux 把“离开内核执行上下文”视作可用于 RCU 推进的事件是一致的
+
+### 4.3 idle 扩展静默态
+
+位置：
+
+- x86 idle loop
+- riscv idle loop
+
+语义：
+
+- CPU 进入 idle 后，对 RCU 来说属于扩展静默态
+- GP 启动时不必等待已处于 idle EQS 的 CPU
+- 若 CPU 在活动 GP 中转入 idle，则可立即从等待集中摘掉
+
+### 4.4 CPU offline
+
+位置：
+
+- 当前已接 x86 `stop_this_cpu()` 路径
+
+语义：
+
+- 下线 CPU 不应卡住当前 GP
+- 若它仍在 `waiting_cpus` 中，必须显式摘除
+
+### 后续可选推进点
+
+后续如果需要强化 GP 收敛速度，可以再考虑：
+
+- 中断退出路径上的补充 QS
+- 更精细的 syscall/exception 公共入口配套状态跟踪
+
+但当前阶段不必过早扩展。
+
+---
+
+## 5. callback 模型
+
+DragonOS 当前采用：
+
+- callback 入队与 GP 推进解耦
+- callback 执行与调度主路径解耦
+- callback 在独立的 RCU worker 内核线程中执行
+
+### 已实现接口
+
+- `call_rcu(head, func)`
+- `rcu_defer_drop<T>()`
+- `rcu_barrier()`
+
+### 为什么不用“在 GP 完成时直接执行 callback”
+
+因为 callback 在 Rust 里往往意味着：
+
+- `drop`
+- 容器析构
+- 释放对象图
+- 清理复杂资源
+
+这些都可能带来明显尾延迟。
+
+若把它们直接塞进：
+
+- `__schedule()`
+- 中断退出
+- softirq 路径
+
+就会污染调度和中断主路径，这在 DragonOS 当前阶段是不合适的。
+
+所以当前采用的原则是：
+
+- 主路径只推进 GP
+- 真正的回调执行由 worker 消化
+
+---
+
+## 6. 内存序模型
+
+当前约束非常明确：
+
+- 发布新指针必须走 `rcu_assign_pointer()`
+- 读侧读取指针必须走 `rcu_dereference()`
+
+当前实现里：
+
+- `rcu_dereference()` 使用 `Acquire`
+- `rcu_assign_pointer()` 使用 `Release`
+
+约束的意义是：
+
+- writer 在发布指针前对对象内容的初始化，对 reader 可见
+- reader 读到新指针后，能看到对象已初始化的状态
+
+当前阶段不允许子系统自己直接用裸 `AtomicPtr::store/load` 伪造 RCU 语义。
+
+---
+
+## 7. 调试与错误保护
+
+当前已具备或应保持的调试约束：
+
+- `rcu_read_unlock()` 下溢直接断言
+- `__schedule()` 遇到 `rcu_read_depth != 0` 给出告警/断言
+- `synchronize_rcu()` 在 RCU 读侧中调用给出告警/断言
+- `call_rcu()` 同一个 `RcuHead` 重复入队直接 panic
+
+后续建议增强：
+
+- stall detector
+- `/proc` 或 debugfs 暴露：
+  - `gp_seq`
+  - `completed_gp_seq`
+  - pending callback 数
+  - ready callback 数
+  - 每 CPU `in_idle_eqs`
+
+---
+
+## 为什么 PR 要这样拆
+
+很多地方“看起来都能用 RCU”，但实际上可以分成两类：
+
+### 第一类：单指针发布对象
+
+典型特征：
+
+- 一个字段是 `Arc<T>` 或等价单对象引用
+- 写侧是“整体替换”
+- 读侧主要是“读当前版本对象”
+
+这类对象适合优先迁移。
+
+### 第二类：容器级并发结构
+
+典型特征：
+
+- `HashMap`
+- `BTreeMap`
+- `Vec`
+- `LinkedList`
+- 原地增删改
+- 迭代和回收交叉
+
+这类对象不能因为“有了 RCU 基础设施”就直接无锁化。
+
+必须先决定一种明确模型：
+
+- snapshot copy-on-write
+- intrusive RCU list/hlist
+- 专用索引结构
+
+所以 PR 必须拆开，否则很容易在“基础设施刚加上”的时候就把容器级问题一起做坏。
+
+---
+
+## PR 拆分方案
+
+## PR1：RCU 核心基础设施
+
+### 目标
+
+把 DragonOS 做成“拥有正确通用 RCU 骨架”的内核。
+
+### 范围
+
+- 新增 `kernel/src/rcu/mod.rs`
+- 增加 `PCB.rcu_read_depth`
+- 增加 RCU API：
+  - `rcu_read_lock/unlock`
+  - `rcu_dereference`
+  - `rcu_assign_pointer`
+  - `call_rcu`
+  - `synchronize_rcu`
+  - `rcu_barrier`
+  - `rcu_defer_drop`
+- 接入 QS 推进点：
+  - 调度
+  
+  - 返回用户态
+  - idle
+  - CPU offline
+- 增加独立 RCU worker 内核线程
+
+### 当前状态
+
+**已完成。**
+
+### 验收标准
+
+- `make kernel` 通过
+- 调度/返回用户态/idle 路径无编译和链接问题
+- 能支撑后续单指针 RCU 化工作
+
+---
+
+## PR2：单指针对象的第一批 RCU 化
+
+### 目标
+
+把最适合、最容易做对的一批“单对象引用字段”迁移到 RCU。
+
+### 推荐对象
+
+- `nsproxy`
+- `cred`
+- `sighand`
+
+这些字段当前都是高频读、低频写、整体替换型对象。
+
+### 迁移方式
+
+以 `RwLock<Arc<T>>` 为例，迁移方向是：
+
+1. 写侧仍然允许通过已有锁决定“要不要更新”
+2. 一旦要发布新对象：
+   - 分配/构造新 `Arc<T>`
+   - 使用 `rcu_assign_pointer()` 发布
+3. 旧对象不立刻 `drop`
+   - 改为 `rcu_defer_drop(old_obj)`
+4. 读侧不再每次都走重锁
+   - 改为 `rcu_read_lock()` + `rcu_dereference()`
+
+### 为什么先做这批
+
+- 它们不是原地修改型容器
+- 没有复杂迭代器失效问题
+- 生命周期边界清楚
+- 能最快验证 RCU 基础设施是否真的可用
+
+### PR2 不做什么
+
+- 不动 `HashMap/BTreeMap/Vec`
+- 不碰 PID 全局可见性表
+- 不碰 mount 树
+- 不碰 procfs 目录缓存树
+
+### PR2 验收标准
+
+- `nsproxy/cred/sighand` 读路径不再依赖重锁 clone
+- 对象替换后旧版本延迟释放
+- 无 use-after-free
+- 现有 process/namespace/signal 测试不退化
+
+---
+
+## PR3：网络命名空间中的单对象引用迁移
+
+### 目标
+
+用真实多核读路径验证 RCU 在网络子系统中的实际收益和稳定性。
+
+### 推荐对象
+
+- `default_iface`
+- loopback 当前引用
+- 某些 netns 下的“当前默认单对象”
+
+### 为什么 PR3 单独拆出来
+
+网络代码的并发形态和进程/凭证不一样：
+
+- 会经历更频繁的跨 CPU 读
+- 与 NAPI/poll/事件唤醒交互更多
+- 更容易暴露 memory ordering 和生命周期问题
+
+把它独立成一个 PR，有两个好处：
+
+1. 出问题时容易归因
+2. 不会把进程对象与网络对象的回归混在一起
+
+### PR3 不做什么
+
+- 不动 `device_list`
+- 不动 `bridge_list`
+- 不动 `netlink_socket_table`
+
+这些都是容器级结构，不属于“单指针引用迁移”的范围。
+
+### PR3 验收标准
+
+- 网络默认对象读取路径可在 RCU 下安全运行
+- 不引入 netns 销毁时的悬空引用
+- socket 基础回归不退化
+
+---
+
+## PR4：容器级 RCU 设计专项
+
+### 目标
+
+不急着写代码，先把容器级 RCU 的方案设计完整。
+
+详细设计见：[`container_rcu_design.md`](container_rcu_design.md)。
+
+### 必须单独设计的对象
+
+- `ALL_PROCESS`
+- `PidNamespace::pid_map`
+- procfs cached children
+- mount 传播树 / mount namespace 相关可见性结构
+- 订阅链 / 事件链 / 某些链表容器
+
+### 为什么不能直接改
+
+因为这些容器的难点不是“读的时候要不要加锁”，而是：
+
+- 节点何时可见
+- 节点何时不可见
+- 旧版本什么时候能回收
+- 迭代时并发删除/替换怎么保证安全
+- 原地 resize / rebalance 怎么办
+
+这不是加一个 `rcu_read_lock()` 就能解决的问题。
+
+### PR4 输出物
+
+每类容器都必须明确采用哪一种模型：
+
+- snapshot copy-on-write
+- intrusive RCU list/hlist
+- 特制数组/索引
+- “保留现有锁，不做 RCU 化”
+
+并说明：
+
+- 为什么选它
+- 生命周期怎么保证
+- 写侧成本如何
+- 读侧收益是否值得
+
+### PR4 验收标准
+
+- 每个目标容器有清晰方案
+- 实现者不需要再临场拍脑袋定模型
+- 形成独立设计文档，明确哪些容器可以 RCU 化、哪些必须保留现有锁
+
+---
+
+## PR5：首个容器级 RCU 落地
+
+### 目标
+
+选择一个最容易做对、收益明确的容器级对象，完成第一例真正的容器级 RCU 化。
+
+### 推荐优先级
+
+优先从下面两类里选：
+
+1. procfs 某些缓存结构
+2. notifier / tracepoint / 订阅链
+
+不建议第一刀就上：
+
+- `ALL_PROCESS`
+- `pid_map`
+
+因为这两者语义复杂、回归面大、和进程退出时序强耦合。
+
+### PR5 验收标准
+
+- 至少有一个容器级结构完成“非单指针”的真实 RCU 化
+- 并发读写和回收语义有测试覆盖
+
+---
+
+## 对 `ALL_PROCESS` 和 `pid_map` 的明确态度
+
+这是最容易误判的点，所以单独写清楚。
+
+### 当前结论
+
+**不要在 PR2/PR3 里直接把 `ALL_PROCESS` 或 `pid_map` 改成“RCU 查表”。**
+
+### 原因
+
+它们当前本质上是：
+
+- `HashMap<RawPid, Arc<ProcessControlBlock>>`
+- `HashMap<RawPid, Arc<Pid>>`
+
+问题不在“值是 Arc 还是不是 Arc”，而在：
+
+- 容器本身会原地修改
+- 迭代器/rehash 生命周期复杂
+- 删除时机与进程退出路径耦合
+
+如果粗暴做成：
+
+- 写侧继续改 `HashMap`
+- 读侧只加 `rcu_read_lock()`
+
+那只是伪 RCU，不能保证安全。
+
+### 合理方向
+
+这两类对象要么：
+
+- 做 snapshot COW map
+
+要么：
+
+- 引入适合 RCU 的专用索引结构
+
+要么：
+
+- 明确保留现有加锁模型，不为“无锁而无锁”
+
+---
+
+## 测试策略
+
+## A. 基础语义测试
+
+需要覆盖：
+
+- `rcu_read_lock/unlock` 嵌套
+- unlock 下溢
+- `synchronize_rcu()` 至少等待一个真实 GP
+- `call_rcu()` callback 只执行一次
+- `rcu_barrier()` 等到历史 callback 全部完成
+
+## B. 并发压力测试
+
+需要覆盖：
+
+- 多 CPU reader 持续进入读侧
+- writer 周期性替换对象
+- 旧对象延迟释放
+- callback 中释放对象
+- 高频切换、idle、返回用户态共同推进 GP
+
+## C. 回归测试
+
+需要覆盖：
+
+- 进程/命名空间/信号相关路径
+- 网络命名空间基础路径
+- 内核线程、调度和 idle 基本路径
+
+## D. 调试观测
+
+建议增加：
+
+- GP 序列号观测
+- callback 队列长度观测
+- 每 CPU 是否处于 idle EQS 的观测
+- 长时间未完成 GP 的告警
+
+---
+
+## 后续扩展路线
+
+在完成 PR1~PR5 后，后续可以按需要继续扩展：
+
+### 方向 1：引入 `SRCU`
+
+只有当 DragonOS 出现大量“读侧允许睡眠”的真实需求时才值得做。
+
+例如：
+
+- 某些需要阻塞的配置读路径
+- 睡眠型订阅/回调保护
+
+### 方向 2：更复杂的 VFS RCU 化
+
+这要求：
+
+- dentry/inode/path/mount 结构整体配套
+- 失败回退到 ref-walk 的完整逻辑
+
+不是当前阶段应触碰的内容。
+
+### 方向 3：更强的调试能力
+
+例如：
+
+- stall detector
+- 类 lockdep 的 RCU 使用检查
+- callback 重入/泄露检测
+
+---
+
+## 实施顺序建议
+
+建议严格按如下顺序推进：
+
+1. PR1：基础设施
+2. PR2：`nsproxy/cred/sighand`
+3. PR3：网络单对象引用
+4. PR4：容器级设计专项
+5. PR5：第一个容器级真实落地
+
+不要把顺序改成：
+
+1. PR1
+2. 直接改 `ALL_PROCESS`
+3. 顺手改 `pid_map`
+
+这会明显提高踩坑概率。
+
+---
+
+## 当前仓库内与 RCU 相关的关键文件
+
+- `kernel/src/rcu/mod.rs`
+- `kernel/src/process/mod.rs`
+- `kernel/src/sched/mod.rs`
+- `kernel/src/exception/entry.rs`
+- `kernel/src/arch/x86_64/process/mod.rs`
+- `kernel/src/arch/riscv64/process/mod.rs`
+- `kernel/src/arch/x86_64/process/idle.rs`
+- `kernel/src/arch/riscv64/process/idle.rs`
+
+后续做 PR2/PR3 时，重点会继续扩展到：
+
+- `kernel/src/process/namespace/nsproxy.rs`
+- `kernel/src/process/cred.rs`
+- `kernel/src/ipc/sighand.rs`
+- `kernel/src/process/namespace/net_namespace.rs`
+
+---
+
+## 一句话总结
+
+当前已经完成的是：
+
+- **“把 DragonOS 做成一个拥有正确通用 RCU 骨架的内核”**
+
+接下来 PR2/PR3 的含义分别是：
+
+- **PR2：把进程/凭证/信号这类单对象引用读路径迁到 RCU**
+- **PR3：把网络命名空间中的单对象引用读路径迁到 RCU**
+
+它们不是“继续补基础设施”，而是“开始在具体子系统上真正使用这套 RCU 语义”。

--- a/kernel/src/libs/notifier.rs
+++ b/kernel/src/libs/notifier.rs
@@ -10,11 +10,16 @@ use crate::{
     rcu::{rcu_read_lock_held, synchronize_rcu, RcuArcSlot},
 };
 
-pub const NOTIFY_DONE: i32 = 0x0000;
-pub const NOTIFY_OK: i32 = 0x0001;
-pub const NOTIFY_STOP_MASK: i32 = 0x8000;
-pub const NOTIFY_BAD: i32 = NOTIFY_STOP_MASK | 0x0002;
-pub const NOTIFY_STOP: i32 = NOTIFY_OK | NOTIFY_STOP_MASK;
+bitflags! {
+    /// Linux notifier callback return values.
+    pub struct NotifyResult: i32 {
+        const DONE = 0x0000;
+        const OK = 0x0001;
+        const STOP_MASK = 0x8000;
+        const BAD = Self::STOP_MASK.bits | 0x0002;
+        const STOP = Self::OK.bits | Self::STOP_MASK.bits;
+    }
+}
 
 /// @brief 通知链节点
 pub trait NotifierBlock<V: Clone + Copy, T>: Debug + Send + Sync {
@@ -110,7 +115,7 @@ impl<V: Clone + Copy, T> NotifierChain<V, T> {
             }
             ret = b.notifier_call(action, data);
             nr_calls += 1;
-            if ret & NOTIFY_STOP_MASK != 0 {
+            if NotifyResult::from_bits_truncate(ret).contains(NotifyResult::STOP_MASK) {
                 break;
             }
         }

--- a/kernel/src/libs/notifier.rs
+++ b/kernel/src/libs/notifier.rs
@@ -1,10 +1,20 @@
 #![allow(dead_code)]
 use core::fmt::Debug;
 
-use crate::libs::{rwlock::RwLock, spinlock::SpinLock};
 use alloc::{sync::Arc, vec::Vec};
 use log::warn;
 use system_error::SystemError;
+
+use crate::{
+    libs::{rwlock::RwLock, spinlock::SpinLock},
+    rcu::{rcu_read_lock_held, synchronize_rcu, RcuArcSlot},
+};
+
+pub const NOTIFY_DONE: i32 = 0x0000;
+pub const NOTIFY_OK: i32 = 0x0001;
+pub const NOTIFY_STOP_MASK: i32 = 0x8000;
+pub const NOTIFY_BAD: i32 = NOTIFY_STOP_MASK | 0x0002;
+pub const NOTIFY_STOP: i32 = NOTIFY_OK | NOTIFY_STOP_MASK;
 
 /// @brief 通知链节点
 pub trait NotifierBlock<V: Clone + Copy, T>: Debug + Send + Sync {
@@ -18,6 +28,12 @@ pub trait NotifierBlock<V: Clone + Copy, T>: Debug + Send + Sync {
 // TODO: 考虑使用红黑树封装
 #[derive(Debug)]
 struct NotifierChain<V: Clone + Copy, T>(Vec<Arc<dyn NotifierBlock<V, T>>>);
+
+impl<V: Clone + Copy, T> Clone for NotifierChain<V, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<V: Clone + Copy, T> NotifierChain<V, T> {
     pub fn new() -> Self {
@@ -79,8 +95,6 @@ impl<V: Clone + Copy, T> NotifierChain<V, T> {
     /// ## 返回
     ///
     /// (最后一次回调函数的返回值，回调次数)
-    ///
-    /// TODO: 增加 NOTIFIER_STOP_MASK 相关功能
     pub fn call_chain(
         &self,
         action: V,
@@ -96,42 +110,81 @@ impl<V: Clone + Copy, T> NotifierChain<V, T> {
             }
             ret = b.notifier_call(action, data);
             nr_calls += 1;
+            if ret & NOTIFY_STOP_MASK != 0 {
+                break;
+            }
         }
         return (ret, nr_calls);
     }
 }
 
-/// @brief 原子的通知链，使用 SpinLock 进行同步
+/// @brief 原子的通知链，更新侧使用 SpinLock 串行化，调用侧使用 RCU 快照遍历
 #[derive(Debug)]
-pub struct AtomicNotifierChain<V: Clone + Copy, T>(SpinLock<NotifierChain<V, T>>);
+pub struct AtomicNotifierChain<V, T>
+where
+    V: Clone + Copy + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+{
+    update_lock: SpinLock<()>,
+    chain: RcuArcSlot<NotifierChain<V, T>>,
+}
 
-impl<V: Clone + Copy, T> Default for AtomicNotifierChain<V, T> {
+impl<V, T> Default for AtomicNotifierChain<V, T>
+where
+    V: Clone + Copy + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<V: Clone + Copy, T> AtomicNotifierChain<V, T> {
+impl<V, T> AtomicNotifierChain<V, T>
+where
+    V: Clone + Copy + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+{
     pub fn new() -> Self {
-        Self(SpinLock::new(NotifierChain::<V, T>::new()))
+        Self {
+            update_lock: SpinLock::new(()),
+            chain: RcuArcSlot::new(Arc::new(NotifierChain::<V, T>::new())),
+        }
     }
 
-    pub fn register(&mut self, block: Arc<dyn NotifierBlock<V, T>>) -> Result<(), SystemError> {
-        let mut notifier_chain_guard = self.0.lock();
-        return notifier_chain_guard.register(block, false);
+    pub fn register(&self, block: Arc<dyn NotifierBlock<V, T>>) -> Result<(), SystemError> {
+        let _guard = self.update_lock.lock_irqsave();
+        let mut new_chain = (*self.chain.load()).clone();
+        new_chain.register(block, false)?;
+        self.chain.store_deferred(Arc::new(new_chain));
+        return Ok(());
     }
 
     pub fn register_unique_prio(
-        &mut self,
+        &self,
         block: Arc<dyn NotifierBlock<V, T>>,
     ) -> Result<(), SystemError> {
-        let mut notifier_chain_guard = self.0.lock();
-        return notifier_chain_guard.register(block, true);
+        let _guard = self.update_lock.lock_irqsave();
+        let mut new_chain = (*self.chain.load()).clone();
+        new_chain.register(block, true)?;
+        self.chain.store_deferred(Arc::new(new_chain));
+        return Ok(());
     }
 
-    pub fn unregister(&mut self, block: Arc<dyn NotifierBlock<V, T>>) -> Result<(), SystemError> {
-        let mut notifier_chain_guard = self.0.lock();
-        return notifier_chain_guard.unregister(block);
+    pub fn unregister(&self, block: Arc<dyn NotifierBlock<V, T>>) -> Result<(), SystemError> {
+        if rcu_read_lock_held() {
+            warn!("atomic notifier unregister called from an RCU read-side section");
+            return Err(SystemError::EDEADLK_OR_EDEADLOCK);
+        }
+
+        {
+            let _guard = self.update_lock.lock_irqsave();
+            let mut new_chain = (*self.chain.load()).clone();
+            new_chain.unregister(block)?;
+            self.chain.store_deferred(Arc::new(new_chain));
+        }
+
+        synchronize_rcu();
+        return Ok(());
     }
 
     pub fn call_chain(
@@ -140,8 +193,9 @@ impl<V: Clone + Copy, T> AtomicNotifierChain<V, T> {
         data: Option<&T>,
         nr_to_call: Option<usize>,
     ) -> (i32, usize) {
-        let notifier_chain_guard = self.0.lock();
-        return notifier_chain_guard.call_chain(action, data, nr_to_call);
+        return self
+            .chain
+            .with_read(|chain| chain.call_chain(action, data, nr_to_call));
     }
 }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -620,11 +620,11 @@ impl ProcessManager {
         let is_mt_exec_leader = current.is_thread_group_leader()
             && exec_task
                 .as_ref()
-                .map(|t| !Arc::ptr_eq(t, &current))
+                .map(|t| !Arc::ptr_eq(t, current))
                 .unwrap_or(false);
         if sighand.flags_contains(SignalFlags::GROUP_EXEC) {
             if let Some(exec_task) = exec_task.as_ref() {
-                if !Arc::ptr_eq(exec_task, &current) {
+                if !Arc::ptr_eq(exec_task, current) {
                     let notify_count = sighand.group_exec_notify_count();
                     if notify_count < 0 {
                         // mt-exec: exec 线程正在等待 leader 退出
@@ -636,7 +636,7 @@ impl ProcessManager {
             }
             let should_clear = exec_task
                 .as_ref()
-                .map(|t| Arc::ptr_eq(t, &current))
+                .map(|t| Arc::ptr_eq(t, current))
                 .unwrap_or(false);
             if should_clear {
                 sighand.finish_group_exec();

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -62,8 +62,9 @@ use crate::{
     process::resource::{RLimit64, RLimitID},
     rcu::RcuArcSlot,
     sched::{
-        DequeueFlag, EnqueueFlag, OnRq, SchedMode, WakeupFlags, __schedule, completion::Completion,
-        cpu_rq, enqueue_task_on_cpu, fair::FairSchedEntity, prio::MAX_PRIO, select_task_rq,
+        DequeueFlag, EnqueueFlag, OnRq, SchedMode, WakeupFlags, __schedule_with_current,
+        completion::Completion, cpu_rq, enqueue_task_on_cpu, fair::FairSchedEntity, prio::MAX_PRIO,
+        select_task_rq,
     },
     smp::{
         core::smp_get_processor_id,
@@ -609,8 +610,7 @@ impl ProcessManager {
 
     /// 当子进程退出后向父进程发送通知
     #[inline(never)]
-    fn exit_notify() {
-        let current = ProcessManager::current_pcb();
+    fn exit_notify(current: &Arc<ProcessControlBlock>) {
         let sighand = current.sighand();
         let exec_task = if sighand.flags_contains(SignalFlags::GROUP_EXEC) {
             sighand.group_exec_task()
@@ -739,15 +739,14 @@ impl ProcessManager {
                 spin_loop();
             }
         }
-        drop(current_pcb);
 
         // 关中断
         let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let pid: Arc<Pid>;
-        let raw_pid = ProcessManager::current_pid();
+        let raw_pid = current_pcb.raw_pid();
         // log::debug!("[exit: {}]", raw_pid.data());
         {
-            let pcb = ProcessManager::current_pcb();
+            let pcb = current_pcb.clone();
             pcb.mark_exiting();
             pid = pcb.pid();
             pcb.wait_queue.mark_dead();
@@ -853,12 +852,10 @@ impl ProcessManager {
 
             unsafe { pcb.basic_mut().set_user_vm(None) };
 
-            drop(pcb);
-
-            ProcessManager::exit_notify();
+            ProcessManager::exit_notify(&pcb);
         }
 
-        __schedule(SchedMode::SM_NONE);
+        __schedule_with_current(SchedMode::SM_NONE, current_pcb);
         error!("raw_pid {raw_pid:?} exited but sched again!");
         #[allow(clippy::empty_loop)]
         loop {

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -14,6 +14,7 @@ use crate::process::kthread::{KernelThreadClosure, KernelThreadMechanism};
 use crate::process::namespace::{nsproxy::NsProxy, NamespaceOps, NamespaceType};
 use crate::process::ProcessControlBlock;
 use crate::process::ProcessManager;
+use crate::rcu::RcuOptionArcSlot;
 use crate::time::{Duration, Instant};
 use crate::{
     driver::net::napi::napi_schedule,
@@ -90,16 +91,34 @@ pub struct NetNamespace {
     unix_abstract_table: Arc<UnixAbstractTable>,
     /// Per-netns IPv4 ephemeral port range (ip_local_port_range)
     local_port_range: AtomicU32,
+    /// 当前网络命名空间的 loopback 网卡。
+    loopback_iface: RcuOptionArcSlot<LoopbackInterface>,
+    /// 当前网络命名空间的默认网卡。
+    default_iface: RcuOptionArcSlot<DefaultIfaceRef>,
 }
 
 #[derive(Debug)]
 pub struct InnerNetNamespace {
     router: Arc<Router>,
-    /// 当前网络命名空间的loopback网卡
-    loopback_iface: Option<Arc<LoopbackInterface>>,
-    /// 当前网络命名空间的默认网卡
-    /// 这个网卡会在没有指定网卡的情况下使用
-    default_iface: Option<Arc<dyn Iface>>,
+}
+
+struct DefaultIfaceRef {
+    iface: Arc<dyn Iface>,
+}
+
+impl DefaultIfaceRef {
+    fn new(iface: Arc<dyn Iface>) -> Arc<Self> {
+        Arc::new(Self { iface })
+    }
+}
+
+impl core::fmt::Debug for DefaultIfaceRef {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DefaultIfaceRef")
+            .field("nic_id", &self.iface.nic_id())
+            .field("iface_name", &self.iface.iface_name())
+            .finish()
+    }
 }
 
 #[derive(Debug)]
@@ -260,10 +279,6 @@ impl InnerNetNamespace {
     pub fn router(&self) -> &Arc<Router> {
         &self.router
     }
-
-    pub fn loopback_iface(&self) -> Option<Arc<LoopbackInterface>> {
-        self.loopback_iface.clone()
-    }
 }
 
 impl NetNamespace {
@@ -271,8 +286,6 @@ impl NetNamespace {
         let inner = InnerNetNamespace {
             // 这里没有直接创建 router，而是留到 init 函数中创建
             router: Router::new_empty(),
-            loopback_iface: None,
-            default_iface: None,
         };
 
         let ns_common = NsCommon::new(0, NamespaceType::Net);
@@ -292,6 +305,8 @@ impl NetNamespace {
             local_port_range: AtomicU32::new(
                 crate::net::socket::inet::common::port::DEFAULT_LOCAL_PORT_RANGE,
             ),
+            loopback_iface: RcuOptionArcSlot::new_none(),
+            default_iface: RcuOptionArcSlot::new_none(),
         });
 
         log::info!("Initialized root net namespace");
@@ -304,8 +319,6 @@ impl NetNamespace {
 
         let inner = InnerNetNamespace {
             router: Router::new(format!("netns_router_{}", counter)),
-            loopback_iface: Some(loopback.clone()),
-            default_iface: None,
         };
 
         let ns_common = NsCommon::new(0, NamespaceType::Net);
@@ -325,6 +338,8 @@ impl NetNamespace {
             local_port_range: AtomicU32::new(
                 crate::net::socket::inet::common::port::DEFAULT_LOCAL_PORT_RANGE,
             ),
+            loopback_iface: RcuOptionArcSlot::new_some(loopback.clone()),
+            default_iface: RcuOptionArcSlot::new_none(),
         });
 
         // Linux 语义：每个 netns 都需要一个可被唤醒的轮询线程来推进协议栈。
@@ -395,19 +410,22 @@ impl NetNamespace {
     }
 
     pub fn set_loopback_iface(&self, loopback: Arc<LoopbackInterface>) {
-        self.inner_mut().loopback_iface = Some(loopback);
+        self.loopback_iface.store_deferred(Some(loopback));
     }
 
     pub fn loopback_iface(&self) -> Option<Arc<LoopbackInterface>> {
-        self.inner().loopback_iface()
+        self.loopback_iface.load()
     }
 
     pub fn set_default_iface(&self, iface: Arc<dyn Iface>) {
-        self.inner_mut().default_iface = Some(iface);
+        self.default_iface
+            .store_deferred(Some(DefaultIfaceRef::new(iface)));
     }
 
     pub fn default_iface(&self) -> Option<Arc<dyn Iface>> {
-        self.inner().default_iface.clone()
+        self.default_iface
+            .load()
+            .map(|current| current.iface.clone())
     }
 
     pub fn router(&self) -> Arc<Router> {
@@ -441,7 +459,15 @@ impl NetNamespace {
     }
 
     pub fn remove_device(&self, nic_id: &usize) {
-        self.device_list_mut().remove(nic_id);
+        let removed = self.device_list_mut().remove(nic_id);
+        if removed.is_none() {
+            return;
+        }
+
+        self.default_iface
+            .clear_if_deferred(|current| current.iface.nic_id() == *nic_id);
+        self.loopback_iface
+            .clear_if_deferred(|current| current.nic_id() == *nic_id);
     }
 
     pub fn insert_bridge(&self, bridge: Arc<BridgeDriver>) {

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -80,6 +80,22 @@ where
     ptr: AtomicPtr<T>,
 }
 
+unsafe fn defer_drop_slot_arc_raw<T>(raw: *mut T)
+where
+    T: Send + Sync + 'static,
+{
+    if raw.is_null() {
+        return;
+    }
+
+    // SAFETY: callers pass a non-null pointer previously created by
+    // Arc::into_raw() for the slot-owned reference. Removing that pointer from
+    // an RCU-visible slot is a publication removal, so the reference must be
+    // released only after a grace period.
+    let old = unsafe { Arc::from_raw(raw) };
+    rcu_defer_drop(old);
+}
+
 impl<T> RcuArcSlot<T>
 where
     T: Send + Sync + 'static,
@@ -136,16 +152,119 @@ where
 {
     fn drop(&mut self) {
         let raw = self.ptr.swap(ptr::null_mut(), Ordering::AcqRel);
+        // SAFETY: `raw` was removed from this slot exactly once. Even though
+        // `Drop` has exclusive access to the slot, an RCU reader may have
+        // already dereferenced the old pointer and not yet pinned its own Arc.
+        unsafe { defer_drop_slot_arc_raw(raw) };
+    }
+}
+
+#[derive(Debug)]
+pub struct RcuOptionArcSlot<T>
+where
+    T: Send + Sync + 'static,
+{
+    ptr: AtomicPtr<T>,
+}
+
+impl<T> RcuOptionArcSlot<T>
+where
+    T: Send + Sync + 'static,
+{
+    pub const fn new_none() -> Self {
+        Self {
+            ptr: AtomicPtr::new(ptr::null_mut()),
+        }
+    }
+
+    pub fn new_some(initial: Arc<T>) -> Self {
+        Self {
+            ptr: AtomicPtr::new(Arc::into_raw(initial) as *mut T),
+        }
+    }
+
+    pub fn load(&self) -> Option<Arc<T>> {
+        let _guard = rcu_read_lock();
+        let raw = rcu_dereference(&self.ptr);
         if raw.is_null() {
-            return;
+            return None;
         }
 
-        // SAFETY: dropping the slot consumes the final slot-owned reference to
-        // the published Arc. Any reader that needed the object must already
-        // have pinned its own strong reference through `load()`.
+        // SAFETY: the non-null pointer is owned by the slot as an Arc raw
+        // pointer. RCU keeps the allocation alive while the read section is
+        // active, so it is safe to acquire a strong reference before leaving.
         unsafe {
-            drop(Arc::from_raw(raw));
+            Arc::increment_strong_count(raw);
+            Some(Arc::from_raw(raw))
         }
+    }
+
+    pub fn swap(&self, new: Option<Arc<T>>) -> Option<Arc<T>> {
+        let new_raw = new
+            .map(|value| Arc::into_raw(value) as *mut T)
+            .unwrap_or_default();
+        let old_raw = self.ptr.swap(new_raw, Ordering::AcqRel);
+
+        NonNull::new(old_raw).map(|old| {
+            // SAFETY: a non-null pointer in the slot was previously created by
+            // Arc::into_raw. The swap removes the slot-owned reference exactly
+            // once, so reconstructing the Arc transfers that ownership back.
+            unsafe { Arc::from_raw(old.as_ptr()) }
+        })
+    }
+
+    pub fn store_deferred(&self, new: Option<Arc<T>>) {
+        if let Some(old) = self.swap(new) {
+            rcu_defer_drop(old);
+        }
+    }
+
+    pub fn clear_if_deferred<F>(&self, mut pred: F) -> bool
+    where
+        F: FnMut(&T) -> bool,
+    {
+        loop {
+            let _guard = rcu_read_lock();
+            let raw = rcu_dereference(&self.ptr);
+            let Some(current) = NonNull::new(raw) else {
+                return false;
+            };
+
+            // SAFETY: the pointer is protected by the RCU read-side critical
+            // section. Writers that remove it must defer the final slot-owned
+            // Arc drop until after this read-side section completes.
+            let should_clear = pred(unsafe { current.as_ref() });
+            if !should_clear {
+                return false;
+            }
+
+            if self
+                .ptr
+                .compare_exchange(raw, ptr::null_mut(), Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                // SAFETY: the successful compare_exchange removed this exact
+                // slot-owned Arc reference, so reconstructing it transfers
+                // ownership for deferred drop exactly once.
+                let old = unsafe { Arc::from_raw(raw) };
+                drop(_guard);
+                rcu_defer_drop(old);
+                return true;
+            }
+        }
+    }
+}
+
+impl<T> Drop for RcuOptionArcSlot<T>
+where
+    T: Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        let raw = self.ptr.swap(ptr::null_mut(), Ordering::AcqRel);
+        // SAFETY: `raw` was removed from this slot exactly once. Dropping a
+        // slot is still a removal from an RCU-visible publication point, so the
+        // slot-owned Arc reference must be released after a grace period.
+        unsafe { defer_drop_slot_arc_raw(raw) };
     }
 }
 

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -120,6 +120,22 @@ where
         }
     }
 
+    pub fn with_read<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        if !rcu_enabled() {
+            let pinned = self.load();
+            return f(&pinned);
+        }
+
+        let _guard = rcu_read_lock();
+        let raw = rcu_dereference(&self.ptr);
+        assert!(!raw.is_null(), "RcuArcSlot::with_read saw a null pointer");
+
+        // SAFETY: RCU keeps the slot-owned Arc allocation alive for the whole
+        // read-side section. The closure receives only a shared reference and
+        // cannot outlive the guard held in this function.
+        f(unsafe { &*raw })
+    }
+
     pub fn swap(&self, new: Arc<T>) -> Arc<T> {
         let new_raw = Arc::into_raw(new) as *mut T;
         let old_raw = self.ptr.swap(new_raw, Ordering::AcqRel);

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, format, string::String, sync::Arc};
 use core::{
     ptr::{self, NonNull},
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use crate::{
@@ -316,8 +316,9 @@ fn run_pr2_selftest() -> Result<(), &'static str> {
     }
 
     drop(slot);
+    rcu_barrier();
     if new_drops.load(Ordering::SeqCst) != 1 {
-        return Err("current slot object was not dropped when the slot was destroyed");
+        return Err("current slot object was not dropped after slot destruction grace period");
     }
 
     let sighand = SigHand::new();
@@ -354,10 +355,133 @@ fn run_pr2_selftest() -> Result<(), &'static str> {
     Ok(())
 }
 
+fn run_pr3_selftest() -> Result<(), &'static str> {
+    let option_drops = Arc::new(AtomicUsize::new(0));
+    let option_replacement_drops = Arc::new(AtomicUsize::new(0));
+    let option_clear_drops = Arc::new(AtomicUsize::new(0));
+    let option_race_old_drops = Arc::new(AtomicUsize::new(0));
+    let option_race_new_drops = Arc::new(AtomicUsize::new(0));
+    let option_drop_drops = Arc::new(AtomicUsize::new(0));
+
+    let option_slot = RcuOptionArcSlot::new_none();
+    if option_slot.load().is_some() {
+        return Err("RcuOptionArcSlot::new_none did not start empty");
+    }
+
+    option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {
+        id: 3,
+        drops: option_drops.clone(),
+    })));
+    let pinned_option = option_slot
+        .load()
+        .ok_or("RcuOptionArcSlot did not publish the first object")?;
+    if pinned_option.id != 3 {
+        return Err("RcuOptionArcSlot loaded the wrong first object");
+    }
+
+    option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {
+        id: 4,
+        drops: option_replacement_drops.clone(),
+    })));
+    rcu_barrier();
+    if option_drops.load(Ordering::SeqCst) != 0 {
+        return Err("RcuOptionArcSlot dropped a pinned old object");
+    }
+    if option_slot.load().map(|value| value.id) != Some(4) {
+        return Err("RcuOptionArcSlot did not publish the replacement object");
+    }
+
+    drop(pinned_option);
+    if option_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot old object was not dropped after final pin");
+    }
+
+    option_slot.store_deferred(None);
+    rcu_barrier();
+    if option_slot.load().is_some() {
+        return Err("RcuOptionArcSlot did not clear to None");
+    }
+    if option_replacement_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot replacement object was not dropped after clear");
+    }
+
+    option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {
+        id: 5,
+        drops: option_clear_drops.clone(),
+    })));
+    if !option_slot.clear_if_deferred(|value| value.id == 5) {
+        return Err("RcuOptionArcSlot clear_if_deferred did not clear a matching object");
+    }
+    rcu_barrier();
+    if option_slot.load().is_some() {
+        return Err("RcuOptionArcSlot clear_if_deferred left a matching object published");
+    }
+    if option_clear_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot clear_if_deferred did not drop the cleared object");
+    }
+
+    option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {
+        id: 6,
+        drops: option_race_old_drops.clone(),
+    })));
+    let replaced_once = AtomicBool::new(false);
+    let cleared = option_slot.clear_if_deferred(|value| {
+        if value.id == 6 && !replaced_once.swap(true, Ordering::SeqCst) {
+            option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {
+                id: 7,
+                drops: option_race_new_drops.clone(),
+            })));
+            return true;
+        }
+
+        value.id == 6
+    });
+    if cleared {
+        return Err("RcuOptionArcSlot clear_if_deferred cleared after a racing replacement");
+    }
+    if option_slot.load().map(|value| value.id) != Some(7) {
+        return Err("RcuOptionArcSlot clear_if_deferred lost the racing replacement");
+    }
+    rcu_barrier();
+    if option_race_old_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot racing old object was not dropped");
+    }
+    if option_race_new_drops.load(Ordering::SeqCst) != 0 {
+        return Err("RcuOptionArcSlot racing replacement was dropped unexpectedly");
+    }
+
+    option_slot.store_deferred(None);
+    rcu_barrier();
+    if option_race_new_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot racing replacement was not dropped after final clear");
+    }
+
+    let drop_slot = RcuOptionArcSlot::new_some(Arc::new(RcuSelftestDropProbe {
+        id: 8,
+        drops: option_drop_drops.clone(),
+    }));
+    let pinned_drop_slot = drop_slot
+        .load()
+        .ok_or("RcuOptionArcSlot drop test did not publish an object")?;
+    drop(drop_slot);
+    rcu_barrier();
+    if option_drop_drops.load(Ordering::SeqCst) != 0 {
+        return Err("RcuOptionArcSlot drop released an object with a live reader pin");
+    }
+
+    drop(pinned_drop_slot);
+    if option_drop_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot drop object was not released after final reader pin");
+    }
+
+    Ok(())
+}
+
 pub fn run_debug_selftests() -> String {
     let pr1 = run_pr1_selftest();
     let pr2 = run_pr2_selftest();
-    let overall_ok = pr1.is_ok() && pr2.is_ok();
+    let pr3 = run_pr3_selftest();
+    let overall_ok = pr1.is_ok() && pr2.is_ok() && pr3.is_ok();
 
     let mut report = String::new();
     report.push_str(if overall_ok {
@@ -374,6 +498,11 @@ pub fn run_debug_selftests() -> String {
     match pr2 {
         Ok(()) => report.push_str("pr2=ok\n"),
         Err(reason) => report.push_str(&format!("pr2=fail:{reason}\n")),
+    }
+
+    match pr3 {
+        Ok(()) => report.push_str("pr3=ok\n"),
+        Err(reason) => report.push_str(&format!("pr3=fail:{reason}\n")),
     }
 
     report

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -8,10 +8,7 @@ use core::{
 use crate::{
     ipc::sighand::SigHand,
     libs::{
-        notifier::{
-            AtomicNotifierChain, NotifierBlock, NOTIFY_DONE, NOTIFY_OK, NOTIFY_STOP,
-            NOTIFY_STOP_MASK,
-        },
+        notifier::{AtomicNotifierChain, NotifierBlock, NotifyResult},
         spinlock::SpinLock,
     },
     smp::{core::smp_get_processor_id, cpu::ProcessorId},
@@ -56,7 +53,7 @@ impl RcuSelftestNotifier {
 impl NotifierBlock<RcuSelftestNotifyEvent, usize> for RcuSelftestNotifier {
     fn notifier_call(&self, _action: RcuSelftestNotifyEvent, data: Option<&usize>) -> i32 {
         if data != Some(&42) {
-            return NOTIFY_STOP;
+            return NotifyResult::STOP.bits();
         }
 
         self.order.lock_irqsave().push(self.id);
@@ -88,7 +85,7 @@ impl NotifierBlock<RcuSelftestNotifyEvent, usize> for RcuSelftestReentrantUnregi
         let target = self.target.lock_irqsave().clone();
         let Some(target) = target else {
             self.result.store(3, Ordering::SeqCst);
-            return NOTIFY_DONE;
+            return NotifyResult::DONE.bits();
         };
 
         match self.chain.unregister(target) {
@@ -96,7 +93,7 @@ impl NotifierBlock<RcuSelftestNotifyEvent, usize> for RcuSelftestReentrantUnregi
             _ => self.result.store(3, Ordering::SeqCst),
         }
 
-        NOTIFY_DONE
+        NotifyResult::DONE.bits()
     }
 
     fn priority(&self) -> i32 {
@@ -620,14 +617,30 @@ fn run_pr5_selftest() -> Result<(), &'static str> {
     let order = Arc::new(SpinLock::new(Vec::new()));
     let data = 42;
 
-    let high: Arc<RcuSelftestNotifierBlock> =
-        Arc::new(RcuSelftestNotifier::new(1, 20, NOTIFY_OK, order.clone()));
-    let low: Arc<RcuSelftestNotifierBlock> =
-        Arc::new(RcuSelftestNotifier::new(2, 10, NOTIFY_DONE, order.clone()));
-    let same_prio: Arc<RcuSelftestNotifierBlock> =
-        Arc::new(RcuSelftestNotifier::new(3, 20, NOTIFY_DONE, order.clone()));
-    let stop: Arc<RcuSelftestNotifierBlock> =
-        Arc::new(RcuSelftestNotifier::new(4, 15, NOTIFY_STOP, order.clone()));
+    let high: Arc<RcuSelftestNotifierBlock> = Arc::new(RcuSelftestNotifier::new(
+        1,
+        20,
+        NotifyResult::OK.bits(),
+        order.clone(),
+    ));
+    let low: Arc<RcuSelftestNotifierBlock> = Arc::new(RcuSelftestNotifier::new(
+        2,
+        10,
+        NotifyResult::DONE.bits(),
+        order.clone(),
+    ));
+    let same_prio: Arc<RcuSelftestNotifierBlock> = Arc::new(RcuSelftestNotifier::new(
+        3,
+        20,
+        NotifyResult::DONE.bits(),
+        order.clone(),
+    ));
+    let stop: Arc<RcuSelftestNotifierBlock> = Arc::new(RcuSelftestNotifier::new(
+        4,
+        15,
+        NotifyResult::STOP.bits(),
+        order.clone(),
+    ));
 
     chain
         .register(low.clone())
@@ -647,7 +660,7 @@ fn run_pr5_selftest() -> Result<(), &'static str> {
     }
 
     let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), None);
-    if ret != NOTIFY_DONE || nr_calls != 2 {
+    if ret != NotifyResult::DONE.bits() || nr_calls != 2 {
         return Err("atomic notifier full call_chain returned the wrong result");
     }
     check_notifier_order(
@@ -658,7 +671,7 @@ fn run_pr5_selftest() -> Result<(), &'static str> {
 
     clear_notifier_order(&order);
     let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), Some(1));
-    if ret != NOTIFY_OK || nr_calls != 1 {
+    if ret != NotifyResult::OK.bits() || nr_calls != 1 {
         return Err("atomic notifier nr_to_call did not stop after one callback");
     }
     check_notifier_order(
@@ -673,7 +686,10 @@ fn run_pr5_selftest() -> Result<(), &'static str> {
 
     clear_notifier_order(&order);
     let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), None);
-    if ret & NOTIFY_STOP_MASK == 0 || ret != NOTIFY_STOP || nr_calls != 2 {
+    if !NotifyResult::from_bits_truncate(ret).contains(NotifyResult::STOP_MASK)
+        || ret != NotifyResult::STOP.bits()
+        || nr_calls != 2
+    {
         return Err("atomic notifier did not honor NOTIFY_STOP_MASK");
     }
     check_notifier_order(
@@ -688,7 +704,7 @@ fn run_pr5_selftest() -> Result<(), &'static str> {
 
     clear_notifier_order(&order);
     let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), None);
-    if ret != NOTIFY_DONE || nr_calls != 2 {
+    if ret != NotifyResult::DONE.bits() || nr_calls != 2 {
         return Err("atomic notifier unregister did not publish the replacement snapshot");
     }
     check_notifier_order(

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -1,13 +1,22 @@
-use alloc::{boxed::Box, format, string::String, sync::Arc};
+use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{
+    fmt::Debug,
     ptr::{self, NonNull},
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use crate::{
     ipc::sighand::SigHand,
+    libs::{
+        notifier::{
+            AtomicNotifierChain, NotifierBlock, NOTIFY_DONE, NOTIFY_OK, NOTIFY_STOP,
+            NOTIFY_STOP_MASK,
+        },
+        spinlock::SpinLock,
+    },
     smp::{core::smp_get_processor_id, cpu::ProcessorId},
 };
+use system_error::SystemError;
 
 use super::*;
 
@@ -15,6 +24,84 @@ use super::*;
 struct RcuSelftestDropProbe {
     id: usize,
     drops: Arc<AtomicUsize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RcuSelftestNotifyEvent {
+    Ping,
+}
+
+type RcuSelftestAtomicNotifierChain = AtomicNotifierChain<RcuSelftestNotifyEvent, usize>;
+type RcuSelftestNotifierBlock = dyn NotifierBlock<RcuSelftestNotifyEvent, usize>;
+
+#[derive(Debug)]
+struct RcuSelftestNotifier {
+    id: usize,
+    priority: i32,
+    ret: i32,
+    order: Arc<SpinLock<Vec<usize>>>,
+}
+
+impl RcuSelftestNotifier {
+    fn new(id: usize, priority: i32, ret: i32, order: Arc<SpinLock<Vec<usize>>>) -> Self {
+        Self {
+            id,
+            priority,
+            ret,
+            order,
+        }
+    }
+}
+
+impl NotifierBlock<RcuSelftestNotifyEvent, usize> for RcuSelftestNotifier {
+    fn notifier_call(&self, _action: RcuSelftestNotifyEvent, data: Option<&usize>) -> i32 {
+        if data != Some(&42) {
+            return NOTIFY_STOP;
+        }
+
+        self.order.lock_irqsave().push(self.id);
+        self.ret
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
+    }
+}
+
+struct RcuSelftestReentrantUnregisterNotifier {
+    priority: i32,
+    chain: Arc<RcuSelftestAtomicNotifierChain>,
+    target: SpinLock<Option<Arc<RcuSelftestNotifierBlock>>>,
+    result: Arc<AtomicUsize>,
+}
+
+impl Debug for RcuSelftestReentrantUnregisterNotifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RcuSelftestReentrantUnregisterNotifier")
+            .field("priority", &self.priority)
+            .finish_non_exhaustive()
+    }
+}
+
+impl NotifierBlock<RcuSelftestNotifyEvent, usize> for RcuSelftestReentrantUnregisterNotifier {
+    fn notifier_call(&self, _action: RcuSelftestNotifyEvent, _data: Option<&usize>) -> i32 {
+        let target = self.target.lock_irqsave().clone();
+        let Some(target) = target else {
+            self.result.store(3, Ordering::SeqCst);
+            return NOTIFY_DONE;
+        };
+
+        match self.chain.unregister(target) {
+            Err(SystemError::EDEADLK_OR_EDEADLOCK) => self.result.store(1, Ordering::SeqCst),
+            _ => self.result.store(3, Ordering::SeqCst),
+        }
+
+        NOTIFY_DONE
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
+    }
 }
 
 impl Drop for RcuSelftestDropProbe {
@@ -321,6 +408,40 @@ fn run_pr2_selftest() -> Result<(), &'static str> {
         return Err("current slot object was not dropped after slot destruction grace period");
     }
 
+    let with_read_old_drops = Arc::new(AtomicUsize::new(0));
+    let with_read_new_drops = Arc::new(AtomicUsize::new(0));
+    let with_read_slot = RcuArcSlot::new(Arc::new(RcuSelftestDropProbe {
+        id: 9,
+        drops: with_read_old_drops.clone(),
+    }));
+
+    let observed_id = with_read_slot.with_read(|old| {
+        with_read_slot.store_deferred(Arc::new(RcuSelftestDropProbe {
+            id: 10,
+            drops: with_read_new_drops.clone(),
+        }));
+
+        if with_read_old_drops.load(Ordering::SeqCst) != 0 {
+            return 0;
+        }
+
+        old.id
+    });
+    if observed_id != 9 {
+        return Err("RcuArcSlot::with_read did not pin the old snapshot during replacement");
+    }
+
+    rcu_barrier();
+    if with_read_old_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuArcSlot::with_read old snapshot was not dropped after the read section");
+    }
+
+    drop(with_read_slot);
+    rcu_barrier();
+    if with_read_new_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuArcSlot::with_read replacement snapshot was not dropped after slot drop");
+    }
+
     let sighand = SigHand::new();
     if sighand.is_shared() {
         return Err("fresh sighand unexpectedly reported shared");
@@ -477,11 +598,143 @@ fn run_pr3_selftest() -> Result<(), &'static str> {
     Ok(())
 }
 
+fn check_notifier_order(
+    order: &Arc<SpinLock<Vec<usize>>>,
+    expected: &[usize],
+    reason: &'static str,
+) -> Result<(), &'static str> {
+    let observed = order.lock_irqsave().clone();
+    if observed.as_slice() != expected {
+        return Err(reason);
+    }
+
+    Ok(())
+}
+
+fn clear_notifier_order(order: &Arc<SpinLock<Vec<usize>>>) {
+    order.lock_irqsave().clear();
+}
+
+fn run_pr5_selftest() -> Result<(), &'static str> {
+    let chain = Arc::new(RcuSelftestAtomicNotifierChain::new());
+    let order = Arc::new(SpinLock::new(Vec::new()));
+    let data = 42;
+
+    let high: Arc<RcuSelftestNotifierBlock> =
+        Arc::new(RcuSelftestNotifier::new(1, 20, NOTIFY_OK, order.clone()));
+    let low: Arc<RcuSelftestNotifierBlock> =
+        Arc::new(RcuSelftestNotifier::new(2, 10, NOTIFY_DONE, order.clone()));
+    let same_prio: Arc<RcuSelftestNotifierBlock> =
+        Arc::new(RcuSelftestNotifier::new(3, 20, NOTIFY_DONE, order.clone()));
+    let stop: Arc<RcuSelftestNotifierBlock> =
+        Arc::new(RcuSelftestNotifier::new(4, 15, NOTIFY_STOP, order.clone()));
+
+    chain
+        .register(low.clone())
+        .map_err(|_| "atomic notifier failed to register the low-priority block")?;
+    chain
+        .register(high.clone())
+        .map_err(|_| "atomic notifier failed to register the high-priority block")?;
+
+    match chain.register(high.clone()) {
+        Err(SystemError::EEXIST) => {}
+        _ => return Err("atomic notifier accepted a duplicated block registration"),
+    }
+
+    match chain.register_unique_prio(same_prio.clone()) {
+        Err(SystemError::EBUSY) => {}
+        _ => return Err("atomic notifier accepted a duplicate unique priority"),
+    }
+
+    let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), None);
+    if ret != NOTIFY_DONE || nr_calls != 2 {
+        return Err("atomic notifier full call_chain returned the wrong result");
+    }
+    check_notifier_order(
+        &order,
+        &[1, 2],
+        "atomic notifier did not dispatch in priority order",
+    )?;
+
+    clear_notifier_order(&order);
+    let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), Some(1));
+    if ret != NOTIFY_OK || nr_calls != 1 {
+        return Err("atomic notifier nr_to_call did not stop after one callback");
+    }
+    check_notifier_order(
+        &order,
+        &[1],
+        "atomic notifier nr_to_call dispatched the wrong callbacks",
+    )?;
+
+    chain
+        .register(stop.clone())
+        .map_err(|_| "atomic notifier failed to register the stop block")?;
+
+    clear_notifier_order(&order);
+    let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), None);
+    if ret & NOTIFY_STOP_MASK == 0 || ret != NOTIFY_STOP || nr_calls != 2 {
+        return Err("atomic notifier did not honor NOTIFY_STOP_MASK");
+    }
+    check_notifier_order(
+        &order,
+        &[1, 4],
+        "atomic notifier continued after a NOTIFY_STOP result",
+    )?;
+
+    chain
+        .unregister(stop.clone())
+        .map_err(|_| "atomic notifier failed to unregister the stop block")?;
+
+    clear_notifier_order(&order);
+    let (ret, nr_calls) = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), None);
+    if ret != NOTIFY_DONE || nr_calls != 2 {
+        return Err("atomic notifier unregister did not publish the replacement snapshot");
+    }
+    check_notifier_order(
+        &order,
+        &[1, 2],
+        "atomic notifier still dispatched an unregistered block",
+    )?;
+
+    let reentrant_result = Arc::new(AtomicUsize::new(0));
+    let reentrant = Arc::new(RcuSelftestReentrantUnregisterNotifier {
+        priority: 30,
+        chain: chain.clone(),
+        target: SpinLock::new(None),
+        result: reentrant_result.clone(),
+    });
+    let reentrant_block: Arc<RcuSelftestNotifierBlock> = reentrant.clone();
+    *reentrant.target.lock_irqsave() = Some(reentrant_block.clone());
+
+    chain
+        .register(reentrant_block.clone())
+        .map_err(|_| "atomic notifier failed to register the reentrant block")?;
+
+    let _ = chain.call_chain(RcuSelftestNotifyEvent::Ping, Some(&data), Some(1));
+    if reentrant_result.load(Ordering::SeqCst) != 1 {
+        return Err("atomic notifier unregister from call_chain did not return EDEADLK");
+    }
+
+    chain
+        .unregister(reentrant_block)
+        .map_err(|_| "atomic notifier failed to unregister the reentrant block afterward")?;
+    chain
+        .unregister(high)
+        .map_err(|_| "atomic notifier failed to unregister the high-priority block")?;
+    chain
+        .unregister(low)
+        .map_err(|_| "atomic notifier failed to unregister the low-priority block")?;
+
+    Ok(())
+}
+
 pub fn run_debug_selftests() -> String {
     let pr1 = run_pr1_selftest();
     let pr2 = run_pr2_selftest();
     let pr3 = run_pr3_selftest();
-    let overall_ok = pr1.is_ok() && pr2.is_ok() && pr3.is_ok();
+    let pr5 = run_pr5_selftest();
+    let overall_ok = pr1.is_ok() && pr2.is_ok() && pr3.is_ok() && pr5.is_ok();
 
     let mut report = String::new();
     report.push_str(if overall_ok {
@@ -503,6 +756,11 @@ pub fn run_debug_selftests() -> String {
     match pr3 {
         Ok(()) => report.push_str("pr3=ok\n"),
         Err(reason) => report.push_str(&format!("pr3=fail:{reason}\n")),
+    }
+
+    match pr5 {
+        Ok(()) => report.push_str("pr5=ok\n"),
+        Err(reason) => report.push_str(&format!("pr5=fail:{reason}\n")),
     }
 
     report

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1077,6 +1077,14 @@ pub fn io_schedule() {
 /// 此函数与schedule的区别为，该函数不会检查preempt_count
 /// 适用于时钟中断等场景
 pub fn __schedule(sched_mod: SchedMode) {
+    __schedule_inner(sched_mod, None);
+}
+
+pub(crate) fn __schedule_with_current(sched_mod: SchedMode, current: Arc<ProcessControlBlock>) {
+    __schedule_inner(sched_mod, Some(current));
+}
+
+fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBlock>>) {
     // 中断/IPI 路径上的抢占调度请求在 preempt_count 非零时不能直接切走当前任务，
     // 否则会破坏依赖 preempt_disable() 的临界区（例如当前 RCU 实现的读侧临界区）。
     if sched_mod.contains(SchedMode::SM_MASK_PREEMPT) {
@@ -1091,11 +1099,20 @@ pub fn __schedule(sched_mod: SchedMode) {
     let cpu = smp_get_processor_id().data() as usize;
     let rq = cpu_rq(cpu);
     let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-    let mut prev = rq.current();
-    if let ProcessState::Exited(_) = prev.clone().sched_info().inner_lock_read_irqsave().state() {
-        // 从exit进的Schedule
-        prev = ProcessManager::current_pcb();
-    }
+    let prev = match current {
+        Some(current) => current,
+        None => {
+            let prev = rq.current();
+            if let ProcessState::Exited(_) =
+                prev.clone().sched_info().inner_lock_read_irqsave().state()
+            {
+                // 从exit进的Schedule
+                ProcessManager::current_pcb()
+            } else {
+                prev
+            }
+        }
+    };
 
     // TODO: hrtick_clear(rq);
 

--- a/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
@@ -44,6 +44,8 @@ void ExpectReportOk(const std::string& report) {
     EXPECT_NE(std::string::npos, report.find("status=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr1=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr2=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("pr3=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("pr5=ok\n")) << report;
 }
 
 }  // namespace


### PR DESCRIPTION
- Add RcuOptionArcSlot for thread-safe interface management
- Replace direct Arc fields with RCU-protected slots in NetNamespace
- Implement new DefaultIfaceRef wrapper for default interface
- Add self-tests for RcuOptionArcSlot functionality