### PR TITLE
fix(uts): allow empty hostname and domainname

### DIFF
--- a/kernel/src/process/syscall/sys_setdomainname.rs
+++ b/kernel/src/process/syscall/sys_setdomainname.rs
@@ -39,8 +39,13 @@ impl Syscall for SysSetdomainname {
         }
 
         // 检查长度是否合法
-        if len == 0 || len >= NewUtsName::MAXLEN {
+        if len >= NewUtsName::MAXLEN {
             return Err(SystemError::EINVAL);
+        }
+
+        if len == 0 {
+            uts_ns.set_domainname(&[])?;
+            return Ok(0);
         }
 
         let reader = UserBufferReader::new_checked(name_ptr, len, true)?;

--- a/kernel/src/process/syscall/sys_sethostname.rs
+++ b/kernel/src/process/syscall/sys_sethostname.rs
@@ -39,8 +39,13 @@ impl Syscall for SysSethostname {
         }
 
         // 检查长度是否合法
-        if len == 0 || len >= NewUtsName::MAXLEN {
+        if len >= NewUtsName::MAXLEN {
             return Err(SystemError::EINVAL);
+        }
+
+        if len == 0 {
+            uts_ns.set_hostname(&[])?;
+            return Ok(0);
         }
 
         let reader = UserBufferReader::new_checked(name_ptr, len, true)?;

--- a/user/apps/c_unitest/test_setdomainname.c
+++ b/user/apps/c_unitest/test_setdomainname.c
@@ -5,15 +5,16 @@
 #include <sys/utsname.h>
 #include <errno.h>
 
-// Since setdomainname might not be in libc, we define it manually
-#ifdef __x86_64__
+// Since setdomainname might not be in libc, define the syscall number when
+// libc headers do not provide it.
+#ifndef __NR_setdomainname
+#if defined(__x86_64__)
 #define __NR_setdomainname 171
-#elif defined(__riscv)
-#define __NR_setdomainname 171
-#elif defined(__aarch64__)
-#define __NR_setdomainname 171
+#elif defined(__riscv) || defined(__loongarch64)
+#define __NR_setdomainname 162
 #else
 #define __NR_setdomainname 171
+#endif
 #endif
 
 static inline int sys_setdomainname(const char *name, size_t len)
@@ -26,6 +27,7 @@ int main() {
     char test_domain1[] = "test.domain.com";
     char test_domain2[] = "dragonos.test";
     char long_domain[256];
+    int failed = 0;
     
     printf("=== Testing setdomainname syscall ===\n\n");
     
@@ -93,10 +95,17 @@ int main() {
     
     // Test 4: Test with zero length
     printf("Test 4: Test with zero length\n");
-    if (sys_setdomainname("test", 0) == -1 && errno == EINVAL) {
-        printf("✓ Correctly returned EINVAL for zero length\n");
+    if (sys_setdomainname("test", 0) == 0) {
+        printf("✓ setdomainname accepted zero length\n");
+        if (uname(&uts) == 0 && strcmp(uts.__domainname, "") == 0) {
+            printf("✓ Domainname is empty\n");
+        } else {
+            printf("✗ Domainname should be empty after zero length set\n");
+            failed = 1;
+        }
     } else {
-        printf("✗ Should have failed with EINVAL for zero length\n");
+        perror("✗ setdomainname should accept zero length");
+        failed = 1;
     }
     printf("\n");
     
@@ -128,6 +137,6 @@ int main() {
         perror("✗ Failed to restore domainname");
     }
     
-    printf("\n=== Test completed ===\n");
-    return 0;
+    printf("\n=== Test %s ===\n", failed ? "failed" : "completed");
+    return failed ? 1 : 0;
 }

--- a/user/apps/c_unitest/test_sethostname.c
+++ b/user/apps/c_unitest/test_sethostname.c
@@ -1,0 +1,116 @@
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#ifndef __NR_sethostname
+#if defined(__x86_64__)
+#define __NR_sethostname 170
+#elif defined(__riscv) || defined(__loongarch64)
+#define __NR_sethostname 161
+#else
+#define __NR_sethostname 170
+#endif
+#endif
+
+static inline int sys_sethostname(const char *name, size_t len)
+{
+    return syscall(__NR_sethostname, name, len);
+}
+
+static int expect_nodename(const char *expected)
+{
+    struct utsname uts;
+
+    if (uname(&uts) != 0) {
+        perror("uname failed");
+        return 1;
+    }
+
+    if (strcmp(uts.nodename, expected) != 0) {
+        printf("nodename mismatch: got '%s', expected '%s'\n", uts.nodename, expected);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    struct utsname uts;
+    char original[sizeof(uts.nodename)];
+    char long_name[65];
+    int failed = 0;
+
+    printf("=== Testing sethostname syscall ===\n\n");
+
+    if (uname(&uts) != 0) {
+        perror("uname failed");
+        return 1;
+    }
+    strncpy(original, uts.nodename, sizeof(original));
+    original[sizeof(original) - 1] = '\0';
+    printf("Initial hostname: '%s'\n\n", original);
+
+    printf("Test 1: Set normal hostname\n");
+    if (sys_sethostname("dragon-test", strlen("dragon-test")) == 0) {
+        printf("sethostname succeeded\n");
+        failed |= expect_nodename("dragon-test");
+    } else {
+        perror("sethostname failed");
+        failed = 1;
+    }
+    printf("\n");
+
+    printf("Test 2: Set empty hostname with len=0\n");
+    if (sys_sethostname("", 0) == 0) {
+        printf("sethostname accepted zero length\n");
+        failed |= expect_nodename("");
+    } else {
+        perror("sethostname should accept zero length");
+        failed = 1;
+    }
+    printf("\n");
+
+    printf("Test 3: NULL pointer with len=0 should not fault\n");
+    if (sys_sethostname(NULL, 0) == 0) {
+        printf("sethostname accepted NULL with zero length\n");
+        failed |= expect_nodename("");
+    } else {
+        perror("sethostname should accept NULL with zero length");
+        failed = 1;
+    }
+    printf("\n");
+
+    printf("Test 4: NULL pointer with non-zero length should fail with EFAULT\n");
+    errno = 0;
+    if (sys_sethostname(NULL, 1) == -1 && errno == EFAULT) {
+        printf("sethostname correctly returned EFAULT\n");
+    } else {
+        printf("sethostname returned unexpected result, errno=%d\n", errno);
+        failed = 1;
+    }
+    printf("\n");
+
+    printf("Test 5: Too long hostname should fail with EINVAL\n");
+    memset(long_name, 'a', sizeof(long_name));
+    errno = 0;
+    if (sys_sethostname(long_name, sizeof(long_name)) == -1 && errno == EINVAL) {
+        printf("sethostname correctly returned EINVAL\n");
+    } else {
+        printf("sethostname returned unexpected result, errno=%d\n", errno);
+        failed = 1;
+    }
+    printf("\n");
+
+    printf("Cleanup: Restoring original hostname\n");
+    if (sys_sethostname(original, strlen(original)) != 0) {
+        perror("failed to restore hostname");
+        failed = 1;
+    }
+
+    printf("\n=== Test %s ===\n", failed ? "failed" : "passed");
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Fixes #1753.

DragonOS rejected `sethostname(..., 0)` and `setdomainname(..., 0)` with `EINVAL`. Linux 6.6 only rejects negative lengths and lengths larger than `__NEW_UTS_LEN` (64); a zero-length copy is valid and clears the corresponding UTS field.

This PR:
- allows `len == 0` for both syscalls;
- handles the zero-length path without reading or validating the user pointer, matching Linux `copy_from_user(..., len=0)` behavior;
- adds `test_sethostname` coverage for empty names, `NULL + len=0`, bad non-empty pointers, and overlong names;
- updates `test_setdomainname` zero-length expectation to success and verifies that the domainname becomes empty.

## Validation

- `make -C user/apps/c_unitest test_sethostname test_setdomainname`
- `make kernel`
- `make fmt` (completed successfully; existing user app subdirectories without a `fmt` target still print `No rule to make target 'fmt'` messages)
- `make run-nographic`, then inside DragonOS guest:
  - `/usr/bin/test_sethostname; echo HOST_RC=$?` -> `HOST_RC=0`
  - `/usr/bin/test_setdomainname; echo DOMAIN_RC=$?` -> `DOMAIN_RC=0`