### PR TITLE
fix(virtiofs): use negotiated queue capacity

### DIFF
--- a/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -52,6 +52,19 @@ make qemu-virtiofs-nographic AUTO_TEST=none
 
 这两个命令需要在两个终端分别运行。QEMU 命令会暴露 tag `hostshare`。
 
+验证不同 virtqueue 深度时，可以给 QEMU 设备传入显式 queue size：
+
+```sh
+DRAGONOS_VIRTIOFS_QUEUE_SIZE=8 make qemu-virtiofs-nographic AUTO_TEST=none
+DRAGONOS_VIRTIOFS_QUEUE_SIZE=128 make qemu-virtiofs-nographic AUTO_TEST=none
+```
+
+需要测试多个普通请求队列时，还可以设置，最大值为 64：
+
+```sh
+DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES=2 make qemu-virtiofs-nographic AUTO_TEST=none
+```
+
 ## 在 DragonOS 中运行
 
 进入 DragonOS 后，先挂载 debugfs：
@@ -137,7 +150,17 @@ virtiofs.bytes_completed_total
 virtiofs.bridge_poll_sleep_ns_total
 virtiofs.response_buffer_waste_bytes
 virtiofs.virtqueue_full_total
+virtiofs.device_queue_depth_max
+virtiofs.hiprio_vring_size_configured
+virtiofs.request_queue_count_configured
+virtiofs.request_vring_size_min_configured
+virtiofs.sg_limit_pages_configured
+virtiofs.inflight_peak
+virtiofs.queue_full_blocked_current
 ```
+
+其中 `*_configured` 是配置快照，benchmark 的 `stats_delta` 通常为 0；判断队列深度是否生效时应看
+`/tmp/dbg/fuse/stats` 中的绝对值。
 
 ## 对比结果
 

--- a/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -52,6 +52,19 @@ make qemu-virtiofs-nographic AUTO_TEST=none
 
 Run the two commands in separate terminals. The QEMU command exposes tag `hostshare`.
 
+To validate different virtqueue depths, pass an explicit queue size to the QEMU device:
+
+```sh
+DRAGONOS_VIRTIOFS_QUEUE_SIZE=8 make qemu-virtiofs-nographic AUTO_TEST=none
+DRAGONOS_VIRTIOFS_QUEUE_SIZE=128 make qemu-virtiofs-nographic AUTO_TEST=none
+```
+
+To test multiple ordinary request queues, also set it up to 64:
+
+```sh
+DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES=2 make qemu-virtiofs-nographic AUTO_TEST=none
+```
+
 ## Run On DragonOS
 
 Inside DragonOS:
@@ -137,7 +150,17 @@ virtiofs.bytes_completed_total
 virtiofs.bridge_poll_sleep_ns_total
 virtiofs.response_buffer_waste_bytes
 virtiofs.virtqueue_full_total
+virtiofs.device_queue_depth_max
+virtiofs.hiprio_vring_size_configured
+virtiofs.request_queue_count_configured
+virtiofs.request_vring_size_min_configured
+virtiofs.sg_limit_pages_configured
+virtiofs.inflight_peak
+virtiofs.queue_full_blocked_current
 ```
+
+The `*_configured` fields are configuration snapshots, so their `stats_delta` is usually 0.
+Check their absolute values in `/tmp/dbg/fuse/stats` when verifying whether queue depth took effect.
 
 ## Compare Results
 

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtio-drivers"
 version = "0.7.2"
