### PR TITLE
fix(overlayfs): implement metadata and xattr semantics

### DIFF
--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -10,7 +10,7 @@ use crate::{
     arch::MMArch,
     filesystem::{
         page_cache::{PageCache, PageCacheBackend},
-        vfs::{file::FileFlags, FilePrivateData, FileType, IndexNode, Metadata},
+        vfs::{file::FileFlags, FilePrivateData, FileType, IndexNode, Metadata, SetMetadataMask},
     },
     libs::mutex::Mutex,
     mm::{readahead::FileReadaheadState, MemoryManagementArch},
@@ -23,10 +23,12 @@ use super::super::{
     },
     protocol::{
         fuse_pack_struct, fuse_read_struct, FuseAttrOut, FuseFlushIn, FuseFsyncIn, FuseOpenIn,
-        FuseOpenOut, FuseReadIn, FuseReleaseIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut, FATTR_FH,
-        FATTR_LOCKOWNER, FATTR_SIZE, FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FUSE_FLUSH, FUSE_FSYNC,
-        FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_OPEN, FUSE_OPENDIR, FUSE_READ,
-        FUSE_READ_LOCKOWNER, FUSE_SETATTR, FUSE_WRITE, FUSE_WRITE_CACHE,
+        FuseOpenOut, FuseReadIn, FuseReleaseIn, FuseSetattrIn, FuseWriteIn, FuseWriteOut,
+        FATTR_ATIME, FATTR_CTIME, FATTR_FH, FATTR_GID, FATTR_LOCKOWNER, FATTR_MODE, FATTR_MTIME,
+        FATTR_SIZE, FATTR_UID, FOPEN_KEEP_CACHE, FOPEN_NOFLUSH, FUSE_FLUSH, FUSE_FSYNC,
+        FUSE_FSYNCDIR, FUSE_FSYNC_FDATASYNC, FUSE_HANDLE_KILLPRIV, FUSE_OPEN, FUSE_OPENDIR,
+        FUSE_READ, FUSE_READ_LOCKOWNER, FUSE_SETATTR, FUSE_WRITE, FUSE_WRITEBACK_CACHE,
+        FUSE_WRITE_CACHE,
     },
 };
 use super::FuseNode;
@@ -114,6 +116,7 @@ impl FuseNode {
         len: usize,
         lock_owner: Option<u64>,
         fh: Option<u64>,
+        truncate_metadata: Option<(&Metadata, SetMetadataMask)>,
     ) -> Result<(), SystemError> {
         self.check_not_stale()?;
         let mut valid = FATTR_SIZE;
@@ -123,22 +126,70 @@ impl FuseNode {
         if fh.is_some() {
             valid |= FATTR_FH;
         }
+        let mut mode = 0;
+        let mut uid = 0;
+        let mut gid = 0;
+        let mut atime = 0;
+        let mut mtime = 0;
+        let mut ctime = 0;
+        let mut atimensec = 0;
+        let mut mtimensec = 0;
+        let mut ctimensec = 0;
+        if let Some((metadata, mask)) = truncate_metadata {
+            let automatic = mask.contains(SetMetadataMask::WRITE_SIDE_EFFECT);
+            let conn = self.conn();
+            let daemon_handles_killpriv = conn.has_init_flag(FUSE_HANDLE_KILLPRIV);
+            let trust_local_cmtime = conn.has_init_flag(FUSE_WRITEBACK_CACHE);
+
+            // Linux sends truncate and its killpriv state in one SETATTR.
+            // With HANDLE_KILLPRIV the daemon owns the mode transition.
+            if mask.contains(SetMetadataMask::MODE) && !(automatic && daemon_handles_killpriv) {
+                valid |= FATTR_MODE;
+                mode = metadata.mode.bits();
+            }
+            if mask.contains(SetMetadataMask::UID) {
+                valid |= FATTR_UID;
+                uid = metadata.uid as u32;
+            }
+            if mask.contains(SetMetadataMask::GID) {
+                valid |= FATTR_GID;
+                gid = metadata.gid as u32;
+            }
+            if mask.contains(SetMetadataMask::ATIME) {
+                valid |= FATTR_ATIME;
+                atime = metadata.atime.tv_sec as u64;
+                atimensec = metadata.atime.tv_nsec as u32;
+            }
+            // DragonOS does not currently negotiate WRITEBACK_CACHE. Match
+            // Linux FUSE by accepting the daemon-returned cmtime for truncate
+            // instead of sending a second SETATTR without the file handle.
+            if mask.contains(SetMetadataMask::MTIME) && (!automatic || trust_local_cmtime) {
+                valid |= FATTR_MTIME;
+                mtime = metadata.mtime.tv_sec as u64;
+                mtimensec = metadata.mtime.tv_nsec as u32;
+            }
+            if mask.contains(SetMetadataMask::CTIME) && (!automatic || trust_local_cmtime) {
+                valid |= FATTR_CTIME;
+                ctime = metadata.ctime.tv_sec as u64;
+                ctimensec = metadata.ctime.tv_nsec as u32;
+            }
+        }
         let inarg = FuseSetattrIn {
             valid,
             padding: 0,
             fh: fh.unwrap_or(0),
             size: len as u64,
             lock_owner: lock_owner.unwrap_or(0),
-            atime: 0,
-            mtime: 0,
-            ctime: 0,
-            atimensec: 0,
-            mtimensec: 0,
-            ctimensec: 0,
-            mode: 0,
+            atime,
+            mtime,
+            ctime,
+            atimensec,
+            mtimensec,
+            ctimensec,
+            mode,
             unused4: 0,
-            uid: 0,
-            gid: 0,
+            uid,
+            gid,
             unused5: 0,
         };
         let payload = self

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -12,7 +12,8 @@ use crate::{
             permission::PermissionMask,
             syscall::RenameFlags,
             utils::DName,
-            FilePrivateData, FileSystem, FileType, IndexNode, InodeMode, Metadata, XattrFlags,
+            FilePrivateData, FileSystem, FileType, IndexNode, InodeMode, Metadata, SetMetadataMask,
+            XattrFlags,
         },
     },
     libs::{casting::DowncastArc, mutex::MutexGuard},
@@ -549,11 +550,11 @@ impl IndexNode for FuseNode {
     }
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
-        self.setattr_size(len, None, None)
+        self.setattr_size(len, None, None, None)
     }
 
     fn resize_with_lock_owner(&self, len: usize, lock_owner: u64) -> Result<(), SystemError> {
-        self.setattr_size(len, Some(lock_owner), None)
+        self.setattr_size(len, Some(lock_owner), None, None)
     }
 
     fn resize_file(
@@ -572,8 +573,45 @@ impl IndexNode for FuseNode {
         drop(data);
 
         match fuse_data {
-            FuseFilePrivateData::File(p) => self.setattr_size(len, Some(lock_owner), Some(p.fh)),
+            FuseFilePrivateData::File(p) => {
+                self.setattr_size(len, Some(lock_owner), Some(p.fh), None)
+            }
             _ => self.resize_with_lock_owner(len, lock_owner),
+        }
+    }
+
+    fn resize_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        self.setattr_size(len, Some(lock_owner), None, Some((metadata, mask)))
+    }
+
+    fn resize_file_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        let fuse_data = match &*data {
+            FilePrivateData::Fuse(data) => data.clone(),
+            _ => {
+                drop(data);
+                return self.resize_with_metadata(len, lock_owner, metadata, mask);
+            }
+        };
+        drop(data);
+
+        match fuse_data {
+            FuseFilePrivateData::File(p) => {
+                self.setattr_size(len, Some(lock_owner), Some(p.fh), Some((metadata, mask)))
+            }
+            _ => self.resize_with_metadata(len, lock_owner, metadata, mask),
         }
     }
 

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -137,7 +137,10 @@ impl OvlInode {
             return Err(err);
         }
 
