### PR TITLE
feat: container blockers

### DIFF
--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -1,6 +1,6 @@
 use super::OvlInode;
 use crate::{
-    filesystem::vfs::{IndexNode, Metadata},
+    filesystem::vfs::{FileType, IndexNode, Metadata},
     libs::mutex::Mutex,
 };
 use alloc::sync::Arc;
@@ -13,16 +13,18 @@ impl OvlInode {
             return Ok(());
         }
 
-        let lower_inode = self.lower_inode.as_ref().ok_or(SystemError::ENOENT)?;
+        let lower_inode = self.lower_inodes.first().ok_or(SystemError::ENOENT)?;
 
         let metadata = lower_inode.metadata()?;
         let new_upper_inode = self.create_upper_inode(metadata.clone())?;
 
-        let mut buffer = vec![0u8; metadata.size as usize];
-        let lock = Mutex::new(crate::filesystem::vfs::FilePrivateData::Unused);
-        lower_inode.read_at(0, metadata.size as usize, &mut buffer, lock.lock())?;
+        if metadata.file_type == FileType::File {
+            let mut buffer = vec![0u8; metadata.size as usize];
+            let lock = Mutex::new(crate::filesystem::vfs::FilePrivateData::Unused);
+            lower_inode.read_at(0, metadata.size as usize, &mut buffer, lock.lock())?;
 
-        new_upper_inode.write_at(0, metadata.size as usize, &buffer, lock.lock())?;
+            new_upper_inode.write_at(0, metadata.size as usize, &buffer, lock.lock())?;
+        }
 
         *upper_inode = Some(new_upper_inode);
 
@@ -30,12 +32,21 @@ impl OvlInode {
     }
 
     fn create_upper_inode(&self, metadata: Metadata) -> Result<Arc<dyn IndexNode>, SystemError> {
-        let upper_inode = self.upper_inode.lock();
-        let upper_root_inode = upper_inode
-            .as_ref()
-            .ok_or(SystemError::ENOSYS)?
-            .fs()
-            .root_inode();
-        upper_root_inode.create_with_data(&self.dname()?.0, metadata.file_type, metadata.mode, 0)
+        let upper_root_inode = self.upper_root_inode()?;
+        if self.redirect.is_empty() {
+            return Ok(upper_root_inode);
+        }
+
+        let (parent_path, name) = match self.redirect.rsplit_once('/') {
+            Some((parent_path, name)) => (parent_path, name),
+            None => ("", self.redirect.as_str()),
+        };
+
+        let parent_inode = self.ensure_upper_dir_path(parent_path)?;
+        if let Ok(existing) = parent_inode.find(name) {
+            return Ok(existing);
+        }
+
+        parent_inode.create_with_data(name, metadata.file_type, metadata.mode, 0)
     }
 }

--- a/kernel/src/filesystem/overlayfs/mod.rs
+++ b/kernel/src/filesystem/overlayfs/mod.rs
@@ -3,6 +3,7 @@ pub mod copy_up;
 pub mod entry;
 
 use super::ramfs::{LockedRamFSInode, RamFSInode};
