### PR TITLE
fix(process): tighten wait visibility semantics

### DIFF
--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -163,6 +163,19 @@ fn push_wait_candidate(
     candidates.push(WaitCandidate { child, relations });
 }
 
+// Wait invariants:
+// - Natural children and ptrace tracees are separate relations. A task that is
+//   present in both sets must be considered through ptrace first, matching Linux
+//   wait_consider_task() for children traced by the caller's thread group.
+// - `children` is a scan index; `wait_parent_pcb` is the thread-level owner used
+//   by __WNOTHREAD. Reparent and ptrace unlink paths must wake the concrete
+//   parent and its group leader via ProcessManager::wake_wait_parent().
+// - `ProcessState::Exited` carries the wait status; `ExitState::Zombie` publishes
+//   wait visibility; `try_mark_dead_from_zombie()` is the only non-WNOWAIT reap
+//   ownership transition. WNOWAIT must not release or account child rusage.
+// - DragonOS does not yet model Linux EXIT_TRACE. Ptrace wait support is limited
+//   to the current ptrace relation list and basic exit/stop reporting; full
+//   ptrace detach/real-parent cascade semantics require a separate design.
 fn wait_candidate_children(options: WaitOption) -> Vec<WaitCandidate> {
     let current = ProcessManager::current_pcb();
     let leader = get_thread_group_leader(&current);
@@ -296,17 +309,10 @@ pub fn kernel_waitid(
         //     writer.size()
         // );
         use crate::ipc::signal_types::{PosixSigInfo, PosixSiginfoFields, PosixSiginfoSigchld};
-        let mut si = PosixSigInfo {
-            si_signo: 0,
-            si_errno: 0,
-            si_code: 0,
-            _sifields: PosixSiginfoFields {
-                _kill: crate::ipc::signal_types::PosixSiginfoKill {
-                    si_pid: 0,
-                    si_uid: 0,
-                },
-            },
-        };
+        // Linux waitid() writes an all-zero siginfo when WNOHANG finds no event.
+        // Zero the whole union, not just the small _kill variant, so fields such
+        // as _sigchld.si_status cannot leak stale stack bytes.
+        let mut si = unsafe { core::mem::zeroed::<PosixSigInfo>() };
         if let Some(info) = &kwo.ret_info {
             si.si_signo = Signal::SIGCHLD as i32; // SIGCHLD
             si.si_errno = 0;

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -928,31 +928,16 @@ impl ProcessManager {
                 }
             }
 
-            // 无论exit_signal是什么值，都要唤醒父进程的wait_queue
-            // 因为父进程可能使用__WALL选项等待任何类型的子进程（包括exit_signal=0的clone子进程）
-            // 根据Linux语义，exit_signal只决定发送什么信号，不决定是否唤醒父进程
-            parent_pcb
-                .wait_queue
-                .wakeup_all(Some(ProcessState::Blocked(true)));
+            // Wake the wait parent regardless of exit_signal value.
+            // exit_signal only determines which signal to send, not whether to wake wait.
+            // DragonOS waiters sleep on per-task wait_queue, so we must also wake
+            // the parent's thread-group leader to compensate for Linux's shared
+            // signal->wait_chldexit queue semantics.
+            ProcessManager::wake_wait_parent(&parent_pcb);
 
             // kthread 退出时显式唤醒 kthreadd，使其回收 zombie
             if is_kthread {
                 let _ = ProcessManager::wakeup(&parent_pcb);
-            }
-
-            // 根据 Linux wait 语义，线程组中的任何线程都可以等待同一线程组中任何线程创建的子进程。
-            // 由于子进程被添加到线程组 leader 的 children 列表中，
-            // 因此还需要唤醒线程组 leader 的 wait_queue（如果 leader 不是 parent_pcb 本身）。
-            let parent_group_leader = {
-                let ti = parent_pcb.thread.read_irqsave();
-                ti.group_leader()
-            };
-            if let Some(leader) = parent_group_leader {
-                if !Arc::ptr_eq(&leader, &parent_pcb) {
-                    leader
-                        .wait_queue
-                        .wakeup_all(Some(ProcessState::Blocked(true)));
-                }
             }
 
             // todo: 这里还需要根据线程组的信息，决定信号的发送
@@ -1291,6 +1276,31 @@ impl ProcessManager {
 
     pub fn exit_ptrace(tracer: &Arc<ProcessControlBlock>) {
         ptrace::exit_ptrace(tracer)
+    }
+
+    /// Wake waiters that can observe child state changes through `parent`.
+    ///
+    /// Linux uses the thread-group shared `signal->wait_chldexit` queue.
+    /// DragonOS currently has one `wait_queue` per task, while `do_wait()`
+    /// sleeps on the caller's thread-group leader. Any path that publishes a
+    /// wait-visible transition through a parent relation must therefore wake
+    /// both the concrete parent task and its thread-group leader.
+    pub(crate) fn wake_wait_parent(parent: &Arc<ProcessControlBlock>) {
+        parent
+            .wait_queue
+            .wakeup_all(Some(ProcessState::Blocked(true)));
+
+        let parent_group_leader = {
+            let ti = parent.thread.read_irqsave();
+            ti.group_leader()
+        };
+        if let Some(leader) = parent_group_leader {
+            if !Arc::ptr_eq(&leader, parent) {
+                leader
+                    .wait_queue
+                    .wakeup_all(Some(ProcessState::Blocked(true)));
+            }
+        }
     }
 
     /// 上下文切换完成后的钩子函数
@@ -2519,6 +2529,13 @@ impl ProcessControlBlock {
         child.basic.write_irqsave().ppid = parent_pid_in_child_ns;
 
         ProcessControlBlock::link_child_to_parent_list(child, new_parent);
+
+        // Linux reparent_leader() notifies the new parent when a zombie child
+        // becomes wait-visible through reparenting. DragonOS keeps per-task wait
+        // queues, so wake both the concrete new parent and its group leader.
+        if child.is_zombie() {
+            ProcessManager::wake_wait_parent(new_parent);
+        }
     }
 
     pub(crate) fn reparent_child_links_from_thread_group(

--- a/kernel/src/process/ptrace.rs
+++ b/kernel/src/process/ptrace.rs
@@ -80,6 +80,13 @@ pub fn unlink_tracee(tracee: &Arc<ProcessControlBlock>) {
         let raw_pid = tracee.raw_pid();
         tracer.ptraced.write_irqsave().retain(|pid| *pid != raw_pid);
     }
+
+    // Detaching can make a tracee observable by its natural parent again.
+    // Wake the DragonOS wait owner pair (parent task + group leader), matching
+    // Linux's shared signal->wait_chldexit visibility.
+    if let Some(real_parent) = tracee.real_parent_pcb() {
+        ProcessManager::wake_wait_parent(&real_parent);
+    }
 }
 
 pub fn exit_ptrace(tracer: &Arc<ProcessControlBlock>) {
@@ -105,10 +112,11 @@ pub fn exit_ptrace(tracer: &Arc<ProcessControlBlock>) {
                 tracee.flags().remove(ProcessFlags::PTRACED);
             }
         }
+        // Releasing a tracee from this tracer can make it naturally waitable.
+        // Wake both the concrete parent and its thread-group leader; see
+        // ProcessManager::wake_wait_parent() for the wait queue invariant.
         if let Some(real_parent) = tracee.real_parent_pcb() {
-            real_parent
-                .wait_queue
-                .wakeup_all(Some(super::ProcessState::Blocked(true)));
+            ProcessManager::wake_wait_parent(&real_parent);
         }
     }
 }

--- a/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
+++ b/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
@@ -228,6 +228,47 @@ void* DelayedWriteByte(void* arg) {
   return nullptr;
 }
 
+struct StartThenReleaseArgs {
+  int started_fd = -1;
+  int release_fd = -1;
+  useconds_t delay_usec = 0;
+};
+
+void* WaitForStartThenRelease(void* arg) {
+  auto* args = reinterpret_cast<StartThenReleaseArgs*>(arg);
+  char byte = 0;
+  if (read(args->started_fd, &byte, 1) == 1) {
+    sched_yield();
+    usleep(args->delay_usec);
+    char release = 'x';
+    WriteExact(args->release_fd, &release, 1);
+  }
+  return nullptr;
+}
+
+pid_t WaitPidWithTimeout(pid_t pid, int* status, uint64_t timeout_usec,
+                         int* wait_errno) {
+  const uint64_t start = MonotonicUsec();
+  while (MonotonicUsec() - start < timeout_usec) {
+    errno = 0;
+    pid_t ret = waitpid(pid, status, WNOHANG);
+    if (ret == pid) {
+      return ret;
+    }
+    if (ret < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      if (wait_errno != nullptr) {
+        *wait_errno = errno;
+      }
+      return -1;
+    }
+    usleep(1000);
+  }
+  return 0;
+}
+
 void* ReportTidAndWait(void* arg) {
   auto* args = reinterpret_cast<ThreadTidArgs*>(arg);
   args->tid = static_cast<pid_t>(syscall(SYS_gettid));
@@ -570,6 +611,75 @@ bool WaitidPidfdExited(int pidfd, pid_t child, siginfo_t* si) {
   return false;
 }
 
+int BlockingWaitExitRaceHelper(int iter) {
+  int started_pipe[2] = {};
+  int release_pipe[2] = {};
+  if (pipe(started_pipe) != 0 || pipe(release_pipe) != 0) {
+    return 10;
+  }
+
+  const int expected_exit = 40 + iter;
+  pid_t child = fork();
+  if (child == 0) {
+    close(started_pipe[0]);
+    close(started_pipe[1]);
+    close(release_pipe[1]);
+    char byte = 0;
+    if (read(release_pipe[0], &byte, 1) != 1) {
+      _exit(11);
+    }
+    close(release_pipe[0]);
+    _exit(expected_exit);
+  }
+  if (child < 0) {
+    return 12;
+  }
+
+  close(release_pipe[0]);
+
+  StartThenReleaseArgs release_args {};
+  release_args.started_fd = started_pipe[0];
+  release_args.release_fd = release_pipe[1];
+  release_args.delay_usec = 20000;
+  pthread_t release_thread {};
+  if (pthread_create(&release_thread, nullptr, WaitForStartThenRelease,
+                     &release_args) != 0) {
+    kill(child, SIGKILL);
+    waitpid(child, nullptr, 0);
+    return 13;
+  }
+
+  char started = 's';
+  if (!WriteExact(started_pipe[1], &started, 1)) {
+    kill(child, SIGKILL);
+    waitpid(child, nullptr, 0);
+    pthread_join(release_thread, nullptr);
+    return 14;
+  }
+  close(started_pipe[1]);
+
+  int status = 0;
+  errno = 0;
+  pid_t ret = wait4(child, &status, 0, nullptr);
+  int wait_errno = errno;
+  pthread_join(release_thread, nullptr);
+  close(started_pipe[0]);
+  close(release_pipe[1]);
+
+  if (ret != child) {
+    kill(child, SIGKILL);
+    waitpid(child, nullptr, WNOHANG);
+    return wait_errno == ECHILD ? 15 : 16;
+  }
+  if (!WIFEXITED(status)) {
+    return 17;
+  }
+  if (WEXITSTATUS(status) != expected_exit) {
+    return 18;
+  }
+  return 0;
+}
+
 }  // namespace
 
 TEST(WaitRusage, WaitidReportsChildRealUid) {
@@ -603,6 +713,51 @@ TEST(WaitRusage, WaitPidSelfReturnsEchild) {
   EXPECT_EQ(-1, syscall(SYS_waitid, P_PID, getpid(), &si,
                         WEXITED | WNOHANG, nullptr));
   EXPECT_EQ(ECHILD, errno);
+}
+
+TEST(WaitRusage, WaitidWnohangLiveChildClearsSiginfoAndLeavesRusage) {
+  int release_pipe[2] = {};
+  ASSERT_EQ(0, pipe(release_pipe)) << strerror(errno);
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    close(release_pipe[1]);
+    char byte = 0;
+    if (read(release_pipe[0], &byte, 1) != 1) {
+      _exit(2);
+    }
+    close(release_pipe[0]);
+    _exit(0);
+  }
+  close(release_pipe[0]);
+
+  siginfo_t si {};
+  memset(&si, 0x5a, sizeof(si));
+  struct rusage usage {};
+  memset(&usage, 0x5a, sizeof(usage));
+  unsigned char usage_before[sizeof(usage)] = {};
+  memcpy(usage_before, &usage, sizeof(usage));
+
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PID, child, &si,
+                       WEXITED | WNOHANG, &usage))
+      << strerror(errno);
+  EXPECT_EQ(0, si.si_signo);
+  EXPECT_EQ(0, si.si_code);
+  EXPECT_EQ(0, si.si_pid);
+  EXPECT_EQ(0, si.si_status);
+  EXPECT_EQ(0, memcmp(usage_before, &usage, sizeof(usage)));
+
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PID, child, nullptr,
+                       WEXITED | WNOHANG, nullptr))
+      << strerror(errno);
+
+  ASSERT_EQ(1, write(release_pipe[1], "x", 1)) << strerror(errno);
+  close(release_pipe[1]);
+  int status = 0;
+  ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(0, WEXITSTATUS(status));
 }
 
 TEST(WaitRusage, CloneParentChildNotWaitableByCreatorWithWnothread) {
@@ -1229,6 +1384,32 @@ TEST(WaitRusage, ConcurrentExitingThreadsDoNotKeepChildOnDyingReaper) {
     ASSERT_EQ(helper, waitpid(helper, &status, 0)) << strerror(errno);
     ASSERT_TRUE(WIFEXITED(status)) << "iter=" << iter << " status=" << status;
     EXPECT_EQ(41, WEXITSTATUS(status)) << "iter=" << iter;
+  }
+}
+
+TEST(WaitRusage, BlockingWait4ChildExitDoesNotLoseWakeup) {
+  for (int iter = 0; iter < 5; ++iter) {
+    pid_t helper = fork();
+    ASSERT_GE(helper, 0) << strerror(errno);
+    if (helper == 0) {
+      _exit(BlockingWaitExitRaceHelper(iter));
+    }
+
+    int status = 0;
+    int wait_errno = 0;
+    pid_t wait_ret = WaitPidWithTimeout(helper, &status, 3000000, &wait_errno);
+    if (wait_ret == 0) {
+      kill(helper, SIGKILL);
+      waitpid(helper, nullptr, 0);
+      FAIL() << "blocking wait helper timed out at iter=" << iter
+             << " helper=" << helper;
+    }
+    ASSERT_EQ(helper, wait_ret) << "iter=" << iter << " helper=" << helper
+                                << " errno=" << wait_errno << " ("
+                                << strerror(wait_errno) << ")";
+
+    ASSERT_TRUE(WIFEXITED(status)) << "iter=" << iter << " status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "iter=" << iter;
   }
 }
 


### PR DESCRIPTION
## Summary

- add a shared wait-parent wakeup path for exit, ptrace unlink, and zombie reparent visibility changes
- zero the full waitid siginfo on WNOHANG/no-event returns
- add dunitest coverage for waitid no-event siginfo and blocking wait4 child-exit wakeups

## Validation

- make fmt
- make kernel
- host: wait_rusage_test --gtest_filter=WaitRusage.WaitidWnohangLiveChildClearsSiginfoAndLeavesRusage:WaitRusage.BlockingWait4ChildExitDoesNotLoseWakeup
- DragonOS guest: /opt/tests/dunitest/bin/normal/wait_rusage_test (33/33 passed)

## Notes

- PR is opened as draft by default.
