### PR TITLE
fix(net): report connecting tcp shutdown as reset

### DIFF
--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -336,6 +336,8 @@ enum ConnectResult {
     Connecting,
     Refused,
     RefusedConsumed,
+    ShutdownReset,
+    ShutdownResetConsumed,
 }
 
 #[derive(Debug)]
@@ -392,7 +394,10 @@ impl Connecting {
                 Inner::Established(Established::new(self.inner, true)),
                 Ok(()),
             ),
-            ConnectResult::Refused | ConnectResult::RefusedConsumed => {
+            ConnectResult::Refused
+            | ConnectResult::RefusedConsumed
+            | ConnectResult::ShutdownReset
+            | ConnectResult::ShutdownResetConsumed => {
                 // unbind port
                 self.inner
                     .port_manager()
@@ -406,9 +411,15 @@ impl Connecting {
                     smoltcp::wire::IpAddress::Ipv4(_) => smoltcp::wire::IpVersion::Ipv4,
                     smoltcp::wire::IpAddress::Ipv6(_) => smoltcp::wire::IpVersion::Ipv6,
                 };
+                let err = match result {
+                    ConnectResult::ShutdownReset | ConnectResult::ShutdownResetConsumed => {
+                        SystemError::ECONNRESET
+                    }
+                    _ => SystemError::ECONNREFUSED,
+                };
                 (
                     Inner::Init(Init::Unbound((Box::new(socket), ver))),
-                    Err(SystemError::ECONNREFUSED),
+                    Err(err),
                 )
             }
         }
