### PR TITLE
fix(mm): unmap full MAP_FIXED target range

### DIFF
--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -1935,19 +1935,19 @@ impl InnerAddressSpace {
             return Err(SystemError::EINVAL);
         }
 
-        let intersect_vma = self.mappings.conflicts(requested).next();
-        if let Some(vma) = intersect_vma {
+        let has_conflict = self.mappings.conflicts(requested).next().is_some();
+        if has_conflict {
             if flags.contains(MapFlags::MAP_FIXED_NOREPLACE) {
                 // 如果指定了 MAP_FIXED_NOREPLACE 标志，由于所指定的地址无法成功建立映射，则放弃映射，不对地址做修正
                 return Err(SystemError::EEXIST);
             }
 
             if flags.contains(MapFlags::MAP_FIXED) {
-                // 对已有的VMA进行覆盖
-                let intersect_region = vma.lock().region.intersect(&requested).unwrap();
+                // Linux mmap_region() unmaps the whole requested range for MAP_FIXED,
+                // because the new mapping may overlap more than the first conflicting VMA.
                 self.munmap(
-                    VirtPageFrame::new(intersect_region.start),
-                    PageFrameCount::from_bytes(intersect_region.size).unwrap(),
+                    VirtPageFrame::new(requested.start()),
+                    PageFrameCount::from_bytes(requested.size()).unwrap(),
                 )?;
                 return Ok(requested);
             }


### PR DESCRIPTION
## Summary

Fix `MAP_FIXED` mmap replacement semantics so the kernel unmaps the entire requested target range before inserting the new VMA, instead of only unmapping the intersection with the first conflicting VMA.

This matches Linux 6.6 `mm/mmap.c::mmap_region()`, which calls `do_vmi_munmap()` over the full requested range before creating the replacement mapping.

## Root Cause

`InnerAddressSpace::find_free_at()` previously handled `MAP_FIXED` conflicts by finding only the first conflicting VMA and unmapping that intersection. If the requested mapping overlapped multiple existing VMAs, later VMAs stayed in `UserMappings`; inserting the replacement VMA then hit the no-overlap assertion in `UserMappings::insert_vma()`.

This reproduces issue #1728 with a sequence of adjacent 4 KiB anonymous mappings followed by an 8 KiB `MAP_FIXED` mapping over one of them.

## Validation

- Reproduced #1728 on current master with the issue PoC: panic at `kernel/src/mm/ucontext.rs` in `UserMappings::insert_vma()` due to `assert!(self.conflicts(region).next().is_none())`.
- `make kernel` passes after the fix.
- Re-ran the same PoC inside DragonOS guest after the fix. It passes through the overlapping `MAP_FIXED` mmap phase and completes without kernel panic.

Closes #1728.