### PR TITLE
fix: remove spurious *.md and .cursor entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,3 @@ config/rootfs.generated.toml
 *.cpio.xz
 *.cpio*
 .direnv/
-
-*.md
-.cursor


### PR DESCRIPTION
## Problem

PR #1832 (commit `f733b8b5`) accidentally added `*.md` and `.cursor` to `.gitignore`.

The `*.md` rule ignores **all** Markdown files in the repository, including README, documentation, and other essential `.md` files, preventing them from being tracked by git.

## Change

Remove the following lines from `.gitignore`:
- `*.md`
- `.cursor`