### PR TITLE
fix(overlayfs): preserve whiteouts for copied-up lower entries

### DIFF
--- a/kernel/src/filesystem/overlayfs/dir.rs
+++ b/kernel/src/filesystem/overlayfs/dir.rs
@@ -21,56 +21,51 @@ pub(super) fn mkdir(
 }
 
 pub(super) fn rmdir(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
-    let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
-    if let Some(ref upper_inode) = *inode.upper_inode.lock() {
-        match upper_inode.rmdir(name) {
-            Ok(()) => return Ok(()),
-            Err(SystemError::ENOENT) => {}
-            Err(err) => return Err(err),
-        }
-    }
-
-    match inode.find(name) {
-        Ok(found) => {
-            if found.metadata()?.file_type != FileType::Dir {
-                return Err(SystemError::ENOTDIR);
-            }
-            if !is_dir_empty(&found)? {
-                return Err(SystemError::ENOTEMPTY);
-            }
-            return inode.create_whiteout_locked(name);
-        }
-        Err(SystemError::ENOENT) => {}
-        Err(err) => return Err(err),
-    }
-
-    Err(SystemError::ENOENT)
+    remove(inode, name, true)
 }
 
 pub(super) fn unlink(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
+    remove(inode, name, false)
+}
+
+fn remove(inode: &OvlInode, name: &str, is_dir: bool) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
-    if let Some(ref upper_inode) = *inode.upper_inode.lock() {
-        match upper_inode.unlink(name) {
-            Ok(()) => return Ok(()),
+
+    let child = inode.lookup_overlay_child(name)?;
+    if is_dir && !child.is_dir() {
+        return Err(SystemError::ENOTDIR);
+    }
+    if !is_dir && child.is_dir() {
+        return Err(SystemError::EISDIR);
+    }
+
+    let lower_positive = inode.lower_positive(name);
+    if is_dir && (lower_positive || child.has_lower()) {
+        let child_inode: Arc<dyn IndexNode> = child.clone();
+        if !is_dir_empty(&child_inode)? {
+            return Err(SystemError::ENOTEMPTY);
+        }
+    }
+
+    let upper_dir = inode.upper_inode.lock().clone();
+    if let Some(upper_dir) = upper_dir {
+        match upper_dir.find(name) {
+            Ok(_) if lower_positive => {
+                return inode.replace_upper_with_whiteout_locked(name, is_dir);
+            }
+            Ok(_) if is_dir => return upper_dir.rmdir(name),
+            Ok(_) => return upper_dir.unlink(name),
             Err(SystemError::ENOENT) => {}
             Err(err) => return Err(err),
         }
     }
 
-    match inode.find(name) {
-        Ok(found) => {
-            if found.metadata()?.file_type == FileType::Dir {
-                return Err(SystemError::EISDIR);
-            }
-            return inode.create_whiteout_locked(name);
-        }
-        Err(SystemError::ENOENT) => {}
-        Err(err) => return Err(err),
+    if lower_positive {
+        inode.create_whiteout_locked(name)
+    } else {
+        Err(SystemError::ENOENT)
     }
-
-    Err(SystemError::ENOENT)
 }
 
 pub(super) fn link(

--- a/kernel/src/filesystem/overlayfs/lookup.rs
+++ b/kernel/src/filesystem/overlayfs/lookup.rs
@@ -4,6 +4,27 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
+impl OvlInode {
+    pub(super) fn lower_positive(&self, name: &str) -> bool {
+        for lower in &self.lower_inodes {
+            match lower.find(name) {
+                Ok(found) => {
+                    // A metadata failure must not turn a possibly positive lower entry into a
+                    // pure-upper decision. Linux makes the same conservative choice for lower
+                    // lookup errors in ovl_lower_positive().
+                    return match Self::is_whiteout_inode_checked(&found) {
+                        Ok(is_whiteout) => !is_whiteout,
+                        Err(_) => true,
+                    };
+                }
+                Err(SystemError::ENOENT) | Err(SystemError::ENAMETOOLONG) => continue,
+                Err(_) => return true,
+            }
+        }
+        false
+    }
+}
+
 pub(super) fn find(
     inode: &OvlInode,
     name: &str,

--- a/kernel/src/filesystem/overlayfs/rename.rs
+++ b/kernel/src/filesystem/overlayfs/rename.rs
@@ -55,8 +55,9 @@ pub(super) fn move_to(
         return Ok(());
     }
 
-    let source_needs_whiteout = source.has_lower();
-    if source_needs_whiteout && source.is_dir() {
+    let source_needs_whiteout = inode.lower_positive(old_name);
+    let source_has_lower_tree = source.is_dir() && source.has_lower();
+    if source_has_lower_tree {
         return Err(SystemError::EXDEV);
     }
 
@@ -84,6 +85,14 @@ pub(super) fn move_to(
     let mut upper_flags = flags;
     if target_had_whiteout {
         upper_flags.remove(RenameFlags::NOREPLACE);
+        if source_needs_whiteout {
+            return old_upper_dir.move_to(
+                old_name,
+                &new_upper_dir,
+                new_name,
+                RenameFlags::EXCHANGE,
+            );
+        }
         if source.is_dir() {
             old_upper_dir.move_to(old_name, &new_upper_dir, new_name, RenameFlags::EXCHANGE)?;
             OvlInode::cleanup_workdir_temp(&old_upper_dir, old_name);

--- a/kernel/src/filesystem/overlayfs/whiteout.rs
+++ b/kernel/src/filesystem/overlayfs/whiteout.rs
@@ -1,19 +1,21 @@
 use super::inode::OvlInode;
 use crate::driver::base::device::device_number::{DeviceNumber, Major};
 use crate::filesystem::vfs::{self, FileType, IndexNode};
-use alloc::sync::Arc;
+use alloc::{string::String, sync::Arc, vec::Vec};
 use system_error::SystemError;
 
 pub(super) const WHITEOUT_DEV: DeviceNumber = DeviceNumber::new(Major::UNNAMED_MAJOR, 0);
 
 impl OvlInode {
+    pub(super) fn is_whiteout_inode_checked(
+        inode: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        let metadata = inode.metadata()?;
+        Ok(metadata.file_type == FileType::CharDevice && metadata.raw_dev == WHITEOUT_DEV)
+    }
+
     pub(super) fn is_whiteout_inode(inode: &Arc<dyn IndexNode>) -> bool {
-        inode
-            .metadata()
-            .map(|metadata| {
-                metadata.file_type == FileType::CharDevice && metadata.raw_dev == WHITEOUT_DEV
-            })
-            .unwrap_or(false)
+        Self::is_whiteout_inode_checked(inode).unwrap_or(false)
     }
 
     pub(super) fn create_whiteout_locked(&self, name: &str) -> Result<(), SystemError> {
@@ -30,6 +32,98 @@ impl OvlInode {
             return Ok(());
         }
         Err(SystemError::EROFS)
+    }
+
+    pub(super) fn replace_upper_with_whiteout_locked(
+        &self,
+        name: &str,
+        is_dir: bool,
+    ) -> Result<(), SystemError> {
+        let upper_dir = self.writable_upper_inode_locked()?;
+        let upper_entry = upper_dir.find(name)?;
+        let internal_whiteouts = if is_dir {
+            Some(Self::validated_whiteout_entries(&upper_entry)?)
+        } else {
+            None
+        };
+
+        let whiteout_mode = vfs::InodeMode::S_IFCHR;
+        let (workdir, _, temp_name) = self.create_workdir_temp(|workdir, temp_name| {
+            workdir.mknod(temp_name, whiteout_mode, WHITEOUT_DEV)
+        })?;
+        let flags = if is_dir {
+            vfs::syscall::RenameFlags::EXCHANGE
+        } else {
+            vfs::syscall::RenameFlags::empty()
+        };
+
+        if let Err(err) = workdir.move_to(&temp_name, &upper_dir, name, flags) {
+            Self::cleanup_workdir_temp(&workdir, &temp_name);
+            return Err(err);
+        }
+
+        if let Some(entries) = internal_whiteouts {
+            Self::cleanup_detached_whiteout_dir(&workdir, &temp_name, &entries);
+        }
+        Ok(())
+    }
+
+    fn validated_whiteout_entries(dir: &Arc<dyn IndexNode>) -> Result<Vec<String>, SystemError> {
+        let mut whiteouts = Vec::new();
+        for name in dir.list()? {
+            if name == "." || name == ".." {
+                continue;
+            }
+            let entry = dir.find(&name)?;
+            if !Self::is_whiteout_inode_checked(&entry)? {
+                return Err(SystemError::ENOTEMPTY);
+            }
+            whiteouts.push(name);
+        }
+        Ok(whiteouts)
+    }
+
+    fn cleanup_detached_whiteout_dir(
+        workdir: &Arc<dyn IndexNode>,
+        temp_name: &str,
+        entries: &[String],
+    ) {
+        let detached = match workdir.find(temp_name) {
+            Ok(detached) => detached,
+            Err(err) => {
+                log::error!(
+                    "overlayfs: failed to find detached upper directory {temp_name}: {err:?}"
+                );
+                return;
+            }
+        };
+
+        for name in entries {
+            let still_whiteout = detached
+                .find(name)
+                .and_then(|entry| Self::is_whiteout_inode_checked(&entry));
+            match still_whiteout {
+                Ok(true) => {
+                    if let Err(err) = detached.unlink(name) {
+                        log::error!(
+                            "overlayfs: failed to remove detached whiteout {temp_name}/{name}: {err:?}"
+                        );
+                    }
+                }
+                Ok(false) => log::error!(
+                    "overlayfs: detached entry {temp_name}/{name} is no longer a whiteout"
+                ),
+                Err(err) => log::error!(
+                    "overlayfs: failed to revalidate detached whiteout {temp_name}/{name}: {err:?}"
+                ),
+            }
+        }
+
+        if let Err(err) = workdir.rmdir(temp_name) {
+            log::error!(
+                "overlayfs: failed to remove detached upper directory {temp_name}: {err:?}"
+            );
+        }
     }
 
     #[allow(dead_code)]

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <sched.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mount.h>
@@ -14,6 +15,8 @@
 #include <sys/wait.h>
 #include <algorithm>
 #include <string>
+#include <utility>
+#include <vector>
 #include <unistd.h>
 
 namespace {
@@ -49,6 +52,13 @@ std::string join_path(const std::string& dir, const char* name) {
 bool path_exists(const std::string& path) {
     struct stat st = {};
     return stat(path.c_str(), &st) == 0;
+}
+
+void expect_path_enoent(const std::string& path) {
+    struct stat st = {};
+    errno = 0;
+    EXPECT_EQ(-1, lstat(path.c_str(), &st));
+    EXPECT_EQ(ENOENT, errno) << path << ": " << strerror(errno);
 }
 
 bool is_whiteout(const std::string& path) {
@@ -235,6 +245,22 @@ struct ScopedOverlayEnv {
     OverlayRenameEnv env;
 };
 
+struct ScopedCustomMount {
+    ScopedCustomMount(std::string root_path, std::string merged_path)
+        : root(std::move(root_path)), merged(std::move(merged_path)) {}
+
+    ~ScopedCustomMount() {
+        if (mounted) {
+            umount(merged.c_str());
+        }
+        remove_recursive(root);
+    }
+
+    std::string root;
+    std::string merged;
+    bool mounted = false;
+};
+
 bool setup_overlay_env(const OverlayRenameEnv& env) {
     if (ensure_dir("/tmp") != 0 || ensure_dir(env.root.c_str()) != 0
         || ensure_dir(env.upper.c_str()) != 0 || ensure_dir(env.lower.c_str()) != 0
@@ -249,6 +275,15 @@ bool setup_overlay_env(const OverlayRenameEnv& env) {
         return false;
     }
     return true;
+}
+
+void prepare_overlay_env(const OverlayRenameEnv& env) {
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
 }
 
 void expect_truncate_copy_up_drops_privileged_bits(const char* name, const char* lower_text) {
@@ -1625,6 +1660,422 @@ TEST(OverlayFsSemantics, LowerOnlyFileRenameCopiesUpAndWhiteoutsOldPath) {
     EXPECT_TRUE(is_whiteout(upper_old));
     EXPECT_EQ("lower-old", read_text(upper_new));
     cleanup_overlay_env(env);
+}
+
+TEST(OverlayFsSemantics, CopiedUpLowerFileUnlinkKeepsOldNameHidden) {
+    ScopedOverlayEnv scoped("overlayfs_copied_up_unlink_whiteout");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, write_text(lower_file, "lower-original"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_file, "copied-up")) << strerror(errno);
+    ASSERT_EQ("copied-up", read_text(upper_file));
+
+    ASSERT_EQ(0, unlink(merged_file.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_file);
+    EXPECT_EQ("lower-original", read_text(lower_file));
+    EXPECT_TRUE(is_whiteout(upper_file));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopiedUpLowerFileRenameKeepsOldNameHidden) {
+    ScopedOverlayEnv scoped("overlayfs_copied_up_rename_whiteout");
+    const auto& env = scoped.env;
+    std::string lower_old = join_path(env.lower, "old");
+    std::string upper_old = join_path(env.upper, "old");
+    std::string upper_new = join_path(env.upper, "new");
+    std::string merged_old = join_path(env.merged, "old");
+    std::string merged_new = join_path(env.merged, "new");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, write_text(lower_old, "lower-original"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_old, "copied-up")) << strerror(errno);
+
+    ASSERT_EQ(0, rename(merged_old.c_str(), merged_new.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_old);
+    EXPECT_EQ("copied-up", read_text(merged_new));
+    EXPECT_EQ("lower-original", read_text(lower_old));
+    EXPECT_TRUE(is_whiteout(upper_old));
+    EXPECT_EQ("copied-up", read_text(upper_new));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, RmdirCleansDetachedUpperChildWhiteouts) {
+    ScopedOverlayEnv scoped("overlayfs_rmdir_internal_whiteouts");
+    const auto& env = scoped.env;
+    std::string lower_dir = join_path(env.lower, "dir");
+    std::string lower_child = join_path(lower_dir, "child");
+    std::string upper_dir = join_path(env.upper, "dir");
+    std::string upper_child = join_path(upper_dir, "child");
+    std::string merged_dir = join_path(env.merged, "dir");
+    std::string merged_child = join_path(merged_dir, "child");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, mkdir(lower_dir.c_str(), 0755));
+    ASSERT_EQ(0, write_text(lower_child, "lower-child"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, unlink(merged_child.c_str())) << strerror(errno);
+    ASSERT_TRUE(is_whiteout(upper_child));
+
+    ASSERT_EQ(0, rmdir(merged_dir.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_dir);
+    EXPECT_TRUE(is_whiteout(upper_dir));
+    EXPECT_EQ("lower-child", read_text(lower_child));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, UpperFileOverLowerDirUnlinkLeavesWhiteout) {
+    ScopedOverlayEnv scoped("overlayfs_upper_file_lower_dir_unlink");
+    const auto& env = scoped.env;
+    std::string upper_entry = join_path(env.upper, "entry");
+    std::string lower_entry = join_path(env.lower, "entry");
+    std::string merged_entry = join_path(env.merged, "entry");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, write_text(upper_entry, "upper-file"));
+    ASSERT_EQ(0, mkdir(lower_entry.c_str(), 0755));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, rmdir(merged_entry.c_str()));
+    EXPECT_EQ(ENOTDIR, errno);
+    EXPECT_EQ("upper-file", read_text(merged_entry));
+
+    ASSERT_EQ(0, unlink(merged_entry.c_str())) << strerror(errno);
+    expect_path_enoent(merged_entry);
+    EXPECT_TRUE(is_whiteout(upper_entry));
+    EXPECT_TRUE(path_exists(lower_entry));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, UpperDirOverLowerFileRmdirLeavesWhiteout) {
+    ScopedOverlayEnv scoped("overlayfs_upper_dir_lower_file_rmdir");
+    const auto& env = scoped.env;
+    std::string upper_entry = join_path(env.upper, "entry");
+    std::string lower_entry = join_path(env.lower, "entry");
+    std::string merged_entry = join_path(env.merged, "entry");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, mkdir(upper_entry.c_str(), 0755));
+    ASSERT_EQ(0, write_text(lower_entry, "lower-file"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, unlink(merged_entry.c_str()));
+    EXPECT_EQ(EISDIR, errno);
+    EXPECT_TRUE(path_exists(merged_entry));
+
+    ASSERT_EQ(0, rmdir(merged_entry.c_str())) << strerror(errno);
+    expect_path_enoent(merged_entry);
+    EXPECT_TRUE(is_whiteout(upper_entry));
+    EXPECT_EQ("lower-file", read_text(lower_entry));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, UpperDirOverLowerFileRenameLeavesWhiteout) {
+    ScopedOverlayEnv scoped("overlayfs_upper_dir_lower_file_rename");
+    const auto& env = scoped.env;
+    std::string upper_old = join_path(env.upper, "old");
+    std::string upper_new = join_path(env.upper, "new");
+    std::string lower_old = join_path(env.lower, "old");
+    std::string merged_old = join_path(env.merged, "old");
+    std::string merged_new = join_path(env.merged, "new");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, mkdir(upper_old.c_str(), 0755));
+    ASSERT_EQ(0, write_text(lower_old, "lower-file"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(merged_old.c_str(), merged_new.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_old);
+    EXPECT_TRUE(is_whiteout(upper_old));
+    EXPECT_TRUE(path_exists(merged_new));
+    EXPECT_TRUE(path_exists(upper_new));
+    EXPECT_EQ("lower-file", read_text(lower_old));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopiedUpRenameOverTargetWhiteoutExchangesWhiteout) {
+    ScopedOverlayEnv scoped("overlayfs_copied_up_rename_target_whiteout");
+    const auto& env = scoped.env;
+    std::string lower_old = join_path(env.lower, "old");
+    std::string lower_new = join_path(env.lower, "new");
+    std::string upper_old = join_path(env.upper, "old");
+    std::string upper_new = join_path(env.upper, "new");
+    std::string merged_old = join_path(env.merged, "old");
+    std::string merged_new = join_path(env.merged, "new");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, write_text(lower_old, "lower-old"));
+    ASSERT_EQ(0, write_text(lower_new, "lower-new"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_old, "copied-up"));
+    ASSERT_EQ(0, unlink(merged_new.c_str())) << strerror(errno);
+    ASSERT_TRUE(is_whiteout(upper_new));
+
+    ASSERT_EQ(0, renameat2_call(merged_old, merged_new, RENAME_NOREPLACE)) << strerror(errno);
+
+    expect_path_enoent(merged_old);
+    EXPECT_TRUE(is_whiteout(upper_old));
+    EXPECT_EQ("copied-up", read_text(merged_new));
+    EXPECT_EQ("copied-up", read_text(upper_new));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopiedUpCrossDirRenameScansOldLowerParent) {
+    ScopedOverlayEnv scoped("overlayfs_copied_up_cross_dir_rename");
+    const auto& env = scoped.env;
+    std::string lower_a = join_path(env.lower, "a");
+    std::string lower_b = join_path(env.lower, "b");
+    std::string lower_old = join_path(lower_a, "old");
+    std::string merged_a = join_path(env.merged, "a");
+    std::string merged_b = join_path(env.merged, "b");
+    std::string merged_old = join_path(merged_a, "old");
+    std::string merged_new = join_path(merged_b, "new");
+    std::string upper_old = join_path(join_path(env.upper, "a"), "old");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, mkdir(lower_a.c_str(), 0755));
+    ASSERT_EQ(0, mkdir(lower_b.c_str(), 0755));
+    ASSERT_EQ(0, write_text(lower_old, "lower-old"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_old, "copied-up"));
+
+    ASSERT_EQ(0, rename(merged_old.c_str(), merged_new.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_old);
+    EXPECT_TRUE(is_whiteout(upper_old));
+    EXPECT_EQ("copied-up", read_text(merged_new));
+    EXPECT_EQ("lower-old", read_text(lower_old));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, CopiedUpCrossDirRenameOverWhiteoutExchangesWhiteout) {
+    ScopedOverlayEnv scoped("overlayfs_cross_dir_target_whiteout");
+    const auto& env = scoped.env;
+    std::string lower_a = join_path(env.lower, "a");
+    std::string lower_b = join_path(env.lower, "b");
+    std::string lower_old = join_path(lower_a, "old");
+    std::string lower_new = join_path(lower_b, "new");
+    std::string merged_a = join_path(env.merged, "a");
+    std::string merged_b = join_path(env.merged, "b");
+    std::string merged_old = join_path(merged_a, "old");
+    std::string merged_new = join_path(merged_b, "new");
+    std::string upper_old = join_path(join_path(env.upper, "a"), "old");
+    std::string upper_new = join_path(join_path(env.upper, "b"), "new");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, mkdir(lower_a.c_str(), 0755));
+    ASSERT_EQ(0, mkdir(lower_b.c_str(), 0755));
+    ASSERT_EQ(0, write_text(lower_old, "lower-old"));
+    ASSERT_EQ(0, write_text(lower_new, "lower-new"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_old, "copied-up"));
+    ASSERT_EQ(0, unlink(merged_new.c_str())) << strerror(errno);
+    ASSERT_TRUE(is_whiteout(upper_new));
+
+    ASSERT_EQ(0, renameat2_call(merged_old, merged_new, RENAME_NOREPLACE)) << strerror(errno);
+
+    expect_path_enoent(merged_old);
+    EXPECT_TRUE(is_whiteout(upper_old));
+    EXPECT_EQ("copied-up", read_text(merged_new));
+    EXPECT_EQ("copied-up", read_text(upper_new));
+    EXPECT_EQ("lower-old", read_text(lower_old));
+    EXPECT_EQ("lower-new", read_text(lower_new));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, PureUpperUnlinkAndRmdirDoNotCreateWhiteouts) {
+    ScopedOverlayEnv scoped("overlayfs_pure_upper_remove");
+    const auto& env = scoped.env;
+    std::string upper_file = join_path(env.upper, "file");
+    std::string upper_dir = join_path(env.upper, "dir");
+    std::string merged_file = join_path(env.merged, "file");
+    std::string merged_dir = join_path(env.merged, "dir");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, write_text(upper_file, "upper-file"));
+    ASSERT_EQ(0, mkdir(upper_dir.c_str(), 0755));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, unlink(merged_file.c_str())) << strerror(errno);
+    ASSERT_EQ(0, rmdir(merged_dir.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_file);
+    expect_path_enoent(merged_dir);
+    expect_path_enoent(upper_file);
+    expect_path_enoent(upper_dir);
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, LowerWhiteoutMakesCoveredUpperRemovalPureUpper) {
+    std::string root =
+        std::string("/tmp/overlayfs_lower_whiteout_remove_") + std::to_string(getpid());
+    std::string upper = join_path(root, "u");
+    std::string lower_top = join_path(root, "l1");
+    std::string lower_bottom = join_path(root, "l2");
+    std::string work = join_path(root, "w");
+    std::string merged = join_path(root, "m");
+    std::string upper_entry = join_path(upper, "entry");
+    std::string top_entry = join_path(lower_top, "entry");
+    std::string bottom_entry = join_path(lower_bottom, "entry");
+    std::string merged_entry = join_path(merged, "entry");
+    ScopedCustomMount cleanup(root, merged);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(root.c_str()));
+    ASSERT_EQ(0, ensure_dir(upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(lower_top.c_str()));
+    ASSERT_EQ(0, ensure_dir(lower_bottom.c_str()));
+    ASSERT_EQ(0, ensure_dir(work.c_str()));
+    ASSERT_EQ(0, ensure_dir(merged.c_str()));
+    ASSERT_EQ(0, write_text(upper_entry, "upper"));
+    ASSERT_EQ(0, mknod(top_entry.c_str(), S_IFCHR | 0600, makedev(0, 0)));
+    ASSERT_EQ(0, write_text(bottom_entry, "bottom"));
+    std::string options = "lowerdir=" + lower_top + ":" + lower_bottom + ",upperdir="
+        + upper + ",workdir=" + work;
+    ASSERT_EQ(0, mount("overlay", merged.c_str(), "overlay", 0, options.c_str()))
+        << strerror(errno);
+    cleanup.mounted = true;
+
+    ASSERT_EQ(0, unlink(merged_entry.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_entry);
+    expect_path_enoent(upper_entry);
+    EXPECT_TRUE(is_whiteout(top_entry));
+    EXPECT_EQ("bottom", read_text(bottom_entry));
+    EXPECT_EQ(0, overlay_temp_entry_count(work));
+
+    ASSERT_EQ(0, umount(merged.c_str())) << strerror(errno);
+    cleanup.mounted = false;
+}
+
+TEST(OverlayFsSemantics, LowerPositiveContinuesPastMissingTopLayer) {
+    std::string root =
+        std::string("/tmp/overlayfs_lower_positive_continue_") + std::to_string(getpid());
+    std::string upper = join_path(root, "u");
+    std::string lower_top = join_path(root, "l1");
+    std::string lower_bottom = join_path(root, "l2");
+    std::string work = join_path(root, "w");
+    std::string merged = join_path(root, "m");
+    std::string upper_entry = join_path(upper, "entry");
+    std::string bottom_entry = join_path(lower_bottom, "entry");
+    std::string merged_entry = join_path(merged, "entry");
+    ScopedCustomMount cleanup(root, merged);
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(root.c_str()));
+    ASSERT_EQ(0, ensure_dir(upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(lower_top.c_str()));
+    ASSERT_EQ(0, ensure_dir(lower_bottom.c_str()));
+    ASSERT_EQ(0, ensure_dir(work.c_str()));
+    ASSERT_EQ(0, ensure_dir(merged.c_str()));
+    ASSERT_EQ(0, write_text(upper_entry, "upper"));
+    ASSERT_EQ(0, write_text(bottom_entry, "bottom"));
+    std::string options = "lowerdir=" + lower_top + ":" + lower_bottom + ",upperdir="
+        + upper + ",workdir=" + work;
+    ASSERT_EQ(0, mount("overlay", merged.c_str(), "overlay", 0, options.c_str()))
+        << strerror(errno);
+    cleanup.mounted = true;
+
+    ASSERT_EQ(0, unlink(merged_entry.c_str())) << strerror(errno);
+
+    expect_path_enoent(merged_entry);
+    EXPECT_TRUE(is_whiteout(upper_entry));
+    EXPECT_EQ("bottom", read_text(bottom_entry));
+    EXPECT_EQ(0, overlay_temp_entry_count(work));
+
+    ASSERT_EQ(0, umount(merged.c_str())) << strerror(errno);
+    cleanup.mounted = false;
+}
+
+TEST(OverlayFsSemantics, ConcurrentCopiedUpUnlinkNeverExposesLowerContent) {
+    constexpr int kFileCount = 32;
+    constexpr int kReadRounds = 128;
+    ScopedOverlayEnv scoped("overlayfs_unlink_visibility");
+    const auto& env = scoped.env;
+    std::vector<std::string> merged_files;
+    std::vector<std::string> upper_files;
+
+    prepare_overlay_env(env);
+    for (int i = 0; i < kFileCount; ++i) {
+        std::string name = "file" + std::to_string(i);
+        std::string lower_file = join_path(env.lower, name.c_str());
+        merged_files.push_back(join_path(env.merged, name.c_str()));
+        upper_files.push_back(join_path(env.upper, name.c_str()));
+        ASSERT_EQ(0, write_text(lower_file, "lower-content"));
+    }
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    for (const auto& path : merged_files) {
+        ASSERT_EQ(0, write_text(path, "upper-content"));
+    }
+
+    int start_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(start_pipe)) << strerror(errno);
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        close(start_pipe[1]);
+        char token = 0;
+        if (read(start_pipe[0], &token, 1) != 1) {
+            _exit(2);
+        }
+        close(start_pipe[0]);
+
+        for (int round = 0; round < kReadRounds; ++round) {
+            for (const auto& path : merged_files) {
+                int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+                if (fd < 0) {
+                    if (errno != ENOENT) {
+                        _exit(3);
+                    }
+                    continue;
+                }
+                char buf[32] = {};
+                ssize_t n = read(fd, buf, sizeof(buf) - 1);
+                close(fd);
+                if (n < 0) {
+                    _exit(4);
+                }
+                std::string content(buf, static_cast<size_t>(n));
+                if (content == "lower-content") {
+                    _exit(5);
+                }
+                if (content != "upper-content") {
+                    _exit(6);
+                }
+            }
+            sched_yield();
+        }
+        _exit(0);
+    }
+
+    close(start_pipe[0]);
+    ASSERT_EQ(1, write(start_pipe[1], "x", 1));
+    close(start_pipe[1]);
+    for (const auto& path : merged_files) {
+        ASSERT_EQ(0, unlink(path.c_str())) << path << ": " << strerror(errno);
+        sched_yield();
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    for (size_t i = 0; i < merged_files.size(); ++i) {
+        expect_path_enoent(merged_files[i]);
+        EXPECT_TRUE(is_whiteout(upper_files[i]));
+    }
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
 }
 
 TEST(OverlayFsSemantics, RenameNoReplaceOverWhiteoutTargetTreatsTargetAsAbsent) {


### PR DESCRIPTION
## Summary

- revalidate lower-layer presence against the old parent before unlink, rmdir, and rename operations
- replace copied-up upper entries with workdir-backed whiteouts so hidden lower objects cannot reappear
- handle detached whiteout-only directories, upper/lower type overlaps, target-whiteout exchanges, and cross-directory renames
- add OverlayFS regression coverage for copied-up removals and renames, multiple lower layers, pure-upper entries, and concurrent lookup pressure

## Root cause

After a lower object was copied up, a fresh lookup could represent a non-directory object as upper-only. Unlink, rmdir, and rename then removed or moved the upper entry without preserving a whiteout at the old name, allowing the original lower object to become visible again.

## Validation

- `make fmt`
- `make kernel`
- targeted dunitest build for `overlayfs_semantics_test`
- QEMU guest: all 53 OverlayFS and rename semantics tests passed
- ext4-backed upper/workdir smoke tests for copied-up unlink, rename, and upper-directory/lower-file overlap
- `git diff --check`

Closes #2004