-source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers?rev=3ac8163046#3ac816304626ad4704ea4cbab2ed9aed85f8c2c8"
+source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers?rev=89f6a402d494cf615cadfd851c9f017f31acac81#89f6a402d494cf615cadfd851c9f017f31acac81"
 dependencies = [
  "bitflags 2.9.1",
  "log",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -82,7 +82,7 @@ smoltcp = { version = "=0.12.0", git = "https://github.com/DragonOS-Community/sm
 syscall_table_macros = { path = "crates/syscall_table_macros" }
 system_error = { path = "crates/system_error" }
 unified-init = { path = "crates/unified-init" }
-virtio-drivers = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers", rev = "3ac8163046" }
+virtio-drivers = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers", rev = "89f6a402d494cf615cadfd851c9f017f31acac81" }
 wait_queue_macros = { path = "crates/wait_queue_macros" }
 paste = "=1.0.14"
 slabmalloc = { path = "crates/rust-slabmalloc" }

--- a/kernel/src/driver/virtio/virtio_fs.rs
+++ b/kernel/src/driver/virtio/virtio_fs.rs
@@ -60,6 +60,24 @@ struct VirtioFsInstanceState {
     active_bridge: Option<VirtioFsActiveBridge>,
 }
 
+impl VirtioFsInstanceState {
+    fn release_active_session_without_transport(&mut self, session_id: u64) -> bool {
+        if !self.session_active || self.active_session_id != session_id {
+            return false;
+        }
+
+        self.active_bridge = None;
+        self.released_session_id = session_id;
+        self.active_session_id = 0;
+        self.session_active = false;
+        true
+    }
+
+    fn is_session_released(&self, session_id: u64) -> bool {
+        self.released_session_id == session_id
+    }
+}
+
 #[derive(Debug)]
 pub struct VirtioFsInstance {
     tag: String,
@@ -222,10 +240,36 @@ impl VirtioFsInstance {
         self.session_wait.wakeup(None);
     }
 
+    /// Publish logical session completion while keeping an unsafe transport quarantined.
+    ///
+    /// This is used only when device reset did not complete. The caller must retain the
+    /// transport, queues, and DMA buffers because the device may still access them.
+    pub fn release_session_without_transport(&self, session_id: u64) -> bool {
+        let conn = {
+            let mut state = self.state.lock_irqsave();
+            if !state.session_active || state.active_session_id != session_id {
+                return false;
+            }
+            let conn = state
+                .active_bridge
+                .as_ref()
+                .and_then(|bridge| bridge.conn.upgrade());
+            if !state.release_active_session_without_transport(session_id) {
+                return false;
+            }
+            conn
+        };
+        if let Some(conn) = conn {
+            conn.clear_bridge_wake();
+        }
+        self.session_wait.wakeup(None);
+        true
+    }
+
     pub fn wait_session_released(&self, session_id: u64) {
         self.session_wait.wait_until(|| {
             let state = self.state.lock_irqsave();
-            if state.released_session_id == session_id && state.transport.is_some() {
+            if state.is_session_released(session_id) {
                 Some(())
             } else {
                 None
@@ -402,4 +446,41 @@ pub fn virtio_fs(
         "virtio-fs: registered instance tag='{}' dev={:?} request_queues={}",
         tag, dev_id, nrqs
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn active_state(session_id: u64) -> VirtioFsInstanceState {
+        VirtioFsInstanceState {
+            transport: None,
+            session_active: true,
+            active_session_id: session_id,
+            released_session_id: 0,
+            next_session_id: session_id + 1,
+            active_bridge: None,
+        }
+    }
+
+    #[test]
+    fn reset_timeout_releases_session_without_transport() {
+        let mut state = active_state(7);
+
+        assert!(state.release_active_session_without_transport(7));
+        assert!(state.is_session_released(7));
+        assert!(!state.session_active);
+        assert_eq!(state.active_session_id, 0);
+        assert!(state.transport.is_none());
+    }
+
+    #[test]
+    fn stale_session_cannot_release_active_session() {
+        let mut state = active_state(9);
+
+        assert!(!state.release_active_session_without_transport(8));
+        assert!(state.session_active);
+        assert_eq!(state.active_session_id, 9);
+        assert!(!state.is_session_released(8));
+    }
 }

--- a/kernel/src/driver/virtio/virtio_fs.rs
+++ b/kernel/src/driver/virtio/virtio_fs.rs
@@ -24,8 +24,7 @@ use super::{
 
 const VIRTIO_FS_TAG_LEN: usize = 36;
 const VIRTIO_FS_REQUEST_QUEUE_BASE: u16 = 1;
-const VIRTIO_FS_MAX_REQUEST_QUEUES: u32 =
-    (u16::MAX as u32) - (VIRTIO_FS_REQUEST_QUEUE_BASE as u32) + 1;
+const VIRTIO_FS_MAX_REQUEST_QUEUES: u32 = 64;
 
 #[repr(C, packed)]
 struct VirtioFsConfig {

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -209,7 +209,7 @@ impl Default for FuseInitNegotiated {
             // Linux guarantees max_write >= 4096 after init; before init keep sane default.
             max_write: 4096,
             time_gran: 0,
-            max_pages: 1,
+            max_pages: FuseConn::DEFAULT_MAX_PAGES as u16,
             flags: 0,
         }
     }
@@ -239,6 +239,7 @@ struct FuseConnInner {
     no_removexattr: bool,
     no_interrupt: bool,
     max_write_cap: usize,
+    max_pages_limit: usize,
     separate_hiprio_pending: bool,
     hiprio_pending: VecDeque<Arc<FuseRequest>>,
     pending: VecDeque<Arc<FuseRequest>>,
@@ -262,6 +263,8 @@ impl FuseConn {
     // Keep this in sync with `sys_read.rs` userspace chunking size.
     const USER_READ_CHUNK: usize = 64 * 1024;
     const MIN_MAX_WRITE: usize = 4096;
+    const DEFAULT_MAX_PAGES: usize = 32;
+    const MAX_MAX_PAGES: usize = 256;
     const DEFAULT_MAX_READAHEAD: usize = 128 * MMArch::PAGE_SIZE;
 
     pub fn new() -> Arc<Self> {
@@ -311,6 +314,7 @@ impl FuseConn {
                 no_removexattr: false,
                 no_interrupt: false,
                 max_write_cap,
+                max_pages_limit: Self::MAX_MAX_PAGES,
                 separate_hiprio_pending,
                 hiprio_pending: VecDeque::new(),
                 pending: VecDeque::new(),
@@ -771,9 +775,16 @@ impl FuseConn {
         }
     }
 
-    fn max_write_cap(&self) -> usize {
-        let g = self.inner.lock();
-        core::cmp::max(Self::MIN_MAX_WRITE, g.max_write_cap)
+    pub fn set_max_pages_limit(&self, max_pages_limit: usize) -> Result<(), SystemError> {
+        if max_pages_limit == 0 {
+            return Err(SystemError::EINVAL);
+        }
+        let mut g = self.inner.lock();
+        if g.initialized {
+            return Err(SystemError::EBUSY);
+        }
+        g.max_pages_limit = core::cmp::min(max_pages_limit, Self::MAX_MAX_PAGES);
+        Ok(())
     }
 
     fn min_read_buffer(&self) -> usize {
@@ -1326,14 +1337,20 @@ impl FuseConn {
                 negotiated_flags |= (init_out.flags2 as u64) << 32;
             }
             let negotiated_minor = core::cmp::min(init_out.minor, FUSE_KERNEL_MINOR_VERSION);
-            let negotiated_max_pages_raw =
-                if (negotiated_flags & FUSE_MAX_PAGES) != 0 && init_out.max_pages != 0 {
-                    init_out.max_pages
-                } else {
-                    1
-                };
-            let negotiated_max_write = core::cmp::max(4096usize, init_out.max_write as usize);
-            let max_write_cap = self.max_write_cap();
+            let negotiated_max_pages_raw = if (negotiated_flags & FUSE_MAX_PAGES) != 0 {
+                core::cmp::max(init_out.max_pages, 1)
+            } else {
+                Self::DEFAULT_MAX_PAGES as u16
+            };
+            let negotiated_max_write =
+                core::cmp::max(Self::MIN_MAX_WRITE, init_out.max_write as usize);
+            let (max_write_cap, max_pages_limit) = {
+                let g = self.inner.lock();
+                (
+                    core::cmp::max(Self::MIN_MAX_WRITE, g.max_write_cap),
+                    g.max_pages_limit,
+                )
+            };
             let capped_max_write = core::cmp::min(negotiated_max_write, max_write_cap);
             if capped_max_write < negotiated_max_write {
                 log::trace!(
@@ -1342,9 +1359,8 @@ impl FuseConn {
                     capped_max_write
                 );
             }
-            let pages_from_write =
-                core::cmp::max(1usize, capped_max_write.div_ceil(MMArch::PAGE_SIZE)) as u16;
-            let negotiated_max_pages = core::cmp::min(negotiated_max_pages_raw, pages_from_write);
+            let negotiated_max_pages =
+                core::cmp::min(negotiated_max_pages_raw, max_pages_limit as u16);
 
             {
                 let mut g = self.inner.lock();

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -181,6 +181,10 @@ impl FuseNode {
         Ok(())
     }
 
+    fn max_pages_bytes(&self) -> usize {
+        core::cmp::max(1, self.conn().max_pages()).saturating_mul(MMArch::PAGE_SIZE)
+    }
+
     pub fn nodeid(&self) -> u64 {
         self.nodeid
     }
@@ -743,7 +747,7 @@ impl FuseNode {
         {
             return Err(SystemError::ESTALE);
         }
-        let max_write = self.conn().max_write();
+        let max_write = core::cmp::min(self.conn().max_write(), self.max_pages_bytes());
         if max_write == 0 {
             return Err(SystemError::EIO);
         }
@@ -1272,7 +1276,7 @@ impl FuseNode {
         file_flags: u32,
         lock_owner: u64,
     ) -> Result<usize, SystemError> {
-        let max_read = self.conn().max_read();
+        let max_read = core::cmp::min(self.conn().max_read(), self.max_pages_bytes());
         if max_read == 0 {
             return Err(SystemError::EIO);
         }
@@ -2179,7 +2183,7 @@ impl IndexNode for FuseNode {
         let fh = private_data.fh;
         let file_flags = private_data.open_flags;
         let fopen_flags = private_data.fopen_flags;
-        let max_write = self.conn().max_write();
+        let max_write = core::cmp::min(self.conn().max_write(), self.max_pages_bytes());
         if max_write == 0 {
             return Err(SystemError::EIO);
         }

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -19,6 +19,19 @@ pub struct FuseStatsSnapshot {
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct VirtioFsStatsSnapshot {
+    pub device_queue_depth_max: u64,
+    pub hiprio_vring_size_configured: u64,
+    pub request_queue_count_configured: u64,
+    pub request_vring_size_min_configured: u64,
+    pub request_vring_size_max_configured: u64,
+    pub sg_limit_pages_configured: u64,
+    pub inflight_current: u64,
+    pub inflight_peak: u64,
+    pub hiprio_inflight_current: u64,
+    pub hiprio_inflight_peak: u64,
+    pub request_inflight_current: u64,
+    pub request_inflight_peak: u64,
+    pub queue_full_blocked_current: u64,
     pub bridge_loop_iterations_total: u64,
     pub bridge_progress_iterations_total: u64,
     pub bridge_idle_sleeps_total: u64,
@@ -59,6 +72,8 @@ pub struct VirtioFsStatsSnapshot {
     pub bridge_queue_full_retry_total: u64,
     pub bridge_queue_full_retry_after_completion_total: u64,
     pub bridge_queue_full_retry_success_total: u64,
+    pub hiprio_queue_full_total: u64,
+    pub request_queue_full_total: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,6 +113,12 @@ pub enum VirtioFsBridgeWaitExit {
     Spurious,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtioFsQueueKind {
+    Hiprio,
+    Request,
+}
+
 impl VirtioFsBridgeWaitExit {
     pub const fn trace_id(self) -> u8 {
         match self {
@@ -120,6 +141,20 @@ static NOREPLY_QUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_BUFFER_TOO_SMALL_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BYTES_REQUEST_TO_DEV_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BYTES_REPLY_PAYLOAD_CLONED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+static DEVICE_QUEUE_DEPTH_MAX: AtomicU64 = AtomicU64::new(0);
+static HIPRIO_VRING_SIZE_CONFIGURED: AtomicU64 = AtomicU64::new(0);
+static REQUEST_QUEUE_COUNT_CONFIGURED: AtomicU64 = AtomicU64::new(0);
+static REQUEST_VRING_SIZE_MIN_CONFIGURED: AtomicU64 = AtomicU64::new(0);
+static REQUEST_VRING_SIZE_MAX_CONFIGURED: AtomicU64 = AtomicU64::new(0);
+static SG_LIMIT_PAGES_CONFIGURED: AtomicU64 = AtomicU64::new(0);
+static INFLIGHT_CURRENT: AtomicU64 = AtomicU64::new(0);
+static INFLIGHT_PEAK: AtomicU64 = AtomicU64::new(0);
+static HIPRIO_INFLIGHT_CURRENT: AtomicU64 = AtomicU64::new(0);
+static HIPRIO_INFLIGHT_PEAK: AtomicU64 = AtomicU64::new(0);
+static REQUEST_INFLIGHT_CURRENT: AtomicU64 = AtomicU64::new(0);
+static REQUEST_INFLIGHT_PEAK: AtomicU64 = AtomicU64::new(0);
+static QUEUE_FULL_BLOCKED_CURRENT: AtomicU64 = AtomicU64::new(0);
 
 static BRIDGE_LOOP_ITERATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_PROGRESS_ITERATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -163,6 +198,8 @@ static BRIDGE_QUEUE_FULL_BLOCKED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_QUEUE_FULL_RETRY_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_QUEUE_FULL_RETRY_AFTER_COMPLETION_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_QUEUE_FULL_RETRY_SUCCESS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static HIPRIO_QUEUE_FULL_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REQUEST_QUEUE_FULL_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
 fn add(counter: &AtomicU64, value: u64) {
@@ -170,8 +207,31 @@ fn add(counter: &AtomicU64, value: u64) {
 }
 
 #[inline]
+fn saturating_sub(counter: &AtomicU64, value: u64) {
+    let mut old = counter.load(Ordering::Relaxed);
+    loop {
+        let new = old.saturating_sub(value);
+        match counter.compare_exchange_weak(old, new, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => return,
+            Err(v) => old = v,
+        }
+    }
+}
+
+#[inline]
 fn inc(counter: &AtomicU64) {
     add(counter, 1);
+}
+
+#[inline]
+fn update_peak(peak: &AtomicU64, value: u64) {
+    let mut old = peak.load(Ordering::Relaxed);
+    while value > old {
+        match peak.compare_exchange_weak(old, value, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(v) => old = v,
+        }
+    }
 }
 
 #[inline]
@@ -244,6 +304,53 @@ pub fn on_virtiofs_loop_iteration(progressed: bool) {
     inc(&BRIDGE_LOOP_ITERATIONS_TOTAL);
     if progressed {
         inc(&BRIDGE_PROGRESS_ITERATIONS_TOTAL);
+    }
+}
+
+pub fn on_virtiofs_queue_configured(
+    device_queue_depth_max: usize,
+    hiprio_vring_size: usize,
+    request_queue_count: usize,
+    request_vring_size_min: usize,
+    request_vring_size_max: usize,
+    sg_limit_pages: usize,
+) {
+    DEVICE_QUEUE_DEPTH_MAX.store(device_queue_depth_max as u64, Ordering::Relaxed);
+    HIPRIO_VRING_SIZE_CONFIGURED.store(hiprio_vring_size as u64, Ordering::Relaxed);
+    REQUEST_QUEUE_COUNT_CONFIGURED.store(request_queue_count as u64, Ordering::Relaxed);
+    REQUEST_VRING_SIZE_MIN_CONFIGURED.store(request_vring_size_min as u64, Ordering::Relaxed);
+    REQUEST_VRING_SIZE_MAX_CONFIGURED.store(request_vring_size_max as u64, Ordering::Relaxed);
+    SG_LIMIT_PAGES_CONFIGURED.store(sg_limit_pages as u64, Ordering::Relaxed);
+}
+
+pub fn on_virtiofs_inflight_add(kind: VirtioFsQueueKind) {
+    let total = INFLIGHT_CURRENT.fetch_add(1, Ordering::Relaxed) + 1;
+    update_peak(&INFLIGHT_PEAK, total);
+    match kind {
+        VirtioFsQueueKind::Hiprio => {
+            let current = HIPRIO_INFLIGHT_CURRENT.fetch_add(1, Ordering::Relaxed) + 1;
+            update_peak(&HIPRIO_INFLIGHT_PEAK, current);
+        }
+        VirtioFsQueueKind::Request => {
+            let current = REQUEST_INFLIGHT_CURRENT.fetch_add(1, Ordering::Relaxed) + 1;
+            update_peak(&REQUEST_INFLIGHT_PEAK, current);
+        }
+    }
+}
+
+pub fn on_virtiofs_inflight_remove(kind: VirtioFsQueueKind, count: usize) {
+    if count == 0 {
+        return;
+    }
+    let count = count as u64;
+    saturating_sub(&INFLIGHT_CURRENT, count);
+    match kind {
+        VirtioFsQueueKind::Hiprio => {
+            saturating_sub(&HIPRIO_INFLIGHT_CURRENT, count);
+        }
+        VirtioFsQueueKind::Request => {
+            saturating_sub(&REQUEST_INFLIGHT_CURRENT, count);
+        }
     }
 }
 
@@ -336,13 +443,23 @@ pub fn on_virtiofs_submitted(req_len: usize) {
 }
 
 #[inline]
-pub fn on_virtiofs_queue_full() {
+pub fn on_virtiofs_queue_full(kind: VirtioFsQueueKind) {
     inc(&VIRTQUEUE_FULL_TOTAL);
+    match kind {
+        VirtioFsQueueKind::Hiprio => inc(&HIPRIO_QUEUE_FULL_TOTAL),
+        VirtioFsQueueKind::Request => inc(&REQUEST_QUEUE_FULL_TOTAL),
+    }
 }
 
 #[inline]
 pub fn on_virtiofs_queue_full_blocked() {
     inc(&BRIDGE_QUEUE_FULL_BLOCKED_TOTAL);
+    inc(&QUEUE_FULL_BLOCKED_CURRENT);
+}
+
+#[inline]
+pub fn on_virtiofs_queue_full_unblocked() {
+    saturating_sub(&QUEUE_FULL_BLOCKED_CURRENT, 1);
 }
 
 #[inline]
@@ -404,6 +521,21 @@ pub fn fuse_snapshot() -> FuseStatsSnapshot {
 
 pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
     VirtioFsStatsSnapshot {
+        device_queue_depth_max: DEVICE_QUEUE_DEPTH_MAX.load(Ordering::Relaxed),
+        hiprio_vring_size_configured: HIPRIO_VRING_SIZE_CONFIGURED.load(Ordering::Relaxed),
+        request_queue_count_configured: REQUEST_QUEUE_COUNT_CONFIGURED.load(Ordering::Relaxed),
+        request_vring_size_min_configured: REQUEST_VRING_SIZE_MIN_CONFIGURED
+            .load(Ordering::Relaxed),
+        request_vring_size_max_configured: REQUEST_VRING_SIZE_MAX_CONFIGURED
+            .load(Ordering::Relaxed),
+        sg_limit_pages_configured: SG_LIMIT_PAGES_CONFIGURED.load(Ordering::Relaxed),
+        inflight_current: INFLIGHT_CURRENT.load(Ordering::Relaxed),
+        inflight_peak: INFLIGHT_PEAK.load(Ordering::Relaxed),
+        hiprio_inflight_current: HIPRIO_INFLIGHT_CURRENT.load(Ordering::Relaxed),
+        hiprio_inflight_peak: HIPRIO_INFLIGHT_PEAK.load(Ordering::Relaxed),
+        request_inflight_current: REQUEST_INFLIGHT_CURRENT.load(Ordering::Relaxed),
+        request_inflight_peak: REQUEST_INFLIGHT_PEAK.load(Ordering::Relaxed),
+        queue_full_blocked_current: QUEUE_FULL_BLOCKED_CURRENT.load(Ordering::Relaxed),
         bridge_loop_iterations_total: BRIDGE_LOOP_ITERATIONS_TOTAL.load(Ordering::Relaxed),
         bridge_progress_iterations_total: BRIDGE_PROGRESS_ITERATIONS_TOTAL.load(Ordering::Relaxed),
         bridge_idle_sleeps_total: BRIDGE_IDLE_SLEEPS_TOTAL.load(Ordering::Relaxed),
@@ -450,6 +582,8 @@ pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
             BRIDGE_QUEUE_FULL_RETRY_AFTER_COMPLETION_TOTAL.load(Ordering::Relaxed),
         bridge_queue_full_retry_success_total: BRIDGE_QUEUE_FULL_RETRY_SUCCESS_TOTAL
             .load(Ordering::Relaxed),
+        hiprio_queue_full_total: HIPRIO_QUEUE_FULL_TOTAL.load(Ordering::Relaxed),
+        request_queue_full_total: REQUEST_QUEUE_FULL_TOTAL.load(Ordering::Relaxed),
     }
 }
 
@@ -470,6 +604,19 @@ bytes_request_to_dev_total {}\n\
 bytes_reply_payload_cloned_total {}\n\
 \n\
 [virtiofs]\n\
+device_queue_depth_max {}\n\
+hiprio_vring_size_configured {}\n\
+request_queue_count_configured {}\n\
+request_vring_size_min_configured {}\n\
+request_vring_size_max_configured {}\n\
+sg_limit_pages_configured {}\n\
+inflight_current {}\n\
+inflight_peak {}\n\
+hiprio_inflight_current {}\n\
+hiprio_inflight_peak {}\n\
+request_inflight_current {}\n\
+request_inflight_peak {}\n\
+queue_full_blocked_current {}\n\
 bridge_loop_iterations_total {}\n\
 bridge_progress_iterations_total {}\n\
 bridge_idle_sleeps_total {}\n\
@@ -517,7 +664,9 @@ bridge_irq_weak_upgrade_failed_total {}\n\
 bridge_queue_full_blocked_total {}\n\
 bridge_queue_full_retry_total {}\n\
 bridge_queue_full_retry_after_completion_total {}\n\
-bridge_queue_full_retry_success_total {}\n",
+bridge_queue_full_retry_success_total {}\n\
+hiprio_queue_full_total {}\n\
+request_queue_full_total {}\n",
         fuse.requests_queued_total,
         fuse.requests_dequeued_total,
         fuse.requests_replied_ok_total,
@@ -528,6 +677,19 @@ bridge_queue_full_retry_success_total {}\n",
         fuse.read_buffer_too_small_total,
         fuse.bytes_request_to_dev_total,
         fuse.bytes_reply_payload_cloned_total,
+        virtiofs.device_queue_depth_max,
+        virtiofs.hiprio_vring_size_configured,
+        virtiofs.request_queue_count_configured,
+        virtiofs.request_vring_size_min_configured,
+        virtiofs.request_vring_size_max_configured,
+        virtiofs.sg_limit_pages_configured,
+        virtiofs.inflight_current,
+        virtiofs.inflight_peak,
+        virtiofs.hiprio_inflight_current,
+        virtiofs.hiprio_inflight_peak,
+        virtiofs.request_inflight_current,
+        virtiofs.request_inflight_peak,
+        virtiofs.queue_full_blocked_current,
         virtiofs.bridge_loop_iterations_total,
         virtiofs.bridge_progress_iterations_total,
         virtiofs.bridge_idle_sleeps_total,
@@ -576,5 +738,7 @@ bridge_queue_full_retry_success_total {}\n",
         virtiofs.bridge_queue_full_retry_total,
         virtiofs.bridge_queue_full_retry_after_completion_total,
         virtiofs.bridge_queue_full_retry_success_total,
+        virtiofs.hiprio_queue_full_total,
+        virtiofs.request_queue_full_total,
     )
 }

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -255,6 +255,7 @@ fn cleanup_created_queues(
 
 fn put_transport_after_start_failure(
     instance: &Arc<VirtioFsInstance>,
+    session_id: u64,
     mut transport: VirtIOTransport,
     hiprio_vq: VirtioFsQueue,
     request_vqs: Vec<VirtioFsQueue>,
@@ -275,11 +276,20 @@ fn put_transport_after_start_failure(
         core::mem::forget(transport);
         core::mem::forget(hiprio_vq);
         core::mem::forget(request_vqs);
+        if !instance.release_session_without_transport(session_id) {
+            warn!(
+                "virtiofs bridge: failed to release quarantined start session id={} tag='{}' dev={:?}",
+                session_id,
+                instance.tag(),
+                instance.dev_id()
+            );
+        }
     }
 }
 
 fn reset_transport_after_start_failure(
     instance: &Arc<VirtioFsInstance>,
+    session_id: u64,
     mut transport: VirtIOTransport,
 ) {
     transport.set_status(DeviceStatus::empty());
@@ -293,6 +303,14 @@ fn reset_transport_after_start_failure(
             instance.dev_id()
         );
         core::mem::forget(transport);
+        if !instance.release_session_without_transport(session_id) {
+            warn!(
+                "virtiofs bridge: failed to release quarantined start session id={} tag='{}' dev={:?}",
+                session_id,
+                instance.tag(),
+                instance.dev_id()
+            );
+        }
     }
 }
 
@@ -1064,11 +1082,7 @@ impl VirtioFsBridgeContext {
         trace::trace_virtiofs_bridge_wait_exit(reason.trace_id(), events);
     }
 
-    fn fail_all_unfinished(&mut self, err: SystemError) {
-        let conn = self.conn.clone();
-        let errno = err.to_posix_errno();
-        let mut need_reply = Vec::new();
-
+    fn drain_pending_reply_uniques(&mut self, need_reply: &mut Vec<u64>) {
         while let Some(req) = self.hiprio_pending.pop_front() {
             if !req.noreply {
                 need_reply.push(req.unique);
@@ -1082,36 +1096,59 @@ impl VirtioFsBridgeContext {
                 }
             }
         }
+    }
 
-        let hiprio_inflight_count = self.hiprio_inflight.len();
+    fn collect_inflight_reply_uniques(&self, need_reply: &mut Vec<u64>) {
         for (_, req) in self.hiprio_inflight.iter() {
             if !req.pending.noreply {
                 need_reply.push(req.pending.unique);
             }
         }
+
+        for inflight_map in &self.request_inflight {
+            for (_, req) in inflight_map.iter() {
+                if !req.pending.noreply {
+                    need_reply.push(req.pending.unique);
+                }
+            }
+        }
+    }
+
+    fn complete_unfinished(&self, err: SystemError, need_reply: Vec<u64>) {
+        let failed = need_reply.len();
+        let errno = err.to_posix_errno();
+        for unique in need_reply {
+            Self::complete_request_with_negative_errno(&self.conn, unique, errno);
+        }
+        stats::on_virtiofs_fail_unfinished(failed);
+    }
+
+    fn fail_unfinished_preserving_inflight_dma(&mut self, err: SystemError) {
+        let mut need_reply = Vec::new();
+        self.drain_pending_reply_uniques(&mut need_reply);
+        self.collect_inflight_reply_uniques(&mut need_reply);
+        self.complete_unfinished(err, need_reply);
+    }
+
+    fn fail_all_unfinished(&mut self, err: SystemError) {
+        let mut need_reply = Vec::new();
+        self.drain_pending_reply_uniques(&mut need_reply);
+        self.collect_inflight_reply_uniques(&mut need_reply);
+
+        let hiprio_inflight_count = self.hiprio_inflight.len();
         self.hiprio_inflight.clear();
         stats::on_virtiofs_inflight_remove(stats::VirtioFsQueueKind::Hiprio, hiprio_inflight_count);
 
         let mut request_inflight_count = 0usize;
         for inflight_map in &mut self.request_inflight {
             request_inflight_count += inflight_map.len();
-            for (_, req) in inflight_map.iter() {
-                if !req.pending.noreply {
-                    need_reply.push(req.pending.unique);
-                }
-            }
             inflight_map.clear();
         }
         stats::on_virtiofs_inflight_remove(
             stats::VirtioFsQueueKind::Request,
             request_inflight_count,
         );
-
-        let failed = need_reply.len();
-        for unique in need_reply {
-            Self::complete_request_with_negative_errno(&conn, unique, errno);
-        }
-        stats::on_virtiofs_fail_unfinished(failed);
+        self.complete_unfinished(err, need_reply);
     }
 
     fn clear_queue_full_blocked_stats(&mut self) {
@@ -1269,6 +1306,18 @@ impl VirtioFsBridgeContext {
         self.clear_queue_full_blocked_stats();
         self.instance.clear_bridge_wake(self.session_id);
         if !self.reset_device_and_unset_queues() {
+            self.fail_unfinished_preserving_inflight_dma(SystemError::ENOTCONN);
+            if !self
+                .instance
+                .release_session_without_transport(self.session_id)
+            {
+                warn!(
+                    "virtiofs bridge: failed to release quarantined session id={} tag='{}' dev={:?}",
+                    self.session_id,
+                    self.instance.tag(),
+                    self.instance.dev_id()
+                );
+            }
             return false;
         }
         self.fail_all_unfinished(SystemError::ENOTCONN);
@@ -1336,7 +1385,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
             instance.dev_id(),
             status
         );
-        reset_transport_after_start_failure(&instance, transport);
+        reset_transport_after_start_failure(&instance, session_id, transport);
         return Err(SystemError::ENODEV);
     }
     transport.set_guest_page_size(PAGE_SIZE as u32);
@@ -1351,7 +1400,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
                     instance.dev_id(),
                     e
                 );
-                reset_transport_after_start_failure(&instance, transport);
+                reset_transport_after_start_failure(&instance, session_id, transport);
                 return Err(e);
             }
         };
@@ -1368,6 +1417,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
             None => {
                 put_transport_after_start_failure(
                     &instance,
+                    session_id,
                     transport,
                     hiprio_vq,
                     request_vqs,
@@ -1391,6 +1441,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
                 );
                 put_transport_after_start_failure(
                     &instance,
+                    session_id,
                     transport,
                     hiprio_vq,
                     request_vqs,
@@ -1411,6 +1462,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
     let Some(sg_limit_pages) = request_size_min.checked_sub(FUSE_HEADER_OVERHEAD) else {
         put_transport_after_start_failure(
             &instance,
+            session_id,
             transport,
             hiprio_vq,
             request_vqs,
@@ -1422,6 +1474,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
     if sg_limit_pages == 0 {
         put_transport_after_start_failure(
             &instance,
+            session_id,
             transport,
             hiprio_vq,
             request_vqs,
@@ -1434,6 +1487,7 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
     if let Err(e) = conn.set_max_pages_limit(max_pages_limit) {
         put_transport_after_start_failure(
             &instance,
+            session_id,
             transport,
             hiprio_vq,
             request_vqs,

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -6,14 +6,15 @@ use alloc::{
     vec,
     vec::Vec,
 };
+use core::hint::spin_loop;
 
 use linkme::distributed_slice;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use system_error::SystemError;
 use virtio_drivers::{
     queue::VirtQueue,
     transport::{DeviceStatus, Transport},
-    Error as VirtioError, PAGE_SIZE,
+    Error as VirtioError, Result as VirtioResult, PAGE_SIZE,
 };
 
 use crate::{
@@ -43,7 +44,11 @@ use super::{
     stats, trace,
 };
 
-const VIRTIOFS_REQ_QUEUE_SIZE: usize = 8;
+const VIRTIOFS_QUEUE_SIZE_MIN: usize = 8;
+const VIRTIOFS_QUEUE_SIZE_MAX: usize = 1024;
+const VIRTIOFS_RESET_WAIT_SPINS: usize = 100_000;
+const FUSE_HEADER_OVERHEAD: usize = 4;
+const FUSE_MAX_MAX_PAGES: usize = 256;
 const VIRTIOFS_REQ_BUF_SIZE: usize = 256 * 1024;
 const VIRTIOFS_RSP_BUF_SIZE: usize = 256 * 1024;
 const VIRTIOFS_POLL_NS: i64 = 1_000_000;
@@ -76,14 +81,239 @@ struct QueueBlockState {
     completion_seen: bool,
 }
 
+enum VirtioFsQueue {
+    Q8(Box<VirtQueue<HalImpl, 8>>),
+    Q16(Box<VirtQueue<HalImpl, 16>>),
+    Q32(Box<VirtQueue<HalImpl, 32>>),
+    Q64(Box<VirtQueue<HalImpl, 64>>),
+    Q128(Box<VirtQueue<HalImpl, 128>>),
+    Q256(Box<VirtQueue<HalImpl, 256>>),
+    Q512(Box<VirtQueue<HalImpl, 512>>),
+    Q1024(Box<VirtQueue<HalImpl, 1024>>),
+}
+
+impl VirtioFsQueue {
+    fn can_pop(&self) -> bool {
+        match self {
+            Self::Q8(q) => q.can_pop(),
+            Self::Q16(q) => q.can_pop(),
+            Self::Q32(q) => q.can_pop(),
+            Self::Q64(q) => q.can_pop(),
+            Self::Q128(q) => q.can_pop(),
+            Self::Q256(q) => q.can_pop(),
+            Self::Q512(q) => q.can_pop(),
+            Self::Q1024(q) => q.can_pop(),
+        }
+    }
+
+    fn peek_used(&self) -> Option<u16> {
+        match self {
+            Self::Q8(q) => q.peek_used(),
+            Self::Q16(q) => q.peek_used(),
+            Self::Q32(q) => q.peek_used(),
+            Self::Q64(q) => q.peek_used(),
+            Self::Q128(q) => q.peek_used(),
+            Self::Q256(q) => q.peek_used(),
+            Self::Q512(q) => q.peek_used(),
+            Self::Q1024(q) => q.peek_used(),
+        }
+    }
+
+    fn should_notify(&self) -> bool {
+        match self {
+            Self::Q8(q) => q.should_notify(),
+            Self::Q16(q) => q.should_notify(),
+            Self::Q32(q) => q.should_notify(),
+            Self::Q64(q) => q.should_notify(),
+            Self::Q128(q) => q.should_notify(),
+            Self::Q256(q) => q.should_notify(),
+            Self::Q512(q) => q.should_notify(),
+            Self::Q1024(q) => q.should_notify(),
+        }
+    }
+
+    unsafe fn add<'a, 'b>(
+        &mut self,
+        inputs: &'a [&'b [u8]],
+        outputs: &'a mut [&'b mut [u8]],
+    ) -> VirtioResult<u16> {
+        match self {
+            Self::Q8(q) => unsafe { q.add(inputs, outputs) },
+            Self::Q16(q) => unsafe { q.add(inputs, outputs) },
+            Self::Q32(q) => unsafe { q.add(inputs, outputs) },
+            Self::Q64(q) => unsafe { q.add(inputs, outputs) },
+            Self::Q128(q) => unsafe { q.add(inputs, outputs) },
+            Self::Q256(q) => unsafe { q.add(inputs, outputs) },
+            Self::Q512(q) => unsafe { q.add(inputs, outputs) },
+            Self::Q1024(q) => unsafe { q.add(inputs, outputs) },
+        }
+    }
+
+    unsafe fn pop_used<'a>(
+        &mut self,
+        token: u16,
+        inputs: &'a [&'a [u8]],
+        outputs: &'a mut [&'a mut [u8]],
+    ) -> VirtioResult<u32> {
+        match self {
+            Self::Q8(q) => unsafe { q.pop_used(token, inputs, outputs) },
+            Self::Q16(q) => unsafe { q.pop_used(token, inputs, outputs) },
+            Self::Q32(q) => unsafe { q.pop_used(token, inputs, outputs) },
+            Self::Q64(q) => unsafe { q.pop_used(token, inputs, outputs) },
+            Self::Q128(q) => unsafe { q.pop_used(token, inputs, outputs) },
+            Self::Q256(q) => unsafe { q.pop_used(token, inputs, outputs) },
+            Self::Q512(q) => unsafe { q.pop_used(token, inputs, outputs) },
+            Self::Q1024(q) => unsafe { q.pop_used(token, inputs, outputs) },
+        }
+    }
+
+    unsafe fn detach_unused<'a>(
+        &mut self,
+        token: u16,
+        inputs: &'a [&'a [u8]],
+        outputs: &'a mut [&'a mut [u8]],
+    ) -> VirtioResult<()> {
+        match self {
+            Self::Q8(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+            Self::Q16(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+            Self::Q32(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+            Self::Q64(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+            Self::Q128(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+            Self::Q256(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+            Self::Q512(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+            Self::Q1024(q) => unsafe { q.detach_unused(token, inputs, outputs) },
+        }
+    }
+}
+
+fn choose_queue_size(device_max: u32) -> Result<usize, SystemError> {
+    let limit = core::cmp::min(device_max as usize, VIRTIOFS_QUEUE_SIZE_MAX);
+    if limit < VIRTIOFS_QUEUE_SIZE_MIN {
+        return Err(SystemError::EINVAL);
+    }
+
+    let mut size = VIRTIOFS_QUEUE_SIZE_MIN;
+    while size <= limit / 2 {
+        size *= 2;
+    }
+    Ok(size)
+}
+
+fn create_queue_with_size(
+    transport: &mut VirtIOTransport,
+    idx: u16,
+    size: usize,
+) -> Result<VirtioFsQueue, VirtioError> {
+    macro_rules! new_queue {
+        ($size:expr, $variant:ident) => {{
+            let mut queue = VirtQueue::<HalImpl, $size>::new_boxed(transport, idx, false, false)?;
+            queue.set_dev_notify(true);
+            Ok(VirtioFsQueue::$variant(queue))
+        }};
+    }
+
+    match size {
+        8 => new_queue!(8, Q8),
+        16 => new_queue!(16, Q16),
+        32 => new_queue!(32, Q32),
+        64 => new_queue!(64, Q64),
+        128 => new_queue!(128, Q128),
+        256 => new_queue!(256, Q256),
+        512 => new_queue!(512, Q512),
+        1024 => new_queue!(1024, Q1024),
+        _ => Err(VirtioError::InvalidParam),
+    }
+}
+
+fn create_queue(
+    transport: &mut VirtIOTransport,
+    idx: u16,
+) -> Result<(VirtioFsQueue, usize, usize), SystemError> {
+    let device_max = transport.max_queue_size(idx) as usize;
+    let size = choose_queue_size(device_max as u32)?;
+    let queue = create_queue_with_size(transport, idx, size)
+        .map_err(virtio_drivers_error_to_system_error)?;
+    Ok((queue, device_max, size))
+}
+
+fn cleanup_created_queues(
+    transport: &mut VirtIOTransport,
+    hiprio_idx: u16,
+    request_indices: &[u16],
+) -> bool {
+    transport.set_status(DeviceStatus::empty());
+    if !wait_transport_reset_complete(transport) {
+        return false;
+    }
+
+    transport.queue_unset(hiprio_idx);
+    for idx in request_indices {
+        transport.queue_unset(*idx);
+    }
+    true
+}
+
+fn put_transport_after_start_failure(
+    instance: &Arc<VirtioFsInstance>,
+    mut transport: VirtIOTransport,
+    hiprio_vq: VirtioFsQueue,
+    request_vqs: Vec<VirtioFsQueue>,
+    hiprio_idx: u16,
+    request_indices: &[u16],
+) {
+    if cleanup_created_queues(&mut transport, hiprio_idx, request_indices) {
+        drop(hiprio_vq);
+        drop(request_vqs);
+        transport.set_status(DeviceStatus::FAILED);
+        instance.put_transport_after_session(transport);
+    } else {
+        warn!(
+            "virtiofs bridge: device reset did not complete during start failure cleanup tag='{}' dev={:?}; keep transport unavailable",
+            instance.tag(),
+            instance.dev_id()
+        );
+        core::mem::forget(transport);
+        core::mem::forget(hiprio_vq);
+        core::mem::forget(request_vqs);
+    }
+}
+
+fn reset_transport_after_start_failure(
+    instance: &Arc<VirtioFsInstance>,
+    mut transport: VirtIOTransport,
+) {
+    transport.set_status(DeviceStatus::empty());
+    if wait_transport_reset_complete(&transport) {
+        transport.set_status(DeviceStatus::FAILED);
+        instance.put_transport_after_session(transport);
+    } else {
+        warn!(
+            "virtiofs bridge: device reset did not complete during start failure tag='{}' dev={:?}; keep transport unavailable",
+            instance.tag(),
+            instance.dev_id()
+        );
+        core::mem::forget(transport);
+    }
+}
+
+fn wait_transport_reset_complete(transport: &VirtIOTransport) -> bool {
+    for _ in 0..VIRTIOFS_RESET_WAIT_SPINS {
+        if transport.get_status().is_empty() {
+            return true;
+        }
+        spin_loop();
+    }
+    false
+}
+
 struct VirtioFsBridgeContext {
     instance: Arc<VirtioFsInstance>,
     conn: Arc<FuseConn>,
     session_id: u64,
     irq_wake_enabled: bool,
     transport: Option<VirtIOTransport>,
-    hiprio_vq: Option<VirtQueue<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>>,
-    request_vqs: Vec<VirtQueue<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>>,
+    hiprio_vq: Option<VirtioFsQueue>,
+    request_vqs: Vec<VirtioFsQueue>,
     hiprio_pending: VecDeque<PendingReq>,
     request_pending: Vec<VecDeque<PendingReq>>,
     hiprio_inflight: BTreeMap<u16, InflightReq>,
@@ -530,7 +760,7 @@ impl VirtioFsBridgeContext {
         let token = match token {
             Ok(token) => token,
             Err(VirtioError::QueueFull) => {
-                stats::on_virtiofs_queue_full();
+                stats::on_virtiofs_queue_full(kind.stats_kind());
                 self.mark_queue_full_blocked(kind)?;
                 let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
                 trace::trace_virtiofs_queue_retry(
@@ -570,19 +800,29 @@ impl VirtioFsBridgeContext {
             }
         };
 
-        if should_notify {
-            self.transport
-                .as_mut()
-                .ok_or(SystemError::EIO)?
-                .notify(queue_idx);
-        }
+        let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
+        let trace_unique = pending.unique;
+        let trace_opcode = pending.opcode;
+        let req_len = pending.req.len();
+        let inflight = InflightReq { pending, rsp };
+        let replaced = match kind {
+            QueueKind::Hiprio => self.hiprio_inflight.insert(token, inflight),
+            QueueKind::Request(slot) => self
+                .request_inflight
+                .get_mut(slot)
+                .ok_or(SystemError::EINVAL)?
+                .insert(token, inflight),
+        };
+        debug_assert!(replaced.is_none());
+        stats::on_virtiofs_inflight_add(kind.stats_kind());
+        stats::on_virtiofs_submitted(req_len);
 
-        stats::on_virtiofs_submitted(pending.req.len());
         let retry_succeeded = {
             let state = self.block_state_mut(kind)?;
             if state.blocked {
                 state.blocked = false;
                 state.completion_seen = false;
+                stats::on_virtiofs_queue_full_unblocked();
                 true
             } else {
                 false
@@ -591,27 +831,22 @@ impl VirtioFsBridgeContext {
         if retry_succeeded {
             stats::on_virtiofs_queue_full_retry_success();
         }
-        let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
+
+        if should_notify {
+            self.transport
+                .as_mut()
+                .ok_or(SystemError::EIO)?
+                .notify(queue_idx);
+        }
+
         trace::trace_virtiofs_submit(
-            pending.unique,
-            pending.opcode,
+            trace_unique,
+            trace_opcode,
             queue_kind,
             queue_slot,
             token,
-            pending.req.len() as u64,
+            req_len as u64,
         );
-        let inflight = InflightReq { pending, rsp };
-        match kind {
-            QueueKind::Hiprio => {
-                self.hiprio_inflight.insert(token, inflight);
-            }
-            QueueKind::Request(slot) => {
-                self.request_inflight
-                    .get_mut(slot)
-                    .ok_or(SystemError::EINVAL)?
-                    .insert(token, inflight);
-            }
-        }
         Ok(true)
     }
 
@@ -691,6 +926,7 @@ impl VirtioFsBridgeContext {
                 return Err(e);
             }
         };
+        stats::on_virtiofs_inflight_remove(kind.stats_kind(), 1);
 
         let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
         trace::trace_virtiofs_complete(
@@ -847,14 +1083,18 @@ impl VirtioFsBridgeContext {
             }
         }
 
+        let hiprio_inflight_count = self.hiprio_inflight.len();
         for (_, req) in self.hiprio_inflight.iter() {
             if !req.pending.noreply {
                 need_reply.push(req.pending.unique);
             }
         }
         self.hiprio_inflight.clear();
+        stats::on_virtiofs_inflight_remove(stats::VirtioFsQueueKind::Hiprio, hiprio_inflight_count);
 
+        let mut request_inflight_count = 0usize;
         for inflight_map in &mut self.request_inflight {
+            request_inflight_count += inflight_map.len();
             for (_, req) in inflight_map.iter() {
                 if !req.pending.noreply {
                     need_reply.push(req.pending.unique);
@@ -862,6 +1102,10 @@ impl VirtioFsBridgeContext {
             }
             inflight_map.clear();
         }
+        stats::on_virtiofs_inflight_remove(
+            stats::VirtioFsQueueKind::Request,
+            request_inflight_count,
+        );
 
         let failed = need_reply.len();
         for unique in need_reply {
@@ -870,9 +1114,90 @@ impl VirtioFsBridgeContext {
         stats::on_virtiofs_fail_unfinished(failed);
     }
 
-    fn reset_device_and_unset_queues(&mut self) {
-        if let Some(transport) = self.transport.as_mut() {
+    fn clear_queue_full_blocked_stats(&mut self) {
+        if self.hiprio_blocked.blocked {
+            self.hiprio_blocked.blocked = false;
+            self.hiprio_blocked.completion_seen = false;
+            stats::on_virtiofs_queue_full_unblocked();
+        }
+
+        for state in &mut self.request_blocked {
+            if state.blocked {
+                state.blocked = false;
+                state.completion_seen = false;
+                stats::on_virtiofs_queue_full_unblocked();
+            }
+        }
+    }
+
+    fn detach_inflight_descriptors_for_queue(
+        queue: &mut VirtioFsQueue,
+        inflight: &mut BTreeMap<u16, InflightReq>,
+        kind: QueueKind,
+    ) {
+        for (token, req) in inflight.iter_mut() {
+            let inputs = [req.pending.req.as_slice()];
+            let result = if let Some(rsp_buf) = req.rsp.as_mut() {
+                let mut outputs = [rsp_buf.as_mut_slice()];
+                // SAFETY: The caller invokes this only after the device reset completed, so the
+                // device can no longer access the queue. The buffers come from the same InflightReq
+                // that was inserted immediately after `VirtQueue::add` returned this token.
+                unsafe { queue.detach_unused(*token, &inputs, &mut outputs) }
+            } else {
+                let mut outputs: [&mut [u8]; 0] = [];
+                // SAFETY: Same as above; this request had no device-writable response buffer.
+                unsafe { queue.detach_unused(*token, &inputs, &mut outputs) }
+            };
+
+            if let Err(e) = result {
+                warn!(
+                    "virtiofs bridge: failed to detach inflight descriptor token={} queue={:?} unique={} err={:?}",
+                    token, kind, req.pending.unique, e
+                );
+            }
+        }
+    }
+
+    fn detach_inflight_descriptors_after_reset(&mut self) {
+        if let Some(queue) = self.hiprio_vq.as_mut() {
+            Self::detach_inflight_descriptors_for_queue(
+                queue,
+                &mut self.hiprio_inflight,
+                QueueKind::Hiprio,
+            );
+        }
+
+        for slot in 0..self.request_vqs.len() {
+            if let Some(inflight) = self.request_inflight.get_mut(slot) {
+                Self::detach_inflight_descriptors_for_queue(
+                    &mut self.request_vqs[slot],
+                    inflight,
+                    QueueKind::Request(slot),
+                );
+            }
+        }
+    }
+
+    fn reset_device_and_unset_queues(&mut self) -> bool {
+        let reset_complete = if let Some(transport) = self.transport.as_mut() {
             transport.set_status(DeviceStatus::empty());
+            wait_transport_reset_complete(transport)
+        } else {
+            return true;
+        };
+
+        if !reset_complete {
+            warn!(
+                "virtiofs bridge: device reset did not complete before queue cleanup tag='{}' dev={:?}; keep queues and transport unavailable",
+                self.instance.tag(),
+                self.instance.dev_id()
+            );
+            return false;
+        } else {
+            self.detach_inflight_descriptors_after_reset();
+        }
+
+        if let Some(transport) = self.transport.as_mut() {
             if self.hiprio_vq.take().is_some() {
                 transport.queue_unset(self.instance.hiprio_queue_index());
             }
@@ -883,6 +1208,8 @@ impl VirtioFsBridgeContext {
             }
             self.request_vqs.clear();
         }
+
+        true
     }
 
     fn run_loop(&mut self) -> Result<(), SystemError> {
@@ -935,16 +1262,30 @@ impl VirtioFsBridgeContext {
         Ok(())
     }
 
-    fn finish(&mut self) {
+    fn finish(&mut self) -> bool {
         if self.irq_wake_enabled {
             self.instance.disable_irq_wake();
         }
+        self.clear_queue_full_blocked_stats();
         self.instance.clear_bridge_wake(self.session_id);
-        self.reset_device_and_unset_queues();
+        if !self.reset_device_and_unset_queues() {
+            return false;
+        }
         self.fail_all_unfinished(SystemError::ENOTCONN);
 
         if let Some(transport) = self.transport.take() {
             self.instance.put_transport_after_session(transport);
+        }
+
+        true
+    }
+}
+
+impl QueueKind {
+    fn stats_kind(self) -> stats::VirtioFsQueueKind {
+        match self {
+            QueueKind::Hiprio => stats::VirtioFsQueueKind::Hiprio,
+            QueueKind::Request(_) => stats::VirtioFsQueueKind::Request,
         }
     }
 }
@@ -955,7 +1296,10 @@ fn virtiofs_bridge_thread_entry(arg: usize) -> i32 {
     if let Err(e) = &result {
         warn!("virtiofs bridge thread exit with error: {:?}", e);
     }
-    ctx.finish();
+    let safe_to_drop = ctx.finish();
+    if !safe_to_drop {
+        Box::leak(ctx);
+    }
     result.map(|_| 0).unwrap_or_else(|e| e.to_posix_errno())
 }
 
@@ -992,50 +1336,133 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
             instance.dev_id(),
             status
         );
-        transport.set_status(DeviceStatus::FAILED);
-        instance.put_transport_after_session(transport);
+        reset_transport_after_start_failure(&instance, transport);
         return Err(SystemError::ENODEV);
     }
     transport.set_guest_page_size(PAGE_SIZE as u32);
 
-    let mut hiprio_vq = match VirtQueue::<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>::new(
-        &mut transport,
-        instance.hiprio_queue_index(),
-        false,
-        false,
-    ) {
-        Ok(vq) => vq,
-        Err(e) => {
-            let se = virtio_drivers_error_to_system_error(e);
-            transport.set_status(DeviceStatus::FAILED);
-            instance.put_transport_after_session(transport);
-            return Err(se);
-        }
-    };
-    hiprio_vq.set_dev_notify(true);
-
-    let mut request_vqs = Vec::with_capacity(instance.request_queue_count());
-    for slot in 0..instance.request_queue_count() {
-        let idx = instance
-            .request_queue_index_by_slot(slot)
-            .ok_or(SystemError::EINVAL)?;
-        let mut vq = match VirtQueue::<HalImpl, { VIRTIOFS_REQ_QUEUE_SIZE }>::new(
-            &mut transport,
-            idx,
-            false,
-            false,
-        ) {
-            Ok(vq) => vq,
+    let (hiprio_vq, hiprio_device_max, hiprio_size) =
+        match create_queue(&mut transport, instance.hiprio_queue_index()) {
+            Ok(v) => v,
             Err(e) => {
-                let se = virtio_drivers_error_to_system_error(e);
-                transport.set_status(DeviceStatus::FAILED);
-                instance.put_transport_after_session(transport);
-                return Err(se);
+                warn!(
+                    "virtiofs bridge: failed to create hiprio queue tag='{}' dev={:?}: {:?}",
+                    instance.tag(),
+                    instance.dev_id(),
+                    e
+                );
+                reset_transport_after_start_failure(&instance, transport);
+                return Err(e);
             }
         };
-        vq.set_dev_notify(true);
+
+    let mut request_vqs = Vec::with_capacity(instance.request_queue_count());
+    let mut request_indices = Vec::with_capacity(instance.request_queue_count());
+    let mut request_size_min = usize::MAX;
+    let mut request_size_max = 0usize;
+    let mut device_queue_depth_max = hiprio_device_max;
+
+    for slot in 0..instance.request_queue_count() {
+        let idx = match instance.request_queue_index_by_slot(slot) {
+            Some(idx) => idx,
+            None => {
+                put_transport_after_start_failure(
+                    &instance,
+                    transport,
+                    hiprio_vq,
+                    request_vqs,
+                    instance.hiprio_queue_index(),
+                    &request_indices,
+                );
+                return Err(SystemError::EINVAL);
+            }
+        };
+
+        let (vq, device_max, queue_size) = match create_queue(&mut transport, idx) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    "virtiofs bridge: failed to create request queue slot={} idx={} tag='{}' dev={:?}: {:?}",
+                    slot,
+                    idx,
+                    instance.tag(),
+                    instance.dev_id(),
+                    e
+                );
+                put_transport_after_start_failure(
+                    &instance,
+                    transport,
+                    hiprio_vq,
+                    request_vqs,
+                    instance.hiprio_queue_index(),
+                    &request_indices,
+                );
+                return Err(e);
+            }
+        };
+
+        request_indices.push(idx);
+        request_size_min = core::cmp::min(request_size_min, queue_size);
+        request_size_max = core::cmp::max(request_size_max, queue_size);
+        device_queue_depth_max = core::cmp::max(device_queue_depth_max, device_max);
         request_vqs.push(vq);
     }
+
+    let Some(sg_limit_pages) = request_size_min.checked_sub(FUSE_HEADER_OVERHEAD) else {
+        put_transport_after_start_failure(
+            &instance,
+            transport,
+            hiprio_vq,
+            request_vqs,
+            instance.hiprio_queue_index(),
+            &request_indices,
+        );
+        return Err(SystemError::EINVAL);
+    };
+    if sg_limit_pages == 0 {
+        put_transport_after_start_failure(
+            &instance,
+            transport,
+            hiprio_vq,
+            request_vqs,
+            instance.hiprio_queue_index(),
+            &request_indices,
+        );
+        return Err(SystemError::EINVAL);
+    }
+    let max_pages_limit = core::cmp::min(sg_limit_pages, FUSE_MAX_MAX_PAGES);
+    if let Err(e) = conn.set_max_pages_limit(max_pages_limit) {
+        put_transport_after_start_failure(
+            &instance,
+            transport,
+            hiprio_vq,
+            request_vqs,
+            instance.hiprio_queue_index(),
+            &request_indices,
+        );
+        return Err(e);
+    }
+
+    stats::on_virtiofs_queue_configured(
+        device_queue_depth_max,
+        hiprio_size,
+        request_vqs.len(),
+        request_size_min,
+        request_size_max,
+        max_pages_limit,
+    );
+
+    info!(
+        "virtiofs bridge: queue config tag='{}' dev={:?} hiprio_vring={} request_queues={} request_vring_min={} request_vring_max={} sg_limit_pages={}",
+        instance.tag(),
+        instance.dev_id(),
+        hiprio_size,
+        request_vqs.len(),
+        request_size_min,
+        request_size_max,
+        max_pages_limit
+    );
+
     transport.finish_init();
 
     instance.install_bridge_wake(session_id, &conn);
@@ -1076,7 +1503,10 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
     .is_none()
     {
         let mut ctx = unsafe { Box::from_raw(raw) };
-        ctx.finish();
+        let safe_to_drop = ctx.finish();
+        if !safe_to_drop {
+            Box::leak(ctx);
+        }
         return Err(SystemError::ENOMEM);
     }
 
@@ -1334,7 +1764,7 @@ mod tests {
 
     use system_error::SystemError;
 
-    use super::{QueueBlockState, VirtioFsBridgeContext};
+    use super::{choose_queue_size, QueueBlockState, VirtioFsBridgeContext};
 
     fn block_state(blocked: bool, completion_seen: bool) -> QueueBlockState {
         QueueBlockState {
@@ -1422,5 +1852,14 @@ mod tests {
             Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
         ));
         assert_eq!(next, 0);
+    }
+
+    #[test]
+    fn choose_queue_size_uses_supported_power_of_two() {
+        assert_eq!(choose_queue_size(8).unwrap(), 8);
+        assert_eq!(choose_queue_size(15).unwrap(), 8);
+        assert_eq!(choose_queue_size(128).unwrap(), 128);
+        assert_eq!(choose_queue_size(2048).unwrap(), 1024);
+        assert_eq!(choose_queue_size(7), Err(SystemError::EINVAL));
     }
 }

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -16,6 +16,8 @@
 # - DRAGONOS_VIRTIOFS_SOCKET: virtiofsd socket路径
 # - DRAGONOS_VIRTIOFS_TAG: virtiofs 挂载tag
 # - DRAGONOS_VIRTIOFS_ENV_FILE: virtiofs配置文件路径（默认 ${ROOT_PATH}/tools/virtiofs/env.sh）
+# - DRAGONOS_VIRTIOFS_QUEUE_SIZE: (optional) queue-size passed to vhost-user-fs-pci
+# - DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES: (optional) num-request-queues passed to vhost-user-fs-pci
 #
 
 check_dependencies()
@@ -129,6 +131,8 @@ DRAGONOS_VIRTIOFS_ENABLE=${DRAGONOS_VIRTIOFS_ENABLE:=0}
 DRAGONOS_VIRTIOFS_SOCKET=${DRAGONOS_VIRTIOFS_SOCKET:=/tmp/dragonos-virtiofsd.sock}
 DRAGONOS_VIRTIOFS_TAG=${DRAGONOS_VIRTIOFS_TAG:=hostshare}
 DRAGONOS_VIRTIOFS_ENV_FILE=${DRAGONOS_VIRTIOFS_ENV_FILE:=}
+DRAGONOS_VIRTIOFS_QUEUE_SIZE=${DRAGONOS_VIRTIOFS_QUEUE_SIZE:=}
+DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES=${DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES:=}
 
 # 检查必要的环境变量
 if [ -z "${ROOT_PATH}" ]; then
@@ -556,14 +560,34 @@ if [ "${DRAGONOS_VIRTIOFS_ENABLE}" == "1" ]; then
         exit 1
     fi
 
-    echo "[INFO] 启用virtiofs: tag=${DRAGONOS_VIRTIOFS_TAG}, socket=${DRAGONOS_VIRTIOFS_SOCKET}"
+    virtiofs_device_opts="vhost-user-fs-pci,chardev=char_virtiofs,tag=${DRAGONOS_VIRTIOFS_TAG}"
+    if [ -n "${DRAGONOS_VIRTIOFS_QUEUE_SIZE}" ]; then
+        if ! [[ "${DRAGONOS_VIRTIOFS_QUEUE_SIZE}" =~ ^[0-9]+$ ]] || [ "${DRAGONOS_VIRTIOFS_QUEUE_SIZE}" -eq 0 ]; then
+            echo "[ERROR] DRAGONOS_VIRTIOFS_QUEUE_SIZE must be a positive integer"
+            exit 1
+        fi
+        virtiofs_device_opts="${virtiofs_device_opts},queue-size=${DRAGONOS_VIRTIOFS_QUEUE_SIZE}"
+    fi
+    if [ -n "${DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES}" ]; then
+        if ! [[ "${DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES}" =~ ^[0-9]+$ ]] || [ "${DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES}" -eq 0 ]; then
+            echo "[ERROR] DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES must be a positive integer"
+            exit 1
+        fi
+        if [ "${DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES}" -gt 64 ]; then
+            echo "[ERROR] DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES cannot exceed 64"
+            exit 1
+        fi
+        virtiofs_device_opts="${virtiofs_device_opts},num-request-queues=${DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES}"
+    fi
+
+    echo "[INFO] Enabling virtiofs: tag=${DRAGONOS_VIRTIOFS_TAG}, socket=${DRAGONOS_VIRTIOFS_SOCKET}, queue_size=${DRAGONOS_VIRTIOFS_QUEUE_SIZE:-qemu-default}, request_queues=${DRAGONOS_VIRTIOFS_NUM_REQUEST_QUEUES:-qemu-default}"
 
     QEMU_OBJECT_ARGS+=(
       -object "memory-backend-memfd,id=mem,size=${QEMU_MEMORY},share=on"
     )
     QEMU_NUMA_ARGS+=(-numa "node,memdev=mem")
     QEMU_CHARDEV_ARGS+=(-chardev "socket,id=char_virtiofs,path=${DRAGONOS_VIRTIOFS_SOCKET}")
-    QEMU_DEVICE_ARGS+=(-device "vhost-user-fs-pci,chardev=char_virtiofs,tag=${DRAGONOS_VIRTIOFS_TAG}")
+    QEMU_DEVICE_ARGS+=(-device "${virtiofs_device_opts}")
 fi
 
 

--- a/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
+++ b/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
@@ -134,6 +134,19 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "read_buffer_too_small_total ");
 
     expect_field(whole, "[virtiofs]\n");
+    expect_field(whole, "device_queue_depth_max ");
+    expect_field(whole, "hiprio_vring_size_configured ");
+    expect_field(whole, "request_queue_count_configured ");
+    expect_field(whole, "request_vring_size_min_configured ");
+    expect_field(whole, "request_vring_size_max_configured ");
+    expect_field(whole, "sg_limit_pages_configured ");
+    expect_field(whole, "inflight_current ");
+    expect_field(whole, "inflight_peak ");
+    expect_field(whole, "hiprio_inflight_current ");
+    expect_field(whole, "hiprio_inflight_peak ");
+    expect_field(whole, "request_inflight_current ");
+    expect_field(whole, "request_inflight_peak ");
+    expect_field(whole, "queue_full_blocked_current ");
     expect_field(whole, "bridge_loop_iterations_total ");
     expect_field(whole, "bridge_idle_sleeps_total ");
     expect_field(whole, "virtqueue_full_total ");
@@ -159,6 +172,17 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "bridge_queue_full_retry_total ");
     expect_field(whole, "bridge_queue_full_retry_after_completion_total ");
     expect_field(whole, "bridge_queue_full_retry_success_total ");
+    expect_field(whole, "hiprio_queue_full_total ");
+    expect_field(whole, "request_queue_full_total ");
+
+    EXPECT_GE(parse_counter(whole, "device_queue_depth_max"), 0);
+    EXPECT_GE(parse_counter(whole, "hiprio_vring_size_configured"), 0);
+    EXPECT_GE(parse_counter(whole, "request_queue_count_configured"), 0);
+    EXPECT_GE(parse_counter(whole, "request_vring_size_min_configured"), 0);
+    EXPECT_GE(parse_counter(whole, "request_vring_size_max_configured"), 0);
+    EXPECT_GE(parse_counter(whole, "sg_limit_pages_configured"), 0);
+    EXPECT_GE(parse_counter(whole, "inflight_current"), 0);
+    EXPECT_GE(parse_counter(whole, "inflight_peak"), 0);
 
     expect_counter_increased(whole, after_fuse, "requests_queued_total");
     expect_counter_increased(whole, after_fuse, "requests_dequeued_total");


### PR DESCRIPTION
## Summary

- replace the fixed eight-entry virtiofs queues with boxed queue variants selected from transport-reported capacity, supporting power-of-two depths from 8 through 1024
- constrain FUSE `max_pages` using the smallest configured request vring and Linux-compatible descriptor overhead while preserving independent `max_write` negotiation
- make queue-full recovery completion-driven, preserve in-flight DMA ownership across reset, and expose queue capacity, in-flight, and retry metrics through debugfs
- add QEMU queue controls, benchmark documentation, dunitest coverage, and update `virtio-drivers` to upstream commit `89f6a402d494cf615cadfd851c9f017f31acac81`

## Root cause

DragonOS instantiated every virtiofs queue as `VirtQueue<HalImpl, 8>`. The compile-time size became the actual vring size, so devices advertising larger queues were still restricted to eight descriptors. FUSE request sizing also lacked the Linux virtiofs rule that reserves descriptor overhead and derives the page limit from the request vring.

## Behavior

The bridge now selects the largest supported power-of-two queue that does not exceed the transport capacity. Queue construction happens directly on the heap, avoiding large temporary queue values on the kernel stack. The minimum request queue capacity controls the FUSE page limit, and read/write request chunking observes both the negotiated byte limit and page limit.

Full queues retain their requests and wait for a completion before retrying. Teardown resets the device before detaching unused descriptors, so request and response buffers remain owned while DMA may still be active. New debugfs counters expose configured queue sizes, SG limits, current and peak in-flight requests, and queue-full retry outcomes.

## Validation

- `make fmt`
- `make kernel`
- `make user`
- `SKIP_GRUB=1 make write_diskimage`
- kernel `cargo check` with all features for `x86_64-unknown-none`
- `FuseStatsDebugFs.StatsFileExistsAndSupportsOffsetReads`
- `VirtioFsSmoke.MountReadExecAndOverlayLower`
- real virtiofs mount, host-to-guest read, guest-to-host write, mmap/exec, and overlay-lower checks at queue depths 8, 128, and 1024
- three complete benchmark runs each at queue depths 8 and 128; all 36 workload results completed with `status=ok errno=0`
- 16-worker queue-depth-8 stress run: 124 queue-full events, 124 completion-driven retries, 124 successful retries, and final submitted/completed counts of 33305/33305 with zero in-flight requests

## Performance results

The same complete workload was run three times at queue depths 8 and 128 with 256 files, a 4 MiB file size, 4 KiB blocks, 4096 iterations, and 4 workers. The table reports the median elapsed time. A positive change means queue depth 128 was faster.

| Workload | Queue 8 median | Queue 128 median | Queue 8 throughput | Queue 128 throughput | Change |
| --- | ---: | ---: | ---: | ---: | ---: |
| Metadata, 768 ops | 4.040 s | 4.097 s | 190.1 ops/s | 187.5 ops/s | -1.42% |
| Sequential write, 4 MiB | 1.319 s | 1.236 s | 3.03 MiB/s | 3.24 MiB/s | +6.31% |
| Sequential read, 4 MiB | 1.453 s | 1.426 s | 2.75 MiB/s | 2.81 MiB/s | +1.91% |
| Random read, 16 MiB | 3.295 s | 3.087 s | 4.86 MiB/s | 5.18 MiB/s | +6.30% |
| mmap scan, 4 MiB | 0.381 s | 0.101 s | 10.50 MiB/s | 39.77 MiB/s | +73.59% |
| Concurrent write, 64 MiB | 12.828 s | 12.921 s | 4.99 MiB/s | 4.95 MiB/s | -0.72% |

The read-side improvements correspond to fewer bridge requests rather than timing alone. In representative runs, random-read completions fell from 509 at queue depth 8 to 160/161 at queue depth 128, and mmap completions fell from 263 to 71. This matches the negotiated SG page limit increasing from 4 to 124 pages, allowing each request to carry more data.

The queue-full path was tested separately at queue depth 8 with 16 workers, 2048 iterations per worker, and 128 MiB total writes. It completed 32768 write operations in 25.847 s and produced 124 queue-full events. All 124 retries occurred after completions and all 124 succeeded. Final bridge counters were submitted/completed=33305/33305, with zero in-flight or blocked requests and no submit, pop-used, or unfinished-request errors.

The metadata and concurrent-write differences are within the noise of this three-run comparison and are not claimed as significant improvements. These results validate that the new capacity affects real request sizing and does not introduce an observable regression; they are not a release-grade benchmark with cold-cache isolation, confidence intervals, a Linux guest baseline, or a long soak run.

Multiple request queues can be configured and constructed, but end-to-end multi-queue I/O was not claimed because the available virtiofsd backend supports only one request queue and rejects additional queues with `InvalidParam`.

Closes #2014
