### PR TITLE
fix(process): account wait rusage

### DIFF
--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -12,8 +12,9 @@ use crate::{
 };
 
 use super::{
-    abi::WaitOption, resource::RUsage, ProcessControlBlock, ProcessFlags, ProcessManager,
-    ProcessState, RawPid,
+    abi::WaitOption,
+    resource::{RUsage, RUsageWho},
+    ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState, RawPid,
 };
 
 /// 将内核中保存的 wstatus（已经按 wait4 语义左移过的编码值）
@@ -74,6 +75,20 @@ fn child_matches_wait_options(child_pcb: &Arc<ProcessControlBlock>, options: Wai
 
     // 子进程类型必须与等待选项匹配
     is_clone_child == wants_clone
+}
+
+fn fill_wait_rusage(child_pcb: &Arc<ProcessControlBlock>, kwo: &mut KernelWaitOption) -> RUsage {
+    let usage = child_pcb
+        .get_rusage(RUsageWho::RUsageBoth)
+        .unwrap_or_default();
+    if let Some(ret_rusage) = kwo.ret_rusage.as_deref_mut() {
+        *ret_rusage = usage;
+    }
+    usage
+}
+
+fn account_reaped_child_rusage(child_rusage: &RUsage) {
+    ProcessManager::current_pcb().add_child_rusage(child_rusage);
 }
 
 /// 内核wait4时的参数
@@ -271,7 +286,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
     // todo: 在signal struct里面增加等待队列，并在这里初始化子进程退出的回调，使得子进程退出时，能唤醒当前进程。
 
     kwo.no_task_error = Some(SystemError::ECHILD);
-    let retval = match &kwo.pid_converter {
+    let retval = match kwo.pid_converter.clone() {
         PidConverter::Pid(pid) => {
             if pid.pid_vnr().data() == ProcessManager::current_pcb().raw_tgid().data() {
                 return Err(SystemError::ECHILD);
@@ -383,6 +398,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 cause: SigChildCode::Stopped.into(),
                             });
                             kwo.ret_status = (stopsig << 8) | 0x7f;
+                            fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                             }
@@ -399,6 +415,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 cause: SigChildCode::Continued.into(),
                             });
                             kwo.ret_status = 0xffff;
+                            fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                             }
@@ -424,11 +441,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 cause: SigChildCode::Exited.into(),
                             });
                             tmp_child_pcb = Some(pcb.clone());
+                            let child_rusage = fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 if !pcb.try_mark_dead_from_zombie() {
                                     drop(sched_guard);
                                     continue;
                                 }
+                                account_reaped_child_rusage(&child_rusage);
                                 pid_to_release = Some(pcb.raw_pid());
                             }
                             scan_result = Some(Ok((*pid).into()));
@@ -499,6 +518,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     cause: SigChildCode::Stopped.into(),
                                 });
                                 kwo.ret_status = (stopsig << 8) | 0x7f;
+                                fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                                 }
@@ -515,6 +535,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     cause: SigChildCode::Continued.into(),
                                 });
                                 kwo.ret_status = 0xffff;
+                                fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                                 }
@@ -540,11 +561,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     cause: SigChildCode::Exited.into(),
                                 });
                                 tmp_child_pcb = Some(pcb.clone());
+                                let child_rusage = fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     if !pcb.try_mark_dead_from_zombie() {
                                         drop(sched_guard);
                                         continue;
                                     }
+                                    account_reaped_child_rusage(&child_rusage);
                                     pid_to_release = Some(pcb.raw_pid());
                                 }
                                 scan_result = Some(Ok((*pid).into()));
@@ -621,7 +644,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
 
                         let child_pgrp = pcb.task_pgrp();
                         let in_target_pgrp = match &child_pgrp {
-                            Some(cp) => Arc::ptr_eq(cp, pgid),
+                            Some(cp) => Arc::ptr_eq(cp, &pgid),
                             None => false,
                         };
                         if !in_target_pgrp {
@@ -651,6 +674,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 cause: SigChildCode::Stopped.into(),
                             });
                             kwo.ret_status = (stopsig << 8) | 0x7f;
