### PR TITLE
refactor(dunitest): streamline test suite build process and integrate 

### DIFF
--- a/user/apps/tests/dunitest/Makefile
+++ b/user/apps/tests/dunitest/Makefile
@@ -18,6 +18,7 @@ RUNNER_DIR = runner
 RUNNER_BIN = $(RUNNER_DIR)/target/$(RUST_TARGET)/release/dunitest-runner
 RESULTS_DIR = results
 BIN_DIR = bin
+BUILD_DIR = build
 
 # 要编译的测试套件目录列表（suites/ 下的子目录名）
 SUITES = demo normal fuse
@@ -26,6 +27,7 @@ GTEST_ROOT = third_party/googletest
 GTEST_REPO = https://git.mirrors.dragonos.org.cn/DragonOS-Community/googletest
 GTEST_TAG = v1.17.0
 GTEST_SRC = $(GTEST_ROOT)/googletest/src/gtest-all.cc
+GTEST_OBJ = $(BUILD_DIR)/gtest/gtest-all.o
 GTEST_TMP_ROOT = $(GTEST_ROOT).tmp
 CXX ?= g++
 CXXFLAGS ?= -Wall -O2 -std=c++17 -pthread
@@ -57,10 +59,15 @@ $(GTEST_SRC):
 
 build-suites: $(TEST_BINS)
 
-$(BIN_DIR)/%_test: suites/%.cc $(GTEST_SRC)
+$(GTEST_OBJ): $(GTEST_SRC)
+	@mkdir -p "$(dir $@)"
+	@echo "编译 googletest: $(GTEST_SRC) -> $@"
+	@$(CXX) $(CXXFLAGS) $(GTEST_INCLUDES) -c "$(GTEST_SRC)" -o "$@"
+
+$(BIN_DIR)/%_test: suites/%.cc $(GTEST_OBJ)
 	@mkdir -p "$(dir $@)"
 	@echo "编译测例: $< -> $@"
-	@$(CXX) $(CXXFLAGS) $(GTEST_INCLUDES) "$<" $(GTEST_SRC) -o "$@"
+	@$(CXX) $(CXXFLAGS) $(GTEST_INCLUDES) "$<" $(GTEST_OBJ) -o "$@"
 
 run: build
 	@$(RUNNER_BIN) --bin-dir $(BIN_DIR) --results-dir $(RESULTS_DIR)
@@ -83,7 +90,7 @@ install: build
 	@echo "安装完成"
 
 clean:
-	@rm -rf $(RESULTS_DIR) install $(BIN_DIR)
+	@rm -rf $(RESULTS_DIR) install $(BIN_DIR) $(BUILD_DIR)
 	@cd $(RUNNER_DIR) && cargo clean
 
 fmt:

--- a/user/apps/tests/dunitest/default.nix
+++ b/user/apps/tests/dunitest/default.nix
@@ -26,8 +26,6 @@ let
     sha256 = "sha256-HIHMxAUR4bjmFLoltJeIAVSulVQ6kVuIT2Ku+lwAx/4=";
   };
 
-  suites = [ "demo" "normal" "fuse" ];
-
   # 1. Build the Rust runner separately
   # This ensures that changes to test scripts or data don't trigger a Rust rebuild.
   runner = rustPlatform.buildRustPackage {
@@ -61,6 +59,7 @@ let
     src = lib.sourceByRegex ./. [
       "^suites$"
       "^suites/.*"
+      "^Makefile$"
       "^whitelist\\.txt$"
       "^scripts$"
       "^scripts/run_tests\\.sh$"
@@ -73,17 +72,10 @@ let
     buildPhase = ''
       runHook preBuild
 
-      for suite in ${lib.concatStringsSep " " suites}; do
-        mkdir -p bin/$suite
-        for f in suites/$suite/*.cc; do
-          name=$(basename "$f" .cc)
-          echo "编译测例: $f -> bin/$suite/''${name}_test"
-          $CXX -Wall -O2 -std=c++17 -pthread \
-            -I${gtest}/googletest -I${gtest}/googletest/include \
-            "$f" ${gtest}/googletest/src/gtest-all.cc \
-            -o bin/$suite/''${name}_test
-        done
-      done
+      make -j"''${NIX_BUILD_CORES:-1}" build-suites \
+        GTEST_ROOT=${gtest} \
+        CXX="$CXX" \
+        CXXFLAGS="-Wall -O2 -std=c++17 -pthread"
 
       runHook postBuild
     '';


### PR DESCRIPTION
- Removed hardcoded suite names from the Nix configuration.
- Updated the build process to utilize a Makefile for compiling test suites and gtest.
- Added a new build directory for gtest object files to improve organization.
- Enhanced the Makefile to handle gtest compilation and test binary generation more efficiently.