### PR TITLE
fix(mm): preserve mapped pages during cache truncate

### DIFF
--- a/kernel/src/arch/x86_64/interrupt/trap.rs
+++ b/kernel/src/arch/x86_64/interrupt/trap.rs
@@ -10,8 +10,9 @@ use super::{
 use crate::exception::debug::DebugException;
 use crate::exception::ebreak::EBreak;
 use crate::{
-    arch::{CurrentIrqArch, MMArch},
+    arch::{ipc::signal::Signal, CurrentIrqArch, MMArch},
     exception::InterruptArch,
+    ipc::signal::force_kernel_signal_to_current,
     mm::VirtAddr,
     process::ProcessManager,
     smp::core::smp_get_processor_id,
@@ -319,6 +320,20 @@ unsafe extern "C" fn do_stack_segment_fault(regs: &'static TrapFrame, error_code
 /// 处理一般保护异常 13 #GP
 #[no_mangle]
 unsafe extern "C" fn do_general_protection(regs: &'static TrapFrame, error_code: u64) {
+    if regs.is_from_user() {
+        CurrentIrqArch::interrupt_enable();
+        if let Err(err) = force_kernel_signal_to_current(Signal::SIGSEGV) {
+            error!(
+                "failed to send SIGSEGV for user general protection fault, pid: {:?}, rip: {:#x}, error_code: {:#x}, err: {:?}",
+                ProcessManager::current_pid(),
+                regs.rip,
+                error_code,
+                err
+            );
+        }
+        return;
+    }
+
     const ERR_MSG_1: &str = "The exception occurred during delivery of an event external to the program, such as an interrupt or an earlier exception.";
     const ERR_MSG_2: &str = "Refers to a gate descriptor in the IDT;\n";
     const ERR_MSG_3: &str = "Refers to a descriptor in the GDT or the current LDT;\n";

--- a/kernel/src/exception/entry.rs
+++ b/kernel/src/exception/entry.rs
@@ -43,6 +43,7 @@ unsafe fn exit_to_user_mode_loop(frame: &mut TrapFrame, mut process_flags_work: 
         // rseq 的 IP fixup 必须在信号递送之前完成
         if process_flags_work.contains(ProcessFlags::NEED_RSEQ) {
             let _ = Rseq::handle_notify_resume(Some(frame));
+            process_flags_work = *ProcessManager::current_pcb().flags();
         }
 
         if process_flags_work.contains(ProcessFlags::HAS_PENDING_SIGNAL) {

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -1287,10 +1287,20 @@ impl PageCache {
                     _ => {}
                 }
 
-                if let Some(page) = self.inner.lock().remove_page(page_index) {
+                let removed_page = {
+                    let mut guard = self.inner.lock();
+                    guard.remove_page(page_index)
+                };
+                if let Some(page) = removed_page {
                     let paddr = page.phys_address();
-                    page_manager_lock().remove_page(&paddr);
+                    let can_remove_from_manager = page.read().can_deallocate();
+                    // The page is no longer reachable from this page cache, so it must not
+                    // remain on the file-page reclaimer LRU even if existing mappings still
+                    // keep its Page metadata alive via page_manager.
                     let _ = page_reclaimer_lock().remove_page(&paddr);
+                    if can_remove_from_manager {
+                        page_manager_lock().remove_page(&paddr);
+                    }
                 }
                 break;
             }

--- a/user/apps/tests/dunitest/suites/normal/general_protection_signal.cc
+++ b/user/apps/tests/dunitest/suites/normal/general_protection_signal.cc
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+void trigger_user_general_protection_fault() {
+#if defined(__x86_64__)
+    __asm__ __volatile__("int $13");
+#endif
+    _exit(42);
+}
+
+}  // namespace
+
+TEST(GeneralProtectionSignal, UserFaultKillsChildWithSigsegv) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+
+    if (child == 0) {
+        trigger_user_general_protection_fault();
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFSIGNALED(status)) << "child exited with status " << WEXITSTATUS(status);
+    EXPECT_EQ(SIGSEGV, WTERMSIG(status));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -25,3 +25,4 @@ normal/test_procfs_link
 normal/user_namespace_id_map
 normal/tty_tcflush
 normal/signal_fpstate_sigreturn
+normal/general_protection_signal


### PR DESCRIPTION
## Summary
- avoid removing page metadata from the page manager/reclaimer while a page cache page is still mapped by a VMA
- convert user-mode #GP into SIGSEGV instead of panicking the kernel
- add a dunitest regression case for user-mode general protection faults

## Validation
- make kernel

## Notes
- During investigation, the mremap cleanup path could trigger `page drop when map count is non-zero` before later unrelated tests. The page cache should drop its own entry on truncate, but the physical page metadata must stay owned by the memory subsystem until the page is actually unmapped and deallocatable.