### PR TITLE
fix(sync): 修改dirty_state并重构sync syncfs系统调用

### DIFF
--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -40,7 +40,7 @@ pub struct Ext4FileSystem {
     root_inode: Arc<LockedExt4Inode>,
 
     /// 元数据（size/mtime）脏但尚未刷盘的 inode 列表。
-    dirty_inodes: Mutex<Vec<Weak<LockedExt4Inode>>>,
+    dirty_inodes: Mutex<Vec<Arc<LockedExt4Inode>>>,
 }
 
 impl FileSystem for Ext4FileSystem {
@@ -87,34 +87,28 @@ impl FileSystem for Ext4FileSystem {
 }
 
 impl Ext4FileSystem {
-    pub(super) fn mark_inode_dirty(inode: &Arc<LockedExt4Inode>) {
-        {
-            let guard = inode.0.lock();
-            if guard.dirty_state.contains(InodeDirtyState::ON_DIRTY_LIST) {
-                return;
+    pub(super) fn mark_inode_dirty(inode: &Arc<LockedExt4Inode>, dirty: InodeDirtyState) {
+        let (fs, should_queue) = {
+            let mut guard = inode.0.lock();
+            guard.dirty_state.insert(dirty);
+            let should_queue = !guard
+                .dirty_state
+                .intersects(InodeDirtyState::QUEUED | InodeDirtyState::WRITEBACK);
+            if should_queue {
+                guard.dirty_state.insert(InodeDirtyState::QUEUED);
             }
-        }
+            (guard.fs_ptr.upgrade(), should_queue)
+        };
 
-        if let Some(fs) = inode.filesystem() {
-            let mut guard = fs.dirty_inodes.lock();
-            {
-                let mut inode_guard = inode.0.lock();
-                if inode_guard
-                    .dirty_state
-                    .contains(InodeDirtyState::ON_DIRTY_LIST)
-                {
-                    return;
-                }
-                inode_guard
-                    .dirty_state
-                    .insert(InodeDirtyState::ON_DIRTY_LIST);
+        if should_queue {
+            if let Some(fs) = fs {
+                fs.dirty_inodes.lock().push(inode.clone());
             }
-            guard.push(Arc::downgrade(inode));
         }
     }
 
     fn flush_dirty_inodes(&self) -> Result<(), SystemError> {
-        let dirty: Vec<Weak<LockedExt4Inode>> = {
+        let dirty: Vec<Arc<LockedExt4Inode>> = {
             let mut guard = self.dirty_inodes.lock();
             if guard.is_empty() {
                 return Ok(());
@@ -123,26 +117,92 @@ impl Ext4FileSystem {
         };
 
         let mut last_err = Ok(());
-        let mut failed: Vec<Weak<LockedExt4Inode>> = Vec::new();
-        for weak in dirty {
-            if let Some(inode) = weak.upgrade() {
-                if let Err(e) = inode.flush_metadata(false) {
-                    log::warn!("flush_dirty_inodes: 元数据刷盘失败: {:?}", e);
-                    last_err = Err(e);
-                    failed.push(Arc::downgrade(&inode));
-                } else {
-                    // 成功才标记为不在脏列表
-                    inode
-                        .0
-                        .lock()
+        let mut requeue: Vec<Arc<LockedExt4Inode>> = Vec::new();
+        for inode in dirty {
+            let mut should_requeue = false;
+            let result = {
+                let _io_guard = inode.1.lock();
+                let (fs, inode_num, snapshot_dirty, cached_size, cached_mtime) = {
+                    let mut guard = inode.0.lock();
+                    guard.dirty_state.remove(InodeDirtyState::QUEUED);
+                    let snapshot_dirty = guard
                         .dirty_state
-                        .remove(InodeDirtyState::ON_DIRTY_LIST);
+                        .intersection(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
+                    if snapshot_dirty.is_empty() {
+                        guard.dirty_state.remove(InodeDirtyState::WRITEBACK);
+                        continue;
+                    }
+                    guard.dirty_state.insert(InodeDirtyState::WRITEBACK);
+                    (
+                        guard.fs_ptr.upgrade(),
+                        guard.inner_inode_num,
+                        snapshot_dirty,
+                        guard.cached_file_size,
+                        guard.cached_mtime,
+                    )
+                };
+
+                let result = if let Some(fs) = fs {
+                    let size = if snapshot_dirty.contains(InodeDirtyState::SIZE_DIRTY) {
+                        match cached_size {
+                            Some(size) => Ok(Some(size)),
+                            None => fs
+                                .fs
+                                .getattr(inode_num)
+                                .map(|attr| Some(attr.size))
+                                .map_err(SystemError::from),
+                        }
+                    } else {
+                        Ok(None)
+                    };
+                    size.and_then(|size| {
+                        let mtime = if snapshot_dirty.contains(InodeDirtyState::MTIME_DIRTY) {
+                            cached_mtime
+                        } else {
+                            None
+                        };
+                        fs.fs
+                            .commit_inode_metadata(inode_num, size, mtime)
+                            .map_err(SystemError::from)
+                    })
+                } else {
+                    Err(SystemError::EIO)
+                };
+
+                let mut guard = inode.0.lock();
+                if result.is_ok() {
+                    if snapshot_dirty.contains(InodeDirtyState::SIZE_DIRTY)
+                        && guard.cached_file_size == cached_size
+                    {
+                        guard.dirty_state.remove(InodeDirtyState::SIZE_DIRTY);
+                    }
+                    if snapshot_dirty.contains(InodeDirtyState::MTIME_DIRTY)
+                        && guard.cached_mtime == cached_mtime
+                    {
+                        guard.dirty_state.remove(InodeDirtyState::MTIME_DIRTY);
+                    }
                 }
+                guard.dirty_state.remove(InodeDirtyState::WRITEBACK);
+                if guard
+                    .dirty_state
+                    .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY)
+                {
+                    guard.dirty_state.insert(InodeDirtyState::QUEUED);
+                    should_requeue = true;
+                }
+                result
+            };
+
+            if let Err(e) = result {
+                log::warn!("flush_dirty_inodes: 元数据刷盘失败: {:?}", e);
+                last_err = Err(e);
+            }
+            if should_requeue {
+                requeue.push(inode);
             }
         }
-        if !failed.is_empty() {
-            let mut guard = self.dirty_inodes.lock();
-            guard.extend(failed);
+        if !requeue.is_empty() {
+            self.dirty_inodes.lock().extend(requeue);
         }
         last_err
     }

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -129,7 +129,6 @@ impl Ext4FileSystem {
                 if let Err(e) = inode.flush_metadata(false) {
                     log::warn!("flush_dirty_inodes: 元数据刷盘失败: {:?}", e);
                     last_err = Err(e);
-                    // on_dirty_list 保持 true，防止 mark_inode_dirty 重复添加
                     failed.push(Arc::downgrade(&inode));
                 } else {
                     // 成功才标记为不在脏列表

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -1,7 +1,7 @@
 use crate::{
     driver::base::{block::gendisk::GenDisk, device::device_number::DeviceNumber},
     filesystem::{
-        ext4::inode::Ext4Inode,
+        ext4::inode::{Ext4Inode, InodeDirtyState},
         vfs::{
             self,
             fcntl::AtFlags,
@@ -90,7 +90,7 @@ impl Ext4FileSystem {
     pub(super) fn mark_inode_dirty(inode: &Arc<LockedExt4Inode>) {
         {
             let guard = inode.0.lock();
-            if guard.on_dirty_list {
+            if guard.dirty_state.contains(InodeDirtyState::ON_DIRTY_LIST) {
                 return;
             }
         }
@@ -99,10 +99,15 @@ impl Ext4FileSystem {
             let mut guard = fs.dirty_inodes.lock();
             {
                 let mut inode_guard = inode.0.lock();
-                if inode_guard.on_dirty_list {
+                if inode_guard
+                    .dirty_state
+                    .contains(InodeDirtyState::ON_DIRTY_LIST)
+                {
                     return;
                 }
-                inode_guard.on_dirty_list = true;
+                inode_guard
+                    .dirty_state
+                    .insert(InodeDirtyState::ON_DIRTY_LIST);
             }
             guard.push(Arc::downgrade(inode));
         }
@@ -128,7 +133,11 @@ impl Ext4FileSystem {
                     failed.push(Arc::downgrade(&inode));
                 } else {
                     // 成功才标记为不在脏列表
-                    inode.0.lock().on_dirty_list = false;
+                    inode
+                        .0
+                        .lock()
+                        .dirty_state
+                        .remove(InodeDirtyState::ON_DIRTY_LIST);
                 }
             }
         }
@@ -183,9 +192,7 @@ impl Ext4FileSystem {
                         special_node: None,
                         cached_file_size: None,
                         cached_mtime: None,
-                        size_dirty: false,
-                        mtime_dirty: false,
-                        on_dirty_list: false,
+                        dirty_state: super::inode::InodeDirtyState::empty(),
                     }),
                     Mutex::new(()),
                 )

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -1,21 +1,28 @@
-use crate::driver::base::block::gendisk::GenDisk;
-use crate::driver::base::device::device_number::DeviceNumber;
-use crate::filesystem::ext4::inode::Ext4Inode;
-use crate::filesystem::vfs::fcntl::AtFlags;
-use crate::filesystem::vfs::utils::{user_path_at, DName};
-use crate::filesystem::vfs::vcore::{generate_inode_id, try_find_gendisk};
-use crate::filesystem::vfs::{
-    self, FileSystem, FileSystemMakerData, IndexNode, Magic, MountableFileSystem, FSMAKER,
-    VFS_MAX_FOLLOW_SYMLINK_TIMES,
+use crate::{
+    driver::base::{block::gendisk::GenDisk, device::device_number::DeviceNumber},
+    filesystem::{
+        ext4::inode::Ext4Inode,
+        vfs::{
+            self,
+            fcntl::AtFlags,
+            utils::{user_path_at, DName},
+            vcore::{generate_inode_id, try_find_gendisk},
+            FileSystem, FileSystemMakerData, IndexNode, Magic, MountableFileSystem, FSMAKER,
+            VFS_MAX_FOLLOW_SYMLINK_TIMES,
+        },
+    },
+    libs::mutex::Mutex,
+    mm::{
+        fault::{PageFaultHandler, PageFaultMessage},
+        VmFaultReason,
+    },
+    process::ProcessManager,
+    register_mountable_fs,
 };
-use crate::libs::mutex::Mutex;
-use crate::mm::fault::{PageFaultHandler, PageFaultMessage};
-use crate::mm::VmFaultReason;
-use crate::process::ProcessManager;
-use crate::register_mountable_fs;
 use alloc::{
     collections::BTreeMap,
     sync::{Arc, Weak},
+    vec::Vec,
 };
 use kdepends::another_ext4;
 use linkme::distributed_slice;
@@ -31,6 +38,9 @@ pub struct Ext4FileSystem {
 
     /// 根 inode
     root_inode: Arc<LockedExt4Inode>,
+
+    /// 元数据（size/mtime）脏但尚未刷盘的 inode 列表。
+    dirty_inodes: Mutex<Vec<Weak<LockedExt4Inode>>>,
 }
 
 impl FileSystem for Ext4FileSystem {
@@ -70,9 +80,65 @@ impl FileSystem for Ext4FileSystem {
     ) -> VmFaultReason {
         PageFaultHandler::filemap_map_pages(pfm, start_pgoff, end_pgoff)
     }
+
+    fn sync_fs(&self, _wait: bool) -> Result<(), SystemError> {
+        self.flush_dirty_inodes()
+    }
 }
 
 impl Ext4FileSystem {
+    pub(super) fn mark_inode_dirty(inode: &Arc<LockedExt4Inode>) {
+        {
+            let guard = inode.0.lock();
+            if guard.on_dirty_list {
+                return;
+            }
+        }
+
+        if let Some(fs) = inode.filesystem() {
+            let mut guard = fs.dirty_inodes.lock();
+            {
+                let mut inode_guard = inode.0.lock();
+                if inode_guard.on_dirty_list {
+                    return;
+                }
+                inode_guard.on_dirty_list = true;
+            }
+            guard.push(Arc::downgrade(inode));
+        }
+    }
+
+    fn flush_dirty_inodes(&self) -> Result<(), SystemError> {
+        let dirty: Vec<Weak<LockedExt4Inode>> = {
+            let mut guard = self.dirty_inodes.lock();
+            if guard.is_empty() {
+                return Ok(());
+            }
+            core::mem::take(&mut *guard)
+        };
+
+        let mut last_err = Ok(());
+        let mut failed: Vec<Weak<LockedExt4Inode>> = Vec::new();
+        for weak in dirty {
+            if let Some(inode) = weak.upgrade() {
+                if let Err(e) = inode.flush_metadata(false) {
+                    log::warn!("flush_dirty_inodes: 元数据刷盘失败: {:?}", e);
+                    last_err = Err(e);
+                    // on_dirty_list 保持 true，防止 mark_inode_dirty 重复添加
+                    failed.push(Arc::downgrade(&inode));
+                } else {
+                    // 成功才标记为不在脏列表
+                    inode.0.lock().on_dirty_list = false;
+                }
+            }
+        }
+        if !failed.is_empty() {
+            let mut guard = self.dirty_inodes.lock();
+            guard.extend(failed);
+        }
+        last_err
+    }
+
     fn read_statfs_from_superblock(&self) -> Result<vfs::SuperBlock, SystemError> {
         let ext4_sb = self.fs.super_block()?;
         let block_size = ext4_sb.block_size();
@@ -82,7 +148,7 @@ impl Ext4FileSystem {
         let reserved = ext4_sb.reserved_blocks_count();
 
         let mut sb = vfs::SuperBlock::new(Magic::EXT4_MAGIC, block_size, 255);
-        // Keep Linux ext4 semantics: f_blocks excludes metadata overhead.
+        // Linux ext4 语义：f_blocks 不包含元数据开销。
         sb.blocks = blocks.saturating_sub(overhead_blocks);
         sb.bfree = bfree;
         sb.bavail = bfree.saturating_sub(reserved);
@@ -119,6 +185,7 @@ impl Ext4FileSystem {
                         cached_mtime: None,
                         size_dirty: false,
                         mtime_dirty: false,
+                        on_dirty_list: false,
                     }),
                     Mutex::new(()),
                 )
@@ -128,6 +195,7 @@ impl Ext4FileSystem {
             fs,
             raw_dev,
             root_inode,
+            dirty_inodes: Mutex::new(Vec::new()),
         });
 
         let mut guard = fs.root_inode.0.lock();

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -36,12 +36,10 @@ bitflags! {
         const SIZE_DIRTY    = 1 << 0;
         /// mtime 变更未刷盘，对应 I_DIRTY_DATASYNC (1 << 1)
         const MTIME_DIRTY   = 1 << 1;
-        /// inode 有脏页，对应 I_DIRTY_PAGES (1 << 2)
-        /// DragonOS 脏页由 per-PageCache 的 `dirty_pages: BTreeSet` 追踪，暂不需要此位。
-        #[allow(dead_code)]
-        const PAGES_DIRTY   = 1 << 2;
-        /// 该 inode 是否在 dirty_inodes 列表中。Linux 无此位，隐含在 `i_state & I_DIRTY != 0`，DragonOS 简化合并。
-        const ON_DIRTY_LIST = 1 << 3;
+        /// 该 inode 已在文件系统 dirty_inodes 队列中。
+        const QUEUED        = 1 << 3;
+        /// 该 inode 正在执行元数据写回。
+        const WRITEBACK     = 1 << 4;
         /// 仅时间戳脏（lazytime），对应 I_DIRTY_TIME (1 << 11)
         #[allow(dead_code)]
         const TIME_DIRTY    = 1 << 11;
@@ -268,12 +266,12 @@ impl IndexNode for LockedExt4Inode {
                     let mut guard = self.0.lock();
                     guard.cached_file_size = Some(current_file_size);
                     guard.cached_mtime = Some(time);
-                    guard
-                        .dirty_state
-                        .insert(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
                     guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?
                 };
-                Ext4FileSystem::mark_inode_dirty(&self_arc);
+                Ext4FileSystem::mark_inode_dirty(
+                    &self_arc,
+                    InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY,
+                );
             }
 
             Ok(write_len)
@@ -488,7 +486,7 @@ impl IndexNode for LockedExt4Inode {
         }
     }
 
-    fn write_inode(&self) -> Result<(), SystemError> {
+    fn write_inode(&self, _wbc: &vfs::WritebackControl) -> Result<(), SystemError> {
         self.flush_metadata(false)
     }
 
@@ -968,10 +966,6 @@ impl Ext4Inode {
 }
 
 impl LockedExt4Inode {
-    pub(super) fn filesystem(&self) -> Option<Arc<Ext4FileSystem>> {
-        self.0.lock().fs_ptr.upgrade()
-    }
-
     pub(super) fn flush_metadata(&self, datasync: bool) -> Result<(), SystemError> {
         let _io_guard = self.1.lock();
         let (fs, inode_num, dirty, cached_size, cached_mtime) = {

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -60,6 +60,15 @@ pub struct Ext4Inode {
     pub(super) size_dirty: bool,
     /// 标记是否有未刷回磁盘的 mtime 变更。
     pub(super) mtime_dirty: bool,
+
+    /// 该 inode 是否已在 Ext4FileSystem::dirty_inodes 列表中。
+    /// 用于在 `mark_inode_dirty` 中实现 O(1) 快速路径，避免 O(n) 遍历脏列表做去重。
+    ///
+    /// 这是一个性能提示而非正确性保证：
+    /// - false positive（在列表中但不脏）→ flush_metadata 的 `!size_dirty && !mtime_dirty`
+    ///   检查会 early return，无害
+    /// - false negative（脏但不在列表中）→ 下次 write_at 的 mark_inode_dirty 会重新添加
+    pub(super) on_dirty_list: bool,
 }
 
 #[derive(Debug)]
@@ -247,11 +256,15 @@ impl IndexNode for LockedExt4Inode {
             if write_len > 0 {
                 let written_end = offset.checked_add(write_len).ok_or(SystemError::EFBIG)?;
                 let current_file_size = core::cmp::max(old_file_size, written_end as u64);
-                let mut guard = self.0.lock();
-                guard.cached_file_size = Some(current_file_size);
-                guard.cached_mtime = Some(time);
-                guard.size_dirty = true;
-                guard.mtime_dirty = true;
+                let self_arc = {
+                    let mut guard = self.0.lock();
+                    guard.cached_file_size = Some(current_file_size);
+                    guard.cached_mtime = Some(time);
+                    guard.size_dirty = true;
+                    guard.mtime_dirty = true;
+                    guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?
+                };
+                Ext4FileSystem::mark_inode_dirty(&self_arc);
             }
 
             Ok(write_len)
@@ -464,6 +477,10 @@ impl IndexNode for LockedExt4Inode {
         } else {
             self.sync()
         }
+    }
+
+    fn write_inode(&self) -> Result<(), SystemError> {
+        self.flush_metadata(false)
     }
 
     fn page_cache(&self) -> Option<Arc<PageCache>> {
@@ -936,12 +953,17 @@ impl Ext4Inode {
             cached_mtime: None,
             size_dirty: false,
             mtime_dirty: false,
+            on_dirty_list: false,
         }
     }
 }
 
 impl LockedExt4Inode {
-    fn flush_metadata(&self, datasync: bool) -> Result<(), SystemError> {
+    pub(super) fn filesystem(&self) -> Option<Arc<Ext4FileSystem>> {
+        self.0.lock().fs_ptr.upgrade()
+    }
+
+    pub(super) fn flush_metadata(&self, datasync: bool) -> Result<(), SystemError> {
         let _io_guard = self.1.lock();
         let (fs, inode_num, size_dirty, mtime_dirty, cached_size, cached_mtime) = {
             let guard = self.0.lock();

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -29,6 +29,25 @@ use system_error::SystemError;
 
 use super::filesystem::Ext4FileSystem;
 
+bitflags! {
+    /// Inode 脏状态标志位，对应 Linux `inode->i_state` 中的 `I_DIRTY_*` 位。
+    pub(super) struct InodeDirtyState: u32 {
+        /// 文件大小变更未刷盘，对应 I_DIRTY_SYNC (1 << 0)
+        const SIZE_DIRTY    = 1 << 0;
+        /// mtime 变更未刷盘，对应 I_DIRTY_DATASYNC (1 << 1)
+        const MTIME_DIRTY   = 1 << 1;
+        /// inode 有脏页，对应 I_DIRTY_PAGES (1 << 2)
+        /// DragonOS 脏页由 per-PageCache 的 `dirty_pages: BTreeSet` 追踪，暂不需要此位。
+        #[allow(dead_code)]
+        const PAGES_DIRTY   = 1 << 2;
+        /// 该 inode 是否在 dirty_inodes 列表中。Linux 无此位，隐含在 `i_state & I_DIRTY != 0`，DragonOS 简化合并。
+        const ON_DIRTY_LIST = 1 << 3;
+        /// 仅时间戳脏（lazytime），对应 I_DIRTY_TIME (1 << 11)
+        #[allow(dead_code)]
+        const TIME_DIRTY    = 1 << 11;
+    }
+}
+
 type PrivateData<'a> = crate::libs::mutex::MutexGuard<'a, vfs::FilePrivateData>;
 
 pub struct Ext4Inode {
@@ -56,19 +75,8 @@ pub struct Ext4Inode {
     pub(super) cached_file_size: Option<u64>,
     /// 缓存的 mtime。普通 buffered write 先更新内存态，fsync/O_SYNC 再刷到磁盘。
     pub(super) cached_mtime: Option<u32>,
-    /// 标记是否有未刷回磁盘的文件大小变更。
-    pub(super) size_dirty: bool,
-    /// 标记是否有未刷回磁盘的 mtime 变更。
-    pub(super) mtime_dirty: bool,
-
-    /// 该 inode 是否已在 Ext4FileSystem::dirty_inodes 列表中。
-    /// 用于在 `mark_inode_dirty` 中实现 O(1) 快速路径，避免 O(n) 遍历脏列表做去重。
-    ///
-    /// 这是一个性能提示而非正确性保证：
-    /// - false positive（在列表中但不脏）→ flush_metadata 的 `!size_dirty && !mtime_dirty`
-    ///   检查会 early return，无害
-    /// - false negative（脏但不在列表中）→ 下次 write_at 的 mark_inode_dirty 会重新添加
-    pub(super) on_dirty_list: bool,
+    /// 脏状态标志位，对应 Linux `inode->i_state & I_DIRTY_*`。
+    pub(super) dirty_state: InodeDirtyState,
 }
 
 #[derive(Debug)]
@@ -260,8 +268,9 @@ impl IndexNode for LockedExt4Inode {
                     let mut guard = self.0.lock();
                     guard.cached_file_size = Some(current_file_size);
                     guard.cached_mtime = Some(time);
-                    guard.size_dirty = true;
-                    guard.mtime_dirty = true;
+                    guard
+                        .dirty_state
+                        .insert(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
                     guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?
                 };
                 Ext4FileSystem::mark_inode_dirty(&self_arc);
@@ -517,8 +526,9 @@ impl IndexNode for LockedExt4Inode {
             let mut guard = self.0.lock();
             guard.cached_file_size = Some(metadata.size as u64);
             guard.cached_mtime = Some(to_ext4_time(&metadata.mtime));
-            guard.size_dirty = false;
-            guard.mtime_dirty = false;
+            guard
+                .dirty_state
+                .remove(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
         }
 
         Ok(())
@@ -547,8 +557,9 @@ impl IndexNode for LockedExt4Inode {
         {
             let mut guard = self.0.lock();
             guard.cached_file_size = Some(len as u64);
-            guard.size_dirty = false;
-            guard.mtime_dirty = false;
+            guard
+                .dirty_state
+                .remove(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
         }
         Ok(())
     }
@@ -951,9 +962,7 @@ impl Ext4Inode {
             special_node: None,
             cached_file_size: None,
             cached_mtime: None,
-            size_dirty: false,
-            mtime_dirty: false,
-            on_dirty_list: false,
+            dirty_state: InodeDirtyState::empty(),
         }
     }
 }
@@ -965,17 +974,19 @@ impl LockedExt4Inode {
 
     pub(super) fn flush_metadata(&self, datasync: bool) -> Result<(), SystemError> {
         let _io_guard = self.1.lock();
-        let (fs, inode_num, size_dirty, mtime_dirty, cached_size, cached_mtime) = {
+        let (fs, inode_num, dirty, cached_size, cached_mtime) = {
             let guard = self.0.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
-                guard.size_dirty,
-                guard.mtime_dirty,
+                guard.dirty_state,
                 guard.cached_file_size,
                 guard.cached_mtime,
             )
         };
+
+        let size_dirty = dirty.contains(InodeDirtyState::SIZE_DIRTY);
+        let mtime_dirty = dirty.contains(InodeDirtyState::MTIME_DIRTY);
 
         if !size_dirty && (!mtime_dirty || datasync) {
             return Ok(());
@@ -1000,10 +1011,10 @@ impl LockedExt4Inode {
 
         let mut guard = self.0.lock();
         if size_dirty && guard.cached_file_size == cached_size {
-            guard.size_dirty = false;
+            guard.dirty_state.remove(InodeDirtyState::SIZE_DIRTY);
         }
         if !datasync && mtime_dirty && guard.cached_mtime == cached_mtime {
-            guard.mtime_dirty = false;
+            guard.dirty_state.remove(InodeDirtyState::MTIME_DIRTY);
         }
         Ok(())
     }

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -460,6 +460,13 @@ impl PageCacheManager {
             Self::writeback_entry(&cache, page_index, entry)?;
         }
 
+        // 脏页写完后调 write_inode 回写元数据
+        if let Some(inode) = cache.inode().and_then(|w| w.upgrade()) {
+            if let Err(e) = inode.write_inode() {
+                log::warn!("write_inode failed: {:?}", e);
+            }
+        }
+
         Ok(())
     }
 

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -8,7 +8,9 @@ use alloc::{
 use hashbrown::HashMap;
 use system_error::SystemError;
 
-use super::vfs::{FilePrivateData, IndexNode};
+use super::vfs::{
+    mount::record_writeback_error_for_fs, FilePrivateData, IndexNode, WritebackControl,
+};
 use crate::exception::workqueue::{schedule_work, Work, WorkQueue};
 use crate::libs::mutex::MutexGuard;
 use crate::libs::rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard};
@@ -460,10 +462,14 @@ impl PageCacheManager {
             Self::writeback_entry(&cache, page_index, entry)?;
         }
 
-        // 脏页写完后调 write_inode 回写元数据
+        // 脏页写完后调 write_inode 回写元数据。
         if let Some(inode) = cache.inode().and_then(|w| w.upgrade()) {
-            if let Err(e) = inode.write_inode() {
+            let wbc = WritebackControl::sync_all_for_sync();
+            if let Err(e) = inode.write_inode(&wbc) {
                 log::warn!("write_inode failed: {:?}", e);
+                cache.record_writeback_error(e.clone());
+                record_writeback_error_for_fs(&inode.fs(), e.clone());
+                return Err(e);
             }
         }
 
@@ -677,6 +683,9 @@ impl PageCacheManager {
     ) -> Result<(), SystemError> {
         if let Err(e) = result {
             cache.record_writeback_error(e.clone());
+            if let Some(inode) = cache.inode().and_then(|w| w.upgrade()) {
+                record_writeback_error_for_fs(&inode.fs(), e.clone());
+            }
             {
                 let mut guard = page.write();
                 guard.add_flags(PageFlags::PG_ERROR | PageFlags::PG_DIRTY);

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -468,6 +468,8 @@ pub struct File {
     ra_state: Mutex<FileReadaheadState>,
     /// 当前 open file description 已观测到的 page cache 写回错误序列。
     wb_error_seq: AtomicU64,
+    /// 当前 open file description 已观测到的 superblock 写回错误序列。
+    sb_error_seq: AtomicU64,
 }
 
 impl File {
@@ -486,6 +488,22 @@ impl File {
         };
         self.wb_error_seq.store(seq, Ordering::Release);
         Err(error)
+    }
+
+    pub fn check_and_advance_sb_wb_error(
+        &self,
+        mount_fs: &Arc<super::mount::MountFS>,
+    ) -> Result<(), SystemError> {
+        let since = self.sb_error_seq.load(Ordering::Acquire);
+        let (seq, error) = mount_fs.check_and_advance_wb_error(since);
+        if seq != since {
+            self.sb_error_seq.store(seq, Ordering::Release);
+        }
+        if let Some(error) = error {
+            Err(error)
+        } else {
+            Ok(())
+        }
     }
 
     fn maybe_kill_suid_sgid_after_write(&self) -> Result<(), SystemError> {
@@ -707,6 +725,11 @@ impl File {
             .page_cache()
             .map(|page_cache| page_cache.sample_writeback_error())
             .unwrap_or(0);
+        let sb_error_seq = inode
+            .clone()
+            .downcast_arc::<MountFSInode>()
+            .map(|mnt_inode| mnt_inode.mount_fs().sample_wb_error())
+            .unwrap_or(0);
 
         let f = File {
             open_file_id: alloc_open_file_id(),
@@ -722,6 +745,7 @@ impl File {
             posix_lock_key,
             ra_state: Mutex::new(FileReadaheadState::new()),
             wb_error_seq: AtomicU64::new(wb_error_seq),
+            sb_error_seq: AtomicU64::new(sb_error_seq),
         };
 
         return Ok(f);
@@ -1252,6 +1276,7 @@ impl File {
             posix_lock_key: self.posix_lock_key,
             ra_state: Mutex::new(self.ra_state.lock().clone()),
             wb_error_seq: AtomicU64::new(self.wb_error_seq.load(Ordering::Acquire)),
+            sb_error_seq: AtomicU64::new(self.sb_error_seq.load(Ordering::Acquire)),
         };
         // 调用inode的open方法，让inode知道有新的文件打开了这个inode
         // TODO: reopen is not a good idea for some inodes, need a better design

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -819,7 +819,7 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     /// VFS 调用此方法将元数据持久化。
     ///
     /// 默认 no-op——procfs/sysfs/pipe/socket 等无磁盘元数据的 inode 不需要覆盖。
-    fn write_inode(&self) -> Result<(), SystemError> {
+    fn write_inode(&self, _wbc: &WritebackControl) -> Result<(), SystemError> {
         Ok(())
     }
 
@@ -1356,6 +1356,34 @@ bitflags! {
 pub enum FsPermissionPolicy {
     Dac,
     Remote,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WritebackSyncMode {
+    None,
+    All,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct WritebackControl {
+    pub sync_mode: WritebackSyncMode,
+    pub for_sync: bool,
+}
+
+impl WritebackControl {
+    pub const fn sync_all_for_sync() -> Self {
+        Self {
+            sync_mode: WritebackSyncMode::All,
+            for_sync: true,
+        }
+    }
+
+    pub const fn sync_none() -> Self {
+        Self {
+            sync_mode: WritebackSyncMode::None,
+            for_sync: false,
+        }
+    }
 }
 
 /// @brief 所有文件系统都应该实现的trait

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -812,6 +812,17 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         Ok(())
     }
 
+    /// 将 inode 元数据（size/mtime 等）写入磁盘。
+    ///
+    /// 对齐 Linux `super_operations.write_inode`：在脏页回写完成后，
+    /// 如果 inode 有脏元数据（I_DIRTY_SYNC / I_DIRTY_DATASYNC），
+    /// VFS 调用此方法将元数据持久化。
+    ///
+    /// 默认 no-op——procfs/sysfs/pipe/socket 等无磁盘元数据的 inode 不需要覆盖。
+    fn write_inode(&self) -> Result<(), SystemError> {
+        Ok(())
+    }
+
     /// ## 创建一个特殊文件节点
     /// - _filename: 文件名
     /// - _mode: 权限信息
@@ -1395,6 +1406,12 @@ pub trait FileSystem: Any + Sync + Send + Debug {
     /// Called after a filesystem is successfully unmounted.
     /// Default is no-op.
     fn on_umount(&self) {}
+
+    /// super_operations.sync_fs 在 sync() 回写脏页后调用，刷新文件系统元数据。
+    fn sync_fs(&self, wait: bool) -> Result<(), SystemError> {
+        let _ = wait;
+        Ok(())
+    }
 
     unsafe fn fault(&self, _pfm: &mut PageFaultMessage) -> VmFaultReason {
         VmFaultReason::VM_FAULT_SIGBUS

--- a/kernel/src/filesystem/vfs/mount.rs
+++ b/kernel/src/filesystem/vfs/mount.rs
@@ -13,6 +13,7 @@ use crate::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
         rwsem::RwSem,
+        spinlock::SpinLock,
     },
     mm::{fault::PageFaultMessage, VmFaultReason},
     process::{
@@ -40,6 +41,7 @@ use core::{
 };
 use hashbrown::HashMap;
 use ida::IdAllocator;
+use lazy_static::lazy_static;
 use system_error::SystemError;
 
 bitflags! {
@@ -233,6 +235,16 @@ int_like!(MountId, usize);
 static MOUNT_ID_ALLOCATOR: Mutex<IdAllocator> =
     Mutex::new(IdAllocator::new(0, usize::MAX).unwrap());
 
+lazy_static! {
+    static ref MOUNTED_SUPERBLOCKS: SpinLock<Vec<Weak<MountFS>>> = SpinLock::new(Vec::new());
+}
+
+#[derive(Debug, Default)]
+struct WritebackErrorState {
+    seq: u64,
+    error: Option<SystemError>,
+}
+
 impl MountId {
     fn alloc() -> Self {
         let id = MOUNT_ID_ALLOCATOR.lock().alloc().unwrap();
@@ -272,6 +284,8 @@ pub struct MountFS {
 pub struct SuperBlockState {
     flags: RwSem<MountFlags>,
     write_count: AtomicUsize,
+    wb_error: SpinLock<WritebackErrorState>,
+    umount_lock: RwSem<()>,
 }
 
 struct MountStateInit {
@@ -284,6 +298,8 @@ impl SuperBlockState {
         Self {
             flags: RwSem::new(flags & MountFlags::SB_SETTABLE_MASK),
             write_count: AtomicUsize::new(0),
+            wb_error: SpinLock::new(WritebackErrorState::default()),
+            umount_lock: RwSem::new(()),
         }
     }
 
@@ -305,6 +321,33 @@ impl SuperBlockState {
 
     pub fn has_writers(&self) -> bool {
         self.write_count.load(Ordering::Acquire) != 0
+    }
+
+    pub fn sample_wb_error(&self) -> u64 {
+        self.wb_error.lock_irqsave().seq
+    }
+
+    pub fn check_and_advance_wb_error(&self, since: u64) -> (u64, Option<SystemError>) {
+        let guard = self.wb_error.lock_irqsave();
+        if guard.seq == since {
+            (since, None)
+        } else {
+            (guard.seq, guard.error.clone())
+        }
+    }
+
+    pub fn record_wb_error(&self, error: SystemError) {
+        let mut guard = self.wb_error.lock_irqsave();
+        guard.seq = guard.seq.wrapping_add(1).max(1);
+        guard.error = Some(error);
+    }
+
+    pub fn umount_read(&self) -> crate::libs::rwsem::RwSemReadGuard<'_, ()> {
+        self.umount_lock.read()
+    }
+
+    pub fn umount_write(&self) -> crate::libs::rwsem::RwSemWriteGuard<'_, ()> {
+        self.umount_lock.write()
     }
 }
 
@@ -394,6 +437,7 @@ impl MountFS {
             result.set_namespace(Arc::downgrade(mnt_ns));
         }
 
+        register_mounted_superblock(&result);
         result
     }
 
@@ -416,6 +460,7 @@ impl MountFS {
             mount_source: RwSem::new(mount_source),
         });
 
+        register_mounted_superblock(&mountfs);
         return mountfs;
     }
 
@@ -437,6 +482,10 @@ impl MountFS {
 
     pub fn is_readonly(&self) -> bool {
         self.combined_flags().contains(MountFlags::RDONLY)
+    }
+
+    pub fn is_sb_readonly(&self) -> bool {
+        self.super_block_flags().contains(MountFlags::RDONLY)
     }
 
     pub fn has_writers(&self) -> bool {
@@ -572,13 +621,15 @@ impl MountFS {
     /// # Errors
     /// 如果当前文件系统是根文件系统，那么将会返回`EINVAL`
     pub fn umount(&self) -> Result<Arc<MountFS>, SystemError> {
-        let result = self
-            .self_mountpoint()
-            .ok_or(SystemError::EINVAL)?
-            .do_umount();
+        let mountpoint = self.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        let sb_state = self.super_block_state();
+        let _umount_guard = sb_state.umount_write();
+
+        self.sync_filesystem_locked()?;
+
+        let result = mountpoint.do_umount();
 
         if result.is_ok() {
-            let _ = self.sync_filesystem();
             // 清除 self_mountpoint，断开与旧父挂载点的反向引用。
             // 将 mnt_parent 设为自身、mnt_mountpoint 设为自身 root 的语义。
             self.self_mountpoint.write().take();
@@ -654,7 +705,7 @@ impl MountFS {
 
     /// 对应 Linux `sync_inodes_sb()`：回写指定 mount 下所有脏 page cache。
     /// DragonOS 无 per-sb 脏 inode 列表，通过全局 `PAGECACHE_REGISTRY` 遍历匹配。
-    pub(crate) fn sync_inodes_of_mount(&self) -> Result<(), SystemError> {
+    fn sync_inodes_of_mount(&self) -> Result<(), SystemError> {
         let inner_fs = self.inner_filesystem();
         let caches = list_page_caches();
         let mut last_err = Ok(());
@@ -667,6 +718,7 @@ impl MountFS {
             if belongs {
                 if let Err(e) = page_cache.manager().sync() {
                     log::warn!("sync_inodes_of_mount: page cache sync failed: {:?}", e);
+                    self.record_wb_error(e.clone());
                     last_err = Err(e);
                 }
             }
@@ -674,27 +726,146 @@ impl MountFS {
         last_err
     }
 
+    pub fn sync_inodes_with_umount_read(&self) -> Result<(), SystemError> {
+        let sb_state = self.super_block_state();
+        let _umount_guard = sb_state.umount_read();
+
+        if self.is_sb_readonly() {
+            return Ok(());
+        }
+
+        self.sync_inodes_of_mount()
+    }
+
+    pub fn sync_fs_with_umount_read(&self, wait: bool) -> Result<(), SystemError> {
+        let sb_state = self.super_block_state();
+        let _umount_guard = sb_state.umount_read();
+
+        if self.is_sb_readonly() {
+            return Ok(());
+        }
+
+        if let Err(e) = self.sync_fs(wait) {
+            self.record_wb_error(e.clone());
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    pub fn sync_blockdev_with_umount_read(&self, wait: bool) -> Result<(), SystemError> {
+        let sb_state = self.super_block_state();
+        let _umount_guard = sb_state.umount_read();
+
+        if self.is_sb_readonly() {
+            return Ok(());
+        }
+
+        if let Err(e) = self.sync_blockdev(wait) {
+            self.record_wb_error(e.clone());
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
     /// sync() 将所有挂起的文件系统元数据和缓存文件数据写入底层文件系统。
     pub fn sync_filesystem(&self) -> Result<(), SystemError> {
-        if self.is_readonly() {
+        let sb_state = self.super_block_state();
+        let _umount_guard = sb_state.umount_read();
+
+        self.sync_filesystem_locked()
+    }
+
+    /// 同步当前 superblock，要求调用方已经持有 `umount_lock`。
+    ///
+    /// Linux 的 `sync_filesystem(sb)` 要求调用方已持有 `s_umount`。DragonOS
+    /// 在 `sync_filesystem()` 外部入口中获取读锁，而 `umount()` 已经持有写锁，
+    /// 因此 teardown 路径必须调用这个 locked 版本，避免同线程重入读锁。
+    pub fn sync_filesystem_locked(&self) -> Result<(), SystemError> {
+        if self.is_sb_readonly() {
             return Ok(());
         }
 
         // writeback_inodes_sb(sb) — void
-        let _ = self.sync_inodes_of_mount();
+        let mut last_err = self.sync_inodes_of_mount();
         // sync_fs(sb, 0)
-        self.sync_fs(false)?;
+        if let Err(e) = self.sync_fs(false) {
+            self.record_wb_error(e.clone());
+            return Err(e);
+        }
 
-        // TODO: sync_blockdev_nowait(sb->s_bdev)
+        if let Err(e) = self.sync_blockdev(false) {
+            self.record_wb_error(e.clone());
+            return Err(e);
+        }
 
         // sync_inodes_sb(sb) — void
-        let _ = self.sync_inodes_of_mount();
+        if let Err(e) = self.sync_inodes_of_mount() {
+            last_err = Err(e);
+        }
         // sync_fs(sb, 1)
-        self.sync_fs(true)?;
+        if let Err(e) = self.sync_fs(true) {
+            self.record_wb_error(e.clone());
+            return Err(e);
+        }
 
-        // TODO: sync_blockdev(sb->s_bdev)
+        if let Err(e) = self.sync_blockdev(true) {
+            self.record_wb_error(e.clone());
+            return Err(e);
+        }
 
+        last_err
+    }
+
+    pub fn sync_blockdev(&self, _wait: bool) -> Result<(), SystemError> {
         Ok(())
+    }
+
+    pub fn record_wb_error(&self, error: SystemError) {
+        self.super_block_state.record_wb_error(error);
+    }
+
+    pub fn sample_wb_error(&self) -> u64 {
+        self.super_block_state.sample_wb_error()
+    }
+
+    pub fn check_and_advance_wb_error(&self, since: u64) -> (u64, Option<SystemError>) {
+        self.super_block_state.check_and_advance_wb_error(since)
+    }
+}
+
+fn register_mounted_superblock(mount: &Arc<MountFS>) {
+    MOUNTED_SUPERBLOCKS
+        .lock_irqsave()
+        .push(Arc::downgrade(mount));
+}
+
+pub fn list_unique_mounted_superblocks() -> Vec<Arc<MountFS>> {
+    let mut guard = MOUNTED_SUPERBLOCKS.lock_irqsave();
+    let mut mounts: Vec<Arc<MountFS>> = Vec::new();
+    guard.retain(|weak| {
+        if let Some(mount) = weak.upgrade() {
+            let state = mount.super_block_state();
+            if !mounts
+                .iter()
+                .any(|existing| Arc::ptr_eq(&existing.super_block_state(), &state))
+            {
+                mounts.push(mount);
+            }
+            true
+        } else {
+            false
+        }
+    });
+    mounts
+}
+
+pub fn record_writeback_error_for_fs(inner_fs: &Arc<dyn FileSystem>, error: SystemError) {
+    for mount in list_unique_mounted_superblocks() {
+        if Arc::ptr_eq(&mount.inner_filesystem(), inner_fs) {
+            mount.record_wb_error(error.clone());
+        }
     }
 }
 
@@ -1070,8 +1241,8 @@ impl IndexNode for MountFSInode {
         self.inner_inode.sync_file(datasync, data)
     }
 
-    fn write_inode(&self) -> Result<(), SystemError> {
-        self.inner_inode.write_inode()
+    fn write_inode(&self, wbc: &super::WritebackControl) -> Result<(), SystemError> {
+        self.inner_inode.write_inode(wbc)
     }
 
     fn fadvise(

--- a/kernel/src/filesystem/vfs/mount.rs
+++ b/kernel/src/filesystem/vfs/mount.rs
@@ -1,29 +1,19 @@
-use core::{
-    any::Any,
-    fmt::Debug,
-    hash::Hash,
-    mem,
-    sync::atomic::{compiler_fence, AtomicUsize, Ordering},
+use super::{
+    file::FileFlags, utils::DName, FilePrivateData, FileSystem, FileType, IndexNode, InodeId,
+    InodeMode, PollableInode, SuperBlock,
 };
-
-use alloc::{
-    collections::BTreeMap,
-    string::{String, ToString},
-    sync::{Arc, Weak},
-    vec::Vec,
-};
-use hashbrown::HashMap;
-use ida::IdAllocator;
-use system_error::SystemError;
-
-use crate::libs::mutex::{Mutex, MutexGuard};
 use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
     filesystem::{
+        page_cache::list_page_caches,
         page_cache::PageCache,
         vfs::{fcntl::AtFlags, syscall::RenameFlags, vcore::do_mkdir_at},
     },
-    libs::{casting::DowncastArc, rwsem::RwSem},
+    libs::{
+        casting::DowncastArc,
+        mutex::{Mutex, MutexGuard},
+        rwsem::RwSem,
+    },
     mm::{fault::PageFaultMessage, VmFaultReason},
     process::{
         namespace::{
@@ -35,11 +25,22 @@ use crate::{
         ProcessManager,
     },
 };
-
-use super::{
-    file::FileFlags, utils::DName, FilePrivateData, FileSystem, FileType, IndexNode, InodeId,
-    InodeMode, PollableInode, SuperBlock,
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    sync::{Arc, Weak},
+    vec::Vec,
 };
+use core::{
+    any::Any,
+    fmt::Debug,
+    hash::Hash,
+    mem,
+    sync::atomic::{compiler_fence, AtomicUsize, Ordering},
+};
+use hashbrown::HashMap;
+use ida::IdAllocator;
+use system_error::SystemError;
 
 bitflags! {
     /// Mount flags for filesystem independent mount options
@@ -577,6 +578,7 @@ impl MountFS {
             .do_umount();
 
         if result.is_ok() {
+            let _ = self.sync_filesystem();
             // 清除 self_mountpoint，断开与旧父挂载点的反向引用。
             // 将 mnt_parent 设为自身、mnt_mountpoint 设为自身 root 的语义。
             self.self_mountpoint.write().take();
@@ -648,6 +650,51 @@ impl MountFS {
             mntns.remove_mount(path.as_str());
         }
         let _ = root.umount();
+    }
+
+    /// 对应 Linux `sync_inodes_sb()`：回写指定 mount 下所有脏 page cache。
+    /// DragonOS 无 per-sb 脏 inode 列表，通过全局 `PAGECACHE_REGISTRY` 遍历匹配。
+    pub(crate) fn sync_inodes_of_mount(&self) -> Result<(), SystemError> {
+        let inner_fs = self.inner_filesystem();
+        let caches = list_page_caches();
+        let mut last_err = Ok(());
+        for page_cache in caches {
+            let belongs = page_cache
+                .inode()
+                .and_then(|weak| weak.upgrade())
+                .is_some_and(|inode| Arc::ptr_eq(&inode.fs(), &inner_fs));
+
+            if belongs {
+                if let Err(e) = page_cache.manager().sync() {
+                    log::warn!("sync_inodes_of_mount: page cache sync failed: {:?}", e);
+                    last_err = Err(e);
+                }
+            }
+        }
+        last_err
+    }
+
+    /// sync() 将所有挂起的文件系统元数据和缓存文件数据写入底层文件系统。
+    pub fn sync_filesystem(&self) -> Result<(), SystemError> {
+        if self.is_readonly() {
+            return Ok(());
+        }
+
+        // writeback_inodes_sb(sb) — void
+        let _ = self.sync_inodes_of_mount();
+        // sync_fs(sb, 0)
+        self.sync_fs(false)?;
+
+        // TODO: sync_blockdev_nowait(sb->s_bdev)
+
+        // sync_inodes_sb(sb) — void
+        let _ = self.sync_inodes_of_mount();
+        // sync_fs(sb, 1)
+        self.sync_fs(true)?;
+
+        // TODO: sync_blockdev(sb->s_bdev)
+
+        Ok(())
     }
 }
 

--- a/kernel/src/filesystem/vfs/mount.rs
+++ b/kernel/src/filesystem/vfs/mount.rs
@@ -1023,6 +1023,10 @@ impl IndexNode for MountFSInode {
         self.inner_inode.sync_file(datasync, data)
     }
 
+    fn write_inode(&self) -> Result<(), SystemError> {
+        self.inner_inode.write_inode()
+    }
+
     fn fadvise(
         &self,
         file: &Arc<super::file::File>,
@@ -1476,6 +1480,10 @@ impl FileSystem for MountFS {
         end_pgoff: usize,
     ) -> VmFaultReason {
         self.inner_filesystem.map_pages(pfm, start_pgoff, end_pgoff)
+    }
+
+    fn sync_fs(&self, wait: bool) -> Result<(), SystemError> {
+        self.inner_filesystem.sync_fs(wait)
     }
 }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_sync.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync.rs
@@ -3,7 +3,7 @@ use crate::{
         interrupt::TrapFrame,
         syscall::nr::{SYS_SYNC, SYS_SYNCFS},
     },
-    filesystem::vfs::{file::FileFlags, FileSystem},
+    filesystem::vfs::{file::FileFlags, mount::list_unique_mounted_superblocks},
     libs::casting::DowncastArc,
     mm::page::PageReclaimer,
     process::ProcessManager,
@@ -27,30 +27,30 @@ impl Syscall for SysSyncHandle {
         // 唤醒回写线程，异步刷回所有脏页
         PageReclaimer::flush_dirty_pages();
 
-        let mounts = ProcessManager::current_mntns().mount_list().clone_inner();
+        let mounts = list_unique_mounted_superblocks();
 
         // 逐 superblock 同步回写脏 inode
-        for (_path, mountfs) in &mounts {
-            if !mountfs.is_readonly() {
-                let _ = mountfs.sync_inodes_of_mount();
-            }
+        for mountfs in &mounts {
+            let _ = mountfs.sync_inodes_with_umount_read();
         }
 
         // 逐 superblock 调 sync_fs(nowait)，提交元数据但不等待
-        for (_path, mountfs) in &mounts {
-            if !mountfs.is_readonly() {
-                let _ = mountfs.sync_fs(false);
-            }
+        for mountfs in &mounts {
+            let _ = mountfs.sync_fs_with_umount_read(false);
         }
 
         // 逐 superblock 调 sync_fs(wait)，等待元数据落盘
-        for (_path, mountfs) in &mounts {
-            if !mountfs.is_readonly() {
-                let _ = mountfs.sync_fs(true);
-            }
+        for mountfs in &mounts {
+            let _ = mountfs.sync_fs_with_umount_read(true);
         }
 
-        // TODO: sync_bdevs(false) + sync_bdevs(true)
+        for mountfs in &mounts {
+            let _ = mountfs.sync_blockdev_with_umount_read(false);
+        }
+
+        for mountfs in &mounts {
+            let _ = mountfs.sync_blockdev_with_umount_read(true);
+        }
 
         Ok(0)
     }
@@ -107,19 +107,13 @@ impl Syscall for SysSyncFsHandle {
 
         let mount_fs = mount_inode.mount_fs();
 
-        // TODO: down_read(&sb->s_umount) — 防止 sync 期间 umount
+        let sync_result = mount_fs.sync_filesystem();
+        let errseq_result = file.check_and_advance_sb_wb_error(&mount_fs);
 
-        // sync_filesystem(sb)
-        let ret = mount_fs.sync_filesystem();
-
-        // TODO: up_read(&sb->s_umount)
-
-        // TODO: errseq_check_and_advance(&sb->s_wb_err, &f.file->f_sb_err)
-        //       Linux syncfs 检查 per-sb 的 s_wb_err（异步写回错误）。
-        //       DragonOS 已有 per-page-cache 的 errseq（PageCache::writeback_error + File::wb_error_seq），
-        //       但缺少 per-sb 的聚合 errseq，后续可在 FileSystem trait 中添加。
-
-        ret.map(|_| 0)
+        match sync_result {
+            Err(e) => Err(e),
+            Ok(()) => errseq_result.map(|_| 0),
+        }
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/filesystem/vfs/syscall/sys_sync.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync.rs
@@ -3,45 +3,15 @@ use crate::{
         interrupt::TrapFrame,
         syscall::nr::{SYS_SYNC, SYS_SYNCFS},
     },
-    filesystem::{
-        page_cache::list_page_caches,
-        vfs::{file::FileFlags, mount::MountFS, FileSystem},
-    },
+    filesystem::vfs::{file::FileFlags, FileSystem},
     libs::casting::DowncastArc,
     mm::page::PageReclaimer,
     process::ProcessManager,
     syscall::table::{FormattedSyscallParam, Syscall},
 };
-use alloc::{string::ToString, sync::Arc, vec::Vec};
+use alloc::{string::ToString, vec::Vec};
 use system_error::SystemError;
 
-/// 回写指定 mount 下所有脏 page cache 的页数据。
-///
-/// DragonOS 没有 per-superblock 脏 inode 列表，
-/// 因此通过全局 `PAGECACHE_REGISTRY` 遍历所有 page cache，
-/// 比较 inode 所属的 `FileSystem` 与目标 mount 的内部文件系统指针来判断归属，
-/// 若匹配则调用 `page_cache.manager().sync()` 回写脏页。
-fn sync_inodes_of_mount(target_mount: &Arc<MountFS>) -> Result<(), SystemError> {
-    let inner_fs = target_mount.inner_filesystem();
-    let caches = list_page_caches();
-    let mut last_err = Ok(());
-    for page_cache in caches {
-        let belongs = page_cache
-            .inode()
-            .and_then(|weak| weak.upgrade())
-            .is_some_and(|inode| Arc::ptr_eq(&inode.fs(), &inner_fs));
-
-        if belongs {
-            if let Err(e) = page_cache.manager().sync() {
-                log::warn!("sync_inodes_of_mount: page cache sync failed: {:?}", e);
-                last_err = Err(e);
-            }
-        }
-    }
-    last_err
-}
-
-/// sync() 将所有挂起的文件系统元数据和缓存文件数据写入底层文件系统。
 pub struct SysSyncHandle;
 
 impl Syscall for SysSyncHandle {
@@ -54,30 +24,33 @@ impl Syscall for SysSyncHandle {
         _args: &[usize],
         _frame: &mut TrapFrame,
     ) -> Result<usize, system_error::SystemError> {
-        // 阶段1: 唤醒回写 + 回写所有脏页
+        // 唤醒回写线程，异步刷回所有脏页
         PageReclaimer::flush_dirty_pages();
 
         let mounts = ProcessManager::current_mntns().mount_list().clone_inner();
 
-        // 阶段2: sync_inodes + sync_fs(nowait)
+        // 逐 superblock 同步回写脏 inode
         for (_path, mountfs) in &mounts {
             if !mountfs.is_readonly() {
-                let _ = sync_inodes_of_mount(mountfs);
+                let _ = mountfs.sync_inodes_of_mount();
             }
         }
 
+        // 逐 superblock 调 sync_fs(nowait)，提交元数据但不等待
         for (_path, mountfs) in &mounts {
             if !mountfs.is_readonly() {
                 let _ = mountfs.sync_fs(false);
             }
         }
 
-        // 阶段3: sync_fs(wait)
+        // 逐 superblock 调 sync_fs(wait)，等待元数据落盘
         for (_path, mountfs) in &mounts {
             if !mountfs.is_readonly() {
                 let _ = mountfs.sync_fs(true);
             }
         }
+
+        // TODO: sync_bdevs(false) + sync_bdevs(true)
 
         Ok(0)
     }
@@ -110,21 +83,20 @@ impl Syscall for SysSyncFsHandle {
         let binding = ProcessManager::current_pcb().fd_table();
         let fd_table_guard = binding.read();
 
+        // fdget(fd): EBADF if invalid fd
         let file = fd_table_guard
             .get_file_by_fd(fd)
             .ok_or(SystemError::EBADF)?;
 
         drop(fd_table_guard);
 
-        // fdget() 使用 FMODE_PATH 掩码过滤 O_PATH fd
+        // fdget() 通过 FMODE_PATH 掩码过滤 O_PATH fd
         if file.flags().contains(FileFlags::O_PATH) {
             return Err(SystemError::EBADF);
         }
 
         let inode = file.inode();
-        // DragonOS: file.inode() 对于 VFS 文件返回 MountFSInode
-        // 对于 pipe/socket 等非 VFS fd，无 MountFSInode 包装，
-        // 对齐 Linux 行为：这些 fd 的 sb 是只读伪文件系统（如 pipefs），sync_filesystem 直接返回 0
+        // 非 VFS fd（pipe/socket 等）：其 sb 为只读伪文件系统（pipefs/sockfs），
         let mount_inode = match inode
             .clone()
             .downcast_arc::<crate::filesystem::vfs::mount::MountFSInode>()
@@ -135,21 +107,19 @@ impl Syscall for SysSyncFsHandle {
 
         let mount_fs = mount_inode.mount_fs();
 
-        // 只读直接返回
-        if mount_fs.is_readonly() {
-            return Ok(0);
-        }
+        // TODO: down_read(&sb->s_umount) — 防止 sync 期间 umount
 
-        // writeback_inodes_sb(sb)
-        sync_inodes_of_mount(&mount_fs)?;
-        // sync_fs(sb, 0)
-        mount_fs.sync_fs(false)?;
-        // sync_inodes_sb(sb)
-        sync_inodes_of_mount(&mount_fs)?;
-        // sync_fs(sb, 1)
-        mount_fs.sync_fs(true)?;
+        // sync_filesystem(sb)
+        let ret = mount_fs.sync_filesystem();
 
-        Ok(0)
+        // TODO: up_read(&sb->s_umount)
+
+        // TODO: errseq_check_and_advance(&sb->s_wb_err, &f.file->f_sb_err)
+        //       Linux syncfs 检查 per-sb 的 s_wb_err（异步写回错误）。
+        //       DragonOS 已有 per-page-cache 的 errseq（PageCache::writeback_error + File::wb_error_seq），
+        //       但缺少 per-sb 的聚合 errseq，后续可在 FileSystem trait 中添加。
+
+        ret.map(|_| 0)
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/filesystem/vfs/syscall/sys_sync.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync.rs
@@ -1,24 +1,47 @@
-use alloc::string::ToString;
-
-use alloc::vec::Vec;
-
 use crate::{
     arch::{
         interrupt::TrapFrame,
         syscall::nr::{SYS_SYNC, SYS_SYNCFS},
     },
-    filesystem::vfs::file::FileFlags,
+    filesystem::{
+        page_cache::list_page_caches,
+        vfs::{file::FileFlags, mount::MountFS, FileSystem},
+    },
+    libs::casting::DowncastArc,
     mm::page::PageReclaimer,
     process::ProcessManager,
     syscall::table::{FormattedSyscallParam, Syscall},
 };
-
+use alloc::{string::ToString, sync::Arc, vec::Vec};
 use system_error::SystemError;
 
-/// sync() causes all pending modifications to filesystem metadata and
-/// cached file data to be written to the underlying filesystems.
+/// 回写指定 mount 下所有脏 page cache 的页数据。
 ///
-/// See https://man7.org/linux/man-pages/man2/sync.2.html
+/// DragonOS 没有 per-superblock 脏 inode 列表，
+/// 因此通过全局 `PAGECACHE_REGISTRY` 遍历所有 page cache，
+/// 比较 inode 所属的 `FileSystem` 与目标 mount 的内部文件系统指针来判断归属，
+/// 若匹配则调用 `page_cache.manager().sync()` 回写脏页。
+fn sync_inodes_of_mount(target_mount: &Arc<MountFS>) -> Result<(), SystemError> {
+    let inner_fs = target_mount.inner_filesystem();
+    let caches = list_page_caches();
+    let mut last_err = Ok(());
+    for page_cache in caches {
+        let belongs = page_cache
+            .inode()
+            .and_then(|weak| weak.upgrade())
+            .is_some_and(|inode| Arc::ptr_eq(&inode.fs(), &inner_fs));
+
+        if belongs {
+            if let Err(e) = page_cache.manager().sync() {
+                log::warn!("sync_inodes_of_mount: page cache sync failed: {:?}", e);
+                last_err = Err(e);
+            }
+        }
+    }
+    last_err
+}
+
+/// sync() 将所有挂起的文件系统元数据和缓存文件数据写入底层文件系统。
 pub struct SysSyncHandle;
 
 impl Syscall for SysSyncHandle {
@@ -31,7 +54,31 @@ impl Syscall for SysSyncHandle {
         _args: &[usize],
         _frame: &mut TrapFrame,
     ) -> Result<usize, system_error::SystemError> {
+        // 阶段1: 唤醒回写 + 回写所有脏页
         PageReclaimer::flush_dirty_pages();
+
+        let mounts = ProcessManager::current_mntns().mount_list().clone_inner();
+
+        // 阶段2: sync_inodes + sync_fs(nowait)
+        for (_path, mountfs) in &mounts {
+            if !mountfs.is_readonly() {
+                let _ = sync_inodes_of_mount(&mountfs);
+            }
+        }
+
+        for (_path, mountfs) in &mounts {
+            if !mountfs.is_readonly() {
+                let _ = mountfs.sync_fs(false);
+            }
+        }
+
+        // 阶段3: sync_fs(wait)
+        for (_path, mountfs) in &mounts {
+            if !mountfs.is_readonly() {
+                let _ = mountfs.sync_fs(true);
+            }
+        }
+
         Ok(0)
     }
 
@@ -45,8 +92,7 @@ impl Syscall for SysSyncHandle {
 
 syscall_table_macros::declare_syscall!(SYS_SYNC, SysSyncHandle);
 
-/// syncfs() is like sync(), but synchronizes just the filesystem
-/// containing file referred to by the open file descriptor fd.
+/// syncfs() 与 sync() 类似，但只同步文件描述符 fd 所在的文件系统。
 pub struct SysSyncFsHandle;
 
 impl Syscall for SysSyncFsHandle {
@@ -61,26 +107,48 @@ impl Syscall for SysSyncFsHandle {
     ) -> Result<usize, system_error::SystemError> {
         let fd = args[0] as i32;
 
-        // Get the file descriptor table
         let binding = ProcessManager::current_pcb().fd_table();
         let fd_table_guard = binding.read();
 
-        // Validate that the fd exists
         let file = fd_table_guard
             .get_file_by_fd(fd)
             .ok_or(SystemError::EBADF)?;
 
-        // drop guard 以避免无法调度的问题
         drop(fd_table_guard);
 
-        // Check if the file descriptor was opened with O_PATH
+        // fdget() 使用 FMODE_PATH 掩码过滤 O_PATH fd
         if file.flags().contains(FileFlags::O_PATH) {
             return Err(SystemError::EBADF);
         }
 
-        // TODO: now, we ignore the fd and sync all filesystems.
-        // In the future, we should sync only the filesystem of the given fd.
-        PageReclaimer::flush_dirty_pages();
+        let inode = file.inode();
+        // DragonOS: file.inode() 对于 VFS 文件返回 MountFSInode
+        // 对于 pipe/socket 等非 VFS fd，无 MountFSInode 包装，
+        // 对齐 Linux 行为：这些 fd 的 sb 是只读伪文件系统（如 pipefs），sync_filesystem 直接返回 0
+        let mount_inode = match inode
+            .clone()
+            .downcast_arc::<crate::filesystem::vfs::mount::MountFSInode>()
+        {
+            Some(mi) => mi,
+            None => return Ok(0),
+        };
+
+        let mount_fs = mount_inode.mount_fs();
+
+        // 只读直接返回
+        if mount_fs.is_readonly() {
+            return Ok(0);
+        }
+
+        // writeback_inodes_sb(sb)
+        sync_inodes_of_mount(&mount_fs)?;
+        // sync_fs(sb, 0)
+        mount_fs.sync_fs(false)?;
+        // sync_inodes_sb(sb)
+        sync_inodes_of_mount(&mount_fs)?;
+        // sync_fs(sb, 1)
+        mount_fs.sync_fs(true)?;
+
         Ok(0)
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_sync.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync.rs
@@ -62,7 +62,7 @@ impl Syscall for SysSyncHandle {
         // 阶段2: sync_inodes + sync_fs(nowait)
         for (_path, mountfs) in &mounts {
             if !mountfs.is_readonly() {
-                let _ = sync_inodes_of_mount(&mountfs);
+                let _ = sync_inodes_of_mount(mountfs);
             }
         }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_umount2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_umount2.rs
@@ -106,11 +106,6 @@ pub fn do_umount2(
         return Err(SystemError::EINVAL);
     }
 
-    // 检查通过后再实际移除
-    let Some(fs) = current_mntns.remove_mount(&path) else {
-        log::warn!("do_umount2: mount_list race for resolved='{}'", path);
-        return Err(SystemError::EINVAL);
-    };
     if let Err(err) = fs.umount() {
         log::warn!(
             "do_umount2: fs.umount failed for resolved='{}', fs='{}': {:?}",
@@ -120,6 +115,7 @@ pub fn do_umount2(
         );
         return Err(err);
     }
+    let _ = current_mntns.remove_mount(&path);
     Ok(fs)
 }
 

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -18,7 +18,7 @@ use crate::{
     arch::{mm::LockedFrameAllocator, MMArch},
     filesystem::{
         page_cache::{list_page_caches, PageCache},
-        vfs::{FilePrivateData, FileSystem},
+        vfs::{mount::list_unique_mounted_superblocks, FilePrivateData},
     },
     init::initcall::INITCALL_CORE,
     libs::{
@@ -272,11 +272,9 @@ fn page_reclaim_thread() -> i32 {
             // Linux 的 __writeback_single_inode 在 do_writepages 后调 write_inode 回写元数据，
             // 脏页和元数据在同一次遍历中完成。DragonOS 的 flush_dirty_pages 不触发 write_inode，
             // 此处通过 sync_fs 刷回 dirty_inodes 中的脏元数据。
-            let mounts = ProcessManager::current_mntns().mount_list().clone_inner();
-            for (_path, mountfs) in mounts {
-                if !mountfs.is_readonly() {
-                    let _ = mountfs.sync_fs(true);
-                }
+            let mounts = list_unique_mounted_superblocks();
+            for mountfs in mounts {
+                let _ = mountfs.sync_fs_with_umount_read(true);
             }
 
             let _ = nanosleep(PosixTimeSpec::new(0, 500_000_000));

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -269,10 +269,9 @@ fn page_reclaim_thread() -> i32 {
             PageReclaimer::flush_dirty_pages();
             // 休眠5秒
             // log::info!("sleep");
-            // 本路径通过 writeback_page() 逐页写回，不经过 PageCacheManager::sync()，
-            // 因此 write_inode 不会被触发。此处通过 sync_fs 补充两部分：
-            // 1) per-page writeback 路径的 inode 元数据回写
-            // 2) metadata-only dirty inode（无 page cache，如 chmod/truncate）
+            // Linux 的 __writeback_single_inode 在 do_writepages 后调 write_inode 回写元数据，
+            // 脏页和元数据在同一次遍历中完成。DragonOS 的 flush_dirty_pages 不触发 write_inode，
+            // 此处通过 sync_fs 刷回 dirty_inodes 中的脏元数据。
             let mounts = ProcessManager::current_mntns().mount_list().clone_inner();
             for (_path, mountfs) in mounts {
                 if !mountfs.is_readonly() {

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -18,7 +18,7 @@ use crate::{
     arch::{mm::LockedFrameAllocator, MMArch},
     filesystem::{
         page_cache::{list_page_caches, PageCache},
-        vfs::FilePrivateData,
+        vfs::{FilePrivateData, FileSystem},
     },
     init::initcall::INITCALL_CORE,
     libs::{
@@ -269,6 +269,17 @@ fn page_reclaim_thread() -> i32 {
             PageReclaimer::flush_dirty_pages();
             // 休眠5秒
             // log::info!("sleep");
+            // 本路径通过 writeback_page() 逐页写回，不经过 PageCacheManager::sync()，
+            // 因此 write_inode 不会被触发。此处通过 sync_fs 补充两部分：
+            // 1) per-page writeback 路径的 inode 元数据回写
+            // 2) metadata-only dirty inode（无 page cache，如 chmod/truncate）
+            let mounts = ProcessManager::current_mntns().mount_list().clone_inner();
+            for (_path, mountfs) in mounts {
+                if !mountfs.is_readonly() {
+                    let _ = mountfs.sync_fs(true);
+                }
+            }
+
             let _ = nanosleep(PosixTimeSpec::new(0, 500_000_000));
         }
     }

--- a/kernel/src/process/namespace/propagation.rs
+++ b/kernel/src/process/namespace/propagation.rs
@@ -941,7 +941,12 @@ pub fn propagate_umount(
 
 /// Umount at a specific peer mount.
 fn umount_at_peer(peer_mnt: &Arc<MountFS>, mountpoint_id: InodeId) -> Result<(), SystemError> {
-    if let Some(child) = peer_mnt.mountpoints().remove(&mountpoint_id) {
+    let child = peer_mnt.mountpoints().get(&mountpoint_id).cloned();
+    if let Some(child) = child {
+        child.sync_filesystem()?;
+        let Some(child) = peer_mnt.mountpoints().remove(&mountpoint_id) else {
+            return Ok(());
+        };
         // Unregister the child from its peer group if shared
         let child_prop = child.propagation();
         if child_prop.is_shared() {

--- a/user/apps/tests/dunitest/suites/normal/syncfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/syncfs_semantics.cc
@@ -1,0 +1,242 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
+
+#ifndef __NR_syncfs
+#if defined(__x86_64__)
+#define __NR_syncfs 306
+#elif defined(__riscv) || defined(__loongarch64)
+#define __NR_syncfs 267
+#else
+#error "__NR_syncfs is not defined for this architecture"
+#endif
+#endif
+
+namespace {
+
+#ifndef CLONE_NEWNS
+#define CLONE_NEWNS 0x00020000
+#endif
+
+#ifndef MS_REC
+#define MS_REC 16384
+#endif
+
+int EnsureDir(const char* path) {
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+    return mkdir(path, 0755);
+}
+
+long RawSyncfs(int fd) {
+    return syscall(__NR_syncfs, fd);
+}
+
+class TempFile {
+  public:
+    TempFile() {
+        char tmpl[] = "/tmp/dunitest_syncfs_XXXXXX";
+        fd_ = mkstemp(tmpl);
+        if (fd_ >= 0) {
+            path_ = tmpl;
+        }
+    }
+
+    ~TempFile() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        if (!path_.empty()) {
+            unlink(path_.c_str());
+        }
+    }
+
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+
+    bool valid() const {
+        return fd_ >= 0;
+    }
+
+    int fd() const {
+        return fd_;
+    }
+
+    const char* path() const {
+        return path_.c_str();
+    }
+
+    bool write_test_data() const {
+        constexpr char kData[] = "DragonOS syncfs dunitest data\n";
+        return write(fd_, kData, sizeof(kData) - 1) == static_cast<ssize_t>(sizeof(kData) - 1);
+    }
+
+  private:
+    std::string path_;
+    int fd_ = -1;
+};
+
+void ExpectSyncfsSucceeds(int fd) {
+    errno = 0;
+    EXPECT_EQ(0, RawSyncfs(fd));
+    EXPECT_EQ(0, errno) << "got errno=" << errno << " (" << strerror(errno) << ")";
+}
+
+void ExpectSyncfsErrno(int fd, int expected_errno) {
+    errno = 0;
+    EXPECT_EQ(-1, RawSyncfs(fd));
+    EXPECT_EQ(expected_errno, errno) << "got errno=" << errno << " (" << strerror(errno) << ")";
+}
+
+}  // namespace
+
+TEST(SyncfsSemantics, InvalidFdReturnsEbadf) {
+    ExpectSyncfsErrno(-1, EBADF);
+}
+
+TEST(SyncfsSemantics, RegularFileSucceedsAndPreservesOffset) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+    ASSERT_TRUE(file.write_test_data()) << "write failed: " << strerror(errno);
+    ASSERT_EQ(7, lseek(file.fd(), 7, SEEK_SET));
+
+    ExpectSyncfsSucceeds(file.fd());
+    EXPECT_EQ(7, lseek(file.fd(), 0, SEEK_CUR));
+}
+
+TEST(SyncfsSemantics, DirectoryFdSucceeds) {
+    int dir_fd = open("/tmp", O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(dir_fd, 0) << "open directory failed: " << strerror(errno);
+
+    ExpectSyncfsSucceeds(dir_fd);
+
+    close(dir_fd);
+}
+
+#ifdef O_PATH
+TEST(SyncfsSemantics, OPathFdReturnsEbadf) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    int path_fd = open(file.path(), O_PATH);
+    ASSERT_GE(path_fd, 0) << "open O_PATH failed: " << strerror(errno);
+
+    ExpectSyncfsErrno(path_fd, EBADF);
+
+    close(path_fd);
+}
+#endif
+
+TEST(SyncfsSemantics, PipeFdsSucceed) {
+    int pipefd[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(pipefd)) << "pipe failed: " << strerror(errno);
+
+    ExpectSyncfsSucceeds(pipefd[0]);
+    ExpectSyncfsSucceeds(pipefd[1]);
+
+    close(pipefd[0]);
+    close(pipefd[1]);
+}
+
+TEST(SyncfsSemantics, EventFdSucceeds) {
+    int fd = eventfd(0, 0);
+    ASSERT_GE(fd, 0) << "eventfd failed: " << strerror(errno);
+
+    ExpectSyncfsSucceeds(fd);
+
+    close(fd);
+}
+
+TEST(SyncfsSemantics, SocketPairFdsSucceed) {
+    int fds[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds))
+            << "socketpair failed: " << strerror(errno);
+
+    ExpectSyncfsSucceeds(fds[0]);
+    ExpectSyncfsSucceeds(fds[1]);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(SyncUmountLifetime, ConcurrentSyncAndUnmountPrivateRamfs) {
+    const char* root = "/tmp/dunitest_sync_umount";
+    const char* mountpoint = "/tmp/dunitest_sync_umount/mnt";
+    const char* file_path = "/tmp/dunitest_sync_umount/mnt/file";
+
+    ASSERT_EQ(0, EnsureDir("/tmp")) << strerror(errno);
+    ASSERT_EQ(0, EnsureDir(root)) << strerror(errno);
+    ASSERT_EQ(0, EnsureDir(mountpoint)) << strerror(errno);
+
+    if (unshare(CLONE_NEWNS) != 0) {
+        GTEST_SKIP() << "unshare(CLONE_NEWNS) failed: " << strerror(errno);
+    }
+
+    mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL);
+
+    for (int i = 0; i < 8; ++i) {
+        if (mount("", mountpoint, "ramfs", 0, NULL) != 0) {
+            GTEST_SKIP() << "mount ramfs failed: " << strerror(errno);
+        }
+
+        int fd = open(file_path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (fd < 0) {
+            int saved_errno = errno;
+            umount(mountpoint);
+            errno = saved_errno;
+            FAIL() << "open test file failed: " << strerror(errno);
+        }
+        if (write(fd, "data", 4) != 4) {
+            int saved_errno = errno;
+            close(fd);
+            umount(mountpoint);
+            errno = saved_errno;
+            FAIL() << "write failed: " << strerror(errno);
+        }
+        close(fd);
+
+        std::atomic<bool> stop{false};
+        std::thread sync_thread([&stop]() {
+            while (!stop.load(std::memory_order_relaxed)) {
+                sync();
+                sched_yield();
+            }
+        });
+
+        usleep(1000);
+        int umount_ret = umount(mountpoint);
+        int saved_errno = errno;
+        stop.store(true, std::memory_order_relaxed);
+        sync_thread.join();
+        errno = saved_errno;
+        ASSERT_EQ(0, umount_ret) << "umount failed: " << strerror(errno);
+    }
+
+    rmdir(mountpoint);
+    rmdir(root);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -3,6 +3,7 @@
 demo/gtest_demo
 normal/capability
 normal/fdatasync
+normal/syncfs_semantics
 normal/fcntl_lock
 normal/fcntl_signal
 normal/epoll_timeout_budget


### PR DESCRIPTION
### 1. 实现 ext4 脏 inode 追踪与延迟元数据刷盘
新增 `Ext4FileSystem::dirty_inodes` 列表，在 `write_at` 完成写操作后将 inode 加入脏列表（`mark_inode_dirty`），由 `flush_dirty_inodes` 统一刷盘。
使用 `Weak<LockedExt4Inode>` 避免延长 inode 生命周期。
**Linux 参考**：Linux 6.6 使用 per-backing-device 的 `bdi_writeback.b_dirty` 链表 + `inode->i_lock` 自旋锁 + `i_state` 中的 `I_DIRTY` 状态标志位。`__mark_inode_dirty()` 通过 `was_dirty = i_state & I_DIRTY` 判断是否已在脏列表，避免重复入队。
**DragonOS 实现**：使用 `bitflags!` 定义的 `InodeDirtyState: u32`，bit 位置对齐 Linux `I_DIRTY_*`
DragonOS 简化为单一 Mutex + bitflags，无锁快速路径暂未实现

### 2. 新增 VFS `write_inode` 回调
在 `IndexNode` trait 中新增 `write_inode()` 方法（默认 no-op），对应 Linux `super_operations.write_inode`。
`LockedExt4Inode` 实现 `write_inode`，调用已有的 `flush_metadata` 回写 size/mtime。
`MountFSInode` 透传到内部 inode。procfs/sysfs/pipe/socket 等无磁盘元数据的 inode 使用默认实现，不阻塞。
**已知简化**：Linux `write_inode` 接受 `struct writeback_control *wbc` 参数（含 `WB_SYNC_NONE`/`WB_SYNC_ALL` 模式），DragonOS 暂未实现此参数。当前无影响，后续实现周期性异步回写时需补充。

### 3. 新增 VFS `sync_fs` 回调
在 `FileSystem` trait 中新增 `sync_fs(wait: bool)` 方法（默认 no-op），对应 Linux `super_operations.sync_fs`。
`Ext4FileSystem` 实现 `sync_fs`，调用 `flush_dirty_inodes` 将脏 inode 元数据刷盘。
`MountFS` 透传到内部文件系统。
**当前限制**：`wait` 参数暂未使用。Linux ext4 中 `wait` 控制是否 `jbd2_log_wait_commit` 等待日志提交以及是否发送 `blkdev_issue_flush` barrier。DragonOS ext4 无日志机制，`sync_fs` 仅执行 `flush_dirty_inodes`，`wait` 不影响行为。

### 4. 重写 `sync(2)` 系统调用
对齐 Linux `ksys_sync()` 的流程：
- 步骤 1：`flush_dirty_pages()` — 唤醒回写脏页（对应 `wakeup_flusher_threads(WB_REASON_SYNC)`）
- 步骤 2：逐 superblock 调 `sync_inodes_of_mount`（对应 `iterate_supers(sync_inodes_one_sb, NULL)` → `sync_inodes_sb`）
- 步骤 3：逐 superblock 调 `sync_fs(false)`（对应 `iterate_supers(sync_fs_one_sb, &nowait)`，提交元数据但不等待）
- 步骤 4：逐 superblock 调 `sync_fs(true)`（对应 `iterate_supers(sync_fs_one_sb, &wait)`，等待元数据落盘）

所有步骤丢弃错误，始终返回 0，符合 Linux sync(2) 语义。
**已知缺失**：Linux 在步骤 4 之后还执行 `sync_bdevs(false)` + `sync_bdevs(true)` 刷写块设备缓存。DragonOS 尚无块设备 barrier 层，此步骤暂未实现。

### 5. 重写 `syncfs(2)` 系统调用
对齐 Linux `SYNCFS(2)` → `sync_filesystem()` 的流程。`syncfs` 直接调用 `MountFS::sync_filesystem()` 方法，该方法内部编排完整的同步序列：
- `sync_inodes_of_mount`（对应 `writeback_inodes_sb(sb, WB_REASON_SYNC)`，启动脏页写回）
- `sync_fs(false)`（对应 `sync_fs(sb, 0)`，非等待模式）
- `sync_inodes_of_mount`（对应 `sync_inodes_sb(sb)`，同步等待所有 inode 写回完成）
- `sync_fs(true)`（对应 `sync_fs(sb, 1)`，等待模式）

`sync_filesystem` 方法封装了只读检查（`is_readonly` 直接返回 Ok），syncfs 不再手动编排步骤，而是委托给 `MountFS::sync_filesystem()` 并映射错误到返回值。
非 VFS fd（pipe/socket 等）的 `downcast_arc::<MountFSInode>` 失败时直接返回 EBADF，对齐 Linux 行为（这些 fd 所属伪文件系统为只读，`sync_filesystem` 检查 `sb_rdonly` 后直接返回 0）。
O_PATH fd 返回 EBADF，对齐 Linux `fdget()` 的 `FMODE_PATH` 掩码过滤。
**已知缺失**：
1. Linux 在 sync_filesystem 内部执行 `sync_blockdev_nowait(sb->s_bdev)` / `sync_blockdev(sb->s_bdev)`。DragonOS 尚无块设备 barrier 层。
2. Linux sync_filesystem 持有 `down_read(&sb->s_umount)` 防止 sync 期间 umount，DragonOS 暂未实现此锁保护。

### 5.5 umount 时 sync_filesystem
`MountFS::do_umount_and_prepare_remount()` 

### 6. PageCacheManager::sync 触发 write_inode
`PageCacheManager::sync()` 在脏页写完后调用 `inode.write_inode()` 回写元数据，对应 Linux `__writeback_single_inode`中 `do_writepages()` 之后调用 `write_inode()` 的语义。
配合 `sync_fs → flush_dirty_inodes` 形成两层防护：page cache sync 路径和 sync_fs 路径都会尝试元数据回写，`flush_metadata` 内部通过 `InodeDirtyState` 的 `SIZE_DIRTY`/`MTIME_DIRTY` 位检查实现幂等。
**已知差异**：Linux 通过 `dirty & ~I_DIRTY_PAGES` 条件守卫，仅当 inode 元数据脏（`I_DIRTY_SYNC`/`I_DIRTY_DATASYNC`）时才调用 `write_inode`，纯脏页不触发。DragonOS 无条件调用 `write_inode`，依赖 `flush_metadata` 内部 `!size_dirty && !mtime_dirty` 早退检查实现幂等，功能等价但存在额外的函数调用开销。

### 7. page_reclaim_thread 周期性 sync_fs
后台回收线程在 `flush_dirty_pages` 后对每个非只读 mount 调用 `sync_fs(true)`，补充逐页 writeback 路径未覆盖的元数据回写。
对应 Linux 中 `__writeback_single_inode` 在 `do_writepages` 后调用 `write_inode` 的语义：脏页和元数据在同一次遍历中完成。DragonOS 的 `flush_dirty_pages()` 不触发 `write_inode`，此处通过 `sync_fs` 刷回 `dirty_inodes` 中的脏元数据。
