### PR TITLE
fix(overlayfs): reject invalid mount options

### DIFF
--- a/kernel/src/filesystem/overlayfs/mod.rs
+++ b/kernel/src/filesystem/overlayfs/mod.rs
@@ -5,6 +5,7 @@ pub mod entry;
 use super::page_cache::PageCache;
 use super::ramfs::{LockedRamFSInode, RamFSInode};
 use super::vfs::file::{File, FileFlags, FilePrivateData};
+use super::vfs::mount::MountFSInode;
 use super::vfs::utils::DName;
 use super::vfs::vcore;
 use super::vfs::FSMAKER;
@@ -33,6 +34,8 @@ use system_error::SystemError;
 const WHITEOUT_MODE: u64 = 0o020000 | 0o600; // whiteout字符设备文件模式与权限
 const WHITEOUT_DEV: DeviceNumber = DeviceNumber::new(Major::UNNAMED_MAJOR, 0); // Whiteout 文件设备号
 const WHITEOUT_FLAG: u64 = 0x1;
+const OVL_MAX_STACK: usize = 500;
+const MAX_MOUNT_ANCESTOR_DEPTH: usize = vfs::MAX_PATHLEN;
 static OVL_TEMP_ID: AtomicUsize = AtomicUsize::new(0);
 type LowerRoot = (String, Arc<dyn IndexNode>);
 type WorkdirTemp = (Arc<dyn IndexNode>, Arc<dyn IndexNode>, String);
