### PR TITLE
feat(pi_lock): feat pi_lock and fix lock

### DIFF
--- a/docs/kernel/sched/fifo.md
+++ b/docs/kernel/sched/fifo.md
@@ -47,7 +47,7 @@ pub struct FifoRunQueue {
 
 ### 3.2 抢占机制
 
-**check_preempt_currnet()**：当有新进程被唤醒时，检查是否需要抢占当前进程
+**check_preempt_current()**：当有新进程被唤醒时，检查是否需要抢占当前进程
 - 如果新进程优先级更高，触发抢占
 - 支持实时任务与普通任务之间的抢占
 

--- a/docs/locales/en/kernel/sched/fifo.md
+++ b/docs/locales/en/kernel/sched/fifo.md
@@ -62,7 +62,7 @@ pub struct FifoRunQueue {
 
 ### 3.2 Preemption Mechanism
 
-**check_preempt_currnet()**: When a new process is awakened, check whether the current process needs to be preempted.
+**check_preempt_current()**: When a new process is awakened, check whether the current process needs to be preempted.
 - If the new process has a higher priority, trigger preemption.
 - Supports preemption between real-time tasks and normal tasks.
 

--- a/flake.nix
+++ b/flake.nix
@@ -142,8 +142,8 @@
                 # QEMU 相关参数：
                 # 内核位置
                 kernel = "${buildDir}/kernel/kernel.elf"; # TODO: make it a drv 用nix构建内核，避免指定相对目录
-                # GDB stub (controlled by debug flag)
-                debug = true;
+                # 不开 GDB stub，普通启动
+                debug = false;
                 enableVsock = vsockConfig.enable;
                 vsockGuestCid = vsockConfig.guestCid;
                 vsockDeviceModel = vsockConfig.deviceModel;
@@ -170,9 +170,28 @@
                 # 优先使用系统 QEMU，避免 Nix 下载 QEMU 依赖
                 preferSystemQemu = true;
               };
+              qemuScriptsDebug = import ./tools/qemu/default.nix {
+                inherit
+                  lib
+                  pkgs
+                  testOpt
+                  diskPath
+                  ;
+                # QEMU 相关参数：
+                # 内核位置
+                kernel = "${buildDir}/kernel/kernel.elf";
+                # 开启 GDB stub，用于调试
+                debug = true;
+                enableVsock = vsockConfig.enable;
+                vsockGuestCid = vsockConfig.guestCid;
+                vsockDeviceModel = vsockConfig.deviceModel;
+                # 启用 VM 状态管理，与 make qemu 行为保持一致
+                vmstateDir = "${buildDir}/vmstate";
+              };
 
               startPkg = qemuScripts.${target};
               startSystemPkg = qemuScriptsSystem.${target};
+              startDebugPkg = qemuScriptsDebug.${target};
               rootfsPkg = pkgs.callPackage ./user/default.nix {
                 inherit
                   lib
@@ -194,7 +213,7 @@
                 GDB_PORT_FILE="${buildDir}/vmstate/gdb"
                 if [ ! -f "$GDB_PORT_FILE" ]; then
                   echo "Error: VM not running or GDB port not allocated"
-                  echo "Start VM first: nix run .#start-''${target}"
+                  echo "Start VM first: nix run .#start-debug-''${target}"
                   exit 1
                 fi
                 GDB_PORT=$(cat "$GDB_PORT_FILE")
@@ -242,6 +261,11 @@
                   program = "${startSystemPkg}/bin/dragonos-run";
                   meta.description = "以系统 QEMU 启动DragonOS (${target})";
                 };
+                "start-debug-${target}" = {
+                  type = "app";
+                  program = "${startDebugPkg}/bin/dragonos-run";
+                  meta.description = "以调试模式启动DragonOS (开启GDB stub, ${target})";
+                };
                 # rootfs 中涉及到基于docker镜像的rootfs构建，修改了 user/ 下软件包相关内容后，
                 # rootfs 的docker镜像会重复构建，并且由于nix特性，副本会全部保留
                 # 因此可能会占很多空间，如果要清理空间请执行 nix store gc
@@ -260,6 +284,7 @@
                 "yolo-${target}" = runApp;
                 "start-${target}" = startPkg;
                 "start-system-${target}" = startSystemPkg;
+                "start-debug-${target}" = startDebugPkg;
                 "rootfs-${target}" = rootfsPkg;
                 "gdb-${target}" = gdbScript;
               };

--- a/flake.nix
+++ b/flake.nix
@@ -109,11 +109,15 @@
 
           testOpt = {
             # 自动测试项目，指定内核启动环境变量参数 AUTO_TEST
-            autotest = "none";
+            autotest = "none"; # syscall / dunit
             syscall = {
               enable = true;
               testDir = "/opt/gvisor";
               version = "20251218";
+            };
+            dunitest = {
+              enable = true;
+              testDir = "/opt/tests/dunitest";
             };
           };
 
@@ -138,8 +142,8 @@
                 # QEMU 相关参数：
                 # 内核位置
                 kernel = "${buildDir}/kernel/kernel.elf"; # TODO: make it a drv 用nix构建内核，避免指定相对目录
-                # -s -S
-                debug = false;
+                # GDB stub (controlled by debug flag)
+                debug = true;
                 enableVsock = vsockConfig.enable;
                 vsockGuestCid = vsockConfig.guestCid;
                 vsockDeviceModel = vsockConfig.deviceModel;
@@ -183,6 +187,23 @@
                   diskPath
                   ;
               };
+
+              gdbBin = if target == "x86_64" then "rust-gdb" else "gdb-multiarch";
+              gdbScript = pkgs.writeScriptBin "dragonos-gdb" ''
+                #!${pkgs.runtimeShell}
+                GDB_PORT_FILE="${buildDir}/vmstate/gdb"
+                if [ ! -f "$GDB_PORT_FILE" ]; then
+                  echo "Error: VM not running or GDB port not allocated"
+                  echo "Start VM first: nix run .#start-''${target}"
+                  exit 1
+                fi
+                GDB_PORT=$(cat "$GDB_PORT_FILE")
+                GDB_INIT_TMP=$(mktemp)
+                trap "rm -f $GDB_INIT_TMP" EXIT
+                sed "s/{{GDB_PORT}}/$GDB_PORT/" ${./tools/.gdbinit} > "$GDB_INIT_TMP"
+                echo "Connecting to GDB port: $GDB_PORT"
+                exec ${gdbBin} -n -x "$GDB_INIT_TMP"
+              '';
 
               # 一键化构建启动脚本 (yolo: You Only Live Once - 一条命令跑通全部)
               runApp = pkgs.writeScriptBin "dragonos-yolo" ''
@@ -229,12 +250,18 @@
                   program = "${rootfsPkg}/bin/dragonos-rootfs";
                   meta.description = "构建 ${target} rootfs 镜像";
                 };
+                "gdb-${target}" = {
+                  type = "app";
+                  program = "${gdbScript}/bin/dragonos-gdb";
+                  meta.description = "Connect GDB to running DragonOS (${target})";
+                };
               };
               packages = {
                 "yolo-${target}" = runApp;
                 "start-${target}" = startPkg;
                 "start-system-${target}" = startSystemPkg;
                 "rootfs-${target}" = rootfsPkg;
+                "gdb-${target}" = gdbScript;
               };
             };
 

