### PR TITLE
perf(virtiofs): read directly into page cache

### DIFF
--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -6,6 +6,7 @@ use core::{
 
 use system_error::SystemError;
 
+use crate::filesystem::page_cache::PageCacheReadDmaReservation;
 use crate::{
     arch::MMArch,
     filesystem::epoll::{
@@ -30,7 +31,7 @@ use super::protocol::{
     FUSE_PARALLEL_DIROPS, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO,
     FUSE_REMOVEXATTR, FUSE_SETXATTR, FUSE_SUBMOUNTS,
 };
-use super::reply::FuseReply;
+use super::reply::{FuseReadPagesReply, FuseReply};
 use super::{stats, trace};
 
 mod daemon;
@@ -120,6 +121,7 @@ pub struct FuseRequest {
     unique: u64,
     opcode: u32,
     reply_contract: FuseReplyContract,
+    read_pages_destination: Option<Arc<PageCacheReadDmaReservation>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -157,6 +159,10 @@ impl FuseRequest {
 
     pub(crate) fn reply_contract(&self) -> FuseReplyContract {
         self.reply_contract
+    }
+
+    pub(crate) fn read_pages_destination(&self) -> Option<&Arc<PageCacheReadDmaReservation>> {
+        self.read_pages_destination.as_ref()
     }
 }
 
@@ -199,8 +205,14 @@ pub struct FusePendingState {
 #[derive(Debug)]
 enum PendingCompletion {
     Waiting,
-    Ready(Result<FuseReply, SystemError>),
+    Ready(Result<FusePendingResult, SystemError>),
     Consumed,
+}
+
+#[derive(Debug)]
+pub(crate) enum FusePendingResult {
+    Reply(FuseReply),
+    ReadPagesDirect { bytes: usize },
 }
 
 impl FusePendingState {
@@ -218,6 +230,17 @@ impl FusePendingState {
     }
 
     pub fn complete(&self, v: Result<FuseReply, SystemError>) -> bool {
+        self.complete_result(v.map(FusePendingResult::Reply))
+    }
+
+    /// Complete a page-cache read whose payload was written into its owned
+    /// destination.  This deliberately shares the ordinary pending state so
+    /// duplicate replies, disconnect and teardown have one retirement point.
+    pub(crate) fn complete_read_pages_direct(&self, bytes: usize) -> bool {
+        self.complete_result(Ok(FusePendingResult::ReadPagesDirect { bytes }))
+    }
+
+    fn complete_result(&self, v: Result<FusePendingResult, SystemError>) -> bool {
         let mut guard = self.response.lock();
         if !matches!(*guard, PendingCompletion::Waiting) {
             // Duplicate replies are ignored (Linux does similarly).
@@ -230,6 +253,24 @@ impl FusePendingState {
     }
 
     pub fn wait_complete(&self) -> Result<FuseReply, SystemError> {
+        match self.wait_result()? {
+            FusePendingResult::Reply(reply) => Ok(reply),
+            // A direct completion is a request-contract violation for ordinary
+            // callers.  Do not expose an empty reply that could look valid.
+            FusePendingResult::ReadPagesDirect { .. } => Err(SystemError::EIO),
+        }
+    }
+
+    pub(crate) fn wait_read_pages_complete(&self) -> Result<FuseReadPagesReply, SystemError> {
+        match self.wait_result()? {
+            FusePendingResult::Reply(reply) => Ok(FuseReadPagesReply::Contiguous(reply)),
+            FusePendingResult::ReadPagesDirect { bytes } => {
+                Ok(FuseReadPagesReply::Direct { bytes })
+            }
+        }
+    }
+
+    fn wait_result(&self) -> Result<FusePendingResult, SystemError> {
         wait_with_recheck(&self.wait, || {
             let mut guard = self.response.lock();
             if matches!(*guard, PendingCompletion::Ready(_)) {
@@ -854,7 +895,7 @@ mod tests {
         FuseEntryOut, FuseOpenOut, FuseOutHeader, FuseStatfsOut, FUSE_CREATE, FUSE_DESTROY,
         FUSE_GETATTR, FUSE_LOOKUP, FUSE_STATFS,
     };
-    use super::{daemon, request, stats, FuseConn, FuseReplyCapacitySource};
+    use super::{daemon, request, stats, FuseConn, FusePendingState, FuseReplyCapacitySource};
 
     fn set_minor(conn: &FuseConn, minor: u32) {
         conn.inner.lock().init.minor = minor;
@@ -966,5 +1007,30 @@ mod tests {
             conn.request_nocreds(FUSE_LOOKUP, 1, b"late\0"),
             Err(SystemError::ENOTCONN)
         );
+    }
+
+    #[test]
+    fn pending_read_pages_preserves_direct_and_contiguous_results() {
+        let direct = FusePendingState::new(1, super::super::protocol::FUSE_READ);
+        assert!(direct.complete_read_pages_direct(4097));
+        assert!(!direct.complete_read_pages_direct(1));
+        assert!(matches!(
+            direct.wait_read_pages_complete().unwrap(),
+            super::super::reply::FuseReadPagesReply::Direct { bytes: 4097 }
+        ));
+
+        let contiguous = FusePendingState::new(3, super::super::protocol::FUSE_READ);
+        assert!(contiguous.complete(Ok(super::super::reply::FuseReply::from_bytes(vec![1, 2]))));
+        assert!(matches!(
+            contiguous.wait_read_pages_complete().unwrap(),
+            super::super::reply::FuseReadPagesReply::Contiguous(reply) if &*reply == [1, 2]
+        ));
+    }
+
+    #[test]
+    fn ordinary_wait_rejects_direct_completion() {
+        let pending = FusePendingState::new(1, super::super::protocol::FUSE_READ);
+        assert!(pending.complete_read_pages_direct(1));
+        assert_eq!(pending.wait_complete(), Err(SystemError::EIO));
     }
 }

--- a/kernel/src/filesystem/fuse/conn/daemon.rs
+++ b/kernel/src/filesystem/fuse/conn/daemon.rs
@@ -12,7 +12,7 @@ use super::super::protocol::{
     FUSE_GETXATTR, FUSE_INIT, FUSE_INIT_EXT, FUSE_INTERRUPT, FUSE_KERNEL_MINOR_VERSION,
     FUSE_KERNEL_VERSION, FUSE_LINK, FUSE_LISTXATTR, FUSE_LOOKUP, FUSE_MAX_PAGES,
     FUSE_MIN_READ_BUFFER, FUSE_MKDIR, FUSE_MKNOD, FUSE_NOTIFY_DELETE, FUSE_NOTIFY_INVAL_ENTRY,
-    FUSE_NOTIFY_INVAL_INODE, FUSE_NOTIFY_POLL, FUSE_NOTIFY_RETRIEVE, FUSE_NOTIFY_STORE,
+    FUSE_NOTIFY_INVAL_INODE, FUSE_NOTIFY_POLL, FUSE_NOTIFY_RETRIEVE, FUSE_NOTIFY_STORE, FUSE_READ,
     FUSE_REMOVEXATTR, FUSE_SETATTR, FUSE_SETXATTR, FUSE_STATFS, FUSE_SYMLINK,
 };
 use super::{
@@ -663,6 +663,36 @@ impl FuseConn {
         trace::trace_fuse_reply_complete(unique, FUSE_DESTROY, 0, 0);
         pending.complete(Ok(FuseReply::from_bytes(Vec::new())));
         self.abort();
+        Ok(())
+    }
+
+    /// Retire a successful FUSE_READ whose payload was written into the request's owned page
+    /// destination instead of a `FuseReply` allocation.
+    pub(crate) fn complete_read_pages_direct(
+        &self,
+        unique: u64,
+        payload_len: usize,
+    ) -> Result<(), SystemError> {
+        let pending = {
+            let g = self.inner.lock();
+            if !g.connected || g.teardown_started {
+                return Err(SystemError::ENOENT);
+            }
+            let pending = g
+                .processing
+                .get(&unique)
+                .cloned()
+                .ok_or(SystemError::ENOENT)?;
+            if pending.opcode != FUSE_READ {
+                return Err(SystemError::EINVAL);
+            }
+            pending
+        };
+        self.claim_pending_reply(unique, &pending, |_| {})?;
+        if pending.complete_read_pages_direct(payload_len) {
+            stats::on_fuse_reply_complete(FUSE_READ, 0, payload_len);
+            trace::trace_fuse_reply_complete(unique, FUSE_READ, 0, payload_len as u64);
+        }
         Ok(())
     }
 

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -27,6 +27,22 @@ use super::{
     FuseReplyContract, FuseRequest, FuseRequestCred,
 };
 use crate::filesystem::fuse::reply::FuseReply;
+use crate::filesystem::{fuse::reply::FuseReadPagesReply, page_cache::PageCacheReadDmaReservation};
+
+/// How the reply for a request being built should be delivered back.
+///
+/// This folds the former separate `no_reply` flag and optional page-cache DMA
+/// destination into a single value so the two can never disagree: a
+/// [`FuseReplyRouting::ReadPages`] request is always a reply-bearing
+/// `FUSE_READ`, validated in [`FuseConn::build_request`].
+enum FuseReplyRouting {
+    /// Deliver the reply into the connection's reply buffer.
+    Normal,
+    /// No reply is expected (e.g. `FUSE_FORGET`).
+    NoReply,
+    /// DMA the `FUSE_READ` reply directly into the reserved page-cache pages.
+    ReadPages(Arc<PageCacheReadDmaReservation>),
+}
 
 impl FuseConn {
     fn is_high_priority_opcode(opcode: u32) -> bool {
@@ -74,7 +90,7 @@ impl FuseConn {
             0,
             fuse_pack_struct(&inarg),
             FuseRequestCred::nocreds(),
-            false,
+            FuseReplyRouting::Normal,
         )?;
         self.push_request(req, None, unique | Self::FUSE_INT_REQ_BIT)
     }
@@ -135,6 +151,26 @@ impl FuseConn {
         }
         let pending = self.enqueue_request_with_cred(opcode, nodeid, payload, req_cred)?;
         self.wait_request_complete(opcode, pending)
+    }
+
+    /// Submit one READ whose owned destination can be used directly by a
+    /// capable transport, while retaining the same-request contiguous fallback.
+    pub(crate) fn request_read_pages(
+        &self,
+        nodeid: u64,
+        payload: &[u8],
+        destination: Arc<PageCacheReadDmaReservation>,
+        req_cred: FuseRequestCred,
+    ) -> Result<FuseReadPagesReply, SystemError> {
+        self.wait_initialized()?;
+        let pending = self.enqueue_read_pages(nodeid, payload, destination, req_cred)?;
+        match pending.wait_read_pages_complete() {
+            Err(SystemError::EINTR) | Err(SystemError::ERESTARTSYS) => {
+                let _ = self.queue_interrupt(pending.unique());
+                Err(SystemError::EINTR)
+            }
+            result => result,
+        }
     }
 
     pub fn request_nocreds_background(
@@ -200,7 +236,7 @@ impl FuseConn {
                 gid: 0,
                 pid: 0,
             },
-            true,
+            FuseReplyRouting::NoReply,
         )?;
         self.push_request(req, None, unique)?;
         Ok(())
@@ -230,9 +266,37 @@ impl FuseConn {
         let unique = self.alloc_unique();
         let pending_state = Arc::new(FusePendingState::new(unique, opcode));
 
-        let req = self.build_request(unique, opcode, nodeid, payload, req_cred, false)?;
+        let req = self.build_request(
+            unique,
+            opcode,
+            nodeid,
+            payload,
+            req_cred,
+            FuseReplyRouting::Normal,
+        )?;
         self.push_request(req, Some(pending_state.clone()), unique)?;
         Ok(pending_state)
+    }
+
+    fn enqueue_read_pages(
+        &self,
+        nodeid: u64,
+        payload: &[u8],
+        destination: Arc<PageCacheReadDmaReservation>,
+        req_cred: FuseRequestCred,
+    ) -> Result<Arc<FusePendingState>, SystemError> {
+        let unique = self.alloc_unique();
+        let pending = Arc::new(FusePendingState::new(unique, FUSE_READ));
+        let req = self.build_request(
+            unique,
+            FUSE_READ,
+            nodeid,
+            payload,
+            req_cred,
+            FuseReplyRouting::ReadPages(destination),
+        )?;
+        self.push_request(req, Some(pending.clone()), unique)?;
+        Ok(pending)
     }
 
     fn reply_capacity(
@@ -363,8 +427,18 @@ impl FuseConn {
         nodeid: u64,
         payload: &[u8],
         req_cred: FuseRequestCred,
-        no_reply: bool,
+        reply_routing: FuseReplyRouting,
     ) -> Result<Arc<FuseRequest>, SystemError> {
+        let (no_reply, read_pages_destination) = match reply_routing {
+            FuseReplyRouting::Normal => (false, None),
+            FuseReplyRouting::NoReply => (true, None),
+            FuseReplyRouting::ReadPages(destination) => {
+                if opcode != FUSE_READ {
+                    return Err(SystemError::EINVAL);
+                }
+                (false, Some(destination))
+            }
+        };
         let request_len = size_of::<FuseInHeader>()
             .checked_add(payload.len())
             .ok_or(SystemError::EOVERFLOW)?;
@@ -396,6 +470,7 @@ impl FuseConn {
             unique,
             opcode,
             reply_contract,
+            read_pages_destination,
         }))
     }
 
@@ -466,7 +541,11 @@ pub(super) fn queue_test_request(
             nodeid,
             payload,
             FuseRequestCred::nocreds(),
-            !pending_reply,
+            if pending_reply {
+                FuseReplyRouting::Normal
+            } else {
+                FuseReplyRouting::NoReply
+            },
         )
         .unwrap();
     let request_ptr = req.bytes().as_ptr();
@@ -652,7 +731,7 @@ mod tests {
                 1,
                 &[],
                 FuseRequestCred::nocreds(),
-                true,
+                FuseReplyRouting::NoReply,
             )
             .unwrap();
         assert_eq!(forget.reply_contract(), FuseReplyContract::NoReply);
@@ -665,7 +744,7 @@ mod tests {
                     0,
                     &[],
                     FuseRequestCred::nocreds(),
-                    false,
+                    FuseReplyRouting::Normal,
                 )
                 .unwrap();
             assert!(matches!(

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -30,6 +30,7 @@ use super::super::{
         FUSE_READ, FUSE_READ_LOCKOWNER, FUSE_SETATTR, FUSE_WRITE, FUSE_WRITEBACK_CACHE,
         FUSE_WRITE_CACHE,
     },
+    reply::FuseReadPagesReply,
 };
 use super::FuseNode;
 
@@ -801,69 +802,60 @@ impl FuseNode {
                 break;
             }
 
-            let mut read_buf = vec![0u8; read_len];
-            let bytes_read = self.read_direct_with_open(
-                read_offset,
-                read_len,
-                &mut read_buf,
+            let target = match page_cache
+                .manager()
+                .reserve_read_dma(run_start, run_end - run_start)
+            {
+                Ok(target) => Arc::new(target),
+                Err(SystemError::EEXIST) => {
+                    // A concurrent reader won the reservation race. Wait for its first page to
+                    // leave Loading, then rebuild the missing run from current cache state.
+                    drop(page_cache.manager().commit_page(run_start)?);
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            let read_in = FuseReadIn {
                 fh,
-                file_flags,
-                0,
+                offset: read_offset as u64,
+                size: read_len as u32,
+                read_flags: 0,
+                lock_owner: 0,
+                flags: file_flags,
+                padding: 0,
+            };
+            let result = self.conn().request_read_pages(
+                self.nodeid,
+                fuse_pack_struct(&read_in),
+                target.clone(),
+                FuseRequestCred::from_current(),
             )?;
-            if bytes_read == 0 {
-                let (eof, should_truncate) = self.note_short_read_eof(run_start, 0, file_size)?;
-                if should_truncate {
-                    truncate_eof = Some(eof);
-                }
-                break;
-            }
-
-            let covered_pages = bytes_read.div_ceil(MMArch::PAGE_SIZE);
-            let pages_to_commit = core::cmp::min(run_end - run_start, covered_pages);
-            let mut saw_short_page = false;
-            for rel_page in 0..pages_to_commit {
-                let page_idx = run_start + rel_page;
-                let page_offset = rel_page * MMArch::PAGE_SIZE;
-                let page_read_len =
-                    core::cmp::min(MMArch::PAGE_SIZE, bytes_read.saturating_sub(page_offset));
-                if page_read_len == 0 {
-                    break;
-                }
-
-                let mut filled_len = None;
-                let page = page_cache.manager().commit_page_with(page_idx, |_, dst| {
-                    dst.fill(0);
-                    dst[..page_read_len]
-                        .copy_from_slice(&read_buf[page_offset..page_offset + page_read_len]);
-                    filled_len = Some(page_read_len);
-                    Ok(page_read_len)
-                })?;
-                drop(page);
-
-                if filled_len.is_some() {
-                    total_read += 1;
-                }
-
-                if page_read_len < MMArch::PAGE_SIZE {
-                    let (eof, should_truncate) =
-                        self.note_short_read_eof(page_idx, page_read_len, file_size)?;
-                    if should_truncate {
-                        truncate_eof = Some(eof);
+            let bytes_read = match result {
+                FuseReadPagesReply::Direct { bytes } => {
+                    if bytes > read_len {
+                        let _ = target.rollback(SystemError::EIO);
+                        return Err(SystemError::EIO);
                     }
-                    saw_short_page = true;
-                    break;
+                    target.publish_completed(bytes)?;
+                    bytes
                 }
-            }
+                FuseReadPagesReply::Contiguous(reply) => {
+                    if reply.len() > read_len {
+                        return Err(SystemError::EIO);
+                    }
+                    let bytes = reply.len();
+                    target.publish_contiguous(&reply)?;
+                    bytes
+                }
+            };
+            total_read += bytes_read.div_ceil(MMArch::PAGE_SIZE);
 
-            if bytes_read < read_len && !saw_short_page {
+            if bytes_read < read_len {
                 let (eof, should_truncate) =
                     self.note_short_read_eof(run_start, bytes_read, file_size)?;
                 if should_truncate {
                     truncate_eof = Some(eof);
                 }
-            }
-
-            if saw_short_page || bytes_read < read_len {
                 break;
             }
             idx = run_end;

--- a/kernel/src/filesystem/fuse/reply.rs
+++ b/kernel/src/filesystem/fuse/reply.rs
@@ -18,6 +18,18 @@ pub struct FuseReply {
     range: Range<usize>,
 }
 
+/// Completion returned only by the page-cache read path.
+///
+/// A transport may either place the payload directly in the owned destination
+/// pages or retain the existing contiguous reply path.  Both variants describe
+/// the result of the same FUSE request; callers must never retry merely because
+/// the contiguous variant was selected.
+#[derive(Debug)]
+pub(crate) enum FuseReadPagesReply {
+    Direct { bytes: usize },
+    Contiguous(FuseReply),
+}
+
 impl fmt::Debug for FuseReply {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FuseReply")

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -3,6 +3,7 @@ use alloc::{
     collections::{BTreeMap, VecDeque},
     string::String,
     sync::Arc,
+    vec,
     vec::Vec,
 };
 
@@ -14,6 +15,7 @@ use virtio_drivers::{
     Error as VirtioError, PAGE_SIZE,
 };
 
+use crate::filesystem::page_cache::PageCacheReadDmaReservation;
 use crate::{
     arch::MMArch,
     driver::virtio::{
@@ -65,20 +67,74 @@ struct PendingReq {
 #[derive(Debug)]
 struct InflightReq {
     pending: Option<PendingReq>,
-    rsp: Option<DeviceOutputBuffer>,
+    output: Option<VirtioFsOutput>,
     retained_capacity: Option<usize>,
     descriptor_live: bool,
+}
+
+#[derive(Debug)]
+enum VirtioFsOutput {
+    Contiguous(DeviceOutputBuffer),
+    ReadPages {
+        header: DeviceOutputBuffer,
+        target: Arc<PageCacheReadDmaReservation>,
+    },
+}
+
+impl VirtioFsOutput {
+    fn writable_len(&self) -> usize {
+        match self {
+            Self::Contiguous(rsp) => rsp.writable_len(),
+            Self::ReadPages { header, target } => header.writable_len() + target.payload_capacity(),
+        }
+    }
+
+    unsafe fn dma_slices(&mut self, submission: bool) -> Result<Vec<&mut [u8]>, SystemError> {
+        match self {
+            Self::Contiguous(rsp) => {
+                let slice = if submission {
+                    unsafe { rsp.submission_dma_slice(response_buffer_virt_to_phys) }
+                } else {
+                    unsafe { rsp.retirement_dma_slice(response_buffer_virt_to_phys) }
+                }
+                .map_err(|_| SystemError::EIO)?;
+                Ok(vec![slice])
+            }
+            Self::ReadPages { header, target } => {
+                let header = if submission {
+                    unsafe { header.submission_dma_slice(response_buffer_virt_to_phys) }
+                } else {
+                    unsafe { header.retirement_dma_slice(response_buffer_virt_to_phys) }
+                }
+                .map_err(|_| SystemError::EIO)?;
+                let mut outputs = Vec::with_capacity(1 + target.page_count());
+                outputs.push(header);
+                for descriptor in target.descriptors() {
+                    // SAFETY: the reservation exclusively owns mapping-invisible candidate pages;
+                    // their recorded direct-map address and full-page length remain fixed until
+                    // this exact descriptor is retired.
+                    outputs.push(unsafe {
+                        core::slice::from_raw_parts_mut(
+                            descriptor.vaddr().data() as *mut u8,
+                            descriptor.len(),
+                        )
+                    });
+                }
+                Ok(outputs)
+            }
+        }
+    }
 }
 
 impl InflightReq {
     fn new(
         pending: PendingReq,
-        rsp: Option<DeviceOutputBuffer>,
+        output: Option<VirtioFsOutput>,
         retained_capacity: Option<usize>,
     ) -> Self {
         Self {
             pending: Some(pending),
-            rsp,
+            output,
             retained_capacity,
             descriptor_live: false,
         }
@@ -91,10 +147,20 @@ impl InflightReq {
     }
 
     fn mark_submitted(&mut self) {
-        if let Some(rsp) = self.rsp.as_mut() {
-            rsp.mark_submitted();
-        }
+        // Queue acceptance is the DMA ownership commit point. From here on Drop must quarantine
+        // every owner even if an internal state assertion unexpectedly fails.
         self.descriptor_live = true;
+        if let Some(output) = self.output.as_mut() {
+            match output {
+                VirtioFsOutput::Contiguous(rsp) => rsp.mark_submitted(),
+                VirtioFsOutput::ReadPages { header, target } => {
+                    header.mark_submitted();
+                    target
+                        .mark_submitted()
+                        .expect("direct-read target must remain Prepared until queue acceptance");
+                }
+            }
+        }
     }
 
     fn mark_completed(&mut self) {
@@ -104,8 +170,17 @@ impl InflightReq {
 
     unsafe fn mark_reset_retired_after_detach(&mut self) -> Result<(), BufferError> {
         debug_assert!(self.descriptor_live);
-        if let Some(rsp) = self.rsp.as_mut() {
-            unsafe { rsp.retire_after_reset_and_detach()? };
+        if let Some(output) = self.output.as_mut() {
+            match output {
+                VirtioFsOutput::Contiguous(rsp) => unsafe { rsp.retire_after_reset_and_detach()? },
+                VirtioFsOutput::ReadPages { header, target } => {
+                    unsafe { header.retire_after_reset_and_detach()? };
+                    target
+                        .mark_reset_retired()
+                        .map_err(|_| BufferError::InvalidState)?;
+                    let _ = target.rollback(SystemError::EIO);
+                }
+            }
         }
         self.descriptor_live = false;
         Ok(())
@@ -123,8 +198,11 @@ impl Drop for InflightReq {
         if let Some(pending) = self.pending.take() {
             core::mem::forget(pending);
         }
-        if let Some(rsp) = self.rsp.take() {
-            core::mem::forget(rsp);
+        if let Some(output) = self.output.take() {
+            if let VirtioFsOutput::ReadPages { target, .. } = &output {
+                let _ = target.detach_mapping_for_quarantine();
+            }
+            core::mem::forget(output);
         }
         stats::on_virtiofs_dma_owner_quarantined();
     }
@@ -248,6 +326,18 @@ struct VirtioFsBridgeContext {
 }
 
 impl VirtioFsBridgeContext {
+    fn release_unsubmitted_output(pool: &ResponseBufferPool, output: Option<VirtioFsOutput>) {
+        match output {
+            Some(VirtioFsOutput::Contiguous(rsp)) => {
+                pool.release(rsp, true);
+            }
+            Some(VirtioFsOutput::ReadPages { header, .. }) => {
+                pool.release(header, true);
+            }
+            None => {}
+        }
+    }
+
     fn poll_pause() {
         let _ = nanosleep(PosixTimeSpec::new(0, VIRTIOFS_POLL_NS));
     }
@@ -758,7 +848,21 @@ impl VirtioFsBridgeContext {
         let trace_unique = pending.unique;
         let trace_opcode = pending.opcode;
         let req_len = pending.req.bytes().len();
-        let (mut rsp, retained_capacity, fallback) = match pending.req.reply_contract() {
+        let queue_size = match kind {
+            QueueKind::Hiprio => self.hiprio_vq.as_ref().ok_or(SystemError::EIO)?.size(),
+            QueueKind::Request(slot) => self
+                .request_vqs
+                .get(slot)
+                .ok_or(SystemError::EINVAL)?
+                .size(),
+        };
+        let direct_target = pending.req.read_pages_destination().filter(|target| {
+            2usize
+                .checked_add(target.page_count())
+                .is_some_and(|descriptors| descriptors <= queue_size)
+        });
+        let direct_selected = direct_target.is_some();
+        let (mut output, retained_capacity, fallback) = match pending.req.reply_contract() {
             FuseReplyContract::NoReply => (None, None, false),
             FuseReplyContract::Reply { capacity } => {
                 let capacity = match capacity {
@@ -768,9 +872,14 @@ impl VirtioFsBridgeContext {
                         return Ok(true);
                     }
                 };
+                let output_capacity = if direct_target.is_some() {
+                    core::mem::size_of::<FuseOutHeader>()
+                } else {
+                    capacity.bytes
+                };
                 let rsp = match self.response_pool.acquire(
                     pending.opcode,
-                    capacity.bytes,
+                    output_capacity,
                     response_buffer_virt_to_phys,
                 ) {
                     Ok(rsp) => rsp,
@@ -779,24 +888,28 @@ impl VirtioFsBridgeContext {
                         return Ok(true);
                     }
                 };
-                (
-                    Some(rsp),
-                    Some(capacity.retained_bytes),
-                    matches!(capacity.source, FuseReplyCapacitySource::ExplicitFallback),
-                )
+                let output = if let Some(target) = direct_target {
+                    VirtioFsOutput::ReadPages {
+                        header: rsp,
+                        target: target.clone(),
+                    }
+                } else {
+                    VirtioFsOutput::Contiguous(rsp)
+                };
+                let retained = matches!(output, VirtioFsOutput::Contiguous(_))
+                    .then_some(capacity.retained_bytes);
+                let fallback = (pending.req.read_pages_destination().is_some() && !direct_selected)
+                    || matches!(capacity.source, FuseReplyCapacitySource::ExplicitFallback);
+                (Some(output), retained, fallback)
             }
         };
 
         let (token, should_notify) = match kind {
             QueueKind::Hiprio => {
                 let queue = self.hiprio_vq.as_mut().ok_or(SystemError::EIO)?;
-                let token = if let Some(rsp_buf) = rsp.as_mut() {
+                let token = if let Some(output) = output.as_mut() {
                     let inputs = [pending.req.bytes()];
-                    let mut outputs = [unsafe {
-                        rsp_buf
-                            .submission_dma_slice(response_buffer_virt_to_phys)
-                            .map_err(|_| SystemError::EIO)?
-                    }];
+                    let mut outputs = unsafe { output.dma_slices(true)? };
                     // SAFETY: The request contains a non-empty FuseInHeader, and the reply
                     // contract makes `rsp_buf` at least a non-empty FuseOutHeader. On success,
                     // only their owners and independent metadata are moved/read before notification;
@@ -818,13 +931,9 @@ impl VirtioFsBridgeContext {
             }
             QueueKind::Request(slot) => {
                 let queue = self.request_vqs.get_mut(slot).ok_or(SystemError::EINVAL)?;
-                let token = if let Some(rsp_buf) = rsp.as_mut() {
+                let token = if let Some(output) = output.as_mut() {
                     let inputs = [pending.req.bytes()];
-                    let mut outputs = [unsafe {
-                        rsp_buf
-                            .submission_dma_slice(response_buffer_virt_to_phys)
-                            .map_err(|_| SystemError::EIO)?
-                    }];
+                    let mut outputs = unsafe { output.dma_slices(true)? };
                     // SAFETY: The request contains a non-empty FuseInHeader, and the reply
                     // contract makes `rsp_buf` at least a non-empty FuseOutHeader. On success,
                     // only their owners and independent metadata are moved/read before notification;
@@ -849,9 +958,7 @@ impl VirtioFsBridgeContext {
         let token = match token {
             Ok(token) => token,
             Err(VirtioError::QueueFull) => {
-                if let Some(rsp_buf) = rsp.take() {
-                    self.response_pool.release(rsp_buf, true);
-                }
+                Self::release_unsubmitted_output(&self.response_pool, output.take());
                 stats::on_virtiofs_queue_full(kind.stats_kind());
                 self.mark_queue_full_blocked(kind)?;
                 let (queue_kind, queue_slot) = Self::trace_queue_fields(kind);
@@ -866,9 +973,7 @@ impl VirtioFsBridgeContext {
                 return Ok(false);
             }
             Err(VirtioError::NotReady) => {
-                if let Some(rsp_buf) = rsp.take() {
-                    self.response_pool.release(rsp_buf, true);
-                }
+                Self::release_unsubmitted_output(&self.response_pool, output.take());
                 stats::on_virtiofs_not_ready();
                 stats::on_virtiofs_submit_error();
                 let se = virtio_drivers_error_to_system_error(VirtioError::NotReady);
@@ -880,9 +985,7 @@ impl VirtioFsBridgeContext {
                 return Ok(true);
             }
             Err(e) => {
-                if let Some(rsp_buf) = rsp.take() {
-                    self.response_pool.release(rsp_buf, true);
-                }
+                Self::release_unsubmitted_output(&self.response_pool, output.take());
                 stats::on_virtiofs_submit_error();
                 let se = virtio_drivers_error_to_system_error(e);
                 warn!(
@@ -894,10 +997,10 @@ impl VirtioFsBridgeContext {
             }
         };
 
-        let mut inflight = InflightReq::new(pending, rsp, retained_capacity);
+        let mut inflight = InflightReq::new(pending, output, retained_capacity);
         inflight.mark_submitted();
-        if let Some(rsp_buf) = inflight.rsp.as_ref() {
-            stats::on_virtiofs_response_submitted(trace_opcode, rsp_buf.writable_len(), fallback);
+        if let Some(output) = inflight.output.as_ref() {
+            stats::on_virtiofs_response_submitted(trace_opcode, output.writable_len(), fallback);
         }
         let replaced = match kind {
             QueueKind::Hiprio => self.hiprio_inflight.insert(token, inflight),
@@ -981,21 +1084,27 @@ impl VirtioFsBridgeContext {
         };
 
         let response_capacity = match kind {
-            QueueKind::Hiprio => self.hiprio_inflight.get(&token).and_then(|req| {
-                req.rsp.as_ref().map(|rsp| {
-                    rsp.allocation_len()
-                        .max(req.retained_capacity.unwrap_or_default())
-                })
-            }),
+            QueueKind::Hiprio => {
+                self.hiprio_inflight
+                    .get(&token)
+                    .and_then(|req| match req.output.as_ref() {
+                        Some(VirtioFsOutput::Contiguous(rsp)) => Some(
+                            rsp.allocation_len()
+                                .max(req.retained_capacity.unwrap_or_default()),
+                        ),
+                        _ => None,
+                    })
+            }
             QueueKind::Request(slot) => self
                 .request_inflight
                 .get(slot)
                 .and_then(|map| map.get(&token))
-                .and_then(|req| {
-                    req.rsp.as_ref().map(|rsp| {
+                .and_then(|req| match req.output.as_ref() {
+                    Some(VirtioFsOutput::Contiguous(rsp)) => Some(
                         rsp.allocation_len()
-                            .max(req.retained_capacity.unwrap_or_default())
-                    })
+                            .max(req.retained_capacity.unwrap_or_default()),
+                    ),
+                    _ => None,
                 }),
         };
         let reservation = if let Some(required_capacity) = response_capacity {
@@ -1027,10 +1136,9 @@ impl VirtioFsBridgeContext {
             .take()
             .expect("inflight request must own pending metadata");
         let inputs = [pending.req.bytes()];
-        let used_len_res = if let Some(rsp_buf) = inflight.rsp.as_mut() {
-            let output = match unsafe { rsp_buf.retirement_dma_slice(response_buffer_virt_to_phys) }
-            {
-                Ok(output) => output,
+        let used_len_res = if let Some(output) = inflight.output.as_mut() {
+            let mut outputs = match unsafe { output.dma_slices(false) } {
+                Ok(outputs) => outputs,
                 Err(_) => {
                     let unique = pending.unique;
                     inflight.pending = Some(pending);
@@ -1042,7 +1150,6 @@ impl VirtioFsBridgeContext {
                     return Err(SystemError::EIO);
                 }
             };
-            let mut outputs = [output];
             // SAFETY: The stateful response buffer reconstructed the exact virtual address and
             // length recorded at add, and `req_owner` references the same immutable FuseRequest.
             // On error the complete token owner is restored to the inflight map.
@@ -1118,12 +1225,73 @@ impl VirtioFsBridgeContext {
             return Ok(true);
         }
 
-        let mut rsp_buf = inflight
-            .rsp
+        let output = inflight
+            .output
             .take()
-            .expect("reply-bearing inflight request must own a response buffer");
-        let reservation = reservation
-            .expect("reply-bearing completion reserved retention capacity before pop_used");
+            .expect("reply-bearing inflight request must own output storage");
+        if let VirtioFsOutput::ReadPages { mut header, target } = output {
+            let capacity = core::mem::size_of::<FuseOutHeader>() + target.payload_capacity();
+            let request_reply_capacity = match pending.req.reply_contract() {
+                FuseReplyContract::Reply {
+                    capacity: Some(capacity),
+                } => capacity.bytes,
+                _ => 0,
+            };
+            stats::on_virtiofs_response_completed(opcode, capacity, used_len);
+            if target.mark_completed().is_err()
+                || used_len < core::mem::size_of::<FuseOutHeader>()
+                || used_len > capacity
+                || used_len > request_reply_capacity
+                || unsafe { header.complete_after_pop(core::mem::size_of::<FuseOutHeader>()) }
+                    .is_err()
+            {
+                let _ = target.rollback(SystemError::EIO);
+                self.terminate_pending_with_error(&pending, SystemError::EIO);
+                self.response_pool.release(header, false);
+                return Ok(true);
+            }
+            let header_bytes = header
+                .initialized_prefix()
+                .expect("direct header completion initialized the fixed header");
+            let out = match fuse_read_struct::<FuseOutHeader>(header_bytes) {
+                Ok(out) => out,
+                Err(_) => {
+                    let _ = target.rollback(SystemError::EIO);
+                    self.terminate_pending_with_error(&pending, SystemError::EIO);
+                    self.response_pool.release(header, true);
+                    return Ok(true);
+                }
+            };
+            let valid_error = out.error <= 0 && out.error > -512;
+            if out.unique != unique || out.len as usize != used_len || !valid_error {
+                let _ = target.rollback(SystemError::EIO);
+                self.terminate_pending_with_error(&pending, SystemError::EIO);
+                self.response_pool.release(header, true);
+                return Ok(true);
+            }
+            let payload_len = used_len - core::mem::size_of::<FuseOutHeader>();
+            if out.error != 0 && payload_len != 0 {
+                let _ = target.rollback(SystemError::EIO);
+                self.terminate_pending_with_error(&pending, SystemError::EIO);
+            } else if out.error != 0 {
+                let _ = target.rollback(SystemError::EIO);
+                Self::complete_request_with_negative_errno(&self.conn, unique, out.error);
+            } else if self
+                .conn
+                .complete_read_pages_direct(unique, payload_len)
+                .is_err()
+            {
+                let _ = target.rollback(SystemError::EIO);
+            }
+            stats::on_virtiofs_completed(used_len, false);
+            self.response_pool.release(header, true);
+            return Ok(true);
+        }
+        let VirtioFsOutput::Contiguous(mut rsp_buf) = output else {
+            unreachable!()
+        };
+        let reservation =
+            reservation.expect("contiguous completion reserved retention capacity before pop_used");
         let capacity = rsp_buf.writable_len();
         stats::on_virtiofs_response_completed(opcode, capacity, used_len);
         // SAFETY: pop_used succeeded for this exact token and DMA identity, so the descriptor is
@@ -1412,11 +1580,9 @@ impl VirtioFsBridgeContext {
         for (token, req) in inflight.iter_mut() {
             let req_owner = req.pending().req.clone();
             let inputs = [req_owner.bytes()];
-            let result = if let Some(rsp_buf) = req.rsp.as_mut() {
-                let output = match unsafe {
-                    rsp_buf.retirement_dma_slice(response_buffer_virt_to_phys)
-                } {
-                    Ok(output) => output,
+            let result = if let Some(output) = req.output.as_mut() {
+                let mut outputs = match unsafe { output.dma_slices(false) } {
+                    Ok(outputs) => outputs,
                     Err(_) => {
                         all_detached = false;
                         stats::on_virtiofs_detach_failure();
@@ -1429,7 +1595,6 @@ impl VirtioFsBridgeContext {
                         continue;
                     }
                 };
-                let mut outputs = [output];
                 // SAFETY: The caller invokes this only after the device reset completed, so the
                 // device can no longer access the queue. The stateful buffer reconstructed the
                 // exact virtual address and length recorded for this token.

--- a/kernel/src/filesystem/fuse/virtiofs/queue.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/queue.rs
@@ -26,6 +26,24 @@ pub(super) enum VirtioFsQueue {
 }
 
 impl VirtioFsQueue {
+    /// Total number of direct descriptors in this split virtqueue.
+    ///
+    /// virtiofs creates these queues with indirect descriptors disabled, so a request whose
+    /// immutable SG shape exceeds this value can never be submitted to this queue. Transient
+    /// descriptor exhaustion is still reported by `add` as `QueueFull`.
+    pub(super) const fn size(&self) -> usize {
+        match self {
+            Self::Q8(_) => 8,
+            Self::Q16(_) => 16,
+            Self::Q32(_) => 32,
+            Self::Q64(_) => 64,
+            Self::Q128(_) => 128,
+            Self::Q256(_) => 256,
+            Self::Q512(_) => 512,
+            Self::Q1024(_) => 1024,
+        }
+    }
+
     pub(super) fn can_pop(&self) -> bool {
         match self {
             Self::Q8(q) => q.can_pop(),

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -1,4 +1,7 @@
-use core::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering};
+use core::{
+    mem::ManuallyDrop,
+    sync::atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
+};
 
 use alloc::{
     collections::BTreeSet,
@@ -36,6 +39,7 @@ use crate::{libs::align::page_align_up, mm::page::PageType};
 use lazy_static::lazy_static;
 
 static PAGE_CACHE_ID: AtomicUsize = AtomicUsize::new(0);
+static PAGE_CACHE_DMA_RESERVATION_ID: AtomicU64 = AtomicU64::new(1);
 
 const PAGECACHE_IO_WORKERS: usize = 4;
 static PAGECACHE_IO_RR: AtomicUsize = AtomicUsize::new(0);
@@ -367,6 +371,345 @@ pub struct PageCacheManager {
     owner: Weak<PageCache>,
 }
 
+/// Lifecycle of pages reserved as direct DMA destinations for a cache read.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum PageCacheReadDmaState {
+    Prepared = 0,
+    Submitted = 1,
+    Completed = 2,
+    ResetRetired = 3,
+}
+
+/// Immutable identity of one full-page DMA output segment.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PageCacheReadDmaDescriptor {
+    page_index: usize,
+    vaddr: crate::mm::VirtAddr,
+    paddr: crate::mm::PhysAddr,
+}
+
+impl PageCacheReadDmaDescriptor {
+    pub fn page_index(&self) -> usize {
+        self.page_index
+    }
+
+    pub fn vaddr(&self) -> crate::mm::VirtAddr {
+        self.vaddr
+    }
+
+    pub fn paddr(&self) -> crate::mm::PhysAddr {
+        self.paddr
+    }
+
+    pub fn len(&self) -> usize {
+        MMArch::PAGE_SIZE
+    }
+}
+
+struct PageCacheReadDmaItem {
+    descriptor: PageCacheReadDmaDescriptor,
+    entry: Arc<PageEntry>,
+    page: Arc<Page>,
+}
+
+/// Owns candidate pages which are inaccessible to page-cache readers until DMA
+/// has retired, the unread tail has been initialized, and each exact marker is
+/// published.
+pub struct PageCacheReadDmaReservation {
+    id: u64,
+    cache: Arc<PageCache>,
+    state: AtomicU8,
+    items: ManuallyDrop<Vec<PageCacheReadDmaItem>>,
+}
+
+impl core::fmt::Debug for PageCacheReadDmaReservation {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PageCacheReadDmaReservation")
+            .field("id", &self.id)
+            .field("state", &self.state())
+            .field("pages", &self.items.len())
+            .finish()
+    }
+}
+
+impl Drop for PageCacheReadDmaReservation {
+    fn drop(&mut self) {
+        if self.state() == PageCacheReadDmaState::Submitted {
+            // A submitted owner is required to live in the pending table or reset
+            // quarantine. Do not detach its marker here: doing so could disguise
+            // a transport lifetime bug and permit a second fill of the same index.
+            log::error!(
+                "dropping submitted page-cache DMA reservation {} without retirement",
+                self.id
+            );
+            // Intentionally leak the exact page/entry owners. This is a last-line
+            // memory-safety guard for a violated transport contract, not a normal
+            // timeout path (which must retain the whole reservation in quarantine).
+            return;
+        }
+        self.rollback_markers(SystemError::EIO, true);
+        unsafe { ManuallyDrop::drop(&mut self.items) };
+    }
+}
+
+impl PageCacheReadDmaReservation {
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub fn state(&self) -> PageCacheReadDmaState {
+        match self.state.load(Ordering::Acquire) {
+            0 => PageCacheReadDmaState::Prepared,
+            1 => PageCacheReadDmaState::Submitted,
+            2 => PageCacheReadDmaState::Completed,
+            3 => PageCacheReadDmaState::ResetRetired,
+            _ => unreachable!("invalid page-cache DMA reservation state"),
+        }
+    }
+
+    pub fn page_count(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn payload_capacity(&self) -> usize {
+        self.items.len() * MMArch::PAGE_SIZE
+    }
+
+    pub fn descriptors(&self) -> impl ExactSizeIterator<Item = PageCacheReadDmaDescriptor> + '_ {
+        self.items.iter().map(|item| item.descriptor)
+    }
+
+    /// Must be called only after the virtqueue accepted all descriptors.
+    pub fn mark_submitted(&self) -> Result<(), SystemError> {
+        self.transition(
+            PageCacheReadDmaState::Prepared,
+            PageCacheReadDmaState::Submitted,
+        )
+    }
+
+    /// Records that the device can no longer access the pages (matching pop).
+    pub fn mark_completed(&self) -> Result<(), SystemError> {
+        self.transition(
+            PageCacheReadDmaState::Submitted,
+            PageCacheReadDmaState::Completed,
+        )
+    }
+
+    /// Records successful exact-token detach after reset. The owner remains alive
+    /// so callers may quarantine it until reset completion is beyond doubt.
+    pub fn mark_reset_retired(&self) -> Result<(), SystemError> {
+        self.transition(
+            PageCacheReadDmaState::Submitted,
+            PageCacheReadDmaState::ResetRetired,
+        )
+    }
+
+    /// Detach cache markers while DMA ownership is still unresolved. The state
+    /// deliberately remains Submitted and `self` must be retained in quarantine;
+    /// no page content may be accessed on this path.
+    pub fn detach_mapping_for_quarantine(&self) -> Result<(), SystemError> {
+        if self.state() != PageCacheReadDmaState::Submitted {
+            return Err(SystemError::EINVAL);
+        }
+        self.rollback_markers(SystemError::EIO, false);
+        Ok(())
+    }
+
+    fn transition(
+        &self,
+        from: PageCacheReadDmaState,
+        to: PageCacheReadDmaState,
+    ) -> Result<(), SystemError> {
+        if !page_cache_dma_transition_allowed(from, to) {
+            return Err(SystemError::EINVAL);
+        }
+        self.state
+            .compare_exchange(from as u8, to as u8, Ordering::AcqRel, Ordering::Acquire)
+            .map(|_| ())
+            .map_err(|_| SystemError::EINVAL)
+    }
+
+    /// Publish a successfully completed payload. Bytes not written by the device
+    /// are zeroed through the end of every reserved page before any page is made
+    /// visible.
+    pub fn publish_completed(&self, payload_len: usize) -> Result<Vec<Arc<Page>>, SystemError> {
+        if self.state() != PageCacheReadDmaState::Completed || payload_len > self.payload_capacity()
+        {
+            return Err(SystemError::EINVAL);
+        }
+
+        for (position, item) in self.items.iter().enumerate() {
+            let page_payload_start = position * MMArch::PAGE_SIZE;
+            let initialized = payload_len
+                .saturating_sub(page_payload_start)
+                .min(MMArch::PAGE_SIZE);
+            if initialized < MMArch::PAGE_SIZE {
+                let mut page = item.page.write();
+                unsafe { page.as_slice_mut()[initialized..].fill(0) };
+            }
+            item.page.write().add_flags(PageFlags::PG_UPTODATE);
+        }
+
+        let inner = self.cache.inner.lock();
+        for item in self.items.iter() {
+            let Some(current) = inner.get_entry(item.descriptor.page_index) else {
+                drop(inner);
+                self.rollback_markers(SystemError::EIO, true);
+                return Err(SystemError::EIO);
+            };
+            if !Arc::ptr_eq(&current, &item.entry)
+                || !Arc::ptr_eq(&current.page, &item.page)
+                || current.state() != PageState::Loading
+            {
+                drop(inner);
+                self.rollback_markers(SystemError::EIO, true);
+                return Err(SystemError::EIO);
+            }
+        }
+
+        let mut published = Vec::with_capacity(self.items.len());
+        for item in self.items.iter() {
+            let current = inner
+                .get_entry(item.descriptor.page_index)
+                .expect("DMA reservation identity was validated under the same lock");
+            self.cache
+                .account_state_transition(PageState::Loading, PageState::UpToDate);
+            current.set_state(PageState::UpToDate);
+            published.push(item.page.clone());
+            current.wait_queue.wake_all();
+        }
+        drop(inner);
+        Ok(published)
+    }
+
+    /// Complete the same reserved read through the bounded contiguous fallback.
+    ///
+    /// No device has observed these pages while they are Prepared. Copy the one reply into the
+    /// final candidate pages, then reuse the same tail-zeroing and identity-checked publication
+    /// path as a direct DMA completion.
+    pub fn publish_contiguous(&self, payload: &[u8]) -> Result<Vec<Arc<Page>>, SystemError> {
+        if payload.len() > self.payload_capacity() {
+            return Err(SystemError::EINVAL);
+        }
+        self.state
+            .compare_exchange(
+                PageCacheReadDmaState::Prepared as u8,
+                PageCacheReadDmaState::Completed as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map_err(|_| SystemError::EINVAL)?;
+
+        for (position, item) in self.items.iter().enumerate() {
+            let start = position * MMArch::PAGE_SIZE;
+            let len = payload.len().saturating_sub(start).min(MMArch::PAGE_SIZE);
+            if len == 0 {
+                break;
+            }
+            let mut page = item.page.write();
+            unsafe { page.as_slice_mut()[..len].copy_from_slice(&payload[start..start + len]) };
+        }
+        self.publish_completed(payload.len())
+    }
+
+    /// Remove all still-matching markers. Candidate pages stay owned by `self`;
+    /// this is important for reset-time quarantine.
+    pub fn rollback(&self, error: SystemError) -> Result<(), SystemError> {
+        match self.state() {
+            PageCacheReadDmaState::Prepared
+            | PageCacheReadDmaState::Completed
+            | PageCacheReadDmaState::ResetRetired => {
+                self.rollback_markers(error, true);
+                Ok(())
+            }
+            PageCacheReadDmaState::Submitted => Err(SystemError::EBUSY),
+        }
+    }
+
+    fn rollback_markers(&self, _error: SystemError, discard_pages: bool) {
+        for item in self.items.iter() {
+            let removed = {
+                let mut inner = self.cache.inner.lock();
+                let matches = inner
+                    .get_entry(item.descriptor.page_index)
+                    .map(|current| {
+                        Arc::ptr_eq(&current, &item.entry)
+                            && Arc::ptr_eq(&current.page, &item.page)
+                            && current.state() == PageState::Loading
+                    })
+                    .unwrap_or(false);
+                if matches {
+                    inner.remove_page(item.descriptor.page_index);
+                    true
+                } else {
+                    false
+                }
+            };
+            if removed {
+                item.entry.set_state(PageState::Error);
+                item.entry.wait_queue.wake_all();
+                if discard_pages {
+                    self.cache.discard_unlinked_page(&item.page);
+                }
+            }
+        }
+    }
+
+    fn cleanup_unsubmitted_items(cache: &Arc<PageCache>, items: &[PageCacheReadDmaItem]) {
+        for item in items {
+            let mut inner = cache.inner.lock();
+            if matches!(inner.get_entry(item.descriptor.page_index), Some(current) if Arc::ptr_eq(&current, &item.entry))
+            {
+                inner.remove_page(item.descriptor.page_index);
+                item.entry.set_state(PageState::Error);
+                item.entry.wait_queue.wake_all();
+            }
+            drop(inner);
+            cache.discard_unlinked_page(&item.page);
+        }
+    }
+}
+
+fn page_cache_dma_transition_allowed(
+    from: PageCacheReadDmaState,
+    to: PageCacheReadDmaState,
+) -> bool {
+    matches!(
+        (from, to),
+        (
+            PageCacheReadDmaState::Prepared,
+            PageCacheReadDmaState::Submitted
+        ) | (
+            PageCacheReadDmaState::Submitted,
+            PageCacheReadDmaState::Completed
+        ) | (
+            PageCacheReadDmaState::Submitted,
+            PageCacheReadDmaState::ResetRetired
+        )
+    )
+}
+
+#[cfg(test)]
+mod page_cache_dma_state_tests {
+    use super::{page_cache_dma_transition_allowed, PageCacheReadDmaState::*};
+
+    #[test]
+    fn accepts_only_submission_and_dma_retirement_edges() {
+        assert!(page_cache_dma_transition_allowed(Prepared, Submitted));
+        assert!(page_cache_dma_transition_allowed(Submitted, Completed));
+        assert!(page_cache_dma_transition_allowed(Submitted, ResetRetired));
+
+        for state in [Prepared, Submitted, Completed, ResetRetired] {
+            assert!(!page_cache_dma_transition_allowed(state, state));
+        }
+        assert!(!page_cache_dma_transition_allowed(Prepared, Completed));
+        assert!(!page_cache_dma_transition_allowed(Prepared, ResetRetired));
+        assert!(!page_cache_dma_transition_allowed(Completed, Submitted));
+        assert!(!page_cache_dma_transition_allowed(ResetRetired, Submitted));
+    }
+}
+
 /// RAII guard: ensures that a page entering Writeback state always calls
 /// `finish_writeback_entry` on any early-exit path, preventing pages from
 /// permanently stuck in Writeback.
@@ -428,6 +771,74 @@ impl PageCacheManager {
         self.upgrade()?.get_or_create_page_for_read(page_index)
     }
 
+    /// Reserve absent cache indices as full-page DMA destinations.
+    ///
+    /// Existing pages, including another Loading entry, are never replaced.
+    pub fn reserve_read_dma(
+        &self,
+        start_page_index: usize,
+        page_count: usize,
+    ) -> Result<PageCacheReadDmaReservation, SystemError> {
+        if page_count == 0 || start_page_index.checked_add(page_count - 1).is_none() {
+            return Err(SystemError::EINVAL);
+        }
+
+        let cache = self.upgrade()?;
+        let _invalidate = cache.invalidate_read();
+        let page_cache_ref = cache.inner.lock().page_cache_ref.clone();
+        let mut items: Vec<PageCacheReadDmaItem> = Vec::with_capacity(page_count);
+
+        for offset in 0..page_count {
+            let page_index = start_page_index + offset;
+            if cache.inner.lock().get_entry(page_index).is_some() {
+                PageCacheReadDmaReservation::cleanup_unsubmitted_items(&cache, &items);
+                return Err(SystemError::EEXIST);
+            }
+
+            let page = match cache.allocate_page(page_cache_ref.clone(), page_index) {
+                Ok(page) => page,
+                Err(error) => {
+                    PageCacheReadDmaReservation::cleanup_unsubmitted_items(&cache, &items);
+                    return Err(error);
+                }
+            };
+            let paddr = page.phys_address();
+            let Some(vaddr) = (unsafe { MMArch::phys_2_virt(paddr) }) else {
+                cache.discard_unlinked_page(&page);
+                PageCacheReadDmaReservation::cleanup_unsubmitted_items(&cache, &items);
+                return Err(SystemError::EFAULT);
+            };
+            let entry = Arc::new(PageEntry::new(page.clone(), PageState::Loading));
+            let mut inner = cache.inner.lock();
+            if inner.get_entry(page_index).is_some() {
+                drop(inner);
+                cache.discard_unlinked_page(&page);
+                PageCacheReadDmaReservation::cleanup_unsubmitted_items(&cache, &items);
+                return Err(SystemError::EEXIST);
+            }
+            inner.insert_entry(page_index, entry.clone());
+            drop(inner);
+            cache.reconcile_entry_unevictable_for_insert(&entry);
+            items.push(PageCacheReadDmaItem {
+                descriptor: PageCacheReadDmaDescriptor {
+                    page_index,
+                    vaddr,
+                    paddr,
+                },
+                entry,
+                page,
+            });
+        }
+
+        drop(_invalidate);
+        Ok(PageCacheReadDmaReservation {
+            id: PAGE_CACHE_DMA_RESERVATION_ID.fetch_add(1, Ordering::Relaxed),
+            cache,
+            state: AtomicU8::new(PageCacheReadDmaState::Prepared as u8),
+            items: ManuallyDrop::new(items),
+        })
+    }
+
     pub fn commit_page_pinned(&self, page_index: usize) -> Result<PageCachePagePin, SystemError> {
         self.upgrade()?
             .get_or_create_page_for_read_pinned(page_index)
@@ -486,9 +897,13 @@ impl PageCacheManager {
     }
 
     pub fn get_page_any(&self, page_index: usize) -> Option<Arc<Page>> {
-        self.upgrade()
-            .ok()
-            .and_then(|cache| cache.lock().get_page(page_index))
+        self.upgrade().ok().and_then(|cache| {
+            let inner = cache.inner.lock();
+            inner
+                .get_entry(page_index)
+                .filter(|entry| entry.state() != PageState::Loading)
+                .map(|entry| entry.page.clone())
+        })
     }
 
     pub fn update_clean_page(


### PR DESCRIPTION
## Summary

- add owned page-cache DMA reservations for virtiofs `FUSE_READ` replies
- submit eligible cached reads as a reply header plus final cache-page SG segments
- retain the bounded contiguous reply as a same-request fallback for unsupported layouts and direct I/O
- validate descriptor usage, reply headers, requested size, short reads, and error replies before publishing pages
- preserve exact DMA owners across queue retry, completion, reset, detach, timeout quarantine, cancellation, invalidation, and unmount

## Root cause

The FUSE request contract only described a maximum contiguous reply capacity. The virtiofs bridge therefore had no owned representation of final destination pages and had to receive every `FUSE_READ` payload into a transport buffer before copying it into the page cache.

## Validation

- `cargo fmt --manifest-path kernel/Cargo.toml --all -- --check`
- `git diff --check`
- `make kernel`
- QEMU nographic boot
- guest `fuse_core_test`: 5/5 passed
- guest `fuse_extended_test`: 55/55 passed
- post-review focused cached/mmap/direct-I/O/truncate filter: 9/9 passed
- `virtiofs_smoke_test` reached the guest but skipped because this host run did not provide the `hostshare` virtiofs device

Closes #2039
