### PR TITLE
fix(ext4): canonicalize inode lifecycle identity

### DIFF
--- a/kernel/src/debug/ext4.rs
+++ b/kernel/src/debug/ext4.rs
@@ -1,0 +1,74 @@
+use alloc::{string::String, string::ToString};
+
+use crate::{
+    debug::sysfs::debugfs_kobj,
+    driver::base::kobject::KObject,
+    filesystem::{
+        kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData},
+        vfs::{InodeMode, PollStatus},
+    },
+};
+use system_error::SystemError;
+
+#[derive(Debug)]
+struct Ext4LifecycleSelftestCallback;
+
+impl KernFSCallback for Ext4LifecycleSelftestCallback {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        let report = crate::filesystem::ext4::inode::run_lifecycle_selftests();
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(report));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report: &String = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+pub fn init_debugfs_ext4() -> Result<(), SystemError> {
+    let debugfs = debugfs_kobj();
+    let root = debugfs.inode().ok_or(SystemError::ENOENT)?;
+    let ext4 = root.add_dir(
+        "ext4".to_string(),
+        InodeMode::from_bits_truncate(0o555),
+        None,
+        None,
+    )?;
+    ext4.add_file(
+        "lifecycle_selftest".to_string(),
+        InodeMode::S_IRUGO,
+        Some(4096),
+        None,
+        Some(&Ext4LifecycleSelftestCallback),
+    )?;
+    Ok(())
+}

--- a/kernel/src/debug/mod.rs
+++ b/kernel/src/debug/mod.rs
@@ -1,4 +1,5 @@
 pub mod errseq;
+pub mod ext4;
 pub mod fuse;
 pub mod jump_label;
 pub mod klog;

