### PR TITLE
fix(vsock): update peer credit after recv

### DIFF
--- a/kernel/src/driver/virtio/virtio_vsock.rs
+++ b/kernel/src/driver/virtio/virtio_vsock.rs
@@ -207,6 +207,20 @@ impl VsockTransport for VirtioVsockTransport {
                     {
                         Ok(read_len) => {
                             data.truncate(read_len);
+                            if read_len > 0 {
+                                if let Err(error) = manager
+                                    .0
+                                    .update_credit(Self::endpoint_to_vsock_addr(peer), local.port)
+                                {
+                                    log::warn!(
+                                        "vsock: credit update failed after receiving {} bytes for {:?}->{:?}: {:?}",
+                                        read_len,
+                                        peer,
+                                        local,
+                                        map_vsock_error(error)
+                                    );
+                                }
+                            }
                             events.push(VsockTransportEvent {
                                 local,
                                 peer,


### PR DESCRIPTION
## Summary

- Send a virtio-vsock credit update after data is drained from the virtio-drivers connection buffer into DragonOS receive handling.
- Preserve already received data even if the credit update itself fails, logging a warning for diagnosis.

## Root Cause

CubeSandbox `CreateContainer` ttRPC payloads can exceed the per-connection staging buffer in `virtio-drivers`. DragonOS moved bytes out of that staging buffer but did not notify the peer via `CREDIT_UPDATE`, so the host stopped sending once the advertised buffer was exhausted. In the observed CubeSandbox path, the request stalled at `468 + 468 + 88 = 1024` bytes.

Linux virtio-vsock updates peer credit after stream dequeue, so this aligns DragonOS with the expected credit accounting behavior.

## Test

- `make kernel`