### PR TITLE
fix(overlayfs): align hardlink copy-up semantics with Linux

### DIFF
--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -118,7 +118,7 @@ impl OvlInode {
             &metadata,
             copy_size,
         ) {
-            Self::cleanup_workdir_temp(&workdir, &temp_name);
+            let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
             return Err(err);
         }
 
@@ -133,7 +133,7 @@ impl OvlInode {
                 vfs::vcore::vfs_truncate(temp_inode.clone(), 0)
             })();
             if let Err(err) = truncate_result {
-                Self::cleanup_workdir_temp(&workdir, &temp_name);
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
                 return Err(err);
             }
             CopyUpOutcome::PublishedAfterTruncate
@@ -147,13 +147,13 @@ impl OvlInode {
                 return Ok(publish_outcome);
             }
             Err(SystemError::EEXIST) => {
-                Self::cleanup_workdir_temp(&workdir, &temp_name);
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
                 let existing = parent_inode.find(name)?;
                 *upper_inode = Some(Self::validate_existing_upper(existing, &metadata)?);
                 return Ok(CopyUpOutcome::Existing);
             }
             Err(err) => {
-                Self::cleanup_workdir_temp(&workdir, &temp_name);
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
                 return Err(err);
             }
         }

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -122,17 +122,13 @@ impl OvlInode {
             return Err(err);
         }
 
