### PR TITLE
feat(ext4): implement two-phase buffered write with per-inode mutation locks

### DIFF
--- a/kernel/crates/another_ext4/ext4_test/src/main.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/main.rs
@@ -223,12 +223,11 @@ fn xattr_test(ext4: &mut Ext4) {
     assert_eq!(names, vec!["user.testtwo"]);
 }
 
-/// Simulate the apt update scenario: multiple files being grown via setattr
-/// in an interleaved pattern, then verified via extent_query (write_data_only).
-/// This reproduces the ENOENT bug where extent_query cannot find blocks that
-/// setattr already allocated.
+/// Simulate the apt update scenario: multiple files grow and dirty page-cache
+/// ranges in an interleaved pattern, then writeback verifies the prepared
+/// extent mappings via write_data_only.
 fn interleaved_setattr_writeback_test() {
-    use another_ext4::{FileAttr, SetAttr};
+    use another_ext4::SetAttr;
 
     make_ext4();
     let ext4 = load_ext4();
@@ -263,7 +262,7 @@ fn interleaved_setattr_writeback_test() {
             all_done = false;
             let new_size = core::cmp::min(file_sizes[i] + chunk_size, target_size);
 
-            // setattr to grow file (allocate blocks)
+            // Grow visible size without allocating holes.
             ext4.setattr(
                 ino,
                 SetAttr {
@@ -284,8 +283,18 @@ fn interleaved_setattr_writeback_test() {
                 )
             });
 
-            // Simulate writeback: write_data_only for all blocks in the
-            // newly allocated region
+            // Simulate buffered-write preparation followed by writeback for
+            // the newly dirtied region.
+            let write_offset = file_sizes[i] as usize;
+            let write_len = (new_size - file_sizes[i]) as usize;
+            ext4.prepare_buffered_write(ino, write_offset, write_len, new_size, None)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "prepare_buffered_write FAILED: ino={} round={} old_size={} \
+                         new_size={} err={:?}",
+                        ino, round, file_sizes[i], new_size, e
+                    )
+                });
             let old_block = (file_sizes[i] as usize) / 4096;
             let new_block = ((new_size as usize) + 4095) / 4096;
             for blk in old_block..new_block {
@@ -335,6 +344,142 @@ fn interleaved_setattr_writeback_test() {
     println!("interleaved setattr+writeback test done");
 }
 
+fn sparse_growth_and_range_writeback_test() {
+    use another_ext4::SetAttr;
+
+    make_ext4();
+    let ext4 = load_ext4();
+    let file_mode: InodeMode = InodeMode::FILE | InodeMode::ALL_RWX;
+    let ino = ext4
+        .generic_create(ROOT_INO, "sparse.dat", file_mode)
+        .expect("create sparse.dat failed");
+
+    let sparse_size = 2 * 1024 * 1024u64;
+    ext4.setattr(
+        ino,
+        SetAttr {
+            mode: None,
+            uid: None,
+            gid: None,
+            size: Some(sparse_size),
+            atime: None,
+            mtime: None,
+            ctime: None,
+            crtime: None,
+        },
+    )
+    .expect("sparse grow setattr failed");
+
+    let attr = ext4.getattr(ino).expect("getattr sparse file failed");
+    assert_eq!(attr.size, sparse_size);
+    assert_eq!(attr.blocks, 0, "sparse growth must not allocate data blocks");
+
+    let mut hole = vec![0x5Au8; 8192];
+    let n = ext4.read(ino, 123, &mut hole).expect("read sparse hole failed");
+    assert_eq!(n, hole.len());
+    assert!(hole.iter().all(|&b| b == 0), "hole read must return zeros");
+
+    let missing = ext4
+        .write_data_only(ino, 4096, &[0x11; 512])
+        .expect_err("writeback into unallocated hole must fail");
+    assert_eq!(missing.code(), ErrCode::ENOENT);
+
+    let write_offset = 1024 * 1024 + 123;
+    let data = vec![0xC3u8; 7000];
+    ext4.prepare_buffered_write(
+        ino,
+        write_offset,
+        data.len(),
+        sparse_size,
+        None,
+    )
+    .expect("prepare buffered sparse write failed");
+    ext4.write_data_only(ino, write_offset, &data)
+        .expect("write_data_only after prepare failed");
+
+    let attr = ext4.getattr(ino).expect("getattr sparse file failed");
+    assert_eq!(attr.size, sparse_size);
+    assert!(attr.blocks > 0, "range write must allocate written blocks");
+    assert!(
+        attr.blocks < sparse_size / 512,
+        "range write must not allocate the entire sparse file"
+    );
+
+    let mut read_back = vec![0u8; data.len()];
+    let n = ext4
+        .read(ino, write_offset, &mut read_back)
+        .expect("read sparse written range failed");
+    assert_eq!(n, data.len());
+    assert_eq!(read_back, data);
+
+    drop(ext4);
+    let output = std::process::Command::new("e2fsck")
+        .args(["-fn", "ext4.img"])
+        .output()
+        .expect("e2fsck failed");
+    assert!(
+        output.status.success(),
+        "e2fsck FAILED:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    println!("sparse growth and range writeback test done");
+}
+
+fn prepare_buffered_write_does_not_commit_size_test() {
+    make_ext4();
+    let ext4 = load_ext4();
+    let file_mode: InodeMode = InodeMode::FILE | InodeMode::ALL_RWX;
+    let ino = ext4
+        .generic_create(ROOT_INO, "prepared.dat", file_mode)
+        .expect("create prepared.dat failed");
+
+    let write_offset = 1024 * 1024;
+    let data = vec![0x7Eu8; 4096];
+    ext4.prepare_buffered_write(
+        ino,
+        write_offset,
+        data.len(),
+        (write_offset + data.len()) as u64,
+        None,
+    )
+    .expect("prepare buffered write failed");
+
+    let attr = ext4.getattr(ino).expect("getattr prepared file failed");
+    assert_eq!(attr.size, 0, "prepare must not commit visible size");
+    assert!(attr.blocks > 0, "prepare must allocate the written range");
+
+    ext4.write_data_only(ino, write_offset, &data)
+        .expect("write_data_only after prepare failed");
+    let mut hidden = vec![0u8; data.len()];
+    assert_eq!(
+        ext4.read(ino, write_offset, &mut hidden)
+            .expect("read beyond uncommitted size failed"),
+        0,
+        "uncommitted size must keep prepared data outside EOF hidden"
+    );
+
+    ext4.commit_inode_size(ino, (write_offset + data.len()) as u64, None)
+        .expect("commit prepared size failed");
+    let mut read_back = vec![0u8; data.len()];
+    let n = ext4
+        .read(ino, write_offset, &mut read_back)
+        .expect("read committed prepared range failed");
+    assert_eq!(n, data.len());
+    assert_eq!(read_back, data);
+
+    drop(ext4);
+    let output = std::process::Command::new("e2fsck")
+        .args(["-fn", "ext4.img"])
+        .output()
+        .expect("e2fsck failed");
+    assert!(
+        output.status.success(),
+        "e2fsck FAILED:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    println!("prepare buffered write size boundary test done");
+}
+
 fn main() {
     SimpleLogger::new().init().unwrap();
     log::set_max_level(log::LevelFilter::Off);
@@ -362,6 +507,10 @@ fn main() {
 
     // Interleaved setattr + writeback test
     interleaved_setattr_writeback_test();
+
+    sparse_growth_and_range_writeback_test();
+
+    prepare_buffered_write_does_not_commit_size_test();
 
     // Cache correctness tests — run on a fresh image
     // Use load_ext4 (not open_ext4) to avoid init() corrupting mkfs.ext4 checksums

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -6,6 +6,19 @@ use crate::prelude::*;
 use crate::return_error;
 
 impl Ext4 {
+    fn block_group_first_block(sb: &SuperBlock, bgid: BlockGroupId) -> PBlockId {
+        bgid as PBlockId * sb.blocks_per_group() as PBlockId
+    }
+
+    fn block_group_block_count(sb: &SuperBlock, bgid: BlockGroupId) -> usize {
+        let first = Self::block_group_first_block(sb, bgid);
+        let total = sb.block_count();
+        if first >= total {
+            return 0;
+        }
+        core::cmp::min(sb.blocks_per_group() as u64, total - first) as usize
+    }
+
     /// Create a new inode, returning the inode and its number
     #[inline(never)]
     pub(super) fn create_inode(&self, mode: InodeMode) -> Result<InodeRef> {
@@ -148,52 +161,69 @@ impl Ext4 {
     pub(super) fn alloc_block(&self, inode: &mut InodeRef) -> Result<PBlockId> {
         let _alloc_guard = self.alloc_lock.lock();
         let mut sb = self.read_super_block_cached();
-
-        // Calc block group id
         let inodes_per_group = sb.inodes_per_group();
-        let bgid = ((inode.id - 1) / inodes_per_group) as BlockGroupId;
+        let preferred_bgid = ((inode.id - 1) / inodes_per_group) as BlockGroupId;
+        let bg_count = sb.block_group_count();
 
-        // Load block group descriptor
-        let mut bg = self.read_block_group(bgid)?;
+        for i in 0..bg_count {
+            let bgid = (preferred_bgid + i) % bg_count;
+            let blocks_in_group = Self::block_group_block_count(&sb, bgid);
+            if blocks_in_group == 0 {
+                continue;
+            }
 
-        // Load block bitmap
-        let bitmap_block_id = bg.desc.block_bitmap_block();
-        let mut bitmap_block = self.read_block(bitmap_block_id)?;
-        let mut bitmap = Bitmap::new(&mut *bitmap_block.data, 8 * BLOCK_SIZE);
+            // Load block group descriptor
+            let mut bg = self.read_block_group(bgid)?;
+            if bg.desc.get_free_blocks_count() == 0 {
+                continue;
+            }
 
-        // Find the first free block
-        let fblock = bitmap
-            .find_and_set_first_clear_bit(0, 8 * BLOCK_SIZE)
-            .ok_or(format_error!(
-                ErrCode::ENOSPC,
-                "No free blocks in block group {}",
-                bgid
-            ))? as PBlockId;
-        // Set block group checksum
-        bg.desc.set_block_bitmap_csum(&sb.uuid(), &bitmap);
-        self.write_block(&bitmap_block)?;
+            // Load block bitmap. Bits are relative to the start of this block group;
+            // extent physical block numbers are absolute filesystem block numbers.
+            let bitmap_block_id = bg.desc.block_bitmap_block();
+            let mut bitmap_block = self.read_block(bitmap_block_id)?;
+            let mut bitmap = Bitmap::new(&mut *bitmap_block.data, blocks_in_group);
 
-        // Update block group counters
-        bg.desc
-            .set_free_blocks_count(bg.desc.get_free_blocks_count() - 1);
-        self.write_block_group_with_csum(&mut bg)?;
+            let bit = match bitmap.find_and_set_first_clear_bit(0, blocks_in_group) {
+                Some(bit) => bit,
+                None => continue,
+            };
+            let fblock = Self::block_group_first_block(&sb, bgid) + bit as PBlockId;
 
-        // Update superblock counters
-        sb.set_free_blocks_count(sb.free_blocks_count() - 1);
-        self.write_super_block(&sb)?;
+            // Set block group checksum
+            bg.desc.set_block_bitmap_csum(&sb.uuid(), &bitmap);
+            self.write_block(&bitmap_block)?;
 
-        trace!("Alloc block {} ok", fblock);
-        Ok(fblock)
+            // Update block group counters
+            bg.desc
+                .set_free_blocks_count(bg.desc.get_free_blocks_count() - 1);
+            self.write_block_group_with_csum(&mut bg)?;
+
+            // Update superblock counters
+            sb.set_free_blocks_count(sb.free_blocks_count() - 1);
+            self.write_super_block(&sb)?;
+
+            trace!("Alloc block {} ok", fblock);
+            return Ok(fblock);
+        }
+
+        return_error!(ErrCode::ENOSPC, "No free blocks in filesystem");
     }
 
     /// Deallocate a physical block allocated for an inode
-    pub(super) fn dealloc_block(&self, inode: &mut InodeRef, pblock: PBlockId) -> Result<()> {
+    pub(super) fn dealloc_block(&self, _inode: &mut InodeRef, pblock: PBlockId) -> Result<()> {
         let _alloc_guard = self.alloc_lock.lock();
         let mut sb = self.read_super_block_cached();
+        if pblock >= sb.block_count() {
+            return_error!(ErrCode::EINVAL, "Invalid block {}", pblock);
+        }
 
-        // Calc block group id
-        let inodes_per_group = sb.inodes_per_group();
-        let bgid = ((inode.id - 1) / inodes_per_group) as BlockGroupId;
+        let bgid = (pblock / sb.blocks_per_group() as PBlockId) as BlockGroupId;
+        let bit = (pblock - Self::block_group_first_block(&sb, bgid)) as usize;
+        let blocks_in_group = Self::block_group_block_count(&sb, bgid);
+        if bit >= blocks_in_group {
+            return_error!(ErrCode::EINVAL, "Invalid block {}", pblock);
+        }
 
         // Load block group descriptor
         let mut bg = self.read_block_group(bgid)?;
@@ -201,13 +231,13 @@ impl Ext4 {
         // Load block bitmap
         let bitmap_block_id = bg.desc.block_bitmap_block();
         let mut bitmap_block = self.read_block(bitmap_block_id)?;
-        let mut bitmap = Bitmap::new(&mut *bitmap_block.data, 8 * BLOCK_SIZE);
+        let mut bitmap = Bitmap::new(&mut *bitmap_block.data, blocks_in_group);
 
         // Free the block
-        if bitmap.is_bit_clear(pblock as usize) {
+        if bitmap.is_bit_clear(bit) {
             return_error!(ErrCode::EINVAL, "Block {} is already free", pblock);
         }
-        bitmap.clear_bit(pblock as usize);
+        bitmap.clear_bit(bit);
         // Set block group checksum
         bg.desc.set_block_bitmap_csum(&sb.uuid(), &bitmap);
         self.write_block(&bitmap_block)?;

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -588,6 +588,9 @@ mod tests {
             cached_block_groups: Vec::new(),
             inode_cache: spin::Mutex::new(crate::ext4::InodeCache::new(16)),
             alloc_lock: spin::Mutex::new(()),
+            inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
+                .map(|_| spin::Mutex::new(()))
+                .collect(),
         }
     }
 

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -40,6 +40,26 @@ impl SetAttr {
 }
 
 impl Ext4 {
+    fn read_extent_or_hole(
+        &self,
+        file: &InodeRef,
+        iblock: LBlockId,
+        block_offset: usize,
+        buf: &mut [u8],
+    ) -> Result<()> {
+        match self.extent_query(file, iblock) {
+            Ok(fblock) => {
+                let block = self.read_block(fblock)?;
+                buf.copy_from_slice(block.read_offset(block_offset, buf.len()));
+            }
+            Err(err) if err.code() == ErrCode::ENOENT => {
+                buf.fill(0);
+            }
+            Err(err) => return Err(err),
+        }
+        Ok(())
+    }
+
     /// Get file attributes.
     ///
     /// # Params
@@ -94,6 +114,7 @@ impl Ext4 {
     ///
     /// `EINVAL` if the inode is invalid (mode == 0).
     pub fn setattr(&self, id: InodeId, attr: SetAttr) -> Result<()> {
+        let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
             return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
@@ -108,36 +129,6 @@ impl Ext4 {
             inode.inode.set_gid(gid);
         }
         if let Some(size) = attr.size {
-            // If size increases, allocate new blocks if needed.
-            // Use BLOCK_SIZE (4096) units, consistent with inode_append_block.
-            let required_fs_blocks = (size as usize).div_ceil(BLOCK_SIZE) as u64;
-            // Compute data-only block count from extent tree (not from i_blocks,
-            // which may include tree metadata blocks).
-            let data_fs_blocks = self.extent_next_data_lblock(&inode)? as u64;
-            if required_fs_blocks > data_fs_blocks {
-                // debug!(
-                //     "setattr grow: ino={} size={} cur_fsblk={} req_fsblk={}",
-                //     id, size, data_fs_blocks, required_fs_blocks
-                // );
-                for i in data_fs_blocks..required_fs_blocks {
-                    if let Err(e) = self.inode_append_block(&mut inode) {
-                        debug!(
-                            "setattr: inode_append_block FAILED at block {}/{}: ino={} err={:?}",
-                            i, required_fs_blocks, id, e
-                        );
-                        return Err(e);
-                    }
-                }
-                // Recompute i_blocks: data blocks + tree metadata blocks
-                let tree_blocks = self.extent_all_tree_blocks(&inode)?.len() as u64;
-                let data_sectors = required_fs_blocks * (BLOCK_SIZE / INODE_BLOCK_SIZE) as u64;
-                let tree_sectors = tree_blocks * (BLOCK_SIZE / INODE_BLOCK_SIZE) as u64;
-                inode.inode.set_block_count(data_sectors + tree_sectors);
-                // debug!(
-                //     "setattr done: ino={} final_fsblk={}",
-                //     id, inode.inode.fs_block_count()
-                // );
-            }
             inode.inode.set_size(size);
         }
         if let Some(atime) = attr.atime {
@@ -156,54 +147,125 @@ impl Ext4 {
         Ok(())
     }
 
-    /// Pre-allocate disk blocks so that the inode can hold at least `size`
-    /// bytes, **without** updating `i_size`.
-    ///
-    /// This is the first half of a two-phase write protocol:
-    ///   1. `allocate_blocks_for_write` – ensure extents exist (before page-cache write)
-    ///   2. `commit_inode_size`         – update `i_size` (after page-cache write succeeds)
-    ///
-    /// If the required blocks are already allocated this is a no-op.
-    pub fn allocate_blocks_for_write(&self, id: InodeId, size: u64) -> Result<()> {
+    fn recompute_inode_block_count(&self, inode: &mut InodeRef) -> Result<()> {
+        let data_blocks = self.extent_all_data_blocks(inode)?.len() as u64;
+        let tree_blocks = self.extent_all_tree_blocks(inode)?.len() as u64;
+        let sectors_per_block = (BLOCK_SIZE / INODE_BLOCK_SIZE) as u64;
+        inode
+            .inode
+            .set_block_count((data_blocks + tree_blocks) * sectors_per_block);
+        Ok(())
+    }
+
+    fn ensure_blocks_for_write_range_locked(
+        &self,
+        inode: &mut InodeRef,
+        offset: usize,
+        len: usize,
+    ) -> Result<()> {
+        if len == 0 {
+            return Ok(());
+        }
+        let end = offset.checked_add(len).ok_or(format_error!(
+            ErrCode::EFBIG,
+            "write range overflow: offset={} len={}",
+            offset,
+            len
+        ))?;
+        let start_iblock = (offset / BLOCK_SIZE) as LBlockId;
+        let end_iblock = ((end - 1) / BLOCK_SIZE) as LBlockId;
+        let mut changed = false;
+        for iblock in start_iblock..=end_iblock {
+            match self.extent_query(inode, iblock) {
+                Ok(_) => {}
+                Err(err) if err.code() == ErrCode::ENOENT => {
+                    self.extent_query_or_create(inode, iblock, 1)?;
+                    self.extent_query(inode, iblock).map_err(|err| {
+                        format_error!(
+                            ErrCode::EIO,
+                            "extent allocation invariant failed: inode {} iblock {} missing after create: {:?}",
+                            inode.id,
+                            iblock,
+                            err
+                        )
+                    })?;
+                    changed = true;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        if changed {
+            self.recompute_inode_block_count(inode)?;
+            self.write_inode_with_csum(inode)?;
+        }
+        Ok(())
+    }
+
+    /// Ensure extents exist for the bytes that will actually be written.
+    pub fn allocate_blocks_for_write_range(
+        &self,
+        id: InodeId,
+        offset: usize,
+        len: usize,
+    ) -> Result<()> {
+        let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
             return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
         }
-        let required_fs_blocks = (size as usize).div_ceil(BLOCK_SIZE) as u64;
-        let data_fs_blocks = self.extent_next_data_lblock(&inode)? as u64;
-        if required_fs_blocks > data_fs_blocks {
-            for i in data_fs_blocks..required_fs_blocks {
-                if let Err(e) = self.inode_append_block(&mut inode) {
-                    debug!(
-                        "allocate_blocks_for_write: FAILED at block {}/{}: ino={} err={:?}",
-                        i, required_fs_blocks, id, e
-                    );
-                    return Err(e);
-                }
-            }
-            // Recompute i_blocks: data blocks + extent-tree metadata blocks
-            let tree_blocks = self.extent_all_tree_blocks(&inode)?.len() as u64;
-            let data_sectors = required_fs_blocks * (BLOCK_SIZE / INODE_BLOCK_SIZE) as u64;
-            let tree_sectors = tree_blocks * (BLOCK_SIZE / INODE_BLOCK_SIZE) as u64;
-            inode.inode.set_block_count(data_sectors + tree_sectors);
-            self.write_inode_with_csum(&mut inode)?;
+        self.ensure_blocks_for_write_range_locked(&mut inode, offset, len)
+    }
+
+    /// Prepare a buffered write by allocating only the written range.
+    ///
+    /// The caller owns the in-memory visible size used by page-cache writeback
+    /// and should call `commit_inode_size()` at fsync/truncate-style sync
+    /// boundaries.
+    pub fn prepare_buffered_write(
+        &self,
+        id: InodeId,
+        offset: usize,
+        len: usize,
+        _size: u64,
+        _mtime: Option<u32>,
+    ) -> Result<()> {
+        let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
+        let mut inode = self.read_inode(id)?;
+        if inode.inode.mode().bits() == 0 {
+            return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
         }
+        self.ensure_blocks_for_write_range_locked(&mut inode, offset, len)?;
+        Ok(())
+    }
+
+    /// Commit cached inode metadata to disk without allocating data blocks.
+    pub fn commit_inode_metadata(
+        &self,
+        id: InodeId,
+        size: Option<u64>,
+        mtime: Option<u32>,
+    ) -> Result<()> {
+        let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
+        let mut inode = self.read_inode(id)?;
+        if inode.inode.mode().bits() == 0 {
+            return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
+        }
+        if let Some(size) = size {
+            inode.inode.set_size(size);
+        }
+        if let Some(mtime) = mtime {
+            inode.inode.set_mtime(mtime);
+        }
+        self.write_inode_with_csum(&mut inode)?;
         Ok(())
     }
 
     /// Commit the file size (`i_size`) and optionally `mtime` to disk,
     /// **without** allocating any blocks.
     ///
-    /// Call this after `allocate_blocks_for_write` + successful page-cache
-    /// write to finalise the new file size.
+    /// Call this after successful page-cache write to finalise the new file size.
     pub fn commit_inode_size(&self, id: InodeId, size: u64, mtime: Option<u32>) -> Result<()> {
-        let mut inode = self.read_inode(id)?;
-        inode.inode.set_size(size);
-        if let Some(mtime) = mtime {
-            inode.inode.set_mtime(mtime);
-        }
-        self.write_inode_with_csum(&mut inode)?;
-        Ok(())
+        self.commit_inode_metadata(id, Some(size), mtime)
     }
 
     /// Link a newly created inode into `parent`.
@@ -340,8 +402,12 @@ impl Ext4 {
         if buf.is_empty() {
             return Ok(0);
         }
+        let file_size = file.inode.size() as usize;
+        if offset >= file_size {
+            return Ok(0);
+        }
         // Calc the actual size to read
-        let read_size = min(buf.len(), file.inode.size() as usize - offset);
+        let read_size = min(buf.len(), file_size - offset);
         // Calc the start block of reading
         let start_iblock = (offset / BLOCK_SIZE) as LBlockId;
         // Calc the length that is not aligned to the block size
@@ -352,27 +418,19 @@ impl Ext4 {
         // Read first block
         if misaligned > 0 {
             let read_len = min(BLOCK_SIZE - misaligned, read_size);
-            let fblock = self.extent_query(&file, start_iblock)?;
-            let block = self.read_block(fblock)?;
-            // Copy data from block to the user buffer
-            buf[cursor..cursor + read_len].copy_from_slice(block.read_offset(misaligned, read_len));
+            self.read_extent_or_hole(
+                &file,
+                start_iblock,
+                misaligned,
+                &mut buf[cursor..cursor + read_len],
+            )?;
             cursor += read_len;
             iblock += 1;
         }
         // Continue with full block reads
         while cursor < read_size {
             let read_len = min(BLOCK_SIZE, read_size - cursor);
-            match self.extent_query(&file, iblock) {
-                Ok(fblock) => {
-                    // normal
-                    let block = self.read_block(fblock)?;
-                    buf[cursor..cursor + read_len].copy_from_slice(block.read_offset(0, read_len));
-                }
-                Err(_) => {
-                    // hole
-                    buf[cursor..cursor + read_len].fill(0);
-                }
-            }
+            self.read_extent_or_hole(&file, iblock, 0, &mut buf[cursor..cursor + read_len])?;
             cursor += read_len;
             iblock += 1;
         }
@@ -416,24 +474,18 @@ impl Ext4 {
         let mut iblock = start_iblock;
         if misaligned > 0 {
             let read_len = min(BLOCK_SIZE - misaligned, read_size);
-            let fblock = self.extent_query(&inode_ref, start_iblock)?;
-            let block = self.read_block(fblock)?;
-            buf[cursor..cursor + read_len].copy_from_slice(block.read_offset(misaligned, read_len));
+            self.read_extent_or_hole(
+                &inode_ref,
+                start_iblock,
+                misaligned,
+                &mut buf[cursor..cursor + read_len],
+            )?;
             cursor += read_len;
             iblock += 1;
         }
         while cursor < read_size {
             let read_len = min(BLOCK_SIZE, read_size - cursor);
-            match self.extent_query(&inode_ref, iblock) {
-                Ok(fblock) => {
-                    let block = self.read_block(fblock)?;
-                    buf[cursor..cursor + read_len].copy_from_slice(block.read_offset(0, read_len));
-                }
-                Err(_) => {
-                    // hole
-                    buf[cursor..cursor + read_len].fill(0);
-                }
-            }
+            self.read_extent_or_hole(&inode_ref, iblock, 0, &mut buf[cursor..cursor + read_len])?;
             cursor += read_len;
             iblock += 1;
         }
@@ -458,25 +510,23 @@ impl Ext4 {
     /// * `EISDIR` - `file` is not a regular file
     /// * `ENOSPC` - no space left on device
     pub fn write(&self, file: InodeId, offset: usize, data: &[u8]) -> Result<usize> {
+        let write_size = data.len();
+        if write_size == 0 {
+            return Ok(0);
+        }
         // Get the inode of the file
+        let _mutation_guard =
+            self.inode_mutation_locks[self.inode_mutation_lock_index(file)].lock();
         let mut file = self.read_inode(file)?;
         if !file.inode.is_file() {
             return_error!(ErrCode::EISDIR, "Inode {} is not a file", file.id);
         }
 
-        let write_size = data.len();
-        // Calc the start and end block of writing
-        let start_iblock = (offset / BLOCK_SIZE) as LBlockId;
-        let end_iblock = ((offset + write_size) / BLOCK_SIZE) as LBlockId;
-        // Append enough block for writing
-        let append_block_count = end_iblock as i64 + 1 - file.inode.fs_block_count() as i64;
-        for _ in 0..append_block_count {
-            self.inode_append_block(&mut file)?;
-        }
+        self.ensure_blocks_for_write_range_locked(&mut file, offset, write_size)?;
 
         // Write data
         let mut cursor = 0;
-        let mut iblock = start_iblock;
+        let mut iblock = (offset / BLOCK_SIZE) as LBlockId;
         while cursor < write_size {
             let block_offset = (offset + cursor) % BLOCK_SIZE;
             let write_len = min(BLOCK_SIZE - block_offset, write_size - cursor);
@@ -487,8 +537,14 @@ impl Ext4 {
             cursor += write_len;
             iblock += 1;
         }
-        if offset + cursor > file.inode.size() as usize {
-            file.inode.set_size((offset + cursor) as u64);
+        let new_end = offset.checked_add(cursor).ok_or(format_error!(
+            ErrCode::EFBIG,
+            "write end overflow: offset={} len={}",
+            offset,
+            cursor
+        ))?;
+        if new_end > file.inode.size() as usize {
+            file.inode.set_size(new_end as u64);
         }
         self.write_inode_with_csum(&mut file)?;
 
@@ -498,7 +554,7 @@ impl Ext4 {
     /// Write data to pre-allocated blocks without modifying inode metadata.
     ///
     /// This is used by page cache writeback: blocks are already allocated by
-    /// `setattr(size=...)` in the foreground `write_at` path; the writeback
+    /// `prepare_buffered_write` in the foreground `write_at` path; the writeback
     /// thread only needs to push dirty page data to the corresponding
     /// physical blocks.
     ///
@@ -511,37 +567,46 @@ impl Ext4 {
     /// and background writeback, which can corrupt the extent tree when both
     /// operate on cloned `InodeRef` snapshots from the inode cache.
     pub fn write_data_only(&self, file: InodeId, offset: usize, data: &[u8]) -> Result<usize> {
-        let file = self.read_inode(file)?;
-        if !file.inode.is_file() {
-            return_error!(ErrCode::EISDIR, "Inode {} is not a file", file.id);
-        }
-
         let write_size = data.len();
-        let mut cursor = 0;
-        let mut iblock = (offset / BLOCK_SIZE) as LBlockId;
-        while cursor < write_size {
-            let block_offset = (offset + cursor) % BLOCK_SIZE;
-            let write_len = min(BLOCK_SIZE - block_offset, write_size - cursor);
-            match self.extent_query(&file, iblock) {
-                Ok(fblock) => {
-                    let mut block = self.read_block(fblock)?;
-                    block.write_offset(block_offset, &data[cursor..cursor + write_len]);
-                    self.write_block(&block)?;
-                }
-                Err(e) => {
-                    debug!(
-                        "write_data_only: extent_query FAILED ino={} iblock={} offset={} len={} fs_blkcnt={} size={} err={:?}",
-                        file.id, iblock, offset, write_size,
-                        file.inode.fs_block_count(), file.inode.size(), e
-                    );
-                    return Err(e);
-                }
+        let mut chunks = Vec::new();
+        {
+            let _mutation_guard =
+                self.inode_mutation_locks[self.inode_mutation_lock_index(file)].lock();
+            let file = self.read_inode(file)?;
+            if !file.inode.is_file() {
+                return_error!(ErrCode::EISDIR, "Inode {} is not a file", file.id);
             }
-            cursor += write_len;
-            iblock += 1;
+
+            let mut cursor = 0;
+            let mut iblock = (offset / BLOCK_SIZE) as LBlockId;
+            while cursor < write_size {
+                let block_offset = (offset + cursor) % BLOCK_SIZE;
+                let write_len = min(BLOCK_SIZE - block_offset, write_size - cursor);
+                match self.extent_query(&file, iblock) {
+                    Ok(fblock) => {
+                        chunks.push((fblock, block_offset, cursor, write_len));
+                    }
+                    Err(e) => {
+                        debug!(
+                            "write_data_only: extent_query FAILED ino={} iblock={} offset={} len={} fs_blkcnt={} size={} err={:?}",
+                            file.id, iblock, offset, write_size,
+                            file.inode.fs_block_count(), file.inode.size(), e
+                        );
+                        return Err(e);
+                    }
+                }
+                cursor += write_len;
+                iblock += 1;
+            }
         }
 
-        Ok(cursor)
+        for (fblock, block_offset, cursor, write_len) in chunks {
+            let mut block = self.read_block(fblock)?;
+            block.write_offset(block_offset, &data[cursor..cursor + write_len]);
+            self.write_block(&block)?;
+        }
+
+        Ok(write_size)
     }
 
     /// Create a hard link. This function will not check name conflict,
@@ -1160,5 +1225,82 @@ impl Ext4 {
         }
         let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
         Ok(xattr_block.list())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubBlockDevice {
+        sb_block: Block,
+    }
+
+    impl StubBlockDevice {
+        fn with_block_count(block_count: u32) -> Self {
+            let mut data = [0u8; BLOCK_SIZE];
+            let off = BASE_OFFSET;
+            data[off..off + 4].copy_from_slice(&block_count.to_le_bytes());
+            Self {
+                sb_block: Block::new(0, Box::new(data)),
+            }
+        }
+    }
+
+    impl BlockDevice for StubBlockDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            if block_id == 0 {
+                Ok(self.sb_block.clone())
+            } else {
+                Ok(Block::new(block_id, Box::new([0u8; BLOCK_SIZE])))
+            }
+        }
+
+        fn write_block(&self, _block: &Block) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_test_fs(block_count: u32) -> Ext4 {
+        let block_device = Arc::new(StubBlockDevice::with_block_count(block_count));
+        let block = block_device.read_block(0).unwrap();
+        let sb = block.read_offset_as::<SuperBlock>(BASE_OFFSET);
+        Ext4 {
+            block_device,
+            cached_super_block: spin::Mutex::new(sb),
+            cached_block_groups: Vec::new(),
+            inode_cache: spin::Mutex::new(crate::ext4::InodeCache::new(16)),
+            alloc_lock: spin::Mutex::new(()),
+            inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
+                .map(|_| spin::Mutex::new(()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn read_extent_or_hole_zero_fills_only_missing_extent() {
+        let fs = make_test_fs(16);
+        let mut inode = Inode::default();
+        inode.extent_init();
+        let inode = InodeRef::new(2, Box::new(inode));
+        let mut buf = [0x5a; 16];
+
+        fs.read_extent_or_hole(&inode, 0, 0, &mut buf).unwrap();
+
+        assert_eq!(buf, [0; 16]);
+    }
+
+    #[test]
+    fn read_extent_or_hole_propagates_extent_corruption() {
+        let fs = make_test_fs(16);
+        let inode = InodeRef::new(2, Box::new(Inode::default()));
+        let mut buf = [0x5a; 16];
+
+        let err = fs
+            .read_extent_or_hole(&inode, 0, 0, &mut buf)
+            .expect_err("invalid extent root must not be treated as a hole");
+
+        assert_eq!(err.code(), ErrCode::EIO);
+        assert_eq!(buf, [0x5a; 16]);
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -69,10 +69,19 @@ pub struct Ext4 {
     /// concurrent modification, which would cause two inodes to receive the
     /// same physical block (corrupting extent trees and data).
     alloc_lock: spin::Mutex<()>,
+    /// Serializes inode metadata and extent-tree mutations per inode shard.
+    ///
+    /// another_ext4 stores inodes as value snapshots in a small cache. Without
+    /// this lock, two writers can clone the same cached inode, mutate disjoint
+    /// fields, then write stale extent roots or sizes back over each other. Use
+    /// sharding so unrelated apt download files do not serialize on one global
+    /// filesystem-wide spin lock.
+    inode_mutation_locks: Vec<spin::Mutex<()>>,
 }
 
 /// Maximum number of inodes to cache in memory.
 const INODE_CACHE_SIZE: usize = 512;
+pub(super) const INODE_MUTATION_LOCK_SHARDS: usize = 64;
 
 impl Ext4 {
     /// Opens and loads an Ext4 from the `block_device`.
@@ -112,12 +121,17 @@ impl Ext4 {
         }
 
         // Create Ext4 instance
+        let mut inode_mutation_locks = Vec::with_capacity(INODE_MUTATION_LOCK_SHARDS);
+        for _ in 0..INODE_MUTATION_LOCK_SHARDS {
+            inode_mutation_locks.push(spin::Mutex::new(()));
+        }
         Ok(Self {
             block_device,
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups,
             inode_cache: spin::Mutex::new(InodeCache::new(INODE_CACHE_SIZE)),
             alloc_lock: spin::Mutex::new(()),
+            inode_mutation_locks,
         })
     }
 
@@ -130,5 +144,10 @@ impl Ext4 {
     /// Returns the current on-disk superblock.
     pub fn super_block(&self) -> Result<SuperBlock> {
         Ok(self.read_super_block_cached())
+    }
+
+    #[inline]
+    fn inode_mutation_lock_index(&self, inode_id: InodeId) -> usize {
+        inode_id as usize % self.inode_mutation_locks.len()
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/extent.rs
@@ -481,17 +481,16 @@ impl<'a> ExtentNodeMut<'a> {
         if pos < self.header().entries_count() as usize && self.extent_at(pos).is_unwritten() {
             // The position has an uninitialized extent
             *self.extent_mut_at(pos) = *extent;
-            self.header_mut().entries_count += 1;
             return Ok(());
         }
         // The position has a valid extent or is at the end
         if self.header().entries_count() < self.header().max_entries_count() {
             // The extent node is not full
             // Insert the extent and move the following extents
-            let mut i = pos;
-            while i < self.header().entries_count() as usize {
-                *self.extent_mut_at(i + 1) = *self.extent_at(i);
-                i += 1;
+            let mut i = self.header().entries_count() as usize;
+            while i > pos {
+                *self.extent_mut_at(i) = *self.extent_at(i - 1);
+                i -= 1;
             }
             *self.extent_mut_at(pos) = *extent;
             self.header_mut().entries_count += 1;
@@ -518,14 +517,13 @@ impl<'a> ExtentNodeMut<'a> {
                 }
             } else {
                 // Move the extents from `pos` to `unwritten`
-                let mut i = pos;
-                while i < unwritten {
-                    *self.extent_mut_at(i + 1) = *self.extent_at(i);
-                    i += 1;
+                let mut i = unwritten;
+                while i > pos {
+                    *self.extent_mut_at(i) = *self.extent_at(i - 1);
+                    i -= 1;
                 }
             }
             *self.extent_mut_at(pos) = *extent;
-            self.header_mut().entries_count += 1;
             return Ok(());
         }
         // The extent node is full and all extents are valid
@@ -567,10 +565,10 @@ impl<'a> ExtentNodeMut<'a> {
         if self.header().entries_count() < self.header().max_entries_count() {
             // The extent node is not full
             // Insert the extent index and move the following extent indexs
-            let mut i = pos;
-            while i < self.header().entries_count() as usize {
-                *self.extent_index_mut_at(i + 1) = *self.extent_index_at(i);
-                i += 1;
+            let mut i = self.header().entries_count() as usize;
+            while i > pos {
+                *self.extent_index_mut_at(i) = *self.extent_index_at(i - 1);
+                i -= 1;
             }
             *self.extent_index_mut_at(pos) = *extent_index;
             self.header_mut().entries_count += 1;
@@ -612,6 +610,41 @@ mod tests {
         assert!(header.check_magic());
         header.magic = 0;
         assert!(!header.check_magic());
+    }
+
+    #[test]
+    fn insert_extent_preserves_entries_after_insert_pos() {
+        let mut raw = [0u8; 60];
+        let mut node = ExtentNodeMut::from_bytes(&mut raw);
+        node.init(0, 0);
+        node.insert_extent(&Extent::new(0, 100, 1), 0).unwrap();
+        node.insert_extent(&Extent::new(2, 200, 1), 1).unwrap();
+        node.insert_extent(&Extent::new(1, 150, 1), 1).unwrap();
+
+        assert_eq!(node.header().entries_count(), 3);
+        assert_eq!(node.extent_at(0).start_lblock(), 0);
+        assert_eq!(node.extent_at(1).start_lblock(), 1);
+        assert_eq!(node.extent_at(2).start_lblock(), 2);
+        assert_eq!(node.extent_at(2).start_pblock(), 200);
+    }
+
+    #[test]
+    fn insert_extent_index_preserves_entries_after_insert_pos() {
+        let mut raw = [0u8; 60];
+        let mut node = ExtentNodeMut::from_bytes(&mut raw);
+        node.init(1, 0);
+        node.insert_extent_index(&ExtentIndex::new(0, 100), 0)
+            .unwrap();
+        node.insert_extent_index(&ExtentIndex::new(2, 200), 1)
+            .unwrap();
+        node.insert_extent_index(&ExtentIndex::new(1, 150), 1)
+            .unwrap();
+
+        assert_eq!(node.header().entries_count(), 3);
+        assert_eq!(node.extent_index_at(0).start_lblock(), 0);
+        assert_eq!(node.extent_index_at(1).start_lblock(), 1);
+        assert_eq!(node.extent_index_at(2).start_lblock(), 2);
+        assert_eq!(node.extent_index_at(2).leaf(), 200);
     }
 
     #[test]

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -104,19 +104,24 @@ impl Ext4FileSystem {
         let fs = another_ext4::Ext4::load(mount_data.clone())?;
         let root_inode: Arc<LockedExt4Inode> =
             Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| {
-                LockedExt4Inode(Mutex::new(Ext4Inode {
-                    inner_inode_num: another_ext4::EXT4_ROOT_INO,
-                    fs_ptr: Weak::default(),
-                    page_cache: None,
-                    children: BTreeMap::new(),
-                    dname: DName::from("/"),
-                    vfs_inode_id: generate_inode_id(),
-                    parent: self_ref.clone(),
-                    self_ref: self_ref.clone(),
-                    special_node: None,
-                    cached_file_size: None,
-                    metadata_dirty: false,
-                }))
+                LockedExt4Inode(
+                    Mutex::new(Ext4Inode {
+                        inner_inode_num: another_ext4::EXT4_ROOT_INO,
+                        fs_ptr: Weak::default(),
+                        page_cache: None,
+                        children: BTreeMap::new(),
+                        dname: DName::from("/"),
+                        vfs_inode_id: generate_inode_id(),
+                        parent: self_ref.clone(),
+                        self_ref: self_ref.clone(),
+                        special_node: None,
+                        cached_file_size: None,
+                        cached_mtime: None,
+                        size_dirty: false,
+                        mtime_dirty: false,
+                    }),
+                    Mutex::new(()),
+                )
             });
 
         let fs = Arc::new(Ext4FileSystem {

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1,4 +1,5 @@
 use crate::{
+    arch::MMArch,
     driver::base::device::device_number::DeviceNumber,
     filesystem::{
         page_cache::{AsyncPageCacheBackend, PageCache},
@@ -12,7 +13,7 @@ use crate::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
     },
-    mm::truncate::truncate_inode_pages,
+    mm::{truncate::truncate_inode_pages, MemoryManagementArch},
     time::PosixTimeSpec,
 };
 use alloc::{
@@ -53,12 +54,16 @@ pub struct Ext4Inode {
     /// 缓存的文件大小，避免频繁调用 getattr/setattr。
     /// None 表示未初始化（第一次写时从磁盘读取并缓存）。
     pub(super) cached_file_size: Option<u64>,
-    /// 标记是否有未刷回磁盘的元数据变更（file_size/mtime）
-    pub(super) metadata_dirty: bool,
+    /// 缓存的 mtime。普通 buffered write 先更新内存态，fsync/O_SYNC 再刷到磁盘。
+    pub(super) cached_mtime: Option<u32>,
+    /// 标记是否有未刷回磁盘的文件大小变更。
+    pub(super) size_dirty: bool,
+    /// 标记是否有未刷回磁盘的 mtime 变更。
+    pub(super) mtime_dirty: bool,
 }
 
 #[derive(Debug)]
-pub struct LockedExt4Inode(pub(super) Mutex<Ext4Inode>);
+pub struct LockedExt4Inode(pub(super) Mutex<Ext4Inode>, pub(super) Mutex<()>);
 
 impl IndexNode for LockedExt4Inode {
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
@@ -182,71 +187,71 @@ impl IndexNode for LockedExt4Inode {
         data: PrivateData,
     ) -> Result<usize, SystemError> {
         let len = core::cmp::min(len, buf.len());
+        if len == 0 {
+            return Ok(0);
+        }
         let buf = &buf[0..len];
 
-        let (fs, inode_num, page_cache, old_cached_size) = {
+        let (fs, inode_num, page_cache) = {
             let guard = self.0.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
                 guard.page_cache.clone(),
-                guard.cached_file_size,
             )
         };
 
         if let Some(page_cache) = page_cache {
+            let _invalidate = page_cache.invalidate_write();
+            let _io_guard = self.1.lock();
+
             // 使用缓存的文件大小，避免 getattr 磁盘 I/O
-            let old_file_size = match old_cached_size {
-                Some(size) => size,
-                None => {
-                    let size = fs.fs.getattr(inode_num)?.size;
-                    self.0.lock().cached_file_size = Some(size);
-                    size
+            let old_file_size = {
+                let cached_size = self.0.lock().cached_file_size;
+                match cached_size {
+                    Some(size) => size,
+                    None => {
+                        let size = fs.fs.getattr(inode_num)?.size;
+                        self.0.lock().cached_file_size = Some(size);
+                        size
+                    }
                 }
             };
 
-            let new_end = (offset + len) as u64;
-            let current_file_size = core::cmp::max(old_file_size, new_end);
+            let new_end = offset.checked_add(len).ok_or(SystemError::EFBIG)?;
+            let alloc_start = (offset >> MMArch::PAGE_SHIFT) << MMArch::PAGE_SHIFT;
+            let alloc_end = new_end
+                .checked_add(MMArch::PAGE_SIZE - 1)
+                .ok_or(SystemError::EFBIG)?
+                & !(MMArch::PAGE_SIZE - 1);
+            let alloc_len = alloc_end
+                .checked_sub(alloc_start)
+                .ok_or(SystemError::EFBIG)?;
 
-            // Two-phase write protocol that decouples block allocation from i_size:
-            //
-            // Phase 1 – Pre-allocate disk blocks WITHOUT updating i_size.
-            //   Ensures the async writeback thread can always find extent
-            //   mappings, avoiding the EIO that would occur if page-cache pages
-            //   were dirtied before blocks existed.
-            //
-            // Phase 2 – Commit i_size BEFORE writing page cache.
-            //   Must complete before PageCache::write so that concurrent
-            //   writeback (flush_dirty_pages / writeback_entry) sees the
-            //   correct file size and does not race with our disk I/O.
-            //   If commit_inode_size fails, no dirty pages exist yet → clean.
-            //   If PageCache::write later fails, i_size is already extended
-            //   but the extended region reads as zeros – same as old setattr
-            //   behaviour and acceptable since PageCache::write only fails on
-            //   OOM.
-            let extending = new_end > old_file_size;
-            if extending {
-                fs.fs
-                    .allocate_blocks_for_write(inode_num, current_file_size)
-                    .map_err(SystemError::from)?;
+            let time = PosixTimeSpec::now().tv_sec.to_u32().unwrap_or_else(|| {
+                log::warn!("Failed to get current time, using 0");
+                0
+            });
+            fs.fs
+                .prepare_buffered_write(
+                    inode_num,
+                    alloc_start,
+                    alloc_len,
+                    new_end as u64,
+                    Some(time),
+                )
+                .map_err(SystemError::from)?;
 
-                let time = PosixTimeSpec::now().tv_sec.to_u32().unwrap_or_else(|| {
-                    log::warn!("Failed to get current time, using 0");
-                    0
-                });
-                fs.fs
-                    .commit_inode_size(inode_num, current_file_size, Some(time))
-                    .map_err(SystemError::from)?;
-            }
-
-            // 磁盘块已就绪、i_size 已更新，现在安全写入 page cache
+            // 写入范围的磁盘块已就绪，现在安全写入 page cache。
             let write_len = PageCache::write(&page_cache, offset, buf)?;
-
-            // 更新内存中的缓存大小
-            {
+            if write_len > 0 {
+                let written_end = offset.checked_add(write_len).ok_or(SystemError::EFBIG)?;
+                let current_file_size = core::cmp::max(old_file_size, written_end as u64);
                 let mut guard = self.0.lock();
                 guard.cached_file_size = Some(current_file_size);
-                guard.metadata_dirty = true;
+                guard.cached_mtime = Some(time);
+                guard.size_dirty = true;
+                guard.mtime_dirty = true;
             }
 
             Ok(write_len)
@@ -256,6 +261,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn write_sync(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
+        let _io_guard = self.1.lock();
         let (fs, inode_num) = {
             let guard = self.0.lock();
             (guard.concret_fs(), guard.inner_inode_num)
@@ -263,7 +269,7 @@ impl IndexNode for LockedExt4Inode {
         match fs.fs.getattr(inode_num)?.ftype {
             FileType::Directory => Err(SystemError::EISDIR),
             FileType::Unknown => Err(SystemError::EROFS),
-            // Use write_data_only: blocks are pre-allocated by allocate_blocks_for_write() in write_at().
+            // Use write_data_only: blocks are pre-allocated by prepare_buffered_write() in write_at().
             // Using Ext4::write() here would cause it to call write_inode_with_csum()
             // which overwrites the inode's block_count/extent tree with a stale
             // snapshot, causing setattr to re-allocate blocks endlessly until
@@ -386,15 +392,19 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn metadata(&self) -> Result<vfs::Metadata, SystemError> {
-        let (fs, inode_num, vfs_inode_id) = {
+        let (fs, inode_num, vfs_inode_id, cached_size, cached_mtime) = {
             let guard = self.0.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
                 guard.vfs_inode_id,
+                guard.cached_file_size,
+                guard.cached_mtime,
             )
         };
         let attr = fs.fs.getattr(inode_num)?;
+        let size = cached_size.unwrap_or(attr.size);
+        let mtime = cached_mtime.unwrap_or(attr.mtime);
 
         // dev_id: filesystem device number (st_dev)
         let dev_id = fs.raw_dev.data() as usize;
@@ -412,12 +422,12 @@ impl IndexNode for LockedExt4Inode {
 
         Ok(vfs::Metadata {
             inode_id: vfs_inode_id,
-            size: attr.size as i64,
+            size: size as i64,
             blk_size: another_ext4::BLOCK_SIZE,
             blocks: attr.blocks as usize,
             atime: PosixTimeSpec::new(attr.atime.into(), 0),
             btime: PosixTimeSpec::new(attr.atime.into(), 0),
-            mtime: PosixTimeSpec::new(attr.mtime.into(), 0),
+            mtime: PosixTimeSpec::new(mtime.into(), 0),
             ctime: PosixTimeSpec::new(attr.ctime.into(), 0),
             file_type: Self::file_type(attr.ftype),
             mode: InodeMode::from_bits_truncate(attr.perm.bits() as u32),
@@ -431,41 +441,29 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn close(&self, _: PrivateData) -> Result<(), SystemError> {
-        // 在 close 时刷回延迟的元数据更新（mtime 等）
-        let (fs, inode_num, dirty, cached_size) = {
-            let mut guard = self.0.lock();
-            let dirty = guard.metadata_dirty;
-            let cached_size = guard.cached_file_size;
-            if dirty {
-                guard.metadata_dirty = false;
-            }
-            (
-                guard.concret_fs(),
-                guard.inner_inode_num,
-                dirty,
-                cached_size,
-            )
-        };
-        if dirty {
-            let time = PosixTimeSpec::now().tv_sec.to_u32().unwrap_or_else(|| {
-                log::warn!("Failed to get current time, using 0");
-                0
-            });
-            let _ = fs.fs.setattr(
-                inode_num,
-                another_ext4::SetAttr {
-                    mode: None,
-                    uid: None,
-                    gid: None,
-                    size: cached_size,
-                    atime: None,
-                    mtime: Some(time),
-                    ctime: None,
-                    crtime: None,
-                },
-            );
-        }
         Ok(())
+    }
+
+    fn sync(&self) -> Result<(), SystemError> {
+        if let Some(page_cache) = self.page_cache() {
+            page_cache.manager().sync()?;
+        }
+        self.flush_metadata(false)
+    }
+
+    fn datasync(&self) -> Result<(), SystemError> {
+        if let Some(page_cache) = self.page_cache() {
+            page_cache.manager().sync()?;
+        }
+        self.flush_metadata(true)
+    }
+
+    fn sync_file(&self, datasync: bool, _data: PrivateData) -> Result<(), SystemError> {
+        if datasync {
+            self.datasync()
+        } else {
+            self.sync()
+        }
     }
 
     fn page_cache(&self) -> Option<Arc<PageCache>> {
@@ -478,10 +476,13 @@ impl IndexNode for LockedExt4Inode {
         let to_ext4_time =
             |time: &PosixTimeSpec| -> u32 { time.tv_sec.max(0).min(u32::MAX as i64) as u32 };
 
-        let guard = self.0.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let (fs, inode_num) = {
+            let guard = self.0.lock();
+            (guard.concret_fs(), guard.inner_inode_num)
+        };
+        let ext4 = &fs.fs;
         ext4.setattr(
-            guard.inner_inode_num,
+            inode_num,
             another_ext4::SetAttr {
                 mode: Some(another_ext4::InodeMode::from_bits_truncate(
                     mode.bits() as u16
@@ -495,6 +496,13 @@ impl IndexNode for LockedExt4Inode {
                 crtime: Some(to_ext4_time(&metadata.btime)),
             },
         )?;
+        {
+            let mut guard = self.0.lock();
+            guard.cached_file_size = Some(metadata.size as u64);
+            guard.cached_mtime = Some(to_ext4_time(&metadata.mtime));
+            guard.size_dirty = false;
+            guard.mtime_dirty = false;
+        }
 
         Ok(())
     }
@@ -519,7 +527,12 @@ impl IndexNode for LockedExt4Inode {
         .map_err(SystemError::from)?;
         drop(guard);
         // 更新缓存的文件大小
-        self.0.lock().cached_file_size = Some(len as u64);
+        {
+            let mut guard = self.0.lock();
+            guard.cached_file_size = Some(len as u64);
+            guard.size_dirty = false;
+            guard.mtime_dirty = false;
+        }
         Ok(())
     }
 
@@ -845,12 +858,10 @@ impl LockedExt4Inode {
         parent: Option<Weak<LockedExt4Inode>>,
     ) -> Arc<Self> {
         let inode = Arc::new({
-            LockedExt4Inode(Mutex::new(Ext4Inode::new(
-                inode_num,
-                fs_ptr.clone(),
-                dname,
-                parent,
-            )))
+            LockedExt4Inode(
+                Mutex::new(Ext4Inode::new(inode_num, fs_ptr.clone(), dname, parent)),
+                Mutex::new(()),
+            )
         });
         let mut guard = inode.0.lock();
 
@@ -922,8 +933,57 @@ impl Ext4Inode {
             self_ref: Weak::new(), // 将在LockedExt4Inode::new()中设置
             special_node: None,
             cached_file_size: None,
-            metadata_dirty: false,
+            cached_mtime: None,
+            size_dirty: false,
+            mtime_dirty: false,
         }
+    }
+}
+
+impl LockedExt4Inode {
+    fn flush_metadata(&self, datasync: bool) -> Result<(), SystemError> {
+        let _io_guard = self.1.lock();
+        let (fs, inode_num, size_dirty, mtime_dirty, cached_size, cached_mtime) = {
+            let guard = self.0.lock();
+            (
+                guard.concret_fs(),
+                guard.inner_inode_num,
+                guard.size_dirty,
+                guard.mtime_dirty,
+                guard.cached_file_size,
+                guard.cached_mtime,
+            )
+        };
+
+        if !size_dirty && (!mtime_dirty || datasync) {
+            return Ok(());
+        }
+
+        let size = if size_dirty {
+            Some(match cached_size {
+                Some(size) => size,
+                None => fs.fs.getattr(inode_num)?.size,
+            })
+        } else {
+            None
+        };
+        let mtime = if !datasync && mtime_dirty {
+            cached_mtime
+        } else {
+            None
+        };
+        fs.fs
+            .commit_inode_metadata(inode_num, size, mtime)
+            .map_err(SystemError::from)?;
+
+        let mut guard = self.0.lock();
+        if size_dirty && guard.cached_file_size == cached_size {
+            guard.size_dirty = false;
+        }
+        if !datasync && mtime_dirty && guard.cached_mtime == cached_mtime {
+            guard.mtime_dirty = false;
+        }
+        Ok(())
     }
 }
 

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -558,6 +558,7 @@ impl PageCacheManager {
             inner.dirty_pages.remove(&page_index);
         }
 
+        let _invalidate = cache.invalidate_read();
         let inode = cache
             .inode()
             .and_then(|inode| inode.upgrade())
@@ -582,8 +583,12 @@ impl PageCacheManager {
                 guard.remove_flags(PageFlags::PG_DIRTY);
             }
             let result = if let Some(backend) = backend {
-                let waiter = backend.write_page_async(page_index, &page, len);
-                waiter.wait().map(|_| len)
+                let data = {
+                    let guard = page.read();
+                    let src = unsafe { guard.as_slice() };
+                    src[..len].to_vec()
+                };
+                backend.write_page(page_index, &data).map(|_| len)
             } else {
                 let data = unsafe {
                     core::slice::from_raw_parts(
@@ -599,9 +604,14 @@ impl PageCacheManager {
                 )
             };
             if let Err(e) = result {
-                page.write().add_flags(PageFlags::PG_ERROR);
-                cache.account_state_transition(PageState::Writeback, PageState::Error);
-                entry.set_state(PageState::Error);
+                {
+                    let mut guard = page.write();
+                    guard.add_flags(PageFlags::PG_ERROR | PageFlags::PG_DIRTY);
+                }
+                cache.account_state_transition(PageState::Writeback, PageState::Dirty);
+                entry.set_state(PageState::Dirty);
+                let mut inner = cache.inner.lock();
+                inner.dirty_pages.insert(page_index);
                 entry.wait_queue.wake_all();
                 return Err(e);
             }
@@ -1381,12 +1391,37 @@ impl PageCache {
         if let Some(current) = guard.get_entry(page_index) {
             if Arc::ptr_eq(&current, entry) {
                 guard.pages.remove(&page_index);
+                guard.dirty_pages.remove(&page_index);
                 if let Some(cache) = guard.page_cache_ref.upgrade() {
                     cache.account_entry_remove(entry.state());
                 }
             }
         }
         self.discard_unlinked_page(&entry.page);
+    }
+
+    fn discard_error_entry(&self, page_index: usize) {
+        let removed = {
+            let mut guard = self.inner.lock();
+            let Some(entry) = guard.get_entry(page_index) else {
+                return;
+            };
+            if entry.state() != PageState::Error {
+                return;
+            }
+            guard.dirty_pages.remove(&page_index);
+            let removed = guard.pages.remove(&page_index);
+            if let Some(entry) = removed.as_ref() {
+                if let Some(cache) = guard.page_cache_ref.upgrade() {
+                    cache.account_entry_remove(entry.state());
+                }
+            }
+            removed
+        };
+
+        if let Some(entry) = removed {
+            self.discard_unlinked_page(&entry.page);
+        }
     }
 
     fn discard_unlinked_page(&self, page: &Arc<Page>) {
@@ -1643,6 +1678,7 @@ impl PageCache {
             let full_page_overwrite =
                 write_start == page_start && page_write_len == MMArch::PAGE_SIZE;
             let populate_backend = !self.is_shmem() && !full_page_overwrite;
+            self.discard_error_entry(page_index);
             let entry = self.get_or_create_entry(page_index, populate_backend)?;
             copies.push(CopyItem {
                 entry,

--- a/kernel/src/filesystem/vfs/syscall/sys_sync.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync.rs
@@ -8,7 +8,7 @@ use crate::{
         syscall::nr::{SYS_SYNC, SYS_SYNCFS},
     },
     filesystem::vfs::file::FileFlags,
-    mm::page::page_reclaimer_lock,
+    mm::page::PageReclaimer,
     process::ProcessManager,
     syscall::table::{FormattedSyscallParam, Syscall},
 };
@@ -31,7 +31,7 @@ impl Syscall for SysSyncHandle {
         _args: &[usize],
         _frame: &mut TrapFrame,
     ) -> Result<usize, system_error::SystemError> {
-        page_reclaimer_lock().flush_dirty_pages();
+        PageReclaimer::flush_dirty_pages();
         Ok(0)
     }
 
@@ -80,7 +80,7 @@ impl Syscall for SysSyncFsHandle {
 
         // TODO: now, we ignore the fd and sync all filesystems.
         // In the future, we should sync only the filesystem of the given fd.
-        page_reclaimer_lock().flush_dirty_pages();
+        PageReclaimer::flush_dirty_pages();
         Ok(0)
     }
 

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -266,7 +266,7 @@ fn page_reclaim_thread() -> i32 {
             PageReclaimer::shrink_list(PageFrameCount::new(page_to_free));
         } else {
             //TODO 暂时让页面回收线程负责脏页回写任务，后续需要分离
-            page_reclaimer_lock().flush_dirty_pages();
+            PageReclaimer::flush_dirty_pages();
             // 休眠5秒
             // log::info!("sleep");
             let _ = nanosleep(PosixTimeSpec::new(0, 500_000_000));
@@ -348,8 +348,23 @@ impl PageReclaimer {
                 let paddr = guard.phys_address();
 
                 if guard.flags().contains(PageFlags::PG_DIRTY) {
-                    // 先回写脏页
-                    Self::page_writeback(&mut guard, true);
+                    let writeback_target = match guard.page_type() {
+                        PageType::File(info) => info
+                            .page_cache
+                            .upgrade()
+                            .map(|page_cache| (page_cache, info.index)),
+                        _ => None,
+                    };
+                    drop(guard);
+
+                    if let Some((page_cache, page_index)) = writeback_target {
+                        let _ = page_cache.manager().writeback_page(page_index);
+                    } else {
+                        let mut guard = page.write();
+                        Self::page_writeback(&mut guard, true);
+                    }
+
+                    guard = page.write();
                     if guard.flags().contains(PageFlags::PG_DIRTY) {
                         drop(guard);
                         page_reclaimer_lock().insert_page(paddr, &page);
@@ -481,13 +496,45 @@ impl PageReclaimer {
     }
 
     /// lru脏页刷新
-    pub fn flush_dirty_pages(&mut self) {
-        // log::info!("flush_dirty_pages");
-        let iter = self.lru.iter();
-        for (_paddr, page) in iter {
+    fn dirty_pages_snapshot(&self) -> Vec<Arc<Page>> {
+        self.lru
+            .iter()
+            .filter_map(|(_paddr, page)| {
+                let guard = page.read();
+                if guard.flags().contains(PageFlags::PG_DIRTY) {
+                    Some(page.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn flush_dirty_pages() {
+        let pages = {
+            let reclaimer = page_reclaimer_lock();
+            reclaimer.dirty_pages_snapshot()
+        };
+        Self::flush_dirty_pages_snapshot(pages);
+    }
+
+    fn flush_dirty_pages_snapshot(pages: Vec<Arc<Page>>) {
+        for page in pages {
             let mut guard = page.write();
             if guard.flags().contains(PageFlags::PG_DIRTY) {
-                Self::page_writeback(&mut guard, false);
+                let writeback_target = match guard.page_type() {
+                    PageType::File(info) => info
+                        .page_cache
+                        .upgrade()
+                        .map(|page_cache| (page_cache, info.index)),
+                    _ => None,
+                };
+                if let Some((page_cache, page_index)) = writeback_target {
+                    drop(guard);
+                    let _ = page_cache.manager().writeback_page(page_index);
+                } else {
+                    Self::page_writeback(&mut guard, false);
+                }
             }
         }
     }

--- a/user/sysconfig/etc/init.d/rcS
+++ b/user/sysconfig/etc/init.d/rcS
@@ -11,6 +11,38 @@ if [ ! -d /tmp ]; then
 fi
 mount -t tmpfs tmpfs /tmp || /bin/busybox mount -t tmpfs tmpfs /tmp
 
+# 如果 rootfs 中带有 apt，则按 Ubuntu 24.04 的 deb822 sources 格式切换到 USTC HTTP 源。
+if command -v apt >/dev/null 2>&1 || command -v apt-get >/dev/null 2>&1; then
+    echo "[rcS] apt detected, switching Ubuntu 24.04 apt sources to USTC..."
+
+    if [ -f /etc/apt/sources.list ] && [ ! -f /etc/apt/sources.list.dragonos.bak ]; then
+        cp /etc/apt/sources.list /etc/apt/sources.list.dragonos.bak
+    fi
+
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ] && [ ! -f /etc/apt/sources.list.d/ubuntu.sources.dragonos.bak ]; then
+        cp /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.dragonos.bak
+    fi
+
+    mkdir -p /etc/apt/sources.list.d
+    cat > /etc/apt/sources.list.d/ubuntu.sources <<'EOF'
+Types: deb
+URIs: http://mirrors.ustc.edu.cn/ubuntu
+Suites: noble noble-updates noble-backports
+Components: main restricted universe multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://mirrors.ustc.edu.cn/ubuntu
+Suites: noble-security
+Components: main restricted universe multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+    if [ -f /etc/apt/sources.list ]; then
+        : > /etc/apt/sources.list
+    fi
+fi
+
 # 根据环境变量AUTO_TEST决定是否进行自动测试
 if [ "$AUTO_TEST" = "syscall" ]; then
     /bin/busybox sh $SYSCALL_TEST_DIR/run_tests.sh


### PR DESCRIPTION


- Replace setattr-based block allocation with`prepare_buffered_write` that only allocates extents for the written range
- Add per-inode sharded mutation locks to prevent concurrent inode metadata corruption
- Fix extent tree insertion to preserve entries after insert position
- Implement deferred metadata flush via`cached_mtime`and`flush_metadata` on sync/datasync
- Add sparse file support with hole reading returning zeros
- Fix writeback to use`PageCacheManager::writeback_page`for file-backed pages
- Add`discard_error_entry`to clean up error state pages before write
- Add apt source configuration to USTC mirror in rcS