### PR TITLE
fix(cgroup): preserve sysfs cgroup mountpoint

### DIFF
--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -438,7 +438,8 @@ impl VirtIOConsoleDriver {
         driver.standard_install(tty.clone())?;
         vc.port().setup_internal_tty(Arc::downgrade(&tty));
         tty.set_port(vc.port());
-        vc.devfs_setup()?;
+        tty.core()
+            .set_vc_index(vc.index().ok_or(SystemError::ENODEV)?);
 
         Ok(())
     }

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -362,7 +362,8 @@ impl Serial8250PIOTtyDriverInner {
         driver.standard_install(tty.clone())?;
         vc.port().setup_internal_tty(Arc::downgrade(&tty));
         tty.set_port(vc.port());
-        vc.devfs_setup()?;
+        tty.core()
+            .set_vc_index(vc.index().ok_or(SystemError::ENODEV)?);
 
         Ok(())
     }

--- a/kernel/src/filesystem/cgroup2/mod.rs
+++ b/kernel/src/filesystem/cgroup2/mod.rs
@@ -15,13 +15,15 @@ use crate::{
         cgroup_accounting_lock, cgroup_common_ancestor, cgroup_migrate_vet_dst_with_src,
         cgroup_root, CgroupNode,
     },
-    filesystem::kernfs::KernFSInode,
-    filesystem::vfs::{
-        file::{FileFlags, FilePrivateData},
-        permission::PermissionMask,
-        vcore::generate_inode_id,
-        FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode, InodeFlags, InodeMode, Magic,
-        Metadata, MountableFileSystem, SuperBlock,
+    filesystem::{
+        sysfs::sysfs_instance,
+        vfs::{
+            file::{FileFlags, FilePrivateData},
+            permission::PermissionMask,
+            vcore::generate_inode_id,
+            FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode, InodeFlags, InodeMode,
+            Magic, Metadata, MountableFileSystem, SuperBlock,
+        },
     },
     libs::{mutex::MutexGuard, once::Once, rwsem::RwSem, spinlock::SpinLock},
     process::ProcessManager,
@@ -118,10 +120,13 @@ pub fn cgroup2_init() -> Result<(), SystemError> {
     let mut result = None;
     INIT.call_once(|| {
         result = Some((|| -> Result<(), SystemError> {
+            sysfs_instance()
+                .ensure_mount_point_path(&["fs", "cgroup"], InodeMode::from_bits_truncate(0o755))?;
+
             let root_inode = ProcessManager::current_mntns().root_inode();
             let sys = root_inode.find("sys")?;
-            let fs_dir = ensure_dir(&sys, "fs", InodeMode::from_bits_truncate(0o755))?;
-            let cgroup_dir = ensure_dir(&fs_dir, "cgroup", InodeMode::from_bits_truncate(0o755))?;
+            let fs_dir = sys.find("fs")?;
+            let cgroup_dir = fs_dir.find("cgroup")?;
 
             let cgroup_fs = Cgroup2Fs::new(cgroup_root().root(), false);
             cgroup_dir.mount(
@@ -134,30 +139,6 @@ pub fn cgroup2_init() -> Result<(), SystemError> {
         })());
     });
     result.unwrap_or(Ok(()))
-}
-
-fn ensure_dir(
-    parent: &Arc<dyn IndexNode>,
-    name: &str,
-    mode: InodeMode,
-) -> Result<Arc<dyn IndexNode>, SystemError> {
-    if let Ok(inode) = parent.find(name) {
-        return Ok(inode);
-    }
-
-    if let Some(kernfs_parent) = parent.as_any_ref().downcast_ref::<KernFSInode>() {
-        return match kernfs_parent.add_dir(name.to_string(), mode, None, None) {
-            Ok(_) => parent.find(name),
-            Err(SystemError::EEXIST) => parent.find(name),
-            Err(e) => Err(e),
-        };
-    }
-
-    match parent.mkdir(name, mode) {
-        Ok(inode) => Ok(inode),
-        Err(SystemError::EEXIST) => parent.find(name),
-        Err(e) => Err(e),
-    }
 }
 
 impl Cgroup2Inode {

--- a/kernel/src/filesystem/kernfs/mod.rs
+++ b/kernel/src/filesystem/kernfs/mod.rs
@@ -113,6 +113,7 @@ impl KernFS {
             children: Mutex::new(HashMap::new()),
             inode_type: KernInodeType::Dir,
             lazy_list: Mutex::new(HashMap::new()),
+            lazy_build_lock: Mutex::new(()),
         });
 
         return root_inode;
@@ -138,6 +139,8 @@ pub struct KernFSInode {
     name: String,
     /// lazy list
     lazy_list: Mutex<HashMap<String, fn() -> KernFSInodeArgs>>,
+    /// Serializes lazy entry materialization without holding entry maps.
+    lazy_build_lock: Mutex<()>,
 }
 
 pub struct KernFSInodeArgs {
@@ -273,26 +276,13 @@ impl IndexNode for KernFSInode {
                     .ok_or(SystemError::ENOENT)?);
             }
             name => {
-                // 在子目录项中查找
-                let child = self.children.lock().get(name).cloned();
-                if let Some(child) = child {
+                if let Some(child) = self.children.lock().get(name).cloned() {
                     return Ok(child);
                 }
-                let lazy_list = self.lazy_list.lock();
-                if let Some(provider) = lazy_list.get(name) {
-                    // 如果存在lazy list，则调用提供者函数创建
-                    let args = provider();
-                    let inode = self.inner_create(
-                        name.to_string(),
-                        args.inode_type,
-                        args.mode,
-                        args.size.unwrap_or(4096),
-                        args.private_data,
-                        args.callback,
-                    )?;
-                    return Ok(inode);
-                }
-                Err(SystemError::ENOENT)
+
+                return self
+                    .materialize_lazy_child(name)
+                    .map(|child| child as Arc<dyn IndexNode>);
             }
         }
     }
@@ -465,6 +455,7 @@ impl KernFSInode {
             children: Mutex::new(HashMap::new()),
             inode_type,
             lazy_list: Mutex::new(HashMap::new()),
+            lazy_build_lock: Mutex::new(()),
         });
 
         // Set fs reference from parent if available
@@ -569,8 +560,53 @@ impl KernFSInode {
         if unlikely(self.inode_type != KernInodeType::Dir) {
             return Err(SystemError::ENOTDIR);
         }
-        self.lazy_list.lock().insert(name, provider);
+
+        let children = self.children.lock();
+        let mut lazy_list = self.lazy_list.lock();
+        if children.contains_key(&name) || lazy_list.contains_key(&name) {
+            return Err(SystemError::EEXIST);
+        }
+
+        lazy_list.insert(name, provider);
         Ok(())
+    }
+
+    fn materialize_lazy_child(&self, name: &str) -> Result<Arc<KernFSInode>, SystemError> {
+        let _build_guard = self.lazy_build_lock.lock();
+
+        if let Some(child) = self.children.lock().get(name).cloned() {
+            return Ok(child);
+        }
+
+        let provider = self
+            .lazy_list
+            .lock()
+            .get(name)
+            .copied()
+            .ok_or(SystemError::ENOENT)?;
+
+        let args = provider();
+        let inode = self.new_child_inode(
+            name.to_string(),
+            args.inode_type,
+            args.mode,
+            args.size.unwrap_or(4096),
+            args.private_data,
+            args.callback,
+        );
+
+        let mut children = self.children.lock();
+        if let Some(child) = children.get(name).cloned() {
+            return Ok(child);
+        }
+
+        let mut lazy_list = self.lazy_list.lock();
+        if lazy_list.remove(name).is_none() {
+            return children.get(name).cloned().ok_or(SystemError::ENOENT);
+        }
+
+        children.insert(name.to_string(), inode.clone());
+        Ok(inode)
     }
 
     fn inner_create(
@@ -578,10 +614,33 @@ impl KernFSInode {
         name: String,
         file_type: KernInodeType,
         mode: InodeMode,
-        mut size: usize,
+        size: usize,
         private_data: Option<KernInodePrivateData>,
         callback: Option<&'static dyn KernFSCallback>,
     ) -> Result<Arc<KernFSInode>, SystemError> {
+        let mut children = self.children.lock();
+        let lazy_list = self.lazy_list.lock();
+        if children.contains_key(&name) || lazy_list.contains_key(&name) {
+            return Err(SystemError::EEXIST);
+        }
+
+        let new_inode =
+            self.new_child_inode(name.clone(), file_type, mode, size, private_data, callback);
+
+        children.insert(name, new_inode.clone());
+
+        return Ok(new_inode);
+    }
+
+    fn new_child_inode(
+        &self,
+        name: String,
+        file_type: KernInodeType,
+        mode: InodeMode,
+        mut size: usize,
+        private_data: Option<KernInodePrivateData>,
+        callback: Option<&'static dyn KernFSCallback>,
+    ) -> Arc<KernFSInode> {
         match file_type {
             KernInodeType::Dir | KernInodeType::SymLink => {
                 size = 0;
@@ -608,18 +667,14 @@ impl KernFSInode {
             flags: InodeFlags::empty(),
         };
 
-        let new_inode: Arc<KernFSInode> = Self::new_with_parent(
+        Self::new_with_parent(
             Some(self.self_ref.upgrade().unwrap()),
-            name.clone(),
+            name,
             metadata,
             file_type,
             private_data,
             callback,
-        );
-
-        self.children.lock().insert(name, new_inode.clone());
-
-        return Ok(new_inode);
+        )
     }
 
     /// 在当前inode下删除子目录或者文件

--- a/kernel/src/filesystem/sysfs/dir.rs
+++ b/kernel/src/filesystem/sysfs/dir.rs
@@ -10,8 +10,9 @@ use crate::{
     driver::base::kobject::KObject,
     filesystem::{
         kernfs::{callback::KernInodePrivateData, KernFSInode},
-        vfs::InodeMode,
+        vfs::{FileType, IndexNode, InodeMode},
     },
+    libs::casting::DowncastArc,
 };
 
 use super::{SysFS, SysFSKernPrivateData};
@@ -74,6 +75,57 @@ impl SysFS {
         kobj.set_inode(Some(dir.clone()));
 
         return Ok(dir);
+    }
+
+    pub fn ensure_mount_point_path(
+        &self,
+        components: &[&str],
+        mode: InodeMode,
+    ) -> Result<Arc<KernFSInode>, SystemError> {
+        let mut current = self.root_inode.clone();
+
+        for component in components {
+            current = self.ensure_mount_point_component(&current, component, mode)?;
+        }
+
+        Ok(current)
+    }
+
+    fn ensure_mount_point_component(
+        &self,
+        parent: &Arc<KernFSInode>,
+        name: &str,
+        mode: InodeMode,
+    ) -> Result<Arc<KernFSInode>, SystemError> {
+        Self::validate_mount_point_component(name)?;
+
+        match parent.add_dir(name.to_string(), mode, None, None) {
+            Ok(inode) => Ok(inode),
+            Err(SystemError::EEXIST) => Self::existing_mount_point_dir(parent, name),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn validate_mount_point_component(name: &str) -> Result<(), SystemError> {
+        if name.is_empty() || name == "." || name == ".." || name.contains('/') {
+            return Err(SystemError::EINVAL);
+        }
+
+        Ok(())
+    }
+
+    fn existing_mount_point_dir(
+        parent: &Arc<KernFSInode>,
+        name: &str,
+    ) -> Result<Arc<KernFSInode>, SystemError> {
+        let inode = parent.find(name)?;
+        if inode.metadata()?.file_type != FileType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+
+        inode
+            .downcast_arc::<KernFSInode>()
+            .ok_or(SystemError::EINVAL)
     }
 
     /// 获取指定的kernfs inode在sysfs中的路径（不包含`/sys`）

--- a/kernel/src/filesystem/sysfs/mod.rs
+++ b/kernel/src/filesystem/sysfs/mod.rs
@@ -22,13 +22,17 @@ pub mod group;
 pub mod symlink;
 
 /// 全局的sysfs实例
-static mut SYSFS_INSTANCE: Option<SysFS> = None;
+static mut SYSFS_INSTANCE: Option<Arc<SysFS>> = None;
 
 #[inline(always)]
 pub fn sysfs_instance() -> &'static SysFS {
     unsafe {
-        return SYSFS_INSTANCE.as_ref().unwrap();
+        return SYSFS_INSTANCE.as_deref().unwrap();
     }
+}
+
+pub fn sysfs_filesystem() -> Result<Arc<SysFS>, SystemError> {
+    unsafe { SYSFS_INSTANCE.as_ref().cloned().ok_or(SystemError::ENODEV) }
 }
 
 pub fn sysfs_init() -> Result<(), SystemError> {
@@ -39,14 +43,15 @@ pub fn sysfs_init() -> Result<(), SystemError> {
 
         // 创建 sysfs 实例
         // let sysfs: Arc<OldSysFS> = OldSysFS::new();
-        let sysfs = SysFS::new();
-        unsafe { SYSFS_INSTANCE = Some(sysfs) };
+        let sysfs = Arc::new(SysFS::new());
+        unsafe { SYSFS_INSTANCE = Some(sysfs.clone()) };
         let root_inode = ProcessManager::current_mntns().root_inode();
+        let fs: Arc<dyn FileSystem> = sysfs;
         // sysfs 挂载
         root_inode
             .mkdir("sys", InodeMode::from_bits_truncate(0o755))
             .expect("Unabled to find /sys")
-            .mount(sysfs_instance().fs().clone(), MountFlags::empty())
+            .mount(fs, MountFlags::empty())
             .expect("Failed to mount at /sys");
         info!("SysFS mounted.");
 
@@ -221,10 +226,6 @@ impl SysFS {
         return &self.root_inode;
     }
 
-    pub fn fs(&self) -> &Arc<KernFS> {
-        return &self.kernfs;
-    }
-
     /// 警告：重复的sysfs entry
     pub(self) fn warn_duplicate(&self, parent: &Arc<KernFSInode>, name: &str) {
         let path = self.kernfs_path(parent);
@@ -271,8 +272,7 @@ impl MountableFileSystem for SysFS {
     fn make_fs(
         _data: Option<&dyn FileSystemMakerData>,
     ) -> Result<Arc<dyn FileSystem + 'static>, SystemError> {
-        let fs = SysFS::new();
-        Ok(Arc::new(fs))
+        Ok(sysfs_filesystem()?)
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/sysfs_cgroup2_mount.cc
+++ b/user/apps/tests/dunitest/suites/normal/sysfs_cgroup2_mount.cc
@@ -1,0 +1,243 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifndef CLONE_NEWNS
+#define CLONE_NEWNS 0x00020000
+#endif
+
+#ifndef MS_REC
+#define MS_REC 16384
+#endif
+
+#ifndef MS_RELATIME
+#define MS_RELATIME (1 << 21)
+#endif
+
+namespace {
+
+[[noreturn]] void child_fail(int detail_fd, const char* step) {
+    dprintf(detail_fd,
+            "%s: errno=%d (%s)",
+            step,
+            errno,
+            errno == 0 ? "no error information" : strerror(errno));
+    _exit(1);
+}
+
+template <typename Fn>
+void run_in_child(const char* case_name, Fn fn) {
+    int detail_pipe[2];
+    ASSERT_EQ(0, pipe(detail_pipe)) << strerror(errno);
+
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0) << strerror(errno);
+
+    if (pid == 0) {
+        close(detail_pipe[0]);
+        fn(detail_pipe[1]);
+        close(detail_pipe[1]);
+        _exit(0);
+    }
+
+    close(detail_pipe[1]);
+
+    std::string detail;
+    char buf[256];
+    ssize_t n = 0;
+    while ((n = read(detail_pipe[0], buf, sizeof(buf))) > 0) {
+        detail.append(buf, static_cast<size_t>(n));
+    }
+    close(detail_pipe[0]);
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+    }
+
+    ASSERT_TRUE(WIFEXITED(status)) << case_name << " child terminated abnormally";
+    ASSERT_EQ(0, WEXITSTATUS(status)) << case_name << " child failed: " << detail;
+}
+
+void expect_dir(int detail_fd, const char* path) {
+    struct stat st = {};
+    if (stat(path, &st) != 0) {
+        child_fail(detail_fd, path);
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        errno = ENOTDIR;
+        child_fail(detail_fd, path);
+    }
+}
+
+void make_private_mount_namespace(int detail_fd) {
+    if (unshare(CLONE_NEWNS) != 0) {
+        child_fail(detail_fd, "unshare(CLONE_NEWNS)");
+    }
+
+    if (mount(nullptr, "/", nullptr, MS_REC | MS_PRIVATE, nullptr) != 0) {
+        child_fail(detail_fd, "mount MS_REC|MS_PRIVATE /");
+    }
+}
+
+void mount_sysfs_on_sys(int detail_fd) {
+    if (mount("sysfs", "/sys", "sysfs", MS_NOSUID | MS_NODEV | MS_NOEXEC, nullptr) != 0) {
+        child_fail(detail_fd, "mount sysfs /sys");
+    }
+}
+
+void ensure_dir_recursive(int detail_fd, const char* path) {
+    std::string current;
+    const char* p = path;
+
+    if (*p == '/') {
+        current = "/";
+        ++p;
+    }
+
+    while (*p != '\0') {
+        const char* start = p;
+        while (*p != '\0' && *p != '/') {
+            ++p;
+        }
+
+        if (p > start) {
+            if (current.size() > 1) {
+                current.push_back('/');
+            }
+            current.append(start, static_cast<size_t>(p - start));
+
+            struct stat st = {};
+            if (stat(current.c_str(), &st) == 0) {
+                if (!S_ISDIR(st.st_mode)) {
+                    errno = ENOTDIR;
+                    child_fail(detail_fd, current.c_str());
+                }
+            } else if (errno == ENOENT) {
+                if (mkdir(current.c_str(), 0755) != 0 && errno != EEXIST) {
+                    child_fail(detail_fd, current.c_str());
+                }
+            } else {
+                child_fail(detail_fd, current.c_str());
+            }
+        }
+
+        while (*p == '/') {
+            ++p;
+        }
+    }
+}
+
+bool read_text_file(const char* path, std::string* out) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    out->clear();
+    char buf[512];
+    ssize_t n = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out->append(buf, static_cast<size_t>(n));
+    }
+
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return n >= 0;
+}
+
+bool mounts_has_exact_entry(const char* mountpoint, const char* fstype) {
+    std::ifstream mounts("/proc/self/mounts");
+    std::string line;
+
+    while (std::getline(mounts, line)) {
+        std::istringstream fields(line);
+        std::string source;
+        std::string target;
+        std::string type;
+        if (!(fields >> source >> target >> type)) {
+            continue;
+        }
+        if (target == mountpoint && type == fstype) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}  // namespace
+
+TEST(SysfsCgroup2Mount, SysfsRemountPreservesKernelMountPoint) {
+    run_in_child("SysfsRemountPreservesKernelMountPoint", [](int detail_fd) {
+        expect_dir(detail_fd, "/sys");
+        expect_dir(detail_fd, "/sys/fs");
+        expect_dir(detail_fd, "/sys/fs/cgroup");
+
+        make_private_mount_namespace(detail_fd);
+        mount_sysfs_on_sys(detail_fd);
+
+        expect_dir(detail_fd, "/sys/fs");
+        expect_dir(detail_fd, "/sys/fs/cgroup");
+    });
+}
+
+TEST(SysfsCgroup2Mount, CubeAgentUnifiedCgroupSequenceSucceeds) {
+    run_in_child("CubeAgentUnifiedCgroupSequenceSucceeds", [](int detail_fd) {
+        make_private_mount_namespace(detail_fd);
+        mount_sysfs_on_sys(detail_fd);
+
+        ensure_dir_recursive(detail_fd, "/sys/fs/cgroup");
+
+        if (mount("cgroup2",
+                  "/sys/fs/cgroup",
+                  "cgroup2",
+                  MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RELATIME,
+                  "nsdelegate") != 0) {
+            child_fail(detail_fd, "mount cgroup2 /sys/fs/cgroup");
+        }
+
+        std::string content;
+        if (!read_text_file("/sys/fs/cgroup/cgroup.procs", &content)) {
+            child_fail(detail_fd, "read cgroup.procs");
+        }
+        if (!read_text_file("/sys/fs/cgroup/cgroup.controllers", &content)) {
+            child_fail(detail_fd, "read cgroup.controllers");
+        }
+        if (!mounts_has_exact_entry("/sys/fs/cgroup", "cgroup2")) {
+            errno = ENOENT;
+            child_fail(detail_fd, "find cgroup2 in /proc/self/mounts");
+        }
+    });
+}
+
+TEST(SysfsCgroup2Mount, SysfsRejectsArbitraryUserMkdir) {
+    run_in_child("SysfsRejectsArbitraryUserMkdir", [](int detail_fd) {
+        make_private_mount_namespace(detail_fd);
+        mount_sysfs_on_sys(detail_fd);
+
+        const char* path = "/sys/dragonos_user_created_should_fail";
+        if (mkdir(path, 0755) == 0) {
+            errno = 0;
+            child_fail(detail_fd, "mkdir unexpectedly succeeded in sysfs");
+        }
+    });
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -42,3 +42,4 @@ normal/signal_fpstate_sigreturn
 normal/general_protection_signal
 normal/seccomp
 normal/process_signal_fork
+normal/sysfs_cgroup2_mount


### PR DESCRIPTION
## Summary

- Keep sysfs backed by a single global instance so sysfs remounts preserve kernel-created mount points such as `/sys/fs/cgroup`.
- Create the cgroup2 mount point through the sysfs/kernfs tree and mount cgroup2 on that stable node.
- Make kernfs reject duplicate child names with `EEXIST`, including lazy entries, matching Linux kernfs semantics.
- Avoid duplicate `dev_t` registration for serial and virtio console tty devices after kernfs duplicate-name checks become strict.
- Add dunitest coverage for sysfs remount behavior, the cube-agent-style cgroup2 mount sequence, and sysfs mkdir rejection.

## Validation

- `make kernel`
- `SKIP_GRUB=1 make write_diskimage`
- Booted DragonOS with `init=/bin/cube-agent agent.unified_cgroup_hierarchy=true`; cube-agent now passes the cgroup mount sequence and reaches the next, separate `/dev/ptmx` unlink issue.
- Ran `sysfs_cgroup2_mount_test` inside DragonOS: 3 tests passed.
- `make fmt`
- `git diff --check`

Refs #1946