### PR TITLE
【TBD】fix(cap): 修复capability 语义使得符合linux

### DIFF
--- a/kernel/src/init/cmdline.rs
+++ b/kernel/src/init/cmdline.rs
@@ -326,9 +326,6 @@ impl KernelCmdlineManager {
         let mut kernel_cmdline_end = false;
         for argument in self.split_args(boot_params.boot_cmdline_str()) {
             if kernel_cmdline_end {
-                if inner.init_path.is_none() {
-                    panic!("cmdline: init proc path is not set while init proc args are set");
-                }
                 if !argument.is_empty() {
                     inner.init_args.push(CString::new(argument).unwrap());
                 }

--- a/kernel/src/process/cred.rs
+++ b/kernel/src/process/cred.rs
@@ -110,12 +110,9 @@ pub struct Cred {
 
 impl Cred {
     fn init() -> Arc<Self> {
-        // 默认 init 进程能力集：
-        // - CAP_FSETID 会影响写/截断时是否清除 suid/sgid 位（Linux: CAP_FSETID 可阻止清理）。
-        //   gVisor syscall 测试假设该能力不启用，否则会观察到 setuid/setgid 位被保留。
-        // - cap_ambient 默认应为空（Linux init 的 ambient 也是空）。
-        let mut init_caps = CAPFlags::CAP_FULL_SET;
-        init_caps.remove(CAPFlags::CAP_FSETID);
+        // 默认 init 进程能力集对齐 Linux init_cred：
+        // permitted/effective/bset 为 full set，ambient 为空。
+        let init_caps = CAPFlags::CAP_FULL_SET;
         Arc::new_cyclic(|weak_self| Self {
             self_ref: weak_self.clone(),
             uid: GLOBAL_ROOT_UID,

--- a/kernel/src/process/syscall/sys_cap_get_set.rs
+++ b/kernel/src/process/syscall/sys_cap_get_set.rs
@@ -105,11 +105,9 @@ impl Syscall for SysCapset {
 
         // 获取旧凭据
         let old = pcb.cred();
-        let p_e_old = old.cap_effective;
         let p_p_old = old.cap_permitted.bits();
         let p_i_old = old.cap_inheritable.bits();
         let bset = old.cap_bset.bits();
-        let _ambient_old = old.cap_ambient.bits();
 
         // 规则 1：pE_new ⊆ pP_new
         if (p_e_new & !p_p_new) != 0 {
@@ -121,22 +119,13 @@ impl Syscall for SysCapset {
             return Err(SystemError::EPERM);
         }
 
-        // 规则 3：pI_new 限幅（对齐 Linux：受 CAP_SETPCAP 与 bset 约束）
-        // - 拥有 CAP_SETPCAP：pI_new ⊆ (pI_old ∪ pP_old) ∩ bset
-        // - 不拥有：pI_new ⊆ (pI_old ∪ pP_old) 且 pI_new ⊆ (pI_old ∪ bset)
-        // 使用公开常量 CAP_SETPCAP_BIT 判定是否拥有 CAP_SETPCAP
-        let has_setpcap = p_e_old.contains(CAPFlags::CAP_SETPCAP);
-        if has_setpcap {
-            let inh_cap_allow = (p_i_old | p_p_old) & bset;
-            if (p_i_new & !inh_cap_allow) != 0 {
-                return Err(SystemError::EPERM);
-            }
-        } else {
-            let inh_cap_allow_1 = p_i_old | p_p_old;
-            let inh_cap_allow_2 = p_i_old | bset;
-            if (p_i_new & !inh_cap_allow_1) != 0 || (p_i_new & !inh_cap_allow_2) != 0 {
-                return Err(SystemError::EPERM);
-            }
+        // 规则 3：pI_new 限幅（对齐 Linux 6.6 security/commoncap.c cap_capset）
+        let inh_capped = !old.has_capability(CAPFlags::CAP_SETPCAP);
+        if inh_capped && (p_i_new & !(p_i_old | p_p_old)) != 0 {
+            return Err(SystemError::EPERM);
+        }
+        if (p_i_new & !(p_i_old | bset)) != 0 {
+            return Err(SystemError::EPERM);
         }
 
         // 构造新 cred（克隆老 cred，更新能力集）
@@ -144,7 +133,9 @@ impl Syscall for SysCapset {
         new_cred.cap_effective = CAPFlags::from_bits_truncate(p_e_new);
         new_cred.cap_permitted = CAPFlags::from_bits_truncate(p_p_new);
         new_cred.cap_inheritable = CAPFlags::from_bits_truncate(p_i_new);
-        // ambient 能力不由 capset 修改，保持不变
+        // ambient：与 Linux 一致，裁剪为 permitted ∩ inheritable 的子集
+        new_cred.cap_ambient &= CAPFlags::from_bits_truncate(p_p_new);
+        new_cred.cap_ambient &= CAPFlags::from_bits_truncate(p_i_new);
 
         // 原子替换 cred（需要 PCB 暴露 set_cred）
         pcb.set_cred(Cred::new_arc(new_cred))?;


### PR DESCRIPTION
本分支补充 Kata/OCI 启动所需的挂载类型和 capability 兼容性：

  - 兼容常见挂载类型：
    - `mqueue` 暂以 tmpfs 提供可挂载实现
  - 调整 init 默认 capability，对齐 Linux init cred：`permitted/effective/bset` 使用完整能力
  集，`ambient` 为空。
  - 修正 `capset` 的 capability 校验与 `ambient` 裁剪逻辑，对齐 Linux 6.6 `cap_capset()` 行
  为。