@@ -79,29 +82,51 @@ pub struct OverlayMountData {
 
 impl OverlayMountData {
     pub fn from_raw(raw_data: Option<&str>) -> Result<Self, SystemError> {
-        if raw_data.is_none() {
+        let raw_str = raw_data.ok_or(SystemError::EINVAL)?;
+        if raw_str.is_empty() {
             return Err(SystemError::EINVAL);
         }
-        let raw_str = raw_data.unwrap();
-        let mut data = OverlayMountData {
-            upper_dir: String::new(),
-            lower_dirs: Vec::new(),
-            work_dir: String::new(),
-        };
+        let mut upper_dir = None;
+        let mut lower_dirs = None;
+        let mut work_dir = None;
 
         for pair in raw_str.split(',') {
-            let mut parts = pair.split('=');
-            let key = parts.next().ok_or(SystemError::EINVAL)?;
-            let value = parts.next().ok_or(SystemError::EINVAL)?;
+            let (key, value) = pair.split_once('=').ok_or(SystemError::EINVAL)?;
+            if key.is_empty() || value.is_empty() {
+                return Err(SystemError::EINVAL);
+            }
 
             match key {
-                "upperdir" => data.upper_dir = value.into(),
-                "lowerdir" => data.lower_dirs = value.split(':').map(|s| s.into()).collect(),
-                "workdir" => data.work_dir = value.into(),
+                "upperdir" => upper_dir = Some(value.into()),
+                "lowerdir" => lower_dirs = Some(Self::parse_lower_dirs(value)?),
+                "workdir" => work_dir = Some(value.into()),
                 _ => return Err(SystemError::EINVAL),
             }
         }
-        Ok(data)
+
+        Ok(OverlayMountData {
+            upper_dir: upper_dir.ok_or(SystemError::EINVAL)?,
+            lower_dirs: lower_dirs.ok_or(SystemError::EINVAL)?,
+            work_dir: work_dir.ok_or(SystemError::EINVAL)?,
+        })
+    }
+
+    fn parse_lower_dirs(raw: &str) -> Result<Vec<String>, SystemError> {
+        let mut lower_dirs = Vec::new();
+        for dir in raw.split(':') {
+            if dir.is_empty() {
+                return Err(SystemError::EINVAL);
+            }
+            if lower_dirs.len() == OVL_MAX_STACK {
+                return Err(SystemError::EINVAL);
+            }
+            lower_dirs.push(dir.into());
+        }
+
+        if lower_dirs.is_empty() {
+            return Err(SystemError::EINVAL);
+        }
+        Ok(lower_dirs)
     }
 }
 impl FileSystemMakerData for OverlayMountData {
@@ -190,6 +215,71 @@ impl OverlayFS {
     pub fn ovl_upper_mnt(&self) -> Arc<OvlInode> {
         self.layers[0].mnt.clone()
     }
+
+    fn same_mount_inode(
+        left: &Arc<dyn IndexNode>,
+        right: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        let left = Self::canonical_inode(left.clone());
+        let right = Self::canonical_inode(right.clone());
+        if !Arc::ptr_eq(&left.fs(), &right.fs()) {
+            return Ok(false);
+        }
+
+        Ok(left.metadata()?.inode_id == right.metadata()?.inode_id)
+    }
+
+    fn is_mount_ancestor(
+        ancestor: &Arc<dyn IndexNode>,
+        node: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        let ancestor = Self::canonical_inode(ancestor.clone());
+        let node = Self::canonical_inode(node.clone());
+        if !Arc::ptr_eq(&ancestor.fs(), &node.fs()) {
+            return Ok(false);
+        }
+
+        let mut current = node;
+        for _ in 0..MAX_MOUNT_ANCESTOR_DEPTH {
+            if Self::same_mount_inode(&ancestor, &current)? {
+                return Ok(true);
+            }
+
+            let parent = Self::canonical_inode(current.parent().map_err(|_| SystemError::EINVAL)?);
+            if Self::same_mount_inode(&parent, &current)? {
+                return Ok(false);
+            }
+            if !Arc::ptr_eq(&ancestor.fs(), &parent.fs()) {
+                return Ok(false);
+            }
+            current = parent;
+        }
+
+        Err(SystemError::ELOOP)
+    }
+
+    fn canonical_inode(mut inode: Arc<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        while let Some(mount_inode) = inode.clone().downcast_arc::<MountFSInode>() {
+            inode = mount_inode.underlying_inode();
+        }
+        inode
+    }
+
+    fn layers_overlap_either_direction(
+        left: &Arc<dyn IndexNode>,
+        right: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        Ok(Self::same_mount_inode(left, right)?
+            || Self::is_mount_ancestor(left, right)?
+            || Self::is_mount_ancestor(right, left)?)
+    }
+
+    fn layer_is_same_or_descendant_of(
+        layer: &Arc<dyn IndexNode>,
+        ancestor: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        Ok(Self::same_mount_inode(layer, ancestor)? || Self::is_mount_ancestor(ancestor, layer)?)
+    }
 }
 
 impl MountableFileSystem for OverlayFS {
@@ -204,6 +294,9 @@ impl MountableFileSystem for OverlayFS {
             .lookup(&mount_data.upper_dir)
             .map_err(|_| SystemError::EINVAL)?;
         let upper_file_type = upper_inode.metadata()?.file_type;
+        if upper_file_type != FileType::Dir {
+            return Err(SystemError::EINVAL);
+        }
         let upper_layer = OvlLayer {
             mnt: Arc::new(OvlInode::new(
                 mount_data.upper_dir.clone(),
@@ -223,6 +316,9 @@ impl MountableFileSystem for OverlayFS {
                     .root_inode()
                     .lookup(dir)
                     .map_err(|_| SystemError::EINVAL)?;
+                if lower_inode.metadata()?.file_type != FileType::Dir {
+                    return Err(SystemError::EINVAL);
+                }
                 Ok((dir.clone(), lower_inode))
             })
             .collect();
@@ -252,14 +348,26 @@ impl MountableFileSystem for OverlayFS {
         let workdir_inode = root_inode
             .lookup(&mount_data.work_dir)
             .map_err(|_| SystemError::EINVAL)?;
-        if upper_file_type != FileType::Dir || workdir_inode.metadata()?.file_type != FileType::Dir
+        if workdir_inode.metadata()?.file_type != FileType::Dir {
+            return Err(SystemError::EINVAL);
+        }
+        if !Arc::ptr_eq(&upper_inode.fs(), &workdir_inode.fs())
+            || Self::layers_overlap_either_direction(&upper_inode, &workdir_inode)?
         {
             return Err(SystemError::EINVAL);
         }
-        if Arc::ptr_eq(&upper_inode, &workdir_inode)
-            || !Arc::ptr_eq(&upper_inode.fs(), &workdir_inode.fs())
-        {
-            return Err(SystemError::EINVAL);
+        for (i, (_, lower_inode)) in lower_roots.iter().enumerate() {
+            if Self::layer_is_same_or_descendant_of(lower_inode, &upper_inode)?
+                || Self::layer_is_same_or_descendant_of(lower_inode, &workdir_inode)?
+            {
+                return Err(SystemError::ELOOP);
+            }
+
+            for (_, other_lower_inode) in lower_roots.iter().skip(i + 1) {
+                if Self::layers_overlap_either_direction(lower_inode, other_lower_inode)? {
+                    return Err(SystemError::ELOOP);
+                }
+            }
         }
 
         if lower_roots.is_empty() {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_mount_validation.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_mount_validation.cc
@@ -1,0 +1,340 @@
+#include <gtest/gtest.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <string>
+#include <utility>
+#include <vector>
+#include <unistd.h>
+
+#ifndef MS_BIND
+#define MS_BIND 4096
+#endif
+
+namespace {
+
+int ensure_dir(const char* path) {
+    struct stat st = {};
+    if (stat(path, &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+    return mkdir(path, 0755);
+}
+
+std::string join_path(const std::string& dir, const char* name) {
+    return dir + "/" + name;
+}
+
+int write_text(const std::string& path, const char* text) {
+    FILE* file = fopen(path.c_str(), "w");
+    if (file == nullptr) {
+        return -1;
+    }
+    int ret = fputs(text, file);
+    int saved_errno = errno;
+    fclose(file);
+    errno = saved_errno;
+    return ret < 0 ? -1 : 0;
+}
+
+std::string read_text(const std::string& path) {
+    char buf[128] = {};
+    FILE* file = fopen(path.c_str(), "r");
+    if (file == nullptr) {
+        return {};
+    }
+    size_t n = fread(buf, 1, sizeof(buf) - 1, file);
+    int saved_errno = errno;
+    fclose(file);
+    errno = saved_errno;
+    return std::string(buf, n);
+}
+
+void remove_recursive(const std::string& path) {
+    struct stat st = {};
+    if (lstat(path.c_str(), &st) != 0) {
+        return;
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        unlink(path.c_str());
+        return;
+    }
+
+    DIR* dir = opendir(path.c_str());
+    if (dir != nullptr) {
+        while (dirent* ent = readdir(dir)) {
+            if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
+                continue;
+            }
+            remove_recursive(join_path(path, ent->d_name));
+        }
+        closedir(dir);
+    }
+    rmdir(path.c_str());
+}
+
+int count_entries(const std::string& path) {
+    DIR* dir = opendir(path.c_str());
+    if (dir == nullptr) {
+        return -1;
+    }
+
+    int count = 0;
+    while (dirent* ent = readdir(dir)) {
+        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
+            continue;
+        }
+        count++;
+    }
+    closedir(dir);
+    return count;
+}
+
+struct OverlayMountValidationEnv {
+    explicit OverlayMountValidationEnv(const char* name) {
+        root = std::string("/tmp/") + name + "_" + std::to_string(getpid());
+        upper = join_path(root, "u");
+        upper_sibling = join_path(root, "u2");
+        upper_child_work = join_path(upper, "w");
+        work = join_path(root, "w");
+        upper_in_work = join_path(work, "u");
+        lower1 = join_path(root, "l1");
+        lower1_child = join_path(lower1, "child");
+        lower2 = join_path(root, "l2");
+        merged = join_path(root, "m");
+        lower_file = join_path(root, "lower_file");
+    }
+
+    ~OverlayMountValidationEnv() {
+        cleanup_mount();
+        cleanup_bind_mounts();
+        remove_recursive(join_path(root, "u"));
+        remove_recursive(join_path(root, "u2"));
+        remove_recursive(join_path(root, "w"));
+        remove_recursive(join_path(root, "l1"));
+        remove_recursive(join_path(root, "l2"));
+        unlink(lower_file.c_str());
+        rmdir(merged.c_str());
+        rmdir(root.c_str());
+    }
+
+    void prepare() {
+        ASSERT_EQ(0, ensure_dir("/tmp")) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(root.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(upper.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(upper_sibling.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(upper_child_work.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(work.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(upper_in_work.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(lower1.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(lower1_child.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(lower2.c_str())) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(merged.c_str())) << strerror(errno);
+        ASSERT_EQ(0, write_text(lower_file, "not a directory")) << strerror(errno);
+    }
+
+    std::string options(const std::string& lower, const std::string& upper_dir,
+                        const std::string& work_dir) const {
+        return "lowerdir=" + lower + ",upperdir=" + upper_dir + ",workdir=" + work_dir;
+    }
+
+    std::string repeated_lowerdirs(const std::string& dir, int count) const {
+        std::string lower = dir;
+        for (int i = 1; i < count; ++i) {
+            lower += ":" + dir;
+        }
+        return options(lower, upper, work);
+    }
+
+    void bind_mount(const std::string& source, const std::string& target) {
+        ASSERT_EQ(0, mount(source.c_str(), target.c_str(), nullptr, MS_BIND, nullptr))
+            << strerror(errno);
+        bind_mounts.push_back(target);
+    }
+
+    void cleanup_mount() {
+        if (!mounted) {
+            return;
+        }
+        if (umount(merged.c_str()) != 0) {
+            umount2(merged.c_str(), MNT_DETACH);
+        }
+        mounted = false;
+    }
+
+    void cleanup_bind_mounts() {
+        for (auto it = bind_mounts.rbegin(); it != bind_mounts.rend(); ++it) {
+            if (umount(it->c_str()) != 0) {
+                umount2(it->c_str(), MNT_DETACH);
+            }
+        }
+        bind_mounts.clear();
+    }
+
+    void expect_mount_errno(const char* data, int expected_errno) {
+        std::vector<std::pair<std::string, int>> before = {
+            {upper, count_entries(upper)}, {work, count_entries(work)},
+            {lower1, count_entries(lower1)}, {lower2, count_entries(lower2)},
+            {merged, count_entries(merged)},
+        };
+
+        errno = 0;
+        int ret = mount("overlay", merged.c_str(), "overlay", 0, data);
+        int saved_errno = errno;
+        if (ret == 0) {
+            mounted = true;
+            cleanup_mount();
+            FAIL() << "mount unexpectedly succeeded with data="
+                   << (data == nullptr ? "<null>" : data);
+        }
+        EXPECT_EQ(expected_errno, saved_errno)
+            << "unexpected errno for data=" << (data == nullptr ? "<null>" : data) << ": "
+            << strerror(saved_errno);
+
+        for (const auto& entry : before) {
+            EXPECT_EQ(entry.second, count_entries(entry.first))
+                << "invalid mount changed " << entry.first;
+        }
+    }
+
+    void expect_mount_errno(const std::string& data, int expected_errno) {
+        expect_mount_errno(data.c_str(), expected_errno);
+    }
+
+    void expect_mount_ok(const std::string& data) {
+        ASSERT_FALSE(mounted);
+        ASSERT_EQ(0, mount("overlay", merged.c_str(), "overlay", 0, data.c_str()))
+            << strerror(errno);
+        mounted = true;
+    }
+
+    void expect_umount_ok() {
+        ASSERT_TRUE(mounted);
+        ASSERT_EQ(0, umount(merged.c_str())) << strerror(errno);
+        mounted = false;
+    }
+
+    std::string root;
+    std::string upper;
+    std::string upper_sibling;
+    std::string upper_child_work;
+    std::string work;
+    std::string upper_in_work;
+    std::string lower1;
+    std::string lower1_child;
+    std::string lower2;
+    std::string merged;
+    std::string lower_file;
+    std::vector<std::string> bind_mounts;
+    bool mounted = false;
+};
+
+}  // namespace
+
+TEST(OverlayFsMountValidation, RejectsMissingAndEmptyOptions) {
+    OverlayMountValidationEnv env("overlayfs_mount_missing");
+    env.prepare();
+
+    env.expect_mount_errno(nullptr, EINVAL);
+    env.expect_mount_errno("", EINVAL);
+    env.expect_mount_errno("lowerdir=/tmp,workdir=/tmp", EINVAL);
+    env.expect_mount_errno("lowerdir=/tmp,upperdir=/tmp", EINVAL);
+    env.expect_mount_errno("upperdir=/tmp,workdir=/tmp", EINVAL);
+    env.expect_mount_errno(env.options(env.lower1, "", env.work), EINVAL);
+    env.expect_mount_errno(env.options("", env.upper, env.work), EINVAL);
+    env.expect_mount_errno(env.options(env.lower1, env.upper, ""), EINVAL);
+}
+
+TEST(OverlayFsMountValidation, RejectsInvalidLowerdirComponentsAndTypes) {
+    OverlayMountValidationEnv env("overlayfs_mount_lower");
+    env.prepare();
+
+    env.expect_mount_errno(env.options(env.lower1 + ":", env.upper, env.work), EINVAL);
+    env.expect_mount_errno(env.options(":" + env.lower1, env.upper, env.work), EINVAL);
+    env.expect_mount_errno(env.options(env.lower1 + "::" + env.lower2, env.upper, env.work),
+                           EINVAL);
+    env.expect_mount_errno(env.repeated_lowerdirs("/", 501), EINVAL);
+    env.expect_mount_errno(env.options(env.lower_file, env.upper, env.work), EINVAL);
+}
+
+TEST(OverlayFsMountValidation, RejectsUpperWorkOverlap) {
+    OverlayMountValidationEnv env("overlayfs_mount_overlap");
+    env.prepare();
+
+    env.expect_mount_errno(env.options(env.lower1, env.upper, env.upper), EINVAL);
+    env.expect_mount_errno(env.options(env.lower1, env.upper, env.upper + "/."), EINVAL);
+    env.expect_mount_errno(env.options(env.lower1, env.upper, env.upper_child_work), EINVAL);
+    env.expect_mount_errno(env.options(env.lower1, env.upper_in_work, env.work), EINVAL);
+}
+
+TEST(OverlayFsMountValidation, RejectsLowerUpperWorkOverlap) {
+    OverlayMountValidationEnv env("overlayfs_mount_lower_overlap");
+    env.prepare();
+
+    env.expect_mount_errno(env.options(env.upper, env.upper, env.work), ELOOP);
+    env.expect_mount_errno(env.options(env.work, env.upper, env.work), ELOOP);
+    env.expect_mount_errno(env.options(env.upper_child_work, env.upper, env.work), ELOOP);
+    env.expect_mount_errno(env.options(env.upper_in_work, env.upper, env.work), ELOOP);
+}
+
+TEST(OverlayFsMountValidation, RejectsLowerLayerOverlap) {
+    OverlayMountValidationEnv env("overlayfs_mount_lower_layer_overlap");
+    env.prepare();
+
+    env.expect_mount_errno(env.options(env.lower1 + ":" + env.lower1, env.upper, env.work),
+                           ELOOP);
+    env.expect_mount_errno(env.options(env.lower1 + ":" + env.lower1_child, env.upper, env.work),
+                           ELOOP);
+    env.expect_mount_errno(env.options(env.lower1_child + ":" + env.lower1, env.upper, env.work),
+                           ELOOP);
+}
+
+TEST(OverlayFsMountValidation, RejectsBindMountedLowerAlias) {
+    OverlayMountValidationEnv env("overlayfs_mount_bind_lower_alias");
+    env.prepare();
+
+    ASSERT_EQ(0, ensure_dir(join_path(env.lower1, "upper").c_str())) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(join_path(env.lower1, "work").c_str())) << strerror(errno);
+    env.bind_mount(env.lower1, env.lower2);
+    env.expect_mount_errno(
+        env.options(env.lower1, join_path(env.lower1, "upper"), join_path(env.lower2, "work")),
+        EINVAL);
+    env.expect_mount_errno(env.options(env.lower1 + ":" + env.lower2, env.upper, env.work),
+                           ELOOP);
+}
+
+TEST(OverlayFsMountValidation, AcceptsValidSingleAndMultipleLowerdirs) {
+    OverlayMountValidationEnv env("overlayfs_mount_valid");
+    env.prepare();
+
+    std::string sibling_options = env.options(env.lower1, env.upper, env.upper_sibling);
+    env.expect_mount_ok(sibling_options);
+    env.expect_umount_ok();
+
+    ASSERT_EQ(0, ensure_dir(join_path(env.lower1, "upper").c_str())) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(join_path(env.lower1, "work").c_str())) << strerror(errno);
+    std::string lower_parent_options =
+        env.options(env.lower1, join_path(env.lower1, "upper"), join_path(env.lower1, "work"));
+    env.expect_mount_ok(lower_parent_options);
+    env.expect_umount_ok();
+
+    ASSERT_EQ(0, write_text(join_path(env.lower1, "shared"), "lower1")) << strerror(errno);
+    ASSERT_EQ(0, write_text(join_path(env.lower2, "shared"), "lower2")) << strerror(errno);
+    ASSERT_EQ(0, write_text(join_path(env.lower2, "only2"), "only2")) << strerror(errno);
+
+    std::string multi_options =
+        env.options(env.lower1 + ":" + env.lower2, env.upper, env.work);
+    env.expect_mount_ok(multi_options);
+    EXPECT_EQ("lower1", read_text(join_path(env.merged, "shared")));
+    EXPECT_EQ("only2", read_text(join_path(env.merged, "only2")));
+    env.expect_umount_ok();
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -16,6 +16,7 @@ normal/mount_reconfigure
 normal/mount_propagation
 normal/mount_move
 normal/overlayfs_semantics
+normal/overlayfs_mount_validation
 normal/test_fchown_o_path
 normal/proc_self_limits
 normal/proc_fd_devfs_readlink


### PR DESCRIPTION
## Summary

- Validate overlayfs mount data before constructing the filesystem instance.
- Reject missing or empty required options, invalid lowerdir chains, non-directory layers, and Linux-style overlapping lower layers.
- Preserve Linux directionality for lower/upper/work overlap: lower may be an ancestor of upper/work, while lower equal to or below another layer is rejected with ELOOP.
- Add dunitest coverage for invalid mount inputs, layer overlap errno, bind-mount aliases, the 500 lower-layer limit, and valid sibling/multiple-lower mounts.

## Validation

- make fmt
- make kernel
- make -C user/apps/tests/dunitest build-suites
- git diff --check
- make run-nographic
- Guest: /opt/tests/dunitest/bin/normal/overlayfs_mount_validation_test: 7 tests passed, RC:0
- Guest: /opt/tests/dunitest/bin/normal/overlayfs_semantics_test: 25 tests passed, SEM_RC:0
- Sub-agent adversarial review rerun after fixes: no blocking issues remaining; noted only bounded O(n^2 * depth) lower/lower overlap check as a future optimization.

Closes #2001