### PR TITLE
fix(process): avoid panic on dead pid namespace fork

### DIFF
--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -563,10 +563,14 @@ impl ProcessManager {
         // 如果新进程使用不同的 pid 或 namespace，
         // 则不允许它与分叉任务共享线程组。
         if clone_flags.contains(CloneFlags::CLONE_THREAD)
-            && !((clone_flags & (CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_NEWPID)).is_empty())
+            && (!((clone_flags & (CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_NEWPID))
+                .is_empty())
+                || !Arc::ptr_eq(
+                    &current_pcb.active_pid_ns(),
+                    current_pcb.nsproxy().pid_namespace_for_children(),
+                ))
         {
             return Err(SystemError::EINVAL);
-            // TODO: 判断新进程与当前进程namespace是否相同，不同则返回错误
         }
 
         // 如果新进程将处于不同的time namespace，

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -712,12 +712,12 @@ impl ProcessManager {
             // 分层PID分配：在父进程的子PID namespace中为新任务分配PID
             let ns = pcb.nsproxy().pid_namespace_for_children().clone();
 
-            let main_pid_arc = alloc_pid(&ns).expect("alloc_pid failed");
+            let main_pid_arc = alloc_pid(&ns)?;
 
             // 根namespace中的PID号作为RawPid
             let root_pid_nr = main_pid_arc
                 .first_upid()
-                .expect("UPid list empty")
+                .ok_or(SystemError::EINVAL)?
                 .nr
                 .data();
             // log::debug!("fork: root_pid_nr: {}", root_pid_nr);

--- a/kernel/src/process/namespace/pid_namespace.rs
+++ b/kernel/src/process/namespace/pid_namespace.rs
@@ -212,7 +212,7 @@ impl PidNamespace {
 impl InnerPidNamespace {
     pub fn do_alloc_pid_in_ns(&mut self, pid: Arc<Pid>) -> Result<RawPid, SystemError> {
         if self.dead {
-            return Err(SystemError::ESRCH);
+            return Err(SystemError::ENOMEM);
         }
         let raw_pid = self.ida.alloc().ok_or(SystemError::ENOMEM)?;
         let raw_pid = RawPid(raw_pid);

--- a/kernel/src/process/pid.rs
+++ b/kernel/src/process/pid.rs
@@ -99,7 +99,7 @@ impl Pid {
     }
 
     pub fn first_upid(&self) -> Option<UPid> {
-        self.numbers.lock().first().cloned().unwrap()
+        self.numbers.lock().first().cloned().flatten()
     }
 
     pub fn tasks_iter(&self, pid_type: PidType) -> PidTaskIterator<'_> {

--- a/user/apps/tests/dunitest/suites/normal/pid_namespace_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/pid_namespace_fork.cc
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+void* fork_worker(void*) {
+    pid_t pid = fork();
+    if (pid == 0) {
+        _exit(0);
+    }
+    if (pid > 0) {
+        waitpid(pid, nullptr, 0);
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+TEST(PidNamespaceFork, DeadPidNamespaceForChildrenDoesNotPanic) {
+    if (unshare(CLONE_NEWPID) != 0) {
+        GTEST_SKIP() << "unshare(CLONE_NEWPID) failed: " << strerror(errno);
+    }
+
+    pid_t first = fork();
+    ASSERT_GE(first, 0) << strerror(errno);
+    if (first == 0) {
+        _exit(0);
+    }
+    ASSERT_EQ(waitpid(first, nullptr, 0), first) << strerror(errno);
+
+    errno = 0;
+    pid_t second = fork();
+    if (second == 0) {
+        _exit(0);
+    }
+    ASSERT_EQ(second, -1) << "fork unexpectedly succeeded in a dead child PID namespace";
+    EXPECT_EQ(errno, ENOMEM) << "unexpected fork errno: " << strerror(errno);
+
+    pthread_t thread;
+    int rc = pthread_create(&thread, nullptr, fork_worker, nullptr);
+    ASSERT_NE(rc, 0) << "pthread_create unexpectedly succeeded in a dead child PID namespace";
+    EXPECT_TRUE(rc == ENOMEM || rc == EAGAIN)
+        << "unexpected pthread_create error: " << strerror(rc);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/pid_namespace_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/pid_namespace_fork.cc
@@ -45,8 +45,7 @@ TEST(PidNamespaceFork, DeadPidNamespaceForChildrenDoesNotPanic) {
     pthread_t thread;
     int rc = pthread_create(&thread, nullptr, fork_worker, nullptr);
     ASSERT_NE(rc, 0) << "pthread_create unexpectedly succeeded in a dead child PID namespace";
-    EXPECT_TRUE(rc == ENOMEM || rc == EAGAIN)
-        << "unexpected pthread_create error: " << strerror(rc);
+    EXPECT_EQ(rc, EINVAL) << "unexpected pthread_create error: " << strerror(rc);
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -16,6 +16,7 @@ normal/sync_file_range
 normal/splice_concurrent_io
 normal/rcu_selftest
 normal/test_tlb_shootdown
+normal/pid_namespace_fork
 normal/tcp_close_semantics
 fuse/fuse_core
 fuse/fuse_extended


### PR DESCRIPTION
## Summary
- propagate PID allocation failures from fork instead of panicking
- return ENOMEM when allocating in a dead PID namespace, matching Linux behavior for stopped PID namespace allocation
- add a dunitest regression for `unshare(CLONE_NEWPID)` followed by fork/thread creation after the namespace init exits

## Validation
- Reproduced before fix in QEMU guest: `./pid_namespace_fork_test` triggered `Kernel Panic Occurred` at `src/process/fork.rs:715`, `alloc_pid failed: ESRCH`
- `make run-nographic`, then in guest: `cd /opt/tests/dunitest/bin/normal && ./pid_namespace_fork_test` -> 1 test passed
- `make fmt` -> kernel `cargo fmt`/`clippy` passed; user/build-scripts fmt completed with existing subdir "No rule to make target 'fmt'" messages treated by the Makefile

Fixes #1730