+use super::vfs::utils::DName;
 use super::vfs::FSMAKER;
 use super::vfs::{
     self, FileSystem, FileType, FsInfo, IndexNode, Metadata, MountableFileSystem, SuperBlock,
@@ -24,6 +25,7 @@ use system_error::SystemError;
 const WHITEOUT_MODE: u64 = 0o020000 | 0o600; // whiteout字符设备文件模式与权限
 const WHITEOUT_DEV: DeviceNumber = DeviceNumber::new(Major::UNNAMED_MAJOR, 0); // Whiteout 文件设备号
 const WHITEOUT_FLAG: u64 = 0x1;
+type LowerRoot = (String, Arc<dyn IndexNode>);
 
 #[derive(Debug)]
 pub struct OverlayMountData {
@@ -79,6 +81,7 @@ struct OverlayFS {
     layers: Vec<OvlLayer>, // 第0层为读写层，后面是只读层
     workdir: Arc<OvlInode>,
     root_inode: Arc<OvlInode>,
+    super_block: SuperBlock,
 }
 
 #[derive(Debug)]
@@ -87,25 +90,30 @@ pub struct OvlInode {
     file_type: FileType,
     flags: Mutex<u64>,
     upper_inode: Mutex<Option<Arc<dyn IndexNode>>>, // 读写层
-    lower_inode: Option<Arc<dyn IndexNode>>,        // 只读层
+    lower_inodes: Vec<Arc<dyn IndexNode>>,          // 只读层（支持多层）
     oe: Arc<OvlEntry>,
-    fs: Weak<OverlayFS>,
+    fs: Mutex<Weak<OverlayFS>>,
 }
 impl OvlInode {
     pub fn new(
         redirect: String,
+        file_type: FileType,
         upper: Option<Arc<dyn IndexNode>>,
-        lower_inode: Option<Arc<dyn IndexNode>>,
+        lower_inodes: Vec<Arc<dyn IndexNode>>,
     ) -> Self {
         Self {
             redirect,
-            file_type: FileType::Dir,
+            file_type,
             flags: Mutex::new(0),
             upper_inode: Mutex::new(upper),
-            lower_inode,
+            lower_inodes,
             oe: Arc::new(OvlEntry::new()),
-            fs: Weak::default(),
+            fs: Mutex::new(Weak::default()),
         }
+    }
+
+    fn set_fs(&self, fs: Weak<OverlayFS>) {
+        *self.fs.lock() = fs;
     }
 }
 
@@ -130,12 +138,12 @@ impl FileSystem for OverlayFS {
     }
 
     fn super_block(&self) -> SuperBlock {
-        todo!()
+        self.super_block.clone()
     }
 }
 
 impl OverlayFS {
-    pub fn ovl_upper_mnt(&self) -> Arc<dyn IndexNode> {
+    pub fn ovl_upper_mnt(&self) -> Arc<OvlInode> {
         self.layers[0].mnt.clone()
     }
 }
@@ -151,27 +159,44 @@ impl MountableFileSystem for OverlayFS {
         let upper_inode = root_inode
             .lookup(&mount_data.upper_dir)
             .map_err(|_| SystemError::EINVAL)?;
+        let upper_file_type = upper_inode.metadata()?.file_type;
         let upper_layer = OvlLayer {
             mnt: Arc::new(OvlInode::new(
                 mount_data.upper_dir.clone(),
-                Some(upper_inode),
-                None,
+                upper_file_type,
+                Some(upper_inode.clone()),
+                Vec::new(),
             )),
             index: 0,
             fsid: 0,
         };
 
-        let lower_layers: Result<Vec<OvlLayer>, SystemError> = mount_data
+        let lower_roots: Result<Vec<LowerRoot>, SystemError> = mount_data
             .lower_dirs
             .iter()
-            .enumerate()
-            .map(|(i, dir)| {
+            .map(|dir| {
                 let lower_inode = ProcessManager::current_mntns()
                     .root_inode()
                     .lookup(dir)
-                    .map_err(|_| SystemError::EINVAL)?; // 处理错误
+                    .map_err(|_| SystemError::EINVAL)?;
+                Ok((dir.clone(), lower_inode))
+            })
+            .collect();
+
+        let lower_roots = lower_roots?;
+
+        let lower_layers: Result<Vec<OvlLayer>, SystemError> = lower_roots
+            .iter()
+            .enumerate()
+            .map(|(i, (dir, lower_inode))| {
+                let lower_file_type = lower_inode.metadata()?.file_type;
                 Ok(OvlLayer {
-                    mnt: Arc::new(OvlInode::new(dir.clone(), None, Some(lower_inode))),
+                    mnt: Arc::new(OvlInode::new(
+                        dir.clone(),
+                        lower_file_type,
+                        None,
+                        vec![lower_inode.clone()],
+                    )),
                     index: (i + 1) as u32,
                     fsid: (i + 1) as u32,
                 })
@@ -180,9 +205,14 @@ impl MountableFileSystem for OverlayFS {
 
         let lower_layers = lower_layers?;
 
-        let workdir = Arc::new(OvlInode::new(mount_data.work_dir.clone(), None, None));
+        let workdir = Arc::new(OvlInode::new(
+            mount_data.work_dir.clone(),
+            FileType::Dir,
+            None,
+            Vec::new(),
+        ));
 
-        if lower_layers.is_empty() {
+        if lower_roots.is_empty() {
             return Err(SystemError::EINVAL);
         }
 
@@ -190,17 +220,35 @@ impl MountableFileSystem for OverlayFS {
         layers.push(upper_layer);
         layers.extend(lower_layers);
 
-        let root_inode = layers[0].mnt.clone();
+        let root_inode = Arc::new(OvlInode::new(
+            String::new(),
+            upper_file_type,
+            Some(upper_inode),
+            lower_roots
+                .iter()
+                .map(|(_, lower_inode)| lower_inode.clone())
+                .collect(),
+        ));
 
-        let fs = OverlayFS {
-            numlayer: layers.len(),
-            numfs: 1,
-            numdatalayer: layers.len() - 1,
-            layers,
-            workdir,
-            root_inode,
-        };
-        Ok(Arc::new(fs))
+        let super_block = SuperBlock::new(vfs::Magic::OVERLAYFS_MAGIC, 4096, 255);
+        let fs = Arc::new_cyclic(|weak_fs| {
+            for layer in &layers {
+                layer.mnt.set_fs(weak_fs.clone());
+            }
+            workdir.set_fs(weak_fs.clone());
+            root_inode.set_fs(weak_fs.clone());
+
+            OverlayFS {
+                numlayer: layers.len(),
+                numfs: 1,
+                numdatalayer: lower_roots.len(),
+                layers,
+                workdir,
+                root_inode,
+                super_block: super_block.clone(),
+            }
+        });
+        Ok(fs)
     }
 
     fn make_mount_data(
@@ -219,47 +267,140 @@ register_mountable_fs!(OverlayFS, OVERLAYFSMAKER, "overlay");
 
 impl OvlInode {
     pub fn ovl_lower_redirect(&self) -> Option<&str> {
-        if self.file_type == FileType::File || self.file_type == FileType::Dir {
+        if !self.lower_inodes.is_empty()
+            && (self.file_type == FileType::File || self.file_type == FileType::Dir)
+        {
             Some(&self.redirect)
         } else {
             None
         }
     }
 
+    fn overlay_fs(&self) -> Result<Arc<OverlayFS>, SystemError> {
+        self.fs.lock().upgrade().ok_or(SystemError::EINVAL)
+    }
+
+    fn upper_root_inode(&self) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let upper_mnt = self.overlay_fs()?.ovl_upper_mnt();
+        let upper_inode = upper_mnt.upper_inode.lock();
+        upper_inode.clone().ok_or(SystemError::EROFS)
+    }
+
+    fn child_redirect(&self, name: &str) -> String {
+        if self.redirect.is_empty() {
+            String::from(name)
+        } else {
+            let mut redirect = self.redirect.clone();
+            redirect.push('/');
+            redirect.push_str(name);
+            redirect
+        }
+    }
+
+    fn ensure_upper_dir_path(&self, path: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let mut current = self.upper_root_inode()?;
+        if path.is_empty() {
+            return Ok(current);
+        }
+
+        let mut current_path = String::new();
+        for component in path.split('/').filter(|component| !component.is_empty()) {
+            if !current_path.is_empty() {
+                current_path.push('/');
+            }
+            current_path.push_str(component);
+
+            match current.find(component) {
+                Ok(next) => current = next,
+                Err(SystemError::ENOENT) => {
+                    let mode = self.lower_dir_mode(&current_path)?;
+                    current = current.mkdir(component, mode)?;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(current)
+    }
+
+    fn lower_dir_mode(&self, path: &str) -> Result<vfs::InodeMode, SystemError> {
+        let fs = self.overlay_fs()?;
+        for layer in fs.layers.iter().skip(1) {
+            if let Some(lower_root) = layer.mnt.lower_inodes.first() {
+                if let Ok(inode) = lower_root.lookup(path) {
+                    return Ok(inode.metadata()?.mode);
+                }
+            }
+        }
+
+        Ok(vfs::InodeMode::S_IRWXUGO)
+    }
+
+    fn is_whiteout_inode(inode: &Arc<dyn IndexNode>) -> bool {
+        inode
+            .metadata()
+            .map(|metadata| {
+                metadata.file_type == FileType::CharDevice && metadata.raw_dev == WHITEOUT_DEV
+            })
+            .unwrap_or(false)
+    }
+
     pub fn create_whiteout(&self, name: &str) -> Result<(), SystemError> {
         let whiteout_mode = vfs::InodeMode::S_IFCHR;
-        let mut upper_inode = self.upper_inode.lock();
+        if let Some(ref upper_inode) = *self.upper_inode.lock() {
+            upper_inode.mknod(name, whiteout_mode, WHITEOUT_DEV)?;
+            return Ok(());
+        }
+
+        self.copy_up()?;
+        let upper_inode = self.upper_inode.lock();
         if let Some(ref upper_inode) = *upper_inode {
             upper_inode.mknod(name, whiteout_mode, WHITEOUT_DEV)?;
-        } else {
-            let new_inode = self
-                .fs
-                .upgrade()
-                .ok_or(SystemError::EROFS)?
-                .root_inode()
-                .create(name, FileType::CharDevice, whiteout_mode)?;
-            *upper_inode = Some(new_inode);
+            return Ok(());
         }
-        let mut flags = self.flags.lock();
-        *flags |= WHITEOUT_FLAG; // 标记为 whiteout
-        Ok(())
+        Err(SystemError::EROFS)
     }
 
     fn is_whiteout(&self) -> bool {
-        let flags = self.flags.lock();
-        self.file_type == FileType::CharDevice && (*flags & WHITEOUT_FLAG) != 0
+        self.file_type == FileType::CharDevice
+            && self
+                .metadata()
+                .map(|metadata| metadata.raw_dev == WHITEOUT_DEV)
+                .unwrap_or(false)
     }
 
     fn has_whiteout(&self, name: &str) -> bool {
         let upper_inode = self.upper_inode.lock();
         if let Some(ref upper_inode) = *upper_inode {
             if let Ok(inode) = upper_inode.find(name) {
-                if let Some(ovl_inode) = inode.as_any_ref().downcast_ref::<OvlInode>() {
-                    return ovl_inode.is_whiteout();
-                }
+                return Self::is_whiteout_inode(&inode);
             }
         }
         false
+    }
+
+    fn remove_whiteout_if_present(&self, name: &str) -> Result<bool, SystemError> {
+        let upper_inode = self.upper_inode.lock().clone().ok_or(SystemError::EROFS)?;
+        match upper_inode.find(name) {
+            Ok(inode) => {
+                if Self::is_whiteout_inode(&inode) {
+                    upper_inode.unlink(name)?;
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Err(SystemError::ENOENT) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn is_dot_entry(name: &str) -> bool {
+        name == "." || name == ".."
+    }
+
+    fn is_dir_empty(inode: &Arc<dyn IndexNode>) -> Result<bool, SystemError> {
+        Ok(inode.list()?.iter().all(|entry| Self::is_dot_entry(entry)))
     }
 }
 
@@ -275,8 +416,21 @@ impl IndexNode for OvlInode {
             return upper_inode.read_at(offset, len, buf, data);
         }
 
-        if let Some(lower_inode) = &self.lower_inode {
-            return lower_inode.read_at(offset, len, buf, data);
+        let mut lower_inodes = self.lower_inodes.iter();
+        if let Some(lower_inode) = lower_inodes.next() {
+            match lower_inode.read_at(offset, len, buf, data) {
+                Ok(read_len) => return Ok(read_len),
+                Err(mut err) => {
+                    for lower_inode in lower_inodes {
+                        let lock = Mutex::new(vfs::FilePrivateData::Unused);
+                        match lower_inode.read_at(offset, len, buf, lock.lock()) {
+                            Ok(read_len) => return Ok(read_len),
+                            Err(next_err) => err = next_err,
+                        }
+                    }
+                    return Err(err);
+                }
+            }
         }
 
         Err(SystemError::ENOENT)
@@ -300,7 +454,7 @@ impl IndexNode for OvlInode {
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {
-        self.fs.upgrade().unwrap()
+        self.fs.lock().upgrade().unwrap()
     }
 
     fn metadata(&self) -> Result<Metadata, SystemError> {
@@ -308,8 +462,10 @@ impl IndexNode for OvlInode {
             return upper_inode.metadata();
         }
 
-        if let Some(ref lower_inode) = self.lower_inode {
-            return lower_inode.metadata();
+        for lower_inode in &self.lower_inodes {
+            if let Ok(metadata) = lower_inode.metadata() {
+                return Ok(metadata);
+            }
         }
         Ok(Metadata::default())
     }
@@ -318,19 +474,50 @@ impl IndexNode for OvlInode {
         self
     }
 
+    fn dname(&self) -> Result<DName, SystemError> {
+        Ok(DName::from(self.redirect.clone()))
+    }
+
     fn list(&self) -> Result<Vec<String>, system_error::SystemError> {
         let mut entries: Vec<String> = Vec::new();
-        let upper_inode = self.upper_inode.lock();
-        if let Some(ref upper_inode) = *upper_inode {
-            let upper_entries = upper_inode.list()?;
-            entries.extend(upper_entries);
+        let mut hidden_entries: Vec<String> = Vec::new();
+        let upper_entries = if let Some(ref upper_inode) = *self.upper_inode.lock() {
+            upper_inode.list()?
+        } else {
+            Vec::new()
+        };
+
+        for entry in upper_entries {
+            if !self.has_whiteout(&entry) {
+                entries.push(entry);
+            }
         }
-        if let Some(lower_inode) = &self.lower_inode {
+
+        for lower_inode in &self.lower_inodes {
             let lower_entries = lower_inode.list()?;
             for entry in lower_entries {
-                if !entries.contains(&entry) && !self.has_whiteout(&entry) {
-                    entries.push(entry);
+                if entries.contains(&entry) || hidden_entries.contains(&entry) {
+                    continue;
                 }
+                if Self::is_dot_entry(&entry) {
+                    entries.push(entry);
+                    continue;
+                }
+                if self.has_whiteout(&entry) {
+                    hidden_entries.push(entry);
+                    continue;
+                }
+                match lower_inode.find(&entry) {
+                    Ok(inode) => {
+                        if Self::is_whiteout_inode(&inode) {
+                            hidden_entries.push(entry);
+                            continue;
+                        }
+                    }
+                    Err(SystemError::ENOENT) => continue,
+                    Err(err) => return Err(err),
+                }
+                entries.push(entry);
             }
         }
 
@@ -350,37 +537,52 @@ impl IndexNode for OvlInode {
     }
 
     fn rmdir(&self, name: &str) -> Result<(), SystemError> {
-        let upper_inode = self.upper_inode.lock();
-        if let Some(ref upper_inode) = *upper_inode {
-            upper_inode.rmdir(name)?;
-        } else if let Some(lower_inode) = &self.lower_inode {
-            if lower_inode.find(name).is_ok() {
-                self.create_whiteout(name)?;
-            } else {
-                return Err(SystemError::ENOENT);
+        if let Some(ref upper_inode) = *self.upper_inode.lock() {
+            match upper_inode.rmdir(name) {
+                Ok(()) => return Ok(()),
+                Err(SystemError::ENOENT) => {}
+                Err(err) => return Err(err),
             }
-        } else {
-            return Err(SystemError::ENOENT);
         }
 
-        Ok(())
+        match self.find(name) {
+            Ok(inode) => {
+                if inode.metadata()?.file_type != FileType::Dir {
+                    return Err(SystemError::ENOTDIR);
+                }
+                if !Self::is_dir_empty(&inode)? {
+                    return Err(SystemError::ENOTEMPTY);
+                }
+                return self.create_whiteout(name);
+            }
+            Err(SystemError::ENOENT) => {}
+            Err(err) => return Err(err),
+        }
+
+        Err(SystemError::ENOENT)
     }
 
     fn unlink(&self, name: &str) -> Result<(), SystemError> {
-        let upper_inode = self.upper_inode.lock();
-        if let Some(ref upper_inode) = *upper_inode {
-            upper_inode.unlink(name)?;
-        } else if let Some(lower_inode) = &self.lower_inode {
-            if lower_inode.find(name).is_ok() {
-                self.create_whiteout(name)?;
-            } else {
-                return Err(SystemError::ENOENT);
+        if let Some(ref upper_inode) = *self.upper_inode.lock() {
+            match upper_inode.unlink(name) {
+                Ok(()) => return Ok(()),
+                Err(SystemError::ENOENT) => {}
+                Err(err) => return Err(err),
             }
-        } else {
-            return Err(SystemError::ENOENT);
         }
 
-        Ok(())
+        match self.find(name) {
+            Ok(inode) => {
+                if inode.metadata()?.file_type == FileType::Dir {
+                    return Err(SystemError::EISDIR);
+                }
+                return self.create_whiteout(name);
+            }
+            Err(SystemError::ENOENT) => {}
+            Err(err) => return Err(err),
+        }
+
+        Err(SystemError::ENOENT)
     }
 
     fn link(
@@ -401,31 +603,85 @@ impl IndexNode for OvlInode {
         file_type: vfs::FileType,
         mode: vfs::InodeMode,
     ) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
-        if let Some(ref upper_inode) = *self.upper_inode.lock() {
-            upper_inode.create(name, file_type, mode)
-        } else {
-            Err(SystemError::EROFS)
-        }
+        let upper_inode = self.upper_inode.lock().clone().ok_or(SystemError::EROFS)?;
+        self.remove_whiteout_if_present(name)?;
+        upper_inode.create(name, file_type, mode)
     }
 
     fn find(&self, name: &str) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
-        let upper_inode = self.upper_inode.lock();
-        if let Some(ref upper) = *upper_inode {
-            if let Ok(inode) = upper.find(name) {
-                return Ok(inode);
+        let mut upper_inode = None;
+        let mut upper_file_type = None;
+        if let Some(ref upper) = *self.upper_inode.lock() {
+            match upper.find(name) {
+                Ok(inode) => {
+                    if Self::is_whiteout_inode(&inode) {
+                        return Err(SystemError::ENOENT);
+                    }
+                    upper_file_type = Some(inode.metadata()?.file_type);
+                    upper_inode = Some(inode);
+                }
+                Err(SystemError::ENOENT) => {}
+                Err(err) => return Err(err),
             }
         }
+
         if self.has_whiteout(name) {
             return Err(SystemError::ENOENT);
         }
 
-        if let Some(lower) = &self.lower_inode {
-            if let Ok(inode) = lower.find(name) {
-                return Ok(inode);
+        let mut lower_inodes = Vec::new();
+        if matches!(upper_file_type, None | Some(FileType::Dir)) {
+            let mut merge_dirs = upper_file_type == Some(FileType::Dir);
+            for lower in &self.lower_inodes {
+                match lower.find(name) {
+                    Ok(inode) => {
+                        if Self::is_whiteout_inode(&inode) {
+                            if upper_inode.is_none() {
+                                return Err(SystemError::ENOENT);
+                            }
+                            break;
+                        }
+                        let lower_file_type = inode.metadata()?.file_type;
+                        if merge_dirs {
+                            if lower_file_type == FileType::Dir {
+                                lower_inodes.push(inode);
+                                continue;
+                            }
+                            break;
+                        }
+
+                        lower_inodes.push(inode);
+                        if lower_file_type == FileType::Dir {
+                            merge_dirs = true;
+                        } else {
+                            break;
+                        }
+                    }
+                    Err(SystemError::ENOENT) => {}
+                    Err(err) => return Err(err),
+                }
             }
         }
 
-        Err(SystemError::ENOENT)
+        if upper_inode.is_none() && lower_inodes.is_empty() {
+            return Err(SystemError::ENOENT);
+        }
+
+        let file_type = if let Some(file_type) = upper_file_type {
+            file_type
+        } else {
+            lower_inodes[0].metadata()?.file_type
+        };
+
+        let inode = Arc::new(OvlInode::new(
+            self.child_redirect(name),
+            file_type,
+            upper_inode,
+            lower_inodes,
+        ));
+        inode.set_fs(self.fs.lock().clone());
+
+        Ok(inode)
     }
 
     fn mknod(

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -662,6 +662,11 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     /// @brief 获取inode所在的文件系统的指针
     fn fs(&self) -> Arc<dyn FileSystem>;
 
+    /// @brief 获取当前 inode 所在挂载点的挂载标志
+    fn mount_flags(&self) -> MountFlags {
+        MountFlags::empty()
+    }
+
     /// @brief 本函数用于实现动态转换。
     /// 具体的文件系统在实现本函数时，最简单的方式就是：直接返回self
     fn as_any_ref(&self) -> &dyn Any;
@@ -1326,6 +1331,7 @@ bitflags! {
         const MOUNT_MAGIC = 61267;
         const PIPEFS_MAGIC = 0x50495045;
         const EVENTFD_MAGIC = 0x45564446; // "EVDF" in ASCII
+        const OVERLAYFS_MAGIC = 0x794c7630;
     }
 }
 

--- a/kernel/src/filesystem/vfs/mount.rs
+++ b/kernel/src/filesystem/vfs/mount.rs
@@ -1108,6 +1108,11 @@ impl IndexNode for MountFSInode {
     }
 
     #[inline]
+    fn mount_flags(&self) -> MountFlags {
+        self.mount_fs.mount_flags()
+    }
+
+    #[inline]
     fn as_any_ref(&self) -> &dyn core::any::Any {
         return self.inner_inode.as_any_ref();
     }

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -4,6 +4,7 @@ use system_error::SystemError;
 use super::{
     fcntl::AtFlags,
     file::{File, FileFlags},
+    mount::MountFlags,
     permission::PermissionMask,
     syscall::{OpenHow, OpenHowResolve},
     utils::{rsplit_path, should_remove_sgid_on_chown, user_path_at},
@@ -314,6 +315,13 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
     let metadata = inode.metadata()?;
     let file_type: FileType = metadata.file_type;
 
+    if !how.o_flags.contains(FileFlags::O_PATH)
+        && (file_type == FileType::CharDevice || file_type == FileType::BlockDevice)
+        && inode.mount_flags().contains(MountFlags::NODEV)
+    {
+        return Err(SystemError::EACCES);
+    }
+
     if how.o_flags.contains(FileFlags::O_NOFOLLOW)
         && !how.o_flags.contains(FileFlags::O_PATH)
         && file_type == FileType::SymLink
@@ -458,6 +466,10 @@ pub fn do_open_execat_with_flags(
 
     // 必须是普通文件
     if file_type != FileType::File {
+        return Err(SystemError::EACCES);
+    }
+
+    if inode.mount_flags().contains(MountFlags::NOEXEC) {
         return Err(SystemError::EACCES);
     }
 

--- a/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
@@ -8,6 +8,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/xattr.h>
 #include <unistd.h>
@@ -223,6 +224,142 @@ TEST(MountReconfigure, OrdinaryRemountReadonlyAffectsSharedSuperblock) {
 
     umount(target);
     cleanup_mount(source);
+}
+
+TEST(MountReconfigure, NodevDeviceOpenAllowsOPath) {
+    const char *root = "/tmp/test_mount_nodev_o_path";
+    const char *source = "/tmp/test_mount_nodev_o_path/source";
+    const char *target = "/tmp/test_mount_nodev_o_path/target";
+    char source_dev[256];
+    char target_dev[256];
+    int fd;
+
+    ensure_dir("/tmp");
+    ensure_dir(root);
+    ensure_dir(source);
+    ensure_dir(target);
+
+    if (unshare(CLONE_NEWNS) != 0) {
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL);
+
+    snprintf(source_dev, sizeof(source_dev), "%s/null_dev", source);
+    snprintf(target_dev, sizeof(target_dev), "%s/null_dev", target);
+    if (mknod(source_dev, S_IFCHR | 0600, makedev(1, 3)) != 0) {
+        rmdir(target);
+        rmdir(source);
+        rmdir(root);
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    if (mount(source, target, NULL, MS_BIND, NULL) != 0) {
+        unlink(source_dev);
+        rmdir(target);
+        rmdir(source);
+        rmdir(root);
+        FAIL() << strerror(errno);
+    }
+
+    if (mount(target, target, NULL, MS_BIND | MS_REMOUNT | MS_NODEV, NULL) != 0) {
+        umount(target);
+        unlink(source_dev);
+        rmdir(target);
+        rmdir(source);
+        rmdir(root);
+        FAIL() << strerror(errno);
+    }
+
+    fd = open(target_dev, O_RDONLY);
+    if (fd >= 0) {
+        close(fd);
+        umount(target);
+        unlink(source_dev);
+        rmdir(target);
+        rmdir(source);
+        rmdir(root);
+        FAIL() << "open without O_PATH unexpectedly succeeded on nodev mount";
+    }
+    EXPECT_EQ(EACCES, errno);
+
+    fd = open(target_dev, O_PATH);
+    if (fd < 0) {
+        umount(target);
+        unlink(source_dev);
+        rmdir(target);
+        rmdir(source);
+        rmdir(root);
+        FAIL() << strerror(errno);
+    }
+
+    struct stat st = {};
+    ASSERT_EQ(0, fstat(fd, &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISCHR(st.st_mode));
+
+    char byte = 0;
+    ASSERT_EQ(-1, read(fd, &byte, 1));
+    EXPECT_EQ(EBADF, errno);
+    close(fd);
+
+    umount(target);
+    unlink(source_dev);
+    rmdir(target);
+    rmdir(source);
+    rmdir(root);
+}
+
+TEST(MountReconfigure, NoexecRejectsExec) {
+    const char *root = "/tmp/test_mount_noexec";
+    const char *source = "/tmp/test_mount_noexec/source";
+    const char *target = "/tmp/test_mount_noexec/target";
+    char source_file[256];
+    char target_file[256];
+
+    ensure_dir("/tmp");
+    ensure_dir(root);
+    ensure_dir(source);
+    ensure_dir(target);
+
+    if (unshare(CLONE_NEWNS) != 0) {
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL);
+
+    snprintf(source_file, sizeof(source_file), "%s/program", source);
+    snprintf(target_file, sizeof(target_file), "%s/program", target);
+    ASSERT_EQ(0, write_file(source_file)) << strerror(errno);
+    ASSERT_EQ(0, chmod(source_file, 0755)) << strerror(errno);
+
+    if (mount(source, target, NULL, MS_BIND, NULL) != 0) {
+        unlink(source_file);
+        rmdir(target);
+        rmdir(source);
+        rmdir(root);
+        FAIL() << strerror(errno);
+    }
+
+    if (mount(target, target, NULL, MS_BIND | MS_REMOUNT | MS_NOEXEC, NULL) != 0) {
+        umount(target);
+        unlink(source_file);
+        rmdir(target);
+        rmdir(source);
+        rmdir(root);
+        FAIL() << strerror(errno);
+    }
+
+    char *const argv[] = {target_file, nullptr};
+    char *const envp[] = {nullptr};
+    errno = 0;
+    EXPECT_EQ(-1, execve(target_file, argv, envp));
+    EXPECT_EQ(EACCES, errno);
+
+    umount(target);
+    unlink(source_file);
+    rmdir(target);
+    rmdir(source);
+    rmdir(root);
 }
 
 TEST(MountReconfigure, BindRemountReadonlyDoesNotChangeSourceSuperblock) {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -1,0 +1,338 @@
+#include <gtest/gtest.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace {
+
+int ensure_dir(const char* path) {
+    struct stat st = {};
+    if (stat(path, &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+    return mkdir(path, 0755);
+}
+
+void remove_tree(const char* root) {
+    char path[256] = {};
+
+    snprintf(path, sizeof(path), "%s/m", root);
+    umount(path);
+    rmdir(path);
+    snprintf(path, sizeof(path), "%s/u/x", root);
+    unlink(path);
+    snprintf(path, sizeof(path), "%s/u/x", root);
+    rmdir(path);
+    snprintf(path, sizeof(path), "%s/l/x", root);
+    unlink(path);
+    snprintf(path, sizeof(path), "%s/u", root);
+    rmdir(path);
+    snprintf(path, sizeof(path), "%s/l", root);
+    rmdir(path);
+    snprintf(path, sizeof(path), "%s/w", root);
+    rmdir(path);
+    rmdir(root);
+}
+
+void alarm_handler(int) {
+    _exit(124);
+}
+
+}  // namespace
+
+TEST(OverlayFsSemantics, ListAndLookupUpperDirOverLowerFile) {
+    char root[128] = {};
+    char upper[160] = {};
+    char lower[160] = {};
+    char work[160] = {};
+    char merged[160] = {};
+    char upper_x[192] = {};
+    char lower_x[192] = {};
+    char merged_x[192] = {};
+    char options[512] = {};
+
+    snprintf(root, sizeof(root), "/tmp/overlayfs_semantics_%d", getpid());
+    snprintf(upper, sizeof(upper), "%s/u", root);
+    snprintf(lower, sizeof(lower), "%s/l", root);
+    snprintf(work, sizeof(work), "%s/w", root);
+    snprintf(merged, sizeof(merged), "%s/m", root);
+    snprintf(upper_x, sizeof(upper_x), "%s/x", upper);
+    snprintf(lower_x, sizeof(lower_x), "%s/x", lower);
+    snprintf(merged_x, sizeof(merged_x), "%s/x", merged);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(root));
+    ASSERT_EQ(0, ensure_dir(upper));
+    ASSERT_EQ(0, ensure_dir(lower));
+    ASSERT_EQ(0, ensure_dir(work));
+    ASSERT_EQ(0, ensure_dir(merged));
+    ASSERT_EQ(0, mkdir(upper_x, 0755));
+
+    FILE* lower_file = fopen(lower_x, "w");
+    ASSERT_NE(nullptr, lower_file) << strerror(errno);
+    fclose(lower_file);
+
+    snprintf(options, sizeof(options), "lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work);
+    if (mount("overlay", merged, "overlay", 0, options) != 0) {
+        remove_tree(root);
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    signal(SIGALRM, alarm_handler);
+    alarm(5);
+
+    DIR* dir = opendir(merged);
+    if (dir != nullptr) {
+        while (readdir(dir) != nullptr) {
+        }
+        closedir(dir);
+    } else if (errno != ENOSYS) {
+        FAIL() << strerror(errno);
+    }
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(merged_x, &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISDIR(st.st_mode));
+
+    alarm(0);
+    remove_tree(root);
+}
+
+TEST(OverlayFsSemantics, CreateOverWhiteoutAfterLowerUnlink) {
+    char root[128] = {};
+    char upper[160] = {};
+    char lower[160] = {};
+    char work[160] = {};
+    char merged[160] = {};
+    char lower_x[192] = {};
+    char merged_x[192] = {};
+    char options[512] = {};
+
+    snprintf(root, sizeof(root), "/tmp/overlayfs_whiteout_%d", getpid());
+    snprintf(upper, sizeof(upper), "%s/u", root);
+    snprintf(lower, sizeof(lower), "%s/l", root);
+    snprintf(work, sizeof(work), "%s/w", root);
+    snprintf(merged, sizeof(merged), "%s/m", root);
+    snprintf(lower_x, sizeof(lower_x), "%s/x", lower);
+    snprintf(merged_x, sizeof(merged_x), "%s/x", merged);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(root));
+    ASSERT_EQ(0, ensure_dir(upper));
+    ASSERT_EQ(0, ensure_dir(lower));
+    ASSERT_EQ(0, ensure_dir(work));
+    ASSERT_EQ(0, ensure_dir(merged));
+
+    FILE* lower_file = fopen(lower_x, "w");
+    ASSERT_NE(nullptr, lower_file) << strerror(errno);
+    ASSERT_EQ(5U, fwrite("lower", 1, 5, lower_file));
+    fclose(lower_file);
+
+    snprintf(options, sizeof(options), "lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work);
+    if (mount("overlay", merged, "overlay", 0, options) != 0) {
+        remove_tree(root);
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    ASSERT_EQ(0, unlink(merged_x)) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(-1, stat(merged_x, &st));
+    ASSERT_EQ(ENOENT, errno);
+
+    int fd = open(merged_x, O_CREAT | O_WRONLY | O_EXCL, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(10, write(fd, "upper-data", 10)) << strerror(errno);
+    close(fd);
+
+    ASSERT_EQ(0, stat(merged_x, &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISREG(st.st_mode));
+    EXPECT_EQ(10, st.st_size);
+
+    remove_tree(root);
+}
+
+TEST(OverlayFsSemantics, LowerWhiteoutHidesLowerLayers) {
+    char root[128] = {};
+    char upper[160] = {};
+    char lower_top[160] = {};
+    char lower_bottom[160] = {};
+    char work[160] = {};
+    char merged[160] = {};
+    char top_x[192] = {};
+    char bottom_x[192] = {};
+    char merged_x[192] = {};
+    char options[512] = {};
+
+    snprintf(root, sizeof(root), "/tmp/overlayfs_lower_whiteout_%d", getpid());
+    snprintf(upper, sizeof(upper), "%s/u", root);
+    snprintf(lower_top, sizeof(lower_top), "%s/l1", root);
+    snprintf(lower_bottom, sizeof(lower_bottom), "%s/l2", root);
+    snprintf(work, sizeof(work), "%s/w", root);
+    snprintf(merged, sizeof(merged), "%s/m", root);
+    snprintf(top_x, sizeof(top_x), "%s/x", lower_top);
+    snprintf(bottom_x, sizeof(bottom_x), "%s/x", lower_bottom);
+    snprintf(merged_x, sizeof(merged_x), "%s/x", merged);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(root));
+    ASSERT_EQ(0, ensure_dir(upper));
+    ASSERT_EQ(0, ensure_dir(lower_top));
+    ASSERT_EQ(0, ensure_dir(lower_bottom));
+    ASSERT_EQ(0, ensure_dir(work));
+    ASSERT_EQ(0, ensure_dir(merged));
+    ASSERT_EQ(0, mknod(top_x, S_IFCHR | 0600, makedev(0, 0))) << strerror(errno);
+
+    FILE* bottom_file = fopen(bottom_x, "w");
+    ASSERT_NE(nullptr, bottom_file) << strerror(errno);
+    ASSERT_EQ(5U, fwrite("lower", 1, 5, bottom_file));
+    fclose(bottom_file);
+
+    snprintf(options, sizeof(options), "lowerdir=%s:%s,upperdir=%s,workdir=%s",
+             lower_top, lower_bottom, upper, work);
+    if (mount("overlay", merged, "overlay", 0, options) != 0) {
+        remove_tree(root);
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    struct stat st = {};
+    ASSERT_EQ(-1, stat(merged_x, &st));
+    EXPECT_EQ(ENOENT, errno);
+
+    remove_tree(root);
+    unlink(top_x);
+    unlink(bottom_x);
+    rmdir(lower_top);
+    rmdir(lower_bottom);
+    rmdir(root);
+}
+
+TEST(OverlayFsSemantics, RmdirLowerOnlyNonEmptyDirFails) {
+    char root[128] = {};
+    char upper[160] = {};
+    char lower[160] = {};
+    char work[160] = {};
+    char merged[160] = {};
+    char lower_dir[192] = {};
+    char lower_child[224] = {};
+    char merged_dir[192] = {};
+    char options[512] = {};
+
+    snprintf(root, sizeof(root), "/tmp/overlayfs_rmdir_lower_%d", getpid());
+    snprintf(upper, sizeof(upper), "%s/u", root);
+    snprintf(lower, sizeof(lower), "%s/l", root);
+    snprintf(work, sizeof(work), "%s/w", root);
+    snprintf(merged, sizeof(merged), "%s/m", root);
+    snprintf(lower_dir, sizeof(lower_dir), "%s/sub", lower);
+    snprintf(lower_child, sizeof(lower_child), "%s/child", lower_dir);
+    snprintf(merged_dir, sizeof(merged_dir), "%s/sub", merged);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(root));
+    ASSERT_EQ(0, ensure_dir(upper));
+    ASSERT_EQ(0, ensure_dir(lower));
+    ASSERT_EQ(0, ensure_dir(work));
+    ASSERT_EQ(0, ensure_dir(merged));
+    ASSERT_EQ(0, mkdir(lower_dir, 0755));
+
+    FILE* child_file = fopen(lower_child, "w");
+    ASSERT_NE(nullptr, child_file) << strerror(errno);
+    ASSERT_EQ(5U, fwrite("child", 1, 5, child_file));
+    fclose(child_file);
+
+    snprintf(options, sizeof(options), "lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work);
+    if (mount("overlay", merged, "overlay", 0, options) != 0) {
+        remove_tree(root);
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    ASSERT_EQ(-1, rmdir(merged_dir));
+    EXPECT_EQ(ENOTEMPTY, errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(merged_dir, &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISDIR(st.st_mode));
+
+    remove_tree(root);
+    unlink(lower_child);
+    rmdir(lower_dir);
+    rmdir(lower);
+    rmdir(root);
+}
+
+TEST(OverlayFsSemantics, UnlinkLowerWhiteoutReturnsEnoent) {
+    char root[128] = {};
+    char upper[160] = {};
+    char lower_top[160] = {};
+    char lower_bottom[160] = {};
+    char work[160] = {};
+    char merged[160] = {};
+    char top_x[192] = {};
+    char bottom_x[192] = {};
+    char merged_x[192] = {};
+    char options[512] = {};
+
+    snprintf(root, sizeof(root), "/tmp/overlayfs_unlink_whiteout_%d", getpid());
+    snprintf(upper, sizeof(upper), "%s/u", root);
+    snprintf(lower_top, sizeof(lower_top), "%s/l1", root);
+    snprintf(lower_bottom, sizeof(lower_bottom), "%s/l2", root);
+    snprintf(work, sizeof(work), "%s/w", root);
+    snprintf(merged, sizeof(merged), "%s/m", root);
+    snprintf(top_x, sizeof(top_x), "%s/x", lower_top);
+    snprintf(bottom_x, sizeof(bottom_x), "%s/x", lower_bottom);
+    snprintf(merged_x, sizeof(merged_x), "%s/x", merged);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(root));
+    ASSERT_EQ(0, ensure_dir(upper));
+    ASSERT_EQ(0, ensure_dir(lower_top));
+    ASSERT_EQ(0, ensure_dir(lower_bottom));
+    ASSERT_EQ(0, ensure_dir(work));
+    ASSERT_EQ(0, ensure_dir(merged));
+    ASSERT_EQ(0, mknod(top_x, S_IFCHR | 0600, makedev(0, 0))) << strerror(errno);
+
+    FILE* bottom_file = fopen(bottom_x, "w");
+    ASSERT_NE(nullptr, bottom_file) << strerror(errno);
+    ASSERT_EQ(5U, fwrite("lower", 1, 5, bottom_file));
+    fclose(bottom_file);
+
+    snprintf(options, sizeof(options), "lowerdir=%s:%s,upperdir=%s,workdir=%s",
+             lower_top, lower_bottom, upper, work);
+    if (mount("overlay", merged, "overlay", 0, options) != 0) {
+        remove_tree(root);
+        unlink(top_x);
+        unlink(bottom_x);
+        rmdir(lower_top);
+        rmdir(lower_bottom);
+        rmdir(root);
+        GTEST_SKIP() << strerror(errno);
+    }
+
+    ASSERT_EQ(-1, unlink(merged_x));
+    EXPECT_EQ(ENOENT, errno);
+
+    struct stat st = {};
+    ASSERT_EQ(-1, stat(merged_x, &st));
+    EXPECT_EQ(ENOENT, errno);
+
+    remove_tree(root);
+    unlink(top_x);
+    unlink(bottom_x);
+    rmdir(lower_top);
+    rmdir(lower_bottom);
+    rmdir(root);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -8,6 +8,7 @@ normal/epoll_timeout_budget
 normal/devpts_dir_read
 normal/test_pivot_root
 normal/mount_reconfigure
+normal/overlayfs_semantics
 normal/test_fchown_o_path
 normal/proc_self_limits
 normal/proc_fd_devfs_readlink


### PR DESCRIPTION
This pull request introduces significant improvements and refactoring to the OverlayFS implementation, enhancing its support for multiple lower layers, improving copy-up logic, and strengthening whiteout and directory handling. The changes also refactor internal structures for better maintainability and correctness.

**Major improvements include:**

- OverlayFS now supports multiple lower layers, allowing for more flexible and correct overlay filesystem semantics.
- The copy-up mechanism and whiteout file handling have been refactored and made more robust.
- Directory and file lookup, creation, and metadata logic have been updated to accommodate the new multi-layer structure.
- Internal struct fields and methods have been refactored for improved clarity, encapsulation, and correctness.

---

### Multi-layer OverlayFS Support

* Replaced single `lower_inode` with a `lower_inodes: Vec<Arc<dyn IndexNode>>` in `OvlInode`, enabling support for multiple lower layers. All relevant logic (lookup, read, metadata, etc.) is updated to iterate over these layers. (`kernel/src/filesystem/overlayfs/mod.rs`, `copy_up.rs`) [[1]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L90-R117) [[2]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1R162-R199) [[3]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L278-R409) [[4]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L412-R603) [[5]](diffhunk://#diff-9553e301d0662dac18f09ca1e23e54cfe89fb2e477f85fc562205e7c11564501L16-R50)
* Overlay mount logic now collects all lower roots and initializes `OvlInode` and `OvlLayer` for each, ensuring proper multi-layer stacking. (`kernel/src/filesystem/overlayfs/mod.rs`) [[1]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1R162-R199) [[2]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L183-R251)

### Copy-up and Whiteout Handling

* Refactored the copy-up process to work with multiple lower layers, copying file data only if the file type is `File`, and ensuring correct parent directory creation in the upper layer. (`copy_up.rs`)
* Improved whiteout creation and detection: now uses device metadata for whiteout identification, and whiteout logic is made more robust and accurate. (`kernel/src/filesystem/overlayfs/mod.rs`)

### Directory and Lookup Semantics

* Enhanced `find`, `list`, `rmdir`, and `unlink` methods to merge results from all lower layers and properly honor whiteouts, ensuring correct overlay semantics. (`kernel/src/filesystem/overlayfs/mod.rs`) [[1]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1R453-R468) [[2]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L353-R529) [[3]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L412-R603)
* Added logic to create missing parent directories in the upper layer as needed during copy-up, and to inherit permissions from lower layers. (`copy_up.rs`, `mod.rs`) [[1]](diffhunk://#diff-9553e301d0662dac18f09ca1e23e54cfe89fb2e477f85fc562205e7c11564501L16-R50) [[2]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L222-R376)

### Refactoring and Internal Improvements

* Changed `fs` field in `OvlInode` to a `Mutex<Weak<OverlayFS>>` for safe concurrent access and added a `set_fs` method for initialization. (`kernel/src/filesystem/overlayfs/mod.rs`) [[1]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L90-R117) [[2]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1L183-R251)
* Added helper methods such as `overlay_fs`, `upper_root_inode`, `ensure_upper_dir_path`, and `lower_dir_mode` to encapsulate common overlay logic. (`kernel/src/filesystem/overlayfs/mod.rs`)

### Miscellaneous

* Added `OVERLAYFS_MAGIC` constant for filesystem identification. (`kernel/src/filesystem/vfs/mod.rs`)
* Minor import and type adjustments to support the above changes. (`kernel/src/filesystem/overlayfs/mod.rs`, `open.rs`, `copy_up.rs`) [[1]](diffhunk://#diff-9553e301d0662dac18f09ca1e23e54cfe89fb2e477f85fc562205e7c11564501L3-R3) [[2]](diffhunk://#diff-dfff194ebd3ddff0b48a126dca4b4ca7552fedcd48388b6f24f49a65e97a69a1R6) [[3]](diffhunk://#diff-0a2edb252fa2205920ce550692438e0234ef3e48fbc3b3683f8c70ed745c868aR7)

These changes collectively make the OverlayFS implementation more robust, flexible, and correct, especially in scenarios involving multiple lower layers.