### PR TITLE
fix: repair CFS EEVDF runtime accounting

### DIFF
--- a/kernel/src/arch/riscv64/interrupt/handle.rs
+++ b/kernel/src/arch/riscv64/interrupt/handle.rs
@@ -11,6 +11,7 @@ use crate::exception::ebreak::EBreak;
 use crate::{
     arch::syscall::syscall_handler,
     driver::{clocksource::timer_riscv::RiscVSbiTimer, irqchip::riscv_intc::riscv_intc_irq},
+    exception::softirq::do_softirq,
     process::{utils::current_pcb_flags, ProcessFlags, ProcessManager},
     sched::{SchedMode, SchedPolicy, __schedule},
 };
@@ -41,13 +42,18 @@ unsafe extern "C" fn riscv64_do_irq(trap_frame: &mut TrapFrame) {
     if trap_frame.cause.is_interrupt() {
         crate::rcu::irq_enter();
         riscv64_do_interrupt(trap_frame);
+        let irq_outermost = crate::rcu::irq_is_outermost();
+        if irq_outermost {
+            do_softirq();
+        }
+
         let should_schedule = current_pcb_flags().contains(ProcessFlags::NEED_SCHEDULE)
             || trap_frame.cause.code() as u32 == RiscVSbiTimer::TIMER_IRQ.data();
         let resume_idle_eqs = !should_schedule
             && ProcessManager::current_pcb().sched_info().policy() == SchedPolicy::IDLE;
-        crate::rcu::irq_exit(resume_idle_eqs);
+        let irq_exited_outermost = crate::rcu::irq_exit(resume_idle_eqs);
 
-        if should_schedule {
+        if should_schedule && irq_exited_outermost {
             __schedule(SchedMode::SM_PREEMPT);
         }
     } else if trap_frame.cause.is_exception() {

--- a/kernel/src/arch/riscv64/process/mod.rs
+++ b/kernel/src/arch/riscv64/process/mod.rs
@@ -180,29 +180,35 @@ impl ProcessManager {
         //     这样后续 `flush_tlb_mm_range` / `flush_tlb_multi` 才能正确把本 CPU 当成目标。
         // 顺序：clear(prev) -> make_current(next) -> set(next) -> tlb_state_set_loaded_mm(next)
         // 与 x86_64 switch_process 保持一致 (见 kernel/src/arch/x86_64/process/mod.rs:switch_process)。
-        let next_addr_space = next.basic().user_vm().unwrap();
-        let prev_addr_space = prev.basic().user_vm();
+        // 如果 next 没有 user mm，则保留当前 CPU 已加载的 mm，进入 lazy-TLB 模式。
+        let next_addr_space = next.basic().user_vm();
+        let prev_user_vm = prev.basic().user_vm();
+        let prev_active_mm = prev_user_vm
+            .clone()
+            .or_else(crate::mm::tlb::tlb_state_loaded_mm);
         let cpu = crate::smp::core::smp_get_processor_id();
         compiler_fence(Ordering::SeqCst);
 
-        let same_mm = match prev_addr_space.as_ref() {
-            Some(p) => Arc::ptr_eq(p, &next_addr_space),
-            None => false,
+        let same_mm = match (prev_active_mm.as_ref(), next_addr_space.as_ref()) {
+            (Some(p), Some(n)) => Arc::ptr_eq(p, n),
+            _ => false,
         };
 
-        if !same_mm {
-            if let Some(prev_mm) = prev_addr_space.as_ref() {
-                prev_mm.active_cpus_clear(cpu);
+        if let Some(next_mm) = next_addr_space {
+            if !same_mm {
+                if let Some(prev_mm) = prev_active_mm.as_ref() {
+                    prev_mm.active_cpus_clear(cpu);
+                }
             }
-        }
 
-        next_addr_space.make_current();
-        compiler_fence(Ordering::SeqCst);
+            next_mm.make_current();
+            compiler_fence(Ordering::SeqCst);
 
-        if !same_mm {
-            next_addr_space.active_cpus_set(cpu);
+            if !same_mm {
+                next_mm.active_cpus_set(cpu);
+            }
+            unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(next_mm.clone()) };
         }
-        unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(next_addr_space.clone()) };
         compiler_fence(Ordering::SeqCst);
 
         // debug!("current sum={}, prev sum={}, next_sum={}", riscv::register::sstatus::read().sum(), prev.arch_info_irqsave().sstatus.sum(), next.arch_info_irqsave().sstatus.sum());

--- a/kernel/src/arch/riscv64/process/mod.rs
+++ b/kernel/src/arch/riscv64/process/mod.rs
@@ -174,11 +174,11 @@ impl ProcessManager {
         Self::switch_local_context(&prev, &next);
 
         // 切换地址空间（无锁快速路径）
-        // 必须同时维护 mm-aware shootdown 的前置状态：
-        //   - 被切出的 mm：从 active_cpus 里摘掉当前 CPU；
-        //   - 被切入的 mm：在加载 satp 后写入 active_cpus 并更新 per-CPU TlbState.loaded_mm，
-        //     这样后续 `flush_tlb_mm_range` / `flush_tlb_multi` 才能正确把本 CPU 当成目标。
-        // 顺序：clear(prev) -> make_current(next) -> set(next) -> tlb_state_set_loaded_mm(next)
+        // 必须同时维护 mm-aware shootdown 的前置状态。切入新 mm 前先把
+        // 当前 CPU 加入 next active_cpus，加载 satp 后再清 prev active_cpus。
+        // 临时双 membership 只会多发 IPI；反向窗口会让 remote shootdown 漏掉
+        // 已经加载 next mm 的 CPU。
+        // 顺序：set(next) -> make_current(next) -> clear(prev) -> tlb_state_set_loaded_mm(next)
         // 与 x86_64 switch_process 保持一致 (见 kernel/src/arch/x86_64/process/mod.rs:switch_process)。
         // 如果 next 没有 user mm，则保留当前 CPU 已加载的 mm，进入 lazy-TLB 模式。
         let next_addr_space = next.basic().user_vm();
@@ -196,16 +196,16 @@ impl ProcessManager {
 
         if let Some(next_mm) = next_addr_space {
             if !same_mm {
-                if let Some(prev_mm) = prev_active_mm.as_ref() {
-                    prev_mm.active_cpus_clear(cpu);
-                }
+                next_mm.active_cpus_set(cpu);
             }
 
             next_mm.make_current();
             compiler_fence(Ordering::SeqCst);
 
             if !same_mm {
-                next_mm.active_cpus_set(cpu);
+                if let Some(prev_mm) = prev_active_mm.as_ref() {
+                    prev_mm.active_cpus_clear(cpu);
+                }
             }
             unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(next_mm.clone()) };
         }

--- a/kernel/src/arch/x86_64/interrupt/handle.rs
+++ b/kernel/src/arch/x86_64/interrupt/handle.rs
@@ -35,16 +35,19 @@ unsafe extern "C" fn x86_64_do_irq(trap_frame: &mut TrapFrame, vector: u32) {
         CurrentApic.send_eoi();
     }
 
-    do_softirq();
+    let irq_outermost = crate::rcu::irq_is_outermost();
+    if irq_outermost {
+        do_softirq();
+    }
 
     // 检测当前进程是否可被调度
     let should_schedule = current_pcb_flags().contains(ProcessFlags::NEED_SCHEDULE)
         || vector == APIC_TIMER_IRQ_NUM.data();
     let resume_idle_eqs = !should_schedule
         && ProcessManager::current_pcb().sched_info().policy() == SchedPolicy::IDLE;
-    crate::rcu::irq_exit(resume_idle_eqs);
+    let irq_exited_outermost = crate::rcu::irq_exit(resume_idle_eqs);
 
-    if should_schedule {
+    if should_schedule && irq_exited_outermost {
         __schedule(SchedMode::SM_PREEMPT);
     }
 }

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -418,35 +418,40 @@ impl ProcessManager {
         Self::switch_gsbase(&prev, &next);
 
         // 切换地址空间（无锁快速路径）
-        let next_addr_space = next.basic().user_vm().unwrap();
-        let prev_addr_space = prev.basic().user_vm();
+        let next_addr_space = next.basic().user_vm();
+        let prev_user_vm = prev.basic().user_vm();
+        let prev_active_mm = prev_user_vm
+            .clone()
+            .or_else(crate::mm::tlb::tlb_state_loaded_mm);
         let cpu = crate::smp::core::smp_get_processor_id();
         compiler_fence(Ordering::SeqCst);
 
-        // INV-1: clear prev mm's bit before switching hardware page table (if prev/next differ),
+        // INV-1: clear prev mm's bit before switching hardware page table to a different user mm,
         // set next mm's bit after switching.
         // Order: clear(prev) → set CR3 → set(next) → update per-CPU TlbState.
         //
-        // Note: if prev and next point to the same mm (same-address-space thread switch), keep the bit unchanged.
-        let same_mm = match prev_addr_space.as_ref() {
-            Some(p) => Arc::ptr_eq(p, &next_addr_space),
-            None => false,
+        // If next has no user mm, keep the current loaded mm in lazy-TLB mode.
+        let same_mm = match (prev_active_mm.as_ref(), next_addr_space.as_ref()) {
+            (Some(p), Some(n)) => Arc::ptr_eq(p, n),
+            _ => false,
         };
 
-        if !same_mm {
-            if let Some(prev_mm) = prev_addr_space.as_ref() {
-                prev_mm.active_cpus_clear(cpu);
+        if let Some(next_mm) = next_addr_space {
+            if !same_mm {
+                if let Some(prev_mm) = prev_active_mm.as_ref() {
+                    prev_mm.active_cpus_clear(cpu);
+                }
             }
-        }
 
-        next_addr_space.make_current();
-        compiler_fence(Ordering::SeqCst);
+            next_mm.make_current();
+            compiler_fence(Ordering::SeqCst);
 
-        if !same_mm {
-            next_addr_space.active_cpus_set(cpu);
+            if !same_mm {
+                next_mm.active_cpus_set(cpu);
+            }
+            // Update per-CPU TlbState: hardware-loaded mm and generation
+            crate::mm::tlb::tlb_state_set_loaded_mm(next_mm.clone());
         }
-        // Update per-CPU TlbState: hardware-loaded mm and generation
-        crate::mm::tlb::tlb_state_set_loaded_mm(next_addr_space.clone());
         compiler_fence(Ordering::SeqCst);
         // 切换内核栈
 

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -426,9 +426,11 @@ impl ProcessManager {
         let cpu = crate::smp::core::smp_get_processor_id();
         compiler_fence(Ordering::SeqCst);
 
-        // INV-1: clear prev mm's bit before switching hardware page table to a different user mm,
-        // set next mm's bit after switching.
-        // Order: clear(prev) → set CR3 → set(next) → update per-CPU TlbState.
+        // INV-1: before loading a different user mm, mark this CPU active in the
+        // next mm so concurrent remote shootdowns cannot miss the CPU after CR3
+        // changes. Keep the previous bit until after the hardware switch; the
+        // temporary double membership is safe and may only cause an extra IPI.
+        // Order: set(next) → set CR3 → clear(prev) → update per-CPU TlbState.
         //
         // If next has no user mm, keep the current loaded mm in lazy-TLB mode.
         let same_mm = match (prev_active_mm.as_ref(), next_addr_space.as_ref()) {
@@ -438,16 +440,16 @@ impl ProcessManager {
 
         if let Some(next_mm) = next_addr_space {
             if !same_mm {
-                if let Some(prev_mm) = prev_active_mm.as_ref() {
-                    prev_mm.active_cpus_clear(cpu);
-                }
+                next_mm.active_cpus_set(cpu);
             }
 
             next_mm.make_current();
             compiler_fence(Ordering::SeqCst);
 
             if !same_mm {
-                next_mm.active_cpus_set(cpu);
+                if let Some(prev_mm) = prev_active_mm.as_ref() {
+                    prev_mm.active_cpus_clear(cpu);
+                }
             }
             // Update per-CPU TlbState: hardware-loaded mm and generation
             crate::mm::tlb::tlb_state_set_loaded_mm(next_mm.clone());

--- a/kernel/src/driver/irqchip/riscv_intc.rs
+++ b/kernel/src/driver/irqchip/riscv_intc.rs
@@ -11,7 +11,6 @@ use crate::{
         irqdata::IrqData,
         irqdesc::{irq_desc_manager, GenericIrqHandler},
         irqdomain::{irq_domain_manager, IrqDomain, IrqDomainOps},
-        softirq::do_softirq,
         HardwareIrqNumber, IrqNumber,
     },
     libs::spinlock::{SpinLock, SpinLockGuard},
@@ -222,5 +221,4 @@ pub fn riscv_intc_irq(trap_frame: &mut TrapFrame) {
         )
         .ok();
     }
-    do_softirq();
 }

--- a/kernel/src/exception/bottom_half.rs
+++ b/kernel/src/exception/bottom_half.rs
@@ -3,8 +3,10 @@
 //! 目标：提供类似 Linux `local_bh_disable/enable` 与 `*_bh` 锁语义的最小实现。
 //!
 //! ## 设计要点（对齐 Linux，适配 DragonOS 现状）
-//! - DragonOS 当前在硬中断退出路径无条件调用 `do_softirq()`，且 softirq 回调期间会重新打开本地中断。
-//! - 如果进程上下文持有普通自旋锁/读写锁时被中断打断，硬中断退出触发 softirq 再取同一把锁，会发生经典死锁。
+//! - DragonOS 会在最外层 IRQ 退出或 task context BH enable 时补跑 pending softirq，
+//!   且 softirq 回调期间会重新打开本地中断。
+//! - 如果进程上下文持有普通自旋锁/读写锁时被中断打断，IRQ 退出或 BH enable 触发 softirq
+//!   再取同一把锁，会发生经典死锁。
 //! - 因此，我们引入"本 CPU 的 BH 禁用计数"，在 IRQ 退出路径检测到 BH disabled 时跳过 softirq 执行；
 //!   在 BH enable（计数归零）且处于 task context 时补跑 pending softirq。
 //!

--- a/kernel/src/exception/softirq.rs
+++ b/kernel/src/exception/softirq.rs
@@ -188,6 +188,12 @@ impl Softirq {
         }
         // 创建一个RunningCountGuard，当退出作用域时，会自动将cpu_running_count减1
         let _count_guard = RunningCountGuard::new(self.cpu_running_count());
+        // Match Linux softirq context accounting: softirq handlers run with a
+        // non-zero preempt count even though local IRQs may be enabled below.
+        // This prevents a timer IRQ nested inside task-context softirq handling
+        // from scheduling away before the softirq handler returns.
+        ProcessManager::preempt_disable();
+        let _preempt_guard = SoftirqPreemptGuard;
 
         // TODO pcb的flags未修改
         let end = clock() + 500 * 2;
@@ -282,6 +288,14 @@ impl<'a> RunningCountGuard<'a> {
 impl Drop for RunningCountGuard<'_> {
     fn drop(&mut self) {
         self.cpu_running_count.get().fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+struct SoftirqPreemptGuard;
+
+impl Drop for SoftirqPreemptGuard {
+    fn drop(&mut self) {
+        ProcessManager::preempt_enable();
     }
 }
 

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -58,6 +58,7 @@ where
 #[derive(Debug)]
 pub struct FuseRequest {
     pub bytes: Vec<u8>,
+    opcode: u32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -561,6 +562,9 @@ impl FuseConn {
         }
 
         out[..req.bytes.len()].copy_from_slice(&req.bytes);
+        if req.opcode == FUSE_DESTROY {
+            self.abort();
+        }
         Ok(req.bytes.len())
     }
 
@@ -696,7 +700,7 @@ impl FuseConn {
         let mut bytes = Vec::with_capacity(hdr.len as usize);
         bytes.extend_from_slice(fuse_pack_struct(&hdr));
         bytes.extend_from_slice(payload);
-        Arc::new(FuseRequest { bytes })
+        Arc::new(FuseRequest { bytes, opcode })
     }
 
     fn push_request(

--- a/kernel/src/filesystem/procfs/pid/maps.rs
+++ b/kernel/src/filesystem/procfs/pid/maps.rs
@@ -109,8 +109,10 @@ fn generate_maps_content(target: &ProcPidTarget) -> Result<Vec<u8>, SystemError>
     let vm = {
         let basic = target_pcb.basic();
         basic.user_vm()
-    }
-    .ok_or(SystemError::EINVAL)?;
+    };
+    let Some(vm) = vm else {
+        return Ok(Vec::new());
+    };
     let root_prefix = target_pcb
         .fs_struct()
         .root()

--- a/kernel/src/libs/futex/pi_futex.rs
+++ b/kernel/src/libs/futex/pi_futex.rs
@@ -298,6 +298,11 @@ impl Futex {
                 Some(bucket) => bucket,
             };
 
+            bucket
+                .pi_waiters
+                .extract_if(|waiter| waiter.waker.is_closed())
+                .for_each(drop);
+
             if bucket.pi_waiters.is_empty() {
                 if atomic_futex
                     .compare_exchange(uval, owner_died, Ordering::SeqCst, Ordering::SeqCst)

--- a/kernel/src/libs/futex/pi_futex.rs
+++ b/kernel/src/libs/futex/pi_futex.rs
@@ -359,8 +359,6 @@ impl Futex {
     /// - `Err(SystemError::EDEADLK_OR_EDEADLOCK)`: 当前线程已持有该锁
     pub fn futex_trylock_pi(uaddr: VirtAddr, flags: FutexFlag) -> Result<usize, SystemError> {
         let current_tid = ProcessManager::current_pcb().task_pid_vnr().data() as u32;
-
-        // 获取futex key（虽然trylock不会阻塞，但还是需要验证地址）
         let key = Self::get_futex_key(
             uaddr,
             flags.contains(FutexFlag::FLAGS_SHARED),
@@ -369,33 +367,68 @@ impl Futex {
 
         let atomic_futex = unsafe { AtomicU32::from_ptr(uaddr.as_ptr::<u32>()) };
 
-        let uval = atomic_futex.load(Ordering::SeqCst);
-        let owner_tid = uval & FUTEX_TID_MASK;
+        loop {
+            let cur_val = atomic_futex.load(Ordering::SeqCst);
+            let cur_owner = cur_val & FUTEX_TID_MASK;
+            let owner_died = cur_val & FUTEX_OWNER_DIED;
 
-        // 检查死锁
-        if owner_tid == current_tid && owner_tid != 0 {
-            return Err(SystemError::EDEADLK_OR_EDEADLOCK);
-        }
+            if cur_owner == current_tid && cur_owner != 0 {
+                return Err(SystemError::EDEADLK_OR_EDEADLOCK);
+            }
 
-        let owner_died = uval & FUTEX_OWNER_DIED;
+            if cur_owner != 0 {
+                let mut futex_map_guard = FutexData::futex_map();
+                let bucket = futex_map_guard
+                    .entry(key.clone())
+                    .or_insert(FutexHashBucket::new());
+                if bucket.pi_owner == 0 {
+                    bucket.pi_owner = cur_owner;
+                }
+                drop(futex_map_guard);
 
-        if owner_tid == 0 && (uval & FUTEX_WAITERS) == 0 {
+                loop {
+                    let val = atomic_futex.load(Ordering::SeqCst);
+                    let owner = val & FUTEX_TID_MASK;
+                    if owner == 0 {
+                        break;
+                    }
+                    if owner == current_tid {
+                        return Err(SystemError::EDEADLK_OR_EDEADLOCK);
+                    }
+                    if (val & FUTEX_WAITERS) != 0
+                        || atomic_futex
+                            .compare_exchange(
+                                val,
+                                val | FUTEX_WAITERS,
+                                Ordering::SeqCst,
+                                Ordering::SeqCst,
+                            )
+                            .is_ok()
+                    {
+                        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                    }
+                }
+                continue;
+            }
+
             let desired = current_tid | owner_died;
             if atomic_futex
-                .compare_exchange(uval, desired, Ordering::SeqCst, Ordering::SeqCst)
-                .is_ok()
+                .compare_exchange(cur_val, desired, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
             {
-                let mut futex_map_guard = FutexData::futex_map();
-                if let Some(bucket) = futex_map_guard.get_mut(&key) {
-                    bucket.pi_owner = current_tid;
-                }
-                if owner_died != 0 {
-                    return Err(SystemError::EOWNERDEAD);
-                }
-                return Ok(0);
+                continue;
             }
-        }
 
-        Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+            let mut futex_map_guard = FutexData::futex_map();
+            if let Some(bucket) = futex_map_guard.get_mut(&key) {
+                bucket.pi_owner = current_tid;
+            }
+            drop(futex_map_guard);
+
+            if owner_died != 0 {
+                return Err(SystemError::EOWNERDEAD);
+            }
+            return Ok(0);
+        }
     }
 }

--- a/kernel/src/libs/wait_queue.rs
+++ b/kernel/src/libs/wait_queue.rs
@@ -752,6 +752,11 @@ impl Waker {
         self.state.store(Self::STATE_CLOSED, Ordering::Release);
     }
 
+    #[inline]
+    pub fn is_closed(&self) -> bool {
+        self.state.load(Ordering::Acquire) == Self::STATE_CLOSED
+    }
+
     fn consume_notification(&self) -> bool {
         loop {
             let state = self.state.load(Ordering::Acquire);

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -129,6 +129,14 @@ impl TlbState {
     }
 }
 
+/// Return this CPU's hardware-loaded mm tracked by the lazy TLB state.
+///
+/// Context switch uses this when the previous task has already dropped its
+/// user-visible mm but the CPU is still running on an active mm.
+pub fn tlb_state_loaded_mm() -> Option<Arc<AddressSpace>> {
+    tlb_state_local_mut().loaded_mm()
+}
+
 /// Per-CPU CSD (Call Single Data) for synchronous ack during TLB shootdown.
 ///
 /// Currently only serves FlushTLB; not abstracted into a generic `smp_call_function`.

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -342,7 +342,9 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
             //     "de_thread: single-thread fast path pid={:?}",
             //     current.raw_pid()
             // );
-            current.exit_signal.store(Signal::SIGCHLD, Ordering::SeqCst);
+            current
+                .exit_signal
+                .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
             return Ok(());
         }
 
@@ -433,8 +435,10 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
 
             ProcessManager::exchange_tid_and_raw_pids(&current, &leader)?;
 
-            current.exit_signal.store(Signal::SIGCHLD, Ordering::SeqCst);
-            leader.exit_signal.store(Signal::INVALID, Ordering::SeqCst);
+            current
+                .exit_signal
+                .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
+            leader.exit_signal.store(-1, Ordering::SeqCst);
 
             // 将当前线程提升为线程组 leader，并清空 group_tasks（已无其他线程）
             {
@@ -489,7 +493,9 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
                 unsafe { ProcessManager::release(leader.raw_pid()) };
             }
         } else {
-            current.exit_signal.store(Signal::SIGCHLD, Ordering::SeqCst);
+            current
+                .exit_signal
+                .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
         }
 
         Ok(())

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -71,7 +71,7 @@ fn child_matches_wait_options(child_pcb: &Arc<ProcessControlBlock>, options: Wai
     }
 
     let child_exit_signal = child_pcb.exit_signal.load(Ordering::SeqCst);
-    let is_clone_child = child_exit_signal != Signal::SIGCHLD;
+    let is_clone_child = child_exit_signal != Signal::SIGCHLD as i32;
     let wants_clone = options.contains(WaitOption::WCLONE);
 
     // 子进程类型必须与等待选项匹配

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -1036,7 +1036,12 @@ impl ProcessControlBlock {
     }
 
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/exit.c#143
-    pub(super) fn __exit_signal(&mut self) {
+    pub(super) fn __exit_signal(&self) {
+        if self.flags().contains(ProcessFlags::PID_UNHASHED) {
+            return;
+        }
+        self.flags().insert(ProcessFlags::PID_UNHASHED);
+
         let sighand = self.sighand();
         if sighand.flags_contains(SignalFlags::GROUP_EXEC) {
             let this = self.self_ref.upgrade();

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -112,8 +112,13 @@ pub struct KernelCloneArgs {
     pub parent_tid: VirtAddr,
     pub set_tid: Vec<usize>,
 
-    /// 进程退出时发送的信号
-    pub exit_signal: Signal,
+    /// 进程退出时发送给父进程的信号。
+    ///
+    /// Linux 的 task_struct::exit_signal 使用整数语义：
+    /// - -1: 非线程组 leader（CLONE_THREAD），不可被普通 wait 回收；
+    /// - 0: 退出时不发送信号，但仍是可被 __WCLONE 等待的 clone 子进程；
+    /// - >0: 退出时发送对应信号。
+    pub exit_signal: i32,
 
     pub stack: usize,
     // clone3用到
@@ -142,7 +147,7 @@ impl KernelCloneArgs {
             child_tid: null_addr,
             parent_tid: null_addr,
             set_tid: Vec::with_capacity(MAX_PID_NS_LEVEL),
-            exit_signal: Signal::SIGCHLD,
+            exit_signal: Signal::SIGCHLD as i32,
             stack: 0,
             stack_size: 0,
             tls: 0,
@@ -221,14 +226,14 @@ impl KernelCloneArgs {
     ///
     /// ## 规则
     ///
-    /// 1. 如果设置了 CLONE_THREAD，进程是线程组成员，不应发送 exit_signal（设为 INVALID）
+    /// 1. 如果设置了 CLONE_THREAD，进程是线程组成员，不应发送 exit_signal（设为 -1）
     /// 2. 其他情况保持 exit_signal 不变
     ///
     /// 这个方法应该在 do_clone() 之前调用，确保 exit_signal 的语义正确。
     pub fn normalize_exit_signal(&mut self) {
         if self.flags.contains(CloneFlags::CLONE_THREAD) {
-            // 线程组成员不发送 exit_signal
-            self.exit_signal = Signal::INVALID;
+            // 线程组成员不是线程组 leader，Linux 中 exit_signal 为 -1。
+            self.exit_signal = -1;
         }
     }
 }
@@ -255,7 +260,7 @@ impl ProcessManager {
     ) -> Result<RawPid, SystemError> {
         let mut args = KernelCloneArgs::new();
         args.flags = clone_flags;
-        args.exit_signal = Signal::SIGCHLD;
+        args.exit_signal = Signal::SIGCHLD as i32;
         Self::fork_with_args(current_trapframe, args)
     }
 
@@ -776,18 +781,22 @@ impl ProcessManager {
             *pcb.parent_pcb.write_irqsave() = current_pcb.parent_pcb.read_irqsave().clone();
             *pcb.real_parent_pcb.write_irqsave() =
                 current_pcb.real_parent_pcb.read_irqsave().clone();
-            pcb.exit_signal.store(Signal::INVALID, Ordering::SeqCst);
+            pcb.exit_signal.store(-1, Ordering::SeqCst);
         } else {
             if clone_flags.contains(CloneFlags::CLONE_PARENT) {
                 *pcb.parent_pcb.write_irqsave() = current_pcb.parent_pcb.read_irqsave().clone();
                 *pcb.real_parent_pcb.write_irqsave() =
                     current_pcb.real_parent_pcb.read_irqsave().clone();
+                pcb.exit_signal.store(
+                    current_leader.exit_signal.load(Ordering::SeqCst),
+                    Ordering::SeqCst,
+                );
             } else {
                 *pcb.parent_pcb.write_irqsave() = Arc::downgrade(&current_leader);
                 *pcb.real_parent_pcb.write_irqsave() = Arc::downgrade(&current_leader);
+                pcb.exit_signal
+                    .store(clone_args.exit_signal, Ordering::SeqCst);
             }
-            pcb.exit_signal
-                .store(clone_args.exit_signal, Ordering::SeqCst);
 
             if let Some(parent) = pcb.parent_pcb() {
                 let ppid_in_child_ns = parent

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -863,10 +863,14 @@ impl ProcessManager {
             }
             let parent_pcb = r.unwrap();
 
-            // 检查子进程的exit_signal，只有在有效时才发送信号
+            // 检查子进程的 exit_signal，只有在正信号编号时才发送信号。
+            // Linux 语义中 exit_signal=0 表示不发信号但仍可 wait，-1 表示非 leader 线程。
             let exit_signal = current.exit_signal.load(Ordering::SeqCst);
-            if exit_signal != Signal::INVALID {
-                let r = crate::ipc::kill::send_signal_to_pcb(parent_pcb.clone(), exit_signal);
+            if exit_signal > 0 {
+                let r = crate::ipc::kill::send_signal_to_pcb(
+                    parent_pcb.clone(),
+                    Signal::from(exit_signal),
+                );
                 if let Err(e) = r {
                     warn!(
                         "failed to send kill signal to {:?}'s parent pcb {:?}: {:?}",
@@ -1568,8 +1572,11 @@ pub struct ProcessControlBlock {
     /// 退出状态（Running/Zombie/Dead）
     exit_state: AtomicU8,
 
-    /// 退出信号S
-    exit_signal: AtomicSignal,
+    /// Linux task_struct::exit_signal 语义：
+    /// - -1: 非线程组 leader（CLONE_THREAD）；
+    /// - 0: 不发退出信号，但仍是可等待的 clone 子进程；
+    /// - >0: 退出时通知父进程的信号编号。
+    exit_signal: AtomicI32,
     /// 父进程退出时要发送给当前进程的信号（PR_SET_PDEATHSIG）
     pdeath_signal: AtomicSignal,
 
@@ -1753,7 +1760,7 @@ impl ProcessControlBlock {
                 sighand: RcuArcSlot::new(initial_sighand.clone()),
                 sig_altstack: RwLock::new(SigStackArch::new()),
                 exit_state: AtomicU8::new(ExitState::Running as u8),
-                exit_signal: AtomicSignal::new(Signal::SIGCHLD),
+                exit_signal: AtomicI32::new(Signal::SIGCHLD as i32),
                 pdeath_signal: AtomicSignal::new(Signal::INVALID),
 
                 no_new_privs: AtomicBool::new(false),
@@ -2696,7 +2703,7 @@ impl ProcessControlBlock {
     }
 
     pub fn is_thread_group_leader(&self) -> bool {
-        self.exit_signal.load(Ordering::SeqCst) != Signal::INVALID
+        self.exit_signal.load(Ordering::SeqCst) >= 0
     }
 
     /// 唤醒等待在本进程 `wait_queue` 上的所有等待者

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -422,7 +422,7 @@ impl ProcessManager {
         }
 
         // 在 pi_lock 保护下读取状态并决定 sched_contributes_to_load
-        let _pi_guard = pcb.sched_info().pi_lock_irqsave();
+        let pi_guard = pcb.sched_info().pi_lock_irqsave();
         fence(Ordering::SeqCst); // smp_mb__after_spinlock()
         let state = pcb.sched_info().state();
         if !state.is_blocked() {
@@ -438,17 +438,54 @@ impl ProcessManager {
 
         pcb.debug_assert_fork_cpu_binding();
 
-        // TODO: select_task_rq 负载均衡
-        // let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
-        // let allowed = pi_guard.cpus_allowed.clone();
-        // let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
-        let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        let mut schedule_dequeue_race = false;
+        if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
+            if let Some(target_cpu) = pcb.sched_info().on_cpu() {
+                let rq = cpu_rq(target_cpu.data() as usize);
+                let (rq, _rq_guard) = rq.self_lock();
 
-        if pcb.flags().contains(ProcessFlags::IN_IOWAIT) {
-            cpu_rq(target_cpu.data() as usize).dec_nr_iowait();
+                // Linux ttwu_runnable(): a blocked-but-still-queued task has
+                // not yet been dequeued by schedule(). Recheck on_rq under the
+                // target rq lock; if schedule() won the race and dequeued it,
+                // fall through to the full enqueue path below.
+                if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
+                    if !Arc::ptr_eq(&rq.current(), pcb) {
+                        rq.update_rq_clock();
+                        rq.check_preempt_current(pcb, WakeupFlags::WF_TTWU);
+                    }
+                    return Ok(());
+                }
+
+                // DragonOS currently tracks task_cpu, but not Linux's
+                // separate p->on_cpu "still switching out" flag. If schedule()
+                // won the race and just dequeued this task, keep the wakeup on
+                // the previous rq instead of migrating it to another CPU where
+                // the same PCB/kernel stack could run before the old CPU
+                // finishes switch_process().
+                schedule_dequeue_race = true;
+            }
         }
 
-        enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::empty(), was_uninterruptible);
+        let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        let allowed = pi_guard.cpus_allowed.clone();
+        let target_cpu = if schedule_dequeue_race {
+            prev_cpu
+        } else {
+            select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed)
+        };
+
+        if was_uninterruptible || pcb.flags().contains(ProcessFlags::IN_IOWAIT) {
+            let prev_rq = cpu_rq(prev_cpu.data() as usize);
+            let (prev_rq, _prev_rq_guard) = prev_rq.self_lock();
+            if was_uninterruptible {
+                prev_rq.dec_nr_uninterruptible();
+            }
+            if pcb.flags().contains(ProcessFlags::IN_IOWAIT) {
+                prev_rq.dec_nr_iowait();
+            }
+        }
+
+        enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::WF_TTWU, false);
 
         Ok(())
     }
@@ -935,6 +972,31 @@ impl ProcessManager {
                 vd.complete_all();
             }
 
+            // Linux exit_mm() happens before exit_files(): after clear_child_tid
+            // and robust-list cleanup have consumed user memory, the exiting task
+            // must stop exposing a user-visible mm even if file close blocks.
+            //
+            // The CPU-visible active mm is switched to idle here and tracked by
+            // per-CPU TlbState. The PCB-visible user_vm becomes None, matching
+            // Linux task->mm == NULL after exit_mm().
+            let old_user_vm = {
+                let idle_vm = IDLE_PROCESS_ADDRESS_SPACE();
+                let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+                let cpu = smp_get_processor_id();
+                let mut basic = pcb.basic_mut();
+                let old_vm = unsafe { basic.replace_user_vm(None) };
+                idle_vm.active_cpus_set(cpu);
+                unsafe { idle_vm.make_current() };
+                if let Some(old_vm) = old_vm.as_ref() {
+                    old_vm.active_cpus_clear(cpu);
+                }
+                unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(idle_vm) };
+                drop(basic);
+                drop(irq_guard);
+                old_vm
+            };
+            drop(old_user_vm);
+
             pcb.exit_files();
             pcb.exit_timers();
             // TODO 由于未实现进程组，tty记录的前台进程组等于当前进程，故退出前要置空
@@ -970,36 +1032,6 @@ impl ProcessManager {
             // 对标 Linux do_task_dead()：不在此处手动 deactivate_task。
             // 任务仍留在 rq 上，由后续 __schedule() 检测到 Exited 状态后
             // 执行唯一的 deactivate_task，避免双重 dequeue 导致 nr_running 下溢。
-
-            // 注意：exit_files() 可能会触发阻塞（例如关闭 FUSE fd 需要等待 daemon 回复），
-            // 因此不能在它之前清空 user_vm，否则后续调度切换会遇到 user_vm==None 的普通进程并崩溃。
-            //
-            // INV-1: Before releasing the hold on user_vm, clear this CPU from the mm's active_cpus,
-            // otherwise after the mm is freed (Arc count reaches zero) a stale per-CPU cpumask bit
-            // will remain, and subsequent flushes by other threads on the same mm would still target
-            // this CPU and send spurious IPIs.
-            //
-            // Switch this exiting task to the idle address space before dropping the old user mm.
-            // The PCB-visible user_vm becomes None, matching Linux's task->mm == NULL after exit;
-            // the CPU-visible active mm is tracked by the per-CPU TLB state instead.
-            let old_user_vm = {
-                let idle_vm = IDLE_PROCESS_ADDRESS_SPACE();
-                let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-                let cpu = smp_get_processor_id();
-                let mut basic = pcb.basic_mut();
-                let old_vm = unsafe { basic.replace_user_vm(None) };
-                if let Some(old_vm) = old_vm.as_ref() {
-                    old_vm.active_cpus_clear(cpu);
-                }
-                unsafe { idle_vm.make_current() };
-                idle_vm.active_cpus_set(cpu);
-                unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(idle_vm) };
-                drop(basic);
-                drop(irq_guard);
-                old_vm
-            };
-
-            drop(old_user_vm);
 
             let _final_irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
             // 在最后，调用 exit_notify 之前，设置调度状态为 Exited
@@ -1127,6 +1159,7 @@ impl ProcessManager {
         let pcb = ProcessManager::find(pid);
         if let Some(ref pcb) = pcb {
             let parent_child_vpid = pcb.real_parent_pcb().and_then(|parent| {
+                let parent = ProcessManager::thread_group_leader_of(&parent);
                 let parent_ns = parent.active_pid_ns();
                 pcb.task_pid_nr_ns(PidType::PID, Some(parent_ns))
                     .map(|vpid| (parent, vpid))

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -705,14 +705,30 @@ impl ProcessManager {
         // DragonOS 采用异步方式（从发送方上下文停止目标线程），因此需要主动 dequeue
         // 并 kick 远端 CPU。这是与 Linux 的架构差异，但锁序和 dequeue 语义对标。
         let pi_guard = pcb.sched_info().pi_lock_irqsave();
-        if pcb.sched_info().state().is_exited() {
+        let prev_state = pcb.sched_info().state();
+        if prev_state.is_exited() {
             return Err(SystemError::EINTR);
         }
+        let target_cpu = pcb.sched_info().on_cpu().unwrap_or_else(current_cpu_id);
+        let update_clock = target_cpu == smp_get_processor_id();
+        let was_off_rq = *pcb.sched_info().on_rq.lock_irqsave() == OnRq::None;
+        let was_uninterruptible = matches!(prev_state, ProcessState::Blocked(false));
+        let was_iowait = pcb.flags().contains(ProcessFlags::IN_IOWAIT);
+
+        if was_off_rq && (was_uninterruptible || was_iowait) {
+            let prev_rq = cpu_rq(target_cpu.data() as usize);
+            let (prev_rq, _prev_rq_guard) = prev_rq.self_lock();
+            if was_uninterruptible {
+                prev_rq.dec_nr_uninterruptible();
+            }
+            if was_iowait {
+                prev_rq.dec_nr_iowait();
+            }
+        }
+
         pcb.sched_info().set_state(ProcessState::Stopped);
         pcb.flags().insert(ProcessFlags::NEED_SCHEDULE);
 
-        let target_cpu = pcb.sched_info().on_cpu().unwrap_or_else(current_cpu_id);
-        let update_clock = target_cpu == smp_get_processor_id();
         let rq = cpu_rq(target_cpu.data() as usize);
 
         // 锁序 pi_lock → rq_lock，与 wakeup() 一致

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -58,7 +58,7 @@ use crate::{
     },
     mm::{
         percpu::{PerCpu, PerCpuVar},
-        set_IDLE_PROCESS_ADDRESS_SPACE,
+        set_IDLE_PROCESS_ADDRESS_SPACE, IDLE_PROCESS_ADDRESS_SPACE,
         ucontext::AddressSpace,
         PhysAddr, VirtAddr,
     },
@@ -888,8 +888,6 @@ impl ProcessManager {
             }
         }
 
-        // 关中断
-        let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let pid: Arc<Pid>;
         let raw_pid = current_pcb.raw_pid();
         // log::debug!("[exit: {}]", raw_pid.data());
@@ -947,13 +945,6 @@ impl ProcessManager {
             }
             pcb.sig_info_mut().set_tty(None);
 
-            // 在最后，调用 exit_notify 之前，设置调度状态为 Exited
-            // 对标 Linux do_task_dead() 中 set_special_state(TASK_DEAD)：
-            // 在 pi_lock 保护下完成状态写入，序列化与 wakeup() 中 pi_lock 保护的并发唤醒。
-            {
-                let _pi_guard = pcb.sched_info.pi_lock_irqsave();
-                pcb.sched_info.set_state(ProcessState::Exited(exit_code));
-            }
             // Linux 语义：zombie 不应出现在 cgroup.procs 中。
             // 必须持有 cgroup_accounting_lock 以避免与 cgroup.procs 写入死锁
             {
@@ -985,27 +976,45 @@ impl ProcessManager {
             // will remain, and subsequent flushes by other threads on the same mm would still target
             // this CPU and send spurious IPIs.
             //
-            // Note that this CPU's hardware page table still points to this mm, but __schedule will
-            // immediately switch to idle, whose IDLE_PROCESS_ADDRESS_SPACE will re-set this CPU's
-            // active_cpus bit and write the correct per-CPU TlbState. So clearing the old mm's bit
-            // here is sufficient.
-            {
+            // Switch this exiting task to the idle address space before dropping the old user mm.
+            // This mirrors Linux's lazy-TLB exit boundary: the expensive mm teardown runs in a
+            // sleepable context, while the task still has a safe kernel-only mm if it is scheduled
+            // during teardown.
+            let old_user_vm = {
+                let idle_vm = IDLE_PROCESS_ADDRESS_SPACE();
+                let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
                 let cpu = smp_get_processor_id();
-                if let Some(old_vm) = pcb.basic().user_vm() {
+                let mut basic = pcb.basic_mut();
+                let old_vm = unsafe { basic.replace_user_vm(Some(idle_vm.clone())) };
+                unsafe { idle_vm.make_current() };
+                if let Some(old_vm) = old_vm.as_ref() {
                     old_vm.active_cpus_clear(cpu);
                 }
+                idle_vm.active_cpus_set(cpu);
+                unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(idle_vm) };
+                drop(basic);
+                drop(irq_guard);
+                old_vm
+            };
+
+            drop(old_user_vm);
+
+            let _final_irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+            // 在最后，调用 exit_notify 之前，设置调度状态为 Exited
+            // 对标 Linux do_task_dead() 中 set_special_state(TASK_DEAD)：
+            // 在 pi_lock 保护下完成状态写入，序列化与 wakeup() 中 pi_lock 保护的并发唤醒。
+            {
+                let _pi_guard = pcb.sched_info.pi_lock_irqsave();
+                pcb.sched_info.set_state(ProcessState::Exited(exit_code));
             }
-
-            unsafe { pcb.basic_mut().set_user_vm(None) };
-
             ProcessManager::exit_notify(&pcb);
-        }
 
-        __schedule_with_current(SchedMode::SM_NONE, current_pcb);
-        error!("raw_pid {raw_pid:?} exited but sched again!");
-        #[allow(clippy::empty_loop)]
-        loop {
-            spin_loop();
+            __schedule_with_current(SchedMode::SM_NONE, current_pcb);
+            error!("raw_pid {raw_pid:?} exited but sched again!");
+            #[allow(clippy::empty_loop)]
+            loop {
+                spin_loop();
+            }
         }
     }
 
@@ -2792,6 +2801,18 @@ impl ProcessBasicInfo {
 
     pub unsafe fn set_user_vm(&mut self, user_vm: Option<Arc<AddressSpace>>) {
         self.user_vm = user_vm;
+    }
+
+    /// Replace the task's user address space and return the old one without
+    /// dropping it while this lock is still held. The caller must preserve the
+    /// active_cpus and TLB-state ordering required by the mm switch/exit path.
+    pub unsafe fn replace_user_vm(
+        &mut self,
+        user_vm: Option<Arc<AddressSpace>>,
+    ) -> Option<Arc<AddressSpace>> {
+        let old = self.user_vm.take();
+        self.user_vm = user_vm;
+        old
     }
 
     pub fn try_fd_table(&self) -> Option<Arc<RwSem<FileDescriptorVec>>> {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -58,9 +58,9 @@ use crate::{
     },
     mm::{
         percpu::{PerCpu, PerCpuVar},
-        set_IDLE_PROCESS_ADDRESS_SPACE, IDLE_PROCESS_ADDRESS_SPACE,
+        set_IDLE_PROCESS_ADDRESS_SPACE,
         ucontext::AddressSpace,
-        PhysAddr, VirtAddr,
+        PhysAddr, VirtAddr, IDLE_PROCESS_ADDRESS_SPACE,
     },
     process::resource::{RLimit64, RLimitID, RUsage},
     rcu::RcuArcSlot,
@@ -895,6 +895,9 @@ impl ProcessManager {
             let pcb = current_pcb.clone();
             pcb.mark_exiting();
             pid = pcb.pid();
+            if pid.is_child_reaper() {
+                pid.ns_of_pid().disable_pid_allocation();
+            }
             pcb.wait_queue.mark_dead();
 
             // 进行进程退出后的工作
@@ -977,19 +980,18 @@ impl ProcessManager {
             // this CPU and send spurious IPIs.
             //
             // Switch this exiting task to the idle address space before dropping the old user mm.
-            // This mirrors Linux's lazy-TLB exit boundary: the expensive mm teardown runs in a
-            // sleepable context, while the task still has a safe kernel-only mm if it is scheduled
-            // during teardown.
+            // The PCB-visible user_vm becomes None, matching Linux's task->mm == NULL after exit;
+            // the CPU-visible active mm is tracked by the per-CPU TLB state instead.
             let old_user_vm = {
                 let idle_vm = IDLE_PROCESS_ADDRESS_SPACE();
                 let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
                 let cpu = smp_get_processor_id();
                 let mut basic = pcb.basic_mut();
-                let old_vm = unsafe { basic.replace_user_vm(Some(idle_vm.clone())) };
-                unsafe { idle_vm.make_current() };
+                let old_vm = unsafe { basic.replace_user_vm(None) };
                 if let Some(old_vm) = old_vm.as_ref() {
                     old_vm.active_cpus_clear(cpu);
                 }
+                unsafe { idle_vm.make_current() };
                 idle_vm.active_cpus_set(cpu);
                 unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(idle_vm) };
                 drop(basic);
@@ -1124,16 +1126,19 @@ impl ProcessManager {
     pub(super) unsafe fn release(pid: RawPid) {
         let pcb = ProcessManager::find(pid);
         if let Some(ref pcb) = pcb {
+            let parent_child_vpid = pcb.real_parent_pcb().and_then(|parent| {
+                let parent_ns = parent.active_pid_ns();
+                pcb.task_pid_nr_ns(PidType::PID, Some(parent_ns))
+                    .map(|vpid| (parent, vpid))
+            });
+
+            pcb.__exit_signal();
             {
                 let _cgroup_guard = crate::cgroup::cgroup_accounting_lock().lock();
                 pcb.task_cgroup_node().uncharge_pids(1);
             }
             // 从父进程的 children 列表中移除
-            if let Some(parent) = pcb.real_parent_pcb() {
-                let parent_ns = parent.active_pid_ns();
-                let vpid = pcb
-                    .task_pid_nr_ns(PidType::PID, Some(parent_ns))
-                    .unwrap_or(RawPid::new(0));
+            if let Some((parent, vpid)) = parent_child_vpid {
                 let mut children = parent.children.write();
                 children.retain(|&p| p != vpid);
             }
@@ -1414,6 +1419,8 @@ bitflags! {
         const IN_IOWAIT = 1 << 13;
         /// 线程组 exec 期间延迟 PID/TGID/PGID/SID 的 unhash
         const DEFER_UNHASH = 1 << 14;
+        /// PID links and visible-thread accounting have already been released.
+        const PID_UNHASHED = 1 << 15;
     }
 }
 

--- a/kernel/src/process/namespace/pid_namespace.rs
+++ b/kernel/src/process/namespace/pid_namespace.rs
@@ -196,6 +196,10 @@ impl PidNamespace {
         self.inner().child_reaper = Some(child_reaper);
     }
 
+    pub fn disable_pid_allocation(&self) {
+        self.inner().dead = true;
+    }
+
     pub fn parent(&self) -> Option<Arc<PidNamespace>> {
         self.parent.as_ref().and_then(|p| p.upgrade())
     }

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -1,7 +1,6 @@
 use core::intrinsics::unlikely;
 
 use crate::arch::interrupt::TrapFrame;
-use crate::arch::ipc::signal::Signal;
 use crate::arch::ipc::signal::MAX_SIG_NUM;
 use crate::arch::MMArch;
 use crate::mm::{MemoryManagementArch, VirtAddr};
@@ -163,7 +162,7 @@ impl KernelCloneArgs {
         self.pidfd = VirtAddr::new(args.pidfd as usize);
         self.child_tid = VirtAddr::new(args.child_tid as usize);
         self.parent_tid = VirtAddr::new(args.parent_tid as usize);
-        self.exit_signal = Signal::from(args.exit_signal as i32);
+        self.exit_signal = args.exit_signal as i32;
         self.stack = args.stack as usize;
         self.stack_size = args.stack_size as usize;
         self.tls = args.tls as usize;

--- a/kernel/src/process/syscall/sys_clone.rs
+++ b/kernel/src/process/syscall/sys_clone.rs
@@ -3,7 +3,6 @@ use crate::arch::syscall::nr::SYS_CLONE;
 use crate::mm::{access_ok, VirtAddr};
 use crate::process::fork::{CloneFlags, KernelCloneArgs};
 use crate::process::syscall::clone_utils::do_clone;
-use crate::process::Signal;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -60,7 +59,7 @@ impl Syscall for SysClone {
 
         // 旧版 clone() 系统调用中，flags 的低 8 位用于指定 exit_signal
         let exit_signal_num = (args[0] & 0xFF) as i32;
-        clone_args.exit_signal = Signal::from(exit_signal_num);
+        clone_args.exit_signal = exit_signal_num;
 
         do_clone(clone_args, frame)
     }

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -872,13 +872,25 @@ pub fn irq_enter() {
     cpu_state.irq_nesting += 1;
 }
 
-pub fn irq_exit(resume_idle_eqs: bool) {
+/// Returns true when this call exits the outermost IRQ nesting level.
+pub fn irq_is_outermost() -> bool {
     if !rcu_enabled() {
-        return;
+        return true;
     }
 
     let cpu = smp_get_processor_id();
-    let wake_worker = {
+    let inner = RCU_STATE.inner.lock_irqsave();
+    inner.cpu_states[cpu.data() as usize].irq_nesting == 1
+}
+
+/// Returns true when this call exits the outermost IRQ nesting level.
+pub fn irq_exit(resume_idle_eqs: bool) -> bool {
+    if !rcu_enabled() {
+        return true;
+    }
+
+    let cpu = smp_get_processor_id();
+    let (outermost, wake_worker) = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
         let cpu_idx = cpu.data() as usize;
         assert!(
@@ -887,15 +899,15 @@ pub fn irq_exit(resume_idle_eqs: bool) {
         );
         inner.cpu_states[cpu_idx].irq_nesting -= 1;
         if inner.cpu_states[cpu_idx].irq_nesting != 0 {
-            false
+            (false, false)
         } else {
             let resume_idle_eqs = inner.cpu_states[cpu_idx].irq_from_idle_eqs && resume_idle_eqs;
             inner.cpu_states[cpu_idx].irq_from_idle_eqs = false;
             if resume_idle_eqs {
-                enter_cpu_idle_eqs(&mut inner, cpu)
+                (true, enter_cpu_idle_eqs(&mut inner, cpu))
             } else {
                 inner.cpu_states[cpu_idx].in_idle_eqs = false;
-                false
+                (true, false)
             }
         }
     };
@@ -905,6 +917,8 @@ pub fn irq_exit(resume_idle_eqs: bool) {
         RCU_STATE.wake_worker();
         RCU_STATE.maybe_process_ready_callbacks_inline();
     }
+
+    outermost
 }
 
 pub fn cpu_offline(cpu: ProcessorId) {

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -1151,73 +1151,12 @@ impl CfsRunQueue {
     pub fn inner_enqueue_entity(&mut self, se: &Arc<FairSchedEntity>) {
         self.avg_vruntime_add(se);
         self.entities.insert(se.clone());
-        // warn!(
-        //     "enqueue pcb {:?} cfsrq {:?}",
-        //     se.pcb().pid(),
-        //     self.entities
-        //         .iter()
-        //         .map(|x| (x.0, x.1.pcb().pid()))
-        //         .collect::<Vec<_>>()
-        // );
-        // send_to_default_serial8250_port(
-        //     format!(
-        //         "enqueue pcb {:?} cfsrq {:?}\n",
-        //         se.pcb().pid(),
-        //         self.entities
-        //             .iter()
-        //             .map(|x| (x.0, x.1.pcb().pid()))
-        //             .collect::<Vec<_>>()
-        //     )
-        //     .as_bytes(),
-        // );
     }
 
     fn inner_dequeue_entity(&mut self, se: &Arc<FairSchedEntity>) {
-        // warn!(
-        //     "before dequeue pcb {:?} cfsrq {:?}",
-        //     se.pcb().pid(),
-        //     self.entities
-        //         .iter()
-        //         .map(|x| (x.0, x.1.pcb().pid()))
-        //         .collect::<Vec<_>>()
-        // );
-
-        // send_to_default_serial8250_port(
-        //     format!(
-        //         "before dequeue pcb {:?} cfsrq {:?}\n",
-        //         se.pcb().pid(),
-        //         self.entities
-        //             .iter()
-        //             .map(|x| (x.0, x.1.pcb().pid()))
-        //             .collect::<Vec<_>>()
-        //     )
-        //     .as_bytes(),
-        // );
-
         if self.entities.remove(se).is_none() {
             panic!("dequeue entity that is not present in CFS timeline");
         }
-        // send_to_default_serial8250_port(
-        //     format!(
-        //         "after dequeue pcb {:?}(real: {:?}) cfsrq {:?}\n",
-        //         se.pcb().pid(),
-        //         remove.pcb().pid(),
-        //         self.entities
-        //             .iter()
-        //             .map(|x| (x.0, x.1.pcb().pid()))
-        //             .collect::<Vec<_>>()
-        //     )
-        //     .as_bytes(),
-        // );
-        // warn!(
-        //     "after dequeue pcb {:?}(real: {:?}) cfsrq {:?}",
-        //     se.pcb().pid(),
-        //     remove.pcb().pid(),
-        //     self.entities
-        //         .iter()
-        //         .map(|x| (x.0, x.1.pcb().pid()))
-        //         .collect::<Vec<_>>()
-        // );
         self.avg_vruntime_sub(se);
     }
 

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -90,7 +90,10 @@ impl FairSchedEntity {
             my_cfs_rq: None,
             on_rq: OnRq::None,
             slice: SYSCTL_SHCED_BASE_SLICE.load(Ordering::SeqCst),
-            load: Default::default(),
+            load: LoadWeight {
+                weight: LoadWeight::NICE_0_LOAD,
+                inv_weight: 0,
+            },
             deadline: Default::default(),
             min_deadline: Default::default(),
             exec_start: Default::default(),
@@ -182,11 +185,11 @@ impl FairSchedEntity {
     }
 
     pub fn calculate_delta_fair(&self, delta: u64) -> u64 {
-        if unlikely(self.load.weight != LoadWeight::NICE_0_LOAD_SHIFT as u64) {
+        if unlikely(self.load.weight != LoadWeight::NICE_0_LOAD) {
             return self
                 .force_mut()
                 .load
-                .calculate_delta(delta, LoadWeight::NICE_0_LOAD_SHIFT as u64);
+                .calculate_delta(delta, LoadWeight::NICE_0_LOAD);
         };
 
         delta
@@ -518,6 +521,7 @@ impl CfsRunQueue {
         let delta_exec = curr
             .sum_exec_runtime
             .saturating_sub(curr.prev_sum_exec_runtime);
+
         if delta_exec < SYSCTL_SHCED_MIN_GRANULARITY.load(Ordering::SeqCst) {
             return;
         }
@@ -576,6 +580,10 @@ impl CfsRunQueue {
 
         let now = self.rq().clock_task();
         let curr = curr.unwrap();
+        if unlikely(!curr.on_rq()) {
+            self.set_current(Weak::default());
+            return;
+        }
 
         fence(Ordering::SeqCst);
         if unlikely(now <= curr.exec_start) {
@@ -648,10 +656,12 @@ impl CfsRunQueue {
         let curr = self.current();
 
         let mut vruntime = self.min_vruntime;
+        let mut curr_on_rq = false;
 
         if let Some(curr) = curr.as_ref() {
             if curr.on_rq() {
                 vruntime = curr.vruntime;
+                curr_on_rq = true;
             } else {
                 self.set_current(Weak::default());
             }
@@ -659,7 +669,7 @@ impl CfsRunQueue {
 
         // 找到最小虚拟运行时间的调度实体
         if let Some(se) = self.entities.leftmost() {
-            if curr.is_none() {
+            if !curr_on_rq {
                 vruntime = se.vruntime;
             } else {
                 vruntime = vruntime.min(se.vruntime);
@@ -806,6 +816,7 @@ impl CfsRunQueue {
 
     /// 为调度实体计算初始vruntime等信息
     fn place_entity(&mut self, se: Arc<FairSchedEntity>, flags: EnqueueFlag) {
+        let current_entity = self.current();
         let vruntime = self.avg_vruntime();
         let mut lag = 0;
 
@@ -814,14 +825,12 @@ impl CfsRunQueue {
 
         let mut vslice = se.calculate_delta_fair(se.slice);
 
-        if self.nr_running > 0 {
-            let curr = self.current();
-
+        if SCHED_FEATURES.contains(SchedFeature::PLACE_LAG) && self.nr_running > 0 {
             lag = se.vlag;
 
             let mut load = self.avg_load;
 
-            if let Some(curr) = curr {
+            if let Some(curr) = current_entity {
                 if curr.on_rq() {
                     load += LoadWeight::scale_load_down(curr.load.weight) as i64;
                 }
@@ -836,9 +845,11 @@ impl CfsRunQueue {
             lag /= load;
         }
 
-        se.vruntime = vruntime - lag as u64;
+        se.vruntime = vruntime.wrapping_sub(lag as u64);
 
-        if flags.contains(EnqueueFlag::ENQUEUE_INITIAL) {
+        if SCHED_FEATURES.contains(SchedFeature::PLACE_DEADLINE_INITIAL)
+            && flags.contains(EnqueueFlag::ENQUEUE_INITIAL)
+        {
             vslice /= 2;
         }
 
@@ -1071,9 +1082,13 @@ impl CfsRunQueue {
         if se.on_rq() {
             self.inner_dequeue_entity(se);
             self.update_load_avg(se, UpdateAvgFlags::UPDATE_TG);
+            // Match Linux EEVDF: stash the picked deadline in vlag so
+            // RUN_TO_PARITY can keep the selected entity running until it
+            // becomes ineligible or receives a new slice.
             se.force_mut().vlag = se.deadline as i64;
         }
 
+        se.force_mut().exec_start = self.rq().clock_task();
         self.set_current(Arc::downgrade(se));
 
         se.force_mut().prev_sum_exec_runtime = se.sum_exec_runtime;
@@ -1343,6 +1358,14 @@ impl CfsRunQueue {
         &self,
         curr: Option<&Arc<FairSchedEntity>>,
     ) -> Option<Arc<FairSchedEntity>> {
+        if SCHED_FEATURES.contains(SchedFeature::RUN_TO_PARITY) {
+            if let Some(curr) = curr.filter(|se| se.on_rq() && self.entity_eligible(se)) {
+                if curr.vlag == curr.deadline as i64 {
+                    return Some(curr.clone());
+                }
+            }
+        }
+
         self.entities
             .pick_eevdf(curr.filter(|se| se.on_rq()), |se| self.entity_eligible(se))
     }
@@ -1358,9 +1381,11 @@ impl CfsRunQueue {
         }
 
         let curr = self.current();
-        self.pick_eevdf_entity(curr.as_ref())
+        let picked = self
+            .pick_eevdf_entity(curr.as_ref())
             .or_else(|| self.entities.leftmost())
-            .or_else(|| curr.filter(|se| se.on_rq()))
+            .or_else(|| curr.clone().filter(|se| se.on_rq()));
+        picked
     }
 
     pub fn entity_eligible(&self, se: &Arc<FairSchedEntity>) -> bool {
@@ -1434,7 +1459,7 @@ impl Scheduler for CompletelyFairScheduler {
         let mut idle_h_nr_running = pcb.sched_info().policy() == SchedPolicy::IDLE;
         let (should_continue, se) = FairSchedEntity::for_each_in_group(&mut se, |se| {
             if se.on_rq() {
-                return (false, true);
+                return (false, false);
             }
 
             let binding = se.cfs_rq();
@@ -1741,6 +1766,15 @@ impl Scheduler for CompletelyFairScheduler {
         }
 
         loop {
+            {
+                let cfs = cfs_rq.force_mut();
+                if cfs.current().is_some() {
+                    // Linux updates curr before EEVDF pick on the path that has
+                    // not put_prev_entity() yet, so eligibility sees fresh runtime.
+                    cfs.update_current();
+                }
+            }
+
             let curr = cfs_rq.current();
             let winner = cfs_rq.pick_next_entity()?;
 

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -580,10 +580,6 @@ impl CfsRunQueue {
 
         let now = self.rq().clock_task();
         let curr = curr.unwrap();
-        if unlikely(!curr.on_rq()) {
-            self.set_current(Weak::default());
-            return;
-        }
 
         fence(Ordering::SeqCst);
         if unlikely(now <= curr.exec_start) {
@@ -662,8 +658,6 @@ impl CfsRunQueue {
             if curr.on_rq() {
                 vruntime = curr.vruntime;
                 curr_on_rq = true;
-            } else {
-                self.set_current(Weak::default());
             }
         }
 
@@ -1200,7 +1194,9 @@ impl CfsRunQueue {
         //     .as_bytes(),
         // );
 
-        self.entities.remove(se);
+        if self.entities.remove(se).is_none() {
+            panic!("dequeue entity that is not present in CFS timeline");
+        }
         // send_to_default_serial8250_port(
         //     format!(
         //         "after dequeue pcb {:?}(real: {:?}) cfsrq {:?}\n",
@@ -1370,8 +1366,10 @@ impl CfsRunQueue {
             .pick_eevdf(curr.filter(|se| se.on_rq()), |se| self.entity_eligible(se))
     }
 
-    /// pick下一个运行的task
-    pub fn pick_next_entity(&self) -> Option<Arc<FairSchedEntity>> {
+    pub fn pick_next_entity_with_curr(
+        &self,
+        curr: Option<&Arc<FairSchedEntity>>,
+    ) -> Option<Arc<FairSchedEntity>> {
         if SCHED_FEATURES.contains(SchedFeature::NEXT_BUDDY) {
             if let Some(next) = self.next() {
                 if self.entity_eligible(&next) {
@@ -1380,12 +1378,17 @@ impl CfsRunQueue {
             }
         }
 
-        let curr = self.current();
         let picked = self
-            .pick_eevdf_entity(curr.as_ref())
+            .pick_eevdf_entity(curr)
             .or_else(|| self.entities.leftmost())
-            .or_else(|| curr.clone().filter(|se| se.on_rq()));
+            .or_else(|| curr.cloned().filter(|se| se.on_rq()));
         picked
+    }
+
+    /// pick下一个运行的task
+    pub fn pick_next_entity(&self) -> Option<Arc<FairSchedEntity>> {
+        let curr = self.current();
+        self.pick_next_entity_with_curr(curr.as_ref().filter(|se| se.on_rq()))
     }
 
     pub fn entity_eligible(&self, se: &Arc<FairSchedEntity>) -> bool {
@@ -1701,15 +1704,18 @@ impl Scheduler for CompletelyFairScheduler {
             let cfs = cfs_rq.unwrap();
             let cfs = cfs.force_mut();
             let curr = cfs.current();
-            if let Some(curr) = curr {
+            let curr = if let Some(curr) = curr {
                 if curr.on_rq() {
                     cfs.update_current();
+                    Some(curr)
                 } else {
-                    cfs.set_current(Weak::default());
+                    None
                 }
-            }
+            } else {
+                None
+            };
 
-            se = cfs.pick_next_entity();
+            se = cfs.pick_next_entity_with_curr(curr.as_ref());
             match se.clone() {
                 Some(val) => cfs_rq = val.my_cfs_rq.clone(),
                 None => {
@@ -1766,17 +1772,18 @@ impl Scheduler for CompletelyFairScheduler {
         }
 
         loop {
+            let curr;
             {
                 let cfs = cfs_rq.force_mut();
-                if cfs.current().is_some() {
-                    // Linux updates curr before EEVDF pick on the path that has
-                    // not put_prev_entity() yet, so eligibility sees fresh runtime.
+                curr = cfs.current().filter(|se| se.on_rq());
+                if curr.is_some() {
+                    // Linux updates runnable curr before EEVDF pick on the path
+                    // that has not put_prev_entity() yet.
                     cfs.update_current();
                 }
             }
 
-            let curr = cfs_rq.current();
-            let winner = cfs_rq.pick_next_entity()?;
+            let winner = cfs_rq.pick_next_entity_with_curr(curr.as_ref())?;
 
             // If winner is curr, descend into curr's group
             if let Some(c) = curr {

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -56,7 +56,7 @@ use self::{
     cputime::{irq_time_read, CpuTimeFunc, IrqTime},
     fair::{CfsRunQueue, CompletelyFairScheduler, FairSchedEntity},
     fifo::FifoScheduler,
-    prio::PrioUtil,
+    prio::{PrioUtil, MAX_RT_PRIO},
 };
 
 static mut CPU_IRQ_TIME: Option<Vec<&'static mut IrqTime>> = None;
@@ -64,6 +64,7 @@ pub static IDLE_CPUS: AtomicCpuMask = AtomicCpuMask::new();
 
 // 这里虽然rq是percpu的，但是在负载均衡的时候需要修改对端cpu的rq，所以仍需加锁
 static CPU_RUNQUEUE: Lazy<PerCpuVar<Arc<CpuRunQueue>>> = PerCpuVar::define_lazy();
+
 
 pub const SCHED_FIXEDPOINT_SHIFT: u64 = 10;
 #[allow(dead_code)]
@@ -236,6 +237,9 @@ lazy_static! {
         | SchedFeature::TTWU_QUEUE
         | SchedFeature::SIS_UTIL
         | SchedFeature::RT_PUSH_IPI
+        | SchedFeature::PLACE_LAG
+        | SchedFeature::PLACE_DEADLINE_INITIAL
+        | SchedFeature::RUN_TO_PARITY
         | SchedFeature::ALT_PERIOD
         | SchedFeature::BASE_SLICE
         | SchedFeature::UTIL_EST
@@ -341,6 +345,12 @@ impl LoadWeight {
     pub const WMULT_CONST: u32 = !0;
 
     pub const NICE_0_LOAD_SHIFT: u32 = Self::SCHED_FIXEDPOINT_SHIFT + Self::SCHED_FIXEDPOINT_SHIFT;
+    pub const NICE_0_LOAD: u64 = 1u64 << Self::NICE_0_LOAD_SHIFT;
+    pub const SCHED_PRIO_TO_WEIGHT: [u64; 40] = [
+        88761, 71755, 56483, 46273, 36291, 29154, 23254, 18705, 14949, 11916, 9548, 7620, 6100,
+        4904, 3906, 3121, 2501, 1991, 1586, 1277, 1024, 820, 655, 526, 423, 335, 272, 215, 172,
+        137, 110, 87, 70, 56, 45, 36, 29, 23, 18, 15,
+    ];
 
     pub fn update_load_add(&mut self, inc: u64) {
         self.weight += inc;
@@ -355,6 +365,13 @@ impl LoadWeight {
     pub fn update_load_set(&mut self, weight: u64) {
         self.weight = weight;
         self.inv_weight = 0;
+    }
+
+    pub fn set_load_weight_from_prio(&mut self, prio: i32) {
+        let index = (prio - MAX_RT_PRIO).clamp(0, Self::SCHED_PRIO_TO_WEIGHT.len() as i32 - 1);
+        self.update_load_set(Self::scale_load(
+            Self::SCHED_PRIO_TO_WEIGHT[index as usize],
+        ));
     }
 
     /// ## 更新负载权重的倒数
@@ -744,12 +761,10 @@ impl CpuRunQueue {
 
     /// 更新rq时钟
     pub fn update_rq_clock(&mut self) {
-        debug_assert_eq!(
-            self.cpu,
-            smp_get_processor_id(),
-            "update_rq_clock must run on its own cpu"
-        );
-
+        // Match Linux rq clock rules: callers may update a remote rq while
+        // holding that rq's lock. DragonOS sched_clock_cpu() returns a
+        // globally comparable clock on supported architectures, and irq time is
+        // tracked per CPU inside update_rq_clock_task().
         let clock = SchedClock::sched_clock_cpu(self.cpu);
         self.update_rq_clock_from_clock(clock);
     }
@@ -868,7 +883,6 @@ impl CpuRunQueue {
         let cpu = self.cpu;
         let already_requested = current.flags().contains(ProcessFlags::NEED_SCHEDULE);
         current.flags().insert(ProcessFlags::NEED_SCHEDULE);
-
         if cpu == smp_get_processor_id() {
             return;
         }
@@ -953,6 +967,12 @@ bitflags! {
         const ALT_PERIOD = 1 << 12;
         /// 启用基本时间片
         const BASE_SLICE = 1 << 13;
+        /// EEVDF: once picked, keep running until ineligible or it gets a new slice.
+        const RUN_TO_PARITY = 1 << 14;
+        /// EEVDF: preserve virtual lag when placing entities.
+        const PLACE_LAG = 1 << 15;
+        /// EEVDF: give initial forked entities half a slice.
+        const PLACE_DEADLINE_INITIAL = 1 << 16;
     }
 
     pub struct EnqueueFlag: u8 {
@@ -1041,7 +1061,6 @@ pub fn scheduler_tick() {
 
     // 更新请求队列时钟
     rq.update_rq_clock();
-
     match current.sched_info().policy() {
         SchedPolicy::CFS => CompletelyFairScheduler::tick(rq, current, false),
         SchedPolicy::FIFO => FifoScheduler::tick(rq, current, false),
@@ -1237,7 +1256,6 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     }
 
     let next = rq.pick_next_task(prev.clone());
-
     if task_is_idle(&next) {
         IDLE_CPUS.set(rq.cpu);
     } else if task_is_idle(&prev) {
@@ -1307,6 +1325,12 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     pcb.sched_info()
         .sched_entity()
         .force_mut()
+        .load
+        .set_load_weight_from_prio(current.sched_info().static_prio());
+
+    pcb.sched_info()
+        .sched_entity()
+        .force_mut()
         .init_entity_runnable_average();
 
     Ok(())
@@ -1359,12 +1383,9 @@ pub fn enqueue_task_on_cpu(
     pcb.sched_info().set_on_cpu(Some(target_cpu));
 
     let rq = cpu_rq(target_cpu.data() as usize);
-    let update_clock = target_cpu == smp_get_processor_id();
     let (rq, _guard) = rq.self_lock();
 
-    if update_clock {
-        rq.update_rq_clock();
-    }
+    rq.update_rq_clock();
 
     if was_uninterruptible {
         rq.dec_nr_uninterruptible();
@@ -1381,11 +1402,7 @@ pub fn enqueue_task_on_cpu(
         IDLE_CPUS.clear(target_cpu);
     }
 
-    if update_clock {
-        rq.check_preempt_current(pcb, wake_flags);
-    } else {
-        rq.check_preempt_remote(pcb, wake_flags);
-    }
+    rq.check_preempt_current(pcb, wake_flags);
 }
 
 pub fn request_task_migration(

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -65,7 +65,6 @@ pub static IDLE_CPUS: AtomicCpuMask = AtomicCpuMask::new();
 // 这里虽然rq是percpu的，但是在负载均衡的时候需要修改对端cpu的rq，所以仍需加锁
 static CPU_RUNQUEUE: Lazy<PerCpuVar<Arc<CpuRunQueue>>> = PerCpuVar::define_lazy();
 
-
 pub const SCHED_FIXEDPOINT_SHIFT: u64 = 10;
 #[allow(dead_code)]
 pub const SCHED_FIXEDPOINT_SCALE: u64 = 1 << SCHED_FIXEDPOINT_SHIFT;
@@ -369,9 +368,7 @@ impl LoadWeight {
 
     pub fn set_load_weight_from_prio(&mut self, prio: i32) {
         let index = (prio - MAX_RT_PRIO).clamp(0, Self::SCHED_PRIO_TO_WEIGHT.len() as i32 - 1);
-        self.update_load_set(Self::scale_load(
-            Self::SCHED_PRIO_TO_WEIGHT[index as usize],
-        ));
+        self.update_load_set(Self::scale_load(Self::SCHED_PRIO_TO_WEIGHT[index as usize]));
     }
 
     /// ## 更新负载权重的倒数

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -684,17 +684,18 @@ impl CpuRunQueue {
         }
     }
 
-    /// 远端 wakeup/策略调整场景下的保守抢占检查。
+    /// 远端策略调整场景下的保守抢占检查。
     ///
-    /// Linux 会在持有目标 rq 锁且目标 rq 时钟已更新后执行完整的 wakeup-preempt 检查。
-    /// 当前明确禁止跨核 `update_rq_clock()`，因此远端路径只能保留那些不依赖
-    /// `rq.clock_task` 最新值的抢占决策：
+    /// Linux wakeup path 会在持有目标 rq 锁且目标 rq 时钟已更新后执行完整的
+    /// wakeup-preempt 检查；DragonOS 的 `ProcessManager::wakeup()` queued fast path
+    /// 也遵循这个约束。该函数只用于没有先更新目标 rq clock 的裸远端路径，
+    /// 因此只能保留那些不依赖 `rq.clock_task` 最新值的抢占决策：
     /// - 更高调度类抢占；
     /// - FIFO 优先级抢占；
     /// - idle 被非 idle 任务抢占。
     ///
-    /// CFS 的 wakeup-preempt 需要像 Linux `check_preempt_wakeup()` 一样先更新当前实体，
-    /// 这在远端场景会重新引入“错误 CPU 更新目标 rq 时钟”的问题，因此这里故意跳过。
+    /// CFS 的 wakeup-preempt 需要像 Linux `check_preempt_wakeup()` 一样先更新当前实体；
+    /// 调用者若不能证明已持目标 rq lock 并更新 rq clock，就必须在这里跳过。
     #[allow(clippy::comparison_chain)]
     pub fn check_preempt_remote(&mut self, pcb: &Arc<ProcessControlBlock>, flags: WakeupFlags) {
         let current = self.current();
@@ -753,7 +754,10 @@ impl CpuRunQueue {
     }
 
     pub fn dec_nr_iowait(&self) {
-        self.nr_iowait.fetch_sub(1, Ordering::Relaxed);
+        let result = self
+            .nr_iowait
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |nr| nr.checked_sub(1));
+        debug_assert!(result.is_ok(), "nr_iowait underflow");
     }
 
     /// 更新rq时钟
@@ -1137,47 +1141,6 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     rq.update_rq_clock();
     rq.clock_updata_flags = ClockUpdataFlag::RQCF_UPDATE;
 
-    let mut migrate_prev_to = None;
-    if let Some(dest_cpu) = take_current_migration_target(&prev) {
-        // 当前任务迁移在真正切出当前 CPU 时才标记 rseq migrate，
-        // 避免在迁移请求发起后、任务仍运行在旧 CPU 时过早处理 NEED_RSEQ。
-        crate::process::rseq::Rseq::on_migrate(&prev);
-
-        debug_assert!(
-            !task_is_idle(&prev),
-            "idle task must not be migrated through current task migration"
-        );
-        debug_assert!(
-            cpu_is_online(dest_cpu),
-            "current task migration target {:?} must be online",
-            dest_cpu
-        );
-        debug_assert!(
-            prev.sched_info()
-                .cpus_allowed()
-                .get(dest_cpu)
-                .unwrap_or(false),
-            "current task migration target {:?} must be allowed by affinity",
-            dest_cpu
-        );
-
-        rq.deactivate_task(
-            prev.clone(),
-            DequeueFlag::DEQUEUE_MOVE | DequeueFlag::DEQUEUE_NOCLOCK,
-        );
-
-        if prev.sched_info().policy() == SchedPolicy::CFS {
-            let mut se = prev.sched_info().sched_entity();
-            crate::sched::fair::FairSchedEntity::for_each_in_group(&mut se, |se| {
-                se.cfs_rq().force_mut().set_current(Weak::default());
-                (true, true)
-            });
-        }
-
-        *prev.sched_info().on_rq.lock_irqsave() = OnRq::None;
-        migrate_prev_to = Some(dest_cpu);
-    }
-
     // 对标 Linux __schedule() 的 prev_state 检查：
     //   Linux 条件: (!(sched_mode & SM_MASK_PREEMPT) && prev_state)
     //   ——非抢占 + prev 非 RUNNING 时进入 deactivate 分支。
@@ -1190,23 +1153,26 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     // on_rq == Queued 守卫保证 deactivate 幂等：
     //   若 stop_task 已出队（!is_current 分支），此处 on_rq != Queued，跳过。
     //   若 stop_task 未出队（远端 current 分支），此处 on_rq == Queued，执行出队。
-    {
-        let prev_state = prev.sched_info().state();
-        if !prev_state.is_runnable() {
-            let interruptible = prev_state.is_blocked_interruptable();
-            let wake_kill = prev_state.is_stopped();
+    let mut prev_state = prev.sched_info().state();
+    if !prev_state.is_runnable() {
+        let interruptible = prev_state.is_blocked_interruptable();
+        let wake_kill = prev_state.is_stopped();
 
-            // signal_pending_state 仅对 SM_NONE（自愿调度）生效：
-            //   TASK_INTERRUPTIBLE → 有任意信号 → 恢复 RUNNING
-            //   TASK_STOPPED       → 仅 SIGKILL → 恢复 RUNNING
-            //   TASK_UNINTERRUPTIBLE → 不检查信号，直接 deactivate
-            // SM_PREEMPT（被抢占）不检查信号，因为异步 stop 不应被信号恢复。
-            let signal_wake = !sched_mod.contains(SchedMode::SM_MASK_PREEMPT)
-                && Signal::signal_pending_state(interruptible, wake_kill, &prev);
+        // signal_pending_state 仅对 SM_NONE（自愿调度）生效：
+        //   TASK_INTERRUPTIBLE → 有任意信号 → 恢复 RUNNING
+        //   TASK_STOPPED       → 仅 SIGKILL → 恢复 RUNNING
+        //   TASK_UNINTERRUPTIBLE → 不检查信号，直接 deactivate
+        // SM_PREEMPT（被抢占）不检查信号，因为异步 stop 不应被信号恢复。
+        let signal_wake = !sched_mod.contains(SchedMode::SM_MASK_PREEMPT)
+            && Signal::signal_pending_state(interruptible, wake_kill, &prev);
 
-            if signal_wake {
-                prev.sched_info().set_state(ProcessState::Runnable);
-            } else if *prev.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
+        if signal_wake {
+            prev.sched_info().set_state(ProcessState::Runnable);
+            prev_state = ProcessState::Runnable;
+        } else {
+            let _ = take_current_migration_target(&prev);
+
+            if *prev.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
                 // sched_contributes_to_load 在 deactivate_task 之前
                 if matches!(prev_state, ProcessState::Blocked(false)) {
                     rq.nr_uninterruptible += 1;
@@ -1223,6 +1189,49 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
                     rq.nr_iowait.fetch_add(1, Ordering::Relaxed);
                 }
             }
+        }
+    }
+
+    let mut migrate_prev_to = None;
+    if prev_state.is_runnable() {
+        if let Some(dest_cpu) = take_current_migration_target(&prev) {
+            // 当前任务迁移在真正切出当前 CPU 时才标记 rseq migrate，
+            // 避免在迁移请求发起后、任务仍运行在旧 CPU 时过早处理 NEED_RSEQ。
+            crate::process::rseq::Rseq::on_migrate(&prev);
+
+            debug_assert!(
+                !task_is_idle(&prev),
+                "idle task must not be migrated through current task migration"
+            );
+            debug_assert!(
+                cpu_is_online(dest_cpu),
+                "current task migration target {:?} must be online",
+                dest_cpu
+            );
+            debug_assert!(
+                prev.sched_info()
+                    .cpus_allowed()
+                    .get(dest_cpu)
+                    .unwrap_or(false),
+                "current task migration target {:?} must be allowed by affinity",
+                dest_cpu
+            );
+
+            rq.deactivate_task(
+                prev.clone(),
+                DequeueFlag::DEQUEUE_MOVE | DequeueFlag::DEQUEUE_NOCLOCK,
+            );
+
+            if prev.sched_info().policy() == SchedPolicy::CFS {
+                let mut se = prev.sched_info().sched_entity();
+                crate::sched::fair::FairSchedEntity::for_each_in_group(&mut se, |se| {
+                    se.cfs_rq().force_mut().set_current(Weak::default());
+                    (true, true)
+                });
+            }
+
+            *prev.sched_info().on_rq.lock_irqsave() = OnRq::None;
+            migrate_prev_to = Some(dest_cpu);
         }
     }
 
@@ -1338,11 +1347,6 @@ fn __set_task_cpu(pcb: &Arc<ProcessControlBlock>, cpu: ProcessorId) {
     se.force_mut().set_cfs(Arc::downgrade(&rq.cfs));
 }
 
-pub fn rebind_task_cpu(pcb: &Arc<ProcessControlBlock>, cpu: ProcessorId) {
-    __set_task_cpu(pcb, cpu);
-    pcb.sched_info().set_on_cpu(Some(cpu));
-}
-
 /// 对标 Linux ttwu_queue + ttwu_do_activate
 pub fn enqueue_task_on_cpu(
     pcb: &Arc<ProcessControlBlock>,
@@ -1381,13 +1385,9 @@ pub fn request_task_migration(
     dest_cpu: ProcessorId,
 ) -> Result<(), SystemError> {
     let Some(src_cpu) = pcb.sched_info().on_cpu() else {
-        // on_cpu == None can mean either first placement of a new task or
-        // migration of an existing off-rq task. Only the latter is an rseq
-        // migration event.
-        if !pcb.sched_info().is_new_task() {
-            crate::process::rseq::Rseq::on_migrate(pcb);
-        }
-        rebind_task_cpu(pcb, dest_cpu);
+        // A new task consumes its placement hint in wake_up_new_task(). An
+        // existing off-rq task must keep its previous task_cpu until wakeup so
+        // sleep/iowait accounting is charged back to the rq that dequeued it.
         return Ok(());
     };
 
@@ -1429,8 +1429,10 @@ pub fn request_task_migration(
         return Ok(());
     }
 
-    crate::process::rseq::Rseq::on_migrate(pcb);
-    rebind_task_cpu(pcb, dest_cpu);
+    // Linux does not set_task_cpu() for blocked tasks directly. DragonOS
+    // wakeup() uses task_cpu as the previous rq for sleep/iowait accounting and
+    // then selects a legal target from cpus_allowed, so keep off-rq tasks bound
+    // to the rq that actually dequeued them.
     Ok(())
 }
 
@@ -1439,10 +1441,10 @@ pub fn take_current_migration_target(current: &Arc<ProcessControlBlock>) -> Opti
         return None;
     }
 
-    let dest_cpu = current.sched_info().migrate_to()?;
+    let dest_cpu = current.sched_info().migrate_to();
     current.sched_info().set_migrate_to(None);
     current.flags().remove(ProcessFlags::NEED_MIGRATE);
-    Some(dest_cpu)
+    dest_cpu
 }
 
 #[inline(never)]

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -788,14 +788,6 @@ impl CpuRunQueue {
     /// 更新任务时钟
     pub fn update_rq_clock_task(&mut self, mut delta: u64) {
         let mut irq_delta = irq_time_read(self.cpu) - self.prev_irq_time;
-        // if self.cpu == 0 {
-        //     error!(
-        //         "cpu 0 delta {delta} irq_delta {} irq_time_read(self.cpu) {} self.prev_irq_time {}",
-        //         irq_delta,
-        //         irq_time_read(self.cpu),
-        //         self.prev_irq_time
-        //     );
-        // }
         compiler_fence(Ordering::SeqCst);
 
         if irq_delta > delta {
@@ -808,13 +800,9 @@ impl CpuRunQueue {
 
         // todo: psi?
 
-        // send_to_default_serial8250_port(format!("\n{delta}\n",).as_bytes());
         compiler_fence(Ordering::SeqCst);
         self.clock_task += delta;
         compiler_fence(Ordering::SeqCst);
-        // if self.cpu == 0 {
-        //     error!("cpu {} clock_task {}", self.cpu, self.clock_task);
-        // }
         // todo: pelt?
     }
 
@@ -1189,20 +1177,6 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
         *prev.sched_info().on_rq.lock_irqsave() = OnRq::None;
         migrate_prev_to = Some(dest_cpu);
     }
-
-    // kBUG!(
-    //     "before cfs rq pcbs {:?}\nvruntimes {:?}\n",
-    //     rq.cfs
-    //         .entities
-    //         .iter()
-    //         .map(|x| { x.1.pcb().pid() })
-    //         .collect::<Vec<_>>(),
-    //     rq.cfs
-    //         .entities
-    //         .iter()
-    //         .map(|x| { x.1.vruntime })
-    //         .collect::<Vec<_>>(),
-    // );
 
     // 对标 Linux __schedule() 的 prev_state 检查：
     //   Linux 条件: (!(sched_mode & SM_MASK_PREEMPT) && prev_state)

--- a/user/apps/c_unitest/test_exit_mm_teardown_stress.c
+++ b/user/apps/c_unitest/test_exit_mm_teardown_stress.c
@@ -1,0 +1,73 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int fault_in_exit_mapping(void) {
+    const size_t len = 64 * 4096;
+    volatile unsigned char *p = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (p == MAP_FAILED) {
+        printf("[FAIL] mmap for exit stress failed: errno=%d(%s)\n",
+               errno, strerror(errno));
+        return -1;
+    }
+
+    for (size_t i = 0; i < len; i += 4096) {
+        p[i] = (unsigned char)(i >> 12);
+    }
+
+    return 0;
+}
+
+static int run_one_child(void) {
+    pid_t child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork failed: errno=%d(%s)\n", errno, strerror(errno));
+        return -1;
+    }
+
+    if (child == 0) {
+        if (fault_in_exit_mapping() != 0) {
+            _exit(10);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        printf("[FAIL] waitpid(%d) failed: errno=%d(%s)\n",
+               child, errno, strerror(errno));
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        printf("[FAIL] child %d exited abnormally: status=0x%x\n", child, status);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void) {
+    int iterations = 128;
+    const char *env = getenv("CAPSET_STRESS_ITERS");
+    if (env && env[0]) {
+        int parsed = atoi(env);
+        if (parsed > 0) {
+            iterations = parsed;
+        }
+    }
+
+    for (int i = 0; i < iterations; ++i) {
+        if (run_one_child() != 0) {
+            printf("[FAIL] exit mm teardown stress failed at iteration %d/%d\n",
+                   i + 1, iterations);
+            return 1;
+        }
+    }
+
+    printf("exit mm teardown stress passed: iterations=%d\n", iterations);
+    return 0;
+}

--- a/user/apps/c_unitest/test_pthread_start_latency.c
+++ b/user/apps/c_unitest/test_pthread_start_latency.c
@@ -1,0 +1,107 @@
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+
+#define NR_THREADS 4
+#define ROUNDS 1000
+#define READY_TIMEOUT_NS 2000000000LL
+
+struct thread_ctx {
+    atomic_int *run;
+    atomic_int *ready;
+};
+
+static void cpu_pause_loop(int rounds) {
+    for (volatile int i = 0; i < rounds; ++i) {
+#if defined(__x86_64__) || defined(__i386__)
+        __asm__ __volatile__("pause" ::: "memory");
+#else
+        __asm__ __volatile__("" ::: "memory");
+#endif
+    }
+}
+
+static void *worker(void *arg) {
+    struct thread_ctx *ctx = (struct thread_ctx *)arg;
+    atomic_fetch_add_explicit(ctx->ready, 1, memory_order_release);
+
+    while (atomic_load_explicit(ctx->run, memory_order_acquire) != 0) {
+        cpu_pause_loop(64);
+    }
+
+    return NULL;
+}
+
+static int64_t monotonic_ns(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return -1;
+    }
+    return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static int wait_ready(atomic_int *ready) {
+    int64_t start = monotonic_ns();
+    if (start < 0) {
+        return -1;
+    }
+
+    for (;;) {
+        if (atomic_load_explicit(ready, memory_order_acquire) >= NR_THREADS) {
+            return 0;
+        }
+        int64_t now = monotonic_ns();
+        if (now < 0 || now - start > READY_TIMEOUT_NS) {
+            return -1;
+        }
+        cpu_pause_loop(64);
+    }
+}
+
+int main(void) {
+    for (int round = 0; round < ROUNDS; ++round) {
+        atomic_int run = ATOMIC_VAR_INIT(1);
+        atomic_int ready = ATOMIC_VAR_INIT(0);
+        pthread_t threads[NR_THREADS];
+        struct thread_ctx ctx = {
+            .run = &run,
+            .ready = &ready,
+        };
+
+        for (int i = 0; i < NR_THREADS; ++i) {
+            int rc = pthread_create(&threads[i], NULL, worker, &ctx);
+            if (rc != 0) {
+                fprintf(stderr, "pthread_create failed at round=%d thread=%d rc=%d\n", round, i, rc);
+                atomic_store_explicit(&run, 0, memory_order_release);
+                for (int j = 0; j < i; ++j) {
+                    pthread_join(threads[j], NULL);
+                }
+                return 1;
+            }
+        }
+
+        if (wait_ready(&ready) != 0) {
+            int seen = atomic_load_explicit(&ready, memory_order_acquire);
+            fprintf(stderr, "ready timeout at round=%d ready=%d/%d\n", round, seen, NR_THREADS);
+            atomic_store_explicit(&run, 0, memory_order_release);
+            for (int i = 0; i < NR_THREADS; ++i) {
+                pthread_join(threads[i], NULL);
+            }
+            return 2;
+        }
+
+        atomic_store_explicit(&run, 0, memory_order_release);
+        for (int i = 0; i < NR_THREADS; ++i) {
+            pthread_join(threads[i], NULL);
+        }
+
+        if ((round + 1) % 10 == 0) {
+            printf("round %d/%d ok\n", round + 1, ROUNDS);
+        }
+    }
+
+    printf("pthread start latency smoke passed: rounds=%d threads=%d\n", ROUNDS, NR_THREADS);
+    return 0;
+}

--- a/user/apps/c_unitest/test_pthread_start_latency.c
+++ b/user/apps/c_unitest/test_pthread_start_latency.c
@@ -86,9 +86,6 @@ int main(void) {
             int seen = atomic_load_explicit(&ready, memory_order_acquire);
             fprintf(stderr, "ready timeout at round=%d ready=%d/%d\n", round, seen, NR_THREADS);
             atomic_store_explicit(&run, 0, memory_order_release);
-            for (int i = 0; i < NR_THREADS; ++i) {
-                pthread_join(threads[i], NULL);
-            }
             return 2;
         }
 

--- a/user/apps/c_unitest/test_sys_capset.c
+++ b/user/apps/c_unitest/test_sys_capset.c
@@ -4,9 +4,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/syscall.h>
-#include <sys/mman.h>
 #include <sys/wait.h>
-#include <stdlib.h>
 
 typedef struct {
     uint32_t version;
@@ -78,30 +76,9 @@ static int test_rule_effective_subset_permitted() {
     return do_capset(_LINUX_CAPABILITY_VERSION_3, 0, data, 2, EPERM) == 0 ? 0 : -1;
 }
 
-static int fault_in_exit_mapping(void) {
-    const size_t len = 64 * 4096;
-    volatile unsigned char *p = mmap(NULL, len, PROT_READ | PROT_WRITE,
-                                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (p == MAP_FAILED) {
-        printf("[FAIL] mmap for exit stress failed: errno=%d(%s)\n",
-               errno, strerror(errno));
-        return -1;
-    }
-
-    for (size_t i = 0; i < len; i += 4096) {
-        p[i] = (unsigned char)(i >> 12);
-    }
-
-    // Intentionally leave the mapping alive. The regression we are probing is
-    // the kernel's exit-time mm teardown path running from a non-sleepable
-    // context after capset-heavy children exit.
-    return 0;
-}
-
 static int expect_capset_eperm_after_drop(uint64_t next_effective,
                                           uint64_t next_permitted,
-                                          uint64_t next_inheritable,
-                                          int stress_mm_exit) {
+                                          uint64_t next_inheritable) {
     pid_t child = fork();
     if (child < 0) {
         printf("[FAIL] fork failed: errno=%d(%s)\n", errno, strerror(errno));
@@ -109,10 +86,6 @@ static int expect_capset_eperm_after_drop(uint64_t next_effective,
     }
 
     if (child == 0) {
-        if (stress_mm_exit && fault_in_exit_mapping() != 0) {
-            _exit(10);
-        }
-
         cap_user_data_t zero[2];
         fill_caps_v3(0, 0, 0, zero);
         if (do_capset(_LINUX_CAPABILITY_VERSION_3, 0, zero, 2, 0) != 0) {
@@ -143,34 +116,12 @@ static int expect_capset_eperm_after_drop(uint64_t next_effective,
 
 static int test_rule_permitted_not_increase() {
     // 期望：pP_new ⊆ pP_old。子进程先清空 pP，再尝试提升 bit0 → EPERM
-    return expect_capset_eperm_after_drop(0, 1, 0, 0);
+    return expect_capset_eperm_after_drop(0, 1, 0);
 }
 
 static int test_rule_inheritable_bounds() {
     // 期望：无 CAP_SETPCAP 时 pI_new ⊆ pI_old ∪ pP_old；先清空 pI/pP，再提升 pI(bit0) → EPERM
-    return expect_capset_eperm_after_drop(0, 0, 1, 0);
-}
-
-static int test_rule_inheritable_bounds_stress() {
-    int iterations = 128;
-    const char *env = getenv("CAPSET_STRESS_ITERS");
-    if (env && env[0]) {
-        int parsed = atoi(env);
-        if (parsed > 0) {
-            iterations = parsed;
-        }
-    }
-
-    for (int i = 0; i < iterations; ++i) {
-        if (expect_capset_eperm_after_drop(0, 0, 1, 1) != 0) {
-            printf("[FAIL] inheritable bounds stress failed at iteration %d/%d\n",
-                   i + 1, iterations);
-            return -1;
-        }
-    }
-
-    printf("[PASS] capset inheritable bounds stress completed %d iterations\n", iterations);
-    return 0;
+    return expect_capset_eperm_after_drop(0, 0, 1);
 }
 
 static int test_version_paths() {
@@ -204,7 +155,6 @@ int main() {
     fails += (test_rule_effective_subset_permitted() != 0);
     fails += (test_rule_permitted_not_increase() != 0);
     fails += (test_rule_inheritable_bounds() != 0);
-    fails += (test_rule_inheritable_bounds_stress() != 0);
     fails += (test_version_paths() != 0);
 
     if (fails) {

--- a/user/apps/c_unitest/test_sys_capset.c
+++ b/user/apps/c_unitest/test_sys_capset.c
@@ -4,7 +4,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/syscall.h>
-#include <pthread.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <stdlib.h>
 
 typedef struct {
     uint32_t version;
@@ -76,20 +78,98 @@ static int test_rule_effective_subset_permitted() {
     return do_capset(_LINUX_CAPABILITY_VERSION_3, 0, data, 2, EPERM) == 0 ? 0 : -1;
 }
 
-static int test_rule_permitted_not_increase() {
-    // 期望：pP_new ⊆ pP_old。尝试把高位拉高（DragonOS 会截断到低41位）→ EPERM
-    cap_user_data_t data[2];
-    fill_caps_v3(0x0ull, (1ull << 40), 0x0ull, data); // 试图拉高 bit40
-    // 对默认 FULL_SET 情况，此用例可能成功；因此先读取当前 pP，再尝试增加新位
-    // 简化：若默认 FULL_SET，跳过此用例；由集成环境决定
+static int fault_in_exit_mapping(void) {
+    const size_t len = 64 * 4096;
+    volatile unsigned char *p = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (p == MAP_FAILED) {
+        printf("[FAIL] mmap for exit stress failed: errno=%d(%s)\n",
+               errno, strerror(errno));
+        return -1;
+    }
+
+    for (size_t i = 0; i < len; i += 4096) {
+        p[i] = (unsigned char)(i >> 12);
+    }
+
+    // Intentionally leave the mapping alive. The regression we are probing is
+    // the kernel's exit-time mm teardown path running from a non-sleepable
+    // context after capset-heavy children exit.
     return 0;
 }
 
+static int expect_capset_eperm_after_drop(uint64_t next_effective,
+                                          uint64_t next_permitted,
+                                          uint64_t next_inheritable,
+                                          int stress_mm_exit) {
+    pid_t child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork failed: errno=%d(%s)\n", errno, strerror(errno));
+        return -1;
+    }
+
+    if (child == 0) {
+        if (stress_mm_exit && fault_in_exit_mapping() != 0) {
+            _exit(10);
+        }
+
+        cap_user_data_t zero[2];
+        fill_caps_v3(0, 0, 0, zero);
+        if (do_capset(_LINUX_CAPABILITY_VERSION_3, 0, zero, 2, 0) != 0) {
+            _exit(11);
+        }
+
+        cap_user_data_t next[2];
+        fill_caps_v3(next_effective, next_permitted, next_inheritable, next);
+        if (do_capset(_LINUX_CAPABILITY_VERSION_3, 0, next, 2, EPERM) != 0) {
+            _exit(12);
+        }
+
+        _exit(0);
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child) {
+        printf("[FAIL] waitpid(%d) failed: errno=%d(%s)\n",
+               child, errno, strerror(errno));
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        printf("[FAIL] child %d exited abnormally: status=0x%x\n", child, status);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_rule_permitted_not_increase() {
+    // 期望：pP_new ⊆ pP_old。子进程先清空 pP，再尝试提升 bit0 → EPERM
+    return expect_capset_eperm_after_drop(0, 1, 0, 0);
+}
+
 static int test_rule_inheritable_bounds() {
-    // 期望：pI_new ⊆ (pI_old ∪ pP_old) 且 ⊆ (pI_old ∪ bset)。构造一个明显越界位（假设 old pP/pI/bset 不含 bit40）
-    cap_user_data_t data[2];
-    fill_caps_v3(0x0ull, 0x0ull, (1ull << 40), data);
-    // 在默认 FULL_SET 下此用例不触发 EPERM；因此仅作为占位
+    // 期望：无 CAP_SETPCAP 时 pI_new ⊆ pI_old ∪ pP_old；先清空 pI/pP，再提升 pI(bit0) → EPERM
+    return expect_capset_eperm_after_drop(0, 0, 1, 0);
+}
+
+static int test_rule_inheritable_bounds_stress() {
+    int iterations = 128;
+    const char *env = getenv("CAPSET_STRESS_ITERS");
+    if (env && env[0]) {
+        int parsed = atoi(env);
+        if (parsed > 0) {
+            iterations = parsed;
+        }
+    }
+
+    for (int i = 0; i < iterations; ++i) {
+        if (expect_capset_eperm_after_drop(0, 0, 1, 1) != 0) {
+            printf("[FAIL] inheritable bounds stress failed at iteration %d/%d\n",
+                   i + 1, iterations);
+            return -1;
+        }
+    }
+
+    printf("[PASS] capset inheritable bounds stress completed %d iterations\n", iterations);
     return 0;
 }
 
@@ -119,25 +199,13 @@ static int test_version_paths() {
     return 0;
 }
 
-static void *thread_capset_ok(void *arg) {
-    (void)arg;
-    cap_user_data_t data[2];
-    // 尝试设置为空集合（总是 pE ⊆ pP），应成功
-    fill_caps_v3(0x0ull, 0x0ull, 0x0ull, data);
-    do_capset(_LINUX_CAPABILITY_VERSION_3, 0, data, 2, 0);
-    return NULL;
-}
-
-/* 移除并发测试，避免在 DragonOS 下触发 clone/cred 未实现导致 panic */
-static int test_concurrent_capset() { return 0; }
-
 int main() {
     int fails = 0;
     fails += (test_rule_effective_subset_permitted() != 0);
     fails += (test_rule_permitted_not_increase() != 0);
     fails += (test_rule_inheritable_bounds() != 0);
+    fails += (test_rule_inheritable_bounds_stress() != 0);
     fails += (test_version_paths() != 0);
-    fails += (test_concurrent_capset() != 0);
 
     if (fails) {
         printf("test_sys_capset: %d test(s) failed\n", fails);

--- a/user/apps/tests/dunitest/runner/Cargo.lock
+++ b/user/apps/tests/dunitest/runner/Cargo.lock
@@ -110,6 +110,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "libc",
  "serde",
  "serde_json",
 ]
@@ -131,6 +132,12 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"

--- a/user/apps/tests/dunitest/runner/Cargo.toml
+++ b/user/apps/tests/dunitest/runner/Cargo.toml
@@ -10,5 +10,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/user/apps/tests/dunitest/runner/src/executor.rs
+++ b/user/apps/tests/dunitest/runner/src/executor.rs
@@ -44,21 +44,40 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
     let mut precheck_log = File::create(&log_path)
         .with_context(|| format!("创建日志文件失败: {}", log_path.display()))?;
 
-    if let Some(msg) = validate_gtest_binary(spec)? {
-        writeln!(precheck_log, "{}", msg).with_context(|| "写入日志失败")?;
-        let result = CaseResult {
-            name: spec.name.clone(),
-            status: CaseStatus::Failed,
-            duration_ms: precheck_start.elapsed().as_millis(),
-            exit_code: None,
-            message: "非 gtest 测例，已拒绝执行".to_string(),
-            log_file: log_path.display().to_string(),
-            gtest_total: 0,
-            gtest_passed: 0,
-            gtest_failed: 0,
-            gtest_skipped: 0,
-        };
-        return Ok(result);
+    match validate_gtest_binary(spec)? {
+        GtestPrecheck::Valid => {}
+        GtestPrecheck::Invalid(msg) => {
+            writeln!(precheck_log, "{}", msg).with_context(|| "写入日志失败")?;
+            let result = CaseResult {
+                name: spec.name.clone(),
+                status: CaseStatus::Failed,
+                duration_ms: precheck_start.elapsed().as_millis(),
+                exit_code: None,
+                message: "非 gtest 测例，已拒绝执行".to_string(),
+                log_file: log_path.display().to_string(),
+                gtest_total: 0,
+                gtest_passed: 0,
+                gtest_failed: 0,
+                gtest_skipped: 0,
+            };
+            return Ok(result);
+        }
+        GtestPrecheck::Timeout(msg) => {
+            writeln!(precheck_log, "{}", msg).with_context(|| "写入日志失败")?;
+            let result = CaseResult {
+                name: spec.name.clone(),
+                status: CaseStatus::Timeout,
+                duration_ms: precheck_start.elapsed().as_millis(),
+                exit_code: None,
+                message: msg,
+                log_file: log_path.display().to_string(),
+                gtest_total: 0,
+                gtest_passed: 0,
+                gtest_failed: 0,
+                gtest_skipped: 0,
+            };
+            return Ok(result);
+        }
     }
     drop(precheck_log);
 
@@ -205,7 +224,7 @@ fn terminate_case_process_group(child_pid: u32) -> Result<()> {
 
 #[cfg(not(unix))]
 fn terminate_case_process_group(_child_pid: u32) -> Result<()> {
-    Ok(())
+    anyhow::bail!("process-group termination is unsupported on this platform")
 }
 
 fn parse_gtest_counts(log_path: &Path) -> Result<(usize, usize, usize, usize)> {
@@ -281,28 +300,102 @@ pub fn abs_or_join(base: &Path, path: &str) -> PathBuf {
     }
 }
 
-fn validate_gtest_binary(spec: &TestSpec) -> Result<Option<String>> {
-    let output = Command::new(&spec.path)
-        .arg("--gtest_help")
-        .output()
-        .with_context(|| format!("预检查 gtest 失败: {}", spec.path))?;
+enum GtestPrecheck {
+    Valid,
+    Invalid(String),
+    Timeout(String),
+}
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+fn validate_gtest_binary(spec: &TestSpec) -> Result<GtestPrecheck> {
+    let mut cmd = Command::new(&spec.path);
+    cmd.arg("--gtest_help")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    configure_case_process_group(&mut cmd);
+
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("预检查 gtest 失败: {}", spec.path))?;
+    let stdout_pipe = child
+        .stdout
+        .take()
+        .with_context(|| "获取预检查 stdout 管道失败")?;
+    let stderr_pipe = child
+        .stderr
+        .take()
+        .with_context(|| "获取预检查 stderr 管道失败")?;
+    let stdout_thread = spawn_pipe_collector(stdout_pipe);
+    let stderr_thread = spawn_pipe_collector(stderr_pipe);
+
+    let timeout = Duration::from_secs(spec.timeout_sec.clamp(1, 5));
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().with_context(|| "等待预检查进程状态失败")? {
+            break status;
+        }
+        if start.elapsed() >= timeout {
+            let kill_group_result = terminate_case_process_group(child.id());
+            let _ = child.kill();
+            let _ = child.wait();
+
+            let mut message = format!("gtest 预检查超时: {} 秒", timeout.as_secs());
+            if let Err(e) = kill_group_result {
+                message.push_str(&format!("; 进程组终止失败，跳过管道线程收尾: {e:#}"));
+            } else {
+                let _ = join_pipe_collector(stdout_thread);
+                let _ = join_pipe_collector(stderr_thread);
+            }
+            return Ok(GtestPrecheck::Timeout(message));
+        }
+        thread::sleep(Duration::from_millis(20));
+    };
+
+    let _ = terminate_case_process_group(child.id());
+    let stdout = join_pipe_collector(stdout_thread)?;
+    let stderr = join_pipe_collector(stderr_thread)?;
+    let stdout = String::from_utf8_lossy(&stdout);
+    let stderr = String::from_utf8_lossy(&stderr);
     let merged = format!("{}\n{}", stdout, stderr);
     let marker = "This program contains tests written using Google Test";
 
-    if output.status.success() && merged.contains(marker) {
-        return Ok(None);
+    if status.success() && merged.contains(marker) {
+        return Ok(GtestPrecheck::Valid);
     }
 
-    Ok(Some(format!(
+    Ok(GtestPrecheck::Invalid(format!(
         "dunitest: '{}' 不是有效 gtest 测例，缺少 gtest 标识文本。\n预检查退出码: {:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
         spec.path,
-        output.status.code(),
+        status.code(),
         stdout,
         stderr
     )))
+}
+
+fn spawn_pipe_collector<R>(mut reader: R) -> JoinHandle<Result<Vec<u8>>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || -> Result<Vec<u8>> {
+        let mut out = Vec::new();
+        let mut buf = [0_u8; 4096];
+        loop {
+            let n = reader
+                .read(&mut buf)
+                .with_context(|| "读取预检查管道失败")?;
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&buf[..n]);
+        }
+        Ok(out)
+    })
+}
+
+fn join_pipe_collector(handle: JoinHandle<Result<Vec<u8>>>) -> Result<Vec<u8>> {
+    match handle.join() {
+        Ok(inner) => inner,
+        Err(_) => anyhow::bail!("预检查输出收集线程发生 panic"),
+    }
 }
 
 fn spawn_pipe_forwarder<R>(
@@ -403,6 +496,102 @@ sleep 30
         assert!(
             started.elapsed() < Duration::from_secs(10),
             "timeout path did not return promptly"
+        );
+
+        let _ = fs::remove_dir_all(tmp);
+    }
+
+    #[test]
+    fn precheck_timeout_kills_forked_descendants_that_keep_pipes_open() {
+        let tmp = std::env::temp_dir().join(format!(
+            "dunitest-runner-precheck-pgrp-{}-{}",
+            std::process::id(),
+            unique_nanos()
+        ));
+        let results = tmp.join("results");
+        fs::create_dir_all(&results).unwrap();
+
+        let script = tmp.join("forking_gtest_help.sh");
+        fs::write(
+            &script,
+            r#"#!/bin/sh
+if [ "$1" = "--gtest_help" ]; then
+  (sleep 30) &
+  sleep 30
+fi
+echo "[==========] Running 1 test from 1 test suite."
+echo "[  PASSED  ] 1 test."
+"#,
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+
+        let spec = TestSpec {
+            name: "normal/forking_precheck_timeout".to_string(),
+            path: script.display().to_string(),
+            args: Vec::new(),
+            timeout_sec: 1,
+        };
+
+        let started = Instant::now();
+        let result = run_test(&spec, &results, false).unwrap();
+
+        assert!(matches!(result.status, CaseStatus::Timeout));
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "precheck timeout path did not return promptly"
+        );
+
+        let _ = fs::remove_dir_all(tmp);
+    }
+
+    #[test]
+    fn precheck_success_reaps_descendants_that_keep_pipes_open() {
+        let tmp = std::env::temp_dir().join(format!(
+            "dunitest-runner-precheck-success-pgrp-{}-{}",
+            std::process::id(),
+            unique_nanos()
+        ));
+        let results = tmp.join("results");
+        fs::create_dir_all(&results).unwrap();
+
+        let script = tmp.join("forking_gtest_help_success.sh");
+        fs::write(
+            &script,
+            r#"#!/bin/sh
+if [ "$1" = "--gtest_help" ]; then
+  echo "This program contains tests written using Google Test"
+  (sleep 30) &
+  exit 0
+fi
+echo "[==========] Running 1 test from 1 test suite."
+echo "[ RUN      ] Smoke.Pass"
+echo "[       OK ] Smoke.Pass"
+echo "[==========] 1 test from 1 test suite ran."
+echo "[  PASSED  ] 1 test."
+"#,
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+
+        let spec = TestSpec {
+            name: "normal/forking_precheck_success".to_string(),
+            path: script.display().to_string(),
+            args: Vec::new(),
+            timeout_sec: 1,
+        };
+
+        let started = Instant::now();
+        let result = run_test(&spec, &results, false).unwrap();
+
+        assert!(matches!(result.status, CaseStatus::Passed));
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "precheck success path did not clean descendant pipe holders"
         );
 
         let _ = fs::remove_dir_all(tmp);

--- a/user/apps/tests/dunitest/runner/src/executor.rs
+++ b/user/apps/tests/dunitest/runner/src/executor.rs
@@ -12,6 +12,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CaseStatus {
@@ -36,17 +39,17 @@ pub struct CaseResult {
 }
 
 pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<CaseResult> {
-    let start = Instant::now();
+    let precheck_start = Instant::now();
     let log_path = results_dir.join(format!("{}.log", sanitize_case_name(&spec.name)));
-    let mut precheck_log =
-        File::create(&log_path).with_context(|| format!("创建日志文件失败: {}", log_path.display()))?;
+    let mut precheck_log = File::create(&log_path)
+        .with_context(|| format!("创建日志文件失败: {}", log_path.display()))?;
 
     if let Some(msg) = validate_gtest_binary(spec)? {
         writeln!(precheck_log, "{}", msg).with_context(|| "写入日志失败")?;
         let result = CaseResult {
             name: spec.name.clone(),
             status: CaseStatus::Failed,
-            duration_ms: start.elapsed().as_millis(),
+            duration_ms: precheck_start.elapsed().as_millis(),
             exit_code: None,
             message: "非 gtest 测例，已拒绝执行".to_string(),
             log_file: log_path.display().to_string(),
@@ -59,14 +62,16 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
     }
     drop(precheck_log);
 
-    let log_file =
-        File::create(&log_path).with_context(|| format!("创建日志文件失败: {}", log_path.display()))?;
+    let log_file = File::create(&log_path)
+        .with_context(|| format!("创建日志文件失败: {}", log_path.display()))?;
     let shared_log = Arc::new(Mutex::new(log_file));
 
+    let start = Instant::now();
     let mut cmd = Command::new(&spec.path);
     cmd.args(&spec.args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    configure_case_process_group(&mut cmd);
 
     let mut child = cmd.spawn().with_context(|| {
         format!(
@@ -93,14 +98,30 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
             break status;
         }
         if start.elapsed() >= timeout {
+            let kill_group_result = terminate_case_process_group(child.id());
             let _ = child.kill();
             let _ = child.wait();
+
+            let mut message = format!("超时: {} 秒", spec.timeout_sec);
+            if let Err(e) = kill_group_result {
+                message.push_str(&format!("; 进程组终止失败，跳过管道线程收尾: {e:#}"));
+            } else {
+                let stdout_join = join_pipe_forwarder(stdout_thread);
+                let stderr_join = join_pipe_forwarder(stderr_thread);
+                if let Err(e) = stdout_join {
+                    message.push_str(&format!("; stdout 日志收尾失败: {e:#}"));
+                }
+                if let Err(e) = stderr_join {
+                    message.push_str(&format!("; stderr 日志收尾失败: {e:#}"));
+                }
+            }
+
             let result = CaseResult {
                 name: spec.name.clone(),
                 status: CaseStatus::Timeout,
                 duration_ms: start.elapsed().as_millis(),
                 exit_code: None,
-                message: format!("超时: {} 秒", spec.timeout_sec),
+                message,
                 log_file: log_path.display().to_string(),
                 gtest_total: 0,
                 gtest_passed: 0,
@@ -138,10 +159,7 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
             status: CaseStatus::Failed,
             duration_ms: elapsed,
             exit_code: code,
-            message: format!(
-                "gtest 返回失败退出码: {:?}",
-                code
-            ),
+            message: format!("gtest 返回失败退出码: {:?}", code),
             log_file: log_path.display().to_string(),
             gtest_total: gtest.0,
             gtest_passed: gtest.1,
@@ -153,6 +171,41 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
     let _ = verbose;
 
     Ok(result)
+}
+
+#[cfg(unix)]
+fn configure_case_process_group(cmd: &mut Command) {
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setpgid(0, 0) == -1 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_case_process_group(_cmd: &mut Command) {}
+
+#[cfg(unix)]
+fn terminate_case_process_group(child_pid: u32) -> Result<()> {
+    let pgid = -(child_pid as libc::pid_t);
+    if unsafe { libc::kill(pgid, libc::SIGKILL) } == 0 {
+        return Ok(());
+    }
+
+    let err = std::io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+    Err(err).with_context(|| format!("kill(-{}, SIGKILL) 失败", child_pid))
+}
+
+#[cfg(not(unix))]
+fn terminate_case_process_group(_child_pid: u32) -> Result<()> {
+    Ok(())
 }
 
 fn parse_gtest_counts(log_path: &Path) -> Result<(usize, usize, usize, usize)> {
@@ -221,7 +274,11 @@ fn sanitize_case_name(name: &str) -> String {
 
 pub fn abs_or_join(base: &Path, path: &str) -> PathBuf {
     let p = PathBuf::from(path);
-    if p.is_absolute() { p } else { base.join(p) }
+    if p.is_absolute() {
+        p
+    } else {
+        base.join(p)
+    }
 }
 
 fn validate_gtest_binary(spec: &TestSpec) -> Result<Option<String>> {
@@ -248,30 +305,41 @@ fn validate_gtest_binary(spec: &TestSpec) -> Result<Option<String>> {
     )))
 }
 
-fn spawn_pipe_forwarder<R>(mut reader: R, shared_log: Arc<Mutex<File>>, is_stderr: bool) -> JoinHandle<Result<()>>
+fn spawn_pipe_forwarder<R>(
+    mut reader: R,
+    shared_log: Arc<Mutex<File>>,
+    is_stderr: bool,
+) -> JoinHandle<Result<()>>
 where
     R: Read + Send + 'static,
 {
     thread::spawn(move || -> Result<()> {
         let mut buf = [0_u8; 4096];
         loop {
-            let n = reader.read(&mut buf).with_context(|| "读取子进程管道失败")?;
+            let n = reader
+                .read(&mut buf)
+                .with_context(|| "读取子进程管道失败")?;
             if n == 0 {
                 break;
             }
 
             if is_stderr {
                 let mut term = std::io::stderr().lock();
-                term.write_all(&buf[..n]).with_context(|| "写入终端 stderr 失败")?;
+                term.write_all(&buf[..n])
+                    .with_context(|| "写入终端 stderr 失败")?;
                 term.flush().with_context(|| "刷新终端 stderr 失败")?;
             } else {
                 let mut term = std::io::stdout().lock();
-                term.write_all(&buf[..n]).with_context(|| "写入终端 stdout 失败")?;
+                term.write_all(&buf[..n])
+                    .with_context(|| "写入终端 stdout 失败")?;
                 term.flush().with_context(|| "刷新终端 stdout 失败")?;
             }
 
-            let mut log = shared_log.lock().map_err(|_| anyhow::anyhow!("日志锁已损坏"))?;
-            log.write_all(&buf[..n]).with_context(|| "写入日志文件失败")?;
+            let mut log = shared_log
+                .lock()
+                .map_err(|_| anyhow::anyhow!("日志锁已损坏"))?;
+            log.write_all(&buf[..n])
+                .with_context(|| "写入日志文件失败")?;
             log.flush().with_context(|| "刷新日志文件失败")?;
         }
         Ok(())
@@ -282,5 +350,68 @@ fn join_pipe_forwarder(handle: JoinHandle<Result<()>>) -> Result<()> {
     match handle.join() {
         Ok(inner) => inner,
         Err(_) => anyhow::bail!("输出转发线程发生 panic"),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::manifest::TestSpec;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn timeout_kills_forked_descendants_that_keep_pipes_open() {
+        let tmp = std::env::temp_dir().join(format!(
+            "dunitest-runner-pgrp-{}-{}",
+            std::process::id(),
+            unique_nanos()
+        ));
+        let results = tmp.join("results");
+        fs::create_dir_all(&results).unwrap();
+
+        let script = tmp.join("forking_gtest.sh");
+        fs::write(
+            &script,
+            r#"#!/bin/sh
+if [ "$1" = "--gtest_help" ]; then
+  echo "This program contains tests written using Google Test"
+  exit 0
+fi
+echo "[==========] Running 1 test from 1 test suite."
+echo "[ RUN      ] Timeout.KeepsPipeOpen"
+(sleep 30) &
+sleep 30
+"#,
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+
+        let spec = TestSpec {
+            name: "normal/forking_timeout".to_string(),
+            path: script.display().to_string(),
+            args: Vec::new(),
+            timeout_sec: 1,
+        };
+
+        let started = Instant::now();
+        let result = run_test(&spec, &results, false).unwrap();
+
+        assert!(matches!(result.status, CaseStatus::Timeout));
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "timeout path did not return promptly"
+        );
+
+        let _ = fs::remove_dir_all(tmp);
+    }
+
+    fn unique_nanos() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
     }
 }

--- a/user/apps/tests/dunitest/runner/src/executor.rs
+++ b/user/apps/tests/dunitest/runner/src/executor.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 const PIPE_JOIN_TIMEOUT: Duration = Duration::from_secs(2);
+const GTEST_PRECHECK_MAX_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
@@ -354,10 +355,11 @@ fn validate_gtest_binary(spec: &TestSpec) -> Result<GtestPrecheck> {
     let stdout_thread = spawn_pipe_collector(stdout_pipe);
     let stderr_thread = spawn_pipe_collector(stderr_pipe);
 
-    let timeout = Duration::from_secs(spec.timeout_sec.clamp(1, 5));
+    let timeout = gtest_precheck_timeout(spec.timeout_sec);
     let start = Instant::now();
     let status = loop {
-        if let Some(status) = child.try_wait().with_context(|| "等待预检查进程状态失败")? {
+        if let Some(status) = child.try_wait().with_context(|| "等待预检查进程状态失败")?
+        {
             break status;
         }
         if start.elapsed() >= timeout {
@@ -396,6 +398,10 @@ fn validate_gtest_binary(spec: &TestSpec) -> Result<GtestPrecheck> {
         stdout,
         stderr
     )))
+}
+
+fn gtest_precheck_timeout(case_timeout_sec: u64) -> Duration {
+    Duration::from_secs(case_timeout_sec.max(1)).min(GTEST_PRECHECK_MAX_TIMEOUT)
 }
 
 fn spawn_pipe_collector<R>(mut reader: R) -> JoinHandle<Result<Vec<u8>>>
@@ -504,6 +510,14 @@ mod tests {
     use crate::manifest::TestSpec;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn gtest_precheck_timeout_is_bounded_but_not_too_aggressive() {
+        assert_eq!(gtest_precheck_timeout(0), Duration::from_secs(1));
+        assert_eq!(gtest_precheck_timeout(1), Duration::from_secs(1));
+        assert_eq!(gtest_precheck_timeout(5), Duration::from_secs(5));
+        assert_eq!(gtest_precheck_timeout(60), Duration::from_secs(15));
+    }
 
     #[test]
     fn timeout_kills_forked_descendants_that_keep_pipes_open() {

--- a/user/apps/tests/dunitest/runner/src/executor.rs
+++ b/user/apps/tests/dunitest/runner/src/executor.rs
@@ -81,6 +81,22 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
             };
             return Ok(result);
         }
+        GtestPrecheck::CleanupFailed(msg) => {
+            writeln!(precheck_log, "{}", msg).with_context(|| "写入日志失败")?;
+            let result = CaseResult {
+                name: spec.name.clone(),
+                status: CaseStatus::Failed,
+                duration_ms: precheck_start.elapsed().as_millis(),
+                exit_code: None,
+                message: msg,
+                log_file: log_path.display().to_string(),
+                gtest_total: 0,
+                gtest_passed: 0,
+                gtest_failed: 0,
+                gtest_skipped: 0,
+            };
+            return Ok(result);
+        }
     }
     drop(precheck_log);
 
@@ -332,6 +348,7 @@ enum GtestPrecheck {
     Valid,
     Invalid(String),
     Timeout(String),
+    CleanupFailed(String),
 }
 
 fn validate_gtest_binary(spec: &TestSpec) -> Result<GtestPrecheck> {
@@ -379,9 +396,28 @@ fn validate_gtest_binary(spec: &TestSpec) -> Result<GtestPrecheck> {
         thread::sleep(Duration::from_millis(20));
     };
 
-    terminate_case_process_group(child.id())?;
-    let stdout = join_pipe_collector_bounded(stdout_thread, PIPE_JOIN_TIMEOUT)?;
-    let stderr = join_pipe_collector_bounded(stderr_thread, PIPE_JOIN_TIMEOUT)?;
+    let cleanup_result = terminate_case_process_group(child.id());
+    let stdout_result = join_pipe_collector_bounded(stdout_thread, PIPE_JOIN_TIMEOUT);
+    let stderr_result = join_pipe_collector_bounded(stderr_thread, PIPE_JOIN_TIMEOUT);
+
+    let mut cleanup_message = String::new();
+    if let Err(e) = cleanup_result {
+        cleanup_message.push_str(&format!("; 进程组清理失败: {e:#}"));
+    }
+    if let Err(e) = stdout_result.as_ref() {
+        cleanup_message.push_str(&format!("; stdout 收集失败: {e:#}"));
+    }
+    if let Err(e) = stderr_result.as_ref() {
+        cleanup_message.push_str(&format!("; stderr 收集失败: {e:#}"));
+    }
+    if !cleanup_message.is_empty() {
+        return Ok(GtestPrecheck::CleanupFailed(format!(
+            "gtest 预检查清理失败{cleanup_message}"
+        )));
+    }
+
+    let stdout = stdout_result.expect("stdout precheck result checked above");
+    let stderr = stderr_result.expect("stderr precheck result checked above");
     let stdout = String::from_utf8_lossy(&stdout);
     let stderr = String::from_utf8_lossy(&stderr);
     let merged = format!("{}\n{}", stdout, stderr);

--- a/user/apps/tests/dunitest/runner/src/executor.rs
+++ b/user/apps/tests/dunitest/runner/src/executor.rs
@@ -12,6 +12,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+const PIPE_JOIN_TIMEOUT: Duration = Duration::from_secs(2);
+
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
@@ -125,8 +127,8 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
             if let Err(e) = kill_group_result {
                 message.push_str(&format!("; 进程组终止失败，跳过管道线程收尾: {e:#}"));
             } else {
-                let stdout_join = join_pipe_forwarder(stdout_thread);
-                let stderr_join = join_pipe_forwarder(stderr_thread);
+                let stdout_join = join_pipe_forwarder_bounded(stdout_thread, PIPE_JOIN_TIMEOUT);
+                let stderr_join = join_pipe_forwarder_bounded(stderr_thread, PIPE_JOIN_TIMEOUT);
                 if let Err(e) = stdout_join {
                     message.push_str(&format!("; stdout 日志收尾失败: {e:#}"));
                 }
@@ -135,6 +137,7 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
                 }
             }
 
+            let gtest = parse_gtest_counts(&log_path).unwrap_or((0, 0, 0, 0));
             let result = CaseResult {
                 name: spec.name.clone(),
                 status: CaseStatus::Timeout,
@@ -142,24 +145,48 @@ pub fn run_test(spec: &TestSpec, results_dir: &Path, verbose: bool) -> Result<Ca
                 exit_code: None,
                 message,
                 log_file: log_path.display().to_string(),
-                gtest_total: 0,
-                gtest_passed: 0,
-                gtest_failed: 0,
-                gtest_skipped: 0,
+                gtest_total: gtest.0,
+                gtest_passed: gtest.1,
+                gtest_failed: gtest.2,
+                gtest_skipped: gtest.3,
             };
             return Ok(result);
         }
         thread::sleep(Duration::from_millis(50));
     };
-    join_pipe_forwarder(stdout_thread)?;
-    join_pipe_forwarder(stderr_thread)?;
+    let cleanup_result = terminate_case_process_group(child.id());
+    let stdout_join = join_pipe_forwarder_bounded(stdout_thread, PIPE_JOIN_TIMEOUT);
+    let stderr_join = join_pipe_forwarder_bounded(stderr_thread, PIPE_JOIN_TIMEOUT);
+    let mut cleanup_message = String::new();
+    if let Err(e) = cleanup_result {
+        cleanup_message.push_str(&format!("; 进程组清理失败: {e:#}"));
+    }
+    if let Err(e) = stdout_join {
+        cleanup_message.push_str(&format!("; stdout 日志收尾失败: {e:#}"));
+    }
+    if let Err(e) = stderr_join {
+        cleanup_message.push_str(&format!("; stderr 日志收尾失败: {e:#}"));
+    }
 
     let elapsed = start.elapsed().as_millis();
     let code = status.code();
     let passed = status.success();
     let gtest = parse_gtest_counts(&log_path).unwrap_or((0, 0, 0, 0));
 
-    let result = if passed {
+    let result = if !cleanup_message.is_empty() {
+        CaseResult {
+            name: spec.name.clone(),
+            status: CaseStatus::Failed,
+            duration_ms: elapsed,
+            exit_code: code,
+            message: format!("测试进程退出后清理失败{cleanup_message}"),
+            log_file: log_path.display().to_string(),
+            gtest_total: gtest.0,
+            gtest_passed: gtest.1,
+            gtest_failed: gtest.2,
+            gtest_skipped: gtest.3,
+        }
+    } else if passed {
         CaseResult {
             name: spec.name.clone(),
             status: CaseStatus::Passed,
@@ -342,17 +369,17 @@ fn validate_gtest_binary(spec: &TestSpec) -> Result<GtestPrecheck> {
             if let Err(e) = kill_group_result {
                 message.push_str(&format!("; 进程组终止失败，跳过管道线程收尾: {e:#}"));
             } else {
-                let _ = join_pipe_collector(stdout_thread);
-                let _ = join_pipe_collector(stderr_thread);
+                let _ = join_pipe_collector_bounded(stdout_thread, PIPE_JOIN_TIMEOUT);
+                let _ = join_pipe_collector_bounded(stderr_thread, PIPE_JOIN_TIMEOUT);
             }
             return Ok(GtestPrecheck::Timeout(message));
         }
         thread::sleep(Duration::from_millis(20));
     };
 
-    let _ = terminate_case_process_group(child.id());
-    let stdout = join_pipe_collector(stdout_thread)?;
-    let stderr = join_pipe_collector(stderr_thread)?;
+    terminate_case_process_group(child.id())?;
+    let stdout = join_pipe_collector_bounded(stdout_thread, PIPE_JOIN_TIMEOUT)?;
+    let stderr = join_pipe_collector_bounded(stderr_thread, PIPE_JOIN_TIMEOUT)?;
     let stdout = String::from_utf8_lossy(&stdout);
     let stderr = String::from_utf8_lossy(&stderr);
     let merged = format!("{}\n{}", stdout, stderr);
@@ -396,6 +423,20 @@ fn join_pipe_collector(handle: JoinHandle<Result<Vec<u8>>>) -> Result<Vec<u8>> {
         Ok(inner) => inner,
         Err(_) => anyhow::bail!("预检查输出收集线程发生 panic"),
     }
+}
+
+fn join_pipe_collector_bounded(
+    handle: JoinHandle<Result<Vec<u8>>>,
+    timeout: Duration,
+) -> Result<Vec<u8>> {
+    let start = Instant::now();
+    while !handle.is_finished() {
+        if start.elapsed() >= timeout {
+            anyhow::bail!("预检查输出收集线程未在 {:?} 内退出", timeout);
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    join_pipe_collector(handle)
 }
 
 fn spawn_pipe_forwarder<R>(
@@ -444,6 +485,17 @@ fn join_pipe_forwarder(handle: JoinHandle<Result<()>>) -> Result<()> {
         Ok(inner) => inner,
         Err(_) => anyhow::bail!("输出转发线程发生 panic"),
     }
+}
+
+fn join_pipe_forwarder_bounded(handle: JoinHandle<Result<()>>, timeout: Duration) -> Result<()> {
+    let start = Instant::now();
+    while !handle.is_finished() {
+        if start.elapsed() >= timeout {
+            anyhow::bail!("输出转发线程在 {:?} 内未结束", timeout);
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    join_pipe_forwarder(handle)
 }
 
 #[cfg(all(test, unix))]
@@ -592,6 +644,57 @@ echo "[  PASSED  ] 1 test."
         assert!(
             started.elapsed() < Duration::from_secs(10),
             "precheck success path did not clean descendant pipe holders"
+        );
+
+        let _ = fs::remove_dir_all(tmp);
+    }
+
+    #[test]
+    fn success_path_kills_forked_descendants_that_keep_pipes_open() {
+        let tmp = std::env::temp_dir().join(format!(
+            "dunitest-runner-success-pgrp-{}-{}",
+            std::process::id(),
+            unique_nanos()
+        ));
+        let results = tmp.join("results");
+        fs::create_dir_all(&results).unwrap();
+
+        let script = tmp.join("forking_gtest_success.sh");
+        fs::write(
+            &script,
+            r#"#!/bin/sh
+if [ "$1" = "--gtest_help" ]; then
+  echo "This program contains tests written using Google Test"
+  exit 0
+fi
+echo "[==========] Running 1 test from 1 test suite."
+echo "[ RUN      ] Smoke.Pass"
+(sleep 30) &
+echo "[       OK ] Smoke.Pass"
+echo "[==========] 1 test from 1 test suite ran."
+echo "[  PASSED  ] 1 test."
+exit 0
+"#,
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+
+        let spec = TestSpec {
+            name: "normal/forking_success".to_string(),
+            path: script.display().to_string(),
+            args: Vec::new(),
+            timeout_sec: 5,
+        };
+
+        let started = Instant::now();
+        let result = run_test(&spec, &results, false).unwrap();
+
+        assert!(matches!(result.status, CaseStatus::Passed));
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "success path did not clean descendant pipe holders"
         );
 
         let _ = fs::remove_dir_all(tmp);

--- a/user/apps/tests/dunitest/runner/src/main.rs
+++ b/user/apps/tests/dunitest/runner/src/main.rs
@@ -64,6 +64,7 @@ fn main() -> Result<()> {
         .with_context(|| format!("创建结果目录失败: {}", results_dir.display()))?;
 
     let mut results: Vec<CaseResult> = Vec::new();
+    let mut runnable_count = 0usize;
     for test in &manifest.tests {
         if let Some(skip_reason) =
             select_test(test, &cli.patterns, whitelist.as_ref(), blocklist.as_ref())
@@ -85,6 +86,7 @@ fn main() -> Result<()> {
             continue;
         }
 
+        runnable_count += 1;
         println!("[RUNNER] START: {}", test.name);
 
         let mut t = test.clone();
@@ -104,6 +106,11 @@ fn main() -> Result<()> {
     let summary = build_summary(results);
     write_reports(&results_dir, &summary)?;
     show_summary(&summary, &results_dir);
+
+    if runnable_count == 0 {
+        eprintln!("[RUNNER] ERROR: no runnable tests selected");
+        std::process::exit(1);
+    }
 
     if summary.failed > 0 || summary.timeout > 0 {
         std::process::exit(1);

--- a/user/apps/tests/dunitest/runner/src/main.rs
+++ b/user/apps/tests/dunitest/runner/src/main.rs
@@ -14,7 +14,11 @@ use std::{
 };
 
 #[derive(Debug, Parser)]
-#[command(name = "dunitest-runner", version, about = "DragonOS dunitest runner (M1)")]
+#[command(
+    name = "dunitest-runner",
+    version,
+    about = "DragonOS dunitest runner (M1)"
+)]
 struct Cli {
     #[arg(long, default_value = "bin")]
     bin_dir: PathBuf,
@@ -49,14 +53,7 @@ fn main() -> Result<()> {
 
     if cli.list {
         for t in &manifest.tests {
-            if select_test(
-                t,
-                &cli.patterns,
-                whitelist.as_ref(),
-                blocklist.as_ref(),
-            )
-            .is_none()
-            {
+            if select_test(t, &cli.patterns, whitelist.as_ref(), blocklist.as_ref()).is_none() {
                 println!("{}", t.name);
             }
         }
@@ -68,12 +65,9 @@ fn main() -> Result<()> {
 
     let mut results: Vec<CaseResult> = Vec::new();
     for test in &manifest.tests {
-        if let Some(skip_reason) = select_test(
-            test,
-            &cli.patterns,
-            whitelist.as_ref(),
-            blocklist.as_ref(),
-        ) {
+        if let Some(skip_reason) =
+            select_test(test, &cli.patterns, whitelist.as_ref(), blocklist.as_ref())
+        {
             let skipped = CaseResult {
                 name: test.name.clone(),
                 status: CaseStatus::Skipped,
@@ -86,10 +80,7 @@ fn main() -> Result<()> {
                 gtest_failed: 0,
                 gtest_skipped: 0,
             };
-            println!(
-                "[RUNNER] SKIP: {} reason={}",
-                skipped.name, skipped.message
-            );
+            println!("[RUNNER] SKIP: {} reason={}", skipped.name, skipped.message);
             results.push(skipped);
             continue;
         }

--- a/user/apps/tests/dunitest/runner/src/manifest.rs
+++ b/user/apps/tests/dunitest/runner/src/manifest.rs
@@ -97,8 +97,8 @@ fn normalize_case_name(relative_path: &str) -> String {
 fn is_executable(path: &Path) -> Result<bool> {
     #[cfg(unix)]
     {
-        let metadata = fs::metadata(path)
-            .with_context(|| format!("读取文件属性失败: {}", path.display()))?;
+        let metadata =
+            fs::metadata(path).with_context(|| format!("读取文件属性失败: {}", path.display()))?;
         Ok(metadata.permissions().mode() & 0o111 != 0)
     }
     #[cfg(not(unix))]

--- a/user/apps/tests/dunitest/runner/src/report.rs
+++ b/user/apps/tests/dunitest/runner/src/report.rs
@@ -19,57 +19,46 @@ pub struct Summary {
 }
 
 pub fn build_summary(cases: Vec<CaseResult>) -> Summary {
+    let mut total = 0usize;
     let mut passed = 0usize;
     let mut failed = 0usize;
     let mut skipped = 0usize;
     let mut timeout = 0usize;
-    let mut gtest_total = 0usize;
-    let mut gtest_passed = 0usize;
-    let mut gtest_failed = 0usize;
-    let mut gtest_skipped = 0usize;
 
     for c in &cases {
-        gtest_total += c.gtest_total;
-        gtest_passed += c.gtest_passed;
-        gtest_failed += c.gtest_failed;
-        gtest_skipped += c.gtest_skipped;
+        if c.gtest_total > 0 {
+            total += c.gtest_total;
+            passed += c.gtest_passed;
+            failed += c.gtest_failed;
+            skipped += c.gtest_skipped;
 
-        match c.status {
-            CaseStatus::Passed => {
-                if c.gtest_total == 0 {
-                    passed += 1;
-                }
-            }
-            CaseStatus::Failed => {
-                if c.gtest_total == 0 {
-                    failed += 1;
-                }
-            }
-            CaseStatus::Skipped => {
-                if c.gtest_total == 0 {
-                    skipped += 1;
-                }
-            }
-            CaseStatus::Timeout => {
-                if c.gtest_total == 0 {
+            match c.status {
+                CaseStatus::Timeout => {
+                    total += 1;
                     timeout += 1;
                 }
+                CaseStatus::Failed if c.gtest_failed == 0 => {
+                    total += 1;
+                    failed += 1;
+                }
+                CaseStatus::Skipped if c.gtest_skipped == 0 => {
+                    total += 1;
+                    skipped += 1;
+                }
+                CaseStatus::Passed | CaseStatus::Failed | CaseStatus::Skipped => {}
             }
+            continue;
+        }
+
+        total += 1;
+        match c.status {
+            CaseStatus::Passed => passed += 1,
+            CaseStatus::Failed => failed += 1,
+            CaseStatus::Skipped => skipped += 1,
+            CaseStatus::Timeout => timeout += 1,
         }
     }
 
-    if gtest_total > 0 {
-        passed = gtest_passed;
-        failed = gtest_failed;
-        skipped = gtest_skipped;
-        timeout = 0;
-    }
-
-    let total = if gtest_total > 0 {
-        gtest_total
-    } else {
-        cases.len()
-    };
     let success_rate = if total == 0 {
         0.0
     } else {
@@ -125,17 +114,125 @@ fn write_text_report(results_dir: &Path, summary: &Summary) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn case(
+        name: &str,
+        status: CaseStatus,
+        gtest_total: usize,
+        gtest_passed: usize,
+        gtest_failed: usize,
+        gtest_skipped: usize,
+    ) -> CaseResult {
+        CaseResult {
+            name: name.to_string(),
+            status,
+            duration_ms: 0,
+            exit_code: None,
+            message: String::new(),
+            log_file: String::new(),
+            gtest_total,
+            gtest_passed,
+            gtest_failed,
+            gtest_skipped,
+        }
+    }
+
+    #[test]
+    fn preserves_timeout_when_mixed_with_gtest_passes() {
+        let summary = build_summary(vec![
+            case("normal/passed", CaseStatus::Passed, 3, 3, 0, 0),
+            case("normal/timeout", CaseStatus::Timeout, 0, 0, 0, 0),
+        ]);
+
+        assert_eq!(summary.total, 4);
+        assert_eq!(summary.passed, 3);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.skipped, 0);
+        assert_eq!(summary.timeout, 1);
+        assert!(summary.success_rate < 100.0);
+    }
+
+    #[test]
+    fn timeout_status_wins_over_partial_gtest_counts() {
+        let summary = build_summary(vec![case(
+            "normal/partial-timeout",
+            CaseStatus::Timeout,
+            2,
+            2,
+            0,
+            0,
+        )]);
+
+        assert_eq!(summary.total, 3);
+        assert_eq!(summary.passed, 2);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.skipped, 0);
+        assert_eq!(summary.timeout, 1);
+    }
+
+    #[test]
+    fn failed_status_is_preserved_when_gtest_counts_do_not_explain_it() {
+        let summary = build_summary(vec![case(
+            "normal/failed-after-gtest",
+            CaseStatus::Failed,
+            2,
+            2,
+            0,
+            0,
+        )]);
+
+        assert_eq!(summary.total, 3);
+        assert_eq!(summary.passed, 2);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.skipped, 0);
+        assert_eq!(summary.timeout, 0);
+    }
+
+    #[test]
+    fn mixes_gtest_failure_and_case_skip() {
+        let summary = build_summary(vec![
+            case("normal/gtest-failed", CaseStatus::Failed, 4, 2, 1, 1),
+            case("normal/skipped", CaseStatus::Skipped, 0, 0, 0, 0),
+        ]);
+
+        assert_eq!(summary.total, 5);
+        assert_eq!(summary.passed, 2);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.skipped, 2);
+        assert_eq!(summary.timeout, 0);
+    }
+
+    #[test]
+    fn keeps_non_gtest_case_only_behavior() {
+        let summary = build_summary(vec![
+            case("case/passed", CaseStatus::Passed, 0, 0, 0, 0),
+            case("case/failed", CaseStatus::Failed, 0, 0, 0, 0),
+            case("case/skipped", CaseStatus::Skipped, 0, 0, 0, 0),
+            case("case/timeout", CaseStatus::Timeout, 0, 0, 0, 0),
+        ]);
+
+        assert_eq!(summary.total, 4);
+        assert_eq!(summary.passed, 1);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(summary.timeout, 1);
+    }
+}
+
 fn write_json_report(results_dir: &Path, summary: &Summary) -> Result<()> {
     let file = results_dir.join("summary.json");
-    let content = serde_json::to_string_pretty(summary).with_context(|| "序列化 summary.json 失败")?;
+    let content =
+        serde_json::to_string_pretty(summary).with_context(|| "序列化 summary.json 失败")?;
     fs::write(&file, content).with_context(|| format!("写入失败: {}", file.display()))?;
     Ok(())
 }
 
 fn write_failed_cases(results_dir: &Path, summary: &Summary) -> Result<()> {
     let file = results_dir.join("failed_cases.txt");
-    let mut f =
-        File::create(&file).with_context(|| format!("创建文件失败: {}", file.display()))?;
+    let mut f = File::create(&file).with_context(|| format!("创建文件失败: {}", file.display()))?;
     for c in &summary.cases {
         match c.status {
             CaseStatus::Failed | CaseStatus::Timeout => {

--- a/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
@@ -21,6 +21,7 @@ constexpr size_t kNrPages = 64;
 constexpr int kNrThreads = 4;
 constexpr int kIters = 2000;
 constexpr int kMunmapRounds = 16;
+constexpr size_t kCowSnapStride = 256;
 
 thread_local sigjmp_buf g_segv_jmp;
 thread_local volatile sig_atomic_t g_segv_active = 0;
@@ -251,6 +252,8 @@ struct HammerCtx {
     size_t len;
     std::atomic<int>* run;
     std::atomic<int>* ready;
+    std::atomic<int>* post_phase;
+    std::atomic<int>* post_done;
     uint8_t mark;
 };
 
@@ -271,7 +274,16 @@ void* hammer_writer_whole(void* arg) {
         ctx->ready->fetch_add(1, std::memory_order_release);
     }
 
+    bool published_post_done = false;
     while (ctx->run->load(std::memory_order_acquire) != 0) {
+        if (!published_post_done && ctx->post_phase != nullptr &&
+            ctx->post_phase->load(std::memory_order_acquire) != 0) {
+            for (size_t off = 0; off < ctx->len; off += kCowSnapStride) {
+                ctx->base[off] = v++;
+            }
+            ctx->post_done->fetch_add(1, std::memory_order_release);
+            published_post_done = true;
+        }
         ctx->base[off] = v++;
         off += 13;
         if (off >= ctx->len) {
@@ -309,8 +321,7 @@ void* hammer_writer_whole(void* arg) {
 //     pages for the parent mm. The child's physical pages stay pristine.
 int case_fork_cow_stale_tlb() {
     const size_t len = kNrPages * kPageSize;
-    constexpr size_t kSnapStride = 256;
-    constexpr size_t kSnapCount = (kNrPages * kPageSize) / kSnapStride;
+    constexpr size_t kSnapCount = (kNrPages * kPageSize) / kCowSnapStride;
     constexpr size_t kSnapMapLen = kPageSize;
     static_assert(kSnapCount <= kSnapMapLen, "snapshot mapping too small");
 
@@ -349,6 +360,8 @@ int case_fork_cow_stale_tlb() {
 
     std::atomic<int> run{1};
     std::atomic<int> ready{0};
+    std::atomic<int> post_phase{0};
+    std::atomic<int> post_done{0};
     pthread_t threads[kNrThreads];
     HammerCtx ctxs[kNrThreads];
     int created = 0;
@@ -357,6 +370,8 @@ int case_fork_cow_stale_tlb() {
         ctxs[created].len = len;
         ctxs[created].run = &run;
         ctxs[created].ready = &ready;
+        ctxs[created].post_phase = &post_phase;
+        ctxs[created].post_done = &post_done;
         ctxs[created].mark = static_cast<uint8_t>(0x10 + created);
         if (pthread_create(&threads[created], nullptr, hammer_writer_whole, &ctxs[created]) != 0) {
             fprintf(stderr, "pthread_create failed\n");
@@ -422,7 +437,7 @@ int case_fork_cow_stale_tlb() {
         // creating worker threads so the post-fork child does not enter
         // malloc/free or stdio paths while only one thread survived fork().
         for (size_t i = 0; i < kSnapCount; ++i) {
-            snap[i] = child_buf[i * kSnapStride];
+            snap[i] = child_buf[i * kCowSnapStride];
         }
 
         const uint8_t token = 1;
@@ -444,7 +459,7 @@ int case_fork_cow_stale_tlb() {
         constexpr int kRounds = 400;
         for (int r = 0; r < kRounds; ++r) {
             for (size_t i = 0; i < kSnapCount; ++i) {
-                const uint8_t v = child_buf[i * kSnapStride];
+                const uint8_t v = child_buf[i * kCowSnapStride];
                 if (v != snap[i]) {
                     _exit(10);
                 }
@@ -475,12 +490,30 @@ int case_fork_cow_stale_tlb() {
         return -1;
     }
 
+    // Force every worker to write all sampled offsets after the child snapshot
+    // has been published. This turns the remote writer part of the stale-TLB
+    // check into an explicit phase instead of relying on scheduler luck.
+    post_phase.store(1, std::memory_order_release);
+    if (wait_for_workers_ready(&post_done) != 0) {
+        fprintf(stderr, "workers did not complete post-snapshot writes\n");
+        run.store(0, std::memory_order_release);
+        for (int i = 0; i < kNrThreads; ++i) {
+            pthread_join(threads[i], nullptr);
+        }
+        close(verify_pipe[1]);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        munmap(snap, kSnapMapLen);
+        munmap(buf, len);
+        return -1;
+    }
+
     // Keep parent writes active for a bounded post-snapshot window without
     // relying on sched_yield() or nanosleep() progress semantics.
     volatile uint8_t* parent_buf = buf;
     for (int round = 0; round < 128; ++round) {
         for (size_t i = 0; i < kSnapCount; ++i) {
-            parent_buf[i * kSnapStride] = static_cast<uint8_t>(round + i);
+            parent_buf[i * kCowSnapStride] = static_cast<uint8_t>(round + i);
         }
     }
     const uint8_t start_verify = 1;

--- a/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
@@ -54,26 +54,38 @@ struct ThreadCtx {
     volatile uint8_t* base;
     size_t len;
     std::atomic<int>* run;
+    std::atomic<int>* ready;
 };
+
+void cpu_pause_loop(int rounds) {
+    for (volatile int i = 0; i < rounds; ++i) {
+#if defined(__x86_64__) || defined(__i386__)
+        __asm__ __volatile__("pause" ::: "memory");
+#else
+        __asm__ __volatile__("" ::: "memory");
+#endif
+    }
+}
 
 void* hammer_writer(void* arg) {
     auto* ctx = static_cast<ThreadCtx*>(arg);
     size_t off = 0;
-    size_t spins = 0;
 
     if (sigsetjmp(g_segv_jmp, 1) != 0) {
-        sched_yield();
+        cpu_pause_loop(1024);
     }
     g_segv_active = 1;
 
+    bool published_ready = false;
     while (ctx->run->load(std::memory_order_acquire)) {
         ctx->base[off] = static_cast<uint8_t>(off);
+        if (!published_ready && ctx->ready != nullptr) {
+            ctx->ready->fetch_add(1, std::memory_order_release);
+            published_ready = true;
+        }
         off += 13;
         if (off >= ctx->len) {
             off = 0;
-        }
-        if ((++spins & 0xff) == 0) {
-            sched_yield();
         }
     }
 
@@ -82,12 +94,13 @@ void* hammer_writer(void* arg) {
 }
 
 int start_workers(uint8_t* buf, size_t len, std::atomic<int>* run, pthread_t* threads,
-                  ThreadCtx* ctxs) {
+                  ThreadCtx* ctxs, std::atomic<int>* ready = nullptr) {
     int created = 0;
     for (; created < kNrThreads; ++created) {
         ctxs[created].base = buf + created * kPageSize;
         ctxs[created].len = len / kNrPages;
         ctxs[created].run = run;
+        ctxs[created].ready = ready;
         if (pthread_create(&threads[created], nullptr, hammer_writer, &ctxs[created]) != 0) {
             fprintf(stderr, "pthread_create failed\n");
             run->store(0, std::memory_order_release);
@@ -98,6 +111,18 @@ int start_workers(uint8_t* buf, size_t len, std::atomic<int>* run, pthread_t* th
         }
     }
     return 0;
+}
+
+int wait_for_workers_ready(std::atomic<int>* ready) {
+    constexpr int kMaxSpins = 2000000;
+    for (int i = 0; i < kMaxSpins; ++i) {
+        if (ready->load(std::memory_order_acquire) >= kNrThreads) {
+            return 0;
+        }
+        cpu_pause_loop(64);
+    }
+    fprintf(stderr, "workers did not become ready\n");
+    return -1;
 }
 
 void stop_workers(std::atomic<int>* run, pthread_t* threads) {
@@ -117,10 +142,17 @@ int case_mprotect_downgrade() {
     }
     memset(buf, 0, len);
 
+    // Writer state: nonzero = write, 0 = stop.
     std::atomic<int> run{1};
+    std::atomic<int> ready{0};
     pthread_t threads[kNrThreads];
     ThreadCtx ctxs[kNrThreads];
-    if (start_workers(buf, len, &run, threads, ctxs) != 0) {
+    if (start_workers(buf, len, &run, threads, ctxs, &ready) != 0) {
+        munmap(buf, len);
+        return -1;
+    }
+    if (wait_for_workers_ready(&ready) != 0) {
+        stop_workers(&run, threads);
         munmap(buf, len);
         return -1;
     }
@@ -169,14 +201,19 @@ int case_munmap_while_writing() {
         memset(buf, 0, len);
 
         std::atomic<int> run{1};
+        std::atomic<int> ready{0};
         pthread_t threads[kNrThreads];
         ThreadCtx ctxs[kNrThreads];
-        if (start_workers(buf, len, &run, threads, ctxs) != 0) {
+        if (start_workers(buf, len, &run, threads, ctxs, &ready) != 0) {
             munmap(buf, len);
             return -1;
         }
 
-        usleep(2000);
+        if (wait_for_workers_ready(&ready) != 0) {
+            stop_workers(&run, threads);
+            munmap(buf, len);
+            return -1;
+        }
         stop_workers(&run, threads);
 
         if (munmap(buf, len) < 0) {
@@ -213,6 +250,7 @@ struct HammerCtx {
     volatile uint8_t* base;
     size_t len;
     std::atomic<int>* run;
+    std::atomic<int>* ready;
     uint8_t mark;
 };
 
@@ -220,21 +258,24 @@ void* hammer_writer_whole(void* arg) {
     auto* ctx = static_cast<HammerCtx*>(arg);
     size_t off = 0;
     uint8_t v = ctx->mark;
-    size_t spins = 0;
 
     if (sigsetjmp(g_segv_jmp, 1) != 0) {
-        sched_yield();
+        _exit(12);
     }
     g_segv_active = 1;
 
-    while (ctx->run->load(std::memory_order_acquire)) {
+    if (ctx->ready != nullptr) {
+        for (size_t off = 0; off < ctx->len; off += kPageSize) {
+            ctx->base[off] = v++;
+        }
+        ctx->ready->fetch_add(1, std::memory_order_release);
+    }
+
+    while (ctx->run->load(std::memory_order_acquire) != 0) {
         ctx->base[off] = v++;
         off += 13;
         if (off >= ctx->len) {
             off = 0;
-        }
-        if ((++spins & 0xff) == 0) {
-            sched_yield();
         }
     }
 
@@ -268,6 +309,11 @@ void* hammer_writer_whole(void* arg) {
 //     pages for the parent mm. The child's physical pages stay pristine.
 int case_fork_cow_stale_tlb() {
     const size_t len = kNrPages * kPageSize;
+    constexpr size_t kSnapStride = 256;
+    constexpr size_t kSnapCount = (kNrPages * kPageSize) / kSnapStride;
+    constexpr size_t kSnapMapLen = kPageSize;
+    static_assert(kSnapCount <= kSnapMapLen, "snapshot mapping too small");
+
     auto* buf = static_cast<uint8_t*>(
         mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
     if (buf == MAP_FAILED) {
@@ -276,7 +322,24 @@ int case_fork_cow_stale_tlb() {
     }
     memset(buf, 0, len);
 
+    auto* snap = static_cast<uint8_t*>(
+        mmap(nullptr, kSnapMapLen, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (snap == MAP_FAILED) {
+        perror("mmap snapshot");
+        munmap(buf, len);
+        return -1;
+    }
+
+    int snapshot_pipe[2];
+    if (pipe(snapshot_pipe) != 0) {
+        perror("pipe");
+        munmap(snap, kSnapMapLen);
+        munmap(buf, len);
+        return -1;
+    }
+
     std::atomic<int> run{1};
+    std::atomic<int> ready{0};
     pthread_t threads[kNrThreads];
     HammerCtx ctxs[kNrThreads];
     int created = 0;
@@ -284,6 +347,7 @@ int case_fork_cow_stale_tlb() {
         ctxs[created].base = buf;
         ctxs[created].len = len;
         ctxs[created].run = &run;
+        ctxs[created].ready = &ready;
         ctxs[created].mark = static_cast<uint8_t>(0x10 + created);
         if (pthread_create(&threads[created], nullptr, hammer_writer_whole, &ctxs[created]) != 0) {
             fprintf(stderr, "pthread_create failed\n");
@@ -291,14 +355,29 @@ int case_fork_cow_stale_tlb() {
             for (int i = 0; i < created; ++i) {
                 pthread_join(threads[i], nullptr);
             }
+            close(snapshot_pipe[0]);
+            close(snapshot_pipe[1]);
+            munmap(snap, kSnapMapLen);
             munmap(buf, len);
             return -1;
         }
     }
 
-    // Give the hammer threads a chance to spread across multiple CPUs so they
-    // really populate writable TLB entries everywhere.
-    usleep(5000);
+    // Wait until each hammer has touched the full buffer once. Keep them active
+    // across fork so the parent mm is still active on remote CPUs when
+    // try_clone() write-protects parent PTEs and performs the parent-side
+    // shootdown.
+    if (wait_for_workers_ready(&ready) != 0) {
+        run.store(0, std::memory_order_release);
+        for (int i = 0; i < kNrThreads; ++i) {
+            pthread_join(threads[i], nullptr);
+        }
+        close(snapshot_pipe[0]);
+        close(snapshot_pipe[1]);
+        munmap(snap, kSnapMapLen);
+        munmap(buf, len);
+        return -1;
+    }
 
     pid_t pid = fork();
     if (pid < 0) {
@@ -307,51 +386,83 @@ int case_fork_cow_stale_tlb() {
         for (int i = 0; i < kNrThreads; ++i) {
             pthread_join(threads[i], nullptr);
         }
+        close(snapshot_pipe[0]);
+        close(snapshot_pipe[1]);
+        munmap(snap, kSnapMapLen);
         munmap(buf, len);
         return -1;
     }
 
     if (pid == 0) {
+        close(snapshot_pipe[0]);
+        volatile uint8_t* child_buf = buf;
         // Child. Snapshot `buf` immediately so we know what the post-fork
         // COW-shared physical pages look like from our point of view. Any
         // subsequent divergence in a sampled byte must be a stale-TLB leak
         // from the parent mm: the child has only one thread and it never
         // writes `buf` itself.
         //
-        // Sample every 256 bytes (16 samples/page). That's 1 KiB per page of
-        // buf state captured, which is more than enough to notice a leak.
-        constexpr size_t kSnapStride = 256;
-        const size_t snap_count = len / kSnapStride;
-        uint8_t* snap = new uint8_t[snap_count];
-        for (size_t i = 0; i < snap_count; ++i) {
-            snap[i] = buf[i * kSnapStride];
+        // Sample every 256 bytes (16 samples/page). `snap` was mmap'ed before
+        // creating worker threads so the post-fork child does not enter
+        // malloc/free or stdio paths while only one thread survived fork().
+        for (size_t i = 0; i < kSnapCount; ++i) {
+            snap[i] = child_buf[i * kSnapStride];
         }
+
+        const uint8_t token = 1;
+        if (write(snapshot_pipe[1], &token, sizeof(token)) != sizeof(token)) {
+            _exit(11);
+        }
+        close(snapshot_pipe[1]);
 
         constexpr int kRounds = 400;
         for (int r = 0; r < kRounds; ++r) {
-            for (size_t i = 0; i < snap_count; ++i) {
-                const uint8_t v = buf[i * kSnapStride];
+            for (size_t i = 0; i < kSnapCount; ++i) {
+                const uint8_t v = child_buf[i * kSnapStride];
                 if (v != snap[i]) {
-                    fprintf(stderr,
-                            "FAIL: child observed parent's stale-TLB write: "
-                            "buf[%zu]: 0x%02x -> 0x%02x (round %d)\n",
-                            i * kSnapStride, snap[i], v, r);
-                    delete[] snap;
                     _exit(10);
                 }
             }
-            sched_yield();
         }
-        delete[] snap;
         _exit(0);
     }
 
-    int status = 0;
-    const pid_t wp = waitpid(pid, &status, 0);
+    close(snapshot_pipe[1]);
+    uint8_t token = 0;
+    ssize_t nread = 0;
+    do {
+        nread = read(snapshot_pipe[0], &token, sizeof(token));
+    } while (nread < 0 && errno == EINTR);
+    close(snapshot_pipe[0]);
+    if (nread != sizeof(token) || token != 1) {
+        fprintf(stderr, "child did not publish COW snapshot\n");
+        run.store(0, std::memory_order_release);
+        for (int i = 0; i < kNrThreads; ++i) {
+            pthread_join(threads[i], nullptr);
+        }
+        int status = 0;
+        waitpid(pid, &status, 0);
+        munmap(snap, kSnapMapLen);
+        munmap(buf, len);
+        return -1;
+    }
+
+    // Keep parent writes active for a bounded post-snapshot window without
+    // relying on sched_yield() or nanosleep() progress semantics.
+    volatile uint8_t* parent_buf = buf;
+    for (int round = 0; round < 128; ++round) {
+        for (size_t i = 0; i < kSnapCount; ++i) {
+            parent_buf[i * kSnapStride] = static_cast<uint8_t>(round + i);
+        }
+    }
     run.store(0, std::memory_order_release);
     for (int i = 0; i < kNrThreads; ++i) {
         pthread_join(threads[i], nullptr);
     }
+
+    int status = 0;
+    const pid_t wp = waitpid(pid, &status, 0);
+    munmap(snap, kSnapMapLen);
     munmap(buf, len);
 
     if (wp != pid) {
@@ -390,5 +501,6 @@ int main(int argc, char** argv) {
     }
 
     ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    const int rc = RUN_ALL_TESTS();
+    _exit(rc == 0 ? 0 : 1);
 }

--- a/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_tlb_shootdown.cc
@@ -337,6 +337,15 @@ int case_fork_cow_stale_tlb() {
         munmap(buf, len);
         return -1;
     }
+    int verify_pipe[2];
+    if (pipe(verify_pipe) != 0) {
+        perror("pipe verify");
+        close(snapshot_pipe[0]);
+        close(snapshot_pipe[1]);
+        munmap(snap, kSnapMapLen);
+        munmap(buf, len);
+        return -1;
+    }
 
     std::atomic<int> run{1};
     std::atomic<int> ready{0};
@@ -357,6 +366,8 @@ int case_fork_cow_stale_tlb() {
             }
             close(snapshot_pipe[0]);
             close(snapshot_pipe[1]);
+            close(verify_pipe[0]);
+            close(verify_pipe[1]);
             munmap(snap, kSnapMapLen);
             munmap(buf, len);
             return -1;
@@ -374,6 +385,8 @@ int case_fork_cow_stale_tlb() {
         }
         close(snapshot_pipe[0]);
         close(snapshot_pipe[1]);
+        close(verify_pipe[0]);
+        close(verify_pipe[1]);
         munmap(snap, kSnapMapLen);
         munmap(buf, len);
         return -1;
@@ -388,6 +401,8 @@ int case_fork_cow_stale_tlb() {
         }
         close(snapshot_pipe[0]);
         close(snapshot_pipe[1]);
+        close(verify_pipe[0]);
+        close(verify_pipe[1]);
         munmap(snap, kSnapMapLen);
         munmap(buf, len);
         return -1;
@@ -395,6 +410,7 @@ int case_fork_cow_stale_tlb() {
 
     if (pid == 0) {
         close(snapshot_pipe[0]);
+        close(verify_pipe[1]);
         volatile uint8_t* child_buf = buf;
         // Child. Snapshot `buf` immediately so we know what the post-fork
         // COW-shared physical pages look like from our point of view. Any
@@ -415,6 +431,16 @@ int case_fork_cow_stale_tlb() {
         }
         close(snapshot_pipe[1]);
 
+        uint8_t start_verify = 0;
+        ssize_t nread_verify = 0;
+        do {
+            nread_verify = read(verify_pipe[0], &start_verify, sizeof(start_verify));
+        } while (nread_verify < 0 && errno == EINTR);
+        close(verify_pipe[0]);
+        if (nread_verify != sizeof(start_verify) || start_verify != 1) {
+            _exit(12);
+        }
+
         constexpr int kRounds = 400;
         for (int r = 0; r < kRounds; ++r) {
             for (size_t i = 0; i < kSnapCount; ++i) {
@@ -428,6 +454,7 @@ int case_fork_cow_stale_tlb() {
     }
 
     close(snapshot_pipe[1]);
+    close(verify_pipe[0]);
     uint8_t token = 0;
     ssize_t nread = 0;
     do {
@@ -440,6 +467,7 @@ int case_fork_cow_stale_tlb() {
         for (int i = 0; i < kNrThreads; ++i) {
             pthread_join(threads[i], nullptr);
         }
+        close(verify_pipe[1]);
         int status = 0;
         waitpid(pid, &status, 0);
         munmap(snap, kSnapMapLen);
@@ -455,6 +483,21 @@ int case_fork_cow_stale_tlb() {
             parent_buf[i * kSnapStride] = static_cast<uint8_t>(round + i);
         }
     }
+    const uint8_t start_verify = 1;
+    if (write(verify_pipe[1], &start_verify, sizeof(start_verify)) != sizeof(start_verify)) {
+        perror("write verify token");
+        run.store(0, std::memory_order_release);
+        for (int i = 0; i < kNrThreads; ++i) {
+            pthread_join(threads[i], nullptr);
+        }
+        close(verify_pipe[1]);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        munmap(snap, kSnapMapLen);
+        munmap(buf, len);
+        return -1;
+    }
+    close(verify_pipe[1]);
     run.store(0, std::memory_order_release);
     for (int i = 0; i < kNrThreads; ++i) {
         pthread_join(threads[i], nullptr);


### PR DESCRIPTION
## Summary
- Repair CFS/EEVDF current lifetime handling so runtime/min-vruntime accounting does not dequeue or subtract the running entity incorrectly.
- Split user-visible exited-task `mm == NULL` semantics from scheduler/TLB active-mm handling, using per-CPU loaded-mm state for lazy-TLB cleanup.
- Fix wait/reap PID unhash timing, pid namespace child-reaper allocation shutdown, and no-mm `/proc/<pid>/maps` behavior.
- Harden dunitest runner precheck timeout/process-group cleanup and strengthen TLB shootdown synchronization.
- Split exit-mm teardown stress out of the capset unit test and make pthread latency failures return instead of hanging in join.

## Validation
- `make fmt`
- `make kernel`
- `cargo test` for the dunitest runner: 8/8 passed
- DragonOS guest focused regression: `/bin/test_pthread_start_latency` passed
- DragonOS guest focused regression: `/bin/test_exit_mm_teardown_stress` passed
- DragonOS guest focused regression: `/bin/test_sys_capset` passed
- DragonOS guest focused regression: `normal/test_tlb_shootdown` 3/3 gtests passed
- DragonOS guest focused regression: `normal/pid_namespace_fork` 1/1 gtest passed
- DragonOS guest focused regression: `normal/proc_pid_reuse_cache` 1/1 gtest passed
- DragonOS guest focused regression: `normal/wait_rusage` 2/2 gtests passed
- `git diff --check` for the staged code/test changes