### PR TITLE
fix(tty): prevent long console input loss

### DIFF
--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         tty::{
             console::ConsoleSwitch,
-            kthread::enqueue_tty_rx_to_vc_from_irq,
+            kthread::{enqueue_tty_rx_to_vc_from_irq, tty_port_input_room},
             termios::{WindowSize, TTY_STD_TERMIOS},
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyDriverType, TtyOperation},
@@ -29,7 +29,11 @@ use crate::{
             VIRTIO_VENDOR_ID,
         },
     },
-    exception::{irqdesc::IrqReturn, IrqNumber},
+    exception::{
+        irqdesc::IrqReturn,
+        tasklet::{tasklet_schedule, Tasklet, TaskletData},
+        IrqNumber,
+    },
     filesystem::kernfs::KernFSInode,
     init::initcall::INITCALL_POSTCORE,
     libs::{
@@ -75,6 +79,22 @@ const VIRTIO_CONSOLE_IRQ_TX_FLUSH_BUDGET: usize = VIRTIO_CONSOLE_TX_CHUNK;
 
 static mut VIRTIO_CONSOLE_DRIVER: Option<Arc<VirtIOConsoleDriver>> = None;
 static mut TTY_HVC_DRIVER: Option<Arc<TtyDriver>> = None;
+
+lazy_static! {
+    static ref VIRTIO_CONSOLE_RX_RETRY_TASKLET: Arc<Tasklet> =
+        Tasklet::new(virtio_console_rx_retry_tasklet, 0, None);
+}
+
+pub fn retry_virtio_console_input() {
+    tasklet_schedule(&VIRTIO_CONSOLE_RX_RETRY_TASKLET);
+}
+
+fn virtio_console_rx_retry_tasklet(_data: usize, _data_obj: Option<Arc<dyn TaskletData>>) {
+    let Some(driver) = (unsafe { VIRTIO_CONSOLE_DRIVER.as_ref().cloned() }) else {
+        return;
+    };
+    driver.retry_input();
+}
 
 #[inline(always)]
 fn tty_hvc_driver() -> &'static Arc<TtyDriver> {
@@ -366,6 +386,7 @@ impl VirtIOConsoleDevice {
                 kobject_common: KObjectCommonData::default(),
                 irq,
                 input_vc_index: None,
+                input_rx_paused: false,
                 output_tty: Weak::new(),
                 outbuf: Vec::with_capacity(VIRTIO_CONSOLE_OUTBUF_SIZE),
                 outbuf_size: VIRTIO_CONSOLE_OUTBUF_SIZE,
@@ -409,6 +430,59 @@ impl VirtIOConsoleDevice {
             tty.tty_wakeup();
         }
     }
+
+    fn pump_input(&self, limit: usize) -> Result<usize, SystemError> {
+        let mut received = 0;
+        while received < limit {
+            let mut inner = self.inner();
+            let Some(vc_index) = inner.input_vc_index else {
+                inner.input_rx_paused = false;
+                break;
+            };
+
+            if tty_port_input_room(vc_index) == 0 {
+                inner.input_rx_paused = true;
+                break;
+            }
+
+            let c = match inner.device_inner.recv(false) {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    inner.input_rx_paused = false;
+                    break;
+                }
+                Err(err) => {
+                    inner.input_rx_paused = false;
+                    return Err(virtio_drivers_error_to_system_error(err));
+                }
+            };
+
+            if enqueue_tty_rx_to_vc_from_irq(vc_index, &[c]) != 1 {
+                inner.input_rx_paused = true;
+                break;
+            }
+
+            match inner.device_inner.recv(true) {
+                Ok(Some(_)) => {
+                    inner.input_rx_paused = false;
+                    received += 1;
+                }
+                Ok(None) => {
+                    inner.input_rx_paused = false;
+                    break;
+                }
+                Err(err) => {
+                    inner.input_rx_paused = false;
+                    return Err(virtio_drivers_error_to_system_error(err));
+                }
+            }
+        }
+        if limit != 0 && received == limit {
+            self.inner().input_rx_paused = true;
+            retry_virtio_console_input();
+        }
+        Ok(received)
+    }
 }
 
 struct InnerVirtIOConsoleDevice {
@@ -419,6 +493,7 @@ struct InnerVirtIOConsoleDevice {
     kobject_common: KObjectCommonData,
     irq: Option<IrqNumber>,
     input_vc_index: Option<usize>,
+    input_rx_paused: bool,
     output_tty: Weak<TtyCore>,
     outbuf: Vec<u8>,
     outbuf_size: usize,
@@ -434,6 +509,7 @@ impl Debug for InnerVirtIOConsoleDevice {
             .field("kobject_common", &self.kobject_common)
             .field("irq", &self.irq)
             .field("input_vc_index", &self.input_vc_index)
+            .field("input_rx_paused", &self.input_rx_paused)
             .field("outbuf_len", &self.outbuf.len())
             .field("outbuf_size", &self.outbuf_size)
             .field("flush_pending", &self.flush_pending)
@@ -636,37 +712,7 @@ impl Device for VirtIOConsoleDevice {
 
 impl VirtIODevice for VirtIOConsoleDevice {
     fn handle_irq(&self, _irq: IrqNumber) -> Result<IrqReturn, SystemError> {
-        let mut buf = [0u8; 256];
-        let mut index = 0;
-        let mut received = 0;
-        let target_vc_index = self.inner().input_vc_index;
-
-        // 不能只取固定前缀：virtio-console 驱动会在本地缓存一个已完成的 rx buffer，
-        // 若中断上半部只消费其中一部分，剩余字节不会自动产生新中断，后续输入会错位。
-        // 同时限制单次 IRQ 的处理量，避免宿主持续写入时 hardirq 长时间不返回。
-        while received < VIRTIO_CONSOLE_RX_IRQ_LIMIT {
-            match self.inner().device_inner.recv(true) {
-                Ok(Some(c)) => {
-                    buf[index] = c;
-                    index += 1;
-                    received += 1;
-                    if index == buf.len() {
-                        if let Some(vc_index) = target_vc_index {
-                            enqueue_tty_rx_to_vc_from_irq(vc_index, &buf);
-                        }
-                        index = 0;
-                    }
-                }
-                Ok(None) => break,
-                Err(_) => break,
-            }
-        }
-
-        if index > 0 {
-            if let Some(vc_index) = target_vc_index {
-                enqueue_tty_rx_to_vc_from_irq(vc_index, &buf[0..index]);
-            }
-        }
+        let _ = self.pump_input(VIRTIO_CONSOLE_RX_IRQ_LIMIT);
         if let Ok((_, tty)) = self.flush_output_budget(VIRTIO_CONSOLE_IRQ_TX_FLUSH_BUDGET) {
             Self::wake_output_tty(tty);
         }
@@ -747,6 +793,16 @@ impl VirtIOConsoleDriver {
 
     fn inner(&self) -> SpinLockGuard<'_, InnerVirtIOConsoleDriver> {
         self.inner.lock()
+    }
+
+    fn retry_input(&self) {
+        let devices = self.devices.read();
+        for dev in devices.iter().flatten() {
+            let paused = dev.inner().input_rx_paused;
+            if paused {
+                let _ = dev.pump_input(VIRTIO_CONSOLE_RX_IRQ_LIMIT);
+            }
+        }
     }
 
     fn do_install(
@@ -925,7 +981,19 @@ impl TtyOperation for VirtIOConsoleDriver {
             return Ok(());
         }
 
-        if let Some(dev) = self.devices.read()[index].clone() {
+        let dev = self.devices.read()[index].clone();
+        if let Some(dev) = &dev {
+            let mut inner = dev.inner();
+            inner.input_vc_index = None;
+            inner.input_rx_paused = false;
+        }
+
+        if let Some(port) = tty.core().port() {
+            port.clear_input();
+        }
+        tty.ldisc().flush_buffer(tty.clone())?;
+
+        if let Some(dev) = dev {
             match dev.flush_output_budget(VIRTIO_CONSOLE_TX_FLUSH_BUDGET) {
                 Ok((_, wake_tty)) => {
                     let close_wake = {
@@ -939,10 +1007,12 @@ impl TtyOperation for VirtIOConsoleDriver {
                     let mut inner = dev.inner();
                     inner.discard_unsubmitted_output_locked();
                     let wake_tty = inner.output_tty.upgrade();
+                    inner.output_tty = Weak::new();
                     drop(inner);
                     VirtIOConsoleDevice::wake_output_tty(wake_tty);
                 }
             }
+            dev.inner().output_tty = Weak::new();
         }
 
         Ok(())
@@ -977,17 +1047,20 @@ impl TtyOperation for VirtIOConsoleDriver {
 
         let vc = VirtConsole::new(Some(vc_data));
         let vc_index = vc_manager().alloc(vc.clone()).ok_or(SystemError::EBUSY)?;
+        self.do_install(driver, tty.clone(), vc.clone())
+            .inspect_err(|_| {
+                vc_manager().free(vc_index);
+                let mut inner = dev.inner();
+                inner.input_vc_index = None;
+                inner.output_tty = Weak::new();
+            })?;
         {
             let mut inner = dev.inner();
             inner.input_vc_index = Some(vc_index);
+            inner.input_rx_paused = false;
             inner.output_tty = Arc::downgrade(&tty);
         }
-        self.do_install(driver, tty, vc.clone()).inspect_err(|_| {
-            vc_manager().free(vc_index);
-            let mut inner = dev.inner();
-            inner.input_vc_index = None;
-            inner.output_tty = Weak::new();
-        })?;
+        let _ = dev.pump_input(VIRTIO_CONSOLE_RX_IRQ_LIMIT);
 
         Ok(())
     }

--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         tty::{
             console::ConsoleSwitch,
-            kthread::{enqueue_tty_rx_to_vc_from_irq, tty_port_input_room},
+            kthread::{enqueue_tty_rx_to_target_from_irq, tty_input_target_room, TtyInputTarget},
             termios::{WindowSize, TTY_STD_TERMIOS},
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyDriverType, TtyOperation},
@@ -385,7 +385,7 @@ impl VirtIOConsoleDevice {
                 device_common: DeviceCommonData::default(),
                 kobject_common: KObjectCommonData::default(),
                 irq,
-                input_vc_index: None,
+                input_target: None,
                 input_rx_paused: false,
                 output_tty: Weak::new(),
                 outbuf: Vec::with_capacity(VIRTIO_CONSOLE_OUTBUF_SIZE),
@@ -435,12 +435,12 @@ impl VirtIOConsoleDevice {
         let mut received = 0;
         while received < limit {
             let mut inner = self.inner();
-            let Some(vc_index) = inner.input_vc_index else {
+            let Some(target) = inner.input_target.clone() else {
                 inner.input_rx_paused = false;
                 break;
             };
 
-            if tty_port_input_room(vc_index) == 0 {
+            if tty_input_target_room(&target) == 0 {
                 inner.input_rx_paused = true;
                 break;
             }
@@ -457,7 +457,7 @@ impl VirtIOConsoleDevice {
                 }
             };
 
-            if enqueue_tty_rx_to_vc_from_irq(vc_index, &[c]) != 1 {
+            if enqueue_tty_rx_to_target_from_irq(&target, &[c]) != 1 {
                 inner.input_rx_paused = true;
                 break;
             }
@@ -492,7 +492,7 @@ struct InnerVirtIOConsoleDevice {
     device_common: DeviceCommonData,
     kobject_common: KObjectCommonData,
     irq: Option<IrqNumber>,
-    input_vc_index: Option<usize>,
+    input_target: Option<TtyInputTarget>,
     input_rx_paused: bool,
     output_tty: Weak<TtyCore>,
     outbuf: Vec<u8>,
@@ -508,7 +508,7 @@ impl Debug for InnerVirtIOConsoleDevice {
             .field("device_common", &self.device_common)
             .field("kobject_common", &self.kobject_common)
             .field("irq", &self.irq)
-            .field("input_vc_index", &self.input_vc_index)
+            .field("input_target", &self.input_target)
             .field("input_rx_paused", &self.input_rx_paused)
             .field("outbuf_len", &self.outbuf.len())
             .field("outbuf_size", &self.outbuf_size)
@@ -984,7 +984,7 @@ impl TtyOperation for VirtIOConsoleDriver {
         let dev = self.devices.read()[index].clone();
         if let Some(dev) = &dev {
             let mut inner = dev.inner();
-            inner.input_vc_index = None;
+            inner.input_target = None;
             inner.input_rx_paused = false;
         }
 
@@ -1051,12 +1051,12 @@ impl TtyOperation for VirtIOConsoleDriver {
             .inspect_err(|_| {
                 vc_manager().free(vc_index);
                 let mut inner = dev.inner();
-                inner.input_vc_index = None;
+                inner.input_target = None;
                 inner.output_tty = Weak::new();
             })?;
         {
             let mut inner = dev.inner();
-            inner.input_vc_index = Some(vc_index);
+            inner.input_target = Some(TtyInputTarget::new(vc_index, vc.port()));
             inner.input_rx_paused = false;
             inner.output_tty = Arc::downgrade(&tty);
         }

--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -982,15 +982,6 @@ impl TtyOperation for VirtIOConsoleDriver {
         }
 
         let dev = self.devices.read()[index].clone();
-        if let Some(dev) = &dev {
-            let mut inner = dev.inner();
-            inner.input_target = None;
-            inner.input_rx_paused = false;
-        }
-
-        if let Some(port) = tty.core().port() {
-            port.clear_input();
-        }
         tty.ldisc().flush_buffer(tty.clone())?;
 
         if let Some(dev) = dev {
@@ -1007,12 +998,10 @@ impl TtyOperation for VirtIOConsoleDriver {
                     let mut inner = dev.inner();
                     inner.discard_unsubmitted_output_locked();
                     let wake_tty = inner.output_tty.upgrade();
-                    inner.output_tty = Weak::new();
                     drop(inner);
                     VirtIOConsoleDevice::wake_output_tty(wake_tty);
                 }
             }
-            dev.inner().output_tty = Weak::new();
         }
 
         Ok(())

--- a/kernel/src/driver/serial/serial8250/mod.rs
+++ b/kernel/src/driver/serial/serial8250/mod.rs
@@ -35,8 +35,9 @@ use crate::{
 
 #[cfg(target_arch = "x86_64")]
 use self::serial8250_pio::{
-    send_to_default_serial8250_pio_port, serial8250_pio_port_early_init,
-    serial_8250_pio_register_tty_devices, Serial8250PIOTtyDriverInner,
+    retry_serial8250_pio_input, send_to_default_serial8250_pio_port,
+    serial8250_pio_port_early_init, serial_8250_pio_register_tty_devices,
+    Serial8250PIOTtyDriverInner,
 };
 
 use super::{uart_manager, UartDriver, UartManager, UartPort, TTY_SERIAL_DEFAULT_TERMIOS};
@@ -46,6 +47,11 @@ mod serial8250_pio;
 
 #[cfg(target_arch = "loongarch64")]
 mod serial8250_la64;
+
+pub fn retry_serial8250_input() {
+    #[cfg(target_arch = "x86_64")]
+    retry_serial8250_pio_input();
+}
 
 static mut SERIAL8250_ISA_DEVICES: Option<Arc<Serial8250ISADevices>> = None;
 static mut SERIAL8250_ISA_DRIVER: Option<Arc<Serial8250ISADriver>> = None;

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -47,6 +47,7 @@ static mut PIO_PORTS: [Option<Serial8250PIOPort>; 8] =
 
 const SERIAL_8250_PIO_IRQ: IrqNumber = IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4);
 const SERIAL_8250_RX_IRQ_LIMIT: usize = 256;
+const SERIAL_8250_IER_RX_AVAILABLE: u8 = 0x01;
 
 lazy_static! {
     static ref SERIAL_8250_RX_RETRY_TASKLET: Arc<Tasklet> =
@@ -133,11 +134,17 @@ pub struct Serial8250PIOPort {
 #[derive(Debug)]
 struct Serial8250RxState {
     input_target: Option<TtyInputTarget>,
+    ier: u8,
+    irq_registered: bool,
 }
 
 impl Serial8250RxState {
     const fn new() -> Self {
-        Self { input_target: None }
+        Self {
+            input_target: None,
+            ier: 0,
+            irq_registered: false,
+        }
     }
 }
 
@@ -187,10 +194,7 @@ impl Serial8250PIOPort {
             // If serial is not faulty set it in normal operation mode
             // (not-loopback with IRQs enabled and OUT#1 and OUT#2 bits enabled)
             CurrentPortIOArch::out8(port + 4, 0x0b);
-
-            CurrentPortIOArch::out8(port + 1, 0x01); // Enable interrupts
         }
-
         return Ok(());
         /*
                 Notice that the initialization code above writes to [PORT + 1]
@@ -249,10 +253,50 @@ impl Serial8250PIOPort {
         self.rx_state.lock_irqsave().input_target = target;
     }
 
+    fn set_rx_interrupt_enabled(&self, enabled: bool) {
+        let mut rx_state = self.rx_state.lock_irqsave();
+        self.set_rx_interrupt_enabled_locked(&mut rx_state, enabled);
+    }
+
+    fn set_rx_interrupt_enabled_locked(&self, rx_state: &mut Serial8250RxState, enabled: bool) {
+        if enabled {
+            rx_state.ier |= SERIAL_8250_IER_RX_AVAILABLE;
+        } else {
+            rx_state.ier &= !SERIAL_8250_IER_RX_AVAILABLE;
+        }
+        self.sync_ier_locked(rx_state);
+    }
+
+    fn sync_ier_locked(&self, rx_state: &Serial8250RxState) {
+        let ier = if rx_state.irq_registered {
+            rx_state.ier
+        } else {
+            0
+        };
+        self.serial_out(1, ier.into());
+    }
+
+    fn mark_rx_irq_registered(&self) {
+        let mut rx_state = self.rx_state.lock_irqsave();
+        rx_state.irq_registered = true;
+        self.sync_ier_locked(&rx_state);
+    }
+
+    fn pause_rx_locked(&self, rx_state: &mut Serial8250RxState) {
+        self.rx_paused.store(true, Ordering::Release);
+        self.set_rx_interrupt_enabled_locked(rx_state, false);
+    }
+
+    fn resume_rx_locked(&self, rx_state: &mut Serial8250RxState) {
+        self.rx_paused.store(false, Ordering::Release);
+        self.set_rx_interrupt_enabled_locked(rx_state, true);
+    }
+
     fn pump_rx(&self) -> Result<(), SystemError> {
-        let rx_state = self.rx_state.lock_irqsave();
+        let mut rx_state = self.rx_state.lock_irqsave();
         let Some(target) = rx_state.input_target.as_ref() else {
             self.rx_paused.store(false, Ordering::Release);
+            self.set_rx_interrupt_enabled_locked(&mut rx_state, false);
             return Ok(());
         };
 
@@ -267,17 +311,17 @@ impl Serial8250PIOPort {
                     self.rx_paused.store(false, Ordering::Release);
                 }
                 TtyInputByteResult::NoRoom => {
-                    self.rx_paused.store(true, Ordering::Release);
+                    self.pause_rx_locked(&mut rx_state);
                     break;
                 }
                 TtyInputByteResult::NoData => {
-                    self.rx_paused.store(false, Ordering::Release);
+                    self.resume_rx_locked(&mut rx_state);
                     break;
                 }
             }
         }
         if received == SERIAL_8250_RX_IRQ_LIMIT {
-            self.rx_paused.store(true, Ordering::Release);
+            self.pause_rx_locked(&mut rx_state);
             retry_serial8250_pio_input();
         }
         Ok(())
@@ -447,16 +491,6 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
     }
 
     fn close(&self, tty: Arc<TtyCore>) -> Result<(), SystemError> {
-        let tty_index = tty.core().index();
-        if tty_index < unsafe { PIO_PORTS.len() } {
-            if let Some(port) = unsafe { PIO_PORTS[tty_index].as_ref() } {
-                port.set_input_target(None);
-                port.rx_paused.store(false, Ordering::Release);
-            }
-        }
-        if let Some(port) = tty.core().port() {
-            port.clear_input();
-        }
         tty.ldisc().flush_buffer(tty.clone())?;
         Ok(())
     }
@@ -489,10 +523,17 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
             vc_manager().free(vc_index);
             port.set_input_target(None);
             port.rx_paused.store(false, Ordering::Release);
+            port.set_rx_interrupt_enabled(false);
         })?;
-        port.set_input_target(Some(TtyInputTarget::new(vc_index, vc.port())));
-        port.rx_paused.store(true, Ordering::Release);
-        retry_serial8250_pio_input();
+        let irq_registered = {
+            let mut rx_state = port.rx_state.lock_irqsave();
+            rx_state.input_target = Some(TtyInputTarget::new(vc_index, vc.port()));
+            port.pause_rx_locked(&mut rx_state);
+            rx_state.irq_registered
+        };
+        if irq_registered {
+            retry_serial8250_pio_input();
+        }
 
         Ok(())
     }
@@ -536,6 +577,11 @@ pub(super) fn serial_8250_pio_register_tty_devices() -> Result<(), SystemError> 
         .inspect_err(|e| {
             log::error!("failed to request irq for serial 8250 pio: {:?}", e);
         })?;
+
+    for port in unsafe { PIO_PORTS.iter() }.flatten() {
+        port.mark_rx_irq_registered();
+    }
+    retry_serial8250_pio_input();
 
     Ok(())
 }

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -2,7 +2,7 @@
 
 use core::{
     hint::spin_loop,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use alloc::{
@@ -33,6 +33,7 @@ use crate::{
         irqdata::IrqHandlerData,
         irqdesc::{IrqHandleFlags, IrqHandler, IrqReturn},
         manage::irq_manager,
+        tasklet::{tasklet_schedule, Tasklet, TaskletData},
         IrqNumber,
     },
     libs::{rwsem::RwSem, spinlock::SpinLock},
@@ -46,6 +47,25 @@ static mut PIO_PORTS: [Option<Serial8250PIOPort>; 8] =
 
 const SERIAL_8250_PIO_IRQ: IrqNumber = IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4);
 const SERIAL_8250_RX_IRQ_LIMIT: usize = 256;
+const SERIAL_8250_NO_VC_INDEX: usize = usize::MAX;
+
+lazy_static! {
+    static ref SERIAL_8250_RX_RETRY_TASKLET: Arc<Tasklet> =
+        Tasklet::new(serial_8250_rx_retry_tasklet, 0, None);
+}
+
+pub(super) fn retry_serial8250_pio_input() {
+    tasklet_schedule(&SERIAL_8250_RX_RETRY_TASKLET);
+}
+
+#[allow(static_mut_refs)]
+fn serial_8250_rx_retry_tasklet(_data: usize, _data_obj: Option<Arc<dyn TaskletData>>) {
+    for port in unsafe { PIO_PORTS.iter() }.flatten() {
+        if port.rx_paused.load(Ordering::Acquire) {
+            let _ = port.pump_rx();
+        }
+    }
+}
 
 impl Serial8250Manager {
     #[allow(static_mut_refs)]
@@ -106,6 +126,9 @@ pub struct Serial8250PIOPort {
     iobase: Serial8250PortBase,
     baudrate: AtomicBaudRate,
     initialized: AtomicBool,
+    input_vc_index: AtomicUsize,
+    rx_paused: AtomicBool,
+    rx_lock: SpinLock<()>,
     inner: RwSem<Serial8250PIOPortInner>,
 }
 
@@ -116,6 +139,9 @@ impl Serial8250PIOPort {
             iobase,
             baudrate: AtomicBaudRate::new(baudrate),
             initialized: AtomicBool::new(false),
+            input_vc_index: AtomicUsize::new(SERIAL_8250_NO_VC_INDEX),
+            rx_paused: AtomicBool::new(false),
+            rx_lock: SpinLock::new(()),
             inner: RwSem::new(Serial8250PIOPortInner::new()),
         };
 
@@ -210,6 +236,56 @@ impl Serial8250PIOPort {
         }
         return Some(self.serial_in(0) as u8);
     }
+
+    fn input_vc_index(&self) -> Option<usize> {
+        let vc_index = self.input_vc_index.load(Ordering::Acquire);
+        if vc_index == SERIAL_8250_NO_VC_INDEX {
+            None
+        } else {
+            Some(vc_index)
+        }
+    }
+
+    fn set_input_vc_index(&self, vc_index: Option<usize>) {
+        self.input_vc_index.store(
+            vc_index.unwrap_or(SERIAL_8250_NO_VC_INDEX),
+            Ordering::Release,
+        );
+    }
+
+    fn pump_rx(&self) -> Result<(), SystemError> {
+        let _rx_guard = self.rx_lock.lock_irqsave();
+        let Some(target_vc_index) = self.input_vc_index() else {
+            self.rx_paused.store(false, Ordering::Release);
+            return Ok(());
+        };
+
+        // Linux serial8250_rx_chars also keeps a 256-byte bound to avoid
+        // unbounded RX IRQ/softirq CPU occupation.
+        let mut received = 0;
+        for _ in 0..SERIAL_8250_RX_IRQ_LIMIT {
+            let mut producer = || self.read_one_byte();
+            match enqueue_tty_rx_byte_to_vc_from_irq(target_vc_index, &mut producer) {
+                TtyInputByteResult::Enqueued => {
+                    received += 1;
+                    self.rx_paused.store(false, Ordering::Release);
+                }
+                TtyInputByteResult::NoRoom => {
+                    self.rx_paused.store(true, Ordering::Release);
+                    break;
+                }
+                TtyInputByteResult::NoData | TtyInputByteResult::NoTarget => {
+                    self.rx_paused.store(false, Ordering::Release);
+                    break;
+                }
+            }
+        }
+        if received == SERIAL_8250_RX_IRQ_LIMIT {
+            self.rx_paused.store(true, Ordering::Release);
+            retry_serial8250_pio_input();
+        }
+        Ok(())
+    }
 }
 
 impl Serial8250Port for Serial8250PIOPort {
@@ -269,19 +345,7 @@ impl UartPort for Serial8250PIOPort {
     }
 
     fn handle_irq(&self) -> Result<(), SystemError> {
-        let Some(target_vc_index) = self.inner.read().input_vc_index else {
-            return Ok(());
-        };
-
-        // Linux serial8250_rx_chars 同样保留 256 字节上限，避免 RX IRQ 无界占用 CPU。
-        for _ in 0..SERIAL_8250_RX_IRQ_LIMIT {
-            let mut producer = || self.read_one_byte();
-            match enqueue_tty_rx_byte_to_vc_from_irq(target_vc_index, &mut producer) {
-                TtyInputByteResult::Enqueued => {}
-                TtyInputByteResult::NoRoom | TtyInputByteResult::NoData => break,
-            }
-        }
-        Ok(())
+        self.pump_rx()
     }
 
     fn iobase(&self) -> Option<usize> {
@@ -295,15 +359,11 @@ struct Serial8250PIOPortInner {
     ///
     /// ps: 存储weak以避免循环引用
     device: Option<Weak<Serial8250ISADevices>>,
-    input_vc_index: Option<usize>,
 }
 
 impl Serial8250PIOPortInner {
     pub const fn new() -> Self {
-        Self {
-            device: None,
-            input_vc_index: None,
-        }
+        Self { device: None }
     }
 
     #[allow(dead_code)]
@@ -390,7 +450,19 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         Err(SystemError::ENOIOCTLCMD)
     }
 
-    fn close(&self, _tty: Arc<TtyCore>) -> Result<(), SystemError> {
+    fn close(&self, tty: Arc<TtyCore>) -> Result<(), SystemError> {
+        let tty_index = tty.core().index();
+        if tty_index < unsafe { PIO_PORTS.len() } {
+            if let Some(port) = unsafe { PIO_PORTS[tty_index].as_ref() } {
+                let _rx_guard = port.rx_lock.lock_irqsave();
+                port.set_input_vc_index(None);
+                port.rx_paused.store(false, Ordering::Release);
+            }
+        }
+        if let Some(port) = tty.core().port() {
+            port.clear_input();
+        }
+        tty.ldisc().flush_buffer(tty.clone())?;
         Ok(())
     }
 
@@ -416,18 +488,16 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         );
         drop(vc_data_guard);
         let vc = VirtConsole::new(Some(vc_data));
+        let port = unsafe { PIO_PORTS[tty_index].as_ref() }.ok_or(SystemError::ENODEV)?;
         let vc_index = vc_manager().alloc(vc.clone()).ok_or(SystemError::EBUSY)?;
-        unsafe { PIO_PORTS[tty_index].as_ref() }
-            .ok_or(SystemError::ENODEV)?
-            .inner
-            .write()
-            .input_vc_index = Some(vc_index);
         self.do_install(driver, tty, vc.clone()).inspect_err(|_| {
             vc_manager().free(vc_index);
-            if let Some(port) = unsafe { PIO_PORTS[tty_index].as_ref() } {
-                port.inner.write().input_vc_index = None;
-            }
+            port.set_input_vc_index(None);
+            port.rx_paused.store(false, Ordering::Release);
         })?;
+        port.set_input_vc_index(Some(vc_index));
+        port.rx_paused.store(true, Ordering::Release);
+        retry_serial8250_pio_input();
 
         Ok(())
     }

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -2,7 +2,7 @@
 
 use core::{
     hint::spin_loop,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use alloc::{
@@ -20,7 +20,7 @@ use crate::{
         serial::{AtomicBaudRate, BaudRate, DivisorFraction, UartPort},
         tty::{
             console::ConsoleSwitch,
-            kthread::enqueue_tty_rx_byte_to_vc_from_irq,
+            kthread::{enqueue_tty_rx_byte_to_target_from_irq, TtyInputTarget},
             termios::WindowSize,
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyOperation},
@@ -47,7 +47,6 @@ static mut PIO_PORTS: [Option<Serial8250PIOPort>; 8] =
 
 const SERIAL_8250_PIO_IRQ: IrqNumber = IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4);
 const SERIAL_8250_RX_IRQ_LIMIT: usize = 256;
-const SERIAL_8250_NO_VC_INDEX: usize = usize::MAX;
 
 lazy_static! {
     static ref SERIAL_8250_RX_RETRY_TASKLET: Arc<Tasklet> =
@@ -126,10 +125,20 @@ pub struct Serial8250PIOPort {
     iobase: Serial8250PortBase,
     baudrate: AtomicBaudRate,
     initialized: AtomicBool,
-    input_vc_index: AtomicUsize,
     rx_paused: AtomicBool,
-    rx_lock: SpinLock<()>,
+    rx_state: SpinLock<Serial8250RxState>,
     inner: RwSem<Serial8250PIOPortInner>,
+}
+
+#[derive(Debug)]
+struct Serial8250RxState {
+    input_target: Option<TtyInputTarget>,
+}
+
+impl Serial8250RxState {
+    const fn new() -> Self {
+        Self { input_target: None }
+    }
 }
 
 impl Serial8250PIOPort {
@@ -139,9 +148,8 @@ impl Serial8250PIOPort {
             iobase,
             baudrate: AtomicBaudRate::new(baudrate),
             initialized: AtomicBool::new(false),
-            input_vc_index: AtomicUsize::new(SERIAL_8250_NO_VC_INDEX),
             rx_paused: AtomicBool::new(false),
-            rx_lock: SpinLock::new(()),
+            rx_state: SpinLock::new(Serial8250RxState::new()),
             inner: RwSem::new(Serial8250PIOPortInner::new()),
         };
 
@@ -237,25 +245,13 @@ impl Serial8250PIOPort {
         return Some(self.serial_in(0) as u8);
     }
 
-    fn input_vc_index(&self) -> Option<usize> {
-        let vc_index = self.input_vc_index.load(Ordering::Acquire);
-        if vc_index == SERIAL_8250_NO_VC_INDEX {
-            None
-        } else {
-            Some(vc_index)
-        }
-    }
-
-    fn set_input_vc_index(&self, vc_index: Option<usize>) {
-        self.input_vc_index.store(
-            vc_index.unwrap_or(SERIAL_8250_NO_VC_INDEX),
-            Ordering::Release,
-        );
+    fn set_input_target(&self, target: Option<TtyInputTarget>) {
+        self.rx_state.lock_irqsave().input_target = target;
     }
 
     fn pump_rx(&self) -> Result<(), SystemError> {
-        let _rx_guard = self.rx_lock.lock_irqsave();
-        let Some(target_vc_index) = self.input_vc_index() else {
+        let rx_state = self.rx_state.lock_irqsave();
+        let Some(target) = rx_state.input_target.as_ref() else {
             self.rx_paused.store(false, Ordering::Release);
             return Ok(());
         };
@@ -265,7 +261,7 @@ impl Serial8250PIOPort {
         let mut received = 0;
         for _ in 0..SERIAL_8250_RX_IRQ_LIMIT {
             let mut producer = || self.read_one_byte();
-            match enqueue_tty_rx_byte_to_vc_from_irq(target_vc_index, &mut producer) {
+            match enqueue_tty_rx_byte_to_target_from_irq(target, &mut producer) {
                 TtyInputByteResult::Enqueued => {
                     received += 1;
                     self.rx_paused.store(false, Ordering::Release);
@@ -274,7 +270,7 @@ impl Serial8250PIOPort {
                     self.rx_paused.store(true, Ordering::Release);
                     break;
                 }
-                TtyInputByteResult::NoData | TtyInputByteResult::NoTarget => {
+                TtyInputByteResult::NoData => {
                     self.rx_paused.store(false, Ordering::Release);
                     break;
                 }
@@ -454,8 +450,7 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         let tty_index = tty.core().index();
         if tty_index < unsafe { PIO_PORTS.len() } {
             if let Some(port) = unsafe { PIO_PORTS[tty_index].as_ref() } {
-                let _rx_guard = port.rx_lock.lock_irqsave();
-                port.set_input_vc_index(None);
+                port.set_input_target(None);
                 port.rx_paused.store(false, Ordering::Release);
             }
         }
@@ -492,10 +487,10 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         let vc_index = vc_manager().alloc(vc.clone()).ok_or(SystemError::EBUSY)?;
         self.do_install(driver, tty, vc.clone()).inspect_err(|_| {
             vc_manager().free(vc_index);
-            port.set_input_vc_index(None);
+            port.set_input_target(None);
             port.rx_paused.store(false, Ordering::Release);
         })?;
-        port.set_input_vc_index(Some(vc_index));
+        port.set_input_target(Some(TtyInputTarget::new(vc_index, vc.port())));
         port.rx_paused.store(true, Ordering::Release);
         retry_serial8250_pio_input();
 

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -20,10 +20,11 @@ use crate::{
         serial::{AtomicBaudRate, BaudRate, DivisorFraction, UartPort},
         tty::{
             console::ConsoleSwitch,
-            kthread::enqueue_tty_rx_to_vc_from_irq,
+            kthread::enqueue_tty_rx_byte_to_vc_from_irq,
             termios::WindowSize,
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyOperation},
+            tty_port::TtyInputByteResult,
             virtual_terminal::{vc_manager, virtual_console::VirtualConsoleData, VirtConsole},
         },
         video::console::dummycon::dummy_console,
@@ -268,22 +269,16 @@ impl UartPort for Serial8250PIOPort {
     }
 
     fn handle_irq(&self) -> Result<(), SystemError> {
-        let mut buf = [0; SERIAL_8250_RX_IRQ_LIMIT];
-        let mut index = 0;
-        let target_vc_index = self.inner.read().input_vc_index;
+        let Some(target_vc_index) = self.inner.read().input_vc_index else {
+            return Ok(());
+        };
 
         // Linux serial8250_rx_chars 同样保留 256 字节上限，避免 RX IRQ 无界占用 CPU。
-        while index < SERIAL_8250_RX_IRQ_LIMIT {
-            let Some(c) = self.read_one_byte() else {
-                break;
-            };
-            buf[index] = c;
-            index += 1;
-        }
-
-        if index > 0 {
-            if let Some(vc_index) = target_vc_index {
-                enqueue_tty_rx_to_vc_from_irq(vc_index, &buf[0..index]);
+        for _ in 0..SERIAL_8250_RX_IRQ_LIMIT {
+            let mut producer = || self.read_one_byte();
+            match enqueue_tty_rx_byte_to_vc_from_irq(target_vc_index, &mut producer) {
+                TtyInputByteResult::Enqueued => {}
+                TtyInputByteResult::NoRoom | TtyInputByteResult::NoData => break,
             }
         }
         Ok(())

--- a/kernel/src/driver/tty/kthread.rs
+++ b/kernel/src/driver/tty/kthread.rs
@@ -1,122 +1,206 @@
 //! tty刷新内核线程
 
 use alloc::{string::ToString, sync::Arc};
-use kdepends::thingbuf::StaticThingBuf;
 
 use crate::{
-    arch::CurrentIrqArch,
-    driver::tty::virtual_terminal::vc_manager,
-    exception::tasklet::{tasklet_schedule, Tasklet, TaskletData},
-    exception::InterruptArch,
-    process::{
-        kthread::{KernelThreadClosure, KernelThreadMechanism},
-        ProcessControlBlock, ProcessManager,
+    driver::{
+        char::virtio_console::retry_virtio_console_input,
+        tty::{
+            tty_core::TtyCore,
+            tty_port::{TtyInputByteResult, TTY_PORT_RX_CHUNK_SIZE},
+            virtual_terminal::{vc_manager, MAX_NR_CONSOLES},
+        },
     },
+    exception::tasklet::{tasklet_schedule, Tasklet, TaskletData},
+    libs::wait_queue::WaitQueue,
+    process::kthread::{KernelThreadClosure, KernelThreadMechanism},
     sched::{schedule, SchedMode},
 };
 
-/// 用于缓存 IRQ 上下文投递的 TTY 输入。
-///
-/// N_TTY 规范模式按 Linux 语义支持 4096 字节行缓冲；这里的 IRQ 暂存队列必须
-/// 大于该长度，避免输入还没进入行规程就被提前截断。
-const TTY_RX_IRQ_BUF_SIZE: usize = 8192;
+const TTY_INPUT_WORK_QUEUE_SIZE: usize = MAX_NR_CONSOLES as usize;
+const TTY_INPUT_DRAIN_BUDGET: usize = 16;
 
-/// 单次从 IRQ 暂存队列投递给行规程的最大字节数。
-const TTY_RX_DEQUEUE_MAX: usize = 256;
-
-#[derive(Clone, Copy, Default)]
-struct TtyRxItem {
-    vc_index: usize,
-    byte: u8,
+struct TtyInputWorkQueue {
+    queue: [usize; TTY_INPUT_WORK_QUEUE_SIZE],
+    in_queue: [bool; TTY_INPUT_WORK_QUEUE_SIZE],
+    head: usize,
+    len: usize,
 }
 
-static KEYBUF: StaticThingBuf<TtyRxItem, TTY_RX_IRQ_BUF_SIZE> = StaticThingBuf::new();
+impl TtyInputWorkQueue {
+    const fn new() -> Self {
+        Self {
+            queue: [0; TTY_INPUT_WORK_QUEUE_SIZE],
+            in_queue: [false; TTY_INPUT_WORK_QUEUE_SIZE],
+            head: 0,
+            len: 0,
+        }
+    }
 
-static mut TTY_REFRESH_THREAD: Option<Arc<ProcessControlBlock>> = None;
+    fn push(&mut self, vc_index: usize) -> bool {
+        if vc_index >= TTY_INPUT_WORK_QUEUE_SIZE || self.in_queue[vc_index] {
+            return false;
+        }
+        debug_assert!(self.len < TTY_INPUT_WORK_QUEUE_SIZE);
+        if self.len >= TTY_INPUT_WORK_QUEUE_SIZE {
+            return false;
+        }
+        let idx = (self.head + self.len) % TTY_INPUT_WORK_QUEUE_SIZE;
+        self.queue[idx] = vc_index;
+        self.in_queue[vc_index] = true;
+        self.len += 1;
+        true
+    }
+
+    fn pop(&mut self) -> Option<usize> {
+        if self.len == 0 {
+            return None;
+        }
+        let vc_index = self.queue[self.head];
+        self.head = (self.head + 1) % TTY_INPUT_WORK_QUEUE_SIZE;
+        self.len -= 1;
+        self.in_queue[vc_index] = false;
+        if self.len == 0 {
+            self.head = 0;
+        }
+        Some(vc_index)
+    }
+}
+
+static TTY_INPUT_WORK_QUEUE: crate::libs::spinlock::SpinLock<TtyInputWorkQueue> =
+    crate::libs::spinlock::SpinLock::new(TtyInputWorkQueue::new());
+static TTY_REFRESH_WAIT_QUEUE: WaitQueue = WaitQueue::default();
 
 lazy_static! {
-    /// TTY RX tasklet，用于在 softirq 上下文中处理 TTY 输入
+    /// TTY RX tasklet that wakes the TTY input thread from softirq context.
     static ref TTY_RX_TASKLET: Arc<Tasklet> = Tasklet::new(tty_rx_tasklet_fn, 0, None);
 }
 
 pub(super) fn tty_flush_thread_init() {
     let closure =
         KernelThreadClosure::StaticEmptyClosure((&(tty_refresh_thread as fn() -> i32), ()));
-    let pcb = KernelThreadMechanism::create_and_run(closure, "tty_refresh".to_string())
+    KernelThreadMechanism::create_and_run(closure, "tty_refresh".to_string())
         .ok_or("")
         .expect("create tty_refresh thread failed");
-    unsafe {
-        TTY_REFRESH_THREAD = Some(pcb);
-    }
 }
 
 fn tty_refresh_thread() -> i32 {
     loop {
-        if KEYBUF.is_empty() {
-            // 如果缓冲区为空，就休眠
-            let _guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-            ProcessManager::mark_sleep(true).expect("TTY_REFRESH_THREAD can not mark sleep");
+        let vc_index =
+            TTY_REFRESH_WAIT_QUEUE.wait_until(|| TTY_INPUT_WORK_QUEUE.lock_irqsave().pop());
+        drain_vc_input(vc_index);
+    }
+}
+
+fn drain_vc_input(vc_index: usize) {
+    let Some(vc) = vc_manager().get(vc_index) else {
+        return;
+    };
+    let port = vc.port();
+    let mut budget = TTY_INPUT_DRAIN_BUDGET;
+
+    while budget != 0 {
+        let drain = match port.drain_input_to_ldisc(TTY_PORT_RX_CHUNK_SIZE) {
+            Ok(drain) => drain,
+            Err(err) => {
+                log::warn!("tty_refresh: drain vc{} input failed: {:?}", vc_index, err);
+                break;
+            }
+        };
+
+        if drain.freed_room != 0 {
+            retry_virtio_console_input();
+        }
+
+        if drain.copied == 0 || !drain.still_pending {
+            break;
+        }
+
+        if drain.blocked {
+            break;
+        }
+
+        budget -= 1;
+        if budget == 0 {
+            queue_tty_input_work(vc_index);
             schedule(SchedMode::SM_NONE);
-        }
-
-        let to_dequeue = core::cmp::min(KEYBUF.len(), TTY_RX_DEQUEUE_MAX);
-        if to_dequeue == 0 {
-            continue;
-        }
-        let mut data = [TtyRxItem::default(); TTY_RX_DEQUEUE_MAX];
-        for item in data.iter_mut().take(to_dequeue) {
-            *item = KEYBUF.pop().unwrap();
-        }
-
-        let mut offset = 0;
-        while offset < to_dequeue {
-            let vc_index = data[offset].vc_index;
-            let mut bytes = [0u8; TTY_RX_DEQUEUE_MAX];
-            let mut count = 0;
-            while offset < to_dequeue && data[offset].vc_index == vc_index {
-                bytes[count] = data[offset].byte;
-                count += 1;
-                offset += 1;
-            }
-
-            if let Some(vc) = vc_manager().get(vc_index) {
-                let _ = vc.port().receive_buf(&bytes[0..count], &[], count);
-            }
+            break;
         }
     }
 }
 
 fn tty_rx_tasklet_fn(_data: usize, _data_obj: Option<Arc<dyn TaskletData>>) {
-    // 在 softirq/tasklet 上下文：不做 drain，只负责唤醒线程去处理输入。
-    if unsafe { TTY_REFRESH_THREAD.is_none() } {
-        return;
+    TTY_REFRESH_WAIT_QUEUE.wakeup(None);
+}
+
+fn queue_tty_input_work_common(vc_index: usize) -> bool {
+    TTY_INPUT_WORK_QUEUE.lock_irqsave().push(vc_index)
+}
+
+fn queue_tty_input_work_from_irq(vc_index: usize) {
+    if queue_tty_input_work_common(vc_index) {
+        tasklet_schedule(&TTY_RX_TASKLET);
     }
-    if KEYBUF.is_empty() {
-        return;
+}
+
+fn queue_tty_input_work(vc_index: usize) {
+    if queue_tty_input_work_common(vc_index) {
+        TTY_REFRESH_WAIT_QUEUE.wakeup(None);
     }
-    let _ = ProcessManager::wakeup(unsafe { TTY_REFRESH_THREAD.as_ref().unwrap() });
 }
 
 /// 在 hardirq 上下文投递输入：只入队并调度 tasklet（不直接唤醒线程）。
-///
-/// 这样可以避免在硬中断里触碰调度/唤醒逻辑，符合 Linux bottom-half 语义。
-pub fn enqueue_tty_rx_from_irq(data: &[u8]) {
-    if let Some(vc_index) = vc_manager().current_vc_index() {
-        enqueue_tty_rx_to_vc_from_irq(vc_index, data);
-    }
+pub fn enqueue_tty_rx_from_irq(data: &[u8]) -> usize {
+    vc_manager()
+        .current_vc_index()
+        .map(|vc_index| enqueue_tty_rx_to_vc_from_irq(vc_index, data))
+        .unwrap_or(0)
 }
 
-pub fn enqueue_tty_rx_to_vc_from_irq(vc_index: usize, data: &[u8]) {
-    if unsafe { TTY_REFRESH_THREAD.is_none() } {
+pub fn enqueue_tty_rx_to_vc_from_irq(vc_index: usize, data: &[u8]) -> usize {
+    let Some(vc) = vc_manager().get(vc_index) else {
+        return 0;
+    };
+    let accepted = vc.port().enqueue_input(data);
+    if accepted != 0 {
+        queue_tty_input_work_from_irq(vc_index);
+    }
+    accepted
+}
+
+pub fn enqueue_tty_rx_byte_to_vc_from_irq(
+    vc_index: usize,
+    producer: &mut dyn FnMut() -> Option<u8>,
+) -> TtyInputByteResult {
+    let Some(vc) = vc_manager().get(vc_index) else {
+        return TtyInputByteResult::NoRoom;
+    };
+    let result = vc.port().enqueue_input_byte_with(producer);
+    if result == TtyInputByteResult::Enqueued {
+        queue_tty_input_work_from_irq(vc_index);
+    }
+    result
+}
+
+pub fn tty_port_input_room(vc_index: usize) -> usize {
+    vc_manager()
+        .get(vc_index)
+        .map(|vc| vc.port().input_room())
+        .unwrap_or(0)
+}
+
+pub fn tty_kick_input_worker(tty: Arc<TtyCore>) {
+    let Some(vc_index) = tty.core().vc_index() else {
+        retry_virtio_console_input();
         return;
+    };
+
+    if vc_manager()
+        .get(vc_index)
+        .map(|vc| vc.port().has_input())
+        .unwrap_or(false)
+    {
+        queue_tty_input_work(vc_index);
     }
-    for item in data {
-        KEYBUF
-            .push(TtyRxItem {
-                vc_index,
-                byte: *item,
-            })
-            .ok();
-    }
-    tasklet_schedule(&TTY_RX_TASKLET);
+    retry_virtio_console_input();
 }

--- a/kernel/src/driver/tty/kthread.rs
+++ b/kernel/src/driver/tty/kthread.rs
@@ -5,6 +5,7 @@ use alloc::{string::ToString, sync::Arc};
 use crate::{
     driver::{
         char::virtio_console::retry_virtio_console_input,
+        serial::serial8250::retry_serial8250_input,
         tty::{
             tty_core::TtyCore,
             tty_port::{TtyInputByteResult, TTY_PORT_RX_CHUNK_SIZE},
@@ -109,7 +110,7 @@ fn drain_vc_input(vc_index: usize) {
         };
 
         if drain.freed_room != 0 {
-            retry_virtio_console_input();
+            retry_tty_input_producers();
         }
 
         if drain.copied == 0 || !drain.still_pending {
@@ -173,7 +174,7 @@ pub fn enqueue_tty_rx_byte_to_vc_from_irq(
     producer: &mut dyn FnMut() -> Option<u8>,
 ) -> TtyInputByteResult {
     let Some(vc) = vc_manager().get(vc_index) else {
-        return TtyInputByteResult::NoRoom;
+        return TtyInputByteResult::NoTarget;
     };
     let result = vc.port().enqueue_input_byte_with(producer);
     if result == TtyInputByteResult::Enqueued {
@@ -189,9 +190,14 @@ pub fn tty_port_input_room(vc_index: usize) -> usize {
         .unwrap_or(0)
 }
 
+pub fn retry_tty_input_producers() {
+    retry_virtio_console_input();
+    retry_serial8250_input();
+}
+
 pub fn tty_kick_input_worker(tty: Arc<TtyCore>) {
     let Some(vc_index) = tty.core().vc_index() else {
-        retry_virtio_console_input();
+        retry_tty_input_producers();
         return;
     };
 
@@ -202,5 +208,5 @@ pub fn tty_kick_input_worker(tty: Arc<TtyCore>) {
     {
         queue_tty_input_work(vc_index);
     }
-    retry_virtio_console_input();
+    retry_tty_input_producers();
 }

--- a/kernel/src/driver/tty/kthread.rs
+++ b/kernel/src/driver/tty/kthread.rs
@@ -8,7 +8,7 @@ use crate::{
         serial::serial8250::retry_serial8250_input,
         tty::{
             tty_core::TtyCore,
-            tty_port::{TtyInputByteResult, TTY_PORT_RX_CHUNK_SIZE},
+            tty_port::{TtyInputByteResult, TtyPort, TTY_PORT_RX_CHUNK_SIZE},
             virtual_terminal::{vc_manager, MAX_NR_CONSOLES},
         },
     },
@@ -20,6 +20,18 @@ use crate::{
 
 const TTY_INPUT_WORK_QUEUE_SIZE: usize = MAX_NR_CONSOLES as usize;
 const TTY_INPUT_DRAIN_BUDGET: usize = 16;
+
+#[derive(Clone, Debug)]
+pub struct TtyInputTarget {
+    vc_index: usize,
+    port: Arc<dyn TtyPort>,
+}
+
+impl TtyInputTarget {
+    pub fn new(vc_index: usize, port: Arc<dyn TtyPort>) -> Self {
+        Self { vc_index, port }
+    }
+}
 
 struct TtyInputWorkQueue {
     queue: [usize; TTY_INPUT_WORK_QUEUE_SIZE],
@@ -162,32 +174,30 @@ pub fn enqueue_tty_rx_to_vc_from_irq(vc_index: usize, data: &[u8]) -> usize {
     let Some(vc) = vc_manager().get(vc_index) else {
         return 0;
     };
-    let accepted = vc.port().enqueue_input(data);
+    enqueue_tty_rx_to_target_from_irq(&TtyInputTarget::new(vc_index, vc.port()), data)
+}
+
+pub fn enqueue_tty_rx_to_target_from_irq(target: &TtyInputTarget, data: &[u8]) -> usize {
+    let accepted = target.port.enqueue_input(data);
     if accepted != 0 {
-        queue_tty_input_work_from_irq(vc_index);
+        queue_tty_input_work_from_irq(target.vc_index);
     }
     accepted
 }
 
-pub fn enqueue_tty_rx_byte_to_vc_from_irq(
-    vc_index: usize,
+pub fn enqueue_tty_rx_byte_to_target_from_irq(
+    target: &TtyInputTarget,
     producer: &mut dyn FnMut() -> Option<u8>,
 ) -> TtyInputByteResult {
-    let Some(vc) = vc_manager().get(vc_index) else {
-        return TtyInputByteResult::NoTarget;
-    };
-    let result = vc.port().enqueue_input_byte_with(producer);
+    let result = target.port.enqueue_input_byte_with(producer);
     if result == TtyInputByteResult::Enqueued {
-        queue_tty_input_work_from_irq(vc_index);
+        queue_tty_input_work_from_irq(target.vc_index);
     }
     result
 }
 
-pub fn tty_port_input_room(vc_index: usize) -> usize {
-    vc_manager()
-        .get(vc_index)
-        .map(|vc| vc.port().input_room())
-        .unwrap_or(0)
+pub fn tty_input_target_room(target: &TtyInputTarget) -> usize {
+    target.port.input_room()
 }
 
 pub fn retry_tty_input_producers() {

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -8,17 +8,21 @@ use system_error::SystemError;
 
 use crate::{
     arch::ipc::signal::Signal,
-    driver::tty::{
-        pty::unix98pty::{
-            pty_drain_pending_to, pty_flush_input_buffer, pty_receive_flush_input_buffer,
+    driver::{
+        char::virtio_console::retry_virtio_console_input,
+        tty::{
+            kthread::tty_kick_input_worker,
+            pty::unix98pty::{
+                pty_drain_pending_to, pty_flush_input_buffer, pty_receive_flush_input_buffer,
+            },
+            termios::{ControlCharIndex, InputMode, LocalMode, OutputMode, Termios},
+            tty_core::{
+                EchoOperation, TtyCore, TtyCoreData, TtyFlag, TtyIoctlCmd, TtyPacketStatus,
+                TtySleepLock,
+            },
+            tty_driver::{TtyDriverFlag, TtyDriverSubType, TtyOperation},
+            tty_job_control::TtyJobCtrlManager,
         },
-        termios::{ControlCharIndex, InputMode, LocalMode, OutputMode, Termios},
-        tty_core::{
-            EchoOperation, TtyCore, TtyCoreData, TtyFlag, TtyIoctlCmd, TtyPacketStatus,
-            TtySleepLock,
-        },
-        tty_driver::{TtyDriverFlag, TtyDriverSubType, TtyOperation},
-        tty_job_control::TtyJobCtrlManager,
     },
     filesystem::{
         epoll::{event_poll::EventPoll, EPollEventType},
@@ -1043,12 +1047,22 @@ impl NTtyData {
         if !termios.local_mode.contains(LocalMode::NOFLSH) {
             self.discard_output_state();
 
-            let _ = tty.flush_buffer(tty.core());
+            if let Some(port) = tty.core().port() {
+                if port.clear_input_from_receive() != 0 {
+                    retry_virtio_console_input();
+                }
+            }
+
+            let ret = tty.core().driver().driver_funcs().flush_buffer(tty.core());
+            if ret != Err(SystemError::ENOSYS) {
+                let _ = ret;
+            }
 
             let _ = pty_receive_flush_input_buffer(tty.clone(), || {
                 self.read_head = 0;
                 self.canon_head = 0;
                 self.read_tail = 0;
+                self.commit_head = 0;
                 self.line_start = 0;
 
                 self.erasing = false;
@@ -1760,6 +1774,11 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     /// ## 重置缓冲区的基本信息
     fn flush_buffer(&self, tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {
         let core = tty.core();
+        if let Some(port) = core.port() {
+            if port.clear_input() != 0 {
+                retry_virtio_console_input();
+            }
+        }
         pty_flush_input_buffer(tty.clone(), || {
             let _ = core.termios();
             let mut ldata = self.disc_data();
@@ -1851,6 +1870,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             let read_tail_moved = tail != ldata.read_tail;
             drop(ldata);
             if read_tail_moved {
+                tty_kick_input_worker(tty.clone());
                 Self::check_pty_unthrottle_after_read(&tty);
             }
             return Ok(offset);
@@ -2018,6 +2038,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let read_tail_moved = tail != ldata.read_tail;
         drop(ldata);
         if read_tail_moved {
+            tty_kick_input_worker(tty.clone());
             Self::check_pty_unthrottle_after_read(&tty);
         }
 

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -8,21 +8,18 @@ use system_error::SystemError;
 
 use crate::{
     arch::ipc::signal::Signal,
-    driver::{
-        char::virtio_console::retry_virtio_console_input,
-        tty::{
-            kthread::tty_kick_input_worker,
-            pty::unix98pty::{
-                pty_drain_pending_to, pty_flush_input_buffer, pty_receive_flush_input_buffer,
-            },
-            termios::{ControlCharIndex, InputMode, LocalMode, OutputMode, Termios},
-            tty_core::{
-                EchoOperation, TtyCore, TtyCoreData, TtyFlag, TtyIoctlCmd, TtyPacketStatus,
-                TtySleepLock,
-            },
-            tty_driver::{TtyDriverFlag, TtyDriverSubType, TtyOperation},
-            tty_job_control::TtyJobCtrlManager,
+    driver::tty::{
+        kthread::{retry_tty_input_producers, tty_kick_input_worker},
+        pty::unix98pty::{
+            pty_drain_pending_to, pty_flush_input_buffer, pty_receive_flush_input_buffer,
         },
+        termios::{ControlCharIndex, InputMode, LocalMode, OutputMode, Termios},
+        tty_core::{
+            EchoOperation, TtyCore, TtyCoreData, TtyFlag, TtyIoctlCmd, TtyPacketStatus,
+            TtySleepLock,
+        },
+        tty_driver::{TtyDriverFlag, TtyDriverSubType, TtyOperation},
+        tty_job_control::TtyJobCtrlManager,
     },
     filesystem::{
         epoll::{event_poll::EventPoll, EPollEventType},
@@ -1049,7 +1046,7 @@ impl NTtyData {
 
             if let Some(port) = tty.core().port() {
                 if port.clear_input_from_receive() != 0 {
-                    retry_virtio_console_input();
+                    retry_tty_input_producers();
                 }
             }
 
@@ -1776,7 +1773,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let core = tty.core();
         if let Some(port) = core.port() {
             if port.clear_input() != 0 {
-                retry_virtio_console_input();
+                retry_tty_input_producers();
             }
         }
         pty_flush_input_buffer(tty.clone(), || {

--- a/kernel/src/driver/tty/tty_port.rs
+++ b/kernel/src/driver/tty/tty_port.rs
@@ -1,25 +1,117 @@
 use core::fmt::Debug;
 
-use alloc::sync::{Arc, Weak};
-use kdepends::thingbuf::mpsc;
+use alloc::{
+    boxed::Box,
+    sync::{Arc, Weak},
+};
 use system_error::SystemError;
 
 use crate::{
     filesystem::epoll::{event_poll::EventPoll, EPollEventType},
-    libs::spinlock::{SpinLock, SpinLockGuard},
+    libs::{
+        spinlock::{SpinLock, SpinLockGuard},
+        wait_queue::WaitQueue,
+    },
 };
 
 use super::tty_core::TtyCore;
 
-const TTY_PORT_BUFSIZE: usize = 4096;
+pub const TTY_PORT_RX_BUF_SIZE: usize = 8192;
+pub const TTY_PORT_RX_CHUNK_SIZE: usize = 256;
+
+#[derive(Debug, Default)]
+pub struct TtyInputDrain {
+    pub copied: usize,
+    pub delivered: usize,
+    pub still_pending: bool,
+    pub blocked: bool,
+    pub freed_room: usize,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum TtyInputByteResult {
+    Enqueued,
+    NoRoom,
+    NoData,
+}
+
+#[derive(Debug)]
+struct TtyInputQueue {
+    buf: Box<[u8; TTY_PORT_RX_BUF_SIZE]>,
+    head: usize,
+    len: usize,
+    generation: usize,
+    draining: bool,
+}
+
+impl TtyInputQueue {
+    fn new() -> Self {
+        Self {
+            buf: Box::new([0; TTY_PORT_RX_BUF_SIZE]),
+            head: 0,
+            len: 0,
+            generation: 0,
+            draining: false,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    fn room(&self) -> usize {
+        TTY_PORT_RX_BUF_SIZE - self.len
+    }
+
+    fn push_slice(&mut self, buf: &[u8]) -> usize {
+        let accepted = buf.len().min(self.room());
+        for (i, c) in buf[..accepted].iter().enumerate() {
+            let idx = (self.head + self.len + i) % TTY_PORT_RX_BUF_SIZE;
+            self.buf[idx] = *c;
+        }
+        self.len += accepted;
+        accepted
+    }
+
+    fn push_byte(&mut self, c: u8) {
+        debug_assert!(self.room() != 0);
+        let idx = (self.head + self.len) % TTY_PORT_RX_BUF_SIZE;
+        self.buf[idx] = c;
+        self.len += 1;
+    }
+
+    fn copy_front(&self, out: &mut [u8]) -> (usize, usize) {
+        let copied = out.len().min(self.len);
+        for (i, slot) in out[..copied].iter_mut().enumerate() {
+            *slot = self.buf[(self.head + i) % TTY_PORT_RX_BUF_SIZE];
+        }
+        (copied, self.generation)
+    }
+
+    fn advance_front(&mut self, count: usize) -> usize {
+        let count = count.min(self.len);
+        self.head = (self.head + count) % TTY_PORT_RX_BUF_SIZE;
+        self.len -= count;
+        if self.len == 0 {
+            self.head = 0;
+        }
+        count
+    }
+
+    fn clear_buffer(&mut self) -> usize {
+        let cleared = self.len;
+        self.head = 0;
+        self.len = 0;
+        self.generation = self.generation.wrapping_add(1);
+        cleared
+    }
+}
 
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct TtyPortData {
     flags: i32,
     iflags: TtyPortState,
-    sender: mpsc::Sender<u8>,
-    receiver: mpsc::Receiver<u8>,
     tty: Weak<TtyCore>,
     /// 内部tty，即与port直接相连的
     internal_tty: Weak<TtyCore>,
@@ -33,12 +125,9 @@ impl Default for TtyPortData {
 
 impl TtyPortData {
     pub fn new() -> Self {
-        let (sender, receiver) = mpsc::channel::<u8>(TTY_PORT_BUFSIZE);
         Self {
             flags: 0,
             iflags: TtyPortState::Initialized,
-            sender,
-            receiver,
             tty: Weak::new(),
             internal_tty: Weak::new(),
         }
@@ -79,7 +168,7 @@ pub trait TtyPort: Sync + Send + Debug {
 
     /// 作为客户端的tty ports接收数据
     fn receive_buf(&self, buf: &[u8], _flags: &[u8], count: usize) -> Result<usize, SystemError> {
-        let tty = self.port_data().internal_tty().unwrap();
+        let tty = self.port_data().internal_tty().ok_or(SystemError::ENODEV)?;
         let ld = tty.ldisc();
         let ret = ld.receive_buf2(tty.clone(), buf, None, count);
         if let Err(SystemError::ENOSYS) = ret {
@@ -94,17 +183,41 @@ pub trait TtyPort: Sync + Send + Debug {
     fn internal_tty(&self) -> Option<Arc<TtyCore>> {
         self.port_data().internal_tty()
     }
+
+    fn input_room(&self) -> usize;
+
+    fn enqueue_input(&self, buf: &[u8]) -> usize;
+
+    /// Atomically reserves one byte of input room, then invokes `producer` and
+    /// commits the produced byte while holding the input queue lock. `producer`
+    /// must be a non-sleeping destructive byte read and must not re-enter TTY locks.
+    fn enqueue_input_byte_with(
+        &self,
+        producer: &mut dyn FnMut() -> Option<u8>,
+    ) -> TtyInputByteResult;
+
+    fn has_input(&self) -> bool;
+
+    fn clear_input(&self) -> usize;
+
+    fn clear_input_from_receive(&self) -> usize;
+
+    fn drain_input_to_ldisc(&self, max_count: usize) -> Result<TtyInputDrain, SystemError>;
 }
 
 #[derive(Debug)]
 pub struct DefaultTtyPort {
     port_data: SpinLock<TtyPortData>,
+    input_queue: SpinLock<TtyInputQueue>,
+    input_drain_wq: WaitQueue,
 }
 
 impl DefaultTtyPort {
     pub fn new() -> Self {
         Self {
             port_data: SpinLock::new(TtyPortData::new()),
+            input_queue: SpinLock::new(TtyInputQueue::new()),
+            input_drain_wq: WaitQueue::default(),
         }
     }
 }
@@ -112,5 +225,101 @@ impl DefaultTtyPort {
 impl TtyPort for DefaultTtyPort {
     fn port_data(&self) -> SpinLockGuard<'_, TtyPortData> {
         self.port_data.lock_irqsave()
+    }
+
+    fn input_room(&self) -> usize {
+        self.input_queue.lock_irqsave().room()
+    }
+
+    fn enqueue_input(&self, buf: &[u8]) -> usize {
+        self.input_queue.lock_irqsave().push_slice(buf)
+    }
+
+    fn enqueue_input_byte_with(
+        &self,
+        producer: &mut dyn FnMut() -> Option<u8>,
+    ) -> TtyInputByteResult {
+        let mut queue = self.input_queue.lock_irqsave();
+        if queue.room() == 0 {
+            return TtyInputByteResult::NoRoom;
+        }
+        let Some(c) = producer() else {
+            return TtyInputByteResult::NoData;
+        };
+        queue.push_byte(c);
+        TtyInputByteResult::Enqueued
+    }
+
+    fn has_input(&self) -> bool {
+        !self.input_queue.lock_irqsave().is_empty()
+    }
+
+    fn clear_input(&self) -> usize {
+        self.input_drain_wq.wait_until(|| {
+            let mut queue = self.input_queue.lock_irqsave();
+            if queue.draining {
+                return None;
+            }
+            Some(queue.clear_buffer())
+        })
+    }
+
+    fn clear_input_from_receive(&self) -> usize {
+        self.input_queue.lock_irqsave().clear_buffer()
+    }
+
+    fn drain_input_to_ldisc(&self, max_count: usize) -> Result<TtyInputDrain, SystemError> {
+        let mut chunk = [0u8; TTY_PORT_RX_CHUNK_SIZE];
+        let max_count = max_count.min(TTY_PORT_RX_CHUNK_SIZE);
+        let (copied, generation) = {
+            let mut queue = self.input_queue.lock_irqsave();
+            let (copied, generation) = queue.copy_front(&mut chunk[..max_count]);
+            if copied != 0 {
+                queue.draining = true;
+            }
+            (copied, generation)
+        };
+
+        if copied == 0 {
+            return Ok(TtyInputDrain::default());
+        }
+
+        let receive_result = self.receive_buf(&chunk[..copied], &[], copied);
+        let mut queue = self.input_queue.lock_irqsave();
+        queue.draining = false;
+        self.input_drain_wq.wakeup_all(None);
+
+        let delivered = match receive_result {
+            Ok(delivered) => delivered.min(copied),
+            Err(SystemError::ENODEV) => {
+                let freed_room = queue.clear_buffer();
+                return Ok(TtyInputDrain {
+                    copied,
+                    freed_room,
+                    ..TtyInputDrain::default()
+                });
+            }
+            Err(err) => return Err(err),
+        };
+
+        if queue.generation != generation {
+            return Ok(TtyInputDrain {
+                copied,
+                delivered,
+                still_pending: !queue.is_empty(),
+                blocked: false,
+                freed_room: 0,
+            });
+        }
+
+        let freed_room = queue.advance_front(delivered);
+        let still_pending = !queue.is_empty();
+        Ok(TtyInputDrain {
+            copied,
+            delivered,
+            still_pending,
+            blocked: delivered < copied,
+            freed_room,
+        })
     }
 }

--- a/kernel/src/driver/tty/tty_port.rs
+++ b/kernel/src/driver/tty/tty_port.rs
@@ -33,7 +33,6 @@ pub enum TtyInputByteResult {
     Enqueued,
     NoRoom,
     NoData,
-    NoTarget,
 }
 
 #[derive(Debug)]

--- a/kernel/src/driver/tty/tty_port.rs
+++ b/kernel/src/driver/tty/tty_port.rs
@@ -33,6 +33,7 @@ pub enum TtyInputByteResult {
     Enqueued,
     NoRoom,
     NoData,
+    NoTarget,
 }
 
 #[derive(Debug)]

--- a/kernel/src/driver/tty/tty_port.rs
+++ b/kernel/src/driver/tty/tty_port.rs
@@ -156,6 +156,8 @@ pub enum TtyPortState {
 pub trait TtyPort: Sync + Send + Debug {
     fn port_data(&self) -> SpinLockGuard<'_, TtyPortData>;
 
+    fn ensure_input_queue(&self);
+
     /// 获取Port的状态
     fn state(&self) -> TtyPortState {
         self.port_data().iflags
@@ -163,6 +165,7 @@ pub trait TtyPort: Sync + Send + Debug {
 
     /// 为port设置tty
     fn setup_internal_tty(&self, tty: Weak<TtyCore>) {
+        self.ensure_input_queue();
         self.port_data().internal_tty = tty;
     }
 
@@ -208,7 +211,7 @@ pub trait TtyPort: Sync + Send + Debug {
 #[derive(Debug)]
 pub struct DefaultTtyPort {
     port_data: SpinLock<TtyPortData>,
-    input_queue: SpinLock<TtyInputQueue>,
+    input_queue: SpinLock<Option<TtyInputQueue>>,
     input_drain_wq: WaitQueue,
 }
 
@@ -216,7 +219,7 @@ impl DefaultTtyPort {
     pub fn new() -> Self {
         Self {
             port_data: SpinLock::new(TtyPortData::new()),
-            input_queue: SpinLock::new(TtyInputQueue::new()),
+            input_queue: SpinLock::new(None),
             input_drain_wq: WaitQueue::default(),
         }
     }
@@ -227,12 +230,35 @@ impl TtyPort for DefaultTtyPort {
         self.port_data.lock_irqsave()
     }
 
+    fn ensure_input_queue(&self) {
+        if self.input_queue.lock_irqsave().is_some() {
+            return;
+        }
+
+        let new_queue = TtyInputQueue::new();
+        let mut queue = self.input_queue.lock_irqsave();
+        if queue.is_none() {
+            *queue = Some(new_queue);
+        }
+    }
+
     fn input_room(&self) -> usize {
-        self.input_queue.lock_irqsave().room()
+        self.input_queue
+            .lock_irqsave()
+            .as_ref()
+            .map(TtyInputQueue::room)
+            .unwrap_or(TTY_PORT_RX_BUF_SIZE)
     }
 
     fn enqueue_input(&self, buf: &[u8]) -> usize {
-        self.input_queue.lock_irqsave().push_slice(buf)
+        if buf.is_empty() {
+            return 0;
+        }
+        let mut queue = self.input_queue.lock_irqsave();
+        let Some(queue) = queue.as_mut() else {
+            return 0;
+        };
+        queue.push_slice(buf)
     }
 
     fn enqueue_input_byte_with(
@@ -240,6 +266,9 @@ impl TtyPort for DefaultTtyPort {
         producer: &mut dyn FnMut() -> Option<u8>,
     ) -> TtyInputByteResult {
         let mut queue = self.input_queue.lock_irqsave();
+        let Some(queue) = queue.as_mut() else {
+            return TtyInputByteResult::NoRoom;
+        };
         if queue.room() == 0 {
             return TtyInputByteResult::NoRoom;
         }
@@ -251,12 +280,19 @@ impl TtyPort for DefaultTtyPort {
     }
 
     fn has_input(&self) -> bool {
-        !self.input_queue.lock_irqsave().is_empty()
+        self.input_queue
+            .lock_irqsave()
+            .as_ref()
+            .map(|queue| !queue.is_empty())
+            .unwrap_or(false)
     }
 
     fn clear_input(&self) -> usize {
         self.input_drain_wq.wait_until(|| {
             let mut queue = self.input_queue.lock_irqsave();
+            let Some(queue) = queue.as_mut() else {
+                return Some(0);
+            };
             if queue.draining {
                 return None;
             }
@@ -265,7 +301,11 @@ impl TtyPort for DefaultTtyPort {
     }
 
     fn clear_input_from_receive(&self) -> usize {
-        self.input_queue.lock_irqsave().clear_buffer()
+        self.input_queue
+            .lock_irqsave()
+            .as_mut()
+            .map(TtyInputQueue::clear_buffer)
+            .unwrap_or(0)
     }
 
     fn drain_input_to_ldisc(&self, max_count: usize) -> Result<TtyInputDrain, SystemError> {
@@ -273,6 +313,9 @@ impl TtyPort for DefaultTtyPort {
         let max_count = max_count.min(TTY_PORT_RX_CHUNK_SIZE);
         let (copied, generation) = {
             let mut queue = self.input_queue.lock_irqsave();
+            let Some(queue) = queue.as_mut() else {
+                return Ok(TtyInputDrain::default());
+            };
             let (copied, generation) = queue.copy_front(&mut chunk[..max_count]);
             if copied != 0 {
                 queue.draining = true;
@@ -286,6 +329,10 @@ impl TtyPort for DefaultTtyPort {
 
         let receive_result = self.receive_buf(&chunk[..copied], &[], copied);
         let mut queue = self.input_queue.lock_irqsave();
+        let Some(queue) = queue.as_mut() else {
+            self.input_drain_wq.wakeup_all(None);
+            return Ok(TtyInputDrain::default());
+        };
         queue.draining = false;
         self.input_drain_wq.wakeup_all(None);
 

--- a/kernel/src/driver/tty/virtual_terminal/mod.rs
+++ b/kernel/src/driver/tty/virtual_terminal/mod.rs
@@ -160,16 +160,16 @@ impl VirtConsoleManager {
     }
 
     pub fn get(&self, index: usize) -> Option<Arc<VirtConsole>> {
-        let inner = self.inner.lock();
+        let inner = self.inner.lock_irqsave();
         inner.consoles.get(&index).cloned()
     }
 
     pub fn alloc(&self, vc: Arc<VirtConsole>) -> Option<usize> {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock_irqsave();
         let index = inner.ida.alloc()?;
         vc.index.init(index);
         if let Some(vc_data) = vc.vc_data.as_ref() {
-            vc_data.lock().vc_index = index;
+            vc_data.lock_irqsave().vc_index = index;
         }
 
         inner.consoles.insert(index, vc);
@@ -178,20 +178,30 @@ impl VirtConsoleManager {
 
     /// 释放虚拟终端
     pub fn free(&self, index: usize) {
-        let mut inner = self.inner.lock();
-        if let Some(vc) = inner.consoles.remove(&index) {
+        let vc = {
+            let mut inner = self.inner.lock_irqsave();
+            let vc = inner.consoles.remove(&index);
+            inner.ida.free(index);
+            vc
+        };
+        if let Some(vc) = vc {
             vc.devfs_remove();
         }
-        inner.ida.free(index);
     }
 
     /// 获取当前虚拟终端
     pub fn current_vc(&self) -> Option<Arc<VirtConsole>> {
-        self.current_vc.read().as_ref().map(|(vc, _)| vc.clone())
+        self.current_vc
+            .read_irqsave()
+            .as_ref()
+            .map(|(vc, _)| vc.clone())
     }
 
     pub fn current_vc_index(&self) -> Option<usize> {
-        self.current_vc.read().as_ref().map(|(_, index)| *index)
+        self.current_vc
+            .read_irqsave()
+            .as_ref()
+            .map(|(_, index)| *index)
     }
 
     pub fn current_vc_tty_name(&self) -> Option<String> {
@@ -203,7 +213,7 @@ impl VirtConsoleManager {
     /// 设置当前虚拟终端
     pub fn set_current_vc(&self, vc: Arc<VirtConsole>) {
         let index = *vc.index.get();
-        *self.current_vc.write() = Some((vc, index));
+        *self.current_vc.write_irqsave() = Some((vc, index));
     }
 
     /// 通过tty名称查找虚拟终端
@@ -212,7 +222,7 @@ impl VirtConsoleManager {
     ///
     /// * `name` - tty名称 (如ttyS0)
     pub fn lookup_vc_by_tty_name(&self, name: &str) -> Option<Arc<VirtConsole>> {
-        let inner = self.inner.lock();
+        let inner = self.inner.lock_irqsave();
         for (_index, vc) in inner.consoles.iter() {
             let found = vc
                 .port

--- a/kernel/src/driver/tty/virtual_terminal/mod.rs
+++ b/kernel/src/driver/tty/virtual_terminal/mod.rs
@@ -75,6 +75,7 @@ pub struct VirtConsole {
 
 struct InnerVirtConsole {
     vcdev: Option<Arc<TtyDevice>>,
+    devfs_removing: bool,
 }
 
 impl VirtConsole {
@@ -83,7 +84,10 @@ impl VirtConsole {
             vc_data,
             port: Arc::new(DefaultTtyPort::new()),
             index: Lazy::new(),
-            inner: SpinLock::new(InnerVirtConsole { vcdev: None }),
+            inner: SpinLock::new(InnerVirtConsole {
+                vcdev: None,
+                devfs_removing: false,
+            }),
         })
     }
 
@@ -124,15 +128,26 @@ impl VirtConsole {
         Ok(())
     }
 
-    fn devfs_remove(&self) {
-        let vcdev = self.inner.lock().vcdev.take();
-        if let Some(vcdev) = vcdev {
-            devfs_unregister(vcdev.name_ref(), vcdev.clone())
-                .inspect_err(|e| {
-                    log::error!("virt console: devfs_unregister failed: {:?}", e);
-                })
-                .ok();
+    fn devfs_remove(&self) -> Result<bool, SystemError> {
+        let vcdev = {
+            let mut inner = self.inner.lock();
+            if inner.devfs_removing {
+                return Ok(false);
+            }
+            let Some(vcdev) = inner.vcdev.take() else {
+                return Ok(true);
+            };
+            inner.devfs_removing = true;
+            vcdev
+        };
+        let result = devfs_unregister(vcdev.name_ref(), vcdev.clone());
+        let mut inner = self.inner.lock();
+        inner.devfs_removing = false;
+        if let Err(e) = result {
+            inner.vcdev = Some(vcdev);
+            return Err(e);
         }
+        Ok(true)
     }
 }
 
@@ -179,13 +194,29 @@ impl VirtConsoleManager {
     /// 释放虚拟终端
     pub fn free(&self, index: usize) {
         let vc = {
-            let mut inner = self.inner.lock_irqsave();
-            let vc = inner.consoles.remove(&index);
-            inner.ida.free(index);
-            vc
+            let inner = self.inner.lock_irqsave();
+            inner.consoles.get(&index).cloned()
         };
         if let Some(vc) = vc {
-            vc.devfs_remove();
+            let remove_done = match vc.devfs_remove() {
+                Ok(remove_done) => remove_done,
+                Err(e) => {
+                    log::error!("virt console: devfs_unregister failed: {:?}", e);
+                    return;
+                }
+            };
+            if !remove_done {
+                return;
+            }
+            let mut inner = self.inner.lock_irqsave();
+            if inner
+                .consoles
+                .get(&index)
+                .is_some_and(|stored| Arc::ptr_eq(stored, &vc))
+            {
+                inner.consoles.remove(&index);
+                inner.ida.free(index);
+            }
         }
     }
 

--- a/user/apps/busybox/Makefile
+++ b/user/apps/busybox/Makefile
@@ -27,11 +27,12 @@ $(busybox_dir): $(busybox_tarball_path)
 	tar -xjf $< -C $(build_dir)
 
 # 配置和编译
-$(bin): $(busybox_dir)
+$(bin): $(busybox_dir) Makefile
 	@# 应用必要补丁和配置调整
 	cd $(busybox_dir) && \
 	make defconfig && \
 	sed -i '/CONFIG_STATIC/s/.*/CONFIG_STATIC=y/' .config && \
+	sed -i '/CONFIG_FEATURE_EDITING_MAX_LEN/s/.*/CONFIG_FEATURE_EDITING_MAX_LEN=8192/' .config && \
 	sed -i '/CONFIG_PIE/d' .config && \
 	echo "CONFIG_CROSS_COMPILER_PREFIX=\"$(prefix)\"" >> .config && \
 	echo "CONFIG_FEATURE_STATIC=y" >> .config && \

--- a/user/apps/default.nix
+++ b/user/apps/default.nix
@@ -64,11 +64,12 @@ let
   );
 in
 [
-  (static.busybox.override {
-    extraConfig = ''
-      CONFIG_FEATURE_DEFAULT_PASSWD_ALGO "sha512"
-    '';
-  })
+	  (static.busybox.override {
+	    extraConfig = ''
+	      CONFIG_FEATURE_DEFAULT_PASSWD_ALGO "sha512"
+	      CONFIG_FEATURE_EDITING_MAX_LEN 8192
+	    '';
+	  })
   static.curl
   static.dropbear
   cross.glibc

--- a/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
@@ -311,6 +311,54 @@ std::string ReadCanonicalLine(int fd) {
     return std::string(buf, buf + n);
 }
 
+std::string ReadExpectedBytesWithPoll(int fd, size_t expected, size_t max_chunk) {
+    std::string output(expected, '\0');
+    size_t total = 0;
+    while (total < expected) {
+        struct pollfd pfd = {
+            .fd = fd,
+            .events = POLLIN | POLLHUP | POLLERR,
+            .revents = 0,
+        };
+        int ret = 0;
+        do {
+            ret = poll(&pfd, 1, 5000);
+        } while (ret < 0 && errno == EINTR);
+
+        if (ret <= 0) {
+            ADD_FAILURE() << "poll waiting for canonical data failed: errno="
+                          << (ret < 0 ? errno : ETIMEDOUT) << " ("
+                          << strerror(ret < 0 ? errno : ETIMEDOUT) << "), total=" << total
+                          << ", expected=" << expected;
+            output.resize(total);
+            return output;
+        }
+        if ((pfd.revents & POLLIN) == 0) {
+            ADD_FAILURE() << "poll returned without POLLIN, revents=" << pfd.revents
+                          << ", total=" << total << ", expected=" << expected;
+            output.resize(total);
+            return output;
+        }
+
+        const size_t chunk = std::min(max_chunk, expected - total);
+        ssize_t n = 0;
+        do {
+            n = read(fd, output.data() + total, chunk);
+        } while (n < 0 && errno == EINTR);
+
+        if (n <= 0) {
+            ADD_FAILURE() << "read canonical data failed: errno=" << (n < 0 ? errno : EIO)
+                          << " (" << strerror(n < 0 ? errno : EIO) << "), total=" << total
+                          << ", expected=" << expected;
+            output.resize(total);
+            return output;
+        }
+        total += static_cast<size_t>(n);
+    }
+
+    return output;
+}
+
 struct ConcurrentSlaveOpenArgs {
     const char* slave_name;
     int start_read_fd;
@@ -1341,6 +1389,95 @@ TEST(TtyPtyHangup, LargeCanonicalMasterWriteDrainsWithSmallSlaveReads) {
     ASSERT_EQ(input.size(), args.written);
     ASSERT_EQ(output.size(), total);
     EXPECT_EQ(input, std::string(output.begin(), output.end()));
+}
+
+TEST(TtyPtyHangup, Canonical4095PayloadPreserved) {
+    PtyPair pair = OpenCanonicalNoEchoPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    std::string input(4095, 'x');
+    input.push_back('\n');
+
+    WriteAllArgs args = {
+        .fd = pair.master.get(),
+        .data = input.data(),
+        .len = input.size(),
+        .written = 0,
+        .error = 0,
+    };
+    pthread_t writer = {};
+    ASSERT_EQ(0, pthread_create(&writer, nullptr, WriteAll, &args)) << "pthread_create failed";
+
+    std::string output = ReadExpectedBytesWithPoll(pair.slave.get(), input.size(), 257);
+
+    ASSERT_EQ(0, pthread_join(writer, nullptr)) << "pthread_join failed";
+    ASSERT_EQ(0, args.error) << "writer failed after " << args.written << " bytes: errno="
+                             << args.error << " (" << strerror(args.error) << ")";
+    ASSERT_EQ(input.size(), args.written);
+    ASSERT_EQ(input.size(), output.size());
+    EXPECT_EQ(input, output);
+}
+
+TEST(TtyPtyHangup, CanonicalOver4095PayloadTruncatedLikeLinux) {
+    PtyPair pair = OpenCanonicalNoEchoPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    std::string input(4096, 'y');
+    input.push_back('\n');
+    std::string expected(4095, 'y');
+    expected.push_back('\n');
+
+    WriteAllArgs args = {
+        .fd = pair.master.get(),
+        .data = input.data(),
+        .len = input.size(),
+        .written = 0,
+        .error = 0,
+    };
+    pthread_t writer = {};
+    ASSERT_EQ(0, pthread_create(&writer, nullptr, WriteAll, &args)) << "pthread_create failed";
+
+    std::string output = ReadExpectedBytesWithPoll(pair.slave.get(), expected.size(), 257);
+
+    ASSERT_EQ(0, pthread_join(writer, nullptr)) << "pthread_join failed";
+    ASSERT_EQ(0, args.error) << "writer failed after " << args.written << " bytes: errno="
+                             << args.error << " (" << strerror(args.error) << ")";
+    ASSERT_EQ(input.size(), args.written);
+    ASSERT_EQ(expected.size(), output.size());
+    EXPECT_EQ(expected, output);
+}
+
+TEST(TtyPtyHangup, MultipleLongCanonicalLinesDrainWithoutLoss) {
+    PtyPair pair = OpenCanonicalNoEchoPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    std::string input;
+    for (int i = 0; i < 8; ++i) {
+        input.append(3072, static_cast<char>('a' + i));
+        input.push_back('\n');
+    }
+
+    WriteAllArgs args = {
+        .fd = pair.master.get(),
+        .data = input.data(),
+        .len = input.size(),
+        .written = 0,
+        .error = 0,
+    };
+    pthread_t writer = {};
+    ASSERT_EQ(0, pthread_create(&writer, nullptr, WriteAll, &args)) << "pthread_create failed";
+
+    std::string output = ReadExpectedBytesWithPoll(pair.slave.get(), input.size(), 511);
+
+    ASSERT_EQ(0, pthread_join(writer, nullptr)) << "pthread_join failed";
+    ASSERT_EQ(0, args.error) << "writer failed after " << args.written << " bytes: errno="
+                             << args.error << " (" << strerror(args.error) << ")";
+    ASSERT_EQ(input.size(), args.written);
+    ASSERT_EQ(input.size(), output.size());
+    EXPECT_EQ(input, output);
 }
 
 TEST(TtyPtyHangup, TciflushDoesNotDiscardLargeOpostSlaveOutput) {


### PR DESCRIPTION
## Summary

- replace the global TTY RX byte buffer with per-port input staging
- preserve undelivered input across line discipline short receives and restart draining after read-side progress
- add virtio-console and serial8250 backpressure handling for destructive input sources
- raise BusyBox ash line editing length for long interactive commands
- add TTY canonical boundary and long-line drain coverage

## Root Cause

The console input path consumed bytes before the line discipline accepted them. When N_TTY returned a short receive or the global queue filled, tail bytes could be dropped or delayed without a per-port retry point.

## Validation

- `make fmt`
- `git diff --check`
- `make kernel`
- nographic 3000-character shell command returned `3001`
- nographic `cat | wc -c` with 3000 input bytes plus newline returned `3001`
- guest `tty_pty_hangup_test` passed: 33 tests
