### PR TITLE
fix(x86_64): use runtime xAPIC mapping during poweroff

### DIFF
--- a/kernel/src/arch/loongarch64/reboot.rs
+++ b/kernel/src/arch/loongarch64/reboot.rs
@@ -23,3 +23,5 @@ pub(crate) fn machine_power_off() -> ! {
         spin_loop();
     }
 }
+
+pub(crate) fn migrate_to_reboot_cpu() {}

--- a/kernel/src/arch/riscv64/interrupt/ipi.rs
+++ b/kernel/src/arch/riscv64/interrupt/ipi.rs
@@ -22,6 +22,7 @@ pub fn send_ipi(kind: IpiKind, target: IpiTarget) {
     let mask = Into::into(target);
     match kind {
         IpiKind::KickCpu => todo!(),
+        IpiKind::StopCpu => todo!(),
         IpiKind::FlushTLB => RiscV64MMArch::remote_invalidate_all_with_mask(mask).ok(),
         IpiKind::SpecVector(_) => todo!(),
     };

--- a/kernel/src/arch/riscv64/reboot.rs
+++ b/kernel/src/arch/riscv64/reboot.rs
@@ -23,3 +23,5 @@ pub(crate) fn machine_power_off() -> ! {
         spin_loop();
     }
 }
+
+pub(crate) fn migrate_to_reboot_cpu() {}

--- a/kernel/src/arch/x86_64/driver/apic/lapic_vector.rs
+++ b/kernel/src/arch/x86_64/driver/apic/lapic_vector.rs
@@ -13,7 +13,10 @@ use crate::{
         },
         interrupt::{
             entry::arch_setup_interrupt_gate,
-            ipi::{arch_ipi_handler_init, send_ipi, IPI_NUM_FLUSH_TLB, IPI_NUM_KICK_CPU},
+            ipi::{
+                arch_ipi_handler_init, send_ipi, IPI_NUM_FLUSH_TLB, IPI_NUM_KICK_CPU,
+                IPI_NUM_STOP_CPU,
+            },
             msi::{X86MsiAddrHi, X86MsiAddrLoNormal, X86MsiDataNormal, X86_MSI_BASE_ADDRESS_LOW},
         },
     },
@@ -260,7 +263,12 @@ pub fn arch_early_irq_init() -> Result<(), SystemError> {
     CurrentApic.init_current_cpu();
     if smp_get_processor_id().data() == 0 {
         unsafe { arch_setup_interrupt_gate() };
-        ioapic_init(&[APIC_TIMER_IRQ_NUM, IPI_NUM_KICK_CPU, IPI_NUM_FLUSH_TLB]);
+        ioapic_init(&[
+            APIC_TIMER_IRQ_NUM,
+            IPI_NUM_KICK_CPU,
+            IPI_NUM_FLUSH_TLB,
+            IPI_NUM_STOP_CPU,
+        ]);
     }
     return Ok(());
 }

--- a/kernel/src/arch/x86_64/driver/apic/mod.rs
+++ b/kernel/src/arch/x86_64/driver/apic/mod.rs
@@ -1,7 +1,4 @@
-use core::{
-    ptr::{read_volatile, write_volatile},
-    sync::atomic::Ordering,
-};
+use core::sync::atomic::Ordering;
 
 use atomic_enum::atomic_enum;
 use log::{debug, info};
@@ -18,7 +15,7 @@ use crate::{
         io::PortIOArch,
         CurrentPortIOArch,
     },
-    mm::{early_ioremap::EarlyIoRemap, PhysAddr},
+    mm::PhysAddr,
     smp::core::smp_get_processor_id,
 };
 
@@ -41,8 +38,6 @@ const APIC_SPIV: u32 = 0xF0;
 // 参考：https://code.dragonos.org.cn/xref/linux-6.1.9/tools/testing/selftests/kvm/include/x86_64/apic.h#35
 const APIC_SPIV_APIC_ENABLED: u32 = 1 << 8;
 const APIC_BASE_MSR: u32 = 0x800;
