### PR TITLE
perf(virtiofs): transfer owned reply buffers

### DIFF
--- a/kernel/crates/device-output-buffer/src/lib.rs
+++ b/kernel/crates/device-output-buffer/src/lib.rs
@@ -25,6 +25,74 @@ pub enum BufferError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetentionLimits {
+    pub max_count: usize,
+    pub max_capacity_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetentionSnapshot {
+    pub count: usize,
+    pub capacity_bytes: usize,
+}
+
+/// Pure accounting state for bounding completed device storage retained by consumers.
+///
+/// Synchronization and wakeups deliberately live in the transport using this type. A successful
+/// reservation must be paired with exactly one `release` unless ownership is moved to another
+/// object that retains that obligation.
+#[derive(Debug)]
+pub struct RetentionCredits {
+    limits: RetentionLimits,
+    used: RetentionSnapshot,
+}
+
+impl RetentionCredits {
+    pub const fn new(limits: RetentionLimits) -> Self {
+        Self {
+            limits,
+            used: RetentionSnapshot {
+                count: 0,
+                capacity_bytes: 0,
+            },
+        }
+    }
+
+    pub fn try_reserve(&mut self, capacity: usize) -> bool {
+        if capacity == 0 {
+            return false;
+        }
+        let Some(count) = self.used.count.checked_add(1) else {
+            return false;
+        };
+        let Some(capacity_bytes) = self.used.capacity_bytes.checked_add(capacity) else {
+            return false;
+        };
+        if count > self.limits.max_count || capacity_bytes > self.limits.max_capacity_bytes {
+            return false;
+        }
+        self.used = RetentionSnapshot {
+            count,
+            capacity_bytes,
+        };
+        true
+    }
+
+    pub fn release(&mut self, capacity: usize) -> bool {
+        if self.used.count == 0 || capacity == 0 || capacity > self.used.capacity_bytes {
+            return false;
+        }
+        self.used.count -= 1;
+        self.used.capacity_bytes -= capacity;
+        true
+    }
+
+    pub const fn snapshot(&self) -> RetentionSnapshot {
+        self.used
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DmaIdentity {
     vaddr: usize,
     paddr: usize,
@@ -263,7 +331,10 @@ impl Drop for DeviceOutputBuffer {
 
 #[cfg(test)]
 mod tests {
-    use super::{BufferError, BufferState, DeviceOutputBuffer};
+    use super::{
+        BufferError, BufferState, DeviceOutputBuffer, RetentionCredits, RetentionLimits,
+        RetentionSnapshot,
+    };
 
     fn direct(vaddr: usize) -> Option<usize> {
         Some(vaddr.wrapping_sub(0x1000))
@@ -348,5 +419,48 @@ mod tests {
         buf.recycle().unwrap();
         assert_eq!(buf.prepare(0, direct), Err(BufferError::InvalidLength));
         assert_eq!(buf.prepare(65, direct), Err(BufferError::InvalidLength));
+    }
+
+    #[test]
+    fn retention_credits_enforce_count_and_capacity() {
+        let mut credits = RetentionCredits::new(RetentionLimits {
+            max_count: 2,
+            max_capacity_bytes: 96,
+        });
+        assert!(credits.try_reserve(64));
+        assert!(!credits.try_reserve(64));
+        assert!(credits.try_reserve(32));
+        assert!(!credits.try_reserve(1));
+        assert_eq!(
+            credits.snapshot(),
+            RetentionSnapshot {
+                count: 2,
+                capacity_bytes: 96,
+            }
+        );
+        assert!(credits.release(64));
+        assert!(credits.try_reserve(48));
+        assert_eq!(credits.snapshot().capacity_bytes, 80);
+    }
+
+    #[test]
+    fn retention_credits_reject_invalid_release_and_overflow() {
+        let mut credits = RetentionCredits::new(RetentionLimits {
+            max_count: usize::MAX,
+            max_capacity_bytes: usize::MAX,
+        });
+        assert!(!credits.release(1));
+        assert!(!credits.try_reserve(0));
+        assert!(credits.try_reserve(usize::MAX));
+        assert!(!credits.try_reserve(1));
+        assert!(!credits.release(0));
+        assert!(credits.release(usize::MAX));
+        assert_eq!(
+            credits.snapshot(),
+            RetentionSnapshot {
+                count: 0,
+                capacity_bytes: 0
+            }
+        );
     }
 }

--- a/kernel/crates/device-output-buffer/src/lib.rs
+++ b/kernel/crates/device-output-buffer/src/lib.rs
@@ -87,6 +87,24 @@ impl RetentionCredits {
         true
     }
 
+    /// Replace the capacity charged to one live reservation without changing its count.
+    pub fn resize(&mut self, old_capacity: usize, new_capacity: usize) -> bool {
+        if self.used.count == 0 || old_capacity == 0 || new_capacity == 0 {
+            return false;
+        }
+        let Some(without_old) = self.used.capacity_bytes.checked_sub(old_capacity) else {
+            return false;
+        };
+        let Some(capacity_bytes) = without_old.checked_add(new_capacity) else {
+            return false;
+        };
+        if capacity_bytes > self.limits.max_capacity_bytes {
+            return false;
+        }
+        self.used.capacity_bytes = capacity_bytes;
+        true
+    }
+
     pub const fn snapshot(&self) -> RetentionSnapshot {
         self.used
     }
@@ -462,5 +480,28 @@ mod tests {
                 capacity_bytes: 0
             }
         );
+    }
+
+    #[test]
+    fn retention_credits_resize_preserves_count_and_enforces_capacity() {
+        let mut credits = RetentionCredits::new(RetentionLimits {
+            max_count: 2,
+            max_capacity_bytes: 96,
+        });
+        assert!(credits.try_reserve(64));
+        assert!(credits.resize(64, 80));
+        assert_eq!(
+            credits.snapshot(),
+            RetentionSnapshot {
+                count: 1,
+                capacity_bytes: 80,
+            }
+        );
+        assert!(!credits.resize(80, 97));
+        assert!(!credits.resize(0, 1));
+        assert!(credits.resize(80, 48));
+        assert_eq!(credits.snapshot().count, 1);
+        assert_eq!(credits.snapshot().capacity_bytes, 48);
+        assert!(credits.release(48));
     }
 }

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -30,6 +30,7 @@ use super::protocol::{
     FUSE_PARALLEL_DIROPS, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO,
     FUSE_REMOVEXATTR, FUSE_SETXATTR, FUSE_SUBMOUNTS,
 };
+use super::reply::FuseReply;
 use super::{stats, trace};
 
 mod daemon;
@@ -190,8 +191,15 @@ impl FuseRequestCred {
 pub struct FusePendingState {
     unique: u64,
     opcode: u32,
-    response: Mutex<Option<Result<Vec<u8>, SystemError>>>,
+    response: Mutex<PendingCompletion>,
     wait: WaitQueue,
+}
+
+#[derive(Debug)]
+enum PendingCompletion {
+    Waiting,
+    Ready(Result<FuseReply, SystemError>),
+    Consumed,
 }
 
 impl FusePendingState {
@@ -199,7 +207,7 @@ impl FusePendingState {
         Self {
             unique,
             opcode,
-            response: Mutex::new(None),
+            response: Mutex::new(PendingCompletion::Waiting),
             wait: WaitQueue::default(),
         }
     }
@@ -208,22 +216,26 @@ impl FusePendingState {
         self.unique
     }
 
-    pub fn complete(&self, v: Result<Vec<u8>, SystemError>) {
+    pub fn complete(&self, v: Result<FuseReply, SystemError>) -> bool {
         let mut guard = self.response.lock();
-        if guard.is_some() {
+        if !matches!(*guard, PendingCompletion::Waiting) {
             // Duplicate replies are ignored (Linux does similarly).
-            return;
+            return false;
         }
-        *guard = Some(v);
+        *guard = PendingCompletion::Ready(v);
         drop(guard);
         self.wait.wakeup(None);
+        true
     }
 
-    pub fn wait_complete(&self) -> Result<Vec<u8>, SystemError> {
+    pub fn wait_complete(&self) -> Result<FuseReply, SystemError> {
         wait_with_recheck(&self.wait, || {
             let mut guard = self.response.lock();
-            if let Some(res) = guard.take() {
-                return Ok(Some(res));
+            if matches!(*guard, PendingCompletion::Ready(_)) {
+                let ready = core::mem::replace(&mut *guard, PendingCompletion::Consumed);
+                if let PendingCompletion::Ready(res) = ready {
+                    return Ok(Some(res));
+                }
             }
             Ok(None)
         })?

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -132,6 +132,7 @@ pub(crate) enum FuseReplyCapacitySource {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct FuseReplyCapacity {
     pub(crate) bytes: usize,
+    pub(crate) retained_bytes: usize,
     pub(crate) source: FuseReplyCapacitySource,
 }
 
@@ -850,8 +851,8 @@ mod tests {
     use system_error::SystemError;
 
     use super::super::protocol::{
-        FuseEntryOut, FuseOpenOut, FuseOutHeader, FUSE_CREATE, FUSE_DESTROY, FUSE_GETATTR,
-        FUSE_LOOKUP, FUSE_STATFS,
+        FuseEntryOut, FuseOpenOut, FuseOutHeader, FuseStatfsOut, FUSE_CREATE, FUSE_DESTROY,
+        FUSE_GETATTR, FUSE_LOOKUP, FUSE_STATFS,
     };
     use super::{daemon, request, stats, FuseConn, FuseReplyCapacitySource};
 
@@ -895,10 +896,14 @@ mod tests {
         let conn = FuseConn::new_for_virtiofs(256 * 1024, 256 * 1024);
         let header = size_of::<FuseOutHeader>();
         set_minor(&conn, 3);
+        let statfs_capacity = request::reply_capacity_for_test(&conn, FUSE_STATFS, &[])
+            .unwrap()
+            .unwrap();
         assert_eq!(
-            capacity(&conn, FUSE_STATFS, &[]).0,
+            statfs_capacity.bytes,
             header + FuseConn::FUSE_COMPAT_STATFS_SIZE
         );
+        assert_eq!(statfs_capacity.retained_bytes, size_of::<FuseStatfsOut>());
         assert_eq!(
             capacity(&conn, FUSE_LOOKUP, &[]).0,
             header + FuseConn::FUSE_COMPAT_ENTRY_OUT_SIZE

--- a/kernel/src/filesystem/fuse/conn/daemon.rs
+++ b/kernel/src/filesystem/fuse/conn/daemon.rs
@@ -18,8 +18,51 @@ use super::super::protocol::{
 use super::{
     stats, trace, wait_with_recheck, FuseConn, FuseConnInner, FuseInitNegotiated, FuseRequest,
 };
+use crate::filesystem::fuse::reply::FuseReply;
 
 impl FuseConn {
+    fn claim_pending_reply<F>(
+        &self,
+        unique: u64,
+        pending: &Arc<super::FusePendingState>,
+        update: F,
+    ) -> Result<(), SystemError>
+    where
+        F: FnOnce(&mut FuseConnInner),
+    {
+        let mut g = self.inner.lock();
+        if !g.connected || (g.teardown_started && pending.opcode != FUSE_DESTROY) {
+            return Err(SystemError::ENOENT);
+        }
+        let Some(current) = g.processing.get(&unique) else {
+            return Err(SystemError::ENOENT);
+        };
+        if !Arc::ptr_eq(current, pending) {
+            return Err(SystemError::ENOENT);
+        }
+        g.processing.remove(&unique);
+        update(&mut g);
+        Ok(())
+    }
+
+    fn complete_claimed_reply_with_error(
+        pending: &Arc<super::FusePendingState>,
+        unique: u64,
+        error: SystemError,
+        reply_error: i32,
+        payload_len: usize,
+    ) {
+        if pending.complete(Err(error)) {
+            stats::on_fuse_reply_complete(pending.opcode, reply_error, payload_len);
+            trace::trace_fuse_reply_complete(
+                unique,
+                pending.opcode,
+                reply_error,
+                payload_len as u64,
+            );
+        }
+    }
+
     pub fn poll_mask(&self, have_pending: bool) -> EPollEventType {
         let mut events = EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM;
         let g = self.inner.lock();
@@ -304,7 +347,7 @@ impl FuseConn {
         minor: u32,
         opcode: u32,
         payload: &[u8],
-    ) -> Result<Vec<u8>, SystemError> {
+    ) -> Result<Option<Vec<u8>>, SystemError> {
         let (compat_len, full_len) = if minor < 4 && opcode == FUSE_STATFS {
             (Self::FUSE_COMPAT_STATFS_SIZE, size_of::<FuseStatfsOut>())
         } else if minor < 9
@@ -328,9 +371,9 @@ impl FuseConn {
                 .copy_from_slice(&payload[..Self::FUSE_COMPAT_ENTRY_OUT_SIZE]);
             normalized[size_of::<FuseEntryOut>()..]
                 .copy_from_slice(&payload[Self::FUSE_COMPAT_ENTRY_OUT_SIZE..compat_len]);
-            return Ok(normalized);
+            return Ok(Some(normalized));
         } else {
-            return Ok(payload.to_vec());
+            return Ok(None);
         };
 
         if payload.len() != compat_len {
@@ -338,18 +381,31 @@ impl FuseConn {
         }
         let mut normalized = vec![0u8; full_len];
         normalized[..compat_len].copy_from_slice(payload);
-        Ok(normalized)
+        Ok(Some(normalized))
     }
 
     pub fn write_reply(&self, data: &[u8]) -> Result<usize, SystemError> {
         if data.len() < core::mem::size_of::<FuseOutHeader>() {
             return Err(SystemError::EINVAL);
         }
-
         let out_hdr: FuseOutHeader = fuse_read_struct(data)?;
         if out_hdr.len as usize != data.len() {
             return Err(SystemError::EINVAL);
         }
+        stats::on_dev_fuse_input_copy(data.len() - core::mem::size_of::<FuseOutHeader>());
+        self.write_owned_reply(FuseReply::from_bytes(data.to_vec()))
+    }
+
+    pub(crate) fn write_owned_reply(&self, data: FuseReply) -> Result<usize, SystemError> {
+        if data.len() < core::mem::size_of::<FuseOutHeader>() {
+            return Err(SystemError::EINVAL);
+        }
+
+        let out_hdr: FuseOutHeader = fuse_read_struct(&data)?;
+        if out_hdr.len as usize != data.len() {
+            return Err(SystemError::EINVAL);
+        }
+        let from_virtiofs = data.is_virtiofs();
 
         if out_hdr.unique == 0 {
             let payload = &data[core::mem::size_of::<FuseOutHeader>()..];
@@ -369,18 +425,20 @@ impl FuseConn {
         }
 
         let (pending, negotiated_minor) = {
-            let mut g = self.inner.lock();
+            let g = self.inner.lock();
             if !g.connected {
                 return Err(SystemError::ENOENT);
             }
             let pending = g
                 .processing
-                .remove(&out_hdr.unique)
+                .get(&out_hdr.unique)
+                .cloned()
                 .ok_or(SystemError::ENOENT)?;
             (pending, g.init.minor)
         };
 
         let payload = &data[core::mem::size_of::<FuseOutHeader>()..];
+        let payload_len = payload.len();
         let error = out_hdr.error;
 
         if error != 0 {
@@ -402,13 +460,13 @@ impl FuseConn {
                     errno
                 );
             }
-            pending.complete(Err(e));
-            stats::on_fuse_reply_complete(pending.opcode, error, payload.len());
-            trace::trace_fuse_reply_complete(
+            self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;
+            Self::complete_claimed_reply_with_error(
+                &pending,
                 out_hdr.unique,
-                pending.opcode,
+                e,
                 error,
-                payload.len() as u64,
+                payload_len,
             );
             if matches!(pending.opcode, FUSE_INIT | FUSE_DESTROY) {
                 self.abort();
@@ -421,14 +479,14 @@ impl FuseConn {
                 Ok(v) => v,
                 Err(e) => {
                     let error = -e.to_posix_errno();
-                    stats::on_fuse_reply_complete(pending.opcode, error, payload.len());
-                    trace::trace_fuse_reply_complete(
+                    self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;
+                    Self::complete_claimed_reply_with_error(
+                        &pending,
                         out_hdr.unique,
-                        pending.opcode,
+                        e,
                         error,
-                        payload.len() as u64,
+                        payload_len,
                     );
-                    pending.complete(Err(e));
                     self.abort();
                     return Ok(data.len());
                 }
@@ -436,14 +494,14 @@ impl FuseConn {
 
             if init_out.major != FUSE_KERNEL_VERSION {
                 let error = -SystemError::EINVAL.to_posix_errno();
-                stats::on_fuse_reply_complete(pending.opcode, error, payload.len());
-                trace::trace_fuse_reply_complete(
+                self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;
+                Self::complete_claimed_reply_with_error(
+                    &pending,
                     out_hdr.unique,
-                    pending.opcode,
+                    SystemError::EINVAL,
                     error,
-                    payload.len() as u64,
+                    payload_len,
                 );
-                pending.complete(Err(SystemError::EINVAL));
                 self.abort();
                 return Ok(data.len());
             }
@@ -478,45 +536,43 @@ impl FuseConn {
             let negotiated_max_pages =
                 core::cmp::min(negotiated_max_pages_raw, max_pages_limit as u16);
 
-            {
-                let mut g = self.inner.lock();
-                if g.connected {
-                    // Align with Linux: only enable feature bits that are in the intersection of
-                    // daemon-supported and locally-requested flags. virtiofsd often sets
-                    // DO_READDIRPLUS etc. in the INIT reply; if adopted directly, it would
-                    // trigger READDIRPLUS + cache_child_from_entry, causing stale inode mappings.
-                    let enabled_flags = negotiated_flags & g.init_flags;
-                    g.initialized = true;
-                    g.init = FuseInitNegotiated {
-                        minor: negotiated_minor,
-                        max_readahead: init_out.max_readahead,
-                        max_write: capped_max_write as u32,
-                        time_gran: init_out.time_gran,
-                        max_pages: negotiated_max_pages,
-                        flags: enabled_flags,
-                    };
-                    self.reply_layout_minor
-                        .store(negotiated_minor, Ordering::Release);
-                }
-            }
+            self.claim_pending_reply(out_hdr.unique, &pending, |g| {
+                // Align with Linux: only enable feature bits that are in the intersection of
+                // daemon-supported and locally-requested flags. virtiofsd often sets
+                // DO_READDIRPLUS etc. in the INIT reply; if adopted directly, it would
+                // trigger READDIRPLUS + cache_child_from_entry, causing stale inode mappings.
+                let enabled_flags = negotiated_flags & g.init_flags;
+                g.initialized = true;
+                g.init = FuseInitNegotiated {
+                    minor: negotiated_minor,
+                    max_readahead: init_out.max_readahead,
+                    max_write: capped_max_write as u32,
+                    time_gran: init_out.time_gran,
+                    max_pages: negotiated_max_pages,
+                    flags: enabled_flags,
+                };
+                self.reply_layout_minor
+                    .store(negotiated_minor, Ordering::Release);
+            })?;
             self.init_wait.wakeup(None);
+        } else {
+            self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;
         }
 
         let normalized_payload = if pending.opcode == FUSE_INIT {
-            payload.to_vec()
+            None
         } else {
             match Self::normalize_compat_reply(negotiated_minor, pending.opcode, payload) {
                 Ok(payload) => payload,
                 Err(e) => {
                     let error = -e.to_posix_errno();
-                    stats::on_fuse_reply_complete(pending.opcode, error, payload.len());
-                    trace::trace_fuse_reply_complete(
+                    Self::complete_claimed_reply_with_error(
+                        &pending,
                         out_hdr.unique,
-                        pending.opcode,
+                        e,
                         error,
-                        payload.len() as u64,
+                        payload_len,
                     );
-                    pending.complete(Err(e));
                     if pending.opcode == FUSE_DESTROY {
                         self.abort();
                     }
@@ -524,14 +580,65 @@ impl FuseConn {
                 }
             }
         };
+        let normalized_payload_len = normalized_payload.as_ref().map(Vec::len);
 
-        stats::on_fuse_reply_complete(pending.opcode, 0, payload.len());
-        trace::trace_fuse_reply_complete(out_hdr.unique, pending.opcode, 0, payload.len() as u64);
-        pending.complete(Ok(normalized_payload));
+        let data_len = data.len();
+        let payload_reply = match data.narrow(core::mem::size_of::<FuseOutHeader>()..data_len) {
+            Ok(reply) => reply,
+            Err(e) => {
+                let error = -e.to_posix_errno();
+                Self::complete_claimed_reply_with_error(
+                    &pending,
+                    out_hdr.unique,
+                    e,
+                    error,
+                    payload_len,
+                );
+                if matches!(pending.opcode, FUSE_INIT | FUSE_DESTROY) {
+                    self.abort();
+                }
+                return Ok(data_len);
+            }
+        };
+        let payload_reply = if let Some(normalized) = normalized_payload {
+            match payload_reply.into_compat_bytes(normalized) {
+                Ok(reply) => reply,
+                Err(e) => {
+                    let error = -e.to_posix_errno();
+                    Self::complete_claimed_reply_with_error(
+                        &pending,
+                        out_hdr.unique,
+                        e,
+                        error,
+                        payload_len,
+                    );
+                    if pending.opcode == FUSE_DESTROY {
+                        self.abort();
+                    }
+                    return Ok(data_len);
+                }
+            }
+        } else {
+            payload_reply
+        };
+
+        let transferred = payload_reply.is_device_transfer();
+        if pending.complete(Ok(payload_reply)) {
+            stats::on_fuse_reply_complete(pending.opcode, 0, payload_len);
+            if transferred {
+                stats::on_fuse_reply_payload_transfer(pending.opcode, payload_len);
+            } else {
+                stats::on_fuse_reply_payload_copy(pending.opcode, payload_len);
+                if from_virtiofs {
+                    stats::on_virtiofs_compat_copy(normalized_payload_len.unwrap_or(payload_len));
+                }
+            }
+            trace::trace_fuse_reply_complete(out_hdr.unique, pending.opcode, 0, payload_len as u64);
+        }
         if pending.opcode == FUSE_DESTROY {
             self.abort();
         }
-        Ok(data.len())
+        Ok(data_len)
     }
 
     /// Linux supplies an output header buffer for DESTROY, while virtiofsd completes the
@@ -554,7 +661,7 @@ impl FuseConn {
 
         stats::on_fuse_reply_complete(FUSE_DESTROY, 0, 0);
         trace::trace_fuse_reply_complete(unique, FUSE_DESTROY, 0, 0);
-        pending.complete(Ok(Vec::new()));
+        pending.complete(Ok(FuseReply::from_bytes(Vec::new())));
         self.abort();
         Ok(())
     }
@@ -626,7 +733,7 @@ pub(super) fn normalize_compat_reply_for_test(
     opcode: u32,
     payload: &[u8],
 ) -> Result<Vec<u8>, SystemError> {
-    FuseConn::normalize_compat_reply(minor, opcode, payload)
+    FuseConn::normalize_compat_reply(minor, opcode, payload)?.ok_or(SystemError::EINVAL)
 }
 
 #[cfg(test)]
@@ -635,6 +742,8 @@ mod tests {
     use core::{mem::size_of, sync::atomic::Ordering};
 
     use system_error::SystemError;
+
+    use crate::filesystem::fuse::protocol::FUSE_FORGET;
 
     use super::super::request::queue_test_request;
     use super::*;

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -242,7 +242,9 @@ impl FuseConn {
     ) -> Result<Option<FuseReplyCapacity>, SystemError> {
         let minor = self.reply_layout_minor.load(Ordering::Acquire);
         let header = size_of::<FuseOutHeader>();
-        let exact = |payload_len: usize| -> Result<Option<FuseReplyCapacity>, SystemError> {
+        let exact = |payload_len: usize,
+                     normalized_payload_len: usize|
+         -> Result<Option<FuseReplyCapacity>, SystemError> {
             let bytes = header
                 .checked_add(payload_len)
                 .ok_or(SystemError::EOVERFLOW)?;
@@ -251,6 +253,7 @@ impl FuseConn {
             }
             Ok(Some(FuseReplyCapacity {
                 bytes,
+                retained_bytes: bytes.max(normalized_payload_len),
                 source: FuseReplyCapacitySource::Exact,
             }))
         };
@@ -288,7 +291,12 @@ impl FuseConn {
             _ => None,
         };
         if let Some(payload_len) = fixed_payload {
-            return exact(payload_len);
+            let normalized_payload_len = if minor < 4 && opcode == FUSE_STATFS {
+                size_of::<FuseStatfsOut>()
+            } else {
+                payload_len
+            };
+            return exact(payload_len, normalized_payload_len);
         }
 
         let requested = match opcode {
@@ -326,6 +334,7 @@ impl FuseConn {
                 return match self.backend_reply_limit {
                     Some(bytes) if bytes >= header => Ok(Some(FuseReplyCapacity {
                         bytes,
+                        retained_bytes: bytes,
                         source: FuseReplyCapacitySource::ExplicitFallback,
                     })),
                     Some(_) => Err(SystemError::EOVERFLOW),
@@ -342,6 +351,7 @@ impl FuseConn {
         }
         Ok(Some(FuseReplyCapacity {
             bytes,
+            retained_bytes: bytes,
             source: FuseReplyCapacitySource::RequestBounded,
         }))
     }

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -26,6 +26,7 @@ use super::{
     stats, trace, FuseConn, FusePendingState, FuseReplyCapacity, FuseReplyCapacitySource,
     FuseReplyContract, FuseRequest, FuseRequestCred,
 };
+use crate::filesystem::fuse::reply::FuseReply;
 
 impl FuseConn {
     fn is_high_priority_opcode(opcode: u32) -> bool {
@@ -96,7 +97,7 @@ impl FuseConn {
         opcode: u32,
         nodeid: u64,
         payload: &[u8],
-    ) -> Result<Vec<u8>, SystemError> {
+    ) -> Result<FuseReply, SystemError> {
         if opcode != FUSE_INIT {
             let cred = ProcessManager::current_pcb().cred();
             if !self.allow_current_process(&cred) {
@@ -113,7 +114,7 @@ impl FuseConn {
         opcode: u32,
         nodeid: u64,
         payload: &[u8],
-    ) -> Result<Vec<u8>, SystemError> {
+    ) -> Result<FuseReply, SystemError> {
         if opcode != FUSE_INIT {
             self.wait_initialized()?;
         }
@@ -128,7 +129,7 @@ impl FuseConn {
         nodeid: u64,
         payload: &[u8],
         req_cred: FuseRequestCred,
-    ) -> Result<Vec<u8>, SystemError> {
+    ) -> Result<FuseReply, SystemError> {
         if opcode != FUSE_INIT {
             self.wait_initialized()?;
         }
@@ -174,7 +175,7 @@ impl FuseConn {
         &self,
         opcode: u32,
         pending: Arc<FusePendingState>,
-    ) -> Result<Vec<u8>, SystemError> {
+    ) -> Result<FuseReply, SystemError> {
         match pending.wait_complete() {
             Err(SystemError::EINTR) | Err(SystemError::ERESTARTSYS) => {
                 if opcode != FUSE_INTERRUPT {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -24,6 +24,7 @@ use crate::{
     time::PosixTimeSpec,
 };
 
+use super::reply::FuseReply;
 use super::{
     conn::FuseConn,
     fs::FuseFS,
@@ -239,7 +240,7 @@ impl FuseNode {
         *self.parent_nodeid.lock()
     }
 
-    fn request_name(&self, opcode: u32, nodeid: u64, name: &str) -> Result<Vec<u8>, SystemError> {
+    fn request_name(&self, opcode: u32, nodeid: u64, name: &str) -> Result<FuseReply, SystemError> {
         self.check_not_stale()?;
         let payload = Self::pack_name_payload(name);
         self.conn().request(opcode, nodeid, &payload)

--- a/kernel/src/filesystem/fuse/mod.rs
+++ b/kernel/src/filesystem/fuse/mod.rs
@@ -4,6 +4,7 @@ pub mod fs;
 pub mod inode;
 pub mod private_data;
 pub mod protocol;
+pub(crate) mod reply;
 pub mod stats;
 pub mod trace;
 pub mod virtiofs;

--- a/kernel/src/filesystem/fuse/reply.rs
+++ b/kernel/src/filesystem/fuse/reply.rs
@@ -1,0 +1,117 @@
+use alloc::vec::Vec;
+use core::{
+    fmt,
+    ops::{Deref, Range},
+};
+
+use system_error::SystemError;
+
+use super::virtiofs::reply::VirtioFsReplyStorage;
+
+pub(crate) enum FuseReplyStorage {
+    Bytes(Vec<u8>),
+    VirtioFs(VirtioFsReplyStorage),
+}
+
+pub struct FuseReply {
+    storage: FuseReplyStorage,
+    range: Range<usize>,
+}
+
+impl fmt::Debug for FuseReply {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FuseReply")
+            .field("len", &self.len())
+            .field("virtiofs", &self.is_virtiofs())
+            .finish()
+    }
+}
+
+impl FuseReply {
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
+        let len = bytes.len();
+        Self {
+            storage: FuseReplyStorage::Bytes(bytes),
+            range: 0..len,
+        }
+    }
+
+    pub(crate) fn from_virtiofs(storage: VirtioFsReplyStorage) -> Self {
+        let len = storage.as_slice().len();
+        Self {
+            storage: FuseReplyStorage::VirtioFs(storage),
+            range: 0..len,
+        }
+    }
+
+    pub(crate) fn narrow(mut self, range: Range<usize>) -> Result<Self, SystemError> {
+        if range.start > range.end || range.end > self.range.len() {
+            return Err(SystemError::EINVAL);
+        }
+        let start = self
+            .range
+            .start
+            .checked_add(range.start)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let end = self
+            .range
+            .start
+            .checked_add(range.end)
+            .ok_or(SystemError::EOVERFLOW)?;
+        self.range = start..end;
+        Ok(self)
+    }
+
+    pub(crate) fn is_virtiofs(&self) -> bool {
+        matches!(self.storage, FuseReplyStorage::VirtioFs(_))
+    }
+
+    pub(crate) fn is_device_transfer(&self) -> bool {
+        matches!(&self.storage, FuseReplyStorage::VirtioFs(storage) if storage.is_device())
+    }
+
+    pub(crate) fn into_compat_bytes(self, bytes: Vec<u8>) -> Result<Self, SystemError> {
+        match self.storage {
+            FuseReplyStorage::VirtioFs(storage) => {
+                let storage = storage.into_compat_bytes(bytes)?;
+                Ok(Self::from_virtiofs(storage))
+            }
+            FuseReplyStorage::Bytes(_) => Ok(Self::from_bytes(bytes)),
+        }
+    }
+
+    fn storage_slice(&self) -> &[u8] {
+        match &self.storage {
+            FuseReplyStorage::Bytes(bytes) => bytes,
+            FuseReplyStorage::VirtioFs(storage) => storage.as_slice(),
+        }
+    }
+}
+
+impl Deref for FuseReply {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.storage_slice()[self.range.clone()]
+    }
+}
+
+impl AsRef<[u8]> for FuseReply {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+impl PartialEq for FuseReply {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl Eq for FuseReply {}
+
+impl PartialEq<Vec<u8>> for FuseReply {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        &**self == other.as_slice()
+    }
+}

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -424,6 +424,21 @@ pub fn on_virtiofs_reply_released(capacity: usize) {
 }
 
 #[inline]
+pub fn on_virtiofs_reply_capacity_reaccounted(old_capacity: usize, new_capacity: usize) {
+    if new_capacity > old_capacity {
+        let delta = (new_capacity - old_capacity) as u64;
+        let bytes =
+            REPLY_RETAINED_CAPACITY_BYTES_CURRENT.fetch_add(delta, Ordering::Relaxed) + delta;
+        update_peak(&REPLY_RETAINED_CAPACITY_BYTES_PEAK, bytes);
+    } else {
+        saturating_sub(
+            &REPLY_RETAINED_CAPACITY_BYTES_CURRENT,
+            (old_capacity - new_capacity) as u64,
+        );
+    }
+}
+
+#[inline]
 pub fn on_virtiofs_reply_credit_blocked() {
     inc(&REPLY_CREDIT_BLOCKED_TOTAL);
 }

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -25,6 +25,13 @@ pub struct FuseStatsSnapshot {
     pub read_buffer_too_small_total: u64,
     pub bytes_request_to_dev_total: u64,
     pub bytes_reply_payload_cloned_total: u64,
+    pub reply_payload_copy_count_total: u64,
+    pub reply_payload_transfer_count_total: u64,
+    pub reply_payload_transfer_bytes_total: u64,
+    pub dev_fuse_input_copy_count_total: u64,
+    pub dev_fuse_input_copy_bytes_total: u64,
+    pub virtiofs_compat_copy_count_total: u64,
+    pub virtiofs_compat_copy_bytes_total: u64,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -42,6 +49,12 @@ pub struct VirtioFsStatsSnapshot {
     pub request_inflight_current: u64,
     pub request_inflight_peak: u64,
     pub queue_full_blocked_current: u64,
+    pub reply_retained_current: u64,
+    pub reply_retained_peak: u64,
+    pub reply_retained_capacity_bytes_current: u64,
+    pub reply_retained_capacity_bytes_peak: u64,
+    pub reply_credit_blocked_total: u64,
+    pub reply_credit_blocked_wake_total: u64,
     pub bridge_loop_iterations_total: u64,
     pub bridge_progress_iterations_total: u64,
     pub bridge_idle_sleeps_total: u64,
@@ -75,6 +88,7 @@ pub struct VirtioFsStatsSnapshot {
     pub bridge_wait_exit_spurious_total: u64,
     pub bridge_wake_request_total: u64,
     pub bridge_wake_completion_total: u64,
+    pub bridge_wake_reply_released_total: u64,
     pub bridge_wake_teardown_total: u64,
     pub bridge_wake_disconnect_total: u64,
     pub bridge_irq_no_active_conn_total: u64,
@@ -94,6 +108,7 @@ pub enum VirtioFsBridgeWakeSource {
     Completion,
     Teardown,
     Disconnect,
+    ReplyReleased,
 }
 
 impl VirtioFsBridgeWakeSource {
@@ -103,6 +118,7 @@ impl VirtioFsBridgeWakeSource {
             Self::Completion => 1 << 1,
             Self::Teardown => 1 << 2,
             Self::Disconnect => 1 << 3,
+            Self::ReplyReleased => 1 << 4,
         }
     }
 
@@ -112,6 +128,7 @@ impl VirtioFsBridgeWakeSource {
             Self::Completion => 2,
             Self::Teardown => 3,
             Self::Disconnect => 4,
+            Self::ReplyReleased => 5,
         }
     }
 }
@@ -153,6 +170,13 @@ static NOREPLY_QUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_BUFFER_TOO_SMALL_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BYTES_REQUEST_TO_DEV_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BYTES_REPLY_PAYLOAD_CLONED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REPLY_PAYLOAD_COPY_COUNT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REPLY_PAYLOAD_TRANSFER_COUNT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REPLY_PAYLOAD_TRANSFER_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static DEV_FUSE_INPUT_COPY_COUNT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static DEV_FUSE_INPUT_COPY_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static VIRTIOFS_COMPAT_COPY_COUNT_TOTAL: AtomicU64 = AtomicU64::new(0);
+static VIRTIOFS_COMPAT_COPY_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 static DEVICE_QUEUE_DEPTH_MAX: AtomicU64 = AtomicU64::new(0);
 static HIPRIO_VRING_SIZE_CONFIGURED: AtomicU64 = AtomicU64::new(0);
@@ -167,6 +191,12 @@ static HIPRIO_INFLIGHT_PEAK: AtomicU64 = AtomicU64::new(0);
 static REQUEST_INFLIGHT_CURRENT: AtomicU64 = AtomicU64::new(0);
 static REQUEST_INFLIGHT_PEAK: AtomicU64 = AtomicU64::new(0);
 static QUEUE_FULL_BLOCKED_CURRENT: AtomicU64 = AtomicU64::new(0);
+static REPLY_RETAINED_CURRENT: AtomicU64 = AtomicU64::new(0);
+static REPLY_RETAINED_PEAK: AtomicU64 = AtomicU64::new(0);
+static REPLY_RETAINED_CAPACITY_BYTES_CURRENT: AtomicU64 = AtomicU64::new(0);
+static REPLY_RETAINED_CAPACITY_BYTES_PEAK: AtomicU64 = AtomicU64::new(0);
+static REPLY_CREDIT_BLOCKED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static REPLY_CREDIT_BLOCKED_WAKE_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 static BRIDGE_LOOP_ITERATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_PROGRESS_ITERATIONS_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -237,6 +267,10 @@ static OPCODE_REPLY_PAYLOAD_COPY_COUNT: [AtomicU64; OPCODE_BUCKETS] =
     [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
 static OPCODE_REPLY_PAYLOAD_COPY_BYTES: [AtomicU64; OPCODE_BUCKETS] =
     [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_REPLY_PAYLOAD_TRANSFER_COUNT: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
+static OPCODE_REPLY_PAYLOAD_TRANSFER_BYTES: [AtomicU64; OPCODE_BUCKETS] =
+    [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
 
 static PUMP_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
 static COMPLETE_BATCH: [AtomicU64; BATCH_BUCKETS] = [const { AtomicU64::new(0) }; BATCH_BUCKETS];
@@ -249,6 +283,7 @@ static BRIDGE_WAIT_EXIT_DISCONNECT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_WAIT_EXIT_SPURIOUS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_WAKE_REQUEST_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_WAKE_COMPLETION_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BRIDGE_WAKE_REPLY_RELEASED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_WAKE_TEARDOWN_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_WAKE_DISCONNECT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BRIDGE_IRQ_NO_ACTIVE_CONN_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -350,18 +385,81 @@ pub fn on_fuse_read_buffer_too_small() {
 }
 
 #[inline]
-pub fn on_fuse_reply_complete(opcode: u32, error: i32, payload_len: usize) {
+pub fn on_fuse_reply_complete(_opcode: u32, error: i32, _payload_len: usize) {
     if error == 0 {
         inc(&REQUESTS_REPLIED_OK_TOTAL);
-        add(&BYTES_REPLY_PAYLOAD_CLONED_TOTAL, payload_len as u64);
-        if detailed_stats_enabled() {
-            let bucket = opcode_bucket(opcode);
-            inc(&OPCODE_REPLY_PAYLOAD_COPY_COUNT[bucket]);
-            add(&OPCODE_REPLY_PAYLOAD_COPY_BYTES[bucket], payload_len as u64);
-        }
     } else {
         inc(&REQUESTS_REPLIED_ERR_TOTAL);
     }
+}
+
+#[inline]
+pub fn on_fuse_reply_payload_copy(opcode: u32, payload_len: usize) {
+    if payload_len == 0 {
+        return;
+    }
+    inc(&REPLY_PAYLOAD_COPY_COUNT_TOTAL);
+    add(&BYTES_REPLY_PAYLOAD_CLONED_TOTAL, payload_len as u64);
+    if detailed_stats_enabled() {
+        let bucket = opcode_bucket(opcode);
+        inc(&OPCODE_REPLY_PAYLOAD_COPY_COUNT[bucket]);
+        add(&OPCODE_REPLY_PAYLOAD_COPY_BYTES[bucket], payload_len as u64);
+    }
+}
+
+#[inline]
+pub fn on_virtiofs_reply_retained(capacity: usize) {
+    let count = REPLY_RETAINED_CURRENT.fetch_add(1, Ordering::Relaxed) + 1;
+    let capacity = capacity as u64;
+    let bytes =
+        REPLY_RETAINED_CAPACITY_BYTES_CURRENT.fetch_add(capacity, Ordering::Relaxed) + capacity;
+    update_peak(&REPLY_RETAINED_PEAK, count);
+    update_peak(&REPLY_RETAINED_CAPACITY_BYTES_PEAK, bytes);
+}
+
+#[inline]
+pub fn on_virtiofs_reply_released(capacity: usize) {
+    saturating_sub(&REPLY_RETAINED_CURRENT, 1);
+    saturating_sub(&REPLY_RETAINED_CAPACITY_BYTES_CURRENT, capacity as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_reply_credit_blocked() {
+    inc(&REPLY_CREDIT_BLOCKED_TOTAL);
+}
+
+#[inline]
+pub fn on_virtiofs_reply_credit_blocked_wake() {
+    inc(&REPLY_CREDIT_BLOCKED_WAKE_TOTAL);
+}
+
+#[inline]
+pub fn on_fuse_reply_payload_transfer(opcode: u32, payload_len: usize) {
+    if payload_len == 0 {
+        return;
+    }
+    inc(&REPLY_PAYLOAD_TRANSFER_COUNT_TOTAL);
+    add(&REPLY_PAYLOAD_TRANSFER_BYTES_TOTAL, payload_len as u64);
+    if detailed_stats_enabled() {
+        let bucket = opcode_bucket(opcode);
+        inc(&OPCODE_REPLY_PAYLOAD_TRANSFER_COUNT[bucket]);
+        add(
+            &OPCODE_REPLY_PAYLOAD_TRANSFER_BYTES[bucket],
+            payload_len as u64,
+        );
+    }
+}
+
+#[inline]
+pub fn on_dev_fuse_input_copy(payload_len: usize) {
+    inc(&DEV_FUSE_INPUT_COPY_COUNT_TOTAL);
+    add(&DEV_FUSE_INPUT_COPY_BYTES_TOTAL, payload_len as u64);
+}
+
+#[inline]
+pub fn on_virtiofs_compat_copy(payload_len: usize) {
+    inc(&VIRTIOFS_COMPAT_COPY_COUNT_TOTAL);
+    add(&VIRTIOFS_COMPAT_COPY_BYTES_TOTAL, payload_len as u64);
 }
 
 #[inline]
@@ -460,6 +558,7 @@ pub fn on_virtiofs_bridge_wake(source: VirtioFsBridgeWakeSource) {
         VirtioFsBridgeWakeSource::Completion => inc(&BRIDGE_WAKE_COMPLETION_TOTAL),
         VirtioFsBridgeWakeSource::Teardown => inc(&BRIDGE_WAKE_TEARDOWN_TOTAL),
         VirtioFsBridgeWakeSource::Disconnect => inc(&BRIDGE_WAKE_DISCONNECT_TOTAL),
+        VirtioFsBridgeWakeSource::ReplyReleased => inc(&BRIDGE_WAKE_REPLY_RELEASED_TOTAL),
     }
 }
 
@@ -690,6 +789,15 @@ pub fn fuse_snapshot() -> FuseStatsSnapshot {
         read_buffer_too_small_total: READ_BUFFER_TOO_SMALL_TOTAL.load(Ordering::Relaxed),
         bytes_request_to_dev_total: BYTES_REQUEST_TO_DEV_TOTAL.load(Ordering::Relaxed),
         bytes_reply_payload_cloned_total: BYTES_REPLY_PAYLOAD_CLONED_TOTAL.load(Ordering::Relaxed),
+        reply_payload_copy_count_total: REPLY_PAYLOAD_COPY_COUNT_TOTAL.load(Ordering::Relaxed),
+        reply_payload_transfer_count_total: REPLY_PAYLOAD_TRANSFER_COUNT_TOTAL
+            .load(Ordering::Relaxed),
+        reply_payload_transfer_bytes_total: REPLY_PAYLOAD_TRANSFER_BYTES_TOTAL
+            .load(Ordering::Relaxed),
+        dev_fuse_input_copy_count_total: DEV_FUSE_INPUT_COPY_COUNT_TOTAL.load(Ordering::Relaxed),
+        dev_fuse_input_copy_bytes_total: DEV_FUSE_INPUT_COPY_BYTES_TOTAL.load(Ordering::Relaxed),
+        virtiofs_compat_copy_count_total: VIRTIOFS_COMPAT_COPY_COUNT_TOTAL.load(Ordering::Relaxed),
+        virtiofs_compat_copy_bytes_total: VIRTIOFS_COMPAT_COPY_BYTES_TOTAL.load(Ordering::Relaxed),
     }
 }
 
@@ -710,6 +818,14 @@ pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
         request_inflight_current: REQUEST_INFLIGHT_CURRENT.load(Ordering::Relaxed),
         request_inflight_peak: REQUEST_INFLIGHT_PEAK.load(Ordering::Relaxed),
         queue_full_blocked_current: QUEUE_FULL_BLOCKED_CURRENT.load(Ordering::Relaxed),
+        reply_retained_current: REPLY_RETAINED_CURRENT.load(Ordering::Relaxed),
+        reply_retained_peak: REPLY_RETAINED_PEAK.load(Ordering::Relaxed),
+        reply_retained_capacity_bytes_current: REPLY_RETAINED_CAPACITY_BYTES_CURRENT
+            .load(Ordering::Relaxed),
+        reply_retained_capacity_bytes_peak: REPLY_RETAINED_CAPACITY_BYTES_PEAK
+            .load(Ordering::Relaxed),
+        reply_credit_blocked_total: REPLY_CREDIT_BLOCKED_TOTAL.load(Ordering::Relaxed),
+        reply_credit_blocked_wake_total: REPLY_CREDIT_BLOCKED_WAKE_TOTAL.load(Ordering::Relaxed),
         bridge_loop_iterations_total: BRIDGE_LOOP_ITERATIONS_TOTAL.load(Ordering::Relaxed),
         bridge_progress_iterations_total: BRIDGE_PROGRESS_ITERATIONS_TOTAL.load(Ordering::Relaxed),
         bridge_idle_sleeps_total: BRIDGE_IDLE_SLEEPS_TOTAL.load(Ordering::Relaxed),
@@ -746,6 +862,7 @@ pub fn virtiofs_snapshot() -> VirtioFsStatsSnapshot {
         bridge_wait_exit_spurious_total: BRIDGE_WAIT_EXIT_SPURIOUS_TOTAL.load(Ordering::Relaxed),
         bridge_wake_request_total: BRIDGE_WAKE_REQUEST_TOTAL.load(Ordering::Relaxed),
         bridge_wake_completion_total: BRIDGE_WAKE_COMPLETION_TOTAL.load(Ordering::Relaxed),
+        bridge_wake_reply_released_total: BRIDGE_WAKE_REPLY_RELEASED_TOTAL.load(Ordering::Relaxed),
         bridge_wake_teardown_total: BRIDGE_WAKE_TEARDOWN_TOTAL.load(Ordering::Relaxed),
         bridge_wake_disconnect_total: BRIDGE_WAKE_DISCONNECT_TOTAL.load(Ordering::Relaxed),
         bridge_irq_no_active_conn_total: BRIDGE_IRQ_NO_ACTIVE_CONN_TOTAL.load(Ordering::Relaxed),
@@ -781,6 +898,13 @@ noreply_queued_total {}\n\
 read_buffer_too_small_total {}\n\
 bytes_request_to_dev_total {}\n\
 bytes_reply_payload_cloned_total {}\n\
+reply_payload_copy_count_total {}\n\
+reply_payload_transfer_count_total {}\n\
+reply_payload_transfer_bytes_total {}\n\
+dev_fuse_input_copy_count_total {}\n\
+dev_fuse_input_copy_bytes_total {}\n\
+virtiofs_compat_copy_count_total {}\n\
+virtiofs_compat_copy_bytes_total {}\n\
 \n\
 [virtiofs]\n\
 device_queue_depth_max {}\n\
@@ -796,6 +920,12 @@ hiprio_inflight_peak {}\n\
 request_inflight_current {}\n\
 request_inflight_peak {}\n\
 queue_full_blocked_current {}\n\
+reply_retained_current {}\n\
+reply_retained_peak {}\n\
+reply_retained_capacity_bytes_current {}\n\
+reply_retained_capacity_bytes_peak {}\n\
+reply_credit_blocked_total {}\n\
+reply_credit_blocked_wake_total {}\n\
 bridge_loop_iterations_total {}\n\
 bridge_progress_iterations_total {}\n\
 bridge_idle_sleeps_total {}\n\
@@ -837,6 +967,7 @@ bridge_wait_exit_disconnect_total {}\n\
 bridge_wait_exit_spurious_total {}\n\
 bridge_wake_request_total {}\n\
 bridge_wake_completion_total {}\n\
+bridge_wake_reply_released_total {}\n\
 bridge_wake_teardown_total {}\n\
 bridge_wake_disconnect_total {}\n\
 bridge_irq_no_active_conn_total {}\n\
@@ -858,6 +989,13 @@ request_queue_full_total {}\n",
         fuse.read_buffer_too_small_total,
         fuse.bytes_request_to_dev_total,
         fuse.bytes_reply_payload_cloned_total,
+        fuse.reply_payload_copy_count_total,
+        fuse.reply_payload_transfer_count_total,
+        fuse.reply_payload_transfer_bytes_total,
+        fuse.dev_fuse_input_copy_count_total,
+        fuse.dev_fuse_input_copy_bytes_total,
+        fuse.virtiofs_compat_copy_count_total,
+        fuse.virtiofs_compat_copy_bytes_total,
         virtiofs.device_queue_depth_max,
         virtiofs.hiprio_vring_size_configured,
         virtiofs.request_queue_count_configured,
@@ -871,6 +1009,12 @@ request_queue_full_total {}\n",
         virtiofs.request_inflight_current,
         virtiofs.request_inflight_peak,
         virtiofs.queue_full_blocked_current,
+        virtiofs.reply_retained_current,
+        virtiofs.reply_retained_peak,
+        virtiofs.reply_retained_capacity_bytes_current,
+        virtiofs.reply_retained_capacity_bytes_peak,
+        virtiofs.reply_credit_blocked_total,
+        virtiofs.reply_credit_blocked_wake_total,
         virtiofs.bridge_loop_iterations_total,
         virtiofs.bridge_progress_iterations_total,
         virtiofs.bridge_idle_sleeps_total,
@@ -912,6 +1056,7 @@ request_queue_full_total {}\n",
         virtiofs.bridge_wait_exit_spurious_total,
         virtiofs.bridge_wake_request_total,
         virtiofs.bridge_wake_completion_total,
+        virtiofs.bridge_wake_reply_released_total,
         virtiofs.bridge_wake_teardown_total,
         virtiofs.bridge_wake_disconnect_total,
         virtiofs.bridge_irq_no_active_conn_total,
@@ -960,7 +1105,9 @@ opcode_{opcode}_response_unused_tail_bytes {}\n\
 opcode_{opcode}_response_overrun_count {}\n\
 opcode_{opcode}_response_overrun_bytes {}\n\
 opcode_{opcode}_reply_payload_copy_count {}\n\
-opcode_{opcode}_reply_payload_copy_bytes {}",
+opcode_{opcode}_reply_payload_copy_bytes {}\n\
+opcode_{opcode}_reply_payload_transfer_count {}\n\
+opcode_{opcode}_reply_payload_transfer_bytes {}",
             OPCODE_REQUESTS_TOTAL[opcode].load(Ordering::Relaxed),
             OPCODE_REQUEST_BYTES_TOTAL[opcode].load(Ordering::Relaxed),
             OPCODE_REQUEST_BRIDGE_COPY_COUNT[opcode].load(Ordering::Relaxed),
@@ -981,6 +1128,8 @@ opcode_{opcode}_reply_payload_copy_bytes {}",
             OPCODE_RESPONSE_OVERRUN_BYTES[opcode].load(Ordering::Relaxed),
             OPCODE_REPLY_PAYLOAD_COPY_COUNT[opcode].load(Ordering::Relaxed),
             OPCODE_REPLY_PAYLOAD_COPY_BYTES[opcode].load(Ordering::Relaxed),
+            OPCODE_REPLY_PAYLOAD_TRANSFER_COUNT[opcode].load(Ordering::Relaxed),
+            OPCODE_REPLY_PAYLOAD_TRANSFER_BYTES[opcode].load(Ordering::Relaxed),
         )
         .expect("formatting fuse opcode stats into String cannot fail");
     }

--- a/kernel/src/filesystem/fuse/virtiofs.rs
+++ b/kernel/src/filesystem/fuse/virtiofs.rs
@@ -1,6 +1,7 @@
 mod bridge;
 mod mount;
 mod queue;
+pub(crate) mod reply;
 
 const VIRTIOFS_MAX_REQUEST_SIZE: usize = 256 * 1024;
 const VIRTIOFS_RSP_BUF_SIZE: usize = 256 * 1024;

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -35,16 +35,17 @@ use super::super::{
 };
 use super::{
     queue::{create_queue, wait_transport_reset_complete, VirtioFsQueue},
-    VIRTIOFS_MAX_REQUEST_SIZE, VIRTIOFS_RSP_BUF_SIZE,
+    reply::{ResponseBufferPool, VirtioFsReplyStorage},
+    VIRTIOFS_MAX_REQUEST_SIZE,
 };
+use crate::filesystem::fuse::reply::FuseReply;
 
 const FUSE_HEADER_OVERHEAD: usize = 4;
 const FUSE_MAX_MAX_PAGES: usize = 256;
-const VIRTIOFS_RSP_POOL_MAX_BUFFERS: usize = 16;
-const VIRTIOFS_RSP_POOL_MAX_CAPACITY_BYTES: usize =
-    VIRTIOFS_RSP_BUF_SIZE * VIRTIOFS_RSP_POOL_MAX_BUFFERS;
 const VIRTIOFS_POLL_NS: i64 = 1_000_000;
 const VIRTIOFS_PUMP_BUDGET: usize = 64;
+const VIRTIOFS_COMPLETE_BUDGET: usize = 64;
+const VIRTIOFS_HIPRIO_COMPLETE_BUDGET: usize = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum QueueKind {
@@ -129,82 +130,16 @@ struct QueueBlockState {
     completion_seen: bool,
 }
 
-#[derive(Debug)]
-struct ResponseBufferPool {
-    buffers: Vec<DeviceOutputBuffer>,
-    retained_capacity_bytes: usize,
-}
-
-impl ResponseBufferPool {
-    fn new() -> Self {
-        Self {
-            buffers: Vec::with_capacity(VIRTIOFS_RSP_POOL_MAX_BUFFERS),
-            retained_capacity_bytes: 0,
-        }
-    }
-
-    fn acquire(&mut self, opcode: u32, len: usize) -> Result<DeviceOutputBuffer, SystemError> {
-        let best_fit = self
-            .buffers
-            .iter()
-            .enumerate()
-            .filter(|(_, buf)| buf.allocation_len() >= len)
-            .min_by_key(|(_, buf)| buf.allocation_len())
-            .map(|(index, _)| index);
-        if let Some(index) = best_fit {
-            let mut buf = self.buffers.swap_remove(index);
-            self.retained_capacity_bytes = self
-                .retained_capacity_bytes
-                .checked_sub(buf.allocation_len())
-                .expect("response pool capacity accounting underflow");
-            buf.prepare(len, response_buffer_virt_to_phys)
-                .map_err(|_| SystemError::EIO)?;
-            stats::on_virtiofs_response_buffer_reuse(opcode, len);
-            return Ok(buf);
-        }
-
-        let buf = DeviceOutputBuffer::new(len, response_buffer_virt_to_phys)
-            .map_err(|_| SystemError::EIO)?;
-        stats::on_virtiofs_response_buffer_alloc(opcode, len);
-        stats::on_virtiofs_response_buffer_zero(opcode, len);
-        Ok(buf)
-    }
-
-    fn release(&mut self, mut buf: DeviceOutputBuffer, reusable: bool) {
-        let capacity = buf.allocation_len();
-        let next_capacity = self.retained_capacity_bytes.checked_add(capacity);
-        let within_limits = reusable
-            && buf.recycle().is_ok()
-            && buf.allocation_len() <= VIRTIOFS_RSP_BUF_SIZE
-            && capacity <= VIRTIOFS_RSP_BUF_SIZE
-            && self.buffers.len() < VIRTIOFS_RSP_POOL_MAX_BUFFERS
-            && next_capacity.is_some_and(|total| total <= VIRTIOFS_RSP_POOL_MAX_CAPACITY_BYTES);
-
-        if !within_limits {
-            stats::on_virtiofs_response_pool_drop();
-            return;
-        }
-
-        self.retained_capacity_bytes = next_capacity.expect("checked above");
-        self.buffers.push(buf);
-    }
-
-    fn clear(&mut self) {
-        self.buffers.clear();
-        self.retained_capacity_bytes = 0;
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReplyCreditBlockedHead {
+    token: u16,
+    required_capacity: usize,
 }
 
 fn response_buffer_virt_to_phys(vaddr: usize) -> Option<usize> {
     // SAFETY: DeviceOutputBuffer supplies the address of its live Box allocation. The kernel
     // allocator obtains slab and buddy memory from the architecture direct map.
     unsafe { MMArch::virt_2_phys(VirtAddr::new(vaddr)) }.map(|paddr| paddr.data())
-}
-
-impl Drop for ResponseBufferPool {
-    fn drop(&mut self) {
-        self.clear();
-    }
 }
 
 fn cleanup_created_queues(
@@ -299,8 +234,11 @@ struct VirtioFsBridgeContext {
     request_inflight: Vec<BTreeMap<u16, InflightReq>>,
     response_pool: ResponseBufferPool,
     next_request_slot: usize,
+    next_completion_slot: usize,
     hiprio_blocked: QueueBlockState,
     request_blocked: Vec<QueueBlockState>,
+    hiprio_reply_blocked: Option<ReplyCreditBlockedHead>,
+    request_reply_blocked: Vec<Option<ReplyCreditBlockedHead>>,
 }
 
 impl VirtioFsBridgeContext {
@@ -317,8 +255,50 @@ impl VirtioFsBridgeContext {
     }
 
     fn has_completion_available(&self) -> bool {
-        self.hiprio_vq.as_ref().is_some_and(|queue| queue.can_pop())
-            || self.request_vqs.iter().any(|queue| queue.can_pop())
+        let hiprio = self.hiprio_vq.as_ref().is_some_and(|queue| {
+            queue.can_pop()
+                && !self.hiprio_reply_blocked.is_some_and(|blocked| {
+                    queue
+                        .peek_used()
+                        .is_some_and(|token| token == blocked.token)
+                })
+        });
+        hiprio
+            || self.request_vqs.iter().enumerate().any(|(slot, queue)| {
+                queue.can_pop()
+                    && !self.request_reply_blocked.get(slot).is_some_and(|blocked| {
+                        blocked.is_some_and(|blocked| {
+                            queue
+                                .peek_used()
+                                .is_some_and(|token| token == blocked.token)
+                        })
+                    })
+            })
+    }
+
+    fn reply_blocked_mut(
+        &mut self,
+        kind: QueueKind,
+    ) -> Result<&mut Option<ReplyCreditBlockedHead>, SystemError> {
+        match kind {
+            QueueKind::Hiprio => Ok(&mut self.hiprio_reply_blocked),
+            QueueKind::Request(slot) => self
+                .request_reply_blocked
+                .get_mut(slot)
+                .ok_or(SystemError::EINVAL),
+        }
+    }
+
+    fn clear_reply_credit_blocked(&mut self) {
+        self.hiprio_reply_blocked = None;
+        for blocked in &mut self.request_reply_blocked {
+            *blocked = None;
+        }
+    }
+
+    fn has_reply_credit_blocked(&self) -> bool {
+        self.hiprio_reply_blocked.is_some()
+            || self.request_reply_blocked.iter().any(Option::is_some)
     }
 
     fn has_queue_full_blocked(&self) -> bool {
@@ -782,7 +762,11 @@ impl VirtioFsBridgeContext {
                         return Ok(true);
                     }
                 };
-                let rsp = match self.response_pool.acquire(pending.opcode, capacity.bytes) {
+                let rsp = match self.response_pool.acquire(
+                    pending.opcode,
+                    capacity.bytes,
+                    response_buffer_virt_to_phys,
+                ) {
                     Ok(rsp) => rsp,
                     Err(e) => {
                         self.terminate_pending_with_error(&pending, e);
@@ -989,6 +973,42 @@ impl VirtioFsBridgeContext {
             }
         };
 
+        let response_capacity = match kind {
+            QueueKind::Hiprio => self
+                .hiprio_inflight
+                .get(&token)
+                .and_then(|req| req.rsp.as_ref())
+                .map(DeviceOutputBuffer::allocation_len),
+            QueueKind::Request(slot) => self
+                .request_inflight
+                .get(slot)
+                .and_then(|map| map.get(&token))
+                .and_then(|req| req.rsp.as_ref())
+                .map(DeviceOutputBuffer::allocation_len),
+        };
+        let reservation = if let Some(required_capacity) = response_capacity {
+            match self.response_pool.reserve(required_capacity) {
+                Some(reservation) => {
+                    *self.reply_blocked_mut(kind)? = None;
+                    Some(reservation)
+                }
+                None => {
+                    let blocked = ReplyCreditBlockedHead {
+                        token,
+                        required_capacity,
+                    };
+                    let state = self.reply_blocked_mut(kind)?;
+                    if *state != Some(blocked) {
+                        stats::on_virtiofs_reply_credit_blocked();
+                        *state = Some(blocked);
+                    }
+                    return Ok(false);
+                }
+            }
+        } else {
+            None
+        };
+
         let mut inflight = self.take_inflight(kind, token)?;
         let pending = inflight
             .pending
@@ -1090,6 +1110,8 @@ impl VirtioFsBridgeContext {
             .rsp
             .take()
             .expect("reply-bearing inflight request must own a response buffer");
+        let reservation = reservation
+            .expect("reply-bearing completion reserved retention capacity before pop_used");
         let capacity = rsp_buf.writable_len();
         stats::on_virtiofs_response_completed(opcode, capacity, used_len);
         // SAFETY: pop_used succeeded for this exact token and DMA identity, so the descriptor is
@@ -1130,13 +1152,22 @@ impl VirtioFsBridgeContext {
                 unique, opcode, used_len
             );
             self.terminate_pending_with_error(&pending, SystemError::EIO);
-            self.response_pool.release(rsp_buf, false);
+            self.response_pool.release(rsp_buf, true);
             return Ok(true);
         }
 
-        let reusable = match self.conn.write_reply(reply) {
-            Ok(_) => true,
-            Err(SystemError::ENOENT) if opcode != FUSE_DESTROY => true,
+        let storage = match VirtioFsReplyStorage::from_completed(rsp_buf, reservation, 0..used_len)
+        {
+            Ok(storage) => storage,
+            Err(_) => {
+                self.terminate_pending_with_error(&pending, SystemError::EIO);
+                return Ok(true);
+            }
+        };
+        let owned_reply = FuseReply::from_virtiofs(storage);
+        match self.conn.write_owned_reply(owned_reply) {
+            Ok(_) => {}
+            Err(SystemError::ENOENT) if opcode != FUSE_DESTROY => {}
             Err(e) => {
                 // Linux virtio-fs always ends a completed request from the used ring.
                 // Keep that behavior here: fail this unique instead of exiting bridge loop.
@@ -1150,17 +1181,18 @@ impl VirtioFsBridgeContext {
                     unique, opcode, e, completion_err
                 );
                 self.terminate_pending_with_error(&pending, completion_err);
-                false
             }
-        };
-        self.response_pool.release(rsp_buf, reusable);
+        }
         Ok(true)
     }
 
     fn drain_completions(&mut self) -> Result<usize, SystemError> {
         let mut completed = 0usize;
         let mut hiprio_completed = 0usize;
-        while self.pop_one_used(QueueKind::Hiprio)? {
+        while hiprio_completed < VIRTIOFS_HIPRIO_COMPLETE_BUDGET
+            && completed < VIRTIOFS_COMPLETE_BUDGET
+            && self.pop_one_used(QueueKind::Hiprio)?
+        {
             hiprio_completed += 1;
             completed += 1;
         }
@@ -1168,14 +1200,24 @@ impl VirtioFsBridgeContext {
             self.mark_queue_completion_seen(QueueKind::Hiprio);
         }
 
-        for slot in 0..self.request_vqs.len() {
-            let mut queue_completed = 0usize;
-            while self.pop_one_used(QueueKind::Request(slot))? {
-                queue_completed += 1;
-                completed += 1;
+        let queue_count = self.request_vqs.len();
+        while queue_count != 0 && completed < VIRTIOFS_COMPLETE_BUDGET {
+            let start = self.next_completion_slot % queue_count;
+            self.next_completion_slot = (start + 1) % queue_count;
+            let mut round_progress = false;
+            for offset in 0..queue_count {
+                if completed == VIRTIOFS_COMPLETE_BUDGET {
+                    break;
+                }
+                let slot = (start + offset) % queue_count;
+                if self.pop_one_used(QueueKind::Request(slot))? {
+                    self.mark_queue_completion_seen(QueueKind::Request(slot));
+                    completed += 1;
+                    round_progress = true;
+                }
             }
-            if queue_completed != 0 {
-                self.mark_queue_completion_seen(QueueKind::Request(slot));
+            if !round_progress {
+                break;
             }
         }
 
@@ -1197,8 +1239,12 @@ impl VirtioFsBridgeContext {
             return Some(stats::VirtioFsBridgeWaitExit::Teardown);
         }
 
-        let completion_event = events & stats::VirtioFsBridgeWakeSource::Completion.bit() != 0;
-        if completion_event || self.has_completion_available() {
+        let reply_released = events & stats::VirtioFsBridgeWakeSource::ReplyReleased.bit() != 0;
+        if reply_released {
+            return Some(stats::VirtioFsBridgeWaitExit::Completion);
+        }
+
+        if self.has_completion_available() {
             return Some(stats::VirtioFsBridgeWaitExit::Completion);
         }
 
@@ -1217,7 +1263,8 @@ impl VirtioFsBridgeContext {
         let known_events = stats::VirtioFsBridgeWakeSource::Request.bit()
             | stats::VirtioFsBridgeWakeSource::Completion.bit()
             | stats::VirtioFsBridgeWakeSource::Teardown.bit()
-            | stats::VirtioFsBridgeWakeSource::Disconnect.bit();
+            | stats::VirtioFsBridgeWakeSource::Disconnect.bit()
+            | stats::VirtioFsBridgeWakeSource::ReplyReleased.bit();
         if events & !known_events != 0 {
             return Some(stats::VirtioFsBridgeWaitExit::Spurious);
         }
@@ -1227,6 +1274,12 @@ impl VirtioFsBridgeContext {
 
     fn wait_for_event(&mut self) {
         if !self.irq_wake_enabled {
+            if self.has_reply_credit_blocked() {
+                // Polling itself guarantees the retry. Do not leave the release gate armed or
+                // every later consumer Drop would signal a WaitQueue nobody is sleeping on.
+                self.response_pool.clear_credit_waiting();
+                self.clear_reply_credit_blocked();
+            }
             stats::on_virtiofs_idle_sleep(VIRTIOFS_POLL_NS);
             Self::poll_pause();
             return;
@@ -1242,6 +1295,13 @@ impl VirtioFsBridgeContext {
         stats::on_virtiofs_bridge_wait();
         let reason = conn.wait_bridge_until(|events| self.bridge_wait_exit_reason(&conn, events));
         let events = conn.take_bridge_wake_events();
+        if events & stats::VirtioFsBridgeWakeSource::ReplyReleased.bit() != 0 {
+            if self.has_reply_credit_blocked() {
+                stats::on_virtiofs_reply_credit_blocked_wake();
+            }
+            self.response_pool.clear_credit_waiting();
+            self.clear_reply_credit_blocked();
+        }
         stats::on_virtiofs_bridge_wait_exit(reason);
         trace::trace_virtiofs_bridge_wait_exit(reason.trace_id(), events);
     }
@@ -1518,10 +1578,10 @@ impl VirtioFsBridgeContext {
         }
         self.clear_queue_full_blocked_stats();
         self.instance.clear_bridge_wake(self.session_id);
+        self.response_pool.close();
         if !self.reset_device_and_unset_queues() {
             // Idle pooled buffers are not visible to the device. Release them before the
             // reset-timeout quarantine keeps the transport, queues and inflight DMA buffers alive.
-            self.response_pool.clear();
             self.fail_unfinished_preserving_inflight_dma(SystemError::ENOTCONN);
             if !self
                 .instance
@@ -1743,6 +1803,7 @@ pub(super) fn start_bridge(
     instance.install_bridge_wake(session_id, &conn);
     let irq_wake_enabled = instance.enable_irq_wake();
     let request_queue_count = request_vqs.len();
+    let response_pool = ResponseBufferPool::new(&conn);
     let ctx = Box::new(VirtioFsBridgeContext {
         instance,
         conn,
@@ -1759,10 +1820,15 @@ pub(super) fn start_bridge(
         request_vqs,
         hiprio_pending: VecDeque::new(),
         hiprio_inflight: BTreeMap::new(),
-        response_pool: ResponseBufferPool::new(),
+        response_pool,
         next_request_slot: 0,
+        next_completion_slot: 0,
         hiprio_blocked: QueueBlockState::default(),
         request_blocked: core::iter::repeat_with(QueueBlockState::default)
+            .take(request_queue_count)
+            .collect(),
+        hiprio_reply_blocked: None,
+        request_reply_blocked: core::iter::repeat_with(|| None)
             .take(request_queue_count)
             .collect(),
     });
@@ -1792,15 +1858,11 @@ pub(super) fn start_bridge(
 
 #[cfg(test)]
 mod tests {
-    use alloc::{vec, vec::Vec};
+    use alloc::vec;
 
     use system_error::SystemError;
 
-    use super::{
-        QueueBlockState, ResponseBufferPool, VirtioFsBridgeContext, VIRTIOFS_RSP_BUF_SIZE,
-        VIRTIOFS_RSP_POOL_MAX_BUFFERS,
-    };
-    use crate::filesystem::fuse::protocol::FUSE_LOOKUP;
+    use super::{QueueBlockState, VirtioFsBridgeContext};
 
     fn block_state(blocked: bool, completion_seen: bool) -> QueueBlockState {
         QueueBlockState {
@@ -1923,112 +1985,5 @@ mod tests {
             &[],
             42
         ));
-    }
-
-    #[test]
-    fn response_pool_reuses_exact_length_without_reinitializing() {
-        let mut pool = ResponseBufferPool::new();
-        let mut buf = pool.acquire(FUSE_LOOKUP, 128).unwrap();
-        let ptr = unsafe {
-            buf.submission_dma_slice(super::response_buffer_virt_to_phys)
-                .unwrap()
-                .as_ptr()
-        };
-        pool.release(buf, true);
-
-        assert_eq!(pool.buffers.len(), 1);
-        let mut reused = pool.acquire(FUSE_LOOKUP, 128).unwrap();
-        let reused_ptr = unsafe {
-            reused
-                .submission_dma_slice(super::response_buffer_virt_to_phys)
-                .unwrap()
-                .as_ptr()
-        };
-        assert_eq!(reused_ptr, ptr);
-        assert_eq!(reused.writable_len(), 128);
-        assert!(pool.buffers.is_empty());
-        assert_eq!(pool.retained_capacity_bytes, 0);
-    }
-
-    #[test]
-    fn response_pool_best_fit_reuses_larger_capacity_without_exposing_tail() {
-        let mut pool = ResponseBufferPool::new();
-        let mut large = pool.acquire(FUSE_LOOKUP, 192).unwrap();
-        let ptr = unsafe {
-            large
-                .submission_dma_slice(super::response_buffer_virt_to_phys)
-                .unwrap()
-                .as_ptr()
-        };
-        pool.release(large, true);
-
-        let mut reused = pool.acquire(FUSE_LOOKUP, 64).unwrap();
-        let reused_ptr = unsafe {
-            reused
-                .submission_dma_slice(super::response_buffer_virt_to_phys)
-                .unwrap()
-                .as_ptr()
-        };
-        assert_eq!(reused_ptr, ptr);
-        assert_eq!(reused.writable_len(), 64);
-        assert_eq!(reused.allocation_len(), 192);
-        assert_eq!(pool.retained_capacity_bytes, 0);
-    }
-
-    #[test]
-    fn response_pool_reuses_retained_allocation_when_writable_length_grows() {
-        let mut pool = ResponseBufferPool::new();
-        let mut buf = pool.acquire(FUSE_LOOKUP, 256).unwrap();
-        let ptr = unsafe {
-            buf.submission_dma_slice(super::response_buffer_virt_to_phys)
-                .unwrap()
-                .as_ptr()
-        };
-        pool.release(buf, true);
-
-        let mut reused = pool.acquire(FUSE_LOOKUP, 128).unwrap();
-        let reused_ptr = unsafe {
-            reused
-                .submission_dma_slice(super::response_buffer_virt_to_phys)
-                .unwrap()
-                .as_ptr()
-        };
-        assert_eq!(reused_ptr, ptr);
-        assert_eq!(reused.writable_len(), 128);
-    }
-
-    #[test]
-    fn response_pool_rejects_excess_capacity_and_nonreusable_buffers() {
-        let mut pool = ResponseBufferPool::new();
-        let oversized_capacity = pool
-            .acquire(FUSE_LOOKUP, VIRTIOFS_RSP_BUF_SIZE + 1)
-            .unwrap();
-        pool.release(oversized_capacity, true);
-        let nonreusable = pool.acquire(FUSE_LOOKUP, 16).unwrap();
-        pool.release(nonreusable, false);
-
-        assert!(pool.buffers.is_empty());
-        assert_eq!(pool.retained_capacity_bytes, 0);
-    }
-
-    #[test]
-    fn response_pool_enforces_buffer_count_and_checked_capacity() {
-        let mut pool = ResponseBufferPool::new();
-        let mut buffers = Vec::new();
-        for _ in 0..=VIRTIOFS_RSP_POOL_MAX_BUFFERS {
-            buffers.push(pool.acquire(FUSE_LOOKUP, 1).unwrap());
-        }
-        for buf in buffers {
-            pool.release(buf, true);
-        }
-        assert_eq!(pool.buffers.len(), VIRTIOFS_RSP_POOL_MAX_BUFFERS);
-
-        pool.clear();
-        pool.retained_capacity_bytes = usize::MAX;
-        let buf = pool.acquire(FUSE_LOOKUP, 1).unwrap();
-        pool.retained_capacity_bytes = usize::MAX;
-        pool.release(buf, true);
-        assert!(pool.buffers.is_empty());
-        pool.retained_capacity_bytes = 0;
     }
 }

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -66,14 +66,20 @@ struct PendingReq {
 struct InflightReq {
     pending: Option<PendingReq>,
     rsp: Option<DeviceOutputBuffer>,
+    retained_capacity: Option<usize>,
     descriptor_live: bool,
 }
 
 impl InflightReq {
-    fn new(pending: PendingReq, rsp: Option<DeviceOutputBuffer>) -> Self {
+    fn new(
+        pending: PendingReq,
+        rsp: Option<DeviceOutputBuffer>,
+        retained_capacity: Option<usize>,
+    ) -> Self {
         Self {
             pending: Some(pending),
             rsp,
+            retained_capacity,
             descriptor_live: false,
         }
     }
@@ -752,8 +758,8 @@ impl VirtioFsBridgeContext {
         let trace_unique = pending.unique;
         let trace_opcode = pending.opcode;
         let req_len = pending.req.bytes().len();
-        let (mut rsp, fallback) = match pending.req.reply_contract() {
-            FuseReplyContract::NoReply => (None, false),
+        let (mut rsp, retained_capacity, fallback) = match pending.req.reply_contract() {
+            FuseReplyContract::NoReply => (None, None, false),
             FuseReplyContract::Reply { capacity } => {
                 let capacity = match capacity {
                     Some(capacity) => capacity,
@@ -775,6 +781,7 @@ impl VirtioFsBridgeContext {
                 };
                 (
                     Some(rsp),
+                    Some(capacity.retained_bytes),
                     matches!(capacity.source, FuseReplyCapacitySource::ExplicitFallback),
                 )
             }
@@ -887,7 +894,7 @@ impl VirtioFsBridgeContext {
             }
         };
 
-        let mut inflight = InflightReq::new(pending, rsp);
+        let mut inflight = InflightReq::new(pending, rsp, retained_capacity);
         inflight.mark_submitted();
         if let Some(rsp_buf) = inflight.rsp.as_ref() {
             stats::on_virtiofs_response_submitted(trace_opcode, rsp_buf.writable_len(), fallback);
@@ -974,17 +981,22 @@ impl VirtioFsBridgeContext {
         };
 
         let response_capacity = match kind {
-            QueueKind::Hiprio => self
-                .hiprio_inflight
-                .get(&token)
-                .and_then(|req| req.rsp.as_ref())
-                .map(DeviceOutputBuffer::allocation_len),
+            QueueKind::Hiprio => self.hiprio_inflight.get(&token).and_then(|req| {
+                req.rsp.as_ref().map(|rsp| {
+                    rsp.allocation_len()
+                        .max(req.retained_capacity.unwrap_or_default())
+                })
+            }),
             QueueKind::Request(slot) => self
                 .request_inflight
                 .get(slot)
                 .and_then(|map| map.get(&token))
-                .and_then(|req| req.rsp.as_ref())
-                .map(DeviceOutputBuffer::allocation_len),
+                .and_then(|req| {
+                    req.rsp.as_ref().map(|rsp| {
+                        rsp.allocation_len()
+                            .max(req.retained_capacity.unwrap_or_default())
+                    })
+                }),
         };
         let reservation = if let Some(required_capacity) = response_capacity {
             match self.response_pool.reserve(required_capacity) {

--- a/kernel/src/filesystem/fuse/virtiofs/reply.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/reply.rs
@@ -1,0 +1,355 @@
+use alloc::{
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::{
+    ops::Range,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use device_output_buffer::{BufferError, DeviceOutputBuffer, RetentionCredits, RetentionLimits};
+use system_error::SystemError;
+
+use crate::libs::spinlock::SpinLock;
+
+use super::super::{conn::FuseConn, stats};
+use super::VIRTIOFS_RSP_BUF_SIZE;
+
+const FREE_MAX_BUFFERS: usize = 16;
+const FREE_MAX_CAPACITY_BYTES: usize = VIRTIOFS_RSP_BUF_SIZE * FREE_MAX_BUFFERS;
+const RETAINED_MAX_BUFFERS: usize = 16;
+const RETAINED_MAX_CAPACITY_BYTES: usize = VIRTIOFS_RSP_BUF_SIZE * RETAINED_MAX_BUFFERS;
+
+#[derive(Debug)]
+struct ReplyReleaseGate {
+    active: AtomicBool,
+    credit_waiting: AtomicBool,
+    conn: Weak<FuseConn>,
+}
+
+impl ReplyReleaseGate {
+    fn new(conn: &Arc<FuseConn>) -> Self {
+        Self {
+            active: AtomicBool::new(true),
+            credit_waiting: AtomicBool::new(false),
+            conn: Arc::downgrade(conn),
+        }
+    }
+
+    fn deactivate(&self) {
+        self.active.store(false, Ordering::Release);
+    }
+
+    fn mark_credit_waiting(&self) {
+        self.credit_waiting.store(true, Ordering::Release);
+    }
+
+    fn clear_credit_waiting(&self) {
+        self.credit_waiting.store(false, Ordering::Release);
+    }
+
+    fn signal(&self) {
+        if self.active.load(Ordering::Acquire) && self.credit_waiting.load(Ordering::Acquire) {
+            if let Some(conn) = self.conn.upgrade() {
+                conn.wake_bridge(stats::VirtioFsBridgeWakeSource::ReplyReleased);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PoolInner {
+    buffers: Vec<DeviceOutputBuffer>,
+    free_capacity_bytes: usize,
+    credits: RetentionCredits,
+    accepting_returns: bool,
+}
+
+impl PoolInner {
+    fn new() -> Self {
+        Self {
+            buffers: Vec::with_capacity(FREE_MAX_BUFFERS),
+            free_capacity_bytes: 0,
+            credits: RetentionCredits::new(RetentionLimits {
+                max_count: RETAINED_MAX_BUFFERS,
+                max_capacity_bytes: RETAINED_MAX_CAPACITY_BYTES,
+            }),
+            accepting_returns: true,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ResponseBufferPool {
+    inner: Arc<SpinLock<PoolInner>>,
+    gate: Arc<ReplyReleaseGate>,
+}
+
+impl ResponseBufferPool {
+    pub(crate) fn new(conn: &Arc<FuseConn>) -> Self {
+        Self {
+            inner: Arc::new(SpinLock::new(PoolInner::new())),
+            gate: Arc::new(ReplyReleaseGate::new(conn)),
+        }
+    }
+
+    pub(crate) fn acquire<F>(
+        &self,
+        opcode: u32,
+        len: usize,
+        virt_to_phys: F,
+    ) -> Result<DeviceOutputBuffer, SystemError>
+    where
+        F: FnMut(usize) -> Option<usize> + Copy,
+    {
+        let candidate = {
+            let mut inner = self.inner.lock();
+            let best = inner
+                .buffers
+                .iter()
+                .enumerate()
+                .filter(|(_, buf)| buf.allocation_len() >= len)
+                .min_by_key(|(_, buf)| buf.allocation_len())
+                .map(|(index, _)| index);
+            best.map(|index| {
+                let buf = inner.buffers.swap_remove(index);
+                inner.free_capacity_bytes -= buf.allocation_len();
+                buf
+            })
+        };
+
+        if let Some(mut buf) = candidate {
+            if buf.prepare(len, virt_to_phys).is_err() {
+                stats::on_virtiofs_response_pool_drop();
+                return Err(SystemError::EIO);
+            }
+            stats::on_virtiofs_response_buffer_reuse(opcode, len);
+            return Ok(buf);
+        }
+
+        let buf = DeviceOutputBuffer::new(len, virt_to_phys).map_err(|_| SystemError::EIO)?;
+        stats::on_virtiofs_response_buffer_alloc(opcode, len);
+        stats::on_virtiofs_response_buffer_zero(opcode, len);
+        Ok(buf)
+    }
+
+    pub(crate) fn release(&self, mut buf: DeviceOutputBuffer, reusable: bool) -> bool {
+        if !reusable || buf.recycle().is_err() {
+            stats::on_virtiofs_response_pool_drop();
+            return false;
+        }
+        let capacity = buf.allocation_len();
+        let mut owner = Some(buf);
+        let retained = {
+            let mut inner = self.inner.lock();
+            let next = inner.free_capacity_bytes.checked_add(capacity);
+            if inner.accepting_returns
+                && capacity <= VIRTIOFS_RSP_BUF_SIZE
+                && inner.buffers.len() < FREE_MAX_BUFFERS
+                && next.is_some_and(|v| v <= FREE_MAX_CAPACITY_BYTES)
+            {
+                inner.free_capacity_bytes = next.expect("checked above");
+                inner.buffers.push(owner.take().expect("owner is present"));
+                true
+            } else {
+                false
+            }
+        };
+        drop(owner);
+        if !retained {
+            stats::on_virtiofs_response_pool_drop();
+        }
+        retained
+    }
+
+    pub(crate) fn reserve(&self, capacity: usize) -> Option<RetentionReservation> {
+        let reserved = {
+            let mut inner = self.inner.lock();
+            let reserved = inner.credits.try_reserve(capacity);
+            if !reserved {
+                // Publish the waiter while holding the same lock used by release. A release is
+                // therefore either visible to this reservation attempt or observes the waiter;
+                // there is no mark-after-release lost-wakeup window.
+                self.gate.mark_credit_waiting();
+            }
+            reserved
+        };
+        reserved.then(|| {
+            stats::on_virtiofs_reply_retained(capacity);
+            RetentionReservation {
+                inner: self.inner.clone(),
+                gate: Arc::downgrade(&self.gate),
+                capacity,
+                active: true,
+            }
+        })
+    }
+
+    pub(crate) fn clear_credit_waiting(&self) {
+        self.gate.clear_credit_waiting();
+    }
+
+    pub(crate) fn close(&self) {
+        self.gate.deactivate();
+        let buffers = {
+            let mut inner = self.inner.lock();
+            inner.accepting_returns = false;
+            inner.free_capacity_bytes = 0;
+            core::mem::take(&mut inner.buffers)
+        };
+        drop(buffers);
+    }
+}
+
+impl Drop for ResponseBufferPool {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RetentionReservation {
+    inner: Arc<SpinLock<PoolInner>>,
+    gate: Weak<ReplyReleaseGate>,
+    capacity: usize,
+    active: bool,
+}
+
+impl RetentionReservation {
+    pub(crate) fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+impl Drop for RetentionReservation {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let released = self.inner.lock().credits.release(self.capacity);
+        debug_assert!(released, "retention credit accounting mismatch");
+        self.active = false;
+        if released {
+            stats::on_virtiofs_reply_released(self.capacity);
+        }
+        if let Some(gate) = self.gate.upgrade() {
+            gate.signal();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum VirtioFsReplyStorage {
+    Device(DeviceReplyLease),
+    CompatBytes {
+        bytes: Vec<u8>,
+        _reservation: RetentionReservation,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct DeviceReplyLease {
+    buffer: Option<DeviceOutputBuffer>,
+    reservation: Option<RetentionReservation>,
+    pool: Arc<SpinLock<PoolInner>>,
+    range: Range<usize>,
+}
+
+impl VirtioFsReplyStorage {
+    pub(crate) fn is_device(&self) -> bool {
+        matches!(self, Self::Device(_))
+    }
+
+    pub(crate) fn from_completed(
+        buffer: DeviceOutputBuffer,
+        reservation: RetentionReservation,
+        range: Range<usize>,
+    ) -> Result<Self, BufferError> {
+        let initialized_len = match buffer.initialized_prefix() {
+            Ok(bytes) => bytes.len(),
+            Err(err) => return Err(err),
+        };
+        if range.start > range.end || range.end > initialized_len {
+            return Err(BufferError::InvalidLength);
+        }
+        let pool = reservation.inner.clone();
+        Ok(Self::Device(DeviceReplyLease {
+            buffer: Some(buffer),
+            reservation: Some(reservation),
+            pool,
+            range,
+        }))
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Device(lease) => &lease
+                .buffer
+                .as_ref()
+                .expect("device reply owns its buffer")
+                .initialized_prefix()
+                .expect("device reply was created from Completed buffer")[lease.range.clone()],
+            Self::CompatBytes { bytes, .. } => bytes,
+        }
+    }
+
+    pub(crate) fn into_compat_bytes(self, bytes: Vec<u8>) -> Result<Self, SystemError> {
+        match self {
+            Self::Device(mut lease) => {
+                let reservation = lease
+                    .reservation
+                    .take()
+                    .expect("device reply owns its retention reservation");
+                if bytes.capacity() > reservation.capacity() {
+                    return Err(SystemError::EIO);
+                }
+                if let Some(mut buf) = lease.buffer.take() {
+                    if buf.recycle().is_ok() {
+                        return_buffer_to_pool(&lease.pool, buf);
+                    } else {
+                        stats::on_virtiofs_response_pool_drop();
+                    }
+                }
+                Ok(Self::CompatBytes {
+                    bytes,
+                    _reservation: reservation,
+                })
+            }
+            Self::CompatBytes { .. } => Err(SystemError::EINVAL),
+        }
+    }
+}
+
+fn return_buffer_to_pool(pool: &Arc<SpinLock<PoolInner>>, buf: DeviceOutputBuffer) {
+    let capacity = buf.allocation_len();
+    let mut owner = Some(buf);
+    {
+        let mut inner = pool.lock();
+        let next = inner.free_capacity_bytes.checked_add(capacity);
+        if inner.accepting_returns
+            && capacity <= VIRTIOFS_RSP_BUF_SIZE
+            && inner.buffers.len() < FREE_MAX_BUFFERS
+            && next.is_some_and(|v| v <= FREE_MAX_CAPACITY_BYTES)
+        {
+            inner.free_capacity_bytes = next.expect("checked above");
+            inner.buffers.push(owner.take().expect("owner present"));
+        }
+    }
+    let retained = owner.is_none();
+    drop(owner);
+    if !retained {
+        stats::on_virtiofs_response_pool_drop();
+    }
+}
+
+impl Drop for DeviceReplyLease {
+    fn drop(&mut self) {
+        if let Some(mut buf) = self.buffer.take() {
+            if buf.recycle().is_ok() {
+                return_buffer_to_pool(&self.pool, buf);
+            } else {
+                stats::on_virtiofs_response_pool_drop();
+            }
+        }
+    }
+}

--- a/kernel/src/filesystem/fuse/virtiofs/reply.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/reply.rs
@@ -216,8 +216,23 @@ pub(crate) struct RetentionReservation {
 }
 
 impl RetentionReservation {
-    pub(crate) fn capacity(&self) -> usize {
-        self.capacity
+    fn reaccount_capacity(&mut self, capacity: usize) -> bool {
+        let old_capacity = self.capacity;
+        if old_capacity == capacity {
+            return true;
+        }
+        let resized = self.inner.lock().credits.resize(old_capacity, capacity);
+        if !resized {
+            return false;
+        }
+        self.capacity = capacity;
+        stats::on_virtiofs_reply_capacity_reaccounted(old_capacity, capacity);
+        if capacity < old_capacity {
+            if let Some(gate) = self.gate.upgrade() {
+                gate.signal();
+            }
+        }
+        true
     }
 }
 
@@ -296,11 +311,11 @@ impl VirtioFsReplyStorage {
     pub(crate) fn into_compat_bytes(self, bytes: Vec<u8>) -> Result<Self, SystemError> {
         match self {
             Self::Device(mut lease) => {
-                let reservation = lease
+                let mut reservation = lease
                     .reservation
                     .take()
                     .expect("device reply owns its retention reservation");
-                if bytes.capacity() > reservation.capacity() {
+                if !reservation.reaccount_capacity(bytes.capacity()) {
                     return Err(SystemError::EIO);
                 }
                 if let Some(mut buf) = lease.buffer.take() {
@@ -351,5 +366,38 @@ impl Drop for DeviceReplyLease {
                 stats::on_virtiofs_response_pool_drop();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use device_output_buffer::DeviceOutputBuffer;
+
+    use super::{ResponseBufferPool, VirtioFsReplyStorage};
+    use crate::filesystem::fuse::conn::FuseConn;
+
+    fn direct(vaddr: usize) -> Option<usize> {
+        Some(vaddr)
+    }
+
+    #[test]
+    fn compat_expansion_uses_precharged_retention_capacity() {
+        let conn = FuseConn::new_for_virtiofs(256 * 1024, 256 * 1024);
+        let pool = ResponseBufferPool::new(&conn);
+        let reservation = pool.reserve(80).unwrap();
+        let mut buffer = DeviceOutputBuffer::new(64, direct).unwrap();
+        unsafe {
+            buffer.submission_dma_slice(direct).unwrap();
+        }
+        buffer.mark_submitted();
+        unsafe {
+            buffer.complete_after_pop(64).unwrap();
+        }
+        let storage = VirtioFsReplyStorage::from_completed(buffer, reservation, 0..64).unwrap();
+
+        let storage = storage.into_compat_bytes(vec![0; 80]).unwrap();
+        assert_eq!(storage.as_slice().len(), 80);
     }
 }

--- a/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
+++ b/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
@@ -132,6 +132,13 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "requests_aborted_total ");
     expect_field(whole, "requests_dropped_umount_total ");
     expect_field(whole, "read_buffer_too_small_total ");
+    expect_field(whole, "reply_payload_transfer_count_total ");
+    expect_field(whole, "reply_payload_transfer_bytes_total ");
+    expect_field(whole, "reply_payload_copy_count_total ");
+    expect_field(whole, "dev_fuse_input_copy_count_total ");
+    expect_field(whole, "dev_fuse_input_copy_bytes_total ");
+    expect_field(whole, "virtiofs_compat_copy_count_total ");
+    expect_field(whole, "virtiofs_compat_copy_bytes_total ");
 
     expect_field(whole, "[virtiofs]\n");
     expect_field(whole, "device_queue_depth_max ");
@@ -147,6 +154,12 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "request_inflight_current ");
     expect_field(whole, "request_inflight_peak ");
     expect_field(whole, "queue_full_blocked_current ");
+    expect_field(whole, "reply_retained_current ");
+    expect_field(whole, "reply_retained_peak ");
+    expect_field(whole, "reply_retained_capacity_bytes_current ");
+    expect_field(whole, "reply_retained_capacity_bytes_peak ");
+    expect_field(whole, "reply_credit_blocked_total ");
+    expect_field(whole, "reply_credit_blocked_wake_total ");
     expect_field(whole, "bridge_loop_iterations_total ");
     expect_field(whole, "bridge_idle_sleeps_total ");
     expect_field(whole, "virtqueue_full_total ");
@@ -166,6 +179,7 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "bridge_wait_exit_spurious_total ");
     expect_field(whole, "bridge_wake_request_total ");
     expect_field(whole, "bridge_wake_completion_total ");
+    expect_field(whole, "bridge_wake_reply_released_total ");
     expect_field(whole, "bridge_wake_teardown_total ");
     expect_field(whole, "bridge_wake_disconnect_total ");
     expect_field(whole, "bridge_irq_no_active_conn_total ");
@@ -183,6 +197,8 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "opcode_16_response_buffer_alloc_count ");
     expect_field(whole, "opcode_16_response_buffer_zero_bytes ");
     expect_field(whole, "opcode_63_reply_payload_copy_bytes ");
+    expect_field(whole, "opcode_63_reply_payload_transfer_count ");
+    expect_field(whole, "opcode_63_reply_payload_transfer_bytes ");
 
     EXPECT_GE(parse_counter(whole, "device_queue_depth_max"), 0);
     EXPECT_GE(parse_counter(whole, "hiprio_vring_size_configured"), 0);
@@ -196,6 +212,13 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_counter_increased(whole, after_fuse, "requests_queued_total");
     expect_counter_increased(whole, after_fuse, "requests_dequeued_total");
     expect_counter_increased(whole, after_fuse, "requests_replied_ok_total");
+    expect_counter_increased(whole, after_fuse, "bytes_reply_payload_cloned_total");
+    expect_counter_increased(whole, after_fuse, "dev_fuse_input_copy_count_total");
+    expect_counter_increased(whole, after_fuse, "dev_fuse_input_copy_bytes_total");
+    EXPECT_EQ(parse_counter(whole, "reply_payload_transfer_count_total"),
+              parse_counter(after_fuse, "reply_payload_transfer_count_total"));
+    EXPECT_EQ(parse_counter(whole, "virtiofs_compat_copy_count_total"),
+              parse_counter(after_fuse, "virtiofs_compat_copy_count_total"));
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdint.h>
@@ -140,6 +141,63 @@ void emit_stats_delta(const char* workload, const StatsMap& before, const StatsM
     }
 }
 
+bool stats_delta(const StatsMap& before, const StatsMap& after, const std::string& key,
+                 long long* delta) {
+    auto old = before.find(key);
+    auto current = after.find(key);
+    if (old == before.end() || current == after.end()) {
+        return false;
+    }
+    *delta = current->second - old->second;
+    return true;
+}
+
+bool require_zero_copy_transfer(const char* workload, const StatsMap& before,
+                                const StatsMap& after, int opcode) {
+    const std::string prefix =
+        "virtiofs_opcode.opcode_" + std::to_string(opcode);
+    long long requests = 0;
+    long long transfer_count = 0;
+    long long transfer_bytes = 0;
+    long long copy_bytes = 0;
+    bool present =
+        stats_delta(before, after, prefix + "_requests_total", &requests) &&
+        stats_delta(before, after, prefix + "_reply_payload_transfer_count", &transfer_count) &&
+        stats_delta(before, after, prefix + "_reply_payload_transfer_bytes", &transfer_bytes) &&
+        stats_delta(before, after, prefix + "_reply_payload_copy_bytes", &copy_bytes);
+    bool passed = present && requests > 0 && transfer_count > 0 && transfer_bytes > 0 &&
+                  copy_bytes == 0;
+    if (!passed) {
+        fprintf(stderr,
+                "stats_assert workload=%s opcode=%d status=fail present=%d requests=%lld "
+                "transfer_count=%lld transfer_bytes=%lld copy_bytes=%lld\n",
+                workload, opcode, present ? 1 : 0, requests, transfer_count, transfer_bytes,
+                copy_bytes);
+    }
+    return passed;
+}
+
+bool validate_zero_copy_metrics(const char* workload, const StatsMap& before,
+                                const StatsMap& after) {
+    if (strcmp(workload, "metadata") == 0) {
+        return require_zero_copy_transfer(workload, before, after, 35);  // CREATE
+    }
+    if (strcmp(workload, "sequential") == 0) {
+        return require_zero_copy_transfer(workload, before, after, 15);  // READ
+    }
+    if (strcmp(workload, "readdir") == 0) {
+        long long readdir_requests = 0;
+        long long readdirplus_requests = 0;
+        stats_delta(before, after, "virtiofs_opcode.opcode_28_requests_total",
+                    &readdir_requests);
+        stats_delta(before, after, "virtiofs_opcode.opcode_44_requests_total",
+                    &readdirplus_requests);
+        int opcode = readdirplus_requests > 0 ? 44 : 28;
+        return require_zero_copy_transfer(workload, before, after, opcode);
+    }
+    return true;
+}
+
 bool write_full(int fd, const void* data, size_t len) {
     const char* p = static_cast<const char*>(data);
     while (len > 0) {
@@ -263,6 +321,59 @@ int metadata_workload(const Options& opt, const std::string& root) {
         ops += 3;
     }
     emit_result("metadata", opt, now_us() - start, 0, ops, err);
+    return err == 0 ? 0 : -1;
+}
+
+int readdir_workload(const Options& opt, const std::string& root) {
+    const std::string prefix = "readdir_";
+    uint64_t start = now_us();
+    uint64_t ops = 0;
+    int err = 0;
+    for (size_t i = 0; i < opt.files; ++i) {
+        std::string path = path_join(root, prefix + std::to_string(i));
+        int fd = open(path.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0644);
+        if (fd < 0) {
+            err = errno_or_eio();
+            break;
+        }
+        close_preserve_error(fd, &err);
+        if (err != 0) {
+            break;
+        }
+    }
+
+    size_t found = 0;
+    if (err == 0) {
+        DIR* dir = opendir(root.c_str());
+        if (!dir) {
+            err = errno_or_eio();
+        } else {
+            errno = 0;
+            while (dirent* entry = readdir(dir)) {
+                if (strncmp(entry->d_name, prefix.c_str(), prefix.size()) == 0) {
+                    ++found;
+                }
+            }
+            if (errno != 0) {
+                err = errno;
+            }
+            if (closedir(dir) != 0 && err == 0) {
+                err = errno_or_eio();
+            }
+        }
+    }
+    if (err == 0 && found != opt.files) {
+        err = EIO;
+    }
+    for (size_t i = 0; i < opt.files; ++i) {
+        std::string path = path_join(root, prefix + std::to_string(i));
+        if (unlink(path.c_str()) == 0) {
+            ++ops;
+        } else if (err == 0) {
+            err = errno_or_eio();
+        }
+    }
+    emit_result("readdir", opt, now_us() - start, 0, ops + found, err);
     return err == 0 ? 0 : -1;
 }
 
@@ -457,7 +568,7 @@ int concurrent_workload(const Options& opt, const std::string& root) {
 
 void usage(const char* argv0) {
     fprintf(stderr,
-            "usage: %s --mount PATH [--workload all|metadata|sequential|random_read|mmap|concurrent] "
+            "usage: %s --mount PATH [--workload all|metadata|readdir|sequential|random_read|mmap|concurrent] "
             "[--files N] [--file-size N] [--block-size N] [--iterations N] [--workers N]\n",
             argv0);
     fprintf(stderr,
@@ -523,7 +634,8 @@ bool parse_args(int argc, char** argv, Options* opt) {
             return false;
         }
     }
-    if (opt->workload != "all" && opt->workload != "metadata" && opt->workload != "sequential" &&
+    if (opt->workload != "all" && opt->workload != "metadata" && opt->workload != "readdir" &&
+        opt->workload != "sequential" &&
         opt->workload != "random_read" && opt->workload != "mmap" &&
         opt->workload != "concurrent") {
         fprintf(stderr, "unknown workload: %s\n", opt->workload.c_str());
@@ -582,10 +694,19 @@ struct AutoMount {
 
 int run_with_stats_delta(const char* name, int (*workload)(const Options&, const std::string&),
                          const Options& opt, const std::string& root) {
+    const bool verify_stats = !stats_path().empty();
     StatsMap before = read_stats();
+    if (verify_stats && before.empty()) {
+        fprintf(stderr, "stats_assert workload=%s status=fail reason=baseline_unavailable\n", name);
+        return -1;
+    }
     int rc = workload(opt, root);
     StatsMap after = read_stats();
     emit_stats_delta(name, before, after);
+    if (rc == 0 && verify_stats &&
+        (!validate_zero_copy_metrics(name, before, after) || after.empty())) {
+        return -1;
+    }
     return rc;
 }
 
@@ -625,6 +746,9 @@ int main(int argc, char** argv) {
     int rc = 0;
     if (opt.workload == "all" || opt.workload == "metadata") {
         rc |= run_with_stats_delta("metadata", metadata_workload, opt, root);
+    }
+    if (opt.workload == "all" || opt.workload == "readdir") {
+        rc |= run_with_stats_delta("readdir", readdir_workload, opt, root);
     }
     if (opt.workload == "all" || opt.workload == "sequential") {
         rc |= run_with_stats_delta("sequential", sequential_workload, opt, root);


### PR DESCRIPTION
## Summary

- transfer retired virtiofs response buffers into an owned FUSE reply instead of cloning payloads into a second Vec
- bound consumer-held replies with RAII retention credits, session-local recycling, credit-aware wakeups, and fair completion draining
- preserve /dev/fuse byte-stream copies and compatibility normalization while exposing copy/transfer source metrics
- add readdir coverage and fail-fast zero-copy benchmark assertions

## Correctness

The reply is published only after pop_used retires the descriptor and DeviceOutputBuffer validates the initialized prefix. Reply claim is linearized against abort and unmount under the connection lock, and Waiting/Ready/Consumed preserves first-completion semantics. Slow consumers are bounded by both reply count and allocation capacity; reset, malformed, late, duplicate, and closed-session paths release ownership through RAII without an unbudgeted fallback.

## Validation

- device-output-buffer tests: 8 passed
- make fmt, including kernel clippy
- make kernel
- make build SKIP_GRUB=1
- QEMU metadata, readdir, and 4 MiB sequential read/write workloads with opcode transfer assertions and zero payload-copy deltas
- debugfs dunitest covering /dev/fuse copy versus transfer metrics
- unmount/remount virtiofs smoke test
- independent adversarial reviews for Linux semantics, ownership and lifecycle safety, performance, fairness, and regression risk

Closes #2038