### PR TITLE
docs: update IPC namespace docs to reflect ucontext module split

### DIFF
--- a/docs/kernel/ipc/ipc_namespace.md
+++ b/docs/kernel/ipc/ipc_namespace.md
@@ -51,6 +51,5 @@ Author: longjin <longjin@dragonos.org>
   - `kernel/src/process/namespace/ipc_namespace.rs`
   - `kernel/src/process/namespace/nsproxy.rs`
   - `kernel/src/ipc/syscall/` 内的 `sys_shm*`
-  - `kernel/src/mm/ucontext.rs`（VMA 与 SHM 计数维护）
-
+  - `kernel/src/mm/ucontext/`（VMA 与 SHM 计数维护）
 

--- a/docs/locales/en/kernel/ipc/ipc_namespace.md
+++ b/docs/locales/en/kernel/ipc/ipc_namespace.md
@@ -66,4 +66,4 @@ This page describes the current support status and future plans for IPC namespac
   - `kernel/src/process/namespace/ipc_namespace.rs`
   - `kernel/src/process/namespace/nsproxy.rs`
   - `kernel/src/ipc/syscall/` within `sys_shm*`
-  - `kernel/src/mm/ucontext.rs` (VMA and SHM count maintenance)
+  - `kernel/src/mm/ucontext/` (VMA and SHM count maintenance)


### PR DESCRIPTION
Update file path references from `kernel/src/mm/ucontext.rs` to `kernel/src/mm/ucontext/` after the ucontext module refactoring in #1993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)