### PR TITLE
feat(virtiofs): add benchmark instrumentation

### DIFF
--- a/docs/kernel/filesystem/index.rst
+++ b/docs/kernel/filesystem/index.rst
@@ -11,6 +11,7 @@ todo: 由于文件系统模块重构，文档暂时不可用，预计在2023年4
 
    overview
    fuse
+   virtiofs_benchmark_runbook
    vfs/index
    proc/index
    sysfs

--- a/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -1,0 +1,155 @@
+# Virtiofs 基准测试运行手册
+
+`virtiofs_bench` 是用于 DragonOS virtiofs 性能分析的客户机侧基准测试工具。它由 `user/apps/virtiofs_bench` 下的 DADK app 安装到 `/bin/virtiofs_bench`。
+
+默认情况下，基准测试会把 virtiofs tag `hostshare` 挂载到 `/tmp/virtiofs_bench_mount_<pid>`，运行指定 workload，然后自动卸载并删除临时目录。只有在需要测试一个已经挂载好的 virtiofs 目录时，才使用 `--mount PATH`。
+
+## 构建
+
+在 DragonOS 仓库根目录执行：
+
+```sh
+make user
+SKIP_GRUB=1 make write_diskimage
+```
+
+快速做一次宿主机编译检查：
+
+```sh
+make -C user/apps/virtiofs_bench clean all
+make -C user/apps/virtiofs_bench clean
+```
+
+## 启动 Virtiofs
+
+创建本地环境配置文件：
+
+```sh
+cp tools/virtiofs/env.sh.example tools/virtiofs/env.sh
+```
+
+默认共享目录是：
+
+```text
+bin/virtiofs-share
+```
+
+准备 virtiofs smoke test 需要的文件：
+
+```sh
+mkdir -p bin/virtiofs-share
+printf 'virtiofs-host-file\n' > bin/virtiofs-share/hello.txt
+cp /bin/busybox bin/virtiofs-share/busybox
+chmod 755 bin/virtiofs-share/busybox
+```
+
+启动后端和客户机：
+
+```sh
+make virtiofsd
+make qemu-virtiofs-nographic AUTO_TEST=none
+```
+
+这两个命令需要在两个终端分别运行。QEMU 命令会暴露 tag `hostshare`。
+
+## 在 DragonOS 中运行
+
+进入 DragonOS 后，先挂载 debugfs：
+
+```sh
+mkdir -p /tmp/dbg
+mount -t debugfs debugfs /tmp/dbg
+```
+
+默认完整运行：
+
+```sh
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench
+mount | grep virtiofs || echo no_virtiofs_mount
+```
+
+小规模 smoke 运行：
+
+```sh
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --workload metadata --files 2
+
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --workload sequential --file-size 65536
+```
+
+显式指定完整参数：
+
+```sh
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --tag hostshare --workload all \
+  --files 256 --file-size 4194304 --block-size 4096 \
+  --iterations 4096 --workers 4
+```
+
+在已有挂载点上运行：
+
+```sh
+mkdir -p /tmp/host
+mount -t virtiofs hostshare /tmp/host
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --mount /tmp/host --workload all
+```
+
+使用 `--mount PATH` 时，基准测试不会卸载 `PATH`。
+
+## 在 Linux 中运行
+
+对照测试时，DragonOS 和 Linux 应使用相同的宿主机、`virtiofsd`、共享目录、缓存策略和基准测试参数。
+
+```sh
+mkdir -p /mnt/hostshare
+mount -t virtiofs hostshare /mnt/hostshare
+c++ -O2 -std=c++17 -pthread virtiofs_bench.cc -o virtiofs_bench
+./virtiofs_bench --mount /mnt/hostshare --workload all \
+  --files 256 --file-size 4194304 --block-size 4096 \
+  --iterations 4096 --workers 4
+```
+
+## 输出
+
+每个 workload 会输出一行 `result`：
+
+```text
+result workload=... status=ok errno=0 elapsed_us=... bytes=... ops=... mount=...
+```
+
+在 DragonOS 中设置 `VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats` 后，还会输出：
+
+```text
+stats_delta workload=... key=virtiofs.bridge_submitted_total delta=...
+stats_delta workload=... key=virtiofs.bridge_completed_total delta=...
+stats_delta workload=... key=virtiofs.bytes_completed_total delta=...
+```
+
+优先关注这些计数器：
+
+```text
+virtiofs.bridge_submitted_total
+virtiofs.bridge_completed_total
+virtiofs.bytes_submitted_total
+virtiofs.bytes_completed_total
+virtiofs.bridge_poll_sleep_ns_total
+virtiofs.response_buffer_waste_bytes
+virtiofs.virtqueue_full_total
+```
+
+## 对比结果
+
+对比 DragonOS 和 Linux 时，应保持这些条件一致：
+
+- 宿主机
+- QEMU CPU 和内存配置
+- `virtiofsd` 二进制及其参数
+- `bin/virtiofs-share` 所在的宿主机文件系统
+- workload 参数
+- 冷缓存或热缓存策略
+
+不要把缓存读结果当成 virtqueue 吞吐量。如果 DragonOS 的请求数或字节计数器没有在读取 workload 中增加，那么结果主要测到的是客户机页缓存。
+
+不要对 `.` 或其他 rootfs 目录做 virtiofs 基准测试。应使用默认的自动挂载，或通过 `--mount` 传入明确的 virtiofs 挂载点。

--- a/docs/locales/en/kernel/filesystem/index.rst
+++ b/docs/locales/en/kernel/filesystem/index.rst
@@ -24,6 +24,7 @@ todo: Due to the file system module reconstruction, the documentation is tempora
 
    overview
    fuse
+   virtiofs_benchmark_runbook
    vfs/index
    proc/index
    sysfs

--- a/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -1,0 +1,155 @@
+# Virtiofs Benchmark Runbook
+
+`virtiofs_bench` is a guest-side benchmark for DragonOS virtiofs performance work. It is installed at `/bin/virtiofs_bench` by the DADK app in `user/apps/virtiofs_bench`.
+
+By default, the benchmark mounts virtiofs tag `hostshare` on `/tmp/virtiofs_bench_mount_<pid>`, runs the workload, then unmounts and removes the temporary directory. Use `--mount PATH` only when you want to benchmark an already mounted virtiofs directory.
+
+## Build
+
+From the DragonOS repository root:
+
+```sh
+make user
+SKIP_GRUB=1 make write_diskimage
+```
+
+Quick host compile check:
+
+```sh
+make -C user/apps/virtiofs_bench clean all
+make -C user/apps/virtiofs_bench clean
+```
+
+## Start Virtiofs
+
+Create the local environment file:
+
+```sh
+cp tools/virtiofs/env.sh.example tools/virtiofs/env.sh
+```
+
+The default shared directory is:
+
+```text
+bin/virtiofs-share
+```
+
+Prepare the smoke-test files:
+
+```sh
+mkdir -p bin/virtiofs-share
+printf 'virtiofs-host-file\n' > bin/virtiofs-share/hello.txt
+cp /bin/busybox bin/virtiofs-share/busybox
+chmod 755 bin/virtiofs-share/busybox
+```
+
+Start the backend and guest:
+
+```sh
+make virtiofsd
+make qemu-virtiofs-nographic AUTO_TEST=none
+```
+
+Run the two commands in separate terminals. The QEMU command exposes tag `hostshare`.
+
+## Run On DragonOS
+
+Inside DragonOS:
+
+```sh
+mkdir -p /tmp/dbg
+mount -t debugfs debugfs /tmp/dbg
+```
+
+Default full run:
+
+```sh
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench
+mount | grep virtiofs || echo no_virtiofs_mount
+```
+
+Small smoke run:
+
+```sh
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --workload metadata --files 2
+
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --workload sequential --file-size 65536
+```
+
+Explicit full run:
+
+```sh
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --tag hostshare --workload all \
+  --files 256 --file-size 4194304 --block-size 4096 \
+  --iterations 4096 --workers 4
+```
+
+Run on an existing mount:
+
+```sh
+mkdir -p /tmp/host
+mount -t virtiofs hostshare /tmp/host
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats \
+/bin/virtiofs_bench --mount /tmp/host --workload all
+```
+
+When `--mount PATH` is used, the benchmark does not unmount `PATH`.
+
+## Run On Linux
+
+Use the same host, `virtiofsd`, shared directory, cache policy, and benchmark parameters.
+
+```sh
+mkdir -p /mnt/hostshare
+mount -t virtiofs hostshare /mnt/hostshare
+c++ -O2 -std=c++17 -pthread virtiofs_bench.cc -o virtiofs_bench
+./virtiofs_bench --mount /mnt/hostshare --workload all \
+  --files 256 --file-size 4194304 --block-size 4096 \
+  --iterations 4096 --workers 4
+```
+
+## Output
+
+Each workload prints one `result` line:
+
+```text
+result workload=... status=ok errno=0 elapsed_us=... bytes=... ops=... mount=...
+```
+
+On DragonOS, set `VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats` to also print:
+
+```text
+stats_delta workload=... key=virtiofs.bridge_submitted_total delta=...
+stats_delta workload=... key=virtiofs.bridge_completed_total delta=...
+stats_delta workload=... key=virtiofs.bytes_completed_total delta=...
+```
+
+Counters to watch first:
+
+```text
+virtiofs.bridge_submitted_total
+virtiofs.bridge_completed_total
+virtiofs.bytes_submitted_total
+virtiofs.bytes_completed_total
+virtiofs.bridge_poll_sleep_ns_total
+virtiofs.response_buffer_waste_bytes
+virtiofs.virtqueue_full_total
+```
+
+## Compare Results
+
+Keep these identical between DragonOS and Linux:
+
+- host machine
+- QEMU CPU and memory
+- `virtiofsd` binary and options
+- backing filesystem for `bin/virtiofs-share`
+- workload parameters
+- cold or warm cache policy
+
+Do not treat cached reads as virtqueue throughput. If DragonOS request or byte counters do not increase during a read workload, the result is mostly guest page cache.
+
+Do not benchmark `.` or another rootfs directory. Use the default automatic mount or pass an explicit virtiofs mount with `--mount`.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ sphinx==5.0.2
 myst-parser==0.18.0
 sphinx-rtd-theme
 sphinxcontrib-mermaid==1.0.0
-git+https://github.com/DragonOS-Community/sphinx-multiversion.git@5858b75#egg=sphinx-multiversion
+git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/sphinx-multiversion.git@5858b75#egg=sphinx-multiversion
 openai~=1.79
 tqdm~=4.65.0
 linkify-it-py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ sphinx==5.0.2
 myst-parser==0.18.0
 sphinx-rtd-theme
 sphinxcontrib-mermaid==1.0.0
-git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/sphinx-multiversion.git@5858b75#egg=sphinx-multiversion
+git+https://github.com/DragonOS-Community/sphinx-multiversion.git@5858b75#egg=sphinx-multiversion
 openai~=1.79
 tqdm~=4.65.0
 linkify-it-py

--- a/kernel/src/debug/fuse.rs
+++ b/kernel/src/debug/fuse.rs
@@ -1,0 +1,104 @@
+use alloc::string::ToString;
+
+use crate::debug::sysfs::debugfs_kobj;
+use crate::driver::base::kobject::KObject;
+use crate::filesystem::kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData};
+use crate::filesystem::vfs::{InodeMode, PollStatus};
+use system_error::SystemError;
+
+#[derive(Debug)]
+struct FuseStatsDirCallBack;
+
+impl KernFSCallback for FuseStatsDirCallBack {
+    fn open(&self, _data: KernCallbackData) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        _data: KernCallbackData,
+        _buf: &mut [u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EISDIR)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EISDIR)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Err(SystemError::EISDIR)
+    }
+}
+
+#[derive(Debug)]
+struct FuseStatsCallBack;
+
+impl KernFSCallback for FuseStatsCallBack {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        let report = crate::filesystem::fuse::stats::format_snapshot();
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(report));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+pub fn init_debugfs_fuse() -> Result<(), SystemError> {
+    let debugfs = debugfs_kobj();
+    let root_dir = debugfs.inode().ok_or(SystemError::ENOENT)?;
+    let fuse_root = root_dir.add_dir(
+        "fuse".to_string(),
+        InodeMode::from_bits_truncate(0o555),
+        None,
+        Some(&FuseStatsDirCallBack),
+    )?;
+
+    fuse_root.add_file(
+        "stats".to_string(),
+        InodeMode::S_IRUSR,
+        Some(4096),
+        None,
+        Some(&FuseStatsCallBack),
+    )?;
+
+    Ok(())
+}

--- a/kernel/src/debug/mod.rs
+++ b/kernel/src/debug/mod.rs
@@ -1,4 +1,5 @@
 pub mod errseq;
+pub mod fuse;
 pub mod jump_label;
 pub mod klog;
 pub mod kprobe;

