### PR TITLE
fix(tty): preserve OPOST chars when output is full

### DIFF
--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -63,6 +63,13 @@ struct EchoStep {
     canon_cursor_column: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpostCharResult {
+    Emitted,
+    ConsumedWithoutOutput,
+    NeedsMoreRoom,
+}
+
 impl NTtyLinediscipline {
     #[inline]
     pub fn disc_data(&self) -> SpinLockGuard<'_, NTtyData> {
@@ -1487,10 +1494,10 @@ impl NTtyData {
         mut c: u8,
         out: &mut Vec<u8>,
         space: usize,
-    ) -> Result<usize, SystemError> {
+    ) -> OpostCharResult {
         let used = out.len();
         if used >= space {
-            return Err(SystemError::ENOBUFS);
+            return OpostCharResult::NeedsMoreRoom;
         }
 
         if c as usize == 8 {
@@ -1498,7 +1505,7 @@ impl NTtyData {
                 self.cursor_column -= 1;
             }
             out.push(c);
-            return Ok(1);
+            return OpostCharResult::Emitted;
         }
 
         match c as char {
@@ -1508,18 +1515,18 @@ impl NTtyData {
                 }
                 if termios.output_mode.contains(OutputMode::ONLCR) {
                     if used + 2 > space {
-                        return Err(SystemError::ENOBUFS);
+                        return OpostCharResult::NeedsMoreRoom;
                     }
                     self.cursor_column = 0;
                     self.canon_cursor_column = 0;
                     out.extend_from_slice(b"\r\n");
-                    return Ok(2);
+                    return OpostCharResult::Emitted;
                 }
                 self.canon_cursor_column = self.cursor_column;
             }
             '\r' => {
                 if termios.output_mode.contains(OutputMode::ONOCR) && self.cursor_column == 0 {
-                    return Ok(0);
+                    return OpostCharResult::ConsumedWithoutOutput;
                 }
 
                 if termios.output_mode.contains(OutputMode::OCRNL) {
@@ -1537,11 +1544,11 @@ impl NTtyData {
                 let spaces = 8 - (self.cursor_column & 7) as usize;
                 if output_mode_has_xtabs(termios) {
                     if used + spaces > space {
-                        return Err(SystemError::ENOBUFS);
+                        return OpostCharResult::NeedsMoreRoom;
                     }
                     self.cursor_column += spaces as u32;
                     out.extend_from_slice(&b"        "[..spaces]);
-                    return Ok(spaces);
+                    return OpostCharResult::Emitted;
                 }
                 self.cursor_column += spaces as u32;
             }
@@ -1561,7 +1568,7 @@ impl NTtyData {
         }
 
         out.push(c);
-        Ok(1)
+        OpostCharResult::Emitted
     }
 
     fn simple_output_block_len(&self, termios: &Termios, buf: &[u8], limit: usize) -> usize {
@@ -1921,30 +1928,23 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                         let mut guard = self.disc_data();
                         let cursor_column = guard.cursor_column;
                         let canon_cursor_column = guard.canon_cursor_column;
-                        match guard.process_output_char_to_buf(
+                        let opost_result = guard.process_output_char_to_buf(
                             &termios,
                             buf[offset],
                             &mut out_buf,
                             space,
-                        ) {
-                            Ok(_) => {}
-                            Err(SystemError::ENOBUFS) => {
-                                guard.cursor_column = cursor_column;
-                                guard.canon_cursor_column = canon_cursor_column;
-                            }
-                            Err(err) => {
-                                guard.cursor_column = cursor_column;
-                                guard.canon_cursor_column = canon_cursor_column;
-                                return Err(err);
-                            }
+                        );
+                        if opost_result == OpostCharResult::NeedsMoreRoom {
+                            guard.cursor_column = cursor_column;
+                            guard.canon_cursor_column = canon_cursor_column;
                         }
                         drop(guard);
 
-                        if out_buf.is_empty() {
+                        if opost_result == OpostCharResult::ConsumedWithoutOutput {
                             offset += 1;
                             nr -= 1;
                             made_progress = true;
-                        } else {
+                        } else if opost_result == OpostCharResult::Emitted {
                             let mut sent = 0;
                             while sent < out_buf.len() {
                                 let written =

--- a/user/dadk/config/all/core_utils-9.4.0.toml
+++ b/user/dadk/config/all/core_utils-9.4.0.toml
@@ -29,7 +29,7 @@ archive-rootdir = "coreutils-9.4"
 # 构建相关信息
 [build]
 # （可选）构建命令
-build-command = "./configure CC=x86_64-linux-musl-gcc CFLAGS=-static && make -j $(nproc) && DESTDIR=$DADK_CURRENT_BUILD_DIR make install"
+build-command = "FORCE_UNSAFE_CONFIGURE=1 ./configure CC=x86_64-linux-musl-gcc CFLAGS=-static && make -j $(nproc) && DESTDIR=$DADK_CURRENT_BUILD_DIR make install && install -Dm755 $DADK_CURRENT_BUILD_DIR/usr/local/bin/true $DADK_CURRENT_BUILD_DIR/bin/true && install -Dm755 $DADK_CURRENT_BUILD_DIR/usr/local/bin/false $DADK_CURRENT_BUILD_DIR/bin/false"
 # 安装相关信息
 [install]
 # （可选）安装到DragonOS的路径


### PR DESCRIPTION
## Summary

- distinguish OPOST output-buffer-full from valid zero-output consumption in `n_tty`
- keep ONLCR-expanded characters pending when PTY output space cannot fit the full expansion
- provide `/bin/true` and `/bin/false` from coreutils in the rootfs for Linux-compatible absolute paths used by gVisor tests

## Root Cause

`process_output_char_to_buf()` returned `ENOBUFS` with an empty temporary output buffer when `OPOST | ONLCR` needed to expand `\n` into `\r\n` but only one output byte of room was available. The caller then treated the empty buffer as a valid consumed-without-output character and advanced the input offset, silently dropping the input newline.

Linux `n_tty` keeps these states distinct: output full means retry without consuming input, while `ONOCR` at column zero is a valid zero-output consume.

The follow-up Integration Test failure in `Waiters/WaitSpecificChildTest.AfterChildExecve/{0,1}` matched the current `origin/master` baseline failure at `e7331811004d725d8303b2ee01878d425ebba63d`: the test execs `/bin/true`, while the DragonOS rootfs only installed coreutils `true` under `/usr/local/bin/true`. The child therefore exited with `ENOENT` (`2`), and wait observed status `512` / `2`.

## Validation

- `make kernel`
- `make user`
- TOML parse check for `user/dadk/config/all/core_utils-9.4.0.toml`
- Verified generated coreutils build output and local sysroot contain static ELF files at:
  - `bin/dadk_cache/build/core_utils_9_4_0/bin/true`
  - `bin/dadk_cache/build/core_utils_9_4_0/bin/false`
  - `bin/sysroot/bin/true`
  - `bin/sysroot/bin/false`
- Earlier PTY-focused validation:
  - `make fmt`
  - `FORCE_UNSAFE_CONFIGURE=1 DUNITEST_PATTERN=normal/tty_pty_hangup make test-dunit`
    - The current Makefile did not propagate `DUNITEST_PATTERN` into the guest, so this ran full dunitest.
    - Result: 419 total, 410 passed, 0 failed, 9 skipped.
    - `TtyPtyHangup.TciflushDoesNotDiscardLargeOpostSlaveOutput` passed in 27 ms.
