### PR TITLE
fix(overlayfs): make copy-up publish atomically

### DIFF
--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -17,6 +17,26 @@ use system_error::SystemError;
 
 const COPY_UP_CHUNK_SIZE: usize = 64 * 1024;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CopyUpOutcome {
+    Published,
+    PublishedAfterTruncate,
+    Existing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OpenCopyUpOutcome {
+    NoTruncateRequested,
+    TruncateCompletedBeforePublish,
+    NeedsPostOpenTruncate,
+}
+
+impl OpenCopyUpOutcome {
+    pub(super) fn needs_post_open_truncate(self) -> bool {
+        self == Self::NeedsPostOpenTruncate
+    }
+}
+
 impl OvlInode {
     pub(super) fn writable_upper_inode_locked(&self) -> Result<Arc<dyn IndexNode>, SystemError> {
         if let Some(inode) = self.upper_inode.lock().clone() {
@@ -27,7 +47,10 @@ impl OvlInode {
         self.upper_inode.lock().clone().ok_or(SystemError::EROFS)
     }
 
-    pub(super) fn copy_up_for_open(&self, flags: &FileFlags) -> Result<(), SystemError> {
+    pub(super) fn copy_up_for_open(
+        &self,
+        flags: &FileFlags,
+    ) -> Result<OpenCopyUpOutcome, SystemError> {
         let copy_size = if flags.contains(FileFlags::O_TRUNC) {
             Some(0)
         } else {
@@ -36,17 +59,27 @@ impl OvlInode {
 
         let fs = self.overlay_fs()?;
         let _mutation_guard = fs.mutation_lock.lock();
-        self.copy_up_locked_with_size(copy_size)
+        let outcome = self.copy_up_locked_with_size(copy_size)?;
+        if copy_size.is_none() {
+            Ok(OpenCopyUpOutcome::NoTruncateRequested)
+        } else if outcome == CopyUpOutcome::PublishedAfterTruncate {
+            Ok(OpenCopyUpOutcome::TruncateCompletedBeforePublish)
+        } else {
+            Ok(OpenCopyUpOutcome::NeedsPostOpenTruncate)
+        }
     }
 
     pub(super) fn copy_up_locked(&self) -> Result<(), SystemError> {
-        self.copy_up_locked_with_size(None)
+        self.copy_up_locked_with_size(None).map(|_| ())
     }
 
-    fn copy_up_locked_with_size(&self, copy_size: Option<usize>) -> Result<(), SystemError> {
+    fn copy_up_locked_with_size(
+        &self,
+        copy_size: Option<usize>,
+    ) -> Result<CopyUpOutcome, SystemError> {
         let mut upper_inode = self.upper_inode.lock();
         if upper_inode.is_some() {
-            return Ok(());
+            return Ok(CopyUpOutcome::Existing);
         }
 
         let lower_inode = self.lower_inodes.first().ok_or(SystemError::ENOENT)?;
@@ -55,7 +88,7 @@ impl OvlInode {
         Self::adjust_metadata_for_truncate_copy_up(&mut metadata, copy_size);
         if self.redirect.is_empty() {
             *upper_inode = Some(self.upper_root_inode()?);
-            return Ok(());
+            return Ok(CopyUpOutcome::Existing);
         }
 
         let (parent_path, name) = self.upper_parent_path_and_name();
@@ -63,7 +96,7 @@ impl OvlInode {
         match parent_inode.find(name) {
             Ok(existing) => {
                 *upper_inode = Some(Self::validate_existing_upper(existing, &metadata)?);
-                return Ok(());
+                return Ok(CopyUpOutcome::Existing);
             }
             Err(SystemError::ENOENT) => {}
             Err(err) => return Err(err),
@@ -89,16 +122,35 @@ impl OvlInode {
             return Err(err);
         }
 
+        let publish_outcome = if copy_size == Some(0) && metadata.file_type == FileType::File {
+            let truncate_result = (|| {
+                // Truncate privilege-bit rules must use the lower inode's semantic owner/group.
+                let mut temp_metadata = temp_inode.metadata()?;
+                temp_metadata.uid = metadata.uid;
+                temp_metadata.gid = metadata.gid;
+                temp_metadata.mode = metadata.mode;
+                temp_inode.set_metadata(&temp_metadata)?;
+                vfs::vcore::vfs_truncate(temp_inode.clone(), 0)
+            })();
+            if let Err(err) = truncate_result {
+                Self::cleanup_workdir_temp(&workdir, &temp_name);
+                return Err(err);
+            }
+            CopyUpOutcome::PublishedAfterTruncate
+        } else {
+            CopyUpOutcome::Published
+        };
+
         match workdir.move_to(&temp_name, &parent_inode, name, RenameFlags::NOREPLACE) {
             Ok(()) => {
                 *upper_inode = Some(Self::validate_existing_upper(temp_inode, &metadata)?);
-                return Ok(());
+                return Ok(publish_outcome);
             }
             Err(SystemError::EEXIST) => {
                 Self::cleanup_workdir_temp(&workdir, &temp_name);
                 let existing = parent_inode.find(name)?;
                 *upper_inode = Some(Self::validate_existing_upper(existing, &metadata)?);
-                return Ok(());
+                return Ok(CopyUpOutcome::Existing);
             }
             Err(err) => {
                 Self::cleanup_workdir_temp(&workdir, &temp_name);

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -1,28 +1,44 @@
 use super::inode::OvlInode;
 use crate::filesystem::vfs::{
     self,
-    file::{File, FileFlags},
+    file::{File, FileFlags, FilePrivateData},
+    syscall::RenameFlags,
     FileType, IndexNode, Metadata,
 };
+use crate::libs::mutex::Mutex;
 use alloc::string::String;
 use alloc::sync::Arc;
 use system_error::SystemError;
 
 const COPY_UP_CHUNK_SIZE: usize = 64 * 1024;
-type UpperCleanup = Option<(Arc<dyn IndexNode>, String)>;
-type CreatedUpper = (Arc<dyn IndexNode>, UpperCleanup);
 
 impl OvlInode {
-    pub(super) fn writable_upper_inode(&self) -> Result<Arc<dyn IndexNode>, SystemError> {
+    pub(super) fn writable_upper_inode_locked(&self) -> Result<Arc<dyn IndexNode>, SystemError> {
         if let Some(inode) = self.upper_inode.lock().clone() {
             return Ok(inode);
         }
 
-        self.copy_up()?;
+        self.copy_up_locked()?;
         self.upper_inode.lock().clone().ok_or(SystemError::EROFS)
     }
 
-    pub(super) fn copy_up(&self) -> Result<(), SystemError> {
+    pub(super) fn copy_up_for_open(&self, flags: &FileFlags) -> Result<(), SystemError> {
+        let copy_size = if flags.contains(FileFlags::O_TRUNC) {
+            Some(0)
+        } else {
+            None
+        };
+
+        let fs = self.overlay_fs()?;
+        let _mutation_guard = fs.mutation_lock.lock();
+        self.copy_up_locked_with_size(copy_size)
+    }
+
+    pub(super) fn copy_up_locked(&self) -> Result<(), SystemError> {
+        self.copy_up_locked_with_size(None)
+    }
+
+    fn copy_up_locked_with_size(&self, copy_size: Option<usize>) -> Result<(), SystemError> {
         let mut upper_inode = self.upper_inode.lock();
         if upper_inode.is_some() {
             return Ok(());
@@ -31,72 +47,65 @@ impl OvlInode {
         let lower_inode = self.lower_inodes.first().ok_or(SystemError::ENOENT)?;
 
         let metadata = lower_inode.metadata()?;
-        let (new_upper_inode, cleanup) = self.create_upper_inode(metadata.clone())?;
+        if self.redirect.is_empty() {
+            *upper_inode = Some(self.upper_root_inode()?);
+            return Ok(());
+        }
 
-        let copy_result = (|| -> Result<(), SystemError> {
-            if metadata.file_type == FileType::File {
-                let size = metadata.size.max(0) as usize;
-                let lower_file = File::new(lower_inode.clone(), FileFlags::O_RDONLY)?;
-                let upper_file = File::new(new_upper_inode.clone(), FileFlags::O_WRONLY)?;
-                let mut buffer = vec![0u8; COPY_UP_CHUNK_SIZE.min(size.max(1))];
-                let mut offset = 0usize;
-
-                while offset < size {
-                    let chunk_len = (size - offset).min(buffer.len());
-                    let read_len = lower_file.pread(offset, chunk_len, &mut buffer[..chunk_len])?;
-                    if read_len == 0 {
-                        return Err(SystemError::EIO);
-                    }
-
-                    let mut written = 0usize;
-                    while written < read_len {
-                        let n = upper_file.pwrite(
-                            offset + written,
-                            read_len - written,
-                            &buffer[written..read_len],
-                        )?;
-                        if n == 0 {
-                            return Err(SystemError::EIO);
-                        }
-                        written += n;
-                    }
-                    offset += read_len;
-                }
+        let (parent_path, name) = self.upper_parent_path_and_name();
+        let parent_inode = self.ensure_upper_dir_path(parent_path)?;
+        match parent_inode.find(name) {
+            Ok(existing) => {
+                *upper_inode = Some(Self::validate_existing_upper(existing, &metadata)?);
+                return Ok(());
             }
+            Err(SystemError::ENOENT) => {}
+            Err(err) => return Err(err),
+        }
 
-            Ok(())
-        })();
+        let symlink_target = if metadata.file_type == FileType::SymLink {
+            Some(Self::read_symlink_target(lower_inode.clone(), &metadata)?)
+        } else {
+            None
+        };
 
-        if let Err(err) = copy_result {
-            if let Some((parent, name)) = cleanup {
-                let _ = parent.unlink(&name);
-            }
+        let (workdir, temp_inode, temp_name) = self.create_workdir_temp(|workdir, temp_name| {
+            Self::create_copy_up_temp(workdir, temp_name, &metadata, symlink_target.as_deref())
+        })?;
+
+        if let Err(err) = Self::copy_data_if_needed(
+            lower_inode.clone(),
+            temp_inode.clone(),
+            &metadata,
+            copy_size,
+        ) {
+            Self::cleanup_workdir_temp(&workdir, &temp_name);
             return Err(err);
         }
 
-        *upper_inode = Some(new_upper_inode);
-
-        Ok(())
+        match workdir.move_to(&temp_name, &parent_inode, name, RenameFlags::NOREPLACE) {
+            Ok(()) => {
+                *upper_inode = Some(Self::validate_existing_upper(temp_inode, &metadata)?);
+                return Ok(());
+            }
+            Err(SystemError::EEXIST) => {
+                Self::cleanup_workdir_temp(&workdir, &temp_name);
+                let existing = parent_inode.find(name)?;
+                *upper_inode = Some(Self::validate_existing_upper(existing, &metadata)?);
+                return Ok(());
+            }
+            Err(err) => {
+                Self::cleanup_workdir_temp(&workdir, &temp_name);
+                return Err(err);
+            }
+        }
     }
 
-    fn create_upper_inode(&self, metadata: Metadata) -> Result<CreatedUpper, SystemError> {
-        let upper_root_inode = self.upper_root_inode()?;
-        if self.redirect.is_empty() {
-            return Ok((upper_root_inode, None));
-        }
-
-        let (parent_path, name) = match self.redirect.rsplit_once('/') {
+    fn upper_parent_path_and_name(&self) -> (&str, &str) {
+        match self.redirect.rsplit_once('/') {
             Some((parent_path, name)) => (parent_path, name),
             None => ("", self.redirect.as_str()),
-        };
-
-        let parent_inode = self.ensure_upper_dir_path(parent_path)?;
-        if let Ok(existing) = parent_inode.find(name) {
-            return Ok((existing, None));
         }
-
-        let inode = parent_inode.create_with_data(name, metadata.file_type, metadata.mode, 0)?;
-        Ok((inode, Some((parent_inode, name.into()))))
     }
 
     fn ensure_upper_dir_path(&self, path: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
@@ -136,5 +145,117 @@ impl OvlInode {
         }
 
         Ok(vfs::InodeMode::S_IRWXUGO)
+    }
+
+    fn validate_existing_upper(
+        inode: Arc<dyn IndexNode>,
+        lower_metadata: &Metadata,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        if Self::is_whiteout_inode(&inode) {
+            return Err(SystemError::ENOENT);
+        }
+
+        let upper_metadata = inode.metadata()?;
+        if upper_metadata.file_type != lower_metadata.file_type {
+            return Err(SystemError::EIO);
+        }
+
+        if matches!(
+            upper_metadata.file_type,
+            FileType::CharDevice | FileType::BlockDevice
+        ) && upper_metadata.raw_dev != lower_metadata.raw_dev
+        {
+            return Err(SystemError::EIO);
+        }
+
+        Ok(inode)
+    }
+
+    fn create_copy_up_temp(
+        workdir: &Arc<dyn IndexNode>,
+        temp_name: &str,
+        metadata: &Metadata,
+        symlink_target: Option<&str>,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        match metadata.file_type {
+            FileType::SymLink => {
+                workdir.symlink(temp_name, symlink_target.ok_or(SystemError::EIO)?)
+            }
+            FileType::CharDevice | FileType::BlockDevice | FileType::Pipe | FileType::Socket => {
+                let mode = (metadata.mode & !vfs::InodeMode::S_IFMT)
+                    | vfs::InodeMode::from(metadata.file_type);
+                workdir.mknod(temp_name, mode, metadata.raw_dev)
+            }
+            _ => workdir.create_with_data(temp_name, metadata.file_type, metadata.mode, 0),
+        }
+    }
+
+    fn copy_data_if_needed(
+        lower_inode: Arc<dyn IndexNode>,
+        upper_inode: Arc<dyn IndexNode>,
+        metadata: &Metadata,
+        copy_size: Option<usize>,
+    ) -> Result<(), SystemError> {
+        if metadata.file_type != FileType::File {
+            return Ok(());
+        }
+
+        let size = copy_size.unwrap_or_else(|| metadata.size.max(0) as usize);
+        if size == 0 {
+            return Ok(());
+        }
+
+        let lower_file = File::new(lower_inode, FileFlags::O_RDONLY)?;
+        let upper_file = File::new(upper_inode, FileFlags::O_WRONLY)?;
+        let mut buffer = vec![0u8; COPY_UP_CHUNK_SIZE.min(size)];
+        let mut offset = 0usize;
+
+        while offset < size {
+            let chunk_len = (size - offset).min(buffer.len());
+            let read_len = lower_file.pread(offset, chunk_len, &mut buffer[..chunk_len])?;
+            if read_len == 0 {
+                return Err(SystemError::EIO);
+            }
+
+            let mut written = 0usize;
+            while written < read_len {
+                let n = upper_file.pwrite(
+                    offset + written,
+                    read_len - written,
+                    &buffer[written..read_len],
+                )?;
+                if n == 0 {
+                    return Err(SystemError::EIO);
+                }
+                written += n;
+            }
+            offset += read_len;
+        }
+
+        Ok(())
+    }
+
+    fn read_symlink_target(
+        lower_inode: Arc<dyn IndexNode>,
+        metadata: &Metadata,
+    ) -> Result<String, SystemError> {
+        let size = metadata.size.max(0) as usize;
+        let mut buffer = vec![0u8; size];
+        let mut offset = 0usize;
+
+        while offset < size {
+            let read_len = lower_inode.read_at(
+                offset,
+                size - offset,
+                &mut buffer[offset..],
+                Mutex::new(FilePrivateData::Unused).lock(),
+            )?;
+            if read_len == 0 {
+                return Err(SystemError::EIO);
+            }
+            offset += read_len;
+        }
+
+        String::from_utf8(buffer).map_err(|_| SystemError::EINVAL)
     }
 }

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -3,9 +3,14 @@ use crate::filesystem::vfs::{
     self,
     file::{File, FileFlags, FilePrivateData},
     syscall::RenameFlags,
+    utils::should_remove_sgid,
     FileType, IndexNode, Metadata,
 };
 use crate::libs::mutex::Mutex;
+use crate::process::{
+    cred::{CAPFlags, Cred},
+    ProcessManager,
+};
 use alloc::string::String;
 use alloc::sync::Arc;
 use system_error::SystemError;
@@ -46,7 +51,8 @@ impl OvlInode {
 
         let lower_inode = self.lower_inodes.first().ok_or(SystemError::ENOENT)?;
 
-        let metadata = lower_inode.metadata()?;
+        let mut metadata = lower_inode.metadata()?;
+        Self::adjust_metadata_for_truncate_copy_up(&mut metadata, copy_size);
         if self.redirect.is_empty() {
             *upper_inode = Some(self.upper_root_inode()?);
             return Ok(());
@@ -169,6 +175,33 @@ impl OvlInode {
         }
 
         Ok(inode)
+    }
+
+    fn adjust_metadata_for_truncate_copy_up(metadata: &mut Metadata, copy_size: Option<usize>) {
+        if copy_size != Some(0) || metadata.file_type != FileType::File || metadata.size == 0 {
+            return;
+        }
+
+        Self::clear_suid_sgid_for_current_cred(metadata, &ProcessManager::current_pcb().cred());
+    }
+
+    fn clear_suid_sgid_for_current_cred(metadata: &mut Metadata, cred: &Arc<Cred>) {
+        if cred.has_capability(CAPFlags::CAP_FSETID) {
+            return;
+        }
+
+        if !metadata
+            .mode
+            .intersects(vfs::InodeMode::S_ISUID | vfs::InodeMode::S_ISGID)
+        {
+            return;
+        }
+
+        metadata.mode.remove(vfs::InodeMode::S_ISUID);
+
+        if should_remove_sgid(metadata.mode, metadata.gid, cred) {
+            metadata.mode.remove(vfs::InodeMode::S_ISGID);
+        }
     }
 
     fn create_copy_up_temp(

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -178,7 +178,7 @@ impl OvlInode {
     }
 
     fn adjust_metadata_for_truncate_copy_up(metadata: &mut Metadata, copy_size: Option<usize>) {
-        if copy_size != Some(0) || metadata.file_type != FileType::File || metadata.size == 0 {
+        if copy_size != Some(0) || metadata.file_type != FileType::File {
             return;
         }
 

--- a/kernel/src/filesystem/overlayfs/dir.rs
+++ b/kernel/src/filesystem/overlayfs/dir.rs
@@ -39,7 +39,7 @@ pub(super) fn rmdir(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
             if !is_dir_empty(&found)? {
                 return Err(SystemError::ENOTEMPTY);
             }
-            return inode.create_whiteout(name);
+            return inode.create_whiteout_locked(name);
         }
         Err(SystemError::ENOENT) => {}
         Err(err) => return Err(err),
@@ -64,7 +64,7 @@ pub(super) fn unlink(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
             if found.metadata()?.file_type == FileType::Dir {
                 return Err(SystemError::EISDIR);
             }
-            return inode.create_whiteout(name);
+            return inode.create_whiteout_locked(name);
         }
         Err(SystemError::ENOENT) => {}
         Err(err) => return Err(err),
@@ -141,7 +141,7 @@ fn create_over_whiteout<F>(
 where
     F: Fn(&Arc<dyn IndexNode>, &str) -> Result<Arc<dyn IndexNode>, SystemError>,
 {
-    let upper_inode = inode.writable_upper_inode()?;
+    let upper_inode = inode.writable_upper_inode_locked()?;
     match upper_inode.find(name) {
         Ok(found) if OvlInode::is_whiteout_inode(&found) => {}
         Ok(_) => return Err(SystemError::EEXIST),

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -180,7 +180,7 @@ fn open_backing_file(
     flags: FileFlags,
 ) -> Result<OverlayFilePrivateData, SystemError> {
     if open_flags_need_copy_up(&flags) {
-        inode.copy_up()?;
+        inode.copy_up_for_open(&flags)?;
     }
 
     let (backing_inode, backing_is_upper) = inode.current_realdata_inode()?;

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -163,7 +163,19 @@ pub(super) fn mmap_file(
         .mmap_file(&backing_file, start, len, offset, vm_flags)
 }
 
-fn open_flags_need_copy_up(flags: &FileFlags) -> bool {
+fn open_flags_need_copy_up(file_type: FileType, flags: &FileFlags) -> bool {
+    if matches!(
+        file_type,
+        FileType::Pipe
+            | FileType::Socket
+            | FileType::CharDevice
+            | FileType::BlockDevice
+            | FileType::KvmDevice
+            | FileType::FramebufferDevice
+    ) {
+        return false;
+    }
+
     let access = flags.access_flags();
     access == FileFlags::O_WRONLY
         || access == FileFlags::O_RDWR
@@ -179,13 +191,12 @@ fn open_backing_file(
     inode: &OvlInode,
     flags: FileFlags,
 ) -> Result<OverlayFilePrivateData, SystemError> {
-    if open_flags_need_copy_up(&flags) {
-        inode.copy_up_for_open(&flags)?;
-    }
+    let needs_post_open_truncate = open_flags_need_copy_up(inode.file_type, &flags)
+        && inode.copy_up_for_open(&flags)?.needs_post_open_truncate();
 
     let (backing_inode, backing_is_upper) = inode.current_realdata_inode()?;
     let backing_file = Arc::new(File::new(backing_inode, backing_open_flags(flags))?);
-    if flags.contains(FileFlags::O_TRUNC) && backing_is_upper {
+    if inode.file_type == FileType::File && backing_is_upper && needs_post_open_truncate {
         vcore::vfs_truncate_file(
             backing_file.inode(),
             0,

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -127,13 +127,6 @@ impl OverlayFS {
             || Self::is_mount_ancestor(left, right)?
             || Self::is_mount_ancestor(right, left)?)
     }
-
-    fn layer_is_same_or_descendant_of(
-        layer: &Arc<dyn IndexNode>,
-        ancestor: &Arc<dyn IndexNode>,
-    ) -> Result<bool, SystemError> {
-        Ok(Self::same_mount_inode(layer, ancestor)? || Self::is_mount_ancestor(ancestor, layer)?)
-    }
 }
 
 impl MountableFileSystem for OverlayFS {
@@ -272,5 +265,14 @@ impl MountableFileSystem for OverlayFS {
             e
         })?;
         Ok(Some(Arc::new(mount_data)))
+    }
+}
+
+impl OverlayFS {
+    fn layer_is_same_or_descendant_of(
+        layer: &Arc<dyn IndexNode>,
+        ancestor: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        Ok(Self::same_mount_inode(layer, ancestor)? || Self::is_mount_ancestor(ancestor, layer)?)
     }
 }

--- a/kernel/src/filesystem/overlayfs/rename.rs
+++ b/kernel/src/filesystem/overlayfs/rename.rs
@@ -44,10 +44,10 @@ pub(super) fn move_to(
             return Err(SystemError::EXDEV);
         }
 
-        source.copy_up()?;
-        target_child.copy_up()?;
-        let old_upper_dir = inode.writable_upper_inode()?;
-        let new_upper_dir = target_ovl.writable_upper_inode()?;
+        source.copy_up_locked()?;
+        target_child.copy_up_locked()?;
+        let old_upper_dir = inode.writable_upper_inode_locked()?;
+        let new_upper_dir = target_ovl.writable_upper_inode_locked()?;
         return old_upper_dir.move_to(old_name, &new_upper_dir, new_name, flags);
     }
 
@@ -76,11 +76,11 @@ pub(super) fn move_to(
     }
 
     if !source.is_pure_upper() {
-        source.copy_up()?;
+        source.copy_up_locked()?;
     }
 
-    let old_upper_dir = inode.writable_upper_inode()?;
-    let new_upper_dir = target_ovl.writable_upper_inode()?;
+    let old_upper_dir = inode.writable_upper_inode_locked()?;
+    let new_upper_dir = target_ovl.writable_upper_inode_locked()?;
     let mut upper_flags = flags;
     if target_had_whiteout {
         upper_flags.remove(RenameFlags::NOREPLACE);

--- a/kernel/src/filesystem/overlayfs/whiteout.rs
+++ b/kernel/src/filesystem/overlayfs/whiteout.rs
@@ -16,14 +16,14 @@ impl OvlInode {
             .unwrap_or(false)
     }
 
-    pub(super) fn create_whiteout(&self, name: &str) -> Result<(), SystemError> {
+    pub(super) fn create_whiteout_locked(&self, name: &str) -> Result<(), SystemError> {
         let whiteout_mode = vfs::InodeMode::S_IFCHR;
         if let Some(ref upper_inode) = *self.upper_inode.lock() {
             upper_inode.mknod(name, whiteout_mode, WHITEOUT_DEV)?;
             return Ok(());
         }
 
-        self.copy_up()?;
+        self.copy_up_locked()?;
         let upper_inode = self.upper_inode.lock();
         if let Some(ref upper_inode) = *upper_inode {
             upper_inode.mknod(name, whiteout_mode, WHITEOUT_DEV)?;

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -724,7 +724,6 @@ where
     F: FnOnce(&Arc<dyn IndexNode>) -> Result<(), SystemError>,
 {
     let md = inode.metadata()?;
-    let old_size = md.size;
 
     // 防御性检查：统一拒绝超出 isize::MAX 的长度，避免后续类型转换溢出
     if len > isize::MAX as usize {
@@ -764,14 +763,14 @@ where
 
     let result = do_resize(&inode);
 
-    if result.is_ok() && old_size != len as i64 {
-        clear_suid_sgid_after_size_change(inode.as_ref())?;
+    if result.is_ok() {
+        clear_suid_sgid_after_truncate(inode.as_ref())?;
     }
 
     result
 }
 
-fn clear_suid_sgid_after_size_change(inode: &dyn IndexNode) -> Result<(), SystemError> {
+fn clear_suid_sgid_after_truncate(inode: &dyn IndexNode) -> Result<(), SystemError> {
     let cred = ProcessManager::current_pcb().cred();
     if cred.has_capability(CAPFlags::CAP_FSETID) {
         return Ok(());
@@ -863,7 +862,7 @@ pub fn resize_based_fallocate(
 
     let result = inode.resize_with_lock_owner(new_size, lock_owner);
     if result.is_ok() && md.size != new_size as i64 {
-        clear_suid_sgid_after_size_change(inode)?;
+        clear_suid_sgid_after_truncate(inode)?;
     }
 
     result

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -779,13 +779,16 @@ fn clear_suid_sgid_after_truncate(inode: &dyn IndexNode) -> Result<(), SystemErr
     let mut md = inode.metadata()?;
     if md.file_type == FileType::File && md.mode.intersects(InodeMode::S_ISUID | InodeMode::S_ISGID)
     {
+        let original_mode = md.mode;
         md.mode.remove(InodeMode::S_ISUID);
 
         if should_remove_sgid(md.mode, md.gid, &cred) {
             md.mode.remove(InodeMode::S_ISGID);
         }
 
-        inode.set_metadata(&md)?;
+        if md.mode != original_mode {
+            inode.set_metadata(&md)?;
+        }
     }
 
     Ok(())

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -984,6 +984,109 @@ TEST(OverlayFsSemantics, CopyUpTruncateEmptyFileDropsPrivilegedBitsWithoutCapFse
     expect_truncate_copy_up_drops_privileged_bits("overlayfs_copy_up_truncate_empty_mode", "");
 }
 
+TEST(OverlayFsSemantics, CopyUpTruncateKeepsMandatoryLockingSgidForMember) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root to prepare setgid lower file";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_copy_up_truncate_keep_sgid");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "mandatory-locking-sgid"));
+    ASSERT_EQ(0, chown(lower_file.c_str(), 1000, 1000)) << strerror(errno);
+    ASSERT_EQ(0, chmod(lower_file.c_str(), 02660)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(1000) != 0) {
+            _exit(2);
+        }
+        if (setuid(1000) != 0) {
+            _exit(3);
+        }
+
+        int fd = open(merged_file.c_str(), O_WRONLY | O_TRUNC | O_CLOEXEC);
+        if (fd < 0) {
+            _exit(4);
+        }
+        _exit(close(fd) == 0 ? 0 : 5);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_file.c_str(), &st)) << strerror(errno);
+    EXPECT_EQ(0, st.st_size);
+    EXPECT_EQ(1000u, st.st_gid);
+    EXPECT_NE(0u, static_cast<unsigned>(st.st_mode & S_ISGID));
+}
+
+TEST(OverlayFsSemantics, CopyUpTruncateExistingUpperStillTruncates) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_truncate_existing_upper");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "lower-data"));
+    ASSERT_EQ(0, write_text(upper_file, "existing-upper-data"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int fd = open(merged_file.c_str(), O_WRONLY | O_TRUNC | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_file.c_str(), &st)) << strerror(errno);
+    EXPECT_EQ(0, st.st_size);
+    EXPECT_EQ("", read_text(upper_file));
+    EXPECT_EQ("", read_text(merged_file));
+    EXPECT_EQ("lower-data", read_text(lower_file));
+}
+
+TEST(OverlayFsSemantics, OpenLowerFifoWithTruncateDoesNotCopyUp) {
+    ScopedOverlayEnv scoped("overlayfs_open_fifo_truncate");
+    const auto& env = scoped.env;
+    std::string lower_fifo = join_path(env.lower, "fifo");
+    std::string upper_fifo = join_path(env.upper, "fifo");
+    std::string merged_fifo = join_path(env.merged, "fifo");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, mkfifo(lower_fifo.c_str(), 0644)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int fd = open(merged_fifo.c_str(), O_RDONLY | O_TRUNC | O_NONBLOCK | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    EXPECT_FALSE(path_exists(upper_fifo));
+}
+
 TEST(OverlayFsSemantics, CopyUpLargeLowerFileConcurrentReadersNeverSeePartialUpper) {
     constexpr size_t kFileSize = 4 * 1024 * 1024;
     ScopedOverlayEnv scoped("overlayfs_copy_up_concurrent");

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -11,6 +11,8 @@
 #include <sys/sysmacros.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/wait.h>
+#include <algorithm>
 #include <string>
 #include <unistd.h>
 
@@ -86,6 +88,83 @@ std::string read_text(const std::string& path) {
     return std::string(buf, static_cast<size_t>(n));
 }
 
+int overlay_temp_entry_count(const std::string& dir_path) {
+    DIR* dir = opendir(dir_path.c_str());
+    if (dir == nullptr) {
+        return -1;
+    }
+
+    int count = 0;
+    while (dirent* ent = readdir(dir)) {
+        if (strncmp(ent->d_name, ".dragonos-ovl-", strlen(".dragonos-ovl-")) == 0) {
+            count++;
+        }
+    }
+    closedir(dir);
+    return count;
+}
+
+bool write_pattern_file(const std::string& path, size_t size) {
+    int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) {
+        return false;
+    }
+
+    char buf[4096] = {};
+    size_t offset = 0;
+    while (offset < size) {
+        size_t chunk = std::min(sizeof(buf), size - offset);
+        for (size_t i = 0; i < chunk; ++i) {
+            buf[i] = static_cast<char>((offset + i) & 0xff);
+        }
+
+        ssize_t written = write(fd, buf, chunk);
+        if (written != static_cast<ssize_t>(chunk)) {
+            int saved_errno = errno;
+            close(fd);
+            errno = saved_errno;
+            return false;
+        }
+        offset += chunk;
+    }
+
+    return close(fd) == 0;
+}
+
+bool validate_pattern_window(int fd, size_t offset, size_t len) {
+    char buf[4096] = {};
+    if (len > sizeof(buf)) {
+        return false;
+    }
+
+    ssize_t n = pread(fd, buf, len, static_cast<off_t>(offset));
+    if (n != static_cast<ssize_t>(len)) {
+        return false;
+    }
+
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] != static_cast<char>((offset + i) & 0xff)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool validate_pattern_file(const std::string& path, size_t size) {
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    bool ok = validate_pattern_window(fd, 0, 4096)
+        && validate_pattern_window(fd, size / 2, 4096)
+        && validate_pattern_window(fd, size - 4096, 4096);
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return ok;
+}
+
 long renameat2_call(const std::string& old_path, const std::string& new_path, unsigned flags) {
     return syscall(__NR_renameat2, AT_FDCWD, old_path.c_str(), AT_FDCWD, new_path.c_str(), flags);
 }
@@ -136,6 +215,16 @@ void cleanup_overlay_env(const OverlayRenameEnv& env) {
     umount(env.merged.c_str());
     remove_recursive(env.root);
 }
+
+struct ScopedOverlayEnv {
+    explicit ScopedOverlayEnv(const char* name) : env(make_overlay_env(name)) {}
+
+    ~ScopedOverlayEnv() {
+        cleanup_overlay_env(env);
+    }
+
+    OverlayRenameEnv env;
+};
 
 bool setup_overlay_env(const OverlayRenameEnv& env) {
     if (ensure_dir("/tmp") != 0 || ensure_dir(env.root.c_str()) != 0
@@ -741,6 +830,165 @@ TEST(OverlayFsSemantics, OpenOverlayDirectoryWithoutFsOpenHook) {
     rmdir(lower);
     rmdir(upper);
     rmdir(root);
+}
+
+TEST(OverlayFsSemantics, CopyUpLowerFilePublishesCompleteUpperFile) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_file");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "lower-copy-up-data"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int fd = open(merged_file.c_str(), O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    EXPECT_EQ("lower-copy-up-data", read_text(upper_file));
+    EXPECT_EQ("lower-copy-up-data", read_text(merged_file));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpNestedLowerFileUsesWorkdirTempAndKeepsLeafAtomic) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_nested");
+    const auto& env = scoped.env;
+    std::string lower_a = join_path(env.lower, "a");
+    std::string lower_b = join_path(lower_a, "b");
+    std::string lower_file = join_path(lower_b, "file");
+    std::string upper_a = join_path(env.upper, "a");
+    std::string upper_b = join_path(upper_a, "b");
+    std::string upper_file = join_path(upper_b, "file");
+    std::string merged_file = join_path(join_path(join_path(env.merged, "a"), "b"), "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, mkdir(lower_a.c_str(), 0755));
+    ASSERT_EQ(0, mkdir(lower_b.c_str(), 0755));
+    ASSERT_EQ(0, write_text(lower_file, "nested-copy-up-data"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int fd = open(merged_file.c_str(), O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_a.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISDIR(st.st_mode));
+    ASSERT_EQ(0, stat(upper_b.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISDIR(st.st_mode));
+    EXPECT_EQ("nested-copy-up-data", read_text(upper_file));
+    EXPECT_EQ("nested-copy-up-data", read_text(merged_file));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpTruncatePublishesEmptyUpperFile) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_truncate");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "must-not-be-published-before-truncate"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int fd = open(merged_file.c_str(), O_WRONLY | O_TRUNC | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_file.c_str(), &st)) << strerror(errno);
+    EXPECT_EQ(0, st.st_size);
+    ASSERT_EQ(0, stat(merged_file.c_str(), &st)) << strerror(errno);
+    EXPECT_EQ(0, st.st_size);
+    EXPECT_EQ("", read_text(upper_file));
+    EXPECT_EQ("", read_text(merged_file));
+    EXPECT_EQ("must-not-be-published-before-truncate", read_text(lower_file));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpLargeLowerFileConcurrentReadersNeverSeePartialUpper) {
+    constexpr size_t kFileSize = 4 * 1024 * 1024;
+    ScopedOverlayEnv scoped("overlayfs_copy_up_concurrent");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "large");
+    std::string upper_file = join_path(env.upper, "large");
+    std::string merged_file = join_path(env.merged, "large");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_TRUE(write_pattern_file(lower_file, kFileSize)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int start_pipe[2] = {};
+    int done_pipe[2] = {};
+    ASSERT_EQ(0, pipe(start_pipe)) << strerror(errno);
+    ASSERT_EQ(0, pipe(done_pipe)) << strerror(errno);
+
+    pid_t reader = fork();
+    ASSERT_GE(reader, 0) << strerror(errno);
+    if (reader == 0) {
+        alarm(10);
+        close(start_pipe[1]);
+        close(done_pipe[1]);
+        char token = 0;
+        if (read(start_pipe[0], &token, 1) != 1) {
+            _exit(3);
+        }
+        fcntl(done_pipe[0], F_SETFL, O_NONBLOCK);
+        for (;;) {
+            if (!validate_pattern_file(merged_file, kFileSize)) {
+                _exit(2);
+            }
+            char done = 0;
+            ssize_t n = read(done_pipe[0], &done, 1);
+            if (n == 0 || n == 1) {
+                break;
+            }
+            if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+                _exit(4);
+            }
+        }
+        _exit(0);
+    }
+
+    close(start_pipe[0]);
+    close(done_pipe[0]);
+    ASSERT_EQ(1, write(start_pipe[1], "x", 1)) << strerror(errno);
+    close(start_pipe[1]);
+    int fd = open(merged_file.c_str(), O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    close(done_pipe[1]);
+
+    int status = 0;
+    ASSERT_EQ(reader, waitpid(reader, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status)) << "reader status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    EXPECT_TRUE(validate_pattern_file(upper_file, kFileSize));
+    EXPECT_TRUE(validate_pattern_file(merged_file, kFileSize));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
 }
 
 TEST(RenameAt2Semantics, RejectsUnknownWhiteoutAndInvalidFlagCombinations) {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -924,6 +924,56 @@ TEST(OverlayFsSemantics, CopyUpTruncatePublishesEmptyUpperFile) {
     EXPECT_EQ(0, overlay_temp_entry_count(env.work));
 }
 
+TEST(OverlayFsSemantics, CopyUpTruncateDropsPrivilegedBitsWithoutCapFsetid) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root to prepare setuid/setgid lower file";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_copy_up_truncate_mode");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "truncate should clear privileged bits"));
+    ASSERT_EQ(0, chmod(lower_file.c_str(), 06777)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(1000) != 0) {
+            _exit(2);
+        }
+        if (setuid(1000) != 0) {
+            _exit(3);
+        }
+
+        int fd = open(merged_file.c_str(), O_WRONLY | O_TRUNC | O_CLOEXEC);
+        if (fd < 0) {
+            _exit(4);
+        }
+        _exit(close(fd) == 0 ? 0 : 5);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_file.c_str(), &st)) << strerror(errno);
+    EXPECT_EQ(0, st.st_size);
+    EXPECT_EQ(0u, static_cast<unsigned>(st.st_mode & (S_ISUID | S_ISGID)));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
 TEST(OverlayFsSemantics, CopyUpLargeLowerFileConcurrentReadersNeverSeePartialUpper) {
     constexpr size_t kFileSize = 4 * 1024 * 1024;
     ScopedOverlayEnv scoped("overlayfs_copy_up_concurrent");

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -242,6 +242,56 @@ bool setup_overlay_env(const OverlayRenameEnv& env) {
     return true;
 }
 
+void expect_truncate_copy_up_drops_privileged_bits(const char* name, const char* lower_text) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root to prepare setuid/setgid lower file";
+    }
+
+    ScopedOverlayEnv scoped(name);
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, lower_text));
+    ASSERT_EQ(0, chmod(lower_file.c_str(), 06777)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(1000) != 0) {
+            _exit(2);
+        }
+        if (setuid(1000) != 0) {
+            _exit(3);
+        }
+
+        int fd = open(merged_file.c_str(), O_WRONLY | O_TRUNC | O_CLOEXEC);
+        if (fd < 0) {
+            _exit(4);
+        }
+        _exit(close(fd) == 0 ? 0 : 5);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_file.c_str(), &st)) << strerror(errno);
+    EXPECT_EQ(0, st.st_size);
+    EXPECT_EQ(0u, static_cast<unsigned>(st.st_mode & (S_ISUID | S_ISGID)));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
 void remove_tree(const char* root) {
     char path[256] = {};
 
@@ -925,53 +975,13 @@ TEST(OverlayFsSemantics, CopyUpTruncatePublishesEmptyUpperFile) {
 }
 
 TEST(OverlayFsSemantics, CopyUpTruncateDropsPrivilegedBitsWithoutCapFsetid) {
-    if (geteuid() != 0) {
-        GTEST_SKIP() << "requires root to prepare setuid/setgid lower file";
-    }
+    expect_truncate_copy_up_drops_privileged_bits(
+        "overlayfs_copy_up_truncate_mode",
+        "truncate should clear privileged bits");
+}
 
-    ScopedOverlayEnv scoped("overlayfs_copy_up_truncate_mode");
-    const auto& env = scoped.env;
-    std::string lower_file = join_path(env.lower, "file");
-    std::string upper_file = join_path(env.upper, "file");
-    std::string merged_file = join_path(env.merged, "file");
-
-    ASSERT_EQ(0, ensure_dir("/tmp"));
-    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
-    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
-    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
-    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
-    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
-    ASSERT_EQ(0, write_text(lower_file, "truncate should clear privileged bits"));
-    ASSERT_EQ(0, chmod(lower_file.c_str(), 06777)) << strerror(errno);
-    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
-
-    pid_t child = fork();
-    ASSERT_GE(child, 0) << strerror(errno);
-    if (child == 0) {
-        if (setgid(1000) != 0) {
-            _exit(2);
-        }
-        if (setuid(1000) != 0) {
-            _exit(3);
-        }
-
-        int fd = open(merged_file.c_str(), O_WRONLY | O_TRUNC | O_CLOEXEC);
-        if (fd < 0) {
-            _exit(4);
-        }
-        _exit(close(fd) == 0 ? 0 : 5);
-    }
-
-    int status = 0;
-    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
-    ASSERT_TRUE(WIFEXITED(status));
-    ASSERT_EQ(0, WEXITSTATUS(status));
-
-    struct stat st = {};
-    ASSERT_EQ(0, stat(upper_file.c_str(), &st)) << strerror(errno);
-    EXPECT_EQ(0, st.st_size);
-    EXPECT_EQ(0u, static_cast<unsigned>(st.st_mode & (S_ISUID | S_ISGID)));
-    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+TEST(OverlayFsSemantics, CopyUpTruncateEmptyFileDropsPrivilegedBitsWithoutCapFsetid) {
+    expect_truncate_copy_up_drops_privileged_bits("overlayfs_copy_up_truncate_empty_mode", "");
 }
 
 TEST(OverlayFsSemantics, CopyUpLargeLowerFileConcurrentReadersNeverSeePartialUpper) {


### PR DESCRIPTION
## Summary
- copy up lower objects through workdir temporary entries and publish them with `RenameFlags::NOREPLACE` only after data is ready
- split copy-up APIs so open handles `O_TRUNC` without publishing old lower data, while already-locked mutation paths avoid reentrant locking
- preserve symlink and special-file semantics during copy-up, including raw device numbers for char/block devices
- add overlayfs copy-up regression coverage for complete publication, nested paths, truncate, and concurrent readers

## Validation
- `make -C user/apps/tests/dunitest build-suites`
- `make fmt`
- QEMU: `overlayfs_semantics_test --gtest_filter=OverlayFsSemantics.CopyUp\*`
- QEMU: `overlayfs_mount_validation_test`
- QEMU: full `overlayfs_semantics_test`

## Issue
Closes #2002
