### PR TITLE
perf(virtiofs): avoid zeroing reused response buffers

### DIFF
--- a/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -192,9 +192,26 @@ opcode_16_requests_total
 ```
 
 比较优化前后时，先确认目标 opcode 的 `requests_total` 在 workload 中确实增加。request bridge copy
-下降和 response allocation/reuse 应分别判断；`response_buffer_zero_bytes` 表示新分配初始化或复用前
-清零产生的显式写入，不应把 allocator 次数下降误报成清零带宽也下降。pool 的容量边界由实现常量和
-单元测试验证；状态型 retained gauge 不做 opt-in 输出，以免首次观测前已有 buffer 导致欠计。
+下降和 response allocation/reuse 应分别判断；`response_buffer_zero_bytes` 只表示新建 backing 的一次
+初始化，复用不再产生清零写入。pool 的容量边界由实现常量和单元测试验证；状态型 retained gauge
+不做 opt-in 输出，以免首次观测前已有 buffer 导致欠计。
+
+清零优化必须在同一个手工挂载 session 内测量，避免自动卸载清空 response pool。第一次运行用于启用
+detailed stats 并预热各响应尺寸，第二次相同运行才是 measurement：
+
+```sh
+mkdir -p /tmp/host
+mount -t virtiofs hostshare /tmp/host
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench --mount /tmp/host \
+  --workload metadata --files 64
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench --mount /tmp/host \
+  --workload metadata --files 64
+umount /tmp/host
+```
+
+工具会为全局字段和本轮活跃 opcode 显式输出 `alloc/reuse/zero_bytes` 的零增量。measurement 阶段应
+满足 `response_buffer_reuse_bytes > 0`、`response_buffer_alloc_bytes == 0`、
+`response_buffer_zero_bytes == 0`；同时检查 submitted capacity、used 与 unused tail 仍保持恒等关系。
 
 其中 `*_configured` 是配置快照，benchmark 的 `stats_delta` 通常为 0；判断队列深度是否生效时应看
 `/tmp/dbg/fuse/stats` 中的绝对值。

--- a/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
+++ b/docs/locales/en/kernel/filesystem/virtiofs_benchmark_runbook.md
@@ -197,11 +197,28 @@ opcode_16_requests_total
 
 Before comparing runs, verify that `requests_total` increased for the opcode exercised by the
 workload. Evaluate request bridge copies and response allocation/reuse separately.
-`response_buffer_zero_bytes` records explicit writes from allocation initialization or clearing a
-reused buffer before submission, so fewer allocator calls must not be reported as fewer zero-fill
-bytes. Pool capacity bounds are enforced by implementation constants and unit tests. A retained
-state gauge is intentionally not opt-in because buffers that predate the first stats read could not
-be represented accurately.
+`response_buffer_zero_bytes` records the one-time initialization of new backing storage; reuse no
+longer writes zeroes. Pool capacity bounds are enforced by implementation constants and unit tests.
+A retained state gauge is intentionally not opt-in because buffers that predate the first stats
+read could not be represented accurately.
+
+Measure the zero-fill optimization in one manually mounted session so automatic unmount does not
+clear the response pool. The first identical run enables detailed stats and warms response sizes;
+the second run is the measurement:
+
+```sh
+mkdir -p /tmp/host
+mount -t virtiofs hostshare /tmp/host
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench --mount /tmp/host \
+  --workload metadata --files 64
+VIRTIOFS_STATS_PATH=/tmp/dbg/fuse/stats /bin/virtiofs_bench --mount /tmp/host \
+  --workload metadata --files 64
+umount /tmp/host
+```
+
+The tool emits zero deltas explicitly for global and active-opcode alloc/reuse/zero byte fields.
+The measured phase should have `response_buffer_reuse_bytes > 0`,
+`response_buffer_alloc_bytes == 0`, and `response_buffer_zero_bytes == 0`.
 
 The `*_configured` fields are configuration snapshots, so their `stats_delta` is usually 0.
 Check their absolute values in `/tmp/dbg/fuse/stats` when verifying whether queue depth took effect.

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -448,6 +448,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "device-output-buffer"
+version = "0.1.0"
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +473,7 @@ dependencies = [
  "cpio_reader",
  "defer",
  "derive_builder",
+ "device-output-buffer",
  "driver_base_macros",
  "elf",
  "fdt",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -103,6 +103,7 @@ cfg-if = { version = "1.0.0" }
 derive_builder = { version = "0.20.2", default-features = false, features = [
     "alloc",
 ] }
+device-output-buffer = { path = "crates/device-output-buffer" }
 
 inherit-methods-macro = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/inherit-methods-macro", rev = "98f7e3e" }
 

--- a/kernel/crates/device-output-buffer/Cargo.toml
+++ b/kernel/crates/device-output-buffer/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "device-output-buffer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/kernel/crates/device-output-buffer/src/lib.rs
+++ b/kernel/crates/device-output-buffer/src/lib.rs
@@ -1,0 +1,352 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{boxed::Box, vec};
+use core::{mem::ManuallyDrop, slice};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferState {
+    Uninitialized,
+    Submitted,
+    Completed,
+    Reusable,
+    Invalid,
+    ResetRetired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferError {
+    InvalidLength,
+    InvalidState,
+    NotDirectMapped,
+    DmaIdentityChanged,
+    UsedLengthOverflow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DmaIdentity {
+    vaddr: usize,
+    paddr: usize,
+    len: usize,
+}
+
+/// A fixed-address, device-writable buffer whose safe readable extent is established only by a
+/// validated device completion.
+///
+/// The backing bytes are initialized once at allocation because virtio-drivers currently accepts
+/// `&mut [u8]`, not `MaybeUninit<u8>`. Reuse makes the bytes logically uninitialized: no safe byte
+/// accessor exists until `complete_after_pop` accepts the used length.
+pub struct DeviceOutputBuffer {
+    backing: ManuallyDrop<Box<[u8]>>,
+    allocation_identity: DmaIdentity,
+    writable_len: usize,
+    initialized_len: usize,
+    submitted_identity: Option<DmaIdentity>,
+    state: BufferState,
+}
+
+impl core::fmt::Debug for DeviceOutputBuffer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceOutputBuffer")
+            .field("allocation_len", &self.allocation_len())
+            .field("writable_len", &self.writable_len)
+            .field("initialized_len", &self.initialized_len)
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+impl DeviceOutputBuffer {
+    pub fn new<F>(len: usize, mut virt_to_phys: F) -> Result<Self, BufferError>
+    where
+        F: FnMut(usize) -> Option<usize>,
+    {
+        if len == 0 {
+            return Err(BufferError::InvalidLength);
+        }
+        let backing = vec![0u8; len].into_boxed_slice();
+        let vaddr = backing.as_ptr() as usize;
+        let paddr = virt_to_phys(vaddr).ok_or(BufferError::NotDirectMapped)?;
+        Ok(Self {
+            backing: ManuallyDrop::new(backing),
+            allocation_identity: DmaIdentity { vaddr, paddr, len },
+            writable_len: len,
+            initialized_len: 0,
+            submitted_identity: None,
+            state: BufferState::Uninitialized,
+        })
+    }
+
+    pub fn allocation_len(&self) -> usize {
+        self.allocation_identity.len
+    }
+
+    pub fn writable_len(&self) -> usize {
+        self.writable_len
+    }
+
+    pub fn state(&self) -> BufferState {
+        self.state
+    }
+
+    pub fn prepare<F>(&mut self, writable_len: usize, virt_to_phys: F) -> Result<(), BufferError>
+    where
+        F: FnMut(usize) -> Option<usize>,
+    {
+        if self.state != BufferState::Reusable {
+            return Err(BufferError::InvalidState);
+        }
+        if writable_len == 0 || writable_len > self.allocation_len() {
+            return Err(BufferError::InvalidLength);
+        }
+        self.verify_allocation_identity(virt_to_phys)?;
+        self.writable_len = writable_len;
+        self.initialized_len = 0;
+        self.submitted_identity = None;
+        self.state = BufferState::Uninitialized;
+        Ok(())
+    }
+
+    /// Returns the exact device-writable range for queue submission.
+    ///
+    /// # Safety
+    ///
+    /// The caller must use the slice only to create the device descriptor, must not inspect its
+    /// contents, and must call `mark_submitted` immediately if queue acceptance succeeds.
+    pub unsafe fn submission_dma_slice<F>(
+        &mut self,
+        virt_to_phys: F,
+    ) -> Result<&mut [u8], BufferError>
+    where
+        F: FnMut(usize) -> Option<usize>,
+    {
+        if self.state != BufferState::Uninitialized {
+            return Err(BufferError::InvalidState);
+        }
+        self.verify_allocation_identity(virt_to_phys)?;
+        Ok(unsafe {
+            slice::from_raw_parts_mut(self.allocation_identity.vaddr as *mut u8, self.writable_len)
+        })
+    }
+
+    /// Records queue ownership after a successful add. This operation is intentionally infallible
+    /// so no error path can occur between descriptor acceptance and the Submitted state.
+    pub fn mark_submitted(&mut self) {
+        assert_eq!(self.state, BufferState::Uninitialized);
+        self.submitted_identity = Some(DmaIdentity {
+            vaddr: self.allocation_identity.vaddr,
+            paddr: self.allocation_identity.paddr,
+            len: self.writable_len,
+        });
+        self.state = BufferState::Submitted;
+    }
+
+    /// Returns the original DMA range solely for pop/detach identity matching.
+    ///
+    /// # Safety
+    ///
+    /// The caller must use the slice only with the exact queue token returned for this submission,
+    /// must not inspect it, and must keep this owner alive if queue retirement fails.
+    pub unsafe fn retirement_dma_slice<F>(
+        &mut self,
+        virt_to_phys: F,
+    ) -> Result<&mut [u8], BufferError>
+    where
+        F: FnMut(usize) -> Option<usize>,
+    {
+        if self.state != BufferState::Submitted {
+            return Err(BufferError::InvalidState);
+        }
+        self.verify_allocation_identity(virt_to_phys)?;
+        let identity = self.submitted_identity.ok_or(BufferError::InvalidState)?;
+        let current = DmaIdentity {
+            vaddr: self.allocation_identity.vaddr,
+            paddr: self.allocation_identity.paddr,
+            len: self.writable_len,
+        };
+        if identity != current {
+            return Err(BufferError::DmaIdentityChanged);
+        }
+        Ok(unsafe { slice::from_raw_parts_mut(identity.vaddr as *mut u8, identity.len) })
+    }
+
+    /// Retires device ownership and marks exactly `used_len` bytes safely readable.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have successfully removed the descriptor associated with this buffer from
+    /// the used ring. A `Submitted` state alone does not prove that the device has stopped writing.
+    pub unsafe fn complete_after_pop(&mut self, used_len: usize) -> Result<(), BufferError> {
+        if self.state != BufferState::Submitted {
+            return Err(BufferError::InvalidState);
+        }
+        self.submitted_identity = None;
+        if used_len > self.writable_len {
+            self.initialized_len = 0;
+            self.state = BufferState::Invalid;
+            return Err(BufferError::UsedLengthOverflow);
+        }
+        self.initialized_len = used_len;
+        self.state = BufferState::Completed;
+        Ok(())
+    }
+
+    pub fn initialized_prefix(&self) -> Result<&[u8], BufferError> {
+        if self.state != BufferState::Completed {
+            return Err(BufferError::InvalidState);
+        }
+        Ok(unsafe {
+            slice::from_raw_parts(
+                self.allocation_identity.vaddr as *const u8,
+                self.initialized_len,
+            )
+        })
+    }
+
+    /// Retires a submitted buffer after device reset and descriptor detachment both succeeded.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have reset the device and successfully detached the exact descriptor
+    /// associated with this buffer, so the device can no longer access the backing allocation.
+    pub unsafe fn retire_after_reset_and_detach(&mut self) -> Result<(), BufferError> {
+        if self.state != BufferState::Submitted {
+            return Err(BufferError::InvalidState);
+        }
+        self.submitted_identity = None;
+        self.initialized_len = 0;
+        self.state = BufferState::ResetRetired;
+        Ok(())
+    }
+
+    pub fn recycle(&mut self) -> Result<(), BufferError> {
+        if !matches!(
+            self.state,
+            BufferState::Uninitialized | BufferState::Completed
+        ) {
+            return Err(BufferError::InvalidState);
+        }
+        self.initialized_len = 0;
+        self.submitted_identity = None;
+        self.state = BufferState::Reusable;
+        Ok(())
+    }
+
+    fn verify_allocation_identity<F>(&self, mut virt_to_phys: F) -> Result<(), BufferError>
+    where
+        F: FnMut(usize) -> Option<usize>,
+    {
+        let paddr =
+            virt_to_phys(self.allocation_identity.vaddr).ok_or(BufferError::NotDirectMapped)?;
+        if paddr != self.allocation_identity.paddr
+            || self.backing.as_ptr() as usize != self.allocation_identity.vaddr
+            || self.backing.len() != self.allocation_identity.len
+        {
+            return Err(BufferError::DmaIdentityChanged);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DeviceOutputBuffer {
+    fn drop(&mut self) {
+        if self.state == BufferState::Submitted {
+            // Fail safe: a live descriptor may still reference this allocation. The bridge's
+            // normal reset-timeout path quarantines its whole context; this is the last-resort
+            // safety net for unexpected owner drops.
+            return;
+        }
+        unsafe { ManuallyDrop::drop(&mut self.backing) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BufferError, BufferState, DeviceOutputBuffer};
+
+    fn direct(vaddr: usize) -> Option<usize> {
+        Some(vaddr.wrapping_sub(0x1000))
+    }
+
+    #[test]
+    fn exposes_only_validated_completion_prefix() {
+        let mut buf = DeviceOutputBuffer::new(128, direct).unwrap();
+        assert_eq!(buf.initialized_prefix(), Err(BufferError::InvalidState));
+        let ptr = unsafe { buf.submission_dma_slice(direct).unwrap().as_ptr() };
+        buf.mark_submitted();
+        assert_eq!(buf.initialized_prefix(), Err(BufferError::InvalidState));
+        let retired_ptr = unsafe { buf.retirement_dma_slice(direct).unwrap().as_ptr() };
+        assert_eq!(ptr, retired_ptr);
+        unsafe { buf.complete_after_pop(17).unwrap() };
+        assert_eq!(buf.initialized_prefix().unwrap().len(), 17);
+    }
+
+    #[test]
+    fn reuse_keeps_allocation_and_hides_old_prefix() {
+        let mut buf = DeviceOutputBuffer::new(256, direct).unwrap();
+        let ptr = unsafe { buf.submission_dma_slice(direct).unwrap().as_ptr() };
+        buf.mark_submitted();
+        unsafe { buf.complete_after_pop(128).unwrap() };
+        buf.recycle().unwrap();
+        buf.prepare(192, direct).unwrap();
+        assert_eq!(buf.allocation_len(), 256);
+        assert_eq!(buf.writable_len(), 192);
+        assert_eq!(buf.initialized_prefix(), Err(BufferError::InvalidState));
+        assert_eq!(
+            unsafe { buf.submission_dma_slice(direct).unwrap().as_ptr() },
+            ptr
+        );
+    }
+
+    #[test]
+    fn oversized_completion_is_never_exposed_or_recycled() {
+        let mut buf = DeviceOutputBuffer::new(64, direct).unwrap();
+        unsafe { buf.submission_dma_slice(direct).unwrap() };
+        buf.mark_submitted();
+        assert_eq!(
+            unsafe { buf.complete_after_pop(65) },
+            Err(BufferError::UsedLengthOverflow)
+        );
+        assert_eq!(buf.state(), BufferState::Invalid);
+        assert_eq!(buf.initialized_prefix(), Err(BufferError::InvalidState));
+        assert_eq!(buf.recycle(), Err(BufferError::InvalidState));
+    }
+
+    #[test]
+    fn identity_change_blocks_retirement_view() {
+        let mut buf = DeviceOutputBuffer::new(64, direct).unwrap();
+        unsafe { buf.submission_dma_slice(direct).unwrap() };
+        buf.mark_submitted();
+        assert_eq!(
+            unsafe { buf.retirement_dma_slice(|v| Some(v.wrapping_sub(0x2000))) },
+            Err(BufferError::DmaIdentityChanged)
+        );
+        assert_eq!(buf.state(), BufferState::Submitted);
+    }
+
+    #[test]
+    fn reset_retirement_never_exposes_bytes() {
+        let mut buf = DeviceOutputBuffer::new(64, direct).unwrap();
+        unsafe { buf.submission_dma_slice(direct).unwrap() };
+        buf.mark_submitted();
+        unsafe { buf.retirement_dma_slice(direct).unwrap() };
+        unsafe { buf.retire_after_reset_and_detach().unwrap() };
+        assert_eq!(buf.state(), BufferState::ResetRetired);
+        assert_eq!(buf.initialized_prefix(), Err(BufferError::InvalidState));
+        assert_eq!(buf.recycle(), Err(BufferError::InvalidState));
+    }
+
+    #[test]
+    fn invalid_lengths_and_states_are_rejected() {
+        assert!(matches!(
+            DeviceOutputBuffer::new(0, direct),
+            Err(BufferError::InvalidLength)
+        ));
+        let mut buf = DeviceOutputBuffer::new(64, direct).unwrap();
+        assert_eq!(buf.prepare(32, direct), Err(BufferError::InvalidState));
+        buf.recycle().unwrap();
+        assert_eq!(buf.prepare(0, direct), Err(BufferError::InvalidLength));
+        assert_eq!(buf.prepare(65, direct), Err(BufferError::InvalidLength));
+    }
+}

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -56,6 +56,8 @@ pub struct VirtioFsStatsSnapshot {
     pub virtqueue_not_ready_total: u64,
     pub submit_error_total: u64,
     pub pop_used_error_total: u64,
+    pub detach_failure_total: u64,
+    pub dma_owner_quarantined_total: u64,
     pub bridge_request_clone_count: u64,
     pub bridge_request_clone_bytes: u64,
     pub response_buffer_alloc_count: u64,
@@ -180,6 +182,8 @@ static VIRTQUEUE_FULL_TOTAL: AtomicU64 = AtomicU64::new(0);
 static VIRTQUEUE_NOT_READY_TOTAL: AtomicU64 = AtomicU64::new(0);
 static SUBMIT_ERROR_TOTAL: AtomicU64 = AtomicU64::new(0);
 static POP_USED_ERROR_TOTAL: AtomicU64 = AtomicU64::new(0);
+static DETACH_FAILURE_TOTAL: AtomicU64 = AtomicU64::new(0);
+static DMA_OWNER_QUARANTINED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_REQUEST_CLONE_COUNT: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_REQUEST_CLONE_BYTES: AtomicU64 = AtomicU64::new(0);
 static RESPONSE_BUFFER_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -651,6 +655,16 @@ pub fn on_virtiofs_pop_used_error() {
 }
 
 #[inline]
+pub fn on_virtiofs_detach_failure() {
+    inc(&DETACH_FAILURE_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_dma_owner_quarantined() {
+    inc(&DMA_OWNER_QUARANTINED_TOTAL);
+}
+
+#[inline]
 pub fn on_virtiofs_completed(used_len: usize, noreply: bool) {
     inc(&BRIDGE_COMPLETED_TOTAL);
     if noreply {
@@ -710,6 +724,8 @@ pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
         virtqueue_not_ready_total: VIRTQUEUE_NOT_READY_TOTAL.load(Ordering::Relaxed),
         submit_error_total: SUBMIT_ERROR_TOTAL.load(Ordering::Relaxed),
         pop_used_error_total: POP_USED_ERROR_TOTAL.load(Ordering::Relaxed),
+        detach_failure_total: DETACH_FAILURE_TOTAL.load(Ordering::Relaxed),
+        dma_owner_quarantined_total: DMA_OWNER_QUARANTINED_TOTAL.load(Ordering::Relaxed),
         bridge_request_clone_count: BRIDGE_REQUEST_CLONE_COUNT.load(Ordering::Relaxed),
         bridge_request_clone_bytes: BRIDGE_REQUEST_CLONE_BYTES.load(Ordering::Relaxed),
         response_buffer_alloc_count: RESPONSE_BUFFER_ALLOC_COUNT.load(Ordering::Relaxed),
@@ -794,6 +810,8 @@ virtqueue_full_total {}\n\
 virtqueue_not_ready_total {}\n\
 submit_error_total {}\n\
 pop_used_error_total {}\n\
+detach_failure_total {}\n\
+dma_owner_quarantined_total {}\n\
 bridge_request_clone_count {}\n\
 bridge_request_clone_bytes {}\n\
 response_buffer_alloc_count {}\n\
@@ -867,6 +885,8 @@ request_queue_full_total {}\n",
         virtiofs.virtqueue_not_ready_total,
         virtiofs.submit_error_total,
         virtiofs.pop_used_error_total,
+        virtiofs.detach_failure_total,
+        virtiofs.dma_owner_quarantined_total,
         virtiofs.bridge_request_clone_count,
         virtiofs.bridge_request_clone_bytes,
         virtiofs.response_buffer_alloc_count,

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -3,10 +3,10 @@ use alloc::{
     collections::{BTreeMap, VecDeque},
     string::String,
     sync::Arc,
-    vec,
     vec::Vec,
 };
 
+use device_output_buffer::{BufferError, DeviceOutputBuffer};
 use log::{debug, info, warn};
 use system_error::SystemError;
 use virtio_drivers::{
@@ -15,10 +15,12 @@ use virtio_drivers::{
 };
 
 use crate::{
+    arch::MMArch,
     driver::virtio::{
         transport::VirtIOTransport, virtio_drivers_error_to_system_error,
         virtio_fs::VirtioFsInstance,
     },
+    mm::{MemoryManagementArch, VirtAddr},
     process::{kthread::KernelThreadClosure, kthread::KernelThreadMechanism},
     time::{sleep::nanosleep, PosixTimeSpec},
 };
@@ -61,8 +63,64 @@ struct PendingReq {
 
 #[derive(Debug)]
 struct InflightReq {
-    pending: PendingReq,
-    rsp: Option<Vec<u8>>,
+    pending: Option<PendingReq>,
+    rsp: Option<DeviceOutputBuffer>,
+    descriptor_live: bool,
+}
+
+impl InflightReq {
+    fn new(pending: PendingReq, rsp: Option<DeviceOutputBuffer>) -> Self {
+        Self {
+            pending: Some(pending),
+            rsp,
+            descriptor_live: false,
+        }
+    }
+
+    fn pending(&self) -> &PendingReq {
+        self.pending
+            .as_ref()
+            .expect("inflight request must own pending metadata")
+    }
+
+    fn mark_submitted(&mut self) {
+        if let Some(rsp) = self.rsp.as_mut() {
+            rsp.mark_submitted();
+        }
+        self.descriptor_live = true;
+    }
+
+    fn mark_completed(&mut self) {
+        debug_assert!(self.descriptor_live);
+        self.descriptor_live = false;
+    }
+
+    unsafe fn mark_reset_retired_after_detach(&mut self) -> Result<(), BufferError> {
+        debug_assert!(self.descriptor_live);
+        if let Some(rsp) = self.rsp.as_mut() {
+            unsafe { rsp.retire_after_reset_and_detach()? };
+        }
+        self.descriptor_live = false;
+        Ok(())
+    }
+}
+
+impl Drop for InflightReq {
+    fn drop(&mut self) {
+        if !self.descriptor_live {
+            return;
+        }
+        // A live descriptor references both the request and optional response allocation. If a
+        // future error path drops the token owner without a successful pop or reset detach, leak
+        // both owners rather than freeing DMA-visible memory.
+        if let Some(pending) = self.pending.take() {
+            core::mem::forget(pending);
+        }
+        if let Some(rsp) = self.rsp.take() {
+            core::mem::forget(rsp);
+        }
+        stats::on_virtiofs_dma_owner_quarantined();
+    }
 }
 
 #[derive(Debug, Default)]
@@ -73,7 +131,7 @@ struct QueueBlockState {
 
 #[derive(Debug)]
 struct ResponseBufferPool {
-    buffers: Vec<Vec<u8>>,
+    buffers: Vec<DeviceOutputBuffer>,
     retained_capacity_bytes: usize,
 }
 
@@ -85,46 +143,39 @@ impl ResponseBufferPool {
         }
     }
 
-    fn acquire(&mut self, opcode: u32, len: usize) -> Vec<u8> {
+    fn acquire(&mut self, opcode: u32, len: usize) -> Result<DeviceOutputBuffer, SystemError> {
         let best_fit = self
             .buffers
             .iter()
             .enumerate()
-            .filter(|(_, buf)| buf.capacity() >= len)
-            .min_by_key(|(_, buf)| buf.capacity())
+            .filter(|(_, buf)| buf.allocation_len() >= len)
+            .min_by_key(|(_, buf)| buf.allocation_len())
             .map(|(index, _)| index);
         if let Some(index) = best_fit {
             let mut buf = self.buffers.swap_remove(index);
             self.retained_capacity_bytes = self
                 .retained_capacity_bytes
-                .checked_sub(buf.capacity())
+                .checked_sub(buf.allocation_len())
                 .expect("response pool capacity accounting underflow");
-            let old_len = buf.len();
-            if len > old_len {
-                // `resize` zero-initializes the newly exposed tail. Clear only the old prefix so
-                // every byte visible to the device is written exactly once on this reuse path.
-                buf.resize(len, 0);
-                buf[..old_len].fill(0);
-            } else {
-                buf.truncate(len);
-                buf.fill(0);
-            }
+            buf.prepare(len, response_buffer_virt_to_phys)
+                .map_err(|_| SystemError::EIO)?;
             stats::on_virtiofs_response_buffer_reuse(opcode, len);
-            stats::on_virtiofs_response_buffer_zero(opcode, len);
-            return buf;
+            return Ok(buf);
         }
 
-        let buf = vec![0u8; len];
+        let buf = DeviceOutputBuffer::new(len, response_buffer_virt_to_phys)
+            .map_err(|_| SystemError::EIO)?;
         stats::on_virtiofs_response_buffer_alloc(opcode, len);
         stats::on_virtiofs_response_buffer_zero(opcode, len);
-        buf
+        Ok(buf)
     }
 
-    fn release(&mut self, buf: Vec<u8>, reusable: bool) {
-        let capacity = buf.capacity();
+    fn release(&mut self, mut buf: DeviceOutputBuffer, reusable: bool) {
+        let capacity = buf.allocation_len();
         let next_capacity = self.retained_capacity_bytes.checked_add(capacity);
         let within_limits = reusable
-            && buf.len() <= VIRTIOFS_RSP_BUF_SIZE
+            && buf.recycle().is_ok()
+            && buf.allocation_len() <= VIRTIOFS_RSP_BUF_SIZE
             && capacity <= VIRTIOFS_RSP_BUF_SIZE
             && self.buffers.len() < VIRTIOFS_RSP_POOL_MAX_BUFFERS
             && next_capacity.is_some_and(|total| total <= VIRTIOFS_RSP_POOL_MAX_CAPACITY_BYTES);
@@ -142,6 +193,12 @@ impl ResponseBufferPool {
         self.buffers.clear();
         self.retained_capacity_bytes = 0;
     }
+}
+
+fn response_buffer_virt_to_phys(vaddr: usize) -> Option<usize> {
+    // SAFETY: DeviceOutputBuffer supplies the address of its live Box allocation. The kernel
+    // allocator obtains slab and buddy memory from the architecture direct map.
+    unsafe { MMArch::virt_2_phys(VirtAddr::new(vaddr)) }.map(|paddr| paddr.data())
 }
 
 impl Drop for ResponseBufferPool {
@@ -363,7 +420,7 @@ impl VirtioFsBridgeContext {
     fn request_inflight_contains_unique(&self, unique: u64) -> bool {
         self.request_inflight
             .iter()
-            .any(|map| map.values().any(|req| req.pending.unique == unique))
+            .any(|map| map.values().any(|req| req.pending().unique == unique))
     }
 
     fn hiprio_pending_submit_ready(&self, pending: &PendingReq) -> bool {
@@ -725,8 +782,15 @@ impl VirtioFsBridgeContext {
                         return Ok(true);
                     }
                 };
+                let rsp = match self.response_pool.acquire(pending.opcode, capacity.bytes) {
+                    Ok(rsp) => rsp,
+                    Err(e) => {
+                        self.terminate_pending_with_error(&pending, e);
+                        return Ok(true);
+                    }
+                };
                 (
-                    Some(self.response_pool.acquire(pending.opcode, capacity.bytes)),
+                    Some(rsp),
                     matches!(capacity.source, FuseReplyCapacitySource::ExplicitFallback),
                 )
             }
@@ -737,7 +801,11 @@ impl VirtioFsBridgeContext {
                 let queue = self.hiprio_vq.as_mut().ok_or(SystemError::EIO)?;
                 let token = if let Some(rsp_buf) = rsp.as_mut() {
                     let inputs = [pending.req.bytes()];
-                    let mut outputs = [rsp_buf.as_mut_slice()];
+                    let mut outputs = [unsafe {
+                        rsp_buf
+                            .submission_dma_slice(response_buffer_virt_to_phys)
+                            .map_err(|_| SystemError::EIO)?
+                    }];
                     // SAFETY: The request contains a non-empty FuseInHeader, and the reply
                     // contract makes `rsp_buf` at least a non-empty FuseOutHeader. On success,
                     // only their owners and independent metadata are moved/read before notification;
@@ -761,7 +829,11 @@ impl VirtioFsBridgeContext {
                 let queue = self.request_vqs.get_mut(slot).ok_or(SystemError::EINVAL)?;
                 let token = if let Some(rsp_buf) = rsp.as_mut() {
                     let inputs = [pending.req.bytes()];
-                    let mut outputs = [rsp_buf.as_mut_slice()];
+                    let mut outputs = [unsafe {
+                        rsp_buf
+                            .submission_dma_slice(response_buffer_virt_to_phys)
+                            .map_err(|_| SystemError::EIO)?
+                    }];
                     // SAFETY: The request contains a non-empty FuseInHeader, and the reply
                     // contract makes `rsp_buf` at least a non-empty FuseOutHeader. On success,
                     // only their owners and independent metadata are moved/read before notification;
@@ -831,10 +903,11 @@ impl VirtioFsBridgeContext {
             }
         };
 
-        if let Some(rsp_buf) = rsp.as_ref() {
-            stats::on_virtiofs_response_submitted(trace_opcode, rsp_buf.len(), fallback);
+        let mut inflight = InflightReq::new(pending, rsp);
+        inflight.mark_submitted();
+        if let Some(rsp_buf) = inflight.rsp.as_ref() {
+            stats::on_virtiofs_response_submitted(trace_opcode, rsp_buf.writable_len(), fallback);
         }
-        let inflight = InflightReq { pending, rsp };
         let replaced = match kind {
             QueueKind::Hiprio => self.hiprio_inflight.insert(token, inflight),
             QueueKind::Request(slot) => self.request_inflight[slot].insert(token, inflight),
@@ -917,55 +990,72 @@ impl VirtioFsBridgeContext {
         };
 
         let mut inflight = self.take_inflight(kind, token)?;
-
-        let used_len_res = match kind {
-            QueueKind::Hiprio => {
-                let queue = self.hiprio_vq.as_mut().ok_or(SystemError::EIO)?;
-                let inputs = [inflight.pending.req.bytes()];
-                if let Some(rsp_buf) = inflight.rsp.as_mut() {
-                    let mut outputs = [rsp_buf.as_mut_slice()];
-                    // SAFETY: `inflight` is the token-indexed owner of the exact request and
-                    // response buffers submitted by `add`. Both remain live during this call;
-                    // an error puts the same owner back, while success retires device access.
-                    unsafe { queue.pop_used(token, &inputs, &mut outputs) }
-                        .map_err(virtio_drivers_error_to_system_error)
-                } else {
-                    let mut outputs: [&mut [u8]; 0] = [];
-                    // SAFETY: `inflight` is the token-indexed owner of the exact request buffer
-                    // submitted by `add` and keeps it live during this call. This no-reply request
-                    // has no output buffer; an error restores the owner, while success retires
-                    // device access.
-                    unsafe { queue.pop_used(token, &inputs, &mut outputs) }
-                        .map_err(virtio_drivers_error_to_system_error)
+        let pending = inflight
+            .pending
+            .take()
+            .expect("inflight request must own pending metadata");
+        let inputs = [pending.req.bytes()];
+        let used_len_res = if let Some(rsp_buf) = inflight.rsp.as_mut() {
+            let output = match unsafe { rsp_buf.retirement_dma_slice(response_buffer_virt_to_phys) }
+            {
+                Ok(output) => output,
+                Err(_) => {
+                    let unique = pending.unique;
+                    inflight.pending = Some(pending);
+                    self.put_back_inflight(kind, token, inflight)?;
+                    warn!(
+                        "virtiofs bridge: response DMA identity changed unique={} token={} queue={:?}",
+                        unique, token, kind
+                    );
+                    return Err(SystemError::EIO);
                 }
+            };
+            let mut outputs = [output];
+            // SAFETY: The stateful response buffer reconstructed the exact virtual address and
+            // length recorded at add, and `req_owner` references the same immutable FuseRequest.
+            // On error the complete token owner is restored to the inflight map.
+            match kind {
+                QueueKind::Hiprio => unsafe {
+                    self.hiprio_vq
+                        .as_mut()
+                        .expect("hiprio queue was validated before taking its inflight owner")
+                        .pop_used(token, &inputs, &mut outputs)
+                },
+                QueueKind::Request(slot) => unsafe {
+                    self.request_vqs
+                        .get_mut(slot)
+                        .expect("request queue was validated before taking its inflight owner")
+                        .pop_used(token, &inputs, &mut outputs)
+                },
             }
-            QueueKind::Request(slot) => {
-                let queue = self.request_vqs.get_mut(slot).ok_or(SystemError::EINVAL)?;
-                let inputs = [inflight.pending.req.bytes()];
-                if let Some(rsp_buf) = inflight.rsp.as_mut() {
-                    let mut outputs = [rsp_buf.as_mut_slice()];
-                    // SAFETY: `inflight` is the token-indexed owner of the exact request and
-                    // response buffers submitted by `add`. Both remain live during this call;
-                    // an error puts the same owner back, while success retires device access.
-                    unsafe { queue.pop_used(token, &inputs, &mut outputs) }
-                        .map_err(virtio_drivers_error_to_system_error)
-                } else {
-                    let mut outputs: [&mut [u8]; 0] = [];
-                    // SAFETY: `inflight` is the token-indexed owner of the exact request buffer
-                    // submitted by `add` and keeps it live during this call. This no-reply request
-                    // has no output buffer; an error restores the owner, while success retires
-                    // device access.
-                    unsafe { queue.pop_used(token, &inputs, &mut outputs) }
-                        .map_err(virtio_drivers_error_to_system_error)
-                }
+            .map_err(virtio_drivers_error_to_system_error)
+        } else {
+            let mut outputs: [&mut [u8]; 0] = [];
+            // SAFETY: This no-reply request is owned by the token-indexed InflightReq and the
+            // request address/length are unchanged from add.
+            match kind {
+                QueueKind::Hiprio => unsafe {
+                    self.hiprio_vq
+                        .as_mut()
+                        .expect("hiprio queue was validated before taking its inflight owner")
+                        .pop_used(token, &inputs, &mut outputs)
+                },
+                QueueKind::Request(slot) => unsafe {
+                    self.request_vqs
+                        .get_mut(slot)
+                        .expect("request queue was validated before taking its inflight owner")
+                        .pop_used(token, &inputs, &mut outputs)
+                },
             }
+            .map_err(virtio_drivers_error_to_system_error)
         };
 
         let used_len = match used_len_res {
             Ok(v) => v as usize,
             Err(e) => {
                 stats::on_virtiofs_pop_used_error();
-                let unique = inflight.pending.unique;
+                let unique = pending.unique;
+                inflight.pending = Some(pending);
                 self.put_back_inflight(kind, token, inflight)?;
                 warn!(
                     "virtiofs bridge: pop_used failed unique={} token={} queue={:?} err={:?}",
@@ -974,51 +1064,56 @@ impl VirtioFsBridgeContext {
                 return Err(e);
             }
         };
+        inflight.mark_completed();
         stats::on_virtiofs_inflight_remove(kind.stats_kind(), 1);
+
+        let unique = pending.unique;
+        let opcode = pending.opcode;
+        let noreply = pending.noreply;
 
         let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
         trace::trace_virtiofs_complete(
-            inflight.pending.unique,
-            inflight.pending.opcode,
+            unique,
+            opcode,
             queue_kind,
             queue_slot,
             token,
             used_len as u64,
         );
 
-        if inflight.pending.noreply {
+        if noreply {
             stats::on_virtiofs_completed(used_len, true);
             return Ok(true);
         }
 
-        let rsp_buf = inflight
+        let mut rsp_buf = inflight
             .rsp
             .take()
             .expect("reply-bearing inflight request must own a response buffer");
-        stats::on_virtiofs_response_completed(inflight.pending.opcode, rsp_buf.len(), used_len);
-        if used_len > rsp_buf.len() {
+        let capacity = rsp_buf.writable_len();
+        stats::on_virtiofs_response_completed(opcode, capacity, used_len);
+        // SAFETY: pop_used succeeded for this exact token and DMA identity, so the descriptor is
+        // retired before the device-written prefix becomes readable or releasable.
+        if unsafe { rsp_buf.complete_after_pop(used_len) }.is_err() {
             stats::on_virtiofs_completed(used_len, false);
-            self.terminate_pending_with_error(&inflight.pending, SystemError::EIO);
+            self.terminate_pending_with_error(&pending, SystemError::EIO);
             self.response_pool.release(rsp_buf, false);
             return Ok(true);
         }
-        if rsp_buf.len() > used_len {
-            stats::on_virtiofs_response_buffer_waste(rsp_buf.len() - used_len);
+        if capacity > used_len {
+            stats::on_virtiofs_response_buffer_waste(capacity - used_len);
         }
         stats::on_virtiofs_completed(used_len, false);
 
-        if inflight.pending.opcode == FUSE_DESTROY && used_len == 0 {
-            let reusable = match self
-                .conn
-                .complete_destroy_without_reply(inflight.pending.unique)
-            {
+        if opcode == FUSE_DESTROY && used_len == 0 {
+            let reusable = match self.conn.complete_destroy_without_reply(unique) {
                 Ok(()) => true,
                 Err(e) => {
                     warn!(
                         "virtiofs bridge: zero-length DESTROY completion failed unique={} err={:?}",
-                        inflight.pending.unique, e
+                        unique, e
                     );
-                    self.terminate_pending_with_error(&inflight.pending, SystemError::EIO);
+                    self.terminate_pending_with_error(&pending, SystemError::EIO);
                     false
                 }
             };
@@ -1026,24 +1121,25 @@ impl VirtioFsBridgeContext {
             return Ok(true);
         }
 
-        let expected_unique = inflight.pending.unique;
-        if !Self::reply_matches_expected_unique(&rsp_buf[..used_len], expected_unique) {
+        let reply = rsp_buf
+            .initialized_prefix()
+            .expect("completion established the initialized response prefix");
+        if !Self::reply_matches_expected_unique(reply, unique) {
             warn!(
                 "virtiofs bridge: reply unique mismatch or short header expected={} opcode={} used_len={}",
-                expected_unique, inflight.pending.opcode, used_len
+                unique, opcode, used_len
             );
-            self.terminate_pending_with_error(&inflight.pending, SystemError::EIO);
+            self.terminate_pending_with_error(&pending, SystemError::EIO);
             self.response_pool.release(rsp_buf, false);
             return Ok(true);
         }
 
-        let reusable = match self.conn.write_reply(&rsp_buf[..used_len]) {
+        let reusable = match self.conn.write_reply(reply) {
             Ok(_) => true,
-            Err(SystemError::ENOENT) if inflight.pending.opcode != FUSE_DESTROY => true,
+            Err(SystemError::ENOENT) if opcode != FUSE_DESTROY => true,
             Err(e) => {
                 // Linux virtio-fs always ends a completed request from the used ring.
                 // Keep that behavior here: fail this unique instead of exiting bridge loop.
-                let unique = inflight.pending.unique;
                 let completion_err = if e == SystemError::EINVAL {
                     SystemError::EIO
                 } else {
@@ -1051,9 +1147,9 @@ impl VirtioFsBridgeContext {
                 };
                 warn!(
                     "virtiofs bridge: write_reply failed unique={} opcode={} err={:?}, complete with {:?}",
-                    unique, inflight.pending.opcode, e, completion_err
+                    unique, opcode, e, completion_err
                 );
-                self.terminate_pending_with_error(&inflight.pending, completion_err);
+                self.terminate_pending_with_error(&pending, completion_err);
                 false
             }
         };
@@ -1168,15 +1264,15 @@ impl VirtioFsBridgeContext {
 
     fn collect_inflight_reply_uniques(&self, need_reply: &mut Vec<u64>) {
         for (_, req) in self.hiprio_inflight.iter() {
-            if !req.pending.noreply {
-                need_reply.push(req.pending.unique);
+            if !req.pending().noreply {
+                need_reply.push(req.pending().unique);
             }
         }
 
         for inflight_map in &self.request_inflight {
             for (_, req) in inflight_map.iter() {
-                if !req.pending.noreply {
-                    need_reply.push(req.pending.unique);
+                if !req.pending().noreply {
+                    need_reply.push(req.pending().unique);
                 }
             }
         }
@@ -1239,14 +1335,32 @@ impl VirtioFsBridgeContext {
         queue: &mut VirtioFsQueue,
         inflight: &mut BTreeMap<u16, InflightReq>,
         kind: QueueKind,
-    ) {
+    ) -> bool {
+        let mut all_detached = true;
         for (token, req) in inflight.iter_mut() {
-            let inputs = [req.pending.req.bytes()];
+            let req_owner = req.pending().req.clone();
+            let inputs = [req_owner.bytes()];
             let result = if let Some(rsp_buf) = req.rsp.as_mut() {
-                let mut outputs = [rsp_buf.as_mut_slice()];
+                let output = match unsafe {
+                    rsp_buf.retirement_dma_slice(response_buffer_virt_to_phys)
+                } {
+                    Ok(output) => output,
+                    Err(_) => {
+                        all_detached = false;
+                        stats::on_virtiofs_detach_failure();
+                        warn!(
+                            "virtiofs bridge: response DMA identity changed during reset token={} queue={:?} unique={}",
+                            token,
+                            kind,
+                            req.pending().unique
+                        );
+                        continue;
+                    }
+                };
+                let mut outputs = [output];
                 // SAFETY: The caller invokes this only after the device reset completed, so the
-                // device can no longer access the queue. The buffers come from the same InflightReq
-                // that was inserted immediately after `VirtQueue::add` returned this token.
+                // device can no longer access the queue. The stateful buffer reconstructed the
+                // exact virtual address and length recorded for this token.
                 unsafe { queue.detach_unused(*token, &inputs, &mut outputs) }
             } else {
                 let mut outputs: [&mut [u8]; 0] = [];
@@ -1254,18 +1368,35 @@ impl VirtioFsBridgeContext {
                 unsafe { queue.detach_unused(*token, &inputs, &mut outputs) }
             };
 
-            if let Err(e) = result {
-                warn!(
-                    "virtiofs bridge: failed to detach inflight descriptor token={} queue={:?} unique={} err={:?}",
-                    token, kind, req.pending.unique, e
-                );
+            match result {
+                Ok(()) => {
+                    // SAFETY: reset preceded this drain and detach_unused just succeeded for the
+                    // exact request/response DMA identity owned by this token.
+                    if unsafe { req.mark_reset_retired_after_detach() }.is_err() {
+                        all_detached = false;
+                        stats::on_virtiofs_detach_failure();
+                    }
+                }
+                Err(e) => {
+                    all_detached = false;
+                    stats::on_virtiofs_detach_failure();
+                    warn!(
+                        "virtiofs bridge: failed to detach inflight descriptor token={} queue={:?} unique={} err={:?}",
+                        token,
+                        kind,
+                        req.pending().unique,
+                        e
+                    );
+                }
             }
         }
+        all_detached
     }
 
-    fn detach_inflight_descriptors_after_reset(&mut self) {
+    fn detach_inflight_descriptors_after_reset(&mut self) -> bool {
+        let mut all_detached = true;
         if let Some(queue) = self.hiprio_vq.as_mut() {
-            Self::detach_inflight_descriptors_for_queue(
+            all_detached &= Self::detach_inflight_descriptors_for_queue(
                 queue,
                 &mut self.hiprio_inflight,
                 QueueKind::Hiprio,
@@ -1274,13 +1405,14 @@ impl VirtioFsBridgeContext {
 
         for slot in 0..self.request_vqs.len() {
             if let Some(inflight) = self.request_inflight.get_mut(slot) {
-                Self::detach_inflight_descriptors_for_queue(
+                all_detached &= Self::detach_inflight_descriptors_for_queue(
                     &mut self.request_vqs[slot],
                     inflight,
                     QueueKind::Request(slot),
                 );
             }
         }
+        all_detached
     }
 
     fn reset_device_and_unset_queues(&mut self) -> bool {
@@ -1298,8 +1430,13 @@ impl VirtioFsBridgeContext {
                 self.instance.dev_id()
             );
             return false;
-        } else {
-            self.detach_inflight_descriptors_after_reset();
+        } else if !self.detach_inflight_descriptors_after_reset() {
+            warn!(
+                "virtiofs bridge: descriptor detach failed after reset tag='{}' dev={:?}; quarantine queues and DMA owners",
+                self.instance.tag(),
+                self.instance.dev_id()
+            );
+            return false;
         }
 
         if let Some(transport) = self.transport.as_mut() {
@@ -1789,17 +1926,26 @@ mod tests {
     }
 
     #[test]
-    fn response_pool_reuses_exact_length_and_zeroes_before_submit() {
+    fn response_pool_reuses_exact_length_without_reinitializing() {
         let mut pool = ResponseBufferPool::new();
-        let mut buf = pool.acquire(FUSE_LOOKUP, 128);
-        buf.fill(0xaa);
-        let ptr = buf.as_ptr();
+        let mut buf = pool.acquire(FUSE_LOOKUP, 128).unwrap();
+        let ptr = unsafe {
+            buf.submission_dma_slice(super::response_buffer_virt_to_phys)
+                .unwrap()
+                .as_ptr()
+        };
         pool.release(buf, true);
 
         assert_eq!(pool.buffers.len(), 1);
-        let reused = pool.acquire(FUSE_LOOKUP, 128);
-        assert_eq!(reused.as_ptr(), ptr);
-        assert!(reused.iter().all(|byte| *byte == 0));
+        let mut reused = pool.acquire(FUSE_LOOKUP, 128).unwrap();
+        let reused_ptr = unsafe {
+            reused
+                .submission_dma_slice(super::response_buffer_virt_to_phys)
+                .unwrap()
+                .as_ptr()
+        };
+        assert_eq!(reused_ptr, ptr);
+        assert_eq!(reused.writable_len(), 128);
         assert!(pool.buffers.is_empty());
         assert_eq!(pool.retained_capacity_bytes, 0);
     }
@@ -1807,40 +1953,59 @@ mod tests {
     #[test]
     fn response_pool_best_fit_reuses_larger_capacity_without_exposing_tail() {
         let mut pool = ResponseBufferPool::new();
-        let mut large = Vec::with_capacity(256);
-        large.resize(192, 0xaa);
-        let ptr = large.as_ptr();
+        let mut large = pool.acquire(FUSE_LOOKUP, 192).unwrap();
+        let ptr = unsafe {
+            large
+                .submission_dma_slice(super::response_buffer_virt_to_phys)
+                .unwrap()
+                .as_ptr()
+        };
         pool.release(large, true);
 
-        let reused = pool.acquire(FUSE_LOOKUP, 64);
-        assert_eq!(reused.as_ptr(), ptr);
-        assert_eq!(reused.len(), 64);
-        assert!(reused.iter().all(|byte| *byte == 0));
-        assert_eq!(reused.capacity(), 256);
+        let mut reused = pool.acquire(FUSE_LOOKUP, 64).unwrap();
+        let reused_ptr = unsafe {
+            reused
+                .submission_dma_slice(super::response_buffer_virt_to_phys)
+                .unwrap()
+                .as_ptr()
+        };
+        assert_eq!(reused_ptr, ptr);
+        assert_eq!(reused.writable_len(), 64);
+        assert_eq!(reused.allocation_len(), 192);
         assert_eq!(pool.retained_capacity_bytes, 0);
     }
 
     #[test]
-    fn response_pool_zeroes_old_prefix_when_reused_length_grows() {
+    fn response_pool_reuses_retained_allocation_when_writable_length_grows() {
         let mut pool = ResponseBufferPool::new();
-        let mut buf = Vec::with_capacity(256);
-        buf.resize(64, 0xaa);
-        let ptr = buf.as_ptr();
+        let mut buf = pool.acquire(FUSE_LOOKUP, 256).unwrap();
+        let ptr = unsafe {
+            buf.submission_dma_slice(super::response_buffer_virt_to_phys)
+                .unwrap()
+                .as_ptr()
+        };
         pool.release(buf, true);
 
-        let reused = pool.acquire(FUSE_LOOKUP, 128);
-        assert_eq!(reused.as_ptr(), ptr);
-        assert_eq!(reused.len(), 128);
-        assert!(reused.iter().all(|byte| *byte == 0));
+        let mut reused = pool.acquire(FUSE_LOOKUP, 128).unwrap();
+        let reused_ptr = unsafe {
+            reused
+                .submission_dma_slice(super::response_buffer_virt_to_phys)
+                .unwrap()
+                .as_ptr()
+        };
+        assert_eq!(reused_ptr, ptr);
+        assert_eq!(reused.writable_len(), 128);
     }
 
     #[test]
     fn response_pool_rejects_excess_capacity_and_nonreusable_buffers() {
         let mut pool = ResponseBufferPool::new();
-        let mut oversized_capacity = Vec::with_capacity(VIRTIOFS_RSP_BUF_SIZE + 1);
-        oversized_capacity.resize(16, 0);
+        let oversized_capacity = pool
+            .acquire(FUSE_LOOKUP, VIRTIOFS_RSP_BUF_SIZE + 1)
+            .unwrap();
         pool.release(oversized_capacity, true);
-        pool.release(vec![0u8; 16], false);
+        let nonreusable = pool.acquire(FUSE_LOOKUP, 16).unwrap();
+        pool.release(nonreusable, false);
 
         assert!(pool.buffers.is_empty());
         assert_eq!(pool.retained_capacity_bytes, 0);
@@ -1849,14 +2014,20 @@ mod tests {
     #[test]
     fn response_pool_enforces_buffer_count_and_checked_capacity() {
         let mut pool = ResponseBufferPool::new();
+        let mut buffers = Vec::new();
         for _ in 0..=VIRTIOFS_RSP_POOL_MAX_BUFFERS {
-            pool.release(vec![0u8; 1], true);
+            buffers.push(pool.acquire(FUSE_LOOKUP, 1).unwrap());
+        }
+        for buf in buffers {
+            pool.release(buf, true);
         }
         assert_eq!(pool.buffers.len(), VIRTIOFS_RSP_POOL_MAX_BUFFERS);
 
         pool.clear();
         pool.retained_capacity_bytes = usize::MAX;
-        pool.release(vec![0u8; 1], true);
+        let buf = pool.acquire(FUSE_LOOKUP, 1).unwrap();
+        pool.retained_capacity_bytes = usize::MAX;
+        pool.release(buf, true);
         assert!(pool.buffers.is_empty());
         pool.retained_capacity_bytes = 0;
     }

--- a/user/apps/tests/dunitest/suites/normal/virtiofs_smoke.cc
+++ b/user/apps/tests/dunitest/suites/normal/virtiofs_smoke.cc
@@ -9,6 +9,7 @@
 #include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/xattr.h>
@@ -16,6 +17,10 @@
 
 #ifndef EOPNOTSUPP
 #define EOPNOTSUPP 95
+#endif
+
+#ifndef FS_IOC_GETFLAGS
+#define FS_IOC_GETFLAGS _IOR('f', 1, long)
 #endif
 
 namespace {
@@ -230,6 +235,36 @@ void assert_directory_probe_loop(const char* path, int count, bool probe_xattr) 
     }
 }
 
+void assert_virtiofs_write_fsync_read_ioctl(const char* mountpoint) {
+    char path[256] = {};
+    snprintf(path, sizeof(path), "%s/.dragonos_output_buffer_test", mountpoint);
+    int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << "open(" << path << ") failed: " << strerror(errno);
+
+    static const char payload[] = "virtiofs-device-output-prefix";
+    ASSERT_EQ((ssize_t)sizeof(payload), write(fd, payload, sizeof(payload)))
+        << "write(" << path << ") failed: " << strerror(errno);
+    ASSERT_EQ(0, fsync(fd)) << "fsync(" << path << ") failed: " << strerror(errno);
+    ASSERT_EQ(0, lseek(fd, 0, SEEK_SET)) << "lseek(" << path << ") failed: " << strerror(errno);
+
+    char readback[sizeof(payload)] = {};
+    ASSERT_EQ((ssize_t)sizeof(readback), read(fd, readback, sizeof(readback)))
+        << "read(" << path << ") failed: " << strerror(errno);
+    EXPECT_EQ(0, memcmp(payload, readback, sizeof(payload)));
+
+    long flags = 0;
+    errno = 0;
+    int ioctl_rc = ioctl(fd, FS_IOC_GETFLAGS, &flags);
+    if (ioctl_rc != 0) {
+        EXPECT_TRUE(errno == ENOTTY || errno == EOPNOTSUPP || errno == ENOSYS || errno == EINVAL)
+            << "FS_IOC_GETFLAGS failed unexpectedly: errno=" << errno << " (" << strerror(errno)
+            << ")";
+    }
+
+    ASSERT_EQ(0, close(fd)) << "close(" << path << ") failed: " << strerror(errno);
+    ASSERT_EQ(0, unlink(path)) << "unlink(" << path << ") failed: " << strerror(errno);
+}
+
 bool should_skip_missing_virtiofs(int err) {
     return err == ENODEV || err == ENOENT || err == EINVAL || err == EOPNOTSUPP || err == ENOSYS;
 }
@@ -272,6 +307,7 @@ TEST(VirtioFsSmoke, MountReadExecAndOverlayLower) {
     }
 
     assert_directory_probe_loop(mnt, 3, true);
+    assert_virtiofs_write_fsync_read_ioctl(mnt);
     snprintf(path, sizeof(path), "%s/hello.txt", mnt);
     assert_file_contains_prefix(path, "virtiofs-host-file");
 
@@ -284,6 +320,12 @@ TEST(VirtioFsSmoke, MountReadExecAndOverlayLower) {
     assert_repeated_busybox_exec(local_copy, "uname", 1);
     assert_repeated_busybox_exec(path, "ls", 2);
     assert_repeated_busybox_exec(path, "uname", 3);
+
+    ASSERT_EQ(0, umount(mnt)) << "first virtiofs umount failed: " << strerror(errno);
+    ASSERT_EQ(0, mount("hostshare", mnt, "virtiofs", 0, nullptr))
+        << "virtiofs remount failed: " << strerror(errno);
+    assert_directory_probe_loop(mnt, 2, true);
+    assert_virtiofs_write_fsync_read_ioctl(mnt);
 
     snprintf(options, sizeof(options), "lowerdir=%s,upperdir=%s,workdir=%s", mnt, upper, work);
     ASSERT_EQ(0, mount("overlay", merged, "overlay", 0, options))

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -98,13 +98,41 @@ StatsMap read_stats() {
 }
 
 void emit_stats_delta(const char* workload, const StatsMap& before, const StatsMap& after) {
+    std::vector<std::string> active_opcode_prefixes;
+    const std::string requests_suffix = "_requests_total";
+    for (const auto& item : after) {
+        auto old = before.find(item.first);
+        if (old == before.end() || item.second <= old->second ||
+            item.first.rfind("virtiofs_opcode.opcode_", 0) != 0 ||
+            item.first.size() <= requests_suffix.size() ||
+            item.first.compare(item.first.size() - requests_suffix.size(), requests_suffix.size(),
+                               requests_suffix) != 0) {
+            continue;
+        }
+        active_opcode_prefixes.push_back(
+            item.first.substr(0, item.first.size() - requests_suffix.size()));
+    }
+
     for (const auto& item : after) {
         auto old = before.find(item.first);
         if (old == before.end()) {
             continue;
         }
         long long delta = item.second - old->second;
-        if (delta == 0) {
+        bool required_zero = item.first == "virtiofs.response_buffer_zero_bytes" ||
+                             item.first == "virtiofs.response_buffer_alloc_bytes" ||
+                             item.first == "virtiofs.response_buffer_reuse_bytes";
+        if (!required_zero) {
+            for (const std::string& prefix : active_opcode_prefixes) {
+                if (item.first == prefix + "_response_buffer_zero_bytes" ||
+                    item.first == prefix + "_response_buffer_alloc_bytes" ||
+                    item.first == prefix + "_response_buffer_reuse_bytes") {
+                    required_zero = true;
+                    break;
+                }
+            }
+        }
+        if (delta == 0 && !required_zero) {
             continue;
         }
         printf("stats_delta workload=%s key=%s delta=%lld\n", workload, item.first.c_str(),


### PR DESCRIPTION
## Summary

- add a fixed-address device output buffer abstraction with explicit submission, completion, reuse, invalidation, and reset-retirement states
- stop clearing the full virtiofs response buffer on every pooled reuse
- validate used lengths and DMA identities before exposing the initialized response prefix
- preserve request and response ownership across normal completion, reset, detach, and quarantine paths
- extend virtiofs metrics, smoke coverage, and warmed benchmark reporting

## Root cause

The response pool represented allocated storage, device-writable capacity, and safely readable response length with the same ordinary byte-slice length. Reusing that storage therefore required clearing the complete writable range before each submission so safe code could not observe stale tail bytes. This generated avoidable memory traffic even though virtiofsd overwrites the valid response prefix.

## Implementation

The new `device-output-buffer` abstraction retains initialized `u8` backing at a stable address while making reuse logically uninitialized. Queue-only slices are restricted to explicit unsafe DMA boundaries, and safe readers can obtain only the prefix established after a successful used-ring retirement and a checked `used_len`.

Submission records the virtual address, physical address, and writable length. Completion and reset detachment reconstruct and verify that exact identity. Oversized or malformed completions are rejected without exposing bytes, while unexpected live-owner destruction and detach failures use fail-safe quarantine behavior instead of freeing device-visible memory.

## Validation

- `cargo +nightly-2026-02-24 test -p device-output-buffer` — 6 tests passed
- `make fmt` — kernel formatting and Clippy passed
- `make kernel` — passed
- `make build SKIP_GRUB=1` — full userspace and disk image build passed
- DragonOS QEMU virtiofs smoke test — passed before and after final review fixes
- warmed metadata workload — 103,768 response bytes reused, with 0 response allocation bytes and 0 response zero bytes
- reset diagnostics — 0 detach failures and 0 quarantined DMA owners

Closes #2037
