### PR TITLE
fs: honor root mount command line options

### DIFF
--- a/kernel/src/debug/klog/loglevel.rs
+++ b/kernel/src/debug/klog/loglevel.rs
@@ -169,6 +169,7 @@ static LOGLEVEL_PARAM: KernelCmdlineParameter = KernelCmdlineParameter::KV(Kerne
     name: "loglevel",
     value: None,
     initialized: false,
+    supplied: false,
     default: "7", // 默认DEBUG级别
 });
 

--- a/kernel/src/driver/virtio/virtio_pmem.rs
+++ b/kernel/src/driver/virtio/virtio_pmem.rs
@@ -546,11 +546,11 @@ impl KObject for VirtIOPmemDevice {
         self.inner().kobject_common.parent = parent;
     }
 
-    fn kset(&self) -> Option<Arc<KSet>> {
+    fn kset(&self) -> Option<Arc<dyn KSet>> {
         self.inner().kobject_common.kset.clone()
     }
 
-    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+    fn set_kset(&self, kset: Option<Arc<dyn KSet>>) {
         self.inner().kobject_common.kset = kset;
     }
 
@@ -697,11 +697,11 @@ impl KObject for VirtIOPmemDriver {
         self.inner().kobj_common.parent = parent;
     }
 
-    fn kset(&self) -> Option<Arc<KSet>> {
+    fn kset(&self) -> Option<Arc<dyn KSet>> {
         self.inner().kobj_common.kset.clone()
     }
 
-    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+    fn set_kset(&self, kset: Option<Arc<dyn KSet>>) {
         self.inner().kobj_common.kset = kset;
     }
 

--- a/kernel/src/driver/virtio/virtio_pmem.rs
+++ b/kernel/src/driver/virtio/virtio_pmem.rs
@@ -546,11 +546,11 @@ impl KObject for VirtIOPmemDevice {
         self.inner().kobject_common.parent = parent;
     }
 
-    fn kset(&self) -> Option<Arc<dyn KSet>> {
+    fn kset(&self) -> Option<Arc<KSet>> {
         self.inner().kobject_common.kset.clone()
     }
 
-    fn set_kset(&self, kset: Option<Arc<dyn KSet>>) {
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
         self.inner().kobject_common.kset = kset;
     }
 
@@ -697,11 +697,11 @@ impl KObject for VirtIOPmemDriver {
         self.inner().kobj_common.parent = parent;
     }
 
-    fn kset(&self) -> Option<Arc<dyn KSet>> {
+    fn kset(&self) -> Option<Arc<KSet>> {
         self.inner().kobj_common.kset.clone()
     }
 
-    fn set_kset(&self, kset: Option<Arc<dyn KSet>>) {
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
         self.inner().kobj_common.kset = kset;
     }
 

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -41,6 +41,38 @@ pub struct Ext4FileSystem {
 
     /// 元数据（size/mtime）脏但尚未刷盘的 inode 列表。
     dirty_inodes: Mutex<Vec<Arc<LockedExt4Inode>>>,
+
+    /// Mount-time ext4 options parsed from user/kernel mount data.
+    _mount_options: Ext4MountOptions,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ext4DaxMode {
+    Never,
+    Always,
+    Inode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ext4ErrorsBehavior {
+    Continue,
+    RemountRo,
+    Panic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ext4MountOptions {
+    pub dax: Option<Ext4DaxMode>,
+    pub errors: Ext4ErrorsBehavior,
+}
+
+impl Default for Ext4MountOptions {
+    fn default() -> Self {
+        Self {
+            dax: None,
+            errors: Ext4ErrorsBehavior::Continue,
+        }
+    }
 }
 
 impl FileSystem for Ext4FileSystem {
@@ -234,6 +266,13 @@ impl Ext4FileSystem {
     }
 
     pub fn from_gendisk(mount_data: Arc<GenDisk>) -> Result<Arc<dyn FileSystem>, SystemError> {
+        Self::from_gendisk_with_options(mount_data, Ext4MountOptions::default())
+    }
+
+    pub fn from_gendisk_with_options(
+        mount_data: Arc<GenDisk>,
+        mount_options: Ext4MountOptions,
+    ) -> Result<Arc<dyn FileSystem>, SystemError> {
         let raw_dev = mount_data.device_num();
         let fs = another_ext4::Ext4::load(mount_data.clone())?;
         let root_inode: Arc<LockedExt4Inode> =
@@ -262,6 +301,7 @@ impl Ext4FileSystem {
             raw_dev,
             root_inode,
             dirty_inodes: Mutex::new(Vec::new()),
+            _mount_options: mount_options,
         });
 
         let mut guard = fs.root_inode.0.lock();

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -253,10 +253,50 @@ fn parse_ext4_errors_option(value: &str) -> Result<Ext4ErrorsBehavior, SystemErr
     }
 }
 
+fn apply_common_rootflag(opt: &str, mount_flags: &mut MountFlags) -> bool {
+    match opt {
+        "defaults" => {}
+        "ro" => mount_flags.insert(MountFlags::RDONLY),
+        "rw" => mount_flags.remove(MountFlags::RDONLY),
+        "sync" => mount_flags.insert(MountFlags::SYNCHRONOUS),
+        "async" => mount_flags.remove(MountFlags::SYNCHRONOUS),
+        "dirsync" => mount_flags.insert(MountFlags::DIRSYNC),
+        "lazytime" => mount_flags.insert(MountFlags::LAZYTIME),
+        "nolazytime" => mount_flags.remove(MountFlags::LAZYTIME),
+        "mand" => mount_flags.insert(MountFlags::MANDLOCK),
+        "nomand" => mount_flags.remove(MountFlags::MANDLOCK),
+        "nosuid" => mount_flags.insert(MountFlags::NOSUID),
+        "suid" => mount_flags.remove(MountFlags::NOSUID),
+        "nodev" => mount_flags.insert(MountFlags::NODEV),
+        "dev" => mount_flags.remove(MountFlags::NODEV),
+        "noexec" => mount_flags.insert(MountFlags::NOEXEC),
+        "exec" => mount_flags.remove(MountFlags::NOEXEC),
+        "noatime" => {
+            mount_flags.remove(MountFlags::RELATIME | MountFlags::STRICTATIME);
+            mount_flags.insert(MountFlags::NOATIME);
+        }
+        "atime" | "strictatime" => {
+            mount_flags.remove(MountFlags::RELATIME | MountFlags::NOATIME);
+        }
+        "relatime" => {
+            mount_flags.remove(MountFlags::NOATIME | MountFlags::STRICTATIME);
+            mount_flags.insert(MountFlags::RELATIME);
+        }
+        "nodiratime" => mount_flags.insert(MountFlags::NODIRATIME),
+        "diratime" => mount_flags.remove(MountFlags::NODIRATIME),
+        "nosymfollow" => mount_flags.insert(MountFlags::NOSYMFOLLOW),
+        "symfollow" => mount_flags.remove(MountFlags::NOSYMFOLLOW),
+        "iversion" => mount_flags.insert(MountFlags::I_VERSION),
+        "noiversion" => mount_flags.remove(MountFlags::I_VERSION),
+        _ => return false,
+    }
+    true
+}
+
 fn parse_rootflags(mode: RootMountMode) -> Result<RootMountOptions, SystemError> {
     let mut mount_flags = match mode {
-        RootMountMode::ReadOnly => MountFlags::RDONLY,
-        RootMountMode::ReadWrite => MountFlags::empty(),
+        RootMountMode::ReadOnly => MountFlags::RDONLY | MountFlags::RELATIME,
+        RootMountMode::ReadWrite => MountFlags::RELATIME,
     };
     let mut ext4_options = Ext4MountOptions::default();
 
@@ -278,15 +318,11 @@ fn parse_rootflags(mode: RootMountMode) -> Result<RootMountOptions, SystemError>
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
     {
+        if apply_common_rootflag(opt, &mut mount_flags) {
+            continue;
+        }
+
         match opt {
-            "ro" => mount_flags.insert(MountFlags::RDONLY),
-            "rw" => mount_flags.remove(MountFlags::RDONLY),
-            "sync" => mount_flags.insert(MountFlags::SYNCHRONOUS),
-            "async" => mount_flags.remove(MountFlags::SYNCHRONOUS),
-            "lazytime" => mount_flags.insert(MountFlags::LAZYTIME),
-            "nolazytime" => mount_flags.remove(MountFlags::LAZYTIME),
-            "mand" => mount_flags.insert(MountFlags::MANDLOCK),
-            "nomand" => mount_flags.remove(MountFlags::MANDLOCK),
             _ if opt == "dax" || opt.starts_with("dax=") => {
                 ext4_options.dax = Some(parse_ext4_dax_option(opt)?);
             }

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -1,6 +1,6 @@
 use core::{hint::spin_loop, sync::atomic::Ordering};
 
-use alloc::{string::ToString, sync::Arc};
+use alloc::{string::ToString, sync::Arc, vec::Vec};
 use log::{error, info, warn};
 use system_error::SystemError;
 
@@ -11,15 +11,16 @@ use crate::{
     filesystem::{
         devfs::devfs_init,
         devpts::devpts_init,
-        ext4::filesystem::Ext4FileSystem,
+        ext4::filesystem::{Ext4DaxMode, Ext4ErrorsBehavior, Ext4FileSystem, Ext4MountOptions},
         fat::fs::FATFileSystem,
         procfs::procfs_init,
         sysfs::sysfs_init,
         vfs::{
-            permission::PermissionMask, AtomicInodeId, FileSystem, FileType, InodeFlags, InodeMode,
-            MountFS,
+            mount::MountFlags, permission::PermissionMask, AtomicInodeId, FileSystem, FileType,
+            InodeFlags, InodeMode, MountFS,
         },
     },
+    init::cmdline::kenrel_cmdline_param_manager,
     mm::truncate::truncate_inode_pages,
     process::{cred::CAPFlags, namespace::mnt::mnt_namespace_init, ProcessManager},
 };
@@ -40,6 +41,10 @@ const ROOTFS_TRY_LIST: [&str; 6] = [
     "/dev/sdio1",
 ];
 kernel_cmdline_param_kv!(ROOTFS_PATH_PARAM, root, "");
+kernel_cmdline_param_arg!(ROOTFS_RO_PARAM, ro, false, false);
+kernel_cmdline_param_arg!(ROOTFS_RW_PARAM, rw, false, false);
+kernel_cmdline_param_kv!(ROOTFS_TYPE_PARAM, rootfstype, "");
+kernel_cmdline_param_kv!(ROOTFS_FLAGS_PARAM, rootflags, "");
 
 /// @brief 原子地生成新的Inode号。
 /// 请注意，所有的inode号都需要通过该函数来生成.全局的inode号，除了以下两个特殊的以外，都是唯一的
@@ -79,7 +84,10 @@ pub fn vfs_init() -> Result<(), SystemError> {
 
 /// @brief 迁移伪文件系统的inode
 /// 请注意，为了避免删掉了伪文件系统内的信息，因此没有在原root inode那里调用unlink.
-fn migrate_virtual_filesystem(new_fs: Arc<dyn FileSystem>) -> Result<(), SystemError> {
+fn migrate_virtual_filesystem(
+    new_fs: Arc<dyn FileSystem>,
+    root_mount_flags: MountFlags,
+) -> Result<(), SystemError> {
     info!("VFS: Migrating filesystems...");
 
     let current_mntns = ProcessManager::current_mntns();
@@ -91,7 +99,7 @@ fn migrate_virtual_filesystem(new_fs: Arc<dyn FileSystem>) -> Result<(), SystemE
         None,
         old_mntfs.propagation(),
         Some(&current_mntns),
-        old_mntfs.mount_flags(),
+        root_mount_flags,
         old_mntfs.mount_source(),
     );
 
@@ -151,6 +159,154 @@ enum RootFsKind {
     Fat,
 }
 
+impl RootFsKind {
+    fn from_cmdline_name(name: &str) -> Option<Self> {
+        match name {
+            "ext4" => Some(Self::Ext4),
+            "fat" | "vfat" => Some(Self::Fat),
+            _ => None,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Ext4 => "ext4",
+            Self::Fat => "fat",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootMountMode {
+    ReadOnly,
+    ReadWrite,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RootMountOptions {
+    mount_flags: MountFlags,
+    ext4_options: Ext4MountOptions,
+}
+
+impl RootMountOptions {
+    fn has_ext4_specific_options(&self) -> bool {
+        self.ext4_options != Ext4MountOptions::default()
+    }
+}
+
+fn root_mount_mode() -> RootMountMode {
+    if ROOTFS_RO_PARAM.was_supplied() && ROOTFS_RW_PARAM.was_supplied() {
+        warn!("rootfs: both ro and rw are supplied; using the last pre-`--` option");
+    }
+
+    match kenrel_cmdline_param_manager()
+        .last_bare_option_before_init_args(&["ro", "rw"])
+        .as_deref()
+    {
+        Some("rw") => RootMountMode::ReadWrite,
+        _ => RootMountMode::ReadOnly,
+    }
+}
+
+fn rootfstype_candidates() -> Result<Vec<RootFsKind>, SystemError> {
+    let Some(rootfstype) = ROOTFS_TYPE_PARAM.value_str() else {
+        return Ok(Vec::new());
+    };
+    if rootfstype.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut result = Vec::new();
+    for name in rootfstype
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+    {
+        let Some(kind) = RootFsKind::from_cmdline_name(name) else {
+            error!("rootfs: unsupported rootfstype '{}'", name);
+            return Err(SystemError::EINVAL);
+        };
+        result.push(kind);
+    }
+
+    if result.is_empty() {
+        return Err(SystemError::EINVAL);
+    }
+    Ok(result)
+}
+
+fn parse_ext4_dax_option(opt: &str) -> Result<Ext4DaxMode, SystemError> {
+    match opt {
+        "dax" | "dax=always" => Ok(Ext4DaxMode::Always),
+        "dax=inode" => Ok(Ext4DaxMode::Inode),
+        "dax=never" => Ok(Ext4DaxMode::Never),
+        _ => Err(SystemError::EINVAL),
+    }
+}
+
+fn parse_ext4_errors_option(value: &str) -> Result<Ext4ErrorsBehavior, SystemError> {
+    match value {
+        "continue" => Ok(Ext4ErrorsBehavior::Continue),
+        "remount-ro" => Ok(Ext4ErrorsBehavior::RemountRo),
+        "panic" => Ok(Ext4ErrorsBehavior::Panic),
+        _ => Err(SystemError::EINVAL),
+    }
+}
+
+fn parse_rootflags(mode: RootMountMode) -> Result<RootMountOptions, SystemError> {
+    let mut mount_flags = match mode {
+        RootMountMode::ReadOnly => MountFlags::RDONLY,
+        RootMountMode::ReadWrite => MountFlags::empty(),
+    };
+    let mut ext4_options = Ext4MountOptions::default();
+
+    let Some(rootflags) = ROOTFS_FLAGS_PARAM.value_str() else {
+        return Ok(RootMountOptions {
+            mount_flags,
+            ext4_options,
+        });
+    };
+    if rootflags.is_empty() {
+        return Ok(RootMountOptions {
+            mount_flags,
+            ext4_options,
+        });
+    }
+
+    for opt in rootflags
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+    {
+        match opt {
+            "ro" => mount_flags.insert(MountFlags::RDONLY),
+            "rw" => mount_flags.remove(MountFlags::RDONLY),
+            "sync" => mount_flags.insert(MountFlags::SYNCHRONOUS),
+            "async" => mount_flags.remove(MountFlags::SYNCHRONOUS),
+            "lazytime" => mount_flags.insert(MountFlags::LAZYTIME),
+            "nolazytime" => mount_flags.remove(MountFlags::LAZYTIME),
+            "mand" => mount_flags.insert(MountFlags::MANDLOCK),
+            "nomand" => mount_flags.remove(MountFlags::MANDLOCK),
+            _ if opt == "dax" || opt.starts_with("dax=") => {
+                ext4_options.dax = Some(parse_ext4_dax_option(opt)?);
+            }
+            _ if opt.starts_with("errors=") => {
+                let value = opt.split_once('=').ok_or(SystemError::EINVAL)?.1;
+                ext4_options.errors = parse_ext4_errors_option(value)?;
+            }
+            _ => {
+                error!("rootfs: unsupported rootflags option '{}'", opt);
+                return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+            }
+        }
+    }
+
+    Ok(RootMountOptions {
+        mount_flags,
+        ext4_options,
+    })
+}
+
 fn probe_rootfs_kind(gendisk: &Arc<GenDisk>) -> Option<RootFsKind> {
     match Ext4FileSystem::probe(gendisk) {
         Ok(true) => return Some(RootFsKind::Ext4),
@@ -171,7 +327,10 @@ fn probe_rootfs_kind(gendisk: &Arc<GenDisk>) -> Option<RootFsKind> {
 pub fn mount_root_fs() -> Result<(), SystemError> {
     info!("Try to mount root fs...");
     block_dev_manager().print_gendisks();
-    let gendisk = if let Some(rootfs_dev_path) = ROOTFS_PATH_PARAM.value_str() {
+    let gendisk = if let Some(rootfs_dev_path) = ROOTFS_PATH_PARAM
+        .value_str()
+        .filter(|path| !path.is_empty())
+    {
         try_find_gendisk(rootfs_dev_path)
             .unwrap_or_else(|| panic!("Failed to find rootfs device {}", rootfs_dev_path))
     } else {
@@ -181,17 +340,55 @@ pub fn mount_root_fs() -> Result<(), SystemError> {
             .ok_or(SystemError::ENODEV)?
     };
 
-    let kind = probe_rootfs_kind(&gendisk);
+    let mode = root_mount_mode();
+    let root_options = parse_rootflags(mode)?;
+    let configured_kinds = rootfstype_candidates()?;
+    let probed_kind = if configured_kinds.is_empty() {
+        probe_rootfs_kind(&gendisk)
+    } else {
+        None
+    };
 
-    let rootfs: Result<Arc<dyn FileSystem>, SystemError> = match kind {
-        Some(RootFsKind::Ext4) => Ext4FileSystem::from_gendisk(gendisk.clone()),
-        Some(RootFsKind::Fat) => Ok(FATFileSystem::new(gendisk.clone())?),
+    let init_rootfs = |kind: RootFsKind| -> Result<Arc<dyn FileSystem>, SystemError> {
+        match kind {
+            RootFsKind::Ext4 => Ext4FileSystem::from_gendisk_with_options(
+                gendisk.clone(),
+                root_options.ext4_options,
+            ),
+            RootFsKind::Fat => {
+                if root_options.has_ext4_specific_options() {
+                    error!("rootfs: ext4-specific rootflags cannot be used with FAT rootfs");
+                    return Err(SystemError::EINVAL);
+                }
+                Ok(FATFileSystem::new(gendisk.clone())?)
+            }
+        }
+    };
+
+    let rootfs: Result<Arc<dyn FileSystem>, SystemError> = match probed_kind {
+        Some(kind) => init_rootfs(kind),
         None => {
-            // 兜底：按常见顺序尝试初始化（ext4 -> fat），便于未来扩展 probe 或处理特殊镜像。
-            Ext4FileSystem::from_gendisk(gendisk.clone()).or_else(|_| {
-                let fat: Arc<FATFileSystem> = FATFileSystem::new(gendisk.clone())?;
-                Ok(fat)
-            })
+            let candidates = if configured_kinds.is_empty() {
+                Vec::from([RootFsKind::Ext4, RootFsKind::Fat])
+            } else {
+                configured_kinds
+            };
+
+            let mut last_err = SystemError::EINVAL;
+            let mut mounted = None;
+            for kind in candidates {
+                match init_rootfs(kind) {
+                    Ok(fs) => {
+                        mounted = Some(fs);
+                        break;
+                    }
+                    Err(e) => {
+                        warn!("rootfs: failed to initialize {}: {:?}", kind.name(), e);
+                        last_err = e;
+                    }
+                }
+            }
+            mounted.ok_or(last_err)
         }
     };
 
@@ -206,7 +403,7 @@ pub fn mount_root_fs() -> Result<(), SystemError> {
     };
 
     let fs_name = rootfs.name().to_string();
-    let r = migrate_virtual_filesystem(rootfs.clone());
+    let r = migrate_virtual_filesystem(rootfs.clone(), root_options.mount_flags);
     if r.is_err() {
         error!(
             "Failed to migrate virtual filesystem to rootfs ({}).",
@@ -225,7 +422,7 @@ pub fn mount_root_fs() -> Result<(), SystemError> {
 pub fn change_root_fs() -> Result<(), SystemError> {
     info!("Try to change root fs to initramfs...");
     let initramfs = crate::init::initram::INIT_ROOT_INODE().fs();
-    let r = migrate_virtual_filesystem(initramfs);
+    let r = migrate_virtual_filesystem(initramfs, MountFlags::empty());
 
     if r.is_err() {
         error!("Failed to migrate virtual filesystem to initramfs!");

--- a/kernel/src/init/cmdline.rs
+++ b/kernel/src/init/cmdline.rs
@@ -3,7 +3,7 @@ use core::{
     sync::atomic::{fence, Ordering},
 };
 
-use alloc::{ffi::CString, vec::Vec};
+use alloc::{ffi::CString, string::String, vec::Vec};
 
 use crate::libs::spinlock::SpinLock;
 
@@ -77,6 +77,7 @@ impl KernelCmdlineParamBuilder {
                 value: [0; KernelCmdlineEarlyKV::VALUE_MAX_LEN],
                 index: 0,
                 initialized: false,
+                supplied: false,
                 default: self.default_str,
             })
         } else {
@@ -90,6 +91,7 @@ impl KernelCmdlineParamBuilder {
                 name: self.name,
                 value: self.default_bool,
                 initialized: false,
+                supplied: false,
                 inv: self.inv,
                 default: self.default_bool,
             })),
@@ -97,6 +99,7 @@ impl KernelCmdlineParamBuilder {
                 name: self.name,
                 value: None,
                 initialized: false,
+                supplied: false,
                 default: self.default_str,
             })),
             _ => None,
@@ -153,6 +156,14 @@ impl KernelCmdlineParameter {
         matches!(self, KernelCmdlineParameter::EarlyKV(_))
     }
 
+    pub fn was_supplied(&self) -> bool {
+        match self {
+            KernelCmdlineParameter::Arg(v) => v.was_supplied(),
+            KernelCmdlineParameter::KV(v) => v.supplied,
+            KernelCmdlineParameter::EarlyKV(v) => v.supplied,
+        }
+    }
+
     /// 强行获取可变引用
     ///
     /// # Safety
@@ -170,6 +181,7 @@ pub struct KernelCmdlineArg {
     name: &'static str,
     value: bool,
     initialized: bool,
+    supplied: bool,
     /// 是否反转
     inv: bool,
     default: bool,
@@ -179,12 +191,17 @@ impl KernelCmdlineArg {
     pub fn value(&self) -> bool {
         volatile_read!(self.value)
     }
+
+    pub fn was_supplied(&self) -> bool {
+        volatile_read!(self.supplied)
+    }
 }
 
 pub struct KernelCmdlineKV {
     pub name: &'static str,
     pub value: Option<CString>,
     pub initialized: bool,
+    pub supplied: bool,
     pub default: &'static str,
 }
 
@@ -194,6 +211,7 @@ pub struct KernelCmdlineEarlyKV {
     pub value: [u8; Self::VALUE_MAX_LEN],
     pub index: usize,
     pub initialized: bool,
+    pub supplied: bool,
     pub default: &'static str,
 }
 
@@ -277,6 +295,7 @@ impl KernelCmdlineManager {
                             p.index = len;
                         }
                         p.initialized = true;
+                        p.supplied = true;
                     }
                     _ => unreachable!(),
                 }
@@ -345,13 +364,18 @@ impl KernelCmdlineManager {
                 let param = unsafe { param.force_mut() };
                 match param {
                     KernelCmdlineParameter::KV(p) => {
+                        let Some(value) = value else {
+                            log::warn!("cmdline: key-value parameter {} has no value", p.name);
+                            continue;
+                        };
                         if p.value.is_some() {
                             log::warn!("cmdline: parameter {} is set twice", p.name);
                             continue;
                         }
 
-                        p.value = Some(CString::new(value.unwrap()).unwrap());
+                        p.value = Some(CString::new(value).unwrap());
                         p.initialized = true;
+                        p.supplied = true;
                     }
                     _ => unreachable!(),
                 }
@@ -366,6 +390,7 @@ impl KernelCmdlineManager {
                         }
                         p.value = !p.inv;
                         p.initialized = true;
+                        p.supplied = true;
                     }
                     _ => unreachable!(),
                 }
@@ -410,6 +435,26 @@ impl KernelCmdlineManager {
             }
             fence(Ordering::SeqCst);
         });
+    }
+
+    pub fn last_bare_option_before_init_args(&self, names: &[&str]) -> Option<String> {
+        let boot_params = boot_params().read();
+        let mut last = None;
+
+        for argument in self.split_args(boot_params.boot_cmdline_str()) {
+            if argument == "--" {
+                break;
+            }
+
+            let Some((node, option, value)) = self.split_arg(argument) else {
+                continue;
+            };
+            if node.is_none() && value.is_none() && names.iter().any(|name| *name == option) {
+                last = Some(String::from(option));
+            }
+        }
+
+        last
     }
 
     fn find_param(

--- a/kernel/src/init/cmdline.rs
+++ b/kernel/src/init/cmdline.rs
@@ -449,7 +449,7 @@ impl KernelCmdlineManager {
             let Some((node, option, value)) = self.split_arg(argument) else {
                 continue;
             };
-            if node.is_none() && value.is_none() && names.iter().any(|name| *name == option) {
+            if node.is_none() && value.is_none() && names.contains(&option) {
                 last = Some(String::from(option));
             }
         }

--- a/tools/qemu/default.nix
+++ b/tools/qemu/default.nix
@@ -345,7 +345,7 @@ let
       EXTRA_CMDLINE="${qemuConfig.cmdlineExtra}"
 
       # FIXED: 补全缺失的默认内核参数 AUTO_TEST 和 SYSCALL_TEST_DIR
-      FINAL_CMDLINE="init=${initProgram} AUTO_TEST=${testOpt.autotest} SYSCALL_TEST_DIR=${testOpt.syscall.testDir} DUNITEST_DIR=${testOpt.dunitest.testDir} $EXTRA_CMDLINE"
+      FINAL_CMDLINE="rw init=${initProgram} AUTO_TEST=${testOpt.autotest} SYSCALL_TEST_DIR=${testOpt.syscall.testDir} DUNITEST_DIR=${testOpt.dunitest.testDir} $EXTRA_CMDLINE"
 
       ARCH_FLAGS=( ${lib.escapeShellArgs commonArchArgs} )
       ${archSpecificBash}

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -373,7 +373,7 @@ check_dependencies
 # 设置无图形界面模式
 QEMU_NOGRAPHIC=false
 
-KERNEL_CMDLINE=" "
+KERNEL_CMDLINE=" rw "
 
 # 自动测试选项，支持的选项：
 # - none: 不进行自动测试

--- a/user/apps/tests/dunitest/suites/normal/root_mount_cmdline.cc
+++ b/user/apps/tests/dunitest/suites/normal/root_mount_cmdline.cc
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool read_text_file(const char* path, std::string* out) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    out->clear();
+    char buf[1024];
+    ssize_t n = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out->append(buf, static_cast<size_t>(n));
+    }
+
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return n >= 0;
+}
+
+std::vector<std::string> split_whitespace(const std::string& input) {
+    std::istringstream stream(input);
+    std::vector<std::string> out;
+    std::string token;
+    while (stream >> token) {
+        out.push_back(token);
+    }
+    return out;
+}
+
+void apply_rw_token(const std::string& token, std::string* mode) {
+    if (token == "ro" || token == "rw") {
+        *mode = token;
+    }
+}
+
+std::string expected_root_mode_from_cmdline(const std::string& cmdline) {
+    std::string mode = "ro";
+
+    for (const std::string& token : split_whitespace(cmdline)) {
+        if (token == "--") {
+            break;
+        }
+
+        apply_rw_token(token, &mode);
+
+        constexpr const char* kRootflags = "rootflags=";
+        if (token.rfind(kRootflags, 0) != 0) {
+            continue;
+        }
+
+        std::string flags = token.substr(strlen(kRootflags));
+        size_t start = 0;
+        while (start <= flags.size()) {
+            const size_t end = flags.find(',', start);
+            const size_t len = (end == std::string::npos) ? flags.size() - start : end - start;
+            apply_rw_token(flags.substr(start, len), &mode);
+            if (end == std::string::npos) {
+                break;
+            }
+            start = end + 1;
+        }
+    }
+
+    return mode;
+}
+
+bool find_root_mount_options(const std::string& mounts, std::string* options) {
+    std::istringstream lines(mounts);
+    std::string line;
+    while (std::getline(lines, line)) {
+        std::istringstream fields(line);
+        std::string source;
+        std::string mountpoint;
+        std::string fstype;
+        if (!(fields >> source >> mountpoint >> fstype >> *options)) {
+            continue;
+        }
+        if (mountpoint == "/") {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST(RootMountCmdline, RootMountModeFollowsKernelCommandLine) {
+    std::string cmdline;
+    ASSERT_TRUE(read_text_file("/proc/cmdline", &cmdline))
+        << "read /proc/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    std::string mounts;
+    ASSERT_TRUE(read_text_file("/proc/self/mounts", &mounts))
+        << "read /proc/self/mounts failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    std::string options;
+    ASSERT_TRUE(find_root_mount_options(mounts, &options)) << "/proc/self/mounts:\n" << mounts;
+
+    const std::string expected = expected_root_mode_from_cmdline(cmdline);
+    ASSERT_GE(options.size(), expected.size()) << "root mount options: " << options;
+    EXPECT_EQ(expected, options.substr(0, expected.size()))
+        << "cmdline:\n" << cmdline << "\n/proc/self/mounts:\n" << mounts;
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/root_mount_cmdline.cc
+++ b/user/apps/tests/dunitest/suites/normal/root_mount_cmdline.cc
@@ -11,6 +11,21 @@
 
 namespace {
 
+struct ExpectedRootMountOptions {
+    std::string mode = "ro";
+    bool sync = false;
+    bool dirsync = false;
+    bool lazytime = false;
+    bool mand = false;
+    bool nosuid = false;
+    bool nodev = false;
+    bool noexec = false;
+    bool noatime = false;
+    bool nodiratime = false;
+    bool relatime = true;
+    bool nosymfollow = false;
+};
+
 bool read_text_file(const char* path, std::string* out) {
     int fd = open(path, O_RDONLY);
     if (fd < 0) {
@@ -40,21 +55,90 @@ std::vector<std::string> split_whitespace(const std::string& input) {
     return out;
 }
 
-void apply_rw_token(const std::string& token, std::string* mode) {
+std::vector<std::string> split_commas(const std::string& input) {
+    std::vector<std::string> out;
+    size_t start = 0;
+    while (start <= input.size()) {
+        const size_t end = input.find(',', start);
+        const size_t len = (end == std::string::npos) ? input.size() - start : end - start;
+        out.push_back(input.substr(start, len));
+        if (end == std::string::npos) {
+            break;
+        }
+        start = end + 1;
+    }
+    return out;
+}
+
+bool has_option(const std::vector<std::string>& options, const char* expected) {
+    for (const std::string& option : options) {
+        if (option == expected) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void apply_rootflag_option(const std::string& token, ExpectedRootMountOptions* expected) {
     if (token == "ro" || token == "rw") {
-        *mode = token;
+        expected->mode = token;
+    } else if (token == "sync") {
+        expected->sync = true;
+    } else if (token == "async") {
+        expected->sync = false;
+    } else if (token == "dirsync") {
+        expected->dirsync = true;
+    } else if (token == "lazytime") {
+        expected->lazytime = true;
+    } else if (token == "nolazytime") {
+        expected->lazytime = false;
+    } else if (token == "mand") {
+        expected->mand = true;
+    } else if (token == "nomand") {
+        expected->mand = false;
+    } else if (token == "nosuid") {
+        expected->nosuid = true;
+    } else if (token == "suid") {
+        expected->nosuid = false;
+    } else if (token == "nodev") {
+        expected->nodev = true;
+    } else if (token == "dev") {
+        expected->nodev = false;
+    } else if (token == "noexec") {
+        expected->noexec = true;
+    } else if (token == "exec") {
+        expected->noexec = false;
+    } else if (token == "noatime") {
+        expected->noatime = true;
+        expected->relatime = false;
+    } else if (token == "atime" || token == "strictatime") {
+        expected->noatime = false;
+        expected->relatime = false;
+    } else if (token == "relatime") {
+        expected->noatime = false;
+        expected->relatime = true;
+    } else if (token == "nodiratime") {
+        expected->nodiratime = true;
+    } else if (token == "diratime") {
+        expected->nodiratime = false;
+    } else if (token == "nosymfollow") {
+        expected->nosymfollow = true;
+    } else if (token == "symfollow") {
+        expected->nosymfollow = false;
     }
 }
 
-std::string expected_root_mode_from_cmdline(const std::string& cmdline) {
-    std::string mode = "ro";
+ExpectedRootMountOptions expected_root_options_from_cmdline(const std::string& cmdline) {
+    ExpectedRootMountOptions expected;
 
     for (const std::string& token : split_whitespace(cmdline)) {
         if (token == "--") {
             break;
         }
 
-        apply_rw_token(token, &mode);
+        if (token == "ro" || token == "rw") {
+            expected.mode = token;
+        }
 
         constexpr const char* kRootflags = "rootflags=";
         if (token.rfind(kRootflags, 0) != 0) {
@@ -62,19 +146,12 @@ std::string expected_root_mode_from_cmdline(const std::string& cmdline) {
         }
 
         std::string flags = token.substr(strlen(kRootflags));
-        size_t start = 0;
-        while (start <= flags.size()) {
-            const size_t end = flags.find(',', start);
-            const size_t len = (end == std::string::npos) ? flags.size() - start : end - start;
-            apply_rw_token(flags.substr(start, len), &mode);
-            if (end == std::string::npos) {
-                break;
-            }
-            start = end + 1;
+        for (const std::string& option : split_commas(flags)) {
+            apply_rootflag_option(option, &expected);
         }
     }
 
-    return mode;
+    return expected;
 }
 
 bool find_root_mount_options(const std::string& mounts, std::string* options) {
@@ -95,6 +172,14 @@ bool find_root_mount_options(const std::string& mounts, std::string* options) {
     return false;
 }
 
+void expect_option(const std::vector<std::string>& options, const char* option) {
+    EXPECT_TRUE(has_option(options, option)) << "missing mount option: " << option;
+}
+
+void expect_no_option(const std::vector<std::string>& options, const char* option) {
+    EXPECT_FALSE(has_option(options, option)) << "unexpected mount option: " << option;
+}
+
 }  // namespace
 
 TEST(RootMountCmdline, RootMountModeFollowsKernelCommandLine) {
@@ -109,10 +194,28 @@ TEST(RootMountCmdline, RootMountModeFollowsKernelCommandLine) {
     std::string options;
     ASSERT_TRUE(find_root_mount_options(mounts, &options)) << "/proc/self/mounts:\n" << mounts;
 
-    const std::string expected = expected_root_mode_from_cmdline(cmdline);
-    ASSERT_GE(options.size(), expected.size()) << "root mount options: " << options;
-    EXPECT_EQ(expected, options.substr(0, expected.size()))
+    const ExpectedRootMountOptions expected = expected_root_options_from_cmdline(cmdline);
+    ASSERT_GE(options.size(), expected.mode.size()) << "root mount options: " << options;
+    EXPECT_EQ(expected.mode, options.substr(0, expected.mode.size()))
         << "cmdline:\n" << cmdline << "\n/proc/self/mounts:\n" << mounts;
+
+    const std::vector<std::string> option_tokens = split_commas(options);
+    if (expected.sync) expect_option(option_tokens, "sync");
+    if (expected.dirsync) expect_option(option_tokens, "dirsync");
+    if (expected.lazytime) expect_option(option_tokens, "lazytime");
+    if (expected.mand) expect_option(option_tokens, "mand");
+    if (expected.nosuid) expect_option(option_tokens, "nosuid");
+    if (expected.nodev) expect_option(option_tokens, "nodev");
+    if (expected.noexec) expect_option(option_tokens, "noexec");
+    if (expected.noatime) expect_option(option_tokens, "noatime");
+    if (expected.nodiratime) expect_option(option_tokens, "nodiratime");
+    if (expected.relatime) expect_option(option_tokens, "relatime");
+    if (expected.nosymfollow) expect_option(option_tokens, "nosymfollow");
+    if (expected.noatime) expect_no_option(option_tokens, "relatime");
+    if (!expected.noatime && !expected.relatime) {
+        expect_no_option(option_tokens, "noatime");
+        expect_no_option(option_tokens, "relatime");
+    }
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -33,6 +33,7 @@ fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link
 normal/proc_mount_exports
+normal/root_mount_cmdline
 normal/proc_pid_reuse_cache
 normal/proc_self_exec_cmdline
 normal/proc_thread_accounting


### PR DESCRIPTION
## Summary
- Handle Linux-style `ro`, `rw`, `rootfstype`, and `rootflags` kernel command line options for root filesystem mounting.
- Apply parsed root mount flags during root filesystem migration without leaking root-only options into init argv/env.
- Plumb ext4 root mount options and add dunitest coverage for the effective root mount mode.
- Set local QEMU launch defaults to request a writable root filesystem explicitly.

## Testing
- `make -j$(nproc) kernel`
- `make -C user/apps/tests/dunitest build-suites -j$(nproc)`
- `make test-dunit`

Depends on #1954.
Related to #1946.