### PR TITLE
perf(virtiofs): reduce hot-path copies and allocations

### DIFF
--- a/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -74,12 +74,29 @@ mkdir -p /tmp/dbg
 mount -t debugfs debugfs /tmp/dbg
 ```
 
+逐 opcode、response reuse/zero 和 pool 详细统计默认关闭，避免正常热路径承担额外原子读改写开销。
+首次读取 `/tmp/dbg/fuse/stats` 会为本次启动后续操作开启这些详细统计。因此必须在目标 workload 前读取
+一次；`virtiofs_bench` 设置 `VIRTIOFS_STATS_PATH` 后会自动完成这次基线读取。首次读取前发生的挂载或
+请求不会计入详细字段，原有 aggregate 计数器不受影响。
+
 默认完整运行：
 
 ```sh
 VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench
 mount | grep virtiofs || echo no_virtiofs_mount
 ```
+
+性能验收和指标归因必须分开运行。纯性能轮次不要设置 `VIRTIOFS_STATS_PATH`，此时 benchmark 不读取
+debugfs，也不会开启逐 opcode 等详细统计：
+
+```sh
+VIRTIOFS_STATS_PATH= /bin/virtiofs_bench --workload metadata --files 64
+VIRTIOFS_STATS_PATH= /bin/virtiofs_bench --workload sequential --file-size 4194304
+```
+
+每个版本预热后至少运行 5 轮，采用 baseline/optimized/baseline 的交替顺序并比较中位数及范围。另起
+设置 `VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats` 的诊断轮次验证请求数量、复制和分配变化，不能把诊断
+轮次耗时当作无观测开销的端到端性能。
 
 小规模 smoke 运行：
 
@@ -149,6 +166,10 @@ virtiofs.bytes_submitted_total
 virtiofs.bytes_completed_total
 virtiofs.bridge_poll_sleep_ns_total
 virtiofs.response_buffer_waste_bytes
+virtiofs.response_buffer_alloc_count
+virtiofs.response_buffer_reuse_count
+virtiofs.response_buffer_zero_bytes
+virtiofs.response_pool_dropped_count
 virtiofs.virtqueue_full_total
 virtiofs.device_queue_depth_max
 virtiofs.hiprio_vring_size_configured
@@ -158,6 +179,22 @@ virtiofs.sg_limit_pages_configured
 virtiofs.inflight_peak
 virtiofs.queue_full_blocked_current
 ```
+
+`[virtiofs_opcode]` 段按 FUSE opcode 输出同口径细分指标，例如 lookup 为 opcode 1、read 为
+opcode 15、write 为 opcode 16：
+
+```text
+opcode_1_request_bridge_copy_bytes
+opcode_1_response_buffer_alloc_count
+opcode_1_response_buffer_reuse_count
+opcode_15_requests_total
+opcode_16_requests_total
+```
+
+比较优化前后时，先确认目标 opcode 的 `requests_total` 在 workload 中确实增加。request bridge copy
+下降和 response allocation/reuse 应分别判断；`response_buffer_zero_bytes` 表示新分配初始化或复用前
+清零产生的显式写入，不应把 allocator 次数下降误报成清零带宽也下降。pool 的容量边界由实现常量和
+单元测试验证；状态型 retained gauge 不做 opt-in 输出，以免首次观测前已有 buffer 导致欠计。
 
 其中 `*_configured` 是配置快照，benchmark 的 `stats_delta` 通常为 0；判断队列深度是否生效时应看
 `/tmp/dbg/fuse/stats` 中的绝对值。

--- a/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -74,12 +74,33 @@ mkdir -p /tmp/dbg
 mount -t debugfs debugfs /tmp/dbg
 ```
 
+Per-opcode, response reuse/zero, and pool details are disabled by default so normal hot paths do
+not pay for extra atomic read-modify-write operations. The first read of `/tmp/dbg/fuse/stats`
+enables these detailed counters for subsequent operations in the current boot. Read it once before
+the target workload; `virtiofs_bench` does this baseline read automatically when
+`VIRTIOFS_STATS_PATH` is set. Requests before that first read are excluded only from detailed
+fields; the existing aggregate counters are unaffected.
+
 Default full run:
 
 ```sh
 VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench
 mount | grep virtiofs || echo no_virtiofs_mount
 ```
+
+Run timing validation separately from counter attribution. For pure timing runs, leave
+`VIRTIOFS_STATS_PATH` unset or empty. The benchmark then does not read debugfs or enable detailed
+per-opcode counters:
+
+```sh
+VIRTIOFS_STATS_PATH= /bin/virtiofs_bench --workload metadata --files 64
+VIRTIOFS_STATS_PATH= /bin/virtiofs_bench --workload sequential --file-size 4194304
+```
+
+After warm-up, run each version at least five times in baseline/optimized/baseline order and compare
+the median and range. Use a separate diagnostic run with
+`VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats` to verify request, copy, and allocation deltas. Do not treat
+the diagnostic timing as an uninstrumented end-to-end result.
 
 Small smoke run:
 
@@ -149,6 +170,10 @@ virtiofs.bytes_submitted_total
 virtiofs.bytes_completed_total
 virtiofs.bridge_poll_sleep_ns_total
 virtiofs.response_buffer_waste_bytes
+virtiofs.response_buffer_alloc_count
+virtiofs.response_buffer_reuse_count
+virtiofs.response_buffer_zero_bytes
+virtiofs.response_pool_dropped_count
 virtiofs.virtqueue_full_total
 virtiofs.device_queue_depth_max
 virtiofs.hiprio_vring_size_configured
@@ -158,6 +183,25 @@ virtiofs.sg_limit_pages_configured
 virtiofs.inflight_peak
 virtiofs.queue_full_blocked_current
 ```
