### PR TITLE
fix(process): complete pidfd wait and file semantics

### DIFF
--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -269,20 +269,6 @@ impl FilePrivateData {
         }
         Ok(())
     }
-
-    pub fn is_pid(&self) -> bool {
-        if let FilePrivateData::Pid(_data) = self {
-            return true;
-        }
-        false
-    }
-
-    pub fn get_pid(&self) -> i32 {
-        if let FilePrivateData::Pid(data) = self {
-            return data.pid();
-        }
-        -1
-    }
 }
 
 bitflags! {
@@ -1692,6 +1678,12 @@ impl DroppedFd {
 #[derive(Debug, Clone, Copy)]
 pub struct ReservedFd {
     fd: i32,
+}
+
+impl ReservedFd {
+    pub fn fd(&self) -> i32 {
+        self.fd
+    }
 }
 
 /// @brief pcb里面的文件描述符数组

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -1475,6 +1475,7 @@ bitflags! {
         const MOUNT_MAGIC = 61267;
         const PIPEFS_MAGIC = 0x50495045;
         const EVENTFD_MAGIC = 0x45564446; // "EVDF" in ASCII
+        const PIDFD_MAGIC = 0x50494446; // "PIDF" in ASCII
         const OVERLAYFS_MAGIC = 0x794c7630;
     }
 }

--- a/kernel/src/ipc/syscall/sys_pidfd_sendsignal.rs
+++ b/kernel/src/ipc/syscall/sys_pidfd_sendsignal.rs
@@ -1,18 +1,33 @@
 use crate::arch::ipc::signal::Signal;
-use crate::ipc::signal_types::SigCode;
+use crate::ipc::signal_types::{PosixSigInfo, SigCode};
 use crate::ipc::signal_types::{SigInfo, SigType};
-use alloc::string::ToString;
-use alloc::vec::Vec;
+use crate::ipc::syscall::sys_kill::check_signal_permission_pcb_with_sig;
+use crate::ipc::syscall::sys_rt_sigqueueinfo::sig_type_from_user_siginfo;
+use crate::process::pid::{Pid, PidType};
+use alloc::{string::ToString, sync::Arc, vec::Vec};
 use core::ffi::c_int;
+use core::mem::size_of;
 
 use crate::arch::interrupt::TrapFrame;
-use crate::process::RawPid;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
+use crate::syscall::user_access::UserBufferReader;
 use crate::{arch::syscall::nr::SYS_PIDFD_SEND_SIGNAL, process::ProcessManager};
 use system_error::SystemError;
 
 pub struct SysPidfdSendSignalHandle;
+
+fn pidfd_pidns_accessible(pid: &Arc<Pid>) -> bool {
+    let active = ProcessManager::current_pcb().active_pid_ns();
+    let mut cursor = Some(pid.ns_of_pid());
+    while let Some(ns) = cursor {
+        if Arc::ptr_eq(&ns, &active) {
+            return true;
+        }
+        cursor = ns.parent();
+    }
+    false
+}
 
 impl SysPidfdSendSignalHandle {
     #[inline(always)]
@@ -41,43 +56,75 @@ impl Syscall for SysPidfdSendSignalHandle {
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let pidfd = Self::pidfd(args);
         let sig_c_int = Self::sig(args);
-        let _sig_info = Self::siginfo(args);
-        let _flags = Self::flags(args);
+        let sig_info = Self::siginfo(args);
+        let flags = Self::flags(args);
 
-        // TODO: 完整的支持此系统调用
-        let mut pid = 0;
-        let file = ProcessManager::current_pcb()
-            .fd_table()
-            .read()
-            .get_file_by_fd(pidfd)
-            .ok_or(SystemError::EBADF)?;
-        if file.private_data.lock().is_pid() {
-            pid = file.private_data.lock().get_pid();
+        if flags != 0 {
+            return Err(SystemError::EINVAL);
         }
 
-        let sig = Signal::from(sig_c_int);
-        if sig == Signal::INVALID {
+        // TODO: 完整的支持此系统调用
+        let target_pid = ProcessManager::current_pcb().pidfd_target_from_fd(pidfd)?;
+        let target = target_pid.task(PidType::TGID).ok_or(SystemError::ESRCH)?;
+
+        if !pidfd_pidns_accessible(&target_pid.pid()) {
+            return Err(SystemError::EINVAL);
+        }
+
+        if sig_c_int == 0 {
+            check_signal_permission_pcb_with_sig(&target, None)?;
             // log::warn!("Pidfd_Send_Signal: Send empty sig(0)");
             // 这里的信号是 0, 是空信号值, 其他的信号处理是怎样的不清楚, 但是这里应该直接返回成功, 因为 0 是空信号
             return Ok(0);
         }
 
-        let current_pcb = ProcessManager::current_pcb();
-        let sender_pid = current_pcb.raw_pid();
-        let sender_uid = current_pcb.cred().uid.data() as u32;
+        let sig = Signal::from(sig_c_int);
+        if sig == Signal::INVALID {
+            return Err(SystemError::EINVAL);
+        }
 
-        let mut info = SigInfo::new(
-            sig,
-            0,
-            SigCode::User,
-            SigType::Kill {
-                pid: sender_pid,
-                uid: sender_uid,
-            },
-        );
+        let mut info = if sig_info.is_null() {
+            let current_pcb = ProcessManager::current_pcb();
+            let sender_pid = current_pcb.raw_pid();
+            let sender_uid = current_pcb.cred().uid.data() as u32;
+            SigInfo::new(
+                sig,
+                0,
+                SigCode::User,
+                SigType::Kill {
+                    pid: sender_pid,
+                    uid: sender_uid,
+                },
+            )
+        } else {
+            let reader = UserBufferReader::new(
+                sig_info as *const PosixSigInfo,
+                size_of::<PosixSigInfo>(),
+                true,
+            )?;
+            let buffer = reader.buffer_protected(0)?;
+            let user_info = buffer.read_one::<PosixSigInfo>(0)?;
+            if user_info.si_signo != sig_c_int {
+                return Err(SystemError::EINVAL);
+            }
+
+            let current_pid = ProcessManager::current_pcb().pid();
+            let si_code = user_info.si_code;
+            if (si_code >= 0 || si_code == SigCode::Tkill.as_i32())
+                && !Arc::ptr_eq(&current_pid, &target_pid.pid())
+            {
+                return Err(SystemError::EPERM);
+            }
+
+            let code_enum = SigCode::try_from_i32(si_code).unwrap_or(SigCode::Raw(si_code));
+            let sig_type = sig_type_from_user_siginfo(sig, code_enum, &user_info);
+            SigInfo::new(sig, user_info.si_errno, code_enum, sig_type)
+        };
+
+        check_signal_permission_pcb_with_sig(&target, Some(sig))?;
 
         let ret = sig
-            .send_signal_info(Some(&mut info), RawPid::new(pid as usize))
+            .send_signal_info_to_pcb(Some(&mut info), target, PidType::TGID)
             .map(|x| x as usize);
 
         ret

--- a/kernel/src/ipc/syscall/sys_pidfd_sendsignal.rs
+++ b/kernel/src/ipc/syscall/sys_pidfd_sendsignal.rs
@@ -39,8 +39,8 @@ impl SysPidfdSendSignalHandle {
         args[1] as c_int
     }
     #[inline(always)]
-    fn siginfo(args: &[usize]) -> *mut i32 {
-        args[2] as *mut i32
+    fn siginfo(args: &[usize]) -> *const PosixSigInfo {
+        args[2] as *const PosixSigInfo
     }
     #[inline(always)]
     fn flags(args: &[usize]) -> usize {
@@ -97,11 +97,7 @@ impl Syscall for SysPidfdSendSignalHandle {
                 },
             )
         } else {
-            let reader = UserBufferReader::new(
-                sig_info as *const PosixSigInfo,
-                size_of::<PosixSigInfo>(),
-                true,
-            )?;
+            let reader = UserBufferReader::new(sig_info, size_of::<PosixSigInfo>(), true)?;
             let buffer = reader.buffer_protected(0)?;
             let user_info = buffer.read_one::<PosixSigInfo>(0)?;
             if user_info.si_signo != sig_c_int {

--- a/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
+++ b/kernel/src/ipc/syscall/sys_rt_sigqueueinfo.rs
@@ -55,7 +55,7 @@ fn raw_siginfo_pid(pid: i32) -> RawPid {
     RawPid::new(pid as usize)
 }
 
-fn sig_type_from_user_siginfo(
+pub(crate) fn sig_type_from_user_siginfo(
     signal: Signal,
     code_enum: SigCode,
     user_info: &PosixSigInfo,

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -60,16 +60,7 @@ fn reap_blocked_by_group_exec(child_pcb: &Arc<ProcessControlBlock>) -> bool {
 }
 
 fn delay_group_leader(child_pcb: &Arc<ProcessControlBlock>) -> bool {
-    if !child_pcb.is_thread_group_leader() {
-        return false;
-    }
-
-    child_pcb
-        .threads_read_irqsave()
-        .group_tasks_clone()
-        .iter()
-        .filter_map(Weak::upgrade)
-        .any(|task| !task.is_exited() && !task.is_zombie() && !task.is_dead())
+    child_pcb.is_thread_group_leader() && child_pcb.thread_group_has_live_nonleader_threads()
 }
 
 /// mt-exec: 非执行线程的组长在退出时，延迟 PID/TGID/PGID/SID 的 unhash
@@ -277,16 +268,25 @@ pub fn kernel_wait4(
 pub fn kernel_waitid(
     pid_selector: WaitSelector,
     mut infop: Option<UserBufferWriter<'_>>, // PosixSigInfo
-    options: WaitOption,
+    mut options: WaitOption,
     rusage_buf: Option<&mut RUsage>,
+    pidfd_nonblock: bool,
 ) -> Result<bool, SystemError> {
+    let original_options = options;
+    if pidfd_nonblock {
+        options.insert(WaitOption::WNOHANG);
+    }
+
     // 构造参数
     let mut kwo = KernelWaitOption::new(pid_selector, options);
     kwo.ret_rusage = rusage_buf;
     // waitid 不强制 WEXITED，由调用者通过 options 指定
 
     // 走通用等待
-    let _ = do_wait(&mut kwo)?;
+    let wait_ret = do_wait(&mut kwo)?;
+    if wait_ret == 0 && pidfd_nonblock && !original_options.contains(WaitOption::WNOHANG) {
+        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+    }
 
     // 写回 siginfo（若提供）
     if let Some(mut writer) = infop.take() {
@@ -885,6 +885,7 @@ impl ProcessControlBlock {
             leader_threads
                 .group_tasks
                 .retain(|pcb| !Weak::ptr_eq(pcb, &self.self_ref));
+            leader.pid().wake_pidfd_pollers();
         }
     }
 

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -6,12 +6,11 @@ use crate::cgroup::{cgroup_accounting_lock, cgroup_can_fork_in, cgroup_migrate_v
 use crate::filesystem::cgroup2::{cgroup2_check_attach_permissions, cgroup2_inode_to_node};
 use crate::filesystem::vfs::file::File;
 use crate::filesystem::vfs::file::FileFlags;
-use crate::filesystem::vfs::file::FilePrivateData;
+use crate::filesystem::vfs::file::ReservedFd;
 use crate::filesystem::vfs::FileType;
-use crate::filesystem::vfs::InodeMode;
 use crate::mm::access_ok;
 use crate::mm::MemoryManagementArch;
-use crate::process::pid::PidPrivateData;
+use crate::process::pidfd::PidFd;
 use alloc::{string::ToString, sync::Arc};
 use log::{error, warn};
 use system_error::SystemError;
@@ -850,43 +849,18 @@ impl ProcessManager {
             None
         };
 
-        // 安装 pidfd 会对父进程 fd 表产生外部可见副作用，必须放在 cgroup
-        // admission 成功之后；若后续发布前失败，需要显式回滚 fd 和 pids 预留。
-        let mut installed_pidfd = None;
+        let mut reserved_pidfd: Option<ReservedFd> = None;
+        let mut pidfd_file: Option<File> = None;
         if clone_flags.contains(CloneFlags::CLONE_PIDFD) {
-            let pid = pcb.raw_pid().0 as i32;
-            let root_inode = ProcessManager::current_mntns().root_inode();
-            let name = format!(
-                "Pidfd(from {} to {})",
-                ProcessManager::current_pcb().raw_pid().data(),
-                pid
-            );
-            let new_inode = match root_inode.create(&name, FileType::File, InodeMode::S_IRWXUGO) {
-                Ok(inode) => inode,
+            let pid = pcb.pid();
+            let prepared = match PidFd::prepare(current_pcb, pid, FileFlags::empty(), false) {
+                Ok(prepared) => prepared,
                 Err(err) => {
                     Self::rollback_failed_fork(current_pcb, None, reserved_cgroup.as_ref());
                     return Err(err);
                 }
             };
-            let file = match File::new(new_inode, FileFlags::O_RDWR | FileFlags::O_CLOEXEC) {
-                Ok(file) => file,
-                Err(err) => {
-                    Self::rollback_failed_fork(current_pcb, None, reserved_cgroup.as_ref());
-                    return Err(err);
-                }
-            };
-            {
-                let mut guard = file.private_data.lock();
-                *guard = FilePrivateData::Pid(PidPrivateData::new(pid));
-            }
-
-            let fd = match current_pcb.fd_table().write().alloc_fd(file, None, true) {
-                Ok(fd) => fd,
-                Err(err) => {
-                    Self::rollback_failed_fork(current_pcb, None, reserved_cgroup.as_ref());
-                    return Err(err);
-                }
-            };
+            let fd = prepared.reservation.fd();
 
             let write_pidfd_result = (|| -> Result<(), SystemError> {
                 let mut writer = UserBufferWriter::new(
@@ -897,11 +871,16 @@ impl ProcessManager {
                 writer.copy_one_to_user(&(fd as i32), 0)
             })();
             if let Err(err) = write_pidfd_result {
-                Self::rollback_failed_fork(current_pcb, Some(fd), reserved_cgroup.as_ref());
+                current_pcb
+                    .fd_table()
+                    .write()
+                    .release_reserved_fd(prepared.reservation);
+                Self::rollback_failed_fork(current_pcb, None, reserved_cgroup.as_ref());
                 return Err(err);
             }
 
-            installed_pidfd = Some(fd);
+            reserved_pidfd = Some(prepared.reservation);
+            pidfd_file = Some(prepared.file);
         }
 
         // 新任务的默认落点 CPU 应在 wake_up_new_task() 时再选择；这里只保留显式 hint，
@@ -1044,8 +1023,21 @@ impl ProcessManager {
             }
         };
         if let Err(err) = publish_result {
-            Self::rollback_failed_fork(current_pcb, installed_pidfd, reserved_cgroup.as_ref());
+            if let Some(reservation) = reserved_pidfd.take() {
+                current_pcb
+                    .fd_table()
+                    .write()
+                    .release_reserved_fd(reservation);
+            }
+            Self::rollback_failed_fork(current_pcb, None, reserved_cgroup.as_ref());
             return Err(err);
+        }
+
+        if let (Some(reservation), Some(file)) = (reserved_pidfd.take(), pidfd_file.take()) {
+            current_pcb
+                .fd_table()
+                .write()
+                .install_reserved_fd(reservation, file)?;
         }
 
         if pcb.raw_pid() > RawPid(0) {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -94,6 +94,7 @@ pub mod idle;
 pub mod kthread;
 pub mod namespace;
 pub mod pid;
+pub mod pidfd;
 pub mod posix_timer;
 pub mod preempt;
 pub mod process_group;
@@ -872,6 +873,7 @@ impl ProcessManager {
         // mt-exec: leader 退出时只标记 zombie，避免触发普通退出通知/收养
         if is_mt_exec_leader {
             current.set_exit_state_zombie();
+            Self::wake_pidfd_pollers_for_task_exit(current);
             return;
         }
         // 让INIT进程收养所有子进程
@@ -884,6 +886,7 @@ impl ProcessManager {
             ProcessManager::exit_ptrace(current);
             // 在通知父进程之前，先标记为 Zombie，保证 wait 可见
             current.set_exit_state_zombie();
+            Self::wake_pidfd_pollers_for_task_exit(current);
             let r = current.parent_pcb.read_irqsave().upgrade();
             if r.is_none() {
                 return;
@@ -953,6 +956,16 @@ impl ProcessManager {
             }
 
             // todo: 这里还需要根据线程组的信息，决定信号的发送
+        }
+    }
+
+    fn wake_pidfd_pollers_for_task_exit(task: &Arc<ProcessControlBlock>) {
+        let thread_pid = task.pid();
+        thread_pid.wake_pidfd_pollers();
+        if let Some(tgid_pid) = task.task_pid_ptr(PidType::TGID) {
+            if !Arc::ptr_eq(&thread_pid, &tgid_pid) {
+                tgid_pid.wake_pidfd_pollers();
+            }
         }
     }
 
@@ -2891,6 +2904,13 @@ impl ProcessControlBlock {
         self.sched_info.state().is_exited()
     }
 
+    /// DragonOS sets `ProcessState::Exited` after the task has left user-visible
+    /// execution, before `ExitState::Zombie`; it is no longer a live thread-group
+    /// member for wait/pidfd readiness.
+    pub(crate) fn is_live_thread_group_member(&self) -> bool {
+        !self.is_exited() && !self.is_zombie() && !self.is_dead()
+    }
+
     pub fn exit_code(&self) -> Option<usize> {
         self.sched_info.state().exit_code()
     }
@@ -2994,6 +3014,18 @@ impl ProcessControlBlock {
 
     pub fn is_thread_group_leader(&self) -> bool {
         self.exit_signal.load(Ordering::SeqCst) >= 0
+    }
+
+    pub(crate) fn thread_group_has_live_nonleader_threads(&self) -> bool {
+        if !self.is_thread_group_leader() {
+            return false;
+        }
+
+        self.threads_read_irqsave()
+            .group_tasks_clone()
+            .into_iter()
+            .filter_map(|task| task.upgrade())
+            .any(|task| task.is_live_thread_group_member())
     }
 
     /// 唤醒等待在本进程 `wait_queue` 上的所有等待者

--- a/kernel/src/process/namespace/setns.rs
+++ b/kernel/src/process/namespace/setns.rs
@@ -7,7 +7,8 @@ use crate::{
     process::{
         cred::{ns_capable, CAPFlags, Cred},
         fork::CloneFlags,
-        ProcessManager, RawPid,
+        pid::PidType,
+        ProcessManager,
     },
 };
 
@@ -35,6 +36,26 @@ fn can_setns_target_userns(
     let current = ProcessManager::current_pcb();
     let cred = current.cred();
     cred.has_cap_sys_admin() && cred.user_ns.is_ancestor_of(target_user_ns)
+}
+
+fn can_access_pidfd_setns_target(target: &Arc<crate::process::ProcessControlBlock>) -> bool {
+    let current = ProcessManager::current_pcb();
+    if Arc::ptr_eq(&current, target) {
+        return true;
+    }
+
+    let current_cred = current.cred();
+    if current_cred.has_capability(CAPFlags::CAP_SYS_PTRACE) {
+        return true;
+    }
+
+    let target_cred = target.cred();
+    current_cred.uid == target_cred.euid
+        && current_cred.uid == target_cred.suid
+        && current_cred.uid == target_cred.uid
+        && current_cred.gid == target_cred.egid
+        && current_cred.gid == target_cred.sgid
+        && current_cred.gid == target_cred.gid
 }
 
 fn nsfd_target_userns(
@@ -92,21 +113,21 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
         .get_file_by_fd(fd)
         .ok_or(SystemError::EBADF)?;
 
-    // 3. 根据 fd 类型决定 setns 模式：pidfd / namespace fd
-    let (pidfd_pid, ns_fd) = {
+    // 3. 根据 fd 类型决定 setns 模式：namespace fd / pidfd
+    let ns_fd = {
         let pdata = file.private_data.lock();
         match &*pdata {
-            FilePrivateData::Pid(p) => (Some(p.pid()), None),
-            FilePrivateData::Namespace(n) => (None, Some(n.clone())),
-            _ => (None, None),
+            FilePrivateData::Namespace(n) => Some(n.clone()),
+            _ => None,
         }
     };
 
-    // pidfd 路径：flags 必须非空
-    if let Some(pid) = pidfd_pid {
-        if pid < 0 {
-            return Err(SystemError::EBADF);
-        }
+    // pidfd 路径：flags 必须非空。fd 存在但不是 pidfd 时不能返回 EBADF；
+    // setns 语义要求这种类型不匹配返回 EINVAL。
+    if ns_fd.is_none() {
+        let Some(target_pid) = file.try_pidfd_target().ok() else {
+            return Err(SystemError::EINVAL);
+        };
         if flags.is_empty() {
             return Err(SystemError::EINVAL);
         }
@@ -114,8 +135,10 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
             return Err(SystemError::EINVAL);
         }
 
-        let target_pid = RawPid::new(pid as usize);
-        let target = ProcessManager::find_task_by_vpid(target_pid).ok_or(SystemError::ESRCH)?;
+        let target = target_pid.task(PidType::TGID).ok_or(SystemError::ESRCH)?;
+        if !can_access_pidfd_setns_target(&target) {
+            return Err(SystemError::EPERM);
+        }
         if !can_setns_target_userns(&target.cred().user_ns) {
             return Err(SystemError::EPERM);
         }
@@ -140,7 +163,7 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
         }
         if flags.contains(CloneFlags::CLONE_NEWPID) {
             // 与 Linux 语义一致：仅影响子进程的 PID namespace
-            new_inner.pid_ns_for_children = target_nsproxy.pid_ns_for_children.clone();
+            new_inner.pid_ns_for_children = target.active_pid_ns();
         }
         if flags.contains(CloneFlags::CLONE_NEWCGROUP) {
             if !can_setns_cgroup(&target_nsproxy.cgroup_ns) {

--- a/kernel/src/process/pid.rs
+++ b/kernel/src/process/pid.rs
@@ -1,6 +1,10 @@
 use core::fmt::Debug;
 use core::sync::atomic::{AtomicBool, Ordering};
 
+use crate::filesystem::epoll::{
+    event_poll::{EventPoll, LockedEPItemLinkedList},
+    EPollEventType, EPollItem,
+};
 use crate::libs::rwlock::RwLock;
 use crate::libs::spinlock::{SpinLock, SpinLockGuard};
 use crate::process::ProcessManager;
@@ -35,16 +39,20 @@ impl PidType {
 /// 例如 struct pid 应该是在进程创建时（如 fork(), clone()）必然创建的
 #[derive(Clone, Debug)]
 pub struct PidPrivateData {
-    pid: i32,
+    pid: Arc<Pid>,
 }
 
 impl PidPrivateData {
-    pub fn new(pid: i32) -> Self {
+    pub fn new(pid: Arc<Pid>) -> Self {
         Self { pid }
     }
 
-    pub fn pid(&self) -> i32 {
-        self.pid
+    pub fn pid(&self) -> Arc<Pid> {
+        self.pid.clone()
+    }
+
+    pub fn pid_nr_ns(&self, ns: &Arc<PidNamespace>) -> RawPid {
+        self.pid.pid_nr_ns(ns)
     }
 }
 
@@ -58,6 +66,8 @@ pub struct Pid {
     tasks: [SpinLock<Vec<Weak<ProcessControlBlock>>>; PidType::PIDTYPE_MAX],
     /// 在各个namespace中的PID值
     numbers: SpinLock<Vec<Option<UPid>>>,
+    /// pidfd poll/epoll waiters. Linux keeps this wakeup edge on struct pid.
+    pidfd_epitems: LockedEPItemLinkedList,
 }
 
 impl Debug for Pid {
@@ -74,6 +84,7 @@ impl Pid {
             level,
             tasks: core::array::from_fn(|_| SpinLock::new(Vec::new())),
             numbers: SpinLock::new(vec![None; level as usize + 1]),
+            pidfd_epitems: LockedEPItemLinkedList::default(),
         });
 
         pid
@@ -85,6 +96,28 @@ impl Pid {
 
     pub fn set_dead(&self) {
         self.dead.store(true, core::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn add_pidfd_epitem(&self, epitem: Arc<EPollItem>) {
+        self.pidfd_epitems.lock().push_back(epitem);
+    }
+
+    pub(crate) fn remove_pidfd_epitem(&self, epitem: &Arc<EPollItem>) -> Result<(), SystemError> {
+        let mut guard = self.pidfd_epitems.lock();
+        let len = guard.len();
+        guard.retain(|x| !Arc::ptr_eq(x, epitem));
+        if len != guard.len() {
+            Ok(())
+        } else {
+            Err(SystemError::ENOENT)
+        }
+    }
+
+    pub(crate) fn wake_pidfd_pollers(&self) {
+        let _ = EventPoll::wakeup_epoll(
+            &self.pidfd_epitems,
+            EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
+        );
     }
 
     /// 获取指定PID所属的命名空间
@@ -139,6 +172,30 @@ impl Pid {
     pub fn thread_group_leader_task(&self) -> Option<Arc<ProcessControlBlock>> {
         self.tasks_iter(PidType::TGID)
             .find(|task| task.is_thread_group_leader())
+    }
+
+    pub(crate) fn thread_group_exited_for_pidfd(&self) -> bool {
+        let mut leader_seen = false;
+        let mut exited_leader_seen = false;
+
+        for task in self.tasks_iter(PidType::TGID) {
+            if task.is_thread_group_leader() {
+                leader_seen = true;
+                if task.is_live_thread_group_member() {
+                    return false;
+                }
+                if task.is_zombie() || task.is_dead() {
+                    exited_leader_seen = true;
+                }
+                continue;
+            }
+
+            if task.is_live_thread_group_member() {
+                return false;
+            }
+        }
+
+        !leader_seen || exited_leader_seen
     }
 
     pub fn pid_vnr(&self) -> RawPid {

--- a/kernel/src/process/pidfd.rs
+++ b/kernel/src/process/pidfd.rs
@@ -1,0 +1,300 @@
+use core::any::Any;
+
+use alloc::{string::String, sync::Arc, vec::Vec};
+use system_error::SystemError;
+
+use crate::filesystem::{
+    epoll::{EPollEventType, EPollItem},
+    vfs::{
+        file::{File, FileFlags, FilePrivateData, ReservedFd},
+        vcore::generate_inode_id,
+        FileSystem, FileType, FsInfo, IndexNode, InodeFlags, InodeMode, Magic, Metadata,
+        PollableInode, SuperBlock,
+    },
+};
+use crate::libs::mutex::MutexGuard;
+use crate::mm::MemoryManagementArch;
+
+use super::{
+    pid::{Pid, PidPrivateData, PidType},
+    ProcessControlBlock,
+};
+
+lazy_static::lazy_static! {
+    static ref PIDFD_FS: Arc<PidFdFs> = Arc::new(PidFdFs);
+}
+
+#[derive(Debug)]
+pub struct PidFdFs;
+
+impl PidFdFs {
+    fn instance() -> Arc<Self> {
+        PIDFD_FS.clone()
+    }
+}
+
+impl FileSystem for PidFdFs {
+    fn root_inode(&self) -> Arc<dyn IndexNode> {
+        Arc::new(PidFdInode::new())
+    }
+
+    fn info(&self) -> FsInfo {
+        FsInfo {
+            blk_dev_id: 0,
+            max_name_len: 255,
+        }
+    }
+
+    fn as_any_ref(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "pidfd"
+    }
+
+    fn super_block(&self) -> SuperBlock {
+        SuperBlock::new(
+            Magic::PIDFD_MAGIC,
+            <crate::arch::MMArch as MemoryManagementArch>::PAGE_SIZE as u64,
+            255,
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct PidFdInode {
+    metadata: Metadata,
+}
+
+impl PidFdInode {
+    fn new() -> Self {
+        Self {
+            metadata: Metadata {
+                dev_id: 0,
+                inode_id: generate_inode_id(),
+                size: 0,
+                blk_size: 0,
+                blocks: 0,
+                atime: crate::time::PosixTimeSpec::default(),
+                mtime: crate::time::PosixTimeSpec::default(),
+                ctime: crate::time::PosixTimeSpec::default(),
+                btime: crate::time::PosixTimeSpec::default(),
+                file_type: FileType::File,
+                mode: InodeMode::from_bits_truncate(0o600),
+                nlinks: 1,
+                uid: 0,
+                gid: 0,
+                raw_dev: Default::default(),
+                flags: InodeFlags::empty(),
+            },
+        }
+    }
+}
+
+impl IndexNode for PidFdInode {
+    fn is_stream(&self) -> bool {
+        true
+    }
+
+    fn open(
+        &self,
+        _data: MutexGuard<FilePrivateData>,
+        _flags: &FileFlags,
+    ) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    fn read_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        _buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EINVAL)
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        _buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EINVAL)
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        PidFdFs::instance()
+    }
+
+    fn as_any_ref(&self) -> &dyn Any {
+        self
+    }
+
+    fn list(&self) -> Result<Vec<String>, SystemError> {
+        Err(SystemError::EINVAL)
+    }
+
+    fn metadata(&self) -> Result<Metadata, SystemError> {
+        Ok(self.metadata.clone())
+    }
+
+    fn absolute_path(&self) -> Result<String, SystemError> {
+        Ok(String::from("anon_inode:[pidfd]"))
+    }
+
+    fn as_pollable_inode(&self) -> Result<&dyn PollableInode, SystemError> {
+        Ok(self)
+    }
+}
+
+impl PollableInode for PidFdInode {
+    fn poll(&self, private_data: &FilePrivateData) -> Result<usize, SystemError> {
+        let FilePrivateData::Pid(pid_data) = private_data else {
+            return Err(SystemError::EBADF);
+        };
+        let exited = pid_data.pid().thread_group_exited_for_pidfd();
+        if exited {
+            Ok((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as usize)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn add_epitem(
+        &self,
+        epitem: Arc<EPollItem>,
+        private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        let FilePrivateData::Pid(pid_data) = private_data else {
+            return Err(SystemError::EBADF);
+        };
+        pid_data.pid().add_pidfd_epitem(epitem);
+        Ok(())
+    }
+
+    fn remove_epitem(
+        &self,
+        epitem: &Arc<EPollItem>,
+        private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        let FilePrivateData::Pid(pid_data) = private_data else {
+            return Err(SystemError::EBADF);
+        };
+        pid_data.pid().remove_pidfd_epitem(epitem)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PidFdTarget {
+    pid: Arc<Pid>,
+    flags: FileFlags,
+}
+
+impl PidFdTarget {
+    fn new(pid: Arc<Pid>, flags: FileFlags) -> Self {
+        Self { pid, flags }
+    }
+
+    pub fn pid(&self) -> Arc<Pid> {
+        self.pid.clone()
+    }
+
+    pub fn flags(&self) -> FileFlags {
+        self.flags
+    }
+
+    pub fn is_nonblock(&self) -> bool {
+        self.flags.contains(FileFlags::O_NONBLOCK)
+    }
+
+    pub fn task(&self, pid_type: PidType) -> Option<Arc<ProcessControlBlock>> {
+        self.pid.pid_task(pid_type)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PidFdFileError {
+    NotPidFd,
+}
+
+impl File {
+    pub(crate) fn try_pidfd_target(&self) -> Result<PidFdTarget, PidFdFileError> {
+        let pid = {
+            let pdata = self.private_data.lock();
+            match &*pdata {
+                FilePrivateData::Pid(data) => data.pid(),
+                _ => return Err(PidFdFileError::NotPidFd),
+            }
+        };
+
+        Ok(PidFdTarget::new(pid, self.flags()))
+    }
+
+    pub(crate) fn pidfd_target(&self) -> Result<PidFdTarget, SystemError> {
+        self.try_pidfd_target()
+            .map_err(|PidFdFileError::NotPidFd| SystemError::EBADF)
+    }
+}
+
+impl ProcessControlBlock {
+    pub fn pidfd_target_from_fd(&self, fd: i32) -> Result<PidFdTarget, SystemError> {
+        let file = self
+            .fd_table()
+            .read()
+            .get_file_by_fd(fd)
+            .ok_or(SystemError::EBADF)?;
+        file.pidfd_target()
+    }
+}
+
+pub struct PreparedPidFd {
+    pub reservation: ReservedFd,
+    pub file: File,
+}
+
+pub struct PidFd;
+
+impl PidFd {
+    const PREPARE_ALLOWED_FLAGS: FileFlags = FileFlags::O_NONBLOCK;
+
+    pub fn create_file(pid: Arc<Pid>, flags: FileFlags) -> Result<File, SystemError> {
+        let file = File::new_with_private_data(
+            Arc::new(PidFdInode::new()),
+            FileFlags::O_RDWR | flags,
+            FilePrivateData::Pid(PidPrivateData::new(pid)),
+        )?;
+        Ok(file)
+    }
+
+    pub fn prepare(
+        task: &Arc<ProcessControlBlock>,
+        pid: Arc<Pid>,
+        flags: FileFlags,
+        require_tgid: bool,
+    ) -> Result<PreparedPidFd, SystemError> {
+        if flags.intersects(!Self::PREPARE_ALLOWED_FLAGS) {
+            return Err(SystemError::EINVAL);
+        }
+        if require_tgid && pid.pid_task(PidType::TGID).is_none() {
+            return Err(SystemError::EINVAL);
+        }
+
+        let reservation = task.fd_table().write().reserve_fd(true)?;
+        let file = match Self::create_file(pid, flags) {
+            Ok(file) => file,
+            Err(err) => {
+                task.fd_table().write().release_reserved_fd(reservation);
+                return Err(err);
+            }
+        };
+
+        Ok(PreparedPidFd { reservation, file })
+    }
+}

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -66,7 +66,9 @@ pub fn do_clone(
 
     let vfork = Arc::new(Completion::new());
 
-    if flags.contains(CloneFlags::CLONE_PIDFD) && flags.contains(CloneFlags::CLONE_PARENT_SETTID) {
+    if flags.contains(CloneFlags::CLONE_PIDFD)
+        && flags.intersects(CloneFlags::CLONE_PARENT_SETTID | CloneFlags::CLONE_THREAD)
+    {
         return Err(SystemError::EINVAL);
     }
 

--- a/kernel/src/process/syscall/sys_pidfdopen.rs
+++ b/kernel/src/process/syscall/sys_pidfdopen.rs
@@ -1,13 +1,9 @@
 use crate::alloc::string::ToString;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_PIDFD_OPEN;
-use crate::filesystem::vfs::file::File;
 use crate::filesystem::vfs::file::FileFlags;
-use crate::filesystem::vfs::file::FilePrivateData;
-use crate::filesystem::vfs::FileType;
-use crate::filesystem::vfs::InodeMode;
-use crate::process::pid::PidPrivateData;
-use crate::process::ProcessManager;
+use crate::process::pidfd::PidFd;
+use crate::process::{ProcessManager, RawPid};
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
 use alloc::vec::Vec;
@@ -37,37 +33,37 @@ impl Syscall for SysPidFdOpen {
         let pid = Self::pid(args);
         let flags = Self::flags(args);
 
-        let mode = InodeMode::from_bits(flags).ok_or_else(|| {
-            log::error!("SysPidFdOpen: failed to get mode!");
-            SystemError::EINVAL
-        })?;
-        let file_type = FileType::from(mode);
-        let file_mode = FileFlags::from_bits(flags).ok_or_else(|| {
-            log::error!("SysPidFdOpen: failed to get file_mode!");
-            SystemError::EINVAL
-        })?;
-
-        let root_inode = ProcessManager::current_mntns().root_inode();
-        let name = format!(
-            "Pidfd(from {} to {})",
-            ProcessManager::current_pcb().raw_pid().data(),
-            pid
-        );
-        let new_inode = root_inode.create(&name, file_type, mode)?;
-        let file = File::new(new_inode, file_mode)?;
-        {
-            let mut guard = file.private_data.lock();
-            *guard = FilePrivateData::Pid(PidPrivateData::new(pid));
+        if pid <= 0 {
+            return Err(SystemError::EINVAL);
         }
+
+        let valid_flags = FileFlags::O_NONBLOCK.bits();
+        if flags & !valid_flags != 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        let mut file_flags = FileFlags::empty();
+        if flags & FileFlags::O_NONBLOCK.bits() != 0 {
+            file_flags.insert(FileFlags::O_NONBLOCK);
+        }
+        let pid = ProcessManager::find_vpid(RawPid::new(pid as usize)).ok_or(SystemError::ESRCH)?;
+        let current = ProcessManager::current_pcb();
+        let prepared = PidFd::prepare(&current, pid, file_flags, true)?;
 
         // 存入pcb
         // Linux 的 __pidfd_prepare() 无条件对 pidfd 设置 O_CLOEXEC，
         // 无论用户传入什么 flags，pidfd 始终是 close-on-exec 的。
-        ProcessManager::current_pcb()
-            .fd_table()
-            .write()
-            .alloc_fd(file, None, true)
-            .map(|fd| fd as usize)
+        let reservation = prepared.reservation;
+        let file = prepared.file;
+        let fd_table = current.fd_table();
+        let mut fd_table = fd_table.write();
+        match fd_table.install_reserved_fd(reservation, file) {
+            Ok(fd) => Ok(fd as usize),
+            Err(err) => {
+                fd_table.release_reserved_fd(reservation);
+                Err(err)
+            }
+        }
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/process/syscall/sys_waitid.rs
+++ b/kernel/src/process/syscall/sys_waitid.rs
@@ -7,12 +7,18 @@ use crate::process::abi::WaitOption;
 use crate::process::exit::kernel_waitid;
 use crate::process::resource::RUsage;
 use crate::process::wait::WaitSelector;
+use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::UserBufferWriter;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
 pub struct SysWaitId;
+
+struct ResolvedWaitIdSelector {
+    selector: WaitSelector,
+    pidfd_nonblock: bool,
+}
 
 impl SysWaitId {
     #[inline(always)]
@@ -34,6 +40,24 @@ impl SysWaitId {
     #[inline(always)]
     fn rusage(args: &[usize]) -> *mut RUsage {
         args[4] as *mut RUsage
+    }
+
+    fn resolve_selector(which: u32, upid: i32) -> Result<ResolvedWaitIdSelector, SystemError> {
+        if which == 3 {
+            if upid < 0 {
+                return Err(SystemError::EINVAL);
+            }
+            let target = ProcessManager::current_pcb().pidfd_target_from_fd(upid)?;
+            Ok(ResolvedWaitIdSelector {
+                selector: WaitSelector::Pid(target.pid()),
+                pidfd_nonblock: target.is_nonblock(),
+            })
+        } else {
+            Ok(ResolvedWaitIdSelector {
+                selector: WaitSelector::from_waitid(which, upid)?,
+                pidfd_nonblock: false,
+            })
+        }
     }
 }
 
@@ -67,7 +91,7 @@ impl Syscall for SysWaitId {
         }
 
         // which/upid → WaitSelector (P_ALL=0, P_PID=1, P_PGID=2, P_PIDFD=3)
-        let pid_selector = WaitSelector::from_waitid(which, upid)?;
+        let resolved = Self::resolve_selector(which, upid)?;
 
         // Build optional infop writer. Linux validates selector/options before touching user pointers.
         let infop_writer = if infop_ptr.is_null() {
@@ -88,7 +112,13 @@ impl Syscall for SysWaitId {
         };
 
         // 调用内核实现
-        let has_event = kernel_waitid(pid_selector, infop_writer, options, tmp_rusage.as_mut())?;
+        let has_event = kernel_waitid(
+            resolved.selector,
+            infop_writer,
+            options,
+            tmp_rusage.as_mut(),
+            resolved.pidfd_nonblock,
+        )?;
         // log::debug!("sys_waitid: kernel_waitid returned OK");
 
         if has_event && !rusage_ptr.is_null() {

--- a/kernel/src/process/wait.rs
+++ b/kernel/src/process/wait.rs
@@ -65,10 +65,9 @@ impl WaitSelector {
                     ))))
                 }
             }
-            // P_PIDFD is a waitid-specific selector. DragonOS has pidfd basics,
-            // but pidfd wait still needs fd validation and O_NONBLOCK/EAGAIN
-            // semantics, so keep the unsupported boundary explicit here after
-            // preserving Linux's invalid negative-fd boundary.
+            // P_PIDFD is a waitid-specific selector and must be resolved by
+            // the syscall layer, where fd validation and O_NONBLOCK/EAGAIN
+            // translation have access to the pidfd file.
             3 => {
                 if upid < 0 {
                     return Err(SystemError::EINVAL);

--- a/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
+++ b/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
@@ -3,10 +3,13 @@
 #endif
 
 #include <errno.h>
+#include <fcntl.h>
 #include <new>
+#include <poll.h>
 #include <pthread.h>
 #include <sched.h>
 #include <signal.h>
+#include <sys/epoll.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,6 +42,14 @@
 
 #ifndef P_PIDFD
 #define P_PIDFD 3
+#endif
+
+#ifndef SYS_pidfd_open
+#ifdef __NR_pidfd_open
+#define SYS_pidfd_open __NR_pidfd_open
+#else
+#define SYS_pidfd_open 434
+#endif
 #endif
 
 #ifndef PR_SET_CHILD_SUBREAPER
@@ -110,6 +121,10 @@ uint64_t BurnCpuForUsec(uint64_t usec) {
 void BusyForUsec(uint64_t usec) {
   uint64_t sink = BurnCpuForUsec(usec);
   _exit(static_cast<int>(sink & 0));
+}
+
+int PidfdOpen(pid_t pid, unsigned int flags) {
+  return static_cast<int>(syscall(SYS_pidfd_open, pid, flags));
 }
 
 void* ThreadBurn(void* arg) {
@@ -199,6 +214,19 @@ struct ThreadTidArgs {
   int release_fd = -1;
   pid_t tid = -1;
 };
+
+struct DelayedWriteArgs {
+  int fd = -1;
+  useconds_t delay_usec = 0;
+};
+
+void* DelayedWriteByte(void* arg) {
+  auto* args = reinterpret_cast<DelayedWriteArgs*>(arg);
+  usleep(args->delay_usec);
+  char byte = 'x';
+  WriteExact(args->fd, &byte, 1);
+  return nullptr;
+}
 
 void* ReportTidAndWait(void* arg) {
   auto* args = reinterpret_cast<ThreadTidArgs*>(arg);
@@ -516,6 +544,21 @@ bool WaitidPeekExited(pid_t child, siginfo_t* si) {
   for (int i = 0; i < 1000; ++i) {
     memset(si, 0, sizeof(*si));
     if (syscall(SYS_waitid, P_PID, child, si, WEXITED | WNOWAIT | WNOHANG,
+                nullptr) != 0) {
+      return false;
+    }
+    if (si->si_pid == child) {
+      return true;
+    }
+    usleep(1000);
+  }
+  return false;
+}
+
+bool WaitidPidfdExited(int pidfd, pid_t child, siginfo_t* si) {
+  for (int i = 0; i < 1000; ++i) {
+    memset(si, 0, sizeof(*si));
+    if (syscall(SYS_waitid, P_PIDFD, pidfd, si, WEXITED | WNOHANG,
                 nullptr) != 0) {
       return false;
     }
@@ -1229,6 +1272,376 @@ TEST(WaitRusage, WaitidPidfdNegativeFdIsEinval) {
   EXPECT_EQ(-1,
             syscall(SYS_waitid, P_PIDFD, -1, &si, WEXITED | WNOHANG, nullptr));
   EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(WaitRusage, PidfdOpenRejectsInvalidPidAndFlags) {
+  errno = 0;
+  EXPECT_EQ(-1, PidfdOpen(0, 0));
+  EXPECT_EQ(EINVAL, errno);
+
+  errno = 0;
+  EXPECT_EQ(-1, PidfdOpen(-1, 0));
+  EXPECT_EQ(EINVAL, errno);
+
+  errno = 0;
+  EXPECT_EQ(-1, PidfdOpen(getpid(), O_CLOEXEC));
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST(WaitRusage, PidfdOpenAllowsRepeatedOpenSamePid) {
+  int first = PidfdOpen(getpid(), 0);
+  ASSERT_GE(first, 0) << strerror(errno);
+
+  int second = PidfdOpen(getpid(), 0);
+  ASSERT_GE(second, 0) << strerror(errno);
+  EXPECT_NE(first, second);
+
+  close(first);
+  close(second);
+}
+
+TEST(WaitRusage, PidfdOpenRejectsNonLeaderTid) {
+  int ready_pipe[2] = {};
+  int release_pipe[2] = {};
+  ASSERT_EQ(0, pipe(ready_pipe)) << strerror(errno);
+  ASSERT_EQ(0, pipe(release_pipe)) << strerror(errno);
+
+  ThreadTidArgs args {};
+  args.ready_fd = ready_pipe[1];
+  args.release_fd = release_pipe[0];
+  pthread_t thread;
+  ASSERT_EQ(0, pthread_create(&thread, nullptr, ReportTidAndWait, &args))
+      << strerror(errno);
+
+  char byte = 0;
+  ASSERT_EQ(1, read(ready_pipe[0], &byte, 1)) << strerror(errno);
+  ASSERT_GT(args.tid, 0);
+  ASSERT_NE(args.tid, getpid());
+
+  errno = 0;
+  EXPECT_EQ(-1, PidfdOpen(args.tid, 0));
+  EXPECT_EQ(EINVAL, errno);
+
+  ASSERT_EQ(1, write(release_pipe[1], "x", 1)) << strerror(errno);
+  ASSERT_EQ(0, pthread_join(thread, nullptr)) << strerror(errno);
+  close(ready_pipe[0]);
+  close(ready_pipe[1]);
+  close(release_pipe[0]);
+  close(release_pipe[1]);
+}
+
+TEST(WaitRusage, WaitidPidfdRejectsNonPidfdFd) {
+  int fds[2] = {};
+  ASSERT_EQ(0, pipe(fds)) << strerror(errno);
+
+  siginfo_t si {};
+  errno = 0;
+  EXPECT_EQ(-1, syscall(SYS_waitid, P_PIDFD, fds[0],
+                        &si, WEXITED | WNOHANG, nullptr));
+  EXPECT_EQ(EBADF, errno);
+
+  close(fds[0]);
+  close(fds[1]);
+}
+
+TEST(WaitRusage, WaitidPidfdWaitsExitedChild) {
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    _exit(33);
+  }
+
+  int pidfd = PidfdOpen(child, 0);
+  ASSERT_GE(pidfd, 0) << strerror(errno);
+
+  siginfo_t si {};
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &si, WEXITED, nullptr))
+      << strerror(errno);
+  EXPECT_EQ(SIGCHLD, si.si_signo);
+  EXPECT_EQ(CLD_EXITED, si.si_code);
+  EXPECT_EQ(child, si.si_pid);
+  EXPECT_EQ(33, si.si_status);
+
+  close(pidfd);
+}
+
+TEST(WaitRusage, WaitidPidfdNonblockWithoutWnohangReturnsEagain) {
+  int release_pipe[2] = {};
+  ASSERT_EQ(0, pipe(release_pipe)) << strerror(errno);
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    close(release_pipe[1]);
+    char byte = 0;
+    if (read(release_pipe[0], &byte, 1) != 1) {
+      _exit(2);
+    }
+    _exit(34);
+  }
+  close(release_pipe[0]);
+
+  int pidfd = PidfdOpen(child, 0);
+  ASSERT_GE(pidfd, 0) << strerror(errno);
+  int flags = fcntl(pidfd, F_GETFL);
+  ASSERT_GE(flags, 0) << strerror(errno);
+  ASSERT_EQ(0, fcntl(pidfd, F_SETFL, flags | O_NONBLOCK)) << strerror(errno);
+
+  DelayedWriteArgs release_args {};
+  release_args.fd = release_pipe[1];
+  release_args.delay_usec = 100000;
+  pthread_t release_thread;
+  ASSERT_EQ(0, pthread_create(&release_thread, nullptr, DelayedWriteByte,
+                              &release_args))
+      << strerror(errno);
+
+  siginfo_t si {};
+  errno = 0;
+  EXPECT_EQ(-1, syscall(SYS_waitid, P_PIDFD, pidfd, &si, WEXITED, nullptr));
+  EXPECT_EQ(EAGAIN, errno);
+
+  ASSERT_EQ(0, pthread_join(release_thread, nullptr)) << strerror(errno);
+  close(release_pipe[1]);
+
+  ASSERT_TRUE(WaitidPidfdExited(pidfd, child, &si)) << strerror(errno);
+  EXPECT_EQ(CLD_EXITED, si.si_code);
+  EXPECT_EQ(34, si.si_status);
+
+  close(pidfd);
+}
+
+TEST(WaitRusage, WaitidPidfdNonblockWithWnohangReturnsZeroAndClearsSiginfo) {
+  int release_pipe[2] = {};
+  ASSERT_EQ(0, pipe(release_pipe)) << strerror(errno);
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    close(release_pipe[1]);
+    char byte = 0;
+    if (read(release_pipe[0], &byte, 1) != 1) {
+      _exit(2);
+    }
+    _exit(35);
+  }
+  close(release_pipe[0]);
+
+  int pidfd = PidfdOpen(child, O_NONBLOCK);
+  ASSERT_GE(pidfd, 0) << strerror(errno);
+
+  siginfo_t si {};
+  si.si_signo = SIGCHLD;
+  si.si_code = CLD_EXITED;
+  si.si_pid = child;
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &si,
+                       WEXITED | WNOHANG, nullptr))
+      << strerror(errno);
+  EXPECT_EQ(0, si.si_signo);
+  EXPECT_EQ(0, si.si_code);
+  EXPECT_EQ(0, si.si_pid);
+
+  ASSERT_EQ(1, write(release_pipe[1], "x", 1)) << strerror(errno);
+  close(release_pipe[1]);
+
+  ASSERT_TRUE(WaitidPidfdExited(pidfd, child, &si)) << strerror(errno);
+  EXPECT_EQ(CLD_EXITED, si.si_code);
+  EXPECT_EQ(35, si.si_status);
+
+  close(pidfd);
+}
+
+TEST(WaitRusage, PidfdPollAndLseekSemantics) {
+  int release_pipe[2] = {};
+  ASSERT_EQ(0, pipe(release_pipe)) << strerror(errno);
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    close(release_pipe[1]);
+    char byte = 0;
+    if (read(release_pipe[0], &byte, 1) != 1) {
+      _exit(2);
+    }
+    _exit(36);
+  }
+  close(release_pipe[0]);
+
+  int pidfd = PidfdOpen(child, 0);
+  ASSERT_GE(pidfd, 0) << strerror(errno);
+
+  errno = 0;
+  EXPECT_EQ(-1, lseek(pidfd, 0, SEEK_SET));
+  EXPECT_EQ(ESPIPE, errno);
+
+  struct pollfd pfd {};
+  pfd.fd = pidfd;
+  pfd.events = POLLIN;
+  ASSERT_EQ(0, poll(&pfd, 1, 0)) << strerror(errno);
+  EXPECT_EQ(0, pfd.revents & POLLIN);
+
+  int epfd = epoll_create1(0);
+  ASSERT_GE(epfd, 0) << strerror(errno);
+  struct epoll_event event {};
+  event.events = EPOLLIN;
+  event.data.fd = pidfd;
+  ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, pidfd, &event))
+      << strerror(errno);
+
+  ASSERT_EQ(1, write(release_pipe[1], "x", 1)) << strerror(errno);
+  close(release_pipe[1]);
+
+  siginfo_t si {};
+  bool exited = false;
+  for (int i = 0; i < 200; ++i) {
+    memset(&si, 0, sizeof(si));
+    ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &si,
+                         WEXITED | WNOWAIT | WNOHANG, nullptr))
+        << strerror(errno);
+    if (si.si_pid == child) {
+      exited = true;
+      break;
+    }
+    usleep(1000);
+  }
+  ASSERT_TRUE(exited);
+
+  pfd.revents = 0;
+  ASSERT_EQ(1, poll(&pfd, 1, 0)) << strerror(errno);
+  EXPECT_NE(0, pfd.revents & POLLIN);
+
+  struct epoll_event ready {};
+  ASSERT_EQ(1, epoll_wait(epfd, &ready, 1, 0)) << strerror(errno);
+  EXPECT_EQ(pidfd, ready.data.fd);
+  EXPECT_NE(0u, ready.events & EPOLLIN);
+
+  memset(&si, 0, sizeof(si));
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &si, WEXITED, nullptr))
+      << strerror(errno);
+  EXPECT_EQ(CLD_EXITED, si.si_code);
+  EXPECT_EQ(36, si.si_status);
+
+  close(epfd);
+  close(pidfd);
+}
+
+TEST(WaitRusage, PidfdPollWaitsForWholeThreadGroupExit) {
+  int thread_ready_pipe[2] = {};
+  int leader_go_pipe[2] = {};
+  int leader_exiting_pipe[2] = {};
+  int release_pipe[2] = {};
+  ASSERT_EQ(0, pipe(thread_ready_pipe)) << strerror(errno);
+  ASSERT_EQ(0, pipe(leader_go_pipe)) << strerror(errno);
+  ASSERT_EQ(0, pipe(leader_exiting_pipe)) << strerror(errno);
+  ASSERT_EQ(0, pipe(release_pipe)) << strerror(errno);
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    close(thread_ready_pipe[0]);
+    close(leader_go_pipe[1]);
+    close(leader_exiting_pipe[0]);
+    close(release_pipe[1]);
+
+    BlockingThreadExitArgs args;
+    args.ready_fd = thread_ready_pipe[1];
+    args.release_fd = release_pipe[0];
+    pthread_t thread {};
+    if (pthread_create(&thread, nullptr, BlockThenExitThread, &args) != 0) {
+      syscall(SYS_exit, 2);
+    }
+
+    char go = 0;
+    if (read(leader_go_pipe[0], &go, 1) != 1) {
+      syscall(SYS_exit, 3);
+    }
+
+    char byte = 'l';
+    if (write(leader_exiting_pipe[1], &byte, 1) != 1) {
+      syscall(SYS_exit, 4);
+    }
+    syscall(SYS_exit, 0);
+  }
+
+  close(thread_ready_pipe[1]);
+  close(leader_go_pipe[0]);
+  close(leader_exiting_pipe[1]);
+  close(release_pipe[0]);
+
+  char byte = 0;
+  ASSERT_EQ(1, read(thread_ready_pipe[0], &byte, 1)) << strerror(errno);
+
+  int pidfd = PidfdOpen(child, 0);
+  ASSERT_GE(pidfd, 0) << strerror(errno);
+
+  int epfd = epoll_create1(0);
+  ASSERT_GE(epfd, 0) << strerror(errno);
+  struct epoll_event event {};
+  event.events = EPOLLIN;
+  event.data.fd = pidfd;
+  ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, pidfd, &event))
+      << strerror(errno);
+
+  ASSERT_EQ(1, write(leader_go_pipe[1], "x", 1)) << strerror(errno);
+  close(leader_go_pipe[1]);
+  ASSERT_EQ(1, read(leader_exiting_pipe[0], &byte, 1)) << strerror(errno);
+  close(leader_exiting_pipe[0]);
+
+  for (int i = 0; i < 1000; ++i) {
+    struct pollfd pfd {};
+    pfd.fd = pidfd;
+    pfd.events = POLLIN;
+    ASSERT_EQ(0, poll(&pfd, 1, 0)) << strerror(errno);
+    EXPECT_EQ(0, pfd.revents & POLLIN);
+
+    struct epoll_event ready {};
+    ASSERT_EQ(0, epoll_wait(epfd, &ready, 1, 0)) << strerror(errno);
+
+    siginfo_t si {};
+    ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &si,
+                         WEXITED | WNOHANG, nullptr))
+        << strerror(errno);
+    EXPECT_EQ(0, si.si_pid);
+    usleep(1000);
+  }
+
+  ASSERT_EQ(1, write(release_pipe[1], "x", 1)) << strerror(errno);
+  close(release_pipe[1]);
+
+  siginfo_t si {};
+  bool exited = false;
+  for (int i = 0; i < 1000; ++i) {
+    memset(&si, 0, sizeof(si));
+    ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &si,
+                         WEXITED | WNOWAIT | WNOHANG, nullptr))
+        << strerror(errno);
+    if (si.si_pid == child) {
+      exited = true;
+      break;
+    }
+    usleep(1000);
+  }
+  ASSERT_TRUE(exited);
+
+  struct pollfd pfd {};
+  pfd.fd = pidfd;
+  pfd.events = POLLIN;
+  ASSERT_EQ(1, poll(&pfd, 1, 0)) << strerror(errno);
+  EXPECT_NE(0, pfd.revents & POLLIN);
+
+  struct epoll_event ready {};
+  ASSERT_EQ(1, epoll_wait(epfd, &ready, 1, 0)) << strerror(errno);
+  EXPECT_EQ(pidfd, ready.data.fd);
+  EXPECT_NE(0u, ready.events & EPOLLIN);
+
+  memset(&si, 0, sizeof(si));
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &si, WEXITED, nullptr))
+      << strerror(errno);
+  EXPECT_EQ(CLD_EXITED, si.si_code);
+  EXPECT_EQ(0, si.si_status);
+
+  close(thread_ready_pipe[0]);
+  close(epfd);
+  close(pidfd);
 }
 
 TEST(WaitRusage, Wait4RejectsWnowaitWithoutReapingChild) {


### PR DESCRIPTION
## Summary

Complete Linux-compatible pidfd wait and file semantics for DragonOS.

This PR implements `waitid(P_PIDFD, ...)`, moves pidfd handling onto stable `Arc<Pid>` identity, refactors pidfd parsing/creation into a typed Rust API, and adds pidfd stream/non-seek plus poll/epoll readiness semantics.

## What changed

- Add `P_PIDFD` handling for `waitid`, including fd validation, negative fd `EINVAL`, non-pidfd `EBADF`, `O_NONBLOCK -> WNOHANG`, and Linux-style `EAGAIN` when a nonblocking pidfd would otherwise block.
- Store pidfd private data as stable `Arc<Pid>` identity and route consumers through `process::pidfd::PidFdTarget` instead of resolving by numeric PID later.
- Add `process::pidfd` as the pidfd bridge layer, with typed `File::pidfd_target()`, `ProcessControlBlock::pidfd_target_from_fd()`, and shared `PidFd::prepare()` / `PidFd::create_file()` helpers.
- Replace root-inode pidfd file creation with anon-inode style `PidFdInode`, avoiding namespace pollution and repeated-open name conflicts.
- Share pidfd fd reservation, close-on-exec installation, and rollback logic between `pidfd_open()` and `clone(CLONE_PIDFD)`.
- Migrate `setns(pidfd, ...)` and `pidfd_send_signal` to the stable pidfd path while preserving Linux error-code distinctions and pid namespace/permission checks.
- Add pidfd stream/non-seek and readiness semantics: `lseek(pidfd, ...)` returns `ESPIPE`, `poll`/`epoll` become readable after the target thread group exits, and pidfd epoll waiters are woken from exit paths.
- Extend `wait_rusage_test` with pidfd validation, repeated pidfd opens, nonblocking waitid behavior, non-pidfd descriptor rejection, and pidfd lseek/poll/epoll coverage.

## Why

`waitid(P_PIDFD)` previously did not have Linux-compatible behavior, and older pidfd private data stored numeric PID state. Numeric PID lookup is not sufficient for pidfd semantics because a pidfd must continue to refer to the original pid identity even after task exit and possible PID reuse.

The refactor also fixes the Rust API shape: pidfd parsing is no longer exposed as loose helper functions in `pid.rs`; pidfd-specific VFS/file bridging now lives in `process::pidfd`, while wait/signal/setns call sites receive a typed pidfd target.

## Validation

- `make fmt`
- `make kernel`
- Booted DragonOS in QEMU with `make run-nographic`
- In the guest: `cd /opt/tests/dunitest/bin/normal && ./wait_rusage_test`
  - Result: 30 tests passed
- `git diff --check`
