### PR TITLE
fix(cmdline): align init argv handling with Linux

### DIFF
--- a/kernel/src/init/cmdline.rs
+++ b/kernel/src/init/cmdline.rs
@@ -326,9 +326,7 @@ impl KernelCmdlineManager {
         let mut kernel_cmdline_end = false;
         for argument in self.split_args(boot_params.boot_cmdline_str()) {
             if kernel_cmdline_end {
-                if !argument.is_empty() {
-                    inner.init_args.push(CString::new(argument).unwrap());
-                }
+                Self::push_init_arg(&mut inner, argument);
                 continue;
             }
 
@@ -342,12 +340,9 @@ impl KernelCmdlineManager {
                 Some(v) => v,
                 None => continue,
             };
-            if option == "init" && value.is_some() {
-                if inner.init_path.is_some() {
-                    panic!("cmdline: init proc path is set twice");
-                }
+            if node.is_none() && option == "init" && value.is_some() {
                 if let Some(val) = value {
-                    inner.init_path = Some(CString::new(val).unwrap());
+                    Self::set_init_path(&mut inner, val);
                 }
                 continue;
             }
@@ -394,11 +389,9 @@ impl KernelCmdlineManager {
                 fence(Ordering::SeqCst);
             } else if node.is_none() {
                 if let Some(val) = value {
-                    inner
-                        .init_envs
-                        .push(CString::new(format!("{}={}", option, val)).unwrap());
+                    Self::set_init_env(&mut inner, option, val);
                 } else if !option.is_empty() {
-                    inner.init_args.push(CString::new(option).unwrap());
+                    Self::push_init_arg(&mut inner, option);
                 }
             }
         }
@@ -409,6 +402,36 @@ impl KernelCmdlineManager {
         crate::debug::klog::loglevel::handle_loglevel_param();
         crate::time::clocksource::handle_clocksource_cmdline_param();
         fence(Ordering::SeqCst);
+    }
+
+    fn set_init_path(inner: &mut InnerKernelCmdlineManager, path: &str) {
+        inner.init_path = Some(CString::new(path).unwrap());
+        inner.init_args.clear();
+    }
+
+    fn push_init_arg(inner: &mut InnerKernelCmdlineManager, arg: &str) {
+        if !arg.is_empty() {
+            inner.init_args.push(CString::new(arg).unwrap());
+        }
+    }
+
+    fn set_init_env(inner: &mut InnerKernelCmdlineManager, key: &str, value: &str) {
+        let env = CString::new(format!("{}={}", key, value)).unwrap();
+        if let Some(slot) = inner
+            .init_envs
+            .iter_mut()
+            .find(|env| Self::cstring_key_matches_env(env, key))
+        {
+            *slot = env;
+        } else {
+            inner.init_envs.push(env);
+        }
+    }
+
+    fn cstring_key_matches_env(env: &CString, key: &str) -> bool {
+        let bytes = env.as_bytes();
+        let key = key.as_bytes();
+        bytes.len() > key.len() && bytes.starts_with(key) && bytes[key.len()] == b'='
     }
 
     fn default_initialize(&self) {

--- a/kernel/src/init/initial_kthread.rs
+++ b/kernel/src/init/initial_kthread.rs
@@ -135,15 +135,16 @@ fn switch_to_user() -> ! {
 
     let mut proc_init_info = ProcInitInfo::new("");
     // 设置默认环境变量
-    proc_init_info.envs.push(CString::new("HOME=/").unwrap());
-    proc_init_info
-        .envs
-        .push(CString::new("TERM=linux").unwrap());
+    set_init_env(&mut proc_init_info.envs, CString::new("HOME=/").unwrap());
+    set_init_env(
+        &mut proc_init_info.envs,
+        CString::new("TERM=linux").unwrap(),
+    );
     proc_init_info.args = kenrel_cmdline_param_manager().init_proc_args();
     // 命令行管理器提供的环境变量会追加到默认环境变量之后
-    proc_init_info
-        .envs
-        .extend(kenrel_cmdline_param_manager().init_proc_envs());
+    for env in kenrel_cmdline_param_manager().init_proc_envs() {
+        set_init_env(&mut proc_init_info.envs, env);
+    }
 
     let mut trap_frame = TrapFrame::new();
 
@@ -224,6 +225,28 @@ fn try_to_run_init_process(
 
     Ok(())
 }
+
+fn set_init_env(envs: &mut alloc::vec::Vec<CString>, env: CString) {
+    let key_len = env
+        .as_bytes()
+        .iter()
+        .position(|&byte| byte == b'=')
+        .unwrap_or(env.as_bytes().len());
+    if let Some(slot) = envs
+        .iter_mut()
+        .find(|candidate| init_env_key_matches(candidate, &env.as_bytes()[..key_len]))
+    {
+        *slot = env;
+    } else {
+        envs.push(env);
+    }
+}
+
+fn init_env_key_matches(env: &CString, key: &[u8]) -> bool {
+    let bytes = env.as_bytes();
+    bytes.len() > key.len() && bytes.starts_with(key) && bytes[key.len()] == b'='
+}
+
 fn run_init_process(
     proc_init_info: &ProcInitInfo,
     trap_frame: &mut TrapFrame,

--- a/user/apps/tests/dunitest/suites/normal/kernel_cmdline_compat.cc
+++ b/user/apps/tests/dunitest/suites/normal/kernel_cmdline_compat.cc
@@ -51,6 +51,21 @@ std::vector<std::string> kernel_param_tokens(const std::string& cmdline) {
     return out;
 }
 
+std::vector<std::string> init_arg_tokens_from_kernel_cmdline(const std::string& cmdline) {
+    std::vector<std::string> out;
+    bool after_double_dash = false;
+    for (const std::string& token : split_whitespace(cmdline)) {
+        if (after_double_dash) {
+            out.push_back(token);
+            continue;
+        }
+        if (token == "--") {
+            after_double_dash = true;
+        }
+    }
+    return out;
+}
+
 std::vector<std::string> split_nul(const std::string& input) {
     std::vector<std::string> out;
     size_t start = 0;
@@ -84,6 +99,10 @@ bool has_prefix_token(const std::vector<std::string>& tokens, const std::string&
         }
     }
     return false;
+}
+
+bool has_init_parameter(const std::vector<std::string>& kernel_tokens) {
+    return has_prefix_token(kernel_tokens, "init=");
 }
 
 }  // namespace
@@ -153,6 +172,78 @@ TEST(KernelCmdlineCompat, AgentDottedParametersStayOutOfInitArgv) {
     if (!saw_agent_param) {
         GTEST_SKIP() << "kernel cmdline does not contain CubeSandbox agent dotted parameters";
     }
+}
+
+TEST(KernelCmdlineCompat, DoubleDashArgsDoNotRequireInitParameter) {
+    std::string kernel_cmdline;
+    ASSERT_TRUE(read_file("/proc/cmdline", &kernel_cmdline))
+        << "read /proc/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    const std::vector<std::string> kernel_tokens = kernel_param_tokens(kernel_cmdline);
+    const std::vector<std::string> init_arg_tokens =
+        init_arg_tokens_from_kernel_cmdline(kernel_cmdline);
+    constexpr char kAfterDashMarker[] = "dragonos_after_dash_marker";
+
+    if (!contains_token(init_arg_tokens, kAfterDashMarker)) {
+        GTEST_SKIP() << "kernel cmdline does not contain the after-dash marker";
+    }
+    if (has_init_parameter(kernel_tokens)) {
+        GTEST_SKIP() << "kernel cmdline contains init=; this case validates default init";
+    }
+
+    std::string init_cmdline;
+    ASSERT_TRUE(read_file("/proc/1/cmdline", &init_cmdline))
+        << "read /proc/1/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+    const std::vector<std::string> init_argv = split_nul(init_cmdline);
+
+    EXPECT_TRUE(contains_token(init_argv, kAfterDashMarker))
+        << kAfterDashMarker << " did not reach init argv";
+}
+
+TEST(KernelCmdlineCompat, InitParameterClearsEarlierUnknownBareArgs) {
+    std::string kernel_cmdline;
+    ASSERT_TRUE(read_file("/proc/cmdline", &kernel_cmdline))
+        << "read /proc/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    const std::vector<std::string> kernel_tokens = kernel_param_tokens(kernel_cmdline);
+    constexpr char kPreInitMarker[] = "dragonos_pre_init_marker";
+
+    if (!contains_token(kernel_tokens, kPreInitMarker)) {
+        GTEST_SKIP() << "kernel cmdline does not contain the pre-init marker";
+    }
+    if (!has_init_parameter(kernel_tokens)) {
+        GTEST_SKIP() << "kernel cmdline does not contain init=";
+    }
+
+    std::string init_cmdline;
+    ASSERT_TRUE(read_file("/proc/1/cmdline", &init_cmdline))
+        << "read /proc/1/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+    const std::vector<std::string> init_argv = split_nul(init_cmdline);
+
+    EXPECT_FALSE(contains_token(init_argv, kPreInitMarker))
+        << kPreInitMarker << " leaked into init argv before init= cleanup";
+}
+
+TEST(KernelCmdlineCompat, DoubleDashArgsSurviveInitParameterCleanup) {
+    std::string kernel_cmdline;
+    ASSERT_TRUE(read_file("/proc/cmdline", &kernel_cmdline))
+        << "read /proc/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    const std::vector<std::string> init_arg_tokens =
+        init_arg_tokens_from_kernel_cmdline(kernel_cmdline);
+    constexpr char kAfterDashMarker[] = "dragonos_after_dash_marker";
+
+    if (!contains_token(init_arg_tokens, kAfterDashMarker)) {
+        GTEST_SKIP() << "kernel cmdline does not contain the after-dash marker";
+    }
+
+    std::string init_cmdline;
+    ASSERT_TRUE(read_file("/proc/1/cmdline", &init_cmdline))
+        << "read /proc/1/cmdline failed: errno=" << errno << " (" << strerror(errno) << ")";
+    const std::vector<std::string> init_argv = split_nul(init_cmdline);
+
+    EXPECT_TRUE(contains_token(init_argv, kAfterDashMarker))
+        << kAfterDashMarker << " was removed while handling init=";
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- allow init arguments after `--` without requiring `init=`
- make repeated `init=` override earlier values and clear earlier unknown init argv
- deduplicate init environment entries by key, including default environment values
- extend cmdline compatibility coverage for init argv semantics

## Validation

- `make fmt`
- `make kernel`
- `make -C user/apps/tests/dunitest build-suites`
- `user/apps/tests/dunitest/bin/normal/kernel_cmdline_compat_test`
- booted DragonOS with a marker cmdline to verify `--` arguments reach PID 1
- booted DragonOS normally and ran `kernel_cmdline_compat_test` in the guest