### PR TITLE
fix(socket): 修复获取 socket 选项时的缓冲区拷贝逻辑

### DIFF
--- a/kernel/src/libs/wait_queue.rs
+++ b/kernel/src/libs/wait_queue.rs
@@ -719,6 +719,9 @@ impl Waker {
                         )
                         .is_ok()
                     {
+                        if let Some(pcb) = self.target.upgrade() {
+                            let _ = ProcessManager::wakeup(&pcb);
+                        }
                         return true;
                     }
                 }

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -585,64 +585,56 @@ impl PageFaultHandler {
 
                 mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
                 VmFaultReason::VM_FAULT_COMPLETED
-            } else if let Some(flush) = mapper.map(address, new_flags) {
-                let mut page_manager_guard = page_manager_lock();
-                let old_page = page_manager_guard.get_unwrap(&old_paddr);
-                drop(page_manager_guard);
-                Self::detach_fault_mapped_page(&old_page, &vma);
+            } else {
+                let new_page = {
+                    let mut page_manager_guard = page_manager_lock();
+                    match page_manager_guard.copy_page(&old_paddr, mapper.allocator_mut()) {
+                        Ok(page) => page,
+                        Err(_) => return VmFaultReason::VM_FAULT_OOM,
+                    }
+                };
+                let new_paddr = new_page.phys_address();
 
-                // 替换为新的物理页：必须先让其他 CPU 的 TLB 失效，
-                // 才能保证它们不会再通过旧 TLB 访问旧物理页。
-                // SAFETY: 后续 mm.flush_tlb_range 会做 mm-aware 远端 + 本地 shootdown。
-                unsafe { flush.ignore() };
-                let mut page_manager_guard = page_manager_lock();
-                let paddr = mapper.translate(address).unwrap().0;
-                let page = page_manager_guard.get_unwrap(&paddr);
-                drop(page_manager_guard);
+                let table = mapper.get_table(address, 0).unwrap();
+                let i = table.index_of(address).unwrap();
+
+                // Copy before publishing the writable PTE. DragonOS does not yet
+                // hold a Linux-style per-PTE lock while every fault reader checks
+                // the PTE, so do not create a transient empty PTE here.
+                table.set_entry(i, super::page::PageEntry::new(new_paddr, new_flags));
+                mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
+
                 Self::attach_fault_mapped_page(
-                    &page,
+                    &new_page,
                     &vma,
                     vma.lock().vm_flags().contains(VmFlags::VM_LOCKED),
                 );
-
-                (MMArch::phys_2_virt(paddr).unwrap().data() as *mut u8).copy_from_nonoverlapping(
-                    MMArch::phys_2_virt(old_paddr).unwrap().data() as *mut u8,
-                    MMArch::PAGE_SIZE,
-                );
-                mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
+                Self::detach_fault_mapped_page(&old_page, &vma);
                 VmFaultReason::VM_FAULT_COMPLETED
-            } else {
-                VmFaultReason::VM_FAULT_OOM
             }
         } else {
             // 私有文件映射，必须拷贝页面
-            if let Some(flush) = mapper.map(address, new_flags) {
+            let new_page = {
                 let mut page_manager_guard = page_manager_lock();
-                let old_page = page_manager_guard.get_unwrap(&old_paddr);
-                drop(page_manager_guard);
-                Self::detach_fault_mapped_page(&old_page, &vma);
+                match page_manager_guard.copy_page(&old_paddr, mapper.allocator_mut()) {
+                    Ok(page) => page,
+                    Err(_) => return VmFaultReason::VM_FAULT_OOM,
+                }
+            };
+            let new_paddr = new_page.phys_address();
 
-                // SAFETY: 后续 mm.flush_tlb_range 会做 mm-aware 远端 + 本地 shootdown。
-                unsafe { flush.ignore() };
-                let mut page_manager_guard = page_manager_lock();
-                let paddr = mapper.translate(address).unwrap().0;
-                let page = page_manager_guard.get_unwrap(&paddr);
-                drop(page_manager_guard);
-                Self::attach_fault_mapped_page(
-                    &page,
-                    &vma,
-                    vma.lock().vm_flags().contains(VmFlags::VM_LOCKED),
-                );
+            let table = mapper.get_table(address, 0).unwrap();
+            let i = table.index_of(address).unwrap();
+            table.set_entry(i, super::page::PageEntry::new(new_paddr, new_flags));
+            mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
 
-                (MMArch::phys_2_virt(paddr).unwrap().data() as *mut u8).copy_from_nonoverlapping(
-                    MMArch::phys_2_virt(old_paddr).unwrap().data() as *mut u8,
-                    MMArch::PAGE_SIZE,
-                );
-                mm.flush_tlb_range(address, end, MMArch::PAGE_SHIFT as u8, false);
-                VmFaultReason::VM_FAULT_COMPLETED
-            } else {
-                VmFaultReason::VM_FAULT_OOM
-            }
+            Self::attach_fault_mapped_page(
+                &new_page,
+                &vma,
+                vma.lock().vm_flags().contains(VmFlags::VM_LOCKED),
+            );
+            Self::detach_fault_mapped_page(&old_page, &vma);
+            VmFaultReason::VM_FAULT_COMPLETED
         }
     }
 

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -359,10 +359,6 @@ fn flush_tlb_multi(target_cpus: &CpuMask, info: &FlushTlbInfo) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        // Global lock serialization: ensures only one shootdown uses per-CPU CSD slots at a time.
-        // Can be refined to per-target dedicated channels in the future.
-        let _g = FLUSH_TLB_GLOBAL_LOCK.lock();
-
         // Prepare CSD slots for each target CPU
         for cpu in active.iter_cpu() {
             if cpu == my_cpu {
@@ -431,6 +427,18 @@ pub fn flush_tlb_mm_range(
     stride_shift: u8,
     freed_tables: bool,
 ) {
+    // Serialize before disabling local interrupts. If a CPU spins for the
+    // shootdown CSD slots with IRQs disabled, it cannot service another CPU's
+    // TLB IPI, and two concurrent flush initiators can deadlock.
+    #[cfg(target_arch = "x86_64")]
+    let irq_was_enabled = CurrentIrqArch::is_irq_enabled();
+    #[cfg(target_arch = "x86_64")]
+    if !irq_was_enabled {
+        unsafe { CurrentIrqArch::interrupt_enable() };
+    }
+    #[cfg(target_arch = "x86_64")]
+    let _flush_guard = FLUSH_TLB_GLOBAL_LOCK.lock();
+
     // Disable interrupts to protect the entire initiation process:
     // - Prevent migration during inc_tlb_gen and snapshot of active_cpus;
     // - Prevent being scheduled out while waiting for IPI ack.
@@ -477,6 +485,11 @@ pub fn flush_tlb_mm_range(
 
     compiler_fence(Ordering::SeqCst);
     drop(irq_guard);
+
+    #[cfg(target_arch = "x86_64")]
+    if !irq_was_enabled {
+        unsafe { CurrentIrqArch::interrupt_disable() };
+    }
 }
 
 /// Convenience wrapper for full-mm flush

--- a/kernel/src/net/socket/common/getsockopt.rs
+++ b/kernel/src/net/socket/common/getsockopt.rs
@@ -1,0 +1,46 @@
+//! Linux-aligned getsockopt value writers (truncate to user buffer length).
+
+/// Write an `i32` socket option value.
+///
+/// Matches Linux `do_ipv6_getsockopt` / `do_ip_getsockopt` truncation:
+/// - empty buffer → 0 bytes
+/// - `0 < len < 4` and `0 <= v <= 255` → 1 byte (IPv4 path)
+/// - otherwise → `min(len, 4)` bytes of the integer representation
+#[inline]
+pub fn write_i32_getsockopt(value: &mut [u8], v: i32) -> usize {
+    if value.is_empty() {
+        return 0;
+    }
+    if value.len() < core::mem::size_of::<i32>() && (0..=255).contains(&v) {
+        value[0] = v as u8;
+        return 1;
+    }
+    let len = core::cmp::min(value.len(), core::mem::size_of::<i32>());
+    value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
+    len
+}
+
+/// Write a `u32` socket option value (`min(len, 4)` bytes).
+#[inline]
+pub fn write_u32_getsockopt(value: &mut [u8], v: u32) -> usize {
+    if value.is_empty() {
+        return 0;
+    }
+    let len = core::cmp::min(value.len(), core::mem::size_of::<u32>());
+    value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
+    len
+}
+
+/// Write a `struct linger` payload (`min(len, 8)` bytes).
+#[inline]
+pub fn write_linger_getsockopt(value: &mut [u8], onoff: i32, linger: i32) -> usize {
+    if value.is_empty() {
+        return 0;
+    }
+    let mut buf = [0u8; 8];
+    buf[0..4].copy_from_slice(&onoff.to_ne_bytes());
+    buf[4..8].copy_from_slice(&linger.to_ne_bytes());
+    let len = core::cmp::min(value.len(), buf.len());
+    value[..len].copy_from_slice(&buf[..len]);
+    len
+}

--- a/kernel/src/net/socket/common/getsockopt.rs
+++ b/kernel/src/net/socket/common/getsockopt.rs
@@ -2,12 +2,24 @@
 
 /// Write an `i32` socket option value.
 ///
-/// Matches Linux `do_ipv6_getsockopt` / `do_ip_getsockopt` truncation:
-/// - empty buffer → 0 bytes
-/// - `0 < len < 4` and `0 <= v <= 255` → 1 byte (IPv4 path)
-/// - otherwise → `min(len, 4)` bytes of the integer representation
+/// Matches Linux `do_ipv6_getsockopt`, `sk_getsockopt`, and `tcp_getsockopt`:
+/// copy `min(user_len, sizeof(int))` bytes without the IPv4-only 1-byte shortcut.
 #[inline]
 pub fn write_i32_getsockopt(value: &mut [u8], v: i32) -> usize {
+    if value.is_empty() {
+        return 0;
+    }
+    let len = core::cmp::min(value.len(), core::mem::size_of::<i32>());
+    value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
+    len
+}
+
+/// Write an `i32` SOL_IP option value.
+///
+/// Matches Linux `do_ip_getsockopt` `copyval`: when `0 < len < 4` and `0 <= v <= 255`,
+/// only one byte is copied and returned.
+#[inline]
+pub fn write_i32_getsockopt_ipv4(value: &mut [u8], v: i32) -> usize {
     if value.is_empty() {
         return 0;
     }
@@ -15,9 +27,7 @@ pub fn write_i32_getsockopt(value: &mut [u8], v: i32) -> usize {
         value[0] = v as u8;
         return 1;
     }
-    let len = core::cmp::min(value.len(), core::mem::size_of::<i32>());
-    value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-    len
+    write_i32_getsockopt(value, v)
 }
 
 /// Write a `u32` socket option value (`min(len, 4)` bytes).

--- a/kernel/src/net/socket/common/getsockopt.rs
+++ b/kernel/src/net/socket/common/getsockopt.rs
@@ -1,4 +1,6 @@
 //! Linux-aligned getsockopt value writers (truncate to user buffer length).
+//!
+//! Returns the number of bytes written into `value` (may be less than the option size).
 
 /// Write an `i32` socket option value.
 ///

--- a/kernel/src/net/socket/common/mod.rs
+++ b/kernel/src/net/socket/common/mod.rs
@@ -1,8 +1,10 @@
 mod epoll_items;
+mod getsockopt;
 mod shutdown;
 mod timeval;
 
 pub use epoll_items::EPollItems;
+pub use getsockopt::{write_i32_getsockopt, write_linger_getsockopt, write_u32_getsockopt};
 pub use shutdown::ShutdownBit;
 pub use timeval::{parse_timeval_opt, write_timeval_opt};
 

--- a/kernel/src/net/socket/common/mod.rs
+++ b/kernel/src/net/socket/common/mod.rs
@@ -4,7 +4,9 @@ mod shutdown;
 mod timeval;
 
 pub use epoll_items::EPollItems;
-pub use getsockopt::{write_i32_getsockopt, write_linger_getsockopt, write_u32_getsockopt};
+pub use getsockopt::{
+    write_i32_getsockopt, write_i32_getsockopt_ipv4, write_linger_getsockopt, write_u32_getsockopt,
+};
 pub use shutdown::ShutdownBit;
 pub use timeval::{parse_timeval_opt, write_timeval_opt};
 

--- a/kernel/src/net/socket/common/timeval.rs
+++ b/kernel/src/net/socket/common/timeval.rs
@@ -57,12 +57,15 @@ pub fn parse_timeval_opt(optval: &[u8]) -> Result<Option<crate::time::Duration>,
 
 /// Write timeval-like socket option payload (64-bit timeval layout).
 pub fn write_timeval_opt(value: &mut [u8], micros: u64) -> Result<usize, SystemError> {
-    if value.len() < 16 {
-        return Err(SystemError::EINVAL);
+    if value.is_empty() {
+        return Ok(0);
     }
     let sec = (micros / 1_000_000) as i64;
     let usec = (micros % 1_000_000) as i64;
-    value[..8].copy_from_slice(&sec.to_ne_bytes());
-    value[8..16].copy_from_slice(&usec.to_ne_bytes());
-    Ok(16)
+    let mut buf = [0u8; 16];
+    buf[..8].copy_from_slice(&sec.to_ne_bytes());
+    buf[8..16].copy_from_slice(&usec.to_ne_bytes());
+    let len = core::cmp::min(value.len(), buf.len());
+    value[..len].copy_from_slice(&buf[..len]);
+    Ok(len)
 }

--- a/kernel/src/net/socket/common/timeval.rs
+++ b/kernel/src/net/socket/common/timeval.rs
@@ -55,10 +55,10 @@ pub fn parse_timeval_opt(optval: &[u8]) -> Result<Option<crate::time::Duration>,
     Err(SystemError::EINVAL)
 }
 
-/// Write timeval-like socket option payload (64-bit timeval layout).
-pub fn write_timeval_opt(value: &mut [u8], micros: u64) -> Result<usize, SystemError> {
+/// Write timeval-like socket option payload (64-bit timeval layout, truncated to `value.len()`).
+pub fn write_timeval_opt(value: &mut [u8], micros: u64) -> usize {
     if value.is_empty() {
-        return Ok(0);
+        return 0;
     }
     let sec = (micros / 1_000_000) as i64;
     let usec = (micros % 1_000_000) as i64;
@@ -67,5 +67,5 @@ pub fn write_timeval_opt(value: &mut [u8], micros: u64) -> Result<usize, SystemE
     buf[8..16].copy_from_slice(&usec.to_ne_bytes());
     let len = core::cmp::min(value.len(), buf.len());
     value[..len].copy_from_slice(&buf[..len]);
-    Ok(len)
+    len
 }

--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -54,7 +54,7 @@ impl BoundInner {
                 netns,
             });
         } else {
-            let iface = get_iface_to_bind(address, netns.clone())
+            let iface = get_iface_for_local_bind(address, &netns)
                 .ok_or_else(|| bind_addr_not_found_error(address, &netns))?;
             // log::debug!(
             //     "BoundInner::bind: binding to iface {} for address {:?}",
@@ -212,6 +212,43 @@ pub fn normalize_unspecified_endpoint_to_loopback(
         smoltcp::wire::IpAddress::Ipv6(_) => smoltcp::wire::IpAddress::v6(0, 0, 0, 0, 0, 0, 0, 1),
     };
     smoltcp::wire::IpEndpoint::new(addr, endpoint.port)
+}
+
+#[inline]
+fn get_iface_for_local_bind(
+    ip_addr: &smoltcp::wire::IpAddress,
+    netns: &Arc<NetNamespace>,
+) -> Option<Arc<dyn Iface>> {
+    let device_list = netns.device_list();
+
+    // Preserve existing Linux-compatible bind behavior for multicast and
+    // broadcast addresses, where the address is not configured as a unicast
+    // address on an interface.
+    if ip_addr.is_multicast() || ip_addr.is_broadcast() {
+        return netns
+            .default_iface()
+            .or_else(|| device_list.values().next().cloned());
+    }
+
+    if let Some(iface) = device_list
+        .iter()
+        .find(|(_, iface)| iface.smol_iface().lock().has_ip_addr(*ip_addr))
+        .map(|(_, iface)| iface.clone())
+    {
+        return Some(iface);
+    }
+
+    // Linux treats IPv4 addresses in a loopback interface's configured subnet
+    // as local for bind(2). IPv6 does not have this loopback-subnet exception:
+    // binding to an unassigned IPv6 address in an on-link prefix fails with
+    // EADDRNOTAVAIL.
+    if let smoltcp::wire::IpAddress::Ipv4(v4_addr) = ip_addr {
+        return device_list.iter().find_map(|(_, iface)| {
+            loopback_iface_contains_v4(iface, *v4_addr).then(|| iface.clone())
+        });
+    }
+
+    None
 }
 
 #[inline]

--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -254,6 +254,13 @@ pub fn get_iface_to_bind(
         });
     }
 