+
+The `[virtiofs_opcode]` section breaks the same metrics down by FUSE opcode. For example, lookup is
+opcode 1, read is opcode 15, and write is opcode 16:
+
+```text
+opcode_1_request_bridge_copy_bytes
+opcode_1_response_buffer_alloc_count
+opcode_1_response_buffer_reuse_count
+opcode_15_requests_total
+opcode_16_requests_total
+```
+
+Before comparing runs, verify that `requests_total` increased for the opcode exercised by the
+workload. Evaluate request bridge copies and response allocation/reuse separately.
+`response_buffer_zero_bytes` records explicit writes from allocation initialization or clearing a
+reused buffer before submission, so fewer allocator calls must not be reported as fewer zero-fill
+bytes. Pool capacity bounds are enforced by implementation constants and unit tests. A retained
+state gauge is intentionally not opt-in because buffers that predate the first stats read could not
+be represented accurately.
 
 The `*_configured` fields are configuration snapshots, so their `stats_delta` is usually 0.
 Check their absolute values in `/tmp/dbg/fuse/stats` when verifying whether queue depth took effect.

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -114,9 +114,23 @@ impl FuseBridgeWake {
 
 #[derive(Debug)]
 pub struct FuseRequest {
-    pub bytes: Vec<u8>,
+    bytes: Vec<u8>,
     unique: u64,
     opcode: u32,
+}
+
+impl FuseRequest {
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub(crate) fn unique(&self) -> u64 {
+        self.unique
+    }
+
+    pub(crate) fn opcode(&self) -> u32 {
+        self.opcode
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -868,12 +882,60 @@ impl FuseConn {
         out: &mut [u8],
     ) -> Result<usize, SystemError> {
         out[..req.bytes.len()].copy_from_slice(&req.bytes);
+        self.account_dequeued_request(&req);
+        Ok(req.bytes.len())
+    }
+
+    fn account_dequeued_request(&self, req: &FuseRequest) {
         stats::on_fuse_request_dequeued(req.bytes.len());
         trace::trace_fuse_request_dequeue(req.unique, req.opcode, req.bytes.len() as u64);
         if req.opcode == FUSE_DESTROY {
             self.abort();
         }
-        Ok(req.bytes.len())
+    }
+
+    fn dequeue_for_kernel_transport<F>(
+        &self,
+        max_message_size: usize,
+        pop_request: F,
+    ) -> Result<Arc<FuseRequest>, SystemError>
+    where
+        F: FnOnce() -> Result<Arc<FuseRequest>, SystemError>,
+    {
+        let req = pop_request()?;
+        if req.bytes.len() > max_message_size {
+            self.fail_oversized_read_request(&req);
+            log::warn!(
+                "fuse: kernel transport buffer smaller than queued request: got={} need={}",
+                max_message_size,
+                req.bytes.len()
+            );
+            // Return to the bridge loop after one malformed request so completion, reset and the
+            // other priority queue cannot be starved by a producer of oversized requests.
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        }
+        self.account_dequeued_request(&req);
+        Ok(req)
+    }
+
+    pub(crate) fn dequeue_virtiofs_ordinary_request(
+        &self,
+        max_message_size: usize,
+    ) -> Result<Arc<FuseRequest>, SystemError> {
+        self.dequeue_for_kernel_transport(max_message_size, || self.pop_ordinary_pending_nonblock())
+    }
+
+    pub(crate) fn dequeue_virtiofs_high_priority_request(
+        &self,
+        max_message_size: usize,
+    ) -> Result<Arc<FuseRequest>, SystemError> {
+        self.dequeue_for_kernel_transport(max_message_size, || {
+            let mut g = self.inner.lock();
+            if !g.connected {
+                return Err(SystemError::ENOTCONN);
+            }
+            Self::pop_high_priority_pending_locked(&mut g).ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        })
     }
 
     fn read_dequeued_request<F>(
@@ -967,7 +1029,7 @@ impl FuseConn {
 
         if let Some(pending) = pending {
             let error = -err.to_posix_errno();
-            stats::on_fuse_reply_complete(error, 0);
+            stats::on_fuse_reply_complete(req.opcode, error, 0);
             trace::trace_fuse_reply_complete(req.unique, req.opcode, error, 0);
             pending.complete(Err(err));
         } else {
@@ -1287,7 +1349,7 @@ impl FuseConn {
                 );
             }
             pending.complete(Err(e));
-            stats::on_fuse_reply_complete(error, payload.len());
+            stats::on_fuse_reply_complete(pending.opcode, error, payload.len());
             trace::trace_fuse_reply_complete(
                 out_hdr.unique,
                 pending.opcode,
@@ -1305,7 +1367,7 @@ impl FuseConn {
                 Ok(v) => v,
                 Err(e) => {
                     let error = -e.to_posix_errno();
-                    stats::on_fuse_reply_complete(error, payload.len());
+                    stats::on_fuse_reply_complete(pending.opcode, error, payload.len());
                     trace::trace_fuse_reply_complete(
                         out_hdr.unique,
                         pending.opcode,
@@ -1320,7 +1382,7 @@ impl FuseConn {
 
             if init_out.major != FUSE_KERNEL_VERSION {
                 let error = -SystemError::EINVAL.to_posix_errno();
-                stats::on_fuse_reply_complete(error, payload.len());
+                stats::on_fuse_reply_complete(pending.opcode, error, payload.len());
                 trace::trace_fuse_reply_complete(
                     out_hdr.unique,
                     pending.opcode,
@@ -1384,7 +1446,7 @@ impl FuseConn {
             self.init_wait.wakeup(None);
         }
 
-        stats::on_fuse_reply_complete(0, payload.len());
+        stats::on_fuse_reply_complete(pending.opcode, 0, payload.len());
         trace::trace_fuse_reply_complete(out_hdr.unique, pending.opcode, 0, payload.len() as u64);
         pending.complete(Ok(payload.to_vec()));
         Ok(data.len())
@@ -1547,6 +1609,67 @@ mod tests {
             Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
         ));
         assert!(conn.has_pending_high_priority_requests());
+    }
+
+    #[test]
+    fn virtiofs_direct_dequeue_transfers_existing_request() {
+        let conn = FuseConn::new_for_virtiofs(8192);
+        let unique = conn.alloc_unique();
+        let req = conn.build_request(
+            unique,
+            FUSE_LOOKUP,
+            1,
+            b"name\0",
+            FuseRequestCred::nocreds(),
+        );
+        let expected_ptr = req.bytes().as_ptr();
+        conn.push_request(
+            req,
+            Some(Arc::new(FusePendingState::new(unique, FUSE_LOOKUP))),
+            unique,
+        )
+        .unwrap();
+
+        let dequeued = conn.dequeue_virtiofs_ordinary_request(8192).unwrap();
+        assert_eq!(dequeued.opcode(), FUSE_LOOKUP);
+        assert_eq!(dequeued.unique(), unique);
+        assert_eq!(dequeued.bytes().as_ptr(), expected_ptr);
+    }
+
+    #[test]
+    fn virtiofs_direct_dequeue_keeps_priority_queues_separate() {
+        let conn = FuseConn::new_for_virtiofs(8192);
+        queue_test_request(&conn, FUSE_FORGET, false);
+        queue_test_request(&conn, FUSE_LOOKUP, true);
+
+        let ordinary = conn.dequeue_virtiofs_ordinary_request(8192).unwrap();
+        assert_eq!(ordinary.opcode(), FUSE_LOOKUP);
+        let hiprio = conn.dequeue_virtiofs_high_priority_request(8192).unwrap();
+        assert_eq!(hiprio.opcode(), FUSE_FORGET);
+    }
+
+    #[test]
+    fn virtiofs_direct_dequeue_rejects_oversized_request() {
+        let conn = FuseConn::new_for_virtiofs(8192);
+        let unique = conn.alloc_unique();
+        let req = conn.build_request(
+            unique,
+            FUSE_FORGET,
+            1,
+            &[0u8; 128],
+            FuseRequestCred::nocreds(),
+        );
+        conn.push_request(req, None, unique).unwrap();
+        queue_test_request(&conn, FUSE_FORGET, false);
+
+        assert!(matches!(
+            conn.dequeue_virtiofs_high_priority_request(64),
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        ));
+        assert!(conn.has_pending_high_priority_requests());
+        let next = conn.dequeue_virtiofs_high_priority_request(8192).unwrap();
+        assert_eq!(next.opcode(), FUSE_FORGET);
+        assert!(!conn.has_pending_high_priority_requests());
     }
 
     #[test]

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -1,7 +1,17 @@
 use alloc::{format, string::String};
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::{
+    fmt::Write,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
 
 const BATCH_BUCKETS: usize = 5;
+const OPCODE_BUCKETS: usize = 64;
+const OPCODE_OVERFLOW_BUCKET: usize = OPCODE_BUCKETS - 1;
+
+// Detailed copy/allocation counters are opt-in so their atomic RMWs do not
+// perturb the normal virtio-fs hot path. Reading the debugfs snapshot enables
+// them for subsequent operations in the current boot.
+static DETAILED_STATS_ENABLED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FuseStatsSnapshot {
@@ -174,9 +184,39 @@ static BRIDGE_REQUEST_CLONE_COUNT: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_REQUEST_CLONE_BYTES: AtomicU64 = AtomicU64::new(0);
 static RESPONSE_BUFFER_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
 static RESPONSE_BUFFER_ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_BUFFER_REUSE_COUNT: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_BUFFER_REUSE_BYTES: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_BUFFER_ZERO_COUNT: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_BUFFER_ZERO_BYTES: AtomicU64 = AtomicU64::new(0);
+static RESPONSE_POOL_DROPPED_COUNT: AtomicU64 = AtomicU64::new(0);
 static RESPONSE_BUFFER_WASTE_BYTES: AtomicU64 = AtomicU64::new(0);
 static BYTES_SUBMITTED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BYTES_COMPLETED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+static OPCODE_REQUESTS_TOTAL: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_REQUEST_BYTES_TOTAL: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_REQUEST_BRIDGE_COPY_COUNT: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_REQUEST_BRIDGE_COPY_BYTES: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_RESPONSE_BUFFER_ALLOC_COUNT: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_RESPONSE_BUFFER_ALLOC_BYTES: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_RESPONSE_BUFFER_REUSE_COUNT: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_RESPONSE_BUFFER_REUSE_BYTES: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_RESPONSE_BUFFER_ZERO_COUNT: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_RESPONSE_BUFFER_ZERO_BYTES: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_REPLY_PAYLOAD_COPY_COUNT: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_REPLY_PAYLOAD_COPY_BYTES: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
 
 static PUMP_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
 static COMPLETE_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
@@ -221,6 +261,16 @@ fn saturating_sub(counter: &AtomicU64, value: u64) {
 #[inline]
 fn inc(counter: &AtomicU64) {
     add(counter, 1);
+}
+
+#[inline]
+fn opcode_bucket(opcode: u32) -> usize {
+    core::cmp::min(opcode as usize, OPCODE_OVERFLOW_BUCKET)
+}
+
+#[inline]
+fn detailed_stats_enabled() -> bool {
+    DETAILED_STATS_ENABLED.load(Ordering::Relaxed)
 }
 
 #[inline]
@@ -280,10 +330,15 @@ pub fn on_fuse_read_buffer_too_small() {
 }
 
 #[inline]
-pub fn on_fuse_reply_complete(error: i32, payload_len: usize) {
+pub fn on_fuse_reply_complete(opcode: u32, error: i32, payload_len: usize) {
     if error == 0 {
         inc(&REQUESTS_REPLIED_OK_TOTAL);
         add(&BYTES_REPLY_PAYLOAD_CLONED_TOTAL, payload_len as u64);
+        if detailed_stats_enabled() {
+            let bucket = opcode_bucket(opcode);
+            inc(&OPCODE_REPLY_PAYLOAD_COPY_COUNT[bucket]);
+            add(&OPCODE_REPLY_PAYLOAD_COPY_BYTES[bucket], payload_len as u64);
+        }
     } else {
         inc(&REQUESTS_REPLIED_ERR_TOTAL);
     }
@@ -420,15 +475,46 @@ pub fn on_virtiofs_complete_batch(count: usize) {
 }
 
 #[inline]
-pub fn on_virtiofs_request_cloned(len: usize) {
-    inc(&BRIDGE_REQUEST_CLONE_COUNT);
-    add(&BRIDGE_REQUEST_CLONE_BYTES, len as u64);
+pub fn on_virtiofs_response_buffer_alloc(opcode: u32, len: usize) {
+    inc(&RESPONSE_BUFFER_ALLOC_COUNT);
+    add(&RESPONSE_BUFFER_ALLOC_BYTES, len as u64);
+    if detailed_stats_enabled() {
+        let bucket = opcode_bucket(opcode);
+        inc(&OPCODE_RESPONSE_BUFFER_ALLOC_COUNT[bucket]);
+        add(&OPCODE_RESPONSE_BUFFER_ALLOC_BYTES[bucket], len as u64);
+    }
 }
 
 #[inline]
-pub fn on_virtiofs_response_buffer_alloc(len: usize) {
-    inc(&RESPONSE_BUFFER_ALLOC_COUNT);
-    add(&RESPONSE_BUFFER_ALLOC_BYTES, len as u64);
+pub fn on_virtiofs_response_buffer_reuse(opcode: u32, len: usize) {
+    if !detailed_stats_enabled() {
+        return;
+    }
+    inc(&RESPONSE_BUFFER_REUSE_COUNT);
+    add(&RESPONSE_BUFFER_REUSE_BYTES, len as u64);
+    let bucket = opcode_bucket(opcode);
+    inc(&OPCODE_RESPONSE_BUFFER_REUSE_COUNT[bucket]);
+    add(&OPCODE_RESPONSE_BUFFER_REUSE_BYTES[bucket], len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_response_buffer_zero(opcode: u32, len: usize) {
+    if !detailed_stats_enabled() {
+        return;
+    }
+    inc(&RESPONSE_BUFFER_ZERO_COUNT);
+    add(&RESPONSE_BUFFER_ZERO_BYTES, len as u64);
+    let bucket = opcode_bucket(opcode);
+    inc(&OPCODE_RESPONSE_BUFFER_ZERO_COUNT[bucket]);
+    add(&OPCODE_RESPONSE_BUFFER_ZERO_BYTES[bucket], len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_response_pool_drop() {
+    if !detailed_stats_enabled() {
+        return;
+    }
+    inc(&RESPONSE_POOL_DROPPED_COUNT);
 }
 
 #[inline]
@@ -437,9 +523,14 @@ pub fn on_virtiofs_response_buffer_waste(len: usize) {
 }
 
 #[inline]
-pub fn on_virtiofs_submitted(req_len: usize) {
+pub fn on_virtiofs_submitted(opcode: u32, req_len: usize) {
     inc(&BRIDGE_SUBMITTED_TOTAL);
     add(&BYTES_SUBMITTED_TOTAL, req_len as u64);
+    if detailed_stats_enabled() {
+        let bucket = opcode_bucket(opcode);
+        inc(&OPCODE_REQUESTS_TOTAL[bucket]);
+        add(&OPCODE_REQUEST_BYTES_TOTAL[bucket], req_len as u64);
+    }
 }
 
 #[inline]
@@ -588,9 +679,12 @@ pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
 }
 
 pub fn format_snapshot() -> String {
+    // A stats read is the explicit start of a detailed observation window.
+    // Enable it before taking the baseline snapshot.
+    DETAILED_STATS_ENABLED.store(true, Ordering::Relaxed);
     let fuse = fuse_snapshot();
     let virtiofs = virtiofs_snapshot();
-    format!(
+    let mut output = format!(
         "[fuse]\n\
 requests_queued_total {}\n\
 requests_dequeued_total {}\n\
@@ -740,5 +834,50 @@ request_queue_full_total {}\n",
         virtiofs.bridge_queue_full_retry_success_total,
         virtiofs.hiprio_queue_full_total,
         virtiofs.request_queue_full_total,
+    );
+
+    writeln!(
+        output,
+        "response_buffer_reuse_count {}\nresponse_buffer_reuse_bytes {}\n\
+response_buffer_zero_count {}\nresponse_buffer_zero_bytes {}\nresponse_pool_dropped_count {}",
+        RESPONSE_BUFFER_REUSE_COUNT.load(Ordering::Relaxed),
+        RESPONSE_BUFFER_REUSE_BYTES.load(Ordering::Relaxed),
+        RESPONSE_BUFFER_ZERO_COUNT.load(Ordering::Relaxed),
+        RESPONSE_BUFFER_ZERO_BYTES.load(Ordering::Relaxed),
+        RESPONSE_POOL_DROPPED_COUNT.load(Ordering::Relaxed),
     )
+    .expect("formatting fuse stats into String cannot fail");
+
+    output.push_str("\n[virtiofs_opcode]\n");
+    for opcode in 0..OPCODE_BUCKETS {
+        writeln!(
+            output,
+            "opcode_{opcode}_requests_total {}\n\
+opcode_{opcode}_request_bytes_total {}\n\
+opcode_{opcode}_request_bridge_copy_count {}\n\
+opcode_{opcode}_request_bridge_copy_bytes {}\n\
+opcode_{opcode}_response_buffer_alloc_count {}\n\
+opcode_{opcode}_response_buffer_alloc_bytes {}\n\
+opcode_{opcode}_response_buffer_reuse_count {}\n\
+opcode_{opcode}_response_buffer_reuse_bytes {}\n\
+opcode_{opcode}_response_buffer_zero_count {}\n\
+opcode_{opcode}_response_buffer_zero_bytes {}\n\
+opcode_{opcode}_reply_payload_copy_count {}\n\
+opcode_{opcode}_reply_payload_copy_bytes {}",
+            OPCODE_REQUESTS_TOTAL[opcode].load(Ordering::Relaxed),
+            OPCODE_REQUEST_BYTES_TOTAL[opcode].load(Ordering::Relaxed),
+            OPCODE_REQUEST_BRIDGE_COPY_COUNT[opcode].load(Ordering::Relaxed),
+            OPCODE_REQUEST_BRIDGE_COPY_BYTES[opcode].load(Ordering::Relaxed),
+            OPCODE_RESPONSE_BUFFER_ALLOC_COUNT[opcode].load(Ordering::Relaxed),
+            OPCODE_RESPONSE_BUFFER_ALLOC_BYTES[opcode].load(Ordering::Relaxed),
+            OPCODE_RESPONSE_BUFFER_REUSE_COUNT[opcode].load(Ordering::Relaxed),
+            OPCODE_RESPONSE_BUFFER_REUSE_BYTES[opcode].load(Ordering::Relaxed),
+            OPCODE_RESPONSE_BUFFER_ZERO_COUNT[opcode].load(Ordering::Relaxed),
+            OPCODE_RESPONSE_BUFFER_ZERO_BYTES[opcode].load(Ordering::Relaxed),
+            OPCODE_REPLY_PAYLOAD_COPY_COUNT[opcode].load(Ordering::Relaxed),
+            OPCODE_REPLY_PAYLOAD_COPY_BYTES[opcode].load(Ordering::Relaxed),
+        )
+        .expect("formatting fuse opcode stats into String cannot fail");
+    }
+    output
 }

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 use super::{
-    conn::FuseConn,
+    conn::{FuseConn, FuseRequest},
     fs::{FuseFS, FuseMountData},
     protocol::{
         fuse_pack_struct, fuse_read_struct, FuseInHeader, FuseOutHeader, FuseReadIn, FUSE_DESTROY,
@@ -49,8 +49,11 @@ const VIRTIOFS_QUEUE_SIZE_MAX: usize = 1024;
 const VIRTIOFS_RESET_WAIT_SPINS: usize = 100_000;
 const FUSE_HEADER_OVERHEAD: usize = 4;
 const FUSE_MAX_MAX_PAGES: usize = 256;
-const VIRTIOFS_REQ_BUF_SIZE: usize = 256 * 1024;
+const VIRTIOFS_MAX_REQUEST_SIZE: usize = 256 * 1024;
 const VIRTIOFS_RSP_BUF_SIZE: usize = 256 * 1024;
+const VIRTIOFS_RSP_POOL_MAX_BUFFERS: usize = 16;
+const VIRTIOFS_RSP_POOL_MAX_CAPACITY_BYTES: usize =
+    VIRTIOFS_RSP_BUF_SIZE * VIRTIOFS_RSP_POOL_MAX_BUFFERS;
 const VIRTIOFS_POLL_NS: i64 = 1_000_000;
 const VIRTIOFS_PUMP_BUDGET: usize = 64;
 
@@ -62,7 +65,7 @@ enum QueueKind {
 
 #[derive(Debug)]
 struct PendingReq {
-    req: Vec<u8>,
+    req: Arc<FuseRequest>,
     unique: u64,
     opcode: u32,
     noreply: bool,
@@ -79,6 +82,69 @@ struct InflightReq {
 struct QueueBlockState {
     blocked: bool,
     completion_seen: bool,
+}
+
+#[derive(Debug)]
+struct ResponseBufferPool {
+    buffers: Vec<Vec<u8>>,
+    retained_capacity_bytes: usize,
+}
+
+impl ResponseBufferPool {
+    fn new() -> Self {
+        Self {
+            buffers: Vec::with_capacity(VIRTIOFS_RSP_POOL_MAX_BUFFERS),
+            retained_capacity_bytes: 0,
+        }
+    }
+
+    fn acquire(&mut self, opcode: u32, len: usize) -> Vec<u8> {
+        if let Some(index) = self.buffers.iter().position(|buf| buf.len() == len) {
+            let mut buf = self.buffers.swap_remove(index);
+            self.retained_capacity_bytes = self
+                .retained_capacity_bytes
+                .checked_sub(buf.capacity())
+                .expect("response pool capacity accounting underflow");
+            buf.fill(0);
+            stats::on_virtiofs_response_buffer_reuse(opcode, len);
+            stats::on_virtiofs_response_buffer_zero(opcode, len);
+            return buf;
+        }
+
+        let buf = vec![0u8; len];
+        stats::on_virtiofs_response_buffer_alloc(opcode, len);
+        stats::on_virtiofs_response_buffer_zero(opcode, len);
+        buf
+    }
+
+    fn release(&mut self, buf: Vec<u8>, reusable: bool) {
+        let capacity = buf.capacity();
+        let next_capacity = self.retained_capacity_bytes.checked_add(capacity);
+        let within_limits = reusable
+            && buf.len() <= VIRTIOFS_RSP_BUF_SIZE
+            && capacity <= VIRTIOFS_RSP_BUF_SIZE
+            && self.buffers.len() < VIRTIOFS_RSP_POOL_MAX_BUFFERS
+            && next_capacity.is_some_and(|total| total <= VIRTIOFS_RSP_POOL_MAX_CAPACITY_BYTES);
+
+        if !within_limits {
+            stats::on_virtiofs_response_pool_drop();
+            return;
+        }
+
+        self.retained_capacity_bytes = next_capacity.expect("checked above");
+        self.buffers.push(buf);
+    }
+
+    fn clear(&mut self) {
+        self.buffers.clear();
+        self.retained_capacity_bytes = 0;
+    }
+}
+
+impl Drop for ResponseBufferPool {
+    fn drop(&mut self) {
+        self.clear();
+    }
 }
 
 enum VirtioFsQueue {
@@ -336,8 +402,8 @@ struct VirtioFsBridgeContext {
     request_pending: Vec<VecDeque<PendingReq>>,
     hiprio_inflight: BTreeMap<u16, InflightReq>,
     request_inflight: Vec<BTreeMap<u16, InflightReq>>,
+    response_pool: ResponseBufferPool,
     next_request_slot: usize,
-    req_buf: Vec<u8>,
     hiprio_blocked: QueueBlockState,
     request_blocked: Vec<QueueBlockState>,
 }
@@ -544,11 +610,11 @@ impl VirtioFsBridgeContext {
     fn response_buffer_size(pending: &PendingReq) -> usize {
         let default_size = VIRTIOFS_RSP_BUF_SIZE;
         let read_like = matches!(pending.opcode, FUSE_READ | FUSE_READDIR | FUSE_READDIRPLUS);
-        if !read_like || pending.req.len() < core::mem::size_of::<FuseInHeader>() {
+        if !read_like || pending.req.bytes().len() < core::mem::size_of::<FuseInHeader>() {
             return default_size;
         }
 
-        let payload = &pending.req[core::mem::size_of::<FuseInHeader>()..];
+        let payload = &pending.req.bytes()[core::mem::size_of::<FuseInHeader>()..];
         let Ok(read_in) = fuse_read_struct::<FuseReadIn>(payload) else {
             return default_size;
         };
@@ -666,20 +732,22 @@ impl VirtioFsBridgeContext {
                 Err(e) => return Err(e),
             };
 
-            let len = match self.conn.read_ordinary_request(true, &mut self.req_buf) {
-                Ok(len) => len,
+            let req = match self
+                .conn
+                .dequeue_virtiofs_ordinary_request(VIRTIOFS_MAX_REQUEST_SIZE)
+            {
+                Ok(req) => req,
                 Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => break,
                 Err(e) => return Err(e),
             };
-            let req = self.req_buf[..len].to_vec();
-            stats::on_virtiofs_request_cloned(req.len());
-            let in_hdr: FuseInHeader = fuse_read_struct(&req)?;
-            let noreply = matches!(in_hdr.opcode, FUSE_FORGET | FUSE_DESTROY);
-            debug_assert!(!matches!(in_hdr.opcode, FUSE_FORGET | FUSE_INTERRUPT));
+            let opcode = req.opcode();
+            let unique = req.unique();
+            let noreply = matches!(opcode, FUSE_FORGET | FUSE_DESTROY);
+            debug_assert!(!matches!(opcode, FUSE_FORGET | FUSE_INTERRUPT));
             self.push_pending_back(PendingReq {
                 req,
-                unique: in_hdr.unique,
-                opcode: in_hdr.opcode,
+                unique,
+                opcode,
                 noreply,
                 queue: QueueKind::Request(slot),
             })?;
@@ -692,20 +760,22 @@ impl VirtioFsBridgeContext {
     fn pump_high_priority_requests(&mut self) -> Result<usize, SystemError> {
         let mut pumped = 0usize;
         for _ in 0..VIRTIOFS_PUMP_BUDGET {
-            let len = match self.conn.read_high_priority_request(&mut self.req_buf) {
-                Ok(len) => len,
+            let req = match self
+                .conn
+                .dequeue_virtiofs_high_priority_request(VIRTIOFS_MAX_REQUEST_SIZE)
+            {
+                Ok(req) => req,
                 Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => break,
                 Err(e) => return Err(e),
             };
-            let req = self.req_buf[..len].to_vec();
-            stats::on_virtiofs_request_cloned(req.len());
-            let in_hdr: FuseInHeader = fuse_read_struct(&req)?;
-            debug_assert!(matches!(in_hdr.opcode, FUSE_FORGET | FUSE_INTERRUPT));
+            let opcode = req.opcode();
+            let unique = req.unique();
+            debug_assert!(matches!(opcode, FUSE_FORGET | FUSE_INTERRUPT));
             self.push_pending_back(PendingReq {
                 req,
-                unique: in_hdr.unique,
-                opcode: in_hdr.opcode,
-                noreply: in_hdr.opcode == FUSE_FORGET,
+                unique,
+                opcode,
+                noreply: opcode == FUSE_FORGET,
                 queue: QueueKind::Hiprio,
             })?;
             pumped += 1;
@@ -726,6 +796,26 @@ impl VirtioFsBridgeContext {
     }
 
     fn submit_one_pending(&mut self, kind: QueueKind) -> Result<bool, SystemError> {
+        let queue_idx = self.queue_index(kind)?;
+        if self.transport.is_none() {
+            return Err(SystemError::EIO);
+        }
+        match kind {
+            QueueKind::Hiprio => {
+                if self.hiprio_vq.is_none() {
+                    return Err(SystemError::EIO);
+                }
+            }
+            QueueKind::Request(slot) => {
+                if slot >= self.request_vqs.len()
+                    || slot >= self.request_inflight.len()
+                    || slot >= self.request_blocked.len()
+                {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+        }
+
         let pending = match self.pop_pending_for_submit(kind)? {
             Some(p) => p,
             None => return Ok(false),
@@ -737,24 +827,26 @@ impl VirtioFsBridgeContext {
         if let Some(after_completion) = retry_after_completion {
             stats::on_virtiofs_queue_full_retry(after_completion);
         }
-        let queue_idx = self.queue_index(kind)?;
+        let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
+        let trace_unique = pending.unique;
+        let trace_opcode = pending.opcode;
+        let req_len = pending.req.bytes().len();
         let mut rsp = if pending.noreply {
             None
         } else {
             let rsp_size = Self::response_buffer_size(&pending);
-            stats::on_virtiofs_response_buffer_alloc(rsp_size);
-            Some(vec![0u8; rsp_size])
+            Some(self.response_pool.acquire(pending.opcode, rsp_size))
         };
 
         let (token, should_notify) = match kind {
             QueueKind::Hiprio => {
                 let queue = self.hiprio_vq.as_mut().ok_or(SystemError::EIO)?;
                 let token = if let Some(rsp_buf) = rsp.as_mut() {
-                    let inputs = [pending.req.as_slice()];
+                    let inputs = [pending.req.bytes()];
                     let mut outputs = [rsp_buf.as_mut_slice()];
                     unsafe { queue.add(&inputs, &mut outputs) }
                 } else {
-                    let inputs = [pending.req.as_slice()];
+                    let inputs = [pending.req.bytes()];
                     let mut outputs: [&mut [u8]; 0] = [];
                     unsafe { queue.add(&inputs, &mut outputs) }
                 };
@@ -763,11 +855,11 @@ impl VirtioFsBridgeContext {
             QueueKind::Request(slot) => {
                 let queue = self.request_vqs.get_mut(slot).ok_or(SystemError::EINVAL)?;
                 let token = if let Some(rsp_buf) = rsp.as_mut() {
-                    let inputs = [pending.req.as_slice()];
+                    let inputs = [pending.req.bytes()];
                     let mut outputs = [rsp_buf.as_mut_slice()];
                     unsafe { queue.add(&inputs, &mut outputs) }
                 } else {
-                    let inputs = [pending.req.as_slice()];
+                    let inputs = [pending.req.bytes()];
                     let mut outputs: [&mut [u8]; 0] = [];
                     unsafe { queue.add(&inputs, &mut outputs) }
                 };
@@ -778,6 +870,9 @@ impl VirtioFsBridgeContext {
         let token = match token {
             Ok(token) => token,
             Err(VirtioError::QueueFull) => {
+                if let Some(rsp_buf) = rsp.take() {
+                    self.response_pool.release(rsp_buf, true);
+                }
                 stats::on_virtiofs_queue_full(kind.stats_kind());
                 self.mark_queue_full_blocked(kind)?;
                 let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
@@ -792,6 +887,9 @@ impl VirtioFsBridgeContext {
                 return Ok(false);
             }
             Err(VirtioError::NotReady) => {
+                if let Some(rsp_buf) = rsp.take() {
+                    self.response_pool.release(rsp_buf, true);
+                }
                 stats::on_virtiofs_not_ready();
                 stats::on_virtiofs_submit_error();
                 let se = virtio_drivers_error_to_system_error(VirtioError::NotReady);
@@ -805,6 +903,9 @@ impl VirtioFsBridgeContext {
                 return Ok(true);
             }
             Err(e) => {
+                if let Some(rsp_buf) = rsp.take() {
+                    self.response_pool.release(rsp_buf, true);
+                }
                 stats::on_virtiofs_submit_error();
                 let se = virtio_drivers_error_to_system_error(e);
                 warn!(
@@ -818,25 +919,19 @@ impl VirtioFsBridgeContext {
             }
         };
 
-        let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
-        let trace_unique = pending.unique;
-        let trace_opcode = pending.opcode;
-        let req_len = pending.req.len();
         let inflight = InflightReq { pending, rsp };
         let replaced = match kind {
             QueueKind::Hiprio => self.hiprio_inflight.insert(token, inflight),
-            QueueKind::Request(slot) => self
-                .request_inflight
-                .get_mut(slot)
-                .ok_or(SystemError::EINVAL)?
-                .insert(token, inflight),
+            QueueKind::Request(slot) => self.request_inflight[slot].insert(token, inflight),
         };
         debug_assert!(replaced.is_none());
         stats::on_virtiofs_inflight_add(kind.stats_kind());
-        stats::on_virtiofs_submitted(req_len);
+        stats::on_virtiofs_submitted(trace_opcode, req_len);
 
         let retry_succeeded = {
-            let state = self.block_state_mut(kind)?;
+            let state = self
+                .block_state_mut(kind)
+                .expect("queue kind was validated before virtqueue submission");
             if state.blocked {
                 state.blocked = false;
                 state.completion_seen = false;
@@ -853,7 +948,7 @@ impl VirtioFsBridgeContext {
         if should_notify {
             self.transport
                 .as_mut()
-                .ok_or(SystemError::EIO)?
+                .expect("transport was validated before virtqueue submission")
                 .notify(queue_idx);
         }
 
@@ -905,7 +1000,7 @@ impl VirtioFsBridgeContext {
         let used_len_res = match kind {
             QueueKind::Hiprio => {
                 let queue = self.hiprio_vq.as_mut().ok_or(SystemError::EIO)?;
-                let inputs = [inflight.pending.req.as_slice()];
+                let inputs = [inflight.pending.req.bytes()];
                 if let Some(rsp_buf) = inflight.rsp.as_mut() {
                     let mut outputs = [rsp_buf.as_mut_slice()];
                     unsafe { queue.pop_used(token, &inputs, &mut outputs) }
@@ -918,7 +1013,7 @@ impl VirtioFsBridgeContext {
             }
             QueueKind::Request(slot) => {
                 let queue = self.request_vqs.get_mut(slot).ok_or(SystemError::EINVAL)?;
-                let inputs = [inflight.pending.req.as_slice()];
+                let inputs = [inflight.pending.req.bytes()];
                 if let Some(rsp_buf) = inflight.rsp.as_mut() {
                     let mut outputs = [rsp_buf.as_mut_slice()];
                     unsafe { queue.pop_used(token, &inputs, &mut outputs) }
@@ -961,10 +1056,14 @@ impl VirtioFsBridgeContext {
             return Ok(true);
         }
 
-        let rsp_buf = inflight.rsp.as_ref().ok_or(SystemError::EIO)?;
+        let rsp_buf = inflight
+            .rsp
+            .take()
+            .expect("reply-bearing inflight request must own a response buffer");
         if used_len > rsp_buf.len() {
             stats::on_virtiofs_completed(used_len, false);
             self.complete_request_with_error(inflight.pending.unique, SystemError::EIO);
+            self.response_pool.release(rsp_buf, false);
             return Ok(true);
         }
         if rsp_buf.len() > used_len {
@@ -972,8 +1071,8 @@ impl VirtioFsBridgeContext {
         }
         stats::on_virtiofs_completed(used_len, false);
 
-        match self.conn.write_reply(&rsp_buf[..used_len]) {
-            Ok(_) | Err(SystemError::ENOENT) => {}
+        let reusable = match self.conn.write_reply(&rsp_buf[..used_len]) {
+            Ok(_) | Err(SystemError::ENOENT) => true,
             Err(e) => {
                 // Linux virtio-fs always ends a completed request from the used ring.
                 // Keep that behavior here: fail this unique instead of exiting bridge loop.
@@ -988,8 +1087,10 @@ impl VirtioFsBridgeContext {
                     unique, inflight.pending.opcode, e, completion_err
                 );
                 self.complete_request_with_error(unique, completion_err);
+                false
             }
-        }
+        };
+        self.response_pool.release(rsp_buf, reusable);
         Ok(true)
     }
 
@@ -1173,7 +1274,7 @@ impl VirtioFsBridgeContext {
         kind: QueueKind,
     ) {
         for (token, req) in inflight.iter_mut() {
-            let inputs = [req.pending.req.as_slice()];
+            let inputs = [req.pending.req.bytes()];
             let result = if let Some(rsp_buf) = req.rsp.as_mut() {
                 let mut outputs = [rsp_buf.as_mut_slice()];
                 // SAFETY: The caller invokes this only after the device reset completed, so the
@@ -1306,6 +1407,9 @@ impl VirtioFsBridgeContext {
         self.clear_queue_full_blocked_stats();
         self.instance.clear_bridge_wake(self.session_id);
         if !self.reset_device_and_unset_queues() {
+            // Idle pooled buffers are not visible to the device. Release them before the
+            // reset-timeout quarantine keeps the transport, queues and inflight DMA buffers alive.
+            self.response_pool.clear();
             self.fail_unfinished_preserving_inflight_dma(SystemError::ENOTCONN);
             if !self
                 .instance
@@ -1538,8 +1642,8 @@ fn start_bridge(instance: Arc<VirtioFsInstance>, conn: Arc<FuseConn>) -> Result<
         request_vqs,
         hiprio_pending: VecDeque::new(),
         hiprio_inflight: BTreeMap::new(),
+        response_pool: ResponseBufferPool::new(),
         next_request_slot: 0,
-        req_buf: vec![0u8; VIRTIOFS_REQ_BUF_SIZE],
         hiprio_blocked: QueueBlockState::default(),
         request_blocked: core::iter::repeat_with(QueueBlockState::default)
             .take(request_queue_count)
@@ -1751,7 +1855,7 @@ impl MountableFileSystem for VirtioFsFs {
             Self::parse_mount_options(raw_data)?;
         let instance = virtio_fs_find_instance(source).ok_or(SystemError::ENODEV)?;
         let conn = FuseConn::new_for_virtiofs(core::cmp::min(
-            VIRTIOFS_REQ_BUF_SIZE,
+            VIRTIOFS_MAX_REQUEST_SIZE,
             VIRTIOFS_RSP_BUF_SIZE,
         ));
 
@@ -1814,11 +1918,15 @@ register_mountable_fs!(VirtioFsFs, VIRTIOFSMAKER, "virtiofs");
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use alloc::{vec, vec::Vec};
 
     use system_error::SystemError;
 
-    use super::{choose_queue_size, QueueBlockState, VirtioFsBridgeContext};
+    use super::{
+        choose_queue_size, QueueBlockState, ResponseBufferPool, VirtioFsBridgeContext,
+        VIRTIOFS_RSP_BUF_SIZE, VIRTIOFS_RSP_POOL_MAX_BUFFERS,
+    };
+    use crate::filesystem::fuse::protocol::FUSE_LOOKUP;
 
     fn block_state(blocked: bool, completion_seen: bool) -> QueueBlockState {
         QueueBlockState {
@@ -1915,5 +2023,48 @@ mod tests {
         assert_eq!(choose_queue_size(128).unwrap(), 128);
         assert_eq!(choose_queue_size(2048).unwrap(), 1024);
         assert_eq!(choose_queue_size(7), Err(SystemError::EINVAL));
+    }
+
+    #[test]
+    fn response_pool_reuses_exact_length_and_zeroes_before_submit() {
+        let mut pool = ResponseBufferPool::new();
+        let mut buf = pool.acquire(FUSE_LOOKUP, 128);
+        buf.fill(0xaa);
+        let ptr = buf.as_ptr();
+        pool.release(buf, true);
+
+        assert_eq!(pool.buffers.len(), 1);
+        let reused = pool.acquire(FUSE_LOOKUP, 128);
+        assert_eq!(reused.as_ptr(), ptr);
+        assert!(reused.iter().all(|byte| *byte == 0));
+        assert!(pool.buffers.is_empty());
+        assert_eq!(pool.retained_capacity_bytes, 0);
+    }
+
+    #[test]
+    fn response_pool_rejects_excess_capacity_and_nonreusable_buffers() {
+        let mut pool = ResponseBufferPool::new();
+        let mut oversized_capacity = Vec::with_capacity(VIRTIOFS_RSP_BUF_SIZE + 1);
+        oversized_capacity.resize(16, 0);
+        pool.release(oversized_capacity, true);
+        pool.release(vec![0u8; 16], false);
+
+        assert!(pool.buffers.is_empty());
+        assert_eq!(pool.retained_capacity_bytes, 0);
+    }
+
+    #[test]
+    fn response_pool_enforces_buffer_count_and_checked_capacity() {
+        let mut pool = ResponseBufferPool::new();
+        for _ in 0..=VIRTIOFS_RSP_POOL_MAX_BUFFERS {
+            pool.release(vec![0u8; 1], true);
+        }
+        assert_eq!(pool.buffers.len(), VIRTIOFS_RSP_POOL_MAX_BUFFERS);
+
+        pool.clear();
+        pool.retained_capacity_bytes = usize::MAX;
+        pool.release(vec![0u8; 1], true);
+        assert!(pool.buffers.is_empty());
+        pool.retained_capacity_bytes = 0;
     }
 }

--- a/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
+++ b/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
@@ -153,6 +153,9 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "virtqueue_not_ready_total ");
     expect_field(whole, "bridge_request_clone_bytes ");
     expect_field(whole, "response_buffer_alloc_bytes ");
+    expect_field(whole, "response_buffer_reuse_count ");
+    expect_field(whole, "response_buffer_zero_bytes ");
+    expect_field(whole, "response_pool_dropped_count ");
     expect_field(whole, "bytes_submitted_total ");
     expect_field(whole, "bytes_completed_total ");
     expect_field(whole, "bridge_waits_total ");
@@ -174,6 +177,12 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "bridge_queue_full_retry_success_total ");
     expect_field(whole, "hiprio_queue_full_total ");
     expect_field(whole, "request_queue_full_total ");
+    expect_field(whole, "[virtiofs_opcode]\n");
+    expect_field(whole, "opcode_1_requests_total ");
+    expect_field(whole, "opcode_15_request_bridge_copy_bytes ");
+    expect_field(whole, "opcode_16_response_buffer_alloc_count ");
+    expect_field(whole, "opcode_16_response_buffer_zero_bytes ");
+    expect_field(whole, "opcode_63_reply_payload_copy_bytes ");
 
     EXPECT_GE(parse_counter(whole, "device_queue_depth_max"), 0);
     EXPECT_GE(parse_counter(whole, "hiprio_vring_size_configured"), 0);

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -63,12 +63,16 @@ const char* result_mount_options(const Options& opt) {
 
 std::string stats_path() {
     const char* value = getenv("VIRTIOFS_STATS_PATH");
-    return value && value[0] != '\0' ? value : "/sys/kernel/debug/fuse/stats";
+    return value && value[0] != '\0' ? value : "";
 }
 
 StatsMap read_stats() {
     StatsMap stats;
-    std::ifstream in(stats_path());
+    std::string path = stats_path();
+    if (path.empty()) {
+        return stats;
+    }
+    std::ifstream in(path);
     if (!in) {
         return stats;
     }
@@ -99,8 +103,12 @@ void emit_stats_delta(const char* workload, const StatsMap& before, const StatsM
         if (old == before.end()) {
             continue;
         }
+        long long delta = item.second - old->second;
+        if (delta == 0) {
+            continue;
+        }
         printf("stats_delta workload=%s key=%s delta=%lld\n", workload, item.first.c_str(),
-               item.second - old->second);
+               delta);
     }
 }
 


### PR DESCRIPTION
## Summary

- submit stable `FuseRequest` storage directly to virtqueues instead of cloning request bytes in the bridge
- add a bounded per-session response buffer pool with checked capacity accounting and explicit teardown behavior
- size read-like response buffers from validated request limits
- add opt-in per-opcode allocation, reuse, zeroing, and reply-copy metrics
- separate uninstrumented benchmark timing from debugfs diagnostic collection
- extend direct-dequeue, oversized-request, response-pool, and debugfs regression coverage

## Motivation

The virtiofs bridge adapted in-kernel FUSE requests through a `/dev/fuse`-style byte stream, adding an ownership allocation and request copy before virtqueue submission. It also allocated a large response vector for each reply. This change removes the bridge-only request copy and reuses response storage while preserving virtqueue buffer lifetimes and FUSE reply matching.

This PR is partial progress on #2015 and intentionally does not close it. Remaining response sizing, zero-fill, ownership-transfer, and direct-page SG work is tracked by #2036, #2037, #2038, and #2039.

## Safety and error handling

- request and response storage remains owned until virtqueue completion or safe post-reset detach
- queue-full, not-ready, malformed reply, short reply, cancellation, late reply, reset, reset timeout, and unmount paths retain bounded cleanup behavior
- detailed metrics are disabled until debugfs observation starts, avoiding their atomic update cost during normal operation
- response-pool count and capacity are bounded independently

## Validation

- `make fmt`
- `make kernel`
- `make user`
- host static build of `virtiofs_bench`
- QEMU guest `fuse_stats_debugfs_test`
- QEMU guest `virtiofs_smoke_test`
- sequential read/write with `FUSE_READ`, `FUSE_WRITE`, and `FUSE_FSYNC`
- baseline/optimized/baseline performance runs with diagnostic counters disabled

The corrected multi-run comparison showed no measurable regression: metadata median improved by about 0.24%, 4 MiB sequential write by about 0.64%, and 4 MiB sequential read by about 0.51%. Request bridge copies fell to zero on measured common paths, while repeated response allocations were replaced by bounded buffer reuse.
