### PR TITLE
feat(rtnetlink): complete NETLINK_ROUTE (rtnetlink) capabilities and netlink socket infrastructure, with userspace unit tests

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1543,7 +1543,7 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 [[package]]
 name = "smoltcp"
 version = "0.12.0"
-source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/smoltcp?rev=c65e776#c65e7763d4497b2e685269cc568d09300392b47a"
+source = "git+https://github.com/DragonOS-Community/smoltcp?rev=3933571#3933571d212b5c10cca7222c2e9a20fb2050870b"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -59,7 +59,7 @@ linkme = "=0.3.27"
 num = { version = "=0.4.0", default-features = false }
 num-derive = "=0.3"
 num-traits = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/num-traits.git", rev = "1597c1c", default-features = false }
-smoltcp = { version = "=0.12.0", git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/smoltcp", rev = "c65e776", default-features = false, features = [
+smoltcp = { version = "=0.12.0", git = "https://github.com/DragonOS-Community/smoltcp", rev = "3933571", default-features = false, features = [
     "alloc",
     "medium-ethernet",
     "socket-raw",

--- a/kernel/src/driver/base/block/manager.rs
+++ b/kernel/src/driver/base/block/manager.rs
@@ -1,6 +1,6 @@
 use core::{fmt::Formatter, sync::atomic::AtomicU32};
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{string::ToString, sync::Arc, vec::Vec};
 use hashbrown::HashMap;
 use system_error::SystemError;
 use unified_init::macros::unified_init;
@@ -9,6 +9,7 @@ use crate::{
     driver::base::{
         block::gendisk::GenDisk,
         device::{device_number::Major, DevName},
+        kobject::KObject,
     },
     filesystem::{
         devfs::{devfs_register, devfs_unregister},
@@ -162,6 +163,7 @@ impl BlockDevManager {
             );
             e
         })?;
+        self.emit_gendisk_uevent(dev, dname.as_ref(), "add");
         Ok(())
     }
 
@@ -222,9 +224,30 @@ impl BlockDevManager {
         }
         drop(inner);
 
+        for gendisk in &gendisks {
+            let dname = gendisk.dname()?;
+            self.emit_gendisk_uevent(dev, dname.as_ref(), "remove");
+        }
+
         let mut meta_inner = blk_meta.inner();
         meta_inner.gendisks.clear();
         Ok(())
+    }
+
+    fn emit_gendisk_uevent(&self, dev: &Arc<dyn BlockDevice>, devname: &str, action: &str) {
+        let kobj = dev.device() as Arc<dyn KObject>;
+        let Ok(parent_devpath) = <dyn KObject>::devpath(&kobj) else {
+            return;
+        };
+        let devpath = format!("{parent_devpath}/block/{devname}");
+        let _ = <dyn KObject>::emit_uevent(
+            action,
+            &devpath,
+            &[
+                ("SUBSYSTEM", "block".into()),
+                ("DEVNAME", devname.to_string()),
+            ],
+        );
     }
     /// 通过路径查找gendisk
     ///

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -618,7 +618,12 @@ impl DeviceManager {
         if let Some(subsystem) = device
             .class()
             .map(|class| class.name().to_string())
-            .or_else(|| device.bus().and_then(|bus| bus.upgrade()).map(|bus| bus.name()))
+            .or_else(|| {
+                device
+                    .bus()
+                    .and_then(|bus| bus.upgrade())
+                    .map(|bus| bus.name())
+            })
         {
             if subsystem != "net" {
                 let devname = device.name();

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -615,8 +615,21 @@ impl DeviceManager {
             );
         }
 
-        // todo: 发送uevent: KOBJ_ADD
-        // kobject_uevent();
+        if let Some(subsystem) = device
+            .class()
+            .map(|class| class.name().to_string())
+            .or_else(|| device.bus().and_then(|bus| bus.upgrade()).map(|bus| bus.name()))
+        {
+            if subsystem != "net" {
+                let devname = device.name();
+                let _ = <dyn KObject>::kobject_uevent(
+                    &(device.clone() as Arc<dyn KObject>),
+                    "add",
+                    &[("SUBSYSTEM", subsystem), ("DEVNAME", devname)],
+                );
+            }
+        }
+
         // probe drivers for a new device
         bus_probe_device(&device);
 

--- a/kernel/src/driver/base/kobject.rs
+++ b/kernel/src/driver/base/kobject.rs
@@ -1,8 +1,16 @@
-use core::{any::Any, fmt::Debug, hash::Hash, ops::Deref};
+use core::{
+    any::Any,
+    fmt::Debug,
+    hash::Hash,
+    ops::Deref,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use alloc::{
+    format,
     string::String,
     sync::{Arc, Weak},
+    vec::Vec,
 };
 use driver_base_macros::get_weak_or_clear;
 use intertrait::CastFromSync;
@@ -18,11 +26,19 @@ use crate::{
         rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
         spinlock::SpinLock,
     },
+    net::socket::netlink::{
+        addr::multicast::GroupIdSet,
+        kobject::message::KobjectUeventMessage,
+        table::{NetlinkKobjectUeventProtocol, SupportedNetlinkProtocol},
+    },
+    process::{namespace::net_namespace::INIT_NET_NAMESPACE, ProcessManager},
 };
 
 use system_error::SystemError;
 
 use super::kset::KSet;
+
+static UEVENT_SEQNUM: AtomicU64 = AtomicU64::new(1);
 
 pub trait KObject: Any + Send + Sync + Debug + CastFromSync {
     fn as_any_ref(&self) -> &dyn core::any::Any;
@@ -67,12 +83,92 @@ impl dyn KObject {
         let mut state = self.kobj_state_mut();
         *state = (*state | insert) & !remove;
     }
+
+    pub fn kobject_uevent(
+        kobj: &Arc<dyn KObject>,
+        action: &str,
+        extra_env: &[(&str, String)],
+    ) -> Result<(), SystemError> {
+        let devpath = Self::devpath(kobj)?;
+        Self::emit_uevent(action, &devpath, extra_env)
+    }
+
+    pub fn emit_uevent(
+        action: &str,
+        devpath: &str,
+        extra_env: &[(&str, String)],
+    ) -> Result<(), SystemError> {
+        let mut payload = Vec::new();
+        push_env_field(&mut payload, &format!("{action}@{devpath}"));
+        push_env_field(&mut payload, &format!("ACTION={action}"));
+        push_env_field(&mut payload, &format!("DEVPATH={devpath}"));
+        for (key, value) in extra_env {
+            push_env_field(&mut payload, &format!("{key}={value}"));
+        }
+        let seqnum = UEVENT_SEQNUM.fetch_add(1, Ordering::Relaxed);
+        push_env_field(&mut payload, &format!("SEQNUM={seqnum}"));
+
+        let netns = if ProcessManager::initialized() {
+            ProcessManager::current_netns()
+        } else {
+            INIT_NET_NAMESPACE.clone()
+        };
+        NetlinkKobjectUeventProtocol::multicast(
+            GroupIdSet::new(1),
+            KobjectUeventMessage::new(&payload),
+            netns,
+        )
+    }
+
+    pub fn devpath(kobj: &Arc<dyn KObject>) -> Result<String, SystemError> {
+        kobject_devpath(kobj)
+    }
 }
 
 impl DowncastArc for dyn KObject {
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any> {
         self
     }
+}
+
+fn push_env_field(payload: &mut Vec<u8>, field: &str) {
+    payload.extend_from_slice(field.as_bytes());
+    payload.push(0);
+}
+
+fn kobject_devpath(kobj: &Arc<dyn KObject>) -> Result<String, SystemError> {
+    let mut parts: Vec<String> = Vec::new();
+    let mut current = Some(kobj.clone());
+
+    while let Some(node) = current {
+        let name = node.name();
+        if !name.is_empty() {
+            parts.push(name);
+        }
+
+        let Some(parent) = node.parent().and_then(|parent| parent.upgrade()) else {
+            break;
+        };
+
+        if Arc::ptr_eq(&parent, &node) {
+            break;
+        }
+
+        current = Some(parent);
+    }
+
+    parts.reverse();
+    let mut path = String::new();
+    for part in parts {
+        path.push('/');
+        path.push_str(&part);
+    }
+
+    if path.is_empty() {
+        return Err(SystemError::ENOENT);
+    }
+
+    Ok(path)
 }
 
 /// kobject的公共数据

--- a/kernel/src/driver/net/e1000e/e1000e_driver.rs
+++ b/kernel/src/driver/net/e1000e/e1000e_driver.rs
@@ -92,7 +92,6 @@ impl Debug for E1000EDriverWrapper {
 pub struct E1000EInterface {
     driver: E1000EDriverWrapper,
     common: IfaceCommon,
-    name: String,
     inner: SpinLock<InnerE1000EInterface>,
     locked_kobj_state: LockedKObjectState,
 }
@@ -252,6 +251,8 @@ impl phy::Device for E1000EDriver {
 
 impl E1000EInterface {
     pub fn new(mut driver: E1000EDriver) -> Arc<Self> {
+        use smoltcp::phy::Device;
+
         let iface_id = generate_iface_id();
         let mut iface_config = smoltcp::iface::Config::new(HardwareAddress::Ethernet(
             smoltcp::wire::EthernetAddress(driver.inner.lock().mac_address()),
@@ -266,16 +267,19 @@ impl E1000EInterface {
             | InterfaceFlags::RUNNING
             | InterfaceFlags::MULTICAST
             | InterfaceFlags::LOWER_UP;
+        let name = format!("eth{}", iface_id);
+        let mtu = driver.capabilities().max_transmission_unit;
 
         let iface = Arc::new(E1000EInterface {
             driver: E1000EDriverWrapper(UnsafeCell::new(driver)),
             common: IfaceCommon::new(
                 iface_id,
                 crate::driver::net::types::InterfaceType::EETHER,
+                name,
+                mtu,
                 flags,
                 iface,
             ),
-            name: format!("eth{}", iface_id),
             inner: SpinLock::new(InnerE1000EInterface {
                 netdevice_common: NetDeviceCommonData::default(),
                 device_common: DeviceCommonData::default(),
@@ -383,7 +387,7 @@ impl Iface for E1000EInterface {
 
     #[inline]
     fn iface_name(&self) -> String {
-        return self.name.clone();
+        return self.common.name();
     }
 
     fn poll(&self) -> bool {
@@ -420,12 +424,7 @@ impl Iface for E1000EInterface {
     }
 
     fn mtu(&self) -> usize {
-        use smoltcp::phy::Device;
-
-        self.driver
-            .force_get_mut()
-            .capabilities()
-            .max_transmission_unit
+        self.common.mtu()
     }
 }
 
@@ -463,11 +462,11 @@ impl KObject for E1000EInterface {
     }
 
     fn name(&self) -> String {
-        self.name.clone()
+        self.common.name()
     }
 
-    fn set_name(&self, _name: String) {
-        // do nothing
+    fn set_name(&self, name: String) {
+        self.common.set_name(name);
     }
 
     fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -341,7 +341,7 @@ impl LoopbackInterface {
     ///
     /// ## 返回值
     /// 返回一个 `Arc<Self>`，即一个指向新创建的 `LoopbackInterface` 实例的智能指针。
-    pub fn new(mut driver: LoopbackDriver) -> Arc<Self> {
+    pub fn new(driver: LoopbackDriver) -> Arc<Self> {
         Self::new_with_ifindex(driver, generate_iface_id())
     }
 

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -342,7 +342,14 @@ impl LoopbackInterface {
     /// ## 返回值
     /// 返回一个 `Arc<Self>`，即一个指向新创建的 `LoopbackInterface` 实例的智能指针。
     pub fn new(mut driver: LoopbackDriver) -> Arc<Self> {
-        let iface_id = generate_iface_id();
+        Self::new_with_ifindex(driver, generate_iface_id())
+    }
+
+    /// 在指定网络命名空间中创建 loopback，使用给定的 per-netns ifindex（Linux 新 netns 中 lo 通常为 1）。
+    pub fn new_with_ifindex(mut driver: LoopbackDriver, ifindex: usize) -> Arc<Self> {
+        use smoltcp::phy::Device;
+
+        let iface_id = ifindex;
 
         // let hardware_addr = HardwareAddress::Ethernet(smoltcp::wire::EthernetAddress([
         //     0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -396,12 +403,15 @@ impl LoopbackInterface {
             | InterfaceFlags::UP
             | InterfaceFlags::RUNNING
             | InterfaceFlags::LOWER_UP;
+        let mtu = driver.capabilities().max_transmission_unit;
 
         let iface = Arc::new(LoopbackInterface {
             driver: LoopbackDriverWapper(UnsafeCell::new(driver)),
             common: IfaceCommon::new(
                 iface_id,
                 super::types::InterfaceType::LOOPBACK,
+                Self::DEVICE_NAME.to_string(),
+                mtu,
                 flags,
                 iface,
             ),
@@ -467,11 +477,11 @@ impl KObject for LoopbackInterface {
     }
 
     fn name(&self) -> String {
-        Self::DEVICE_NAME.to_string()
+        self.common.name()
     }
 
-    fn set_name(&self, _name: String) {
-        // do nothing
+    fn set_name(&self, name: String) {
+        self.common.set_name(name);
     }
 
     fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {
@@ -566,7 +576,7 @@ impl Iface for LoopbackInterface {
     }
 
     fn iface_name(&self) -> String {
-        Self::DEVICE_NAME.to_string()
+        self.common.name()
     }
 
     /// 由于lo网卡设备不是实际的物理设备，其mac地址需要手动设置为一个默认值，这里默认为00:00:00:00:00
@@ -620,12 +630,7 @@ impl Iface for LoopbackInterface {
     }
 
     fn mtu(&self) -> usize {
-        use smoltcp::phy::Device;
-
-        self.driver
-            .force_get_mut()
-            .capabilities()
-            .max_transmission_unit
+        self.common.mtu()
     }
 }
 

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -383,7 +383,7 @@ impl LoopbackInterface {
             routes_map
                 .push(smoltcp::iface::Route {
                     cidr,
-                    via_router: addr,
+                    via_router: None,
                     preferred_until: None,
                     expires_at: None,
                 })
@@ -392,7 +392,7 @@ impl LoopbackInterface {
             routes_map
                 .push(smoltcp::iface::Route {
                     cidr: cidr6,
-                    via_router: addr6,
+                    via_router: None,
                     preferred_until: None,
                     expires_at: None,
                 })

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -2,11 +2,12 @@ use alloc::sync::Weak;
 use alloc::{fmt, vec::Vec};
 use alloc::{string::String, sync::Arc};
 use core::net::Ipv4Addr;
+use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use sysfs::netdev_register_kobject;
 
 use crate::driver::net::napi::NapiStruct;
 use crate::driver::net::types::{InterfaceFlags, InterfaceType};
-use crate::libs::rwsem::RwSemReadGuard;
+use crate::libs::rwsem::{RwSem, RwSemReadGuard};
 use crate::net::routing::RouterEnableDeviceCommon;
 use crate::net::socket::packet::PacketSocket;
 use crate::process::namespace::net_namespace::NetNamespace;
@@ -209,6 +210,26 @@ impl Default for NetDeviceCommonData {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct NetlinkRouteEntry {
+    pub destination: smoltcp::wire::IpCidr,
+    pub source: Option<smoltcp::wire::IpCidr>,
+    pub gateway: Option<smoltcp::wire::IpAddress>,
+    pub priority: u32,
+    pub table: u8,
+    pub protocol: u8,
+    pub scope: u8,
+    pub kind: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticNeighborEntry {
+    pub ip_addr: smoltcp::wire::IpAddress,
+    pub hw_addr: smoltcp::wire::HardwareAddress,
+    pub state: u16,
+    pub flags: u8,
+}
+
 /// 将网络设备注册到sysfs中
 /// 参考：https://code.dragonos.org.cn/xref/linux-2.6.39/net/core/dev.c?fi=register_netdev#5373
 fn register_netdevice(dev: Arc<dyn Iface>) -> Result<(), SystemError> {
@@ -223,7 +244,9 @@ fn register_netdevice(dev: Arc<dyn Iface>) -> Result<(), SystemError> {
 
 pub struct IfaceCommon {
     iface_id: usize,
-    flags: InterfaceFlags,
+    name: RwLock<String>,
+    flags: AtomicU32,
+    mtu: AtomicUsize,
     type_: InterfaceType,
     smol_iface: Mutex<smoltcp::iface::Interface>,
     /// 存smoltcp网卡的套接字集
@@ -242,6 +265,8 @@ pub struct IfaceCommon {
     napi_struct: RwLock<Option<Arc<NapiStruct>>>,
     /// Packet sockets registered to receive raw frames
     packet_sockets: RwLock<Vec<Weak<PacketSocket>>>,
+    netlink_routes: RwSem<Vec<NetlinkRouteEntry>>,
+    static_neighbors: RwSem<Vec<StaticNeighborEntry>>,
     /// TCP close(2) 语义辅助：延迟回收 smoltcp TCP socket（Linux-like）。
     tcp_close_defer: crate::net::tcp_close_defer::TcpCloseDefer,
     /// TCP listener/backlog 语义辅助（Linux-like 丢 SYN 等）。
@@ -262,6 +287,8 @@ impl IfaceCommon {
     pub fn new(
         iface_id: usize,
         type_: InterfaceType,
+        name: String,
+        mtu: usize,
         flags: InterfaceFlags,
         iface: smoltcp::iface::Interface,
     ) -> Self {
@@ -272,6 +299,7 @@ impl IfaceCommon {
             .extend_from_slice(iface.ip_addrs());
         IfaceCommon {
             iface_id,
+            name: RwLock::new(name),
             smol_iface: Mutex::new(iface),
             sockets: Mutex::new(smoltcp::iface::SocketSet::new(Vec::new())),
             bounds: RwLock::new(Vec::new()),
@@ -279,10 +307,13 @@ impl IfaceCommon {
             poll_at_us: core::sync::atomic::AtomicU64::new(0),
             net_namespace: RwLock::new(Weak::new()),
             router_common_data,
-            flags,
+            flags: AtomicU32::new(flags.bits()),
+            mtu: AtomicUsize::new(mtu),
             type_,
             napi_struct: RwLock::new(None),
             packet_sockets: RwLock::new(Vec::new()),
+            netlink_routes: RwSem::new(Vec::new()),
+            static_neighbors: RwSem::new(Vec::new()),
             tcp_close_defer: crate::net::tcp_close_defer::TcpCloseDefer::new(),
             tcp_listener_backlog: crate::net::tcp_listener_backlog::TcpListenerBacklog::new(),
             ipv4_multicast_refcnt: Mutex::new(Vec::new()),
@@ -622,12 +653,101 @@ impl IfaceCommon {
         *guard = Arc::downgrade(&ns);
     }
 
+    pub fn name(&self) -> String {
+        self.name.read().clone()
+    }
+
+    pub fn set_name(&self, name: String) {
+        *self.name.write() = name;
+    }
+
     pub fn flags(&self) -> InterfaceFlags {
-        self.flags
+        InterfaceFlags::from_bits_truncate(self.flags.load(Ordering::Relaxed))
+    }
+
+    pub fn set_flags(&self, flags: InterfaceFlags) {
+        self.flags.store(flags.bits(), Ordering::Relaxed);
     }
 
     pub fn type_(&self) -> InterfaceType {
         self.type_
+    }
+
+    pub fn mtu(&self) -> usize {
+        self.mtu.load(Ordering::Relaxed)
+    }
+
+    pub fn set_mtu(&self, mtu: usize) {
+        self.mtu.store(mtu, Ordering::Relaxed);
+    }
+
+    pub fn netlink_routes(&self) -> RwSemReadGuard<'_, Vec<NetlinkRouteEntry>> {
+        self.netlink_routes.read()
+    }
+
+    pub fn upsert_netlink_route(&self, route: NetlinkRouteEntry) {
+        let mut routes = self.netlink_routes.write();
+        if let Some(existing) = routes.iter_mut().find(|existing| {
+            existing.destination == route.destination
+                && existing.table == route.table
+                && existing
+                    .source
+                    .as_ref()
+                    .map(|cidr| (cidr.address(), cidr.prefix_len()))
+                    == route
+                        .source
+                        .as_ref()
+                        .map(|cidr| (cidr.address(), cidr.prefix_len()))
+        }) {
+            *existing = route;
+        } else {
+            routes.push(route);
+        }
+    }
+
+    pub fn remove_netlink_route(
+        &self,
+        destination: smoltcp::wire::IpCidr,
+        source: Option<smoltcp::wire::IpCidr>,
+        table: u8,
+    ) -> bool {
+        let mut routes = self.netlink_routes.write();
+        let before = routes.len();
+        routes.retain(|existing| {
+            !(existing.destination == destination
+                && existing.table == table
+                && existing
+                    .source
+                    .as_ref()
+                    .map(|cidr| (cidr.address(), cidr.prefix_len()))
+                    == source
+                        .as_ref()
+                        .map(|cidr| (cidr.address(), cidr.prefix_len())))
+        });
+        routes.len() != before
+    }
+
+    pub fn static_neighbors(&self) -> RwSemReadGuard<'_, Vec<StaticNeighborEntry>> {
+        self.static_neighbors.read()
+    }
+
+    pub fn set_static_neighbor(&self, entry: StaticNeighborEntry) {
+        let mut neighbors = self.static_neighbors.write();
+        if let Some(existing) = neighbors
+            .iter_mut()
+            .find(|existing| existing.ip_addr == entry.ip_addr)
+        {
+            *existing = entry;
+        } else {
+            neighbors.push(entry);
+        }
+    }
+
+    pub fn remove_static_neighbor(&self, ip_addr: smoltcp::wire::IpAddress) -> bool {
+        let mut neighbors = self.static_neighbors.write();
+        let before = neighbors.len();
+        neighbors.retain(|existing| existing.ip_addr != ip_addr);
+        neighbors.len() != before
     }
 
     /// 注册 packet socket 以接收原始数据包

--- a/kernel/src/driver/net/napi.rs
+++ b/kernel/src/driver/net/napi.rs
@@ -1,4 +1,4 @@
-use crate::driver::net::Iface;
+use crate::driver::net::{types::InterfaceFlags, Iface};
 use crate::init::initcall::INITCALL_SUBSYS;
 use crate::libs::spinlock::{SpinLock, SpinLockGuard};
 use crate::libs::wait_queue::WaitQueue;
@@ -46,6 +46,9 @@ impl NapiStruct {
         // log::info!("NAPI instance {} polling", self.napi_id);
         // 获取网卡的强引用
         if let Some(iface) = self.net_device.upgrade() {
+            if !iface.flags().contains(InterfaceFlags::UP) {
+                return false;
+            }
             // Linux NAPI 语义：每次 poll 处理有限工作量（budget/weight），避免无界处理导致 DoS/长时间关中断。
             // smoltcp 的 Interface::poll() 会在一次调用内处理 device 队列中所有包，因此这里必须走 bounded poll。
             //

--- a/kernel/src/driver/net/sysfs.rs
+++ b/kernel/src/driver/net/sysfs.rs
@@ -34,6 +34,16 @@ pub fn netdev_register_kobject(dev: Arc<dyn Iface>) -> Result<(), SystemError> {
     dev.set_name(dev.iface_name().clone());
 
     device_manager().add_device(dev.clone() as Arc<dyn Device>)?;
+    let ifname = dev.iface_name();
+    <dyn KObject>::kobject_uevent(
+        &(dev.clone() as Arc<dyn KObject>),
+        "add",
+        &[
+            ("SUBSYSTEM", "net".into()),
+            ("DEVNAME", ifname.clone()),
+            ("INTERFACE", ifname),
+        ],
+    )?;
 
     return Ok(());
 }

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -392,6 +392,8 @@ impl VethInterface {
     }
 
     pub fn new(driver: VethDriver) -> Arc<Self> {
+        use smoltcp::phy::Device;
+
         let iface_id = generate_iface_id();
         let name = driver.name();
         let mac = [
@@ -417,11 +419,19 @@ impl VethInterface {
             | InterfaceFlags::UP
             | InterfaceFlags::RUNNING
             | InterfaceFlags::LOWER_UP;
+        let mtu = driver.capabilities().max_transmission_unit;
 
         let device = Arc::new(VethInterface {
             name,
             driver: VethDriverWarpper(UnsafeCell::new(driver.clone())),
-            common: IfaceCommon::new(iface_id, super::types::InterfaceType::EETHER, flags, iface),
+            common: IfaceCommon::new(
+                iface_id,
+                super::types::InterfaceType::EETHER,
+                driver.name(),
+                mtu,
+                flags,
+                iface,
+            ),
             inner: SpinLock::new(VethCommonData::default()),
             locked_kobj_state: LockedKObjectState::default(),
         });
@@ -563,10 +573,12 @@ impl KObject for VethInterface {
     }
 
     fn name(&self) -> String {
-        self.name.clone()
+        self.common.name()
     }
 
-    fn set_name(&self, _name: String) {}
+    fn set_name(&self, name: String) {
+        self.common.set_name(name);
+    }
     fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {
         self.locked_kobj_state.read()
     }
@@ -590,7 +602,7 @@ impl device::Device for VethInterface {
     }
 
     fn id_table(&self) -> IdTable {
-        IdTable::new(self.name.clone(), None)
+        IdTable::new(self.common.name(), None)
     }
 
     fn bus(&self) -> Option<Weak<dyn Bus>> {
@@ -657,7 +669,7 @@ impl Iface for VethInterface {
     }
 
     fn iface_name(&self) -> String {
-        self.name.clone()
+        self.common.name()
     }
 
     fn mac(&self) -> EthernetAddress {
@@ -704,11 +716,7 @@ impl Iface for VethInterface {
     }
 
     fn mtu(&self) -> usize {
-        use smoltcp::phy::Device;
-        self.driver
-            .force_get_mut()
-            .capabilities()
-            .max_transmission_unit
+        self.common.mtu()
     }
 }
 

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -516,7 +516,7 @@ impl VethInterface {
             routes_map
                 .push(smoltcp::iface::Route {
                     cidr: IpCidr::new(IpAddress::v4(0, 0, 0, 0), 0),
-                    via_router: peer_ip,
+                    via_router: Some(peer_ip),
                     preferred_until: None,
                     expires_at: None,
                 })
@@ -530,7 +530,7 @@ impl VethInterface {
     //         routes_map
     //             .push(smoltcp::iface::Route {
     //                 cidr,
-    //                 via_router,
+    //                 via_router: Some(via_router),
     //                 preferred_until: None,
     //                 expires_at: None,
     //             })

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -498,7 +498,6 @@ impl VirtioInterface {
     fn inner(&self) -> SpinLockGuard<'_, InnerVirtIOInterface> {
         return self.inner.lock();
     }
-
 }
 
 impl Drop for VirtioInterface {

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -432,7 +432,6 @@ impl Debug for VirtIONicDeviceInner {
 #[derive(Debug)]
 pub struct VirtioInterface {
     device_inner: VirtIONicDeviceInnerWrapper,
-    iface_name: String,
     iface_common: super::IfaceCommon,
     inner: SpinLock<InnerVirtIOInterface>,
     locked_kobj_state: LockedKObjectState,
@@ -447,6 +446,8 @@ struct InnerVirtIOInterface {
 
 impl VirtioInterface {
     pub fn new(mut device_inner: VirtIONicDeviceInner) -> Arc<Self> {
+        use smoltcp::phy::Device;
+
         let iface_id = generate_iface_id();
         let mut iface_config = iface::Config::new(wire::HardwareAddress::Ethernet(
             wire::EthernetAddress(device_inner.inner.lock_irqsave().mac_address()),
@@ -460,14 +461,17 @@ impl VirtioInterface {
             | InterfaceFlags::RUNNING
             | InterfaceFlags::MULTICAST
             | InterfaceFlags::LOWER_UP;
+        let iface_name = format!("eth{}", iface_id);
+        let mtu = device_inner.capabilities().max_transmission_unit;
 
         let iface = Arc::new(VirtioInterface {
             device_inner: VirtIONicDeviceInnerWrapper(UnsafeCell::new(device_inner)),
             locked_kobj_state: LockedKObjectState::default(),
-            iface_name: format!("eth{}", iface_id),
             iface_common: super::IfaceCommon::new(
                 iface_id,
                 crate::driver::net::types::InterfaceType::EETHER,
+                iface_name,
+                mtu,
                 flags,
                 iface,
             ),
@@ -495,11 +499,6 @@ impl VirtioInterface {
         return self.inner.lock();
     }
 
-    /// 获取网卡接口的名称
-    #[allow(dead_code)]
-    pub fn iface_name(&self) -> String {
-        self.iface_name.clone()
-    }
 }
 
 impl Drop for VirtioInterface {
@@ -771,7 +770,7 @@ impl Iface for VirtioInterface {
 
     #[inline]
     fn iface_name(&self) -> String {
-        return self.iface_name.clone();
+        return self.iface_common.name();
     }
 
     fn poll(&self) -> bool {
@@ -814,11 +813,7 @@ impl Iface for VirtioInterface {
     }
 
     fn mtu(&self) -> usize {
-        use smoltcp::phy::Device;
-        self.device_inner
-            .force_get_mut()
-            .capabilities()
-            .max_transmission_unit
+        self.iface_common.mtu()
     }
 }
 
@@ -856,11 +851,11 @@ impl KObject for VirtioInterface {
     }
 
     fn name(&self) -> String {
-        self.iface_name.clone()
+        self.iface_common.name()
     }
 
-    fn set_name(&self, _name: String) {
-        // do nothing
+    fn set_name(&self, name: String) {
+        self.iface_common.set_name(name);
     }
 
     fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {

--- a/kernel/src/net/neighbor.rs
+++ b/kernel/src/net/neighbor.rs
@@ -62,6 +62,18 @@ pub fn get_arp_entries() -> Vec<ArpEntry> {
                 });
             }
         }
+
+        for neighbor in iface.common().static_neighbors().iter() {
+            if let IpAddress::Ipv4(ipv4) = neighbor.ip_addr {
+                entries.push(ArpEntry {
+                    ip_addr: IpAddress::Ipv4(ipv4),
+                    hw_type: ArpHrd::Ethernet,
+                    flags: ArpFlags::COM,
+                    hw_addr: neighbor.hw_addr,
+                    device: dev_name.clone(),
+                });
+            }
+        }
     }
 
     entries

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -71,7 +71,7 @@ fn dhcp_query() -> Result<(), SystemError> {
                                 smoltcp::wire::Ipv4Address::new(127, 0, 0, 0),
                                 8,
                             )),
-                            via_router: smoltcp::wire::IpAddress::v4(127, 0, 0, 1),
+                            via_router: None,
                             preferred_until: None,
                             expires_at: None,
                         });

--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -316,7 +316,10 @@ fn iface_matches_directed_broadcast(
 }
 
 #[inline]
-fn loopback_iface_contains_v4(iface: &Arc<dyn Iface>, v4_addr: smoltcp::wire::Ipv4Address) -> bool {
+pub(super) fn loopback_iface_contains_v4(
+    iface: &Arc<dyn Iface>,
+    v4_addr: smoltcp::wire::Ipv4Address,
+) -> bool {
     if !iface.flags().contains(InterfaceFlags::LOOPBACK) {
         return false;
     }

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -28,8 +28,8 @@ use core::sync::atomic::{
 use smoltcp::wire::{IpAddress::*, IpEndpoint, IpListenEndpoint, IpVersion, Ipv4Address};
 
 use super::{
-    common::ensure_bound_dual_stack_remote_compatible, InetSocket, UNSPECIFIED_LOCAL_ENDPOINT_V4,
-    UNSPECIFIED_LOCAL_ENDPOINT_V6,
+    common::{ensure_bound_dual_stack_remote_compatible, loopback_iface_contains_v4},
+    InetSocket, UNSPECIFIED_LOCAL_ENDPOINT_V4, UNSPECIFIED_LOCAL_ENDPOINT_V6,
 };
 
 mod option;
@@ -991,6 +991,10 @@ impl UdpSocket {
                         Ipv4(v4) => v4.is_loopback(),
                         Ipv6(v6) => v6.is_loopback(),
                     };
+                    let is_loopback_local_subnet = match dest.addr {
+                        Ipv4(v4) => loopback_iface_contains_v4(&bound_iface, v4),
+                        Ipv6(_) => false,
+                    };
                     let loopback_broadcast = self
                         .netns
                         .loopback_iface()
@@ -1004,6 +1008,7 @@ impl UdpSocket {
                                 .inner
                                 .is_broadcast(&dest.addr));
                     let should_loopback_send = is_loopback
+                        || is_loopback_local_subnet
                         || ((is_multicast || is_broadcast)
                             && (send_iface_is_loopback || loopback_broadcast));
                     if should_loopback_send {

--- a/kernel/src/net/socket/netlink/addr/multicast.rs
+++ b/kernel/src/net/socket/netlink/addr/multicast.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct GroupIdSet(u32);
+pub struct GroupIdSet(u64);
 
 impl GroupIdSet {
     pub const fn new_empty() -> Self {
@@ -7,7 +7,19 @@ impl GroupIdSet {
     }
 
     pub const fn new(groups: u32) -> Self {
+        Self(groups as u64)
+    }
+
+    pub const fn new_u64(groups: u64) -> Self {
         Self(groups)
+    }
+
+    pub fn from_group_id(group_id: u32) -> Option<Self> {
+        if group_id == 0 || group_id > 64 {
+            return None;
+        }
+
+        Some(Self(1u64 << (group_id - 1)))
     }
 
     pub const fn ids_iter(&self) -> GroupIdIter {
@@ -23,7 +35,7 @@ impl GroupIdSet {
     }
 
     pub fn set_groups(&mut self, new_groups: u32) {
-        self.0 = new_groups;
+        self.0 = new_groups as u64;
     }
 
     pub fn clear(&mut self) {
@@ -35,12 +47,16 @@ impl GroupIdSet {
     }
 
     pub fn as_u32(&self) -> u32 {
+        self.0 as u32
+    }
+
+    pub fn as_u64(&self) -> u64 {
         self.0
     }
 }
 
 pub struct GroupIdIter {
-    groups: u32,
+    groups: u64,
 }
 
 impl GroupIdIter {

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -373,15 +373,9 @@ where
                             .addr()
                             .map_or(0, |addr| addr.groups().as_u64());
                         let needed = self.list_memberships_needed_bytes();
-                        let groups_array = [
-                            groups as u32,
-                            (groups >> 32) as u32,
-                        ];
+                        let groups_array = [groups as u32, (groups >> 32) as u32];
                         let bytes = unsafe {
-                            core::slice::from_raw_parts(
-                                groups_array.as_ptr() as *const u8,
-                                needed,
-                            )
+                            core::slice::from_raw_parts(groups_array.as_ptr() as *const u8, needed)
                         };
                         let copy_len = core::cmp::min(value.len(), bytes.len());
                         value[..copy_len].copy_from_slice(&bytes[..copy_len]);

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     net::{
         posix::SockAddr,
         socket::{
+            common::EPollItems,
             common::{parse_timeval_opt, write_i32_getsockopt, write_timeval_opt},
             endpoint::Endpoint,
             netlink::{
@@ -27,18 +28,41 @@ use system_error::SystemError;
 pub(super) mod bound;
 mod unbound;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+enum NetlinkSockOpt {
+    AddMembership = 1,
+    DropMembership = 2,
+    ListMemberships = 9,
+}
+
+impl TryFrom<u32> for NetlinkSockOpt {
+    type Error = SystemError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::AddMembership),
+            2 => Ok(Self::DropMembership),
+            9 => Ok(Self::ListMemberships),
+            _ => Err(SystemError::ENOPROTOOPT),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct NetlinkSocket<P: SupportedNetlinkProtocol> {
     inner: RwSem<Inner<UnboundNetlink<P>, BoundNetlink<P::Message>>>,
 
     is_nonblocking: AtomicBool,
     wait_queue: Arc<WaitQueue>,
+    epoll_items: Arc<EPollItems>,
     netns: Arc<NetNamespace>,
     socket_type: PSOCK,
     protocol: u32,
+    group_count: AtomicUsize,
     send_timeout_us: AtomicU64,
     recv_timeout_us: AtomicU64,
-    fasync_items: FAsyncItems,
+    fasync_items: Arc<FAsyncItems>,
     inode_id: InodeId,
     open_files: AtomicUsize,
 }
@@ -48,17 +72,22 @@ where
     BoundNetlink<P::Message>: Bound<Endpoint = NetlinkSocketAddr>,
 {
     pub fn new(is_nonblocking: bool, socket_type: PSOCK, protocol: u32) -> Arc<Self> {
-        let unbound = UnboundNetlink::new();
+        let wait_queue = Arc::new(WaitQueue::default());
+        let epoll_items = Arc::new(EPollItems::default());
+        let fasync_items = Arc::new(FAsyncItems::default());
+        let unbound = UnboundNetlink::new(epoll_items.clone(), fasync_items.clone());
         Arc::new(Self {
             inner: RwSem::new(Inner::Unbound(unbound)),
             is_nonblocking: AtomicBool::new(is_nonblocking),
-            wait_queue: Arc::new(WaitQueue::default()),
+            wait_queue,
+            epoll_items,
             netns: ProcessManager::current_netns(),
             socket_type,
             protocol,
+            group_count: AtomicUsize::new(0),
             send_timeout_us: AtomicU64::new(u64::MAX),
             recv_timeout_us: AtomicU64::new(u64::MAX),
-            fasync_items: FAsyncItems::default(),
+            fasync_items,
             inode_id: generate_inode_id(),
             open_files: AtomicUsize::new(0),
         })
@@ -155,6 +184,33 @@ where
     pub fn netns(&self) -> Arc<NetNamespace> {
         self.netns.clone()
     }
+
+    fn ensure_membership_capacity(&self) {
+        let target = P::multicast_group_count() as usize;
+        let mut current = self.group_count.load(Ordering::Relaxed);
+        while current < target {
+            match self.group_count.compare_exchange(
+                current,
+                target,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn update_membership_capacity_for_bind(&self, addr: &NetlinkSocketAddr) {
+        if !addr.groups().is_empty() {
+            self.ensure_membership_capacity();
+        }
+    }
+
+    fn list_memberships_needed_bytes(&self) -> usize {
+        let groups = self.group_count.load(Ordering::Relaxed);
+        groups.div_ceil(32) * core::mem::size_of::<u32>()
+    }
 }
 
 impl<P: SupportedNetlinkProtocol + 'static> Socket for NetlinkSocket<P>
@@ -181,6 +237,7 @@ where
         endpoint: crate::net::socket::endpoint::Endpoint,
     ) -> Result<(), system_error::SystemError> {
         let endpoint = endpoint.try_into()?;
+        self.update_membership_capacity_for_bind(&endpoint);
 
         self.inner
             .write()
@@ -276,33 +333,62 @@ where
     }
 
     fn option(&self, level: PSOL, name: usize, value: &mut [u8]) -> Result<usize, SystemError> {
-        if !matches!(level, PSOL::SOCKET) {
-            return Err(SystemError::ENOPROTOOPT);
-        }
-
-        let opt = PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
-        match opt {
-            PSO::TYPE => {
-                let v = self.socket_type as i32;
-                Ok(write_i32_getsockopt(value, v))
+        match level {
+            PSOL::SOCKET => {
+                let opt = PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
+                match opt {
+                    PSO::TYPE => {
+                        let v = self.socket_type as i32;
+                        Ok(write_i32_getsockopt(value, v))
+                    }
+                    PSO::DOMAIN => {
+                        let v = AddressFamily::Netlink as i32;
+                        Ok(write_i32_getsockopt(value, v))
+                    }
+                    PSO::PROTOCOL => {
+                        let v = self.protocol as i32;
+                        Ok(write_i32_getsockopt(value, v))
+                    }
+                    PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
+                        let us = self.send_timeout_us.load(Ordering::Relaxed);
+                        let us = if us == u64::MAX { 0 } else { us };
+                        Ok(write_timeval_opt(value, us))
+                    }
+                    PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW => {
+                        let us = self.recv_timeout_us.load(Ordering::Relaxed);
+                        let us = if us == u64::MAX { 0 } else { us };
+                        Ok(write_timeval_opt(value, us))
+                    }
+                    _ => Err(SystemError::ENOPROTOOPT),
+                }
             }
-            PSO::DOMAIN => {
-                let v = AddressFamily::Netlink as i32;
-                Ok(write_i32_getsockopt(value, v))
-            }
-            PSO::PROTOCOL => {
-                let v = self.protocol as i32;
-                Ok(write_i32_getsockopt(value, v))
-            }
-            PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
-                let us = self.send_timeout_us.load(Ordering::Relaxed);
-                let us = if us == u64::MAX { 0 } else { us };
-                Ok(write_timeval_opt(value, us))
-            }
-            PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW => {
-                let us = self.recv_timeout_us.load(Ordering::Relaxed);
-                let us = if us == u64::MAX { 0 } else { us };
-                Ok(write_timeval_opt(value, us))
+            PSOL::NETLINK => {
+                let opt =
+                    NetlinkSockOpt::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
+                match opt {
+                    NetlinkSockOpt::ListMemberships => {
+                        let groups: u64 = self
+                            .inner
+                            .read()
+                            .addr()
+                            .map_or(0, |addr| addr.groups().as_u64());
+                        let needed = self.list_memberships_needed_bytes();
+                        let groups_array = [
+                            groups as u32,
+                            (groups >> 32) as u32,
+                        ];
+                        let bytes = unsafe {
+                            core::slice::from_raw_parts(
+                                groups_array.as_ptr() as *const u8,
+                                needed,
+                            )
+                        };
+                        let copy_len = core::cmp::min(value.len(), bytes.len());
+                        value[..copy_len].copy_from_slice(&bytes[..copy_len]);
+                        Ok(needed)
+                    }
+                    _ => Err(SystemError::ENOPROTOOPT),
+                }
             }
             _ => Err(SystemError::ENOPROTOOPT),
         }
@@ -321,23 +407,43 @@ where
     }
 
     fn set_option(&self, level: PSOL, name: usize, val: &[u8]) -> Result<(), SystemError> {
-        if !matches!(level, PSOL::SOCKET) {
-            return Err(SystemError::ENOPROTOOPT);
-        }
-
-        let opt = PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
-        match opt {
-            PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
-                let d = parse_timeval_opt(val)?;
-                let us = d.map(|v| v.total_micros()).unwrap_or(u64::MAX);
-                self.send_timeout_us.store(us, Ordering::Relaxed);
-                Ok(())
+        match level {
+            PSOL::SOCKET => {
+                let opt = PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
+                match opt {
+                    PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
+                        let d = parse_timeval_opt(val)?;
+                        let us = d.map(|v| v.total_micros()).unwrap_or(u64::MAX);
+                        self.send_timeout_us.store(us, Ordering::Relaxed);
+                        Ok(())
+                    }
+                    PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW => {
+                        let d = parse_timeval_opt(val)?;
+                        let us = d.map(|v| v.total_micros()).unwrap_or(u64::MAX);
+                        self.recv_timeout_us.store(us, Ordering::Relaxed);
+                        Ok(())
+                    }
+                    _ => Err(SystemError::ENOPROTOOPT),
+                }
             }
-            PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW => {
-                let d = parse_timeval_opt(val)?;
-                let us = d.map(|v| v.total_micros()).unwrap_or(u64::MAX);
-                self.recv_timeout_us.store(us, Ordering::Relaxed);
-                Ok(())
+            PSOL::NETLINK => {
+                let opt =
+                    NetlinkSockOpt::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
+                match opt {
+                    NetlinkSockOpt::AddMembership => {
+                        let groups = read_group_membership_sockopt::<P>(val)?;
+                        self.ensure_membership_capacity();
+                        self.inner.write().add_groups(groups);
+                        Ok(())
+                    }
+                    NetlinkSockOpt::DropMembership => {
+                        let groups = read_group_membership_sockopt::<P>(val)?;
+                        self.ensure_membership_capacity();
+                        self.inner.write().drop_groups(groups);
+                        Ok(())
+                    }
+                    NetlinkSockOpt::ListMemberships => Err(SystemError::ENOPROTOOPT),
+                }
             }
             _ => Err(SystemError::ENOPROTOOPT),
         }
@@ -349,11 +455,11 @@ where
     }
 
     fn epoll_items(&self) -> &crate::net::socket::common::EPollItems {
-        todo!("implement epoll_items for netlink socket");
+        self.epoll_items.as_ref()
     }
 
     fn fasync_items(&self) -> &FAsyncItems {
-        &self.fasync_items
+        self.fasync_items.as_ref()
     }
 
     fn local_endpoint(&self) -> Result<Endpoint, SystemError> {
@@ -387,6 +493,27 @@ impl<P: SupportedNetlinkProtocol> NetlinkSocket<P> {
     pub fn set_nonblocking(&self, nonblocking: bool) {
         self.is_nonblocking.store(nonblocking, Ordering::Relaxed);
     }
+}
+
+fn read_u32_sockopt(val: &[u8]) -> Result<u32, SystemError> {
+    if val.len() < size_of::<u32>() {
+        return Err(SystemError::EINVAL);
+    }
+
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&val[..4]);
+    Ok(u32::from_ne_bytes(bytes))
+}
+
+fn read_group_membership_sockopt<P: SupportedNetlinkProtocol>(
+    val: &[u8],
+) -> Result<GroupIdSet, SystemError> {
+    let group_id = read_u32_sockopt(val)?;
+    if group_id == 0 || group_id > P::multicast_group_count() {
+        return Err(SystemError::EINVAL);
+    }
+
+    GroupIdSet::from_group_id(group_id).ok_or(SystemError::EINVAL)
 }
 
 // 多播消息的时候会用到，比如uevent

--- a/kernel/src/net/socket/netlink/common/unbound.rs
+++ b/kernel/src/net/socket/netlink/common/unbound.rs
@@ -1,7 +1,9 @@
 use crate::{
     filesystem::epoll::EPollEventType,
+    filesystem::vfs::fasync::FAsyncItems,
     libs::wait_queue::WaitQueue,
     net::socket::{
+        common::EPollItems,
         netlink::{
             addr::{multicast::GroupIdSet, NetlinkSocketAddr},
             common::bound::BoundNetlink,
@@ -19,13 +21,17 @@ use system_error::SystemError;
 #[derive(Debug)]
 pub struct UnboundNetlink<P: SupportedNetlinkProtocol> {
     groups: GroupIdSet,
+    epoll_items: Arc<EPollItems>,
+    fasync_items: Arc<FAsyncItems>,
     phantom: PhantomData<BoundNetlink<P::Message>>,
 }
 
 impl<P: SupportedNetlinkProtocol> UnboundNetlink<P> {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(epoll_items: Arc<EPollItems>, fasync_items: Arc<FAsyncItems>) -> Self {
         Self {
             groups: GroupIdSet::new_empty(),
+            epoll_items,
+            fasync_items,
             phantom: PhantomData,
         }
     }
@@ -60,7 +66,12 @@ impl<P: SupportedNetlinkProtocol> datagram_common::Unbound for UnboundNetlink<P>
                 endpoint.add_groups(self.groups);
                 endpoint
             };
-            let receiver = MessageReceiver::new(message_queue.clone(), wait_queue);
+            let receiver = MessageReceiver::new(
+                message_queue.clone(),
+                wait_queue,
+                self.epoll_items.clone(),
+                self.fasync_items.clone(),
+            );
             <P as SupportedNetlinkProtocol>::bind(&endpoint, receiver, netns.clone())?
         };
 
@@ -81,7 +92,12 @@ impl<P: SupportedNetlinkProtocol> datagram_common::Unbound for UnboundNetlink<P>
                 endpoint.add_groups(self.groups);
                 endpoint
             };
-            let receiver = MessageReceiver::new(message_queue.clone(), wait_queue);
+            let receiver = MessageReceiver::new(
+                message_queue.clone(),
+                wait_queue,
+                self.epoll_items.clone(),
+                self.fasync_items.clone(),
+            );
             <P as SupportedNetlinkProtocol>::bind(&endpoint, receiver, netns.clone())?
         };
 

--- a/kernel/src/net/socket/netlink/message/attr/mod.rs
+++ b/kernel/src/net/socket/netlink/message/attr/mod.rs
@@ -125,8 +125,9 @@ pub trait Attribute: core::fmt::Debug + Send + Sync {
                 return Err(SystemError::EINVAL);
             }
 
+            let attr_total_with_padding = attr_header.total_len_with_padding();
             total_len = total_len
-                .checked_sub(attr_header.total_len())
+                .checked_sub(attr_total_with_padding)
                 .ok_or(SystemError::EINVAL)?;
 
             if buf.len() - offset < attr_header.total_len() {
@@ -143,12 +144,7 @@ pub trait Attribute: core::fmt::Debug + Send + Sync {
                 attrs.push(attr);
             }
 
-            // 移动到下一个属性（考虑对齐）
-            let attr_total_with_padding = attr_header.total_len_with_padding();
             offset += attr_total_with_padding;
-
-            let padding_len = total_len.min(attr_header.padding_len());
-            total_len -= padding_len;
         }
 
         Ok(attrs)

--- a/kernel/src/net/socket/netlink/message/attr/noattr.rs
+++ b/kernel/src/net/socket/netlink/message/attr/noattr.rs
@@ -1,7 +1,7 @@
 use crate::net::socket::netlink::message::attr::Attribute;
 use alloc::vec::Vec;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum NoAttr {}
 
 impl Attribute for NoAttr {

--- a/kernel/src/net/socket/netlink/message/mod.rs
+++ b/kernel/src/net/socket/netlink/message/mod.rs
@@ -1,5 +1,6 @@
 use crate::net::socket::netlink::{
-    message::segment::header::CMsgSegHdr, table::StandardNetlinkProtocol,
+    message::segment::header::CMsgSegHdr,
+    table::{MulticastMessage, StandardNetlinkProtocol},
 };
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -7,7 +8,7 @@ use system_error::SystemError;
 pub(super) mod attr;
 pub(super) mod segment;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Message<T: ProtocolSegment> {
     segments: Vec<T>,
 }
@@ -77,5 +78,7 @@ pub trait ProtocolSegment: Sized + alloc::fmt::Debug {
     fn write_to(&self, writer: &mut [u8]) -> Result<usize, SystemError>;
     fn protocol(&self) -> StandardNetlinkProtocol;
 }
+
+impl<T: ProtocolSegment + Clone> MulticastMessage for Message<T> {}
 
 pub(super) const NLMSG_ALIGN: usize = 4;

--- a/kernel/src/net/socket/netlink/message/segment/common.rs
+++ b/kernel/src/net/socket/netlink/message/segment/common.rs
@@ -5,7 +5,7 @@ use crate::net::socket::netlink::message::{
 use alloc::vec::Vec;
 use system_error::SystemError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SegmentCommon<Body, Attr> {
     header: CMsgSegHdr,
     body: Body,

--- a/kernel/src/net/socket/netlink/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/message/segment/mod.rs
@@ -30,7 +30,13 @@ pub enum CSegmentType {
     NEWROUTE = 24,
     DELROUTE = 25,
     GETROUTE = 26,
-    // TODO 补充
+    NEWNEIGH = 28,
+    DELNEIGH = 29,
+    GETNEIGH = 30,
+
+    NEWRULE = 32,
+    DELRULE = 33,
+    GETRULE = 34,
 }
 
 impl TryFrom<u16> for CSegmentType {
@@ -52,6 +58,12 @@ impl TryFrom<u16> for CSegmentType {
             24 => Ok(CSegmentType::NEWROUTE),
             25 => Ok(CSegmentType::DELROUTE),
             26 => Ok(CSegmentType::GETROUTE),
+            28 => Ok(CSegmentType::NEWNEIGH),
+            29 => Ok(CSegmentType::DELNEIGH),
+            30 => Ok(CSegmentType::GETNEIGH),
+            32 => Ok(CSegmentType::NEWRULE),
+            33 => Ok(CSegmentType::DELRULE),
+            34 => Ok(CSegmentType::GETRULE),
             _ => Err(SystemError::EINVAL),
         }
     }

--- a/kernel/src/net/socket/netlink/mod.rs
+++ b/kernel/src/net/socket/netlink/mod.rs
@@ -11,7 +11,7 @@ use system_error::SystemError;
 
 pub mod addr;
 mod common;
-mod kobject;
+pub(crate) mod kobject;
 mod message;
 mod receiver;
 mod route;

--- a/kernel/src/net/socket/netlink/receiver.rs
+++ b/kernel/src/net/socket/netlink/receiver.rs
@@ -1,5 +1,8 @@
+use crate::filesystem::epoll::{event_poll::EventPoll, EPollEventType};
+use crate::filesystem::vfs::fasync::{FAsyncItems, FASYNC_POLL_IN};
 use crate::libs::mutex::Mutex;
 use crate::libs::wait_queue::WaitQueue;
+use crate::net::socket::common::EPollItems;
 use crate::process::ProcessState;
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
@@ -32,13 +35,22 @@ impl<Message> MessageQueue<Message> {
 pub struct MessageReceiver<Message> {
     message_queue: MessageQueue<Message>,
     wait_queue: Arc<WaitQueue>,
+    epoll_items: Arc<EPollItems>,
+    fasync_items: Arc<FAsyncItems>,
 }
 
 impl<Message> MessageReceiver<Message> {
-    pub fn new(message_queue: MessageQueue<Message>, wait_queue: Arc<WaitQueue>) -> Self {
+    pub fn new(
+        message_queue: MessageQueue<Message>,
+        wait_queue: Arc<WaitQueue>,
+        epoll_items: Arc<EPollItems>,
+        fasync_items: Arc<FAsyncItems>,
+    ) -> Self {
         Self {
             message_queue,
             wait_queue,
+            epoll_items,
+            fasync_items,
         }
     }
 
@@ -46,6 +58,9 @@ impl<Message> MessageReceiver<Message> {
         self.message_queue.enqueue(message)?;
         // 唤醒等待队列中的线程
         self.wait_queue.wakeup(Some(ProcessState::Blocked(true)));
+        let _ =
+            EventPoll::wakeup_epoll(self.epoll_items.as_ref().as_ref(), EPollEventType::EPOLLIN);
+        self.fasync_items.send_sigio(FASYNC_POLL_IN);
         Ok(())
     }
 }

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -1,16 +1,28 @@
 use crate::{
     filesystem::epoll::EPollEventType,
+    libs::align::align_up,
     net::socket::{
         netlink::{
             addr::NetlinkSocketAddr,
             common::bound::BoundNetlink,
-            message::ProtocolSegment,
+            message::{
+                segment::{
+                    ack::ErrorSegment,
+                    header::{CMsgSegHdr, SegHdrCommonFlags},
+                    CSegmentType,
+                },
+                ProtocolSegment, NLMSG_ALIGN,
+            },
             route::{kern::NetlinkRouteKernelSocket, message::RouteNlMessage},
+            table::{NetlinkRouteProtocol, SupportedNetlinkProtocol},
         },
         utils::datagram_common,
         PMSG,
     },
+    process::namespace::net_namespace::NetNamespace,
 };
+use alloc::sync::Arc;
+use core::mem::size_of;
 use system_error::SystemError;
 
 impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
@@ -43,45 +55,80 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
         }
 
         let sum_lens = buf.len();
-
-        let mut nlmsg = match RouteNlMessage::read_from(buf) {
-            Ok(msg) => msg,
-            Err(e) if e == SystemError::EFAULT => {
-                // 说明这个时候 buf 不是一个完整的 netlink 消息
-                return Err(e);
-            }
-            Err(e) => {
-                log::warn!(
-                    "netlink_send: failed to read netlink message from buffer: {:?}",
-                    e
-                );
-                return Err(e);
-            }
-        };
-
         let local_port = self.handle.port();
+        let netns = self.netns();
 
-        for segment in nlmsg.segments_mut() {
-            let header = segment.header_mut();
-            if header.pid == 0 {
-                header.pid = local_port;
-            }
-        }
-
-        let Some(route_kernel) = self
-            .netns
-            .get_netlink_kernel_socket_by_protocol(nlmsg.protocol().into())
-        else {
+        let Some(route_kernel) = netns.get_netlink_kernel_socket_by_protocol(
+            crate::net::socket::netlink::table::StandardNetlinkProtocol::ROUTE.into(),
+        ) else {
             log::warn!("No route kernel socket available in net namespace");
-            return Ok(sum_lens);
+            return Err(SystemError::ECONNREFUSED);
         };
 
         let route_kernel_socket = route_kernel
             .as_any_ref()
             .downcast_ref::<NetlinkRouteKernelSocket>()
-            .unwrap();
+            .ok_or(SystemError::EINVAL)?;
 
-        route_kernel_socket.request(&nlmsg, local_port, self.netns());
+        let mut offset = 0usize;
+        while offset < buf.len() {
+            let slice = &buf[offset..];
+            if slice.len() < size_of::<CMsgSegHdr>() {
+                return Err(SystemError::EINVAL);
+            }
+
+            // SAFETY: `slice` has at least `size_of::<CMsgSegHdr>()` bytes.
+            let header =
+                unsafe { core::ptr::read_unaligned(slice.as_ptr() as *const CMsgSegHdr) };
+            let msg_len = header.len as usize;
+            if msg_len < size_of::<CMsgSegHdr>() || offset + msg_len > buf.len() {
+                return Err(SystemError::EINVAL);
+            }
+
+            let msg_buf = &buf[offset..offset + msg_len];
+            offset += align_up(msg_len, NLMSG_ALIGN);
+
+            let flags = SegHdrCommonFlags::from_bits_truncate(header.flags);
+            if !flags.contains(SegHdrCommonFlags::REQUEST) {
+                continue;
+            }
+
+            if CSegmentType::try_from(header.type_).is_err() {
+                send_route_error_ack(&header, SystemError::EOPNOTSUPP_OR_ENOTSUP, local_port, netns.clone());
+                continue;
+            }
+
+            let segment = match RouteNlMessage::read_from(msg_buf) {
+                Ok(msg) => {
+                    if msg.segments().len() != 1 {
+                        return Err(SystemError::EINVAL);
+                    }
+                    msg.segments()[0].clone()
+                }
+                Err(e) => {
+                    log::warn!(
+                        "netlink_send: failed to read netlink message from buffer: {:?}",
+                        e
+                    );
+                    return Err(e);
+                }
+            };
+
+            let mut nlmsg = RouteNlMessage::new(vec![segment]);
+            for seg in nlmsg.segments_mut() {
+                let hdr = seg.header_mut();
+                if hdr.pid == 0 {
+                    hdr.pid = local_port;
+                }
+            }
+
+            route_kernel_socket.request(&nlmsg, local_port, netns.clone());
+
+            // gVisor 测例常以 sizeof(req) 发送，nlmsg_len 之后多为结构体尾部零填充，勿当作下一条消息。
+            if offset < buf.len() && buf[offset..].iter().all(|&b| b == 0) {
+                break;
+            }
+        }
 
         Ok(sum_lens)
     }
@@ -114,7 +161,6 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
             receive_queue.pop_front();
         }
 
-        // todo 目前这个信息只能来自内核
         let remote = NetlinkSocketAddr::new_unspecified();
 
         Ok((copied, orig_len, remote))
@@ -122,5 +168,24 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
 
     fn check_io_events(&self) -> EPollEventType {
         self.check_io_events_common()
+    }
+}
+
+fn send_route_error_ack(
+    request_header: &CMsgSegHdr,
+    error: SystemError,
+    dst_port: u32,
+    netns: Arc<NetNamespace>,
+) {
+    use crate::net::socket::netlink::route::message::segment::RouteNlSegment;
+
+    let err_segment = ErrorSegment::new_from_request(request_header, Some(error));
+    let err_msg = RouteNlMessage::new(vec![RouteNlSegment::Error(err_segment)]);
+    if let Err(e) = NetlinkRouteProtocol::unicast(dst_port, err_msg, netns) {
+        log::warn!(
+            "netlink route: failed to deliver error ack to port {}: {:?}",
+            dst_port,
+            e
+        );
     }
 }

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -78,8 +78,7 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
             }
 
             // SAFETY: `slice` has at least `size_of::<CMsgSegHdr>()` bytes.
-            let header =
-                unsafe { core::ptr::read_unaligned(slice.as_ptr() as *const CMsgSegHdr) };
+            let header = unsafe { core::ptr::read_unaligned(slice.as_ptr() as *const CMsgSegHdr) };
             let msg_len = header.len as usize;
             if msg_len < size_of::<CMsgSegHdr>() || offset + msg_len > buf.len() {
                 return Err(SystemError::EINVAL);
@@ -94,7 +93,12 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
             }
 
             if CSegmentType::try_from(header.type_).is_err() {
-                send_route_error_ack(&header, SystemError::EOPNOTSUPP_OR_ENOTSUP, local_port, netns.clone());
+                send_route_error_ack(
+                    &header,
+                    SystemError::EOPNOTSUPP_OR_ENOTSUP,
+                    local_port,
+                    netns.clone(),
+                );
                 continue;
             }
 

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -318,12 +318,9 @@ fn sync_router_ip_addrs(iface: &Arc<dyn Iface>) {
 
 fn add_local_route(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemError> {
     let mut pushed = false;
-    let via_router = cidr.address();
 
     iface.smol_iface().lock().routes_mut().update(|routes| {
-        let exists = routes
-            .iter()
-            .any(|route| is_same_local_route(route, cidr, via_router));
+        let exists = routes.iter().any(|route| is_same_local_route(route, cidr));
         if exists {
             pushed = true;
             return;
@@ -332,7 +329,7 @@ fn add_local_route(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemErr
         pushed = routes
             .push(smoltcp::iface::Route {
                 cidr,
-                via_router,
+                via_router: None,
                 preferred_until: None,
                 expires_at: None,
             })
@@ -341,9 +338,8 @@ fn add_local_route(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemErr
 
     if !pushed {
         log::warn!(
-            "netlink add_addr: route table full while adding local route {} via {}",
-            cidr,
-            via_router
+            "netlink add_addr: route table full while adding local route {}",
+            cidr
         );
         return Err(SystemError::ENOSPC);
     }
@@ -352,11 +348,10 @@ fn add_local_route(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemErr
 }
 
 fn remove_local_route(iface: &Arc<dyn Iface>, cidr: IpCidr) {
-    let via_router = cidr.address();
     iface.smol_iface().lock().routes_mut().update(|routes| {
         if let Some(index) = routes
             .iter()
-            .position(|route| is_same_local_route(route, cidr, via_router))
+            .position(|route| is_same_local_route(route, cidr))
         {
             routes.remove(index);
         }
@@ -373,8 +368,8 @@ fn rollback_added_addr(iface: &Arc<dyn Iface>, cidr: IpCidr) {
 }
 
 #[inline]
-fn is_same_local_route(route: &smoltcp::iface::Route, cidr: IpCidr, via_router: IpAddress) -> bool {
-    route.cidr == cidr && route.via_router == via_router
+fn is_same_local_route(route: &smoltcp::iface::Route, cidr: IpCidr) -> bool {
+    route.cidr == cidr && route.via_router.is_none()
 }
 
 fn addr_notify_group(ip: IpAddress) -> u32 {

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -7,7 +7,10 @@ use crate::{
                 CSegmentType,
             },
             route::{
-                kern::utils::finish_response,
+                kern::utils::{
+                    finish_response, kernel_notify_header, multicast_notify, RTMGRP_IPV4_IFADDR,
+                    RTMGRP_IPV6_IFADDR,
+                },
                 message::{
                     attr::addr::AddrAttr,
                     segment::{
@@ -42,12 +45,31 @@ pub(super) fn do_get_addr(
         return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
     }
 
+    let requested_index = request_segment.body().index.map(NonZeroU32::get);
+    let requested_family = AddressFamily::try_from(request_segment.body().family as u16)
+        .ok()
+        .filter(|family| *family != AddressFamily::Unspecified);
+
     let mut responce: Vec<RouteNlSegment> = netns
         .device_list()
         .iter()
+        .filter(|(_, iface)| requested_index.is_none_or(|index| iface.nic_id() as u32 == index))
         .flat_map(|(_, iface)| iface_to_new_addr(request_segment.header(), iface))
+        .filter(|segment| {
+            requested_family.is_none_or(|family| {
+                AddressFamily::try_from(segment.body().family as u16)
+                    .ok()
+                    .is_some_and(|segment_family| segment_family == family)
+            })
+        })
         .map(RouteNlSegment::NewAddr)
         .collect();
+
+    // getifaddrs(3) 期望全局地址列表按族排序：IPv4 在前、IPv6 在后。
+    responce.sort_by_key(|segment| match segment {
+        RouteNlSegment::NewAddr(addr) => addr.body().family,
+        _ => 0,
+    });
 
     finish_response(request_segment.header(), dump_all, &mut responce);
 
@@ -58,7 +80,19 @@ pub(super) fn do_new_addr(
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    add_addr(request_segment, netns)?;
+    let (iface, cidr, changed) = add_addr(request_segment, netns.clone())?;
+    if changed {
+        multicast_notify(
+            netns,
+            addr_notify_group(cidr.address()),
+            RouteNlSegment::NewAddr(addr_to_segment(
+                &kernel_notify_header(CSegmentType::NEWADDR),
+                &iface,
+                cidr,
+                CSegmentType::NEWADDR,
+            )?),
+        );
+    }
     Ok(Vec::new())
 }
 
@@ -66,11 +100,24 @@ pub(super) fn do_del_addr(
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    del_addr(request_segment, netns)?;
+    let (iface, cidr) = del_addr(request_segment, netns.clone())?;
+    multicast_notify(
+        netns,
+        addr_notify_group(cidr.address()),
+        RouteNlSegment::DelAddr(addr_to_segment(
+            &kernel_notify_header(CSegmentType::DELADDR),
+            &iface,
+            cidr,
+            CSegmentType::DELADDR,
+        )?),
+    );
     Ok(Vec::new())
 }
 
-fn add_addr(request_segment: &AddrSegment, netns: Arc<NetNamespace>) -> Result<(), SystemError> {
+fn add_addr(
+    request_segment: &AddrSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<(Arc<dyn Iface>, IpCidr, bool), SystemError> {
     let iface = lookup_iface_by_index(request_segment, netns)?;
     let cidr = parse_cidr(request_segment)?;
     let flags = NewRequestFlags::from_bits_truncate(request_segment.header().flags);
@@ -97,7 +144,7 @@ fn add_addr(request_segment: &AddrSegment, netns: Arc<NetNamespace>) -> Result<(
 
     if exists {
         if flags.contains(NewRequestFlags::REPLACE) {
-            return Ok(());
+            return Ok((iface, cidr, false));
         }
         return Err(SystemError::EEXIST);
     }
@@ -113,10 +160,13 @@ fn add_addr(request_segment: &AddrSegment, netns: Arc<NetNamespace>) -> Result<(
 
     sync_router_ip_addrs(&iface);
 
-    Ok(())
+    Ok((iface, cidr, true))
 }
 
-fn del_addr(request_segment: &AddrSegment, netns: Arc<NetNamespace>) -> Result<(), SystemError> {
+fn del_addr(
+    request_segment: &AddrSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<(Arc<dyn Iface>, IpCidr), SystemError> {
     let iface = lookup_iface_by_index(request_segment, netns)?;
     let cidr = parse_cidr(request_segment)?;
 
@@ -136,7 +186,7 @@ fn del_addr(request_segment: &AddrSegment, netns: Arc<NetNamespace>) -> Result<(
     remove_local_route(&iface, cidr);
     sync_router_ip_addrs(&iface);
 
-    Ok(())
+    Ok((iface, cidr))
 }
 
 fn lookup_iface_by_index(
@@ -200,7 +250,6 @@ fn parse_cidr(request_segment: &AddrSegment) -> Result<IpCidr, SystemError> {
 }
 
 fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<dyn Iface>) -> Vec<AddrSegment> {
-    let ifname = CString::new(iface.iface_name()).unwrap();
     let mut segments = Vec::new();
     let ip_addrs: Vec<IpCidr> = {
         let smol_iface = iface.smol_iface().lock();
@@ -208,37 +257,57 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<dyn Iface>) -> Vec
     };
 
     for cidr in &ip_addrs {
-        let (family, octets): (i32, Vec<u8>) = match cidr.address() {
-            IpAddress::Ipv4(addr) => (AddressFamily::INet as i32, addr.octets().to_vec()),
-            IpAddress::Ipv6(addr) => (AddressFamily::INet6 as i32, addr.octets().to_vec()),
-        };
-
-        let header = CMsgSegHdr {
-            len: 0,
-            type_: CSegmentType::NEWADDR as _,
-            flags: SegHdrCommonFlags::empty().bits(),
-            seq: request_header.seq,
-            pid: request_header.pid,
-        };
-
-        let addr_message = AddrSegmentBody {
-            family,
-            prefix_len: cidr.prefix_len(),
-            flags: AddrMessageFlags::PERMANENT,
-            scope: RtScope::HOST,
-            index: NonZeroU32::new(iface.nic_id() as u32),
-        };
-
-        let attrs = vec![
-            AddrAttr::Address(octets.clone()),
-            AddrAttr::Label(ifname.clone()),
-            AddrAttr::Local(octets),
-        ];
-
-        segments.push(AddrSegment::new(header, addr_message, attrs));
+        if let Ok(segment) = addr_to_segment(
+            request_header,
+            iface,
+            *cidr,
+            CSegmentType::NEWADDR,
+        ) {
+            segments.push(segment);
+        }
     }
 
     segments
+}
+
+fn addr_to_segment(
+    request_header: &CMsgSegHdr,
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+    msg_type: CSegmentType,
+) -> Result<AddrSegment, SystemError> {
+    let (family, octets): (i32, Vec<u8>) = match cidr.address() {
+        IpAddress::Ipv4(addr) => (AddressFamily::INet as i32, addr.octets().to_vec()),
+        IpAddress::Ipv6(addr) => (AddressFamily::INet6 as i32, addr.octets().to_vec()),
+    };
+
+    let header = CMsgSegHdr {
+        len: 0,
+        type_: msg_type as _,
+        flags: SegHdrCommonFlags::empty().bits(),
+        seq: request_header.seq,
+        pid: request_header.pid,
+    };
+
+    let addr_message = AddrSegmentBody {
+        family,
+        prefix_len: cidr.prefix_len(),
+        flags: AddrMessageFlags::PERMANENT,
+        scope: if iface.name() == "lo" {
+            RtScope::HOST
+        } else {
+            RtScope::UNIVERSE
+        },
+        index: NonZeroU32::new(iface.nic_id() as u32),
+    };
+
+    let attrs = vec![
+        AddrAttr::Address(octets.clone()),
+        AddrAttr::Label(CString::new(iface.iface_name()).map_err(|_| SystemError::EINVAL)?),
+        AddrAttr::Local(octets),
+    ];
+
+    Ok(AddrSegment::new(header, addr_message, attrs))
 }
 
 fn sync_router_ip_addrs(iface: &Arc<dyn Iface>) {
@@ -311,4 +380,11 @@ fn rollback_added_addr(iface: &Arc<dyn Iface>, cidr: IpCidr) {
 #[inline]
 fn is_same_local_route(route: &smoltcp::iface::Route, cidr: IpCidr, via_router: IpAddress) -> bool {
     route.cidr == cidr && route.via_router == via_router
+}
+
+fn addr_notify_group(ip: IpAddress) -> u32 {
+    match ip {
+        IpAddress::Ipv4(_) => RTMGRP_IPV4_IFADDR,
+        IpAddress::Ipv6(_) => RTMGRP_IPV6_IFADDR,
+    }
 }

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -257,12 +257,7 @@ fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<dyn Iface>) -> Vec
     };
 
     for cidr in &ip_addrs {
-        if let Ok(segment) = addr_to_segment(
-            request_header,
-            iface,
-            *cidr,
-            CSegmentType::NEWADDR,
-        ) {
+        if let Ok(segment) = addr_to_segment(request_header, iface, *cidr, CSegmentType::NEWADDR) {
             segments.push(segment);
         }
     }

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -1,5 +1,8 @@
 use crate::{
-    driver::net::{types::InterfaceType, Iface},
+    driver::net::{
+        types::{InterfaceFlags, InterfaceType},
+        Iface, Operstate,
+    },
     net::socket::{
         netlink::{
             message::segment::{
@@ -7,7 +10,7 @@ use crate::{
                 CSegmentType,
             },
             route::{
-                kern::utils::finish_response,
+                kern::utils::{finish_response, kernel_notify_header, multicast_notify, RTMGRP_LINK},
                 message::{
                     attr::link::LinkAttr,
                     segment::{
@@ -41,9 +44,11 @@ pub(super) fn do_get_link(
             FilterBy::Name(name) => *name == iface.name(),
             FilterBy::Dump => true,
         })
-        .map(|(_, iface)| iface_to_new_link(request_segment.header(), iface))
-        .map(RouteNlSegment::NewLink)
-        .collect();
+        .map(|(_, iface)| {
+            iface_to_link_message(request_segment.header(), CSegmentType::NEWLINK, iface)
+                .map(RouteNlSegment::NewLink)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     let dump_all = matches!(filter_by, FilterBy::Dump);
 
@@ -98,12 +103,9 @@ impl<'a> FilterBy<'a> {
 }
 
 fn validate_getlink_request(body: &LinkSegmentBody) -> Result<(), SystemError> {
-    if !body.flags.is_empty()
-        || body.type_ != InterfaceType::NETROM
-        || body.pad.is_some()
-        || !body.change.is_empty()
-    {
-        log::error!("the flags or the type is not valid");
+    // Linux 对 RTM_GETLINK 不校验 ifi_type/ifi_flags；仅拒绝带 change/pad 的请求。
+    if body.pad.is_some() || !body.change.is_empty() {
+        log::error!("invalid GETLINK ifinfomsg change/pad");
         return Err(SystemError::EINVAL);
     }
 
@@ -111,17 +113,12 @@ fn validate_getlink_request(body: &LinkSegmentBody) -> Result<(), SystemError> {
 }
 
 fn validate_dumplink_request(body: &LinkSegmentBody) -> Result<(), SystemError> {
-    // <https://elixir.bootlin.com/linux/v6.13/source/net/core/rtnetlink.c#L2378>.
-    if !body.flags.is_empty()
-        || body.type_ != InterfaceType::NETROM
-        || body.pad.is_some()
-        || !body.change.is_empty()
-    {
-        log::error!("the flags or the type is not valid");
+    // <https://elixir.bootlin.com/linux/v6.13/source/net/core/rtnetlink.c#L2383>.
+    if body.pad.is_some() || !body.change.is_empty() {
+        log::error!("invalid DUMP GETLINK ifinfomsg change/pad");
         return Err(SystemError::EINVAL);
     }
 
-    //  <https://elixir.bootlin.com/linux/v6.13/source/net/core/rtnetlink.c#L2383>.
     if body.index.is_some() {
         log::error!("filtering by interface index is not valid for link dumps");
         return Err(SystemError::EINVAL);
@@ -130,10 +127,14 @@ fn validate_dumplink_request(body: &LinkSegmentBody) -> Result<(), SystemError> 
     Ok(())
 }
 
-fn iface_to_new_link(request_header: &CMsgSegHdr, iface: &Arc<dyn Iface>) -> LinkSegment {
+fn iface_to_link_message(
+    request_header: &CMsgSegHdr,
+    msg_type: CSegmentType,
+    iface: &Arc<dyn Iface>,
+) -> Result<LinkSegment, SystemError> {
     let header = CMsgSegHdr {
         len: 0,
-        type_: CSegmentType::NEWLINK as _,
+        type_: msg_type as _,
         flags: SegHdrCommonFlags::empty().bits(),
         seq: request_header.seq,
         pid: request_header.pid,
@@ -149,9 +150,155 @@ fn iface_to_new_link(request_header: &CMsgSegHdr, iface: &Arc<dyn Iface>) -> Lin
     };
 
     let attrs = vec![
-        LinkAttr::Name(CString::new(iface.name()).unwrap()),
+        LinkAttr::Address(iface.mac().as_bytes().to_vec()),
+        LinkAttr::Name(CString::new(iface.name()).map_err(|_| SystemError::EINVAL)?),
         LinkAttr::Mtu(iface.mtu() as u32),
     ];
 
-    LinkSegment::new(header, link_message, attrs)
+    Ok(LinkSegment::new(header, link_message, attrs))
+}
+
+pub(super) fn do_del_link(
+    request_segment: &LinkSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let iface = find_iface_for_setlink(request_segment, netns)?;
+    if iface.type_() == InterfaceType::LOOPBACK {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+}
+
+pub(super) fn do_set_link(
+    request_segment: &LinkSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let iface = find_iface_for_setlink(request_segment, netns.clone())?;
+    let updates = validate_setlink_request(request_segment, iface.as_ref())?;
+
+    if let Some(ref name) = updates.name {
+        let duplicate = netns.device_list().iter().any(|(_, other)| {
+            !Arc::ptr_eq(other, &iface) && other.name() == *name
+        });
+        if duplicate {
+            return Err(SystemError::EEXIST);
+        }
+    }
+
+    let current_flags = iface.flags();
+    let change_mask = InterfaceFlags::from_bits_truncate(request_segment.body().change.bits());
+    let requested_flags = InterfaceFlags::from_bits_truncate(request_segment.body().flags.bits());
+    let new_flags = InterfaceFlags::from_bits_truncate(
+        (current_flags.bits() & !change_mask.bits())
+            | (requested_flags.bits() & change_mask.bits()),
+    );
+
+    iface.common().set_flags(new_flags);
+
+    if change_mask.contains(InterfaceFlags::UP) {
+        let operstate = if new_flags.contains(InterfaceFlags::UP) {
+            Operstate::IF_OPER_UP
+        } else {
+            Operstate::IF_OPER_DOWN
+        };
+        iface.set_operstate(operstate);
+    }
+
+    if let Some(name) = updates.name {
+        iface.set_name(name);
+    }
+
+    if let Some(mtu) = updates.mtu {
+        iface.common().set_mtu(mtu as usize);
+    }
+
+    multicast_notify(
+        netns,
+        RTMGRP_LINK,
+        RouteNlSegment::NewLink(iface_to_link_message(
+            &kernel_notify_header(CSegmentType::NEWLINK),
+            CSegmentType::NEWLINK,
+            &iface,
+        )?),
+    );
+
+    Ok(Vec::new())
+}
+
+fn find_iface_for_setlink(
+    request_segment: &LinkSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Arc<dyn Iface>, SystemError> {
+    if let Some(index) = request_segment.body().index {
+        return netns
+            .device_list()
+            .get(&(index.get() as usize))
+            .cloned()
+            .ok_or(SystemError::ENODEV);
+    }
+
+    let requested_name = request_segment.attrs().iter().find_map(|attr| {
+        if let LinkAttr::Name(name) = attr {
+            name.to_str().ok()
+        } else {
+            None
+        }
+    });
+
+    if let Some(name) = requested_name {
+        return netns
+            .device_list()
+            .iter()
+            .find(|(_, iface)| iface.name() == name)
+            .map(|(_, iface)| iface.clone())
+            .ok_or(SystemError::ENODEV);
+    }
+
+    Err(SystemError::EINVAL)
+}
+
+struct SetLinkUpdates {
+    name: Option<alloc::string::String>,
+    mtu: Option<u32>,
+}
+
+fn validate_setlink_request(
+    request_segment: &LinkSegment,
+    iface: &dyn Iface,
+) -> Result<SetLinkUpdates, SystemError> {
+    let body = request_segment.body();
+    if body.pad.is_some() {
+        return Err(SystemError::EINVAL);
+    }
+
+    let mut updates = SetLinkUpdates {
+        name: None,
+        mtu: None,
+    };
+    for attr in request_segment.attrs() {
+        match attr {
+            LinkAttr::Name(name) => {
+                let name =
+                    alloc::string::String::from(name.to_str().map_err(|_| SystemError::EINVAL)?);
+                if name.is_empty() {
+                    return Err(SystemError::EINVAL);
+                }
+                if name != iface.name() {
+                    updates.name = Some(name);
+                }
+            }
+            LinkAttr::Mtu(mtu) => {
+                if *mtu == 0 {
+                    return Err(SystemError::EINVAL);
+                }
+                if *mtu != iface.mtu() as u32 {
+                    updates.mtu = Some(*mtu);
+                }
+            }
+            LinkAttr::TxqLen(_) | LinkAttr::LinkMode(_) | LinkAttr::ExtMask(_) => {}
+            _ => return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
+        }
+    }
+
+    Ok(updates)
 }

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -10,7 +10,9 @@ use crate::{
                 CSegmentType,
             },
             route::{
-                kern::utils::{finish_response, kernel_notify_header, multicast_notify, RTMGRP_LINK},
+                kern::utils::{
+                    finish_response, kernel_notify_header, multicast_notify, RTMGRP_LINK,
+                },
                 message::{
                     attr::link::LinkAttr,
                     segment::{
@@ -177,9 +179,10 @@ pub(super) fn do_set_link(
     let updates = validate_setlink_request(request_segment, iface.as_ref())?;
 
     if let Some(ref name) = updates.name {
-        let duplicate = netns.device_list().iter().any(|(_, other)| {
-            !Arc::ptr_eq(other, &iface) && other.name() == *name
-        });
+        let duplicate = netns
+            .device_list()
+            .iter()
+            .any(|(_, other)| !Arc::ptr_eq(other, &iface) && other.name() == *name);
         if duplicate {
             return Err(SystemError::EEXIST);
         }

--- a/kernel/src/net/socket/netlink/route/kern/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kern/mod.rs
@@ -21,6 +21,8 @@ use system_error::SystemError;
 
 mod addr;
 mod link;
+mod neigh;
+mod route;
 mod utils;
 
 /// 负责处理 Netlink 路由相关的内核模块
@@ -49,7 +51,13 @@ impl NetlinkRouteKernelSocket {
             let Ok(seg_type) = CSegmentType::try_from(header.type_) else {
                 let err_segment = ErrorSegment::new_from_request(header, Some(SystemError::EINVAL));
                 let err_msg = RouteNlMessage::new(vec![RouteNlSegment::Error(err_segment)]);
-                let _ = NetlinkRouteProtocol::unicast(dst_port, err_msg, netns.clone());
+                if let Err(e) = NetlinkRouteProtocol::unicast(dst_port, err_msg, netns.clone()) {
+                    log::warn!(
+                        "netlink route: failed to deliver EINVAL ack to port {}: {:?}",
+                        dst_port,
+                        e
+                    );
+                }
                 continue;
             };
 
@@ -61,7 +69,19 @@ impl NetlinkRouteKernelSocket {
                 RouteNlSegment::NewAddr(request) => addr::do_new_addr(request, netns.clone()),
                 RouteNlSegment::DelAddr(request) => addr::do_del_addr(request, netns.clone()),
                 RouteNlSegment::GetLink(request) => link::do_get_link(request, netns.clone()),
-                RouteNlSegment::GetRoute(_new_route) => Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
+                RouteNlSegment::SetLink(request) if seg_type == CSegmentType::DELLINK => {
+                    link::do_del_link(request, netns.clone())
+                }
+                RouteNlSegment::SetLink(request) => link::do_set_link(request, netns.clone()),
+                RouteNlSegment::GetRoute(request) if seg_type == CSegmentType::GETRULE => {
+                    route::do_get_rule(request, netns.clone())
+                }
+                RouteNlSegment::GetRoute(request) => route::do_get_route(request, netns.clone()),
+                RouteNlSegment::NewRoute(request) => route::do_new_route(request, netns.clone()),
+                RouteNlSegment::DelRoute(request) => route::do_del_route(request, netns.clone()),
+                RouteNlSegment::NewNeigh(request) => neigh::do_new_neigh(request, netns.clone()),
+                RouteNlSegment::GetNeigh(request) => neigh::do_get_neigh(request, netns.clone()),
+                RouteNlSegment::DelNeigh(request) => neigh::do_del_neigh(request, netns.clone()),
                 _ => {
                     log::warn!("Unsupported route request segment type: {:?}", seg_type);
                     Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
@@ -85,7 +105,13 @@ impl NetlinkRouteKernelSocket {
                 }
             };
 
-            let _ = NetlinkRouteProtocol::unicast(dst_port, response, netns.clone());
+            if let Err(e) = NetlinkRouteProtocol::unicast(dst_port, response, netns.clone()) {
+                log::warn!(
+                    "netlink route: failed to deliver response to port {}: {:?}",
+                    dst_port,
+                    e
+                );
+            }
         }
     }
 }

--- a/kernel/src/net/socket/netlink/route/kern/neigh.rs
+++ b/kernel/src/net/socket/netlink/route/kern/neigh.rs
@@ -1,0 +1,242 @@
+use crate::{
+    driver::net::StaticNeighborEntry,
+    net::socket::{
+        netlink::{
+            message::segment::{
+                header::{CMsgSegHdr, GetRequestFlags, SegHdrCommonFlags},
+                CSegmentType,
+            },
+            route::{
+                kern::utils::{
+                    finish_response, kernel_notify_header, multicast_notify, RTMGRP_NEIGH,
+                },
+                message::segment::neigh::{NeighSegmentBody, NeighState},
+            },
+        },
+        netlink::route::message::{
+            attr::neigh::NeighAttr,
+            segment::{neigh::NeighSegment, RouteNlSegment},
+        },
+        AddressFamily,
+    },
+    process::namespace::net_namespace::NetNamespace,
+};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use smoltcp::wire::{EthernetAddress, HardwareAddress, IpAddress, Ipv4Address, Ipv6Address};
+use system_error::SystemError;
+
+pub(super) fn do_get_neigh(
+    request_segment: &NeighSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let dump_all = GetRequestFlags::from_bits_truncate(request_segment.header().flags)
+        .contains(GetRequestFlags::DUMP);
+    if !dump_all {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+
+    let requested_family = request_segment.body().family;
+    let requested_ifindex = if request_segment.body().ifindex > 0 {
+        Some(request_segment.body().ifindex as usize)
+    } else {
+        None
+    };
+
+    let mut response = Vec::new();
+    for (_, iface) in netns.device_list().iter() {
+        if requested_ifindex.is_some_and(|ifindex| iface.nic_id() != ifindex) {
+            continue;
+        }
+
+        for entry in iface.common().static_neighbors().iter() {
+            if !family_matches(requested_family, family_of_ip(entry.ip_addr)) {
+                continue;
+            }
+            response.push(RouteNlSegment::NewNeigh(neigh_to_segment(
+                request_segment.header(),
+                iface.nic_id() as i32,
+                entry,
+                CSegmentType::NEWNEIGH,
+            )));
+        }
+    }
+
+    finish_response(request_segment.header(), true, &mut response);
+    Ok(response)
+}
+
+pub(super) fn do_new_neigh(
+    request_segment: &NeighSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    if request_segment.body().ifindex <= 0 {
+        return Err(SystemError::EINVAL);
+    }
+    let ifindex =
+        usize::try_from(request_segment.body().ifindex).map_err(|_| SystemError::EINVAL)?;
+    let iface = netns
+        .device_list()
+        .get(&ifindex)
+        .cloned()
+        .ok_or(SystemError::ENODEV)?;
+    let family = request_segment.body().family;
+    let ip = request_segment
+        .attrs()
+        .iter()
+        .find_map(|attr| match attr {
+            NeighAttr::Destination(bytes) => Some(bytes.as_slice()),
+            NeighAttr::LinkLocalAddress(_) => None,
+        })
+        .ok_or(SystemError::EINVAL)
+        .and_then(|bytes| parse_ip(bytes, family))?;
+    let lladdr_bytes = request_segment.attrs().iter().find_map(|attr| match attr {
+        NeighAttr::LinkLocalAddress(bytes) => Some(bytes.as_slice()),
+        NeighAttr::Destination(_) => None,
+    });
+    let hw_addr = match lladdr_bytes {
+        Some(bytes) => parse_mac(bytes)?,
+        None => return Err(SystemError::EINVAL),
+    };
+
+    let entry = StaticNeighborEntry {
+        ip_addr: ip,
+        hw_addr,
+        state: request_segment.body().state.bits(),
+        flags: request_segment.body().flags,
+    };
+    iface.common().set_static_neighbor(entry.clone());
+    multicast_notify(
+        netns,
+        RTMGRP_NEIGH,
+        RouteNlSegment::NewNeigh(neigh_to_segment(
+            &kernel_notify_header(CSegmentType::NEWNEIGH),
+            iface.nic_id() as i32,
+            &entry,
+            CSegmentType::NEWNEIGH,
+        )),
+    );
+    Ok(Vec::new())
+}
+
+pub(super) fn do_del_neigh(
+    request_segment: &NeighSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    if request_segment.body().ifindex <= 0 {
+        return Err(SystemError::EINVAL);
+    }
+    let ifindex =
+        usize::try_from(request_segment.body().ifindex).map_err(|_| SystemError::EINVAL)?;
+    let iface = netns
+        .device_list()
+        .get(&ifindex)
+        .cloned()
+        .ok_or(SystemError::ENODEV)?;
+    let family = request_segment.body().family;
+    let ip = request_segment
+        .attrs()
+        .iter()
+        .find_map(|attr| match attr {
+            NeighAttr::Destination(bytes) => Some(bytes.as_slice()),
+            NeighAttr::LinkLocalAddress(_) => None,
+        })
+        .ok_or(SystemError::EINVAL)
+        .and_then(|bytes| parse_ip(bytes, family))?;
+
+    if !iface.common().remove_static_neighbor(ip) {
+        return Err(SystemError::ENOENT);
+    }
+
+    multicast_notify(
+        netns,
+        RTMGRP_NEIGH,
+        RouteNlSegment::DelNeigh(neigh_to_segment(
+            &kernel_notify_header(CSegmentType::DELNEIGH),
+            iface.nic_id() as i32,
+            &StaticNeighborEntry {
+                ip_addr: ip,
+                hw_addr: HardwareAddress::Ethernet(EthernetAddress::default()),
+                state: request_segment.body().state.bits(),
+                flags: request_segment.body().flags,
+            },
+            CSegmentType::DELNEIGH,
+        )),
+    );
+
+    Ok(Vec::new())
+}
+
+fn neigh_to_segment(
+    request_header: &CMsgSegHdr,
+    ifindex: i32,
+    entry: &StaticNeighborEntry,
+    msg_type: CSegmentType,
+) -> NeighSegment {
+    let header = crate::net::socket::netlink::message::segment::header::CMsgSegHdr {
+        len: 0,
+        type_: msg_type as u16,
+        flags: SegHdrCommonFlags::empty().bits(),
+        seq: request_header.seq,
+        pid: request_header.pid,
+    };
+    let body = NeighSegmentBody {
+        family: family_of_ip(entry.ip_addr),
+        ifindex,
+        state: NeighState::from_bits_truncate(entry.state),
+        flags: entry.flags,
+        kind: crate::net::socket::netlink::route::message::segment::route::RouteType::Unicast,
+    };
+    let mut attrs = vec![NeighAttr::Destination(ip_to_bytes(entry.ip_addr))];
+    if let HardwareAddress::Ethernet(addr) = entry.hw_addr {
+        attrs.push(NeighAttr::LinkLocalAddress(addr.as_bytes().to_vec()));
+    }
+    NeighSegment::new(header, body, attrs)
+}
+
+fn family_matches(requested_family: AddressFamily, actual_family: AddressFamily) -> bool {
+    requested_family == AddressFamily::Unspecified || requested_family == actual_family
+}
+
+fn family_of_ip(ip: IpAddress) -> AddressFamily {
+    match ip {
+        IpAddress::Ipv4(_) => AddressFamily::INet,
+        IpAddress::Ipv6(_) => AddressFamily::INet6,
+    }
+}
+
+fn ip_to_bytes(ip: IpAddress) -> Vec<u8> {
+    match ip {
+        IpAddress::Ipv4(addr) => addr.octets().to_vec(),
+        IpAddress::Ipv6(addr) => addr.octets().to_vec(),
+    }
+}
+
+fn parse_ip(bytes: &[u8], family: AddressFamily) -> Result<IpAddress, SystemError> {
+    match family {
+        AddressFamily::INet if bytes.len() == 4 => Ok(IpAddress::Ipv4(Ipv4Address::new(
+            bytes[0], bytes[1], bytes[2], bytes[3],
+        ))),
+        AddressFamily::INet6 if bytes.len() == 16 => Ok(IpAddress::Ipv6(Ipv6Address::new(
+            u16::from_be_bytes([bytes[0], bytes[1]]),
+            u16::from_be_bytes([bytes[2], bytes[3]]),
+            u16::from_be_bytes([bytes[4], bytes[5]]),
+            u16::from_be_bytes([bytes[6], bytes[7]]),
+            u16::from_be_bytes([bytes[8], bytes[9]]),
+            u16::from_be_bytes([bytes[10], bytes[11]]),
+            u16::from_be_bytes([bytes[12], bytes[13]]),
+            u16::from_be_bytes([bytes[14], bytes[15]]),
+        ))),
+        _ => Err(SystemError::EINVAL),
+    }
+}
+
+fn parse_mac(bytes: &[u8]) -> Result<HardwareAddress, SystemError> {
+    if bytes.len() != 6 {
+        return Err(SystemError::EINVAL);
+    }
+
+    let mut mac = [0u8; 6];
+    mac.copy_from_slice(bytes);
+    Ok(HardwareAddress::Ethernet(EthernetAddress(mac)))
+}

--- a/kernel/src/net/socket/netlink/route/kern/neigh.rs
+++ b/kernel/src/net/socket/netlink/route/kern/neigh.rs
@@ -1,6 +1,10 @@
 use crate::{
     driver::net::StaticNeighborEntry,
     net::socket::{
+        netlink::route::message::{
+            attr::neigh::NeighAttr,
+            segment::{neigh::NeighSegment, RouteNlSegment},
+        },
         netlink::{
             message::segment::{
                 header::{CMsgSegHdr, GetRequestFlags, SegHdrCommonFlags},
@@ -12,10 +16,6 @@ use crate::{
                 },
                 message::segment::neigh::{NeighSegmentBody, NeighState},
             },
-        },
-        netlink::route::message::{
-            attr::neigh::NeighAttr,
-            segment::{neigh::NeighSegment, RouteNlSegment},
         },
         AddressFamily,
     },

--- a/kernel/src/net/socket/netlink/route/kern/route.rs
+++ b/kernel/src/net/socket/netlink/route/kern/route.rs
@@ -1,0 +1,589 @@
+use crate::{
+    driver::net::{Iface, NetlinkRouteEntry},
+    net::socket::{
+        netlink::{
+            message::segment::{
+                header::{CMsgSegHdr, GetRequestFlags, NewRequestFlags, SegHdrCommonFlags},
+                CSegmentType,
+            },
+            route::{
+                kern::utils::{
+                    finish_response, kernel_notify_header, multicast_notify, RTMGRP_IPV4_ROUTE,
+                    RTMGRP_IPV6_ROUTE,
+                },
+                message::{
+                    attr::route::RouteAttr,
+                    segment::{
+                        route::{
+                            RouteFlags, RouteProtocol, RouteScope, RouteSegment, RouteSegmentBody,
+                            RouteTable, RouteType,
+                        },
+                        RouteNlSegment,
+                    },
+                },
+            },
+        },
+        AddressFamily,
+    },
+    process::namespace::net_namespace::NetNamespace,
+};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use smoltcp::wire::{IpAddress, IpCidr, Ipv4Address, Ipv4Cidr, Ipv6Address, Ipv6Cidr};
+use system_error::SystemError;
+
+/// `rtm_table == 0` 表示 RT_TABLE_MAIN（254），与 Linux 一致。
+fn effective_route_table(table: u8) -> u8 {
+    if table == 0 {
+        RouteTable::Main as u8
+    } else {
+        table
+    }
+}
+
+fn route_entry_key(entry: &NetlinkRouteEntry) -> (IpCidr, u8, Option<(IpAddress, u8)>) {
+    (
+        entry.destination,
+        entry.table,
+        entry
+            .source
+            .as_ref()
+            .map(|cidr| (cidr.address(), cidr.prefix_len())),
+    )
+}
+
+fn netlink_route_exists(iface: &Arc<dyn Iface>, entry: &NetlinkRouteEntry) -> bool {
+    let key = route_entry_key(entry);
+    iface
+        .common()
+        .netlink_routes()
+        .iter()
+        .any(|existing| route_entry_key(existing) == key)
+}
+
+pub(super) fn do_get_route(
+    request_segment: &RouteSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let dump_all = GetRequestFlags::from_bits_truncate(request_segment.header().flags)
+        .contains(GetRequestFlags::DUMP);
+    if !dump_all {
+        if request_segment
+            .body()
+            .flags
+            .contains(RouteFlags::LOOKUP_TABLE)
+        {
+            return do_lookup_route(request_segment, netns);
+        }
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+
+    let requested_family = request_segment.body().family;
+    let mut response = Vec::new();
+
+    for (_, iface) in netns.device_list().iter() {
+        response.extend(build_connected_route_segments(
+            request_segment,
+            iface,
+            requested_family,
+        )?);
+        response.extend(build_netlink_route_segments(
+            request_segment,
+            iface,
+            requested_family,
+        )?);
+    }
+
+    finish_response(request_segment.header(), true, &mut response);
+    Ok(response)
+}
+
+/// RTM_GETRULE：当前仅支持 DUMP 语义，返回空规则表 + NLMSG_DONE。
+pub(super) fn do_get_rule(
+    request_segment: &RouteSegment,
+    _netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let dump_all = GetRequestFlags::from_bits_truncate(request_segment.header().flags)
+        .contains(GetRequestFlags::DUMP);
+    if !dump_all {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    let mut response = Vec::new();
+    finish_response(request_segment.header(), true, &mut response);
+    Ok(response)
+}
+
+pub(super) fn do_new_route(
+    request_segment: &RouteSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let parsed = ParsedRouteRequest::from_segment(request_segment)?;
+    let iface = netns
+        .device_list()
+        .get(&(parsed.oif as usize))
+        .cloned()
+        .ok_or(SystemError::ENODEV)?;
+
+    if parsed.destination.prefix_len() == 0 && parsed.gateway.is_none() {
+        return Err(SystemError::EINVAL);
+    }
+
+    let table = effective_route_table(parsed.table);
+    let entry = NetlinkRouteEntry {
+        destination: parsed.destination,
+        source: parsed.source,
+        gateway: parsed.gateway,
+        priority: parsed.priority,
+        table,
+        protocol: request_segment.body().protocol as u8,
+        scope: request_segment.body().scope as u8,
+        kind: request_segment.body().type_ as u8,
+    };
+
+    let replace = NewRequestFlags::from_bits_truncate(request_segment.header().flags)
+        .contains(NewRequestFlags::REPLACE);
+    if netlink_route_exists(&iface, &entry) && !replace {
+        return Err(SystemError::EEXIST);
+    }
+
+    iface.common().upsert_netlink_route(entry);
+
+    if let Err(err) = sync_iface_route_table(&iface, &parsed) {
+        iface.common().remove_netlink_route(
+            parsed.destination,
+            parsed.source,
+            parsed.table,
+        );
+        return Err(err);
+    }
+    multicast_notify(
+        netns,
+        route_notify_group(parsed.destination.address()),
+        RouteNlSegment::NewRoute(route_to_segment(
+            &kernel_notify_header(CSegmentType::NEWROUTE),
+            CSegmentType::NEWROUTE,
+            &iface,
+            RouteView {
+                destination: parsed.destination,
+                source: parsed.source,
+                gateway: parsed.gateway,
+                priority: parsed.priority,
+                table: parsed.table,
+                protocol: request_segment.body().protocol as u8,
+                scope: request_segment.body().scope as u8,
+                kind: request_segment.body().type_ as u8,
+                flags: RouteFlags::empty(),
+            },
+        )?),
+    );
+    Ok(Vec::new())
+}
+
+pub(super) fn do_del_route(
+    request_segment: &RouteSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let parsed = ParsedRouteRequest::from_segment(request_segment)?;
+    let iface = netns
+        .device_list()
+        .get(&(parsed.oif as usize))
+        .cloned()
+        .ok_or(SystemError::ENODEV)?;
+
+    let table = effective_route_table(parsed.table);
+    if !iface
+        .common()
+        .remove_netlink_route(parsed.destination, parsed.source, table)
+    {
+        return Err(SystemError::ESRCH);
+    }
+
+    sync_iface_route_table_remove(
+        &iface,
+        parsed.destination,
+        parsed.source,
+        parsed.gateway,
+        table,
+    );
+    multicast_notify(
+        netns,
+        route_notify_group(parsed.destination.address()),
+        RouteNlSegment::DelRoute(route_to_segment(
+            &kernel_notify_header(CSegmentType::DELROUTE),
+            CSegmentType::DELROUTE,
+            &iface,
+            RouteView {
+                destination: parsed.destination,
+                source: parsed.source,
+                gateway: parsed.gateway,
+                priority: parsed.priority,
+                table: parsed.table,
+                protocol: request_segment.body().protocol as u8,
+                scope: request_segment.body().scope as u8,
+                kind: request_segment.body().type_ as u8,
+                flags: RouteFlags::empty(),
+            },
+        )?),
+    );
+    Ok(Vec::new())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ParsedRouteRequest {
+    destination: IpCidr,
+    source: Option<IpCidr>,
+    gateway: Option<IpAddress>,
+    oif: u32,
+    priority: u32,
+    table: u8,
+}
+
+impl ParsedRouteRequest {
+    fn from_segment(segment: &RouteSegment) -> Result<Self, SystemError> {
+        let family = segment.body().family;
+        let mut destination = default_cidr(family)?;
+        let mut source = None;
+        let mut gateway = None;
+        let mut oif = None;
+        let mut priority = 0;
+        let mut table = segment.body().table as u8;
+
+        for attr in segment.attrs() {
+            match attr {
+                RouteAttr::Dst(bytes) => {
+                    destination = parse_cidr(bytes, segment.body().dst_len, family)?;
+                }
+                RouteAttr::Src(bytes) => {
+                    source = Some(parse_cidr(bytes, segment.body().src_len, family)?);
+                }
+                RouteAttr::Prefsrc(bytes) => {
+                    source = Some(parse_cidr(bytes, 0, family)?);
+                }
+                RouteAttr::Gateway(bytes) => gateway = Some(parse_ip(bytes, family)?),
+                RouteAttr::Oif(index) => oif = Some(*index),
+                RouteAttr::Priority(metric) => priority = *metric,
+                RouteAttr::Table(route_table) => table = *route_table as u8,
+                RouteAttr::Iif(_) => {}
+            }
+        }
+
+        let oif = oif.ok_or(SystemError::EINVAL)?;
+        Ok(Self {
+            destination,
+            source,
+            gateway,
+            oif,
+            priority,
+            table,
+        })
+    }
+}
+
+fn build_connected_route_segments(
+    request_segment: &RouteSegment,
+    iface: &Arc<dyn Iface>,
+    requested_family: AddressFamily,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let mut segments = Vec::new();
+    for cidr in iface.common().ip_addrs().iter() {
+        let family = family_of_ip(cidr.address());
+        if !family_matches(requested_family, family) {
+            continue;
+        }
+
+        let scope = if iface.name() == "lo" {
+            RouteScope::Host
+        } else {
+            RouteScope::Link
+        };
+
+        segments.push(RouteNlSegment::NewRoute(route_to_segment(
+            request_segment.header(),
+            CSegmentType::NEWROUTE,
+            iface,
+            RouteView {
+                destination: *cidr,
+                source: None,
+                gateway: None,
+                priority: 0,
+                table: RouteTable::Main as u8,
+                protocol: RouteProtocol::Kernel as u8,
+                scope: scope as u8,
+                kind: RouteType::Unicast as u8,
+                flags: RouteFlags::empty(),
+            },
+        )?));
+    }
+
+    Ok(segments)
+}
+
+fn build_netlink_route_segments(
+    request_segment: &RouteSegment,
+    iface: &Arc<dyn Iface>,
+    requested_family: AddressFamily,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    iface
+        .common()
+        .netlink_routes()
+        .iter()
+        .filter(|route| family_matches(requested_family, family_of_ip(route.destination.address())))
+        .map(|route| {
+            route_to_segment(
+                request_segment.header(),
+                CSegmentType::NEWROUTE,
+                iface,
+                RouteView {
+                    destination: route.destination,
+                    source: route.source,
+                    gateway: route.gateway,
+                    priority: route.priority,
+                    table: route.table,
+                    protocol: route.protocol,
+                    scope: route.scope,
+                    kind: route.kind,
+                    flags: RouteFlags::empty(),
+                },
+            )
+            .map(RouteNlSegment::NewRoute)
+        })
+        .collect()
+}
+
+fn do_lookup_route(
+    request_segment: &RouteSegment,
+    netns: Arc<NetNamespace>,
+) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let family = request_segment.body().family;
+    let mut destination = default_cidr(family)?;
+    for attr in request_segment.attrs() {
+        if let RouteAttr::Dst(bytes) = attr {
+            destination = parse_cidr(bytes, request_segment.body().dst_len, family)?;
+        }
+    }
+
+    let lo = netns.loopback_iface().ok_or(SystemError::ENODEV)?;
+    let iface: Arc<dyn Iface> = lo;
+
+    let segment = route_to_segment(
+        request_segment.header(),
+        CSegmentType::NEWROUTE,
+        &iface,
+        RouteView {
+            destination,
+            source: None,
+            gateway: None,
+            priority: 0,
+            table: RouteTable::Main as u8,
+            protocol: RouteProtocol::Kernel as u8,
+            scope: RouteScope::Host as u8,
+            kind: RouteType::Unicast as u8,
+            flags: RouteFlags::CLONED,
+        },
+    )?;
+
+    Ok(vec![RouteNlSegment::NewRoute(segment)])
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RouteView {
+    destination: IpCidr,
+    source: Option<IpCidr>,
+    gateway: Option<IpAddress>,
+    priority: u32,
+    table: u8,
+    protocol: u8,
+    scope: u8,
+    kind: u8,
+    flags: RouteFlags,
+}
+
+fn route_to_segment(
+    request_header: &CMsgSegHdr,
+    msg_type: CSegmentType,
+    iface: &Arc<dyn Iface>,
+    route: RouteView,
+) -> Result<crate::net::socket::netlink::route::message::segment::route::RouteSegment, SystemError>
+{
+    let family = family_of_ip(route.destination.address());
+    let header = crate::net::socket::netlink::message::segment::header::CMsgSegHdr {
+        len: 0,
+        type_: msg_type as u16,
+        flags: SegHdrCommonFlags::empty().bits(),
+        seq: request_header.seq,
+        pid: request_header.pid,
+    };
+    let body = RouteSegmentBody {
+        family,
+        dst_len: route.destination.prefix_len(),
+        src_len: route.source.map(|cidr| cidr.prefix_len()).unwrap_or(0),
+        tos: 0,
+        table: RouteTable::try_from(route.table).unwrap_or(RouteTable::Main),
+        protocol: RouteProtocol::try_from(route.protocol).unwrap_or(RouteProtocol::Boot),
+        scope: RouteScope::try_from(route.scope).unwrap_or(RouteScope::Universe),
+        type_: RouteType::try_from(route.kind).unwrap_or(RouteType::Unicast),
+        flags: route.flags,
+    };
+
+    let mut attrs = vec![
+        RouteAttr::Dst(ip_to_bytes(route_destination_prefix(route.destination))),
+        RouteAttr::Oif(iface.nic_id() as u32),
+    ];
+    if let Some(source) = route.source {
+        attrs.push(RouteAttr::Src(ip_to_bytes(source.address())));
+    }
+    if let Some(gateway) = route.gateway {
+        attrs.push(RouteAttr::Gateway(ip_to_bytes(gateway)));
+    }
+    if route.priority != 0 {
+        attrs.push(RouteAttr::Priority(route.priority));
+    }
+
+    Ok(RouteSegment::new(header, body, attrs))
+}
+
+fn sync_iface_route_table(
+    iface: &Arc<dyn Iface>,
+    route: &ParsedRouteRequest,
+) -> Result<(), SystemError> {
+    let mut push_failed = false;
+    iface.smol_iface().lock().routes_mut().update(|routes| {
+        routes.retain(|existing| {
+            !(existing.cidr == route.destination && !is_local_connected_route(existing))
+        });
+
+        if let Some(gateway) = route.gateway {
+            if routes
+                .push(smoltcp::iface::Route {
+                    cidr: route.destination,
+                    via_router: gateway,
+                    preferred_until: None,
+                    expires_at: None,
+                })
+                .is_err()
+            {
+                push_failed = true;
+            }
+        }
+    });
+    if push_failed {
+        Err(SystemError::ENOSPC)
+    } else {
+        Ok(())
+    }
+}
+
+fn sync_iface_route_table_remove(
+    iface: &Arc<dyn Iface>,
+    destination: IpCidr,
+    source: Option<IpCidr>,
+    gateway: Option<IpAddress>,
+    table: u8,
+) {
+    iface.smol_iface().lock().routes_mut().update(|routes| {
+        routes.retain(|existing| {
+            if is_local_connected_route(existing) {
+                return true;
+            }
+            if existing.cidr != destination {
+                return true;
+            }
+            if let Some(gw) = gateway {
+                existing.via_router != gw
+            } else {
+                false
+            }
+        });
+    });
+    let _ = (source, table);
+}
+
+fn family_matches(requested_family: AddressFamily, actual_family: AddressFamily) -> bool {
+    requested_family == AddressFamily::Unspecified || requested_family == actual_family
+}
+
+fn family_of_ip(ip: IpAddress) -> AddressFamily {
+    match ip {
+        IpAddress::Ipv4(_) => AddressFamily::INet,
+        IpAddress::Ipv6(_) => AddressFamily::INet6,
+    }
+}
+
+fn default_cidr(family: AddressFamily) -> Result<IpCidr, SystemError> {
+    match family {
+        AddressFamily::INet => Ok(IpCidr::Ipv4(Ipv4Cidr::new(Ipv4Address::UNSPECIFIED, 0))),
+        AddressFamily::INet6 => Ok(IpCidr::Ipv6(Ipv6Cidr::new(Ipv6Address::UNSPECIFIED, 0))),
+        _ => Err(SystemError::EAFNOSUPPORT),
+    }
+}
+
+fn parse_cidr(bytes: &[u8], prefix_len: u8, family: AddressFamily) -> Result<IpCidr, SystemError> {
+    let ip = parse_ip(bytes, family)?;
+    match ip {
+        IpAddress::Ipv4(addr) if prefix_len <= 32 => {
+            Ok(IpCidr::Ipv4(Ipv4Cidr::new(addr, prefix_len)))
+        }
+        IpAddress::Ipv6(addr) if prefix_len <= 128 => {
+            Ok(IpCidr::Ipv6(Ipv6Cidr::new(addr, prefix_len)))
+        }
+        _ => Err(SystemError::EINVAL),
+    }
+}
+
+fn parse_ip(bytes: &[u8], family: AddressFamily) -> Result<IpAddress, SystemError> {
+    match family {
+        AddressFamily::INet if bytes.len() == 4 => Ok(IpAddress::Ipv4(Ipv4Address::new(
+            bytes[0], bytes[1], bytes[2], bytes[3],
+        ))),
+        AddressFamily::INet6 if bytes.len() == 16 => Ok(IpAddress::Ipv6(Ipv6Address::new(
+            u16::from_be_bytes([bytes[0], bytes[1]]),
+            u16::from_be_bytes([bytes[2], bytes[3]]),
+            u16::from_be_bytes([bytes[4], bytes[5]]),
+            u16::from_be_bytes([bytes[6], bytes[7]]),
+            u16::from_be_bytes([bytes[8], bytes[9]]),
+            u16::from_be_bytes([bytes[10], bytes[11]]),
+            u16::from_be_bytes([bytes[12], bytes[13]]),
+            u16::from_be_bytes([bytes[14], bytes[15]]),
+        ))),
+        _ => Err(SystemError::EINVAL),
+    }
+}
+
+fn ip_to_bytes(ip: IpAddress) -> Vec<u8> {
+    match ip {
+        IpAddress::Ipv4(addr) => addr.octets().to_vec(),
+        IpAddress::Ipv6(addr) => addr.octets().to_vec(),
+    }
+}
+
+fn route_destination_prefix(cidr: IpCidr) -> IpAddress {
+    match cidr {
+        IpCidr::Ipv4(cidr) => IpAddress::Ipv4(cidr.network().address()),
+        IpCidr::Ipv6(cidr) => {
+            let mut octets = cidr.address().octets();
+            let prefix_len = cidr.prefix_len() as usize;
+            let full_bytes = prefix_len / 8;
+            let partial_bits = prefix_len % 8;
+
+            if partial_bits != 0 && full_bytes < octets.len() {
+                octets[full_bytes] &= 0xffu8 << (8 - partial_bits);
+            }
+            for byte in octets.iter_mut().skip(full_bytes + usize::from(partial_bits != 0)) {
+                *byte = 0;
+            }
+
+            IpAddress::Ipv6(Ipv6Address::from(octets))
+        }
+    }
+}
+
+fn is_local_connected_route(route: &smoltcp::iface::Route) -> bool {
+    route.via_router == route.cidr.address()
+}
+
+fn route_notify_group(ip: IpAddress) -> u32 {
+    match ip {
+        IpAddress::Ipv4(_) => RTMGRP_IPV4_ROUTE,
+        IpAddress::Ipv6(_) => RTMGRP_IPV6_ROUTE,
+    }
+}

--- a/kernel/src/net/socket/netlink/route/kern/route.rs
+++ b/kernel/src/net/socket/netlink/route/kern/route.rs
@@ -162,7 +162,7 @@ pub(super) fn do_new_route(
                 source: parsed.source,
                 gateway: parsed.gateway,
                 priority: parsed.priority,
-                table: parsed.table,
+                table,
                 protocol: request_segment.body().protocol as u8,
                 scope: request_segment.body().scope as u8,
                 kind: request_segment.body().type_ as u8,
@@ -211,7 +211,7 @@ pub(super) fn do_del_route(
                 source: parsed.source,
                 gateway: parsed.gateway,
                 priority: parsed.priority,
-                table: parsed.table,
+                table,
                 protocol: request_segment.body().protocol as u8,
                 scope: request_segment.body().scope as u8,
                 kind: request_segment.body().type_ as u8,
@@ -436,25 +436,20 @@ fn route_to_segment(
     Ok(RouteSegment::new(header, body, attrs))
 }
 
-fn smoltcp_via_router(destination: IpCidr, gateway: Option<IpAddress>) -> IpAddress {
-    gateway.unwrap_or_else(|| route_destination_prefix(destination))
-}
-
 fn sync_iface_route_table(
     iface: &Arc<dyn Iface>,
     route: &ParsedRouteRequest,
 ) -> Result<(), SystemError> {
-    let via_router = smoltcp_via_router(route.destination, route.gateway);
     let mut push_failed = false;
     iface.smol_iface().lock().routes_mut().update(|routes| {
         routes.retain(|existing| {
-            existing.cidr != route.destination || is_local_connected_route(existing)
+            existing.cidr != route.destination || is_local_connected_route(iface, existing)
         });
 
         if routes
             .push(smoltcp::iface::Route {
                 cidr: route.destination,
-                via_router,
+                via_router: route.gateway,
                 preferred_until: None,
                 expires_at: None,
             })
@@ -479,17 +474,13 @@ fn sync_iface_route_table_remove(
 ) {
     iface.smol_iface().lock().routes_mut().update(|routes| {
         routes.retain(|existing| {
-            if is_local_connected_route(existing) {
+            if is_local_connected_route(iface, existing) {
                 return true;
             }
             if existing.cidr != destination {
                 return true;
             }
-            if let Some(gw) = gateway {
-                existing.via_router != gw
-            } else {
-                false
-            }
+            existing.via_router != gateway
         });
     });
     let _ = (source, table);
@@ -577,8 +568,8 @@ fn route_destination_prefix(cidr: IpCidr) -> IpAddress {
     }
 }
 
-fn is_local_connected_route(route: &smoltcp::iface::Route) -> bool {
-    route.via_router == route.cidr.address()
+fn is_local_connected_route(iface: &Arc<dyn Iface>, route: &smoltcp::iface::Route) -> bool {
+    route.via_router.is_none() && iface.common().ip_addrs().contains(&route.cidr)
 }
 
 fn route_notify_group(ip: IpAddress) -> u32 {

--- a/kernel/src/net/socket/netlink/route/kern/route.rs
+++ b/kernel/src/net/socket/netlink/route/kern/route.rs
@@ -149,11 +149,9 @@ pub(super) fn do_new_route(
     iface.common().upsert_netlink_route(entry);
 
     if let Err(err) = sync_iface_route_table(&iface, &parsed) {
-        iface.common().remove_netlink_route(
-            parsed.destination,
-            parsed.source,
-            parsed.table,
-        );
+        iface
+            .common()
+            .remove_netlink_route(parsed.destination, parsed.source, parsed.table);
         return Err(err);
     }
     multicast_notify(
@@ -449,7 +447,7 @@ fn sync_iface_route_table(
     let mut push_failed = false;
     iface.smol_iface().lock().routes_mut().update(|routes| {
         routes.retain(|existing| {
-            !(existing.cidr == route.destination && !is_local_connected_route(existing))
+            existing.cidr != route.destination || is_local_connected_route(existing)
         });
 
         if let Some(gateway) = route.gateway {
@@ -568,7 +566,10 @@ fn route_destination_prefix(cidr: IpCidr) -> IpAddress {
             if partial_bits != 0 && full_bytes < octets.len() {
                 octets[full_bytes] &= 0xffu8 << (8 - partial_bits);
             }
-            for byte in octets.iter_mut().skip(full_bytes + usize::from(partial_bits != 0)) {
+            for byte in octets
+                .iter_mut()
+                .skip(full_bytes + usize::from(partial_bits != 0))
+            {
                 *byte = 0;
             }
 

--- a/kernel/src/net/socket/netlink/route/kern/route.rs
+++ b/kernel/src/net/socket/netlink/route/kern/route.rs
@@ -124,10 +124,6 @@ pub(super) fn do_new_route(
         .cloned()
         .ok_or(SystemError::ENODEV)?;
 
-    if parsed.destination.prefix_len() == 0 && parsed.gateway.is_none() {
-        return Err(SystemError::EINVAL);
-    }
-
     let table = effective_route_table(parsed.table);
     let entry = NetlinkRouteEntry {
         destination: parsed.destination,
@@ -151,7 +147,7 @@ pub(super) fn do_new_route(
     if let Err(err) = sync_iface_route_table(&iface, &parsed) {
         iface
             .common()
-            .remove_netlink_route(parsed.destination, parsed.source, parsed.table);
+            .remove_netlink_route(parsed.destination, parsed.source, table);
         return Err(err);
     }
     multicast_notify(
@@ -440,28 +436,31 @@ fn route_to_segment(
     Ok(RouteSegment::new(header, body, attrs))
 }
 
+fn smoltcp_via_router(destination: IpCidr, gateway: Option<IpAddress>) -> IpAddress {
+    gateway.unwrap_or_else(|| route_destination_prefix(destination))
+}
+
 fn sync_iface_route_table(
     iface: &Arc<dyn Iface>,
     route: &ParsedRouteRequest,
 ) -> Result<(), SystemError> {
+    let via_router = smoltcp_via_router(route.destination, route.gateway);
     let mut push_failed = false;
     iface.smol_iface().lock().routes_mut().update(|routes| {
         routes.retain(|existing| {
             existing.cidr != route.destination || is_local_connected_route(existing)
         });
 
-        if let Some(gateway) = route.gateway {
-            if routes
-                .push(smoltcp::iface::Route {
-                    cidr: route.destination,
-                    via_router: gateway,
-                    preferred_until: None,
-                    expires_at: None,
-                })
-                .is_err()
-            {
-                push_failed = true;
-            }
+        if routes
+            .push(smoltcp::iface::Route {
+                cidr: route.destination,
+                via_router,
+                preferred_until: None,
+                expires_at: None,
+            })
+            .is_err()
+        {
+            push_failed = true;
         }
     });
     if push_failed {

--- a/kernel/src/net/socket/netlink/route/kern/utils.rs
+++ b/kernel/src/net/socket/netlink/route/kern/utils.rs
@@ -1,14 +1,25 @@
 use crate::net::socket::netlink::{
+    addr::multicast::GroupIdSet,
     message::{
         segment::{
             ack::DoneSegment,
             header::{CMsgSegHdr, SegHdrCommonFlags},
+            CSegmentType,
         },
-        ProtocolSegment,
+        Message, ProtocolSegment,
     },
     route::message::segment::RouteNlSegment,
+    table::{NetlinkRouteProtocol, SupportedNetlinkProtocol},
 };
-use alloc::vec::Vec;
+use crate::process::namespace::net_namespace::NetNamespace;
+use alloc::{sync::Arc, vec::Vec};
+
+pub const RTMGRP_LINK: u32 = 0x1;
+pub const RTMGRP_NEIGH: u32 = 0x4;
+pub const RTMGRP_IPV4_IFADDR: u32 = 0x10;
+pub const RTMGRP_IPV4_ROUTE: u32 = 0x40;
+pub const RTMGRP_IPV6_IFADDR: u32 = 0x100;
+pub const RTMGRP_IPV6_ROUTE: u32 = 0x400;
 
 pub fn finish_response(
     request_header: &CMsgSegHdr,
@@ -16,7 +27,12 @@ pub fn finish_response(
     response_segments: &mut Vec<RouteNlSegment>,
 ) {
     if !dump_all {
-        assert_eq!(response_segments.len(), 1);
+        if response_segments.len() != 1 {
+            log::warn!(
+                "netlink route: expected exactly one response segment, got {}",
+                response_segments.len()
+            );
+        }
         return;
     }
 
@@ -35,5 +51,25 @@ fn add_multi_flag(responce_segment: &mut [RouteNlSegment]) {
         let mut flags = SegHdrCommonFlags::from_bits_truncate(header.flags);
         flags |= SegHdrCommonFlags::MULTI;
         header.flags = flags.bits();
+    }
+}
+
+pub fn kernel_notify_header(type_: CSegmentType) -> CMsgSegHdr {
+    CMsgSegHdr {
+        len: 0,
+        type_: type_ as u16,
+        flags: SegHdrCommonFlags::empty().bits(),
+        seq: 0,
+        pid: 0,
+    }
+}
+
+pub fn multicast_notify(netns: Arc<NetNamespace>, group_mask: u32, segment: RouteNlSegment) {
+    if let Err(e) = NetlinkRouteProtocol::multicast(
+        GroupIdSet::new(group_mask),
+        Message::new(vec![segment]),
+        netns,
+    ) {
+        log::warn!("netlink route: multicast notify failed: {:?}", e);
     }
 }

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -42,7 +42,7 @@ impl TryFrom<u16> for AddrAttrClass {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum AddrAttr {
     Address(Vec<u8>),
     Local(Vec<u8>),

--- a/kernel/src/net/socket/netlink/route/message/attr/link.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/link.rs
@@ -3,6 +3,7 @@ use crate::net::socket::netlink::message::attr::CAttrHeader;
 use crate::net::socket::netlink::route::message::attr::convert_one_from_raw_buf;
 use crate::net::socket::netlink::route::message::attr::IFNAME_SIZE;
 use alloc::ffi::CString;
+use alloc::vec::Vec;
 use num_traits::FromPrimitive;
 use system_error::SystemError;
 
@@ -86,8 +87,9 @@ impl TryFrom<u16> for LinkAttrClass {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum LinkAttr {
+    Address(Vec<u8>),
     Name(CString),
     Mtu(u32),
     TxqLen(u32),
@@ -98,6 +100,7 @@ pub enum LinkAttr {
 impl LinkAttr {
     fn class(&self) -> LinkAttrClass {
         match self {
+            LinkAttr::Address(_) => LinkAttrClass::ADDRESS,
             LinkAttr::Name(_) => LinkAttrClass::IFNAME,
             LinkAttr::Mtu(_) => LinkAttrClass::MTU,
             LinkAttr::TxqLen(_) => LinkAttrClass::TXQLEN,
@@ -126,6 +129,7 @@ impl Attribute for LinkAttr {
 
     fn payload_as_bytes(&self) -> &[u8] {
         match self {
+            LinkAttr::Address(address) => address.as_slice(),
             LinkAttr::Name(name) => name.as_bytes_with_nul(),
             LinkAttr::Mtu(mtu) => unsafe {
                 core::slice::from_raw_parts(mtu as *const u32 as *const u8, 4)

--- a/kernel/src/net/socket/netlink/route/message/attr/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/mod.rs
@@ -3,6 +3,7 @@ use system_error::SystemError;
 
 pub mod addr;
 pub mod link;
+pub mod neigh;
 pub mod route;
 
 /// 网卡名字长度

--- a/kernel/src/net/socket/netlink/route/message/attr/neigh.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/neigh.rs
@@ -1,0 +1,68 @@
+use crate::net::socket::netlink::message::attr::{Attribute, CAttrHeader};
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u16)]
+enum NeighAttrClass {
+    UNSPEC = 0,
+    DST = 1,
+    LLADDR = 2,
+}
+
+impl TryFrom<u16> for NeighAttrClass {
+    type Error = SystemError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::UNSPEC),
+            1 => Ok(Self::DST),
+            2 => Ok(Self::LLADDR),
+            _ => Err(SystemError::EINVAL),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum NeighAttr {
+    Destination(Vec<u8>),
+    LinkLocalAddress(Vec<u8>),
+}
+
+impl NeighAttr {
+    fn class(&self) -> NeighAttrClass {
+        match self {
+            Self::Destination(_) => NeighAttrClass::DST,
+            Self::LinkLocalAddress(_) => NeighAttrClass::LLADDR,
+        }
+    }
+}
+
+impl Attribute for NeighAttr {
+    fn type_(&self) -> u16 {
+        self.class() as u16
+    }
+
+    fn payload_as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Destination(bytes) | Self::LinkLocalAddress(bytes) => bytes.as_slice(),
+        }
+    }
+
+    fn read_from_buf(header: &CAttrHeader, payload_buf: &[u8]) -> Result<Option<Self>, SystemError>
+    where
+        Self: Sized,
+    {
+        let Ok(class) = NeighAttrClass::try_from(header.type_()) else {
+            return Ok(None);
+        };
+
+        let attr = match class {
+            NeighAttrClass::DST => Self::Destination(payload_buf.to_vec()),
+            NeighAttrClass::LLADDR => Self::LinkLocalAddress(payload_buf.to_vec()),
+            NeighAttrClass::UNSPEC => return Ok(None),
+        };
+
+        Ok(Some(attr))
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/attr/route.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/route.rs
@@ -1,21 +1,22 @@
-use crate::net::socket::netlink::message::attr::Attribute;
+use crate::net::socket::netlink::message::attr::{Attribute, CAttrHeader};
+use crate::net::socket::netlink::route::message::attr::convert_one_from_raw_buf;
+use alloc::vec::Vec;
 use system_error::SystemError;
 
-/// 路由相关属性
 #[derive(Debug, Clone, Copy)]
 #[repr(u16)]
 enum RouteAttrClass {
     UNSPEC = 0,
-    DST = 1,       // 目标地址
-    SRC = 2,       // 源地址
-    IIF = 3,       // 输入接口
-    OIF = 4,       // 输出接口
-    GATEWAY = 5,   // 网关地址
-    PRIORITY = 6,  // 路由优先级
-    PREFSRC = 7,   // 首选源地址
-    METRICS = 8,   // 路由度量
-    MULTIPATH = 9, // 多路径信息
-    TABLE = 15,    // 路由表ID
+    DST = 1,
+    SRC = 2,
+    IIF = 3,
+    OIF = 4,
+    GATEWAY = 5,
+    PRIORITY = 6,
+    PREFSRC = 7,
+    METRICS = 8,
+    MULTIPATH = 9,
+    TABLE = 15,
 }
 
 impl TryFrom<u16> for RouteAttrClass {
@@ -39,16 +40,16 @@ impl TryFrom<u16> for RouteAttrClass {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RouteAttr {
-    Dst([u8; 4]),     // 目标地址 (IPv4)
-    Src([u8; 4]),     // 源地址 (IPv4)
-    Gateway([u8; 4]), // 网关地址 (IPv4)
-    Oif(u32),         // 输出接口索引
-    Iif(u32),         // 输入接口索引
-    Priority(u32),    // 路由优先级
-    Prefsrc([u8; 4]), // 首选源地址 (IPv4)
-    Table(u32),       // 路由表ID
+    Dst(Vec<u8>),
+    Src(Vec<u8>),
+    Gateway(Vec<u8>),
+    Oif(u32),
+    Iif(u32),
+    Priority(u32),
+    Prefsrc(Vec<u8>),
+    Table(u32),
 }
 
 impl RouteAttr {
@@ -70,26 +71,68 @@ impl Attribute for RouteAttr {
     fn type_(&self) -> u16 {
         self.class() as u16
     }
+
     fn payload_as_bytes(&self) -> &[u8] {
-        // match self {
-        //     RouteAttr::Dst(addr)
-        //     | RouteAttr::Src(addr)
-        //     | RouteAttr::Gateway(addr)
-        //     | RouteAttr::Prefsrc(addr) => addr,
-        //     RouteAttr::Oif(idx) | RouteAttr::Iif(idx) => idx.as_bytes(),
-        //     RouteAttr::Priority(pri) => pri.as_bytes(),
-        //     RouteAttr::Table(table) => table.as_bytes(),
-        // }
-        todo!()
+        match self {
+            RouteAttr::Dst(addr)
+            | RouteAttr::Src(addr)
+            | RouteAttr::Gateway(addr)
+            | RouteAttr::Prefsrc(addr) => addr.as_slice(),
+            RouteAttr::Oif(idx)
+            | RouteAttr::Iif(idx)
+            | RouteAttr::Priority(idx)
+            | RouteAttr::Table(idx) => unsafe {
+                core::slice::from_raw_parts(idx as *const u32 as *const u8, 4)
+            },
+        }
     }
 
-    fn read_from_buf(
-        _header: &crate::net::socket::netlink::message::attr::CAttrHeader,
-        _payload_buf: &[u8],
-    ) -> Result<Option<Self>, SystemError>
+    fn read_from_buf(header: &CAttrHeader, payload_buf: &[u8]) -> Result<Option<Self>, SystemError>
     where
         Self: Sized,
     {
-        todo!()
+        let payload_len = header.payload_len();
+        let Ok(class) = RouteAttrClass::try_from(header.type_()) else {
+            return Ok(None);
+        };
+
+        let attr = match class {
+            RouteAttrClass::DST
+            | RouteAttrClass::SRC
+            | RouteAttrClass::GATEWAY
+            | RouteAttrClass::PREFSRC
+                if matches!(payload_len, 4 | 16) =>
+            {
+                let bytes = payload_buf.to_vec();
+                match class {
+                    RouteAttrClass::DST => RouteAttr::Dst(bytes),
+                    RouteAttrClass::SRC => RouteAttr::Src(bytes),
+                    RouteAttrClass::GATEWAY => RouteAttr::Gateway(bytes),
+                    RouteAttrClass::PREFSRC => RouteAttr::Prefsrc(bytes),
+                    _ => unreachable!(),
+                }
+            }
+            RouteAttrClass::OIF | RouteAttrClass::IIF | RouteAttrClass::PRIORITY
+                if payload_len == 4 =>
+            {
+                let value = *convert_one_from_raw_buf::<u32>(payload_buf)?;
+                match class {
+                    RouteAttrClass::OIF => RouteAttr::Oif(value),
+                    RouteAttrClass::IIF => RouteAttr::Iif(value),
+                    RouteAttrClass::PRIORITY => RouteAttr::Priority(value),
+                    _ => unreachable!(),
+                }
+            }
+            RouteAttrClass::TABLE if payload_len == 1 => RouteAttr::Table(payload_buf[0] as u32),
+            RouteAttrClass::TABLE if payload_len == 4 => {
+                RouteAttr::Table(*convert_one_from_raw_buf::<u32>(payload_buf)?)
+            }
+            RouteAttrClass::METRICS | RouteAttrClass::MULTIPATH | RouteAttrClass::UNSPEC => {
+                return Ok(None);
+            }
+            _ => return Err(SystemError::EINVAL),
+        };
+
+        Ok(Some(attr))
     }
 }

--- a/kernel/src/net/socket/netlink/route/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/mod.rs
@@ -186,9 +186,7 @@ impl ProtocolSegment for RouteNlSegment {
             RouteNlSegment::NewLink(link_segment) => link_segment.write_to_buf(buf)?,
             RouteNlSegment::NewNeigh(neigh_segment)
             | RouteNlSegment::DelNeigh(neigh_segment)
-            | RouteNlSegment::GetNeigh(neigh_segment) => {
-                neigh_segment.write_to_buf(buf)?
-            }
+            | RouteNlSegment::GetNeigh(neigh_segment) => neigh_segment.write_to_buf(buf)?,
             RouteNlSegment::Done(done_segment) => done_segment.write_to_buf(buf)?,
             RouteNlSegment::Error(error_segment) => error_segment.write_to_buf(buf)?,
             _ => {

--- a/kernel/src/net/socket/netlink/route/message/segment/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/mod.rs
@@ -1,5 +1,6 @@
 pub mod addr;
 pub mod link;
+pub mod neigh;
 pub mod route;
 
 use crate::net::socket::netlink::{
@@ -12,10 +13,11 @@ use crate::net::socket::netlink::{
         ProtocolSegment,
     },
     route::message::{
-        attr::{addr::AddrAttr, link::LinkAttr, route::RouteAttr},
+        attr::{addr::AddrAttr, link::LinkAttr, neigh::NeighAttr, route::RouteAttr},
         segment::{
             addr::{AddrMessageFlags, AddrSegment, AddrSegmentBody, CIfaddrMsg, RtScope},
             link::{CIfinfoMsg, LinkMessageFlags, LinkSegment, LinkSegmentBody},
+            neigh::{CNdMsg, NeighSegment, NeighSegmentBody, NeighState},
             route::{
                 CRtMsg, RouteFlags, RouteProtocol, RouteScope, RouteSegment, RouteSegmentBody,
                 RouteTable, RouteType,
@@ -30,9 +32,10 @@ use crate::{
 use alloc::vec::Vec;
 use system_error::SystemError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RouteNlSegment {
     NewLink(LinkSegment),
+    SetLink(LinkSegment),
     GetLink(LinkSegment),
     NewAddr(AddrSegment),
     DelAddr(AddrSegment),
@@ -42,6 +45,9 @@ pub enum RouteNlSegment {
     NewRoute(RouteSegment),
     DelRoute(RouteSegment),
     GetRoute(RouteSegment),
+    NewNeigh(NeighSegment),
+    DelNeigh(NeighSegment),
+    GetNeigh(NeighSegment),
 }
 
 impl ProtocolSegment for RouteNlSegment {
@@ -56,6 +62,10 @@ impl ProtocolSegment for RouteNlSegment {
             RouteNlSegment::NewLink(link_segment) | RouteNlSegment::GetLink(link_segment) => {
                 link_segment.header()
             }
+            RouteNlSegment::SetLink(link_segment) => link_segment.header(),
+            RouteNlSegment::NewNeigh(neigh_segment)
+            | RouteNlSegment::DelNeigh(neigh_segment)
+            | RouteNlSegment::GetNeigh(neigh_segment) => neigh_segment.header(),
             RouteNlSegment::Done(done_segment) => done_segment.header(),
             RouteNlSegment::Error(error_segment) => error_segment.header(),
         }
@@ -74,6 +84,10 @@ impl ProtocolSegment for RouteNlSegment {
             RouteNlSegment::NewLink(link_segment) | RouteNlSegment::GetLink(link_segment) => {
                 link_segment.header_mut()
             }
+            RouteNlSegment::SetLink(link_segment) => link_segment.header_mut(),
+            RouteNlSegment::NewNeigh(neigh_segment)
+            | RouteNlSegment::DelNeigh(neigh_segment)
+            | RouteNlSegment::GetNeigh(neigh_segment) => neigh_segment.header_mut(),
             RouteNlSegment::Done(done_segment) => done_segment.header_mut(),
             RouteNlSegment::Error(error_segment) => error_segment.header_mut(),
         }
@@ -118,11 +132,40 @@ impl ProtocolSegment for RouteNlSegment {
                     RouteNlSegment::GetRoute(RouteSegment::read_from_buf(header, payload_buf)?)
                 }
             }
+            CSegmentType::NEWROUTE => {
+                RouteNlSegment::NewRoute(RouteSegment::read_from_buf(header, payload_buf)?)
+            }
+            CSegmentType::DELROUTE => {
+                RouteNlSegment::DelRoute(RouteSegment::read_from_buf(header, payload_buf)?)
+            }
             CSegmentType::GETLINK => {
                 if payload_len < size_of::<CIfinfoMsg>() {
                     RouteNlSegment::GetLink(read_short_getlink_segment(header, payload_buf)?)
                 } else {
                     RouteNlSegment::GetLink(LinkSegment::read_from_buf(header, payload_buf)?)
+                }
+            }
+            CSegmentType::SETLINK | CSegmentType::NEWLINK | CSegmentType::DELLINK => {
+                RouteNlSegment::SetLink(LinkSegment::read_from_buf(header, payload_buf)?)
+            }
+            CSegmentType::GETRULE => {
+                if payload_len < size_of::<CRtMsg>() {
+                    RouteNlSegment::GetRoute(read_short_getroute_segment(header, payload_buf)?)
+                } else {
+                    RouteNlSegment::GetRoute(RouteSegment::read_from_buf(header, payload_buf)?)
+                }
+            }
+            CSegmentType::NEWNEIGH => {
+                RouteNlSegment::NewNeigh(NeighSegment::read_from_buf(header, payload_buf)?)
+            }
+            CSegmentType::DELNEIGH => {
+                RouteNlSegment::DelNeigh(NeighSegment::read_from_buf(header, payload_buf)?)
+            }
+            CSegmentType::GETNEIGH => {
+                if payload_len < size_of::<CNdMsg>() {
+                    RouteNlSegment::GetNeigh(read_short_getneigh_segment(header, payload_buf)?)
+                } else {
+                    RouteNlSegment::GetNeigh(NeighSegment::read_from_buf(header, payload_buf)?)
                 }
             }
             _ => return Err(SystemError::EINVAL),
@@ -137,8 +180,15 @@ impl ProtocolSegment for RouteNlSegment {
             RouteNlSegment::NewAddr(addr_segment) | RouteNlSegment::DelAddr(addr_segment) => {
                 addr_segment.write_to_buf(buf)?
             }
-            RouteNlSegment::NewRoute(route_segment) => route_segment.write_to_buf(buf)?,
+            RouteNlSegment::NewRoute(route_segment) | RouteNlSegment::DelRoute(route_segment) => {
+                route_segment.write_to_buf(buf)?
+            }
             RouteNlSegment::NewLink(link_segment) => link_segment.write_to_buf(buf)?,
+            RouteNlSegment::NewNeigh(neigh_segment)
+            | RouteNlSegment::DelNeigh(neigh_segment)
+            | RouteNlSegment::GetNeigh(neigh_segment) => {
+                neigh_segment.write_to_buf(buf)?
+            }
             RouteNlSegment::Done(done_segment) => done_segment.write_to_buf(buf)?,
             RouteNlSegment::Error(error_segment) => error_segment.write_to_buf(buf)?,
             _ => {
@@ -207,6 +257,24 @@ fn read_short_getroute_segment(
         flags: RouteFlags::empty(),
     };
     let mut segment = RouteSegment::new(header, body, Vec::<RouteAttr>::new());
+    segment.header_mut().len = header.len;
+    Ok(segment)
+}
+
+#[allow(dead_code)]
+fn read_short_getneigh_segment(
+    header: CMsgSegHdr,
+    payload: &[u8],
+) -> Result<NeighSegment, SystemError> {
+    let family = read_rtgen_family(payload)?;
+    let body = NeighSegmentBody {
+        family,
+        ifindex: 0,
+        state: NeighState::empty(),
+        flags: 0,
+        kind: RouteType::Unspec,
+    };
+    let mut segment = NeighSegment::new(header, body, Vec::<NeighAttr>::new());
     segment.header_mut().len = header.len;
     Ok(segment)
 }

--- a/kernel/src/net/socket/netlink/route/message/segment/neigh.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/neigh.rs
@@ -1,0 +1,78 @@
+use crate::net::socket::{
+    netlink::{
+        message::segment::{common::SegmentCommon, SegmentBody},
+        route::message::attr::neigh::NeighAttr,
+    },
+    AddressFamily,
+};
+use system_error::SystemError;
+
+use super::route::RouteType;
+
+pub type NeighSegment = SegmentCommon<NeighSegmentBody, NeighAttr>;
+
+impl SegmentBody for NeighSegmentBody {
+    type CType = CNdMsg;
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CNdMsg {
+    pub family: u8,
+    pub pad1: u8,
+    pub pad2: u16,
+    pub ifindex: i32,
+    pub state: u16,
+    pub flags: u8,
+    pub type_: u8,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct NeighSegmentBody {
+    pub family: AddressFamily,
+    pub ifindex: i32,
+    pub state: NeighState,
+    pub flags: u8,
+    pub kind: RouteType,
+}
+
+impl TryFrom<CNdMsg> for NeighSegmentBody {
+    type Error = SystemError;
+
+    fn try_from(value: CNdMsg) -> Result<Self, Self::Error> {
+        Ok(Self {
+            family: AddressFamily::try_from(value.family as u16)?,
+            ifindex: value.ifindex,
+            state: NeighState::from_bits_truncate(value.state),
+            flags: value.flags,
+            kind: RouteType::try_from(value.type_)?,
+        })
+    }
+}
+
+impl From<NeighSegmentBody> for CNdMsg {
+    fn from(value: NeighSegmentBody) -> Self {
+        Self {
+            family: value.family as u8,
+            pad1: 0,
+            pad2: 0,
+            ifindex: value.ifindex,
+            state: value.state.bits(),
+            flags: value.flags,
+            type_: value.kind as u8,
+        }
+    }
+}
+
+bitflags::bitflags! {
+    pub struct NeighState: u16 {
+        const INCOMPLETE = 0x01;
+        const REACHABLE = 0x02;
+        const STALE = 0x04;
+        const DELAY = 0x08;
+        const PROBE = 0x10;
+        const FAILED = 0x20;
+        const NOARP = 0x40;
+        const PERMANENT = 0x80;
+    }
+}

--- a/kernel/src/net/socket/netlink/route/message/segment/route.rs
+++ b/kernel/src/net/socket/netlink/route/message/segment/route.rs
@@ -167,6 +167,8 @@ bitflags::bitflags! {
         const CLONED = 0x200;
         const EQUALIZE = 0x400;
         const PREFIX = 0x800;
+        /// `RTM_F_LOOKUP_TABLE` — fib lookup (Linux 6.6).
+        const LOOKUP_TABLE = 0x1000;
     }
 }
 

--- a/kernel/src/net/socket/netlink/table/mod.rs
+++ b/kernel/src/net/socket/netlink/table/mod.rs
@@ -95,7 +95,10 @@ impl<Message: 'static + Debug> ProtocolSocketTable<Message> {
 
     fn unicast(&self, dst_port: u32, message: Message) -> Result<(), SystemError> {
         let Some(receiver) = self.unicast_sockets.get(&dst_port) else {
-            log::warn!("netlink unicast: destination port {} is not bound", dst_port);
+            log::warn!(
+                "netlink unicast: destination port {} is not bound",
+                dst_port
+            );
             return Err(SystemError::ECONNREFUSED);
         };
         receiver.enqueue_message(message)

--- a/kernel/src/net/socket/netlink/table/mod.rs
+++ b/kernel/src/net/socket/netlink/table/mod.rs
@@ -21,7 +21,7 @@ use hashbrown::HashMap;
 use system_error::SystemError;
 
 pub const MAX_ALLOWED_PROTOCOL_ID: u32 = 32;
-const MAX_GROUPS: u32 = 32;
+const MAX_GROUPS: u32 = 64;
 
 #[derive(Debug)]
 pub struct NetlinkSocketTable {
@@ -95,7 +95,8 @@ impl<Message: 'static + Debug> ProtocolSocketTable<Message> {
 
     fn unicast(&self, dst_port: u32, message: Message) -> Result<(), SystemError> {
         let Some(receiver) = self.unicast_sockets.get(&dst_port) else {
-            return Ok(());
+            log::warn!("netlink unicast: destination port {} is not bound", dst_port);
+            return Err(SystemError::ECONNREFUSED);
         };
         receiver.enqueue_message(message)
     }
@@ -201,6 +202,8 @@ impl<Message: 'static + Debug> Drop for BoundHandle<Message> {
 pub trait SupportedNetlinkProtocol: Debug {
     type Message: 'static + Send + Debug;
 
+    fn multicast_group_count() -> u32;
+
     fn socket_table(netns: Arc<NetNamespace>) -> Arc<RwSem<ProtocolSocketTable<Self::Message>>>;
 
     fn bind(
@@ -243,6 +246,10 @@ pub struct NetlinkRouteProtocol;
 impl SupportedNetlinkProtocol for NetlinkRouteProtocol {
     type Message = RouteNlMessage;
 
+    fn multicast_group_count() -> u32 {
+        33
+    }
+
     fn socket_table(netns: Arc<NetNamespace>) -> Arc<RwSem<ProtocolSocketTable<Self::Message>>> {
         netns.netlink_socket_table().route()
     }
@@ -253,6 +260,10 @@ pub struct NetlinkKobjectUeventProtocol;
 
 impl SupportedNetlinkProtocol for NetlinkKobjectUeventProtocol {
     type Message = KobjectUeventMessage;
+
+    fn multicast_group_count() -> u32 {
+        1
+    }
 
     fn socket_table(netns: Arc<NetNamespace>) -> Arc<RwSem<ProtocolSocketTable<Self::Message>>> {
         netns.netlink_socket_table().kobject_uevent()

--- a/kernel/src/net/syscall/sys_getsockopt.rs
+++ b/kernel/src/net/syscall/sys_getsockopt.rs
@@ -14,8 +14,9 @@ use alloc::vec::Vec;
 
 /// getsockopt optval 最大长度限制（一页）
 const MAX_OPTVAL_LEN: usize = MMArch::PAGE_SIZE;
+const NETLINK_LIST_MEMBERSHIPS: usize = 9;
 
-/// 计算实际输出长度：若 optval 为 null 则返回 need，否则返回 min(user_len, need)
+/// 计算实际拷贝长度：若 optval 为 null 则返回 need，否则返回 min(user_len, need)
 #[inline]
 fn calc_out_len(optval: *mut u8, user_len: usize, need: usize) -> usize {
     if optval.is_null() {
@@ -163,12 +164,12 @@ pub(super) fn do_getsockopt(
                     optval_writer.copy_to_user_protected(&bytes[..out_len], 0)?;
                 }
 
-                // 写回实际需要的长度
+                // 写回选项值的实际长度（Linux ABI），而不是截断后的拷贝长度。
                 let mut optlen_writer =
                     UserBufferWriter::new(optlen, core::mem::size_of::<u32>(), from_user)?;
                 optlen_writer
                     .buffer_protected(0)?
-                    .write_one::<u32>(0, &(out_len as u32))?;
+                    .write_one::<u32>(0, &(need as u32))?;
                 return Ok(0);
             }
             PSO::RCVBUF => {
@@ -182,12 +183,12 @@ pub(super) fn do_getsockopt(
                     optval_writer.copy_to_user_protected(&bytes[..out_len], 0)?;
                 }
 
-                // 写回实际需要的长度
+                // 写回选项值的实际长度（Linux ABI），而不是截断后的拷贝长度。
                 let mut optlen_writer =
                     UserBufferWriter::new(optlen, core::mem::size_of::<u32>(), from_user)?;
                 optlen_writer
                     .buffer_protected(0)?
-                    .write_one::<u32>(0, &(out_len as u32))?;
+                    .write_one::<u32>(0, &(need as u32))?;
                 return Ok(0);
             }
             _ => {
@@ -203,12 +204,12 @@ pub(super) fn do_getsockopt(
                     optval_writer.copy_to_user_protected(&kbuf[..out_len], 0)?;
                 }
 
-                // 写回实际需要的长度
+                // 写回选项值的实际长度（Linux ABI），而不是截断后的拷贝长度。
                 let mut optlen_writer =
                     UserBufferWriter::new(optlen, core::mem::size_of::<u32>(), from_user)?;
                 optlen_writer
                     .buffer_protected(0)?
-                    .write_one::<u32>(0, &(out_len as u32))?;
+                    .write_one::<u32>(0, &(written as u32))?;
                 return Ok(0);
             }
         }
@@ -224,6 +225,31 @@ pub(super) fn do_getsockopt(
         let _optname = TcpOption::try_from(optname as i32).map_err(|_| SystemError::ENOPROTOOPT)?;
         // TcpOption::Congestion => return Ok(0),
         // Other TCP options are delegated to the socket implementation below.
+    }
+
+    if matches!(level, PSOL::NETLINK) && optname == NETLINK_LIST_MEMBERSHIPS {
+        let mut kbuf = vec![0u8; MAX_OPTVAL_LEN];
+        let written = socket.option(level, optname, &mut kbuf)?;
+        let out_len = if optval.is_null() {
+            0
+        } else {
+            core::cmp::min(
+                (user_len / core::mem::size_of::<u32>()) * core::mem::size_of::<u32>(),
+                written,
+            )
+        };
+
+        if !optval.is_null() && out_len != 0 {
+            let mut optval_writer = UserBufferWriter::new(optval, out_len, from_user)?;
+            optval_writer.copy_to_user_protected(&kbuf[..out_len], 0)?;
+        }
+
+        let mut optlen_writer =
+            UserBufferWriter::new(optlen, core::mem::size_of::<u32>(), from_user)?;
+        optlen_writer
+            .buffer_protected(0)?
+            .write_one::<u32>(0, &(written as u32))?;
+        return Ok(0);
     }
 
     // 其它 level（如 SOL_IP/SOL_IPV6/SOL_RAW 等）交给具体 socket 实现。
@@ -245,7 +271,7 @@ pub(super) fn do_getsockopt(
             UserBufferWriter::new(optlen, core::mem::size_of::<u32>(), from_user)?;
         optlen_writer
             .buffer_protected(0)?
-            .write_one::<u32>(0, &(out_len as u32))?;
+            .write_one::<u32>(0, &(written as u32))?;
         Ok(0)
     }
 }

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -315,11 +315,10 @@ impl NetNamespace {
 
     pub fn new_empty(user_ns: Arc<UserNamespace>) -> Result<Arc<Self>, SystemError> {
         let counter = get_next_netns_counter();
-        let loopback =
-            crate::driver::net::loopback::LoopbackInterface::new_with_ifindex(
-                crate::driver::net::loopback::LoopbackDriver::default(),
-                1,
-            );
+        let loopback = crate::driver::net::loopback::LoopbackInterface::new_with_ifindex(
+            crate::driver::net::loopback::LoopbackDriver::default(),
+            1,
+        );
 
         let inner = InnerNetNamespace {
             router: Router::new(format!("netns_router_{}", counter)),

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -1,5 +1,5 @@
 use crate::driver::net::bridge::BridgeDriver;
-use crate::driver::net::loopback::{generate_loopback_iface_default, LoopbackInterface};
+use crate::driver::net::loopback::LoopbackInterface;
 use crate::init::initcall::INITCALL_SUBSYS;
 use crate::libs::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use crate::libs::rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard};
@@ -315,7 +315,11 @@ impl NetNamespace {
 
     pub fn new_empty(user_ns: Arc<UserNamespace>) -> Result<Arc<Self>, SystemError> {
         let counter = get_next_netns_counter();
-        let loopback = generate_loopback_iface_default();
+        let loopback =
+            crate::driver::net::loopback::LoopbackInterface::new_with_ifindex(
+                crate::driver::net::loopback::LoopbackDriver::default(),
+                1,
+            );
 
         let inner = InnerNetNamespace {
             router: Router::new(format!("netns_router_{}", counter)),

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/cycp1yjk0pfzbgrgxz5xjgn1qf7nxk0g-dragonos-run

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/cycp1yjk0pfzbgrgxz5xjgn1qf7nxk0g-dragonos-run

--- a/user/apps/c_unitest/netlink_test_lib.h
+++ b/user/apps/c_unitest/netlink_test_lib.h
@@ -1,0 +1,363 @@
+#ifndef NETLINK_TEST_LIB_H
+#define NETLINK_TEST_LIB_H
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define NL_TEST_BUF_SIZE 8192
+
+#define NL_TEST_ASSERT(cond, fmt, ...)                                          \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            fprintf(stderr, "ASSERT FAIL: " fmt "\n", ##__VA_ARGS__);           \
+            return 1;                                                           \
+        }                                                                       \
+    } while (0)
+
+typedef int (*nl_msg_cb)(struct nlmsghdr *nlh, void *ctx);
+
+struct nl_link_info {
+    int ifindex;
+    unsigned int flags;
+    unsigned int mtu;
+    char name[IFNAMSIZ];
+    unsigned char addr[8];
+    size_t addr_len;
+};
+
+static inline void nl_parse_rtattr(struct rtattr *tb[],
+                                   int max,
+                                   struct rtattr *rta,
+                                   int len) {
+    memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
+    while (RTA_OK(rta, len)) {
+        if (rta->rta_type <= max) {
+            tb[rta->rta_type] = rta;
+        }
+        rta = RTA_NEXT(rta, len);
+    }
+}
+
+static inline int nl_addattr_l(struct nlmsghdr *nlh,
+                               size_t maxlen,
+                               int type,
+                               const void *data,
+                               size_t alen) {
+    size_t len = RTA_LENGTH(alen);
+    size_t new_len = NLMSG_ALIGN(nlh->nlmsg_len) + RTA_ALIGN(len);
+    struct rtattr *rta;
+
+    if (new_len > maxlen) {
+        errno = ENOSPC;
+        return -1;
+    }
+
+    rta = (struct rtattr *)(((char *)nlh) + NLMSG_ALIGN(nlh->nlmsg_len));
+    rta->rta_type = type;
+    rta->rta_len = (unsigned short)len;
+    if (alen > 0 && data != NULL) {
+        memcpy(RTA_DATA(rta), data, alen);
+    }
+    nlh->nlmsg_len = (unsigned int)new_len;
+    return 0;
+}
+
+static inline int nl_open_socket(int protocol) {
+    int fd = socket(AF_NETLINK, SOCK_RAW, protocol);
+    struct sockaddr_nl addr;
+    struct timeval timeout = {
+        .tv_sec = 2,
+        .tv_usec = 0,
+    };
+
+    if (fd < 0) {
+        perror("socket(AF_NETLINK) failed");
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.nl_family = AF_NETLINK;
+    addr.nl_pid = 0;
+    addr.nl_groups = 0;
+
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind(AF_NETLINK) failed");
+        close(fd);
+        return -1;
+    }
+
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        perror("setsockopt(SO_RCVTIMEO) failed");
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+static inline int nl_send_request(int fd, const void *buf, size_t len) {
+    struct sockaddr_nl kernel_addr;
+
+    memset(&kernel_addr, 0, sizeof(kernel_addr));
+    kernel_addr.nl_family = AF_NETLINK;
+    kernel_addr.nl_pid = 0;
+    kernel_addr.nl_groups = 0;
+
+    if (sendto(fd,
+               buf,
+               len,
+               0,
+               (struct sockaddr *)&kernel_addr,
+               sizeof(kernel_addr)) < 0) {
+        perror("sendto(AF_NETLINK) failed");
+        return -1;
+    }
+
+    return 0;
+}
+
+static inline int nl_recv_ack(int fd, uint32_t seq, int expected_errno) {
+    char buf[NL_TEST_BUF_SIZE];
+    ssize_t len;
+    struct nlmsghdr *nlh;
+
+    while ((len = recv(fd, buf, sizeof(buf), 0)) > 0) {
+        ssize_t remaining = len;
+
+        for (nlh = (struct nlmsghdr *)buf; NLMSG_OK(nlh, remaining);
+             nlh = NLMSG_NEXT(nlh, remaining)) {
+            struct nlmsgerr *err;
+
+            if (nlh->nlmsg_seq != seq) {
+                continue;
+            }
+            if (nlh->nlmsg_type != NLMSG_ERROR) {
+                continue;
+            }
+
+            err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+            if (expected_errno == 0) {
+                if (err->error != 0) {
+                    int saved_errno = -err->error;
+                    errno = saved_errno;
+                    perror("unexpected netlink ack error");
+                    errno = saved_errno;
+                    return -1;
+                }
+                return 0;
+            }
+
+            if (err->error != -expected_errno) {
+                fprintf(stderr,
+                        "unexpected netlink error: got=%d expected=%d\n",
+                        -err->error,
+                        expected_errno);
+                errno = -err->error;
+                return -1;
+            }
+            return 0;
+        }
+    }
+
+    perror("recv ack failed");
+    return -1;
+}
+
+static inline int nl_recv_dump(int fd, uint32_t seq, nl_msg_cb cb, void *ctx) {
+    char buf[NL_TEST_BUF_SIZE];
+    ssize_t len;
+    struct nlmsghdr *nlh;
+
+    while ((len = recv(fd, buf, sizeof(buf), 0)) > 0) {
+        ssize_t remaining = len;
+
+        for (nlh = (struct nlmsghdr *)buf; NLMSG_OK(nlh, remaining);
+             nlh = NLMSG_NEXT(nlh, remaining)) {
+            int cb_ret;
+
+            if (nlh->nlmsg_seq != seq) {
+                continue;
+            }
+            if (nlh->nlmsg_type == NLMSG_DONE) {
+                return 0;
+            }
+            if (nlh->nlmsg_type == NLMSG_ERROR) {
+                struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+                errno = err->error == 0 ? EPROTO : -err->error;
+                perror("dump returned netlink error");
+                return -1;
+            }
+
+            cb_ret = cb(nlh, ctx);
+            if (cb_ret < 0) {
+                return -1;
+            }
+        }
+    }
+
+    perror("recv dump failed");
+    return -1;
+}
+
+static inline int nl_recv_single(int fd, uint32_t seq, nl_msg_cb cb, void *ctx) {
+    char buf[NL_TEST_BUF_SIZE];
+    ssize_t len;
+    struct nlmsghdr *nlh;
+
+    while ((len = recv(fd, buf, sizeof(buf), 0)) > 0) {
+        ssize_t remaining = len;
+
+        for (nlh = (struct nlmsghdr *)buf; NLMSG_OK(nlh, remaining);
+             nlh = NLMSG_NEXT(nlh, remaining)) {
+            int cb_ret;
+
+            if (nlh->nlmsg_seq != seq) {
+                continue;
+            }
+            if (nlh->nlmsg_type == NLMSG_ERROR) {
+                struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+                errno = err->error == 0 ? EPROTO : -err->error;
+                perror("single request returned netlink error");
+                return -1;
+            }
+            if (nlh->nlmsg_type == NLMSG_DONE) {
+                continue;
+            }
+
+            cb_ret = cb(nlh, ctx);
+            if (cb_ret < 0) {
+                return -1;
+            }
+            if (cb_ret == 0) {
+                return 0;
+            }
+        }
+    }
+
+    perror("recv single failed");
+    return -1;
+}
+
+static inline int nl_parse_link_info(struct nlmsghdr *nlh, struct nl_link_info *info) {
+    struct ifinfomsg *ifi;
+    struct rtattr *tb[IFLA_MAX + 1];
+    int attr_len;
+
+    if (nlh->nlmsg_type != RTM_NEWLINK) {
+        errno = EPROTO;
+        return -1;
+    }
+
+    ifi = (struct ifinfomsg *)NLMSG_DATA(nlh);
+    attr_len = (int)(nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*ifi)));
+    nl_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), attr_len);
+
+    if (tb[IFLA_IFNAME] == NULL || tb[IFLA_MTU] == NULL || tb[IFLA_ADDRESS] == NULL) {
+        errno = EPROTO;
+        return -1;
+    }
+
+    memset(info, 0, sizeof(*info));
+    info->ifindex = ifi->ifi_index;
+    info->flags = ifi->ifi_flags;
+    info->mtu = *(unsigned int *)RTA_DATA(tb[IFLA_MTU]);
+    strncpy(info->name, (const char *)RTA_DATA(tb[IFLA_IFNAME]), sizeof(info->name) - 1);
+    info->addr_len = RTA_PAYLOAD(tb[IFLA_ADDRESS]);
+    if (info->addr_len > sizeof(info->addr)) {
+        info->addr_len = sizeof(info->addr);
+    }
+    memcpy(info->addr, RTA_DATA(tb[IFLA_ADDRESS]), info->addr_len);
+    return 0;
+}
+
+struct nl_link_lookup_ctx {
+    struct nl_link_info *out;
+};
+
+static inline int nl_link_lookup_cb(struct nlmsghdr *nlh, void *ctx) {
+    struct nl_link_lookup_ctx *lookup = (struct nl_link_lookup_ctx *)ctx;
+    return nl_parse_link_info(nlh, lookup->out);
+}
+
+static inline int nl_get_link_by_name(int fd,
+                                      uint32_t seq,
+                                      const char *name,
+                                      struct nl_link_info *out) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+        char attrbuf[128];
+    } req;
+    struct nl_link_lookup_ctx ctx = {
+        .out = out,
+    };
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_GETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST;
+    req.nlh.nlmsg_seq = seq;
+    req.ifi.ifi_family = AF_UNSPEC;
+
+    if (nl_addattr_l(&req.nlh, sizeof(req), IFLA_IFNAME, name, strlen(name) + 1) < 0) {
+        perror("nl_addattr_l(IFLA_IFNAME) failed");
+        return -1;
+    }
+
+    if (nl_send_request(fd, &req, req.nlh.nlmsg_len) < 0) {
+        return -1;
+    }
+
+    return nl_recv_single(fd, seq, nl_link_lookup_cb, &ctx);
+}
+
+static inline int nl_get_link_by_index(int fd,
+                                       uint32_t seq,
+                                       int ifindex,
+                                       struct nl_link_info *out) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+    } req;
+    struct nl_link_lookup_ctx ctx = {
+        .out = out,
+    };
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_GETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST;
+    req.nlh.nlmsg_seq = seq;
+    req.ifi.ifi_family = AF_UNSPEC;
+    req.ifi.ifi_index = ifindex;
+
+    if (nl_send_request(fd, &req, req.nlh.nlmsg_len) < 0) {
+        return -1;
+    }
+
+    return nl_recv_single(fd, seq, nl_link_lookup_cb, &ctx);
+}
+
+static inline int nl_lookup_ifindex(int fd, const char *name, int *ifindex) {
+    struct nl_link_info info;
+
+    if (nl_get_link_by_name(fd, 100, name, &info) < 0) {
+        return -1;
+    }
+
+    *ifindex = info.ifindex;
+    return 0;
+}
+
+#endif

--- a/user/apps/c_unitest/test_netlink_sockopt.c
+++ b/user/apps/c_unitest/test_netlink_sockopt.c
@@ -1,0 +1,334 @@
+#include "netlink_test_lib.h"
+
+#include <arpa/inet.h>
+#include <sys/epoll.h>
+
+struct dump_seen_ctx {
+    int seen;
+};
+
+static int verify_empty_list_memberships_linux_abi(int fd) {
+    socklen_t optlen;
+    uint32_t groups[4];
+    unsigned char short_buf[2];
+
+    optlen = 0;
+    NL_TEST_ASSERT(getsockopt(fd,
+                              SOL_NETLINK,
+                              NETLINK_LIST_MEMBERSHIPS,
+                              NULL,
+                              &optlen) == 0,
+                   "getsockopt(NULL, LIST_MEMBERSHIPS) failed: %s", strerror(errno));
+    NL_TEST_ASSERT(optlen == 0,
+                   "unexpected LIST_MEMBERSHIPS required size=%u",
+                   (unsigned int)optlen);
+
+    memset(groups, 0xa5, sizeof(groups));
+    optlen = sizeof(groups);
+    NL_TEST_ASSERT(getsockopt(fd,
+                              SOL_NETLINK,
+                              NETLINK_LIST_MEMBERSHIPS,
+                              groups,
+                              &optlen) == 0,
+                   "LIST_MEMBERSHIPS array read failed: %s", strerror(errno));
+    NL_TEST_ASSERT(optlen == 0,
+                   "LIST_MEMBERSHIPS optlen should report required size, got=%u",
+                   (unsigned int)optlen);
+    NL_TEST_ASSERT(groups[0] == 0xa5a5a5a5u && groups[1] == 0xa5a5a5a5u,
+                   "empty LIST_MEMBERSHIPS should not modify user buffer");
+
+    memset(short_buf, 0xa5, sizeof(short_buf));
+    optlen = sizeof(short_buf);
+    NL_TEST_ASSERT(getsockopt(fd,
+                              SOL_NETLINK,
+                              NETLINK_LIST_MEMBERSHIPS,
+                              short_buf,
+                              &optlen) == 0,
+                   "LIST_MEMBERSHIPS short read failed: %s", strerror(errno));
+    NL_TEST_ASSERT(optlen == 0,
+                   "short LIST_MEMBERSHIPS should still report required size, got=%u",
+                   (unsigned int)optlen);
+    NL_TEST_ASSERT(short_buf[0] == 0xa5 && short_buf[1] == 0xa5,
+                   "empty LIST_MEMBERSHIPS short buffer should stay untouched");
+    return 0;
+}
+
+static int verify_list_memberships_linux_abi(int fd,
+                                             uint32_t expected_mask_low,
+                                             uint32_t expected_mask_high,
+                                             socklen_t expected_len) {
+    socklen_t optlen;
+    uint32_t groups[4];
+    uint32_t one_word = 0xaaaaaaaa;
+    unsigned char short_buf[2];
+
+    optlen = 0;
+    NL_TEST_ASSERT(getsockopt(fd,
+                              SOL_NETLINK,
+                              NETLINK_LIST_MEMBERSHIPS,
+                              NULL,
+                              &optlen) == 0,
+                   "getsockopt(NULL, LIST_MEMBERSHIPS) failed: %s", strerror(errno));
+    NL_TEST_ASSERT(optlen == expected_len,
+                   "unexpected LIST_MEMBERSHIPS required size=%u expected=%u",
+                   (unsigned int)optlen,
+                   (unsigned int)expected_len);
+
+    memset(groups, 0xa5, sizeof(groups));
+    optlen = sizeof(groups);
+    NL_TEST_ASSERT(getsockopt(fd,
+                              SOL_NETLINK,
+                              NETLINK_LIST_MEMBERSHIPS,
+                              groups,
+                              &optlen) == 0,
+                   "LIST_MEMBERSHIPS array read failed: %s", strerror(errno));
+    NL_TEST_ASSERT(optlen == expected_len,
+                   "LIST_MEMBERSHIPS optlen should report required size, got=%u",
+                   (unsigned int)optlen);
+    NL_TEST_ASSERT(groups[0] == expected_mask_low,
+                   "unexpected groups[0]=0x%x expected=0x%x",
+                   groups[0],
+                   expected_mask_low);
+    if (expected_len >= 2 * sizeof(uint32_t)) {
+        NL_TEST_ASSERT(groups[1] == expected_mask_high,
+                       "unexpected groups[1]=0x%x expected=0x%x",
+                       groups[1],
+                       expected_mask_high);
+    }
+
+    one_word = 0xaaaaaaaa;
+    optlen = sizeof(one_word);
+    NL_TEST_ASSERT(getsockopt(fd,
+                              SOL_NETLINK,
+                              NETLINK_LIST_MEMBERSHIPS,
+                              &one_word,
+                              &optlen) == 0,
+                   "LIST_MEMBERSHIPS single-word read failed: %s", strerror(errno));
+    NL_TEST_ASSERT(optlen == expected_len,
+                   "single-word LIST_MEMBERSHIPS should still report required size, got=%u",
+                   (unsigned int)optlen);
+    NL_TEST_ASSERT(one_word == expected_mask_low,
+                   "single-word LIST_MEMBERSHIPS mismatch: got=0x%x expected=0x%x",
+                   one_word,
+                   expected_mask_low);
+
+    memset(short_buf, 0xa5, sizeof(short_buf));
+    optlen = sizeof(short_buf);
+    NL_TEST_ASSERT(getsockopt(fd,
+                              SOL_NETLINK,
+                              NETLINK_LIST_MEMBERSHIPS,
+                              short_buf,
+                              &optlen) == 0,
+                   "LIST_MEMBERSHIPS short read failed: %s", strerror(errno));
+    NL_TEST_ASSERT(optlen == expected_len,
+                   "short LIST_MEMBERSHIPS should still report required size, got=%u",
+                   (unsigned int)optlen);
+    NL_TEST_ASSERT(short_buf[0] == 0xa5 && short_buf[1] == 0xa5,
+                   "short LIST_MEMBERSHIPS should not copy partial u32 values");
+    return 0;
+}
+
+static int setlink_mtu(int fd, uint32_t seq, int ifindex, unsigned int mtu) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+        char attrbuf[128];
+    } req;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_SETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.ifi.ifi_family = AF_UNSPEC;
+    req.ifi.ifi_index = ifindex;
+
+    if (nl_addattr_l(&req.nlh, sizeof(req), IFLA_MTU, &mtu, sizeof(mtu)) < 0) {
+        return -errno;
+    }
+    if (nl_send_request(fd, &req, req.nlh.nlmsg_len) < 0) {
+        return -errno;
+    }
+    if (nl_recv_ack(fd, seq, 0) < 0) {
+        return -errno;
+    }
+    return 0;
+}
+
+static int dump_seen_cb(struct nlmsghdr *nlh, void *arg) {
+    struct nl_link_info info;
+    struct dump_seen_ctx *state = (struct dump_seen_ctx *)arg;
+
+    if (nl_parse_link_info(nlh, &info) < 0) {
+        return -1;
+    }
+    state->seen = 1;
+    return 0;
+}
+
+static int verify_epoll_for_dump(int fd) {
+    int epfd;
+    struct epoll_event ev;
+    struct epoll_event out;
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+    } req;
+    struct dump_seen_ctx ctx = {0};
+
+    epfd = epoll_create1(0);
+    NL_TEST_ASSERT(epfd >= 0, "epoll_create1 failed: %s", strerror(errno));
+
+    memset(&ev, 0, sizeof(ev));
+    ev.events = EPOLLIN;
+    ev.data.fd = fd;
+    NL_TEST_ASSERT(epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) == 0,
+                   "epoll_ctl add route fd failed: %s", strerror(errno));
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_GETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq = 1;
+    req.ifi.ifi_family = AF_UNSPEC;
+
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_GETLINK dump send failed");
+    NL_TEST_ASSERT(epoll_wait(epfd, &out, 1, 1000) == 1, "epoll_wait dump timeout");
+    NL_TEST_ASSERT((out.events & EPOLLIN) != 0, "epoll dump event missing EPOLLIN");
+    NL_TEST_ASSERT(nl_recv_dump(fd, 1, dump_seen_cb, &ctx) == 0,
+                   "recv dump after epoll failed");
+    NL_TEST_ASSERT(ctx.seen, "no RTM_NEWLINK message observed after epoll wake");
+
+    close(epfd);
+    return 0;
+}
+
+static int verify_memberships_and_notify(int control_fd, int ifindex, unsigned int original_mtu) {
+    int notify_fd;
+    int epfd;
+    unsigned int group_id = RTNLGRP_LINK;
+    struct epoll_event ev;
+    struct epoll_event out;
+    char buf[NL_TEST_BUF_SIZE];
+    ssize_t len;
+    struct nlmsghdr *nlh;
+    int ret;
+    int saw_notify = 0;
+
+    notify_fd = nl_open_socket(NETLINK_ROUTE);
+    NL_TEST_ASSERT(notify_fd >= 0, "open notify NETLINK_ROUTE failed");
+    NL_TEST_ASSERT(verify_empty_list_memberships_linux_abi(notify_fd) == 0,
+                   "empty LIST_MEMBERSHIPS ABI check failed");
+
+    NL_TEST_ASSERT(setsockopt(notify_fd,
+                              SOL_NETLINK,
+                              NETLINK_ADD_MEMBERSHIP,
+                              &group_id,
+                              sizeof(group_id)) == 0,
+                   "NETLINK_ADD_MEMBERSHIP failed: %s", strerror(errno));
+    NL_TEST_ASSERT(verify_list_memberships_linux_abi(
+                       notify_fd, 1u << (RTNLGRP_LINK - 1), 0, 2 * sizeof(uint32_t))
+                       == 0,
+                   "post-add LIST_MEMBERSHIPS ABI check failed");
+
+    epfd = epoll_create1(0);
+    NL_TEST_ASSERT(epfd >= 0, "epoll_create1 failed: %s", strerror(errno));
+    memset(&ev, 0, sizeof(ev));
+    ev.events = EPOLLIN;
+    ev.data.fd = notify_fd;
+    NL_TEST_ASSERT(epoll_ctl(epfd, EPOLL_CTL_ADD, notify_fd, &ev) == 0,
+                   "epoll_ctl add notify fd failed: %s", strerror(errno));
+
+    ret = setlink_mtu(control_fd, 2, ifindex, original_mtu + 64);
+    if (ret < 0) {
+        if (-ret == EPERM || -ret == EACCES) {
+            fprintf(stderr,
+                    "SKIP: RTM_SETLINK requires CAP_NET_ADMIN on this Linux environment\n");
+            close(epfd);
+            close(notify_fd);
+            return 0;
+        }
+        NL_TEST_ASSERT(0, "trigger RTM_NEWLINK notify failed: %s", strerror(-ret));
+    }
+    NL_TEST_ASSERT(epoll_wait(epfd, &out, 1, 1000) == 1, "epoll_wait notify timeout");
+    NL_TEST_ASSERT((out.events & EPOLLIN) != 0, "notify event missing EPOLLIN");
+
+    len = recv(notify_fd, buf, sizeof(buf), 0);
+    NL_TEST_ASSERT(len > 0, "recv notify failed: %s", strerror(errno));
+    for (nlh = (struct nlmsghdr *)buf; NLMSG_OK(nlh, len); nlh = NLMSG_NEXT(nlh, len)) {
+        struct nl_link_info info;
+        if (nlh->nlmsg_type != RTM_NEWLINK) {
+            continue;
+        }
+        if (nl_parse_link_info(nlh, &info) < 0) {
+            perror("nl_parse_link_info notify failed");
+            return 1;
+        }
+        if (info.ifindex == ifindex && info.mtu == original_mtu + 64) {
+            saw_notify = 1;
+            break;
+        }
+    }
+    NL_TEST_ASSERT(saw_notify, "did not observe expected RTM_NEWLINK notify");
+
+    NL_TEST_ASSERT(setlink_mtu(control_fd, 3, ifindex, original_mtu) == 0,
+                   "restore mtu after notify test failed");
+
+    NL_TEST_ASSERT(setsockopt(notify_fd,
+                              SOL_NETLINK,
+                              NETLINK_DROP_MEMBERSHIP,
+                              &group_id,
+                              sizeof(group_id)) == 0,
+                   "NETLINK_DROP_MEMBERSHIP failed: %s", strerror(errno));
+    NL_TEST_ASSERT(verify_list_memberships_linux_abi(notify_fd, 0, 0, 2 * sizeof(uint32_t))
+                       == 0,
+                   "post-drop LIST_MEMBERSHIPS ABI check failed");
+
+    close(epfd);
+    close(notify_fd);
+    return 0;
+}
+
+static int verify_bind_groups_linux_abi(void) {
+    int fd;
+    struct sockaddr_nl addr;
+
+    fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    NL_TEST_ASSERT(fd >= 0, "socket(AF_NETLINK, NETLINK_ROUTE) failed: %s", strerror(errno));
+
+    memset(&addr, 0, sizeof(addr));
+    addr.nl_family = AF_NETLINK;
+    addr.nl_groups = RTMGRP_LINK;
+    NL_TEST_ASSERT(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0,
+                   "bind(nl_groups=RTMGRP_LINK) failed: %s", strerror(errno));
+    NL_TEST_ASSERT(verify_list_memberships_linux_abi(fd, RTMGRP_LINK, 0, 2 * sizeof(uint32_t))
+                       == 0,
+                   "bind-path LIST_MEMBERSHIPS ABI check failed");
+
+    close(fd);
+    return 0;
+}
+
+int main(void) {
+    int control_fd = -1;
+    struct nl_link_info info;
+
+    control_fd = nl_open_socket(NETLINK_ROUTE);
+    NL_TEST_ASSERT(control_fd >= 0, "open control NETLINK_ROUTE failed");
+    if (nl_get_link_by_name(control_fd, 10, "lo", &info) < 0) {
+        NL_TEST_ASSERT(nl_get_link_by_name(control_fd, 11, "veth_a", &info) == 0,
+                       "GETLINK lo/veth_a failed");
+    }
+
+    NL_TEST_ASSERT(verify_epoll_for_dump(control_fd) == 0,
+                   "epoll dump readiness test failed");
+    NL_TEST_ASSERT(verify_bind_groups_linux_abi() == 0,
+                   "bind-path LIST_MEMBERSHIPS test failed");
+    NL_TEST_ASSERT(verify_memberships_and_notify(control_fd, info.ifindex, info.mtu) == 0,
+                   "membership/notify test failed");
+
+    close(control_fd);
+    printf("netlink sockopt and epoll tests passed\n");
+    return 0;
+}

--- a/user/apps/c_unitest/test_rtnetlink_addr.c
+++ b/user/apps/c_unitest/test_rtnetlink_addr.c
@@ -1,0 +1,141 @@
+#include "netlink_test_lib.h"
+
+#include <arpa/inet.h>
+
+struct addr_dump_ctx {
+    int target_ifindex;
+    int seen_primary;
+    int seen_extra;
+};
+
+static int parse_addr_msg(struct nlmsghdr *nlh,
+                          struct ifaddrmsg **ifa_out,
+                          struct rtattr *tb[]) {
+    struct ifaddrmsg *ifa;
+    int attr_len;
+
+    NL_TEST_ASSERT(nlh->nlmsg_type == RTM_NEWADDR, "unexpected nlmsg_type=%u", nlh->nlmsg_type);
+    ifa = (struct ifaddrmsg *)NLMSG_DATA(nlh);
+    attr_len = (int)(nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*ifa)));
+    nl_parse_rtattr(tb, IFA_MAX, IFA_RTA(ifa), attr_len);
+    *ifa_out = ifa;
+    return 0;
+}
+
+static int addr_dump_cb(struct nlmsghdr *nlh, void *ctx) {
+    struct addr_dump_ctx *dump = (struct addr_dump_ctx *)ctx;
+    struct ifaddrmsg *ifa;
+    struct rtattr *tb[IFA_MAX + 1];
+    struct in_addr addr;
+    char text[INET_ADDRSTRLEN];
+
+    if (parse_addr_msg(nlh, &ifa, tb) != 0) {
+        return -1;
+    }
+
+    NL_TEST_ASSERT(ifa->ifa_family == AF_INET, "unexpected family=%u", ifa->ifa_family);
+    NL_TEST_ASSERT((int)ifa->ifa_index == dump->target_ifindex,
+                   "unexpected ifindex=%u expected=%d",
+                   ifa->ifa_index,
+                   dump->target_ifindex);
+    NL_TEST_ASSERT(tb[IFA_LOCAL] != NULL, "IFA_LOCAL missing");
+
+    memcpy(&addr, RTA_DATA(tb[IFA_LOCAL]), sizeof(addr));
+    inet_ntop(AF_INET, &addr, text, sizeof(text));
+    if (strcmp(text, "200.0.0.1") == 0) {
+        dump->seen_primary = 1;
+    } else if (strcmp(text, "198.18.10.1") == 0) {
+        dump->seen_extra = 1;
+    }
+
+    return 0;
+}
+
+static int send_getaddr_dump(int fd, uint32_t seq, int ifindex, struct addr_dump_ctx *ctx) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifaddrmsg ifa;
+    } req;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifa));
+    req.nlh.nlmsg_type = RTM_GETADDR;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq = seq;
+    req.ifa.ifa_family = AF_INET;
+    req.ifa.ifa_index = ifindex;
+
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_GETADDR dump send failed");
+    NL_TEST_ASSERT(nl_recv_dump(fd, seq, addr_dump_cb, ctx) == 0,
+                   "RTM_GETADDR dump recv failed");
+    return 0;
+}
+
+static int send_addr_update(int fd, uint32_t seq, int msg_type, int ifindex, const char *ip) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifaddrmsg ifa;
+        char attrbuf[128];
+    } req;
+    struct in_addr addr;
+
+    NL_TEST_ASSERT(inet_pton(AF_INET, ip, &addr) == 1, "inet_pton(%s) failed", ip);
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifa));
+    req.nlh.nlmsg_type = msg_type;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.ifa.ifa_family = AF_INET;
+    req.ifa.ifa_prefixlen = 24;
+    req.ifa.ifa_index = ifindex;
+
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), IFA_LOCAL, &addr, sizeof(addr)) == 0,
+                   "add IFA_LOCAL failed");
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), IFA_ADDRESS, &addr, sizeof(addr)) == 0,
+                   "add IFA_ADDRESS failed");
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_NEWADDR/DELADDR send failed");
+    NL_TEST_ASSERT(nl_recv_ack(fd, seq, 0) == 0, "addr update ack failed");
+    return 0;
+}
+
+int main(void) {
+    int fd = -1;
+    int ifindex = -1;
+    struct addr_dump_ctx ctx;
+
+    fd = nl_open_socket(NETLINK_ROUTE);
+    NL_TEST_ASSERT(fd >= 0, "open NETLINK_ROUTE failed");
+    NL_TEST_ASSERT(nl_lookup_ifindex(fd, "veth_a", &ifindex) == 0,
+                   "lookup veth_a ifindex failed");
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getaddr_dump(fd, 1, ifindex, &ctx) == 0,
+                   "initial RTM_GETADDR dump failed");
+    NL_TEST_ASSERT(ctx.seen_primary, "200.0.0.1 missing from filtered GETADDR");
+
+    NL_TEST_ASSERT(send_addr_update(fd, 2, RTM_NEWADDR, ifindex, "198.18.10.1") == 0,
+                   "RTM_NEWADDR failed");
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getaddr_dump(fd, 3, ifindex, &ctx) == 0,
+                   "post-add RTM_GETADDR dump failed");
+    NL_TEST_ASSERT(ctx.seen_extra, "198.18.10.1 missing after RTM_NEWADDR");
+
+    NL_TEST_ASSERT(send_addr_update(fd, 4, RTM_DELADDR, ifindex, "198.18.10.1") == 0,
+                   "RTM_DELADDR failed");
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getaddr_dump(fd, 5, ifindex, &ctx) == 0,
+                   "post-del RTM_GETADDR dump failed");
+    NL_TEST_ASSERT(!ctx.seen_extra, "198.18.10.1 still present after RTM_DELADDR");
+
+    close(fd);
+    printf("rtnetlink addr tests passed\n");
+    return 0;
+}

--- a/user/apps/c_unitest/test_rtnetlink_link.c
+++ b/user/apps/c_unitest/test_rtnetlink_link.c
@@ -1,0 +1,183 @@
+#include "netlink_test_lib.h"
+
+#include <net/if.h>
+
+struct link_dump_ctx {
+    int seen_veth_a;
+    int seen_veth_b;
+    int count;
+};
+
+static int link_dump_cb(struct nlmsghdr *nlh, void *ctx) {
+    struct link_dump_ctx *dump = (struct link_dump_ctx *)ctx;
+    struct nl_link_info info;
+
+    if (nl_parse_link_info(nlh, &info) < 0) {
+        perror("nl_parse_link_info failed");
+        return -1;
+    }
+
+    NL_TEST_ASSERT(info.name[0] != '\0', "link name is empty");
+    NL_TEST_ASSERT(info.addr_len == 6, "link %s addr len=%zu", info.name, info.addr_len);
+    NL_TEST_ASSERT(info.mtu > 0, "link %s mtu=%u", info.name, info.mtu);
+
+    if (strcmp(info.name, "veth_a") == 0) {
+        dump->seen_veth_a = 1;
+    } else if (strcmp(info.name, "veth_b") == 0) {
+        dump->seen_veth_b = 1;
+    }
+    dump->count++;
+    return 0;
+}
+
+static int test_getlink_dump(int fd) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+    } req;
+    struct link_dump_ctx ctx;
+
+    memset(&req, 0, sizeof(req));
+    memset(&ctx, 0, sizeof(ctx));
+
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_GETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq = 1;
+    req.ifi.ifi_family = AF_UNSPEC;
+
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_GETLINK dump send failed");
+    NL_TEST_ASSERT(nl_recv_dump(fd, 1, link_dump_cb, &ctx) == 0,
+                   "RTM_GETLINK dump recv failed");
+    NL_TEST_ASSERT(ctx.count >= 4, "unexpected link count=%d", ctx.count);
+    NL_TEST_ASSERT(ctx.seen_veth_a, "veth_a missing from RTM_GETLINK dump");
+    NL_TEST_ASSERT(ctx.seen_veth_b, "veth_b missing from RTM_GETLINK dump");
+    return 0;
+}
+
+static int setlink_name(int fd, uint32_t seq, int ifindex, const char *name, int expect_errno) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+        char attrbuf[128];
+    } req;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_SETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.ifi.ifi_family = AF_UNSPEC;
+    req.ifi.ifi_index = ifindex;
+
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), IFLA_IFNAME, name, strlen(name) + 1) == 0,
+                   "add IFLA_IFNAME failed");
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_SETLINK(name) send failed");
+    NL_TEST_ASSERT(nl_recv_ack(fd, seq, expect_errno) == 0,
+                   "RTM_SETLINK(name) ack mismatch");
+    return 0;
+}
+
+static int setlink_mtu(int fd, uint32_t seq, int ifindex, unsigned int mtu) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+        char attrbuf[128];
+    } req;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_SETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.ifi.ifi_family = AF_UNSPEC;
+    req.ifi.ifi_index = ifindex;
+
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), IFLA_MTU, &mtu, sizeof(mtu)) == 0,
+                   "add IFLA_MTU failed");
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_SETLINK(mtu) send failed");
+    NL_TEST_ASSERT(nl_recv_ack(fd, seq, 0) == 0, "RTM_SETLINK(mtu) ack failed");
+    return 0;
+}
+
+static int setlink_up(int fd, uint32_t seq, int ifindex, int up) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ifinfomsg ifi;
+    } req;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type = RTM_SETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.ifi.ifi_family = AF_UNSPEC;
+    req.ifi.ifi_index = ifindex;
+    req.ifi.ifi_change = IFF_UP;
+    req.ifi.ifi_flags = up ? IFF_UP : 0;
+
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_SETLINK(flags) send failed");
+    NL_TEST_ASSERT(nl_recv_ack(fd, seq, 0) == 0, "RTM_SETLINK(flags) ack failed");
+    return 0;
+}
+
+int main(void) {
+    int fd = -1;
+    int ifindex = -1;
+    struct nl_link_info by_name;
+    struct nl_link_info by_index;
+    unsigned int original_mtu;
+
+    fd = nl_open_socket(NETLINK_ROUTE);
+    NL_TEST_ASSERT(fd >= 0, "open NETLINK_ROUTE failed");
+
+    NL_TEST_ASSERT(test_getlink_dump(fd) == 0, "test_getlink_dump failed");
+
+    NL_TEST_ASSERT(nl_get_link_by_name(fd, 2, "veth_a", &by_name) == 0,
+                   "GETLINK by name veth_a failed");
+    ifindex = by_name.ifindex;
+    original_mtu = by_name.mtu;
+
+    NL_TEST_ASSERT(nl_get_link_by_index(fd, 3, ifindex, &by_index) == 0,
+                   "GETLINK by index failed");
+    NL_TEST_ASSERT(strcmp(by_index.name, "veth_a") == 0,
+                   "GETLINK by index returned %s", by_index.name);
+
+    NL_TEST_ASSERT(setlink_name(fd, 4, ifindex, "veth_b", EEXIST) == 0,
+                   "duplicate rename check failed");
+
+    NL_TEST_ASSERT(setlink_name(fd, 5, ifindex, "veth_a_rt", 0) == 0,
+                   "rename to veth_a_rt failed");
+    NL_TEST_ASSERT(nl_get_link_by_name(fd, 6, "veth_a_rt", &by_name) == 0,
+                   "GETLINK renamed iface failed");
+    NL_TEST_ASSERT(by_name.ifindex == ifindex,
+                   "ifindex changed after rename: %d -> %d", ifindex, by_name.ifindex);
+    NL_TEST_ASSERT(setlink_name(fd, 7, ifindex, "veth_a", 0) == 0,
+                   "rename back to veth_a failed");
+
+    NL_TEST_ASSERT(setlink_mtu(fd, 8, ifindex, original_mtu + 128) == 0,
+                   "set mtu failed");
+    NL_TEST_ASSERT(nl_get_link_by_index(fd, 9, ifindex, &by_index) == 0,
+                   "GETLINK after mtu change failed");
+    NL_TEST_ASSERT(by_index.mtu == original_mtu + 128,
+                   "mtu mismatch after update: %u", by_index.mtu);
+    NL_TEST_ASSERT(setlink_mtu(fd, 10, ifindex, original_mtu) == 0,
+                   "restore mtu failed");
+
+    NL_TEST_ASSERT(setlink_up(fd, 11, ifindex, 0) == 0, "set link down failed");
+    NL_TEST_ASSERT(nl_get_link_by_index(fd, 12, ifindex, &by_index) == 0,
+                   "GETLINK after down failed");
+    NL_TEST_ASSERT((by_index.flags & IFF_UP) == 0, "IFF_UP still set after down");
+    NL_TEST_ASSERT(setlink_up(fd, 13, ifindex, 1) == 0, "set link up failed");
+    NL_TEST_ASSERT(nl_get_link_by_index(fd, 14, ifindex, &by_index) == 0,
+                   "GETLINK after up failed");
+    NL_TEST_ASSERT((by_index.flags & IFF_UP) != 0, "IFF_UP missing after up");
+
+    close(fd);
+    printf("rtnetlink link tests passed\n");
+    return 0;
+}

--- a/user/apps/c_unitest/test_rtnetlink_neigh.c
+++ b/user/apps/c_unitest/test_rtnetlink_neigh.c
@@ -1,0 +1,128 @@
+#include "netlink_test_lib.h"
+
+#include <arpa/inet.h>
+
+#ifndef NDA_RTA
+#define NDA_RTA(r)                                                              \
+    ((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ndmsg))))
+#endif
+
+struct neigh_dump_ctx {
+    int target_ifindex;
+    int seen_entry;
+};
+
+static int neigh_dump_cb(struct nlmsghdr *nlh, void *ctx) {
+    struct neigh_dump_ctx *dump = (struct neigh_dump_ctx *)ctx;
+    struct ndmsg *ndm;
+    struct rtattr *tb[NDA_MAX + 1];
+    int attr_len;
+    struct in_addr dst;
+    char dst_text[INET_ADDRSTRLEN];
+
+    NL_TEST_ASSERT(nlh->nlmsg_type == RTM_NEWNEIGH, "unexpected nlmsg_type=%u", nlh->nlmsg_type);
+    ndm = (struct ndmsg *)NLMSG_DATA(nlh);
+    NL_TEST_ASSERT(ndm->ndm_family == AF_INET, "unexpected neigh family=%u", ndm->ndm_family);
+    NL_TEST_ASSERT(ndm->ndm_ifindex == dump->target_ifindex,
+                   "unexpected neigh ifindex=%d expected=%d",
+                   ndm->ndm_ifindex,
+                   dump->target_ifindex);
+
+    attr_len = (int)(nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*ndm)));
+    nl_parse_rtattr(tb, NDA_MAX, NDA_RTA(ndm), attr_len);
+    NL_TEST_ASSERT(tb[NDA_DST] != NULL, "NDA_DST missing");
+
+    memcpy(&dst, RTA_DATA(tb[NDA_DST]), sizeof(dst));
+    inet_ntop(AF_INET, &dst, dst_text, sizeof(dst_text));
+    if (strcmp(dst_text, "198.18.0.254") == 0) {
+        NL_TEST_ASSERT(tb[NDA_LLADDR] != NULL, "NDA_LLADDR missing");
+        NL_TEST_ASSERT(RTA_PAYLOAD(tb[NDA_LLADDR]) == 6,
+                       "unexpected lladdr len=%lu",
+                       (unsigned long)RTA_PAYLOAD(tb[NDA_LLADDR]));
+        dump->seen_entry = 1;
+    }
+
+    return 0;
+}
+
+static int send_getneigh_dump(int fd, uint32_t seq, int ifindex, struct neigh_dump_ctx *ctx) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ndmsg ndm;
+    } req;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ndm));
+    req.nlh.nlmsg_type = RTM_GETNEIGH;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq = seq;
+    req.ndm.ndm_family = AF_INET;
+    req.ndm.ndm_ifindex = ifindex;
+
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_GETNEIGH dump send failed");
+    NL_TEST_ASSERT(nl_recv_dump(fd, seq, neigh_dump_cb, ctx) == 0,
+                   "RTM_GETNEIGH dump recv failed");
+    return 0;
+}
+
+static int send_neigh_update(int fd, uint32_t seq, int msg_type, int ifindex) {
+    struct {
+        struct nlmsghdr nlh;
+        struct ndmsg ndm;
+        char attrbuf[128];
+    } req;
+    struct in_addr dst;
+    unsigned char lladdr[6] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x44};
+
+    NL_TEST_ASSERT(inet_pton(AF_INET, "198.18.0.254", &dst) == 1, "inet_pton(dst) failed");
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.ndm));
+    req.nlh.nlmsg_type = msg_type;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.ndm.ndm_family = AF_INET;
+    req.ndm.ndm_ifindex = ifindex;
+    req.ndm.ndm_state = NUD_PERMANENT;
+
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), NDA_DST, &dst, sizeof(dst)) == 0,
+                   "add NDA_DST failed");
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), NDA_LLADDR, lladdr, sizeof(lladdr)) == 0,
+                   "add NDA_LLADDR failed");
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_NEWNEIGH/DELNEIGH send failed");
+    NL_TEST_ASSERT(nl_recv_ack(fd, seq, 0) == 0, "neigh update ack failed");
+    return 0;
+}
+
+int main(void) {
+    int fd = -1;
+    int ifindex = -1;
+    struct neigh_dump_ctx ctx;
+
+    fd = nl_open_socket(NETLINK_ROUTE);
+    NL_TEST_ASSERT(fd >= 0, "open NETLINK_ROUTE failed");
+    NL_TEST_ASSERT(nl_lookup_ifindex(fd, "veth_a", &ifindex) == 0,
+                   "lookup veth_a ifindex failed");
+
+    NL_TEST_ASSERT(send_neigh_update(fd, 1, RTM_NEWNEIGH, ifindex) == 0,
+                   "RTM_NEWNEIGH failed");
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getneigh_dump(fd, 2, ifindex, &ctx) == 0,
+                   "post-add RTM_GETNEIGH failed");
+    NL_TEST_ASSERT(ctx.seen_entry, "neigh entry missing after RTM_NEWNEIGH");
+
+    NL_TEST_ASSERT(send_neigh_update(fd, 3, RTM_DELNEIGH, ifindex) == 0,
+                   "RTM_DELNEIGH failed");
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getneigh_dump(fd, 4, ifindex, &ctx) == 0,
+                   "post-del RTM_GETNEIGH failed");
+    NL_TEST_ASSERT(!ctx.seen_entry, "neigh entry still present after RTM_DELNEIGH");
+
+    close(fd);
+    printf("rtnetlink neigh tests passed\n");
+    return 0;
+}

--- a/user/apps/c_unitest/test_rtnetlink_route.c
+++ b/user/apps/c_unitest/test_rtnetlink_route.c
@@ -1,0 +1,185 @@
+#include "netlink_test_lib.h"
+
+#include <arpa/inet.h>
+
+struct route_dump_ctx {
+    int target_ifindex;
+    int seen_connected;
+    int seen_static;
+};
+
+static int route_dump_cb(struct nlmsghdr *nlh, void *ctx) {
+    struct route_dump_ctx *dump = (struct route_dump_ctx *)ctx;
+    struct rtmsg *rtm;
+    struct rtattr *tb[RTA_MAX + 1];
+    int attr_len;
+    uint32_t oif = 0;
+    uint32_t priority = 0;
+    struct in_addr dst = {0};
+    struct in_addr gateway = {0};
+    char dst_text[INET_ADDRSTRLEN];
+    char gw_text[INET_ADDRSTRLEN];
+
+    NL_TEST_ASSERT(nlh->nlmsg_type == RTM_NEWROUTE, "unexpected nlmsg_type=%u", nlh->nlmsg_type);
+    rtm = (struct rtmsg *)NLMSG_DATA(nlh);
+    NL_TEST_ASSERT(rtm->rtm_family == AF_INET, "unexpected route family=%u", rtm->rtm_family);
+
+    attr_len = (int)(nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*rtm)));
+    nl_parse_rtattr(tb, RTA_MAX, RTM_RTA(rtm), attr_len);
+    NL_TEST_ASSERT(tb[RTA_DST] != NULL, "RTA_DST missing");
+    NL_TEST_ASSERT(tb[RTA_OIF] != NULL, "RTA_OIF missing");
+
+    memcpy(&dst, RTA_DATA(tb[RTA_DST]), sizeof(dst));
+    memcpy(&oif, RTA_DATA(tb[RTA_OIF]), sizeof(oif));
+    inet_ntop(AF_INET, &dst, dst_text, sizeof(dst_text));
+    if (tb[RTA_GATEWAY] != NULL) {
+        memcpy(&gateway, RTA_DATA(tb[RTA_GATEWAY]), sizeof(gateway));
+        inet_ntop(AF_INET, &gateway, gw_text, sizeof(gw_text));
+    } else {
+        gw_text[0] = '\0';
+    }
+    if (tb[RTA_PRIORITY] != NULL) {
+        memcpy(&priority, RTA_DATA(tb[RTA_PRIORITY]), sizeof(priority));
+    }
+
+    if ((int)oif == dump->target_ifindex &&
+        strcmp(dst_text, "200.0.0.0") == 0 &&
+        rtm->rtm_dst_len == 24) {
+        dump->seen_connected = 1;
+    }
+
+    if ((int)oif == dump->target_ifindex &&
+        strcmp(dst_text, "198.18.0.0") == 0 &&
+        rtm->rtm_dst_len == 16 &&
+        strcmp(gw_text, "200.0.0.2") == 0 &&
+        priority == 123) {
+        dump->seen_static = 1;
+    }
+
+    return 0;
+}
+
+static int send_getroute_dump(int fd, uint32_t seq, struct route_dump_ctx *ctx) {
+    struct {
+        struct nlmsghdr nlh;
+        struct rtmsg rtm;
+    } req;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.rtm));
+    req.nlh.nlmsg_type = RTM_GETROUTE;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq = seq;
+    req.rtm.rtm_family = AF_INET;
+
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_GETROUTE dump send failed");
+    NL_TEST_ASSERT(nl_recv_dump(fd, seq, route_dump_cb, ctx) == 0,
+                   "RTM_GETROUTE dump recv failed");
+    return 0;
+}
+
+static int send_route_del_no_gateway(int fd, uint32_t seq, int ifindex) {
+    struct {
+        struct nlmsghdr nlh;
+        struct rtmsg rtm;
+        char attrbuf[128];
+    } req;
+    struct in_addr dst;
+    uint32_t oif = (uint32_t)ifindex;
+
+    NL_TEST_ASSERT(inet_pton(AF_INET, "198.18.0.0", &dst) == 1, "inet_pton(dst) failed");
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.rtm));
+    req.nlh.nlmsg_type = RTM_DELROUTE;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.rtm.rtm_family = AF_INET;
+    req.rtm.rtm_dst_len = 16;
+    req.rtm.rtm_table = RT_TABLE_MAIN;
+
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), RTA_DST, &dst, sizeof(dst)) == 0,
+                   "add RTA_DST failed");
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), RTA_OIF, &oif, sizeof(oif)) == 0,
+                   "add RTA_OIF failed");
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_DELROUTE send failed");
+    NL_TEST_ASSERT(nl_recv_ack(fd, seq, 0) == 0, "RTM_DELROUTE ack failed");
+    return 0;
+}
+
+static int send_route_update(int fd, uint32_t seq, int msg_type, int ifindex) {
+    struct {
+        struct nlmsghdr nlh;
+        struct rtmsg rtm;
+        char attrbuf[128];
+    } req;
+    struct in_addr dst;
+    struct in_addr gateway;
+    uint32_t oif = (uint32_t)ifindex;
+    uint32_t priority = 123;
+
+    NL_TEST_ASSERT(inet_pton(AF_INET, "198.18.0.0", &dst) == 1, "inet_pton(dst) failed");
+    NL_TEST_ASSERT(inet_pton(AF_INET, "200.0.0.2", &gateway) == 1, "inet_pton(gateway) failed");
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.rtm));
+    req.nlh.nlmsg_type = msg_type;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq = seq;
+    req.rtm.rtm_family = AF_INET;
+    req.rtm.rtm_dst_len = 16;
+    req.rtm.rtm_table = RT_TABLE_MAIN;
+    req.rtm.rtm_protocol = RTPROT_BOOT;
+    req.rtm.rtm_scope = RT_SCOPE_UNIVERSE;
+    req.rtm.rtm_type = RTN_UNICAST;
+
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), RTA_DST, &dst, sizeof(dst)) == 0,
+                   "add RTA_DST failed");
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), RTA_GATEWAY, &gateway, sizeof(gateway)) == 0,
+                   "add RTA_GATEWAY failed");
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), RTA_OIF, &oif, sizeof(oif)) == 0,
+                   "add RTA_OIF failed");
+    NL_TEST_ASSERT(nl_addattr_l(&req.nlh, sizeof(req), RTA_PRIORITY, &priority, sizeof(priority)) == 0,
+                   "add RTA_PRIORITY failed");
+    NL_TEST_ASSERT(nl_send_request(fd, &req, req.nlh.nlmsg_len) == 0,
+                   "RTM_NEWROUTE/DELROUTE send failed");
+    NL_TEST_ASSERT(nl_recv_ack(fd, seq, 0) == 0, "route update ack failed");
+    return 0;
+}
+
+int main(void) {
+    int fd = -1;
+    int ifindex = -1;
+    struct route_dump_ctx ctx;
+
+    fd = nl_open_socket(NETLINK_ROUTE);
+    NL_TEST_ASSERT(fd >= 0, "open NETLINK_ROUTE failed");
+    NL_TEST_ASSERT(nl_lookup_ifindex(fd, "veth_a", &ifindex) == 0,
+                   "lookup veth_a ifindex failed");
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getroute_dump(fd, 1, &ctx) == 0, "initial RTM_GETROUTE failed");
+    NL_TEST_ASSERT(ctx.seen_connected,
+                   "connected route 200.0.0.0/24 missing or not normalized");
+
+    NL_TEST_ASSERT(send_route_update(fd, 2, RTM_NEWROUTE, ifindex) == 0,
+                   "RTM_NEWROUTE failed");
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getroute_dump(fd, 3, &ctx) == 0, "post-add RTM_GETROUTE failed");
+    NL_TEST_ASSERT(ctx.seen_static, "static route missing after RTM_NEWROUTE");
+
+    NL_TEST_ASSERT(send_route_del_no_gateway(fd, 4, ifindex) == 0,
+                   "RTM_DELROUTE without gateway failed");
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.target_ifindex = ifindex;
+    NL_TEST_ASSERT(send_getroute_dump(fd, 5, &ctx) == 0, "post-del RTM_GETROUTE failed");
+    NL_TEST_ASSERT(!ctx.seen_static, "static route still present after RTM_DELROUTE");
+
+    close(fd);
+    printf("rtnetlink route tests passed\n");
+    return 0;
+}

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_route_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_route_semantics.cc
@@ -2,11 +2,13 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <linux/if_addr.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #include <cstring>
@@ -55,6 +57,8 @@ struct DumpedRoute {
     uint32_t oif = 0;
     bool has_gateway = false;
 };
+
+uint32_t Ipv4(const char* text);
 
 int OpenRouteSocket() {
     int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
@@ -134,6 +138,32 @@ int SendRouteRequest(int fd, uint16_t type, uint16_t flags, const RouteSpec& rou
         uint32_t gw = *route.gateway;
         AddAttr(nlh, sizeof(buf), RTA_GATEWAY, &gw, sizeof(gw));
     }
+
+    if (send(fd, nlh, nlh->nlmsg_len, 0) != static_cast<ssize_t>(nlh->nlmsg_len)) {
+        return errno;
+    }
+    return RecvAck(fd, seq);
+}
+
+int SendAddrRequest(int fd, uint16_t type, uint16_t flags, uint32_t ifindex, const char* addr,
+                    uint8_t prefix_len, uint32_t seq) {
+    alignas(nlmsghdr) char buf[512] = {};
+    auto* nlh = reinterpret_cast<nlmsghdr*>(buf);
+    auto* ifa = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(nlh));
+
+    nlh->nlmsg_len = NLMSG_LENGTH(sizeof(ifaddrmsg));
+    nlh->nlmsg_type = type;
+    nlh->nlmsg_flags = flags;
+    nlh->nlmsg_seq = seq;
+
+    ifa->ifa_family = AF_INET;
+    ifa->ifa_prefixlen = prefix_len;
+    ifa->ifa_scope = RT_SCOPE_HOST;
+    ifa->ifa_index = ifindex;
+
+    uint32_t ip = Ipv4(addr);
+    AddAttr(nlh, sizeof(buf), IFA_LOCAL, &ip, sizeof(ip));
+    AddAttr(nlh, sizeof(buf), IFA_ADDRESS, &ip, sizeof(ip));
 
     if (send(fd, nlh, nlh->nlmsg_len, 0) != static_cast<ssize_t>(nlh->nlmsg_len)) {
         return errno;
@@ -222,6 +252,12 @@ std::optional<DumpedRoute> FindRoute(int fd, const RouteSpec& spec, uint32_t seq
 
 void DeleteRouteIfPresent(int fd, const RouteSpec& spec, uint32_t* seq) {
     (void)SendRouteRequest(fd, RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, spec, ++(*seq));
+}
+
+void DeleteAddrIfPresent(int fd, uint32_t ifindex, const char* addr, uint8_t prefix_len,
+                         uint32_t* seq) {
+    (void)SendAddrRequest(fd, RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, ifindex, addr, prefix_len,
+                          ++(*seq));
 }
 
 uint32_t Ipv4(const char* text) {
@@ -352,6 +388,62 @@ TEST(RtnetlinkRouteSemantics, OnLinkRouteAllowsUdpSendWithoutNoRoute) {
 
     EXPECT_EQ(SendRouteRequest(netlink_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route,
                                ++seq),
+              0);
+}
+
+TEST(RtnetlinkRouteSemantics, LoopbackIpv4SubnetRoutesAreLocalForUdp) {
+    FdGuard netlink_fd(OpenRouteSocket());
+    ASSERT_GE(netlink_fd.Get(), 0) << "socket(AF_NETLINK, NETLINK_ROUTE) failed: "
+                                   << ErrnoString(errno);
+    uint32_t seq = 5000;
+    uint32_t lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+
+    DeleteAddrIfPresent(netlink_fd.Get(), lo, "192.0.2.1", 24, &seq);
+    ASSERT_EQ(SendAddrRequest(netlink_fd.Get(), RTM_NEWADDR,
+                              NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, lo,
+                              "192.0.2.1", 24, ++seq),
+              0);
+
+    FdGuard snd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(snd.Get(), 0) << "sender socket failed: " << ErrnoString(errno);
+    FdGuard rcv(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(rcv.Get(), 0) << "receiver socket failed: " << ErrnoString(errno);
+
+    timeval timeout = {};
+    timeout.tv_sec = 2;
+    ASSERT_EQ(setsockopt(rcv.Get(), SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)), 0)
+            << "setsockopt(SO_RCVTIMEO) failed: " << ErrnoString(errno);
+
+    sockaddr_in sender = {};
+    sender.sin_family = AF_INET;
+    sender.sin_addr.s_addr = Ipv4("192.0.2.2");
+    ASSERT_EQ(bind(snd.Get(), reinterpret_cast<sockaddr*>(&sender), sizeof(sender)), 0)
+            << "bind sender failed: " << ErrnoString(errno);
+
+    sockaddr_in receiver = {};
+    receiver.sin_family = AF_INET;
+    receiver.sin_addr.s_addr = Ipv4("192.0.2.254");
+    ASSERT_EQ(bind(rcv.Get(), reinterpret_cast<sockaddr*>(&receiver), sizeof(receiver)), 0)
+            << "bind receiver failed: " << ErrnoString(errno);
+
+    socklen_t receiver_len = sizeof(receiver);
+    ASSERT_EQ(getsockname(rcv.Get(), reinterpret_cast<sockaddr*>(&receiver), &receiver_len), 0)
+            << "getsockname receiver failed: " << ErrnoString(errno);
+
+    const char payload[] = "loopback-subnet";
+    ASSERT_EQ(sendto(snd.Get(), payload, sizeof(payload), 0,
+                     reinterpret_cast<sockaddr*>(&receiver), receiver_len),
+              static_cast<ssize_t>(sizeof(payload)))
+            << "sendto failed: " << ErrnoString(errno);
+
+    char buf[sizeof(payload)] = {};
+    ASSERT_EQ(recv(rcv.Get(), buf, sizeof(buf), 0), static_cast<ssize_t>(sizeof(payload)))
+            << "recv failed: " << ErrnoString(errno);
+    EXPECT_EQ(std::memcmp(payload, buf, sizeof(payload)), 0);
+
+    EXPECT_EQ(SendAddrRequest(netlink_fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, lo,
+                              "192.0.2.1", 24, ++seq),
               0);
 }
 

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_route_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_route_semantics.cc
@@ -1,0 +1,361 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    ~FdGuard() { Reset(); }
+
+    int Get() const { return fd_; }
+
+    void Reset(int fd = -1) {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        fd_ = fd;
+    }
+
+  private:
+    int fd_;
+};
+
+std::string ErrnoString(int err) {
+    return std::to_string(err) + " (" + std::strerror(err) + ")";
+}
+
+struct RouteSpec {
+    uint32_t dst = 0;
+    uint8_t prefix_len = 0;
+    uint8_t table = RT_TABLE_UNSPEC;
+    uint32_t oif = 0;
+    std::optional<uint32_t> gateway;
+};
+
+struct DumpedRoute {
+    uint32_t dst = 0;
+    uint8_t prefix_len = 0;
+    uint8_t table = RT_TABLE_UNSPEC;
+    uint32_t oif = 0;
+    bool has_gateway = false;
+};
+
+int OpenRouteSocket() {
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (fd < 0) {
+        return -1;
+    }
+
+    sockaddr_nl addr = {};
+    addr.nl_family = AF_NETLINK;
+    if (bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        int saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+    return fd;
+}
+
+void AddAttr(nlmsghdr* nlh, size_t max_len, uint16_t type, const void* data, size_t len) {
+    size_t attr_len = RTA_LENGTH(len);
+    size_t aligned_len = RTA_ALIGN(attr_len);
+    ASSERT_LE(static_cast<size_t>(nlh->nlmsg_len) + aligned_len, max_len);
+
+    auto* rta = reinterpret_cast<rtattr*>(reinterpret_cast<char*>(nlh) + NLMSG_ALIGN(nlh->nlmsg_len));
+    rta->rta_type = type;
+    rta->rta_len = attr_len;
+    std::memcpy(RTA_DATA(rta), data, len);
+    std::memset(reinterpret_cast<char*>(rta) + attr_len, 0, aligned_len - attr_len);
+    nlh->nlmsg_len = NLMSG_ALIGN(nlh->nlmsg_len) + aligned_len;
+}
+
+int RecvAck(int fd, uint32_t seq) {
+    char buf[4096] = {};
+    for (;;) {
+        ssize_t len = recv(fd, buf, sizeof(buf), 0);
+        if (len < 0) {
+            return errno;
+        }
+
+        for (auto* nlh = reinterpret_cast<nlmsghdr*>(buf); NLMSG_OK(nlh, len);
+             nlh = NLMSG_NEXT(nlh, len)) {
+            if (nlh->nlmsg_seq != seq) {
+                continue;
+            }
+            if (nlh->nlmsg_type != NLMSG_ERROR) {
+                continue;
+            }
+
+            auto* err = reinterpret_cast<nlmsgerr*>(NLMSG_DATA(nlh));
+            return err->error == 0 ? 0 : -err->error;
+        }
+    }
+}
+
+int SendRouteRequest(int fd, uint16_t type, uint16_t flags, const RouteSpec& route, uint32_t seq) {
+    alignas(nlmsghdr) char buf[512] = {};
+    auto* nlh = reinterpret_cast<nlmsghdr*>(buf);
+    auto* rtm = reinterpret_cast<rtmsg*>(NLMSG_DATA(nlh));
+
+    nlh->nlmsg_len = NLMSG_LENGTH(sizeof(rtmsg));
+    nlh->nlmsg_type = type;
+    nlh->nlmsg_flags = flags;
+    nlh->nlmsg_seq = seq;
+
+    rtm->rtm_family = AF_INET;
+    rtm->rtm_dst_len = route.prefix_len;
+    rtm->rtm_table = route.table;
+    rtm->rtm_protocol = RTPROT_STATIC;
+    rtm->rtm_scope = route.gateway.has_value() ? RT_SCOPE_UNIVERSE : RT_SCOPE_LINK;
+    rtm->rtm_type = RTN_UNICAST;
+
+    if (route.prefix_len != 0) {
+        AddAttr(nlh, sizeof(buf), RTA_DST, &route.dst, sizeof(route.dst));
+    }
+    AddAttr(nlh, sizeof(buf), RTA_OIF, &route.oif, sizeof(route.oif));
+    if (route.gateway.has_value()) {
+        uint32_t gw = *route.gateway;
+        AddAttr(nlh, sizeof(buf), RTA_GATEWAY, &gw, sizeof(gw));
+    }
+
+    if (send(fd, nlh, nlh->nlmsg_len, 0) != static_cast<ssize_t>(nlh->nlmsg_len)) {
+        return errno;
+    }
+    return RecvAck(fd, seq);
+}
+
+std::vector<DumpedRoute> DumpRoutes(int fd, uint32_t seq) {
+    alignas(nlmsghdr) char req_buf[NLMSG_LENGTH(sizeof(rtmsg))] = {};
+    auto* nlh = reinterpret_cast<nlmsghdr*>(req_buf);
+    auto* rtm = reinterpret_cast<rtmsg*>(NLMSG_DATA(nlh));
+
+    nlh->nlmsg_len = NLMSG_LENGTH(sizeof(rtmsg));
+    nlh->nlmsg_type = RTM_GETROUTE;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    nlh->nlmsg_seq = seq;
+    rtm->rtm_family = AF_INET;
+
+    EXPECT_EQ(send(fd, nlh, nlh->nlmsg_len, 0), static_cast<ssize_t>(nlh->nlmsg_len))
+            << "send RTM_GETROUTE failed: " << ErrnoString(errno);
+
+    std::vector<DumpedRoute> routes;
+    char buf[8192] = {};
+    bool done = false;
+    while (!done) {
+        ssize_t len = recv(fd, buf, sizeof(buf), 0);
+        if (len < 0) {
+            ADD_FAILURE() << "recv RTM_GETROUTE failed: " << ErrnoString(errno);
+            break;
+        }
+
+        for (auto* msg = reinterpret_cast<nlmsghdr*>(buf); NLMSG_OK(msg, len);
+             msg = NLMSG_NEXT(msg, len)) {
+            if (msg->nlmsg_seq != seq) {
+                continue;
+            }
+            if (msg->nlmsg_type == NLMSG_DONE) {
+                done = true;
+                break;
+            }
+            if (msg->nlmsg_type != RTM_NEWROUTE) {
+                continue;
+            }
+
+            auto* route_msg = reinterpret_cast<rtmsg*>(NLMSG_DATA(msg));
+            DumpedRoute route = {};
+            route.prefix_len = route_msg->rtm_dst_len;
+            route.table = route_msg->rtm_table;
+
+            int attr_len = msg->nlmsg_len - NLMSG_LENGTH(sizeof(rtmsg));
+            for (auto* attr = RTM_RTA(route_msg); RTA_OK(attr, attr_len);
+                 attr = RTA_NEXT(attr, attr_len)) {
+                switch (attr->rta_type) {
+                    case RTA_DST:
+                        if (RTA_PAYLOAD(attr) >= sizeof(route.dst)) {
+                            std::memcpy(&route.dst, RTA_DATA(attr), sizeof(route.dst));
+                        }
+                        break;
+                    case RTA_OIF:
+                        if (RTA_PAYLOAD(attr) >= sizeof(route.oif)) {
+                            std::memcpy(&route.oif, RTA_DATA(attr), sizeof(route.oif));
+                        }
+                        break;
+                    case RTA_GATEWAY:
+                        route.has_gateway = true;
+                        break;
+                    default:
+                        break;
+                }
+            }
+            routes.push_back(route);
+        }
+    }
+    return routes;
+}
+
+std::optional<DumpedRoute> FindRoute(int fd, const RouteSpec& spec, uint32_t seq) {
+    for (const auto& route : DumpRoutes(fd, seq)) {
+        if (route.dst == spec.dst && route.prefix_len == spec.prefix_len &&
+            route.oif == spec.oif) {
+            return route;
+        }
+    }
+    return std::nullopt;
+}
+
+void DeleteRouteIfPresent(int fd, const RouteSpec& spec, uint32_t* seq) {
+    (void)SendRouteRequest(fd, RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, spec, ++(*seq));
+}
+
+uint32_t Ipv4(const char* text) {
+    in_addr addr = {};
+    EXPECT_EQ(inet_pton(AF_INET, text, &addr), 1) << text;
+    return addr.s_addr;
+}
+
+RouteSpec MakeIpv4Route(const char* dst, uint8_t prefix_len, uint32_t oif) {
+    RouteSpec route = {};
+    route.dst = Ipv4(dst);
+    route.prefix_len = prefix_len;
+    route.oif = oif;
+    return route;
+}
+
+}  // namespace
+
+TEST(RtnetlinkRouteSemantics, OnLinkRouteWithUnspecTableDumpsAsMainWithoutGateway) {
+    FdGuard fd(OpenRouteSocket());
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_NETLINK, NETLINK_ROUTE) failed: " << ErrnoString(errno);
+    uint32_t seq = 1000;
+    uint32_t lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+
+    RouteSpec route = MakeIpv4Route("198.18.77.0", 24, lo);
+    DeleteRouteIfPresent(fd.Get(), route, &seq);
+
+    ASSERT_EQ(SendRouteRequest(fd.Get(), RTM_NEWROUTE,
+                               NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, route,
+                               ++seq),
+              0);
+    auto dumped = FindRoute(fd.Get(), route, ++seq);
+    ASSERT_TRUE(dumped.has_value());
+    EXPECT_EQ(dumped->table, RT_TABLE_MAIN);
+    EXPECT_FALSE(dumped->has_gateway);
+
+    EXPECT_EQ(SendRouteRequest(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route, ++seq),
+              0);
+}
+
+TEST(RtnetlinkRouteSemantics, DefaultDevRouteWithoutGatewaySucceeds) {
+    FdGuard fd(OpenRouteSocket());
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_NETLINK, NETLINK_ROUTE) failed: " << ErrnoString(errno);
+    uint32_t seq = 2000;
+    uint32_t lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+
+    RouteSpec route = {};
+    route.oif = lo;
+    DeleteRouteIfPresent(fd.Get(), route, &seq);
+
+    EXPECT_EQ(SendRouteRequest(fd.Get(), RTM_NEWROUTE,
+                               NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, route,
+                               ++seq),
+              0);
+    EXPECT_EQ(SendRouteRequest(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route, ++seq),
+              0);
+}
+
+TEST(RtnetlinkRouteSemantics, FailedDataPlaneSyncRollsBackNormalizedTableRoute) {
+    FdGuard fd(OpenRouteSocket());
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_NETLINK, NETLINK_ROUTE) failed: " << ErrnoString(errno);
+    uint32_t seq = 3000;
+    uint32_t lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+
+    std::vector<RouteSpec> added;
+    std::optional<RouteSpec> failed;
+    for (int i = 0; i < 16; ++i) {
+        std::string dst = std::string("198.18.") + std::to_string(100 + i) + ".0";
+        RouteSpec route = MakeIpv4Route(dst.c_str(), 24, lo);
+        DeleteRouteIfPresent(fd.Get(), route, &seq);
+        int err = SendRouteRequest(fd.Get(), RTM_NEWROUTE,
+                                   NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, route,
+                                   ++seq);
+        if (err == 0) {
+            added.push_back(route);
+            continue;
+        }
+        if (err == ENOSPC) {
+            failed = route;
+            break;
+        }
+        FAIL() << "unexpected RTM_NEWROUTE error: " << ErrnoString(err);
+    }
+
+    ASSERT_TRUE(failed.has_value()) << "route table did not reach ENOSPC during rollback test";
+    EXPECT_FALSE(FindRoute(fd.Get(), *failed, ++seq).has_value())
+            << "failed add left a netlink control-plane route behind";
+
+    for (const auto& route : added) {
+        EXPECT_EQ(SendRouteRequest(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route,
+                                   ++seq),
+                  0);
+    }
+}
+
+TEST(RtnetlinkRouteSemantics, OnLinkRouteAllowsUdpSendWithoutNoRoute) {
+    FdGuard netlink_fd(OpenRouteSocket());
+    ASSERT_GE(netlink_fd.Get(), 0) << "socket(AF_NETLINK, NETLINK_ROUTE) failed: "
+                                   << ErrnoString(errno);
+    uint32_t seq = 4000;
+    uint32_t lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+
+    RouteSpec route = MakeIpv4Route("198.18.201.0", 24, lo);
+    DeleteRouteIfPresent(netlink_fd.Get(), route, &seq);
+    ASSERT_EQ(SendRouteRequest(netlink_fd.Get(), RTM_NEWROUTE,
+                               NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, route,
+                               ++seq),
+              0);
+
+    FdGuard udp_fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(udp_fd.Get(), 0) << "socket(AF_INET, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    sockaddr_in dst = {};
+    dst.sin_family = AF_INET;
+    dst.sin_port = htons(9);
+    dst.sin_addr.s_addr = Ipv4("198.18.201.42");
+
+    const char payload[] = "x";
+    errno = 0;
+    ssize_t sent = sendto(udp_fd.Get(), payload, sizeof(payload), 0,
+                          reinterpret_cast<sockaddr*>(&dst), sizeof(dst));
+    EXPECT_GE(sent, 0) << "sendto failed: " << ErrnoString(errno);
+    EXPECT_NE(errno, ENETUNREACH);
+
+    EXPECT_EQ(SendRouteRequest(netlink_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route,
+                               ++seq),
+              0);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- Implement/complete RTM_GET/SET/DEL LINK, RTM_GET/NEW/DEL ADDR, RTM_GET/NEW/DEL ROUTE, RTM_GET/NEW/DEL NEIGH, and RTM_GETRULE dump (empty table) — the common paths used by Kata
- Fix netlink message parsing, DUMP finalization, sendmsg multi-message, multicast, and epoll wakeup issues so that Tokio/rtnetlink can send and receive asynchronously
- Maintain a netlink routing table at the interface layer; add kobject uevent skeleton on the device/driver side (block devices, NIC sysfs, etc.)
- Add 5 groups of rtnetlink / sockopt tests under user/apps/c_unitest

---

## Background

Kata Agent relies on NETLINK_ROUTE to configure interfaces, addresses, routes, and neighbors. Previously DragonOS only partially implemented GETLINK/GETADDR/NEWADDR/DELADDR, and epoll_items() was not ready, blocking async netlink usage.

---

## Main Changes

### Kernel — rtnetlink (kernel/src/net/socket/netlink/route/)

| Capability | Description |
|------------|-------------|
| Link | RTM_GETLINK dump / query by name; RTM_SETLINK change MTU/flags/rename; RTM_DELLINK |
| Addr | RTM_GETADDR dump (sorted by family); RTM_NEWADDR / RTM_DELADDR |
| Route | RTM_GETROUTE (with RTM_F_LOOKUP_TABLE); RTM_NEWROUTE / RTM_DELROUTE (EEXIST/ESRCH, rtm_table==0→main) |
| Neigh | RTM_NEWNEIGH / GETNEIGH / DELNEIGH |
| Rule | RTM_GETRULE dump returns empty table + NLMSG_DONE (placeholder, not full fib rule) |

**Protocol and socket layer fixes** (bound.rs, utils.rs, message/attr/mod.rs, etc.):

- DUMP responses append NLMSG_DONE only during dump; non-DUMP GET no longer incorrectly carries DONE
- sendmsg supports multiple nlmsgs; skip DONE without NLM_F_REQUEST; unknown type returns ENOTSUP ack
- Zero-padding after multiple REQUEST messages in a single packet stops parsing (aligned with gVisor multi-segment packets)
- rtattr advances by total_len_with_padding(), fixing attribute misalignment
- RTM_GETLINK no longer incorrectly requires ifi_type==NETROM
- New netns has loopback ifindex=1 (LinkedToNetns, etc.)

### Kernel — Networking and Drivers

- Interface CommonIface gains a **netlink routing table** (NetlinkRouteEntry) for RTM_*ROUTE read/write
- **Neighbor table** integrated with rtnetlink neigh messages (neighbor.rs, route/kern/neigh.rs)
- **kobject_uevent / emit_uevent**: block device gendisk, NIC sysfs, etc. can send NETLINK_KOBJECT_UEVENT multicast (agent hotplug still pending)
- NIC drivers (virtio, e1000e, veth, loopback, etc.) tied to netns lifecycle

### Kernel — netlink common layer

- **epoll_items()** and receive queue wakeup (common/mod.rs, receiver.rs)
- **NETLINK_LIST_MEMBERSHIPS** (sys_getsockopt.rs)
- Improved multicast group membership management (addr/multicast.rs)

### Userspace tests (user/apps/c_unitest/)

- test_netlink_sockopt.c — sockopt / epoll
- test_rtnetlink_addr.c, test_rtnetlink_link.c, test_rtnetlink_neigh.c, test_rtnetlink_route.c — various RTM paths
- netlink_test_lib.h — common netlink helpers

---

## gVisor Test Results (DragonOS guest, feat/rtnetlink kernel)

Using user/apps/mytest/run_netlink_pr_tests (if packaged) and run_netlink_route_test (excluding RecvmsgTrunc which can cause hangs).

| Test Case | Result |
|-----------|--------|
| socket_netlink_test | All pass |
| socket_ip_unbound_netlink_test | All pass |
| socket_ipv4_udp_unbound_loopback_netlink_test | All pass |
| socket_netlink_route_test (excluding RecvmsgTrunc) | 28 passed, 10 SKIPPED (gVisor-specific), 9 failed (see below) |
| socket_ipv6_udp_unbound_loopback_netlink_test | 1 failure: JoinSubnet/1 |
| socket_netlink_netfilter_test | NETLINK_NETFILTER not implemented, not in this PR |
| socket_netlink_uevent_test | uevent socket option, not rtnetlink mainline |

**Route items still failing (planned for follow-up PR / explicitly out of scope)**:

- GetRuleDump, AddAndRemoveRule — no full fib rule
- VethAdd — requires RTM_NEWLINK + dynamic veth creation
- Passcred*, SockOptTest.GetSockOpt — generic sockopt, not RTM semantics

---

## Known Limitations / Follow-up Work

- **Policy routing**: RTM_NEWRULE / full RTM_GETRULE not implemented
- **Dynamic veth**: VethAdd-like test cases still fail
- **uevent**: Only send skeleton; device hotplug wait_for_uevent() loop not yet complete
- **netfilter**: NETLINK_NETFILTER not implemented
- **sockopt**: SO_PASSCRED and some buffer queries still differ from Linux