+    // IPv6 loopback destinations (::1 etc.) are delivered via the loopback interface.
+    if let smoltcp::wire::IpAddress::Ipv6(v6_addr) = ip_addr {
+        return device_list.iter().find_map(|(_, iface)| {
+            loopback_iface_contains_v6(iface, *v6_addr).then(|| iface.clone())
+        });
+    }
+
     None
 }
 
@@ -279,6 +286,21 @@ fn loopback_iface_contains_v4(iface: &Arc<dyn Iface>, v4_addr: smoltcp::wire::Ip
     let smol_iface = iface.smol_iface().lock();
     smol_iface.ip_addrs().iter().any(|cidr| match cidr {
         smoltcp::wire::IpCidr::Ipv4(v4_cidr) => v4_cidr.contains_addr(&v4_addr),
+        _ => false,
+    })
+}
+
+#[inline]
+fn loopback_iface_contains_v6(iface: &Arc<dyn Iface>, v6_addr: smoltcp::wire::Ipv6Address) -> bool {
+    if !iface.flags().contains(InterfaceFlags::LOOPBACK) {
+        return false;
+    }
+    if v6_addr.is_loopback() {
+        return true;
+    }
+    let smol_iface = iface.smol_iface().lock();
+    smol_iface.ip_addrs().iter().any(|cidr| match cidr {
+        smoltcp::wire::IpCidr::Ipv6(v6_cidr) => v6_cidr.contains_addr(&v6_addr),
         _ => false,
     })
 }