-        if copy_size == Some(0) && metadata.file_type == FileType::File {
+        // A length-aware copy-up already contains the post-truncate data.
+        // Drop capabilities before publishing that changed content so lookup
+        // and exec can never observe a stale capability on the new upper.
+        if copy_size.is_some() && metadata.file_type == FileType::File {
             if let Err(err) = metadata::remove_security_capability(&temp_inode) {
                 let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
                 return Err(err);

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -1,10 +1,11 @@
 use super::inode::OvlInode;
+use super::{cred::CredOverrideGuard, metadata};
 use crate::filesystem::vfs::{
     self,
     file::{File, FileFlags, FilePrivateData},
     syscall::RenameFlags,
     utils::should_remove_sgid,
-    FileType, IndexNode, Metadata, MAX_PATHLEN,
+    FileType, IndexNode, Metadata, SetMetadataMask, MAX_PATHLEN,
 };
 use crate::libs::mutex::Mutex;
 use crate::process::{
@@ -77,6 +78,9 @@ impl OvlInode {
         &self,
         copy_size: Option<usize>,
     ) -> Result<CopyUpOutcome, SystemError> {
+        let fs = self.overlay_fs()?;
+        let caller_cred = ProcessManager::current_pcb().cred();
+        let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
         let mut upper_inode = self.upper_inode.lock();
         if upper_inode.is_some() {
             return Ok(CopyUpOutcome::Existing);
@@ -85,7 +89,7 @@ impl OvlInode {
         let lower_inode = self.lower_inodes.first().ok_or(SystemError::ENOENT)?;
 
         let mut metadata = lower_inode.metadata()?;
-        Self::adjust_metadata_for_truncate_copy_up(&mut metadata, copy_size);
+        Self::adjust_metadata_for_truncate_copy_up(&mut metadata, copy_size, &caller_cred);
         if self.redirect.is_empty() {
             *upper_inode = Some(self.upper_root_inode()?);
             return Ok(CopyUpOutcome::Existing);
@@ -95,7 +99,9 @@ impl OvlInode {
         let parent_inode = self.ensure_upper_dir_path(parent_path)?;
         match parent_inode.find(name) {
             Ok(existing) => {
-                *upper_inode = Some(Self::validate_existing_upper(existing, &metadata)?);
+                let existing = Self::validate_existing_upper(existing, &metadata)?;
+                self.set_origin(metadata::load_origin(self, &existing)?);
+                *upper_inode = Some(existing);
                 return Ok(CopyUpOutcome::Existing);
             }
             Err(SystemError::ENOENT) => {}
@@ -122,6 +128,19 @@ impl OvlInode {
             return Err(err);
         }
 
+        if let Err(err) = metadata::copy_xattrs(lower_inode, &temp_inode) {
+            let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+            return Err(err);
+        }
+
+        let origin = match metadata::prepare_origin(self, lower_inode, &temp_inode, &metadata) {
+            Ok(origin) => origin,
+            Err(err) => {
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+                return Err(err);
+            }
+        };
+
         if let Err(err) = Self::restore_copy_up_metadata(&temp_inode, &metadata) {
             let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
             return Err(err);
@@ -137,15 +156,26 @@ impl OvlInode {
             CopyUpOutcome::Published
         };
 
+        let parent_metadata = match parent_inode.metadata() {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+                return Err(err);
+            }
+        };
         match workdir.move_to(&temp_name, &parent_inode, name, RenameFlags::NOREPLACE) {
             Ok(()) => {
+                Self::restore_parent_timestamps(&parent_inode, &parent_metadata);
+                self.set_origin(origin);
                 *upper_inode = Some(Self::validate_existing_upper(temp_inode, &metadata)?);
                 return Ok(publish_outcome);
             }
             Err(SystemError::EEXIST) => {
                 let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
                 let existing = parent_inode.find(name)?;
-                *upper_inode = Some(Self::validate_existing_upper(existing, &metadata)?);
+                let existing = Self::validate_existing_upper(existing, &metadata)?;
+                self.set_origin(metadata::load_origin(self, &existing)?);
+                *upper_inode = Some(existing);
                 return Ok(CopyUpOutcome::Existing);
             }
             Err(err) => {
@@ -176,10 +206,16 @@ impl OvlInode {
             current_path.push_str(component);
 
             match current.find(component) {
-                Ok(next) => current = next,
+                Ok(next) => {
+                    if Self::is_whiteout_inode_checked(&next)?
+                        || next.metadata()?.file_type != FileType::Dir
+                    {
+                        return Err(SystemError::ENOTDIR);
+                    }
+                    current = next;
+                }
                 Err(SystemError::ENOENT) => {
-                    let mode = self.lower_dir_mode(&current_path)?;
-                    current = current.mkdir(component, mode)?;
+                    current = self.copy_up_dir_component(&current, component, &current_path)?;
                 }
                 Err(err) => return Err(err),
             }
@@ -188,17 +224,64 @@ impl OvlInode {
         Ok(current)
     }
 
-    fn lower_dir_mode(&self, path: &str) -> Result<vfs::InodeMode, SystemError> {
+    fn lower_dir_inode(&self, path: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
         let fs = self.overlay_fs()?;
         for layer in fs.layers.iter().skip(1) {
             if let Some(lower_root) = layer.mnt.lower_inodes.first() {
                 if let Ok(inode) = lower_root.lookup(path) {
-                    return Ok(inode.metadata()?.mode);
+                    if inode.metadata()?.file_type == FileType::Dir {
+                        return Ok(inode);
+                    }
+                    return Err(SystemError::ENOTDIR);
                 }
             }
         }
+        Err(SystemError::ENOENT)
+    }
 
-        Ok(vfs::InodeMode::S_IRWXUGO)
+    fn copy_up_dir_component(
+        &self,
+        upper_parent: &Arc<dyn IndexNode>,
+        name: &str,
+        lower_path: &str,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let lower = self.lower_dir_inode(lower_path)?;
+        let lower_metadata = lower.metadata()?;
+        let parent_metadata = upper_parent.metadata()?;
+        let (workdir, temp, temp_name) = self.create_workdir_temp(|workdir, temp_name| {
+            workdir.mkdir(temp_name, lower_metadata.mode)
+        })?;
+
+        let prepared = (|| {
+            metadata::copy_xattrs(&lower, &temp)?;
+            metadata::prepare_origin(self, &lower, &temp, &lower_metadata)?;
+            Self::restore_copy_up_metadata(&temp, &lower_metadata)
+        })();
+        if let Err(err) = prepared {
+            let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+            return Err(err);
+        }
+
+        match workdir.move_to(&temp_name, upper_parent, name, RenameFlags::NOREPLACE) {
+            Ok(()) => {
+                Self::restore_parent_timestamps(upper_parent, &parent_metadata);
+                Ok(temp)
+            }
+            Err(SystemError::EEXIST) => {
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+                let existing = upper_parent.find(name)?;
+                if Self::is_whiteout_inode_checked(&existing)?
+                    || existing.metadata()?.file_type != FileType::Dir
+                {
+                    return Err(SystemError::EIO);
+                }
+                Ok(existing)
+            }
+            Err(err) => {
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+                Err(err)
+            }
+        }
     }
 
     fn validate_existing_upper(
@@ -225,12 +308,16 @@ impl OvlInode {
         Ok(inode)
     }
 
-    fn adjust_metadata_for_truncate_copy_up(metadata: &mut Metadata, copy_size: Option<usize>) {
+    fn adjust_metadata_for_truncate_copy_up(
+        metadata: &mut Metadata,
+        copy_size: Option<usize>,
+        caller_cred: &Arc<Cred>,
+    ) {
         if copy_size != Some(0) || metadata.file_type != FileType::File {
             return;
         }
 
-        Self::clear_suid_sgid_for_current_cred(metadata, &ProcessManager::current_pcb().cred());
+        Self::clear_suid_sgid_for_current_cred(metadata, caller_cred);
     }
 
     fn clear_suid_sgid_for_current_cred(metadata: &mut Metadata, cred: &Arc<Cred>) {
@@ -284,6 +371,18 @@ impl OvlInode {
         upper_metadata.atime = lower_metadata.atime;
         upper_metadata.mtime = lower_metadata.mtime;
         upper_inode.set_metadata(&upper_metadata)
+    }
+
+    fn restore_parent_timestamps(parent: &Arc<dyn IndexNode>, saved: &Metadata) {
+        let result = (|| {
+            let mut current = parent.metadata()?;
+            current.atime = saved.atime;
+            current.mtime = saved.mtime;
+            parent.set_metadata_masked(&current, SetMetadataMask::ATIME | SetMetadataMask::MTIME)
+        })();
+        if let Err(err) = result {
+            log::warn!("overlayfs: failed to restore parent timestamps: {err:?}");
+        }
     }
 
     fn copy_up_file_type(file_type: FileType) -> FileType {

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -133,6 +133,13 @@ impl OvlInode {
             return Err(err);
         }
 
+        if copy_size == Some(0) && metadata.file_type == FileType::File {
+            if let Err(err) = metadata::remove_security_capability(&temp_inode) {
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+                return Err(err);
+            }
+        }
+
         let origin = match metadata::prepare_origin(self, lower_inode, &temp_inode, &metadata) {
             Ok(origin) => origin,
             Err(err) => {

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -74,6 +74,10 @@ impl OvlInode {
         self.copy_up_locked_with_size(None).map(|_| ())
     }
 
+    pub(super) fn copy_up_locked_for_truncate(&self, len: usize) -> Result<(), SystemError> {
+        self.copy_up_locked_with_size(Some(len)).map(|_| ())
+    }
+
     fn copy_up_locked_with_size(
         &self,
         copy_size: Option<usize>,
@@ -320,7 +324,7 @@ impl OvlInode {
         copy_size: Option<usize>,
         caller_cred: &Arc<Cred>,
     ) {
-        if copy_size != Some(0) || metadata.file_type != FileType::File {
+        if copy_size.is_none() || metadata.file_type != FileType::File {
             return;
         }
 
@@ -424,7 +428,8 @@ impl OvlInode {
             return Ok(());
         }
 
-        let size = copy_size.unwrap_or_else(|| metadata.size.max(0) as usize);
+        let lower_size = metadata.size.max(0) as usize;
+        let size = copy_size.map_or(lower_size, |target_size| target_size.min(lower_size));
         if size == 0 {
             return Ok(());
         }

--- a/kernel/src/filesystem/overlayfs/cred.rs
+++ b/kernel/src/filesystem/overlayfs/cred.rs
@@ -1,0 +1,28 @@
+use crate::process::{Cred, ProcessControlBlock, ProcessManager};
+use alloc::sync::Arc;
+use system_error::SystemError;
+
+/// RAII guard for Linux-style overlayfs backing credential overrides.
+///
+/// Callers must finish all user-memory access before constructing this guard.
+pub(super) struct CredOverrideGuard {
+    pcb: Arc<ProcessControlBlock>,
+    saved_cred: Arc<Cred>,
+}
+
+impl CredOverrideGuard {
+    pub(super) fn new(override_cred: Arc<Cred>) -> Result<Self, SystemError> {
+        let pcb = ProcessManager::current_pcb();
+        let saved_cred = pcb.cred();
+        pcb.set_cred(override_cred)?;
+        Ok(Self { pcb, saved_cred })
+    }
+}
+
+impl Drop for CredOverrideGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.pcb.set_cred(self.saved_cred.clone()) {
+            log::error!("overlayfs: failed to restore backing credentials: {err:?}");
+        }
+    }
+}

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -1,9 +1,10 @@
+use super::cred::CredOverrideGuard;
 use super::inode::OvlInode;
 use crate::filesystem::vfs::file::{File, FileFlags, FilePrivateData};
 use crate::filesystem::vfs::{self, vcore, FileType};
 use crate::libs::mutex::Mutex;
 use crate::mm::VmFlags;
-use crate::process::{Cred, ProcessControlBlock, ProcessManager};
+use crate::process::Cred;
 use alloc::sync::Arc;
 use core::mem;
 use system_error::SystemError;
@@ -21,28 +22,6 @@ struct OverlayFilePrivateDataInner {
     backing_is_upper: bool,
     flags: FileFlags,
     backing_cred: Arc<Cred>,
-}
-
-struct CredOverrideGuard {
-    pcb: Arc<ProcessControlBlock>,
-    saved_cred: Arc<Cred>,
-}
-
-impl CredOverrideGuard {
-    fn new(override_cred: Arc<Cred>) -> Result<Self, SystemError> {
-        let pcb = ProcessManager::current_pcb();
-        let saved_cred = pcb.cred();
-        pcb.set_cred(override_cred)?;
-        Ok(Self { pcb, saved_cred })
-    }
-}
-
-impl Drop for CredOverrideGuard {
-    fn drop(&mut self) {
-        if let Err(err) = self.pcb.set_cred(self.saved_cred.clone()) {
-            log::error!("overlayfs: failed to restore backing-open credentials: {err:?}");
-        }
-    }
 }
 
 impl OverlayFilePrivateData {

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -1,7 +1,7 @@
 use super::cred::CredOverrideGuard;
 use super::inode::OvlInode;
 use crate::filesystem::vfs::file::{File, FileFlags, FilePrivateData};
-use crate::filesystem::vfs::{self, vcore, FileType};
+use crate::filesystem::vfs::{self, vcore, FileType, Metadata, SetMetadataMask};
 use crate::libs::mutex::Mutex;
 use crate::mm::VmFlags;
 use crate::process::Cred;
@@ -129,6 +129,27 @@ pub(super) fn flush_file(
 ) -> Result<(), SystemError> {
     let (backing_file, _) = backing_file_for_io(inode, data)?;
     backing_file.flush_for_close(lock_owner)
+}
+
+pub(super) fn resize_file_with_metadata(
+    inode: &OvlInode,
+    data: crate::libs::mutex::MutexGuard<FilePrivateData>,
+    len: usize,
+    lock_owner: u64,
+    metadata: &Metadata,
+    mask: SetMetadataMask,
+) -> Result<(), SystemError> {
+    let (backing_file, backing_is_upper) = backing_file_for_io(inode, data)?;
+    if !backing_is_upper {
+        return Err(SystemError::EIO);
+    }
+    backing_file.inode().resize_file_with_metadata(
+        len,
+        lock_owner,
+        backing_file.private_data.lock(),
+        metadata,
+        mask,
+    )
 }
 
 pub(super) fn close(

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -90,7 +90,16 @@ pub(super) fn write_at(
     buf: &[u8],
     data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
 ) -> Result<usize, SystemError> {
+    if len == 0 {
+        let (backing_file, _) = backing_file_for_io(inode, data)?;
+        return backing_file.pwrite(offset, len, buf);
+    }
+
+    let _privilege_guard = inode.content_privilege_lock.lock();
     let (backing_file, _) = backing_file_for_io(inode, data)?;
+    let fs = inode.overlay_fs()?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    super::metadata::remove_security_capability(&backing_file.inode())?;
     backing_file.pwrite(offset, len, buf)
 }
 

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -2,22 +2,24 @@ use super::config::OverlayMountData;
 use super::entry::OvlLayer;
 use super::inode::OvlInode;
 use crate::driver::base::device::device_number::DeviceNumber;
-use crate::filesystem::vfs::mount::MountFSInode;
+use crate::filesystem::vfs::mount::{MountFS, MountFSInode};
 use crate::filesystem::vfs::{
-    self, FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode, InodeId,
-    MountableFileSystem, SuperBlock,
+    self, vcore::generate_inode_id, FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode,
+    InodeId, MountableFileSystem, SuperBlock,
 };
 use crate::libs::{casting::DowncastArc, mutex::Mutex};
 use crate::process::Cred;
 use crate::process::ProcessManager;
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, VecDeque};
 use alloc::string::String;
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
 use system_error::SystemError;
 
 const MAX_MOUNT_ANCESTOR_DEPTH: usize = vfs::MAX_PATHLEN;
 const INODE_CACHE_PRUNE_INTERVAL: usize = 256;
+static OVL_MOUNT_EPOCH: AtomicU64 = AtomicU64::new(1);
 type LowerRoot = (String, Arc<dyn IndexNode>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -29,7 +31,7 @@ struct RealInodeIdentity {
 
 impl RealInodeIdentity {
     fn from_inode(inode: &Arc<dyn IndexNode>) -> Result<Self, SystemError> {
-        let fs = inode.fs();
+        let fs = OverlayFS::canonical_backing_fs(inode);
         let metadata = inode.metadata()?;
         Ok(Self {
             filesystem: Arc::as_ptr(&fs) as *const () as usize,
@@ -57,27 +59,43 @@ struct OvlInodeCacheKey {
 #[derive(Debug, Default)]
 struct OvlInodeCache {
     entries: BTreeMap<OvlInodeCacheKey, Weak<OvlInode>>,
+    /// Bounded strong cache for non-samefs directories whose fallback inode
+    /// number is only meaningful for the OvlInode cache lifetime.
+    recent_fallback_dirs: VecDeque<Arc<OvlInode>>,
     insertions_since_prune: usize,
 }
+
+const FALLBACK_DIR_CACHE_SIZE: usize = 256;
 
 impl OvlInodeCache {
     fn intern(
         &mut self,
         key: OvlInodeCacheKey,
+        retain_fallback_dir: bool,
         create: impl FnOnce() -> Arc<OvlInode>,
     ) -> Arc<OvlInode> {
-        if let Some(inode) = self.entries.get(&key).and_then(Weak::upgrade) {
-            return inode;
-        }
+        let inode = if let Some(inode) = self.entries.get(&key).and_then(Weak::upgrade) {
+            inode
+        } else {
+            if self.insertions_since_prune >= INODE_CACHE_PRUNE_INTERVAL {
+                self.entries.retain(|_, inode| inode.strong_count() != 0);
+                self.insertions_since_prune = 0;
+            }
 
-        if self.insertions_since_prune >= INODE_CACHE_PRUNE_INTERVAL {
-            self.entries.retain(|_, inode| inode.strong_count() != 0);
-            self.insertions_since_prune = 0;
-        }
+            let inode = create();
+            self.entries.insert(key, Arc::downgrade(&inode));
+            self.insertions_since_prune += 1;
+            inode
+        };
 
-        let inode = create();
-        self.entries.insert(key, Arc::downgrade(&inode));
-        self.insertions_since_prune += 1;
+        if retain_fallback_dir {
+            self.recent_fallback_dirs
+                .retain(|cached| !Arc::ptr_eq(cached, &inode));
+            self.recent_fallback_dirs.push_back(inode.clone());
+            if self.recent_fallback_dirs.len() > FALLBACK_DIR_CACHE_SIZE {
+                self.recent_fallback_dirs.pop_front();
+            }
+        }
         inode
     }
 }
@@ -104,6 +122,8 @@ pub(super) struct OverlayFS {
     pub(super) super_block: SuperBlock,
     pub(super) mutation_lock: Mutex<()>,
     pub(super) backing_cred: Arc<Cred>,
+    pub(super) samefs: bool,
+    pub(super) mount_epoch: u64,
     inode_cache: Mutex<OvlInodeCache>,
 }
 
@@ -165,17 +185,56 @@ impl OverlayFS {
             origin,
         };
 
-        let inode = self.inode_cache.lock().intern(key, || {
-            let inode = Arc::new(OvlInode::new(
-                redirect,
-                file_type,
-                upper_inode,
-                lower_inodes,
-            ));
-            inode.set_fs(Arc::downgrade(self));
-            inode
-        });
+        let retain_fallback_dir = !self.samefs && file_type == FileType::Dir;
+        let inode = self
+            .inode_cache
+            .lock()
+            .intern(key, retain_fallback_dir, || {
+                let fallback_id = retain_fallback_dir.then(generate_inode_id);
+                let inode = Arc::new(OvlInode::new(
+                    redirect,
+                    file_type,
+                    upper_inode,
+                    lower_inodes,
+                    fallback_id,
+                ));
+                inode.set_fs(Arc::downgrade(self));
+                inode
+            });
+        inode.load_origin_once()?;
         Ok(inode)
+    }
+
+    fn canonical_backing_fs(inode: &Arc<dyn IndexNode>) -> Arc<dyn FileSystem> {
+        let mut fs = inode.fs();
+        while let Some(mount_fs) = fs.clone().downcast_arc::<MountFS>() {
+            fs = mount_fs.inner_filesystem();
+        }
+        fs
+    }
+
+    pub(super) fn backing_fsid(&self, inode: &Arc<dyn IndexNode>) -> Result<u32, SystemError> {
+        let target_fs = Self::canonical_backing_fs(inode);
+        // Origin records describe a lower object. Prefer a lower layer when the
+        // upper and lower directories happen to share the same filesystem.
+        for layer in self.layers.iter().skip(1).chain(self.layers.iter().take(1)) {
+            let real = if layer.index == 0 {
+                layer.mnt.upper_inode.lock().clone()
+            } else {
+                layer.mnt.lower_inodes.first().cloned()
+            };
+            let Some(real) = real else {
+                continue;
+            };
+            if Arc::ptr_eq(&target_fs, &Self::canonical_backing_fs(&real)) {
+                return Ok(layer.fsid);
+            }
+        }
+        Err(SystemError::EXDEV)
+    }
+
+    pub(super) fn has_backing_fsid(&self, fsid: u32) -> bool {
+        self.layers.iter().any(|layer| layer.fsid == fsid)
     }
 
     fn same_mount_inode(
@@ -258,6 +317,7 @@ impl MountableFileSystem for OverlayFS {
                 upper_file_type,
                 Some(upper_inode.clone()),
                 Vec::new(),
+                None,
             )),
             index: 0,
             fsid: 0,
@@ -291,6 +351,7 @@ impl MountableFileSystem for OverlayFS {
                         lower_file_type,
                         None,
                         vec![lower_inode.clone()],
+                        None,
                     )),
                     index: (i + 1) as u32,
                     fsid: (i + 1) as u32,
@@ -333,6 +394,18 @@ impl MountableFileSystem for OverlayFS {
         layers.push(upper_layer);
         layers.extend(lower_layers);
 
+        let upper_backing_fs = Self::canonical_backing_fs(&upper_inode);
+        let samefs = lower_roots
+            .iter()
+            .all(|(_, lower)| Arc::ptr_eq(&upper_backing_fs, &Self::canonical_backing_fs(lower)));
+        let sequence = OVL_MOUNT_EPOCH.fetch_add(1, Ordering::Relaxed);
+        let random = u64::from_le_bytes(crate::libs::rand::rand_bytes::<8>());
+        let now = crate::time::PosixTimeSpec::now();
+        let mount_epoch = random
+            ^ sequence.rotate_left(17)
+            ^ (now.tv_sec as u64).rotate_left(31)
+            ^ now.tv_nsec as u64;
+
         let root_inode = Arc::new(OvlInode::new(
             String::new(),
             upper_file_type,
@@ -341,6 +414,7 @@ impl MountableFileSystem for OverlayFS {
                 .iter()
                 .map(|(_, lower_inode)| lower_inode.clone())
                 .collect(),
+            (!samefs).then(generate_inode_id),
         ));
 
         let super_block = SuperBlock::new(vfs::Magic::OVERLAYFS_MAGIC, 4096, 255);
@@ -361,9 +435,12 @@ impl MountableFileSystem for OverlayFS {
                 super_block: super_block.clone(),
                 mutation_lock: Mutex::new(()),
                 backing_cred,
+                samefs,
+                mount_epoch,
                 inode_cache: Mutex::new(OvlInodeCache::default()),
             }
         });
+        fs.root_inode.load_origin_once()?;
         Ok(fs)
     }
 

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -14,12 +14,10 @@ use alloc::collections::{BTreeMap, VecDeque};
 use alloc::string::String;
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
-use core::sync::atomic::{AtomicU64, Ordering};
 use system_error::SystemError;
 
 const MAX_MOUNT_ANCESTOR_DEPTH: usize = vfs::MAX_PATHLEN;
 const INODE_CACHE_PRUNE_INTERVAL: usize = 256;
-static OVL_MOUNT_EPOCH: AtomicU64 = AtomicU64::new(1);
 type LowerRoot = (String, Arc<dyn IndexNode>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -123,7 +121,6 @@ pub(super) struct OverlayFS {
     pub(super) mutation_lock: Mutex<()>,
     pub(super) backing_cred: Arc<Cred>,
     pub(super) samefs: bool,
-    pub(super) mount_epoch: u64,
     inode_cache: Mutex<OvlInodeCache>,
 }
 
@@ -233,8 +230,18 @@ impl OverlayFS {
         Err(SystemError::EXDEV)
     }
 
-    pub(super) fn has_backing_fsid(&self, fsid: u32) -> bool {
-        self.layers.iter().any(|layer| layer.fsid == fsid)
+    pub(super) fn backing_fsid_matches_device(
+        &self,
+        fsid: u32,
+        dev_id: usize,
+    ) -> Result<bool, SystemError> {
+        let Some(layer) = self.layers.iter().find(|layer| layer.fsid == fsid) else {
+            return Ok(false);
+        };
+        let Some(lower) = layer.mnt.lower_inodes.first() else {
+            return Ok(false);
+        };
+        Ok(lower.metadata()?.dev_id == dev_id)
     }
 
     fn same_mount_inode(
@@ -398,14 +405,6 @@ impl MountableFileSystem for OverlayFS {
         let samefs = lower_roots
             .iter()
             .all(|(_, lower)| Arc::ptr_eq(&upper_backing_fs, &Self::canonical_backing_fs(lower)));
-        let sequence = OVL_MOUNT_EPOCH.fetch_add(1, Ordering::Relaxed);
-        let random = u64::from_le_bytes(crate::libs::rand::rand_bytes::<8>());
-        let now = crate::time::PosixTimeSpec::now();
-        let mount_epoch = random
-            ^ sequence.rotate_left(17)
-            ^ (now.tv_sec as u64).rotate_left(31)
-            ^ now.tv_nsec as u64;
-
         let root_inode = Arc::new(OvlInode::new(
             String::new(),
             upper_file_type,
@@ -436,7 +435,6 @@ impl MountableFileSystem for OverlayFS {
                 mutation_lock: Mutex::new(()),
                 backing_cred,
                 samefs,
-                mount_epoch,
                 inode_cache: Mutex::new(OvlInodeCache::default()),
             }
         });

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -1,12 +1,15 @@
 use super::entry::OvlEntry;
 use super::fs::OverlayFS;
+use super::metadata::OvlOrigin;
 use super::{dir, file, lookup, readdir, rename};
 use crate::driver::base::device::device_number::DeviceNumber;
 use crate::filesystem::page_cache::PageCache;
 use crate::filesystem::vfs::file::{File, FileFlags, FilePrivateData};
 use crate::filesystem::vfs::syscall::RenameFlags;
 use crate::filesystem::vfs::utils::DName;
-use crate::filesystem::vfs::{self, FileSystem, FileType, IndexNode, Metadata};
+use crate::filesystem::vfs::{
+    self, FileSystem, FileType, IndexNode, InodeId, Metadata, SetMetadataMask, XattrFlags,
+};
 use crate::libs::casting::DowncastArc;
 use crate::libs::mutex::Mutex;
 use crate::mm::VmFlags;
@@ -23,9 +26,17 @@ pub struct OvlInode {
     pub(super) flags: Mutex<u64>,
     pub(super) upper_inode: Mutex<Option<Arc<dyn IndexNode>>>, // Read-write layer (upper)
     pub(super) lower_inodes: Vec<Arc<dyn IndexNode>>, // Read-only layer (lower, supports multi-layer)
+    pub(super) overlay_inode_id: Option<InodeId>,
+    origin: Mutex<OriginState>,
     #[allow(dead_code)]
     pub(super) oe: Arc<OvlEntry>,
     pub(super) fs: Mutex<Weak<OverlayFS>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OriginState {
+    Unchecked,
+    Checked(Option<OvlOrigin>),
 }
 
 impl OvlInode {
@@ -34,6 +45,7 @@ impl OvlInode {
         file_type: FileType,
         upper: Option<Arc<dyn IndexNode>>,
         lower_inodes: Vec<Arc<dyn IndexNode>>,
+        overlay_inode_id: Option<InodeId>,
     ) -> Self {
         Self {
             redirect,
@@ -41,6 +53,8 @@ impl OvlInode {
             flags: Mutex::new(0),
             upper_inode: Mutex::new(upper),
             lower_inodes,
+            overlay_inode_id,
+            origin: Mutex::new(OriginState::Unchecked),
             oe: Arc::new(OvlEntry::new()),
             fs: Mutex::new(Weak::default()),
         }
@@ -89,6 +103,37 @@ impl OvlInode {
 
     pub(super) fn is_dir(&self) -> bool {
         self.file_type == FileType::Dir
+    }
+
+    pub(super) fn load_origin_once(&self) -> Result<(), SystemError> {
+        if matches!(*self.origin.lock(), OriginState::Checked(_)) {
+            return Ok(());
+        }
+
+        // Never hold the origin state while taking upper_inode: copy-up owns
+        // upper_inode while publishing the checked origin state.
+        let upper = self.upper_inode.lock().clone();
+        let loaded = upper
+            .as_ref()
+            .map(|upper| super::metadata::load_origin(self, upper))
+            .transpose()?
+            .flatten();
+        let mut state = self.origin.lock();
+        if matches!(*state, OriginState::Unchecked) {
+            *state = OriginState::Checked(loaded);
+        }
+        Ok(())
+    }
+
+    pub(super) fn set_origin(&self, origin: Option<OvlOrigin>) {
+        *self.origin.lock() = OriginState::Checked(origin);
+    }
+
+    pub(super) fn origin(&self) -> Option<OvlOrigin> {
+        match *self.origin.lock() {
+            OriginState::Unchecked => None,
+            OriginState::Checked(origin) => origin,
+        }
     }
 }
 
@@ -192,16 +237,62 @@ impl IndexNode for OvlInode {
     }
 
     fn metadata(&self) -> Result<Metadata, SystemError> {
-        if let Some(ref upper_inode) = *self.upper_inode.lock() {
-            return upper_inode.metadata();
-        }
+        self.load_origin_once()?;
+        super::metadata::metadata(self)
+    }
 
-        for lower_inode in &self.lower_inodes {
-            if let Ok(metadata) = lower_inode.metadata() {
-                return Ok(metadata);
-            }
-        }
-        Ok(Metadata::default())
+    fn set_metadata(&self, metadata: &Metadata) -> Result<(), SystemError> {
+        super::metadata::set_metadata_masked(
+            self,
+            metadata,
+            SetMetadataMask::MODE
+                | SetMetadataMask::UID
+                | SetMetadataMask::GID
+                | SetMetadataMask::ATIME
+                | SetMetadataMask::MTIME
+                | SetMetadataMask::CTIME,
+        )
+    }
+
+    fn set_metadata_masked(
+        &self,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        super::metadata::set_metadata_masked(self, metadata, mask)
+    }
+
+    fn resize(&self, len: usize) -> Result<(), SystemError> {
+        super::metadata::resize_with_lock_owner(self, len, 0)
+    }
+
+    fn resize_with_lock_owner(&self, len: usize, lock_owner: u64) -> Result<(), SystemError> {
+        super::metadata::resize_with_lock_owner(self, len, lock_owner)
+    }
+
+    fn resize_file(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        super::metadata::resize_file(self, len, lock_owner, data)
+    }
+
+    fn getxattr(&self, name: &str, buf: &mut [u8]) -> Result<usize, SystemError> {
+        super::metadata::getxattr(self, name, buf)
+    }
+
+    fn setxattr(&self, name: &str, value: &[u8], flags: XattrFlags) -> Result<usize, SystemError> {
+        super::metadata::setxattr(self, name, value, flags)
+    }
+
+    fn listxattr(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
+        super::metadata::listxattr(self, buf)
+    }
+
+    fn removexattr(&self, name: &str) -> Result<usize, SystemError> {
+        super::metadata::removexattr(self, name)
     }
 
     fn as_any_ref(&self) -> &dyn core::any::Any {

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -279,6 +279,27 @@ impl IndexNode for OvlInode {
         super::metadata::resize_file(self, len, lock_owner, data)
     }
 
+    fn resize_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        super::metadata::resize_with_metadata(self, len, lock_owner, metadata, mask)
+    }
+
+    fn resize_file_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        super::metadata::resize_file_with_metadata(self, len, lock_owner, data, metadata, mask)
+    }
+
     fn getxattr(&self, name: &str, buf: &mut [u8]) -> Result<usize, SystemError> {
         super::metadata::getxattr(self, name, buf)
     }

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -28,6 +28,7 @@ pub struct OvlInode {
     pub(super) lower_inodes: Vec<Arc<dyn IndexNode>>, // Read-only layer (lower, supports multi-layer)
     pub(super) overlay_inode_id: Option<InodeId>,
     origin: Mutex<OriginState>,
+    pub(super) content_privilege_lock: Mutex<()>,
     #[allow(dead_code)]
     pub(super) oe: Arc<OvlEntry>,
     pub(super) fs: Mutex<Weak<OverlayFS>>,
@@ -55,6 +56,7 @@ impl OvlInode {
             lower_inodes,
             overlay_inode_id,
             origin: Mutex::new(OriginState::Unchecked),
+            content_privilege_lock: Mutex::new(()),
             oe: Arc::new(OvlEntry::new()),
             fs: Mutex::new(Weak::default()),
         }

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -1,8 +1,8 @@
 use super::cred::CredOverrideGuard;
 use super::inode::OvlInode;
 use crate::filesystem::vfs::{
-    permission::PermissionMask, FilePrivateData, FileType, IndexNode, InodeFlags, InodeId,
-    InodeMode, Metadata, SetMetadataMask, XattrFlags,
+    merge_metadata_masked, permission::PermissionMask, FilePrivateData, FileType, IndexNode,
+    InodeFlags, InodeId, InodeMode, Metadata, SetMetadataMask, XattrFlags,
 };
 use crate::libs::mutex::MutexGuard;
 use crate::process::{cred::CAPFlags, cred::Kgid, ProcessManager};
@@ -423,26 +423,36 @@ pub(super) fn set_metadata_masked(
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
-    let mut upper_metadata = upper.metadata()?;
-    if mask.contains(SetMetadataMask::MODE) {
-        upper_metadata.mode = requested.mode;
-    }
-    if mask.contains(SetMetadataMask::UID) {
-        upper_metadata.uid = requested.uid;
-    }
-    if mask.contains(SetMetadataMask::GID) {
-        upper_metadata.gid = requested.gid;
-    }
-    if mask.contains(SetMetadataMask::ATIME) {
-        upper_metadata.atime = requested.atime;
-    }
-    if mask.contains(SetMetadataMask::MTIME) {
-        upper_metadata.mtime = requested.mtime;
-    }
-    if mask.contains(SetMetadataMask::CTIME) {
-        upper_metadata.ctime = requested.ctime;
-    }
+    let upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
     upper.set_metadata_masked(&upper_metadata, mask)
+}
+
+fn prepare_upper_metadata(
+    upper: &Arc<dyn IndexNode>,
+    requested: &Metadata,
+    mask: SetMetadataMask,
+) -> Result<Metadata, SystemError> {
+    let mut upper_metadata = upper.metadata()?;
+    merge_metadata_masked(&mut upper_metadata, requested, mask);
+    Ok(upper_metadata)
+}
+
+pub(super) fn resize_with_metadata(
+    inode: &OvlInode,
+    len: usize,
+    lock_owner: u64,
+    requested: &Metadata,
+    mask: SetMetadataMask,
+) -> Result<(), SystemError> {
+    let fs = inode.overlay_fs()?;
+    let _mutation_guard = fs.mutation_lock.lock();
+    check_metadata_mutation_permission(inode, requested, mask)?;
+    inode.copy_up_locked()?;
+    let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    let mut upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
+    upper_metadata.size = len as i64;
+    upper.resize_with_metadata(len, lock_owner, &upper_metadata, mask)
 }
 
 fn check_metadata_mutation_permission(
@@ -507,6 +517,25 @@ pub(super) fn resize_file(
 ) -> Result<(), SystemError> {
     drop(data);
     resize_with_lock_owner(inode, len, lock_owner)
+}
+
+pub(super) fn resize_file_with_metadata(
+    inode: &OvlInode,
+    len: usize,
+    lock_owner: u64,
+    data: MutexGuard<FilePrivateData>,
+    requested: &Metadata,
+    mask: SetMetadataMask,
+) -> Result<(), SystemError> {
+    let fs = inode.overlay_fs()?;
+    let _mutation_guard = fs.mutation_lock.lock();
+    check_metadata_mutation_permission(inode, requested, mask)?;
+    inode.copy_up_locked()?;
+    let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    let mut upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
+    upper_metadata.size = len as i64;
+    super::file::resize_file_with_metadata(inode, data, len, lock_owner, &upper_metadata, mask)
 }
 
 pub(super) fn getxattr(inode: &OvlInode, name: &str, buf: &mut [u8]) -> Result<usize, SystemError> {

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -25,7 +25,6 @@ const ORIGIN_ENCODED_SIZE: usize = 40;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct OvlOrigin {
-    pub(super) epoch: u64,
     pub(super) fsid: u32,
     pub(super) dev_id: usize,
     pub(super) inode_id: InodeId,
@@ -66,7 +65,9 @@ fn encode_origin(origin: OvlOrigin) -> [u8; ORIGIN_ENCODED_SIZE] {
     encoded[..4].copy_from_slice(&ORIGIN_MAGIC);
     encoded[4] = ORIGIN_VERSION;
     encoded[5] = file_type_to_u8(origin.file_type);
-    encoded[8..16].copy_from_slice(&origin.epoch.to_le_bytes());
+    // Bytes 8..16 are reserved. Early version-1 records stored a mount-local
+    // epoch there; leaving them unused keeps those records readable across
+    // remounts without changing the on-disk layout.
     encoded[16..20].copy_from_slice(&origin.fsid.to_le_bytes());
     encoded[24..32].copy_from_slice(&(origin.dev_id as u64).to_le_bytes());
     encoded[32..40].copy_from_slice(&(origin.inode_id.data() as u64).to_le_bytes());
@@ -84,14 +85,12 @@ fn decode_origin(value: &[u8]) -> Option<OvlOrigin> {
         return None;
     }
 
-    let epoch = u64::from_le_bytes(value[8..16].try_into().ok()?);
     let fsid = u32::from_le_bytes(value[16..20].try_into().ok()?);
     let dev_id_u64 = u64::from_le_bytes(value[24..32].try_into().ok()?);
     let inode_id_u64 = u64::from_le_bytes(value[32..40].try_into().ok()?);
     let dev_id = usize::try_from(dev_id_u64).ok()?;
     let inode_id = usize::try_from(inode_id_u64).ok()?;
     Some(OvlOrigin {
-        epoch,
         fsid,
         dev_id,
         inode_id: InodeId::new(inode_id),
@@ -300,7 +299,6 @@ pub(super) fn prepare_origin(
     let fs = inode.overlay_fs()?;
     let fsid = fs.backing_fsid(lower)?;
     let origin = OvlOrigin {
-        epoch: fs.mount_epoch,
         fsid,
         dev_id: lower_metadata.dev_id,
         inode_id: lower_metadata.inode_id,
@@ -339,9 +337,8 @@ pub(super) fn load_origin(
     let Some(origin) = decode_origin(&value) else {
         return Ok(None);
     };
-    if origin.epoch != fs.mount_epoch
-        || origin.file_type != inode.file_type
-        || !fs.has_backing_fsid(origin.fsid)
+    if origin.file_type != inode.file_type
+        || !fs.backing_fsid_matches_device(origin.fsid, origin.dev_id)?
     {
         return Ok(None);
     }

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -17,6 +17,7 @@ const XATTR_TRUSTED_PREFIX: &str = "trusted.";
 const XATTR_SECURITY_PREFIX: &str = "security.";
 const XATTR_POSIX_ACL_ACCESS: &str = "system.posix_acl_access";
 const XATTR_POSIX_ACL_DEFAULT: &str = "system.posix_acl_default";
+const XATTR_SECURITY_CAPABILITY: &str = "security.capability";
 const XATTR_MAX_SIZE: usize = 65_536;
 const XATTR_READ_RETRIES: usize = 3;
 const ORIGIN_MAGIC: [u8; 4] = *b"DOVL";
@@ -188,6 +189,20 @@ fn must_copy_xattr(name: &str) -> bool {
     name == XATTR_POSIX_ACL_ACCESS
         || name == XATTR_POSIX_ACL_DEFAULT
         || name.starts_with(XATTR_SECURITY_PREFIX)
+}
+
+pub(super) fn remove_security_capability(inode: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
+    match inode.removexattr(XATTR_SECURITY_CAPABILITY) {
+        Ok(_) | Err(SystemError::ENODATA) => Ok(()),
+        Err(err) if is_unsupported(&err) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+fn metadata_change_kills_capability(mask: SetMetadataMask) -> bool {
+    mask.intersects(
+        SetMetadataMask::WRITE_SIDE_EFFECT | SetMetadataMask::UID | SetMetadataMask::GID,
+    )
 }
 
 fn read_xattr_list(inode: &Arc<dyn IndexNode>) -> Result<Vec<u8>, SystemError> {
@@ -400,9 +415,11 @@ pub(super) fn resize_with_lock_owner(
 ) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
+    let _privilege_guard = inode.content_privilege_lock.lock();
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    remove_security_capability(&upper)?;
     upper.resize_with_lock_owner(len, lock_owner)
 }
 
@@ -416,10 +433,15 @@ pub(super) fn set_metadata_masked(
     }
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
+    let kill_capability = metadata_change_kills_capability(mask);
+    let _privilege_guard = kill_capability.then(|| inode.content_privilege_lock.lock());
     check_metadata_mutation_permission(inode, requested, mask)?;
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    if kill_capability {
+        remove_security_capability(&upper)?;
+    }
     let upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
     upper.set_metadata_masked(&upper_metadata, mask)
 }
@@ -443,10 +465,12 @@ pub(super) fn resize_with_metadata(
 ) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
+    let _privilege_guard = inode.content_privilege_lock.lock();
     check_metadata_mutation_permission(inode, requested, mask)?;
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    remove_security_capability(&upper)?;
     let mut upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
     upper_metadata.size = len as i64;
     upper.resize_with_metadata(len, lock_owner, &upper_metadata, mask)
@@ -526,10 +550,12 @@ pub(super) fn resize_file_with_metadata(
 ) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
+    let _privilege_guard = inode.content_privilege_lock.lock();
     check_metadata_mutation_permission(inode, requested, mask)?;
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    remove_security_capability(&upper)?;
     let mut upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
     upper_metadata.size = len as i64;
     super::file::resize_file_with_metadata(inode, data, len, lock_owner, &upper_metadata, mask)
@@ -562,6 +588,8 @@ pub(super) fn setxattr(
     }
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
+    let _privilege_guard =
+        (name == XATTR_SECURITY_CAPABILITY).then(|| inode.content_privilege_lock.lock());
     check_xattr_mutation_permission(inode, name)?;
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
@@ -606,6 +634,8 @@ pub(super) fn removexattr(inode: &OvlInode, name: &str) -> Result<usize, SystemE
     }
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
+    let _privilege_guard =
+        (name == XATTR_SECURITY_CAPABILITY).then(|| inode.content_privilege_lock.lock());
     check_xattr_mutation_permission(inode, name)?;
     let copied_up_for_remove = !inode.has_upper();
     if copied_up_for_remove {

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -610,7 +610,8 @@ pub(super) fn removexattr(inode: &OvlInode, name: &str) -> Result<usize, SystemE
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
     check_xattr_mutation_permission(inode, name)?;
-    if !inode.has_upper() {
+    let copied_up_for_remove = !inode.has_upper();
+    if copied_up_for_remove {
         let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
         inode.current_realdata_inode()?.0.getxattr(name, &mut [])?;
     }
@@ -618,5 +619,23 @@ pub(super) fn removexattr(inode: &OvlInode, name: &str) -> Result<usize, SystemE
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
-    upper.removexattr(name)
+    match upper.removexattr(name) {
+        Ok(size) => Ok(size),
+        Err(err)
+            if copied_up_for_remove && (err == SystemError::ENODATA || is_unsupported(&err)) =>
+        {
+            // Optional lower xattrs may be intentionally discarded when the
+            // upper backing does not support their namespace. The attribute
+            // existed in the merged view before copy-up, so report a
+            // completed removal only after confirming that it is no longer
+            // observable through the published upper inode.
+            match upper.getxattr(name, &mut []) {
+                Err(SystemError::ENODATA) => Ok(0),
+                Err(probe_err) if is_unsupported(&probe_err) => Ok(0),
+                Ok(_) => Err(err),
+                Err(probe_err) => Err(probe_err),
+            }
+        }
+        Err(err) => Err(err),
+    }
 }

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -1,0 +1,585 @@
+use super::cred::CredOverrideGuard;
+use super::inode::OvlInode;
+use crate::filesystem::vfs::{
+    permission::PermissionMask, FilePrivateData, FileType, IndexNode, InodeFlags, InodeId,
+    InodeMode, Metadata, SetMetadataMask, XattrFlags,
+};
+use crate::libs::mutex::MutexGuard;
+use crate::process::{cred::CAPFlags, cred::Kgid, ProcessManager};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+pub(super) const OVL_XATTR_ORIGIN: &str = "trusted.dragonos.overlay.origin";
+const OVL_XATTR_PRIVATE_PREFIX: &str = "trusted.overlay.";
+const XATTR_USER_PREFIX: &str = "user.";
+const XATTR_TRUSTED_PREFIX: &str = "trusted.";
+const XATTR_SECURITY_PREFIX: &str = "security.";
+const XATTR_POSIX_ACL_ACCESS: &str = "system.posix_acl_access";
+const XATTR_POSIX_ACL_DEFAULT: &str = "system.posix_acl_default";
+const XATTR_MAX_SIZE: usize = 65_536;
+const XATTR_READ_RETRIES: usize = 3;
+const ORIGIN_MAGIC: [u8; 4] = *b"DOVL";
+const ORIGIN_VERSION: u8 = 1;
+const ORIGIN_ENCODED_SIZE: usize = 40;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct OvlOrigin {
+    pub(super) epoch: u64,
+    pub(super) fsid: u32,
+    pub(super) dev_id: usize,
+    pub(super) inode_id: InodeId,
+    pub(super) file_type: FileType,
+}
+
+fn file_type_to_u8(file_type: FileType) -> u8 {
+    match file_type {
+        FileType::File => 1,
+        FileType::Dir => 2,
+        FileType::BlockDevice => 3,
+        FileType::CharDevice => 4,
+        FileType::FramebufferDevice => 5,
+        FileType::KvmDevice => 6,
+        FileType::Pipe => 7,
+        FileType::SymLink => 8,
+        FileType::Socket => 9,
+    }
+}
+
+fn file_type_from_u8(value: u8) -> Option<FileType> {
+    Some(match value {
+        1 => FileType::File,
+        2 => FileType::Dir,
+        3 => FileType::BlockDevice,
+        4 => FileType::CharDevice,
+        5 => FileType::FramebufferDevice,
+        6 => FileType::KvmDevice,
+        7 => FileType::Pipe,
+        8 => FileType::SymLink,
+        9 => FileType::Socket,
+        _ => return None,
+    })
+}
+
+fn encode_origin(origin: OvlOrigin) -> [u8; ORIGIN_ENCODED_SIZE] {
+    let mut encoded = [0u8; ORIGIN_ENCODED_SIZE];
+    encoded[..4].copy_from_slice(&ORIGIN_MAGIC);
+    encoded[4] = ORIGIN_VERSION;
+    encoded[5] = file_type_to_u8(origin.file_type);
+    encoded[8..16].copy_from_slice(&origin.epoch.to_le_bytes());
+    encoded[16..20].copy_from_slice(&origin.fsid.to_le_bytes());
+    encoded[24..32].copy_from_slice(&(origin.dev_id as u64).to_le_bytes());
+    encoded[32..40].copy_from_slice(&(origin.inode_id.data() as u64).to_le_bytes());
+    encoded
+}
+
+fn decode_origin(value: &[u8]) -> Option<OvlOrigin> {
+    if value.len() != ORIGIN_ENCODED_SIZE
+        || value[..4] != ORIGIN_MAGIC
+        || value[4] != ORIGIN_VERSION
+        || value[6] != 0
+        || value[7] != 0
+        || value[20..24] != [0; 4]
+    {
+        return None;
+    }
+
+    let epoch = u64::from_le_bytes(value[8..16].try_into().ok()?);
+    let fsid = u32::from_le_bytes(value[16..20].try_into().ok()?);
+    let dev_id_u64 = u64::from_le_bytes(value[24..32].try_into().ok()?);
+    let inode_id_u64 = u64::from_le_bytes(value[32..40].try_into().ok()?);
+    let dev_id = usize::try_from(dev_id_u64).ok()?;
+    let inode_id = usize::try_from(inode_id_u64).ok()?;
+    Some(OvlOrigin {
+        epoch,
+        fsid,
+        dev_id,
+        inode_id: InodeId::new(inode_id),
+        file_type: file_type_from_u8(value[5])?,
+    })
+}
+
+fn is_unsupported(err: &SystemError) -> bool {
+    matches!(
+        err,
+        SystemError::ENOSYS | SystemError::EOPNOTSUPP_OR_ENOTSUP
+    )
+}
+
+fn is_private_xattr(name: &str) -> bool {
+    name.starts_with(OVL_XATTR_PRIVATE_PREFIX) || name == OVL_XATTR_ORIGIN
+}
+
+fn caller_may_access_xattr(name: &str) -> bool {
+    !name.starts_with(XATTR_TRUSTED_PREFIX)
+        || ProcessManager::current_pcb()
+            .cred()
+            .has_capability(CAPFlags::CAP_SYS_ADMIN)
+}
+
+fn check_xattr_mutation_permission(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
+    let cred = ProcessManager::current_pcb().cred();
+    let metadata = inode.metadata()?;
+    if metadata
+        .flags
+        .intersects(InodeFlags::S_IMMUTABLE | InodeFlags::S_APPEND)
+    {
+        return Err(SystemError::EPERM);
+    }
+    if name.starts_with(XATTR_TRUSTED_PREFIX) {
+        return cred
+            .has_capability(CAPFlags::CAP_SYS_ADMIN)
+            .then_some(())
+            .ok_or(SystemError::EPERM);
+    }
+    if name == "security.capability" {
+        return cred
+            .has_capability(CAPFlags::CAP_SETFCAP)
+            .then_some(())
+            .ok_or(SystemError::EPERM);
+    }
+    if name.starts_with(XATTR_SECURITY_PREFIX) {
+        // DragonOS has no LSM xattr hook yet. Do not let the overlay backing
+        // credential turn arbitrary security labels into an unprivileged API.
+        return cred
+            .has_capability(CAPFlags::CAP_SYS_ADMIN)
+            .then_some(())
+            .ok_or(SystemError::EPERM);
+    }
+
+    if name.starts_with(XATTR_USER_PREFIX) {
+        if !matches!(metadata.file_type, FileType::File | FileType::Dir) {
+            return Err(SystemError::EPERM);
+        }
+        if metadata.file_type == FileType::Dir
+            && metadata.mode.contains(InodeMode::S_ISVTX)
+            && cred.fsuid.data() != metadata.uid
+            && !cred.has_capability(CAPFlags::CAP_FOWNER)
+        {
+            return Err(SystemError::EPERM);
+        }
+        return cred.inode_permission(&metadata, PermissionMask::MAY_WRITE.bits());
+    }
+    if name == XATTR_POSIX_ACL_ACCESS || name == XATTR_POSIX_ACL_DEFAULT {
+        return (cred.fsuid.data() == metadata.uid || cred.has_capability(CAPFlags::CAP_FOWNER))
+            .then_some(())
+            .ok_or(SystemError::EPERM);
+    }
+    cred.inode_permission(&metadata, PermissionMask::MAY_WRITE.bits())
+}
+
+fn check_xattr_read_permission(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
+    if !name.starts_with(XATTR_USER_PREFIX) {
+        return Ok(());
+    }
+    let metadata = inode.metadata()?;
+    if !matches!(metadata.file_type, FileType::File | FileType::Dir) {
+        return Err(SystemError::ENODATA);
+    }
+    ProcessManager::current_pcb()
+        .cred()
+        .inode_permission(&metadata, PermissionMask::MAY_READ.bits())
+}
+
+fn must_copy_xattr(name: &str) -> bool {
+    name == XATTR_POSIX_ACL_ACCESS
+        || name == XATTR_POSIX_ACL_DEFAULT
+        || name.starts_with(XATTR_SECURITY_PREFIX)
+}
+
+fn read_xattr_list(inode: &Arc<dyn IndexNode>) -> Result<Vec<u8>, SystemError> {
+    for _ in 0..XATTR_READ_RETRIES {
+        let size = inode.listxattr(&mut [])?;
+        if size > XATTR_MAX_SIZE {
+            return Err(SystemError::E2BIG);
+        }
+        if size == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut list = vec![0u8; size];
+        match inode.listxattr(&mut list) {
+            Ok(actual) => {
+                if actual > list.len() {
+                    return Err(SystemError::EIO);
+                }
+                list.truncate(actual);
+                return Ok(list);
+            }
+            Err(SystemError::ERANGE) => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Err(SystemError::ERANGE)
+}
+
+fn read_xattr_value(inode: &Arc<dyn IndexNode>, name: &str) -> Result<Vec<u8>, SystemError> {
+    for _ in 0..XATTR_READ_RETRIES {
+        let size = inode.getxattr(name, &mut [])?;
+        if size > XATTR_MAX_SIZE {
+            return Err(SystemError::E2BIG);
+        }
+        if size == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut value = vec![0u8; size];
+        match inode.getxattr(name, &mut value) {
+            Ok(actual) => {
+                if actual > value.len() {
+                    return Err(SystemError::EIO);
+                }
+                value.truncate(actual);
+                return Ok(value);
+            }
+            Err(SystemError::ERANGE) => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Err(SystemError::ERANGE)
+}
+
+fn for_each_xattr_name(
+    list: &[u8],
+    mut visit: impl FnMut(&str) -> Result<(), SystemError>,
+) -> Result<(), SystemError> {
+    let mut offset = 0usize;
+    while offset < list.len() {
+        let relative_end = list[offset..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .ok_or(SystemError::EIO)?;
+        if relative_end == 0 {
+            return Err(SystemError::EIO);
+        }
+        let end = offset.checked_add(relative_end).ok_or(SystemError::E2BIG)?;
+        let name = core::str::from_utf8(&list[offset..end]).map_err(|_| SystemError::EIO)?;
+        visit(name)?;
+        offset = end.checked_add(1).ok_or(SystemError::E2BIG)?;
+    }
+    Ok(())
+}
+
+pub(super) fn copy_xattrs(
+    lower: &Arc<dyn IndexNode>,
+    upper: &Arc<dyn IndexNode>,
+) -> Result<(), SystemError> {
+    let list = match read_xattr_list(lower) {
+        Ok(list) => list,
+        Err(err) if is_unsupported(&err) => return Ok(()),
+        Err(err) => return Err(err),
+    };
+
+    for_each_xattr_name(&list, |name| {
+        if is_private_xattr(name) {
+            return Ok(());
+        }
+        let value = read_xattr_value(lower, name)?;
+        match upper.setxattr(name, &value, XattrFlags::empty()) {
+            Ok(_) => Ok(()),
+            Err(err) if is_unsupported(&err) && !must_copy_xattr(name) => Ok(()),
+            Err(err) => Err(err),
+        }
+    })
+}
+
+pub(super) fn prepare_origin(
+    inode: &OvlInode,
+    lower: &Arc<dyn IndexNode>,
+    upper: &Arc<dyn IndexNode>,
+    lower_metadata: &Metadata,
+) -> Result<Option<OvlOrigin>, SystemError> {
+    if lower_metadata.file_type != FileType::Dir && lower_metadata.nlinks > 1 {
+        return Ok(None);
+    }
+
+    let fs = inode.overlay_fs()?;
+    let fsid = fs.backing_fsid(lower)?;
+    let origin = OvlOrigin {
+        epoch: fs.mount_epoch,
+        fsid,
+        dev_id: lower_metadata.dev_id,
+        inode_id: lower_metadata.inode_id,
+        file_type: lower_metadata.file_type,
+    };
+    match upper.setxattr(
+        OVL_XATTR_ORIGIN,
+        &encode_origin(origin),
+        XattrFlags::empty(),
+    ) {
+        Ok(_) => Ok(Some(origin)),
+        // Some backings (notably the current ext4 symlink path) cannot store
+        // xattrs. Fall back consistently to the upper identity rather than
+        // claiming provenance that a later lookup cannot recover.
+        Err(err) if is_unsupported(&err) || err == SystemError::EPERM => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+pub(super) fn load_origin(
+    inode: &OvlInode,
+    upper: &Arc<dyn IndexNode>,
+) -> Result<Option<OvlOrigin>, SystemError> {
+    let fs = inode.overlay_fs()?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    let value = match read_xattr_value(upper, OVL_XATTR_ORIGIN) {
+        Ok(value) => value,
+        Err(SystemError::ENODATA) => return Ok(None),
+        Err(err) if is_unsupported(&err) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let Some(origin) = decode_origin(&value) else {
+        return Ok(None);
+    };
+    if origin.epoch != fs.mount_epoch
+        || origin.file_type != inode.file_type
+        || !fs.has_backing_fsid(origin.fsid)
+    {
+        return Ok(None);
+    }
+
+    if !inode.lower_inodes.is_empty() {
+        let mut matched = false;
+        for lower in &inode.lower_inodes {
+            if fs.backing_fsid(lower)? != origin.fsid {
+                continue;
+            }
+            let metadata = lower.metadata()?;
+            if metadata.dev_id == origin.dev_id
+                && metadata.inode_id == origin.inode_id
+                && metadata.file_type == origin.file_type
+            {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(origin))
+}
+
+pub(super) fn metadata(inode: &OvlInode) -> Result<Metadata, SystemError> {
+    let fs = inode.overlay_fs()?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    let (real_inode, _) = inode.current_realdata_inode()?;
+    let mut metadata = real_inode.metadata()?;
+    let origin = inode.origin();
+
+    if fs.samefs {
+        metadata.dev_id = 0;
+        if let Some(origin) = origin {
+            metadata.inode_id = origin.inode_id;
+        }
+    } else if inode.file_type == FileType::Dir {
+        metadata.dev_id = 0;
+        metadata.inode_id = inode.overlay_inode_id.ok_or(SystemError::EIO)?;
+    } else if let Some(origin) = origin {
+        metadata.dev_id = origin.dev_id;
+        metadata.inode_id = origin.inode_id;
+    }
+
+    let real_dir_count = inode.lower_inodes.len() + usize::from(inode.upper_inode.lock().is_some());
+    if inode.file_type == FileType::Dir && real_dir_count > 1 {
+        metadata.nlinks = 1;
+    }
+    Ok(metadata)
+}
+
+pub(super) fn resize_with_lock_owner(
+    inode: &OvlInode,
+    len: usize,
+    lock_owner: u64,
+) -> Result<(), SystemError> {
+    let fs = inode.overlay_fs()?;
+    let _mutation_guard = fs.mutation_lock.lock();
+    inode.copy_up_locked()?;
+    let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    upper.resize_with_lock_owner(len, lock_owner)
+}
+
+pub(super) fn set_metadata_masked(
+    inode: &OvlInode,
+    requested: &Metadata,
+    mask: SetMetadataMask,
+) -> Result<(), SystemError> {
+    if mask.is_empty() {
+        return Ok(());
+    }
+    let fs = inode.overlay_fs()?;
+    let _mutation_guard = fs.mutation_lock.lock();
+    check_metadata_mutation_permission(inode, requested, mask)?;
+    inode.copy_up_locked()?;
+    let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    let mut upper_metadata = upper.metadata()?;
+    if mask.contains(SetMetadataMask::MODE) {
+        upper_metadata.mode = requested.mode;
+    }
+    if mask.contains(SetMetadataMask::UID) {
+        upper_metadata.uid = requested.uid;
+    }
+    if mask.contains(SetMetadataMask::GID) {
+        upper_metadata.gid = requested.gid;
+    }
+    if mask.contains(SetMetadataMask::ATIME) {
+        upper_metadata.atime = requested.atime;
+    }
+    if mask.contains(SetMetadataMask::MTIME) {
+        upper_metadata.mtime = requested.mtime;
+    }
+    if mask.contains(SetMetadataMask::CTIME) {
+        upper_metadata.ctime = requested.ctime;
+    }
+    upper.set_metadata_masked(&upper_metadata, mask)
+}
+
+fn check_metadata_mutation_permission(
+    inode: &OvlInode,
+    requested: &Metadata,
+    mask: SetMetadataMask,
+) -> Result<(), SystemError> {
+    if mask.contains(SetMetadataMask::WRITE_SIDE_EFFECT) {
+        return Ok(());
+    }
+
+    let current = inode.metadata()?;
+    if current.flags.contains(InodeFlags::S_IMMUTABLE) {
+        return Err(SystemError::EPERM);
+    }
+    let cred = ProcessManager::current_pcb().cred();
+
+    if mask.intersects(SetMetadataMask::UID | SetMetadataMask::GID) {
+        if cred.uid.data() == 0 {
+            return Ok(());
+        }
+        if cred.uid.data() != current.uid
+            || (mask.contains(SetMetadataMask::UID) && requested.uid != current.uid)
+        {
+            return Err(SystemError::EPERM);
+        }
+        if mask.contains(SetMetadataMask::GID)
+            && requested.gid != cred.gid.data()
+            && !cred
+                .group_info
+                .as_ref()
+                .is_some_and(|groups| groups.gids.contains(&Kgid::from(requested.gid)))
+        {
+            return Err(SystemError::EPERM);
+        }
+        return Ok(());
+    }
+
+    if mask.contains(SetMetadataMask::MODE) {
+        return (cred.fsuid.data() == current.uid || cred.has_capability(CAPFlags::CAP_FOWNER))
+            .then_some(())
+            .ok_or(SystemError::EPERM);
+    }
+
+    if mask.intersects(SetMetadataMask::ATIME | SetMetadataMask::MTIME) {
+        if cred.fsuid.data() == current.uid || cred.has_capability(CAPFlags::CAP_FOWNER) {
+            return Ok(());
+        }
+        if mask.contains(SetMetadataMask::TIMES_BY_WRITE) {
+            return cred.inode_permission(&current, PermissionMask::MAY_WRITE.bits());
+        }
+        return Err(SystemError::EPERM);
+    }
+    Ok(())
+}
+
+pub(super) fn resize_file(
+    inode: &OvlInode,
+    len: usize,
+    lock_owner: u64,
+    data: MutexGuard<FilePrivateData>,
+) -> Result<(), SystemError> {
+    drop(data);
+    resize_with_lock_owner(inode, len, lock_owner)
+}
+
+pub(super) fn getxattr(inode: &OvlInode, name: &str, buf: &mut [u8]) -> Result<usize, SystemError> {
+    if is_private_xattr(name) {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    if !caller_may_access_xattr(name) {
+        return Err(SystemError::EPERM);
+    }
+    check_xattr_read_permission(inode, name)?;
+    let fs = inode.overlay_fs()?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    inode.current_realdata_inode()?.0.getxattr(name, buf)
+}
+
+pub(super) fn setxattr(
+    inode: &OvlInode,
+    name: &str,
+    value: &[u8],
+    flags: XattrFlags,
+) -> Result<usize, SystemError> {
+    if is_private_xattr(name) {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    if !caller_may_access_xattr(name) {
+        return Err(SystemError::EPERM);
+    }
+    let fs = inode.overlay_fs()?;
+    let _mutation_guard = fs.mutation_lock.lock();
+    check_xattr_mutation_permission(inode, name)?;
+    inode.copy_up_locked()?;
+    let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    upper.setxattr(name, value, flags)
+}
+
+pub(super) fn listxattr(inode: &OvlInode, buf: &mut [u8]) -> Result<usize, SystemError> {
+    let may_list_trusted = ProcessManager::current_pcb()
+        .cred()
+        .has_capability(CAPFlags::CAP_SYS_ADMIN);
+    let fs = inode.overlay_fs()?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    let real = inode.current_realdata_inode()?.0;
+    let list = read_xattr_list(&real)?;
+    let mut filtered = Vec::with_capacity(list.len());
+    for_each_xattr_name(&list, |name| {
+        if is_private_xattr(name) || (!may_list_trusted && name.starts_with(XATTR_TRUSTED_PREFIX)) {
+            return Ok(());
+        }
+        filtered.extend_from_slice(name.as_bytes());
+        filtered.push(0);
+        Ok(())
+    })?;
+
+    if buf.is_empty() {
+        return Ok(filtered.len());
+    }
+    if buf.len() < filtered.len() {
+        return Err(SystemError::ERANGE);
+    }
+    buf[..filtered.len()].copy_from_slice(&filtered);
+    Ok(filtered.len())
+}
+
+pub(super) fn removexattr(inode: &OvlInode, name: &str) -> Result<usize, SystemError> {
+    if is_private_xattr(name) {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+    if !caller_may_access_xattr(name) {
+        return Err(SystemError::EPERM);
+    }
+    let fs = inode.overlay_fs()?;
+    let _mutation_guard = fs.mutation_lock.lock();
+    check_xattr_mutation_permission(inode, name)?;
+    if !inode.has_upper() {
+        let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+        inode.current_realdata_inode()?.0.getxattr(name, &mut [])?;
+    }
+
+    inode.copy_up_locked()?;
+    let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
+    upper.removexattr(name)
+}

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -416,7 +416,7 @@ pub(super) fn resize_with_lock_owner(
     let fs = inode.overlay_fs()?;
     let _mutation_guard = fs.mutation_lock.lock();
     let _privilege_guard = inode.content_privilege_lock.lock();
-    inode.copy_up_locked()?;
+    inode.copy_up_locked_for_truncate(len)?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     remove_security_capability(&upper)?;
@@ -467,7 +467,7 @@ pub(super) fn resize_with_metadata(
     let _mutation_guard = fs.mutation_lock.lock();
     let _privilege_guard = inode.content_privilege_lock.lock();
     check_metadata_mutation_permission(inode, requested, mask)?;
-    inode.copy_up_locked()?;
+    inode.copy_up_locked_for_truncate(len)?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     remove_security_capability(&upper)?;
@@ -552,7 +552,7 @@ pub(super) fn resize_file_with_metadata(
     let _mutation_guard = fs.mutation_lock.lock();
     let _privilege_guard = inode.content_privilege_lock.lock();
     check_metadata_mutation_permission(inode, requested, mask)?;
-    inode.copy_up_locked()?;
+    inode.copy_up_locked_for_truncate(len)?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     remove_security_capability(&upper)?;

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -106,6 +106,10 @@ fn is_unsupported(err: &SystemError) -> bool {
     )
 }
 
+fn is_origin_xattr_unavailable(err: &SystemError) -> bool {
+    is_unsupported(err) || *err == SystemError::EPERM
+}
+
 fn is_private_xattr(name: &str) -> bool {
     name.starts_with(OVL_XATTR_PRIVATE_PREFIX) || name == OVL_XATTR_ORIGIN
 }
@@ -311,7 +315,7 @@ pub(super) fn prepare_origin(
         // Some backings (notably the current ext4 symlink path) cannot store
         // xattrs. Fall back consistently to the upper identity rather than
         // claiming provenance that a later lookup cannot recover.
-        Err(err) if is_unsupported(&err) || err == SystemError::EPERM => Ok(None),
+        Err(err) if is_origin_xattr_unavailable(&err) => Ok(None),
         Err(err) => Err(err),
     }
 }
@@ -325,7 +329,11 @@ pub(super) fn load_origin(
     let value = match read_xattr_value(upper, OVL_XATTR_ORIGIN) {
         Ok(value) => value,
         Err(SystemError::ENODATA) => return Ok(None),
-        Err(err) if is_unsupported(&err) => return Ok(None),
+        // Keep this symmetric with prepare_origin(): if the backing
+        // filesystem cannot store the private origin xattr, a later inode
+        // instantiation must use the upper identity instead of exposing the
+        // backing xattr error through lookup/stat.
+        Err(err) if is_origin_xattr_unavailable(&err) => return Ok(None),
         Err(err) => return Err(err),
     };
     let Some(origin) = decode_origin(&value) else {

--- a/kernel/src/filesystem/overlayfs/mod.rs
+++ b/kernel/src/filesystem/overlayfs/mod.rs
@@ -1,11 +1,13 @@
 mod config;
 mod copy_up;
+mod cred;
 mod dir;
 mod entry;
 mod file;
 mod fs;
 mod inode;
 mod lookup;
+mod metadata;
 mod path;
 mod readdir;
 mod rename;

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -9,7 +9,7 @@ use system_error::SystemError;
 
 use super::{
     append_lock::with_inode_append_lock, mount::MountFSInode, utils::should_remove_sgid, FileType,
-    IndexNode, InodeId, Metadata, SpecialNodeData,
+    IndexNode, InodeId, Metadata, SetMetadataMask, SpecialNodeData,
 };
 use crate::{arch::ipc::signal::Signal, filesystem::vfs::InodeFlags, process::pid::PidPrivateData};
 use crate::{
@@ -617,7 +617,10 @@ impl File {
             md.mode.remove(InodeMode::S_ISGID);
         }
 
-        self.inode.set_metadata(&md)?;
+        self.inode.set_metadata_masked(
+            &md,
+            SetMetadataMask::MODE | SetMetadataMask::WRITE_SIDE_EFFECT,
+        )?;
         Ok(())
     }
 

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -139,6 +139,29 @@ bitflags! {
     }
 }
 
+/// Merge only fields selected by `mask` into an existing metadata snapshot.
+/// Intent-only bits do not map to stored fields.
+pub fn merge_metadata_masked(target: &mut Metadata, requested: &Metadata, mask: SetMetadataMask) {
+    if mask.contains(SetMetadataMask::MODE) {
+        target.mode = requested.mode;
+    }
+    if mask.contains(SetMetadataMask::UID) {
+        target.uid = requested.uid;
+    }
+    if mask.contains(SetMetadataMask::GID) {
+        target.gid = requested.gid;
+    }
+    if mask.contains(SetMetadataMask::ATIME) {
+        target.atime = requested.atime;
+    }
+    if mask.contains(SetMetadataMask::MTIME) {
+        target.mtime = requested.mtime;
+    }
+    if mask.contains(SetMetadataMask::CTIME) {
+        target.ctime = requested.ctime;
+    }
+}
+
 impl From<FileType> for InodeMode {
     fn from(val: FileType) -> Self {
         match val {
@@ -650,6 +673,41 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     ) -> Result<(), SystemError> {
         drop(data);
         self.resize_with_lock_owner(len, lock_owner)
+    }
+
+    /// Atomically apply a size change and its VFS-computed metadata side
+    /// effects when the filesystem can represent them in one operation.
+    ///
+    /// Local filesystems that keep size and inode metadata separately can use
+    /// the default two-step implementation. Protocol and stacking
+    /// filesystems should override this method to preserve their transaction
+    /// and request-context semantics.
+    fn resize_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        self.resize_with_lock_owner(len, lock_owner)?;
+        let mut current = self.metadata()?;
+        merge_metadata_masked(&mut current, metadata, mask);
+        self.set_metadata_masked(&current, mask)
+    }
+
+    /// File-context variant of `resize_with_metadata()`.
+    fn resize_file_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        self.resize_file(len, lock_owner, data)?;
+        let mut current = self.metadata()?;
+        merge_metadata_masked(&mut current, metadata, mask);
+        self.set_metadata_masked(&current, mask)
     }
 
     /// @brief 在当前目录下创建一个新的inode

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -213,6 +213,26 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// 指定 `set_metadata_masked()` 实际要更新的元数据字段。
+    ///
+    /// 该掩码对应 Linux `iattr::ia_valid` 中 DragonOS 当前可表达的
+    /// setattr 字段，避免将调用者读取的完整元数据快照误当成完整更新。
+    pub struct SetMetadataMask: u32 {
+        const MODE = 1 << 0;
+        const UID = 1 << 1;
+        const GID = 1 << 2;
+        const ATIME = 1 << 3;
+        const MTIME = 1 << 4;
+        /// 仅供 VFS/backing 自动维护；用户态 setattr 不能提供任意 ctime。
+        const CTIME = 1 << 5;
+        /// 时间设置来自“当前时间”请求，可由当前写权限授权。
+        const TIMES_BY_WRITE = 1 << 6;
+        /// 已授权的数据写/size change 引发的 metadata 副作用。
+        const WRITE_SIDE_EFFECT = 1 << 7;
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum SpecialNodeData {
@@ -581,6 +601,21 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     fn set_metadata(&self, _metadata: &Metadata) -> Result<(), SystemError> {
         // 若文件系统没有实现此方法，则返回"不支持"
         return Err(SystemError::ENOSYS);
+    }
+
+    /// 仅更新 `mask` 指定的元数据字段。
+    ///
+    /// 旧文件系统默认回退到完整 metadata 更新，以保持现有实现兼容；需要在
+    /// copy-up 等并发边界精确保留未请求字段的堆叠文件系统应覆盖此方法。
+    fn set_metadata_masked(
+        &self,
+        metadata: &Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        if mask.is_empty() {
+            return Ok(());
+        }
+        self.set_metadata(metadata)
     }
 
     /// @brief 重新设置文件的大小

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -2,7 +2,7 @@ use super::{
     file::{FileFlags, FileMode},
     utils::DName,
     FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode, PollableInode,
-    SuperBlock, XattrFlags,
+    SetMetadataMask, SuperBlock, XattrFlags,
 };
 use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
@@ -246,6 +246,11 @@ int_like!(MountId, usize);
 static MOUNT_ID_ALLOCATOR: Mutex<IdAllocator> =
     Mutex::new(IdAllocator::new(0, usize::MAX).unwrap());
 
+/// Linux `unnamed_dev_ida` 的 DragonOS 等价物。minor 0 保留为“尚未分配”，
+/// 上界传入 `MINOR_MASK + 1` 是因为 `IdAllocator` 的 max_id 为开区间。
+static UNNAMED_DEV_ID_ALLOCATOR: Mutex<IdAllocator> =
+    Mutex::new(IdAllocator::new(1, DeviceNumber::MINOR_MASK as usize + 1).unwrap());
+
 lazy_static! {
     static ref MOUNTED_SUPERBLOCKS: SpinLock<Vec<Weak<MountFS>>> = SpinLock::new(Vec::new());
 }
@@ -291,6 +296,7 @@ pub struct SuperBlockState {
     write_count: AtomicUsize,
     wb_error: ErrSeq,
     umount_lock: RwSem<()>,
+    unnamed_dev_minor: Mutex<Option<u32>>,
 }
 
 struct MountStateInit {
@@ -305,6 +311,7 @@ impl SuperBlockState {
             write_count: AtomicUsize::new(0),
             wb_error: ErrSeq::new(),
             umount_lock: RwSem::new(()),
+            unnamed_dev_minor: Mutex::new(None),
         }
     }
 
@@ -350,6 +357,31 @@ impl SuperBlockState {
 
     pub fn umount_write(&self) -> crate::libs::rwsem::RwSemWriteGuard<'_, ()> {
         self.umount_lock.write()
+    }
+
+    /// 返回该 superblock 的匿名设备号，首次需要时才分配。
+    ///
+    /// 锁覆盖“检查并分配”全过程，确保并发 metadata 查询只消耗一个 minor。
+    pub fn unnamed_dev(&self) -> Result<DeviceNumber, SystemError> {
+        let mut minor = self.unnamed_dev_minor.lock();
+        if let Some(minor) = *minor {
+            return Ok(DeviceNumber::new(Major::UNNAMED_MAJOR, minor));
+        }
+
+        let allocated = UNNAMED_DEV_ID_ALLOCATOR
+            .lock()
+            .alloc()
+            .ok_or(SystemError::EMFILE)? as u32;
+        *minor = Some(allocated);
+        Ok(DeviceNumber::new(Major::UNNAMED_MAJOR, allocated))
+    }
+}
+
+impl Drop for SuperBlockState {
+    fn drop(&mut self) {
+        if let Some(minor) = self.unnamed_dev_minor.lock().take() {
+            UNNAMED_DEV_ID_ALLOCATOR.lock().free(minor as usize);
+        }
     }
 }
 
@@ -1459,12 +1491,10 @@ impl IndexNode for MountFSInode {
     fn metadata(&self) -> Result<super::Metadata, SystemError> {
         let mut md = self.inner_inode.metadata()?;
 
-        // Provide a stable and unique st_dev for each mount point (via metadata.dev_id).
-        // This handles the case where the underlying filesystem does not provide a dev_id.
+        // Filesystems without a real device share one lazily allocated st_dev across all
+        // views of the same superblock (including bind mounts and namespace copies).
         if md.dev_id == 0 {
-            let mnt_id: usize = self.mount_fs.mount_id().into();
-            let minor = (mnt_id as u32) & DeviceNumber::MINOR_MASK;
-            md.dev_id = DeviceNumber::new(Major::UNNAMED_MAJOR, minor).data() as usize;
+            md.dev_id = self.mount_fs.super_block_state.unnamed_dev()?.data() as usize;
         }
 
         Ok(md)
@@ -1474,6 +1504,16 @@ impl IndexNode for MountFSInode {
     fn set_metadata(&self, metadata: &super::Metadata) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
         return self.inner_inode.set_metadata(metadata);
+    }
+
+    #[inline]
+    fn set_metadata_masked(
+        &self,
+        metadata: &super::Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        self.ensure_mount_writable()?;
+        self.inner_inode.set_metadata_masked(metadata, mask)
     }
 
     #[inline]

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1540,6 +1540,33 @@ impl IndexNode for MountFSInode {
     }
 
     #[inline]
+    fn resize_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        metadata: &super::Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        self.ensure_mount_writable()?;
+        self.inner_inode
+            .resize_with_metadata(len, lock_owner, metadata, mask)
+    }
+
+    #[inline]
+    fn resize_file_with_metadata(
+        &self,
+        len: usize,
+        lock_owner: u64,
+        data: MutexGuard<FilePrivateData>,
+        metadata: &super::Metadata,
+        mask: SetMetadataMask,
+    ) -> Result<(), SystemError> {
+        self.ensure_mount_writable()?;
+        self.inner_inode
+            .resize_file_with_metadata(len, lock_owner, data, metadata, mask)
+    }
+
+    #[inline]
     fn fallocate_file(
         &self,
         mode: i32,

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -9,7 +9,8 @@ use super::{
     syscall::{OpenHow, OpenHowResolve},
     utils::{rsplit_path, should_remove_sgid_on_chown, user_path_at},
     vcore::{check_parent_dir_permission_inode, resolve_parent_inode, vfs_truncate},
-    FileType, FsPermissionPolicy, IndexNode, InodeMode, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
+    FileType, FsPermissionPolicy, IndexNode, InodeMode, SetMetadataMask, MAX_PATHLEN,
+    VFS_MAX_FOLLOW_SYMLINK_TIMES,
 };
 use crate::{filesystem::vfs::syscall::UtimensFlags, process::cred::Kgid};
 use crate::{
@@ -125,7 +126,8 @@ pub fn do_fchmod(inode: Arc<dyn IndexNode>, mode: InodeMode) -> Result<usize, Sy
     }
 
     metadata.mode = chmod_preserve_type(metadata.mode, mode);
-    inode.set_metadata(&metadata)?;
+    metadata.ctime = PosixTimeSpec::now();
+    inode.set_metadata_masked(&metadata, SetMetadataMask::MODE | SetMetadataMask::CTIME)?;
     Ok(0)
 }
 
@@ -180,6 +182,7 @@ fn chown_common(inode: Arc<dyn IndexNode>, uid: usize, gid: usize) -> Result<usi
     let change_gid = gid != usize::MAX;
     let old_uid = meta.uid;
     let old_gid = meta.gid;
+    let old_mode = meta.mode;
 
     // 检查权限
     match current_uid {
@@ -219,7 +222,21 @@ fn chown_common(inode: Arc<dyn IndexNode>, uid: usize, gid: usize) -> Result<usi
             meta.mode.remove(InodeMode::S_ISGID);
         }
     }
-    inode.set_metadata(&meta)?;
+    let mut mask = SetMetadataMask::empty();
+    if change_uid {
+        mask.insert(SetMetadataMask::UID);
+    }
+    if change_gid {
+        mask.insert(SetMetadataMask::GID);
+    }
+    if meta.mode != old_mode {
+        mask.insert(SetMetadataMask::MODE);
+    }
+    if !mask.is_empty() {
+        meta.ctime = PosixTimeSpec::now();
+        mask.insert(SetMetadataMask::CTIME);
+    }
+    inode.set_metadata_masked(&meta, mask)?;
 
     return Ok(0);
 }
@@ -545,22 +562,50 @@ pub fn do_utimensat(
     let now = PosixTimeSpec::now();
     let mut meta = inode.metadata()?;
 
+    let both_omit =
+        times.is_some_and(|times| times[0].tv_nsec == UTIME_OMIT && times[1].tv_nsec == UTIME_OMIT);
+    if both_omit {
+        return Ok(0);
+    }
+    let both_now =
+        times.is_none_or(|times| times[0].tv_nsec == UTIME_NOW && times[1].tv_nsec == UTIME_NOW);
+    check_timestamp_update_permission(&inode, &meta, both_now)?;
+
     if let Some([atime, mtime]) = times {
+        let mut mask = SetMetadataMask::empty();
         if atime.tv_nsec == UTIME_NOW {
             meta.atime = now;
+            mask.insert(SetMetadataMask::ATIME);
         } else if atime.tv_nsec != UTIME_OMIT {
             meta.atime = atime;
+            mask.insert(SetMetadataMask::ATIME);
         }
         if mtime.tv_nsec == UTIME_NOW {
             meta.mtime = now;
+            mask.insert(SetMetadataMask::MTIME);
         } else if mtime.tv_nsec != UTIME_OMIT {
             meta.mtime = mtime;
+            mask.insert(SetMetadataMask::MTIME);
         }
-        inode.set_metadata(&meta).unwrap();
+        if !mask.is_empty() {
+            meta.ctime = now;
+            mask.insert(SetMetadataMask::CTIME);
+            if both_now {
+                mask.insert(SetMetadataMask::TIMES_BY_WRITE);
+            }
+        }
+        inode.set_metadata_masked(&meta, mask)?;
     } else {
         meta.atime = now;
         meta.mtime = now;
-        inode.set_metadata(&meta).unwrap();
+        meta.ctime = now;
+        inode.set_metadata_masked(
+            &meta,
+            SetMetadataMask::ATIME
+                | SetMetadataMask::MTIME
+                | SetMetadataMask::CTIME
+                | SetMetadataMask::TIMES_BY_WRITE,
+        )?;
     }
     return Ok(0);
 }
@@ -574,16 +619,47 @@ pub fn do_utimes(path: &str, times: Option<[PosixTimeval; 2]>) -> Result<usize, 
     )?;
     let inode = inode_begin.lookup_follow_symlink(path.as_str(), VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
     let mut meta = inode.metadata()?;
+    check_timestamp_update_permission(&inode, &meta, times.is_none())?;
 
     if let Some([atime, mtime]) = times {
         meta.atime = PosixTimeSpec::from(atime);
         meta.mtime = PosixTimeSpec::from(mtime);
-        inode.set_metadata(&meta)?;
+        meta.ctime = PosixTimeSpec::now();
+        inode.set_metadata_masked(
+            &meta,
+            SetMetadataMask::ATIME | SetMetadataMask::MTIME | SetMetadataMask::CTIME,
+        )?;
     } else {
         let now = PosixTimeSpec::now();
         meta.atime = now;
         meta.mtime = now;
-        inode.set_metadata(&meta)?;
+        meta.ctime = now;
+        inode.set_metadata_masked(
+            &meta,
+            SetMetadataMask::ATIME
+                | SetMetadataMask::MTIME
+                | SetMetadataMask::CTIME
+                | SetMetadataMask::TIMES_BY_WRITE,
+        )?;
     }
     return Ok(0);
+}
+
+fn check_timestamp_update_permission(
+    inode: &Arc<dyn IndexNode>,
+    metadata: &super::Metadata,
+    may_use_write_permission: bool,
+) -> Result<(), SystemError> {
+    let cred = ProcessManager::current_pcb().cred();
+    if cred.fsuid.data() == metadata.uid || cred.has_capability(CAPFlags::CAP_FOWNER) {
+        return Ok(());
+    }
+    if may_use_write_permission {
+        return super::permission::check_inode_permission(
+            inode,
+            metadata,
+            PermissionMask::MAY_WRITE,
+        );
+    }
+    Err(SystemError::EPERM)
 }

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -19,7 +19,7 @@ use crate::{
             file::{File, FileMode, FilePrivateData},
             mount::MountFlags,
             permission::PermissionMask,
-            AtomicInodeId, FileSystem, FileType, InodeFlags, InodeMode, MountFS,
+            AtomicInodeId, FileSystem, FileType, InodeFlags, InodeMode, MountFS, SetMetadataMask,
         },
     },
     init::cmdline::kenrel_cmdline_param_manager,
@@ -764,20 +764,24 @@ where
     let result = do_resize(&inode);
 
     if result.is_ok() {
-        clear_suid_sgid_after_truncate(inode.as_ref())?;
+        finish_truncate_metadata(inode.as_ref())?;
     }
 
     result
 }
 
-fn clear_suid_sgid_after_truncate(inode: &dyn IndexNode) -> Result<(), SystemError> {
+fn finish_truncate_metadata(inode: &dyn IndexNode) -> Result<(), SystemError> {
     let cred = ProcessManager::current_pcb().cred();
-    if cred.has_capability(CAPFlags::CAP_FSETID) {
-        return Ok(());
-    }
-
     let mut md = inode.metadata()?;
-    if md.file_type == FileType::File && md.mode.intersects(InodeMode::S_ISUID | InodeMode::S_ISGID)
+    let now = crate::time::PosixTimeSpec::now();
+    md.mtime = now;
+    md.ctime = now;
+    let mut mask =
+        SetMetadataMask::MTIME | SetMetadataMask::CTIME | SetMetadataMask::WRITE_SIDE_EFFECT;
+
+    if !cred.has_capability(CAPFlags::CAP_FSETID)
+        && md.file_type == FileType::File
+        && md.mode.intersects(InodeMode::S_ISUID | InodeMode::S_ISGID)
     {
         let original_mode = md.mode;
         md.mode.remove(InodeMode::S_ISUID);
@@ -787,11 +791,10 @@ fn clear_suid_sgid_after_truncate(inode: &dyn IndexNode) -> Result<(), SystemErr
         }
 
         if md.mode != original_mode {
-            inode.set_metadata(&md)?;
+            mask.insert(SetMetadataMask::MODE);
         }
     }
-
-    Ok(())
+    inode.set_metadata_masked(&md, mask)
 }
 
 /// 统一的 VFS 截断封装：对 inode 进行基本检查并调用 resize
@@ -865,7 +868,7 @@ pub fn resize_based_fallocate(
 
     let result = inode.resize_with_lock_owner(new_size, lock_owner);
     if result.is_ok() && md.size != new_size as i64 {
-        clear_suid_sgid_after_truncate(inode)?;
+        finish_truncate_metadata(inode)?;
     }
 
     result

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -19,7 +19,8 @@ use crate::{
             file::{File, FileMode, FilePrivateData},
             mount::MountFlags,
             permission::PermissionMask,
-            AtomicInodeId, FileSystem, FileType, InodeFlags, InodeMode, MountFS, SetMetadataMask,
+            AtomicInodeId, FileSystem, FileType, InodeFlags, InodeMode, Metadata, MountFS,
+            SetMetadataMask,
         },
     },
     init::cmdline::kenrel_cmdline_param_manager,
@@ -721,7 +722,7 @@ fn vfs_truncate_inner<F>(
     do_resize: F,
 ) -> Result<(), SystemError>
 where
-    F: FnOnce(&Arc<dyn IndexNode>) -> Result<(), SystemError>,
+    F: FnOnce(&Arc<dyn IndexNode>, &Metadata, SetMetadataMask) -> Result<(), SystemError>,
 {
     let md = inode.metadata()?;
 
@@ -761,19 +762,17 @@ where
         }
     }
 
-    let result = do_resize(&inode);
-
-    if result.is_ok() {
-        finish_truncate_metadata(inode.as_ref())?;
-    }
-
-    result
+    let (md, mask) = prepare_write_side_effect_metadata(md, len);
+    do_resize(&inode, &md, mask)
 }
 
-fn finish_truncate_metadata(inode: &dyn IndexNode) -> Result<(), SystemError> {
+fn prepare_write_side_effect_metadata(
+    mut md: Metadata,
+    new_size: usize,
+) -> (Metadata, SetMetadataMask) {
     let cred = ProcessManager::current_pcb().cred();
-    let mut md = inode.metadata()?;
     let now = crate::time::PosixTimeSpec::now();
+    md.size = new_size as i64;
     md.mtime = now;
     md.ctime = now;
     let mut mask =
@@ -794,7 +793,7 @@ fn finish_truncate_metadata(inode: &dyn IndexNode) -> Result<(), SystemError> {
             mask.insert(SetMetadataMask::MODE);
         }
     }
-    inode.set_metadata_masked(&md, mask)
+    (md, mask)
 }
 
 /// 统一的 VFS 截断封装：对 inode 进行基本检查并调用 resize
@@ -804,8 +803,8 @@ fn finish_truncate_metadata(inode: &dyn IndexNode) -> Result<(), SystemError> {
 #[inline(never)]
 pub fn vfs_truncate(inode: Arc<dyn IndexNode>, len: usize) -> Result<(), SystemError> {
     let lock_owner = current_file_lock_owner_id();
-    vfs_truncate_inner(inode, len, |inode| {
-        inode.resize_with_lock_owner(len, lock_owner)
+    vfs_truncate_inner(inode, len, |inode, metadata, mask| {
+        inode.resize_with_metadata(len, lock_owner, metadata, mask)
     })
 }
 
@@ -817,8 +816,8 @@ pub fn vfs_truncate_file<'a>(
     lock_owner: u64,
     data: impl FnOnce() -> MutexGuard<'a, FilePrivateData>,
 ) -> Result<(), SystemError> {
-    vfs_truncate_inner(inode, len, |inode| {
-        inode.resize_file(len, lock_owner, data())
+    vfs_truncate_inner(inode, len, |inode, metadata, mask| {
+        inode.resize_file_with_metadata(len, lock_owner, data(), metadata, mask)
     })
 }
 
@@ -866,12 +865,8 @@ pub fn resize_based_fallocate(
 
     check_file_size_limit(new_size)?;
 
-    let result = inode.resize_with_lock_owner(new_size, lock_owner);
-    if result.is_ok() && md.size != new_size as i64 {
-        finish_truncate_metadata(inode)?;
-    }
-
-    result
+    let (metadata, mask) = prepare_write_side_effect_metadata(md, new_size);
+    inode.resize_with_metadata(new_size, lock_owner, &metadata, mask)
 }
 
 /// 基于已打开文件执行 VFS fallocate 公共检查，再分派给具体文件系统。

--- a/kernel/src/libs/rand.rs
+++ b/kernel/src/libs/rand.rs
@@ -1,4 +1,5 @@
 use crate::arch::rand::rand;
+use core::sync::atomic::{AtomicU64, Ordering};
 
 bitflags! {
     pub struct GRandFlags: u8{
@@ -51,13 +52,22 @@ pub fn rand_bytes<const N: usize>() -> [u8; N] {
 // 软件实现的随机数生成器
 #[allow(dead_code)]
 pub fn soft_rand() -> usize {
-    static mut SEED: u64 = 0xdead_beef_cafe_babe;
+    static SEED: AtomicU64 = AtomicU64::new(0xdead_beef_cafe_babe);
     let mut buf = [0u8; size_of::<usize>()];
     for x in buf.iter_mut() {
-        unsafe {
-            // from musl
-            SEED = SEED.wrapping_mul(0x5851_f42d_4c95_7f2d);
-            *x = (SEED >> 33) as u8;
+        let mut current = SEED.load(Ordering::Relaxed);
+        loop {
+            // Linear congruential step inherited from the existing musl-style
+            // fallback. Atomic CAS avoids cross-CPU data races on architectures
+            // without a hardware random source.
+            let next = current.wrapping_mul(0x5851_f42d_4c95_7f2d);
+            match SEED.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => {
+                    *x = (next >> 33) as u8;
+                    break;
+                }
+                Err(actual) => current = actual,
+            }
         }
     }
     let x: usize = usize::from_ne_bytes(buf);

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -292,6 +292,7 @@ static int ext_test_positive_lookup_cache_respects_entry_ttl() {
     args.lookup_count = &lookup_count;
     args.entry_valid_sec = 60;
     args.attr_valid_sec = 60;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -421,6 +422,7 @@ static int ext_test_xattr_ops() {
     args.listxattr_count = &listxattr_count;
     args.removexattr_count = &removexattr_count;
     args.last_setxattr_flags = &last_setxattr_flags;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -3040,6 +3042,7 @@ static int ext_test_clone() {
     clone_args.init_done = &init_done;
     clone_args.enable_write_ops = 0;
     clone_args.exit_after_init = 0;
+    clone_args.stop_on_destroy = 1;
 
     pthread_t clone_th;
     if (pthread_create(&clone_th, NULL, fuse_daemon_thread, &clone_args) != 0) {
@@ -3142,6 +3145,7 @@ static int ext_test_large_read_over_max_write() {
     args.read_sizes = read_sizes;
     args.read_trace_capacity = 4;
     args.hello_data_size_override = data_size;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -3257,6 +3261,7 @@ static int ext_test_cached_read_uses_open_fh_without_extra_open() {
     args.read_fhs = read_fhs;
     args.read_trace_capacity = 4;
     args.next_open_fh = 100;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -3364,6 +3369,7 @@ static int ext_test_cached_short_read_updates_eof() {
     args.read_trace_capacity = 4;
     args.hello_data_size_override = 8192;
     args.hello_read_size_override = 5;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -3876,6 +3882,7 @@ static int ext_test_mmap_fault_batches_readaround_pages() {
     args.read_trace_capacity = 8;
     args.hello_generated_size_override = map_len;
     args.init_out_max_write_override = map_len;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -3997,6 +4004,7 @@ static int ext_test_direct_io_read_bypasses_page_cache() {
     args.read_trace_capacity = 4;
     args.next_open_fh = 700;
     args.hello_open_out_flags = FOPEN_DIRECT_IO;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
@@ -4107,6 +4115,7 @@ static int ext_test_direct_io_write_invalidates_cached_read() {
     args.dynamic_hello_open_out_flags = &open_out_flags;
     args.last_write_fh = &last_write_fh;
     args.next_open_fh = 520;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -675,6 +675,7 @@ static int ext_test_xattr_enosys_is_cached() {
     args.init_done = &init_done;
     args.listxattr_count = &listxattr_count;
     args.force_xattr_enosys = 1;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -2864,6 +2864,7 @@ static int ext_run_permission_case(const char *mp, const char *opts, uint32_t ro
     args.init_done = &init_done;
     args.enable_write_ops = 0;
     args.exit_after_init = 0;
+    args.stop_on_destroy = 1;
     args.root_mode_override = root_mode_override;
     args.hello_mode_override = hello_mode_override;
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -3473,6 +3473,7 @@ static int ext_test_cached_read_sees_write_through_update() {
     args.write_count = &write_count;
     args.last_write_fh = &last_write_fh;
     args.next_open_fh = 300;
+    args.stop_on_destroy = 1;
 
     pthread_t th;
     if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -2785,6 +2785,35 @@ TEST(OverlayFsSemantics, UpperDirRenameOverEmptyLowerDirSucceeds) {
     cleanup_overlay_env(env);
 }
 
+TEST(OverlayFsSemantics, CopiedUpIdentitySurvivesRemount) {
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires the Ubuntu 24.04 ext4 rootfs backing";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_remount_identity", "/root");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+    std::string lower_file = join_path(env.lower, "file");
+    std::string merged_file = join_path(env.merged, "file");
+    ASSERT_EQ(0, write_text(lower_file, "lower")) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    struct stat before = {};
+    struct stat copied_up = {};
+    struct stat remounted = {};
+    ASSERT_EQ(0, stat(merged_file.c_str(), &before)) << strerror(errno);
+    ASSERT_EQ(0, chmod(merged_file.c_str(), 0600)) << strerror(errno);
+    ASSERT_EQ(0, stat(merged_file.c_str(), &copied_up)) << strerror(errno);
+    EXPECT_EQ(before.st_dev, copied_up.st_dev);
+    EXPECT_EQ(before.st_ino, copied_up.st_ino);
+
+    ASSERT_EQ(0, umount(env.merged.c_str())) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, stat(merged_file.c_str(), &remounted)) << strerror(errno);
+    EXPECT_EQ(before.st_dev, remounted.st_dev);
+    EXPECT_EQ(before.st_ino, remounted.st_ino);
+}
+
 TEST(OverlayFsSemantics, LowerMetadataMutationsCopyUpAndKeepStableIdentity) {
     if (geteuid() != 0) {
         GTEST_SKIP() << "requires root for chown coverage";

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -3192,7 +3192,7 @@ TEST(OverlayFsSemantics, ContentMutationRemovesCopiedUpFileCapability) {
     ASSERT_GE(fd, 0) << strerror(errno);
     ASSERT_EQ(1, write(fd, "x", 1)) << strerror(errno);
     ASSERT_EQ(0, close(fd)) << strerror(errno);
-    ASSERT_EQ(0, truncate(join_path(env.merged, names[1]).c_str(), 0)) << strerror(errno);
+    ASSERT_EQ(0, truncate(join_path(env.merged, names[1]).c_str(), 3)) << strerror(errno);
     ASSERT_EQ(0, chown(join_path(env.merged, names[2]).c_str(), 1000, 1001)) << strerror(errno);
 
     for (const char* name : names) {
@@ -3206,6 +3206,8 @@ TEST(OverlayFsSemantics, ContentMutationRemovesCopiedUpFileCapability) {
             EXPECT_EQ(ENODATA, errno) << *file;
         }
     }
+    EXPECT_EQ("low", read_text(join_path(env.upper, names[1])));
+    EXPECT_EQ("low", read_text(join_path(env.merged, names[1])));
 }
 
 TEST(OverlayFsSemantics, NonRootOwnerCanTriggerCopyUpThroughMounterCredentials) {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -3,6 +3,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <linux/capability.h>
 #include <signal.h>
 #include <sched.h>
 #include <stdio.h>
@@ -10,10 +11,12 @@
 #include <sys/mount.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/statfs.h>
 #include <sys/sysmacros.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/xattr.h>
 #include <algorithm>
 #include <string>
 #include <utility>
@@ -53,6 +56,44 @@ std::string join_path(const std::string& dir, const char* name) {
 bool path_exists(const std::string& path) {
     struct stat st = {};
     return stat(path.c_str(), &st) == 0;
+}
+
+std::vector<std::string> xattr_names(const std::string& path) {
+    ssize_t needed = listxattr(path.c_str(), nullptr, 0);
+    EXPECT_GE(needed, 0) << path << ": " << strerror(errno);
+    if (needed <= 0) {
+        return {};
+    }
+
+    std::vector<char> list(static_cast<size_t>(needed));
+    ssize_t actual = listxattr(path.c_str(), list.data(), list.size());
+    EXPECT_EQ(needed, actual) << path << ": " << strerror(errno);
+    if (actual != needed) {
+        return {};
+    }
+
+    std::vector<std::string> names;
+    size_t start = 0;
+    for (size_t i = 0; i < static_cast<size_t>(actual); ++i) {
+        if (list[i] == '\0') {
+            names.emplace_back(list.data() + start, i - start);
+            start = i + 1;
+        }
+    }
+    EXPECT_EQ(static_cast<size_t>(actual), start);
+    return names;
+}
+
+bool has_xattr_name(const std::vector<std::string>& names, const char* name) {
+    return std::find(names.begin(), names.end(), name) != names.end();
+}
+
+void expect_xattr(const std::string& path, const char* name, const void* expected, size_t size) {
+    std::vector<unsigned char> value(size == 0 ? 1 : size);
+    ssize_t actual = getxattr(path.c_str(), name, value.data(), value.size());
+    ASSERT_EQ(static_cast<ssize_t>(size), actual)
+        << path << " " << name << ": " << strerror(errno);
+    EXPECT_EQ(0, memcmp(value.data(), expected, size));
 }
 
 void expect_path_enoent(const std::string& path) {
@@ -220,8 +261,8 @@ struct OverlayRenameEnv {
     std::string merged;
 };
 
-OverlayRenameEnv make_overlay_env(const char* name) {
-    std::string root = std::string("/tmp/") + name + "_" + std::to_string(getpid());
+OverlayRenameEnv make_overlay_env(const char* name, const char* base = "/tmp") {
+    std::string root = std::string(base) + "/" + name + "_" + std::to_string(getpid());
     OverlayRenameEnv env = {};
     env.root = root;
     env.upper = join_path(root, "u");
@@ -237,7 +278,8 @@ void cleanup_overlay_env(const OverlayRenameEnv& env) {
 }
 
 struct ScopedOverlayEnv {
-    explicit ScopedOverlayEnv(const char* name) : env(make_overlay_env(name)) {}
+    explicit ScopedOverlayEnv(const char* name, const char* base = "/tmp")
+        : env(make_overlay_env(name, base)) {}
 
     ~ScopedOverlayEnv() {
         cleanup_overlay_env(env);
@@ -245,6 +287,11 @@ struct ScopedOverlayEnv {
 
     OverlayRenameEnv env;
 };
+
+bool root_supports_ext4_xattrs() {
+    struct statfs st = {};
+    return statfs("/root", &st) == 0 && st.f_type == 0xEF53;
+}
 
 struct ScopedCustomMount {
     ScopedCustomMount(std::string root_path, std::string merged_path)
@@ -1111,7 +1158,6 @@ TEST(OverlayFsSemantics, HardlinkUsesRealUpperInodeForLowerAndUpperSources) {
     ASSERT_EQ(0, stat(upper_a.c_str(), &upper_a_st)) << strerror(errno);
     ASSERT_EQ(0, stat(upper_b.c_str(), &upper_b_st)) << strerror(errno);
     EXPECT_EQ(merged_a_st.st_ino, merged_b_st.st_ino);
-    EXPECT_EQ(merged_a_st.st_ino, upper_a_st.st_ino);
     EXPECT_EQ(upper_a_st.st_ino, upper_b_st.st_ino);
     EXPECT_EQ(2u, static_cast<unsigned>(merged_a_st.st_nlink));
     EXPECT_EQ(2u, static_cast<unsigned>(upper_b_st.st_nlink));
@@ -2699,6 +2745,361 @@ TEST(OverlayFsSemantics, UpperDirRenameOverEmptyLowerDirSucceeds) {
     EXPECT_EQ("source", read_text(join_path(merged_new, "child")));
     EXPECT_EQ(0, close(old_target_fd)) << strerror(errno);
     cleanup_overlay_env(env);
+}
+
+TEST(OverlayFsSemantics, LowerMetadataMutationsCopyUpAndKeepStableIdentity) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root for chown coverage";
+    }
+
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires the Ubuntu 24.04 ext4 rootfs backing";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_metadata_copy_up", "/root");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+
+    const char* names[] = {"mode", "owner", "time", "truncate", "ftruncate"};
+    for (const char* name : names) {
+        ASSERT_EQ(0, write_text(join_path(env.lower, name), "0123456789")) << strerror(errno);
+    }
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    struct stat before[5] = {};
+    for (size_t i = 0; i < 5; ++i) {
+        ASSERT_EQ(0, stat(join_path(env.merged, names[i]).c_str(), &before[i])) << strerror(errno);
+    }
+    sleep(1);
+
+    ASSERT_EQ(0, chmod(join_path(env.merged, names[0]).c_str(), 0601)) << strerror(errno);
+    ASSERT_EQ(0, chown(join_path(env.merged, names[1]).c_str(), 1000, 1001)) << strerror(errno);
+    timespec times[2] = {{123456789, 123456789}, {123456790, 987654321}};
+    ASSERT_EQ(0, utimensat(AT_FDCWD, join_path(env.merged, names[2]).c_str(), times, 0))
+        << strerror(errno);
+    ASSERT_EQ(0, truncate(join_path(env.merged, names[3]).c_str(), 3)) << strerror(errno);
+    int fd = open(join_path(env.merged, names[4]).c_str(), O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, ftruncate(fd, 4)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    for (size_t i = 0; i < 5; ++i) {
+        struct stat merged_st = {};
+        struct stat lower_st = {};
+        struct stat upper_st = {};
+        ASSERT_EQ(0, stat(join_path(env.merged, names[i]).c_str(), &merged_st)) << strerror(errno);
+        ASSERT_EQ(0, stat(join_path(env.lower, names[i]).c_str(), &lower_st)) << strerror(errno);
+        ASSERT_EQ(0, stat(join_path(env.upper, names[i]).c_str(), &upper_st)) << strerror(errno);
+        EXPECT_EQ(before[i].st_dev, merged_st.st_dev) << names[i];
+        EXPECT_EQ(before[i].st_ino, merged_st.st_ino) << names[i];
+        EXPECT_GT(merged_st.st_ctim.tv_sec, before[i].st_ctim.tv_sec) << names[i];
+        EXPECT_EQ(10, lower_st.st_size) << names[i];
+        if (i >= 3) {
+            EXPECT_GT(merged_st.st_mtim.tv_sec, before[i].st_mtim.tv_sec) << names[i];
+        }
+    }
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(join_path(env.merged, names[0]).c_str(), &st));
+    EXPECT_EQ(0601u, st.st_mode & 07777);
+    ASSERT_EQ(0, stat(join_path(env.lower, names[0]).c_str(), &st));
+    EXPECT_EQ(0644u, st.st_mode & 07777);
+    ASSERT_EQ(0, stat(join_path(env.merged, names[1]).c_str(), &st));
+    EXPECT_EQ(1000u, st.st_uid);
+    EXPECT_EQ(1001u, st.st_gid);
+    ASSERT_EQ(0, stat(join_path(env.lower, names[1]).c_str(), &st));
+    EXPECT_EQ(0u, st.st_uid);
+    EXPECT_EQ(0u, st.st_gid);
+    ASSERT_EQ(0, stat(join_path(env.merged, names[2]).c_str(), &st));
+    EXPECT_EQ(times[0].tv_sec, st.st_atim.tv_sec);
+    EXPECT_EQ(times[1].tv_sec, st.st_mtim.tv_sec);
+    // DragonOS ext4 currently exposes second-resolution timestamps.
+    EXPECT_EQ(0, st.st_atim.tv_nsec);
+    EXPECT_EQ(0, st.st_mtim.tv_nsec);
+    ASSERT_EQ(0, stat(join_path(env.lower, names[2]).c_str(), &st));
+    EXPECT_NE(times[1].tv_sec, st.st_mtim.tv_sec);
+    ASSERT_EQ(0, stat(join_path(env.merged, names[3]).c_str(), &st));
+    EXPECT_EQ(3, st.st_size);
+    ASSERT_EQ(0, stat(join_path(env.merged, names[4]).c_str(), &st));
+    EXPECT_EQ(4, st.st_size);
+
+    std::string pure_upper = join_path(env.merged, "pure_upper_time");
+    ASSERT_EQ(0, write_text(pure_upper, "upper"));
+    struct stat pure_before = {};
+    ASSERT_EQ(0, stat(pure_upper.c_str(), &pure_before));
+    sleep(1);
+    ASSERT_EQ(0, chmod(pure_upper.c_str(), 0600));
+    struct stat pure_after_chmod = {};
+    ASSERT_EQ(0, stat(pure_upper.c_str(), &pure_after_chmod));
+    EXPECT_GT(pure_after_chmod.st_ctim.tv_sec, pure_before.st_ctim.tv_sec);
+    sleep(1);
+    ASSERT_EQ(0, truncate(pure_upper.c_str(), 2));
+    struct stat pure_after_truncate = {};
+    ASSERT_EQ(0, stat(pure_upper.c_str(), &pure_after_truncate));
+    EXPECT_GT(pure_after_truncate.st_ctim.tv_sec, pure_after_chmod.st_ctim.tv_sec);
+    EXPECT_GT(pure_after_truncate.st_mtim.tv_sec, pure_after_chmod.st_mtim.tv_sec);
+}
+
+TEST(OverlayFsSemantics, UserXattrOperationsAndPrivateNamespaceSemantics) {
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires the Ubuntu 24.04 ext4 rootfs backing";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_xattr_ops", "/root");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+    std::string lower_file = join_path(env.lower, "file");
+    std::string merged_file = join_path(env.merged, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    std::string missing_lower = join_path(env.lower, "missing");
+    std::string missing_merged = join_path(env.merged, "missing");
+    std::string missing_upper = join_path(env.upper, "missing");
+    ASSERT_EQ(0, write_text(lower_file, "lower"));
+    ASSERT_EQ(0, write_text(missing_lower, "lower"));
+    ASSERT_EQ(0, setxattr(lower_file.c_str(), "user.base", "lower", 5, 0)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    expect_xattr(merged_file, "user.base", "lower", 5);
+    EXPECT_TRUE(has_xattr_name(xattr_names(merged_file), "user.base"));
+    ASSERT_EQ(0, setxattr(merged_file.c_str(), "user.base", "upper", 5, XATTR_REPLACE))
+        << strerror(errno);
+    expect_xattr(merged_file, "user.base", "upper", 5);
+    expect_xattr(upper_file, "user.base", "upper", 5);
+    expect_xattr(lower_file, "user.base", "lower", 5);
+    errno = 0;
+    EXPECT_EQ(-1, setxattr(merged_file.c_str(), "user.base", "new", 3, XATTR_CREATE));
+    EXPECT_EQ(EEXIST, errno);
+    ASSERT_EQ(0, setxattr(merged_file.c_str(), "user.created", "value", 5, XATTR_CREATE));
+    ASSERT_EQ(0, removexattr(merged_file.c_str(), "user.base"));
+    errno = 0;
+    EXPECT_EQ(-1, getxattr(merged_file.c_str(), "user.base", nullptr, 0));
+    EXPECT_EQ(ENODATA, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, removexattr(missing_merged.c_str(), "user.absent"));
+    EXPECT_EQ(ENODATA, errno);
+    EXPECT_FALSE(path_exists(missing_upper));
+
+    constexpr const char* kPrivate = "trusted.overlay.origin";
+    errno = 0;
+    EXPECT_EQ(-1, getxattr(merged_file.c_str(), kPrivate, nullptr, 0));
+    EXPECT_EQ(EOPNOTSUPP, errno);
+    errno = 0;
+    EXPECT_EQ(-1, setxattr(merged_file.c_str(), kPrivate, "x", 1, 0));
+    EXPECT_EQ(EOPNOTSUPP, errno);
+    errno = 0;
+    EXPECT_EQ(-1, removexattr(merged_file.c_str(), kPrivate));
+    EXPECT_EQ(EOPNOTSUPP, errno);
+    errno = 0;
+    EXPECT_EQ(-1,
+              getxattr(merged_file.c_str(), "trusted.dragonos.overlay.origin", nullptr, 0));
+    EXPECT_EQ(EOPNOTSUPP, errno);
+    for (const auto& name : xattr_names(merged_file)) {
+        EXPECT_NE(0u, name.find("trusted.overlay."));
+        EXPECT_NE("trusted.dragonos.overlay.origin", name);
+    }
+}
+
+TEST(OverlayFsSemantics, CallerPermissionsProtectTimestampsAndUserXattrs) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root to create the non-root caller";
+    }
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires the Ubuntu 24.04 ext4 rootfs backing";
+    }
+
+    ASSERT_EQ(0, ensure_dir("/var/tmp"));
+    ASSERT_EQ(0, chmod("/var/tmp", 01777));
+    ScopedOverlayEnv scoped("overlayfs_caller_permissions", "/var/tmp");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+    std::string lower_file = join_path(env.lower, "secret");
+    std::string lower_sticky = join_path(env.lower, "sticky");
+    std::string lower_fifo = join_path(env.lower, "fifo");
+    std::string merged_file = join_path(env.merged, "secret");
+    std::string merged_sticky = join_path(env.merged, "sticky");
+    std::string merged_fifo = join_path(env.merged, "fifo");
+    ASSERT_EQ(0, write_text(lower_file, "secret"));
+    ASSERT_EQ(0, setxattr(lower_file.c_str(), "user.secret", "hidden", 6, 0));
+    ASSERT_EQ(0, chmod(lower_file.c_str(), 0000));
+    ASSERT_EQ(0, mkdir(lower_sticky.c_str(), 01777));
+    ASSERT_EQ(0, chmod(lower_sticky.c_str(), 01777));
+    ASSERT_EQ(0, mkfifo(lower_fifo.c_str(), 0666));
+    ASSERT_EQ(0, chmod(lower_fifo.c_str(), 0666));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(1000) != 0 || setuid(1000) != 0) {
+            _exit(10);
+        }
+        __user_cap_header_struct cap_header = {_LINUX_CAPABILITY_VERSION_3, 0};
+        __user_cap_data_struct cap_data[2] = {};
+        if (syscall(SYS_capset, &cap_header, cap_data) != 0) {
+            _exit(16);
+        }
+        char value[8] = {};
+        if (getxattr(merged_file.c_str(), "user.secret", value, sizeof(value)) != -1
+            || errno != EACCES) {
+            _exit(11);
+        }
+        if (setxattr(merged_sticky.c_str(), "user.denied", "x", 1, 0) != -1
+            || errno != EPERM) {
+            _exit(12);
+        }
+        if (setxattr(merged_fifo.c_str(), "user.denied", "x", 1, 0) != -1
+            || errno != EPERM) {
+            _exit(13);
+        }
+        timespec explicit_times[2] = {{123456789, 0}, {123456790, 0}};
+        if (utimensat(AT_FDCWD, merged_file.c_str(), explicit_times, 0) != -1
+            || errno != EPERM) {
+            _exit(14);
+        }
+        if (utimensat(AT_FDCWD, merged_file.c_str(), nullptr, 0) != -1
+            || errno != EACCES) {
+            _exit(15);
+        }
+        _exit(0);
+    }
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    EXPECT_FALSE(path_exists(join_path(env.upper, "secret")));
+    EXPECT_FALSE(path_exists(join_path(env.upper, "sticky")));
+    EXPECT_FALSE(path_exists(join_path(env.upper, "fifo")));
+}
+
+TEST(OverlayFsSemantics, CopyUpPreservesRawAclCapabilityAndAncestorMetadata) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root for ownership and security xattr coverage";
+    }
+
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires the Ubuntu 24.04 ext4 rootfs backing";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_copy_up_raw_metadata", "/root");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+    std::string lower_a = join_path(env.lower, "a");
+    std::string lower_b = join_path(lower_a, "b");
+    std::string lower_file = join_path(lower_b, "file");
+    std::string upper_a = join_path(env.upper, "a");
+    std::string upper_b = join_path(upper_a, "b");
+    std::string upper_file = join_path(upper_b, "file");
+    std::string merged_file = join_path(join_path(join_path(env.merged, "a"), "b"), "file");
+    ASSERT_EQ(0, mkdir(lower_a.c_str(), 0751));
+    ASSERT_EQ(0, mkdir(lower_b.c_str(), 0710));
+    ASSERT_EQ(0, write_text(lower_file, "metadata"));
+    ASSERT_EQ(0, chown(lower_a.c_str(), 1000, 1001));
+    ASSERT_EQ(0, chown(lower_b.c_str(), 1002, 1003));
+    timespec a_times[2] = {{123400000, 111}, {123400001, 222}};
+    timespec b_times[2] = {{123500000, 333}, {123500001, 444}};
+    ASSERT_EQ(0, utimensat(AT_FDCWD, lower_a.c_str(), a_times, 0));
+    ASSERT_EQ(0, utimensat(AT_FDCWD, lower_b.c_str(), b_times, 0));
+
+    const unsigned char acl[] = {
+        2, 0, 0, 0, 1, 0, 7, 0, 0xff, 0xff, 0xff, 0xff,
+        4, 0, 5, 0, 0xff, 0xff, 0xff, 0xff, 0x20, 0, 5, 0, 0xff, 0xff, 0xff, 0xff};
+    const unsigned char capability[] = {
+        0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    ASSERT_EQ(0, setxattr(lower_a.c_str(), "user.ancestor", "a", 1, 0)) << strerror(errno);
+    ASSERT_EQ(0, setxattr(lower_b.c_str(), "system.posix_acl_default", acl, sizeof(acl), 0))
+        << "ext4 must accept the raw default ACL used by this test: " << strerror(errno);
+    ASSERT_EQ(0, setxattr(lower_file.c_str(), "system.posix_acl_access", acl, sizeof(acl), 0))
+        << "ext4 must accept the raw access ACL used by this test: " << strerror(errno);
+    ASSERT_EQ(0,
+              setxattr(lower_file.c_str(), "security.capability", capability, sizeof(capability), 0))
+        << "ext4 must accept the raw file capability used by this test: " << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int fd = open(merged_file.c_str(), O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd));
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_a.c_str(), &st));
+    EXPECT_EQ(1000u, st.st_uid);
+    EXPECT_EQ(1001u, st.st_gid);
+    EXPECT_EQ(0751u, st.st_mode & 07777);
+    EXPECT_EQ(a_times[0].tv_sec, st.st_atim.tv_sec);
+    EXPECT_EQ(a_times[1].tv_sec, st.st_mtim.tv_sec);
+    ASSERT_EQ(0, stat(upper_b.c_str(), &st));
+    EXPECT_EQ(1002u, st.st_uid);
+    EXPECT_EQ(1003u, st.st_gid);
+    EXPECT_EQ(0710u, st.st_mode & 07777);
+    EXPECT_EQ(b_times[0].tv_sec, st.st_atim.tv_sec);
+    EXPECT_EQ(b_times[1].tv_sec, st.st_mtim.tv_sec);
+    expect_xattr(upper_a, "user.ancestor", "a", 1);
+    expect_xattr(upper_b, "system.posix_acl_default", acl, sizeof(acl));
+    expect_xattr(upper_file, "system.posix_acl_access", acl, sizeof(acl));
+    expect_xattr(upper_file, "security.capability", capability, sizeof(capability));
+    expect_xattr(merged_file, "system.posix_acl_access", acl, sizeof(acl));
+    expect_xattr(merged_file, "security.capability", capability, sizeof(capability));
+}
+
+TEST(OverlayFsSemantics, NonRootOwnerCanTriggerCopyUpThroughMounterCredentials) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root to create the non-root caller";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_nonroot_copy_up");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+    std::string lower_file = join_path(env.lower, "file");
+    std::string merged_file = join_path(env.merged, "file");
+    std::string upper_file = join_path(env.upper, "file");
+    ASSERT_EQ(0, write_text(lower_file, "owned"));
+    ASSERT_EQ(0, chown(lower_file.c_str(), 1000, 1000));
+    ASSERT_EQ(0, chmod(lower_file.c_str(), 0644));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(1000) != 0 || setuid(1000) != 0) {
+            _exit(2);
+        }
+        _exit(chmod(merged_file.c_str(), 0600) == 0 ? 0 : 3);
+    }
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+    struct stat st = {};
+    ASSERT_EQ(0, stat(upper_file.c_str(), &st));
+    EXPECT_EQ(1000u, st.st_uid);
+    EXPECT_EQ(0600u, st.st_mode & 07777);
+}
+
+TEST(OverlayFsSemantics, BindSharesDeviceAndIndependentOverlayGetsNewDevice) {
+    ScopedOverlayEnv first("overlayfs_stat_device_first");
+    ScopedOverlayEnv second("overlayfs_stat_device_second");
+    prepare_overlay_env(first.env);
+    prepare_overlay_env(second.env);
+    ASSERT_EQ(0, write_text(join_path(first.env.lower, "file"), "first"));
+    ASSERT_EQ(0, write_text(join_path(second.env.lower, "file"), "second"));
+    ASSERT_TRUE(setup_overlay_env(first.env)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(second.env)) << strerror(errno);
+
+    std::string bind_path = join_path(first.env.root, "bind");
+    ASSERT_EQ(0, mkdir(bind_path.c_str(), 0755));
+    ASSERT_EQ(0, mount(first.env.merged.c_str(), bind_path.c_str(), nullptr, MS_BIND, nullptr))
+        << strerror(errno);
+    struct stat original = {};
+    struct stat bound = {};
+    struct stat independent = {};
+    ASSERT_EQ(0, stat(join_path(first.env.merged, "file").c_str(), &original));
+    ASSERT_EQ(0, stat(join_path(bind_path, "file").c_str(), &bound));
+    ASSERT_EQ(0, stat(join_path(second.env.merged, "file").c_str(), &independent));
+    EXPECT_EQ(original.st_dev, bound.st_dev);
+    EXPECT_EQ(original.st_ino, bound.st_ino);
+    EXPECT_NE(original.st_dev, independent.st_dev);
+    ASSERT_EQ(0, umount(bind_path.c_str()));
+    ASSERT_EQ(0, rmdir(bind_path.c_str()));
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -1743,6 +1743,40 @@ TEST(OverlayFsSemantics, CopyUpLowerSymlinkPreservesTarget) {
     EXPECT_EQ(0, overlay_temp_entry_count(env.work));
 }
 
+TEST(OverlayFsSemantics, ReloadCopiedUpExt4SymlinkWithoutOriginXattr) {
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires ext4 rootfs symlink xattr behavior";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_reload_ext4_symlink", "/root");
+    const auto& env = scoped.env;
+    std::string lower_target = join_path(env.lower, "target");
+    std::string lower_link = join_path(env.lower, "link");
+    std::string merged_link = join_path(env.merged, "link");
+    std::string merged_renamed = join_path(env.merged, "renamed-link");
+
+    ASSERT_EQ(0, ensure_dir(env.root.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.work.c_str()));
+    ASSERT_EQ(0, ensure_dir(env.merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_target, "target-data"));
+    ASSERT_EQ(0, symlink("target", lower_link.c_str())) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    ASSERT_EQ(0, rename(merged_link.c_str(), merged_renamed.c_str())) << strerror(errno);
+
+    // ext4 currently rejects xattrs on symlinks with EPERM. Remount to force
+    // OverlayFS to instantiate a fresh inode and reload the optional origin
+    // xattr instead of reusing the copy-up inode state.
+    ASSERT_EQ(0, umount(env.merged.c_str())) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+    struct stat st = {};
+    ASSERT_EQ(0, lstat(merged_renamed.c_str(), &st)) << strerror(errno);
+    EXPECT_TRUE(S_ISLNK(st.st_mode));
+    EXPECT_EQ("target", read_symlink_target(merged_renamed));
+    EXPECT_EQ("target-data", read_text(merged_renamed));
+}
+
 TEST(OverlayFsSemantics, CopyUpLowerCharDevicePreservesRdev) {
     ScopedOverlayEnv scoped("overlayfs_copy_up_chrdev");
     const auto& env = scoped.env;

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -293,6 +293,10 @@ bool root_supports_ext4_xattrs() {
     return statfs("/root", &st) == 0 && st.f_type == 0xEF53;
 }
 
+bool is_xattr_unsupported_errno(int error) {
+    return error == ENOSYS || error == EOPNOTSUPP;
+}
+
 struct ScopedCustomMount {
     ScopedCustomMount(std::string root_path, std::string merged_path)
         : root(std::move(root_path)), merged(std::move(merged_path)) {}
@@ -2932,6 +2936,56 @@ TEST(OverlayFsSemantics, UserXattrOperationsAndPrivateNamespaceSemantics) {
         EXPECT_NE(0u, name.find("trusted.overlay."));
         EXPECT_NE("trusted.dragonos.overlay.origin", name);
     }
+}
+
+TEST(OverlayFsSemantics, RemoveLowerXattrDroppedByUnsupportedUpperSucceeds) {
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires an ext4 lower and tmpfs upper";
+    }
+
+    std::string suffix = std::to_string(getpid());
+    std::string lower_root = "/root/overlayfs_xattr_drop_lower_" + suffix;
+    std::string upper_root = "/tmp/overlayfs_xattr_drop_upper_" + suffix;
+    std::string lower = join_path(lower_root, "l");
+    std::string upper = join_path(upper_root, "u");
+    std::string work = join_path(upper_root, "w");
+    std::string merged = join_path(upper_root, "m");
+    std::string lower_file = join_path(lower, "file");
+    std::string upper_file = join_path(upper, "file");
+    std::string merged_file = join_path(merged, "file");
+    std::string upper_probe = join_path(upper_root, "xattr_probe");
+    ScopedCustomMount lower_cleanup(lower_root, "");
+    ScopedCustomMount upper_cleanup(upper_root, merged);
+
+    ASSERT_EQ(0, ensure_dir(lower_root.c_str()));
+    ASSERT_EQ(0, ensure_dir(upper_root.c_str()));
+    ASSERT_EQ(0, ensure_dir(lower.c_str()));
+    ASSERT_EQ(0, ensure_dir(upper.c_str()));
+    ASSERT_EQ(0, ensure_dir(work.c_str()));
+    ASSERT_EQ(0, ensure_dir(merged.c_str()));
+    ASSERT_EQ(0, write_text(lower_file, "lower"));
+    ASSERT_EQ(0, write_text(upper_probe, "probe"));
+    errno = 0;
+    int probe_result = setxattr(upper_probe.c_str(), "user.probe", "value", 5, 0);
+    if (probe_result == 0) {
+        GTEST_SKIP() << "requires an upper filesystem without xattr support";
+    }
+    ASSERT_TRUE(is_xattr_unsupported_errno(errno)) << strerror(errno);
+    ASSERT_EQ(0, setxattr(lower_file.c_str(), "user.dropped", "value", 5, 0))
+        << strerror(errno);
+
+    std::string options = "lowerdir=" + lower + ",upperdir=" + upper + ",workdir=" + work;
+    ASSERT_EQ(0, mount("overlay", merged.c_str(), "overlay", 0, options.c_str()))
+        << strerror(errno);
+    upper_cleanup.mounted = true;
+
+    expect_xattr(merged_file, "user.dropped", "value", 5);
+    ASSERT_EQ(0, removexattr(merged_file.c_str(), "user.dropped")) << strerror(errno);
+    EXPECT_TRUE(path_exists(upper_file));
+    errno = 0;
+    EXPECT_EQ(-1, getxattr(merged_file.c_str(), "user.dropped", nullptr, 0));
+    EXPECT_TRUE(errno == ENODATA || is_xattr_unsupported_errno(errno)) << strerror(errno);
+    expect_xattr(lower_file, "user.dropped", "value", 5);
 }
 
 TEST(OverlayFsSemantics, CallerPermissionsProtectTimestampsAndUserXattrs) {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -2850,6 +2850,11 @@ TEST(OverlayFsSemantics, LowerMetadataMutationsCopyUpAndKeepStableIdentity) {
     ASSERT_EQ(0, ftruncate(fd, 4)) << strerror(errno);
     ASSERT_EQ(0, close(fd)) << strerror(errno);
 
+    EXPECT_EQ("012", read_text(join_path(env.upper, names[3])));
+    EXPECT_EQ("012", read_text(join_path(env.merged, names[3])));
+    EXPECT_EQ("0123", read_text(join_path(env.upper, names[4])));
+    EXPECT_EQ("0123", read_text(join_path(env.merged, names[4])));
+
     for (size_t i = 0; i < 5; ++i) {
         struct stat merged_st = {};
         struct stat lower_st = {};

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -3158,6 +3158,51 @@ TEST(OverlayFsSemantics, CopyUpPreservesRawAclCapabilityAndAncestorMetadata) {
     expect_xattr(merged_file, "security.capability", capability, sizeof(capability));
 }
 
+TEST(OverlayFsSemantics, ContentMutationRemovesCopiedUpFileCapability) {
+    if (geteuid() != 0) {
+        GTEST_SKIP() << "requires root for security xattr coverage";
+    }
+    if (!root_supports_ext4_xattrs()) {
+        GTEST_SKIP() << "requires the Ubuntu 24.04 ext4 rootfs backing";
+    }
+
+    ScopedOverlayEnv scoped("overlayfs_kill_file_capability", "/root");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+    const unsigned char capability[] = {
+        0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    const char* names[] = {"write", "truncate", "chown"};
+    for (const char* name : names) {
+        std::string lower_file = join_path(env.lower, name);
+        ASSERT_EQ(0, write_text(lower_file, "lower")) << strerror(errno);
+        ASSERT_EQ(0,
+                  setxattr(lower_file.c_str(), "security.capability", capability,
+                           sizeof(capability), 0))
+            << strerror(errno);
+    }
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    std::string merged_write = join_path(env.merged, names[0]);
+    int fd = open(merged_write.c_str(), O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(1, write(fd, "x", 1)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_EQ(0, truncate(join_path(env.merged, names[1]).c_str(), 0)) << strerror(errno);
+    ASSERT_EQ(0, chown(join_path(env.merged, names[2]).c_str(), 1000, 1001)) << strerror(errno);
+
+    for (const char* name : names) {
+        std::string lower_file = join_path(env.lower, name);
+        std::string upper_file = join_path(env.upper, name);
+        std::string merged_file = join_path(env.merged, name);
+        expect_xattr(lower_file, "security.capability", capability, sizeof(capability));
+        for (const std::string* file : {&upper_file, &merged_file}) {
+            errno = 0;
+            EXPECT_EQ(-1, getxattr(file->c_str(), "security.capability", nullptr, 0));
+            EXPECT_EQ(ENODATA, errno) << *file;
+        }
+    }
+}
+
 TEST(OverlayFsSemantics, NonRootOwnerCanTriggerCopyUpThroughMounterCredentials) {
     if (geteuid() != 0) {
         GTEST_SKIP() << "requires root to create the non-root caller";


### PR DESCRIPTION
## Background

DragonOS OverlayFS did not fully support metadata updates, extended attribute forwarding, or stable file identity across copy-up. Operations such as `chmod`, `chown`, timestamp updates, and truncation on lower-backed files could return `ENOSYS`, while xattrs, ACLs, and file capabilities were not reliably preserved during copy-up.

## What changed

- Implement copy-up-aware `chmod`, `chown`, `utimens`, `truncate`, and `ftruncate` paths.
- Copy file data, xattrs, and metadata in Linux 6.6-compatible order, then atomically publish the completed upper inode.
- Forward and preserve regular xattrs, POSIX ACLs, and security xattrs while hiding OverlayFS-private attributes.
- Add VFS metadata update intents, timestamp handling, and SUID/SGID clearing semantics.
- Provide stable OverlayFS-visible `st_dev` and `st_ino` values across copy-up, while keeping superblock device IDs consistent across bind mounts.
- Harden backing credential overrides, caller authorization, concurrent origin state handling, and random fallback state.
- Extend the OverlayFS dunitest suite to cover metadata operations, xattrs, permissions, ACLs, file capabilities, ancestor copy-up, hard links, and mount identity.

## Root cause

The previous implementation primarily covered merged lookup, basic copy-up, and whiteout operations. Metadata and xattr operations still relied on default VFS behavior or exposed backing inode information directly. As a result, the OverlayFS layer lacked the required copy-up coordination, authorization revalidation, private xattr filtering, metadata preservation, and stable identity handling.

## Validation

- `make fmt`
- `make kernel`
- `overlayfs_semantics_test` on an Ubuntu 24.04 ext4 rootfs: 71/71 tests passed
- `ext4_xattr_test` on an Ubuntu 24.04 ext4 rootfs: 1/1 test passed
- `git diff --check`

Closes #2009
