### PR TITLE
fix(rseq): handle deferred reschedule before user return

### DIFF
--- a/kernel/src/exception/entry.rs
+++ b/kernel/src/exception/entry.rs
@@ -2,6 +2,7 @@ use crate::{
     arch::{interrupt::TrapFrame, CurrentSignalArch},
     ipc::signal_types::SignalArch,
     process::{rseq::Rseq, ProcessFlags, ProcessManager},
+    sched::{schedule, SchedMode},
 };
 
 #[no_mangle]
@@ -39,6 +40,12 @@ unsafe fn exit_to_user_mode_prepare(frame: &mut TrapFrame) {
 /// 必须保证所有的栈上的Arc/Box指针等，都已经被释放。否则，可能会导致内存泄漏。
 unsafe fn exit_to_user_mode_loop(frame: &mut TrapFrame, mut process_flags_work: ProcessFlags) {
     while !process_flags_work.exit_to_user_mode_work().is_empty() {
+        if process_flags_work.contains(ProcessFlags::NEED_SCHEDULE) {
+            schedule(SchedMode::SM_PREEMPT);
+            process_flags_work = *ProcessManager::current_pcb().flags();
+            continue;
+        }
+
         // 优先处理 rseq，因为信号递送会保存 trapframe 到 sigframe
         // rseq 的 IP fixup 必须在信号递送之前完成
         if process_flags_work.contains(ProcessFlags::NEED_RSEQ) {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1221,7 +1221,10 @@ bitflags! {
 
 impl ProcessFlags {
     pub const fn exit_to_user_mode_work(&self) -> Self {
-        Self::from_bits_truncate(self.bits & (Self::HAS_PENDING_SIGNAL.bits | Self::NEED_RSEQ.bits))
+        Self::from_bits_truncate(
+            self.bits
+                & (Self::NEED_SCHEDULE.bits | Self::HAS_PENDING_SIGNAL.bits | Self::NEED_RSEQ.bits),
+        )
     }
 
     /// 测试并清除标志位


### PR DESCRIPTION
## Summary

- Include `NEED_SCHEDULE` in the return-to-user work mask so deferred preemption is handled before returning to userspace.
- Process deferred reschedule work before rseq notify-resume and signal delivery, preserving the existing rseq-before-signal ordering.
- Keep rseq ABI behavior unchanged; this fixes the scheduling boundary that can otherwise delay lazy `rseq_cs` clear/fixup.

## Validation

- Before the fix, booted the existing kernel under TCG and ran `RseqTest.InvalidAbortClearsCS` 20 times locally. The hang did not reproduce locally, but the test emitted the same `clear tid failed: EFAULT` warning observed in CI.
- `make kernel`
- Booted the fixed kernel with `DRAGONOS_QEMU_ACCEL=tcg make qemu-nographic`.
- In the guest, ran `./rseq_test --gtest_filter=*Invalid* --gtest_repeat=100`: passed 100/100.
- In the guest, ran `./rseq_test --gtest_filter=*Abort* --gtest_repeat=20`: all 6 abort-related rseq tests passed across 20 iterations.

## Notes

- Did not run the full `make test-syscall` suite because this PR is targeted at the rseq CI flake and the full suite is much slower.