### PR TITLE
fix(tty): preserve burst serial input order

### DIFF
--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         tty::{
             console::ConsoleSwitch,
-            kthread::enqueue_tty_rx_from_irq,
+            kthread::enqueue_tty_rx_to_vc_from_irq,
             termios::{WindowSize, TTY_STD_TERMIOS},
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyDriverType, TtyOperation},
@@ -38,6 +38,7 @@ use crate::{
         rwsem::{RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
     },
+    mm::page::PAGE_4K_SIZE,
 };
 use alloc::string::String;
 use alloc::string::ToString;
@@ -56,6 +57,7 @@ use virtio_drivers::device::console::VirtIOConsole;
 
 const VIRTIO_CONSOLE_BASENAME: &str = "virtio_console";
 const HVC_MINOR: u32 = 0;
+const VIRTIO_CONSOLE_RX_IRQ_LIMIT: usize = PAGE_4K_SIZE;
 
 static mut VIRTIO_CONSOLE_DRIVER: Option<Arc<VirtIOConsoleDriver>> = None;
 static mut TTY_HVC_DRIVER: Option<Arc<TtyDriver>> = None;
@@ -153,6 +155,7 @@ impl VirtIOConsoleDevice {
                 device_common: DeviceCommonData::default(),
                 kobject_common: KObjectCommonData::default(),
                 irq,
+                input_vc_index: None,
             }),
         });
 
@@ -171,6 +174,7 @@ struct InnerVirtIOConsoleDevice {
     device_common: DeviceCommonData,
     kobject_common: KObjectCommonData,
     irq: Option<IrqNumber>,
+    input_vc_index: Option<usize>,
 }
 
 impl Debug for InnerVirtIOConsoleDevice {
@@ -181,6 +185,7 @@ impl Debug for InnerVirtIOConsoleDevice {
             .field("device_common", &self.device_common)
             .field("kobject_common", &self.kobject_common)
             .field("irq", &self.irq)
+            .field("input_vc_index", &self.input_vc_index)
             .finish()
     }
 }
