### PR TITLE
fix(overlayfs): preserve special files during copy-up

### DIFF
--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -4,7 +4,7 @@ use crate::filesystem::vfs::{
     file::{File, FileFlags, FilePrivateData},
     syscall::RenameFlags,
     utils::should_remove_sgid,
-    FileType, IndexNode, Metadata,
+    FileType, IndexNode, Metadata, MAX_PATHLEN,
 };
 use crate::libs::mutex::Mutex;
 use crate::process::{
@@ -103,7 +103,7 @@ impl OvlInode {
         }
 
         let symlink_target = if metadata.file_type == FileType::SymLink {
-            Some(Self::read_symlink_target(lower_inode.clone(), &metadata)?)
+            Some(Self::read_symlink_target(lower_inode.clone())?)
         } else {
             None
         };
@@ -214,14 +214,14 @@ impl OvlInode {
         }
 
         let upper_metadata = inode.metadata()?;
-        if upper_metadata.file_type != lower_metadata.file_type {
+        if Self::copy_up_file_type(upper_metadata.file_type)
+            != Self::copy_up_file_type(lower_metadata.file_type)
+        {
             return Err(SystemError::EIO);
         }
 
-        if matches!(
-            upper_metadata.file_type,
-            FileType::CharDevice | FileType::BlockDevice
-        ) && upper_metadata.raw_dev != lower_metadata.raw_dev
+        if Self::is_device_node_file_type(lower_metadata.file_type)
+            && upper_metadata.raw_dev != lower_metadata.raw_dev
         {
             return Err(SystemError::EIO);
         }
@@ -266,13 +266,35 @@ impl OvlInode {
             FileType::SymLink => {
                 workdir.symlink(temp_name, symlink_target.ok_or(SystemError::EIO)?)
             }
-            FileType::CharDevice | FileType::BlockDevice | FileType::Pipe | FileType::Socket => {
+            file_type if Self::is_mknod_copy_up_type(file_type) => {
                 let mode = (metadata.mode & !vfs::InodeMode::S_IFMT)
-                    | vfs::InodeMode::from(metadata.file_type);
+                    | vfs::InodeMode::from(Self::copy_up_file_type(file_type));
                 workdir.mknod(temp_name, mode, metadata.raw_dev)
             }
             _ => workdir.create_with_data(temp_name, metadata.file_type, metadata.mode, 0),
         }
+    }
+
+    fn copy_up_file_type(file_type: FileType) -> FileType {
+        match file_type {
+            FileType::KvmDevice | FileType::FramebufferDevice => FileType::CharDevice,
+            _ => file_type,
+        }
+    }
+
+    fn is_device_node_file_type(file_type: FileType) -> bool {
+        matches!(
+            file_type,
+            FileType::CharDevice
+                | FileType::BlockDevice
+                | FileType::KvmDevice
+                | FileType::FramebufferDevice
+        )
+    }
+
+    fn is_mknod_copy_up_type(file_type: FileType) -> bool {
+        Self::is_device_node_file_type(file_type)
+            || matches!(file_type, FileType::Pipe | FileType::Socket)
     }
 
     fn copy_data_if_needed(
@@ -320,27 +342,23 @@ impl OvlInode {
         Ok(())
     }
 
-    fn read_symlink_target(
-        lower_inode: Arc<dyn IndexNode>,
-        metadata: &Metadata,
-    ) -> Result<String, SystemError> {
-        let size = metadata.size.max(0) as usize;
-        let mut buffer = vec![0u8; size];
-        let mut offset = 0usize;
+    fn read_symlink_target(lower_inode: Arc<dyn IndexNode>) -> Result<String, SystemError> {
+        let mut buffer = vec![0u8; MAX_PATHLEN];
+        let len = lower_inode.read_at(
+            0,
+            MAX_PATHLEN,
+            &mut buffer,
+            Mutex::new(FilePrivateData::Unused).lock(),
+        )?;
 
-        while offset < size {
-            let read_len = lower_inode.read_at(
-                offset,
-                size - offset,
-                &mut buffer[offset..],
-                Mutex::new(FilePrivateData::Unused).lock(),
-            )?;
-            if read_len == 0 {
-                return Err(SystemError::EIO);
-            }
-            offset += read_len;
+        if len == 0 {
+            return Err(SystemError::EIO);
+        }
+        if len >= MAX_PATHLEN {
+            return Err(SystemError::ENAMETOOLONG);
         }
 
+        buffer.truncate(len);
         String::from_utf8(buffer).map_err(|_| SystemError::EINVAL)
     }
 }

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -164,15 +164,7 @@ pub(super) fn mmap_file(
 }
 
 fn open_flags_need_copy_up(file_type: FileType, flags: &FileFlags) -> bool {
-    if matches!(
-        file_type,
-        FileType::Pipe
-            | FileType::Socket
-            | FileType::CharDevice
-            | FileType::BlockDevice
-            | FileType::KvmDevice
-            | FileType::FramebufferDevice
-    ) {
+    if file_type != FileType::File {
         return false;
     }
 

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -88,6 +88,15 @@ std::string read_text(const std::string& path) {
     return std::string(buf, static_cast<size_t>(n));
 }
 
+std::string read_symlink_target(const std::string& path) {
+    char buf[512] = {};
+    ssize_t n = readlink(path.c_str(), buf, sizeof(buf) - 1);
+    if (n < 0) {
+        return {};
+    }
+    return std::string(buf, static_cast<size_t>(n));
+}
+
 int overlay_temp_entry_count(const std::string& dir_path) {
     DIR* dir = opendir(dir_path.c_str());
     if (dir == nullptr) {
@@ -1151,6 +1160,177 @@ TEST(OverlayFsSemantics, CopyUpLargeLowerFileConcurrentReadersNeverSeePartialUpp
     EXPECT_EQ(0, WEXITSTATUS(status));
     EXPECT_TRUE(validate_pattern_file(upper_file, kFileSize));
     EXPECT_TRUE(validate_pattern_file(merged_file, kFileSize));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpLowerSymlinkPreservesTarget) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_symlink");
+    const auto& env = scoped.env;
+    std::string lower_target = join_path(env.lower, "target");
+    std::string lower_link = join_path(env.lower, "link");
+    std::string upper_renamed = join_path(env.upper, "renamed-link");
+    std::string merged_link = join_path(env.merged, "link");
+    std::string merged_renamed = join_path(env.merged, "renamed-link");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_target, "target-data"));
+    ASSERT_EQ(0, symlink("target", lower_link.c_str())) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(merged_link.c_str(), merged_renamed.c_str())) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, lstat(upper_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISLNK(st.st_mode));
+    EXPECT_EQ("target", read_symlink_target(upper_renamed));
+    EXPECT_EQ("target", read_symlink_target(merged_renamed));
+    EXPECT_EQ("target-data", read_text(merged_renamed));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpLowerCharDevicePreservesRdev) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_chrdev");
+    const auto& env = scoped.env;
+    std::string lower_node = join_path(env.lower, "node");
+    std::string upper_renamed = join_path(env.upper, "renamed-node");
+    std::string merged_node = join_path(env.merged, "node");
+    std::string merged_renamed = join_path(env.merged, "renamed-node");
+    dev_t dev = makedev(1, 7);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, mknod(lower_node.c_str(), S_IFCHR | 0600, dev)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(merged_node.c_str(), merged_renamed.c_str())) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, lstat(upper_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISCHR(st.st_mode));
+    EXPECT_EQ(dev, st.st_rdev);
+    EXPECT_FALSE(is_whiteout(upper_renamed));
+    ASSERT_EQ(0, lstat(merged_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISCHR(st.st_mode));
+    EXPECT_EQ(dev, st.st_rdev);
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpLowerBlockDevicePreservesRdev) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_blkdev");
+    const auto& env = scoped.env;
+    std::string lower_node = join_path(env.lower, "node");
+    std::string upper_renamed = join_path(env.upper, "renamed-node");
+    std::string merged_node = join_path(env.merged, "node");
+    std::string merged_renamed = join_path(env.merged, "renamed-node");
+    dev_t dev = makedev(7, 1);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, mknod(lower_node.c_str(), S_IFBLK | 0600, dev)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(merged_node.c_str(), merged_renamed.c_str())) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, lstat(upper_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISBLK(st.st_mode));
+    EXPECT_EQ(dev, st.st_rdev);
+    ASSERT_EQ(0, lstat(merged_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISBLK(st.st_mode));
+    EXPECT_EQ(dev, st.st_rdev);
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpLowerFifoPreservesType) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_fifo");
+    const auto& env = scoped.env;
+    std::string lower_fifo = join_path(env.lower, "fifo");
+    std::string upper_renamed = join_path(env.upper, "renamed-fifo");
+    std::string merged_fifo = join_path(env.merged, "fifo");
+    std::string merged_renamed = join_path(env.merged, "renamed-fifo");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, mkfifo(lower_fifo.c_str(), 0600)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(merged_fifo.c_str(), merged_renamed.c_str())) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, lstat(upper_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISFIFO(st.st_mode));
+    ASSERT_EQ(0, lstat(merged_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISFIFO(st.st_mode));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopyUpLowerSocketPreservesType) {
+    ScopedOverlayEnv scoped("overlayfs_copy_up_socket");
+    const auto& env = scoped.env;
+    std::string lower_socket = join_path(env.lower, "sock");
+    std::string upper_renamed = join_path(env.upper, "renamed-sock");
+    std::string merged_socket = join_path(env.merged, "sock");
+    std::string merged_renamed = join_path(env.merged, "renamed-sock");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, mknod(lower_socket.c_str(), S_IFSOCK | 0600, 0)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(merged_socket.c_str(), merged_renamed.c_str())) << strerror(errno);
+
+    struct stat st = {};
+    ASSERT_EQ(0, lstat(upper_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISSOCK(st.st_mode));
+    ASSERT_EQ(0, lstat(merged_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISSOCK(st.st_mode));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, OpenLowerFifoForWriteDoesNotCopyUp) {
+    ScopedOverlayEnv scoped("overlayfs_open_fifo_no_copy_up");
+    const auto& env = scoped.env;
+    std::string lower_fifo = join_path(env.lower, "fifo");
+    std::string upper_fifo = join_path(env.upper, "fifo");
+    std::string merged_fifo = join_path(env.merged, "fifo");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, mkfifo(lower_fifo.c_str(), 0600)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int fd = open(merged_fifo.c_str(), O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+    ASSERT_EQ(-1, fd);
+    EXPECT_EQ(ENXIO, errno);
+
+    struct stat st = {};
+    EXPECT_EQ(-1, lstat(upper_fifo.c_str(), &st));
+    EXPECT_EQ(ENOENT, errno);
     EXPECT_EQ(0, overlay_temp_entry_count(env.work));
 }
 


### PR DESCRIPTION
## Summary

- preserve symlink targets when copying lower symlinks to the upper layer
- preserve special-file types and device numbers for character devices, block devices, FIFOs, and sockets
- avoid copy-up when opening non-regular files, matching Linux overlayfs semantics
- add dunitest coverage for symlinks, device nodes, FIFOs, sockets, and special-file open behavior

## Root cause

Overlayfs copy-up used generic inode creation without carrying type-specific payloads. This could lose symlink targets and device numbers or create special files with incorrect semantics. The open path could also trigger unnecessary copy-up for non-regular files.

## Validation

- `make fmt`
- `make kernel`
- `make -C user/apps/tests/dunitest bin/normal/overlayfs_semantics_test`
- QEMU guest: `overlayfs_semantics_test` passed all 40 tests

Closes #2003
