### PR TITLE
fix(signal): validate fpstate on sigreturn

### DIFF
--- a/kernel/src/arch/x86_64/fpu.rs
+++ b/kernel/src/arch/x86_64/fpu.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 /// XSAVE area 的最大大小
 /// 对于 AVX: 约 832 字节 (512 + 64 header + 256 YMM)
@@ -15,6 +15,9 @@ static XSAVE_FEATURE_MASK: AtomicU64 = AtomicU64::new(0);
 
 /// 全局变量：XSAVE area 大小
 static XSAVE_AREA_SIZE: AtomicUsize = AtomicUsize::new(512);
+
+/// 全局变量：当前 CPU 支持的 MXCSR 特性位掩码
+static MXCSR_FEATURE_MASK: AtomicU32 = AtomicU32::new(0x0000_ffbf);
 
 /// XSAVE 特性位
 pub const XFEATURE_X87: u64 = 1 << 0;
@@ -56,6 +59,7 @@ impl FpState {
         use raw_cpuid::CpuId;
 
         let cpuid = CpuId::new();
+        MXCSR_FEATURE_MASK.store(Self::detect_mxcsr_feature_mask(), Ordering::SeqCst);
 
         // 检查 XSAVE 支持
         let has_xsave = cpuid
@@ -120,6 +124,29 @@ impl FpState {
     #[inline]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    fn detect_mxcsr_feature_mask() -> u32 {
+        let mut state = Self {
+            data: [0u8; MAX_XSAVE_SIZE],
+        };
+
+        unsafe {
+            core::arch::asm!(
+                "fxsave64 [{}]",
+                in(reg) state.data.as_mut_ptr(),
+                options(nostack)
+            );
+        }
+
+        let mask = u32::from_le_bytes(state.data[28..32].try_into().unwrap());
+        if mask == 0 {
+            // 与 Linux 一致：旧 CPU 可能在 FXSAVE 的 mxcsr_mask 字段返回 0，
+            // 此时使用除 DAZ(bit 6) 之外的默认 MXCSR 特性掩码。
+            0x0000_ffbf
+        } else {
+            mask
+        }
     }
 
     /// 初始化为默认的 FPU 状态
@@ -259,5 +286,15 @@ impl FpState {
     /// 返回 XSAVE area 大小
     pub fn xsave_area_size() -> usize {
         XSAVE_AREA_SIZE.load(Ordering::Relaxed)
+    }
+
+    /// 返回当前 CPU 支持的 XSAVE 用户特性位
+    pub fn xsave_feature_mask() -> u64 {
+        XSAVE_FEATURE_MASK.load(Ordering::Relaxed)
+    }
+
+    /// 返回当前 CPU 支持的 MXCSR 特性位
+    pub fn mxcsr_feature_mask() -> u32 {
+        MXCSR_FEATURE_MASK.load(Ordering::Relaxed)
     }
 }

--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -14,7 +14,7 @@ pub use crate::ipc::generic_signal::GenericSignal as Signal;
 use crate::process::rseq::Rseq;
 use crate::{
     arch::{
-        fpu::FpState,
+        fpu::{FpState, XFEATURE_AVX, XFEATURE_SSE, XFEATURE_X87},
         interrupt::TrapFrame,
         process::table::{USER_CS, USER_DS},
         syscall::nr::SYS_RESTART_SYSCALL,
@@ -194,6 +194,46 @@ const _: () = {
 };
 
 impl UserXState {
+    fn validate_for_sigreturn(&self) -> Result<(), SystemError> {
+        let mxcsr_mask = FpState::mxcsr_feature_mask();
+        if self.fpstate.mxcsr & !mxcsr_mask != 0 {
+            error!(
+                "invalid signal fpstate mxcsr: value={:#x}, supported_mask={:#x}",
+                self.fpstate.mxcsr, mxcsr_mask
+            );
+            return Err(SystemError::EINVAL);
+        }
+
+        if !FpState::is_xsave_enabled() {
+            return Ok(());
+        }
+
+        let supported_user_xfeatures =
+            FpState::xsave_feature_mask() & (XFEATURE_X87 | XFEATURE_SSE | XFEATURE_AVX);
+        if self.header.xfeatures & !supported_user_xfeatures != 0 {
+            error!(
+                "invalid signal xstate features: value={:#x}, supported_mask={:#x}",
+                self.header.xfeatures, supported_user_xfeatures
+            );
+            return Err(SystemError::EINVAL);
+        }
+
+        if self.header.xcomp_bv != 0 {
+            error!(
+                "invalid signal xstate compacted format: xcomp_bv={:#x}",
+                self.header.xcomp_bv
+            );
+            return Err(SystemError::EINVAL);
+        }
+
+        if self.header.reserved.iter().any(|value| *value != 0) {
+            error!("invalid signal xstate header: reserved bits are non-zero");
+            return Err(SystemError::EINVAL);
+        }
+
+        Ok(())
+    }
+
     /// 从内核 FpState 转换到用户态完整的 XSAVE 状态
     ///
     /// 包含：
@@ -260,7 +300,9 @@ impl UserXState {
     /// 从用户态 XSAVE 状态转换回内核 FpState
     ///
     /// 恢复完整的 XSAVE 状态，包括 AVX
-    pub fn to_kernel_fpstate(self) -> FpState {
+    pub fn to_kernel_fpstate(self) -> Result<FpState, SystemError> {
+        self.validate_for_sigreturn()?;
+
         let mut result = FpState::new();
 
         // 写入 FXSAVE 兼容区域（前 512 字节）
@@ -299,7 +341,7 @@ impl UserXState {
             }
         }
 
-        result
+        Ok(result)
     }
 }
 
@@ -567,9 +609,9 @@ impl SigFrame {
 
     /// 从栈帧恢复 fpstate，包含安全性检查（防止 SROP 攻击）
     /// 返回包含完整 XSAVE 状态（包括 AVX）的 FpState
-    pub fn restore_fpstate(&self) -> Option<FpState> {
+    pub fn restore_fpstate(&self) -> Result<Option<FpState>, SystemError> {
         if self.ucontext.uc_mcontext.fpstate.is_null() {
-            return None;
+            return Ok(None);
         }
 
         // 验证指针确实指向 ucontext 内的 __fpregs_mem.fpstate
@@ -580,11 +622,11 @@ impl SigFrame {
                 "fpstate pointer mismatch: expected={:p}, got={:p}, possible SROP attack",
                 expected_addr, self.ucontext.uc_mcontext.fpstate
             );
-            return None;
+            return Err(SystemError::EFAULT);
         }
 
         // 使用 UserXState::to_kernel_fpstate 恢复完整的 XSAVE 状态（包括 AVX）
-        Some(self.ucontext.__fpregs_mem.to_kernel_fpstate())
+        self.ucontext.__fpregs_mem.to_kernel_fpstate().map(Some)
     }
 }
 
@@ -801,11 +843,22 @@ impl SignalArch for X86_64SignalArch {
         let mut sigmask = frame.ucontext.uc_sigmask.to_kernel_sigset();
         set_current_blocked(&mut sigmask);
 
-        // 2. 恢复通用寄存器
+        // 2. 先校验并构造 FP 状态。失败时按 Linux badframe 语义强制 SIGSEGV，
+        // 避免把用户篡改的状态交给 FXRSTOR/XRSTOR 触发内核 #GP。
+        let kernel_fp = match frame.restore_fpstate() {
+            Ok(kernel_fp) => kernel_fp,
+            Err(err) => {
+                error!("sys_rt_sigreturn: failed to restore fpstate: {:?}", err);
+                let _ = crate::ipc::signal::force_kernel_default_signal_to_current(Signal::SIGSEGV);
+                return 0;
+            }
+        };
+
+        // 3. 恢复通用寄存器
         frame.ucontext.restore_to_trapframe(trap_frame);
 
-        // 3. 恢复 FP 状态（包含安全性检查）
-        if let Some(kernel_fp) = frame.restore_fpstate() {
+        // 4. 恢复 FP 状态
+        if let Some(kernel_fp) = kernel_fp {
             let pcb = ProcessManager::current_pcb();
             let mut archinfo_guard = pcb.arch_info_irqsave();
             *archinfo_guard.fp_state_mut() = Some(kernel_fp);
@@ -813,8 +866,6 @@ impl SignalArch for X86_64SignalArch {
 
             // 恢复 cr2
             *archinfo_guard.cr2_mut() = frame.ucontext.uc_mcontext.cr2 as usize;
-        } else {
-            error!("sys_rt_sigreturn: failed to restore fpstate");
         }
 
         // 返回恢复后的 rax 值

--- a/user/apps/tests/dunitest/suites/normal/signal_fpstate_sigreturn.cc
+++ b/user/apps/tests/dunitest/suites/normal/signal_fpstate_sigreturn.cc
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/ucontext.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+void corrupt_fpstate_handler(int, siginfo_t*, void* raw_ucontext) {
+#if defined(__x86_64__)
+    auto* ctx = reinterpret_cast<ucontext_t*>(raw_ucontext);
+    if (ctx == nullptr || ctx->uc_mcontext.fpregs == nullptr) {
+        _exit(2);
+    }
+
+    auto* fpstate = reinterpret_cast<volatile uint8_t*>(ctx->uc_mcontext.fpregs);
+    for (size_t i = 0; i < 32; ++i) {
+        fpstate[i] = 0xff;
+    }
+#else
+    (void)raw_ucontext;
+    _exit(3);
+#endif
+}
+
+void run_corrupt_sigreturn_child() {
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_sigaction = corrupt_fpstate_handler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_SIGINFO;
+
+    if (sigaction(SIGUSR1, &action, nullptr) != 0) {
+        _exit(4);
+    }
+
+    if (raise(SIGUSR1) != 0) {
+        _exit(5);
+    }
+
+    _exit(6);
+}
+
+}  // namespace
+
+TEST(SignalFpstateSigreturn, InvalidMxcsrKillsProcessWithoutKernelFault) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+
+    if (child == 0) {
+        run_corrupt_sigreturn_child();
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFSIGNALED(status)) << "child exited with status " << WEXITSTATUS(status);
+    EXPECT_EQ(SIGSEGV, WTERMSIG(status));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -21,3 +21,4 @@ fuse/fuse_extended
 normal/test_procfs_link
 normal/user_namespace_id_map
 normal/tty_tcflush
+normal/signal_fpstate_sigreturn


### PR DESCRIPTION
## Summary

Fixes #1722.

This adds Linux-style validation before restoring x86_64 signal-frame FP state in `rt_sigreturn`:

- reject invalid MXCSR values before `FXRSTOR/XRSTOR`
- reject unsupported xstate feature bits, compacted xstate format, and non-zero xstate header reserved fields
- treat invalid signal-frame FP state as a bad signal frame and force SIGSEGV instead of letting malformed user state trigger a kernel #GP
- add a dunitest regression that corrupts the signal frame FP state and verifies the child process receives SIGSEGV while the kernel stays alive

## Validation

Pre-fix reproduction on parent commit `3bdd90d0`:

- `make kernel`
- `make qemu-nographic`
- in DragonOS guest: `cd /opt/tests/dunitest/bin/normal && ./signal_fpstate_sigreturn_test`
- reproduced kernel panic: `do_general_protection(13)` followed by `Kernel Panic Occurred`, matching issue #1722

Post-fix validation:

- `cargo fmt --manifest-path kernel/Cargo.toml`
- `make -C user/apps/tests/dunitest bin/normal/signal_fpstate_sigreturn_test`
- host run: `./user/apps/tests/dunitest/bin/normal/signal_fpstate_sigreturn_test` passed
- `make kernel` passed
- `make run-nographic`
- in DragonOS guest: `cd /opt/tests/dunitest/bin/normal && ./signal_fpstate_sigreturn_test` passed

Guest post-fix log showed the malformed state being rejected before hardware restore:

```text
invalid signal fpstate mxcsr: value=0xffffffff, supported_mask=0xffff
sys_rt_sigreturn: failed to restore fpstate: EINVAL
[  PASSED  ] 1 test.
```