### PR TITLE
fix(virtiofs): replace bridge polling with event wakeups

### DIFF
--- a/kernel/src/driver/virtio/irq.rs
+++ b/kernel/src/driver/virtio/irq.rs
@@ -11,7 +11,7 @@ use crate::{
         IrqNumber,
     },
     init::initcall::INITCALL_CORE,
-    libs::rwlock::RwLock,
+    libs::{rwlock::RwLock, spinlock::SpinLock},
 };
 
 use super::VirtIODevice;
@@ -24,27 +24,39 @@ pub fn virtio_irq_manager() -> &'static VirtIOIrqManager {
 }
 
 pub struct VirtIOIrqManager {
+    registration_lock: SpinLock<()>,
     map: RwLock<HashMap<Arc<DeviceId>, Arc<dyn VirtIODevice>>>,
+    callbacks: RwLock<HashMap<Arc<DeviceId>, Arc<dyn VirtioIrqCallback>>>,
+}
+
+pub trait VirtioIrqCallback: Send + Sync {
+    fn handle_irq(&self, irq: IrqNumber) -> Result<IrqReturn, SystemError>;
 }
 
 impl VirtIOIrqManager {
     fn new() -> Self {
         VirtIOIrqManager {
+            registration_lock: SpinLock::new(()),
             map: RwLock::new(HashMap::new()),
+            callbacks: RwLock::new(HashMap::new()),
         }
     }
 
-    /// 注册一个新的设备到virtio中断请求（IRQ）映射中。
+    /// Registers a new device in the virtio interrupt request (IRQ) mapping.
     ///
-    /// # 参数
+    /// # Parameters
     ///
-    /// - `device` - 实现了 `VirtIODevice` trait 的设备对象，被封装在 `Arc` 智能指针中。
+    /// - `device` - The device object implementing the `VirtIODevice` trait, wrapped in an `Arc` smart pointer.
     ///
-    /// # 返回值
+    /// # Returns
     ///
-    /// - 如果设备成功注册，返回 `Ok(())`。
-    /// - 如果设备ID已经存在于映射中，返回 `Err(SystemError::EEXIST)`。
+    /// - If the device is successfully registered, returns `Ok(())`.
+    /// - If the device ID already exists in the mapping, returns `Err(SystemError::EEXIST)`.
     pub fn register_device(&self, device: Arc<dyn VirtIODevice>) -> Result<(), SystemError> {
+        let _guard = self.registration_lock.lock_irqsave();
+        if self.callbacks.read_irqsave().contains_key(device.dev_id()) {
+            return Err(SystemError::EEXIST);
+        }
         let mut map = self.map.write_irqsave();
 
         if map.contains_key(device.dev_id()) {
@@ -56,30 +68,60 @@ impl VirtIOIrqManager {
         return Ok(());
     }
 
-    /// 取消注册设备
+    /// Unregisters a device.
     ///
-    /// 这个函数会从内部映射中移除指定的设备。设备是通过设备ID来识别的。
+    /// This function removes the specified device from the internal mapping. The device is identified by its device ID.
     ///
-    /// # 参数
+    /// # Parameters
     ///
-    /// - `device` - 需要被取消注册的设备，它是一个实现了 `VirtIODevice` trait 的智能指针。
+    /// - `dev_id` - The device ID of the device to be unregistered.
     #[allow(dead_code)]
     pub fn unregister_device(&self, dev_id: &Arc<DeviceId>) {
+        let _guard = self.registration_lock.lock_irqsave();
         let mut map = self.map.write_irqsave();
         map.remove(dev_id);
     }
 
-    /// 查找并返回指定设备ID的设备。
+    pub fn register_callback(
+        &self,
+        dev_id: Arc<DeviceId>,
+        callback: Arc<dyn VirtioIrqCallback>,
+    ) -> Result<(), SystemError> {
+        let _guard = self.registration_lock.lock_irqsave();
+        if self.map.read_irqsave().contains_key(&dev_id) {
+            return Err(SystemError::EEXIST);
+        }
+
+        let mut callbacks = self.callbacks.write_irqsave();
+        if callbacks.contains_key(&dev_id) {
+            return Err(SystemError::EEXIST);
+        }
+        callbacks.insert(dev_id, callback);
+        Ok(())
+    }
+
+    pub fn unregister_callback(&self, dev_id: &Arc<DeviceId>) {
+        let _guard = self.registration_lock.lock_irqsave();
+        let mut callbacks = self.callbacks.write_irqsave();
+        callbacks.remove(dev_id);
+    }
+
+    /// Looks up and returns the device with the specified device ID.
     ///
-    /// # 参数
-    /// - `dev_id` - 我们要查找的设备的设备ID。
+    /// # Parameters
+    /// - `dev_id` - The device ID of the device to look up.
     ///
-    /// # 返回
-    /// - 如果找到了设备，返回一个包含设备的`Option<Arc<dyn VirtIODevice>>`。
-    /// - 如果没有找到设备，返回`None`。
+    /// # Returns
+    /// - If the device is found, returns `Some` containing the device.
+    /// - If no device is found, returns `None`.
     pub fn lookup_device(&self, dev_id: &Arc<DeviceId>) -> Option<Arc<dyn VirtIODevice>> {
         let map = self.map.read_irqsave();
         map.get(dev_id).cloned()
+    }
+
+    pub fn lookup_callback(&self, dev_id: &Arc<DeviceId>) -> Option<Arc<dyn VirtioIrqCallback>> {
+        let callbacks = self.callbacks.read_irqsave();
+        callbacks.get(dev_id).cloned()
     }
 }
 
@@ -92,13 +134,14 @@ fn init_virtio_irq_manager() -> Result<(), SystemError> {
     return Ok(());
 }
 
-/// `DefaultVirtioIrqHandler` 是一个默认的virtio设备中断处理程序。
+/// `DefaultVirtioIrqHandler` is the default interrupt handler for virtio devices.
 ///
-/// 当虚拟设备产生中断时，该处理程序会被调用。
+/// This handler is invoked when a virtio device raises an interrupt.
 ///
-/// 它首先检查设备ID是否存在，然后尝试查找与设备ID关联的设备。
-/// 如果找到设备，它会调用设备的 `handle_irq` 方法来处理中断。
-/// 如果没有找到设备，它会记录一条警告并返回 `IrqReturn::NotHandled`，表示中断未被处理。
+/// It first checks whether the device ID exists, then attempts to look up the device
+/// (or callback) associated with the device ID. If a device or callback is found, it
+/// delegates interrupt handling to it. Otherwise it returns `IrqReturn::NotHandled`,
+/// indicating that the interrupt was not handled.
 #[derive(Debug)]
 pub(super) struct DefaultVirtioIrqHandler;
 
@@ -117,8 +160,10 @@ impl IrqHandler for DefaultVirtioIrqHandler {
 
         if let Some(dev) = virtio_irq_manager().lookup_device(&dev_id) {
             return dev.handle_irq(irq);
+        } else if let Some(callback) = virtio_irq_manager().lookup_callback(&dev_id) {
+            return callback.handle_irq(irq);
         } else {
-            // 未绑定具体设备，因此无法处理中断
+            // No device or callback bound, so the interrupt cannot be handled
             // warn!("No device found for IRQ: {:?}", irq);
             return Ok(IrqReturn::NotHandled);
         }

--- a/kernel/src/driver/virtio/transport_pci.rs
+++ b/kernel/src/driver/virtio/transport_pci.rs
@@ -29,9 +29,9 @@ use super::VIRTIO_VENDOR_ID;
 use crate::driver::pci::pci_irq::IrqType;
 
 /// The offset to add to a VirtIO device ID to get the corresponding PCI device ID.
-/// PCI Virtio设备的DEVICE_ID 的offset
+/// The offset of the PCI VirtIO device ID.
 const PCI_DEVICE_ID_OFFSET: u16 = 0x1040;
-/// PCI Virtio 设备的DEVICE_ID及其对应的设备类型
+/// PCI VirtIO device IDs and their corresponding device types.
 const TRANSITIONAL_NETWORK: u16 = 0x1000;
 const TRANSITIONAL_BLOCK: u16 = 0x1001;
 const TRANSITIONAL_MEMORY_BALLOONING: u16 = 0x1002;
@@ -58,15 +58,13 @@ const VIRTIO_PCI_CAP_ISR_CFG: u8 = 3;
 /// Device specific configuration.
 const VIRTIO_PCI_CAP_DEVICE_CFG: u8 = 4;
 
-/// Virtio设备接收中断的设备号
+/// The interrupt vector number for VirtIO device receive interrupts.
 const VIRTIO_RECV_VECTOR: IrqNumber = IrqNumber::new(56);
-/// Virtio设备接收中断的设备号的表项号
+/// The MSI-X table entry index for VirtIO device receive interrupts.
 const VIRTIO_RECV_VECTOR_INDEX: u16 = 0;
-// 接收的queue号
+// Receive queue number
 const QUEUE_RECEIVE: u16 = 0;
-///@brief device id 转换为设备类型
-///@param pci_device_id，device_id
-///@return DeviceType 对应的设备类型
+/// Converts a PCI device ID to the corresponding VirtIO device type.
 fn device_type(pci_device_id: u16) -> DeviceType {
     match pci_device_id {
         TRANSITIONAL_NETWORK => DeviceType::Network,
@@ -106,11 +104,31 @@ pub struct PciTransport {
     device: Arc<PciDeviceStructureGeneralDevice>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct PciInterruptAck {
+    isr_status: NonNull<Volatile<u8>>,
+}
+
+// The handle only permits an atomic MMIO ISR-status read used for interrupt acknowledgement.
+// Queue/config mutation remains owned by PciTransport.
+unsafe impl Send for PciInterruptAck {}
+unsafe impl Sync for PciInterruptAck {}
+
+impl PciInterruptAck {
+    pub fn ack_interrupt(&self) -> bool {
+        // Safe because the ISR status pointer comes from a valid VirtIO PCI ISR BAR region.
+        // Reading the ISR status resets it to 0 and causes the device to de-assert the interrupt.
+        let isr_status = unsafe { self.isr_status.as_ptr().vread() };
+        // TODO: Distinguish between queue interrupt and device configuration interrupt.
+        isr_status & 0x3 != 0
+    }
+}
+
 impl PciTransport {
     /// Construct a new PCI VirtIO device driver for the given device function on the given PCI
     /// root controller.
     ///
-    /// ## 参数
+    /// ## Parameters
     ///
     /// - `device` - The PCI device structure for the VirtIO device.
     /// - `irq_handler` - An optional handler for the device's interrupt. If `None`, a default
@@ -137,12 +155,13 @@ impl PciTransport {
         device.bar_ioremap().unwrap()?;
         device.enable_master();
         let standard_device = device.as_standard_device().unwrap();
-        // 目前缺少对PCI设备中断号的统一管理，所以这里需要指定一个中断号。不能与其他中断重复
+        // Currently there is no unified management of PCI device interrupt numbers, so an
+        // interrupt number must be specified here. It must not conflict with other interrupts.
         let irq_vector = standard_device.irq_vector_mut().unwrap();
         irq_vector.write().push(irq);
 
         // panic!();
-        //device_capability为迭代器，遍历其相当于遍历所有的cap空间
+        // device_capability is an iterator; iterating over it traverses all capability space.
         for capability in device.capabilities().unwrap() {
             if capability.id != PCI_CAP_ID_VNDR {
                 continue;
@@ -237,6 +256,16 @@ impl PciTransport {
 
     pub fn irq(&self) -> IrqNumber {
         self.irq
+    }
+
+    pub fn interrupt_ack(&self) -> PciInterruptAck {
+        PciInterruptAck {
+            isr_status: self.isr_status,
+        }
+    }
+
+    pub fn ack_interrupt_ref(&self) -> bool {
+        self.interrupt_ack().ack_interrupt()
     }
 
     fn cache_queue_notify_index(&mut self, queue: u16) -> Option<usize> {
@@ -390,7 +419,7 @@ impl Transport for PciTransport {
             if self.cache_queue_notify_index(queue).is_none() {
                 self.fail_bad_notify_config(queue);
             }
-            // 这里设置队列中断对应的中断项
+            // Set the interrupt entry corresponding to the queue interrupt
             if matches!(*self.device.irq_type.read(), IrqType::Msix { .. }) {
                 if queue == QUEUE_RECEIVE {
                     volwrite!(self.common_cfg, msix_config, VIRTIO_RECV_VECTOR_INDEX);
@@ -441,12 +470,7 @@ impl Transport for PciTransport {
     }
 
     fn ack_interrupt(&mut self) -> bool {
-        // Safe because the common config pointer is valid and we checked in get_bar_region that it
-        // was aligned.
-        // Reading the ISR status resets it to 0 and causes the device to de-assert the interrupt.
-        let isr_status = unsafe { self.isr_status.as_ptr().vread() };
-        // TODO: Distinguish between queue interrupt and device configuration interrupt.
-        isr_status & 0x3 != 0
+        self.ack_interrupt_ref()
     }
 
     fn config_space<T>(&self) -> Result<NonNull<T>, Error> {
@@ -475,7 +499,8 @@ impl Drop for PciTransport {
         // Reset the device when the transport is dropped.
         self.set_status(DeviceStatus::empty());
 
-        // todo: 调用pci的中断释放函数，并且在virtio_irq_manager里面删除对应的设备的中断
+        // TODO: Call the PCI interrupt release function and remove the corresponding device
+        // interrupt from virtio_irq_manager
     }
 }
 
@@ -500,7 +525,7 @@ struct CommonCfg {
 }
 
 /// Information about a VirtIO structure within some BAR, as provided by a `virtio_pci_cap`.
-/// cfg空间在哪个bar的多少偏移处，长度多少
+/// Information about which BAR a VirtIO structure resides in, at what offset, and its length.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct VirtioCapabilityInfo {
     /// The bar in which the structure can be found.
@@ -512,7 +537,7 @@ struct VirtioCapabilityInfo {
 }
 
 /// An error encountered initialising a VirtIO PCI transport.
-/// VirtIO PCI transport 初始化时的错误
+/// An error encountered during VirtIO PCI transport initialization.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VirtioPciError {
     /// PCI device vender ID was not the VirtIO vendor ID.
@@ -539,7 +564,7 @@ pub enum VirtioPciError {
         /// The expected alignment in bytes.
         alignment: usize,
     },
-    ///获取虚拟地址失败
+    /// Failed to obtain the virtual address.
     BarGetVaddrFailed,
     /// A generic PCI error,
     Pci(PciError),
@@ -585,16 +610,19 @@ impl Display for VirtioPciError {
     }
 }
 
-/// PCI error到VirtioPciError的转换，层层上报
+/// Conversion from `PciError` to `VirtioPciError`, propagated up through the layers.
 impl From<PciError> for VirtioPciError {
     fn from(error: PciError) -> Self {
         Self::Pci(error)
     }
 }
 
-/// @brief 获取虚拟地址并将其转化为对应类型的指针
-/// @param device_bar 存储bar信息的结构体 struct_info 存储cfg空间的位置信息
-/// @return Result<NonNull<T>, VirtioPciError> 成功则返回对应类型的指针，失败则返回Error
+/// Obtains a virtual address and casts it to a pointer of the corresponding type.
+///
+/// * `device_bar` - The BAR info structure.
+/// * `struct_info` - The location info of the config space.
+///
+/// Returns a pointer of type `T` on success, or a `VirtioPciError` on failure.
 fn get_bar_region<T>(
     device_bar: &PciStandardDeviceBar,
     struct_info: &VirtioCapabilityInfo,
@@ -626,9 +654,12 @@ fn get_bar_region<T>(
     Ok(vaddr.cast())
 }
 
-/// @brief 获取虚拟地址并将其转化为对应类型的切片的指针
-/// @param device_bar 存储bar信息的结构体 struct_info 存储cfg空间的位置信息切片的指针
-/// @return Result<NonNull<[T]>, VirtioPciError> 成功则返回对应类型的指针切片，失败则返回Error
+/// Obtains a virtual address and casts it to a pointer to a slice of the corresponding type.
+///
+/// * `device_bar` - The BAR info structure.
+/// * `struct_info` - The location info of the config space.
+///
+/// Returns a pointer to a `[T]` slice on success, or a `VirtioPciError` on failure.
 fn get_bar_region_slice<T>(
     device_bar: &PciStandardDeviceBar,
     struct_info: &VirtioCapabilityInfo,

--- a/kernel/src/driver/virtio/virtio_fs.rs
+++ b/kernel/src/driver/virtio/virtio_fs.rs
@@ -1,7 +1,7 @@
 use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 use core::ptr;
 
@@ -11,10 +11,16 @@ use virtio_drivers::transport::Transport;
 
 use crate::{
     driver::base::device::{Device, DeviceId},
+    exception::{irqdesc::IrqReturn, IrqNumber},
+    filesystem::fuse::{conn::FuseConn, stats},
     libs::{spinlock::SpinLock, wait_queue::WaitQueue},
 };
 
-use super::transport::VirtIOTransport;
+use super::{
+    irq::{virtio_irq_manager, VirtioIrqCallback},
+    transport::VirtIOTransport,
+    transport_pci::PciInterruptAck,
+};
 
 const VIRTIO_FS_TAG_LEN: usize = 36;
 const VIRTIO_FS_REQUEST_QUEUE_BASE: u16 = 1;
@@ -40,12 +46,19 @@ impl core::fmt::Debug for VirtioFsTransportHolder {
 unsafe impl Send for VirtioFsTransportHolder {}
 
 #[derive(Debug)]
+struct VirtioFsActiveBridge {
+    session_id: u64,
+    conn: Weak<FuseConn>,
+}
+
+#[derive(Debug)]
 struct VirtioFsInstanceState {
     transport: Option<VirtioFsTransportHolder>,
     session_active: bool,
     active_session_id: u64,
     released_session_id: u64,
     next_session_id: u64,
+    active_bridge: Option<VirtioFsActiveBridge>,
 }
 
 #[derive(Debug)]
@@ -53,6 +66,9 @@ pub struct VirtioFsInstance {
     tag: String,
     num_request_queues: u32,
     dev_id: Arc<DeviceId>,
+    irq_wake_enabled: bool,
+    irq_is_msix: bool,
+    irq_ack: Option<PciInterruptAck>,
     state: SpinLock<VirtioFsInstanceState>,
     session_wait: WaitQueue,
 }
@@ -63,17 +79,24 @@ impl VirtioFsInstance {
         num_request_queues: u32,
         dev_id: Arc<DeviceId>,
         transport: VirtIOTransport,
+        irq_wake_enabled: bool,
+        irq_is_msix: bool,
+        irq_ack: Option<PciInterruptAck>,
     ) -> Self {
         Self {
             tag,
             num_request_queues,
             dev_id,
+            irq_wake_enabled,
+            irq_is_msix,
+            irq_ack,
             state: SpinLock::new(VirtioFsInstanceState {
                 transport: Some(VirtioFsTransportHolder(transport)),
                 session_active: false,
                 active_session_id: 0,
                 released_session_id: 0,
                 next_session_id: 1,
+                active_bridge: None,
             }),
             session_wait: WaitQueue::default(),
         }
@@ -123,11 +146,56 @@ impl VirtioFsInstance {
         state.next_session_id = state.next_session_id.wrapping_add(1);
         state.active_session_id = session_id;
         state.session_active = true;
+        state.active_bridge = None;
         Ok((transport, session_id))
+    }
+
+    pub fn install_bridge_wake(&self, session_id: u64, conn: &Arc<FuseConn>) {
+        let mut state = self.state.lock_irqsave();
+        if state.session_active && state.active_session_id == session_id {
+            state.active_bridge = Some(VirtioFsActiveBridge {
+                session_id,
+                conn: Arc::downgrade(conn),
+            });
+        }
+    }
+
+    pub fn enable_irq_wake(self: &Arc<Self>) -> bool {
+        if !self.irq_wake_enabled {
+            return false;
+        }
+        match virtio_irq_manager().register_callback(self.dev_id.clone(), self.clone()) {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(
+                    "virtio-fs: failed to register irq callback for tag='{}' dev={:?}: {:?}; use polling fallback",
+                    self.tag, self.dev_id, e
+                );
+                false
+            }
+        }
+    }
+
+    pub fn disable_irq_wake(&self) {
+        if self.irq_wake_enabled {
+            virtio_irq_manager().unregister_callback(&self.dev_id);
+        }
+    }
+
+    pub fn clear_bridge_wake(&self, session_id: u64) {
+        let mut state = self.state.lock_irqsave();
+        if state
+            .active_bridge
+            .as_ref()
+            .is_some_and(|bridge| bridge.session_id == session_id)
+        {
+            state.active_bridge = None;
+        }
     }
 
     pub fn put_transport_after_session(&self, transport: VirtIOTransport) {
         let mut state = self.state.lock_irqsave();
+        state.active_bridge = None;
         state.transport = Some(VirtioFsTransportHolder(transport));
         state.released_session_id = state.active_session_id;
         state.active_session_id = 0;
@@ -145,6 +213,57 @@ impl VirtioFsInstance {
                 None
             }
         });
+    }
+
+    fn wake_bridge_from_irq(&self) -> IrqReturn {
+        let mut owned_irq = self.irq_is_msix;
+        if let Some(irq_ack) = self.irq_ack.as_ref() {
+            let acked = irq_ack.ack_interrupt();
+            if !acked && !self.irq_is_msix {
+                return IrqReturn::NotHandled;
+            }
+            owned_irq = acked || self.irq_is_msix;
+        }
+
+        let (session_id, conn) = {
+            let state = self.state.lock_irqsave();
+            let Some(bridge) = state.active_bridge.as_ref() else {
+                stats::on_virtiofs_irq_no_active_conn();
+                return if owned_irq {
+                    IrqReturn::Handled
+                } else {
+                    IrqReturn::NotHandled
+                };
+            };
+            if !state.session_active || bridge.session_id != state.active_session_id {
+                stats::on_virtiofs_irq_stale_session();
+                return if owned_irq {
+                    IrqReturn::Handled
+                } else {
+                    IrqReturn::NotHandled
+                };
+            }
+            (bridge.session_id, bridge.conn.clone())
+        };
+
+        let Some(conn) = conn.upgrade() else {
+            stats::on_virtiofs_irq_weak_upgrade_failed();
+            self.clear_bridge_wake(session_id);
+            return if owned_irq {
+                IrqReturn::Handled
+            } else {
+                IrqReturn::NotHandled
+            };
+        };
+
+        conn.wake_bridge_irq_safe(stats::VirtioFsBridgeWakeSource::Completion);
+        IrqReturn::Handled
+    }
+}
+
+impl VirtioIrqCallback for VirtioFsInstance {
+    fn handle_irq(&self, _irq: IrqNumber) -> Result<IrqReturn, SystemError> {
+        Ok(self.wake_bridge_from_irq())
     }
 }
 
@@ -207,11 +326,48 @@ pub fn virtio_fs(
         }
     };
 
+    {
+        let map = VIRTIO_FS_INSTANCES.lock_irqsave();
+        if map.contains_key(&tag) {
+            warn!(
+                "virtio-fs: duplicated tag '{}' for device {:?}, ignore new device",
+                tag, dev_id
+            );
+            return;
+        }
+    }
+
+    let mut irq_wake_enabled = false;
+    let mut irq_is_msix = false;
+    let mut irq_ack = None;
+    if matches!(transport, VirtIOTransport::Pci(_)) {
+        if let Err(e) = transport.setup_irq(dev_id.clone()) {
+            warn!(
+                "virtio-fs: failed to setup irq for tag='{}' dev={:?}: {:?}; use polling fallback",
+                tag, dev_id, e
+            );
+        } else {
+            irq_wake_enabled = true;
+            irq_is_msix = transport.irq_is_msix();
+            if let VirtIOTransport::Pci(pci_transport) = &transport {
+                irq_ack = Some(pci_transport.interrupt_ack());
+            }
+        }
+    } else {
+        warn!(
+            "virtio-fs: tag='{}' dev={:?} has no event-driven IRQ wake path; use polling fallback",
+            tag, dev_id
+        );
+    }
+
     let instance = Arc::new(VirtioFsInstance::new(
         tag.clone(),
         nrqs,
         dev_id.clone(),
         transport,
+        irq_wake_enabled,
+        irq_is_msix,
+        irq_ack,
     ));
 
     let mut map = VIRTIO_FS_INSTANCES.lock_irqsave();

--- a/kernel/src/driver/virtio/virtio_fs.rs
+++ b/kernel/src/driver/virtio/virtio_fs.rs
@@ -153,6 +153,7 @@ impl VirtioFsInstance {
     pub fn install_bridge_wake(&self, session_id: u64, conn: &Arc<FuseConn>) {
         let mut state = self.state.lock_irqsave();
         if state.session_active && state.active_session_id == session_id {
+            conn.install_bridge_wake();
             state.active_bridge = Some(VirtioFsActiveBridge {
                 session_id,
                 conn: Arc::downgrade(conn),
@@ -183,24 +184,42 @@ impl VirtioFsInstance {
     }
 
     pub fn clear_bridge_wake(&self, session_id: u64) {
-        let mut state = self.state.lock_irqsave();
-        if state
-            .active_bridge
-            .as_ref()
-            .is_some_and(|bridge| bridge.session_id == session_id)
-        {
-            state.active_bridge = None;
+        let conn = {
+            let mut state = self.state.lock_irqsave();
+            if state
+                .active_bridge
+                .as_ref()
+                .is_some_and(|bridge| bridge.session_id == session_id)
+            {
+                state
+                    .active_bridge
+                    .take()
+                    .and_then(|bridge| bridge.conn.upgrade())
+            } else {
+                None
+            }
+        };
+        if let Some(conn) = conn {
+            conn.clear_bridge_wake();
         }
     }
 
     pub fn put_transport_after_session(&self, transport: VirtIOTransport) {
-        let mut state = self.state.lock_irqsave();
-        state.active_bridge = None;
-        state.transport = Some(VirtioFsTransportHolder(transport));
-        state.released_session_id = state.active_session_id;
-        state.active_session_id = 0;
-        state.session_active = false;
-        drop(state);
+        let conn = {
+            let mut state = self.state.lock_irqsave();
+            let conn = state
+                .active_bridge
+                .take()
+                .and_then(|bridge| bridge.conn.upgrade());
+            state.transport = Some(VirtioFsTransportHolder(transport));
+            state.released_session_id = state.active_session_id;
+            state.active_session_id = 0;
+            state.session_active = false;
+            conn
+        };
+        if let Some(conn) = conn {
+            conn.clear_bridge_wake();
+        }
         self.session_wait.wakeup(None);
     }
 

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -1,5 +1,5 @@
 use alloc::{collections::BTreeMap, collections::VecDeque, sync::Arc, vec::Vec};
-use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 use num_traits::FromPrimitive;
 use system_error::SystemError;
@@ -60,6 +60,7 @@ where
 
 #[derive(Debug)]
 struct FuseBridgeWake {
+    active: AtomicBool,
     events: AtomicU32,
     wait: WaitQueue,
 }
@@ -67,12 +68,26 @@ struct FuseBridgeWake {
 impl FuseBridgeWake {
     fn new() -> Self {
         Self {
+            active: AtomicBool::new(false),
             events: AtomicU32::new(0),
             wait: WaitQueue::default(),
         }
     }
 
+    fn install(&self) {
+        self.active.store(true, Ordering::Release);
+    }
+
+    fn clear(&self) {
+        self.active.store(false, Ordering::Release);
+        self.events.store(0, Ordering::Release);
+        self.wait.wakeup(None);
+    }
+
     fn signal(&self, source: stats::VirtioFsBridgeWakeSource, trace_allowed: bool) {
+        if !self.active.load(Ordering::Acquire) {
+            return;
+        }
         self.events.fetch_or(source.bit(), Ordering::Release);
         stats::on_virtiofs_bridge_wake(source);
         if trace_allowed {
@@ -354,6 +369,14 @@ impl FuseConn {
         F: FnMut(u32) -> Option<R>,
     {
         self.bridge_wake.wait_until(cond)
+    }
+
+    pub fn install_bridge_wake(&self) {
+        self.bridge_wake.install();
+    }
+
+    pub fn clear_bridge_wake(&self) {
+        self.bridge_wake.clear();
     }
 
     pub fn wake_bridge(&self, source: stats::VirtioFsBridgeWakeSource) {
@@ -1522,5 +1545,28 @@ mod tests {
         buf.resize(conn.min_read_buffer(), 0);
         let len = conn.read_request(true, &mut buf).unwrap();
         assert_eq!(read_opcode(&buf[..len]), FUSE_FORGET);
+    }
+
+    #[test]
+    fn bridge_wake_events_are_ignored_until_bridge_is_installed() {
+        let conn = FuseConn::new();
+
+        conn.wake_bridge(stats::VirtioFsBridgeWakeSource::Request);
+        assert_eq!(conn.bridge_wake_events(), 0);
+
+        conn.install_bridge_wake();
+        conn.wake_bridge(stats::VirtioFsBridgeWakeSource::Request);
+        assert_eq!(
+            conn.bridge_wake_events(),
+            stats::VirtioFsBridgeWakeSource::Request.bit()
+        );
+        assert_eq!(
+            conn.take_bridge_wake_events(),
+            stats::VirtioFsBridgeWakeSource::Request.bit()
+        );
+
+        conn.clear_bridge_wake();
+        conn.wake_bridge(stats::VirtioFsBridgeWakeSource::Request);
+        assert_eq!(conn.bridge_wake_events(), 0);
     }
 }

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -329,6 +329,10 @@ impl FuseConn {
         !self.inner.lock().hiprio_pending.is_empty()
     }
 
+    pub fn has_pending_ordinary_requests(&self) -> bool {
+        !self.inner.lock().pending.is_empty()
+    }
+
     pub fn has_processing_request(&self, unique: u64) -> bool {
         self.inner.lock().processing.contains_key(&unique)
     }
@@ -775,6 +779,29 @@ impl FuseConn {
         })
     }
 
+    fn pop_ordinary_pending_nonblock(&self) -> Result<Arc<FuseRequest>, SystemError> {
+        let mut g = self.inner.lock();
+        if !g.connected {
+            return Err(SystemError::ENOTCONN);
+        }
+        g.pending
+            .pop_front()
+            .ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)
+    }
+
+    fn pop_ordinary_pending_blocking(&self) -> Result<Arc<FuseRequest>, SystemError> {
+        wait_with_recheck(&self.read_wait, || {
+            let mut g = self.inner.lock();
+            if !g.connected {
+                return Err(SystemError::ENOTCONN);
+            }
+            if let Some(req) = g.pending.pop_front() {
+                return Ok(Some(req));
+            }
+            Ok(None)
+        })
+    }
+
     fn is_high_priority_opcode(opcode: u32) -> bool {
         matches!(opcode, FUSE_FORGET | FUSE_INTERRUPT)
     }
@@ -815,12 +842,21 @@ impl FuseConn {
         Ok(req.bytes.len())
     }
 
-    pub fn read_request(&self, nonblock: bool, out: &mut [u8]) -> Result<usize, SystemError> {
-        // Linux: require a sane minimum read buffer for all reads.
+    fn read_dequeued_request<F>(
+        &self,
+        nonblock: bool,
+        out: &mut [u8],
+        context: &str,
+        mut pop_request: F,
+    ) -> Result<usize, SystemError>
+    where
+        F: FnMut() -> Result<Arc<FuseRequest>, SystemError>,
+    {
         let min_read = self.min_read_buffer();
         if out.len() < min_read {
             log::warn!(
-                "fuse: read buffer too small: got={} min={} nonblock={}",
+                "fuse: read buffer too small for {}: got={} min={} nonblock={}",
+                context,
                 out.len(),
                 min_read,
                 nonblock
@@ -829,12 +865,7 @@ impl FuseConn {
         }
 
         let req = loop {
-            // Linux: if O_NONBLOCK and no pending request, return EAGAIN.
-            let req = if nonblock {
-                self.pop_pending_nonblock()?
-            } else {
-                self.pop_pending_blocking()?
-            };
+            let req = pop_request()?;
 
             if out.len() >= req.bytes.len() {
                 break req;
@@ -842,7 +873,8 @@ impl FuseConn {
 
             self.fail_oversized_read_request(&req);
             log::warn!(
-                "fuse: read buffer smaller than queued request: got={} need={}",
+                "fuse: read buffer smaller than queued {} request: got={} need={}",
+                context,
                 out.len(),
                 req.bytes.len()
             );
@@ -851,40 +883,40 @@ impl FuseConn {
         self.complete_dequeued_request(req, out)
     }
 
-    pub fn read_high_priority_request(&self, out: &mut [u8]) -> Result<usize, SystemError> {
-        let min_read = self.min_read_buffer();
-        if out.len() < min_read {
-            log::warn!(
-                "fuse: read buffer too small for high-priority request: got={} min={}",
-                out.len(),
-                min_read
-            );
-            return Err(SystemError::EINVAL);
-        }
-
-        let req = loop {
-            let req = {
-                let mut g = self.inner.lock();
-                if !g.connected {
-                    return Err(SystemError::ENOTCONN);
-                }
-                Self::pop_high_priority_pending_locked(&mut g)
-                    .ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)?
-            };
-
-            if out.len() >= req.bytes.len() {
-                break req;
+    pub fn read_request(&self, nonblock: bool, out: &mut [u8]) -> Result<usize, SystemError> {
+        // Linux: require a sane minimum read buffer for all reads.
+        self.read_dequeued_request(nonblock, out, "request", || {
+            // Linux: if O_NONBLOCK and no pending request, return EAGAIN.
+            if nonblock {
+                self.pop_pending_nonblock()
+            } else {
+                self.pop_pending_blocking()
             }
+        })
+    }
 
-            self.fail_oversized_read_request(&req);
-            log::warn!(
-                "fuse: read buffer smaller than queued high-priority request: got={} need={}",
-                out.len(),
-                req.bytes.len()
-            );
-        };
+    pub fn read_ordinary_request(
+        &self,
+        nonblock: bool,
+        out: &mut [u8],
+    ) -> Result<usize, SystemError> {
+        self.read_dequeued_request(nonblock, out, "ordinary request", || {
+            if nonblock {
+                self.pop_ordinary_pending_nonblock()
+            } else {
+                self.pop_ordinary_pending_blocking()
+            }
+        })
+    }
 
-        self.complete_dequeued_request(req, out)
+    pub fn read_high_priority_request(&self, out: &mut [u8]) -> Result<usize, SystemError> {
+        self.read_dequeued_request(true, out, "high-priority request", || {
+            let mut g = self.inner.lock();
+            if !g.connected {
+                return Err(SystemError::ENOTCONN);
+            }
+            Self::pop_high_priority_pending_locked(&mut g).ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        })
     }
 
     fn fail_oversized_read_request(&self, req: &FuseRequest) {
@@ -1416,5 +1448,79 @@ impl FuseConn {
             g.init.max_readahead as usize
         };
         core::cmp::max(1, bytes >> MMArch::PAGE_SHIFT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{sync::Arc, vec::Vec};
+
+    use system_error::SystemError;
+
+    use super::{
+        fuse_read_struct, FuseConn, FuseInHeader, FusePendingState, FuseRequestCred, FUSE_FORGET,
+        FUSE_LOOKUP,
+    };
+
+    fn queue_test_request(conn: &Arc<FuseConn>, opcode: u32, pending_reply: bool) -> u64 {
+        let unique = conn.alloc_unique();
+        let req = conn.build_request(unique, opcode, 1, &[], FuseRequestCred::nocreds());
+        let pending = pending_reply.then(|| Arc::new(FusePendingState::new(unique, opcode)));
+        conn.push_request(req, pending, unique).unwrap();
+        unique
+    }
+
+    fn read_opcode(buf: &[u8]) -> u32 {
+        let hdr: FuseInHeader = fuse_read_struct(buf).unwrap();
+        hdr.opcode
+    }
+
+    #[test]
+    fn ordinary_read_does_not_consume_high_priority_queue() {
+        let conn = FuseConn::new_for_virtiofs(8192);
+        queue_test_request(&conn, FUSE_FORGET, false);
+        queue_test_request(&conn, FUSE_LOOKUP, true);
+
+        assert!(conn.has_pending_high_priority_requests());
+        assert!(conn.has_pending_ordinary_requests());
+
+        let mut buf = Vec::new();
+        buf.resize(conn.min_read_buffer(), 0);
+        let len = conn.read_ordinary_request(true, &mut buf).unwrap();
+        assert_eq!(read_opcode(&buf[..len]), FUSE_LOOKUP);
+        assert!(conn.has_pending_high_priority_requests());
+        assert!(!conn.has_pending_ordinary_requests());
+
+        let len = conn.read_high_priority_request(&mut buf).unwrap();
+        assert_eq!(read_opcode(&buf[..len]), FUSE_FORGET);
+        assert!(!conn.has_pending_high_priority_requests());
+    }
+
+    #[test]
+    fn ordinary_read_returns_eagain_when_only_high_priority_is_pending() {
+        let conn = FuseConn::new_for_virtiofs(8192);
+        queue_test_request(&conn, FUSE_FORGET, false);
+
+        let mut buf = Vec::new();
+        buf.resize(conn.min_read_buffer(), 0);
+        assert!(matches!(
+            conn.read_ordinary_request(true, &mut buf),
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        ));
+        assert!(conn.has_pending_high_priority_requests());
+    }
+
+    #[test]
+    fn normal_fuse_read_request_keeps_high_priority_visible() {
+        let conn = FuseConn::new();
+        queue_test_request(&conn, FUSE_FORGET, false);
+
+        assert!(!conn.has_pending_high_priority_requests());
+        assert!(conn.has_pending_ordinary_requests());
+
+        let mut buf = Vec::new();
+        buf.resize(conn.min_read_buffer(), 0);
+        let len = conn.read_request(true, &mut buf).unwrap();
+        assert_eq!(read_opcode(&buf[..len]), FUSE_FORGET);
     }
 }

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -224,6 +224,8 @@ struct FuseConnInner {
     no_removexattr: bool,
     no_interrupt: bool,
     max_write_cap: usize,
+    separate_hiprio_pending: bool,
+    hiprio_pending: VecDeque<Arc<FuseRequest>>,
     pending: VecDeque<Arc<FuseRequest>>,
     processing: BTreeMap<u64, Arc<FusePendingState>>,
 }
@@ -251,6 +253,7 @@ impl FuseConn {
         Self::new_with_max_write_cap(
             Self::max_write_cap_for_user_read_chunk(),
             Self::kernel_init_flags(),
+            false,
         )
     }
 
@@ -261,10 +264,14 @@ impl FuseConn {
         } else {
             Self::MIN_MAX_WRITE
         };
-        Self::new_with_max_write_cap(cap, Self::virtiofs_init_flags())
+        Self::new_with_max_write_cap(cap, Self::virtiofs_init_flags(), true)
     }
 
-    fn new_with_max_write_cap(max_write_cap: usize, init_flags: u64) -> Arc<Self> {
+    fn new_with_max_write_cap(
+        max_write_cap: usize,
+        init_flags: u64,
+        separate_hiprio_pending: bool,
+    ) -> Arc<Self> {
         Arc::new(Self {
             inner: Mutex::new(FuseConnInner {
                 connected: true,
@@ -289,6 +296,8 @@ impl FuseConn {
                 no_removexattr: false,
                 no_interrupt: false,
                 max_write_cap,
+                separate_hiprio_pending,
+                hiprio_pending: VecDeque::new(),
                 pending: VecDeque::new(),
                 processing: BTreeMap::new(),
             }),
@@ -312,7 +321,20 @@ impl FuseConn {
     }
 
     pub fn has_pending_requests(&self) -> bool {
-        !self.inner.lock().pending.is_empty()
+        let g = self.inner.lock();
+        !g.hiprio_pending.is_empty() || !g.pending.is_empty()
+    }
+
+    pub fn has_pending_high_priority_requests(&self) -> bool {
+        !self.inner.lock().hiprio_pending.is_empty()
+    }
+
+    pub fn has_processing_request(&self, unique: u64) -> bool {
+        self.inner.lock().processing.contains_key(&unique)
+    }
+
+    pub fn interrupt_target_unique(unique: u64) -> u64 {
+        unique & !Self::FUSE_INT_REQ_BIT
     }
 
     pub fn bridge_wake_events(&self) -> u32 {
@@ -532,8 +554,10 @@ impl FuseConn {
             let pending_noreply_count = g
                 .pending
                 .iter()
+                .chain(g.hiprio_pending.iter())
                 .filter(|req| matches!(req.opcode, FUSE_FORGET | FUSE_DESTROY | FUSE_INTERRUPT))
                 .count();
+            g.hiprio_pending.clear();
             g.pending.clear();
             let processing = g.processing.values().cloned().collect();
             g.processing.clear();
@@ -572,7 +596,7 @@ impl FuseConn {
             // complete after unmount.
             let mut dropped_noreply = 0usize;
             let mut dropped_reply_unique = Vec::new();
-            for req in g.pending.iter() {
+            for req in g.hiprio_pending.iter().chain(g.pending.iter()) {
                 if req.opcode == FUSE_FORGET {
                     continue;
                 }
@@ -582,6 +606,7 @@ impl FuseConn {
                     dropped_reply_unique.push(req.unique);
                 }
             }
+            g.hiprio_pending.retain(|req| req.opcode == FUSE_FORGET);
             g.pending.retain(|req| req.opcode == FUSE_FORGET);
             dropped_processing = dropped_reply_unique
                 .into_iter()
@@ -683,7 +708,7 @@ impl FuseConn {
 
     pub fn poll(&self) -> EPollEventType {
         let g = self.inner.lock();
-        let have_pending = !g.pending.is_empty();
+        let have_pending = !g.hiprio_pending.is_empty() || !g.pending.is_empty();
         drop(g);
         self.poll_mask(have_pending)
     }
@@ -734,9 +759,7 @@ impl FuseConn {
         if !g.connected {
             return Err(SystemError::ENOTCONN);
         }
-        g.pending
-            .pop_front()
-            .ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        Self::pop_pending_locked(&mut g).ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)
     }
 
     fn pop_pending_blocking(&self) -> Result<Arc<FuseRequest>, SystemError> {
@@ -745,11 +768,51 @@ impl FuseConn {
             if !g.connected {
                 return Err(SystemError::ENOTCONN);
             }
-            if let Some(req) = g.pending.pop_front() {
+            if let Some(req) = Self::pop_pending_locked(&mut g) {
                 return Ok(Some(req));
             }
             Ok(None)
         })
+    }
+
+    fn is_high_priority_opcode(opcode: u32) -> bool {
+        matches!(opcode, FUSE_FORGET | FUSE_INTERRUPT)
+    }
+
+    fn is_stale_interrupt_locked(req: &FuseRequest, g: &FuseConnInner) -> bool {
+        req.opcode == FUSE_INTERRUPT
+            && !g
+                .processing
+                .contains_key(&Self::interrupt_target_unique(req.unique))
+    }
+
+    fn pop_high_priority_pending_locked(g: &mut FuseConnInner) -> Option<Arc<FuseRequest>> {
+        loop {
+            let req = g.hiprio_pending.pop_front()?;
+            if Self::is_stale_interrupt_locked(&req, g) {
+                stats::on_fuse_requests_aborted(1);
+                continue;
+            }
+            return Some(req);
+        }
+    }
+
+    fn pop_pending_locked(g: &mut FuseConnInner) -> Option<Arc<FuseRequest>> {
+        Self::pop_high_priority_pending_locked(g).or_else(|| g.pending.pop_front())
+    }
+
+    fn complete_dequeued_request(
+        &self,
+        req: Arc<FuseRequest>,
+        out: &mut [u8],
+    ) -> Result<usize, SystemError> {
+        out[..req.bytes.len()].copy_from_slice(&req.bytes);
+        stats::on_fuse_request_dequeued(req.bytes.len());
+        trace::trace_fuse_request_dequeue(req.unique, req.opcode, req.bytes.len() as u64);
+        if req.opcode == FUSE_DESTROY {
+            self.abort();
+        }
+        Ok(req.bytes.len())
     }
 
     pub fn read_request(&self, nonblock: bool, out: &mut [u8]) -> Result<usize, SystemError> {
@@ -785,13 +848,43 @@ impl FuseConn {
             );
         };
 
-        out[..req.bytes.len()].copy_from_slice(&req.bytes);
-        stats::on_fuse_request_dequeued(req.bytes.len());
-        trace::trace_fuse_request_dequeue(req.unique, req.opcode, req.bytes.len() as u64);
-        if req.opcode == FUSE_DESTROY {
-            self.abort();
+        self.complete_dequeued_request(req, out)
+    }
+
+    pub fn read_high_priority_request(&self, out: &mut [u8]) -> Result<usize, SystemError> {
+        let min_read = self.min_read_buffer();
+        if out.len() < min_read {
+            log::warn!(
+                "fuse: read buffer too small for high-priority request: got={} min={}",
+                out.len(),
+                min_read
+            );
+            return Err(SystemError::EINVAL);
         }
-        Ok(req.bytes.len())
+
+        let req = loop {
+            let req = {
+                let mut g = self.inner.lock();
+                if !g.connected {
+                    return Err(SystemError::ENOTCONN);
+                }
+                Self::pop_high_priority_pending_locked(&mut g)
+                    .ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)?
+            };
+
+            if out.len() >= req.bytes.len() {
+                break req;
+            }
+
+            self.fail_oversized_read_request(&req);
+            log::warn!(
+                "fuse: read buffer smaller than queued high-priority request: got={} need={}",
+                out.len(),
+                req.bytes.len()
+            );
+        };
+
+        self.complete_dequeued_request(req, out)
     }
 
     fn fail_oversized_read_request(&self, req: &FuseRequest) {
@@ -1047,7 +1140,11 @@ impl FuseConn {
             if !g.connected {
                 return Err(SystemError::ENOTCONN);
             }
-            g.pending.push_back(req);
+            if g.separate_hiprio_pending && Self::is_high_priority_opcode(opcode) {
+                g.hiprio_pending.push_back(req);
+            } else {
+                g.pending.push_back(req);
+            }
             if let Some(pending) = pending_state {
                 g.processing.insert(unique, pending);
             }

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -1,5 +1,5 @@
 use alloc::{collections::BTreeMap, collections::VecDeque, sync::Arc, vec::Vec};
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 use num_traits::FromPrimitive;
 use system_error::SystemError;
@@ -55,6 +55,45 @@ where
             waitq.remove_waker(&waker);
             return Err(e);
         }
+    }
+}
+
+#[derive(Debug)]
+struct FuseBridgeWake {
+    events: AtomicU32,
+    wait: WaitQueue,
+}
+
+impl FuseBridgeWake {
+    fn new() -> Self {
+        Self {
+            events: AtomicU32::new(0),
+            wait: WaitQueue::default(),
+        }
+    }
+
+    fn signal(&self, source: stats::VirtioFsBridgeWakeSource, trace_allowed: bool) {
+        self.events.fetch_or(source.bit(), Ordering::Release);
+        stats::on_virtiofs_bridge_wake(source);
+        if trace_allowed {
+            trace::trace_virtiofs_bridge_wake(source.trace_id());
+        }
+        self.wait.wakeup(None);
+    }
+
+    fn take_events(&self) -> u32 {
+        self.events.swap(0, Ordering::AcqRel)
+    }
+
+    fn events(&self) -> u32 {
+        self.events.load(Ordering::Acquire)
+    }
+
+    fn wait_until<F, R>(&self, mut cond: F) -> R
+    where
+        F: FnMut(u32) -> Option<R>,
+    {
+        self.wait.wait_until(|| cond(self.events()))
     }
 }
 
@@ -197,6 +236,7 @@ pub struct FuseConn {
     dev_count: AtomicUsize,
     read_wait: WaitQueue,
     init_wait: WaitQueue,
+    bridge_wake: FuseBridgeWake,
     epitems: LockedEPItemLinkedList,
 }
 
@@ -257,6 +297,7 @@ impl FuseConn {
             dev_count: AtomicUsize::new(1),
             read_wait: WaitQueue::default(),
             init_wait: WaitQueue::default(),
+            bridge_wake: FuseBridgeWake::new(),
             epitems: LockedEPItemLinkedList::default(),
         })
     }
@@ -272,6 +313,29 @@ impl FuseConn {
 
     pub fn has_pending_requests(&self) -> bool {
         !self.inner.lock().pending.is_empty()
+    }
+
+    pub fn bridge_wake_events(&self) -> u32 {
+        self.bridge_wake.events()
+    }
+
+    pub fn take_bridge_wake_events(&self) -> u32 {
+        self.bridge_wake.take_events()
+    }
+
+    pub fn wait_bridge_until<F, R>(&self, cond: F) -> R
+    where
+        F: FnMut(u32) -> Option<R>,
+    {
+        self.bridge_wake.wait_until(cond)
+    }
+
+    pub fn wake_bridge(&self, source: stats::VirtioFsBridgeWakeSource) {
+        self.bridge_wake.signal(source, true);
+    }
+
+    pub fn wake_bridge_irq_safe(&self, source: stats::VirtioFsBridgeWakeSource) {
+        self.bridge_wake.signal(source, false);
     }
 
     pub fn mark_mounted(&self) -> Result<(), SystemError> {
@@ -480,6 +544,7 @@ impl FuseConn {
             p.complete(Err(SystemError::ENOTCONN));
         }
         self.read_wait.wakeup(None);
+        self.wake_bridge(stats::VirtioFsBridgeWakeSource::Disconnect);
         self.init_wait.wakeup(None);
         let _ = EventPoll::wakeup_epoll(
             &self.epitems,
@@ -536,6 +601,7 @@ impl FuseConn {
             p.complete(Err(SystemError::ENOTCONN));
         }
         self.init_wait.wakeup(None);
+        self.wake_bridge(stats::VirtioFsBridgeWakeSource::Teardown);
 
         if !should_destroy {
             self.abort();
@@ -990,6 +1056,7 @@ impl FuseConn {
         stats::on_fuse_request_queued(req_len, no_reply);
         trace::trace_fuse_request_queue(unique, opcode, req_len as u64, no_reply as u8);
         self.read_wait.wakeup(None);
+        self.wake_bridge(stats::VirtioFsBridgeWakeSource::Request);
         let _ = EventPoll::wakeup_epoll(
             &self.epitems,
             EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM,
@@ -1130,9 +1197,10 @@ impl FuseConn {
             {
                 let mut g = self.inner.lock();
                 if g.connected {
-                    // 对齐 Linux：仅启用「daemon 支持 ∩ 本端请求」的特性位。
-                    // virtiofsd 常在 INIT 回复里带上 DO_READDIRPLUS 等位；若直接采纳，
-                    // 会走 READDIRPLUS + cache_child_from_entry，导致 inode 映射过期。
+                    // Align with Linux: only enable feature bits that are in the intersection of
+                    // daemon-supported and locally-requested flags. virtiofsd often sets
+                    // DO_READDIRPLUS etc. in the INIT reply; if adopted directly, it would
+                    // trigger READDIRPLUS + cache_child_from_entry, causing stale inode mappings.
                     let enabled_flags = negotiated_flags & g.init_flags;
                     g.initialized = true;
                     g.init = FuseInitNegotiated {

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -626,7 +626,6 @@ impl FuseConn {
             p.complete(Err(SystemError::ENOTCONN));
         }
         self.init_wait.wakeup(None);
-        self.wake_bridge(stats::VirtioFsBridgeWakeSource::Teardown);
 
         if !should_destroy {
             self.abort();
@@ -637,6 +636,7 @@ impl FuseConn {
             self.abort();
             return;
         }
+        self.wake_bridge(stats::VirtioFsBridgeWakeSource::Teardown);
     }
 
     /// Queue a FORGET message (no reply expected).

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -42,6 +42,72 @@ pub struct VirtioFsStatsSnapshot {
     pub bytes_completed_total: u64,
     pub pump_batch: [u64; BATCH_BUCKETS],
     pub complete_batch: [u64; BATCH_BUCKETS],
+    pub bridge_waits_total: u64,
+    pub bridge_wait_exit_request_pending_total: u64,
+    pub bridge_wait_exit_completion_total: u64,
+    pub bridge_wait_exit_teardown_total: u64,
+    pub bridge_wait_exit_disconnect_total: u64,
+    pub bridge_wait_exit_spurious_total: u64,
+    pub bridge_wake_request_total: u64,
+    pub bridge_wake_completion_total: u64,
+    pub bridge_wake_teardown_total: u64,
+    pub bridge_wake_disconnect_total: u64,
+    pub bridge_irq_no_active_conn_total: u64,
+    pub bridge_irq_stale_session_total: u64,
+    pub bridge_irq_weak_upgrade_failed_total: u64,
+    pub bridge_queue_full_blocked_total: u64,
+    pub bridge_queue_full_retry_total: u64,
+    pub bridge_queue_full_retry_after_completion_total: u64,
+    pub bridge_queue_full_retry_success_total: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtioFsBridgeWakeSource {
+    Request,
+    Completion,
+    Teardown,
+    Disconnect,
+}
+
+impl VirtioFsBridgeWakeSource {
+    pub const fn bit(self) -> u32 {
+        match self {
+            Self::Request => 1 << 0,
+            Self::Completion => 1 << 1,
+            Self::Teardown => 1 << 2,
+            Self::Disconnect => 1 << 3,
+        }
+    }
+
+    pub const fn trace_id(self) -> u8 {
+        match self {
+            Self::Request => 1,
+            Self::Completion => 2,
+            Self::Teardown => 3,
+            Self::Disconnect => 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtioFsBridgeWaitExit {
+    RequestPending,
+    Completion,
+    Teardown,
+    Disconnect,
+    Spurious,
+}
+
+impl VirtioFsBridgeWaitExit {
+    pub const fn trace_id(self) -> u8 {
+        match self {
+            Self::RequestPending => 1,
+            Self::Completion => 2,
+            Self::Teardown => 3,
+            Self::Disconnect => 4,
+            Self::Spurious => 5,
+        }
+    }
 }
 
 static REQUESTS_QUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -79,6 +145,24 @@ static BYTES_COMPLETED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 static PUMP_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
 static COMPLETE_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
+
+static BRIDGE_WAITS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAIT_EXIT_REQUEST_PENDING_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAIT_EXIT_COMPLETION_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAIT_EXIT_TEARDOWN_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAIT_EXIT_DISCONNECT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAIT_EXIT_SPURIOUS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAKE_REQUEST_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAKE_COMPLETION_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAKE_TEARDOWN_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAKE_DISCONNECT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_IRQ_NO_ACTIVE_CONN_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_IRQ_STALE_SESSION_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_IRQ_WEAK_UPGRADE_FAILED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_QUEUE_FULL_BLOCKED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_QUEUE_FULL_RETRY_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_QUEUE_FULL_RETRY_AFTER_COMPLETION_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_QUEUE_FULL_RETRY_SUCCESS_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
 fn add(counter: &AtomicU64, value: u64) {
@@ -172,6 +256,47 @@ pub fn on_virtiofs_idle_sleep(ns: i64) {
 }
 
 #[inline]
+pub fn on_virtiofs_bridge_wait() {
+    inc(&BRIDGE_WAITS_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_bridge_wait_exit(reason: VirtioFsBridgeWaitExit) {
+    match reason {
+        VirtioFsBridgeWaitExit::RequestPending => inc(&BRIDGE_WAIT_EXIT_REQUEST_PENDING_TOTAL),
+        VirtioFsBridgeWaitExit::Completion => inc(&BRIDGE_WAIT_EXIT_COMPLETION_TOTAL),
+        VirtioFsBridgeWaitExit::Teardown => inc(&BRIDGE_WAIT_EXIT_TEARDOWN_TOTAL),
+        VirtioFsBridgeWaitExit::Disconnect => inc(&BRIDGE_WAIT_EXIT_DISCONNECT_TOTAL),
+        VirtioFsBridgeWaitExit::Spurious => inc(&BRIDGE_WAIT_EXIT_SPURIOUS_TOTAL),
+    }
+}
+
+#[inline]
+pub fn on_virtiofs_bridge_wake(source: VirtioFsBridgeWakeSource) {
+    match source {
+        VirtioFsBridgeWakeSource::Request => inc(&BRIDGE_WAKE_REQUEST_TOTAL),
+        VirtioFsBridgeWakeSource::Completion => inc(&BRIDGE_WAKE_COMPLETION_TOTAL),
+        VirtioFsBridgeWakeSource::Teardown => inc(&BRIDGE_WAKE_TEARDOWN_TOTAL),
+        VirtioFsBridgeWakeSource::Disconnect => inc(&BRIDGE_WAKE_DISCONNECT_TOTAL),
+    }
+}
+
+#[inline]
+pub fn on_virtiofs_irq_no_active_conn() {
+    inc(&BRIDGE_IRQ_NO_ACTIVE_CONN_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_irq_stale_session() {
+    inc(&BRIDGE_IRQ_STALE_SESSION_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_irq_weak_upgrade_failed() {
+    inc(&BRIDGE_IRQ_WEAK_UPGRADE_FAILED_TOTAL);
+}
+
+#[inline]
 pub fn on_virtiofs_ack_interrupt() {
     inc(&BRIDGE_ACK_INTERRUPT_TOTAL);
 }
@@ -213,6 +338,24 @@ pub fn on_virtiofs_submitted(req_len: usize) {
 #[inline]
 pub fn on_virtiofs_queue_full() {
     inc(&VIRTQUEUE_FULL_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_queue_full_blocked() {
+    inc(&BRIDGE_QUEUE_FULL_BLOCKED_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_queue_full_retry(after_completion: bool) {
+    inc(&BRIDGE_QUEUE_FULL_RETRY_TOTAL);
+    if after_completion {
+        inc(&BRIDGE_QUEUE_FULL_RETRY_AFTER_COMPLETION_TOTAL);
+    }
+}
+
+#[inline]
+pub fn on_virtiofs_queue_full_retry_success() {
+    inc(&BRIDGE_QUEUE_FULL_RETRY_SUCCESS_TOTAL);
 }
 
 #[inline]
@@ -284,6 +427,29 @@ pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
         bytes_completed_total: BYTES_COMPLETED_TOTAL.load(Ordering::Relaxed),
         pump_batch: snapshot_batch(&PUMP_BATCH),
         complete_batch: snapshot_batch(&COMPLETE_BATCH),
+        bridge_waits_total: BRIDGE_WAITS_TOTAL.load(Ordering::Relaxed),
+        bridge_wait_exit_request_pending_total: BRIDGE_WAIT_EXIT_REQUEST_PENDING_TOTAL
+            .load(Ordering::Relaxed),
+        bridge_wait_exit_completion_total: BRIDGE_WAIT_EXIT_COMPLETION_TOTAL
+            .load(Ordering::Relaxed),
+        bridge_wait_exit_teardown_total: BRIDGE_WAIT_EXIT_TEARDOWN_TOTAL.load(Ordering::Relaxed),
+        bridge_wait_exit_disconnect_total: BRIDGE_WAIT_EXIT_DISCONNECT_TOTAL
+            .load(Ordering::Relaxed),
+        bridge_wait_exit_spurious_total: BRIDGE_WAIT_EXIT_SPURIOUS_TOTAL.load(Ordering::Relaxed),
+        bridge_wake_request_total: BRIDGE_WAKE_REQUEST_TOTAL.load(Ordering::Relaxed),
+        bridge_wake_completion_total: BRIDGE_WAKE_COMPLETION_TOTAL.load(Ordering::Relaxed),
+        bridge_wake_teardown_total: BRIDGE_WAKE_TEARDOWN_TOTAL.load(Ordering::Relaxed),
+        bridge_wake_disconnect_total: BRIDGE_WAKE_DISCONNECT_TOTAL.load(Ordering::Relaxed),
+        bridge_irq_no_active_conn_total: BRIDGE_IRQ_NO_ACTIVE_CONN_TOTAL.load(Ordering::Relaxed),
+        bridge_irq_stale_session_total: BRIDGE_IRQ_STALE_SESSION_TOTAL.load(Ordering::Relaxed),
+        bridge_irq_weak_upgrade_failed_total: BRIDGE_IRQ_WEAK_UPGRADE_FAILED_TOTAL
+            .load(Ordering::Relaxed),
+        bridge_queue_full_blocked_total: BRIDGE_QUEUE_FULL_BLOCKED_TOTAL.load(Ordering::Relaxed),
+        bridge_queue_full_retry_total: BRIDGE_QUEUE_FULL_RETRY_TOTAL.load(Ordering::Relaxed),
+        bridge_queue_full_retry_after_completion_total:
+            BRIDGE_QUEUE_FULL_RETRY_AFTER_COMPLETION_TOTAL.load(Ordering::Relaxed),
+        bridge_queue_full_retry_success_total: BRIDGE_QUEUE_FULL_RETRY_SUCCESS_TOTAL
+            .load(Ordering::Relaxed),
     }
 }
 
@@ -334,7 +500,24 @@ complete_batch_0 {}\n\
 complete_batch_1 {}\n\
 complete_batch_2_4 {}\n\
 complete_batch_5_16 {}\n\
-complete_batch_gt_16 {}\n",
+complete_batch_gt_16 {}\n\
+bridge_waits_total {}\n\
+bridge_wait_exit_request_pending_total {}\n\
+bridge_wait_exit_completion_total {}\n\
+bridge_wait_exit_teardown_total {}\n\
+bridge_wait_exit_disconnect_total {}\n\
+bridge_wait_exit_spurious_total {}\n\
+bridge_wake_request_total {}\n\
+bridge_wake_completion_total {}\n\
+bridge_wake_teardown_total {}\n\
+bridge_wake_disconnect_total {}\n\
+bridge_irq_no_active_conn_total {}\n\
+bridge_irq_stale_session_total {}\n\
+bridge_irq_weak_upgrade_failed_total {}\n\
+bridge_queue_full_blocked_total {}\n\
+bridge_queue_full_retry_total {}\n\
+bridge_queue_full_retry_after_completion_total {}\n\
+bridge_queue_full_retry_success_total {}\n",
         fuse.requests_queued_total,
         fuse.requests_dequeued_total,
         fuse.requests_replied_ok_total,
@@ -376,5 +559,22 @@ complete_batch_gt_16 {}\n",
         virtiofs.complete_batch[2],
         virtiofs.complete_batch[3],
         virtiofs.complete_batch[4],
+        virtiofs.bridge_waits_total,
+        virtiofs.bridge_wait_exit_request_pending_total,
+        virtiofs.bridge_wait_exit_completion_total,
+        virtiofs.bridge_wait_exit_teardown_total,
+        virtiofs.bridge_wait_exit_disconnect_total,
+        virtiofs.bridge_wait_exit_spurious_total,
+        virtiofs.bridge_wake_request_total,
+        virtiofs.bridge_wake_completion_total,
+        virtiofs.bridge_wake_teardown_total,
+        virtiofs.bridge_wake_disconnect_total,
+        virtiofs.bridge_irq_no_active_conn_total,
+        virtiofs.bridge_irq_stale_session_total,
+        virtiofs.bridge_irq_weak_upgrade_failed_total,
+        virtiofs.bridge_queue_full_blocked_total,
+        virtiofs.bridge_queue_full_retry_total,
+        virtiofs.bridge_queue_full_retry_after_completion_total,
+        virtiofs.bridge_queue_full_retry_success_total,
     )
 }

--- a/kernel/src/filesystem/fuse/trace.rs
+++ b/kernel/src/filesystem/fuse/trace.rs
@@ -6,34 +6,99 @@ pub const VIRTIOFS_QUEUE_HIPRIO: u8 = 0;
 pub const VIRTIOFS_QUEUE_REQUEST: u8 = 1;
 
 pub const VIRTIOFS_RETRY_QUEUE_FULL: u8 = 1;
-pub const VIRTIOFS_RETRY_NOT_READY: u8 = 2;
 
 define_event_trace!(
-    fuse_request_queue,
+fuse_request_queue,
+TP_system(fuse),
+TP_PROTO(unique: u64, opcode: u32, len: u64, no_reply: u8),
+TP_STRUCT__entry {
+    unique: u64,
+    opcode: u32,
+    len: u64,
+    no_reply: u8,
+},
+TP_fast_assign {
+    unique: unique,
+    opcode: opcode,
+    len: len,
+    no_reply: no_reply,
+},
+TP_ident(__entry),
+TP_printk({
+    let unique = __entry.unique;
+    let opcode = __entry.opcode;
+    let len = __entry.len;
+    let no_reply = __entry.no_reply;
+    format!(
+        "unique={} opcode={} len={} no_reply={}",
+        unique, opcode, len, no_reply
+    )
+})
+);
+
+define_event_trace!(
+    virtiofs_bridge_wait_enter,
     TP_system(fuse),
-    TP_PROTO(unique: u64, opcode: u32, len: u64, no_reply: u8),
+    TP_PROTO(pending: u8, inflight: u8, can_pop: u8, queue_full_blocked: u8),
     TP_STRUCT__entry {
-        unique: u64,
-        opcode: u32,
-        len: u64,
-        no_reply: u8,
+        pending: u8,
+        inflight: u8,
+        can_pop: u8,
+        queue_full_blocked: u8,
     },
     TP_fast_assign {
-        unique: unique,
-        opcode: opcode,
-        len: len,
-        no_reply: no_reply,
+        pending: pending,
+        inflight: inflight,
+        can_pop: can_pop,
+        queue_full_blocked: queue_full_blocked,
     },
     TP_ident(__entry),
     TP_printk({
-        let unique = __entry.unique;
-        let opcode = __entry.opcode;
-        let len = __entry.len;
-        let no_reply = __entry.no_reply;
+        let pending = __entry.pending;
+        let inflight = __entry.inflight;
+        let can_pop = __entry.can_pop;
+        let queue_full_blocked = __entry.queue_full_blocked;
         format!(
-            "unique={} opcode={} len={} no_reply={}",
-            unique, opcode, len, no_reply
+            "pending={} inflight={} can_pop={} queue_full_blocked={}",
+            pending, inflight, can_pop, queue_full_blocked
         )
+    })
+);
+
+define_event_trace!(
+    virtiofs_bridge_wait_exit,
+    TP_system(fuse),
+    TP_PROTO(reason: u8, events: u32),
+    TP_STRUCT__entry {
+        reason: u8,
+        events: u32,
+    },
+    TP_fast_assign {
+        reason: reason,
+        events: events,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let reason = __entry.reason;
+        let events = __entry.events;
+        format!("reason={} events={}", reason, events)
+    })
+);
+
+define_event_trace!(
+    virtiofs_bridge_wake,
+    TP_system(fuse),
+    TP_PROTO(source: u8),
+    TP_STRUCT__entry {
+        source: u8,
+    },
+    TP_fast_assign {
+        source: source,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let source = __entry.source;
+        format!("source={}", source)
     })
 );
 

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -70,9 +70,17 @@ struct InflightReq {
     rsp: Option<Vec<u8>>,
 }
 
+#[derive(Debug, Default)]
+struct QueueBlockState {
+    blocked: bool,
+    completion_seen: bool,
+}
+
 struct VirtioFsBridgeContext {
     instance: Arc<VirtioFsInstance>,
     conn: Arc<FuseConn>,
+    session_id: u64,
+    irq_wake_enabled: bool,
     transport: Option<VirtIOTransport>,
     hiprio_vq: Option<VirtQueue<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>>,
     request_vqs: Vec<VirtQueue<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>>,
@@ -82,6 +90,8 @@ struct VirtioFsBridgeContext {
     request_inflight: Vec<BTreeMap<u16, InflightReq>>,
     next_request_slot: usize,
     req_buf: Vec<u8>,
+    hiprio_blocked: QueueBlockState,
+    request_blocked: Vec<QueueBlockState>,
 }
 
 impl VirtioFsBridgeContext {
@@ -95,6 +105,42 @@ impl VirtioFsBridgeContext {
 
     fn has_inflight(&self) -> bool {
         !self.hiprio_inflight.is_empty() || self.request_inflight.iter().any(|m| !m.is_empty())
+    }
+
+    fn has_completion_available(&self) -> bool {
+        self.hiprio_vq.as_ref().is_some_and(|queue| queue.can_pop())
+            || self.request_vqs.iter().any(|queue| queue.can_pop())
+    }
+
+    fn has_queue_full_blocked(&self) -> bool {
+        self.hiprio_blocked.blocked || self.request_blocked.iter().any(|state| state.blocked)
+    }
+
+    fn block_state_mut(&mut self, kind: QueueKind) -> Result<&mut QueueBlockState, SystemError> {
+        match kind {
+            QueueKind::Hiprio => Ok(&mut self.hiprio_blocked),
+            QueueKind::Request(slot) => self
+                .request_blocked
+                .get_mut(slot)
+                .ok_or(SystemError::EINVAL),
+        }
+    }
+
+    fn mark_queue_full_blocked(&mut self, kind: QueueKind) -> Result<(), SystemError> {
+        let state = self.block_state_mut(kind)?;
+        if !state.blocked {
+            stats::on_virtiofs_queue_full_blocked();
+        }
+        state.blocked = true;
+        Ok(())
+    }
+
+    fn mark_queue_completion_seen(&mut self, kind: QueueKind) {
+        if let Ok(state) = self.block_state_mut(kind) {
+            if state.blocked {
+                state.completion_seen = true;
+            }
+        }
     }
 
     fn push_pending_back(&mut self, pending: PendingReq) -> Result<(), SystemError> {
@@ -276,6 +322,13 @@ impl VirtioFsBridgeContext {
             Some(p) => p,
             None => return Ok(false),
         };
+        let retry_after_completion = {
+            let state = self.block_state_mut(kind)?;
+            state.blocked.then_some(state.completion_seen)
+        };
+        if let Some(after_completion) = retry_after_completion {
+            stats::on_virtiofs_queue_full_retry(after_completion);
+        }
         let queue_idx = self.queue_index(kind)?;
         let mut rsp = if pending.noreply {
             None
@@ -318,6 +371,7 @@ impl VirtioFsBridgeContext {
             Ok(token) => token,
             Err(VirtioError::QueueFull) => {
                 stats::on_virtiofs_queue_full();
+                self.mark_queue_full_blocked(kind)?;
                 let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
                 trace::trace_virtiofs_queue_retry(
                     pending.unique,
@@ -331,16 +385,16 @@ impl VirtioFsBridgeContext {
             }
             Err(VirtioError::NotReady) => {
                 stats::on_virtiofs_not_ready();
-                let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
-                trace::trace_virtiofs_queue_retry(
-                    pending.unique,
-                    pending.opcode,
-                    queue_kind,
-                    queue_slot,
-                    trace::VIRTIOFS_RETRY_NOT_READY,
+                stats::on_virtiofs_submit_error();
+                let se = virtio_drivers_error_to_system_error(VirtioError::NotReady);
+                warn!(
+                    "virtiofs bridge: queue not ready opcode={} unique={} queue={:?} err={:?}",
+                    pending.opcode, pending.unique, kind, se
                 );
-                self.push_pending_front(pending)?;
-                return Ok(false);
+                if !pending.noreply {
+                    self.complete_request_with_error(pending.unique, se);
+                }
+                return Ok(true);
             }
             Err(e) => {
                 stats::on_virtiofs_submit_error();
@@ -364,6 +418,19 @@ impl VirtioFsBridgeContext {
         }
 
         stats::on_virtiofs_submitted(pending.req.len());
+        let retry_succeeded = {
+            let state = self.block_state_mut(kind)?;
+            if state.blocked {
+                state.blocked = false;
+                state.completion_seen = false;
+                true
+            } else {
+                false
+            }
+        };
+        if retry_succeeded {
+            stats::on_virtiofs_queue_full_retry_success();
+        }
         let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
         trace::trace_virtiofs_submit(
             pending.unique,
@@ -514,18 +581,89 @@ impl VirtioFsBridgeContext {
 
     fn drain_completions(&mut self) -> Result<usize, SystemError> {
         let mut completed = 0usize;
+        let mut hiprio_completed = 0usize;
         while self.pop_one_used(QueueKind::Hiprio)? {
+            hiprio_completed += 1;
             completed += 1;
+        }
+        if hiprio_completed != 0 {
+            self.mark_queue_completion_seen(QueueKind::Hiprio);
         }
 
         for slot in 0..self.request_vqs.len() {
+            let mut queue_completed = 0usize;
             while self.pop_one_used(QueueKind::Request(slot))? {
+                queue_completed += 1;
                 completed += 1;
+            }
+            if queue_completed != 0 {
+                self.mark_queue_completion_seen(QueueKind::Request(slot));
             }
         }
 
         stats::on_virtiofs_complete_batch(completed);
         Ok(completed)
+    }
+
+    fn bridge_wait_exit_reason(
+        &self,
+        conn: &FuseConn,
+        events: u32,
+    ) -> Option<stats::VirtioFsBridgeWaitExit> {
+        if !conn.is_connected() {
+            return Some(stats::VirtioFsBridgeWaitExit::Disconnect);
+        }
+
+        let teardown_event = events & stats::VirtioFsBridgeWakeSource::Teardown.bit() != 0;
+        if teardown_event || !conn.is_mounted() {
+            return Some(stats::VirtioFsBridgeWaitExit::Teardown);
+        }
+
+        let completion_event = events & stats::VirtioFsBridgeWakeSource::Completion.bit() != 0;
+        if completion_event || self.has_completion_available() {
+            return Some(stats::VirtioFsBridgeWaitExit::Completion);
+        }
+
+        let request_event = events & stats::VirtioFsBridgeWakeSource::Request.bit() != 0;
+        if !self.has_queue_full_blocked() && (request_event || conn.has_pending_requests()) {
+            return Some(stats::VirtioFsBridgeWaitExit::RequestPending);
+        }
+
+        let disconnect_event = events & stats::VirtioFsBridgeWakeSource::Disconnect.bit() != 0;
+        if disconnect_event {
+            return Some(stats::VirtioFsBridgeWaitExit::Disconnect);
+        }
+
+        let known_events = stats::VirtioFsBridgeWakeSource::Request.bit()
+            | stats::VirtioFsBridgeWakeSource::Completion.bit()
+            | stats::VirtioFsBridgeWakeSource::Teardown.bit()
+            | stats::VirtioFsBridgeWakeSource::Disconnect.bit();
+        if events & !known_events != 0 {
+            return Some(stats::VirtioFsBridgeWaitExit::Spurious);
+        }
+
+        None
+    }
+
+    fn wait_for_event(&mut self) {
+        if !self.irq_wake_enabled {
+            stats::on_virtiofs_idle_sleep(VIRTIOFS_POLL_NS);
+            Self::poll_pause();
+            return;
+        }
+
+        let conn = self.conn.clone();
+        trace::trace_virtiofs_bridge_wait_enter(
+            self.has_internal_pending() as u8,
+            self.has_inflight() as u8,
+            self.has_completion_available() as u8,
+            self.has_queue_full_blocked() as u8,
+        );
+        stats::on_virtiofs_bridge_wait();
+        let reason = conn.wait_bridge_until(|events| self.bridge_wait_exit_reason(&conn, events));
+        let events = conn.take_bridge_wake_events();
+        stats::on_virtiofs_bridge_wait_exit(reason);
+        trace::trace_virtiofs_bridge_wait_exit(reason.trace_id(), events);
     }
 
     fn fail_all_unfinished(&mut self, err: SystemError) {
@@ -570,17 +708,34 @@ impl VirtioFsBridgeContext {
         stats::on_virtiofs_fail_unfinished(failed);
     }
 
+    fn reset_device_and_unset_queues(&mut self) {
+        if let Some(transport) = self.transport.as_mut() {
+            transport.set_status(DeviceStatus::empty());
+            if self.hiprio_vq.take().is_some() {
+                transport.queue_unset(self.instance.hiprio_queue_index());
+            }
+            for slot in 0..self.request_vqs.len() {
+                if let Some(idx) = self.instance.request_queue_index_by_slot(slot) {
+                    transport.queue_unset(idx);
+                }
+            }
+            self.request_vqs.clear();
+        }
+    }
+
     fn run_loop(&mut self) -> Result<(), SystemError> {
         loop {
             let mut progressed = false;
 
-            match self.pump_new_requests() {
-                Ok(v) => progressed |= v != 0,
-                Err(SystemError::ENOTCONN) => {}
-                Err(e) => {
-                    warn!("virtiofs bridge: read_request failed: {:?}", e);
-                    if !self.conn.is_connected() {
-                        break;
+            if !self.has_queue_full_blocked() {
+                match self.pump_new_requests() {
+                    Ok(v) => progressed |= v != 0,
+                    Err(SystemError::ENOTCONN) => {}
+                    Err(e) => {
+                        warn!("virtiofs bridge: read_request failed: {:?}", e);
+                        if !self.conn.is_connected() {
+                            break;
+                        }
                     }
                 }
             }
@@ -592,10 +747,14 @@ impl VirtioFsBridgeContext {
                     stats::on_virtiofs_ack_interrupt();
                 }
             }
-            progressed |= self.drain_completions()? != 0;
+            let completed = self.drain_completions()?;
+            if completed != 0 {
+                progressed = true;
+                progressed |= self.submit_pending()?;
+            }
             stats::on_virtiofs_loop_iteration(progressed);
 
-            if !self.conn.is_connected() && !self.has_inflight() {
+            if !self.conn.is_connected() {
                 break;
             }
 
@@ -608,8 +767,7 @@ impl VirtioFsBridgeContext {
             }
 
             if !progressed {
-                stats::on_virtiofs_idle_sleep(VIRTIOFS_POLL_NS);
-                Self::poll_pause();
+                self.wait_for_event();
             }
         }
 
@@ -617,20 +775,12 @@ impl VirtioFsBridgeContext {
     }
 
     fn finish(&mut self) {
-        self.fail_all_unfinished(SystemError::ENOTCONN);
-
-        if let Some(transport) = self.transport.as_mut() {
-            if self.hiprio_vq.take().is_some() {
-                transport.queue_unset(self.instance.hiprio_queue_index());
-            }
-            for slot in 0..self.request_vqs.len() {
-                if let Some(idx) = self.instance.request_queue_index_by_slot(slot) {
-                    transport.queue_unset(idx);
-                }
-            }
-            self.request_vqs.clear();
-            transport.set_status(DeviceStatus::empty());
+        if self.irq_wake_enabled {
+            self.instance.disable_irq_wake();
         }
+        self.instance.clear_bridge_wake(self.session_id);
+        self.reset_device_and_unset_queues();
+        self.fail_all_unfinished(SystemError::ENOTCONN);
 
         if let Some(transport) = self.transport.take() {
             self.instance.put_transport_after_session(transport);
@@ -725,9 +875,14 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
     }
     transport.finish_init();
 
+    instance.install_bridge_wake(session_id, &conn);
+    let irq_wake_enabled = instance.enable_irq_wake();
+    let request_queue_count = request_vqs.len();
     let ctx = Box::new(VirtioFsBridgeContext {
         instance,
         conn,
+        session_id,
+        irq_wake_enabled,
         transport: Some(transport),
         hiprio_vq: Some(hiprio_vq),
         request_pending: core::iter::repeat_with(VecDeque::new)
@@ -741,6 +896,10 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
         hiprio_inflight: BTreeMap::new(),
         next_request_slot: 0,
         req_buf: vec![0u8; VIRTIOFS_REQ_BUF_SIZE],
+        hiprio_blocked: QueueBlockState::default(),
+        request_blocked: core::iter::repeat_with(QueueBlockState::default)
+            .take(request_queue_count)
+            .collect(),
     });
 
     let raw = Box::into_raw(ctx);

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -116,6 +116,10 @@ impl VirtioFsBridgeContext {
         self.hiprio_blocked.blocked || self.request_blocked.iter().any(|state| state.blocked)
     }
 
+    fn can_pump_high_priority(&self) -> bool {
+        !self.hiprio_blocked.blocked
+    }
+
     fn block_state_mut(&mut self, kind: QueueKind) -> Result<&mut QueueBlockState, SystemError> {
         match kind {
             QueueKind::Hiprio => Ok(&mut self.hiprio_blocked),
@@ -132,6 +136,7 @@ impl VirtioFsBridgeContext {
             stats::on_virtiofs_queue_full_blocked();
         }
         state.blocked = true;
+        state.completion_seen = false;
         Ok(())
     }
 
@@ -176,6 +181,84 @@ impl VirtioFsBridgeContext {
                 .ok_or(SystemError::EINVAL)?
                 .pop_front(),
         })
+    }
+
+    fn queue_can_retry(&self, kind: QueueKind) -> Result<bool, SystemError> {
+        let state = match kind {
+            QueueKind::Hiprio => &self.hiprio_blocked,
+            QueueKind::Request(slot) => {
+                self.request_blocked.get(slot).ok_or(SystemError::EINVAL)?
+            }
+        };
+        Ok(!state.blocked || state.completion_seen)
+    }
+
+    fn request_inflight_contains_unique(&self, unique: u64) -> bool {
+        self.request_inflight
+            .iter()
+            .any(|map| map.values().any(|req| req.pending.unique == unique))
+    }
+
+    fn hiprio_pending_submit_ready(&self, pending: &PendingReq) -> bool {
+        if pending.opcode != FUSE_INTERRUPT {
+            return true;
+        }
+
+        let target_unique = FuseConn::interrupt_target_unique(pending.unique);
+        self.conn.has_processing_request(target_unique)
+            && self.request_inflight_contains_unique(target_unique)
+    }
+
+    fn pop_ready_hiprio_pending(&mut self) -> Result<Option<PendingReq>, SystemError> {
+        if !self.queue_can_retry(QueueKind::Hiprio)? {
+            return Ok(None);
+        }
+
+        let mut index = 0usize;
+        while index < self.hiprio_pending.len() {
+            let (opcode, unique) = {
+                let pending = self.hiprio_pending.get(index).ok_or(SystemError::EINVAL)?;
+                (pending.opcode, pending.unique)
+            };
+
+            if opcode == FUSE_INTERRUPT {
+                let target_unique = FuseConn::interrupt_target_unique(unique);
+                if !self.conn.has_processing_request(target_unique) {
+                    self.hiprio_pending.remove(index);
+                    stats::on_fuse_requests_aborted(1);
+                    continue;
+                }
+            }
+
+            if self
+                .hiprio_pending
+                .get(index)
+                .is_some_and(|pending| self.hiprio_pending_submit_ready(pending))
+            {
+                return self
+                    .hiprio_pending
+                    .remove(index)
+                    .map(Some)
+                    .ok_or(SystemError::EINVAL);
+            }
+
+            index += 1;
+        }
+
+        Ok(None)
+    }
+
+    fn pop_pending_for_submit(
+        &mut self,
+        kind: QueueKind,
+    ) -> Result<Option<PendingReq>, SystemError> {
+        if matches!(kind, QueueKind::Hiprio) {
+            return self.pop_ready_hiprio_pending();
+        }
+        if !self.queue_can_retry(kind)? {
+            return Ok(None);
+        }
+        self.pop_pending_front(kind)
     }
 
     fn queue_index(&self, kind: QueueKind) -> Result<u16, SystemError> {
@@ -317,8 +400,33 @@ impl VirtioFsBridgeContext {
         Ok(pumped)
     }
 
+    fn pump_high_priority_requests(&mut self) -> Result<usize, SystemError> {
+        let mut pumped = 0usize;
+        for _ in 0..VIRTIOFS_PUMP_BUDGET {
+            let len = match self.conn.read_high_priority_request(&mut self.req_buf) {
+                Ok(len) => len,
+                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => break,
+                Err(e) => return Err(e),
+            };
+            let req = self.req_buf[..len].to_vec();
+            stats::on_virtiofs_request_cloned(req.len());
+            let in_hdr: FuseInHeader = fuse_read_struct(&req)?;
+            debug_assert!(matches!(in_hdr.opcode, FUSE_FORGET | FUSE_INTERRUPT));
+            self.push_pending_back(PendingReq {
+                req,
+                unique: in_hdr.unique,
+                opcode: in_hdr.opcode,
+                noreply: in_hdr.opcode == FUSE_FORGET,
+                queue: QueueKind::Hiprio,
+            })?;
+            pumped += 1;
+        }
+        stats::on_virtiofs_pump_batch(pumped);
+        Ok(pumped)
+    }
+
     fn submit_one_pending(&mut self, kind: QueueKind) -> Result<bool, SystemError> {
-        let pending = match self.pop_pending_front(kind)? {
+        let pending = match self.pop_pending_for_submit(kind)? {
             Some(p) => p,
             None => return Ok(false),
         };
@@ -615,7 +723,7 @@ impl VirtioFsBridgeContext {
         }
 
         let teardown_event = events & stats::VirtioFsBridgeWakeSource::Teardown.bit() != 0;
-        if teardown_event || !conn.is_mounted() {
+        if teardown_event {
             return Some(stats::VirtioFsBridgeWaitExit::Teardown);
         }
 
@@ -626,6 +734,9 @@ impl VirtioFsBridgeContext {
 
         let request_event = events & stats::VirtioFsBridgeWakeSource::Request.bit() != 0;
         if !self.has_queue_full_blocked() && (request_event || conn.has_pending_requests()) {
+            return Some(stats::VirtioFsBridgeWaitExit::RequestPending);
+        }
+        if self.can_pump_high_priority() && conn.has_pending_high_priority_requests() {
             return Some(stats::VirtioFsBridgeWaitExit::RequestPending);
         }
 
@@ -727,15 +838,20 @@ impl VirtioFsBridgeContext {
         loop {
             let mut progressed = false;
 
-            if !self.has_queue_full_blocked() {
-                match self.pump_new_requests() {
-                    Ok(v) => progressed |= v != 0,
-                    Err(SystemError::ENOTCONN) => {}
-                    Err(e) => {
-                        warn!("virtiofs bridge: read_request failed: {:?}", e);
-                        if !self.conn.is_connected() {
-                            break;
-                        }
+            let pump_result = if !self.has_queue_full_blocked() {
+                self.pump_new_requests()
+            } else if self.can_pump_high_priority() {
+                self.pump_high_priority_requests()
+            } else {
+                Ok(0)
+            };
+            match pump_result {
+                Ok(v) => progressed |= v != 0,
+                Err(SystemError::ENOTCONN) => {}
+                Err(e) => {
+                    warn!("virtiofs bridge: read_request failed: {:?}", e);
+                    if !self.conn.is_connected() {
+                        break;
                     }
                 }
             }

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -953,7 +953,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
     }
     transport.set_guest_page_size(PAGE_SIZE as u32);
 
-    let hiprio_vq = match VirtQueue::<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>::new(
+    let mut hiprio_vq = match VirtQueue::<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>::new(
         &mut transport,
         instance.hiprio_queue_index(),
         false,
@@ -967,13 +967,14 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
             return Err(se);
         }
     };
+    hiprio_vq.set_dev_notify(true);
 
     let mut request_vqs = Vec::with_capacity(instance.request_queue_count());
     for slot in 0..instance.request_queue_count() {
         let idx = instance
             .request_queue_index_by_slot(slot)
             .ok_or(SystemError::EINVAL)?;
-        let vq = match VirtQueue::<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>::new(
+        let mut vq = match VirtQueue::<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>::new(
             &mut transport,
             idx,
             false,
@@ -987,6 +988,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
                 return Err(se);
             }
         };
+        vq.set_dev_notify(true);
         request_vqs.push(vq);
     }
     transport.finish_init();

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -718,7 +718,7 @@ impl VirtioFsBridgeContext {
         conn: &FuseConn,
         events: u32,
     ) -> Option<stats::VirtioFsBridgeWaitExit> {
-        if !conn.is_connected() {
+        if !conn.is_connected() && !self.has_inflight() {
             return Some(stats::VirtioFsBridgeWaitExit::Disconnect);
         }
 
@@ -741,7 +741,7 @@ impl VirtioFsBridgeContext {
         }
 
         let disconnect_event = events & stats::VirtioFsBridgeWakeSource::Disconnect.bit() != 0;
-        if disconnect_event {
+        if disconnect_event && !self.has_inflight() {
             return Some(stats::VirtioFsBridgeWaitExit::Disconnect);
         }
 
@@ -870,7 +870,7 @@ impl VirtioFsBridgeContext {
             }
             stats::on_virtiofs_loop_iteration(progressed);
 
-            if !self.conn.is_connected() {
+            if !self.conn.is_connected() && !self.has_inflight() {
                 break;
             }
 

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -120,6 +120,21 @@ impl VirtioFsBridgeContext {
         !self.hiprio_blocked.blocked
     }
 
+    fn has_unblocked_request_slot(&self) -> bool {
+        Self::has_unblocked_request_slot_in(&self.request_blocked, self.request_vqs.len())
+    }
+
+    fn has_unblocked_request_slot_in(
+        request_blocked: &[QueueBlockState],
+        request_queue_count: usize,
+    ) -> bool {
+        (0..request_queue_count).any(|slot| {
+            request_blocked
+                .get(slot)
+                .is_some_and(|state| !state.blocked)
+        })
+    }
+
     fn block_state_mut(&mut self, kind: QueueKind) -> Result<&mut QueueBlockState, SystemError> {
         match kind {
             QueueKind::Hiprio => Ok(&mut self.hiprio_blocked),
@@ -361,19 +376,49 @@ impl VirtioFsBridgeContext {
         Self::complete_request_with_negative_errno(&self.conn, unique, err.to_posix_errno());
     }
 
-    fn choose_request_slot(&mut self) -> Result<usize, SystemError> {
-        if self.request_vqs.is_empty() {
-            return Err(SystemError::ENODEV);
-        }
-        let slot = self.next_request_slot % self.request_vqs.len();
-        self.next_request_slot = (self.next_request_slot + 1) % self.request_vqs.len();
-        Ok(slot)
+    fn choose_unblocked_request_slot(&mut self) -> Result<usize, SystemError> {
+        Self::choose_unblocked_request_slot_in(
+            &mut self.next_request_slot,
+            &self.request_blocked,
+            self.request_vqs.len(),
+        )
     }
 
-    fn pump_new_requests(&mut self) -> Result<usize, SystemError> {
+    fn choose_unblocked_request_slot_in(
+        next_request_slot: &mut usize,
+        request_blocked: &[QueueBlockState],
+        request_queue_count: usize,
+    ) -> Result<usize, SystemError> {
+        if request_queue_count == 0 {
+            return Err(SystemError::ENODEV);
+        }
+
+        for offset in 0..request_queue_count {
+            let slot = (*next_request_slot + offset) % request_queue_count;
+            let state = request_blocked.get(slot).ok_or(SystemError::EINVAL)?;
+            if !state.blocked {
+                *next_request_slot = (slot + 1) % request_queue_count;
+                return Ok(slot);
+            }
+        }
+
+        Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+    }
+
+    fn pump_ordinary_requests(&mut self) -> Result<usize, SystemError> {
         let mut pumped = 0usize;
         for _ in 0..VIRTIOFS_PUMP_BUDGET {
-            let len = match self.conn.read_request(true, &mut self.req_buf) {
+            if !self.conn.has_pending_ordinary_requests() {
+                break;
+            }
+
+            let slot = match self.choose_unblocked_request_slot() {
+                Ok(slot) => slot,
+                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => break,
+                Err(e) => return Err(e),
+            };
+
+            let len = match self.conn.read_ordinary_request(true, &mut self.req_buf) {
                 Ok(len) => len,
                 Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => break,
                 Err(e) => return Err(e),
@@ -382,17 +427,13 @@ impl VirtioFsBridgeContext {
             stats::on_virtiofs_request_cloned(req.len());
             let in_hdr: FuseInHeader = fuse_read_struct(&req)?;
             let noreply = matches!(in_hdr.opcode, FUSE_FORGET | FUSE_DESTROY);
-            let queue = if matches!(in_hdr.opcode, FUSE_FORGET | FUSE_INTERRUPT) {
-                QueueKind::Hiprio
-            } else {
-                QueueKind::Request(self.choose_request_slot()?)
-            };
+            debug_assert!(!matches!(in_hdr.opcode, FUSE_FORGET | FUSE_INTERRUPT));
             self.push_pending_back(PendingReq {
                 req,
                 unique: in_hdr.unique,
                 opcode: in_hdr.opcode,
                 noreply,
-                queue,
+                queue: QueueKind::Request(slot),
             })?;
             pumped += 1;
         }
@@ -422,6 +463,17 @@ impl VirtioFsBridgeContext {
             pumped += 1;
         }
         stats::on_virtiofs_pump_batch(pumped);
+        Ok(pumped)
+    }
+
+    fn pump_available_requests(&mut self) -> Result<usize, SystemError> {
+        let mut pumped = 0usize;
+        if self.can_pump_high_priority() && self.conn.has_pending_high_priority_requests() {
+            pumped += self.pump_high_priority_requests()?;
+        }
+        if self.has_unblocked_request_slot() && self.conn.has_pending_ordinary_requests() {
+            pumped += self.pump_ordinary_requests()?;
+        }
         Ok(pumped)
     }
 
@@ -732,11 +784,10 @@ impl VirtioFsBridgeContext {
             return Some(stats::VirtioFsBridgeWaitExit::Completion);
         }
 
-        let request_event = events & stats::VirtioFsBridgeWakeSource::Request.bit() != 0;
-        if !self.has_queue_full_blocked() && (request_event || conn.has_pending_requests()) {
+        if self.can_pump_high_priority() && conn.has_pending_high_priority_requests() {
             return Some(stats::VirtioFsBridgeWaitExit::RequestPending);
         }
-        if self.can_pump_high_priority() && conn.has_pending_high_priority_requests() {
+        if self.has_unblocked_request_slot() && conn.has_pending_ordinary_requests() {
             return Some(stats::VirtioFsBridgeWaitExit::RequestPending);
         }
 
@@ -838,13 +889,7 @@ impl VirtioFsBridgeContext {
         loop {
             let mut progressed = false;
 
-            let pump_result = if !self.has_queue_full_blocked() {
-                self.pump_new_requests()
-            } else if self.can_pump_high_priority() {
-                self.pump_high_priority_requests()
-            } else {
-                Ok(0)
-            };
+            let pump_result = self.pump_available_requests();
             match pump_result {
                 Ok(v) => progressed |= v != 0,
                 Err(SystemError::ENOTCONN) => {}
@@ -1282,3 +1327,100 @@ impl MountableFileSystem for VirtioFsFs {
 }
 
 register_mountable_fs!(VirtioFsFs, VIRTIOFSMAKER, "virtiofs");
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use system_error::SystemError;
+
+    use super::{QueueBlockState, VirtioFsBridgeContext};
+
+    fn block_state(blocked: bool, completion_seen: bool) -> QueueBlockState {
+        QueueBlockState {
+            blocked,
+            completion_seen,
+        }
+    }
+
+    #[test]
+    fn choose_unblocked_request_slot_skips_blocked_slots() {
+        let states = vec![
+            block_state(true, false),
+            block_state(false, false),
+            block_state(false, false),
+        ];
+        let mut next = 0usize;
+
+        assert!(VirtioFsBridgeContext::has_unblocked_request_slot_in(
+            &states,
+            states.len()
+        ));
+        assert_eq!(
+            VirtioFsBridgeContext::choose_unblocked_request_slot_in(
+                &mut next,
+                &states,
+                states.len()
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(next, 2);
+        assert_eq!(
+            VirtioFsBridgeContext::choose_unblocked_request_slot_in(
+                &mut next,
+                &states,
+                states.len()
+            )
+            .unwrap(),
+            2
+        );
+        assert_eq!(next, 0);
+        assert_eq!(
+            VirtioFsBridgeContext::choose_unblocked_request_slot_in(
+                &mut next,
+                &states,
+                states.len()
+            )
+            .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn completion_seen_does_not_accept_new_ordinary_requests() {
+        let states = vec![block_state(true, true), block_state(false, false)];
+        let mut next = 0usize;
+
+        assert_eq!(
+            VirtioFsBridgeContext::choose_unblocked_request_slot_in(
+                &mut next,
+                &states,
+                states.len()
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(next, 0);
+    }
+
+    #[test]
+    fn all_blocked_request_slots_are_not_pumpable() {
+        let states = vec![block_state(true, false), block_state(true, true)];
+        let mut next = 0usize;
+
+        assert!(!VirtioFsBridgeContext::has_unblocked_request_slot_in(
+            &states,
+            states.len()
+        ));
+        assert!(matches!(
+            VirtioFsBridgeContext::choose_unblocked_request_slot_in(
+                &mut next,
+                &states,
+                states.len()
+            ),
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        ));
+        assert_eq!(next, 0);
+    }
+}

--- a/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
+++ b/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
@@ -142,6 +142,23 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "response_buffer_alloc_bytes ");
     expect_field(whole, "bytes_submitted_total ");
     expect_field(whole, "bytes_completed_total ");
+    expect_field(whole, "bridge_waits_total ");
+    expect_field(whole, "bridge_wait_exit_request_pending_total ");
+    expect_field(whole, "bridge_wait_exit_completion_total ");
+    expect_field(whole, "bridge_wait_exit_teardown_total ");
+    expect_field(whole, "bridge_wait_exit_disconnect_total ");
+    expect_field(whole, "bridge_wait_exit_spurious_total ");
+    expect_field(whole, "bridge_wake_request_total ");
+    expect_field(whole, "bridge_wake_completion_total ");
+    expect_field(whole, "bridge_wake_teardown_total ");
+    expect_field(whole, "bridge_wake_disconnect_total ");
+    expect_field(whole, "bridge_irq_no_active_conn_total ");
+    expect_field(whole, "bridge_irq_stale_session_total ");
+    expect_field(whole, "bridge_irq_weak_upgrade_failed_total ");
+    expect_field(whole, "bridge_queue_full_blocked_total ");
+    expect_field(whole, "bridge_queue_full_retry_total ");
+    expect_field(whole, "bridge_queue_full_retry_after_completion_total ");
+    expect_field(whole, "bridge_queue_full_retry_success_total ");
 
     expect_counter_increased(whole, after_fuse, "requests_queued_total");
     expect_counter_increased(whole, after_fuse, "requests_dequeued_total");


### PR DESCRIPTION
## Summary

Replace the normal PCI virtiofs bridge polling path with event-driven wakeups.

- wake the bridge when FUSE requests become pending
- wake the bridge from virtqueue completion IRQ callbacks
- keep virtqueue and transport mutation owned by the bridge thread
- ACK PCI interrupts through a lightweight IRQ-safe helper
- wait for completion capacity on queue-full instead of blindly sleeping
- add debugfs stats and tracepoints for wait exits, wake sources, queue-full retry, and IRQ wake edge cases
- extend fuse_stats_debugfs coverage for the new counters

## Validation

- make fmt && make kernel
- make user && SKIP_GRUB=1 make write_diskimage
- DragonOS guest: ./fuse_stats_debugfs_test
- DragonOS guest: virtiofs_bench --workload metadata --files 2
- DragonOS guest: virtiofs_bench --workload sequential --file-size 65536
- DragonOS guest: virtiofs_bench --workload concurrent --workers 8 --file-size 65536
- DragonOS guest: ./virtiofs_smoke_test

The guest validation kept bridge_idle_sleeps_total and bridge_poll_sleep_ns_total at 0 on the normal virtiofs path. The concurrent benchmark also triggered queue-full retry counters and confirmed retries after completion capacity became available.

Closes #2013