### PR TITLE
refactor(rseq): simplify rseq state management and migration handling

### DIFF
--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -690,9 +690,26 @@ unsafe fn do_signal(frame: &mut TrapFrame, got_signal: &mut bool) {
     if sigaction.is_none() {
         return;
     }
-    *got_signal = true;
 
     let mut sigaction = sigaction.unwrap();
+    match sigaction.action() {
+        SigactionType::SaHandler(SaHandlerType::Default) => {
+            *got_signal = true;
+            sig_number.handle_default();
+            return;
+        }
+        SigactionType::SaHandler(SaHandlerType::Customized(_)) => {}
+        SigactionType::SaHandler(SaHandlerType::Ignore) => return,
+        _ => {
+            error!(
+                "Unsupported signal action for signal: {}, pid={:?}",
+                sig_number as i32,
+                ProcessManager::current_pcb().raw_pid()
+            );
+            return;
+        }
+    }
+    *got_signal = true;
 
     // 注意！由于handle_signal里面可能会退出进程，
     // 因此这里需要检查清楚：上面所有的锁、arc指针都被释放了。否则会产生资源泄露的问题！
@@ -700,6 +717,11 @@ unsafe fn do_signal(frame: &mut TrapFrame, got_signal: &mut bool) {
         handle_signal(sig_number, &mut sigaction, &info.unwrap(), &oldset, frame);
     compiler_fence(Ordering::SeqCst);
     if let Err(e) = res {
+        let _ = if sig_number == Signal::SIGSEGV {
+            crate::ipc::signal::force_kernel_default_signal_to_current(Signal::SIGSEGV)
+        } else {
+            crate::ipc::signal::force_kernel_signal_to_current(Signal::SIGSEGV)
+        };
         if e != SystemError::EFAULT {
             error!(
                 "Error occurred when handling signal: {}, pid={:?}, errcode={:?}",
@@ -874,10 +896,6 @@ fn setup_frame(
 
     match sigaction.action() {
         SigactionType::SaHandler(handler_type) => match handler_type {
-            SaHandlerType::Default => {
-                sig.handle_default();
-                return Ok(0);
-            }
             SaHandlerType::Customized(handler) => {
                 // 如果handler地址大于等于用户空间末尾，说明它在内核空间，这是非法的。
                 if handler >= MMArch::USER_END_VADDR {
@@ -905,9 +923,6 @@ fn setup_frame(
                     }
                     handler_addr = handler.data();
                 }
-            }
-            SaHandlerType::Ignore => {
-                return Ok(0);
             }
             _ => {
                 return Err(SystemError::EINVAL);

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -11,8 +11,8 @@ use system_error::SystemError;
 use crate::{
     arch::ipc::signal::{SigSet, Signal},
     ipc::signal_types::{
-        SigCode, SigInfo, SigType, SigactionType, SignalFlags, SIG_KERNEL_IGNORE_MASK,
-        SIG_KERNEL_ONLY_MASK, SIG_KERNEL_STOP_MASK,
+        SaHandlerType, SigCode, SigInfo, SigType, SigactionType, SignalFlags,
+        SIG_KERNEL_IGNORE_MASK, SIG_KERNEL_ONLY_MASK, SIG_KERNEL_STOP_MASK,
     },
     libs::rwlock::RwLockWriteGuard,
     mm::VirtAddr,
@@ -46,6 +46,86 @@ pub fn send_kernel_signal_to_current(sig: Signal) -> Result<(), SystemError> {
 
     compiler_fence(Ordering::SeqCst);
     let ret = sig.send_signal_info(Some(&mut info), pid);
+    compiler_fence(Ordering::SeqCst);
+    ret.map(|_| ())
+}
+
+/// Force a kernel-originated signal to the current thread.
+///
+/// This mirrors Linux's force-signal behavior used by rseq error handling:
+/// a blocked or ignored fatal signal must be made deliverable instead of being
+/// left pending forever.
+pub fn force_kernel_signal_to_current(sig: Signal) -> Result<(), SystemError> {
+    let pcb = ProcessManager::current_pcb();
+
+    if let Some(mut action) = pcb.sighand().handler(sig) {
+        let blocked = pcb
+            .sig_info_irqsave()
+            .sig_blocked()
+            .contains(sig.into_sigset());
+        if blocked || action.is_ignore() {
+            action.set_action(SigactionType::SaHandler(SaHandlerType::Default));
+            pcb.sighand().set_handler(sig, action);
+        }
+
+        if action.is_default() {
+            pcb.sighand().flags_remove(SignalFlags::UNKILLABLE);
+        }
+    }
+
+    {
+        let mut siginfo = pcb.sig_info_mut();
+        siginfo.sig_block_mut().remove(sig.into_sigset());
+        siginfo.saved_sigmask_mut().remove(sig.into_sigset());
+    }
+    pcb.recalc_sigpending();
+
+    let mut info = SigInfo::new(
+        sig,
+        0,
+        SigCode::Kernel,
+        SigType::Kill {
+            pid: RawPid::new(0),
+            uid: 0,
+        },
+    );
+
+    compiler_fence(Ordering::SeqCst);
+    let ret = sig.send_signal_info_to_pcb(Some(&mut info), pcb, PidType::PID);
+    compiler_fence(Ordering::SeqCst);
+    ret.map(|_| ())
+}
+
+/// Force a kernel-originated signal to the current thread with its default
+/// disposition, even if userspace installed a handler.
+pub fn force_kernel_default_signal_to_current(sig: Signal) -> Result<(), SystemError> {
+    let pcb = ProcessManager::current_pcb();
+
+    if let Some(mut action) = pcb.sighand().handler(sig) {
+        action.set_action(SigactionType::SaHandler(SaHandlerType::Default));
+        pcb.sighand().set_handler(sig, action);
+    }
+    pcb.sighand().flags_remove(SignalFlags::UNKILLABLE);
+
+    {
+        let mut siginfo = pcb.sig_info_mut();
+        siginfo.sig_block_mut().remove(sig.into_sigset());
+        siginfo.saved_sigmask_mut().remove(sig.into_sigset());
+    }
+    pcb.recalc_sigpending();
+
+    let mut info = SigInfo::new(
+        sig,
+        0,
+        SigCode::Kernel,
+        SigType::Kill {
+            pid: RawPid::new(0),
+            uid: 0,
+        },
+    );
+
+    compiler_fence(Ordering::SeqCst);
+    let ret = sig.send_signal_info_to_pcb(Some(&mut info), pcb, PidType::PID);
     compiler_fence(Ordering::SeqCst);
     ret.map(|_| ())
 }

--- a/kernel/src/process/rseq.rs
+++ b/kernel/src/process/rseq.rs
@@ -537,7 +537,11 @@ impl Rseq {
         unsafe { access.reset() }.map_err(|_| SystemError::EFAULT)?;
 
         // 清除注册
-        pcb.rseq_state_mut().registration = None;
+        let mut rseq_state = pcb.rseq_state_mut();
+        rseq_state.registration = None;
+        rseq_state.event_mask.store(0, Ordering::SeqCst);
+        drop(rseq_state);
+        pcb.flags().remove(ProcessFlags::NEED_RSEQ);
 
         Ok(0)
     }
@@ -573,7 +577,7 @@ impl Rseq {
         if let Some(frame) = frame {
             if let Err(e) = Self::ip_fixup(frame, &access, sig, user_end, &pcb) {
                 log::debug!("rseq ip_fixup failed: {:?}", e);
-                Self::disable_current_rseq_after_fault(&pcb);
+                pcb.flags().remove(ProcessFlags::NEED_RSEQ);
                 let _ = crate::ipc::signal::send_kernel_signal_to_current(
                     crate::arch::ipc::signal::Signal::SIGSEGV,
                 );
@@ -585,7 +589,7 @@ impl Rseq {
         let cpu_id = smp_get_processor_id().data() as u32;
         if let Err(_e) = unsafe { access.update_cpu_node_id(cpu_id, 0, 0) } {
             // log::debug!("rseq update_cpu_node_id failed: {:?}", e);
-            Self::disable_current_rseq_after_fault(&pcb);
+            pcb.flags().remove(ProcessFlags::NEED_RSEQ);
             let _ = crate::ipc::signal::send_kernel_signal_to_current(
                 crate::arch::ipc::signal::Signal::SIGSEGV,
             );
@@ -594,14 +598,6 @@ impl Rseq {
 
         pcb.flags().remove(ProcessFlags::NEED_RSEQ);
         Ok(())
-    }
-
-    fn disable_current_rseq_after_fault(pcb: &ProcessControlBlock) {
-        let mut rseq_state = pcb.rseq_state_mut();
-        rseq_state.registration = None;
-        rseq_state.event_mask.store(0, Ordering::SeqCst);
-        drop(rseq_state);
-        pcb.flags().remove(ProcessFlags::NEED_RSEQ);
     }
 
     /// 执行 IP 修正
@@ -629,9 +625,8 @@ impl Rseq {
 
         // 在临界区内，检查是否需要重启
         let event_mask = pcb.rseq_state().fetch_clear_event_mask();
-        let cs_flags = RseqCsFlags::from_bits_truncate(rseq_cs.flags);
 
-        if !Self::need_restart(access, cs_flags, event_mask)? {
+        if !Self::need_restart(access, rseq_cs.flags, event_mask)? {
             return Ok(());
         }
 
@@ -645,41 +640,42 @@ impl Rseq {
     /// 判断是否需要重启
     fn need_restart(
         access: &UserRseqAccess,
-        cs_flags: RseqCsFlags,
+        cs_flags: u32,
         event_mask: RseqEventMask,
     ) -> Result<bool, RseqError> {
         // 检查用户态 flags
         let user_flags = unsafe { access.read_flags() }?;
-        let user_rseq_flags = RseqCsFlags::from_bits_truncate(user_flags);
 
-        Self::warn_flags("rseq", user_rseq_flags)?;
+        Self::warn_flags("rseq", user_flags)?;
         Self::warn_flags("rseq_cs", cs_flags)?;
 
         Ok(!event_mask.is_empty())
     }
 
     /// 检查并警告已弃用的 flags
-    fn warn_flags(name: &str, flags: RseqCsFlags) -> Result<(), RseqError> {
-        if flags.is_empty() {
+    fn warn_flags(name: &str, flags: u32) -> Result<(), RseqError> {
+        if flags == 0 {
             return Ok(());
         }
 
         let no_restart = RseqCsFlags::NO_RESTART_ON_PREEMPT
             | RseqCsFlags::NO_RESTART_ON_SIGNAL
             | RseqCsFlags::NO_RESTART_ON_MIGRATE;
+        let no_restart_bits = no_restart.bits();
 
-        if flags.intersects(no_restart) {
+        let deprecated = flags & no_restart_bits;
+        if deprecated != 0 {
             log::warn!(
-                "rseq: deprecated flags ({:?}) in {} ABI structure",
-                flags & no_restart,
+                "rseq: deprecated flags ({:#x}) in {} ABI structure",
+                deprecated,
                 name
             );
         }
 
-        let unknown = flags & !no_restart;
-        if !unknown.is_empty() {
+        let unknown = flags & !no_restart_bits;
+        if unknown != 0 {
             log::warn!(
-                "rseq: unknown flags ({:?}) in {} ABI structure",
+                "rseq: unknown flags ({:#x}) in {} ABI structure",
                 unknown,
                 name
             );
@@ -728,23 +724,39 @@ impl Rseq {
 pub fn rseq_fork(child: &ProcessControlBlock, clone_vm: bool) {
     if clone_vm {
         // 线程共享地址空间，子线程需要重新注册
-        child.rseq_state_mut().registration = None;
+        let mut child_state = child.rseq_state_mut();
+        child_state.registration = None;
+        child_state.event_mask.store(0, Ordering::SeqCst);
+        drop(child_state);
+        child.flags().remove(ProcessFlags::NEED_RSEQ);
     } else {
         // 进程 fork，继承父进程的 rseq 状态
         // 先获取父进程的注册信息副本，然后释放读锁
-        let parent_reg = {
+        let (parent_reg, parent_event_mask) = {
             let pcb = ProcessManager::current_pcb();
             let parent_state = pcb.rseq_state();
-            parent_state.registration().copied()
+            (
+                parent_state.registration().copied(),
+                parent_state.event_mask.load(Ordering::SeqCst),
+            )
         };
-        if let Some(reg) = parent_reg {
-            child.rseq_state_mut().registration = Some(reg);
+        let mut child_state = child.rseq_state_mut();
+        child_state.registration = parent_reg;
+        child_state
+            .event_mask
+            .store(parent_event_mask, Ordering::SeqCst);
+        drop(child_state);
+        if parent_reg.is_some() {
+            child.flags().insert(ProcessFlags::NEED_RSEQ);
         }
     }
 }
 
 /// exec 时清除 rseq 状态
 pub fn rseq_execve(pcb: &ProcessControlBlock) {
-    pcb.rseq_state_mut().registration = None;
-    pcb.rseq_state_mut().event_mask.store(0, Ordering::SeqCst);
+    let mut rseq_state = pcb.rseq_state_mut();
+    rseq_state.registration = None;
+    rseq_state.event_mask.store(0, Ordering::SeqCst);
+    drop(rseq_state);
+    pcb.flags().remove(ProcessFlags::NEED_RSEQ);
 }

--- a/kernel/src/process/rseq.rs
+++ b/kernel/src/process/rseq.rs
@@ -578,7 +578,7 @@ impl Rseq {
             if let Err(e) = Self::ip_fixup(frame, &access, sig, user_end, &pcb) {
                 log::debug!("rseq ip_fixup failed: {:?}", e);
                 pcb.flags().remove(ProcessFlags::NEED_RSEQ);
-                let _ = crate::ipc::signal::send_kernel_signal_to_current(
+                let _ = crate::ipc::signal::force_kernel_signal_to_current(
                     crate::arch::ipc::signal::Signal::SIGSEGV,
                 );
                 return Err(());
@@ -590,7 +590,7 @@ impl Rseq {
         if let Err(_e) = unsafe { access.update_cpu_node_id(cpu_id, 0, 0) } {
             // log::debug!("rseq update_cpu_node_id failed: {:?}", e);
             pcb.flags().remove(ProcessFlags::NEED_RSEQ);
-            let _ = crate::ipc::signal::send_kernel_signal_to_current(
+            let _ = crate::ipc::signal::force_kernel_signal_to_current(
                 crate::arch::ipc::signal::Signal::SIGSEGV,
             );
             return Err(());

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -514,26 +514,31 @@ impl CfsRunQueue {
 
     /// ## 在时间片到期时检查当前任务是否需要被抢占，
     /// 如果需要，则抢占当前任务，并确保不会由于与其他任务的“好友偏爱（buddy favours）”而重新选举为下一个运行的任务。
-    #[allow(dead_code)]
     pub fn check_preempt_tick(&mut self, curr: Arc<FairSchedEntity>) {
-        // 计算理想状态下该调度实体的理想运行时间
-        let ideal_runtime = self.sched_slice(curr.clone());
-
-        let delta_exec = curr.sum_exec_runtime - curr.prev_sum_exec_runtime;
-
-        if delta_exec > ideal_runtime {
-            // 表明实际运行时间长于理想运行时间
-            self.rq().resched_current();
-
-            self.clear_buddies(&curr);
-            return;
-        }
-
+        let delta_exec = curr
+            .sum_exec_runtime
+            .saturating_sub(curr.prev_sum_exec_runtime);
         if delta_exec < SYSCTL_SHCED_MIN_GRANULARITY.load(Ordering::SeqCst) {
             return;
         }
 
-        todo!()
+        if self.nr_running <= 1 {
+            // rseq critical sections need a bounded preempt notification even
+            // when the scheduler ultimately has no other CFS entity to select.
+            if curr.pcb().rseq_state().is_registered() {
+                self.rq().resched_current();
+            }
+            return;
+        }
+
+        let Some(next) = self.pick_eevdf_entity(Some(&curr)) else {
+            return;
+        };
+
+        if !Arc::ptr_eq(&next, &curr) {
+            self.rq().resched_current();
+            self.clear_buddies(&curr);
+        }
     }
 
     pub fn clear_buddies(&mut self, se: &Arc<FairSchedEntity>) {
@@ -558,6 +563,8 @@ impl CfsRunQueue {
             self.rq().resched_current();
             return;
         }
+
+        self.check_preempt_tick(curr);
     }
 
     /// 更新当前调度实体的运行时间统计信息

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1196,6 +1196,7 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
         IDLE_CPUS.clear(rq.cpu);
     }
 
+    let had_need_schedule = prev.flags().contains(ProcessFlags::NEED_SCHEDULE);
     prev.flags().remove(ProcessFlags::NEED_SCHEDULE);
     fence(Ordering::SeqCst);
     if likely(!Arc::ptr_eq(&prev, &next)) {
@@ -1220,6 +1221,11 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
             migrate_prev_to.is_none(),
             "current task migration must switch away from the migrated task"
         );
+        // A tick preempt request may pick the same task again. Preserve rseq's
+        // preempt notification semantics for that return-to-user boundary.
+        if sched_mod.contains(SchedMode::SM_MASK_PREEMPT) && had_need_schedule {
+            crate::process::rseq::Rseq::on_preempt(&prev);
+        }
         drop(guard);
         assert!(
             Arc::ptr_eq(&ProcessManager::current_pcb(), &prev),

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1125,6 +1125,10 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
 
     let mut migrate_prev_to = None;
     if let Some(dest_cpu) = take_current_migration_target(&prev) {
+        // 当前任务迁移在真正切出当前 CPU 时才标记 rseq migrate，
+        // 避免在迁移请求发起后、任务仍运行在旧 CPU 时过早处理 NEED_RSEQ。
+        crate::process::rseq::Rseq::on_migrate(&prev);
+
         debug_assert!(
             !task_is_idle(&prev),
             "idle task must not be migrated through current task migration"
@@ -1196,9 +1200,6 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     fence(Ordering::SeqCst);
     if likely(!Arc::ptr_eq(&prev, &next)) {
         crate::process::rseq::Rseq::on_preempt(&prev);
-        if next.rseq_state().is_registered() {
-            next.flags().insert(ProcessFlags::NEED_RSEQ);
-        }
 
         rq.set_current(Arc::downgrade(&next));
         compiler_fence(Ordering::SeqCst);
@@ -1320,6 +1321,12 @@ pub fn request_task_migration(
     dest_cpu: ProcessorId,
 ) -> Result<(), SystemError> {
     let Some(src_cpu) = pcb.sched_info().on_cpu() else {
+        // on_cpu == None can mean either first placement of a new task or
+        // migration of an existing off-rq task. Only the latter is an rseq
+        // migration event.
+        if !pcb.sched_info().is_new_task() {
+            crate::process::rseq::Rseq::on_migrate(pcb);
+        }
         rebind_task_cpu(pcb, dest_cpu);
         return Ok(());
     };
@@ -1353,6 +1360,7 @@ pub fn request_task_migration(
             pcb.clone(),
             DequeueFlag::DEQUEUE_MOVE | DequeueFlag::DEQUEUE_NOCLOCK,
         );
+        crate::process::rseq::Rseq::on_migrate(pcb);
         *pcb.sched_info().on_rq.lock_irqsave() = OnRq::None;
         pcb.sched_info().set_on_cpu(None);
         drop(_guard);
@@ -1361,6 +1369,7 @@ pub fn request_task_migration(
         return Ok(());
     }
 
+    crate::process::rseq::Rseq::on_migrate(pcb);
     rebind_task_cpu(pcb, dest_cpu);
     Ok(())
 }


### PR DESCRIPTION
- Remove disable_current_rseq_after_fault helper function
- Directly modify flags instead of using helper
- Improve rseq state handling during fork/exec
- Adjust rseq migration timing in scheduler