### PR TITLE
fix(signal): preserve Linux siginfo and thread target semantics

### DIFF
--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -710,11 +710,13 @@ unsafe fn do_signal(frame: &mut TrapFrame, got_signal: &mut bool) {
          * case, the signal cannot be dropped.
          */
         // todo: https://code.dragonos.org.cn/xref/linux-6.6.21/include/linux/signal.h?fi=sig_kernel_only#444
-        if ProcessManager::current_pcb()
-            .sighand()
-            .flags_contains(SignalFlags::UNKILLABLE)
+        let is_customized_action = sigaction
+            .as_ref()
+            .is_some_and(|action| action.action().is_customized());
+        let drop_for_unkillable = pcb.sighand().flags_contains(SignalFlags::UNKILLABLE)
             && !sig_number.kernel_only()
-        {
+            && !is_customized_action;
+        if drop_for_unkillable {
             continue;
         }
 

--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -11,7 +11,10 @@ use crate::{
         CurrentIrqArch, MMArch,
     },
     exception::{extable::ExceptionTableManager, InterruptArch},
-    ipc::signal_types::{SigCode, SigInfo, SigType},
+    ipc::{
+        signal::force_sig_fault_to_current,
+        signal_types::{BUS_ADRERR, SEGV_ACCERR, SEGV_MAPERR},
+    },
     mm::{
         fault::{FaultFlags, PageFaultHandler, PageFaultMessage},
         ucontext::{AddressSpace, LockedVMA},
@@ -276,19 +279,21 @@ impl X86_64MMArch {
             flags |= FaultFlags::FAULT_FLAG_INSTRUCTION;
         }
 
-        let send_segv = || {
-            let pid = ProcessManager::current_pid();
-            let uid = ProcessManager::current_pcb().cred().uid.data() as u32;
-            let mut info = SigInfo::new(
-                Signal::SIGSEGV,
-                0,
-                SigCode::User,
-                SigType::Kill { pid, uid },
-            );
-            Signal::SIGSEGV
-                .send_signal_info(Some(&mut info), pid)
-                .expect("failed to send SIGSEGV to process");
+        let send_fault_signal = |sig: Signal, code: i32, addr: VirtAddr| {
+            if let Err(e) = force_sig_fault_to_current(sig, code, addr) {
+                error!(
+                    "failed to force {:?} fault to current process: pid={:?}, code={}, addr={:#x}, err={:?}",
+                    sig,
+                    ProcessManager::current_pid(),
+                    code,
+                    addr.data(),
+                    e
+                );
+            }
         };
+        let send_segv_maperr = || send_fault_signal(Signal::SIGSEGV, SEGV_MAPERR, address);
+        let send_segv_accerr = || send_fault_signal(Signal::SIGSEGV, SEGV_ACCERR, address);
+        let send_bus_adrerr = || send_fault_signal(Signal::SIGBUS, BUS_ADRERR, address);
 
         // 辅助函数：处理内核访问用户地址失败的情况
         let handle_kernel_access_failed = |r: &mut TrapFrame| {
@@ -330,7 +335,7 @@ impl X86_64MMArch {
                         return; // 已通过异常表修复
                     }
 
-                    send_segv();
+                    send_segv_maperr();
                     return;
                 }
             };
@@ -359,7 +364,7 @@ impl X86_64MMArch {
                             return; // 已通过异常表修复
                         }
 
-                        send_segv();
+                        send_segv_maperr();
                         return;
                     }
 
@@ -377,7 +382,7 @@ impl X86_64MMArch {
                             return; // 已通过异常表修复
                         }
 
-                        send_segv();
+                        send_segv_maperr();
                         return;
                     }
                     space_guard
@@ -405,7 +410,7 @@ impl X86_64MMArch {
                         return; // 已通过异常表修复
                     }
 
-                    send_segv();
+                    send_segv_maperr();
                     return;
                 }
             }
@@ -422,7 +427,7 @@ impl X86_64MMArch {
                 //     address.data(),
                 // );
 
-                send_segv();
+                send_segv_accerr();
                 return;
             }
             let mapper = &mut space_guard.user_mapper.utable;
@@ -468,24 +473,28 @@ impl X86_64MMArch {
                 );
             }
 
-            // 用户态 fault：发送对应信号
-            let sig = if fault.contains(VmFaultReason::VM_FAULT_SIGSEGV) {
-                Signal::SIGSEGV
+            if fault.contains(VmFaultReason::VM_FAULT_OOM) {
+                error!(
+                    "page fault OOM: pid={:?}, addr={:#x}, rip={:#x}, fault={:?}",
+                    ProcessManager::current_pid(),
+                    address.data(),
+                    regs.rip,
+                    fault
+                );
+                // TODO: OOM 处理 
+                return;
+            } else if fault.contains(VmFaultReason::VM_FAULT_SIGBUS)
+                || fault.contains(VmFaultReason::VM_FAULT_HWPOISON)
+                || fault.contains(VmFaultReason::VM_FAULT_HWPOISON_LARGE)
+            {
+                // Linux x86 maps these fault handler errors to SIGBUS/BUS_ADRERR
+                // except for hwpoison's MCE-specific si_code, which DragonOS does not model yet.
+                send_bus_adrerr();
+            } else if fault.contains(VmFaultReason::VM_FAULT_SIGSEGV) {
+                send_segv_maperr();
             } else {
-                // 包括 SIGBUS / OOM / HWPOISON 等：目前统一 SIGBUS（后续可按 Linux 进一步细分）
-                Signal::SIGBUS
-            };
-
-            let mut info = SigInfo::new(
-                sig,
-                0,
-                SigCode::User,
-                SigType::Kill {
-                    pid: ProcessManager::current_pid(),
-                    uid: ProcessManager::current_pcb().cred().uid.data() as u32,
-                },
-            );
-            let _ = sig.send_signal_info(Some(&mut info), ProcessManager::current_pid());
+                panic!("unexpected fault error: {:?}", fault);
+            }
             return;
         }
 