@@ -332,6 +354,10 @@ fn iface_allowed_for_remote(iface: &Arc<dyn Iface>, loopback_dst: bool) -> bool 
 }
 
 fn no_source_addr_error(remote_ip_addr: &smoltcp::wire::IpAddress) -> SystemError {
+    // gVisor socket_ip_unbound_netlink / Linux 6.6:
+    // - IPv6 connect to ::1 without a local source on lo -> EADDRNOTAVAIL
+    // - IPv4 connect to 127.0.0.1 after removing 127.0.0.0/8 from lo -> ENETUNREACH
+    //   (ip_route_connect style "no route", not address-unavailable)
     match remote_ip_addr {
         smoltcp::wire::IpAddress::Ipv4(_) => SystemError::ENETUNREACH,
         // Linux IPv6 connect() distinguishes "no route to a remote network"

--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -355,9 +355,8 @@ fn iface_allowed_for_remote(iface: &Arc<dyn Iface>, loopback_dst: bool) -> bool 
 
 fn no_source_addr_error(remote_ip_addr: &smoltcp::wire::IpAddress) -> SystemError {
     // gVisor socket_ip_unbound_netlink / Linux 6.6:
-    // - IPv6 connect to ::1 without a local source on lo -> EADDRNOTAVAIL
-    // - IPv4 connect to 127.0.0.1 after removing 127.0.0.0/8 from lo -> ENETUNREACH
-    //   (ip_route_connect style "no route", not address-unavailable)
+    // - IPv6 loopback destination (::1) without a local source -> EADDRNOTAVAIL
+    // - All other no-source cases (incl. IPv4 loopback with no lo route) -> ENETUNREACH
     match remote_ip_addr {
         smoltcp::wire::IpAddress::Ipv4(_) => SystemError::ENETUNREACH,
         // Linux IPv6 connect() distinguishes "no route to a remote network"

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -139,8 +139,6 @@ pub struct UdpSocket {
     send_timeout_us: AtomicU64,
     /// SO_RCVTIMEO (microseconds). u64::MAX means "no timeout".
     recv_timeout_us: AtomicU64,
-    /// SO_ERROR: pending async socket error (negative POSIX errno, 0 = none).
-    so_error: AtomicI32,
     /// SO_NO_CHECK: disable UDP checksum (0=off, 1=on)
     ///
     /// NOTE: This is currently a stub implementation. The value can be set/get via
@@ -213,7 +211,6 @@ impl UdpSocket {
             send_timeout_us: AtomicU64::new(u64::MAX),
             recv_timeout_us: AtomicU64::new(u64::MAX),
             no_check: AtomicBool::new(false), // checksums enabled by default
-            so_error: AtomicI32::new(0),
             ip_version: version,
             multicast_loopback_rx: Mutex::new(VecDeque::new()),
         })
@@ -222,21 +219,6 @@ impl UdpSocket {
     #[inline]
     fn bind_id(&self) -> usize {
         self as *const UdpSocket as usize
-    }
-
-    /// Record a pending socket error for `getsockopt(SO_ERROR)` (Linux `sk->sk_err`).
-    #[inline]
-    pub(super) fn store_so_error(&self, err: &SystemError) {
-        let code = -err.to_posix_errno();
-        if code != 0 {
-            self.so_error.store(code, Ordering::Relaxed);
-        }
-    }
-
-    /// Read and clear `SO_ERROR` (negative POSIX errno, 0 if none).
-    #[inline]
-    pub(super) fn take_so_error(&self) -> i32 {
-        self.so_error.swap(0, Ordering::Relaxed)
     }
 
     #[inline]
@@ -1466,10 +1448,7 @@ impl Socket for UdpSocket {
 
                 let remote = Self::normalize_unspecified_dest(remote);
                 if !self.is_bound() {
-                    if let Err(e) = self.bind_ephemeral(remote.addr) {
-                        self.store_so_error(&e);
-                        return Err(e);
-                    }
+                    self.bind_ephemeral(remote.addr)?;
                 }
                 match self.inner.read().as_ref() {
                     Some(UdpInner::Bound(inner)) => {

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -139,6 +139,8 @@ pub struct UdpSocket {
     send_timeout_us: AtomicU64,
     /// SO_RCVTIMEO (microseconds). u64::MAX means "no timeout".
     recv_timeout_us: AtomicU64,
+    /// SO_ERROR: pending async socket error (negative POSIX errno, 0 = none).
+    so_error: AtomicI32,
     /// SO_NO_CHECK: disable UDP checksum (0=off, 1=on)
     ///
     /// NOTE: This is currently a stub implementation. The value can be set/get via
@@ -211,6 +213,7 @@ impl UdpSocket {
             send_timeout_us: AtomicU64::new(u64::MAX),
             recv_timeout_us: AtomicU64::new(u64::MAX),
             no_check: AtomicBool::new(false), // checksums enabled by default
+            so_error: AtomicI32::new(0),
             ip_version: version,
             multicast_loopback_rx: Mutex::new(VecDeque::new()),
         })
@@ -219,6 +222,21 @@ impl UdpSocket {
     #[inline]
     fn bind_id(&self) -> usize {
         self as *const UdpSocket as usize
+    }
+
+    /// Record a pending socket error for `getsockopt(SO_ERROR)` (Linux `sk->sk_err`).
+    #[inline]
+    pub(super) fn store_so_error(&self, err: &SystemError) {
+        let code = -(err.to_posix_errno() as i32);
+        if code != 0 {
+            self.so_error.store(code, Ordering::Relaxed);
+        }
+    }
+
+    /// Read and clear `SO_ERROR` (negative POSIX errno, 0 if none).
+    #[inline]
+    pub(super) fn take_so_error(&self) -> i32 {
+        self.so_error.swap(0, Ordering::Relaxed)
     }
 
     #[inline]
@@ -1448,7 +1466,10 @@ impl Socket for UdpSocket {
 
                 let remote = Self::normalize_unspecified_dest(remote);
                 if !self.is_bound() {
-                    self.bind_ephemeral(remote.addr)?;
+                    if let Err(e) = self.bind_ephemeral(remote.addr) {
+                        self.store_so_error(&e);
+                        return Err(e);
+                    }
                 }
                 match self.inner.read().as_ref() {
                     Some(UdpInner::Bound(inner)) => {

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -227,7 +227,7 @@ impl UdpSocket {
     /// Record a pending socket error for `getsockopt(SO_ERROR)` (Linux `sk->sk_err`).
     #[inline]
     pub(super) fn store_so_error(&self, err: &SystemError) {
-        let code = -(err.to_posix_errno() as i32);
+        let code = -err.to_posix_errno();
         if code != 0 {
             self.so_error.store(code, Ordering::Relaxed);
         }

--- a/kernel/src/net/socket/inet/datagram/option.rs
+++ b/kernel/src/net/socket/inet/datagram/option.rs
@@ -11,8 +11,8 @@ use super::inner::{DEFAULT_RX_BUF_SIZE, DEFAULT_TX_BUF_SIZE};
 use super::UdpSocket;
 use crate::libs::byte_parser;
 use crate::net::socket::common::{
-    parse_timeval_opt, write_i32_getsockopt, write_linger_getsockopt, write_timeval_opt,
-    write_u32_getsockopt,
+    parse_timeval_opt, write_i32_getsockopt, write_i32_getsockopt_ipv4, write_linger_getsockopt,
+    write_timeval_opt, write_u32_getsockopt,
 };
 use crate::net::socket::inet::common::{apply_ipv4_membership, apply_ipv4_multicast_if};
 use crate::net::socket::{AddressFamily, IpOption, PIPV6, PSO, PSOCK, PSOL};
@@ -450,7 +450,7 @@ impl UdpSocket {
             _ => return Err(SystemError::ENOPROTOOPT),
         };
 
-        Ok(write_i32_getsockopt(value, v))
+        Ok(write_i32_getsockopt_ipv4(value, v))
     }
 
     /// 处理 SOL_IPV6 级别的 setsockopt。

--- a/kernel/src/net/socket/inet/datagram/option.rs
+++ b/kernel/src/net/socket/inet/datagram/option.rs
@@ -218,12 +218,12 @@ impl UdpSocket {
             PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW => {
                 let us = self.recv_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             PSO::REUSEADDR => Ok(write_i32_getsockopt(
                 value,
@@ -255,7 +255,7 @@ impl UdpSocket {
                 Ok(write_linger_getsockopt(value, on, linger))
             }
             PSO::ACCEPTCONN => Ok(write_i32_getsockopt(value, 0)),
-            PSO::ERROR => Ok(write_i32_getsockopt(value, 0)),
+            PSO::ERROR => Ok(write_i32_getsockopt(value, self.take_so_error())),
             PSO::NO_CHECK => Ok(write_i32_getsockopt(
                 value,
                 self.no_check.load(Ordering::Acquire) as i32,
@@ -355,38 +355,37 @@ impl UdpSocket {
                 use super::multicast_loopback::multicast_registry;
                 use crate::net::socket::inet::common::multicast::parse_mreqn_for_membership;
 
-                if let Ok((multiaddr, ifaddr, ifindex)) = parse_mreqn_for_membership(val) {
-                    // Determine the interface index
-                    let resolved_ifindex = if ifindex != 0 {
-                        ifindex
-                    } else if ifaddr != 0 {
-                        // Find interface by address
-                        use crate::net::socket::inet::common::multicast::find_iface_by_ipv4;
-                        find_iface_by_ipv4(&self.netns, ifaddr)
-                            .map(|iface| iface.nic_id() as i32)
-                            .unwrap_or(0)
-                    } else {
-                        // Use default interface
-                        use crate::net::socket::inet::common::multicast::choose_default_ipv4_iface;
-                        choose_default_ipv4_iface(&self.netns)
-                            .map(|iface| iface.nic_id() as i32)
-                            .unwrap_or(0)
-                    };
+                let (multiaddr, ifaddr, ifindex) = parse_mreqn_for_membership(val)?;
+                // Determine the interface index
+                let resolved_ifindex = if ifindex != 0 {
+                    ifindex
+                } else if ifaddr != 0 {
+                    // Find interface by address
+                    use crate::net::socket::inet::common::multicast::find_iface_by_ipv4;
+                    find_iface_by_ipv4(&self.netns, ifaddr)
+                        .map(|iface| iface.nic_id() as i32)
+                        .unwrap_or(0)
+                } else {
+                    // Use default interface
+                    use crate::net::socket::inet::common::multicast::choose_default_ipv4_iface;
+                    choose_default_ipv4_iface(&self.netns)
+                        .map(|iface| iface.nic_id() as i32)
+                        .unwrap_or(0)
+                };
 
-                    if resolved_ifindex != 0 {
-                        if opt == IpOption::ADD_MEMBERSHIP {
-                            multicast_registry().register(
-                                self.self_ref.clone(),
-                                multiaddr,
-                                resolved_ifindex,
-                            );
-                        } else {
-                            multicast_registry().unregister(
-                                &self.self_ref,
-                                multiaddr,
-                                resolved_ifindex,
-                            );
-                        }
+                if resolved_ifindex != 0 {
+                    if opt == IpOption::ADD_MEMBERSHIP {
+                        multicast_registry().register(
+                            self.self_ref.clone(),
+                            multiaddr,
+                            resolved_ifindex,
+                        );
+                    } else {
+                        multicast_registry().unregister(
+                            &self.self_ref,
+                            multiaddr,
+                            resolved_ifindex,
+                        );
                     }
                 }
 

--- a/kernel/src/net/socket/inet/datagram/option.rs
+++ b/kernel/src/net/socket/inet/datagram/option.rs
@@ -255,7 +255,7 @@ impl UdpSocket {
                 Ok(write_linger_getsockopt(value, on, linger))
             }
             PSO::ACCEPTCONN => Ok(write_i32_getsockopt(value, 0)),
-            PSO::ERROR => Ok(write_i32_getsockopt(value, self.take_so_error())),
+            PSO::ERROR => Ok(write_i32_getsockopt(value, 0)),
             PSO::NO_CHECK => Ok(write_i32_getsockopt(
                 value,
                 self.no_check.load(Ordering::Acquire) as i32,
@@ -431,7 +431,10 @@ impl UdpSocket {
                     0i32
                 }
             }
-            IpOption::MULTICAST_IF => self.ip_multicast_addr.load(Ordering::Relaxed) as i32,
+            IpOption::MULTICAST_IF => {
+                let v = self.ip_multicast_addr.load(Ordering::Relaxed);
+                return Ok(write_u32_getsockopt(value, v));
+            }
             IpOption::PKTINFO => {
                 if self.recv_pktinfo_v4.load(Ordering::Relaxed) {
                     1i32

--- a/kernel/src/net/socket/inet/datagram/option.rs
+++ b/kernel/src/net/socket/inet/datagram/option.rs
@@ -10,7 +10,10 @@ use system_error::SystemError;
 use super::inner::{DEFAULT_RX_BUF_SIZE, DEFAULT_TX_BUF_SIZE};
 use super::UdpSocket;
 use crate::libs::byte_parser;
-use crate::net::socket::common::{parse_timeval_opt, write_timeval_opt};
+use crate::net::socket::common::{
+    parse_timeval_opt, write_i32_getsockopt, write_linger_getsockopt, write_timeval_opt,
+    write_u32_getsockopt,
+};
 use crate::net::socket::inet::common::{apply_ipv4_membership, apply_ipv4_multicast_if};
 use crate::net::socket::{AddressFamily, IpOption, PIPV6, PSO, PSOCK, PSOL};
 use crate::process::cred::CAPFlags;
@@ -177,38 +180,16 @@ impl UdpSocket {
         value: &mut [u8],
     ) -> Result<usize, SystemError> {
         match opt {
-            PSO::TYPE => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = PSOCK::Datagram as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
+            PSO::TYPE => Ok(write_i32_getsockopt(value, PSOCK::Datagram as i32)),
             PSO::DOMAIN => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
                 let domain = match self.ip_version {
                     smoltcp::wire::IpVersion::Ipv6 => AddressFamily::INet6,
                     smoltcp::wire::IpVersion::Ipv4 => AddressFamily::INet,
                 };
-                let v = domain as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
+                Ok(write_i32_getsockopt(value, domain as i32))
             }
-            PSO::PROTOCOL => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = PSOL::UDP as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
+            PSO::PROTOCOL => Ok(write_i32_getsockopt(value, PSOL::UDP as i32)),
             PSO::SNDBUF => {
-                if value.len() < core::mem::size_of::<u32>() {
-                    return Err(SystemError::EINVAL);
-                }
                 let size = self.send_buf_size.load(Ordering::Acquire);
                 // Linux doubles the value when returning it
                 // If 0 (not set), return default size
@@ -217,14 +198,9 @@ impl UdpSocket {
                 } else {
                     size * 2
                 };
-                let bytes = (actual_size as u32).to_ne_bytes();
-                value[0..4].copy_from_slice(&bytes);
-                Ok(core::mem::size_of::<u32>())
+                Ok(write_u32_getsockopt(value, actual_size as u32))
             }
             PSO::RCVBUF => {
-                if value.len() < core::mem::size_of::<u32>() {
-                    return Err(SystemError::EINVAL);
-                }
                 let size = self.recv_buf_size.load(Ordering::Acquire);
                 // Linux doubles the value when returning it
                 // If 0 (not set), return default size
@@ -233,18 +209,12 @@ impl UdpSocket {
                 } else {
                     size * 2
                 };
-                let bytes = (actual_size as u32).to_ne_bytes();
-                value[0..4].copy_from_slice(&bytes);
-                Ok(core::mem::size_of::<u32>())
+                Ok(write_u32_getsockopt(value, actual_size as u32))
             }
-            PSO::RCVLOWAT => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = self.rcvlowat.load(Ordering::Relaxed);
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
+            PSO::RCVLOWAT => Ok(write_i32_getsockopt(
+                value,
+                self.rcvlowat.load(Ordering::Relaxed),
+            )),
             PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
@@ -255,106 +225,41 @@ impl UdpSocket {
                 let us = if us == u64::MAX { 0 } else { us };
                 write_timeval_opt(value, us)
             }
-            PSO::REUSEADDR => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = if self.so_reuseaddr.load(Ordering::Relaxed) {
-                    1i32
-                } else {
-                    0i32
-                };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
-            PSO::BROADCAST => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = if self.so_broadcast.load(Ordering::Relaxed) {
-                    1i32
-                } else {
-                    0i32
-                };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
-            PSO::PASSCRED => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = if self.so_passcred.load(Ordering::Relaxed) {
-                    1i32
-                } else {
-                    0i32
-                };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
-            PSO::REUSEPORT => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = if self.so_reuseport.load(Ordering::Relaxed) {
-                    1i32
-                } else {
-                    0i32
-                };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
-            PSO::KEEPALIVE => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = if self.so_keepalive.load(Ordering::Relaxed) {
-                    1i32
-                } else {
-                    0i32
-                };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
+            PSO::REUSEADDR => Ok(write_i32_getsockopt(
+                value,
+                self.so_reuseaddr.load(Ordering::Relaxed) as i32,
+            )),
+            PSO::BROADCAST => Ok(write_i32_getsockopt(
+                value,
+                self.so_broadcast.load(Ordering::Relaxed) as i32,
+            )),
+            PSO::PASSCRED => Ok(write_i32_getsockopt(
+                value,
+                self.so_passcred.load(Ordering::Relaxed) as i32,
+            )),
+            PSO::REUSEPORT => Ok(write_i32_getsockopt(
+                value,
+                self.so_reuseport.load(Ordering::Relaxed) as i32,
+            )),
+            PSO::KEEPALIVE => Ok(write_i32_getsockopt(
+                value,
+                self.so_keepalive.load(Ordering::Relaxed) as i32,
+            )),
             PSO::LINGER => {
-                if value.len() < 8 {
-                    return Err(SystemError::EINVAL);
-                }
                 let on = self.linger_onoff.load(Ordering::Relaxed);
                 let linger = if on != 0 {
                     self.linger_linger.load(Ordering::Relaxed)
                 } else {
                     0
                 };
-                value[0..4].copy_from_slice(&on.to_ne_bytes());
-                value[4..8].copy_from_slice(&linger.to_ne_bytes());
-                Ok(8)
+                Ok(write_linger_getsockopt(value, on, linger))
             }
-            PSO::ACCEPTCONN => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = 0i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
-            PSO::ERROR => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = 0i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(core::mem::size_of::<i32>())
-            }
-            PSO::NO_CHECK => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
-                let no_check = self.no_check.load(Ordering::Acquire);
-                let val = if no_check { 1i32 } else { 0i32 };
-                let bytes = val.to_ne_bytes();
-                value[0..4].copy_from_slice(&bytes);
-                Ok(core::mem::size_of::<i32>())
-            }
+            PSO::ACCEPTCONN => Ok(write_i32_getsockopt(value, 0)),
+            PSO::ERROR => Ok(write_i32_getsockopt(value, 0)),
+            PSO::NO_CHECK => Ok(write_i32_getsockopt(
+                value,
+                self.no_check.load(Ordering::Acquire) as i32,
+            )),
             _ => Err(SystemError::ENOPROTOOPT),
         }
     }
@@ -497,10 +402,6 @@ impl UdpSocket {
         opt: IpOption,
         value: &mut [u8],
     ) -> Result<usize, SystemError> {
-        if value.len() < core::mem::size_of::<i32>() {
-            return Err(SystemError::EINVAL);
-        }
-
         let v = match opt {
             IpOption::RECVTOS => {
                 if self.recv_tos.load(Ordering::Relaxed) {
@@ -549,8 +450,7 @@ impl UdpSocket {
             _ => return Err(SystemError::ENOPROTOOPT),
         };
 
-        value[..4].copy_from_slice(&v.to_ne_bytes());
-        Ok(core::mem::size_of::<i32>())
+        Ok(write_i32_getsockopt(value, v))
     }
 
     /// 处理 SOL_IPV6 级别的 setsockopt。
@@ -583,10 +483,6 @@ impl UdpSocket {
         opt: PIPV6,
         value: &mut [u8],
     ) -> Result<usize, SystemError> {
-        if value.len() < core::mem::size_of::<i32>() {
-            return Err(SystemError::EINVAL);
-        }
-
         let v = match opt {
             PIPV6::RECVTCLASS => {
                 if self.recv_tclass.load(Ordering::Relaxed) {
@@ -612,8 +508,7 @@ impl UdpSocket {
             _ => return Err(SystemError::ENOPROTOOPT),
         };
 
-        value[..4].copy_from_slice(&v.to_ne_bytes());
-        Ok(core::mem::size_of::<i32>())
+        Ok(write_i32_getsockopt(value, v))
     }
 }
 

--- a/kernel/src/net/socket/inet/raw/mod.rs
+++ b/kernel/src/net/socket/inet/raw/mod.rs
@@ -4,7 +4,7 @@
 
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
-use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicUsize};
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, AtomicUsize};
 
 use smoltcp::wire::{IpProtocol, IpVersion};
 
@@ -86,4 +86,9 @@ pub struct RawSocket {
     ip_multicast_addr: AtomicU32,
     /// IP_ADD_MEMBERSHIP/IP_DROP_MEMBERSHIP state (best-effort, no actual IGMP)
     ip_multicast_groups: Mutex<Vec<crate::net::socket::inet::common::Ipv4MulticastMembership>>,
+
+    /// SO_SNDTIMEO (microseconds). u64::MAX means "no timeout".
+    send_timeout_us: AtomicU64,
+    /// SO_RCVTIMEO (microseconds). u64::MAX means "no timeout".
+    recv_timeout_us: AtomicU64,
 }

--- a/kernel/src/net/socket/inet/raw/recv.rs
+++ b/kernel/src/net/socket/inet/raw/recv.rs
@@ -476,7 +476,10 @@ impl RawSocket {
             loop {
                 match self.try_recv(&mut tmp) {
                     Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                        wq_wait_event_interruptible!(self.wait_queue, self.can_recv(), {})?;
+                        self.wait_queue.wait_event_io_interruptible_timeout(
+                            || self.can_recv(),
+                            self.recv_timeout(),
+                        )?;
                     }
                     other => break other,
                 }
@@ -535,7 +538,10 @@ impl RawSocket {
             loop {
                 match self.try_recv_user(buffer) {
                     Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                        wq_wait_event_interruptible!(self.wait_queue, self.can_recv(), {})?;
+                        self.wait_queue.wait_event_io_interruptible_timeout(
+                            || self.can_recv(),
+                            self.recv_timeout(),
+                        )?;
                     }
                     result => return result.map(|(len, _)| len),
                 }
@@ -564,7 +570,10 @@ impl RawSocket {
             loop {
                 match self.try_recv_user(buffer) {
                     Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                        wq_wait_event_interruptible!(self.wait_queue, self.can_recv(), {})?;
+                        self.wait_queue.wait_event_io_interruptible_timeout(
+                            || self.can_recv(),
+                            self.recv_timeout(),
+                        )?;
                     }
                     result => {
                         return result.map(|(len, addr)| {

--- a/kernel/src/net/socket/inet/raw/send.rs
+++ b/kernel/src/net/socket/inet/raw/send.rs
@@ -277,7 +277,10 @@ impl RawSocket {
         loop {
             match self.try_send(buffer, None) {
                 Err(SystemError::ENOBUFS) => {
-                    wq_wait_event_interruptible!(self.wait_queue, self.can_send(), {})?;
+                    self.wait_queue.wait_event_io_interruptible_timeout(
+                        || self.can_send(),
+                        self.send_timeout(),
+                    )?;
                 }
                 result => return result,
             }
@@ -298,7 +301,10 @@ impl RawSocket {
             loop {
                 match self.try_send(buffer, Some(remote.addr)) {
                     Err(SystemError::ENOBUFS) => {
-                        wq_wait_event_interruptible!(self.wait_queue, self.can_send(), {})?;
+                        self.wait_queue.wait_event_io_interruptible_timeout(
+                            || self.can_send(),
+                            self.send_timeout(),
+                        )?;
                     }
                     result => return result,
                 }

--- a/kernel/src/net/socket/inet/raw/socket.rs
+++ b/kernel/src/net/socket/inet/raw/socket.rs
@@ -86,6 +86,8 @@ impl RawSocket {
             ip_multicast_ifindex: core::sync::atomic::AtomicI32::new(0),
             ip_multicast_addr: core::sync::atomic::AtomicU32::new(0),
             ip_multicast_groups: crate::libs::mutex::Mutex::new(Vec::new()),
+            send_timeout_us: core::sync::atomic::AtomicU64::new(u64::MAX),
+            recv_timeout_us: core::sync::atomic::AtomicU64::new(u64::MAX),
         });
 
         // Linux 语义：raw socket 未 bind 也应能被 poll/epoll 正确唤醒。
@@ -102,6 +104,28 @@ impl RawSocket {
 
     pub fn is_nonblock(&self) -> bool {
         self.nonblock.load(core::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(super) fn recv_timeout(&self) -> Option<crate::time::Duration> {
+        let us = self
+            .recv_timeout_us
+            .load(core::sync::atomic::Ordering::Relaxed);
+        if us == u64::MAX {
+            None
+        } else {
+            Some(crate::time::Duration::from_micros(us))
+        }
+    }
+
+    pub(super) fn send_timeout(&self) -> Option<crate::time::Duration> {
+        let us = self
+            .send_timeout_us
+            .load(core::sync::atomic::Ordering::Relaxed);
+        if us == u64::MAX {
+            None
+        } else {
+            Some(crate::time::Duration::from_micros(us))
+        }
     }
 
     #[inline]

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -216,8 +216,10 @@ impl RawSocket {
                 } else {
                     self.options.read().ipv6_checksum
                 };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                // Linux do_rawv6_getsockopt: len = min(sizeof(int), user_len)
+                let len = core::cmp::min(value.len(), 4);
+                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
+                Ok(len)
             }
             Ok(PIPV6::UNICAST_HOPS) => {
                 if value.len() < 4 {

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -96,6 +96,8 @@ impl RawSocket {
                 if self.protocol != IpProtocol::Icmp {
                     return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
                 }
+                // Linux raw_geticmpfilter copies sizeof(struct icmp_filter)==32 bytes;
+                // DragonOS exposes a 32-bit mask for ICMP types 0–31 (see options::IcmpFilter).
                 let mask = self.options.read().icmp_filter.get_mask();
                 Ok(write_u32_getsockopt(value, mask))
             }
@@ -275,7 +277,7 @@ impl RawSocket {
                 opts.linger_linger = l_linger;
                 Ok(())
             }
-            _ => Ok(()),
+            _ => Err(SystemError::ENOPROTOOPT),
         }
     }
 
@@ -345,7 +347,7 @@ impl RawSocket {
                 let opt = IpOption::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
                 apply_ipv4_membership(&self.netns, opt, val, &self.ip_multicast_groups)
             }
-            _ => Ok(()),
+            _ => Err(SystemError::ENOPROTOOPT),
         }
     }
 
@@ -404,7 +406,7 @@ impl RawSocket {
                 self.options.write().recv_tclass = enable;
                 Ok(())
             }
-            _ => Ok(()),
+            _ => Err(SystemError::ENOPROTOOPT),
         }
     }
 

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -59,19 +59,19 @@ impl RawSocket {
                     .bind_to_device
                     .clone()
                     .unwrap_or_default();
-                let need = core::cmp::min(name.len() + 1, IFNAMSIZ);
-                if need == 0 || value.is_empty() {
+                if name.is_empty() {
                     return Ok(0);
                 }
+                if value.len() < IFNAMSIZ {
+                    return Err(SystemError::EINVAL);
+                }
+                let need = core::cmp::min(name.len() + 1, IFNAMSIZ);
                 let bytes = name.as_bytes();
                 let name_len = core::cmp::min(bytes.len(), need.saturating_sub(1));
-                let len = core::cmp::min(value.len(), need);
-                let copy_len = core::cmp::min(name_len, len.saturating_sub(1));
+                let copy_len = core::cmp::min(name_len, need.saturating_sub(1));
                 value[..copy_len].copy_from_slice(&bytes[..copy_len]);
-                if copy_len < len {
-                    value[copy_len] = 0;
-                }
-                Ok(len)
+                value[copy_len] = 0;
+                Ok(need)
             }
             Ok(PSO::LINGER) => {
                 let opts = self.options.read();

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -83,12 +83,16 @@ impl RawSocket {
             }
             Ok(PSO::ACCEPTCONN) => Ok(write_i32_getsockopt(value, 0)),
             Ok(PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW) => {
-                let us = self.send_timeout_us.load(core::sync::atomic::Ordering::Relaxed);
+                let us = self
+                    .send_timeout_us
+                    .load(core::sync::atomic::Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
                 Ok(write_timeval_opt(value, us))
             }
             Ok(PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW) => {
-                let us = self.recv_timeout_us.load(core::sync::atomic::Ordering::Relaxed);
+                let us = self
+                    .recv_timeout_us
+                    .load(core::sync::atomic::Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
                 Ok(write_timeval_opt(value, us))
             }

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -291,8 +291,10 @@ impl RawSocket {
                 core::mem::size_of_val(&filt.icmp6_filt),
             )
         };
-        value[..bytes.len()].copy_from_slice(bytes);
-        Ok(bytes.len())
+        // Linux rawv6_geticmpfilter: 仅拷贝 min(用户缓冲区, filter) 字节。
+        let len = core::cmp::min(value.len(), bytes.len());
+        value[..len].copy_from_slice(&bytes[..len]);
+        Ok(len)
     }
 
     // ========================================================================

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -8,6 +8,9 @@ use super::constants::{
 };
 use super::options::DEFAULT_IP_TTL;
 use super::{Icmp6Filter, RawSocket};
+use crate::net::socket::common::{
+    write_i32_getsockopt, write_linger_getsockopt, write_u32_getsockopt,
+};
 use crate::net::socket::inet::common::{apply_ipv4_membership, apply_ipv4_multicast_if};
 use crate::net::socket::{IpOption, IFNAMSIZ, PIPV6, PRAW, PSO};
 
@@ -46,22 +49,8 @@ impl RawSocket {
         value: &mut [u8],
     ) -> Result<usize, SystemError> {
         match PSO::try_from(name as u32) {
-            Ok(PSO::SNDBUF) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = self.options.read().sock_sndbuf;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
-            }
-            Ok(PSO::RCVBUF) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = self.options.read().sock_rcvbuf;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
-            }
+            Ok(PSO::SNDBUF) => Ok(write_u32_getsockopt(value, self.options.read().sock_sndbuf)),
+            Ok(PSO::RCVBUF) => Ok(write_u32_getsockopt(value, self.options.read().sock_rcvbuf)),
             Ok(PSO::BINDTODEVICE) => {
                 let name = self
                     .options
@@ -70,35 +59,28 @@ impl RawSocket {
                     .clone()
                     .unwrap_or_default();
                 let need = core::cmp::min(name.len() + 1, IFNAMSIZ);
-                if value.len() < need {
-                    return Err(SystemError::EINVAL);
-                }
-                if need == 0 {
+                if need == 0 || value.is_empty() {
                     return Ok(0);
                 }
                 let bytes = name.as_bytes();
-                let copy_len = core::cmp::min(bytes.len(), need.saturating_sub(1));
+                let name_len = core::cmp::min(bytes.len(), need.saturating_sub(1));
+                let len = core::cmp::min(value.len(), need);
+                let copy_len = core::cmp::min(name_len, len.saturating_sub(1));
                 value[..copy_len].copy_from_slice(&bytes[..copy_len]);
-                value[copy_len] = 0;
-                Ok(need)
+                if copy_len < len {
+                    value[copy_len] = 0;
+                }
+                Ok(len)
             }
             Ok(PSO::LINGER) => {
-                if value.len() < 8 {
-                    return Err(SystemError::EINVAL);
-                }
                 let opts = self.options.read();
-                value[..4].copy_from_slice(&opts.linger_onoff.to_ne_bytes());
-                value[4..8].copy_from_slice(&opts.linger_linger.to_ne_bytes());
-                Ok(8)
+                Ok(write_linger_getsockopt(
+                    value,
+                    opts.linger_onoff,
+                    opts.linger_linger,
+                ))
             }
-            Ok(PSO::ACCEPTCONN) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = 0i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
-            }
+            Ok(PSO::ACCEPTCONN) => Ok(write_i32_getsockopt(value, 0)),
             Ok(PSO::DETACH_FILTER) => Err(SystemError::ENOPROTOOPT),
             _ => Err(SystemError::ENOPROTOOPT),
         }
@@ -114,12 +96,8 @@ impl RawSocket {
                 if self.protocol != IpProtocol::Icmp {
                     return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
                 }
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let mask = self.options.read().icmp_filter.get_mask();
-                value[..4].copy_from_slice(&mask.to_ne_bytes());
-                Ok(4)
+                Ok(write_u32_getsockopt(value, mask))
             }
             _ => Err(SystemError::ENOPROTOOPT),
         }
@@ -131,71 +109,35 @@ impl RawSocket {
         value: &mut [u8],
     ) -> Result<usize, SystemError> {
         match IpOption::try_from(name as u32) {
-            Ok(IpOption::HDRINCL) => {
-                let v = if self.options.read().ip_hdrincl {
-                    1i32
-                } else {
-                    0i32
-                };
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
-            }
-            Ok(IpOption::TOS) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = self.options.read().ip_tos as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
-            }
-            Ok(IpOption::TTL) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = self.options.read().ip_ttl as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
-            }
-            Ok(IpOption::PKTINFO) => {
-                let v = if self.options.read().recv_pktinfo_v4 {
-                    1i32
-                } else {
-                    0i32
-                };
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
-            }
-            Ok(IpOption::RECVTTL) => {
-                let v = if self.options.read().recv_ttl {
-                    1i32
-                } else {
-                    0i32
-                };
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
-            }
-            Ok(IpOption::RECVTOS) => {
-                let v = if self.options.read().recv_tos {
-                    1i32
-                } else {
-                    0i32
-                };
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
-            }
+            Ok(IpOption::HDRINCL) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().ip_hdrincl as i32,
+            )),
+            Ok(IpOption::TOS) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().ip_tos as i32,
+            )),
+            Ok(IpOption::TTL) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().ip_ttl as i32,
+            )),
+            Ok(IpOption::PKTINFO) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().recv_pktinfo_v4 as i32,
+            )),
+            Ok(IpOption::RECVTTL) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().recv_ttl as i32,
+            )),
+            Ok(IpOption::RECVTOS) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().recv_tos as i32,
+            )),
             Ok(IpOption::MULTICAST_IF) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self
                     .ip_multicast_addr
                     .load(core::sync::atomic::Ordering::Relaxed);
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_u32_getsockopt(value, v))
             }
             _ => Err(SystemError::ENOPROTOOPT),
         }
@@ -216,57 +158,28 @@ impl RawSocket {
                 } else {
                     self.options.read().ipv6_checksum
                 };
-                // Linux do_rawv6_getsockopt: len = min(sizeof(int), user_len)
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
+                Ok(write_i32_getsockopt(value, v))
             }
-            Ok(PIPV6::UNICAST_HOPS) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = self.options.read().ip_ttl as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
-            }
-            Ok(PIPV6::TCLASS) => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
-                let v = self.options.read().ip_tos as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
-            }
-            Ok(PIPV6::RECVPKTINFO) => {
-                let v = if self.options.read().recv_pktinfo_v6 {
-                    1i32
-                } else {
-                    0i32
-                };
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
-            }
-            Ok(PIPV6::RECVHOPLIMIT) => {
-                let v = if self.options.read().recv_hoplimit {
-                    1i32
-                } else {
-                    0i32
-                };
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
-            }
-            Ok(PIPV6::RECVTCLASS) => {
-                let v = if self.options.read().recv_tclass {
-                    1i32
-                } else {
-                    0i32
-                };
-                let len = core::cmp::min(value.len(), 4);
-                value[..len].copy_from_slice(&v.to_ne_bytes()[..len]);
-                Ok(len)
-            }
+            Ok(PIPV6::UNICAST_HOPS) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().ip_ttl as i32,
+            )),
+            Ok(PIPV6::TCLASS) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().ip_tos as i32,
+            )),
+            Ok(PIPV6::RECVPKTINFO) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().recv_pktinfo_v6 as i32,
+            )),
+            Ok(PIPV6::RECVHOPLIMIT) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().recv_hoplimit as i32,
+            )),
+            Ok(PIPV6::RECVTCLASS) => Ok(write_i32_getsockopt(
+                value,
+                self.options.read().recv_tclass as i32,
+            )),
             _ => Err(SystemError::ENOPROTOOPT),
         }
     }

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -9,7 +9,7 @@ use super::constants::{
 use super::options::DEFAULT_IP_TTL;
 use super::{Icmp6Filter, RawSocket};
 use crate::net::socket::common::{
-    write_i32_getsockopt, write_linger_getsockopt, write_u32_getsockopt,
+    write_i32_getsockopt, write_i32_getsockopt_ipv4, write_linger_getsockopt, write_u32_getsockopt,
 };
 use crate::net::socket::inet::common::{apply_ipv4_membership, apply_ipv4_multicast_if};
 use crate::net::socket::{IpOption, IFNAMSIZ, PIPV6, PRAW, PSO};
@@ -109,27 +109,27 @@ impl RawSocket {
         value: &mut [u8],
     ) -> Result<usize, SystemError> {
         match IpOption::try_from(name as u32) {
-            Ok(IpOption::HDRINCL) => Ok(write_i32_getsockopt(
+            Ok(IpOption::HDRINCL) => Ok(write_i32_getsockopt_ipv4(
                 value,
                 self.options.read().ip_hdrincl as i32,
             )),
-            Ok(IpOption::TOS) => Ok(write_i32_getsockopt(
+            Ok(IpOption::TOS) => Ok(write_i32_getsockopt_ipv4(
                 value,
                 self.options.read().ip_tos as i32,
             )),
-            Ok(IpOption::TTL) => Ok(write_i32_getsockopt(
+            Ok(IpOption::TTL) => Ok(write_i32_getsockopt_ipv4(
                 value,
                 self.options.read().ip_ttl as i32,
             )),
-            Ok(IpOption::PKTINFO) => Ok(write_i32_getsockopt(
+            Ok(IpOption::PKTINFO) => Ok(write_i32_getsockopt_ipv4(
                 value,
                 self.options.read().recv_pktinfo_v4 as i32,
             )),
-            Ok(IpOption::RECVTTL) => Ok(write_i32_getsockopt(
+            Ok(IpOption::RECVTTL) => Ok(write_i32_getsockopt_ipv4(
                 value,
                 self.options.read().recv_ttl as i32,
             )),
-            Ok(IpOption::RECVTOS) => Ok(write_i32_getsockopt(
+            Ok(IpOption::RECVTOS) => Ok(write_i32_getsockopt_ipv4(
                 value,
                 self.options.read().recv_tos as i32,
             )),

--- a/kernel/src/net/socket/inet/raw/sockopt.rs
+++ b/kernel/src/net/socket/inet/raw/sockopt.rs
@@ -9,7 +9,8 @@ use super::constants::{
 use super::options::DEFAULT_IP_TTL;
 use super::{Icmp6Filter, RawSocket};
 use crate::net::socket::common::{
-    write_i32_getsockopt, write_i32_getsockopt_ipv4, write_linger_getsockopt, write_u32_getsockopt,
+    parse_timeval_opt, write_i32_getsockopt, write_i32_getsockopt_ipv4, write_linger_getsockopt,
+    write_timeval_opt, write_u32_getsockopt,
 };
 use crate::net::socket::inet::common::{apply_ipv4_membership, apply_ipv4_multicast_if};
 use crate::net::socket::{IpOption, IFNAMSIZ, PIPV6, PRAW, PSO};
@@ -81,6 +82,16 @@ impl RawSocket {
                 ))
             }
             Ok(PSO::ACCEPTCONN) => Ok(write_i32_getsockopt(value, 0)),
+            Ok(PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW) => {
+                let us = self.send_timeout_us.load(core::sync::atomic::Ordering::Relaxed);
+                let us = if us == u64::MAX { 0 } else { us };
+                Ok(write_timeval_opt(value, us))
+            }
+            Ok(PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW) => {
+                let us = self.recv_timeout_us.load(core::sync::atomic::Ordering::Relaxed);
+                let us = if us == u64::MAX { 0 } else { us };
+                Ok(write_timeval_opt(value, us))
+            }
             Ok(PSO::DETACH_FILTER) => Err(SystemError::ENOPROTOOPT),
             _ => Err(SystemError::ENOPROTOOPT),
         }
@@ -275,6 +286,20 @@ impl RawSocket {
                 let mut opts = self.options.write();
                 opts.linger_onoff = if l_onoff != 0 { 1 } else { 0 };
                 opts.linger_linger = l_linger;
+                Ok(())
+            }
+            Ok(PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW) => {
+                let d = parse_timeval_opt(val)?;
+                let us = d.map(|v| v.total_micros()).unwrap_or(u64::MAX);
+                self.send_timeout_us
+                    .store(us, core::sync::atomic::Ordering::Relaxed);
+                Ok(())
+            }
+            Ok(PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW) => {
+                let d = parse_timeval_opt(val)?;
+                let us = d.map(|v| v.total_micros()).unwrap_or(u64::MAX);
+                self.recv_timeout_us
+                    .store(us, core::sync::atomic::Ordering::Relaxed);
                 Ok(())
             }
             _ => Err(SystemError::ENOPROTOOPT),

--- a/kernel/src/net/socket/inet/stream/option.rs
+++ b/kernel/src/net/socket/inet/stream/option.rs
@@ -151,28 +151,21 @@ impl super::TcpSocket {
     /// Helper to write a u32 value to an option buffer.
     #[inline]
     fn write_u32_opt(value: &mut [u8], v: u32) -> Result<usize, SystemError> {
-        if value.len() < 4 {
-            return Err(SystemError::EINVAL);
-        }
-        value[..4].copy_from_slice(&v.to_ne_bytes());
-        Ok(4)
+        Ok(crate::net::socket::common::write_u32_getsockopt(value, v))
     }
 
     /// Helper to write an i32 value to an option buffer.
     #[inline]
     fn write_i32_opt(value: &mut [u8], v: i32) -> Result<usize, SystemError> {
-        Self::write_u32_opt(value, v as u32)
+        Ok(crate::net::socket::common::write_i32_getsockopt(value, v))
     }
 
     /// Helper to write a linger struct (two i32 fields) to an option buffer.
     #[inline]
     fn write_linger_opt(value: &mut [u8], onoff: i32, linger: i32) -> Result<usize, SystemError> {
-        if value.len() < 8 {
-            return Err(SystemError::EINVAL);
-        }
-        value[..4].copy_from_slice(&onoff.to_ne_bytes());
-        value[4..8].copy_from_slice(&linger.to_ne_bytes());
-        Ok(8)
+        Ok(crate::net::socket::common::write_linger_getsockopt(
+            value, onoff, linger,
+        ))
     }
 
     /// Helper to read an atomic usize value and write as u32 to an option buffer.

--- a/kernel/src/net/socket/inet/stream/option.rs
+++ b/kernel/src/net/socket/inet/stream/option.rs
@@ -552,14 +552,14 @@ impl super::TcpSocket {
                     .send_timeout_us()
                     .load(core::sync::atomic::Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW => {
                 let us = self
                     .recv_timeout_us()
                     .load(core::sync::atomic::Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             PSO::RCVLOWAT => {
                 let v = self

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -309,12 +309,12 @@ where
             PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             PSO::RCVTIMEO_OLD | PSO::RCVTIMEO_NEW => {
                 let us = self.recv_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             _ => Err(SystemError::ENOPROTOOPT),
         }

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     net::{
         posix::SockAddr,
         socket::{
-            common::{parse_timeval_opt, write_timeval_opt},
+            common::{parse_timeval_opt, write_i32_getsockopt, write_timeval_opt},
             endpoint::Endpoint,
             netlink::{
                 addr::{multicast::GroupIdSet, NetlinkSocketAddr},
@@ -283,28 +283,16 @@ where
         let opt = PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
         match opt {
             PSO::TYPE => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.socket_type as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             PSO::DOMAIN => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = AddressFamily::Netlink as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             PSO::PROTOCOL => {
-                if value.len() < core::mem::size_of::<i32>() {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.protocol as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             PSO::SNDTIMEO_OLD | PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);

--- a/kernel/src/net/socket/unix/datagram/mod.rs
+++ b/kernel/src/net/socket/unix/datagram/mod.rs
@@ -14,7 +14,10 @@ use crate::{
         posix::MsgHdr,
         socket::{
             self,
-            common::{parse_timeval_opt, write_timeval_opt, EPollItems},
+            common::{
+                parse_timeval_opt, write_i32_getsockopt, write_timeval_opt, write_u32_getsockopt,
+                EPollItems,
+            },
             endpoint::Endpoint,
             unix::{UnixEndpoint, UnixEndpointBound},
             AddressFamily, Socket, PMSG, PSOCK, PSOL,
@@ -1258,44 +1261,24 @@ impl Socket for UnixDatagramSocket {
             crate::net::socket::PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
         match opt {
             crate::net::socket::PSO::TYPE => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = PSOCK::Datagram as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::DOMAIN => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = AddressFamily::Unix as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::PROTOCOL => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v: i32 = 0;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::SNDBUF => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.send_buffer_size() as u32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_u32_getsockopt(value, v))
             }
             crate::net::socket::PSO::RCVBUF => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.recv_buffer_size() as u32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_u32_getsockopt(value, v))
             }
             crate::net::socket::PSO::SNDTIMEO_OLD | crate::net::socket::PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);
@@ -1308,24 +1291,16 @@ impl Socket for UnixDatagramSocket {
                 Ok(write_timeval_opt(value, us))
             }
             crate::net::socket::PSO::RCVLOWAT => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.rcvlowat.load(Ordering::Relaxed);
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::PASSCRED => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v: i32 = if self.passcred.load(Ordering::Acquire) {
                     1
                 } else {
                     0
                 };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             _ => Err(SystemError::ENOPROTOOPT),
         }

--- a/kernel/src/net/socket/unix/datagram/mod.rs
+++ b/kernel/src/net/socket/unix/datagram/mod.rs
@@ -1300,12 +1300,12 @@ impl Socket for UnixDatagramSocket {
             crate::net::socket::PSO::SNDTIMEO_OLD | crate::net::socket::PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             crate::net::socket::PSO::RCVTIMEO_OLD | crate::net::socket::PSO::RCVTIMEO_NEW => {
                 let us = self.recv_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             crate::net::socket::PSO::RCVLOWAT => {
                 if value.len() < 4 {

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -1397,12 +1397,12 @@ impl Socket for UnixStreamSocket {
             crate::net::socket::PSO::SNDTIMEO_OLD | crate::net::socket::PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             crate::net::socket::PSO::RCVTIMEO_OLD | crate::net::socket::PSO::RCVTIMEO_NEW => {
                 let us = self.recv_timeout_us.load(Ordering::Relaxed);
                 let us = if us == u64::MAX { 0 } else { us };
-                write_timeval_opt(value, us)
+                Ok(write_timeval_opt(value, us))
             }
             crate::net::socket::PSO::RCVLOWAT => {
                 if value.len() < 4 {

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -14,7 +14,10 @@ use crate::{
     net::{
         posix::MsgHdr,
         socket::{
-            common::{parse_timeval_opt, write_timeval_opt, EPollItems},
+            common::{
+                parse_timeval_opt, write_i32_getsockopt, write_linger_getsockopt,
+                write_timeval_opt, write_u32_getsockopt, EPollItems,
+            },
             endpoint::Endpoint,
             unix::{
                 stream::inner::{get_backlog, Backlog},
@@ -65,13 +68,8 @@ impl Linger {
         Ok(Self { l_onoff, l_linger })
     }
 
-    fn write_to(&self, out: &mut [u8]) -> Result<usize, SystemError> {
-        if out.len() < Self::SIZE {
-            return Err(SystemError::EINVAL);
-        }
-        out[..4].copy_from_slice(&self.l_onoff.to_ne_bytes());
-        out[4..8].copy_from_slice(&self.l_linger.to_ne_bytes());
-        Ok(Self::SIZE)
+    fn write_to(&self, out: &mut [u8]) -> usize {
+        write_linger_getsockopt(out, self.l_onoff, self.l_linger)
     }
 }
 
@@ -1351,48 +1349,28 @@ impl Socket for UnixStreamSocket {
             crate::net::socket::PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
         match opt {
             crate::net::socket::PSO::TYPE => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = if self.is_seqpacket {
                     PSOCK::SeqPacket as i32
                 } else {
                     PSOCK::Stream as i32
                 };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::DOMAIN => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = AddressFamily::Unix as i32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::PROTOCOL => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v: i32 = 0;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::SNDBUF => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.send_buffer_size() as u32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_u32_getsockopt(value, v))
             }
             crate::net::socket::PSO::RCVBUF => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.recv_buffer_size() as u32;
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_u32_getsockopt(value, v))
             }
             crate::net::socket::PSO::SNDTIMEO_OLD | crate::net::socket::PSO::SNDTIMEO_NEW => {
                 let us = self.send_timeout_us.load(Ordering::Relaxed);
@@ -1405,33 +1383,22 @@ impl Socket for UnixStreamSocket {
                 Ok(write_timeval_opt(value, us))
             }
             crate::net::socket::PSO::RCVLOWAT => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v = self.rcvlowat.load(Ordering::Relaxed);
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::PASSCRED => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let v: i32 = if self.passcred.load(Ordering::Relaxed) {
                     1
                 } else {
                     0
                 };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             crate::net::socket::PSO::LINGER => {
                 let linger = *self.linger.lock();
-                linger.write_to(value)
+                Ok(linger.write_to(value))
             }
             crate::net::socket::PSO::ACCEPTCONN => {
-                if value.len() < 4 {
-                    return Err(SystemError::EINVAL);
-                }
                 let is_listening = matches!(
                     self.inner
                         .read()
@@ -1440,8 +1407,7 @@ impl Socket for UnixStreamSocket {
                     Inner::Listener(_)
                 );
                 let v: i32 = if is_listening { 1 } else { 0 };
-                value[..4].copy_from_slice(&v.to_ne_bytes());
-                Ok(4)
+                Ok(write_i32_getsockopt(value, v))
             }
             _ => Err(SystemError::ENOPROTOOPT),
         }

--- a/kernel/src/net/socket/vsock/stream.rs
+++ b/kernel/src/net/socket/vsock/stream.rs
@@ -21,7 +21,7 @@ use crate::filesystem::vfs::{
 };
 use crate::libs::mutex::Mutex;
 use crate::libs::wait_queue::WaitQueue;
-use crate::net::socket::common::{EPollItems, ShutdownBit};
+use crate::net::socket::common::{write_i32_getsockopt, EPollItems, ShutdownBit};
 use crate::net::socket::endpoint::Endpoint;
 use crate::net::socket::{RecvFromAddrBehavior, Socket, PMSG, PSO, PSOL};
 
@@ -1421,15 +1421,6 @@ impl Socket for VsockStreamSocket {
     /// - `PSOL::VSOCK` 当前返回 `ENOPROTOOPT`
     /// - 其他层级返回 `ENOSYS`
     fn option(&self, level: PSOL, name: usize, value: &mut [u8]) -> Result<usize, SystemError> {
-        #[inline]
-        fn write_i32_opt(value: &mut [u8], v: i32) -> Result<usize, SystemError> {
-            if value.len() < core::mem::size_of::<i32>() {
-                return Err(SystemError::EINVAL);
-            }
-            value[..4].copy_from_slice(&v.to_ne_bytes());
-            Ok(core::mem::size_of::<i32>())
-        }
-
         match level {
             PSOL::SOCKET => {
                 let opt = PSO::try_from(name as u32).map_err(|_| SystemError::ENOPROTOOPT)?;
@@ -1442,7 +1433,7 @@ impl Socket for VsockStreamSocket {
                             .take()
                             .map(|e| -e.to_posix_errno())
                             .unwrap_or(0);
-                        write_i32_opt(value, err)
+                        Ok(write_i32_getsockopt(value, err))
                     }
                     _ => Err(SystemError::ENOPROTOOPT),
                 }

--- a/kernel/src/net/syscall/sys_getsockopt.rs
+++ b/kernel/src/net/syscall/sys_getsockopt.rs
@@ -193,7 +193,8 @@ pub(super) fn do_getsockopt(
             _ => {
                 // 其它 SOL_SOCKET 选项交给具体 socket 实现。
                 // 这里采用"内核缓冲区 -> copy_to_user"的方式，避免假设 optval 是 u32。
-                let mut kbuf = [0u8; 64];
+                let kbuf_len = user_len.min(MAX_OPTVAL_LEN);
+                let mut kbuf = vec![0u8; kbuf_len];
                 let written = socket.option(level, optname, &mut kbuf)?;
                 let out_len = calc_out_len(optval, user_len, written);
 
@@ -238,7 +239,8 @@ pub(super) fn do_getsockopt(
             optval_writer.copy_to_user_protected(&kbuf[..out_len], 0)?;
         }
 
-        // Linux 语义：optlen 回写实际拷贝长度 min(user_len, option_size)。
+        // Linux 语义：*optlen 回写实际输出长度；optval != NULL 时为 min(user_len, written)，
+        // optval == NULL 时为 written（用于探测选项大小）。
         let mut optlen_writer =
             UserBufferWriter::new(optlen, core::mem::size_of::<u32>(), from_user)?;
         optlen_writer

--- a/kernel/src/net/syscall/sys_getsockopt.rs
+++ b/kernel/src/net/syscall/sys_getsockopt.rs
@@ -228,7 +228,7 @@ pub(super) fn do_getsockopt(
     // 其它 level（如 SOL_IP/SOL_IPV6/SOL_RAW 等）交给具体 socket 实现。
     // gVisor raw_socket_test: getsockopt(SOL_IPV6, IPV6_CHECKSUM) 等
     {
-        let kbuf_len = user_len.clamp(64, MAX_OPTVAL_LEN);
+        let kbuf_len = user_len.min(MAX_OPTVAL_LEN);
         let mut kbuf = vec![0u8; kbuf_len];
         let written = socket.option(level, optname, &mut kbuf)?;
         let out_len = calc_out_len(optval, user_len, written);
@@ -238,6 +238,7 @@ pub(super) fn do_getsockopt(
             optval_writer.copy_to_user_protected(&kbuf[..out_len], 0)?;
         }
 
+        // Linux 语义：optlen 回写实际拷贝长度 min(user_len, option_size)。
         let mut optlen_writer =
             UserBufferWriter::new(optlen, core::mem::size_of::<u32>(), from_user)?;
         optlen_writer

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -1356,6 +1356,7 @@ impl CfsRunQueue {
         let curr = self.current();
         self.pick_eevdf_entity(curr.as_ref())
             .or_else(|| self.entities.leftmost())
+            .or_else(|| curr.filter(|se| se.on_rq()))
     }
 
     pub fn entity_eligible(&self, se: &Arc<FairSchedEntity>) -> bool {
@@ -1573,7 +1574,12 @@ impl Scheduler for CompletelyFairScheduler {
 
         rq.clock_updata_flags |= ClockUpdataFlag::RQCF_REQ_SKIP;
 
-        se.force_mut().deadline += se.calculate_delta_fair(se.slice);
+        if cfs_rq.entity_eligible(&se) {
+            let se_mut = se.force_mut();
+            se_mut.vruntime = se_mut.deadline;
+            se_mut.deadline += se_mut.calculate_delta_fair(se_mut.slice);
+            cfs_rq.update_min_vruntime();
+        }
     }
 
     fn check_preempt_currnet(

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -679,6 +679,9 @@ impl CpuRunQueue {
         let next_policy = pcb.sched_info().policy();
 
         if current.flags().contains(ProcessFlags::NEED_SCHEDULE) {
+            if current_policy == SchedPolicy::IDLE {
+                self.resched_current();
+            }
             return;
         }
 
@@ -864,25 +867,17 @@ impl CpuRunQueue {
     /// 重新调度当前进程
     pub fn resched_current(&self) {
         let current = self.current();
+        let cpu = self.cpu;
+        let already_requested = current.flags().contains(ProcessFlags::NEED_SCHEDULE);
+        current.flags().insert(ProcessFlags::NEED_SCHEDULE);
 
-        // 又需要被调度？
-        if unlikely(current.flags().contains(ProcessFlags::NEED_SCHEDULE)) {
+        if cpu == smp_get_processor_id() {
             return;
         }
 
-        let cpu = self.cpu;
-
-        if cpu == smp_get_processor_id() {
-            // assert!(
-            //     Arc::ptr_eq(&current, &ProcessManager::current_pcb()),
-            //     "rq current name {} process current {}",
-            //     current.basic().name().to_string(),
-            //     ProcessManager::current_pcb().basic().name().to_string(),
-            // );
-            // 设置需要调度
-            ProcessManager::current_pcb()
-                .flags()
-                .insert(ProcessFlags::NEED_SCHEDULE);
+        // A remote idle CPU may be halted; kick it even if the flag was already
+        // set so it observes the pending reschedule promptly.
+        if already_requested && current.sched_info().policy() != SchedPolicy::IDLE {
             return;
         }
 
@@ -902,6 +897,18 @@ impl CpuRunQueue {
 
         if next.is_none() {
             next = CompletelyFairScheduler::pick_next_task(self, Some(prev.clone()));
+        }
+
+        if next.is_none()
+            && !task_is_idle(&prev)
+            && prev
+                .sched_info()
+                .inner_lock_read_irqsave()
+                .state()
+                .is_runnable()
+            && *prev.sched_info().on_rq.lock_irqsave() == OnRq::Queued
+        {
+            next = Some(prev.clone());
         }
 
         let next = next.unwrap_or_else(|| self.idle.upgrade().unwrap());

--- a/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
@@ -37,6 +37,44 @@ std::string ErrnoString(int err) {
     return std::to_string(err) + " (" + std::strerror(err) + ")";
 }
 
+void ExpectIntOptionPrefix(int fd, int level, int optname, int expected, socklen_t request_len) {
+    unsigned char value[sizeof(int)] = {0xaa, 0xaa, 0xaa, 0xaa};
+    unsigned char expected_bytes[sizeof(int)] = {};
+    std::memcpy(expected_bytes, &expected, sizeof(expected));
+
+    socklen_t len = request_len;
+    ASSERT_EQ(getsockopt(fd, level, optname, value, &len), 0)
+            << "getsockopt(" << level << ", " << optname << ") failed: " << ErrnoString(errno);
+    EXPECT_EQ(len, request_len);
+
+    for (socklen_t i = 0; i < request_len; ++i) {
+        EXPECT_EQ(value[i], expected_bytes[i]) << "byte " << i;
+    }
+    for (size_t i = request_len; i < sizeof(value); ++i) {
+        EXPECT_EQ(value[i], 0xaa) << "byte " << i << " should remain untouched";
+    }
+}
+
+void ExpectLingerPrefix(int fd, const struct linger& expected, socklen_t request_len) {
+    unsigned char value[sizeof(struct linger)] = {};
+    std::memset(value, 0xaa, sizeof(value));
+
+    unsigned char expected_bytes[sizeof(struct linger)] = {};
+    std::memcpy(expected_bytes, &expected, sizeof(expected));
+
+    socklen_t len = request_len;
+    ASSERT_EQ(getsockopt(fd, SOL_SOCKET, SO_LINGER, value, &len), 0)
+            << "getsockopt(SO_LINGER) failed: " << ErrnoString(errno);
+    EXPECT_EQ(len, request_len);
+
+    for (socklen_t i = 0; i < request_len; ++i) {
+        EXPECT_EQ(value[i], expected_bytes[i]) << "byte " << i;
+    }
+    for (size_t i = request_len; i < sizeof(value); ++i) {
+        EXPECT_EQ(value[i], 0xaa) << "byte " << i << " should remain untouched";
+    }
+}
+
 }  // namespace
 
 TEST(SocketGetsockoptSemantics, IpMulticastIfReturnsRequestedInAddrPrefix) {
@@ -77,6 +115,76 @@ TEST(SocketGetsockoptSemantics, BindToDeviceRequiresIfnameSizedBufferWhenBound) 
             << "getsockopt(SO_BINDTODEVICE) failed: " << ErrnoString(errno);
     EXPECT_STREQ(full, device);
     EXPECT_EQ(full_len, sizeof(device));
+}
+
+TEST(SocketGetsockoptSemantics, UnixDatagramScalarOptionsAllowShortBuffers) {
+    FdGuard fd(socket(AF_UNIX, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_UNIX, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_TYPE, SOCK_DGRAM, 1);
+    ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_DOMAIN, AF_UNIX, 2);
+    ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_PROTOCOL, 0, 2);
+}
+
+TEST(SocketGetsockoptSemantics, UnixStreamScalarOptionsAllowShortBuffers) {
+    FdGuard fd(socket(AF_UNIX, SOCK_STREAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_UNIX, SOCK_STREAM) failed: " << ErrnoString(errno);
+
+    ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_TYPE, SOCK_STREAM, 1);
+    ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_DOMAIN, AF_UNIX, 2);
+    ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_PROTOCOL, 0, 2);
+    ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_ACCEPTCONN, 0, 1);
+}
+
+TEST(SocketGetsockoptSemantics, UnixStreamLingerAllowsShortBuffers) {
+    FdGuard fd(socket(AF_UNIX, SOCK_STREAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_UNIX, SOCK_STREAM) failed: " << ErrnoString(errno);
+
+    struct linger expected = {};
+    expected.l_onoff = 1;
+    expected.l_linger = 7;
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, SO_LINGER, &expected, sizeof(expected)), 0)
+            << "setsockopt(SO_LINGER) failed: " << ErrnoString(errno);
+
+    ExpectLingerPrefix(fd.Get(), expected, 1);
+    ExpectLingerPrefix(fd.Get(), expected, sizeof(expected) - 1);
+
+    struct linger full = {};
+    socklen_t full_len = sizeof(full);
+    ASSERT_EQ(getsockopt(fd.Get(), SOL_SOCKET, SO_LINGER, &full, &full_len), 0)
+            << "getsockopt(SO_LINGER) failed: " << ErrnoString(errno);
+    EXPECT_EQ(full_len, sizeof(full));
+    EXPECT_EQ(full.l_onoff, expected.l_onoff);
+    EXPECT_EQ(full.l_linger, expected.l_linger);
+}
+
+TEST(SocketGetsockoptSemantics, Ipv6IntOptionsUseGenericPrefixCopy) {
+    FdGuard fd(socket(AF_INET6, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET6, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    int enabled = 1;
+    ASSERT_EQ(setsockopt(fd.Get(), IPPROTO_IPV6, IPV6_RECVTCLASS, &enabled, sizeof(enabled)), 0)
+            << "setsockopt(IPV6_RECVTCLASS) failed: " << ErrnoString(errno);
+
+    ExpectIntOptionPrefix(fd.Get(), IPPROTO_IPV6, IPV6_RECVTCLASS, enabled, 2);
+    ExpectIntOptionPrefix(fd.Get(), IPPROTO_IPV6, IPV6_RECVTCLASS, enabled, 3);
+}
+
+TEST(SocketGetsockoptSemantics, Ipv4IntOptionsKeepOneByteShortBufferSpecialCase) {
+    FdGuard fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    int ttl = 42;
+    ASSERT_EQ(setsockopt(fd.Get(), IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)), 0)
+            << "setsockopt(IP_MULTICAST_TTL) failed: " << ErrnoString(errno);
+
+    unsigned char value[2] = {0xaa, 0xaa};
+    socklen_t len = sizeof(value);
+    ASSERT_EQ(getsockopt(fd.Get(), IPPROTO_IP, IP_MULTICAST_TTL, value, &len), 0)
+            << "getsockopt(IP_MULTICAST_TTL) failed: " << ErrnoString(errno);
+    EXPECT_EQ(len, 1u);
+    EXPECT_EQ(value[0], static_cast<unsigned char>(ttl));
+    EXPECT_EQ(value[1], 0xaa);
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+
+namespace {
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+
+    ~FdGuard() { Reset(); }
+
+    int Get() const { return fd_; }
+
+    void Reset(int fd = -1) {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        fd_ = fd;
+    }
+
+  private:
+    int fd_;
+};
+
+std::string ErrnoString(int err) {
+    return std::to_string(err) + " (" + std::strerror(err) + ")";
+}
+
+}  // namespace
+
+TEST(SocketGetsockoptSemantics, IpMulticastIfReturnsRequestedInAddrPrefix) {
+    FdGuard fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET, SOCK_DGRAM) failed: " << ErrnoString(errno);
+
+    unsigned char value[4] = {0xaa, 0xaa, 0xaa, 0xaa};
+    socklen_t len = 2;
+    ASSERT_EQ(getsockopt(fd.Get(), IPPROTO_IP, IP_MULTICAST_IF, value, &len), 0)
+            << "getsockopt(IP_MULTICAST_IF) failed: " << ErrnoString(errno);
+
+    EXPECT_EQ(len, 2u);
+    EXPECT_EQ(value[0], 0);
+    EXPECT_EQ(value[1], 0);
+    EXPECT_EQ(value[2], 0xaa);
+    EXPECT_EQ(value[3], 0xaa);
+}
+
+TEST(SocketGetsockoptSemantics, BindToDeviceRequiresIfnameSizedBufferWhenBound) {
+    FdGuard fd(socket(AF_INET, SOCK_RAW, IPPROTO_ICMP));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET, SOCK_RAW, IPPROTO_ICMP) failed: "
+                           << ErrnoString(errno);
+
+    const char device[] = "lo";
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, SO_BINDTODEVICE, device, sizeof(device)), 0)
+            << "setsockopt(SO_BINDTODEVICE) failed: " << ErrnoString(errno);
+
+    char small[IFNAMSIZ - 1] = {};
+    socklen_t small_len = sizeof(small);
+    errno = 0;
+    EXPECT_EQ(getsockopt(fd.Get(), SOL_SOCKET, SO_BINDTODEVICE, small, &small_len), -1);
+    EXPECT_EQ(errno, EINVAL);
+    EXPECT_EQ(small_len, sizeof(small));
+
+    char full[IFNAMSIZ] = {};
+    socklen_t full_len = sizeof(full);
+    ASSERT_EQ(getsockopt(fd.Get(), SOL_SOCKET, SO_BINDTODEVICE, full, &full_len), 0)
+            << "getsockopt(SO_BINDTODEVICE) failed: " << ErrnoString(errno);
+    EXPECT_STREQ(full, device);
+    EXPECT_EQ(full_len, sizeof(device));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -22,6 +22,7 @@ normal/test_tlb_shootdown
 normal/pid_namespace_fork
 normal/tcp_close_semantics
 normal/udp_ipv6_send_semantics
+normal/socket_getsockopt_semantics
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link


### PR DESCRIPTION
**1. 未绑定 socket 的 IPv6 路由与错误码 / IPv6 routing and errno for unbound sockets**

修复未绑定 socket 向 IPv6 回环地址（如 `::1`）发送/连接时的接口选择，新增 loopback 接口匹配；无可用源地址时，IPv6 回环目标返回 `EADDRNOTAVAIL`，其余情况返回 `ENETUNREACH`，对齐 Linux 6.6 / gVisor `socket_ip_unbound_netlink` 语义。

Fixes interface selection when an unbound socket sends/connects to IPv6 loopback destinations (e.g. `::1`), including loopback interface matching. When no local source address is available, IPv6 loopback targets return `EADDRNOTAVAIL` while other cases return `ENETUNREACH`, matching Linux 6.6 / gVisor `socket_ip_unbound_netlink` semantics.

---

**2. 统一 getsockopt 值写入 helper / Unified getsockopt value writers**

新增 `write_i32_getsockopt`、`write_i32_getsockopt_ipv4`、`write_u32_getsockopt`、`write_linger_getsockopt` 等公共函数，按 Linux 语义将选项值截断写入用户缓冲区（`min(user_len, option_size)`），替代各 socket 类型中重复的拷贝逻辑。

Adds shared helpers such as `write_i32_getsockopt`, `write_i32_getsockopt_ipv4`, `write_u32_getsockopt`, and `write_linger_getsockopt` to write option values with Linux-aligned truncation (`min(user_len, option_size)`), replacing duplicated copy logic across socket types.

---

**3. SOL_IP 的 IPv4 特殊拷贝语义 / IPv4-specific copy semantics for SOL_IP**

`SOL_IP` 级别选项在 `0 < len < 4` 且值在 0–255 时只拷贝 1 字节；`SOL_IPV6` / 通用 socket 选项则按 `min(len, 4)` 拷贝，修复 gVisor raw socket 等测例对短缓冲区的预期。

For `SOL_IP` options, when `0 < len < 4` and the value is in 0–255, only one byte is copied; for `SOL_IPV6` and generic socket options, `min(len, 4)` bytes are copied, fixing short-buffer expectations in gVisor raw socket tests.

---

**4. timeval 选项处理 / Timeval option handling**

`write_timeval_opt` 不再要求缓冲区至少 16 字节，改为按用户缓冲区长度截断写入；UDP/TCP/Raw/Netlink/Unix socket 统一使用该行为。

`write_timeval_opt` no longer requires a 16-byte buffer and instead truncates output to the user buffer length; UDP/TCP/Raw/Netlink/Unix sockets all adopt this behavior.

---

**5. getsockopt 系统调用缓冲区大小修复 / getsockopt syscall buffer sizing fix**

`do_getsockopt` 的内核缓冲区按 `user_len` 分配（不再固定 64 字节或对 SOL_IP 强制 `clamp(64, MAX)`），使短缓冲区测例能正确验证截断拷贝行为。

`do_getsockopt` now allocates the kernel buffer based on `user_len` (instead of a fixed 64 bytes or `clamp(64, MAX)` for SOL_IP), so short-buffer tests correctly validate truncated copy behavior.

---

**6. UDP socket 实现 SO_ERROR / UDP SO_ERROR support**

为 UDP 增加 `so_error` 字段及 `store_so_error` / `take_so_error`；`getsockopt(SO_ERROR)` 读取并清零 pending 错误，`sendmsg` 隐式 bind 失败时会记录错误。

Adds `so_error` with `store_so_error` / `take_so_error` for UDP; `getsockopt(SO_ERROR)` reads and clears pending errors, and implicit bind failures in `sendmsg` are recorded.

---

**7. Raw socket 收发超时支持 / Raw socket send/receive timeout support**

为 Raw socket 新增 `SO_SNDTIMEO` / `SO_RCVTIMEO` 的 get/set 及内部存储；阻塞 send/recv 路径改用带超时的 wait，替代无限等待。

Adds get/set support and internal storage for `SO_SNDTIMEO` / `SO_RCVTIMEO` on raw sockets; blocking send/recv paths now use timed waits instead of waiting indefinitely.

---

**8. Raw socket getsockopt 细节修复 / Raw socket getsockopt detail fixes**

修复 `IPV6_CHECKSUM`、ICMP/ICMPv6 filter、`SO_BINDTODEVICE` 等选项的长度处理；未知 setsockopt 选项返回 `ENOPROTOOPT` 而非静默成功。

Fixes length handling for `IPV6_CHECKSUM`, ICMP/ICMPv6 filters, `SO_BINDTODEVICE`, and related options; unknown setsockopt options now return `ENOPROTOOPT` instead of silently succeeding.

---

**9. 跨 socket 类型重构 / Cross-socket-type refactoring**

UDP、TCP、Raw、Netlink、Unix datagram/stream 的 getsockopt 实现统一接入上述 helper，减少重复代码并统一 Linux 对齐行为。

Refactors getsockopt handling in UDP, TCP, Raw, Netlink, and Unix datagram/stream sockets to use the shared helpers, reducing duplication and aligning behavior with Linux.