+                            fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                             }
@@ -667,6 +691,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 cause: SigChildCode::Continued.into(),
                             });
                             kwo.ret_status = 0xffff;
+                            fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                             }
@@ -692,11 +717,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 cause: SigChildCode::Exited.into(),
                             });
                             tmp_child_pcb = Some(pcb.clone());
+                            let child_rusage = fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 if !pcb.try_mark_dead_from_zombie() {
                                     drop(sched_guard);
                                     continue;
                                 }
+                                account_reaped_child_rusage(&child_rusage);
                                 pid_to_release = Some(pcb.raw_pid());
                             }
                             drop(sched_guard);
@@ -748,7 +775,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
 
                             let child_pgrp = pcb.task_pgrp();
                             let in_target_pgrp = match &child_pgrp {
-                                Some(cp) => Arc::ptr_eq(cp, pgid),
+                                Some(cp) => Arc::ptr_eq(cp, &pgid),
                                 None => false,
                             };
                             if !in_target_pgrp {
@@ -779,6 +806,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     cause: SigChildCode::Stopped.into(),
                                 });
                                 kwo.ret_status = (stopsig << 8) | 0x7f;
+                                fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                                 }
@@ -795,6 +823,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     cause: SigChildCode::Continued.into(),
                                 });
                                 kwo.ret_status = 0xffff;
+                                fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                                 }
@@ -820,11 +849,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     cause: SigChildCode::Exited.into(),
                                 });
                                 tmp_child_pcb = Some(pcb.clone());
+                                let child_rusage = fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     if !pcb.try_mark_dead_from_zombie() {
                                         drop(sched_guard);
                                         continue;
                                     }
+                                    account_reaped_child_rusage(&child_rusage);
                                     pid_to_release = Some(pcb.raw_pid());
                                 }
                                 scan_result = Some(Ok(pcb.task_pid_vnr().into()));
