### PR TITLE
feat(tty): implement tcflush functionality and add test cases

### DIFF
--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -143,10 +143,15 @@ impl TtyOperation for Unix98PtyDriverInner {
     }
 
     fn flush_buffer(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
-        let to = tty.checked_link()?;
+        let Some(to) = tty.link() else {
+            return Ok(());
+        };
 
-        let mut ctrl = to.core().contorl_info_irqsave();
-        ctrl.pktstatus.insert(TtyPacketStatus::TIOCPKT_FLUSHWRITE);
+        if to.core().contorl_info_irqsave().packet {
+            tty.contorl_info_irqsave()
+                .pktstatus
+                .insert(TtyPacketStatus::TIOCPKT_FLUSHWRITE);
+        }
 
         to.core().read_wq().wakeup_all();
 

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -10,6 +10,7 @@ use alloc::{
 use system_error::SystemError;
 
 use crate::{
+    arch::ipc::signal::Signal,
     driver::{base::device::device_number::DeviceNumber, tty::pty::ptm_driver},
     filesystem::epoll::{event_poll::LockedEPItemLinkedList, EPollEventType, EPollItem},
     libs::{
@@ -206,6 +207,34 @@ impl TtyCore {
                 return Err(SystemError::ENOIOCTLCMD);
             }
         }
+    }
+
+    pub fn tty_perform_flush(tty: Arc<TtyCore>, arg: usize) -> Result<usize, SystemError> {
+        TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTOU)?;
+
+        match arg {
+            TtyFlushArg::TCIFLUSH => {
+                tty.ldisc().flush_buffer(tty.clone())?;
+            }
+            TtyFlushArg::TCIOFLUSH => {
+                tty.ldisc().flush_buffer(tty.clone())?;
+                let ret = tty.core().driver().driver_funcs().flush_buffer(tty.core());
+                if ret != Err(SystemError::ENOSYS) {
+                    ret?;
+                }
+            }
+            TtyFlushArg::TCOFLUSH => {
+                let ret = tty.core().driver().driver_funcs().flush_buffer(tty.core());
+                if ret != Err(SystemError::ENOSYS) {
+                    ret?;
+                }
+            }
+            _ => {
+                return Err(SystemError::EINVAL);
+            }
+        }
+
+        Ok(0)
     }
 
     pub fn core_set_termios(
@@ -844,4 +873,16 @@ impl TtyIoctlCmd {
     pub const TIOCGPKT: u32 = 0x80045438;
     /// 获取pts index
     pub const TIOCGPTN: u32 = 0x80045430;
+}
+
+pub struct TtyFlushArg;
+
+#[allow(dead_code)]
+impl TtyFlushArg {
+    /// 丢弃已收到但尚未读取的数据
+    pub const TCIFLUSH: usize = 0;
+    /// 丢弃已写入但尚未发送的数据
+    pub const TCOFLUSH: usize = 1;
+    /// 丢弃所有待处理输入和输出数据
+    pub const TCIOFLUSH: usize = 2;
 }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -56,10 +56,7 @@ impl NTtyLinediscipline {
             TtyIoctlCmd::TCXONC => {
                 todo!()
             }
-            TtyIoctlCmd::TCFLSH => {
-                log::warn!("NTTY TCFLSH has not been implemented yet");
-                Ok(0)
-            }
+            TtyIoctlCmd::TCFLSH => TtyCore::tty_perform_flush(tty, arg),
             _ => {
                 return TtyCore::tty_mode_ioctl(tty.clone(), cmd, arg);
             }
@@ -1575,11 +1572,17 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         ldata.read_flags.set_all(false);
         ldata.pushing = false;
         ldata.lookahead_count = 0;
+        ldata.no_room = false;
 
-        // todo: kick worker?
-        // packet mode?
         if core.link().is_some() {
             ldata.packet_mode_flush(core);
+        }
+
+        core.read_wq().wakeup_all();
+        core.write_wq().wakeup_all();
+
+        if let Some(link) = core.link() {
+            link.core().write_wq().wakeup_all();
         }
 
         Ok(())

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -193,8 +193,14 @@ impl Default for FilePrivateData {
 
 impl FilePrivateData {
     pub fn update_flags(&mut self, flags: FileFlags) {
-        if let FilePrivateData::Pipefs(pdata) = self {
-            pdata.set_flags(flags);
+        match self {
+            FilePrivateData::Pipefs(pdata) => {
+                pdata.set_flags(flags);
+            }
+            FilePrivateData::Tty(pdata) => {
+                pdata.flags = flags;
+            }
+            _ => {}
         }
     }
 

--- a/user/apps/tests/dunitest/suites/normal/tty_tcflush.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_tcflush.cc
@@ -1,0 +1,279 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pty.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+
+namespace {
+
+#ifndef TIOCPKT
+constexpr int kTiocpkt = 0x5420;
+#else
+constexpr int kTiocpkt = TIOCPKT;
+#endif
+
+#ifndef TIOCPKT_FLUSHREAD
+constexpr unsigned char kTiocpktFlushRead = 1;
+#else
+constexpr unsigned char kTiocpktFlushRead = TIOCPKT_FLUSHREAD;
+#endif
+
+#ifndef TIOCPKT_FLUSHWRITE
+constexpr unsigned char kTiocpktFlushWrite = 2;
+#else
+constexpr unsigned char kTiocpktFlushWrite = TIOCPKT_FLUSHWRITE;
+#endif
+
+class UniqueFd {
+public:
+    UniqueFd() = default;
+    explicit UniqueFd(int fd) : fd_(fd) {}
+    UniqueFd(const UniqueFd&) = delete;
+    UniqueFd& operator=(const UniqueFd&) = delete;
+
+    UniqueFd(UniqueFd&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+
+    UniqueFd& operator=(UniqueFd&& other) noexcept {
+        if (this != &other) {
+            reset();
+            fd_ = other.fd_;
+            other.fd_ = -1;
+        }
+        return *this;
+    }
+
+    ~UniqueFd() { reset(); }
+
+    int get() const { return fd_; }
+
+    void reset(int fd = -1) {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        fd_ = fd;
+    }
+
+private:
+    int fd_ = -1;
+};
+
+struct PtyPair {
+    UniqueFd master;
+    UniqueFd slave;
+};
+
+PtyPair OpenRawPty() {
+    int master = -1;
+    int slave = -1;
+    if (openpty(&master, &slave, nullptr, nullptr, nullptr) < 0) {
+        ADD_FAILURE() << "openpty failed: errno=" << errno << " (" << strerror(errno) << ")";
+        return {};
+    }
+
+    PtyPair pair{UniqueFd(master), UniqueFd(slave)};
+
+    struct termios term = {};
+    if (tcgetattr(pair.slave.get(), &term) < 0) {
+        ADD_FAILURE() << "tcgetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
+        return pair;
+    }
+
+    term.c_iflag = 0;
+    term.c_oflag = 0;
+    term.c_lflag = 0;
+    term.c_cflag |= CS8;
+    term.c_cc[VMIN] = 1;
+    term.c_cc[VTIME] = 0;
+
+    if (tcsetattr(pair.slave.get(), TCSANOW, &term) < 0) {
+        ADD_FAILURE() << "tcsetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
+    }
+
+    return pair;
+}
+
+int WaitFionread(int fd) {
+    int nread = 0;
+    for (int i = 0; i < 100; ++i) {
+        if (ioctl(fd, FIONREAD, &nread) < 0) {
+            ADD_FAILURE() << "ioctl(FIONREAD) failed: errno=" << errno << " ("
+                          << strerror(errno) << ")";
+            return -1;
+        }
+        if (nread > 0) {
+            return nread;
+        }
+        usleep(1000);
+    }
+    return nread;
+}
+
+unsigned char ReadPacketStatus(int master_fd) {
+    int old_flags = fcntl(master_fd, F_GETFL);
+    if (old_flags < 0) {
+        ADD_FAILURE() << "fcntl(F_GETFL) failed: errno=" << errno << " (" << strerror(errno)
+                      << ")";
+        return 0;
+    }
+
+    if (fcntl(master_fd, F_SETFL, old_flags | O_NONBLOCK) < 0) {
+        ADD_FAILURE() << "fcntl(F_SETFL, O_NONBLOCK) failed: errno=" << errno << " ("
+                      << strerror(errno) << ")";
+        return 0;
+    }
+
+    unsigned char status = 0;
+    for (int i = 0; i < 100; ++i) {
+        errno = 0;
+        ssize_t nread = read(master_fd, &status, 1);
+        if (nread == 1) {
+            EXPECT_EQ(0, fcntl(master_fd, F_SETFL, old_flags))
+                << "restore packet fd flags failed: errno=" << errno << " (" << strerror(errno)
+                << ")";
+            return status;
+        }
+        if (nread < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            ADD_FAILURE() << "read packet status failed: errno=" << errno << " ("
+                          << strerror(errno) << ")";
+            break;
+        }
+        usleep(10000);
+    }
+
+    ADD_FAILURE() << "timeout waiting for pty packet status";
+    EXPECT_EQ(0, fcntl(master_fd, F_SETFL, old_flags))
+        << "restore packet fd flags failed: errno=" << errno << " (" << strerror(errno) << ")";
+    return 0;
+}
+
+TEST(TtyTcflush, NonblockEmptyReadReturnsEagain) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    int flags = fcntl(pair.slave.get(), F_GETFL);
+    ASSERT_GE(flags, 0) << "fcntl(F_GETFL) failed: errno=" << errno << " (" << strerror(errno)
+                        << ")";
+    ASSERT_EQ(0, fcntl(pair.slave.get(), F_SETFL, flags | O_NONBLOCK))
+        << "fcntl(F_SETFL, O_NONBLOCK) failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+
+    char ch = 0;
+    errno = 0;
+    EXPECT_EQ(-1, read(pair.slave.get(), &ch, 1));
+    EXPECT_EQ(EAGAIN, errno) << "empty nonblocking tty read should return EAGAIN, got errno="
+                             << errno << " (" << strerror(errno) << ")";
+}
+
+TEST(TtyTcflush, TciflushDiscardsInput) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    ASSERT_EQ(3, write(pair.master.get(), "abc", 3))
+        << "write master failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_EQ(3, WaitFionread(pair.slave.get()));
+
+    ASSERT_EQ(0, tcflush(pair.slave.get(), TCIFLUSH))
+        << "tcflush(TCIFLUSH) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    int nread = -1;
+    ASSERT_EQ(0, ioctl(pair.slave.get(), FIONREAD, &nread))
+        << "ioctl(FIONREAD) after TCIFLUSH failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+    EXPECT_EQ(0, nread);
+
+    int flags = fcntl(pair.slave.get(), F_GETFL);
+    ASSERT_GE(flags, 0);
+    ASSERT_EQ(0, fcntl(pair.slave.get(), F_SETFL, flags | O_NONBLOCK));
+
+    char ch = 0;
+    errno = 0;
+    EXPECT_EQ(-1, read(pair.slave.get(), &ch, 1));
+    EXPECT_EQ(EAGAIN, errno);
+}
+
+TEST(TtyTcflush, TcioflushDiscardsInput) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    ASSERT_EQ(3, write(pair.master.get(), "xyz", 3))
+        << "write master failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_EQ(3, WaitFionread(pair.slave.get()));
+
+    ASSERT_EQ(0, tcflush(pair.slave.get(), TCIOFLUSH))
+        << "tcflush(TCIOFLUSH) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    int nread = -1;
+    ASSERT_EQ(0, ioctl(pair.slave.get(), FIONREAD, &nread))
+        << "ioctl(FIONREAD) after TCIOFLUSH failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+    EXPECT_EQ(0, nread);
+}
+
+TEST(TtyTcflush, PacketModeReportsFlushStatus) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    int on = 1;
+    ASSERT_EQ(0, ioctl(pair.master.get(), kTiocpkt, &on))
+        << "ioctl(TIOCPKT) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    ASSERT_EQ(1, write(pair.master.get(), "r", 1));
+    ASSERT_EQ(1, WaitFionread(pair.slave.get()));
+    ASSERT_EQ(0, tcflush(pair.slave.get(), TCIFLUSH));
+    unsigned char status = ReadPacketStatus(pair.master.get());
+    EXPECT_NE(0, status & kTiocpktFlushRead);
+
+    ASSERT_EQ(0, tcflush(pair.slave.get(), TCOFLUSH));
+    status = ReadPacketStatus(pair.master.get());
+    EXPECT_NE(0, status & kTiocpktFlushWrite);
+
+    ASSERT_EQ(1, write(pair.master.get(), "b", 1));
+    ASSERT_EQ(1, WaitFionread(pair.slave.get()));
+    ASSERT_EQ(0, tcflush(pair.slave.get(), TCIOFLUSH));
+    status = ReadPacketStatus(pair.master.get());
+    EXPECT_EQ(kTiocpktFlushRead | kTiocpktFlushWrite,
+              status & (kTiocpktFlushRead | kTiocpktFlushWrite));
+}
+
+TEST(TtyTcflush, InvalidArgumentReturnsEinval) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    errno = 0;
+    EXPECT_EQ(-1, tcflush(pair.slave.get(), 999));
+    EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(TtyTcflush, MasterFlushAfterSlaveCloseSucceeds) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    pair.slave.reset();
+
+    EXPECT_EQ(0, tcflush(pair.master.get(), TCIFLUSH))
+        << "tcflush(master, TCIFLUSH) after slave close failed: errno=" << errno << " ("
+        << strerror(errno) << ")";
+    EXPECT_EQ(0, tcflush(pair.master.get(), TCOFLUSH))
+        << "tcflush(master, TCOFLUSH) after slave close failed: errno=" << errno << " ("
+        << strerror(errno) << ")";
+    EXPECT_EQ(0, tcflush(pair.master.get(), TCIOFLUSH))
+        << "tcflush(master, TCIOFLUSH) after slave close failed: errno=" << errno << " ("
+        << strerror(errno) << ")";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -19,3 +19,4 @@ fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
 normal/user_namespace_id_map
+normal/tty_tcflush


### PR DESCRIPTION
- Added TtyFlushArg enum to define flush operation types (TCIFLUSH, TCOFLUSH, TCIOFLUSH)
- Implemented tty_perform_flush() in TtyCore to handle different flush operations
- Modified NTtyLinediscipline to use new flush functionality
- Added wakeup calls for read/write queues after flush
- Added comprehensive test cases for tcflush functionality
- Updated packet mode handling to report flush status


## Summary

Implement Linux-compatible `TCFLSH` handling for the NTTY line discipline and fix related PTY and TTY flag propagation edge cases.

This change wires `TCFLSH` to real input/output flush behavior instead of returning success after logging an unimplemented warning. It also keeps PTY packet-mode flush notifications aligned with Linux semantics and ensures `fcntl(F_SETFL, O_NONBLOCK)` takes effect for TTY reads.

## Changes

- Add shared TTY flush handling for `TCIFLUSH`, `TCOFLUSH`, and `TCIOFLUSH`.
- Route NTTY `TCFLSH` ioctls through the new flush helper.
- Reset NTTY input state on input flush, including pending no-room state, and wake relevant wait queues.
- Treat PTY output flush with no peer as a successful no-op, matching Linux `pty_flush_buffer()`.
- Report PTY packet-mode `TIOCPKT_FLUSHWRITE` from the flushed tty and only when packet mode is enabled by the peer.
- Propagate `F_SETFL` updates into TTY per-open private flags so `O_NONBLOCK` is honored by TTY read/write paths.
- Add a dunitest suite covering TTY nonblocking reads, tcflush input/output behavior, packet-mode flush status, invalid arguments, and PTY peer-close flush behavior.

## Notes

- The `TCXONC` path remains unimplemented and is intentionally left out of this change.
- The dunitest case is enabled through `normal/tty_tcflush` in the dunitest whitelist.