--- a/kernel/src/debug/sysfs/mod.rs
+++ b/kernel/src/debug/sysfs/mod.rs
@@ -23,6 +23,7 @@ fn debugfs_init() -> Result<(), SystemError> {
     super::tracing::init_debugfs_tracing()?;
     super::rcu::init_debugfs_rcu()?;
     super::errseq::init_debugfs_errseq()?;
+    super::ext4::init_debugfs_ext4()?;
     super::fuse::init_debugfs_fuse()?;
     return Ok(());
 }

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -1,7 +1,7 @@
 use crate::{
     driver::base::{block::gendisk::GenDisk, device::device_number::DeviceNumber},
     filesystem::{
-        ext4::inode::{Ext4Inode, InodeDirtyState},
+        ext4::inode::{Ext4Inode, Ext4InodeLifecycle, Ext4InodeLifecycleState, InodeDirtyState},
         vfs::{
             self,
             fcntl::AtFlags,
@@ -11,7 +11,10 @@ use crate::{
             VFS_MAX_FOLLOW_SYMLINK_TIMES,
         },
     },
-    libs::{mutex::Mutex, rwsem::RwSem},
+    libs::{
+        mutex::Mutex,
+        rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
+    },
     mm::{
         fault::{PageFaultHandler, PageFaultMessage},
         VmFaultReason,
@@ -30,6 +33,20 @@ use system_error::SystemError;
 
 use super::inode::LockedExt4Inode;
 
+#[derive(Debug)]
+struct CanonicalInodeEntry {
+    inode: Weak<LockedExt4Inode>,
+    lifecycle: Arc<Ext4InodeLifecycle>,
+}
+
+#[must_use]
+pub(super) struct Ext4InodeTombstone {
+    fs: Weak<Ext4FileSystem>,
+    inode_num: u32,
+    lifecycle: Arc<Ext4InodeLifecycle>,
+    resolved: bool,
+}
+
 pub struct Ext4FileSystem {
     /// 对应 another_ext4 中的实际文件系统
     pub(super) fs: another_ext4::Ext4,
@@ -41,6 +58,17 @@ pub struct Ext4FileSystem {
 
     /// 元数据（size/mtime）脏但尚未刷盘的 inode 列表。
     dirty_inodes: Mutex<Vec<Arc<LockedExt4Inode>>>,
+
+    /// Per-superblock canonical VFS inode identity, keyed by the on-disk inode number.
+    inode_table: Mutex<BTreeMap<u32, CanonicalInodeEntry>>,
+
+    /// Allocations hold a read guard through canonical publication. Physical reclaim
+    /// holds a write guard through tombstone completion so an inode number cannot be
+    /// reused in the handoff window.
+    inode_reuse_barrier: RwSem<()>,
+
+    /// Fail-stop allocation after an indeterminate physical reclaim.
+    lifecycle_error: Mutex<Option<SystemError>>,
 
     /// Mount-time ext4 options parsed from user/kernel mount data.
     _mount_options: Ext4MountOptions,
@@ -123,7 +151,204 @@ impl FileSystem for Ext4FileSystem {
 }
 
 impl Ext4FileSystem {
-    pub(super) fn mark_inode_dirty(inode: &Arc<LockedExt4Inode>, dirty: InodeDirtyState) {
+    pub(super) fn begin_allocation(&self) -> Result<RwSemReadGuard<'_, ()>, SystemError> {
+        let guard = self.inode_reuse_barrier.read();
+        if let Some(error) = self.lifecycle_error.lock().clone() {
+            return Err(error);
+        }
+        Ok(guard)
+    }
+
+    pub(super) fn begin_reclaim(&self) -> RwSemWriteGuard<'_, ()> {
+        self.inode_reuse_barrier.write()
+    }
+
+    pub(super) fn fail_stop_lifecycle(&self) {
+        *self.lifecycle_error.lock() = Some(SystemError::EIO);
+    }
+
+    pub(super) fn get_or_create_inode(
+        self: &Arc<Self>,
+        inode_num: u32,
+        dname: DName,
+        parent: Option<Weak<LockedExt4Inode>>,
+    ) -> Result<Arc<LockedExt4Inode>, SystemError> {
+        self.get_or_create_inode_inner(inode_num, dname, parent, false, None)
+    }
+
+    pub(super) fn publish_allocated_inode(
+        self: &Arc<Self>,
+        inode_num: u32,
+        dname: DName,
+        parent: Option<Weak<LockedExt4Inode>>,
+        file_type: another_ext4::FileType,
+        _reuse_guard: &RwSemReadGuard<'_, ()>,
+    ) -> Result<Arc<LockedExt4Inode>, SystemError> {
+        self.get_or_create_inode_inner(inode_num, dname, parent, true, Some(file_type))
+    }
+
+    fn get_or_create_inode_inner(
+        self: &Arc<Self>,
+        inode_num: u32,
+        dname: DName,
+        parent: Option<Weak<LockedExt4Inode>>,
+        reuse_guard_held: bool,
+        known_file_type: Option<another_ext4::FileType>,
+    ) -> Result<Arc<LockedExt4Inode>, SystemError> {
+        let mut candidate = None;
+        let mut admission_guard = None;
+        loop {
+            let wait_lifecycle = {
+                let mut table = self.inode_table.lock();
+                match table.get(&inode_num) {
+                    Some(entry) => match entry.lifecycle.state() {
+                        Ext4InodeLifecycleState::Live => {
+                            if let Some(inode) = entry.inode.upgrade() {
+                                return Ok(inode);
+                            }
+                            entry.lifecycle.set_state(Ext4InodeLifecycleState::Retired);
+                            table.remove(&inode_num);
+                            None
+                        }
+                        Ext4InodeLifecycleState::Freeing => {
+                            candidate = None;
+                            drop(admission_guard.take());
+                            Some(entry.lifecycle.clone())
+                        }
+                        Ext4InodeLifecycleState::Retired => {
+                            candidate = None;
+                            drop(admission_guard.take());
+                            table.remove(&inode_num);
+                            None
+                        }
+                        Ext4InodeLifecycleState::Poisoned(error) => return Err(error),
+                    },
+                    None => {
+                        if candidate.is_none() {
+                            drop(table);
+                            if !reuse_guard_held {
+                                admission_guard = Some(self.inode_reuse_barrier.read());
+                            }
+                            candidate = Some(LockedExt4Inode::new(
+                                inode_num,
+                                Arc::downgrade(self),
+                                dname.clone(),
+                                parent.clone(),
+                                known_file_type,
+                            )?);
+                            continue;
+                        }
+                        let inode = candidate.take().expect("candidate checked above");
+                        table.insert(
+                            inode_num,
+                            CanonicalInodeEntry {
+                                inode: Arc::downgrade(&inode),
+                                lifecycle: inode.lifecycle().clone(),
+                            },
+                        );
+                        drop(admission_guard.take());
+                        return Ok(inode);
+                    }
+                }
+            };
+
+            if let Some(lifecycle) = wait_lifecycle {
+                match lifecycle.wait_while_freeing() {
+                    Ext4InodeLifecycleState::Poisoned(error) => return Err(error),
+                    _ => continue,
+                }
+            }
+        }
+    }
+
+    pub(super) fn validate_inode(&self, inode: &Arc<LockedExt4Inode>) -> Result<(), SystemError> {
+        let inode_num = inode.0.lock().inner_inode_num;
+        let table = self.inode_table.lock();
+        let entry = table.get(&inode_num).ok_or(SystemError::ESTALE)?;
+        if !Weak::ptr_eq(&entry.inode, &Arc::downgrade(inode))
+            || !Arc::ptr_eq(&entry.lifecycle, inode.lifecycle())
+        {
+            return Err(SystemError::ESTALE);
+        }
+        inode.lifecycle().begin_operation().map(drop)
+    }
+
+    pub(super) fn begin_freeing(
+        self: &Arc<Self>,
+        inode: &Arc<LockedExt4Inode>,
+    ) -> Result<Ext4InodeTombstone, SystemError> {
+        let inode_num = inode.0.lock().inner_inode_num;
+        {
+            let table = self.inode_table.lock();
+            let entry = table.get(&inode_num).ok_or(SystemError::ESTALE)?;
+            if !Weak::ptr_eq(&entry.inode, &Arc::downgrade(inode))
+                || !Arc::ptr_eq(&entry.lifecycle, inode.lifecycle())
+            {
+                return Err(SystemError::ESTALE);
+            }
+            entry.lifecycle.begin_freeing()?;
+        }
+        inode.lifecycle().wait_for_quiescent();
+        Ok(Ext4InodeTombstone {
+            fs: Arc::downgrade(self),
+            inode_num,
+            lifecycle: inode.lifecycle().clone(),
+            resolved: false,
+        })
+    }
+
+    fn finish_tombstone(
+        &self,
+        tombstone: &mut Ext4InodeTombstone,
+        state: Ext4InodeLifecycleState,
+        remove: bool,
+    ) -> Result<(), SystemError> {
+        let mut table = self.inode_table.lock();
+        let entry = table.get(&tombstone.inode_num).ok_or(SystemError::ESTALE)?;
+        if !Arc::ptr_eq(&entry.lifecycle, &tombstone.lifecycle) {
+            return Err(SystemError::ESTALE);
+        }
+        tombstone.lifecycle.set_state(state);
+        if remove {
+            table.remove(&tombstone.inode_num);
+        }
+        tombstone.resolved = true;
+        Ok(())
+    }
+
+    pub(super) fn complete_freeing(
+        &self,
+        mut tombstone: Ext4InodeTombstone,
+    ) -> Result<(), SystemError> {
+        self.finish_tombstone(&mut tombstone, Ext4InodeLifecycleState::Retired, true)
+    }
+
+    pub(super) fn abort_freeing(
+        &self,
+        mut tombstone: Ext4InodeTombstone,
+    ) -> Result<(), SystemError> {
+        self.finish_tombstone(&mut tombstone, Ext4InodeLifecycleState::Live, false)
+    }
+
+    pub(super) fn poison_freeing(
+        &self,
+        mut tombstone: Ext4InodeTombstone,
+        _error: SystemError,
+    ) -> Result<(), SystemError> {
+        let poison = SystemError::EIO;
+        *self.lifecycle_error.lock() = Some(poison.clone());
+        self.finish_tombstone(
+            &mut tombstone,
+            Ext4InodeLifecycleState::Poisoned(poison),
+            false,
+        )
+    }
+
+    pub(super) fn mark_inode_dirty(
+        inode: &Arc<LockedExt4Inode>,
+        dirty: InodeDirtyState,
+    ) -> Result<(), SystemError> {
+        let _operation = inode.lifecycle().begin_operation()?;
         let (fs, should_queue) = {
             let mut guard = inode.0.lock();
             guard.dirty_state.insert(dirty);
@@ -141,6 +366,7 @@ impl Ext4FileSystem {
                 fs.dirty_inodes.lock().push(inode.clone());
             }
         }
+        Ok(())
     }
 
     fn flush_dirty_inodes(&self) -> Result<(), SystemError> {
@@ -157,6 +383,37 @@ impl Ext4FileSystem {
         for inode in dirty {
             let mut should_requeue = false;
             let result = {
+                let has_dirty_metadata = {
+                    let mut guard = inode.0.lock();
+                    let has_dirty = guard
+                        .dirty_state
+                        .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
+                    if !has_dirty {
+                        guard.dirty_state.remove(InodeDirtyState::QUEUED);
+                    }
+                    has_dirty
+                };
+                if !has_dirty_metadata {
+                    continue;
+                }
+                let _operation = match inode.lifecycle().begin_operation() {
+                    Ok(operation) => operation,
+                    Err(error @ (SystemError::ESTALE | SystemError::EIO)) => {
+                        log::error!(
+                            "ext4: rejecting stale metadata writeback before disk access: {:?}",
+                            error
+                        );
+                        if let Some(page_cache) = inode.0.lock().page_cache.clone() {
+                            page_cache.record_writeback_error_with_superblock(error);
+                        }
+                        continue;
+                    }
+                    Err(error) => {
+                        requeue.push(inode);
+                        last_err = Err(error);
+                        continue;
+                    }
+                };
                 let _io_guard = inode.1.lock();
                 let (fs, inode_num, snapshot_dirty, cached_size, cached_mtime) = {
                     let mut guard = inode.0.lock();
@@ -298,6 +555,8 @@ impl Ext4FileSystem {
                     }),
                     Mutex::new(()),
                     RwSem::new(()),
+                    Mutex::new(()),
+                    Ext4InodeLifecycle::new(),
                 )
             });
 
@@ -306,14 +565,56 @@ impl Ext4FileSystem {
             raw_dev,
             root_inode,
             dirty_inodes: Mutex::new(Vec::new()),
+            inode_table: Mutex::new(BTreeMap::new()),
+            inode_reuse_barrier: RwSem::new(()),
+            lifecycle_error: Mutex::new(None),
             _mount_options: mount_options,
         });
 
         let mut guard = fs.root_inode.0.lock();
         guard.fs_ptr = Arc::downgrade(&fs);
         drop(guard);
+        fs.inode_table.lock().insert(
+            another_ext4::EXT4_ROOT_INO,
+            CanonicalInodeEntry {
+                inode: Arc::downgrade(&fs.root_inode),
+                lifecycle: fs.root_inode.lifecycle().clone(),
+            },
+        );
 
         Ok(fs)
+    }
+}
+
+impl Drop for Ext4InodeTombstone {
+    fn drop(&mut self) {
+        if self.resolved {
+            return;
+        }
+        if let Some(fs) = self.fs.upgrade() {
+            let error = SystemError::EIO;
+            *fs.lifecycle_error.lock() = Some(error.clone());
+            if fs
+                .finish_tombstone(
+                    self,
+                    Ext4InodeLifecycleState::Poisoned(error.clone()),
+                    false,
+                )
+                .is_err()
+            {
+                // The canonical table may itself be inconsistent. Always wake waiters on
+                // the tombstone's original lifecycle before fail-stopping the filesystem.
+                self.lifecycle
+                    .set_state(Ext4InodeLifecycleState::Poisoned(error));
+            }
+            log::error!(
+                "ext4: unresolved inode tombstone for inode {}, filesystem fail-stopped",
+                self.inode_num
+            );
+        } else {
+            self.lifecycle
+                .set_state(Ext4InodeLifecycleState::Poisoned(SystemError::EIO));
+        }
     }
 }
 

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -171,15 +171,15 @@ impl Drop for Ext4InodeOperation {
             let mut inner = self.lifecycle.inner.lock();
             debug_assert!(inner.active_operations > 0);
             inner.active_operations = inner.active_operations.saturating_sub(1);
-            let remove_owner = if let Some(owner_depth) = inner.operation_owners.get_mut(&self.owner)
-            {
-                debug_assert!(*owner_depth > 0);
-                *owner_depth = owner_depth.saturating_sub(1);
-                *owner_depth == 0
-            } else {
-                debug_assert!(false, "missing ext4 lifecycle operation owner");
-                false
-            };
+            let remove_owner =
+                if let Some(owner_depth) = inner.operation_owners.get_mut(&self.owner) {
+                    debug_assert!(*owner_depth > 0);
+                    *owner_depth = owner_depth.saturating_sub(1);
+                    *owner_depth == 0
+                } else {
+                    debug_assert!(false, "missing ext4 lifecycle operation owner");
+                    false
+                };
             if remove_owner {
                 inner.operation_owners.remove(&self.owner);
             }
@@ -1258,7 +1258,12 @@ impl IndexNode for LockedExt4Inode {
 
             let mut temp_name = String::new();
             let mut whiteout_inode = None;
-            let source_parent = self.0.lock().self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+            let source_parent = self
+                .0
+                .lock()
+                .self_ref
+                .upgrade()
+                .ok_or(SystemError::ENOENT)?;
             for _ in 0..32 {
                 let candidate = format!(".dragonos-whiteout-{}", generate_inode_id().data());
                 if ext4.lookup(src_inode_num, &candidate).is_ok() {
@@ -1276,13 +1281,13 @@ impl IndexNode for LockedExt4Inode {
                     }
                 };
                 let whiteout_num = match ext4.mknod(
-                        src_inode_num,
-                        &candidate,
-                        another_ext4::InodeMode::CHARDEV
-                            | another_ext4::InodeMode::from_bits_retain(0o600),
-                        WHITEOUT_DEV.major().data(),
-                        WHITEOUT_DEV.minor(),
-                    ) {
+                    src_inode_num,
+                    &candidate,
+                    another_ext4::InodeMode::CHARDEV
+                        | another_ext4::InodeMode::from_bits_retain(0o600),
+                    WHITEOUT_DEV.major().data(),
+                    WHITEOUT_DEV.minor(),
+                ) {
                     Ok(inode_num) => inode_num,
                     Err(error) => {
                         if let Some(tombstone) = tombstone.take() {
@@ -1347,20 +1352,15 @@ impl IndexNode for LockedExt4Inode {
             }
             if let Err(err) = ext4.rename(src_inode_num, &temp_name, target_inode_num, new_name) {
                 let rename_error = SystemError::from(err);
-                let rollback = ext4.rename_exchange(
-                    src_inode_num,
-                    old_name,
-                    src_inode_num,
-                    &temp_name,
-                );
+                let rollback =
+                    ext4.rename_exchange(src_inode_num, old_name, src_inode_num, &temp_name);
                 if let Some(tombstone) = tombstone.take() {
                     let _ = ext4_fs.poison_freeing(tombstone, rename_error.clone());
                 }
                 drop(_reuse);
                 if rollback.is_err() {
-                    let whiteout_tombstone = ext4_fs.begin_freeing(
-                        whiteout_inode.as_ref().expect("whiteout was published"),
-                    )?;
+                    let whiteout_tombstone = ext4_fs
+                        .begin_freeing(whiteout_inode.as_ref().expect("whiteout was published"))?;
                     let _ = ext4_fs.poison_freeing(whiteout_tombstone, SystemError::EIO);
                     return Err(SystemError::EIO);
                 }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -13,6 +13,7 @@ use crate::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
         rwsem::RwSem,
+        wait_queue::WaitQueue,
     },
     mm::{truncate::truncate_inode_pages, MemoryManagementArch},
     time::PosixTimeSpec,
@@ -47,6 +48,118 @@ bitflags! {
         /// 仅时间戳脏（lazytime），对应 I_DIRTY_TIME (1 << 11)
         #[allow(dead_code)]
         const TIME_DIRTY    = 1 << 11;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Ext4InodeLifecycleState {
+    Live,
+    Freeing,
+    Retired,
+    Poisoned(SystemError),
+}
+
+#[derive(Debug)]
+struct Ext4InodeLifecycleInner {
+    state: Ext4InodeLifecycleState,
+    active_operations: usize,
+}
+
+#[derive(Debug)]
+pub(super) struct Ext4InodeLifecycle {
+    inner: Mutex<Ext4InodeLifecycleInner>,
+    link_mutation: Mutex<()>,
+    wait_queue: WaitQueue,
+}
+
+impl Ext4InodeLifecycle {
+    pub(super) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(Ext4InodeLifecycleInner {
+                state: Ext4InodeLifecycleState::Live,
+                active_operations: 0,
+            }),
+            link_mutation: Mutex::new(()),
+            wait_queue: WaitQueue::default(),
+        })
+    }
+
+    pub(super) fn state(&self) -> Ext4InodeLifecycleState {
+        self.inner.lock().state.clone()
+    }
+
+    /// Serializes link-count mutations for all aliases of this canonical inode.
+    pub(super) fn lock_link_mutation(&self) -> MutexGuard<'_, ()> {
+        self.link_mutation.lock()
+    }
+
+    pub(super) fn begin_operation(self: &Arc<Self>) -> Result<Ext4InodeOperation, SystemError> {
+        let mut inner = self.inner.lock();
+        match inner.state.clone() {
+            Ext4InodeLifecycleState::Live => {
+                inner.active_operations = inner
+                    .active_operations
+                    .checked_add(1)
+                    .ok_or(SystemError::EOVERFLOW)?;
+                Ok(Ext4InodeOperation {
+                    lifecycle: self.clone(),
+                })
+            }
+            Ext4InodeLifecycleState::Freeing => Err(SystemError::EBUSY),
+            Ext4InodeLifecycleState::Retired => Err(SystemError::ESTALE),
+            Ext4InodeLifecycleState::Poisoned(error) => Err(error),
+        }
+    }
+
+    pub(super) fn begin_freeing(&self) -> Result<(), SystemError> {
+        let mut inner = self.inner.lock();
+        match inner.state.clone() {
+            Ext4InodeLifecycleState::Live => {
+                inner.state = Ext4InodeLifecycleState::Freeing;
+                Ok(())
+            }
+            Ext4InodeLifecycleState::Freeing => Err(SystemError::EBUSY),
+            Ext4InodeLifecycleState::Retired => Err(SystemError::ESTALE),
+            Ext4InodeLifecycleState::Poisoned(error) => Err(error),
+        }
+    }
+
+    pub(super) fn wait_for_quiescent(&self) {
+        self.wait_queue.wait_until(|| {
+            let inner = self.inner.lock();
+            (inner.active_operations == 0).then_some(())
+        });
+    }
+
+    pub(super) fn wait_while_freeing(&self) -> Ext4InodeLifecycleState {
+        self.wait_queue.wait_until(|| {
+            let state = self.inner.lock().state.clone();
+            (state != Ext4InodeLifecycleState::Freeing).then_some(state)
+        })
+    }
+
+    pub(super) fn set_state(&self, state: Ext4InodeLifecycleState) {
+        self.inner.lock().state = state;
+        self.wait_queue.wake_all();
+    }
+}
+
+#[must_use]
+pub(super) struct Ext4InodeOperation {
+    lifecycle: Arc<Ext4InodeLifecycle>,
+}
+
+impl Drop for Ext4InodeOperation {
+    fn drop(&mut self) {
+        let should_wake = {
+            let mut inner = self.lifecycle.inner.lock();
+            debug_assert!(inner.active_operations > 0);
+            inner.active_operations = inner.active_operations.saturating_sub(1);
+            inner.active_operations == 0
+        };
+        if should_wake {
+            self.lifecycle.wait_queue.wake_all();
+        }
     }
 }
 
@@ -86,6 +199,8 @@ pub struct LockedExt4Inode(
     pub(super) Mutex<Ext4Inode>,
     pub(super) Mutex<()>,
     pub(super) RwSem<()>,
+    pub(super) Mutex<()>,
+    pub(super) Arc<Ext4InodeLifecycle>,
 );
 
 impl IndexNode for LockedExt4Inode {
@@ -107,11 +222,15 @@ impl IndexNode for LockedExt4Inode {
         file_type: vfs::FileType,
         mode: vfs::InodeMode,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let _operation = self.begin_operation()?;
+        let _namespace = self.3.lock();
         let mut guard = self.0.lock();
         // another_ext4的高4位是文件类型，低12位是权限
         let file_mode = InodeMode::from(file_type).union(mode);
         let file_mode = another_ext4::InodeMode::from_bits_truncate(file_mode.bits() as u16);
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let _reuse = fs.begin_allocation()?;
+        let ext4 = &fs.fs;
 
         let id = if file_type == vfs::FileType::Dir {
             ext4.mkdir(guard.inner_inode_num, name, file_mode)?
@@ -122,12 +241,13 @@ impl IndexNode for LockedExt4Inode {
         let dname = DName::from(name);
         // 通过self_ref获取Arc<Self>，然后转换为Arc<dyn IndexNode>
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
-        let inode = LockedExt4Inode::new(
+        let inode = fs.publish_allocated_inode(
             id,
-            guard.fs_ptr.clone(),
             dname.clone(),
             Some(Arc::downgrade(&self_arc)),
-        );
+            Self::disk_file_type(file_type),
+            &_reuse,
+        )?;
         // 更新 children 缓存
         guard.children.insert(dname, inode.clone());
         drop(guard);
@@ -155,6 +275,7 @@ impl IndexNode for LockedExt4Inode {
         buf: &mut [u8],
         data: PrivateData,
     ) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let len = core::cmp::min(len, buf.len());
         let buf = &mut buf[0..len];
 
@@ -178,6 +299,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn read_sync(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let (fs, inode_num) = {
             let guard = self.0.lock();
             (guard.concret_fs(), guard.inner_inode_num)
@@ -209,6 +331,7 @@ impl IndexNode for LockedExt4Inode {
         buf: &[u8],
         data: PrivateData,
     ) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let len = core::cmp::min(len, buf.len());
         if len == 0 {
             return Ok(0);
@@ -280,7 +403,7 @@ impl IndexNode for LockedExt4Inode {
                 Ext4FileSystem::mark_inode_dirty(
                     &self_arc,
                     InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY,
-                );
+                )?;
             }
 
             Ok(write_len)
@@ -290,6 +413,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn write_sync(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let _io_guard = self.1.lock();
         let (fs, inode_num) = {
             let guard = self.0.lock();
@@ -331,20 +455,24 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn find(&self, name: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let _operation = self.begin_operation()?;
+        let _namespace = self.3.lock();
         let mut guard = self.0.lock();
         let dname = DName::from(name);
         if let Some(child) = guard.children.get(&dname) {
-            return Ok(child.clone() as Arc<dyn IndexNode>);
+            let child = child.clone();
+            let fs = guard.concret_fs();
+            if fs.validate_inode(&child).is_ok() {
+                return Ok(child as Arc<dyn IndexNode>);
+            }
+            guard.children.remove(&dname);
         }
-        let next_inode = guard.concret_fs().fs.lookup(guard.inner_inode_num, name)?;
+        let fs = guard.concret_fs();
+        let next_inode = fs.fs.lookup(guard.inner_inode_num, name)?;
         // 通过self_ref获取Arc<Self>，然后转换为Arc<dyn IndexNode>
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
-        let inode = LockedExt4Inode::new(
-            next_inode,
-            guard.fs_ptr.clone(),
-            dname.clone(),
-            Some(Arc::downgrade(&self_arc)),
-        );
+        let inode =
+            fs.get_or_create_inode(next_inode, dname.clone(), Some(Arc::downgrade(&self_arc)))?;
         guard.children.insert(dname, inode.clone());
         Ok(inode)
     }
@@ -363,6 +491,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn list(&self) -> Result<Vec<String>, SystemError> {
+        let _operation = self.begin_operation()?;
         let guard = self.0.lock();
         let dentry = guard.concret_fs().fs.listdir(guard.inner_inode_num)?;
         let mut list = Vec::new();
@@ -373,14 +502,24 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn link(&self, name: &str, other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
+        let _namespace = self.3.lock();
         let mut guard = self.0.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
         let other_arc = other
             .clone()
             .downcast_arc::<LockedExt4Inode>()
             .ok_or(SystemError::EINVAL)?;
+        let other_fs = other_arc.0.lock().concret_fs();
+        if !Arc::ptr_eq(&fs, &other_fs) {
+            return Err(SystemError::EXDEV);
+        }
+        let other_lifecycle = other_arc.lifecycle().clone();
+        let _link_mutation = other_lifecycle.lock_link_mutation();
+        let _other_operation = other_arc.begin_operation()?;
         let other_inode_num = other_arc.0.lock().inner_inode_num;
 
         let my_attr = ext4.getattr(inode_num)?;
@@ -407,20 +546,82 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn unlink(&self, name: &str) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
+        let _namespace = self.3.lock();
         let mut guard = self.0.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
         let attr = ext4.getattr(inode_num)?;
         if attr.ftype != another_ext4::FileType::Directory {
             return Err(SystemError::ENOTDIR);
         }
-        ext4.unlink(inode_num, name)?;
+        let target_num = ext4.lookup(inode_num, name)?;
+        if ext4.getattr(target_num)?.ftype == FileType::Directory {
+            return Err(SystemError::EISDIR);
+        }
+        let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        let target = fs.get_or_create_inode(
+            target_num,
+            DName::from(name),
+            Some(Arc::downgrade(&self_arc)),
+        )?;
+        let target_lifecycle = target.lifecycle().clone();
+        let _link_mutation = target_lifecycle.lock_link_mutation();
+        let target_attr = ext4.getattr(target_num)?;
+
+        // Removing a non-final hard link must not enter the eviction lifecycle: the
+        // canonical inode and its shared page cache remain live for the other aliases.
+        if target_attr.links > 1 {
+            let _target_operation = target.begin_operation()?;
+            if ext4.lookup(inode_num, name)? != target_num {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            ext4.unlink(inode_num, name)?;
+            let _ = guard.children.remove(&DName::from(name));
+            return Ok(());
+        }
+
+        let tombstone = fs.begin_freeing(&target)?;
+        match ext4.lookup(inode_num, name) {
+            Ok(current) if current == target_num => {}
+            Ok(_) => {
+                fs.abort_freeing(tombstone)?;
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            Err(error) => {
+                fs.abort_freeing(tombstone)?;
+                return Err(error.into());
+            }
+        }
+        let _reuse = fs.begin_reclaim();
+        if let Some(page_cache) = target.page_cache() {
+            truncate_inode_pages(page_cache, 0);
+        }
+        let result = ext4.unlink(inode_num, name).map_err(SystemError::from);
+        if let Err(error) = result {
+            let _ = fs.poison_freeing(tombstone, error.clone());
+            return Err(error);
+        }
+        match ext4.getattr(target_num) {
+            Ok(_) => fs.abort_freeing(tombstone)?,
+            Err(error) => {
+                let error = SystemError::from(error);
+                if error == SystemError::EINVAL {
+                    fs.complete_freeing(tombstone)?;
+                } else {
+                    let _ = fs.poison_freeing(tombstone, error.clone());
+                    return Err(error);
+                }
+            }
+        }
         // 清理 children 缓存
         let _ = guard.children.remove(&DName::from(name));
         Ok(())
     }
 
     fn metadata(&self) -> Result<vfs::Metadata, SystemError> {
+        let _operation = self.begin_operation()?;
         let (fs, inode_num, vfs_inode_id, cached_size, cached_mtime) = {
             let guard = self.0.lock();
             (
@@ -474,6 +675,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn sync(&self) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
         if let Some(page_cache) = self.page_cache() {
             page_cache.manager().sync()?;
         }
@@ -481,6 +683,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn datasync(&self) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
         if let Some(page_cache) = self.page_cache() {
             page_cache.manager().sync()?;
         }
@@ -502,6 +705,7 @@ impl IndexNode for LockedExt4Inode {
         datasync: bool,
         _data: PrivateData,
     ) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
         if let Some(page_cache) = self.page_cache() {
             let start_index = start >> MMArch::PAGE_SHIFT;
             let end_index = end >> MMArch::PAGE_SHIFT;
@@ -521,6 +725,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn set_metadata(&self, metadata: &vfs::Metadata) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
         let mode = metadata.mode.union(InodeMode::from(metadata.file_type));
 
         let to_ext4_time =
@@ -559,6 +764,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
         let _size_guard = self.2.write();
         let (fs, inode_num, page_cache, cached_size) = {
             let guard = self.0.lock();
@@ -626,13 +832,86 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn rmdir(&self, name: &str) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
+        let _namespace = self.3.lock();
         let mut guard = self.0.lock();
-        let concret_fs = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let concret_fs = &fs.fs;
         let inode_num = guard.inner_inode_num;
         if concret_fs.getattr(inode_num)?.ftype != FileType::Directory {
             return Err(SystemError::ENOTDIR);
         }
-        concret_fs.rmdir(inode_num, name)?;
+        let target_num = concret_fs.lookup(inode_num, name)?;
+        if concret_fs.getattr(target_num)?.ftype != FileType::Directory {
+            return Err(SystemError::ENOTDIR);
+        }
+        if concret_fs.listdir(target_num)?.len() > 2 {
+            return Err(SystemError::ENOTEMPTY);
+        }
+        let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        let target = fs.get_or_create_inode(
+            target_num,
+            DName::from(name),
+            Some(Arc::downgrade(&self_arc)),
+        )?;
+        let target_lifecycle = target.lifecycle().clone();
+        let _link_mutation = target_lifecycle.lock_link_mutation();
+        let tombstone = fs.begin_freeing(&target)?;
+        match concret_fs.lookup(inode_num, name) {
+            Ok(current) if current == target_num => {}
+            Ok(_) => {
+                fs.abort_freeing(tombstone)?;
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            Err(error) => {
+                fs.abort_freeing(tombstone)?;
+                return Err(error.into());
+            }
+        }
+        let target_attr = match concret_fs.getattr(target_num) {
+            Ok(attr) => attr,
+            Err(error) => {
+                fs.abort_freeing(tombstone)?;
+                return Err(error.into());
+            }
+        };
+        if target_attr.ftype != FileType::Directory {
+            fs.abort_freeing(tombstone)?;
+            return Err(SystemError::ENOTDIR);
+        }
+        match concret_fs.listdir(target_num) {
+            Ok(entries) if entries.len() <= 2 => {}
+            Ok(_) => {
+                fs.abort_freeing(tombstone)?;
+                return Err(SystemError::ENOTEMPTY);
+            }
+            Err(error) => {
+                fs.abort_freeing(tombstone)?;
+                return Err(error.into());
+            }
+        }
+        let _reuse = fs.begin_reclaim();
+        let result = concret_fs.rmdir(inode_num, name).map_err(SystemError::from);
+        if let Err(error) = result {
+            let _ = fs.poison_freeing(tombstone, error.clone());
+            return Err(error);
+        }
+        match concret_fs.getattr(target_num) {
+            Ok(_) => {
+                let error = SystemError::EIO;
+                let _ = fs.poison_freeing(tombstone, error.clone());
+                return Err(error);
+            }
+            Err(error) => {
+                let error = SystemError::from(error);
+                if error == SystemError::EINVAL {
+                    fs.complete_freeing(tombstone)?;
+                } else {
+                    let _ = fs.poison_freeing(tombstone, error.clone());
+                    return Err(error);
+                }
+            }
+        }
         // 清理 children 缓存
         let _ = guard.children.remove(&DName::from(name));
 
@@ -644,6 +923,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn getxattr(&self, name: &str, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let guard = self.0.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
@@ -673,6 +953,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn setxattr(&self, name: &str, value: &[u8], flags: XattrFlags) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let guard = self.0.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
@@ -693,6 +974,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn listxattr(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let guard = self.0.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
@@ -724,6 +1006,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn removexattr(&self, name: &str) -> Result<usize, SystemError> {
+        let _operation = self.begin_operation()?;
         let guard = self.0.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
@@ -746,9 +1029,13 @@ impl IndexNode for LockedExt4Inode {
         if file_type == vfs::FileType::File {
             return self.create(filename, vfs::FileType::File, mode);
         }
+        let _operation = self.begin_operation()?;
+        let _namespace = self.3.lock();
 
         let mut guard = self.0.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let _reuse = fs.begin_allocation()?;
+        let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
         if ext4.getattr(inode_num)?.ftype != FileType::Directory {
@@ -779,12 +1066,13 @@ impl IndexNode for LockedExt4Inode {
         // Wrap as VFS inode and cache
         let dname = DName::from(filename);
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
-        let inode = LockedExt4Inode::new(
+        let inode = fs.publish_allocated_inode(
             id,
-            guard.fs_ptr.clone(),
             dname.clone(),
             Some(Arc::downgrade(&self_arc)),
-        );
+            Self::disk_file_type(file_type),
+            &_reuse,
+        )?;
         guard.children.insert(dname, inode.clone());
         drop(guard);
         Ok(inode as Arc<dyn IndexNode>)
@@ -801,10 +1089,12 @@ impl IndexNode for LockedExt4Inode {
         new_name: &str,
         flags: RenameFlags,
     ) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
         let target_locked = target
             .clone()
             .downcast_arc::<LockedExt4Inode>()
             .ok_or(SystemError::EXDEV)?;
+        let _target_operation = target_locked.begin_operation()?;
 
         let (ext4_fs, src_inode_num) = {
             let guard = self.0.lock();
@@ -812,6 +1102,17 @@ impl IndexNode for LockedExt4Inode {
         };
         let ext4 = &ext4_fs.fs;
         let target_inode_num = target_locked.0.lock().inner_inode_num;
+        if !Arc::ptr_eq(&ext4_fs, &target_locked.0.lock().concret_fs()) {
+            return Err(SystemError::EXDEV);
+        }
+
+        let (_first_namespace, _second_namespace) = if src_inode_num == target_inode_num {
+            (self.3.lock(), None)
+        } else if src_inode_num < target_inode_num {
+            (self.3.lock(), Some(target_locked.3.lock()))
+        } else {
+            (target_locked.3.lock(), Some(self.3.lock()))
+        };
 
         let old_dname = DName::from(old_name);
         let new_dname = DName::from(new_name);
@@ -843,55 +1144,288 @@ impl IndexNode for LockedExt4Inode {
             return Ok(());
         }
 
-        // Check if target exists (for cache update and page cache cleanup)
-        let had_dst = ext4.lookup(target_inode_num, new_name).is_ok();
-
-        // Clear target's page cache if it exists and is a file
-        if had_dst {
-            if let Ok(target_inode) = target_locked.find(new_name) {
-                if let Some(pc) = target_inode.page_cache() {
-                    truncate_inode_pages(pc, 0);
+        // Capture the replacement target while both parent namespace locks are held.
+        let dst_inode_num = ext4.lookup(target_inode_num, new_name).ok();
+        let src_child_num = ext4.lookup(src_inode_num, old_name)?;
+        if dst_inode_num == Some(src_child_num) {
+            return Ok(());
+        }
+        let had_dst = dst_inode_num.is_some();
+        let dst_inode = if let Some(dst_inode_num) = dst_inode_num {
+            let target_parent = target_locked
+                .0
+                .lock()
+                .self_ref
+                .upgrade()
+                .ok_or(SystemError::ENOENT)?;
+            Some(ext4_fs.get_or_create_inode(
+                dst_inode_num,
+                new_dname.clone(),
+                Some(Arc::downgrade(&target_parent)),
+            )?)
+        } else {
+            None
+        };
+        let dst_lifecycle = dst_inode.as_ref().map(|inode| inode.lifecycle().clone());
+        let _dst_link_mutation = dst_lifecycle
+            .as_ref()
+            .map(|lifecycle| lifecycle.lock_link_mutation());
+        if let Some(dst_inode_num) = dst_inode_num {
+            let src_type = ext4.getattr(src_child_num)?.ftype;
+            let dst_type = ext4.getattr(dst_inode_num)?.ftype;
+            match (
+                src_type == FileType::Directory,
+                dst_type == FileType::Directory,
+            ) {
+                (true, false) => return Err(SystemError::ENOTDIR),
+                (false, true) => return Err(SystemError::EISDIR),
+                (true, true) if ext4.listdir(dst_inode_num)?.len() > 2 => {
+                    return Err(SystemError::ENOTEMPTY);
                 }
+                _ => {}
             }
         }
 
+        let mut resulting_whiteout = None;
         if flags.contains(RenameFlags::WHITEOUT) {
+            // Prepare and drain the replacement target before changing the source
+            // namespace. No fallible target preparation may occur after exchange.
+            let mut tombstone = None;
+            let mut will_free = false;
+            if let (Some(dst_inode), Some(dst_inode_num)) = (&dst_inode, dst_inode_num) {
+                let attr = ext4.getattr(dst_inode_num)?;
+                will_free = if attr.ftype == FileType::Directory {
+                    attr.links <= 2
+                } else {
+                    attr.links <= 1
+                };
+                if will_free {
+                    tombstone = Some(ext4_fs.begin_freeing(dst_inode)?);
+                    if ext4.lookup(target_inode_num, new_name).ok() != Some(dst_inode_num) {
+                        ext4_fs.abort_freeing(tombstone.take().unwrap())?;
+                        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                    }
+                    let fresh_attr = match ext4.getattr(dst_inode_num) {
+                        Ok(attr) => attr,
+                        Err(error) => {
+                            ext4_fs.abort_freeing(tombstone.take().unwrap())?;
+                            return Err(error.into());
+                        }
+                    };
+                    if fresh_attr.ftype == FileType::Directory {
+                        match ext4.listdir(dst_inode_num) {
+                            Ok(entries) if entries.len() <= 2 => {}
+                            Ok(_) => {
+                                ext4_fs.abort_freeing(tombstone.take().unwrap())?;
+                                return Err(SystemError::ENOTEMPTY);
+                            }
+                            Err(error) => {
+                                ext4_fs.abort_freeing(tombstone.take().unwrap())?;
+                                return Err(error.into());
+                            }
+                        }
+                    }
+                }
+            }
+
             let mut temp_name = String::new();
+            let mut whiteout_inode = None;
+            let source_parent = self.0.lock().self_ref.upgrade().ok_or(SystemError::ENOENT)?;
             for _ in 0..32 {
                 let candidate = format!(".dragonos-whiteout-{}", generate_inode_id().data());
                 if ext4.lookup(src_inode_num, &candidate).is_ok() {
                     continue;
                 }
-                ext4.mknod(
-                    src_inode_num,
-                    &candidate,
-                    another_ext4::InodeMode::CHARDEV
-                        | another_ext4::InodeMode::from_bits_retain(0o600),
-                    WHITEOUT_DEV.major().data(),
-                    WHITEOUT_DEV.minor(),
-                )?;
+                let allocation = {
+                    match ext4_fs.begin_allocation() {
+                        Ok(guard) => guard,
+                        Err(error) => {
+                            if let Some(tombstone) = tombstone.take() {
+                                ext4_fs.abort_freeing(tombstone)?;
+                            }
+                            return Err(error);
+                        }
+                    }
+                };
+                let whiteout_num = match ext4.mknod(
+                        src_inode_num,
+                        &candidate,
+                        another_ext4::InodeMode::CHARDEV
+                            | another_ext4::InodeMode::from_bits_retain(0o600),
+                        WHITEOUT_DEV.major().data(),
+                        WHITEOUT_DEV.minor(),
+                    ) {
+                    Ok(inode_num) => inode_num,
+                    Err(error) => {
+                        if let Some(tombstone) = tombstone.take() {
+                            ext4_fs.abort_freeing(tombstone)?;
+                        }
+                        return Err(error.into());
+                    }
+                };
+                whiteout_inode = match ext4_fs.publish_allocated_inode(
+                    whiteout_num,
+                    DName::from(candidate.as_str()),
+                    Some(Arc::downgrade(&source_parent)),
+                    FileType::CharacterDev,
+                    &allocation,
+                ) {
+                    Ok(inode) => Some(inode),
+                    Err(error) => {
+                        drop(allocation);
+                        let _reclaim = ext4_fs.begin_reclaim();
+                        if ext4.unlink(src_inode_num, &candidate).is_err() {
+                            ext4_fs.fail_stop_lifecycle();
+                            if let Some(tombstone) = tombstone.take() {
+                                let _ = ext4_fs.poison_freeing(tombstone, SystemError::EIO);
+                            }
+                            return Err(SystemError::EIO);
+                        }
+                        if let Some(tombstone) = tombstone.take() {
+                            ext4_fs.abort_freeing(tombstone)?;
+                        }
+                        return Err(error);
+                    }
+                };
                 temp_name = candidate;
                 break;
             }
             if temp_name.is_empty() {
+                if let Some(tombstone) = tombstone.take() {
+                    ext4_fs.abort_freeing(tombstone)?;
+                }
                 return Err(SystemError::EEXIST);
             }
 
             if let Err(err) =
                 ext4.rename_exchange(src_inode_num, old_name, src_inode_num, &temp_name)
             {
-                let _ = ext4.unlink(src_inode_num, &temp_name);
+                if let Some(tombstone) = tombstone.take() {
+                    ext4_fs.abort_freeing(tombstone)?;
+                }
+                Self::reclaim_temporary_inode(
+                    &ext4_fs,
+                    src_inode_num,
+                    &temp_name,
+                    whiteout_inode.take().unwrap(),
+                )?;
                 return Err(err.into());
             }
-
+            let _reuse = tombstone.as_ref().map(|_| ext4_fs.begin_reclaim());
+            if will_free {
+                if let Some(pc) = dst_inode.as_ref().and_then(|inode| inode.page_cache()) {
+                    truncate_inode_pages(pc, 0);
+                }
+            }
             if let Err(err) = ext4.rename(src_inode_num, &temp_name, target_inode_num, new_name) {
-                let _ = ext4.rename_exchange(src_inode_num, old_name, src_inode_num, &temp_name);
-                let _ = ext4.unlink(src_inode_num, &temp_name);
-                return Err(err.into());
+                let rename_error = SystemError::from(err);
+                let rollback = ext4.rename_exchange(
+                    src_inode_num,
+                    old_name,
+                    src_inode_num,
+                    &temp_name,
+                );
+                if let Some(tombstone) = tombstone.take() {
+                    let _ = ext4_fs.poison_freeing(tombstone, rename_error.clone());
+                }
+                drop(_reuse);
+                if rollback.is_err() {
+                    let whiteout_tombstone = ext4_fs.begin_freeing(
+                        whiteout_inode.as_ref().expect("whiteout was published"),
+                    )?;
+                    let _ = ext4_fs.poison_freeing(whiteout_tombstone, SystemError::EIO);
+                    return Err(SystemError::EIO);
+                }
+                Self::reclaim_temporary_inode(
+                    &ext4_fs,
+                    src_inode_num,
+                    &temp_name,
+                    whiteout_inode.take().unwrap(),
+                )?;
+                return Err(rename_error);
             }
+            if let (Some(dst_inode_num), Some(tombstone)) = (dst_inode_num, tombstone.take()) {
+                match ext4.getattr(dst_inode_num) {
+                    Ok(_) => ext4_fs.abort_freeing(tombstone)?,
+                    Err(error) => {
+                        let error = SystemError::from(error);
+                        if error == SystemError::EINVAL {
+                            ext4_fs.complete_freeing(tombstone)?;
+                        } else {
+                            let _ = ext4_fs.poison_freeing(tombstone, error.clone());
+                            return Err(error);
+                        }
+                    }
+                }
+            }
+            if let Some(whiteout) = &whiteout_inode {
+                whiteout.0.lock().dname = old_dname.clone();
+            }
+            resulting_whiteout = whiteout_inode;
         } else {
-            // ext4 library now correctly handles atomic replace
-            ext4.rename(src_inode_num, old_name, target_inode_num, new_name)?;
+            if let Some(dst_inode) = &dst_inode {
+                let attr = ext4.getattr(dst_inode_num.unwrap())?;
+                let will_free = if attr.ftype == FileType::Directory {
+                    attr.links <= 2
+                } else {
+                    attr.links <= 1
+                };
+                if !will_free {
+                    ext4.rename(src_inode_num, old_name, target_inode_num, new_name)?;
+                } else {
+                    let tombstone = ext4_fs.begin_freeing(dst_inode)?;
+                    if ext4.lookup(target_inode_num, new_name).ok() != dst_inode_num {
+                        ext4_fs.abort_freeing(tombstone)?;
+                        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                    }
+                    let fresh_attr = match ext4.getattr(dst_inode_num.unwrap()) {
+                        Ok(attr) => attr,
+                        Err(error) => {
+                            ext4_fs.abort_freeing(tombstone)?;
+                            return Err(error.into());
+                        }
+                    };
+                    if fresh_attr.ftype == FileType::Directory {
+                        match ext4.listdir(dst_inode_num.unwrap()) {
+                            Ok(entries) if entries.len() <= 2 => {}
+                            Ok(_) => {
+                                ext4_fs.abort_freeing(tombstone)?;
+                                return Err(SystemError::ENOTEMPTY);
+                            }
+                            Err(error) => {
+                                ext4_fs.abort_freeing(tombstone)?;
+                                return Err(error.into());
+                            }
+                        }
+                    }
+                    let _reuse = ext4_fs.begin_reclaim();
+                    if let Some(pc) = dst_inode.page_cache() {
+                        truncate_inode_pages(pc, 0);
+                    }
+                    if let Err(err) =
+                        ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
+                    {
+                        let error = SystemError::from(err);
+                        let _ = ext4_fs.poison_freeing(tombstone, error.clone());
+                        return Err(error);
+                    }
+                    match ext4.getattr(dst_inode_num.unwrap()) {
+                        Ok(_) => ext4_fs.abort_freeing(tombstone)?,
+                        Err(error) => {
+                            let error = SystemError::from(error);
+                            if error == SystemError::EINVAL {
+                                ext4_fs.complete_freeing(tombstone)?;
+                            } else {
+                                let _ = ext4_fs.poison_freeing(tombstone, error.clone());
+                                return Err(error);
+                            }
+                        }
+                    }
+                }
+            } else {
+                // ext4 library now correctly handles atomic replace
+                ext4.rename(src_inode_num, old_name, target_inode_num, new_name)?;
+            }
         }
 
         // Update cache
@@ -903,11 +1437,71 @@ impl IndexNode for LockedExt4Inode {
             &new_dname,
             had_dst,
         );
+        if let Some(whiteout) = resulting_whiteout {
+            self.0.lock().children.insert(old_dname, whiteout);
+        }
         Ok(())
     }
 }
 
 impl LockedExt4Inode {
+    fn reclaim_temporary_inode(
+        fs: &Arc<Ext4FileSystem>,
+        parent_inode_num: u32,
+        name: &str,
+        inode: Arc<LockedExt4Inode>,
+    ) -> Result<(), SystemError> {
+        let lifecycle = inode.lifecycle().clone();
+        let _link_mutation = lifecycle.lock_link_mutation();
+        let tombstone = fs.begin_freeing(&inode)?;
+        let _reuse = fs.begin_reclaim();
+        if let Err(error) = fs.fs.unlink(parent_inode_num, name) {
+            let error = SystemError::from(error);
+            let _ = fs.poison_freeing(tombstone, error.clone());
+            return Err(error);
+        }
+        let inode_num = inode.0.lock().inner_inode_num;
+        match fs.fs.getattr(inode_num) {
+            Ok(_) => {
+                let error = SystemError::EIO;
+                let _ = fs.poison_freeing(tombstone, error.clone());
+                Err(error)
+            }
+            Err(error) => {
+                let error = SystemError::from(error);
+                if error == SystemError::EINVAL {
+                    fs.complete_freeing(tombstone)
+                } else {
+                    let _ = fs.poison_freeing(tombstone, error.clone());
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    fn disk_file_type(file_type: vfs::FileType) -> FileType {
+        match file_type {
+            vfs::FileType::Dir => FileType::Directory,
+            vfs::FileType::BlockDevice => FileType::BlockDev,
+            vfs::FileType::CharDevice
+            | vfs::FileType::FramebufferDevice
+            | vfs::FileType::KvmDevice => FileType::CharacterDev,
+            vfs::FileType::Pipe => FileType::Fifo,
+            vfs::FileType::SymLink => FileType::SymLink,
+            vfs::FileType::Socket => FileType::Socket,
+            vfs::FileType::File => FileType::RegularFile,
+        }
+    }
+
+    #[inline]
+    fn begin_operation(&self) -> Result<Ext4InodeOperation, SystemError> {
+        self.4.begin_operation()
+    }
+
+    pub(super) fn lifecycle(&self) -> &Arc<Ext4InodeLifecycle> {
+        &self.4
+    }
+
     /// 更新 rename 后的缓存
     fn update_rename_cache(
         &self,
@@ -1025,12 +1619,16 @@ impl LockedExt4Inode {
         fs_ptr: Weak<super::filesystem::Ext4FileSystem>,
         dname: DName,
         parent: Option<Weak<LockedExt4Inode>>,
-    ) -> Arc<Self> {
+        known_file_type: Option<FileType>,
+    ) -> Result<Arc<Self>, SystemError> {
+        let lifecycle = Ext4InodeLifecycle::new();
         let inode = Arc::new({
             LockedExt4Inode(
                 Mutex::new(Ext4Inode::new(inode_num, fs_ptr.clone(), dname, parent)),
                 Mutex::new(()),
                 RwSem::new(()),
+                Mutex::new(()),
+                lifecycle,
             )
         });
         let mut guard = inode.0.lock();
@@ -1049,17 +1647,19 @@ impl LockedExt4Inode {
 
         // 对于 FIFO，创建 pipe inode
         if let Some(fs) = fs_ptr.upgrade() {
-            if let Ok(attr) = fs.fs.getattr(inode_num) {
-                if attr.ftype == FileType::Fifo {
-                    let pipe_inode = LockedPipeInode::new();
-                    pipe_inode.set_fifo();
-                    guard.special_node = Some(SpecialNodeData::Pipe(pipe_inode));
-                }
+            let file_type = match known_file_type {
+                Some(file_type) => file_type,
+                None => fs.fs.getattr(inode_num)?.ftype,
+            };
+            if file_type == FileType::Fifo {
+                let pipe_inode = LockedPipeInode::new();
+                pipe_inode.set_fifo();
+                guard.special_node = Some(SpecialNodeData::Pipe(pipe_inode));
             }
         }
 
         drop(guard);
-        return inode;
+        Ok(inode)
     }
 
     fn file_type(ftype: FileType) -> vfs::FileType {
@@ -1111,6 +1711,7 @@ impl Ext4Inode {
 
 impl LockedExt4Inode {
     pub(super) fn flush_metadata(&self, datasync: bool) -> Result<(), SystemError> {
+        let _operation = self.begin_operation()?;
         let _io_guard = self.1.lock();
         let (fs, inode_num, dirty, cached_size, cached_mtime) = {
             let guard = self.0.lock();
@@ -1162,4 +1763,48 @@ impl Debug for Ext4Inode {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Ext4Inode")
     }
+}
+
+pub(crate) fn run_lifecycle_selftests() -> String {
+    let mut failures = 0usize;
+    let mut report = String::new();
+    let mut append = |name: &str, ok: bool| {
+        if ok {
+            report.push_str(&format!("{name}=ok\n"));
+        } else {
+            failures += 1;
+            report.push_str(&format!("{name}=fail\n"));
+        }
+    };
+
+    let lifecycle = Ext4InodeLifecycle::new();
+    let operation = lifecycle.begin_operation();
+    append("live_operation", operation.is_ok());
+    drop(operation);
+    append("begin_freeing", lifecycle.begin_freeing().is_ok());
+    lifecycle.wait_for_quiescent();
+    lifecycle.set_state(Ext4InodeLifecycleState::Retired);
+    append(
+        "retired_rejects_operation",
+        lifecycle.begin_operation().err() == Some(SystemError::ESTALE),
+    );
+
+    let lifecycle = Ext4InodeLifecycle::new();
+    append("abort_begin", lifecycle.begin_freeing().is_ok());
+    lifecycle.set_state(Ext4InodeLifecycleState::Live);
+    append("abort_restores_live", lifecycle.begin_operation().is_ok());
+
+    let lifecycle = Ext4InodeLifecycle::new();
+    lifecycle.set_state(Ext4InodeLifecycleState::Poisoned(SystemError::EIO));
+    append(
+        "poison_is_observable",
+        lifecycle.begin_operation().err() == Some(SystemError::EIO),
+    );
+
+    if failures == 0 {
+        report.insert_str(0, "status=ok\n");
+    } else {
+        report.insert_str(0, &format!("status=fail failures={failures}\n"));
+    }
+    report
 }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -16,6 +16,7 @@ use crate::{
         wait_queue::WaitQueue,
     },
     mm::{truncate::truncate_inode_pages, MemoryManagementArch},
+    process::{ProcessManager, RawPid},
     time::PosixTimeSpec,
 };
 use alloc::{
@@ -63,6 +64,7 @@ pub(super) enum Ext4InodeLifecycleState {
 struct Ext4InodeLifecycleInner {
     state: Ext4InodeLifecycleState,
     active_operations: usize,
+    operation_owners: BTreeMap<RawPid, usize>,
 }
 
 #[derive(Debug)]
@@ -78,6 +80,7 @@ impl Ext4InodeLifecycle {
             inner: Mutex::new(Ext4InodeLifecycleInner {
                 state: Ext4InodeLifecycleState::Live,
                 active_operations: 0,
+                operation_owners: BTreeMap::new(),
             }),
             link_mutation: Mutex::new(()),
             wait_queue: WaitQueue::default(),
@@ -94,21 +97,33 @@ impl Ext4InodeLifecycle {
     }
 
     pub(super) fn begin_operation(self: &Arc<Self>) -> Result<Ext4InodeOperation, SystemError> {
+        let owner = ProcessManager::current_pcb().raw_pid();
         let mut inner = self.inner.lock();
         match inner.state.clone() {
-            Ext4InodeLifecycleState::Live => {
-                inner.active_operations = inner
-                    .active_operations
-                    .checked_add(1)
-                    .ok_or(SystemError::EOVERFLOW)?;
-                Ok(Ext4InodeOperation {
-                    lifecycle: self.clone(),
-                })
-            }
-            Ext4InodeLifecycleState::Freeing => Err(SystemError::EBUSY),
-            Ext4InodeLifecycleState::Retired => Err(SystemError::ESTALE),
-            Ext4InodeLifecycleState::Poisoned(error) => Err(error),
+            Ext4InodeLifecycleState::Live => {}
+            Ext4InodeLifecycleState::Freeing if inner.operation_owners.contains_key(&owner) => {}
+            Ext4InodeLifecycleState::Freeing => return Err(SystemError::EBUSY),
+            Ext4InodeLifecycleState::Retired => return Err(SystemError::ESTALE),
+            Ext4InodeLifecycleState::Poisoned(error) => return Err(error),
         }
+
+        let active_operations = inner
+            .active_operations
+            .checked_add(1)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let owner_depth = inner
+            .operation_owners
+            .get(&owner)
+            .copied()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or(SystemError::EOVERFLOW)?;
+        inner.active_operations = active_operations;
+        inner.operation_owners.insert(owner, owner_depth);
+        Ok(Ext4InodeOperation {
+            lifecycle: self.clone(),
+            owner,
+        })
     }
 
     pub(super) fn begin_freeing(&self) -> Result<(), SystemError> {
@@ -147,6 +162,7 @@ impl Ext4InodeLifecycle {
 #[must_use]
 pub(super) struct Ext4InodeOperation {
     lifecycle: Arc<Ext4InodeLifecycle>,
+    owner: RawPid,
 }
 
 impl Drop for Ext4InodeOperation {
@@ -155,6 +171,18 @@ impl Drop for Ext4InodeOperation {
             let mut inner = self.lifecycle.inner.lock();
             debug_assert!(inner.active_operations > 0);
             inner.active_operations = inner.active_operations.saturating_sub(1);
+            let remove_owner = if let Some(owner_depth) = inner.operation_owners.get_mut(&self.owner)
+            {
+                debug_assert!(*owner_depth > 0);
+                *owner_depth = owner_depth.saturating_sub(1);
+                *owner_depth == 0
+            } else {
+                debug_assert!(false, "missing ext4 lifecycle operation owner");
+                false
+            };
+            if remove_owner {
+                inner.operation_owners.remove(&self.owner);
+            }
             inner.active_operations == 0
         };
         if should_wake {
@@ -1787,6 +1815,19 @@ pub(crate) fn run_lifecycle_selftests() -> String {
     append(
         "retired_rejects_operation",
         lifecycle.begin_operation().err() == Some(SystemError::ESTALE),
+    );
+
+    let lifecycle = Ext4InodeLifecycle::new();
+    let outer = lifecycle.begin_operation().expect("live operation");
+    append("reentrant_begin_freeing", lifecycle.begin_freeing().is_ok());
+    let nested = lifecycle.begin_operation();
+    append("freeing_allows_owner_nested_operation", nested.is_ok());
+    drop(nested);
+    drop(outer);
+    lifecycle.wait_for_quiescent();
+    append(
+        "reentrant_operations_drained",
+        lifecycle.inner.lock().active_operations == 0,
     );
 
     let lifecycle = Ext4InodeLifecycle::new();

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -870,6 +870,13 @@ impl IndexNode for LockedExt4Inode {
             return Err(SystemError::ENOTDIR);
         }
         let target_num = concret_fs.lookup(inode_num, name)?;
+        if target_num == inode_num {
+            return Err(if name == "." {
+                SystemError::EINVAL
+            } else {
+                SystemError::ENOTEMPTY
+            });
+        }
         if concret_fs.getattr(target_num)?.ftype != FileType::Directory {
             return Err(SystemError::ENOTDIR);
         }

--- a/kernel/src/filesystem/procfs/pid/fd.rs
+++ b/kernel/src/filesystem/procfs/pid/fd.rs
@@ -9,6 +9,7 @@ use crate::filesystem::{
     },
     vfs::{IndexNode, InodeMode, SpecialNodeData},
 };
+use crate::libs::casting::DowncastArc;
 use alloc::{
     format,
     string::ToString,
@@ -149,11 +150,20 @@ impl SymOps for FdSymOps {
             .unwrap_or_default();
 
         // 现在安全地获取文件的路径
-        let mut path = if let Ok(p) = file.inode().absolute_path() {
+        let inode = file.inode();
+        let path_result = if let Some(mount_inode) = inode
+            .clone()
+            .downcast_arc::<crate::filesystem::vfs::mount::MountFSInode>(
+        ) {
+            mount_inode.procfs_path()
+        } else {
+            inode.absolute_path()
+        };
+        let mut path = if let Ok(p) = path_result {
             p
         } else {
             // 匿名文件或无法获取路径
-            let inode_id = file.inode().metadata()?.inode_id;
+            let inode_id = inode.metadata()?.inode_id;
             format!("anon_inode:[{}]", inode_id)
         };
 

--- a/kernel/src/filesystem/procfs/pid/maps.rs
+++ b/kernel/src/filesystem/procfs/pid/maps.rs
@@ -2,7 +2,7 @@
 //!
 //! 返回进程的内存映射信息，格式兼容 Linux procfs
 
-use crate::libs::mutex::MutexGuard;
+use crate::libs::{casting::DowncastArc, mutex::MutexGuard};
 use crate::{
     arch::MMArch,
     filesystem::{
@@ -67,7 +67,7 @@ fn perms_from_vm_flags(vm_flags: VmFlags) -> [u8; 4] {
 /// 格式化设备号、inode 和路径
 #[inline(never)]
 fn format_dev_inode_and_path(
-    file_inode: Option<&dyn IndexNode>,
+    file_inode: Option<&Arc<dyn IndexNode>>,
     root_prefix: &str,
 ) -> (String, String) {
     if let Some(inode) = file_inode {
@@ -75,7 +75,12 @@ fn format_dev_inode_and_path(
             Ok(md) => {
                 let dev = format!("{:02x}:{:02x}", (md.dev_id >> 8) & 0xff, md.dev_id & 0xff);
                 let ino = md.inode_id.into();
-                let mut path = inode.absolute_path().unwrap_or_default();
+                let mut path = inode
+                    .clone()
+                    .downcast_arc::<crate::filesystem::vfs::mount::MountFSInode>()
+                    .map(|inode| inode.procfs_path())
+                    .unwrap_or_else(|| inode.absolute_path())
+                    .unwrap_or_default();
                 // 尊重进程的 chroot：去掉根目录前缀
                 if !root_prefix.is_empty() && root_prefix != "/" {
                     if let Some(rest) = path.strip_prefix(root_prefix) {
@@ -140,7 +145,7 @@ fn generate_maps_content(target: &ProcPidTarget) -> Result<Vec<u8>, SystemError>
 
         let (dev_ino, path_tail) = if let Some(f) = g.vm_file() {
             let inode = f.inode();
-            format_dev_inode_and_path(Some(inode.as_ref()), &root_prefix)
+            format_dev_inode_and_path(Some(&inode), &root_prefix)
         } else {
             format_dev_inode_and_path(None, &root_prefix)
         };

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -269,6 +269,13 @@ pub struct MountFS {
     inner_filesystem: Arc<dyn FileSystem>,
     /// The root inode exposed by this mount. For bind-mount subdirectories, this is not the global root of the underlying filesystem.
     root_inner_inode: Arc<dyn IndexNode>,
+    /// Stable VFS wrapper for the root of this mount. Besides avoiding needless
+    /// allocations, this keeps the root dentry's child cache shared by all
+    /// lookups that enter the mount.
+    root_inode: Mutex<Weak<MountFSInode>>,
+    /// Serializes directory mutations against lookups while allowing lookups
+    /// within the mount to proceed concurrently.
+    dentry_namespace_lock: RwSem<()>,
     /// B-tree mapping InodeId -> MountFS at that mount point
     mountpoints: Mutex<BTreeMap<InodeId, Arc<MountFS>>>,
     /// The inode of the mount point where this filesystem is mounted
@@ -386,6 +393,16 @@ pub struct MountFSInode {
     mount_fs: Arc<MountFS>,
     /// Weak reference to self
     self_ref: Weak<MountFSInode>,
+    /// Alias-specific dentry identity. The underlying inode may be shared by hard links.
+    dentry: Mutex<MountDentryState>,
+}
+
+#[derive(Debug, Default)]
+struct MountDentryState {
+    name: Option<DName>,
+    parent: Option<Arc<MountFSInode>>,
+    children: BTreeMap<DName, Weak<MountFSInode>>,
+    disconnected: bool,
 }
 
 impl MountFS {
@@ -425,6 +442,8 @@ impl MountFS {
         let result = Arc::new_cyclic(|self_ref| MountFS {
             inner_filesystem,
             root_inner_inode,
+            root_inode: Mutex::new(Weak::new()),
+            dentry_namespace_lock: RwSem::new(()),
             mountpoints: Mutex::new(BTreeMap::new()),
             self_mountpoint: RwSem::new(self_mountpoint),
             self_ref: self_ref.clone(),
@@ -452,6 +471,8 @@ impl MountFS {
         let mountfs = Arc::new_cyclic(|self_ref| MountFS {
             inner_filesystem: self.inner_filesystem.clone(),
             root_inner_inode: self.root_inner_inode.clone(),
+            root_inode: Mutex::new(Weak::new()),
+            dentry_namespace_lock: RwSem::new(()),
             mountpoints: Mutex::new(BTreeMap::new()),
             self_mountpoint: RwSem::new(self_mountpoint),
             self_ref: self_ref.clone(),
@@ -602,11 +623,17 @@ impl MountFS {
 
     /// @brief Get the root inode of the filesystem at this mount point
     pub fn mountpoint_root_inode(&self) -> Arc<MountFSInode> {
-        return Arc::new_cyclic(|self_ref| MountFSInode {
-            inner_inode: self.root_inner_inode.clone(),
-            mount_fs: self.self_ref.upgrade().unwrap(),
-            self_ref: self_ref.clone(),
-        });
+        let mut root_inode = self.root_inode.lock();
+        if let Some(inode) = root_inode.upgrade() {
+            return inode;
+        }
+
+        let inode = MountFSInode::new_root(
+            self.root_inner_inode.clone(),
+            self.self_ref.upgrade().unwrap(),
+        );
+        *root_inode = Arc::downgrade(&inode);
+        inode
     }
 
     pub fn inner_filesystem(&self) -> Arc<dyn FileSystem> {
@@ -891,6 +918,141 @@ impl Drop for MountFS {
 }
 
 impl MountFSInode {
+    fn new_root(inner_inode: Arc<dyn IndexNode>, mount_fs: Arc<MountFS>) -> Arc<Self> {
+        Arc::new_cyclic(|self_ref| Self {
+            inner_inode,
+            mount_fs,
+            self_ref: self_ref.clone(),
+            dentry: Mutex::new(MountDentryState::default()),
+        })
+    }
+
+    fn new_child(
+        inner_inode: Arc<dyn IndexNode>,
+        mount_fs: Arc<MountFS>,
+        parent: &Arc<MountFSInode>,
+        name: DName,
+    ) -> Arc<Self> {
+        let mut parent_state = parent.dentry.lock();
+        if let Some(cached) = parent_state.children.get(&name).and_then(Weak::upgrade) {
+            if cached
+                .inner_inode
+                .metadata()
+                .ok()
+                .zip(inner_inode.metadata().ok())
+                .is_some_and(|(cached, found)| cached.inode_id == found.inode_id)
+            {
+                return cached;
+            }
+        }
+        let inode = Arc::new_cyclic(|self_ref| Self {
+            inner_inode,
+            mount_fs,
+            self_ref: self_ref.clone(),
+            dentry: Mutex::new(MountDentryState {
+                name: Some(name.clone()),
+                parent: Some(parent.clone()),
+                children: BTreeMap::new(),
+                disconnected: false,
+            }),
+        });
+        parent_state.children.insert(name, Arc::downgrade(&inode));
+        inode
+    }
+
+    fn update_move_dentries(
+        source: &Arc<MountFSInode>,
+        old_name: DName,
+        target: &Arc<MountFSInode>,
+        new_name: DName,
+        exchange: bool,
+    ) {
+        fn update_locked(
+            source_state: &mut MountDentryState,
+            old_name: &DName,
+            target_state: &mut MountDentryState,
+            new_name: &DName,
+            exchange: bool,
+        ) -> (Option<Arc<MountFSInode>>, Option<Arc<MountFSInode>>) {
+            let old_child = source_state
+                .children
+                .remove(old_name)
+                .and_then(|w| w.upgrade());
+            let new_child = target_state
+                .children
+                .remove(new_name)
+                .and_then(|w| w.upgrade());
+            if let Some(child) = &old_child {
+                target_state
+                    .children
+                    .insert(new_name.clone(), Arc::downgrade(child));
+            }
+            if exchange {
+                if let Some(child) = &new_child {
+                    source_state
+                        .children
+                        .insert(old_name.clone(), Arc::downgrade(child));
+                }
+            }
+            (old_child, new_child)
+        }
+
+        let same_parent = Arc::ptr_eq(source, target);
+        let (old_child, new_child) = if same_parent {
+            let mut state = source.dentry.lock();
+            let old_child = state.children.remove(&old_name).and_then(|w| w.upgrade());
+            let new_child = state.children.remove(&new_name).and_then(|w| w.upgrade());
+            if let Some(child) = &old_child {
+                state
+                    .children
+                    .insert(new_name.clone(), Arc::downgrade(child));
+            }
+            if exchange {
+                if let Some(child) = &new_child {
+                    state
+                        .children
+                        .insert(old_name.clone(), Arc::downgrade(child));
+                }
+            }
+            (old_child, new_child)
+        } else if Arc::as_ptr(source) < Arc::as_ptr(target) {
+            let mut source_state = source.dentry.lock();
+            let mut target_state = target.dentry.lock();
+            update_locked(
+                &mut source_state,
+                &old_name,
+                &mut target_state,
+                &new_name,
+                exchange,
+            )
+        } else {
+            let mut target_state = target.dentry.lock();
+            let mut source_state = source.dentry.lock();
+            update_locked(
+                &mut source_state,
+                &old_name,
+                &mut target_state,
+                &new_name,
+                exchange,
+            )
+        };
+
+        if let Some(child) = old_child {
+            let mut state = child.dentry.lock();
+            state.name = Some(new_name);
+            state.parent = Some(target.clone());
+        }
+        if let Some(child) = new_child {
+            let mut state = child.dentry.lock();
+            if exchange {
+                state.name = Some(old_name);
+                state.parent = Some(source.clone());
+            } else {
+                state.disconnected = true;
+            }
+        }
+    }
+
     #[inline]
     fn ensure_mount_writable(&self) -> Result<(), SystemError> {
         if self.mount_fs.is_readonly() {
@@ -1069,13 +1231,26 @@ impl MountFSInode {
 
     fn do_find(&self, name: &str) -> Result<Arc<MountFSInode>, SystemError> {
         let base = self.overlaid_inode();
+        let _namespace_guard = base.mount_fs.dentry_namespace_lock.read();
         // Directly call the find method of the filesystem the current inode belongs to.
         // Since downward lookups may cross filesystem boundaries, we need to attempt inode replacement.
         let inner_inode = base.inner_inode.find(name)?;
-        let mount_inode = Arc::new_cyclic(|self_ref| MountFSInode {
-            inner_inode: inner_inode.clone(),
-            mount_fs: base.mount_fs.clone(),
-            self_ref: self_ref.clone(),
+        let dname = DName::from(name);
+        let inode_id = inner_inode.metadata()?.inode_id;
+        let cached = base
+            .dentry
+            .lock()
+            .children
+            .get(&dname)
+            .and_then(Weak::upgrade)
+            .filter(|cached| {
+                cached
+                    .inner_inode
+                    .metadata()
+                    .is_ok_and(|metadata| metadata.inode_id == inode_id)
+            });
+        let mount_inode = cached.unwrap_or_else(|| {
+            MountFSInode::new_child(inner_inode.clone(), base.mount_fs.clone(), &base, dname)
         });
         if let Some(fuse_node) =
             inner_inode.downcast_arc::<crate::filesystem::fuse::inode::FuseNode>()
@@ -1114,15 +1289,13 @@ impl MountFSInode {
                     return Ok(self.self_ref.upgrade().unwrap());
                 }
             }
-        } else {
-            let inner_inode = self.inner_inode.parent()?;
-            // When looking up parent, we don't cross filesystem boundaries, so directly call the parent method of the current inode's filesystem
-            return Ok(Arc::new_cyclic(|self_ref| MountFSInode {
-                inner_inode,
-                mount_fs: self.mount_fs.clone(),
-                self_ref: self_ref.clone(),
-            }));
         }
+        if let Some(parent) = self.dentry.lock().parent.clone() {
+            return Ok(parent);
+        }
+        let inner_inode = self.inner_inode.parent()?;
+        // Legacy fallback for wrappers constructed without a lookup dentry.
+        return Ok(MountFSInode::new_root(inner_inode, self.mount_fs.clone()));
     }
 
     /// Remove the filesystem mounted at this mount point
@@ -1163,8 +1336,20 @@ impl MountFSInode {
         return Ok(child_mount);
     }
 
-    #[inline(never)]
     fn do_absolute_path(&self) -> Result<String, SystemError> {
+        self.do_absolute_path_impl(false)
+    }
+
+    pub(crate) fn procfs_path(&self) -> Result<String, SystemError> {
+        let mut path = self.do_absolute_path_impl(true)?;
+        if self.dentry.lock().disconnected {
+            path.push_str(" (deleted)");
+        }
+        Ok(path)
+    }
+
+    #[inline(never)]
+    fn do_absolute_path_impl(&self, allow_disconnected: bool) -> Result<String, SystemError> {
         // Prefer mount_list records: FUSE/virtiofs inodes may report synthetic paths
         // such as "fuse:<nodeid>" from absolute_path(), which breaks MS_MOVE path rewrite.
         if self.is_mountpoint_root()? {
@@ -1178,10 +1363,19 @@ impl MountFSInode {
 
         let mut current = self.self_ref.upgrade().unwrap();
 
-        // Only accept filesystem-provided paths that look like real VFS paths.
-        if let Ok(p) = current.inner_inode.absolute_path() {
-            if p.starts_with('/') {
-                return Ok(p);
+        // A lookup-created wrapper has authoritative alias-specific dentry identity.
+        // Filesystem-provided paths are only a fallback for roots/legacy wrappers.
+        let current_state = current.dentry.lock();
+        if current_state.disconnected && !allow_disconnected {
+            return Err(SystemError::ENOENT);
+        }
+        let use_inner_path = current_state.name.is_none();
+        drop(current_state);
+        if use_inner_path {
+            if let Ok(p) = current.inner_inode.absolute_path() {
+                if p.starts_with('/') {
+                    return Ok(p);
+                }
             }
         }
 
@@ -1252,11 +1446,7 @@ impl MountFSInode {
     }
 
     pub fn clone_with_new_mount_fs(&self, mount_fs: Arc<MountFS>) -> Arc<MountFSInode> {
-        Arc::new_cyclic(|self_ref| MountFSInode {
-            inner_inode: self.inner_inode.clone(),
-            mount_fs,
-            self_ref: self_ref.clone(),
-        })
+        MountFSInode::new_root(self.inner_inode.clone(), mount_fs)
     }
 
     pub fn mount_fs(&self) -> Arc<MountFS> {
@@ -1383,14 +1573,17 @@ impl IndexNode for MountFSInode {
         data: usize,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         let inner_inode = self
             .inner_inode
             .create_with_data(name, file_type, mode, data)?;
-        return Ok(Arc::new_cyclic(|self_ref| MountFSInode {
+        let parent = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        return Ok(MountFSInode::new_child(
             inner_inode,
-            mount_fs: self.mount_fs.clone(),
-            self_ref: self_ref.clone(),
-        }));
+            self.mount_fs.clone(),
+            &parent,
+            DName::from(name),
+        ));
     }
 
     fn truncate(&self, len: usize) -> Result<(), SystemError> {
@@ -1522,16 +1715,20 @@ impl IndexNode for MountFSInode {
         mode: InodeMode,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         let inner_inode = self.inner_inode.create(name, file_type, mode)?;
-        return Ok(Arc::new_cyclic(|self_ref| MountFSInode {
+        let parent = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        return Ok(MountFSInode::new_child(
             inner_inode,
-            mount_fs: self.mount_fs.clone(),
-            self_ref: self_ref.clone(),
-        }));
+            self.mount_fs.clone(),
+            &parent,
+            DName::from(name),
+        ));
     }
 
     fn link(&self, name: &str, other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         // Filesystem implementations expect `other` to be an inode of the same concrete filesystem (e.g. LockedExt4Inode).
         // When VFS mount wrapping is enabled, `other` is typically a `MountFSInode`, which causes
         // filesystem-level downcasts to fail and incorrectly return EINVAL.
@@ -1548,18 +1745,22 @@ impl IndexNode for MountFSInode {
 
     fn symlink(&self, name: &str, target: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         let inner_inode = self.inner_inode.symlink(name, target)?;
-        Ok(Arc::new_cyclic(|self_ref| MountFSInode {
+        let parent = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        Ok(MountFSInode::new_child(
             inner_inode,
-            mount_fs: self.mount_fs.clone(),
-            self_ref: self_ref.clone(),
-        }))
+            self.mount_fs.clone(),
+            &parent,
+            DName::from(name),
+        ))
     }
 
     /// @brief Delete a file/directory in the mounted filesystem
     #[inline]
     fn unlink(&self, name: &str) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         let inode_id = self.inner_inode.find(name)?.metadata()?.inode_id;
 
         // First check if this inode is a mount point; if so, it cannot be deleted
@@ -1567,12 +1768,24 @@ impl IndexNode for MountFSInode {
             return Err(SystemError::EBUSY);
         }
         // Delegate to the inner inode's unlink method to delete this inode
-        return self.inner_inode.unlink(name);
+        self.inner_inode.unlink(name)?;
+        if let Some(child) = self
+            .dentry
+            .lock()
+            .children
+            .remove(&DName::from(name))
+            .and_then(|w| w.upgrade())
+        {
+            let mut state = child.dentry.lock();
+            state.disconnected = true;
+        }
+        return Ok(());
     }
 
     #[inline]
     fn rmdir(&self, name: &str) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         let inode_id = self.inner_inode.find(name)?.metadata()?.inode_id;
 
         // First check if this inode is a mount point; if so, it cannot be deleted
@@ -1580,9 +1793,18 @@ impl IndexNode for MountFSInode {
             return Err(SystemError::EBUSY);
         }
         // Delegate to the inner inode's rmdir method to delete this inode
-        let r = self.inner_inode.rmdir(name);
-
-        return r;
+        self.inner_inode.rmdir(name)?;
+        if let Some(child) = self
+            .dentry
+            .lock()
+            .children
+            .remove(&DName::from(name))
+            .and_then(|w| w.upgrade())
+        {
+            let mut state = child.dentry.lock();
+            state.disconnected = true;
+        }
+        return Ok(());
     }
 
     #[inline]
@@ -1594,21 +1816,31 @@ impl IndexNode for MountFSInode {
         flags: RenameFlags,
     ) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         // Filesystem implementations generally expect `target` to be an inode
         // of the same concrete FS (e.g. tmpfs' LockedTmpfsInode). When VFS
         // mount wrapping is enabled, `target` is often a `MountFSInode`, which
         // would make FS-level downcasts fail and incorrectly return EINVAL.
         //
         // So we unwrap the mount wrapper before delegating.
-        let target_inner: Arc<dyn IndexNode> = target
-            .clone()
-            .downcast_arc::<MountFSInode>()
+        let target_mount = target.clone().downcast_arc::<MountFSInode>();
+        let target_inner: Arc<dyn IndexNode> = target_mount
+            .as_ref()
             .map(|mnt| mnt.inner_inode.clone())
             .unwrap_or_else(|| target.clone());
 
-        return self
-            .inner_inode
-            .move_to(old_name, &target_inner, new_name, flags);
+        self.inner_inode
+            .move_to(old_name, &target_inner, new_name, flags)?;
+        if let (Some(source), Some(target)) = (self.self_ref.upgrade(), target_mount) {
+            Self::update_move_dentries(
+                &source,
+                DName::from(old_name),
+                &target,
+                DName::from(new_name),
+                flags.contains(RenameFlags::EXCHANGE),
+            );
+        }
+        return Ok(());
     }
 
     fn check_access(
@@ -1748,12 +1980,15 @@ impl IndexNode for MountFSInode {
         dev_t: DeviceNumber,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
+        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
         let inner_inode = self.inner_inode.mknod(filename, mode, dev_t)?;
-        return Ok(Arc::new_cyclic(|self_ref| MountFSInode {
+        let parent = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        return Ok(MountFSInode::new_child(
             inner_inode,
-            mount_fs: self.mount_fs.clone(),
-            self_ref: self_ref.clone(),
-        }));
+            self.mount_fs.clone(),
+            &parent,
+            DName::from(filename),
+        ));
     }
 
     #[inline]
@@ -1768,8 +2003,14 @@ impl IndexNode for MountFSInode {
     fn dname(&self) -> Result<DName, SystemError> {
         if self.is_mountpoint_root()? {
             if let Some(inode) = self.mount_fs.self_mountpoint() {
+                if let Some(name) = inode.dentry.lock().name.clone() {
+                    return Ok(name);
+                }
                 return inode.inner_inode.dname();
             }
+        }
+        if let Some(name) = self.dentry.lock().name.clone() {
+            return Ok(name);
         }
         return self.inner_inode.dname();
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -325,6 +325,20 @@ impl SuperBlockState {
     }
 
     fn dentry_state(&self, parent: InodeId, child: InodeId, name: DName) -> Arc<AtomicBool> {
+        self.get_dentry_state(parent, child, name, false)
+    }
+
+    fn live_dentry_state(&self, parent: InodeId, child: InodeId, name: DName) -> Arc<AtomicBool> {
+        self.get_dentry_state(parent, child, name, true)
+    }
+
+    fn get_dentry_state(
+        &self,
+        parent: InodeId,
+        child: InodeId,
+        name: DName,
+        require_live: bool,
+    ) -> Arc<AtomicBool> {
         let key = DentryKey {
             parent,
             child,
@@ -332,7 +346,9 @@ impl SuperBlockState {
         };
         let mut states = self.dentry_states.lock();
         if let Some(state) = states.get(&key).and_then(Weak::upgrade) {
-            return state;
+            if !require_live || !state.load(Ordering::Acquire) {
+                return state;
+            }
         }
         // Keep dead weak entries bounded without adding work to every lookup.
         if !states.is_empty() && states.len().is_multiple_of(256) {
@@ -961,12 +977,13 @@ impl MountFSInode {
     ) -> Arc<Self> {
         let mut parent_state = parent.dentry.lock();
         if let Some(cached) = parent_state.children.get(&name).and_then(Weak::upgrade) {
-            if cached
-                .inner_inode
-                .metadata()
-                .ok()
-                .zip(inner_inode.metadata().ok())
-                .is_some_and(|(cached, found)| cached.inode_id == found.inode_id)
+            if !cached.dentry.lock().disconnected.load(Ordering::Acquire)
+                && cached
+                    .inner_inode
+                    .metadata()
+                    .ok()
+                    .zip(inner_inode.metadata().ok())
+                    .is_some_and(|(cached, found)| cached.inode_id == found.inode_id)
             {
                 return cached;
             }
@@ -977,7 +994,7 @@ impl MountFSInode {
             .ok()
             .zip(inner_inode.metadata().ok())
             .map(|(parent, child)| {
-                mount_fs.super_block_state.dentry_state(
+                mount_fs.super_block_state.live_dentry_state(
                     parent.inode_id,
                     child.inode_id,
                     name.clone(),
@@ -1283,10 +1300,11 @@ impl MountFSInode {
             .get(&dname)
             .and_then(Weak::upgrade)
             .filter(|cached| {
-                cached
-                    .inner_inode
-                    .metadata()
-                    .is_ok_and(|metadata| metadata.inode_id == inode_id)
+                !cached.dentry.lock().disconnected.load(Ordering::Acquire)
+                    && cached
+                        .inner_inode
+                        .metadata()
+                        .is_ok_and(|metadata| metadata.inode_id == inode_id)
             });
         let mount_inode = cached.unwrap_or_else(|| {
             MountFSInode::new_child(inner_inode.clone(), base.mount_fs.clone(), &base, dname)

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -41,7 +41,7 @@ use core::{
     fmt::Debug,
     hash::Hash,
     mem,
-    sync::atomic::{compiler_fence, AtomicUsize, Ordering},
+    sync::atomic::{compiler_fence, AtomicBool, AtomicUsize, Ordering},
 };
 use hashbrown::HashMap;
 use ida::IdAllocator;
@@ -273,9 +273,6 @@ pub struct MountFS {
     /// allocations, this keeps the root dentry's child cache shared by all
     /// lookups that enter the mount.
     root_inode: Mutex<Weak<MountFSInode>>,
-    /// Serializes directory mutations against lookups while allowing lookups
-    /// within the mount to proceed concurrently.
-    dentry_namespace_lock: RwSem<()>,
     /// B-tree mapping InodeId -> MountFS at that mount point
     mountpoints: Mutex<BTreeMap<InodeId, Arc<MountFS>>>,
     /// The inode of the mount point where this filesystem is mounted
@@ -298,6 +295,16 @@ pub struct SuperBlockState {
     write_count: AtomicUsize,
     wb_error: ErrSeq,
     umount_lock: RwSem<()>,
+    /// Shared by all mounts of this superblock, including bind mounts.
+    dentry_namespace_lock: RwSem<()>,
+    dentry_states: Mutex<BTreeMap<DentryKey, Weak<AtomicBool>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct DentryKey {
+    parent: InodeId,
+    child: InodeId,
+    name: DName,
 }
 
 struct MountStateInit {
@@ -312,7 +319,28 @@ impl SuperBlockState {
             write_count: AtomicUsize::new(0),
             wb_error: ErrSeq::new(),
             umount_lock: RwSem::new(()),
+            dentry_namespace_lock: RwSem::new(()),
+            dentry_states: Mutex::new(BTreeMap::new()),
         }
+    }
+
+    fn dentry_state(&self, parent: InodeId, child: InodeId, name: DName) -> Arc<AtomicBool> {
+        let key = DentryKey {
+            parent,
+            child,
+            name,
+        };
+        let mut states = self.dentry_states.lock();
+        if let Some(state) = states.get(&key).and_then(Weak::upgrade) {
+            return state;
+        }
+        // Keep dead weak entries bounded without adding work to every lookup.
+        if !states.is_empty() && states.len().is_multiple_of(256) {
+            states.retain(|_, state| state.strong_count() != 0);
+        }
+        let state = Arc::new(AtomicBool::new(false));
+        states.insert(key, Arc::downgrade(&state));
+        state
     }
 
     pub fn flags(&self) -> MountFlags {
@@ -402,7 +430,7 @@ struct MountDentryState {
     name: Option<DName>,
     parent: Option<Arc<MountFSInode>>,
     children: BTreeMap<DName, Weak<MountFSInode>>,
-    disconnected: bool,
+    disconnected: Arc<AtomicBool>,
 }
 
 impl MountFS {
@@ -443,7 +471,6 @@ impl MountFS {
             inner_filesystem,
             root_inner_inode,
             root_inode: Mutex::new(Weak::new()),
-            dentry_namespace_lock: RwSem::new(()),
             mountpoints: Mutex::new(BTreeMap::new()),
             self_mountpoint: RwSem::new(self_mountpoint),
             self_ref: self_ref.clone(),
@@ -472,7 +499,6 @@ impl MountFS {
             inner_filesystem: self.inner_filesystem.clone(),
             root_inner_inode: self.root_inner_inode.clone(),
             root_inode: Mutex::new(Weak::new()),
-            dentry_namespace_lock: RwSem::new(()),
             mountpoints: Mutex::new(BTreeMap::new()),
             self_mountpoint: RwSem::new(self_mountpoint),
             self_ref: self_ref.clone(),
@@ -945,6 +971,19 @@ impl MountFSInode {
                 return cached;
             }
         }
+        let disconnected = parent
+            .inner_inode
+            .metadata()
+            .ok()
+            .zip(inner_inode.metadata().ok())
+            .map(|(parent, child)| {
+                mount_fs.super_block_state.dentry_state(
+                    parent.inode_id,
+                    child.inode_id,
+                    name.clone(),
+                )
+            })
+            .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
         let inode = Arc::new_cyclic(|self_ref| Self {
             inner_inode,
             mount_fs,
@@ -953,7 +992,7 @@ impl MountFSInode {
                 name: Some(name.clone()),
                 parent: Some(parent.clone()),
                 children: BTreeMap::new(),
-                disconnected: false,
+                disconnected,
             }),
         });
         parent_state.children.insert(name, Arc::downgrade(&inode));
@@ -1048,7 +1087,7 @@ impl MountFSInode {
                 state.name = Some(old_name);
                 state.parent = Some(source.clone());
             } else {
-                state.disconnected = true;
+                state.disconnected.store(true, Ordering::Release);
             }
         }
     }
@@ -1231,7 +1270,7 @@ impl MountFSInode {
 
     fn do_find(&self, name: &str) -> Result<Arc<MountFSInode>, SystemError> {
         let base = self.overlaid_inode();
-        let _namespace_guard = base.mount_fs.dentry_namespace_lock.read();
+        let _namespace_guard = base.mount_fs.super_block_state.dentry_namespace_lock.read();
         // Directly call the find method of the filesystem the current inode belongs to.
         // Since downward lookups may cross filesystem boundaries, we need to attempt inode replacement.
         let inner_inode = base.inner_inode.find(name)?;
@@ -1342,7 +1381,7 @@ impl MountFSInode {
 
     pub(crate) fn procfs_path(&self) -> Result<String, SystemError> {
         let mut path = self.do_absolute_path_impl(true)?;
-        if self.dentry.lock().disconnected {
+        if self.dentry.lock().disconnected.load(Ordering::Acquire) {
             path.push_str(" (deleted)");
         }
         Ok(path)
@@ -1366,7 +1405,7 @@ impl MountFSInode {
         // A lookup-created wrapper has authoritative alias-specific dentry identity.
         // Filesystem-provided paths are only a fallback for roots/legacy wrappers.
         let current_state = current.dentry.lock();
-        if current_state.disconnected && !allow_disconnected {
+        if current_state.disconnected.load(Ordering::Acquire) && !allow_disconnected {
             return Err(SystemError::ENOENT);
         }
         let use_inner_path = current_state.name.is_none();
@@ -1573,7 +1612,11 @@ impl IndexNode for MountFSInode {
         data: usize,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         let inner_inode = self
             .inner_inode
             .create_with_data(name, file_type, mode, data)?;
@@ -1715,7 +1758,11 @@ impl IndexNode for MountFSInode {
         mode: InodeMode,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         let inner_inode = self.inner_inode.create(name, file_type, mode)?;
         let parent = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
         return Ok(MountFSInode::new_child(
@@ -1728,7 +1775,11 @@ impl IndexNode for MountFSInode {
 
     fn link(&self, name: &str, other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         // Filesystem implementations expect `other` to be an inode of the same concrete filesystem (e.g. LockedExt4Inode).
         // When VFS mount wrapping is enabled, `other` is typically a `MountFSInode`, which causes
         // filesystem-level downcasts to fail and incorrectly return EINVAL.
@@ -1745,7 +1796,11 @@ impl IndexNode for MountFSInode {
 
     fn symlink(&self, name: &str, target: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         let inner_inode = self.inner_inode.symlink(name, target)?;
         let parent = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
         Ok(MountFSInode::new_child(
@@ -1760,8 +1815,13 @@ impl IndexNode for MountFSInode {
     #[inline]
     fn unlink(&self, name: &str) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         let inode_id = self.inner_inode.find(name)?.metadata()?.inode_id;
+        let parent_id = self.inner_inode.metadata()?.inode_id;
 
         // First check if this inode is a mount point; if so, it cannot be deleted
         if self.mount_fs.mountpoints.lock().contains_key(&inode_id) {
@@ -1769,6 +1829,10 @@ impl IndexNode for MountFSInode {
         }
         // Delegate to the inner inode's unlink method to delete this inode
         self.inner_inode.unlink(name)?;
+        self.mount_fs
+            .super_block_state
+            .dentry_state(parent_id, inode_id, DName::from(name))
+            .store(true, Ordering::Release);
         if let Some(child) = self
             .dentry
             .lock()
@@ -1776,8 +1840,8 @@ impl IndexNode for MountFSInode {
             .remove(&DName::from(name))
             .and_then(|w| w.upgrade())
         {
-            let mut state = child.dentry.lock();
-            state.disconnected = true;
+            let state = child.dentry.lock();
+            state.disconnected.store(true, Ordering::Release);
         }
         return Ok(());
     }
@@ -1785,8 +1849,13 @@ impl IndexNode for MountFSInode {
     #[inline]
     fn rmdir(&self, name: &str) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         let inode_id = self.inner_inode.find(name)?.metadata()?.inode_id;
+        let parent_id = self.inner_inode.metadata()?.inode_id;
 
         // First check if this inode is a mount point; if so, it cannot be deleted
         if self.mount_fs.mountpoints.lock().contains_key(&inode_id) {
@@ -1794,6 +1863,10 @@ impl IndexNode for MountFSInode {
         }
         // Delegate to the inner inode's rmdir method to delete this inode
         self.inner_inode.rmdir(name)?;
+        self.mount_fs
+            .super_block_state
+            .dentry_state(parent_id, inode_id, DName::from(name))
+            .store(true, Ordering::Release);
         if let Some(child) = self
             .dentry
             .lock()
@@ -1801,8 +1874,8 @@ impl IndexNode for MountFSInode {
             .remove(&DName::from(name))
             .and_then(|w| w.upgrade())
         {
-            let mut state = child.dentry.lock();
-            state.disconnected = true;
+            let state = child.dentry.lock();
+            state.disconnected.store(true, Ordering::Release);
         }
         return Ok(());
     }
@@ -1816,7 +1889,11 @@ impl IndexNode for MountFSInode {
         flags: RenameFlags,
     ) -> Result<(), SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         // Filesystem implementations generally expect `target` to be an inode
         // of the same concrete FS (e.g. tmpfs' LockedTmpfsInode). When VFS
         // mount wrapping is enabled, `target` is often a `MountFSInode`, which
@@ -1828,9 +1905,26 @@ impl IndexNode for MountFSInode {
             .as_ref()
             .map(|mnt| mnt.inner_inode.clone())
             .unwrap_or_else(|| target.clone());
+        let replaced = if flags.contains(RenameFlags::EXCHANGE) {
+            None
+        } else {
+            target_inner.find(new_name).ok().and_then(|inode| {
+                target_inner
+                    .metadata()
+                    .ok()
+                    .zip(inode.metadata().ok())
+                    .map(|(parent, child)| (parent.inode_id, child.inode_id))
+            })
+        };
 
         self.inner_inode
             .move_to(old_name, &target_inner, new_name, flags)?;
+        if let Some((parent, child)) = replaced {
+            self.mount_fs
+                .super_block_state
+                .dentry_state(parent, child, DName::from(new_name))
+                .store(true, Ordering::Release);
+        }
         if let (Some(source), Some(target)) = (self.self_ref.upgrade(), target_mount) {
             Self::update_move_dentries(
                 &source,
@@ -1980,7 +2074,11 @@ impl IndexNode for MountFSInode {
         dev_t: DeviceNumber,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.ensure_mount_writable()?;
-        let _namespace_guard = self.mount_fs.dentry_namespace_lock.write();
+        let _namespace_guard = self
+            .mount_fs
+            .super_block_state
+            .dentry_namespace_lock
+            .write();
         let inner_inode = self.inner_inode.mknod(filename, mode, dev_t)?;
         let parent = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
         return Ok(MountFSInode::new_child(

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -25,7 +25,6 @@ use crate::{
     init::cmdline::kenrel_cmdline_param_manager,
     ipc::kill::send_signal_to_pid,
     libs::mutex::MutexGuard,
-    mm::truncate::truncate_inode_pages,
     process::{
         cred::CAPFlags, namespace::mnt::mnt_namespace_init, resource::RLimitID, ProcessManager,
     },
@@ -684,11 +683,6 @@ pub fn do_unlink_at(dirfd: i32, path: &str) -> Result<u64, SystemError> {
     // 如果目标是目录，则返回 EISDIR
     if target_inode.metadata()?.file_type == FileType::Dir {
         return Err(SystemError::EISDIR);
-    }
-
-    // 对目标 inode 执行页缓存清理
-    if let Some(page_cache) = target_inode.page_cache().clone() {
-        truncate_inode_pages(page_cache, 0);
     }
 
     // 在父目录上执行 unlink 操作

--- a/user/apps/tests/dunitest/Makefile
+++ b/user/apps/tests/dunitest/Makefile
@@ -62,7 +62,7 @@ build-suites: $(TEST_BINS) $(EXT4_FIXTURE)
 
 $(EXT4_FIXTURE):
 	@mkdir -p "$(dir $@)"
-	@truncate -s 32M "$@"
+	@truncate -s 8M "$@"
 	@mke2fs -q -t ext4 -F "$@"
 
 $(GTEST_OBJ): $(GTEST_SRC)

--- a/user/apps/tests/dunitest/Makefile
+++ b/user/apps/tests/dunitest/Makefile
@@ -19,6 +19,7 @@ RUNNER_BIN = $(RUNNER_DIR)/target/$(RUST_TARGET)/release/dunitest-runner
 RESULTS_DIR = results
 BIN_DIR = bin
 BUILD_DIR = build
+EXT4_FIXTURE = $(BUILD_DIR)/fixtures/ext4_inode_identity.img
 
 # 要编译的测试套件目录列表（suites/ 下的子目录名）
 SUITES = demo normal fuse
@@ -57,7 +58,12 @@ $(GTEST_SRC):
 	@mv "$(GTEST_TMP_ROOT)" "$(GTEST_ROOT)"
 	@test -f "$(GTEST_SRC)"
 
-build-suites: $(TEST_BINS)
+build-suites: $(TEST_BINS) $(EXT4_FIXTURE)
+
+$(EXT4_FIXTURE):
+	@mkdir -p "$(dir $@)"
+	@truncate -s 32M "$@"
+	@mke2fs -q -t ext4 -F "$@"
 
 $(GTEST_OBJ): $(GTEST_SRC)
 	@mkdir -p "$(dir $@)"
@@ -84,6 +90,8 @@ install: build
 	@cp -f $(RUNNER_BIN) $(INSTALL_DIR)/dunitest-runner
 	@chmod +x $(INSTALL_DIR)/dunitest-runner
 	@cp -rf $(BIN_DIR) $(INSTALL_DIR)/
+	@mkdir -p $(INSTALL_DIR)/fixtures
+	@cp --sparse=always -f $(EXT4_FIXTURE) $(INSTALL_DIR)/fixtures/
 	@cp -f whitelist.txt $(INSTALL_DIR)/whitelist.txt
 	@cp -f scripts/run_tests.sh $(INSTALL_DIR)/run_tests.sh
 	@chmod +x $(INSTALL_DIR)/run_tests.sh

--- a/user/apps/tests/dunitest/default.nix
+++ b/user/apps/tests/dunitest/default.nix
@@ -65,7 +65,10 @@ let
       "^scripts/run_tests\\.sh$"
     ];
 
-    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+    nativeBuildInputs = [
+      pkgs.autoPatchelfHook
+      pkgs.e2fsprogs
+    ];
 
     buildInputs = [ pkgs.stdenv.cc.cc.lib ];
 
@@ -85,6 +88,7 @@ let
 
       mkdir -p $out/${installDir}
       cp -r bin $out/${installDir}/
+      cp -r build/fixtures $out/${installDir}/
       install -m644 whitelist.txt $out/${installDir}/
       install -m755 scripts/run_tests.sh $out/${installDir}/
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -1412,7 +1412,10 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
     case FUSE_DESTROY:
         if (a->destroy_count)
             (*a->destroy_count)++;
-        if (a->stop_on_destroy && a->stop)
+        // DESTROY is the final request for this connection. Always leave the
+        // daemon loop instead of racing a subsequent blocking read against a
+        // close from the test thread.
+        if (a->stop)
             *a->stop = 1;
         return 0;
     case FUSE_WRITE: {

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -267,6 +267,7 @@ TEST(Ext4InodeIdentity, BindAliasAndMapsShareDeletedDentryState) {
     const std::string source_dir = base + "/source";
     const std::string bind_dir = base + "/bind";
     const std::string source = source_dir + "/file";
+    const std::string keeper = source_dir + "/keeper";
     const std::string alias = bind_dir + "/file";
 
     ASSERT_EQ(0, mkdir(base.c_str(), 0700)) << strerror(errno);
@@ -276,6 +277,7 @@ TEST(Ext4InodeIdentity, BindAliasAndMapsShareDeletedDentryState) {
     ASSERT_GE(create_fd, 0) << strerror(errno);
     ASSERT_EQ(0, ftruncate(create_fd, 4096)) << strerror(errno);
     ASSERT_EQ(0, close(create_fd)) << strerror(errno);
+    ASSERT_EQ(0, link(source.c_str(), keeper.c_str())) << strerror(errno);
     ASSERT_EQ(0, mount(source_dir.c_str(), bind_dir.c_str(), nullptr, MS_BIND, nullptr))
         << strerror(errno);
 
@@ -295,8 +297,22 @@ TEST(Ext4InodeIdentity, BindAliasAndMapsShareDeletedDentryState) {
     const std::string maps = ReadFile("/proc/self/maps");
     EXPECT_NE(std::string::npos, maps.find(deleted_path)) << maps;
 
+    ASSERT_EQ(0, link(keeper.c_str(), source.c_str())) << strerror(errno);
+    int recreated_fd = open(alias.c_str(), O_RDONLY);
+    ASSERT_GE(recreated_fd, 0) << strerror(errno);
+    const std::string recreated_proc_fd =
+        "/proc/self/fd/" + std::to_string(recreated_fd);
+    memset(target, 0, sizeof(target));
+    target_size =
+        readlink(recreated_proc_fd.c_str(), target, sizeof(target) - 1);
+    ASSERT_GT(target_size, 0) << strerror(errno);
+    EXPECT_EQ(alias, std::string(target, static_cast<size_t>(target_size)));
+    ASSERT_EQ(0, close(recreated_fd)) << strerror(errno);
+
     ASSERT_EQ(0, munmap(mapping, 4096)) << strerror(errno);
     ASSERT_EQ(0, close(alias_fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(source.c_str())) << strerror(errno);
+    ASSERT_EQ(0, unlink(keeper.c_str())) << strerror(errno);
     ASSERT_EQ(0, umount(bind_dir.c_str())) << strerror(errno);
     ASSERT_EQ(0, rmdir(bind_dir.c_str())) << strerror(errno);
     ASSERT_EQ(0, rmdir(source_dir.c_str())) << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+constexpr unsigned long kLoopCtlGetFree = 0x4C82;
+constexpr unsigned long kLoopSetFd = 0x4C00;
+constexpr unsigned long kLoopClrFd = 0x4C01;
+
+class LoopExt4 {
+  public:
+    ~LoopExt4() {
+        if (mounted_) {
+            umount(mount_point_.c_str());
+        }
+        if (loop_fd_ >= 0) {
+            ioctl(loop_fd_, kLoopClrFd, 0);
+            close(loop_fd_);
+        }
+        if (backing_fd_ >= 0) {
+            close(backing_fd_);
+        }
+        if (!mount_point_.empty()) {
+            rmdir(mount_point_.c_str());
+        }
+        if (!image_.empty()) {
+            unlink(image_.c_str());
+        }
+    }
+
+    void SetUp() {
+        image_ = "/tmp/ext4_inode_identity_" + std::to_string(getpid()) + ".img";
+        mount_point_ = "/tmp/ext4_inode_identity_" + std::to_string(getpid()) + "_mnt";
+
+        ASSERT_EQ(0, mkdir(mount_point_.c_str(), 0700)) << strerror(errno);
+
+        backing_fd_ = open(image_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+        ASSERT_GE(backing_fd_, 0) << strerror(errno);
+        ASSERT_EQ(0, ftruncate(backing_fd_, 32 * 1024 * 1024)) << strerror(errno);
+        close(backing_fd_);
+        backing_fd_ = -1;
+
+        std::string command = "/usr/sbin/mke2fs -q -t ext4 -F " + image_;
+        ASSERT_EQ(0, system(command.c_str())) << "mke2fs failed";
+
+        int control = open("/dev/loop-control", O_RDWR);
+        ASSERT_GE(control, 0) << strerror(errno);
+        int minor = ioctl(control, kLoopCtlGetFree, 0);
+        int saved_errno = errno;
+        close(control);
+        ASSERT_GE(minor, 0) << strerror(saved_errno);
+
+        loop_path_ = "/dev/loop" + std::to_string(minor);
+        loop_fd_ = open(loop_path_.c_str(), O_RDWR);
+        ASSERT_GE(loop_fd_, 0) << strerror(errno);
+        backing_fd_ = open(image_.c_str(), O_RDWR);
+        ASSERT_GE(backing_fd_, 0) << strerror(errno);
+        ASSERT_EQ(0, ioctl(loop_fd_, kLoopSetFd, backing_fd_)) << strerror(errno);
+    }
+
+    void Mount() {
+        ASSERT_EQ(0, mount(loop_path_.c_str(), mount_point_.c_str(), "ext4", 0, nullptr))
+            << strerror(errno);
+        mounted_ = true;
+    }
+
+    void Unmount() {
+        ASSERT_TRUE(mounted_);
+        ASSERT_EQ(0, umount(mount_point_.c_str())) << strerror(errno);
+        mounted_ = false;
+    }
+
+    const std::string& mount_point() const {
+        return mount_point_;
+    }
+
+  private:
+    std::string image_;
+    std::string mount_point_;
+    std::string loop_path_;
+    int backing_fd_ = -1;
+    int loop_fd_ = -1;
+    bool mounted_ = false;
+};
+
+void WriteAll(int fd, const char* data, size_t len) {
+    size_t done = 0;
+    while (done < len) {
+        ssize_t written = write(fd, data + done, len - done);
+        ASSERT_GT(written, 0) << strerror(errno);
+        done += static_cast<size_t>(written);
+    }
+}
+
+TEST(Ext4InodeIdentity, KernelLifecycleSelftestPasses) {
+    int fd = open("/sys/kernel/debug/ext4/lifecycle_selftest", O_RDONLY);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    char report[4096] = {};
+    ssize_t size = read(fd, report, sizeof(report) - 1);
+    int saved_errno = errno;
+    close(fd);
+    ASSERT_GT(size, 0) << strerror(saved_errno);
+    std::string text(report, static_cast<size_t>(size));
+    EXPECT_NE(std::string::npos, text.find("status=ok\n")) << text;
+    EXPECT_EQ(std::string::npos, text.find("=fail\n")) << text;
+}
+
+TEST(Ext4InodeIdentity, RemountedHardLinksShareCanonicalInodeAndPageCache) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string dir_a = fs.mount_point() + "/a";
+    const std::string dir_b = fs.mount_point() + "/b";
+    const std::string source = dir_a + "/source";
+    const std::string alias = dir_b + "/alias";
+
+    ASSERT_EQ(0, mkdir(dir_a.c_str(), 0755)) << strerror(errno);
+    ASSERT_EQ(0, mkdir(dir_b.c_str(), 0755)) << strerror(errno);
+    int create_fd = open(source.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(create_fd, 0) << strerror(errno);
+    constexpr char kInitial[] = "initial";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(create_fd, kInitial, sizeof(kInitial) - 1));
+    ASSERT_EQ(0, fsync(create_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(create_fd)) << strerror(errno);
+    ASSERT_EQ(0, link(source.c_str(), alias.c_str())) << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    struct stat source_stat = {};
+    struct stat alias_stat = {};
+    ASSERT_EQ(0, stat(source.c_str(), &source_stat)) << strerror(errno);
+    ASSERT_EQ(0, stat(alias.c_str(), &alias_stat)) << strerror(errno);
+    EXPECT_EQ(source_stat.st_dev, alias_stat.st_dev);
+    EXPECT_EQ(source_stat.st_ino, alias_stat.st_ino);
+    EXPECT_EQ(2u, source_stat.st_nlink);
+
+    int source_fd = open(source.c_str(), O_RDWR | O_TRUNC);
+    ASSERT_GE(source_fd, 0) << strerror(errno);
+    int alias_fd = open(alias.c_str(), O_RDONLY);
+    ASSERT_GE(alias_fd, 0) << strerror(errno);
+
+    constexpr char kUpdated[] = "shared-page-cache";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(source_fd, kUpdated, sizeof(kUpdated) - 1));
+    ASSERT_EQ(0, lseek(alias_fd, 0, SEEK_SET)) << strerror(errno);
+    char buffer[sizeof(kUpdated)] = {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(kUpdated) - 1),
+              read(alias_fd, buffer, sizeof(kUpdated) - 1))
+        << strerror(errno);
+    EXPECT_EQ(0, memcmp(buffer, kUpdated, sizeof(kUpdated) - 1));
+
+    // The dirty mapping belongs to the canonical inode. Dropping one alias must
+    // neither truncate it nor expose an eviction state to the surviving alias.
+    ASSERT_EQ(0, unlink(alias.c_str())) << strerror(errno);
+    ASSERT_EQ(0, lseek(source_fd, 0, SEEK_SET)) << strerror(errno);
+    memset(buffer, 0, sizeof(buffer));
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(kUpdated) - 1),
+              read(source_fd, buffer, sizeof(kUpdated) - 1))
+        << strerror(errno);
+    EXPECT_EQ(0, memcmp(buffer, kUpdated, sizeof(kUpdated) - 1));
+    ASSERT_EQ(0, fstat(source_fd, &source_stat)) << strerror(errno);
+    EXPECT_EQ(1u, source_stat.st_nlink);
+
+    ASSERT_EQ(0, fsync(source_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(alias_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(source_fd)) << strerror(errno);
+
+    ASSERT_EQ(0, unlink(source.c_str())) << strerror(errno);
+    ASSERT_EQ(0, rmdir(dir_a.c_str())) << strerror(errno);
+    ASSERT_EQ(0, rmdir(dir_b.c_str())) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -153,6 +154,23 @@ void WriteAll(int fd, const char* data, size_t len) {
     }
 }
 
+std::string ReadFile(const char* path) {
+    int fd = open(path, O_RDONLY);
+    EXPECT_GE(fd, 0) << strerror(errno);
+    std::string result;
+    char buffer[4096];
+    for (;;) {
+        ssize_t count = read(fd, buffer, sizeof(buffer));
+        EXPECT_GE(count, 0) << strerror(errno);
+        if (count <= 0) {
+            break;
+        }
+        result.append(buffer, static_cast<size_t>(count));
+    }
+    EXPECT_EQ(0, close(fd)) << strerror(errno);
+    return result;
+}
+
 TEST(Ext4InodeIdentity, KernelLifecycleSelftestPasses) {
     int fd = open("/sys/kernel/debug/ext4/lifecycle_selftest", O_RDONLY);
     ASSERT_GE(fd, 0) << strerror(errno);
@@ -242,6 +260,47 @@ TEST(Ext4InodeIdentity, RemountedHardLinksShareCanonicalInodeAndPageCache) {
     ASSERT_EQ(0, rmdir(dir_a.c_str())) << strerror(errno);
     ASSERT_EQ(0, rmdir(dir_b.c_str())) << strerror(errno);
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, BindAliasAndMapsShareDeletedDentryState) {
+    const std::string base = "/tmp/dentry_bind_" + std::to_string(getpid());
+    const std::string source_dir = base + "/source";
+    const std::string bind_dir = base + "/bind";
+    const std::string source = source_dir + "/file";
+    const std::string alias = bind_dir + "/file";
+
+    ASSERT_EQ(0, mkdir(base.c_str(), 0700)) << strerror(errno);
+    ASSERT_EQ(0, mkdir(source_dir.c_str(), 0700)) << strerror(errno);
+    ASSERT_EQ(0, mkdir(bind_dir.c_str(), 0700)) << strerror(errno);
+    int create_fd = open(source.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    ASSERT_GE(create_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, ftruncate(create_fd, 4096)) << strerror(errno);
+    ASSERT_EQ(0, close(create_fd)) << strerror(errno);
+    ASSERT_EQ(0, mount(source_dir.c_str(), bind_dir.c_str(), nullptr, MS_BIND, nullptr))
+        << strerror(errno);
+
+    int alias_fd = open(alias.c_str(), O_RDWR);
+    ASSERT_GE(alias_fd, 0) << strerror(errno);
+    void* mapping = mmap(nullptr, 4096, PROT_READ, MAP_PRIVATE, alias_fd, 0);
+    ASSERT_NE(MAP_FAILED, mapping) << strerror(errno);
+    ASSERT_EQ(0, unlink(source.c_str())) << strerror(errno);
+
+    char target[512] = {};
+    const std::string proc_fd = "/proc/self/fd/" + std::to_string(alias_fd);
+    ssize_t target_size = readlink(proc_fd.c_str(), target, sizeof(target) - 1);
+    ASSERT_GT(target_size, 0) << strerror(errno);
+    const std::string deleted_path = alias + " (deleted)";
+    EXPECT_EQ(deleted_path,
+              std::string(target, static_cast<size_t>(target_size)));
+    const std::string maps = ReadFile("/proc/self/maps");
+    EXPECT_NE(std::string::npos, maps.find(deleted_path)) << maps;
+
+    ASSERT_EQ(0, munmap(mapping, 4096)) << strerror(errno);
+    ASSERT_EQ(0, close(alias_fd)) << strerror(errno);
+    ASSERT_EQ(0, umount(bind_dir.c_str())) << strerror(errno);
+    ASSERT_EQ(0, rmdir(bind_dir.c_str())) << strerror(errno);
+    ASSERT_EQ(0, rmdir(source_dir.c_str())) << strerror(errno);
+    ASSERT_EQ(0, rmdir(base.c_str())) << strerror(errno);
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -18,6 +18,59 @@ constexpr unsigned long kLoopCtlGetFree = 0x4C82;
 constexpr unsigned long kLoopSetFd = 0x4C00;
 constexpr unsigned long kLoopClrFd = 0x4C01;
 
+std::string FixturePath() {
+    char executable[512] = {};
+    ssize_t size = readlink("/proc/self/exe", executable, sizeof(executable) - 1);
+    if (size <= 0) {
+        return {};
+    }
+    std::string path(executable, static_cast<size_t>(size));
+    for (int i = 0; i < 3; ++i) {
+        size_t slash = path.rfind('/');
+        if (slash == std::string::npos) {
+            return {};
+        }
+        path.resize(slash);
+    }
+    return path + "/fixtures/ext4_inode_identity.img";
+}
+
+void CopySparseFile(const std::string& source, int destination) {
+    int source_fd = open(source.c_str(), O_RDONLY);
+    ASSERT_GE(source_fd, 0) << source << ": " << strerror(errno);
+    char buffer[64 * 1024];
+    off_t size = 0;
+    for (;;) {
+        ssize_t count = read(source_fd, buffer, sizeof(buffer));
+        ASSERT_GE(count, 0) << strerror(errno);
+        if (count == 0) {
+            break;
+        }
+        bool all_zero = true;
+        for (ssize_t i = 0; i < count; ++i) {
+            if (buffer[i] != 0) {
+                all_zero = false;
+                break;
+            }
+        }
+        if (all_zero) {
+            ASSERT_NE(static_cast<off_t>(-1), lseek(destination, count, SEEK_CUR))
+                << strerror(errno);
+        } else {
+            ssize_t done = 0;
+            while (done < count) {
+                ssize_t written = write(destination, buffer + done, count - done);
+                ASSERT_GT(written, 0) << strerror(errno);
+                done += written;
+            }
+        }
+        size += count;
+    }
+    ASSERT_EQ(0, ftruncate(destination, size)) << strerror(errno);
+    ASSERT_EQ(0, close(source_fd)) << strerror(errno);
+    ASSERT_EQ(0, lseek(destination, 0, SEEK_SET)) << strerror(errno);
+}
+
 class LoopExt4 {
   public:
     ~LoopExt4() {
@@ -47,12 +100,9 @@ class LoopExt4 {
 
         backing_fd_ = open(image_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
         ASSERT_GE(backing_fd_, 0) << strerror(errno);
-        ASSERT_EQ(0, ftruncate(backing_fd_, 32 * 1024 * 1024)) << strerror(errno);
+        ASSERT_NO_FATAL_FAILURE(CopySparseFile(FixturePath(), backing_fd_));
         close(backing_fd_);
         backing_fd_ = -1;
-
-        std::string command = "/usr/sbin/mke2fs -q -t ext4 -F " + image_;
-        ASSERT_EQ(0, system(command.c_str())) << "mke2fs failed";
 
         int control = open("/dev/loop-control", O_RDWR);
         ASSERT_GE(control, 0) << strerror(errno);
@@ -146,6 +196,17 @@ TEST(Ext4InodeIdentity, RemountedHardLinksShareCanonicalInodeAndPageCache) {
     EXPECT_EQ(source_stat.st_dev, alias_stat.st_dev);
     EXPECT_EQ(source_stat.st_ino, alias_stat.st_ino);
     EXPECT_EQ(2u, source_stat.st_nlink);
+
+    int alias_path_fd = open(alias.c_str(), O_RDONLY);
+    ASSERT_GE(alias_path_fd, 0) << strerror(errno);
+    const std::string proc_fd =
+        "/proc/self/fd/" + std::to_string(alias_path_fd);
+    char link_target[512] = {};
+    ssize_t link_size =
+        readlink(proc_fd.c_str(), link_target, sizeof(link_target) - 1);
+    ASSERT_GT(link_size, 0) << strerror(errno);
+    EXPECT_EQ(alias, std::string(link_target, static_cast<size_t>(link_size)));
+    ASSERT_EQ(0, close(alias_path_fd)) << strerror(errno);
 
     int source_fd = open(source.c_str(), O_RDWR | O_TRUNC);
     ASSERT_GE(source_fd, 0) << strerror(errno);

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -4,6 +4,7 @@ demo/gtest_demo
 normal/capability
 normal/fdatasync
 normal/ext4_xattr
+normal/ext4_inode_identity
 normal/fallocate_semantics
 normal/syncfs_semantics
 normal/fcntl_lock


### PR DESCRIPTION
## Summary

- canonicalize ext4 VFS inode wrappers per superblock and share page-cache identity across hardlink aliases
- gate stale disk-facing work with lifecycle tokens and coordinate final reclaim with tombstones and an inode-number reuse barrier
- preserve non-final hardlink data, harden rename/whiteout rollback, and add lifecycle plus remount regression coverage

## Validation

- `make kernel`
- `ext4_inode_identity_test`: 2/2 passed in DragonOS QEMU
- `fdatasync_test`: 7/7 passed
- `syncfs_semantics_test`: 9/9 passed
- `sync_file_range_test`: 4/4 passed
- adversarial lifecycle/locking/rollback review: no remaining blockers

Closes #2051