+        if let Err(err) = Self::restore_copy_up_metadata(&temp_inode, &metadata) {
+            let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+            return Err(err);
+        }
+
         let publish_outcome = if copy_size == Some(0) && metadata.file_type == FileType::File {
-            let truncate_result = (|| {
-                // Truncate privilege-bit rules must use the lower inode's semantic owner/group.
-                let mut temp_metadata = temp_inode.metadata()?;
-                temp_metadata.uid = metadata.uid;
-                temp_metadata.gid = metadata.gid;
-                temp_metadata.mode = metadata.mode;
-                temp_inode.set_metadata(&temp_metadata)?;
-                vfs::vcore::vfs_truncate(temp_inode.clone(), 0)
-            })();
-            if let Err(err) = truncate_result {
+            if let Err(err) = vfs::vcore::vfs_truncate(temp_inode.clone(), 0) {
                 let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
                 return Err(err);
             }
@@ -273,6 +269,21 @@ impl OvlInode {
             }
             _ => workdir.create_with_data(temp_name, metadata.file_type, metadata.mode, 0),
         }
+    }
+
+    fn restore_copy_up_metadata(
+        upper_inode: &Arc<dyn IndexNode>,
+        lower_metadata: &Metadata,
+    ) -> Result<(), SystemError> {
+        let mut upper_metadata = upper_inode.metadata()?;
+        if lower_metadata.file_type != FileType::SymLink {
+            upper_metadata.mode = lower_metadata.mode;
+        }
+        upper_metadata.uid = lower_metadata.uid;
+        upper_metadata.gid = lower_metadata.gid;
+        upper_metadata.atime = lower_metadata.atime;
+        upper_metadata.mtime = lower_metadata.mtime;
+        upper_inode.set_metadata(&upper_metadata)
     }
 
     fn copy_up_file_type(file_type: FileType) -> FileType {

--- a/kernel/src/filesystem/overlayfs/dir.rs
+++ b/kernel/src/filesystem/overlayfs/dir.rs
@@ -75,12 +75,28 @@ pub(super) fn link(
 ) -> Result<(), system_error::SystemError> {
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
+
+    match inode.find(name) {
+        Ok(_) => return Err(SystemError::EEXIST),
+        Err(SystemError::ENOENT) => {}
+        Err(err) => return Err(err),
+    }
+
+    let source = OvlInode::downcast_overlay_inode(other.clone())?;
+    let source_fs = source.overlay_fs()?;
+    if !Arc::ptr_eq(&fs, &source_fs) {
+        return Err(SystemError::EXDEV);
+    }
+
+    source.copy_up_locked()?;
+    let source_upper = source.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+
     create_over_whiteout(
         inode,
         name,
         |dir, temp_name| {
-            dir.link(temp_name, other)?;
-            dir.find(temp_name)
+            dir.link(temp_name, &source_upper)?;
+            Ok(source_upper.clone())
         },
         false,
     )
@@ -138,8 +154,11 @@ where
 {
     let upper_inode = inode.writable_upper_inode_locked()?;
     match upper_inode.find(name) {
-        Ok(found) if OvlInode::is_whiteout_inode(&found) => {}
-        Ok(_) => return Err(SystemError::EEXIST),
+        Ok(found) => {
+            if !OvlInode::is_whiteout_inode_checked(&found)? {
+                return Err(SystemError::EEXIST);
+            }
+        }
         Err(SystemError::ENOENT) => return create_temp(&upper_inode, name),
         Err(err) => return Err(err),
     }
@@ -162,12 +181,20 @@ where
     };
 
     if let Err(err) = commit_result {
-        OvlInode::cleanup_workdir_temp(&workdir, &temp_name);
+        if let Err(cleanup_err) = OvlInode::cleanup_workdir_temp(&workdir, &temp_name) {
+            log::error!(
+                "overlayfs: failed to clean workdir temp {temp_name} after publish error {err:?}: {cleanup_err:?}"
+            );
+        }
         return Err(err);
     }
 
     if is_dir {
-        OvlInode::cleanup_workdir_temp(&workdir, &temp_name);
+        if let Err(err) = OvlInode::cleanup_workdir_temp(&workdir, &temp_name) {
+            log::error!(
+                "overlayfs: failed to clean detached workdir temp {temp_name} after publish: {err:?}"
+            );
+        }
     }
 
     upper_inode.find(name).or(Ok(temp_inode))

--- a/kernel/src/filesystem/overlayfs/rename.rs
+++ b/kernel/src/filesystem/overlayfs/rename.rs
@@ -95,7 +95,7 @@ pub(super) fn move_to(
         }
         if source.is_dir() {
             old_upper_dir.move_to(old_name, &new_upper_dir, new_name, RenameFlags::EXCHANGE)?;
-            OvlInode::cleanup_workdir_temp(&old_upper_dir, old_name);
+            let _ = OvlInode::cleanup_workdir_temp(&old_upper_dir, old_name);
             return Ok(());
         }
     }

--- a/kernel/src/filesystem/overlayfs/whiteout.rs
+++ b/kernel/src/filesystem/overlayfs/whiteout.rs
@@ -58,7 +58,7 @@ impl OvlInode {
         };
 
         if let Err(err) = workdir.move_to(&temp_name, &upper_dir, name, flags) {
-            Self::cleanup_workdir_temp(&workdir, &temp_name);
+            let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
             return Err(err);
         }
 

--- a/kernel/src/filesystem/overlayfs/workdir.rs
+++ b/kernel/src/filesystem/overlayfs/workdir.rs
@@ -28,18 +28,21 @@ impl OvlInode {
         Err(SystemError::EEXIST)
     }
 
-    pub(super) fn cleanup_workdir_temp(workdir: &Arc<dyn IndexNode>, name: &str) {
-        let Ok(inode) = workdir.find(name) else {
-            return;
+    pub(super) fn cleanup_workdir_temp(
+        workdir: &Arc<dyn IndexNode>,
+        name: &str,
+    ) -> Result<(), SystemError> {
+        let inode = match workdir.find(name) {
+            Ok(inode) => inode,
+            Err(SystemError::ENOENT) => return Ok(()),
+            Err(err) => return Err(err),
         };
-        let Ok(metadata) = inode.metadata() else {
-            return;
-        };
+        let metadata = inode.metadata()?;
 
         if metadata.file_type == FileType::Dir {
-            let _ = workdir.rmdir(name);
+            workdir.rmdir(name)
         } else {
-            let _ = workdir.unlink(name);
+            workdir.unlink(name)
         }
     }
 }

--- a/kernel/src/filesystem/vfs/syscall/link_utils.rs
+++ b/kernel/src/filesystem/vfs/syscall/link_utils.rs
@@ -1,13 +1,17 @@
+use crate::filesystem::vfs::mount::MountFS;
+use crate::filesystem::vfs::permission::check_inode_permission;
 use crate::filesystem::vfs::permission::PermissionMask;
 use crate::filesystem::vfs::syscall::AtFlags;
 use crate::filesystem::vfs::utils::rsplit_path;
 use crate::filesystem::vfs::utils::user_path_at;
 use crate::filesystem::vfs::FileType;
 use crate::filesystem::vfs::IndexNode;
+use crate::filesystem::vfs::InodeFlags;
 use crate::filesystem::vfs::InodeMode;
 use crate::filesystem::vfs::Metadata;
 use crate::filesystem::vfs::SystemError;
 use crate::filesystem::vfs::VFS_MAX_FOLLOW_SYMLINK_TIMES;
+use crate::libs::casting::DowncastArc;
 use crate::process::cred::CAPFlags;
 use crate::process::ProcessManager;
 use alloc::sync::Arc;
@@ -75,25 +79,58 @@ pub fn do_linkat(
         )?
     };
 
-    // old_inode为目录时返回EPERM
-    if old_inode.metadata()?.file_type == FileType::Dir {
-        return Err(SystemError::EPERM);
-    }
-    // 硬链接安全检查
-    may_linkat(&old_inode)?;
-
     // 得到新创建节点的父节点
     let (new_begin_inode, new_remain_path) = user_path_at(&pcb, newfd, new)?;
     let (new_name, new_parent_path) = rsplit_path(&new_remain_path);
     let new_parent = new_begin_inode
         .lookup_follow_symlink(new_parent_path.unwrap_or("/"), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
 
+    let new_parent_metadata = new_parent.metadata()?;
+    if new_parent_metadata.file_type != FileType::Dir {
+        return Err(SystemError::ENOTDIR);
+    }
+
+    // Match Linux may_create() error ordering: search permission is needed to
+    // inspect the target, an existing target wins over a missing write bit,
+    // and write permission is checked only for a negative target.
+    check_inode_permission(&new_parent, &new_parent_metadata, PermissionMask::MAY_EXEC)?;
+    match new_parent.find(new_name) {
+        Ok(_) => return Err(SystemError::EEXIST),
+        Err(SystemError::ENOENT) => {}
+        Err(err) => return Err(err),
+    }
+
+    // Linux filename_create() lets an existing target win over a read-only
+    // mount, but returns EROFS for a negative target before later EXDEV and
+    // inode permission checks.
+    let new_parent_fs = new_parent.fs();
+    if let Some(mount_fs) = new_parent_fs.clone().downcast_arc::<MountFS>() {
+        if mount_fs.is_readonly() {
+            return Err(SystemError::EROFS);
+        }
+    }
+
     // 跨文件系统检查：类似 Linux 的 "if (dir->i_sb != inode->i_sb) return -EXDEV;"
     // 通过比较文件系统指针地址判断是否为同一文件系统实例
-    let new_parent_fs = new_parent.fs();
     let old_inode_fs = old_inode.fs();
     if !Arc::ptr_eq(&new_parent_fs, &old_inode_fs) {
         return Err(SystemError::EXDEV);
+    }
+
+    // Linux do_linkat() checks protected-hardlink policy after preparing the
+    // negative target and checking the target mount identity.
+    may_linkat(&old_inode)?;
+    check_inode_permission(&new_parent, &new_parent_metadata, PermissionMask::MAY_WRITE)?;
+
+    let old_metadata = old_inode.metadata()?;
+    if old_metadata
+        .flags
+        .intersects(InodeFlags::S_APPEND | InodeFlags::S_IMMUTABLE)
+    {
+        return Err(SystemError::EPERM);
+    }
+    if old_metadata.file_type == FileType::Dir {
+        return Err(SystemError::EPERM);
     }
 
     return new_parent.link(new_name, &old_inode).map(|_| 0);

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -1115,6 +1115,60 @@ TEST(OverlayFsSemantics, HardlinkUsesRealUpperInodeForLowerAndUpperSources) {
     EXPECT_EQ(0, overlay_temp_entry_count(env.work));
 }
 
+TEST(OverlayFsSemantics, HardlinkCopyUpPreservesLowerOwnershipAndMode) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root to prepare lower ownership";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_hardlink_copy_up_metadata");
+    const auto& env = scoped.env;
+    std::string lower_source = join_path(env.lower, "source");
+    std::string merged_source = join_path(env.merged, "source");
+    std::string merged_target = join_path(env.merged, "target");
+    std::string upper_source = join_path(env.upper, "source");
+    std::string upper_target = join_path(env.upper, "target");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_source, "lower-owned"));
+    ASSERT_EQ(0, chown(lower_source.c_str(), 1000, 1001)) << strerror(errno);
+    ASSERT_EQ(0, chmod(lower_source.c_str(), 0640)) << strerror(errno);
+
+    struct stat lower_st = {};
+    ASSERT_EQ(0, stat(lower_source.c_str(), &lower_st)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, link(merged_source.c_str(), merged_target.c_str())) << strerror(errno);
+
+    struct stat merged_source_st = {};
+    struct stat merged_target_st = {};
+    struct stat upper_source_st = {};
+    struct stat upper_target_st = {};
+    ASSERT_EQ(0, stat(merged_source.c_str(), &merged_source_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(merged_target.c_str(), &merged_target_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(upper_source.c_str(), &upper_source_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(upper_target.c_str(), &upper_target_st)) << strerror(errno);
+
+    EXPECT_EQ(lower_st.st_uid, merged_source_st.st_uid);
+    EXPECT_EQ(lower_st.st_gid, merged_source_st.st_gid);
+    EXPECT_EQ(lower_st.st_mode & 07777, merged_source_st.st_mode & 07777);
+    EXPECT_EQ(lower_st.st_uid, merged_target_st.st_uid);
+    EXPECT_EQ(lower_st.st_gid, merged_target_st.st_gid);
+    EXPECT_EQ(lower_st.st_mode & 07777, merged_target_st.st_mode & 07777);
+    EXPECT_EQ(lower_st.st_uid, upper_source_st.st_uid);
+    EXPECT_EQ(lower_st.st_gid, upper_source_st.st_gid);
+    EXPECT_EQ(lower_st.st_mode & 07777, upper_source_st.st_mode & 07777);
+    EXPECT_EQ(lower_st.st_uid, upper_target_st.st_uid);
+    EXPECT_EQ(lower_st.st_gid, upper_target_st.st_gid);
+    EXPECT_EQ(lower_st.st_mode & 07777, upper_target_st.st_mode & 07777);
+    EXPECT_EQ(upper_source_st.st_ino, upper_target_st.st_ino);
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
 TEST(OverlayFsSemantics, HardlinkExistingMergedTargetFailsBeforeSourceCopyUp) {
     ScopedOverlayEnv scoped("overlayfs_hardlink_existing_target");
     const auto& env = scoped.env;

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -1051,6 +1051,269 @@ TEST(OverlayFsSemantics, LowerHardlinkRedirectsKeepIndependentCopyUpState) {
     EXPECT_EQ(0, close(old_a)) << strerror(errno);
 }
 
+TEST(OverlayFsSemantics, HardlinkUsesRealUpperInodeForLowerAndUpperSources) {
+    ScopedOverlayEnv scoped("overlayfs_hardlink_real_upper");
+    const auto& env = scoped.env;
+    std::string lower_a = join_path(env.lower, "a");
+    std::string merged_a = join_path(env.merged, "a");
+    std::string merged_b = join_path(env.merged, "b");
+    std::string upper_a = join_path(env.upper, "a");
+    std::string upper_b = join_path(env.upper, "b");
+    std::string merged_c = join_path(env.merged, "c");
+    std::string merged_d = join_path(env.merged, "d");
+    std::string upper_c = join_path(env.upper, "c");
+    std::string upper_d = join_path(env.upper, "d");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_a, "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, link(merged_a.c_str(), merged_b.c_str())) << strerror(errno);
+
+    struct stat merged_a_st = {};
+    struct stat merged_b_st = {};
+    struct stat upper_a_st = {};
+    struct stat upper_b_st = {};
+    ASSERT_EQ(0, stat(merged_a.c_str(), &merged_a_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(merged_b.c_str(), &merged_b_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(upper_a.c_str(), &upper_a_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(upper_b.c_str(), &upper_b_st)) << strerror(errno);
+    EXPECT_EQ(merged_a_st.st_ino, merged_b_st.st_ino);
+    EXPECT_EQ(merged_a_st.st_ino, upper_a_st.st_ino);
+    EXPECT_EQ(upper_a_st.st_ino, upper_b_st.st_ino);
+    EXPECT_EQ(2u, static_cast<unsigned>(merged_a_st.st_nlink));
+    EXPECT_EQ(2u, static_cast<unsigned>(upper_b_st.st_nlink));
+
+    ASSERT_EQ(0, write_text(merged_b, "lower-linked")) << strerror(errno);
+    EXPECT_EQ("lower-linked", read_text(merged_a));
+    EXPECT_EQ("lower-linked", read_text(upper_a));
+
+    ASSERT_EQ(0, write_text(merged_c, "upper")) << strerror(errno);
+    ASSERT_EQ(0, link(merged_c.c_str(), merged_d.c_str())) << strerror(errno);
+
+    struct stat merged_c_st = {};
+    struct stat merged_d_st = {};
+    struct stat upper_c_st = {};
+    struct stat upper_d_st = {};
+    ASSERT_EQ(0, stat(merged_c.c_str(), &merged_c_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(merged_d.c_str(), &merged_d_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(upper_c.c_str(), &upper_c_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(upper_d.c_str(), &upper_d_st)) << strerror(errno);
+    EXPECT_EQ(merged_c_st.st_ino, merged_d_st.st_ino);
+    EXPECT_EQ(merged_c_st.st_ino, upper_c_st.st_ino);
+    EXPECT_EQ(upper_c_st.st_ino, upper_d_st.st_ino);
+    EXPECT_EQ(2u, static_cast<unsigned>(merged_c_st.st_nlink));
+
+    ASSERT_EQ(0, write_text(merged_d, "upper-linked")) << strerror(errno);
+    EXPECT_EQ("upper-linked", read_text(merged_c));
+    EXPECT_EQ("upper-linked", read_text(upper_c));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, HardlinkExistingMergedTargetFailsBeforeSourceCopyUp) {
+    ScopedOverlayEnv scoped("overlayfs_hardlink_existing_target");
+    const auto& env = scoped.env;
+    std::string lower_source = join_path(env.lower, "source");
+    std::string lower_target = join_path(env.lower, "target");
+    std::string upper_source = join_path(env.upper, "source");
+    std::string upper_target = join_path(env.upper, "target");
+    std::string merged_source = join_path(env.merged, "source");
+    std::string merged_target = join_path(env.merged, "target");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_source, "source"));
+    ASSERT_EQ(0, write_text(lower_target, "lower-target"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, link(merged_source.c_str(), merged_target.c_str()));
+    EXPECT_EQ(EEXIST, errno);
+    EXPECT_FALSE(path_exists(upper_source));
+    EXPECT_FALSE(path_exists(upper_target));
+    EXPECT_EQ("source", read_text(merged_source));
+    EXPECT_EQ("lower-target", read_text(merged_target));
+
+    struct stat lower_source_st = {};
+    ASSERT_EQ(0, stat(lower_source.c_str(), &lower_source_st)) << strerror(errno);
+    EXPECT_EQ(1u, static_cast<unsigned>(lower_source_st.st_nlink));
+
+    ASSERT_EQ(0, write_text(upper_target, "upper-target"));
+    errno = 0;
+    EXPECT_EQ(-1, link(merged_source.c_str(), merged_target.c_str()));
+    EXPECT_EQ(EEXIST, errno);
+    EXPECT_FALSE(path_exists(upper_source));
+    EXPECT_EQ("upper-target", read_text(merged_target));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, HardlinkMayCreatePermissionAndErrorOrdering) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root to prepare a non-owner caller";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_hardlink_permission");
+    const auto& env = scoped.env;
+    std::string lower_source = join_path(env.lower, "source");
+    std::string lower_existing = join_path(env.lower, "existing");
+    std::string upper_source = join_path(env.upper, "source");
+    std::string merged_source = join_path(env.merged, "source");
+    std::string merged_existing = join_path(env.merged, "existing");
+    std::string merged_missing = join_path(env.merged, "missing");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_source, "source"));
+    ASSERT_EQ(0, write_text(lower_existing, "existing"));
+    ASSERT_EQ(0, chown(lower_source.c_str(), 1000, 1000)) << strerror(errno);
+    ASSERT_EQ(0, chmod(env.upper.c_str(), 0555)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(1000) != 0 || setuid(1000) != 0) {
+            _exit(2);
+        }
+
+        errno = 0;
+        if (link(merged_source.c_str(), merged_existing.c_str()) != -1 || errno != EEXIST) {
+            _exit(3);
+        }
+
+        errno = 0;
+        if (link(merged_source.c_str(), merged_missing.c_str()) != -1 || errno != EACCES) {
+            _exit(4);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    EXPECT_FALSE(path_exists(upper_source));
+    EXPECT_FALSE(path_exists(merged_missing));
+}
+
+TEST(OverlayFsSemantics, HardlinkReadonlyMountAndExistingTargetErrorOrdering) {
+    ScopedOverlayEnv scoped("overlayfs_hardlink_readonly");
+    const auto& env = scoped.env;
+    std::string lower_source = join_path(env.lower, "source");
+    std::string lower_existing = join_path(env.lower, "existing");
+    std::string merged_source = join_path(env.merged, "source");
+    std::string merged_existing = join_path(env.merged, "existing");
+    std::string merged_missing = join_path(env.merged, "missing");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_source, "source"));
+    ASSERT_EQ(0, write_text(lower_existing, "existing"));
+
+    std::string options =
+        "lowerdir=" + env.lower + ",upperdir=" + env.upper + ",workdir=" + env.work;
+    ASSERT_EQ(0, mount("overlay", env.merged.c_str(), "overlay", MS_RDONLY, options.c_str()))
+        << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, link(env.merged.c_str(), merged_existing.c_str()));
+    EXPECT_EQ(EEXIST, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, link(merged_source.c_str(), merged_existing.c_str()));
+    EXPECT_EQ(EEXIST, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, link(merged_source.c_str(), merged_missing.c_str()));
+    EXPECT_EQ(EROFS, errno);
+}
+
+TEST(OverlayFsSemantics, HardlinkReplacesWhiteoutWithRealUpperInode) {
+    ScopedOverlayEnv scoped("overlayfs_hardlink_whiteout");
+    const auto& env = scoped.env;
+    std::string lower_source = join_path(env.lower, "source");
+    std::string lower_target = join_path(env.lower, "target");
+    std::string upper_source = join_path(env.upper, "source");
+    std::string upper_target = join_path(env.upper, "target");
+    std::string merged_source = join_path(env.merged, "source");
+    std::string merged_target = join_path(env.merged, "target");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_source, "source"));
+    ASSERT_EQ(0, write_text(lower_target, "lower-target"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, unlink(merged_target.c_str())) << strerror(errno);
+    ASSERT_TRUE(is_whiteout(upper_target));
+    ASSERT_EQ(0, link(merged_source.c_str(), merged_target.c_str())) << strerror(errno);
+    EXPECT_FALSE(is_whiteout(upper_target));
+    EXPECT_EQ("source", read_text(merged_target));
+    EXPECT_EQ("lower-target", read_text(lower_target));
+
+    struct stat source_st = {};
+    struct stat target_st = {};
+    ASSERT_EQ(0, stat(upper_source.c_str(), &source_st)) << strerror(errno);
+    ASSERT_EQ(0, stat(upper_target.c_str(), &target_st)) << strerror(errno);
+    EXPECT_EQ(source_st.st_ino, target_st.st_ino);
+    EXPECT_EQ(2u, static_cast<unsigned>(source_st.st_nlink));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
+TEST(OverlayFsSemantics, LowerSymlinkHardlinkUsesRealUpperInode) {
+    ScopedOverlayEnv scoped("overlayfs_hardlink_symlink");
+    const auto& env = scoped.env;
+    std::string lower_source = join_path(env.lower, "source");
+    std::string merged_source = join_path(env.merged, "source");
+    std::string merged_target = join_path(env.merged, "target");
+    std::string upper_source = join_path(env.upper, "source");
+    std::string upper_target = join_path(env.upper, "target");
+
+    ASSERT_EQ(0, ensure_dir("/tmp"));
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, symlink("symlink-value", lower_source.c_str())) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, link(merged_source.c_str(), merged_target.c_str())) << strerror(errno);
+    EXPECT_EQ("symlink-value", read_symlink_target(merged_source));
+    EXPECT_EQ("symlink-value", read_symlink_target(merged_target));
+    EXPECT_EQ("symlink-value", read_symlink_target(upper_source));
+    EXPECT_EQ("symlink-value", read_symlink_target(upper_target));
+
+    struct stat source_st = {};
+    struct stat target_st = {};
+    ASSERT_EQ(0, lstat(merged_source.c_str(), &source_st)) << strerror(errno);
+    ASSERT_EQ(0, lstat(merged_target.c_str(), &target_st)) << strerror(errno);
+    EXPECT_EQ(source_st.st_ino, target_st.st_ino);
+    EXPECT_EQ(2u, static_cast<unsigned>(source_st.st_nlink));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
 TEST(OverlayFsSemantics, CopyUpLowerFilePublishesCompleteUpperFile) {
     ScopedOverlayEnv scoped("overlayfs_copy_up_file");
     const auto& env = scoped.env;


### PR DESCRIPTION
## Summary

- fix overlayfs hardlink creation to use the copied-up real upper inode instead of forwarding the overlay inode wrapper into the backing link path
- align `do_linkat()` target lookup, permission, and read-only error ordering with Linux semantics for `EEXIST`, `EROFS`, and append/immutable hardlink rejection
- add dunitest coverage for lower and upper hardlink success, whiteout replacement, symlink hardlinks, existing-target ordering, permission ordering, and readonly-mount ordering

## Root Cause

DragonOS overlayfs passed the overlay inode wrapper into the backing filesystem hardlink path after copy-up. That broke hardlinks for lower-backed and pure-upper sources, and the surrounding syscall checks did not preserve Linux-compatible target-side error ordering or immutable/append rejection semantics.

## Validation

- `make fmt`
- `make kernel`
- `overlayfs_semantics_test --gtest_filter="*Hardlink*"`
- `overlayfs_semantics_test`

Closes: #2006