### PR TITLE
procfs: add oom_score_adj

### DIFF
--- a/kernel/src/filesystem/procfs/pid/mod.rs
+++ b/kernel/src/filesystem/procfs/pid/mod.rs
@@ -29,6 +29,7 @@ mod id_map;
 mod limits;
 mod maps;
 mod ns;
+mod oom_score_adj;
 pub mod stat;
 mod statm;
 mod status;
@@ -44,6 +45,7 @@ use id_map::{IdMapFileOps, SetgroupsFileOps};
 use limits::LimitsFile;
 use maps::MapsFileOps;
 use ns::NsDirOps;
+use oom_score_adj::OomScoreAdjFileOps;
 use stat::StatFileOps;
 use statm::StatmFileOps;
 use status::StatusFileOps;
@@ -178,6 +180,9 @@ impl PidDirOps {
         }),
         ("mountstats", |ops, parent| {
             MountProcFileOps::new_inode(ops.target.clone(), ProcMountRenderKind::MountStats, parent)
+        }),
+        ("oom_score_adj", |ops, parent| {
+            OomScoreAdjFileOps::new_inode(ops.target.clone(), parent)
         }),
         ("ns", |ops, parent| {
             NsDirOps::new_inode(ops.target.clone(), parent)

--- a/kernel/src/filesystem/procfs/pid/oom_score_adj.rs
+++ b/kernel/src/filesystem/procfs/pid/oom_score_adj.rs
@@ -1,0 +1,92 @@
+//! /proc/[pid]/oom_score_adj - OOM killer score adjustment.
+
+use crate::libs::mutex::MutexGuard;
+use crate::{
+    filesystem::{
+        procfs::{
+            pid::ProcPidTarget,
+            template::{Builder, FileOps, ProcFileBuilder},
+            utils::proc_read,
+        },
+        vfs::{FilePrivateData, IndexNode, InodeMode},
+    },
+    process::ProcessControlBlock,
+};
+use alloc::{
+    format,
+    sync::{Arc, Weak},
+};
+use system_error::SystemError;
+
+const OOM_SCORE_ADJ_MIN: i16 = -1000;
+const OOM_SCORE_ADJ_MAX: i16 = 1000;
+const PROC_NUMBUF: usize = 13;
+
+#[derive(Debug)]
+pub struct OomScoreAdjFileOps {
+    target: ProcPidTarget,
+}
+
+impl OomScoreAdjFileOps {
+    pub fn new(target: ProcPidTarget) -> Self {
+        Self { target }
+    }
+
+    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self::new(target), InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    fn target_process(&self) -> Result<Arc<ProcessControlBlock>, SystemError> {
+        self.target.thread_group_leader().ok_or(SystemError::ESRCH)
+    }
+
+    fn parse_score(buf: &[u8]) -> Result<i16, SystemError> {
+        let len = buf.len().min(PROC_NUMBUF - 1);
+        let input = core::str::from_utf8(&buf[..len]).map_err(|_| SystemError::EINVAL)?;
+        let score = input
+            .trim()
+            .parse::<i32>()
+            .map_err(|_| SystemError::EINVAL)?;
+
+        if !(OOM_SCORE_ADJ_MIN as i32..=OOM_SCORE_ADJ_MAX as i32).contains(&score) {
+            return Err(SystemError::EINVAL);
+        }
+
+        Ok(score as i16)
+    }
+}
+
+impl FileOps for OomScoreAdjFileOps {
+    fn read_at(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        let pcb = self.target_process()?;
+        let score = pcb.sig_info_irqsave().oom_score_adj();
+        let content = format!("{}\n", score);
+        proc_read(offset, len, buf, content.as_bytes())
+    }
+
+    fn write_at(
+        &self,
+        offset: usize,
+        _len: usize,
+        buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        if offset != 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        let score = Self::parse_score(buf)?;
+        let pcb = self.target_process()?;
+        pcb.sig_info_mut().set_oom_score_adj(score);
+        Ok(buf.len())
+    }
+}

--- a/kernel/src/filesystem/procfs/pid/task.rs
+++ b/kernel/src/filesystem/procfs/pid/task.rs
@@ -2,6 +2,8 @@
 //!
 //! 列出进程的所有线程，每个线程对应一个子目录 /proc/[pid]/task/[tid]
 
+use super::oom_score_adj::OomScoreAdjFileOps;
+
 use crate::{
     filesystem::{
         procfs::{
@@ -140,6 +142,9 @@ impl TidDirOps {
         }),
         ("ns", |ops, parent| {
             NsDirOps::new_inode(ops.target.clone(), parent)
+        }),
+        ("oom_score_adj", |ops, parent| {
+            OomScoreAdjFileOps::new_inode(ops.target.clone(), parent)
         }),
     ];
 }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -422,14 +422,18 @@ impl ProcessManager {
     ) -> Result<(), SystemError> {
         // 只复制信号掩码 - POSIX 要求 fork 和 execve 都保留信号掩码
         // 注意：先读取父进程的，然后释放锁，再写入子进程的，避免死锁
-        let sig_blocked = {
+        let sig_info_state = {
             let current_sig_info = current_pcb.sig_info_irqsave();
-            *current_sig_info.sig_blocked()
+            (
+                *current_sig_info.sig_blocked(),
+                current_sig_info.oom_score_adj(),
+            )
         };
 
         {
             let mut new_sig_info = new_pcb.sig_info_mut();
-            *new_sig_info.sig_block_mut() = sig_blocked;
+            *new_sig_info.sig_block_mut() = sig_info_state.0;
+            new_sig_info.set_oom_score_adj(sig_info_state.1);
         }
 
         Ok(())

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -3528,6 +3528,9 @@ pub struct ProcessSignalInfo {
 
     /// boolean value for session group leader
     pub is_session_leader: bool,
+
+    /// OOM killer score adjustment exposed through `/proc/[pid]/oom_score_adj`.
+    oom_score_adj: i16,
 }
 
 impl ProcessSignalInfo {
@@ -3587,6 +3590,14 @@ impl ProcessSignalInfo {
     pub fn set_is_child_subreaper(&mut self, is_child_subreaper: bool) {
         self.is_child_subreaper = is_child_subreaper;
     }
+
+    pub fn oom_score_adj(&self) -> i16 {
+        self.oom_score_adj
+    }
+
+    pub fn set_oom_score_adj(&mut self, oom_score_adj: i16) {
+        self.oom_score_adj = oom_score_adj;
+    }
 }
 
 impl Default for ProcessSignalInfo {
@@ -3599,6 +3610,7 @@ impl Default for ProcessSignalInfo {
             has_child_subreaper: false,
             is_child_subreaper: false,
             is_session_leader: false,
+            oom_score_adj: 0,
         }
     }
 }


### PR DESCRIPTION
## Summary

- add `/proc/[pid]/oom_score_adj` procfs support
- expose the same entry under `/proc/[pid]/task/[tid]`
- store and inherit the OOM score adjustment across fork

## Validation

- `make fmt`
- `make kernel`