### PR TITLE
feat(virtio): support virtio pmem block device

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtio-drivers"
 version = "0.7.2"
-source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers?rev=6dbe8d3#6dbe8d3d037ca88eea9723894df2563c69f69edf"
+source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers?rev=3ac8163046#3ac816304626ad4704ea4cbab2ed9aed85f8c2c8"
 dependencies = [
  "bitflags 2.9.1",
  "log",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -82,7 +82,7 @@ smoltcp = { version = "=0.12.0", git = "https://github.com/DragonOS-Community/sm
 syscall_table_macros = { path = "crates/syscall_table_macros" }
 system_error = { path = "crates/system_error" }
 unified-init = { path = "crates/unified-init" }
-virtio-drivers = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers", rev = "6dbe8d3" }
+virtio-drivers = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers", rev = "3ac8163046" }
 wait_queue_macros = { path = "crates/wait_queue_macros" }
 paste = "=1.0.14"
 slabmalloc = { path = "crates/rust-slabmalloc" }

--- a/kernel/src/driver/base/block/gendisk/mod.rs
+++ b/kernel/src/driver/base/block/gendisk/mod.rs
@@ -257,14 +257,13 @@ impl IndexNode for GenDisk {
 
     fn metadata(&self) -> Result<crate::filesystem::vfs::Metadata, SystemError> {
         let mut meta = self.metadata.clone();
-        let bdev = self.block_device();
-        let range = bdev.disk_range();
-        let blocks = range.lba_end.saturating_sub(range.lba_start);
+        let blocks = self.range.lba_end.saturating_sub(self.range.lba_start);
         let size_in_bytes = blocks.saturating_mul(LBA_SIZE);
 
         meta.size = i64::try_from(size_in_bytes).unwrap_or(i64::MAX);
         meta.blocks = blocks;
         meta.blk_size = LBA_SIZE;
+        meta.raw_dev = self.device_num;
         Ok(meta)
     }
 

--- a/kernel/src/driver/base/block/manager.rs
+++ b/kernel/src/driver/base/block/manager.rs
@@ -66,58 +66,77 @@ impl BlockDevManager {
 
     /// 注册磁盘设备
     pub fn register(&self, dev: Arc<dyn BlockDevice>) -> Result<(), SystemError> {
-        let mut inner = self.inner();
         let dev_name = dev.dev_name();
-        if inner.disks.contains_key(dev_name) {
-            return Err(SystemError::EEXIST);
+        {
+            let inner = self.inner();
+            if inner.disks.contains_key(dev_name) {
+                return Err(SystemError::EEXIST);
+            }
         }
-        inner.disks.insert(dev_name.clone(), dev.clone());
 
-        // 检测分区表，并创建gendisk
-        let res = self.check_partitions(&dev);
-        if res.is_err() {
+        let gendisks = self.prepare_gendisks(&dev)?;
+
+        {
+            let mut inner = self.inner();
+            if inner.disks.contains_key(dev_name) {
+                return Err(SystemError::EEXIST);
+            }
+            inner.disks.insert(dev_name.clone(), dev.clone());
+        }
+
+        if let Err(e) = self.publish_gendisks(&dev, &gendisks) {
+            let mut inner = self.inner();
             inner.disks.remove(dev_name);
-        };
-        res?;
+            drop(inner);
+            dev.blkdev_meta().inner().gendisks.clear();
+            return Err(e);
+        }
+
         Ok(())
     }
 
-    /// 检测分区表，并创建gendisk
-    fn check_partitions(&self, dev: &Arc<dyn BlockDevice>) -> Result<(), SystemError> {
-        if self.try_register_disk_by_mbr(dev).is_ok() {
-            return Ok(());
-        }
-
-        // use entire disk as a gendisk
-        self.register_entire_disk_as_gendisk(dev)
-    }
-
-    fn try_register_disk_by_mbr(&self, dev: &Arc<dyn BlockDevice>) -> Result<(), SystemError> {
-        let mbr = MbrDiskPartionTable::from_disk(dev.clone())?;
-        let piter = mbr.partitions_raw();
-        let mut idx;
-        for p in piter {
-            idx = dev.blkdev_meta().inner().gendisks.alloc_idx();
-            self.register_gendisk_with_range(dev, p.try_into()?, idx)?;
-        }
-        Ok(())
-    }
-
-    /// 将整个磁盘注册为gendisk
-    fn register_entire_disk_as_gendisk(
+    /// Detect partitions without holding the global block manager lock.
+    fn prepare_gendisks(
         &self,
         dev: &Arc<dyn BlockDevice>,
-    ) -> Result<(), SystemError> {
-        let range = dev.disk_range();
-        self.register_gendisk_with_range(dev, range, GenDisk::ENTIRE_DISK_IDX)
+    ) -> Result<Vec<Arc<GenDisk>>, SystemError> {
+        if let Ok(gendisks) = self.prepare_gendisks_by_mbr(dev) {
+            if !gendisks.is_empty() {
+                return Ok(gendisks);
+            }
+        }
+
+        let gendisks =
+            vec![self.create_gendisk_with_range(dev, dev.disk_range(), GenDisk::ENTIRE_DISK_IDX)];
+        Ok(gendisks)
     }
 
-    fn register_gendisk_with_range(
+    fn prepare_gendisks_by_mbr(
+        &self,
+        dev: &Arc<dyn BlockDevice>,
+    ) -> Result<Vec<Arc<GenDisk>>, SystemError> {
+        let mbr = MbrDiskPartionTable::from_disk(dev.clone())?;
+        let mut gendisks = Vec::new();
+        for p in mbr.partitions_raw() {
+            let idx = dev.blkdev_meta().inner().gendisks.alloc_idx();
+            let range = p.try_into()?;
+            if gendisks
+                .iter()
+                .any(|gendisk: &Arc<GenDisk>| gendisk.range().intersects_with(&range).is_some())
+            {
+                return Err(SystemError::EEXIST);
+            }
+            gendisks.push(self.create_gendisk_with_range(dev, range, idx));
+        }
+        Ok(gendisks)
+    }
+
+    fn create_gendisk_with_range(
         &self,
         dev: &Arc<dyn BlockDevice>,
         range: GeneralBlockRange,
         idx: u32,
-    ) -> Result<(), SystemError> {
+    ) -> Arc<GenDisk> {
         let weak_dev = Arc::downgrade(dev);
 
         // 这里先拿到硬盘的设备名，然后在根据idx来生成gendisk的名字
@@ -130,32 +149,56 @@ impl BlockDevManager {
             id => (Some(id), DName::from(format!("{}{}", dev_name.name(), idx))),
         };
 
-        let gendisk = GenDisk::new(weak_dev, range, idx, dev_name);
-        // log::info!("Registering gendisk");
-        self.register_gendisk(dev, gendisk)
+        GenDisk::new(weak_dev, range, idx, dev_name)
     }
 
-    fn register_gendisk(
+    fn publish_gendisks(
+        &self,
+        dev: &Arc<dyn BlockDevice>,
+        gendisks: &[Arc<GenDisk>],
+    ) -> Result<(), SystemError> {
+        let mut registered: Vec<Arc<GenDisk>> = Vec::new();
+        for gendisk in gendisks {
+            if let Err(e) = self.publish_gendisk(dev, gendisk.clone()) {
+                for rg in registered.into_iter() {
+                    if let Ok(name) = rg.dname() {
+                        let _ = devfs_unregister(name.as_ref(), rg.clone());
+                    }
+                    dev.blkdev_meta().inner().gendisks.remove(&rg.idx());
+                }
+                return Err(e);
+            }
+            registered.push(gendisk.clone());
+        }
+        Ok(())
+    }
+
+    fn publish_gendisk(
         &self,
         dev: &Arc<dyn BlockDevice>,
         gendisk: Arc<GenDisk>,
     ) -> Result<(), SystemError> {
         let blk_meta = dev.blkdev_meta();
         let idx = gendisk.idx();
-        let mut meta_inner = blk_meta.inner();
-        // 检查是否重复
-        if meta_inner.gendisks.intersects(gendisk.range()) {
-            return Err(SystemError::EEXIST);
+        {
+            let mut meta_inner = blk_meta.inner();
+            // 检查是否重复
+            if meta_inner.gendisks.intersects(gendisk.range()) {
+                return Err(SystemError::EEXIST);
+            }
+
+            meta_inner.gendisks.insert(idx, gendisk.clone());
         }
 
-        meta_inner.gendisks.insert(idx, gendisk.clone());
-        dev.callback_gendisk_registered(&gendisk).inspect_err(|_| {
-            meta_inner.gendisks.remove(&idx);
-        })?;
+        if let Err(e) = dev.callback_gendisk_registered(&gendisk) {
+            blk_meta.inner().gendisks.remove(&idx);
+            return Err(e);
+        }
 
         // 注册到devfs
         let dname = gendisk.dname()?;
         devfs_register(dname.as_ref(), gendisk.clone()).map_err(|e| {
+            blk_meta.inner().gendisks.remove(&idx);
             log::error!(
                 "Failed to register gendisk {:?} to devfs: {:?}",
                 dname.as_ref(),

--- a/kernel/src/driver/block/pmem/device.rs
+++ b/kernel/src/driver/block/pmem/device.rs
@@ -3,11 +3,14 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use core::{any::Any, fmt::Debug};
+use core::{
+    any::Any,
+    fmt::Debug,
+    sync::atomic::{compiler_fence, Ordering},
+};
 use system_error::SystemError;
 
 use crate::{
-    arch::MMArch,
     driver::base::{
         block::{
             block_device::{BlockDevice, BlockId, GeneralBlockRange, LBA_SIZE},
@@ -36,13 +39,13 @@ use crate::{
         rwsem::{RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
     },
-    mm::{
-        mmio_buddy::{mmio_pool, MMIOSpaceGuard},
-        MemoryManagementArch, PhysAddr, VirtAddr,
-    },
+    mm::{mmio_buddy::mmio_pool, PhysAddr},
 };
 
+use super::{PmemAccessMode, PmemFlushOps, PmemRegion};
+
 const PMEM_BASENAME: &str = "pmem";
+const PMEM_WINDOW_CHUNK_SIZE: usize = 1024 * 1024;
 
 #[derive(Debug)]
 struct InnerPmemBlockDevice {
@@ -61,8 +64,8 @@ pub struct PmemBlockDevice {
     metadata: Metadata,
     region_start: PhysAddr,
     usable_size: usize,
-    mapped_start: Option<VirtAddr>,
-    _mmio_guard: Option<MMIOSpaceGuard>,
+    access: PmemAccessMode,
+    flush: Option<Arc<dyn PmemFlushOps>>,
 }
 
 impl Debug for PmemBlockDevice {
@@ -71,19 +74,15 @@ impl Debug for PmemBlockDevice {
             .field("devname", &self.blkdev_meta.devname)
             .field("region_start", &self.region_start)
             .field("usable_size", &self.usable_size)
-            .field("mapped_start", &self.mapped_start)
+            .field("access", &self.access)
             .finish()
     }
 }
 
 impl PmemBlockDevice {
-    pub fn new(region_start: PhysAddr, region_size: usize, id: usize) -> Arc<Self> {
-        let usable_size = region_size / LBA_SIZE * LBA_SIZE;
+    pub(super) fn new(region: PmemRegion, id: usize) -> Arc<Self> {
+        let usable_size = region.size / LBA_SIZE * LBA_SIZE;
         let devname = DevName::new(format!("{PMEM_BASENAME}{id}"), id);
-        let (mmio_guard, mapped_start) = match Self::try_map_region(region_start, usable_size) {
-            Ok((guard, start)) => (Some(guard), Some(start)),
-            Err(_) => (None, None),
-        };
 
         Arc::new_cyclic(|self_ref| {
             let blkdev_meta = BlockDevMeta::new(devname, Major::PMEM_BLK_MAJOR);
@@ -117,33 +116,12 @@ impl PmemBlockDevice {
                     gid: 0,
                     raw_dev,
                 },
-                region_start,
+                region_start: region.start,
                 usable_size,
-                mapped_start,
-                _mmio_guard: mmio_guard,
+                access: region.access,
+                flush: region.flush,
             }
         })
-    }
-
-    fn try_map_region(
-        region_start: PhysAddr,
-        usable_size: usize,
-    ) -> Result<(MMIOSpaceGuard, VirtAddr), SystemError> {
-        if usable_size == 0 {
-            return Err(SystemError::EINVAL);
-        }
-
-        let paddr_base = page_align_down(region_start.data());
-        let offset = region_start.data() - paddr_base;
-        let map_size = page_align_up(
-            usable_size
-                .checked_add(offset)
-                .ok_or(SystemError::EOVERFLOW)?,
-        );
-
-        let mmio_guard = mmio_pool().create_mmio(map_size)?;
-        let mapped_start = unsafe { mmio_guard.map_any_phys(region_start, usable_size)? };
-        Ok((mmio_guard, mapped_start))
     }
 
     pub fn region_start(&self) -> PhysAddr {
@@ -156,6 +134,79 @@ impl PmemBlockDevice {
 
     fn inner(&self) -> SpinLockGuard<'_, InnerPmemBlockDevice> {
         self.inner.lock_irqsave()
+    }
+
+    fn checked_io_range(&self, offset: usize, len: usize) -> Result<(), SystemError> {
+        let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        if end > self.usable_size {
+            return Err(SystemError::ENOSPC);
+        }
+        Ok(())
+    }
+
+    fn copy_from_pmem(&self, offset: usize, buf: &mut [u8]) -> Result<(), SystemError> {
+        self.copy_pmem_window(offset, buf, true)
+    }
+
+    fn copy_to_pmem(&self, offset: usize, buf: &[u8]) -> Result<(), SystemError> {
+        let mut owned = buf;
+        let mut copied = 0;
+        while !owned.is_empty() {
+            let phys = self.region_start.add(offset + copied);
+            let page_base = page_align_down(phys.data());
+            let page_offset = phys.data() - page_base;
+            let chunk_len = owned.len().min(PMEM_WINDOW_CHUNK_SIZE - page_offset);
+            let map_size = page_align_up(page_offset + chunk_len);
+            let guard = mmio_pool().create_mmio(map_size)?;
+            let mapped = unsafe { guard.map_any_phys(PhysAddr::new(page_base), map_size)? };
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    owned.as_ptr(),
+                    (mapped.data() + page_offset) as *mut u8,
+                    chunk_len,
+                );
+            }
+            compiler_fence(Ordering::SeqCst);
+            owned = &owned[chunk_len..];
+            copied += chunk_len;
+        }
+        Ok(())
+    }
+
+    fn copy_pmem_window(
+        &self,
+        offset: usize,
+        buf: &mut [u8],
+        from_pmem: bool,
+    ) -> Result<(), SystemError> {
+        let mut copied = 0;
+        while copied < buf.len() {
+            let phys = self.region_start.add(offset + copied);
+            let page_base = page_align_down(phys.data());
+            let page_offset = phys.data() - page_base;
+            let chunk_len = (buf.len() - copied).min(PMEM_WINDOW_CHUNK_SIZE - page_offset);
+            let map_size = page_align_up(page_offset + chunk_len);
+            let guard = mmio_pool().create_mmio(map_size)?;
+            let mapped = unsafe { guard.map_any_phys(PhysAddr::new(page_base), map_size)? };
+            unsafe {
+                if from_pmem {
+                    core::ptr::copy_nonoverlapping(
+                        (mapped.data() + page_offset) as *const u8,
+                        buf[copied..].as_mut_ptr(),
+                        chunk_len,
+                    );
+                } else {
+                    core::ptr::copy_nonoverlapping(
+                        buf[copied..].as_ptr(),
+                        (mapped.data() + page_offset) as *mut u8,
+                        chunk_len,
+                    );
+                    compiler_fence(Ordering::SeqCst);
+                }
+            }
+            copied += chunk_len;
+        }
+        Ok(())
     }
 }
 
@@ -275,35 +326,41 @@ impl BlockDevice for PmemBlockDevice {
             return Err(SystemError::ENOSPC);
         }
 
-        let src = if let Some(mapped_start) = self.mapped_start {
-            let src_vaddr = VirtAddr::new(
-                mapped_start
-                    .data()
-                    .checked_add(offset)
-                    .ok_or(SystemError::EOVERFLOW)?,
-            );
-            src_vaddr
-        } else {
-            let paddr = self.region_start.add(offset);
-            unsafe { MMArch::phys_2_virt(paddr) }.ok_or(SystemError::EFAULT)?
-        };
-        unsafe {
-            core::ptr::copy_nonoverlapping(src.data() as *const u8, buf.as_mut_ptr(), len);
-        }
+        self.copy_from_pmem(offset, &mut buf[..len])?;
 
         Ok(len)
     }
 
     fn write_at_sync(
         &self,
-        _lba_id_start: BlockId,
-        _count: usize,
-        _buf: &[u8],
+        lba_id_start: BlockId,
+        count: usize,
+        buf: &[u8],
     ) -> Result<usize, SystemError> {
-        Err(SystemError::EROFS)
+        if count == 0 {
+            return Ok(0);
+        }
+        if self.access == PmemAccessMode::ReadOnly {
+            return Err(SystemError::EROFS);
+        }
+
+        let offset = lba_id_start
+            .checked_mul(LBA_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let len = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
+
+        if len > buf.len() {
+            return Err(SystemError::EINVAL);
+        }
+        self.checked_io_range(offset, len)?;
+        self.copy_to_pmem(offset, &buf[..len])?;
+        Ok(len)
     }
 
     fn sync(&self) -> Result<(), SystemError> {
+        if let Some(flush) = &self.flush {
+            flush.flush()?;
+        }
         Ok(())
     }
 

--- a/kernel/src/driver/block/pmem/mod.rs
+++ b/kernel/src/driver/block/pmem/mod.rs
@@ -1,21 +1,132 @@
 mod device;
 
 use alloc::{string::ToString, sync::Arc, vec::Vec};
-use core::convert::TryFrom;
+use core::{
+    convert::TryFrom,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
 use crate::{
     driver::base::block::{block_device::BlockDevice, manager::block_dev_manager},
     init::initcall::INITCALL_DEVICE,
+    libs::spinlock::SpinLock,
+    mm::{memblock::mem_block_manager, PhysAddr},
 };
 
-use self::device::PmemBlockDevice;
+pub use self::device::PmemBlockDevice;
 
 const E820_TYPE_PMEM: u32 = 7;
 const E820_TYPE_PRAM: u32 = 12;
 const MAX_E820_ENTRIES: usize = 128;
 const PMEM_BLOCK_SIZE: usize = crate::driver::base::block::block_device::LBA_SIZE;
+static PMEM_NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+static PMEM_REGISTERED_REGIONS: SpinLock<Vec<PmemRegisteredRegion>> = SpinLock::new(Vec::new());
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PmemRegionSource {
+    Platform,
+    Virtio,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PmemAccessMode {
+    ReadOnly,
+    ReadWrite,
+}
+
+pub trait PmemFlushOps: Send + Sync {
+    fn flush(&self) -> Result<(), SystemError>;
+}
+
+#[derive(Clone)]
+pub struct PmemRegion {
+    pub start: PhysAddr,
+    pub size: usize,
+    pub source: PmemRegionSource,
+    pub access: PmemAccessMode,
+    pub flush: Option<Arc<dyn PmemFlushOps>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PmemRegisteredRegion {
+    start: PhysAddr,
+    size: usize,
+}
+
+fn ranges_overlap(start_a: usize, size_a: usize, start_b: usize, size_b: usize) -> bool {
+    let Some(end_a) = start_a.checked_add(size_a) else {
+        return true;
+    };
+    let Some(end_b) = start_b.checked_add(size_b) else {
+        return true;
+    };
+    start_a < end_b && start_b < end_a
+}
+
+fn validate_pmem_region_against_memory(start: PhysAddr, size: usize) -> Result<(), SystemError> {
+    if size == 0 {
+        return Err(SystemError::EINVAL);
+    }
+
+    let start_data = start.data();
+    start_data.checked_add(size).ok_or(SystemError::EOVERFLOW)?;
+
+    for area in mem_block_manager().to_iter() {
+        if ranges_overlap(start_data, size, area.base.data(), area.size) {
+            return Err(SystemError::EBUSY);
+        }
+    }
+    Ok(())
+}
+
+fn reserve_pmem_region(start: PhysAddr, size: usize) -> Result<PmemRegisteredRegion, SystemError> {
+    validate_pmem_region_against_memory(start, size)?;
+
+    let start_data = start.data();
+    let mut regions = PMEM_REGISTERED_REGIONS.lock_irqsave();
+    for region in regions.iter() {
+        if ranges_overlap(start_data, size, region.start.data(), region.size) {
+            return Err(SystemError::EBUSY);
+        }
+    }
+
+    let reservation = PmemRegisteredRegion { start, size };
+    regions.push(reservation);
+    Ok(reservation)
+}
+
+fn release_pmem_region(reservation: PmemRegisteredRegion) {
+    let mut regions = PMEM_REGISTERED_REGIONS.lock_irqsave();
+    if let Some(idx) = regions.iter().position(|region| *region == reservation) {
+        regions.remove(idx);
+    }
+}
+
+pub fn register_pmem_region(mut region: PmemRegion) -> Result<Arc<PmemBlockDevice>, SystemError> {
+    region.size = trim_to_block_aligned(region.size);
+    let reservation = reserve_pmem_region(region.start, region.size)?;
+
+    let id = PMEM_NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    let dev = PmemBlockDevice::new(region.clone(), id);
+    let dev_name = dev.dev_name().to_string();
+    let registered = dev.clone() as Arc<dyn BlockDevice>;
+    if let Err(e) = block_dev_manager().register(registered) {
+        release_pmem_region(reservation);
+        return Err(e);
+    }
+
+    log::info!(
+        "PMEM block device registered: /dev/{} source={:?} start={:?} size={:#x}",
+        dev_name,
+        region.source,
+        dev.region_start(),
+        dev.usable_size()
+    );
+
+    Ok(dev)
+}
 
 #[cfg(target_arch = "x86_64")]
 const NFIT_SUBTABLE_HEADER_SIZE: usize = 4;
@@ -308,17 +419,14 @@ fn pmem_init() -> Result<(), SystemError> {
         return Ok(());
     }
 
-    for (id, (start, size)) in regions.into_iter().enumerate() {
-        let dev = PmemBlockDevice::new(start, size, id);
-        let dev_name = dev.dev_name().to_string();
-        let registered = dev.clone() as Arc<dyn BlockDevice>;
-        block_dev_manager().register(registered)?;
-        log::info!(
-            "PMEM block device registered: /dev/{} start={:?} size={:#x}",
-            dev_name,
-            dev.region_start(),
-            dev.usable_size()
-        );
+    for (start, size) in regions {
+        register_pmem_region(PmemRegion {
+            start,
+            size,
+            source: PmemRegionSource::Platform,
+            access: PmemAccessMode::ReadWrite,
+            flush: None,
+        })?;
     }
 
     Ok(())

--- a/kernel/src/driver/virtio/mod.rs
+++ b/kernel/src/driver/virtio/mod.rs
@@ -15,6 +15,7 @@ pub mod transport_pci;
 pub mod virtio;
 pub mod virtio_fs;
 pub mod virtio_impl;
+pub mod virtio_pmem;
 pub mod virtio_vsock;
 
 /// virtio 设备厂商ID

--- a/kernel/src/driver/virtio/virtio.rs
+++ b/kernel/src/driver/virtio/virtio.rs
@@ -13,6 +13,7 @@ use crate::driver::pci::pci::{
 };
 use crate::driver::pci::subsys::pci_bus;
 use crate::driver::virtio::transport::VirtIOTransport;
+use crate::driver::virtio::virtio_pmem::virtio_pmem;
 use crate::driver::virtio::virtio_vsock::virtio_vsock;
 use crate::init::initcall::INITCALL_DEVICE;
 
@@ -79,6 +80,7 @@ pub(super) fn virtio_device_init(
         }
         DeviceType::Network => virtio_net(transport, dev_id, dev_parent),
         DeviceType::FileSystem => virtio_fs(transport, dev_id, dev_parent),
+        DeviceType::Pmem => virtio_pmem(transport, dev_id, dev_parent),
         DeviceType::Socket => virtio_vsock(transport, dev_id, dev_parent),
         t => {
             warn!("Unrecognized virtio device: {:?}", t);

--- a/kernel/src/driver/virtio/virtio_pmem.rs
+++ b/kernel/src/driver/virtio/virtio_pmem.rs
@@ -1,0 +1,786 @@
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::{any::Any, fmt::Debug, mem::size_of};
+use log::{error, warn};
+use system_error::SystemError;
+use unified_init::macros::unified_init;
+use virtio_drivers::{
+    queue::VirtQueue,
+    transport::{DeviceStatus, DeviceType, Transport},
+};
+
+use crate::{
+    driver::{
+        base::{
+            block::{block_device::BlockDevice, manager::block_dev_manager},
+            class::Class,
+            device::{
+                bus::Bus,
+                driver::{Driver, DriverCommonData},
+                Device, DeviceCommonData, DeviceId, IdTable,
+            },
+            kobject::{KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState},
+            kset::KSet,
+        },
+        block::pmem::{
+            register_pmem_region, PmemAccessMode, PmemBlockDevice, PmemFlushOps, PmemRegion,
+            PmemRegionSource,
+        },
+        virtio::{
+            sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager},
+            transport::VirtIOTransport,
+            virtio_drivers_error_to_system_error,
+            virtio_impl::HalImpl,
+            VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId,
+            VIRTIO_VENDOR_ID,
+        },
+    },
+    exception::{irqdesc::IrqReturn, IrqNumber},
+    filesystem::kernfs::KernFSInode,
+    init::initcall::INITCALL_POSTCORE,
+    libs::{
+        mutex::Mutex,
+        rwsem::{RwSemReadGuard, RwSemWriteGuard},
+        spinlock::{SpinLock, SpinLockGuard},
+        wait_queue::WaitQueue,
+    },
+    mm::PhysAddr,
+    time::{sleep::nanosleep, PosixTimeSpec},
+};
+
+const VIRTIO_PMEM_BASENAME: &str = "virtio_pmem";
+const VIRTIO_PMEM_FLUSH_QUEUE: u16 = 0;
+const VIRTIO_PMEM_REQ_TYPE_FLUSH: u32 = 0;
+const VIRTIO_PMEM_QUEUE_SIZE: usize = 4;
+const VIRTIO_PMEM_FLUSH_POLL_RETRIES: usize = 1000;
+const VIRTIO_PMEM_FLUSH_POLL_INTERVAL_NS: i64 = 1_000_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum VirtIOPmemState {
+    ReadyNotPublished,
+    Published,
+    Quiescing,
+    Dead,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct VirtioPmemReq {
+    type_: u32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct VirtioPmemResp {
+    ret: u32,
+}
+
+#[derive(Debug)]
+struct FlushRequest {
+    token: u16,
+    req: Box<VirtioPmemReq>,
+    resp: Box<VirtioPmemResp>,
+    done: bool,
+    result: Result<(), SystemError>,
+}
+
+struct InnerVirtIOPmemDevice {
+    transport: Option<VirtIOTransport>,
+    flush_queue: Option<VirtQueue<HalImpl, VIRTIO_PMEM_QUEUE_SIZE>>,
+    pending_flush: Option<FlushRequest>,
+    block_device: Option<Arc<PmemBlockDevice>>,
+    state: VirtIOPmemState,
+    start: PhysAddr,
+    size: usize,
+    name: Option<String>,
+    virtio_index: Option<VirtIODeviceIndex>,
+    device_common: DeviceCommonData,
+    kobject_common: KObjectCommonData,
+    irq: Option<IrqNumber>,
+    irq_is_msix: bool,
+}
+
+#[cast_to([sync] VirtIODevice)]
+#[cast_to([sync] Device)]
+pub struct VirtIOPmemDevice {
+    dev_id: Arc<DeviceId>,
+    inner: SpinLock<InnerVirtIOPmemDevice>,
+    locked_kobj_state: LockedKObjectState,
+    flush_mutex: Mutex<()>,
+    flush_wait: WaitQueue,
+}
+
+impl Debug for VirtIOPmemDevice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VirtIOPmemDevice")
+            .field("dev_id", &self.dev_id.id())
+            .finish()
+    }
+}
+
+unsafe impl Send for VirtIOPmemDevice {}
+unsafe impl Sync for VirtIOPmemDevice {}
+
+impl VirtIOPmemDevice {
+    pub fn new(mut transport: VirtIOTransport, dev_id: Arc<DeviceId>) -> Option<Arc<Self>> {
+        let irq_ready = match transport.setup_irq(dev_id.clone()) {
+            Ok(()) => true,
+            Err(err) => {
+                warn!(
+                    "VirtIOPmemDevice '{dev_id:?}' setup_irq failed, falling back to polling: {:?}",
+                    err
+                );
+                false
+            }
+        };
+
+        begin_pmem_init(&mut transport);
+        let (start, size) = match read_config(&transport) {
+            Ok(config) => config,
+            Err(e) => {
+                error!("VirtIOPmemDevice '{dev_id:?}' read config failed: {:?}", e);
+                transport.set_status(DeviceStatus::FAILED);
+                return None;
+            }
+        };
+
+        let mut flush_queue = match VirtQueue::<HalImpl, VIRTIO_PMEM_QUEUE_SIZE>::new(
+            &mut transport,
+            VIRTIO_PMEM_FLUSH_QUEUE,
+            false,
+            false,
+        ) {
+            Ok(queue) => queue,
+            Err(e) => {
+                error!(
+                    "VirtIOPmemDevice '{dev_id:?}' create flush queue failed: {:?}",
+                    e
+                );
+                transport.set_status(DeviceStatus::FAILED);
+                return None;
+            }
+        };
+        flush_queue.set_dev_notify(true);
+        transport.finish_init();
+
+        let irq = irq_ready.then(|| transport.irq());
+        let irq_is_msix = irq_ready && transport.irq_is_msix();
+        Some(Arc::new(Self {
+            dev_id,
+            inner: SpinLock::new(InnerVirtIOPmemDevice {
+                transport: Some(transport),
+                flush_queue: Some(flush_queue),
+                pending_flush: None,
+                block_device: None,
+                state: VirtIOPmemState::ReadyNotPublished,
+                start,
+                size,
+                name: None,
+                virtio_index: None,
+                device_common: DeviceCommonData::default(),
+                kobject_common: KObjectCommonData::default(),
+                irq,
+                irq_is_msix,
+            }),
+            locked_kobj_state: LockedKObjectState::default(),
+            flush_mutex: Mutex::new(()),
+            flush_wait: WaitQueue::default(),
+        }))
+    }
+
+    fn inner(&self) -> SpinLockGuard<'_, InnerVirtIOPmemDevice> {
+        self.inner.lock_irqsave()
+    }
+
+    fn publish_pmem(self: &Arc<Self>) -> Result<(), SystemError> {
+        let (start, size) = {
+            let inner = self.inner();
+            if inner.state != VirtIOPmemState::ReadyNotPublished {
+                return Err(SystemError::EINVAL);
+            }
+            (inner.start, inner.size)
+        };
+
+        let pmem = register_pmem_region(PmemRegion {
+            start,
+            size,
+            source: PmemRegionSource::Virtio,
+            access: PmemAccessMode::ReadWrite,
+            flush: Some(Arc::new(VirtIOPmemFlushOps {
+                device: Arc::downgrade(self),
+            })),
+        })?;
+
+        let mut inner = self.inner();
+        inner.block_device = Some(pmem);
+        inner.state = VirtIOPmemState::Published;
+        Ok(())
+    }
+
+    fn fail_unpublished(&self) {
+        let mut inner = self.inner();
+        inner.state = VirtIOPmemState::Dead;
+        inner.pending_flush = None;
+        if let Some(transport) = inner.transport.as_mut() {
+            transport.set_status(DeviceStatus::FAILED);
+            transport.queue_unset(VIRTIO_PMEM_FLUSH_QUEUE);
+        }
+        self.flush_wait.wakeup_all(None);
+    }
+
+    fn flush(&self) -> Result<(), SystemError> {
+        let _guard = self.flush_mutex.lock();
+        let mut request = FlushRequest {
+            token: 0,
+            req: Box::new(VirtioPmemReq {
+                type_: VIRTIO_PMEM_REQ_TYPE_FLUSH.to_le(),
+            }),
+            resp: Box::new(VirtioPmemResp { ret: 0 }),
+            done: false,
+            result: Err(SystemError::EIO),
+        };
+
+        {
+            let mut inner = self.inner();
+            if inner.state != VirtIOPmemState::Published {
+                return Err(SystemError::EIO);
+            }
+            if inner
+                .transport
+                .as_ref()
+                .is_some_and(|t| t.get_status().contains(DeviceStatus::DEVICE_NEEDS_RESET))
+            {
+                return Err(SystemError::EIO);
+            }
+            if inner.pending_flush.is_some() {
+                return Err(SystemError::EBUSY);
+            }
+
+            let queue = inner.flush_queue.as_mut().ok_or(SystemError::ENODEV)?;
+            let token = unsafe {
+                queue.add(
+                    &[bytes_of(&*request.req)],
+                    &mut [bytes_of_mut(&mut *request.resp)],
+                )
+            }
+            .map_err(virtio_drivers_error_to_system_error)?;
+            request.token = token;
+            let should_notify = queue.should_notify();
+            inner.pending_flush = Some(request);
+            if should_notify {
+                inner
+                    .transport
+                    .as_mut()
+                    .ok_or(SystemError::ENODEV)?
+                    .notify(VIRTIO_PMEM_FLUSH_QUEUE);
+            }
+        }
+
+        for _ in 0..VIRTIO_PMEM_FLUSH_POLL_RETRIES {
+            {
+                let mut inner = self.inner();
+                self.complete_flush_locked(&mut inner);
+                if inner.state >= VirtIOPmemState::Quiescing {
+                    inner.pending_flush.take();
+                    return Err(SystemError::EIO);
+                }
+                let done = inner
+                    .pending_flush
+                    .as_ref()
+                    .is_some_and(|request| request.done);
+                if done {
+                    return inner
+                        .pending_flush
+                        .take()
+                        .map(|request| request.result)
+                        .unwrap_or(Err(SystemError::EIO));
+                }
+            }
+            nanosleep(PosixTimeSpec::new(0, VIRTIO_PMEM_FLUSH_POLL_INTERVAL_NS))?;
+        }
+
+        self.inner().pending_flush.take();
+        Err(SystemError::EIO)
+    }
+
+    fn complete_flush_locked(&self, inner: &mut InnerVirtIOPmemDevice) -> bool {
+        let Some(pending) = inner.pending_flush.as_ref() else {
+            return false;
+        };
+        let Some(token) = inner
+            .flush_queue
+            .as_ref()
+            .and_then(|queue| queue.peek_used())
+        else {
+            return false;
+        };
+        if token != pending.token {
+            return false;
+        }
+
+        let mut pending = inner.pending_flush.take().unwrap();
+        let result = unsafe {
+            inner.flush_queue.as_mut().unwrap().pop_used(
+                pending.token,
+                &[bytes_of(&*pending.req)],
+                &mut [bytes_of_mut(&mut *pending.resp)],
+            )
+        }
+        .map_err(virtio_drivers_error_to_system_error)
+        .and_then(|_| {
+            if u32::from_le(pending.resp.ret) == 0 {
+                Ok(())
+            } else {
+                Err(SystemError::EIO)
+            }
+        });
+
+        pending.done = true;
+        pending.result = result;
+        inner.pending_flush = Some(pending);
+        true
+    }
+
+    fn shutdown(&self) -> Result<(), SystemError> {
+        let block_device = {
+            let mut inner = self.inner();
+            if inner.state >= VirtIOPmemState::Quiescing {
+                return Ok(());
+            }
+            inner.state = VirtIOPmemState::Quiescing;
+            self.flush_wait.wakeup_all(None);
+            inner.block_device.take()
+        };
+
+        if let Some(block_device) = block_device {
+            let block_device = block_device as Arc<dyn BlockDevice>;
+            let _ = block_dev_manager().unregister(&block_device);
+        }
+
+        let mut inner = self.inner();
+        inner.pending_flush = None;
+        if let Some(transport) = inner.transport.as_mut() {
+            transport.queue_unset(VIRTIO_PMEM_FLUSH_QUEUE);
+            transport.set_status(DeviceStatus::empty());
+        }
+        inner.state = VirtIOPmemState::Dead;
+        Ok(())
+    }
+}
+
+struct VirtIOPmemFlushOps {
+    device: Weak<VirtIOPmemDevice>,
+}
+
+impl PmemFlushOps for VirtIOPmemFlushOps {
+    fn flush(&self) -> Result<(), SystemError> {
+        let device = self.device.upgrade().ok_or(SystemError::ENODEV)?;
+        device.flush()
+    }
+}
+
+impl VirtIODevice for VirtIOPmemDevice {
+    fn handle_irq(&self, _irq: IrqNumber) -> Result<IrqReturn, SystemError> {
+        let mut inner = self.inner();
+        if inner.state >= VirtIOPmemState::Dead {
+            return Ok(IrqReturn::NotHandled);
+        }
+
+        let acked = inner
+            .transport
+            .as_mut()
+            .is_some_and(|transport| transport.ack_interrupt());
+        if !acked && !inner.irq_is_msix {
+            return Ok(IrqReturn::NotHandled);
+        }
+        let completed = self.complete_flush_locked(&mut inner);
+        drop(inner);
+        if completed {
+            self.flush_wait.wakeup_all(None);
+        }
+        Ok(IrqReturn::Handled)
+    }
+
+    fn dev_id(&self) -> &Arc<DeviceId> {
+        &self.dev_id
+    }
+
+    fn set_device_name(&self, name: String) {
+        self.inner().name = Some(name);
+    }
+
+    fn device_name(&self) -> String {
+        self.inner()
+            .name
+            .clone()
+            .unwrap_or_else(|| VIRTIO_PMEM_BASENAME.to_string())
+    }
+
+    fn set_virtio_device_index(&self, index: VirtIODeviceIndex) {
+        self.inner().virtio_index = Some(index);
+    }
+
+    fn virtio_device_index(&self) -> Option<VirtIODeviceIndex> {
+        self.inner().virtio_index
+    }
+
+    fn device_type_id(&self) -> u32 {
+        DeviceType::Pmem as u32
+    }
+
+    fn vendor(&self) -> u32 {
+        VIRTIO_VENDOR_ID.into()
+    }
+
+    fn irq(&self) -> Option<IrqNumber> {
+        self.inner().irq
+    }
+}
+
+impl Device for VirtIOPmemDevice {
+    fn dev_type(&self) -> crate::driver::base::device::DeviceType {
+        crate::driver::base::device::DeviceType::Block
+    }
+
+    fn id_table(&self) -> IdTable {
+        IdTable::new(VIRTIO_PMEM_BASENAME.to_string(), None)
+    }
+
+    fn bus(&self) -> Option<Weak<dyn Bus>> {
+        self.inner().device_common.bus.clone()
+    }
+
+    fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
+        self.inner().device_common.bus = bus;
+    }
+
+    fn class(&self) -> Option<Arc<dyn Class>> {
+        let mut guard = self.inner();
+        let class = guard.device_common.class.clone()?.upgrade();
+        if class.is_none() {
+            guard.device_common.class = None;
+        }
+        class
+    }
+
+    fn set_class(&self, class: Option<Weak<dyn Class>>) {
+        self.inner().device_common.class = class;
+    }
+
+    fn driver(&self) -> Option<Arc<dyn Driver>> {
+        let mut guard = self.inner();
+        let driver = guard.device_common.driver.clone()?.upgrade();
+        if driver.is_none() {
+            guard.device_common.driver = None;
+        }
+        driver
+    }
+
+    fn set_driver(&self, driver: Option<Weak<dyn Driver>>) {
+        self.inner().device_common.driver = driver;
+    }
+
+    fn is_dead(&self) -> bool {
+        self.inner().state == VirtIOPmemState::Dead
+    }
+
+    fn can_match(&self) -> bool {
+        self.inner().device_common.can_match
+    }
+
+    fn set_can_match(&self, can_match: bool) {
+        self.inner().device_common.can_match = can_match;
+    }
+
+    fn state_synced(&self) -> bool {
+        true
+    }
+
+    fn dev_parent(&self) -> Option<Weak<dyn Device>> {
+        self.inner().device_common.get_parent_weak_or_clear()
+    }
+
+    fn set_dev_parent(&self, parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = parent;
+    }
+}
+
+impl KObject for VirtIOPmemDevice {
+    fn as_any_ref(&self) -> &dyn Any {
+        self
+    }
+
+    fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
+        self.inner().kobject_common.kern_inode = inode;
+    }
+
+    fn inode(&self) -> Option<Arc<KernFSInode>> {
+        self.inner().kobject_common.kern_inode.clone()
+    }
+
+    fn parent(&self) -> Option<Weak<dyn KObject>> {
+        self.inner().kobject_common.parent.clone()
+    }
+
+    fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
+        self.inner().kobject_common.parent = parent;
+    }
+
+    fn kset(&self) -> Option<Arc<KSet>> {
+        self.inner().kobject_common.kset.clone()
+    }
+
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+        self.inner().kobject_common.kset = kset;
+    }
+
+    fn kobj_type(&self) -> Option<&'static dyn KObjType> {
+        self.inner().kobject_common.kobj_type
+    }
+
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.inner().kobject_common.kobj_type = ktype;
+    }
+
+    fn name(&self) -> String {
+        self.device_name()
+    }
+
+    fn set_name(&self, name: String) {
+        self.set_device_name(name);
+    }
+
+    fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {
+        self.locked_kobj_state.read()
+    }
+
+    fn kobj_state_mut(&self) -> RwSemWriteGuard<'_, KObjectState> {
+        self.locked_kobj_state.write()
+    }
+
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.locked_kobj_state.write() = state;
+    }
+}
+
+#[cast_to([sync] VirtIODriver)]
+#[cast_to([sync] Driver)]
+#[derive(Debug)]
+struct VirtIOPmemDriver {
+    inner: SpinLock<InnerVirtIOPmemDriver>,
+    kobj_state: LockedKObjectState,
+}
+
+#[derive(Debug)]
+struct InnerVirtIOPmemDriver {
+    virtio_driver_common: VirtIODriverCommonData,
+    driver_common: DriverCommonData,
+    kobj_common: KObjectCommonData,
+}
+
+impl VirtIOPmemDriver {
+    fn new() -> Arc<Self> {
+        let driver = Arc::new(Self {
+            inner: SpinLock::new(InnerVirtIOPmemDriver {
+                virtio_driver_common: VirtIODriverCommonData::default(),
+                driver_common: DriverCommonData::default(),
+                kobj_common: KObjectCommonData::default(),
+            }),
+            kobj_state: LockedKObjectState::default(),
+        });
+        driver.add_virtio_id(VirtioDeviceId::new(
+            DeviceType::Pmem as u32,
+            VIRTIO_VENDOR_ID.into(),
+        ));
+        driver
+    }
+
+    fn inner(&self) -> SpinLockGuard<'_, InnerVirtIOPmemDriver> {
+        self.inner.lock()
+    }
+}
+
+impl VirtIODriver for VirtIOPmemDriver {
+    fn probe(&self, device: &Arc<dyn VirtIODevice>) -> Result<(), SystemError> {
+        let dev = device
+            .clone()
+            .arc_any()
+            .downcast::<VirtIOPmemDevice>()
+            .map_err(|_| SystemError::EINVAL)?;
+        if let Err(e) = dev.publish_pmem() {
+            dev.fail_unpublished();
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    fn shutdown(&self, device: &Arc<dyn VirtIODevice>) -> Result<(), SystemError> {
+        let dev = device
+            .clone()
+            .arc_any()
+            .downcast::<VirtIOPmemDevice>()
+            .map_err(|_| SystemError::EINVAL)?;
+        dev.shutdown()
+    }
+
+    fn virtio_id_table(&self) -> Vec<VirtioDeviceId> {
+        self.inner().virtio_driver_common.id_table.clone()
+    }
+
+    fn add_virtio_id(&self, id: VirtioDeviceId) {
+        self.inner().virtio_driver_common.id_table.push(id);
+    }
+}
+
+impl Driver for VirtIOPmemDriver {
+    fn id_table(&self) -> Option<IdTable> {
+        Some(IdTable::new(VIRTIO_PMEM_BASENAME.to_string(), None))
+    }
+
+    fn devices(&self) -> Vec<Arc<dyn Device>> {
+        self.inner().driver_common.devices.clone()
+    }
+
+    fn add_device(&self, device: Arc<dyn Device>) {
+        self.inner().driver_common.push_device(device);
+    }
+
+    fn delete_device(&self, device: &Arc<dyn Device>) {
+        self.inner().driver_common.delete_device(device);
+    }
+
+    fn bus(&self) -> Option<Weak<dyn Bus>> {
+        Some(Arc::downgrade(&virtio_bus()) as Weak<dyn Bus>)
+    }
+
+    fn set_bus(&self, _bus: Option<Weak<dyn Bus>>) {}
+}
+
+impl KObject for VirtIOPmemDriver {
+    fn as_any_ref(&self) -> &dyn Any {
+        self
+    }
+
+    fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
+        self.inner().kobj_common.kern_inode = inode;
+    }
+
+    fn inode(&self) -> Option<Arc<KernFSInode>> {
+        self.inner().kobj_common.kern_inode.clone()
+    }
+
+    fn parent(&self) -> Option<Weak<dyn KObject>> {
+        self.inner().kobj_common.parent.clone()
+    }
+
+    fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
+        self.inner().kobj_common.parent = parent;
+    }
+
+    fn kset(&self) -> Option<Arc<KSet>> {
+        self.inner().kobj_common.kset.clone()
+    }
+
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+        self.inner().kobj_common.kset = kset;
+    }
+
+    fn kobj_type(&self) -> Option<&'static dyn KObjType> {
+        self.inner().kobj_common.kobj_type
+    }
+
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.inner().kobj_common.kobj_type = ktype;
+    }
+
+    fn name(&self) -> String {
+        VIRTIO_PMEM_BASENAME.to_string()
+    }
+
+    fn set_name(&self, _name: String) {}
+
+    fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {
+        self.kobj_state.read()
+    }
+
+    fn kobj_state_mut(&self) -> RwSemWriteGuard<'_, KObjectState> {
+        self.kobj_state.write()
+    }
+
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.kobj_state.write() = state;
+    }
+}
+
+pub fn virtio_pmem(
+    transport: VirtIOTransport,
+    dev_id: Arc<DeviceId>,
+    dev_parent: Option<Arc<dyn Device>>,
+) {
+    let Some(device) = VirtIOPmemDevice::new(transport, dev_id) else {
+        return;
+    };
+    if let Some(dev_parent) = dev_parent {
+        device.set_dev_parent(Some(Arc::downgrade(&dev_parent)));
+    }
+    virtio_device_manager()
+        .device_add(device as Arc<dyn VirtIODevice>)
+        .expect("Add virtio pmem failed");
+}
+
+#[unified_init(INITCALL_POSTCORE)]
+fn virtio_pmem_driver_init() -> Result<(), SystemError> {
+    virtio_driver_manager().register(VirtIOPmemDriver::new() as Arc<dyn VirtIODriver>)
+}
+
+fn read_config(transport: &VirtIOTransport) -> Result<(PhysAddr, usize), SystemError> {
+    let cfg = transport
+        .config_space::<[u32; 4]>()
+        .map_err(virtio_drivers_error_to_system_error)?;
+    let base = cfg.as_ptr() as *const u8;
+    let start = read_config_le64(base, 0)?;
+    let size = read_config_le64(base, 8)?;
+    let start = usize::try_from(start).map_err(|_| SystemError::EOVERFLOW)?;
+    let size = usize::try_from(size).map_err(|_| SystemError::EOVERFLOW)?;
+    if size == 0 {
+        return Err(SystemError::EINVAL);
+    }
+    start.checked_add(size).ok_or(SystemError::EOVERFLOW)?;
+    Ok((PhysAddr::new(start), size))
+}
+
+fn read_config_le64(base: *const u8, offset: usize) -> Result<u64, SystemError> {
+    let end = offset
+        .checked_add(size_of::<u64>())
+        .ok_or(SystemError::EOVERFLOW)?;
+    if end > 16 {
+        return Err(SystemError::EINVAL);
+    }
+    let mut raw = [0u8; size_of::<u64>()];
+    for (idx, byte) in raw.iter_mut().enumerate() {
+        *byte = unsafe { core::ptr::read_volatile(base.add(offset + idx)) };
+    }
+    Ok(u64::from_le_bytes(raw))
+}
+
+fn bytes_of<T>(value: &T) -> &[u8] {
+    unsafe { core::slice::from_raw_parts((value as *const T) as *const u8, size_of::<T>()) }
+}
+
+fn bytes_of_mut<T>(value: &mut T) -> &mut [u8] {
+    unsafe { core::slice::from_raw_parts_mut((value as *mut T) as *mut u8, size_of::<T>()) }
+}
+
+fn begin_pmem_init(transport: &mut VirtIOTransport) {
+    transport.set_status(DeviceStatus::empty());
+    transport.set_status(DeviceStatus::ACKNOWLEDGE | DeviceStatus::DRIVER);
+    let _device_features = transport.read_device_features();
+    transport.write_driver_features(0);
+    transport
+        .set_status(DeviceStatus::ACKNOWLEDGE | DeviceStatus::DRIVER | DeviceStatus::FEATURES_OK);
+    transport.set_guest_page_size(virtio_drivers::PAGE_SIZE as u32);
+}

--- a/kernel/src/driver/virtio/virtio_pmem.rs
+++ b/kernel/src/driver/virtio/virtio_pmem.rs
@@ -234,6 +234,9 @@ impl VirtIOPmemDevice {
 
     fn flush(&self) -> Result<(), SystemError> {
         let _guard = self.flush_mutex.lock();
+
+        self.wait_for_pending_flush()?;
+
         let mut request = FlushRequest {
             token: 0,
             req: Box::new(VirtioPmemReq {
@@ -280,31 +283,43 @@ impl VirtIOPmemDevice {
             }
         }
 
+        self.wait_for_pending_flush()
+    }
+
+    fn wait_for_pending_flush(&self) -> Result<(), SystemError> {
         for _ in 0..VIRTIO_PMEM_FLUSH_POLL_RETRIES {
             {
                 let mut inner = self.inner();
-                self.complete_flush_locked(&mut inner);
+                if let Some(result) = self.take_completed_flush_locked(&mut inner) {
+                    return result;
+                }
                 if inner.state >= VirtIOPmemState::Quiescing {
-                    inner.pending_flush.take();
                     return Err(SystemError::EIO);
                 }
-                let done = inner
-                    .pending_flush
-                    .as_ref()
-                    .is_some_and(|request| request.done);
-                if done {
-                    return inner
-                        .pending_flush
-                        .take()
-                        .map(|request| request.result)
-                        .unwrap_or(Err(SystemError::EIO));
+                if inner.pending_flush.is_none() {
+                    return Ok(());
                 }
             }
             nanosleep(PosixTimeSpec::new(0, VIRTIO_PMEM_FLUSH_POLL_INTERVAL_NS))?;
         }
 
-        self.inner().pending_flush.take();
-        Err(SystemError::EIO)
+        warn!("VirtIOPmem: flush timed out while descriptor is still owned by the device");
+        Err(SystemError::ETIMEDOUT)
+    }
+
+    fn take_completed_flush_locked(
+        &self,
+        inner: &mut InnerVirtIOPmemDevice,
+    ) -> Option<Result<(), SystemError>> {
+        self.complete_flush_locked(inner);
+        if inner
+            .pending_flush
+            .as_ref()
+            .is_some_and(|request| request.done)
+        {
+            return Some(inner.pending_flush.take().unwrap().result);
+        }
+        None
     }
 
     fn complete_flush_locked(&self, inner: &mut InnerVirtIOPmemDevice) -> bool {
@@ -361,12 +376,13 @@ impl VirtIOPmemDevice {
             let _ = block_dev_manager().unregister(&block_device);
         }
 
+        let _guard = self.flush_mutex.lock();
         let mut inner = self.inner();
-        inner.pending_flush = None;
         if let Some(transport) = inner.transport.as_mut() {
-            transport.queue_unset(VIRTIO_PMEM_FLUSH_QUEUE);
             transport.set_status(DeviceStatus::empty());
+            transport.queue_unset(VIRTIO_PMEM_FLUSH_QUEUE);
         }
+        inner.pending_flush = None;
         inner.state = VirtIOPmemState::Dead;
         Ok(())
     }

--- a/user/apps/tests/dunitest/suites/normal/pmem_block.cc
+++ b/user/apps/tests/dunitest/suites/normal/pmem_block.cc
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+namespace {
+
+constexpr const char* kPmem0 = "/dev/pmem0";
+constexpr size_t kSectorSize = 512;
+
+void SkipIfNoPmem() {
+    struct stat st = {};
+    if (stat(kPmem0, &st) != 0) {
+        if (errno == ENOENT) {
+            GTEST_SKIP() << kPmem0 << " is not present in this boot configuration";
+        }
+        FAIL() << "stat(" << kPmem0 << ") failed: errno=" << errno << " ("
+               << std::strerror(errno) << ")";
+    }
+}
+
+}  // namespace
+
+TEST(PmemBlock, ExposesWholeDiskBlockDevice) {
+    SkipIfNoPmem();
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(kPmem0, &st)) << "stat(" << kPmem0 << ") failed: errno=" << errno
+                                    << " (" << std::strerror(errno) << ")";
+
+    EXPECT_TRUE(S_ISBLK(st.st_mode)) << kPmem0 << " is not a block device";
+    EXPECT_EQ(259U, major(st.st_rdev)) << kPmem0 << " major mismatch";
+    EXPECT_EQ(0U, minor(st.st_rdev)) << kPmem0 << " minor mismatch";
+    EXPECT_GE(st.st_size, static_cast<off_t>(kSectorSize));
+}
+
+TEST(PmemBlock, SupportsAlignedAndPartialReads) {
+    SkipIfNoPmem();
+
+    int fd = open(kPmem0, O_RDONLY);
+    ASSERT_GE(fd, 0) << "open(" << kPmem0 << ") failed: errno=" << errno << " ("
+                     << std::strerror(errno) << ")";
+
+    std::array<unsigned char, kSectorSize> sector {};
+    sector.fill(0xaa);
+    ASSERT_EQ(static_cast<ssize_t>(sector.size()), pread(fd, sector.data(), sector.size(), 0))
+        << "pread first sector failed: errno=" << errno << " (" << std::strerror(errno) << ")";
+
+    std::array<unsigned char, 17> partial {};
+    partial.fill(0x55);
+    ASSERT_EQ(static_cast<ssize_t>(partial.size()), pread(fd, partial.data(), partial.size(), 3))
+        << "pread partial range failed: errno=" << errno << " (" << std::strerror(errno) << ")";
+
+    EXPECT_EQ(0, close(fd));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/pmem_block.cc
+++ b/user/apps/tests/dunitest/suites/normal/pmem_block.cc
@@ -13,25 +13,34 @@ namespace {
 constexpr const char* kPmem0 = "/dev/pmem0";
 constexpr size_t kSectorSize = 512;
 
-void SkipIfNoPmem() {
-    struct stat st = {};
-    if (stat(kPmem0, &st) != 0) {
-        if (errno == ENOENT) {
-            GTEST_SKIP() << kPmem0 << " is not present in this boot configuration";
-        }
-        FAIL() << "stat(" << kPmem0 << ") failed: errno=" << errno << " ("
-               << std::strerror(errno) << ")";
+enum class PmemProbeResult {
+    Present,
+    Missing,
+    Error,
+};
+
+PmemProbeResult ProbePmem(struct stat* st, int* err) {
+    if (stat(kPmem0, st) == 0) {
+        return PmemProbeResult::Present;
     }
+    *err = errno;
+    return errno == ENOENT ? PmemProbeResult::Missing : PmemProbeResult::Error;
 }
 
 }  // namespace
 
 TEST(PmemBlock, ExposesWholeDiskBlockDevice) {
-    SkipIfNoPmem();
-
     struct stat st = {};
-    ASSERT_EQ(0, stat(kPmem0, &st)) << "stat(" << kPmem0 << ") failed: errno=" << errno
-                                    << " (" << std::strerror(errno) << ")";
+    int err = 0;
+    switch (ProbePmem(&st, &err)) {
+        case PmemProbeResult::Missing:
+            GTEST_SKIP() << kPmem0 << " is not present in this boot configuration";
+        case PmemProbeResult::Error:
+            FAIL() << "stat(" << kPmem0 << ") failed: errno=" << err << " ("
+                   << std::strerror(err) << ")";
+        case PmemProbeResult::Present:
+            break;
+    }
 
     EXPECT_TRUE(S_ISBLK(st.st_mode)) << kPmem0 << " is not a block device";
     EXPECT_EQ(259U, major(st.st_rdev)) << kPmem0 << " major mismatch";
@@ -40,7 +49,17 @@ TEST(PmemBlock, ExposesWholeDiskBlockDevice) {
 }
 
 TEST(PmemBlock, SupportsAlignedAndPartialReads) {
-    SkipIfNoPmem();
+    struct stat st = {};
+    int err = 0;
+    switch (ProbePmem(&st, &err)) {
+        case PmemProbeResult::Missing:
+            GTEST_SKIP() << kPmem0 << " is not present in this boot configuration";
+        case PmemProbeResult::Error:
+            FAIL() << "stat(" << kPmem0 << ") failed: errno=" << err << " ("
+                   << std::strerror(err) << ")";
+        case PmemProbeResult::Present:
+            break;
+    }
 
     int fd = open(kPmem0, O_RDONLY);
     ASSERT_GE(fd, 0) << "open(" << kPmem0 << ") failed: errno=" << errno << " ("

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -45,3 +45,4 @@ normal/seccomp
 normal/process_signal_fork
 normal/sysfs_cgroup2_mount
 normal/devfs_ptmx_unlink
+normal/pmem_block


### PR DESCRIPTION
## Summary
- Add virtio-pmem PCI device probing and flush support.
- Register virtio-pmem regions as PMEM block devices and expose `/dev/pmem*` for rootfs use.
- Move block partition publication out of the global block-manager lock and add dunitest coverage for PMEM block-device exposure and reads.

## Validation
- `make fmt`
- Booted with a writable virtio-pmem ext4 image and verified `/dev/pmem0` can be mounted, read, written, synced, and unmounted.
- Verified CubeSandbox reaches PMEM rootfs loading and migrates rootfs to ext4 with this kernel.

Refs #1946
Closes #1953
