### PR TITLE
Implement Linux devtmpfs semantics

### DIFF
--- a/kernel/src/driver/base/device/bus.rs
+++ b/kernel/src/driver/base/device/bus.rs
@@ -765,7 +765,7 @@ impl Attribute for DriverAttrUnbind {
         let dev = bus.find_device_by_name(s).ok_or(SystemError::ENODEV)?;
         let p = dev.driver().ok_or(SystemError::ENODEV)?;
         if Arc::ptr_eq(&p, &driver) {
-            device_manager().device_driver_detach(&dev);
+            device_manager().device_driver_detach(&dev)?;
             return Ok(buf.len());
         }
         return Err(SystemError::ENODEV);

--- a/kernel/src/driver/base/device/dd.rs
+++ b/kernel/src/driver/base/device/dd.rs
@@ -62,7 +62,7 @@ impl DeviceManager {
             // todo!("do_device_attach: allow_async")
             warn!("do_device_attach: allow_async is true, but currently not supported");
         }
-        if dev.is_dead() {
+        if dev.is_dead() || device_manager().is_device_removing(dev) {
             return Ok(false);
         }
 
@@ -359,7 +359,10 @@ impl DriverManager {
         driver: &Arc<dyn Driver>,
         device: &Arc<dyn Device>,
     ) -> Result<(), SystemError> {
-        if device.is_dead() || (!device.is_registered()) {
+        if device.is_dead()
+            || device_manager().is_device_removing(device)
+            || (!device.is_registered())
+        {
             return Err(SystemError::ENODEV);
         }
         if device.driver().is_some() {
@@ -393,12 +396,12 @@ impl DriverManager {
             }
         };
 
-        let probe_failed = || {
+        let remove_driver_sysfs = || {
             self.remove_from_sysfs(device);
         };
 
-        let dev_groups_failed = || {
-            device_manager().remove(device);
+        let remove_probed_driver = || {
+            self.remove_probed_driver(device);
         };
 
         device.set_driver(Some(Arc::downgrade(driver)));
@@ -421,7 +424,7 @@ impl DriverManager {
                 e
             );
 
-            probe_failed();
+            remove_driver_sysfs();
             sysfs_failed();
             bind_failed();
             e
@@ -435,8 +438,8 @@ impl DriverManager {
                     device.name(),
                     e
                 );
-                dev_groups_failed();
-                probe_failed();
+                remove_probed_driver();
+                remove_driver_sysfs();
                 sysfs_failed();
                 bind_failed();
                 e
@@ -451,8 +454,9 @@ impl DriverManager {
                     device.name(),
                     e
                 );
-                dev_groups_failed();
-                probe_failed();
+                device_manager().remove_groups(device, driver.dev_groups());
+                remove_probed_driver();
+                remove_driver_sysfs();
                 sysfs_failed();
                 bind_failed();
                 e
@@ -501,8 +505,33 @@ impl DriverManager {
     }
 
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/dd.c?fi=driver_attach#469
-    fn remove_from_sysfs(&self, _device: &Arc<dyn Device>) {
-        todo!("remove_from_sysfs")
+    fn remove_from_sysfs(&self, device: &Arc<dyn Device>) {
+        let Some(driver) = device.driver() else {
+            return;
+        };
+
+        let driver_kobj = driver.clone() as Arc<dyn KObject>;
+        let device_kobj = device.clone() as Arc<dyn KObject>;
+
+        sysfs_instance().remove_file(&device_kobj, &DeviceAttrCoredump);
+        sysfs_instance().remove_file(&device_kobj, &DeviceAttrStateSynced);
+        sysfs_instance().remove_link(&device_kobj, "driver".to_string());
+        sysfs_instance().remove_link(&driver_kobj, device.name());
+    }
+
+    fn remove_probed_driver(&self, device: &Arc<dyn Device>) {
+        let Some(bus) = device.bus().and_then(|bus| bus.upgrade()) else {
+            return;
+        };
+
+        if let Err(err) = bus.remove(device) {
+            warn!(
+                "probe rollback: failed to remove device '{}' from bus '{}': {:?}",
+                device.name(),
+                bus.name(),
+                err
+            );
+        }
     }
 
     fn call_driver_probe(

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -777,7 +777,7 @@ impl DeviceManager {
     /// core containers are removed, so a failing driver callback cannot leave driver-private state
     /// alive while sysfs/notifier state says the device is unbound.
     ///
-    /// 参考 Linux 6.6.139:
+    /// Reference: Linux 6.6.139:
     /// - drivers/base/core.c:device_del()
     /// - drivers/base/bus.c:bus_remove_device()
     #[inline(never)]
@@ -1032,10 +1032,10 @@ impl DeviceManager {
         return sysfs_instance().create_file(&kobj, attr);
     }
 
-    /// 从设备对应的 sysfs 目录中删除属性文件。
+    /// Remove an attribute file from the device's sysfs directory.
     ///
-    /// Linux 的 `device_remove_file()` 是 void/best-effort 语义；DragonOS 这里沿用同样策略，
-    /// 因为删除路径可能来自部分初始化失败后的回滚。
+    /// Linux's `device_remove_file()` uses void/best-effort semantics; DragonOS follows the same strategy,
+    /// because the removal path may be triggered during rollback after a partial initialization failure.
     pub fn remove_file(&self, dev: &Arc<dyn Device>, attr: &'static dyn Attribute) {
         let kobj = dev.clone() as Arc<dyn KObject>;
         sysfs_instance().remove_file(&kobj, attr);

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -2,6 +2,7 @@ use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
     sync::{Arc, Weak},
+    vec::Vec,
 };
 use intertrait::cast::CastArc;
 use log::{error, warn};
@@ -13,6 +14,7 @@ use crate::{
     },
     exception::irqdata::IrqHandlerData,
     filesystem::{
+        devfs::{devfs_create_node_dyn, devfs_unregister_dyn, DeviceINode},
         kernfs::KernFSInode,
         sysfs::{
             file::sysfs_emit_str, sysfs_instance, Attribute, AttributeGroup, SysFSOps,
@@ -31,7 +33,8 @@ use core::{fmt::Display, intrinsics::unlikely, ops::Deref};
 use system_error::SystemError;
 
 use self::{
-    bus::{bus_add_device, bus_probe_device, Bus},
+    bus::{bus_add_device, bus_probe_device, Bus, BusNotifyEvent},
+    dd::{DeviceAttrCoredump, DeviceAttrStateSynced},
     device_number::{DeviceNumber, Major},
     driver::Driver,
 };
@@ -69,6 +72,7 @@ lazy_static! {
     // 全局设备管理实例
     pub static ref DEVMAP: Arc<LockedKObjMap> = Arc::new(LockedKObjMap::default());
 
+    static ref REMOVING_DEVICES: SpinLock<Vec<Weak<dyn Device>>> = SpinLock::new(Vec::new());
 }
 
 /// `/sys/devices` 的 kset 实例
@@ -539,6 +543,11 @@ impl SysFSOps for DeviceSysFSOps {
 #[derive(Debug)]
 pub struct DeviceManager;
 
+struct DevtmpfsNode {
+    name: String,
+    inode: Arc<dyn DeviceINode>,
+}
+
 impl DeviceManager {
     /// @brief: 创建一个新的设备管理器
     /// @parameter: None
@@ -606,6 +615,8 @@ impl DeviceManager {
             self.create_sys_dev_entry(&device)?;
         }
 
+        let devtmpfs_node = self.devtmpfs_create_node(&device);
+
         // 通知客户端有关设备添加的信息。此调用必须在 dpm_sysfs_add() 之后且在 kobject_uevent() 之前执行。
         if let Some(bus) = device.bus().and_then(|bus| bus.upgrade()) {
             bus.subsystem().bus_notifier().call_chain(
@@ -639,10 +650,23 @@ impl DeviceManager {
         bus_probe_device(&device);
 
         if let Some(class) = device.class() {
-            class.subsystem().add_device_to_vec(&device)?;
-
-            for class_interface in class.subsystem().interfaces() {
-                class_interface.add_device(&device).ok();
+            match class.subsystem().add_device_to_vec(&device) {
+                Ok(()) => {
+                    for class_interface in class.subsystem().interfaces() {
+                        class_interface.add_device(&device).ok();
+                    }
+                }
+                Err(SystemError::EEXIST) => {
+                    warn!(
+                        "device '{}' is already present in class '{}'",
+                        device.name(),
+                        class.name()
+                    );
+                }
+                Err(err) => {
+                    self.devtmpfs_delete_node(devtmpfs_node.as_ref());
+                    return Err(err);
+                }
             }
         }
 
@@ -746,9 +770,65 @@ impl DeviceManager {
         todo!()
     }
 
-    /// 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/dd.c?fi=driver_attach#542
-    pub fn remove(&self, _dev: &Arc<dyn Device>) {
-        todo!("DeviceManager::remove")
+    /// Remove a registered device from DragonOS driver-core containers.
+    ///
+    /// This mirrors the core teardown of Linux `device_del()` / `bus_remove_device()` as far as the
+    /// current DragonOS fallible driver `remove()` API allows. Bound devices are detached before
+    /// core containers are removed, so a failing driver callback cannot leave driver-private state
+    /// alive while sysfs/notifier state says the device is unbound.
+    ///
+    /// 参考 Linux 6.6.139:
+    /// - drivers/base/core.c:device_del()
+    /// - drivers/base/bus.c:bus_remove_device()
+    #[inline(never)]
+    pub fn remove(&self, dev: &Arc<dyn Device>) {
+        if !dev.is_registered() {
+            return;
+        }
+
+        if !self.mark_device_removing(dev) {
+            return;
+        }
+
+        if self.device_is_bound(dev) {
+            if let Err(err) = self.release_driver(dev) {
+                warn!(
+                    "skip removing bound device '{}': driver detach failed: {:?}",
+                    dev.name(),
+                    err
+                );
+                self.unmark_device_removing(dev);
+                return;
+            }
+        }
+
+        if let Some(bus) = dev.bus().and_then(|bus| bus.upgrade()) {
+            bus.subsystem()
+                .bus_notifier()
+                .call_chain(BusNotifyEvent::DelDevice, Some(dev), None);
+        }
+
+        self.devtmpfs_delete_node_for_device(dev);
+
+        if dev.id_table().device_number().major() != Major::UNNAMED_MAJOR {
+            self.remove_sys_dev_entry(dev);
+            self.remove_file(dev, &DeviceAttrDev);
+        }
+
+        self.remove_class_device(dev);
+        self.remove_attrs(dev);
+        self.remove_bus_device(dev);
+
+        if let Some(bus) = dev.bus().and_then(|bus| bus.upgrade()) {
+            bus.subsystem().bus_notifier().call_chain(
+                BusNotifyEvent::RemovedDevice,
+                Some(dev),
+                None,
+            );
+        }
+
+        KObjectManager::remove_kobj(dev.clone() as Arc<dyn KObject>);
+        self.unmark_device_removing(dev);
     }
 
     /// @brief: 获取设备
@@ -763,6 +843,40 @@ impl DeviceManager {
     fn device_platform_notify(&self, dev: &Arc<dyn Device>) {
         acpi_device_notify(dev);
         software_node_notify(dev);
+    }
+
+    pub fn is_device_removing(&self, dev: &Arc<dyn Device>) -> bool {
+        let mut removing = REMOVING_DEVICES.lock();
+        removing.retain(|weak_dev| weak_dev.upgrade().is_some());
+        removing
+            .iter()
+            .filter_map(|weak_dev| weak_dev.upgrade())
+            .any(|removing_dev| Arc::ptr_eq(&removing_dev, dev))
+    }
+
+    fn mark_device_removing(&self, dev: &Arc<dyn Device>) -> bool {
+        let mut removing = REMOVING_DEVICES.lock();
+        removing.retain(|weak_dev| weak_dev.upgrade().is_some());
+
+        if removing
+            .iter()
+            .filter_map(|weak_dev| weak_dev.upgrade())
+            .any(|removing_dev| Arc::ptr_eq(&removing_dev, dev))
+        {
+            return false;
+        }
+
+        removing.push(Arc::downgrade(dev));
+        true
+    }
+
+    fn unmark_device_removing(&self, dev: &Arc<dyn Device>) {
+        let mut removing = REMOVING_DEVICES.lock();
+        removing.retain(|weak_dev| {
+            weak_dev
+                .upgrade()
+                .is_some_and(|removing_dev| !Arc::ptr_eq(&removing_dev, dev))
+        });
     }
 
     // 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/core.c#3224
@@ -918,6 +1032,109 @@ impl DeviceManager {
         return sysfs_instance().create_file(&kobj, attr);
     }
 
+    /// 从设备对应的 sysfs 目录中删除属性文件。
+    ///
+    /// Linux 的 `device_remove_file()` 是 void/best-effort 语义；DragonOS 这里沿用同样策略，
+    /// 因为删除路径可能来自部分初始化失败后的回滚。
+    pub fn remove_file(&self, dev: &Arc<dyn Device>, attr: &'static dyn Attribute) {
+        let kobj = dev.clone() as Arc<dyn KObject>;
+        sysfs_instance().remove_file(&kobj, attr);
+    }
+
+    fn remove_attrs(&self, dev: &Arc<dyn Device>) {
+        self.remove_groups(dev, dev.attribute_groups().unwrap_or(&[]));
+
+        if let Some(kobj_type) = dev.kobj_type() {
+            self.remove_groups(dev, kobj_type.attribute_groups().unwrap_or(&[]));
+        }
+
+        if let Some(class) = dev.class() {
+            self.remove_groups(dev, class.dev_groups());
+        }
+    }
+
+    fn remove_class_device(&self, dev: &Arc<dyn Device>) {
+        let Some(class) = dev.class() else {
+            return;
+        };
+
+        let dev_kobj = dev.clone() as Arc<dyn KObject>;
+        if dev.dev_parent().and_then(|x| x.upgrade()).is_some() {
+            sysfs_instance().remove_link(&dev_kobj, "device".to_string());
+        }
+        sysfs_instance().remove_link(&dev_kobj, "subsystem".to_string());
+
+        let subsys_kobj = class.subsystem().subsys() as Arc<dyn KObject>;
+        sysfs_instance().remove_link(&subsys_kobj, dev.name());
+
+        for class_interface in class.subsystem().interfaces() {
+            class_interface.remove_device(dev);
+        }
+        class.subsystem().remove_device_from_vec(dev);
+    }
+
+    fn remove_bus_device(&self, dev: &Arc<dyn Device>) {
+        let Some(bus) = dev.bus().and_then(|bus| bus.upgrade()) else {
+            return;
+        };
+
+        for interface in bus.subsystem().interfaces() {
+            interface.remove_device(dev);
+        }
+
+        let dev_kobj = dev.clone() as Arc<dyn KObject>;
+        sysfs_instance().remove_link(&dev_kobj, "subsystem".to_string());
+
+        if let Some(bus_devices_kset) = bus.subsystem().devices_kset() {
+            sysfs_instance().remove_link(&bus_devices_kset.as_kobject(), dev.name());
+        }
+
+        self.remove_groups(dev, bus.dev_groups());
+        bus.subsystem().remove_device_from_vec(dev);
+    }
+
+    fn remove_driver_sysfs_binding(&self, dev: &Arc<dyn Device>, driver: &Arc<dyn Driver>) {
+        let driver_kobj = driver.clone() as Arc<dyn KObject>;
+        let dev_kobj = dev.clone() as Arc<dyn KObject>;
+
+        sysfs_instance().remove_file(&dev_kobj, &DeviceAttrStateSynced);
+        sysfs_instance().remove_file(&dev_kobj, &DeviceAttrCoredump);
+        self.remove_groups(dev, driver.dev_groups());
+        sysfs_instance().remove_link(&dev_kobj, "driver".to_string());
+        sysfs_instance().remove_link(&driver_kobj, dev.name());
+    }
+
+    fn release_driver(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
+        let driver = dev.driver().ok_or(SystemError::ENODEV)?;
+        let bus = dev
+            .bus()
+            .and_then(|bus| bus.upgrade())
+            .ok_or(SystemError::ENODEV)?;
+
+        bus.remove(dev).inspect_err(|err| {
+            warn!(
+                "failed to remove device '{}' from bus '{}': {:?}",
+                dev.name(),
+                bus.name(),
+                err
+            );
+        })?;
+
+        bus.subsystem()
+            .bus_notifier()
+            .call_chain(BusNotifyEvent::UnbindDriver, Some(dev), None);
+
+        self.remove_driver_sysfs_binding(dev, &driver);
+        driver.delete_device(dev);
+        dev.set_driver(None);
+
+        bus.subsystem()
+            .bus_notifier()
+            .call_chain(BusNotifyEvent::UnboundDriver, Some(dev), None);
+
+        Ok(())
+    }
+
     /// 在/sys/dev下，或者设备所属的class下，为指定的设备创建链接
     fn create_sys_dev_entry(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
         let target_kobj = self.device_to_dev_kobj(dev);
@@ -927,7 +1144,6 @@ impl DeviceManager {
     }
 
     /// Delete symlink for device in `/sys/dev` or `/sys/class/<class_name>`
-    #[allow(dead_code)]
     fn remove_sys_dev_entry(&self, dev: &Arc<dyn Device>) {
         let kobj = self.device_to_dev_kobj(dev);
         let name = dev.id_table().name();
@@ -941,10 +1157,79 @@ impl DeviceManager {
     /// ## 参数
     ///
     /// - `dev`: 设备
-    fn device_to_dev_kobj(&self, _dev: &Arc<dyn Device>) -> Arc<dyn KObject> {
-        // todo: 处理class的逻辑
-        let kobj = sys_dev_char_kobj() as Arc<dyn KObject>;
-        return kobj;
+    fn device_to_dev_kobj(&self, dev: &Arc<dyn Device>) -> Arc<dyn KObject> {
+        match dev.dev_type() {
+            DeviceType::Block => sys_dev_block_kobj() as Arc<dyn KObject>,
+            _ => sys_dev_char_kobj() as Arc<dyn KObject>,
+        }
+    }
+
+    /// Create the `/dev` node for a registered device, matching Linux device_add() ordering.
+    ///
+    /// Linux treats devtmpfs population as best-effort: failures are reported but do not fail
+    /// device registration. DragonOS keeps the same policy here.
+    fn devtmpfs_create_node(&self, dev: &Arc<dyn Device>) -> Option<DevtmpfsNode> {
+        let node = self.devtmpfs_node_from_device(dev)?;
+
+        match devfs_create_node_dyn(&node.name, node.inode.clone()) {
+            Ok(true) => Some(node),
+            Ok(false) => None,
+            Err(err) => {
+                warn!(
+                    "failed to create devtmpfs node '{}' for {:?}: {:?}",
+                    dev.name(),
+                    dev.id_table(),
+                    err
+                );
+                None
+            }
+        }
+    }
+
+    fn devtmpfs_node_from_device(&self, dev: &Arc<dyn Device>) -> Option<DevtmpfsNode> {
+        let kobj = dev.clone() as Arc<dyn KObject>;
+        let Ok(device_inode) = kobj.cast::<dyn DeviceINode>() else {
+            return None;
+        };
+
+        let metadata = match device_inode.metadata() {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                warn!(
+                    "failed to read device metadata for devtmpfs node '{}': {:?}",
+                    dev.name(),
+                    err
+                );
+                return None;
+            }
+        };
+
+        if metadata.raw_dev.major() == Major::UNNAMED_MAJOR {
+            return None;
+        }
+
+        Some(DevtmpfsNode {
+            name: dev.name(),
+            inode: device_inode,
+        })
+    }
+
+    fn devtmpfs_delete_node(&self, node: Option<&DevtmpfsNode>) {
+        if let Some(node) = node {
+            if let Err(err) = devfs_unregister_dyn(&node.name, node.inode.clone()) {
+                warn!("failed to delete devtmpfs node '{}': {:?}", node.name, err);
+            }
+        }
+    }
+
+    /// Delete the `/dev` node for a registered device.
+    ///
+    /// This helper mirrors the devtmpfs part of Linux `device_del()`. DragonOS still lacks a
+    /// complete `device_del()` implementation; when that lifecycle is added, call this after
+    /// DEL_DEVICE notification and before removing `/sys/dev/{char,block}` links.
+    fn devtmpfs_delete_node_for_device(&self, dev: &Arc<dyn Device>) {
+        let node = self.devtmpfs_node_from_device(dev);
+        self.devtmpfs_delete_node(node.as_ref());
     }
 
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/core.c?fi=device_links_force_bind#1226
@@ -971,8 +1256,8 @@ impl DeviceManager {
     }
 
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/dd.c?r=&mo=35401&fi=1313#1313
-    pub fn device_driver_detach(&self, _dev: &Arc<dyn Device>) {
-        todo!("device_driver_detach")
+    pub fn device_driver_detach(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
+        self.release_driver(dev)
     }
 }
 
@@ -986,16 +1271,8 @@ pub fn device_register<T: Device>(device: Arc<T>) -> Result<(), SystemError> {
 /// @brief: 设备卸载
 /// @parameter: name: 设备名
 /// @return: 操作成功，返回()，操作失败，返回错误码
-pub fn device_unregister<T: Device>(_device: Arc<T>) {
-    // DEVICE_MANAGER.add_device(device.id_table(), device.clone());
-    // match sys_device_unregister(&device.id_table().name()) {
-    //     Ok(_) => {
-    //         device.set_inode(None);
-    //         return Ok(());
-    //     }
-    //     Err(_) => Err(DeviceError::RegisterError),
-    // }
-    todo!("device_unregister")
+pub fn device_unregister<T: Device + 'static>(device: Arc<T>) {
+    device_manager().remove(&(device as Arc<dyn Device>));
 }
 
 /// # 关闭所有设备

--- a/kernel/src/driver/base/platform/subsys.rs
+++ b/kernel/src/driver/base/platform/subsys.rs
@@ -76,8 +76,25 @@ impl Bus for PlatformBus {
         return pdrv.probe(&pdev);
     }
 
-    fn remove(&self, _device: &Arc<dyn Device>) -> Result<(), SystemError> {
-        todo!()
+    fn remove(&self, device: &Arc<dyn Device>) -> Result<(), SystemError> {
+        let drv = device.driver().ok_or(SystemError::EINVAL)?;
+        let pdrv = drv.cast::<dyn PlatformDriver>().map_err(|_| {
+            error!(
+                "PlatformBus::remove() failed: device.driver() is not a PlatformDriver. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+
+        let pdev = device.clone().cast::<dyn PlatformDevice>().map_err(|_| {
+            error!(
+                "PlatformBus::remove() failed: device is not a PlatformDevice. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+
+        return pdrv.remove(&pdev);
     }
 
     fn sync_state(&self, _device: &Arc<dyn Device>) {

--- a/kernel/src/driver/block/loop_device/loop_control.rs
+++ b/kernel/src/driver/block/loop_device/loop_control.rs
@@ -49,7 +49,7 @@ use super::{
 /// - 设备分配和查找
 /// - 设备绑定和解绑
 /// - 设备状态查询和配置（配置设备参数，如偏移量、大小限制等）
-#[cast_to([sync] Device)]
+#[cast_to([sync] Device, DeviceINode)]
 pub struct LoopControlDevice {
     inner: SpinLock<LoopControlDeviceInner>,
     locked_kobj_state: LockedKObjectState,

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -94,6 +94,7 @@ impl<'a> Drop for IoGuard<'a> {
 }
 
 /// Loop 设备
+#[cast_to([sync] Device, DeviceINode)]
 pub struct LoopDevice {
     id: usize,
     minor: u32,

--- a/kernel/src/driver/block/pmem/device.rs
+++ b/kernel/src/driver/block/pmem/device.rs
@@ -53,7 +53,7 @@ struct InnerPmemBlockDevice {
     kobject_common: KObjectCommonData,
 }
 
-#[cast_to([sync] Device)]
+#[cast_to([sync] Device, DeviceINode)]
 pub struct PmemBlockDevice {
     blkdev_meta: BlockDevMeta,
     inner: SpinLock<InnerPmemBlockDevice>,

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -383,7 +383,7 @@ impl VirtIOBlkManager {
 
 /// virtio block device
 #[cast_to([sync] VirtIODevice)]
-#[cast_to([sync] Device)]
+#[cast_to([sync] Device, DeviceINode)]
 pub struct VirtIOBlkDevice {
     blkdev_meta: BlockDevMeta,
     dev_id: Arc<DeviceId>,

--- a/kernel/src/driver/input/ps2_mouse/ps_mouse_device.rs
+++ b/kernel/src/driver/input/ps2_mouse/ps_mouse_device.rs
@@ -174,7 +174,7 @@ impl MouseState {
 }
 
 #[derive(Debug)]
-#[cast_to([sync] Device, SerioDevice)]
+#[cast_to([sync] Device, DeviceINode, SerioDevice)]
 pub struct Ps2MouseDevice {
     inner: SpinLock<InnerPs2MouseDevice>,
     kobj_state: LockedKObjectState,

--- a/kernel/src/driver/input/ps2_mouse/ps_mouse_driver.rs
+++ b/kernel/src/driver/input/ps2_mouse/ps_mouse_driver.rs
@@ -267,7 +267,7 @@ impl SerioDriver for Ps2MouseDriver {
     }
 
     fn disconnect(&self, _device: &Arc<dyn SerioDevice>) -> Result<(), system_error::SystemError> {
-        todo!()
+        Err(SystemError::ENOSYS)
     }
 
     // TODO: https://elixir.bootlin.com/linux/v6.6/source/drivers/input/mouse/psmouse-base.c#L1428

--- a/kernel/src/driver/input/serio/i8042/i8042_driver.rs
+++ b/kernel/src/driver/input/serio/i8042/i8042_driver.rs
@@ -79,7 +79,7 @@ impl PlatformDriver for I8042Driver {
 
     // TODO: https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/input/serio/i8042.c#1587
     fn remove(&self, _device: &Arc<dyn PlatformDevice>) -> Result<(), SystemError> {
-        todo!()
+        Err(SystemError::ENOSYS)
     }
 
     // TODO: https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/input/serio/i8042.c#1322

--- a/kernel/src/driver/input/serio/subsys.rs
+++ b/kernel/src/driver/input/serio/subsys.rs
@@ -78,8 +78,25 @@ impl Bus for SerioBus {
         return pdrv.connect(&pdev);
     }
 
-    fn remove(&self, _device: &Arc<dyn Device>) -> Result<(), SystemError> {
-        todo!()
+    fn remove(&self, device: &Arc<dyn Device>) -> Result<(), SystemError> {
+        let drv = device.driver().ok_or(SystemError::EINVAL)?;
+        let pdrv = drv.cast::<dyn SerioDriver>().map_err(|_| {
+            error!(
+                "SerioBus::remove() failed: device.driver() is not a SerioDriver. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+
+        let pdev = device.clone().cast::<dyn SerioDevice>().map_err(|_| {
+            error!(
+                "SerioBus::remove() failed: device is not a SerioDevice. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+
+        pdrv.disconnect(&pdev)
     }
 
     fn sync_state(&self, _device: &Arc<dyn Device>) {

--- a/kernel/src/driver/pci/subsys.rs
+++ b/kernel/src/driver/pci/subsys.rs
@@ -108,8 +108,23 @@ impl Bus for PciBus {
         pci_drv.probe(&pci_dev, &id)
     }
 
-    fn remove(&self, _device: &Arc<dyn Device>) -> Result<(), SystemError> {
-        todo!()
+    fn remove(&self, device: &Arc<dyn Device>) -> Result<(), SystemError> {
+        let drv = device.driver().ok_or(SystemError::EINVAL)?;
+        let pci_drv = drv.cast::<dyn PciDriver>().map_err(|_| {
+            error!(
+                "PciBus::remove() failed: device.driver() is not a PciDriver. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+        let pci_dev = device.clone().cast::<dyn PciDevice>().map_err(|_| {
+            error!(
+                "PciBus::remove() failed: device is not a PciDevice. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+        pci_drv.remove(&pci_dev)
     }
 
     fn sync_state(&self, _device: &Arc<dyn Device>) {

--- a/kernel/src/driver/serial/serial8250/mod.rs
+++ b/kernel/src/driver/serial/serial8250/mod.rs
@@ -462,7 +462,7 @@ impl PlatformDriver for Serial8250ISADriver {
     }
 
     fn remove(&self, _device: &Arc<dyn PlatformDevice>) -> Result<(), SystemError> {
-        todo!()
+        Err(SystemError::ENOSYS)
     }
 
     fn shutdown(&self, _device: &Arc<dyn PlatformDevice>) -> Result<(), SystemError> {

--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -15,16 +15,35 @@ use crate::{
     filesystem::{
         devpts::DevPtsFs,
         epoll::{event_poll::EventPoll, EPollEventType},
-        vfs::{file::FileFlags, FilePrivateData, FileSystem, FileType, IndexNode, InodeMode},
+        vfs::{
+            file::FileFlags, FilePrivateData, FileSystem, FileType, IndexNode, InodeMode, MountFS,
+        },
     },
     libs::{casting::DowncastArc, mutex::MutexGuard},
     mm::VirtAddr,
+    process::ProcessManager,
     syscall::user_access::UserBufferWriter,
 };
 
 use super::{ptm_driver, pts_driver, PtyCommon};
 
 pub const NR_UNIX98_PTY_MAX: u32 = 128;
+
+fn current_devpts() -> Result<Arc<DevPtsFs>, SystemError> {
+    let fs = ProcessManager::current_mntns()
+        .root_inode()
+        .find("dev")?
+        .find("pts")?
+        .fs();
+
+    if let Some(devpts) = fs.clone().downcast_arc::<DevPtsFs>() {
+        return Ok(devpts);
+    }
+
+    fs.downcast_arc::<MountFS>()
+        .and_then(|mount_fs| mount_fs.inner_filesystem().downcast_arc::<DevPtsFs>())
+        .ok_or(SystemError::ENODEV)
+}
 
 #[derive(Debug)]
 struct PtyDevPtsLink {
@@ -371,13 +390,12 @@ pub fn ptmx_open(
         return Ok(());
     }
     // 根据当前节点所属的文件系统决定 devpts 根
-    let (pts_root_inode, fsinfo) =
-        if let Some(devpts) = this.fs().clone().downcast_arc::<DevPtsFs>() {
-            let root_inode = devpts.root_inode();
-            (root_inode, devpts)
-        } else {
-            return Err(SystemError::ENODEV);
-        };
+    let fsinfo = if let Some(devpts) = this.fs().clone().downcast_arc::<DevPtsFs>() {
+        devpts
+    } else {
+        current_devpts()?
+    };
+    let pts_root_inode = fsinfo.root_inode();
 
     let index = fsinfo.alloc_index()?;
 

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -100,7 +100,7 @@ pub enum PtyType {
     Pts,
 }
 
-#[cast_to([sync] Device)]
+#[cast_to([sync] Device, DeviceINode)]
 pub struct TtyDevice {
     name: String,
     id_table: IdTable,

--- a/kernel/src/driver/video/fbdev/base/fbmem.rs
+++ b/kernel/src/driver/video/fbdev/base/fbmem.rs
@@ -212,7 +212,7 @@ impl FrameBufferManager {
 ///
 /// 该设备的父设备为真实的帧缓冲区设备
 #[derive(Debug)]
-#[cast_to([sync] Device)]
+#[cast_to([sync] Device, DeviceINode)]
 pub struct FbDevice {
     inner: SpinLock<InnerFbDevice>,
     kobj_state: LockedKObjectState,

--- a/kernel/src/driver/video/fbdev/vesafb.rs
+++ b/kernel/src/driver/video/fbdev/vesafb.rs
@@ -748,7 +748,7 @@ impl PlatformDriver for VesaFbDriver {
     }
 
     fn remove(&self, _device: &Arc<dyn PlatformDevice>) -> Result<(), SystemError> {
-        todo!()
+        Err(SystemError::ENOSYS)
     }
 
     fn shutdown(&self, _device: &Arc<dyn PlatformDevice>) -> Result<(), SystemError> {

--- a/kernel/src/driver/virtio/mod.rs
+++ b/kernel/src/driver/virtio/mod.rs
@@ -54,6 +54,10 @@ pub trait VirtIODevice: Device {
 pub trait VirtIODriver: Driver {
     fn probe(&self, device: &Arc<dyn VirtIODevice>) -> Result<(), SystemError>;
 
+    fn remove(&self, _device: &Arc<dyn VirtIODevice>) -> Result<(), SystemError> {
+        Err(SystemError::ENOSYS)
+    }
+
     fn shutdown(&self, _device: &Arc<dyn VirtIODevice>) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/driver/virtio/sysfs.rs
+++ b/kernel/src/driver/virtio/sysfs.rs
@@ -98,8 +98,25 @@ impl Bus for VirtIOBus {
         return virtio_drv.probe(&virtio_dev);
     }
 
-    fn remove(&self, _device: &Arc<dyn Device>) -> Result<(), SystemError> {
-        todo!()
+    fn remove(&self, device: &Arc<dyn Device>) -> Result<(), SystemError> {
+        let drv = device.driver().ok_or(SystemError::EINVAL)?;
+        let virtio_drv = drv.cast::<dyn VirtIODriver>().map_err(|_| {
+            error!(
+                "VirtIOBus::remove() failed: device.driver() is not a VirtioDriver. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+
+        let virtio_dev = device.clone().cast::<dyn VirtIODevice>().map_err(|_| {
+            error!(
+                "VirtIOBus::remove() failed: device is not a VirtIODevice. Device: '{:?}'",
+                device.name()
+            );
+            SystemError::EINVAL
+        })?;
+
+        return virtio_drv.remove(&virtio_dev);
     }
 
     fn sync_state(&self, _device: &Arc<dyn Device>) {

--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -8,12 +8,13 @@ use super::{
     devpts::{DevPtsFs, LockedDevPtsFSInode},
     vfs::{
         file::FileFlags, utils::DName, vcore::generate_inode_id, FilePrivateData, FileSystem,
-        FileType, FsInfo, IndexNode, InodeFlags, InodeMode, Magic, Metadata, SuperBlock,
+        FileSystemMakerData, FileType, FsInfo, IndexNode, InodeFlags, InodeMode, Magic, Metadata,
+        MountableFileSystem, SuperBlock, FSMAKER,
     },
 };
 
 use crate::{
-    driver::base::{block::gendisk::GenDisk, device::device_number::DeviceNumber},
+    driver::base::device::device_number::DeviceNumber,
     filesystem::{
         devfs::zero_dev::LockedZeroInode,
         vfs::{mount::MountFlags, produce_fs},
@@ -28,6 +29,7 @@ use crate::{
         VmFaultReason,
     },
     process::ProcessManager,
+    register_mountable_fs,
     time::PosixTimeSpec,
 };
 use alloc::{
@@ -36,17 +38,91 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
+use linkme::distributed_slice;
 use log::{error, info, warn};
 use system_error::SystemError;
 
-const DEVFS_BLOCK_SIZE: u64 = 512;
+const DEVFS_BLOCK_SIZE: u64 = 4096;
 const DEVFS_MAX_NAMELEN: usize = 255;
+
+static DEVFS_INIT: Once = Once::new();
+static mut DEVFS_INSTANCE: Option<Arc<DevFS>> = None;
+
+fn devfs_global_instance() -> Arc<DevFS> {
+    DEVFS_INIT.call_once(|| unsafe {
+        DEVFS_INSTANCE = Some(DevFS::new());
+    });
+
+    unsafe { DEVFS_INSTANCE.as_ref().unwrap().clone() }
+}
+
+#[derive(Debug)]
+struct DevNodePath {
+    dirs: Vec<DName>,
+    basename: DName,
+}
+
+impl DevNodePath {
+    fn parse(name: &str) -> Result<Self, SystemError> {
+        let normalized = name.replace('!', "/");
+        let normalized = normalized.trim_start_matches('/');
+        if normalized.is_empty() {
+            return Err(SystemError::EINVAL);
+        }
+
+        let mut components = Vec::new();
+        for component in normalized.split('/') {
+            if component.is_empty() || component == "." || component == ".." {
+                return Err(SystemError::EINVAL);
+            }
+            if component.len() > DEVFS_MAX_NAMELEN {
+                return Err(SystemError::ENAMETOOLONG);
+            }
+            components.push(DName::from(component));
+        }
+
+        let basename = components.pop().ok_or(SystemError::EINVAL)?;
+        Ok(Self {
+            dirs: components,
+            basename,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum DeviceIndexKind {
+    Char,
+    Block,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct DeviceIndexKey {
+    kind: DeviceIndexKind,
+    dev_t: DeviceNumber,
+}
+
+impl DeviceIndexKey {
+    fn from_file_type(file_type: FileType, dev_t: DeviceNumber) -> Option<Self> {
+        let kind = match file_type {
+            FileType::BlockDevice => DeviceIndexKind::Block,
+            FileType::CharDevice | FileType::KvmDevice | FileType::FramebufferDevice => {
+                DeviceIndexKind::Char
+            }
+            _ => return None,
+        };
+
+        Some(Self { kind, dev_t })
+    }
+}
+
 /// @brief dev文件系统
 #[derive(Debug)]
 pub struct DevFS {
     // 文件系统根节点
     root_inode: Arc<LockedDevFSInode>,
     super_block: SuperBlock,
+    operation_lock: Mutex<()>,
+    device_by_devnum: Mutex<BTreeMap<DeviceIndexKey, Vec<Arc<dyn IndexNode>>>>,
 }
 
 fn is_zero_inode(pfm: &PageFaultMessage) -> bool {
@@ -81,7 +157,7 @@ impl FileSystem for DevFS {
     }
 
     fn name(&self) -> &str {
-        "devfs"
+        "devtmpfs"
     }
 
     fn super_block(&self) -> SuperBlock {
@@ -109,30 +185,9 @@ impl FileSystem for DevFS {
 }
 
 impl DevFS {
-    fn char_device_uses_root(name: &str) -> bool {
-        (name.starts_with("tty") && name.len() >= 3)
-            || (name.starts_with("hvc") && name.len() > 3)
-            || name == "console"
-            || name == "ptmx"
-            || name == "loop-control"
-    }
-
-    fn is_loop_block_device(name: &str) -> bool {
-        name.starts_with("loop") && name.len() > 4 && name[4..].chars().all(|c| c.is_ascii_digit())
-    }
-
-    fn block_device_uses_root(name: &str) -> bool {
-        (name.starts_with("vd") && name.len() > 2)
-            || name.starts_with("nvme")
-            || Self::is_loop_block_device(name)
-            || (name.starts_with("pmem")
-                && name.len() > 4
-                && name[4..].chars().all(|c| c.is_ascii_digit()))
-    }
-
     pub fn new() -> Arc<Self> {
         let super_block = SuperBlock::new(
-            Magic::DEVFS_MAGIC,
+            Magic::TMPFS_MAGIC,
             DEVFS_BLOCK_SIZE,
             DEVFS_MAX_NAMELEN as u64,
         );
@@ -148,6 +203,8 @@ impl DevFS {
         let devfs: Arc<DevFS> = Arc::new(DevFS {
             root_inode: root,
             super_block,
+            operation_lock: Mutex::new(()),
+            device_by_devnum: Mutex::new(BTreeMap::new()),
         });
 
         // 对root inode加锁，并继续完成初始化工作
@@ -158,15 +215,7 @@ impl DevFS {
         // 释放锁
         drop(root_guard);
 
-        // 创建文件夹
         let root: &Arc<LockedDevFSInode> = &devfs.root_inode;
-        root.add_dir("char")
-            .expect("DevFS: Failed to create /dev/char");
-
-        root.add_dir("block")
-            .expect("DevFS: Failed to create /dev/block");
-        // 预创建 /dev/ptmx 符号链接指向 devpts 内部节点，避免早期 ENOENT
-        let _ = root.add_dev_symlink("pts/ptmx", "ptmx");
         // Linux 用户态会通过 /dev/fd/N[/path] 重新访问 fd 派生的可见路径。
         // DragonOS 的真实对象解析能力在 /proc/self/fd，因此这里补兼容入口。
         root.add_dev_symlink("/proc/self/fd", "fd")
@@ -179,7 +228,13 @@ impl DevFS {
 
     /// @brief 注册系统内部自带的设备
     fn register_bultinin_device(&self) {
-        use crate::driver::base::device::device_number::{DeviceNumber, Major};
+        use crate::driver::{
+            base::device::{
+                device_number::{DeviceNumber, Major},
+                IdTable,
+            },
+            tty::tty_device::{PtyType, TtyDevice, TtyType},
+        };
         use crate::filesystem::fuse::dev::LockedFuseDevInode;
         use full_dev::LockedFullInode;
         use null_dev::LockedNullInode;
@@ -204,6 +259,22 @@ impl DevFS {
         .expect("DevFS: Failed to register /dev/urandom");
         self.register_builtin_root_device("fuse", LockedFuseDevInode::new())
             .expect("DevFS: Failed to register /dev/fuse");
+
+        let ptmx_devnum = DeviceNumber::new(Major::TTYAUX_MAJOR, 2);
+        let ptmx = TtyDevice::new(
+            "ptmx".to_string(),
+            IdTable::new("ptmx".to_string(), Some(ptmx_devnum)),
+            TtyType::Pty(PtyType::Ptm),
+        );
+        let mut metadata = ptmx
+            .metadata()
+            .expect("DevFS: Failed to read /dev/ptmx metadata");
+        metadata.mode = InodeMode::from_bits_truncate(0o666) | InodeMode::S_IFCHR;
+        metadata.raw_dev = ptmx_devnum;
+        ptmx.set_metadata(&metadata)
+            .expect("DevFS: Failed to set /dev/ptmx metadata");
+        self.register_builtin_root_device("ptmx", ptmx)
+            .expect("DevFS: Failed to register /dev/ptmx");
     }
 
     fn register_builtin_root_device<T: DeviceINode + 'static>(
@@ -214,172 +285,134 @@ impl DevFS {
         let dev_root = self.root_inode.clone();
         device.set_fs(dev_root.0.lock().fs.clone());
         device.set_parent(Arc::downgrade(&dev_root));
-        dev_root.add_dev(name, device)
+        let device_inode: Arc<dyn IndexNode> = device;
+        dev_root.add_dev_or_same(name, device_inode.clone())?;
+        self.remember_device_node(device_inode)?;
+        Ok(())
+    }
+
+    fn remember_device_node(&self, device: Arc<dyn IndexNode>) -> Result<(), SystemError> {
+        let metadata = device.metadata()?;
+        let raw_dev = metadata.raw_dev;
+        if raw_dev != DeviceNumber::default() {
+            let Some(key) = DeviceIndexKey::from_file_type(metadata.file_type, raw_dev) else {
+                return Ok(());
+            };
+
+            let mut devices = self.device_by_devnum.lock();
+            let entries = devices.entry(key).or_default();
+            if !entries
+                .iter()
+                .any(|registered| Arc::ptr_eq(registered, &device))
+            {
+                entries.push(device);
+            }
+        }
+        Ok(())
+    }
+
+    fn forget_device_node_if_same(&self, device: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
+        let metadata = device.metadata()?;
+        let raw_dev = metadata.raw_dev;
+        if raw_dev == DeviceNumber::default() {
+            return Ok(());
+        }
+        let Some(key) = DeviceIndexKey::from_file_type(metadata.file_type, raw_dev) else {
+            return Ok(());
+        };
+
+        let mut devices = self.device_by_devnum.lock();
+        if let Some(entries) = devices.get_mut(&key) {
+            entries.retain(|registered| !Arc::ptr_eq(registered, device));
+            if entries.is_empty() {
+                devices.remove(&key);
+            }
+        }
+        Ok(())
+    }
+
+    fn lookup_device_by_devnum(
+        &self,
+        file_type: FileType,
+        dev_t: DeviceNumber,
+    ) -> Option<Arc<dyn IndexNode>> {
+        let key = DeviceIndexKey::from_file_type(file_type, dev_t)?;
+        self.device_by_devnum
+            .lock()
+            .get(&key)
+            .and_then(|entries| entries.first().cloned())
     }
 
     /// @brief 在devfs内注册设备
     ///
     /// @param name 设备名称
     /// @param device 设备节点的结构体
-    pub fn register_device<T: DeviceINode>(
+    pub fn register_device<T: DeviceINode + 'static>(
         &self,
         name: &str,
         device: Arc<T>,
     ) -> Result<(), SystemError> {
+        self.register_device_dyn(name, device).map(|_| ())
+    }
+
+    /// @brief 在devfs内注册一个动态设备节点
+    ///
+    /// 该接口用于设备核心层从 `Arc<dyn Device>` 动态转换后注册节点。
+    pub fn register_device_dyn(
+        &self,
+        name: &str,
+        device: Arc<dyn DeviceINode>,
+    ) -> Result<bool, SystemError> {
+        let _guard = self.operation_lock.lock();
         let dev_root_inode = self.root_inode.clone();
         let metadata = device.metadata()?;
-        match metadata.file_type {
-            // 字节设备挂载在 /dev/char
-            FileType::CharDevice => {
-                // 对 ptmx 使用符号链接至 devpts 内部节点，避免重复注册字符设备。
-                if name == "ptmx" {
-                    dev_root_inode.add_dev_symlink("pts/ptmx", name)?;
-                    return Ok(());
-                }
-
-                if dev_root_inode.find("char").is_err() {
-                    dev_root_inode.create(
-                        "char",
-                        FileType::Dir,
-                        InodeMode::from_bits_truncate(0o755),
-                    )?;
-                }
-
-                let any_char_inode = dev_root_inode.find("char")?;
-                let dev_char_inode = any_char_inode.downcast_arc::<LockedDevFSInode>().unwrap();
-
-                device.set_fs(dev_root_inode.0.lock().fs.clone());
-                device.set_parent(Arc::downgrade(&dev_root_inode));
-                // 特殊处理 tty 设备，挂载在 /dev 下
-                if Self::char_device_uses_root(name) {
-                    dev_root_inode.add_dev(name, device.clone())?;
-                } else {
-                    // 在 /dev/char 下创建设备节点
-                    dev_char_inode.add_dev(name, device.clone())?;
-                    device.set_parent(Arc::downgrade(&dev_char_inode));
-                }
-            }
-            FileType::BlockDevice => {
-                if dev_root_inode.find("block").is_err() {
-                    dev_root_inode.create(
-                        "block",
-                        FileType::Dir,
-                        InodeMode::from_bits_truncate(0o755),
-                    )?;
-                }
-
-                let any_block_inode = dev_root_inode.find("block")?;
-                let dev_block_inode = any_block_inode.downcast_arc::<LockedDevFSInode>().unwrap();
-
-                // default parent is dev_root_inode
-                device.set_parent(Arc::downgrade(&dev_root_inode));
-                device.set_fs(dev_root_inode.0.lock().fs.clone());
-
-                if Self::block_device_uses_root(name) {
-                    // 部分块设备挂载在 /dev 下
-                    dev_root_inode.add_dev(name, device.clone())?;
-                    if name.starts_with("vd") && name.len() > 2 {
-                        let path = format!("/dev/{}", name);
-                        let symlink_name = device
-                            .as_any_ref()
-                            .downcast_ref::<GenDisk>()
-                            .unwrap()
-                            .symlink_name();
-
-                        dev_block_inode.add_dev_symlink(&path, &symlink_name)?;
-                    }
-                } else {
-                    dev_block_inode.add_dev(name, device.clone())?;
-                    device.set_parent(Arc::downgrade(&dev_block_inode));
-                }
-            }
-            FileType::KvmDevice | FileType::FramebufferDevice => {
-                dev_root_inode
-                    .add_dev(name, device.clone())
-                    .unwrap_or_else(|_| panic!("DevFS: Failed to register /dev/{}", name));
-
-                // default parent is dev_root_inode
-                device.set_parent(Arc::downgrade(&dev_root_inode));
-                device.set_fs(dev_root_inode.0.lock().fs.clone());
-            }
-            _ => {
-                return Err(SystemError::ENOSYS);
-            }
+        if !matches!(
+            metadata.file_type,
+            FileType::CharDevice
+                | FileType::BlockDevice
+                | FileType::KvmDevice
+                | FileType::FramebufferDevice
+        ) {
+            return Err(SystemError::ENOSYS);
         }
-        return Ok(());
+
+        let path = DevNodePath::parse(name)?;
+        let parent = dev_root_inode.ensure_kernel_parent_dir(&path)?;
+        device.set_fs(parent.0.lock().fs.clone());
+        device.set_parent(Arc::downgrade(&parent));
+        let device_inode: Arc<dyn IndexNode> = device;
+        let inserted = parent.add_dev_or_same(path.basename.as_ref(), device_inode.clone())?;
+        self.remember_device_node(device_inode)?;
+        Ok(inserted)
     }
 
     /// @brief 卸载设备
-    pub fn unregister_device<T: DeviceINode>(
+    pub fn unregister_device<T: DeviceINode + 'static>(
         &self,
         name: &str,
         device: Arc<T>,
     ) -> Result<(), SystemError> {
+        self.unregister_device_dyn(name, device)
+    }
+
+    /// @brief 卸载一个动态设备节点
+    pub fn unregister_device_dyn(
+        &self,
+        name: &str,
+        device: Arc<dyn DeviceINode>,
+    ) -> Result<(), SystemError> {
+        let _guard = self.operation_lock.lock();
         let dev_root_inode: Arc<LockedDevFSInode> = self.root_inode.clone();
         let expected: Arc<dyn IndexNode> = device.clone();
-        match device.metadata().unwrap().file_type {
-            // 字节设备挂载在 /dev/char
-            FileType::CharDevice => {
-                if Self::char_device_uses_root(name) {
-                    if name == "ptmx" {
-                        dev_root_inode.remove_kernel_managed_if_exists(name)?;
-                    } else {
-                        dev_root_inode.remove_if_same(name, &expected)?;
-                    }
-                } else {
-                    if dev_root_inode.find("char").is_err() {
-                        return Err(SystemError::ENOENT);
-                    }
+        self.forget_device_node_if_same(&expected)?;
+        let path = DevNodePath::parse(name)?;
+        let Some(parent) = dev_root_inode.find_parent_dir_if_exists(&path)? else {
+            return Ok(());
+        };
 
-                    let any_char_inode = dev_root_inode.find("char")?;
-                    let dev_char_inode = any_char_inode
-                        .as_any_ref()
-                        .downcast_ref::<LockedDevFSInode>()
-                        .unwrap();
-                    // TODO： 调用设备的卸载接口（当引入卸载接口之后）
-                    dev_char_inode.remove_if_same(name, &expected)?;
-                }
-            }
-            FileType::BlockDevice => {
-                if Self::block_device_uses_root(name) {
-                    if name.starts_with("vd") && name.len() > 2 {
-                        if dev_root_inode.find("block").is_err() {
-                            return Err(SystemError::ENOENT);
-                        }
-
-                        let any_block_inode = dev_root_inode.find("block")?;
-                        let dev_block_inode = any_block_inode
-                            .as_any_ref()
-                            .downcast_ref::<LockedDevFSInode>()
-                            .unwrap();
-                        let symlink_name = device
-                            .as_any_ref()
-                            .downcast_ref::<GenDisk>()
-                            .unwrap()
-                            .symlink_name();
-                        dev_block_inode.remove_kernel_managed_if_exists(&symlink_name)?;
-                    }
-                    dev_root_inode.remove_if_same(name, &expected)?;
-                } else {
-                    if dev_root_inode.find("block").is_err() {
-                        return Err(SystemError::ENOENT);
-                    }
-
-                    let any_block_inode = dev_root_inode.find("block")?;
-                    let dev_block_inode = any_block_inode
-                        .as_any_ref()
-                        .downcast_ref::<LockedDevFSInode>()
-                        .unwrap();
-
-                    dev_block_inode.remove_if_same(name, &expected)?;
-                }
-            }
-            _ => {
-                return Err(SystemError::ENOSYS);
-            }
-        }
-
-        return Ok(());
+        parent.remove_if_same(path.basename.as_ref(), &expected)?;
+        dev_root_inode.prune_kernel_dirs(&path)?;
+        Ok(())
     }
 }
 
@@ -450,38 +483,132 @@ impl DevFSInode {
 }
 
 impl LockedDevFSInode {
-    pub fn add_dir(&self, name: &str) -> Result<(), SystemError> {
-        let guard: MutexGuard<DevFSInode> = self.0.lock();
-
-        if guard.children.contains_key(&DName::from(name)) {
-            return Err(SystemError::EEXIST);
-        }
-
-        match self.do_create_with_data(
-            guard,
-            name,
-            FileType::Dir,
-            InodeMode::from_bits_truncate(0o755),
-            0,
-        ) {
-            Ok(inode) => inode,
-            Err(err) => {
-                return Err(err);
-            }
-        };
-
-        return Ok(());
-    }
-
-    pub fn add_dev(&self, name: &str, dev: Arc<dyn IndexNode>) -> Result<(), SystemError> {
+    fn add_dev_or_same(&self, name: &str, dev: Arc<dyn IndexNode>) -> Result<bool, SystemError> {
         let mut this = self.0.lock();
         let name = DName::from(name);
-        if this.children.contains_key(&name) {
+        if let Some(existing) = this.children.get(&name) {
+            if Arc::ptr_eq(existing, &dev) {
+                return Ok(false);
+            }
             return Err(SystemError::EEXIST);
         }
 
         this.children.insert(name, dev);
-        return Ok(());
+        return Ok(true);
+    }
+
+    fn ensure_kernel_parent_dir(
+        &self,
+        path: &DevNodePath,
+    ) -> Result<Arc<LockedDevFSInode>, SystemError> {
+        let mut current = self.0.lock().self_ref.upgrade().ok_or(SystemError::EIO)?;
+
+        for component in &path.dirs {
+            let next = match current.find(component.as_ref()) {
+                Ok(inode) => inode
+                    .downcast_arc::<LockedDevFSInode>()
+                    .ok_or(SystemError::ENOTDIR)?,
+                Err(SystemError::ENOENT) => {
+                    let inode = current.create_with_data(
+                        component.as_ref(),
+                        FileType::Dir,
+                        InodeMode::from_bits_truncate(0o755),
+                        0,
+                    )?;
+                    let inode = inode
+                        .downcast_arc::<LockedDevFSInode>()
+                        .ok_or(SystemError::EIO)?;
+                    inode.0.lock().kernel_managed = true;
+                    inode
+                }
+                Err(e) => return Err(e),
+            };
+
+            if next.metadata()?.file_type != FileType::Dir {
+                return Err(SystemError::ENOTDIR);
+            }
+            current = next;
+        }
+
+        Ok(current)
+    }
+
+    fn find_parent_dir_if_exists(
+        &self,
+        path: &DevNodePath,
+    ) -> Result<Option<Arc<LockedDevFSInode>>, SystemError> {
+        let mut current = self.0.lock().self_ref.upgrade().ok_or(SystemError::EIO)?;
+
+        for component in &path.dirs {
+            let inode = match current.find(component.as_ref()) {
+                Ok(inode) => inode,
+                Err(SystemError::ENOENT) => return Ok(None),
+                Err(e) => return Err(e),
+            };
+
+            let Some(next) = inode.downcast_arc::<LockedDevFSInode>() else {
+                return Ok(None);
+            };
+            if next.metadata()?.file_type != FileType::Dir {
+                return Ok(None);
+            }
+            current = next;
+        }
+
+        Ok(Some(current))
+    }
+
+    fn remove_kernel_dir_if_empty(&self, name: &DName) -> Result<bool, SystemError> {
+        let child = {
+            let inode = self.0.lock();
+            inode.children.get(name).cloned()
+        };
+
+        let Some(child) = child else {
+            return Ok(false);
+        };
+        let Some(child) = child.as_any_ref().downcast_ref::<LockedDevFSInode>() else {
+            return Ok(false);
+        };
+
+        let should_remove = {
+            let child = child.0.lock();
+            child.kernel_managed
+                && child.metadata.file_type == FileType::Dir
+                && child.children.is_empty()
+        };
+        if !should_remove {
+            return Ok(false);
+        }
+
+        self.0.lock().children.remove(name);
+        Ok(true)
+    }
+
+    fn prune_kernel_dirs(&self, path: &DevNodePath) -> Result<(), SystemError> {
+        let mut current = self.0.lock().self_ref.upgrade().ok_or(SystemError::EIO)?;
+        let mut chain: Vec<(Arc<LockedDevFSInode>, DName)> = Vec::new();
+
+        for component in &path.dirs {
+            let inode = match current.find(component.as_ref()) {
+                Ok(inode) => inode,
+                Err(SystemError::ENOENT) => return Ok(()),
+                Err(e) => return Err(e),
+            };
+            let Some(next) = inode.downcast_arc::<LockedDevFSInode>() else {
+                return Ok(());
+            };
+            chain.push((current.clone(), component.clone()));
+            current = next;
+        }
+
+        for (parent, name) in chain.into_iter().rev() {
+            if !parent.remove_kernel_dir_if_empty(&name)? {
+                break;
+            }
+        }
+
+        Ok(())
     }
 
     /// # 在devfs中添加一个符号链接
@@ -508,23 +635,6 @@ impl LockedDevFSInode {
             .children
             .get(&dname)
             .is_some_and(|child| Arc::ptr_eq(child, expected));
-
-        if should_remove {
-            inode.children.remove(&dname);
-        }
-
-        Ok(())
-    }
-
-    fn remove_kernel_managed_if_exists(&self, name: &str) -> Result<(), SystemError> {
-        let mut inode = self.0.lock();
-        let dname = DName::from(name);
-        let should_remove = inode.children.get(&dname).is_some_and(|child| {
-            child
-                .as_any_ref()
-                .downcast_ref::<LockedDevFSInode>()
-                .is_some_and(|child| child.0.lock().kernel_managed)
-        });
 
         if should_remove {
             inode.children.remove(&dname);
@@ -889,20 +999,37 @@ impl IndexNode for LockedDevFSInode {
         }
 
         // 判断需要创建的类型
-        let file_type = if mode.contains(InodeMode::S_IFCHR) {
-            FileType::CharDevice
-        } else if mode.contains(InodeMode::S_IFBLK) {
-            FileType::BlockDevice
-        } else if mode.contains(InodeMode::S_IFIFO) {
-            FileType::Pipe
-        } else {
-            return Err(SystemError::EINVAL);
+        let file_type = match FileType::from(mode) {
+            FileType::CharDevice => FileType::CharDevice,
+            FileType::BlockDevice => FileType::BlockDevice,
+            FileType::Pipe => FileType::Pipe,
+            _ => return Err(SystemError::EINVAL),
         };
 
         drop(inode);
         self.create_with_data(filename, file_type, mode, dev_t.data() as usize)
     }
 }
+
+impl MountableFileSystem for DevFS {
+    fn make_mount_data(
+        raw_data: Option<&str>,
+        _source: &str,
+    ) -> Result<Option<Arc<dyn FileSystemMakerData + 'static>>, SystemError> {
+        if raw_data.is_some_and(|raw| !raw.trim().is_empty()) {
+            return Err(SystemError::EINVAL);
+        }
+        Ok(None)
+    }
+
+    fn make_fs(
+        _data: Option<&dyn FileSystemMakerData>,
+    ) -> Result<Arc<dyn FileSystem + 'static>, SystemError> {
+        Ok(devfs_global_instance())
+    }
+}
+
+register_mountable_fs!(DevFS, DEVTMPFSMAKER, "devtmpfs");
 
 /// @brief 所有的设备INode都需要额外实现这个trait
 pub trait DeviceINode: IndexNode {
@@ -917,69 +1044,65 @@ pub trait DeviceINode: IndexNode {
     // TODO: 增加 unregister 方法
 }
 
-/// @brief 获取devfs实例的强类型不可变引用
-macro_rules! devfs_exact_ref {
-    () => {{
-        let devfs_inode: Result<Arc<dyn IndexNode>, SystemError> =
-            crate::process::ProcessManager::current_mntns()
-                .root_inode()
-                .find("dev");
-        if let Err(e) = devfs_inode {
-            error!("failed to get DevFS ref. errcode = {:?}", e);
-            return Err(SystemError::ENOENT);
-        }
-
-        let binding = devfs_inode.unwrap();
-        let devfs_inode: &LockedDevFSInode = binding
-            .as_any_ref()
-            .downcast_ref::<LockedDevFSInode>()
-            .unwrap();
-        let binding = devfs_inode.fs();
-        binding
-    }
-    .as_any_ref()
-    .downcast_ref::<DevFS>()
-    .unwrap()};
-}
 /// @brief devfs的设备注册函数
-pub fn devfs_register<T: DeviceINode>(name: &str, device: Arc<T>) -> Result<(), SystemError> {
-    return devfs_exact_ref!().register_device(name, device);
+pub fn devfs_register<T: DeviceINode + 'static>(
+    name: &str,
+    device: Arc<T>,
+) -> Result<(), SystemError> {
+    return devfs_global_instance().register_device(name, device);
+}
+
+/// @brief devfs的动态设备卸载函数
+pub fn devfs_unregister_dyn(name: &str, device: Arc<dyn DeviceINode>) -> Result<(), SystemError> {
+    return devfs_global_instance().unregister_device_dyn(name, device);
+}
+
+/// @brief devfs的动态设备创建函数，返回本次调用是否真实插入目录项
+pub fn devfs_create_node_dyn(
+    name: &str,
+    device: Arc<dyn DeviceINode>,
+) -> Result<bool, SystemError> {
+    return devfs_global_instance().register_device_dyn(name, device);
 }
 
 /// 在 /dev 下创建符号链接
 #[allow(dead_code)]
 pub fn devfs_add_symlink(link_name: &str, target: &str) -> Result<(), SystemError> {
-    let dev_inode = ProcessManager::current_mntns()
-        .root_inode()
-        .find("dev")
-        .map_err(|_| SystemError::ENOENT)?;
-    let dev_inode = dev_inode
-        .downcast_arc::<LockedDevFSInode>()
-        .ok_or(SystemError::ENOENT)?;
-    dev_inode.add_dev_symlink(target, link_name)
+    devfs_global_instance()
+        .root_inode
+        .add_dev_symlink(target, link_name)
 }
 
 /// @brief devfs的设备卸载函数
 #[allow(dead_code)]
 pub fn devfs_unregister<T: DeviceINode>(name: &str, device: Arc<T>) -> Result<(), SystemError> {
-    return devfs_exact_ref!().unregister_device(name, device);
+    return devfs_global_instance().unregister_device(name, device);
+}
+
+pub fn devfs_lookup_device_by_devnum(
+    file_type: FileType,
+    dev_t: DeviceNumber,
+) -> Option<Arc<dyn IndexNode>> {
+    devfs_global_instance().lookup_device_by_devnum(file_type, dev_t)
 }
 
 pub fn devfs_init() -> Result<(), SystemError> {
-    static INIT: Once = Once::new();
-    let mut result = None;
-    INIT.call_once(|| {
-        info!("Initializing DevFS...");
-        // 创建 devfs 实例
-        let devfs: Arc<DevFS> = DevFS::new();
+    info!("Initializing devtmpfs...");
+    let devfs = devfs_global_instance();
+    static MOUNT_INIT: Once = Once::new();
+    let mut result = Ok(());
+    MOUNT_INIT.call_once(|| {
         // devfs 挂载
         let root_inode = ProcessManager::current_mntns().root_inode();
-        root_inode
+        if let Err(e) = root_inode
             .mkdir("dev", InodeMode::from_bits_truncate(0o755))
             .expect("Unabled to find /dev")
-            .mount(devfs, MountFlags::empty())
-            .expect("Failed to mount at /dev");
-        info!("DevFS mounted.");
+            .mount(devfs.clone(), MountFlags::empty())
+        {
+            result = Err(e);
+            return;
+        }
+        info!("devtmpfs mounted.");
         // 挂载 /dev/shm 为 tmpfs，符合 linux 语义
         if let Ok(dev_inode) = ProcessManager::current_mntns().root_inode().find("dev") {
             let shm_inode = dev_inode
@@ -1004,8 +1127,8 @@ pub fn devfs_init() -> Result<(), SystemError> {
             warn!("Cannot find /dev mountpoint for /dev/shm");
         }
 
-        result = Some(Ok(()));
+        result = Ok(());
     });
 
-    return result.unwrap();
+    return result;
 }

--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -355,9 +355,10 @@ impl DevFS {
         self.register_device_dyn(name, device).map(|_| ())
     }
 
-    /// @brief 在devfs内注册一个动态设备节点
+    /// @brief Register a dynamic device node in devfs
     ///
-    /// 该接口用于设备核心层从 `Arc<dyn Device>` 动态转换后注册节点。
+    /// This interface is used by the device core layer to register a node after
+    /// dynamic conversion from `Arc<dyn Device>`.
     pub fn register_device_dyn(
         &self,
         name: &str,
@@ -395,7 +396,7 @@ impl DevFS {
         self.unregister_device_dyn(name, device)
     }
 
-    /// @brief 卸载一个动态设备节点
+    /// @brief Unregister a dynamic device node
     pub fn unregister_device_dyn(
         &self,
         name: &str,
@@ -1003,6 +1004,7 @@ impl IndexNode for LockedDevFSInode {
             FileType::CharDevice => FileType::CharDevice,
             FileType::BlockDevice => FileType::BlockDevice,
             FileType::Pipe => FileType::Pipe,
+            FileType::Socket => FileType::Socket,
             _ => return Err(SystemError::EINVAL),
         };
 
@@ -1044,7 +1046,7 @@ pub trait DeviceINode: IndexNode {
     // TODO: 增加 unregister 方法
 }
 
-/// @brief devfs的设备注册函数
+/// @brief devfs device registration function
 pub fn devfs_register<T: DeviceINode + 'static>(
     name: &str,
     device: Arc<T>,
@@ -1052,12 +1054,12 @@ pub fn devfs_register<T: DeviceINode + 'static>(
     return devfs_global_instance().register_device(name, device);
 }
 
-/// @brief devfs的动态设备卸载函数
+/// @brief devfs dynamic device unregistration function
 pub fn devfs_unregister_dyn(name: &str, device: Arc<dyn DeviceINode>) -> Result<(), SystemError> {
     return devfs_global_instance().unregister_device_dyn(name, device);
 }
 
-/// @brief devfs的动态设备创建函数，返回本次调用是否真实插入目录项
+/// @brief devfs dynamic device creation function; returns whether this call actually inserted a directory entry
 pub fn devfs_create_node_dyn(
     name: &str,
     device: Arc<dyn DeviceINode>,

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -656,7 +656,8 @@ impl IndexNode for LockedExt4Inode {
         mode: InodeMode,
         dev_t: DeviceNumber,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
-        if mode.contains(InodeMode::S_IFREG) {
+        let file_type = vfs::FileType::from(mode);
+        if file_type == vfs::FileType::File {
             return self.create(filename, vfs::FileType::File, mode);
         }
 
@@ -672,7 +673,10 @@ impl IndexNode for LockedExt4Inode {
         let file_mode = another_ext4::InodeMode::from_bits_truncate(mode.bits() as u16);
 
         // Create inode based on file type
-        let id = if mode.contains(InodeMode::S_IFCHR) || mode.contains(InodeMode::S_IFBLK) {
+        let id = if matches!(
+            file_type,
+            vfs::FileType::CharDevice | vfs::FileType::BlockDevice
+        ) {
             // Character/block device: use mknod to store device number in i_block
             ext4.mknod(
                 inode_num,

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -2314,8 +2314,9 @@ impl IndexNode for LockedFATInode {
             .umask();
         let final_mode = mode & !umask;
 
+        let file_type = FileType::from(final_mode);
         // 判断需要创建的类型
-        if unlikely(final_mode.contains(InodeMode::S_IFREG)) {
+        if unlikely(file_type == FileType::File) {
             // 普通文件
             drop(inode);
             return self.create(filename, FileType::File, mode);
@@ -2329,7 +2330,7 @@ impl IndexNode for LockedFATInode {
             FATDirEntry::File(FATFile::default()),
         );
 
-        if final_mode.contains(InodeMode::S_IFIFO) {
+        if file_type == FileType::Pipe {
             nod.0.lock().metadata.file_type = FileType::Pipe;
             // 创建pipe文件
             let pipe_inode = LockedPipeInode::new();
@@ -2337,10 +2338,10 @@ impl IndexNode for LockedFATInode {
             pipe_inode.set_fifo();
             // 设置special_node
             nod.0.lock().special_node = Some(SpecialNodeData::Pipe(pipe_inode));
-        } else if final_mode.contains(InodeMode::S_IFBLK) {
+        } else if file_type == FileType::BlockDevice {
             nod.0.lock().metadata.file_type = FileType::BlockDevice;
             unimplemented!()
-        } else if final_mode.contains(InodeMode::S_IFCHR) {
+        } else if file_type == FileType::CharDevice {
             nod.0.lock().metadata.file_type = FileType::CharDevice;
             unimplemented!()
         } else {

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -2338,6 +2338,8 @@ impl IndexNode for LockedFATInode {
             pipe_inode.set_fifo();
             // 设置special_node
             nod.0.lock().special_node = Some(SpecialNodeData::Pipe(pipe_inode));
+        } else if file_type == FileType::Socket {
+            nod.0.lock().metadata.file_type = FileType::Socket;
         } else if file_type == FileType::BlockDevice {
             nod.0.lock().metadata.file_type = FileType::BlockDevice;
             unimplemented!()

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -676,6 +676,7 @@ impl IndexNode for LockedRamFSInode {
             FileType::Pipe => FileType::Pipe,
             FileType::CharDevice => FileType::CharDevice,
             FileType::BlockDevice => FileType::BlockDevice,
+            FileType::Socket => FileType::Socket,
             _ => return Err(SystemError::EINVAL),
         };
 

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -663,7 +663,8 @@ impl IndexNode for LockedRamFSInode {
         }
 
         // Regular file: delegate to create(), must drop lock first to avoid deadlock
-        if unlikely(mode.contains(InodeMode::S_IFREG)) {
+        let file_type = FileType::from(mode);
+        if unlikely(file_type == FileType::File) {
             drop(inode);
             return self.create(filename, FileType::File, mode);
         }
@@ -671,14 +672,11 @@ impl IndexNode for LockedRamFSInode {
         let filename = DName::from(filename);
 
         // Determine file type from mode
-        let file_type = if mode.contains(InodeMode::S_IFIFO) {
-            FileType::Pipe
-        } else if mode.contains(InodeMode::S_IFCHR) {
-            FileType::CharDevice
-        } else if mode.contains(InodeMode::S_IFBLK) {
-            FileType::BlockDevice
-        } else {
-            FileType::File
+        let file_type = match file_type {
+            FileType::Pipe => FileType::Pipe,
+            FileType::CharDevice => FileType::CharDevice,
+            FileType::BlockDevice => FileType::BlockDevice,
+            _ => return Err(SystemError::EINVAL),
         };
 
         let nod = Arc::new(LockedRamFSInode(Mutex::new(RamFSInode {

--- a/kernel/src/filesystem/sysfs/symlink.rs
+++ b/kernel/src/filesystem/sysfs/symlink.rs
@@ -3,6 +3,7 @@ use alloc::{
     string::{String, ToString},
     sync::Arc,
 };
+use log::warn;
 use system_error::SystemError;
 
 use crate::{driver::base::kobject::KObject, filesystem::kernfs::KernFSInode};
@@ -38,8 +39,22 @@ impl SysFS {
     ///
     ///
     /// 参考：https://code.dragonos.org.cn/xref/linux-6.1.9/fs/sysfs/symlink.c#143
-    pub fn remove_link(&self, _kobj: &Arc<dyn KObject>, _name: String) {
-        todo!("sysfs remove link")
+    pub fn remove_link(&self, kobj: &Arc<dyn KObject>, name: String) {
+        let Some(parent) = kobj.inode() else {
+            return;
+        };
+
+        match parent.remove(&name) {
+            Ok(()) | Err(SystemError::ENOENT) => {}
+            Err(err) => {
+                warn!(
+                    "sysfs: failed to remove symlink '{}' under '{}': {:?}",
+                    name,
+                    kobj.name(),
+                    err
+                );
+            }
+        }
     }
 
     fn do_create_link(

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -1178,6 +1178,7 @@ impl IndexNode for LockedTmpfsInode {
             FileType::Pipe => FileType::Pipe,
             FileType::CharDevice => FileType::CharDevice,
             FileType::BlockDevice => FileType::BlockDevice,
+            FileType::Socket => FileType::Socket,
             _ => return Err(SystemError::EINVAL),
         };
 

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -1163,7 +1163,8 @@ impl IndexNode for LockedTmpfsInode {
             return Err(SystemError::ENOTDIR);
         }
 
-        if unlikely(mode.contains(InodeMode::S_IFREG)) {
+        let file_type = FileType::from(mode);
+        if unlikely(file_type == FileType::File) {
             // Regular file creation must not recurse while holding the directory lock,
             // otherwise self.create() will try to lock the same Mutex and deadlock.
             drop(inode);
@@ -1173,14 +1174,11 @@ impl IndexNode for LockedTmpfsInode {
         let filename = DName::from(filename);
 
         // 确定文件类型
-        let file_type = if mode.contains(InodeMode::S_IFIFO) {
-            FileType::Pipe
-        } else if mode.contains(InodeMode::S_IFCHR) {
-            FileType::CharDevice
-        } else if mode.contains(InodeMode::S_IFBLK) {
-            FileType::BlockDevice
-        } else {
-            FileType::File
+        let file_type = match file_type {
+            FileType::Pipe => FileType::Pipe,
+            FileType::CharDevice => FileType::CharDevice,
+            FileType::BlockDevice => FileType::BlockDevice,
+            _ => return Err(SystemError::EINVAL),
         };
 
         let nod = Arc::new(LockedTmpfsInode(Mutex::new(TmpfsInode {

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -20,11 +20,16 @@ use crate::{
         tty::tty_device::TtyFilePrivateData,
     },
     filesystem::{
+        devfs::{devfs_lookup_device_by_devnum, LockedDevFSInode},
         epoll::{event_poll::EPollPrivateData, EPollItem},
+        ext4::inode::LockedExt4Inode,
+        fat::fs::LockedFATInode,
         fuse::private_data::FuseFilePrivateData,
         kernfs::callback::KernFilePrivateData,
         page_cache::PageCache,
         procfs::ProcfsFilePrivateData,
+        ramfs::LockedRamFSInode,
+        tmpfs::LockedTmpfsInode,
         vfs::FilldirContext,
     },
     ipc::{kill::send_signal_to_pid, pipe::PipeFsPrivateData},
@@ -69,6 +74,53 @@ fn canonical_inode_for_posix_lock(mut inode: Arc<dyn IndexNode>) -> Arc<dyn Inde
             None => return inode,
         }
     }
+}
+
+fn is_plain_special_inode(inode: &Arc<dyn IndexNode>) -> bool {
+    inode
+        .as_any_ref()
+        .downcast_ref::<LockedDevFSInode>()
+        .is_some()
+        || inode
+            .as_any_ref()
+            .downcast_ref::<LockedTmpfsInode>()
+            .is_some()
+        || inode
+            .as_any_ref()
+            .downcast_ref::<LockedRamFSInode>()
+            .is_some()
+        || inode
+            .as_any_ref()
+            .downcast_ref::<LockedExt4Inode>()
+            .is_some()
+        || inode
+            .as_any_ref()
+            .downcast_ref::<LockedFATInode>()
+            .is_some()
+}
+
+fn resolve_device_special_inode(
+    inode: Arc<dyn IndexNode>,
+    file_type: FileType,
+) -> Result<Arc<dyn IndexNode>, SystemError> {
+    if !matches!(file_type, FileType::CharDevice | FileType::BlockDevice) {
+        return Ok(inode);
+    }
+
+    let raw_dev = inode.metadata()?.raw_dev;
+    if raw_dev == Default::default() {
+        return Ok(inode);
+    }
+
+    if is_plain_special_inode(&inode) {
+        if let Some(device_inode) = devfs_lookup_device_by_devnum(file_type, raw_dev) {
+            return Ok(device_inode);
+        }
+
+        return Err(SystemError::ENXIO);
+    }
+
+    Ok(inode)
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -661,11 +713,12 @@ impl File {
         private_data_init: FilePrivateData,
     ) -> Result<Self, SystemError> {
         let mut inode = inode;
-        let file_type = inode.metadata()?.file_type;
+        let mut file_type = inode.metadata()?.file_type;
         // 检查是否为命名管道（FIFO）
         let is_named_pipe = if file_type == FileType::Pipe {
             if let Some(SpecialNodeData::Pipe(pipe_inode)) = inode.special_node() {
                 inode = pipe_inode;
+                file_type = inode.metadata()?.file_type;
                 true
             } else {
                 false
@@ -677,6 +730,10 @@ impl File {
         // 对于命名管道，自动添加 O_LARGEFILE 标志（符合 Linux 行为）
         if is_named_pipe {
             flags.insert(FileFlags::O_LARGEFILE);
+        }
+
+        if !flags.contains(FileFlags::O_PATH) {
+            inode = resolve_device_special_inode(inode, file_type)?;
         }
 
         let metadata = inode.metadata()?;

--- a/user/apps/tests/dunitest/suites/normal/devfs_ptmx_unlink.cc
+++ b/user/apps/tests/dunitest/suites/normal/devfs_ptmx_unlink.cc
@@ -4,9 +4,8 @@
 #include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
-
-#include <string>
 
 namespace {
 
@@ -14,14 +13,8 @@ constexpr const char* kDevPtmx = "/dev/ptmx";
 constexpr const char* kDevPtsPtmx = "/dev/pts/ptmx";
 constexpr const char* kScratchLink = "/dev/dunitest_devfs_unlink_link";
 
-std::string readlink_string(const char* path) {
-    char buf[256];
-    ssize_t len = readlink(path, buf, sizeof(buf) - 1);
-    if (len < 0) {
-        return {};
-    }
-    buf[len] = '\0';
-    return std::string(buf, static_cast<size_t>(len));
+bool is_ptmx_char_device(const struct stat& st) {
+    return S_ISCHR(st.st_mode) && major(st.st_rdev) == 5 && minor(st.st_rdev) == 2;
 }
 
 void expect_open_ptmx(const char* path) {
@@ -38,10 +31,8 @@ public:
         struct stat st = {};
         existed_ = lstat(kDevPtmx, &st) == 0;
         if (existed_) {
-            was_symlink_ = S_ISLNK(st.st_mode);
-            if (was_symlink_) {
-                target_ = readlink_string(kDevPtmx);
-            }
+            mode_ = st.st_mode;
+            rdev_ = st.st_rdev;
         }
     }
 
@@ -49,14 +40,11 @@ public:
         restore();
     }
 
-    void require_original_symlink() const {
+    void require_original_ptmx() const {
         ASSERT_TRUE(existed_) << "/dev/ptmx must exist before this test";
-        ASSERT_TRUE(was_symlink_) << "/dev/ptmx must be a symlink before this test";
-        ASSERT_FALSE(target_.empty()) << "failed to capture original /dev/ptmx target";
-    }
-
-    const std::string& target() const {
-        return target_;
+        ASSERT_TRUE(S_ISCHR(mode_)) << "/dev/ptmx must be a character device before this test";
+        ASSERT_EQ(5u, major(rdev_)) << "/dev/ptmx major mismatch";
+        ASSERT_EQ(2u, minor(rdev_)) << "/dev/ptmx minor mismatch";
     }
 
     void restore() const {
@@ -65,20 +53,20 @@ public:
         }
 
         unlink(kDevPtmx);
-        if (existed_ && was_symlink_ && !target_.empty()) {
-            int ret = symlink(target_.c_str(), kDevPtmx);
+        if (existed_) {
+            int ret = mknod(kDevPtmx, (mode_ & 07777) | S_IFCHR, rdev_);
             (void)ret;
         }
     }
 
 private:
     bool can_restore() const {
-        return !existed_ || (was_symlink_ && !target_.empty());
+        return !existed_ || S_ISCHR(mode_);
     }
 
     bool existed_ = false;
-    bool was_symlink_ = false;
-    std::string target_;
+    mode_t mode_ = 0;
+    dev_t rdev_ = 0;
 };
 
 void remove_scratch_link() {
@@ -100,8 +88,9 @@ public:
 
 TEST(DevfsPtmxUnlink, UnlinkDevPtmxRemovesOnlyDevfsEntry) {
     DevPtmxRestorer restorer;
-    restorer.require_original_symlink();
+    restorer.require_original_ptmx();
 
+    expect_open_ptmx(kDevPtmx);
     expect_open_ptmx(kDevPtsPtmx);
 
     ASSERT_EQ(0, unlink(kDevPtmx)) << "unlink(/dev/ptmx) failed: errno=" << errno << " ("
@@ -116,34 +105,37 @@ TEST(DevfsPtmxUnlink, UnlinkDevPtmxRemovesOnlyDevfsEntry) {
     expect_open_ptmx(kDevPtsPtmx);
 
     restorer.restore();
-    ASSERT_EQ(restorer.target(), readlink_string(kDevPtmx));
+    ASSERT_EQ(0, lstat(kDevPtmx, &st)) << "lstat(/dev/ptmx) failed after restore: errno="
+                                      << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(is_ptmx_char_device(st)) << "/dev/ptmx should be restored as c 5:2";
     expect_open_ptmx(kDevPtmx);
 }
 
-TEST(DevfsPtmxUnlink, RecreateDevPtmxSymlinkAfterUnlink) {
+TEST(DevfsPtmxUnlink, RecreateDevPtmxSpecialNodeAfterUnlink) {
     DevPtmxRestorer restorer;
-    restorer.require_original_symlink();
+    restorer.require_original_ptmx();
 
-    ASSERT_EQ(-1, symlink(kDevPtsPtmx, kDevPtmx))
-        << "symlink unexpectedly replaced existing /dev/ptmx";
+    ASSERT_EQ(-1, mknod(kDevPtmx, S_IFCHR | 0666, makedev(5, 2)))
+        << "mknod unexpectedly replaced existing /dev/ptmx";
     ASSERT_EQ(EEXIST, errno) << "unexpected errno for existing /dev/ptmx: " << strerror(errno);
 
     ASSERT_EQ(0, unlink(kDevPtmx)) << "unlink(/dev/ptmx) failed: errno=" << errno << " ("
                                   << strerror(errno) << ")";
-    ASSERT_EQ(0, symlink(kDevPtsPtmx, kDevPtmx))
-        << "symlink(/dev/pts/ptmx, /dev/ptmx) failed: errno=" << errno << " ("
+    ASSERT_EQ(0, mknod(kDevPtmx, S_IFCHR | 0666, makedev(5, 2)))
+        << "mknod(/dev/ptmx) failed: errno=" << errno << " ("
         << strerror(errno) << ")";
 
     struct stat st = {};
     ASSERT_EQ(0, lstat(kDevPtmx, &st)) << "lstat(/dev/ptmx) failed: errno=" << errno << " ("
                                       << strerror(errno) << ")";
-    ASSERT_TRUE(S_ISLNK(st.st_mode)) << "/dev/ptmx should be a symlink";
-    ASSERT_EQ(std::string(kDevPtsPtmx), readlink_string(kDevPtmx));
+    ASSERT_TRUE(is_ptmx_char_device(st)) << "/dev/ptmx should be c 5:2";
 
     expect_open_ptmx(kDevPtmx);
 
     restorer.restore();
-    ASSERT_EQ(restorer.target(), readlink_string(kDevPtmx));
+    ASSERT_EQ(0, lstat(kDevPtmx, &st)) << "lstat(/dev/ptmx) failed after restore: errno="
+                                      << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(is_ptmx_char_device(st)) << "/dev/ptmx should be restored as c 5:2";
     expect_open_ptmx(kDevPtmx);
 }
 

--- a/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
@@ -1,0 +1,253 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+constexpr long kTmpfsMagic = 0x01021994;
+constexpr const char* kMountPoint = "/tmp/dunitest-devtmpfs-mnt";
+constexpr const char* kTmpfsMountPoint = "/tmp/dunitest-tmpfs-special-mnt";
+
+std::string ReadLink(const char* path) {
+    char buf[256];
+    ssize_t len = readlink(path, buf, sizeof(buf) - 1);
+    if (len < 0) {
+        return {};
+    }
+    buf[len] = '\0';
+    return std::string(buf, static_cast<size_t>(len));
+}
+
+bool ProcMountsHasDevtmpfsAt(const std::string& path) {
+    std::ifstream in("/proc/self/mounts");
+    std::string source;
+    std::string target;
+    std::string fstype;
+    while (in >> source >> target >> fstype) {
+        std::string rest;
+        std::getline(in, rest);
+        if (target == path && fstype == "devtmpfs") {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool MountInfoHasDevtmpfsAt(const std::string& path) {
+    std::ifstream in("/proc/self/mountinfo");
+    std::string line;
+    while (std::getline(in, line)) {
+        std::istringstream iss(line);
+        std::string field;
+        for (int i = 0; i < 4; ++i) {
+            if (!(iss >> field)) {
+                return false;
+            }
+        }
+
+        std::string mount_point;
+        if (!(iss >> mount_point)) {
+            return false;
+        }
+        while (iss >> field && field != "-") {
+        }
+        std::string fstype;
+        if (iss >> fstype) {
+            if (mount_point == path && fstype == "devtmpfs") {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void ExpectCharDeviceNumber(const char* path, unsigned int major_num, unsigned int minor_num) {
+    struct stat st = {};
+    ASSERT_EQ(0, stat(path, &st)) << "stat(" << path << ") failed: errno=" << errno << " ("
+                                  << strerror(errno) << ")";
+    EXPECT_TRUE(S_ISCHR(st.st_mode)) << path << " is not a character device";
+    EXPECT_EQ(major_num, major(st.st_rdev)) << path << " major mismatch";
+    EXPECT_EQ(minor_num, minor(st.st_rdev)) << path << " minor mismatch";
+    EXPECT_EQ(0u, st.st_uid) << path << " uid mismatch";
+    EXPECT_EQ(0u, st.st_gid) << path << " gid mismatch";
+}
+
+void ExpectReadZeros(const char* path) {
+    int fd = open(path, O_RDONLY);
+    ASSERT_GE(fd, 0) << "open(" << path << ") failed: errno=" << errno << " ("
+                     << strerror(errno) << ")";
+
+    char buf[8];
+    memset(buf, 0x7f, sizeof(buf));
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(buf)), read(fd, buf, sizeof(buf)))
+        << "read(" << path << ") failed: errno=" << errno << " (" << strerror(errno) << ")";
+    for (char c : buf) {
+        EXPECT_EQ(0, c);
+    }
+    EXPECT_EQ(0, close(fd));
+}
+
+void EnsureMountPoint(const char* mount_point = kMountPoint) {
+    mkdir("/tmp", 0777);
+    umount(mount_point);
+    mkdir(mount_point, 0755);
+}
+
+}  // namespace
+
+TEST(DevtmpfsSemantics, DevMountExportsLinuxTypeAndStatfs) {
+    struct statfs st = {};
+    ASSERT_EQ(0, statfs("/dev", &st)) << "statfs(/dev) failed: errno=" << errno << " ("
+                                      << strerror(errno) << ")";
+    EXPECT_EQ(kTmpfsMagic, st.f_type);
+    EXPECT_EQ(255, st.f_namelen);
+    EXPECT_GT(st.f_bsize, 0);
+
+    EXPECT_TRUE(ProcMountsHasDevtmpfsAt("/dev"));
+    EXPECT_TRUE(MountInfoHasDevtmpfsAt("/dev"));
+}
+
+TEST(DevtmpfsSemantics, BuiltinDeviceNumbersAndLinks) {
+    ExpectCharDeviceNumber("/dev/null", 1, 3);
+    ExpectCharDeviceNumber("/dev/zero", 1, 5);
+    ExpectCharDeviceNumber("/dev/full", 1, 7);
+    ExpectCharDeviceNumber("/dev/random", 1, 8);
+    ExpectCharDeviceNumber("/dev/urandom", 1, 9);
+    ExpectCharDeviceNumber("/dev/ptmx", 5, 2);
+
+    EXPECT_EQ("/proc/self/fd", ReadLink("/dev/fd"));
+    ExpectReadZeros("/dev/zero");
+}
+
+TEST(DevtmpfsSemantics, PublicMountReusesKernelInstance) {
+    EnsureMountPoint();
+    ASSERT_EQ(0, mount("devtmpfs", kMountPoint, "devtmpfs", 0, nullptr))
+        << "mount(devtmpfs) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    struct statfs st = {};
+    EXPECT_EQ(0, statfs(kMountPoint, &st)) << strerror(errno);
+    EXPECT_EQ(kTmpfsMagic, st.f_type);
+    EXPECT_TRUE(ProcMountsHasDevtmpfsAt(kMountPoint));
+    EXPECT_TRUE(MountInfoHasDevtmpfsAt(kMountPoint));
+
+    std::string mounted_null = std::string(kMountPoint) + "/null";
+    std::string mounted_zero = std::string(kMountPoint) + "/zero";
+    ExpectCharDeviceNumber(mounted_null.c_str(), 1, 3);
+    ExpectCharDeviceNumber(mounted_zero.c_str(), 1, 5);
+    ExpectReadZeros(mounted_zero.c_str());
+
+    ASSERT_EQ(0, umount(kMountPoint)) << "umount(" << kMountPoint << ") failed: errno=" << errno
+                                      << " (" << strerror(errno) << ")";
+}
+
+TEST(DevtmpfsSemantics, ManualMknodResolvesRegisteredDeviceNumber) {
+    EnsureMountPoint();
+    ASSERT_EQ(0, mount("devtmpfs", kMountPoint, "devtmpfs", 0, nullptr))
+        << "mount(devtmpfs) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    std::string manual_zero = std::string(kMountPoint) + "/manual-zero";
+    unlink(manual_zero.c_str());
+    ASSERT_EQ(0, mknod(manual_zero.c_str(), S_IFCHR | 0600, makedev(1, 5)))
+        << "mknod(" << manual_zero << ") failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+    ExpectCharDeviceNumber(manual_zero.c_str(), 1, 5);
+    ExpectReadZeros(manual_zero.c_str());
+
+    std::string block_zero = std::string(kMountPoint) + "/block-zero";
+    unlink(block_zero.c_str());
+    ASSERT_EQ(0, mknod(block_zero.c_str(), S_IFBLK | 0600, makedev(1, 5)))
+        << "mknod(" << block_zero << ") failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+    errno = 0;
+    int block_fd = open(block_zero.c_str(), O_RDONLY);
+    EXPECT_EQ(-1, block_fd);
+    EXPECT_EQ(ENXIO, errno);
+    if (block_fd >= 0) {
+        close(block_fd);
+    }
+
+    std::string missing = std::string(kMountPoint) + "/manual-missing";
+    unlink(missing.c_str());
+    ASSERT_EQ(0, mknod(missing.c_str(), S_IFCHR | 0600, makedev(250, 250)))
+        << "mknod(" << missing << ") failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    errno = 0;
+    int fd = open(missing.c_str(), O_RDONLY);
+    EXPECT_EQ(-1, fd);
+    EXPECT_EQ(ENXIO, errno);
+    if (fd >= 0) {
+        close(fd);
+    }
+
+    unlink(manual_zero.c_str());
+    unlink(block_zero.c_str());
+    unlink(missing.c_str());
+    ASSERT_EQ(0, umount(kMountPoint)) << "umount(" << kMountPoint << ") failed: errno=" << errno
+                                      << " (" << strerror(errno) << ")";
+}
+
+TEST(DevtmpfsSemantics, TmpfsManualMknodUsesRegisteredDeviceNumber) {
+    EnsureMountPoint(kTmpfsMountPoint);
+    ASSERT_EQ(0, mount("tmpfs", kTmpfsMountPoint, "tmpfs", 0, "mode=0755"))
+        << "mount(tmpfs) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    std::string manual_zero = std::string(kTmpfsMountPoint) + "/manual-zero";
+    unlink(manual_zero.c_str());
+    ASSERT_EQ(0, mknod(manual_zero.c_str(), S_IFCHR | 0600, makedev(1, 5)))
+        << "mknod(" << manual_zero << ") failed: errno=" << errno << " (" << strerror(errno)
+        << ")";
+    ExpectCharDeviceNumber(manual_zero.c_str(), 1, 5);
+    ExpectReadZeros(manual_zero.c_str());
+
+    std::string missing = std::string(kTmpfsMountPoint) + "/manual-missing";
+    unlink(missing.c_str());
+    ASSERT_EQ(0, mknod(missing.c_str(), S_IFCHR | 0600, makedev(250, 250)))
+        << "mknod(" << missing << ") failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    errno = 0;
+    int fd = open(missing.c_str(), O_RDONLY);
+    EXPECT_EQ(-1, fd);
+    EXPECT_EQ(ENXIO, errno);
+    if (fd >= 0) {
+        close(fd);
+    }
+
+    unlink(manual_zero.c_str());
+    unlink(missing.c_str());
+    ASSERT_EQ(0, umount(kTmpfsMountPoint))
+        << "umount(" << kTmpfsMountPoint << ") failed: errno=" << errno << " ("
+        << strerror(errno) << ")";
+}
+
+TEST(DevtmpfsSemantics, RejectsUnsupportedMountDataWithoutPollutingDev) {
+    struct stat before = {};
+    ASSERT_EQ(0, stat("/dev", &before)) << strerror(errno);
+
+    EnsureMountPoint();
+    errno = 0;
+    EXPECT_EQ(-1, mount("devtmpfs", kMountPoint, "devtmpfs", 0, "badopt=1"));
+    EXPECT_EQ(EINVAL, errno);
+
+    struct stat after = {};
+    ASSERT_EQ(0, stat("/dev", &after)) << strerror(errno);
+    EXPECT_EQ(before.st_mode, after.st_mode);
+    EXPECT_EQ(before.st_uid, after.st_uid);
+    EXPECT_EQ(before.st_gid, after.st_gid);
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/mknod_socket.cc
+++ b/user/apps/tests/dunitest/suites/normal/mknod_socket.cc
@@ -1,0 +1,88 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+class TempDir {
+  public:
+    explicit TempDir(const char *prefix) {
+        char tmpl[128];
+        snprintf(tmpl, sizeof(tmpl), "/tmp/%s-%d-XXXXXX", prefix, getpid());
+        char *created = mkdtemp(tmpl);
+        if (created != nullptr) {
+            path_ = created;
+        }
+    }
+
+    ~TempDir() {
+        if (!path_.empty()) {
+            std::string node = path_ + "/sock";
+            unlink(node.c_str());
+            rmdir(path_.c_str());
+        }
+    }
+
+    const std::string &path() const { return path_; }
+
+  private:
+    std::string path_;
+};
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd) : fd_(fd) {}
+    ~FdGuard() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    int get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+} // namespace
+
+TEST(MknodSocket, CreatesDisconnectedPathnameSocketNode) {
+    TempDir dir("dunitest-mknod-socket");
+    ASSERT_FALSE(dir.path().empty()) << "mkdtemp failed: " << strerror(errno);
+
+    std::string socket_path = dir.path() + "/sock";
+    ASSERT_EQ(0, mknod(socket_path.c_str(), S_IFSOCK | 0600, 0))
+        << "mknod(S_IFSOCK) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    struct stat st {};
+    ASSERT_EQ(0, lstat(socket_path.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISSOCK(st.st_mode));
+    EXPECT_EQ(static_cast<mode_t>(0600), st.st_mode & 0777);
+
+    ASSERT_EQ(-1, open(socket_path.c_str(), O_RDONLY));
+    EXPECT_EQ(ENXIO, errno);
+
+    FdGuard sock(socket(AF_UNIX, SOCK_SEQPACKET, 0));
+    ASSERT_GE(sock.get(), 0) << "socket(AF_UNIX, SOCK_SEQPACKET) failed: " << strerror(errno);
+
+    struct sockaddr_un addr {};
+    addr.sun_family = AF_UNIX;
+    snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", socket_path.c_str());
+
+    ASSERT_EQ(-1, connect(sock.get(), reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)));
+    EXPECT_EQ(ECONNREFUSED, errno);
+}
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -47,4 +47,5 @@ normal/seccomp
 normal/process_signal_fork
 normal/sysfs_cgroup2_mount
 normal/devfs_ptmx_unlink
+normal/devtmpfs_semantics
 normal/pmem_block

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -48,4 +48,5 @@ normal/process_signal_fork
 normal/sysfs_cgroup2_mount
 normal/devfs_ptmx_unlink
 normal/devtmpfs_semantics
+normal/mknod_socket
 normal/pmem_block


### PR DESCRIPTION
## Summary
- expose devfs as Linux-style devtmpfs with singleton public mounts, Linux magic/statfs behavior, built-in nodes, and /dev/ptmx as c 5:2
- add devtmpfs device registration/indexing, VFS special-node resolution by (char/block, dev_t), and safer device unregister/remove hooks
- fix mknod file-type extraction across devfs/tmpfs/ramfs/ext4/fat and add focused dunitest coverage

## Validation
- make fmt
- make kernel
- ROOTFS_MANIFEST=ubuntu2404 SKIP_GRUB=1 make write_diskimage
- ROOTFS_MANIFEST=ubuntu2404 make qemu-nographic
- ubuntu2404 guest: bin/normal/devtmpfs_semantics_test (6/6 passed)
- ubuntu2404 guest: bin/normal/devfs_ptmx_unlink_test (4/4 passed)
- ubuntu2404 guest: bin/normal/devpts_dir_read_test (1/1 passed)

Notes: env.mk and docs are intentionally excluded from this PR.