--- a/kernel/src/debug/sysfs/mod.rs
+++ b/kernel/src/debug/sysfs/mod.rs
@@ -23,6 +23,7 @@ fn debugfs_init() -> Result<(), SystemError> {
     super::tracing::init_debugfs_tracing()?;
     super::rcu::init_debugfs_rcu()?;
     super::errseq::init_debugfs_errseq()?;
+    super::fuse::init_debugfs_fuse()?;
     return Ok(());
 }
 

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -32,6 +32,7 @@ use super::protocol::{
     FUSE_NO_OPENDIR_SUPPORT, FUSE_NO_OPEN_SUPPORT, FUSE_PARALLEL_DIROPS, FUSE_POSIX_ACL,
     FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO, FUSE_REMOVEXATTR, FUSE_SETXATTR, FUSE_SUBMOUNTS,
 };
+use super::{stats, trace};
 
 fn wait_with_recheck<T, F>(waitq: &WaitQueue, mut check: F) -> Result<T, SystemError>
 where
@@ -60,6 +61,7 @@ where
 #[derive(Debug)]
 pub struct FuseRequest {
     pub bytes: Vec<u8>,
+    unique: u64,
     opcode: u32,
 }
 
@@ -459,15 +461,21 @@ impl FuseConn {
     }
 
     pub fn abort(&self) {
-        let processing: Vec<Arc<FusePendingState>> = {
+        let (processing, pending_noreply_count): (Vec<Arc<FusePendingState>>, usize) = {
             let mut g = self.inner.lock();
             g.connected = false;
             g.mounted = false;
+            let pending_noreply_count = g
+                .pending
+                .iter()
+                .filter(|req| matches!(req.opcode, FUSE_FORGET | FUSE_DESTROY | FUSE_INTERRUPT))
+                .count();
             g.pending.clear();
             let processing = g.processing.values().cloned().collect();
             g.processing.clear();
-            processing
+            (processing, pending_noreply_count)
         };
+        stats::on_fuse_requests_aborted(processing.len() + pending_noreply_count);
         for p in processing {
             p.complete(Err(SystemError::ENOTCONN));
         }
@@ -485,7 +493,9 @@ impl FuseConn {
     /// happens when /dev/fuse is closed or explicit abort path is triggered.
     pub fn on_umount(&self) {
         let processing: Vec<Arc<FusePendingState>>;
+        let dropped_processing: Vec<Arc<FusePendingState>>;
         let should_destroy: bool;
+        let dropped_pending: usize;
         {
             let mut g = self.inner.lock();
             should_destroy = g.connected && g.initialized;
@@ -495,12 +505,34 @@ impl FuseConn {
             // requests so the daemon can release lookup references before
             // it receives DESTROY; drop ordinary requests that can no longer
             // complete after unmount.
+            let mut dropped_noreply = 0usize;
+            let mut dropped_reply_unique = Vec::new();
+            for req in g.pending.iter() {
+                if req.opcode == FUSE_FORGET {
+                    continue;
+                }
+                if matches!(req.opcode, FUSE_DESTROY | FUSE_INTERRUPT) {
+                    dropped_noreply += 1;
+                } else if g.processing.contains_key(&req.unique) {
+                    dropped_reply_unique.push(req.unique);
+                }
+            }
             g.pending.retain(|req| req.opcode == FUSE_FORGET);
+            dropped_processing = dropped_reply_unique
+                .into_iter()
+                .filter_map(|unique| g.processing.remove(&unique))
+                .collect();
+            dropped_pending = dropped_noreply + dropped_processing.len();
             processing = g.processing.values().cloned().collect();
             g.processing.clear();
         }
 
+        stats::on_fuse_requests_dropped_umount(dropped_pending);
+        stats::on_fuse_requests_aborted(processing.len());
         for p in processing {
+            p.complete(Err(SystemError::ENOTCONN));
+        }
+        for p in dropped_processing {
             p.complete(Err(SystemError::ENOTCONN));
         }
         self.init_wait.wakeup(None);
@@ -667,33 +699,55 @@ impl FuseConn {
             return Err(SystemError::EINVAL);
         }
 
-        // Linux: if O_NONBLOCK and no pending request, return EAGAIN.
-        let req = if nonblock {
-            self.pop_pending_nonblock()?
-        } else {
-            self.pop_pending_blocking()?
-        };
+        let req = loop {
+            // Linux: if O_NONBLOCK and no pending request, return EAGAIN.
+            let req = if nonblock {
+                self.pop_pending_nonblock()?
+            } else {
+                self.pop_pending_blocking()?
+            };
 
-        if out.len() < req.bytes.len() {
-            // Put it back and report EINVAL: userspace must provide a sufficiently large buffer.
-            let req_len = req.bytes.len();
-            let mut g = self.inner.lock();
-            if g.connected {
-                g.pending.push_front(req);
+            if out.len() >= req.bytes.len() {
+                break req;
             }
+
+            self.fail_oversized_read_request(&req);
             log::warn!(
                 "fuse: read buffer smaller than queued request: got={} need={}",
                 out.len(),
-                req_len
+                req.bytes.len()
             );
-            return Err(SystemError::EINVAL);
-        }
+        };
 
         out[..req.bytes.len()].copy_from_slice(&req.bytes);
+        stats::on_fuse_request_dequeued(req.bytes.len());
+        trace::trace_fuse_request_dequeue(req.unique, req.opcode, req.bytes.len() as u64);
         if req.opcode == FUSE_DESTROY {
             self.abort();
         }
         Ok(req.bytes.len())
+    }
+
+    fn fail_oversized_read_request(&self, req: &FuseRequest) {
+        stats::on_fuse_read_buffer_too_small();
+        let err = if req.opcode == FUSE_SETXATTR {
+            SystemError::E2BIG
+        } else {
+            SystemError::EIO
+        };
+        let pending = {
+            let mut g = self.inner.lock();
+            g.processing.remove(&req.unique)
+        };
+
+        if let Some(pending) = pending {
+            let error = -err.to_posix_errno();
+            stats::on_fuse_reply_complete(error, 0);
+            trace::trace_fuse_reply_complete(req.unique, req.opcode, error, 0);
+            pending.complete(Err(err));
+        } else {
+            stats::on_fuse_requests_aborted(1);
+        }
     }
 
     fn kernel_init_flags() -> u64 {
@@ -906,7 +960,11 @@ impl FuseConn {
         let mut bytes = Vec::with_capacity(hdr.len as usize);
         bytes.extend_from_slice(fuse_pack_struct(&hdr));
         bytes.extend_from_slice(payload);
-        Arc::new(FuseRequest { bytes, opcode })
+        Arc::new(FuseRequest {
+            bytes,
+            unique,
+            opcode,
+        })
     }
 
     fn push_request(
@@ -915,6 +973,9 @@ impl FuseConn {
         pending_state: Option<Arc<FusePendingState>>,
         unique: u64,
     ) -> Result<(), SystemError> {
+        let req_len = req.bytes.len();
+        let opcode = req.opcode;
+        let no_reply = pending_state.is_none();
         {
             let mut g = self.inner.lock();
             if !g.connected {
@@ -926,6 +987,8 @@ impl FuseConn {
             }
         }
 
+        stats::on_fuse_request_queued(req_len, no_reply);
+        trace::trace_fuse_request_queue(unique, opcode, req_len as u64, no_reply as u8);
         self.read_wait.wakeup(None);
         let _ = EventPoll::wakeup_epoll(
             &self.epitems,
@@ -952,6 +1015,13 @@ impl FuseConn {
 
         if (out_hdr.unique & Self::FUSE_INT_REQ_BIT) != 0 {
             return self.write_interrupt_reply(&out_hdr, data.len());
+        }
+
+        if out_hdr.error <= -512 || out_hdr.error > 0 {
+            return Err(SystemError::EINVAL);
+        }
+        if out_hdr.error != 0 && data.len() != core::mem::size_of::<FuseOutHeader>() {
+            return Err(SystemError::EINVAL);
         }
 
         let pending = {
@@ -987,6 +1057,13 @@ impl FuseConn {
                 );
             }
             pending.complete(Err(e));
+            stats::on_fuse_reply_complete(error, payload.len());
+            trace::trace_fuse_reply_complete(
+                out_hdr.unique,
+                pending.opcode,
+                error,
+                payload.len() as u64,
+            );
             if pending.opcode == FUSE_INIT {
                 self.abort();
             }
@@ -997,6 +1074,14 @@ impl FuseConn {
             let init_out: FuseInitOut = match fuse_read_struct(payload) {
                 Ok(v) => v,
                 Err(e) => {
+                    let error = -e.to_posix_errno();
+                    stats::on_fuse_reply_complete(error, payload.len());
+                    trace::trace_fuse_reply_complete(
+                        out_hdr.unique,
+                        pending.opcode,
+                        error,
+                        payload.len() as u64,
+                    );
                     pending.complete(Err(e));
                     self.abort();
                     return Ok(data.len());
@@ -1004,6 +1089,14 @@ impl FuseConn {
             };
 
             if init_out.major != FUSE_KERNEL_VERSION {
+                let error = -SystemError::EINVAL.to_posix_errno();
+                stats::on_fuse_reply_complete(error, payload.len());
+                trace::trace_fuse_reply_complete(
+                    out_hdr.unique,
+                    pending.opcode,
+                    error,
+                    payload.len() as u64,
+                );
                 pending.complete(Err(SystemError::EINVAL));
                 self.abort();
                 return Ok(data.len());
@@ -1055,6 +1148,8 @@ impl FuseConn {
             self.init_wait.wakeup(None);
         }
 
+        stats::on_fuse_reply_complete(0, payload.len());
+        trace::trace_fuse_reply_complete(out_hdr.unique, pending.opcode, 0, payload.len() as u64);
         pending.complete(Ok(payload.to_vec()));
         Ok(data.len())
     }

--- a/kernel/src/filesystem/fuse/mod.rs
+++ b/kernel/src/filesystem/fuse/mod.rs
@@ -4,4 +4,6 @@ pub mod fs;
 pub mod inode;
 pub mod private_data;
 pub mod protocol;
+pub mod stats;
+pub mod trace;
 pub mod virtiofs;

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -1,0 +1,380 @@
+use alloc::{format, string::String};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+const BATCH_BUCKETS: usize = 5;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FuseStatsSnapshot {
+    pub requests_queued_total: u64,
+    pub requests_dequeued_total: u64,
+    pub requests_replied_ok_total: u64,
+    pub requests_replied_err_total: u64,
+    pub requests_aborted_total: u64,
+    pub requests_dropped_umount_total: u64,
+    pub noreply_queued_total: u64,
+    pub read_buffer_too_small_total: u64,
+    pub bytes_request_to_dev_total: u64,
+    pub bytes_reply_payload_cloned_total: u64,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct VirtioFsStatsSnapshot {
+    pub bridge_loop_iterations_total: u64,
+    pub bridge_progress_iterations_total: u64,
+    pub bridge_idle_sleeps_total: u64,
+    pub bridge_poll_sleep_ns_total: u64,
+    pub bridge_ack_interrupt_total: u64,
+    pub bridge_pumped_requests_total: u64,
+    pub bridge_submitted_total: u64,
+    pub bridge_completed_total: u64,
+    pub bridge_noreply_completed_total: u64,
+    pub bridge_fail_unfinished_total: u64,
+    pub virtqueue_full_total: u64,
+    pub virtqueue_not_ready_total: u64,
+    pub submit_error_total: u64,
+    pub pop_used_error_total: u64,
+    pub bridge_request_clone_count: u64,
+    pub bridge_request_clone_bytes: u64,
+    pub response_buffer_alloc_count: u64,
+    pub response_buffer_alloc_bytes: u64,
+    pub response_buffer_waste_bytes: u64,
+    pub bytes_submitted_total: u64,
+    pub bytes_completed_total: u64,
+    pub pump_batch: [u64; BATCH_BUCKETS],
+    pub complete_batch: [u64; BATCH_BUCKETS],
+}
+
+static REQUESTS_QUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REQUESTS_DEQUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REQUESTS_REPLIED_OK_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REQUESTS_REPLIED_ERR_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REQUESTS_ABORTED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REQUESTS_DROPPED_UMOUNT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static NOREPLY_QUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static READ_BUFFER_TOO_SMALL_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BYTES_REQUEST_TO_DEV_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BYTES_REPLY_PAYLOAD_CLONED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+static BRIDGE_LOOP_ITERATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_PROGRESS_ITERATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_IDLE_SLEEPS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_POLL_SLEEP_NS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_ACK_INTERRUPT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_PUMPED_REQUESTS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_SUBMITTED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_COMPLETED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_NOREPLY_COMPLETED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_FAIL_UNFINISHED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static VIRTQUEUE_FULL_TOTAL: AtomicU64 = AtomicU64::new(0);
+static VIRTQUEUE_NOT_READY_TOTAL: AtomicU64 = AtomicU64::new(0);
+static SUBMIT_ERROR_TOTAL: AtomicU64 = AtomicU64::new(0);
+static POP_USED_ERROR_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_REQUEST_CLONE_COUNT: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_REQUEST_CLONE_BYTES: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_BUFFER_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_BUFFER_ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_BUFFER_WASTE_BYTES: AtomicU64 = AtomicU64::new(0);
+static BYTES_SUBMITTED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BYTES_COMPLETED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+static PUMP_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
+static COMPLETE_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
+
+#[inline]
+fn add(counter: &AtomicU64, value: u64) {
+    counter.fetch_add(value, Ordering::Relaxed);
+}
+
+#[inline]
+fn inc(counter: &AtomicU64) {
+    add(counter, 1);
+}
+
+#[inline]
+fn batch_bucket(count: usize) -> usize {
+    match count {
+        0 => 0,
+        1 => 1,
+        2..=4 => 2,
+        5..=16 => 3,
+        _ => 4,
+    }
+}
+
+#[inline]
+fn record_batch(buckets: &[AtomicU64; BATCH_BUCKETS], count: usize) {
+    inc(&buckets[batch_bucket(count)]);
+}
+
+fn snapshot_batch(buckets: &[AtomicU64; BATCH_BUCKETS]) -> [u64; BATCH_BUCKETS] {
+    [
+        buckets[0].load(Ordering::Relaxed),
+        buckets[1].load(Ordering::Relaxed),
+        buckets[2].load(Ordering::Relaxed),
+        buckets[3].load(Ordering::Relaxed),
+        buckets[4].load(Ordering::Relaxed),
+    ]
+}
+
+#[inline]
+pub fn on_fuse_request_queued(_len: usize, no_reply: bool) {
+    inc(&REQUESTS_QUEUED_TOTAL);
+    if no_reply {
+        inc(&NOREPLY_QUEUED_TOTAL);
+    }
+}
+
+#[inline]
+pub fn on_fuse_request_dequeued(len: usize) {
+    inc(&REQUESTS_DEQUEUED_TOTAL);
+    add(&BYTES_REQUEST_TO_DEV_TOTAL, len as u64);
+}
+
+#[inline]
+pub fn on_fuse_read_buffer_too_small() {
+    inc(&READ_BUFFER_TOO_SMALL_TOTAL);
+}
+
+#[inline]
+pub fn on_fuse_reply_complete(error: i32, payload_len: usize) {
+    if error == 0 {
+        inc(&REQUESTS_REPLIED_OK_TOTAL);
+        add(&BYTES_REPLY_PAYLOAD_CLONED_TOTAL, payload_len as u64);
+    } else {
+        inc(&REQUESTS_REPLIED_ERR_TOTAL);
+    }
+}
+
+#[inline]
+pub fn on_fuse_requests_aborted(count: usize) {
+    add(&REQUESTS_ABORTED_TOTAL, count as u64);
+}
+
+#[inline]
+pub fn on_fuse_requests_dropped_umount(count: usize) {
+    add(&REQUESTS_DROPPED_UMOUNT_TOTAL, count as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_loop_iteration(progressed: bool) {
+    inc(&BRIDGE_LOOP_ITERATIONS_TOTAL);
+    if progressed {
+        inc(&BRIDGE_PROGRESS_ITERATIONS_TOTAL);
+    }
+}
+
+#[inline]
+pub fn on_virtiofs_idle_sleep(ns: i64) {
+    inc(&BRIDGE_IDLE_SLEEPS_TOTAL);
+    if ns > 0 {
+        add(&BRIDGE_POLL_SLEEP_NS_TOTAL, ns as u64);
+    }
+}
+
+#[inline]
+pub fn on_virtiofs_ack_interrupt() {
+    inc(&BRIDGE_ACK_INTERRUPT_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_pump_batch(count: usize) {
+    add(&BRIDGE_PUMPED_REQUESTS_TOTAL, count as u64);
+    record_batch(&PUMP_BATCH, count);
+}
+
+#[inline]
+pub fn on_virtiofs_complete_batch(count: usize) {
+    record_batch(&COMPLETE_BATCH, count);
+}
+
+#[inline]
+pub fn on_virtiofs_request_cloned(len: usize) {
+    inc(&BRIDGE_REQUEST_CLONE_COUNT);
+    add(&BRIDGE_REQUEST_CLONE_BYTES, len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_response_buffer_alloc(len: usize) {
+    inc(&RESPONSE_BUFFER_ALLOC_COUNT);
+    add(&RESPONSE_BUFFER_ALLOC_BYTES, len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_response_buffer_waste(len: usize) {
+    add(&RESPONSE_BUFFER_WASTE_BYTES, len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_submitted(req_len: usize) {
+    inc(&BRIDGE_SUBMITTED_TOTAL);
+    add(&BYTES_SUBMITTED_TOTAL, req_len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_queue_full() {
+    inc(&VIRTQUEUE_FULL_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_not_ready() {
+    inc(&VIRTQUEUE_NOT_READY_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_submit_error() {
+    inc(&SUBMIT_ERROR_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_pop_used_error() {
+    inc(&POP_USED_ERROR_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_completed(used_len: usize, noreply: bool) {
+    inc(&BRIDGE_COMPLETED_TOTAL);
+    if noreply {
+        inc(&BRIDGE_NOREPLY_COMPLETED_TOTAL);
+    }
+    add(&BYTES_COMPLETED_TOTAL, used_len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_fail_unfinished(count: usize) {
+    add(&BRIDGE_FAIL_UNFINISHED_TOTAL, count as u64);
+}
+
+pub fn fuse_snapshot() -> FuseStatsSnapshot {
+    FuseStatsSnapshot {
+        requests_queued_total: REQUESTS_QUEUED_TOTAL.load(Ordering::Relaxed),
+        requests_dequeued_total: REQUESTS_DEQUEUED_TOTAL.load(Ordering::Relaxed),
+        requests_replied_ok_total: REQUESTS_REPLIED_OK_TOTAL.load(Ordering::Relaxed),
+        requests_replied_err_total: REQUESTS_REPLIED_ERR_TOTAL.load(Ordering::Relaxed),
+        requests_aborted_total: REQUESTS_ABORTED_TOTAL.load(Ordering::Relaxed),
+        requests_dropped_umount_total: REQUESTS_DROPPED_UMOUNT_TOTAL.load(Ordering::Relaxed),
+        noreply_queued_total: NOREPLY_QUEUED_TOTAL.load(Ordering::Relaxed),
+        read_buffer_too_small_total: READ_BUFFER_TOO_SMALL_TOTAL.load(Ordering::Relaxed),
+        bytes_request_to_dev_total: BYTES_REQUEST_TO_DEV_TOTAL.load(Ordering::Relaxed),
+        bytes_reply_payload_cloned_total: BYTES_REPLY_PAYLOAD_CLONED_TOTAL.load(Ordering::Relaxed),
+    }
+}
+
+pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
+    VirtioFsStatsSnapshot {
+        bridge_loop_iterations_total: BRIDGE_LOOP_ITERATIONS_TOTAL.load(Ordering::Relaxed),
+        bridge_progress_iterations_total: BRIDGE_PROGRESS_ITERATIONS_TOTAL.load(Ordering::Relaxed),
+        bridge_idle_sleeps_total: BRIDGE_IDLE_SLEEPS_TOTAL.load(Ordering::Relaxed),
+        bridge_poll_sleep_ns_total: BRIDGE_POLL_SLEEP_NS_TOTAL.load(Ordering::Relaxed),
+        bridge_ack_interrupt_total: BRIDGE_ACK_INTERRUPT_TOTAL.load(Ordering::Relaxed),
+        bridge_pumped_requests_total: BRIDGE_PUMPED_REQUESTS_TOTAL.load(Ordering::Relaxed),
+        bridge_submitted_total: BRIDGE_SUBMITTED_TOTAL.load(Ordering::Relaxed),
+        bridge_completed_total: BRIDGE_COMPLETED_TOTAL.load(Ordering::Relaxed),
+        bridge_noreply_completed_total: BRIDGE_NOREPLY_COMPLETED_TOTAL.load(Ordering::Relaxed),
+        bridge_fail_unfinished_total: BRIDGE_FAIL_UNFINISHED_TOTAL.load(Ordering::Relaxed),
+        virtqueue_full_total: VIRTQUEUE_FULL_TOTAL.load(Ordering::Relaxed),
+        virtqueue_not_ready_total: VIRTQUEUE_NOT_READY_TOTAL.load(Ordering::Relaxed),
+        submit_error_total: SUBMIT_ERROR_TOTAL.load(Ordering::Relaxed),
+        pop_used_error_total: POP_USED_ERROR_TOTAL.load(Ordering::Relaxed),
+        bridge_request_clone_count: BRIDGE_REQUEST_CLONE_COUNT.load(Ordering::Relaxed),
+        bridge_request_clone_bytes: BRIDGE_REQUEST_CLONE_BYTES.load(Ordering::Relaxed),
+        response_buffer_alloc_count: RESPONSE_BUFFER_ALLOC_COUNT.load(Ordering::Relaxed),
+        response_buffer_alloc_bytes: RESPONSE_BUFFER_ALLOC_BYTES.load(Ordering::Relaxed),
+        response_buffer_waste_bytes: RESPONSE_BUFFER_WASTE_BYTES.load(Ordering::Relaxed),
+        bytes_submitted_total: BYTES_SUBMITTED_TOTAL.load(Ordering::Relaxed),
+        bytes_completed_total: BYTES_COMPLETED_TOTAL.load(Ordering::Relaxed),
+        pump_batch: snapshot_batch(&PUMP_BATCH),
+        complete_batch: snapshot_batch(&COMPLETE_BATCH),
+    }
+}
+
+pub fn format_snapshot() -> String {
+    let fuse = fuse_snapshot();
+    let virtiofs = virtiofs_snapshot();
+    format!(
+        "[fuse]\n\
+requests_queued_total {}\n\
+requests_dequeued_total {}\n\
+requests_replied_ok_total {}\n\
+requests_replied_err_total {}\n\
+requests_aborted_total {}\n\
+requests_dropped_umount_total {}\n\
+noreply_queued_total {}\n\
+read_buffer_too_small_total {}\n\
+bytes_request_to_dev_total {}\n\
+bytes_reply_payload_cloned_total {}\n\
+\n\
+[virtiofs]\n\
+bridge_loop_iterations_total {}\n\
+bridge_progress_iterations_total {}\n\
+bridge_idle_sleeps_total {}\n\
+bridge_poll_sleep_ns_total {}\n\
+bridge_ack_interrupt_total {}\n\
+bridge_pumped_requests_total {}\n\
+bridge_submitted_total {}\n\
+bridge_completed_total {}\n\
+bridge_noreply_completed_total {}\n\
+bridge_fail_unfinished_total {}\n\
+virtqueue_full_total {}\n\
+virtqueue_not_ready_total {}\n\
+submit_error_total {}\n\
+pop_used_error_total {}\n\
+bridge_request_clone_count {}\n\
+bridge_request_clone_bytes {}\n\
+response_buffer_alloc_count {}\n\
+response_buffer_alloc_bytes {}\n\
+response_buffer_waste_bytes {}\n\
+bytes_submitted_total {}\n\
+bytes_completed_total {}\n\
+pump_batch_0 {}\n\
+pump_batch_1 {}\n\
+pump_batch_2_4 {}\n\
+pump_batch_5_16 {}\n\
+pump_batch_gt_16 {}\n\
+complete_batch_0 {}\n\
+complete_batch_1 {}\n\
+complete_batch_2_4 {}\n\
+complete_batch_5_16 {}\n\
+complete_batch_gt_16 {}\n",
+        fuse.requests_queued_total,
+        fuse.requests_dequeued_total,
+        fuse.requests_replied_ok_total,
+        fuse.requests_replied_err_total,
+        fuse.requests_aborted_total,
+        fuse.requests_dropped_umount_total,
+        fuse.noreply_queued_total,
+        fuse.read_buffer_too_small_total,
+        fuse.bytes_request_to_dev_total,
+        fuse.bytes_reply_payload_cloned_total,
+        virtiofs.bridge_loop_iterations_total,
+        virtiofs.bridge_progress_iterations_total,
+        virtiofs.bridge_idle_sleeps_total,
+        virtiofs.bridge_poll_sleep_ns_total,
+        virtiofs.bridge_ack_interrupt_total,
+        virtiofs.bridge_pumped_requests_total,
+        virtiofs.bridge_submitted_total,
+        virtiofs.bridge_completed_total,
+        virtiofs.bridge_noreply_completed_total,
+        virtiofs.bridge_fail_unfinished_total,
+        virtiofs.virtqueue_full_total,
+        virtiofs.virtqueue_not_ready_total,
+        virtiofs.submit_error_total,
+        virtiofs.pop_used_error_total,
+        virtiofs.bridge_request_clone_count,
+        virtiofs.bridge_request_clone_bytes,
+        virtiofs.response_buffer_alloc_count,
+        virtiofs.response_buffer_alloc_bytes,
+        virtiofs.response_buffer_waste_bytes,
+        virtiofs.bytes_submitted_total,
+        virtiofs.bytes_completed_total,
+        virtiofs.pump_batch[0],
+        virtiofs.pump_batch[1],
+        virtiofs.pump_batch[2],
+        virtiofs.pump_batch[3],
+        virtiofs.pump_batch[4],
+        virtiofs.complete_batch[0],
+        virtiofs.complete_batch[1],
+        virtiofs.complete_batch[2],
+        virtiofs.complete_batch[3],
+        virtiofs.complete_batch[4],
+    )
+}

--- a/kernel/src/filesystem/fuse/trace.rs
+++ b/kernel/src/filesystem/fuse/trace.rs
@@ -1,0 +1,192 @@
+use alloc::format;
+
+use crate::define_event_trace;
+
+pub const VIRTIOFS_QUEUE_HIPRIO: u8 = 0;
+pub const VIRTIOFS_QUEUE_REQUEST: u8 = 1;
+
+pub const VIRTIOFS_RETRY_QUEUE_FULL: u8 = 1;
+pub const VIRTIOFS_RETRY_NOT_READY: u8 = 2;
+
+define_event_trace!(
+    fuse_request_queue,
+    TP_system(fuse),
+    TP_PROTO(unique: u64, opcode: u32, len: u64, no_reply: u8),
+    TP_STRUCT__entry {
+        unique: u64,
+        opcode: u32,
+        len: u64,
+        no_reply: u8,
+    },
+    TP_fast_assign {
+        unique: unique,
+        opcode: opcode,
+        len: len,
+        no_reply: no_reply,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let unique = __entry.unique;
+        let opcode = __entry.opcode;
+        let len = __entry.len;
+        let no_reply = __entry.no_reply;
+        format!(
+            "unique={} opcode={} len={} no_reply={}",
+            unique, opcode, len, no_reply
+        )
+    })
+);
+
+define_event_trace!(
+    fuse_request_dequeue,
+    TP_system(fuse),
+    TP_PROTO(unique: u64, opcode: u32, len: u64),
+    TP_STRUCT__entry {
+        unique: u64,
+        opcode: u32,
+        len: u64,
+    },
+    TP_fast_assign {
+        unique: unique,
+        opcode: opcode,
+        len: len,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let unique = __entry.unique;
+        let opcode = __entry.opcode;
+        let len = __entry.len;
+        format!("unique={} opcode={} len={}", unique, opcode, len)
+    })
+);
+
+define_event_trace!(
+    fuse_reply_complete,
+    TP_system(fuse),
+    TP_PROTO(unique: u64, opcode: u32, error: i32, payload_len: u64),
+    TP_STRUCT__entry {
+        unique: u64,
+        opcode: u32,
+        error: i32,
+        payload_len: u64,
+    },
+    TP_fast_assign {
+        unique: unique,
+        opcode: opcode,
+        error: error,
+        payload_len: payload_len,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let unique = __entry.unique;
+        let opcode = __entry.opcode;
+        let error = __entry.error;
+        let payload_len = __entry.payload_len;
+        format!(
+            "unique={} opcode={} error={} payload_len={}",
+            unique, opcode, error, payload_len
+        )
+    })
+);
+
+define_event_trace!(
+    virtiofs_submit,
+    TP_system(fuse),
+    TP_PROTO(unique: u64, opcode: u32, queue_kind: u8, queue_slot: u16, token: u16, req_len: u64),
+    TP_STRUCT__entry {
+        unique: u64,
+        opcode: u32,
+        queue_kind: u8,
+        queue_slot: u16,
+        token: u16,
+        req_len: u64,
+    },
+    TP_fast_assign {
+        unique: unique,
+        opcode: opcode,
+        queue_kind: queue_kind,
+        queue_slot: queue_slot,
+        token: token,
+        req_len: req_len,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let unique = __entry.unique;
+        let opcode = __entry.opcode;
+        let queue_kind = __entry.queue_kind;
+        let queue_slot = __entry.queue_slot;
+        let token = __entry.token;
+        let req_len = __entry.req_len;
+        format!(
+            "unique={} opcode={} queue_kind={} queue_slot={} token={} req_len={}",
+            unique, opcode, queue_kind, queue_slot, token, req_len
+        )
+    })
+);
+
+define_event_trace!(
+    virtiofs_queue_retry,
+    TP_system(fuse),
+    TP_PROTO(unique: u64, opcode: u32, queue_kind: u8, queue_slot: u16, reason: u8),
+    TP_STRUCT__entry {
+        unique: u64,
+        opcode: u32,
+        queue_kind: u8,
+        queue_slot: u16,
+        reason: u8,
+    },
+    TP_fast_assign {
+        unique: unique,
+        opcode: opcode,
+        queue_kind: queue_kind,
+        queue_slot: queue_slot,
+        reason: reason,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let unique = __entry.unique;
+        let opcode = __entry.opcode;
+        let queue_kind = __entry.queue_kind;
+        let queue_slot = __entry.queue_slot;
+        let reason = __entry.reason;
+        format!(
+            "unique={} opcode={} queue_kind={} queue_slot={} reason={}",
+            unique, opcode, queue_kind, queue_slot, reason
+        )
+    })
+);
+
+define_event_trace!(
+    virtiofs_complete,
+    TP_system(fuse),
+    TP_PROTO(unique: u64, opcode: u32, queue_kind: u8, queue_slot: u16, token: u16, used_len: u64),
+    TP_STRUCT__entry {
+        unique: u64,
+        opcode: u32,
+        queue_kind: u8,
+        queue_slot: u16,
+        token: u16,
+        used_len: u64,
+    },
+    TP_fast_assign {
+        unique: unique,
+        opcode: opcode,
+        queue_kind: queue_kind,
+        queue_slot: queue_slot,
+        token: token,
+        used_len: used_len,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let unique = __entry.unique;
+        let opcode = __entry.opcode;
+        let queue_kind = __entry.queue_kind;
+        let queue_slot = __entry.queue_slot;
+        let token = __entry.token;
+        let used_len = __entry.used_len;
+        format!(
+            "unique={} opcode={} queue_kind={} queue_slot={} token={} used_len={}",
+            unique, opcode, queue_kind, queue_slot, token, used_len
+        )
+    })
+);

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -40,6 +40,7 @@ use super::{
         fuse_pack_struct, fuse_read_struct, FuseInHeader, FuseOutHeader, FuseReadIn, FUSE_DESTROY,
         FUSE_FORGET, FUSE_INTERRUPT, FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS,
     },
+    stats, trace,
 };
 
 const VIRTIOFS_REQ_QUEUE_SIZE: usize = 8;
@@ -141,6 +142,13 @@ impl VirtioFsBridgeContext {
         }
     }
 
+    fn trace_queue_fields(kind: QueueKind) -> (u8, u16) {
+        match kind {
+            QueueKind::Hiprio => (trace::VIRTIOFS_QUEUE_HIPRIO, 0),
+            QueueKind::Request(slot) => (trace::VIRTIOFS_QUEUE_REQUEST, slot as u16),
+        }
+    }
+
     fn response_buffer_size(pending: &PendingReq) -> usize {
         let default_size = VIRTIOFS_RSP_BUF_SIZE;
         let read_like = matches!(pending.opcode, FUSE_READ | FUSE_READDIR | FUSE_READDIRPLUS);
@@ -212,8 +220,8 @@ impl VirtioFsBridgeContext {
         Ok(slot)
     }
 
-    fn pump_new_requests(&mut self) -> Result<bool, SystemError> {
-        let mut progressed = false;
+    fn pump_new_requests(&mut self) -> Result<usize, SystemError> {
+        let mut pumped = 0usize;
         for _ in 0..VIRTIOFS_PUMP_BUDGET {
             let len = match self.conn.read_request(true, &mut self.req_buf) {
                 Ok(len) => len,
@@ -221,6 +229,7 @@ impl VirtioFsBridgeContext {
                 Err(e) => return Err(e),
             };
             let req = self.req_buf[..len].to_vec();
+            stats::on_virtiofs_request_cloned(req.len());
             let in_hdr: FuseInHeader = fuse_read_struct(&req)?;
             let noreply = matches!(in_hdr.opcode, FUSE_FORGET | FUSE_DESTROY);
             let queue = if matches!(in_hdr.opcode, FUSE_FORGET | FUSE_INTERRUPT) {
@@ -235,9 +244,10 @@ impl VirtioFsBridgeContext {
                 noreply,
                 queue,
             })?;
-            progressed = true;
+            pumped += 1;
         }
-        Ok(progressed)
+        stats::on_virtiofs_pump_batch(pumped);
+        Ok(pumped)
     }
 
     fn submit_one_pending(&mut self, kind: QueueKind) -> Result<bool, SystemError> {
@@ -250,6 +260,7 @@ impl VirtioFsBridgeContext {
             None
         } else {
             let rsp_size = Self::response_buffer_size(&pending);
+            stats::on_virtiofs_response_buffer_alloc(rsp_size);
             Some(vec![0u8; rsp_size])
         };
 
@@ -284,11 +295,34 @@ impl VirtioFsBridgeContext {
 
         let token = match token {
             Ok(token) => token,
-            Err(VirtioError::QueueFull) | Err(VirtioError::NotReady) => {
+            Err(VirtioError::QueueFull) => {
+                stats::on_virtiofs_queue_full();
+                let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
+                trace::trace_virtiofs_queue_retry(
+                    pending.unique,
+                    pending.opcode,
+                    queue_kind,
+                    queue_slot,
+                    trace::VIRTIOFS_RETRY_QUEUE_FULL,
+                );
+                self.push_pending_front(pending)?;
+                return Ok(false);
+            }
+            Err(VirtioError::NotReady) => {
+                stats::on_virtiofs_not_ready();
+                let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
+                trace::trace_virtiofs_queue_retry(
+                    pending.unique,
+                    pending.opcode,
+                    queue_kind,
+                    queue_slot,
+                    trace::VIRTIOFS_RETRY_NOT_READY,
+                );
                 self.push_pending_front(pending)?;
                 return Ok(false);
             }
             Err(e) => {
+                stats::on_virtiofs_submit_error();
                 let se = virtio_drivers_error_to_system_error(e);
                 warn!(
                     "virtiofs bridge: submit failed opcode={} unique={} queue={:?} err={:?}",
@@ -308,6 +342,16 @@ impl VirtioFsBridgeContext {
                 .notify(queue_idx);
         }
 
+        stats::on_virtiofs_submitted(pending.req.len());
+        let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
+        trace::trace_virtiofs_submit(
+            pending.unique,
+            pending.opcode,
+            queue_kind,
+            queue_slot,
+            token,
+            pending.req.len() as u64,
+        );
         let inflight = InflightReq { pending, rsp };
         match kind {
             QueueKind::Hiprio => {
@@ -389,6 +433,7 @@ impl VirtioFsBridgeContext {
         let used_len = match used_len_res {
             Ok(v) => v as usize,
             Err(e) => {
+                stats::on_virtiofs_pop_used_error();
                 let unique = inflight.pending.unique;
                 self.put_back_inflight(kind, token, inflight)?;
                 warn!(
@@ -399,15 +444,31 @@ impl VirtioFsBridgeContext {
             }
         };
 
+        let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
+        trace::trace_virtiofs_complete(
+            inflight.pending.unique,
+            inflight.pending.opcode,
+            queue_kind,
+            queue_slot,
+            token,
+            used_len as u64,
+        );
+
         if inflight.pending.noreply {
+            stats::on_virtiofs_completed(used_len, true);
             return Ok(true);
         }
 
         let rsp_buf = inflight.rsp.as_ref().ok_or(SystemError::EIO)?;
         if used_len > rsp_buf.len() {
+            stats::on_virtiofs_completed(used_len, false);
             self.complete_request_with_error(inflight.pending.unique, SystemError::EIO);
             return Ok(true);
         }
+        if rsp_buf.len() > used_len {
+            stats::on_virtiofs_response_buffer_waste(rsp_buf.len() - used_len);
+        }
+        stats::on_virtiofs_completed(used_len, false);
 
         match self.conn.write_reply(&rsp_buf[..used_len]) {
             Ok(_) | Err(SystemError::ENOENT) => {}
@@ -430,19 +491,20 @@ impl VirtioFsBridgeContext {
         Ok(true)
     }
 
-    fn drain_completions(&mut self) -> Result<bool, SystemError> {
-        let mut progressed = false;
+    fn drain_completions(&mut self) -> Result<usize, SystemError> {
+        let mut completed = 0usize;
         while self.pop_one_used(QueueKind::Hiprio)? {
-            progressed = true;
+            completed += 1;
         }
 
         for slot in 0..self.request_vqs.len() {
             while self.pop_one_used(QueueKind::Request(slot))? {
-                progressed = true;
+                completed += 1;
             }
         }
 
-        Ok(progressed)
+        stats::on_virtiofs_complete_batch(completed);
+        Ok(completed)
     }
 
     fn fail_all_unfinished(&mut self, err: SystemError) {
@@ -480,9 +542,11 @@ impl VirtioFsBridgeContext {
             inflight_map.clear();
         }
 
+        let failed = need_reply.len();
         for unique in need_reply {
             Self::complete_request_with_errno(&conn, unique, errno);
         }
+        stats::on_virtiofs_fail_unfinished(failed);
     }
 
     fn run_loop(&mut self) -> Result<(), SystemError> {
@@ -490,7 +554,7 @@ impl VirtioFsBridgeContext {
             let mut progressed = false;
 
             match self.pump_new_requests() {
-                Ok(v) => progressed |= v,
+                Ok(v) => progressed |= v != 0,
                 Err(SystemError::ENOTCONN) => {}
                 Err(e) => {
                     warn!("virtiofs bridge: read_request failed: {:?}", e);
@@ -503,9 +567,12 @@ impl VirtioFsBridgeContext {
             progressed |= self.submit_pending()?;
 
             if let Some(transport) = self.transport.as_mut() {
-                let _ = transport.ack_interrupt();
+                if transport.ack_interrupt() {
+                    stats::on_virtiofs_ack_interrupt();
+                }
             }
-            progressed |= self.drain_completions()?;
+            progressed |= self.drain_completions()? != 0;
+            stats::on_virtiofs_loop_iteration(progressed);
 
             if !self.conn.is_connected() && !self.has_inflight() {
                 break;
@@ -520,6 +587,7 @@ impl VirtioFsBridgeContext {
             }
 
             if !progressed {
+                stats::on_virtiofs_idle_sleep(VIRTIOFS_POLL_NS);
                 Self::poll_pause();
             }
         }

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -194,8 +194,15 @@ impl VirtioFsBridgeContext {
         Ok(())
     }
 
-    fn complete_request_with_errno(conn: &Arc<FuseConn>, unique: u64, errno: i32) {
+    fn complete_request_with_negative_errno(conn: &Arc<FuseConn>, unique: u64, errno: i32) {
         if unique == 0 {
+            return;
+        }
+        if errno <= -512 || errno >= 0 {
+            warn!(
+                "virtiofs bridge: invalid internal completion errno={} unique={}",
+                errno, unique
+            );
             return;
         }
         let out_hdr = FuseOutHeader {
@@ -204,11 +211,25 @@ impl VirtioFsBridgeContext {
             unique,
         };
         let payload = fuse_pack_struct(&out_hdr);
-        let _ = conn.write_reply(payload);
+        match conn.write_reply(payload) {
+            Ok(_) => {}
+            Err(SystemError::ENOENT) => {
+                debug!(
+                    "virtiofs bridge: late internal completion ignored unique={} errno={}",
+                    unique, errno
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "virtiofs bridge: internal completion failed unique={} errno={} err={:?}",
+                    unique, errno, e
+                );
+            }
+        }
     }
 
     fn complete_request_with_error(&self, unique: u64, err: SystemError) {
-        Self::complete_request_with_errno(&self.conn, unique, err.to_posix_errno());
+        Self::complete_request_with_negative_errno(&self.conn, unique, err.to_posix_errno());
     }
 
     fn choose_request_slot(&mut self) -> Result<usize, SystemError> {
@@ -544,7 +565,7 @@ impl VirtioFsBridgeContext {
 
         let failed = need_reply.len();
         for unique in need_reply {
-            Self::complete_request_with_errno(&conn, unique, errno);
+            Self::complete_request_with_negative_errno(&conn, unique, errno);
         }
         stats::on_virtiofs_fail_unfinished(failed);
     }

--- a/kernel/src/filesystem/kernfs/callback.rs
+++ b/kernel/src/filesystem/kernfs/callback.rs
@@ -117,6 +117,7 @@ pub enum KernFilePrivateData {
     TraceSavedCmdlines(TraceCmdLineCacheSnapshot),
     RcuSelftestReport(String),
     ErrSeqSelftestReport(String),
+    DebugTextSnapshot(String),
 }
 
 impl KernInodePrivateData {

--- a/kernel/src/net/socket/unix/stream/inner.rs
+++ b/kernel/src/net/socket/unix/stream/inner.rs
@@ -826,10 +826,23 @@ impl Backlog {
         let c2s_cap = core::cmp::max(client_snd_cap, server_rcv_cap);
         let s2c_cap = core::cmp::max(server_snd_cap, client_rcv_cap);
 
-        let _ = client_conn.resize_sendbuf(c2s_cap);
-        let _ = server_conn.resize_recvbuf(c2s_cap);
-        let _ = server_conn.resize_sendbuf(s2c_cap);
-        let _ = client_conn.resize_recvbuf(s2c_cap);
+        debug_assert!(c2s_cap.is_power_of_two());
+        debug_assert!(s2c_cap.is_power_of_two());
+        let restore_init = || Init {
+            addr: client_conn.addr.clone(),
+        };
+        if let Err(e) = client_conn.resize_sendbuf(c2s_cap) {
+            return Err((restore_init(), e));
+        }
+        if let Err(e) = server_conn.resize_recvbuf(c2s_cap) {
+            return Err((restore_init(), e));
+        }
+        if let Err(e) = server_conn.resize_sendbuf(s2c_cap) {
+            return Err((restore_init(), e));
+        }
+        if let Err(e) = client_conn.resize_recvbuf(s2c_cap) {
+            return Err((restore_init(), e));
+        }
 
         let server_socket =
             UnixStreamSocket::new_connected(server_conn, false, is_seqpacket, self.netns.clone());

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -123,9 +123,9 @@ impl UnixStreamSocket {
     #[allow(dead_code)]
     pub const DEFAULT_METADATA_BUF_SIZE: usize = 1024;
     pub const MIN_SOCKET_BUF_SIZE: usize = 1024;
-    /// Upper bound for the *effective* (doubled) SO_SNDBUF/SO_RCVBUF value.
-    /// Must be a power-of-two friendly size to keep ring buffer resizes sane.
-    const MAX_EFFECTIVE_SOCKET_BUF_SIZE: usize = 8 * 1024 * 1024;
+    /// Linux defaults `net.core.wmem_max`/`rmem_max` to SK_WMEM_MAX/SK_RMEM_MAX
+    /// and stores the doubled effective value for SO_SNDBUF/SO_RCVBUF.
+    const MAX_EFFECTIVE_SOCKET_BUF_SIZE: usize = 425_984;
 
     pub(super) fn new_init(
         init: Init,

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -80,7 +80,7 @@ fn ring_cap_for_effective_sockbuf(effective: usize) -> usize {
     // Underlying ring buffer requires power-of-two capacity.
     let mut cap = effective.next_power_of_two();
     cap = core::cmp::max(cap, inner::UNIX_STREAM_DEFAULT_BUF_SIZE);
-    cap = core::cmp::min(cap, UnixStreamSocket::MAX_EFFECTIVE_SOCKET_BUF_SIZE);
+    cap = core::cmp::min(cap, UnixStreamSocket::MAX_RING_SOCKET_BUF_CAPACITY);
     cap
 }
 
@@ -126,6 +126,9 @@ impl UnixStreamSocket {
     /// Linux defaults `net.core.wmem_max`/`rmem_max` to SK_WMEM_MAX/SK_RMEM_MAX
     /// and stores the doubled effective value for SO_SNDBUF/SO_RCVBUF.
     const MAX_EFFECTIVE_SOCKET_BUF_SIZE: usize = 425_984;
+    /// Internal Unix stream rings require power-of-two capacity. Keep this
+    /// separate from the Linux-visible SO_SNDBUF/SO_RCVBUF value.
+    const MAX_RING_SOCKET_BUF_CAPACITY: usize = 524_288;
 
     pub(super) fn new_init(
         init: Init,
@@ -225,14 +228,37 @@ impl UnixStreamSocket {
     fn wake_peer_writable(&self) {
         if let Some(peer_weak) = self.peer.lock().as_ref() {
             if let Some(peer) = peer_weak.upgrade() {
-                peer.wait_queue
-                    .wakeup(Some(crate::process::ProcessState::Blocked(true)));
-                let _ = EventPoll::wakeup_epoll(
-                    peer.epoll_items().as_ref(),
-                    EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM,
-                );
-                peer.fasync_items.send_sigio(FASYNC_POLL_OUT);
+                peer.wake_self_writable();
             }
+        }
+    }
+
+    fn is_self_writable_now(&self) -> bool {
+        let inner_guard = self.inner.read();
+        let Some(inner) = inner_guard.as_ref() else {
+            return false;
+        };
+        let Inner::Connected(connected) = inner else {
+            return false;
+        };
+        if connected.send_closed() {
+            return false;
+        }
+
+        let sndbuf = self.sndbuf.load(Ordering::Relaxed);
+        let queued = connected.outq_len(self.is_seqpacket);
+        connected.send_free_len() > 0 && queued < sndbuf
+    }
+
+    fn wake_self_writable(&self) {
+        self.wait_queue
+            .wakeup(Some(crate::process::ProcessState::Blocked(true)));
+        if self.is_self_writable_now() {
+            let _ = EventPoll::wakeup_epoll(
+                self.epoll_items().as_ref(),
+                EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM,
+            );
+            self.fasync_items.send_sigio(FASYNC_POLL_OUT);
         }
     }
 
@@ -646,7 +672,7 @@ impl Socket for UnixStreamSocket {
                 }
 
                 let effective = Self::effective_sockbuf(requested as usize);
-                self.sndbuf.store(effective, Ordering::SeqCst);
+                let old_effective = self.sndbuf.load(Ordering::Relaxed);
 
                 let new_cap = ring_cap_for_effective_sockbuf(effective);
                 if let Some(inner) = self.inner.read().as_ref() {
@@ -663,6 +689,10 @@ impl Socket for UnixStreamSocket {
                         Inner::Init(_) => {}
                     }
                 }
+                self.sndbuf.store(effective, Ordering::SeqCst);
+                if effective > old_effective {
+                    self.wake_self_writable();
+                }
                 Ok(())
             }
             crate::net::socket::PSO::RCVBUF | crate::net::socket::PSO::RCVBUFFORCE => {
@@ -672,7 +702,7 @@ impl Socket for UnixStreamSocket {
                 }
 
                 let effective = Self::effective_sockbuf(requested as usize);
-                self.rcvbuf.store(effective, Ordering::SeqCst);
+                let old_effective = self.rcvbuf.load(Ordering::Relaxed);
 
                 let new_cap = ring_cap_for_effective_sockbuf(effective);
                 if let Some(inner) = self.inner.read().as_ref() {
@@ -688,6 +718,10 @@ impl Socket for UnixStreamSocket {
                         }
                         Inner::Init(_) => {}
                     }
+                }
+                self.rcvbuf.store(effective, Ordering::SeqCst);
+                if effective > old_effective {
+                    self.wake_peer_writable();
                 }
                 Ok(())
             }

--- a/tools/virtiofs/env.sh.example
+++ b/tools/virtiofs/env.sh.example
@@ -3,14 +3,17 @@
 # 复制为 env.sh 后按需修改：
 #   cp env.sh.example env.sh
 
+VIRTIOFS_ENV_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DRAGONOS_REPO_ROOT="$(cd -- "${VIRTIOFS_ENV_DIR}/../.." && pwd)"
+
 # Host 上要共享给 guest 的目录
-export HOST_SHARE_DIR="${HOME}/dragonos-virtiofs-share"
+export HOST_SHARE_DIR="${DRAGONOS_REPO_ROOT}/bin/virtiofs-share"
 
 # Guest 内 mount -t virtiofs 使用的 tag
 export VIRTIOFS_TAG="hostshare"
 
 # virtiofsd 运行时目录与 socket
-export RUNTIME_DIR="${HOME}/.dragonos-virtiofs"
+export RUNTIME_DIR="${DRAGONOS_REPO_ROOT}/bin/virtiofs-runtime"
 export SOCKET_PATH="${RUNTIME_DIR}/virtiofsd.sock"
 
 # 可选：手动指定 virtiofsd 可执行文件，留空则自动探测

--- a/tools/virtiofs/virtiofs_bench.sh
+++ b/tools/virtiofs/virtiofs_bench.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPER="${VIRTIOFS_BENCH_HELPER:-${SCRIPT_DIR}/virtiofs_bench}"
+SRC="${SCRIPT_DIR}/../../user/apps/virtiofs_bench/virtiofs_bench.cc"
+MOUNT_PATH="${1:-}"
+
+if [ -z "${MOUNT_PATH}" ]; then
+    echo "usage: $0 MOUNT_PATH [helper args...]" >&2
+    exit 2
+fi
+shift || true
+
+if [ ! -x "${HELPER}" ]; then
+    if command -v c++ >/dev/null 2>&1; then
+        c++ -O2 -std=c++17 -pthread "${SRC}" -o "${HELPER}"
+    else
+        echo "missing helper ${HELPER}; build ${SRC} for this guest or set VIRTIOFS_BENCH_HELPER" >&2
+        exit 2
+    fi
+fi
+
+STATS_PATH="${VIRTIOFS_STATS_PATH:-/sys/kernel/debug/fuse/stats}"
+OUT_DIR="${VIRTIOFS_BENCH_OUT:-/tmp/virtiofs_bench_$$}"
+mkdir -p "${OUT_DIR}"
+
+snapshot() {
+    name="$1"
+    if [ -r "${STATS_PATH}" ]; then
+        cat "${STATS_PATH}" > "${OUT_DIR}/${name}.stats"
+    else
+        : > "${OUT_DIR}/${name}.stats"
+    fi
+}
+
+write_delta() {
+    before="$1"
+    after="$2"
+    out="$3"
+    awk '
+        FILENAME == ARGV[1] && /^\[/ { section = substr($0, 2, length($0) - 2); next }
+        FILENAME == ARGV[2] && /^\[/ { section = substr($0, 2, length($0) - 2); next }
+        FILENAME == ARGV[1] && NF == 2 {
+            before[section "." $1] = $2
+            next
+        }
+        FILENAME == ARGV[2] && NF == 2 {
+            key = section "." $1
+            if (key in before) {
+                print key, $2 - before[key]
+            }
+        }
+    ' "$before" "$after" > "$out"
+}
+
+snapshot before
+set +e
+"${HELPER}" --mount "${MOUNT_PATH}" "$@" > "${OUT_DIR}/results.txt"
+rc=$?
+set -e
+cat "${OUT_DIR}/results.txt"
+snapshot after
+write_delta "${OUT_DIR}/before.stats" "${OUT_DIR}/after.stats" "${OUT_DIR}/delta.stats"
+
+echo "bench_output=${OUT_DIR}"
+echo "stats_before=${OUT_DIR}/before.stats"
+echo "stats_after=${OUT_DIR}/after.stats"
+echo "stats_delta=${OUT_DIR}/delta.stats"
+exit "$rc"

--- a/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
+++ b/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "../fuse/fuse_gtest_common.h"
+
+namespace {
+
+std::string read_all_with_chunk(const char* path, size_t chunk) {
+    int fd = open(path, O_RDONLY);
+    EXPECT_GE(fd, 0) << "open(" << path << ") failed: errno=" << errno << " ("
+                     << strerror(errno) << ")";
+    if (fd < 0) {
+        return {};
+    }
+
+    std::string out;
+    char buf[64];
+    if (chunk > sizeof(buf)) {
+        chunk = sizeof(buf);
+    }
+    while (true) {
+        ssize_t n = read(fd, buf, chunk);
+        if (n == 0) {
+            break;
+        }
+        EXPECT_GT(n, 0) << "read(" << path << ") failed: errno=" << errno << " ("
+                        << strerror(errno) << ")";
+        if (n <= 0) {
+            close(fd);
+            return {};
+        }
+        out.append(buf, static_cast<size_t>(n));
+    }
+
+    EXPECT_EQ(0, close(fd)) << "close(" << path << ") failed: errno=" << errno << " ("
+                            << strerror(errno) << ")";
+    return out;
+}
+
+void expect_field(const std::string& stats, const char* field) {
+    ASSERT_NE(std::string::npos, stats.find(field)) << "missing field " << field << "\n"
+                                                    << stats;
+}
+
+long long parse_counter(const std::string& stats, const char* field) {
+    std::string needle = std::string(field) + " ";
+    size_t pos = stats.find(needle);
+    if (pos == std::string::npos) {
+        return -1;
+    }
+    pos += needle.size();
+    char* end = nullptr;
+    long long value = strtoll(stats.c_str() + pos, &end, 10);
+    if (end == stats.c_str() + pos) {
+        return -1;
+    }
+    return value;
+}
+
+void expect_counter_increased(const std::string& before, const std::string& after,
+                              const char* field) {
+    long long old_value = parse_counter(before, field);
+    long long new_value = parse_counter(after, field);
+    ASSERT_GE(old_value, 0) << "missing or invalid before counter " << field << "\n" << before;
+    ASSERT_GE(new_value, 0) << "missing or invalid after counter " << field << "\n" << after;
+    EXPECT_GT(new_value, old_value) << field << " did not increase";
+}
+
+void drive_minimal_fuse_request() {
+    char mp[128] = {};
+    snprintf(mp, sizeof(mp), "/tmp/fuse_stats_mount_%d", getpid());
+    ASSERT_EQ(0, ensure_dir(mp)) << strerror(errno);
+
+    int fd = open("/dev/fuse", O_RDWR);
+    ASSERT_GE(fd, 0) << "open(/dev/fuse): " << strerror(errno);
+
+    char opts[256] = {};
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    ASSERT_EQ(0, mount("none", mp, "fuse", 0, opts)) << "mount(fuse): " << strerror(errno);
+
+    ASSERT_EQ(0, fuseg_do_init_handshake_basic(fd)) << "FUSE_INIT handshake: " << strerror(errno);
+
+    EXPECT_EQ(0, umount(mp)) << "umount(" << mp << "): " << strerror(errno);
+    EXPECT_EQ(0, close(fd)) << "close(/dev/fuse): " << strerror(errno);
+    EXPECT_EQ(0, rmdir(mp)) << "rmdir(" << mp << "): " << strerror(errno);
+}
+
+}  // namespace
+
+TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
+    char root[128] = {};
+    char stats_path[192] = {};
+    snprintf(root, sizeof(root), "/tmp/fuse_stats_debugfs_%d", getpid());
+    snprintf(stats_path, sizeof(stats_path), "%s/fuse/stats", root);
+
+    ASSERT_EQ(0, ensure_dir("/tmp")) << strerror(errno);
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+
+    if (mount("none", root, "debugfs", 0, nullptr) != 0) {
+        int saved_errno = errno;
+        rmdir(root);
+        FAIL() << "mount debugfs failed: errno=" << saved_errno << " (" << strerror(saved_errno)
+               << ")";
+    }
+
+    std::string whole = read_all_with_chunk(stats_path, 64);
+    std::string small = read_all_with_chunk(stats_path, 7);
+    drive_minimal_fuse_request();
+    std::string after_fuse = read_all_with_chunk(stats_path, 64);
+
+    EXPECT_EQ(0, umount(root)) << strerror(errno);
+    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+
+    ASSERT_FALSE(whole.empty());
+    ASSERT_EQ(whole, small);
+
+    expect_field(whole, "[fuse]\n");
+    expect_field(whole, "requests_queued_total ");
+    expect_field(whole, "requests_dequeued_total ");
+    expect_field(whole, "requests_replied_ok_total ");
+    expect_field(whole, "requests_replied_err_total ");
+    expect_field(whole, "requests_aborted_total ");
+    expect_field(whole, "requests_dropped_umount_total ");
+    expect_field(whole, "read_buffer_too_small_total ");
+
+    expect_field(whole, "[virtiofs]\n");
+    expect_field(whole, "bridge_loop_iterations_total ");
+    expect_field(whole, "bridge_idle_sleeps_total ");
+    expect_field(whole, "virtqueue_full_total ");
+    expect_field(whole, "virtqueue_not_ready_total ");
+    expect_field(whole, "bridge_request_clone_bytes ");
+    expect_field(whole, "response_buffer_alloc_bytes ");
+    expect_field(whole, "bytes_submitted_total ");
+    expect_field(whole, "bytes_completed_total ");
+
+    expect_counter_increased(whole, after_fuse, "requests_queued_total");
+    expect_counter_increased(whole, after_fuse, "requests_dequeued_total");
+    expect_counter_increased(whole, after_fuse, "requests_replied_ok_total");
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
@@ -2,6 +2,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <limits.h>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -134,6 +135,22 @@ TEST(SocketGetsockoptSemantics, UnixStreamScalarOptionsAllowShortBuffers) {
     ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_DOMAIN, AF_UNIX, 2);
     ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_PROTOCOL, 0, 2);
     ExpectIntOptionPrefix(fd.Get(), SOL_SOCKET, SO_ACCEPTCONN, 0, 1);
+}
+
+TEST(SocketGetsockoptSemantics, UnixStreamSndbufClampsToLinuxDefaultMax) {
+    FdGuard fd(socket(AF_UNIX, SOCK_STREAM, 0));
+    ASSERT_GE(fd.Get(), 0) << "socket(AF_UNIX, SOCK_STREAM) failed: " << ErrnoString(errno);
+
+    const int requested = INT_MAX;
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, SO_SNDBUF, &requested, sizeof(requested)), 0)
+            << "setsockopt(SO_SNDBUF) failed: " << ErrnoString(errno);
+
+    int actual = 0;
+    socklen_t len = sizeof(actual);
+    ASSERT_EQ(getsockopt(fd.Get(), SOL_SOCKET, SO_SNDBUF, &actual, &len), 0)
+            << "getsockopt(SO_SNDBUF) failed: " << ErrnoString(errno);
+    EXPECT_EQ(len, sizeof(actual));
+    EXPECT_EQ(actual, 425984);
 }
 
 TEST(SocketGetsockoptSemantics, UnixStreamLingerAllowsShortBuffers) {

--- a/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_getsockopt_semantics.cc
@@ -153,6 +153,34 @@ TEST(SocketGetsockoptSemantics, UnixStreamSndbufClampsToLinuxDefaultMax) {
     EXPECT_EQ(actual, 425984);
 }
 
+TEST(SocketGetsockoptSemantics, ConnectedUnixStreamBuffersClampToLinuxDefaultMax) {
+    int sv[2] = {-1, -1};
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0)
+            << "socketpair(AF_UNIX, SOCK_STREAM) failed: " << ErrnoString(errno);
+    FdGuard first(sv[0]);
+    FdGuard second(sv[1]);
+
+    const int requested = INT_MAX;
+    ASSERT_EQ(setsockopt(first.Get(), SOL_SOCKET, SO_SNDBUF, &requested, sizeof(requested)), 0)
+            << "setsockopt(SO_SNDBUF) failed: " << ErrnoString(errno);
+    ASSERT_EQ(setsockopt(first.Get(), SOL_SOCKET, SO_RCVBUF, &requested, sizeof(requested)), 0)
+            << "setsockopt(SO_RCVBUF) failed: " << ErrnoString(errno);
+
+    int actual = 0;
+    socklen_t len = sizeof(actual);
+    ASSERT_EQ(getsockopt(first.Get(), SOL_SOCKET, SO_SNDBUF, &actual, &len), 0)
+            << "getsockopt(SO_SNDBUF) failed: " << ErrnoString(errno);
+    EXPECT_EQ(len, sizeof(actual));
+    EXPECT_EQ(actual, 425984);
+
+    actual = 0;
+    len = sizeof(actual);
+    ASSERT_EQ(getsockopt(first.Get(), SOL_SOCKET, SO_RCVBUF, &actual, &len), 0)
+            << "getsockopt(SO_RCVBUF) failed: " << ErrnoString(errno);
+    EXPECT_EQ(len, sizeof(actual));
+    EXPECT_EQ(actual, 425984);
+}
+
 TEST(SocketGetsockoptSemantics, UnixStreamLingerAllowsShortBuffers) {
     FdGuard fd(socket(AF_UNIX, SOCK_STREAM, 0));
     ASSERT_GE(fd.Get(), 0) << "socket(AF_UNIX, SOCK_STREAM) failed: " << ErrnoString(errno);

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -11,6 +11,7 @@ normal/fcntl_signal
 normal/epoll_timeout_budget
 normal/devpts_dir_read
 normal/debugfs_mount
+normal/fuse_stats_debugfs
 normal/test_pivot_root
 normal/mount_reconfigure
 normal/mount_propagation

--- a/user/apps/virtiofs_bench/Makefile
+++ b/user/apps/virtiofs_bench/Makefile
@@ -1,0 +1,32 @@
+ARCH ?= x86_64
+
+ifeq ($(ARCH), x86_64)
+	CROSS_COMPILE = x86_64-linux-musl-
+else ifeq ($(ARCH), riscv64)
+	CROSS_COMPILE = riscv64-linux-musl-
+endif
+
+ifeq ($(origin CXX), default)
+	CXX = $(CROSS_COMPILE)g++
+endif
+CXXFLAGS ?= -Wall -O2 -std=c++17 -pthread -static
+
+BIN = virtiofs_bench
+SRC = virtiofs_bench.cc
+
+.PHONY: all install clean fmt
+
+all: $(BIN)
+
+$(BIN): $(SRC)
+	$(CXX) $(CXXFLAGS) $< -o $@
+
+install: all
+	@echo "Installing $(BIN) to $(DADK_CURRENT_BUILD_DIR)/"
+	@mkdir -p "$(DADK_CURRENT_BUILD_DIR)"
+	cp -f "$(BIN)" "$(DADK_CURRENT_BUILD_DIR)/$(BIN)"
+
+clean:
+	rm -f "$(BIN)"
+
+fmt:

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -1,0 +1,572 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::string mount;
+    std::string tag = "hostshare";
+    std::string mount_options;
+    std::string workload = "all";
+    size_t files = 256;
+    size_t file_size = 4 * 1024 * 1024;
+    size_t block_size = 4096;
+    size_t iterations = 4096;
+    size_t workers = 4;
+};
+
+using StatsMap = std::map<std::string, long long>;
+
+uint64_t now_us() {
+    timeval tv = {};
+    gettimeofday(&tv, nullptr);
+    return static_cast<uint64_t>(tv.tv_sec) * 1000000ULL + tv.tv_usec;
+}
+
+std::string path_join(const std::string& a, const std::string& b) {
+    if (!a.empty() && a.back() == '/') {
+        return a + b;
+    }
+    return a + "/" + b;
+}
+
+const char* env_or_empty(const char* name) {
+    const char* value = getenv(name);
+    return value ? value : "";
+}
+
+const char* result_mount_options(const Options& opt) {
+    const char* value = getenv("VIRTIOFS_BENCH_MOUNT_OPTIONS");
+    if (value && value[0] != '\0') {
+        return value;
+    }
+    return opt.mount_options.c_str();
+}
+
+std::string stats_path() {
+    const char* value = getenv("VIRTIOFS_STATS_PATH");
+    return value && value[0] != '\0' ? value : "/sys/kernel/debug/fuse/stats";
+}
+
+StatsMap read_stats() {
+    StatsMap stats;
+    std::ifstream in(stats_path());
+    if (!in) {
+        return stats;
+    }
+
+    std::string section;
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        if (line.front() == '[' && line.back() == ']') {
+            section = line.substr(1, line.size() - 2);
+            continue;
+        }
+        std::istringstream iss(line);
+        std::string key;
+        long long value = 0;
+        if (iss >> key >> value) {
+            stats[section + "." + key] = value;
+        }
+    }
+    return stats;
+}
+
+void emit_stats_delta(const char* workload, const StatsMap& before, const StatsMap& after) {
+    for (const auto& item : after) {
+        auto old = before.find(item.first);
+        if (old == before.end()) {
+            continue;
+        }
+        printf("stats_delta workload=%s key=%s delta=%lld\n", workload, item.first.c_str(),
+               item.second - old->second);
+    }
+}
+
+bool write_full(int fd, const void* data, size_t len) {
+    const char* p = static_cast<const char*>(data);
+    while (len > 0) {
+        ssize_t n = write(fd, p, len);
+        if (n <= 0) {
+            return false;
+        }
+        p += n;
+        len -= static_cast<size_t>(n);
+    }
+    return true;
+}
+
+bool read_full_loop(int fd, std::vector<char>& buf, uint64_t* bytes) {
+    for (;;) {
+        ssize_t n = read(fd, buf.data(), buf.size());
+        if (n < 0) {
+            return false;
+        }
+        if (n == 0) {
+            return true;
+        }
+        *bytes += static_cast<uint64_t>(n);
+    }
+}
+
+void emit_result(const char* workload, const Options& opt, uint64_t elapsed_us, uint64_t bytes,
+                 uint64_t ops, int err) {
+    utsname uts = {};
+    uname(&uts);
+    printf("result workload=%s status=%s errno=%d elapsed_us=%llu bytes=%llu ops=%llu "
+           "mount=%s files=%zu file_size=%zu block_size=%zu iterations=%zu workers=%zu "
+           "cache_mode=%s mount_options=%s sysname=%s release=%s\n",
+           workload, err == 0 ? "ok" : "fail", err,
+           static_cast<unsigned long long>(elapsed_us),
+           static_cast<unsigned long long>(bytes),
+           static_cast<unsigned long long>(ops), opt.mount.c_str(), opt.files, opt.file_size,
+           opt.block_size, opt.iterations, opt.workers, env_or_empty("VIRTIOFS_BENCH_CACHE_MODE"),
+           result_mount_options(opt), uts.sysname, uts.release);
+}
+
+int ensure_dir(const std::string& path) {
+    struct stat st = {};
+    if (stat(path.c_str(), &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+    return mkdir(path.c_str(), 0755);
+}
+
+int prepare_data_file(const Options& opt, const std::string& path, char fill) {
+    std::vector<char> buf(opt.block_size, fill);
+    int fd = open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0644);
+    if (fd < 0) {
+        return errno;
+    }
+
+    int err = 0;
+    for (size_t done = 0; done < opt.file_size; done += buf.size()) {
+        size_t n = buf.size();
+        if (done + n > opt.file_size) {
+            n = opt.file_size - done;
+        }
+        if (!write_full(fd, buf.data(), n)) {
+            err = errno;
+            break;
+        }
+    }
+    if (err == 0 && fsync(fd) != 0) {
+        err = errno;
+    }
+    close(fd);
+    return err;
+}
+
+int metadata_workload(const Options& opt, const std::string& root) {
+    uint64_t start = now_us();
+    uint64_t ops = 0;
+    int err = 0;
+    for (size_t i = 0; i < opt.files; ++i) {
+        std::string p = path_join(root, "meta_" + std::to_string(i));
+        int fd = open(p.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0644);
+        if (fd < 0) {
+            err = errno;
+            break;
+        }
+        close(fd);
+        struct stat st = {};
+        if (stat(p.c_str(), &st) != 0) {
+            err = errno;
+            break;
+        }
+        if (unlink(p.c_str()) != 0) {
+            err = errno;
+            break;
+        }
+        ops += 3;
+    }
+    emit_result("metadata", opt, now_us() - start, 0, ops, err);
+    return err == 0 ? 0 : -1;
+}
+
+int sequential_workload(const Options& opt, const std::string& root) {
+    std::string p = path_join(root, "seq.dat");
+    std::vector<char> buf(opt.block_size, 'D');
+    uint64_t bytes = 0;
+    uint64_t ops = 0;
+    int err = 0;
+    uint64_t start = now_us();
+
+    int fd = open(p.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0644);
+    if (fd < 0) {
+        err = errno;
+    } else {
+        for (size_t done = 0; err == 0 && done < opt.file_size; done += buf.size()) {
+            size_t n = buf.size();
+            if (done + n > opt.file_size) {
+                n = opt.file_size - done;
+            }
+            if (!write_full(fd, buf.data(), n)) {
+                err = errno;
+                break;
+            }
+            bytes += n;
+            ++ops;
+        }
+        fsync(fd);
+        close(fd);
+    }
+    emit_result("sequential_write", opt, now_us() - start, bytes, ops, err);
+    if (err != 0) {
+        return -1;
+    }
+
+    bytes = 0;
+    ops = 1;
+    start = now_us();
+    fd = open(p.c_str(), O_RDONLY);
+    if (fd < 0) {
+        err = errno;
+    } else {
+        if (!read_full_loop(fd, buf, &bytes)) {
+            err = errno;
+        }
+        close(fd);
+    }
+    emit_result("sequential_read", opt, now_us() - start, bytes, ops, err);
+    return err == 0 ? 0 : -1;
+}
+
+int random_read_workload(const Options& opt, const std::string& root) {
+    std::string p = path_join(root, "random.dat");
+    std::vector<char> buf(opt.block_size);
+    uint64_t bytes = 0;
+    uint64_t ops = 0;
+    int err = 0;
+    uint64_t start = now_us();
+
+    if (err == 0) {
+        int fd = open(p.c_str(), O_RDONLY);
+        if (fd < 0) {
+            err = errno;
+        } else {
+            size_t blocks = (opt.file_size + buf.size() - 1) / buf.size();
+            if (blocks == 0) {
+                blocks = 1;
+            }
+            for (size_t i = 0; i < opt.iterations; ++i) {
+                off_t off = static_cast<off_t>((i * 2654435761ULL) % blocks);
+                off *= static_cast<off_t>(buf.size());
+                ssize_t n = pread(fd, buf.data(), buf.size(), off);
+                if (n < 0) {
+                    err = errno;
+                    break;
+                }
+                bytes += static_cast<uint64_t>(n);
+                ++ops;
+            }
+            close(fd);
+        }
+    }
+    emit_result("random_read", opt, now_us() - start, bytes, ops, err);
+    return err == 0 ? 0 : -1;
+}
+
+int mmap_scan_workload(const Options& opt, const std::string& root) {
+    std::string p = path_join(root, "mmap.dat");
+    uint64_t start = now_us();
+    uint64_t bytes = 0;
+    int err = 0;
+    volatile uint64_t checksum = 0;
+
+    if (err == 0) {
+        int fd = open(p.c_str(), O_RDONLY);
+        if (fd < 0) {
+            err = errno;
+        } else {
+            void* map = mmap(nullptr, opt.file_size, PROT_READ, MAP_PRIVATE, fd, 0);
+            if (map == MAP_FAILED) {
+                err = errno;
+            } else {
+                const unsigned char* p8 = static_cast<const unsigned char*>(map);
+                for (size_t i = 0; i < opt.file_size; i += 4096) {
+                    checksum += p8[i];
+                    bytes += (opt.file_size - i) < 4096 ? (opt.file_size - i) : 4096;
+                }
+                munmap(map, opt.file_size);
+            }
+            close(fd);
+        }
+    }
+    emit_result("mmap_scan", opt, now_us() - start, bytes, checksum, err);
+    return err == 0 ? 0 : -1;
+}
+
+struct WorkerArg {
+    Options opt;
+    std::string root;
+    size_t id;
+    int err;
+    uint64_t bytes;
+};
+
+void* worker_main(void* raw) {
+    WorkerArg* arg = static_cast<WorkerArg*>(raw);
+    std::vector<char> buf(arg->opt.block_size, static_cast<char>('A' + (arg->id % 26)));
+    std::string p = path_join(arg->root, "worker_" + std::to_string(arg->id) + ".dat");
+    int fd = open(p.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0644);
+    if (fd < 0) {
+        arg->err = errno;
+        return nullptr;
+    }
+    for (size_t i = 0; i < arg->opt.iterations; ++i) {
+        if (!write_full(fd, buf.data(), buf.size())) {
+            arg->err = errno;
+            close(fd);
+            return nullptr;
+        }
+        arg->bytes += buf.size();
+    }
+    fsync(fd);
+    close(fd);
+    return nullptr;
+}
+
+int concurrent_workload(const Options& opt, const std::string& root) {
+    std::vector<pthread_t> threads(opt.workers);
+    std::vector<WorkerArg> args(opt.workers);
+    uint64_t start = now_us();
+    for (size_t i = 0; i < opt.workers; ++i) {
+        args[i].opt = opt;
+        args[i].root = root;
+        args[i].id = i;
+        args[i].err = 0;
+        args[i].bytes = 0;
+        if (pthread_create(&threads[i], nullptr, worker_main, &args[i]) != 0) {
+            args[i].err = errno;
+        }
+    }
+    uint64_t bytes = 0;
+    int err = 0;
+    for (size_t i = 0; i < opt.workers; ++i) {
+        pthread_join(threads[i], nullptr);
+        bytes += args[i].bytes;
+        if (args[i].err != 0 && err == 0) {
+            err = args[i].err;
+        }
+    }
+    emit_result("concurrent_write", opt, now_us() - start, bytes, opt.workers * opt.iterations,
+                err);
+    return err == 0 ? 0 : -1;
+}
+
+void usage(const char* argv0) {
+    fprintf(stderr,
+            "usage: %s --mount PATH [--workload all|metadata|sequential|random_read|mmap|concurrent] "
+            "[--files N] [--file-size N] [--block-size N] [--iterations N] [--workers N]\n",
+            argv0);
+    fprintf(stderr,
+            "       %s [--tag hostshare] [--mount-options OPTIONS] [workload options...]\n",
+            argv0);
+    fprintf(stderr,
+            "If --mount is omitted, the benchmark mounts the virtiofs tag on a temporary "
+            "directory and unmounts it before exit.\n");
+}
+
+bool parse_size(const char* s, size_t* out) {
+    char* end = nullptr;
+    errno = 0;
+    unsigned long long v = strtoull(s, &end, 10);
+    if (errno != 0 || end == s || *end != '\0') {
+        return false;
+    }
+    *out = static_cast<size_t>(v);
+    return true;
+}
+
+bool parse_args(int argc, char** argv, Options* opt) {
+    for (int i = 1; i < argc; ++i) {
+        auto need = [&](const char* name) -> const char* {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "%s requires a value\n", name);
+                return nullptr;
+            }
+            return argv[++i];
+        };
+        if (strcmp(argv[i], "--mount") == 0) {
+            const char* v = need(argv[i]);
+            if (!v) return false;
+            opt->mount = v;
+        } else if (strcmp(argv[i], "--tag") == 0) {
+            const char* v = need(argv[i]);
+            if (!v) return false;
+            opt->tag = v;
+        } else if (strcmp(argv[i], "--mount-options") == 0) {
+            const char* v = need(argv[i]);
+            if (!v) return false;
+            opt->mount_options = v;
+        } else if (strcmp(argv[i], "--workload") == 0) {
+            const char* v = need(argv[i]);
+            if (!v) return false;
+            opt->workload = v;
+        } else if (strcmp(argv[i], "--files") == 0) {
+            const char* v = need(argv[i]);
+            if (!v || !parse_size(v, &opt->files)) return false;
+        } else if (strcmp(argv[i], "--file-size") == 0) {
+            const char* v = need(argv[i]);
+            if (!v || !parse_size(v, &opt->file_size)) return false;
+        } else if (strcmp(argv[i], "--block-size") == 0) {
+            const char* v = need(argv[i]);
+            if (!v || !parse_size(v, &opt->block_size)) return false;
+        } else if (strcmp(argv[i], "--iterations") == 0) {
+            const char* v = need(argv[i]);
+            if (!v || !parse_size(v, &opt->iterations)) return false;
+        } else if (strcmp(argv[i], "--workers") == 0) {
+            const char* v = need(argv[i]);
+            if (!v || !parse_size(v, &opt->workers)) return false;
+        } else {
+            return false;
+        }
+    }
+    if (opt->workload != "all" && opt->workload != "metadata" && opt->workload != "sequential" &&
+        opt->workload != "random_read" && opt->workload != "mmap" &&
+        opt->workload != "concurrent") {
+        fprintf(stderr, "unknown workload: %s\n", opt->workload.c_str());
+        return false;
+    }
+    if (opt->tag.empty()) {
+        fprintf(stderr, "--tag must not be empty\n");
+        return false;
+    }
+    return opt->file_size != 0 && opt->block_size != 0 && opt->workers != 0;
+}
+
+struct AutoMount {
+    bool active = false;
+    std::string path;
+
+    int mount_if_needed(Options* opt) {
+        if (!opt->mount.empty()) {
+            return 0;
+        }
+
+        path = "/tmp/virtiofs_bench_mount_" + std::to_string(getpid());
+        if (ensure_dir(path) != 0) {
+            return errno == 0 ? ENOTDIR : errno;
+        }
+
+        const char* data = opt->mount_options.empty() ? nullptr : opt->mount_options.c_str();
+        if (mount(opt->tag.c_str(), path.c_str(), "virtiofs", 0, data) != 0) {
+            int err = errno;
+            rmdir(path.c_str());
+            return err;
+        }
+
+        opt->mount = path;
+        active = true;
+        return 0;
+    }
+
+    void cleanup() {
+        if (!active) {
+            return;
+        }
+        if (umount(path.c_str()) != 0) {
+            fprintf(stderr, "warning: umount(%s) failed: %s\n", path.c_str(), strerror(errno));
+        }
+        if (rmdir(path.c_str()) != 0) {
+            fprintf(stderr, "warning: rmdir(%s) failed: %s\n", path.c_str(), strerror(errno));
+        }
+        active = false;
+    }
+
+    ~AutoMount() {
+        cleanup();
+    }
+};
+
+int run_with_stats_delta(const char* name, int (*workload)(const Options&, const std::string&),
+                         const Options& opt, const std::string& root) {
+    StatsMap before = read_stats();
+    int rc = workload(opt, root);
+    StatsMap after = read_stats();
+    emit_stats_delta(name, before, after);
+    return rc;
+}
+
+int prepare_read_input(const char* workload, const Options& opt, const std::string& path,
+                       char fill) {
+    int err = prepare_data_file(opt, path, fill);
+    if (err != 0) {
+        emit_result(workload, opt, 0, 0, 0, err);
+        return -1;
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Options opt;
+    if (!parse_args(argc, argv, &opt)) {
+        usage(argv[0]);
+        return 2;
+    }
+
+    AutoMount automount;
+    int mount_err = automount.mount_if_needed(&opt);
+    if (mount_err != 0) {
+        fprintf(stderr, "failed to mount virtiofs tag '%s': %s\n", opt.tag.c_str(),
+                strerror(mount_err));
+        return 1;
+    }
+
+    std::string root = path_join(opt.mount, ".virtiofs_bench_" + std::to_string(getpid()));
+    if (ensure_dir(root) != 0) {
+        fprintf(stderr, "failed to create %s: %s\n", root.c_str(), strerror(errno));
+        return 1;
+    }
+
+    int rc = 0;
+    if (opt.workload == "all" || opt.workload == "metadata") {
+        rc |= run_with_stats_delta("metadata", metadata_workload, opt, root);
+    }
+    if (opt.workload == "all" || opt.workload == "sequential") {
+        rc |= run_with_stats_delta("sequential", sequential_workload, opt, root);
+    }
+    if (opt.workload == "all" || opt.workload == "random_read") {
+        if (prepare_read_input("random_read", opt, path_join(root, "random.dat"), 'R') == 0) {
+            rc |= run_with_stats_delta("random_read", random_read_workload, opt, root);
+        } else {
+            rc |= -1;
+        }
+    }
+    if (opt.workload == "all" || opt.workload == "mmap") {
+        if (prepare_read_input("mmap_scan", opt, path_join(root, "mmap.dat"), 'M') == 0) {
+            rc |= run_with_stats_delta("mmap", mmap_scan_workload, opt, root);
+        } else {
+            rc |= -1;
+        }
+    }
+    if (opt.workload == "all" || opt.workload == "concurrent") {
+        rc |= run_with_stats_delta("concurrent", concurrent_workload, opt, root);
+    }
+
+    return rc == 0 ? 0 : 1;
+}

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -130,6 +130,28 @@ bool read_full_loop(int fd, std::vector<char>& buf, uint64_t* bytes) {
     }
 }
 
+int errno_or_eio() {
+    return errno == 0 ? EIO : errno;
+}
+
+void record_first_error(int* err, int value) {
+    if (*err == 0) {
+        *err = value;
+    }
+}
+
+void fsync_preserve_error(int fd, int* err) {
+    if (fsync(fd) != 0) {
+        record_first_error(err, errno_or_eio());
+    }
+}
+
+void close_preserve_error(int fd, int* err) {
+    if (close(fd) != 0) {
+        record_first_error(err, errno_or_eio());
+    }
+}
+
 void emit_result(const char* workload, const Options& opt, uint64_t elapsed_us, uint64_t bytes,
                  uint64_t ops, int err) {
     utsname uts = {};
@@ -167,14 +189,14 @@ int prepare_data_file(const Options& opt, const std::string& path, char fill) {
             n = opt.file_size - done;
         }
         if (!write_full(fd, buf.data(), n)) {
-            err = errno;
+            err = errno_or_eio();
             break;
         }
     }
-    if (err == 0 && fsync(fd) != 0) {
-        err = errno;
+    if (err == 0) {
+        fsync_preserve_error(fd, &err);
     }
-    close(fd);
+    close_preserve_error(fd, &err);
     return err;
 }
 
@@ -189,7 +211,10 @@ int metadata_workload(const Options& opt, const std::string& root) {
             err = errno;
             break;
         }
-        close(fd);
+        close_preserve_error(fd, &err);
+        if (err != 0) {
+            break;
+        }
         struct stat st = {};
         if (stat(p.c_str(), &st) != 0) {
             err = errno;
@@ -223,14 +248,16 @@ int sequential_workload(const Options& opt, const std::string& root) {
                 n = opt.file_size - done;
             }
             if (!write_full(fd, buf.data(), n)) {
-                err = errno;
+                err = errno_or_eio();
                 break;
             }
             bytes += n;
             ++ops;
         }
-        fsync(fd);
-        close(fd);
+        if (err == 0) {
+            fsync_preserve_error(fd, &err);
+        }
+        close_preserve_error(fd, &err);
     }
     emit_result("sequential_write", opt, now_us() - start, bytes, ops, err);
     if (err != 0) {
@@ -324,6 +351,8 @@ struct WorkerArg {
     size_t id;
     int err;
     uint64_t bytes;
+    uint64_t ops;
+    bool started;
 };
 
 void* worker_main(void* raw) {
@@ -337,14 +366,16 @@ void* worker_main(void* raw) {
     }
     for (size_t i = 0; i < arg->opt.iterations; ++i) {
         if (!write_full(fd, buf.data(), buf.size())) {
-            arg->err = errno;
-            close(fd);
-            return nullptr;
+            arg->err = errno_or_eio();
+            break;
         }
         arg->bytes += buf.size();
+        ++arg->ops;
     }
-    fsync(fd);
-    close(fd);
+    if (arg->err == 0) {
+        fsync_preserve_error(fd, &arg->err);
+    }
+    close_preserve_error(fd, &arg->err);
     return nullptr;
 }
 
@@ -358,21 +389,33 @@ int concurrent_workload(const Options& opt, const std::string& root) {
         args[i].id = i;
         args[i].err = 0;
         args[i].bytes = 0;
-        if (pthread_create(&threads[i], nullptr, worker_main, &args[i]) != 0) {
-            args[i].err = errno;
+        args[i].ops = 0;
+        args[i].started = false;
+        int rc = pthread_create(&threads[i], nullptr, worker_main, &args[i]);
+        if (rc != 0) {
+            args[i].err = rc;
+        } else {
+            args[i].started = true;
         }
     }
     uint64_t bytes = 0;
+    uint64_t ops = 0;
     int err = 0;
     for (size_t i = 0; i < opt.workers; ++i) {
-        pthread_join(threads[i], nullptr);
+        if (args[i].started) {
+            int rc = pthread_join(threads[i], nullptr);
+            if (rc != 0) {
+                record_first_error(&err, rc);
+                continue;
+            }
+        }
         bytes += args[i].bytes;
+        ops += args[i].ops;
         if (args[i].err != 0 && err == 0) {
             err = args[i].err;
         }
     }
-    emit_result("concurrent_write", opt, now_us() - start, bytes, opt.workers * opt.iterations,
-                err);
+    emit_result("concurrent_write", opt, now_us() - start, bytes, ops, err);
     return err == 0 ? 0 : -1;
 }
 

--- a/user/dadk/config/all/virtiofs_bench.toml
+++ b/user/dadk/config/all/virtiofs_bench.toml
@@ -1,0 +1,36 @@
+# 用户程序名称
+name = "virtiofs_bench"
+# 版本号
+version = "0.1.0"
+# 用户程序描述信息
+description = "Guest-local virtiofs benchmark and DragonOS fuse stats delta helper"
+# （可选）是否只构建一次，如果为true，DADK会在构建成功后，将构建结果缓存起来，下次构建时，直接使用缓存的构建结果
+build-once = false
+#  (可选) 是否只安装一次，如果为true，DADK会在安装成功后，不再重复安装
+install-once = false
+# 目标架构
+# 可选值："x86_64", "aarch64", "riscv64"
+target-arch = ["x86_64"]
+
+[task-source]
+# 构建类型
+# 可选值："build-from_source", "install-from-prebuilt"
+type = "build-from-source"
+# 构建来源
+# "build_from_source" 可选值："git", "local", "archive"
+# "install_from_prebuilt" 可选值："local", "archive"
+source = "local"
+# 路径或URL
+source-path = "user/apps/virtiofs_bench"
+
+[build]
+# （可选）构建命令
+build-command = "make install"
+
+[install]
+# （可选）安装到DragonOS的路径
+in-dragonos-path = "/bin"
+
+[clean]
+# （可选）清除命令
+clean-command = "make clean"

--- a/user/dadk/config/sets/default/virtiofs_bench.toml
+++ b/user/dadk/config/sets/default/virtiofs_bench.toml
@@ -1,0 +1,1 @@
+../../all/virtiofs_bench.toml

--- a/user/dadk/config/sets/ubuntu2404/virtiofs_bench.toml
+++ b/user/dadk/config/sets/ubuntu2404/virtiofs_bench.toml
@@ -1,0 +1,1 @@
+../../all/virtiofs_bench.toml


### PR DESCRIPTION
## Summary

- add DragonOS FUSE/virtiofs debugfs counters and trace helpers
- add a guest-side virtiofs benchmark DADK app with automatic temporary mounting
- add dunitest coverage for debugfs stats and document the benchmark runbook in Chinese and English

## Validation

- make fmt
- make kernel
- make -C user/apps/tests/dunitest build-suites
- make test-dunit DUNITEST_PATTERN=fuse_stats_debugfs
- make user
- SKIP_GRUB=1 make write_diskimage
- DragonOS QEMU virtiofs smoke and /bin/virtiofs_bench default all workload

Close: https://github.com/DragonOS-Community/DragonOS/issues/2012