--- a/kernel/src/arch/riscv64/process/kthread.rs
+++ b/kernel/src/arch/riscv64/process/kthread.rs
@@ -41,6 +41,7 @@ impl KernelThreadMechanism {
         // fork失败的话，子线程不会执行。否则将导致内存安全问题。
         let mut clone_args = KernelCloneArgs::new();
         clone_args.flags = clone_flags;
+        clone_args.kthread = true;
         if info
             .flags()
             .contains(crate::process::kthread::KernelThreadFlags::IS_PER_CPU)

--- a/kernel/src/arch/x86_64/process/kthread.rs
+++ b/kernel/src/arch/x86_64/process/kthread.rs
@@ -43,6 +43,7 @@ impl KernelThreadMechanism {
         // fork失败的话，子线程不会执行。否则将导致内存安全问题。
         let mut clone_args = KernelCloneArgs::new();
         clone_args.flags = clone_flags;
+        clone_args.kthread = true;
         if info
             .flags()
             .contains(crate::process::kthread::KernelThreadFlags::IS_PER_CPU)

--- a/kernel/src/filesystem/procfs/pid/stat.rs
+++ b/kernel/src/filesystem/procfs/pid/stat.rs
@@ -135,10 +135,7 @@ impl FileOps for StatFileOps {
             let basic = pcb.basic();
             (basic.name().to_string(), basic.user_vm())
         };
-        let state = {
-            let sched = pcb.sched_info();
-            sched.inner_lock_read_irqsave().state()
-        };
+        let state = pcb.sched_info().state();
         let tty_nr = {
             pcb.sig_info_irqsave()
                 .tty()
@@ -148,13 +145,8 @@ impl FileOps for StatFileOps {
         let cpu_time = pcb.cputime();
         let utime = ns_to_clock_t(cpu_time.utime.load(Ordering::Relaxed));
         let stime = ns_to_clock_t(cpu_time.stime.load(Ordering::Relaxed));
-        let (priority, nice) = {
-            let prio_data = pcb.sched_info().prio_data();
-            (
-                prio_data.prio as i64,
-                PrioUtil::prio_to_nice(prio_data.static_prio) as i64,
-            )
-        };
+        let priority = pcb.sched_info().prio() as i64;
+        let nice = PrioUtil::prio_to_nice(pcb.sched_info().static_prio()) as i64;
         let num_threads = pcb
             .task_pid_ptr(PidType::TGID)
             .map(|tgid_pid| tgid_pid.tasks_iter(PidType::TGID).count() as i64)

--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -59,12 +59,9 @@ impl StatusFileOps {
             )
         };
 
-        let state = {
-            let sched_info = pcb.sched_info();
-            sched_info.inner_lock_read_irqsave().state()
-        };
-        let cpu_id = pcb
-            .sched_info()
+        let sched_info_guard = pcb.sched_info();
+        let state = sched_info_guard.state();
+        let cpu_id = sched_info_guard
             .on_cpu()
             .map(|cpu| cpu.data() as i32)
             .unwrap_or(-1);
@@ -134,11 +131,6 @@ impl StatusFileOps {
         pdata.append(&mut format!("\nKthread:\t{}", pcb.is_kthread() as usize).into());
         pdata.append(&mut format!("\ncpu_id:\t{}", cpu_id).as_bytes().to_owned());
         pdata.append(&mut format!("\npriority:\t{:?}", priority).as_bytes().to_owned());
-        pdata.append(
-            &mut format!("\npreempt:\t{}", pcb.preempt_count())
-                .as_bytes()
-                .to_owned(),
-        );
 
         pdata.append(&mut format!("\nvrtime:\t{}", vrtime).as_bytes().to_owned());
 

--- a/kernel/src/init/initial_kthread.rs
+++ b/kernel/src/init/initial_kthread.rs
@@ -115,6 +115,9 @@ fn kenrel_init_freeable() -> Result<(), SystemError> {
 }
 
 /// 切换到用户态
+///
+/// DragonOS 的 init 进程以 BSP idle task 身份创建（调度策略为 IDLE），
+/// 此处清除 kthread 标志并将策略改为 CFS，使其作为普通用户进程被调度。
 #[inline(never)]
 fn switch_to_user() -> ! {
     let current_pcb = ProcessManager::current_pcb();
@@ -123,7 +126,10 @@ fn switch_to_user() -> ! {
     current_pcb.flags().remove(ProcessFlags::KTHREAD);
     current_pcb.worker_private().take();
 
-    *current_pcb.sched_info().sched_policy.write_irqsave() = crate::sched::SchedPolicy::CFS;
+    // BSP idle task 的调度策略为 IDLE，必须切换为 CFS 才能被正常调度
+    current_pcb
+        .sched_info()
+        .set_policy(crate::sched::SchedPolicy::CFS);
     drop(current_pcb);
 
     let mut proc_init_info = ProcInitInfo::new("");

--- a/kernel/src/ipc/generic_signal.rs
+++ b/kernel/src/ipc/generic_signal.rs
@@ -476,11 +476,7 @@ fn sig_stop(sig: Signal) {
 fn sig_continue(_sig: Signal) {
     // 默认处理改为最小化：仅在已处于 Stopped 时唤醒停止，让进程继续运行。
     let pcb = ProcessManager::current_pcb();
-    let is_stopped = pcb
-        .sched_info()
-        .inner_lock_read_irqsave()
-        .state()
-        .is_stopped();
+    let is_stopped = pcb.sched_info().state().is_stopped();
     if is_stopped {
         let _ = ProcessManager::wakeup_stop(&pcb);
     }

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -438,7 +438,7 @@ impl Signal {
 
         // 若线程正处于可中断阻塞，且当前在 set_user_sigmask 语义下（如 rt_sigtimedwait/pselect 等）
         // 则无论该信号是否在常规 blocked 集内，都应唤醒，由具体系统调用在返回路径上判定。
-        let state = pcb.sched_info().inner_lock_read_irqsave().state();
+        let state = pcb.sched_info().state();
 
         // SIGCONT：即便被屏蔽或默认忽略，也应唤醒处于 Stopped 的任务，让其继续运行。
         if *self == Signal::SIGCONT && state.is_stopped() {
@@ -459,13 +459,9 @@ impl Signal {
             return false;
         }
 
-        let is_blocked_non_interruptable =
-            state.is_blocked() && (!state.is_blocked_interruptable());
-
-        if is_blocked_non_interruptable {
-            return false;
-        }
-
+        // wants_signal() 不检查 TASK_UNINTERRUPTIBLE / TASK_KILLABLE 状态：
+        // 只要信号未被屏蔽且进程未 stopped/traced，就应该接收信号。
+        // 唤醒与否由 signal_wake_up() / __schedule() 中的 signal_pending_state() 决定。
         return true;
     }
 
@@ -613,6 +609,13 @@ impl Signal {
             // 不应作为“可传递到用户态”的 pending 信号继续入队。
             // 否则在 SIGCONT 后可能错误地以 EINTR/ERESTART* 形式打断正在执行的系统调用（gVisor sigstop_test 即依赖这一点）。
             if *self == Signal::SIGSTOP {
+                // DragonOS 采用异步 stop_task，因此需要在此处补上 schedule。
+                let current = ProcessManager::current_pcb();
+                let is_self_stop =
+                    Arc::ptr_eq(&current, &pcb) || Arc::ptr_eq(&current, &thread_group_leader);
+                if is_self_stop {
+                    crate::sched::schedule(crate::sched::SchedMode::SM_NONE);
+                }
                 return false;
             }
         } else if *self == Signal::SIGCONT {
@@ -628,7 +631,7 @@ impl Signal {
 
             // 仅当确实处于 job-control stopped 时，才报告 continued 事件并通知父进程
             let was_stopped = {
-                let state = pcb.sched_info().inner_lock_read_irqsave().state();
+                let state = pcb.sched_info().state();
                 state.is_stopped()
                     || pcb.sighand().flags_contains(SignalFlags::STOP_STOPPED)
                     || pcb.sighand().flags_contains(SignalFlags::CLD_STOPPED)
@@ -687,7 +690,7 @@ fn signal_wake_up(pcb: Arc<ProcessControlBlock>, fatal: bool) {
     // 如果不是 fatal 的就只唤醒 stop 的进程来响应
     // debug!("signal_wake_up");
     // 如果目标进程已经在运行，则发起一个ipi，使得它陷入内核
-    let state = pcb.sched_info().inner_lock_read_irqsave().state();
+    let state = pcb.sched_info().state();
     let mut wakeup_ok = true;
     if state.is_blocked_interruptable() {
         ProcessManager::wakeup(&pcb).unwrap_or_else(|e| {

--- a/kernel/src/libs/rwlock.rs
+++ b/kernel/src/libs/rwlock.rs
@@ -176,10 +176,13 @@ impl<T> RwLock<T> {
     }
 
     /// 关中断并获取读者守卫
+    ///
+    /// 等价于 Linux `__raw_read_lock_irqsave`：先关 IRQ 再关抢占，自旋期间两者始终关闭。
     pub fn read_irqsave(&self) -> RwLockReadGuard<'_, T> {
+        let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+        ProcessManager::preempt_disable();
         loop {
-            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-            match self.try_read() {
+            match self.inner_try_read() {
                 Some(mut guard) => {
                     guard.irq_guard = Some(irq_guard);
                     return guard;
@@ -240,8 +243,8 @@ impl<T> RwLock<T> {
     #[allow(dead_code)]
     #[inline]
     pub fn try_write_irqsave(&self) -> Option<RwLockWriteGuard<'_, T>> {
-        ProcessManager::preempt_disable();
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+        ProcessManager::preempt_disable();
         let r = self.inner_try_write().map(|mut g| {
             g.irq_guard = Some(irq_guard);
             g
@@ -286,10 +289,13 @@ impl<T> RwLock<T> {
     #[allow(dead_code)]
     #[inline]
     /// @brief 获取WRITER守卫并关中断
+    ///
+    /// 等价于 Linux `__raw_write_lock_irqsave`：先关 IRQ 再关抢占，自旋期间两者始终关闭。
     pub fn write_irqsave(&self) -> RwLockWriteGuard<'_, T> {
+        let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+        ProcessManager::preempt_disable();
         loop {
-            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-            match self.try_write() {
+            match self.inner_try_write() {
                 Some(mut guard) => {
                     guard.irq_guard = Some(irq_guard);
                     return guard;
@@ -353,11 +359,14 @@ impl<T> RwLock<T> {
     }
 
     #[inline]
-    /// @brief 获得UPGRADER守卫
+    /// @brief 获得UPGRADER守卫并关中断
+    ///
+    /// 等价于 Linux irqsave 模式：先关 IRQ 再关抢占，自旋期间两者始终关闭。
     pub fn upgradeable_read_irqsave(&self) -> RwLockUpgradableGuard<'_, T> {
+        let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+        ProcessManager::preempt_disable();
         loop {
-            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-            match self.try_upgradeable_read() {
+            match self.inner_try_upgradeable_read() {
                 Some(mut guard) => {
                     guard.irq_guard = Some(irq_guard);
                     return guard;
@@ -507,8 +516,13 @@ impl<'rwlock, T> RwLockUpgradableGuard<'rwlock, T> {
 
         let inner: &RwLock<T> = self.inner;
         let irq_guard = self.irq_guard.take();
-        // 自动移去UPGRADED比特位
-        mem::drop(self);
+
+        // 手动清除 UPGRADED 位（UpgradableGuard::drop 会做这件事）
+        inner.lock.fetch_and(!UPGRADED, Ordering::Release);
+
+        // forget self 以跳过 UpgradableGuard::drop 中的 preempt_enable
+        // 新的 ReadGuard 接管 preempt_count 所有权
+        mem::forget(self);
 
         RwLockReadGuard {
             data: unsafe { &*inner.data.get() },
@@ -558,11 +572,18 @@ impl<'rwlock, T> RwLockWriteGuard<'rwlock, T> {
         while self.inner.current_reader().is_err() {
             spin_loop();
         }
-        //本质上来说绝对保证没有任何读者
 
         let inner = self.inner;
         let irq_guard = self.irq_guard.take();
-        mem::drop(self);
+
+        // 手动清除 WRITER | UPGRADED 位（WriteGuard::drop 会做这件事）
+        inner
+            .lock
+            .fetch_and(!(WRITER | UPGRADED), Ordering::Release);
+
+        // forget self 以跳过 WriteGuard::drop 中的 preempt_enable
+        // 新的 ReadGuard 接管 preempt_count 所有权
+        mem::forget(self);
 
         return RwLockReadGuard {
             data: unsafe { &*inner.data.get() },
@@ -629,6 +650,8 @@ impl<T> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
         debug_assert!(self.lock.load(Ordering::Relaxed) & !(WRITER | UPGRADED) > 0);
         self.lock.fetch_sub(READER, Ordering::Release);
+        // 先恢复中断，再启用抢占
+        self.irq_guard.take();
         ProcessManager::preempt_enable();
     }
 }
@@ -639,9 +662,10 @@ impl<T> Drop for RwLockUpgradableGuard<'_, T> {
             self.inner.lock.load(Ordering::Relaxed) & (WRITER | UPGRADED),
             UPGRADED
         );
-        self.inner.lock.fetch_sub(UPGRADED, Ordering::AcqRel);
+        self.inner.lock.fetch_and(!UPGRADED, Ordering::Release);
+        // 先恢复中断，再启用抢占
+        self.irq_guard.take();
         ProcessManager::preempt_enable();
-        //这里为啥要AcqRel? Release应该就行了?
     }
 }
 
@@ -651,6 +675,7 @@ impl<T> Drop for RwLockWriteGuard<'_, T> {
         self.inner
             .lock
             .fetch_and(!(WRITER | UPGRADED), Ordering::Release);
+        // 先恢复中断，再启用抢占
         self.irq_guard.take();
         ProcessManager::preempt_enable();
     }

--- a/kernel/src/libs/spinlock.rs
+++ b/kernel/src/libs/spinlock.rs
@@ -33,10 +33,11 @@ pub struct SpinLockGuard<'a, T: 'a> {
 
 /// `spin_lock_bh` 风格的守卫：持锁期间屏蔽本 CPU 的 softirq/tasklet 执行（不关硬中断）。
 ///
-/// Drop 顺序：先解锁，再恢复 BH（等价于 Linux 的 `spin_unlock_bh`）。
+/// Drop 顺序：先解锁(guard)，再恢复 BH。等价于 Linux 的 `spin_unlock_bh`。
+/// Rust 按字段声明顺序 drop，因此 guard 必须在 bh 前面。
 pub struct SpinLockBhGuard<'a, T: 'a> {
-    bh: LocalBhDisableGuard,
     guard: SpinLockGuard<'a, T>,
+    bh: LocalBhDisableGuard,
 }
 
 impl<'a, T: 'a> SpinLockGuard<'a, T> {
@@ -152,7 +153,6 @@ impl<T> SpinLock<T> {
 
     fn unlock(&self) {
         self.lock.store(false, Ordering::Release);
-        ProcessManager::preempt_enable();
     }
 
     pub fn is_locked(&self) -> bool {
@@ -180,8 +180,9 @@ impl<T> DerefMut for SpinLockGuard<'_, T> {
 impl<T> Drop for SpinLockGuard<'_, T> {
     fn drop(&mut self) {
         self.lock.unlock();
-        // restore irq
+        // 先恢复中断，再启用抢占
         self.irq_flag.take();
+        ProcessManager::preempt_enable();
     }
 }
 

--- a/kernel/src/libs/wait_queue.rs
+++ b/kernel/src/libs/wait_queue.rs
@@ -857,13 +857,10 @@ fn block_current_impl(
         // Handle a wake racing between prepare_sleep and mark_sleep.
         if waiter.waker.consume_notification() {
             let pcb = ProcessManager::current_pcb();
-            let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-            if matches!(writer.state(), ProcessState::Blocked(_)) {
-                writer.set_state(ProcessState::Runnable);
-                writer.set_wakeup();
+            if pcb.sched_info().state().is_blocked() {
+                pcb.sched_info().set_state(ProcessState::Runnable);
             }
             pcb.flags().remove(ProcessFlags::NEED_SCHEDULE);
-            drop(writer);
             drop(irq_guard);
             return Ok(());
         }
@@ -904,13 +901,10 @@ fn block_current_killable(waiter: &Waiter) -> Result<(), SystemError> {
 
         if waiter.waker.consume_notification() {
             let pcb = ProcessManager::current_pcb();
-            let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-            if matches!(writer.state(), ProcessState::Blocked(_)) {
-                writer.set_state(ProcessState::Runnable);
-                writer.set_wakeup();
+            if pcb.sched_info().state().is_blocked() {
+                pcb.sched_info().set_state(ProcessState::Runnable);
             }
             pcb.flags().remove(ProcessFlags::NEED_SCHEDULE);
-            drop(writer);
             drop(irq_guard);
             return Ok(());
         }

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -163,8 +163,7 @@ impl PageFaultHandler {
         let vma = pfm.vma();
         let current_pcb = ProcessManager::current_pcb();
         {
-            let mut guard = current_pcb.sched_info().inner_lock_write_irqsave();
-            guard.set_state(ProcessState::Runnable);
+            current_pcb.sched_info().set_state(ProcessState::Runnable);
         }
 
         if !MMArch::vma_access_permitted(

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -385,13 +385,12 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                         }
                         has_waitable_child = true;
 
-                        let sched_guard = pcb.sched_info().inner_lock_read_irqsave();
-                        let state = sched_guard.state();
+                        let state = pcb.sched_info().state();
                         if !pcb.is_zombie() {
                             all_waitable_children_exited = false;
                         }
 
-                        if matches!(state, ProcessState::Stopped)
+                        if state.is_stopped()
                             && kwo.options.contains(WaitOption::WSTOPPED)
                             && pcb.sighand().flags_contains(SignalFlags::CLD_STOPPED)
                         {
@@ -408,7 +407,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                             }
                             scan_result = Some(Ok((*pid).into()));
-                            drop(sched_guard);
+
                             break;
                         } else if kwo.options.contains(WaitOption::WCONTINUED)
                             && pcb.sighand().flags_contains(SignalFlags::CLD_CONTINUED)
@@ -425,15 +424,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                             }
                             scan_result = Some(Ok((*pid).into()));
-                            drop(sched_guard);
+
                             break;
                         } else if pcb.is_zombie() && kwo.options.contains(WaitOption::WEXITED) {
                             if reap_blocked_by_group_exec(&pcb) {
-                                drop(sched_guard);
                                 continue;
                             }
                             let Some(code) = state.exit_code() else {
-                                drop(sched_guard);
                                 continue;
                             };
                             let raw = code as i32;
@@ -449,17 +446,15 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                             let child_rusage = fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 if !pcb.try_mark_dead_from_zombie() {
-                                    drop(sched_guard);
                                     continue;
                                 }
                                 account_reaped_child_rusage(&child_rusage);
                                 pid_to_release = Some(pcb.raw_pid());
                             }
                             scan_result = Some(Ok((*pid).into()));
-                            drop(sched_guard);
+
                             break;
                         }
-                        drop(sched_guard);
                     }
                     drop(rd_children);
                     if let Some(pid) = pid_to_release {
@@ -505,13 +500,12 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                             }
                             has_waitable_child = true;
 
-                            let sched_guard = pcb.sched_info().inner_lock_read_irqsave();
-                            let state = sched_guard.state();
+                            let state = pcb.sched_info().state();
                             if !pcb.is_zombie() {
                                 all_waitable_children_exited = false;
                             }
 
-                            if matches!(state, ProcessState::Stopped)
+                            if state.is_stopped()
                                 && kwo.options.contains(WaitOption::WSTOPPED)
                                 && pcb.sighand().flags_contains(SignalFlags::CLD_STOPPED)
                             {
@@ -528,7 +522,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                                 }
                                 scan_result = Some(Ok((*pid).into()));
-                                drop(sched_guard);
+
                                 break;
                             } else if kwo.options.contains(WaitOption::WCONTINUED)
                                 && pcb.sighand().flags_contains(SignalFlags::CLD_CONTINUED)
@@ -545,15 +539,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                                 }
                                 scan_result = Some(Ok((*pid).into()));
-                                drop(sched_guard);
+
                                 break;
                             } else if pcb.is_zombie() && kwo.options.contains(WaitOption::WEXITED) {
                                 if reap_blocked_by_group_exec(&pcb) {
-                                    drop(sched_guard);
                                     continue;
                                 }
                                 let Some(code) = state.exit_code() else {
-                                    drop(sched_guard);
                                     continue;
                                 };
                                 let raw = code as i32;
@@ -569,17 +561,15 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 let child_rusage = fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     if !pcb.try_mark_dead_from_zombie() {
-                                        drop(sched_guard);
                                         continue;
                                     }
                                     account_reaped_child_rusage(&child_rusage);
                                     pid_to_release = Some(pcb.raw_pid());
                                 }
                                 scan_result = Some(Ok((*pid).into()));
-                                drop(sched_guard);
+
                                 break;
                             }
-                            drop(sched_guard);
                         }
                         drop(rd_childen);
                         if let Some(pid) = pid_to_release {
@@ -661,13 +651,12 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                         }
                         has_matching_child = true;
 
-                        let sched_guard = pcb.sched_info().inner_lock_read_irqsave();
-                        let state = sched_guard.state();
+                        let state = pcb.sched_info().state();
                         if !pcb.is_zombie() {
                             all_matching_children_exited = false;
                         }
 
-                        if matches!(state, ProcessState::Stopped)
+                        if state.is_stopped()
                             && kwo.options.contains(WaitOption::WSTOPPED)
                             && pcb.sighand().flags_contains(SignalFlags::CLD_STOPPED)
                         {
@@ -683,7 +672,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                             }
-                            drop(sched_guard);
+
                             scan_result = Some(Ok(pcb.task_pid_vnr().into()));
                             break;
                         } else if kwo.options.contains(WaitOption::WCONTINUED)
@@ -700,16 +689,14 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                             }
-                            drop(sched_guard);
+
                             scan_result = Some(Ok(pcb.task_pid_vnr().into()));
                             break;
                         } else if pcb.is_zombie() && kwo.options.contains(WaitOption::WEXITED) {
                             if reap_blocked_by_group_exec(&pcb) {
-                                drop(sched_guard);
                                 continue;
                             }
                             let Some(code) = state.exit_code() else {
-                                drop(sched_guard);
                                 continue;
                             };
                             let raw = code as i32;
@@ -725,17 +712,15 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                             let child_rusage = fill_wait_rusage(&pcb, kwo);
                             if !kwo.options.contains(WaitOption::WNOWAIT) {
                                 if !pcb.try_mark_dead_from_zombie() {
-                                    drop(sched_guard);
                                     continue;
                                 }
                                 account_reaped_child_rusage(&child_rusage);
                                 pid_to_release = Some(pcb.raw_pid());
                             }
-                            drop(sched_guard);
+
                             scan_result = Some(Ok(pcb.task_pid_vnr().into()));
                             break;
                         }
-                        drop(sched_guard);
                     }
                     drop(rd_children);
                     if let Some(pid) = pid_to_release {
@@ -792,14 +777,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                             }
                             has_matching_child = true;
 
-                            let sched_guard = pcb.sched_info().inner_lock_read_irqsave();
-                            let state = sched_guard.state();
+                            let state = pcb.sched_info().state();
 
                             if !pcb.is_zombie() {
                                 all_matching_children_exited = false;
                             }
 
-                            if matches!(state, ProcessState::Stopped)
+                            if state.is_stopped()
                                 && kwo.options.contains(WaitOption::WSTOPPED)
                                 && pcb.sighand().flags_contains(SignalFlags::CLD_STOPPED)
                             {
@@ -816,7 +800,7 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_STOPPED);
                                 }
                                 scan_result = Some(Ok(pcb.task_pid_vnr().into()));
-                                drop(sched_guard);
+
                                 break;
                             } else if kwo.options.contains(WaitOption::WCONTINUED)
                                 && pcb.sighand().flags_contains(SignalFlags::CLD_CONTINUED)
@@ -833,15 +817,13 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                     pcb.sighand().flags_remove(SignalFlags::CLD_CONTINUED);
                                 }
                                 scan_result = Some(Ok(pcb.task_pid_vnr().into()));
-                                drop(sched_guard);
+
                                 break;
                             } else if pcb.is_zombie() && kwo.options.contains(WaitOption::WEXITED) {
                                 if reap_blocked_by_group_exec(&pcb) {
-                                    drop(sched_guard);
                                     continue;
                                 }
                                 let Some(code) = state.exit_code() else {
-                                    drop(sched_guard);
                                     continue;
                                 };
                                 let raw = code as i32;
@@ -857,17 +839,15 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
                                 let child_rusage = fill_wait_rusage(&pcb, kwo);
                                 if !kwo.options.contains(WaitOption::WNOWAIT) {
                                     if !pcb.try_mark_dead_from_zombie() {
-                                        drop(sched_guard);
                                         continue;
                                     }
                                     account_reaped_child_rusage(&child_rusage);
                                     pid_to_release = Some(pcb.raw_pid());
                                 }
                                 scan_result = Some(Ok(pcb.task_pid_vnr().into()));
-                                drop(sched_guard);
+
                                 break;
                             }
-                            drop(sched_guard);
                         }
                         drop(rd_children);
                         if let Some(pid) = pid_to_release {
@@ -959,7 +939,7 @@ fn do_waitpid(
         return Some(Ok(child_pcb.raw_pid().data()));
     }
 
-    let state = child_pcb.sched_info().inner_lock_read_irqsave().state();
+    let state = child_pcb.sched_info().state();
     // 获取退出码
     match state {
         ProcessState::Runnable => {
@@ -1077,7 +1057,7 @@ impl ProcessControlBlock {
         //     "Process {} is exiting, group_dead: {}, state: {:?}",
         //     self.raw_pid(),
         //     group_dead,
-        //     self.sched_info().inner_lock_read_irqsave().state()
+        //     self.sched_info().state()
         // );
         if group_dead {
             tty = sig_guard.tty();

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -310,24 +310,20 @@ impl ProcessManager {
         kthread: bool,
         new_pcb: &Arc<ProcessControlBlock>,
     ) -> Result<(), SystemError> {
-        // 先复制父进程的 flags
         let parent_flags = *ProcessManager::current_pcb().flags();
-
-        // DragonOS 无 SUPERPRIV/WQ_WORKER/IDLE/NO_SETAFFINITY 的对应，暂时只清 KTHREAD。
-        *new_pcb.flags.get_mut() = parent_flags & !ProcessFlags::KTHREAD;
+        let mut child_flags = parent_flags.fork_inherited();
 
         // KTHREAD 不通过继承传递，而是由创建参数显式赋予。
         if kthread {
-            new_pcb.flags().insert(ProcessFlags::KTHREAD);
+            child_flags.insert(ProcessFlags::KTHREAD);
         }
 
-        // 然后根据 clone_flags 设置需要的标志
         if clone_flags.contains(CloneFlags::CLONE_VFORK) {
-            new_pcb.flags().insert(ProcessFlags::VFORK);
+            child_flags.insert(ProcessFlags::VFORK);
         }
+        child_flags.insert(ProcessFlags::FORKNOEXEC);
 
-        // 标记新进程还未执行 exec
-        new_pcb.flags().insert(ProcessFlags::FORKNOEXEC);
+        *new_pcb.flags.get_mut() = child_flags;
 
         return Ok(());
     }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -170,13 +170,13 @@ impl KernelCloneArgs {
     }
 
     #[inline]
-    fn target_cpu_is_allowed(allowed: &CpuMask, cpu: ProcessorId) -> bool {
+    fn target_cpu_is_allowed(cpu: ProcessorId, allowed: &CpuMask) -> bool {
         allowed.get(cpu).unwrap_or(false)
     }
 
     #[inline]
     fn validate_target_cpu(cpu: ProcessorId, allowed: &CpuMask) -> Result<(), SystemError> {
-        if Self::target_cpu_is_allowed(allowed, cpu) && Self::target_cpu_is_online(cpu) {
+        if Self::target_cpu_is_allowed(cpu, allowed) && Self::target_cpu_is_online(cpu) {
             Ok(())
         } else {
             Err(SystemError::EINVAL)
@@ -202,7 +202,7 @@ impl KernelCloneArgs {
         let target_cpu = if let Some(target_cpu) = self.target_cpu {
             Self::validate_target_cpu(target_cpu, allowed)?;
             target_cpu
-        } else if Self::target_cpu_is_allowed(allowed, default_cpu)
+        } else if Self::target_cpu_is_allowed(default_cpu, allowed)
             && Self::target_cpu_is_online(default_cpu)
         {
             default_cpu
@@ -290,7 +290,7 @@ impl ProcessManager {
         //     );
         // }
 
-        ProcessManager::wakeup_new_task(&pcb).unwrap_or_else(|e| {
+        ProcessManager::wake_up_new_task(&pcb).unwrap_or_else(|e| {
             panic!(
                 "fork: Failed to wakeup new process, pid: [{:?}]. Error: {:?}",
                 pcb.raw_pid(),
@@ -307,10 +307,19 @@ impl ProcessManager {
 
     fn copy_flags(
         clone_flags: &CloneFlags,
+        kthread: bool,
         new_pcb: &Arc<ProcessControlBlock>,
     ) -> Result<(), SystemError> {
         // 先复制父进程的 flags
-        *new_pcb.flags.get_mut() = *ProcessManager::current_pcb().flags();
+        let parent_flags = *ProcessManager::current_pcb().flags();
+
+        // DragonOS 无 SUPERPRIV/WQ_WORKER/IDLE/NO_SETAFFINITY 的对应，暂时只清 KTHREAD。
+        *new_pcb.flags.get_mut() = parent_flags & !ProcessFlags::KTHREAD;
+
+        // KTHREAD 不通过继承传递，而是由创建参数显式赋予。
+        if kthread {
+            new_pcb.flags().insert(ProcessFlags::KTHREAD);
+        }
 
         // 然后根据 clone_flags 设置需要的标志
         if clone_flags.contains(CloneFlags::CLONE_VFORK) {
@@ -621,7 +630,7 @@ impl ProcessManager {
         clone_args.validate_requested_target_cpu(&pcb.sched_info().cpus_allowed())?;
 
         // 拷贝标志位
-        Self::copy_flags(&clone_flags, pcb).unwrap_or_else(|e| {
+        Self::copy_flags(&clone_flags, clone_args.kthread, pcb).unwrap_or_else(|e| {
             panic!(
                 "fork: Failed to copy flags from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.raw_pid(), pcb.raw_pid(), e
@@ -943,7 +952,7 @@ impl ProcessManager {
             pcb.thread.write_irqsave().set_child_tid = Some(clone_args.child_tid);
         }
 
-        // 新任务的默认落点 CPU 应在 wakeup_new_task() 时再选择；这里只保留显式 hint，
+        // 新任务的默认落点 CPU 应在 wake_up_new_task() 时再选择；这里只保留显式 hint，
         // 以避免 fork 长路径内父任务迁移导致的“过早采样当前 CPU”问题。
         pcb.sched_info().mark_new_task(clone_args.target_cpu);
         sched_cgroup_fork(pcb);

--- a/kernel/src/process/idle.rs
+++ b/kernel/src/process/idle.rs
@@ -61,14 +61,16 @@ impl ProcessManager {
             };
 
             assert!(idle_pcb.sched_info().on_cpu().is_none());
-            idle_pcb.sched_info().set_on_cpu(Some(ProcessorId::new(i)));
-            idle_pcb
-                .sched_info()
-                .set_cpus_allowed(CpuMask::from_cpu(ProcessorId::new(i)));
-            *idle_pcb.sched_info().sched_policy.write_irqsave() = crate::sched::SchedPolicy::IDLE;
 
+            // 锁序：先取 pi_lock，再取 rq_lock（禁止反向）
+            let mut pi_guard = idle_pcb.sched_info().pi_lock_irqsave();
             let rq = cpu_rq(i as usize);
-            let (rq, _guard) = rq.self_lock();
+            let (rq, rq_guard) = rq.self_lock();
+
+            // 在双锁保护下设置 cpus_allowed 和 task_cpu
+            pi_guard.set_cpus_allowed(CpuMask::from_cpu(ProcessorId::new(i)));
+            idle_pcb.sched_info().set_on_cpu(Some(ProcessorId::new(i)));
+
             rq.set_current(Arc::downgrade(&idle_pcb));
             rq.set_idle(Arc::downgrade(&idle_pcb));
             IDLE_CPUS.set(ProcessorId::new(i));
@@ -80,6 +82,15 @@ impl ProcessManager {
                 .sched_entity()
                 .force_mut()
                 .set_cfs(Arc::downgrade(&rq.cfs_rq()));
+
+            // 释放顺序：先 rq_lock，再 pi_lock
+            drop(rq_guard);
+            drop(pi_guard);
+
+            // 在锁外设置调度策略
+            idle_pcb
+                .sched_info()
+                .set_policy(crate::sched::SchedPolicy::IDLE);
 
             v.push(idle_pcb);
         }

--- a/kernel/src/process/kthread.rs
+++ b/kernel/src/process/kthread.rs
@@ -466,7 +466,7 @@ impl KernelThreadMechanism {
 
         ProcessManager::wakeup(pcb).ok();
 
-        if let ProcessState::Exited(code) = pcb.sched_info().inner_lock_read_irqsave().state() {
+        if let ProcessState::Exited(code) = pcb.sched_info().state() {
             return Ok(code);
         }
 
@@ -477,13 +477,7 @@ impl KernelThreadMechanism {
             .as_ref()
             .and_then(|x| x.kernel_thread())
             .map(|x| x.result())
-            .unwrap_or_else(|| {
-                pcb.sched_info()
-                    .inner_lock_read_irqsave()
-                    .state()
-                    .exit_code()
-                    .unwrap_or(0)
-            });
+            .unwrap_or_else(|| pcb.sched_info().state().exit_code().unwrap_or(0));
         Ok(result)
     }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -605,13 +605,13 @@ impl ProcessManager {
                     DequeueFlag::DEQUEUE_STOPPED | DequeueFlag::DEQUEUE_NOCLOCK,
                 );
             } else if !update_clock {
-                // 正在远端 CPU 运行：dequeue + kick
-                // 此处异步 dequeue，远端 CPU 收到 kick 后 __schedule(SM_PREEMPT) 时
-                // stopped task 已不在红黑树中，pick_next_task 不会选中它
-                rq.deactivate_task(
-                    pcb.clone(),
-                    DequeueFlag::DEQUEUE_STOPPED | DequeueFlag::DEQUEUE_NOCLOCK,
-                );
+                // 远端 CPU 上的 current：只设状态 + kick，不在发送端 dequeue。
+                //
+                // 对标 Linux signal_wake_up_state() + kick_process()：
+                //   发送端仅设 TIF_SIGPENDING / NEED_SCHEDULE 并 kick，不做 dequeue。
+                //   远端 CPU 的 __schedule() 看到非 runnable 的 prev 后自行完成唯一一次出队。
+                //
+                // 现在由 __schedule_inner 统一出队路径 + on_rq 守卫保证幂等。
                 kick_cpu(target_cpu).ok();
             }
         }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -5,7 +5,10 @@ use core::{
     intrinsics::unlikely,
     mem::ManuallyDrop,
     str::FromStr,
-    sync::atomic::{compiler_fence, fence, AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
+    sync::atomic::{
+        compiler_fence, fence, AtomicBool, AtomicI32, AtomicU32, AtomicU64, AtomicU8, AtomicUsize,
+        Ordering,
+    },
 };
 
 use alloc::{
@@ -62,9 +65,9 @@ use crate::{
     process::resource::{RLimit64, RLimitID, RUsage},
     rcu::RcuArcSlot,
     sched::{
-        DequeueFlag, EnqueueFlag, OnRq, SchedMode, WakeupFlags, __schedule_with_current,
-        completion::Completion, cpu_rq, enqueue_task_on_cpu, fair::FairSchedEntity, prio::MAX_PRIO,
-        select_task_rq,
+        DequeueFlag, EnqueueFlag, OnRq, SchedMode, SchedPolicy, Scheduler, WakeupFlags,
+        __schedule_with_current, completion::Completion, cpu_is_online, cpu_rq,
+        enqueue_task_on_cpu, fair::FairSchedEntity, prio::MAX_PRIO, rq_is_idle_cpu, select_task_rq,
     },
     smp::{
         core::smp_get_processor_id,
@@ -350,66 +353,7 @@ impl ProcessManager {
     /// 唤醒一个进程
     pub fn wakeup(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         let _guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-        let state = pcb.sched_info().inner_lock_read_irqsave().state();
-        let was_uninterruptible = matches!(state, ProcessState::Blocked(false));
-        if state.is_blocked() {
-            let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-            let state = writer.state();
-            if state.is_blocked() {
-                writer.set_state(ProcessState::Runnable);
-                writer.set_wakeup();
-
-                // avoid deadlock
-                drop(writer);
-
-                pcb.debug_assert_fork_cpu_binding();
-
-                let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
-                let update_clock = target_cpu == smp_get_processor_id();
-                let rq = cpu_rq(target_cpu.data() as usize);
-
-                let (rq, _guard) = rq.self_lock();
-                debug_assert_eq!(
-                    pcb.sched_info().on_cpu(),
-                    Some(rq.cpu()),
-                    "wakeup: on_cpu mismatch with rq.cpu"
-                );
-                if update_clock {
-                    rq.update_rq_clock();
-                }
-                if was_uninterruptible {
-                    rq.dec_nr_uninterruptible();
-                }
-                rq.activate_task(
-                    pcb,
-                    EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
-                );
-
-                if update_clock {
-                    rq.check_preempt_currnet(pcb, WakeupFlags::empty());
-                } else {
-                    rq.check_preempt_remote(pcb, WakeupFlags::empty());
-                }
-
-                // sched_enqueue(pcb.clone(), true);
-                return Ok(());
-            } else if state.is_exited() {
-                return Err(SystemError::EINVAL);
-            } else {
-                return Ok(());
-            }
-        } else if state.is_exited() {
-            return Err(SystemError::EINVAL);
-        } else {
-            return Ok(());
-        }
-    }
-
-    pub fn wakeup_new_task(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
-        let _guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-
-        let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-        let state = writer.state();
+        let state = pcb.sched_info().state();
         if !state.is_blocked() {
             if state.is_exited() {
                 return Err(SystemError::EINVAL);
@@ -417,24 +361,88 @@ impl ProcessManager {
             return Ok(());
         }
 
-        writer.set_state(ProcessState::Runnable);
-        writer.set_wakeup();
-        drop(writer);
+        // 在 pi_lock 保护下读取状态并决定 sched_contributes_to_load
+        let _pi_guard = pcb.sched_info().pi_lock_irqsave();
+        fence(Ordering::SeqCst); // smp_mb__after_spinlock()
+        let state = pcb.sched_info().state();
+        if !state.is_blocked() {
+            if state.is_exited() {
+                return Err(SystemError::EINVAL);
+            }
+            return Ok(());
+        }
+        let was_uninterruptible = matches!(state, ProcessState::Blocked(false));
+
+        pcb.sched_info().set_state(ProcessState::Runnable);
+        fence(Ordering::SeqCst);
+
+        pcb.debug_assert_fork_cpu_binding();
+
+        let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        let update_clock = target_cpu == smp_get_processor_id();
+        let rq = cpu_rq(target_cpu.data() as usize);
+
+        let (rq, _guard) = rq.self_lock();
+        debug_assert_eq!(
+            pcb.sched_info().on_cpu(),
+            Some(rq.cpu()),
+            "wakeup: on_cpu mismatch with rq.cpu"
+        );
+        if update_clock {
+            rq.update_rq_clock();
+        }
+        if was_uninterruptible {
+            rq.dec_nr_uninterruptible();
+        }
+
+        if pcb.flags().contains(ProcessFlags::IN_IOWAIT) {
+            rq.dec_nr_iowait();
+        }
+
+        let was_idle = rq_is_idle_cpu(rq);
+
+        rq.activate_task(
+            pcb,
+            EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
+        );
+
+        if was_idle && !rq_is_idle_cpu(rq) {
+            crate::sched::IDLE_CPUS.clear(target_cpu);
+        }
+
+        if update_clock {
+            rq.check_preempt_current(pcb, WakeupFlags::empty());
+        } else {
+            rq.check_preempt_remote(pcb, WakeupFlags::empty());
+        }
+
+        Ok(())
+    }
+
+    // 在 pi_lock 保护下完成状态写入和 CPU 选择
+    pub fn wake_up_new_task(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
+        let _guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
 
         debug_assert_eq!(*pcb.sched_info().on_rq.lock_irqsave(), OnRq::None);
         debug_assert!(pcb.sched_info().is_new_task());
         debug_assert!(pcb.sched_info().on_cpu().is_none());
 
-        let target_cpu =
-            pcb.sched_info()
-                .consume_new_task_target_cpu(smp_get_processor_id(), |allowed| {
-                    let cpu = select_task_rq(pcb, smp_get_processor_id(), WakeupFlags::WF_FORK);
-                    if allowed.get(cpu).unwrap_or(false) {
-                        Some(cpu)
-                    } else {
-                        None
-                    }
-                })?;
+        let pi_guard = pcb.sched_info().pi_lock_irqsave();
+        pcb.sched_info().set_state(ProcessState::Runnable);
+
+        let target_cpu = pcb.sched_info().consume_new_task_target_cpu(
+            smp_get_processor_id(),
+            pi_guard.cpus_allowed.clone(),
+            |allowed| {
+                let cpu =
+                    select_task_rq(pcb, smp_get_processor_id(), WakeupFlags::WF_FORK, allowed);
+                if allowed.get(cpu).unwrap_or(false) {
+                    Some(cpu)
+                } else {
+                    None
+                }
+            },
+        )?;
 
         enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::WF_FORK);
 
@@ -442,7 +450,10 @@ impl ProcessManager {
         Ok(())
     }
 
-    #[allow(dead_code)]
+    /// 将指定内核线程设置为 SCHED_FIFO 调度策略。
+    ///
+    /// task_rq_lock → update_rq_clock → 读取 queued/running →
+    /// dequeue/put_prev → 修改参数 → enqueue → check_class_changed → unlock
     pub fn set_fifo_policy(pcb: &Arc<ProcessControlBlock>, prio: i32) -> Result<(), SystemError> {
         if !pcb.flags().contains(ProcessFlags::KTHREAD) {
             return Err(SystemError::EPERM);
@@ -454,53 +465,88 @@ impl ProcessManager {
 
         let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
 
-        let on_rq = *pcb.sched_info().on_rq.lock_irqsave();
-        if on_rq == crate::sched::OnRq::Queued {
-            let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
-            let update_clock = target_cpu == smp_get_processor_id();
-            let rq = crate::sched::cpu_rq(target_cpu.data() as usize);
-            let (rq, _guard) = rq.self_lock();
-            if update_clock {
-                rq.update_rq_clock();
-            }
+        // 锁序：pi_lock → rq_lock，与 Linux task_rq_lock() 一致
+        let pi_guard = pcb.sched_info().pi_lock_irqsave();
 
-            let old_policy = pcb.sched_info().policy();
-            if old_policy != crate::sched::SchedPolicy::FIFO {
-                rq.dequeue_task(
-                    pcb.clone(),
-                    crate::sched::DequeueFlag::DEQUEUE_NOCLOCK
-                        | crate::sched::DequeueFlag::DEQUEUE_SAVE,
-                );
-            }
-
-            {
-                *pcb.sched_info().sched_policy.write_irqsave() = crate::sched::SchedPolicy::FIFO;
-                let mut prio_data = pcb.sched_info().prio_data.write_irqsave();
-                prio_data.prio = prio;
-                prio_data.static_prio = prio;
-                prio_data.normal_prio = prio;
-            }
-
-            if old_policy != crate::sched::SchedPolicy::FIFO {
-                rq.enqueue_task(
-                    pcb.clone(),
-                    crate::sched::EnqueueFlag::ENQUEUE_NOCLOCK
-                        | crate::sched::EnqueueFlag::ENQUEUE_RESTORE,
-                );
-            }
-
-            if update_clock {
-                rq.check_preempt_currnet(pcb, crate::sched::WakeupFlags::empty());
-            } else {
-                rq.check_preempt_remote(pcb, crate::sched::WakeupFlags::empty());
-            }
-        } else {
-            *pcb.sched_info().sched_policy.write_irqsave() = crate::sched::SchedPolicy::FIFO;
-            let mut prio_data = pcb.sched_info().prio_data.write_irqsave();
-            prio_data.prio = prio;
-            prio_data.static_prio = prio;
-            prio_data.normal_prio = prio;
+        let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        let update_clock = target_cpu == smp_get_processor_id();
+        let rq = cpu_rq(target_cpu.data() as usize);
+        let (rq, rq_guard) = rq.self_lock();
+        if update_clock {
+            rq.update_rq_clock();
         }
+
+        // 在锁内读取任务状态
+        let old_policy = pcb.sched_info().policy();
+        let queued = *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued;
+
+        // 判断目标是否就是 rq 上正在运行的任务
+        let running = Arc::ptr_eq(&rq.current(), pcb);
+
+        // 先将任务从调度器中摘出，再修改参数，最后重新入队
+        if queued {
+            rq.dequeue_task(
+                pcb.clone(),
+                DequeueFlag::DEQUEUE_NOCLOCK | DequeueFlag::DEQUEUE_SAVE,
+            );
+        }
+
+        // running 任务需要先 put_prev_task 让出当前执行位置
+        if running {
+            match old_policy {
+                SchedPolicy::FIFO => {
+                    crate::sched::fifo::FifoScheduler::put_prev_task(rq, pcb.clone())
+                }
+                SchedPolicy::CFS => {
+                    crate::sched::fair::CompletelyFairScheduler::put_prev_task(rq, pcb.clone())
+                }
+                SchedPolicy::IDLE => {
+                    crate::sched::idle::IdleScheduler::put_prev_task(rq, pcb.clone())
+                }
+                SchedPolicy::RT => todo!("RT scheduler not implemented yet"),
+            }
+        }
+
+        // 修改调度参数（rq_lock 保护下）
+        // 对标 Linux __setscheduler_params + __setscheduler_prio：
+        //   - policy 设为 FIFO
+        //   - prio = normal_prio = MAX_RT_PRIO - 1 - rt_priority（调用者传入的已是内核 prio）
+        //   - static_prio 不动（Linux 只对 fair_policy 修改 static_prio，core.c:7528-7529）
+        pcb.sched_info().set_policy(SchedPolicy::FIFO);
+        pcb.sched_info().set_prio(prio);
+        pcb.sched_info().set_normal_prio(prio);
+
+        // 重新入队
+        if queued {
+            rq.enqueue_task(
+                pcb.clone(),
+                EnqueueFlag::ENQUEUE_NOCLOCK | EnqueueFlag::ENQUEUE_RESTORE,
+            );
+        }
+
+        // 对标 Linux __sched_setscheduler: running 任务修改策略后需要 set_next_task
+        if running {
+            match pcb.sched_info().policy() {
+                SchedPolicy::FIFO => {
+                    crate::sched::fifo::FifoScheduler::set_next_task(rq, pcb.clone());
+                }
+                SchedPolicy::CFS => {
+                    crate::sched::fair::CompletelyFairScheduler::set_next_task(rq, pcb.clone());
+                }
+                _ => {}
+            }
+        }
+
+        // check_class_changed → 抢占检查
+        if update_clock {
+            rq.check_preempt_current(pcb, WakeupFlags::empty());
+        } else {
+            rq.check_preempt_remote(pcb, WakeupFlags::empty());
+        }
+
+        // 释放顺序：先 rq_lock 再 pi_lock，与 Linux task_rq_unlock() 一致
+        drop(rq_guard);
+        drop(pi_guard);
 
         Ok(())
     }
@@ -508,16 +554,13 @@ impl ProcessManager {
     /// 唤醒暂停的进程
     pub fn wakeup_stop(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         let _guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-        let state = pcb.sched_info().inner_lock_read_irqsave().state();
+        let state = pcb.sched_info().state();
         if let ProcessState::Stopped = state {
-            let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-            let state = writer.state();
+            let _pi_guard = pcb.sched_info().pi_lock_irqsave();
+            let state = pcb.sched_info().state();
             if let ProcessState::Stopped = state {
-                writer.set_state(ProcessState::Runnable);
-                // Stopped -> Runnable：必须清理 sleep 标志，否则调度器可能把该任务当作“睡眠出队”处理。
-                writer.set_wakeup();
-                // avoid deadlock
-                drop(writer);
+                pcb.sched_info().set_state(ProcessState::Runnable);
+                fence(Ordering::SeqCst);
 
                 let target_cpu = pcb.sched_info().on_cpu().unwrap_or(smp_get_processor_id());
                 let update_clock = target_cpu == smp_get_processor_id();
@@ -532,18 +575,24 @@ impl ProcessManager {
                 if update_clock {
                     rq.update_rq_clock();
                 }
+
+                let was_idle = rq_is_idle_cpu(rq);
+
                 rq.activate_task(
                     pcb,
                     EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
                 );
 
+                if was_idle && !rq_is_idle_cpu(rq) {
+                    crate::sched::IDLE_CPUS.clear(target_cpu);
+                }
+
                 if update_clock {
-                    rq.check_preempt_currnet(pcb, WakeupFlags::empty());
+                    rq.check_preempt_current(pcb, WakeupFlags::empty());
                 } else {
                     rq.check_preempt_remote(pcb, WakeupFlags::empty());
                 }
 
-                // sched_enqueue(pcb.clone(), true);
                 return Ok(());
             } else if state.is_runnable() {
                 return Ok(());
@@ -561,40 +610,57 @@ impl ProcessManager {
     ///
     /// 注意：该函数用于对“目标进程”进行停止标记，不要求在目标进程上下文调用。
     /// 与 `mark_stop`（仅当前进程）相对应。
+    ///
+    /// Linux 中 stop 由目标线程在自身上下文中完成（设 Stopped + schedule → deactivate）。
+    /// DragonOS 采用异步方式，因此需要在这里主动 dequeue 排队中的任务，
+    /// 防止 `pick_next_task()` 选中 state=Stopped 的任务短暂运行。
+    ///
+    /// 锁序：pi_lock → rq_lock，与 wakeup() / set_fifo_policy() 序列化一致。
     pub fn stop_task(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         let _guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-        let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-        let state = writer.state();
-        if matches!(state, ProcessState::Exited(_)) {
+
+        // 对齐 Linux set_special_state(TASK_STOPPED)：pi_lock 保护状态写入与 exit 检查，
+        // 序列化与 wakeup()/wakeup_stop()/do_exit() 中 pi_lock 保护的并发操作。
+        //
+        // Linux 中 stop 是同步的：目标线程在 get_signal() → do_signal_stop() 中
+        // 调 set_special_state(TASK_STOPPED) + schedule()。
+        // DragonOS 采用异步方式（从发送方上下文停止目标线程），因此需要主动 dequeue
+        // 并 kick 远端 CPU。这是与 Linux 的架构差异，但锁序和 dequeue 语义对标。
+        let pi_guard = pcb.sched_info().pi_lock_irqsave();
+        if pcb.sched_info().state().is_exited() {
             return Err(SystemError::EINTR);
         }
-
-        // Stopped 的任务不应继续留在 runqueue 中，否则仍可能被选中运行。
-        let on_rq = *pcb.sched_info().on_rq.lock_irqsave();
-        writer.set_state(ProcessState::Stopped);
-        // stop 后不应再被视为“睡眠任务”，避免后续调度错误地做 DEQUEUE_SLEEP。
-        writer.set_wakeup();
+        pcb.sched_info().set_state(ProcessState::Stopped);
         pcb.flags().insert(ProcessFlags::NEED_SCHEDULE);
-        drop(writer);
 
-        if on_rq == OnRq::Queued {
-            let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
-            let update_clock = target_cpu == smp_get_processor_id();
-            let rq = cpu_rq(target_cpu.data() as usize);
-            let (rq, _guard) = rq.self_lock();
-            if update_clock {
-                rq.update_rq_clock();
-            }
-            // STOP 使任务不可运行：应从 rq 移除，但这不是 CPU 迁移。
-            // 使用 DEQUEUE_STOPPED 让 OnRq 进入 None，避免后续 activate_task() 走 ENQUEUE_MIGRATED 分支。
+        let target_cpu = pcb.sched_info().on_cpu().unwrap_or_else(current_cpu_id);
+        let update_clock = target_cpu == smp_get_processor_id();
+        let rq = cpu_rq(target_cpu.data() as usize);
+
+        // 锁序 pi_lock → rq_lock，与 wakeup() 一致
+        let (rq, rq_guard) = rq.self_lock();
+        if update_clock {
+            rq.update_rq_clock();
+        }
+
+        let is_current = Arc::ptr_eq(&rq.current(), pcb);
+
+        // 排队中且非 current → 主动 dequeue。
+        // 使用 DEQUEUE_STOPPED 让 on_rq 进入 None（而非 Migrating），
+        if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued && !is_current {
             rq.deactivate_task(
                 pcb.clone(),
                 DequeueFlag::DEQUEUE_STOPPED | DequeueFlag::DEQUEUE_NOCLOCK,
             );
         }
 
-        // 强制让目标 CPU 尽快进入内核并重新调度，缩短 stop 生效延迟。
-        ProcessManager::kick(pcb);
+        // 正在远端 CPU 运行 → 发 IPI 让其尽快进 __schedule()，在那里 deactivate
+        if is_current && !update_clock {
+            kick_cpu(target_cpu).ok();
+        }
+
+        drop(rq_guard);
+        drop(pi_guard);
         Ok(())
     }
 
@@ -611,13 +677,11 @@ impl ProcessManager {
             "interrupt must be disabled before enter ProcessManager::mark_sleep()"
         );
         let pcb = ProcessManager::current_pcb();
-        let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-        if !matches!(writer.state(), ProcessState::Exited(_)) {
-            writer.set_state(ProcessState::Blocked(interruptable));
-            writer.set_sleep();
+        if !pcb.sched_info().state().is_exited() {
+            pcb.sched_info()
+                .set_state(ProcessState::Blocked(interruptable));
             pcb.flags().insert(ProcessFlags::NEED_SCHEDULE);
             fence(Ordering::SeqCst);
-            drop(writer);
             return Ok(());
         }
         return Err(SystemError::EINTR);
@@ -636,12 +700,11 @@ impl ProcessManager {
         );
 
         let pcb = ProcessManager::current_pcb();
-        let mut writer = pcb.sched_info().inner_lock_write_irqsave();
-        if !matches!(writer.state(), ProcessState::Exited(_)) {
-            writer.set_state(ProcessState::Stopped);
+        if !pcb.sched_info().state().is_exited() {
+            // pi_lock 保护 STOPPED 写入，序列化与 wakeup()/wakeup_stop() 的并发。
+            let _pi_guard = pcb.sched_info().pi_lock_irqsave();
+            pcb.sched_info().set_state(ProcessState::Stopped);
             pcb.flags().insert(ProcessFlags::NEED_SCHEDULE);
-            drop(writer);
-
             return Ok(());
         }
         return Err(SystemError::EINTR);
@@ -839,9 +902,12 @@ impl ProcessManager {
             pcb.sig_info_mut().set_tty(None);
 
             // 在最后，调用 exit_notify 之前，设置调度状态为 Exited
-            pcb.sched_info
-                .inner_lock_write_irqsave()
-                .set_state(ProcessState::Exited(exit_code));
+            // 对标 Linux do_task_dead() 中 set_special_state(TASK_DEAD)：
+            // 在 pi_lock 保护下完成状态写入，序列化与 wakeup() 中 pi_lock 保护的并发唤醒。
+            {
+                let _pi_guard = pcb.sched_info.pi_lock_irqsave();
+                pcb.sched_info.set_state(ProcessState::Exited(exit_code));
+            }
             // Linux 语义：zombie 不应出现在 cgroup.procs 中。
             // 必须持有 cgroup_accounting_lock 以避免与 cgroup.procs 写入死锁
             {
@@ -861,14 +927,9 @@ impl ProcessManager {
                 }
             }
 
-            let rq = cpu_rq(smp_get_processor_id().data() as usize);
-            let (rq, guard) = rq.self_lock();
-            rq.update_rq_clock();
-            rq.deactivate_task(
-                pcb.clone(),
-                DequeueFlag::DEQUEUE_SLEEP | DequeueFlag::DEQUEUE_NOCLOCK,
-            );
-            drop(guard);
+            // 对标 Linux do_task_dead()：不在此处手动 deactivate_task。
+            // 任务仍留在 rq 上，由后续 __schedule() 检测到 Exited 状态后
+            // 执行唯一的 deactivate_task，避免双重 dequeue 导致 nr_running 下溢。
 
             // 注意：exit_files() 可能会触发阻塞（例如关闭 FUSE fd 需要等待 daemon 回复），
             // 因此不能在它之前清空 user_vm，否则后续调度切换会遇到 user_vm==None 的普通进程并崩溃。
@@ -1180,6 +1241,15 @@ impl ExitState {
     }
 }
 
+mod state_bits {
+    pub const TASK_RUNNING: u32 = 0x0000;
+    pub const TASK_INTERRUPTIBLE: u32 = 0x0001;
+    pub const TASK_UNINTERRUPTIBLE: u32 = 0x0002;
+    pub const TASK_STOPPED: u32 = 0x0004;
+    pub const TASK_DEAD_MARKER: u32 = 0x0080;
+    pub const EXIT_CODE_SHIFT: u32 = 12;
+}
+
 #[allow(dead_code)]
 impl ProcessState {
     #[inline(always)]
@@ -1217,6 +1287,40 @@ impl ProcessState {
         match self {
             ProcessState::Exited(code) => Some(*code),
             _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn to_u32(self) -> u32 {
+        match self {
+            ProcessState::Runnable => state_bits::TASK_RUNNING,
+            ProcessState::Blocked(true) => state_bits::TASK_INTERRUPTIBLE,
+            ProcessState::Blocked(false) => state_bits::TASK_UNINTERRUPTIBLE,
+            ProcessState::Stopped => state_bits::TASK_STOPPED,
+            ProcessState::Exited(code) => {
+                state_bits::TASK_DEAD_MARKER | ((code as u32) << state_bits::EXIT_CODE_SHIFT)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn from_u32(val: u32) -> Self {
+        if val & state_bits::TASK_DEAD_MARKER != 0 {
+            let code = (val >> state_bits::EXIT_CODE_SHIFT) as usize;
+            ProcessState::Exited(code)
+        } else {
+            match val {
+                v if v == state_bits::TASK_RUNNING => ProcessState::Runnable,
+                v if v == state_bits::TASK_INTERRUPTIBLE => ProcessState::Blocked(true),
+                v if v == state_bits::TASK_UNINTERRUPTIBLE => ProcessState::Blocked(false),
+                v if v == state_bits::TASK_STOPPED => ProcessState::Stopped,
+                _ => {
+                    panic!(
+                        "ProcessState::from_u32: corrupted state value 0x{val:08x}, \
+                         this indicates memory corruption or a kernel bug"
+                    );
+                }
+            }
         }
     }
 }
@@ -2372,17 +2476,11 @@ impl ProcessControlBlock {
     }
 
     pub fn is_exited(&self) -> bool {
-        self.sched_info
-            .inner_lock_read_irqsave()
-            .state()
-            .is_exited()
+        self.sched_info.state().is_exited()
     }
 
     pub fn exit_code(&self) -> Option<usize> {
-        self.sched_info
-            .inner_lock_read_irqsave()
-            .state()
-            .exit_code()
+        self.sched_info.state().exit_code()
     }
 
     pub fn exit_state(&self) -> ExitState {
@@ -2675,7 +2773,8 @@ pub struct ProcessSchedulerInfo {
     /// 如果当前进程等待被迁移到另一个cpu核心上（也就是flags中的PF_NEED_MIGRATE被置位），
     /// 该字段存储要被迁移到的目标处理器核心号
     migrate_to: AtomicProcessorId,
-    inner_locked: RwLock<InnerSchedInfo>,
+    state_atomic: AtomicU32,
+    pi_lock: SpinLock<PiProtected>,
     /// 进程的调度优先级
     // priority: SchedPriority,
     /// 当前进程的虚拟运行时间
@@ -2683,16 +2782,17 @@ pub struct ProcessSchedulerInfo {
     /// 由实时调度器管理的时间片
     // rt_time_slice: AtomicIsize,
     pub sched_stat: RwLock<SchedInfo>,
-    /// 调度策略
-    pub sched_policy: RwLock<crate::sched::SchedPolicy>,
+    /// 调度策略（由 rq_lock / pi_lock 保护）
+    sched_policy: AtomicU8,
     /// cfs调度实体
     pub sched_entity: Arc<FairSchedEntity>,
     pub on_rq: SpinLock<OnRq>,
     placement: SpinLock<NewTaskPlacement>,
-    pub cpus_allowed: SpinLock<CpuMask>,
-    pub nr_cpus_allowed: AtomicUsize,
 
-    pub prio_data: RwLock<PrioData>,
+    /// 由 rq_lock 保护
+    prio: AtomicI32,
+    static_prio: AtomicI32,
+    normal_prio: AtomicI32,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -2714,51 +2814,25 @@ pub struct SchedInfo {
     pub last_queued: u64,
 }
 
+/// 由 pi_lock 保护的字段集合。
 #[derive(Debug)]
-#[allow(dead_code)]
-pub struct PrioData {
-    pub prio: i32,
-    pub static_prio: i32,
-    pub normal_prio: i32,
+pub struct PiProtected {
+    pub cpus_allowed: CpuMask,
+    pub nr_cpus_allowed: usize,
 }
 
-impl Default for PrioData {
-    fn default() -> Self {
+impl PiProtected {
+    pub fn new(cpus_allowed: CpuMask) -> Self {
+        let nr_cpus_allowed = cpus_allowed.iter_cpu().count();
         Self {
-            prio: MAX_PRIO - 20,
-            static_prio: MAX_PRIO - 20,
-            normal_prio: MAX_PRIO - 20,
+            cpus_allowed,
+            nr_cpus_allowed,
         }
     }
-}
 
-#[derive(Debug)]
-pub struct InnerSchedInfo {
-    /// 当前进程的状态
-    state: ProcessState,
-    /// 进程的调度策略
-    sleep: bool,
-}
-
-impl InnerSchedInfo {
-    pub fn state(&self) -> ProcessState {
-        return self.state;
-    }
-
-    pub fn set_state(&mut self, state: ProcessState) {
-        self.state = state;
-    }
-
-    pub fn set_sleep(&mut self) {
-        self.sleep = true;
-    }
-
-    pub fn set_wakeup(&mut self) {
-        self.sleep = false;
-    }
-
-    pub fn is_mark_sleep(&self) -> bool {
-        self.sleep
+    pub fn set_cpus_allowed(&mut self, new_mask: CpuMask) {
+        self.cpus_allowed = new_mask;
+        self.nr_cpus_allowed = self.cpus_allowed.iter_cpu().count();
     }
 }
 
@@ -2777,25 +2851,22 @@ impl ProcessSchedulerInfo {
     pub fn new(on_cpu: Option<ProcessorId>) -> Self {
         let cpu_id = on_cpu.unwrap_or(ProcessorId::INVALID);
         let cpus_allowed = Self::default_cpus_allowed();
-        let nr_cpus_allowed = cpus_allowed.iter_cpu().count();
         return Self {
             on_cpu: AtomicProcessorId::new(cpu_id),
             migrate_to: AtomicProcessorId::new(ProcessorId::INVALID),
-            inner_locked: RwLock::new(InnerSchedInfo {
-                state: ProcessState::Blocked(false),
-                sleep: false,
-            }),
+            state_atomic: AtomicU32::new(ProcessState::Blocked(false).to_u32()),
+            pi_lock: SpinLock::new(PiProtected::new(cpus_allowed)),
             // virtual_runtime: AtomicIsize::new(0),
             // rt_time_slice: AtomicIsize::new(0),
             // priority: SchedPriority::new(100).unwrap(),
             sched_stat: RwLock::new(SchedInfo::default()),
-            sched_policy: RwLock::new(crate::sched::SchedPolicy::CFS),
+            sched_policy: AtomicU8::new(SchedPolicy::CFS.to_u8()),
             sched_entity: FairSchedEntity::new(),
             on_rq: SpinLock::new(OnRq::None),
             placement: SpinLock::new(NewTaskPlacement::default()),
-            cpus_allowed: SpinLock::new(cpus_allowed),
-            nr_cpus_allowed: AtomicUsize::new(nr_cpus_allowed),
-            prio_data: RwLock::new(PrioData::default()),
+            prio: AtomicI32::new(MAX_PRIO - 20),
+            static_prio: AtomicI32::new(MAX_PRIO - 20),
+            normal_prio: AtomicI32::new(MAX_PRIO - 20),
         };
     }
 
@@ -2820,6 +2891,7 @@ impl ProcessSchedulerInfo {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn placement_lock(&self) -> SpinLockGuard<'_, NewTaskPlacement> {
         self.placement.lock_irqsave()
     }
@@ -2830,58 +2902,51 @@ impl ProcessSchedulerInfo {
         guard.target_cpu_hint = target_cpu_hint;
     }
 
+    /// # 参数
+    /// - `allowed`: 调用者必须在 pi_lock 保护下预先读取 cpus_allowed 并传入，以避免重入 pi_lock
     pub fn consume_new_task_target_cpu(
         &self,
         current_cpu: ProcessorId,
+        allowed: CpuMask,
         default_selector: impl FnOnce(&CpuMask) -> Option<ProcessorId>,
     ) -> Result<ProcessorId, SystemError> {
         let mut placement = self.placement.lock_irqsave();
         if !placement.is_new_task {
             return Err(SystemError::EINVAL);
         }
-
-        let allowed = self.cpus_allowed();
         let selected_cpu = default_selector(&allowed).filter(|&cpu| {
             allowed.get(cpu).unwrap_or(false)
-                && (!crate::smp::cpu::smp_cpu_manager_initialized()
-                    || crate::sched::cpu_is_online(cpu))
+                && (!crate::smp::cpu::smp_cpu_manager_initialized() || cpu_is_online(cpu))
         });
         let target_cpu = if let Some(target_cpu) = placement.target_cpu_hint {
             if allowed.get(target_cpu).unwrap_or(false)
-                && (!crate::smp::cpu::smp_cpu_manager_initialized()
-                    || crate::sched::cpu_is_online(target_cpu))
+                && (!crate::smp::cpu::smp_cpu_manager_initialized() || cpu_is_online(target_cpu))
             {
                 target_cpu
             } else if let Some(selected_cpu) = selected_cpu {
                 selected_cpu
             } else if allowed.get(current_cpu).unwrap_or(false)
-                && (!crate::smp::cpu::smp_cpu_manager_initialized()
-                    || crate::sched::cpu_is_online(current_cpu))
+                && (!crate::smp::cpu::smp_cpu_manager_initialized() || cpu_is_online(current_cpu))
             {
                 current_cpu
             } else {
                 allowed
                     .iter_cpu()
                     .find(|&cpu| {
-                        !crate::smp::cpu::smp_cpu_manager_initialized()
-                            || crate::sched::cpu_is_online(cpu)
+                        !crate::smp::cpu::smp_cpu_manager_initialized() || cpu_is_online(cpu)
                     })
                     .ok_or(SystemError::EINVAL)?
             }
         } else if let Some(selected_cpu) = selected_cpu {
             selected_cpu
         } else if allowed.get(current_cpu).unwrap_or(false)
-            && (!crate::smp::cpu::smp_cpu_manager_initialized()
-                || crate::sched::cpu_is_online(current_cpu))
+            && (!crate::smp::cpu::smp_cpu_manager_initialized() || cpu_is_online(current_cpu))
         {
             current_cpu
         } else {
             allowed
                 .iter_cpu()
-                .find(|&cpu| {
-                    !crate::smp::cpu::smp_cpu_manager_initialized()
-                        || crate::sched::cpu_is_online(cpu)
-                })
+                .find(|&cpu| !crate::smp::cpu::smp_cpu_manager_initialized() || cpu_is_online(cpu))
                 .ok_or(SystemError::EINVAL)?
         };
 
@@ -2908,39 +2973,19 @@ impl ProcessSchedulerInfo {
             .store(migrate_to.unwrap_or(ProcessorId::INVALID), Ordering::SeqCst);
     }
 
-    pub fn inner_lock_write_irqsave(&self) -> RwLockWriteGuard<'_, InnerSchedInfo> {
-        return self.inner_locked.write_irqsave();
+    pub fn state(&self) -> ProcessState {
+        ProcessState::from_u32(self.state_atomic.load(Ordering::Acquire))
     }
 
-    pub fn inner_lock_read_irqsave(&self) -> RwLockReadGuard<'_, InnerSchedInfo> {
-        return self.inner_locked.read_irqsave();
+    pub fn set_state(&self, state: ProcessState) {
+        self.state_atomic.store(state.to_u32(), Ordering::Release);
     }
 
-    // pub fn inner_lock_try_read_irqsave(
-    //     &self,
-    //     times: u8,
-    // ) -> Option<RwLockReadGuard<InnerSchedInfo>> {
-    //     for _ in 0..times {
-    //         if let Some(r) = self.inner_locked.try_read_irqsave() {
-    //             return Some(r);
-    //         }
-    //     }
-
-    //     return None;
-    // }
-
-    // pub fn inner_lock_try_upgradable_read_irqsave(
-    //     &self,
-    //     times: u8,
-    // ) -> Option<RwLockUpgradableGuard<InnerSchedInfo>> {
-    //     for _ in 0..times {
-    //         if let Some(r) = self.inner_locked.try_upgradeable_read_irqsave() {
-    //             return Some(r);
-    //         }
-    //     }
-
-    //     return None;
-    // }
+    /// 获取 pi_lock（SpinLock），同时关闭中断并禁用抢占。
+    /// 锁序：pi_lock 可嵌套 rq_lock（pi_lock → rq_lock），禁止反向。
+    pub fn pi_lock_irqsave(&self) -> SpinLockGuard<'_, PiProtected> {
+        self.pi_lock.lock_irqsave()
+    }
 
     // pub fn virtual_runtime(&self) -> isize {
     //     return self.virtual_runtime.load(Ordering::SeqCst);
@@ -2966,27 +3011,72 @@ impl ProcessSchedulerInfo {
     //     self.rt_time_slice.fetch_add(delta, Ordering::SeqCst);
     // }
 
-    pub fn policy(&self) -> crate::sched::SchedPolicy {
-        return *self.sched_policy.read_irqsave();
+    /// 读取调度策略
+    #[inline]
+    pub fn policy(&self) -> SchedPolicy {
+        SchedPolicy::from_u8(self.sched_policy.load(Ordering::Relaxed))
     }
 
-    pub fn prio_data(&self) -> RwLockReadGuard<'_, PrioData> {
-        return self.prio_data.read_irqsave();
+    /// 设置调度策略
+    #[inline]
+    pub fn set_policy(&self, policy: SchedPolicy) {
+        self.sched_policy.store(policy.to_u8(), Ordering::Relaxed);
+    }
+
+    /// 读取动态优先级
+    #[inline]
+    pub fn prio(&self) -> i32 {
+        self.prio.load(Ordering::Relaxed)
+    }
+
+    /// 设置动态优先级
+    #[inline]
+    pub fn set_prio(&self, val: i32) {
+        self.prio.store(val, Ordering::Relaxed);
+    }
+
+    /// 读取静态优先级
+    #[inline]
+    pub fn static_prio(&self) -> i32 {
+        self.static_prio.load(Ordering::Relaxed)
+    }
+
+    /// 设置静态优先级
+    #[inline]
+    pub fn set_static_prio(&self, val: i32) {
+        self.static_prio.store(val, Ordering::Relaxed);
+    }
+
+    /// 读取普通优先级
+    #[inline]
+    pub fn normal_prio(&self) -> i32 {
+        self.normal_prio.load(Ordering::Relaxed)
+    }
+
+    /// 设置普通优先级
+    #[inline]
+    pub fn set_normal_prio(&self, val: i32) {
+        self.normal_prio.store(val, Ordering::Relaxed);
+    }
+
+    /// 同时设置所有优先级
+    #[inline]
+    pub fn set_prio_all(&self, prio: i32, static_prio: i32, normal_prio: i32) {
+        self.prio.store(prio, Ordering::Relaxed);
+        self.static_prio.store(static_prio, Ordering::Relaxed);
+        self.normal_prio.store(normal_prio, Ordering::Relaxed);
     }
 
     pub fn cpus_allowed(&self) -> CpuMask {
-        return self.cpus_allowed.lock_irqsave().clone();
+        self.pi_lock.lock_irqsave().cpus_allowed.clone()
     }
 
     pub fn nr_cpus_allowed(&self) -> usize {
-        return self.nr_cpus_allowed.load(Ordering::SeqCst);
+        self.pi_lock.lock_irqsave().nr_cpus_allowed
     }
 
     pub fn set_cpus_allowed(&self, cpus_allowed: CpuMask) {
-        let nr_cpus_allowed = cpus_allowed.iter_cpu().count();
-        *self.cpus_allowed.lock_irqsave() = cpus_allowed;
-        self.nr_cpus_allowed
-            .store(nr_cpus_allowed, Ordering::SeqCst);
+        self.pi_lock.lock_irqsave().set_cpus_allowed(cpus_allowed);
     }
 }
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -529,33 +529,62 @@ impl ProcessManager {
     pub fn wakeup_stop(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         let _guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let state = pcb.sched_info().state();
-        if let ProcessState::Stopped = state {
-            let _pi_guard = pcb.sched_info().pi_lock_irqsave();
-            let state = pcb.sched_info().state();
-            if let ProcessState::Stopped = state {
-                pcb.sched_info().set_state(ProcessState::Runnable);
-                fence(Ordering::SeqCst);
-
-                // TODO: select_task_rq 负载均衡
-                // let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(smp_get_processor_id());
-                // let allowed = pi_guard.cpus_allowed.clone();
-                // let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
-                let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
-
-                // stop task
-                enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::empty(), false);
-
-                return Ok(());
-            } else if state.is_runnable() {
-                return Ok(());
+        if !state.is_stopped() {
+            return if state.is_runnable() {
+                Ok(())
             } else {
-                return Err(SystemError::EINVAL);
-            }
-        } else if state.is_runnable() {
-            return Ok(());
-        } else {
-            return Err(SystemError::EINVAL);
+                Err(SystemError::EINVAL)
+            };
         }
+
+        let _pi_guard = pcb.sched_info().pi_lock_irqsave();
+        let state = pcb.sched_info().state();
+        if !state.is_stopped() {
+            return if state.is_runnable() {
+                Ok(())
+            } else {
+                Err(SystemError::EINVAL)
+            };
+        }
+
+        pcb.sched_info().set_state(ProcessState::Runnable);
+        fence(Ordering::SeqCst);
+
+        // TODO: select_task_rq 负载均衡
+        // let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(smp_get_processor_id());
+        // let allowed = pi_guard.cpus_allowed.clone();
+        // let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
+        let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        let update_clock = target_cpu == smp_get_processor_id();
+        let rq = cpu_rq(target_cpu.data() as usize);
+
+        let should_enqueue = {
+            let (rq, _rq_guard) = rq.self_lock();
+            match *pcb.sched_info().on_rq.lock_irqsave() {
+                OnRq::Queued => {
+                    let is_current = Arc::ptr_eq(&rq.current(), pcb);
+                    if !is_current {
+                        if update_clock {
+                            rq.update_rq_clock();
+                            rq.check_preempt_current(pcb, WakeupFlags::empty());
+                        } else {
+                            rq.check_preempt_remote(pcb, WakeupFlags::empty());
+                        }
+                    } else if !update_clock {
+                        kick_cpu(target_cpu).ok();
+                    }
+                    false
+                }
+                OnRq::None => true,
+                OnRq::Migrating => false,
+            }
+        };
+
+        if should_enqueue {
+            enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::empty(), false);
+        }
+
+        Ok(())
     }
 
     /// 异步将目标进程置为停止状态（用于 SIGSTOP/SIGTSTP 等作业控制停止）
@@ -1320,6 +1349,10 @@ bitflags! {
 }
 
 impl ProcessFlags {
+    pub const fn fork_inherited(&self) -> Self {
+        Self::from_bits_truncate(self.bits & Self::RANDOMIZE.bits)
+    }
+
     pub const fn exit_to_user_mode_work(&self) -> Self {
         Self::from_bits_truncate(
             self.bits

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -67,7 +67,7 @@ use crate::{
     sched::{
         DequeueFlag, EnqueueFlag, OnRq, SchedMode, SchedPolicy, Scheduler, WakeupFlags,
         __schedule_with_current, completion::Completion, cpu_is_online, cpu_rq,
-        enqueue_task_on_cpu, fair::FairSchedEntity, prio::MAX_PRIO, rq_is_idle_cpu, select_task_rq,
+        enqueue_task_on_cpu, fair::FairSchedEntity, prio::MAX_PRIO, select_task_rq,
     },
     smp::{
         core::smp_get_processor_id,
@@ -597,18 +597,23 @@ impl ProcessManager {
 
         let is_current = Arc::ptr_eq(&rq.current(), pcb);
 
-        // 排队中且非 current → 主动 dequeue。
-        // 使用 DEQUEUE_STOPPED 让 on_rq 进入 None（而非 Migrating），
-        if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued && !is_current {
-            rq.deactivate_task(
-                pcb.clone(),
-                DequeueFlag::DEQUEUE_STOPPED | DequeueFlag::DEQUEUE_NOCLOCK,
-            );
-        }
-
-        // 正在远端 CPU 运行 → 发 IPI 让其尽快进 __schedule()，在那里 deactivate
-        if is_current && !update_clock {
-            kick_cpu(target_cpu).ok();
+        if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
+            // 排队中且非current → 主动 dequeue
+            if !is_current {
+                rq.deactivate_task(
+                    pcb.clone(),
+                    DequeueFlag::DEQUEUE_STOPPED | DequeueFlag::DEQUEUE_NOCLOCK,
+                );
+            } else if !update_clock {
+                // 正在远端 CPU 运行：dequeue + kick
+                // 此处异步 dequeue，远端 CPU 收到 kick 后 __schedule(SM_PREEMPT) 时
+                // stopped task 已不在红黑树中，pick_next_task 不会选中它
+                rq.deactivate_task(
+                    pcb.clone(),
+                    DequeueFlag::DEQUEUE_STOPPED | DequeueFlag::DEQUEUE_NOCLOCK,
+                );
+                kick_cpu(target_cpu).ok();
+            }
         }
 
         drop(rq_guard);

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -378,43 +378,17 @@ impl ProcessManager {
 
         pcb.debug_assert_fork_cpu_binding();
 
+        // TODO: select_task_rq 负载均衡
+        // let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        // let allowed = pi_guard.cpus_allowed.clone();
+        // let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
         let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
-        let update_clock = target_cpu == smp_get_processor_id();
-        let rq = cpu_rq(target_cpu.data() as usize);
-
-        let (rq, _guard) = rq.self_lock();
-        debug_assert_eq!(
-            pcb.sched_info().on_cpu(),
-            Some(rq.cpu()),
-            "wakeup: on_cpu mismatch with rq.cpu"
-        );
-        if update_clock {
-            rq.update_rq_clock();
-        }
-        if was_uninterruptible {
-            rq.dec_nr_uninterruptible();
-        }
 
         if pcb.flags().contains(ProcessFlags::IN_IOWAIT) {
-            rq.dec_nr_iowait();
+            cpu_rq(target_cpu.data() as usize).dec_nr_iowait();
         }
 
-        let was_idle = rq_is_idle_cpu(rq);
-
-        rq.activate_task(
-            pcb,
-            EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
-        );
-
-        if was_idle && !rq_is_idle_cpu(rq) {
-            crate::sched::IDLE_CPUS.clear(target_cpu);
-        }
-
-        if update_clock {
-            rq.check_preempt_current(pcb, WakeupFlags::empty());
-        } else {
-            rq.check_preempt_remote(pcb, WakeupFlags::empty());
-        }
+        enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::empty(), was_uninterruptible);
 
         Ok(())
     }
@@ -444,7 +418,7 @@ impl ProcessManager {
             },
         )?;
 
-        enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::WF_FORK);
+        enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::WF_FORK, false);
 
         debug_assert!(!pcb.sched_info().is_new_task());
         Ok(())
@@ -562,36 +536,14 @@ impl ProcessManager {
                 pcb.sched_info().set_state(ProcessState::Runnable);
                 fence(Ordering::SeqCst);
 
-                let target_cpu = pcb.sched_info().on_cpu().unwrap_or(smp_get_processor_id());
-                let update_clock = target_cpu == smp_get_processor_id();
-                let rq = cpu_rq(target_cpu.data() as usize);
+                // TODO: select_task_rq 负载均衡
+                // let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(smp_get_processor_id());
+                // let allowed = pi_guard.cpus_allowed.clone();
+                // let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
+                let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
 
-                let (rq, _guard) = rq.self_lock();
-                debug_assert_eq!(
-                    pcb.sched_info().on_cpu(),
-                    Some(rq.cpu()),
-                    "wakeup_stop: on_cpu mismatch with rq.cpu"
-                );
-                if update_clock {
-                    rq.update_rq_clock();
-                }
-
-                let was_idle = rq_is_idle_cpu(rq);
-
-                rq.activate_task(
-                    pcb,
-                    EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
-                );
-
-                if was_idle && !rq_is_idle_cpu(rq) {
-                    crate::sched::IDLE_CPUS.clear(target_cpu);
-                }
-
-                if update_clock {
-                    rq.check_preempt_current(pcb, WakeupFlags::empty());
-                } else {
-                    rq.check_preempt_remote(pcb, WakeupFlags::empty());
-                }
+                // stop task
+                enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::empty(), false);
 
                 return Ok(());
             } else if state.is_runnable() {
@@ -1124,7 +1076,7 @@ impl ProcessManager {
         if let Some(dest_cpu) = migrate_prev_to {
             debug_assert!(!Arc::ptr_eq(&prev_pcb, &next_pcb));
             prev_pcb.sched_info().set_on_cpu(None);
-            enqueue_task_on_cpu(&prev_pcb, dest_cpu, WakeupFlags::WF_MIGRATED);
+            enqueue_task_on_cpu(&prev_pcb, dest_cpu, WakeupFlags::WF_MIGRATED, false);
         }
 
         let set_child_tid = next_pcb.thread.write_irqsave().set_child_tid.take();

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -91,7 +91,7 @@ pub fn do_clone(
         pcb.thread.write_irqsave().vfork_done = Some(vfork.clone());
     }
 
-    ProcessManager::wakeup_new_task(&pcb).unwrap_or_else(|e| {
+    ProcessManager::wake_up_new_task(&pcb).unwrap_or_else(|e| {
         panic!(
             "fork: Failed to wakeup new process, pid: [{:?}]. Error: {:?}",
             pcb.raw_pid(),

--- a/kernel/src/sched/cputime.rs
+++ b/kernel/src/sched/cputime.rs
@@ -221,8 +221,7 @@ impl CpuTimeFunc {
         } else if user_tick {
             // 用户态时间：区分 NICE
             // 获取进程的 nice 值（通过 static_prio 计算）
-            let prio_data = pcb.sched_info().prio_data();
-            let static_prio = prio_data.static_prio;
+            let static_prio = pcb.sched_info().static_prio();
             // 使用 PrioUtil 将 prio 转换为 nice 值
             let nice = PrioUtil::prio_to_nice(static_prio);
 

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -1130,6 +1130,7 @@ impl CfsRunQueue {
         }
 
         self.nr_running -= 1;
+        debug_assert!(self.nr_running < i64::MAX as u64, "cfs_rq nr_running underflow");
         if se.is_idle() {
             self.idle_nr_running -= 1;
         }

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -1582,7 +1582,7 @@ impl Scheduler for CompletelyFairScheduler {
         }
     }
 
-    fn check_preempt_currnet(
+    fn check_preempt_current(
         rq: &mut CpuRunQueue,
         pcb: &Arc<crate::process::ProcessControlBlock>,
         wake_flags: WakeupFlags,

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -1130,7 +1130,10 @@ impl CfsRunQueue {
         }
 
         self.nr_running -= 1;
-        debug_assert!(self.nr_running < i64::MAX as u64, "cfs_rq nr_running underflow");
+        debug_assert!(
+            self.nr_running < i64::MAX as u64,
+            "cfs_rq nr_running underflow"
+        );
         if se.is_idle() {
             self.idle_nr_running -= 1;
         }

--- a/kernel/src/sched/fifo.rs
+++ b/kernel/src/sched/fifo.rs
@@ -29,7 +29,7 @@ impl FifoRunQueue {
 
     #[inline]
     fn prio_index(pcb: &ProcessControlBlock) -> usize {
-        let prio = pcb.sched_info().prio_data.read_irqsave().prio;
+        let prio = pcb.sched_info().prio();
         let prio = prio.clamp(0, MAX_RT_PRIO - 1);
         prio as usize
     }
@@ -95,7 +95,18 @@ pub struct FifoScheduler;
 impl FifoScheduler {
     #[inline]
     fn rt_prio(pcb: &ProcessControlBlock) -> i32 {
-        pcb.sched_info().prio_data.read_irqsave().prio
+        pcb.sched_info().prio()
+    }
+
+    /// 对标 Linux set_next_task_rt：将 FIFO 任务设为当前运行任务。
+    ///
+    /// FIFO 不像 CFS 那样维护 per-class current entity，
+    /// 但需要在 running 任务修改策略/优先级后被调用以保持与 Linux 一致的流程。
+    pub fn set_next_task(
+        _rq: &mut super::CpuRunQueue,
+        _pcb: alloc::sync::Arc<crate::process::ProcessControlBlock>,
+    ) {
+        // FIFO 不维护 per-class 调度实体状态，无需额外操作
     }
 }
 
@@ -120,7 +131,7 @@ impl Scheduler for FifoScheduler {
         rq.resched_current();
     }
 
-    fn check_preempt_currnet(
+    fn check_preempt_current(
         rq: &mut CpuRunQueue,
         pcb: &Arc<ProcessControlBlock>,
         _flags: WakeupFlags,

--- a/kernel/src/sched/idle.rs
+++ b/kernel/src/sched/idle.rs
@@ -20,7 +20,7 @@ impl Scheduler for IdleScheduler {
 
     fn yield_task(_rq: &mut super::CpuRunQueue) {}
 
-    fn check_preempt_currnet(
+    fn check_preempt_current(
         rq: &mut super::CpuRunQueue,
         _pcb: &alloc::sync::Arc<crate::process::ProcessControlBlock>,
         _flags: super::WakeupFlags,

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1336,10 +1336,12 @@ pub fn rebind_task_cpu(pcb: &Arc<ProcessControlBlock>, cpu: ProcessorId) {
     pcb.sched_info().set_on_cpu(Some(cpu));
 }
 
+/// 对标 Linux ttwu_queue + ttwu_do_activate
 pub fn enqueue_task_on_cpu(
     pcb: &Arc<ProcessControlBlock>,
     target_cpu: ProcessorId,
     wake_flags: WakeupFlags,
+    was_uninterruptible: bool,
 ) {
     __set_task_cpu(pcb, target_cpu);
     pcb.sched_info().set_on_cpu(Some(target_cpu));
@@ -1350,6 +1352,10 @@ pub fn enqueue_task_on_cpu(
 
     if update_clock {
         rq.update_rq_clock();
+    }
+
+    if was_uninterruptible {
+        rq.dec_nr_uninterruptible();
     }
 
     let was_idle = rq_is_idle_cpu(rq);
@@ -1419,7 +1425,7 @@ pub fn request_task_migration(
         pcb.sched_info().set_on_cpu(None);
         drop(_guard);
 
-        enqueue_task_on_cpu(pcb, dest_cpu, WakeupFlags::WF_MIGRATED);
+        enqueue_task_on_cpu(pcb, dest_cpu, WakeupFlags::WF_MIGRATED, false);
         return Ok(());
     }
 

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -899,11 +899,7 @@ impl CpuRunQueue {
 
         if next.is_none()
             && !task_is_idle(&prev)
-            && prev
-                .sched_info()
-                .inner_lock_read_irqsave()
-                .state()
-                .is_runnable()
+            && prev.sched_info().state().is_runnable()
             && *prev.sched_info().on_rq.lock_irqsave() == OnRq::Queued
         {
             next = Some(prev.clone());

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -27,7 +27,7 @@ use alloc::{
 use system_error::SystemError;
 
 use crate::{
-    arch::{cpu::current_cpu_id, interrupt::ipi::send_ipi, CurrentIrqArch},
+    arch::{cpu::current_cpu_id, interrupt::ipi::send_ipi, ipc::signal::Signal, CurrentIrqArch},
     exception::{
         ipi::{IpiKind, IpiTarget},
         InterruptArch,
@@ -95,7 +95,7 @@ fn task_is_idle(pcb: &Arc<ProcessControlBlock>) -> bool {
 }
 
 #[inline]
-fn rq_is_idle_cpu(rq: &CpuRunQueue) -> bool {
+pub(crate) fn rq_is_idle_cpu(rq: &CpuRunQueue) -> bool {
     task_is_idle(&rq.current()) && rq.nr_running == 0
 }
 
@@ -187,19 +187,20 @@ fn select_least_loaded_cpu(allowed: &CpuMask, fallback_cpu: ProcessorId) -> Proc
     best_cpu
 }
 
+/// 选择目标 CPU。调用者必须在 pi_lock 保护下读取 cpus_allowed 并传入，
 pub fn select_task_rq(
     pcb: &Arc<ProcessControlBlock>,
     prev_cpu: ProcessorId,
     wake_flags: WakeupFlags,
+    allowed: &CpuMask,
 ) -> ProcessorId {
-    let allowed = pcb.sched_info().cpus_allowed();
     let current_cpu = smp_get_processor_id();
-    let fallback_cpu = if cpu_allowed_and_online(&allowed, prev_cpu) {
+    let fallback_cpu = if cpu_allowed_and_online(allowed, prev_cpu) {
         prev_cpu
-    } else if cpu_allowed_and_online(&allowed, current_cpu) {
+    } else if cpu_allowed_and_online(allowed, current_cpu) {
         current_cpu
     } else {
-        first_allowed_online_cpu(&allowed)
+        first_allowed_online_cpu(allowed)
             .or_else(|| allowed.iter_cpu().next())
             .unwrap_or(prev_cpu)
     };
@@ -210,16 +211,16 @@ pub fn select_task_rq(
     }
 
     if wake_flags.contains(WakeupFlags::WF_FORK) {
-        return select_fork_idle_cpu(&allowed, fallback_cpu)
-            .unwrap_or_else(|| select_least_loaded_cpu(&allowed, fallback_cpu));
+        return select_fork_idle_cpu(allowed, fallback_cpu)
+            .unwrap_or_else(|| select_least_loaded_cpu(allowed, fallback_cpu));
     }
 
     if wake_flags.contains(WakeupFlags::WF_TTWU) {
-        if let Some(idle_cpu) = pick_idle_cpu(&allowed) {
+        if let Some(idle_cpu) = pick_idle_cpu(allowed) {
             return idle_cpu;
         }
 
-        return select_least_loaded_cpu(&allowed, fallback_cpu);
+        return select_least_loaded_cpu(allowed, fallback_cpu);
     }
 
     fallback_cpu
@@ -252,7 +253,7 @@ pub trait Scheduler {
     fn yield_task(rq: &mut CpuRunQueue);
 
     /// ## 检查进入可运行状态的任务能否抢占当前正在运行的任务
-    fn check_preempt_currnet(
+    fn check_preempt_current(
         rq: &mut CpuRunQueue,
         pcb: &Arc<ProcessControlBlock>,
         flags: WakeupFlags,
@@ -278,17 +279,38 @@ pub trait Scheduler {
 }
 
 /// 调度策略
+///
+/// 裸字段，由调用者持 rq_lock 或 pi_lock 保护。
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
 pub enum SchedPolicy {
     /// 实时进程
-    RT,
+    RT = 0,
     /// 先进先出调度
-    FIFO,
+    FIFO = 1,
     /// 完全公平调度
-    CFS,
+    CFS = 2,
     /// IDLE
-    IDLE,
+    IDLE = 3,
+}
+
+impl SchedPolicy {
+    #[inline]
+    pub fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    #[inline]
+    pub fn from_u8(val: u8) -> Self {
+        match val {
+            0 => SchedPolicy::RT,
+            1 => SchedPolicy::FIFO,
+            2 => SchedPolicy::CFS,
+            3 => SchedPolicy::IDLE,
+            _ => panic!("Invalid SchedPolicy value: {val}"),
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -605,15 +627,9 @@ impl CpuRunQueue {
         }
     }
 
-    /// 启用一个任务，将加入队列
+    /// 将任务加入运行队列，设置 on_rq = Queued。
     pub fn activate_task(&mut self, pcb: &Arc<ProcessControlBlock>, mut flags: EnqueueFlag) {
-        let was_idle_cpu = rq_is_idle_cpu(self);
-
-        // 如果进程之前因 IO 等待而睡眠，现在被唤醒，减少 nr_iowait 计数
-        if pcb.flags().contains(ProcessFlags::IN_IOWAIT) {
-            self.nr_iowait.fetch_sub(1, Ordering::Relaxed);
-        }
-
+        // 1. 迁移标志处理
         if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Migrating {
             flags |= EnqueueFlag::ENQUEUE_MIGRATED;
         }
@@ -622,31 +638,24 @@ impl CpuRunQueue {
             todo!()
         }
 
+        // 2. enqueue_task
         self.enqueue_task(pcb.clone(), flags);
 
+        // 3. 设置 on_rq = Queued
         *pcb.sched_info().on_rq.lock_irqsave() = OnRq::Queued;
-        pcb.sched_info().set_on_cpu(Some(self.cpu));
-
-        if was_idle_cpu && !rq_is_idle_cpu(self) {
-            IDLE_CPUS.clear(self.cpu);
-        }
-
-        debug_assert_eq!(*pcb.sched_info().on_rq.lock_irqsave(), OnRq::Queued);
-        debug_assert_eq!(pcb.sched_info().on_cpu(), Some(self.cpu));
-        pcb.debug_assert_fork_cpu_binding();
     }
 
     /// 检查对应的task是否可以抢占当前运行的task
     #[allow(clippy::comparison_chain)]
-    pub fn check_preempt_currnet(&mut self, pcb: &Arc<ProcessControlBlock>, flags: WakeupFlags) {
+    pub fn check_preempt_current(&mut self, pcb: &Arc<ProcessControlBlock>, flags: WakeupFlags) {
         if pcb.sched_info().policy() == self.current().sched_info().policy() {
             match self.current().sched_info().policy() {
                 SchedPolicy::CFS => {
-                    CompletelyFairScheduler::check_preempt_currnet(self, pcb, flags)
+                    CompletelyFairScheduler::check_preempt_current(self, pcb, flags)
                 }
-                SchedPolicy::FIFO => FifoScheduler::check_preempt_currnet(self, pcb, flags),
+                SchedPolicy::FIFO => FifoScheduler::check_preempt_current(self, pcb, flags),
                 SchedPolicy::RT => todo!(),
-                SchedPolicy::IDLE => IdleScheduler::check_preempt_currnet(self, pcb, flags),
+                SchedPolicy::IDLE => IdleScheduler::check_preempt_current(self, pcb, flags),
             }
         } else if pcb.sched_info().policy() < self.current().sched_info().policy() {
             // 调度优先级更高
@@ -690,9 +699,9 @@ impl CpuRunQueue {
         } else if next_policy == current_policy {
             match current_policy {
                 SchedPolicy::CFS => {}
-                SchedPolicy::FIFO => FifoScheduler::check_preempt_currnet(self, pcb, flags),
+                SchedPolicy::FIFO => FifoScheduler::check_preempt_current(self, pcb, flags),
                 SchedPolicy::RT => todo!(),
-                SchedPolicy::IDLE => IdleScheduler::check_preempt_currnet(self, pcb, flags),
+                SchedPolicy::IDLE => IdleScheduler::check_preempt_current(self, pcb, flags),
             }
         }
 
@@ -704,25 +713,9 @@ impl CpuRunQueue {
         }
     }
 
-    /// 禁用一个任务，将离开队列
+    /// 设置 on_rq，将任务移出运行队列
     pub fn deactivate_task(&mut self, pcb: Arc<ProcessControlBlock>, flags: DequeueFlag) {
-        if flags.contains(DequeueFlag::DEQUEUE_SLEEP)
-            && matches!(
-                pcb.sched_info().inner_lock_read_irqsave().state(),
-                ProcessState::Blocked(false)
-            )
-        {
-            self.nr_uninterruptible += 1;
-            loadavg::inc_nr_uninterruptible(1);
-        }
-
-        // 如果进程因 IO 等待而睡眠，增加 nr_iowait 计数
-        if flags.contains(DequeueFlag::DEQUEUE_SLEEP)
-            && pcb.flags().contains(ProcessFlags::IN_IOWAIT)
-        {
-            self.nr_iowait.fetch_add(1, Ordering::Relaxed);
-        }
-
+        // 1. 根据标志设置 on_rq 状态
         *pcb.sched_info().on_rq.lock_irqsave() =
             if flags.intersects(DequeueFlag::DEQUEUE_SLEEP | DequeueFlag::DEQUEUE_STOPPED) {
                 OnRq::None
@@ -730,6 +723,7 @@ impl CpuRunQueue {
                 OnRq::Migrating
             };
 
+        // 2. dequeue_task
         self.dequeue_task(pcb, flags);
     }
 
@@ -742,6 +736,10 @@ impl CpuRunQueue {
     #[inline]
     pub fn nr_iowait(&self) -> usize {
         self.nr_iowait.load(Ordering::Relaxed)
+    }
+
+    pub fn dec_nr_iowait(&self) {
+        self.nr_iowait.fetch_sub(1, Ordering::Relaxed);
     }
 
     /// 更新rq时钟
@@ -1118,9 +1116,7 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
         Some(current) => current,
         None => {
             let prev = rq.current();
-            if let ProcessState::Exited(_) =
-                prev.clone().sched_info().inner_lock_read_irqsave().state()
-            {
+            if let ProcessState::Exited(_) = prev.clone().sched_info().state() {
                 // 从exit进的Schedule
                 ProcessManager::current_pcb()
             } else {
@@ -1132,6 +1128,9 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     // TODO: hrtick_clear(rq);
 
     let (rq, guard) = rq.self_lock();
+    // 对标 Linux __schedule() rq_lock 后的 smp_mb__after_spinlock()：
+    // x86_64 (TSO) 上 spinlock 已含 full barrier，此处为冗余；RISC-V 上必要。
+    fence(Ordering::SeqCst);
 
     rq.clock_updata_flags = ClockUpdataFlag::from_bits_truncate(rq.clock_updata_flags.bits() << 1);
 
@@ -1193,14 +1192,36 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     //         .collect::<Vec<_>>(),
     // );
 
-    if !sched_mod.contains(SchedMode::SM_MASK_PREEMPT)
-        && prev.sched_info().policy() != SchedPolicy::IDLE
-        && prev.sched_info().inner_lock_read_irqsave().is_mark_sleep()
-    {
-        rq.deactivate_task(
-            prev.clone(),
-            DequeueFlag::DEQUEUE_SLEEP | DequeueFlag::DEQUEUE_NOCLOCK,
-        );
+    if !sched_mod.contains(SchedMode::SM_MASK_PREEMPT) {
+        let prev_state = prev.sched_info().state();
+        if !prev_state.is_runnable() {
+            // 对齐 Linux __schedule() signal_pending_state(prev_state, prev):
+            //   TASK_INTERRUPTIBLE              → 有任意信号 → 恢复 RUNNING
+            //   TASK_STOPPED (含 TASK_WAKEKILL) → 只有 SIGKILL → 恢复 RUNNING
+            //   TASK_UNINTERRUPTIBLE            → 不检查信号，直接 deactivate
+            let interruptible = prev_state.is_blocked_interruptable();
+            let wake_kill = prev_state.is_stopped();
+
+            if Signal::signal_pending_state(interruptible, wake_kill, &prev) {
+                prev.sched_info().set_state(ProcessState::Runnable);
+            } else {
+                // sched_contributes_to_load 在 deactivate_task 之前
+                if matches!(prev_state, ProcessState::Blocked(false)) {
+                    rq.nr_uninterruptible += 1;
+                    loadavg::inc_nr_uninterruptible(1);
+                }
+
+                rq.deactivate_task(
+                    prev.clone(),
+                    DequeueFlag::DEQUEUE_SLEEP | DequeueFlag::DEQUEUE_NOCLOCK,
+                );
+
+                // nr_iowait++ 在 deactivate_task 之后
+                if prev.flags().contains(ProcessFlags::IN_IOWAIT) {
+                    rq.nr_iowait.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
     }
 
     let next = rq.pick_next_task(prev.clone());
@@ -1252,19 +1273,23 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
 }
 
 pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
-    let mut prio_guard = pcb.sched_info().prio_data.write_irqsave();
     let current = ProcessManager::current_pcb();
+    let fork_prio = current.sched_info().normal_prio();
 
-    prio_guard.prio = current.sched_info().prio_data.read_irqsave().normal_prio;
+    // 子进程是 TASK_NEW，不可见。可以直接写裸字段
+    // 子进程继承父进程的 prio、static_prio、normal_prio
+    pcb.sched_info().set_prio(fork_prio);
+    pcb.sched_info()
+        .set_static_prio(current.sched_info().static_prio());
+    pcb.sched_info().set_normal_prio(fork_prio);
 
-    if PrioUtil::dl_prio(prio_guard.prio) {
+    if PrioUtil::dl_prio(fork_prio) {
         return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-    } else if PrioUtil::rt_prio(prio_guard.prio) {
-        let policy = &pcb.sched_info().sched_policy;
-        *policy.write_irqsave() = SchedPolicy::RT;
+    } else if PrioUtil::rt_prio(fork_prio) {
+        // 子进程继承父进程的调度策略（FIFO/RR），而非统一设为 RT
+        pcb.sched_info().set_policy(current.sched_info().policy());
     } else {
-        let policy = &pcb.sched_info().sched_policy;
-        *policy.write_irqsave() = SchedPolicy::CFS;
+        pcb.sched_info().set_policy(SchedPolicy::CFS);
     }
 
     pcb.sched_info()
@@ -1317,6 +1342,7 @@ pub fn enqueue_task_on_cpu(
     wake_flags: WakeupFlags,
 ) {
     __set_task_cpu(pcb, target_cpu);
+    pcb.sched_info().set_on_cpu(Some(target_cpu));
 
     let rq = cpu_rq(target_cpu.data() as usize);
     let update_clock = target_cpu == smp_get_processor_id();
@@ -1326,13 +1352,19 @@ pub fn enqueue_task_on_cpu(
         rq.update_rq_clock();
     }
 
+    let was_idle = rq_is_idle_cpu(rq);
+
     rq.activate_task(
         pcb,
         EnqueueFlag::ENQUEUE_WAKEUP | EnqueueFlag::ENQUEUE_NOCLOCK,
     );
 
+    if was_idle && !rq_is_idle_cpu(rq) {
+        IDLE_CPUS.clear(target_cpu);
+    }
+
     if update_clock {
-        rq.check_preempt_currnet(pcb, wake_flags);
+        rq.check_preempt_current(pcb, wake_flags);
     } else {
         rq.check_preempt_remote(pcb, wake_flags);
     }

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1192,19 +1192,35 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     //         .collect::<Vec<_>>(),
     // );
 
-    if !sched_mod.contains(SchedMode::SM_MASK_PREEMPT) {
+    // 对标 Linux __schedule() 的 prev_state 检查：
+    //   Linux 条件: (!(sched_mode & SM_MASK_PREEMPT) && prev_state)
+    //   ——非抢占 + prev 非 RUNNING 时进入 deactivate 分支。
+    //
+    // DragonOS 扩展：SM_PREEMPT 路径也需处理非 runnable 的 prev，
+    // 因为异步 stop_task() 可在发送端上下文将远端 current 设为 Stopped（仅 kick 不 dequeue），
+    // 导致远端 IPI 退出时 prev 已非 runnable 但仍在 runqueue 上。
+    // 此时必须在这里完成唯一一次出队。
+    //
+    // on_rq == Queued 守卫保证 deactivate 幂等：
+    //   若 stop_task 已出队（!is_current 分支），此处 on_rq != Queued，跳过。
+    //   若 stop_task 未出队（远端 current 分支），此处 on_rq == Queued，执行出队。
+    {
         let prev_state = prev.sched_info().state();
         if !prev_state.is_runnable() {
-            // 对齐 Linux __schedule() signal_pending_state(prev_state, prev):
-            //   TASK_INTERRUPTIBLE              → 有任意信号 → 恢复 RUNNING
-            //   TASK_STOPPED (含 TASK_WAKEKILL) → 只有 SIGKILL → 恢复 RUNNING
-            //   TASK_UNINTERRUPTIBLE            → 不检查信号，直接 deactivate
             let interruptible = prev_state.is_blocked_interruptable();
             let wake_kill = prev_state.is_stopped();
 
-            if Signal::signal_pending_state(interruptible, wake_kill, &prev) {
+            // signal_pending_state 仅对 SM_NONE（自愿调度）生效：
+            //   TASK_INTERRUPTIBLE → 有任意信号 → 恢复 RUNNING
+            //   TASK_STOPPED       → 仅 SIGKILL → 恢复 RUNNING
+            //   TASK_UNINTERRUPTIBLE → 不检查信号，直接 deactivate
+            // SM_PREEMPT（被抢占）不检查信号，因为异步 stop 不应被信号恢复。
+            let signal_wake = !sched_mod.contains(SchedMode::SM_MASK_PREEMPT)
+                && Signal::signal_pending_state(interruptible, wake_kill, &prev);
+
+            if signal_wake {
                 prev.sched_info().set_state(ProcessState::Runnable);
-            } else {
+            } else if *prev.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
                 // sched_contributes_to_load 在 deactivate_task 之前
                 if matches!(prev_state, ProcessState::Blocked(false)) {
                     rq.nr_uninterruptible += 1;

--- a/kernel/src/sched/syscall/sys_sched_getparam.rs
+++ b/kernel/src/sched/syscall/sys_sched_getparam.rs
@@ -78,9 +78,8 @@ impl Syscall for SysSchedGetparam {
         }
 
         // 获取调度策略和优先级
-        let policy = *target_pcb.sched_info().sched_policy.read_irqsave();
-        let prio_data = target_pcb.sched_info().prio_data.read_irqsave();
-        let prio = prio_data.prio;
+        let policy = target_pcb.sched_info().policy();
+        let prio = target_pcb.sched_info().prio();
 
         // 根据调度策略计算 sched_priority
         // Linux 行为：

--- a/kernel/src/sched/syscall/sys_sched_getscheduler.rs
+++ b/kernel/src/sched/syscall/sys_sched_getscheduler.rs
@@ -77,7 +77,7 @@ impl Syscall for SysSchedGetscheduler {
         }
 
         // 获取调度策略
-        let policy = *target_pcb.sched_info().sched_policy.read_irqsave();
+        let policy = target_pcb.sched_info().policy();
 
         // 将 DragonOS 的 SchedPolicy 映射到 Linux 的调度策略值
         // Linux 调度策略值：

--- a/kernel/src/smp/syscall/sys_sched_setaffinity.rs
+++ b/kernel/src/smp/syscall/sys_sched_setaffinity.rs
@@ -58,8 +58,8 @@ impl Syscall for SysSchedSetaffinity {
         }
 
         {
-            let _placement_guard = target_pcb.sched_info().placement_lock();
-            target_pcb.sched_info().set_cpus_allowed(mask.clone());
+            let mut pi_guard = target_pcb.sched_info().pi_lock_irqsave();
+            pi_guard.set_cpus_allowed(mask.clone());
         }
 
         if target_pcb.sched_info().is_new_task() {
@@ -68,7 +68,8 @@ impl Syscall for SysSchedSetaffinity {
 
         if let Some(cpu) = target_pcb.sched_info().on_cpu() {
             if !mask.get(cpu).unwrap_or(false) {
-                let dest_cpu = select_task_rq(&target_pcb, cpu, crate::sched::WakeupFlags::WF_TTWU);
+                let dest_cpu =
+                    select_task_rq(&target_pcb, cpu, crate::sched::WakeupFlags::WF_TTWU, &mask);
                 request_task_migration(&target_pcb, dest_cpu)?;
             }
         }

--- a/tools/qemu/default.nix
+++ b/tools/qemu/default.nix
@@ -56,11 +56,6 @@ let
         "cpu_reset,guest_errors,trace:virtio*,trace:e1000e_rx*,trace:e1000e_tx*,trace:e1000e_irq*"
         "-trace"
         "fw_cfg*"
-      ]
-      ++ lib.optionals debug [
-        # GDB Stub
-        "-s"
-        "-S"
       ];
       nographicArgs = lib.optionals isNographic (
         [
@@ -199,6 +194,7 @@ let
 
       # 动态分配端口
       HOST_PORT=$(find_available_port 12580)
+      GDB_PORT=$(find_available_port $((HOST_PORT + 1)))
 
       ACCEL="tcg"
       if [ -e /dev/kvm ] && [ -w /dev/kvm ]; then ACCEL="kvm"; fi
@@ -328,6 +324,7 @@ let
             mkdir -p "$VMSTATE_DIR"
             rm -f "$VMSTATE_DIR/pid" "$VMSTATE_DIR/vsock_cid"
             echo "$HOST_PORT" > "$VMSTATE_DIR/port"
+            echo "$GDB_PORT" > "$VMSTATE_DIR/gdb"
             if [ -n "$VSOCK_GUEST_CID" ]; then
               echo "$VSOCK_GUEST_CID" > "$VMSTATE_DIR/vsock_cid"
             fi
@@ -338,7 +335,7 @@ let
 
       cleanup() {
         sudo rm -f /dev/shm/${baseConfig.shmId}
-        ${if hasVmstateDir then ''rm -f "$VMSTATE_DIR/pid" "$VMSTATE_DIR/vsock_cid"'' else ""}
+        ${if hasVmstateDir then ''rm -f "$VMSTATE_DIR/pid" "$VMSTATE_DIR/vsock_cid" "$VMSTATE_DIR/port" "$VMSTATE_DIR/gdb"'' else ""}
       }
       trap cleanup EXIT
       # FIXED: 既然用了 sudo 运行 qemu，这里创建 shm 也需要权限，
@@ -348,7 +345,7 @@ let
       EXTRA_CMDLINE="${qemuConfig.cmdlineExtra}"
 
       # FIXED: 补全缺失的默认内核参数 AUTO_TEST 和 SYSCALL_TEST_DIR
-      FINAL_CMDLINE="init=${initProgram} AUTO_TEST=${testOpt.autotest} SYSCALL_TEST_DIR=${testOpt.syscall.testDir} $EXTRA_CMDLINE"
+      FINAL_CMDLINE="init=${initProgram} AUTO_TEST=${testOpt.autotest} SYSCALL_TEST_DIR=${testOpt.syscall.testDir} DUNITEST_DIR=${testOpt.dunitest.testDir} $EXTRA_CMDLINE"
 
       ARCH_FLAGS=( ${lib.escapeShellArgs commonArchArgs} )
       ${archSpecificBash}
@@ -380,15 +377,27 @@ let
       ${
         if hasVmstateDir then
           ''
+            ${lib.optionalString debug ''
+            GDB_ARGS=( "-gdb" "tcp::$GDB_PORT" )
+            if [ "''${QEMU_GDB_WAIT:-0}" = "1" ]; then
+              GDB_ARGS+=( "-S" )
+            fi
+            ''}
             sudo bash -c 'pidfile="$1"; shift; echo $$ > "$pidfile"; exec "$@"' bash "$VMSTATE_DIR/pid" ${qemuBin} ${qemuFlagsStr} "''${NET_ARGS[@]}" ${
               if qemuFirmware != null then "-L ${qemuFirmware}" else ""
-            } "''${ARCH_FLAGS[@]}" "''${BOOT_ARGS[@]}" "''${DISK_ARGS[@]}" "''${VSOCK_ARGS[@]}" "$@"
+            } "''${ARCH_FLAGS[@]}" "''${BOOT_ARGS[@]}" "''${DISK_ARGS[@]}" "''${VSOCK_ARGS[@]}" ${lib.optionalString debug ''"''${GDB_ARGS[@]}"''} "$@"
           ''
         else
           ''
+            ${lib.optionalString debug ''
+            GDB_ARGS=( "-gdb" "tcp::$GDB_PORT" )
+            if [ "''${QEMU_GDB_WAIT:-0}" = "1" ]; then
+              GDB_ARGS+=( "-S" )
+            fi
+            ''}
             sudo ${qemuBin} ${qemuFlagsStr} "''${NET_ARGS[@]}" ${
               if qemuFirmware != null then "-L ${qemuFirmware}" else ""
-            } "''${ARCH_FLAGS[@]}" "''${BOOT_ARGS[@]}" "''${DISK_ARGS[@]}" "''${VSOCK_ARGS[@]}" "$@"
+            } "''${ARCH_FLAGS[@]}" "''${BOOT_ARGS[@]}" "''${DISK_ARGS[@]}" "''${VSOCK_ARGS[@]}" ${lib.optionalString debug ''"''${GDB_ARGS[@]}"''} "$@"
           ''
       }
     '';

--- a/user/apps/default.nix
+++ b/user/apps/default.nix
@@ -55,6 +55,13 @@ let
       version = testOpt.syscall.version;
     }
   );
+
+  dunitest = (
+    pkgs.callPackage ./tests/dunitest {
+      inherit fenix system;
+      installDir = testOpt.dunitest.testDir;
+    }
+  );
 in
 [
   (static.busybox.override {
@@ -75,4 +82,7 @@ in
   # gvisor test case only included on x86_64
   gvisor-syscall-tests
   # TODO: Add debian libcxx deps or FHS
+]
+++ lib.optionals (target == "x86_64" && testOpt.dunitest.enable) [
+  dunitest
 ]

--- a/user/apps/tests/dunitest/default.nix
+++ b/user/apps/tests/dunitest/default.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  pkgs,
+  fenix,
+  system,
+  installDir,
+}:
+
+let
+  fenixPkgs = fenix.packages.${system};
+  toolchain = fenixPkgs.combine (
+    with fenixPkgs;
+    [
+      minimal.rustc
+      minimal.cargo
+    ]
+  );
+  rustPlatform = pkgs.makeRustPlatform {
+    cargo = toolchain;
+    rustc = toolchain;
+  };
+
+  gtest = pkgs.fetchgit {
+    url = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/googletest";
+    rev = "v1.17.0";
+    sha256 = "sha256-HIHMxAUR4bjmFLoltJeIAVSulVQ6kVuIT2Ku+lwAx/4=";
+  };
+
+  suites = [ "demo" "normal" "fuse" ];
+
+  # 1. Build the Rust runner separately
+  # This ensures that changes to test scripts or data don't trigger a Rust rebuild.
+  runner = rustPlatform.buildRustPackage {
+    pname = "dunitest-runner-bin";
+    version = "0.1.0";
+
+    src = ./runner;
+    cargoLock = {
+      lockFile = ./runner/Cargo.lock;
+    };
+
+    # Move the binary to the expected install directory structure
+    postInstall = ''
+      mkdir -p $out/${installDir}
+      if [ -f "$out/bin/dunitest-runner" ]; then
+        mv "$out/bin/dunitest-runner" "$out/${installDir}/dunitest-runner"
+        # Clean up empty bin directory if it exists, to avoid clutter in symlinkJoin
+        rmdir "$out/bin" || true
+      fi
+    '';
+  };
+
+  # 2. Build the C++ test suites
+  # This derivation handles compiling the gtest-based test cases.
+  testSuites = pkgs.stdenv.mkDerivation {
+    pname = "dunitest-suites";
+    version = "0.1.0";
+
+    # Use sourceByRegex to only depend on relevant files.
+    # This prevents rebuilds when files in ./runner change.
+    src = lib.sourceByRegex ./. [
+      "^suites$"
+      "^suites/.*"
+      "^whitelist\\.txt$"
+      "^scripts$"
+      "^scripts/run_tests\\.sh$"
+    ];
+
+    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+
+    buildInputs = [ pkgs.stdenv.cc.cc.lib ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      for suite in ${lib.concatStringsSep " " suites}; do
+        mkdir -p bin/$suite
+        for f in suites/$suite/*.cc; do
+          name=$(basename "$f" .cc)
+          echo "编译测例: $f -> bin/$suite/''${name}_test"
+          $CXX -Wall -O2 -std=c++17 -pthread \
+            -I${gtest}/googletest -I${gtest}/googletest/include \
+            "$f" ${gtest}/googletest/src/gtest-all.cc \
+            -o bin/$suite/''${name}_test
+        done
+      done
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/${installDir}
+      cp -r bin $out/${installDir}/
+      install -m644 whitelist.txt $out/${installDir}/
+      install -m755 scripts/run_tests.sh $out/${installDir}/
+
+      runHook postInstall
+    '';
+  };
+
+in
+pkgs.symlinkJoin {
+  name = "dunitest";
+  paths = [
+    runner
+    testSuites
+  ];
+  meta = with lib; {
+    description = "DragonOS dunitest runner and test suites";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#ifdef _WIN32
+
+TEST(ProcessSignalFork, PosixForkAndJobControlUnavailableOnWindows) {
+    GTEST_SKIP() << "Windows does not provide POSIX fork/SIGSTOP/SIGCONT semantics";
+}
+
+#else
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+namespace {
+
+void SleepForMillis(long millis) {
+    timespec ts {};
+    ts.tv_sec = millis / 1000;
+    ts.tv_nsec = (millis % 1000) * 1000 * 1000;
+    while (nanosleep(&ts, &ts) != 0 && errno == EINTR) {
+    }
+}
+
+bool WaitForExit(pid_t child, int* status, int rounds) {
+    for (int i = 0; i < rounds; ++i) {
+        pid_t ret = waitpid(child, status, WNOHANG);
+        if (ret == child) {
+            return true;
+        }
+        if (ret < 0 && errno != EINTR) {
+            return false;
+        }
+        SleepForMillis(10);
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST(ProcessSignalFork, StopContinueRaceDoesNotLeaveChildStuck) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (child == 0) {
+        for (;;) {
+            asm volatile("" ::: "memory");
+        }
+    }
+
+    for (int i = 0; i < 200; ++i) {
+        ASSERT_EQ(0, kill(child, SIGSTOP))
+            << "SIGSTOP failed at iteration " << i << ": errno=" << errno << " ("
+            << strerror(errno) << ")";
+        sched_yield();
+        ASSERT_EQ(0, kill(child, SIGCONT))
+            << "SIGCONT failed at iteration " << i << ": errno=" << errno << " ("
+            << strerror(errno) << ")";
+
+        int event_status = 0;
+        while (waitpid(child, &event_status, WUNTRACED | WCONTINUED | WNOHANG) == child) {
+        }
+    }
+
+    ASSERT_EQ(0, kill(child, SIGCONT))
+        << "final SIGCONT failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_EQ(0, kill(child, SIGTERM))
+        << "SIGTERM failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    int status = 0;
+    if (!WaitForExit(child, &status, 300)) {
+        kill(child, SIGKILL);
+        waitpid(child, &status, 0);
+        FAIL() << "child did not exit after SIGSTOP/SIGCONT race stress";
+    }
+
+    ASSERT_TRUE(WIFSIGNALED(status) || WIFEXITED(status)) << "child status=" << status;
+    if (WIFSIGNALED(status)) {
+        EXPECT_EQ(SIGTERM, WTERMSIG(status));
+    } else {
+        EXPECT_EQ(0, WEXITSTATUS(status));
+    }
+}
+
+#endif
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -36,3 +36,4 @@ normal/tty_tcflush
 normal/signal_fpstate_sigreturn
 normal/general_protection_signal
 normal/seccomp
+normal/process_signal_fork


### PR DESCRIPTION
### 1. 引入 `pi_lock` 替代 `inner_lock`，对齐 Linux `task_rq_lock()` 锁序
原实现使用 `RwLock<InnerSchedInfo>` 保护进程状态、优先级、调度策略，锁粒度过大且与 Linux 语义不符。
- **状态字段原子化**：移除 `InnerSchedInfo`（含 `state` + `sleep`），新增 `state_atomic: AtomicU32`，使用与 Linux 一致的位编码（`TASK_RUNNING=0x0000`, `TASK_INTERRUPTIBLE=0x0001`, `TASK_UNINTERRUPTIBLE=0x0002`, `TASK_STOPPED=0x0004`, `TASK_DEAD_MARKER=0x0080`，退出码存高 20 位）。
- **新增 `pi_lock: SpinLock<PiProtected>`**：保护 `cpus_allowed` 和 `nr_cpus_allowed`，集中管理受 pi_lock 保护的字段。
- **调度策略与优先级原子化**：`sched_policy: RwLock<SchedPolicy>` → `AtomicU8`；`prio_data: RwLock<PrioData>` → 拆分为 `prio: AtomicI32`、`static_prio: AtomicI32`、`normal_prio: AtomicI32`。
- **锁序规范**：`pi_lock → rq_lock`（对齐 Linux `task_rq_lock()`），释放时先 `rq_lock` 后 `pi_lock`。

### 2. 修复 `rwlock` 抢占/中断顺序
原 `read_irqsave`/`write_irqsave`/`upgradeable_read_irqsave` 在自旋循环内部每次迭代都重新关中断，中断状态不一致。
- 在循环外先 `save_and_disable_irq()` + `preempt_disable()`，循环内仅尝试获取锁。
- 修复 Guard 转换（`downgrade_to_read`）：使用 `mem::forget(self)` 跳过原 Guard 的 `preempt_enable`，由新 Guard 接管。
- 修正 `Drop` 顺序：所有 Guard 先恢复中断（`irq_guard.take()`），再启用抢占（`preempt_enable()`）。

### 3. 修复 `spinlock` 解锁顺序，对齐 Linux `spin_unlock_irqrestore` / `spin_unlock_bh`
- **移除** `SpinLock::unlock()` 中的 `preempt_enable()`，移至 `SpinLockGuard::drop()` 中，确保顺序为：先解锁 → 恢复中断 → 启用抢占。
- **调整** `SpinLockBhGuard` 字段顺序为 `guard` 在前、`bh` 在后，确保 Rust Drop 顺序为：先解锁 → 恢复 BH（对齐 `spin_unlock_bh`）。

### 4. 重构 `__schedule()` 对齐 Linux 信号检查语义
- **移除** `is_mark_sleep` 判断（原 `InnerSchedInfo.sleep` 标志）。
- **对标** `smp_mb__after_spinlock()` 语义：获取 `rq_lock` 后插入 `fence(Ordering::SeqCst)`。
- **调整** 计数位置：`nr_uninterruptible++` 在 `deactivate_task` 之前；`nr_iowait++` 在 `deactivate_task` 之后。
- **调整** `activate_task`/`deactivate_task`：移除其中的 `nr_iowait`/`nr_uninterruptible`/`IDLE_CPUS` 维护，移至调用方。

### 5. 修复 `sched_fork()` 子进程策略/优先级继承
- 子进程继承父进程的 `normal_prio`、`static_prio`、`policy`
- 使用原子操作替代读写锁。

### 6. 修复 `copy_flags()` 子进程标志位继承
子进程不再继承父进程运行时状态标志（`NEED_SCHEDULE`、`EXITING`、`WAKEKILL`、`SIGNALED`、`NEED_MIGRATE` 等），仅继承 `RANDOMIZE`（ASLR 配置）。`KTHREAD` 标志由创建参数显式设置。

### 7. 函数重命名（修复拼写）
- `check_preempt_currnet` → `check_preempt_current`
- `wakeup_new_task` → `wake_up_new_task`

### 8. Nix 构建系统：新增 GDB 调试支持
- QEMU 动态分配 GDB 端口，支持 `QEMU_GDB_WAIT=1` 暂停等待连接。
- 新增 `gdb-${target}` app/package，使用 `rust-gdb`（x86_64）或 `gdb-multiarch`（其他架构）。
- 新增 `dunitest` 测试框架集成。