### PR TITLE
feat(rootfs): use ubuntu2404 as default rootfs manifest

### DIFF
--- a/env.mk
+++ b/env.mk
@@ -18,4 +18,4 @@ export DADK?=$(shell which dadk)
 endif
 
 # RootFS manifest name under config/rootfs-manifests/
-export ROOTFS_MANIFEST?=default
+export ROOTFS_MANIFEST?=ubuntu2404


### PR DESCRIPTION
将默认的 ROOTFS_MANIFEST 从 `default` 更改为 `ubuntu2404`。

### Changes
- 修改 `env.mk` 中 `ROOTFS_MANIFEST` 默认值从 `default` 改为 `ubuntu2404`

### Motivation
使用 Ubuntu 24.04 作为默认 rootfs，提供更现代的用户空间环境。