### PR TITLE
fix(fuse) support FUSE submounts and fix virtiofs mount semantics

### DIFF
--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -95,6 +95,13 @@ impl FileSystem for DevFS {
         PageFaultHandler::zero_fault(pfm)
     }
 
+    unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
+        if !is_zero_inode(pfm) {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        }
+        VmFaultReason::empty()
+    }
+
     unsafe fn map_pages(
         &self,
         pfm: &mut PageFaultMessage,

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -104,6 +104,10 @@ impl FileSystem for Ext4FileSystem {
         PageFaultHandler::filemap_fault(pfm)
     }
 
+    unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
+        PageFaultHandler::filemap_page_mkwrite(pfm)
+    }
+
     unsafe fn map_pages(
         &self,
         pfm: &mut PageFaultMessage,

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -579,6 +579,18 @@ impl IndexNode for LockedExt4Inode {
         Ok(())
     }
 
+    fn fallocate_file(
+        &self,
+        mode: i32,
+        offset: usize,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        drop(data);
+        vfs::vcore::resize_based_fallocate(self, mode, offset, len, lock_owner)
+    }
+
     fn truncate(&self, len: usize) -> Result<(), SystemError> {
         // 复用 resize 的实现
         self.resize(len)

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -2083,6 +2083,18 @@ impl IndexNode for LockedFATInode {
         }
     }
 
+    fn fallocate_file(
+        &self,
+        mode: i32,
+        offset: usize,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        drop(data);
+        crate::filesystem::vfs::vcore::resize_based_fallocate(self, mode, offset, len, lock_owner)
+    }
+
     fn truncate(&self, len: usize) -> Result<(), SystemError> {
         let guard: MutexGuard<FATInode> = self.0.lock();
         let old_size = guard.metadata.size as usize;

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -486,6 +486,10 @@ impl FileSystem for FATFileSystem {
         PageFaultHandler::filemap_fault(pfm)
     }
 
+    unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
+        PageFaultHandler::filemap_page_mkwrite(pfm)
+    }
+
     unsafe fn map_pages(
         &self,
         pfm: &mut PageFaultMessage,

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -733,6 +733,20 @@ impl FuseConn {
         self.wait_request_complete(opcode, pending)
     }
 
+    pub(crate) fn request_with_cred(
+        &self,
+        opcode: u32,
+        nodeid: u64,
+        payload: &[u8],
+        req_cred: FuseRequestCred,
+    ) -> Result<Vec<u8>, SystemError> {
+        if opcode != FUSE_INIT {
+            self.wait_initialized()?;
+        }
+        let pending = self.enqueue_request_with_cred(opcode, nodeid, payload, req_cred)?;
+        self.wait_request_complete(opcode, pending)
+    }
+
     pub fn request_nocreds_background(
         self: &Arc<Self>,
         opcode: u32,

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -28,7 +28,7 @@ use super::protocol::{
     FUSE_KERNEL_VERSION, FUSE_LOOKUP, FUSE_MAX_PAGES, FUSE_MIN_READ_BUFFER, FUSE_NOTIFY_DELETE,
     FUSE_NOTIFY_INVAL_ENTRY, FUSE_NOTIFY_INVAL_INODE, FUSE_NOTIFY_POLL, FUSE_NOTIFY_RETRIEVE,
     FUSE_NOTIFY_STORE, FUSE_NO_OPENDIR_SUPPORT, FUSE_NO_OPEN_SUPPORT, FUSE_PARALLEL_DIROPS,
-    FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO, FUSE_WRITEBACK_CACHE,
+    FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO, FUSE_SUBMOUNTS,
 };
 
 fn wait_with_recheck<T, F>(waitq: &WaitQueue, mut check: F) -> Result<T, SystemError>
@@ -143,6 +143,7 @@ struct FuseConnInner {
     owner_uid: u32,
     owner_gid: u32,
     allow_other: bool,
+    init_flags: u64,
     init: FuseInitNegotiated,
     no_open: bool,
     no_opendir: bool,
@@ -169,7 +170,10 @@ impl FuseConn {
     const MIN_MAX_WRITE: usize = 4096;
 
     pub fn new() -> Arc<Self> {
-        Self::new_with_max_write_cap(Self::max_write_cap_for_user_read_chunk())
+        Self::new_with_max_write_cap(
+            Self::max_write_cap_for_user_read_chunk(),
+            Self::kernel_init_flags(),
+        )
     }
 
     pub fn new_for_virtiofs(max_message_size: usize) -> Arc<Self> {
@@ -179,10 +183,10 @@ impl FuseConn {
         } else {
             Self::MIN_MAX_WRITE
         };
-        Self::new_with_max_write_cap(cap)
+        Self::new_with_max_write_cap(cap, Self::virtiofs_init_flags())
     }
 
-    fn new_with_max_write_cap(max_write_cap: usize) -> Arc<Self> {
+    fn new_with_max_write_cap(max_write_cap: usize, init_flags: u64) -> Arc<Self> {
         Arc::new(Self {
             inner: Mutex::new(FuseConnInner {
                 connected: true,
@@ -191,6 +195,7 @@ impl FuseConn {
                 owner_uid: 0,
                 owner_gid: 0,
                 allow_other: false,
+                init_flags,
                 init: FuseInitNegotiated::default(),
                 no_open: false,
                 no_opendir: false,
@@ -252,7 +257,7 @@ impl FuseConn {
         g.allow_other = allow_other;
     }
 
-    fn has_init_flag(&self, flag: u64) -> bool {
+    pub(crate) fn has_init_flag(&self, flag: u64) -> bool {
         let g = self.inner.lock();
         (g.init.flags & flag) != 0
     }
@@ -575,20 +580,29 @@ impl FuseConn {
             | FUSE_DO_READDIRPLUS
             | FUSE_READDIRPLUS_AUTO
             | FUSE_ASYNC_DIO
-            | FUSE_WRITEBACK_CACHE
             | FUSE_NO_OPEN_SUPPORT
+            | FUSE_NO_OPENDIR_SUPPORT
             | FUSE_PARALLEL_DIROPS
             | FUSE_HANDLE_KILLPRIV
             | FUSE_POSIX_ACL
             | FUSE_ABORT_ERROR
             | FUSE_MAX_PAGES
-            | FUSE_NO_OPENDIR_SUPPORT
             | FUSE_EXPLICIT_INVAL_DATA
             | FUSE_INIT_EXT
     }
 
+    /// virtiofs uses the normal FUSE capability request plus Linux's submount bit.
+    /// WRITEBACK_CACHE is not requested until DragonOS has complete writeback-cache semantics.
+    fn virtiofs_init_flags() -> u64 {
+        Self::kernel_init_flags() | FUSE_SUBMOUNTS
+    }
+
+    pub fn supports_submounts(&self) -> bool {
+        self.has_init_flag(FUSE_SUBMOUNTS)
+    }
+
     pub fn enqueue_init(&self) -> Result<(), SystemError> {
-        let flags = Self::kernel_init_flags();
+        let flags = self.inner.lock().init_flags;
         let init_in = FuseInitIn {
             major: FUSE_KERNEL_VERSION,
             minor: FUSE_KERNEL_MINOR_VERSION,
@@ -658,6 +672,7 @@ impl FuseConn {
         }
         let pid = pcb.task_tgid_vnr().map(|p| p.data() as u32).unwrap_or(0);
         let pending_state = Arc::new(FusePendingState::new(unique, opcode));
+
         let req = self.build_request(
             unique,
             opcode,
@@ -823,6 +838,10 @@ impl FuseConn {
             {
                 let mut g = self.inner.lock();
                 if g.connected {
+                    // 对齐 Linux：仅启用「daemon 支持 ∩ 本端请求」的特性位。
+                    // virtiofsd 常在 INIT 回复里带上 DO_READDIRPLUS 等位；若直接采纳，
+                    // 会走 READDIRPLUS + cache_child_from_entry，导致 inode 映射过期。
+                    let enabled_flags = negotiated_flags & g.init_flags;
                     g.initialized = true;
                     g.init = FuseInitNegotiated {
                         minor: negotiated_minor,
@@ -830,7 +849,7 @@ impl FuseConn {
                         max_write: capped_max_write as u32,
                         time_gran: init_out.time_gran,
                         max_pages: negotiated_max_pages,
-                        flags: negotiated_flags,
+                        flags: enabled_flags,
                     };
                 }
             }

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -159,6 +159,7 @@ struct FuseConnInner {
     no_open: bool,
     no_opendir: bool,
     no_readdirplus: bool,
+    no_fallocate: bool,
     no_interrupt: bool,
     max_write_cap: usize,
     pending: VecDeque<Arc<FuseRequest>>,
@@ -214,6 +215,7 @@ impl FuseConn {
                 no_open: false,
                 no_opendir: false,
                 no_readdirplus: false,
+                no_fallocate: false,
                 no_interrupt: false,
                 max_write_cap,
                 pending: VecDeque::new(),
@@ -318,6 +320,14 @@ impl FuseConn {
     pub fn disable_readdirplus(&self) {
         let mut g = self.inner.lock();
         g.no_readdirplus = true;
+    }
+
+    pub fn no_fallocate(&self) -> bool {
+        self.inner.lock().no_fallocate
+    }
+
+    pub fn mark_no_fallocate(&self) {
+        self.inner.lock().no_fallocate = true;
     }
 
     fn alloc_unique(&self) -> u64 {

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -143,6 +143,7 @@ struct FuseConnInner {
     owner_uid: u32,
     owner_gid: u32,
     allow_other: bool,
+    max_read: u32,
     init_flags: u64,
     init: FuseInitNegotiated,
     no_open: bool,
@@ -195,6 +196,7 @@ impl FuseConn {
                 owner_uid: 0,
                 owner_gid: 0,
                 allow_other: false,
+                max_read: u32::MAX,
                 init_flags,
                 init: FuseInitNegotiated::default(),
                 no_open: false,
@@ -250,11 +252,18 @@ impl FuseConn {
         self.inner.lock().initialized
     }
 
-    pub fn configure_mount(&self, owner_uid: u32, owner_gid: u32, allow_other: bool) {
+    pub fn configure_mount(
+        &self,
+        owner_uid: u32,
+        owner_gid: u32,
+        allow_other: bool,
+        max_read: u32,
+    ) {
         let mut g = self.inner.lock();
         g.owner_uid = owner_uid;
         g.owner_gid = owner_gid;
         g.allow_other = allow_other;
+        g.max_read = core::cmp::max(Self::MIN_MAX_WRITE as u32, max_read);
     }
 
     pub(crate) fn has_init_flag(&self, flag: u64) -> bool {
@@ -903,5 +912,10 @@ impl FuseConn {
     pub fn max_write(&self) -> usize {
         let g = self.inner.lock();
         core::cmp::max(4096usize, g.init.max_write as usize)
+    }
+
+    pub fn max_read(&self) -> usize {
+        let g = self.inner.lock();
+        core::cmp::max(Self::MIN_MAX_WRITE, g.max_read as usize)
     }
 }

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -67,6 +67,16 @@ struct FuseRequestCred {
     pid: u32,
 }
 
+impl FuseRequestCred {
+    fn nocreds() -> Self {
+        Self {
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct FusePendingState {
     unique: u64,
@@ -149,6 +159,7 @@ struct FuseConnInner {
     no_open: bool,
     no_opendir: bool,
     no_readdirplus: bool,
+    no_interrupt: bool,
     max_write_cap: usize,
     pending: VecDeque<Arc<FuseRequest>>,
     processing: BTreeMap<u64, Arc<FusePendingState>>,
@@ -166,6 +177,7 @@ pub struct FuseConn {
 }
 
 impl FuseConn {
+    const FUSE_INT_REQ_BIT: u64 = 1;
     // Keep this in sync with `sys_read.rs` userspace chunking size.
     const USER_READ_CHUNK: usize = 64 * 1024;
     const MIN_MAX_WRITE: usize = 4096;
@@ -202,6 +214,7 @@ impl FuseConn {
                 no_open: false,
                 no_opendir: false,
                 no_readdirplus: false,
+                no_interrupt: false,
                 max_write_cap,
                 pending: VecDeque::new(),
                 processing: BTreeMap::new(),
@@ -433,14 +446,24 @@ impl FuseConn {
         }
         let can_send = {
             let g = self.inner.lock();
-            g.connected && g.mounted && g.initialized
+            g.connected
+                && g.mounted
+                && g.initialized
+                && !g.no_interrupt
+                && g.processing.contains_key(&unique)
         };
         if !can_send {
             return Ok(());
         }
         let inarg = FuseInterruptIn { unique };
-        let _ = self.enqueue_request(FUSE_INTERRUPT, 0, fuse_pack_struct(&inarg))?;
-        Ok(())
+        let req = self.build_request(
+            unique | Self::FUSE_INT_REQ_BIT,
+            FUSE_INTERRUPT,
+            0,
+            fuse_pack_struct(&inarg),
+            FuseRequestCred::nocreds(),
+        );
+        self.push_request(req, None, unique | Self::FUSE_INT_REQ_BIT)
     }
 
     /// Acquire a new `/dev/fuse` file handle reference to this connection.
@@ -638,6 +661,28 @@ impl FuseConn {
             self.wait_initialized()?;
         }
         let pending = self.enqueue_request(opcode, nodeid, payload)?;
+        self.wait_request_complete(opcode, pending)
+    }
+
+    pub fn request_nocreds(
+        &self,
+        opcode: u32,
+        nodeid: u64,
+        payload: &[u8],
+    ) -> Result<Vec<u8>, SystemError> {
+        if opcode != FUSE_INIT {
+            self.wait_initialized()?;
+        }
+        let pending =
+            self.enqueue_request_with_cred(opcode, nodeid, payload, FuseRequestCred::nocreds())?;
+        self.wait_request_complete(opcode, pending)
+    }
+
+    fn wait_request_complete(
+        &self,
+        opcode: u32,
+        pending: Arc<FusePendingState>,
+    ) -> Result<Vec<u8>, SystemError> {
         match pending.wait_complete() {
             Err(SystemError::EINTR) | Err(SystemError::ERESTARTSYS) => {
                 if opcode != FUSE_INTERRUPT {
@@ -672,18 +717,13 @@ impl FuseConn {
         nodeid: u64,
         payload: &[u8],
     ) -> Result<Arc<FusePendingState>, SystemError> {
-        let unique = self.alloc_unique();
-
         let pcb = ProcessManager::current_pcb();
         let cred = pcb.cred();
         if !self.allow_current_process(&cred) {
             return Err(SystemError::EACCES);
         }
         let pid = pcb.task_tgid_vnr().map(|p| p.data() as u32).unwrap_or(0);
-        let pending_state = Arc::new(FusePendingState::new(unique, opcode));
-
-        let req = self.build_request(
-            unique,
+        self.enqueue_request_with_cred(
             opcode,
             nodeid,
             payload,
@@ -692,7 +732,20 @@ impl FuseConn {
                 gid: cred.fsgid.data() as u32,
                 pid,
             },
-        );
+        )
+    }
+
+    fn enqueue_request_with_cred(
+        &self,
+        opcode: u32,
+        nodeid: u64,
+        payload: &[u8],
+        req_cred: FuseRequestCred,
+    ) -> Result<Arc<FusePendingState>, SystemError> {
+        let unique = self.alloc_unique();
+        let pending_state = Arc::new(FusePendingState::new(unique, opcode));
+
+        let req = self.build_request(unique, opcode, nodeid, payload, req_cred);
         self.push_request(req, Some(pending_state.clone()), unique)?;
         Ok(pending_state)
     }
@@ -762,6 +815,10 @@ impl FuseConn {
             let payload = &data[core::mem::size_of::<FuseOutHeader>()..];
             self.handle_notify(out_hdr.error, payload)?;
             return Ok(data.len());
+        }
+
+        if (out_hdr.unique & Self::FUSE_INT_REQ_BIT) != 0 {
+            return self.write_interrupt_reply(&out_hdr, data.len());
         }
 
         let pending = {
@@ -867,6 +924,36 @@ impl FuseConn {
 
         pending.complete(Ok(payload.to_vec()));
         Ok(data.len())
+    }
+
+    fn write_interrupt_reply(
+        &self,
+        out_hdr: &FuseOutHeader,
+        data_len: usize,
+    ) -> Result<usize, SystemError> {
+        if data_len != core::mem::size_of::<FuseOutHeader>() {
+            return Err(SystemError::EINVAL);
+        }
+        if out_hdr.error <= -512 || out_hdr.error > 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        let target_unique = out_hdr.unique & !Self::FUSE_INT_REQ_BIT;
+        {
+            let mut g = self.inner.lock();
+            if !g.connected || !g.processing.contains_key(&target_unique) {
+                return Err(SystemError::ENOENT);
+            }
+            if out_hdr.error == -SystemError::ENOSYS.to_posix_errno() {
+                g.no_interrupt = true;
+            }
+        }
+
+        if out_hdr.error == -SystemError::EAGAIN_OR_EWOULDBLOCK.to_posix_errno() {
+            self.queue_interrupt(target_unique)?;
+        }
+
+        Ok(data_len)
     }
 
     fn handle_notify(&self, code: i32, payload: &[u8]) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -6,6 +6,7 @@ use system_error::SystemError;
 
 use crate::{
     arch::MMArch,
+    exception::workqueue::{schedule_work, Work},
     filesystem::epoll::{
         event_poll::EventPoll, event_poll::LockedEPItemLinkedList, EPollEventType, EPollItem,
     },
@@ -24,11 +25,12 @@ use super::protocol::{
     FuseInterruptIn, FuseOutHeader, FuseWriteIn, FUSE_ABORT_ERROR, FUSE_ASYNC_DIO, FUSE_ASYNC_READ,
     FUSE_ATOMIC_O_TRUNC, FUSE_AUTO_INVAL_DATA, FUSE_BIG_WRITES, FUSE_DESTROY, FUSE_DONT_MASK,
     FUSE_DO_READDIRPLUS, FUSE_EXPLICIT_INVAL_DATA, FUSE_EXPORT_SUPPORT, FUSE_FLUSH, FUSE_FORGET,
-    FUSE_HANDLE_KILLPRIV, FUSE_INIT, FUSE_INIT_EXT, FUSE_INTERRUPT, FUSE_KERNEL_MINOR_VERSION,
-    FUSE_KERNEL_VERSION, FUSE_LOOKUP, FUSE_MAX_PAGES, FUSE_MIN_READ_BUFFER, FUSE_NOTIFY_DELETE,
-    FUSE_NOTIFY_INVAL_ENTRY, FUSE_NOTIFY_INVAL_INODE, FUSE_NOTIFY_POLL, FUSE_NOTIFY_RETRIEVE,
-    FUSE_NOTIFY_STORE, FUSE_NO_OPENDIR_SUPPORT, FUSE_NO_OPEN_SUPPORT, FUSE_PARALLEL_DIROPS,
-    FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO, FUSE_SUBMOUNTS,
+    FUSE_FSYNC, FUSE_FSYNCDIR, FUSE_HANDLE_KILLPRIV, FUSE_INIT, FUSE_INIT_EXT, FUSE_INTERRUPT,
+    FUSE_KERNEL_MINOR_VERSION, FUSE_KERNEL_VERSION, FUSE_LOOKUP, FUSE_MAX_PAGES,
+    FUSE_MIN_READ_BUFFER, FUSE_NOTIFY_DELETE, FUSE_NOTIFY_INVAL_ENTRY, FUSE_NOTIFY_INVAL_INODE,
+    FUSE_NOTIFY_POLL, FUSE_NOTIFY_RETRIEVE, FUSE_NOTIFY_STORE, FUSE_NO_OPENDIR_SUPPORT,
+    FUSE_NO_OPEN_SUPPORT, FUSE_PARALLEL_DIROPS, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS,
+    FUSE_READDIRPLUS_AUTO, FUSE_SUBMOUNTS,
 };
 
 fn wait_with_recheck<T, F>(waitq: &WaitQueue, mut check: F) -> Result<T, SystemError>
@@ -61,18 +63,29 @@ pub struct FuseRequest {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct FuseRequestCred {
-    uid: u32,
-    gid: u32,
-    pid: u32,
+pub struct FuseRequestCred {
+    pub uid: u32,
+    pub gid: u32,
+    pub pid: u32,
 }
 
 impl FuseRequestCred {
-    fn nocreds() -> Self {
+    pub(crate) fn nocreds() -> Self {
         Self {
             uid: 0,
             gid: 0,
             pid: 0,
+        }
+    }
+
+    pub(crate) fn from_current() -> Self {
+        let pcb = ProcessManager::current_pcb();
+        let cred = pcb.cred();
+        let pid = pcb.task_tgid_vnr().map(|p| p.data() as u32).unwrap_or(0);
+        Self {
+            uid: cred.fsuid.data() as u32,
+            gid: cred.fsgid.data() as u32,
+            pid,
         }
     }
 }
@@ -160,6 +173,9 @@ struct FuseConnInner {
     no_opendir: bool,
     no_readdirplus: bool,
     no_fallocate: bool,
+    no_flush: bool,
+    no_fsync: bool,
+    no_fsyncdir: bool,
     no_interrupt: bool,
     max_write_cap: usize,
     pending: VecDeque<Arc<FuseRequest>>,
@@ -216,6 +232,9 @@ impl FuseConn {
                 no_opendir: false,
                 no_readdirplus: false,
                 no_fallocate: false,
+                no_flush: false,
+                no_fsync: false,
+                no_fsyncdir: false,
                 no_interrupt: false,
                 max_write_cap,
                 pending: VecDeque::new(),
@@ -328,6 +347,32 @@ impl FuseConn {
 
     pub fn mark_no_fallocate(&self) {
         self.inner.lock().no_fallocate = true;
+    }
+
+    pub fn no_flush(&self) -> bool {
+        self.inner.lock().no_flush
+    }
+
+    pub fn mark_no_flush(&self) {
+        self.inner.lock().no_flush = true;
+    }
+
+    pub fn no_fsync(&self, opcode: u32) -> bool {
+        let g = self.inner.lock();
+        match opcode {
+            FUSE_FSYNC => g.no_fsync,
+            FUSE_FSYNCDIR => g.no_fsyncdir,
+            _ => false,
+        }
+    }
+
+    pub fn mark_no_fsync(&self, opcode: u32) {
+        let mut g = self.inner.lock();
+        match opcode {
+            FUSE_FSYNC => g.no_fsync = true,
+            FUSE_FSYNCDIR => g.no_fsyncdir = true,
+            _ => {}
+        }
     }
 
     fn alloc_unique(&self) -> u64 {
@@ -688,6 +733,40 @@ impl FuseConn {
         self.wait_request_complete(opcode, pending)
     }
 
+    pub fn request_nocreds_background(
+        self: &Arc<Self>,
+        opcode: u32,
+        nodeid: u64,
+        payload: &[u8],
+    ) -> Result<(), SystemError> {
+        if opcode != FUSE_INIT {
+            self.wait_initialized()?;
+        }
+        let pending =
+            self.enqueue_request_with_cred(opcode, nodeid, payload, FuseRequestCred::nocreds())?;
+        let conn = self.clone();
+        schedule_work(Work::new(move || {
+            if let Err(err) = conn.wait_request_complete(opcode, pending.clone()) {
+                if matches!(err, SystemError::ENOTCONN | SystemError::ENOENT) {
+                    log::debug!(
+                        "fuse: background request aborted opcode={} nodeid={} err={:?}",
+                        opcode,
+                        nodeid,
+                        err
+                    );
+                } else {
+                    log::warn!(
+                        "fuse: background request failed opcode={} nodeid={} err={:?}",
+                        opcode,
+                        nodeid,
+                        err
+                    );
+                }
+            }
+        }));
+        Ok(())
+    }
+
     fn wait_request_complete(
         &self,
         opcode: u32,
@@ -732,17 +811,7 @@ impl FuseConn {
         if !self.allow_current_process(&cred) {
             return Err(SystemError::EACCES);
         }
-        let pid = pcb.task_tgid_vnr().map(|p| p.data() as u32).unwrap_or(0);
-        self.enqueue_request_with_cred(
-            opcode,
-            nodeid,
-            payload,
-            FuseRequestCred {
-                uid: cred.fsuid.data() as u32,
-                gid: cred.fsgid.data() as u32,
-                pid,
-            },
-        )
+        self.enqueue_request_with_cred(opcode, nodeid, payload, FuseRequestCred::from_current())
     }
 
     fn enqueue_request_with_cred(

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -176,7 +176,6 @@ impl FuseFS {
                     let old_gen = n.generation();
                     if old_gen != 0 && old_gen != gen {
                         n.mark_stale();
-                        n.flush_forget();
                         nodes.remove(&nodeid);
                     } else {
                         n.set_generation(gen);
@@ -188,6 +187,81 @@ impl FuseFS {
                     }
                 } else {
                     n.set_parent_nodeid(parent_nodeid);
+                    if let Some(md) = cached {
+                        n.set_cached_metadata(md);
+                    }
+                    return n;
+                }
+            }
+        }
+
+        let n = FuseNode::new(
+            Arc::downgrade(self),
+            self.conn.clone(),
+            nodeid,
+            parent_nodeid,
+            cached,
+        );
+        if let Some(gen) = generation {
+            n.set_generation(gen);
+        }
+        nodes.insert(nodeid, Arc::downgrade(&n));
+        n
+    }
+
+    pub(crate) fn find_cached_child(
+        self: &Arc<Self>,
+        parent_nodeid: u64,
+        name: &str,
+    ) -> Option<Arc<FuseNode>> {
+        let mut stale = Vec::new();
+        let nodes = self.nodes.lock();
+        for (nodeid, weak) in nodes.iter() {
+            let Some(node) = weak.upgrade() else {
+                stale.push(*nodeid);
+                continue;
+            };
+            if node.parent_fuse_nodeid() == parent_nodeid && node.has_dname(name) {
+                return Some(node);
+            }
+        }
+        drop(nodes);
+        if !stale.is_empty() {
+            let mut nodes = self.nodes.lock();
+            for nodeid in stale {
+                nodes.remove(&nodeid);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn get_or_create_node_for_link(
+        self: &Arc<Self>,
+        nodeid: u64,
+        parent_nodeid: u64,
+        cached: Option<Metadata>,
+        generation: Option<u64>,
+    ) -> Arc<FuseNode> {
+        if nodeid == self.root.nodeid() {
+            return self.root.clone();
+        }
+
+        let mut nodes = self.nodes.lock();
+        if let Some(w) = nodes.get(&nodeid) {
+            if let Some(n) = w.upgrade() {
+                if let Some(gen) = generation {
+                    let old_gen = n.generation();
+                    if old_gen != 0 && old_gen != gen {
+                        n.mark_stale();
+                        nodes.remove(&nodeid);
+                    } else {
+                        n.set_generation(gen);
+                        if let Some(md) = cached {
+                            n.set_cached_metadata(md);
+                        }
+                        return n;
+                    }
+                } else {
                     if let Some(md) = cached {
                         n.set_cached_metadata(md);
                     }
@@ -258,6 +332,7 @@ impl FuseFS {
 pub fn fuse_try_automount_submount(
     fuse_node: &Arc<FuseNode>,
     mountpoint: &Arc<crate::filesystem::vfs::mount::MountFSInode>,
+    mount_path_override: Option<Arc<crate::filesystem::vfs::mount::MountPath>>,
 ) -> Result<(), SystemError> {
     use crate::filesystem::vfs::mount::{MountFlags, MountPath};
 
@@ -285,7 +360,16 @@ pub fn fuse_try_automount_submount(
         fuse_node.parent_fuse_nodeid(),
         md,
     );
-    let mount_path = Arc::new(MountPath::from(mountpoint.absolute_path()?));
+    let mount_path = match mount_path_override {
+        Some(path) => path,
+        None => {
+            let path = mountpoint.absolute_path()?;
+            if !path.starts_with('/') {
+                return Err(SystemError::EINVAL);
+            }
+            Arc::new(MountPath::from(path))
+        }
+    };
     let submount_flags = mountpoint.mount_fs().mount_flags() | MountFlags::SUBMOUNT;
     let mount_res = mountpoint.mount_subtree_with_state(
         sub_fs.clone(),

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -11,7 +11,10 @@ use crate::{
         InodeId, InodeMode, Magic, Metadata, MountableFileSystem, SuperBlock, FSMAKER,
     },
     libs::mutex::Mutex,
-    mm::{fault::PageFaultMessage, VmFaultReason, VmFlags},
+    mm::{
+        fault::{PageFaultHandler, PageFaultMessage},
+        VirtRegion, VmFaultReason, VmFlags,
+    },
     process::ProcessManager,
     register_mountable_fs,
     time::PosixTimeSpec,
@@ -559,9 +562,6 @@ impl FileSystem for FuseFS {
         let vma = pfm.vma();
         let vma_guard = vma.lock();
         let vm_flags = *vma_guard.vm_flags();
-        if vm_flags.contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
-            return VmFaultReason::VM_FAULT_SIGBUS;
-        }
         let Some(file) = vma_guard.vm_file() else {
             return VmFaultReason::VM_FAULT_SIGBUS;
         };
@@ -599,15 +599,58 @@ impl FileSystem for FuseFS {
         }
     }
 
-    unsafe fn page_mkwrite(&self, _pfm: &mut PageFaultMessage) -> VmFaultReason {
-        VmFaultReason::VM_FAULT_SIGBUS
+    unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
+        let vma = pfm.vma();
+        let vma_guard = vma.lock();
+        let vm_flags = *vma_guard.vm_flags();
+        let Some(file) = vma_guard.vm_file() else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        drop(vma_guard);
+
+        let node = {
+            let data = file.private_data.lock();
+            let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            };
+            if (p.fopen_flags & FOPEN_DIRECT_IO) != 0 && vm_flags.contains(VmFlags::VM_MAYSHARE) {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            }
+            p.node.clone()
+        };
+
+        let Ok(_pin) = node.pin_writeback_handle() else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        PageFaultHandler::filemap_page_mkwrite(pfm)
     }
 
     fn mprotect(&self, _old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {
-        if new_vm_flags.contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
-            return Err(SystemError::EACCES);
-        }
+        let _ = new_vm_flags;
         Ok(())
+    }
+
+    fn vma_close(
+        &self,
+        file: &Arc<crate::filesystem::vfs::file::File>,
+        _region: VirtRegion,
+        vm_flags: VmFlags,
+    ) {
+        if !vm_flags.contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
+            return;
+        }
+
+        let node = {
+            let data = file.private_data.lock();
+            let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
+                return;
+            };
+            p.node.clone()
+        };
+
+        if let Err(e) = node.sync_cached_pages() {
+            log::warn!("fuse: vma_close writeback failed: {:?}", e);
+        }
     }
 
     unsafe fn map_pages(

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -574,7 +574,7 @@ impl FileSystem for FuseFS {
             };
             (p.node.clone(), p.fh, p.open_flags, p.fopen_flags)
         };
-        if (fopen_flags & FOPEN_DIRECT_IO) != 0 {
+        if (fopen_flags & FOPEN_DIRECT_IO) != 0 && vm_flags.contains(VmFlags::VM_MAYSHARE) {
             return VmFaultReason::VM_FAULT_SIGBUS;
         }
 

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -7,11 +7,11 @@ use system_error::SystemError;
 
 use crate::{
     filesystem::vfs::{
-        FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode, InodeFlags, InodeId,
-        InodeMode, Magic, Metadata, MountableFileSystem, SuperBlock, FSMAKER,
+        FilePrivateData, FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode, InodeFlags,
+        InodeId, InodeMode, Magic, Metadata, MountableFileSystem, SuperBlock, FSMAKER,
     },
     libs::mutex::Mutex,
-    mm::{fault::PageFaultMessage, VmFaultReason},
+    mm::{fault::PageFaultMessage, VmFaultReason, VmFlags},
     process::ProcessManager,
     register_mountable_fs,
     time::PosixTimeSpec,
@@ -23,7 +23,10 @@ use super::{
     conn::FuseConn,
     inode::FuseNode,
     private_data::FuseFilePrivateData,
-    protocol::{fuse_read_struct, FuseStatfsOut, FUSE_ATTR_SUBMOUNT, FUSE_ROOT_ID, FUSE_STATFS},
+    protocol::{
+        fuse_read_struct, FuseStatfsOut, FOPEN_DIRECT_IO, FUSE_ATTR_SUBMOUNT, FUSE_ROOT_ID,
+        FUSE_STATFS,
+    },
 };
 
 #[derive(Debug)]
@@ -553,8 +556,54 @@ impl FileSystem for FuseFS {
     }
 
     unsafe fn fault(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
-        let _ = pfm;
-        VmFaultReason::VM_FAULT_SIGBUS
+        let vma = pfm.vma();
+        let vma_guard = vma.lock();
+        let vm_flags = *vma_guard.vm_flags();
+        if vm_flags.contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        }
+        let Some(file) = vma_guard.vm_file() else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        drop(vma_guard);
+
+        let (node, fh, file_flags, fopen_flags) = {
+            let data = file.private_data.lock();
+            let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            };
+            (p.node.clone(), p.fh, p.open_flags, p.fopen_flags)
+        };
+        if (fopen_flags & FOPEN_DIRECT_IO) != 0 {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        }
+
+        let Some(page_index) = pfm.backing_pgoff() else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        let major = node
+            .page_cache()
+            .map(|cache| !cache.is_page_ready(page_index))
+            .unwrap_or(true);
+
+        match node.fault_page_with_open(page_index, fh, file_flags) {
+            Ok(page) => {
+                pfm.set_page(page);
+                if major {
+                    VmFaultReason::VM_FAULT_MAJOR
+                } else {
+                    VmFaultReason::empty()
+                }
+            }
+            Err(_) => VmFaultReason::VM_FAULT_SIGBUS,
+        }
+    }
+
+    fn mprotect(&self, _old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {
+        if new_vm_flags.contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
+            return Err(SystemError::EACCES);
+        }
+        Ok(())
     }
 
     unsafe fn map_pages(

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -3,7 +3,6 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-
 use system_error::SystemError;
 
 use crate::{
@@ -12,6 +11,7 @@ use crate::{
         InodeMode, Magic, Metadata, MountableFileSystem, SuperBlock, FSMAKER,
     },
     libs::mutex::Mutex,
+    mm::{fault::PageFaultHandler, fault::PageFaultMessage, VmFaultReason},
     process::ProcessManager,
     register_mountable_fs,
     time::PosixTimeSpec,
@@ -23,7 +23,7 @@ use super::{
     conn::FuseConn,
     inode::FuseNode,
     private_data::FuseFilePrivateData,
-    protocol::{fuse_read_struct, FuseStatfsOut, FUSE_ROOT_ID, FUSE_STATFS},
+    protocol::{fuse_read_struct, FuseStatfsOut, FUSE_ATTR_SUBMOUNT, FUSE_ROOT_ID, FUSE_STATFS},
 };
 
 #[derive(Debug)]
@@ -49,6 +49,7 @@ pub struct FuseFS {
     conn: Arc<FuseConn>,
     nodes: Mutex<BTreeMap<u64, Weak<FuseNode>>>,
     default_permissions: bool,
+    is_submount: bool,
 }
 
 impl FuseFS {
@@ -140,18 +141,44 @@ impl FuseFS {
         parent_nodeid: u64,
         cached: Option<Metadata>,
     ) -> Arc<FuseNode> {
-        if nodeid == FUSE_ROOT_ID {
+        self.get_or_create_node_with_generation(nodeid, parent_nodeid, cached, None)
+    }
+
+    pub fn get_or_create_node_with_generation(
+        self: &Arc<Self>,
+        nodeid: u64,
+        parent_nodeid: u64,
+        cached: Option<Metadata>,
+        generation: Option<u64>,
+    ) -> Arc<FuseNode> {
+        if nodeid == self.root.nodeid() {
             return self.root.clone();
         }
 
         let mut nodes = self.nodes.lock();
         if let Some(w) = nodes.get(&nodeid) {
             if let Some(n) = w.upgrade() {
-                n.set_parent_nodeid(parent_nodeid);
-                if let Some(md) = cached {
-                    n.set_cached_metadata(md);
+                if let Some(gen) = generation {
+                    let old_gen = n.generation();
+                    if old_gen != 0 && old_gen != gen {
+                        n.mark_stale();
+                        n.flush_forget();
+                        nodes.remove(&nodeid);
+                    } else {
+                        n.set_generation(gen);
+                        n.set_parent_nodeid(parent_nodeid);
+                        if let Some(md) = cached {
+                            n.set_cached_metadata(md);
+                        }
+                        return n;
+                    }
+                } else {
+                    n.set_parent_nodeid(parent_nodeid);
+                    if let Some(md) = cached {
+                        n.set_cached_metadata(md);
+                    }
+                    return n;
                 }
-                return n;
             }
         }
 
@@ -162,9 +189,104 @@ impl FuseFS {
             parent_nodeid,
             cached,
         );
+        if let Some(gen) = generation {
+            n.set_generation(gen);
+        }
         nodes.insert(nodeid, Arc::downgrade(&n));
         n
     }
+
+    /// 为 virtiofs announce-submounts 创建子挂载树（共享同一 FuseConn）。
+    pub fn new_submount(
+        parent: &Arc<Self>,
+        root_nodeid: u64,
+        parent_nodeid: u64,
+        root_md: Metadata,
+    ) -> Arc<Self> {
+        let conn = parent.conn.clone();
+        let fs = Arc::new_cyclic(|weak| FuseFS {
+            root: FuseNode::new(
+                weak.clone(),
+                conn.clone(),
+                root_nodeid,
+                parent_nodeid,
+                Some(root_md),
+            ),
+            super_block: parent.super_block.clone(),
+            conn,
+            nodes: Mutex::new(BTreeMap::new()),
+            default_permissions: parent.default_permissions,
+            is_submount: true,
+        });
+        fs.nodes
+            .lock()
+            .insert(root_nodeid, Arc::downgrade(&fs.root));
+        fs
+    }
+}
+
+/// DragonOS currently mounts announced FUSE submounts eagerly at lookup time.
+/// Linux uses dentry automount and only overlays the mountpoint; parent-tree
+/// nodes outside that mountpoint remain valid.
+///
+/// ## Arguments
+///
+/// - `fuse_node`: FUSE node whose lookup attributes may contain
+///   `FUSE_ATTR_SUBMOUNT`.
+/// - `mountpoint`: VFS mount inode corresponding to the looked-up node.
+///
+/// ## Returns
+///
+/// - `Ok(())`: no submount was needed, the connection does not support
+///   submounts, the submount already exists, or a new submount was attached.
+/// - `Err(SystemError)`: metadata lookup, path resolution, or mount attachment
+///   failed.
+pub fn fuse_try_automount_submount(
+    fuse_node: &Arc<FuseNode>,
+    mountpoint: &Arc<crate::filesystem::vfs::mount::MountFSInode>,
+) -> Result<(), SystemError> {
+    use crate::filesystem::vfs::mount::{MountFlags, MountPath};
+
+    let attr_flags = fuse_node.lookup_attr_flags();
+    if (attr_flags & FUSE_ATTR_SUBMOUNT) == 0 {
+        return Ok(());
+    }
+    if !fuse_node.conn().supports_submounts() {
+        return Ok(());
+    }
+
+    let md = mountpoint.metadata()?;
+    if mountpoint
+        .mount_fs()
+        .mountpoints()
+        .contains_key(&md.inode_id)
+    {
+        return Ok(());
+    }
+
+    let parent_fs = fuse_node.fuse_fs().ok_or(SystemError::ENOENT)?;
+    let sub_fs = FuseFS::new_submount(
+        &parent_fs,
+        fuse_node.nodeid(),
+        fuse_node.parent_fuse_nodeid(),
+        md,
+    );
+    let mount_path = Arc::new(MountPath::from(mountpoint.absolute_path()?));
+    let submount_flags = mountpoint.mount_fs().mount_flags() | MountFlags::SUBMOUNT;
+    let mount_res = mountpoint.mount_subtree_with_state(
+        sub_fs.clone(),
+        sub_fs.root_node(),
+        submount_flags,
+        None,
+        None,
+        Some(mount_path),
+    );
+    if let Err(e) = mount_res {
+        if e != SystemError::EEXIST {
+            return Err(e);
+        }
+    }
+    Ok(())
 }
 
 impl MountableFileSystem for FuseFS {
@@ -249,6 +371,7 @@ impl MountableFileSystem for FuseFS {
             conn: conn.clone(),
             nodes: Mutex::new(BTreeMap::new()),
             default_permissions: mount_data.default_permissions,
+            is_submount: false,
         });
 
         if let Err(e) = conn.enqueue_init() {
@@ -326,6 +449,25 @@ impl FileSystem for FuseFS {
         }
     }
 
+    fn support_readahead(&self) -> bool {
+        false
+    }
+
+    unsafe fn fault(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
+        // FUSE regular files use the shared page cache; page faults should fetch
+        // through the inode read path instead of SIGBUS/panicking on mmap access.
+        PageFaultHandler::filemap_fault(pfm)
+    }
+
+    unsafe fn map_pages(
+        &self,
+        pfm: &mut PageFaultMessage,
+        start_pgoff: usize,
+        end_pgoff: usize,
+    ) -> VmFaultReason {
+        PageFaultHandler::filemap_map_pages(pfm, start_pgoff, end_pgoff)
+    }
+
     fn on_umount(&self) {
         let live_nodes: Vec<Arc<FuseNode>> = {
             let nodes = self.nodes.lock();
@@ -334,6 +476,8 @@ impl FileSystem for FuseFS {
         for node in live_nodes {
             node.flush_forget();
         }
-        self.conn.on_umount();
+        if !self.is_submount {
+            self.conn.on_umount();
+        }
     }
 }

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -31,9 +31,20 @@ pub struct FuseMountData {
     pub rootmode: u32,
     pub user_id: u32,
     pub group_id: u32,
+    pub max_read: u32,
     pub allow_other: bool,
     pub default_permissions: bool,
     pub conn: Arc<FuseConn>,
+}
+
+struct FuseParsedMountOptions {
+    fd: i32,
+    rootmode: u32,
+    user_id: u32,
+    group_id: u32,
+    max_read: u32,
+    default_permissions: bool,
+    allow_other: bool,
 }
 
 impl FileSystemMakerData for FuseMountData {
@@ -69,13 +80,12 @@ impl FuseFS {
         v.is_empty() || v != "0"
     }
 
-    fn parse_mount_options(
-        raw: Option<&str>,
-    ) -> Result<(i32, u32, u32, u32, bool, bool), SystemError> {
+    fn parse_mount_options(raw: Option<&str>) -> Result<FuseParsedMountOptions, SystemError> {
         let mut fd: Option<i32> = None;
         let mut rootmode: Option<u32> = None;
         let mut user_id: Option<u32> = None;
         let mut group_id: Option<u32> = None;
+        let mut max_read = u32::MAX;
         let mut default_permissions = false;
         let mut allow_other = false;
 
@@ -103,6 +113,9 @@ impl FuseFS {
                 "group_id" => {
                     group_id = Some(Self::parse_opt_u32_decimal(v)?);
                 }
+                "max_read" => {
+                    max_read = Self::parse_opt_u32_decimal(v)?;
+                }
                 "default_permissions" => {
                     default_permissions = Self::parse_opt_bool_switch(v);
                 }
@@ -121,14 +134,15 @@ impl FuseFS {
         // Default root mode: directory 0755 (with type bit).
         let rootmode = rootmode.unwrap_or(0o040755);
 
-        Ok((
+        Ok(FuseParsedMountOptions {
             fd,
             rootmode,
             user_id,
             group_id,
+            max_read,
             default_permissions,
             allow_other,
-        ))
+        })
     }
 
     pub fn root_node(&self) -> Arc<FuseNode> {
@@ -294,13 +308,12 @@ impl MountableFileSystem for FuseFS {
         raw_data: Option<&str>,
         _source: &str,
     ) -> Result<Option<Arc<dyn FileSystemMakerData + 'static>>, SystemError> {
-        let (fd, rootmode, user_id, group_id, default_permissions, allow_other) =
-            Self::parse_mount_options(raw_data)?;
+        let opts = Self::parse_mount_options(raw_data)?;
 
         let file = ProcessManager::current_pcb()
             .fd_table()
             .read()
-            .get_file_by_fd(fd)
+            .get_file_by_fd(opts.fd)
             .ok_or(SystemError::EBADF)?;
 
         let conn = {
@@ -314,11 +327,12 @@ impl MountableFileSystem for FuseFS {
         };
 
         Ok(Some(Arc::new(FuseMountData {
-            rootmode,
-            user_id,
-            group_id,
-            allow_other,
-            default_permissions,
+            rootmode: opts.rootmode,
+            user_id: opts.user_id,
+            group_id: opts.group_id,
+            max_read: opts.max_read,
+            allow_other: opts.allow_other,
+            default_permissions: opts.default_permissions,
             conn,
         })))
     }
@@ -357,6 +371,7 @@ impl MountableFileSystem for FuseFS {
             mount_data.user_id,
             mount_data.group_id,
             mount_data.allow_other,
+            mount_data.max_read,
         );
 
         let fs = Arc::new_cyclic(|weak_fs| FuseFS {

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -599,6 +599,10 @@ impl FileSystem for FuseFS {
         }
     }
 
+    unsafe fn page_mkwrite(&self, _pfm: &mut PageFaultMessage) -> VmFaultReason {
+        VmFaultReason::VM_FAULT_SIGBUS
+    }
+
     fn mprotect(&self, _old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {
         if new_vm_flags.contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
             return Err(SystemError::EACCES);

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -11,7 +11,7 @@ use crate::{
         InodeMode, Magic, Metadata, MountableFileSystem, SuperBlock, FSMAKER,
     },
     libs::mutex::Mutex,
-    mm::{fault::PageFaultHandler, fault::PageFaultMessage, VmFaultReason},
+    mm::{fault::PageFaultMessage, VmFaultReason},
     process::ProcessManager,
     register_mountable_fs,
     time::PosixTimeSpec,
@@ -469,9 +469,8 @@ impl FileSystem for FuseFS {
     }
 
     unsafe fn fault(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
-        // FUSE regular files use the shared page cache; page faults should fetch
-        // through the inode read path instead of SIGBUS/panicking on mmap access.
-        PageFaultHandler::filemap_fault(pfm)
+        let _ = pfm;
+        VmFaultReason::VM_FAULT_SIGBUS
     }
 
     unsafe fn map_pages(
@@ -480,7 +479,8 @@ impl FileSystem for FuseFS {
         start_pgoff: usize,
         end_pgoff: usize,
     ) -> VmFaultReason {
-        PageFaultHandler::filemap_map_pages(pfm, start_pgoff, end_pgoff)
+        let _ = (pfm, start_pgoff, end_pgoff);
+        VmFaultReason::VM_FAULT_SIGBUS
     }
 
     fn on_umount(&self) {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -10,6 +10,7 @@ use system_error::SystemError;
 
 use crate::time::timekeep::ktime_get_real_ns;
 use crate::{
+    arch::MMArch,
     driver::base::device::device_number::DeviceNumber,
     filesystem::{
         page_cache::PageCache,
@@ -23,6 +24,7 @@ use crate::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
     },
+    mm::{page::PageFlags, MemoryManagementArch},
     time::PosixTimeSpec,
 };
 
@@ -35,12 +37,12 @@ use super::{
         FuseDirent, FuseDirentPlus, FuseEntryOut, FuseFlushIn, FuseFsyncIn, FuseGetattrIn,
         FuseLinkIn, FuseMkdirIn, FuseMknodIn, FuseOpenIn, FuseOpenOut, FuseReadIn, FuseReleaseIn,
         FuseRename2In, FuseRenameIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut, FATTR_ATIME,
-        FATTR_CTIME, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_SIZE, FATTR_UID, FUSE_ACCESS,
-        FUSE_CREATE, FUSE_FLUSH, FUSE_FSYNC, FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_GETATTR,
-        FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ,
-        FUSE_READDIR, FUSE_READDIRPLUS, FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME,
-        FUSE_RENAME2, FUSE_RMDIR, FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK,
-        FUSE_WRITE,
+        FATTR_CTIME, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_SIZE, FATTR_UID, FOPEN_DIRECT_IO,
+        FOPEN_KEEP_CACHE, FUSE_ACCESS, FUSE_CREATE, FUSE_FLUSH, FUSE_FSYNC, FUSE_FSYNCDIR,
+        FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD,
+        FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS, FUSE_READLINK,
+        FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_ROOT_ID,
+        FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE,
     },
 };
 
@@ -53,6 +55,7 @@ pub struct FuseNode {
     parent_nodeid: Mutex<u64>,
     name: Mutex<Option<String>>,
     cached_metadata: Mutex<Option<Metadata>>,
+    page_cache: Mutex<Option<Arc<PageCache>>>,
     cached_metadata_deadline_ns: AtomicU64,
     lookup_count: AtomicU64,
     /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
@@ -81,6 +84,7 @@ impl FuseNode {
             parent_nodeid: Mutex::new(parent_nodeid),
             name: Mutex::new(None),
             cached_metadata: Mutex::new(cached),
+            page_cache: Mutex::new(None),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
@@ -188,6 +192,28 @@ impl FuseNode {
         &self.conn
     }
 
+    fn ensure_page_cache(&self) -> Result<Arc<PageCache>, SystemError> {
+        let mut guard = self.page_cache.lock();
+        if let Some(cache) = guard.as_ref() {
+            return Ok(cache.clone());
+        }
+        let node = self.self_ref.upgrade().ok_or(SystemError::EIO)?;
+        let inode: Arc<dyn IndexNode> = node;
+        let cache = PageCache::new(Some(Arc::downgrade(&inode)), None);
+        *guard = Some(cache.clone());
+        Ok(cache)
+    }
+
+    fn cached_page_cache(&self) -> Option<Arc<PageCache>> {
+        self.page_cache.lock().clone()
+    }
+
+    fn invalidate_clean_page_cache(&self) {
+        if let Some(cache) = self.cached_page_cache() {
+            let _ = cache.manager().invalidate_all_clean();
+        }
+    }
+
     pub(crate) fn fuse_fs(&self) -> Option<Arc<FuseFS>> {
         self.fs.upgrade()
     }
@@ -247,12 +273,22 @@ impl FuseNode {
         }
     }
 
+    fn fuse_file_snapshot(data: &FilePrivateData) -> Result<(u64, u32, u32), SystemError> {
+        match data {
+            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => {
+                Ok((p.fh, p.open_flags, p.fopen_flags))
+            }
+            _ => Err(SystemError::EBADF),
+        }
+    }
+
     fn set_open_private_data(
         &self,
         data: &mut FilePrivateData,
         opcode: u32,
         fh: u64,
         open_flags: u32,
+        fopen_flags: u32,
         no_open: bool,
     ) -> Result<(), SystemError> {
         let conn_any: Arc<dyn core::any::Any + Send + Sync> = self.conn.clone();
@@ -263,6 +299,7 @@ impl FuseNode {
                 node: node.clone(),
                 fh,
                 open_flags,
+                fopen_flags,
                 no_open,
             })),
             FUSE_OPENDIR => FilePrivateData::Fuse(FuseFilePrivateData::Dir(FuseOpenPrivateData {
@@ -270,6 +307,7 @@ impl FuseNode {
                 node,
                 fh,
                 open_flags,
+                fopen_flags,
                 no_open,
             })),
             _ => return Err(SystemError::EINVAL),
@@ -446,7 +484,7 @@ impl FuseNode {
         self.check_not_stale()?;
         let file_flags = flags.bits();
         if self.conn.should_skip_open(opcode) {
-            return self.set_open_private_data(data, opcode, 0, file_flags, true);
+            return self.set_open_private_data(data, opcode, 0, file_flags, FOPEN_KEEP_CACHE, true);
         }
 
         let fuse_open_flags = self.fuse_open_in_flags(file_flags);
@@ -461,12 +499,22 @@ impl FuseNode {
             Ok(v) => v,
             Err(SystemError::ENOSYS) if self.conn.open_enosys_is_supported(opcode) => {
                 self.conn.mark_no_open(opcode);
-                return self.set_open_private_data(data, opcode, 0, file_flags, true);
+                return self.set_open_private_data(
+                    data,
+                    opcode,
+                    0,
+                    file_flags,
+                    FOPEN_KEEP_CACHE,
+                    true,
+                );
             }
             Err(e) => return Err(e),
         };
         let out: FuseOpenOut = fuse_read_struct(&payload)?;
-        self.set_open_private_data(data, opcode, out.fh, file_flags, false)
+        if opcode == FUSE_OPEN && (out.open_flags & FOPEN_KEEP_CACHE) == 0 {
+            self.invalidate_clean_page_cache();
+        }
+        self.set_open_private_data(data, opcode, out.fh, file_flags, out.open_flags, false)
     }
 
     fn release_common(&self, opcode: u32, fh: u64, file_flags: u32) -> Result<(), SystemError> {
@@ -583,6 +631,202 @@ impl FuseNode {
         );
         Ok(child)
     }
+
+    fn read_direct_with_open(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        fh: u64,
+        file_flags: u32,
+    ) -> Result<usize, SystemError> {
+        let max_read = self.conn().max_read();
+        if max_read == 0 {
+            return Err(SystemError::EIO);
+        }
+
+        let mut total_read = 0usize;
+        while total_read < len {
+            let chunk = core::cmp::min(max_read, len - total_read);
+            let Some(chunk_offset) = offset.checked_add(total_read) else {
+                return if total_read > 0 {
+                    Ok(total_read)
+                } else {
+                    Err(SystemError::EOVERFLOW)
+                };
+            };
+            if chunk_offset > i64::MAX as usize {
+                return if total_read > 0 {
+                    Ok(total_read)
+                } else {
+                    Err(SystemError::EINVAL)
+                };
+            }
+            let read_in = FuseReadIn {
+                fh,
+                offset: chunk_offset as u64,
+                size: chunk as u32,
+                read_flags: 0,
+                lock_owner: 0,
+                flags: file_flags,
+                padding: 0,
+            };
+            let payload =
+                match self
+                    .conn()
+                    .request(FUSE_READ, self.nodeid, fuse_pack_struct(&read_in))
+                {
+                    Ok(payload) => payload,
+                    Err(_) if total_read > 0 => return Ok(total_read),
+                    Err(err) => return Err(err),
+                };
+            if payload.len() > chunk {
+                return if total_read > 0 {
+                    Ok(total_read)
+                } else {
+                    Err(SystemError::EIO)
+                };
+            }
+            let n = payload.len();
+            buf[total_read..total_read + n].copy_from_slice(&payload);
+            total_read += n;
+            if n < chunk {
+                break;
+            }
+        }
+
+        Ok(total_read)
+    }
+
+    fn read_page_with_open(
+        &self,
+        page_index: usize,
+        page_buf: &mut [u8],
+        fh: u64,
+        file_flags: u32,
+    ) -> Result<usize, SystemError> {
+        page_buf.fill(0);
+        self.read_direct_with_open(
+            page_index
+                .checked_mul(MMArch::PAGE_SIZE)
+                .ok_or(SystemError::EOVERFLOW)?,
+            MMArch::PAGE_SIZE,
+            page_buf,
+            fh,
+            file_flags,
+        )
+    }
+
+    fn read_cached_with_open(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        fh: u64,
+        file_flags: u32,
+    ) -> Result<usize, SystemError> {
+        let md = self.cached_or_fetch_metadata()?;
+        let file_size = md.size.max(0) as usize;
+        if offset >= file_size || len == 0 {
+            return Ok(0);
+        }
+
+        let read_len = core::cmp::min(len, file_size - offset);
+        let start_page_index = offset >> MMArch::PAGE_SHIFT;
+        let end_page_index = (offset + read_len - 1) >> MMArch::PAGE_SHIFT;
+        let page_cache = self.ensure_page_cache()?;
+
+        let mut dst_offset = 0usize;
+        for page_index in start_page_index..=end_page_index {
+            let page_start = page_index << MMArch::PAGE_SHIFT;
+            let page_end = page_start + MMArch::PAGE_SIZE;
+            let copy_start = core::cmp::max(offset, page_start);
+            let copy_end = core::cmp::min(offset + read_len, page_end);
+            let copy_len = copy_end.saturating_sub(copy_start);
+            if copy_len == 0 {
+                continue;
+            }
+
+            let page = page_cache
+                .manager()
+                .commit_page_with(page_index, |idx, dst| {
+                    self.read_page_with_open(idx, dst, fh, file_flags)
+                })?;
+            let page_guard = page.read();
+            let page_offset = copy_start - page_start;
+            unsafe {
+                buf[dst_offset..dst_offset + copy_len]
+                    .copy_from_slice(&page_guard.as_slice()[page_offset..page_offset + copy_len]);
+            }
+            dst_offset += copy_len;
+        }
+
+        Ok(dst_offset)
+    }
+
+    pub(crate) fn fault_page_with_open(
+        &self,
+        page_index: usize,
+        fh: u64,
+        file_flags: u32,
+    ) -> Result<Arc<crate::mm::page::Page>, SystemError> {
+        let md = self.cached_or_fetch_metadata()?;
+        let file_size = md.size.max(0) as usize;
+        if file_size == 0 || page_index.saturating_mul(MMArch::PAGE_SIZE) >= file_size {
+            return Err(SystemError::EINVAL);
+        }
+        let page_cache = self.ensure_page_cache()?;
+        page_cache
+            .manager()
+            .commit_page_with(page_index, |idx, dst| {
+                self.read_page_with_open(idx, dst, fh, file_flags)
+            })
+    }
+
+    fn update_cached_pages_after_write(&self, offset: usize, data: &[u8]) {
+        if data.is_empty() {
+            return;
+        }
+        let Some(page_cache) = self.cached_page_cache() else {
+            return;
+        };
+
+        let start_page_index = offset >> MMArch::PAGE_SHIFT;
+        let end_page_index = (offset + data.len() - 1) >> MMArch::PAGE_SHIFT;
+        for page_index in start_page_index..=end_page_index {
+            let Some(page) = page_cache.manager().peek_page(page_index) else {
+                continue;
+            };
+            let page_start = page_index << MMArch::PAGE_SHIFT;
+            let page_end = page_start + MMArch::PAGE_SIZE;
+            let write_start = core::cmp::max(offset, page_start);
+            let write_end = core::cmp::min(offset + data.len(), page_end);
+            let write_len = write_end.saturating_sub(write_start);
+            if write_len == 0 {
+                continue;
+            }
+
+            let mut guard = page.write();
+            let flags = guard.flags();
+            if flags.intersects(PageFlags::PG_DIRTY | PageFlags::PG_WRITEBACK) {
+                continue;
+            }
+            let src_offset = write_start - offset;
+            let page_offset = write_start - page_start;
+            unsafe {
+                guard.as_slice_mut()[page_offset..page_offset + write_len]
+                    .copy_from_slice(&data[src_offset..src_offset + write_len]);
+            }
+            guard.add_flags(PageFlags::PG_UPTODATE);
+        }
+
+        let end = offset.saturating_add(data.len());
+        if let Some(md) = self.cached_metadata.lock().as_mut() {
+            if end > md.size.max(0) as usize {
+                md.size = end as i64;
+            }
+        }
+    }
 }
 
 impl IndexNode for FuseNode {
@@ -608,7 +852,8 @@ impl IndexNode for FuseNode {
         let _ = (start, len, offset);
         self.check_not_stale()?;
         self.ensure_regular()?;
-        Err(SystemError::ENODEV)
+        self.ensure_page_cache()?;
+        Ok(())
     }
 
     fn open(
@@ -686,64 +931,14 @@ impl IndexNode for FuseNode {
             return Ok(n);
         }
         self.ensure_regular()?;
-        let fh = self.resolve_file_fh(&data)?;
-        let file_flags = Self::fuse_file_flags(&data)?;
-        let max_read = self.conn().max_read();
-        if max_read == 0 {
-            return Err(SystemError::EIO);
+        let (fh, file_flags, fopen_flags) = Self::fuse_file_snapshot(&data)?;
+        drop(data);
+
+        if (fopen_flags & FOPEN_DIRECT_IO) != 0 || (file_flags & FileFlags::O_DIRECT.bits()) != 0 {
+            return self.read_direct_with_open(offset, len, buf, fh, file_flags);
         }
 
-        let mut total_read = 0usize;
-        while total_read < len {
-            let chunk = core::cmp::min(max_read, len - total_read);
-            let Some(chunk_offset) = offset.checked_add(total_read) else {
-                return if total_read > 0 {
-                    Ok(total_read)
-                } else {
-                    Err(SystemError::EOVERFLOW)
-                };
-            };
-            if chunk_offset > i64::MAX as usize {
-                return if total_read > 0 {
-                    Ok(total_read)
-                } else {
-                    Err(SystemError::EINVAL)
-                };
-            }
-            let read_in = FuseReadIn {
-                fh,
-                offset: chunk_offset as u64,
-                size: chunk as u32,
-                read_flags: 0,
-                lock_owner: 0,
-                flags: file_flags,
-                padding: 0,
-            };
-            let payload =
-                match self
-                    .conn()
-                    .request(FUSE_READ, self.nodeid, fuse_pack_struct(&read_in))
-                {
-                    Ok(payload) => payload,
-                    Err(_) if total_read > 0 => return Ok(total_read),
-                    Err(err) => return Err(err),
-                };
-            if payload.len() > chunk {
-                return if total_read > 0 {
-                    Ok(total_read)
-                } else {
-                    Err(SystemError::EIO)
-                };
-            }
-            let n = payload.len();
-            buf[total_read..total_read + n].copy_from_slice(&payload);
-            total_read += n;
-            if n < chunk {
-                break;
-            }
-        }
-
-        Ok(total_read)
+        self.read_cached_with_open(offset, len, buf, fh, file_flags)
     }
 
     fn write_at(
@@ -783,7 +978,18 @@ impl IndexNode for FuseNode {
             payload_in.extend_from_slice(&buf[total_written..total_written + chunk]);
             let payload = self.conn().request(FUSE_WRITE, self.nodeid, &payload_in)?;
             let out: FuseWriteOut = fuse_read_struct(&payload)?;
-            let wrote = core::cmp::min(out.size as usize, chunk);
+            if out.size as usize > chunk {
+                return if total_written > 0 {
+                    Ok(total_written)
+                } else {
+                    Err(SystemError::EIO)
+                };
+            }
+            let wrote = out.size as usize;
+            self.update_cached_pages_after_write(
+                chunk_offset,
+                &buf[total_written..total_written + wrote],
+            );
             total_written += wrote;
             if wrote < chunk {
                 break;
@@ -904,7 +1110,7 @@ impl IndexNode for FuseNode {
     }
 
     fn page_cache(&self) -> Option<Arc<PageCache>> {
-        None
+        self.cached_page_cache()
     }
 
     fn sync_file(

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -40,13 +40,13 @@ use super::{
         FuseDirent, FuseDirentPlus, FuseEntryOut, FuseFlushIn, FuseFsyncIn, FuseGetattrIn,
         FuseLinkIn, FuseMkdirIn, FuseMknodIn, FuseOpenIn, FuseOpenOut, FuseReadIn, FuseReleaseIn,
         FuseRename2In, FuseRenameIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut, FATTR_ATIME,
-        FATTR_CTIME, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_SIZE, FATTR_UID, FOPEN_DIRECT_IO,
-        FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FOPEN_NONSEEKABLE, FOPEN_STREAM, FUSE_ACCESS, FUSE_CREATE,
-        FUSE_FLUSH, FUSE_FSYNC, FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK,
-        FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR,
-        FUSE_READDIRPLUS, FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2,
-        FUSE_RMDIR, FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE,
-        FUSE_WRITE_CACHE,
+        FATTR_CTIME, FATTR_FH, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_SIZE, FATTR_UID,
+        FOPEN_DIRECT_IO, FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FOPEN_NONSEEKABLE, FOPEN_STREAM,
+        FUSE_ACCESS, FUSE_CREATE, FUSE_FLUSH, FUSE_FSYNC, FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC,
+        FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR,
+        FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS, FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR,
+        FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK,
+        FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
     },
 };
 
@@ -268,6 +268,41 @@ impl FuseNode {
         if let Some(cache) = self.cached_page_cache() {
             cache.truncate(new_size)?;
         }
+        Ok(())
+    }
+
+    fn setattr_size(&self, len: usize, fh: Option<u64>) -> Result<(), SystemError> {
+        self.check_not_stale()?;
+        let mut valid = FATTR_SIZE;
+        if fh.is_some() {
+            valid |= FATTR_FH;
+        }
+        let inarg = FuseSetattrIn {
+            valid,
+            padding: 0,
+            fh: fh.unwrap_or(0),
+            size: len as u64,
+            lock_owner: 0,
+            atime: 0,
+            mtime: 0,
+            ctime: 0,
+            atimensec: 0,
+            mtimensec: 0,
+            ctimensec: 0,
+            mode: 0,
+            unused4: 0,
+            uid: 0,
+            gid: 0,
+            unused5: 0,
+        };
+        let payload = self
+            .conn()
+            .request(FUSE_SETATTR, self.nodeid, fuse_pack_struct(&inarg))?;
+        let out: FuseAttrOut = fuse_read_struct(&payload)?;
+        let md = Self::attr_to_metadata(&out.attr);
+        let new_size = md.size.max(0) as usize;
+        self.set_cached_metadata_with_valid(md, out.attr_valid, out.attr_valid_nsec);
+        self.truncate_page_cache(new_size)?;
         Ok(())
     }
 
@@ -1486,34 +1521,27 @@ impl IndexNode for FuseNode {
     }
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
-        self.check_not_stale()?;
-        let inarg = FuseSetattrIn {
-            valid: FATTR_SIZE,
-            padding: 0,
-            fh: 0,
-            size: len as u64,
-            lock_owner: 0,
-            atime: 0,
-            mtime: 0,
-            ctime: 0,
-            atimensec: 0,
-            mtimensec: 0,
-            ctimensec: 0,
-            mode: 0,
-            unused4: 0,
-            uid: 0,
-            gid: 0,
-            unused5: 0,
+        self.setattr_size(len, None)
+    }
+
+    fn resize_file(
+        &self,
+        len: usize,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        let fuse_data = match &*data {
+            FilePrivateData::Fuse(data) => data.clone(),
+            _ => {
+                drop(data);
+                return self.resize(len);
+            }
         };
-        let payload = self
-            .conn()
-            .request(FUSE_SETATTR, self.nodeid, fuse_pack_struct(&inarg))?;
-        let out: FuseAttrOut = fuse_read_struct(&payload)?;
-        let md = Self::attr_to_metadata(&out.attr);
-        let new_size = md.size.max(0) as usize;
-        self.set_cached_metadata_with_valid(md, out.attr_valid, out.attr_valid_nsec);
-        self.truncate_page_cache(new_size)?;
-        Ok(())
+        drop(data);
+
+        match fuse_data {
+            FuseFilePrivateData::File(p) => self.setattr_size(len, Some(p.fh)),
+            _ => self.resize(len),
+        }
     }
 
     fn sync(&self) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -15,7 +15,10 @@ use crate::{
     filesystem::{
         page_cache::{PageCache, PageCacheBackend},
         vfs::{
-            file::FileFlags, permission::PermissionMask, syscall::RenameFlags, utils::DName,
+            file::{FileFlags, FileMode},
+            permission::PermissionMask,
+            syscall::RenameFlags,
+            utils::DName,
             FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags, InodeId, InodeMode,
             Metadata,
         },
@@ -38,11 +41,12 @@ use super::{
         FuseLinkIn, FuseMkdirIn, FuseMknodIn, FuseOpenIn, FuseOpenOut, FuseReadIn, FuseReleaseIn,
         FuseRename2In, FuseRenameIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut, FATTR_ATIME,
         FATTR_CTIME, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_SIZE, FATTR_UID, FOPEN_DIRECT_IO,
-        FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FUSE_ACCESS, FUSE_CREATE, FUSE_FLUSH, FUSE_FSYNC,
-        FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR,
-        FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS,
-        FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR,
-        FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
+        FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FOPEN_NONSEEKABLE, FOPEN_STREAM, FUSE_ACCESS, FUSE_CREATE,
+        FUSE_FLUSH, FUSE_FSYNC, FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK,
+        FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR,
+        FUSE_READDIRPLUS, FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2,
+        FUSE_RMDIR, FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE,
+        FUSE_WRITE_CACHE,
     },
 };
 
@@ -1223,6 +1227,26 @@ impl IndexNode for FuseNode {
             FileType::Dir => self.open_common(FUSE_OPENDIR, &mut data, flags),
             FileType::File => self.open_common(FUSE_OPEN, &mut data, flags),
             _ => Err(SystemError::EINVAL),
+        }
+    }
+
+    fn adjust_file_mode_after_open(&self, data: &FilePrivateData, mode: &mut FileMode) {
+        let fopen_flags = match data {
+            FilePrivateData::Fuse(FuseFilePrivateData::File(p))
+            | FilePrivateData::Fuse(FuseFilePrivateData::Dir(p)) => p.fopen_flags,
+            _ => return,
+        };
+
+        if (fopen_flags & FOPEN_STREAM) != 0 {
+            mode.remove(
+                FileMode::FMODE_LSEEK
+                    | FileMode::FMODE_PREAD
+                    | FileMode::FMODE_PWRITE
+                    | FileMode::FMODE_ATOMIC_POS,
+            );
+            mode.insert(FileMode::FMODE_STREAM);
+        } else if (fopen_flags & FOPEN_NONSEEKABLE) != 0 {
+            mode.remove(FileMode::FMODE_LSEEK | FileMode::FMODE_PREAD | FileMode::FMODE_PWRITE);
         }
     }
 

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -4,16 +4,19 @@ use alloc::{
     vec::Vec,
 };
 use core::mem::size_of;
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 use system_error::SystemError;
 
 use crate::time::timekeep::ktime_get_real_ns;
 use crate::{
     driver::base::device::device_number::DeviceNumber,
-    filesystem::vfs::{
-        file::FileFlags, permission::PermissionMask, syscall::RenameFlags, FilePrivateData,
-        FileSystem, FileType, IndexNode, InodeFlags, InodeId, InodeMode, Metadata,
+    filesystem::{
+        page_cache::{AsyncPageCacheBackend, PageCache},
+        vfs::{
+            file::FileFlags, permission::PermissionMask, syscall::RenameFlags, FilePrivateData,
+            FileSystem, FileType, IndexNode, InodeFlags, InodeId, InodeMode, Metadata,
+        },
     },
     libs::mutex::{Mutex, MutexGuard},
     time::PosixTimeSpec,
@@ -41,11 +44,18 @@ use super::{
 pub struct FuseNode {
     fs: Weak<FuseFS>,
     conn: Arc<FuseConn>,
+    self_ref: Weak<FuseNode>,
     nodeid: u64,
     parent_nodeid: Mutex<u64>,
     cached_metadata: Mutex<Option<Metadata>>,
+    page_cache: Mutex<Option<Arc<PageCache>>>,
     cached_metadata_deadline_ns: AtomicU64,
     lookup_count: AtomicU64,
+    /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
+    lookup_attr_flags: AtomicU32,
+    /// LOOKUP 返回的 generation，用于检测 virtiofsd 复用 nodeid。
+    generation: AtomicU64,
+    stale: AtomicBool,
 }
 
 impl FuseNode {
@@ -59,15 +69,43 @@ impl FuseNode {
         cached: Option<Metadata>,
     ) -> Arc<Self> {
         let has_cached = cached.is_some();
-        Arc::new(Self {
+        Arc::new_cyclic(|self_ref| Self {
             fs,
             conn,
+            self_ref: self_ref.clone(),
             nodeid,
             parent_nodeid: Mutex::new(parent_nodeid),
             cached_metadata: Mutex::new(cached),
+            page_cache: Mutex::new(None),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             lookup_count: AtomicU64::new(0),
+            lookup_attr_flags: AtomicU32::new(0),
+            generation: AtomicU64::new(0),
+            stale: AtomicBool::new(false),
         })
+    }
+
+    pub fn lookup_attr_flags(&self) -> u32 {
+        self.lookup_attr_flags.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn set_generation(&self, gen: u64) {
+        self.generation.store(gen, Ordering::Relaxed);
+    }
+
+    pub(crate) fn mark_stale(&self) {
+        self.stale.store(true, Ordering::Release);
+    }
+
+    fn check_not_stale(&self) -> Result<(), SystemError> {
+        if self.stale.load(Ordering::Acquire) {
+            return Err(SystemError::ESTALE);
+        }
+        Ok(())
     }
 
     pub fn nodeid(&self) -> u64 {
@@ -90,6 +128,11 @@ impl FuseNode {
             .store(Self::cache_deadline(valid, valid_nsec), Ordering::Relaxed);
     }
 
+    /// 累计该 inode 在 userspace daemon 侧持有的 LOOKUP 引用。
+    ///
+    /// 对齐 Linux：每个成功的 LOOKUP/READDIRPLUS entry 都必须被记账，并在 inode
+    /// 释放或卸载时用对应的 `FUSE_FORGET(nlookup=...)` 归还。打开的文件句柄会在
+    /// `FuseOpenPrivateData` 中持有 `Arc<FuseNode>`，避免 fd 存活期间过早 FORGET。
     pub fn inc_lookup(&self, count: u64) {
         if self.nodeid == FUSE_ROOT_ID || count == 0 {
             return;
@@ -122,11 +165,20 @@ impl FuseNode {
         Self::now_ns().saturating_add(delta_ns)
     }
 
-    fn conn(&self) -> &Arc<FuseConn> {
+    pub(crate) fn conn(&self) -> &Arc<FuseConn> {
         &self.conn
     }
 
+    pub(crate) fn fuse_fs(&self) -> Option<Arc<FuseFS>> {
+        self.fs.upgrade()
+    }
+
+    pub(crate) fn parent_fuse_nodeid(&self) -> u64 {
+        *self.parent_nodeid.lock()
+    }
+
     fn request_name(&self, opcode: u32, nodeid: u64, name: &str) -> Result<Vec<u8>, SystemError> {
+        self.check_not_stale()?;
         let payload = Self::pack_name_payload(name);
         self.conn().request(opcode, nodeid, &payload)
     }
@@ -155,6 +207,27 @@ impl FuseNode {
         payload
     }
 
+    /// Linux `fuse_send_open()` forwards file flags except creation-only bits.
+    fn fuse_open_in_flags(&self, raw: u32) -> u32 {
+        let mut flags = raw
+            & !(FileFlags::O_CREAT.bits() | FileFlags::O_EXCL.bits() | FileFlags::O_NOCTTY.bits());
+        if !self
+            .conn
+            .has_init_flag(super::protocol::FUSE_ATOMIC_O_TRUNC)
+        {
+            flags &= !FileFlags::O_TRUNC.bits();
+        }
+        flags
+    }
+
+    fn fuse_file_flags(data: &FilePrivateData) -> Result<u32, SystemError> {
+        match data {
+            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => Ok(p.open_flags),
+            FilePrivateData::Fuse(FuseFilePrivateData::Dir(p)) => Ok(p.open_flags),
+            _ => Err(SystemError::EBADF),
+        }
+    }
+
     fn set_open_private_data(
         &self,
         data: &mut FilePrivateData,
@@ -164,15 +237,18 @@ impl FuseNode {
         no_open: bool,
     ) -> Result<(), SystemError> {
         let conn_any: Arc<dyn core::any::Any + Send + Sync> = self.conn.clone();
+        let node = self.self_ref.upgrade().ok_or(SystemError::EIO)?;
         *data = match opcode {
             FUSE_OPEN => FilePrivateData::Fuse(FuseFilePrivateData::File(FuseOpenPrivateData {
                 conn: conn_any,
+                node: node.clone(),
                 fh,
                 open_flags,
                 no_open,
             })),
             FUSE_OPENDIR => FilePrivateData::Fuse(FuseFilePrivateData::Dir(FuseOpenPrivateData {
                 conn: conn_any,
+                node,
                 fh,
                 open_flags,
                 no_open,
@@ -310,6 +386,7 @@ impl FuseNode {
     }
 
     fn fetch_attr(&self) -> Result<Metadata, SystemError> {
+        self.check_not_stale()?;
         let getattr_in = FuseGetattrIn {
             getattr_flags: 0,
             dummy: 0,
@@ -341,12 +418,15 @@ impl FuseNode {
         data: &mut FilePrivateData,
         flags: &FileFlags,
     ) -> Result<(), SystemError> {
+        self.check_not_stale()?;
+        let file_flags = flags.bits();
         if self.conn.should_skip_open(opcode) {
-            return self.set_open_private_data(data, opcode, 0, flags.bits(), true);
+            return self.set_open_private_data(data, opcode, 0, file_flags, true);
         }
 
+        let fuse_open_flags = self.fuse_open_in_flags(file_flags);
         let open_in = FuseOpenIn {
-            flags: flags.bits(),
+            flags: fuse_open_flags,
             open_flags: 0,
         };
         let payload = match self
@@ -356,18 +436,18 @@ impl FuseNode {
             Ok(v) => v,
             Err(SystemError::ENOSYS) if self.conn.open_enosys_is_supported(opcode) => {
                 self.conn.mark_no_open(opcode);
-                return self.set_open_private_data(data, opcode, 0, open_in.flags, true);
+                return self.set_open_private_data(data, opcode, 0, file_flags, true);
             }
             Err(e) => return Err(e),
         };
         let out: FuseOpenOut = fuse_read_struct(&payload)?;
-        self.set_open_private_data(data, opcode, out.fh, open_in.flags, false)
+        self.set_open_private_data(data, opcode, out.fh, file_flags, false)
     }
 
-    fn release_common(&self, opcode: u32, fh: u64, open_flags: u32) -> Result<(), SystemError> {
+    fn release_common(&self, opcode: u32, fh: u64, file_flags: u32) -> Result<(), SystemError> {
         let inarg = FuseReleaseIn {
             fh,
-            flags: open_flags,
+            flags: file_flags,
             release_flags: 0,
             lock_owner: 0,
         };
@@ -393,7 +473,76 @@ impl FuseNode {
         Ok(())
     }
 
+    fn ensure_page_cache(&self) -> Option<Arc<PageCache>> {
+        let md = self.cached_or_fetch_metadata().ok()?;
+        if md.file_type != FileType::File {
+            return None;
+        }
+
+        let mut guard = self.page_cache.lock();
+        if let Some(cache) = guard.clone() {
+            return Some(cache);
+        }
+
+        let inode = self.self_ref.upgrade()? as Arc<dyn IndexNode>;
+        let backend = Arc::new(AsyncPageCacheBackend::new(Arc::downgrade(&inode)));
+        let cache = PageCache::new(Some(Arc::downgrade(&inode)), Some(backend));
+        *guard = Some(cache.clone());
+        Some(cache)
+    }
+
+    fn read_with_temp_open(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let private = Mutex::new(FilePrivateData::Unused);
+        {
+            let mut data = private.lock();
+            self.open_common(FUSE_OPEN, &mut data, &FileFlags::O_RDONLY)?;
+        }
+
+        let result = self.read_at(offset, buf.len(), buf, private.lock());
+        let close_result = self.close(private.lock());
+        match result {
+            Ok(n) => {
+                if let Err(e) = close_result {
+                    log::warn!("fuse temporary close after successful read failed: {:?}", e);
+                }
+                Ok(n)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn write_with_temp_open(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
+        let private = Mutex::new(FilePrivateData::Unused);
+        {
+            let mut data = private.lock();
+            self.open_common(FUSE_OPEN, &mut data, &FileFlags::O_WRONLY)?;
+        }
+
+        let result = self.write_at(offset, buf.len(), buf, private.lock());
+        let close_result = self.close(private.lock());
+        match result {
+            Ok(n) => {
+                if let Err(e) = close_result {
+                    log::warn!(
+                        "fuse temporary close after successful write failed: {:?}",
+                        e
+                    );
+                }
+                Ok(n)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn resolve_file_fh(&self, data: &FilePrivateData) -> Result<u64, SystemError> {
+        let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = data else {
+            return Err(SystemError::EBADF);
+        };
+        Ok(p.fh)
+    }
+
     fn fsync_common(&self, datasync: bool) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         let md = self.cached_or_fetch_metadata()?;
         let opcode = match md.file_type {
             FileType::File => FUSE_FSYNC,
@@ -416,16 +565,12 @@ impl FuseNode {
         datasync: bool,
         data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let (opcode, fh, no_open) = match data {
-            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => (FUSE_FSYNC, p.fh, p.no_open),
-            FilePrivateData::Fuse(FuseFilePrivateData::Dir(p)) => (FUSE_FSYNCDIR, p.fh, p.no_open),
+        self.check_not_stale()?;
+        let (opcode, fh) = match data {
+            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => (FUSE_FSYNC, p.fh),
+            FilePrivateData::Fuse(FuseFilePrivateData::Dir(p)) => (FUSE_FSYNCDIR, p.fh),
             _ => return self.fsync_common(datasync),
         };
-
-        // Linux 对 no_open/no_opendir 语义允许缺省 open，fh 不可靠，直接成功返回。
-        if no_open {
-            return Ok(());
-        }
 
         let inarg = FuseFsyncIn {
             fh,
@@ -453,6 +598,7 @@ impl FuseNode {
         &self,
         entry: &FuseEntryOut,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        self.check_not_stale()?;
         let md = Self::attr_to_metadata(&entry.attr);
         let fs = self.fs.upgrade().ok_or(SystemError::ENOENT)?;
         let child = fs.get_or_create_node(entry.nodeid, self.nodeid, Some(md));
@@ -471,11 +617,24 @@ impl IndexNode for FuseNode {
         self
     }
 
+    fn read_sync(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
+        self.check_not_stale()?;
+        self.ensure_regular()?;
+        self.read_with_temp_open(offset, buf)
+    }
+
+    fn write_sync(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
+        self.check_not_stale()?;
+        self.ensure_regular()?;
+        self.write_with_temp_open(offset, buf)
+    }
+
     fn open(
         &self,
         mut data: MutexGuard<FilePrivateData>,
         flags: &FileFlags,
     ) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         let md = self.cached_or_fetch_metadata()?;
         match md.file_type {
             FileType::Dir => self.open_common(FUSE_OPENDIR, &mut data, flags),
@@ -530,6 +689,7 @@ impl IndexNode for FuseNode {
         buf: &mut [u8],
         data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
+        self.check_not_stale()?;
         if buf.len() < len {
             return Err(SystemError::EINVAL);
         }
@@ -544,22 +704,22 @@ impl IndexNode for FuseNode {
             return Ok(n);
         }
         self.ensure_regular()?;
-        let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
-            return Err(SystemError::EBADF);
-        };
+        let fh = self.resolve_file_fh(&data)?;
+        let file_flags = Self::fuse_file_flags(&data)?;
+        let read_len = core::cmp::min(len, self.conn().max_write());
         let read_in = FuseReadIn {
-            fh: p.fh,
+            fh,
             offset: offset as u64,
-            size: len as u32,
+            size: read_len as u32,
             read_flags: 0,
             lock_owner: 0,
-            flags: 0,
+            flags: file_flags,
             padding: 0,
         };
         let payload = self
             .conn()
             .request(FUSE_READ, self.nodeid, fuse_pack_struct(&read_in))?;
-        let n = core::cmp::min(payload.len(), len);
+        let n = core::cmp::min(payload.len(), read_len);
         buf[..n].copy_from_slice(&payload[..n]);
         Ok(n)
     }
@@ -571,13 +731,13 @@ impl IndexNode for FuseNode {
         buf: &[u8],
         data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
+        self.check_not_stale()?;
         self.ensure_regular()?;
         if buf.len() < len {
             return Err(SystemError::EINVAL);
         }
-        let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
-            return Err(SystemError::EBADF);
-        };
+        let fh = self.resolve_file_fh(&data)?;
+        let file_flags = Self::fuse_file_flags(&data)?;
         let max_write = self.conn().max_write();
         let mut total_written = 0usize;
 
@@ -588,12 +748,12 @@ impl IndexNode for FuseNode {
                 .ok_or(SystemError::EOVERFLOW)?;
 
             let write_in = FuseWriteIn {
-                fh: p.fh,
+                fh,
                 offset: chunk_offset as u64,
                 size: chunk as u32,
                 write_flags: 0,
                 lock_owner: 0,
-                flags: 0,
+                flags: file_flags,
                 padding: 0,
             };
             let mut payload_in = Vec::with_capacity(size_of::<FuseWriteIn>() + chunk);
@@ -612,10 +772,12 @@ impl IndexNode for FuseNode {
     }
 
     fn metadata(&self) -> Result<Metadata, SystemError> {
+        self.check_not_stale()?;
         self.cached_or_fetch_metadata()
     }
 
     fn check_access(&self, mask: PermissionMask) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         let inarg = FuseAccessIn {
             mask: mask.bits() & PermissionMask::MAY_RWX.bits(),
             padding: 0,
@@ -627,6 +789,7 @@ impl IndexNode for FuseNode {
     }
 
     fn set_metadata(&self, metadata: &Metadata) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         let old = self.cached_or_fetch_metadata()?;
         let mut valid = 0u32;
         if metadata.mode != old.mode {
@@ -682,6 +845,7 @@ impl IndexNode for FuseNode {
     }
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         let inarg = FuseSetattrIn {
             valid: FATTR_SIZE,
             padding: 0,
@@ -717,6 +881,13 @@ impl IndexNode for FuseNode {
         self.fsync_common(true)
     }
 
+    fn page_cache(&self) -> Option<Arc<PageCache>> {
+        if self.check_not_stale().is_err() {
+            return None;
+        }
+        self.ensure_page_cache()
+    }
+
     fn sync_file(
         &self,
         datasync: bool,
@@ -730,6 +901,7 @@ impl IndexNode for FuseNode {
     }
 
     fn list(&self) -> Result<Vec<String>, SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
 
         // OPENDIR
@@ -753,7 +925,7 @@ impl IndexNode for FuseNode {
                 size: 64 * 1024,
                 read_flags: 0,
                 lock_owner: 0,
-                flags: 0,
+                flags: open_flags,
                 padding: 0,
             };
             let opcode = if use_readdirplus {
@@ -799,6 +971,7 @@ impl IndexNode for FuseNode {
     }
 
     fn find(&self, name: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
         if name == "." {
             let fs = self.fs.upgrade().ok_or(SystemError::ENOENT)?;
@@ -813,7 +986,15 @@ impl IndexNode for FuseNode {
         let md = Self::attr_to_metadata(&entry.attr);
 
         let fs = self.fs.upgrade().ok_or(SystemError::ENOENT)?;
-        let child = fs.get_or_create_node(entry.nodeid, self.nodeid, Some(md));
+        let child = fs.get_or_create_node_with_generation(
+            entry.nodeid,
+            self.nodeid,
+            Some(md),
+            Some(entry.generation),
+        );
+        child
+            .lookup_attr_flags
+            .store(entry.attr.flags, Ordering::Relaxed);
         child.inc_lookup(1);
         child.set_cached_metadata_with_valid(
             Self::attr_to_metadata(&entry.attr),
@@ -838,6 +1019,7 @@ impl IndexNode for FuseNode {
         file_type: FileType,
         mode: InodeMode,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
         if file_type != FileType::File {
             return self.create_with_data(name, file_type, mode, 0);
@@ -867,6 +1049,7 @@ impl IndexNode for FuseNode {
         mode: InodeMode,
         _data: usize,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
 
         match file_type {
@@ -908,6 +1091,7 @@ impl IndexNode for FuseNode {
     }
 
     fn symlink(&self, name: &str, target: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
         let payload_in = Self::pack_two_names_payload(target, name);
         let payload = self
@@ -918,6 +1102,7 @@ impl IndexNode for FuseNode {
     }
 
     fn link(&self, name: &str, other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
         let target = other
             .as_any_ref()
@@ -933,12 +1118,14 @@ impl IndexNode for FuseNode {
     }
 
     fn unlink(&self, name: &str) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
         let _ = self.request_name(FUSE_UNLINK, self.nodeid, name)?;
         Ok(())
     }
 
     fn rmdir(&self, name: &str) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
         let _ = self.request_name(FUSE_RMDIR, self.nodeid, name)?;
         Ok(())
@@ -951,6 +1138,7 @@ impl IndexNode for FuseNode {
         new_name: &str,
         flag: RenameFlags,
     ) -> Result<(), SystemError> {
+        self.check_not_stale()?;
         self.ensure_dir()?;
         let target_any = target
             .as_any_ref()

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -37,16 +37,16 @@ use super::{
     private_data::{FuseFilePrivateData, FuseOpenPrivateData, FuseWritebackHandle},
     protocol::{
         fuse_pack_struct, fuse_read_struct, FuseAccessIn, FuseAttr, FuseAttrOut, FuseCreateIn,
-        FuseDirent, FuseDirentPlus, FuseEntryOut, FuseFlushIn, FuseFsyncIn, FuseGetattrIn,
-        FuseLinkIn, FuseMkdirIn, FuseMknodIn, FuseOpenIn, FuseOpenOut, FuseReadIn, FuseReleaseIn,
-        FuseRename2In, FuseRenameIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut, FATTR_ATIME,
-        FATTR_CTIME, FATTR_FH, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_SIZE, FATTR_UID,
-        FOPEN_DIRECT_IO, FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FOPEN_NONSEEKABLE, FOPEN_STREAM,
-        FUSE_ACCESS, FUSE_CREATE, FUSE_FLUSH, FUSE_FSYNC, FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC,
-        FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR,
-        FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS, FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR,
-        FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK,
-        FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
+        FuseDirent, FuseDirentPlus, FuseEntryOut, FuseFallocateIn, FuseFlushIn, FuseFsyncIn,
+        FuseGetattrIn, FuseLinkIn, FuseMkdirIn, FuseMknodIn, FuseOpenIn, FuseOpenOut, FuseReadIn,
+        FuseReleaseIn, FuseRename2In, FuseRenameIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut,
+        FATTR_ATIME, FATTR_CTIME, FATTR_FH, FATTR_GID, FATTR_LOCKOWNER, FATTR_MODE, FATTR_MTIME,
+        FATTR_SIZE, FATTR_UID, FOPEN_DIRECT_IO, FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FOPEN_NONSEEKABLE,
+        FOPEN_STREAM, FUSE_ACCESS, FUSE_CREATE, FUSE_FALLOCATE, FUSE_FLUSH, FUSE_FSYNC,
+        FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR,
+        FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS,
+        FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR,
+        FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
     },
 };
 
@@ -271,9 +271,17 @@ impl FuseNode {
         Ok(())
     }
 
-    fn setattr_size(&self, len: usize, fh: Option<u64>) -> Result<(), SystemError> {
+    fn setattr_size(
+        &self,
+        len: usize,
+        lock_owner: Option<u64>,
+        fh: Option<u64>,
+    ) -> Result<(), SystemError> {
         self.check_not_stale()?;
         let mut valid = FATTR_SIZE;
+        if lock_owner.is_some() {
+            valid |= FATTR_LOCKOWNER;
+        }
         if fh.is_some() {
             valid |= FATTR_FH;
         }
@@ -282,7 +290,7 @@ impl FuseNode {
             padding: 0,
             fh: fh.unwrap_or(0),
             size: len as u64,
-            lock_owner: 0,
+            lock_owner: lock_owner.unwrap_or(0),
             atime: 0,
             mtime: 0,
             ctime: 0,
@@ -1521,26 +1529,87 @@ impl IndexNode for FuseNode {
     }
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
-        self.setattr_size(len, None)
+        self.setattr_size(len, None, None)
+    }
+
+    fn resize_with_lock_owner(&self, len: usize, lock_owner: u64) -> Result<(), SystemError> {
+        self.setattr_size(len, Some(lock_owner), None)
     }
 
     fn resize_file(
         &self,
         len: usize,
+        lock_owner: u64,
         data: MutexGuard<FilePrivateData>,
     ) -> Result<(), SystemError> {
         let fuse_data = match &*data {
             FilePrivateData::Fuse(data) => data.clone(),
             _ => {
                 drop(data);
-                return self.resize(len);
+                return self.resize_with_lock_owner(len, lock_owner);
             }
         };
         drop(data);
 
         match fuse_data {
-            FuseFilePrivateData::File(p) => self.setattr_size(len, Some(p.fh)),
-            _ => self.resize(len),
+            FuseFilePrivateData::File(p) => self.setattr_size(len, Some(lock_owner), Some(p.fh)),
+            _ => self.resize_with_lock_owner(len, lock_owner),
+        }
+    }
+
+    fn fallocate_file(
+        &self,
+        mode: i32,
+        offset: usize,
+        len: usize,
+        _lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        if mode != 0 {
+            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        }
+        self.check_not_stale()?;
+        let new_size = offset.checked_add(len).ok_or(SystemError::EFBIG)?;
+        if self.conn().no_fallocate() {
+            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        }
+
+        let fuse_data = match &*data {
+            FilePrivateData::Fuse(FuseFilePrivateData::File(data)) => data.clone(),
+            _ => return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
+        };
+        drop(data);
+
+        let md = self.metadata()?;
+        if new_size > md.size.max(0) as usize {
+            crate::filesystem::vfs::vcore::check_file_size_limit(new_size)?;
+        }
+
+        let in_arg = FuseFallocateIn {
+            fh: fuse_data.fh,
+            offset: offset as u64,
+            length: len as u64,
+            mode: mode as u32,
+            padding: 0,
+        };
+        match self
+            .conn()
+            .request(FUSE_FALLOCATE, self.nodeid, fuse_pack_struct(&in_arg))
+        {
+            Ok(_) => {
+                if let Some(md) = self.cached_metadata.lock().as_mut() {
+                    if new_size > md.size.max(0) as usize {
+                        md.size = new_size as i64;
+                    }
+                }
+                self.cached_metadata_deadline_ns.store(0, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(SystemError::ENOSYS) => {
+                self.conn().mark_no_fallocate();
+                Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+            }
+            Err(e) => Err(e),
         }
     }
 

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -214,6 +214,13 @@ impl FuseNode {
         }
     }
 
+    fn truncate_page_cache(&self, new_size: usize) -> Result<(), SystemError> {
+        if let Some(cache) = self.cached_page_cache() {
+            cache.truncate(new_size)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn fuse_fs(&self) -> Option<Arc<FuseFS>> {
         self.fs.upgrade()
     }
@@ -1068,7 +1075,11 @@ impl IndexNode for FuseNode {
             .request(FUSE_SETATTR, self.nodeid, fuse_pack_struct(&inarg))?;
         let out: FuseAttrOut = fuse_read_struct(&payload)?;
         let md = Self::attr_to_metadata(&out.attr);
+        let new_size = md.size.max(0) as usize;
         self.set_cached_metadata_with_valid(md, out.attr_valid, out.attr_valid_nsec);
+        if (valid & FATTR_SIZE) != 0 {
+            self.truncate_page_cache(new_size)?;
+        }
         Ok(())
     }
 
@@ -1097,7 +1108,9 @@ impl IndexNode for FuseNode {
             .request(FUSE_SETATTR, self.nodeid, fuse_pack_struct(&inarg))?;
         let out: FuseAttrOut = fuse_read_struct(&payload)?;
         let md = Self::attr_to_metadata(&out.attr);
+        let new_size = md.size.max(0) as usize;
         self.set_cached_metadata_with_valid(md, out.attr_valid, out.attr_valid_nsec);
+        self.truncate_page_cache(new_size)?;
         Ok(())
     }
 

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -32,9 +32,11 @@ use crate::{
 };
 
 use super::{
-    conn::FuseConn,
+    conn::{FuseConn, FuseRequestCred},
     fs::FuseFS,
-    private_data::{FuseFilePrivateData, FuseOpenPrivateData, FuseWritebackHandle},
+    private_data::{
+        FuseFilePrivateData, FuseOpenContext, FuseOpenPrivateData, FuseWritebackHandle,
+    },
     protocol::{
         fuse_pack_struct, fuse_read_struct, FuseAccessIn, FuseAttr, FuseAttrOut, FuseCreateIn,
         FuseDirent, FuseDirentPlus, FuseEntryOut, FuseFallocateIn, FuseFlushIn, FuseFsyncIn,
@@ -45,8 +47,9 @@ use super::{
         FOPEN_STREAM, FUSE_ACCESS, FUSE_CREATE, FUSE_FALLOCATE, FUSE_FLUSH, FUSE_FSYNC,
         FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR,
         FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS,
-        FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR,
-        FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
+        FUSE_READLINK, FUSE_READ_LOCKOWNER, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME,
+        FUSE_RENAME2, FUSE_RMDIR, FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK,
+        FUSE_WRITE, FUSE_WRITE_CACHE, FUSE_WRITE_LOCKOWNER,
     },
 };
 
@@ -61,6 +64,7 @@ pub struct FuseNode {
     cached_metadata: Mutex<Option<Metadata>>,
     page_cache: Mutex<Option<Arc<PageCache>>>,
     writeback_handles: Mutex<Vec<Arc<FuseWritebackHandle>>>,
+    direct_io_lock: Mutex<()>,
     cached_metadata_deadline_ns: AtomicU64,
     lookup_count: AtomicU64,
     /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
@@ -128,6 +132,7 @@ impl FuseNode {
             cached_metadata: Mutex::new(cached),
             page_cache: Mutex::new(None),
             writeback_handles: Mutex::new(Vec::new()),
+            direct_io_lock: Mutex::new(()),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
@@ -391,11 +396,11 @@ impl FuseNode {
         flags
     }
 
-    fn fuse_file_snapshot(data: &FilePrivateData) -> Result<(u64, u32, u32), SystemError> {
+    fn fuse_file_private_snapshot(
+        data: &FilePrivateData,
+    ) -> Result<FuseOpenPrivateData, SystemError> {
         match data {
-            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => {
-                Ok((p.fh, p.open_flags, p.fopen_flags))
-            }
+            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => Ok(p.clone()),
             _ => Err(SystemError::EBADF),
         }
     }
@@ -412,6 +417,7 @@ impl FuseNode {
         fh: u64,
         fopen_flags: u32,
         no_open: bool,
+        open_context: FuseOpenContext,
     ) -> Option<Arc<FuseWritebackHandle>> {
         if !Self::open_flags_are_writable(open_flags) {
             return None;
@@ -421,6 +427,7 @@ impl FuseNode {
             open_flags,
             fopen_flags,
             no_open,
+            open_context,
         ));
         self.writeback_handles.lock().push(handle.clone());
         Some(handle)
@@ -439,6 +446,67 @@ impl FuseNode {
             page_cache.manager().sync()?;
         }
         Ok(())
+    }
+
+    fn sync_dirty_cached_pages(&self) -> Result<(), SystemError> {
+        let Some(page_cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+        if !page_cache.has_dirty_pages() {
+            return Ok(());
+        }
+        page_cache.manager().sync()
+    }
+
+    fn check_and_advance_open_wb_error(
+        &self,
+        data: &FuseOpenPrivateData,
+    ) -> Result<(), SystemError> {
+        let Some(page_cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+        let mut since = data.open_context.wb_errseq.lock();
+        match page_cache.check_and_advance_writeback_error(&mut since) {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    fn flush_open_file(
+        &self,
+        data: &FuseOpenPrivateData,
+        lock_owner: u64,
+    ) -> Result<(), SystemError> {
+        let writeback_result = if data.writeback_handle.is_some() {
+            self.sync_dirty_cached_pages()
+        } else {
+            Ok(())
+        };
+        let wb_error_result = self.check_and_advance_open_wb_error(data);
+
+        writeback_result?;
+        wb_error_result?;
+
+        if data.no_open || (data.fopen_flags & FOPEN_NOFLUSH) != 0 || self.conn().no_flush() {
+            return Ok(());
+        }
+
+        let flush_in = FuseFlushIn {
+            fh: data.fh,
+            unused: 0,
+            padding: 0,
+            lock_owner,
+        };
+        match self
+            .conn()
+            .request(FUSE_FLUSH, self.nodeid, fuse_pack_struct(&flush_in))
+        {
+            Err(SystemError::ENOSYS) => {
+                self.conn().mark_no_flush();
+                Ok(())
+            }
+            result => result.map(|_| ()),
+        }
     }
 
     pub(crate) fn pin_writeback_handle(
@@ -461,6 +529,13 @@ impl FuseNode {
         self.check_not_stale()?;
         let pin = self.pin_writeback_handle()?;
         let handle = pin.handle();
+        let current_generation = self.generation();
+        if handle.open_context.node_generation != 0
+            && current_generation != 0
+            && handle.open_context.node_generation != current_generation
+        {
+            return Err(SystemError::ESTALE);
+        }
         let max_write = self.conn().max_write();
         if max_write == 0 {
             return Err(SystemError::EIO);
@@ -471,6 +546,15 @@ impl FuseNode {
             .ok_or(SystemError::EOVERFLOW)?;
         let mut total = 0usize;
         while total < buf.len() {
+            self.check_not_stale()?;
+            let current_generation = self.generation();
+            if handle.open_context.node_generation != 0
+                && current_generation != 0
+                && handle.open_context.node_generation != current_generation
+            {
+                return Err(SystemError::ESTALE);
+            }
+
             let chunk = core::cmp::min(max_write, buf.len() - total);
             let offset = base_offset
                 .checked_add(total)
@@ -512,8 +596,24 @@ impl FuseNode {
     ) -> Result<(), SystemError> {
         let conn_any: Arc<dyn core::any::Any + Send + Sync> = self.conn.clone();
         let node = self.self_ref.upgrade().ok_or(SystemError::EIO)?;
+        let open_context = FuseOpenContext {
+            request_cred: FuseRequestCred::from_current(),
+            lock_owner: crate::filesystem::vfs::vcore::current_file_lock_owner_id(),
+            node_generation: self.generation(),
+            wb_errseq: Arc::new(Mutex::new(
+                self.cached_page_cache()
+                    .map(|page_cache| page_cache.sample_writeback_error())
+                    .unwrap_or(0),
+            )),
+        };
         let writeback_handle = if opcode == FUSE_OPEN {
-            self.register_writeback_handle(open_flags, fh, fopen_flags, no_open)
+            self.register_writeback_handle(
+                open_flags,
+                fh,
+                fopen_flags,
+                no_open,
+                open_context.clone(),
+            )
         } else {
             None
         };
@@ -525,6 +625,7 @@ impl FuseNode {
                 open_flags,
                 fopen_flags,
                 no_open,
+                open_context,
                 writeback_handle,
             })),
             FUSE_OPENDIR => FilePrivateData::Fuse(FuseFilePrivateData::Dir(FuseOpenPrivateData {
@@ -534,6 +635,7 @@ impl FuseNode {
                 open_flags,
                 fopen_flags,
                 no_open,
+                open_context,
                 writeback_handle: None,
             })),
             _ => return Err(SystemError::EINVAL),
@@ -770,17 +872,25 @@ impl FuseNode {
         self.set_open_private_data(data, opcode, out.fh, file_flags, out.open_flags, false)
     }
 
-    fn release_common(&self, opcode: u32, fh: u64, file_flags: u32) -> Result<(), SystemError> {
+    fn release_common(&self, opcode: u32, fh: u64, file_flags: u32, lock_owner: u64) {
         let inarg = FuseReleaseIn {
             fh,
             flags: file_flags,
             release_flags: 0,
-            lock_owner: 0,
+            lock_owner,
         };
-        let _ = self
-            .conn()
-            .request_nocreds(opcode, self.nodeid, fuse_pack_struct(&inarg))?;
-        Ok(())
+        let conn = self.conn.clone();
+        let nodeid = self.nodeid;
+        let payload = fuse_pack_struct(&inarg).to_vec();
+        if let Err(err) = conn.request_nocreds_background(opcode, nodeid, &payload) {
+            log::warn!(
+                "fuse: queue async release failed opcode={} nodeid={} fh={} err={:?}",
+                opcode,
+                nodeid,
+                fh,
+                err
+            );
+        }
     }
 
     fn ensure_dir(&self) -> Result<(), SystemError> {
@@ -807,27 +917,45 @@ impl FuseNode {
             FileType::Dir => FUSE_FSYNCDIR,
             _ => return Ok(()),
         };
+        if self.conn().no_fsync(opcode) {
+            return Ok(());
+        }
         let inarg = FuseFsyncIn {
             fh: 0,
             fsync_flags: if datasync { FUSE_FSYNC_FDATASYNC } else { 0 },
             padding: 0,
         };
-        let _ = self
+        match self
             .conn()
-            .request(opcode, self.nodeid, fuse_pack_struct(&inarg))?;
-        Ok(())
+            .request(opcode, self.nodeid, fuse_pack_struct(&inarg))
+        {
+            Err(SystemError::ENOSYS) => {
+                self.conn().mark_no_fsync(opcode);
+                Ok(())
+            }
+            result => result.map(|_| ()),
+        }
     }
 
     fn fsync_with_fh(&self, opcode: u32, fh: u64, datasync: bool) -> Result<(), SystemError> {
+        if self.conn().no_fsync(opcode) {
+            return Ok(());
+        }
         let inarg = FuseFsyncIn {
             fh,
             fsync_flags: if datasync { FUSE_FSYNC_FDATASYNC } else { 0 },
             padding: 0,
         };
-        let _ = self
+        match self
             .conn()
-            .request(opcode, self.nodeid, fuse_pack_struct(&inarg))?;
-        Ok(())
+            .request(opcode, self.nodeid, fuse_pack_struct(&inarg))
+        {
+            Err(SystemError::ENOSYS) => {
+                self.conn().mark_no_fsync(opcode);
+                Ok(())
+            }
+            result => result.map(|_| ()),
+        }
     }
 
     fn parse_create_reply(payload: &[u8]) -> Result<(FuseEntryOut, FuseOpenOut), SystemError> {
@@ -874,6 +1002,7 @@ impl FuseNode {
         buf: &mut [u8],
         fh: u64,
         file_flags: u32,
+        lock_owner: u64,
     ) -> Result<usize, SystemError> {
         let max_read = self.conn().max_read();
         if max_read == 0 {
@@ -901,8 +1030,12 @@ impl FuseNode {
                 fh,
                 offset: chunk_offset as u64,
                 size: chunk as u32,
-                read_flags: 0,
-                lock_owner: 0,
+                read_flags: if lock_owner != 0 {
+                    FUSE_READ_LOCKOWNER
+                } else {
+                    0
+                },
+                lock_owner,
                 flags: file_flags,
                 padding: 0,
             };
@@ -949,6 +1082,7 @@ impl FuseNode {
             page_buf,
             fh,
             file_flags,
+            0,
         )
     }
 
@@ -1162,6 +1296,56 @@ impl FuseNode {
             .discard_clean_range(start_page_index, end_page_index)?;
         Ok(())
     }
+
+    fn direct_io_page_range(
+        offset: usize,
+        len: usize,
+    ) -> Result<Option<(usize, usize, usize)>, SystemError> {
+        if len == 0 {
+            return Ok(None);
+        }
+        let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        let start_page_index = offset >> MMArch::PAGE_SHIFT;
+        let end_page_index = (end - 1) >> MMArch::PAGE_SHIFT;
+        let end_page_exclusive = end_page_index
+            .checked_add(1)
+            .ok_or(SystemError::EOVERFLOW)?;
+        Ok(Some((start_page_index, end_page_index, end_page_exclusive)))
+    }
+
+    fn prepare_direct_io_range(
+        &self,
+        offset: usize,
+        len: usize,
+        data: &FuseOpenPrivateData,
+        discard_clean: bool,
+    ) -> Result<(), SystemError> {
+        let Some((start_page_index, end_page_index, end_page_exclusive)) =
+            Self::direct_io_page_range(offset, len)?
+        else {
+            return Ok(());
+        };
+        let Some(page_cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+
+        page_cache
+            .manager()
+            .writeback_range(start_page_index, end_page_index)?;
+        page_cache
+            .manager()
+            .wait_writeback_range(start_page_index, end_page_index)?;
+        self.check_and_advance_open_wb_error(data)?;
+
+        if discard_clean {
+            let _invalidate = page_cache.invalidate_write();
+            page_cache.unmap_mapping_pages(start_page_index, Some(end_page_exclusive))?;
+            let _ = page_cache
+                .manager()
+                .discard_clean_range(start_page_index, end_page_index)?;
+        }
+        Ok(())
+    }
 }
 
 impl IndexNode for FuseNode {
@@ -1295,12 +1479,28 @@ impl IndexNode for FuseNode {
         }
     }
 
+    fn flush_file(
+        &self,
+        data: MutexGuard<FilePrivateData>,
+        lock_owner: u64,
+    ) -> Result<(), SystemError> {
+        let fuse_data = match &*data {
+            FilePrivateData::Fuse(data) => data.clone(),
+            _ => return Ok(()),
+        };
+        drop(data);
+
+        match fuse_data {
+            FuseFilePrivateData::File(p) => self.flush_open_file(&p, lock_owner),
+            FuseFilePrivateData::Dir(_) | FuseFilePrivateData::Dev(_) => Ok(()),
+        }
+    }
+
     fn close(&self, data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         // `IndexNode::close()` is called from `File::drop()`, i.e. after the
-        // last `Arc<File>` reference is gone.  FUSE file/dir private data is
-        // immutable after open, so taking a snapshot here is not a TOCTOU
-        // window; it prevents holding the private-data mutex while waiting for
-        // userspace to reply to FLUSH/RELEASE.
+        // last `Arc<File>` reference is gone.  User-visible FUSE_FLUSH errors
+        // are handled by `flush_file()` on fd close; this final close only
+        // drains dirty mappings and sends RELEASE.
         let fuse_data = match &*data {
             FilePrivateData::Fuse(data) => data.clone(),
             _ => return Ok(()),
@@ -1310,7 +1510,7 @@ impl IndexNode for FuseNode {
         match fuse_data {
             FuseFilePrivateData::File(p) => {
                 let writeback_result = if p.writeback_handle.is_some() {
-                    self.sync_cached_pages()
+                    self.sync_dirty_cached_pages()
                 } else {
                     Ok(())
                 };
@@ -1320,25 +1520,15 @@ impl IndexNode for FuseNode {
                 if p.no_open {
                     return writeback_result;
                 }
-                if (p.fopen_flags & FOPEN_NOFLUSH) == 0 {
-                    let flush_in = FuseFlushIn {
-                        fh: p.fh,
-                        unused: 0,
-                        padding: 0,
-                        lock_owner: 0,
-                    };
-                    let _ =
-                        self.conn()
-                            .request(FUSE_FLUSH, self.nodeid, fuse_pack_struct(&flush_in));
-                }
-                let release_result = self.release_common(FUSE_RELEASE, p.fh, p.open_flags);
-                writeback_result.and(release_result)
+                self.release_common(FUSE_RELEASE, p.fh, p.open_flags, 0);
+                writeback_result
             }
             FuseFilePrivateData::Dir(p) => {
                 if p.no_open {
                     Ok(())
                 } else {
-                    self.release_common(FUSE_RELEASEDIR, p.fh, p.open_flags)
+                    self.release_common(FUSE_RELEASEDIR, p.fh, p.open_flags, 0);
+                    Ok(())
                 }
             }
             FuseFilePrivateData::Dev(_) => Ok(()),
@@ -1367,11 +1557,16 @@ impl IndexNode for FuseNode {
             return Ok(n);
         }
         self.ensure_regular()?;
-        let (fh, file_flags, fopen_flags) = Self::fuse_file_snapshot(&data)?;
+        let private_data = Self::fuse_file_private_snapshot(&data)?;
         drop(data);
+        let fh = private_data.fh;
+        let file_flags = private_data.open_flags;
+        let fopen_flags = private_data.fopen_flags;
 
         if (fopen_flags & FOPEN_DIRECT_IO) != 0 || (file_flags & FileFlags::O_DIRECT.bits()) != 0 {
-            return self.read_direct_with_open(offset, len, buf, fh, file_flags);
+            self.prepare_direct_io_range(offset, len, &private_data, false)?;
+            let lock_owner = crate::filesystem::vfs::vcore::current_file_lock_owner_id();
+            return self.read_direct_with_open(offset, len, buf, fh, file_flags, lock_owner);
         }
 
         self.read_cached_with_open(offset, len, buf, fh, file_flags)
@@ -1392,15 +1587,31 @@ impl IndexNode for FuseNode {
         if len > 0 {
             offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
         }
-        let (fh, file_flags, fopen_flags) = Self::fuse_file_snapshot(&data)?;
+        let private_data = Self::fuse_file_private_snapshot(&data)?;
         drop(data);
+        let fh = private_data.fh;
+        let file_flags = private_data.open_flags;
+        let fopen_flags = private_data.fopen_flags;
         let max_write = self.conn().max_write();
         if max_write == 0 {
             return Err(SystemError::EIO);
         }
         let cached_write =
             (fopen_flags & FOPEN_DIRECT_IO) == 0 && (file_flags & FileFlags::O_DIRECT.bits()) == 0;
+        let lock_owner = if cached_write {
+            0
+        } else {
+            crate::filesystem::vfs::vcore::current_file_lock_owner_id()
+        };
+        let _direct_write_guard = if cached_write {
+            None
+        } else {
+            Some(self.direct_io_lock.lock())
+        };
         let mut total_written = 0usize;
+        if !cached_write {
+            self.prepare_direct_io_range(offset, len, &private_data, true)?;
+        }
 
         while total_written < len {
             let chunk = core::cmp::min(max_write, len - total_written);
@@ -1412,8 +1623,12 @@ impl IndexNode for FuseNode {
                 fh,
                 offset: chunk_offset as u64,
                 size: chunk as u32,
-                write_flags: 0,
-                lock_owner: 0,
+                write_flags: if lock_owner != 0 {
+                    FUSE_WRITE_LOCKOWNER
+                } else {
+                    0
+                },
+                lock_owner,
                 flags: file_flags,
                 padding: 0,
             };
@@ -1641,7 +1856,10 @@ impl IndexNode for FuseNode {
 
         match fuse_data {
             FuseFilePrivateData::File(p) => {
-                self.sync_cached_pages()?;
+                let sync_result = self.sync_cached_pages();
+                let wb_error_result = self.check_and_advance_open_wb_error(&p);
+                sync_result?;
+                wb_error_result?;
                 self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync)
             }
             FuseFilePrivateData::Dir(p) => self.fsync_with_fh(FUSE_FSYNCDIR, p.fh, datasync),
@@ -1676,7 +1894,10 @@ impl IndexNode for FuseNode {
         }
 
         match fuse_data {
-            FuseFilePrivateData::File(p) => self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync),
+            FuseFilePrivateData::File(p) => {
+                self.check_and_advance_open_wb_error(&p)?;
+                self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync)
+            }
             FuseFilePrivateData::Dir(p) => self.fsync_with_fh(FUSE_FSYNCDIR, p.fh, datasync),
             FuseFilePrivateData::Dev(_) => self.fsync_common(datasync),
         }
@@ -1751,7 +1972,7 @@ impl IndexNode for FuseNode {
 
         // RELEASEDIR (best-effort)
         if !dir_p.no_open {
-            let _ = self.release_common(FUSE_RELEASEDIR, fh, open_flags);
+            self.release_common(FUSE_RELEASEDIR, fh, open_flags, 0);
         }
         Ok(names)
     }

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -227,6 +227,36 @@ impl FuseNode {
         Ok(())
     }
 
+    fn note_short_read_eof(
+        &self,
+        page_index: usize,
+        read_len: usize,
+        observed_size: usize,
+        truncate_cache: bool,
+    ) -> Result<usize, SystemError> {
+        let eof = page_index
+            .checked_mul(MMArch::PAGE_SIZE)
+            .and_then(|start| start.checked_add(read_len))
+            .ok_or(SystemError::EOVERFLOW)?;
+        let mut should_truncate = false;
+        {
+            let mut guard = self.cached_metadata.lock();
+            if let Some(md) = guard.as_mut() {
+                let current_size = md.size.max(0) as usize;
+                if current_size == observed_size && eof < current_size {
+                    md.size = eof as i64;
+                    self.cached_metadata_deadline_ns
+                        .store(u64::MAX, Ordering::Relaxed);
+                    should_truncate = true;
+                }
+            }
+        }
+        if should_truncate && truncate_cache {
+            self.truncate_page_cache(eof)?;
+        }
+        Ok(eof)
+    }
+
     pub(crate) fn fuse_fs(&self) -> Option<Arc<FuseFS>> {
         self.fs.upgrade()
     }
@@ -787,11 +817,33 @@ impl FuseNode {
                 continue;
             }
 
+            let mut filled_len = None;
             let page = page_cache
                 .manager()
                 .commit_page_with(page_index, |idx, dst| {
-                    self.read_page_with_open(idx, dst, fh, file_flags)
+                    let read_len = self.read_page_with_open(idx, dst, fh, file_flags)?;
+                    filled_len = Some(read_len);
+                    Ok(read_len)
                 })?;
+
+            let mut copy_end = copy_end;
+            if let Some(read_len) = filled_len {
+                if read_len < MMArch::PAGE_SIZE {
+                    let eof = self.note_short_read_eof(page_index, read_len, file_size, true)?;
+                    copy_end = core::cmp::min(copy_end, eof);
+                }
+            }
+
+            let current_size = self
+                .cached_metadata_snapshot()
+                .map(|md| md.size.max(0) as usize)
+                .unwrap_or(file_size);
+            copy_end = core::cmp::min(copy_end, current_size);
+            if copy_start >= copy_end {
+                break;
+            }
+
+            let copy_len = copy_end.saturating_sub(copy_start);
             let page_guard = page.read();
             let page_offset = copy_start - page_start;
             unsafe {
@@ -799,6 +851,12 @@ impl FuseNode {
                     .copy_from_slice(&page_guard.as_slice()[page_offset..page_offset + copy_len]);
             }
             dst_offset += copy_len;
+
+            if filled_len.is_some_and(|read_len| read_len < MMArch::PAGE_SIZE)
+                || current_size <= page_end
+            {
+                break;
+            }
         }
 
         Ok(dst_offset)
@@ -816,11 +874,34 @@ impl FuseNode {
             return Err(SystemError::EINVAL);
         }
         let page_cache = self.ensure_page_cache()?;
-        page_cache
+        let mut filled_len = None;
+        let page = page_cache
             .manager()
             .commit_page_with(page_index, |idx, dst| {
-                self.read_page_with_open(idx, dst, fh, file_flags)
-            })
+                let read_len = self.read_page_with_open(idx, dst, fh, file_flags)?;
+                filled_len = Some(read_len);
+                Ok(read_len)
+            })?;
+        if let Some(read_len) = filled_len {
+            if read_len < MMArch::PAGE_SIZE {
+                let eof = self.note_short_read_eof(page_index, read_len, file_size, false)?;
+                if page_index.saturating_mul(MMArch::PAGE_SIZE) >= eof {
+                    drop(page);
+                    page_cache.manager().discard_clean_page(page_index)?;
+                    return Err(SystemError::EINVAL);
+                }
+            }
+        }
+        let current_size = self
+            .cached_metadata_snapshot()
+            .map(|md| md.size.max(0) as usize)
+            .unwrap_or(file_size);
+        if page_index.saturating_mul(MMArch::PAGE_SIZE) >= current_size {
+            drop(page);
+            page_cache.manager().discard_clean_page(page_index)?;
+            return Err(SystemError::EINVAL);
+        }
+        Ok(page)
     }
 
     fn update_cached_pages_after_write(&self, offset: usize, data: &[u8]) {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -24,7 +24,7 @@ use crate::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
     },
-    mm::{page::PageFlags, MemoryManagementArch},
+    mm::MemoryManagementArch,
     time::PosixTimeSpec,
 };
 
@@ -232,8 +232,7 @@ impl FuseNode {
         page_index: usize,
         read_len: usize,
         observed_size: usize,
-        truncate_cache: bool,
-    ) -> Result<usize, SystemError> {
+    ) -> Result<(usize, bool), SystemError> {
         let eof = page_index
             .checked_mul(MMArch::PAGE_SIZE)
             .and_then(|start| start.checked_add(read_len))
@@ -251,10 +250,7 @@ impl FuseNode {
                 }
             }
         }
-        if should_truncate && truncate_cache {
-            self.truncate_page_cache(eof)?;
-        }
-        Ok(eof)
+        Ok((eof, should_truncate))
     }
 
     pub(crate) fn fuse_fs(&self) -> Option<Arc<FuseFS>> {
@@ -306,14 +302,6 @@ impl FuseNode {
             flags &= !FileFlags::O_TRUNC.bits();
         }
         flags
-    }
-
-    fn fuse_file_flags(data: &FilePrivateData) -> Result<u32, SystemError> {
-        match data {
-            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => Ok(p.open_flags),
-            FilePrivateData::Fuse(FuseFilePrivateData::Dir(p)) => Ok(p.open_flags),
-            _ => Err(SystemError::EBADF),
-        }
     }
 
     fn fuse_file_snapshot(data: &FilePrivateData) -> Result<(u64, u32, u32), SystemError> {
@@ -616,13 +604,6 @@ impl FuseNode {
         Ok(())
     }
 
-    fn resolve_file_fh(&self, data: &FilePrivateData) -> Result<u64, SystemError> {
-        let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = data else {
-            return Err(SystemError::EBADF);
-        };
-        Ok(p.fh)
-    }
-
     fn fsync_common(&self, datasync: bool) -> Result<(), SystemError> {
         self.check_not_stale()?;
         let md = self.cached_or_fetch_metadata()?;
@@ -805,8 +786,10 @@ impl FuseNode {
         let start_page_index = offset >> MMArch::PAGE_SHIFT;
         let end_page_index = (offset + read_len - 1) >> MMArch::PAGE_SHIFT;
         let page_cache = self.ensure_page_cache()?;
+        let _invalidate = page_cache.invalidate_read();
 
         let mut dst_offset = 0usize;
+        let mut truncate_eof = None;
         for page_index in start_page_index..=end_page_index {
             let page_start = page_index << MMArch::PAGE_SHIFT;
             let page_end = page_start + MMArch::PAGE_SIZE;
@@ -829,8 +812,12 @@ impl FuseNode {
             let mut copy_end = copy_end;
             if let Some(read_len) = filled_len {
                 if read_len < MMArch::PAGE_SIZE {
-                    let eof = self.note_short_read_eof(page_index, read_len, file_size, true)?;
+                    let (eof, should_truncate) =
+                        self.note_short_read_eof(page_index, read_len, file_size)?;
                     copy_end = core::cmp::min(copy_end, eof);
+                    if should_truncate {
+                        truncate_eof = Some(eof);
+                    }
                 }
             }
 
@@ -858,6 +845,16 @@ impl FuseNode {
                 break;
             }
         }
+        drop(_invalidate);
+
+        if let Some(eof) = truncate_eof {
+            if matches!(
+                self.cached_metadata_snapshot(),
+                Some(md) if md.size.max(0) as usize == eof
+            ) {
+                self.truncate_page_cache(eof)?;
+            }
+        }
 
         Ok(dst_offset)
     }
@@ -874,6 +871,7 @@ impl FuseNode {
             return Err(SystemError::EINVAL);
         }
         let page_cache = self.ensure_page_cache()?;
+        let _invalidate = page_cache.invalidate_read();
         let mut filled_len = None;
         let page = page_cache
             .manager()
@@ -884,7 +882,7 @@ impl FuseNode {
             })?;
         if let Some(read_len) = filled_len {
             if read_len < MMArch::PAGE_SIZE {
-                let eof = self.note_short_read_eof(page_index, read_len, file_size, false)?;
+                let (eof, _) = self.note_short_read_eof(page_index, read_len, file_size)?;
                 if page_index.saturating_mul(MMArch::PAGE_SIZE) >= eof {
                     drop(page);
                     page_cache.manager().discard_clean_page(page_index)?;
@@ -904,49 +902,82 @@ impl FuseNode {
         Ok(page)
     }
 
-    fn update_cached_pages_after_write(&self, offset: usize, data: &[u8]) {
+    fn update_cached_pages_after_write(
+        &self,
+        offset: usize,
+        data: &[u8],
+    ) -> Result<(), SystemError> {
         if data.is_empty() {
-            return;
+            return Ok(());
         }
         let Some(page_cache) = self.cached_page_cache() else {
-            return;
+            return Ok(());
         };
+        let end = offset
+            .checked_add(data.len())
+            .ok_or(SystemError::EOVERFLOW)?;
+        let _invalidate = page_cache.invalidate_read();
 
         let start_page_index = offset >> MMArch::PAGE_SHIFT;
-        let end_page_index = (offset + data.len() - 1) >> MMArch::PAGE_SHIFT;
+        let end_page_index = (end - 1) >> MMArch::PAGE_SHIFT;
         for page_index in start_page_index..=end_page_index {
-            let Some(page) = page_cache.manager().peek_page(page_index) else {
-                continue;
-            };
             let page_start = page_index << MMArch::PAGE_SHIFT;
             let page_end = page_start + MMArch::PAGE_SIZE;
             let write_start = core::cmp::max(offset, page_start);
-            let write_end = core::cmp::min(offset + data.len(), page_end);
+            let write_end = core::cmp::min(end, page_end);
             let write_len = write_end.saturating_sub(write_start);
             if write_len == 0 {
                 continue;
             }
 
-            let mut guard = page.write();
-            let flags = guard.flags();
-            if flags.intersects(PageFlags::PG_DIRTY | PageFlags::PG_WRITEBACK) {
-                continue;
-            }
             let src_offset = write_start - offset;
             let page_offset = write_start - page_start;
-            unsafe {
-                guard.as_slice_mut()[page_offset..page_offset + write_len]
-                    .copy_from_slice(&data[src_offset..src_offset + write_len]);
-            }
-            guard.add_flags(PageFlags::PG_UPTODATE);
+            let _ = page_cache.manager().update_clean_page(
+                page_index,
+                page_offset,
+                &data[src_offset..src_offset + write_len],
+            )?;
         }
 
-        let end = offset.saturating_add(data.len());
+        Ok(())
+    }
+
+    fn note_successful_write(&self, offset: usize, len: usize) -> Result<(), SystemError> {
+        if len == 0 {
+            return Ok(());
+        }
+        let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
         if let Some(md) = self.cached_metadata.lock().as_mut() {
             if end > md.size.max(0) as usize {
                 md.size = end as i64;
             }
         }
+        Ok(())
+    }
+
+    fn invalidate_cached_pages_after_direct_write(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Result<(), SystemError> {
+        if len == 0 {
+            return Ok(());
+        }
+        let Some(page_cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+        let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        let start_page_index = offset >> MMArch::PAGE_SHIFT;
+        let end_page_index = (end - 1) >> MMArch::PAGE_SHIFT;
+        let end_page_exclusive = end_page_index
+            .checked_add(1)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let _invalidate = page_cache.invalidate_write();
+        page_cache.unmap_mapping_pages(start_page_index, Some(end_page_exclusive))?;
+        let _ = page_cache
+            .manager()
+            .discard_clean_range(start_page_index, end_page_index)?;
+        Ok(())
     }
 }
 
@@ -1144,9 +1175,17 @@ impl IndexNode for FuseNode {
         if buf.len() < len {
             return Err(SystemError::EINVAL);
         }
-        let fh = self.resolve_file_fh(&data)?;
-        let file_flags = Self::fuse_file_flags(&data)?;
+        if len > 0 {
+            offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        }
+        let (fh, file_flags, fopen_flags) = Self::fuse_file_snapshot(&data)?;
+        drop(data);
         let max_write = self.conn().max_write();
+        if max_write == 0 {
+            return Err(SystemError::EIO);
+        }
+        let cached_write =
+            (fopen_flags & FOPEN_DIRECT_IO) == 0 && (file_flags & FileFlags::O_DIRECT.bits()) == 0;
         let mut total_written = 0usize;
 
         while total_written < len {
@@ -1177,11 +1216,19 @@ impl IndexNode for FuseNode {
                 };
             }
             let wrote = out.size as usize;
-            self.update_cached_pages_after_write(
-                chunk_offset,
-                &buf[total_written..total_written + wrote],
-            );
+            self.note_successful_write(chunk_offset, wrote)?;
+            let cache_result = if cached_write {
+                self.update_cached_pages_after_write(
+                    chunk_offset,
+                    &buf[total_written..total_written + wrote],
+                )
+            } else {
+                self.invalidate_cached_pages_after_direct_write(chunk_offset, wrote)
+            };
             total_written += wrote;
+            if cache_result.is_err() {
+                break;
+            }
             if wrote < chunk {
                 break;
             }

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -14,11 +14,15 @@ use crate::{
     filesystem::{
         page_cache::PageCache,
         vfs::{
-            file::FileFlags, permission::PermissionMask, syscall::RenameFlags, FilePrivateData,
-            FileSystem, FileType, IndexNode, InodeFlags, InodeId, InodeMode, Metadata,
+            file::FileFlags, permission::PermissionMask, syscall::RenameFlags, utils::DName,
+            FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags, InodeId, InodeMode,
+            Metadata,
         },
     },
-    libs::mutex::{Mutex, MutexGuard},
+    libs::{
+        casting::DowncastArc,
+        mutex::{Mutex, MutexGuard},
+    },
     time::PosixTimeSpec,
 };
 
@@ -47,6 +51,7 @@ pub struct FuseNode {
     self_ref: Weak<FuseNode>,
     nodeid: u64,
     parent_nodeid: Mutex<u64>,
+    name: Mutex<Option<String>>,
     cached_metadata: Mutex<Option<Metadata>>,
     cached_metadata_deadline_ns: AtomicU64,
     lookup_count: AtomicU64,
@@ -74,6 +79,7 @@ impl FuseNode {
             self_ref: self_ref.clone(),
             nodeid,
             parent_nodeid: Mutex::new(parent_nodeid),
+            name: Mutex::new(None),
             cached_metadata: Mutex::new(cached),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             lookup_count: AtomicU64::new(0),
@@ -108,6 +114,21 @@ impl FuseNode {
 
     pub fn nodeid(&self) -> u64 {
         self.nodeid
+    }
+
+    pub(crate) fn set_dname(&self, name: &str) {
+        *self.name.lock() = Some(name.to_string());
+    }
+
+    pub(crate) fn has_dname(&self, name: &str) -> bool {
+        self.name.lock().as_deref() == Some(name)
+    }
+
+    pub(crate) fn clear_dname_if(&self, name: &str) {
+        let mut dname = self.name.lock();
+        if dname.as_deref() == Some(name) {
+            *dname = None;
+        }
     }
 
     pub fn set_parent_nodeid(&self, parent: u64) {
@@ -260,13 +281,19 @@ impl FuseNode {
         (base_len + Self::FUSE_DIRENT_ALIGN - 1) & !(Self::FUSE_DIRENT_ALIGN - 1)
     }
 
-    fn cache_child_from_entry(&self, entry: &FuseEntryOut) {
+    fn cache_child_from_entry(&self, entry: &FuseEntryOut, name: &str) {
         if entry.nodeid == 0 {
             return;
         }
         if let Some(fs) = self.fs.upgrade() {
             let md = Self::attr_to_metadata(&entry.attr);
-            let child = fs.get_or_create_node(entry.nodeid, self.nodeid, Some(md.clone()));
+            let child = fs.get_or_create_node_with_generation(
+                entry.nodeid,
+                self.nodeid,
+                Some(md.clone()),
+                Some(entry.generation),
+            );
+            child.set_dname(name);
             child.inc_lookup(1);
             child.set_cached_metadata_with_valid(md, entry.attr_valid, entry.attr_valid_nsec);
         }
@@ -292,7 +319,7 @@ impl FuseNode {
             if let Ok(name) = core::str::from_utf8(name_bytes) {
                 if !name.is_empty() && name != "." && name != ".." {
                     names.push(name.to_string());
-                    self.cache_child_from_entry(&plus.entry_out);
+                    self.cache_child_from_entry(&plus.entry_out, name);
                 }
             }
 
@@ -534,11 +561,20 @@ impl FuseNode {
     fn create_node_from_entry(
         &self,
         entry: &FuseEntryOut,
+        name: Option<&str>,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.check_not_stale()?;
         let md = Self::attr_to_metadata(&entry.attr);
         let fs = self.fs.upgrade().ok_or(SystemError::ENOENT)?;
-        let child = fs.get_or_create_node(entry.nodeid, self.nodeid, Some(md));
+        let child = fs.get_or_create_node_with_generation(
+            entry.nodeid,
+            self.nodeid,
+            Some(md),
+            Some(entry.generation),
+        );
+        if let Some(name) = name {
+            child.set_dname(name);
+        }
         child.inc_lookup(1);
         child.set_cached_metadata_with_valid(
             Self::attr_to_metadata(&entry.attr),
@@ -975,6 +1011,7 @@ impl IndexNode for FuseNode {
             Some(md),
             Some(entry.generation),
         );
+        child.set_dname(name);
         child
             .lookup_attr_flags
             .store(entry.attr.flags, Ordering::Relaxed);
@@ -1022,7 +1059,7 @@ impl IndexNode for FuseNode {
             Err(e) => return Err(e),
         };
         let (entry, _) = Self::parse_create_reply(&payload)?;
-        self.create_node_from_entry(&entry)
+        self.create_node_from_entry(&entry, Some(name))
     }
 
     fn create_with_data(
@@ -1044,7 +1081,7 @@ impl IndexNode for FuseNode {
                 let payload_in = Self::pack_struct_and_name_payload(&inarg, name);
                 let payload = self.conn().request(FUSE_MKDIR, self.nodeid, &payload_in)?;
                 let entry: FuseEntryOut = fuse_read_struct(&payload)?;
-                self.create_node_from_entry(&entry)
+                self.create_node_from_entry(&entry, Some(name))
             }
             FileType::File => {
                 let inarg = FuseMknodIn {
@@ -1056,7 +1093,7 @@ impl IndexNode for FuseNode {
                 let payload_in = Self::pack_struct_and_name_payload(&inarg, name);
                 let payload = self.conn().request(FUSE_MKNOD, self.nodeid, &payload_in)?;
                 let entry: FuseEntryOut = fuse_read_struct(&payload)?;
-                self.create_node_from_entry(&entry)
+                self.create_node_from_entry(&entry, Some(name))
             }
             FileType::SymLink => {
                 let mut payload_in = Vec::with_capacity(name.len() + 2);
@@ -1067,7 +1104,7 @@ impl IndexNode for FuseNode {
                     .conn()
                     .request(FUSE_SYMLINK, self.nodeid, &payload_in)?;
                 let entry: FuseEntryOut = fuse_read_struct(&payload)?;
-                self.create_node_from_entry(&entry)
+                self.create_node_from_entry(&entry, Some(name))
             }
             _ => Err(SystemError::ENOSYS),
         }
@@ -1081,7 +1118,7 @@ impl IndexNode for FuseNode {
             .conn()
             .request(FUSE_SYMLINK, self.nodeid, &payload_in)?;
         let entry: FuseEntryOut = fuse_read_struct(&payload)?;
-        self.create_node_from_entry(&entry)
+        self.create_node_from_entry(&entry, Some(name))
     }
 
     fn link(&self, name: &str, other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
@@ -1096,7 +1133,21 @@ impl IndexNode for FuseNode {
         };
         let payload_in = Self::pack_struct_and_name_payload(&inarg, name);
         let payload = self.conn().request(FUSE_LINK, self.nodeid, &payload_in)?;
-        let _entry: FuseEntryOut = fuse_read_struct(&payload)?;
+        let entry: FuseEntryOut = fuse_read_struct(&payload)?;
+        let md = Self::attr_to_metadata(&entry.attr);
+        let fs = self.fs.upgrade().ok_or(SystemError::ENOENT)?;
+        let child = fs.get_or_create_node_for_link(
+            entry.nodeid,
+            self.nodeid,
+            Some(md),
+            Some(entry.generation),
+        );
+        child.inc_lookup(1);
+        child.set_cached_metadata_with_valid(
+            Self::attr_to_metadata(&entry.attr),
+            entry.attr_valid,
+            entry.attr_valid_nsec,
+        );
         Ok(())
     }
 
@@ -1148,16 +1199,59 @@ impl IndexNode for FuseNode {
         payload_in.push(0);
         payload_in.extend_from_slice(new_name.as_bytes());
         payload_in.push(0);
+        let cached_old = self
+            .fs
+            .upgrade()
+            .and_then(|fs| fs.find_cached_child(self.nodeid, old_name))
+            .or_else(|| {
+                self.find(old_name)
+                    .ok()
+                    .and_then(|inode| inode.downcast_arc::<FuseNode>())
+            });
+        let cached_new = target_any
+            .fs
+            .upgrade()
+            .and_then(|fs| fs.find_cached_child(target_any.nodeid, new_name))
+            .or_else(|| {
+                if flag.contains(RenameFlags::EXCHANGE) {
+                    target_any
+                        .find(new_name)
+                        .ok()
+                        .and_then(|inode| inode.downcast_arc::<FuseNode>())
+                } else {
+                    None
+                }
+            });
         let r = self.conn().request(opcode, self.nodeid, &payload_in);
         if opcode == FUSE_RENAME2 && matches!(r, Err(SystemError::ENOSYS)) {
             return Err(SystemError::EINVAL);
         }
         let _ = r?;
+        if let Some(node) = cached_old {
+            node.set_parent_nodeid(target_any.nodeid);
+            node.set_dname(new_name);
+        }
+        if let Some(node) = cached_new {
+            if flag.contains(RenameFlags::EXCHANGE) {
+                node.set_parent_nodeid(self.nodeid);
+                node.set_dname(old_name);
+            } else {
+                node.clear_dname_if(new_name);
+            }
+        }
         Ok(())
     }
 
     fn absolute_path(&self) -> Result<String, SystemError> {
         Ok(format!("fuse:{}", self.nodeid))
+    }
+
+    fn dname(&self) -> Result<DName, SystemError> {
+        self.name
+            .lock()
+            .as_ref()
+            .map(|name| DName(Arc::new(name.clone())))
+            .ok_or(SystemError::ENOENT)
     }
 }
 

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -482,6 +482,33 @@ impl FuseNode {
         self.fetch_attr()
     }
 
+    fn finish_open_cache_state(
+        &self,
+        opcode: u32,
+        flags: &FileFlags,
+        fopen_flags: u32,
+    ) -> Result<(), SystemError> {
+        if opcode != FUSE_OPEN {
+            return Ok(());
+        }
+
+        if flags.contains(FileFlags::O_TRUNC)
+            && self
+                .conn
+                .has_init_flag(super::protocol::FUSE_ATOMIC_O_TRUNC)
+        {
+            self.truncate_page_cache(0)?;
+            let mut guard = self.cached_metadata.lock();
+            if let Some(md) = guard.as_mut() {
+                md.size = 0;
+            }
+        } else if (fopen_flags & FOPEN_KEEP_CACHE) == 0 {
+            self.invalidate_clean_page_cache();
+        }
+
+        Ok(())
+    }
+
     fn open_common(
         &self,
         opcode: u32,
@@ -491,6 +518,7 @@ impl FuseNode {
         self.check_not_stale()?;
         let file_flags = flags.bits();
         if self.conn.should_skip_open(opcode) {
+            self.finish_open_cache_state(opcode, flags, FOPEN_KEEP_CACHE)?;
             return self.set_open_private_data(data, opcode, 0, file_flags, FOPEN_KEEP_CACHE, true);
         }
 
@@ -506,6 +534,7 @@ impl FuseNode {
             Ok(v) => v,
             Err(SystemError::ENOSYS) if self.conn.open_enosys_is_supported(opcode) => {
                 self.conn.mark_no_open(opcode);
+                self.finish_open_cache_state(opcode, flags, FOPEN_KEEP_CACHE)?;
                 return self.set_open_private_data(
                     data,
                     opcode,
@@ -518,9 +547,7 @@ impl FuseNode {
             Err(e) => return Err(e),
         };
         let out: FuseOpenOut = fuse_read_struct(&payload)?;
-        if opcode == FUSE_OPEN && (out.open_flags & FOPEN_KEEP_CACHE) == 0 {
-            self.invalidate_clean_page_cache();
-        }
+        self.finish_open_cache_state(opcode, flags, out.open_flags)?;
         self.set_open_private_data(data, opcode, out.fh, file_flags, out.open_flags, false)
     }
 
@@ -861,6 +888,13 @@ impl IndexNode for FuseNode {
         self.ensure_regular()?;
         self.ensure_page_cache()?;
         Ok(())
+    }
+
+    fn truncate_before_open(&self, flags: &FileFlags) -> bool {
+        flags.contains(FileFlags::O_TRUNC)
+            && !self
+                .conn
+                .has_init_flag(super::protocol::FUSE_ATOMIC_O_TRUNC)
     }
 
     fn open(

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -444,7 +444,9 @@ impl FuseNode {
             let mut payload_in = Vec::with_capacity(size_of::<FuseWriteIn>() + chunk);
             payload_in.extend_from_slice(fuse_pack_struct(&write_in));
             payload_in.extend_from_slice(&buf[total..total + chunk]);
-            let payload = self.conn().request(FUSE_WRITE, self.nodeid, &payload_in)?;
+            let payload = self
+                .conn()
+                .request_nocreds(FUSE_WRITE, self.nodeid, &payload_in)?;
             let out: FuseWriteOut = fuse_read_struct(&payload)?;
             if out.size as usize != chunk {
                 return Err(SystemError::EIO);
@@ -734,7 +736,7 @@ impl FuseNode {
         };
         let _ = self
             .conn()
-            .request(opcode, self.nodeid, fuse_pack_struct(&inarg))?;
+            .request_nocreds(opcode, self.nodeid, fuse_pack_struct(&inarg))?;
         Ok(())
     }
 

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -13,7 +13,7 @@ use crate::{
     arch::MMArch,
     driver::base::device::device_number::DeviceNumber,
     filesystem::{
-        page_cache::PageCache,
+        page_cache::{PageCache, PageCacheBackend},
         vfs::{
             file::FileFlags, permission::PermissionMask, syscall::RenameFlags, utils::DName,
             FilePrivateData, FileSystem, FileType, IndexNode, InodeFlags, InodeId, InodeMode,
@@ -31,7 +31,7 @@ use crate::{
 use super::{
     conn::FuseConn,
     fs::FuseFS,
-    private_data::{FuseFilePrivateData, FuseOpenPrivateData},
+    private_data::{FuseFilePrivateData, FuseOpenPrivateData, FuseWritebackHandle},
     protocol::{
         fuse_pack_struct, fuse_read_struct, FuseAccessIn, FuseAttr, FuseAttrOut, FuseCreateIn,
         FuseDirent, FuseDirentPlus, FuseEntryOut, FuseFlushIn, FuseFsyncIn, FuseGetattrIn,
@@ -42,7 +42,7 @@ use super::{
         FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD,
         FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS, FUSE_READLINK,
         FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_ROOT_ID,
-        FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE,
+        FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
     },
 };
 
@@ -56,6 +56,7 @@ pub struct FuseNode {
     name: Mutex<Option<String>>,
     cached_metadata: Mutex<Option<Metadata>>,
     page_cache: Mutex<Option<Arc<PageCache>>>,
+    writeback_handles: Mutex<Vec<Arc<FuseWritebackHandle>>>,
     cached_metadata_deadline_ns: AtomicU64,
     lookup_count: AtomicU64,
     /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
@@ -63,6 +64,43 @@ pub struct FuseNode {
     /// LOOKUP 返回的 generation，用于检测 virtiofsd 复用 nodeid。
     generation: AtomicU64,
     stale: AtomicBool,
+}
+
+#[derive(Debug)]
+struct FusePageCacheBackend {
+    node: Weak<FuseNode>,
+}
+
+impl FusePageCacheBackend {
+    fn new(node: Weak<FuseNode>) -> Self {
+        Self { node }
+    }
+}
+
+impl PageCacheBackend for FusePageCacheBackend {
+    fn read_page(&self, _index: usize, _buf: &mut [u8]) -> Result<usize, SystemError> {
+        Err(SystemError::EIO)
+    }
+
+    fn write_page(&self, index: usize, buf: &[u8]) -> Result<usize, SystemError> {
+        let node = self.node.upgrade().ok_or(SystemError::EIO)?;
+        node.writeback_page_with_handle(index, buf)
+    }
+
+    fn npages(&self) -> usize {
+        let Some(node) = self.node.upgrade() else {
+            return 0;
+        };
+        let Some(md) = node.cached_metadata_snapshot() else {
+            return 0;
+        };
+        let size = md.size.max(0) as usize;
+        if size == 0 {
+            0
+        } else {
+            (size + MMArch::PAGE_SIZE - 1) >> MMArch::PAGE_SHIFT
+        }
+    }
 }
 
 impl FuseNode {
@@ -85,6 +123,7 @@ impl FuseNode {
             name: Mutex::new(None),
             cached_metadata: Mutex::new(cached),
             page_cache: Mutex::new(None),
+            writeback_handles: Mutex::new(Vec::new()),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
@@ -199,7 +238,8 @@ impl FuseNode {
         }
         let node = self.self_ref.upgrade().ok_or(SystemError::EIO)?;
         let inode: Arc<dyn IndexNode> = node;
-        let cache = PageCache::new(Some(Arc::downgrade(&inode)), None);
+        let backend = Arc::new(FusePageCacheBackend::new(self.self_ref.clone()));
+        let cache = PageCache::new(Some(Arc::downgrade(&inode)), Some(backend));
         *guard = Some(cache.clone());
         Ok(cache)
     }
@@ -313,6 +353,105 @@ impl FuseNode {
         }
     }
 
+    fn open_flags_are_writable(open_flags: u32) -> bool {
+        let flags = FileFlags::from_bits_truncate(open_flags);
+        let access = flags.access_flags();
+        access == FileFlags::O_WRONLY || access == FileFlags::O_RDWR
+    }
+
+    fn register_writeback_handle(
+        &self,
+        open_flags: u32,
+        fh: u64,
+        fopen_flags: u32,
+        no_open: bool,
+    ) -> Option<Arc<FuseWritebackHandle>> {
+        if !Self::open_flags_are_writable(open_flags) {
+            return None;
+        }
+        let handle = Arc::new(FuseWritebackHandle::new(
+            fh,
+            open_flags,
+            fopen_flags,
+            no_open,
+        ));
+        self.writeback_handles.lock().push(handle.clone());
+        Some(handle)
+    }
+
+    fn unregister_writeback_handle(&self, handle: &Arc<FuseWritebackHandle>) {
+        handle.mark_closing();
+        self.writeback_handles
+            .lock()
+            .retain(|candidate| !Arc::ptr_eq(candidate, handle));
+        handle.wait_inflight_zero();
+    }
+
+    pub(crate) fn sync_cached_pages(&self) -> Result<(), SystemError> {
+        if let Some(page_cache) = self.cached_page_cache() {
+            page_cache.manager().sync()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn pin_writeback_handle(
+        &self,
+    ) -> Result<super::private_data::FuseWritebackHandlePin, SystemError> {
+        let handles = self.writeback_handles.lock().clone();
+        for handle in handles {
+            if let Some(pin) = handle.try_pin() {
+                return Ok(pin);
+            }
+        }
+        Err(SystemError::EIO)
+    }
+
+    fn writeback_page_with_handle(
+        &self,
+        page_index: usize,
+        buf: &[u8],
+    ) -> Result<usize, SystemError> {
+        self.check_not_stale()?;
+        let pin = self.pin_writeback_handle()?;
+        let handle = pin.handle();
+        let max_write = self.conn().max_write();
+        if max_write == 0 {
+            return Err(SystemError::EIO);
+        }
+
+        let base_offset = page_index
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let mut total = 0usize;
+        while total < buf.len() {
+            let chunk = core::cmp::min(max_write, buf.len() - total);
+            let offset = base_offset
+                .checked_add(total)
+                .ok_or(SystemError::EOVERFLOW)?;
+            let write_in = FuseWriteIn {
+                fh: handle.fh,
+                offset: offset as u64,
+                size: chunk as u32,
+                write_flags: FUSE_WRITE_CACHE,
+                lock_owner: 0,
+                flags: 0,
+                padding: 0,
+            };
+            let mut payload_in = Vec::with_capacity(size_of::<FuseWriteIn>() + chunk);
+            payload_in.extend_from_slice(fuse_pack_struct(&write_in));
+            payload_in.extend_from_slice(&buf[total..total + chunk]);
+            let payload = self.conn().request(FUSE_WRITE, self.nodeid, &payload_in)?;
+            let out: FuseWriteOut = fuse_read_struct(&payload)?;
+            if out.size as usize != chunk {
+                return Err(SystemError::EIO);
+            }
+            self.note_successful_write(offset, chunk)?;
+            total += chunk;
+        }
+
+        Ok(total)
+    }
+
     fn set_open_private_data(
         &self,
         data: &mut FilePrivateData,
@@ -324,6 +463,11 @@ impl FuseNode {
     ) -> Result<(), SystemError> {
         let conn_any: Arc<dyn core::any::Any + Send + Sync> = self.conn.clone();
         let node = self.self_ref.upgrade().ok_or(SystemError::EIO)?;
+        let writeback_handle = if opcode == FUSE_OPEN {
+            self.register_writeback_handle(open_flags, fh, fopen_flags, no_open)
+        } else {
+            None
+        };
         *data = match opcode {
             FUSE_OPEN => FilePrivateData::Fuse(FuseFilePrivateData::File(FuseOpenPrivateData {
                 conn: conn_any,
@@ -332,6 +476,7 @@ impl FuseNode {
                 open_flags,
                 fopen_flags,
                 no_open,
+                writeback_handle,
             })),
             FUSE_OPENDIR => FilePrivateData::Fuse(FuseFilePrivateData::Dir(FuseOpenPrivateData {
                 conn: conn_any,
@@ -340,6 +485,7 @@ impl FuseNode {
                 open_flags,
                 fopen_flags,
                 no_open,
+                writeback_handle: None,
             })),
             _ => return Err(SystemError::EINVAL),
         };
@@ -623,18 +769,7 @@ impl FuseNode {
         Ok(())
     }
 
-    fn fsync_with_file_data(
-        &self,
-        datasync: bool,
-        data: &FilePrivateData,
-    ) -> Result<(), SystemError> {
-        self.check_not_stale()?;
-        let (opcode, fh) = match data {
-            FilePrivateData::Fuse(FuseFilePrivateData::File(p)) => (FUSE_FSYNC, p.fh),
-            FilePrivateData::Fuse(FuseFilePrivateData::Dir(p)) => (FUSE_FSYNCDIR, p.fh),
-            _ => return self.fsync_common(datasync),
-        };
-
+    fn fsync_with_fh(&self, opcode: u32, fh: u64, datasync: bool) -> Result<(), SystemError> {
         let inarg = FuseFsyncIn {
             fh,
             fsync_flags: if datasync { FUSE_FSYNC_FDATASYNC } else { 0 },
@@ -871,7 +1006,6 @@ impl FuseNode {
             return Err(SystemError::EINVAL);
         }
         let page_cache = self.ensure_page_cache()?;
-        let _invalidate = page_cache.invalidate_read();
         let mut filled_len = None;
         let page = page_cache
             .manager()
@@ -1106,8 +1240,16 @@ impl IndexNode for FuseNode {
 
         match fuse_data {
             FuseFilePrivateData::File(p) => {
+                let writeback_result = if p.writeback_handle.is_some() {
+                    self.sync_cached_pages()
+                } else {
+                    Ok(())
+                };
+                if let Some(handle) = &p.writeback_handle {
+                    self.unregister_writeback_handle(handle);
+                }
                 if p.no_open {
-                    return Ok(());
+                    return writeback_result;
                 }
                 let flush_in = FuseFlushIn {
                     fh: p.fh,
@@ -1118,7 +1260,8 @@ impl IndexNode for FuseNode {
                 let _ = self
                     .conn()
                     .request(FUSE_FLUSH, self.nodeid, fuse_pack_struct(&flush_in));
-                self.release_common(FUSE_RELEASE, p.fh, p.open_flags)
+                let release_result = self.release_common(FUSE_RELEASE, p.fh, p.open_flags);
+                writeback_result.and(release_result)
             }
             FuseFilePrivateData::Dir(p) => {
                 if p.no_open {
@@ -1362,7 +1505,53 @@ impl IndexNode for FuseNode {
         datasync: bool,
         data: MutexGuard<FilePrivateData>,
     ) -> Result<(), SystemError> {
-        self.fsync_with_file_data(datasync, &data)
+        let fuse_data = match &*data {
+            FilePrivateData::Fuse(data) => data.clone(),
+            _ => {
+                drop(data);
+                return self.fsync_common(datasync);
+            }
+        };
+        drop(data);
+
+        match fuse_data {
+            FuseFilePrivateData::File(p) => self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync),
+            FuseFilePrivateData::Dir(p) => self.fsync_with_fh(FUSE_FSYNCDIR, p.fh, datasync),
+            FuseFilePrivateData::Dev(_) => self.fsync_common(datasync),
+        }
+    }
+
+    fn sync_file_range(
+        &self,
+        start: usize,
+        end: usize,
+        datasync: bool,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        let fuse_data = match &*data {
+            FilePrivateData::Fuse(data) => data.clone(),
+            _ => {
+                drop(data);
+                return self.fsync_common(datasync);
+            }
+        };
+        drop(data);
+
+        if let FuseFilePrivateData::File(_) = &fuse_data {
+            if let Some(page_cache) = self.cached_page_cache() {
+                let start_index = start >> MMArch::PAGE_SHIFT;
+                let end_index = end >> MMArch::PAGE_SHIFT;
+                page_cache
+                    .manager()
+                    .writeback_range(start_index, end_index)?;
+            }
+        }
+
+        match fuse_data {
+            FuseFilePrivateData::File(p) => self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync),
+            FuseFilePrivateData::Dir(p) => self.fsync_with_fh(FUSE_FSYNCDIR, p.fh, datasync),
+            FuseFilePrivateData::Dev(_) => self.fsync_common(datasync),
+        }
     }
 
     fn fs(&self) -> Arc<dyn FileSystem> {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -1543,7 +1543,10 @@ impl IndexNode for FuseNode {
         drop(data);
 
         match fuse_data {
-            FuseFilePrivateData::File(p) => self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync),
+            FuseFilePrivateData::File(p) => {
+                self.sync_cached_pages()?;
+                self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync)
+            }
             FuseFilePrivateData::Dir(p) => self.fsync_with_fh(FUSE_FSYNCDIR, p.fh, datasync),
             FuseFilePrivateData::Dev(_) => self.fsync_common(datasync),
         }

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -706,22 +706,62 @@ impl IndexNode for FuseNode {
         self.ensure_regular()?;
         let fh = self.resolve_file_fh(&data)?;
         let file_flags = Self::fuse_file_flags(&data)?;
-        let read_len = core::cmp::min(len, self.conn().max_write());
-        let read_in = FuseReadIn {
-            fh,
-            offset: offset as u64,
-            size: read_len as u32,
-            read_flags: 0,
-            lock_owner: 0,
-            flags: file_flags,
-            padding: 0,
-        };
-        let payload = self
-            .conn()
-            .request(FUSE_READ, self.nodeid, fuse_pack_struct(&read_in))?;
-        let n = core::cmp::min(payload.len(), read_len);
-        buf[..n].copy_from_slice(&payload[..n]);
-        Ok(n)
+        let max_read = self.conn().max_read();
+        if max_read == 0 {
+            return Err(SystemError::EIO);
+        }
+
+        let mut total_read = 0usize;
+        while total_read < len {
+            let chunk = core::cmp::min(max_read, len - total_read);
+            let Some(chunk_offset) = offset.checked_add(total_read) else {
+                return if total_read > 0 {
+                    Ok(total_read)
+                } else {
+                    Err(SystemError::EOVERFLOW)
+                };
+            };
+            if chunk_offset > i64::MAX as usize {
+                return if total_read > 0 {
+                    Ok(total_read)
+                } else {
+                    Err(SystemError::EINVAL)
+                };
+            }
+            let read_in = FuseReadIn {
+                fh,
+                offset: chunk_offset as u64,
+                size: chunk as u32,
+                read_flags: 0,
+                lock_owner: 0,
+                flags: file_flags,
+                padding: 0,
+            };
+            let payload =
+                match self
+                    .conn()
+                    .request(FUSE_READ, self.nodeid, fuse_pack_struct(&read_in))
+                {
+                    Ok(payload) => payload,
+                    Err(_) if total_read > 0 => return Ok(total_read),
+                    Err(err) => return Err(err),
+                };
+            if payload.len() > chunk {
+                return if total_read > 0 {
+                    Ok(total_read)
+                } else {
+                    Err(SystemError::EIO)
+                };
+            }
+            let n = payload.len();
+            buf[total_read..total_read + n].copy_from_slice(&payload);
+            total_read += n;
+            if n < chunk {
+                break;
+            }
+        }
+
+        Ok(total_read)
     }
 
     fn write_at(

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -12,7 +12,7 @@ use crate::time::timekeep::ktime_get_real_ns;
 use crate::{
     driver::base::device::device_number::DeviceNumber,
     filesystem::{
-        page_cache::{AsyncPageCacheBackend, PageCache},
+        page_cache::PageCache,
         vfs::{
             file::FileFlags, permission::PermissionMask, syscall::RenameFlags, FilePrivateData,
             FileSystem, FileType, IndexNode, InodeFlags, InodeId, InodeMode, Metadata,
@@ -48,7 +48,6 @@ pub struct FuseNode {
     nodeid: u64,
     parent_nodeid: Mutex<u64>,
     cached_metadata: Mutex<Option<Metadata>>,
-    page_cache: Mutex<Option<Arc<PageCache>>>,
     cached_metadata_deadline_ns: AtomicU64,
     lookup_count: AtomicU64,
     /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
@@ -76,7 +75,6 @@ impl FuseNode {
             nodeid,
             parent_nodeid: Mutex::new(parent_nodeid),
             cached_metadata: Mutex::new(cached),
-            page_cache: Mutex::new(None),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
@@ -473,67 +471,6 @@ impl FuseNode {
         Ok(())
     }
 
-    fn ensure_page_cache(&self) -> Option<Arc<PageCache>> {
-        let md = self.cached_or_fetch_metadata().ok()?;
-        if md.file_type != FileType::File {
-            return None;
-        }
-
-        let mut guard = self.page_cache.lock();
-        if let Some(cache) = guard.clone() {
-            return Some(cache);
-        }
-
-        let inode = self.self_ref.upgrade()? as Arc<dyn IndexNode>;
-        let backend = Arc::new(AsyncPageCacheBackend::new(Arc::downgrade(&inode)));
-        let cache = PageCache::new(Some(Arc::downgrade(&inode)), Some(backend));
-        *guard = Some(cache.clone());
-        Some(cache)
-    }
-
-    fn read_with_temp_open(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
-        let private = Mutex::new(FilePrivateData::Unused);
-        {
-            let mut data = private.lock();
-            self.open_common(FUSE_OPEN, &mut data, &FileFlags::O_RDONLY)?;
-        }
-
-        let result = self.read_at(offset, buf.len(), buf, private.lock());
-        let close_result = self.close(private.lock());
-        match result {
-            Ok(n) => {
-                if let Err(e) = close_result {
-                    log::warn!("fuse temporary close after successful read failed: {:?}", e);
-                }
-                Ok(n)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    fn write_with_temp_open(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
-        let private = Mutex::new(FilePrivateData::Unused);
-        {
-            let mut data = private.lock();
-            self.open_common(FUSE_OPEN, &mut data, &FileFlags::O_WRONLY)?;
-        }
-
-        let result = self.write_at(offset, buf.len(), buf, private.lock());
-        let close_result = self.close(private.lock());
-        match result {
-            Ok(n) => {
-                if let Err(e) = close_result {
-                    log::warn!(
-                        "fuse temporary close after successful write failed: {:?}",
-                        e
-                    );
-                }
-                Ok(n)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
     fn resolve_file_fh(&self, data: &FilePrivateData) -> Result<u64, SystemError> {
         let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = data else {
             return Err(SystemError::EBADF);
@@ -618,15 +555,24 @@ impl IndexNode for FuseNode {
     }
 
     fn read_sync(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let _ = (offset, buf);
         self.check_not_stale()?;
         self.ensure_regular()?;
-        self.read_with_temp_open(offset, buf)
+        Err(SystemError::ENOSYS)
     }
 
     fn write_sync(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
+        let _ = (offset, buf);
         self.check_not_stale()?;
         self.ensure_regular()?;
-        self.write_with_temp_open(offset, buf)
+        Err(SystemError::ENOSYS)
+    }
+
+    fn mmap(&self, start: usize, len: usize, offset: usize) -> Result<(), SystemError> {
+        let _ = (start, len, offset);
+        self.check_not_stale()?;
+        self.ensure_regular()?;
+        Err(SystemError::ENODEV)
     }
 
     fn open(
@@ -922,10 +868,7 @@ impl IndexNode for FuseNode {
     }
 
     fn page_cache(&self) -> Option<Arc<PageCache>> {
-        if self.check_not_stale().is_err() {
-            return None;
-        }
-        self.ensure_page_cache()
+        None
     }
 
     fn sync_file(

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -38,11 +38,11 @@ use super::{
         FuseLinkIn, FuseMkdirIn, FuseMknodIn, FuseOpenIn, FuseOpenOut, FuseReadIn, FuseReleaseIn,
         FuseRename2In, FuseRenameIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut, FATTR_ATIME,
         FATTR_CTIME, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_SIZE, FATTR_UID, FOPEN_DIRECT_IO,
-        FOPEN_KEEP_CACHE, FUSE_ACCESS, FUSE_CREATE, FUSE_FLUSH, FUSE_FSYNC, FUSE_FSYNCDIR,
-        FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD,
-        FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS, FUSE_READLINK,
-        FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_ROOT_ID,
-        FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
+        FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FUSE_ACCESS, FUSE_CREATE, FUSE_FLUSH, FUSE_FSYNC,
+        FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_GETATTR, FUSE_LINK, FUSE_LOOKUP, FUSE_MKDIR,
+        FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS,
+        FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR,
+        FUSE_ROOT_ID, FUSE_SETATTR, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_CACHE,
     },
 };
 
@@ -1251,15 +1251,17 @@ impl IndexNode for FuseNode {
                 if p.no_open {
                     return writeback_result;
                 }
-                let flush_in = FuseFlushIn {
-                    fh: p.fh,
-                    unused: 0,
-                    padding: 0,
-                    lock_owner: 0,
-                };
-                let _ = self
-                    .conn()
-                    .request(FUSE_FLUSH, self.nodeid, fuse_pack_struct(&flush_in));
+                if (p.fopen_flags & FOPEN_NOFLUSH) == 0 {
+                    let flush_in = FuseFlushIn {
+                        fh: p.fh,
+                        unused: 0,
+                        padding: 0,
+                        lock_owner: 0,
+                    };
+                    let _ =
+                        self.conn()
+                            .request(FUSE_FLUSH, self.nodeid, fuse_pack_struct(&flush_in));
+                }
                 let release_result = self.release_common(FUSE_RELEASE, p.fh, p.open_flags);
                 writeback_result.and(release_result)
             }

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -571,9 +571,12 @@ impl FuseNode {
             let mut payload_in = Vec::with_capacity(size_of::<FuseWriteIn>() + chunk);
             payload_in.extend_from_slice(fuse_pack_struct(&write_in));
             payload_in.extend_from_slice(&buf[total..total + chunk]);
-            let payload = self
-                .conn()
-                .request_nocreds(FUSE_WRITE, self.nodeid, &payload_in)?;
+            let payload = self.conn().request_with_cred(
+                FUSE_WRITE,
+                self.nodeid,
+                &payload_in,
+                handle.open_context.request_cred,
+            )?;
             let out: FuseWriteOut = fuse_read_struct(&payload)?;
             if out.size as usize != chunk {
                 return Err(SystemError::EIO);
@@ -1221,19 +1224,16 @@ impl FuseNode {
 
     fn update_cached_pages_after_write(
         &self,
+        page_cache: &Arc<PageCache>,
         offset: usize,
         data: &[u8],
     ) -> Result<(), SystemError> {
         if data.is_empty() {
             return Ok(());
         }
-        let Some(page_cache) = self.cached_page_cache() else {
-            return Ok(());
-        };
         let end = offset
             .checked_add(data.len())
             .ok_or(SystemError::EOVERFLOW)?;
-        let _invalidate = page_cache.invalidate_read();
 
         let start_page_index = offset >> MMArch::PAGE_SHIFT;
         let end_page_index = (end - 1) >> MMArch::PAGE_SHIFT;
@@ -1249,7 +1249,7 @@ impl FuseNode {
 
             let src_offset = write_start - offset;
             let page_offset = write_start - page_start;
-            let _ = page_cache.manager().update_clean_page(
+            let _ = page_cache.manager().update_ready_page(
                 page_index,
                 page_offset,
                 &data[src_offset..src_offset + write_len],
@@ -1257,6 +1257,22 @@ impl FuseNode {
         }
 
         Ok(())
+    }
+
+    fn prepare_cached_write_range(
+        &self,
+        page_cache: &Arc<PageCache>,
+        offset: usize,
+        len: usize,
+    ) -> Result<(), SystemError> {
+        let Some((start_page_index, end_page_index, _)) = Self::direct_io_page_range(offset, len)?
+        else {
+            return Ok(());
+        };
+
+        page_cache
+            .manager()
+            .wait_writeback_range(start_page_index, end_page_index)
     }
 
     fn note_successful_write(&self, offset: usize, len: usize) -> Result<(), SystemError> {
@@ -1612,6 +1628,19 @@ impl IndexNode for FuseNode {
         if !cached_write {
             self.prepare_direct_io_range(offset, len, &private_data, true)?;
         }
+        let cached_page_cache = if cached_write {
+            self.cached_page_cache()
+        } else {
+            None
+        };
+        let _cached_write_guard = cached_page_cache
+            .as_ref()
+            .map(|page_cache| page_cache.invalidate_write());
+        if let Some(page_cache) = cached_page_cache.as_ref() {
+            // Serialize ordinary cached writes against page-cache writeback so an older
+            // dirty mmap page cannot be written back after the daemon sees this write.
+            self.prepare_cached_write_range(page_cache, offset, len)?;
+        }
 
         while total_written < len {
             let chunk = core::cmp::min(max_write, len - total_written);
@@ -1647,10 +1676,15 @@ impl IndexNode for FuseNode {
             let wrote = out.size as usize;
             self.note_successful_write(chunk_offset, wrote)?;
             let cache_result = if cached_write {
-                self.update_cached_pages_after_write(
-                    chunk_offset,
-                    &buf[total_written..total_written + wrote],
-                )
+                if let Some(page_cache) = cached_page_cache.as_ref() {
+                    self.update_cached_pages_after_write(
+                        page_cache,
+                        chunk_offset,
+                        &buf[total_written..total_written + wrote],
+                    )
+                } else {
+                    Ok(())
+                }
             } else {
                 self.invalidate_cached_pages_after_direct_write(chunk_offset, wrote)
             };

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -208,10 +208,16 @@ impl FuseNode {
         self.page_cache.lock().clone()
     }
 
-    fn invalidate_clean_page_cache(&self) {
+    fn cached_metadata_snapshot(&self) -> Option<Metadata> {
+        self.cached_metadata.lock().clone()
+    }
+
+    fn invalidate_clean_page_cache(&self) -> Result<(), SystemError> {
         if let Some(cache) = self.cached_page_cache() {
+            cache.unmap_mapping_pages(0, None)?;
             let _ = cache.manager().invalidate_all_clean();
         }
+        Ok(())
     }
 
     fn truncate_page_cache(&self, new_size: usize) -> Result<(), SystemError> {
@@ -503,7 +509,7 @@ impl FuseNode {
                 md.size = 0;
             }
         } else if (fopen_flags & FOPEN_KEEP_CACHE) == 0 {
-            self.invalidate_clean_page_cache();
+            self.invalidate_clean_page_cache()?;
         }
 
         Ok(())
@@ -804,7 +810,7 @@ impl FuseNode {
         fh: u64,
         file_flags: u32,
     ) -> Result<Arc<crate::mm::page::Page>, SystemError> {
-        let md = self.cached_or_fetch_metadata()?;
+        let md = self.cached_metadata_snapshot().ok_or(SystemError::EIO)?;
         let file_size = md.size.max(0) as usize;
         if file_size == 0 || page_index.saturating_mul(MMArch::PAGE_SIZE) >= file_size {
             return Err(SystemError::EINVAL);
@@ -886,6 +892,69 @@ impl IndexNode for FuseNode {
         let _ = (start, len, offset);
         self.check_not_stale()?;
         self.ensure_regular()?;
+        self.ensure_page_cache()?;
+        Ok(())
+    }
+
+    fn check_mmap_file(
+        &self,
+        file: &Arc<crate::filesystem::vfs::file::File>,
+        len: usize,
+        offset: usize,
+        vm_flags: crate::mm::VmFlags,
+    ) -> Result<(), SystemError> {
+        let _ = (len, offset);
+        self.check_not_stale()?;
+        if file.file_type() != FileType::File {
+            return Err(SystemError::EINVAL);
+        }
+
+        let fopen_flags = {
+            let data = file.private_data.lock();
+            let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
+                return Err(SystemError::EINVAL);
+            };
+            p.fopen_flags
+        };
+
+        if (fopen_flags & FOPEN_DIRECT_IO) != 0
+            && vm_flags.contains(crate::mm::VmFlags::VM_MAYSHARE)
+        {
+            return Err(SystemError::ENODEV);
+        }
+
+        Ok(())
+    }
+
+    fn mmap_file(
+        &self,
+        file: &Arc<crate::filesystem::vfs::file::File>,
+        start: usize,
+        len: usize,
+        offset: usize,
+        vm_flags: crate::mm::VmFlags,
+    ) -> Result<(), SystemError> {
+        let _ = (start, len, offset);
+        self.check_not_stale()?;
+        if file.file_type() != FileType::File {
+            return Err(SystemError::EINVAL);
+        }
+
+        let fopen_flags = {
+            let data = file.private_data.lock();
+            let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
+                return Err(SystemError::EINVAL);
+            };
+            p.fopen_flags
+        };
+
+        if (fopen_flags & FOPEN_DIRECT_IO) != 0 {
+            if vm_flags.contains(crate::mm::VmFlags::VM_MAYSHARE) {
+                return Err(SystemError::ENODEV);
+            }
+            self.invalidate_clean_page_cache()?;
+        }
+
         self.ensure_page_cache()?;
         Ok(())
     }

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::any::Any;
 use system_error::SystemError;
 
-use super::conn::FuseConn;
+use super::{conn::FuseConn, inode::FuseNode};
 
 #[derive(Debug, Clone)]
 pub struct FuseDevPrivateData {
@@ -19,6 +19,7 @@ impl FuseDevPrivateData {
 #[derive(Debug, Clone)]
 pub struct FuseOpenPrivateData {
     pub conn: Arc<dyn Any + Send + Sync>,
+    pub node: Arc<FuseNode>,
     pub fh: u64,
     pub open_flags: u32,
     pub no_open: bool,

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -21,7 +21,10 @@ pub struct FuseOpenPrivateData {
     pub conn: Arc<dyn Any + Send + Sync>,
     pub node: Arc<FuseNode>,
     pub fh: u64,
+    /// User-visible file flags sent in FUSE_OPEN/FUSE_READ/FUSE_WRITE.
     pub open_flags: u32,
+    /// Daemon-returned FOPEN_* flags from fuse_open_out.
+    pub fopen_flags: u32,
     pub no_open: bool,
 }
 

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -3,9 +3,15 @@ use core::any::Any;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use system_error::SystemError;
 
-use crate::{filesystem::vfs::file::FileFlags, libs::wait_queue::WaitQueue};
+use crate::{
+    filesystem::vfs::file::FileFlags,
+    libs::{errseq::ErrSeqValue, mutex::Mutex, wait_queue::WaitQueue},
+};
 
-use super::{conn::FuseConn, inode::FuseNode};
+use super::{
+    conn::{FuseConn, FuseRequestCred},
+    inode::FuseNode,
+};
 
 #[derive(Debug, Clone)]
 pub struct FuseDevPrivateData {
@@ -29,7 +35,20 @@ pub struct FuseOpenPrivateData {
     /// Daemon-returned FOPEN_* flags from fuse_open_out.
     pub fopen_flags: u32,
     pub no_open: bool,
+    pub open_context: FuseOpenContext,
     pub writeback_handle: Option<Arc<FuseWritebackHandle>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FuseOpenContext {
+    /// Request credential sampled at open time for asynchronous writeback.
+    pub request_cred: FuseRequestCred,
+    /// POSIX lock-owner id for requests whose semantics depend on the opener.
+    pub lock_owner: u64,
+    /// Node generation observed when this file was opened.
+    pub node_generation: u64,
+    /// Per-open-file writeback error cursor used by FUSE file-level sync paths.
+    pub wb_errseq: Arc<Mutex<ErrSeqValue>>,
 }
 
 pub struct FuseWritebackHandle {
@@ -37,6 +56,7 @@ pub struct FuseWritebackHandle {
     open_flags: AtomicU32,
     pub fopen_flags: u32,
     pub no_open: bool,
+    pub open_context: FuseOpenContext,
     closing: AtomicBool,
     inflight: AtomicUsize,
     wait_queue: WaitQueue,
@@ -70,6 +90,7 @@ impl core::fmt::Debug for FuseWritebackHandle {
             .field("open_flags", &self.open_flags())
             .field("fopen_flags", &self.fopen_flags)
             .field("no_open", &self.no_open)
+            .field("open_context", &self.open_context)
             .field("closing", &self.is_closing())
             .field("inflight", &self.inflight.load(Ordering::Acquire))
             .finish()
@@ -77,12 +98,19 @@ impl core::fmt::Debug for FuseWritebackHandle {
 }
 
 impl FuseWritebackHandle {
-    pub fn new(fh: u64, open_flags: u32, fopen_flags: u32, no_open: bool) -> Self {
+    pub fn new(
+        fh: u64,
+        open_flags: u32,
+        fopen_flags: u32,
+        no_open: bool,
+        open_context: FuseOpenContext,
+    ) -> Self {
         Self {
             fh,
             open_flags: AtomicU32::new(open_flags),
             fopen_flags,
             no_open,
+            open_context,
             closing: AtomicBool::new(false),
             inflight: AtomicUsize::new(0),
             wait_queue: WaitQueue::default(),

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -1,6 +1,9 @@
 use alloc::sync::Arc;
 use core::any::Any;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use system_error::SystemError;
+
+use crate::{filesystem::vfs::file::FileFlags, libs::wait_queue::WaitQueue};
 
 use super::{conn::FuseConn, inode::FuseNode};
 
@@ -26,6 +29,104 @@ pub struct FuseOpenPrivateData {
     /// Daemon-returned FOPEN_* flags from fuse_open_out.
     pub fopen_flags: u32,
     pub no_open: bool,
+    pub writeback_handle: Option<Arc<FuseWritebackHandle>>,
+}
+
+pub struct FuseWritebackHandle {
+    pub fh: u64,
+    pub open_flags: u32,
+    pub fopen_flags: u32,
+    pub no_open: bool,
+    closing: AtomicBool,
+    inflight: AtomicUsize,
+    wait_queue: WaitQueue,
+}
+
+impl core::fmt::Debug for FuseWritebackHandle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FuseWritebackHandle")
+            .field("fh", &self.fh)
+            .field("open_flags", &self.open_flags)
+            .field("fopen_flags", &self.fopen_flags)
+            .field("no_open", &self.no_open)
+            .field("closing", &self.is_closing())
+            .field("inflight", &self.inflight.load(Ordering::Acquire))
+            .finish()
+    }
+}
+
+impl FuseWritebackHandle {
+    pub fn new(fh: u64, open_flags: u32, fopen_flags: u32, no_open: bool) -> Self {
+        Self {
+            fh,
+            open_flags,
+            fopen_flags,
+            no_open,
+            closing: AtomicBool::new(false),
+            inflight: AtomicUsize::new(0),
+            wait_queue: WaitQueue::default(),
+        }
+    }
+
+    pub fn is_writable(&self) -> bool {
+        let flags = FileFlags::from_bits_truncate(self.open_flags);
+        let access = flags.access_flags();
+        access == FileFlags::O_WRONLY || access == FileFlags::O_RDWR
+    }
+
+    pub fn is_closing(&self) -> bool {
+        self.closing.load(Ordering::Acquire)
+    }
+
+    pub fn mark_closing(&self) {
+        self.closing.store(true, Ordering::Release);
+    }
+
+    pub fn wait_inflight_zero(&self) {
+        self.wait_queue.wait_until(|| {
+            if self.inflight.load(Ordering::Acquire) == 0 {
+                Some(())
+            } else {
+                None
+            }
+        });
+    }
+
+    fn unpin_inflight(&self) {
+        if self.inflight.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.wait_queue.wake_all();
+        }
+    }
+
+    pub fn try_pin(self: &Arc<Self>) -> Option<FuseWritebackHandlePin> {
+        if self.is_closing() || !self.is_writable() {
+            return None;
+        }
+        self.inflight.fetch_add(1, Ordering::AcqRel);
+        if self.is_closing() {
+            self.unpin_inflight();
+            return None;
+        }
+        Some(FuseWritebackHandlePin {
+            handle: self.clone(),
+        })
+    }
+}
+
+pub struct FuseWritebackHandlePin {
+    handle: Arc<FuseWritebackHandle>,
+}
+
+impl FuseWritebackHandlePin {
+    pub fn handle(&self) -> &FuseWritebackHandle {
+        &self.handle
+    }
+}
+
+impl Drop for FuseWritebackHandlePin {
+    fn drop(&mut self) {
+        self.handle.unpin_inflight();
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 use core::any::Any;
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use system_error::SystemError;
 
 use crate::{filesystem::vfs::file::FileFlags, libs::wait_queue::WaitQueue};
@@ -34,7 +34,7 @@ pub struct FuseOpenPrivateData {
 
 pub struct FuseWritebackHandle {
     pub fh: u64,
-    pub open_flags: u32,
+    open_flags: AtomicU32,
     pub fopen_flags: u32,
     pub no_open: bool,
     closing: AtomicBool,
@@ -42,11 +42,32 @@ pub struct FuseWritebackHandle {
     wait_queue: WaitQueue,
 }
 
+impl FuseOpenPrivateData {
+    pub fn set_open_flags(&mut self, flags: FileFlags) {
+        let bits = flags.bits();
+        self.open_flags = bits;
+        if let Some(handle) = &self.writeback_handle {
+            handle.set_open_flags(bits);
+        }
+    }
+}
+
+impl FuseFilePrivateData {
+    pub fn set_flags(&mut self, flags: FileFlags) {
+        match self {
+            FuseFilePrivateData::File(p) | FuseFilePrivateData::Dir(p) => p.set_open_flags(flags),
+            FuseFilePrivateData::Dev(p) => {
+                p.nonblock = flags.contains(FileFlags::O_NONBLOCK);
+            }
+        }
+    }
+}
+
 impl core::fmt::Debug for FuseWritebackHandle {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("FuseWritebackHandle")
             .field("fh", &self.fh)
-            .field("open_flags", &self.open_flags)
+            .field("open_flags", &self.open_flags())
             .field("fopen_flags", &self.fopen_flags)
             .field("no_open", &self.no_open)
             .field("closing", &self.is_closing())
@@ -59,7 +80,7 @@ impl FuseWritebackHandle {
     pub fn new(fh: u64, open_flags: u32, fopen_flags: u32, no_open: bool) -> Self {
         Self {
             fh,
-            open_flags,
+            open_flags: AtomicU32::new(open_flags),
             fopen_flags,
             no_open,
             closing: AtomicBool::new(false),
@@ -69,9 +90,17 @@ impl FuseWritebackHandle {
     }
 
     pub fn is_writable(&self) -> bool {
-        let flags = FileFlags::from_bits_truncate(self.open_flags);
+        let flags = FileFlags::from_bits_truncate(self.open_flags());
         let access = flags.access_flags();
         access == FileFlags::O_WRONLY || access == FileFlags::O_RDWR
+    }
+
+    pub fn open_flags(&self) -> u32 {
+        self.open_flags.load(Ordering::Acquire)
+    }
+
+    pub fn set_open_flags(&self, open_flags: u32) {
+        self.open_flags.store(open_flags, Ordering::Release);
     }
 
     pub fn is_closing(&self) -> bool {

--- a/kernel/src/filesystem/fuse/protocol.rs
+++ b/kernel/src/filesystem/fuse/protocol.rs
@@ -71,6 +71,9 @@ pub const FUSE_EXPLICIT_INVAL_DATA: u64 = 1 << 25;
 /// Guest auto-mounts directories marked FUSE_ATTR_SUBMOUNT (Linux fuse.h: init->flags bit 27).
 pub const FUSE_SUBMOUNTS: u64 = 1 << 27;
 pub const FUSE_INIT_EXT: u64 = 1 << 30;
+/// Allow shared mmap for FOPEN_DIRECT_IO files (Linux 6.6 fuse.h bit 36).
+#[allow(dead_code)]
+pub const FUSE_DIRECT_IO_ALLOW_MMAP: u64 = 1 << 36;
 
 /// fuse_attr.flags (Linux 6.6): directory is a submount root announced by virtiofsd.
 pub const FUSE_ATTR_SUBMOUNT: u32 = 1 << 0;
@@ -91,6 +94,10 @@ pub const FOPEN_PARALLEL_DIRECT_WRITES: u32 = 1 << 6;
 
 // fuse_write_in.write_flags (Linux 6.6 uapi subset)
 pub const FUSE_WRITE_CACHE: u32 = 1 << 0;
+pub const FUSE_WRITE_LOCKOWNER: u32 = 1 << 1;
+
+// fuse_read_in.read_flags (Linux 6.6 uapi subset)
+pub const FUSE_READ_LOCKOWNER: u32 = 1 << 1;
 
 // getattr/setattr valid bits (subset)
 pub const FATTR_MODE: u32 = 1 << 0;

--- a/kernel/src/filesystem/fuse/protocol.rs
+++ b/kernel/src/filesystem/fuse/protocol.rs
@@ -57,6 +57,7 @@ pub const FUSE_AUTO_INVAL_DATA: u64 = 1 << 12;
 pub const FUSE_DO_READDIRPLUS: u64 = 1 << 13;
 pub const FUSE_READDIRPLUS_AUTO: u64 = 1 << 14;
 pub const FUSE_ASYNC_DIO: u64 = 1 << 15;
+#[allow(dead_code)]
 pub const FUSE_WRITEBACK_CACHE: u64 = 1 << 16;
 pub const FUSE_NO_OPEN_SUPPORT: u64 = 1 << 17;
 pub const FUSE_PARALLEL_DIROPS: u64 = 1 << 18;
@@ -66,7 +67,12 @@ pub const FUSE_ABORT_ERROR: u64 = 1 << 21;
 pub const FUSE_MAX_PAGES: u64 = 1 << 22;
 pub const FUSE_NO_OPENDIR_SUPPORT: u64 = 1 << 24;
 pub const FUSE_EXPLICIT_INVAL_DATA: u64 = 1 << 25;
+/// Guest auto-mounts directories marked FUSE_ATTR_SUBMOUNT (Linux fuse.h: init->flags bit 27).
+pub const FUSE_SUBMOUNTS: u64 = 1 << 27;
 pub const FUSE_INIT_EXT: u64 = 1 << 30;
+
+/// fuse_attr.flags (Linux 6.6): directory is a submount root announced by virtiofsd.
+pub const FUSE_ATTR_SUBMOUNT: u32 = 1 << 0;
 
 // getattr/setattr valid bits (subset)
 pub const FATTR_MODE: u32 = 1 << 0;

--- a/kernel/src/filesystem/fuse/protocol.rs
+++ b/kernel/src/filesystem/fuse/protocol.rs
@@ -88,6 +88,9 @@ pub const FOPEN_NOFLUSH: u32 = 1 << 5;
 #[allow(dead_code)]
 pub const FOPEN_PARALLEL_DIRECT_WRITES: u32 = 1 << 6;
 
+// fuse_write_in.write_flags (Linux 6.6 uapi subset)
+pub const FUSE_WRITE_CACHE: u32 = 1 << 0;
+
 // getattr/setattr valid bits (subset)
 pub const FATTR_MODE: u32 = 1 << 0;
 pub const FATTR_UID: u32 = 1 << 1;

--- a/kernel/src/filesystem/fuse/protocol.rs
+++ b/kernel/src/filesystem/fuse/protocol.rs
@@ -43,6 +43,7 @@ pub const FUSE_ACCESS: u32 = 34;
 pub const FUSE_CREATE: u32 = 35;
 pub const FUSE_INTERRUPT: u32 = 36;
 pub const FUSE_DESTROY: u32 = 38; // no reply
+pub const FUSE_FALLOCATE: u32 = 43;
 pub const FUSE_READDIRPLUS: u32 = 44;
 pub const FUSE_RENAME2: u32 = 45;
 
@@ -104,6 +105,7 @@ pub const FATTR_FH: u32 = 1 << 6;
 pub const FATTR_ATIME_NOW: u32 = 1 << 7;
 #[allow(dead_code)]
 pub const FATTR_MTIME_NOW: u32 = 1 << 8;
+pub const FATTR_LOCKOWNER: u32 = 1 << 9;
 pub const FATTR_CTIME: u32 = 1 << 10;
 
 pub const FUSE_FSYNC_FDATASYNC: u32 = 1 << 0;
@@ -269,6 +271,16 @@ pub struct FuseWriteIn {
 #[derive(Debug, Clone, Copy)]
 pub struct FuseWriteOut {
     pub size: u32,
+    pub padding: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FuseFallocateIn {
+    pub fh: u64,
+    pub offset: u64,
+    pub length: u64,
+    pub mode: u32,
     pub padding: u32,
 }
 

--- a/kernel/src/filesystem/fuse/protocol.rs
+++ b/kernel/src/filesystem/fuse/protocol.rs
@@ -74,6 +74,20 @@ pub const FUSE_INIT_EXT: u64 = 1 << 30;
 /// fuse_attr.flags (Linux 6.6): directory is a submount root announced by virtiofsd.
 pub const FUSE_ATTR_SUBMOUNT: u32 = 1 << 0;
 
+// fuse_open_out.open_flags (Linux 6.6 uapi subset)
+pub const FOPEN_DIRECT_IO: u32 = 1 << 0;
+pub const FOPEN_KEEP_CACHE: u32 = 1 << 1;
+#[allow(dead_code)]
+pub const FOPEN_NONSEEKABLE: u32 = 1 << 2;
+#[allow(dead_code)]
+pub const FOPEN_CACHE_DIR: u32 = 1 << 3;
+#[allow(dead_code)]
+pub const FOPEN_STREAM: u32 = 1 << 4;
+#[allow(dead_code)]
+pub const FOPEN_NOFLUSH: u32 = 1 << 5;
+#[allow(dead_code)]
+pub const FOPEN_PARALLEL_DIRECT_WRITES: u32 = 1 << 6;
+
 // getattr/setattr valid bits (subset)
 pub const FATTR_MODE: u32 = 1 << 0;
 pub const FATTR_UID: u32 = 1 << 1;

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -36,8 +36,8 @@ use super::{
     conn::FuseConn,
     fs::{FuseFS, FuseMountData},
     protocol::{
-        fuse_pack_struct, fuse_read_struct, FuseInHeader, FuseOutHeader, FUSE_DESTROY, FUSE_FORGET,
-        FUSE_INTERRUPT,
+        fuse_pack_struct, fuse_read_struct, FuseInHeader, FuseOutHeader, FuseReadIn, FUSE_DESTROY,
+        FUSE_FORGET, FUSE_INTERRUPT, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS,
     },
 };
 
@@ -140,6 +140,21 @@ impl VirtioFsBridgeContext {
         }
     }
 
+    fn response_buffer_size(pending: &PendingReq) -> usize {
+        let default_size = VIRTIOFS_RSP_BUF_SIZE;
+        let read_like = matches!(pending.opcode, FUSE_READ | FUSE_READDIR | FUSE_READDIRPLUS);
+        if !read_like || pending.req.len() < core::mem::size_of::<FuseInHeader>() {
+            return default_size;
+        }
+
+        let payload = &pending.req[core::mem::size_of::<FuseInHeader>()..];
+        let Ok(read_in) = fuse_read_struct::<FuseReadIn>(payload) else {
+            return default_size;
+        };
+        let wanted = core::mem::size_of::<FuseOutHeader>().saturating_add(read_in.size as usize);
+        core::cmp::max(core::mem::size_of::<FuseOutHeader>(), wanted).min(default_size)
+    }
+
     fn take_inflight(&mut self, kind: QueueKind, token: u16) -> Result<InflightReq, SystemError> {
         match kind {
             QueueKind::Hiprio => self.hiprio_inflight.remove(&token).ok_or(SystemError::EIO),
@@ -233,7 +248,8 @@ impl VirtioFsBridgeContext {
         let mut rsp = if pending.noreply {
             None
         } else {
-            Some(vec![0u8; VIRTIOFS_RSP_BUF_SIZE])
+            let rsp_size = Self::response_buffer_size(&pending);
+            Some(vec![0u8; rsp_size])
         };
 
         let (token, should_notify) = match kind {

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -857,6 +857,9 @@ impl MountableFileSystem for VirtioFsFs {
             rootmode: md.rootmode,
             user_id: md.user_id,
             group_id: md.group_id,
+            max_read: VIRTIOFS_RSP_BUF_SIZE
+                .saturating_sub(core::mem::size_of::<FuseOutHeader>())
+                .min(u32::MAX as usize) as u32,
             allow_other: md.allow_other,
             default_permissions: md.default_permissions,
             conn: md.conn.clone(),

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -612,6 +612,24 @@ impl PageCacheManager {
         Ok(self.upgrade()?.lock().evict_clean_pages())
     }
 
+    pub(crate) fn discard_clean_page(&self, page_index: usize) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        let removed = {
+            let mut guard = cache.lock();
+            let Some(entry) = guard.get_entry(page_index) else {
+                return Ok(());
+            };
+            if entry.state() != PageState::UpToDate {
+                return Ok(());
+            }
+            guard.remove_page(page_index)
+        };
+        if let Some(page) = removed {
+            cache.discard_unlinked_page(&page);
+        }
+        Ok(())
+    }
+
     pub fn pages_count(&self) -> Result<usize, SystemError> {
         Ok(self.upgrade()?.lock().pages_count())
     }

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -497,6 +497,59 @@ impl PageCacheManager {
             .and_then(|cache| cache.lock().get_page(page_index))
     }
 
+    pub fn update_clean_page(
+        &self,
+        page_index: usize,
+        page_offset: usize,
+        data: &[u8],
+    ) -> Result<bool, SystemError> {
+        if data.is_empty() {
+            return Ok(false);
+        }
+        match page_offset.checked_add(data.len()) {
+            Some(end) if end <= MMArch::PAGE_SIZE => {}
+            _ => return Err(SystemError::EINVAL),
+        }
+
+        let cache = self.upgrade()?;
+        let Some(entry) = cache.inner.lock().get_entry(page_index) else {
+            return Ok(false);
+        };
+
+        loop {
+            match entry.state() {
+                PageState::Loading => {
+                    if entry.wait_ready().is_err() {
+                        return Ok(false);
+                    }
+                    let current = cache.inner.lock().get_entry(page_index);
+                    if !matches!(current.as_ref(), Some(current) if Arc::ptr_eq(current, &entry)) {
+                        return Ok(false);
+                    }
+                    continue;
+                }
+                PageState::Error | PageState::Dirty | PageState::Writeback => return Ok(false),
+                PageState::UpToDate => {
+                    let current = cache.inner.lock().get_entry(page_index);
+                    if !matches!(current.as_ref(), Some(current) if Arc::ptr_eq(current, &entry)) {
+                        return Ok(false);
+                    }
+                    let mut guard = entry.page.write();
+                    if guard
+                        .flags()
+                        .intersects(PageFlags::PG_DIRTY | PageFlags::PG_WRITEBACK)
+                    {
+                        return Ok(false);
+                    }
+                    let dst = unsafe { guard.as_slice_mut() };
+                    dst[page_offset..page_offset + data.len()].copy_from_slice(data);
+                    guard.add_flags(PageFlags::PG_UPTODATE);
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
     pub fn sync(&self) -> Result<(), SystemError> {
         let cache = self.upgrade()?;
         let dirty_entries: Vec<(usize, Arc<PageEntry>)> = {
@@ -606,6 +659,68 @@ impl PageCacheManager {
             .upgrade()?
             .lock()
             .invalidate_range(start_index, end_index))
+    }
+
+    pub fn discard_clean_range(
+        &self,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<usize, SystemError> {
+        let cache = self.upgrade()?;
+        let indices: Vec<usize> = {
+            let guard = cache.inner.lock();
+            (start_index..=end_index)
+                .filter(|index| guard.get_entry(*index).is_some())
+                .collect()
+        };
+
+        let mut discarded = 0;
+        for page_index in indices {
+            loop {
+                let entry = {
+                    let guard = cache.inner.lock();
+                    guard.get_entry(page_index)
+                };
+                let Some(entry) = entry else {
+                    break;
+                };
+
+                match entry.state() {
+                    PageState::Loading => {
+                        let _ = entry.wait_ready();
+                        continue;
+                    }
+                    PageState::UpToDate | PageState::Error => {}
+                    PageState::Dirty | PageState::Writeback => break,
+                }
+
+                let removed = {
+                    let mut guard = cache.inner.lock();
+                    let Some(current) = guard.get_entry(page_index) else {
+                        break;
+                    };
+                    if !Arc::ptr_eq(&current, &entry)
+                        || !matches!(current.state(), PageState::UpToDate | PageState::Error)
+                    {
+                        continue;
+                    }
+                    guard.remove_page(page_index)
+                };
+
+                if let Some(page) = removed {
+                    let paddr = page.phys_address();
+                    let can_remove_from_manager = page.read().can_deallocate();
+                    let _ = page_reclaimer_lock().remove_page(&paddr);
+                    if can_remove_from_manager {
+                        page_manager_lock().remove_page(&paddr);
+                    }
+                    discarded += 1;
+                }
+                break;
+            }
+        }
+
+        Ok(discarded)
     }
 
     pub fn invalidate_all_clean(&self) -> Result<usize, SystemError> {

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -452,6 +452,13 @@ impl PageCacheManager {
         self.upgrade()?.get_or_create_page_for_read(page_index)
     }
 
+    pub fn commit_page_with<F>(&self, page_index: usize, fill: F) -> Result<Arc<Page>, SystemError>
+    where
+        F: FnOnce(usize, &mut [u8]) -> Result<usize, SystemError>,
+    {
+        self.upgrade()?.get_or_create_page_with(page_index, fill)
+    }
+
     pub fn commit_overwrite(&self, page_index: usize) -> Result<Arc<Page>, SystemError> {
         self.upgrade()?.get_or_create_page_zero(page_index)
     }
@@ -599,6 +606,10 @@ impl PageCacheManager {
             .upgrade()?
             .lock()
             .invalidate_range(start_index, end_index))
+    }
+
+    pub fn invalidate_all_clean(&self) -> Result<usize, SystemError> {
+        Ok(self.upgrade()?.lock().evict_clean_pages())
     }
 
     pub fn pages_count(&self) -> Result<usize, SystemError> {
@@ -1833,6 +1844,100 @@ impl PageCache {
 
     pub fn get_or_create_page_for_read(&self, page_index: usize) -> Result<Arc<Page>, SystemError> {
         Ok(self.get_or_create_entry(page_index, true)?.page.clone())
+    }
+
+    pub fn get_or_create_page_with<F>(
+        &self,
+        page_index: usize,
+        fill: F,
+    ) -> Result<Arc<Page>, SystemError>
+    where
+        F: FnOnce(usize, &mut [u8]) -> Result<usize, SystemError>,
+    {
+        let mut page_cache_ref = None;
+        let mut existing_entry = None;
+        {
+            let guard = self.inner.lock();
+            if let Some(entry) = guard.get_entry(page_index) {
+                existing_entry = Some(entry);
+            } else {
+                page_cache_ref = Some(guard.page_cache_ref.clone());
+            }
+        }
+
+        if let Some(entry) = existing_entry {
+            let state = entry.state();
+            if state.is_ready() {
+                return Ok(entry.page.clone());
+            }
+            if state == PageState::Error {
+                return Err(SystemError::EIO);
+            }
+            let page = entry.wait_ready()?;
+            return Ok(page);
+        }
+
+        let mut page = Some(self.allocate_page(
+            page_cache_ref.expect("page_cache_ref should exist"),
+            page_index,
+        )?);
+
+        let (entry, need_populate) = {
+            let mut guard = self.inner.lock();
+            if let Some(entry) = guard.get_entry(page_index) {
+                (entry, false)
+            } else {
+                let entry = Arc::new(PageEntry::new(
+                    page.take().expect("allocated page must exist"),
+                    PageState::Loading,
+                ));
+                guard.insert_entry(page_index, entry.clone());
+                (entry, true)
+            }
+        };
+
+        if !need_populate {
+            if let Some(page) = page.take() {
+                self.discard_unlinked_page(&page);
+            }
+            let state = entry.state();
+            if state.is_ready() {
+                return Ok(entry.page.clone());
+            }
+            if state == PageState::Error {
+                return Err(SystemError::EIO);
+            }
+            return entry.wait_ready();
+        }
+
+        let populate_result = {
+            let mut tmp = vec![0; MMArch::PAGE_SIZE];
+            match fill(page_index, &mut tmp) {
+                Ok(read_len) if read_len <= MMArch::PAGE_SIZE => {
+                    let mut page_guard = entry.page.write();
+                    let dst = unsafe { page_guard.as_slice_mut() };
+                    dst.copy_from_slice(&tmp);
+                    page_guard.add_flags(PageFlags::PG_UPTODATE);
+                    Ok(())
+                }
+                Ok(_) => Err(SystemError::EIO),
+                Err(e) => Err(e),
+            }
+        };
+
+        match populate_result {
+            Ok(()) => {
+                entry.set_state(PageState::UpToDate);
+                entry.wait_queue.wake_all();
+                Ok(entry.page.clone())
+            }
+            Err(e) => {
+                entry.set_state(PageState::Error);
+                entry.wait_queue.wake_all();
+                self.remove_failed_entry(page_index, &entry);
+                Err(e)
+            }
+        }
     }
 
     pub fn get_or_create_page_zero(&self, page_index: usize) -> Result<Arc<Page>, SystemError> {

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -628,6 +628,62 @@ impl PageCacheManager {
         Ok(())
     }
 
+    pub fn prepare_page_mkwrite(
+        &self,
+        page_index: usize,
+        page: &Arc<Page>,
+    ) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+
+        loop {
+            let entry = {
+                let inner = cache.inner.lock();
+                let Some(entry) = inner.get_entry(page_index) else {
+                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                };
+                if !Arc::ptr_eq(&entry.page, page) {
+                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                }
+                entry
+            };
+
+            match entry.state() {
+                PageState::Loading => {
+                    let _ = entry.wait_ready()?;
+                    continue;
+                }
+                PageState::Writeback => {
+                    Self::wait_writeback_entry(entry)?;
+                    continue;
+                }
+                PageState::Error => return Err(SystemError::EIO),
+                PageState::UpToDate | PageState::Dirty => {}
+            }
+
+            page.write().add_flags(PageFlags::PG_DIRTY);
+
+            let mut inner = cache.inner.lock();
+            let Some(current) = inner.get_entry(page_index) else {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            };
+            if !Arc::ptr_eq(&current, &entry) || !Arc::ptr_eq(&current.page, page) {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+
+            match current.state() {
+                PageState::Loading | PageState::Writeback => continue,
+                PageState::Error => return Err(SystemError::EIO),
+                PageState::UpToDate | PageState::Dirty => {
+                    let old_state = current.state();
+                    inner.dirty_pages.insert(page_index);
+                    cache.account_state_transition(old_state, PageState::Dirty);
+                    current.set_state(PageState::Dirty);
+                    return Ok(());
+                }
+            }
+        }
+    }
+
     pub fn start_writeback_range(
         &self,
         start_index: usize,

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -1012,7 +1012,11 @@ impl PageCacheManager {
             let result = match &data {
                 Some(data) => {
                     if let Some(backend) = &backend {
-                        backend.write_page(page_index, data).map(|_| ())
+                        match backend.write_page(page_index, data) {
+                            Ok(written) if written == data.len() => Ok(()),
+                            Ok(_) => Err(SystemError::EIO),
+                            Err(e) => Err(e),
+                        }
                     } else {
                         inode
                             .write_direct(
@@ -1082,7 +1086,11 @@ impl PageCacheManager {
                     let src = unsafe { guard.as_slice() };
                     src[..len].to_vec()
                 };
-                backend.write_page(page_index, &data).map(|_| len)
+                match backend.write_page(page_index, &data) {
+                    Ok(written) if written == data.len() => Ok(len),
+                    Ok(_) => Err(SystemError::EIO),
+                    Err(e) => Err(e),
+                }
             } else {
                 let data = unsafe {
                     core::slice::from_raw_parts(

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -550,6 +550,92 @@ impl PageCacheManager {
         }
     }
 
+    /// Merge data into an existing ready cache page.
+    ///
+    /// This waits for an in-flight writeback before copying, but callers that need
+    /// backend write ordering must still hold the page cache invalidate write lock
+    /// around their full backend-write and cache-merge sequence.
+    pub fn update_ready_page(
+        &self,
+        page_index: usize,
+        page_offset: usize,
+        data: &[u8],
+    ) -> Result<bool, SystemError> {
+        if data.is_empty() {
+            return Ok(false);
+        }
+        match page_offset.checked_add(data.len()) {
+            Some(end) if end <= MMArch::PAGE_SIZE => {}
+            _ => return Err(SystemError::EINVAL),
+        }
+
+        let cache = self.upgrade()?;
+
+        loop {
+            let Some(entry) = cache.inner.lock().get_entry(page_index) else {
+                return Ok(false);
+            };
+
+            match entry.state() {
+                PageState::Loading => {
+                    if entry.wait_ready().is_err() {
+                        return Ok(false);
+                    }
+                    continue;
+                }
+                PageState::Writeback => {
+                    Self::wait_writeback_entry(entry)?;
+                    continue;
+                }
+                PageState::Error => return Ok(false),
+                PageState::UpToDate | PageState::Dirty => {}
+            }
+
+            let mut page = entry.page.write();
+            match entry.state() {
+                PageState::Loading | PageState::Writeback => {
+                    drop(page);
+                    continue;
+                }
+                PageState::Error => return Ok(false),
+                PageState::UpToDate | PageState::Dirty => {}
+            }
+
+            let keep_dirty =
+                entry.state() == PageState::Dirty || page.flags().contains(PageFlags::PG_DIRTY);
+            let dst = unsafe { page.as_slice_mut() };
+            dst[page_offset..page_offset + data.len()].copy_from_slice(data);
+            page.add_flags(PageFlags::PG_UPTODATE);
+            if keep_dirty {
+                page.add_flags(PageFlags::PG_DIRTY);
+            }
+            drop(page);
+
+            if keep_dirty {
+                let mut inner = cache.inner.lock();
+                let Some(current) = inner.get_entry(page_index) else {
+                    return Ok(false);
+                };
+                if !Arc::ptr_eq(&current, &entry) {
+                    return Ok(false);
+                }
+                match current.state() {
+                    PageState::Loading => continue,
+                    PageState::Writeback => return Ok(true),
+                    PageState::Error => return Ok(false),
+                    PageState::UpToDate | PageState::Dirty => {
+                        let old_state = current.state();
+                        inner.dirty_pages.insert(page_index);
+                        cache.account_state_transition(old_state, PageState::Dirty);
+                        current.set_state(PageState::Dirty);
+                    }
+                }
+            }
+
+            return Ok(true);
+        }
+    }
+
     pub fn sync(&self) -> Result<(), SystemError> {
         let cache = self.upgrade()?;
         let dirty_entries: Vec<(usize, Arc<PageEntry>)> = {
@@ -961,12 +1047,12 @@ impl PageCacheManager {
         page_index: usize,
         entry: Arc<PageEntry>,
     ) -> Result<(), SystemError> {
+        let _invalidate = cache.invalidate_read();
         if !Self::try_prepare_async_writeback_entry(cache, page_index, &entry)? {
             return Ok(());
         }
 
         let page = entry.page.clone();
-        let _invalidate = cache.invalidate_read();
 
         // If the inode has been freed, restore page state via finish_writeback_entry and return error.
         let inode = match cache.inode().and_then(|inode| inode.upgrade()) {
@@ -1047,6 +1133,7 @@ impl PageCacheManager {
         page_index: usize,
         entry: Arc<PageEntry>,
     ) -> Result<(), SystemError> {
+        let _invalidate = cache.invalidate_read();
         if !Self::prepare_writeback_entry(cache, page_index, &entry)? {
             return Ok(());
         }
@@ -1056,7 +1143,6 @@ impl PageCacheManager {
         let mut wb_guard =
             WritebackGuard::new(cache.clone(), page_index, entry.clone(), page.clone());
 
-        let _invalidate = cache.invalidate_read();
         let inode = cache
             .inode()
             .and_then(|inode| inode.upgrade())

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -365,6 +365,18 @@ impl IndexNode for LockedRamFSInode {
         }
     }
 
+    fn fallocate_file(
+        &self,
+        mode: i32,
+        offset: usize,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        drop(data);
+        super::vfs::vcore::resize_based_fallocate(self, mode, offset, len, lock_owner)
+    }
+
     fn create_with_data(
         &self,
         name: &str,

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -799,6 +799,18 @@ impl IndexNode for LockedTmpfsInode {
         }
     }
 
+    fn fallocate_file(
+        &self,
+        mode: i32,
+        offset: usize,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        drop(data);
+        crate::filesystem::vfs::vcore::resize_based_fallocate(self, mode, offset, len, lock_owner)
+    }
+
     fn create_with_data(
         &self,
         name: &str,

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -283,6 +283,13 @@ impl FileSystem for Tmpfs {
         PageFaultHandler::pagecache_fault_zero(pfm)
     }
 
+    unsafe fn page_mkwrite(
+        &self,
+        pfm: &mut crate::mm::fault::PageFaultMessage,
+    ) -> crate::mm::VmFaultReason {
+        PageFaultHandler::filemap_page_mkwrite(pfm)
+    }
+
     unsafe fn map_pages(
         &self,
         pfm: &mut crate::mm::fault::PageFaultMessage,

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -527,6 +527,11 @@ impl File {
         }
     }
 
+    pub fn flush_for_close(&self, lock_owner: u64) -> Result<(), SystemError> {
+        let inode = self.inode();
+        inode.flush_file(self.private_data.lock(), lock_owner)
+    }
+
     fn maybe_kill_suid_sgid_after_write(&self) -> Result<(), SystemError> {
         // 仅对普通文件生效。
         if self.file_type != FileType::File {
@@ -1564,6 +1569,27 @@ impl Drop for File {
     }
 }
 
+#[derive(Debug)]
+pub struct DroppedFd {
+    file: Arc<File>,
+    lock_owner_id: usize,
+}
+
+impl DroppedFd {
+    pub fn new(file: Arc<File>, lock_owner_id: usize) -> Self {
+        Self {
+            file,
+            lock_owner_id,
+        }
+    }
+
+    pub fn finish_close(self) -> Result<(), SystemError> {
+        let flush_result = self.file.flush_for_close(self.lock_owner_id as u64);
+        super::posix_lock::release_posix_for_file_owner(&self.file, self.lock_owner_id);
+        flush_result
+    }
+}
+
 /// @brief pcb里面的文件描述符数组
 #[derive(Debug)]
 pub struct FileDescriptorVec {
@@ -1809,6 +1835,38 @@ impl FileDescriptorVec {
         }
     }
 
+    /// Atomically install `file` at an exact fd, returning the old fd object if one existed.
+    ///
+    /// The table is resized before the old slot is removed, so allocation failure cannot
+    /// publish a half-replaced descriptor state.
+    pub fn replace_fd_arc(
+        &mut self,
+        file: Arc<File>,
+        fd: i32,
+        cloexec: bool,
+    ) -> Result<(i32, Option<DroppedFd>), SystemError> {
+        let nofile_limit = crate::process::ProcessManager::current_pcb()
+            .get_rlimit(crate::process::resource::RLimitID::Nofile)
+            .rlim_cur as usize;
+
+        if fd < 0 || fd as usize >= nofile_limit {
+            return Err(SystemError::EMFILE);
+        }
+
+        let fd_index = fd as usize;
+        if fd_index >= self.fds.len() {
+            self.resize_to_capacity(fd_index + 1)?;
+        }
+
+        let old = self.fds[fd_index].replace(file);
+        self.cloexec[fd_index] = cloexec;
+        if fd_index == self.next_fd {
+            self.next_fd = fd_index + 1;
+        }
+
+        Ok((fd, old.map(|file| DroppedFd::new(file, self.lock_owner_id))))
+    }
+
     /// 根据文件描述符序号，获取文件结构体的Arc指针
     ///
     /// ## 参数
@@ -1864,12 +1922,11 @@ impl FileDescriptorVec {
     /// ## 参数
     ///
     /// - `fd` 文件描述符序号
-    pub fn drop_fd(&mut self, fd: i32) -> Result<Arc<File>, SystemError> {
+    pub fn drop_fd(&mut self, fd: i32) -> Result<DroppedFd, SystemError> {
         self.get_file_by_fd(fd).ok_or(SystemError::EBADF)?;
 
         // 把文件描述符数组对应位置设置为空
         let file = self.fds[fd as usize].take().unwrap();
-        super::posix_lock::release_posix_for_file_owner(&file, self.lock_owner_id);
         // 清除 per-fd close_on_exec 标志
         self.cloexec[fd as usize] = false;
 
@@ -1880,7 +1937,7 @@ impl FileDescriptorVec {
             self.next_fd = fd as usize;
         }
 
-        return Ok(file);
+        return Ok(DroppedFd::new(file, self.lock_owner_id));
     }
 
     #[allow(dead_code)]
@@ -1911,26 +1968,34 @@ impl FileDescriptorVec {
     }
 
     /// 在 execve 时关闭所有设置了 close_on_exec 的文件描述符
-    pub fn close_on_exec(&mut self) {
+    pub fn close_on_exec(&mut self) -> Vec<DroppedFd> {
+        let mut dropped = Vec::new();
         for i in 0..self.fds.len() {
             if self.fds[i].is_some() && self.cloexec[i] {
-                if let Err(r) = self.drop_fd(i as i32) {
-                    error!(
-                        "Failed to close file: pid = {:?}, fd = {}, error = {:?}",
-                        ProcessManager::current_pcb().raw_pid(),
-                        i,
-                        r
-                    );
+                match self.drop_fd(i as i32) {
+                    Ok(fd) => dropped.push(fd),
+                    Err(r) => {
+                        error!(
+                            "Failed to close file: pid = {:?}, fd = {}, error = {:?}",
+                            ProcessManager::current_pcb().raw_pid(),
+                            i,
+                            r
+                        );
+                    }
                 }
             }
         }
+        dropped
     }
 }
 
 impl Drop for FileDescriptorVec {
     fn drop(&mut self) {
-        for file in self.fds.iter().filter_map(|f| f.as_ref()) {
-            super::posix_lock::release_posix_for_file_owner(file, self.lock_owner_id);
+        for file in self.fds.iter_mut().filter_map(|f| f.take()) {
+            let dropped = DroppedFd::new(file, self.lock_owner_id);
+            if let Err(err) = dropped.finish_close() {
+                log::warn!("fd table teardown close failed: {:?}", err);
+            }
         }
     }
 }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -201,6 +201,9 @@ impl FilePrivateData {
             FilePrivateData::Tty(pdata) => {
                 pdata.flags = flags;
             }
+            FilePrivateData::Fuse(pdata) => {
+                pdata.set_flags(flags);
+            }
             _ => {}
         }
     }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1091,10 +1091,6 @@ impl File {
         let actual_offset = offset;
         let actual_len = self.limit_write_len_by_fsize(file_type, actual_offset, len)?;
 
-        if matches!(file_type, FileType::File) && actual_offset > md.size.max(0) as usize {
-            self.inode.resize(actual_offset)?;
-        }
-
         self.write_at_and_finalize(
             actual_offset,
             actual_len,
@@ -1445,9 +1441,12 @@ impl File {
         }
 
         // 统一通过 VFS 封装，复用类型/只读检查，同时保留 fd 上下文。
-        crate::filesystem::vfs::vcore::vfs_truncate_file(self.inode(), len, || {
-            self.private_data.lock()
-        })?;
+        crate::filesystem::vfs::vcore::vfs_truncate_file(
+            self.inode(),
+            len,
+            crate::filesystem::vfs::vcore::current_file_lock_owner_id(),
+            || self.private_data.lock(),
+        )?;
         return Ok(());
     }
 

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -715,6 +715,8 @@ impl File {
             mode.insert(FileMode::FMODE_PWRITE);
         }
 
+        inode.adjust_file_mode_after_open(&private_data.lock(), &mut mode);
+
         // TODO: 检查inode是否有read/write方法,设置FMODE_CAN_READ/WRITE
         // 这需要在IndexNode trait中添加相应的检查方法
         if mode.contains(FileMode::FMODE_READ) {
@@ -787,22 +789,25 @@ impl File {
     /// - `Ok(usize)`: 成功读取的字节数
     /// - `Err(SystemError)`: 错误码
     pub fn read(&self, len: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
-        self.do_read(
-            self.offset.load(core::sync::atomic::Ordering::SeqCst),
-            len,
-            buf,
-            true,
-        )
+        let stream = self.mode.read().contains(FileMode::FMODE_STREAM);
+        let offset = if stream {
+            0
+        } else {
+            self.offset.load(Ordering::SeqCst)
+        };
+
+        self.do_read(offset, len, buf, !stream)
     }
 
     /// Read from the current file position without advancing it.
     pub fn read_noadv(&self, len: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
-        self.do_read(
-            self.offset.load(core::sync::atomic::Ordering::SeqCst),
-            len,
-            buf,
-            false,
-        )
+        let offset = if self.mode.read().contains(FileMode::FMODE_STREAM) {
+            0
+        } else {
+            self.offset.load(Ordering::SeqCst)
+        };
+
+        self.do_read(offset, len, buf, false)
     }
 
     /// ## 从buffer向文件写入指定的字节数的数据
@@ -816,13 +821,14 @@ impl File {
     /// - `Ok(usize)`: 成功写入的字节数
     /// - `Err(SystemError)`: 错误码
     pub fn write(&self, len: usize, buf: &[u8]) -> Result<usize, SystemError> {
-        self.do_write(
-            self.offset.load(core::sync::atomic::Ordering::SeqCst),
-            len,
-            buf,
-            true,
-            false,
-        )
+        let stream = self.mode.read().contains(FileMode::FMODE_STREAM);
+        let offset = if stream {
+            0
+        } else {
+            self.offset.load(Ordering::SeqCst)
+        };
+
+        self.do_write(offset, len, buf, !stream, false)
     }
 
     /// ## 从文件中指定的偏移处读取指定的字节数到buf中

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1444,8 +1444,10 @@ impl File {
             return Err(SystemError::EFBIG);
         }
 
-        // 统一通过 VFS 封装，复用类型/只读检查
-        crate::filesystem::vfs::vcore::vfs_truncate(self.inode(), len)?;
+        // 统一通过 VFS 封装，复用类型/只读检查，同时保留 fd 上下文。
+        crate::filesystem::vfs::vcore::vfs_truncate_file(self.inode(), len, || {
+            self.private_data.lock()
+        })?;
         return Ok(());
     }
 

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -38,7 +38,7 @@ use crate::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
     },
-    mm::{fault::PageFaultMessage, VmFaultReason},
+    mm::{fault::PageFaultMessage, VmFaultReason, VmFlags},
     net::socket::Socket,
     process::ProcessManager,
     syscall::user_buffer::UserBuffer,
@@ -1506,6 +1506,10 @@ pub trait FileSystem: Any + Sync + Send + Debug {
 
     unsafe fn fault(&self, _pfm: &mut PageFaultMessage) -> VmFaultReason {
         VmFaultReason::VM_FAULT_SIGBUS
+    }
+
+    fn mprotect(&self, _old_vm_flags: VmFlags, _new_vm_flags: VmFlags) -> Result<(), SystemError> {
+        Ok(())
     }
 
     unsafe fn map_pages(

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -367,6 +367,10 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         !self.is_stream()
     }
 
+    fn truncate_before_open(&self, flags: &FileFlags) -> bool {
+        flags.contains(FileFlags::O_TRUNC)
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         return Err(SystemError::ENOSYS);
     }

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -432,6 +432,18 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     ///
     /// @return 成功：Ok()
     ///         失败：Err(错误码)
+    fn flush_file(
+        &self,
+        _data: MutexGuard<FilePrivateData>,
+        _lock_owner: u64,
+    ) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    /// @brief 释放最后一个 open file description 引用
+    ///
+    /// @return 成功：Ok()
+    ///         失败：Err(错误码)
     fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         // 若文件系统没有实现此方法，则返回"不支持"
         return Err(SystemError::ENOSYS);

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -472,6 +472,21 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError>;
 
+    /// 基于打开文件上下文执行 fallocate。
+    ///
+    /// 默认不模拟预分配；只有真正支持 fallocate 语义的文件系统应覆盖此方法。
+    fn fallocate_file(
+        &self,
+        _mode: i32,
+        _offset: usize,
+        _len: usize,
+        _lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        drop(data);
+        Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+    }
+
     /// # 在inode的指定偏移量开始，读取指定大小的数据，忽略PageCache
     ///
     /// ## 参数
@@ -548,6 +563,14 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         return Err(SystemError::ENOSYS);
     }
 
+    /// 基于当前 files_struct lock owner 重新设置文件大小。
+    ///
+    /// 默认回退到 inode 级 resize；需要 mandatory-locking 协议语义的文件系统
+    /// 可覆盖该方法。
+    fn resize_with_lock_owner(&self, len: usize, _lock_owner: u64) -> Result<(), SystemError> {
+        self.resize(len)
+    }
+
     /// 基于打开文件上下文重新设置文件大小。
     ///
     /// 默认回退到 inode 级 resize；需要文件句柄语义的文件系统（如 FUSE）
@@ -555,10 +578,11 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     fn resize_file(
         &self,
         len: usize,
+        lock_owner: u64,
         data: MutexGuard<FilePrivateData>,
     ) -> Result<(), SystemError> {
         drop(data);
-        self.resize(len)
+        self.resize_with_lock_owner(len, lock_owner)
     }
 
     /// @brief 在当前目录下创建一个新的inode

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -45,8 +45,12 @@ use crate::{
     time::PosixTimeSpec,
 };
 
-use self::{file::FileFlags, utils::DName, vcore::generate_inode_id};
 pub use self::{file::FilePrivateData, mount::MountFS};
+use self::{
+    file::{FileFlags, FileMode},
+    utils::DName,
+    vcore::generate_inode_id,
+};
 
 use super::page_cache::PageCache;
 
@@ -416,6 +420,13 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         // 若文件系统没有实现此方法，则返回"不支持"
         return Err(SystemError::ENOSYS);
     }
+
+    /// Adjust per-open file mode bits after `open()` initialized private data.
+    ///
+    /// This models Linux helpers such as `nonseekable_open()` and
+    /// `stream_open()` without making VFS syscalls know filesystem-specific
+    /// protocol flags.
+    fn adjust_file_mode_after_open(&self, _data: &FilePrivateData, _mode: &mut FileMode) {}
 
     /// @brief 关闭文件
     ///

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -38,7 +38,7 @@ use crate::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
     },
-    mm::{fault::PageFaultMessage, VmFaultReason, VmFlags},
+    mm::{fault::PageFaultMessage, VirtRegion, VmFaultReason, VmFlags},
     net::socket::Socket,
     process::ProcessManager,
     syscall::user_buffer::UserBuffer,
@@ -1545,6 +1545,13 @@ pub trait FileSystem: Any + Sync + Send + Debug {
     fn mprotect(&self, _old_vm_flags: VmFlags, _new_vm_flags: VmFlags) -> Result<(), SystemError> {
         Ok(())
     }
+
+    /// Called when a file-backed VMA range is genuinely detached from an address space.
+    ///
+    /// This is not called for VMA split/reinsert used by mprotect-like metadata
+    /// changes. Filesystems may use it to flush dirty shared mappings before
+    /// the last mapping reference disappears.
+    fn vma_close(&self, _file: &Arc<File>, _region: VirtRegion, _vm_flags: VmFlags) {}
 
     unsafe fn map_pages(
         &self,

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -548,6 +548,19 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         return Err(SystemError::ENOSYS);
     }
 
+    /// 基于打开文件上下文重新设置文件大小。
+    ///
+    /// 默认回退到 inode 级 resize；需要文件句柄语义的文件系统（如 FUSE）
+    /// 可覆盖该方法，从 `FilePrivateData` 中取得 per-open 状态。
+    fn resize_file(
+        &self,
+        len: usize,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        drop(data);
+        self.resize(len)
+    }
+
     /// @brief 在当前目录下创建一个新的inode
     ///
     /// @param name 目录项的名字

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -1533,6 +1533,15 @@ pub trait FileSystem: Any + Sync + Send + Debug {
         VmFaultReason::VM_FAULT_SIGBUS
     }
 
+    /// Called before a shared writable file mapping is made writable and dirty.
+    ///
+    /// Filesystems that need writeback handles, size validation, or remote
+    /// permission checks should override this hook. Returning an error fault
+    /// keeps the PTE read-only and prevents the page from being marked dirty.
+    unsafe fn page_mkwrite(&self, _pfm: &mut PageFaultMessage) -> VmFaultReason {
+        VmFaultReason::VM_FAULT_SIGBUS
+    }
+
     fn mprotect(&self, _old_vm_flags: VmFlags, _new_vm_flags: VmFlags) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -375,6 +375,27 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         return Err(SystemError::ENOSYS);
     }
 
+    fn check_mmap_file(
+        &self,
+        _file: &Arc<File>,
+        _len: usize,
+        _offset: usize,
+        _vm_flags: VmFlags,
+    ) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    fn mmap_file(
+        &self,
+        _file: &Arc<File>,
+        start: usize,
+        len: usize,
+        offset: usize,
+        _vm_flags: VmFlags,
+    ) -> Result<(), SystemError> {
+        self.mmap(start, len, offset)
+    }
+
     fn read_sync(&self, _offset: usize, _buf: &mut [u8]) -> Result<usize, SystemError> {
         return Err(SystemError::ENOSYS);
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1804,6 +1804,10 @@ impl FileSystem for MountFS {
         self.inner_filesystem.fault(pfm)
     }
 
+    unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
+        self.inner_filesystem.page_mkwrite(pfm)
+    }
+
     fn mprotect(&self, old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {
         self.inner_filesystem.mprotect(old_vm_flags, new_vm_flags)
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1472,6 +1472,16 @@ impl IndexNode for MountFSInode {
     }
 
     #[inline]
+    fn resize_file(
+        &self,
+        len: usize,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        self.ensure_mount_writable()?;
+        return self.inner_inode.resize_file(len, data);
+    }
+
+    #[inline]
     fn create(
         &self,
         name: &str,

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1961,21 +1961,25 @@ impl MountList {
     #[inline(never)]
     pub fn remove<T: Into<MountPath>>(&self, path: T) -> Option<Arc<MountFS>> {
         let mut inner = self.inner.write();
-        let path: MountPath = path.into();
-        if let Some(stack) = inner.mounts.get_mut(&path) {
+        let path = Arc::new(path.into());
+        if let Some(mut stack) = inner.mounts.remove(&path) {
             if let Some(rec) = stack.pop() {
-                let empty = stack.is_empty();
                 let rec_fs = rec.fs.clone();
-                let rec_ino = rec.ino;
-                if empty {
-                    inner.mounts.remove(&path);
-                }
                 if let Some(ino) = inner.mfs2ino.remove(&rec_fs) {
                     inner.ino2mp.remove(&ino);
                 }
                 inner.mfs2mp.remove(&rec_fs);
-                if let Some(ino) = rec_ino {
+                if let Some(ino) = rec.ino {
                     inner.ino2mp.remove(&ino);
+                }
+
+                if let Some(visible) = stack.last() {
+                    inner.mfs2mp.insert(visible.fs.clone(), path.clone());
+                    if let Some(ino) = visible.ino {
+                        inner.mfs2ino.insert(visible.fs.clone(), ino);
+                        inner.ino2mp.insert(ino, path.clone());
+                    }
+                    inner.mounts.insert(path.clone(), stack);
                 }
                 return Some(rec_fs);
             }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         rwsem::RwSem,
         spinlock::SpinLock,
     },
-    mm::{fault::PageFaultMessage, VmFaultReason},
+    mm::{fault::PageFaultMessage, VmFaultReason, VmFlags},
     process::{
         namespace::{
             mnt::MntNamespace,
@@ -1775,6 +1775,10 @@ impl FileSystem for MountFS {
 
     unsafe fn fault(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
         self.inner_filesystem.fault(pfm)
+    }
+
+    fn mprotect(&self, old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {
+        self.inner_filesystem.mprotect(old_vm_flags, new_vm_flags)
     }
 
     unsafe fn map_pages(

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -515,14 +515,11 @@ impl MountFS {
     }
 
     pub fn add_mount(&self, inode_id: InodeId, mount_fs: Arc<MountFS>) -> Result<(), SystemError> {
-        // Check if a mount point with the same name already exists
-        if self.mountpoints.lock().contains_key(&inode_id) {
+        let mut mountpoints = self.mountpoints.lock();
+        if mountpoints.contains_key(&inode_id) {
             return Err(SystemError::EEXIST);
         }
-
-        // Add the new mount point to the current MountFS's mount point list
-        self.mountpoints.lock().insert(inode_id, mount_fs.clone());
-
+        mountpoints.insert(inode_id, mount_fs);
         Ok(())
     }
 
@@ -910,7 +907,7 @@ impl MountFSInode {
         root_inner_inode: Arc<dyn IndexNode>,
         mount_flags: MountFlags,
     ) -> Result<Arc<MountFS>, SystemError> {
-        self.mount_subtree_with_state(inner_fs, root_inner_inode, mount_flags, None, None)
+        self.mount_subtree_with_state(inner_fs, root_inner_inode, mount_flags, None, None, None)
     }
 
     pub(crate) fn mount_subtree_with_state(
@@ -920,6 +917,7 @@ impl MountFSInode {
         mount_flags: MountFlags,
         super_block_state: Option<Arc<SuperBlockState>>,
         bind_source: Option<&Arc<MountFS>>,
+        mount_path_override: Option<Arc<MountPath>>,
     ) -> Result<Arc<MountFS>, SystemError> {
         // Linux do_add_mount: the parent mount point must belong to the current mount namespace.
         let current_mntns = ProcessManager::current_mntns();
@@ -957,7 +955,12 @@ impl MountFSInode {
             },
         );
 
-        let mount_path = Arc::new(MountPath::from(self.absolute_path()?));
+        // 调用者可以传入已经按 VFS 解析过的命名空间路径，避免 FUSE/virtiofs 等
+        // 文件系统的 inner inode absolute_path() 返回合成路径或无法反查真实挂载点。
+        let mount_path = match mount_path_override {
+            Some(p) => p,
+            None => Arc::new(MountPath::from(self.absolute_path()?)),
+        };
 
         if let Some(source) = bind_source {
             inherit_bind_mount_propagation(source, &new_mount_fs);
@@ -1036,7 +1039,7 @@ impl MountFSInode {
     /// replacement is needed, so the current inode is returned directly.
     ///
     /// @return Arc<MountFSInode>
-    fn overlaid_inode(&self) -> Arc<MountFSInode> {
+    pub(crate) fn overlaid_inode(&self) -> Arc<MountFSInode> {
         let mut current = self.self_ref.upgrade().unwrap();
         for _ in 0..1024 {
             let inode_id = match current.metadata() {
@@ -1067,15 +1070,21 @@ impl MountFSInode {
     }
 
     fn do_find(&self, name: &str) -> Result<Arc<MountFSInode>, SystemError> {
+        let base = self.overlaid_inode();
         // Directly call the find method of the filesystem the current inode belongs to.
         // Since downward lookups may cross filesystem boundaries, we need to attempt inode replacement.
-        let inner_inode = self.inner_inode.find(name)?;
-        return Ok(Arc::new_cyclic(|self_ref| MountFSInode {
-            inner_inode,
-            mount_fs: self.mount_fs.clone(),
+        let inner_inode = base.inner_inode.find(name)?;
+        let mount_inode = Arc::new_cyclic(|self_ref| MountFSInode {
+            inner_inode: inner_inode.clone(),
+            mount_fs: base.mount_fs.clone(),
             self_ref: self_ref.clone(),
-        })
-        .overlaid_inode());
+        });
+        if let Some(fuse_node) =
+            inner_inode.downcast_arc::<crate::filesystem::fuse::inode::FuseNode>()
+        {
+            crate::filesystem::fuse::fs::fuse_try_automount_submount(&fuse_node, &mount_inode)?;
+        }
+        Ok(mount_inode.overlaid_inode())
     }
 
     pub(super) fn do_parent(&self) -> Result<Arc<MountFSInode>, SystemError> {
@@ -1146,11 +1155,24 @@ impl MountFSInode {
 
     #[inline(never)]
     fn do_absolute_path(&self) -> Result<String, SystemError> {
+        // Prefer mount_list records: FUSE/virtiofs inodes may report synthetic paths
+        // such as "fuse:<nodeid>" from absolute_path(), which breaks MS_MOVE path rewrite.
+        if self.is_mountpoint_root()? {
+            if let Some(path) = ProcessManager::current_mntns()
+                .mount_list()
+                .get_mount_path_by_mountfs(&self.mount_fs)
+            {
+                return Ok(path.as_str().to_string());
+            }
+        }
+
         let mut current = self.self_ref.upgrade().unwrap();
 
-        // For special inode, we can directly get the absolute path
+        // Only accept filesystem-provided paths that look like real VFS paths.
         if let Ok(p) = current.inner_inode.absolute_path() {
-            return Ok(p);
+            if p.starts_with('/') {
+                return Ok(p);
+            }
         }
 
         let mut path_parts = Vec::new();
@@ -1364,7 +1386,7 @@ impl IndexNode for MountFSInode {
 
     #[inline]
     fn fs(&self) -> Arc<dyn FileSystem> {
-        return self.mount_fs.clone();
+        return self.overlaid_inode().mount_fs.clone();
     }
 
     #[inline]
@@ -1514,7 +1536,7 @@ impl IndexNode for MountFSInode {
             "" | "." => self
                 .self_ref
                 .upgrade()
-                .map(|inode| inode as Arc<dyn IndexNode>)
+                .map(|inode| inode.overlaid_inode() as Arc<dyn IndexNode>)
                 .ok_or(SystemError::ENOENT),
             // Looking up the parent directory
             ".." => self.parent(),
@@ -1592,12 +1614,23 @@ impl IndexNode for MountFSInode {
             .ok_or(SystemError::EINVAL)?;
 
         let target_mountpoint = self.self_ref.upgrade().unwrap();
-        let old_source_path = from_mfs
-            .self_mountpoint()
-            .ok_or(SystemError::EINVAL)?
-            .absolute_path()?;
-        let new_target_path = target_mountpoint.absolute_path()?;
         let mntns = ProcessManager::current_mntns();
+        let old_source_path = mntns
+            .mount_list()
+            .get_mount_path_by_mountfs(&from_mfs)
+            .map(|p| p.as_str().to_string())
+            .or_else(|| {
+                from_mfs
+                    .self_mountpoint()
+                    .and_then(|mp| mp.absolute_path().ok())
+            })
+            .filter(|p| p.starts_with('/'))
+            .ok_or(SystemError::EINVAL)?;
+        let new_target_path = target_mountpoint
+            .absolute_path()
+            .ok()
+            .filter(|p| p.starts_with('/'))
+            .ok_or(SystemError::EINVAL)?;
         mntns.move_mount(
             &from_mfs,
             &target_mountpoint,
@@ -1832,7 +1865,7 @@ impl MountList {
     ///
     /// ## Returns
     ///
-    /// - `MountList`: A new mount point list instance
+    /// - `Arc<MountList>`: A shared empty mount point list instance.
     pub fn new() -> Arc<Self> {
         Arc::new(MountList {
             inner: RwSem::new(InnerMountList {
@@ -1846,16 +1879,17 @@ impl MountList {
 
     /// Inserts a filesystem mount point into the mount list.
     ///
-    /// This function adds a new filesystem mount point to the mount list. If a mount point
-    /// already exists at the specified path, it will be updated with the new filesystem.
+    /// This function records a new mount at `path`. Multiple mounts may exist at
+    /// the same path; they are stored as a stack, and the newest entry is the
+    /// visible mount returned by lookup helpers.
     ///
     /// # Thread Safety
     /// This function is thread-safe as it uses a RwSem to ensure safe concurrent access.
     ///
     /// # Arguments
-    /// * `ino` - An optional InodeId representing the inode of the `fs` mounted at.
-    /// * `path` - The mount path where the filesystem will be mounted
-    /// * `fs` - The filesystem instance to be mounted at the specified path
+    /// * `ino` - Optional inode id of the parent-side mount point.
+    /// * `path` - Namespace path where the filesystem is mounted.
+    /// * `fs` - MountFS instance mounted at the specified path.
     #[inline(never)]
     pub fn insert(&self, ino: Option<InodeId>, path: Arc<MountPath>, fs: Arc<MountFS>) {
         let mut inner = self.inner.write();
@@ -1883,8 +1917,8 @@ impl MountList {
     ///
     /// ## Returns
     ///
-    /// - `Option<(String, String, Arc<MountFS>)>`:
-    ///   - `Some((mount_point, rest_path, fs))`: If a matching mount point is found, returns a tuple of mount point path, remaining path, and mounted filesystem.
+    /// - `Option<(Arc<MountPath>, String, Arc<MountFS>)>`:
+    ///   - `Some((mount_point, rest_path, fs))`: If a matching mount point is found, returns the recorded mount path, remaining path, and currently visible mounted filesystem.
     ///   - `None`: If no matching mount point is found.
     #[inline(never)]
     #[allow(dead_code)]
@@ -1910,9 +1944,11 @@ impl MountList {
 
     /// # remove — Remove a mount point
     ///
-    /// Removes a mount point from the mount point manager.
+    /// Removes the currently visible mount at `path`.
     ///
-    /// This function removes an existing mount point from the manager. If the mount point does not exist, no action is taken.
+    /// If multiple mounts are stacked on the same path, this function pops only
+    /// the top entry. Lower entries remain recorded and become visible again. If
+    /// the path has no mount stack, no action is taken.
     ///
     /// ## Arguments
     ///
@@ -1920,7 +1956,8 @@ impl MountList {
     ///
     /// ## Returns
     ///
-    /// - `Option<Arc<MountFS>>`: Returns an optional `Arc<MountFS>` representing the removed mount point, or `None` if the mount point does not exist.
+    /// - `Option<Arc<MountFS>>`: the removed visible mount, or `None` if the
+    ///   path does not exist in the mount list.
     #[inline(never)]
     pub fn remove<T: Into<MountPath>>(&self, path: T) -> Option<Arc<MountFS>> {
         let mut inner = self.inner.write();
@@ -2032,12 +2069,19 @@ impl Debug for MountList {
     }
 }
 
-/// Determine whether the given inode is the root inode of its filesystem
+/// Determine whether the given inode is the root inode of its mounted filesystem.
+///
+/// ## Arguments
+///
+/// - `inode`: inode to test. Non-`MountFSInode` values are treated as not being
+///   a mount root.
 ///
 /// ## Returns
 ///
-/// - `true`: is the root inode
-/// - `false`: is not the root inode, the given inode is not a MountFSInode, or calling the inode's metadata method failed.
+/// - `true`: `inode` is a `MountFSInode` whose inner inode is the root inode of
+///   its `MountFS`.
+/// - `false`: `inode` is not a mount root, is not a `MountFSInode`, or metadata
+///   lookup failed.
 pub fn is_mountpoint_root(inode: &Arc<dyn IndexNode>) -> bool {
     let mnt_inode = inode.clone().downcast_arc::<MountFSInode>();
     if let Some(mnt) = mnt_inode {
@@ -2049,18 +2093,18 @@ pub fn is_mountpoint_root(inode: &Arc<dyn IndexNode>) -> bool {
 
 /// # do_mount_mkdir — Create a directory at the specified mount point and mount a filesystem
 ///
-/// Creates a directory at the specified mount point and mounts it into the filesystem.
-/// If the mount point already exists and is not empty, an error is returned.
-/// On success, returns a reference to the newly mounted filesystem.
+/// Creates `mount_point` with mode `0755`, rejects it if it is already an
+/// existing mount point, and mounts `fs` there with the supplied mount flags.
 ///
 /// ## Arguments
 ///
-/// - `fs`: FileSystem — Reference to the filesystem, used for creating and mounting the directory.
-/// - `mount_point`: &str — The mount point path, used for creating and mounting the directory.
+/// - `fs`: filesystem instance to mount.
+/// - `mount_point`: path of the directory to create and use as mount point.
+/// - `mount_flags`: per-mount flags for the new mount.
 ///
 /// ## Returns
 ///
-/// - `Ok(Arc<MountFS>)`: On successful mount, returns a shared reference to the mounted filesystem.
+/// - `Ok(Arc<MountFS>)`: returns the newly mounted `MountFS`.
 /// - `Err(SystemError)`: On mount failure, returns a system error.
 pub fn do_mount_mkdir(
     fs: Arc<dyn FileSystem>,

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1082,7 +1082,19 @@ impl MountFSInode {
         if let Some(fuse_node) =
             inner_inode.downcast_arc::<crate::filesystem::fuse::inode::FuseNode>()
         {
-            crate::filesystem::fuse::fs::fuse_try_automount_submount(&fuse_node, &mount_inode)?;
+            let mut submount_path = base.absolute_path()?;
+            if !submount_path.starts_with('/') {
+                return Err(SystemError::EINVAL);
+            }
+            if submount_path != "/" {
+                submount_path.push('/');
+            }
+            submount_path.push_str(name);
+            crate::filesystem::fuse::fs::fuse_try_automount_submount(
+                &fuse_node,
+                &mount_inode,
+                Some(Arc::new(MountPath::from(submount_path))),
+            )?;
         }
         Ok(mount_inode.overlaid_inode())
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1291,6 +1291,29 @@ impl IndexNode for MountFSInode {
         return self.inner_inode.mmap(start, len, offset);
     }
 
+    fn check_mmap_file(
+        &self,
+        file: &Arc<super::file::File>,
+        len: usize,
+        offset: usize,
+        vm_flags: VmFlags,
+    ) -> Result<(), SystemError> {
+        self.inner_inode
+            .check_mmap_file(file, len, offset, vm_flags)
+    }
+
+    fn mmap_file(
+        &self,
+        file: &Arc<super::file::File>,
+        start: usize,
+        len: usize,
+        offset: usize,
+        vm_flags: VmFlags,
+    ) -> Result<(), SystemError> {
+        self.inner_inode
+            .mmap_file(file, start, len, offset, vm_flags)
+    }
+
     fn truncate_before_open(&self, flags: &FileFlags) -> bool {
         self.inner_inode.truncate_before_open(flags)
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1360,6 +1360,14 @@ impl IndexNode for MountFSInode {
         return self.inner_inode.fadvise(file, offset, len, advise);
     }
 
+    fn flush_file(
+        &self,
+        data: MutexGuard<FilePrivateData>,
+        lock_owner: u64,
+    ) -> Result<(), SystemError> {
+        self.inner_inode.flush_file(data, lock_owner)
+    }
+
     fn close(&self, data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
         self.inner_inode.close(data)
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1,6 +1,8 @@
 use super::{
-    file::FileFlags, utils::DName, FilePrivateData, FileSystem, FileType, IndexNode, InodeId,
-    InodeMode, PollableInode, SuperBlock,
+    file::{FileFlags, FileMode},
+    utils::DName,
+    FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode, PollableInode,
+    SuperBlock,
 };
 use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
@@ -1285,6 +1287,10 @@ impl IndexNode for MountFSInode {
             return Err(SystemError::EROFS);
         }
         return self.inner_inode.open(data, flags);
+    }
+
+    fn adjust_file_mode_after_open(&self, data: &FilePrivateData, mode: &mut FileMode) {
+        self.inner_inode.adjust_file_mode_after_open(data, mode)
     }
 
     fn mmap(&self, start: usize, len: usize, offset: usize) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1472,13 +1472,35 @@ impl IndexNode for MountFSInode {
     }
 
     #[inline]
+    fn resize_with_lock_owner(&self, len: usize, lock_owner: u64) -> Result<(), SystemError> {
+        self.ensure_mount_writable()?;
+        return self.inner_inode.resize_with_lock_owner(len, lock_owner);
+    }
+
+    #[inline]
     fn resize_file(
         &self,
         len: usize,
+        lock_owner: u64,
         data: MutexGuard<FilePrivateData>,
     ) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
-        return self.inner_inode.resize_file(len, data);
+        return self.inner_inode.resize_file(len, lock_owner, data);
+    }
+
+    #[inline]
+    fn fallocate_file(
+        &self,
+        mode: i32,
+        offset: usize,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        self.ensure_mount_writable()?;
+        return self
+            .inner_inode
+            .fallocate_file(mode, offset, len, lock_owner, data);
     }
 
     #[inline]

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         rwsem::RwSem,
         spinlock::SpinLock,
     },
-    mm::{fault::PageFaultMessage, VmFaultReason, VmFlags},
+    mm::{fault::PageFaultMessage, VirtRegion, VmFaultReason, VmFlags},
     process::{
         namespace::{
             mnt::MntNamespace,
@@ -1810,6 +1810,10 @@ impl FileSystem for MountFS {
 
     fn mprotect(&self, old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {
         self.inner_filesystem.mprotect(old_vm_flags, new_vm_flags)
+    }
+
+    fn vma_close(&self, file: &Arc<super::file::File>, region: VirtRegion, vm_flags: VmFlags) {
+        self.inner_filesystem.vma_close(file, region, vm_flags)
     }
 
     unsafe fn map_pages(

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1291,6 +1291,10 @@ impl IndexNode for MountFSInode {
         return self.inner_inode.mmap(start, len, offset);
     }
 
+    fn truncate_before_open(&self, flags: &FileFlags) -> bool {
+        self.inner_inode.truncate_before_open(flags)
+    }
+
     fn sync(&self) -> Result<(), SystemError> {
         return self.inner_inode.sync();
     }

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -394,7 +394,7 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
     // 注意：必须在创建 File 对象之前截断
     // 因为 O_TRUNC 的截断基于文件系统权限，而不是打开模式
     // 例如：open(file, O_RDONLY | O_TRUNC) 是合法的，只要用户对文件有写权限
-    if how.o_flags.contains(FileFlags::O_TRUNC) && file_type == FileType::File {
+    if file_type == FileType::File && inode.truncate_before_open(&how.o_flags) {
         inode.resize(0)?;
     }
     let file: File = File::new(inode, how.o_flags)?;

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -8,7 +8,7 @@ use super::{
     permission::PermissionMask,
     syscall::{OpenHow, OpenHowResolve},
     utils::{rsplit_path, should_remove_sgid_on_chown, user_path_at},
-    vcore::{check_parent_dir_permission_inode, resolve_parent_inode},
+    vcore::{check_parent_dir_permission_inode, resolve_parent_inode, vfs_truncate},
     FileType, FsPermissionPolicy, IndexNode, InodeMode, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
 };
 use crate::{filesystem::vfs::syscall::UtimensFlags, process::cred::Kgid};
@@ -395,7 +395,7 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
     // 因为 O_TRUNC 的截断基于文件系统权限，而不是打开模式
     // 例如：open(file, O_RDONLY | O_TRUNC) 是合法的，只要用户对文件有写权限
     if file_type == FileType::File && inode.truncate_before_open(&how.o_flags) {
-        inode.resize(0)?;
+        vfs_truncate(inode.clone(), 0)?;
     }
     let file: File = File::new(inode, how.o_flags)?;
     let cloexec = how.o_flags.contains(FileFlags::O_CLOEXEC);

--- a/kernel/src/filesystem/vfs/syscall/dup2.rs
+++ b/kernel/src/filesystem/vfs/syscall/dup2.rs
@@ -1,7 +1,7 @@
 use system_error::SystemError;
 
 use crate::{
-    filesystem::vfs::file::{FileDescriptorVec, FileFlags},
+    filesystem::vfs::file::{DroppedFd, FileDescriptorVec, FileFlags},
     libs::rwsem::RwSemWriteGuard,
 };
 
@@ -9,7 +9,7 @@ pub fn do_dup2(
     oldfd: i32,
     newfd: i32,
     fd_table_guard: &mut RwSemWriteGuard<'_, FileDescriptorVec>,
-) -> Result<usize, SystemError> {
+) -> Result<(usize, Option<DroppedFd>), SystemError> {
     do_dup3(oldfd, newfd, FileFlags::empty(), fd_table_guard)
 }
 
@@ -18,7 +18,7 @@ pub fn do_dup3(
     newfd: i32,
     flags: FileFlags,
     fd_table_guard: &mut RwSemWriteGuard<'_, FileDescriptorVec>,
-) -> Result<usize, SystemError> {
+) -> Result<(usize, Option<DroppedFd>), SystemError> {
     // 检查 RLIMIT_NOFILE：newfd 必须小于软限制（与 Linux ksys_dup3 一致，返回 EBADF）
     let nofile = crate::process::ProcessManager::current_pcb()
         .get_rlimit(crate::process::resource::RLimitID::Nofile)
@@ -33,7 +33,7 @@ pub fn do_dup3(
         fd_table_guard
             .get_file_by_fd(oldfd)
             .ok_or(SystemError::EBADF)?;
-        return Ok(newfd as usize);
+        return Ok((newfd as usize, None));
     }
 
     // 验证 oldfd 有效（必须在当前 fd 表范围内且已打开）
@@ -43,17 +43,9 @@ pub fn do_dup3(
         .get_file_by_fd(oldfd)
         .ok_or(SystemError::EBADF)?;
 
-    // 如果 newfd 已被占用，先关闭它
-    if fd_table_guard.get_file_by_fd(newfd).is_some() && fd_table_guard.drop_fd(newfd).is_err() {
-        // An I/O error occurred while attempting to close fildes2.
-        return Err(SystemError::EIO);
-    }
-
     let cloexec = flags.contains(FileFlags::O_CLOEXEC);
 
     // 共享同一个 open file description（Arc<File>），符合 POSIX dup 语义
-    let res = fd_table_guard
-        .alloc_fd_arc(old_file, Some(newfd), cloexec)
-        .map(|x| x as usize);
-    return res;
+    let (res, dropped) = fd_table_guard.replace_fd_arc(old_file, newfd, cloexec)?;
+    return Ok((res as usize, dropped));
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_close.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_close.rs
@@ -48,7 +48,8 @@ syscall_table_macros::declare_syscall!(SYS_CLOSE, SysCloseHandle);
 pub(super) fn do_close(fd: i32) -> Result<usize, SystemError> {
     let binding = ProcessManager::current_pcb().fd_table();
     let mut fd_table_guard = binding.write();
-    let _file = fd_table_guard.drop_fd(fd)?;
+    let dropped = fd_table_guard.drop_fd(fd)?;
     drop(fd_table_guard);
+    dropped.finish_close()?;
     Ok(0)
 }

--- a/kernel/src/filesystem/vfs/syscall/sys_dup2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_dup2.rs
@@ -35,7 +35,14 @@ impl Syscall for SysDup2Handle {
         let newfd = Self::newfd(args);
         let binding = ProcessManager::current_pcb().fd_table();
         let mut fd_table_guard = binding.write();
-        return do_dup2(oldfd, newfd, &mut fd_table_guard);
+        let (newfd, dropped) = do_dup2(oldfd, newfd, &mut fd_table_guard)?;
+        drop(fd_table_guard);
+        if let Some(dropped) = dropped {
+            if let Err(err) = dropped.finish_close() {
+                log::warn!("dup2 implicit close failed after fd replacement: {:?}", err);
+            }
+        }
+        Ok(newfd)
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/filesystem/vfs/syscall/sys_dup3.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_dup3.rs
@@ -32,7 +32,14 @@ impl Syscall for SysDup3Handle {
 
         let binding = ProcessManager::current_pcb().fd_table();
         let mut fd_table_guard = binding.write();
-        return do_dup3(oldfd, newfd, flags, &mut fd_table_guard);
+        let (newfd, dropped) = do_dup3(oldfd, newfd, flags, &mut fd_table_guard)?;
+        drop(fd_table_guard);
+        if let Some(dropped) = dropped {
+            if let Err(err) = dropped.finish_close() {
+                log::warn!("dup3 implicit close failed after fd replacement: {:?}", err);
+            }
+        }
+        Ok(newfd)
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/filesystem/vfs/syscall/sys_fallocate.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fallocate.rs
@@ -1,8 +1,4 @@
-use crate::arch::ipc::signal::Signal;
 use crate::arch::syscall::nr::SYS_FALLOCATE;
-use crate::filesystem::vfs::{file::FileMode, FileType};
-use crate::ipc::kill::send_signal_to_pid;
-use crate::process::resource::RLimitID;
 use crate::{
     arch::interrupt::TrapFrame,
     process::ProcessManager,
@@ -49,56 +45,14 @@ impl Syscall for SysFallocateHandle {
         let offset = Self::offset(args)?;
         let len = Self::len(args)?;
 
-        // 暂时只支持 mode = 0
-        if mode != 0 {
-            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
-        }
-
-        if len == 0 {
-            return Err(SystemError::EINVAL);
-        }
         let binding = ProcessManager::current_pcb().fd_table();
         let fd_table_guard = binding.read();
 
         if let Some(file) = fd_table_guard.get_file_by_fd(fd) {
             drop(fd_table_guard);
 
-            let mode_flags = file.mode();
-
-            if mode_flags.contains(FileMode::FMODE_PATH) {
-                return Err(SystemError::EBADF);
-            }
-
-            if !mode_flags.contains(FileMode::FMODE_WRITE) || !mode_flags.can_write() {
-                return Err(SystemError::EBADF);
-            }
-
-            let md = file.inode().metadata()?;
-            match md.file_type {
-                FileType::File => { /* 普通文件，继续处理 */ }
-                FileType::Dir => return Err(SystemError::EISDIR),
-                FileType::Pipe => return Err(SystemError::ESPIPE),
-                _ => return Err(SystemError::ENODEV),
-            }
-
-            let new_size = offset.checked_add(len).ok_or(SystemError::EFBIG)?;
-
-            let current_size = md.size as usize;
-            // 暂不支持预分配能力，当 new_size <= current_size 时返回 EOPNOTSUPP
-            // 避免 Linux 应用误以为空间已预留，导致后续写入 ENOSPC 的隐蔽问题
-            if new_size <= current_size {
-                return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
-            }
-
-            let current_pcb = ProcessManager::current_pcb();
-            let fsize_limit = current_pcb.get_rlimit(RLimitID::Fsize);
-            if fsize_limit.rlim_cur != u64::MAX && new_size as u64 > fsize_limit.rlim_cur {
-                let _ = send_signal_to_pid(current_pcb.raw_pid(), Signal::SIGXFSZ);
-                return Err(SystemError::EFBIG);
-            }
-
-            let r = crate::filesystem::vfs::vcore::vfs_truncate(file.inode(), new_size).map(|_| 0);
-            return r;
+            return crate::filesystem::vfs::vcore::vfs_fallocate_file(file, mode, offset, len)
+                .map(|_| 0);
         }
 
         return Err(SystemError::EBADF);

--- a/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
@@ -101,16 +101,21 @@ impl SysFcntlHandle {
                 // 在RLIMIT_NOFILE范围内查找可用的文件描述符
                 for i in arg..nofile {
                     if fd_table_guard.get_file_by_fd(i as i32).is_none() {
-                        if cmd == FcntlCommand::DupFd {
-                            return do_dup2(fd, i as i32, &mut fd_table_guard);
+                        let (newfd, dropped) = if cmd == FcntlCommand::DupFd {
+                            do_dup2(fd, i as i32, &mut fd_table_guard)?
                         } else {
-                            return do_dup3(
-                                fd,
-                                i as i32,
-                                FileFlags::O_CLOEXEC,
-                                &mut fd_table_guard,
-                            );
+                            do_dup3(fd, i as i32, FileFlags::O_CLOEXEC, &mut fd_table_guard)?
+                        };
+                        drop(fd_table_guard);
+                        if let Some(dropped) = dropped {
+                            if let Err(err) = dropped.finish_close() {
+                                log::warn!(
+                                    "fcntl dup implicit close failed after fd replacement: {:?}",
+                                    err
+                                );
+                            }
                         }
+                        return Ok(newfd);
                     }
                 }
                 return Err(SystemError::EMFILE);

--- a/kernel/src/filesystem/vfs/syscall/sys_mount.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mount.rs
@@ -24,25 +24,29 @@ use crate::{
     },
 };
 use alloc::string::String;
+use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
 /// # Mount filesystem
 ///
-/// Used to mount filesystems. Currently only ramfs mount is supported.
+/// Handles the Linux-compatible `mount(2)` syscall entry point.
+///
+/// Depending on `mountflags`, this may create a new mount, bind mount, remount,
+/// move an existing mount, or change mount propagation attributes.
 ///
 /// ## Parameters:
 ///
-/// - source       Mount device (currently only ext4 format hard disks supported)
-/// - target       Mount target directory
-/// - filesystemtype   Filesystem type
-/// - mountflags     Mount flags
-/// - data        Data mount
+/// - `source`: source path/device string, or the mount path being moved for `MS_MOVE`
+/// - `target`: target mount point path
+/// - `filesystemtype`: filesystem type for new mounts; ignored by bind/move/propagation changes
+/// - `mountflags`: Linux `MS_*` mount flags
+/// - `data`: filesystem-specific mount data
 ///
 /// ## Return value
-/// - Ok(0): Mount successful
-/// - Err(SystemError): Error occurred during mounting
+/// - `Ok(0)`: mount operation completed successfully
+/// - `Err(SystemError)`: mount operation failed
 pub struct SysMountHandle;
 
 impl Syscall for SysMountHandle {
@@ -141,21 +145,26 @@ impl SysMountHandle {
 
 syscall_table_macros::declare_syscall!(SYS_MOUNT, SysMountHandle);
 
-/// # do_mount - Mount a filesystem
+/// # do_mount - Dispatch a mount operation
 ///
-/// Mounts the given filesystem to the specified mount point.
+/// Resolves `target` in the current mount namespace and dispatches the request
+/// according to `mount_flags`.
 ///
-/// This function checks whether the same filesystem is already mounted; if so, returns an error.
-/// It also handles symbolic links and ensures the mount point is valid.
+/// The resolved target path is passed down so `MountList` records the namespace
+/// mount point rather than a filesystem-specific synthetic path such as
+/// `fuse:<nodeid>`.
 ///
 /// ## Arguments
 ///
-/// - `fs`: Arc<dyn FileSystem>, the filesystem to mount.
-/// - `mount_point`: &str, the mount point path.
+/// - `source`: source path/device string, or the mount path being moved for `MS_MOVE`.
+/// - `target`: target mount point path from userspace.
+/// - `filesystemtype`: filesystem type for new mounts.
+/// - `data`: filesystem-specific mount data.
+/// - `mount_flags`: Linux `MS_*` mount flags.
 ///
 /// ## Return value
 ///
-/// - `Ok(Arc<MountFS>)`: Returns the mounted filesystem on success.
+/// - `Ok(())`: mount operation completed successfully.
 /// - `Err(SystemError)`: Returns an error on failure.
 pub fn do_mount(
     source: Option<String>,
@@ -170,11 +179,20 @@ pub fn do_mount(
         target.as_deref().unwrap_or(""),
     )?;
     let inode = current_node.lookup_follow_symlink(&rest_path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
-    return path_mount(source, inode, filesystemtype, data, mount_flags);
+    let resolved_target_path = inode.absolute_path()?;
+    return path_mount(
+        source,
+        &resolved_target_path,
+        inode,
+        filesystemtype,
+        data,
+        mount_flags,
+    );
 }
 
 fn path_mount(
     source: Option<String>,
+    target_path: &str,
     target_inode: Arc<dyn IndexNode>,
     filesystemtype: Option<String>,
     data: Option<String>,
@@ -258,7 +276,7 @@ fn path_mount(
     }
 
     if flags.contains(MountFlags::BIND) {
-        return do_bind_mount(source, target_inode, flags);
+        return do_bind_mount(source, target_path, target_inode, flags);
     }
     // Handle propagation type changes (mount --make-{shared,private,slave,unbindable})
     if is_propagation_change(flags) {
@@ -270,7 +288,15 @@ fn path_mount(
     }
 
     // Create a new mount
-    return do_new_mount(source, target_inode, filesystemtype, data, mnt_flags).map(|_| ());
+    return do_new_mount(
+        source,
+        target_path,
+        target_inode,
+        filesystemtype,
+        data,
+        mnt_flags,
+    )
+    .map(|_| ());
 }
 
 /// Modify the mount flags of an existing mount.
@@ -423,6 +449,7 @@ fn parse_remount_data(
 
 fn do_new_mount(
     source: Option<String>,
+    target_path: &str,
     target_inode: Arc<dyn IndexNode>,
     filesystemtype: Option<String>,
     data: Option<String>,
@@ -434,11 +461,34 @@ fn do_new_mount(
         log::warn!("Failed to produce filesystem: {:?}", e);
     })?;
 
-    let _abs_path = target_inode.absolute_path()?;
+    // target_path 已由 do_mount() 解析为命名空间绝对路径；不要在这里反查
+    // target inner inode 的 absolute_path()，FUSE/virtiofs 可能返回合成路径。
+    let new_mount_res: Result<Arc<MountFS>, SystemError> =
+        if let Some(mnt_inode) = target_inode.clone().downcast_arc::<MountFSInode>() {
+            let (to_mount_fs, root_inner_inode) = fs
+                .clone()
+                .downcast_arc::<MountFS>()
+                .map(|it| (it.inner_filesystem(), it.root_inner_inode()))
+                .unwrap_or_else(|| {
+                    let root_inner_inode = fs.root_inode();
+                    (fs, root_inner_inode)
+                });
 
-    // Linux lock_mount() preserves the user-specified mountpoint and keeps stacking mounts on top of it.
-    let new_mount = target_inode.mount(fs, mount_flags)?;
+            mnt_inode.mount_subtree_with_state(
+                to_mount_fs,
+                root_inner_inode,
+                mount_flags,
+                None,
+                None,
+                Some(Arc::new(MountPath::from(target_path))),
+            )
+        } else {
+            target_inode.mount(fs, mount_flags)
+        };
+
+    let new_mount = new_mount_res?;
     new_mount.set_mount_source(Some(source));
+
     Ok(new_mount)
 }
 #[inline(never)]
@@ -478,7 +528,8 @@ fn copy_mount_path_string(raw: Option<*const u8>) -> Result<Option<String>, Syst
 ///
 /// # Arguments
 /// * `source` - The source path to bind from
-/// * `target_inode` - The target mount point
+/// * `target_path` - Resolved namespace path of the target mount point
+/// * `target_inode` - The target mount point inode
 /// * `flags` - Mount flags (MS_BIND, optionally MS_REC)
 ///
 /// # Returns
@@ -486,6 +537,7 @@ fn copy_mount_path_string(raw: Option<*const u8>) -> Result<Option<String>, Syst
 /// * `Err(SystemError)` on failure
 fn do_bind_mount(
     source: Option<String>,
+    target_path: &str,
     target_inode: Arc<dyn IndexNode>,
     flags: MountFlags,
 ) -> Result<(), SystemError> {
@@ -505,6 +557,13 @@ fn do_bind_mount(
     )?;
     let source_inode =
         current_node.lookup_follow_symlink(&rest_path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+
+    // 穿越挂载点（含 FUSE announce-submounts 自动子挂载），避免 bind 仍绑定父 virtiofs 树上的 inode。
+    let source_inode: Arc<dyn IndexNode> = source_inode
+        .clone()
+        .downcast_arc::<MountFSInode>()
+        .map(|mnt| mnt.overlaid_inode() as Arc<dyn IndexNode>)
+        .unwrap_or(source_inode);
 
     let source_is_dir = source_inode.metadata()?.file_type == FileType::Dir;
     let target_is_dir = target_inode.metadata()?.file_type == FileType::Dir;
@@ -529,7 +588,6 @@ fn do_bind_mount(
     // Check if source is unbindable - if so, reject the bind mount
     if let Some(ref mfs) = source_mfs {
         if mfs.propagation().is_unbindable() {
-            // log::debug!("do_bind_mount: source is unbindable, rejecting bind mount");
             return Err(SystemError::EINVAL);
         }
     }
@@ -537,11 +595,18 @@ fn do_bind_mount(
     // Clone source_mfs for recursive bind mount (need to keep it for later use)
     let source_mfs_for_recursive = source_mfs.clone();
 
-    let root_inner_inode = source_inode
-        .clone()
-        .downcast_arc::<crate::filesystem::vfs::mount::MountFSInode>()
-        .map(|inode| inode.underlying_inode())
-        .unwrap_or_else(|| source_inode.clone());
+    let root_inner_inode = if is_mountpoint_root(&source_inode) {
+        source_mfs
+            .as_ref()
+            .map(|mfs| mfs.root_inner_inode())
+            .unwrap_or_else(|| source_inode.clone())
+    } else {
+        source_inode
+            .clone()
+            .downcast_arc::<MountFSInode>()
+            .map(|inode| inode.underlying_inode())
+            .unwrap_or_else(|| source_inode.clone())
+    };
 
     // Get the inner filesystem for mounting while preserving the source subtree root.
     let inner_fs = source_mfs
@@ -570,6 +635,7 @@ fn do_bind_mount(
                 .as_ref()
                 .map(|mfs| mfs.super_block_state()),
             source_mfs_for_recursive.as_ref(),
+            Some(Arc::new(MountPath::from(target_path))),
         )?;
     target_mfs.set_mount_source(Some(source_path.clone()));
 
@@ -669,6 +735,10 @@ fn do_change_type(target_inode: Arc<dyn IndexNode>, flags: MountFlags) -> Result
 /// # Arguments
 /// * `source` - The source path of the mount being moved.
 /// * `target_inode` - The target inode of the new mount point.
+///
+/// # Returns
+/// * `Ok(())` on success
+/// * `Err(SystemError)` on failure
 fn do_move_mount(
     source: Option<String>,
     target_inode: Arc<dyn IndexNode>,
@@ -757,13 +827,20 @@ fn do_move_mount(
 
     // Perform topology move + mount_list subtree path rewrite.
     //
-    // The source inode is the root inode inside the visible mounted filesystem.
-    // For stacked mounts, its absolute_path() may describe the mounted root from
-    // inside that filesystem rather than the parent-side mountpoint path stored
-    // in MountList. Use self_mountpoint() to get the actual namespace path where
-    // this mount is attached.
-    let old_source_path = source_mountpoint.absolute_path()?;
-    let new_target_path = target_mountpoint.absolute_path()?;
+    // Use mount_list paths: virtiofs/FUSE absolute_path() may return "fuse:<nodeid>"
+    // instead of the namespace mountpoint (e.g. /run/kata-containers/.../rootfs).
+    let old_source_path = current_mntns
+        .mount_list()
+        .get_mount_path_by_mountfs(&source_mfs)
+        .map(|p| p.as_str().to_string())
+        .or_else(|| source_mountpoint.absolute_path().ok())
+        .filter(|p| p.starts_with('/'))
+        .ok_or(SystemError::EINVAL)?;
+    let new_target_path = target_mountpoint
+        .absolute_path()
+        .ok()
+        .filter(|p| p.starts_with('/'))
+        .ok_or(SystemError::EINVAL)?;
     current_mntns.move_mount(
         &source_mfs,
         &target_mountpoint,
@@ -804,7 +881,9 @@ fn tree_contains_unbindable(root: &Arc<MountFS>) -> bool {
 ///
 /// # Arguments
 /// * `source_mfs` - The source MountFS to copy submounts from
-/// * `target_mfs` - The target MountFS to create submounts in
+/// * `_target_mfs` - The target MountFS for the recursive bind operation. The
+///   current implementation derives concrete child targets from
+///   `target_base_path`.
 /// * `source_base_path` - The absolute path of the source mount point
 /// * `target_base_path` - The absolute path of the target mount point
 ///
@@ -923,6 +1002,7 @@ fn do_recursive_bind_mount(
                 MountFlags::empty(),
                 Some(info.source_mfs.super_block_state()),
                 Some(&info.source_mfs),
+                None,
             ) {
             Ok(new_child_mnt) => {
                 let source = info

--- a/kernel/src/filesystem/vfs/syscall/sys_truncate.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_truncate.rs
@@ -25,7 +25,7 @@ use crate::filesystem::vfs::vcore::vfs_truncate;
 /// - 跟随符号链接定位最终 inode。
 /// - 目录返回 EISDIR；非普通文件返回 EINVAL。
 /// - 只读挂载点返回 EROFS。
-/// - 调用 inode.resize(length)。
+/// - 通过 VFS truncate 封装执行公共检查和文件系统 resize。
 pub struct SysTruncateHandle;
 
 impl Syscall for SysTruncateHandle {

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -16,15 +16,22 @@ use crate::{
         procfs::procfs_init,
         sysfs::sysfs_init,
         vfs::{
-            file::FilePrivateData, mount::MountFlags, permission::PermissionMask, AtomicInodeId,
-            FileSystem, FileType, InodeFlags, InodeMode, MountFS,
+            file::{File, FileMode, FilePrivateData},
+            mount::MountFlags,
+            permission::PermissionMask,
+            AtomicInodeId, FileSystem, FileType, InodeFlags, InodeMode, MountFS,
         },
     },
     init::cmdline::kenrel_cmdline_param_manager,
+    ipc::kill::send_signal_to_pid,
     libs::mutex::MutexGuard,
     mm::truncate::truncate_inode_pages,
-    process::{cred::CAPFlags, namespace::mnt::mnt_namespace_init, ProcessManager},
+    process::{
+        cred::CAPFlags, namespace::mnt::mnt_namespace_init, resource::RLimitID, ProcessManager,
+    },
 };
+
+use crate::arch::ipc::signal::Signal;
 
 use super::{
     stat::LookUpFlags,
@@ -702,6 +709,13 @@ pub(super) fn do_file_lookup_at(
     return inode.lookup_follow_symlink2(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES, follow_final);
 }
 
+#[inline]
+pub fn current_file_lock_owner_id() -> u64 {
+    let binding = ProcessManager::current_pcb().fd_table();
+    let fd_table_guard = binding.read();
+    fd_table_guard.lock_owner_id() as u64
+}
+
 #[inline(never)]
 fn vfs_truncate_inner<F>(
     inode: Arc<dyn IndexNode>,
@@ -786,7 +800,10 @@ where
 /// - 只读挂载返回 EROFS
 #[inline(never)]
 pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemError> {
-    vfs_truncate_inner(inode, len, |inode| inode.resize(len))
+    let lock_owner = current_file_lock_owner_id();
+    vfs_truncate_inner(inode, len, |inode| {
+        inode.resize_with_lock_owner(len, lock_owner)
+    })
 }
 
 /// 基于已打开文件执行 VFS 截断，保留公共检查，并把 fd 私有数据传给文件系统。
@@ -794,7 +811,120 @@ pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemE
 pub fn vfs_truncate_file<'a>(
     inode: Arc<dyn IndexNode>,
     len: usize,
+    lock_owner: u64,
     data: impl FnOnce() -> MutexGuard<'a, FilePrivateData>,
 ) -> Result<(), SystemError> {
-    vfs_truncate_inner(inode, len, |inode| inode.resize_file(len, data()))
+    vfs_truncate_inner(inode, len, |inode| {
+        inode.resize_file(len, lock_owner, data())
+    })
+}
+
+pub fn check_file_size_limit(new_size: usize) -> Result<(), SystemError> {
+    let current_pcb = ProcessManager::current_pcb();
+    let fsize_limit = current_pcb.get_rlimit(RLimitID::Fsize);
+    if fsize_limit.rlim_cur != u64::MAX && new_size as u64 > fsize_limit.rlim_cur {
+        let _ = send_signal_to_pid(current_pcb.raw_pid(), Signal::SIGXFSZ);
+        return Err(SystemError::EFBIG);
+    }
+    Ok(())
+}
+
+/// 基于已打开文件执行 VFS fallocate 公共检查，再分派给具体文件系统。
+#[inline(never)]
+pub fn vfs_fallocate_file(
+    file: Arc<File>,
+    mode: i32,
+    offset: usize,
+    len: usize,
+) -> Result<(), SystemError> {
+    const FALLOC_FL_KEEP_SIZE: u32 = 0x01;
+    const FALLOC_FL_PUNCH_HOLE: u32 = 0x02;
+    const FALLOC_FL_COLLAPSE_RANGE: u32 = 0x08;
+    const FALLOC_FL_ZERO_RANGE: u32 = 0x10;
+    const FALLOC_FL_INSERT_RANGE: u32 = 0x20;
+    const FALLOC_FL_UNSHARE_RANGE: u32 = 0x40;
+    const FALLOC_FL_SUPPORTED_MASK: u32 = FALLOC_FL_KEEP_SIZE
+        | FALLOC_FL_PUNCH_HOLE
+        | FALLOC_FL_COLLAPSE_RANGE
+        | FALLOC_FL_ZERO_RANGE
+        | FALLOC_FL_INSERT_RANGE
+        | FALLOC_FL_UNSHARE_RANGE;
+
+    if len == 0 || offset > isize::MAX as usize || len > isize::MAX as usize {
+        return Err(SystemError::EINVAL);
+    }
+
+    let mode_bits = mode as u32;
+    if mode < 0 || (mode_bits & !FALLOC_FL_SUPPORTED_MASK) != 0 {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    if (mode_bits & (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_ZERO_RANGE))
+        == (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_ZERO_RANGE)
+    {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    if (mode_bits & FALLOC_FL_PUNCH_HOLE) != 0 && (mode_bits & FALLOC_FL_KEEP_SIZE) == 0 {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    if (mode_bits & FALLOC_FL_COLLAPSE_RANGE) != 0 && (mode_bits & !FALLOC_FL_COLLAPSE_RANGE) != 0 {
+        return Err(SystemError::EINVAL);
+    }
+    if (mode_bits & FALLOC_FL_INSERT_RANGE) != 0 && (mode_bits & !FALLOC_FL_INSERT_RANGE) != 0 {
+        return Err(SystemError::EINVAL);
+    }
+    if (mode_bits & FALLOC_FL_UNSHARE_RANGE) != 0
+        && (mode_bits & !(FALLOC_FL_UNSHARE_RANGE | FALLOC_FL_KEEP_SIZE)) != 0
+    {
+        return Err(SystemError::EINVAL);
+    }
+
+    let mode_flags = file.mode();
+    if mode_flags.contains(FileMode::FMODE_PATH) {
+        return Err(SystemError::EBADF);
+    }
+    if !mode_flags.contains(FileMode::FMODE_WRITE) || !mode_flags.can_write() {
+        return Err(SystemError::EBADF);
+    }
+
+    let inode = file.inode();
+    let md = inode.metadata()?;
+    if md.flags.contains(InodeFlags::S_APPEND) && (mode_bits & !FALLOC_FL_KEEP_SIZE) != 0 {
+        return Err(SystemError::EPERM);
+    }
+    if md.flags.contains(InodeFlags::S_IMMUTABLE) {
+        return Err(SystemError::EPERM);
+    }
+    if md.flags.contains(InodeFlags::S_SWAPFILE) {
+        return Err(SystemError::ETXTBSY);
+    }
+
+    let fs = inode.fs();
+    if let Some(mfs) = fs.clone().downcast_arc::<MountFS>() {
+        if mfs
+            .mount_flags()
+            .contains(crate::filesystem::vfs::mount::MountFlags::RDONLY)
+        {
+            return Err(SystemError::EROFS);
+        }
+    }
+
+    match md.file_type {
+        FileType::File | FileType::BlockDevice => {}
+        FileType::Dir => return Err(SystemError::EISDIR),
+        FileType::Pipe => return Err(SystemError::ESPIPE),
+        _ => return Err(SystemError::ENODEV),
+    }
+
+    let new_size = offset.checked_add(len).ok_or(SystemError::EFBIG)?;
+    if new_size > isize::MAX as usize {
+        return Err(SystemError::EFBIG);
+    }
+
+    inode.fallocate_file(
+        mode,
+        offset,
+        len,
+        current_file_lock_owner_id(),
+        file.private_data.lock(),
+    )
 }

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -16,11 +16,12 @@ use crate::{
         procfs::procfs_init,
         sysfs::sysfs_init,
         vfs::{
-            mount::MountFlags, permission::PermissionMask, AtomicInodeId, FileSystem, FileType,
-            InodeFlags, InodeMode, MountFS,
+            file::FilePrivateData, mount::MountFlags, permission::PermissionMask, AtomicInodeId,
+            FileSystem, FileType, InodeFlags, InodeMode, MountFS,
         },
     },
     init::cmdline::kenrel_cmdline_param_manager,
+    libs::mutex::MutexGuard,
     mm::truncate::truncate_inode_pages,
     process::{cred::CAPFlags, namespace::mnt::mnt_namespace_init, ProcessManager},
 };
@@ -701,12 +702,15 @@ pub(super) fn do_file_lookup_at(
     return inode.lookup_follow_symlink2(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES, follow_final);
 }
 
-/// 统一的 VFS 截断封装：对 inode 进行基本检查并调用 resize
-/// - 目录返回 EISDIR
-/// - 非普通文件返回 EINVAL
-/// - 只读挂载返回 EROFS
 #[inline(never)]
-pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemError> {
+fn vfs_truncate_inner<F>(
+    inode: Arc<dyn IndexNode>,
+    len: usize,
+    do_resize: F,
+) -> Result<(), SystemError>
+where
+    F: FnOnce(&Arc<dyn IndexNode>) -> Result<(), SystemError>,
+{
     let md = inode.metadata()?;
     let old_size = md.size;
 
@@ -746,7 +750,7 @@ pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemE
         }
     }
 
-    let result = inode.resize(len);
+    let result = do_resize(&inode);
 
     // Linux 语义：对普通文件进行截断（且确实改变 size）后，若无 CAP_FSETID，清理 suid/sgid。
     if result.is_ok() && old_size != len as i64 {
@@ -774,4 +778,23 @@ pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemE
     }
 
     result
+}
+
+/// 统一的 VFS 截断封装：对 inode 进行基本检查并调用 resize
+/// - 目录返回 EISDIR
+/// - 非普通文件返回 EINVAL
+/// - 只读挂载返回 EROFS
+#[inline(never)]
+pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemError> {
+    vfs_truncate_inner(inode, len, |inode| inode.resize(len))
+}
+
+/// 基于已打开文件执行 VFS 截断，保留公共检查，并把 fd 私有数据传给文件系统。
+#[inline(never)]
+pub fn vfs_truncate_file<'a>(
+    inode: Arc<dyn IndexNode>,
+    len: usize,
+    data: impl FnOnce() -> MutexGuard<'a, FilePrivateData>,
+) -> Result<(), SystemError> {
+    vfs_truncate_inner(inode, len, |inode| inode.resize_file(len, data()))
 }

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -766,23 +766,8 @@ where
 
     let result = do_resize(&inode);
 
-    // Linux 语义：对普通文件进行截断（且确实改变 size）后，若无 CAP_FSETID，清理 suid/sgid。
     if result.is_ok() && old_size != len as i64 {
-        let cred = ProcessManager::current_pcb().cred();
-        if !cred.has_capability(CAPFlags::CAP_FSETID) {
-            let mut md2 = inode.metadata()?;
-            if md2.file_type == FileType::File
-                && md2.mode.intersects(InodeMode::S_ISUID | InodeMode::S_ISGID)
-            {
-                md2.mode.remove(InodeMode::S_ISUID);
-
-                if should_remove_sgid(md2.mode, md2.gid, &cred) {
-                    md2.mode.remove(InodeMode::S_ISGID);
-                }
-
-                inode.set_metadata(&md2)?;
-            }
-        }
+        clear_suid_sgid_after_size_change(inode.as_ref())?;
     }
 
     if result.is_ok() && len < old_size as usize {
@@ -792,6 +777,27 @@ where
     }
 
     result
+}
+
+fn clear_suid_sgid_after_size_change(inode: &dyn IndexNode) -> Result<(), SystemError> {
+    let cred = ProcessManager::current_pcb().cred();
+    if cred.has_capability(CAPFlags::CAP_FSETID) {
+        return Ok(());
+    }
+
+    let mut md = inode.metadata()?;
+    if md.file_type == FileType::File && md.mode.intersects(InodeMode::S_ISUID | InodeMode::S_ISGID)
+    {
+        md.mode.remove(InodeMode::S_ISUID);
+
+        if should_remove_sgid(md.mode, md.gid, &cred) {
+            md.mode.remove(InodeMode::S_ISGID);
+        }
+
+        inode.set_metadata(&md)?;
+    }
+
+    Ok(())
 }
 
 /// 统一的 VFS 截断封装：对 inode 进行基本检查并调用 resize
@@ -827,6 +833,48 @@ pub fn check_file_size_limit(new_size: usize) -> Result<(), SystemError> {
         return Err(SystemError::EFBIG);
     }
     Ok(())
+}
+
+/// Generic resize-backed `fallocate(mode=0)` for real local regular files.
+///
+/// This helper provides DragonOS' compatibility guarantee that mode=0 makes the
+/// file size at least `offset + len`. It is intentionally opt-in: pseudo
+/// filesystems and protocol filesystems must keep returning EOPNOTSUPP or
+/// provide their own fallocate implementation.
+pub fn resize_based_fallocate(
+    inode: &dyn IndexNode,
+    mode: i32,
+    offset: usize,
+    len: usize,
+    lock_owner: u64,
+) -> Result<(), SystemError> {
+    if mode != 0 {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+
+    let new_size = offset.checked_add(len).ok_or(SystemError::EFBIG)?;
+    if new_size > isize::MAX as usize {
+        return Err(SystemError::EFBIG);
+    }
+
+    let md = inode.metadata()?;
+    if md.file_type != FileType::File {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+
+    let current_size = md.size.max(0) as usize;
+    if new_size <= current_size {
+        return Ok(());
+    }
+
+    check_file_size_limit(new_size)?;
+
+    let result = inode.resize_with_lock_owner(new_size, lock_owner);
+    if result.is_ok() && md.size != new_size as i64 {
+        clear_suid_sgid_after_size_change(inode)?;
+    }
+
+    result
 }
 
 /// 基于已打开文件执行 VFS fallocate 公共检查，再分派给具体文件系统。

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -6,6 +6,7 @@ use core::{
 };
 
 use alloc::sync::Arc;
+use system_error::SystemError;
 
 use crate::{
     arch::{mm::PageMapper, MMArch},
@@ -134,6 +135,15 @@ impl<'a> PageFaultMessage<'a> {
 pub struct PageFaultHandler;
 
 impl PageFaultHandler {
+    fn mkwrite_finished(ret: VmFaultReason) -> bool {
+        ret.intersects(
+            VmFaultReason::VM_FAULT_ERROR
+                | VmFaultReason::VM_FAULT_NOPAGE
+                | VmFaultReason::VM_FAULT_RETRY
+                | VmFaultReason::VM_FAULT_COMPLETED,
+        )
+    }
+
     fn attach_fault_mapped_page(page: &Arc<Page>, vma: &Arc<LockedVMA>, mlocked: bool) {
         let mut page_guard = page.write();
         page_guard.insert_vma(vma.clone());
@@ -485,6 +495,11 @@ impl PageFaultHandler {
             return ret;
         }
 
+        ret = ret.union(fs.page_mkwrite(pfm));
+        if Self::mkwrite_finished(ret) {
+            return ret;
+        }
+
         let cache_page = pfm.page.clone().expect("no cache_page in PageFaultMessage");
 
         // 将pagecache页设为脏页，以便回收时能够回写
@@ -552,16 +567,33 @@ impl PageFaultHandler {
         let address = pfm.address_aligned_down();
         let vma = pfm.vma.clone();
         let mm = pfm.mm().clone();
-        let _pt_edit = mm.page_table_edit();
-        let mapper = &mut pfm.mapper;
 
-        let old_paddr = mapper.translate(address).unwrap().0;
+        let Some((old_paddr, _old_flags)) = pfm.mapper.translate(address) else {
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        };
         let mut page_manager = page_manager_lock();
         let old_page = page_manager.get_unwrap(&old_paddr);
         let map_count = old_page.read().map_count();
         drop(page_manager);
 
-        let mut entry = mapper.get_entry(address, 0).unwrap();
+        if vma.lock().vm_flags().contains(VmFlags::VM_SHARED) {
+            if let Some(file) = vma.lock().vm_file() {
+                pfm.set_page(old_page.clone());
+                let ret = file.inode().fs().page_mkwrite(pfm);
+                if Self::mkwrite_finished(ret) {
+                    return ret;
+                }
+            }
+        }
+
+        let _pt_edit = mm.page_table_edit();
+        let mapper = &mut pfm.mapper;
+        let Some(mut entry) = mapper.get_entry(address, 0) else {
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        };
+        if entry.address() != Ok(old_paddr) {
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        }
         let new_flags = entry.flags().set_write(true).set_dirty(true);
 
         // 统一为 do_wp_page 所有分支做 mm-aware shootdown：
@@ -575,15 +607,14 @@ impl PageFaultHandler {
             // 共享映射：原地升级 PTE 为可写，并标记脏。
             let table = mapper.get_table(address, 0).unwrap();
             let i = table.index_of(address).unwrap();
-            entry.set_flags(new_flags);
-            table.set_entry(i, entry);
-
             old_page.write().add_flags(PageFlags::PG_DIRTY);
             if let PageType::File(info) = old_page.read().page_type().clone() {
                 if let Some(page_cache) = info.page_cache.upgrade() {
                     page_cache.mark_page_dirty(info.index);
                 }
             }
+            entry.set_flags(new_flags);
+            table.set_entry(i, entry);
 
             // PTE 从 RO 升级为 RW：其他 CPU 持有的 RO 缓存会导致它们访问时触发虚假写保护 fault，
             // 必须 mm-aware shootdown 让其它 CPU 重新 walk 最新 PTE。
@@ -838,6 +869,48 @@ impl PageFaultHandler {
             }
         }
         ret
+    }
+
+    pub unsafe fn filemap_page_mkwrite(pfm: &mut PageFaultMessage) -> VmFaultReason {
+        let vma = pfm.vma();
+        let vma_guard = vma.lock();
+        let file = vma_guard.vm_file().expect("no vm_file in vma");
+        drop(vma_guard);
+
+        let page = match pfm.page.clone() {
+            Some(page) => page,
+            None => return VmFaultReason::VM_FAULT_SIGBUS,
+        };
+        let (page_cache, page_index) = match page.read().page_type().clone() {
+            PageType::File(info) => match info.page_cache.upgrade() {
+                Some(page_cache) => (page_cache, info.index),
+                None => return VmFaultReason::VM_FAULT_SIGBUS,
+            },
+            _ => return VmFaultReason::VM_FAULT_SIGBUS,
+        };
+
+        let backing_pgoff = match pfm.backing_pgoff {
+            Some(backing_pgoff) => backing_pgoff,
+            None => return VmFaultReason::VM_FAULT_SIGBUS,
+        };
+        if page_index != backing_pgoff {
+            return VmFaultReason::VM_FAULT_RETRY;
+        }
+
+        if let Ok(md) = file.inode().metadata() {
+            let size = md.size.max(0) as usize;
+            if size == 0 || backing_pgoff.saturating_mul(MMArch::PAGE_SIZE) >= size {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            }
+        }
+
+        match page_cache.manager().prepare_page_mkwrite(page_index, &page) {
+            Ok(()) => {}
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => return VmFaultReason::VM_FAULT_RETRY,
+            Err(_) => return VmFaultReason::VM_FAULT_SIGBUS,
+        }
+
+        VmFaultReason::empty()
     }
 
     /// 纯 page-cache 后端的缺页处理（不走 pread/磁盘 IO）。

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -113,6 +113,16 @@ impl<'a> PageFaultMessage<'a> {
         self.flags
     }
 
+    #[inline(always)]
+    pub fn backing_pgoff(&self) -> Option<usize> {
+        self.backing_pgoff
+    }
+
+    #[inline(always)]
+    pub fn set_page(&mut self, page: Arc<Page>) {
+        self.page = Some(page);
+    }
+
     /// 缺页所属的地址空间。
     #[inline(always)]
     pub fn mm(&self) -> &Arc<AddressSpace> {
@@ -384,7 +394,8 @@ impl PageFaultHandler {
         let _invalidate = page_cache
             .as_ref()
             .map(|page_cache| page_cache.invalidate_read());
-        let mut ret = Self::filemap_fault(pfm);
+        let fs = pfm.vma().lock().vm_file().unwrap().inode().fs();
+        let mut ret = fs.fault(pfm);
 
         if unlikely(ret.intersects(
             VmFaultReason::VM_FAULT_ERROR
@@ -392,6 +403,9 @@ impl PageFaultHandler {
                 | VmFaultReason::VM_FAULT_RETRY
                 | VmFaultReason::VM_FAULT_DONE_COW,
         )) {
+            return ret;
+        }
+        if ret.contains(VmFaultReason::VM_FAULT_COMPLETED) {
             return ret;
         }
 
@@ -461,9 +475,13 @@ impl PageFaultHandler {
         let _invalidate = page_cache
             .as_ref()
             .map(|page_cache| page_cache.invalidate_read());
-        let mut ret = Self::filemap_fault(pfm);
+        let fs = pfm.vma().lock().vm_file().unwrap().inode().fs();
+        let mut ret = fs.fault(pfm);
 
         if ret.intersects(VmFaultReason::VM_FAULT_ERROR) {
+            return ret;
+        }
+        if ret.contains(VmFaultReason::VM_FAULT_COMPLETED) {
             return ret;
         }
 

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -577,7 +577,11 @@ impl PageFaultHandler {
         drop(page_manager);
 
         if vma.lock().vm_flags().contains(VmFlags::VM_SHARED) {
-            if let Some(file) = vma.lock().vm_file() {
+            let file = {
+                let guard = vma.lock();
+                guard.vm_file()
+            };
+            if let Some(file) = file {
                 pfm.set_page(old_page.clone());
                 let ret = file.inode().fs().page_mkwrite(pfm);
                 if Self::mkwrite_finished(ret) {
@@ -810,10 +814,14 @@ impl PageFaultHandler {
                     let address =
                         VirtAddr::new(addr.data() + ((pgoff - start_pgoff) << MMArch::PAGE_SHIFT));
                     if mapper.get_entry(address, 0).is_none() {
-                        mapper
-                            .map_phys(address, phys, vma_guard.flags())
-                            .unwrap()
-                            .flush();
+                        let mut flags = vma_guard.flags();
+                        if vma_guard
+                            .vm_flags()
+                            .contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE)
+                        {
+                            flags = flags.set_write(false);
+                        }
+                        mapper.map_phys(address, phys, flags).unwrap().flush();
                     }
                     drop(page_guard);
                     Self::attach_fault_mapped_page(&page, &vma, mlocked);
@@ -986,7 +994,16 @@ impl PageFaultHandler {
         let page_phys = page_to_map.phys_address();
         let mlocked = vma_guard.vm_flags().contains(VmFlags::VM_LOCKED);
 
-        mapper.map_phys(address, page_phys, vma_guard.flags());
+        let mut map_flags = vma_guard.flags();
+        if vma_guard
+            .vm_flags()
+            .contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE)
+            && !flags.contains(FaultFlags::FAULT_FLAG_WRITE)
+        {
+            map_flags = map_flags.set_write(false);
+        }
+
+        mapper.map_phys(address, page_phys, map_flags);
         Self::attach_fault_mapped_page(&page_to_map, &pfm.vma(), mlocked);
         VmFaultReason::VM_FAULT_COMPLETED
     }

--- a/kernel/src/mm/syscall/sys_fadvise64.rs
+++ b/kernel/src/mm/syscall/sys_fadvise64.rs
@@ -102,8 +102,10 @@ pub fn do_fadvise(fd: i32, offset: i64, len: i64, advise: i32) -> Result<usize, 
         return Err(SystemError::ESPIPE);
     }
 
+    let advice = PosixFadviseFlag::from_i32(advise)?;
+
     // 根据POSIX规范，len == 0 表示从offset到文件结尾
-    if len < 0 || inode.page_cache().is_none() {
+    if offset < 0 || len < 0 {
         return Err(SystemError::EINVAL);
     }
 
@@ -114,12 +116,13 @@ pub fn do_fadvise(fd: i32, offset: i64, len: i64, advise: i32) -> Result<usize, 
 
     // 后续需要考虑DAX和noop_backing_dev_info
 
-    let mut endbyte = offset.saturating_add(len) as usize;
-    if len == 0 {
-        endbyte = usize::MAX;
-    }
+    let endbyte = if len == 0 {
+        usize::MAX
+    } else {
+        offset.checked_add(len - 1).ok_or(SystemError::EINVAL)? as usize
+    };
 
-    match PosixFadviseFlag::from_i32(advise)? {
+    match advice {
         PosixFadviseFlag::Normal => {
             file.set_ra_pages(MAX_READAHEAD);
             file.remove_mode_flags(FileMode::FMODE_RANDOM | FileMode::FMODE_NOREUSE);
@@ -132,29 +135,36 @@ pub fn do_fadvise(fd: i32, offset: i64, len: i64, advise: i32) -> Result<usize, 
             file.remove_mode_flags(FileMode::FMODE_RANDOM);
         }
         PosixFadviseFlag::WillNeed => {
-            let start_page = (offset >> MMArch::PAGE_SHIFT) as usize;
-            let end_page = (endbyte - 1) >> MMArch::PAGE_SHIFT;
-            let mut page_num = end_page - start_page + 1;
-            if page_num == 0 {
-                page_num = usize::MAX;
-            }
+            let Some(page_cache) = inode.page_cache() else {
+                return Ok(0);
+            };
+            let start_page = (offset as usize) >> MMArch::PAGE_SHIFT;
+            let end_page = endbyte >> MMArch::PAGE_SHIFT;
+            let page_num = end_page.saturating_sub(start_page).saturating_add(1);
 
-            let inode = file.inode();
-            let page_cache = inode.page_cache().unwrap();
             let mut ra_state = file.get_ra_state();
             force_page_cache_readahead(&page_cache, &inode, &mut ra_state, start_page, page_num)?;
             file.set_ra_state(ra_state)?;
         }
         PosixFadviseFlag::NoReuse => {
-            file.remove_mode_flags(FileMode::FMODE_NOREUSE);
+            file.set_mode_flags(FileMode::FMODE_NOREUSE);
         }
         PosixFadviseFlag::DontNeed => {
+            let Some(page_cache) = inode.page_cache() else {
+                return Ok(0);
+            };
             let start_index = page_align_up(offset as usize) >> MMArch::PAGE_SHIFT;
             let mut end_index = endbyte >> MMArch::PAGE_SHIFT;
+            let metadata = inode.metadata()?;
+            let last_file_byte = if metadata.size > 0 {
+                Some(metadata.size as usize - 1)
+            } else {
+                None
+            };
 
             // 如果要驱逐的最后一页不是整页，则需要保留
             if (endbyte & MMArch::PAGE_OFFSET_MASK) != MMArch::PAGE_OFFSET_MASK
-                && endbyte != inode.metadata()?.size as usize - 1
+                && Some(endbyte) != last_file_byte
             {
                 if end_index == 0 {
                     return Ok(0);
@@ -165,7 +175,6 @@ pub fn do_fadvise(fd: i32, offset: i64, len: i64, advise: i32) -> Result<usize, 
             // 若以后实现了per-CPU LRU批处理，需要额外处理（lru_add_drain）
 
             if end_index >= start_index {
-                let page_cache = inode.page_cache().unwrap();
                 // 先写回脏页
                 page_cache
                     .manager()

--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -883,10 +883,16 @@ impl InnerAddressSpace {
             .mmap(start_page.virt_address().data(), len, offset)
         {
             Ok(_) => {
+                if let Some(vma) = self.mappings.contains(start_page.virt_address()) {
+                    self.mappings.attach_vma(&vma);
+                }
                 self.post_map_population(start_page.virt_address(), len, map_flags);
                 Ok(start_page)
             }
             Err(SystemError::ENOSYS) => {
+                if let Some(vma) = self.mappings.contains(start_page.virt_address()) {
+                    self.mappings.attach_vma(&vma);
+                }
                 self.post_map_population(start_page.virt_address(), len, map_flags);
                 Ok(start_page)
             } // 文件系统未实现 mmap，视为成功
@@ -1431,7 +1437,19 @@ impl InnerAddressSpace {
 
         for r in regions {
             // debug!("mprotect: r: {:?}", r);
-            let r = *r.lock().region();
+            let (r, new_vm_flags) = {
+                let guard = r.lock();
+                if !guard.can_have_flags(prot_flags) {
+                    return Err(SystemError::EACCES);
+                }
+                let old_vm_flags = *guard.vm_flags();
+                let access_flags = VmFlags::VM_READ | VmFlags::VM_WRITE | VmFlags::VM_EXEC;
+                let new_vm_flags = (old_vm_flags & !access_flags) | VmFlags::from(prot_flags);
+                if let Some(file) = guard.vm_file() {
+                    file.inode().fs().mprotect(old_vm_flags, new_vm_flags)?;
+                }
+                (*guard.region(), new_vm_flags)
+            };
             let r = self.mappings.remove_vma(&r).unwrap();
 
             let intersection = r.lock().region().intersect(&region).unwrap();
@@ -1442,19 +1460,12 @@ impl InnerAddressSpace {
                     .expect("Failed to extract VMA");
 
                 let mut r_guard = r.lock();
-                if !r_guard.can_have_flags(prot_flags) {
-                    Err(SystemError::EACCES)
-                } else {
-                    r_guard.set_vm_flags(VmFlags::from(prot_flags));
+                r_guard.set_vm_flags(new_vm_flags);
 
-                    let new_flags: EntryFlags<MMArch> = r_guard
-                        .flags()
-                        .set_execute(prot_flags.contains(ProtFlags::PROT_EXEC))
-                        .set_write(prot_flags.contains(ProtFlags::PROT_WRITE));
+                let new_flags: EntryFlags<MMArch> = MMArch::vm_get_page_prot(new_vm_flags);
 
-                    r_guard.remap(new_flags, mapper, &mut tlb)?;
-                    Ok((split_result.prev, split_result.after))
-                }
+                r_guard.remap(new_flags, mapper, &mut tlb)?;
+                Ok((split_result.prev, split_result.after))
             };
             let (before, after) = match remap_result {
                 Ok(result) => result,
@@ -2299,14 +2310,14 @@ impl LockedVMA {
     ) -> Result<(), SystemError> {
         let mut guard = self.lock();
         for page in guard.region.pages() {
-            // 暂时要求所有的页帧都已经映射到页表
-            // TODO: 引入Lazy Mapping, 通过缺页中断来映射页帧，这里就不必要求所有的页帧都已经映射到页表了
-            let r = unsafe {
-                mapper
-                    .remap(page.virt_address(), flags)
-                    .expect("Failed to remap, beacuse of some page is not mapped")
-            };
-            flusher.consume(r);
+            if mapper.translate(page.virt_address()).is_some() {
+                let r = unsafe {
+                    mapper
+                        .remap(page.virt_address(), flags)
+                        .expect("Failed to remap")
+                };
+                flusher.consume(r);
+            }
         }
         guard.flags = flags;
         return Ok(());

--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -833,8 +833,7 @@ impl InnerAddressSpace {
             }
         }
 
-        let meta = file.metadata()?;
-        if matches!(meta.file_type, FileType::Pipe | FileType::Dir) {
+        if matches!(file.file_type(), FileType::Pipe | FileType::Dir) {
             return Err(SystemError::ENODEV);
         }
 
@@ -845,6 +844,15 @@ impl InnerAddressSpace {
         let pgoff = offset >> MMArch::PAGE_SHIFT;
 
         let page_count = PageFrameCount::from_bytes(len).unwrap();
+        let precheck_vm_flags = VmFlags::from(prot_flags)
+            | VmFlags::from(map_flags)
+            | self.mlock_future
+            | VmFlags::VM_MAYREAD
+            | VmFlags::VM_MAYWRITE
+            | VmFlags::VM_MAYEXEC;
+        file.inode()
+            .check_mmap_file(&file, len, offset, precheck_vm_flags)?;
+
         let start_page: VirtPageFrame = self.mmap(
             round_hint_to_min(start_vaddr),
             page_count,
@@ -878,19 +886,28 @@ impl InnerAddressSpace {
         // todo!(impl mmap for other file)
         // https://github.com/DragonOS-Community/DragonOS/pull/912#discussion_r1765334272
         // 传入实际映射后的起始虚拟地址，而非用户传入的 hint
-        match file
-            .inode()
-            .mmap(start_page.virt_address().data(), len, offset)
-        {
+        let vma = self.mappings.contains(start_page.virt_address());
+        let vm_flags = vma
+            .as_ref()
+            .map(|vma| *vma.lock().vm_flags())
+            .unwrap_or(VmFlags::empty());
+
+        match file.inode().mmap_file(
+            &file,
+            start_page.virt_address().data(),
+            len,
+            offset,
+            vm_flags,
+        ) {
             Ok(_) => {
-                if let Some(vma) = self.mappings.contains(start_page.virt_address()) {
+                if let Some(vma) = vma {
                     self.mappings.attach_vma(&vma);
                 }
                 self.post_map_population(start_page.virt_address(), len, map_flags);
                 Ok(start_page)
             }
             Err(SystemError::ENOSYS) => {
-                if let Some(vma) = self.mappings.contains(start_page.virt_address()) {
+                if let Some(vma) = vma {
                     self.mappings.attach_vma(&vma);
                 }
                 self.post_map_population(start_page.virt_address(), len, map_flags);

--- a/kernel/src/mm/ucontext.rs
+++ b/kernel/src/mm/ucontext.rs
@@ -281,6 +281,12 @@ pub struct InnerAddressSpace {
     outer: Weak<AddressSpace>,
 }
 
+struct VmaCloseNotification {
+    file: Arc<File>,
+    region: VirtRegion,
+    vm_flags: VmFlags,
+}
+
 impl InnerAddressSpace {
     /// 当前地址空间已占用的虚拟内存字节数（简单求和所有 VMA 尺寸）
     pub fn vma_usage_bytes(&self) -> usize {
@@ -844,12 +850,16 @@ impl InnerAddressSpace {
         let pgoff = offset >> MMArch::PAGE_SHIFT;
 
         let page_count = PageFrameCount::from_bytes(len).unwrap();
-        let precheck_vm_flags = VmFlags::from(prot_flags)
+        let may_write =
+            !map_flags.contains(MapFlags::MAP_SHARED) || file_mode.contains(FileMode::FMODE_WRITE);
+        let mut precheck_vm_flags = VmFlags::from(prot_flags)
             | VmFlags::from(map_flags)
             | self.mlock_future
             | VmFlags::VM_MAYREAD
-            | VmFlags::VM_MAYWRITE
             | VmFlags::VM_MAYEXEC;
+        if may_write {
+            precheck_vm_flags |= VmFlags::VM_MAYWRITE;
+        }
         file.inode()
             .check_mmap_file(&file, len, offset, precheck_vm_flags)?;
 
@@ -859,6 +869,11 @@ impl InnerAddressSpace {
             prot_flags,
             map_flags,
             |page, count, vm_flags, flags, mapper, flusher| {
+                let vm_flags = if may_write {
+                    vm_flags
+                } else {
+                    vm_flags & !VmFlags::VM_MAYWRITE
+                };
                 if allocate_at_once {
                     VMA::zeroed(
                         page,
@@ -1374,6 +1389,7 @@ impl InnerAddressSpace {
         // Use MmuGather: clear PTEs + stash pages first, then unified shootdown, and finally free physical pages (INV-3)
         let mm = self.outer_addr_space().ok_or(SystemError::EFAULT)?;
         let mut tlb = MmuGather::gather(&mm);
+        let mut vma_close_notifications: Vec<VmaCloseNotification> = Vec::new();
 
         // 遍历每个相关的 VMA，将当前的 VMA 拆分为可能的三块 VMA，然后删除与需要删除的区域相交的部分。
         // 示意图：对每个与 region_to_unmap 相交的 VMA，按交集拆分成三段（before / intersection / after），
@@ -1412,7 +1428,9 @@ impl InnerAddressSpace {
                 (split_result.prev, split_result.after)
             };
 
-            // TODO: 当引入后备页映射后，这里需要增加通知文件的逻辑
+            if let Some(notification) = Self::collect_vma_close(&cur_vma, intersection) {
+                vma_close_notifications.push(notification);
+            }
 
             if let Some(before) = before {
                 self.mappings.insert_vma(before);
@@ -1426,9 +1444,37 @@ impl InnerAddressSpace {
         // Shootdown first, then free physical pages
         tlb.finish();
 
-        // TODO: 当引入后备页映射后，这里需要增加通知文件的逻辑
+        for notification in vma_close_notifications {
+            Self::notify_vma_close(notification);
+        }
 
         return Ok(());
+    }
+
+    fn collect_vma_close(vma: &Arc<LockedVMA>, region: VirtRegion) -> Option<VmaCloseNotification> {
+        let (file, vm_flags) = {
+            let guard = vma.lock();
+            let file = guard.vm_file()?;
+            (file, *guard.vm_flags())
+        };
+
+        if vm_flags.contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
+            Some(VmaCloseNotification {
+                file,
+                region,
+                vm_flags,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn notify_vma_close(notification: VmaCloseNotification) {
+        notification.file.inode().fs().vma_close(
+            &notification.file,
+            notification.region,
+            notification.vm_flags,
+        );
     }
 
     pub fn mprotect(
@@ -1855,12 +1901,20 @@ impl InnerAddressSpace {
         };
         // Full-mm flush (fullmm); no need to accumulate ranges.
         tlb.set_fullmm();
+        let mut vma_close_notifications = Vec::new();
         for vma in self.mappings.iter_vmas() {
             if vma.mapped() {
+                let region = *vma.lock().region();
+                if let Some(notification) = Self::collect_vma_close(vma, region) {
+                    vma_close_notifications.push(notification);
+                }
                 vma.unmap(&mut self.user_mapper.utable, &mut tlb);
             }
         }
         tlb.finish();
+        for notification in vma_close_notifications {
+            Self::notify_vma_close(notification);
+        }
     }
 
     /// 设置进程的堆的内存空间
@@ -2937,12 +2991,21 @@ impl VMA {
         mapper: &mut PageMapper,
         tlb: &mut MmuGather<'_>,
     ) -> Result<(), SystemError> {
+        let pte_flags = if self.vm_file.is_some()
+            && self
+                .vm_flags
+                .contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE)
+        {
+            flags.set_write(false)
+        } else {
+            flags
+        };
         for page in self.region.pages() {
             // debug!("remap page {:?}", page.virt_address());
             if mapper.translate(page.virt_address()).is_some() {
                 let r = unsafe {
                     mapper
-                        .remap(page.virt_address(), flags)
+                        .remap(page.virt_address(), pte_flags)
                         .expect("Failed to remap")
                 };
                 unsafe { r.ignore() };
@@ -2961,6 +3024,20 @@ impl VMA {
     ///
     /// - `prot_flags` 要检查的标志位
     pub fn can_have_flags(&self, prot_flags: ProtFlags) -> bool {
+        if prot_flags.contains(ProtFlags::PROT_READ) && !self.vm_flags.contains(VmFlags::VM_MAYREAD)
+        {
+            return false;
+        }
+        if prot_flags.contains(ProtFlags::PROT_WRITE)
+            && !self.vm_flags.contains(VmFlags::VM_MAYWRITE)
+        {
+            return false;
+        }
+        if prot_flags.contains(ProtFlags::PROT_EXEC) && !self.vm_flags.contains(VmFlags::VM_MAYEXEC)
+        {
+            return false;
+        }
+
         let is_downgrade = (self.flags.has_write() || !prot_flags.contains(ProtFlags::PROT_WRITE))
             && (self.flags.has_execute() || !prot_flags.contains(ProtFlags::PROT_EXEC));
 

--- a/kernel/src/net/socket/unix/utils.rs
+++ b/kernel/src/net/socket/unix/utils.rs
@@ -14,9 +14,16 @@ pub(super) fn rollback_allocated_fds(fds: &[i32]) {
     }
 
     let fd_table_binding = ProcessManager::current_pcb().fd_table();
+    let mut dropped_fds = alloc::vec::Vec::new();
     let mut fd_table = fd_table_binding.write();
     for &fd in fds {
-        let _ = fd_table.drop_fd(fd);
+        if let Ok(dropped) = fd_table.drop_fd(fd) {
+            dropped_fds.push(dropped);
+        }
+    }
+    drop(fd_table);
+    for dropped in dropped_fds {
+        let _ = dropped.finish_close();
     }
 }
 

--- a/kernel/src/perf/mod.rs
+++ b/kernel/src/perf/mod.rs
@@ -344,6 +344,11 @@ impl FileSystem for PerfFakeFs {
         let res = PageFaultHandler::filemap_fault(pfm);
         res
     }
+
+    unsafe fn page_mkwrite(&self, _pfm: &mut PageFaultMessage) -> VmFaultReason {
+        VmFaultReason::empty()
+    }
+
     unsafe fn map_pages(
         &self,
         pfm: &mut PageFaultMessage,

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -172,7 +172,16 @@ fn do_execve_internal(
             }
 
             // close-on-exec 必须属于成功 exec 的 commit 过程，不能留在 syscall wrapper 尾部。
-            pcb.fd_table().write().close_on_exec();
+            let dropped_fds = {
+                let fd_table = pcb.fd_table();
+                let dropped = fd_table.write().close_on_exec();
+                dropped
+            };
+            for dropped in dropped_fds {
+                if let Err(err) = dropped.finish_close() {
+                    log::error!("execve close_on_exec flush failed: {:?}", err);
+                }
+            }
 
             if pcb.sighand().is_shared() {
                 // Linux出于进程和线程隔离，要确保在execve时，对共享的 SigHand 进行深拷贝

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -777,6 +777,119 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_fsync_enosys_cached_success() {
+    const char *mp = "/tmp/test_fuse_fsync_enosys";
+    int f = -1;
+    int dfd = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t fsync_count = 0;
+    volatile uint32_t fsyncdir_count = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.fsync_count = &fsync_count;
+    args.fsyncdir_count = &fsyncdir_count;
+    args.force_fsync_errno = ENOSYS;
+    args.force_fsyncdir_errno = ENOSYS;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (fsync(f) != 0 || fsync(f) != 0) {
+        printf("[FAIL] fsync(file ENOSYS cache): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+
+    dfd = open(mp, O_RDONLY | O_DIRECTORY);
+    if (dfd < 0) {
+        printf("[FAIL] open dirfd(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+    if (fsync(dfd) != 0 || fsync(dfd) != 0) {
+        printf("[FAIL] fsync(dir ENOSYS cache): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(dfd);
+    dfd = -1;
+
+    if (fsync_count != 1 || fsyncdir_count != 1) {
+        printf("[FAIL] ENOSYS fsync cache counters fsync=%u fsyncdir=%u\n", fsync_count,
+               fsyncdir_count);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    if (dfd >= 0) {
+        close(dfd);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_open_release_flags_match_linux() {
     const char *mp = "/tmp/test_fuse_open_flags";
     int requested = O_RDWR | O_NOCTTY | O_TRUNC | O_APPEND | O_NONBLOCK;
@@ -1175,6 +1288,210 @@ static int ext_test_fopen_noflush_skips_flush() {
     usleep(100 * 1000);
     if (flush_count != 0 || release_count != 1) {
         printf("[FAIL] noflush counters flush=%u release=%u\n", flush_count, release_count);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_close_returns_flush_error_and_closes_fd() {
+    const char *mp = "/tmp/test_fuse_close_flush_error";
+    int f = -1;
+    int oldfd = -1;
+    int rc = 0;
+    char tmp = 0;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t flush_count = 0;
+    volatile uint32_t release_count = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.flush_count = &flush_count;
+    args.release_count = &release_count;
+    args.force_flush_errno = EIO;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+
+    errno = 0;
+    oldfd = f;
+    rc = close(f);
+    f = -1;
+    if (rc != -1 || errno != EIO) {
+        printf("[FAIL] close should return EIO rc=%d errno=%d\n", rc, errno);
+        goto fail;
+    }
+    errno = 0;
+    if (read(oldfd, &tmp, 1) != -1 || errno != EBADF) {
+        printf("[FAIL] close error must still close fd read_errno=%d\n", errno);
+        goto fail;
+    }
+
+    usleep(100 * 1000);
+    if (flush_count != 1 || release_count != 1) {
+        printf("[FAIL] close flush error counters flush=%u release=%u\n", flush_count,
+               release_count);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_flush_enosys_cached_success() {
+    const char *mp = "/tmp/test_fuse_flush_enosys";
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t flush_count = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.flush_count = &flush_count;
+    args.force_flush_errno = ENOSYS;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    for (int i = 0; i < 2; ++i) {
+        f = open(path, O_RDONLY);
+        if (f < 0) {
+            printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+            goto fail;
+        }
+        if (close(f) != 0) {
+            printf("[FAIL] close after FLUSH ENOSYS: %s (errno=%d)\n", strerror(errno), errno);
+            f = -1;
+            goto fail;
+        }
+        f = -1;
+    }
+
+    usleep(100 * 1000);
+    if (flush_count != 1) {
+        printf("[FAIL] FLUSH ENOSYS should be cached, flush_count=%u\n", flush_count);
         goto fail;
     }
 
@@ -3452,6 +3769,7 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
     void *addr = MAP_FAILED;
     volatile char c = 0;
     pid_t daemon = -1;
+    const uint32_t expected_writeback_flags = FUSE_WRITE_CACHE;
     struct mmap_shared_state {
         volatile int stop;
         volatile int init_done;
@@ -3565,7 +3883,7 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
     }
     if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
         shared->last_write_fh != 900 || shared->last_write_offset != 0 ||
-        shared->last_write_size != 16 || shared->last_write_flags != FUSE_WRITE_CACHE ||
+        shared->last_write_size != 16 || shared->last_write_flags != expected_writeback_flags ||
         shared->last_write_open_flags != 0 || shared->last_write_uid != 0 ||
         shared->last_write_gid != 0 || shared->last_write_pid != 0) {
         printf("[FAIL] shared writable mmap counters open=%u read=%u write=%u wfh=%llu off=%llu size=%u wflags=%u oflags=%u uid=%u gid=%u pid=%u\n",
@@ -3615,6 +3933,7 @@ static int ext_test_shared_writable_mmap_osync_writeback() {
     void *addr = MAP_FAILED;
     volatile char c = 0;
     pid_t daemon = -1;
+    const uint32_t expected_writeback_flags = FUSE_WRITE_CACHE;
     const size_t page_size = 4096;
     const size_t map_len = page_size * 2;
     const char marker = 'Z';
@@ -3736,9 +4055,9 @@ static int ext_test_shared_writable_mmap_osync_writeback() {
     if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 2 ||
         shared->fsync_count != 1 || shared->last_write_fh != 930 || shared->last_fsync_fh != 930 ||
         shared->last_write_offset != 0 || shared->last_write_size != page_size ||
-        shared->last_write_flags != FUSE_WRITE_CACHE || shared->last_write_open_flags != 0 ||
+        shared->last_write_flags != expected_writeback_flags || shared->last_write_open_flags != 0 ||
         shared->write_count_at_fsync != 2 ||
-        shared->last_write_flags_at_fsync != FUSE_WRITE_CACHE) {
+        shared->last_write_flags_at_fsync != expected_writeback_flags) {
         printf("[FAIL] shared mmap osync counters open=%u read=%u write=%u fsync=%u wfh=%llu fsh=%llu off=%llu size=%u wflags=%u oflags=%u fsync_writes=%u fsync_wflags=%u\n",
                shared->open_count, shared->read_count, shared->write_count, shared->fsync_count,
                (unsigned long long)shared->last_write_fh,
@@ -4081,6 +4400,7 @@ static int ext_test_shared_writable_mmap_munmap_writeback_without_msync() {
     char path[256];
     int f = -1;
     void *addr = MAP_FAILED;
+    const uint32_t expected_writeback_flags = FUSE_WRITE_CACHE;
     pid_t daemon = -1;
     struct mmap_shared_state {
         volatile int stop;
@@ -4191,7 +4511,7 @@ static int ext_test_shared_writable_mmap_munmap_writeback_without_msync() {
 
     if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
         shared->last_write_fh != 940 || shared->last_write_offset != 0 ||
-        shared->last_write_size != 16 || shared->last_write_flags != FUSE_WRITE_CACHE ||
+        shared->last_write_size != 16 || shared->last_write_flags != expected_writeback_flags ||
         shared->last_write_open_flags != 0) {
         printf("[FAIL] munmap writeback counters open=%u read=%u write=%u wfh=%llu off=%llu size=%u wflags=%u oflags=%u\n",
                shared->open_count, shared->read_count, shared->write_count,
@@ -5657,6 +5977,10 @@ TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {
     ASSERT_EQ(0, ext_test_noopen_fsync_uses_zero_fh());
 }
 
+TEST(FuseExtended, FsyncEnosysCachedSuccess) {
+    ASSERT_EQ(0, ext_test_fsync_enosys_cached_success());
+}
+
 TEST(FuseExtended, OpenFlagsMatchLinuxMask) {
     ASSERT_EQ(0, ext_test_open_release_flags_match_linux());
 }
@@ -5671,6 +5995,14 @@ TEST(FuseExtended, FsetflUpdatesFuseDevNonblock) {
 
 TEST(FuseExtended, FopenNoFlushSkipsFlush) {
     ASSERT_EQ(0, ext_test_fopen_noflush_skips_flush());
+}
+
+TEST(FuseExtended, CloseReturnsFlushErrorAndClosesFd) {
+    ASSERT_EQ(0, ext_test_close_returns_flush_error_and_closes_fd());
+}
+
+TEST(FuseExtended, FlushEnosysCachedSuccess) {
+    ASSERT_EQ(0, ext_test_flush_enosys_cached_success());
 }
 
 TEST(FuseExtended, FopenNonseekableDisablesRandomIo) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -551,6 +551,372 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_open_zero_fh_valid() {
+    const char *mp = "/tmp/test_fuse_zero_fh";
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint64_t last_open_fh = UINT64_MAX;
+    volatile uint64_t last_read_fh = UINT64_MAX;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.open_count = &open_count;
+    args.read_count = &read_count;
+    args.last_open_fh = &last_open_fh;
+    args.last_read_fh = &last_read_fh;
+    args.has_hello_open_fh_override = 1;
+    args.hello_open_fh_override = 0;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    char buf[128];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    if (fuseg_read_file_cstr(path, buf, sizeof(buf)) < 0) {
+        printf("[FAIL] read(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (strcmp(buf, "hello from fuse\n") != 0) {
+        printf("[FAIL] content mismatch: got='%s'\n", buf);
+        goto fail;
+    }
+
+    usleep(100 * 1000);
+    if (open_count == 0 || read_count == 0 || last_open_fh != 0 || last_read_fh != 0) {
+        printf("[FAIL] fh counters open=%u read=%u open_fh=%llu read_fh=%llu\n", open_count,
+               read_count, (unsigned long long)last_open_fh, (unsigned long long)last_read_fh);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_noopen_fsync_uses_zero_fh() {
+    const char *mp = "/tmp/test_fuse_noopen_fsync";
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t fsync_count = 0;
+    volatile uint32_t release_count = 0;
+    volatile uint64_t last_fsync_fh = UINT64_MAX;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.open_count = &open_count;
+    args.fsync_count = &fsync_count;
+    args.release_count = &release_count;
+    args.last_fsync_fh = &last_fsync_fh;
+    args.force_open_enosys = 1;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_NO_OPEN_SUPPORT;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (fsync(f) != 0) {
+        printf("[FAIL] fsync(no-open file): %s (errno=%d)\n", strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    close(f);
+
+    usleep(100 * 1000);
+    if (open_count != 1 || fsync_count == 0 || release_count != 0 || last_fsync_fh != 0) {
+        printf("[FAIL] counters open=%u fsync=%u release=%u fsync_fh=%llu\n", open_count,
+               fsync_count, release_count, (unsigned long long)last_fsync_fh);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_open_release_flags_match_linux() {
+    const char *mp = "/tmp/test_fuse_open_flags";
+    int requested = O_RDWR | O_NOCTTY | O_TRUNC | O_APPEND | O_NONBLOCK;
+    uint32_t expected_open = (uint32_t)(requested & ~(O_CREAT | O_EXCL | O_NOCTTY));
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t last_open_flags = 0;
+    volatile uint32_t last_release_flags = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.last_open_in_flags = &last_open_flags;
+    args.last_release_in_flags = &last_release_flags;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_ATOMIC_O_TRUNC;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, requested);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+
+    usleep(100 * 1000);
+    if (last_open_flags != expected_open) {
+        printf("[FAIL] open flags got=0%o expected=0%o\n", last_open_flags, expected_open);
+        goto fail;
+    }
+    if (last_release_flags != (uint32_t)requested) {
+        printf("[FAIL] release flags got=0%o expected=0%o\n", last_release_flags,
+               (uint32_t)requested);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_init_requests_linux_no_open_support() {
+    const char *mp = "/tmp/test_fuse_init_flags";
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t init_flags = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.init_in_flags = &init_flags;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    if ((init_flags & FUSE_NO_OPEN_SUPPORT) == 0 ||
+        (init_flags & FUSE_NO_OPENDIR_SUPPORT) == 0) {
+        printf("[FAIL] INIT flags missing no-open support bits: flags=0x%x\n", init_flags);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_p4_subtype_mount() {
     const char *mp = "/tmp/test_fuse_p4_subtype";
     if (ensure_dir(mp) != 0) {
@@ -992,6 +1358,22 @@ TEST(FuseExtended, InterruptDeliversFuseInterrupt) {
 
 TEST(FuseExtended, NoOpenNoOpendirReaddirplusNotify) {
     ASSERT_EQ(0, ext_test_p3_noopen_readdirplus_notify());
+}
+
+TEST(FuseExtended, OpenReturnsZeroFhIsValid) {
+    ASSERT_EQ(0, ext_test_open_zero_fh_valid());
+}
+
+TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {
+    ASSERT_EQ(0, ext_test_noopen_fsync_uses_zero_fh());
+}
+
+TEST(FuseExtended, OpenFlagsMatchLinuxMask) {
+    ASSERT_EQ(0, ext_test_open_release_flags_match_linux());
+}
+
+TEST(FuseExtended, InitRequestsLinuxNoOpenSupport) {
+    ASSERT_EQ(0, ext_test_init_requests_linux_no_open_support());
 }
 
 TEST(FuseExtended, SubtypeMountFuseDotSubtype) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -957,6 +957,222 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_fopen_nonseekable_mode(uint32_t open_out_flags, const char *mp,
+                                           int expect_stream) {
+    int f = -1;
+    char buf[8];
+    ssize_t n = -1;
+    volatile uint64_t last_write_offset = UINT64_MAX;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.hello_open_out_flags = open_out_flags;
+    args.last_write_offset = &last_write_offset;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+
+    errno = 0;
+    if (lseek(f, 0, SEEK_SET) >= 0 || errno != ESPIPE) {
+        printf("[FAIL] lseek expected ESPIPE, ret errno=%d (%s)\n", errno, strerror(errno));
+        goto fail;
+    }
+    errno = 0;
+    if (pread(f, buf, 1, 0) >= 0 || errno != ESPIPE) {
+        printf("[FAIL] pread expected ESPIPE, errno=%d (%s)\n", errno, strerror(errno));
+        goto fail;
+    }
+    errno = 0;
+    if (pwrite(f, "x", 1, 0) >= 0 || errno != ESPIPE) {
+        printf("[FAIL] pwrite expected ESPIPE, errno=%d (%s)\n", errno, strerror(errno));
+        goto fail;
+    }
+
+    memset(buf, 0, sizeof(buf));
+    if (read(f, buf, 5) != 5 || memcmp(buf, "hello", 5) != 0) {
+        printf("[FAIL] ordinary read failed got='%.*s' errno=%d\n", 5, buf, errno);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    n = read(f, buf, 5);
+    if (expect_stream) {
+        if (n != 5 || memcmp(buf, "hello", 5) != 0) {
+            printf("[FAIL] stream read did not restart at offset 0 got n=%zd data='%.*s' errno=%d\n",
+                   n, 5, buf, errno);
+            goto fail;
+        }
+        if (write(f, "Z", 1) != 1) {
+            printf("[FAIL] stream write failed: %s (errno=%d)\n", strerror(errno), errno);
+            goto fail;
+        }
+        if (last_write_offset != 0) {
+            printf("[FAIL] stream write offset expected 0 got %llu\n",
+                   (unsigned long long)last_write_offset);
+            goto fail;
+        }
+    } else if (n != 5 || memcmp(buf, " from", 5) != 0) {
+        printf("[FAIL] nonseekable sequential read should advance offset got n=%zd data='%.*s'\n", n,
+               5, buf);
+        goto fail;
+    }
+
+    close(f);
+    f = -1;
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_fopen_nonseekable_dir_mode(uint32_t open_out_flags, const char *mp) {
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.root_open_out_flags = open_out_flags;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    f = open(mp, O_RDONLY | O_DIRECTORY);
+    if (f < 0) {
+        printf("[FAIL] open(%s, O_DIRECTORY): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+
+    errno = 0;
+    if (lseek(f, 0, SEEK_SET) >= 0 || errno != ESPIPE) {
+        printf("[FAIL] dir lseek expected ESPIPE, errno=%d (%s)\n", errno, strerror(errno));
+        goto fail;
+    }
+
+    close(f);
+    f = -1;
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_atomic_otrunc_uses_open_without_setattr() {
     const char *mp = "/tmp/test_fuse_atomic_otrunc";
     int requested = O_RDWR | O_TRUNC;
@@ -4738,6 +4954,20 @@ TEST(FuseExtended, OpenFlagsMatchLinuxMask) {
 
 TEST(FuseExtended, FopenNoFlushSkipsFlush) {
     ASSERT_EQ(0, ext_test_fopen_noflush_skips_flush());
+}
+
+TEST(FuseExtended, FopenNonseekableDisablesRandomIo) {
+    ASSERT_EQ(0,
+              ext_test_fopen_nonseekable_mode(FOPEN_NONSEEKABLE, "/tmp/test_fuse_nonseek", 0));
+}
+
+TEST(FuseExtended, FopenStreamDisablesRandomIo) {
+    ASSERT_EQ(0, ext_test_fopen_nonseekable_mode(FOPEN_STREAM, "/tmp/test_fuse_stream", 1));
+}
+
+TEST(FuseExtended, FopenNonseekableDirectoryDisablesLseek) {
+    ASSERT_EQ(0,
+              ext_test_fopen_nonseekable_dir_mode(FOPEN_NONSEEKABLE, "/tmp/test_fuse_dir_nonseek"));
 }
 
 TEST(FuseExtended, AtomicOTruncUsesOpenWithoutSetattr) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -313,6 +313,7 @@ static int ext_test_p3_interrupt() {
     volatile int init_done = 0;
     volatile uint32_t interrupt_count = 0;
     volatile uint64_t blocked_read_unique = 0;
+    volatile uint64_t last_interrupt_header_unique = 0;
     volatile uint64_t last_interrupt_target = 0;
 
     struct fuse_daemon_args args;
@@ -325,6 +326,7 @@ static int ext_test_p3_interrupt() {
     args.block_read_until_interrupt = 1000;
     args.interrupt_count = &interrupt_count;
     args.blocked_read_unique = &blocked_read_unique;
+    args.last_interrupt_header_unique = &last_interrupt_header_unique;
     args.last_interrupt_target = &last_interrupt_target;
 
     pthread_t daemon_th;
@@ -403,6 +405,12 @@ static int ext_test_p3_interrupt() {
     if (last_interrupt_target == 0 || last_interrupt_target != blocked_read_unique) {
         printf("[FAIL] interrupt target mismatch: blocked=%llu interrupt_target=%llu\n",
                (unsigned long long)blocked_read_unique, (unsigned long long)last_interrupt_target);
+        goto fail;
+    }
+    if (last_interrupt_header_unique != (blocked_read_unique | 1ULL)) {
+        printf("[FAIL] interrupt header unique mismatch: blocked=%llu header=%llu\n",
+               (unsigned long long)blocked_read_unique,
+               (unsigned long long)last_interrupt_header_unique);
         goto fail;
     }
 
@@ -890,11 +898,18 @@ static int ext_test_fsetfl_updates_fuse_io_flags() {
     volatile uint32_t open_count = 0;
     volatile uint32_t read_count = 0;
     volatile uint32_t write_count = 0;
+    volatile uint32_t flush_count = 0;
     volatile uint32_t release_count = 0;
     volatile uint32_t last_open_flags = 0;
     volatile uint32_t last_read_flags = 0;
     volatile uint32_t last_write_flags = 0;
+    volatile uint32_t last_flush_uid = UINT32_MAX;
+    volatile uint32_t last_flush_gid = UINT32_MAX;
+    volatile uint32_t last_flush_pid = 0;
     volatile uint32_t last_release_flags = 0;
+    volatile uint32_t last_release_uid = UINT32_MAX;
+    volatile uint32_t last_release_gid = UINT32_MAX;
+    volatile uint32_t last_release_pid = UINT32_MAX;
 
     struct fuse_daemon_args args;
     memset(&args, 0, sizeof(args));
@@ -906,11 +921,18 @@ static int ext_test_fsetfl_updates_fuse_io_flags() {
     args.open_count = &open_count;
     args.read_count = &read_count;
     args.write_count = &write_count;
+    args.flush_count = &flush_count;
     args.release_count = &release_count;
     args.last_open_in_flags = &last_open_flags;
     args.last_read_open_flags = &last_read_flags;
     args.last_write_open_flags = &last_write_flags;
+    args.last_flush_uid = &last_flush_uid;
+    args.last_flush_gid = &last_flush_gid;
+    args.last_flush_pid = &last_flush_pid;
     args.last_release_in_flags = &last_release_flags;
+    args.last_release_uid = &last_release_uid;
+    args.last_release_gid = &last_release_gid;
+    args.last_release_pid = &last_release_pid;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -967,9 +989,10 @@ static int ext_test_fsetfl_updates_fuse_io_flags() {
     usleep(100 * 1000);
 
     expected_setfl = (uint32_t)(old_flags | O_NONBLOCK);
-    if (open_count != 1 || read_count != 1 || write_count != 1 || release_count != 1) {
-        printf("[FAIL] counters open=%u read=%u write=%u release=%u\n", open_count, read_count,
-               write_count, release_count);
+    if (open_count != 1 || read_count != 1 || write_count != 1 || flush_count != 1 ||
+        release_count != 1) {
+        printf("[FAIL] counters open=%u read=%u write=%u flush=%u release=%u\n", open_count,
+               read_count, write_count, flush_count, release_count);
         goto fail;
     }
     if (last_open_flags != expected_open) {
@@ -980,6 +1003,16 @@ static int ext_test_fsetfl_updates_fuse_io_flags() {
         last_release_flags != expected_setfl) {
         printf("[FAIL] updated flags read=0%o write=0%o release=0%o expected=0%o\n",
                last_read_flags, last_write_flags, last_release_flags, expected_setfl);
+        goto fail;
+    }
+    if (last_flush_uid != 0 || last_flush_gid != 0 || last_flush_pid == 0) {
+        printf("[FAIL] flush should use caller credentials uid=%u gid=%u pid=%u\n",
+               last_flush_uid, last_flush_gid, last_flush_pid);
+        goto fail;
+    }
+    if (last_release_uid != 0 || last_release_gid != 0 || last_release_pid != 0) {
+        printf("[FAIL] release should use nocreds uid=%u gid=%u pid=%u\n", last_release_uid,
+               last_release_gid, last_release_pid);
         goto fail;
     }
 
@@ -1315,6 +1348,10 @@ static int ext_test_fopen_nonseekable_dir_mode(uint32_t open_out_flags, const ch
 
     volatile int stop = 0;
     volatile int init_done = 0;
+    volatile uint32_t releasedir_count = 0;
+    volatile uint32_t last_releasedir_uid = UINT32_MAX;
+    volatile uint32_t last_releasedir_gid = UINT32_MAX;
+    volatile uint32_t last_releasedir_pid = UINT32_MAX;
 
     struct fuse_daemon_args args;
     memset(&args, 0, sizeof(args));
@@ -1323,6 +1360,10 @@ static int ext_test_fopen_nonseekable_dir_mode(uint32_t open_out_flags, const ch
     args.init_done = &init_done;
     args.stop_on_destroy = 1;
     args.root_open_out_flags = open_out_flags;
+    args.releasedir_count = &releasedir_count;
+    args.last_releasedir_uid = &last_releasedir_uid;
+    args.last_releasedir_gid = &last_releasedir_gid;
+    args.last_releasedir_pid = &last_releasedir_pid;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -1361,6 +1402,15 @@ static int ext_test_fopen_nonseekable_dir_mode(uint32_t open_out_flags, const ch
 
     close(f);
     f = -1;
+    usleep(100 * 1000);
+
+    if (releasedir_count != 1 || last_releasedir_uid != 0 || last_releasedir_gid != 0 ||
+        last_releasedir_pid != 0) {
+        printf("[FAIL] releasedir nocreds count=%u uid=%u gid=%u pid=%u\n", releasedir_count,
+               last_releasedir_uid, last_releasedir_gid, last_releasedir_pid);
+        goto fail;
+    }
+
     if (umount(mp) != 0) {
         printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
         goto fail_no_umount;
@@ -3149,6 +3199,9 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
         volatile uint32_t last_write_size;
         volatile uint32_t last_write_flags;
         volatile uint32_t last_write_open_flags;
+        volatile uint32_t last_write_uid;
+        volatile uint32_t last_write_gid;
+        volatile uint32_t last_write_pid;
     };
     struct mmap_shared_state *shared =
         (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
@@ -3197,6 +3250,9 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
         child_args.last_write_size = &shared->last_write_size;
         child_args.last_write_flags = &shared->last_write_flags;
         child_args.last_write_open_flags = &shared->last_write_open_flags;
+        child_args.last_write_uid = &shared->last_write_uid;
+        child_args.last_write_gid = &shared->last_write_gid;
+        child_args.last_write_pid = &shared->last_write_pid;
         child_args.next_open_fh = 900;
         fuse_daemon_thread(&child_args);
         _exit(0);
@@ -3246,12 +3302,14 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
     if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
         shared->last_write_fh != 900 || shared->last_write_offset != 0 ||
         shared->last_write_size != 16 || shared->last_write_flags != FUSE_WRITE_CACHE ||
-        shared->last_write_open_flags != 0) {
-        printf("[FAIL] shared writable mmap counters open=%u read=%u write=%u wfh=%llu off=%llu size=%u wflags=%u oflags=%u\n",
+        shared->last_write_open_flags != 0 || shared->last_write_uid != 0 ||
+        shared->last_write_gid != 0 || shared->last_write_pid != 0) {
+        printf("[FAIL] shared writable mmap counters open=%u read=%u write=%u wfh=%llu off=%llu size=%u wflags=%u oflags=%u uid=%u gid=%u pid=%u\n",
                shared->open_count, shared->read_count, shared->write_count,
                (unsigned long long)shared->last_write_fh,
                (unsigned long long)shared->last_write_offset, shared->last_write_size,
-               shared->last_write_flags, shared->last_write_open_flags);
+               shared->last_write_flags, shared->last_write_open_flags, shared->last_write_uid,
+               shared->last_write_gid, shared->last_write_pid);
         goto fail;
     }
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1911,6 +1911,160 @@ fail:
     return -1;
 }
 
+static int ext_test_mmap_sees_write_through_update() {
+    const char *mp = "/tmp/test_fuse_mmap_write_through";
+    char path[256];
+    char buf[16];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    pid_t child = -1;
+    struct mmap_write_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint64_t last_write_fh;
+        volatile uint64_t read_fhs[4];
+    };
+    struct mmap_write_shared_state *shared =
+        (struct mmap_write_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                               MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (child == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.enable_write_ops = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.last_write_fh = &shared->last_write_fh;
+        child_args.read_fhs = shared->read_fhs;
+        child_args.read_trace_capacity = 4;
+        child_args.next_open_fh = 320;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(child, SIGTERM);
+        waitpid(child, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (((volatile char *)addr)[0] != 'h') {
+        printf("[FAIL] mmap warmup first byte got=%d\n", ((volatile char *)addr)[0]);
+        goto fail;
+    }
+    if (pwrite(f, "MMAP!", 5, 0) != 5) {
+        printf("[FAIL] pwrite MMAP!: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (memcmp(addr, "MMAP!", 5) != 0) {
+        printf("[FAIL] mmap page did not observe write-through update, got='%.*s'\n", 5,
+               (char *)addr);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    if (pread(f, buf, 5, 0) != 5 || memcmp(buf, "MMAP!", 5) != 0) {
+        printf("[FAIL] cached pread after mmap write got='%.*s' read=%u errno=%d\n", 5, buf,
+               shared->read_count, errno);
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
+        shared->last_write_fh != 320 || shared->read_fhs[0] != 320) {
+        printf("[FAIL] mmap write-through counters open=%u read=%u write=%u rfh=%llu wfh=%llu\n",
+               shared->open_count, shared->read_count, shared->write_count,
+               (unsigned long long)shared->read_fhs[0],
+               (unsigned long long)shared->last_write_fh);
+        goto fail;
+    }
+
+    munmap(addr, 4096);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(child, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (child > 0) {
+        kill(child, SIGTERM);
+        waitpid(child, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_mmap_fault_uses_open_fh_without_extra_open() {
     const char *mp = "/tmp/test_fuse_mmap_fh";
     char path[256];
@@ -2144,6 +2298,143 @@ static int ext_test_direct_io_read_bypasses_page_cache() {
 fail:
     if (f >= 0) {
         close(f);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_direct_io_write_invalidates_cached_read() {
+    const char *mp = "/tmp/test_fuse_direct_write_inval";
+    char path[256];
+    char buf[16];
+    int cached_fd = -1;
+    int direct_fd = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint32_t open_out_flags = 0;
+    volatile uint64_t last_write_fh = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.open_count = &open_count;
+    args.read_count = &read_count;
+    args.write_count = &write_count;
+    args.dynamic_hello_open_out_flags = &open_out_flags;
+    args.last_write_fh = &last_write_fh;
+    args.next_open_fh = 520;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    cached_fd = open(path, O_RDWR);
+    if (cached_fd < 0) {
+        printf("[FAIL] open cached fd: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    if (pread(cached_fd, buf, 5, 0) != 5 || memcmp(buf, "hello", 5) != 0) {
+        printf("[FAIL] initial cached pread got='%.*s' read=%u errno=%d\n", 5, buf, read_count,
+               errno);
+        goto fail;
+    }
+
+    open_out_flags = FOPEN_DIRECT_IO;
+    direct_fd = open(path, O_WRONLY);
+    if (direct_fd < 0) {
+        printf("[FAIL] open direct fd: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (pwrite(direct_fd, "DIO!!", 5, 0) != 5) {
+        printf("[FAIL] direct pwrite: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (pwrite(direct_fd, "TAIL!", 5, 20) != 5) {
+        printf("[FAIL] direct pwrite extend: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(direct_fd);
+    direct_fd = -1;
+    open_out_flags = 0;
+
+    memset(buf, 0, sizeof(buf));
+    if (pread(cached_fd, buf, 5, 0) != 5 || memcmp(buf, "DIO!!", 5) != 0) {
+        printf("[FAIL] cached pread after direct write got='%.*s' read=%u errno=%d\n", 5, buf,
+               read_count, errno);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    if (pread(cached_fd, buf, 5, 20) != 5 || memcmp(buf, "TAIL!", 5) != 0) {
+        printf("[FAIL] cached pread after direct extend got='%.*s' read=%u errno=%d\n", 5, buf,
+               read_count, errno);
+        goto fail;
+    }
+    if (open_count != 2 || read_count != 2 || write_count != 2 || last_write_fh != 521) {
+        printf("[FAIL] direct write counters open=%u read=%u write=%u wfh=%llu\n", open_count,
+               read_count, write_count, (unsigned long long)last_write_fh);
+        goto fail;
+    }
+
+    close(cached_fd);
+    cached_fd = -1;
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (direct_fd >= 0) {
+        close(direct_fd);
+    }
+    if (cached_fd >= 0) {
+        close(cached_fd);
     }
     umount(mp);
     stop = 1;
@@ -3937,12 +4228,20 @@ TEST(FuseExtended, CachedReadSeesWriteThroughUpdate) {
     ASSERT_EQ(0, ext_test_cached_read_sees_write_through_update());
 }
 
+TEST(FuseExtended, MmapSeesWriteThroughUpdate) {
+    ASSERT_EQ(0, ext_test_mmap_sees_write_through_update());
+}
+
 TEST(FuseExtended, MmapFaultUsesOpenFhWithoutExtraOpen) {
     ASSERT_EQ(0, ext_test_mmap_fault_uses_open_fh_without_extra_open());
 }
 
 TEST(FuseExtended, DirectIoReadBypassesPageCache) {
     ASSERT_EQ(0, ext_test_direct_io_read_bypasses_page_cache());
+}
+
+TEST(FuseExtended, DirectIoWriteInvalidatesCachedRead) {
+    ASSERT_EQ(0, ext_test_direct_io_write_invalidates_cached_read());
 }
 
 TEST(FuseExtended, DirectIoMmapPolicy) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -11,6 +11,10 @@
 #define FUSE_DEV_IOC_CLONE 0x8004e500
 #endif
 
+#ifndef POSIX_FADV_NOREUSE
+#define POSIX_FADV_NOREUSE 5
+#endif
+
 static int ext_test_p2_ops() {
     const char *mp = "/tmp/test_fuse_p2_ops";
     int f = -1;
@@ -1462,6 +1466,102 @@ fail:
     return -1;
 }
 
+static int ext_test_fadvise_without_page_cache() {
+    const char *mp = "/tmp/test_fuse_fadvise";
+    char path[256];
+    int f = -1;
+    const int advices[] = {
+        POSIX_FADV_NORMAL,     POSIX_FADV_RANDOM, POSIX_FADV_SEQUENTIAL,
+        POSIX_FADV_WILLNEED,   POSIX_FADV_DONTNEED,
+        POSIX_FADV_NOREUSE,
+    };
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+
+    for (size_t i = 0; i < sizeof(advices) / sizeof(advices[0]); i++) {
+        int rc = posix_fadvise(f, 0, 0, advices[i]);
+        if (rc != 0) {
+            printf("[FAIL] posix_fadvise(advice=%d): rc=%d\n", advices[i], rc);
+            goto fail;
+        }
+    }
+
+    if (posix_fadvise(f, 0, -1, POSIX_FADV_NORMAL) != EINVAL) {
+        printf("[FAIL] posix_fadvise negative len should return EINVAL\n");
+        goto fail;
+    }
+
+    close(f);
+    f = -1;
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 TEST(FuseExtended, OpsAccessCreateSymlinkLinkRename2FlushFsync) {
     ASSERT_EQ(0, ext_test_p2_ops());
 }
@@ -1480,6 +1580,10 @@ TEST(FuseExtended, OpenReturnsZeroFhIsValid) {
 
 TEST(FuseExtended, LargeReadSplitsOverMaxWrite) {
     ASSERT_EQ(0, ext_test_large_read_over_max_write());
+}
+
+TEST(FuseExtended, FadviseWithoutPageCacheSucceeds) {
+    ASSERT_EQ(0, ext_test_fadvise_without_page_cache());
 }
 
 TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1348,6 +1348,120 @@ fail:
     return -1;
 }
 
+static int ext_test_large_read_over_max_write() {
+    const char *mp = "/tmp/test_fuse_large_read";
+    const size_t data_size = 6000;
+    char path[256];
+    char *buf = NULL;
+    int n = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint64_t read_offsets[4] = {0};
+    volatile uint32_t read_sizes[4] = {0};
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.read_count = &read_count;
+    args.read_offsets = read_offsets;
+    args.read_sizes = read_sizes;
+    args.read_trace_capacity = 4;
+    args.hello_data_size_override = data_size;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    buf = (char *)malloc(data_size);
+    if (!buf) {
+        printf("[FAIL] malloc read buffer\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    n = fuseg_read_file(path, buf, data_size);
+    if (n < 0) {
+        printf("[FAIL] read(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if ((size_t)n != data_size) {
+        printf("[FAIL] read size mismatch: got=%d expected=%zu read_count=%u\n", n, data_size,
+               read_count);
+        goto fail;
+    }
+    for (size_t i = 0; i < data_size; i++) {
+        char expected = (char)('A' + (i % 26));
+        if (buf[i] != expected) {
+            printf("[FAIL] read data mismatch at %zu: got=%d expected=%d\n", i, buf[i],
+                   expected);
+            goto fail;
+        }
+    }
+    if (read_count != 2 || read_offsets[0] != 0 || read_offsets[1] != 4096 ||
+        read_sizes[0] != 4096 || read_sizes[1] != data_size - 4096) {
+        printf("[FAIL] unexpected FUSE_READ split: count=%u off0=%llu size0=%u off1=%llu size1=%u\n",
+               read_count, (unsigned long long)read_offsets[0], read_sizes[0],
+               (unsigned long long)read_offsets[1], read_sizes[1]);
+        goto fail;
+    }
+
+    free(buf);
+    buf = NULL;
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (buf) {
+        free(buf);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 TEST(FuseExtended, OpsAccessCreateSymlinkLinkRename2FlushFsync) {
     ASSERT_EQ(0, ext_test_p2_ops());
 }
@@ -1362,6 +1476,10 @@ TEST(FuseExtended, NoOpenNoOpendirReaddirplusNotify) {
 
 TEST(FuseExtended, OpenReturnsZeroFhIsValid) {
     ASSERT_EQ(0, ext_test_open_zero_fh_valid());
+}
+
+TEST(FuseExtended, LargeReadSplitsOverMaxWrite) {
+    ASSERT_EQ(0, ext_test_large_read_over_max_write());
 }
 
 TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -2612,19 +2612,24 @@ fail:
     return -1;
 }
 
-static int ext_test_shared_writable_mmap_fault_sigbus() {
+static int ext_test_shared_writable_mmap_msync_writeback() {
     const char *mp = "/tmp/test_fuse_mmap_shared_write";
     char path[256];
     int f = -1;
     void *addr = MAP_FAILED;
+    volatile char c = 0;
     pid_t daemon = -1;
-    struct sigaction old_bus;
-    bool bus_handler_installed = false;
     struct mmap_shared_state {
         volatile int stop;
         volatile int init_done;
         volatile uint32_t open_count;
         volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint64_t last_write_fh;
+        volatile uint64_t last_write_offset;
+        volatile uint32_t last_write_size;
+        volatile uint32_t last_write_flags;
+        volatile uint32_t last_write_open_flags;
     };
     struct mmap_shared_state *shared =
         (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
@@ -2663,9 +2668,17 @@ static int ext_test_shared_writable_mmap_fault_sigbus() {
         child_args.fd = fd;
         child_args.stop = &shared->stop;
         child_args.init_done = &shared->init_done;
+        child_args.enable_write_ops = 1;
         child_args.stop_on_destroy = 1;
         child_args.open_count = &shared->open_count;
         child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.last_write_fh = &shared->last_write_fh;
+        child_args.last_write_offset = &shared->last_write_offset;
+        child_args.last_write_size = &shared->last_write_size;
+        child_args.last_write_flags = &shared->last_write_flags;
+        child_args.last_write_open_flags = &shared->last_write_open_flags;
+        child_args.next_open_fh = 900;
         fuse_daemon_thread(&child_args);
         _exit(0);
     }
@@ -2701,30 +2714,25 @@ static int ext_test_shared_writable_mmap_fault_sigbus() {
         goto fail;
     }
 
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = fuse_sigbus_longjmp_handler;
-    sigemptyset(&sa.sa_mask);
-    if (sigaction(SIGBUS, &sa, &old_bus) != 0) {
-        printf("[FAIL] sigaction(SIGBUS): %s (errno=%d)\n", strerror(errno), errno);
+    c = ((volatile char *)addr)[0];
+    if (c != 'h') {
+        printf("[FAIL] shared writable mmap first byte got=%d\n", c);
         goto fail;
     }
-    bus_handler_installed = true;
-    g_fuse_sigbus_seen = 0;
-    if (sigsetjmp(g_fuse_sigbus_jmp, 1) == 0) {
-        volatile char c = ((volatile char *)addr)[0];
-        (void)c;
-    }
-    sigaction(SIGBUS, &old_bus, NULL);
-    bus_handler_installed = false;
-    if (!g_fuse_sigbus_seen) {
-        printf("[FAIL] shared writable mmap access did not SIGBUS open=%u read=%u\n",
-               shared->open_count, shared->read_count);
+    ((volatile char *)addr)[1] = 'M';
+    if (msync(addr, 4096, MS_SYNC) != 0) {
+        printf("[FAIL] msync(shared writable mmap): %s (errno=%d)\n", strerror(errno), errno);
         goto fail;
     }
-    if (shared->open_count != 1 || shared->read_count != 0) {
-        printf("[FAIL] shared writable mmap counters open=%u read=%u\n", shared->open_count,
-               shared->read_count);
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
+        shared->last_write_fh != 900 || shared->last_write_offset != 0 ||
+        shared->last_write_size != 16 || shared->last_write_flags != FUSE_WRITE_CACHE ||
+        shared->last_write_open_flags != 0) {
+        printf("[FAIL] shared writable mmap counters open=%u read=%u write=%u wfh=%llu off=%llu size=%u wflags=%u oflags=%u\n",
+               shared->open_count, shared->read_count, shared->write_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_write_offset, shared->last_write_size,
+               shared->last_write_flags, shared->last_write_open_flags);
         goto fail;
     }
 
@@ -2741,9 +2749,6 @@ static int ext_test_shared_writable_mmap_fault_sigbus() {
     return 0;
 
 fail:
-    if (bus_handler_installed) {
-        sigaction(SIGBUS, &old_bus, NULL);
-    }
     if (addr != MAP_FAILED) {
         munmap(addr, 4096);
     }
@@ -2762,7 +2767,7 @@ fail:
     return -1;
 }
 
-static int ext_test_shared_mmap_mprotect_write_denied() {
+static int ext_test_shared_mmap_mprotect_writeback() {
     const char *mp = "/tmp/test_fuse_mmap_mprotect_write";
     char path[256];
     int f = -1;
@@ -2774,6 +2779,8 @@ static int ext_test_shared_mmap_mprotect_write_denied() {
         volatile int init_done;
         volatile uint32_t open_count;
         volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint64_t last_write_fh;
     };
     struct mmap_shared_state *shared =
         (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
@@ -2812,9 +2819,13 @@ static int ext_test_shared_mmap_mprotect_write_denied() {
         child_args.fd = fd;
         child_args.stop = &shared->stop;
         child_args.init_done = &shared->init_done;
+        child_args.enable_write_ops = 1;
         child_args.stop_on_destroy = 1;
         child_args.open_count = &shared->open_count;
         child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.last_write_fh = &shared->last_write_fh;
+        child_args.next_open_fh = 910;
         fuse_daemon_thread(&child_args);
         _exit(0);
     }
@@ -2860,14 +2871,21 @@ static int ext_test_shared_mmap_mprotect_write_denied() {
                shared->read_count);
         goto fail;
     }
-    errno = 0;
-    if (mprotect(addr, 4096, PROT_READ | PROT_WRITE) == 0) {
-        printf("[FAIL] mprotect unexpectedly allowed shared writable FUSE mapping\n");
+    if (mprotect(addr, 4096, PROT_READ | PROT_WRITE) != 0) {
+        printf("[FAIL] mprotect shared writable FUSE mapping: %s (errno=%d)\n", strerror(errno),
+               errno);
         goto fail;
     }
-    if (shared->open_count != 1 || shared->read_count != 1) {
-        printf("[FAIL] after mprotect counters open=%u read=%u\n", shared->open_count,
-               shared->read_count);
+    ((volatile char *)addr)[2] = 'P';
+    if (msync(addr, 4096, MS_SYNC) != 0) {
+        printf("[FAIL] msync(after mprotect): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
+        shared->last_write_fh != 910) {
+        printf("[FAIL] after mprotect counters open=%u read=%u write=%u wfh=%llu\n",
+               shared->open_count, shared->read_count, shared->write_count,
+               (unsigned long long)shared->last_write_fh);
         goto fail;
     }
 
@@ -2902,7 +2920,304 @@ fail:
     return -1;
 }
 
-static int ext_test_shared_mmap_subrange_mprotect_failure_preserves_vma() {
+static int ext_test_shared_mmap_readonly_fd_mprotect_write_denied() {
+    const char *mp = "/tmp/test_fuse_mmap_readonly_mprotect";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t daemon = -1;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint64_t last_write_fh;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.enable_write_ops = 1;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.last_write_fh = &shared->last_write_fh;
+        child_args.next_open_fh = 930;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s, O_RDONLY): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+
+    c = ((volatile char *)addr)[0];
+    if (c != 'h') {
+        printf("[FAIL] readonly shared mmap first byte got=%d\n", c);
+        goto fail;
+    }
+    errno = 0;
+    if (mprotect(addr, 4096, PROT_READ | PROT_WRITE) == 0) {
+        printf("[FAIL] mprotect unexpectedly allowed write upgrade on readonly fd\n");
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 0 ||
+        shared->last_write_fh != 0) {
+        printf("[FAIL] readonly mprotect counters open=%u read=%u write=%u wfh=%llu\n",
+               shared->open_count, shared->read_count, shared->write_count,
+               (unsigned long long)shared->last_write_fh);
+        goto fail;
+    }
+
+    munmap(addr, 4096);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_shared_writable_mmap_munmap_writeback_without_msync() {
+    const char *mp = "/tmp/test_fuse_mmap_munmap_writeback";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    pid_t daemon = -1;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint64_t last_write_fh;
+        volatile uint64_t last_write_offset;
+        volatile uint32_t last_write_size;
+        volatile uint32_t last_write_flags;
+        volatile uint32_t last_write_open_flags;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.enable_write_ops = 1;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.last_write_fh = &shared->last_write_fh;
+        child_args.last_write_offset = &shared->last_write_offset;
+        child_args.last_write_size = &shared->last_write_size;
+        child_args.last_write_flags = &shared->last_write_flags;
+        child_args.last_write_open_flags = &shared->last_write_open_flags;
+        child_args.next_open_fh = 940;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+
+    if (((volatile char *)addr)[0] != 'h') {
+        printf("[FAIL] shared close-writeback mmap first byte got=%d\n",
+               ((volatile char *)addr)[0]);
+        goto fail;
+    }
+    ((volatile char *)addr)[3] = 'C';
+    if (munmap(addr, 4096) != 0) {
+        printf("[FAIL] munmap(shared writable mmap): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    addr = MAP_FAILED;
+
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
+        shared->last_write_fh != 940 || shared->last_write_offset != 0 ||
+        shared->last_write_size != 16 || shared->last_write_flags != FUSE_WRITE_CACHE ||
+        shared->last_write_open_flags != 0) {
+        printf("[FAIL] munmap writeback counters open=%u read=%u write=%u wfh=%llu off=%llu size=%u wflags=%u oflags=%u\n",
+               shared->open_count, shared->read_count, shared->write_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_write_offset, shared->last_write_size,
+               shared->last_write_flags, shared->last_write_open_flags);
+        goto fail;
+    }
+
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_shared_mmap_subrange_mprotect_writeback_preserves_vma() {
     const char *mp = "/tmp/test_fuse_mmap_mprotect_subrange";
     const size_t page_size = 4096;
     const size_t map_len = page_size * 2;
@@ -2918,6 +3233,8 @@ static int ext_test_shared_mmap_subrange_mprotect_failure_preserves_vma() {
         volatile int init_done;
         volatile uint32_t open_count;
         volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint64_t last_write_fh;
     };
     struct mmap_shared_state *shared =
         (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
@@ -2957,9 +3274,13 @@ static int ext_test_shared_mmap_subrange_mprotect_failure_preserves_vma() {
         child_args.stop = &shared->stop;
         child_args.init_done = &shared->init_done;
         child_args.stop_on_destroy = 1;
+        child_args.enable_write_ops = 1;
         child_args.open_count = &shared->open_count;
         child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.last_write_fh = &shared->last_write_fh;
         child_args.hello_data_size_override = map_len;
+        child_args.next_open_fh = 920;
         fuse_daemon_thread(&child_args);
         _exit(0);
     }
@@ -3010,8 +3331,19 @@ static int ext_test_shared_mmap_subrange_mprotect_failure_preserves_vma() {
                shared->open_count, shared->read_count);
         goto fail;
     }
-    if (mprotect((char *)addr + page_size, page_size, PROT_READ | PROT_WRITE) == 0) {
-        printf("[FAIL] subrange mprotect unexpectedly allowed shared writable FUSE mapping\n");
+    if (mprotect((char *)addr + page_size, page_size, PROT_READ | PROT_WRITE) != 0) {
+        printf("[FAIL] subrange mprotect(shared writable): %s (errno=%d)\n", strerror(errno),
+               errno);
+        goto fail;
+    }
+    ((volatile char *)addr)[page_size + 1] = 'S';
+    if (msync((char *)addr + page_size, page_size, MS_SYNC) != 0) {
+        printf("[FAIL] msync(subrange shared writable): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (shared->write_count != 1 || shared->last_write_fh != 920) {
+        printf("[FAIL] subrange writeback counters write=%u wfh=%llu\n", shared->write_count,
+               (unsigned long long)shared->last_write_fh);
         goto fail;
     }
     if (mprotect(addr, page_size, PROT_NONE) != 0) {
@@ -4248,16 +4580,24 @@ TEST(FuseExtended, DirectIoMmapPolicy) {
     ASSERT_EQ(0, ext_test_direct_io_mmap_policy());
 }
 
-TEST(FuseExtended, SharedWritableMmapFaultSigbus) {
-    ASSERT_EQ(0, ext_test_shared_writable_mmap_fault_sigbus());
+TEST(FuseExtended, SharedWritableMmapMsyncWriteback) {
+    ASSERT_EQ(0, ext_test_shared_writable_mmap_msync_writeback());
 }
 
-TEST(FuseExtended, SharedMmapMprotectWriteDenied) {
-    ASSERT_EQ(0, ext_test_shared_mmap_mprotect_write_denied());
+TEST(FuseExtended, SharedMmapMprotectWriteback) {
+    ASSERT_EQ(0, ext_test_shared_mmap_mprotect_writeback());
 }
 
-TEST(FuseExtended, SharedMmapSubrangeMprotectFailurePreservesVma) {
-    ASSERT_EQ(0, ext_test_shared_mmap_subrange_mprotect_failure_preserves_vma());
+TEST(FuseExtended, SharedMmapReadonlyFdMprotectWriteDenied) {
+    ASSERT_EQ(0, ext_test_shared_mmap_readonly_fd_mprotect_write_denied());
+}
+
+TEST(FuseExtended, SharedWritableMmapMunmapWritebackWithoutMsync) {
+    ASSERT_EQ(0, ext_test_shared_writable_mmap_munmap_writeback_without_msync());
+}
+
+TEST(FuseExtended, SharedMmapSubrangeMprotectWritebackPreservesVma) {
+    ASSERT_EQ(0, ext_test_shared_mmap_subrange_mprotect_writeback_preserves_vma());
 }
 
 TEST(FuseExtended, SharedMmapUnfaultedMprotectProtNone) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1534,6 +1534,115 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_ftruncate_setattr_uses_open_fh() {
+    const char *mp = "/tmp/test_fuse_ftruncate_fh";
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t setattr_count = 0;
+    volatile uint32_t last_setattr_valid = 0;
+    volatile uint64_t last_setattr_fh = 0;
+    volatile uint64_t last_setattr_size = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.open_count = &open_count;
+    args.setattr_count = &setattr_count;
+    args.last_setattr_valid = &last_setattr_valid;
+    args.last_setattr_fh = &last_setattr_fh;
+    args.last_setattr_size = &last_setattr_size;
+    args.next_open_fh = 940;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (ftruncate(f, 7) != 0) {
+        printf("[FAIL] ftruncate: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+
+    usleep(100 * 1000);
+    if (open_count != 1 || setattr_count != 1) {
+        printf("[FAIL] counters open=%u setattr=%u\n", open_count, setattr_count);
+        goto fail;
+    }
+    if ((last_setattr_valid & FATTR_SIZE) == 0 || (last_setattr_valid & FATTR_FH) == 0 ||
+        last_setattr_fh != 940 || last_setattr_size != 7) {
+        printf("[FAIL] setattr valid=0x%x fh=%llu size=%llu\n", last_setattr_valid,
+               (unsigned long long)last_setattr_fh, (unsigned long long)last_setattr_size);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_init_requests_linux_no_open_support() {
     const char *mp = "/tmp/test_fuse_init_flags";
     if (ensure_dir(mp) != 0) {
@@ -5425,6 +5534,10 @@ TEST(FuseExtended, FopenNonseekableDirectoryDisablesLseek) {
 
 TEST(FuseExtended, AtomicOTruncUsesOpenWithoutSetattr) {
     ASSERT_EQ(0, ext_test_atomic_otrunc_uses_open_without_setattr());
+}
+
+TEST(FuseExtended, FtruncateSetattrUsesOpenFh) {
+    ASSERT_EQ(0, ext_test_ftruncate_setattr_uses_open_fh());
 }
 
 TEST(FuseExtended, InitRequestsLinuxNoOpenSupport) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -3344,6 +3344,178 @@ fail:
     return -1;
 }
 
+static int ext_test_shared_writable_mmap_osync_writeback() {
+    const char *mp = "/tmp/test_fuse_mmap_shared_osync";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t daemon = -1;
+    const size_t page_size = 4096;
+    const size_t map_len = page_size * 2;
+    const char marker = 'Z';
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint32_t fsync_count;
+        volatile uint64_t last_write_fh;
+        volatile uint64_t last_write_offset;
+        volatile uint32_t last_write_size;
+        volatile uint32_t last_write_flags;
+        volatile uint32_t last_write_open_flags;
+        volatile uint64_t last_fsync_fh;
+        volatile uint32_t write_count_at_fsync;
+        volatile uint32_t last_write_flags_at_fsync;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.enable_write_ops = 1;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.fsync_count = &shared->fsync_count;
+        child_args.last_write_fh = &shared->last_write_fh;
+        child_args.last_write_offset = &shared->last_write_offset;
+        child_args.last_write_size = &shared->last_write_size;
+        child_args.last_write_flags = &shared->last_write_flags;
+        child_args.last_write_open_flags = &shared->last_write_open_flags;
+        child_args.last_fsync_fh = &shared->last_fsync_fh;
+        child_args.write_count_at_fsync = &shared->write_count_at_fsync;
+        child_args.last_write_flags_at_fsync = &shared->last_write_flags_at_fsync;
+        child_args.next_open_fh = 930;
+        child_args.hello_data_size_override = map_len;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR | O_SYNC);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, map_len, PROT_READ | PROT_WRITE, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+
+    c = ((volatile char *)addr)[0];
+    if (c != 'A') {
+        printf("[FAIL] shared writable mmap first byte got=%d\n", c);
+        goto fail;
+    }
+    ((volatile char *)addr)[2] = 'F';
+    if (pwrite(f, &marker, 1, (off_t)page_size) != 1) {
+        printf("[FAIL] pwrite(O_SYNC): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 2 ||
+        shared->fsync_count != 1 || shared->last_write_fh != 930 || shared->last_fsync_fh != 930 ||
+        shared->last_write_offset != 0 || shared->last_write_size != page_size ||
+        shared->last_write_flags != FUSE_WRITE_CACHE || shared->last_write_open_flags != 0 ||
+        shared->write_count_at_fsync != 2 ||
+        shared->last_write_flags_at_fsync != FUSE_WRITE_CACHE) {
+        printf("[FAIL] shared mmap osync counters open=%u read=%u write=%u fsync=%u wfh=%llu fsh=%llu off=%llu size=%u wflags=%u oflags=%u fsync_writes=%u fsync_wflags=%u\n",
+               shared->open_count, shared->read_count, shared->write_count, shared->fsync_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_fsync_fh,
+               (unsigned long long)shared->last_write_offset, shared->last_write_size,
+               shared->last_write_flags, shared->last_write_open_flags,
+               shared->write_count_at_fsync, shared->last_write_flags_at_fsync);
+        goto fail;
+    }
+
+    munmap(addr, map_len);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, map_len);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_shared_mmap_mprotect_writeback() {
     const char *mp = "/tmp/test_fuse_mmap_mprotect_write";
     char path[256];
@@ -5159,6 +5331,10 @@ TEST(FuseExtended, DirectIoMmapPolicy) {
 
 TEST(FuseExtended, SharedWritableMmapMsyncWriteback) {
     ASSERT_EQ(0, ext_test_shared_writable_mmap_msync_writeback());
+}
+
+TEST(FuseExtended, SharedWritableMmapOSyncWriteback) {
+    ASSERT_EQ(0, ext_test_shared_writable_mmap_osync_writeback());
 }
 
 TEST(FuseExtended, SharedMmapMprotectWriteback) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -865,6 +865,217 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_fsetfl_updates_fuse_io_flags() {
+    const char *mp = "/tmp/test_fuse_fsetfl_flags";
+    int requested = O_RDWR;
+    int f = -1;
+    int old_flags = -1;
+    uint32_t expected_open = (uint32_t)requested;
+    uint32_t expected_setfl = 0;
+    char buf[8];
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint32_t release_count = 0;
+    volatile uint32_t last_open_flags = 0;
+    volatile uint32_t last_read_flags = 0;
+    volatile uint32_t last_write_flags = 0;
+    volatile uint32_t last_release_flags = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.open_count = &open_count;
+    args.read_count = &read_count;
+    args.write_count = &write_count;
+    args.release_count = &release_count;
+    args.last_open_in_flags = &last_open_flags;
+    args.last_read_open_flags = &last_read_flags;
+    args.last_write_open_flags = &last_write_flags;
+    args.last_release_in_flags = &last_release_flags;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, requested);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+
+    old_flags = fcntl(f, F_GETFL);
+    if (old_flags < 0) {
+        printf("[FAIL] fcntl(F_GETFL): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (fcntl(f, F_SETFL, old_flags | O_NONBLOCK) != 0) {
+        printf("[FAIL] fcntl(F_SETFL): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    memset(buf, 0, sizeof(buf));
+    if (read(f, buf, 5) != 5 || memcmp(buf, "hello", 5) != 0) {
+        printf("[FAIL] read after F_SETFL got='%.*s' errno=%d\n", 5, buf, errno);
+        goto fail;
+    }
+    if (write(f, "X", 1) != 1) {
+        printf("[FAIL] write after F_SETFL: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+    usleep(100 * 1000);
+
+    expected_setfl = (uint32_t)(old_flags | O_NONBLOCK);
+    if (open_count != 1 || read_count != 1 || write_count != 1 || release_count != 1) {
+        printf("[FAIL] counters open=%u read=%u write=%u release=%u\n", open_count, read_count,
+               write_count, release_count);
+        goto fail;
+    }
+    if (last_open_flags != expected_open) {
+        printf("[FAIL] open flags got=0%o expected=0%o\n", last_open_flags, expected_open);
+        goto fail;
+    }
+    if ((last_read_flags & O_NONBLOCK) == 0 || last_write_flags != expected_setfl ||
+        last_release_flags != expected_setfl) {
+        printf("[FAIL] updated flags read=0%o write=0%o release=0%o expected=0%o\n",
+               last_read_flags, last_write_flags, last_release_flags, expected_setfl);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_fsetfl_updates_fuse_dev_nonblock() {
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+
+    int old_flags = fcntl(fd, F_GETFL);
+    if (old_flags < 0) {
+        printf("[FAIL] fcntl(F_GETFL): %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        return -1;
+    }
+    if ((old_flags & O_NONBLOCK) != 0) {
+        printf("[FAIL] /dev/fuse unexpectedly opened nonblocking: flags=0%o\n", old_flags);
+        close(fd);
+        return -1;
+    }
+    if (fcntl(fd, F_SETFL, old_flags | O_NONBLOCK) != 0) {
+        printf("[FAIL] fcntl(F_SETFL O_NONBLOCK): %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        return -1;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        return -1;
+    }
+    if (child == 0) {
+        unsigned char *buf = (unsigned char *)malloc(FUSE_TEST_BUF_SIZE);
+        if (!buf) {
+            _exit(11);
+        }
+        ssize_t n = read(fd, buf, FUSE_TEST_BUF_SIZE);
+        int saved_errno = errno;
+        free(buf);
+        if (n < 0 && (saved_errno == EAGAIN || saved_errno == EWOULDBLOCK)) {
+            _exit(0);
+        }
+        _exit(12);
+    }
+
+    for (int i = 0; i < 50; i++) {
+        int status = 0;
+        pid_t got = waitpid(child, &status, WNOHANG);
+        if (got == child) {
+            close(fd);
+            if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+                return 0;
+            }
+            printf("[FAIL] child read did not return EAGAIN, status=%d\n", status);
+            return -1;
+        }
+        if (got < 0) {
+            printf("[FAIL] waitpid: %s (errno=%d)\n", strerror(errno), errno);
+            close(fd);
+            return -1;
+        }
+        usleep(20 * 1000);
+    }
+
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
+    close(fd);
+    printf("[FAIL] /dev/fuse read blocked after F_SETFL O_NONBLOCK\n");
+    return -1;
+}
+
 static int ext_test_fopen_noflush_skips_flush() {
     const char *mp = "/tmp/test_fuse_noflush";
     int f = -1;
@@ -4950,6 +5161,14 @@ TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {
 
 TEST(FuseExtended, OpenFlagsMatchLinuxMask) {
     ASSERT_EQ(0, ext_test_open_release_flags_match_linux());
+}
+
+TEST(FuseExtended, FsetflUpdatesFuseIoFlags) {
+    ASSERT_EQ(0, ext_test_fsetfl_updates_fuse_io_flags());
+}
+
+TEST(FuseExtended, FsetflUpdatesFuseDevNonblock) {
+    ASSERT_EQ(0, ext_test_fsetfl_updates_fuse_dev_nonblock());
 }
 
 TEST(FuseExtended, FopenNoFlushSkipsFlush) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -3777,6 +3777,7 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
         volatile uint32_t read_count;
         volatile uint32_t write_count;
         volatile uint64_t last_write_fh;
+        volatile uint32_t last_open_pid;
         volatile uint64_t last_write_offset;
         volatile uint32_t last_write_size;
         volatile uint32_t last_write_flags;
@@ -3828,6 +3829,7 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
         child_args.read_count = &shared->read_count;
         child_args.write_count = &shared->write_count;
         child_args.last_write_fh = &shared->last_write_fh;
+        child_args.last_open_pid = &shared->last_open_pid;
         child_args.last_write_offset = &shared->last_write_offset;
         child_args.last_write_size = &shared->last_write_size;
         child_args.last_write_flags = &shared->last_write_flags;
@@ -3885,13 +3887,172 @@ static int ext_test_shared_writable_mmap_msync_writeback() {
         shared->last_write_fh != 900 || shared->last_write_offset != 0 ||
         shared->last_write_size != 16 || shared->last_write_flags != expected_writeback_flags ||
         shared->last_write_open_flags != 0 || shared->last_write_uid != 0 ||
-        shared->last_write_gid != 0 || shared->last_write_pid != 0) {
-        printf("[FAIL] shared writable mmap counters open=%u read=%u write=%u wfh=%llu off=%llu size=%u wflags=%u oflags=%u uid=%u gid=%u pid=%u\n",
+        shared->last_write_gid != 0 || shared->last_open_pid == 0 ||
+        shared->last_write_pid != shared->last_open_pid) {
+        printf("[FAIL] shared writable mmap counters open=%u read=%u write=%u wfh=%llu open_pid=%u off=%llu size=%u wflags=%u oflags=%u uid=%u gid=%u pid=%u\n",
                shared->open_count, shared->read_count, shared->write_count,
-               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_write_fh, shared->last_open_pid,
                (unsigned long long)shared->last_write_offset, shared->last_write_size,
                shared->last_write_flags, shared->last_write_open_flags, shared->last_write_uid,
                shared->last_write_gid, shared->last_write_pid);
+        goto fail;
+    }
+
+    munmap(addr, 4096);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_shared_mmap_dirty_then_pwrite_keeps_latest_data() {
+    const char *mp = "/tmp/test_fuse_mmap_dirty_pwrite";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t daemon = -1;
+    struct dirty_pwrite_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t read_count;
+        volatile uint32_t write_count;
+        volatile uint64_t last_write_offset;
+        volatile uint32_t last_write_size;
+        volatile uint32_t last_write_flags;
+        volatile unsigned char last_write_watch_byte;
+    };
+    struct dirty_pwrite_shared_state *shared =
+        (struct dirty_pwrite_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                                 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.enable_write_ops = 1;
+        child_args.stop_on_destroy = 1;
+        child_args.read_count = &shared->read_count;
+        child_args.write_count = &shared->write_count;
+        child_args.last_write_offset = &shared->last_write_offset;
+        child_args.last_write_size = &shared->last_write_size;
+        child_args.last_write_flags = &shared->last_write_flags;
+        child_args.last_write_watch_byte = &shared->last_write_watch_byte;
+        child_args.write_watch_offset = 1;
+        child_args.next_open_fh = 901;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+
+    c = ((volatile char *)addr)[0];
+    if (c != 'h') {
+        printf("[FAIL] shared writable mmap first byte got=%d\n", c);
+        goto fail;
+    }
+    ((volatile char *)addr)[1] = 'M';
+    if (pwrite(f, "P", 1, 1) != 1) {
+        printf("[FAIL] pwrite over dirty mmap byte: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (((volatile char *)addr)[1] != 'P') {
+        printf("[FAIL] mmap cache was not updated by overlapping pwrite got=%d\n",
+               ((volatile char *)addr)[1]);
+        goto fail;
+    }
+    if (msync(addr, 4096, MS_SYNC) != 0) {
+        printf("[FAIL] msync(shared dirty pwrite): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (shared->write_count < 2 || shared->last_write_offset != 0 ||
+        shared->last_write_size != 16 || shared->last_write_flags != FUSE_WRITE_CACHE ||
+        shared->last_write_watch_byte != 'P') {
+        printf("[FAIL] dirty mmap pwrite counters read=%u write=%u off=%llu size=%u flags=%u watched=%u\n",
+               shared->read_count, shared->write_count,
+               (unsigned long long)shared->last_write_offset, shared->last_write_size,
+               shared->last_write_flags, shared->last_write_watch_byte);
         goto fail;
     }
 
@@ -5915,6 +6076,10 @@ TEST(FuseExtended, DirectIoMmapPolicy) {
 
 TEST(FuseExtended, SharedWritableMmapMsyncWriteback) {
     ASSERT_EQ(0, ext_test_shared_writable_mmap_msync_writeback());
+}
+
+TEST(FuseExtended, SharedMmapDirtyThenPwriteKeepsLatestData) {
+    ASSERT_EQ(0, ext_test_shared_mmap_dirty_then_pwrite_keeps_latest_data());
 }
 
 TEST(FuseExtended, SharedWritableMmapOSyncWriteback) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1692,6 +1692,115 @@ fail:
     return -1;
 }
 
+static int ext_test_cached_short_read_updates_eof() {
+    const char *mp = "/tmp/test_fuse_cached_short_read";
+    char path[256];
+    char buf[32];
+    int f = -1;
+    ssize_t n = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint64_t read_offsets[4] = {0};
+    volatile uint32_t read_sizes[4] = {0};
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.read_count = &read_count;
+    args.read_offsets = read_offsets;
+    args.read_sizes = read_sizes;
+    args.read_trace_capacity = 4;
+    args.hello_data_size_override = 8192;
+    args.hello_read_size_override = 5;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+
+    memset(buf, 0x7f, sizeof(buf));
+    n = pread(f, buf, sizeof(buf), 0);
+    if (n != 5 || memcmp(buf, "ABCDE", 5) != 0) {
+        printf("[FAIL] short cached pread got=%zd data='%.*s' read=%u errno=%d\n", n, 5, buf,
+               read_count, errno);
+        goto fail;
+    }
+    memset(buf, 0x7f, sizeof(buf));
+    n = pread(f, buf, sizeof(buf), 5);
+    if (n != 0) {
+        printf("[FAIL] EOF cached pread got=%zd read=%u errno=%d\n", n, read_count, errno);
+        goto fail;
+    }
+
+    if (read_count != 1 || read_offsets[0] != 0 || read_sizes[0] != 4096) {
+        printf("[FAIL] short read trace count=%u off0=%llu size0=%u\n", read_count,
+               (unsigned long long)read_offsets[0], read_sizes[0]);
+        goto fail;
+    }
+
+    close(f);
+    f = -1;
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_cached_read_sees_write_through_update() {
     const char *mp = "/tmp/test_fuse_cached_read_write";
     char path[256];
@@ -3818,6 +3927,10 @@ TEST(FuseExtended, LargeReadSplitsOverMaxWrite) {
 
 TEST(FuseExtended, CachedReadUsesOpenFhWithoutExtraOpen) {
     ASSERT_EQ(0, ext_test_cached_read_uses_open_fh_without_extra_open());
+}
+
+TEST(FuseExtended, CachedShortReadUpdatesEof) {
+    ASSERT_EQ(0, ext_test_cached_short_read_updates_eof());
 }
 
 TEST(FuseExtended, CachedReadSeesWriteThroughUpdate) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -865,6 +865,98 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_fopen_noflush_skips_flush() {
+    const char *mp = "/tmp/test_fuse_noflush";
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t flush_count = 0;
+    volatile uint32_t release_count = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.flush_count = &flush_count;
+    args.release_count = &release_count;
+    args.hello_open_out_flags = FOPEN_NOFLUSH;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+
+    usleep(100 * 1000);
+    if (flush_count != 0 || release_count != 1) {
+        printf("[FAIL] noflush counters flush=%u release=%u\n", flush_count, release_count);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_atomic_otrunc_uses_open_without_setattr() {
     const char *mp = "/tmp/test_fuse_atomic_otrunc";
     int requested = O_RDWR | O_TRUNC;
@@ -4642,6 +4734,10 @@ TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {
 
 TEST(FuseExtended, OpenFlagsMatchLinuxMask) {
     ASSERT_EQ(0, ext_test_open_release_flags_match_linux());
+}
+
+TEST(FuseExtended, FopenNoFlushSkipsFlush) {
+    ASSERT_EQ(0, ext_test_fopen_noflush_skips_flush());
 }
 
 TEST(FuseExtended, AtomicOTruncUsesOpenWithoutSetattr) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1592,6 +1592,116 @@ fail:
     return -1;
 }
 
+static int ext_test_cached_read_sees_write_through_update() {
+    const char *mp = "/tmp/test_fuse_cached_read_write";
+    char path[256];
+    char buf[16];
+    int f = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint64_t last_write_fh = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.open_count = &open_count;
+    args.read_count = &read_count;
+    args.write_count = &write_count;
+    args.last_write_fh = &last_write_fh;
+    args.next_open_fh = 300;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    if (pread(f, buf, 5, 0) != 5 || memcmp(buf, "hello", 5) != 0) {
+        printf("[FAIL] first cached pread got='%.*s' read=%u errno=%d\n", 5, buf, read_count,
+               errno);
+        goto fail;
+    }
+    if (pwrite(f, "CACHE", 5, 0) != 5) {
+        printf("[FAIL] pwrite CACHE: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    if (pread(f, buf, 5, 0) != 5 || memcmp(buf, "CACHE", 5) != 0) {
+        printf("[FAIL] second cached pread got='%.*s' read=%u errno=%d\n", 5, buf, read_count,
+               errno);
+        goto fail;
+    }
+    if (open_count != 1 || read_count != 1 || write_count != 1 || last_write_fh != 300) {
+        printf("[FAIL] cached write counters open=%u read=%u write=%u wfh=%llu\n", open_count,
+               read_count, write_count, (unsigned long long)last_write_fh);
+        goto fail;
+    }
+
+    close(f);
+    f = -1;
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_mmap_fault_uses_open_fh_without_extra_open() {
     const char *mp = "/tmp/test_fuse_mmap_fh";
     char path[256];
@@ -3334,6 +3444,10 @@ TEST(FuseExtended, LargeReadSplitsOverMaxWrite) {
 
 TEST(FuseExtended, CachedReadUsesOpenFhWithoutExtraOpen) {
     ASSERT_EQ(0, ext_test_cached_read_uses_open_fh_without_extra_open());
+}
+
+TEST(FuseExtended, CachedReadSeesWriteThroughUpdate) {
+    ASSERT_EQ(0, ext_test_cached_read_sees_write_through_update());
 }
 
 TEST(FuseExtended, MmapFaultUsesOpenFhWithoutExtraOpen) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -865,6 +865,106 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_atomic_otrunc_uses_open_without_setattr() {
+    const char *mp = "/tmp/test_fuse_atomic_otrunc";
+    int requested = O_RDWR | O_TRUNC;
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t last_open_flags = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t setattr_count = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 0;
+    args.stop_on_destroy = 1;
+    args.open_count = &open_count;
+    args.setattr_count = &setattr_count;
+    args.last_open_in_flags = &last_open_flags;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_ATOMIC_O_TRUNC;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, requested);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+
+    usleep(100 * 1000);
+    if (open_count != 1 || (last_open_flags & O_TRUNC) == 0) {
+        printf("[FAIL] open counters/flags open=%u flags=0%o\n", open_count, last_open_flags);
+        goto fail;
+    }
+    if (setattr_count != 0) {
+        printf("[FAIL] atomic O_TRUNC unexpectedly sent SETATTR count=%u\n", setattr_count);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_init_requests_linux_no_open_support() {
     const char *mp = "/tmp/test_fuse_init_flags";
     if (ensure_dir(mp) != 0) {
@@ -3508,6 +3608,10 @@ TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {
 
 TEST(FuseExtended, OpenFlagsMatchLinuxMask) {
     ASSERT_EQ(0, ext_test_open_release_flags_match_linux());
+}
+
+TEST(FuseExtended, AtomicOTruncUsesOpenWithoutSetattr) {
+    ASSERT_EQ(0, ext_test_atomic_otrunc_uses_open_without_setattr());
 }
 
 TEST(FuseExtended, InitRequestsLinuxNoOpenSupport) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1938,6 +1938,280 @@ fail:
     return -1;
 }
 
+static int ext_test_direct_io_read_bypasses_page_cache() {
+    const char *mp = "/tmp/test_fuse_direct_read";
+    char path[256];
+    char buf[32];
+    int f = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint64_t read_fhs[4] = {0};
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.open_count = &open_count;
+    args.read_count = &read_count;
+    args.read_fhs = read_fhs;
+    args.read_trace_capacity = 4;
+    args.next_open_fh = 700;
+    args.hello_open_out_flags = FOPEN_DIRECT_IO;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    if (pread(f, buf, 5, 0) != 5 || memcmp(buf, "hello", 5) != 0) {
+        printf("[FAIL] first direct pread got='%.*s' read=%u errno=%d\n", 5, buf, read_count,
+               errno);
+        goto fail;
+    }
+    memset(buf, 0, sizeof(buf));
+    if (pread(f, buf, 5, 0) != 5 || memcmp(buf, "hello", 5) != 0) {
+        printf("[FAIL] second direct pread got='%.*s' read=%u errno=%d\n", 5, buf, read_count,
+               errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+
+    if (open_count != 1 || read_count != 2 || read_fhs[0] != 700 || read_fhs[1] != 700) {
+        printf("[FAIL] direct read counters open=%u read=%u fh0=%llu fh1=%llu\n", open_count,
+               read_count, (unsigned long long)read_fhs[0], (unsigned long long)read_fhs[1]);
+        goto fail;
+    }
+
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_direct_io_mmap_policy() {
+    const char *mp = "/tmp/test_fuse_direct_mmap";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    char warm = 0;
+    pid_t child = -1;
+    struct direct_mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_out_flags;
+        volatile unsigned char first_byte;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+        volatile uint64_t read_fhs[4];
+    };
+    struct direct_mmap_shared_state *shared =
+        (struct direct_mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                                MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (child == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.read_fhs = shared->read_fhs;
+        child_args.read_trace_capacity = 4;
+        child_args.next_open_fh = 800;
+        child_args.dynamic_hello_open_out_flags = &shared->open_out_flags;
+        child_args.dynamic_hello_first_byte = &shared->first_byte;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(child, SIGTERM);
+        waitpid(child, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (pread(f, &warm, 1, 0) != 1 || warm != 'h') {
+        printf("[FAIL] warm cached read got=%d read=%u errno=%d\n", warm, shared->read_count,
+               errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+
+    shared->open_out_flags = FOPEN_DIRECT_IO;
+    shared->first_byte = 'Z';
+
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] direct open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+
+    errno = 0;
+    addr = mmap(NULL, 4096, PROT_READ, MAP_SHARED, f, 0);
+    if (addr != MAP_FAILED) {
+        printf("[FAIL] direct_io MAP_SHARED unexpectedly succeeded\n");
+        munmap(addr, 4096);
+        addr = MAP_FAILED;
+        goto fail;
+    }
+    if (errno != ENODEV) {
+        printf("[FAIL] direct_io MAP_SHARED errno=%d expected=%d\n", errno, ENODEV);
+        goto fail;
+    }
+
+    addr = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] direct_io MAP_PRIVATE mmap: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    c = ((volatile char *)addr)[0];
+    if (c != 'Z') {
+        printf("[FAIL] direct_io MAP_PRIVATE first byte got=%d\n", c);
+        goto fail;
+    }
+    if (shared->open_count != 2 || shared->read_count != 2 || shared->read_fhs[1] != 801) {
+        printf("[FAIL] direct mmap counters open=%u read=%u fh0=%llu fh1=%llu\n",
+               shared->open_count, shared->read_count, (unsigned long long)shared->read_fhs[0],
+               (unsigned long long)shared->read_fhs[1]);
+        goto fail;
+    }
+
+    munmap(addr, 4096);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(child, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (child > 0) {
+        kill(child, SIGTERM);
+        waitpid(child, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_shared_writable_mmap_fault_sigbus() {
     const char *mp = "/tmp/test_fuse_mmap_shared_write";
     char path[256];
@@ -3552,6 +3826,14 @@ TEST(FuseExtended, CachedReadSeesWriteThroughUpdate) {
 
 TEST(FuseExtended, MmapFaultUsesOpenFhWithoutExtraOpen) {
     ASSERT_EQ(0, ext_test_mmap_fault_uses_open_fh_without_extra_open());
+}
+
+TEST(FuseExtended, DirectIoReadBypassesPageCache) {
+    ASSERT_EQ(0, ext_test_direct_io_read_bypasses_page_cache());
+}
+
+TEST(FuseExtended, DirectIoMmapPolicy) {
+    ASSERT_EQ(0, ext_test_direct_io_mmap_policy());
 }
 
 TEST(FuseExtended, SharedWritableMmapFaultSigbus) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1562,6 +1562,704 @@ fail:
     return -1;
 }
 
+static int ext_test_mount_on_fuse_dir_uses_namespace_path() {
+    const char *mp = "/tmp/test_fuse_mount_target";
+    char dir_path[512];
+    char marker_path[1024];
+    int ramfs_mounted = 0;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(dir_path, sizeof(dir_path), "%s/ramfs_target", mp);
+    if (mkdir(dir_path, 0755) != 0) {
+        printf("[FAIL] mkdir(%s): %s (errno=%d)\n", dir_path, strerror(errno), errno);
+        goto fail;
+    }
+
+    if (mount("", dir_path, "ramfs", 0, NULL) != 0) {
+        printf("[FAIL] mount(ramfs on fuse dir): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    ramfs_mounted = 1;
+
+    snprintf(marker_path, sizeof(marker_path), "%s/marker", dir_path);
+    if (fuseg_write_file(marker_path, "mounted") != 0) {
+        printf("[FAIL] write marker under ramfs: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    if (umount(dir_path) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", dir_path, strerror(errno), errno);
+        goto fail_no_ramfs_umount;
+    }
+    ramfs_mounted = 0;
+    if (rmdir(dir_path) != 0) {
+        printf("[FAIL] rmdir(%s): %s (errno=%d)\n", dir_path, strerror(errno), errno);
+        goto fail;
+    }
+
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (ramfs_mounted) {
+        umount(dir_path);
+    }
+fail_no_ramfs_umount:
+    rmdir(dir_path);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_rename_updates_fuse_dir_cwd_path() {
+    const char *mp = "/tmp/test_fuse_rename_path";
+    char old_path[512];
+    char new_path[512];
+    char cwd[512];
+    int dir_fd = -1;
+    int ramfs_mounted = 0;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(old_path, sizeof(old_path), "%s/old_dir", mp);
+    snprintf(new_path, sizeof(new_path), "%s/new_dir", mp);
+    if (mkdir(old_path, 0755) != 0) {
+        printf("[FAIL] mkdir(%s): %s (errno=%d)\n", old_path, strerror(errno), errno);
+        goto fail;
+    }
+    dir_fd = open(old_path, O_RDONLY | O_DIRECTORY);
+    if (dir_fd < 0) {
+        printf("[FAIL] open dir fd %s: %s (errno=%d)\n", old_path, strerror(errno), errno);
+        goto fail;
+    }
+    if (rename(old_path, new_path) != 0) {
+        printf("[FAIL] rename(%s -> %s): %s (errno=%d)\n", old_path, new_path, strerror(errno),
+               errno);
+        goto fail;
+    }
+    if (fchdir(dir_fd) != 0) {
+        printf("[FAIL] fchdir renamed dir fd: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (!getcwd(cwd, sizeof(cwd))) {
+        printf("[FAIL] getcwd after rename: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail_chdir_root;
+    }
+    if (strcmp(cwd, new_path) != 0) {
+        printf("[FAIL] getcwd after rename: got '%s', want '%s'\n", cwd, new_path);
+        goto fail_chdir_root;
+    }
+    if (chdir("/") != 0) {
+        printf("[FAIL] chdir(/): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(dir_fd);
+    dir_fd = -1;
+
+    if (mount("", new_path, "ramfs", 0, NULL) != 0) {
+        printf("[FAIL] mount(ramfs on renamed fuse dir): %s (errno=%d)\n", strerror(errno),
+               errno);
+        goto fail;
+    }
+    ramfs_mounted = 1;
+    if (umount(new_path) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", new_path, strerror(errno), errno);
+        goto fail_no_ramfs_umount;
+    }
+    ramfs_mounted = 0;
+    if (rmdir(new_path) != 0) {
+        printf("[FAIL] rmdir(%s): %s (errno=%d)\n", new_path, strerror(errno), errno);
+        goto fail;
+    }
+
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail_chdir_root:
+    {
+        int ignored_chdir = chdir("/");
+        (void)ignored_chdir;
+    }
+fail:
+    if (dir_fd >= 0) {
+        close(dir_fd);
+    }
+    if (ramfs_mounted) {
+        umount(new_path);
+    }
+fail_no_ramfs_umount:
+    rmdir(new_path);
+    rmdir(old_path);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_readdirplus_generation_mismatch_stales_old_node() {
+    const char *mp = "/tmp/test_fuse_readdirplus_generation";
+    char file_path[512];
+    int old_fd = -1;
+    int new_fd = -1;
+    DIR *dir = NULL;
+    int saw = 0;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t readdirplus_count = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.readdirplus_count = &readdirplus_count;
+    args.force_opendir_enosys = 1;
+    args.init_out_flags_override =
+        FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_NO_OPENDIR_SUPPORT | FUSE_DO_READDIRPLUS;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(file_path, sizeof(file_path), "%s/hello.txt", mp);
+    old_fd = open(file_path, O_RDONLY);
+    if (old_fd < 0) {
+        printf("[FAIL] open old hello: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    char buf[64];
+    if (read(old_fd, buf, sizeof(buf)) <= 0) {
+        printf("[FAIL] initial read old hello: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    args.fs.nodes[1].generation = 2;
+    dir = opendir(mp);
+    if (!dir) {
+        printf("[FAIL] opendir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+    struct dirent *de;
+    while ((de = readdir(dir)) != NULL) {
+        if (strcmp(de->d_name, "hello.txt") == 0) {
+            saw = 1;
+        }
+    }
+    closedir(dir);
+    dir = NULL;
+    if (!saw || readdirplus_count == 0) {
+        printf("[FAIL] expected hello.txt from READDIRPLUS, saw=%d count=%u\n", saw,
+               readdirplus_count);
+        goto fail;
+    }
+
+    errno = 0;
+    if (pread(old_fd, buf, sizeof(buf), 0) >= 0) {
+        printf("[FAIL] stale old fd read unexpectedly succeeded\n");
+        goto fail;
+    }
+    close(old_fd);
+    old_fd = -1;
+
+    new_fd = open(file_path, O_RDONLY);
+    if (new_fd < 0) {
+        printf("[FAIL] open fresh hello: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (read(new_fd, buf, sizeof(buf)) <= 0) {
+        printf("[FAIL] read fresh hello: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(new_fd);
+    new_fd = -1;
+
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (dir) {
+        closedir(dir);
+    }
+    if (new_fd >= 0) {
+        close(new_fd);
+    }
+    if (old_fd >= 0) {
+        close(old_fd);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_create_generation_mismatch_stales_old_node() {
+    const char *mp = "/tmp/test_fuse_create_generation";
+    char old_path[512];
+    char new_path[512];
+    int old_fd = -1;
+    int new_fd = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(old_path, sizeof(old_path), "%s/hello.txt", mp);
+    snprintf(new_path, sizeof(new_path), "%s/reused.txt", mp);
+    old_fd = open(old_path, O_RDONLY);
+    if (old_fd < 0) {
+        printf("[FAIL] open old hello: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (unlink(old_path) != 0) {
+        printf("[FAIL] unlink old hello: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    args.create_reuse_nodeid = 2;
+    args.create_generation_override = 2;
+    new_fd = open(new_path, O_CREAT | O_RDWR, 0644);
+    if (new_fd < 0) {
+        printf("[FAIL] create reused node: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    char buf[64];
+    errno = 0;
+    if (pread(old_fd, buf, sizeof(buf), 0) >= 0) {
+        printf("[FAIL] stale old fd after create unexpectedly succeeded\n");
+        goto fail;
+    }
+    close(old_fd);
+    old_fd = -1;
+    close(new_fd);
+    new_fd = -1;
+
+    if (unlink(new_path) != 0) {
+        printf("[FAIL] unlink reused node: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (new_fd >= 0) {
+        close(new_fd);
+    }
+    if (old_fd >= 0) {
+        close(old_fd);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_link_generation_mismatch_stales_old_node() {
+    const char *mp = "/tmp/test_fuse_link_generation";
+    char old_path[512];
+    char hard_path[512];
+    int old_fd = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.link_reuse_old_nodeid = 1;
+    args.link_generation_override = 2;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(old_path, sizeof(old_path), "%s/hello.txt", mp);
+    snprintf(hard_path, sizeof(hard_path), "%s/hard.txt", mp);
+    old_fd = open(old_path, O_RDONLY);
+    if (old_fd < 0) {
+        printf("[FAIL] open old hello: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (link(old_path, hard_path) != 0) {
+        printf("[FAIL] link reused node: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    char buf[64];
+    errno = 0;
+    if (pread(old_fd, buf, sizeof(buf), 0) >= 0) {
+        printf("[FAIL] stale old fd after link unexpectedly succeeded\n");
+        goto fail;
+    }
+    close(old_fd);
+    old_fd = -1;
+
+    unlink(hard_path);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (old_fd >= 0) {
+        close(old_fd);
+    }
+    unlink(hard_path);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_rename_replace_clears_old_target_path() {
+    const char *mp = "/tmp/test_fuse_rename_replace";
+    char old_path[512];
+    char victim_path[512];
+    char cwd[512];
+    int old_fd = -1;
+    int victim_fd = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.allow_rename_replace = 1;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(old_path, sizeof(old_path), "%s/old_dir", mp);
+    snprintf(victim_path, sizeof(victim_path), "%s/victim_dir", mp);
+    if (mkdir(old_path, 0755) != 0 || mkdir(victim_path, 0755) != 0) {
+        printf("[FAIL] mkdir rename-replace dirs: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    old_fd = open(old_path, O_RDONLY | O_DIRECTORY);
+    victim_fd = open(victim_path, O_RDONLY | O_DIRECTORY);
+    if (old_fd < 0 || victim_fd < 0) {
+        printf("[FAIL] open rename-replace dirs: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (rename(old_path, victim_path) != 0) {
+        printf("[FAIL] rename replace: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (fchdir(old_fd) != 0 || !getcwd(cwd, sizeof(cwd)) || strcmp(cwd, victim_path) != 0) {
+        printf("[FAIL] source fd path after rename replace: cwd='%s' errno=%d (%s)\n", cwd, errno,
+               strerror(errno));
+        goto fail_chdir_root;
+    }
+    if (chdir("/") != 0) {
+        printf("[FAIL] chdir(/): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    errno = 0;
+    if (fchdir(victim_fd) == 0) {
+        printf("[FAIL] replaced target fd still resolved to a path\n");
+        goto fail_chdir_root;
+    }
+    close(old_fd);
+    close(victim_fd);
+    old_fd = -1;
+    victim_fd = -1;
+
+    rmdir(victim_path);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail_chdir_root:
+    {
+        int ignored_chdir = chdir("/");
+        (void)ignored_chdir;
+    }
+fail:
+    if (old_fd >= 0) {
+        close(old_fd);
+    }
+    if (victim_fd >= 0) {
+        close(victim_fd);
+    }
+    rmdir(victim_path);
+    rmdir(old_path);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 TEST(FuseExtended, OpsAccessCreateSymlinkLinkRename2FlushFsync) {
     ASSERT_EQ(0, ext_test_p2_ops());
 }
@@ -1584,6 +2282,30 @@ TEST(FuseExtended, LargeReadSplitsOverMaxWrite) {
 
 TEST(FuseExtended, FadviseWithoutPageCacheSucceeds) {
     ASSERT_EQ(0, ext_test_fadvise_without_page_cache());
+}
+
+TEST(FuseExtended, MountRamfsOnFuseDirectoryUsesNamespacePath) {
+    ASSERT_EQ(0, ext_test_mount_on_fuse_dir_uses_namespace_path());
+}
+
+TEST(FuseExtended, RenameUpdatesFuseDirectoryCwdPath) {
+    ASSERT_EQ(0, ext_test_rename_updates_fuse_dir_cwd_path());
+}
+
+TEST(FuseExtended, ReaddirplusGenerationMismatchStalesOldNode) {
+    ASSERT_EQ(0, ext_test_readdirplus_generation_mismatch_stales_old_node());
+}
+
+TEST(FuseExtended, CreateGenerationMismatchStalesOldNode) {
+    ASSERT_EQ(0, ext_test_create_generation_mismatch_stales_old_node());
+}
+
+TEST(FuseExtended, LinkGenerationMismatchStalesOldNode) {
+    ASSERT_EQ(0, ext_test_link_generation_mismatch_stales_old_node());
+}
+
+TEST(FuseExtended, RenameReplaceClearsOldTargetPath) {
+    ASSERT_EQ(0, ext_test_rename_replace_clears_old_target_path());
 }
 
 TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1,11 +1,30 @@
 #include <gtest/gtest.h>
 
 #include <signal.h>
+#include <setjmp.h>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 
 #include "fuse_gtest_common.h"
+
+static sigjmp_buf g_fuse_sigbus_jmp;
+static volatile sig_atomic_t g_fuse_sigbus_seen = 0;
+static sigjmp_buf g_fuse_sigsegv_jmp;
+static volatile sig_atomic_t g_fuse_sigsegv_seen = 0;
+
+static void fuse_sigbus_longjmp_handler(int sig) {
+    (void)sig;
+    g_fuse_sigbus_seen = 1;
+    siglongjmp(g_fuse_sigbus_jmp, 1);
+}
+
+static void fuse_sigsegv_longjmp_handler(int sig) {
+    (void)sig;
+    g_fuse_sigsegv_seen = 1;
+    siglongjmp(g_fuse_sigsegv_jmp, 1);
+}
 
 #ifndef FUSE_DEV_IOC_CLONE
 #define FUSE_DEV_IOC_CLONE 0x8004e500
@@ -1438,7 +1457,7 @@ static int ext_test_large_read_over_max_write() {
         }
     }
     if (read_count != 2 || read_offsets[0] != 0 || read_offsets[1] != 4096 ||
-        read_sizes[0] != 4096 || read_sizes[1] != data_size - 4096) {
+        read_sizes[0] != 4096 || read_sizes[1] > 4096 || read_sizes[1] == 0) {
         printf("[FAIL] unexpected FUSE_READ split: count=%u off0=%llu size0=%u off1=%llu size1=%u\n",
                read_count, (unsigned long long)read_offsets[0], read_sizes[0],
                (unsigned long long)read_offsets[1], read_sizes[1]);
@@ -1462,6 +1481,1039 @@ fail:
     stop = 1;
     close(fd);
     pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_cached_read_uses_open_fh_without_extra_open() {
+    const char *mp = "/tmp/test_fuse_cached_read_fh";
+    char path[256];
+    char buf[32];
+    int f = -1;
+    ssize_t n = -1;
+    ssize_t first_n = -1;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint64_t read_fhs[4] = {0};
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.open_count = &open_count;
+    args.read_count = &read_count;
+    args.read_fhs = read_fhs;
+    args.read_trace_capacity = 4;
+    args.next_open_fh = 100;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    n = pread(f, buf, sizeof(buf), 0);
+    if (n <= 0) {
+        printf("[FAIL] first pread got=%zd errno=%d\n", n, errno);
+        close(f);
+        goto fail;
+    }
+    first_n = n;
+    memset(buf, 0, sizeof(buf));
+    n = pread(f, buf, sizeof(buf), 0);
+    close(f);
+    f = -1;
+    if (n != first_n) {
+        printf("[FAIL] second pread got=%zd errno=%d\n", n, errno);
+        goto fail;
+    }
+    if (open_count != 1 || read_count != 1 || read_fhs[0] != 100) {
+        printf("[FAIL] cached read counters open=%u read=%u fh0=%llu\n", open_count,
+               read_count, (unsigned long long)read_fhs[0]);
+        goto fail;
+    }
+
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_mmap_fault_uses_open_fh_without_extra_open() {
+    const char *mp = "/tmp/test_fuse_mmap_fh";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t child = -1;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+        volatile uint64_t read_fhs[4];
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (child == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.read_fhs = shared->read_fhs;
+        child_args.read_trace_capacity = 4;
+        child_args.next_open_fh = 200;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(child, SIGTERM);
+        waitpid(child, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDONLY);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    c = ((volatile char *)addr)[0];
+    if (c != 'h') {
+        printf("[FAIL] mmap first byte got=%d\n", c);
+        munmap(addr, 4096);
+        close(f);
+        goto fail;
+    }
+    munmap(addr, 4096);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->read_fhs[0] != 200) {
+        printf("[FAIL] mmap counters open=%u read=%u fh0=%llu\n", shared->open_count,
+               shared->read_count, (unsigned long long)shared->read_fhs[0]);
+        goto fail;
+    }
+
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(child, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (child > 0) {
+        kill(child, SIGTERM);
+        waitpid(child, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_shared_writable_mmap_fault_sigbus() {
+    const char *mp = "/tmp/test_fuse_mmap_shared_write";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    pid_t daemon = -1;
+    struct sigaction old_bus;
+    bool bus_handler_installed = false;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = fuse_sigbus_longjmp_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGBUS, &sa, &old_bus) != 0) {
+        printf("[FAIL] sigaction(SIGBUS): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    bus_handler_installed = true;
+    g_fuse_sigbus_seen = 0;
+    if (sigsetjmp(g_fuse_sigbus_jmp, 1) == 0) {
+        volatile char c = ((volatile char *)addr)[0];
+        (void)c;
+    }
+    sigaction(SIGBUS, &old_bus, NULL);
+    bus_handler_installed = false;
+    if (!g_fuse_sigbus_seen) {
+        printf("[FAIL] shared writable mmap access did not SIGBUS open=%u read=%u\n",
+               shared->open_count, shared->read_count);
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 0) {
+        printf("[FAIL] shared writable mmap counters open=%u read=%u\n", shared->open_count,
+               shared->read_count);
+        goto fail;
+    }
+
+    munmap(addr, 4096);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (bus_handler_installed) {
+        sigaction(SIGBUS, &old_bus, NULL);
+    }
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_shared_mmap_mprotect_write_denied() {
+    const char *mp = "/tmp/test_fuse_mmap_mprotect_write";
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t daemon = -1;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+
+    c = ((volatile char *)addr)[0];
+    if (c != 'h') {
+        printf("[FAIL] mmap first byte got=%d\n", c);
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 1) {
+        printf("[FAIL] before mprotect counters open=%u read=%u\n", shared->open_count,
+               shared->read_count);
+        goto fail;
+    }
+    errno = 0;
+    if (mprotect(addr, 4096, PROT_READ | PROT_WRITE) == 0) {
+        printf("[FAIL] mprotect unexpectedly allowed shared writable FUSE mapping\n");
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 1) {
+        printf("[FAIL] after mprotect counters open=%u read=%u\n", shared->open_count,
+               shared->read_count);
+        goto fail;
+    }
+
+    munmap(addr, 4096);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_shared_mmap_subrange_mprotect_failure_preserves_vma() {
+    const char *mp = "/tmp/test_fuse_mmap_mprotect_subrange";
+    const size_t page_size = 4096;
+    const size_t map_len = page_size * 2;
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t daemon = -1;
+    struct sigaction old_segv;
+    bool segv_handler_installed = false;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.hello_data_size_override = map_len;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, map_len, PROT_READ, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+
+    c = ((volatile char *)addr)[0];
+    if (c != 'A') {
+        printf("[FAIL] first page byte got=%d\n", c);
+        goto fail;
+    }
+    c = ((volatile char *)addr)[page_size];
+    if (c != 'O') {
+        printf("[FAIL] second page byte got=%d\n", c);
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 2) {
+        printf("[FAIL] before subrange mprotect counters open=%u read=%u\n",
+               shared->open_count, shared->read_count);
+        goto fail;
+    }
+    if (mprotect((char *)addr + page_size, page_size, PROT_READ | PROT_WRITE) == 0) {
+        printf("[FAIL] subrange mprotect unexpectedly allowed shared writable FUSE mapping\n");
+        goto fail;
+    }
+    if (mprotect(addr, page_size, PROT_NONE) != 0) {
+        printf("[FAIL] mprotect(PROT_NONE first page): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = fuse_sigsegv_longjmp_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSEGV, &sa, &old_segv) != 0) {
+        printf("[FAIL] sigaction(SIGSEGV): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    segv_handler_installed = true;
+    g_fuse_sigsegv_seen = 0;
+    if (sigsetjmp(g_fuse_sigsegv_jmp, 1) == 0) {
+        c = ((volatile char *)addr)[0];
+        (void)c;
+    }
+    sigaction(SIGSEGV, &old_segv, NULL);
+    segv_handler_installed = false;
+    if (!g_fuse_sigsegv_seen) {
+        printf("[FAIL] first page remained readable after PROT_NONE\n");
+        goto fail;
+    }
+
+    munmap(addr, map_len);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (segv_handler_installed) {
+        sigaction(SIGSEGV, &old_segv, NULL);
+    }
+    if (addr != MAP_FAILED) {
+        munmap(addr, map_len);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_shared_mmap_unfaulted_mprotect_prot_none() {
+    const char *mp = "/tmp/test_fuse_mmap_unfaulted_mprotect";
+    const size_t page_size = 4096;
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t daemon = -1;
+    struct sigaction old_segv;
+    bool segv_handler_installed = false;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.hello_data_size_override = page_size;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, page_size, PROT_READ, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 0) {
+        printf("[FAIL] before unfaulted mprotect counters open=%u read=%u\n",
+               shared->open_count, shared->read_count);
+        goto fail;
+    }
+    if (mprotect(addr, page_size, PROT_NONE) != 0) {
+        printf("[FAIL] mprotect(PROT_NONE unfaulted): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = fuse_sigsegv_longjmp_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGSEGV, &sa, &old_segv) != 0) {
+        printf("[FAIL] sigaction(SIGSEGV): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    segv_handler_installed = true;
+    g_fuse_sigsegv_seen = 0;
+    if (sigsetjmp(g_fuse_sigsegv_jmp, 1) == 0) {
+        c = ((volatile char *)addr)[0];
+        (void)c;
+    }
+    sigaction(SIGSEGV, &old_segv, NULL);
+    segv_handler_installed = false;
+    if (!g_fuse_sigsegv_seen) {
+        printf("[FAIL] unfaulted PROT_NONE mapping remained readable\n");
+        goto fail;
+    }
+    if (shared->read_count != 0) {
+        printf("[FAIL] unfaulted PROT_NONE triggered read_count=%u\n", shared->read_count);
+        goto fail;
+    }
+
+    munmap(addr, page_size);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (segv_handler_installed) {
+        sigaction(SIGSEGV, &old_segv, NULL);
+    }
+    if (addr != MAP_FAILED) {
+        munmap(addr, page_size);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_mmap_truncate_unmaps_stale_page() {
+    const char *mp = "/tmp/test_fuse_mmap_truncate";
+    const size_t page_size = 4096;
+    const size_t map_len = page_size * 2;
+    char path[256];
+    int f = -1;
+    void *addr = MAP_FAILED;
+    volatile char c = 0;
+    pid_t daemon = -1;
+    struct sigaction old_bus;
+    bool bus_handler_installed = false;
+    struct mmap_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile uint32_t open_count;
+        volatile uint32_t read_count;
+    };
+    struct mmap_shared_state *shared =
+        (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] mmap(shared counters): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset(shared, 0, sizeof(*shared));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] fork fuse daemon: %s (errno=%d)\n", strerror(errno), errno);
+        close(fd);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.stop_on_destroy = 1;
+        child_args.enable_write_ops = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.read_count = &shared->read_count;
+        child_args.hello_data_size_override = map_len;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        shared->stop = 1;
+        close(fd);
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+        munmap(shared, sizeof(*shared));
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, map_len, PROT_READ, MAP_PRIVATE, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+
+    c = ((volatile char *)addr)[page_size];
+    if (c != 'O') {
+        printf("[FAIL] second page byte before truncate got=%d\n", c);
+        goto fail;
+    }
+    if (shared->open_count != 1 || shared->read_count != 1) {
+        printf("[FAIL] before truncate counters open=%u read=%u\n", shared->open_count,
+               shared->read_count);
+        goto fail;
+    }
+    if (ftruncate(f, page_size) != 0) {
+        printf("[FAIL] ftruncate: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = fuse_sigbus_longjmp_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGBUS, &sa, &old_bus) != 0) {
+        printf("[FAIL] sigaction(SIGBUS): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    bus_handler_installed = true;
+    g_fuse_sigbus_seen = 0;
+    if (sigsetjmp(g_fuse_sigbus_jmp, 1) == 0) {
+        c = ((volatile char *)addr)[page_size];
+        (void)c;
+    }
+    sigaction(SIGBUS, &old_bus, NULL);
+    bus_handler_installed = false;
+    if (!g_fuse_sigbus_seen) {
+        printf("[FAIL] truncated second page remained readable read=%u\n", shared->read_count);
+        goto fail;
+    }
+    if (shared->read_count != 1) {
+        printf("[FAIL] truncated EOF fault issued extra FUSE_READ count=%u\n", shared->read_count);
+        goto fail;
+    }
+
+    munmap(addr, map_len);
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    waitpid(daemon, NULL, 0);
+    munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (bus_handler_installed) {
+        sigaction(SIGBUS, &old_bus, NULL);
+    }
+    if (addr != MAP_FAILED) {
+        munmap(addr, map_len);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+    shared->stop = 1;
+    close(fd);
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap(shared, sizeof(*shared));
     rmdir(mp);
     return -1;
 }
@@ -2278,6 +3330,34 @@ TEST(FuseExtended, OpenReturnsZeroFhIsValid) {
 
 TEST(FuseExtended, LargeReadSplitsOverMaxWrite) {
     ASSERT_EQ(0, ext_test_large_read_over_max_write());
+}
+
+TEST(FuseExtended, CachedReadUsesOpenFhWithoutExtraOpen) {
+    ASSERT_EQ(0, ext_test_cached_read_uses_open_fh_without_extra_open());
+}
+
+TEST(FuseExtended, MmapFaultUsesOpenFhWithoutExtraOpen) {
+    ASSERT_EQ(0, ext_test_mmap_fault_uses_open_fh_without_extra_open());
+}
+
+TEST(FuseExtended, SharedWritableMmapFaultSigbus) {
+    ASSERT_EQ(0, ext_test_shared_writable_mmap_fault_sigbus());
+}
+
+TEST(FuseExtended, SharedMmapMprotectWriteDenied) {
+    ASSERT_EQ(0, ext_test_shared_mmap_mprotect_write_denied());
+}
+
+TEST(FuseExtended, SharedMmapSubrangeMprotectFailurePreservesVma) {
+    ASSERT_EQ(0, ext_test_shared_mmap_subrange_mprotect_failure_preserves_vma());
+}
+
+TEST(FuseExtended, SharedMmapUnfaultedMprotectProtNone) {
+    ASSERT_EQ(0, ext_test_shared_mmap_unfaulted_mprotect_prot_none());
+}
+
+TEST(FuseExtended, MmapTruncateUnmapsStalePage) {
+    ASSERT_EQ(0, ext_test_mmap_truncate_unmaps_stale_page());
 }
 
 TEST(FuseExtended, FadviseWithoutPageCacheSucceeds) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1553,9 +1553,19 @@ static int ext_test_ftruncate_setattr_uses_open_fh() {
     volatile int init_done = 0;
     volatile uint32_t open_count = 0;
     volatile uint32_t setattr_count = 0;
+    volatile uint32_t fallocate_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint64_t last_open_fh = 0;
     volatile uint32_t last_setattr_valid = 0;
     volatile uint64_t last_setattr_fh = 0;
     volatile uint64_t last_setattr_size = 0;
+    volatile uint64_t last_setattr_lock_owner = 0;
+    volatile uint64_t last_fallocate_fh = 0;
+    volatile uint64_t last_fallocate_offset = 0;
+    volatile uint64_t last_fallocate_length = 0;
+    volatile uint32_t last_fallocate_mode = 0;
+    volatile uint64_t last_write_offset = 0;
+    volatile uint32_t last_write_size = 0;
 
     struct fuse_daemon_args args;
     memset(&args, 0, sizeof(args));
@@ -1566,9 +1576,19 @@ static int ext_test_ftruncate_setattr_uses_open_fh() {
     args.stop_on_destroy = 1;
     args.open_count = &open_count;
     args.setattr_count = &setattr_count;
+    args.fallocate_count = &fallocate_count;
+    args.write_count = &write_count;
+    args.last_open_fh = &last_open_fh;
     args.last_setattr_valid = &last_setattr_valid;
     args.last_setattr_fh = &last_setattr_fh;
     args.last_setattr_size = &last_setattr_size;
+    args.last_setattr_lock_owner = &last_setattr_lock_owner;
+    args.last_fallocate_fh = &last_fallocate_fh;
+    args.last_fallocate_offset = &last_fallocate_offset;
+    args.last_fallocate_length = &last_fallocate_length;
+    args.last_fallocate_mode = &last_fallocate_mode;
+    args.last_write_offset = &last_write_offset;
+    args.last_write_size = &last_write_size;
     args.next_open_fh = 940;
 
     pthread_t th;
@@ -1614,9 +1634,144 @@ static int ext_test_ftruncate_setattr_uses_open_fh() {
         goto fail;
     }
     if ((last_setattr_valid & FATTR_SIZE) == 0 || (last_setattr_valid & FATTR_FH) == 0 ||
-        last_setattr_fh != 940 || last_setattr_size != 7) {
-        printf("[FAIL] setattr valid=0x%x fh=%llu size=%llu\n", last_setattr_valid,
-               (unsigned long long)last_setattr_fh, (unsigned long long)last_setattr_size);
+        (last_setattr_valid & FATTR_LOCKOWNER) == 0 || last_setattr_fh != 940 ||
+        last_setattr_size != 7 || last_setattr_lock_owner == 0) {
+        printf("[FAIL] setattr valid=0x%x fh=%llu size=%llu lock_owner=%llu\n",
+               last_setattr_valid, (unsigned long long)last_setattr_fh,
+               (unsigned long long)last_setattr_size,
+               (unsigned long long)last_setattr_lock_owner);
+        goto fail;
+    }
+
+    last_setattr_valid = 0;
+    last_setattr_fh = 0;
+    last_setattr_size = 0;
+    last_setattr_lock_owner = 0;
+    if (truncate(path, 5) != 0) {
+        printf("[FAIL] truncate(path): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    usleep(100 * 1000);
+    if (setattr_count != 2) {
+        printf("[FAIL] path truncate setattr_count=%u\n", setattr_count);
+        goto fail;
+    }
+    if ((last_setattr_valid & FATTR_SIZE) == 0 || (last_setattr_valid & FATTR_FH) != 0 ||
+        (last_setattr_valid & FATTR_LOCKOWNER) == 0 || last_setattr_size != 5 ||
+        last_setattr_lock_owner == 0) {
+        printf("[FAIL] path setattr valid=0x%x fh=%llu size=%llu lock_owner=%llu\n",
+               last_setattr_valid, (unsigned long long)last_setattr_fh,
+               (unsigned long long)last_setattr_size,
+               (unsigned long long)last_setattr_lock_owner);
+        goto fail;
+    }
+
+    last_setattr_valid = 0;
+    last_setattr_fh = 0;
+    last_setattr_size = 0;
+    last_setattr_lock_owner = 0;
+    f = open(path, O_RDWR | O_TRUNC);
+    if (f < 0) {
+        printf("[FAIL] open(O_TRUNC): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+    usleep(100 * 1000);
+    if (setattr_count != 3) {
+        printf("[FAIL] open(O_TRUNC) setattr_count=%u\n", setattr_count);
+        goto fail;
+    }
+    if ((last_setattr_valid & FATTR_SIZE) == 0 || (last_setattr_valid & FATTR_FH) != 0 ||
+        (last_setattr_valid & FATTR_LOCKOWNER) == 0 || last_setattr_size != 0 ||
+        last_setattr_lock_owner == 0) {
+        printf("[FAIL] open truncate setattr valid=0x%x fh=%llu size=%llu lock_owner=%llu\n",
+               last_setattr_valid, (unsigned long long)last_setattr_fh,
+               (unsigned long long)last_setattr_size,
+               (unsigned long long)last_setattr_lock_owner);
+        goto fail;
+    }
+
+    setattr_count = 0;
+    fallocate_count = 0;
+    last_open_fh = 0;
+    last_fallocate_fh = 0;
+    last_fallocate_offset = 0;
+    last_fallocate_length = 0;
+    last_fallocate_mode = 0;
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open for fallocate: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (syscall(SYS_fallocate, f, 0, 0, 16) != 0) {
+        printf("[FAIL] fallocate: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+    usleep(100 * 1000);
+    if (setattr_count != 0 || fallocate_count != 1 || last_fallocate_fh != last_open_fh ||
+        last_fallocate_offset != 0 || last_fallocate_length != 16 || last_fallocate_mode != 0) {
+        printf("[FAIL] fallocate counters setattr=%u fallocate=%u fh=%llu open_fh=%llu "
+               "offset=%llu length=%llu mode=%u\n",
+               setattr_count, fallocate_count, (unsigned long long)last_fallocate_fh,
+               (unsigned long long)last_open_fh, (unsigned long long)last_fallocate_offset,
+               (unsigned long long)last_fallocate_length, last_fallocate_mode);
+        goto fail;
+    }
+    struct stat st;
+    if (stat(path, &st) != 0 || st.st_size != 16) {
+        printf("[FAIL] stat after fallocate rc/size errno=%d (%s) size=%lld\n", errno,
+               strerror(errno), (long long)st.st_size);
+        goto fail;
+    }
+
+    setattr_count = 0;
+    fallocate_count = 0;
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open for fallocate overflow: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (syscall(SYS_fallocate, f, 0, INT64_MAX - 1, 4) == 0 || errno != EFBIG) {
+        printf("[FAIL] fallocate overflow expected EFBIG, errno=%d (%s)\n", errno,
+               strerror(errno));
+        goto fail;
+    }
+    close(f);
+    f = -1;
+    usleep(100 * 1000);
+    if (setattr_count != 0 || fallocate_count != 0) {
+        printf("[FAIL] fallocate overflow sent requests setattr=%u fallocate=%u\n", setattr_count,
+               fallocate_count);
+        goto fail;
+    }
+
+    setattr_count = 0;
+    last_setattr_valid = 0;
+    last_setattr_fh = 0;
+    last_setattr_size = 0;
+    last_setattr_lock_owner = 0;
+    write_count = 0;
+    last_write_offset = 0;
+    last_write_size = 0;
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open for pwrite: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (pwrite(f, "xy", 2, 9) != 2) {
+        printf("[FAIL] pwrite hole: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+    usleep(100 * 1000);
+    if (setattr_count != 0 || write_count != 1 || last_write_offset != 9 || last_write_size != 2) {
+        printf("[FAIL] pwrite hole counters setattr=%u write=%u offset=%llu size=%u\n",
+               setattr_count, write_count, (unsigned long long)last_write_offset,
+               last_write_size);
         goto fail;
     }
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -144,6 +144,9 @@ static inline int fuse_test_log_enabled(void) {
 #ifndef FUSE_DESTROY
 #define FUSE_DESTROY 38
 #endif
+#ifndef FUSE_FALLOCATE
+#define FUSE_FALLOCATE 43
+#endif
 #ifndef FUSE_READDIRPLUS
 #define FUSE_READDIRPLUS 44
 #endif
@@ -230,6 +233,9 @@ static inline int fuse_test_log_enabled(void) {
 #endif
 #ifndef FATTR_FH
 #define FATTR_FH (1u << 6)
+#endif
+#ifndef FATTR_LOCKOWNER
+#define FATTR_LOCKOWNER (1u << 9)
 #endif
 
 struct fuse_in_header {
@@ -364,6 +370,14 @@ struct fuse_write_in {
 
 struct fuse_write_out {
     uint32_t size;
+    uint32_t padding;
+};
+
+struct fuse_fallocate_in {
+    uint64_t fh;
+    uint64_t offset;
+    uint64_t length;
+    uint32_t mode;
     uint32_t padding;
 };
 
@@ -678,9 +692,15 @@ struct fuse_daemon_args {
     volatile uint32_t *open_count;
     volatile uint32_t *opendir_count;
     volatile uint32_t *setattr_count;
+    volatile uint32_t *fallocate_count;
     volatile uint32_t *last_setattr_valid;
     volatile uint64_t *last_setattr_fh;
     volatile uint64_t *last_setattr_size;
+    volatile uint64_t *last_setattr_lock_owner;
+    volatile uint64_t *last_fallocate_fh;
+    volatile uint64_t *last_fallocate_offset;
+    volatile uint64_t *last_fallocate_length;
+    volatile uint32_t *last_fallocate_mode;
     volatile uint32_t *release_count;
     volatile uint32_t *releasedir_count;
     volatile uint32_t *readdirplus_count;
@@ -1608,6 +1628,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (a->last_setattr_size) {
             *a->last_setattr_size = in->size;
         }
+        if (a->last_setattr_lock_owner) {
+            *a->last_setattr_lock_owner = in->lock_owner;
+        }
         struct simplefs_node *node = simplefs_find_node(&a->fs, h->nodeid);
         if (!node) {
             return fuse_write_reply(a->fd, h->unique, -ENOENT, NULL, 0);
@@ -1628,6 +1651,45 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         memset(&out, 0, sizeof(out));
         simplefs_fill_attr(node, &out.attr);
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
+    }
+    case FUSE_FALLOCATE: {
+        if (!a->enable_write_ops) {
+            return fuse_write_reply(a->fd, h->unique, -ENOSYS, NULL, 0);
+        }
+        if (payload_len < sizeof(struct fuse_fallocate_in)) {
+            return -1;
+        }
+        const struct fuse_fallocate_in *in = (const struct fuse_fallocate_in *)payload;
+        if (a->fallocate_count) {
+            (*a->fallocate_count)++;
+        }
+        if (a->last_fallocate_fh) {
+            *a->last_fallocate_fh = in->fh;
+        }
+        if (a->last_fallocate_offset) {
+            *a->last_fallocate_offset = in->offset;
+        }
+        if (a->last_fallocate_length) {
+            *a->last_fallocate_length = in->length;
+        }
+        if (a->last_fallocate_mode) {
+            *a->last_fallocate_mode = in->mode;
+        }
+        struct simplefs_node *node = simplefs_find_node(&a->fs, h->nodeid);
+        if (!node || simplefs_node_is_dir(node) || simplefs_node_is_symlink(node)) {
+            return fuse_write_reply(a->fd, h->unique, -EINVAL, NULL, 0);
+        }
+        if (in->mode != 0) {
+            return fuse_write_reply(a->fd, h->unique, -EOPNOTSUPP, NULL, 0);
+        }
+        if (in->offset > SIMPLEFS_DATA_MAX || in->length > SIMPLEFS_DATA_MAX ||
+            in->offset + in->length > SIMPLEFS_DATA_MAX) {
+            return fuse_write_reply(a->fd, h->unique, -EFBIG, NULL, 0);
+        }
+        if (node->size < in->offset + in->length) {
+            node->size = (size_t)(in->offset + in->length);
+        }
+        return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     }
     default:
         return fuse_write_reply(a->fd, h->unique, -ENOSYS, NULL, 0);

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -695,6 +695,8 @@ struct fuse_daemon_args {
     volatile uint32_t *last_write_gid;
     volatile uint32_t *last_write_pid;
     volatile uint64_t *last_fsync_fh;
+    volatile uint32_t *write_count_at_fsync;
+    volatile uint32_t *last_write_flags_at_fsync;
     volatile uint64_t *last_release_fh;
     volatile uint32_t *last_release_uid;
     volatile uint32_t *last_release_gid;
@@ -1231,6 +1233,12 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (a->last_fsync_fh) {
             *a->last_fsync_fh = in->fh;
+        }
+        if (a->write_count_at_fsync && a->write_count) {
+            *a->write_count_at_fsync = *a->write_count;
+        }
+        if (a->last_write_flags_at_fsync && a->last_write_flags) {
+            *a->last_write_flags_at_fsync = *a->last_write_flags;
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     }

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -694,6 +694,7 @@ struct fuse_daemon_args {
     int force_opendir_enosys;
     int block_read_until_interrupt;
     size_t hello_data_size_override;
+    size_t hello_read_size_override;
     struct simplefs fs;
 };
 
@@ -965,14 +966,19 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 a->read_sizes[read_index] = in->size;
             }
         }
-        if (in->offset >= node->size) {
+        size_t effective_size = node->size;
+        if (h->nodeid == 2 && a->hello_read_size_override > 0
+            && a->hello_read_size_override < effective_size) {
+            effective_size = a->hello_read_size_override;
+        }
+        if (in->offset >= effective_size) {
             return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
         }
         if (h->nodeid == 2 && a->dynamic_hello_first_byte && *a->dynamic_hello_first_byte != 0
             && node->size > 0) {
             node->data[0] = *a->dynamic_hello_first_byte;
         }
-        size_t remain = node->size - (size_t)in->offset;
+        size_t remain = effective_size - (size_t)in->offset;
         size_t to_copy = in->size;
         if (to_copy > remain) {
             to_copy = remain;

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -665,6 +665,9 @@ struct fuse_daemon_args {
     volatile uint32_t *init_in_max_readahead;
     volatile uint32_t *access_count;
     volatile uint32_t *flush_count;
+    volatile uint32_t *last_flush_uid;
+    volatile uint32_t *last_flush_gid;
+    volatile uint32_t *last_flush_pid;
     volatile uint32_t *fsync_count;
     volatile uint32_t *fsyncdir_count;
     volatile uint32_t *create_count;
@@ -688,14 +691,24 @@ struct fuse_daemon_args {
     volatile uint32_t *last_write_size;
     volatile uint32_t *last_write_flags;
     volatile uint32_t *last_write_open_flags;
+    volatile uint32_t *last_write_uid;
+    volatile uint32_t *last_write_gid;
+    volatile uint32_t *last_write_pid;
     volatile uint64_t *last_fsync_fh;
     volatile uint64_t *last_release_fh;
+    volatile uint32_t *last_release_uid;
+    volatile uint32_t *last_release_gid;
+    volatile uint32_t *last_release_pid;
+    volatile uint32_t *last_releasedir_uid;
+    volatile uint32_t *last_releasedir_gid;
+    volatile uint32_t *last_releasedir_pid;
     volatile uint64_t *read_offsets;
     volatile uint64_t *read_fhs;
     volatile uint32_t *read_sizes;
     uint32_t read_trace_capacity;
     volatile uint32_t *interrupt_count;
     volatile uint64_t *blocked_read_unique;
+    volatile uint64_t *last_interrupt_header_unique;
     volatile uint64_t *last_interrupt_target;
     uint32_t access_deny_mask;
     uint32_t init_out_flags_override;
@@ -1153,11 +1166,29 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (a->last_release_fh) {
             *a->last_release_fh = in->fh;
         }
+        if (a->last_release_uid) {
+            *a->last_release_uid = h->uid;
+        }
+        if (a->last_release_gid) {
+            *a->last_release_gid = h->gid;
+        }
+        if (a->last_release_pid) {
+            *a->last_release_pid = h->pid;
+        }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     }
     case FUSE_RELEASEDIR:
         if (a->releasedir_count) {
             (*a->releasedir_count)++;
+        }
+        if (a->last_releasedir_uid) {
+            *a->last_releasedir_uid = h->uid;
+        }
+        if (a->last_releasedir_gid) {
+            *a->last_releasedir_gid = h->gid;
+        }
+        if (a->last_releasedir_pid) {
+            *a->last_releasedir_pid = h->pid;
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     case FUSE_INTERRUPT: {
@@ -1168,6 +1199,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (a->interrupt_count) {
             (*a->interrupt_count)++;
         }
+        if (a->last_interrupt_header_unique) {
+            *a->last_interrupt_header_unique = h->unique;
+        }
         if (a->last_interrupt_target) {
             *a->last_interrupt_target = in->unique;
         }
@@ -1176,6 +1210,15 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
     case FUSE_FLUSH:
         if (a->flush_count) {
             (*a->flush_count)++;
+        }
+        if (a->last_flush_uid) {
+            *a->last_flush_uid = h->uid;
+        }
+        if (a->last_flush_gid) {
+            *a->last_flush_gid = h->gid;
+        }
+        if (a->last_flush_pid) {
+            *a->last_flush_pid = h->pid;
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     case FUSE_FSYNC: {
@@ -1252,6 +1295,15 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (a->last_write_open_flags) {
             *a->last_write_open_flags = in->flags;
+        }
+        if (a->last_write_uid) {
+            *a->last_write_uid = h->uid;
+        }
+        if (a->last_write_gid) {
+            *a->last_write_gid = h->gid;
+        }
+        if (a->last_write_pid) {
+            *a->last_write_pid = h->pid;
         }
         size_t to_copy = in->size;
         if (in->offset + to_copy > SIMPLEFS_DATA_MAX) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -177,6 +177,12 @@ static inline int fuse_test_log_enabled(void) {
 #ifndef FUSE_WRITE_CACHE
 #define FUSE_WRITE_CACHE (1u << 0)
 #endif
+#ifndef FUSE_WRITE_LOCKOWNER
+#define FUSE_WRITE_LOCKOWNER (1u << 1)
+#endif
+#ifndef FUSE_READ_LOCKOWNER
+#define FUSE_READ_LOCKOWNER (1u << 1)
+#endif
 #ifndef FUSE_NO_OPEN_SUPPORT
 #define FUSE_NO_OPEN_SUPPORT (1u << 17)
 #endif
@@ -751,6 +757,9 @@ struct fuse_daemon_args {
     int has_hello_open_fh_override;
     int force_open_enosys;
     int force_opendir_enosys;
+    int force_flush_errno;
+    int force_fsync_errno;
+    int force_fsyncdir_errno;
     int block_read_until_interrupt;
     size_t hello_data_size_override;
     size_t hello_read_size_override;
@@ -1248,6 +1257,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (a->last_flush_pid) {
             *a->last_flush_pid = h->pid;
         }
+        if (a->force_flush_errno > 0) {
+            return fuse_write_reply(a->fd, h->unique, -a->force_flush_errno, NULL, 0);
+        }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     case FUSE_FSYNC: {
         if (payload_len < sizeof(struct fuse_fsync_in)) {
@@ -1266,11 +1278,17 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (a->last_write_flags_at_fsync && a->last_write_flags) {
             *a->last_write_flags_at_fsync = *a->last_write_flags;
         }
+        if (a->force_fsync_errno > 0) {
+            return fuse_write_reply(a->fd, h->unique, -a->force_fsync_errno, NULL, 0);
+        }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     }
     case FUSE_FSYNCDIR:
         if (a->fsyncdir_count) {
             (*a->fsyncdir_count)++;
+        }
+        if (a->force_fsyncdir_errno > 0) {
+            return fuse_write_reply(a->fd, h->unique, -a->force_fsyncdir_errno, NULL, 0);
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     case FUSE_ACCESS: {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -474,6 +474,7 @@ struct simplefs_node {
     int used;
     uint64_t nodeid;
     uint64_t ino;
+    uint64_t generation;
     uint64_t parent;
     int is_dir;
     int is_symlink;
@@ -500,6 +501,7 @@ static inline void simplefs_init(struct simplefs *fs) {
     fs->nodes[0].used = 1;
     fs->nodes[0].nodeid = 1;
     fs->nodes[0].ino = 1;
+    fs->nodes[0].generation = 1;
     fs->nodes[0].parent = 1;
     fs->nodes[0].is_dir = 1;
     fs->nodes[0].is_symlink = 0;
@@ -512,6 +514,7 @@ static inline void simplefs_init(struct simplefs *fs) {
     fs->nodes[1].used = 1;
     fs->nodes[1].nodeid = 2;
     fs->nodes[1].ino = 2;
+    fs->nodes[1].generation = 1;
     fs->nodes[1].parent = 1;
     fs->nodes[1].is_dir = 0;
     fs->nodes[1].is_symlink = 0;
@@ -574,6 +577,7 @@ static inline struct simplefs_node *simplefs_alloc(struct simplefs *fs) {
             n->used = 1;
             n->nodeid = fs->next_nodeid++;
             n->ino = fs->next_ino++;
+            n->generation = 1;
             n->open_fh = n->nodeid;
             return n;
         }
@@ -668,6 +672,12 @@ struct fuse_daemon_args {
     uint32_t access_deny_mask;
     uint32_t init_out_flags_override;
     uint64_t hello_open_fh_override;
+    uint64_t create_reuse_nodeid;
+    uint64_t create_generation_override;
+    uint64_t link_generation_override;
+    uint64_t hello_generation_override;
+    int link_reuse_old_nodeid;
+    int allow_rename_replace;
     int has_hello_open_fh_override;
     int force_open_enosys;
     int force_opendir_enosys;
@@ -703,6 +713,7 @@ static inline int simplefs_fill_entry_reply(struct fuse_daemon_args *a, const st
     struct fuse_entry_out out;
     memset(&out, 0, sizeof(out));
     out.nodeid = node->nodeid;
+    out.generation = node->generation;
     simplefs_fill_attr(node, &out.attr);
     return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
 }
@@ -753,7 +764,9 @@ static inline int simplefs_do_rename(struct fuse_daemon_args *a, const struct fu
         if (flags & RENAME_NOREPLACE) {
             return fuse_write_reply(a->fd, h->unique, -EEXIST, NULL, 0);
         }
-        return fuse_write_reply(a->fd, h->unique, -EEXIST, NULL, 0);
+        if (!a->allow_rename_replace) {
+            return fuse_write_reply(a->fd, h->unique, -EEXIST, NULL, 0);
+        }
     }
     src->parent = newdir;
     strncpy(src->name, newname, sizeof(src->name) - 1);
@@ -829,6 +842,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         struct fuse_entry_out out;
         memset(&out, 0, sizeof(out));
         out.nodeid = child->nodeid;
+        out.generation = child->generation;
         simplefs_fill_attr(child, &out.attr);
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
     }
@@ -972,6 +986,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 struct fuse_direntplus dp;
                 memset(&dp, 0, sizeof(dp));
                 dp.entry_out.nodeid = 1;
+                dp.entry_out.generation = a->fs.nodes[0].generation;
                 simplefs_fill_attr(&a->fs.nodes[0], &dp.entry_out.attr);
                 dp.dirent.ino = 1;
                 dp.dirent.off = idx + 1;
@@ -1016,6 +1031,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 struct fuse_direntplus dp;
                 memset(&dp, 0, sizeof(dp));
                 dp.entry_out.nodeid = c->nodeid;
+                dp.entry_out.generation = c->generation;
                 simplefs_fill_attr(c, &dp.entry_out.attr);
                 dp.dirent.ino = c->ino;
                 dp.dirent.off = child_base + 1;
@@ -1209,6 +1225,13 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (!nnode) {
             return fuse_write_reply(a->fd, h->unique, -ENOSPC, NULL, 0);
         }
+        if (a->create_reuse_nodeid != 0) {
+            nnode->nodeid = a->create_reuse_nodeid;
+            nnode->ino = a->create_reuse_nodeid;
+        }
+        if (a->create_generation_override != 0) {
+            nnode->generation = a->create_generation_override;
+        }
         nnode->parent = h->nodeid;
         nnode->is_dir = 0;
         nnode->is_symlink = 0;
@@ -1224,6 +1247,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         } out;
         memset(&out, 0, sizeof(out));
         out.entry.nodeid = nnode->nodeid;
+        out.entry.generation = nnode->generation;
         simplefs_fill_attr(nnode, &out.entry.attr);
         out.open_out.fh = nnode->open_fh;
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
@@ -1256,6 +1280,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         struct simplefs_node *nnode = simplefs_alloc(&a->fs);
         if (!nnode) {
             return fuse_write_reply(a->fd, h->unique, -ENOSPC, NULL, 0);
+        }
+        if (a->create_generation_override != 0) {
+            nnode->generation = a->create_generation_override;
         }
         nnode->parent = h->nodeid;
         nnode->is_dir = 0;
@@ -1297,6 +1324,13 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         struct simplefs_node *nnode = simplefs_alloc(&a->fs);
         if (!nnode) {
             return fuse_write_reply(a->fd, h->unique, -ENOSPC, NULL, 0);
+        }
+        if (a->link_reuse_old_nodeid) {
+            nnode->nodeid = src->nodeid;
+            nnode->ino = src->ino;
+        }
+        if (a->link_generation_override != 0) {
+            nnode->generation = a->link_generation_override;
         }
         nnode->parent = h->nodeid;
         nnode->is_dir = 0;
@@ -1347,6 +1381,13 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         struct simplefs_node *nnode = simplefs_alloc(&a->fs);
         if (!nnode) {
             return fuse_write_reply(a->fd, h->unique, -ENOSPC, NULL, 0);
+        }
+        if (a->create_reuse_nodeid != 0) {
+            nnode->nodeid = a->create_reuse_nodeid;
+            nnode->ino = a->create_reuse_nodeid;
+        }
+        if (a->create_generation_override != 0) {
+            nnode->generation = a->create_generation_override;
         }
         nnode->parent = h->nodeid;
         nnode->is_dir = is_dir;
@@ -1461,6 +1502,9 @@ static inline void *fuse_daemon_thread(void *arg) {
     }
     if (a->hello_mode_override) {
         a->fs.nodes[1].mode = a->hello_mode_override;
+    }
+    if (a->hello_generation_override != 0) {
+        a->fs.nodes[1].generation = a->hello_generation_override;
     }
     if (a->has_hello_open_fh_override) {
         a->fs.nodes[1].open_fh = a->hello_open_fh_override;

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -655,9 +655,13 @@ struct fuse_daemon_args {
     volatile uint32_t *last_release_in_flags;
     volatile uint64_t *last_open_fh;
     volatile uint64_t *last_read_fh;
+    volatile uint32_t *last_read_size;
     volatile uint64_t *last_write_fh;
     volatile uint64_t *last_fsync_fh;
     volatile uint64_t *last_release_fh;
+    volatile uint64_t *read_offsets;
+    volatile uint32_t *read_sizes;
+    uint32_t read_trace_capacity;
     volatile uint32_t *interrupt_count;
     volatile uint64_t *blocked_read_unique;
     volatile uint64_t *last_interrupt_target;
@@ -668,6 +672,7 @@ struct fuse_daemon_args {
     int force_open_enosys;
     int force_opendir_enosys;
     int block_read_until_interrupt;
+    size_t hello_data_size_override;
     struct simplefs fs;
 };
 
@@ -903,11 +908,24 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             }
             usleep((useconds_t)a->block_read_until_interrupt * 1000);
         }
+        uint32_t read_index = 0;
         if (a->read_count) {
+            read_index = *a->read_count;
             (*a->read_count)++;
         }
         if (a->last_read_fh) {
             *a->last_read_fh = in->fh;
+        }
+        if (a->last_read_size) {
+            *a->last_read_size = in->size;
+        }
+        if (read_index < a->read_trace_capacity) {
+            if (a->read_offsets) {
+                a->read_offsets[read_index] = in->offset;
+            }
+            if (a->read_sizes) {
+                a->read_sizes[read_index] = in->size;
+            }
         }
         if (in->offset >= node->size) {
             return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
@@ -1446,6 +1464,16 @@ static inline void *fuse_daemon_thread(void *arg) {
     }
     if (a->has_hello_open_fh_override) {
         a->fs.nodes[1].open_fh = a->hello_open_fh_override;
+    }
+    if (a->hello_data_size_override > 0) {
+        size_t size = a->hello_data_size_override;
+        if (size > SIMPLEFS_DATA_MAX) {
+            size = SIMPLEFS_DATA_MAX;
+        }
+        for (size_t i = 0; i < size; i++) {
+            a->fs.nodes[1].data[i] = (unsigned char)('A' + (i % 26));
+        }
+        a->fs.nodes[1].size = size;
     }
 
     while (!*a->stop) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -715,6 +715,7 @@ struct fuse_daemon_args {
     volatile uint32_t *last_open_in_flags;
     volatile uint32_t *last_release_in_flags;
     volatile uint64_t *last_open_fh;
+    volatile uint32_t *last_open_pid;
     volatile uint64_t *last_read_fh;
     volatile uint32_t *last_read_size;
     volatile uint32_t *last_read_open_flags;
@@ -726,6 +727,7 @@ struct fuse_daemon_args {
     volatile uint32_t *last_write_uid;
     volatile uint32_t *last_write_gid;
     volatile uint32_t *last_write_pid;
+    volatile unsigned char *last_write_watch_byte;
     volatile uint64_t *last_fsync_fh;
     volatile uint32_t *write_count_at_fsync;
     volatile uint32_t *last_write_flags_at_fsync;
@@ -746,6 +748,7 @@ struct fuse_daemon_args {
     volatile uint64_t *last_interrupt_target;
     uint32_t access_deny_mask;
     uint32_t init_out_flags_override;
+    uint64_t write_watch_offset;
     uint64_t hello_open_fh_override;
     uint64_t next_open_fh;
     uint64_t create_reuse_nodeid;
@@ -955,6 +958,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (h->opcode == FUSE_OPEN && a->last_open_in_flags) {
             *a->last_open_in_flags = in->flags;
+        }
+        if (h->opcode == FUSE_OPEN && a->last_open_pid) {
+            *a->last_open_pid = h->pid;
         }
         if (h->opcode == FUSE_OPEN && a->force_open_enosys) {
             return fuse_write_reply(a->fd, h->unique, -ENOSYS, NULL, 0);
@@ -1360,6 +1366,13 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         size_t to_copy = in->size;
         if (in->offset + to_copy > SIMPLEFS_DATA_MAX) {
             to_copy = SIMPLEFS_DATA_MAX - (size_t)in->offset;
+        }
+        if (a->last_write_watch_byte) {
+            uint64_t watch = a->write_watch_offset;
+            uint64_t end = in->offset + to_copy;
+            if (watch >= in->offset && watch < end) {
+                *a->last_write_watch_byte = data[(size_t)(watch - in->offset)];
+            }
         }
         memcpy(node->data + in->offset, data, to_copy);
         if (node->size < in->offset + to_copy) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -664,6 +664,7 @@ struct fuse_daemon_args {
     volatile uint64_t *last_fsync_fh;
     volatile uint64_t *last_release_fh;
     volatile uint64_t *read_offsets;
+    volatile uint64_t *read_fhs;
     volatile uint32_t *read_sizes;
     uint32_t read_trace_capacity;
     volatile uint32_t *interrupt_count;
@@ -672,6 +673,7 @@ struct fuse_daemon_args {
     uint32_t access_deny_mask;
     uint32_t init_out_flags_override;
     uint64_t hello_open_fh_override;
+    uint64_t next_open_fh;
     uint64_t create_reuse_nodeid;
     uint64_t create_generation_override;
     uint64_t link_generation_override;
@@ -890,7 +892,11 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         struct fuse_open_out out;
         memset(&out, 0, sizeof(out));
-        out.fh = node->open_fh;
+        if (h->opcode == FUSE_OPEN && a->next_open_fh != 0) {
+            out.fh = a->next_open_fh++;
+        } else {
+            out.fh = node->open_fh;
+        }
         out.open_flags = node->open_out_flags;
         if (h->opcode == FUSE_OPEN && a->last_open_fh) {
             *a->last_open_fh = out.fh;
@@ -934,6 +940,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             *a->last_read_size = in->size;
         }
         if (read_index < a->read_trace_capacity) {
+            if (a->read_fhs) {
+                a->read_fhs[read_index] = in->fh;
+            }
             if (a->read_offsets) {
                 a->read_offsets[read_index] = in->offset;
             }

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -171,6 +171,9 @@ static inline int fuse_test_log_enabled(void) {
 #ifndef FUSE_WRITEBACK_CACHE
 #define FUSE_WRITEBACK_CACHE (1u << 16)
 #endif
+#ifndef FUSE_WRITE_CACHE
+#define FUSE_WRITE_CACHE (1u << 0)
+#endif
 #ifndef FUSE_NO_OPEN_SUPPORT
 #define FUSE_NO_OPEN_SUPPORT (1u << 17)
 #endif
@@ -670,6 +673,10 @@ struct fuse_daemon_args {
     volatile uint64_t *last_read_fh;
     volatile uint32_t *last_read_size;
     volatile uint64_t *last_write_fh;
+    volatile uint64_t *last_write_offset;
+    volatile uint32_t *last_write_size;
+    volatile uint32_t *last_write_flags;
+    volatile uint32_t *last_write_open_flags;
     volatile uint64_t *last_fsync_fh;
     volatile uint64_t *last_release_fh;
     volatile uint64_t *read_offsets;
@@ -1219,6 +1226,18 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (a->last_write_fh) {
             *a->last_write_fh = in->fh;
+        }
+        if (a->last_write_offset) {
+            *a->last_write_offset = in->offset;
+        }
+        if (a->last_write_size) {
+            *a->last_write_size = in->size;
+        }
+        if (a->last_write_flags) {
+            *a->last_write_flags = in->write_flags;
+        }
+        if (a->last_write_open_flags) {
+            *a->last_write_open_flags = in->flags;
         }
         size_t to_copy = in->size;
         if (in->offset + to_copy > SIMPLEFS_DATA_MAX) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -191,6 +191,9 @@ static inline int fuse_test_log_enabled(void) {
 #ifndef FOPEN_DIRECT_IO
 #define FOPEN_DIRECT_IO (1u << 0)
 #endif
+#ifndef FOPEN_NOFLUSH
+#define FOPEN_NOFLUSH (1u << 5)
+#endif
 
 #ifndef FUSE_NOTIFY_INVAL_INODE
 #define FUSE_NOTIFY_INVAL_INODE 2

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -168,11 +168,17 @@ static inline int fuse_test_log_enabled(void) {
 #ifndef FUSE_READDIRPLUS_AUTO
 #define FUSE_READDIRPLUS_AUTO (1u << 14)
 #endif
+#ifndef FUSE_WRITEBACK_CACHE
+#define FUSE_WRITEBACK_CACHE (1u << 16)
+#endif
 #ifndef FUSE_NO_OPEN_SUPPORT
 #define FUSE_NO_OPEN_SUPPORT (1u << 17)
 #endif
 #ifndef FUSE_NO_OPENDIR_SUPPORT
 #define FUSE_NO_OPENDIR_SUPPORT (1u << 24)
+#endif
+#ifndef FUSE_ATOMIC_O_TRUNC
+#define FUSE_ATOMIC_O_TRUNC (1u << 3)
 #endif
 #ifndef FUSE_FSYNC_FDATASYNC
 #define FUSE_FSYNC_FDATASYNC (1u << 0)
@@ -472,6 +478,8 @@ struct simplefs_node {
     int is_dir;
     int is_symlink;
     uint32_t mode; /* includes type bits */
+    uint64_t open_fh;
+    uint32_t open_out_flags;
     char name[SIMPLEFS_NAME_MAX];
     unsigned char data[SIMPLEFS_DATA_MAX];
     size_t size;
@@ -496,6 +504,7 @@ static inline void simplefs_init(struct simplefs *fs) {
     fs->nodes[0].is_dir = 1;
     fs->nodes[0].is_symlink = 0;
     fs->nodes[0].mode = 0040755;
+    fs->nodes[0].open_fh = 1;
     strcpy(fs->nodes[0].name, "");
     fs->nodes[0].size = 0;
 
@@ -507,6 +516,7 @@ static inline void simplefs_init(struct simplefs *fs) {
     fs->nodes[1].is_dir = 0;
     fs->nodes[1].is_symlink = 0;
     fs->nodes[1].mode = 0100644;
+    fs->nodes[1].open_fh = 2;
     strcpy(fs->nodes[1].name, "hello.txt");
     const char *msg = "hello from fuse\n";
     fs->nodes[1].size = strlen(msg);
@@ -564,6 +574,7 @@ static inline struct simplefs_node *simplefs_alloc(struct simplefs *fs) {
             n->used = 1;
             n->nodeid = fs->next_nodeid++;
             n->ino = fs->next_ino++;
+            n->open_fh = n->nodeid;
             return n;
         }
     }
@@ -638,11 +649,22 @@ struct fuse_daemon_args {
     volatile uint32_t *release_count;
     volatile uint32_t *releasedir_count;
     volatile uint32_t *readdirplus_count;
+    volatile uint32_t *read_count;
+    volatile uint32_t *write_count;
+    volatile uint32_t *last_open_in_flags;
+    volatile uint32_t *last_release_in_flags;
+    volatile uint64_t *last_open_fh;
+    volatile uint64_t *last_read_fh;
+    volatile uint64_t *last_write_fh;
+    volatile uint64_t *last_fsync_fh;
+    volatile uint64_t *last_release_fh;
     volatile uint32_t *interrupt_count;
     volatile uint64_t *blocked_read_unique;
     volatile uint64_t *last_interrupt_target;
     uint32_t access_deny_mask;
     uint32_t init_out_flags_override;
+    uint64_t hello_open_fh_override;
+    int has_hello_open_fh_override;
     int force_open_enosys;
     int force_opendir_enosys;
     int block_read_until_interrupt;
@@ -818,6 +840,10 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
     }
     case FUSE_OPENDIR:
     case FUSE_OPEN: {
+        if (payload_len < sizeof(struct fuse_open_in)) {
+            return -1;
+        }
+        const struct fuse_open_in *in = (const struct fuse_open_in *)payload;
         struct simplefs_node *node = simplefs_find_node(&a->fs, h->nodeid);
         if (!node) {
             return fuse_write_reply(a->fd, h->unique, -ENOENT, NULL, 0);
@@ -827,6 +853,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (h->opcode == FUSE_OPENDIR && a->opendir_count) {
             (*a->opendir_count)++;
+        }
+        if (h->opcode == FUSE_OPEN && a->last_open_in_flags) {
+            *a->last_open_in_flags = in->flags;
         }
         if (h->opcode == FUSE_OPEN && a->force_open_enosys) {
             return fuse_write_reply(a->fd, h->unique, -ENOSYS, NULL, 0);
@@ -842,7 +871,11 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         struct fuse_open_out out;
         memset(&out, 0, sizeof(out));
-        out.fh = node->nodeid;
+        out.fh = node->open_fh;
+        out.open_flags = node->open_out_flags;
+        if (h->opcode == FUSE_OPEN && a->last_open_fh) {
+            *a->last_open_fh = out.fh;
+        }
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
     }
     case FUSE_READLINK: {
@@ -869,6 +902,12 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 *a->blocked_read_unique = h->unique;
             }
             usleep((useconds_t)a->block_read_until_interrupt * 1000);
+        }
+        if (a->read_count) {
+            (*a->read_count)++;
+        }
+        if (a->last_read_fh) {
+            *a->last_read_fh = in->fh;
         }
         if (in->offset >= node->size) {
             return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
@@ -1011,11 +1050,22 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                       (unsigned long long)out.st.bavail);
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
     }
-    case FUSE_RELEASE:
+    case FUSE_RELEASE: {
+        if (payload_len < sizeof(struct fuse_release_in)) {
+            return -1;
+        }
+        const struct fuse_release_in *in = (const struct fuse_release_in *)payload;
         if (a->release_count) {
             (*a->release_count)++;
         }
+        if (a->last_release_in_flags) {
+            *a->last_release_in_flags = in->flags;
+        }
+        if (a->last_release_fh) {
+            *a->last_release_fh = in->fh;
+        }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
+    }
     case FUSE_RELEASEDIR:
         if (a->releasedir_count) {
             (*a->releasedir_count)++;
@@ -1039,11 +1089,19 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             (*a->flush_count)++;
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
-    case FUSE_FSYNC:
+    case FUSE_FSYNC: {
+        if (payload_len < sizeof(struct fuse_fsync_in)) {
+            return -1;
+        }
+        const struct fuse_fsync_in *in = (const struct fuse_fsync_in *)payload;
         if (a->fsync_count) {
             (*a->fsync_count)++;
         }
+        if (a->last_fsync_fh) {
+            *a->last_fsync_fh = in->fh;
+        }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
+    }
     case FUSE_FSYNCDIR:
         if (a->fsyncdir_count) {
             (*a->fsyncdir_count)++;
@@ -1088,6 +1146,12 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (in->offset >= SIMPLEFS_DATA_MAX) {
             return fuse_write_reply(a->fd, h->unique, -EFBIG, NULL, 0);
         }
+        if (a->write_count) {
+            (*a->write_count)++;
+        }
+        if (a->last_write_fh) {
+            *a->last_write_fh = in->fh;
+        }
         size_t to_copy = in->size;
         if (in->offset + to_copy > SIMPLEFS_DATA_MAX) {
             to_copy = SIMPLEFS_DATA_MAX - (size_t)in->offset;
@@ -1131,6 +1195,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         nnode->is_dir = 0;
         nnode->is_symlink = 0;
         nnode->mode = in->mode;
+        nnode->open_fh = nnode->nodeid;
         strncpy(nnode->name, name, sizeof(nnode->name) - 1);
         nnode->name[sizeof(nnode->name) - 1] = '\0';
         nnode->size = 0;
@@ -1142,7 +1207,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         memset(&out, 0, sizeof(out));
         out.entry.nodeid = nnode->nodeid;
         simplefs_fill_attr(nnode, &out.entry.attr);
-        out.open_out.fh = nnode->nodeid;
+        out.open_out.fh = nnode->open_fh;
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
     }
     case FUSE_SYMLINK: {
@@ -1178,6 +1243,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         nnode->is_dir = 0;
         nnode->is_symlink = 1;
         nnode->mode = 0120777;
+        nnode->open_fh = nnode->nodeid;
         strncpy(nnode->name, name, sizeof(nnode->name) - 1);
         nnode->name[sizeof(nnode->name) - 1] = '\0';
         nnode->size = (target_len < SIMPLEFS_DATA_MAX) ? target_len : SIMPLEFS_DATA_MAX;
@@ -1218,6 +1284,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         nnode->is_dir = 0;
         nnode->is_symlink = src->is_symlink;
         nnode->mode = src->mode;
+        nnode->open_fh = nnode->nodeid;
         strncpy(nnode->name, name, sizeof(nnode->name) - 1);
         nnode->name[sizeof(nnode->name) - 1] = '\0';
         nnode->size = src->size;
@@ -1267,6 +1334,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         nnode->is_dir = is_dir;
         nnode->is_symlink = 0;
         nnode->mode = mode;
+        nnode->open_fh = nnode->nodeid;
         strncpy(nnode->name, name, sizeof(nnode->name) - 1);
         nnode->name[sizeof(nnode->name) - 1] = '\0';
         nnode->size = 0;
@@ -1375,6 +1443,9 @@ static inline void *fuse_daemon_thread(void *arg) {
     }
     if (a->hello_mode_override) {
         a->fs.nodes[1].mode = a->hello_mode_override;
+    }
+    if (a->has_hello_open_fh_override) {
+        a->fs.nodes[1].open_fh = a->hello_open_fh_override;
     }
 
     while (!*a->stop) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -650,6 +650,7 @@ struct fuse_daemon_args {
     volatile uint32_t *rename2_count;
     volatile uint32_t *open_count;
     volatile uint32_t *opendir_count;
+    volatile uint32_t *setattr_count;
     volatile uint32_t *release_count;
     volatile uint32_t *releasedir_count;
     volatile uint32_t *readdirplus_count;
@@ -889,6 +890,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (h->opcode == FUSE_OPEN && simplefs_node_is_dir(node)) {
             return fuse_write_reply(a->fd, h->unique, -EISDIR, NULL, 0);
+        }
+        if (h->opcode == FUSE_OPEN && (in->flags & O_TRUNC)) {
+            node->size = 0;
         }
         struct fuse_open_out out;
         memset(&out, 0, sizeof(out));
@@ -1465,6 +1469,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         return simplefs_do_rename(a, h, in->newdir, in->flags, oldname, newname);
     }
     case FUSE_SETATTR: {
+        if (a->setattr_count) {
+            (*a->setattr_count)++;
+        }
         if (!a->enable_write_ops) {
             return fuse_write_reply(a->fd, h->unique, -ENOSYS, NULL, 0);
         }

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -682,6 +682,7 @@ struct fuse_daemon_args {
     volatile uint64_t *last_open_fh;
     volatile uint64_t *last_read_fh;
     volatile uint32_t *last_read_size;
+    volatile uint32_t *last_read_open_flags;
     volatile uint64_t *last_write_fh;
     volatile uint64_t *last_write_offset;
     volatile uint32_t *last_write_size;
@@ -971,6 +972,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (a->last_read_size) {
             *a->last_read_size = in->size;
+        }
+        if (a->last_read_open_flags) {
+            *a->last_read_open_flags = in->flags;
         }
         if (read_index < a->read_trace_capacity) {
             if (a->read_fhs) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -228,6 +228,9 @@ static inline int fuse_test_log_enabled(void) {
 #ifndef FATTR_SIZE
 #define FATTR_SIZE (1u << 3)
 #endif
+#ifndef FATTR_FH
+#define FATTR_FH (1u << 6)
+#endif
 
 struct fuse_in_header {
     uint32_t len;
@@ -675,6 +678,9 @@ struct fuse_daemon_args {
     volatile uint32_t *open_count;
     volatile uint32_t *opendir_count;
     volatile uint32_t *setattr_count;
+    volatile uint32_t *last_setattr_valid;
+    volatile uint64_t *last_setattr_fh;
+    volatile uint64_t *last_setattr_size;
     volatile uint32_t *release_count;
     volatile uint32_t *releasedir_count;
     volatile uint32_t *readdirplus_count;
@@ -1593,6 +1599,15 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             return -1;
         }
         const struct fuse_setattr_in *in = (const struct fuse_setattr_in *)payload;
+        if (a->last_setattr_valid) {
+            *a->last_setattr_valid = in->valid;
+        }
+        if (a->last_setattr_fh) {
+            *a->last_setattr_fh = in->fh;
+        }
+        if (a->last_setattr_size) {
+            *a->last_setattr_size = in->size;
+        }
         struct simplefs_node *node = simplefs_find_node(&a->fs, h->nodeid);
         if (!node) {
             return fuse_write_reply(a->fd, h->unique, -ENOENT, NULL, 0);

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -191,6 +191,12 @@ static inline int fuse_test_log_enabled(void) {
 #ifndef FOPEN_DIRECT_IO
 #define FOPEN_DIRECT_IO (1u << 0)
 #endif
+#ifndef FOPEN_NONSEEKABLE
+#define FOPEN_NONSEEKABLE (1u << 2)
+#endif
+#ifndef FOPEN_STREAM
+#define FOPEN_STREAM (1u << 4)
+#endif
 #ifndef FOPEN_NOFLUSH
 #define FOPEN_NOFLUSH (1u << 5)
 #endif
@@ -647,6 +653,7 @@ struct fuse_daemon_args {
     int stop_on_destroy;
     uint32_t root_mode_override;
     uint32_t hello_mode_override;
+    uint32_t root_open_out_flags;
     uint32_t hello_open_out_flags;
     volatile uint32_t *dynamic_hello_open_out_flags;
     volatile unsigned char *dynamic_hello_first_byte;
@@ -1558,6 +1565,9 @@ static inline void *fuse_daemon_thread(void *arg) {
     simplefs_init(&a->fs);
     if (a->root_mode_override) {
         a->fs.nodes[0].mode = a->root_mode_override;
+    }
+    if (a->root_open_out_flags != 0) {
+        a->fs.nodes[0].open_out_flags = a->root_open_out_flags;
     }
     if (a->hello_mode_override) {
         a->fs.nodes[1].mode = a->hello_mode_override;

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -184,6 +184,11 @@ static inline int fuse_test_log_enabled(void) {
 #define FUSE_FSYNC_FDATASYNC (1u << 0)
 #endif
 
+/* fuse_open_out.open_flags (subset) */
+#ifndef FOPEN_DIRECT_IO
+#define FOPEN_DIRECT_IO (1u << 0)
+#endif
+
 #ifndef FUSE_NOTIFY_INVAL_INODE
 #define FUSE_NOTIFY_INVAL_INODE 2
 #endif
@@ -636,6 +641,9 @@ struct fuse_daemon_args {
     int stop_on_destroy;
     uint32_t root_mode_override;
     uint32_t hello_mode_override;
+    uint32_t hello_open_out_flags;
+    volatile uint32_t *dynamic_hello_open_out_flags;
+    volatile unsigned char *dynamic_hello_first_byte;
     volatile uint32_t *forget_count;
     volatile uint64_t *forget_nlookup_sum;
     volatile uint32_t *destroy_count;
@@ -894,6 +902,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (h->opcode == FUSE_OPEN && (in->flags & O_TRUNC)) {
             node->size = 0;
         }
+        if (h->opcode == FUSE_OPEN && h->nodeid == 2 && a->dynamic_hello_open_out_flags) {
+            node->open_out_flags = *a->dynamic_hello_open_out_flags;
+        }
         struct fuse_open_out out;
         memset(&out, 0, sizeof(out));
         if (h->opcode == FUSE_OPEN && a->next_open_fh != 0) {
@@ -956,6 +967,10 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         if (in->offset >= node->size) {
             return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
+        }
+        if (h->nodeid == 2 && a->dynamic_hello_first_byte && *a->dynamic_hello_first_byte != 0
+            && node->size > 0) {
+            node->data[0] = *a->dynamic_hello_first_byte;
         }
         size_t remain = node->size - (size_t)in->offset;
         size_t to_copy = in->size;
@@ -1521,6 +1536,9 @@ static inline void *fuse_daemon_thread(void *arg) {
     }
     if (a->hello_generation_override != 0) {
         a->fs.nodes[1].generation = a->hello_generation_override;
+    }
+    if (a->hello_open_out_flags != 0) {
+        a->fs.nodes[1].open_out_flags = a->hello_open_out_flags;
     }
     if (a->has_hello_open_fh_override) {
         a->fs.nodes[1].open_fh = a->hello_open_fh_override;

--- a/user/apps/tests/dunitest/suites/normal/fallocate_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/fallocate_semantics.cc
@@ -1,0 +1,209 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <string>
+
+#ifndef __NR_fallocate
+#if defined(__x86_64__)
+#define __NR_fallocate 285
+#elif defined(__riscv) || defined(__loongarch64)
+#define __NR_fallocate 47
+#else
+#error "__NR_fallocate is not defined for this architecture"
+#endif
+#endif
+
+#ifndef FALLOC_FL_KEEP_SIZE
+#define FALLOC_FL_KEEP_SIZE 0x01
+#endif
+
+namespace {
+
+long RawFallocate(int fd, int mode, off_t offset, off_t len) {
+    return syscall(__NR_fallocate, fd, mode, offset, len);
+}
+
+class TempFile {
+  public:
+    TempFile() {
+        char tmpl[] = "/tmp/dunitest_fallocate_XXXXXX";
+        fd_ = mkstemp(tmpl);
+        if (fd_ >= 0) {
+            path_ = tmpl;
+        }
+    }
+
+    ~TempFile() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        if (!path_.empty()) {
+            unlink(path_.c_str());
+        }
+    }
+
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+
+    bool valid() const {
+        return fd_ >= 0;
+    }
+
+    int fd() const {
+        return fd_;
+    }
+
+    const char* path() const {
+        return path_.c_str();
+    }
+
+    void unlink_path() {
+        if (!path_.empty()) {
+            ASSERT_EQ(0, unlink(path_.c_str())) << "unlink failed: errno=" << errno << " ("
+                                                << strerror(errno) << ")";
+            path_.clear();
+        }
+    }
+
+    int reopen_readonly() const {
+        return open(path_.c_str(), O_RDONLY);
+    }
+
+  private:
+    std::string path_;
+    int fd_ = -1;
+};
+
+off_t FileSize(int fd) {
+    struct stat st {};
+    if (fstat(fd, &st) != 0) {
+        return -1;
+    }
+    return st.st_size;
+}
+
+class ScopedSignalIgnore {
+  public:
+    explicit ScopedSignalIgnore(int signal) : signal_(signal) {
+        old_handler_ = ::signal(signal_, SIG_IGN);
+    }
+
+    ~ScopedSignalIgnore() {
+        if (old_handler_ != SIG_ERR) {
+            ::signal(signal_, old_handler_);
+        }
+    }
+
+  private:
+    int signal_;
+    sighandler_t old_handler_;
+};
+
+class ScopedRlimit {
+  public:
+    ScopedRlimit(int resource, rlim_t soft_limit) : resource_(resource) {
+        valid_ = getrlimit(resource_, &old_) == 0;
+        if (!valid_) {
+            return;
+        }
+
+        struct rlimit next = old_;
+        next.rlim_cur = soft_limit;
+        valid_ = setrlimit(resource_, &next) == 0;
+    }
+
+    ~ScopedRlimit() {
+        if (valid_) {
+            setrlimit(resource_, &old_);
+        }
+    }
+
+    bool valid() const {
+        return valid_;
+    }
+
+  private:
+    int resource_;
+    struct rlimit old_ {};
+    bool valid_ = false;
+};
+
+}  // namespace
+
+TEST(FallocateSemantics, DeletedOpenFileMode0ExtendsSize) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+    file.unlink_path();
+
+    errno = 0;
+    ASSERT_EQ(0, RawFallocate(file.fd(), 0, 0, 123)) << "fallocate failed: errno=" << errno << " ("
+                                                     << strerror(errno) << ")";
+    EXPECT_EQ(123, FileSize(file.fd()));
+}
+
+TEST(FallocateSemantics, Mode0DoesNotShrink) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    ASSERT_EQ(0, RawFallocate(file.fd(), 0, 0, 4096)) << "initial fallocate failed: errno=" << errno
+                                                      << " (" << strerror(errno) << ")";
+    ASSERT_EQ(4096, FileSize(file.fd()));
+
+    errno = 0;
+    EXPECT_EQ(0, RawFallocate(file.fd(), 0, 0, 128)) << "smaller fallocate failed: errno=" << errno
+                                                     << " (" << strerror(errno) << ")";
+    EXPECT_EQ(4096, FileSize(file.fd()));
+}
+
+TEST(FallocateSemantics, UnsupportedKeepSizeRemainsUnsupported) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, RawFallocate(file.fd(), FALLOC_FL_KEEP_SIZE, 0, 4096));
+    EXPECT_EQ(EOPNOTSUPP, errno) << "unexpected errno=" << errno << " (" << strerror(errno)
+                                 << ")";
+}
+
+TEST(FallocateSemantics, ReadonlyFdReturnsEbadf) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    int readonly_fd = file.reopen_readonly();
+    ASSERT_GE(readonly_fd, 0) << "reopen readonly failed: " << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, RawFallocate(readonly_fd, 0, 0, 123));
+    EXPECT_EQ(EBADF, errno) << "unexpected errno=" << errno << " (" << strerror(errno) << ")";
+
+    close(readonly_fd);
+}
+
+TEST(FallocateSemantics, RlimitFsizeBlocksGrowth) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    ScopedSignalIgnore ignore_sigxfsz(SIGXFSZ);
+    ScopedRlimit limit(RLIMIT_FSIZE, 64);
+    ASSERT_TRUE(limit.valid()) << "setrlimit failed: " << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, RawFallocate(file.fd(), 0, 0, 128));
+    EXPECT_EQ(EFBIG, errno) << "unexpected errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_EQ(0, FileSize(file.fd()));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
@@ -841,6 +841,21 @@ TEST(MountReconfigure, StackedMountKeepsOriginalTarget) {
     EXPECT_FALSE(path_exists(upper_marker));
     EXPECT_TRUE(path_exists(sibling));
 
+    // Regression: popping the top mount must restore the lower mount's reverse
+    // mountpoint inode index. copy_mnt_ns() uses that index when cloning the
+    // namespace, so a second unshare should preserve the now-visible lower mount.
+    if (unshare(CLONE_NEWNS) != 0) {
+        int saved_errno = errno;
+        umount(target);
+        unlink(sibling);
+        rmdir(target);
+        rmdir(base);
+        FAIL() << strerror(saved_errno);
+    }
+    EXPECT_TRUE(path_exists(lower_marker));
+    EXPECT_FALSE(path_exists(upper_marker));
+    EXPECT_TRUE(path_exists(sibling));
+
     ASSERT_EQ(0, umount(target)) << strerror(errno);
     unlink(sibling);
     rmdir(target);

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -3,6 +3,7 @@
 demo/gtest_demo
 normal/capability
 normal/fdatasync
+normal/fallocate_semantics
 normal/syncfs_semantics
 normal/fcntl_lock
 normal/fcntl_signal


### PR DESCRIPTION
## Summary

This PR brings FUSE/virtiofs and related VFS paths closer to Linux-compatible semantics. It covers FUSE submounts, node generation lifetime, page-cache/mmap writeback, open-file context handling, close/sync error propagation, mount topology, and fallocate behavior.

- Add virtiofs/FUSE `FUSE_SUBMOUNTS` and `FUSE_ATTR_SUBMOUNT` support, eagerly creating DragonOS submounts when lookup returns a submount-marked directory and avoiding synthetic paths such as `fuse:<nodeid>` in mount topology records.
- Track FUSE lookup attr flags and generation values, mark old nodes stale when a daemon reuses a nodeid with a different generation, and return `ESTALE` for later accesses to stale nodes.
- Refine FUSE INIT negotiation: normal FUSE and virtiofs request different capability sets, virtiofs requests submounts, and DragonOS only enables capabilities that were both requested locally and accepted by the daemon. `FUSE_WRITEBACK_CACHE` remains disabled until the full semantics are implemented.
- Fix FUSE open/read/write/release/flush/fsync behavior: apply Linux-style open flag filtering, treat `fh=0` as valid, use zero fh for no-open fsync, support `FOPEN_NOFLUSH`, `FOPEN_NONSEEKABLE`, `FOPEN_STREAM`, and `FUSE_ATOMIC_O_TRUNC`, and cache `ENOSYS` for flush/fsync/fallocate.
- Wire FUSE regular files into page-cache fault, `page_mkwrite`, shared mmap dirty writeback, and direct-I/O cache coherency paths so mmap, pwrite, fsync, munmap, and close observe consistent data and writeback ordering.
- Use the open-time FUSE credentials and file handle for page-cache writeback, truncate setattr, fsync, and related requests, avoiding uid/gid/pid loss and wrong-fh operations in asynchronous paths.
- Improve VFS mount behavior: lookups cross covering mounts and trigger FUSE submount automounts; bind/move/recursive bind prefer real mount namespace paths over filesystem-specific synthetic absolute paths.
- Adjust fd close/dup/exec handling so user-visible flush runs after the fd has been removed from the fd table, avoiding FUSE daemon deadlocks under fd-table locks while preserving close-time error reporting.
- Rework `fallocate`: centralize Linux-style VFS checks, add resize-backed `mode=0` support for local filesystems, and implement FUSE `FUSE_FALLOCATE` with `ENOSYS` fallback.

### Test Coverage

This PR adds or extends dunitest coverage for:

- FUSE open flags, `fh=0`, no-open/no-opendir, flush/fsync/release, ENOSYS caching, nonseekable/stream opens, atomic `O_TRUNC`, and ftruncate fh handling.
- FUSE page cache and mmap behavior, including cached reads, short-read EOF, write-through visibility, shared mmap dirty writeback, msync/munmap/close writeback, direct-I/O mmap policy, and truncate invalidation.
- FUSE generation and mount path behavior, including readdirplus/create/link generation mismatch, rename replace, and mounting over FUSE directories with namespace paths.
- VFS fallocate semantics for deleted-but-open files, non-shrinking `mode=0`, unsupported KEEP_SIZE, readonly fd `EBADF`, and `RLIMIT_FSIZE` `EFBIG`.
- Mount namespace behavior for stacked mounts across repeated `unshare(CLONE_NEWNS)`.
