### PR TITLE
fix(ipc): align restart syscall semantics with Linux

### DIFF
--- a/kernel/src/arch/x86_64/ipc/signal.rs
+++ b/kernel/src/arch/x86_64/ipc/signal.rs
@@ -910,6 +910,11 @@ impl SignalArch for X86_64SignalArch {
         }
 
         let frame = unsafe { &*frame_ptr };
+        // Align with Linux restore_sigcontext(): after a signal handler returns, any pending
+        // restart block should degrade to no-restart state. Subsequent manual calls to
+        // restart_syscall should only get EINTR and must not continue consuming the old restart context.
+        let _ = ProcessManager::current_pcb().restart_block().take();
+
         // 1. 恢复信号掩码（从 1024-bit 用户态格式转换到 64-bit 内核格式）
         let mut sigmask = frame.ucontext.uc_sigmask.to_kernel_sigset();
         set_current_blocked(&mut sigmask);
@@ -966,20 +971,10 @@ fn handle_signal(
     if unsafe { frame.syscall_nr() }.is_some() {
         if let Some(syscall_err) = unsafe { frame.syscall_error() } {
             match syscall_err {
-                SystemError::ERESTARTNOHAND => {
+                SystemError::ERESTARTNOHAND | SystemError::ERESTART_RESTARTBLOCK => {
                     frame.rax = SystemError::EINTR.to_posix_errno() as i64 as u64;
                 }
                 SystemError::ERESTARTSYS => {
-                    if !sigaction.flags().contains(SigFlags::SA_RESTART) {
-                        frame.rax = SystemError::EINTR.to_posix_errno() as i64 as u64;
-                    } else {
-                        frame.rax = frame.errcode;
-                        frame.rip -= 2;
-                    }
-                }
-                SystemError::ERESTART_RESTARTBLOCK => {
-                    // 为了让带 SA_RESTART 的时序（例如 clock_nanosleep 相对睡眠）也能自动重启，
-                    // 当 SA_RESTART 设置时，按 ERESTARTSYS 的语义处理；否则返回 EINTR。
                     if !sigaction.flags().contains(SigFlags::SA_RESTART) {
                         frame.rax = SystemError::EINTR.to_posix_errno() as i64 as u64;
                     } else {

--- a/kernel/src/ipc/syscall/sys_restart.rs
+++ b/kernel/src/ipc/syscall/sys_restart.rs
@@ -1,11 +1,8 @@
-use super::super::signal_types::{SigInfo, SigType};
 use crate::arch::interrupt::TrapFrame;
 use crate::{
     alloc::vec::Vec,
-    arch::ipc::signal::Signal,
     arch::syscall::nr::SYS_RESTART_SYSCALL,
-    ipc::signal_types::SigCode,
-    process::{ProcessManager, RawPid},
+    process::ProcessManager,
     syscall::table::{FormattedSyscallParam, Syscall},
 };
 use syscall_table_macros::declare_syscall;
@@ -22,14 +19,10 @@ pub(super) fn do_kernel_restart_syscall() -> Result<usize, SystemError> {
     if let Some(mut restart_block) = restart_block {
         return restart_block.restart_fn.call(&mut restart_block.data);
     } else {
-        // 不应该走到这里，因此kill掉当前进程及同组的进程
-        let pid = RawPid::new(0);
-        let sig = Signal::SIGKILL;
-        let mut info = SigInfo::new(sig, 0, SigCode::Kernel, SigType::Kill { pid, uid: 0 });
-
-        sig.send_signal_info(Some(&mut info), pid)
-            .expect("Failed to kill ");
-        return Ok(0);
+        // Align with Linux do_no_restart_syscall(): userspace can directly call
+        // restart_syscall, so the absence of a restart block is a normal EINTR return,
+        // not a kernel invariant violation that requires killing the process or panicking.
+        return Err(SystemError::EINTR);
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/restart_syscall_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/restart_syscall_semantics.cc
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef SYS_restart_syscall
+#if defined(__x86_64__)
+#define SYS_restart_syscall 219
+#elif defined(__riscv) || defined(__loongarch64)
+#define SYS_restart_syscall 128
+#else
+#error "SYS_restart_syscall is not defined for this architecture"
+#endif
+#endif
+
+#ifndef SYS_clock_nanosleep
+#if defined(__x86_64__)
+#define SYS_clock_nanosleep 230
+#elif defined(__riscv) || defined(__loongarch64)
+#define SYS_clock_nanosleep 115
+#else
+#error "SYS_clock_nanosleep is not defined for this architecture"
+#endif
+#endif
+
+namespace {
+
+volatile sig_atomic_t g_signal_count = 0;
+
+void SignalHandler(int) {
+    ++g_signal_count;
+}
+
+struct SignalAfterArgs {
+    pthread_t target;
+    int signo;
+    int send_result;
+};
+
+void* SendSignalAfterDelay(void* raw_args) {
+    auto* args = static_cast<SignalAfterArgs*>(raw_args);
+    timespec delay {};
+    delay.tv_nsec = 100 * 1000 * 1000;
+    nanosleep(&delay, nullptr);
+    args->send_result = pthread_kill(args->target, args->signo);
+    return nullptr;
+}
+
+long RawClockNanosleep(clockid_t clockid, int flags, const timespec* request,
+                       timespec* remain) {
+    return syscall(SYS_clock_nanosleep, static_cast<int>(clockid), flags, request,
+                   remain);
+}
+
+}  // namespace
+
+TEST(RestartSyscallSemantics, DirectCallWithoutRestartBlockReturnsEintr) {
+    errno = 0;
+    long ret = syscall(SYS_restart_syscall);
+
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EINTR, errno) << "restart_syscall returned ret=" << ret
+                            << ", errno=" << errno << " (" << strerror(errno)
+                            << ")";
+}
+
+TEST(RestartSyscallSemantics, RestartBlockDeliveredHandlerReturnsEintrEvenWithSaRestart) {
+    struct sigaction action {};
+    struct sigaction old_action {};
+    action.sa_handler = SignalHandler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_RESTART;
+    ASSERT_EQ(0, sigaction(SIGUSR1, &action, &old_action))
+        << "sigaction failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    g_signal_count = 0;
+    SignalAfterArgs args {};
+    args.target = pthread_self();
+    args.signo = SIGUSR1;
+    args.send_result = -1;
+
+    pthread_t sender;
+    ASSERT_EQ(0, pthread_create(&sender, nullptr, SendSignalAfterDelay, &args));
+
+    errno = 0;
+    timespec request {};
+    request.tv_sec = 2;
+    timespec remain {};
+    long ret = RawClockNanosleep(CLOCK_REALTIME, 0, &request, &remain);
+    int saved_errno = errno;
+
+    ASSERT_EQ(0, pthread_join(sender, nullptr));
+
+    EXPECT_EQ(0, args.send_result);
+    EXPECT_EQ(1, g_signal_count);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EINTR, saved_errno)
+        << "clock_nanosleep returned ret=" << ret << ", errno=" << saved_errno
+        << " (" << strerror(saved_errno) << "), remain={" << remain.tv_sec << ", "
+        << remain.tv_nsec << "}";
+
+    errno = 0;
+    long restart_ret = syscall(SYS_restart_syscall);
+    int restart_errno = errno;
+    EXPECT_EQ(-1, restart_ret);
+    EXPECT_EQ(EINTR, restart_errno)
+        << "stale restart block was consumed after signal handler returned";
+
+    EXPECT_EQ(0, sigaction(SIGUSR1, &old_action, nullptr));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -26,6 +26,7 @@ normal/sched_affinity
 normal/sync_file_range
 normal/splice_concurrent_io
 normal/rcu_selftest
+normal/restart_syscall_semantics
 normal/errseq_selftest
 normal/errseq_writeback_reporting
 normal/test_tlb_shootdown


### PR DESCRIPTION
## Summary

Align restart syscall semantics with Linux behavior.

## Changes

- **restore_sigcontext**: take restart block after signal handler returns to prevent stale restart context from being consumed by subsequent `restart_syscall` calls
- **do_restart_syscall**: return `EINTR` instead of killing the process when no restart block exists, since userspace can directly call `restart_syscall`
- **handle_signal**: merge `ERESTART_RESTARTBLOCK` handler into `ERESTARTNOHAND`, removing the `SA_RESTART`-based auto-restart path for restart_block-based syscalls
- **test**: add `restart_syscall_semantics` test suite covering direct call and post-signal restart block consumption scenarios

## References

- Linux `restore_sigcontext()` and `do_no_restart_syscall()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Close: #1724 