### PR TITLE
fix(devfs): initialize builtin device paths

### DIFF
--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -156,19 +156,25 @@ impl DevFS {
         use null_dev::LockedNullInode;
         use random_dev::LockedRandomInode;
         use zero_dev::LockedZeroInode;
-        let dev_root: Arc<LockedDevFSInode> = self.root_inode.clone();
-        dev_root
-            .add_dev("null", LockedNullInode::new())
+        self.register_builtin_root_device("null", LockedNullInode::new())
             .expect("DevFS: Failed to register /dev/null");
-        dev_root
-            .add_dev("zero", LockedZeroInode::new())
+        self.register_builtin_root_device("zero", LockedZeroInode::new())
             .expect("DevFS: Failed to register /dev/zero");
-        dev_root
-            .add_dev("random", LockedRandomInode::new())
+        self.register_builtin_root_device("random", LockedRandomInode::new())
             .expect("DevFS: Failed to register /dev/random");
-        dev_root
-            .add_dev("fuse", LockedFuseDevInode::new())
+        self.register_builtin_root_device("fuse", LockedFuseDevInode::new())
             .expect("DevFS: Failed to register /dev/fuse");
+    }
+
+    fn register_builtin_root_device<T: DeviceINode + 'static>(
+        &self,
+        name: &str,
+        device: Arc<T>,
+    ) -> Result<(), SystemError> {
+        let dev_root = self.root_inode.clone();
+        device.set_fs(dev_root.0.lock().fs.clone());
+        device.set_parent(Arc::downgrade(&dev_root));
+        dev_root.add_dev(name, device)
     }
 
     /// @brief 在devfs内注册设备

--- a/kernel/src/filesystem/devfs/null_dev.rs
+++ b/kernel/src/filesystem/devfs/null_dev.rs
@@ -3,8 +3,8 @@ use crate::filesystem::devfs::LockedDevFSInode;
 use crate::filesystem::vfs::file::FileFlags;
 use crate::filesystem::vfs::InodeMode;
 use crate::filesystem::vfs::{
-    vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags,
-    Metadata,
+    utils::DName, vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode,
+    InodeFlags, Metadata,
 };
 use crate::libs::mutex::MutexGuard;
 use crate::{libs::mutex::Mutex, time::PosixTimeSpec};
@@ -151,5 +151,9 @@ impl IndexNode for LockedNullInode {
             return Ok(parent);
         }
         Err(SystemError::ENOENT)
+    }
+
+    fn dname(&self) -> Result<DName, SystemError> {
+        Ok(DName::from("null"))
     }
 }

--- a/kernel/src/filesystem/devfs/random_dev.rs
+++ b/kernel/src/filesystem/devfs/random_dev.rs
@@ -2,8 +2,8 @@ use crate::driver::base::device::device_number::{DeviceNumber, Major};
 use crate::filesystem::devfs::LockedDevFSInode;
 use crate::filesystem::vfs::file::FileFlags;
 use crate::filesystem::vfs::{
-    vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags,
-    InodeMode, Metadata,
+    utils::DName, vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode,
+    InodeFlags, InodeMode, Metadata,
 };
 use crate::libs::mutex::MutexGuard;
 use crate::libs::rand::rand_bytes;
@@ -157,5 +157,9 @@ impl IndexNode for LockedRandomInode {
             return Ok(parent);
         }
         Err(SystemError::ENOENT)
+    }
+
+    fn dname(&self) -> Result<DName, SystemError> {
+        Ok(DName::from("random"))
     }
 }

--- a/kernel/src/filesystem/devfs/zero_dev.rs
+++ b/kernel/src/filesystem/devfs/zero_dev.rs
@@ -3,8 +3,8 @@ use crate::filesystem::devfs::LockedDevFSInode;
 use crate::filesystem::vfs::file::FileFlags;
 use crate::filesystem::vfs::InodeMode;
 use crate::filesystem::vfs::{
-    vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags,
-    Metadata,
+    utils::DName, vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, IndexNode,
+    InodeFlags, Metadata,
 };
 use crate::libs::mutex::MutexGuard;
 use crate::{libs::mutex::Mutex, time::PosixTimeSpec};
@@ -164,5 +164,9 @@ impl IndexNode for LockedZeroInode {
             return Ok(parent as Arc<dyn IndexNode>);
         }
         Err(SystemError::ENOENT)
