### PR TITLE
fix(overlayfs): revalidate backing files after copy-up

### DIFF
--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -3,6 +3,7 @@ use crate::filesystem::vfs::file::{File, FileFlags, FilePrivateData};
 use crate::filesystem::vfs::{self, vcore, FileType};
 use crate::libs::mutex::Mutex;
 use crate::mm::VmFlags;
+use crate::process::{Cred, ProcessControlBlock, ProcessManager};
 use alloc::sync::Arc;
 use core::mem;
 use system_error::SystemError;
@@ -14,18 +15,52 @@ pub struct OverlayFilePrivateData {
 
 #[derive(Debug)]
 struct OverlayFilePrivateDataInner {
+    _initial_backing_file: Arc<File>,
+    active_real_inode: Arc<dyn vfs::IndexNode>,
     backing_file: Arc<File>,
     backing_is_upper: bool,
     flags: FileFlags,
+    backing_cred: Arc<Cred>,
+}
+
+struct CredOverrideGuard {
+    pcb: Arc<ProcessControlBlock>,
+    saved_cred: Arc<Cred>,
+}
+
+impl CredOverrideGuard {
+    fn new(override_cred: Arc<Cred>) -> Result<Self, SystemError> {
+        let pcb = ProcessManager::current_pcb();
+        let saved_cred = pcb.cred();
+        pcb.set_cred(override_cred)?;
+        Ok(Self { pcb, saved_cred })
+    }
+}
+
+impl Drop for CredOverrideGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.pcb.set_cred(self.saved_cred.clone()) {
+            log::error!("overlayfs: failed to restore backing-open credentials: {err:?}");
+        }
+    }
 }
 
 impl OverlayFilePrivateData {
-    fn new(backing_file: Arc<File>, backing_is_upper: bool, flags: FileFlags) -> Self {
+    fn new(
+        active_real_inode: Arc<dyn vfs::IndexNode>,
+        backing_file: Arc<File>,
+        backing_is_upper: bool,
+        flags: FileFlags,
+        backing_cred: Arc<Cred>,
+    ) -> Self {
         Self {
             inner: Arc::new(Mutex::new(OverlayFilePrivateDataInner {
+                _initial_backing_file: backing_file.clone(),
+                active_real_inode,
                 backing_file,
                 backing_is_upper,
                 flags,
+                backing_cred,
             })),
         }
     }
@@ -65,27 +100,27 @@ pub(super) fn read_at(
             crate::libs::mutex::Mutex::new(FilePrivateData::Unused).lock(),
         );
     }
-    let (backing_file, _) = backing_file_for_io(data)?;
+    let (backing_file, _) = backing_file_for_io(inode, data)?;
     backing_file.pread(offset, len, buf)
 }
 
 pub(super) fn write_at(
-    _inode: &OvlInode,
+    inode: &OvlInode,
     offset: usize,
     len: usize,
     buf: &[u8],
     data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
 ) -> Result<usize, SystemError> {
-    let (backing_file, _) = backing_file_for_io(data)?;
+    let (backing_file, _) = backing_file_for_io(inode, data)?;
     backing_file.pwrite(offset, len, buf)
 }
 
 pub(super) fn sync_file(
-    _inode: &OvlInode,
+    inode: &OvlInode,
     datasync: bool,
     data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
 ) -> Result<(), SystemError> {
-    let (backing_file, backing_is_upper) = backing_file_for_io(data)?;
+    let (backing_file, backing_is_upper) = backing_file_for_io(inode, data)?;
     if backing_is_upper {
         backing_file.sync_range_and_check_wb_error(0, usize::MAX, datasync)
     } else {
@@ -94,13 +129,13 @@ pub(super) fn sync_file(
 }
 
 pub(super) fn sync_file_range(
-    _inode: &OvlInode,
+    inode: &OvlInode,
     start: usize,
     end: usize,
     datasync: bool,
     data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
 ) -> Result<(), SystemError> {
-    let (backing_file, backing_is_upper) = backing_file_for_io(data)?;
+    let (backing_file, backing_is_upper) = backing_file_for_io(inode, data)?;
     if backing_is_upper {
         backing_file.sync_range_and_check_wb_error(start, end, datasync)
     } else {
@@ -109,11 +144,11 @@ pub(super) fn sync_file_range(
 }
 
 pub(super) fn flush_file(
-    _inode: &OvlInode,
+    inode: &OvlInode,
     data: crate::libs::mutex::MutexGuard<FilePrivateData>,
     lock_owner: u64,
 ) -> Result<(), SystemError> {
-    let (backing_file, _) = backing_file_for_io(data)?;
+    let (backing_file, _) = backing_file_for_io(inode, data)?;
     backing_file.flush_for_close(lock_owner)
 }
 
@@ -129,35 +164,35 @@ pub(super) fn close(
 }
 
 pub(super) fn check_mmap_file(
-    _inode: &OvlInode,
+    inode: &OvlInode,
     file: &Arc<File>,
     len: usize,
     offset: usize,
     vm_flags: VmFlags,
 ) -> Result<(), SystemError> {
-    let (backing_file, _) = backing_file_for_io(file.private_data.lock())?;
+    let (backing_file, _) = backing_file_for_io(inode, file.private_data.lock())?;
     backing_file
         .inode()
         .check_mmap_file(&backing_file, len, offset, vm_flags)
 }
 
 pub(super) fn mmap_effective_file(
-    _inode: &OvlInode,
+    inode: &OvlInode,
     file: &Arc<File>,
 ) -> Result<Arc<File>, SystemError> {
-    let (backing_file, _) = backing_file_for_io(file.private_data.lock())?;
+    let (backing_file, _) = backing_file_for_io(inode, file.private_data.lock())?;
     Ok(backing_file)
 }
 
 pub(super) fn mmap_file(
-    _inode: &OvlInode,
+    inode: &OvlInode,
     file: &Arc<File>,
     start: usize,
     len: usize,
     offset: usize,
     vm_flags: VmFlags,
 ) -> Result<(), SystemError> {
-    let (backing_file, _) = backing_file_for_io(file.private_data.lock())?;
+    let (backing_file, _) = backing_file_for_io(inode, file.private_data.lock())?;
     backing_file
         .inode()
         .mmap_file(&backing_file, start, len, offset, vm_flags)
@@ -187,7 +222,12 @@ fn open_backing_file(
         && inode.copy_up_for_open(&flags)?.needs_post_open_truncate();
 
     let (backing_inode, backing_is_upper) = inode.current_realdata_inode()?;
-    let backing_file = Arc::new(File::new(backing_inode, backing_open_flags(flags))?);
+    let backing_cred = inode.overlay_fs()?.backing_cred.clone();
+    let backing_file = open_real_file_with_cred(
+        backing_inode.clone(),
+        backing_open_flags(flags),
+        backing_cred.clone(),
+    )?;
     if inode.file_type == FileType::File && backing_is_upper && needs_post_open_truncate {
         vcore::vfs_truncate_file(
             backing_file.inode(),
@@ -197,13 +237,25 @@ fn open_backing_file(
         )?;
     }
     Ok(OverlayFilePrivateData::new(
+        backing_inode,
         backing_file,
         backing_is_upper,
         flags,
+        backing_cred,
     ))
 }
 
+fn open_real_file_with_cred(
+    inode: Arc<dyn vfs::IndexNode>,
+    flags: FileFlags,
+    cred: Arc<Cred>,
+) -> Result<Arc<File>, SystemError> {
+    let _cred_guard = CredOverrideGuard::new(cred)?;
+    Ok(Arc::new(File::new(inode, flags)?))
+}
+
 fn backing_file_for_io(
+    inode: &OvlInode,
     data: crate::libs::mutex::MutexGuard<FilePrivateData>,
 ) -> Result<(Arc<File>, bool), SystemError> {
     let FilePrivateData::Overlayfs(overlay_data) = &*data else {
@@ -212,6 +264,19 @@ fn backing_file_for_io(
     let overlay_data = overlay_data.clone();
     drop(data);
 
-    let inner = overlay_data.inner.lock();
+    let mut inner = overlay_data.inner.lock();
+    let (current_real_inode, current_is_upper) = inode.current_realdata_inode()?;
+    if inner.backing_is_upper != current_is_upper
+        || !Arc::ptr_eq(&inner.active_real_inode, &current_real_inode)
+    {
+        let backing_file = open_real_file_with_cred(
+            current_real_inode.clone(),
+            backing_open_flags(inner.flags),
+            inner.backing_cred.clone(),
+        )?;
+        inner.active_real_inode = current_real_inode;
+        inner.backing_file = backing_file;
+        inner.backing_is_upper = current_is_upper;
+    }
     Ok((inner.backing_file.clone(), inner.backing_is_upper))
 }

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -4,18 +4,83 @@ use super::inode::OvlInode;
 use crate::driver::base::device::device_number::DeviceNumber;
 use crate::filesystem::vfs::mount::MountFSInode;
 use crate::filesystem::vfs::{
-    self, FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode, MountableFileSystem,
-    SuperBlock,
+    self, FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode, InodeId,
+    MountableFileSystem, SuperBlock,
 };
 use crate::libs::{casting::DowncastArc, mutex::Mutex};
+use crate::process::Cred;
 use crate::process::ProcessManager;
+use alloc::collections::BTreeMap;
 use alloc::string::String;
-use alloc::sync::Arc;
+use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use system_error::SystemError;
 
 const MAX_MOUNT_ANCESTOR_DEPTH: usize = vfs::MAX_PATHLEN;
+const INODE_CACHE_PRUNE_INTERVAL: usize = 256;
 type LowerRoot = (String, Arc<dyn IndexNode>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct RealInodeIdentity {
+    filesystem: usize,
+    dev_id: usize,
+    inode_id: InodeId,
+}
+
+impl RealInodeIdentity {
+    fn from_inode(inode: &Arc<dyn IndexNode>) -> Result<Self, SystemError> {
+        let fs = inode.fs();
+        let metadata = inode.metadata()?;
+        Ok(Self {
+            filesystem: Arc::as_ptr(&fs) as *const () as usize,
+            dev_id: metadata.dev_id,
+            inode_id: metadata.inode_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum OvlInodeOrigin {
+    Lower {
+        lower: Vec<RealInodeIdentity>,
+        upper: Option<RealInodeIdentity>,
+    },
+    Upper(RealInodeIdentity),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct OvlInodeCacheKey {
+    redirect: String,
+    origin: OvlInodeOrigin,
+}
+
+#[derive(Debug, Default)]
+struct OvlInodeCache {
+    entries: BTreeMap<OvlInodeCacheKey, Weak<OvlInode>>,
+    insertions_since_prune: usize,
+}
+
+impl OvlInodeCache {
+    fn intern(
+        &mut self,
+        key: OvlInodeCacheKey,
+        create: impl FnOnce() -> Arc<OvlInode>,
+    ) -> Arc<OvlInode> {
+        if let Some(inode) = self.entries.get(&key).and_then(Weak::upgrade) {
+            return inode;
+        }
+
+        if self.insertions_since_prune >= INODE_CACHE_PRUNE_INTERVAL {
+            self.entries.retain(|_, inode| inode.strong_count() != 0);
+            self.insertions_since_prune = 0;
+        }
+
+        let inode = create();
+        self.entries.insert(key, Arc::downgrade(&inode));
+        self.insertions_since_prune += 1;
+        inode
+    }
+}
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -38,6 +103,8 @@ pub(super) struct OverlayFS {
     pub(super) root_inode: Arc<OvlInode>,
     pub(super) super_block: SuperBlock,
     pub(super) mutation_lock: Mutex<()>,
+    pub(super) backing_cred: Arc<Cred>,
+    inode_cache: Mutex<OvlInodeCache>,
 }
 
 impl FileSystem for OverlayFS {
@@ -68,6 +135,47 @@ impl FileSystem for OverlayFS {
 impl OverlayFS {
     pub(super) fn ovl_upper_mnt(&self) -> Arc<OvlInode> {
         self.layers[0].mnt.clone()
+    }
+
+    pub(super) fn intern_inode(
+        self: &Arc<Self>,
+        redirect: String,
+        file_type: FileType,
+        upper_inode: Option<Arc<dyn IndexNode>>,
+        lower_inodes: Vec<Arc<dyn IndexNode>>,
+    ) -> Result<Arc<OvlInode>, SystemError> {
+        let origin = if lower_inodes.is_empty() {
+            OvlInodeOrigin::Upper(RealInodeIdentity::from_inode(
+                upper_inode.as_ref().ok_or(SystemError::ENOENT)?,
+            )?)
+        } else {
+            OvlInodeOrigin::Lower {
+                lower: lower_inodes
+                    .iter()
+                    .map(RealInodeIdentity::from_inode)
+                    .collect::<Result<Vec<_>, _>>()?,
+                upper: upper_inode
+                    .as_ref()
+                    .map(RealInodeIdentity::from_inode)
+                    .transpose()?,
+            }
+        };
+        let key = OvlInodeCacheKey {
+            redirect: redirect.clone(),
+            origin,
+        };
+
+        let inode = self.inode_cache.lock().intern(key, || {
+            let inode = Arc::new(OvlInode::new(
+                redirect,
+                file_type,
+                upper_inode,
+                lower_inodes,
+            ));
+            inode.set_fs(Arc::downgrade(self));
+            inode
+        });
+        Ok(inode)
     }
 
     fn same_mount_inode(
@@ -236,6 +344,7 @@ impl MountableFileSystem for OverlayFS {
         ));
 
         let super_block = SuperBlock::new(vfs::Magic::OVERLAYFS_MAGIC, 4096, 255);
+        let backing_cred = ProcessManager::current_pcb().cred();
         let fs = Arc::new_cyclic(|weak_fs| {
             for layer in &layers {
                 layer.mnt.set_fs(weak_fs.clone());
@@ -251,6 +360,8 @@ impl MountableFileSystem for OverlayFS {
                 root_inode,
                 super_block: super_block.clone(),
                 mutation_lock: Mutex::new(()),
+                backing_cred,
+                inode_cache: Mutex::new(OvlInodeCache::default()),
             }
         });
         Ok(fs)

--- a/kernel/src/filesystem/overlayfs/lookup.rs
+++ b/kernel/src/filesystem/overlayfs/lookup.rs
@@ -93,13 +93,13 @@ pub(super) fn find(
         lower_inodes[0].metadata()?.file_type
     };
 
-    let child = Arc::new(OvlInode::new(
+    let fs = inode.overlay_fs()?;
+    let child = fs.intern_inode(
         inode.child_redirect(name),
         file_type,
         upper_inode,
         lower_inodes,
-    ));
-    child.set_fs(inode.fs.lock().clone());
+    )?;
 
     Ok(child)
 }

--- a/kernel/src/mm/ucontext/address_space.rs
+++ b/kernel/src/mm/ucontext/address_space.rs
@@ -634,7 +634,10 @@ impl AddressSpace {
                 map_fail!(err);
             }
 
-            if let Err(err) = file.inode().check_mmap_file(&file, len, offset, vm_flags) {
+            if let Err(err) = vma_file
+                .inode()
+                .check_mmap_file(&vma_file, len, offset, vm_flags)
+            {
                 map_fail!(err);
             }
 
@@ -696,15 +699,16 @@ impl AddressSpace {
 
             let mut reservation = MmapReservationGuard::new(self.clone(), reservation_id);
             let hook_result =
-                file.inode()
-                    .mmap_file(&file, region.start().data(), len, offset, vm_flags);
+                vma_file
+                    .inode()
+                    .mmap_file(&vma_file, region.start().data(), len, offset, vm_flags);
             let file_mmap_opened = hook_result.is_ok();
             let mut guard = self.write();
             macro_rules! close_file_mmap_if_opened {
                 () => {
                     if file_mmap_opened {
                         InnerAddressSpace::notify_vma_close(VmaCloseNotification {
-                            file: file.clone(),
+                            file: vma_file.clone(),
                             region,
                             vm_flags,
                         });

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/mount.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/syscall.h>
@@ -924,6 +925,130 @@ TEST(OverlayFsSemantics, OpenOverlayDirectoryWithoutFsOpenHook) {
     rmdir(lower);
     rmdir(upper);
     rmdir(root);
+}
+
+TEST(OverlayFsSemantics, OldLowerFileDescriptorsSwitchToUpperAfterCopyUp) {
+    ScopedOverlayEnv scoped("overlayfs_revalidate_old_fds");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int old_fd1 = open(merged_file.c_str(), O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(old_fd1, 0) << strerror(errno);
+    int old_fd2 = open(merged_file.c_str(), O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(old_fd2, 0) << strerror(errno);
+
+    ASSERT_EQ(0, write_text(merged_file, "upper")) << strerror(errno);
+    for (int fd : {old_fd1, old_fd2}) {
+        char buf[8] = {};
+        ASSERT_EQ(5, pread(fd, buf, 5, 0)) << strerror(errno);
+        EXPECT_EQ("upper", std::string(buf, 5));
+    }
+
+    ASSERT_EQ(0, write_text(merged_file, "newer")) << strerror(errno);
+    char buf[8] = {};
+    ASSERT_EQ(5, pread(old_fd1, buf, 5, 0)) << strerror(errno);
+    EXPECT_EQ("newer", std::string(buf, 5));
+    EXPECT_EQ(0, fdatasync(old_fd1)) << strerror(errno);
+
+    EXPECT_EQ(0, close(old_fd2)) << strerror(errno);
+    EXPECT_EQ(0, close(old_fd1)) << strerror(errno);
+}
+
+TEST(OverlayFsSemantics, OldLowerFileDescriptorDoesNotFollowSameNameReplacement) {
+    ScopedOverlayEnv scoped("overlayfs_revalidate_identity");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int old_fd = open(merged_file.c_str(), O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(old_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, unlink(merged_file.c_str())) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_file, "other")) << strerror(errno);
+    EXPECT_EQ("other", read_text(merged_file));
+
+    char buf[8] = {};
+    ASSERT_EQ(5, pread(old_fd, buf, 5, 0)) << strerror(errno);
+    EXPECT_EQ("lower", std::string(buf, 5));
+    EXPECT_EQ(0, close(old_fd)) << strerror(errno);
+}
+
+TEST(OverlayFsSemantics, NewMmapFromOldLowerFdUsesUpperSnapshot) {
+    ScopedOverlayEnv scoped("overlayfs_revalidate_mmap");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "file");
+    std::string merged_file = join_path(env.merged, "file");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int old_fd = open(merged_file.c_str(), O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(old_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_file, "upper")) << strerror(errno);
+
+    void* mapping = mmap(nullptr, 4096, PROT_READ, MAP_PRIVATE, old_fd, 0);
+    ASSERT_NE(MAP_FAILED, mapping) << strerror(errno);
+    EXPECT_EQ("upper", std::string(static_cast<const char*>(mapping), 5));
+    EXPECT_EQ(0, munmap(mapping, 4096)) << strerror(errno);
+    EXPECT_EQ(0, close(old_fd)) << strerror(errno);
+}
+
+TEST(OverlayFsSemantics, LowerHardlinkRedirectsKeepIndependentCopyUpState) {
+    ScopedOverlayEnv scoped("overlayfs_revalidate_hardlinks");
+    const auto& env = scoped.env;
+    std::string lower_a = join_path(env.lower, "a");
+    std::string lower_b = join_path(env.lower, "b");
+    std::string merged_a = join_path(env.merged, "a");
+    std::string merged_b = join_path(env.merged, "b");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_a, "lower"));
+    ASSERT_EQ(0, link(lower_a.c_str(), lower_b.c_str())) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int old_a = open(merged_a.c_str(), O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(old_a, 0) << strerror(errno);
+    int old_b = open(merged_b.c_str(), O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(old_b, 0) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_a, "upper")) << strerror(errno);
+
+    char a_buf[8] = {};
+    char b_buf[8] = {};
+    ASSERT_EQ(5, pread(old_a, a_buf, 5, 0)) << strerror(errno);
+    ASSERT_EQ(5, pread(old_b, b_buf, 5, 0)) << strerror(errno);
+    EXPECT_EQ("upper", std::string(a_buf, 5));
+    EXPECT_EQ("lower", std::string(b_buf, 5));
+    EXPECT_EQ(0, close(old_b)) << strerror(errno);
+    EXPECT_EQ(0, close(old_a)) << strerror(errno);
 }
 
 TEST(OverlayFsSemantics, CopyUpLowerFilePublishesCompleteUpperFile) {
@@ -2202,6 +2327,7 @@ TEST(OverlayFsSemantics, UpperDirRenameOverNonEmptyLowerDirReturnsEnotempty) {
 TEST(OverlayFsSemantics, UpperDirRenameOverEmptyLowerDirSucceeds) {
     auto env = make_overlay_env("overlayfs_upper_dir_over_empty_lower_dir");
     std::string upper_old = join_path(env.upper, "old");
+    std::string upper_old_child = join_path(upper_old, "child");
     std::string upper_new = join_path(env.upper, "new");
     std::string lower_new = join_path(env.lower, "new");
     std::string merged_old = join_path(env.merged, "old");
@@ -2214,15 +2340,20 @@ TEST(OverlayFsSemantics, UpperDirRenameOverEmptyLowerDirSucceeds) {
     ASSERT_EQ(0, ensure_dir(env.work.c_str()));
     ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
     ASSERT_EQ(0, mkdir(upper_old.c_str(), 0755));
+    ASSERT_EQ(0, write_text(upper_old_child, "source"));
     ASSERT_EQ(0, mkdir(lower_new.c_str(), 0755));
     ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
 
+    int old_target_fd = open(merged_new.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    ASSERT_GE(old_target_fd, 0) << strerror(errno);
     ASSERT_EQ(0, rename(merged_old.c_str(), merged_new.c_str())) << strerror(errno);
 
     EXPECT_FALSE(path_exists(merged_old));
     EXPECT_TRUE(path_exists(merged_new));
     EXPECT_FALSE(path_exists(upper_old));
     EXPECT_TRUE(path_exists(upper_new));
+    EXPECT_EQ("source", read_text(join_path(merged_new, "child")));
+    EXPECT_EQ(0, close(old_target_fd)) << strerror(errno);
     cleanup_overlay_env(env);
 }
 


### PR DESCRIPTION
## Summary

- intern lower-origin overlay inodes per mount so independent lookups observe the same copy-up transition
- revalidate open overlay files against the current data inode and reopen the backing file with mount-time credentials when copy-up changes it
- keep mmap validation, hooks, VMA state, and rollback bound to one effective backing-file snapshot
- cover stale descriptors, same-name replacement, mmap selection, hardlink isolation, and directory rename replacement with regression tests

## User impact

Open file descriptions no longer continue reading or mapping stale lower-layer data after another lookup triggers copy-up. The implementation preserves the original backing-file lifetime while switching subsequent operations to the current overlay data inode.

## Validation

- `make fmt`
- `make kernel`
- `overlayfs_semantics_test` (57/57)
- `mmap_truncate_cow_test` (2/2)
- `fcntl_lock_test` (13/13)

Closes #2005
