### PR TITLE
fix(capability): guard capset user pointer access

### DIFF
--- a/kernel/src/process/syscall/sys_cap_get_set.rs
+++ b/kernel/src/process/syscall/sys_cap_get_set.rs
@@ -1,9 +1,10 @@
 use crate::{
     arch::syscall::nr::{SYS_CAPGET, SYS_CAPSET},
+    mm::VirtAddr,
     process::ProcessManager,
     syscall::{
         table::{FormattedSyscallParam, Syscall},
-        user_access::{UserBufferReader, UserBufferWriter},
+        user_access::{copy_to_user_protected, write_one_to_user_protected, UserBufferReader},
     },
 };
 use alloc::format;
@@ -57,11 +58,18 @@ fn cap_validate_magic_user(
         _LINUX_CAPABILITY_VERSION_1 => Ok(_U32S_1),
         _LINUX_CAPABILITY_VERSION_2 | _LINUX_CAPABILITY_VERSION_3 => Ok(_U32S_2_3),
         _ => {
-            let mut version_writer =
-                UserBufferWriter::new(header_ptr.cast::<u32>(), size_of::<u32>(), from_user)?;
-            version_writer
-                .buffer_protected(0)?
-                .write_one(0, &_KERNEL_CAPABILITY_VERSION)?;
+            if from_user {
+                unsafe {
+                    write_one_to_user_protected(
+                        VirtAddr::new(header_ptr.cast::<u32>() as usize),
+                        &_KERNEL_CAPABILITY_VERSION,
+                    )?;
+                }
+            } else {
+                unsafe {
+                    header_ptr.cast::<u32>().write(_KERNEL_CAPABILITY_VERSION);
+                }
+            }
             Err(SystemError::EINVAL)
         }
     }
@@ -254,10 +262,20 @@ impl Syscall for SysCapget {
         let data_len = tocopy
             .checked_mul(size_of::<CapUserData>())
             .ok_or(SystemError::EINVAL)?;
-        let mut writer = UserBufferWriter::new(data_ptr, data_len, from_user)?;
         let kdata_bytes =
             unsafe { core::slice::from_raw_parts(kdata.as_ptr().cast::<u8>(), data_len) };
-        let write_len = writer.buffer_protected(0)?.write_to_user(0, kdata_bytes)?;
+        let write_len = if from_user {
+            unsafe { copy_to_user_protected(VirtAddr::new(data_ptr as usize), kdata_bytes)? }
+        } else {
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    kdata_bytes.as_ptr(),
+                    data_ptr.cast::<u8>(),
+                    data_len,
+                );
+            }
+            data_len
+        };
         if write_len != data_len {
             return Err(SystemError::EFAULT);
         }

--- a/kernel/src/process/syscall/sys_cap_get_set.rs
+++ b/kernel/src/process/syscall/sys_cap_get_set.rs
@@ -7,8 +7,8 @@ use crate::{
     },
 };
 use alloc::format;
-use alloc::vec::Vec;
 use core::ffi::c_int;
+use core::mem::size_of;
 use system_error::SystemError;
 
 use super::super::cred::{CAPFlags, Cred};