-// 参考: https://elixir.bootlin.com/linux/v6.6/source/arch/x86/include/asm/fixmap.h#L95
-const FIX_APIC_BASE: usize = 0x2;
 
 /// 当前启用的APIC类型
 #[atomic_enum]
@@ -537,6 +532,10 @@ impl CurrentApic {
 
     fn apic_soft_disable(&mut self) {
         debug!("apic soft disable");
+        if !apic_accessible() {
+            return;
+        }
+
         self.clear_local_apic();
 
         // 软禁用APIC（意味着清除 82489DX 寄存器）
@@ -548,6 +547,10 @@ impl CurrentApic {
     /// 确保Local APIC的状态没有残留信息
     fn clear_local_apic(&mut self) {
         debug!("clear local apic");
+        if !apic_accessible() {
+            return;
+        }
+
         // 获取Local APIC的最多支持的LVT项数量
         let max_lvt = self.max_lvt_entry();
         let mut lvt;
@@ -753,16 +756,25 @@ impl LocalAPIC for CurrentApic {
 }
 
 #[inline(always)]
+fn apic_accessible() -> bool {
+    if LOCAL_APIC_ENABLE_TYPE.load(Ordering::SeqCst) == LocalApicEnableType::X2Apic {
+        true
+    } else {
+        current_xapic_instance().borrow().is_some()
+    }
+}
+
+#[inline(always)]
 fn apic_read(reg: u32) -> u32 {
     if LOCAL_APIC_ENABLE_TYPE.load(Ordering::SeqCst) == LocalApicEnableType::X2Apic {
         return unsafe { rdmsr(APIC_BASE_MSR + (reg >> 4)) as u32 };
-    } else {
-        return unsafe {
-            read_volatile(
-                (EarlyIoRemap::idx_to_virt(FIX_APIC_BASE).data() + reg as usize) as *const u32,
-            ) as u32
-        };
     }
+
+    current_xapic_instance()
+        .borrow()
+        .as_ref()
+        .map(|xapic| unsafe { xapic.read_offset(reg) })
+        .unwrap_or(0)
 }
 
 #[inline(always)]
@@ -771,12 +783,7 @@ fn apic_write(reg: u32, value: u32) {
         unsafe {
             wrmsr(APIC_BASE_MSR + (reg >> 4), value as u64);
         };
-    } else {
-        unsafe {
-            write_volatile(
-                (EarlyIoRemap::idx_to_virt(FIX_APIC_BASE).data() + reg as usize) as *mut u32,
-                value,
-            );
-        }
+    } else if let Some(xapic) = current_xapic_instance().borrow().as_ref() {
+        unsafe { xapic.write_offset(reg, value) };
     }
 }

--- a/kernel/src/arch/x86_64/driver/apic/xapic.rs
+++ b/kernel/src/arch/x86_64/driver/apic/xapic.rs
@@ -126,20 +126,27 @@ pub struct XApic {
 }
 
 impl XApic {
+    /// Read the register at the specified APIC MMIO offset.
+    pub(super) unsafe fn read_offset(&self, reg: u32) -> u32 {
+        read_volatile((self.apic_vaddr.data() + reg as usize) as *const u32)
+    }
+
+    /// Write the register at the specified APIC MMIO offset.
+    pub(super) unsafe fn write_offset(&self, reg: u32, value: u32) {
+        write_volatile((self.apic_vaddr.data() + reg as usize) as *mut u32, value);
+        self.read(XApicOffset::LOCAL_APIC_OFFSET_Local_APIC_ID);
+    }
+
     /// 读取指定寄存器的值
     #[allow(dead_code)]
     pub unsafe fn read(&self, reg: XApicOffset) -> u32 {
-        read_volatile((self.apic_vaddr.data() + reg as usize) as *const u32)
+        self.read_offset(reg as u32)
     }
 
     /// 将指定的值写入寄存器
     #[allow(dead_code)]
     pub unsafe fn write(&self, reg: XApicOffset, value: u32) {
-        write_volatile(
-            (self.apic_vaddr.data() + (reg as u32) as usize) as *mut u32,
-            value,
-        );
-        self.read(XApicOffset::LOCAL_APIC_OFFSET_Local_APIC_ID); // 等待写操作完成，通过读取进行同步
+        self.write_offset(reg as u32, value);
     }
 }
 

--- a/kernel/src/arch/x86_64/interrupt/ipi.rs
+++ b/kernel/src/arch/x86_64/interrupt/ipi.rs
@@ -6,6 +6,7 @@ use x86::apic::ApicId;
 use crate::{
     arch::{
         driver::apic::{lapic_vector::local_apic_chip, CurrentApic, LocalAPIC},
+        process::stop_this_cpu,
         smp::SMP_BOOT_DATA,
     },
     exception::{
@@ -21,12 +22,14 @@ use super::TrapFrame;
 
 pub const IPI_NUM_KICK_CPU: IrqNumber = IrqNumber::new(200);
 pub const IPI_NUM_FLUSH_TLB: IrqNumber = IrqNumber::new(201);
+pub const IPI_NUM_STOP_CPU: IrqNumber = IrqNumber::new(202);
 /// IPI的种类(架构相关，指定了向量号)
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u32)]
 pub enum ArchIpiKind {
     KickCpu = IPI_NUM_KICK_CPU.data(),
     FlushTLB = IPI_NUM_FLUSH_TLB.data(),
+    StopCpu = IPI_NUM_STOP_CPU.data(),
     SpecVector(HardwareIrqNumber),
 }
 
@@ -35,6 +38,7 @@ impl From<IpiKind> for ArchIpiKind {
         match kind {
             IpiKind::KickCpu => ArchIpiKind::KickCpu,
             IpiKind::FlushTLB => ArchIpiKind::FlushTLB,
+            IpiKind::StopCpu => ArchIpiKind::StopCpu,
             IpiKind::SpecVector(vec) => ArchIpiKind::SpecVector(vec),
         }
     }
@@ -45,6 +49,7 @@ impl From<ArchIpiKind> for u8 {
         match value {
             ArchIpiKind::KickCpu => IPI_NUM_KICK_CPU.data() as u8,
             ArchIpiKind::FlushTLB => IPI_NUM_FLUSH_TLB.data() as u8,
+            ArchIpiKind::StopCpu => IPI_NUM_STOP_CPU.data() as u8,
             ArchIpiKind::SpecVector(vec) => (vec.data() & 0xFF) as u8,
         }
     }
@@ -267,6 +272,7 @@ pub fn ipi_send_smp_startup(target_cpu: ProcessorId) -> Result<(), SystemError> 
 pub fn arch_ipi_handler_init() {
     do_init_irq_handler(IPI_NUM_KICK_CPU);
     do_init_irq_handler(IPI_NUM_FLUSH_TLB);
+    do_init_irq_handler(IPI_NUM_STOP_CPU);
 }
 
 fn do_init_irq_handler(irq: IrqNumber) {
@@ -293,6 +299,10 @@ impl IrqFlowHandler for X86_64IpiIrqFlowHandler {
             IPI_NUM_FLUSH_TLB => {
                 FlushTLBIpiHandler.handle(irq, None, None).ok();
                 CurrentApic.send_eoi();
+            }
+            IPI_NUM_STOP_CPU => {
+                CurrentApic.send_eoi();
+                stop_this_cpu();
             }
             _ => {
                 error!("Unknown IPI: {}", irq.data());

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -655,7 +655,7 @@ unsafe extern "sysv64" fn ready_to_switch_to_user(
 /// # 功能
 ///
 /// 停止当前CPU的运行，系统进入最终的停机状态
-pub(super) fn stop_this_cpu() -> ! {
+pub(crate) fn stop_this_cpu() -> ! {
     let cpu_id = current_cpu_id();
 
     unsafe {

--- a/kernel/src/arch/x86_64/reboot.rs
+++ b/kernel/src/arch/x86_64/reboot.rs
@@ -10,12 +10,27 @@ use super::{
 use crate::{
     arch::{driver::apic::CurrentApic, io::PortIOArch, CurrentPortIOArch, MMArch},
     driver::acpi::reboot::{acpi_poweroff_probe_status, acpi_reboot},
-    exception::InterruptArch,
+    exception::{
+        ipi::{IpiKind, IpiTarget},
+        InterruptArch,
+    },
+    libs::cpumask::CpuMask,
     misc::reboot::do_machine_power_off,
     mm::{MemoryManagementArch, PhysAddr},
+    process::ProcessManager,
+    sched::{request_task_migration, schedule, SchedMode},
+    smp::{
+        core::smp_get_processor_id,
+        cpu::{smp_cpu_manager, ProcessorId},
+    },
     time::{sleep::nanosleep, PosixTimeSpec},
 };
-use core::{arch::asm, ptr};
+use core::{
+    arch::asm,
+    hint::spin_loop,
+    ptr,
+    sync::atomic::{AtomicBool, Ordering},
+};
 use log::debug;
 use x86::dtables::{lidt, DescriptorTablePointer};
 
@@ -49,6 +64,8 @@ enum RebootMode {
 
 static mut REBOOT_FORCE: bool = false;
 static mut REBOOT_MODE: RebootMode = RebootMode::RebootUndefined;
+static STOPPING_CPUS: AtomicBool = AtomicBool::new(false);
+const STOP_OTHER_CPUS_TIMEOUT_LOOPS: usize = 10_000_000;
 
 /// # 功能
 ///
@@ -109,10 +126,84 @@ fn machine_shutdown() {
         CurrentIrqArch::interrupt_disable();
     }
 
+    stop_other_cpus();
     CurrentApic.lapic_shutdown();
 
     // 禁用HPET
     hpet_disable();
+}
+
+/// Migrate the current shutdown task to the reboot CPU.
+///
+/// Linux pins the shutdown task to reboot_cpu before syscore_shutdown, so the
+/// later shutdown sequence does not run on an AP that is about to be stopped.
+pub(crate) fn migrate_to_reboot_cpu() {
+    let reboot_cpu = ProcessorId::new(0);
+    let dest_cpu = if smp_cpu_manager().is_online_cpu(reboot_cpu) {
+        reboot_cpu
+    } else {
+        smp_cpu_manager()
+            .present_cpus()
+            .iter_cpu()
+            .find(|&cpu| smp_cpu_manager().is_online_cpu(cpu))
+            .unwrap_or_else(smp_get_processor_id)
+    };
+
+    let current = ProcessManager::current_pcb();
+    current
+        .sched_info()
+        .set_cpus_allowed(CpuMask::from_cpu(dest_cpu));
+
+    if smp_get_processor_id() != dest_cpu {
+        if let Err(e) = request_task_migration(&current, dest_cpu) {
+            log::warn!(
+                "migrate_to_reboot_cpu: failed to migrate to CPU {}: {e:?}",
+                dest_cpu.data()
+            );
+            return;
+        }
+        schedule(SchedMode::SM_NONE);
+    }
+}
+
+fn stop_other_cpus() {
+    if STOPPING_CPUS.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    let this_cpu = smp_get_processor_id();
+    let mut targets = CpuMask::new();
+
+    for cpu in smp_cpu_manager().present_cpus().iter_cpu() {
+        if cpu != this_cpu && smp_cpu_manager().is_online_cpu(cpu) {
+            targets.set(cpu, true);
+        }
+    }
+
+    if targets.is_empty() {
+        return;
+    }
+
+    crate::arch::interrupt::ipi::send_ipi(IpiKind::StopCpu, IpiTarget::Other);
+
+    for _ in 0..STOP_OTHER_CPUS_TIMEOUT_LOOPS {
+        if targets
+            .iter_cpu()
+            .all(|cpu| !smp_cpu_manager().is_online_cpu(cpu))
+        {
+            return;
+        }
+        spin_loop();
+    }
+
+    for cpu in targets.iter_cpu() {
+        if smp_cpu_manager().is_online_cpu(cpu) {
+            log::warn!(
+                "stop_other_cpus: CPU {} did not stop before timeout",
+                cpu.data()
+            );
+        }
+    }
 }
 
 /// # 功能

--- a/kernel/src/exception/ipi.rs
+++ b/kernel/src/exception/ipi.rs
@@ -19,6 +19,7 @@ use super::{
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum IpiKind {
     KickCpu,
+    StopCpu,
     /// TLB shootdown IPI.
     ///
     /// Do NOT directly `send_ipi(IpiKind::FlushTLB, ..)` in new code:

--- a/kernel/src/misc/reboot.rs
+++ b/kernel/src/misc/reboot.rs
@@ -2,7 +2,7 @@ use alloc::{string::String, sync::Arc, vec::Vec};
 use system_error::SystemError;
 
 use crate::{
-    arch::reboot::{machine_halt, machine_power_off, machine_restart},
+    arch::reboot::{machine_halt, machine_power_off, machine_restart, migrate_to_reboot_cpu},
     driver::base::device::device_shutdown,
     init::initial_kthread::{set_system_state, SystemState},
     libs::{
@@ -255,6 +255,7 @@ pub(super) fn do_sys_reboot(
 pub fn kernel_restart(cmd: Option<&str>) -> ! {
     kernel_restart_prepare(cmd);
     do_kernel_restart_prepare();
+    migrate_to_reboot_cpu();
     syscore_shutdown();
 
     if let Some(cmd) = cmd {
@@ -297,6 +298,7 @@ pub fn kernel_power_off() -> ! {
     kernel_shutdown_prepare(SystemState::PowerOff);
     do_kernel_power_off_prepare();
     do_power_off_handlers_prepare();
+    migrate_to_reboot_cpu();
     syscore_shutdown();
 
     log::warn!("Power down");
@@ -382,6 +384,7 @@ pub fn do_machine_power_off() -> Result<(), SystemError> {
 /// 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/kernel/reboot.c#293
 pub fn kernel_halt() -> ! {
     kernel_shutdown_prepare(SystemState::Halt);
+    migrate_to_reboot_cpu();
     syscore_shutdown();
 
     machine_halt();


### PR DESCRIPTION
Fix TCG poweroff panic by avoiding runtime APIC accesses through the early fixmap slot. xAPIC register reads and writes now use the per-CPU XApic MMIO mapping created during APIC initialization.

Also align the shutdown flow with Linux by migrating the shutdown task to the reboot CPU before syscore shutdown and stopping secondary CPUs before shutting down the current LAPIC.


## Summary

Fix a kernel panic triggered by running `busybox poweroff` inside DragonOS when the system is started with `DRAGONOS_QEMU_ACCEL=tcg make run-nographic`.

The root cause was that runtime APIC register accesses in xAPIC mode still used an early fixmap address. During shutdown, `clear_local_apic()` accessed the APIC ESR through the unreliable mapping at `0xffffb00000002280`, which caused a kernel address fault. KVM usually uses the x2APIC MSR path, so it did not hit this faulty MMIO access path.

## Changes

- Switch runtime xAPIC register access to the existing per-CPU `XApic` MMIO mapping instead of relying on the early fixmap slot.
- Add an APIC accessibility check in the LAPIC shutdown path, following the Linux `apic_accessible()` model.
- Migrate the current shutdown task to the reboot CPU before `syscore_shutdown()` in reboot, poweroff, and halt paths.
- Add a x86_64 `StopCpu` IPI so `machine_shutdown()` stops secondary CPUs before shutting down the current LAPIC and HPET.
- Add no-op `migrate_to_reboot_cpu()` implementations for non-x86 architectures to keep the generic reboot path buildable.

## Verification

- `make kernel` passes.
- `make fmt` passes.
- Manually verified that `busybox poweroff` in the TCG scenario no longer triggers the `0xffffb00000002280` fault or a kernel panic. The shutdown log shows the AP entering `stop_this_cpu()`, while the current CPU completes LAPIC shutdown and proceeds to `HPET disable`.
