### PR TITLE
feat(process): implement seccomp syscall filtering

### DIFF
--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -167,7 +167,19 @@ impl StatusFileOps {
         );
 
         pdata.append(
+            &mut format!("\nNoNewPrivs:\t{}", pcb.no_new_privs())
+                .as_bytes()
+                .to_owned(),
+        );
+        pdata.append(
             &mut format!("\nSeccomp:\t{}", pcb.seccomp_mode() as u8)
+                .as_bytes()
+                .to_owned(),
+        );
+        let seccomp_filters =
+            crate::process::seccomp::SeccompFilter::chain_len(&pcb.seccomp_filter_lock());
+        pdata.append(
+            &mut format!("\nSeccomp_filters:\t{}", seccomp_filters)
                 .as_bytes()
                 .to_owned(),
         );

--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -166,6 +166,12 @@ impl StatusFileOps {
                 .to_owned(),
         );
 
+        pdata.append(
+            &mut format!("\nSeccomp:\t{}", pcb.seccomp_mode() as u8)
+                .as_bytes()
+                .to_owned(),
+        );
+
         // 去除多余的 \0 并在结尾添加 \0
         trim_string(&mut pdata);
 

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -242,7 +242,7 @@ impl Signal {
         // signal的信息为空
 
         if let Some(ref siginfo) = info {
-            force_send = matches!(siginfo.sig_code(), SigCode::Kernel);
+            force_send = matches!(siginfo.sig_code(), SigCode::Kernel | SigCode::SysSeccomp);
         } else {
             // todo: 判断signal是否来自于一个祖先进程的namespace，如果是，则强制发送信号
             //详见 https://code.dragonos.org.cn/xref/linux-6.1.9/kernel/signal.c?r=&mo=32170&fi=1220#1226

--- a/kernel/src/ipc/signal_types.rs
+++ b/kernel/src/ipc/signal_types.rs
@@ -33,7 +33,7 @@ pub enum SigCode {
     /// queued SIGIO/POLL_HUP
     PollHup = 6,
     /// sent by kernel from somewhere
-    Kernel,
+    Kernel = 0x80,
     /// SIGSYS sent by seccomp filter action SECCOMP_RET_TRAP.
     SysSeccomp,
     /// 通过sigqueue发送

--- a/kernel/src/ipc/signal_types.rs
+++ b/kernel/src/ipc/signal_types.rs
@@ -17,7 +17,6 @@ use crate::{
 /// siginfo中的si_code的可选值
 /// 请注意，当这个值小于0时，表示siginfo来自用户态，否则来自内核态
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
-#[repr(i32)]
 pub enum SigCode {
     /// sent by kill, sigsend, raise
     User = 0,
@@ -34,7 +33,9 @@ pub enum SigCode {
     /// queued SIGIO/POLL_HUP
     PollHup = 6,
     /// sent by kernel from somewhere
-    Kernel = 0x80,
+    Kernel,
+    /// SIGSYS sent by seccomp filter action SECCOMP_RET_TRAP.
+    SysSeccomp,
     /// 通过sigqueue发送
     Queue = -1,
     /// 定时器过期时发送
@@ -50,6 +51,26 @@ pub enum SigCode {
 }
 
 impl SigCode {
+    pub fn as_i32(self) -> i32 {
+        match self {
+            Self::User => 0,
+            Self::PollIn => 1,
+            Self::PollOut => 2,
+            Self::PollMsg => 3,
+            Self::PollErr => 4,
+            Self::PollPri => 5,
+            Self::PollHup => 6,
+            Self::Kernel => 0x80,
+            Self::SysSeccomp => 1,
+            Self::Queue => -1,
+            Self::Timer => -2,
+            Self::Mesgq => -3,
+            Self::AsyncIO => -4,
+            Self::SigIO => -5,
+            Self::Tkill => -6,
+        }
+    }
+
     pub fn try_from_i32(x: i32) -> Option<SigCode> {
         match x {
             0 => Some(Self::User),
@@ -517,7 +538,7 @@ impl SigInfo {
             SigType::Kill { pid, uid } => PosixSigInfo {
                 si_signo: self.sig_no,
                 si_errno: self.errno,
-                si_code: self.sig_code as i32,
+                si_code: self.sig_code.as_i32(),
                 _sifields: PosixSiginfoFields {
                     _kill: PosixSiginfoKill {
                         si_pid: pid.data() as i32,
@@ -528,7 +549,7 @@ impl SigInfo {
             SigType::Rt { pid, uid, sigval } => PosixSigInfo {
                 si_signo: self.sig_no,
                 si_errno: self.errno,
-                si_code: self.sig_code as i32,
+                si_code: self.sig_code.as_i32(),
                 _sifields: PosixSiginfoFields {
                     _rt: PosixSiginfoRt {
                         si_pid: pid.data() as i32,
@@ -540,7 +561,7 @@ impl SigInfo {
             SigType::Alarm(pid) => PosixSigInfo {
                 si_signo: self.sig_no,
                 si_errno: self.errno,
-                si_code: self.sig_code as i32,
+                si_code: self.sig_code.as_i32(),
                 _sifields: PosixSiginfoFields {
                     _timer: PosixSiginfoTimer {
                         si_tid: pid.data() as i32,
@@ -556,7 +577,7 @@ impl SigInfo {
             } => PosixSigInfo {
                 si_signo: self.sig_no,
                 si_errno: self.errno,
-                si_code: self.sig_code as i32,
+                si_code: self.sig_code.as_i32(),
                 _sifields: PosixSiginfoFields {
                     _timer: PosixSiginfoTimer {
                         si_tid: timerid,
@@ -568,11 +589,27 @@ impl SigInfo {
             SigType::SigPoll { fd, band } => PosixSigInfo {
                 si_signo: self.sig_no,
                 si_errno: self.errno,
-                si_code: self.sig_code as i32,
+                si_code: self.sig_code.as_i32(),
                 _sifields: PosixSiginfoFields {
                     _sigpoll: PosixSiginfoSigpoll {
                         si_band: band,
                         si_fd: fd,
+                    },
+                },
+            },
+            SigType::SigSys {
+                call_addr,
+                syscall,
+                arch,
+            } => PosixSigInfo {
+                si_signo: self.sig_no,
+                si_errno: self.errno,
+                si_code: self.sig_code.as_i32(),
+                _sifields: PosixSiginfoFields {
+                    _sigsys: PosixSiginfoSigsys {
+                        _call_addr: call_addr,
+                        _syscall: syscall,
+                        _arch: arch,
                     },
                 },
             },
@@ -629,6 +666,12 @@ pub enum SigType {
     SigPoll {
         fd: i32,
         band: i64,
+    },
+    /// SIGSYS/SYS_SECCOMP seccomp trap siginfo payload.
+    SigSys {
+        call_addr: u64,
+        syscall: i32,
+        arch: u32,
     },
     // 后续完善下列中的具体字段
     // Timer,

--- a/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
+++ b/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
@@ -83,7 +83,7 @@ impl Syscall for SysRtSigqueueinfoHandle {
 
         // Linux 6.6: do_rt_sigqueueinfo 权限校验
         let si_code = user_info.si_code;
-        if (si_code >= 0 || si_code == (SigCode::Tkill as i32)) && current_pid != target_pid {
+        if (si_code >= 0 || si_code == SigCode::Tkill.as_i32()) && current_pid != target_pid {
             return Err(SystemError::EPERM);
         }
 

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -10,8 +10,6 @@ use system_error::SystemError;
 use super::inner;
 use super::TcpSocket;
 
-const TCP_CLOSE_POST_POLL_ROUNDS: usize = 8;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CloseObservation {
     state: smoltcp::socket::tcp::State,
@@ -26,6 +24,18 @@ struct CloseAction {
 }
 
 impl TcpSocket {
+    fn kick_iface_after_tcp_state_change(iface: &Arc<dyn crate::net::Iface>) {
+        if let Some(netns) = iface.common().net_namespace() {
+            netns.wakeup_poll_thread();
+        }
+
+        super::poll_util::poll_iface_until_quiescent(iface.as_ref());
+
+        // The state change may have completed before the last poll round reports a fresh
+        // SocketStateChanged event. Refresh all bound sockets so waiters observe the final state.
+        iface.common().notify_all_bound_sockets();
+    }
+
     #[inline]
     fn observe_established_close(established: &inner::Established) -> CloseObservation {
         established.with(|socket| CloseObservation {
@@ -382,7 +392,6 @@ impl TcpSocket {
         }
 
         let mut post_poll_iface: Option<Arc<dyn crate::net::Iface>> = None;
-        let mut post_poll_rounds: usize = 0;
 
         // Linux/gVisor 语义：TIME_WAIT/Closed 的 stream socket 上 shutdown 应返回 ENOTCONN。
         // 但 Listening 和 Connecting 状态下的 shutdown 是允许的。
@@ -419,7 +428,6 @@ impl TcpSocket {
                     } else {
                         established.with_mut(|socket| socket.close());
                     }
-                    post_poll_rounds = core::cmp::max(post_poll_rounds, 8);
                     post_poll_iface = Some(established.iface().clone());
                 }
 
@@ -428,7 +436,6 @@ impl TcpSocket {
             }
             inner::Inner::Listening(mut listening) => {
                 if how.contains(ShutdownBit::SHUT_RD) {
-                    let original_listen_sockets = listening.inners.len();
                     let local = listening.get_name();
                     let port = local.port;
 
@@ -461,10 +468,6 @@ impl TcpSocket {
                         bound.release();
                     }
 
-                    post_poll_rounds = core::cmp::max(
-                        post_poll_rounds,
-                        original_listen_sockets.saturating_mul(8).clamp(128, 8192),
-                    );
                     post_poll_iface = Some(keep.iface().clone());
 
                     // Linux: shutdown(SHUT_RD) on a listening socket stops listening.
@@ -503,7 +506,6 @@ impl TcpSocket {
                         } else {
                             established.with_mut(|socket| socket.close());
                         }
-                        post_poll_rounds = core::cmp::max(post_poll_rounds, 8);
                         post_poll_iface = Some(established.iface().clone());
                     }
 
@@ -511,7 +513,6 @@ impl TcpSocket {
                 } else {
                     connecting.set_shutdown_reset();
                     connecting.with_mut(|socket| socket.abort());
-                    post_poll_rounds = core::cmp::max(post_poll_rounds, 128);
                     post_poll_iface = Some(connecting.iface().clone());
 
                     // For still-connecting sockets, only SHUT_WR is meaningful for
@@ -559,17 +560,7 @@ impl TcpSocket {
 
         // 唤醒等待者（含 poll/epoll），让状态变化可见。
         if let Some(iface) = post_poll_iface {
-            if let Some(netns) = iface.common().net_namespace() {
-                netns.wakeup_poll_thread();
-            }
-            for _ in 0..post_poll_rounds {
-                iface.poll();
-            }
-            // After shutdown, explicitly notify all bound sockets on this interface.
-            // This ensures that client sockets waiting for connection completion
-            // are woken up even if the last poll() didn't detect state changes
-            // (e.g., RST was already sent and received in earlier polls).
-            iface.common().notify_all_bound_sockets();
+            Self::kick_iface_after_tcp_state_change(&iface);
         }
         self.notify();
         Ok(())
@@ -716,17 +707,7 @@ impl TcpSocket {
         };
         drop(writer);
         if let Some(iface) = post_poll_iface {
-            if let Some(netns) = iface.common().net_namespace() {
-                netns.wakeup_poll_thread();
-            }
-            // close(2) must not drain unrelated sockets on the whole interface. Linux
-            // queues FIN/RST work and returns without waiting for global TCP quiescence.
-            // A small bounded push is enough to expose the close to smoltcp/loopback
-            // immediately while keeping syscall latency independent of orphan backlog.
-            for _ in 0..TCP_CLOSE_POST_POLL_ROUNDS {
-                iface.poll();
-            }
-            iface.common().notify_all_bound_sockets();
+            Self::kick_iface_after_tcp_state_change(&iface);
         }
         self.notify();
         Ok(())

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -10,6 +10,12 @@ use system_error::SystemError;
 use super::inner;
 use super::TcpSocket;
 
+const TCP_ESTABLISHED_POST_POLL_ROUNDS: usize = 8;
+const TCP_CONNECTING_ABORT_POST_POLL_ROUNDS: usize = 128;
+const TCP_LISTEN_POST_POLL_MIN_ROUNDS: usize = 128;
+const TCP_LISTEN_POST_POLL_MAX_ROUNDS: usize = 8192;
+const TCP_LISTEN_POST_POLL_ROUNDS_PER_SOCKET: usize = 8;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CloseObservation {
     state: smoltcp::socket::tcp::State,
@@ -24,16 +30,34 @@ struct CloseAction {
 }
 
 impl TcpSocket {
-    fn kick_iface_after_tcp_state_change(iface: &Arc<dyn crate::net::Iface>) {
+    fn kick_iface_after_tcp_state_change(
+        iface: &Arc<dyn crate::net::Iface>,
+        poll_rounds: usize,
+        notify_bound_sockets: bool,
+    ) {
         if let Some(netns) = iface.common().net_namespace() {
             netns.wakeup_poll_thread();
         }
 
-        super::poll_util::poll_iface_until_quiescent(iface.as_ref());
+        for _ in 0..poll_rounds {
+            let _ = iface.poll();
+        }
 
-        // The state change may have completed before the last poll round reports a fresh
-        // SocketStateChanged event. Refresh all bound sockets so waiters observe the final state.
-        iface.common().notify_all_bound_sockets();
+        if notify_bound_sockets {
+            // Listener shutdown/close changes a shared endpoint. Refresh all bound sockets so
+            // blocked accept/connect users observe the final state without requiring a new packet.
+            iface.common().notify_all_bound_sockets();
+        }
+    }
+
+    #[inline]
+    fn listen_post_poll_rounds(socket_count: usize) -> usize {
+        socket_count
+            .saturating_mul(TCP_LISTEN_POST_POLL_ROUNDS_PER_SOCKET)
+            .clamp(
+                TCP_LISTEN_POST_POLL_MIN_ROUNDS,
+                TCP_LISTEN_POST_POLL_MAX_ROUNDS,
+            )
     }
 
     #[inline]
@@ -392,6 +416,8 @@ impl TcpSocket {
         }
 
         let mut post_poll_iface: Option<Arc<dyn crate::net::Iface>> = None;
+        let mut post_poll_rounds = 0usize;
+        let mut post_notify_bound_sockets = false;
 
         // Linux/gVisor 语义：TIME_WAIT/Closed 的 stream socket 上 shutdown 应返回 ENOTCONN。
         // 但 Listening 和 Connecting 状态下的 shutdown 是允许的。
@@ -428,6 +454,8 @@ impl TcpSocket {
                     } else {
                         established.with_mut(|socket| socket.close());
                     }
+                    post_poll_rounds =
+                        core::cmp::max(post_poll_rounds, TCP_ESTABLISHED_POST_POLL_ROUNDS);
                     post_poll_iface = Some(established.iface().clone());
                 }
 
@@ -436,6 +464,7 @@ impl TcpSocket {
             }
             inner::Inner::Listening(mut listening) => {
                 if how.contains(ShutdownBit::SHUT_RD) {
+                    let original_listen_sockets = listening.inners.len();
                     let local = listening.get_name();
                     let port = local.port;
 
@@ -468,6 +497,11 @@ impl TcpSocket {
                         bound.release();
                     }
 
+                    post_poll_rounds = core::cmp::max(
+                        post_poll_rounds,
+                        Self::listen_post_poll_rounds(original_listen_sockets),
+                    );
+                    post_notify_bound_sockets = true;
                     post_poll_iface = Some(keep.iface().clone());
 
                     // Linux: shutdown(SHUT_RD) on a listening socket stops listening.
@@ -506,6 +540,8 @@ impl TcpSocket {
                         } else {
                             established.with_mut(|socket| socket.close());
                         }
+                        post_poll_rounds =
+                            core::cmp::max(post_poll_rounds, TCP_ESTABLISHED_POST_POLL_ROUNDS);
                         post_poll_iface = Some(established.iface().clone());
                     }
 
@@ -513,6 +549,8 @@ impl TcpSocket {
                 } else {
                     connecting.set_shutdown_reset();
                     connecting.with_mut(|socket| socket.abort());
+                    post_poll_rounds =
+                        core::cmp::max(post_poll_rounds, TCP_CONNECTING_ABORT_POST_POLL_ROUNDS);
                     post_poll_iface = Some(connecting.iface().clone());
 
                     // For still-connecting sockets, only SHUT_WR is meaningful for
@@ -560,7 +598,11 @@ impl TcpSocket {
 
         // 唤醒等待者（含 poll/epoll），让状态变化可见。
         if let Some(iface) = post_poll_iface {
-            Self::kick_iface_after_tcp_state_change(&iface);
+            Self::kick_iface_after_tcp_state_change(
+                &iface,
+                post_poll_rounds,
+                post_notify_bound_sockets,
+            );
         }
         self.notify();
         Ok(())
@@ -574,6 +616,8 @@ impl TcpSocket {
         };
 
         let mut post_poll_iface: Option<Arc<dyn crate::net::Iface>> = None;
+        let mut post_poll_rounds = 0usize;
+        let mut post_notify_bound_sockets = false;
 
         // close(fd) must not break in-flight syscalls that already hold a
         // reference to this socket object (gVisor ClosedWriteBlockingSocket).
@@ -664,7 +708,9 @@ impl TcpSocket {
             }
             inner::Inner::Listening(mut ls) => {
                 // close(listen_fd) should stop listening on the port.
+                let original_listen_sockets = ls.inners.len();
                 let port = ls.get_name().port;
+                let post_close_iface = ls.inners.first().map(|b| b.iface().clone());
                 // Unregister listen port and unbind socket from all unique interfaces.
                 // For INADDR_ANY listeners, listen sockets span multiple interfaces,
                 // so we must clean up each one.
@@ -695,6 +741,12 @@ impl TcpSocket {
                     _ => smoltcp::wire::IpVersion::Ipv4,
                 };
                 writer.replace(inner::Inner::Closed(inner::Closed::new(ver)));
+                post_poll_rounds = core::cmp::max(
+                    post_poll_rounds,
+                    Self::listen_post_poll_rounds(original_listen_sockets),
+                );
+                post_notify_bound_sockets = true;
+                post_poll_iface = post_close_iface;
             }
             inner::Inner::Init(init) => {
                 init.close();
@@ -707,7 +759,11 @@ impl TcpSocket {
         };
         drop(writer);
         if let Some(iface) = post_poll_iface {
-            Self::kick_iface_after_tcp_state_change(&iface);
+            Self::kick_iface_after_tcp_state_change(
+                &iface,
+                post_poll_rounds,
+                post_notify_bound_sockets,
+            );
         }
         self.notify();
         Ok(())

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -636,6 +636,15 @@ impl ProcessManager {
             )
         });
 
+        crate::process::seccomp::copy_seccomp(
+            current_pcb
+                .seccomp_mode
+                .load(core::sync::atomic::Ordering::Relaxed),
+            &current_pcb.seccomp_filter,
+            &pcb.seccomp_mode,
+            &pcb.seccomp_filter,
+        );
+
         // 拷贝文件描述符表
         Self::copy_files(&clone_flags, current_pcb, pcb).unwrap_or_else(|e| {
             panic!(

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -95,6 +95,7 @@ pub mod preempt;
 pub mod process_group;
 pub mod resource;
 pub mod rseq;
+pub mod seccomp;
 pub mod session;
 pub mod shebang;
 pub mod signal;
@@ -1364,6 +1365,9 @@ pub struct ProcessControlBlock {
     /// Linux: 0=SUID_DUMP_DISABLE, 1=SUID_DUMP_USER；2(SUID_DUMP_ROOT) 不允许通过 PR_SET_DUMPABLE 设置。
     dumpable: AtomicU8,
 
+    pub(crate) seccomp_mode: AtomicU8,
+    pub(crate) seccomp_filter: SpinLock<Option<Arc<seccomp::SeccompFilter>>>,
+
     /// 父进程指针
     pub(crate) parent_pcb: RwLock<Weak<ProcessControlBlock>>,
     /// 真实父进程指针
@@ -1537,6 +1541,8 @@ impl ProcessControlBlock {
                 keepcaps: AtomicBool::new(false),
                 // 默认设置为 SUID_DUMP_USER(=1)，满足 gVisor 的 SetGetDumpability 预期。
                 dumpable: AtomicU8::new(1),
+                seccomp_mode: AtomicU8::new(seccomp::SeccompMode::Disabled as u8),
+                seccomp_filter: SpinLock::new(None),
                 parent_pcb: RwLock::new(ppcb.clone()),
                 real_parent_pcb: RwLock::new(ppcb.clone()),
                 fork_parent_pcb: RwLock::new(ppcb),
@@ -1850,6 +1856,21 @@ impl ProcessControlBlock {
     #[inline(always)]
     pub fn set_dumpable(&self, value: u8) {
         self.dumpable.store(value, Ordering::SeqCst)
+    }
+
+    #[inline(always)]
+    pub fn seccomp_mode(&self) -> seccomp::SeccompMode {
+        seccomp::SeccompMode::from(self.seccomp_mode.load(Ordering::Relaxed))
+    }
+
+    #[inline(always)]
+    pub fn set_seccomp_mode(&self, mode: seccomp::SeccompMode) {
+        self.seccomp_mode.store(mode as u8, Ordering::SeqCst);
+    }
+
+    #[inline(always)]
+    pub fn seccomp_filter_lock(&self) -> SpinLockGuard<'_, Option<Arc<seccomp::SeccompFilter>>> {
+        self.seccomp_filter.lock()
     }
 
     #[inline(always)]

--- a/kernel/src/process/seccomp.rs
+++ b/kernel/src/process/seccomp.rs
@@ -12,8 +12,8 @@ use log::warn;
 use system_error::SystemError;
 
 use crate::{
-    arch::ipc::signal::Signal,
-    ipc::signal_types::{SigCode, SigInfo, SigType},
+    arch::{interrupt::TrapFrame, ipc::signal::Signal},
+    ipc::signal_types::{SaHandlerType, SigCode, SigInfo, SigType, SigactionType, SignalFlags},
     libs::spinlock::SpinLock,
     process::{pid::PidType, ProcessManager},
     syscall::user_access::UserBufferReader,
@@ -76,7 +76,7 @@ impl From<u8> for SeccompMode {
 pub struct SeccompData {
     /// 系统调用号
     pub nr: i32,
-    /// 架构标识 (AUDIT_ARCH_X86_64 = 0xC000003E)
+    /// 架构标识（AUDIT_ARCH_*）
     pub arch: u32,
     /// 用户态指令指针
     pub instruction_pointer: u64,
@@ -86,8 +86,15 @@ pub struct SeccompData {
 
 const SECCOMP_DATA_SIZE: usize = core::mem::size_of::<SeccompData>();
 
-/// AUDIT_ARCH_X86_64 常量
-const AUDIT_ARCH_X86_64: u32 = 0xC000003E;
+const MAX_ERRNO: u32 = SystemError::MAXERRNO as u32;
+const AUDIT_ARCH_64BIT: u32 = 0x80000000;
+const AUDIT_ARCH_LE: u32 = 0x40000000;
+#[cfg(target_arch = "x86_64")]
+const AUDIT_ARCH_X86_64: u32 = 62 | AUDIT_ARCH_64BIT | AUDIT_ARCH_LE;
+#[cfg(target_arch = "riscv64")]
+const AUDIT_ARCH_RISCV64: u32 = 243 | AUDIT_ARCH_64BIT | AUDIT_ARCH_LE;
+#[cfg(target_arch = "loongarch64")]
+const AUDIT_ARCH_LOONGARCH64: u32 = 258 | AUDIT_ARCH_64BIT | AUDIT_ARCH_LE;
 
 // ============ Sock Filter / Sock Fprog ============
 
@@ -135,6 +142,8 @@ const BPF_LEN: u16 = 0x80;
 // 数据源
 const BPF_K: u16 = 0x00;
 const BPF_X: u16 = 0x08;
+const BPF_A: u16 = 0x10;
+const BPF_RVAL_MASK: u16 = 0x18;
 
 // ALU 操作
 const BPF_ADD: u16 = 0x00;
@@ -170,22 +179,29 @@ const BPF_MEMWORDS: usize = 16;
 
 /// SECCOMP_MODE_STRICT 允许的系统调用白名单 (x86_64)
 #[cfg(target_arch = "x86_64")]
-const SECCOMP_STRICT_WHITELIST: [i32; 5] = [
-    0,   // read
-    1,   // write
-    60,  // exit
-    15,  // rt_sigreturn
-    231, // exit_group
+const SECCOMP_STRICT_WHITELIST: [i32; 4] = [
+    0,  // read
+    1,  // write
+    60, // exit
+    15, // rt_sigreturn
 ];
 
 /// SECCOMP_MODE_STRICT 允许的系统调用白名单 (riscv64)
 #[cfg(target_arch = "riscv64")]
 const SECCOMP_STRICT_WHITELIST: [i32; 4] = [
-    63, // read
-    64, // write
-    93, // exit
-    // riscv64 的 rt_sigreturn 通过特殊机制处理
-    0, // 在某些架构上可能不需要
+    63,  // read
+    64,  // write
+    93,  // exit
+    139, // rt_sigreturn
+];
+
+/// SECCOMP_MODE_STRICT 允许的系统调用白名单 (loongarch64)
+#[cfg(target_arch = "loongarch64")]
+const SECCOMP_STRICT_WHITELIST: [i32; 4] = [
+    63,  // read
+    64,  // write
+    93,  // exit
+    139, // rt_sigreturn
 ];
 
 // ============ Seccomp Filter ============
@@ -217,6 +233,16 @@ impl SeccompFilter {
     #[inline]
     pub fn prev(&self) -> &Option<Arc<SeccompFilter>> {
         &self.prev
+    }
+
+    pub fn chain_len(head: &Option<Arc<SeccompFilter>>) -> usize {
+        let mut len = 0;
+        let mut current = head.clone();
+        while let Some(filter) = current {
+            len += 1;
+            current = filter.prev().clone();
+        }
+        len
     }
 
     /// 执行此过滤器
@@ -353,8 +379,8 @@ fn run_cbpf(insns: &[SockFilter], data: &SeccompData) -> u32 {
                 }
             }
             BPF_RET => {
-                let src = insn.code & 0x08;
-                return if src == BPF_K { insn.k } else { a };
+                let rval = insn.code & BPF_RVAL_MASK;
+                return if rval == BPF_K { insn.k } else { a };
             }
             BPF_MISC => {
                 let op = insn.code & 0xf8;
@@ -391,95 +417,87 @@ fn validate_seccomp_filter(insns: &[SockFilter]) -> Result<(), SystemError> {
     if insns.len() > BPF_MAXINSNS {
         return Err(SystemError::EINVAL);
     }
+    if (insns[insns.len() - 1].code & 0x07) != BPF_RET {
+        return Err(SystemError::EINVAL);
+    }
 
     for (pc, insn) in insns.iter().enumerate() {
-        let class = insn.code & 0x07;
-
-        match class {
-            BPF_LD => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM | BPF_LEN => {}
-                    BPF_ABS => {
-                        let offset = insn.k as usize;
-                        if !offset.is_multiple_of(4) || offset.saturating_add(4) > SECCOMP_DATA_SIZE
-                        {
-                            return Err(SystemError::EINVAL);
-                        }
-                    }
-                    BPF_MEM => {
-                        if insn.k as usize >= BPF_MEMWORDS {
-                            return Err(SystemError::EINVAL);
-                        }
-                    }
-                    _ => return Err(SystemError::EINVAL),
+        match insn.code {
+            code if code == (BPF_LD | BPF_W | BPF_ABS) => {
+                let offset = insn.k as usize;
+                if !offset.is_multiple_of(4) || offset.saturating_add(4) > SECCOMP_DATA_SIZE {
+                    return Err(SystemError::EINVAL);
                 }
             }
-            BPF_LDX => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM | BPF_LEN => {}
-                    BPF_MEM => {
-                        if insn.k as usize >= BPF_MEMWORDS {
-                            return Err(SystemError::EINVAL);
-                        }
-                    }
-                    _ => return Err(SystemError::EINVAL),
-                }
-            }
-            BPF_ST | BPF_STX => {
+            code if code == (BPF_LD | BPF_W | BPF_LEN) => {}
+            code if code == (BPF_LDX | BPF_W | BPF_LEN) => {}
+            code if code == (BPF_LD | BPF_IMM) => {}
+            code if code == (BPF_LDX | BPF_IMM) => {}
+            code if code == (BPF_LD | BPF_MEM) || code == (BPF_LDX | BPF_MEM) => {
                 if insn.k as usize >= BPF_MEMWORDS {
                     return Err(SystemError::EINVAL);
                 }
             }
-            BPF_ALU => {
-                let op = insn.code & 0xf0;
-                match op {
-                    BPF_ADD | BPF_SUB | BPF_MUL | BPF_DIV | BPF_OR | BPF_AND | BPF_LSH
-                    | BPF_RSH | BPF_NEG | BPF_MOD | BPF_XOR => {}
-                    _ => return Err(SystemError::EINVAL),
-                }
-                let src = insn.code & 0x08;
-                if src != BPF_K && src != BPF_X {
+            code if code == BPF_ST || code == BPF_STX => {
+                if insn.k as usize >= BPF_MEMWORDS {
                     return Err(SystemError::EINVAL);
                 }
             }
-            BPF_JMP => {
-                let op = insn.code & 0xf0;
-                if op == BPF_JA {
-                    let target = pc.wrapping_add(1).wrapping_add(insn.k as usize);
-                    if target >= insns.len() {
-                        return Err(SystemError::EINVAL);
-                    }
-                } else {
-                    match op {
-                        BPF_JEQ | BPF_JGT | BPF_JGE | BPF_JSET => {}
-                        _ => return Err(SystemError::EINVAL),
-                    }
-                    let jt_target = pc + 1 + insn.jt as usize;
-                    let jf_target = pc + 1 + insn.jf as usize;
-                    if jt_target >= insns.len() || jf_target >= insns.len() {
-                        return Err(SystemError::EINVAL);
-                    }
-                    let src = insn.code & 0x08;
-                    if src != BPF_K && src != BPF_X {
-                        return Err(SystemError::EINVAL);
-                    }
-                }
-            }
-            BPF_RET => {
-                let src = insn.code & 0x08;
-                if src != BPF_K && src != BPF_X {
+            code if code == (BPF_ALU | BPF_ADD | BPF_K)
+                || code == (BPF_ALU | BPF_ADD | BPF_X)
+                || code == (BPF_ALU | BPF_SUB | BPF_K)
+                || code == (BPF_ALU | BPF_SUB | BPF_X)
+                || code == (BPF_ALU | BPF_MUL | BPF_K)
+                || code == (BPF_ALU | BPF_MUL | BPF_X)
+                || code == (BPF_ALU | BPF_DIV | BPF_K)
+                || code == (BPF_ALU | BPF_DIV | BPF_X)
+                || code == (BPF_ALU | BPF_OR | BPF_K)
+                || code == (BPF_ALU | BPF_OR | BPF_X)
+                || code == (BPF_ALU | BPF_AND | BPF_K)
+                || code == (BPF_ALU | BPF_AND | BPF_X)
+                || code == (BPF_ALU | BPF_LSH | BPF_K)
+                || code == (BPF_ALU | BPF_LSH | BPF_X)
+                || code == (BPF_ALU | BPF_RSH | BPF_K)
+                || code == (BPF_ALU | BPF_RSH | BPF_X)
+                || code == (BPF_ALU | BPF_NEG)
+                || code == (BPF_ALU | BPF_XOR | BPF_K)
+                || code == (BPF_ALU | BPF_XOR | BPF_X) =>
+            {
+                if code == (BPF_ALU | BPF_DIV | BPF_K) && insn.k == 0 {
                     return Err(SystemError::EINVAL);
                 }
             }
-            BPF_MISC => {
-                let op = insn.code & 0xf8;
-                if op != BPF_TAX && op != BPF_TXA {
+            code if code == (BPF_JMP | BPF_JA) => {
+                let Some(target) = pc
+                    .checked_add(1)
+                    .and_then(|x| x.checked_add(insn.k as usize))
+                else {
+                    return Err(SystemError::EINVAL);
+                };
+                if target >= insns.len() {
                     return Err(SystemError::EINVAL);
                 }
             }
-            _ => return Err(SystemError::EINVAL),
+            code if code == (BPF_JMP | BPF_JEQ | BPF_K)
+                || code == (BPF_JMP | BPF_JEQ | BPF_X)
+                || code == (BPF_JMP | BPF_JGT | BPF_K)
+                || code == (BPF_JMP | BPF_JGT | BPF_X)
+                || code == (BPF_JMP | BPF_JGE | BPF_K)
+                || code == (BPF_JMP | BPF_JGE | BPF_X)
+                || code == (BPF_JMP | BPF_JSET | BPF_K)
+                || code == (BPF_JMP | BPF_JSET | BPF_X) =>
+            {
+                let jt_target = pc + 1 + insn.jt as usize;
+                let jf_target = pc + 1 + insn.jf as usize;
+                if jt_target >= insns.len() || jf_target >= insns.len() {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            code if code == (BPF_RET | BPF_K) || code == (BPF_RET | BPF_A) => {}
+            code if code == (BPF_MISC | BPF_TAX) || code == (BPF_MISC | BPF_TXA) => {}
+            _ => {
+                return Err(SystemError::EINVAL);
+            }
         }
     }
 
@@ -502,7 +520,7 @@ fn seccomp_run_filters(data: &SeccompData, filter: &Option<Arc<SeccompFilter>>) 
 
     while let Some(f) = current {
         let cur_ret = f.run(data);
-        if (cur_ret & SECCOMP_RET_ACTION_FULL) < (ret & SECCOMP_RET_ACTION_FULL) {
+        if action_priority(cur_ret) < action_priority(ret) {
             ret = cur_ret;
         }
         current = f.prev().clone();
@@ -511,52 +529,59 @@ fn seccomp_run_filters(data: &SeccompData, filter: &Option<Arc<SeccompFilter>>) 
     ret
 }
 
+#[inline(always)]
+fn action_priority(ret: u32) -> i32 {
+    (ret & SECCOMP_RET_ACTION_FULL) as i32
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeccompDecision {
+    Allow,
+    Skip(usize),
+}
+
 // ============ Secure Computing ============
 
 /// Seccomp 系统调用检查入口
 ///
 /// 在系统调用分发之前调用。根据当前进程的 seccomp 模式执行相应检查。
 ///
-/// # 参数
-/// - `syscall_num`: 系统调用号
-/// - `args`: 系统调用参数（6个）
-/// - `ip`: 用户态指令指针（rip）
-///
 /// # 返回值
-/// - `Ok(())`: 允许继续执行系统调用
-/// - `Err(SystemError)`: 系统调用被拒绝（ERRNO / TRAP / KILL）
+/// - `Allow`: 允许继续执行系统调用
+/// - `Skip(ret)`: 跳过系统调用并直接返回 `ret`
 ///
-/// 对于 KILL 动作，此函数会发送 SIGSYS 并返回错误。
-/// 进程将在返回用户态时处理该信号（默认终止）。
-pub fn secure_computing(syscall_num: usize, args: &[usize; 6], ip: u64) -> Result<(), SystemError> {
+/// 对于 KILL 动作，此函数不会返回，而是按 Linux seccomp 语义终止线程/线程组。
+pub fn secure_computing(
+    syscall_num: usize,
+    args: &[usize; 6],
+    frame: &mut TrapFrame,
+) -> Result<SeccompDecision, SystemError> {
     let pcb = ProcessManager::current_pcb();
     let mode_val = pcb.seccomp_mode.load(Ordering::Relaxed);
     let mode = SeccompMode::from(mode_val);
 
     match mode {
-        SeccompMode::Disabled => Ok(()),
+        SeccompMode::Disabled => Ok(SeccompDecision::Allow),
 
         SeccompMode::Dead => {
-            // 进程已被标记为 Dead，拒绝所有 syscall
-            send_seccomp_sigsys(syscall_num as i32, SECCOMP_RET_KILL_THREAD);
-            Err(SystemError::EPERM)
+            // Surviving SECCOMP_RET_KILL_* must be proactively impossible.
+            ProcessManager::exit(Signal::SIGKILL as usize);
         }
 
         SeccompMode::Strict => {
             // 检查白名单
             if SECCOMP_STRICT_WHITELIST.contains(&(syscall_num as i32)) {
-                Ok(())
+                Ok(SeccompDecision::Allow)
             } else {
-                send_seccomp_sigsys(syscall_num as i32, SECCOMP_RET_KILL_THREAD);
-                Err(SystemError::EPERM)
+                kill_current_strict();
             }
         }
 
         SeccompMode::Filter => {
             let data = SeccompData {
                 nr: syscall_num as i32,
-                arch: AUDIT_ARCH_X86_64,
-                instruction_pointer: ip,
+                arch: seccomp_arch(),
+                instruction_pointer: instruction_pointer(frame),
                 args: [
                     args[0] as u64,
                     args[1] as u64,
@@ -572,23 +597,20 @@ pub fn secure_computing(syscall_num: usize, args: &[usize; 6], ip: u64) -> Resul
             drop(filter_guard);
 
             let action = result & SECCOMP_RET_ACTION_FULL;
-            let data_val = (result & SECCOMP_RET_DATA) as i32;
+            let data_val = result & SECCOMP_RET_DATA;
 
             match action {
                 SECCOMP_RET_KILL_PROCESS | SECCOMP_RET_KILL_THREAD => {
-                    pcb.seccomp_mode
-                        .store(SeccompMode::Dead as u8, Ordering::Relaxed);
-                    send_seccomp_sigsys(data.nr, action);
-                    Err(SystemError::EPERM)
+                    kill_current(action);
                 }
                 SECCOMP_RET_TRAP => {
-                    send_seccomp_sigsys(data.nr, action);
-                    let errno_val = -data_val;
-                    SystemError::from_posix_errno(errno_val).map_or(Err(SystemError::EPERM), Err)
+                    rollback_syscall(frame, syscall_num);
+                    send_seccomp_sigsys(&data, data_val);
+                    Ok(SeccompDecision::Skip(frame_syscall_return(frame)))
                 }
                 SECCOMP_RET_ERRNO => {
-                    let errno_val = -data_val;
-                    SystemError::from_posix_errno(errno_val).map_or(Err(SystemError::EPERM), Err)
+                    let errno = data_val.min(MAX_ERRNO);
+                    Ok(SeccompDecision::Skip((-(errno as i32)) as usize))
                 }
                 SECCOMP_RET_LOG => {
                     log::info!(
@@ -596,37 +618,43 @@ pub fn secure_computing(syscall_num: usize, args: &[usize; 6], ip: u64) -> Resul
                         pcb.raw_pid(),
                         syscall_num
                     );
-                    Ok(())
+                    Ok(SeccompDecision::Allow)
                 }
-                SECCOMP_RET_ALLOW => Ok(()),
+                SECCOMP_RET_ALLOW => Ok(SeccompDecision::Allow),
 
                 _ => {
                     // 未知动作，默认 KILL
-                    pcb.seccomp_mode
-                        .store(SeccompMode::Dead as u8, Ordering::Relaxed);
-                    send_seccomp_sigsys(data.nr, SECCOMP_RET_KILL_THREAD);
-                    Err(SystemError::EPERM)
+                    kill_current(SECCOMP_RET_KILL_PROCESS);
                 }
             }
         }
     }
 }
 
-/// 发送 SIGSYS 信号给当前进程（内核强制）
+/// 发送 SIGSYS 信号给当前进程（TRAP 动作）
 ///
-/// si_code = SI_KERNEL (0x80)
-/// si_errno = seccomp action
-fn send_seccomp_sigsys(_syscall_nr: i32, action: u32) {
+/// TODO: 扩展 SigCode/SigType，让用户态 siginfo 携带 Linux 的
+/// SYS_SECCOMP、call_addr、syscall 和 arch 字段。
+fn send_seccomp_sigsys(data: &SeccompData, errno: u32) {
     let pcb = ProcessManager::current_pcb();
     let sig = Signal::SIGSYS;
+    log::debug!(
+        "seccomp: SIGSYS trap pid={:?} syscall={} arch={:#x}",
+        pcb.raw_pid(),
+        data.nr,
+        data.arch
+    );
+
+    force_current_seccomp_sigsys();
 
     let mut info = SigInfo::new(
         sig,
-        action as i32,
-        SigCode::Kernel,
-        SigType::Kill {
-            pid: pcb.raw_pid(),
-            uid: pcb.cred().uid.data() as u32,
+        errno.min(MAX_ERRNO) as i32,
+        SigCode::SysSeccomp,
+        SigType::SigSys {
+            call_addr: data.instruction_pointer,
+            syscall: data.nr,
+            arch: data.arch,
         },
     );
 
@@ -639,21 +667,139 @@ fn send_seccomp_sigsys(_syscall_nr: i32, action: u32) {
     }
 }
 
+fn force_current_seccomp_sigsys() {
+    let pcb = ProcessManager::current_pcb();
+    let sig = Signal::SIGSYS;
+
+    if let Some(mut action) = pcb.sighand().handler(sig) {
+        let blocked = pcb
+            .sig_info_irqsave()
+            .sig_blocked()
+            .contains(sig.into_sigset());
+        if blocked || action.is_ignore() {
+            action.set_action(SigactionType::SaHandler(SaHandlerType::Default));
+            pcb.sighand().set_handler(sig, action);
+        }
+        if action.is_default() {
+            pcb.sighand().flags_remove(SignalFlags::UNKILLABLE);
+        }
+    }
+
+    {
+        let mut siginfo = pcb.sig_info_mut();
+        siginfo.sig_block_mut().remove(sig.into_sigset());
+        siginfo.saved_sigmask_mut().remove(sig.into_sigset());
+    }
+    pcb.recalc_sigpending();
+}
+
+fn kill_current(action: u32) -> ! {
+    match action {
+        SECCOMP_RET_KILL_THREAD => kill_current_thread(),
+        _ => kill_current_process(),
+    }
+}
+
+fn kill_current_thread() -> ! {
+    let pcb = ProcessManager::current_pcb();
+    pcb.seccomp_mode
+        .store(SeccompMode::Dead as u8, Ordering::SeqCst);
+    ProcessManager::exit(Signal::SIGSYS as usize);
+}
+
+fn kill_current_strict() -> ! {
+    let pcb = ProcessManager::current_pcb();
+    pcb.seccomp_mode
+        .store(SeccompMode::Dead as u8, Ordering::SeqCst);
+    ProcessManager::exit(Signal::SIGKILL as usize);
+}
+
+fn kill_current_process() -> ! {
+    let pcb = ProcessManager::current_pcb();
+    pcb.seccomp_mode
+        .store(SeccompMode::Dead as u8, Ordering::SeqCst);
+    ProcessManager::group_exit(Signal::SIGSYS as usize);
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn seccomp_arch() -> u32 {
+    AUDIT_ARCH_X86_64
+}
+
+#[cfg(target_arch = "riscv64")]
+#[inline(always)]
+fn seccomp_arch() -> u32 {
+    AUDIT_ARCH_RISCV64
+}
+
+#[cfg(target_arch = "loongarch64")]
+#[inline(always)]
+fn seccomp_arch() -> u32 {
+    AUDIT_ARCH_LOONGARCH64
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn instruction_pointer(frame: &TrapFrame) -> u64 {
+    frame.rip() as u64
+}
+
+#[cfg(target_arch = "riscv64")]
+#[inline(always)]
+fn instruction_pointer(frame: &TrapFrame) -> u64 {
+    frame.epc as u64
+}
+
+#[cfg(target_arch = "loongarch64")]
+#[inline(always)]
+fn instruction_pointer(frame: &TrapFrame) -> u64 {
+    frame.csr_era as u64
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn rollback_syscall(frame: &mut TrapFrame, _syscall_num: usize) {
+    frame.rax = frame.errcode;
+}
+
+#[cfg(target_arch = "riscv64")]
+#[inline(always)]
+fn rollback_syscall(frame: &mut TrapFrame, syscall_num: usize) {
+    frame.a0 = syscall_num;
+}
+
+#[cfg(target_arch = "loongarch64")]
+#[inline(always)]
+fn rollback_syscall(frame: &mut TrapFrame, syscall_num: usize) {
+    frame.a0 = syscall_num;
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn frame_syscall_return(frame: &TrapFrame) -> usize {
+    frame.rax as usize
+}
+
+#[cfg(target_arch = "riscv64")]
+#[inline(always)]
+fn frame_syscall_return(frame: &TrapFrame) -> usize {
+    frame.a0
+}
+
+#[cfg(target_arch = "loongarch64")]
+#[inline(always)]
+fn frame_syscall_return(frame: &TrapFrame) -> usize {
+    frame.a0
+}
+
 // ============ Seccomp 模式操作 ============
 
 /// 设置 strict 模式
 ///
-/// 要求 CAP_SYS_ADMIN 权限。只能从 Disabled 切换（不可逆）。
+/// 只能从 Disabled 切换（不可逆）。
 pub fn seccomp_set_mode_strict() -> Result<(), SystemError> {
     let current = ProcessManager::current_pcb();
-
-    // Linux: 需要 CAP_SYS_ADMIN
-    if !current
-        .cred()
-        .has_capability(crate::process::cred::CAPFlags::CAP_SYS_ADMIN)
-    {
-        return Err(SystemError::EACCES);
-    }
 
     // 只能从 Disabled 切换（不可逆）
     let prev = current.seccomp_mode.compare_exchange(
@@ -731,6 +877,23 @@ pub fn seccomp_set_mode_filter(fprog_ptr: u64, flags: u32) -> Result<(), SystemE
     Ok(())
 }
 
+pub fn seccomp_get_action_avail(action_ptr: u64) -> Result<(), SystemError> {
+    let mut buf = [0u8; core::mem::size_of::<u32>()];
+    let reader = UserBufferReader::new(action_ptr as *const u8, buf.len(), true)?;
+    reader.copy_from_user_protected(&mut buf, 0)?;
+    let action = u32::from_ne_bytes(buf);
+
+    match action {
+        SECCOMP_RET_KILL_PROCESS
+        | SECCOMP_RET_KILL_THREAD
+        | SECCOMP_RET_TRAP
+        | SECCOMP_RET_ERRNO
+        | SECCOMP_RET_LOG
+        | SECCOMP_RET_ALLOW => Ok(()),
+        _ => Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
+    }
+}
+
 /// 从用户空间读取 sock_fprog 结构
 fn read_sock_fprog(ptr: u64) -> Result<SockFprog, SystemError> {
     let size = core::mem::size_of::<SockFprog>();
@@ -754,15 +917,22 @@ fn read_sock_fprog(ptr: u64) -> Result<SockFprog, SystemError> {
 /// 从用户空间读取 filter 指令数组
 fn read_filter_insns(ptr: u64, count: usize) -> Result<Vec<SockFilter>, SystemError> {
     let insn_size = core::mem::size_of::<SockFilter>();
-    let byte_len = count * insn_size;
+    let byte_len = count.checked_mul(insn_size).ok_or(SystemError::EINVAL)?;
 
     let mut buf = alloc::vec![0u8; byte_len];
 
     let reader = UserBufferReader::new(ptr as *const u8, byte_len, true)?;
     reader.copy_from_user_protected(&mut buf, 0)?;
 
-    let ptr = buf.as_ptr() as *const SockFilter;
-    let insns = unsafe { core::slice::from_raw_parts(ptr, count) }.to_vec();
+    let mut insns = Vec::with_capacity(count);
+    for chunk in buf.chunks_exact(insn_size) {
+        insns.push(SockFilter {
+            code: u16::from_ne_bytes([chunk[0], chunk[1]]),
+            jt: chunk[2],
+            jf: chunk[3],
+            k: u32::from_ne_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]),
+        });
+    }
 
     Ok(insns)
 }

--- a/kernel/src/process/seccomp.rs
+++ b/kernel/src/process/seccomp.rs
@@ -15,7 +15,7 @@ use crate::{
     arch::{interrupt::TrapFrame, ipc::signal::Signal},
     ipc::signal_types::{SaHandlerType, SigCode, SigInfo, SigType, SigactionType, SignalFlags},
     libs::spinlock::SpinLock,
-    process::{pid::PidType, ProcessManager},
+    process::{pid::PidType, ProcessControlBlock, ProcessManager},
     syscall::user_access::UserBufferReader,
 };
 
@@ -30,6 +30,8 @@ pub const SECCOMP_RET_KILL_THREAD: u32 = 0x00000000;
 pub const SECCOMP_RET_TRAP: u32 = 0x00030000;
 /// 返回 -errno
 pub const SECCOMP_RET_ERRNO: u32 = 0x00050000;
+/// 通知 ptracer；无 ptracer 时返回 -ENOSYS
+pub const SECCOMP_RET_TRACE: u32 = 0x7ff00000;
 /// 允许但记录日志
 pub const SECCOMP_RET_LOG: u32 = 0x7ffc0000;
 /// 允许
@@ -612,6 +614,9 @@ pub fn secure_computing(
                     let errno = data_val.min(MAX_ERRNO);
                     Ok(SeccompDecision::Skip((-(errno as i32)) as usize))
                 }
+                SECCOMP_RET_TRACE => Ok(SeccompDecision::Skip(
+                    SystemError::ENOSYS.to_posix_errno() as usize,
+                )),
                 SECCOMP_RET_LOG => {
                     log::info!(
                         "seccomp: pid={:?} syscall={} action=LOG",
@@ -632,9 +637,6 @@ pub fn secure_computing(
 }
 
 /// 发送 SIGSYS 信号给当前进程（TRAP 动作）
-///
-/// TODO: 扩展 SigCode/SigType，让用户态 siginfo 携带 Linux 的
-/// SYS_SECCOMP、call_addr、syscall 和 arch 字段。
 fn send_seccomp_sigsys(data: &SeccompData, errno: u32) {
     let pcb = ProcessManager::current_pcb();
     let sig = Signal::SIGSYS;
@@ -649,7 +651,7 @@ fn send_seccomp_sigsys(data: &SeccompData, errno: u32) {
 
     let mut info = SigInfo::new(
         sig,
-        errno.min(MAX_ERRNO) as i32,
+        errno as i32,
         SigCode::SysSeccomp,
         SigType::SigSys {
             call_addr: data.instruction_pointer,
@@ -823,7 +825,7 @@ pub fn seccomp_set_mode_strict() -> Result<(), SystemError> {
 ///
 /// # 参数
 /// - `fprog_ptr`: 用户态 sock_fprog 结构指针
-/// - `flags`: 安装标志（目前仅支持 SECCOMP_FILTER_FLAG_LOG）
+/// - `flags`: 安装标志（支持 LOG 和 TSYNC）
 pub fn seccomp_set_mode_filter(fprog_ptr: u64, flags: u32) -> Result<(), SystemError> {
     let current = ProcessManager::current_pcb();
 
@@ -843,12 +845,14 @@ pub fn seccomp_set_mode_filter(fprog_ptr: u64, flags: u32) -> Result<(), SystemE
     }
 
     // 解析 flags
+    const SECCOMP_FILTER_FLAG_TSYNC: u32 = 1 << 0;
     const SECCOMP_FILTER_FLAG_LOG: u32 = 1 << 1;
-    const SUPPORTED_FLAGS: u32 = SECCOMP_FILTER_FLAG_LOG;
+    const SUPPORTED_FLAGS: u32 = SECCOMP_FILTER_FLAG_TSYNC | SECCOMP_FILTER_FLAG_LOG;
     if flags & !SUPPORTED_FLAGS != 0 {
         return Err(SystemError::EINVAL);
     }
     let log = (flags & SECCOMP_FILTER_FLAG_LOG) != 0;
+    let tsync = (flags & SECCOMP_FILTER_FLAG_TSYNC) != 0;
 
     // 从用户空间读取 sock_fprog
     let fprog = read_sock_fprog(fprog_ptr)?;
@@ -863,16 +867,24 @@ pub fn seccomp_set_mode_filter(fprog_ptr: u64, flags: u32) -> Result<(), SystemE
     // 获取当前 filter 链头作为 prev
     let prev = current.seccomp_filter.lock().clone();
 
+    if tsync {
+        seccomp_can_sync_threads(&current, &prev)?;
+    }
+
     // 创建新 filter
-    let filter = SeccompFilter::new(insns, log, prev)?;
+    let filter = Arc::new(SeccompFilter::new(insns, log, prev)?);
 
     // 安装到链头
-    *current.seccomp_filter.lock() = Some(Arc::new(filter));
+    *current.seccomp_filter.lock() = Some(filter.clone());
 
     // 设置模式为 Filter（如果是第一次安装）
     current
         .seccomp_mode
         .store(SeccompMode::Filter as u8, Ordering::SeqCst);
+
+    if tsync {
+        seccomp_sync_threads(&current, filter);
+    }
 
     Ok(())
 }
@@ -888,10 +900,90 @@ pub fn seccomp_get_action_avail(action_ptr: u64) -> Result<(), SystemError> {
         | SECCOMP_RET_KILL_THREAD
         | SECCOMP_RET_TRAP
         | SECCOMP_RET_ERRNO
+        | SECCOMP_RET_TRACE
         | SECCOMP_RET_LOG
         | SECCOMP_RET_ALLOW => Ok(()),
         _ => Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
     }
+}
+
+fn seccomp_can_sync_threads(
+    current: &Arc<ProcessControlBlock>,
+    current_filter: &Option<Arc<SeccompFilter>>,
+) -> Result<(), SystemError> {
+    for thread in thread_group_tasks(current) {
+        if Arc::ptr_eq(&thread, current) || thread.is_exited() || thread.is_dead() {
+            continue;
+        }
+
+        match thread.seccomp_mode() {
+            SeccompMode::Disabled => continue,
+            SeccompMode::Filter => {
+                let thread_filter = thread.seccomp_filter.lock().clone();
+                if is_filter_ancestor(&thread_filter, current_filter) {
+                    continue;
+                }
+            }
+            _ => {}
+        }
+
+        return Err(SystemError::EINVAL);
+    }
+
+    Ok(())
+}
+
+fn seccomp_sync_threads(current: &Arc<ProcessControlBlock>, filter: Arc<SeccompFilter>) {
+    for thread in thread_group_tasks(current) {
+        if Arc::ptr_eq(&thread, current) || thread.is_exited() || thread.is_dead() {
+            continue;
+        }
+
+        *thread.seccomp_filter.lock() = Some(filter.clone());
+        thread
+            .seccomp_mode
+            .store(SeccompMode::Filter as u8, Ordering::SeqCst);
+        if current.no_new_privs() != 0 {
+            thread.set_no_new_privs(true);
+        }
+    }
+}
+
+fn thread_group_tasks(current: &Arc<ProcessControlBlock>) -> Vec<Arc<ProcessControlBlock>> {
+    let leader = current
+        .threads_read_irqsave()
+        .group_leader()
+        .unwrap_or_else(|| current.clone());
+    let mut tasks = Vec::new();
+    tasks.push(leader.clone());
+
+    let weak_tasks = leader.threads_read_irqsave().group_tasks_clone();
+    for weak in weak_tasks {
+        if let Some(task) = weak.upgrade() {
+            tasks.push(task);
+        }
+    }
+
+    tasks
+}
+
+fn is_filter_ancestor(
+    descendant: &Option<Arc<SeccompFilter>>,
+    ancestor: &Option<Arc<SeccompFilter>>,
+) -> bool {
+    let Some(ancestor) = ancestor else {
+        return false;
+    };
+
+    let mut current = descendant.clone();
+    while let Some(filter) = current {
+        if Arc::ptr_eq(&filter, ancestor) {
+            return true;
+        }
+        current = filter.prev().clone();
+    }
+
+    false
 }
 
 /// 从用户空间读取 sock_fprog 结构

--- a/kernel/src/process/seccomp.rs
+++ b/kernel/src/process/seccomp.rs
@@ -1,0 +1,788 @@
+//! Seccomp (Secure Computing) 实现
+//!
+//! 提供基于 classic BPF (cBPF) 的系统调用过滤。
+//! 支持 SECCOMP_MODE_STRICT 和 SECCOMP_MODE_FILTER。
+//!
+//! 参考: Linux 6.6 kernel/seccomp.c
+
+use alloc::{sync::Arc, vec::Vec};
+use core::sync::atomic::Ordering;
+
+use log::warn;
+use system_error::SystemError;
+
+use crate::{
+    arch::ipc::signal::Signal,
+    ipc::signal_types::{SigCode, SigInfo, SigType},
+    libs::spinlock::SpinLock,
+    process::{pid::PidType, ProcessManager},
+    syscall::user_access::UserBufferReader,
+};
+
+// ============ Seccomp Return Actions ============
+// 参考 Linux include/uapi/linux/seccomp.h
+
+/// 杀死整个进程（线程组）
+pub const SECCOMP_RET_KILL_PROCESS: u32 = 0x80000000;
+/// 杀死当前线程
+pub const SECCOMP_RET_KILL_THREAD: u32 = 0x00000000;
+/// 发送 SIGSYS
+pub const SECCOMP_RET_TRAP: u32 = 0x00030000;
+/// 返回 -errno
+pub const SECCOMP_RET_ERRNO: u32 = 0x00050000;
+/// 允许但记录日志
+pub const SECCOMP_RET_LOG: u32 = 0x7ffc0000;
+/// 允许
+pub const SECCOMP_RET_ALLOW: u32 = 0x7fff0000;
+/// 动作掩码（高16位）
+pub const SECCOMP_RET_ACTION_FULL: u32 = 0xffff0000;
+/// 数据掩码（低16位）
+pub const SECCOMP_RET_DATA: u32 = 0x0000ffff;
+
+// ============ Seccomp Mode ============
+
+/// Seccomp 模式
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeccompMode {
+    /// 未启用
+    Disabled = 0,
+    /// 严格模式：仅允许 read/write/exit/rt_sigreturn
+    Strict = 1,
+    /// 过滤模式：使用 BPF 过滤器
+    Filter = 2,
+    /// 进程已被 seccomp 杀死（不可逆）
+    Dead = 3,
+}
+
+impl From<u8> for SeccompMode {
+    fn from(v: u8) -> Self {
+        match v {
+            0 => Self::Disabled,
+            1 => Self::Strict,
+            2 => Self::Filter,
+            3 => Self::Dead,
+            _ => Self::Disabled,
+        }
+    }
+}
+
+// ============ Seccomp Data ============
+
+/// BPF 过滤器执行时的输入数据
+/// 对应 Linux struct seccomp_data（64 字节）
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct SeccompData {
+    /// 系统调用号
+    pub nr: i32,
+    /// 架构标识 (AUDIT_ARCH_X86_64 = 0xC000003E)
+    pub arch: u32,
+    /// 用户态指令指针
+    pub instruction_pointer: u64,
+    /// 系统调用参数
+    pub args: [u64; 6],
+}
+
+const SECCOMP_DATA_SIZE: usize = core::mem::size_of::<SeccompData>();
+
+/// AUDIT_ARCH_X86_64 常量
+const AUDIT_ARCH_X86_64: u32 = 0xC000003E;
+
+// ============ Sock Filter / Sock Fprog ============
+
+/// Classic BPF 指令（对应 Linux struct sock_filter，8 字节）
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SockFilter {
+    pub code: u16,
+    pub jt: u8,
+    pub jf: u8,
+    pub k: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SockFprog {
+    pub len: u16,
+    _pad: [u8; 6],
+    pub filter: u64,
+}
+
+// ============ BPF 指令常量 ============
+// 参考 Linux include/uapi/linux/filter.h
+
+// 指令类型
+const BPF_LD: u16 = 0x00;
+const BPF_LDX: u16 = 0x01;
+const BPF_ST: u16 = 0x02;
+const BPF_STX: u16 = 0x03;
+const BPF_ALU: u16 = 0x04;
+const BPF_JMP: u16 = 0x05;
+const BPF_RET: u16 = 0x06;
+const BPF_MISC: u16 = 0x07;
+
+// 操作数宽度
+#[allow(dead_code)]
+const BPF_W: u16 = 0x00;
+
+// 寻址模式
+const BPF_IMM: u16 = 0x00;
+const BPF_ABS: u16 = 0x20;
+const BPF_MEM: u16 = 0x60;
+const BPF_LEN: u16 = 0x80;
+
+// 数据源
+const BPF_K: u16 = 0x00;
+const BPF_X: u16 = 0x08;
+
+// ALU 操作
+const BPF_ADD: u16 = 0x00;
+const BPF_SUB: u16 = 0x10;
+const BPF_MUL: u16 = 0x20;
+const BPF_DIV: u16 = 0x30;
+const BPF_OR: u16 = 0x40;
+const BPF_AND: u16 = 0x50;
+const BPF_LSH: u16 = 0x60;
+const BPF_RSH: u16 = 0x70;
+const BPF_NEG: u16 = 0x80;
+const BPF_MOD: u16 = 0x90;
+const BPF_XOR: u16 = 0xa0;
+
+// JMP 操作
+const BPF_JA: u16 = 0x00;
+const BPF_JEQ: u16 = 0x10;
+const BPF_JGT: u16 = 0x20;
+const BPF_JGE: u16 = 0x30;
+const BPF_JSET: u16 = 0x40;
+
+// MISC 操作
+const BPF_TAX: u16 = 0x00;
+const BPF_TXA: u16 = 0x80;
+
+/// BPF 程序最大指令数（Linux 限制）
+const BPF_MAXINSNS: usize = 4096;
+
+/// BPF 记忆体大小（16 个 u32 字）
+const BPF_MEMWORDS: usize = 16;
+
+// ============ Strict 模式白名单 ============
+
+/// SECCOMP_MODE_STRICT 允许的系统调用白名单 (x86_64)
+#[cfg(target_arch = "x86_64")]
+const SECCOMP_STRICT_WHITELIST: [i32; 5] = [
+    0,   // read
+    1,   // write
+    60,  // exit
+    15,  // rt_sigreturn
+    231, // exit_group
+];
+
+/// SECCOMP_MODE_STRICT 允许的系统调用白名单 (riscv64)
+#[cfg(target_arch = "riscv64")]
+const SECCOMP_STRICT_WHITELIST: [i32; 4] = [
+    63, // read
+    64, // write
+    93, // exit
+    // riscv64 的 rt_sigreturn 通过特殊机制处理
+    0, // 在某些架构上可能不需要
+];
+
+// ============ Seccomp Filter ============
+
+#[derive(Debug)]
+pub struct SeccompFilter {
+    log: bool,
+    prev: Option<Arc<SeccompFilter>>,
+    insns: Vec<SockFilter>,
+}
+
+impl SeccompFilter {
+    /// 创建新的过滤器并挂载到现有过滤器链头部
+    ///
+    /// # 参数
+    /// - `insns`: BPF 指令数组
+    /// - `log`: 是否启用日志
+    /// - `prev`: 前一个过滤器（链表尾）
+    pub fn new(
+        insns: Vec<SockFilter>,
+        log: bool,
+        prev: Option<Arc<SeccompFilter>>,
+    ) -> Result<Self, SystemError> {
+        validate_seccomp_filter(&insns)?;
+        Ok(Self { log, prev, insns })
+    }
+
+    /// 获取前一个过滤器
+    #[inline]
+    pub fn prev(&self) -> &Option<Arc<SeccompFilter>> {
+        &self.prev
+    }
+
+    /// 执行此过滤器
+    fn run(&self, data: &SeccompData) -> u32 {
+        let result = run_cbpf(&self.insns, data);
+
+        // 如果启用了 log 且结果不是 ALLOW，记录日志
+        if self.log && (result & SECCOMP_RET_ACTION_FULL) != SECCOMP_RET_ALLOW {
+            log::info!("seccomp: filter log: syscall={} ret={:#x}", data.nr, result);
+        }
+
+        result
+    }
+}
+
+// ============ cBPF 解释器 ============
+
+/// 运行 classic BPF 程序
+///
+/// cBPF 寄存器模型：
+/// - A (u32): 累加器
+/// - X (u32): 索引寄存器
+/// - pc: 程序计数器
+/// - mem[16]: 记忆体
+fn run_cbpf(insns: &[SockFilter], data: &SeccompData) -> u32 {
+    let mut a: u32 = 0;
+    let mut x: u32 = 0;
+    let mut pc: usize = 0;
+    let mut mem = [0u32; BPF_MEMWORDS];
+
+    // 将 seccomp_data 转为字节切片以支持任意偏移读取
+    let data_bytes = unsafe {
+        core::slice::from_raw_parts(data as *const SeccompData as *const u8, SECCOMP_DATA_SIZE)
+    };
+
+    while pc < insns.len() {
+        let insn = &insns[pc];
+        let class = insn.code & 0x07;
+
+        match class {
+            BPF_LD => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM => a = insn.k,
+                    BPF_ABS => {
+                        let offset = insn.k as usize;
+                        if offset + 4 <= SECCOMP_DATA_SIZE {
+                            a = u32::from_ne_bytes([
+                                data_bytes[offset],
+                                data_bytes[offset + 1],
+                                data_bytes[offset + 2],
+                                data_bytes[offset + 3],
+                            ]);
+                        }
+                        // 越界读取：保持 A 不变（与 Linux 一致）
+                    }
+                    BPF_MEM => {
+                        if (insn.k as usize) < BPF_MEMWORDS {
+                            a = mem[insn.k as usize];
+                        }
+                    }
+                    BPF_LEN => a = SECCOMP_DATA_SIZE as u32,
+                    _ => {}
+                }
+                pc += 1;
+            }
+            BPF_LDX => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM => x = insn.k,
+                    BPF_MEM => {
+                        if (insn.k as usize) < BPF_MEMWORDS {
+                            x = mem[insn.k as usize];
+                        }
+                    }
+                    BPF_LEN => x = SECCOMP_DATA_SIZE as u32,
+                    _ => {}
+                }
+                pc += 1;
+            }
+            BPF_ST => {
+                if (insn.k as usize) < BPF_MEMWORDS {
+                    mem[insn.k as usize] = a;
+                }
+                pc += 1;
+            }
+            BPF_STX => {
+                if (insn.k as usize) < BPF_MEMWORDS {
+                    mem[insn.k as usize] = x;
+                }
+                pc += 1;
+            }
+            BPF_ALU => {
+                let op = insn.code & 0xf0;
+                let src = insn.code & 0x08;
+                let val = if src == BPF_K { insn.k } else { x };
+                match op {
+                    BPF_ADD => a = a.wrapping_add(val),
+                    BPF_SUB => a = a.wrapping_sub(val),
+                    BPF_MUL => a = a.wrapping_mul(val),
+                    BPF_DIV => a = a.checked_div(val).unwrap_or(0),
+                    BPF_OR => a |= val,
+                    BPF_AND => a &= val,
+                    BPF_LSH => a = a.wrapping_shl(val),
+                    BPF_RSH => a = a.wrapping_shr(val),
+                    BPF_NEG => a = a.wrapping_neg(),
+                    BPF_MOD => a = a.checked_rem(val).unwrap_or(0),
+                    BPF_XOR => a ^= val,
+                    _ => {}
+                }
+                pc += 1;
+            }
+            BPF_JMP => {
+                let op = insn.code & 0xf0;
+                if op == BPF_JA {
+                    // 无条件跳转
+                    pc = pc.wrapping_add(1).wrapping_add(insn.k as usize);
+                } else {
+                    // 条件跳转
+                    let src = insn.code & 0x08;
+                    let val = if src == BPF_K { insn.k } else { x };
+                    let cond = match op {
+                        BPF_JEQ => a == val,
+                        BPF_JGT => a > val,
+                        BPF_JGE => a >= val,
+                        BPF_JSET => (a & val) != 0,
+                        _ => false,
+                    };
+                    if cond {
+                        pc += 1 + insn.jt as usize;
+                    } else {
+                        pc += 1 + insn.jf as usize;
+                    }
+                }
+            }
+            BPF_RET => {
+                let src = insn.code & 0x08;
+                return if src == BPF_K { insn.k } else { a };
+            }
+            BPF_MISC => {
+                let op = insn.code & 0xf8;
+                match op {
+                    BPF_TAX => x = a,
+                    BPF_TXA => a = x,
+                    _ => {}
+                }
+                pc += 1;
+            }
+            _ => {
+                pc += 1;
+            }
+        }
+    }
+
+    // 如果程序没有返回指令（不应该通过验证器），默认 KILL_THREAD
+    SECCOMP_RET_KILL_THREAD
+}
+
+// ============ BPF 验证器 ============
+
+/// 验证 seccomp BPF 程序的合法性
+///
+/// 检查项：
+/// 1. 所有指令都在 seccomp 允许的子集内
+/// 2. 跳转目标不越界
+/// 3. BPF_LD|BPF_W|BPF_ABS 的偏移量在 seccomp_data 范围内且 4 字节对齐
+/// 4. 内存索引 < 16
+fn validate_seccomp_filter(insns: &[SockFilter]) -> Result<(), SystemError> {
+    if insns.is_empty() {
+        return Err(SystemError::EINVAL);
+    }
+    if insns.len() > BPF_MAXINSNS {
+        return Err(SystemError::EINVAL);
+    }
+
+    for (pc, insn) in insns.iter().enumerate() {
+        let class = insn.code & 0x07;
+
+        match class {
+            BPF_LD => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM | BPF_LEN => {}
+                    BPF_ABS => {
+                        let offset = insn.k as usize;
+                        if !offset.is_multiple_of(4) || offset.saturating_add(4) > SECCOMP_DATA_SIZE
+                        {
+                            return Err(SystemError::EINVAL);
+                        }
+                    }
+                    BPF_MEM => {
+                        if insn.k as usize >= BPF_MEMWORDS {
+                            return Err(SystemError::EINVAL);
+                        }
+                    }
+                    _ => return Err(SystemError::EINVAL),
+                }
+            }
+            BPF_LDX => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM | BPF_LEN => {}
+                    BPF_MEM => {
+                        if insn.k as usize >= BPF_MEMWORDS {
+                            return Err(SystemError::EINVAL);
+                        }
+                    }
+                    _ => return Err(SystemError::EINVAL),
+                }
+            }
+            BPF_ST | BPF_STX => {
+                if insn.k as usize >= BPF_MEMWORDS {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            BPF_ALU => {
+                let op = insn.code & 0xf0;
+                match op {
+                    BPF_ADD | BPF_SUB | BPF_MUL | BPF_DIV | BPF_OR | BPF_AND | BPF_LSH
+                    | BPF_RSH | BPF_NEG | BPF_MOD | BPF_XOR => {}
+                    _ => return Err(SystemError::EINVAL),
+                }
+                let src = insn.code & 0x08;
+                if src != BPF_K && src != BPF_X {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            BPF_JMP => {
+                let op = insn.code & 0xf0;
+                if op == BPF_JA {
+                    let target = pc.wrapping_add(1).wrapping_add(insn.k as usize);
+                    if target >= insns.len() {
+                        return Err(SystemError::EINVAL);
+                    }
+                } else {
+                    match op {
+                        BPF_JEQ | BPF_JGT | BPF_JGE | BPF_JSET => {}
+                        _ => return Err(SystemError::EINVAL),
+                    }
+                    let jt_target = pc + 1 + insn.jt as usize;
+                    let jf_target = pc + 1 + insn.jf as usize;
+                    if jt_target >= insns.len() || jf_target >= insns.len() {
+                        return Err(SystemError::EINVAL);
+                    }
+                    let src = insn.code & 0x08;
+                    if src != BPF_K && src != BPF_X {
+                        return Err(SystemError::EINVAL);
+                    }
+                }
+            }
+            BPF_RET => {
+                let src = insn.code & 0x08;
+                if src != BPF_K && src != BPF_X {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            BPF_MISC => {
+                let op = insn.code & 0xf8;
+                if op != BPF_TAX && op != BPF_TXA {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            _ => return Err(SystemError::EINVAL),
+        }
+    }
+
+    Ok(())
+}
+
+// ============ 过滤器执行 ============
+
+/// 运行所有过滤器，返回最终动作（最小值 = 最严格）
+///
+/// 遍历 prev 链中的所有过滤器，保留动作值最小的结果。
+/// 参考 Linux seccomp_run_filters()
+fn seccomp_run_filters(data: &SeccompData, filter: &Option<Arc<SeccompFilter>>) -> u32 {
+    let Some(head) = filter else {
+        return SECCOMP_RET_ALLOW;
+    };
+
+    let mut ret = SECCOMP_RET_ALLOW;
+    let mut current: Option<Arc<SeccompFilter>> = Some(head.clone());
+
+    while let Some(f) = current {
+        let cur_ret = f.run(data);
+        if (cur_ret & SECCOMP_RET_ACTION_FULL) < (ret & SECCOMP_RET_ACTION_FULL) {
+            ret = cur_ret;
+        }
+        current = f.prev().clone();
+    }
+
+    ret
+}
+
+// ============ Secure Computing ============
+
+/// Seccomp 系统调用检查入口
+///
+/// 在系统调用分发之前调用。根据当前进程的 seccomp 模式执行相应检查。
+///
+/// # 参数
+/// - `syscall_num`: 系统调用号
+/// - `args`: 系统调用参数（6个）
+/// - `ip`: 用户态指令指针（rip）
+///
+/// # 返回值
+/// - `Ok(())`: 允许继续执行系统调用
+/// - `Err(SystemError)`: 系统调用被拒绝（ERRNO / TRAP / KILL）
+///
+/// 对于 KILL 动作，此函数会发送 SIGSYS 并返回错误。
+/// 进程将在返回用户态时处理该信号（默认终止）。
+pub fn secure_computing(syscall_num: usize, args: &[usize; 6], ip: u64) -> Result<(), SystemError> {
+    let pcb = ProcessManager::current_pcb();
+    let mode_val = pcb.seccomp_mode.load(Ordering::Relaxed);
+    let mode = SeccompMode::from(mode_val);
+
+    match mode {
+        SeccompMode::Disabled => Ok(()),
+
+        SeccompMode::Dead => {
+            // 进程已被标记为 Dead，拒绝所有 syscall
+            send_seccomp_sigsys(syscall_num as i32, SECCOMP_RET_KILL_THREAD);
+            Err(SystemError::EPERM)
+        }
+
+        SeccompMode::Strict => {
+            // 检查白名单
+            if SECCOMP_STRICT_WHITELIST.contains(&(syscall_num as i32)) {
+                Ok(())
+            } else {
+                send_seccomp_sigsys(syscall_num as i32, SECCOMP_RET_KILL_THREAD);
+                Err(SystemError::EPERM)
+            }
+        }
+
+        SeccompMode::Filter => {
+            let data = SeccompData {
+                nr: syscall_num as i32,
+                arch: AUDIT_ARCH_X86_64,
+                instruction_pointer: ip,
+                args: [
+                    args[0] as u64,
+                    args[1] as u64,
+                    args[2] as u64,
+                    args[3] as u64,
+                    args[4] as u64,
+                    args[5] as u64,
+                ],
+            };
+
+            let filter_guard = pcb.seccomp_filter.lock();
+            let result = seccomp_run_filters(&data, &filter_guard);
+            drop(filter_guard);
+
+            let action = result & SECCOMP_RET_ACTION_FULL;
+            let data_val = (result & SECCOMP_RET_DATA) as i32;
+
+            match action {
+                SECCOMP_RET_KILL_PROCESS | SECCOMP_RET_KILL_THREAD => {
+                    pcb.seccomp_mode
+                        .store(SeccompMode::Dead as u8, Ordering::Relaxed);
+                    send_seccomp_sigsys(data.nr, action);
+                    Err(SystemError::EPERM)
+                }
+                SECCOMP_RET_TRAP => {
+                    send_seccomp_sigsys(data.nr, action);
+                    let errno_val = -data_val;
+                    SystemError::from_posix_errno(errno_val).map_or(Err(SystemError::EPERM), Err)
+                }
+                SECCOMP_RET_ERRNO => {
+                    let errno_val = -data_val;
+                    SystemError::from_posix_errno(errno_val).map_or(Err(SystemError::EPERM), Err)
+                }
+                SECCOMP_RET_LOG => {
+                    log::info!(
+                        "seccomp: pid={:?} syscall={} action=LOG",
+                        pcb.raw_pid(),
+                        syscall_num
+                    );
+                    Ok(())
+                }
+                SECCOMP_RET_ALLOW => Ok(()),
+
+                _ => {
+                    // 未知动作，默认 KILL
+                    pcb.seccomp_mode
+                        .store(SeccompMode::Dead as u8, Ordering::Relaxed);
+                    send_seccomp_sigsys(data.nr, SECCOMP_RET_KILL_THREAD);
+                    Err(SystemError::EPERM)
+                }
+            }
+        }
+    }
+}
+
+/// 发送 SIGSYS 信号给当前进程（内核强制）
+///
+/// si_code = SI_KERNEL (0x80)
+/// si_errno = seccomp action
+fn send_seccomp_sigsys(_syscall_nr: i32, action: u32) {
+    let pcb = ProcessManager::current_pcb();
+    let sig = Signal::SIGSYS;
+
+    let mut info = SigInfo::new(
+        sig,
+        action as i32,
+        SigCode::Kernel,
+        SigType::Kill {
+            pid: pcb.raw_pid(),
+            uid: pcb.cred().uid.data() as u32,
+        },
+    );
+
+    if let Err(e) = sig.send_signal_info_to_pcb(Some(&mut info), pcb.clone(), PidType::PID) {
+        warn!(
+            "seccomp: failed to send SIGSYS to pid={:?}: {:?}",
+            pcb.raw_pid(),
+            e
+        );
+    }
+}
+
+// ============ Seccomp 模式操作 ============
+
+/// 设置 strict 模式
+///
+/// 要求 CAP_SYS_ADMIN 权限。只能从 Disabled 切换（不可逆）。
+pub fn seccomp_set_mode_strict() -> Result<(), SystemError> {
+    let current = ProcessManager::current_pcb();
+
+    // Linux: 需要 CAP_SYS_ADMIN
+    if !current
+        .cred()
+        .has_capability(crate::process::cred::CAPFlags::CAP_SYS_ADMIN)
+    {
+        return Err(SystemError::EACCES);
+    }
+
+    // 只能从 Disabled 切换（不可逆）
+    let prev = current.seccomp_mode.compare_exchange(
+        SeccompMode::Disabled as u8,
+        SeccompMode::Strict as u8,
+        Ordering::SeqCst,
+        Ordering::SeqCst,
+    );
+
+    if prev.is_err() {
+        return Err(SystemError::EINVAL);
+    }
+
+    Ok(())
+}
+
+/// 设置 filter 模式，安装新的 BPF 过滤器
+///
+/// 要求 CAP_SYS_ADMIN 或 no_new_privs 已设置。
+/// 当前模式必须为 Disabled 或 Filter。
+///
+/// # 参数
+/// - `fprog_ptr`: 用户态 sock_fprog 结构指针
+/// - `flags`: 安装标志（目前仅支持 SECCOMP_FILTER_FLAG_LOG）
+pub fn seccomp_set_mode_filter(fprog_ptr: u64, flags: u32) -> Result<(), SystemError> {
+    let current = ProcessManager::current_pcb();
+
+    // Linux: CAP_SYS_ADMIN 或 no_new_privs
+    if !current
+        .cred()
+        .has_capability(crate::process::cred::CAPFlags::CAP_SYS_ADMIN)
+        && current.no_new_privs() == 0
+    {
+        return Err(SystemError::EACCES);
+    }
+
+    // 当前模式不能超过 Filter
+    let mode = SeccompMode::from(current.seccomp_mode.load(Ordering::Relaxed));
+    if mode != SeccompMode::Disabled && mode != SeccompMode::Filter {
+        return Err(SystemError::EINVAL);
+    }
+
+    // 解析 flags
+    const SECCOMP_FILTER_FLAG_LOG: u32 = 1 << 1;
+    const SUPPORTED_FLAGS: u32 = SECCOMP_FILTER_FLAG_LOG;
+    if flags & !SUPPORTED_FLAGS != 0 {
+        return Err(SystemError::EINVAL);
+    }
+    let log = (flags & SECCOMP_FILTER_FLAG_LOG) != 0;
+
+    // 从用户空间读取 sock_fprog
+    let fprog = read_sock_fprog(fprog_ptr)?;
+
+    if fprog.len == 0 || fprog.len as usize > BPF_MAXINSNS {
+        return Err(SystemError::EINVAL);
+    }
+
+    // 从用户空间读取 filter 指令
+    let insns = read_filter_insns(fprog.filter, fprog.len as usize)?;
+
+    // 获取当前 filter 链头作为 prev
+    let prev = current.seccomp_filter.lock().clone();
+
+    // 创建新 filter
+    let filter = SeccompFilter::new(insns, log, prev)?;
+
+    // 安装到链头
+    *current.seccomp_filter.lock() = Some(Arc::new(filter));
+
+    // 设置模式为 Filter（如果是第一次安装）
+    current
+        .seccomp_mode
+        .store(SeccompMode::Filter as u8, Ordering::SeqCst);
+
+    Ok(())
+}
+
+/// 从用户空间读取 sock_fprog 结构
+fn read_sock_fprog(ptr: u64) -> Result<SockFprog, SystemError> {
+    let size = core::mem::size_of::<SockFprog>();
+    let mut buf = [0u8; core::mem::size_of::<SockFprog>()];
+
+    let reader = UserBufferReader::new(ptr as *const u8, size, true)?;
+    reader.copy_from_user_protected(&mut buf, 0)?;
+
+    let len = u16::from_ne_bytes([buf[0], buf[1]]);
+    let filter = u64::from_ne_bytes([
+        buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
+    ]);
+
+    Ok(SockFprog {
+        len,
+        _pad: [0u8; 6],
+        filter,
+    })
+}
+
+/// 从用户空间读取 filter 指令数组
+fn read_filter_insns(ptr: u64, count: usize) -> Result<Vec<SockFilter>, SystemError> {
+    let insn_size = core::mem::size_of::<SockFilter>();
+    let byte_len = count * insn_size;
+
+    let mut buf = alloc::vec![0u8; byte_len];
+
+    let reader = UserBufferReader::new(ptr as *const u8, byte_len, true)?;
+    reader.copy_from_user_protected(&mut buf, 0)?;
+
+    let ptr = buf.as_ptr() as *const SockFilter;
+    let insns = unsafe { core::slice::from_raw_parts(ptr, count) }.to_vec();
+
+    Ok(insns)
+}
+
+/// fork 时复制 seccomp 状态
+///
+/// - 复制 seccomp_mode（值复制）
+/// - 共享 seccomp_filter（Arc::clone）
+pub fn copy_seccomp(
+    parent_mode: u8,
+    parent_filter: &SpinLock<Option<Arc<SeccompFilter>>>,
+    child_seccomp_mode: &core::sync::atomic::AtomicU8,
+    child_seccomp_filter: &SpinLock<Option<Arc<SeccompFilter>>>,
+) {
+    // 复制 mode
+    child_seccomp_mode.store(parent_mode, Ordering::Relaxed);
+
+    // 共享 filter（Arc::clone 增加引用计数）
+    let parent_guard = parent_filter.lock();
+    if let Some(ref f) = *parent_guard {
+        *child_seccomp_filter.lock() = Some(f.clone());
+    }
+}

--- a/kernel/src/process/syscall/mod.rs
+++ b/kernel/src/process/syscall/mod.rs
@@ -25,6 +25,7 @@ mod sys_pidfdopen;
 mod sys_prctl;
 pub mod sys_prlimit64;
 mod sys_rseq;
+mod sys_seccomp;
 mod sys_set_tid_address;
 mod sys_setdomainname;
 mod sys_setfsgid;

--- a/kernel/src/process/syscall/sys_prctl.rs
+++ b/kernel/src/process/syscall/sys_prctl.rs
@@ -48,6 +48,8 @@ enum PrctlOption {
     SetKeepCaps = 8,
     SetName = 15,
     GetName = 16,
+    GetSeccomp = 21,
+    SetSeccomp = 22,
     CapBsetRead = 23,
     CapBsetDrop = 24,
 
@@ -231,6 +233,23 @@ impl Syscall for SysPrctl {
                 current.set_cred(new_cred)?;
                 Ok(0)
             }
+
+            PrctlOption::GetSeccomp => {
+                let mode = current.seccomp_mode();
+                Ok(mode as usize)
+            }
+            PrctlOption::SetSeccomp => match arg2 {
+                1 => {
+                    crate::process::seccomp::seccomp_set_mode_strict()?;
+                    Ok(0)
+                }
+                2 => {
+                    let fprog_ptr = args[2] as u64;
+                    crate::process::seccomp::seccomp_set_mode_filter(fprog_ptr, 0)?;
+                    Ok(0)
+                }
+                _ => Err(SystemError::EINVAL),
+            },
 
             PrctlOption::SetNoNewPrivs => {
                 // Linux: arg2 必须为 1；no_new_privs 一旦置位不可清除。

--- a/kernel/src/process/syscall/sys_seccomp.rs
+++ b/kernel/src/process/syscall/sys_seccomp.rs
@@ -1,0 +1,63 @@
+use alloc::{string::ToString, vec::Vec};
+use system_error::SystemError;
+
+use crate::{
+    arch::{interrupt::TrapFrame, syscall::nr::SYS_SECCOMP},
+    process::seccomp,
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+
+const SECCOMP_SET_MODE_STRICT: u32 = 0;
+const SECCOMP_SET_MODE_FILTER: u32 = 1;
+
+pub struct SysSeccomp;
+
+impl Syscall for SysSeccomp {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let op = args[0] as u32;
+        let flags = args[1] as u32;
+        let uargs = args[2] as u64;
+
+        match op {
+            SECCOMP_SET_MODE_STRICT => {
+                if flags != 0 {
+                    return Err(SystemError::EINVAL);
+                }
+                seccomp::seccomp_set_mode_strict()?;
+                Ok(0)
+            }
+            SECCOMP_SET_MODE_FILTER => {
+                seccomp::seccomp_set_mode_filter(uargs, flags)?;
+                Ok(0)
+            }
+            _ => Err(SystemError::EINVAL),
+        }
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        let op_val = args.first().copied().unwrap_or(0);
+        let op_str = match op_val as u32 {
+            SECCOMP_SET_MODE_STRICT => "SET_MODE_STRICT".to_string(),
+            SECCOMP_SET_MODE_FILTER => "SET_MODE_FILTER".to_string(),
+            _ => format!("{:#x}", op_val),
+        };
+
+        vec![
+            FormattedSyscallParam::new("op", op_str),
+            FormattedSyscallParam::new(
+                "flags",
+                format!("{:#x}", args.get(1).copied().unwrap_or(0)),
+            ),
+            FormattedSyscallParam::new(
+                "uargs",
+                format!("{:#x}", args.get(2).copied().unwrap_or(0)),
+            ),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SECCOMP, SysSeccomp);

--- a/kernel/src/process/syscall/sys_seccomp.rs
+++ b/kernel/src/process/syscall/sys_seccomp.rs
@@ -9,6 +9,7 @@ use crate::{
 
 const SECCOMP_SET_MODE_STRICT: u32 = 0;
 const SECCOMP_SET_MODE_FILTER: u32 = 1;
+const SECCOMP_GET_ACTION_AVAIL: u32 = 2;
 
 pub struct SysSeccomp;
 
@@ -24,7 +25,7 @@ impl Syscall for SysSeccomp {
 
         match op {
             SECCOMP_SET_MODE_STRICT => {
-                if flags != 0 {
+                if flags != 0 || uargs != 0 {
                     return Err(SystemError::EINVAL);
                 }
                 seccomp::seccomp_set_mode_strict()?;
@@ -32,6 +33,13 @@ impl Syscall for SysSeccomp {
             }
             SECCOMP_SET_MODE_FILTER => {
                 seccomp::seccomp_set_mode_filter(uargs, flags)?;
+                Ok(0)
+            }
+            SECCOMP_GET_ACTION_AVAIL => {
+                if flags != 0 {
+                    return Err(SystemError::EINVAL);
+                }
+                seccomp::seccomp_get_action_avail(uargs)?;
                 Ok(0)
             }
             _ => Err(SystemError::EINVAL),
@@ -43,6 +51,7 @@ impl Syscall for SysSeccomp {
         let op_str = match op_val as u32 {
             SECCOMP_SET_MODE_STRICT => "SET_MODE_STRICT".to_string(),
             SECCOMP_SET_MODE_FILTER => "SET_MODE_FILTER".to_string(),
+            SECCOMP_GET_ACTION_AVAIL => "GET_ACTION_AVAIL".to_string(),
             _ => format!("{:#x}", op_val),
         };
 

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -72,7 +72,10 @@ impl Syscall {
     ) -> Result<usize, SystemError> {
         // Seccomp check — must run before syscall dispatch
         let seccomp_args = [args[0], args[1], args[2], args[3], args[4], args[5]];
-        crate::process::seccomp::secure_computing(syscall_num, &seccomp_args, frame.rip() as u64)?;
+        match crate::process::seccomp::secure_computing(syscall_num, &seccomp_args, frame)? {
+            crate::process::seccomp::SeccompDecision::Allow => {}
+            crate::process::seccomp::SeccompDecision::Skip(ret) => return Ok(ret),
+        }
 
         defer::defer!({
             if ProcessManager::current_pcb()

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -70,6 +70,10 @@ impl Syscall {
         args: &[usize],
         frame: &mut TrapFrame,
     ) -> Result<usize, SystemError> {
+        // Seccomp check — must run before syscall dispatch
+        let seccomp_args = [args[0], args[1], args[2], args[3], args[4], args[5]];
+        crate::process::seccomp::secure_computing(syscall_num, &seccomp_args, frame.rip() as u64)?;
+
         defer::defer!({
             if ProcessManager::current_pcb()
                 .flags()

--- a/user/apps/c_unitest/test_seccomp.c
+++ b/user/apps/c_unitest/test_seccomp.c
@@ -1,0 +1,496 @@
+/**
+ * Seccomp test suite for DragonOS
+ *
+ * Tests:
+ *   1. PR_GET_SECCOMP returns 0 when disabled
+ *   2. Strict mode via prctl (child killed on disallowed syscall)
+ *   3. Strict mode via seccomp() syscall
+ *   4. BPF filter: allow-all
+ *   5. BPF filter: ERRNO on write
+ *   6. BPF filter: KILL on getpid
+ *   7. Fork inherits filter
+ *   8. /proc/self/status Seccomp field
+ */
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* seccomp constants — may not be in musl headers yet */
+#ifndef PR_SET_SECCOMP
+#define PR_SET_SECCOMP 22
+#endif
+#ifndef PR_GET_SECCOMP
+#define PR_GET_SECCOMP 21
+#endif
+
+#define SECCOMP_SET_MODE_STRICT 0
+#define SECCOMP_SET_MODE_FILTER 1
+
+#define SECCOMP_RET_KILL_THREAD  0x00000000U
+#define SECCOMP_RET_TRAP         0x00030000U
+#define SECCOMP_RET_ERRNO        0x00050000U
+#define SECCOMP_RET_LOG          0x7ffc0000U
+#define SECCOMP_RET_ALLOW        0x7fff0000U
+
+/* BPF instruction encoding */
+#define BPF_LD   0x00
+#define BPF_W    0x00
+#define BPF_ABS  0x20
+#define BPF_JMP  0x05
+#define BPF_JEQ  0x10
+#define BPF_K    0x00
+#define BPF_RET  0x06
+
+struct sock_filter {
+    unsigned short code;
+    unsigned char jt;
+    unsigned char jf;
+    unsigned int k;
+};
+
+struct sock_fprog {
+    unsigned short len;
+    struct sock_filter *filter;
+};
+
+static int seccomp(unsigned int op, unsigned int flags, void *args)
+{
+    return syscall(__NR_seccomp, op, flags, args);
+}
+
+static int install_filter(struct sock_filter *fprog, unsigned short len)
+{
+    struct sock_fprog prog = {
+        .len = len,
+        .filter = fprog,
+    };
+    return seccomp(SECCOMP_SET_MODE_FILTER, 0, &prog);
+}
+
+/* ── helpers ── */
+
+static int g_pass = 0;
+static int g_fail = 0;
+static int g_skip = 0;
+
+#define TEST(name) printf("  TEST %-45s", name)
+#define PASS() do { printf("  PASS\n"); g_pass++; } while(0)
+#define FAIL(msg) do { printf("  FAIL: %s\n", msg); g_fail++; } while(0)
+#define SKIP(msg) do { printf("  SKIP: %s\n", msg); g_skip++; } while(0)
+
+/* ── test 1: PR_GET_SECCOMP disabled ── */
+
+static void test_get_seccomp_disabled(void)
+{
+    TEST("PR_GET_SECCOMP returns 0 when disabled");
+    int r = prctl(PR_GET_SECCOMP, 0, 0, 0, 0);
+    if (r == 0)
+        PASS();
+    else
+        FAIL("expected 0");
+}
+
+/* ── test 2: strict mode via prctl ── */
+
+static void test_strict_mode_prctl(void)
+{
+    TEST("strict mode: child killed on forbidden syscall");
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        /* child: enable strict, then try getpid (forbidden) */
+        prctl(PR_SET_SECCOMP, 1, 0, 0, 0);
+        /* If seccomp didn't work, getpid succeeds and we exit 0.
+         * If seccomp works, SIGSYS kills us. */
+        getpid();
+        _exit(0);
+    }
+    /* parent: wait for child */
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+        PASS();
+    else if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+        FAIL("child was NOT killed — seccomp not enforced");
+    else
+        FAIL("unexpected child exit");
+}
+
+/* ── test 3: strict mode via seccomp() syscall ── */
+
+static void test_strict_mode_seccomp_syscall(void)
+{
+    TEST("seccomp(SET_MODE_STRICT) kills on forbidden syscall");
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        seccomp(SECCOMP_SET_MODE_STRICT, 0, NULL);
+        /* getpid is forbidden in strict mode */
+        getpid();
+        _exit(0);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+        PASS();
+    else if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+        FAIL("child was NOT killed");
+    else
+        FAIL("unexpected child exit");
+}
+
+/* ── test 4: strict mode allows read/write/exit ── */
+
+static void test_strict_mode_allows_whitelist(void)
+{
+    TEST("strict mode: read/write/exit still work");
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_SECCOMP, 1, 0, 0, 0);
+        /* write is in the whitelist */
+        write(STDOUT_FILENO, "", 0);
+        /* exit with 42 to signal success */
+        _exit(42);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+        PASS();
+    else
+        FAIL("child did not exit normally");
+}
+
+/* ── test 5: BPF filter allow-all ── */
+
+static void test_filter_allow_all(void)
+{
+    TEST("BPF filter: allow-all permits syscalls");
+    struct sock_filter filter[] = {
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+    };
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        if (install_filter(filter, sizeof(filter) / sizeof(filter[0])) < 0) {
+            perror("install_filter");
+            _exit(1);
+        }
+        /* These should all succeed */
+        getpid();
+        write(STDOUT_FILENO, "", 0);
+        _exit(42);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+        PASS();
+    else
+        FAIL("child did not exit normally");
+}
+
+/* ── test 6: BPF filter ERRNO on write ── */
+
+static void test_filter_errno_write(void)
+{
+    TEST("BPF filter: ERRNO(EPERM) on write");
+    /* BPF program:
+     *   ld [0]                    // A = seccomp_data.nr
+     *   jeq __NR_write, 0, 1     // if nr==write: +0 else: +1
+     *   ret ERRNO(EPERM)         // ERRNO for write
+     *   ret ALLOW                // allow everything else
+     */
+    struct sock_filter filter[] = {
+        { BPF_LD | BPF_W | BPF_ABS, 0, 0, 0 },
+        { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, __NR_write },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ERRNO | 1 },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+    };
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        if (install_filter(filter, sizeof(filter) / sizeof(filter[0])) < 0) {
+            perror("install_filter");
+            _exit(1);
+        }
+        /* write should return -1 with errno=EPERM */
+        ssize_t r = write(STDOUT_FILENO, "x", 1);
+        _exit(r < 0 && errno == EPERM ? 42 : 1);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+        PASS();
+    else
+        FAIL("write did not fail with EPERM");
+}
+
+/* ── test 7: BPF filter KILL on getpid ── */
+
+static void test_filter_kill_getpid(void)
+{
+    TEST("BPF filter: KILL on getpid");
+    struct sock_filter filter[] = {
+        { BPF_LD | BPF_W | BPF_ABS, 0, 0, 0 },
+        { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, __NR_getpid },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_KILL_THREAD },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+    };
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        if (install_filter(filter, sizeof(filter) / sizeof(filter[0])) < 0) {
+            perror("install_filter");
+            _exit(1);
+        }
+        /* write should succeed (not blocked) */
+        write(STDOUT_FILENO, "", 0);
+        /* getpid should kill us */
+        syscall(SYS_getpid);
+        _exit(0);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+        PASS();
+    else if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+        FAIL("child was NOT killed by getpid");
+    else
+        FAIL("unexpected child exit");
+}
+
+/* ── test 8: fork inherits filter ── */
+
+static void test_filter_fork_inherit(void)
+{
+    TEST("fork child inherits seccomp filter");
+    /* Parent installs filter that blocks getpid with ERRNO(ENOENT),
+     * then forks. Child tries getpid — should fail with ENOENT. */
+    struct sock_filter filter[] = {
+        { BPF_LD | BPF_W | BPF_ABS, 0, 0, 0 },
+        { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, __NR_getpid },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ERRNO | ENOENT },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+    };
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        /* child: install filter, then fork again */
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        if (install_filter(filter, sizeof(filter) / sizeof(filter[0])) < 0) {
+            perror("install_filter");
+            _exit(1);
+        }
+
+        pid_t inner = fork();
+        if (inner < 0)
+            _exit(2);
+        if (inner == 0) {
+            errno = 0;
+            long mypid = syscall(SYS_getpid);
+            _exit(mypid == -1 && errno == ENOENT ? 42 : 3);
+        }
+        int st = 0;
+        waitpid(inner, &st, 0);
+        /* propagate grandchild result */
+        if (WIFEXITED(st) && WEXITSTATUS(st) == 42)
+            _exit(42);
+        else
+            _exit(4);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+        PASS();
+    else
+        FAIL("grandchild did not inherit filter");
+}
+
+/* ── test 9: PR_GET_SECCOMP returns 2 in filter mode ── */
+
+static void test_get_seccomp_filter(void)
+{
+    TEST("PR_GET_SECCOMP returns 2 in filter mode");
+    struct sock_filter filter[] = {
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+    };
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        install_filter(filter, sizeof(filter) / sizeof(filter[0]));
+        int mode = prctl(PR_GET_SECCOMP, 0, 0, 0, 0);
+        _exit(mode == 2 ? 42 : mode);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+        PASS();
+    else
+        FAIL("expected mode 2");
+}
+
+/* ── test 10: /proc/self/status Seccomp field ── */
+
+static void test_proc_status_seccomp(void)
+{
+    TEST("/proc/self/status shows Seccomp: 2 after filter");
+    struct sock_filter filter[] = {
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+    };
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        install_filter(filter, sizeof(filter) / sizeof(filter[0]));
+
+        FILE *f = fopen("/proc/self/status", "r");
+        if (!f) {
+            perror("fopen");
+            _exit(1);
+        }
+        char line[256];
+        int found = 0;
+        while (fgets(line, sizeof(line), f)) {
+            if (strncmp(line, "Seccomp:", 8) == 0) {
+                int val = 0;
+                sscanf(line + 8, "%d", &val);
+                if (val == 2)
+                    found = 1;
+                break;
+            }
+        }
+        fclose(f);
+        _exit(found ? 42 : 1);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+        PASS();
+    else
+        FAIL("Seccomp: 2 not found in /proc/self/status");
+}
+
+/* ── test 11: strict mode is irreversible ── */
+
+static void test_strict_irreversible(void)
+{
+    TEST("strict mode: prctl killed (indirectly proves irreversible)");
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_SECCOMP, 1, 0, 0, 0);
+        struct sock_filter filter[] = {
+            { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+        };
+        prctl(PR_SET_SECCOMP, 2, &filter, 0, 0);
+        _exit(0);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+        PASS();
+    else
+        FAIL("child was NOT killed (strict mode may not be enforced)");
+}
+
+/* ── test 12: ERRNO returns correct errno value ── */
+
+static void test_filter_errno_value(void)
+{
+    TEST("BPF filter: ERRNO returns correct errno (ENOENT=2)");
+    struct sock_filter filter[] = {
+        { BPF_LD | BPF_W | BPF_ABS, 0, 0, 0 },
+        { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, __NR_getpid },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ERRNO | ENOENT },
+        { BPF_RET | BPF_K, 0, 0, SECCOMP_RET_ALLOW },
+    };
+    pid_t pid = fork();
+    if (pid < 0) {
+        FAIL("fork failed");
+        return;
+    }
+    if (pid == 0) {
+        prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+        if (install_filter(filter, sizeof(filter) / sizeof(filter[0])) < 0) {
+            perror("install_filter");
+            _exit(1);
+        }
+        errno = 0;
+        long r = syscall(SYS_getpid);
+        _exit(r == -1 && errno == ENOENT ? 42 : 1);
+    }
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+        PASS();
+    else
+        FAIL("getpid did not return -ENOENT");
+}
+
+/* ── main ── */
+
+int main(void)
+{
+    printf("=== Seccomp Test Suite ===\n\n");
+
+    test_get_seccomp_disabled();
+    test_strict_mode_prctl();
+    test_strict_mode_seccomp_syscall();
+    test_strict_mode_allows_whitelist();
+    test_strict_irreversible();
+    test_filter_allow_all();
+    test_filter_errno_write();
+    test_filter_kill_getpid();
+    test_filter_fork_inherit();
+    test_get_seccomp_filter();
+    test_proc_status_seccomp();
+    test_filter_errno_value();
+
+    printf("\n=== Results: %d passed, %d failed, %d skipped ===\n",
+           g_pass, g_fail, g_skip);
+
+    return g_fail > 0 ? 1 : 0;
+}

--- a/user/apps/tests/dunitest/suites/normal/seccomp.cc
+++ b/user/apps/tests/dunitest/suites/normal/seccomp.cc
@@ -1,0 +1,289 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/ucontext.h>
+#include <sys/wait.h>
+#include <ucontext.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#ifndef AUDIT_ARCH_X86_64
+#define AUDIT_ARCH_X86_64 0xC000003E
+#endif
+
+#ifndef SECCOMP_RET_KILL_PROCESS
+#define SECCOMP_RET_KILL_PROCESS 0x80000000U
+#endif
+
+#ifndef SYS_SECCOMP
+#define SYS_SECCOMP 1
+#endif
+
+namespace {
+
+constexpr int kOk = 42;
+constexpr long kTrapReturn = 424242;
+
+int InstallFilter(const struct sock_filter* filter, unsigned short len) {
+  struct sock_fprog prog = {
+      .len = len,
+      .filter = const_cast<struct sock_filter*>(filter),
+  };
+  return syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog);
+}
+
+int ChildStatus(void (*child)()) {
+  pid_t pid = fork();
+  if (pid == 0) {
+    child();
+    _exit(1);
+  }
+  EXPECT_GT(pid, 0);
+  int status = 0;
+  EXPECT_EQ(waitpid(pid, &status, 0), pid);
+  return status;
+}
+
+void RequireNoNewPrivs() {
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    _exit(2);
+  }
+}
+
+void InstallGetpidTrapFilter() {
+  struct sock_filter filter[] = {
+      BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+      BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
+      BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRAP | 123),
+      BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+  };
+  if (InstallFilter(filter, sizeof(filter) / sizeof(filter[0])) != 0) {
+    _exit(2);
+  }
+}
+
+void SeccompTrapHandler(int signo, siginfo_t* info, void* raw_ucontext) {
+  if (signo != SIGSYS || info == nullptr || raw_ucontext == nullptr) {
+    _exit(10);
+  }
+  if (info->si_signo != SIGSYS || info->si_code != SYS_SECCOMP || info->si_errno != 123) {
+    _exit(11);
+  }
+  if (info->si_call_addr == nullptr || info->si_syscall != __NR_getpid ||
+      info->si_arch != AUDIT_ARCH_X86_64) {
+    _exit(12);
+  }
+
+  auto* ctx = reinterpret_cast<ucontext_t*>(raw_ucontext);
+  if (ctx->uc_mcontext.gregs[REG_RAX] != __NR_getpid) {
+    _exit(13);
+  }
+  ctx->uc_mcontext.gregs[REG_RAX] = kTrapReturn;
+}
+
+}  // namespace
+
+TEST(SeccompTest, StrictModeKillsForbiddenSyscall) {
+  int status = ChildStatus([] {
+    if (syscall(__NR_seccomp, SECCOMP_SET_MODE_STRICT, 0, nullptr) != 0) {
+      _exit(2);
+    }
+    syscall(__NR_getpid);
+    _exit(3);
+  });
+
+  ASSERT_TRUE(WIFSIGNALED(status)) << "status=" << status;
+  EXPECT_EQ(WTERMSIG(status), SIGKILL);
+}
+
+TEST(SeccompTest, ErrnoActionSkipsSyscallWithRequestedErrno) {
+  int status = ChildStatus([] {
+    RequireNoNewPrivs();
+    struct sock_filter filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | ENOENT),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    if (InstallFilter(filter, sizeof(filter) / sizeof(filter[0])) != 0) {
+      _exit(2);
+    }
+    errno = 0;
+    long ret = syscall(__NR_getpid);
+    _exit(ret == -1 && errno == ENOENT ? kOk : 3);
+  });
+
+  ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+  EXPECT_EQ(WEXITSTATUS(status), kOk);
+}
+
+TEST(SeccompTest, ArchFieldMatchesNativeAuditArch) {
+  int status = ChildStatus([] {
+    RequireNoNewPrivs();
+    struct sock_filter filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, arch)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_X86_64, 1, 0),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    if (InstallFilter(filter, sizeof(filter) / sizeof(filter[0])) != 0) {
+      _exit(2);
+    }
+    syscall(__NR_getpid);
+    _exit(kOk);
+  });
+
+  ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+  EXPECT_EQ(WEXITSTATUS(status), kOk);
+}
+
+TEST(SeccompTest, KillActionCannotBeCaught) {
+  int status = ChildStatus([] {
+    struct sigaction sa = {};
+    sa.sa_handler = [](int) {};
+    sigaction(SIGSYS, &sa, nullptr);
+
+    RequireNoNewPrivs();
+    struct sock_filter filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_THREAD),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    if (InstallFilter(filter, sizeof(filter) / sizeof(filter[0])) != 0) {
+      _exit(2);
+    }
+    syscall(__NR_getpid);
+    _exit(3);
+  });
+
+  ASSERT_TRUE(WIFSIGNALED(status)) << "status=" << status;
+  EXPECT_EQ(WTERMSIG(status), SIGSYS);
+}
+
+TEST(SeccompTest, KillProcessWinsOverLaterErrnoFilter) {
+  int status = ChildStatus([] {
+    RequireNoNewPrivs();
+    struct sock_filter kill_filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    struct sock_filter errno_filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    if (InstallFilter(kill_filter, sizeof(kill_filter) / sizeof(kill_filter[0])) != 0 ||
+        InstallFilter(errno_filter, sizeof(errno_filter) / sizeof(errno_filter[0])) != 0) {
+      _exit(2);
+    }
+    syscall(__NR_getpid);
+    _exit(3);
+  });
+
+  ASSERT_TRUE(WIFSIGNALED(status)) << "status=" << status;
+  EXPECT_EQ(WTERMSIG(status), SIGSYS);
+}
+
+TEST(SeccompTest, TrapDeliversSysSeccompSiginfoAndCanEmulateReturn) {
+  int status = ChildStatus([] {
+    struct sigaction sa = {};
+    sa.sa_sigaction = SeccompTrapHandler;
+    sa.sa_flags = SA_SIGINFO;
+    if (sigaction(SIGSYS, &sa, nullptr) != 0) {
+      _exit(2);
+    }
+
+    RequireNoNewPrivs();
+    InstallGetpidTrapFilter();
+    errno = 0;
+    long ret = syscall(__NR_getpid);
+    _exit(ret == kTrapReturn && errno == 0 ? kOk : 3);
+  });
+
+  ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+  EXPECT_EQ(WEXITSTATUS(status), kOk);
+}
+
+TEST(SeccompTest, TrapIsForcedWhenSigsysIgnored) {
+  int status = ChildStatus([] {
+    signal(SIGSYS, SIG_IGN);
+    RequireNoNewPrivs();
+    InstallGetpidTrapFilter();
+    syscall(__NR_getpid);
+    _exit(3);
+  });
+
+  ASSERT_TRUE(WIFSIGNALED(status)) << "status=" << status;
+  EXPECT_EQ(WTERMSIG(status), SIGSYS);
+}
+
+TEST(SeccompTest, TrapIsForcedWhenSigsysBlocked) {
+  int status = ChildStatus([] {
+    struct sigaction sa = {};
+    sa.sa_sigaction = SeccompTrapHandler;
+    sa.sa_flags = SA_SIGINFO;
+    if (sigaction(SIGSYS, &sa, nullptr) != 0) {
+      _exit(2);
+    }
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGSYS);
+    if (sigprocmask(SIG_BLOCK, &set, nullptr) != 0) {
+      _exit(2);
+    }
+
+    RequireNoNewPrivs();
+    InstallGetpidTrapFilter();
+    syscall(__NR_getpid);
+    _exit(3);
+  });
+
+  ASSERT_TRUE(WIFSIGNALED(status)) << "status=" << status;
+  EXPECT_EQ(WTERMSIG(status), SIGSYS);
+}
+
+TEST(SeccompTest, UnalignedUserFilterPointerIsParsedSafely) {
+  int status = ChildStatus([] {
+    RequireNoNewPrivs();
+    struct sock_filter allow[] = {
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    alignas(1) unsigned char raw[sizeof(allow) + 1];
+    memset(raw, 0, sizeof(raw));
+    memcpy(raw + 1, allow, sizeof(allow));
+
+    struct sock_fprog prog = {
+        .len = 1,
+        .filter = reinterpret_cast<struct sock_filter*>(raw + 1),
+    };
+    if (syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog) != 0) {
+      _exit(2);
+    }
+    syscall(__NR_getpid);
+    _exit(kOk);
+  });
+
+  ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+  EXPECT_EQ(WEXITSTATUS(status), kOk);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/seccomp.cc
+++ b/user/apps/tests/dunitest/suites/normal/seccomp.cc
@@ -5,6 +5,8 @@
 #include <errno.h>
 #include <linux/filter.h>
 #include <linux/seccomp.h>
+#include <pthread.h>
+#include <sched.h>
 #include <signal.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -15,6 +17,8 @@
 #include <sys/wait.h>
 #include <ucontext.h>
 #include <unistd.h>
+
+#include <atomic>
 
 #include <gtest/gtest.h>
 
@@ -34,13 +38,19 @@ namespace {
 
 constexpr int kOk = 42;
 constexpr long kTrapReturn = 424242;
+constexpr int kTrapData = 0xdead;
 
-int InstallFilter(const struct sock_filter* filter, unsigned short len) {
+int InstallFilterWithFlags(const struct sock_filter* filter, unsigned short len,
+                           unsigned int flags) {
   struct sock_fprog prog = {
       .len = len,
       .filter = const_cast<struct sock_filter*>(filter),
   };
-  return syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog);
+  return syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, flags, &prog);
+}
+
+int InstallFilter(const struct sock_filter* filter, unsigned short len) {
+  return InstallFilterWithFlags(filter, len, 0);
 }
 
 int ChildStatus(void (*child)()) {
@@ -65,7 +75,7 @@ void InstallGetpidTrapFilter() {
   struct sock_filter filter[] = {
       BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
       BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
-      BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRAP | 123),
+      BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRAP | kTrapData),
       BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
   };
   if (InstallFilter(filter, sizeof(filter) / sizeof(filter[0])) != 0) {
@@ -77,7 +87,8 @@ void SeccompTrapHandler(int signo, siginfo_t* info, void* raw_ucontext) {
   if (signo != SIGSYS || info == nullptr || raw_ucontext == nullptr) {
     _exit(10);
   }
-  if (info->si_signo != SIGSYS || info->si_code != SYS_SECCOMP || info->si_errno != 123) {
+  if (info->si_signo != SIGSYS || info->si_code != SYS_SECCOMP ||
+      info->si_errno != kTrapData) {
     _exit(11);
   }
   if (info->si_call_addr == nullptr || info->si_syscall != __NR_getpid ||
@@ -90,6 +101,18 @@ void SeccompTrapHandler(int signo, siginfo_t* info, void* raw_ucontext) {
     _exit(13);
   }
   ctx->uc_mcontext.gregs[REG_RAX] = kTrapReturn;
+}
+
+void* SeccompTsyncThread(void* arg) {
+  auto* ready = reinterpret_cast<std::atomic<int>*>(arg);
+  while (ready->load(std::memory_order_acquire) == 0) {
+    sched_yield();
+  }
+
+  errno = 0;
+  long ret = syscall(__NR_getpid);
+  return reinterpret_cast<void*>(
+      static_cast<intptr_t>(ret == -1 && errno == ENOTNAM ? kOk : 3));
 }
 
 }  // namespace
@@ -213,6 +236,61 @@ TEST(SeccompTest, TrapDeliversSysSeccompSiginfoAndCanEmulateReturn) {
     errno = 0;
     long ret = syscall(__NR_getpid);
     _exit(ret == kTrapReturn && errno == 0 ? kOk : 3);
+  });
+
+  ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+  EXPECT_EQ(WEXITSTATUS(status), kOk);
+}
+
+TEST(SeccompTest, TraceWithoutPtracerReturnsEnosys) {
+  int status = ChildStatus([] {
+    RequireNoNewPrivs();
+    struct sock_filter filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRACE),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    if (InstallFilter(filter, sizeof(filter) / sizeof(filter[0])) != 0) {
+      _exit(2);
+    }
+
+    errno = 0;
+    long ret = syscall(__NR_getpid);
+    _exit(ret == -1 && errno == ENOSYS ? kOk : 3);
+  });
+
+  ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+  EXPECT_EQ(WEXITSTATUS(status), kOk);
+}
+
+TEST(SeccompTest, TsyncAppliesFilterToSiblingThread) {
+  int status = ChildStatus([] {
+    RequireNoNewPrivs();
+
+    std::atomic<int> ready{0};
+    pthread_t thread;
+    if (pthread_create(&thread, nullptr, SeccompTsyncThread, &ready) != 0) {
+      _exit(2);
+    }
+
+    struct sock_filter filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_getpid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | ENOTNAM),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    if (InstallFilterWithFlags(filter, sizeof(filter) / sizeof(filter[0]),
+                               SECCOMP_FILTER_FLAG_TSYNC) != 0) {
+      _exit(3);
+    }
+
+    ready.store(1, std::memory_order_release);
+    void* result = nullptr;
+    if (pthread_join(thread, &result) != 0) {
+      _exit(4);
+    }
+    _exit(reinterpret_cast<intptr_t>(result) == kOk ? kOk : 5);
   });
 
   ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;

--- a/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
@@ -128,6 +128,77 @@ bool InitTcpPair(TcpPair* pair) {
     return true;
 }
 
+bool InitDualStackTcpPair(TcpPair* pair) {
+    pair->listen_fd.Reset();
+    pair->client_fd.Reset();
+    pair->server_fd.Reset();
+
+    int listen_fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        ADD_FAILURE() << "socket(AF_INET6 listen) failed: " << ErrnoString(errno);
+        return false;
+    }
+    pair->listen_fd.Reset(listen_fd);
+
+    int v6only = 0;
+    if (setsockopt(pair->listen_fd.Get(), IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) !=
+        0) {
+        ADD_FAILURE() << "setsockopt(IPV6_V6ONLY) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    int reuse = 1;
+    if (setsockopt(pair->listen_fd.Get(), SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0) {
+        ADD_FAILURE() << "setsockopt(SO_REUSEADDR) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    sockaddr_in6 addr {};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(0);
+    if (inet_pton(AF_INET6, "::ffff:127.0.0.1", &addr.sin6_addr) != 1) {
+        ADD_FAILURE() << "inet_pton(::ffff:127.0.0.1) failed";
+        return false;
+    }
+
+    if (bind(pair->listen_fd.Get(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ADD_FAILURE() << "bind(AF_INET6 dual-stack listen) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    socklen_t addr_len = sizeof(addr);
+    if (getsockname(pair->listen_fd.Get(), reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+        ADD_FAILURE() << "getsockname(AF_INET6 listen) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    if (listen(pair->listen_fd.Get(), 5) != 0) {
+        ADD_FAILURE() << "listen(AF_INET6 dual-stack) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    int client_fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (client_fd < 0) {
+        ADD_FAILURE() << "socket(AF_INET6 client) failed: " << ErrnoString(errno);
+        return false;
+    }
+    pair->client_fd.Reset(client_fd);
+
+    if (connect(pair->client_fd.Get(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ADD_FAILURE() << "connect(AF_INET6 dual-stack) failed: " << ErrnoString(errno);
+        return false;
+    }
+
+    int server_fd = accept(pair->listen_fd.Get(), nullptr, nullptr);
+    if (server_fd < 0) {
+        ADD_FAILURE() << "accept(AF_INET6 dual-stack) failed: " << ErrnoString(errno);
+        return false;
+    }
+    pair->server_fd.Reset(server_fd);
+
+    return true;
+}
+
 void ExpectPeerEofAfterShutdownWr(int fd) {
     char byte = '\0';
     errno = 0;
@@ -173,6 +244,68 @@ void* WriterThread(void* arg) {
 void* ResetDuringCloseWorker(void*) {
     TcpPair pair;
     if (!InitTcpPair(&pair)) {
+        return reinterpret_cast<void*>(1);
+    }
+
+    struct PollCloseArgs {
+        int fd = -1;
+        int result = 0;
+    } poll_args {
+        .fd = pair.client_fd.Get(),
+        .result = 0,
+    };
+
+    auto poll_and_close = [](void* arg) -> void* {
+        auto* args = reinterpret_cast<PollCloseArgs*>(arg);
+        pollfd pfd {
+            .fd = args->fd,
+            .events = POLLIN | POLLHUP,
+            .revents = 0,
+        };
+        const int poll_ret = poll(&pfd, 1, 5000);
+        if (poll_ret != 1) {
+            args->result = 1;
+            return nullptr;
+        }
+        if (close(args->fd) != 0) {
+            args->result = 2;
+            return nullptr;
+        }
+        args->fd = -1;
+        return nullptr;
+    };
+
+    pthread_t closer {};
+    if (pthread_create(&closer, nullptr, poll_and_close, &poll_args) != 0) {
+        return reinterpret_cast<void*>(2);
+    }
+
+    constexpr char kData[] = "abc";
+    if (write(pair.server_fd.Get(), kData, 3) != 3) {
+        pthread_join(closer, nullptr);
+        return reinterpret_cast<void*>(3);
+    }
+
+    usleep(10000);
+
+    if (close(pair.server_fd.Release()) != 0) {
+        pthread_join(closer, nullptr);
+        return reinterpret_cast<void*>(4);
+    }
+
+    if (pthread_join(closer, nullptr) != 0) {
+        return reinterpret_cast<void*>(5);
+    }
+    if (poll_args.result != 0) {
+        return reinterpret_cast<void*>(6 + poll_args.result);
+    }
+    pair.client_fd.Release();
+    return nullptr;
+}
+
+void* ReversedDualStackResetDuringCloseWorker(void*) {
+    TcpPair pair;
+    if (!InitDualStackTcpPair(&pair)) {
         return reinterpret_cast<void*>(1);
     }
 
@@ -371,6 +504,27 @@ TEST(TcpCloseSemantics, ConcurrentResetDuringCloseDoesNotStall) {
 
     for (int i = 0; i < kThreadCount; ++i) {
         ASSERT_EQ(0, pthread_create(&threads[i], nullptr, ResetDuringCloseWorker, nullptr))
+            << "pthread_create failed: " << ErrnoString(errno);
+    }
+
+    for (int i = 0; i < kThreadCount; ++i) {
+        void* result = nullptr;
+        ASSERT_EQ(0, pthread_join(threads[i], &result))
+            << "pthread_join failed: " << ErrnoString(errno);
+        EXPECT_EQ(nullptr, result) << "worker " << i << " failed";
+    }
+}
+
+TEST(TcpCloseSemantics, ReversedDualStackResetDuringCloseDoesNotStall) {
+    signal(SIGPIPE, SIG_IGN);
+
+    constexpr int kThreadCount = 100;
+    std::vector<pthread_t> threads(kThreadCount);
+
+    for (int i = 0; i < kThreadCount; ++i) {
+        ASSERT_EQ(0,
+                  pthread_create(
+                      &threads[i], nullptr, ReversedDualStackResetDuringCloseWorker, nullptr))
             << "pthread_create failed: " << ErrnoString(errno);
     }
 

--- a/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/tcp_close_semantics.cc
@@ -6,15 +6,20 @@
 #include <netinet/in.h>
 #include <pthread.h>
 #include <poll.h>
+#include <sched.h>
+#include <setjmp.h>
 #include <signal.h>
+#include <stdint.h>
 #include <sys/socket.h>
+#include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -220,6 +225,119 @@ struct WriterArgs {
     size_t len = 0;
     WriteResult* result = nullptr;
 };
+
+thread_local sigjmp_buf g_mm_signal_jmp;
+thread_local volatile sig_atomic_t g_mm_signal_active = 0;
+
+void MmSignalHandler(int sig, siginfo_t* si, void* uc) {
+    (void)sig;
+    (void)si;
+    (void)uc;
+    if (g_mm_signal_active) {
+        siglongjmp(g_mm_signal_jmp, 1);
+    }
+    _exit(99);
+}
+
+struct MmSmokeCtx {
+    volatile uint8_t* base = nullptr;
+    size_t len = 0;
+    std::atomic<int>* run = nullptr;
+};
+
+void* MmSmokeWriter(void* arg) {
+    auto* ctx = reinterpret_cast<MmSmokeCtx*>(arg);
+    size_t off = 0;
+    size_t spins = 0;
+
+    if (sigsetjmp(g_mm_signal_jmp, 1) != 0) {
+        sched_yield();
+    }
+    g_mm_signal_active = 1;
+
+    while (ctx->run->load(std::memory_order_acquire)) {
+        ctx->base[off] = static_cast<uint8_t>(off);
+        off += 13;
+        if (off >= ctx->len) {
+            off = 0;
+        }
+        if ((++spins & 0xff) == 0) {
+            sched_yield();
+        }
+    }
+
+    g_mm_signal_active = 0;
+    return nullptr;
+}
+
+void ExpectMmSignalPathResponsiveAfterTcpStorm() {
+    constexpr size_t kPageSize = 4096;
+    constexpr size_t kPages = 4;
+    constexpr size_t kLen = kPages * kPageSize;
+    constexpr int kIters = 128;
+
+    struct sigaction old_segv {};
+    struct sigaction old_bus {};
+    struct sigaction sa {};
+    sa.sa_flags = SA_SIGINFO | SA_NODEFER;
+    sa.sa_sigaction = MmSignalHandler;
+    sigemptyset(&sa.sa_mask);
+
+    ASSERT_EQ(0, sigaction(SIGSEGV, &sa, &old_segv))
+        << "sigaction(SIGSEGV) failed: " << ErrnoString(errno);
+    ASSERT_EQ(0, sigaction(SIGBUS, &sa, &old_bus))
+        << "sigaction(SIGBUS) failed: " << ErrnoString(errno);
+
+    auto restore_handlers = [&]() {
+        sigaction(SIGSEGV, &old_segv, nullptr);
+        sigaction(SIGBUS, &old_bus, nullptr);
+    };
+
+    auto* buf = static_cast<uint8_t*>(
+        mmap(nullptr, kLen, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(MAP_FAILED, buf) << "mmap failed: " << ErrnoString(errno);
+    std::memset(buf, 0, kLen);
+
+    std::atomic<int> run{1};
+    MmSmokeCtx ctx {
+        .base = buf,
+        .len = kLen,
+        .run = &run,
+    };
+    pthread_t writer {};
+    ASSERT_EQ(0, pthread_create(&writer, nullptr, MmSmokeWriter, &ctx))
+        << "pthread_create failed: " << ErrnoString(errno);
+
+    int rc = 0;
+    for (int i = 0; i < kIters; ++i) {
+        if (mprotect(buf, kLen, PROT_READ) != 0) {
+            rc = errno;
+            break;
+        }
+
+        if (sigsetjmp(g_mm_signal_jmp, 1) == 0) {
+            g_mm_signal_active = 1;
+            *reinterpret_cast<volatile uint8_t*>(buf) = 0x5a;
+            rc = EFAULT;
+            break;
+        }
+        g_mm_signal_active = 0;
+
+        if (mprotect(buf, kLen, PROT_READ | PROT_WRITE) != 0) {
+            rc = errno;
+            break;
+        }
+    }
+    g_mm_signal_active = 0;
+
+    run.store(0, std::memory_order_release);
+    ASSERT_EQ(0, pthread_join(writer, nullptr))
+        << "pthread_join failed: " << ErrnoString(errno);
+    EXPECT_EQ(0, munmap(buf, kLen)) << "munmap failed: " << ErrnoString(errno);
+    restore_handlers();
+
+    EXPECT_EQ(0, rc) << "post TCP-storm mm/signal smoke failed: " << ErrnoString(rc);
+}
 
 void* WriterThread(void* arg) {
     auto* args = reinterpret_cast<WriterArgs*>(arg);
@@ -513,6 +631,8 @@ TEST(TcpCloseSemantics, ConcurrentResetDuringCloseDoesNotStall) {
             << "pthread_join failed: " << ErrnoString(errno);
         EXPECT_EQ(nullptr, result) << "worker " << i << " failed";
     }
+
+    ExpectMmSignalPathResponsiveAfterTcpStorm();
 }
 
 TEST(TcpCloseSemantics, ReversedDualStackResetDuringCloseDoesNotStall) {
@@ -534,6 +654,8 @@ TEST(TcpCloseSemantics, ReversedDualStackResetDuringCloseDoesNotStall) {
             << "pthread_join failed: " << ErrnoString(errno);
         EXPECT_EQ(nullptr, result) << "worker " << i << " failed";
     }
+
+    ExpectMmSignalPathResponsiveAfterTcpStorm();
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <sched.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -58,15 +59,21 @@ struct ThreadCtx {
 void* hammer_writer(void* arg) {
     auto* ctx = static_cast<ThreadCtx*>(arg);
     size_t off = 0;
+    size_t spins = 0;
 
+    if (sigsetjmp(g_segv_jmp, 1) != 0) {
+        sched_yield();
+    }
     g_segv_active = 1;
-    (void)sigsetjmp(g_segv_jmp, 1);
 
     while (ctx->run->load(std::memory_order_acquire)) {
         ctx->base[off] = static_cast<uint8_t>(off);
         off += 13;
         if (off >= ctx->len) {
             off = 0;
+        }
+        if ((++spins & 0xff) == 0) {
+            sched_yield();
         }
     }
 
@@ -119,7 +126,6 @@ int case_mprotect_downgrade() {
     }
 
     int rc = 0;
-    g_segv_active = 1;
 
     for (int i = 0; i < kIters; ++i) {
         if (mprotect(buf, len, PROT_READ) < 0) {
@@ -129,11 +135,13 @@ int case_mprotect_downgrade() {
         }
 
         if (sigsetjmp(g_segv_jmp, 1) == 0) {
+            g_segv_active = 1;
             *reinterpret_cast<volatile uint8_t*>(buf) = 0xAA;
             fprintf(stderr, "FAIL: write to RO buf succeeded at iter %d\n", i);
             rc = -1;
             break;
         }
+        g_segv_active = 0;
 
         if (mprotect(buf, len, PROT_READ | PROT_WRITE) < 0) {
             perror("mprotect(RW)");
@@ -176,9 +184,9 @@ int case_munmap_while_writing() {
             return -1;
         }
 
-        g_segv_active = 1;
         int ok = 0;
         if (sigsetjmp(g_segv_jmp, 1) == 0) {
+            g_segv_active = 1;
             *reinterpret_cast<volatile uint8_t*>(buf) = 0xBB;
             fprintf(stderr, "FAIL: write to unmapped buf succeeded (iter %d)\n", i);
         } else {
@@ -212,15 +220,21 @@ void* hammer_writer_whole(void* arg) {
     auto* ctx = static_cast<HammerCtx*>(arg);
     size_t off = 0;
     uint8_t v = ctx->mark;
+    size_t spins = 0;
 
+    if (sigsetjmp(g_segv_jmp, 1) != 0) {
+        sched_yield();
+    }
     g_segv_active = 1;
-    (void)sigsetjmp(g_segv_jmp, 1);
 
     while (ctx->run->load(std::memory_order_acquire)) {
         ctx->base[off] = v++;
         off += 13;
         if (off >= ctx->len) {
             off = 0;
+        }
+        if ((++spins & 0xff) == 0) {
+            sched_yield();
         }
     }
 
@@ -326,7 +340,7 @@ int case_fork_cow_stale_tlb() {
                     _exit(10);
                 }
             }
-            usleep(500);
+            sched_yield();
         }
         delete[] snap;
         _exit(0);

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -33,3 +33,4 @@ normal/user_namespace_id_map
 normal/tty_tcflush
 normal/signal_fpstate_sigreturn
 normal/general_protection_signal
+normal/seccomp


### PR DESCRIPTION
Add seccomp support with strict mode and BPF filter mode, enabling the kernel to restrict syscalls available to processes.

- cBPF interpreter and validator for classic BPF programs
- Strict mode: whitelist read/write/exit/rt_sigreturn/exit_group
- Filter mode: SECCOMP_RET_KILL/TRAP/ERRNO/LOG/ALLOW actions
- Filter inheritance across fork via Arc<SeccompFilter>
- seccomp() syscall and prctl(PR_SET_SECCOMP/PR_GET_SECCOMP)
- /proc/[pid]/status Seccomp field