### PR TITLE
fix(net): honor IPv4 multicast send interface

### DIFF
--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -317,6 +317,11 @@ fn iface_allowed_for_remote(iface: &Arc<dyn Iface>, loopback_dst: bool) -> bool 
 fn no_source_addr_error(remote_ip_addr: &smoltcp::wire::IpAddress) -> SystemError {
     match remote_ip_addr {
         smoltcp::wire::IpAddress::Ipv4(_) => SystemError::ENETUNREACH,
+        // Linux IPv6 connect() distinguishes "no route to a remote network"
+        // from "the local/loopback destination exists but no source address can
+        // be selected".  After ::1 is removed from lo, connecting to ::1 fails
+        // from ipv6_get_saddr() with EADDRNOTAVAIL.
+        smoltcp::wire::IpAddress::Ipv6(addr) if addr.is_loopback() => SystemError::EADDRNOTAVAIL,
         smoltcp::wire::IpAddress::Ipv6(_) => SystemError::ENETUNREACH,
     }
 }

--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -197,6 +197,23 @@ pub fn ensure_bound_dual_stack_remote_compatible(
     }
 }
 
+/// Linux treats connect/send destinations of INADDR_ANY/IN6ADDR_ANY as
+/// loopback in the same address family.
+#[inline]
+pub fn normalize_unspecified_endpoint_to_loopback(
+    endpoint: smoltcp::wire::IpEndpoint,
+) -> smoltcp::wire::IpEndpoint {
+    if !endpoint.addr.is_unspecified() {
+        return endpoint;
+    }
+
+    let addr = match endpoint.addr {
+        smoltcp::wire::IpAddress::Ipv4(_) => smoltcp::wire::IpAddress::v4(127, 0, 0, 1),
+        smoltcp::wire::IpAddress::Ipv6(_) => smoltcp::wire::IpAddress::v6(0, 0, 0, 0, 0, 0, 0, 1),
+    };
+    smoltcp::wire::IpEndpoint::new(addr, endpoint.port)
+}
+
 #[inline]
 pub fn get_iface_to_bind(
     ip_addr: &smoltcp::wire::IpAddress,

--- a/kernel/src/net/socket/inet/datagram/inner.rs
+++ b/kernel/src/net/socket/inet/datagram/inner.rs
@@ -4,7 +4,7 @@ use smoltcp;
 use system_error::SystemError;
 
 use crate::{
-    libs::mutex::Mutex, net::socket::inet::common::BoundInner,
+    libs::mutex::Mutex, net::socket::inet::common::BoundInner, net::Iface,
     process::namespace::net_namespace::NetNamespace,
 };
 
@@ -145,9 +145,16 @@ impl UnboundUdp {
         bind_id: usize,
     ) -> Result<BoundUdp, SystemError> {
         let (inner, local_addr) = BoundInner::bind_ephemeral(self.socket, remote, netns)?;
-        let bound_port = inner
+        let bound_port = match inner
             .port_manager()
-            .bind_udp_ephemeral_port(local_addr, reuseaddr, reuseport, bind_id)?;
+            .bind_udp_ephemeral_port(local_addr, reuseaddr, reuseport, bind_id)
+        {
+            Ok(port) => port,
+            Err(e) => {
+                inner.release();
+                return Err(e);
+            }
+        };
         // log::debug!(
         //     "UnboundUdp::bind_ephemeral: allocated ephemeral port {} for remote {:?}",
         //     bound_port,
@@ -161,6 +168,7 @@ impl UnboundUdp {
                 .is_err()
             {
                 inner.port_manager().unbind_udp_port(bound_port, bind_id);
+                inner.release();
                 return Err(SystemError::EINVAL);
             }
         } else if inner
@@ -170,6 +178,50 @@ impl UnboundUdp {
             .is_err()
         {
             inner.port_manager().unbind_udp_port(bound_port, bind_id);
+            inner.release();
+            return Err(SystemError::EINVAL);
+        }
+
+        let port_mgr_ifindex = inner.iface().nic_id();
+        Ok(BoundUdp {
+            inner,
+            remote: Mutex::new(None),
+            explicitly_bound: false,
+            has_preconnect_data: Mutex::new(false),
+            bind_id,
+            port_mgr_ifindex,
+        })
+    }
+
+    pub fn bind_ephemeral_on_iface(
+        self,
+        iface: Arc<dyn Iface>,
+        local_addr: smoltcp::wire::IpAddress,
+        netns: Arc<NetNamespace>,
+        reuseaddr: bool,
+        reuseport: bool,
+        bind_id: usize,
+    ) -> Result<BoundUdp, SystemError> {
+        let inner = BoundInner::bind_on_iface(self.socket, iface, netns)?;
+        let bound_port = match inner
+            .port_manager()
+            .bind_udp_ephemeral_port(local_addr, reuseaddr, reuseport, bind_id)
+        {
+            Ok(port) => port,
+            Err(e) => {
+                inner.release();
+                return Err(e);
+            }
+        };
+
+        if inner
+            .with_mut::<smoltcp::socket::udp::Socket, _, _>(|socket| {
+                socket.bind(smoltcp::wire::IpEndpoint::new(local_addr, bound_port))
+            })
+            .is_err()
+        {
+            inner.port_manager().unbind_udp_port(bound_port, bind_id);
+            inner.release();
             return Err(SystemError::EINVAL);
         }
 

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -25,7 +25,7 @@ use alloc::vec::Vec;
 use core::sync::atomic::{
     AtomicBool, AtomicI32, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
 };
-use smoltcp::wire::{IpAddress::*, IpEndpoint, IpListenEndpoint, IpVersion};
+use smoltcp::wire::{IpAddress::*, IpEndpoint, IpListenEndpoint, IpVersion, Ipv4Address};
 
 use super::{
     common::ensure_bound_dual_stack_remote_compatible, InetSocket, UNSPECIFIED_LOCAL_ENDPOINT_V4,
@@ -481,13 +481,21 @@ impl UdpSocket {
 
                 let reuseaddr = self.so_reuseaddr.load(Ordering::Relaxed);
                 let reuseport = self.so_reuseport.load(Ordering::Relaxed);
-                match inner.bind_ephemeral(
-                    remote,
-                    self.netns(),
-                    reuseaddr,
-                    reuseport,
-                    self.bind_id(),
-                ) {
+                let bound_result = if let Some((iface, local_addr)) =
+                    self.ipv4_multicast_ephemeral_bind_target(remote)
+                {
+                    inner.bind_ephemeral_on_iface(
+                        iface,
+                        local_addr,
+                        self.netns(),
+                        reuseaddr,
+                        reuseport,
+                        self.bind_id(),
+                    )
+                } else {
+                    inner.bind_ephemeral(remote, self.netns(), reuseaddr, reuseport, self.bind_id())
+                };
+                match bound_result {
                     Ok(bound) => {
                         newly_bound_iface = Some(bound.inner().iface().clone());
                         let local = bound.endpoint();
@@ -792,6 +800,48 @@ impl UdpSocket {
         }
     }
 
+    fn ipv4_multicast_ephemeral_bind_target(
+        &self,
+        dest: smoltcp::wire::IpAddress,
+    ) -> Option<(Arc<dyn Iface>, smoltcp::wire::IpAddress)> {
+        if !matches!(dest, Ipv4(addr) if addr.is_multicast()) {
+            return None;
+        }
+
+        let ifindex = self.ip_multicast_ifindex.load(Ordering::Relaxed);
+        let ifaddr = self.ip_multicast_addr.load(Ordering::Relaxed);
+        if ifindex == 0 && ifaddr == 0 {
+            return None;
+        }
+
+        let iface = if ifindex != 0 {
+            crate::net::socket::inet::common::multicast::find_iface_by_ifindex(&self.netns, ifindex)
+        } else {
+            crate::net::socket::inet::common::multicast::find_iface_by_ipv4(&self.netns, ifaddr)
+        }?;
+
+        if ifaddr != 0 {
+            let octets = ifaddr.to_ne_bytes();
+            return Some((
+                iface,
+                Ipv4(Ipv4Address::new(octets[0], octets[1], octets[2], octets[3])),
+            ));
+        }
+
+        let local_addr = {
+            let smol_iface = iface.smol_iface().lock();
+            smol_iface
+                .ip_addrs()
+                .iter()
+                .find_map(|cidr| match cidr.address() {
+                    Ipv4(addr) => Some(Ipv4(addr)),
+                    _ => None,
+                })
+        }?;
+
+        Some((iface, local_addr))
+    }
+
     fn enqueue_errqueue(
         &self,
         err: SockExtendedErr,
@@ -852,13 +902,27 @@ impl UdpSocket {
                 };
                 let reuseaddr = self.so_reuseaddr.load(Ordering::Relaxed);
                 let reuseport = self.so_reuseport.load(Ordering::Relaxed);
-                match unbound.bind_ephemeral(
-                    to_addr,
-                    self.netns(),
-                    reuseaddr,
-                    reuseport,
-                    self.bind_id(),
-                ) {
+                let bound_result = if let Some((iface, local_addr)) =
+                    self.ipv4_multicast_ephemeral_bind_target(to_addr)
+                {
+                    unbound.bind_ephemeral_on_iface(
+                        iface,
+                        local_addr,
+                        self.netns(),
+                        reuseaddr,
+                        reuseport,
+                        self.bind_id(),
+                    )
+                } else {
+                    unbound.bind_ephemeral(
+                        to_addr,
+                        self.netns(),
+                        reuseaddr,
+                        reuseport,
+                        self.bind_id(),
+                    )
+                };
+                match bound_result {
                     Ok(bound) => {
                         // Register for iface notifications on implicit bind via sendto().
                         bound

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -224,6 +224,10 @@ impl TcpSocket {
         &self,
         remote_endpoint: smoltcp::wire::IpEndpoint,
     ) -> Result<(), SystemError> {
+        let remote_endpoint =
+            crate::net::socket::inet::common::normalize_unspecified_endpoint_to_loopback(
+                remote_endpoint,
+            );
         let mut writer = self.inner.write();
         let inner = writer.take().expect("Tcp inner::Inner is None");
         let (init, result) = match inner {


### PR DESCRIPTION
## Summary

Fix two Linux-compatible UDP/IP edge cases exposed by upstream master CI:

- return `EADDRNOTAVAIL` for IPv6 loopback connects when `::1` has been removed and no source address can be selected
- honor `IP_MULTICAST_IF` when an unbound IPv4 UDP socket implicitly binds for multicast `sendto()`/`connect()` inside a fresh network namespace

The multicast fix follows Linux's IPv4 UDP behavior: multicast routing uses the socket's multicast interface/address (`mc_index`/`mc_addr`) when no explicit bind/device overrides it. DragonOS now keeps this logic in the UDP layer instead of changing shared TCP/raw bind selection.

Also releases the smoltcp socket handle on UDP implicit-bind failure paths after the socket has already been attached to an iface.

## Validation

- `make fmt`
- `make kernel`
- QEMU guest: `./gvisor-test-runner socket_ipv4_udp_unbound_loopback_test`
  - 86 passed, 4 skipped, 0 failed
- QEMU guest: `./gvisor-test-runner socket_ip_unbound_netlink_test`
  - 4 passed
- QEMU guest: `./udp_ipv6_send_semantics_test`
  - 3 passed

Note: full `DISK_SAVE_MODE=1 make test-syscall` did not reach guest execution locally because host GCC 13 hit an internal compiler error while compiling dunitest/googletest (`internal compiler error: Segmentation fault`).