--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -481,7 +481,7 @@ impl X86_64MMArch {
                     regs.rip,
                     fault
                 );
-                // TODO: OOM 处理 
+                // TODO: OOM 处理
                 return;
             } else if fault.contains(VmFaultReason::VM_FAULT_SIGBUS)
                 || fault.contains(VmFaultReason::VM_FAULT_HWPOISON)

--- a/kernel/src/ipc/sighand.rs
+++ b/kernel/src/ipc/sighand.rs
@@ -47,6 +47,8 @@ pub struct InnerSigHand {
     pub handlers: Vec<Sigaction>,
     /// 当前线程所属进程要处理的信号
     pub shared_pending: SigPending,
+    /// 进程级信号投递的轮转游标，对应 Linux `signal_struct::curr_target`。
+    pub curr_target: Option<Weak<ProcessControlBlock>>,
     pub flags: SignalFlags,
     /// 线程组退出码（仿照 Linux 的 signal_struct::group_exit_code）
     /// 仅当 flags 中包含 GROUP_EXIT 时才有效
@@ -256,6 +258,18 @@ impl SigHand {
         g.shared_pending.signal_mut().insert(sig.into());
     }
 
+    pub fn curr_target(&self) -> Option<Arc<ProcessControlBlock>> {
+        self.inner().curr_target.as_ref().and_then(Weak::upgrade)
+    }
+
+    pub fn set_curr_target(&self, task: &Arc<ProcessControlBlock>) {
+        self.inner_mut().curr_target = Some(Arc::downgrade(task));
+    }
+
+    pub fn clear_curr_target(&self) {
+        self.inner_mut().curr_target = None;
+    }
+
     // ===== Signal flags helpers =====
     pub fn flags(&self) -> SignalFlags {
         self.inner().flags
@@ -410,6 +424,7 @@ impl Default for InnerSigHand {
             handlers: default_sighandlers(),
             pids: core::array::from_fn(|_| None),
             shared_pending: SigPending::default(),
+            curr_target: None,
             flags: SignalFlags::empty(),
             group_exit_code: 0,
             group_exec_task: None,

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -96,6 +96,55 @@ pub fn force_kernel_signal_to_current(sig: Signal) -> Result<(), SystemError> {
     ret.map(|_| ())
 }
 
+/// Force a synchronous fault signal to the current thread.
+///
+/// This mirrors Linux `force_sig_fault(sig, code, addr)`: the signal targets
+/// `current` directly and carries `si_code` plus `si_addr` for SA_SIGINFO.
+pub fn force_sig_fault_to_current(
+    sig: Signal,
+    code: i32,
+    addr: VirtAddr,
+) -> Result<(), SystemError> {
+    let pcb = ProcessManager::current_pcb();
+
+    if let Some(mut action) = pcb.sighand().handler(sig) {
+        let blocked = pcb
+            .sig_info_irqsave()
+            .sig_blocked()
+            .contains(sig.into_sigset());
+        if blocked || action.is_ignore() {
+            action.set_action(SigactionType::SaHandler(SaHandlerType::Default));
+            pcb.sighand().set_handler(sig, action);
+        }
+
+        if action.is_default() {
+            pcb.sighand().flags_remove(SignalFlags::UNKILLABLE);
+        }
+    }
+
+    {
+        let mut siginfo = pcb.sig_info_mut();
+        siginfo.sig_block_mut().remove(sig.into_sigset());
+        siginfo.saved_sigmask_mut().remove(sig.into_sigset());
+    }
+    pcb.recalc_sigpending();
+
+    let mut info = SigInfo::new(
+        sig,
+        0,
+        SigCode::Raw(code),
+        SigType::Fault {
+            addr: addr.data() as u64,
+            addr_lsb: 0,
+        },
+    );
+
+    compiler_fence(Ordering::SeqCst);
+    let ret = sig.send_signal_info_to_pcb(Some(&mut info), pcb, PidType::PID);
+    compiler_fence(Ordering::SeqCst);
+    ret.map(|_| ())
+}
+
 /// Force a kernel-originated signal to the current thread with its default
 /// disposition, even if userspace installed a handler.
 pub fn force_kernel_default_signal_to_current(sig: Signal) -> Result<(), SystemError> {
@@ -362,14 +411,6 @@ impl Signal {
     #[allow(clippy::if_same_then_else)]
     fn complete_signal(&self, pcb: Arc<ProcessControlBlock>, pt: PidType) {
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
-        // ===== 寻找需要wakeup的目标进程 =====
-        // 备注：由于当前没有进程组的概念，每个进程只有1个对应的线程，因此不需要通知进程组内的每个进程。
-        //      todo: 当引入进程组的概念后，需要完善这里，使得它能寻找一个目标进程来唤醒，接着执行信号处理的操作。
-
-        // let _signal = pcb.sig_struct();
-
-        let target_pcb: Option<Arc<ProcessControlBlock>>;
-
         // 根据信号类型选择添加到线程级 pending 还是进程级 shared_pending
         let is_thread_target = matches!(pt, PidType::PID);
         if is_thread_target {
@@ -386,35 +427,65 @@ impl Signal {
             // 不会入队 siginfo，但仍需要让共享 pending 位图反映该信号已到达。
             pcb.sighand().shared_pending_signal_insert(*self);
         }
-        // 根据实际 pending/blocked 关系更新 HAS_PENDING_SIGNAL，避免长时间误置位
-        pcb.recalc_sigpending();
 
         // 若目标进程存在 signalfd 监听该信号，需要唤醒其等待者/epoll。
         crate::ipc::signalfd::notify_signalfd_for_pcb(&pcb, *self);
-        // 判断目标进程是否应该被唤醒以立即处理该信号
-        let wants_signal = self.wants_signal(pcb.clone());
-        if wants_signal {
-            target_pcb = Some(pcb.clone());
-        } else if pt == PidType::PID {
-            /*
-             * 单线程场景且不需要唤醒：信号已入队，等待合适时机被取走
-             */
-            return;
+
+        let target_pcb = if is_thread_target {
+            if self.wants_signal(pcb.clone()) {
+                Some(pcb.clone())
+            } else {
+                None
+            }
         } else {
-            /*
-             * Otherwise try to find a suitable thread.
-             * 由于目前每个进程只有1个线程，因此当前情况可以返回。信号队列的dequeue操作不需要考虑同步阻塞的问题。
-             */
+            self.select_group_signal_target(pcb.clone())
+        };
+
+        let Some(target_pcb) = target_pcb else {
+            if is_thread_target {
+                pcb.recalc_sigpending();
+            }
             return;
+        };
+
+        target_pcb.recalc_sigpending();
+        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        signal_wake_up(target_pcb, *self == Signal::SIGKILL);
+    }
+
+    fn select_group_signal_target(
+        &self,
+        suggested: Arc<ProcessControlBlock>,
+    ) -> Option<Arc<ProcessControlBlock>> {
+        if self.wants_signal(suggested.clone()) {
+            return Some(suggested);
         }
 
-        // TODO:引入进程组后，在这里挑选一个进程来唤醒，让它执行相应的操作。
-        compiler_fence(core::sync::atomic::Ordering::SeqCst);
-        // 统一按既有规则唤醒：STOP 信号需要把阻塞的系统调用唤醒到信号处理路径，
-        // 由目标进程在自身上下文中执行默认处理（sig_stop），从而原地进入 Stopped，避免返回到用户态。
-        if let Some(target_pcb) = target_pcb {
-            signal_wake_up(target_pcb.clone(), *self == Signal::SIGKILL);
+        let leader = ProcessManager::thread_group_leader_of(&suggested);
+        let tasks = ProcessManager::thread_group_tasks_snapshot(leader.clone());
+        if tasks.len() <= 1 {
+            return None;
         }
+
+        let start = suggested
+            .sighand()
+            .curr_target()
+            .unwrap_or_else(|| leader.clone());
+        let start_index = tasks
+            .iter()
+            .position(|task| Arc::ptr_eq(task, &start))
+            .unwrap_or(0);
+
+        for offset in 0..tasks.len() {
+            let idx = (start_index + offset) % tasks.len();
+            let task = tasks[idx].clone();
+            if self.wants_signal(task.clone()) {
+                suggested.sighand().set_curr_target(&task);
+                return Some(task);
+            }
+        }
+
+        None
     }
 
     /// 本函数用于检测指定的进程是否想要接收SIG这个信号。
@@ -423,6 +494,11 @@ impl Signal {
     /// 这么做是为了防止我们把信号发送给了一个正在或已经退出的进程，或者是不响应该信号的进程。
     #[inline]
     fn wants_signal(&self, pcb: Arc<ProcessControlBlock>) -> bool {
+        let blocked = *pcb.sig_info_irqsave().sig_blocked();
+        if blocked.contains((*self).into()) {
+            return false;
+        }
+
         // 若进程正在退出，则不能接收
         if pcb.flags().contains(ProcessFlags::EXITING) {
             return false;
@@ -436,33 +512,12 @@ impl Signal {
             return true;
         }
 
-        // 若线程正处于可中断阻塞，且当前在 set_user_sigmask 语义下（如 rt_sigtimedwait/pselect 等）
-        // 则无论该信号是否在常规 blocked 集内，都应唤醒，由具体系统调用在返回路径上判定。
         let state = pcb.sched_info().state();
-
-        // SIGCONT：即便被屏蔽或默认忽略，也应唤醒处于 Stopped 的任务，让其继续运行。
-        if *self == Signal::SIGCONT && state.is_stopped() {
-            return true;
-        }
-        let is_blocked_interruptable = state.is_blocked_interruptable();
-        let has_restore_sig_mask = pcb.flags().contains(ProcessFlags::RESTORE_SIG_MASK);
-
-        if is_blocked_interruptable && has_restore_sig_mask {
-            return true;
-        }
-
-        // 常规规则：被屏蔽则不唤醒；否则在可中断阻塞下唤醒
-        let blocked = *pcb.sig_info_irqsave().sig_blocked();
-        let is_blocked = blocked.contains((*self).into());
-
-        if is_blocked {
+        if state.is_stopped() {
             return false;
         }
 
-        // wants_signal() 不检查 TASK_UNINTERRUPTIBLE / TASK_KILLABLE 状态：
-        // 只要信号未被屏蔽且进程未 stopped/traced，就应该接收信号。
-        // 唤醒与否由 signal_wake_up() / __schedule() 中的 signal_pending_state() 决定。
-        return true;
+        ProcessManager::is_current(&pcb) || !pcb.has_pending_signal_fast()
     }
 
     /// @brief 判断signal的处理是否可能使得整个进程组退出
@@ -547,29 +602,7 @@ impl Signal {
     fn prepare_sianal(&self, pcb: Arc<ProcessControlBlock>, _force: bool) -> bool {
         // 统一从线程组组长的 ThreadInfo 中获取完整线程列表。
         // 注意：当前 sighand 共享在 CLONE_THREAD 线程组内，因此标志位操作仍然只需要对共享 sighand 做一次。
-        let thread_group_leader = {
-            let ti = pcb.threads_read_irqsave();
-            ti.group_leader().unwrap_or_else(|| pcb.clone())
-        };
-
-        let for_each_thread_in_group = |f: &mut dyn FnMut(&Arc<ProcessControlBlock>)| {
-            // 先处理组长
-            f(&thread_group_leader);
-            // 再处理其他线程
-            let group_tasks = {
-                let ti = thread_group_leader.threads_read_irqsave();
-                ti.group_tasks_clone()
-            };
-            for weak in group_tasks {
-                if let Some(t) = weak.upgrade() {
-                    // 可能包含组长或重复；跳过重复即可
-                    if Arc::ptr_eq(&t, &thread_group_leader) {
-                        continue;
-                    }
-                    f(&t);
-                }
-            }
-        };
+        let thread_group_leader = ProcessManager::thread_group_leader_of(&pcb);
 
         let flush: SigSet;
         if !(self.into_sigset() & SIG_KERNEL_STOP_MASK).is_empty() {
@@ -578,8 +611,9 @@ impl Signal {
             thread_group_leader
                 .sighand()
                 .shared_pending_flush_by_mask(&flush);
-            for_each_thread_in_group(&mut |t| {
+            ProcessManager::for_each_thread_in_group(thread_group_leader.clone(), |t| {
                 t.sig_info_mut().sig_pending_mut().flush_by_mask(&flush);
+                true
             });
             // 异步作业控制停止：立即将目标进程置为 Stopped，并上报/唤醒父进程等待
             // 这样即便目标进程尚未返回用户态执行默认处理，也能及时观测到 WSTOPPED 事件
@@ -591,8 +625,9 @@ impl Signal {
                 .flags_insert(SignalFlags::STOP_STOPPED);
 
             // 线程组 stop：对组内所有线程置为 Stopped，保证 SIGSTOP 对整个线程组生效。
-            for_each_thread_in_group(&mut |t| {
-                let _ = ProcessManager::stop_task(t);
+            ProcessManager::for_each_thread_in_group(thread_group_leader.clone(), |t| {
+                let _ = ProcessManager::stop_task(&t);
+                true
             });
 
             if let Some(parent) = pcb.parent_pcb() {
@@ -601,8 +636,9 @@ impl Signal {
             }
             // 唤醒等待在该子进程/线程上的等待者
             thread_group_leader.wake_all_waiters();
-            for_each_thread_in_group(&mut |t| {
+            ProcessManager::for_each_thread_in_group(thread_group_leader.clone(), |t| {
                 t.wake_all_waiters();
+                true
             });
 
             // SIGSTOP 是 kernel-only stop 信号：其效果是把线程组置为 stopped 并通知父进程，
@@ -625,8 +661,9 @@ impl Signal {
             thread_group_leader
                 .sighand()
                 .shared_pending_flush_by_mask(&flush);
-            for_each_thread_in_group(&mut |t| {
+            ProcessManager::for_each_thread_in_group(thread_group_leader.clone(), |t| {
                 t.sig_info_mut().sig_pending_mut().flush_by_mask(&flush);
+                true
             });
 
             // 仅当确实处于 job-control stopped 时，才报告 continued 事件并通知父进程
@@ -639,8 +676,9 @@ impl Signal {
 
             if was_stopped {
                 // 线程组 continue：唤醒组内所有线程（由各线程在内核路径继续执行/重新阻塞）。
-                for_each_thread_in_group(&mut |t| {
-                    let _ = ProcessManager::wakeup_stop(t);
+                ProcessManager::for_each_thread_in_group(thread_group_leader.clone(), |t| {
+                    let _ = ProcessManager::wakeup_stop(&t);
+                    true
                 });
                 // 标记继续事件，供 waitid(WCONTINUED) 可见
                 thread_group_leader
@@ -662,8 +700,9 @@ impl Signal {
                 }
                 // 唤醒等待在该子进程上的等待者
                 thread_group_leader.wake_all_waiters();
-                for_each_thread_in_group(&mut |t| {
+                ProcessManager::for_each_thread_in_group(thread_group_leader.clone(), |t| {
                     t.wake_all_waiters();
+                    true
                 });
             }
             // 如果未处于 stopped，则不生成 CLD_CONTINUED/不通知父进程。
@@ -872,44 +911,31 @@ fn retarget_shared_pending(pcb: Arc<ProcessControlBlock>, which: SigSet) {
     // Linux 语义：当线程的 blocked 集发生变化（尤其是“新增屏蔽”）时，
     // 需要尝试把 shared_pending 中受影响的信号“重定向”给同一线程组内
     // 其他未屏蔽该信号的线程去处理。
-    let retarget = pcb.sighand().shared_pending_signal().intersection(which);
+    let mut retarget = pcb.sighand().shared_pending_signal().intersection(which);
     if retarget.is_empty() {
         return;
     }
 
-    // 对于线程组中的每一个线程都要执行的函数
-    let thread_handling_function = |pcb: Arc<ProcessControlBlock>, retarget: &SigSet| {
-        if retarget.is_empty() {
-            return;
-        }
-
-        if pcb.flags().contains(ProcessFlags::EXITING) {
-            return;
+    ProcessManager::for_each_thread_in_group(pcb, |task| {
+        if task.flags().contains(ProcessFlags::EXITING) {
+            return true;
         }
 
         // 若该线程把 retarget 中的信号全部屏蔽，则它无法处理这些 shared_pending 信号
-        let blocked = *pcb.sig_info_irqsave().sig_blocked();
+        let blocked = *task.sig_info_irqsave().sig_blocked();
         if retarget.difference(blocked).is_empty() {
-            return;
+            return true;
         }
 
-        if !pcb.has_pending_signal() {
-            signal_wake_up(pcb.clone(), false);
-        }
-        // 之前的对retarget的判断移动到最前面，因为对于当前线程的线程的处理已经结束，对于后面的线程在一开始判断retarget为空即可结束处理
+        // 当前线程能处理的信号不需要再重定向给后续线程。
+        retarget = retarget.intersection(blocked);
 
-        // debug!("handle done");
-    };
-
-    // 暴力遍历每一个线程，找到相同的tgid
-    let tgid = pcb.task_tgid_vnr();
-    for &pid in pcb.children_read_irqsave().iter() {
-        if let Some(child) = ProcessManager::find_task_by_vpid(pid) {
-            if child.task_tgid_vnr() == tgid {
-                thread_handling_function(child, &retarget);
-            }
+        if !task.has_pending_signal_fast() {
+            signal_wake_up(task.clone(), false);
         }
-    }
+
+        !retarget.is_empty()
+    });
     // debug!("retarget_shared_pending done!");
 }
 

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -780,6 +780,12 @@ fn signal_wake_up(pcb: Arc<ProcessControlBlock>, fatal: bool) {
     }
 }
 
+fn recalc_sigpending_and_wake(pcb: Arc<ProcessControlBlock>) {
+    if pcb.recalc_sigpending_tsk() {
+        signal_wake_up(pcb, false);
+    }
+}
+
 fn has_pending_signals(sigset: &SigSet, blocked: &SigSet) -> bool {
     sigset.bits() & (!blocked.bits()) != 0
 }
@@ -886,10 +892,7 @@ fn __set_task_blocked(pcb: &Arc<ProcessControlBlock>, new_set: &SigSet) {
         newblocked.remove(*guard.sig_blocked());
         drop(guard);
 
-        // 从主线程开始去遍历
-        if let Some(group_leader) = pcb.threads_read_irqsave().group_leader() {
-            retarget_shared_pending(group_leader, newblocked);
-        }
+        retarget_shared_pending(pcb.clone(), newblocked);
     }
     *pcb.sig_info_mut().sig_block_mut() = *new_set;
     pcb.recalc_sigpending();
@@ -916,26 +919,40 @@ fn retarget_shared_pending(pcb: Arc<ProcessControlBlock>, which: SigSet) {
         return;
     }
 
-    ProcessManager::for_each_thread_in_group(pcb, |task| {
+    let tasks = ProcessManager::thread_group_tasks_snapshot(pcb.clone());
+    if tasks.len() <= 1 {
+        return;
+    }
+
+    let start_index = tasks
+        .iter()
+        .position(|task| Arc::ptr_eq(task, &pcb))
+        .unwrap_or(0);
+
+    for offset in 1..tasks.len() {
+        let idx = (start_index + offset) % tasks.len();
+        let task = tasks[idx].clone();
         if task.flags().contains(ProcessFlags::EXITING) {
-            return true;
+            continue;
         }
 
         // 若该线程把 retarget 中的信号全部屏蔽，则它无法处理这些 shared_pending 信号
         let blocked = *task.sig_info_irqsave().sig_blocked();
         if retarget.difference(blocked).is_empty() {
-            return true;
+            continue;
         }
 
         // 当前线程能处理的信号不需要再重定向给后续线程。
         retarget = retarget.intersection(blocked);
 
         if !task.has_pending_signal_fast() {
-            signal_wake_up(task.clone(), false);
+            recalc_sigpending_and_wake(task.clone());
         }
 
-        !retarget.is_empty()
-    });
+        if retarget.is_empty() {
+            break;
+        }
+    }
     // debug!("retarget_shared_pending done!");
 }
 

--- a/kernel/src/ipc/signal_types.rs
+++ b/kernel/src/ipc/signal_types.rs
@@ -19,36 +19,42 @@ use crate::{
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum SigCode {
     /// sent by kill, sigsend, raise
-    User = 0,
+    User,
     /// queued SIGIO/POLL_IN
-    PollIn = 1,
+    PollIn,
     /// queued SIGIO/POLL_OUT
-    PollOut = 2,
+    PollOut,
     /// queued SIGIO/POLL_MSG
-    PollMsg = 3,
+    PollMsg,
     /// queued SIGIO/POLL_ERR
-    PollErr = 4,
+    PollErr,
     /// queued SIGIO/POLL_PRI
-    PollPri = 5,
+    PollPri,
     /// queued SIGIO/POLL_HUP
-    PollHup = 6,
+    PollHup,
     /// sent by kernel from somewhere
-    Kernel = 0x80,
+    Kernel,
     /// SIGSYS sent by seccomp filter action SECCOMP_RET_TRAP.
     SysSeccomp,
     /// 通过sigqueue发送
-    Queue = -1,
+    Queue,
     /// 定时器过期时发送
-    Timer = -2,
+    Timer,
     /// 当实时消息队列的状态发生改变时发送
-    Mesgq = -3,
+    Mesgq,
     /// 当异步IO完成时发送
-    AsyncIO = -4,
+    AsyncIO,
     /// sent by queued SIGIO
-    SigIO = -5,
+    SigIO,
     /// sent by tgkill/tkill
-    Tkill = -6,
+    Tkill,
+    /// Linux 的正数 si_code 是按 signal 复用的，保留 raw 值避免错误归类。
+    Raw(i32),
 }
+
+pub const SEGV_MAPERR: i32 = 1;
+pub const SEGV_ACCERR: i32 = 2;
+pub const BUS_ADRERR: i32 = 2;
 
 impl SigCode {
     pub fn as_i32(self) -> i32 {
@@ -68,6 +74,7 @@ impl SigCode {
             Self::AsyncIO => -4,
             Self::SigIO => -5,
             Self::Tkill => -6,
+            Self::Raw(code) => code,
         }
     }
 
@@ -87,7 +94,7 @@ impl SigCode {
             -4 => Some(Self::AsyncIO),
             -5 => Some(Self::SigIO),
             -6 => Some(Self::Tkill),
-            _ => None,
+            _ => Some(Self::Raw(x)),
         }
     }
 }
@@ -613,6 +620,19 @@ impl SigInfo {
                     },
                 },
             },
+            SigType::Fault { addr, addr_lsb } => PosixSigInfo {
+                si_signo: self.sig_no,
+                si_errno: self.errno,
+                si_code: self.sig_code.as_i32(),
+                _sifields: PosixSiginfoFields {
+                    _sigfault: PosixSiginfoSigfault {
+                        si_addr: addr,
+                        si_addr_lsb: addr_lsb,
+                        si_band: 0,
+                        si_fd: 0,
+                    },
+                },
+            },
         }
     }
 
@@ -672,6 +692,11 @@ pub enum SigType {
         call_addr: u64,
         syscall: i32,
         arch: u32,
+    },
+    /// synchronous fault signal carrying siginfo_t::si_addr.
+    Fault {
+        addr: u64,
+        addr_lsb: u16,
     },
     // 后续完善下列中的具体字段
     // Timer,

--- a/kernel/src/ipc/signal_types.rs
+++ b/kernel/src/ipc/signal_types.rs
@@ -81,12 +81,6 @@ impl SigCode {
     pub fn try_from_i32(x: i32) -> Option<SigCode> {
         match x {
             0 => Some(Self::User),
-            1 => Some(Self::PollIn),
-            2 => Some(Self::PollOut),
-            3 => Some(Self::PollMsg),
-            4 => Some(Self::PollErr),
-            5 => Some(Self::PollPri),
-            6 => Some(Self::PollHup),
             0x80 => Some(Self::Kernel),
             -1 => Some(Self::Queue),
             -2 => Some(Self::Timer),

--- a/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
+++ b/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
@@ -5,13 +5,146 @@ use core::mem::size_of;
 
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_RT_SIGQUEUEINFO;
-use crate::ipc::signal_types::{PosixSigInfo, SigCode, SigInfo, SigType};
+use crate::ipc::signal_types::{
+    PosixSigInfo, SigCode, SigInfo, SigType, SIG_SPECIFIC_SICODES_MASK,
+};
 use crate::ipc::syscall::sys_kill::check_signal_permission_pcb_with_sig;
 use crate::process::pid::PidType;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::UserBufferReader;
 use crate::{arch::ipc::signal::Signal, process::ProcessManager, process::RawPid};
 use system_error::SystemError;
+
+const NSIGPOLL: i32 = 6;
+const NSIGILL: i32 = 11;
+const NSIGFPE: i32 = 15;
+const NSIGSEGV: i32 = 10;
+const NSIGBUS: i32 = 5;
+const NSIGTRAP: i32 = 6;
+const NSIGSYS: i32 = 2;
+
+fn is_positive_sig_specific_code(si_code: i32) -> bool {
+    si_code > SigCode::User.as_i32() && si_code < SigCode::Kernel.as_i32()
+}
+
+fn is_fault_layout_signal(signal: Signal) -> bool {
+    matches!(
+        signal,
+        Signal::SIGILL | Signal::SIGFPE | Signal::SIGSEGV | Signal::SIGBUS | Signal::SIGTRAP
+    )
+}
+
+fn signal_specific_code_limit(signal: Signal) -> Option<i32> {
+    match signal {
+        Signal::SIGILL => Some(NSIGILL),
+        Signal::SIGFPE => Some(NSIGFPE),
+        Signal::SIGSEGV => Some(NSIGSEGV),
+        Signal::SIGBUS => Some(NSIGBUS),
+        Signal::SIGTRAP => Some(NSIGTRAP),
+        Signal::SIGSYS => Some(NSIGSYS),
+        Signal::SIGIO_OR_POLL => Some(NSIGPOLL),
+        _ => None,
+    }
+}
+
+fn signal_has_specific_si_codes(signal: Signal) -> bool {
+    SIG_SPECIFIC_SICODES_MASK.contains(Signal::into_sigset(signal))
+}
+
+fn raw_siginfo_pid(pid: i32) -> RawPid {
+    RawPid::new(pid as usize)
+}
+
+fn sig_type_from_user_siginfo(
+    signal: Signal,
+    code_enum: SigCode,
+    user_info: &PosixSigInfo,
+) -> SigType {
+    match code_enum {
+        SigCode::Timer => {
+            let timer = unsafe { user_info._sifields._timer };
+            SigType::PosixTimer {
+                timerid: timer.si_tid,
+                overrun: timer.si_overrun,
+                sigval: timer.si_sigval,
+            }
+        }
+        SigCode::SigIO => {
+            let sigpoll = unsafe { user_info._sifields._sigpoll };
+            SigType::SigPoll {
+                fd: sigpoll.si_fd,
+                band: sigpoll.si_band,
+            }
+        }
+        SigCode::Raw(code) if is_positive_sig_specific_code(code) => {
+            let specific_limit = signal_specific_code_limit(signal);
+            if is_fault_layout_signal(signal) && specific_limit.is_some_and(|limit| code <= limit) {
+                let fault = unsafe { user_info._sifields._sigfault };
+                SigType::Fault {
+                    addr: fault.si_addr,
+                    addr_lsb: fault.si_addr_lsb,
+                }
+            } else if signal == Signal::SIGSYS && specific_limit.is_some_and(|limit| code <= limit)
+            {
+                let sigsys = unsafe { user_info._sifields._sigsys };
+                SigType::SigSys {
+                    call_addr: sigsys._call_addr,
+                    syscall: sigsys._syscall,
+                    arch: sigsys._arch,
+                }
+            } else if code <= NSIGPOLL
+                && (signal == Signal::SIGIO_OR_POLL || !signal_has_specific_si_codes(signal))
+            {
+                let sigpoll = unsafe { user_info._sifields._sigpoll };
+                SigType::SigPoll {
+                    fd: sigpoll.si_fd,
+                    band: sigpoll.si_band,
+                }
+            } else {
+                let kill = unsafe { user_info._sifields._kill };
+                SigType::Kill {
+                    pid: raw_siginfo_pid(kill.si_pid),
+                    uid: kill.si_uid,
+                }
+            }
+        }
+        SigCode::Raw(code) if code < 0 => {
+            let rt = unsafe { user_info._sifields._rt };
+            SigType::Rt {
+                pid: raw_siginfo_pid(rt.si_pid),
+                uid: rt.si_uid,
+                sigval: rt.si_sigval,
+            }
+        }
+        SigCode::Queue | SigCode::Mesgq | SigCode::AsyncIO | SigCode::Tkill => {
+            let rt = unsafe { user_info._sifields._rt };
+            SigType::Rt {
+                pid: raw_siginfo_pid(rt.si_pid),
+                uid: rt.si_uid,
+                sigval: rt.si_sigval,
+            }
+        }
+        SigCode::PollIn
+        | SigCode::PollOut
+        | SigCode::PollMsg
+        | SigCode::PollErr
+        | SigCode::PollPri
+        | SigCode::PollHup => {
+            let sigpoll = unsafe { user_info._sifields._sigpoll };
+            SigType::SigPoll {
+                fd: sigpoll.si_fd,
+                band: sigpoll.si_band,
+            }
+        }
+        _ => {
+            let kill = unsafe { user_info._sifields._kill };
+            SigType::Kill {
+                pid: raw_siginfo_pid(kill.si_pid),
+                uid: kill.si_uid,
+            }
+        }
+    }
+}
 
 /// rt_sigqueueinfo 系统调用（最小兼容实现）
 ///
@@ -87,41 +220,8 @@ impl Syscall for SysRtSigqueueinfoHandle {
             return Err(SystemError::EPERM);
         }
 
-        // 解析 si_code（未知 code：尽量保持“来自用户态(负值)”的语义，不 panic）
-        let code_enum = SigCode::try_from_i32(si_code).unwrap_or({
-            if si_code < 0 {
-                SigCode::Queue
-            } else {
-                SigCode::User
-            }
-        });
-
-        let sender_uid = current_pcb.cred().uid.data() as u32;
-        let sender_pid = current_pid;
-
-        // 根据信号来源/布局构造内核 SigInfo
-        let sig_type = match code_enum {
-            SigCode::Queue => {
-                let sigval = unsafe { user_info._sifields._rt.si_sigval };
-                SigType::Rt {
-                    pid: sender_pid,
-                    uid: sender_uid,
-                    sigval,
-                }
-            }
-            SigCode::Timer => {
-                let timer = unsafe { user_info._sifields._timer };
-                SigType::PosixTimer {
-                    timerid: timer.si_tid,
-                    overrun: timer.si_overrun,
-                    sigval: timer.si_sigval,
-                }
-            }
-            _ => SigType::Kill {
-                pid: sender_pid,
-                uid: sender_uid,
-            },
-        };
+        let code_enum = SigCode::try_from_i32(si_code).unwrap_or(SigCode::Raw(si_code));
+        let sig_type = sig_type_from_user_siginfo(signal, code_enum, &user_info);
 
         let mut info = SigInfo::new(signal, user_info.si_errno, code_enum, sig_type);
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -203,6 +203,66 @@ impl SwitchResult {
 #[derive(Debug)]
 pub struct ProcessManager;
 impl ProcessManager {
+    pub fn is_current(pcb: &Arc<ProcessControlBlock>) -> bool {
+        Arc::ptr_eq(pcb, &Self::current_pcb())
+    }
+
+    pub fn thread_group_leader_of(pcb: &Arc<ProcessControlBlock>) -> Arc<ProcessControlBlock> {
+        pcb.threads_read_irqsave()
+            .group_leader()
+            .unwrap_or_else(|| pcb.clone())
+    }
+
+    /// 遍历 `pcb` 所在线程组中的线程。
+    ///
+    /// 遍历顺序为线程组组长优先，随后遍历组长维护的其他线程列表；
+    /// 回调返回 `false` 时提前停止遍历。
+    pub fn for_each_thread_in_group<F>(pcb: Arc<ProcessControlBlock>, mut func: F)
+    where
+        F: FnMut(Arc<ProcessControlBlock>) -> bool,
+    {
+        let thread_group_leader = Self::thread_group_leader_of(&pcb);
+        if !func(thread_group_leader.clone()) {
+            return;
+        }
+
+        let group_tasks = thread_group_leader
+            .threads_read_irqsave()
+            .group_tasks_clone();
+        for weak in group_tasks {
+            let Some(task) = weak.upgrade() else {
+                continue;
+            };
+            if Arc::ptr_eq(&task, &thread_group_leader) {
+                continue;
+            }
+            if !func(task) {
+                break;
+            }
+        }
+    }
+
+    pub fn thread_group_tasks_snapshot(
+        pcb: Arc<ProcessControlBlock>,
+    ) -> Vec<Arc<ProcessControlBlock>> {
+        let leader = Self::thread_group_leader_of(&pcb);
+        let mut tasks = Vec::new();
+        tasks.push(leader.clone());
+
+        let group_tasks = leader.threads_read_irqsave().group_tasks_clone();
+        for weak in group_tasks {
+            let Some(task) = weak.upgrade() else {
+                continue;
+            };
+            if tasks.iter().any(|existing| Arc::ptr_eq(existing, &task)) {
+                continue;
+            }
+            tasks.push(task);
+        }
+
+        tasks
+    }
+
     #[inline(never)]
     fn init() {
         static INIT_FLAG: AtomicBool = AtomicBool::new(false);

--- a/user/apps/tests/dunitest/suites/normal/signal_sigqueueinfo.cc
+++ b/user/apps/tests/dunitest/suites/normal/signal_sigqueueinfo.cc
@@ -1,0 +1,161 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef __NR_rt_sigqueueinfo
+#error "__NR_rt_sigqueueinfo is required"
+#endif
+
+#ifndef SEGV_MAPERR
+#define SEGV_MAPERR 1
+#endif
+
+#ifndef POLL_IN
+#define POLL_IN 1
+#endif
+
+#ifndef SI_QUEUE
+#define SI_QUEUE -1
+#endif
+
+namespace {
+
+class ScopedSignalBlock {
+public:
+    explicit ScopedSignalBlock(int sig) : sig_(sig), active_(false) {
+        sigset_t set;
+        sigemptyset(&set);
+        sigaddset(&set, sig_);
+        if (sigprocmask(SIG_BLOCK, &set, &oldset_) == 0) {
+            active_ = true;
+        }
+    }
+
+    ~ScopedSignalBlock() {
+        if (active_) {
+            sigprocmask(SIG_SETMASK, &oldset_, nullptr);
+        }
+    }
+
+    bool active() const {
+        return active_;
+    }
+
+private:
+    int sig_;
+    bool active_;
+    sigset_t oldset_ {};
+};
+
+void DrainPendingSignal(int sig) {
+    sigset_t waitset;
+    sigemptyset(&waitset);
+    sigaddset(&waitset, sig);
+
+    siginfo_t drained {};
+    timespec zero {};
+    while (sigtimedwait(&waitset, &drained, &zero) == sig) {
+    }
+}
+
+void SendQueuedInfoToSelf(int sig, const siginfo_t& info) {
+    errno = 0;
+    long ret = syscall(__NR_rt_sigqueueinfo, getpid(), sig, &info);
+    ASSERT_EQ(0, ret) << "rt_sigqueueinfo failed: errno=" << errno << " ("
+                      << strerror(errno) << ")";
+}
+
+siginfo_t WaitForSignalInfo(int sig) {
+    sigset_t waitset;
+    sigemptyset(&waitset);
+    sigaddset(&waitset, sig);
+
+    siginfo_t received {};
+    timespec timeout {};
+    timeout.tv_sec = 2;
+    int ret = sigtimedwait(&waitset, &received, &timeout);
+    EXPECT_EQ(sig, ret) << "sigtimedwait failed: errno=" << errno << " ("
+                        << strerror(errno) << ")";
+    return received;
+}
+
+}  // namespace
+
+TEST(SignalSigqueueinfo, SegvMaperrPreservesFaultAddress) {
+    ScopedSignalBlock block(SIGSEGV);
+    ASSERT_TRUE(block.active()) << "sigprocmask(SIG_BLOCK, SIGSEGV) failed";
+    DrainPendingSignal(SIGSEGV);
+
+    constexpr uintptr_t kFaultAddress = 0x12345000;
+    siginfo_t info {};
+    info.si_signo = SIGSEGV;
+    info.si_errno = 0;
+    info.si_code = SEGV_MAPERR;
+    info.si_addr = reinterpret_cast<void*>(kFaultAddress);
+
+    SendQueuedInfoToSelf(SIGSEGV, info);
+    siginfo_t received = WaitForSignalInfo(SIGSEGV);
+
+    EXPECT_EQ(SIGSEGV, received.si_signo);
+    EXPECT_EQ(SEGV_MAPERR, received.si_code);
+    EXPECT_EQ(reinterpret_cast<void*>(kFaultAddress), received.si_addr);
+}
+
+TEST(SignalSigqueueinfo, PositivePollCodePreservesPollFields) {
+    ScopedSignalBlock block(SIGUSR1);
+    ASSERT_TRUE(block.active()) << "sigprocmask(SIG_BLOCK, SIGUSR1) failed";
+    DrainPendingSignal(SIGUSR1);
+
+    constexpr long kBand = 0x41;
+    constexpr int kFd = 123;
+    siginfo_t info {};
+    info.si_signo = SIGUSR1;
+    info.si_errno = 0;
+    info.si_code = POLL_IN;
+    info.si_band = kBand;
+    info.si_fd = kFd;
+
+    SendQueuedInfoToSelf(SIGUSR1, info);
+    siginfo_t received = WaitForSignalInfo(SIGUSR1);
+
+    EXPECT_EQ(SIGUSR1, received.si_signo);
+    EXPECT_EQ(POLL_IN, received.si_code);
+    EXPECT_EQ(kBand, received.si_band);
+    EXPECT_EQ(kFd, received.si_fd);
+}
+
+TEST(SignalSigqueueinfo, SiQueuePreservesRtFields) {
+    ScopedSignalBlock block(SIGUSR2);
+    ASSERT_TRUE(block.active()) << "sigprocmask(SIG_BLOCK, SIGUSR2) failed";
+    DrainPendingSignal(SIGUSR2);
+
+    constexpr int kPid = 1234;
+    constexpr int kUid = 5678;
+    constexpr int kValue = 0x1357;
+    siginfo_t info {};
+    info.si_signo = SIGUSR2;
+    info.si_errno = 0;
+    info.si_code = SI_QUEUE;
+    info.si_pid = kPid;
+    info.si_uid = kUid;
+    info.si_value.sival_int = kValue;
+
+    SendQueuedInfoToSelf(SIGUSR2, info);
+    siginfo_t received = WaitForSignalInfo(SIGUSR2);
+
+    EXPECT_EQ(SIGUSR2, received.si_signo);
+    EXPECT_EQ(SI_QUEUE, received.si_code);
+    EXPECT_EQ(kPid, received.si_pid);
+    EXPECT_EQ(static_cast<uid_t>(kUid), received.si_uid);
+    EXPECT_EQ(kValue, received.si_value.sival_int);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -44,6 +44,7 @@ normal/signal_fpstate_sigreturn
 normal/general_protection_signal
 normal/ioperm_semantics
 normal/seccomp
+normal/signal_sigqueueinfo
 normal/process_signal_fork
 normal/sysfs_cgroup2_mount
 normal/devfs_ptmx_unlink


### PR DESCRIPTION
## Summary

- Preserve Linux-style `siginfo_t` data for synchronous faults and `rt_sigqueueinfo`:
  - add raw `si_code` preservation for signal-specific positive codes
  - add fault `siginfo` support carrying `si_addr`
  - map x86 page fault outcomes to `SIGSEGV`/`SIGBUS` with `SEGV_MAPERR`, `SEGV_ACCERR`, and `BUS_ADRERR`
  - preserve fault addresses, poll fields, and queued realtime fields when userspace supplies `siginfo_t`

- Align signal delivery target selection with Linux thread-group behavior:
  - add a `curr_target` cursor for process-directed signal delivery
  - select eligible thread-group targets with `wants_signal()` semantics closer to Linux
  - add thread-group traversal/snapshot helpers
  - retarget shared pending signals after signal mask changes and recalculate pending state before wakeup

- Keep customized signal handlers visible for unkillable tasks instead of dropping non-kernel-only signals when a handler is installed.

- Add dunitest coverage for `rt_sigqueueinfo` preserving:
  - `SIGSEGV + SEGV_MAPERR` fault address
  - positive poll-code `si_band`/`si_fd`
  - `SI_QUEUE` pid, uid, and sigval fields

## Validation

- `make fmt`
- `make kernel`
- `make run-nographic`
- DragonOS guest: `signal_sigqueueinfo_test` passed all 3 tests

## Follow-up

- OOM page-fault handling still needs a real OOM killer path. This PR leaves OOM as a logged follow-up instead of incorrectly converting it to a normal fault signal.