@@ -915,6 +946,7 @@ fn do_waitpid(
         // 设置 ret_status 供 wait4 使用
         // Linux wait(2) 语义：continued 进程的 wstatus = 0xffff
         kwo.ret_status = 0xffff;
+        fill_wait_rusage(&child_pcb, kwo);
 
         if !kwo.options.contains(WaitOption::WNOWAIT) {
             child_pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
@@ -958,6 +990,7 @@ fn do_waitpid(
             // 设置 ret_status 供 wait4 使用
             // Linux wait(2) 语义：stopped 进程的 wstatus = (stopsig << 8) | 0x7f
             kwo.ret_status = (stopsig << 8) | 0x7f;
+            fill_wait_rusage(&child_pcb, kwo);
 
             if !kwo.options.contains(WaitOption::WNOWAIT) {
                 // 消费一次停止事件标志（若存在）
@@ -988,6 +1021,7 @@ fn do_waitpid(
             });
 
             kwo.ret_status = status as i32;
+            let child_rusage = fill_wait_rusage(&child_pcb, kwo);
 
             // 若指定 WNOWAIT，则只观测不回收
             if !kwo.options.contains(WaitOption::WNOWAIT) {
@@ -995,6 +1029,7 @@ fn do_waitpid(
                     drop(child_pcb);
                     return Some(Err(SystemError::ECHILD));
                 }
+                account_reaped_child_rusage(&child_rusage);
                 unsafe { ProcessManager::release(child_pcb.raw_pid()) };
                 drop(child_pcb);
             } else {

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -1092,11 +1092,16 @@ impl ProcessControlBlock {
             }
         }
 
-        // 从线程组中移除
+        // 从线程组中移除。非组长线程离开 group_tasks 后，线程组 rusage 仍需保留其 CPU 时间。
         let thread_group_leader = self.threads_read_irqsave().group_leader();
         if let Some(leader) = thread_group_leader {
-            leader
-                .threads_write_irqsave()
+            let mut leader_threads = leader.threads_write_irqsave();
+            if !group_dead {
+                if let Some(rusage) = self.get_rusage(RUsageWho::RusageThread) {
+                    leader.add_exited_thread_group_rusage(&rusage);
+                }
+            }
+            leader_threads
                 .group_tasks
                 .retain(|pcb| !Weak::ptr_eq(pcb, &self.self_ref));
         }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -59,7 +59,7 @@ use crate::{
         ucontext::AddressSpace,
         PhysAddr, VirtAddr,
     },
-    process::resource::{RLimit64, RLimitID},
+    process::resource::{RLimit64, RLimitID, RUsage},
     rcu::RcuArcSlot,
     sched::{
         DequeueFlag, EnqueueFlag, OnRq, SchedMode, WakeupFlags, __schedule_with_current,
@@ -1350,6 +1350,8 @@ pub struct ProcessControlBlock {
 
     /// CPU时间片
     cpu_time: Arc<ProcessCpuTime>,
+    /// 已被 wait 系列成功回收的子进程资源累计，对齐 getrusage(RUSAGE_CHILDREN)。
+    children_rusage: SpinLock<RUsage>,
 
     /// 进程的robust lock列表
     robust_list: RwLock<Option<RobustListHead>>,
@@ -1501,6 +1503,7 @@ impl ProcessControlBlock {
                 itimers: SpinLock::new(ProcessItimers::default()),
                 posix_timers: SpinLock::new(posix_timer::ProcessPosixTimers::default()),
                 cpu_time: Arc::new(ProcessCpuTime::default()),
+                children_rusage: SpinLock::new(RUsage::default()),
                 robust_list: RwLock::new(None),
                 rseq_state: RwLock::new(rseq::RseqState::new()),
                 cred: RcuArcSlot::new(cred),

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1350,6 +1350,8 @@ pub struct ProcessControlBlock {
 
     /// CPU时间片
     cpu_time: Arc<ProcessCpuTime>,
+    /// 已退出线程的线程组级资源累计。对齐 Linux signal_struct 的已退出线程统计。
+    exited_thread_group_rusage: SpinLock<RUsage>,
     /// 已被 wait 系列成功回收的子进程资源累计，对齐 getrusage(RUSAGE_CHILDREN)。
     children_rusage: SpinLock<RUsage>,
 
@@ -1503,6 +1505,7 @@ impl ProcessControlBlock {
                 itimers: SpinLock::new(ProcessItimers::default()),
                 posix_timers: SpinLock::new(posix_timer::ProcessPosixTimers::default()),
                 cpu_time: Arc::new(ProcessCpuTime::default()),
+                exited_thread_group_rusage: SpinLock::new(RUsage::default()),
                 children_rusage: SpinLock::new(RUsage::default()),
                 robust_list: RwLock::new(None),
                 rseq_state: RwLock::new(rseq::RseqState::new()),

--- a/kernel/src/process/resource.rs
+++ b/kernel/src/process/resource.rs
@@ -1,17 +1,20 @@
 use num_traits::FromPrimitive;
 use system_error::SystemError;
 
-use crate::time::PosixTimeSpec;
+use alloc::sync::Arc;
+use core::sync::atomic::Ordering;
 
-use super::ProcessControlBlock;
+use crate::time::syscall::PosixTimeval;
+
+use super::{ProcessControlBlock, ProcessManager};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(C)]
 pub struct RUsage {
     /// User time used
-    pub ru_utime: PosixTimeSpec,
+    pub ru_utime: PosixTimeval,
     /// System time used
-    pub ru_stime: PosixTimeSpec,
+    pub ru_stime: PosixTimeval,
 
     // 以下是linux的rusage结构体扩展
     /// Maximum resident set size
@@ -42,6 +45,32 @@ pub struct RUsage {
     pub ru_nvcsw: usize,
     /// Involuntary context switches
     pub ru_nivcsw: usize,
+}
+
+impl RUsage {
+    #[inline]
+    fn add_time(lhs: &mut PosixTimeval, rhs: PosixTimeval) {
+        *lhs = PosixTimeval::from_ns(lhs.to_ns().saturating_add(rhs.to_ns()));
+    }
+
+    pub fn add_assign_saturating(&mut self, rhs: &RUsage) {
+        Self::add_time(&mut self.ru_utime, rhs.ru_utime);
+        Self::add_time(&mut self.ru_stime, rhs.ru_stime);
+        self.ru_maxrss = self.ru_maxrss.max(rhs.ru_maxrss);
+        self.ru_ixrss = self.ru_ixrss.saturating_add(rhs.ru_ixrss);
+        self.ru_idrss = self.ru_idrss.saturating_add(rhs.ru_idrss);
+        self.ru_isrss = self.ru_isrss.saturating_add(rhs.ru_isrss);
+        self.ru_minflt = self.ru_minflt.saturating_add(rhs.ru_minflt);
+        self.ru_majflt = self.ru_majflt.saturating_add(rhs.ru_majflt);
+        self.ru_nswap = self.ru_nswap.saturating_add(rhs.ru_nswap);
+        self.ru_inblock = self.ru_inblock.saturating_add(rhs.ru_inblock);
+        self.ru_oublock = self.ru_oublock.saturating_add(rhs.ru_oublock);
+        self.ru_msgsnd = self.ru_msgsnd.saturating_add(rhs.ru_msgsnd);
+        self.ru_msgrcv = self.ru_msgrcv.saturating_add(rhs.ru_msgrcv);
+        self.ru_nsignals = self.ru_nsignals.saturating_add(rhs.ru_nsignals);
+        self.ru_nvcsw = self.ru_nvcsw.saturating_add(rhs.ru_nvcsw);
+        self.ru_nivcsw = self.ru_nivcsw.saturating_add(rhs.ru_nivcsw);
+    }
 }
 
 ///
@@ -138,14 +167,63 @@ impl TryFrom<usize> for RLimitID {
 }
 
 impl ProcessControlBlock {
-    /// 获取进程资源使用情况
-    ///
-    /// ## TODO
-    ///
-    /// 当前函数尚未实现，只是返回了一个默认的RUsage结构体
-    pub fn get_rusage(&self, _who: RUsageWho) -> Option<RUsage> {
-        let rusage = RUsage::default();
+    fn leader_for_rusage(&self) -> Arc<ProcessControlBlock> {
+        if self.is_thread_group_leader() {
+            return self
+                .self_ref
+                .upgrade()
+                .unwrap_or_else(ProcessManager::current_pcb);
+        }
 
-        Some(rusage)
+        self.threads_read_irqsave()
+            .group_leader()
+            .or_else(|| self.self_ref.upgrade())
+            .unwrap_or_else(ProcessManager::current_pcb)
+    }
+
+    fn task_rusage(&self) -> RUsage {
+        let ct = self.cputime();
+        RUsage {
+            ru_utime: PosixTimeval::from_ns(ct.utime.load(Ordering::Relaxed)),
+            ru_stime: PosixTimeval::from_ns(ct.stime.load(Ordering::Relaxed)),
+            ..RUsage::default()
+        }
+    }
+
+    fn thread_group_rusage(&self) -> RUsage {
+        let leader = self.leader_for_rusage();
+        let mut usage = leader.task_rusage();
+        let ti = leader.threads_read_irqsave();
+        for task in &ti.group_tasks {
+            if let Some(task) = task.upgrade() {
+                usage.add_assign_saturating(&task.task_rusage());
+            }
+        }
+        usage
+    }
+
+    pub fn add_child_rusage(&self, rusage: &RUsage) {
+        let leader = self.leader_for_rusage();
+        leader.children_rusage.lock().add_assign_saturating(rusage);
+    }
+
+    /// 获取进程资源使用情况
+    pub fn get_rusage(&self, who: RUsageWho) -> Option<RUsage> {
+        match who {
+            RUsageWho::RUsageSelf => Some(self.thread_group_rusage()),
+            RUsageWho::RUsageBoth => {
+                let mut rusage = self.thread_group_rusage();
+                let leader = self.leader_for_rusage();
+                let children = *leader.children_rusage.lock();
+                rusage.add_assign_saturating(&children);
+                Some(rusage)
+            }
+            RUsageWho::RusageThread => Some(self.task_rusage()),
+            RUsageWho::RUsageChildren => {
+                let leader = self.leader_for_rusage();
+                let rusage = *leader.children_rusage.lock();
+                Some(rusage)
+            }
+        }
     }
 }

--- a/kernel/src/process/resource.rs
+++ b/kernel/src/process/resource.rs
@@ -2,19 +2,45 @@ use num_traits::FromPrimitive;
 use system_error::SystemError;
 
 use alloc::sync::Arc;
-use core::sync::atomic::Ordering;
-
-use crate::time::syscall::PosixTimeval;
+use core::{ffi::c_long, sync::atomic::Ordering};
 
 use super::{ProcessControlBlock, ProcessManager};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(C)]
+pub struct RUsageTimeval {
+    pub tv_sec: c_long,
+    pub tv_usec: c_long,
+}
+
+impl RUsageTimeval {
+    #[inline]
+    pub fn from_ns(ns: u64) -> Self {
+        Self {
+            tv_sec: (ns / 1_000_000_000) as c_long,
+            tv_usec: ((ns % 1_000_000_000) / 1000) as c_long,
+        }
+    }
+
+    #[inline]
+    pub fn to_ns(self) -> u64 {
+        if self.tv_usec < 0 || self.tv_usec >= 1_000_000 {
+            (self.tv_sec as u64).saturating_mul(1_000_000_000)
+        } else {
+            let sec_ns = (self.tv_sec as u64).saturating_mul(1_000_000_000);
+            let usec_ns = (self.tv_usec as u64).saturating_mul(1000);
+            sec_ns.saturating_add(usec_ns)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C)]
 pub struct RUsage {
     /// User time used
-    pub ru_utime: PosixTimeval,
+    pub ru_utime: RUsageTimeval,
     /// System time used
-    pub ru_stime: PosixTimeval,
+    pub ru_stime: RUsageTimeval,
 
     // 以下是linux的rusage结构体扩展
     /// Maximum resident set size
@@ -49,8 +75,8 @@ pub struct RUsage {
 
 impl RUsage {
     #[inline]
-    fn add_time(lhs: &mut PosixTimeval, rhs: PosixTimeval) {
-        *lhs = PosixTimeval::from_ns(lhs.to_ns().saturating_add(rhs.to_ns()));
+    fn add_time(lhs: &mut RUsageTimeval, rhs: RUsageTimeval) {
+        *lhs = RUsageTimeval::from_ns(lhs.to_ns().saturating_add(rhs.to_ns()));
     }
 
     pub fn add_assign_saturating(&mut self, rhs: &RUsage) {
@@ -184,22 +210,31 @@ impl ProcessControlBlock {
     fn task_rusage(&self) -> RUsage {
         let ct = self.cputime();
         RUsage {
-            ru_utime: PosixTimeval::from_ns(ct.utime.load(Ordering::Relaxed)),
-            ru_stime: PosixTimeval::from_ns(ct.stime.load(Ordering::Relaxed)),
+            ru_utime: RUsageTimeval::from_ns(ct.utime.load(Ordering::Relaxed)),
+            ru_stime: RUsageTimeval::from_ns(ct.stime.load(Ordering::Relaxed)),
             ..RUsage::default()
         }
     }
 
     fn thread_group_rusage(&self) -> RUsage {
         let leader = self.leader_for_rusage();
-        let mut usage = leader.task_rusage();
         let ti = leader.threads_read_irqsave();
+        let mut usage = *leader.exited_thread_group_rusage.lock();
+        usage.add_assign_saturating(&leader.task_rusage());
         for task in &ti.group_tasks {
             if let Some(task) = task.upgrade() {
                 usage.add_assign_saturating(&task.task_rusage());
             }
         }
         usage
+    }
+
+    pub fn add_exited_thread_group_rusage(&self, rusage: &RUsage) {
+        let leader = self.leader_for_rusage();
+        leader
+            .exited_thread_group_rusage
+            .lock()
+            .add_assign_saturating(rusage);
     }
 
     pub fn add_child_rusage(&self, rusage: &RUsage) {

--- a/kernel/src/time/syscall/mod.rs
+++ b/kernel/src/time/syscall/mod.rs
@@ -27,7 +27,7 @@ pub type PosixTimeT = c_longlong;
 pub type PosixSusecondsT = c_int;
 
 #[repr(C)]
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PosixTimeval {
     pub tv_sec: PosixTimeT,
     pub tv_usec: PosixSusecondsT,

--- a/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
+++ b/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
@@ -1,0 +1,91 @@
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+uint64_t RusageCpuUsec(const struct rusage& ru) {
+  return static_cast<uint64_t>(ru.ru_utime.tv_sec) * 1000000ULL +
+         static_cast<uint64_t>(ru.ru_utime.tv_usec) +
+         static_cast<uint64_t>(ru.ru_stime.tv_sec) * 1000000ULL +
+         static_cast<uint64_t>(ru.ru_stime.tv_usec);
+}
+
+uint64_t MonotonicUsec() {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    return 0;
+  }
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000ULL +
+         static_cast<uint64_t>(ts.tv_nsec) / 1000ULL;
+}
+
+void BusyForUsec(uint64_t usec) {
+  const uint64_t start = MonotonicUsec();
+  volatile uint64_t sink = 0;
+  while (MonotonicUsec() - start < usec) {
+    for (int i = 0; i < 10000; ++i) {
+      sink += static_cast<uint64_t>(i);
+    }
+  }
+  _exit(static_cast<int>(sink & 0));
+}
+
+}  // namespace
+
+TEST(WaitRusage, WNowaitDoesNotReapAndWait4AccountsChildUsage) {
+  struct rusage before {};
+  ASSERT_EQ(0, getrusage(RUSAGE_CHILDREN, &before)) << strerror(errno);
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    BusyForUsec(500000);
+  }
+
+  siginfo_t si {};
+  struct rusage nowait_usage {};
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PID, child, &si, WEXITED | WNOWAIT,
+                       &nowait_usage))
+      << strerror(errno);
+  EXPECT_EQ(SIGCHLD, si.si_signo);
+  EXPECT_EQ(CLD_EXITED, si.si_code);
+  EXPECT_EQ(0, si.si_status);
+  EXPECT_EQ(child, si.si_pid);
+  EXPECT_GT(RusageCpuUsec(nowait_usage), 0u);
+
+  struct rusage after_nowait {};
+  ASSERT_EQ(0, getrusage(RUSAGE_CHILDREN, &after_nowait)) << strerror(errno);
+  EXPECT_EQ(RusageCpuUsec(before), RusageCpuUsec(after_nowait));
+
+  int status = 0;
+  struct rusage waited_usage {};
+  ASSERT_EQ(child, wait4(child, &status, 0, &waited_usage)) << strerror(errno);
+  EXPECT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(0, WEXITSTATUS(status));
+  EXPECT_GT(RusageCpuUsec(waited_usage), 0u);
+
+  struct rusage after_wait {};
+  ASSERT_EQ(0, getrusage(RUSAGE_CHILDREN, &after_wait)) << strerror(errno);
+  EXPECT_GE(RusageCpuUsec(after_wait) - RusageCpuUsec(before),
+            RusageCpuUsec(waited_usage));
+
+  errno = 0;
+  EXPECT_EQ(-1, wait4(child, nullptr, WNOHANG, nullptr));
+  EXPECT_EQ(ECHILD, errno);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
+++ b/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdint.h>
 #include <string.h>
@@ -30,7 +31,7 @@ uint64_t MonotonicUsec() {
          static_cast<uint64_t>(ts.tv_nsec) / 1000ULL;
 }
 
-void BusyForUsec(uint64_t usec) {
+uint64_t BurnCpuForUsec(uint64_t usec) {
   const uint64_t start = MonotonicUsec();
   volatile uint64_t sink = 0;
   while (MonotonicUsec() - start < usec) {
@@ -38,7 +39,17 @@ void BusyForUsec(uint64_t usec) {
       sink += static_cast<uint64_t>(i);
     }
   }
+  return sink;
+}
+
+void BusyForUsec(uint64_t usec) {
+  uint64_t sink = BurnCpuForUsec(usec);
   _exit(static_cast<int>(sink & 0));
+}
+
+void* ThreadBurn(void* arg) {
+  BurnCpuForUsec(reinterpret_cast<uintptr_t>(arg));
+  return nullptr;
 }
 
 }  // namespace
@@ -83,6 +94,29 @@ TEST(WaitRusage, WNowaitDoesNotReapAndWait4AccountsChildUsage) {
   errno = 0;
   EXPECT_EQ(-1, wait4(child, nullptr, WNOHANG, nullptr));
   EXPECT_EQ(ECHILD, errno);
+}
+
+TEST(WaitRusage, Wait4IncludesExitedThreadCpuTime) {
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    pthread_t worker {};
+    if (pthread_create(&worker, nullptr, ThreadBurn,
+                       reinterpret_cast<void*>(static_cast<uintptr_t>(600000))) != 0) {
+      _exit(2);
+    }
+    if (pthread_join(worker, nullptr) != 0) {
+      _exit(3);
+    }
+    _exit(0);
+  }
+
+  int status = 0;
+  struct rusage usage {};
+  ASSERT_EQ(child, wait4(child, &status, 0, &usage)) << strerror(errno);
+  ASSERT_TRUE(WIFEXITED(status));
+  ASSERT_EQ(0, WEXITSTATUS(status));
+  EXPECT_GE(RusageCpuUsec(usage), 100000u);
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/syscall/gvisor/blocklists/wait_test
+++ b/user/apps/tests/syscall/gvisor/blocklists/wait_test
@@ -1,9 +1,6 @@
-WaitTest.Wait4Rusage
-WaitTest.WaitidRusage
 # 缺少 SYS_PTRACE
 WaitTest.TraceeWALL
 # 卡死
-Waiters/WaitAnyChildTest.WaitedChildRusage/*
 Waiters/WaitAnyChildTest.IgnoredChildRusage/*
 
 # 缺少 /bin/true


### PR DESCRIPTION
## Summary
- implement CPU-time backed rusage for wait4/waitid and getrusage
- account reaped child rusage only after successful zombie reaping, preserving WNOWAIT observation semantics
- add dunitest coverage for waitid(WNOWAIT), wait4 rusage, and RUSAGE_CHILDREN accounting
- unblock covered gVisor wait rusage cases

## Validation
- make kernel
- make -C user/apps/tests/dunitest build-suites ARCH=x86_64
- make run-nographic
- in DragonOS guest: cd /opt/tests/dunitest/bin/normal && ./wait_rusage_test
- make qemu-nographic
- in DragonOS guest: cd /opt/tests/dunitest/bin/normal && ./wait_rusage_test
- make fmt