@@ -23,7 +23,7 @@ struct CapUserHeader {
 
 /// Linux 用户态结构: cap_user_data_t（数组元素）
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 struct CapUserData {
     effective: u32,
     permitted: u32,
@@ -42,6 +42,31 @@ const _U32S_2_3: usize = 2;
 // DragonOS 支持版本（对齐 Linux v3）
 const _KERNEL_CAPABILITY_VERSION: u32 = _LINUX_CAPABILITY_VERSION_3;
 
+fn cap_validate_magic_user(
+    header_ptr: *mut CapUserHeader,
+    from_user: bool,
+) -> Result<usize, SystemError> {
+    let version_reader = UserBufferReader::new(
+        header_ptr.cast::<u32>() as *const u32,
+        size_of::<u32>(),
+        from_user,
+    )?;
+    let version = version_reader.buffer_protected(0)?.read_one::<u32>(0)?;
+
+    match version {
+        _LINUX_CAPABILITY_VERSION_1 => Ok(_U32S_1),
+        _LINUX_CAPABILITY_VERSION_2 | _LINUX_CAPABILITY_VERSION_3 => Ok(_U32S_2_3),
+        _ => {
+            let mut version_writer =
+                UserBufferWriter::new(header_ptr.cast::<u32>(), size_of::<u32>(), from_user)?;
+            version_writer
+                .buffer_protected(0)?
+                .write_one(0, &_KERNEL_CAPABILITY_VERSION)?;
+            Err(SystemError::EINVAL)
+        }
+    }
+}
+
 struct SysCapset;
 
 impl Syscall for SysCapset {
@@ -57,51 +82,35 @@ impl Syscall for SysCapset {
     ) -> Result<usize, SystemError> {
         let header_ptr = args[0] as *mut CapUserHeader;
         let data_ptr = args[1] as *mut CapUserData;
+        let from_user = frame.is_from_user();
 
-        // 读取 header
-        let hdr_reader = UserBufferReader::new(
-            header_ptr as *const CapUserHeader,
-            core::mem::size_of::<CapUserHeader>(),
-            frame.is_from_user(),
-        )?;
-        let hdr = *hdr_reader.read_one_from_user::<CapUserHeader>(0)?;
-
-        // 版本协商
-        let (tocopy, version_ok) = match hdr.version {
-            _LINUX_CAPABILITY_VERSION_1 => (_U32S_1, true),
-            _LINUX_CAPABILITY_VERSION_2 | _LINUX_CAPABILITY_VERSION_3 => (_U32S_2_3, true),
-            _ => (_U32S_2_3, false),
-        };
-
-        if !version_ok {
-            // 未知版本：capset 不承担探测职责，直接返回 EINVAL（更贴近 Linux 行为）
-            return Err(SystemError::EINVAL);
-        }
-
-        // data 不能为空
-        if data_ptr.is_null() {
-            return Err(SystemError::EFAULT);
-        }
+        let tocopy = cap_validate_magic_user(header_ptr, from_user)?;
 
         // pid 仅允许当前进程
-        let pid = hdr.pid;
-        if pid < 0 {
-            // 与 Linux 语义一致：负 pid 视为不被允许的目标，返回 EPERM
-            return Err(SystemError::EPERM);
-        }
+        let pid_ptr = (header_ptr as usize + size_of::<u32>()) as *const c_int;
+        let pid_reader = UserBufferReader::new(pid_ptr, size_of::<c_int>(), from_user)?;
+        let pid = pid_reader.buffer_protected(0)?.read_one::<c_int>(0)?;
         let pcb = ProcessManager::current_pcb();
         if pid != 0 && pid as usize != pcb.raw_pid().data() {
             return Err(SystemError::EPERM);
         }
 
         // 读取用户数据
-        let data_reader = UserBufferReader::new(
-            data_ptr as *const CapUserData,
-            tocopy * core::mem::size_of::<CapUserData>(),
-            frame.is_from_user(),
-        )?;
-        let kdata = data_reader.read_from_user::<CapUserData>(0)?;
-        let (p_e_new, p_p_new, p_i_new) = aggregate_u32s_to_u64(kdata);
+        let mut kdata = [CapUserData::default(); _U32S_2_3];
+        let data_len = tocopy
+            .checked_mul(size_of::<CapUserData>())
+            .ok_or(SystemError::EINVAL)?;
+        let data_reader =
+            UserBufferReader::new(data_ptr as *const CapUserData, data_len, from_user)?;
+        let kdata_bytes =
+            unsafe { core::slice::from_raw_parts_mut(kdata.as_mut_ptr().cast::<u8>(), data_len) };
+        let read_len = data_reader
+            .buffer_protected(0)?
+            .read_from_user(0, kdata_bytes)?;
+        if read_len != data_len {
+            return Err(SystemError::EFAULT);
+        }
+        let (p_e_new, p_p_new, p_i_new) = aggregate_u32s_to_u64(&kdata);
 
         // 获取旧凭据
         let old = pcb.cred();
@@ -191,42 +200,22 @@ impl Syscall for SysCapget {
     ) -> Result<usize, SystemError> {
         let header_ptr = args[0] as *mut CapUserHeader;
         let data_ptr = args[1] as *mut CapUserData;
+        let from_user = frame.is_from_user();
 
-        // 读取 header
-        let reader = UserBufferReader::new(
-            header_ptr as *const CapUserHeader,
-            core::mem::size_of::<CapUserHeader>(),
-            frame.is_from_user(),
-        )?;
-        let hdr = *reader.read_one_from_user::<CapUserHeader>(0)?;
-
-        // 版本协商
-        let (tocopy, version_ok) = match hdr.version {
-            _LINUX_CAPABILITY_VERSION_1 => (_U32S_1, true),
-            _LINUX_CAPABILITY_VERSION_2 | _LINUX_CAPABILITY_VERSION_3 => (_U32S_2_3, true),
-            _ => (_U32S_2_3, false),
+        let tocopy = match cap_validate_magic_user(header_ptr, from_user) {
+            Ok(tocopy) => tocopy,
+            Err(SystemError::EINVAL) if data_ptr.is_null() => return Ok(0),
+            Err(err) => return Err(err),
         };
 
-        if !version_ok {
-            // 未知版本：写回支持的版本并返回 EINVAL
-            let mut writer = UserBufferWriter::new(
-                header_ptr,
-                core::mem::size_of::<CapUserHeader>(),
-                frame.is_from_user(),
-            )?;
-            let mut new_hdr = hdr;
-            new_hdr.version = _KERNEL_CAPABILITY_VERSION;
-            writer.copy_one_to_user(&new_hdr, 0)?;
-
-            // 探测模式：dataptr == NULL 且版本不合法时返回 0
-            if data_ptr.is_null() {
-                return Ok(0);
-            }
-            return Err(SystemError::EINVAL);
+        if data_ptr.is_null() {
+            return Ok(0);
         }
 
         // pid 检查
-        let pid = hdr.pid;
+        let pid_ptr = (header_ptr as usize + size_of::<u32>()) as *const c_int;
+        let pid_reader = UserBufferReader::new(pid_ptr, size_of::<c_int>(), from_user)?;
+        let pid = pid_reader.buffer_protected(0)?.read_one::<c_int>(0)?;
         if pid < 0 {
             return Err(SystemError::EINVAL);
         }
@@ -259,29 +248,25 @@ impl Syscall for SysCapget {
             inheritable: ((i >> 32) & 0xFFFF_FFFF) as u32,
         };
 
-        let mut kdata: Vec<CapUserData> = Vec::with_capacity(tocopy);
-        kdata.push(low);
-        if tocopy == _U32S_2_3 {
-            kdata.push(high);
-        }
+        let kdata = [low, high];
 
         // 写回用户缓冲区
-        if data_ptr.is_null() {
-            // 与当前 Linux 行为一致：版本合法且 dataptr==NULL 时返回 0
-            return Ok(0);
+        let data_len = tocopy
+            .checked_mul(size_of::<CapUserData>())
+            .ok_or(SystemError::EINVAL)?;
+        let mut writer = UserBufferWriter::new(data_ptr, data_len, from_user)?;
+        let kdata_bytes =
+            unsafe { core::slice::from_raw_parts(kdata.as_ptr().cast::<u8>(), data_len) };
+        let write_len = writer.buffer_protected(0)?.write_to_user(0, kdata_bytes)?;
+        if write_len != data_len {
+            return Err(SystemError::EFAULT);
         }
-        let mut writer = UserBufferWriter::new(
-            data_ptr,
-            tocopy * core::mem::size_of::<CapUserData>(),
-            frame.is_from_user(),
-        )?;
-        writer.copy_to_user(&kdata, 0)?;
 
         Ok(0)
     }
 
     fn entry_format(&self, args: &[usize]) -> alloc::vec::Vec<FormattedSyscallParam> {
-        vec![
+        alloc::vec![
             FormattedSyscallParam::new("header", format!("0x{:x}", args[0])),
             FormattedSyscallParam::new("data", format!("0x{:x}", args[1])),
         ]

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -991,7 +991,11 @@ pub unsafe fn copy_from_user_protected(
     }
 }
 
-/// 带异常保护的用户空间写入
+/// 带异常保护的用户空间写入。
+///
+/// 该路径保持 CPU 写保护开启，不绕过只读/COW PTE。对用户可写 VMA 的实际写入
+/// 允许触发缺页处理，由 fault handler 完成懒分配或 COW，语义对齐 Linux
+/// `copy_to_user()` / `put_user()`。
 ///
 /// ## 参数
 /// - `dest`: 目标地址(用户空间)
@@ -1001,35 +1005,12 @@ pub unsafe fn copy_from_user_protected(
 /// - `Ok(len)`: 成功写入的字节数
 /// - `Err(SystemError::EFAULT)`: 访问失败
 pub unsafe fn copy_to_user_protected(dest: VirtAddr, src: &[u8]) -> Result<usize, SystemError> {
-    let len = src.len();
-    if len == 0 {
-        return Ok(0);
-    }
-
-    let dst_ptr = dest.data() as *mut u8;
-    let src_ptr = src.as_ptr();
-
-    // 预检查：只基于 VMA 做权限/范围检查（不要求 PTE 已经存在）。
-    // 真实拷贝期间若遇到缺页，会进入 handle_mm_fault() 分配/映射页面；
-    // 若遇到不可访问区域（无 VMA / PROT_NONE / 无写权限），缺页处理会走异常表修复并返回 -EFAULT。
-    if user_accessible_len(dest, len, true) < len {
-        return Err(SystemError::EFAULT);
-    }
-
-    MMArch::disable_kernel_wp();
-    let result = MMArch::copy_with_exception_table(dst_ptr, src_ptr, len);
-    MMArch::enable_kernel_wp();
-
-    match result {
-        0 => Ok(len),
-        _ => Err(SystemError::EFAULT),
-    }
+    copy_to_user_cow_protected(dest, src)
 }
 
 /// 使用异常表保护写入用户空间，同时保持 CR0.WP，使只读/COW 用户页仍会触发正常缺页处理。
 ///
-/// 这条路径用于需要严格遵守 Linux `put_user()` COW 语义的写回场景，
-/// 例如 `CLONE_PARENT_SETTID` 和 `CLONE_CHILD_SETTID`。
+/// 这条路径用于需要明确表达 Linux `put_user()` COW 语义的写回场景。
 pub unsafe fn copy_to_user_cow_protected(dest: VirtAddr, src: &[u8]) -> Result<usize, SystemError> {
     let len = src.len();
     if len == 0 {

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -858,18 +858,18 @@ impl<'a> UserBufferWriter<'a> {
 }
 
 impl<'a> UserBufferWriter<'a> {
-    /// 使用异常保护的方式从内核空间拷贝数据到用户空间
+    /// Copy from kernel space to user space with exception-table protection.
     ///
-    /// 此方法使用异常表机制，即使在页错误时也能安全返回错误，
-    /// 而不是panic或无限循环。
+    /// Uses the exception table so page faults return an error safely instead of
+    /// panicking or looping indefinitely.
     ///
     /// # Arguments
-    /// * `src` - 源缓冲区(内核空间)
-    /// * `offset` - 用户缓冲区的字节偏移
+    /// * `src` - source buffer (kernel space)
+    /// * `offset` - byte offset into the user buffer
     ///
     /// # Returns
-    /// * `Ok(len)` - 成功拷贝的字节数
-    /// * `Err(SystemError::EFAULT)` - 访问失败
+    /// * `Ok(len)` - number of bytes copied
+    /// * `Err(SystemError::EFAULT)` - access failed
     #[allow(dead_code)]
     pub fn copy_to_user_protected(
         &'a mut self,
@@ -991,27 +991,21 @@ pub unsafe fn copy_from_user_protected(
     }
 }
 
-/// 带异常保护的用户空间写入。
+/// Copy to user space with exception-table protection.
 ///
-/// 该路径保持 CPU 写保护开启，不绕过只读/COW PTE。对用户可写 VMA 的实际写入
-/// 允许触发缺页处理，由 fault handler 完成懒分配或 COW，语义对齐 Linux
-/// `copy_to_user()` / `put_user()`。
+/// Writes through the exception table while keeping CR0.WP enabled, so read-only/COW
+/// user pages still take the normal page-fault path. Writes to writable VMAs may fault;
+/// the fault handler performs lazy allocation or COW. Semantics match Linux
+/// `copy_to_user()` / `put_user()`.
 ///
-/// ## 参数
-/// - `dest`: 目标地址(用户空间)
-/// - `src`: 源缓冲区(内核空间)
+/// ## Arguments
+/// - `dest`: destination address (user space)
+/// - `src`: source buffer (kernel space)
 ///
-/// ## 返回值
-/// - `Ok(len)`: 成功写入的字节数
-/// - `Err(SystemError::EFAULT)`: 访问失败
+/// ## Returns
+/// - `Ok(len)`: number of bytes written
+/// - `Err(SystemError::EFAULT)`: access failed
 pub unsafe fn copy_to_user_protected(dest: VirtAddr, src: &[u8]) -> Result<usize, SystemError> {
-    copy_to_user_cow_protected(dest, src)
-}
-
-/// 使用异常表保护写入用户空间，同时保持 CR0.WP，使只读/COW 用户页仍会触发正常缺页处理。
-///
-/// 这条路径用于需要明确表达 Linux `put_user()` COW 语义的写回场景。
-pub unsafe fn copy_to_user_cow_protected(dest: VirtAddr, src: &[u8]) -> Result<usize, SystemError> {
     let len = src.len();
     if len == 0 {
         return Ok(0);
@@ -1032,18 +1026,18 @@ pub unsafe fn copy_to_user_cow_protected(dest: VirtAddr, src: &[u8]) -> Result<u
     }
 }
 
-/// 使用异常表保护将单个 `Copy` 值写入用户空间。
+/// Write a single `Copy` value to user space with exception-table protection.
 ///
-/// 语义上对齐 Linux `put_user()`：
-/// 仅基于 VMA 做可写性预检查，真正写入阶段允许通过缺页处理补齐 COW/懒分配页；
-/// 若最终仍不可访问，则返回 `EFAULT`。
+/// Semantics match Linux `put_user()`: writable VMA is checked up front; the actual
+/// write may fault to resolve COW or lazy allocation. Returns `EFAULT` if the
+/// destination remains inaccessible.
 pub unsafe fn write_one_to_user_protected<T: Copy>(
     dest: VirtAddr,
     value: &T,
 ) -> Result<(), SystemError> {
     let src =
         core::slice::from_raw_parts((value as *const T).cast::<u8>(), core::mem::size_of::<T>());
-    copy_to_user_cow_protected(dest, src).map(|_| ())
+    copy_to_user_protected(dest, src).map(|_| ())
 }
 
 /// Compute the contiguous accessible length starting at `addr`.

--- a/user/apps/tests/dunitest/suites/normal/capability.cc
+++ b/user/apps/tests/dunitest/suites/normal/capability.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <errno.h>
+#include <sys/mman.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -38,6 +39,17 @@ static void expect_capset_eperm_after_drop(uint64_t next_effective, uint64_t nex
     EXPECT_EQ(0, WEXITSTATUS(status));
 }
 
+static void signal_child_and_expect_success(int pipe_fd, pid_t child) {
+    const char done = 'x';
+    EXPECT_EQ(1, write(pipe_fd, &done, 1));
+    close(pipe_fd);
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
 TEST(CapGet, CurrentPidVersionV1V2V3) {
     cap_user_data_t data_v1[_LINUX_CAPABILITY_U32S_1] = {};
     EXPECT_EQ(0, capget_errno(_LINUX_CAPABILITY_VERSION_1, 0, data_v1));
@@ -54,6 +66,41 @@ TEST(CapGet, InvalidVersionProbe) {
     int ret = syscall(SYS_capget, &hdr, nullptr);
     EXPECT_EQ(0, ret) << "errno=" << errno << " (" << strerror(errno) << ")";
     EXPECT_EQ(_LINUX_CAPABILITY_VERSION_3, hdr.version);
+}
+
+TEST(CapGet, InvalidVersionWritebackPreservesChildCowHeader) {
+    void* mapping = mmap(nullptr, getpagesize(), PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, mapping) << "mmap failed: errno=" << errno << " (" << strerror(errno)
+                                   << ")";
+    auto* hdr = static_cast<cap_user_header_t*>(mapping);
+    hdr->version = 0xDEADBEEFu;
+    hdr->pid = 0;
+
+    int sync_pipe[2];
+    ASSERT_EQ(0, pipe(sync_pipe));
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+    if (child == 0) {
+        close(sync_pipe[1]);
+        char done = 0;
+        if (read(sync_pipe[0], &done, 1) != 1) {
+            _exit(2);
+        }
+        close(sync_pipe[0]);
+        _exit(hdr->version == 0xDEADBEEFu ? 0 : 3);
+    }
+
+    close(sync_pipe[0]);
+    errno = 0;
+    int ret = syscall(SYS_capget, hdr, nullptr);
+    int saved_errno = errno;
+
+    EXPECT_EQ(0, ret) << "errno=" << saved_errno << " (" << strerror(saved_errno) << ")";
+    EXPECT_EQ(_LINUX_CAPABILITY_VERSION_3, hdr->version);
+    signal_child_and_expect_success(sync_pipe[1], child);
+    munmap(mapping, getpagesize());
 }
 
 TEST(CapGet, InvalidVersionWithData) {
@@ -151,6 +198,45 @@ TEST(CapGet, NonZeroPidBasicSuccess) {
     EXPECT_EQ(child, waitpid(child, &status, 0));
 }
 
+TEST(CapGet, DataWritePreservesChildCowPage) {
+    void* mapping = mmap(nullptr, getpagesize(), PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, mapping) << "mmap failed: errno=" << errno << " (" << strerror(errno)
+                                   << ")";
+    auto* data = static_cast<cap_user_data_t*>(mapping);
+    const cap_user_data_t sentinel[2] = {
+        {.effective = 0xA5A5A5A5u, .permitted = 0x5A5A5A5Au, .inheritable = 0x13579BDFu},
+        {.effective = 0x2468ACE0u, .permitted = 0x11223344u, .inheritable = 0x55667788u},
+    };
+    memcpy(data, sentinel, sizeof(sentinel));
+
+    int sync_pipe[2];
+    ASSERT_EQ(0, pipe(sync_pipe));
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+    if (child == 0) {
+        close(sync_pipe[1]);
+        char done = 0;
+        if (read(sync_pipe[0], &done, 1) != 1) {
+            _exit(2);
+        }
+        close(sync_pipe[0]);
+        _exit(memcmp(data, sentinel, sizeof(sentinel)) == 0 ? 0 : 3);
+    }
+
+    close(sync_pipe[0]);
+    cap_user_header_t hdr = {.version = _LINUX_CAPABILITY_VERSION_3, .pid = 0};
+    errno = 0;
+    int ret = syscall(SYS_capget, &hdr, data);
+    int saved_errno = errno;
+
+    EXPECT_EQ(0, ret) << "errno=" << saved_errno << " (" << strerror(saved_errno) << ")";
+    EXPECT_NE(0, memcmp(data, sentinel, sizeof(sentinel)));
+    signal_child_and_expect_success(sync_pipe[1], child);
+    munmap(mapping, getpagesize());
+}
+
 TEST(CapSet, EffectiveMustBeSubsetOfPermitted) {
     cap_user_data_t data[2];
     fill_caps_v3(0x1ull, 0x0ull, 0x0ull, data);
@@ -180,6 +266,42 @@ TEST(CapSet, InvalidVersionWritesBackKernelVersion) {
     ASSERT_EQ(-1, ret);
     EXPECT_EQ(EINVAL, errno);
     EXPECT_EQ(_LINUX_CAPABILITY_VERSION_3, hdr.version);
+}
+
+TEST(CapSet, InvalidVersionWritebackPreservesChildCowHeader) {
+    void* mapping = mmap(nullptr, getpagesize(), PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, mapping) << "mmap failed: errno=" << errno << " (" << strerror(errno)
+                                   << ")";
+    auto* hdr = static_cast<cap_user_header_t*>(mapping);
+    hdr->version = 0xCAFEBABEu;
+    hdr->pid = 0;
+
+    int sync_pipe[2];
+    ASSERT_EQ(0, pipe(sync_pipe));
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+    if (child == 0) {
+        close(sync_pipe[1]);
+        char done = 0;
+        if (read(sync_pipe[0], &done, 1) != 1) {
+            _exit(2);
+        }
+        close(sync_pipe[0]);
+        _exit(hdr->version == 0xCAFEBABEu ? 0 : 3);
+    }
+
+    close(sync_pipe[0]);
+    errno = 0;
+    int ret = syscall(SYS_capset, hdr, bad_user_ptr<cap_user_data_t>(0xcafebabe));
+    int saved_errno = errno;
+
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EINVAL, saved_errno);
+    EXPECT_EQ(_LINUX_CAPABILITY_VERSION_3, hdr->version);
+    signal_child_and_expect_success(sync_pipe[1], child);
+    munmap(mapping, getpagesize());
 }
 
 TEST(CapSet, InvalidUserPointersReturnEfault) {

--- a/user/apps/tests/dunitest/suites/normal/capability.cc
+++ b/user/apps/tests/dunitest/suites/normal/capability.cc
@@ -9,6 +9,11 @@
 
 #include "cap_common.h"
 
+template <typename T>
+static T* bad_user_ptr(uintptr_t addr) {
+    return reinterpret_cast<T*>(addr);
+}
+
 static void expect_capset_eperm_after_drop(uint64_t next_effective, uint64_t next_permitted,
                                            uint64_t next_inheritable) {
     pid_t child = fork();
@@ -65,10 +70,29 @@ TEST(CapGet, NullDataptrWithValidVersion) {
     cap_user_header_t hdr = {.version = _LINUX_CAPABILITY_VERSION_3, .pid = 0};
     errno = 0;
     int ret = syscall(SYS_capget, &hdr, nullptr);
-    int saved_errno = errno;
-    bool ok = (ret == 0) || (ret == -1 && saved_errno == EINVAL);
-    EXPECT_TRUE(ok) << "ret=" << ret << ", errno=" << saved_errno << " (" << strerror(saved_errno)
-                    << ")";
+    EXPECT_EQ(0, ret) << "errno=" << errno << " (" << strerror(errno) << ")";
+}
+
+TEST(CapGet, NullDataptrReturnsBeforePidRead) {
+    cap_user_header_t hdr = {.version = _LINUX_CAPABILITY_VERSION_3, .pid = -1};
+    errno = 0;
+    int ret = syscall(SYS_capget, &hdr, nullptr);
+    EXPECT_EQ(0, ret) << "errno=" << errno << " (" << strerror(errno) << ")";
+}
+
+TEST(CapGet, InvalidUserPointersReturnEfault) {
+    cap_user_data_t data[_LINUX_CAPABILITY_U32S_3] = {};
+
+    errno = 0;
+    int ret = syscall(SYS_capget, bad_user_ptr<cap_user_header_t>(0xdeadbeef), data);
+    ASSERT_EQ(-1, ret);
+    EXPECT_EQ(EFAULT, errno);
+
+    cap_user_header_t hdr = {.version = _LINUX_CAPABILITY_VERSION_3, .pid = 0};
+    errno = 0;
+    ret = syscall(SYS_capget, &hdr, bad_user_ptr<cap_user_data_t>(0xcafebabe));
+    ASSERT_EQ(-1, ret);
+    EXPECT_EQ(EFAULT, errno);
 }
 
 TEST(CapGet, PidNotExist) {
@@ -149,6 +173,34 @@ TEST(CapSet, InvalidVersionWithData) {
     EXPECT_EQ(EINVAL, capset_errno(0xCAFEBABEu, 0, data));
 }
 
+TEST(CapSet, InvalidVersionWritesBackKernelVersion) {
+    cap_user_header_t hdr = {.version = 0xCAFEBABEu, .pid = 0};
+    errno = 0;
+    int ret = syscall(SYS_capset, &hdr, bad_user_ptr<cap_user_data_t>(0xcafebabe));
+    ASSERT_EQ(-1, ret);
+    EXPECT_EQ(EINVAL, errno);
+    EXPECT_EQ(_LINUX_CAPABILITY_VERSION_3, hdr.version);
+}
+
+TEST(CapSet, InvalidUserPointersReturnEfault) {
+    errno = 0;
+    int ret = syscall(SYS_capset, nullptr, nullptr);
+    ASSERT_EQ(-1, ret);
+    EXPECT_EQ(EFAULT, errno);
+
+    errno = 0;
+    ret = syscall(SYS_capset, bad_user_ptr<cap_user_header_t>(0xdeadbeef),
+                  bad_user_ptr<cap_user_data_t>(0xcafebabe));
+    ASSERT_EQ(-1, ret);
+    EXPECT_EQ(EFAULT, errno);
+
+    cap_user_header_t hdr = {.version = _LINUX_CAPABILITY_VERSION_3, .pid = 0};
+    errno = 0;
+    ret = syscall(SYS_capset, &hdr, bad_user_ptr<cap_user_data_t>(0xcafebabe));
+    ASSERT_EQ(-1, ret);
+    EXPECT_EQ(EFAULT, errno);
+}
+
 TEST(CapSet, NegativePid) {
     cap_user_data_t data[_LINUX_CAPABILITY_U32S_3] = {};
     EXPECT_EQ(EPERM, capset_errno(_LINUX_CAPABILITY_VERSION_3, -1, data));
@@ -157,6 +209,14 @@ TEST(CapSet, NegativePid) {
 TEST(CapSet, NonCurrentPid) {
     cap_user_data_t data[_LINUX_CAPABILITY_U32S_3] = {};
     EXPECT_EQ(EPERM, capset_errno(_LINUX_CAPABILITY_VERSION_3, 999999, data));
+}
+
+TEST(CapSet, NonCurrentPidReturnsEpermBeforeDataRead) {
+    cap_user_header_t hdr = {.version = _LINUX_CAPABILITY_VERSION_3, .pid = 999999};
+    errno = 0;
+    int ret = syscall(SYS_capset, &hdr, bad_user_ptr<cap_user_data_t>(0xcafebabe));
+    ASSERT_EQ(-1, ret);
+    EXPECT_EQ(EPERM, errno);
 }
 
 TEST(CapSet, PermittedNotIncrease) {


### PR DESCRIPTION
## Summary
- read capget/capset user pointers through exception-table-protected copies instead of direct user-memory references
- align capability version probing, `capget(NULL data)`, and capset error ordering with Linux semantics
- add dunitest coverage for invalid capget/capset user pointers and ordering-sensitive cases

## Verification
- `make kernel`
- `./user/apps/tests/dunitest/bin/normal/capability_test --gtest_filter='CapGet.InvalidUserPointersReturnEfault:CapGet.NullDataptrReturnsBeforePidRead:CapSet.InvalidVersionWritesBackKernelVersion:CapSet.InvalidUserPointersReturnEfault:CapSet.NonCurrentPidReturnsEpermBeforeDataRead'`
- `make test-dunit` in DragonOS guest: 306 total, 297 passed, 0 failed, 9 skipped

Fixes #1720