### PR TITLE
fix(net): reset post-close TCP data for orphaned streams

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1543,7 +1543,7 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 [[package]]
 name = "smoltcp"
 version = "0.12.0"
-source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/smoltcp?rev=5a73cad#5a73cad31a0bb7b5df0166894cc619181ab1ab4d"
+source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/smoltcp?rev=c65e776#c65e7763d4497b2e685269cc568d09300392b47a"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -59,7 +59,7 @@ linkme = "=0.3.27"
 num = { version = "=0.4.0", default-features = false }
 num-derive = "=0.3"
 num-traits = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/num-traits.git", rev = "1597c1c", default-features = false }
-smoltcp = { version = "=0.12.0", git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/smoltcp", rev = "5a73cad", default-features = false, features = [
+smoltcp = { version = "=0.12.0", git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/smoltcp", rev = "c65e776", default-features = false, features = [
     "alloc",
     "medium-ethernet",
     "socket-raw",

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -340,14 +340,9 @@ impl IfaceCommon {
     }
 
     /// Defer removing a TCP socket from the SocketSet until it reaches Closed.
-    pub fn defer_tcp_close(
-        &self,
-        handle: smoltcp::iface::SocketHandle,
-        local_port: u16,
-        sock: alloc::sync::Weak<dyn crate::net::socket::inet::InetSocket>,
-    ) {
-        self.tcp_close_defer
-            .defer_tcp_close(handle, local_port, sock);
+    pub fn defer_tcp_close(&self, request: crate::net::tcp_close_defer::DeferredTcpCloseRequest) {
+        let now = crate::time::Instant::now().into();
+        self.tcp_close_defer.defer_tcp_close(now, request);
     }
 
     pub fn poll<D>(&self, device: &mut D) -> bool
@@ -365,6 +360,11 @@ impl IfaceCommon {
         let (has_events, poll_at) = {
             let poll_result = interface.poll(timestamp, device, &mut sockets);
 
+            // Reclaim/advance orphaned TCP sockets after smoltcp has processed ingress.
+            // If this aborts an orphan, compute poll_at afterwards so the pending RST is
+            // scheduled immediately instead of waiting for an unrelated future poll.
+            self.tcp_close_defer.reap_closed(timestamp, &mut sockets);
+
             (
                 matches!(poll_result, smoltcp::iface::PollResult::SocketStateChanged),
                 {
@@ -381,10 +381,6 @@ impl IfaceCommon {
                 },
             )
         };
-
-        // Reclaim TCP sockets that have fully closed.
-        // Lock order: sockets -> tcp_close_defer (matches close path, which may touch sockets then defer close).
-        self.tcp_close_defer.reap_closed(&mut sockets);
 
         // drop sockets here to avoid deadlock
         drop(interface);

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -1,6 +1,9 @@
 use crate::net::socket::common::ShutdownBit;
 use crate::net::socket::inet::InetSocket;
 use crate::net::socket::inet::Types;
+use crate::net::tcp_close_defer::{
+    DeferredTcpCloseKind, DeferredTcpCloseReason, DeferredTcpCloseRequest,
+};
 use alloc::sync::Arc;
 use system_error::SystemError;
 
@@ -15,17 +18,10 @@ struct CloseObservation {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EstablishedCloseDisposition {
-    Abort,
-    GracefulPendingDecision,
-    PreserveGracefulState,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EstablishedCloseStateClass {
-    PendingDecision,
-    GracefulInProgress,
-    Closed,
+struct CloseAction {
+    kind: DeferredTcpCloseKind,
+    reason: DeferredTcpCloseReason,
+    abort_on_post_close_data: bool,
 }
 
 impl TcpSocket {
@@ -37,77 +33,35 @@ impl TcpSocket {
         })
     }
 
-    fn decide_established_close(
-        &self,
-        established: &inner::Established,
-    ) -> EstablishedCloseDisposition {
-        let initial = Self::observe_established_close(established);
+    fn decide_established_close(&self, established: &inner::Established) -> CloseAction {
+        let observation = Self::observe_established_close(established);
 
-        if initial.unread > 0 {
-            return EstablishedCloseDisposition::Abort;
+        if observation.unread > 0 {
+            return CloseAction {
+                kind: DeferredTcpCloseKind::Reset,
+                reason: DeferredTcpCloseReason::UnreadDataOnClose,
+                abort_on_post_close_data: false,
+            };
         }
 
-        if self.should_abort_established_zero_linger(initial.state) {
-            return EstablishedCloseDisposition::Abort;
+        if self.should_abort_established_zero_linger(observation.state) {
+            return CloseAction {
+                kind: DeferredTcpCloseKind::Reset,
+                reason: DeferredTcpCloseReason::ZeroLinger,
+                abort_on_post_close_data: false,
+            };
         }
 
-        if matches!(
-            Self::classify_established_close_state(initial.state),
-            EstablishedCloseStateClass::GracefulInProgress | EstablishedCloseStateClass::Closed
-        ) {
-            return EstablishedCloseDisposition::PreserveGracefulState;
+        let abort_on_post_close_data = matches!(
+            observation.state,
+            smoltcp::socket::tcp::State::Established | smoltcp::socket::tcp::State::SynReceived
+        );
+
+        CloseAction {
+            kind: DeferredTcpCloseKind::GracefulFin,
+            reason: DeferredTcpCloseReason::NormalClose,
+            abort_on_post_close_data,
         }
-
-        // Linux `__tcp_close()` decides between FIN and active reset based on whether unread
-        // data is discarded. DragonOS loopback can race with in-flight protocol progress around
-        // close time, so a single `recv_queue()` snapshot is too weak. Require two consecutive
-        // identical zero-unread observations after quiescent polls; otherwise fall back to abort.
-        // Only apply this when `close(fd)` is still deciding whether to initiate graceful close
-        // or abort. If the socket is already in graceful-closing states, preserve that path.
-        let iface = established.iface().clone();
-        let mut last: Option<CloseObservation> = Some(initial);
-        let mut stable_zero_observations = 0usize;
-        const MAX_CLOSE_SAMPLING_ROUNDS: usize = 4;
-
-        for round in 0..MAX_CLOSE_SAMPLING_ROUNDS {
-            if let Some(netns) = iface.common().net_namespace() {
-                netns.wakeup_poll_thread();
-            }
-            poll_util::poll_iface_until_quiescent(iface.as_ref());
-
-            let observation = Self::observe_established_close(established);
-            if observation.unread > 0 {
-                return EstablishedCloseDisposition::Abort;
-            }
-
-            if self.should_abort_established_zero_linger(observation.state) {
-                return EstablishedCloseDisposition::Abort;
-            }
-
-            match Self::classify_established_close_state(observation.state) {
-                EstablishedCloseStateClass::GracefulInProgress
-                | EstablishedCloseStateClass::Closed => {
-                    return EstablishedCloseDisposition::PreserveGracefulState;
-                }
-                EstablishedCloseStateClass::PendingDecision => {}
-            }
-
-            if last == Some(observation) {
-                stable_zero_observations += 1;
-                if stable_zero_observations >= 1 {
-                    return EstablishedCloseDisposition::GracefulPendingDecision;
-                }
-            } else {
-                stable_zero_observations = 0;
-            }
-            last = Some(observation);
-
-            if round + 1 < MAX_CLOSE_SAMPLING_ROUNDS {
-                crate::sched::sched_yield();
-            }
-        }
-
-        EstablishedCloseDisposition::Abort
     }
 
     #[inline]
@@ -138,28 +92,14 @@ impl TcpSocket {
     }
 
     #[inline]
-    fn classify_established_close_state(
-        state: smoltcp::socket::tcp::State,
-    ) -> EstablishedCloseStateClass {
-        match state {
-            smoltcp::socket::tcp::State::FinWait1
-            | smoltcp::socket::tcp::State::FinWait2
-            | smoltcp::socket::tcp::State::Closing
-            | smoltcp::socket::tcp::State::LastAck
-            | smoltcp::socket::tcp::State::TimeWait => {
-                EstablishedCloseStateClass::GracefulInProgress
-            }
-            smoltcp::socket::tcp::State::Closed => EstablishedCloseStateClass::Closed,
-            smoltcp::socket::tcp::State::SynReceived
-            | smoltcp::socket::tcp::State::Established
-            | smoltcp::socket::tcp::State::CloseWait => EstablishedCloseStateClass::PendingDecision,
-            unexpected => {
-                debug_assert!(
-                    false,
-                    "unexpected established close state: {:?}",
-                    unexpected
-                );
-                EstablishedCloseStateClass::PendingDecision
+    fn apply_close_action(socket: &mut smoltcp::socket::tcp::Socket, action: CloseAction) {
+        match action.kind {
+            DeferredTcpCloseKind::Reset => socket.abort(),
+            DeferredTcpCloseKind::GracefulFin => {
+                if action.abort_on_post_close_data {
+                    socket.shutdown_recv();
+                }
+                socket.close();
             }
         }
     }
@@ -667,11 +607,20 @@ impl TcpSocket {
                     let local_port = conn.get_name().port;
                     let iface = conn.iface().clone();
                     let me: alloc::sync::Weak<dyn InetSocket> = self.self_ref.clone();
-                    conn.with_mut(|socket| socket.close());
+                    conn.with_mut(|socket| socket.abort());
+                    let initial_state = conn.with(|socket| socket.state());
                     if conn.owns_port() {
                         iface.port_manager().unbind_port(Types::Tcp, local_port);
                     }
-                    iface.common().defer_tcp_close(handle, local_port, me);
+                    iface.common().defer_tcp_close(DeferredTcpCloseRequest {
+                        handle,
+                        local_port,
+                        sock: me,
+                        initial_state,
+                        kind: DeferredTcpCloseKind::Reset,
+                        reason: DeferredTcpCloseReason::ConnectingClose,
+                        abort_on_post_close_data: false,
+                    });
                     post_poll_iface = Some(iface);
                     writer.replace(inner::Inner::Established(conn));
                 }
@@ -681,27 +630,21 @@ impl TcpSocket {
                 let local_port = es.get_name().port;
                 let iface = es.iface().clone();
                 let me: alloc::sync::Weak<dyn InetSocket> = self.self_ref.clone();
-                let close_disposition = self.decide_established_close(&es);
-                match close_disposition {
-                    EstablishedCloseDisposition::Abort => {
-                        es.with_mut(|socket| socket.abort());
-                    }
-                    EstablishedCloseDisposition::GracefulPendingDecision
-                    | EstablishedCloseDisposition::PreserveGracefulState => {
-                        let final_observation = Self::observe_established_close(&es);
-                        if final_observation.unread > 0
-                            || self.should_abort_established_zero_linger(final_observation.state)
-                        {
-                            es.with_mut(|socket| socket.abort());
-                        } else {
-                            es.with_mut(|socket| socket.close());
-                        }
-                    }
-                }
+                let close_action = self.decide_established_close(&es);
+                es.with_mut(|socket| Self::apply_close_action(socket, close_action));
+                let initial_state = es.with(|socket| socket.state());
                 if es.owns_port() {
                     iface.port_manager().unbind_port(Types::Tcp, local_port);
                 }
-                iface.common().defer_tcp_close(handle, local_port, me);
+                iface.common().defer_tcp_close(DeferredTcpCloseRequest {
+                    handle,
+                    local_port,
+                    sock: me,
+                    initial_state,
+                    kind: close_action.kind,
+                    reason: close_action.reason,
+                    abort_on_post_close_data: close_action.abort_on_post_close_data,
+                });
                 post_poll_iface = Some(iface);
                 writer.replace(inner::Inner::Established(es));
             }

--- a/kernel/src/net/tcp_close_defer.rs
+++ b/kernel/src/net/tcp_close_defer.rs
@@ -15,10 +15,52 @@ use alloc::vec::Vec;
 use crate::libs::mutex::Mutex;
 use crate::net::socket::inet::InetSocket;
 
+const TCP_ORPHAN_MAX_LIFETIME_SECS: u64 = 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeferredTcpCloseKind {
+    GracefulFin,
+    Reset,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeferredTcpCloseReason {
+    NormalClose,
+    ZeroLinger,
+    UnreadDataOnClose,
+    PostCloseData,
+    OrphanTimeout,
+    ConnectingClose,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TcpCloseDeferStats {
+    pub current: usize,
+    pub graceful_deferred: usize,
+    pub reset_deferred: usize,
+    pub unread_abort: usize,
+    pub zero_linger_abort: usize,
+    pub post_close_data_abort: usize,
+    pub orphan_timeout_abort: usize,
+    pub closed_reaped: usize,
+    pub reset_pending_dropped: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeferredTcpCloseRequest {
+    pub handle: smoltcp::iface::SocketHandle,
+    pub local_port: u16,
+    pub sock: Weak<dyn InetSocket>,
+    pub initial_state: smoltcp::socket::tcp::State,
+    pub kind: DeferredTcpCloseKind,
+    pub reason: DeferredTcpCloseReason,
+    pub abort_on_post_close_data: bool,
+}
+
 #[derive(Debug, Clone)]
 struct ClosingTcpSocket {
     handle: smoltcp::iface::SocketHandle,
-    local_port: u16,
+    _local_port: u16,
     /// 对应的内核 TcpSocket（或其 trait object）。
     ///
     /// 目的：避免并发窗口——当 handle 已从 SocketSet remove 后，仍有在途引用调用
@@ -26,63 +68,148 @@ struct ClosingTcpSocket {
     ///
     /// 只有当 Weak 无法 upgrade（说明 socket 对象已彻底释放）时，才允许回收 handle。
     sock: Weak<dyn InetSocket>,
+    deferred_at: smoltcp::time::Instant,
+    last_state: smoltcp::socket::tcp::State,
+    _state_since: smoltcp::time::Instant,
+    _kind: DeferredTcpCloseKind,
+    _reason: DeferredTcpCloseReason,
+    abort_on_post_close_data: bool,
 }
 
 /// 延迟回收 TCP sockets：close(fd) 后不立刻从 SocketSet 移除，等状态机 Closed 再回收。
 #[derive(Debug)]
 pub struct TcpCloseDefer {
     closing: Mutex<Vec<ClosingTcpSocket>>,
+    stats: Mutex<TcpCloseDeferStats>,
 }
 
 impl TcpCloseDefer {
     pub fn new() -> Self {
         Self {
             closing: Mutex::new(Vec::new()),
+            stats: Mutex::new(TcpCloseDeferStats::default()),
         }
     }
 
     #[inline]
-    pub fn defer_tcp_close(
-        &self,
-        handle: smoltcp::iface::SocketHandle,
-        local_port: u16,
-        sock: Weak<dyn InetSocket>,
-    ) {
+    pub fn defer_tcp_close(&self, now: smoltcp::time::Instant, request: DeferredTcpCloseRequest) {
         let mut guard = self.closing.lock();
         guard.push(ClosingTcpSocket {
-            handle,
-            local_port,
-            sock,
+            handle: request.handle,
+            _local_port: request.local_port,
+            sock: request.sock,
+            deferred_at: now,
+            last_state: request.initial_state,
+            _state_since: now,
+            _kind: request.kind,
+            _reason: request.reason,
+            abort_on_post_close_data: request.abort_on_post_close_data,
         });
+        drop(guard);
+
+        let mut stats = self.stats.lock();
+        stats.current += 1;
+        match request.kind {
+            DeferredTcpCloseKind::GracefulFin => stats.graceful_deferred += 1,
+            DeferredTcpCloseKind::Reset => stats.reset_deferred += 1,
+        }
+        match request.reason {
+            DeferredTcpCloseReason::UnreadDataOnClose => stats.unread_abort += 1,
+            DeferredTcpCloseReason::ZeroLinger => stats.zero_linger_abort += 1,
+            _ => {}
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub fn stats(&self) -> TcpCloseDeferStats {
+        let current = self.closing.lock().len();
+        let mut stats = *self.stats.lock();
+        stats.current = current;
+        stats
     }
 
     /// 在持有 `SocketSet` 锁的前提下，回收已进入 Closed 的 TCP sockets。
     ///
     /// 重要：
     /// - 锁顺序必须保持为：`SocketSet` -> `TcpCloseDefer::closing`，避免与 close 路径反转。
-    pub fn reap_closed(&self, sockets: &mut smoltcp::iface::SocketSet<'static>) {
+    pub fn reap_closed(
+        &self,
+        now: smoltcp::time::Instant,
+        sockets: &mut smoltcp::iface::SocketSet<'static>,
+    ) {
         let mut closing = self.closing.lock();
         if closing.is_empty() {
             return;
         }
         let mut i = 0;
         while i < closing.len() {
-            let ClosingTcpSocket {
-                handle,
-                local_port: _local_port,
-                ref sock,
-            } = closing[i];
+            let handle = closing[i].handle;
             let state = sockets.get::<smoltcp::socket::tcp::Socket>(handle).state();
+            if state != closing[i].last_state {
+                closing[i].last_state = state;
+                closing[i]._state_since = now;
+            }
+
+            let age = now - closing[i].deferred_at;
+            let orphan_timed_out =
+                age >= smoltcp::time::Duration::from_secs(TCP_ORPHAN_MAX_LIFETIME_SECS);
+
+            let should_abort_post_close_data = closing[i].abort_on_post_close_data
+                && !matches!(state, smoltcp::socket::tcp::State::Closed)
+                && sockets
+                    .get::<smoltcp::socket::tcp::Socket>(handle)
+                    .recv_queue()
+                    > 0;
+
+            if should_abort_post_close_data
+                || (orphan_timed_out && !matches!(state, smoltcp::socket::tcp::State::Closed))
+            {
+                sockets
+                    .get_mut::<smoltcp::socket::tcp::Socket>(handle)
+                    .abort();
+                closing[i]._kind = DeferredTcpCloseKind::Reset;
+                closing[i]._reason = if should_abort_post_close_data {
+                    DeferredTcpCloseReason::PostCloseData
+                } else {
+                    DeferredTcpCloseReason::OrphanTimeout
+                };
+                closing[i].abort_on_post_close_data = false;
+
+                let mut stats = self.stats.lock();
+                if should_abort_post_close_data {
+                    stats.post_close_data_abort += 1;
+                } else {
+                    stats.orphan_timeout_abort += 1;
+                }
+                i += 1;
+                continue;
+            }
+
             if matches!(state, smoltcp::socket::tcp::State::Closed) {
+                let rst_pending = sockets
+                    .get::<smoltcp::socket::tcp::Socket>(handle)
+                    .remote_endpoint()
+                    .is_some();
+                if rst_pending && !orphan_timed_out {
+                    i += 1;
+                    continue;
+                }
+
                 // 关键：若仍存在在途引用（Weak 可 upgrade），则暂不回收 handle。
                 // 否则在 handle remove 后，update_events()/poll/notify 仍可能访问该 handle，
                 // 触发 smoltcp 的 "handle does not refer to a valid socket" panic。
-                if sock.upgrade().is_some() {
+                if closing[i].sock.upgrade().is_some() {
                     i += 1;
                     continue;
                 }
                 sockets.remove(handle);
                 closing.swap_remove(i);
+                let mut stats = self.stats.lock();
+                stats.closed_reaped += 1;
+                if rst_pending {
+                    stats.reset_pending_dropped += 1;
+                }
                 continue;
             }
             i += 1;

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -6,11 +6,14 @@ use core::{
 };
 
 use crate::{
+    arch::CurrentIrqArch,
+    exception::InterruptArch,
     ipc::sighand::SigHand,
     libs::{
         notifier::{AtomicNotifierChain, NotifierBlock, NotifyResult},
         spinlock::SpinLock,
     },
+    process::preempt::PreemptGuard,
     smp::{core::smp_get_processor_id, cpu::ProcessorId},
 };
 use system_error::SystemError;
@@ -121,13 +124,34 @@ unsafe fn rcu_selftest_callback(head: NonNull<RcuHead>) {
     probe.hits.fetch_add(1, Ordering::SeqCst);
 }
 
-fn force_current_cpu_active_for_selftest(cpu: ProcessorId) {
-    let wake_worker = {
+struct RcuSelftestCpuStateGuard {
+    cpu: ProcessorId,
+    saved: RcuCpuState,
+}
+
+impl RcuSelftestCpuStateGuard {
+    fn new_active(cpu: ProcessorId) -> Self {
         let mut inner = RCU_STATE.inner.lock_irqsave();
         let cpu_idx = cpu.data() as usize;
+        let saved = inner.cpu_states[cpu_idx];
         inner.cpu_states[cpu_idx].in_idle_eqs = false;
         inner.cpu_states[cpu_idx].irq_nesting = 0;
         inner.cpu_states[cpu_idx].irq_from_idle_eqs = false;
+        Self { cpu, saved }
+    }
+}
+
+impl Drop for RcuSelftestCpuStateGuard {
+    fn drop(&mut self) {
+        restore_cpu_state_after_selftest(self.cpu, self.saved);
+    }
+}
+
+fn restore_cpu_state_after_selftest(cpu: ProcessorId, saved: RcuCpuState) {
+    let wake_worker = {
+        let mut inner = RCU_STATE.inner.lock_irqsave();
+        let cpu_idx = cpu.data() as usize;
+        inner.cpu_states[cpu_idx] = saved;
         if inner.gp_active && inner.waiting_cpus.get(cpu).unwrap_or(false) {
             inner.waiting_cpus.set(cpu, false);
         }
@@ -150,6 +174,10 @@ fn run_idle_irq_wakeup_selftest() -> Result<(), &'static str> {
     if pending_before != 0 || ready_before != 0 {
         return Err("rcu callback queues were not empty before idle IRQ selftest");
     }
+
+    let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+    let _preempt_guard = PreemptGuard::new();
+    let cpu_state_guard = RcuSelftestCpuStateGuard::new_active(cpu);
 
     let wake_worker = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
@@ -195,7 +223,6 @@ fn run_idle_irq_wakeup_selftest() -> Result<(), &'static str> {
         }
     };
     if let Some(error) = pre_exit_error {
-        force_current_cpu_active_for_selftest(cpu);
         return Err(error);
     }
 
@@ -213,7 +240,6 @@ fn run_idle_irq_wakeup_selftest() -> Result<(), &'static str> {
     let wake_worker = match idle_irq_exit_result {
         Ok(wake_worker) => wake_worker,
         Err(error) => {
-            force_current_cpu_active_for_selftest(cpu);
             return Err(error);
         }
     };
@@ -229,12 +255,14 @@ fn run_idle_irq_wakeup_selftest() -> Result<(), &'static str> {
         inner.waiting_cpus.get(cpu).unwrap_or(false)
     };
     if post_exit_waiting {
-        force_current_cpu_active_for_selftest(cpu);
         return Err("idle IRQ exit left the current CPU in waiting_cpus");
     }
 
+    drop(cpu_state_guard);
+    drop(_preempt_guard);
+    drop(_irq_guard);
+
     rcu_barrier();
-    force_current_cpu_active_for_selftest(cpu);
 
     if idle_hits.load(Ordering::SeqCst) != 1 {
         return Err("callback did not execute after the idle IRQ wakeup selftest finished");


### PR DESCRIPTION
### Background

On DragonOS, when downloading a large file and reading only the first 10 MiB before a normal `close(fd)`, the kernel keeps printing:

```text
non-zero-length segment with zero receive window, will only send an ACK
```

This indicates that after close, the TCP socket is still treated as receivable in FIN-WAIT while the peer sends more payload. The application has already closed the fd, but smoltcp may keep ACKing or zero-window ACKing subsequent data, leaving the orphan TCP state machine alive for a long time.

The corresponding Linux 6.6 semantics are:

- At the start of `tcp_close()`, set `sk_shutdown = SHUTDOWN_MASK`.
- If unread receive-queue data is discarded on close, perform an active reset.
- In `FIN_WAIT1`/`FIN_WAIT2` with `RCV_SHUTDOWN`, if payload arrives again, Linux resets the connection instead of continuing to receive or sending sustained zero-window ACKs.

### Changes

smoltcp:

- Add an explicit receive-shutdown state to the TCP socket.
- Add `shutdown_recv()` / `recv_shutdown()` APIs.
- In `FIN-WAIT-1` / `FIN-WAIT-2`, if the receive half is shut down and payload advances the receive sequence number:
  - Log at debug level;
  - Move the socket to `Closed`;
  - Return an active RST.
- Adjust `may_recv()` so receive-shutdown with an empty receive buffer no longer means receivable.
- Add unit test `test_fin_wait_receive_shutdown_data_resets`.

DragonOS:

- Refactor established TCP close decisions into an explicit `CloseAction`:
  - Close with unread data -> reset;
  - `SO_LINGER={1,0}` -> reset;
  - Connecting close -> reset;
  - Normal close -> graceful FIN and set smoltcp receive-shutdown.
- The close path no longer relies on multiple stable `recv_queue()==0` samples to decide graceful close.
- Extend `TcpCloseDefer`:
  - Record close kind/reason;
  - Record defer time and state transitions;
  - Retain `Closed` sockets with RST pending so handles are not removed before the RST is sent;
  - Add a 60s orphan timeout fallback;
  - Add statistics fields.
- Adjust when deferred close is reaped in NIC poll so `poll_at` is updated promptly after abort/RST.