@@ -465,6 +476,8 @@ impl Connecting {
                     ConnectResult::Refused
                         | ConnectResult::Connected
                         | ConnectResult::RefusedConsumed
+                        | ConnectResult::ShutdownReset
+                        | ConnectResult::ShutdownResetConsumed
                 ) {
                     if matches!(state, tcp::State::Established | tcp::State::CloseWait) {
                         // log::debug!(
@@ -528,7 +541,10 @@ impl Connecting {
                             Ordering::Relaxed,
                         );
                     }
-                    ConnectResult::Refused | ConnectResult::RefusedConsumed => {
+                    ConnectResult::Refused
+                    | ConnectResult::RefusedConsumed
+                    | ConnectResult::ShutdownReset
+                    | ConnectResult::ShutdownResetConsumed => {
                         // Connection attempt refused (or reset during handshake).
                         // This is equivalent to a closed socket with error.
                         // Should be readable, writable, and have HUP/ERR set.
@@ -541,14 +557,20 @@ impl Connecting {
                             | EPollEventType::EPOLLRDHUP;
 
                         // If error not consumed yet, set EPOLLERR
-                        if matches!(*result, ConnectResult::Refused) {
+                        if matches!(
+                            *result,
+                            ConnectResult::Refused | ConnectResult::ShutdownReset
+                        ) {
                             events_to_set |= EPollEventType::EPOLLERR;
                         }
 
                         pollee.fetch_or(events_to_set.bits() as usize, Ordering::Relaxed);
 
                         // If error IS consumed, clear EPOLLERR (if it was set previously)
-                        if matches!(*result, ConnectResult::RefusedConsumed) {
+                        if matches!(
+                            *result,
+                            ConnectResult::RefusedConsumed | ConnectResult::ShutdownResetConsumed
+                        ) {
                             pollee.fetch_and(
                                 !(EPollEventType::EPOLLERR).bits() as usize,
                                 Ordering::Relaxed,
@@ -576,6 +598,8 @@ impl Connecting {
                     ConnectResult::Refused
                         | ConnectResult::Connected
                         | ConnectResult::RefusedConsumed
+                        | ConnectResult::ShutdownReset
+                        | ConnectResult::ShutdownResetConsumed
                 )
             })
     }
@@ -589,22 +613,31 @@ impl Connecting {
     }
 
     pub fn failure_reason(&self) -> Option<SystemError> {
-        if matches!(*self.result.read(), ConnectResult::Refused) {
-            Some(SystemError::ECONNREFUSED)
-        } else {
-            None
+        match *self.result.read() {
+            ConnectResult::Refused => Some(SystemError::ECONNREFUSED),
+            ConnectResult::ShutdownReset => Some(SystemError::ECONNRESET),
+            _ => None,
         }
     }
 
     pub fn consume_error(&self) {
         let mut guard = self.result.write();
-        if matches!(*guard, ConnectResult::Refused) {
-            *guard = ConnectResult::RefusedConsumed;
+        match *guard {
+            ConnectResult::Refused => *guard = ConnectResult::RefusedConsumed,
+            ConnectResult::ShutdownReset => *guard = ConnectResult::ShutdownResetConsumed,
+            _ => {}
         }
     }
 
     pub fn is_refused_consumed(&self) -> bool {
-        matches!(*self.result.read(), ConnectResult::RefusedConsumed)
+        matches!(
+            *self.result.read(),
+            ConnectResult::RefusedConsumed | ConnectResult::ShutdownResetConsumed
+        )
+    }
+
+    pub fn set_shutdown_reset(&self) {
+        *self.result.write() = ConnectResult::ShutdownReset;
     }
 }
 

--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -429,6 +429,15 @@ impl Connecting {
         matches!(*self.result.read(), ConnectResult::Connected)
     }
 
+    pub fn is_transport_established(&self) -> bool {
+        self.with(|socket| {
+            matches!(
+                socket.state(),
+                tcp::State::Established | tcp::State::CloseWait
+            )
+        })
+    }
+
     /// Transmutes the Connecting state to Established state.
     ///
     /// # Safety

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -477,22 +477,50 @@ impl TcpSocket {
                 }
             }
             inner::Inner::Connecting(connecting) => {
-                connecting.set_shutdown_reset();
-                connecting.with_mut(|socket| socket.abort());
-                post_poll_rounds = core::cmp::max(post_poll_rounds, 128);
-                post_poll_iface = Some(connecting.iface().clone());
+                if connecting.is_transport_established() {
+                    let established = unsafe { connecting.into_established() };
 
-                // For Connecting sockets, only SHUT_WR is meaningful for user-visible
-                // send() behavior (EPIPE). Recording SHUT_RD would incorrectly make
-                // recv() return EOF on an unconnected stream socket.
-                (
-                    inner::Inner::Connecting(connecting),
+                    if how.contains(ShutdownBit::SHUT_RD) {
+                        let queued = established.with(|socket| socket.recv_queue());
+                        self.recv_shutdown.init(queued);
+                    }
+
                     if how.contains(ShutdownBit::SHUT_WR) {
-                        ShutdownBit::SHUT_WR
-                    } else {
-                        ShutdownBit::from_bits_truncate(0)
-                    },
-                )
+                        let pending = established.with(|socket| socket.send_queue());
+                        if pending > 0 {
+                            self.send_fin_deferred
+                                .store(true, core::sync::atomic::Ordering::Relaxed);
+                        } else if self
+                            .send_fin_deferred
+                            .load(core::sync::atomic::Ordering::Relaxed)
+                        {
+                            // FIN will be sent once deferred bytes are fully flushed.
+                        } else {
+                            established.with_mut(|socket| socket.close());
+                        }
+                        post_poll_rounds = core::cmp::max(post_poll_rounds, 8);
+                        post_poll_iface = Some(established.iface().clone());
+                    }
+
+                    (inner::Inner::Established(established), how)
+                } else {
+                    connecting.set_shutdown_reset();
+                    connecting.with_mut(|socket| socket.abort());
+                    post_poll_rounds = core::cmp::max(post_poll_rounds, 128);
+                    post_poll_iface = Some(connecting.iface().clone());
+
+                    // For still-connecting sockets, only SHUT_WR is meaningful for
+                    // user-visible send() behavior (EPIPE). Recording SHUT_RD would
+                    // incorrectly make recv() return EOF on an unconnected stream socket.
+                    (
+                        inner::Inner::Connecting(connecting),
+                        if how.contains(ShutdownBit::SHUT_WR) {
+                            ShutdownBit::SHUT_WR
+                        } else {
+                            ShutdownBit::from_bits_truncate(0)
+                        },
+                    )
+                }
             }
             inner::Inner::SelfConnected(sc) => {
                 // SelfConnected: shutdown affects only the user-visible data path.

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -477,19 +477,10 @@ impl TcpSocket {
                 }
             }
             inner::Inner::Connecting(connecting) => {
-                if how.contains(ShutdownBit::SHUT_RD) {
-                    connecting.with_mut(|socket| {
-                        socket.abort();
-                    });
-                    post_poll_rounds = core::cmp::max(post_poll_rounds, 128);
-                    post_poll_iface = Some(connecting.iface().clone());
-                }
-
-                if how.contains(ShutdownBit::SHUT_WR) {
-                    connecting.with_mut(|socket| socket.close());
-                    post_poll_rounds = core::cmp::max(post_poll_rounds, 8);
-                    post_poll_iface = Some(connecting.iface().clone());
-                }
+                connecting.set_shutdown_reset();
+                connecting.with_mut(|socket| socket.abort());
+                post_poll_rounds = core::cmp::max(post_poll_rounds, 128);
+                post_poll_iface = Some(connecting.iface().clone());
 
                 // For Connecting sockets, only SHUT_WR is meaningful for user-visible
                 // send() behavior (EPIPE). Recording SHUT_RD would incorrectly make
@@ -599,6 +590,9 @@ impl TcpSocket {
 
                 if conn.failure_reason().is_some() {
                     conn.consume_error();
+                    let (new_inner, _) = conn.into_result();
+                    writer.replace(new_inner);
+                } else if conn.is_refused_consumed() {
                     let (new_inner, _) = conn.into_result();
                     writer.replace(new_inner);
                 } else {


### PR DESCRIPTION
## Summary

Fix TCP connecting socket shutdown readiness to match Linux/gVisor semantics.

When a nonblocking TCP socket is still connecting, `shutdown(SHUT_RD/SHUT_WR/SHUT_RDWR)` should put the socket into an error state. `poll(events=0)` must immediately report `POLLHUP | POLLERR` for the gVisor `Shutdown*ConnectingSocket` cases.

## Root Cause

DragonOS only drove the underlying smoltcp connecting socket with `abort()`/`close()`. After that, `Connecting::update_io_events()` could observe a closed socket with valid endpoints and classify it as `Connected`, clearing the HUP/ERR readiness bits. This made `poll()` return 0 for the gVisor failure case.

## Changes

- Add explicit `ShutdownReset` connecting-result states.
- Treat shutdown of a connecting TCP socket as a reset-style asynchronous error (`ECONNRESET`).
- Keep HUP/ERR readiness stable for the connecting-shutdown terminal state.
- Handle consumed connecting errors in close cleanup without forcing the socket into Established.

## Validation

Inside DragonOS QEMU guest:

```text
cd /opt/tests/gvisor/tests
./tcp_socket_test --gtest_filter='*ShutdownWriteConnectingSocket*:*ShutdownReadWriteConnectingSocket*'
[  PASSED  ] 4 tests.

./tcp_socket_test --gtest_filter=*ShutdownReadConnectingSocket*
[  PASSED  ] 2 tests.

./tcp_socket_test
[==========] 184 tests from 2 test suites ran. (28646 ms total)
[  PASSED  ] 184 tests.
```

Build/format checks:

```text
make kernel
rustfmt +nightly-2026-02-24 --check kernel/src/net/socket/inet/stream/inner.rs kernel/src/net/socket/inet/stream/lifecycle.rs
git diff --check
```
