### PR TITLE
fix(tty): rework PTY flush semantics, add hangup support and epoll fixes

### DIFF
--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -181,6 +181,13 @@ impl PtyByteQueue {
     }
 }
 
+fn wake_pty_packet_readers(tty: &Arc<TtyCore>) -> Result<(), SystemError> {
+    let events = EPollEventType::EPOLLPRI | EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM;
+    tty.core().read_wq().wakeup_any(events.bits() as u64);
+    EventPoll::wakeup_epoll(tty.core().epitems(), events)?;
+    Ok(())
+}
+
 impl crate::driver::tty::tty_driver::TtyCorePrivateField for PtyDevPtsLink {
     fn as_any(&self) -> &dyn core::any::Any {
         self
@@ -242,6 +249,12 @@ impl PtyDevPtsLink {
         }
     }
 
+    fn wake_source_writer(to: &Arc<TtyCore>) {
+        if let Some(source) = to.core().link() {
+            source.tty_wakeup();
+        }
+    }
+
     fn pending_write_room(&self, subtype: TtyDriverSubType) -> usize {
         self.queue_for_source(subtype)
             .map(|queue| queue.lock_irqsave().room())
@@ -280,14 +293,7 @@ impl PtyDevPtsLink {
         Ok(())
     }
 
-    fn discard_requested_prefix(&self, queue: &SpinLock<PtyByteQueue>) -> usize {
-        queue.lock_irqsave().discard_requested_prefix()
-    }
-
-    fn request_discard_pending_from(
-        &self,
-        subtype: TtyDriverSubType,
-    ) -> Result<usize, SystemError> {
+    fn begin_flush_from(&self, subtype: TtyDriverSubType) -> Result<(), SystemError> {
         let Some(queue) = self.queue_for_source(subtype) else {
             return Err(SystemError::ENODEV);
         };
@@ -297,33 +303,71 @@ impl PtyDevPtsLink {
             return Err(SystemError::ENODEV);
         };
 
-        if flushing.load(Ordering::Acquire) {
-            return Ok(0);
-        }
-
-        if discarding
+        while flushing
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_err()
         {
-            return Ok(0);
+            spin_loop();
         }
 
-        queue.lock_irqsave().request_discard_prefix();
+        while draining
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            spin_loop();
+        }
+
+        drain_requested.store(false, Ordering::Release);
+        discarding.store(false, Ordering::Release);
+        queue.lock_irqsave().clear();
+        draining.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    fn finish_flush_from(&self, subtype: TtyDriverSubType) -> Result<(), SystemError> {
+        let Some((_, drain_requested, discarding, flushing)) = self.state_flags_for_source(subtype)
+        else {
+            return Err(SystemError::ENODEV);
+        };
+
+        drain_requested.store(false, Ordering::Release);
+        discarding.store(false, Ordering::Release);
+        flushing.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    fn request_receive_flush_from(&self, subtype: TtyDriverSubType) -> Result<(), SystemError> {
+        let Some(queue) = self.queue_for_source(subtype) else {
+            return Err(SystemError::ENODEV);
+        };
+        let Some((draining, drain_requested, discarding, flushing)) =
+            self.state_flags_for_source(subtype)
+        else {
+            return Err(SystemError::ENODEV);
+        };
+
+        while flushing.load(Ordering::Acquire) {
+            spin_loop();
+        }
 
         if draining
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
+            .is_ok()
         {
+            drain_requested.store(false, Ordering::Release);
             discarding.store(false, Ordering::Release);
-            return Ok(0);
+            queue.lock_irqsave().clear();
+            draining.store(false, Ordering::Release);
+        } else {
+            queue.lock_irqsave().request_discard_prefix();
+            drain_requested.store(true, Ordering::Release);
         }
 
-        let discarded = self.discard_requested_prefix(queue);
-        drain_requested.store(false, Ordering::Release);
-        draining.store(false, Ordering::Release);
-        discarding.store(false, Ordering::Release);
+        Ok(())
+    }
 
-        Ok(discarded)
+    fn discard_requested_prefix(&self, queue: &SpinLock<PtyByteQueue>) -> usize {
+        queue.lock_irqsave().discard_requested_prefix()
     }
 
     fn write_to_peer(
@@ -345,36 +389,42 @@ impl PtyDevPtsLink {
                 spin_loop();
             }
 
-            let mut queue = queue.lock_irqsave();
+            let mut queue_guard = queue.lock_irqsave();
             if flushing.load(Ordering::Acquire) || discarding.load(Ordering::Acquire) {
-                drop(queue);
+                drop(queue_guard);
                 spin_loop();
                 continue;
             }
-            break queue.push_slice(&buf[..nr]);
+            break queue_guard.push_slice(&buf[..nr]);
         };
 
         if accepted == 0 {
-            self.drain_to_peer(subtype, to.clone())?;
+            let result = self.drain_to_peer(subtype, to.clone())?;
+            if result.freed_backlog != 0 {
+                // Space became available in this PTY direction.
+                Self::wake_source_writer(&to);
+            }
             accepted = loop {
                 while flushing.load(Ordering::Acquire) || discarding.load(Ordering::Acquire) {
                     spin_loop();
                 }
 
-                let mut queue = queue.lock_irqsave();
+                let mut queue_guard = queue.lock_irqsave();
                 if flushing.load(Ordering::Acquire) || discarding.load(Ordering::Acquire) {
-                    drop(queue);
+                    drop(queue_guard);
                     spin_loop();
                     continue;
                 }
-                break queue.push_slice(&buf[..nr]);
+                break queue_guard.push_slice(&buf[..nr]);
             };
         }
 
         if accepted != 0 {
-            self.drain_to_peer(subtype, to)?;
+            let result = self.drain_to_peer(subtype, to.clone())?;
+            if result.freed_backlog != 0 {
+                Self::wake_source_writer(&to);
+            }
         }
-
         Ok(accepted)
     }
 
@@ -408,6 +458,7 @@ impl PtyDevPtsLink {
 
         loop {
             if flushing.load(Ordering::Acquire) {
+                let _ = self.discard_requested_prefix(queue);
                 result.still_pending = !queue.lock_irqsave().is_empty();
                 draining.store(false, Ordering::Release);
                 break;
@@ -448,6 +499,17 @@ impl PtyDevPtsLink {
                     continue;
                 }
                 break;
+            }
+
+            if flushing.load(Ordering::Acquire) {
+                queue.lock_irqsave().advance_front(chunk_len);
+                result.freed_backlog += chunk_len;
+                draining.store(false, Ordering::Release);
+                break;
+            }
+            if discarding.load(Ordering::Acquire) {
+                queue.lock_irqsave().request_discard_prefix();
+                continue;
             }
 
             let delivered =
@@ -710,6 +772,7 @@ impl TtyOperation for Unix98PtyDriverInner {
             tty.contorl_info_irqsave()
                 .pktstatus
                 .insert(TtyPacketStatus::TIOCPKT_FLUSHWRITE);
+            let _ = wake_pty_packet_readers(&to);
         }
 
         to.core().read_wq().wakeup_all();
@@ -791,7 +854,11 @@ impl TtyOperation for Unix98PtyDriverInner {
                         ctrl.pktstatus.insert(TtyPacketStatus::TIOCPKT_IOCTL);
                     }
 
+                    let events = EPollEventType::EPOLLPRI
+                        | EPollEventType::EPOLLIN
+                        | EPollEventType::EPOLLRDNORM;
                     link.read_wq().wakeup_all();
+                    let _ = EventPoll::wakeup_epoll(link.epitems(), events);
                 }
             }
         }
@@ -816,9 +883,10 @@ impl TtyOperation for Unix98PtyDriverInner {
         ctrl.pktstatus.remove(TtyPacketStatus::TIOCPKT_STOP);
         ctrl.pktstatus.insert(TtyPacketStatus::TIOCPKT_START);
 
-        link.core()
-            .read_wq()
-            .wakeup_any(EPollEventType::EPOLLIN.bits() as u64);
+        let events =
+            EPollEventType::EPOLLPRI | EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM;
+        link.core().read_wq().wakeup_any(events.bits() as u64);
+        let _ = EventPoll::wakeup_epoll(link.core().epitems(), events);
 
         Ok(())
     }
@@ -834,15 +902,17 @@ impl TtyOperation for Unix98PtyDriverInner {
         ctrl.pktstatus.remove(TtyPacketStatus::TIOCPKT_START);
         ctrl.pktstatus.insert(TtyPacketStatus::TIOCPKT_STOP);
 
-        link.core()
-            .read_wq()
-            .wakeup_any(EPollEventType::EPOLLIN.bits() as u64);
+        let events =
+            EPollEventType::EPOLLPRI | EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM;
+        link.core().read_wq().wakeup_any(events.bits() as u64);
+        let _ = EventPoll::wakeup_epoll(link.core().epitems(), events);
 
         Ok(())
     }
 
     fn flush_chars(&self, _tty: &TtyCoreData) {
-        // 不做处理
+        // Linux pty does not implement flush_chars; writes are pushed by the
+        // pty write path itself rather than by recursively draining here.
     }
 
     fn lookup(
@@ -899,6 +969,7 @@ impl TtyOperation for Unix98PtyDriverInner {
                 link_core.write_wq().wakeup_all();
                 let epitems = link_core.epitems();
                 let _ = EventPoll::wakeup_epoll(epitems, EPollEventType::EPOLLHUP);
+                TtyCore::tty_vhangup(link.clone());
                 if link_core.flags().contains(TtyFlag::IO_ERROR) {
                     link_core.driver().ttys().remove(&link_core.index());
                 }
@@ -1059,37 +1130,54 @@ pub fn pty_drain_pending_to(tty: Arc<TtyCore>) -> Result<(), SystemError> {
     Ok(())
 }
 
-pub fn pty_discard_pending_to(tty: Arc<TtyCore>) -> Result<(), SystemError> {
+pub fn pty_flush_input_buffer<F>(tty: Arc<TtyCore>, clear_input: F) -> Result<(), SystemError>
+where
+    F: FnOnce(),
+{
     let Some(peer) = tty.core().link() else {
+        clear_input();
         return Ok(());
     };
     let Some(hook_arc) = tty.private_fields() else {
+        clear_input();
         return Ok(());
     };
     let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() else {
+        clear_input();
         return Ok(());
     };
 
-    hook.clear_pending_from(peer.core().driver().tty_driver_sub_type())?;
+    let subtype = peer.core().driver().tty_driver_sub_type();
+    hook.begin_flush_from(subtype)?;
+    clear_input();
+    hook.finish_flush_from(subtype)?;
     peer.tty_wakeup();
     Ok(())
 }
 
-pub fn pty_request_discard_pending_to(tty: Arc<TtyCore>) -> Result<(), SystemError> {
+pub fn pty_receive_flush_input_buffer<F>(
+    tty: Arc<TtyCore>,
+    clear_input: F,
+) -> Result<(), SystemError>
+where
+    F: FnOnce(),
+{
     let Some(peer) = tty.core().link() else {
+        clear_input();
         return Ok(());
     };
     let Some(hook_arc) = tty.private_fields() else {
+        clear_input();
         return Ok(());
     };
     let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() else {
+        clear_input();
         return Ok(());
     };
 
-    let discarded =
-        hook.request_discard_pending_from(peer.core().driver().tty_driver_sub_type())?;
-    if discarded != 0 {
-        peer.tty_wakeup();
-    }
+    let subtype = peer.core().driver().tty_driver_sub_type();
+    hook.request_receive_flush_from(subtype)?;
+    clear_input();
+    peer.tty_wakeup();
     Ok(())
 }

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -38,6 +38,7 @@ pub struct Termios {
     pub output_speed: u32,
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Default)]
 pub struct PosixTermios {
     pub c_iflag: u32,

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -12,7 +12,10 @@ use system_error::SystemError;
 use crate::{
     arch::ipc::signal::Signal,
     driver::base::device::device_number::DeviceNumber,
-    filesystem::epoll::{event_poll::LockedEPItemLinkedList, EPollEventType, EPollItem},
+    filesystem::epoll::{
+        event_poll::{EventPoll, LockedEPItemLinkedList},
+        EPollEventType, EPollItem,
+    },
     libs::{
         rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableGuard, RwLockWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
@@ -229,12 +232,55 @@ impl TtyCore {
 
     pub fn tty_wakeup(&self) {
         if self.core.flags().contains(TtyFlag::DO_WRITE_WAKEUP) {
-            let _ = self.ldisc().write_wakeup(self.core());
+            let _ = self.ldisc().write_wakeup(self);
         }
 
-        self.core()
-            .write_wq
-            .wakeup_any(EPollEventType::EPOLLOUT.bits() as u64);
+        let events = EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM;
+        self.core().write_wq.wakeup_any(events.bits() as u64);
+        let _ = EventPoll::wakeup_epoll(self.core().epitems(), events);
+    }
+
+    pub fn tty_vhangup(tty: Arc<TtyCore>) {
+        {
+            let mut flags = tty.core().flags_write();
+            if flags.contains(TtyFlag::HUPPED) {
+                return;
+            }
+            flags.insert(TtyFlag::HUPPING);
+        }
+
+        let (sid, pgid) = {
+            let ctrl = tty.core().contorl_info_irqsave();
+            (ctrl.session.clone(), ctrl.pgid.clone())
+        };
+
+        if let Some(pgrp) = pgid {
+            let _ = crate::ipc::kill::send_signal_to_pgid(&pgrp, Signal::SIGHUP);
+            let _ = crate::ipc::kill::send_signal_to_pgid(&pgrp, Signal::SIGCONT);
+        }
+
+        let _ = tty.ldisc().hangup(tty.clone());
+
+        {
+            let mut ctrl = tty.core().contorl_info_irqsave();
+            ctrl.session = None;
+            ctrl.pgid = None;
+            ctrl.pktstatus = TtyPacketStatus::empty();
+        }
+        if let Some(sid) = sid {
+            TtyJobCtrlManager::session_clear_tty(sid);
+        }
+
+        {
+            let mut flags = tty.core().flags_write();
+            flags.remove(TtyFlag::DO_WRITE_WAKEUP);
+            flags.remove(TtyFlag::HUPPING);
+            flags.insert(TtyFlag::HUPPED);
+        }
+
+        tty.core().read_wq().wakeup_all();
+        tty.core().write_wq().wakeup_all();
+        let _ = EventPoll::wakeup_epoll(tty.core().epitems(), EPollEventType::EPOLLHUP);
     }
 
     pub fn tty_mode_ioctl(tty: Arc<TtyCore>, cmd: u32, arg: usize) -> Result<usize, SystemError> {
@@ -297,19 +343,9 @@ impl TtyCore {
             TtyFlushArg::TCIOFLUSH => {
                 tty.ldisc().flush_buffer(tty.clone())?;
                 tty.ldisc().flush_output(tty.clone())?;
-                let ret = tty.core().driver().driver_funcs().flush_buffer(tty.core());
-                if ret != Err(SystemError::ENOSYS) {
-                    ret?;
-                }
-                tty.core().write_wq().wakeup_all();
             }
             TtyFlushArg::TCOFLUSH => {
                 tty.ldisc().flush_output(tty.clone())?;
-                let ret = tty.core().driver().driver_funcs().flush_buffer(tty.core());
-                if ret != Err(SystemError::ENOSYS) {
-                    ret?;
-                }
-                tty.core().write_wq().wakeup_all();
             }
             _ => {
                 return Err(SystemError::EINVAL);

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -392,7 +392,6 @@ impl IndexNode for TtyDevice {
                     return Err(err);
                 }
             };
-
             if ret == 0 {
                 break;
             }

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -7,7 +7,7 @@ use crate::filesystem::vfs::file::FileFlags;
 
 use super::{
     termios::Termios,
-    tty_core::{TtyCore, TtyCoreData, TtyFlag},
+    tty_core::{TtyCore, TtyFlag},
 };
 
 pub mod ntty;
@@ -16,7 +16,12 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
     fn open(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
     fn close(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
     fn flush_buffer(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
-    fn flush_output(&self, _tty: Arc<TtyCore>) -> Result<(), SystemError> {
+    fn flush_output(&self, tty: Arc<TtyCore>) -> Result<(), SystemError> {
+        let ret = tty.core().driver().driver_funcs().flush_buffer(tty.core());
+        if ret != Err(SystemError::ENOSYS) {
+            ret?;
+        }
+        tty.core().write_wq().wakeup_all();
         Ok(())
     }
 
@@ -54,6 +59,10 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
     fn poll(&self, tty: Arc<TtyCore>) -> Result<usize, SystemError>;
     fn hangup(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
 
+    fn receive_room(&self, _tty: Arc<TtyCore>) -> usize {
+        usize::MAX
+    }
+
     /// ## 接收数据
     fn receive_buf(
         &self,
@@ -73,7 +82,7 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
     ) -> Result<usize, SystemError>;
 
     /// ## 唤醒线路写者
-    fn write_wakeup(&self, _tty: &TtyCoreData) -> Result<(), SystemError> {
+    fn write_wakeup(&self, _tty: &TtyCore) -> Result<(), SystemError> {
         Err(SystemError::ENOSYS)
     }
 }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1,6 +1,5 @@
 use alloc::{boxed::Box, vec::Vec};
-use core::intrinsics::likely;
-use core::ops::BitXor;
+use core::{intrinsics::likely, ops::BitXor};
 
 use bitmap::{static_bitmap, traits::BitMapOps, StaticBitmap};
 
@@ -11,7 +10,7 @@ use crate::{
     arch::ipc::signal::Signal,
     driver::tty::{
         pty::unix98pty::{
-            pty_discard_pending_to, pty_drain_pending_to, pty_request_discard_pending_to,
+            pty_drain_pending_to, pty_flush_input_buffer, pty_receive_flush_input_buffer,
         },
         termios::{ControlCharIndex, InputMode, LocalMode, OutputMode, Termios},
         tty_core::{
@@ -21,7 +20,10 @@ use crate::{
         tty_driver::{TtyDriverFlag, TtyDriverSubType, TtyOperation},
         tty_job_control::TtyJobCtrlManager,
     },
-    filesystem::{epoll::EPollEventType, vfs::file::FileFlags},
+    filesystem::{
+        epoll::{event_poll::EventPoll, EPollEventType},
+        vfs::file::FileFlags,
+    },
     libs::{
         rwlock::RwLockReadGuard,
         spinlock::{SpinLock, SpinLockGuard},
@@ -29,6 +31,7 @@ use crate::{
     mm::VirtAddr,
     process::ProcessManager,
     syscall::user_access::UserBufferWriter,
+    time::Duration,
 };
 
 use super::TtyLineDiscipline;
@@ -39,6 +42,11 @@ pub const ECHO_DISCARD_WATERMARK: usize = NTTY_BUFSIZE - (ECHO_BLOCK + 32);
 
 fn ntty_buf_mask(idx: usize) -> usize {
     return idx & (NTTY_BUFSIZE - 1);
+}
+
+fn wake_tty_readers(tty: &Arc<TtyCore>, events: EPollEventType) {
+    tty.core().read_wq().wakeup_any(events.bits() as u64);
+    let _ = EventPoll::wakeup_epoll(tty.core().epitems(), events);
 }
 
 fn is_ascii_control(c: u8) -> bool {
@@ -56,6 +64,7 @@ pub struct NTtyLinediscipline {
     pub(crate) output_lock: TtySleepLock,
 }
 
+#[derive(Debug, Clone)]
 struct EchoStep {
     bytes: Vec<u8>,
     tail: usize,
@@ -63,11 +72,25 @@ struct EchoStep {
     canon_cursor_column: u32,
 }
 
+#[derive(Debug)]
+struct EchoPendingStep {
+    bytes: Vec<u8>,
+    offset: usize,
+    step: EchoStep,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OpostCharResult {
     Emitted,
     ConsumedWithoutOutput,
     NeedsMoreRoom,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum NTtyReadWait {
+    NoWait,
+    Forever,
+    Timeout(Duration),
 }
 
 impl NTtyLinediscipline {
@@ -93,9 +116,41 @@ impl NTtyLinediscipline {
         }
     }
 
-    fn drain_echoes(&self, tty: Arc<TtyCore>) -> Result<(), SystemError> {
+    fn drain_opost_pending(&self, tty: &TtyCore) -> Result<bool, SystemError> {
         let core = tty.core();
         loop {
+            let pending = self.disc_data().opost_pending_bytes().to_vec();
+            if pending.is_empty() {
+                return Ok(true);
+            }
+
+            let written = tty.write(core, &pending, pending.len())?;
+            if written == 0 {
+                core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+                return Ok(false);
+            }
+
+            self.disc_data().advance_opost_pending(written);
+            tty.flush_chars(core);
+        }
+    }
+
+    fn drain_echoes(&self, tty: &TtyCore) -> Result<(), SystemError> {
+        let core = tty.core();
+        loop {
+            while let Some(bytes) = { self.disc_data().echo_pending_bytes() } {
+                let written = tty.write(core, &bytes, bytes.len())?;
+                if written == 0 {
+                    core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+                    return Ok(());
+                }
+                {
+                    let mut guard = self.disc_data();
+                    guard.advance_echo_pending(written);
+                }
+                tty.flush_chars(core);
+            }
+
             let termios = *core.termios();
             let space = tty.write_room(core);
             let step = {
@@ -112,14 +167,12 @@ impl NTtyLinediscipline {
                 while sent < step.bytes.len() {
                     let written = tty.write(core, &step.bytes[sent..], step.bytes.len() - sent)?;
                     if written == 0 {
-                        if sent == 0 {
-                            return Ok(());
+                        if sent != 0 {
+                            let mut guard = self.disc_data();
+                            guard.set_echo_pending_step(step, sent);
                         }
-                        let _ = core.write_wq().wait_event_interruptible(
-                            EPollEventType::EPOLLOUT.bits() as u64,
-                            || tty.write_room(core) > 0,
-                        );
-                        continue;
+                        core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+                        return Ok(());
                     }
                     sent += written;
                 }
@@ -130,7 +183,35 @@ impl NTtyLinediscipline {
             guard.apply_echo_step(step);
         }
 
+        if self.disc_data().has_output_wakeup_pending() {
+            core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+        } else {
+            core.flags_write().remove(TtyFlag::DO_WRITE_WAKEUP);
+        }
         Ok(())
+    }
+
+    fn packet_status_pending(core: &TtyCoreData, packet: bool) -> bool {
+        if !packet {
+            return false;
+        }
+        let Some(link) = core.link() else {
+            return false;
+        };
+        let pending = !link.core().contorl_info_irqsave().pktstatus.is_empty();
+        pending
+    }
+
+    fn check_pty_unthrottle_after_read(tty: &Arc<TtyCore>) {
+        let _ = pty_drain_pending_to(tty.clone());
+        match tty.core().driver().tty_driver_sub_type() {
+            TtyDriverSubType::PtyMaster | TtyDriverSubType::PtySlave => {
+                if let Some(peer) = tty.core().link() {
+                    peer.tty_wakeup();
+                }
+            }
+            _ => {}
+        }
     }
 }
 
@@ -183,6 +264,7 @@ pub struct NTtyData {
     /// OPOST 处理后尚未被底层 driver 接收的输出字节。
     opost_pending: Vec<u8>,
     opost_pending_offset: usize,
+    echo_pending_step: Option<EchoPendingStep>,
     /// 回显缓冲区的尾指针
     echo_tail: usize,
 
@@ -220,6 +302,7 @@ impl NTtyData {
             canon_cursor_column: 0,
             opost_pending: Vec::with_capacity(NTTY_BUFSIZE),
             opost_pending_offset: 0,
+            echo_pending_step: None,
             echo_tail: 0,
             read_buf: vec![0; NTTY_BUFSIZE].into_boxed_slice().try_into().unwrap(),
             echo_buf: vec![0; NTTY_BUFSIZE].into_boxed_slice().try_into().unwrap(),
@@ -244,6 +327,52 @@ impl NTtyData {
             self.opost_pending.clear();
             self.opost_pending_offset = 0;
         }
+    }
+
+    fn echo_pending_bytes(&self) -> Option<Vec<u8>> {
+        let pending = self.echo_pending_step.as_ref()?;
+        if pending.offset >= pending.bytes.len() {
+            None
+        } else {
+            Some(pending.bytes[pending.offset..].to_vec())
+        }
+    }
+
+    fn advance_echo_pending(&mut self, count: usize) {
+        let Some(pending) = self.echo_pending_step.as_mut() else {
+            return;
+        };
+        pending.offset += count;
+        if pending.offset >= pending.bytes.len() {
+            let pending = self.echo_pending_step.take().unwrap();
+            self.apply_echo_step(pending.step);
+        }
+    }
+
+    fn set_echo_pending_step(&mut self, step: EchoStep, offset: usize) {
+        self.echo_pending_step = Some(EchoPendingStep {
+            bytes: step.bytes.clone(),
+            offset,
+            step,
+        });
+    }
+
+    fn has_echo_output_pending(&self) -> bool {
+        self.echo_pending_step.is_some()
+            || ntty_buf_mask(self.echo_commit) != ntty_buf_mask(self.echo_tail)
+    }
+
+    fn discard_output_state(&mut self) {
+        self.opost_pending.clear();
+        self.opost_pending_offset = 0;
+        self.echo_pending_step = None;
+        self.echo_tail = self.echo_head;
+        self.echo_mark = self.echo_head;
+        self.echo_commit = self.echo_head;
+    }
+
+    fn has_output_wakeup_pending(&self) -> bool {
+        !self.opost_pending_bytes().is_empty() || self.has_echo_output_pending()
     }
 
     fn opost_char_space(&self, termios: &Termios, c: u8) -> usize {
@@ -374,7 +503,15 @@ impl NTtyData {
             }
 
             if count > look_ahead {
-                self.receive_buf_standard(tty.clone(), buf, flags, count - look_ahead, false);
+                let remaining = &buf[look_ahead..];
+                let remaining_flags = flags.map(|f| &f[look_ahead..]);
+                self.receive_buf_standard(
+                    tty.clone(),
+                    remaining,
+                    remaining_flags,
+                    count - look_ahead,
+                    false,
+                );
             }
 
             // 刷新echo
@@ -392,9 +529,7 @@ impl NTtyData {
         self.commit_head = self.read_head;
 
         if self.read_cnt() > 0 {
-            tty.core()
-                .read_wq()
-                .wakeup_any((EPollEventType::EPOLLIN | EPollEventType::EPOLLRDBAND).bits() as u64);
+            wake_tty_readers(&tty, EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM);
         }
     }
 
@@ -618,9 +753,7 @@ impl NTtyData {
                 self.read_buf[ntty_buf_mask(self.read_head)] = c;
                 self.read_head += 1;
                 self.canon_head = self.read_head;
-                tty.core().read_wq().wakeup_any(
-                    (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64,
-                );
+                wake_tty_readers(&tty, EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM);
                 return;
             }
 
@@ -631,9 +764,7 @@ impl NTtyData {
                 self.read_buf[ntty_buf_mask(self.read_head)] = c;
                 self.read_head += 1;
                 self.canon_head = self.read_head;
-                tty.core().read_wq().wakeup_any(
-                    (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64,
-                );
+                wake_tty_readers(&tty, EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM);
                 return;
             }
 
@@ -659,9 +790,7 @@ impl NTtyData {
                 self.read_buf[ntty_buf_mask(self.read_head)] = c;
                 self.read_head += 1;
                 self.canon_head = self.read_head;
-                tty.core().read_wq().wakeup_any(
-                    (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64,
-                );
+                wake_tty_readers(&tty, EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM);
                 return;
             }
         }
@@ -912,29 +1041,25 @@ impl NTtyData {
         }
 
         if !termios.local_mode.contains(LocalMode::NOFLSH) {
-            // 重置
-            self.echo_head = 0;
-            self.echo_tail = 0;
-            self.echo_mark = 0;
-            self.echo_commit = 0;
+            self.discard_output_state();
 
             let _ = tty.flush_buffer(tty.core());
 
-            self.read_head = 0;
-            self.canon_head = 0;
-            self.read_tail = 0;
-            self.line_start = 0;
+            let _ = pty_receive_flush_input_buffer(tty.clone(), || {
+                self.read_head = 0;
+                self.canon_head = 0;
+                self.read_tail = 0;
+                self.line_start = 0;
 
-            self.erasing = false;
-            self.read_flags.set_all(false);
-            self.pushing = false;
-            self.lookahead_count = 0;
+                self.erasing = false;
+                self.read_flags.set_all(false);
+                self.pushing = false;
+                self.lookahead_count = 0;
 
-            let _ = pty_request_discard_pending_to(tty.clone());
-
-            if tty.core().link().is_some() {
-                self.packet_mode_flush(tty.core());
-            }
+                if tty.core().link().is_some() {
+                    self.packet_mode_flush(tty.core());
+                }
+            });
         }
     }
 
@@ -1611,6 +1736,10 @@ impl NTtyData {
                 .insert(TtyPacketStatus::TIOCPKT_FLUSHREAD);
 
             link.core().read_wq().wakeup_all();
+            let _ = EventPoll::wakeup_epoll(
+                link.core().epitems(),
+                EPollEventType::EPOLLPRI | EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
+            );
         }
     }
 }
@@ -1631,25 +1760,24 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     /// ## 重置缓冲区的基本信息
     fn flush_buffer(&self, tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {
         let core = tty.core();
-        let _ = core.termios();
-        let mut ldata = self.disc_data();
-        ldata.read_head = 0;
-        ldata.canon_head = 0;
-        ldata.read_tail = 0;
-        ldata.commit_head = 0;
-        ldata.line_start = 0;
-        ldata.erasing = false;
-        ldata.read_flags.set_all(false);
-        ldata.pushing = false;
-        ldata.lookahead_count = 0;
-        ldata.no_room = false;
+        pty_flush_input_buffer(tty.clone(), || {
+            let _ = core.termios();
+            let mut ldata = self.disc_data();
+            ldata.read_head = 0;
+            ldata.canon_head = 0;
+            ldata.read_tail = 0;
+            ldata.commit_head = 0;
+            ldata.line_start = 0;
+            ldata.erasing = false;
+            ldata.read_flags.set_all(false);
+            ldata.pushing = false;
+            ldata.lookahead_count = 0;
+            ldata.no_room = false;
 
-        if core.link().is_some() {
-            ldata.packet_mode_flush(core);
-        }
-        drop(ldata);
-
-        let _ = pty_discard_pending_to(tty.clone());
+            if core.link().is_some() {
+                ldata.packet_mode_flush(core);
+            }
+        })?;
 
         core.read_wq().wakeup_all();
         core.write_wq().wakeup_all();
@@ -1661,10 +1789,17 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         Ok(())
     }
 
-    fn flush_output(&self, _tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {
+    fn flush_output(&self, tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {
+        let _output_guard = self.output_lock.lock();
         let mut ldata = self.disc_data();
-        ldata.opost_pending.clear();
-        ldata.opost_pending_offset = 0;
+        ldata.discard_output_state();
+
+        let ret = tty.core().driver().driver_funcs().flush_buffer(tty.core());
+        if ret != Err(SystemError::ENOSYS) {
+            ret?;
+        }
+        tty.core().flags_write().remove(TtyFlag::DO_WRITE_WAKEUP);
+        tty.core().write_wq().wakeup_all();
 
         Ok(())
     }
@@ -1716,7 +1851,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             let read_tail_moved = tail != ldata.read_tail;
             drop(ldata);
             if read_tail_moved {
-                let _ = pty_drain_pending_to(tty.clone());
+                Self::check_pty_unthrottle_after_read(&tty);
             }
             return Ok(offset);
         }
@@ -1726,12 +1861,23 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTIN)?;
 
         let mut minimum: usize = 0;
+        let mut current_wait = NTtyReadWait::Forever;
+        let mut inter_byte_timeout = None;
         if !ldata.icanon {
             let core = tty.core();
             let termios = core.termios();
-            minimum = termios.control_characters[ControlCharIndex::VMIN] as usize;
-            if minimum == 0 {
+            let vmin = termios.control_characters[ControlCharIndex::VMIN] as usize;
+            let vtime = termios.control_characters[ControlCharIndex::VTIME] as u64;
+            minimum = vmin;
+            if vmin == 0 {
                 minimum = 1;
+                current_wait = if vtime == 0 {
+                    NTtyReadWait::NoWait
+                } else {
+                    NTtyReadWait::Timeout(Duration::from_millis(vtime * 100))
+                };
+            } else if vtime != 0 {
+                inter_byte_timeout = Some(Duration::from_millis(vtime * 100));
             }
         }
 
@@ -1764,16 +1910,33 @@ impl TtyLineDiscipline for NTtyLinediscipline {
 
             let core = tty.core();
             if !ldata.input_available(core.termios(), false) {
-                if core.flags().contains(TtyFlag::OTHER_CLOSED) {
-                    if core.driver().tty_driver_sub_type() == TtyDriverSubType::PtyMaster {
-                        // Linux pty master read after the last slave close returns EIO.
-                        ret = Err(SystemError::EIO);
-                    }
-                    break;
+                drop(ldata);
+                let _ = pty_drain_pending_to(tty.clone());
+                ldata = self.disc_data();
+            }
+
+            if !ldata.input_available(core.termios(), false) {
+                if Self::packet_status_pending(core, packet) {
+                    drop(ldata);
+                    continue;
                 }
 
-                if core.flags().contains(TtyFlag::HUPPED) || core.flags().contains(TtyFlag::HUPPING)
                 {
+                    let flags = core.flags();
+                    if flags.contains(TtyFlag::OTHER_CLOSED) {
+                        if flags.contains(TtyFlag::HUPPED) || flags.contains(TtyFlag::HUPPING) {
+                            break;
+                        }
+                        ret = Err(SystemError::EIO);
+                        break;
+                    }
+
+                    if flags.contains(TtyFlag::HUPPED) || flags.contains(TtyFlag::HUPPING) {
+                        break;
+                    }
+                }
+
+                if matches!(current_wait, NTtyReadWait::NoWait) {
                     break;
                 }
 
@@ -1789,17 +1952,33 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                     break;
                 }
 
-                // 休眠一段时间
-                // 获取到termios读锁，避免termios被更改导致行为异常
-                // let termios = core.termios_preempt_enable();
-                // let helper = WakeUpHelper::new(ProcessManager::current_pcb());
-                // let wakeup_helper = Timer::new(helper, timeout);
-                // wakeup_helper.activate();
-                // drop(termios);
-                core.read_wq().sleep_unlock_spinlock(
-                    (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64,
-                    ldata,
-                );
+                drop(ldata);
+                let events = (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64;
+                let readiness = || {
+                    let ldata = self.disc_data();
+                    ldata.input_available(core.termios(), false)
+                        || Self::packet_status_pending(core, packet)
+                        || core.flags().contains(TtyFlag::OTHER_CLOSED)
+                        || core.flags().contains(TtyFlag::HUPPED)
+                        || core.flags().contains(TtyFlag::HUPPING)
+                        || core.flags().contains(TtyFlag::LDISC_CHANGING)
+                        || ProcessManager::current_pcb().has_pending_signal_fast()
+                };
+                let wait_result = match current_wait {
+                    NTtyReadWait::NoWait => Ok(()),
+                    NTtyReadWait::Forever => {
+                        core.read_wq().wait_event_interruptible(events, readiness)
+                    }
+                    NTtyReadWait::Timeout(timeout) => core
+                        .read_wq()
+                        .wait_event_interruptible_timeout(events, readiness, timeout),
+                };
+                if let Err(err) = wait_result {
+                    if err != SystemError::EAGAIN_OR_EWOULDBLOCK {
+                        ret = Err(err);
+                    }
+                    break;
+                }
                 continue;
             }
 
@@ -1829,12 +2008,17 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             if offset >= minimum {
                 break;
             }
+            if let Some(timeout) = inter_byte_timeout {
+                if offset != 0 {
+                    current_wait = NTtyReadWait::Timeout(timeout);
+                }
+            }
         }
         let ldata = self.disc_data();
         let read_tail_moved = tail != ldata.read_tail;
         drop(ldata);
         if read_tail_moved {
-            let _ = pty_drain_pending_to(tty.clone());
+            Self::check_pty_unthrottle_after_read(&tty);
         }
 
         if offset > 0 {
@@ -1865,7 +2049,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let mut output_guard = Some(self.output_lock.lock());
 
         self.disc_data().process_echoes(tty.clone());
-        self.drain_echoes(tty.clone())?;
+        self.drain_echoes(&tty)?;
 
         let mut offset = 0;
         loop {
@@ -1956,18 +2140,18 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                                         guard.canon_cursor_column = canon_cursor_column;
                                         break;
                                     } else {
-                                        let _ = core.write_wq().wait_event_interruptible(
-                                            EPollEventType::EPOLLOUT.bits() as u64,
-                                            || tty.write_room(core) > 0,
-                                        );
-                                        continue;
+                                        let mut guard = self.disc_data();
+                                        guard.opost_pending.clear();
+                                        guard.opost_pending.extend_from_slice(&out_buf[sent..]);
+                                        guard.opost_pending_offset = 0;
+                                        break;
                                     }
                                 }
                                 sent += written;
                                 tty.flush_chars(core);
                             }
 
-                            if sent == out_buf.len() {
+                            if sent != 0 {
                                 offset += 1;
                                 nr -= 1;
                                 made_progress = true;
@@ -2000,6 +2184,9 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 || core.flags().contains(TtyFlag::LDISC_CHANGING)
             {
                 if offset != 0 {
+                    if self.disc_data().has_output_wakeup_pending() {
+                        core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+                    }
                     break;
                 }
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -2040,6 +2227,10 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             }
             output_guard = Some(self.output_lock.lock());
             termios = *core.termios();
+        }
+
+        if self.disc_data().has_output_wakeup_pending() {
+            core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
         }
 
         drop(output_guard);
@@ -2248,15 +2439,15 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             // 原模式或real_raw
             ldata.raw = true;
 
-            ldata.real_raw = termios.input_mode.contains(InputMode::IGNBRK)
+            ldata.real_raw = (termios.input_mode.contains(InputMode::IGNBRK)
                 || (!termios.input_mode.contains(InputMode::BRKINT)
-                    && !termios.input_mode.contains(InputMode::PARMRK))
-                    && (termios.input_mode.contains(InputMode::IGNPAR)
-                        || !termios.input_mode.contains(InputMode::INPCK))
-                    && (core
-                        .driver()
-                        .flags()
-                        .contains(TtyDriverFlag::TTY_DRIVER_REAL_RAW));
+                    && !termios.input_mode.contains(InputMode::PARMRK)))
+                && (termios.input_mode.contains(InputMode::IGNPAR)
+                    || !termios.input_mode.contains(InputMode::INPCK))
+                && (core
+                    .driver()
+                    .flags()
+                    .contains(TtyDriverFlag::TTY_DRIVER_REAL_RAW));
         }
 
         // if !termios.input_mode.contains(InputMode::IXON)
@@ -2271,11 +2462,18 @@ impl TtyLineDiscipline for NTtyLinediscipline {
 
     fn poll(&self, tty: Arc<TtyCore>) -> Result<usize, system_error::SystemError> {
         let core = tty.core();
-        let ldata = self.disc_data();
+        let mut ldata = self.disc_data();
 
         let mut event = EPollEventType::empty();
         if ldata.input_available(core.termios(), true) {
             event.insert(EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM)
+        } else {
+            drop(ldata);
+            let _ = pty_drain_pending_to(tty.clone());
+            ldata = self.disc_data();
+            if ldata.input_available(core.termios(), true) {
+                event.insert(EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM)
+            }
         }
 
         if core.contorl_info_irqsave().packet {
@@ -2310,6 +2508,34 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         Ok(event.bits() as usize)
     }
 
+    fn write_wakeup(&self, tty: &TtyCore) -> Result<(), SystemError> {
+        if let Some(_output_guard) = self.output_lock.try_lock() {
+            if self.drain_opost_pending(tty)? {
+                self.drain_echoes(tty)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn receive_room(&self, tty: Arc<TtyCore>) -> usize {
+        let termios = tty.core().termios();
+        let ldata = self.disc_data();
+        let tail = ldata.read_tail;
+        let mut room = NTTY_BUFSIZE as isize - (ldata.read_head - tail) as isize;
+
+        if termios.input_mode.contains(InputMode::PARMRK) {
+            room = if room > 0 { (room + 2) / 3 } else { room };
+        }
+
+        room -= 1;
+        if room <= 0 {
+            let overflow = ldata.icanon && ldata.canon_head == tail;
+            room = if overflow { 1 } else { 0 };
+        }
+
+        room as usize
+    }
+
     fn hangup(&self, tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {
         self.flush_buffer(tty.clone())?;
         self.flush_output(tty.clone())?;
@@ -2333,7 +2559,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, false);
         drop(ldata);
         if let Some(_output_guard) = self.output_lock.try_lock() {
-            self.drain_echoes(tty)?;
+            self.drain_echoes(&tty)?;
         }
         ret
     }
@@ -2349,7 +2575,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, true);
         drop(ldata);
         if let Some(_output_guard) = self.output_lock.try_lock() {
-            self.drain_echoes(tty)?;
+            self.drain_echoes(&tty)?;
         }
         ret
     }

--- a/kernel/src/libs/wait_queue.rs
+++ b/kernel/src/libs/wait_queue.rs
@@ -1011,6 +1011,92 @@ impl EventWaitQueue {
         }
     }
 
+    pub fn wait_event_interruptible_timeout<F>(
+        &self,
+        events: u64,
+        mut cond: F,
+        timeout: Duration,
+    ) -> Result<(), SystemError>
+    where
+        F: FnMut() -> bool,
+    {
+        before_sleep_check(0);
+        if cond() {
+            return Ok(());
+        }
+
+        let deadline = Instant::now() + timeout;
+        let (waiter, waker) = Waiter::new_pair();
+        loop {
+            if Instant::now() >= deadline {
+                self.remove_waker(&waker);
+                waker.close();
+                if cond() {
+                    return Ok(());
+                }
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+
+            self.register_waker(events, waker.clone());
+
+            if cond() {
+                self.remove_waker(&waker);
+                return Ok(());
+            }
+
+            if Signal::signal_pending_state(true, false, &ProcessManager::current_pcb()) {
+                self.remove_waker(&waker);
+                waker.close();
+                if cond() {
+                    return Ok(());
+                }
+                return Err(SystemError::ERESTARTSYS);
+            }
+
+            let remain = deadline
+                .duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+            if remain == Duration::ZERO {
+                self.remove_waker(&waker);
+                waker.close();
+                if cond() {
+                    return Ok(());
+                }
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+
+            let timer: Arc<Timer> = Timer::new(
+                TimeoutWaker::new(waker.clone()),
+                next_n_us_timer_jiffies(remain.total_micros()),
+            );
+            timer.activate();
+
+            let wait_result = waiter.wait(true);
+            let was_timeout = timer.timeout();
+            if !was_timeout {
+                timer.cancel();
+            }
+
+            if was_timeout {
+                self.remove_waker(&waker);
+                waker.close();
+                if cond() {
+                    return Ok(());
+                }
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+
+            if let Err(err) = wait_result {
+                self.remove_waker(&waker);
+                waker.close();
+                if cond() {
+                    return Ok(());
+                }
+                return Err(err);
+            }
+        }
+    }
+
     pub fn sleep(&self, events: u64) {
         before_sleep_check(0);
         let (waiter, waker) = Waiter::new_pair();

--- a/kernel/src/time/clocksource.rs
+++ b/kernel/src/time/clocksource.rs
@@ -1,6 +1,6 @@
 use core::{
     fmt::Debug,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
 use alloc::{
@@ -11,7 +11,7 @@ use alloc::{
     vec::Vec,
 };
 use lazy_static::__Deref;
-use log::{debug, info};
+use log::{debug, info, warn};
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
@@ -73,6 +73,7 @@ static mut WATCHDOG_KTHREAD: Option<Arc<ProcessControlBlock>> = None;
 pub static CUR_CLOCKSOURCE: SpinLock<Option<Arc<dyn Clocksource>>> = SpinLock::new(None);
 /// 是否完成加载
 pub static FINISHED_BOOTING: AtomicBool = AtomicBool::new(false);
+static WATCHDOG_MAX_INTERVAL_NS_SEEN: AtomicU64 = AtomicU64::new(WATCHDOG_INTERVAL_MAX_NS);
 
 /// Interval: 0.5sec Threshold: 0.0625s
 /// 系统节拍率
@@ -80,12 +81,29 @@ pub const HZ: u64 = 250;
 // 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/time/clocksource.c#101
 /// watchdog检查间隔
 pub const WATCHDOG_INTERVAL: u64 = HZ >> 1;
+pub const WATCHDOG_INTERVAL_MAX_NS: u64 = (2 * WATCHDOG_INTERVAL) * (NSEC_PER_SEC as u64 / HZ);
 // 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/time/clocksource.c#108
 /// 最大能接受的误差大小
 pub const WATCHDOG_THRESHOLD: u32 = NSEC_PER_SEC >> 4;
 
 pub const MAX_SKEW_USEC: u64 = 125 * WATCHDOG_INTERVAL / HZ;
 pub const WATCHDOG_MAX_SKEW: u32 = MAX_SKEW_USEC as u32 * NSEC_PER_USEC;
+
+fn should_report_long_watchdog_interval(interval: u64) -> bool {
+    loop {
+        let max_interval = WATCHDOG_MAX_INTERVAL_NS_SEEN.load(Ordering::Relaxed);
+        if interval <= max_interval.saturating_mul(2) {
+            return false;
+        }
+
+        if WATCHDOG_MAX_INTERVAL_NS_SEEN
+            .compare_exchange(max_interval, interval, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return true;
+        }
+    }
+}
 
 // 时钟周期数
 #[derive(Debug, Clone, Copy)]
@@ -890,7 +908,20 @@ pub fn clocksource_watchdog() -> Result<(), SystemError> {
         cs_data.cs_last = cs_now_clock;
         cs.update_clocksource_data(cs_data.clone())?;
 
-        // 判断是否有误差
+        // 判断是否有误差。长间隔判断只能基于可信 watchdog 的读数；
+        // 被监视 clocksource 单侧跳变必须继续进入 skew 检测。
+        if wd_dev_nsec > WATCHDOG_INTERVAL_MAX_NS {
+            if FINISHED_BOOTING.load(Ordering::Relaxed)
+                && should_report_long_watchdog_interval(wd_dev_nsec)
+            {
+                warn!(
+                    "clocksource watchdog: long readout interval, skip check: cs_nsec={} wd_nsec={}",
+                    cs_dev_nsec, wd_dev_nsec
+                );
+            }
+            continue;
+        }
+
         if cs_dev_nsec.abs_diff(wd_dev_nsec) > WATCHDOG_THRESHOLD.into() {
             // debug!("set_unstable");
             // 误差过大，标记为unstable

--- a/user/apps/tests/dunitest/suites/normal/cubesandbox_pty_exec_chain.cc
+++ b/user/apps/tests/dunitest/suites/normal/cubesandbox_pty_exec_chain.cc
@@ -8,6 +8,7 @@
 #include <sched.h>
 #include <signal.h>
 #include <string.h>
+#include <sys/epoll.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <termios.h>
@@ -19,6 +20,12 @@
 #include <string>
 
 namespace {
+
+#ifndef TIOCPKT
+constexpr int kTiocpkt = 0x5420;
+#else
+constexpr int kTiocpkt = TIOCPKT;
+#endif
 
 class UniqueFd {
 public:
@@ -93,6 +100,25 @@ void SetRawByteMode(int fd) {
         << "tcsetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
 }
 
+void SetNoncanonicalMode(int fd, cc_t vmin, cc_t vtime) {
+    struct termios term = {};
+    ASSERT_EQ(0, tcgetattr(fd, &term))
+        << "tcgetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    term.c_lflag &= static_cast<tcflag_t>(~ICANON);
+    term.c_cc[VMIN] = vmin;
+    term.c_cc[VTIME] = vtime;
+
+    ASSERT_EQ(0, tcsetattr(fd, TCSANOW, &term))
+        << "tcsetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
+}
+
+void EnablePacketMode(int master_fd) {
+    int on = 1;
+    ASSERT_EQ(0, ioctl(master_fd, kTiocpkt, &on))
+        << "ioctl(TIOCPKT) failed: errno=" << errno << " (" << strerror(errno) << ")";
+}
+
 bool WriteAll(int fd, const char* data, size_t len) {
     size_t written = 0;
     while (written < len) {
@@ -107,6 +133,10 @@ bool WriteAll(int fd, const char* data, size_t len) {
         return false;
     }
     return true;
+}
+
+bool WriteReport(int fd, const std::string& report) {
+    return WriteAll(fd, report.data(), report.size());
 }
 
 bool SetNonblockNoAssert(int fd) {
@@ -131,8 +161,10 @@ bool WaitForChild(pid_t child, int* status, int rounds = 300) {
     return false;
 }
 
-bool WriteReport(int report_fd, const std::string& report) {
-    return WriteAll(report_fd, report.c_str(), report.size());
+long MonotonicMillis() {
+    struct timespec ts = {};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<long>(ts.tv_sec) * 1000 + ts.tv_nsec / (1000 * 1000);
 }
 
 bool DrainAvailableReport(int report_fd, std::string* report) {
@@ -160,6 +192,109 @@ void KillAndReap(pid_t child) {
     kill(child, SIGKILL);
     waitpid(child, nullptr, 0);
 }
+
+class ChildReaper {
+public:
+    explicit ChildReaper(pid_t child) : child_(child) {}
+    ChildReaper(const ChildReaper&) = delete;
+    ChildReaper& operator=(const ChildReaper&) = delete;
+    ~ChildReaper() { Cleanup(); }
+
+    void Disarm() { child_ = -1; }
+
+    void Cleanup() {
+        if (child_ > 0) {
+            KillAndReap(child_);
+            child_ = -1;
+        }
+    }
+
+private:
+    pid_t child_ = -1;
+};
+
+class ShimCleanup {
+public:
+    ShimCleanup(pid_t child, UniqueFd* stdin_write, UniqueFd* pty_master,
+                std::atomic<int>* child_exited = nullptr)
+        : child_(child),
+          stdin_write_(stdin_write),
+          pty_master_(pty_master),
+          child_exited_(child_exited) {}
+
+    ShimCleanup(const ShimCleanup&) = delete;
+    ShimCleanup& operator=(const ShimCleanup&) = delete;
+    ~ShimCleanup() { Cleanup(); }
+
+    void SetStdinThread(pthread_t thread) {
+        stdin_thread_ = thread;
+        stdin_started_ = true;
+    }
+
+    void SetStdoutThread(pthread_t thread) {
+        stdout_thread_ = thread;
+        stdout_started_ = true;
+    }
+
+    void JoinStdin(void** result) {
+        if (stdin_started_) {
+            EXPECT_EQ(0, pthread_join(stdin_thread_, result)) << strerror(errno);
+            stdin_started_ = false;
+        }
+    }
+
+    void JoinStdout(void** result) {
+        if (stdout_started_) {
+            EXPECT_EQ(0, pthread_join(stdout_thread_, result)) << strerror(errno);
+            stdout_started_ = false;
+        }
+    }
+
+    void ChildReaped() { child_ = -1; }
+
+    void Disarm() { active_ = false; }
+
+    void Cleanup() {
+        if (!active_) {
+            return;
+        }
+        active_ = false;
+
+        if (stdin_write_ != nullptr) {
+            stdin_write_->reset();
+        }
+        if (child_ > 0) {
+            KillAndReap(child_);
+            child_ = -1;
+        }
+        if (child_exited_ != nullptr) {
+            child_exited_->store(1, std::memory_order_release);
+        }
+        if (pty_master_ != nullptr) {
+            pty_master_->reset();
+        }
+
+        if (stdin_started_) {
+            pthread_join(stdin_thread_, nullptr);
+            stdin_started_ = false;
+        }
+        if (stdout_started_) {
+            pthread_join(stdout_thread_, nullptr);
+            stdout_started_ = false;
+        }
+    }
+
+private:
+    bool active_ = true;
+    pid_t child_ = -1;
+    UniqueFd* stdin_write_ = nullptr;
+    UniqueFd* pty_master_ = nullptr;
+    std::atomic<int>* child_exited_ = nullptr;
+    pthread_t stdin_thread_ = {};
+    bool stdin_started_ = false;
+    pthread_t stdout_thread_ = {};
+    bool stdout_started_ = false;
+};
 
 bool ReadUntilContains(int fd, const std::string& needle, std::string* output, int timeout_ms) {
     const size_t search_from = 0;
@@ -275,6 +410,136 @@ bool ReadUntilContainsFrom(int fd, const std::string& needle, std::string* outpu
 
         usleep(10 * 1000);
         elapsed_ms += 10;
+    }
+    return false;
+}
+
+size_t FindShellPromptFrom(const std::string& output, size_t search_from) {
+    size_t hash_prompt = output.find("# ", search_from);
+    size_t dollar_prompt = output.find("$ ", search_from);
+    if (hash_prompt == std::string::npos) {
+        return dollar_prompt;
+    }
+    if (dollar_prompt == std::string::npos) {
+        return hash_prompt;
+    }
+    return hash_prompt < dollar_prompt ? hash_prompt : dollar_prompt;
+}
+
+bool ReadUntilShellPromptFrom(int fd, std::string* output, size_t search_from, int timeout_ms) {
+    if (FindShellPromptFrom(*output, search_from) != std::string::npos) {
+        return true;
+    }
+
+    int elapsed_ms = 0;
+    while (elapsed_ms < timeout_ms) {
+        struct pollfd pfd = {
+            .fd = fd,
+            .events = POLLIN | POLLERR | POLLHUP,
+            .revents = 0,
+        };
+        sigset_t mask;
+        sigemptyset(&mask);
+        struct timespec ts = {
+            .tv_sec = 0,
+            .tv_nsec = 10 * 1000 * 1000,
+        };
+        int ret = ppoll(&pfd, 1, &ts, &mask);
+        if (ret < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (ret == 0) {
+            elapsed_ms += 10;
+            continue;
+        }
+
+        if ((pfd.revents & POLLIN) != 0) {
+            char buf[256] = {};
+            ssize_t n = read(fd, buf, sizeof(buf));
+            if (n > 0) {
+                output->append(buf, static_cast<size_t>(n));
+                if (FindShellPromptFrom(*output, search_from) != std::string::npos) {
+                    return true;
+                }
+                continue;
+            }
+            if (n < 0 && errno == EINTR) {
+                continue;
+            }
+            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                continue;
+            }
+            return false;
+        }
+
+        if ((pfd.revents & (POLLERR | POLLHUP)) != 0) {
+            return FindShellPromptFrom(*output, search_from) != std::string::npos;
+        }
+    }
+    return false;
+}
+
+bool ReadUntilCommandOutputAndPrompt(int fd, const std::string& marker, std::string* output,
+                                     size_t search_from, int timeout_ms) {
+    auto has_marker_and_prompt = [&]() {
+        size_t marker_pos = output->find(marker, search_from);
+        return marker_pos != std::string::npos &&
+               FindShellPromptFrom(*output, marker_pos + marker.size()) != std::string::npos;
+    };
+    if (has_marker_and_prompt()) {
+        return true;
+    }
+
+    int elapsed_ms = 0;
+    while (elapsed_ms < timeout_ms) {
+        struct pollfd pfd = {
+            .fd = fd,
+            .events = POLLIN | POLLERR | POLLHUP,
+            .revents = 0,
+        };
+        sigset_t mask;
+        sigemptyset(&mask);
+        struct timespec ts = {
+            .tv_sec = 0,
+            .tv_nsec = 10 * 1000 * 1000,
+        };
+        int ret = ppoll(&pfd, 1, &ts, &mask);
+        if (ret < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (ret == 0) {
+            elapsed_ms += 10;
+            continue;
+        }
+
+        if ((pfd.revents & POLLIN) != 0) {
+            char buf[256] = {};
+            ssize_t n = read(fd, buf, sizeof(buf));
+            if (n > 0) {
+                output->append(buf, static_cast<size_t>(n));
+                if (has_marker_and_prompt()) {
+                    return true;
+                }
+                continue;
+            }
+            if (n < 0 && errno == EINTR) {
+                continue;
+            }
+            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                continue;
+            }
+            return false;
+        }
+
+        if ((pfd.revents & (POLLERR | POLLHUP)) != 0) {
+            return has_marker_and_prompt();
+        }
     }
     return false;
 }
@@ -475,6 +740,7 @@ void RunShellCommandSequence(void (*exec_shell)(int), const char* shell_name) {
         pair.master.reset();
         exec_shell(pair.slave.get());
     }
+    ChildReaper child_guard(child);
 
     pair.slave.reset();
 
@@ -499,8 +765,70 @@ void RunShellCommandSequence(void (*exec_shell)(int), const char* shell_name) {
     if (!WaitForChild(child, &status)) {
         kill(child, SIGKILL);
         waitpid(child, nullptr, 0);
+        child_guard.Disarm();
         FAIL() << shell_name << " did not exit after command sequence, captured: " << output;
     }
+    child_guard.Disarm();
+    ASSERT_TRUE(WIFEXITED(status) || WIFSIGNALED(status));
+}
+
+void RunPromptDrivenShellCommandSequence(void (*exec_shell)(int), const char* shell_name,
+                                         bool packet_mode = false) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    SetNonblock(pair.master.get());
+    if (packet_mode) {
+        EnablePacketMode(pair.master.get());
+    }
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        pair.master.reset();
+        exec_shell(pair.slave.get());
+    }
+    ChildReaper child_guard(child);
+
+    pair.slave.reset();
+
+    std::string output;
+    ASSERT_TRUE(ReadUntilShellPromptFrom(pair.master.get(), &output, 0, 3000))
+        << "did not observe initial prompt through " << shell_name << ", captured: " << output;
+
+    size_t before_first = output.size();
+    constexpr char kFirstCommand[] = "x=one; echo CUBE_${x}_OK\n";
+    ASSERT_TRUE(WriteAll(pair.master.get(), kFirstCommand, strlen(kFirstCommand)))
+        << "write first prompt-driven command failed through " << shell_name
+        << ": errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(ReadUntilCommandOutputAndPrompt(pair.master.get(), "CUBE_one_OK", &output,
+                                               before_first, 5000))
+        << "did not observe first command output and prompt through " << shell_name
+        << ", captured: " << output;
+
+    size_t before_second = output.size();
+    constexpr char kSecondCommand[] = "x=two; echo CUBE_${x}_OK\n";
+    ASSERT_TRUE(WriteAll(pair.master.get(), kSecondCommand, strlen(kSecondCommand)))
+        << "write second prompt-driven command failed through " << shell_name
+        << ": errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(ReadUntilCommandOutputAndPrompt(pair.master.get(), "CUBE_two_OK", &output,
+                                               before_second, 5000))
+        << "did not observe second command output and prompt through " << shell_name
+        << ", captured: " << output;
+
+    ASSERT_TRUE(WriteAll(pair.master.get(), "exit\n", strlen("exit\n")))
+        << "write exit failed through " << shell_name << ": errno=" << errno << " ("
+        << strerror(errno) << ")";
+
+    int status = 0;
+    if (!WaitForChild(child, &status)) {
+        kill(child, SIGKILL);
+        waitpid(child, nullptr, 0);
+        child_guard.Disarm();
+        FAIL() << shell_name << " did not exit after prompt-driven command sequence, captured: "
+               << output;
+    }
+    child_guard.Disarm();
     ASSERT_TRUE(WIFEXITED(status) || WIFSIGNALED(status));
 }
 
@@ -516,6 +844,7 @@ void RunRepeatedShellCommandSequence(void (*exec_shell)(int), const char* shell_
         pair.master.reset();
         exec_shell(pair.slave.get());
     }
+    ChildReaper child_guard(child);
 
     pair.slave.reset();
 
@@ -547,9 +876,11 @@ void RunRepeatedShellCommandSequence(void (*exec_shell)(int), const char* shell_
     if (!WaitForChild(child, &status)) {
         kill(child, SIGKILL);
         waitpid(child, nullptr, 0);
+        child_guard.Disarm();
         FAIL() << shell_name << " did not exit after repeated command sequence, captured: "
                << output;
     }
+    child_guard.Disarm();
     ASSERT_TRUE(WIFEXITED(status) || WIFSIGNALED(status));
 }
 
@@ -721,6 +1052,82 @@ void* ForwardPtyOutputToClient(void* arg) {
     return nullptr;
 }
 
+void* ForwardPtyOutputToClientWithEpollEt(void* arg) {
+    auto* forwarder = reinterpret_cast<MockShimStdoutForwarder*>(arg);
+    forwarder->stages->fetch_or(kConcurrentStdoutForwardStarted, std::memory_order_release);
+
+    int epfd = epoll_create1(EPOLL_CLOEXEC);
+    if (epfd < 0) {
+        close(forwarder->client_stdout_fd);
+        return reinterpret_cast<void*>(1);
+    }
+    UniqueFd epoll_fd(epfd);
+
+    struct epoll_event event = {};
+    event.events = EPOLLIN | EPOLLERR | EPOLLHUP | EPOLLET;
+    event.data.fd = forwarder->pty_master_fd;
+    if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, forwarder->pty_master_fd, &event) != 0) {
+        close(forwarder->client_stdout_fd);
+        return reinterpret_cast<void*>(2);
+    }
+
+    int idle_after_child_exit = 0;
+    std::array<char, 256> buf = {};
+    for (;;) {
+        struct epoll_event ready = {};
+        int ret = epoll_wait(epoll_fd.get(), &ready, 1, 10);
+        if (ret < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            close(forwarder->client_stdout_fd);
+            return reinterpret_cast<void*>(3);
+        }
+
+        if (ret == 0) {
+            if (forwarder->child_exited->load(std::memory_order_acquire) != 0 &&
+                ++idle_after_child_exit >= 5) {
+                break;
+            }
+            continue;
+        }
+        idle_after_child_exit = 0;
+
+        if ((ready.events & EPOLLIN) != 0) {
+            for (;;) {
+                ssize_t n = read(forwarder->pty_master_fd, buf.data(), buf.size());
+                if (n > 0) {
+                    if (!WriteAll(forwarder->client_stdout_fd, buf.data(),
+                                  static_cast<size_t>(n))) {
+                        close(forwarder->client_stdout_fd);
+                        return reinterpret_cast<void*>(4);
+                    }
+                    continue;
+                }
+                if (n == 0 || (n < 0 && errno == EIO)) {
+                    break;
+                }
+                if (n < 0 && errno == EINTR) {
+                    continue;
+                }
+                if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                    break;
+                }
+                close(forwarder->client_stdout_fd);
+                return reinterpret_cast<void*>(5);
+            }
+        }
+
+        if ((ready.events & (EPOLLERR | EPOLLHUP)) != 0) {
+            break;
+        }
+    }
+
+    forwarder->stages->fetch_or(kConcurrentStdoutForwardFinished, std::memory_order_release);
+    close(forwarder->client_stdout_fd);
+    return nullptr;
+}
+
 void RunCubeShimLikeExecChain(void (*exec_shell)(int), const char* shell_name) {
     // Model the interactive Cube exec path at the kernel ABI boundary:
     // client stdin pipe -> shim forwarder thread -> PTY master -> shell on the
@@ -754,10 +1161,12 @@ void RunCubeShimLikeExecChain(void (*exec_shell)(int), const char* shell_name) {
         .pty_master_fd = pair.master.get(),
         .stages = &stages,
     };
+    ShimCleanup cleanup(child, &client_stdin_write, &pair.master);
 
     pthread_t stdin_thread = {};
-    ASSERT_EQ(0, pthread_create(&stdin_thread, nullptr, ForwardClientInputToPty, &forwarder))
-        << strerror(errno);
+    int thread_rc = pthread_create(&stdin_thread, nullptr, ForwardClientInputToPty, &forwarder);
+    ASSERT_EQ(0, thread_rc) << strerror(errno);
+    cleanup.SetStdinThread(stdin_thread);
 
     ASSERT_TRUE(WaitUntilAtomic(stages, kShimStdinForwardStarted, 1000))
         << "stdin forwarder did not start for " << shell_name;
@@ -820,17 +1229,17 @@ void RunCubeShimLikeExecChain(void (*exec_shell)(int), const char* shell_name) {
     }
 
     void* thread_result = nullptr;
-    ASSERT_EQ(0, pthread_join(stdin_thread, &thread_result)) << strerror(errno);
+    cleanup.JoinStdin(&thread_result);
     EXPECT_EQ(nullptr, thread_result) << "stdin forwarder failed for " << shell_name;
 
     int status = 0;
     if (!WaitForChild(child, &status)) {
         int observed = stages.load(std::memory_order_acquire);
-        kill(child, SIGKILL);
-        waitpid(child, nullptr, 0);
+        cleanup.Cleanup();
         FAIL() << "mock shim child did not exit for " << shell_name << ", stages=0x" << std::hex
                << observed << " (" << DescribeShimStages(observed) << "), captured: " << output;
     }
+    cleanup.ChildReaped();
     stages.fetch_or(kShimChildExited, std::memory_order_release);
 
     constexpr int kExpectedStages = kShimChildForked | kShimStdinForwardStarted |
@@ -841,6 +1250,7 @@ void RunCubeShimLikeExecChain(void (*exec_shell)(int), const char* shell_name) {
         << "mock shim chain did not reach all stages for " << shell_name
         << ", stages=0x" << std::hex << observed << " (" << DescribeShimStages(observed) << ")"
         << ", captured output: " << output;
+    cleanup.Disarm();
     ASSERT_TRUE(WIFEXITED(status) || WIFSIGNALED(status));
 }
 
@@ -889,15 +1299,17 @@ void RunCubeShimLikeConcurrentForwarders(void (*exec_shell)(int), const char* sh
         .stages = &stages,
         .child_exited = &child_exited,
     };
+    ShimCleanup cleanup(child, &client_stdin_write, &pair.master, &child_exited);
 
     pthread_t stdin_thread = {};
-    ASSERT_EQ(0, pthread_create(&stdin_thread, nullptr, ForwardClientInputToPty, &stdin_forwarder))
-        << strerror(errno);
+    int stdin_rc = pthread_create(&stdin_thread, nullptr, ForwardClientInputToPty, &stdin_forwarder);
+    ASSERT_EQ(0, stdin_rc) << strerror(errno);
+    cleanup.SetStdinThread(stdin_thread);
 
     pthread_t stdout_thread = {};
-    ASSERT_EQ(0,
-              pthread_create(&stdout_thread, nullptr, ForwardPtyOutputToClient, &stdout_forwarder))
-        << strerror(errno);
+    int stdout_rc = pthread_create(&stdout_thread, nullptr, ForwardPtyOutputToClient, &stdout_forwarder);
+    ASSERT_EQ(0, stdout_rc) << strerror(errno);
+    cleanup.SetStdoutThread(stdout_thread);
 
     ASSERT_TRUE(WaitUntilAtomic(stages, kShimStdinForwardStarted, 1000))
         << "stdin forwarder did not start for " << shell_name;
@@ -935,25 +1347,23 @@ void RunCubeShimLikeConcurrentForwarders(void (*exec_shell)(int), const char* sh
     stages.fetch_or(kConcurrentSawEndMarker, std::memory_order_release);
 
     void* stdin_result = nullptr;
-    ASSERT_EQ(0, pthread_join(stdin_thread, &stdin_result)) << strerror(errno);
+    cleanup.JoinStdin(&stdin_result);
     EXPECT_EQ(nullptr, stdin_result) << "stdin forwarder failed for " << shell_name;
 
     int status = 0;
     if (!WaitForChild(child, &status)) {
         int observed = stages.load(std::memory_order_acquire);
-        kill(child, SIGKILL);
-        waitpid(child, nullptr, 0);
-        child_exited.store(1, std::memory_order_release);
-        pthread_join(stdout_thread, nullptr);
+        cleanup.Cleanup();
         FAIL() << "child did not exit for " << shell_name << ", stages=0x" << std::hex
                << observed << " (" << DescribeConcurrentStages(observed)
                << "), captured: " << output;
     }
+    cleanup.ChildReaped();
     stages.fetch_or(kConcurrentChildExited, std::memory_order_release);
     child_exited.store(1, std::memory_order_release);
 
     void* stdout_result = nullptr;
-    ASSERT_EQ(0, pthread_join(stdout_thread, &stdout_result)) << strerror(errno);
+    cleanup.JoinStdout(&stdout_result);
     EXPECT_EQ(nullptr, stdout_result) << "stdout forwarder failed for " << shell_name;
 
     constexpr int kExpectedStages =
@@ -967,6 +1377,7 @@ void RunCubeShimLikeConcurrentForwarders(void (*exec_shell)(int), const char* sh
         << ", stages=0x" << std::hex << observed << " ("
         << DescribeConcurrentStages(observed) << ")"
         << ", captured output: " << output;
+    cleanup.Disarm();
     ASSERT_TRUE(WIFEXITED(status) || WIFSIGNALED(status));
 }
 
@@ -1015,15 +1426,17 @@ void RunCubeShimLikeByteStreamInput(void (*exec_shell)(int), const char* shell_n
         .stages = &stages,
         .child_exited = &child_exited,
     };
+    ShimCleanup cleanup(child, &client_stdin_write, &pair.master, &child_exited);
 
     pthread_t stdin_thread = {};
-    ASSERT_EQ(0, pthread_create(&stdin_thread, nullptr, ForwardClientInputToPty, &stdin_forwarder))
-        << strerror(errno);
+    int stdin_rc = pthread_create(&stdin_thread, nullptr, ForwardClientInputToPty, &stdin_forwarder);
+    ASSERT_EQ(0, stdin_rc) << strerror(errno);
+    cleanup.SetStdinThread(stdin_thread);
 
     pthread_t stdout_thread = {};
-    ASSERT_EQ(0,
-              pthread_create(&stdout_thread, nullptr, ForwardPtyOutputToClient, &stdout_forwarder))
-        << strerror(errno);
+    int stdout_rc = pthread_create(&stdout_thread, nullptr, ForwardPtyOutputToClient, &stdout_forwarder);
+    ASSERT_EQ(0, stdout_rc) << strerror(errno);
+    cleanup.SetStdoutThread(stdout_thread);
 
     ASSERT_TRUE(WaitUntilAtomic(stages, kShimStdinForwardStarted, 1000))
         << "stdin forwarder did not start for " << shell_name;
@@ -1053,25 +1466,140 @@ void RunCubeShimLikeByteStreamInput(void (*exec_shell)(int), const char* shell_n
         << ", captured: " << output;
 
     void* stdin_result = nullptr;
-    ASSERT_EQ(0, pthread_join(stdin_thread, &stdin_result)) << strerror(errno);
+    cleanup.JoinStdin(&stdin_result);
     EXPECT_EQ(nullptr, stdin_result) << "stdin forwarder failed for " << shell_name;
 
     int status = 0;
     if (!WaitForChild(child, &status)) {
         int observed = stages.load(std::memory_order_acquire);
-        kill(child, SIGKILL);
-        waitpid(child, nullptr, 0);
-        child_exited.store(1, std::memory_order_release);
-        pthread_join(stdout_thread, nullptr);
+        cleanup.Cleanup();
         FAIL() << "byte-stream child did not exit for " << shell_name << ", stages=0x"
                << std::hex << observed << " (" << DescribeConcurrentStages(observed)
                << "), captured: " << output;
     }
+    cleanup.ChildReaped();
     child_exited.store(1, std::memory_order_release);
 
     void* stdout_result = nullptr;
-    ASSERT_EQ(0, pthread_join(stdout_thread, &stdout_result)) << strerror(errno);
+    cleanup.JoinStdout(&stdout_result);
     EXPECT_EQ(nullptr, stdout_result) << "stdout forwarder failed for " << shell_name;
+    cleanup.Disarm();
+    ASSERT_TRUE(WIFEXITED(status) || WIFSIGNALED(status));
+}
+
+void RunCubeShimLikePromptDrivenEpollEt(void (*exec_shell)(int), const char* shell_name) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    SetNonblock(pair.master.get());
+
+    int client_stdin[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(client_stdin)) << strerror(errno);
+    UniqueFd client_stdin_read(client_stdin[0]);
+    UniqueFd client_stdin_write(client_stdin[1]);
+
+    int client_stdout[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(client_stdout)) << strerror(errno);
+    UniqueFd client_stdout_read(client_stdout[0]);
+    int client_stdout_write = client_stdout[1];
+    SetNonblock(client_stdout_read.get());
+
+    std::atomic<int> stages{0};
+    std::atomic<int> child_exited{0};
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        client_stdin_read.reset();
+        client_stdin_write.reset();
+        client_stdout_read.reset();
+        close(client_stdout_write);
+        pair.master.reset();
+        exec_shell(pair.slave.get());
+    }
+
+    stages.fetch_or(kConcurrentChildForked, std::memory_order_release);
+    pair.slave.reset();
+
+    MockShimForwarder stdin_forwarder = {
+        .source_fd = client_stdin_read.get(),
+        .pty_master_fd = pair.master.get(),
+        .stages = &stages,
+    };
+    MockShimStdoutForwarder stdout_forwarder = {
+        .pty_master_fd = pair.master.get(),
+        .client_stdout_fd = client_stdout_write,
+        .stages = &stages,
+        .child_exited = &child_exited,
+    };
+    ShimCleanup cleanup(child, &client_stdin_write, &pair.master, &child_exited);
+
+    pthread_t stdin_thread = {};
+    int stdin_rc = pthread_create(&stdin_thread, nullptr, ForwardClientInputToPty, &stdin_forwarder);
+    ASSERT_EQ(0, stdin_rc) << strerror(errno);
+    cleanup.SetStdinThread(stdin_thread);
+
+    pthread_t stdout_thread = {};
+    int stdout_rc =
+        pthread_create(&stdout_thread, nullptr, ForwardPtyOutputToClientWithEpollEt,
+                       &stdout_forwarder);
+    ASSERT_EQ(0, stdout_rc) << strerror(errno);
+    cleanup.SetStdoutThread(stdout_thread);
+
+    ASSERT_TRUE(WaitUntilAtomic(stages, kShimStdinForwardStarted, 1000))
+        << "stdin forwarder did not start for " << shell_name;
+    ASSERT_TRUE(WaitUntilAtomic(stages, kConcurrentStdoutForwardStarted, 1000))
+        << "epoll stdout forwarder did not start for " << shell_name;
+
+    std::string output;
+    ASSERT_TRUE(ReadUntilShellPromptFrom(client_stdout_read.get(), &output, 0, 5000))
+        << "initial prompt not captured for " << shell_name << ", captured: " << output;
+
+    size_t after_initial_prompt = output.size();
+    ASSERT_TRUE(WriteAll(client_stdin_write.get(), "echo one\n", strlen("echo one\n")))
+        << "first prompt-driven write failed for " << shell_name << ": errno=" << errno << " ("
+        << strerror(errno) << ")";
+    ASSERT_TRUE(ReadUntilCommandOutputAndPrompt(client_stdout_read.get(), "one", &output,
+                                                after_initial_prompt, 5000))
+        << "first command did not reach shell through epoll forwarder for " << shell_name
+        << ", captured: " << output;
+    stages.fetch_or(kConcurrentSawStartMarker, std::memory_order_release);
+
+    size_t after_first_prompt = output.size();
+    ASSERT_TRUE(WriteAll(client_stdin_write.get(), "echo two\n", strlen("echo two\n")))
+        << "second prompt-driven write failed for " << shell_name << ": errno=" << errno << " ("
+        << strerror(errno) << ")";
+    ASSERT_TRUE(ReadUntilCommandOutputAndPrompt(client_stdout_read.get(), "two", &output,
+                                                after_first_prompt, 5000))
+        << "second command did not reach shell through epoll forwarder for " << shell_name
+        << ", captured: " << output;
+    stages.fetch_or(kConcurrentSawEndMarker, std::memory_order_release);
+
+    ASSERT_TRUE(WriteAll(client_stdin_write.get(), "exit\n", strlen("exit\n")))
+        << "exit write failed for " << shell_name << ": errno=" << errno << " (" << strerror(errno)
+        << ")";
+    client_stdin_write.reset();
+
+    void* stdin_result = nullptr;
+    cleanup.JoinStdin(&stdin_result);
+    EXPECT_EQ(nullptr, stdin_result) << "stdin forwarder failed for " << shell_name;
+
+    int status = 0;
+    if (!WaitForChild(child, &status)) {
+        int observed = stages.load(std::memory_order_acquire);
+        cleanup.Cleanup();
+        FAIL() << "prompt-driven epoll child did not exit for " << shell_name << ", stages=0x"
+               << std::hex << observed << " (" << DescribeConcurrentStages(observed)
+               << "), captured: " << output;
+    }
+    cleanup.ChildReaped();
+    stages.fetch_or(kConcurrentChildExited, std::memory_order_release);
+    child_exited.store(1, std::memory_order_release);
+
+    void* stdout_result = nullptr;
+    cleanup.JoinStdout(&stdout_result);
+    EXPECT_EQ(nullptr, stdout_result) << "epoll stdout forwarder failed for " << shell_name;
+    cleanup.Disarm();
     ASSERT_TRUE(WIFEXITED(status) || WIFSIGNALED(status));
 }
 
@@ -1214,8 +1742,8 @@ int RunPidNamespaceInteractiveShellAndReport(int report_fd) {
     close(master);
 
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-        WriteReport(report_fd, "shell bad status: " + std::to_string(status) + " output: " +
-                                   output);
+        WriteReport(report_fd,
+                    "shell bad status: " + std::to_string(status) + " output: " + output);
         return 39;
     }
 
@@ -1258,6 +1786,7 @@ void ExpectVforkExecLsCompletesInChildPidNamespace() {
         }
         _exit(WEXITSTATUS(status));
     }
+    ChildReaper outer_guard(outer);
 
     report_write.reset();
 
@@ -1277,8 +1806,10 @@ void ExpectVforkExecLsCompletesInChildPidNamespace() {
 
     if (!exited) {
         KillAndReap(outer);
+        outer_guard.Disarm();
         FAIL() << "vfork+exec /bin/ls did not finish inside a child PID namespace";
     }
+    outer_guard.Disarm();
     ASSERT_TRUE(DrainAvailableReport(report_read.get(), &report)) << strerror(errno);
     ASSERT_TRUE(WIFEXITED(status)) << "outer status=" << status;
     if (WEXITSTATUS(status) == 77) {
@@ -1321,6 +1852,7 @@ void ExpectInteractiveShellCommandsCompleteInChildPidNamespace() {
         }
         _exit(WEXITSTATUS(status));
     }
+    ChildReaper outer_guard(outer);
 
     report_write.reset();
 
@@ -1341,10 +1873,12 @@ void ExpectInteractiveShellCommandsCompleteInChildPidNamespace() {
 
     if (!exited) {
         KillAndReap(outer);
+        outer_guard.Disarm();
         FAIL() << "interactive shell commands did not finish inside a child PID namespace, "
                   "captured report: "
                << report;
     }
+    outer_guard.Disarm();
     ASSERT_TRUE(DrainAvailableReport(report_read.get(), &report)) << strerror(errno);
     ASSERT_TRUE(WIFEXITED(status)) << "outer status=" << status << ", report: " << report;
     if (WEXITSTATUS(status) == 77) {
@@ -1366,6 +1900,7 @@ TEST(CubeSandboxPtyExecChain, BlockingPtyMasterReadDoesNotBlockConcurrentWrite) 
         pair.master.reset();
         ExecDefaultShellOnSlave(pair.slave.get());
     }
+    ChildReaper shell_guard(shell);
 
     pair.slave.reset();
 
@@ -1395,6 +1930,7 @@ TEST(CubeSandboxPtyExecChain, BlockingPtyMasterReadDoesNotBlockConcurrentWrite) 
             _exit(n == 0 ? 0 : 1);
         }
     }
+    ChildReaper reader_guard(reader);
 
     captured_write.reset();
 
@@ -1419,21 +1955,20 @@ TEST(CubeSandboxPtyExecChain, BlockingPtyMasterReadDoesNotBlockConcurrentWrite) 
 
     int shell_status = 0;
     if (!WaitForChild(shell, &shell_status)) {
-        kill(shell, SIGKILL);
-        waitpid(shell, nullptr, 0);
-        kill(reader, SIGKILL);
-        waitpid(reader, nullptr, 0);
+        shell_guard.Cleanup();
+        reader_guard.Cleanup();
         FAIL() << "shell did not exit after blocking-read test, captured: " << output;
     }
+    shell_guard.Disarm();
 
     pair.master.reset();
 
     int reader_status = 0;
     if (!WaitForChild(reader, &reader_status)) {
-        kill(reader, SIGKILL);
-        waitpid(reader, nullptr, 0);
+        reader_guard.Cleanup();
         FAIL() << "PTY master reader did not exit after shell close, captured: " << output;
     }
+    reader_guard.Disarm();
 
     ASSERT_TRUE(WIFEXITED(shell_status) || WIFSIGNALED(shell_status));
     ASSERT_TRUE(WIFEXITED(reader_status) || WIFSIGNALED(reader_status));
@@ -1618,8 +2153,169 @@ TEST(CubeSandboxPtyExecChain, RawPtyByteReadsSurviveSigmaskAndPpoll) {
     EXPECT_EQ(0, WEXITSTATUS(status));
 }
 
+TEST(CubeSandboxPtyExecChain, PtyMasterReadAfterLastSlaveCloseReturnsEio) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    SetNoncanonicalMode(pair.master.get(), 0, 0);
+
+    pair.slave.reset();
+
+    char ch = 0;
+    errno = 0;
+    EXPECT_EQ(-1, read(pair.master.get(), &ch, 1));
+    EXPECT_EQ(EIO, errno);
+}
+
+TEST(CubeSandboxPtyExecChain, NoncanonicalVtimeReadTimesOut) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    SetNoncanonicalMode(pair.slave.get(), 0, 1);
+
+    char ch = 0;
+    long start_ms = MonotonicMillis();
+    errno = 0;
+    ssize_t n = read(pair.slave.get(), &ch, 1);
+    long elapsed_ms = MonotonicMillis() - start_ms;
+
+    EXPECT_EQ(0, n) << "errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_GE(elapsed_ms, 50);
+    EXPECT_LT(elapsed_ms, 1500);
+}
+
+TEST(CubeSandboxPtyExecChain, CanonicalPollWaitsForLineCommit) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    SetNonblock(pair.slave.get());
+
+    ASSERT_TRUE(WriteAll(pair.master.get(), "abc", 3));
+
+    struct pollfd pfd = {
+        .fd = pair.slave.get(),
+        .events = POLLIN | POLLERR | POLLHUP,
+        .revents = 0,
+    };
+    EXPECT_EQ(0, poll(&pfd, 1, 100)) << "unexpected revents=" << pfd.revents;
+
+    char buf[8] = {};
+    errno = 0;
+    EXPECT_EQ(-1, read(pair.slave.get(), buf, sizeof(buf)));
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+
+    ASSERT_TRUE(WriteAll(pair.master.get(), "\n", 1));
+    pfd.revents = 0;
+    ASSERT_EQ(1, poll(&pfd, 1, 1000));
+    ASSERT_NE(0, pfd.revents & POLLIN);
+    ssize_t n = read(pair.slave.get(), buf, sizeof(buf));
+    ASSERT_GT(n, 0) << strerror(errno);
+    EXPECT_NE(nullptr, memchr(buf, '\n', static_cast<size_t>(n)));
+}
+
+TEST(CubeSandboxPtyExecChain, PacketOnlyStatusWakesRead) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    EnablePacketMode(pair.master.get());
+
+    ASSERT_EQ(0, tcflush(pair.slave.get(), TCIFLUSH)) << strerror(errno);
+
+    struct pollfd pfd = {
+        .fd = pair.master.get(),
+        .events = POLLIN | POLLPRI | POLLERR | POLLHUP,
+        .revents = 0,
+    };
+    ASSERT_EQ(1, poll(&pfd, 1, 1000)) << strerror(errno);
+    ASSERT_NE(0, pfd.revents & (POLLIN | POLLPRI));
+
+    unsigned char status = 0;
+    ASSERT_EQ(1, read(pair.master.get(), &status, 1)) << strerror(errno);
+    EXPECT_NE(0, status);
+}
+
+TEST(CubeSandboxPtyExecChain, SignalFlushDropsPrefixAndKeepsSuffix) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    struct termios term = {};
+    ASSERT_EQ(0, tcgetattr(pair.slave.get(), &term)) << strerror(errno);
+    term.c_lflag |= ICANON | ISIG;
+    term.c_lflag &= static_cast<tcflag_t>(~ECHO);
+    ASSERT_EQ(0, tcsetattr(pair.slave.get(), TCSANOW, &term)) << strerror(errno);
+    SetNonblock(pair.slave.get());
+
+    const char input[] = {'o', 'l', 'd', '\003', 'a', 'f', 't', 'e', 'r', '\n'};
+    ASSERT_TRUE(WriteAll(pair.master.get(), input, sizeof(input)));
+
+    char buf[32] = {};
+    ASSERT_EQ(6, read(pair.slave.get(), buf, sizeof(buf))) << strerror(errno);
+    EXPECT_EQ(0, memcmp(buf, "after\n", 6));
+}
+
+TEST(CubeSandboxPtyExecChain, TciflushDropsOldInputAndAcceptsNewInput) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    SetRawByteMode(pair.slave.get());
+    SetNonblock(pair.slave.get());
+
+    ASSERT_TRUE(WriteAll(pair.master.get(), "old-data", strlen("old-data")));
+    ASSERT_EQ(0, tcflush(pair.slave.get(), TCIFLUSH)) << strerror(errno);
+
+    char buf[16] = {};
+    errno = 0;
+    EXPECT_EQ(-1, read(pair.slave.get(), buf, sizeof(buf)));
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+
+    ASSERT_TRUE(WriteAll(pair.master.get(), "N", 1));
+    ASSERT_EQ(1, read(pair.slave.get(), buf, 1)) << strerror(errno);
+    EXPECT_EQ('N', buf[0]);
+}
+
+TEST(CubeSandboxPtyExecChain, WriterPolloutAfterPeerDrainsInput) {
+    PtyPair pair = OpenPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+    SetRawByteMode(pair.slave.get());
+    SetNonblock(pair.master.get());
+
+    std::array<char, 1024> chunk = {};
+    chunk.fill('x');
+    bool saturated = false;
+    for (int i = 0; i < 1024; ++i) {
+        ssize_t n = write(pair.master.get(), chunk.data(), chunk.size());
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            saturated = true;
+            break;
+        }
+        ASSERT_GT(n, 0) << strerror(errno);
+    }
+    ASSERT_TRUE(saturated) << "PTY master did not report a full output direction";
+
+    std::array<char, 4096> drain = {};
+    ASSERT_GT(read(pair.slave.get(), drain.data(), drain.size()), 0) << strerror(errno);
+
+    struct pollfd pfd = {
+        .fd = pair.master.get(),
+        .events = POLLOUT | POLLERR | POLLHUP,
+        .revents = 0,
+    };
+    ASSERT_EQ(1, poll(&pfd, 1, 1000)) << strerror(errno);
+    EXPECT_NE(0, pfd.revents & POLLOUT);
+}
+
 TEST(CubeSandboxPtyExecChain, ShellRunsLsThenUnameThroughControllingPty) {
     RunShellCommandSequence(ExecDefaultShellOnSlave, "default shell");
+}
+
+TEST(CubeSandboxPtyExecChain, ShellRunsPromptDrivenCommandsThroughControllingPty) {
+    RunPromptDrivenShellCommandSequence(ExecDefaultShellOnSlave, "default shell");
+}
+
+TEST(CubeSandboxPtyExecChain, ShellRunsPromptDrivenCommandsThroughPacketModePty) {
+    RunPromptDrivenShellCommandSequence(ExecDefaultShellOnSlave, "default shell packet mode", true);
 }
 
 TEST(CubeSandboxPtyExecChain, ShellRepeatedlyRunsLsThenUnameThroughControllingPty) {
@@ -1633,6 +2329,13 @@ TEST(CubeSandboxPtyExecChain, BusyBoxAshRunsLsThenUnameThroughControllingPty) {
     RunShellCommandSequence(ExecBusyBoxShellOnSlave, "busybox ash");
 }
 
+TEST(CubeSandboxPtyExecChain, BusyBoxAshRunsPromptDrivenCommandsThroughControllingPty) {
+    if (access("/bin/busybox", X_OK) != 0) {
+        GTEST_SKIP() << "/bin/busybox is not available on this host";
+    }
+    RunPromptDrivenShellCommandSequence(ExecBusyBoxShellOnSlave, "busybox ash");
+}
+
 TEST(CubeSandboxPtyExecChain, MockShimForwardsClientInputAndCollectsExecOutput) {
     RunCubeShimLikeExecChain(ExecDefaultShellOnSlave, "default shell");
 }
@@ -1643,6 +2346,17 @@ TEST(CubeSandboxPtyExecChain, MockShimConcurrentForwardersPublishExecProgress) {
 
 TEST(CubeSandboxPtyExecChain, MockShimByteStreamInputCommandsReachShell) {
     RunCubeShimLikeByteStreamInput(ExecDefaultShellOnSlave, "default shell");
+}
+
+TEST(CubeSandboxPtyExecChain, MockShimPromptDrivenEpollEtCommandsReachShell) {
+    RunCubeShimLikePromptDrivenEpollEt(ExecDefaultShellOnSlave, "default shell");
+}
+
+TEST(CubeSandboxPtyExecChain, BusyBoxAshPromptDrivenEpollEtCommandsReachShell) {
+    if (access("/bin/busybox", X_OK) != 0) {
+        GTEST_SKIP() << "/bin/busybox is not available on this host";
+    }
+    RunCubeShimLikePromptDrivenEpollEt(ExecBusyBoxShellOnSlave, "busybox ash");
 }
 
 }  // namespace


### PR DESCRIPTION
Rework the PTY flush buffer flow with begin_flush_from/finish_flush_from
to match Linux semantics. Add tty_vhangup for proper terminal hangup
handling. Fix epoll event notifications to include EPOLLPRI and
EPOLLRDNORM where appropriate.

Also includes:
- Add wait_event_interruptible_timeout to EventWaitQueue
- Mark PosixTermios as #[repr(C)]
- Add receive_room to TtyLineDiscipline trait
- Strip O_APPEND in overlayfs backing_open_flags
- Use copy_one_to_user_checked in sys_uname
- Add clocksource watchdog long-interval detection
- Extend PTY exec chain tests

Refs: #1946