### PR TITLE
fix(net): preserve TCP socket state after failed bind

### DIFF
--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -45,8 +45,22 @@ impl BoundInner {
     where
         T: smoltcp::socket::AnySocket<'static>,
     {
+        Self::bind_recoverable(socket, address, netns).map_err(|(_, err)| err)
+    }
+
+    pub fn bind_recoverable<T>(
+        socket: T,
+        address: &smoltcp::wire::IpAddress,
+        netns: Arc<NetNamespace>,
+    ) -> Result<Self, (T, SystemError)>
+    where
+        T: smoltcp::socket::AnySocket<'static>,
+    {
         if address.is_unspecified() {
-            let iface = select_iface_for_unspecified(address, &netns)?;
+            let iface = match select_iface_for_unspecified(address, &netns) {
+                Ok(iface) => iface,
+                Err(err) => return Err((socket, err)),
+            };
             let handle = iface.sockets().lock().add(socket);
             return Ok(Self {
                 handle,
@@ -54,8 +68,10 @@ impl BoundInner {
                 netns,
             });
         } else {
-            let iface = get_iface_for_local_bind(address, &netns)
-                .ok_or_else(|| bind_addr_not_found_error(address, &netns))?;
+            let iface = match get_iface_for_local_bind(address, &netns) {
+                Some(iface) => iface,
+                None => return Err((socket, bind_addr_not_found_error(address, &netns))),
+            };
             // log::debug!(
             //     "BoundInner::bind: binding to iface {} for address {:?}",
             //     iface.iface_name(),
@@ -100,7 +116,21 @@ impl BoundInner {
     where
         T: smoltcp::socket::AnySocket<'static>,
     {
-        let (iface, address) = get_ephemeral_iface(&remote, netns.clone())?;
+        Self::bind_ephemeral_recoverable(socket, remote, netns).map_err(|(_, err)| err)
+    }
+
+    pub fn bind_ephemeral_recoverable<T>(
+        socket: T,
+        remote: smoltcp::wire::IpAddress,
+        netns: Arc<NetNamespace>,
+    ) -> Result<(Self, smoltcp::wire::IpAddress), (T, SystemError)>
+    where
+        T: smoltcp::socket::AnySocket<'static>,
+    {
+        let (iface, address) = match get_ephemeral_iface(&remote, netns.clone()) {
+            Ok(result) => result,
+            Err(err) => return Err((socket, err)),
+        };
         // let bound_port = iface.port_manager().bind_ephemeral_port(socket_type)?;
         let handle = iface.sockets().lock().add(socket);
         // let endpoint = smoltcp::wire::IpEndpoint::new(local_addr, bound_port);

--- a/kernel/src/net/socket/inet/stream/inner.rs
+++ b/kernel/src/net/socket/inet/stream/inner.rs
@@ -112,18 +112,41 @@ impl Init {
         self,
         local_endpoint: smoltcp::wire::IpEndpoint,
         netns: Arc<NetNamespace>,
-    ) -> Result<Self, SystemError> {
+    ) -> Result<Self, (Self, SystemError)> {
         match self {
-            Init::Unbound((socket, _)) => {
-                let bound = socket::inet::BoundInner::bind(*socket, &local_endpoint.addr, netns)?;
+            Init::Unbound((socket, ver)) => {
+                let bound = match socket::inet::BoundInner::bind_recoverable(
+                    *socket,
+                    &local_endpoint.addr,
+                    netns,
+                ) {
+                    Ok(bound) => bound,
+                    Err((socket, err)) => {
+                        return Err((Init::Unbound((Box::new(socket), ver)), err))
+                    }
+                };
 
                 // Handle ephemeral port assignment (port 0)
                 let bind_port = if local_endpoint.port == 0 {
-                    bound.port_manager().bind_ephemeral_port(Types::Tcp)?
+                    match bound.port_manager().bind_ephemeral_port(Types::Tcp) {
+                        Ok(port) => port,
+                        Err(err) => {
+                            let smoltcp::socket::Socket::Tcp(socket) = bound.into_socket() else {
+                                unreachable!("TCP BoundInner should contain a TCP socket");
+                            };
+                            return Err((Init::Unbound((Box::new(socket), ver)), err));
+                        }
+                    }
                 } else {
-                    bound
+                    if let Err(err) = bound
                         .port_manager()
-                        .bind_port(Types::Tcp, local_endpoint.port)?;
+                        .bind_port(Types::Tcp, local_endpoint.port)
+                    {
+                        let smoltcp::socket::Socket::Tcp(socket) = bound.into_socket() else {
+                            unreachable!("TCP BoundInner should contain a TCP socket");
+                        };
+                        return Err((Init::Unbound((Box::new(socket), ver)), err));
+                    }
                     local_endpoint.port
                 };
 
@@ -133,7 +156,7 @@ impl Init {
             }
             Init::Bound(_) => {
                 log::debug!("Already Bound");
-                Err(SystemError::EINVAL)
+                Err((self, SystemError::EINVAL))
             }
         }
     }
@@ -145,13 +168,25 @@ impl Init {
     ) -> Result<(socket::inet::BoundInner, smoltcp::wire::IpEndpoint), (Self, SystemError)> {
         match self {
             Init::Unbound((socket, ver)) => {
-                let (bound, address) =
-                    socket::inet::BoundInner::bind_ephemeral(*socket, remote_endpoint.addr, netns)
-                        .map_err(|err| (Self::new(ver), err))?;
-                let bound_port = bound
-                    .port_manager()
-                    .bind_ephemeral_port(Types::Tcp)
-                    .map_err(|err| (Self::new(ver), err))?;
+                let (bound, address) = match socket::inet::BoundInner::bind_ephemeral_recoverable(
+                    *socket,
+                    remote_endpoint.addr,
+                    netns,
+                ) {
+                    Ok(result) => result,
+                    Err((socket, err)) => {
+                        return Err((Self::Unbound((Box::new(socket), ver)), err))
+                    }
+                };
+                let bound_port = match bound.port_manager().bind_ephemeral_port(Types::Tcp) {
+                    Ok(port) => port,
+                    Err(err) => {
+                        let smoltcp::socket::Socket::Tcp(socket) = bound.into_socket() else {
+                            unreachable!("TCP BoundInner should contain a TCP socket");
+                        };
+                        return Err((Self::Unbound((Box::new(socket), ver)), err));
+                    }
+                };
                 let endpoint = smoltcp::wire::IpEndpoint::new(address, bound_port);
                 Ok((bound, endpoint))
             }
@@ -213,7 +248,7 @@ impl Init {
             let auto_bind_ep = smoltcp::wire::IpEndpoint::new(unspec_addr, 0);
             match self.bind(auto_bind_ep, netns.clone()) {
                 Ok(bound) => bound,
-                Err(err) => return Err((Init::new(ver), err)),
+                Err((init, err)) => return Err((init, err)),
             }
         } else {
             self

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -143,17 +143,22 @@ impl TcpSocket {
     pub fn do_bind(&self, local_endpoint: smoltcp::wire::IpEndpoint) -> Result<(), SystemError> {
         let mut writer = self.inner.write();
         match writer.take().expect("Tcp inner::Inner is None") {
-            inner::Inner::Init(inner) => {
-                let bound = inner.bind(local_endpoint, self.netns())?;
-                if let inner::Init::Bound((ref bound, _)) = bound {
-                    bound
-                        .iface()
-                        .common()
-                        .bind_socket(self.self_ref.upgrade().unwrap());
+            inner::Inner::Init(inner) => match inner.bind(local_endpoint, self.netns()) {
+                Ok(bound) => {
+                    if let inner::Init::Bound((ref bound, _)) = bound {
+                        bound
+                            .iface()
+                            .common()
+                            .bind_socket(self.self_ref.upgrade().unwrap());
+                    }
+                    writer.replace(inner::Inner::Init(bound));
+                    Ok(())
                 }
-                writer.replace(inner::Inner::Init(bound));
-                Ok(())
-            }
+                Err((inner, err)) => {
+                    writer.replace(inner::Inner::Init(inner));
+                    Err(err)
+                }
+            },
             any => {
                 writer.replace(any);
                 log::error!("TcpSocket::do_bind: not Init");

--- a/user/apps/tests/dunitest/suites/normal/tcp_bind_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/tcp_bind_semantics.cc
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+
+namespace {
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+
+    ~FdGuard() { Reset(); }
+
+    int Get() const { return fd_; }
+
+    void Reset(int fd = -1) {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        fd_ = fd;
+    }
+
+  private:
+    int fd_;
+};
+
+std::string ErrnoString(int err) {
+    return std::to_string(err) + " (" + std::strerror(err) + ")";
+}
+
+sockaddr_in LoopbackAddr(uint16_t port) {
+    sockaddr_in addr {};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    return addr;
+}
+
+uint16_t BoundPort(int fd) {
+    sockaddr_in addr {};
+    socklen_t len = sizeof(addr);
+    EXPECT_EQ(getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len), 0)
+            << "getsockname failed: " << ErrnoString(errno);
+    EXPECT_EQ(len, sizeof(addr));
+    return ntohs(addr.sin_port);
+}
+
+}  // namespace
+
+TEST(TcpBindSemantics, RepeatedBindReturnsEinvalAndPreservesSocket) {
+    FdGuard fd(socket(AF_INET, SOCK_STREAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET, SOCK_STREAM) failed: " << ErrnoString(errno);
+
+    sockaddr_in addr = LoopbackAddr(0);
+    ASSERT_EQ(bind(fd.Get(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0)
+            << "first bind failed: " << ErrnoString(errno);
+    const uint16_t first_port = BoundPort(fd.Get());
+    ASSERT_NE(first_port, 0);
+
+    errno = 0;
+    EXPECT_EQ(bind(fd.Get(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), -1);
+    EXPECT_EQ(errno, EINVAL);
+    EXPECT_EQ(BoundPort(fd.Get()), first_port);
+
+    EXPECT_EQ(listen(fd.Get(), 1), 0) << "listen after failed rebind failed: "
+                                     << ErrnoString(errno);
+}
+
+TEST(TcpBindSemantics, PortConflictDoesNotPoisonSocket) {
+    FdGuard first(socket(AF_INET, SOCK_STREAM, 0));
+    ASSERT_GE(first.Get(), 0) << "socket(first) failed: " << ErrnoString(errno);
+
+    sockaddr_in addr = LoopbackAddr(0);
+    ASSERT_EQ(bind(first.Get(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0)
+            << "bind(first) failed: " << ErrnoString(errno);
+    const uint16_t occupied_port = BoundPort(first.Get());
+    ASSERT_NE(occupied_port, 0);
+
+    FdGuard second(socket(AF_INET, SOCK_STREAM, 0));
+    ASSERT_GE(second.Get(), 0) << "socket(second) failed: " << ErrnoString(errno);
+
+    sockaddr_in occupied = LoopbackAddr(occupied_port);
+    errno = 0;
+    EXPECT_EQ(bind(second.Get(), reinterpret_cast<sockaddr*>(&occupied), sizeof(occupied)), -1);
+    EXPECT_EQ(errno, EADDRINUSE);
+
+    sockaddr_in ephemeral = LoopbackAddr(0);
+    ASSERT_EQ(bind(second.Get(), reinterpret_cast<sockaddr*>(&ephemeral), sizeof(ephemeral)), 0)
+            << "bind(second, ephemeral) after conflict failed: " << ErrnoString(errno);
+    ASSERT_NE(BoundPort(second.Get()), 0);
+    EXPECT_EQ(listen(second.Get(), 1), 0) << "listen(second) failed: " << ErrnoString(errno);
+}
+
+TEST(TcpBindSemantics, NonlocalAddressFailureDoesNotPoisonSocket) {
+    FdGuard fd(socket(AF_INET, SOCK_STREAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_INET, SOCK_STREAM) failed: " << ErrnoString(errno);
+
+    sockaddr_in nonlocal = LoopbackAddr(0);
+    ASSERT_EQ(inet_pton(AF_INET, "203.0.113.1", &nonlocal.sin_addr), 1);
+
+    errno = 0;
+    EXPECT_EQ(bind(fd.Get(), reinterpret_cast<sockaddr*>(&nonlocal), sizeof(nonlocal)), -1);
+    EXPECT_EQ(errno, EADDRNOTAVAIL);
+
+    sockaddr_in loopback = LoopbackAddr(0);
+    ASSERT_EQ(bind(fd.Get(), reinterpret_cast<sockaddr*>(&loopback), sizeof(loopback)), 0)
+            << "bind(loopback) after nonlocal failure failed: " << ErrnoString(errno);
+    ASSERT_NE(BoundPort(fd.Get()), 0);
+    EXPECT_EQ(listen(fd.Get(), 1), 0) << "listen after nonlocal failure failed: "
+                                     << ErrnoString(errno);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -25,6 +25,7 @@ normal/errseq_selftest
 normal/errseq_writeback_reporting
 normal/test_tlb_shootdown
 normal/pid_namespace_fork
+normal/tcp_bind_semantics
 normal/tcp_close_semantics
 normal/udp_ipv6_send_semantics
 normal/socket_getsockopt_semantics


### PR DESCRIPTION
## Summary

Fixes #1736.

This change preserves TCP socket state when `bind()` fails after `TcpSocket::do_bind()` temporarily takes the inner state. Repeated `bind()` on an already-bound TCP socket now returns `EINVAL` without leaving `TcpSocket.inner` as `None`, so later operations such as `listen()` no longer panic.

The patch also adds recoverable bind helpers for TCP initialization paths so failed interface selection or port allocation can restore the original smoltcp TCP socket and remove any inserted `SocketSet` handle.

## Tests

- `make fmt`
- `make kernel`
- `make all -j$(nproc)`
- `git diff --check`
- `user/apps/tests/dunitest/bin/normal/tcp_bind_semantics_test`
- QEMU guest: `/opt/tests/dunitest/bin/normal/tcp_bind_semantics_test`