### PR TITLE
kernel: consume Linux-compatible boot parameters

### DIFF
--- a/kernel/crates/kcmdline_macros/src/lib.rs
+++ b/kernel/crates/kcmdline_macros/src/lib.rs
@@ -12,6 +12,18 @@
 /// - `$inv`: 是否反转
 #[macro_export]
 macro_rules! kernel_cmdline_param_arg {
+    ($varname:ident, $name:literal, $default_bool:expr, $inv:expr) => {
+        #[::linkme::distributed_slice(crate::init::cmdline::KCMDLINE_PARAM_ARG)]
+        static $varname: crate::init::cmdline::KernelCmdlineParameter =
+            crate::init::cmdline::KernelCmdlineParamBuilder::new(
+                $name,
+                crate::init::cmdline::KCmdlineParamType::Arg,
+            )
+            .default_bool($default_bool)
+            .inv($inv)
+            .build()
+            .unwrap();
+    };
     ($varname:ident, $name:ident, $default_bool:expr, $inv:expr) => {
         #[::linkme::distributed_slice(crate::init::cmdline::KCMDLINE_PARAM_ARG)]
         static $varname: crate::init::cmdline::KernelCmdlineParameter =
@@ -34,6 +46,17 @@ macro_rules! kernel_cmdline_param_arg {
 /// - `$default_str`: 默认值
 #[macro_export]
 macro_rules! kernel_cmdline_param_kv {
+    ($varname:ident, $name:literal, $default_str:expr) => {
+        #[::linkme::distributed_slice(crate::init::cmdline::KCMDLINE_PARAM_KV)]
+        static $varname: crate::init::cmdline::KernelCmdlineParameter =
+            crate::init::cmdline::KernelCmdlineParamBuilder::new(
+                $name,
+                crate::init::cmdline::KCmdlineParamType::KV,
+            )
+            .default_str($default_str)
+            .build()
+            .unwrap();
+    };
     ($varname:ident, $name:ident, $default_str:expr) => {
         #[::linkme::distributed_slice(crate::init::cmdline::KCMDLINE_PARAM_KV)]
         static $varname: crate::init::cmdline::KernelCmdlineParameter =
@@ -55,11 +78,37 @@ macro_rules! kernel_cmdline_param_kv {
 /// - `$default_str`: 默认值
 #[macro_export]
 macro_rules! kernel_cmdline_param_early_kv {
+    ($varname:ident, $name:literal, $default_str:expr) => {
+        #[::linkme::distributed_slice(crate::init::cmdline::KCMDLINE_PARAM_EARLY_KV)]
+        static $varname: crate::init::cmdline::KernelCmdlineParameter = {
+            static ___KV: crate::init::cmdline::KernelCmdlineEarlyKV = {
+                const {
+                    assert!(
+                        $default_str.len()
+                            < crate::init::cmdline::KernelCmdlineEarlyKV::VALUE_MAX_LEN
+                    )
+                };
+                crate::init::cmdline::KernelCmdlineParamBuilder::new(
+                    $name,
+                    crate::init::cmdline::KCmdlineParamType::EarlyKV,
+                )
+                .default_str($default_str)
+                .build_early_kv()
+                .unwrap()
+            };
+            crate::init::cmdline::KernelCmdlineParameter::EarlyKV(&___KV)
+        };
+    };
     ($varname:ident, $name:ident, $default_str:expr) => {
         #[::linkme::distributed_slice(crate::init::cmdline::KCMDLINE_PARAM_EARLY_KV)]
         static $varname: crate::init::cmdline::KernelCmdlineParameter = {
             static ___KV: crate::init::cmdline::KernelCmdlineEarlyKV = {
-                const { assert!($default_str.len() < KernelCmdlineEarlyKV::VALUE_MAX_LEN) };
+                const {
+                    assert!(
+                        $default_str.len()
+                            < crate::init::cmdline::KernelCmdlineEarlyKV::VALUE_MAX_LEN
+                    )
+                };
                 crate::init::cmdline::KernelCmdlineParamBuilder::new(
                     stringify!($name),
                     crate::init::cmdline::KCmdlineParamType::EarlyKV,

--- a/kernel/src/debug/klog/loglevel.rs
+++ b/kernel/src/debug/klog/loglevel.rs
@@ -7,7 +7,12 @@ use core::sync::atomic::{AtomicU8, Ordering};
 
 use system_error::SystemError;
 
-use crate::init::cmdline::{KernelCmdlineKV, KernelCmdlineParameter, KCMDLINE_PARAM_KV};
+use crate::init::{
+    boot_params,
+    cmdline::{
+        kenrel_cmdline_param_manager, KernelCmdlineKV, KernelCmdlineParameter, KCMDLINE_PARAM_KV,
+    },
+};
 
 /// 全局内核日志级别配置
 ///
@@ -17,6 +22,8 @@ use crate::init::cmdline::{KernelCmdlineKV, KernelCmdlineParameter, KCMDLINE_PAR
 /// - minimum_console_loglevel: 最小控制台级别
 /// - default_console_loglevel: 默认控制台级别
 pub static KERNEL_LOG_LEVEL: KernelLogLevel = KernelLogLevel::new();
+
+const QUIET_CONSOLE_LOGLEVEL: u8 = 4;
 
 /// 日志级别
 #[derive(Default, Clone, PartialEq, Debug)]
@@ -173,16 +180,41 @@ static LOGLEVEL_PARAM: KernelCmdlineParameter = KernelCmdlineParameter::KV(Kerne
     default: "7", // 默认DEBUG级别
 });
 
+kernel_cmdline_param_arg!(QUIET_PARAM, quiet, false, false);
+
 /// 处理loglevel参数
 ///
 /// 在cmdline参数解析完成后调用，设置全局日志级别
 pub fn handle_loglevel_param() {
-    if let Some(param) = KCMDLINE_PARAM_KV.iter().find(|x| x.name() == "loglevel") {
-        if let Some(value_str) = param.value_str() {
+    let manager = kenrel_cmdline_param_manager();
+    let boot_params = boot_params().read();
+    let mut selected_level = None;
+
+    for argument in manager.split_args(boot_params.boot_cmdline_str()) {
+        if argument == "--" {
+            break;
+        }
+
+        let Some((node, option, value)) = manager.split_arg(argument) else {
+            continue;
+        };
+        if node.is_some() {
+            continue;
+        }
+
+        if option == "quiet" && value.is_none() {
+            selected_level = Some(QUIET_CONSOLE_LOGLEVEL);
+            continue;
+        }
+
+        if option == "loglevel" {
+            let Some(value_str) = value else {
+                log::warn!("loglevel: missing value, must be a number");
+                continue;
+            };
             if let Ok(level) = value_str.parse::<u8>() {
                 if level <= 7 {
-                    let _ = KERNEL_LOG_LEVEL.set_console_level(level);
-                    log::info!("loglevel: set console log level to {} via cmdline", level);
+                    selected_level = Some(level);
                 } else {
                     log::warn!("loglevel: invalid level {}, must be 0-7", level);
                 }
@@ -190,5 +222,10 @@ pub fn handle_loglevel_param() {
                 log::warn!("loglevel: invalid value '{}', must be a number", value_str);
             }
         }
+    }
+
+    if let Some(level) = selected_level {
+        let _ = KERNEL_LOG_LEVEL.set_console_level(level);
+        log::info!("loglevel: set console log level to {} via cmdline", level);
     }
 }

--- a/kernel/src/init/cmdline.rs
+++ b/kernel/src/init/cmdline.rs
@@ -410,6 +410,7 @@ impl KernelCmdlineManager {
         self.default_initialize();
         // 处理loglevel参数
         crate::debug::klog::loglevel::handle_loglevel_param();
+        crate::time::clocksource::handle_clocksource_cmdline_param();
         fence(Ordering::SeqCst);
     }
 
@@ -470,19 +471,54 @@ impl KernelCmdlineManager {
         };
 
         list.iter().find(|x| {
-            let name = x.name();
-            if let Some(node) = node {
-                // 加1是因为有一个点号
-                name.len() == (node.len() + option.len() + 1)
-                    && name.starts_with(node)
-                    && name[node.len() + 1..].starts_with(option)
-            } else {
-                name == option
-            }
+            Self::split_registered_param_name(x.name())
+                .map(|(param_node, param_option)| match (node, param_node) {
+                    (Some(node), Some(param_node)) => {
+                        Self::cmdline_param_name_eq(node, param_node)
+                            && Self::cmdline_param_name_eq(option, param_option)
+                    }
+                    (None, None) => Self::cmdline_param_name_eq(option, param_option),
+                    _ => false,
+                })
+                .unwrap_or(false)
         })
     }
 
-    fn split_arg<'a>(&self, arg: &'a str) -> Option<(Option<&'a str>, &'a str, Option<&'a str>)> {
+    fn split_registered_param_name(name: &str) -> Option<(Option<&str>, &str)> {
+        let mut iter = name.splitn(2, '.');
+        let v1 = iter.next().map(|v| v.trim());
+        let v2 = iter.next().map(|v| v.trim());
+        let v3 = iter.next().map(|v| v.trim());
+        let v = [v1, v2, v3];
+
+        let mut key_split_len = 0;
+        v.iter().for_each(|x| {
+            if x.is_some() {
+                key_split_len += 1
+            }
+        });
+
+        match key_split_len {
+            1 => Some((None, v[0].unwrap())),
+            2 => Some((Some(v[0].unwrap()), v[1].unwrap())),
+            _ => None,
+        }
+    }
+
+    fn cmdline_param_name_eq(a: &str, b: &str) -> bool {
+        if a.len() != b.len() {
+            return false;
+        }
+
+        a.bytes()
+            .zip(b.bytes())
+            .all(|(a, b)| a == b || matches!((a, b), (b'-', b'_') | (b'_', b'-')))
+    }
+
+    pub(crate) fn split_arg<'a>(
+        &self,
+        arg: &'a str,
+    ) -> Option<(Option<&'a str>, &'a str, Option<&'a str>)> {
         let mut iter = arg.splitn(2, '=');
         let key = iter.next().unwrap();
         let value = iter.next();
@@ -517,7 +553,7 @@ impl KernelCmdlineManager {
         Some((node, option, value))
     }
 
-    fn split_args<'a>(&self, cmdline: &'a str) -> impl Iterator<Item = &'a str> {
+    pub(crate) fn split_args<'a>(&self, cmdline: &'a str) -> impl Iterator<Item = &'a str> {
         // 是否在引号内
         let mut in_quote = false;
         cmdline.split(move |c: char| {

--- a/kernel/src/init/cmdline_compat.rs
+++ b/kernel/src/init/cmdline_compat.rs
@@ -1,0 +1,38 @@
+//! Linux-compatible boot parameters that DragonOS currently consumes as no-ops.
+//!
+//! These registrations prevent Linux-recognized kernel parameters from being
+//! forwarded to PID 1 as unknown init argv/env entries. They intentionally do
+//! not implement subsystem behavior that DragonOS does not have yet.
+
+// Linux/x86 uses this to skip an IO-APIC timer check. DragonOS currently has
+// no equivalent check path, so the parameter is consumed for boot compatibility.
+#[cfg(target_arch = "x86_64")]
+kernel_cmdline_param_arg!(NO_TIMER_CHECK_PARAM, no_timer_check, false, false);
+
+// Linux/x86 uses this to disable SMP alternatives replacement. DragonOS does
+// not implement that Linux alternatives path yet.
+#[cfg(target_arch = "x86_64")]
+kernel_cmdline_param_arg!(NOREPLACE_SMP_PARAM, "noreplace-smp", false, false);
+
+// DragonOS does not have panic timeout reboot handling yet.
+kernel_cmdline_param_kv!(PANIC_TIMEOUT_PARAM, panic, "");
+
+// Audit, md raid autodetect, early printk target selection, mitigation policy,
+// and high-resolution timer mode are not implemented as Linux-compatible
+// runtime controls yet. Register them so Linux-known boot parameters do not
+// leak into init env.
+kernel_cmdline_param_kv!(AUDIT_PARAM, audit, "");
+kernel_cmdline_param_kv!(RAID_PARAM, raid, "");
+kernel_cmdline_param_kv!(EARLY_PRINTK_PARAM, earlyprintk, "");
+kernel_cmdline_param_kv!(MITIGATIONS_PARAM, mitigations, "");
+kernel_cmdline_param_kv!(HIGHRES_PARAM, highres, "");
+
+// TSC policy options are Linux/x86-specific. DragonOS currently consumes them
+// for compatibility without changing TSC watchdog/reliability state.
+#[cfg(target_arch = "x86_64")]
+kernel_cmdline_param_kv!(TSC_PARAM, tsc, "");
+
+// Linux handles printk.devkmsg as a kernel printk setting. DragonOS has no
+// equivalent /dev/kmsg write policy control yet, but explicit registration
+// documents that this is a kernel-recognized dotted parameter.
+kernel_cmdline_param_kv!(PRINTK_DEVKMSG_PARAM, "printk.devkmsg", "");

--- a/kernel/src/init/mod.rs
+++ b/kernel/src/init/mod.rs
@@ -3,6 +3,7 @@ use crate::libs::rwlock::RwLock;
 use self::boot::BootParams;
 pub mod boot;
 pub mod cmdline;
+pub mod cmdline_compat;
 #[allow(clippy::module_inception)]
 pub mod init;
 pub mod initcall;

--- a/kernel/src/time/clocksource.rs
+++ b/kernel/src/time/clocksource.rs
@@ -34,6 +34,8 @@ use super::{
     NSEC_PER_SEC, NSEC_PER_USEC,
 };
 
+kernel_cmdline_param_kv!(CLOCKSOURCE_PARAM, clocksource, "");
+
 lazy_static! {
     /// linked list with the registered clocksources
     pub static ref CLOCKSOURCE_LIST: SpinLock<LinkedList<Arc<dyn Clocksource>>> =
@@ -47,6 +49,22 @@ lazy_static! {
     pub static ref OVERRIDE_NAME: SpinLock<String> = SpinLock::new(String::from(""));
 
 
+}
+
+pub fn handle_clocksource_cmdline_param() {
+    if !CLOCKSOURCE_PARAM.was_supplied() {
+        return;
+    }
+
+    let Some(name) = CLOCKSOURCE_PARAM.value_str() else {
+        return;
+    };
+    if name.is_empty() {
+        return;
+    }
+
+    *OVERRIDE_NAME.lock() = String::from(name);
+    debug!("clocksource: boot override set to {}", name);
 }
 
 static mut WATCHDOG_KTHREAD: Option<Arc<ProcessControlBlock>> = None;

--- a/user/apps/tests/dunitest/suites/normal/kernel_cmdline_compat.cc
+++ b/user/apps/tests/dunitest/suites/normal/kernel_cmdline_compat.cc
@@ -1,0 +1,161 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool read_file(const char* path, std::string* out) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    out->clear();
+    char buf[1024];
+    ssize_t n = 0;
+    while ((n = read(fd, buf, sizeof(buf))) > 0) {
+        out->append(buf, static_cast<size_t>(n));
+    }
+
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return n >= 0;
+}
+
+std::vector<std::string> split_whitespace(const std::string& input) {
+    std::istringstream stream(input);
+    std::vector<std::string> out;
+    std::string token;
+    while (stream >> token) {
+        out.push_back(token);
+    }
+    return out;
+}
+
+std::vector<std::string> kernel_param_tokens(const std::string& cmdline) {
+    std::vector<std::string> out;
+    for (const std::string& token : split_whitespace(cmdline)) {
+        if (token == "--") {
+            break;
+        }
+        out.push_back(token);
+    }
+    return out;
+}
+
+std::vector<std::string> split_nul(const std::string& input) {
+    std::vector<std::string> out;
+    size_t start = 0;
+    while (start < input.size()) {
+        const size_t end = input.find('\0', start);
+        const size_t len = (end == std::string::npos) ? input.size() - start : end - start;
+        if (len != 0) {
+            out.push_back(input.substr(start, len));
+        }
+        if (end == std::string::npos) {
+            break;
+        }
+        start = end + 1;
+    }
+    return out;
+}
+
+bool contains_token(const std::vector<std::string>& tokens, const std::string& token) {
+    for (const std::string& candidate : tokens) {
+        if (candidate == token) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool has_prefix_token(const std::vector<std::string>& tokens, const std::string& prefix) {
+    for (const std::string& candidate : tokens) {
+        if (candidate.rfind(prefix, 0) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST(KernelCmdlineCompat, LinuxKnownBareParametersDoNotReachInitArgv) {
+    std::string kernel_cmdline;
+    ASSERT_TRUE(read_file("/proc/cmdline", &kernel_cmdline))
+        << "read /proc/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    std::string init_cmdline;
+    ASSERT_TRUE(read_file("/proc/1/cmdline", &init_cmdline))
+        << "read /proc/1/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    const std::vector<std::string> kernel_tokens = kernel_param_tokens(kernel_cmdline);
+    const std::vector<std::string> init_argv = split_nul(init_cmdline);
+    const std::vector<std::string> linux_bare_params = {
+        "no_timer_check",
+        "no-timer-check",
+        "noreplace-smp",
+        "noreplace_smp",
+        "quiet",
+    };
+
+    bool saw_target_param = false;
+    for (const std::string& param : linux_bare_params) {
+        if (!contains_token(kernel_tokens, param)) {
+            continue;
+        }
+        saw_target_param = true;
+        EXPECT_FALSE(contains_token(init_argv, param))
+            << param << " leaked into /proc/1/cmdline";
+    }
+
+    if (!saw_target_param) {
+        GTEST_SKIP() << "kernel cmdline does not contain CubeSandbox Linux bare parameters";
+    }
+}
+
+TEST(KernelCmdlineCompat, AgentDottedParametersStayOutOfInitArgv) {
+    std::string kernel_cmdline;
+    ASSERT_TRUE(read_file("/proc/cmdline", &kernel_cmdline))
+        << "read /proc/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    std::string init_cmdline;
+    ASSERT_TRUE(read_file("/proc/1/cmdline", &init_cmdline))
+        << "read /proc/1/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    const std::vector<std::string> kernel_tokens = kernel_param_tokens(kernel_cmdline);
+    const std::vector<std::string> init_argv = split_nul(init_cmdline);
+    const std::vector<std::string> agent_prefixes = {
+        "agent.debug_console",
+        "agent.debug_console_vport=",
+        "agent.log=",
+        "agent.log_vport=",
+    };
+
+    bool saw_agent_param = false;
+    for (const std::string& prefix : agent_prefixes) {
+        if (!has_prefix_token(kernel_tokens, prefix)) {
+            continue;
+        }
+        saw_agent_param = true;
+        EXPECT_FALSE(has_prefix_token(init_argv, prefix))
+            << prefix << " leaked into /proc/1/cmdline";
+    }
+
+    if (!saw_agent_param) {
+        GTEST_SKIP() << "kernel cmdline does not contain CubeSandbox agent dotted parameters";
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -34,6 +34,7 @@ fuse/fuse_extended
 normal/test_procfs_link
 normal/proc_mount_exports
 normal/root_mount_cmdline
+normal/kernel_cmdline_compat
 normal/proc_pid_reuse_cache
 normal/proc_self_exec_cmdline
 normal/proc_thread_accounting


### PR DESCRIPTION
## Summary

Close: https://github.com/DragonOS-Community/DragonOS/issues/1958

This PR improves DragonOS kernel command-line compatibility for CubeSandbox/Linux-style boot arguments.

- Add a small compatibility layer for Linux boot parameters that DragonOS can safely consume or explicitly no-op.
- Support bare kernel command-line switches and mark selected Linux-compatible options as consumed before init arguments.
- Handle `quiet`, `loglevel=`, `highres=`, and `clocksource=` in the kernel subsystems that own those semantics.
- Add dunitest coverage for the kernel command-line compatibility behavior.

## Notes

Some Linux boot options are intentionally accepted as no-ops when DragonOS does not currently implement the underlying feature. Those cases are centralized and documented in code so they do not leak into userspace argv or break CubeSandbox boot flows.

## Verification

- `make kernel`
- dunitest coverage added: `kernel_cmdline_compat_test`
- Smoke-tested the rebuilt kernel in CubeSandbox; the boot now progresses through kernel startup, virtio device activation, guest agent startup, and `/etc/rc.local`, with the remaining failure occurring later at sandbox ready/event timeout rather than early command-line parsing.