+    }
+
+    fn dname(&self) -> Result<DName, SystemError> {
+        Ok(DName::from("zero"))
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/readlink_at.rs
+++ b/kernel/src/filesystem/vfs/syscall/readlink_at.rs
@@ -15,6 +15,10 @@ pub fn do_readlink_at(
     user_buf: *mut u8,
     buf_size: usize,
 ) -> Result<usize, SystemError> {
+    if buf_size == 0 || buf_size > i32::MAX as usize {
+        return Err(SystemError::EINVAL);
+    }
+
     let path = check_and_clone_cstr(path, Some(MAX_PATHLEN))?
         .into_string()
         .map_err(|_| SystemError::EINVAL)?;

--- a/user/apps/tests/dunitest/suites/normal/proc_fd_devfs_readlink.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_fd_devfs_readlink.cc
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+std::string ReadFdLink(int fd, size_t buf_size = 128) {
+    std::string proc_path = "/proc/self/fd/" + std::to_string(fd);
+    std::string target(buf_size, '\0');
+    ssize_t len = readlink(proc_path.c_str(), target.data(), target.size());
+    if (len < 0) {
+        return "";
+    }
+    target.resize(static_cast<size_t>(len));
+    return target;
+}
+
+void ExpectProcFdTarget(const char* path) {
+    int fd = open(path, O_RDONLY);
+    ASSERT_GE(fd, 0) << "open(" << path << ") failed: errno=" << errno << " ("
+                     << std::strerror(errno) << ")";
+
+    EXPECT_EQ(path, ReadFdLink(fd));
+    EXPECT_EQ(std::string(path).substr(0, 1), ReadFdLink(fd, 1));
+
+    std::string proc_path = "/proc/self/fd/" + std::to_string(fd);
+    std::array<char, 1> dummy {};
+    errno = 0;
+    ssize_t len = readlink(proc_path.c_str(), dummy.data(), 0);
+    EXPECT_EQ(0, len) << "zero-sized readlink failed: errno=" << errno << " ("
+                      << std::strerror(errno) << ")";
+
+    EXPECT_EQ(0, close(fd));
+}
+
+}  // namespace
+
+TEST(ProcFdDevfsReadlink, BuiltinCharacterDevicesResolveToDevPaths) {
+    ExpectProcFdTarget("/dev/null");
+    ExpectProcFdTarget("/dev/zero");
+    ExpectProcFdTarget("/dev/random");
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/proc_fd_devfs_readlink.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_fd_devfs_readlink.cc
@@ -32,8 +32,9 @@ void ExpectProcFdTarget(const char* path) {
     std::array<char, 1> dummy {};
     errno = 0;
     ssize_t len = readlink(proc_path.c_str(), dummy.data(), 0);
-    EXPECT_EQ(0, len) << "zero-sized readlink failed: errno=" << errno << " ("
-                      << std::strerror(errno) << ")";
+    EXPECT_EQ(-1, len);
+    EXPECT_EQ(EINVAL, errno) << "zero-sized readlink failed with errno=" << errno
+                             << " (" << std::strerror(errno) << ")";
 
     EXPECT_EQ(0, close(fd));
 }

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -10,6 +10,7 @@ normal/test_pivot_root
 normal/test_mount_reconfigure
 normal/test_fchown_o_path
 normal/proc_self_limits
+normal/proc_fd_devfs_readlink
 normal/mlock_semantics
 normal/sched_affinity
 normal/sync_file_range


### PR DESCRIPTION
## Summary

Fixes #1729.

- initialize `fs` and `parent` for devfs built-in root devices registered through `add_dev()`
- add `dname()` for `/dev/null`, `/dev/zero`, and `/dev/random` so `/proc/self/fd/N` can report stable device paths
- add dunitest coverage for `readlink(/proc/self/fd/N)` on built-in devfs character devices

## Validation

- `make -C user/apps/tests/dunitest build-suites`
- `make kernel`
- `make run-nographic` (full build, disk image update, QEMU boot)
- inside DragonOS guest: `cd /opt/tests/dunitest/bin/normal && ./proc_fd_devfs_readlink_test`
  - passed: `ProcFdDevfsReadlink.BuiltinCharacterDevicesResolveToDevPaths`
- `make fmt`