@@ -316,16 +321,22 @@ impl VirtIODevice for VirtIOConsoleDevice {
     fn handle_irq(&self, _irq: IrqNumber) -> Result<IrqReturn, SystemError> {
         let mut buf = [0u8; 256];
         let mut index = 0;
+        let mut received = 0;
+        let target_vc_index = self.inner().input_vc_index;
 
         // 不能只取固定前缀：virtio-console 驱动会在本地缓存一个已完成的 rx buffer，
         // 若中断上半部只消费其中一部分，剩余字节不会自动产生新中断，后续输入会错位。
-        loop {
+        // 同时限制单次 IRQ 的处理量，避免宿主持续写入时 hardirq 长时间不返回。
+        while received < VIRTIO_CONSOLE_RX_IRQ_LIMIT {
             match self.inner().device_inner.recv(true) {
                 Ok(Some(c)) => {
                     buf[index] = c;
                     index += 1;
+                    received += 1;
                     if index == buf.len() {
-                        enqueue_tty_rx_from_irq(&buf);
+                        if let Some(vc_index) = target_vc_index {
+                            enqueue_tty_rx_to_vc_from_irq(vc_index, &buf);
+                        }
                         index = 0;
                     }
                 }
@@ -335,7 +346,9 @@ impl VirtIODevice for VirtIOConsoleDevice {
         }
 
         if index > 0 {
-            enqueue_tty_rx_from_irq(&buf[0..index]);
+            if let Some(vc_index) = target_vc_index {
+                enqueue_tty_rx_to_vc_from_irq(vc_index, &buf[0..index]);
+            }
         }
         Ok(IrqReturn::Handled)
     }
@@ -536,8 +549,10 @@ impl TtyOperation for VirtIOConsoleDriver {
 
         let vc = VirtConsole::new(Some(vc_data));
         let vc_index = vc_manager().alloc(vc.clone()).ok_or(SystemError::EBUSY)?;
+        dev.inner().input_vc_index = Some(vc_index);
         self.do_install(driver, tty, vc.clone()).inspect_err(|_| {
             vc_manager().free(vc_index);
+            dev.inner().input_vc_index = None;
         })?;
 
         Ok(())

--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -314,19 +314,29 @@ impl Device for VirtIOConsoleDevice {
 
 impl VirtIODevice for VirtIOConsoleDevice {
     fn handle_irq(&self, _irq: IrqNumber) -> Result<IrqReturn, SystemError> {
-        let mut buf = [0u8; 8];
+        let mut buf = [0u8; 256];
         let mut index = 0;
-        // Read up to the size of the buffer
-        while index < buf.len() {
-            if let Ok(Some(c)) = self.inner().device_inner.recv(true) {
-                buf[index] = c;
-                index += 1;
-            } else {
-                break; // No more bytes to read
+
+        // 不能只取固定前缀：virtio-console 驱动会在本地缓存一个已完成的 rx buffer，
+        // 若中断上半部只消费其中一部分，剩余字节不会自动产生新中断，后续输入会错位。
+        loop {
+            match self.inner().device_inner.recv(true) {
+                Ok(Some(c)) => {
+                    buf[index] = c;
+                    index += 1;
+                    if index == buf.len() {
+                        enqueue_tty_rx_from_irq(&buf);
+                        index = 0;
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => break,
             }
         }
 
-        enqueue_tty_rx_from_irq(&buf[0..index]);
+        if index > 0 {
+            enqueue_tty_rx_from_irq(&buf[0..index]);
+        }
         Ok(IrqReturn::Handled)
     }
 

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -267,20 +267,22 @@ impl UartPort for Serial8250PIOPort {
     }
 
     fn handle_irq(&self) -> Result<(), SystemError> {
-        let mut buf = [0; 8];
+        let mut buf = [0; 256];
         let mut index = 0;
 
-        // Read up to the size of the buffer
-        while index < buf.len() {
-            if let Some(c) = self.read_one_byte() {
-                buf[index] = c;
-                index += 1;
-            } else {
-                break; // No more bytes to read
+        // 排空当前可读的硬件 FIFO，避免粘贴长输入时只投递固定前缀。
+        while let Some(c) = self.read_one_byte() {
+            buf[index] = c;
+            index += 1;
+            if index == buf.len() {
+                enqueue_tty_rx_from_irq(&buf);
+                index = 0;
             }
         }
 
-        enqueue_tty_rx_from_irq(&buf[0..index]);
+        if index > 0 {
+            enqueue_tty_rx_from_irq(&buf[0..index]);
+        }
         Ok(())
     }
 

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -20,7 +20,7 @@ use crate::{
         serial::{AtomicBaudRate, BaudRate, DivisorFraction, UartPort},
         tty::{
             console::ConsoleSwitch,
-            kthread::enqueue_tty_rx_from_irq,
+            kthread::enqueue_tty_rx_to_vc_from_irq,
             termios::WindowSize,
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyOperation},
@@ -44,6 +44,7 @@ static mut PIO_PORTS: [Option<Serial8250PIOPort>; 8] =
     [None, None, None, None, None, None, None, None];
 
 const SERIAL_8250_PIO_IRQ: IrqNumber = IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4);
+const SERIAL_8250_RX_IRQ_LIMIT: usize = 256;
 
 impl Serial8250Manager {
     #[allow(static_mut_refs)]
@@ -267,21 +268,23 @@ impl UartPort for Serial8250PIOPort {
     }
 
     fn handle_irq(&self) -> Result<(), SystemError> {
-        let mut buf = [0; 256];
+        let mut buf = [0; SERIAL_8250_RX_IRQ_LIMIT];
         let mut index = 0;
+        let target_vc_index = self.inner.read().input_vc_index;
 
-        // 排空当前可读的硬件 FIFO，避免粘贴长输入时只投递固定前缀。
-        while let Some(c) = self.read_one_byte() {
+        // Linux serial8250_rx_chars 同样保留 256 字节上限，避免 RX IRQ 无界占用 CPU。
+        while index < SERIAL_8250_RX_IRQ_LIMIT {
+            let Some(c) = self.read_one_byte() else {
+                break;
+            };
             buf[index] = c;
             index += 1;
-            if index == buf.len() {
-                enqueue_tty_rx_from_irq(&buf);
-                index = 0;
-            }
         }
 
         if index > 0 {
-            enqueue_tty_rx_from_irq(&buf[0..index]);
+            if let Some(vc_index) = target_vc_index {
+                enqueue_tty_rx_to_vc_from_irq(vc_index, &buf[0..index]);
+            }
         }
         Ok(())
     }
@@ -297,11 +300,15 @@ struct Serial8250PIOPortInner {
     ///
     /// ps: 存储weak以避免循环引用
     device: Option<Weak<Serial8250ISADevices>>,
+    input_vc_index: Option<usize>,
 }
 
 impl Serial8250PIOPortInner {
     pub const fn new() -> Self {
-        Self { device: None }
+        Self {
+            device: None,
+            input_vc_index: None,
+        }
     }
 
     #[allow(dead_code)]
@@ -397,7 +404,8 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
     }
 
     fn install(&self, driver: Arc<TtyDriver>, tty: Arc<TtyCore>) -> Result<(), SystemError> {
-        if tty.core().index() >= unsafe { PIO_PORTS.len() } {
+        let tty_index = tty.core().index();
+        if tty_index >= unsafe { PIO_PORTS.len() } {
             return Err(SystemError::ENODEV);
         }
 
@@ -413,8 +421,16 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         drop(vc_data_guard);
         let vc = VirtConsole::new(Some(vc_data));
         let vc_index = vc_manager().alloc(vc.clone()).ok_or(SystemError::EBUSY)?;
+        unsafe { PIO_PORTS[tty_index].as_ref() }
+            .ok_or(SystemError::ENODEV)?
+            .inner
+            .write()
+            .input_vc_index = Some(vc_index);
         self.do_install(driver, tty, vc.clone()).inspect_err(|_| {
             vc_manager().free(vc_index);
+            if let Some(port) = unsafe { PIO_PORTS[tty_index].as_ref() } {
+                port.inner.write().input_vc_index = None;
+            }
         })?;
 
         Ok(())

--- a/kernel/src/driver/tty/kthread.rs
+++ b/kernel/src/driver/tty/kthread.rs
@@ -24,7 +24,13 @@ const TTY_RX_IRQ_BUF_SIZE: usize = 8192;
 /// 单次从 IRQ 暂存队列投递给行规程的最大字节数。
 const TTY_RX_DEQUEUE_MAX: usize = 256;
 
-static KEYBUF: StaticThingBuf<u8, TTY_RX_IRQ_BUF_SIZE> = StaticThingBuf::new();
+#[derive(Clone, Copy, Default)]
+struct TtyRxItem {
+    vc_index: usize,
+    byte: u8,
+}
+
+static KEYBUF: StaticThingBuf<TtyRxItem, TTY_RX_IRQ_BUF_SIZE> = StaticThingBuf::new();
 
 static mut TTY_REFRESH_THREAD: Option<Arc<ProcessControlBlock>> = None;
 
@@ -57,18 +63,25 @@ fn tty_refresh_thread() -> i32 {
         if to_dequeue == 0 {
             continue;
         }
-        let mut data = [0u8; TTY_RX_DEQUEUE_MAX];
+        let mut data = [TtyRxItem::default(); TTY_RX_DEQUEUE_MAX];
         for item in data.iter_mut().take(to_dequeue) {
             *item = KEYBUF.pop().unwrap();
         }
 
-        if let Some(cur_vc) = vc_manager().current_vc() {
-            let _ = cur_vc
-                .port()
-                .receive_buf(&data[0..to_dequeue], &[], to_dequeue);
-        } else {
-            // 这里由于stdio未初始化，所以无法找到port
-            // TODO: 考虑改用双端队列，能够将丢失的输入插回
+        let mut offset = 0;
+        while offset < to_dequeue {
+            let vc_index = data[offset].vc_index;
+            let mut bytes = [0u8; TTY_RX_DEQUEUE_MAX];
+            let mut count = 0;
+            while offset < to_dequeue && data[offset].vc_index == vc_index {
+                bytes[count] = data[offset].byte;
+                count += 1;
+                offset += 1;
+            }
+
+            if let Some(vc) = vc_manager().get(vc_index) {
+                let _ = vc.port().receive_buf(&bytes[0..count], &[], count);
+            }
         }
     }
 }
@@ -88,11 +101,22 @@ fn tty_rx_tasklet_fn(_data: usize, _data_obj: Option<Arc<dyn TaskletData>>) {
 ///
 /// 这样可以避免在硬中断里触碰调度/唤醒逻辑，符合 Linux bottom-half 语义。
 pub fn enqueue_tty_rx_from_irq(data: &[u8]) {
+    if let Some(vc_index) = vc_manager().current_vc_index() {
+        enqueue_tty_rx_to_vc_from_irq(vc_index, data);
+    }
+}
+
+pub fn enqueue_tty_rx_to_vc_from_irq(vc_index: usize, data: &[u8]) {
     if unsafe { TTY_REFRESH_THREAD.is_none() } {
         return;
     }
     for item in data {
-        KEYBUF.push(*item).ok();
+        KEYBUF
+            .push(TtyRxItem {
+                vc_index,
+                byte: *item,
+            })
+            .ok();
     }
     tasklet_schedule(&TTY_RX_TASKLET);
 }

--- a/kernel/src/driver/tty/kthread.rs
+++ b/kernel/src/driver/tty/kthread.rs
@@ -15,8 +15,16 @@ use crate::{
     sched::{schedule, SchedMode},
 };
 
-/// 用于缓存键盘输入的缓冲区
-static KEYBUF: StaticThingBuf<u8, 512> = StaticThingBuf::new();
+/// 用于缓存 IRQ 上下文投递的 TTY 输入。
+///
+/// N_TTY 规范模式按 Linux 语义支持 4096 字节行缓冲；这里的 IRQ 暂存队列必须
+/// 大于该长度，避免输入还没进入行规程就被提前截断。
+const TTY_RX_IRQ_BUF_SIZE: usize = 8192;
+
+/// 单次从 IRQ 暂存队列投递给行规程的最大字节数。
+const TTY_RX_DEQUEUE_MAX: usize = 256;
+
+static KEYBUF: StaticThingBuf<u8, TTY_RX_IRQ_BUF_SIZE> = StaticThingBuf::new();
 
 static mut TTY_REFRESH_THREAD: Option<Arc<ProcessControlBlock>> = None;
 
@@ -37,7 +45,6 @@ pub(super) fn tty_flush_thread_init() {
 }
 
 fn tty_refresh_thread() -> i32 {
-    const TO_DEQUEUE_MAX: usize = 256;
     loop {
         if KEYBUF.is_empty() {
             // 如果缓冲区为空，就休眠
@@ -46,11 +53,11 @@ fn tty_refresh_thread() -> i32 {
             schedule(SchedMode::SM_NONE);
         }
 
-        let to_dequeue = core::cmp::min(KEYBUF.len(), TO_DEQUEUE_MAX);
+        let to_dequeue = core::cmp::min(KEYBUF.len(), TTY_RX_DEQUEUE_MAX);
         if to_dequeue == 0 {
             continue;
         }
-        let mut data = [0u8; TO_DEQUEUE_MAX];
+        let mut data = [0u8; TTY_RX_DEQUEUE_MAX];
         for item in data.iter_mut().take(to_dequeue) {
             *item = KEYBUF.pop().unwrap();
         }


### PR DESCRIPTION
## Summary
- drain virtio-console RX in bounded IRQ batches instead of a fixed tiny prefix or an unbounded loop
- restore the Linux-style 256-byte serial8250 RX IRQ budget
- route IRQ-staged TTY input to the source VC instead of always injecting into the current VC, avoiding hvc0/ttyS0 mixing when QEMU muxes stdio to both devices
- keep the enlarged IRQ-to-TTY staging queue so input is not truncated before N_TTY's 4096-byte canonical line handling

## Validation
- `make fmt`
- `make kernel`
- booted with `make qemu-nographic`
- in DragonOS guest on `/dev/hvc0`, pasted five burst commands; all echoed/executed in order
- in DragonOS guest on `/dev/hvc0`, sent one 600-byte command line in chunks without embedded newlines; `wc -c` reported `600`