### PR TITLE
fix(overlayfs): propagate post-commit lookup errors

### DIFF
--- a/kernel/src/filesystem/overlayfs/dir.rs
+++ b/kernel/src/filesystem/overlayfs/dir.rs
@@ -163,7 +163,7 @@ where
         Err(err) => return Err(err),
     }
 
-    let (workdir, temp_inode, temp_name) = inode.create_workdir_temp(create_temp)?;
+    let (workdir, _temp_inode, temp_name) = inode.create_workdir_temp(create_temp)?;
     let commit_result = if is_dir {
         workdir.move_to(
             &temp_name,
@@ -197,7 +197,7 @@ where
         }
     }
 
-    upper_inode.find(name).or(Ok(temp_inode))
+    upper_inode.find(name)
 }
 
 fn is_dot_entry(name: &str) -> bool {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -567,6 +567,33 @@ TEST(OverlayFsSemantics, MknodWhiteoutOnOverlayIsDenied) {
     remove_tree(root);
 }
 
+TEST(OverlayFsSemantics, MknodFifoOverWhiteoutCreatesReachableUpperNode) {
+    ScopedOverlayEnv scoped("overlayfs_mknod_fifo_whiteout");
+    const auto& env = scoped.env;
+    std::string lower_entry = join_path(env.lower, "entry");
+    std::string upper_entry = join_path(env.upper, "entry");
+    std::string merged_entry = join_path(env.merged, "entry");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, write_text(lower_entry, "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    ASSERT_EQ(0, unlink(merged_entry.c_str())) << strerror(errno);
+    ASSERT_TRUE(is_whiteout(upper_entry));
+    ASSERT_EQ(0, mkfifo(merged_entry.c_str(), 0640)) << strerror(errno);
+
+    struct stat merged_st = {};
+    struct stat upper_st = {};
+    struct stat lower_st = {};
+    ASSERT_EQ(0, lstat(merged_entry.c_str(), &merged_st)) << strerror(errno);
+    ASSERT_EQ(0, lstat(upper_entry.c_str(), &upper_st)) << strerror(errno);
+    ASSERT_EQ(0, lstat(lower_entry.c_str(), &lower_st)) << strerror(errno);
+    EXPECT_TRUE(S_ISFIFO(merged_st.st_mode));
+    EXPECT_TRUE(S_ISFIFO(upper_st.st_mode));
+    EXPECT_TRUE(S_ISREG(lower_st.st_mode));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
 TEST(OverlayFsSemantics, LowerWhiteoutHidesLowerLayers) {
     char root[128] = {};
     char upper[160] = {};


### PR DESCRIPTION
## Summary

- propagate upper lookup errors after publishing an object over a whiteout
- stop treating the temporary inode as proof that the target name is reachable
- add FIFO-over-whiteout coverage for the shared mknod path

## Root cause

`create_over_whiteout()` performed a target lookup after the rename commit, but converted every lookup failure into success by returning the temporary inode. Real backing filesystem errors such as `EIO`, `EACCES`, `ESTALE`, or `ENOENT` could therefore be hidden from create, mkdir, mknod, and link callers.

The temporary reference also cannot prove target-name reachability: in the hardlink path it identifies the source upper inode, while the target directory entry is a separate name.

## Fix

Return `upper_inode.find(name)` directly after the existing publish and cleanup sequence. This preserves the backend error without changing the mutation lock, rename flow, cleanup rules, allocation behavior, or successful-path I/O count.

The regression test creates an upper whiteout from a lower regular file, replaces it through `mkfifo()`, and verifies that the merged and upper paths contain the FIFO, the lower file remains unchanged, and no workdir temporary entry remains.

## Validation

- `make fmt`
- `make kernel`
- DragonOS QEMU boot
- `OverlayFsSemantics.MknodFifoOverWhiteoutCreatesReachableUpperNode`
- complete `overlayfs_semantics_test`: 65 tests passed

The current upper filesystems do not expose a deterministic post-rename lookup fault-injection hook. The error path is therefore covered by direct result propagation, while the guest tests verify that normal create, mkdir, mknod, link, rename, copy-up, and whiteout behavior remains intact.

Closes #2007