### PR TITLE
fix(net): preserve UDP IPv6 source family

### DIFF
--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -278,7 +278,7 @@ fn get_ephemeral_iface(
     let loopback_dst = is_loopback_destination(remote_ip_addr);
 
     if let Some(iface) = get_iface_to_bind(remote_ip_addr, netns.clone()) {
-        if !loopback_dst || iface.flags().contains(InterfaceFlags::LOOPBACK) {
+        if iface_allowed_for_remote(&iface, loopback_dst) {
             if let Some(local_addr) = pick_configured_source_addr(&iface, remote_ip_addr) {
                 return Ok((iface, local_addr));
             }
@@ -286,7 +286,7 @@ fn get_ephemeral_iface(
     }
 
     if let Some(iface) = default_iface {
-        if !loopback_dst || iface.flags().contains(InterfaceFlags::LOOPBACK) {
+        if iface_allowed_for_remote(&iface, loopback_dst) {
             if let Some(local_addr) = pick_configured_source_addr(&iface, remote_ip_addr) {
                 return Ok((iface, local_addr));
             }
@@ -294,7 +294,7 @@ fn get_ephemeral_iface(
     }
 
     for (_, iface) in netns.device_list().iter() {
-        if loopback_dst && !iface.flags().contains(InterfaceFlags::LOOPBACK) {
+        if !iface_allowed_for_remote(iface, loopback_dst) {
             continue;
         }
 
@@ -310,10 +310,14 @@ fn get_ephemeral_iface(
     Err(no_source_error)
 }
 
+fn iface_allowed_for_remote(iface: &Arc<dyn Iface>, loopback_dst: bool) -> bool {
+    iface.flags().contains(InterfaceFlags::LOOPBACK) == loopback_dst
+}
+
 fn no_source_addr_error(remote_ip_addr: &smoltcp::wire::IpAddress) -> SystemError {
     match remote_ip_addr {
         smoltcp::wire::IpAddress::Ipv4(_) => SystemError::ENETUNREACH,
-        smoltcp::wire::IpAddress::Ipv6(_) => SystemError::EADDRNOTAVAIL,
+        smoltcp::wire::IpAddress::Ipv6(_) => SystemError::ENETUNREACH,
     }
 }
 

--- a/kernel/src/net/socket/inet/datagram/inner.rs
+++ b/kernel/src/net/socket/inet/datagram/inner.rs
@@ -622,10 +622,17 @@ impl BoundUdp {
             return Err(SystemError::EINVAL);
         }
 
-        // Linux treats sending to 0.0.0.0 (INADDR_ANY) as sending to localhost
-        // smoltcp rejects it as "Unaddressable", so we translate it here
+        // Linux treats an unspecified UDP destination as loopback for the same
+        // address family. Keep the destination family unchanged before passing
+        // it to smoltcp; mixing an IPv6 local endpoint with 127.0.0.1 would
+        // violate smoltcp's IP version invariant and panic.
         if remote.addr.is_unspecified() {
-            remote.addr = smoltcp::wire::IpAddress::v4(127, 0, 0, 1);
+            remote.addr = match remote.addr {
+                smoltcp::wire::IpAddress::Ipv4(_) => smoltcp::wire::IpAddress::v4(127, 0, 0, 1),
+                smoltcp::wire::IpAddress::Ipv6(_) => {
+                    smoltcp::wire::IpAddress::v6(0, 0, 0, 0, 0, 0, 0, 1)
+                }
+            };
         }
 
         // log::debug!(

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -1382,6 +1382,7 @@ impl Socket for UdpSocket {
                     return Ok(());
                 }
 
+                let remote = Self::normalize_unspecified_dest(remote);
                 if !self.is_bound() {
                     self.bind_ephemeral(remote.addr)?;
                 }

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -229,6 +229,19 @@ impl UdpSocket {
         }
     }
 
+    #[inline]
+    fn normalize_unspecified_dest(dest: IpEndpoint) -> IpEndpoint {
+        if !dest.addr.is_unspecified() {
+            return dest;
+        }
+
+        let addr = match dest.addr {
+            Ipv4(_) => smoltcp::wire::IpAddress::v4(127, 0, 0, 1),
+            Ipv6(_) => smoltcp::wire::IpAddress::v6(0, 0, 0, 0, 0, 0, 0, 1),
+        };
+        IpEndpoint::new(addr, dest.port)
+    }
+
     pub fn is_nonblock(&self) -> bool {
         self.nonblock.load(core::sync::atomic::Ordering::Relaxed)
     }
@@ -831,7 +844,8 @@ impl UdpSocket {
 
             // If unbound, bind to ephemeral port
             if let UdpInner::Unbound(_) = inner {
-                let to_addr = to.ok_or(SystemError::EDESTADDRREQ)?.addr;
+                let to_addr =
+                    Self::normalize_unspecified_dest(to.ok_or(SystemError::EDESTADDRREQ)?).addr;
                 let unbound = match inner_guard.take().unwrap() {
                     UdpInner::Unbound(unbound) => unbound,
                     _ => unreachable!(),
@@ -878,6 +892,7 @@ impl UdpSocket {
                     let dest = to
                         .or_else(|| bound.remote_endpoint().ok())
                         .ok_or(SystemError::EDESTADDRREQ)?;
+                    let dest = Self::normalize_unspecified_dest(dest);
                     self.validate_bound_send_dest(bound, dest)?;
                     let bound_iface = bound.inner().iface().clone();
                     let is_multicast = dest.addr.is_multicast();
@@ -958,7 +973,7 @@ impl UdpSocket {
                             }
                         }
 
-                        let ret = bound.try_send(buf, to);
+                        let ret = bound.try_send(buf, Some(dest));
                         (
                             ret,
                             send_iface,

--- a/user/apps/tests/dunitest/suites/normal/udp_ipv6_send_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/udp_ipv6_send_semantics.cc
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+
+namespace {
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+
+    ~FdGuard() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    int Get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+std::string ErrnoString(int err) {
+    return std::to_string(err) + " (" + std::strerror(err) + ")";
+}
+
+sockaddr_in6 MakeIpv6Addr(const char* addr, uint16_t port) {
+    sockaddr_in6 sa {};
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = htons(port);
+    EXPECT_EQ(inet_pton(AF_INET6, addr, &sa.sin6_addr), 1);
+    return sa;
+}
+
+}  // namespace
+
+TEST(UdpIpv6SendSemantics, UnreachableNativeIpv6DoesNotPanic) {
+    FdGuard fd(socket(AF_INET6, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET6, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    sockaddr_in6 dst = MakeIpv6Addr("2001:db8::1", 12345);
+    errno = 0;
+    ssize_t ret = sendto(fd.Get(), "test", 4, 0, reinterpret_cast<sockaddr*>(&dst), sizeof(dst));
+
+    EXPECT_EQ(ret, -1);
+    EXPECT_EQ(errno, ENETUNREACH) << "unexpected errno: " << ErrnoString(errno);
+}
+
+TEST(UdpIpv6SendSemantics, UnspecifiedIpv6DestinationUsesIpv6Loopback) {
+    FdGuard fd(socket(AF_INET6, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET6, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    sockaddr_in6 dst = MakeIpv6Addr("::", 12345);
+    errno = 0;
+    ssize_t ret = sendto(fd.Get(), "test", 4, 0, reinterpret_cast<sockaddr*>(&dst), sizeof(dst));
+
+    EXPECT_EQ(ret, 4) << "sendto(::) failed: " << ErrnoString(errno);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/udp_ipv6_send_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/udp_ipv6_send_semantics.cc
@@ -66,6 +66,24 @@ TEST(UdpIpv6SendSemantics, UnspecifiedIpv6DestinationUsesIpv6Loopback) {
     EXPECT_EQ(ret, 4) << "sendto(::) failed: " << ErrnoString(errno);
 }
 
+TEST(UdpIpv6SendSemantics, ConnectToUnspecifiedIpv6UsesIpv6Loopback) {
+    FdGuard fd(socket(AF_INET6, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET6, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    sockaddr_in6 dst = MakeIpv6Addr("::", 12345);
+    errno = 0;
+    int ret = connect(fd.Get(), reinterpret_cast<sockaddr*>(&dst), sizeof(dst));
+
+    EXPECT_EQ(ret, 0) << "connect(::) failed: " << ErrnoString(errno);
+
+    sockaddr_in6 peer {};
+    socklen_t peer_len = sizeof(peer);
+    ASSERT_EQ(getpeername(fd.Get(), reinterpret_cast<sockaddr*>(&peer), &peer_len), 0)
+        << "getpeername failed: " << ErrnoString(errno);
+    EXPECT_TRUE(IN6_IS_ADDR_LOOPBACK(&peer.sin6_addr));
+    EXPECT_EQ(ntohs(peer.sin6_port), 12345);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -19,6 +19,7 @@ normal/rcu_selftest
 normal/test_tlb_shootdown
 normal/pid_namespace_fork
 normal/tcp_close_semantics
+normal/udp_ipv6_send_semantics
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link


### PR DESCRIPTION
## Summary

Fixes #1733.

This fixes UDP implicit bind/source selection so non-loopback destinations cannot fall back to the loopback interface, and keeps unspecified UDP destinations in the same IP family before passing them to smoltcp. In particular:

- `AF_INET6` UDP send to a native non-loopback IPv6 destination without an IPv6 route/source now returns `ENETUNREACH` instead of succeeding via `lo` or reaching smoltcp with mismatched source/destination IP families.
- `AF_INET6` UDP send to `::` is normalized to `::1`, matching Linux's UDP IPv6 behavior and avoiding IPv4/IPv6 address mixing.
- `AF_INET6` UDP `connect(::)` is normalized before implicit bind, so connected UDP sockets also use the IPv6 loopback destination instead of rejecting `lo` as unreachable.
- Added a dunitest regression covering `sendto(2001:db8::1)`, `sendto(::)`, and `connect(::)` for IPv6 UDP sockets.

## Validation

- Host Linux reference check: `connect(AF_INET6, ::)` succeeds and reports peer `::1:12345`.
- Linux 6.6.139 reference: `net/ipv6/udp.c` normalizes an any IPv6 destination with `fl6->daddr.s6_addr[15] = 0x1`.
- Pre-fix DragonOS guest reproduction with the new regression: `./udp_ipv6_send_semantics_test` failed `ConnectToUnspecifiedIpv6UsesIpv6Loopback` with `connect(::) failed: 101 (Network is unreachable)`.
- `make fmt`
- `make -C user/apps/tests/dunitest build-suites`
- `git diff --check`
- `make run-nographic` rebuilt kernel/user programs and wrote the disk image successfully.
- Post-fix DragonOS guest validation:
  - `cd /opt/tests/dunitest/bin/normal`
  - `./udp_ipv6_send_semantics_test` -> 3 passed