### PR TITLE
feat(syscall): implement sync_file_range

### DIFF
--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -42,6 +42,12 @@ struct FileVmaIndex {
     vmas: HashMap<usize, Weak<LockedVMA>>,
 }
 
+#[derive(Debug, Default)]
+struct WritebackErrorState {
+    seq: u64,
+    error: Option<SystemError>,
+}
+
 impl FileVmaIndex {
     fn register(&mut self, vma: &Arc<LockedVMA>) {
         self.vmas.insert(vma.id(), Arc::downgrade(vma));
@@ -258,6 +264,7 @@ pub struct PageCache {
     invalidate_lock: RwSem<()>,
     file_vma_seq: AtomicU64,
     file_vmas: SpinLock<FileVmaIndex>,
+    writeback_error: SpinLock<WritebackErrorState>,
     unevictable: AtomicBool,
     is_shmem: AtomicBool,
     manager: PageCacheManager,
@@ -478,6 +485,56 @@ impl PageCacheManager {
         Ok(())
     }
 
+    pub fn wait_writeback_range(
+        &self,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        let entries: Vec<Arc<PageEntry>> = {
+            let inner = cache.inner.lock();
+            inner
+                .pages
+                .iter()
+                .filter_map(|(idx, entry)| {
+                    if *idx >= start_index && *idx <= end_index {
+                        Some(entry.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+        for entry in entries {
+            Self::wait_writeback_entry(entry)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn start_writeback_range(
+        &self,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        let dirty_entries: Vec<(usize, Arc<PageEntry>)> = {
+            let inner = cache.inner.lock();
+            inner
+                .dirty_pages
+                .range(start_index..=end_index)
+                .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
+                .collect()
+        };
+
+        for (page_index, entry) in dirty_entries {
+            Self::start_writeback_entry(&cache, page_index, entry)?;
+        }
+
+        Ok(())
+    }
+
     pub fn invalidate_range(
         &self,
         start_index: usize,
@@ -506,12 +563,19 @@ impl PageCacheManager {
         Self::writeback_entry(&cache, page_index, entry)
     }
 
-    fn writeback_entry(
+    fn wait_writeback_entry(entry: Arc<PageEntry>) -> Result<(), SystemError> {
+        entry.wait_queue.wait_until(|| match entry.state() {
+            PageState::Writeback => None,
+            PageState::Error => Some(Err(SystemError::EIO)),
+            _ => Some(Ok(())),
+        })
+    }
+
+    fn prepare_writeback_entry(
         cache: &Arc<PageCache>,
         page_index: usize,
-        entry: Arc<PageEntry>,
-    ) -> Result<(), SystemError> {
-        let page = entry.page.clone();
+        entry: &Arc<PageEntry>,
+    ) -> Result<bool, SystemError> {
         loop {
             match entry.state() {
                 PageState::Loading => {
@@ -519,18 +583,14 @@ impl PageCacheManager {
                     continue;
                 }
                 PageState::Writeback => {
-                    entry.wait_queue.wait_until(|| match entry.state() {
-                        PageState::Writeback => None,
-                        PageState::Error => Some(Err(SystemError::EIO)),
-                        _ => Some(Ok(())),
-                    })?;
+                    Self::wait_writeback_entry(entry.clone())?;
                     continue;
                 }
                 PageState::Error => return Err(SystemError::EIO),
                 PageState::UpToDate => {
-                    let guard = page.read();
+                    let guard = entry.page.read();
                     if !guard.flags().contains(PageFlags::PG_DIRTY) {
-                        return Ok(());
+                        return Ok(false);
                     }
                     drop(guard);
                     entry.set_state(PageState::Dirty);
@@ -539,9 +599,9 @@ impl PageCacheManager {
                     continue;
                 }
                 PageState::Dirty => {
-                    let guard = page.read();
+                    let guard = entry.page.read();
                     if !guard.flags().contains(PageFlags::PG_DIRTY) {
-                        return Ok(());
+                        return Ok(false);
                     }
                 }
             }
@@ -550,14 +610,178 @@ impl PageCacheManager {
                 .is_ok()
             {
                 cache.account_state_transition(PageState::Dirty, PageState::Writeback);
-                break;
+                let mut inner = cache.inner.lock();
+                inner.dirty_pages.remove(&page_index);
+                return Ok(true);
             }
         }
-        {
+    }
+
+    fn try_prepare_async_writeback_entry(
+        cache: &Arc<PageCache>,
+        page_index: usize,
+        entry: &Arc<PageEntry>,
+    ) -> Result<bool, SystemError> {
+        loop {
+            match entry.state() {
+                PageState::Loading => {
+                    let _ = entry.wait_ready()?;
+                    continue;
+                }
+                PageState::Writeback => return Ok(false),
+                PageState::Error => return Err(SystemError::EIO),
+                PageState::UpToDate => {
+                    let guard = entry.page.read();
+                    if !guard.flags().contains(PageFlags::PG_DIRTY) {
+                        return Ok(false);
+                    }
+                    drop(guard);
+                    entry.set_state(PageState::Dirty);
+                    let mut inner = cache.inner.lock();
+                    inner.dirty_pages.insert(page_index);
+                    continue;
+                }
+                PageState::Dirty => {
+                    let guard = entry.page.read();
+                    if !guard.flags().contains(PageFlags::PG_DIRTY) {
+                        return Ok(false);
+                    }
+                }
+            }
+
+            if entry
+                .compare_exchange_state(PageState::Dirty, PageState::Writeback)
+                .is_ok()
+            {
+                cache.account_state_transition(PageState::Dirty, PageState::Writeback);
+                let mut inner = cache.inner.lock();
+                inner.dirty_pages.remove(&page_index);
+                return Ok(true);
+            }
+        }
+    }
+
+    fn finish_writeback_entry(
+        cache: Arc<PageCache>,
+        page_index: usize,
+        entry: Arc<PageEntry>,
+        page: Arc<Page>,
+        result: Result<(), SystemError>,
+    ) -> Result<(), SystemError> {
+        if let Err(e) = result {
+            cache.record_writeback_error(e.clone());
+            {
+                let mut guard = page.write();
+                guard.add_flags(PageFlags::PG_ERROR | PageFlags::PG_DIRTY);
+            }
+            cache.account_state_transition(PageState::Writeback, PageState::Dirty);
+            entry.set_state(PageState::Dirty);
             let mut inner = cache.inner.lock();
-            inner.dirty_pages.remove(&page_index);
+            inner.dirty_pages.insert(page_index);
+            entry.wait_queue.wake_all();
+            return Err(e);
         }
 
+        {
+            let mut guard = page.write();
+            guard.remove_flags(PageFlags::PG_ERROR);
+            if guard.flags().contains(PageFlags::PG_DIRTY) {
+                cache.account_state_transition(PageState::Writeback, PageState::Dirty);
+                entry.set_state(PageState::Dirty);
+                let mut inner = cache.inner.lock();
+                inner.dirty_pages.insert(page_index);
+            } else {
+                cache.account_state_transition(PageState::Writeback, PageState::UpToDate);
+                entry.set_state(PageState::UpToDate);
+                let mut inner = cache.inner.lock();
+                inner.dirty_pages.remove(&page_index);
+            }
+        }
+        entry.wait_queue.wake_all();
+        Ok(())
+    }
+
+    fn start_writeback_entry(
+        cache: &Arc<PageCache>,
+        page_index: usize,
+        entry: Arc<PageEntry>,
+    ) -> Result<(), SystemError> {
+        if !Self::try_prepare_async_writeback_entry(cache, page_index, &entry)? {
+            return Ok(());
+        }
+
+        let page = entry.page.clone();
+        let _invalidate = cache.invalidate_read();
+        let inode = cache
+            .inode()
+            .and_then(|inode| inode.upgrade())
+            .ok_or(SystemError::EIO)?;
+        let backend = cache.backend();
+        let page_start = page_index * MMArch::PAGE_SIZE;
+        let len = if let Ok(metadata) = inode.metadata() {
+            let file_size = metadata.size.max(0) as usize;
+            if file_size <= page_start {
+                0
+            } else {
+                core::cmp::min(MMArch::PAGE_SIZE, file_size - page_start)
+            }
+        } else {
+            MMArch::PAGE_SIZE
+        };
+
+        let data = if len > 0 {
+            let _ = cache.mkclean_page(page_index, false);
+            let mut guard = page.write();
+            guard.remove_flags(PageFlags::PG_DIRTY);
+            let src = unsafe { guard.as_slice() };
+            Some(src[..len].to_vec())
+        } else {
+            None
+        };
+
+        let cache = cache.clone();
+        let work_page = page.clone();
+        let work_entry = entry.clone();
+        let work = Work::new(move || {
+            let result = match &data {
+                Some(data) => {
+                    if let Some(backend) = &backend {
+                        backend.write_page(page_index, data).map(|_| ())
+                    } else {
+                        inode
+                            .write_direct(
+                                page_start,
+                                data.len(),
+                                data,
+                                Mutex::new(FilePrivateData::Unused).lock(),
+                            )
+                            .map(|_| ())
+                    }
+                }
+                None => Ok(()),
+            };
+            let _ = Self::finish_writeback_entry(
+                cache.clone(),
+                page_index,
+                work_entry.clone(),
+                work_page.clone(),
+                result,
+            );
+        });
+        schedule_pagecache_io(work);
+        Ok(())
+    }
+
+    fn writeback_entry(
+        cache: &Arc<PageCache>,
+        page_index: usize,
+        entry: Arc<PageEntry>,
+    ) -> Result<(), SystemError> {
+        if !Self::prepare_writeback_entry(cache, page_index, &entry)? {
+            return Ok(());
+        }
+
+        let page = entry.page.clone();
         let _invalidate = cache.invalidate_read();
         let inode = cache
             .inode()
@@ -603,37 +827,10 @@ impl PageCacheManager {
                     Mutex::new(FilePrivateData::Unused).lock(),
                 )
             };
-            if let Err(e) = result {
-                {
-                    let mut guard = page.write();
-                    guard.add_flags(PageFlags::PG_ERROR | PageFlags::PG_DIRTY);
-                }
-                cache.account_state_transition(PageState::Writeback, PageState::Dirty);
-                entry.set_state(PageState::Dirty);
-                let mut inner = cache.inner.lock();
-                inner.dirty_pages.insert(page_index);
-                entry.wait_queue.wake_all();
-                return Err(e);
-            }
+            Self::finish_writeback_entry(cache.clone(), page_index, entry, page, result.map(|_| ()))
+        } else {
+            Self::finish_writeback_entry(cache.clone(), page_index, entry, page, Ok(()))
         }
-
-        {
-            let mut guard = page.write();
-            guard.remove_flags(PageFlags::PG_ERROR);
-            if guard.flags().contains(PageFlags::PG_DIRTY) {
-                cache.account_state_transition(PageState::Writeback, PageState::Dirty);
-                entry.set_state(PageState::Dirty);
-                let mut inner = cache.inner.lock();
-                inner.dirty_pages.insert(page_index);
-            } else {
-                cache.account_state_transition(PageState::Writeback, PageState::UpToDate);
-                entry.set_state(PageState::UpToDate);
-                let mut inner = cache.inner.lock();
-                inner.dirty_pages.remove(&page_index);
-            }
-        }
-        entry.wait_queue.wake_all();
-        Ok(())
     }
 }
 
@@ -852,12 +1049,31 @@ impl PageCache {
             invalidate_lock: RwSem::new(()),
             file_vma_seq: AtomicU64::new(0),
             file_vmas: SpinLock::new(FileVmaIndex::default()),
+            writeback_error: SpinLock::new(WritebackErrorState::default()),
             unevictable: AtomicBool::new(false),
             is_shmem: AtomicBool::new(false),
             manager: PageCacheManager::new(weak.clone()),
         });
         register_page_cache(&cache);
         cache
+    }
+
+    pub fn sample_writeback_error(&self) -> u64 {
+        self.writeback_error.lock_irqsave().seq
+    }
+
+    pub fn check_writeback_error_since(&self, since: u64) -> Option<(u64, SystemError)> {
+        let guard = self.writeback_error.lock_irqsave();
+        if guard.seq == since {
+            return None;
+        }
+        guard.error.clone().map(|err| (guard.seq, err))
+    }
+
+    fn record_writeback_error(&self, error: SystemError) {
+        let mut guard = self.writeback_error.lock_irqsave();
+        guard.seq = guard.seq.wrapping_add(1).max(1);
+        guard.error = Some(error);
     }
 
     /// # 获取页缓存的ID
@@ -1560,6 +1776,7 @@ impl PageCache {
     }
 
     pub fn mark_page_error(&self, page_index: usize) {
+        self.record_writeback_error(SystemError::EIO);
         let mut guard = self.inner.lock();
         if let Some(entry) = guard.get_entry(page_index) {
             let old_state = entry.state();

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1,6 +1,6 @@
 use core::{
     fmt,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
 };
 
 use alloc::{string::String, sync::Arc, vec::Vec};
@@ -23,6 +23,7 @@ use crate::{
         epoll::{event_poll::EPollPrivateData, EPollItem},
         fuse::private_data::FuseFilePrivateData,
         kernfs::callback::KernFilePrivateData,
+        page_cache::PageCache,
         procfs::ProcfsFilePrivateData,
         vfs::FilldirContext,
     },
@@ -459,12 +460,26 @@ pub struct File {
     posix_lock_key: (usize, InodeId),
     /// 预读状态
     ra_state: Mutex<FileReadaheadState>,
+    /// 当前 open file description 已观测到的 page cache 写回错误序列。
+    wb_error_seq: AtomicU64,
 }
 
 impl File {
     #[inline]
     pub fn cred(&self) -> Arc<Cred> {
         self.cred.clone()
+    }
+
+    pub fn check_and_advance_wb_error(
+        &self,
+        page_cache: &Arc<PageCache>,
+    ) -> Result<(), SystemError> {
+        let since = self.wb_error_seq.load(Ordering::Acquire);
+        let Some((seq, error)) = page_cache.check_writeback_error_since(since) else {
+            return Ok(());
+        };
+        self.wb_error_seq.store(seq, Ordering::Release);
+        Err(error)
     }
 
     fn maybe_kill_suid_sgid_after_write(&self) -> Result<(), SystemError> {
@@ -675,6 +690,11 @@ impl File {
             mode = FileMode::FMODE_PATH | FileMode::FMODE_OPENED;
         }
 
+        let wb_error_seq = inode
+            .page_cache()
+            .map(|page_cache| page_cache.sample_writeback_error())
+            .unwrap_or(0);
+
         let f = File {
             open_file_id: alloc_open_file_id(),
             inode,
@@ -688,6 +708,7 @@ impl File {
             owner: Mutex::new(FileOwner::new()),
             posix_lock_key,
             ra_state: Mutex::new(FileReadaheadState::new()),
+            wb_error_seq: AtomicU64::new(wb_error_seq),
         };
 
         return Ok(f);
@@ -1217,6 +1238,7 @@ impl File {
             owner: Mutex::new(FileOwner::new()),
             posix_lock_key: self.posix_lock_key,
             ra_state: Mutex::new(self.ra_state.lock().clone()),
+            wb_error_seq: AtomicU64::new(self.wb_error_seq.load(Ordering::Acquire)),
         };
         // 调用inode的open方法，让inode知道有新的文件打开了这个inode
         // TODO: reopen is not a good idea for some inodes, need a better design

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -77,6 +77,7 @@ pub mod sys_mount;
 mod sys_sendfile;
 mod sys_splice;
 mod sys_sync;
+mod sys_sync_file_range;
 mod sys_tee;
 pub mod sys_umount2;
 

--- a/kernel/src/filesystem/vfs/syscall/sys_sync_file_range.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync_file_range.rs
@@ -1,0 +1,126 @@
+//! sync_file_range 系统调用实现。
+//!
+//! 语义参考 Linux 6.6.21 `fs/sync.c`：该调用只控制文件数据页写回，
+//! 不同步文件元数据，也不改变文件当前位置。
+
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+use system_error::SystemError;
+
+use crate::arch::{interrupt::TrapFrame, syscall::nr::SYS_SYNC_FILE_RANGE, MMArch};
+use crate::filesystem::vfs::{
+    file::{File, FileMode},
+    FileType,
+};
+use crate::mm::MemoryManagementArch;
+use crate::process::ProcessManager;
+use crate::syscall::table::{FormattedSyscallParam, Syscall};
+
+bitflags::bitflags! {
+    struct SyncFileRangeFlags: u32 {
+        const WAIT_BEFORE = 1;
+        const WRITE = 2;
+        const WAIT_AFTER = 4;
+    }
+}
+
+pub struct SysSyncFileRangeHandle;
+
+impl Syscall for SysSyncFileRangeHandle {
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let fd = args[0] as i32;
+        let offset = args[1] as i64;
+        let nbytes = args[2] as i64;
+        let raw_flags = args[3] as u32;
+
+        do_sync_file_range(fd, offset, nbytes, raw_flags)?;
+        Ok(0)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", (args[0] as i32).to_string()),
+            FormattedSyscallParam::new("offset", (args[1] as i64).to_string()),
+            FormattedSyscallParam::new("nbytes", (args[2] as i64).to_string()),
+            FormattedSyscallParam::new("flags", format!("{:#x}", args[3] as u32)),
+        ]
+    }
+}
+
+fn do_sync_file_range(
+    fd: i32,
+    offset: i64,
+    nbytes: i64,
+    raw_flags: u32,
+) -> Result<(), SystemError> {
+    let file = {
+        let binding = ProcessManager::current_pcb().fd_table();
+        let fd_table_guard = binding.read();
+        fd_table_guard
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?
+    };
+
+    if file.mode().contains(FileMode::FMODE_PATH) {
+        return Err(SystemError::EBADF);
+    }
+
+    let flags = SyncFileRangeFlags::from_bits(raw_flags).ok_or(SystemError::EINVAL)?;
+
+    let endbyte = offset.checked_add(nbytes).ok_or(SystemError::EINVAL)?;
+    if offset < 0 || endbyte < 0 || endbyte < offset {
+        return Err(SystemError::EINVAL);
+    }
+
+    sync_file_range(&file, offset as usize, nbytes as usize, flags)
+}
+
+fn sync_file_range(
+    file: &File,
+    offset: usize,
+    nbytes: usize,
+    flags: SyncFileRangeFlags,
+) -> Result<(), SystemError> {
+    let inode = file.inode();
+    let file_type = inode.metadata()?.file_type;
+    if !matches!(
+        file_type,
+        FileType::File | FileType::BlockDevice | FileType::Dir | FileType::SymLink
+    ) {
+        return Err(SystemError::ESPIPE);
+    }
+
+    let endbyte = if nbytes == 0 {
+        usize::MAX
+    } else {
+        offset.checked_add(nbytes).ok_or(SystemError::EINVAL)? - 1
+    };
+    let start_index = offset >> MMArch::PAGE_SHIFT;
+    let end_index = endbyte >> MMArch::PAGE_SHIFT;
+
+    let Some(page_cache) = inode.page_cache() else {
+        return Ok(());
+    };
+    let manager = page_cache.manager();
+
+    if flags.contains(SyncFileRangeFlags::WAIT_BEFORE) {
+        manager.wait_writeback_range(start_index, end_index)?;
+        file.check_and_advance_wb_error(&page_cache)?;
+    }
+    if flags.contains(SyncFileRangeFlags::WRITE) {
+        manager.start_writeback_range(start_index, end_index)?;
+    }
+    if flags.contains(SyncFileRangeFlags::WAIT_AFTER) {
+        manager.wait_writeback_range(start_index, end_index)?;
+        file.check_and_advance_wb_error(&page_cache)?;
+    }
+
+    Ok(())
+}
+
+syscall_table_macros::declare_syscall!(SYS_SYNC_FILE_RANGE, SysSyncFileRangeHandle);

--- a/user/apps/tests/dunitest/suites/normal/sync_file_range.cc
+++ b/user/apps/tests/dunitest/suites/normal/sync_file_range.cc
@@ -1,0 +1,188 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <string>
+
+#ifndef __NR_sync_file_range
+#if defined(__x86_64__)
+#define __NR_sync_file_range 277
+#elif defined(__riscv) || defined(__loongarch64)
+#define __NR_sync_file_range 84
+#else
+#error "__NR_sync_file_range is not defined for this architecture"
+#endif
+#endif
+
+#ifndef SYNC_FILE_RANGE_WAIT_BEFORE
+#define SYNC_FILE_RANGE_WAIT_BEFORE 1
+#endif
+
+#ifndef SYNC_FILE_RANGE_WRITE
+#define SYNC_FILE_RANGE_WRITE 2
+#endif
+
+#ifndef SYNC_FILE_RANGE_WAIT_AFTER
+#define SYNC_FILE_RANGE_WAIT_AFTER 4
+#endif
+
+namespace {
+
+constexpr char kTestData[] = "DragonOS sync_file_range dunitest data\n";
+
+long RawSyncFileRange(int fd, off_t offset, off_t nbytes, unsigned int flags) {
+    return syscall(__NR_sync_file_range, fd, offset, nbytes, flags);
+}
+
+class TempFile {
+  public:
+    TempFile() {
+        char tmpl[] = "/tmp/dunitest_sync_file_range_XXXXXX";
+        fd_ = mkstemp(tmpl);
+        if (fd_ >= 0) {
+            path_ = tmpl;
+        }
+    }
+
+    ~TempFile() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        if (!path_.empty()) {
+            unlink(path_.c_str());
+        }
+    }
+
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+
+    bool valid() const {
+        return fd_ >= 0;
+    }
+
+    int fd() const {
+        return fd_;
+    }
+
+    const char* path() const {
+        return path_.c_str();
+    }
+
+    bool write_test_data() const {
+        return write(fd_, kTestData, sizeof(kTestData) - 1) == static_cast<ssize_t>(sizeof(kTestData) - 1);
+    }
+
+  private:
+    std::string path_;
+    int fd_ = -1;
+};
+
+void ExpectSyncFileRangeErrno(int fd, off_t offset, off_t nbytes, unsigned int flags,
+                              int expected_errno) {
+    errno = 0;
+    EXPECT_EQ(-1, RawSyncFileRange(fd, offset, nbytes, flags));
+    EXPECT_EQ(expected_errno, errno) << "got errno=" << errno << " (" << strerror(errno) << ")";
+}
+
+}  // namespace
+
+TEST(SyncFileRange, RegularFileAcceptedFlagsAndPreservesOffset) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+    ASSERT_TRUE(file.write_test_data()) << "write failed: " << strerror(errno);
+
+    const unsigned int flags[] = {
+        0,
+        SYNC_FILE_RANGE_WRITE,
+        SYNC_FILE_RANGE_WAIT_BEFORE,
+        SYNC_FILE_RANGE_WAIT_AFTER,
+        SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE,
+        SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER,
+    };
+
+    for (unsigned int flag : flags) {
+        errno = 0;
+        EXPECT_EQ(0, RawSyncFileRange(file.fd(), 0, 0, flag)) << "flags=" << flag;
+        EXPECT_EQ(0, errno);
+    }
+
+    ASSERT_EQ(1, lseek(file.fd(), 1, SEEK_SET));
+
+    errno = 0;
+    EXPECT_EQ(0, RawSyncFileRange(file.fd(), 1, 8, SYNC_FILE_RANGE_WRITE));
+    EXPECT_EQ(0, errno);
+    EXPECT_EQ(1, lseek(file.fd(), 0, SEEK_CUR));
+}
+
+TEST(SyncFileRange, ReadonlyRegularFileCanStartWriteback) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+    ASSERT_TRUE(file.write_test_data()) << "write failed: " << strerror(errno);
+
+    int ro_fd = open(file.path(), O_RDONLY);
+    ASSERT_GE(ro_fd, 0) << "open readonly failed: " << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(0, RawSyncFileRange(ro_fd, 0, 0, SYNC_FILE_RANGE_WRITE));
+    EXPECT_EQ(0, errno);
+
+    close(ro_fd);
+}
+
+TEST(SyncFileRange, DirectoryFdIsAccepted) {
+    int dir_fd = open("/tmp", O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(dir_fd, 0) << "open directory failed: " << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(0, RawSyncFileRange(dir_fd, 0, 0, SYNC_FILE_RANGE_WRITE));
+    EXPECT_EQ(0, errno);
+
+    close(dir_fd);
+}
+
+TEST(SyncFileRange, LinuxCompatibleErrnos) {
+    ExpectSyncFileRangeErrno(-1, 0, 0, SYNC_FILE_RANGE_WRITE, EBADF);
+    ExpectSyncFileRangeErrno(-1, -1, 1, SYNC_FILE_RANGE_WRITE, EBADF);
+    ExpectSyncFileRangeErrno(-1, 0, 0, 0x8, EBADF);
+
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    ExpectSyncFileRangeErrno(file.fd(), 0, 0, 0x8, EINVAL);
+    ExpectSyncFileRangeErrno(file.fd(), -1, 1, SYNC_FILE_RANGE_WRITE, EINVAL);
+    ExpectSyncFileRangeErrno(file.fd(), 0, -1, SYNC_FILE_RANGE_WRITE, EINVAL);
+    ExpectSyncFileRangeErrno(file.fd(), static_cast<off_t>(1) << 62, static_cast<off_t>(1) << 62,
+                             SYNC_FILE_RANGE_WRITE, EINVAL);
+
+#ifdef O_PATH
+    int path_fd = open(file.path(), O_PATH);
+    ASSERT_GE(path_fd, 0) << "open O_PATH failed: " << strerror(errno);
+    ExpectSyncFileRangeErrno(path_fd, 0, 0, SYNC_FILE_RANGE_WRITE, EBADF);
+    ExpectSyncFileRangeErrno(path_fd, -1, 1, SYNC_FILE_RANGE_WRITE, EBADF);
+    ExpectSyncFileRangeErrno(path_fd, 0, 0, 0x8, EBADF);
+    close(path_fd);
+#endif
+
+    int pipefd[2];
+    ASSERT_EQ(0, pipe(pipefd)) << "pipe failed: " << strerror(errno);
+    ExpectSyncFileRangeErrno(pipefd[0], -1, 1, SYNC_FILE_RANGE_WRITE, EINVAL);
+    ExpectSyncFileRangeErrno(pipefd[0], 0, 0, 0x8, EINVAL);
+    ExpectSyncFileRangeErrno(pipefd[0], 0, 0, SYNC_FILE_RANGE_WRITE, ESPIPE);
+    close(pipefd[0]);
+    close(pipefd[1]);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -12,6 +12,7 @@ normal/test_fchown_o_path
 normal/proc_self_limits
 normal/mlock_semantics
 normal/sched_affinity
+normal/sync_file_range
 normal/rcu_selftest
 normal/test_tlb_shootdown
 normal/tcp_close_semantics


### PR DESCRIPTION
Close: https://github.com/DragonOS-Community/DragonOS/issues/1905

Add Linux-compatible SYS_SYNC_FILE_RANGE handling and connect it to page-cache range writeback.

The implementation validates fd and O_PATH state before flags and range checks to match Linux errno priority, supports WAIT_BEFORE, WRITE, and WAIT_AFTER semantics, skips existing writeback for async WRITE, and records writeback errors for later WAIT_* reporting.

Add dunitest coverage for accepted calls, errno ordering, O_PATH, pipe, directory, readonly fd, and file offset preservation.


## Summary

Implement Linux-compatible `sync_file_range(2)` support for DragonOS and register `SYS_SYNC_FILE_RANGE`, fixing `ENOSYS` reports seen by Linux userland such as `dpkg` and `apt`.

## Changes

- Add the `sync_file_range` syscall handler with Linux 6.6-compatible fd, `O_PATH`, flag, range, and file-type error ordering.
- Add page-cache range writeback and wait support for `SYNC_FILE_RANGE_WAIT_BEFORE`, `SYNC_FILE_RANGE_WRITE`, and `SYNC_FILE_RANGE_WAIT_AFTER`.
- Preserve async `SYNC_FILE_RANGE_WRITE` semantics by skipping pages already under writeback instead of waiting on them.
- Record page-cache writeback errors and expose a per-open-file error cursor so `WAIT_*` paths can report asynchronous writeback failures.
- Add dunitest coverage for valid calls, errno priority, `O_PATH`, pipe, directory, readonly fd, and file offset preservation.


