### PR TITLE
feat(x86): implement ioperm syscall

### DIFF
--- a/kernel/src/arch/x86_64/process/io_bitmap.rs
+++ b/kernel/src/arch/x86_64/process/io_bitmap.rs
@@ -1,0 +1,169 @@
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use system_error::SystemError;
+
+use crate::{
+    libs::spinlock::SpinLock,
+    process::{
+        cred::{capable, CAPFlags},
+        ProcessManager,
+    },
+};
+
+pub const IO_BITMAP_BITS: usize = 65_536;
+pub const IO_BITMAP_BYTES: usize = IO_BITMAP_BITS / 8;
+pub const IO_BITMAP_TERMINATOR_BYTES: usize = 1;
+
+static IO_BITMAP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+fn next_sequence() -> u64 {
+    IO_BITMAP_SEQUENCE.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskIoBitmap {
+    sequence: u64,
+    max_bytes: usize,
+    bitmap: [u8; IO_BITMAP_BYTES],
+}
+
+impl TaskIoBitmap {
+    pub fn new_all_denied() -> Self {
+        Self {
+            sequence: next_sequence(),
+            max_bytes: 0,
+            bitmap: [0xff; IO_BITMAP_BYTES],
+        }
+    }
+
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    pub fn max_bytes(&self) -> usize {
+        self.max_bytes
+    }
+
+    pub fn bitmap(&self) -> &[u8; IO_BITMAP_BYTES] {
+        &self.bitmap
+    }
+
+    pub fn allow_range(&mut self, from: usize, num: usize) {
+        self.update_range(from, num, false);
+    }
+
+    pub fn deny_range(&mut self, from: usize, num: usize) {
+        self.update_range(from, num, true);
+    }
+
+    pub fn all_denied(&self) -> bool {
+        self.max_bytes == 0
+    }
+
+    fn update_range(&mut self, from: usize, num: usize, deny: bool) {
+        let end = from + num;
+        for port in from..end {
+            let byte = port / 8;
+            let bit = 1u8 << (port & 7);
+            if deny {
+                self.bitmap[byte] |= bit;
+            } else {
+                self.bitmap[byte] &= !bit;
+            }
+        }
+        self.recompute_max_bytes();
+        self.sequence = next_sequence();
+    }
+
+    fn recompute_max_bytes(&mut self) {
+        self.max_bytes = self
+            .bitmap
+            .iter()
+            .rposition(|byte| *byte != 0xff)
+            .map(|index| index + 1)
+            .unwrap_or(0);
+    }
+}
+
+fn validate_range(from: usize, num: usize) -> Result<(), SystemError> {
+    let end = from.checked_add(num).ok_or(SystemError::EINVAL)?;
+    if end <= from || end > IO_BITMAP_BITS {
+        return Err(SystemError::EINVAL);
+    }
+    Ok(())
+}
+
+pub fn do_ioperm(from: usize, num: usize, turn_on: bool) -> Result<usize, SystemError> {
+    validate_range(from, num)?;
+
+    if turn_on && !capable(CAPFlags::CAP_SYS_RAWIO) {
+        return Err(SystemError::EPERM);
+    }
+
+    let current = ProcessManager::current_pcb();
+    let bitmap = loop {
+        let shared_bitmap = {
+            let mut arch = current.arch_info_irqsave();
+
+            if arch.io_bitmap_ref().is_none() {
+                if !turn_on {
+                    return Ok(0);
+                }
+                arch.set_io_bitmap(Some(Arc::new(
+                    SpinLock::new(TaskIoBitmap::new_all_denied()),
+                )));
+            }
+
+            let existing = arch
+                .io_bitmap_ref()
+                .expect("ioperm bitmap must exist after allocation");
+            if Arc::strong_count(existing) == 1 {
+                break arch
+                    .io_bitmap()
+                    .expect("ioperm bitmap must exist after allocation");
+            }
+            arch.io_bitmap()
+                .expect("ioperm bitmap must exist after allocation")
+        };
+
+        let cloned = {
+            let guard = shared_bitmap.lock_irqsave();
+            guard.clone()
+        };
+        let private_bitmap = Arc::new(SpinLock::new(cloned));
+
+        let mut arch = current.arch_info_irqsave();
+        if arch
+            .io_bitmap_ref()
+            .map(|existing| Arc::ptr_eq(existing, &shared_bitmap))
+            .unwrap_or(false)
+        {
+            arch.set_io_bitmap(Some(private_bitmap.clone()));
+            break private_bitmap;
+        }
+    };
+
+    let all_denied = {
+        let mut guard = bitmap.lock_irqsave();
+        if turn_on {
+            guard.allow_range(from, num);
+        } else {
+            guard.deny_range(from, num);
+        }
+        guard.all_denied()
+    };
+
+    if all_denied {
+        let mut arch = current.arch_info_irqsave();
+        if arch
+            .io_bitmap_ref()
+            .map(|existing| Arc::ptr_eq(existing, &bitmap))
+            .unwrap_or(false)
+        {
+            arch.set_io_bitmap(None);
+        }
+    }
+
+    Ok(0)
+}

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -17,7 +17,7 @@ use x86::{controlregs::Cr4, segmentation::SegmentSelector};
 use crate::{
     arch::process::table::TSSManager,
     exception::InterruptArch,
-    libs::spinlock::SpinLockGuard,
+    libs::spinlock::{SpinLock, SpinLockGuard},
     mm::VirtAddr,
     process::{
         fork::{CloneFlags, KernelCloneArgs},
@@ -28,6 +28,7 @@ use crate::{
 };
 
 use self::{
+    io_bitmap::TaskIoBitmap,
     kthread::kernel_thread_bootstrap_stage1,
     syscall::ARCH_SET_FS,
     table::{switch_fs_and_gs, KERNEL_DS, USER_DS},
@@ -39,6 +40,7 @@ use super::{
 };
 
 pub mod idle;
+pub mod io_bitmap;
 pub mod kthread;
 pub mod syscall;
 pub mod table;
@@ -83,6 +85,8 @@ pub struct ArchPCBInfo {
     gsdata: X86_64GSData,
     /// 浮点寄存器的状态
     fp_state: Option<FpState>,
+    /// x86 I/O permission bitmap shared with forked user tasks.
+    io_bitmap: Option<Arc<SpinLock<TaskIoBitmap>>>,
 }
 
 #[allow(dead_code)]
@@ -118,6 +122,7 @@ impl ArchPCBInfo {
             fs: KERNEL_DS,
             gs: KERNEL_DS,
             fp_state: None,
+            io_bitmap: None,
         };
 
         r.rsp = kstack.stack_max_address().data() - 8;
@@ -242,6 +247,18 @@ impl ArchPCBInfo {
         &mut self.fp_state
     }
 
+    pub fn io_bitmap(&self) -> Option<Arc<SpinLock<TaskIoBitmap>>> {
+        self.io_bitmap.clone()
+    }
+
+    pub fn io_bitmap_ref(&self) -> Option<&Arc<SpinLock<TaskIoBitmap>>> {
+        self.io_bitmap.as_ref()
+    }
+
+    pub fn set_io_bitmap(&mut self, bitmap: Option<Arc<SpinLock<TaskIoBitmap>>>) {
+        self.io_bitmap = bitmap;
+    }
+
     /// ### 克隆ArchPCBInfo,需要注意gsdata也是对应clone的
     pub fn clone_all(&self) -> Self {
         Self {
@@ -261,6 +278,7 @@ impl ArchPCBInfo {
             gs: self.gs,
             gsdata: self.gsdata.clone(),
             fp_state: self.fp_state,
+            io_bitmap: self.io_bitmap.clone(),
         }
     }
 
@@ -352,6 +370,7 @@ impl ProcessManager {
         new_arch_guard.fs = current_arch_guard.fs;
         new_arch_guard.gs = current_arch_guard.gs;
         new_arch_guard.fp_state = current_arch_guard.fp_state;
+        new_arch_guard.io_bitmap = current_arch_guard.io_bitmap.clone();
 
         // 拷贝浮点寄存器的状态
         if let Some(fp_state) = current_arch_guard.fp_state.as_ref() {
@@ -361,6 +380,7 @@ impl ProcessManager {
 
         // 设置返回地址（子进程开始执行的指令地址）
         if new_pcb.flags().contains(ProcessFlags::KTHREAD) {
+            new_arch_guard.io_bitmap = None;
             let kthread_bootstrap_stage1_func_addr = kernel_thread_bootstrap_stage1 as usize;
             new_arch_guard.rip = kthread_bootstrap_stage1_func_addr;
         } else {
@@ -445,6 +465,7 @@ impl ProcessManager {
             x86::Ring::Ring0,
             next.kernel_stack().stack_max_address().data() as u64,
         );
+        TSSManager::invalidate_io_bitmap();
         PROCESS_SWITCH_RESULT.as_mut().unwrap().get_mut().prev_pcb = Some(prev);
         PROCESS_SWITCH_RESULT.as_mut().unwrap().get_mut().next_pcb = Some(next);
         // debug!("switch tss ok");
@@ -596,6 +617,7 @@ pub unsafe fn arch_switch_to_user(trap_frame: TrapFrame) -> ! {
     // 重要！在这里之后，一定要保证上面的引用计数变量、动态申请的变量、锁的守卫都被drop了，否则可能导致内存安全问题！
 
     compiler_fence(Ordering::SeqCst);
+    TSSManager::update_io_bitmap_from_current();
     crate::rcu::note_exit_to_user_mode();
     ready_to_switch_to_user(trap_frame, trap_frame_vaddr.data(), new_rip.data());
 }

--- a/kernel/src/arch/x86_64/process/table.rs
+++ b/kernel/src/arch/x86_64/process/table.rs
@@ -1,7 +1,15 @@
+use core::cmp;
+
 use x86::{current::task::TaskStateSegment, segmentation::SegmentSelector, Ring};
 
 use crate::{
+    arch::{
+        process::io_bitmap::{TaskIoBitmap, IO_BITMAP_BYTES, IO_BITMAP_TERMINATOR_BYTES},
+        CurrentIrqArch,
+    },
+    exception::InterruptArch,
     mm::{percpu::PerCpu, VirtAddr},
+    process::ProcessManager,
     smp::core::smp_get_processor_id,
 };
 
@@ -16,13 +24,24 @@ pub const USER_DS: SegmentSelector = SegmentSelector::new(5, Ring::Ring3);
 /// 如果改这里，记得改syscall_64里面写死的常量
 pub const USER_CS: SegmentSelector = SegmentSelector::new(6, Ring::Ring3);
 
+const HARDWARE_TSS_SIZE: usize = core::mem::size_of::<TaskStateSegment>();
+const IO_BITMAP_OFFSET_VALID: u16 = HARDWARE_TSS_SIZE as u16;
+const IO_BITMAP_TOTAL_BYTES: usize = IO_BITMAP_BYTES + IO_BITMAP_TERMINATOR_BYTES;
+const TSS_LIMIT: u16 = (HARDWARE_TSS_SIZE + IO_BITMAP_TOTAL_BYTES - 1) as u16;
+const IO_BITMAP_OFFSET_INVALID: u16 = TSS_LIMIT + 1;
+
+const _: () = assert!(HARDWARE_TSS_SIZE <= u16::MAX as usize);
+const _: () = assert!(HARDWARE_TSS_SIZE + IO_BITMAP_TOTAL_BYTES <= u16::MAX as usize);
+const _: () = assert!(TSS_LIMIT as usize <= 0x000f_ffff);
+
 static mut TSS_MANAGER: TSSManager = TSSManager {
-    tss: [TaskStateSegment::new(); PerCpu::MAX_CPU_NUM as usize],
+    tss: [DragonOsTss::new(); PerCpu::MAX_CPU_NUM as usize],
 };
 
 extern "C" {
     static mut GDT_Table: [u64; 512];
 }
+
 /// 切换fs和gs段寄存器
 ///
 /// 由于需要return使得它生效，所以不能inline
@@ -32,14 +51,63 @@ pub unsafe fn switch_fs_and_gs(fs: SegmentSelector, gs: SegmentSelector) {
     x86::segmentation::load_gs(gs);
 }
 
+#[derive(Clone, Copy, Debug)]
+#[repr(C, align(4096))]
+pub struct DragonOsTss {
+    hw_tss: TaskStateSegment,
+    io_bitmap: [u8; IO_BITMAP_TOTAL_BYTES],
+    prev_sequence: u64,
+    prev_max_bytes: usize,
+}
+
+impl DragonOsTss {
+    pub const fn new() -> Self {
+        let mut hw_tss = TaskStateSegment::new();
+        hw_tss.iomap_base = IO_BITMAP_OFFSET_INVALID;
+
+        Self {
+            hw_tss,
+            io_bitmap: [0xff; IO_BITMAP_TOTAL_BYTES],
+            prev_sequence: 0,
+            prev_max_bytes: 0,
+        }
+    }
+
+    pub fn set_rsp(&mut self, pl: Ring, stack_ptr: u64) {
+        self.hw_tss.set_rsp(pl, stack_ptr);
+    }
+
+    pub fn set_ist(&mut self, index: usize, stack_ptr: u64) {
+        self.hw_tss.set_ist(index, stack_ptr);
+    }
+
+    fn invalidate_io_bitmap(&mut self) {
+        self.hw_tss.iomap_base = IO_BITMAP_OFFSET_INVALID;
+    }
+
+    fn load_io_bitmap(&mut self, bitmap: &TaskIoBitmap) {
+        if self.prev_sequence != bitmap.sequence() {
+            let copy_len = cmp::max(self.prev_max_bytes, bitmap.max_bytes()).min(IO_BITMAP_BYTES);
+            if copy_len > 0 {
+                self.io_bitmap[..copy_len].copy_from_slice(&bitmap.bitmap()[..copy_len]);
+            }
+            self.io_bitmap[IO_BITMAP_BYTES] = 0xff;
+            self.prev_sequence = bitmap.sequence();
+            self.prev_max_bytes = bitmap.max_bytes();
+        }
+
+        self.hw_tss.iomap_base = IO_BITMAP_OFFSET_VALID;
+    }
+}
+
 #[derive(Debug)]
 pub struct TSSManager {
-    tss: [TaskStateSegment; PerCpu::MAX_CPU_NUM as usize],
+    tss: [DragonOsTss; PerCpu::MAX_CPU_NUM as usize],
 }
 
 impl TSSManager {
     /// 获取当前CPU的TSS
-    pub unsafe fn current_tss() -> &'static mut TaskStateSegment {
+    pub unsafe fn current_tss() -> &'static mut DragonOsTss {
         &mut TSS_MANAGER.tss[smp_get_processor_id().data() as usize]
     }
 
@@ -48,25 +116,44 @@ impl TSSManager {
         let index = (10 + smp_get_processor_id().data() * 2) as u16;
         let selector = SegmentSelector::new(index, Ring::Ring0);
 
-        Self::set_tss_descriptor(
-            index,
-            VirtAddr::new(Self::current_tss() as *mut TaskStateSegment as usize),
-        );
+        Self::set_tss_descriptor(index, VirtAddr::new(Self::current_tss() as *mut _ as usize));
         x86::task::load_tr(selector);
+    }
+
+    pub unsafe fn invalidate_io_bitmap() {
+        Self::current_tss().invalidate_io_bitmap();
+    }
+
+    pub fn update_io_bitmap_from_current() {
+        let bitmap = {
+            let current = ProcessManager::current_pcb();
+            let arch = current.arch_info_irqsave();
+            arch.io_bitmap()
+        };
+
+        let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+        let tss = unsafe { Self::current_tss() };
+        if let Some(bitmap) = bitmap {
+            let guard = bitmap.lock_irqsave();
+            tss.load_io_bitmap(&guard);
+        } else {
+            tss.invalidate_io_bitmap();
+        }
     }
 
     #[allow(static_mut_refs)]
     unsafe fn set_tss_descriptor(index: u16, vaddr: VirtAddr) {
-        const LIMIT: u64 = 103;
+        let limit = TSS_LIMIT as u64;
         let gdt_vaddr = VirtAddr::new(&GDT_Table as *const _ as usize);
 
         let gdt: &mut [u64] = core::slice::from_raw_parts_mut(gdt_vaddr.data() as *mut u64, 512);
 
         let vaddr = vaddr.data() as u64;
-        gdt[index as usize] = (LIMIT & 0xffff)
+        gdt[index as usize] = (limit & 0xffff)
             | ((vaddr & 0xffff) << 16)
             | (((vaddr >> 16) & 0xff) << 32)
             | (0x89 << 40)
+            | (((limit >> 16) & 0xf) << 48)
             | (((vaddr >> 24) & 0xff) << 56);
         gdt[index as usize + 1] = (vaddr >> 32) & 0xffffffff;
     }

--- a/kernel/src/exception/entry.rs
+++ b/kernel/src/exception/entry.rs
@@ -20,6 +20,8 @@ unsafe extern "C" fn irqentry_exit(frame: &mut TrapFrame) {
 /// 必须保证所有的栈上的Arc/Box指针等，都已经被释放。否则，可能会导致内存泄漏。
 unsafe fn irqentry_exit_to_user_mode(frame: &mut TrapFrame) {
     exit_to_user_mode_prepare(frame);
+    #[cfg(target_arch = "x86_64")]
+    crate::arch::process::table::TSSManager::update_io_bitmap_from_current();
     crate::rcu::note_exit_to_user_mode();
 }
 

--- a/kernel/src/process/cred.rs
+++ b/kernel/src/process/cred.rs
@@ -293,6 +293,15 @@ pub fn ns_capable(ns: &Arc<UserNamespace>, cap: CAPFlags) -> bool {
     cap_capable(&pcb.cred(), ns, cap)
 }
 
+/// Check whether the current process has a capability in the initial user namespace.
+///
+/// Linux `capable(cap)` is equivalent to `ns_capable(&init_user_ns, cap)`.
+/// Hardware-level capabilities such as `CAP_SYS_RAWIO` must use this semantic
+/// instead of checking the current process user namespace.
+pub fn capable(cap: CAPFlags) -> bool {
+    ns_capable(&INIT_USER_NAMESPACE, cap)
+}
+
 /// 检查当前进程在指定 ns 中是否有某 capability（setid 上下文）
 pub fn ns_capable_setid(ns: &Arc<UserNamespace>, cap: CAPFlags) -> bool {
     ns_capable(ns, cap)

--- a/kernel/src/process/syscall/mod.rs
+++ b/kernel/src/process/syscall/mod.rs
@@ -54,6 +54,8 @@ mod sys_getpgrp;
 #[cfg(target_arch = "x86_64")]
 mod sys_getrlimit;
 #[cfg(target_arch = "x86_64")]
+mod sys_ioperm;
+#[cfg(target_arch = "x86_64")]
 mod sys_setrlimit;
 #[cfg(target_arch = "x86_64")]
 mod sys_vfork;

--- a/kernel/src/process/syscall/sys_ioperm.rs
+++ b/kernel/src/process/syscall/sys_ioperm.rs
@@ -1,0 +1,48 @@
+use alloc::{format, vec::Vec};
+
+use system_error::SystemError;
+
+use crate::{
+    arch::{interrupt::TrapFrame, syscall::nr::SYS_IOPERM},
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+
+pub struct SysIoperm;
+
+impl SysIoperm {
+    fn from(args: &[usize]) -> usize {
+        args[0]
+    }
+
+    fn num(args: &[usize]) -> usize {
+        args[1]
+    }
+
+    fn turn_on(args: &[usize]) -> bool {
+        args[2] != 0
+    }
+}
+
+impl Syscall for SysIoperm {
+    fn num_args(&self) -> usize {
+        3
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        crate::arch::process::io_bitmap::do_ioperm(
+            Self::from(args),
+            Self::num(args),
+            Self::turn_on(args),
+        )
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("from", format!("{:#x}", Self::from(args))),
+            FormattedSyscallParam::new("num", format!("{}", Self::num(args))),
+            FormattedSyscallParam::new("turn_on", format!("{}", args[2])),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_IOPERM, SysIoperm);

--- a/user/apps/tests/dunitest/suites/normal/ioperm_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/ioperm_semantics.cc
@@ -1,0 +1,235 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#ifndef SYS_ioperm
+#define SYS_ioperm 173
+#endif
+
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER 0x10000000
+#endif
+
+namespace {
+
+constexpr uint16_t kPort = 0x80;
+constexpr uint16_t kSecondPort = 0x81;
+constexpr size_t kCloneStackSize = 1 << 20;
+
+const char* g_program_path = nullptr;
+
+int ioperm_errno(unsigned long from, unsigned long num, int turn_on) {
+    errno = 0;
+    long ret = syscall(SYS_ioperm, from, num, turn_on);
+    if (ret == 0) {
+        return 0;
+    }
+    return errno;
+}
+
+void outb(uint16_t port) {
+#if defined(__x86_64__)
+    uint8_t value = 0;
+    __asm__ __volatile__("outb %0, %w1" : : "a"(value), "Nd"(port) : "memory");
+#endif
+}
+
+int run_outb_child(uint16_t port) {
+    pid_t child = fork();
+    if (child < 0) {
+        return -errno;
+    }
+
+    if (child == 0) {
+        outb(port);
+        _exit(0);
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        return -errno;
+    }
+    return status;
+}
+
+void expect_outb_sigsegv(uint16_t port) {
+    int status = run_outb_child(port);
+    ASSERT_GE(status, 0);
+    ASSERT_TRUE(WIFSIGNALED(status)) << "status=" << status;
+    EXPECT_EQ(SIGSEGV, WTERMSIG(status));
+}
+
+int wait_for_child(pid_t child) {
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        return -errno;
+    }
+    return status;
+}
+
+int new_userns_child(void*) {
+    int grant_err = ioperm_errno(kPort, 1, 1);
+    if (grant_err != EPERM) {
+        return grant_err == 0 ? 10 : grant_err;
+    }
+    return ioperm_errno(kPort, 1, 0);
+}
+
+int run_in_new_userns() {
+    std::vector<char> stack(kCloneStackSize);
+    pid_t child = clone(new_userns_child, stack.data() + stack.size(), CLONE_NEWUSER | SIGCHLD,
+                        nullptr);
+    if (child < 0) {
+        return -errno;
+    }
+    return wait_for_child(child);
+}
+
+int exec_child_main() {
+    outb(kPort);
+    return 0;
+}
+
+class IopermSemantics : public ::testing::Test {
+protected:
+    void SetUp() override {
+        (void)ioperm_errno(kPort, 1, 0);
+        (void)ioperm_errno(kSecondPort, 1, 0);
+    }
+
+    void TearDown() override {
+        (void)ioperm_errno(kPort, 1, 0);
+        (void)ioperm_errno(kSecondPort, 1, 0);
+    }
+};
+
+}  // namespace
+
+TEST_F(IopermSemantics, DefaultOutbWithoutIopermGetsSigsegv) {
+    expect_outb_sigsegv(kPort);
+}
+
+TEST_F(IopermSemantics, InvalidRangesReturnEinval) {
+    EXPECT_EQ(EINVAL, ioperm_errno(kPort, 0, 1));
+    EXPECT_EQ(EINVAL, ioperm_errno(65535, 2, 1));
+    EXPECT_EQ(EINVAL, ioperm_errno(~0UL, 2, 1));
+}
+
+TEST_F(IopermSemantics, RevokeWithoutBitmapSucceeds) {
+    EXPECT_EQ(0, ioperm_errno(kPort, 1, 0));
+}
+
+TEST_F(IopermSemantics, GrantAllowsImmediateOutbAndRevokeDenies) {
+    ASSERT_EQ(0, ioperm_errno(kPort, 1, 1));
+    outb(kPort);
+
+    ASSERT_EQ(0, ioperm_errno(kPort, 1, 0));
+    expect_outb_sigsegv(kPort);
+}
+
+TEST_F(IopermSemantics, ForkInheritsPermissionAndMutationIsCopyOnWrite) {
+    ASSERT_EQ(0, ioperm_errno(kPort, 1, 1));
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        int status = run_outb_child(kPort);
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            _exit(11);
+        }
+
+        if (ioperm_errno(kPort, 1, 0) != 0) {
+            _exit(12);
+        }
+
+        status = run_outb_child(kPort);
+        if (!WIFSIGNALED(status) || WTERMSIG(status) != SIGSEGV) {
+            _exit(13);
+        }
+        _exit(0);
+    }
+
+    int status = wait_for_child(child);
+    ASSERT_GE(status, 0);
+    ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    outb(kPort);
+}
+
+TEST_F(IopermSemantics, ExecPreservesPermission) {
+    ASSERT_NE(nullptr, g_program_path);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        if (ioperm_errno(kPort, 1, 1) != 0) {
+            _exit(11);
+        }
+        setenv("DRAGONOS_IOPERM_EXEC_CHILD", "1", 1);
+        execl(g_program_path, g_program_path, nullptr);
+        _exit(errno == 0 ? 12 : errno);
+    }
+
+    int status = wait_for_child(child);
+    ASSERT_GE(status, 0);
+    ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
+TEST_F(IopermSemantics, GrantRequiresCapSysRawioButRevokeDoesNot) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        if (setresuid(1000, 1000, 1000) != 0) {
+            _exit(errno == 0 ? 11 : errno);
+        }
+
+        int grant_err = ioperm_errno(kPort, 1, 1);
+        if (grant_err != EPERM) {
+            _exit(grant_err == 0 ? 12 : grant_err);
+        }
+
+        int revoke_err = ioperm_errno(kPort, 1, 0);
+        _exit(revoke_err);
+    }
+
+    int status = wait_for_child(child);
+    ASSERT_GE(status, 0);
+    ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
+TEST_F(IopermSemantics, NewUserNamespaceRootStillCannotGrantRawIo) {
+    int status = run_in_new_userns();
+    if (status == -ENOSYS || status == -EINVAL || status == -EPERM) {
+        GTEST_SKIP() << "CLONE_NEWUSER unavailable: " << strerror(-status);
+    }
+
+    ASSERT_GE(status, 0);
+    ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
+int main(int argc, char** argv) {
+    if (getenv("DRAGONOS_IOPERM_EXEC_CHILD") != nullptr) {
+        return exec_child_main();
+    }
+
+    g_program_path = argv[0];
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -40,6 +40,7 @@ normal/user_namespace_id_map
 normal/tty_tcflush
 normal/signal_fpstate_sigreturn
 normal/general_protection_signal
+normal/ioperm_semantics
 normal/seccomp
 normal/process_signal_fork
 normal/sysfs_cgroup2_mount


### PR DESCRIPTION
## Summary
- implement x86_64 ioperm(2) with per-task I/O permission bitmaps and TSS bitmap loading
- preserve Linux-compatible inheritance across fork and exec, with copy-on-write updates after fork
- require CAP_SYS_RAWIO in the initial user namespace for granting I/O port access
- add dunitest coverage for range validation, permission enforcement, fork/exec semantics, revoke behavior, and user namespace capability checks

## Validation
- make fmt
- ioperm_semantics dunitest passed in DragonOS guest during local validation

Closes #1950
Related to #1946