### PR TITLE
perf(overlayfs): cache merged directories and narrow mutation locks

### DIFF
--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -106,12 +106,12 @@ impl OvlInode {
         let (parent_path, name) = self.upper_parent_path_and_name();
         let parent_inode = self.ensure_upper_dir_path(parent_path)?;
         match parent_inode.find(name) {
-            Ok(existing) => {
-                let existing = Self::validate_existing_upper(existing, &metadata)?;
-                self.set_origin(metadata::load_origin(self, &existing)?);
-                *upper_inode = Some(existing);
-                return Ok(CopyUpOutcome::Existing);
-            }
+            // The redirect stripe is held for the whole copy-up, so another
+            // copy-up of this object cannot have published this entry.  An
+            // unexpected upper therefore belongs to a newer namespace
+            // object; adopting it would let a stale lower inode modify that
+            // replacement.
+            Ok(_) => return Err(SystemError::ESTALE),
             Err(SystemError::ENOENT) => {}
             Err(err) => return Err(err),
         }
@@ -190,11 +190,10 @@ impl OvlInode {
             }
             Err(SystemError::EEXIST) => {
                 let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
-                let existing = parent_inode.find(name)?;
-                let existing = Self::validate_existing_upper(existing, &metadata)?;
-                self.set_origin(metadata::load_origin(self, &existing)?);
-                *upper_inode = Some(existing);
-                return Ok(CopyUpOutcome::Existing);
+                // NOREPLACE can fail here only if the parent namespace changed
+                // after the absence check above.  Never bind this stale lower
+                // inode to the replacement that won the race.
+                return Err(SystemError::ESTALE);
             }
             Err(err) => {
                 let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -223,6 +223,11 @@ impl OvlInode {
             }
             current_path.push_str(component);
 
+            // Serialize the absence check and publication for this ancestor
+            // independently from leaf copy-up stripes.  The guard is dropped
+            // after each component, so ancestor locks are never nested.
+            let fs = self.overlay_fs()?;
+            let _ancestor_guard = fs.ancestor_copy_up_lock(&current_path).lock();
             match current.find(component) {
                 Ok(next) => {
                     if Self::is_whiteout_inode_checked(&next)?

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -59,7 +59,7 @@ impl OvlInode {
         };
 
         let fs = self.overlay_fs()?;
-        let _mutation_guard = fs.mutation_lock.lock();
+        let _copy_up_guard = fs.copy_up_lock(&self.redirect).lock();
         let outcome = self.copy_up_locked_with_size(copy_size)?;
         if copy_size.is_none() {
             Ok(OpenCopyUpOutcome::NoTruncateRequested)
@@ -71,10 +71,14 @@ impl OvlInode {
     }
 
     pub(super) fn copy_up_locked(&self) -> Result<(), SystemError> {
+        let fs = self.overlay_fs()?;
+        let _copy_up_guard = fs.copy_up_lock(&self.redirect).lock();
         self.copy_up_locked_with_size(None).map(|_| ())
     }
 
     pub(super) fn copy_up_locked_for_truncate(&self, len: usize) -> Result<(), SystemError> {
+        let fs = self.overlay_fs()?;
+        let _copy_up_guard = fs.copy_up_lock(&self.redirect).lock();
         self.copy_up_locked_with_size(Some(len)).map(|_| ())
     }
 

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -106,7 +106,25 @@ impl OvlInode {
 
         let (parent_path, name) = self.upper_parent_path_and_name();
         let parent_inode = self.ensure_upper_dir_path(parent_path)?;
+        // Directory copy-up and publication of this path as another object's
+        // ancestor share the same exact-path commit domain.  Parent ancestor
+        // guards have already been released by ensure_upper_dir_path().
+        let _ancestor_publish_guard = (metadata.file_type == FileType::Dir)
+            .then(|| fs.ancestor_copy_up_lock(&self.redirect).lock());
         match parent_inode.find(name) {
+            Ok(existing)
+                if metadata.file_type == FileType::Dir
+                    && fs.matches_ancestor_publication(
+                        &self.redirect,
+                        &self.lower_inodes,
+                        &existing,
+                    )? =>
+            {
+                let existing = Self::validate_existing_upper(existing, &metadata)?;
+                self.set_origin(metadata::load_origin(self, &existing)?);
+                *upper_inode = Some(existing);
+                return Ok(CopyUpOutcome::Existing);
+            }
             // The redirect stripe is held for the whole copy-up, so another
             // copy-up of this object cannot have published this entry.  An
             // unexpected upper therefore belongs to a newer namespace

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -295,6 +295,9 @@ impl OvlInode {
                         return Ok(existing);
                     }
                 }
+                if fs.matches_ancestor_publication(lower_path, &lowers, &existing)? {
+                    return Ok(existing);
+                }
                 return Err(SystemError::ESTALE);
             }
             Err(SystemError::ENOENT) => {}
@@ -319,6 +322,13 @@ impl OvlInode {
                 return Err(err);
             }
         };
+        let publication = match fs.prepare_ancestor_publication(&lowers, &temp) {
+            Ok(publication) => publication,
+            Err(err) => {
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+                return Err(err);
+            }
+        };
 
         match workdir.move_to(&temp_name, upper_parent, name, RenameFlags::NOREPLACE) {
             Ok(()) => {
@@ -329,6 +339,7 @@ impl OvlInode {
                         inode.set_origin(origin);
                     }
                 }
+                fs.remember_ancestor_publication(lower_path, publication);
                 Ok(temp)
             }
             Err(SystemError::EEXIST) => {

--- a/kernel/src/filesystem/overlayfs/copy_up.rs
+++ b/kernel/src/filesystem/overlayfs/copy_up.rs
@@ -14,6 +14,7 @@ use crate::process::{
 };
 use alloc::string::String;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use system_error::SystemError;
 
 const COPY_UP_CHUNK_SIZE: usize = 64 * 1024;
@@ -241,19 +242,23 @@ impl OvlInode {
         Ok(current)
     }
 
-    fn lower_dir_inode(&self, path: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
+    fn lower_dir_inodes(&self, path: &str) -> Result<Vec<Arc<dyn IndexNode>>, SystemError> {
         let fs = self.overlay_fs()?;
+        let mut lowers = Vec::new();
         for layer in fs.layers.iter().skip(1) {
             if let Some(lower_root) = layer.mnt.lower_inodes.first() {
-                if let Ok(inode) = lower_root.lookup(path) {
-                    if inode.metadata()?.file_type == FileType::Dir {
-                        return Ok(inode);
-                    }
-                    return Err(SystemError::ENOTDIR);
+                match lower_root.lookup(path) {
+                    Ok(inode) if inode.metadata()?.file_type == FileType::Dir => lowers.push(inode),
+                    Ok(_) if lowers.is_empty() => return Err(SystemError::ENOTDIR),
+                    Ok(_) => break,
+                    Err(SystemError::ENOENT) => {}
+                    Err(err) => return Err(err),
                 }
             }
         }
-        Err(SystemError::ENOENT)
+        (!lowers.is_empty())
+            .then_some(lowers)
+            .ok_or(SystemError::ENOENT)
     }
 
     fn copy_up_dir_component(
@@ -262,7 +267,34 @@ impl OvlInode {
         name: &str,
         lower_path: &str,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
-        let lower = self.lower_dir_inode(lower_path)?;
+        let fs = self.overlay_fs()?;
+        let lowers = self.lower_dir_inodes(lower_path)?;
+        let lower = &lowers[0];
+        let cached_dirs = fs.cached_lower_dirs(lower_path, &lowers)?;
+        let mut cached_upper_guards = cached_dirs
+            .iter()
+            .map(|inode| inode.upper_inode.lock())
+            .collect::<Vec<_>>();
+        match upper_parent.find(name) {
+            Ok(existing) => {
+                if Self::is_whiteout_inode_checked(&existing)?
+                    || existing.metadata()?.file_type != FileType::Dir
+                {
+                    return Err(SystemError::ENOTDIR);
+                }
+                for upper in cached_upper_guards
+                    .iter()
+                    .filter_map(|upper| upper.as_ref())
+                {
+                    if fs.same_backing_inode(upper, &existing)? {
+                        return Ok(existing);
+                    }
+                }
+                return Err(SystemError::ESTALE);
+            }
+            Err(SystemError::ENOENT) => {}
+            Err(err) => return Err(err),
+        }
         let lower_metadata = lower.metadata()?;
         let parent_metadata = upper_parent.metadata()?;
         let (workdir, temp, temp_name) = self.create_workdir_temp(|workdir, temp_name| {
@@ -270,29 +302,33 @@ impl OvlInode {
         })?;
 
         let prepared = (|| {
-            metadata::copy_xattrs(&lower, &temp)?;
-            metadata::prepare_origin(self, &lower, &temp, &lower_metadata)?;
-            Self::restore_copy_up_metadata(&temp, &lower_metadata)
+            metadata::copy_xattrs(lower, &temp)?;
+            let origin = metadata::prepare_origin(self, lower, &temp, &lower_metadata)?;
+            Self::restore_copy_up_metadata(&temp, &lower_metadata)?;
+            Ok(origin)
         })();
-        if let Err(err) = prepared {
-            let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
-            return Err(err);
-        }
+        let origin = match prepared {
+            Ok(origin) => origin,
+            Err(err) => {
+                let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
+                return Err(err);
+            }
+        };
 
         match workdir.move_to(&temp_name, upper_parent, name, RenameFlags::NOREPLACE) {
             Ok(()) => {
                 Self::restore_parent_timestamps(upper_parent, &parent_metadata);
+                for (inode, upper) in cached_dirs.iter().zip(cached_upper_guards.iter_mut()) {
+                    if upper.is_none() {
+                        **upper = Some(temp.clone());
+                        inode.set_origin(origin);
+                    }
+                }
                 Ok(temp)
             }
             Err(SystemError::EEXIST) => {
                 let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);
-                let existing = upper_parent.find(name)?;
-                if Self::is_whiteout_inode_checked(&existing)?
-                    || existing.metadata()?.file_type != FileType::Dir
-                {
-                    return Err(SystemError::EIO);
-                }
-                Ok(existing)
+                Err(SystemError::ESTALE)
             }
             Err(err) => {
                 let _ = Self::cleanup_workdir_temp(&workdir, &temp_name);

--- a/kernel/src/filesystem/overlayfs/dir.rs
+++ b/kernel/src/filesystem/overlayfs/dir.rs
@@ -10,14 +10,18 @@ pub(super) fn mkdir(
     name: &str,
     mode: vfs::InodeMode,
 ) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
-    let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
-    create_over_whiteout(
+    let state = inode.dir_state()?;
+    let _mutation_guard = state.mutation_lock.lock();
+    let result = create_over_whiteout(
         inode,
         name,
         |dir, temp_name| dir.mkdir(temp_name, mode),
         true,
-    )
+    );
+    if result.is_ok() {
+        state.modified(&[name]);
+    }
+    result
 }
 
 pub(super) fn rmdir(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
@@ -30,9 +34,13 @@ pub(super) fn unlink(inode: &OvlInode, name: &str) -> Result<(), SystemError> {
 
 fn remove(inode: &OvlInode, name: &str, is_dir: bool) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
+    // rmdir keeps the mount-wide commit lock because it nests a child directory
+    // emptiness check. Unlink only needs the stable parent namespace lock.
+    let _commit_guard = is_dir.then(|| fs.mutation_lock.lock());
+    let state = inode.dir_state()?;
+    let _mutation_guard = state.mutation_lock.lock();
 
-    let child = inode.lookup_overlay_child(name)?;
+    let child = inode.lookup_overlay_child_locked(name, &state)?;
     if is_dir && !child.is_dir() {
         return Err(SystemError::ENOTDIR);
     }
@@ -49,23 +57,26 @@ fn remove(inode: &OvlInode, name: &str, is_dir: bool) -> Result<(), SystemError>
     }
 
     let upper_dir = inode.upper_inode.lock().clone();
-    if let Some(upper_dir) = upper_dir {
+    let result = if let Some(upper_dir) = upper_dir {
         match upper_dir.find(name) {
             Ok(_) if lower_positive => {
-                return inode.replace_upper_with_whiteout_locked(name, is_dir);
+                inode.replace_upper_with_whiteout_locked(name, is_dir)
             }
-            Ok(_) if is_dir => return upper_dir.rmdir(name),
-            Ok(_) => return upper_dir.unlink(name),
-            Err(SystemError::ENOENT) => {}
-            Err(err) => return Err(err),
+            Ok(_) if is_dir => upper_dir.rmdir(name),
+            Ok(_) => upper_dir.unlink(name),
+            Err(SystemError::ENOENT) if lower_positive => inode.create_whiteout_locked(name),
+            Err(SystemError::ENOENT) => Err(SystemError::ENOENT),
+            Err(err) => Err(err),
         }
-    }
-
-    if lower_positive {
+    } else if lower_positive {
         inode.create_whiteout_locked(name)
     } else {
         Err(SystemError::ENOENT)
+    };
+    if result.is_ok() {
+        state.modified(&[name]);
     }
+    result
 }
 
 pub(super) fn link(
@@ -74,9 +85,10 @@ pub(super) fn link(
     other: &Arc<dyn IndexNode>,
 ) -> Result<(), system_error::SystemError> {
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
+    let state = inode.dir_state()?;
+    let _mutation_guard = state.mutation_lock.lock();
 
-    match inode.find(name) {
+    match super::lookup::find_locked(inode, name, &state) {
         Ok(_) => return Err(SystemError::EEXIST),
         Err(SystemError::ENOENT) => {}
         Err(err) => return Err(err),
@@ -91,7 +103,7 @@ pub(super) fn link(
     source.copy_up_locked()?;
     let source_upper = source.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
 
-    create_over_whiteout(
+    let result = create_over_whiteout(
         inode,
         name,
         |dir, temp_name| {
@@ -100,7 +112,11 @@ pub(super) fn link(
         },
         false,
     )
-    .map(|_| ())
+    .map(|_| ());
+    if result.is_ok() {
+        state.modified(&[name]);
+    }
+    result
 }
 
 pub(super) fn create(
@@ -109,14 +125,18 @@ pub(super) fn create(
     file_type: vfs::FileType,
     mode: vfs::InodeMode,
 ) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
-    let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
-    create_over_whiteout(
+    let state = inode.dir_state()?;
+    let _mutation_guard = state.mutation_lock.lock();
+    let result = create_over_whiteout(
         inode,
         name,
         |dir, temp_name| dir.create(temp_name, file_type, mode),
         file_type == FileType::Dir,
-    )
+    );
+    if result.is_ok() {
+        state.modified(&[name]);
+    }
+    result
 }
 
 pub(super) fn mknod(
@@ -125,18 +145,22 @@ pub(super) fn mknod(
     mode: vfs::InodeMode,
     dev_t: DeviceNumber,
 ) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
-    let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
+    let state = inode.dir_state()?;
+    let _mutation_guard = state.mutation_lock.lock();
     if FileType::from(mode) == FileType::CharDevice && dev_t == WHITEOUT_DEV {
         return Err(SystemError::EPERM);
     }
 
-    create_over_whiteout(
+    let result = create_over_whiteout(
         inode,
         filename,
         |dir, temp_name| dir.mknod(temp_name, mode, dev_t),
         FileType::from(mode) == FileType::Dir,
-    )
+    );
+    if result.is_ok() {
+        state.modified(&[filename]);
+    }
+    result
 }
 
 pub(super) fn is_dir_empty(inode: &Arc<dyn IndexNode>) -> Result<bool, SystemError> {

--- a/kernel/src/filesystem/overlayfs/dir.rs
+++ b/kernel/src/filesystem/overlayfs/dir.rs
@@ -59,9 +59,7 @@ fn remove(inode: &OvlInode, name: &str, is_dir: bool) -> Result<(), SystemError>
     let upper_dir = inode.upper_inode.lock().clone();
     let result = if let Some(upper_dir) = upper_dir {
         match upper_dir.find(name) {
-            Ok(_) if lower_positive => {
-                inode.replace_upper_with_whiteout_locked(name, is_dir)
-            }
+            Ok(_) if lower_positive => inode.replace_upper_with_whiteout_locked(name, is_dir),
             Ok(_) if is_dir => upper_dir.rmdir(name),
             Ok(_) => upper_dir.unlink(name),
             Err(SystemError::ENOENT) if lower_positive => inode.create_whiteout_locked(name),

--- a/kernel/src/filesystem/overlayfs/dir.rs
+++ b/kernel/src/filesystem/overlayfs/dir.rs
@@ -1,4 +1,4 @@
-use super::inode::OvlInode;
+use super::inode::{DirState, OvlInode};
 use super::whiteout::WHITEOUT_DEV;
 use crate::driver::base::device::device_number::DeviceNumber;
 use crate::filesystem::vfs::{self, FileType, IndexNode};
@@ -48,12 +48,18 @@ fn remove(inode: &OvlInode, name: &str, is_dir: bool) -> Result<(), SystemError>
         return Err(SystemError::EISDIR);
     }
 
+    // Serialize the emptiness check and namespace commit with mutations made
+    // through an already-resolved fd for the child directory.  The parent
+    // lock alone cannot exclude create/unlink operations inside that child.
+    let child_state = is_dir.then(|| child.dir_state()).transpose()?;
+    let _child_mutation_guard = child_state.as_ref().map(|state| state.mutation_lock.lock());
+
     let lower_positive = inode.lower_positive(name);
-    if is_dir && (lower_positive || child.has_lower()) {
-        let child_inode: Arc<dyn IndexNode> = child.clone();
-        if !is_dir_empty(&child_inode)? {
-            return Err(SystemError::ENOTEMPTY);
-        }
+    if is_dir
+        && (lower_positive || child.has_lower())
+        && !is_dir_empty_locked(&child, child_state.as_ref().ok_or(SystemError::EIO)?)?
+    {
+        return Err(SystemError::ENOTEMPTY);
     }
 
     let upper_dir = inode.upper_inode.lock().clone();
@@ -161,8 +167,10 @@ pub(super) fn mknod(
     result
 }
 
-pub(super) fn is_dir_empty(inode: &Arc<dyn IndexNode>) -> Result<bool, SystemError> {
-    Ok(inode.list()?.iter().all(|entry| is_dot_entry(entry)))
+pub(super) fn is_dir_empty_locked(inode: &OvlInode, state: &DirState) -> Result<bool, SystemError> {
+    Ok(super::readdir::list_locked(inode, state)?
+        .iter()
+        .all(|entry| is_dot_entry(entry)))
 }
 
 fn create_over_whiteout<F>(

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -98,6 +98,7 @@ pub(super) fn write_at(
     let _privilege_guard = inode.content_privilege_lock.lock();
     let (backing_file, _) = backing_file_for_io(inode, data)?;
     let fs = inode.overlay_fs()?;
+    let _content_guard = fs.content_lock(&backing_file.inode())?.lock();
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     super::metadata::remove_security_capability(&backing_file.inode())?;
     backing_file.pwrite(offset, len, buf)
@@ -238,6 +239,8 @@ fn open_backing_file(
         backing_cred.clone(),
     )?;
     if inode.file_type == FileType::File && backing_is_upper && needs_post_open_truncate {
+        let fs = inode.overlay_fs()?;
+        let _content_guard = fs.content_lock(&backing_file.inode())?.lock();
         vcore::vfs_truncate_file(
             backing_file.inode(),
             0,

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -205,7 +205,8 @@ impl OverlayFS {
         file_type: FileType,
         upper_inode: Option<Arc<dyn IndexNode>>,
         lower_inodes: Vec<Arc<dyn IndexNode>>,
-    ) -> Result<Arc<OvlInode>, SystemError> {
+        replace_stale: bool,
+    ) -> Result<Option<Arc<OvlInode>>, SystemError> {
         let origin = if lower_inodes.is_empty() {
             OvlInodeOrigin::Upper(RealInodeIdentity::from_inode(
                 upper_inode.as_ref().ok_or(SystemError::ENOENT)?,
@@ -242,6 +243,12 @@ impl OverlayFS {
                     }
                     continue;
                 }
+                // A lower-only backing snapshot can race with this candidate's
+                // copy-up publication.  Ask lookup to refresh the backing once
+                // before deciding that the cached upper is detached.
+                if !expected_has_upper && !replace_stale {
+                    return Ok(None);
+                }
             }
 
             let replacement = {
@@ -263,7 +270,7 @@ impl OverlayFS {
             }
         };
         inode.load_origin_once()?;
-        Ok(inode)
+        Ok(Some(inode))
     }
 
     pub(super) fn cached_lower_dirs(

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -1,6 +1,6 @@
 use super::config::OverlayMountData;
 use super::entry::OvlLayer;
-use super::inode::OvlInode;
+use super::inode::{DirState, OvlInode};
 use crate::driver::base::device::device_number::DeviceNumber;
 use crate::filesystem::vfs::mount::{MountFS, MountFSInode};
 use crate::filesystem::vfs::{
@@ -54,9 +54,39 @@ struct OvlInodeCacheKey {
     origin: OvlInodeOrigin,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum DirIdentity {
+    Lower(Vec<RealInodeIdentity>),
+    Upper(RealInodeIdentity),
+}
+
+#[derive(Debug, Default)]
+struct DirStateCache {
+    entries: BTreeMap<DirIdentity, Weak<DirState>>,
+    insertions_since_prune: usize,
+}
+
+impl DirStateCache {
+    fn intern(&mut self, key: DirIdentity) -> Arc<DirState> {
+        if let Some(state) = self.entries.get(&key).and_then(Weak::upgrade) {
+            return state;
+        }
+        if self.insertions_since_prune >= INODE_CACHE_PRUNE_INTERVAL {
+            self.entries.retain(|_, state| state.strong_count() != 0);
+            self.insertions_since_prune = 0;
+        }
+        let state = Arc::new(DirState::default());
+        self.entries.insert(key, Arc::downgrade(&state));
+        self.insertions_since_prune += 1;
+        state
+    }
+}
+
 #[derive(Debug, Default)]
 struct OvlInodeCache {
     entries: BTreeMap<OvlInodeCacheKey, Weak<OvlInode>>,
+    /// Mount-global bounded retention for repeated short-lived lookups.
+    recent_lookups: VecDeque<Arc<OvlInode>>,
     /// Bounded strong cache for non-samefs directories whose fallback inode
     /// number is only meaningful for the OvlInode cache lifetime.
     recent_fallback_dirs: VecDeque<Arc<OvlInode>>,
@@ -64,6 +94,8 @@ struct OvlInodeCache {
 }
 
 const FALLBACK_DIR_CACHE_SIZE: usize = 256;
+const LOOKUP_RETENTION_SIZE: usize = 1024;
+const LOCK_STRIPE_COUNT: usize = 64;
 
 impl OvlInodeCache {
     fn intern(
@@ -85,6 +117,13 @@ impl OvlInodeCache {
             self.insertions_since_prune += 1;
             inode
         };
+
+        self.recent_lookups
+            .retain(|cached| !Arc::ptr_eq(cached, &inode));
+        self.recent_lookups.push_back(inode.clone());
+        if self.recent_lookups.len() > LOOKUP_RETENTION_SIZE {
+            self.recent_lookups.pop_front();
+        }
 
         if retain_fallback_dir {
             self.recent_fallback_dirs
@@ -122,6 +161,9 @@ pub(super) struct OverlayFS {
     pub(super) backing_cred: Arc<Cred>,
     pub(super) samefs: bool,
     inode_cache: Mutex<OvlInodeCache>,
+    dir_state_cache: Mutex<DirStateCache>,
+    copy_up_locks: Vec<Mutex<()>>,
+    content_locks: Vec<Mutex<()>>,
 }
 
 impl FileSystem for OverlayFS {
@@ -200,6 +242,46 @@ impl OverlayFS {
             });
         inode.load_origin_once()?;
         Ok(inode)
+    }
+
+    pub(super) fn intern_dir_state(
+        &self,
+        inode: &OvlInode,
+    ) -> Result<Arc<DirState>, SystemError> {
+        let identity = if inode.lower_inodes.is_empty() {
+            DirIdentity::Upper(RealInodeIdentity::from_inode(
+                inode.upper_inode.lock().as_ref().ok_or(SystemError::ENOENT)?,
+            )?)
+        } else {
+            DirIdentity::Lower(
+                inode
+                    .lower_inodes
+                    .iter()
+                    .map(RealInodeIdentity::from_inode)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+        };
+        Ok(self.dir_state_cache.lock().intern(identity))
+    }
+
+    pub(super) fn copy_up_lock(&self, redirect: &str) -> &Mutex<()> {
+        let mut hash = 0xcbf29ce484222325u64;
+        for byte in redirect.as_bytes() {
+            hash ^= *byte as u64;
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        &self.copy_up_locks[hash as usize % self.copy_up_locks.len()]
+    }
+
+    pub(super) fn content_lock(
+        &self,
+        inode: &Arc<dyn IndexNode>,
+    ) -> Result<&Mutex<()>, SystemError> {
+        let identity = RealInodeIdentity::from_inode(inode)?;
+        let mut hash = identity.filesystem as u64;
+        hash ^= (identity.dev_id as u64).rotate_left(21);
+        hash ^= (identity.inode_id.data() as u64).rotate_left(42);
+        Ok(&self.content_locks[hash as usize % self.content_locks.len()])
     }
 
     fn canonical_backing_fs(inode: &Arc<dyn IndexNode>) -> Arc<dyn FileSystem> {
@@ -436,6 +518,9 @@ impl MountableFileSystem for OverlayFS {
                 backing_cred,
                 samefs,
                 inode_cache: Mutex::new(OvlInodeCache::default()),
+                dir_state_cache: Mutex::new(DirStateCache::default()),
+                copy_up_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),
+                content_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),
             }
         });
         fs.root_inode.load_origin_once()?;

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -244,6 +244,42 @@ impl OverlayFS {
         Ok(inode)
     }
 
+    pub(super) fn cached_lower_dirs(
+        &self,
+        redirect: &str,
+        lowers: &[Arc<dyn IndexNode>],
+    ) -> Result<Vec<Arc<OvlInode>>, SystemError> {
+        let lower_identities = lowers
+            .iter()
+            .map(RealInodeIdentity::from_inode)
+            .collect::<Result<Vec<_>, _>>()?;
+        let cache = self.inode_cache.lock();
+        let mut inodes = cache
+            .entries
+            .iter()
+            .filter_map(|(key, inode)| {
+                let OvlInodeOrigin::Lower { lower, .. } = &key.origin else {
+                    return None;
+                };
+                (key.redirect == redirect && *lower == lower_identities)
+                    .then(|| inode.upgrade())
+                    .flatten()
+            })
+            .filter(|inode| inode.is_dir())
+            .collect::<Vec<_>>();
+        inodes.sort_by_key(Arc::as_ptr);
+        inodes.dedup_by(|left, right| Arc::ptr_eq(left, right));
+        Ok(inodes)
+    }
+
+    pub(super) fn same_backing_inode(
+        &self,
+        left: &Arc<dyn IndexNode>,
+        right: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        Self::same_mount_inode(left, right)
+    }
+
     pub(super) fn intern_dir_state(&self, inode: &OvlInode) -> Result<Arc<DirState>, SystemError> {
         let identity = if inode.lower_inodes.is_empty() {
             DirIdentity::Upper(RealInodeIdentity::from_inode(

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -93,6 +93,18 @@ struct OvlInodeCache {
     insertions_since_prune: usize,
 }
 
+#[derive(Debug)]
+pub(super) struct AncestorPublication {
+    lower: Vec<RealInodeIdentity>,
+    upper: Weak<dyn IndexNode>,
+}
+
+#[derive(Debug, Default)]
+struct AncestorPublicationCache {
+    entries: BTreeMap<String, AncestorPublication>,
+    insertions_since_prune: usize,
+}
+
 const FALLBACK_DIR_CACHE_SIZE: usize = 256;
 const LOOKUP_RETENTION_SIZE: usize = 1024;
 const LOCK_STRIPE_COUNT: usize = 64;
@@ -164,6 +176,7 @@ pub(super) struct OverlayFS {
     pub(super) samefs: bool,
     inode_cache: Mutex<OvlInodeCache>,
     dir_state_cache: Mutex<DirStateCache>,
+    ancestor_publications: Mutex<AncestorPublicationCache>,
     copy_up_locks: Vec<Mutex<()>>,
     ancestor_copy_up_locks: Vec<Mutex<()>>,
     content_locks: Vec<Mutex<()>>,
@@ -299,6 +312,60 @@ impl OverlayFS {
         inodes.sort_by_key(Arc::as_ptr);
         inodes.dedup_by(|left, right| Arc::ptr_eq(left, right));
         Ok(inodes)
+    }
+
+    pub(super) fn prepare_ancestor_publication(
+        &self,
+        lowers: &[Arc<dyn IndexNode>],
+        upper: &Arc<dyn IndexNode>,
+    ) -> Result<AncestorPublication, SystemError> {
+        let lower = lowers
+            .iter()
+            .map(RealInodeIdentity::from_inode)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(AncestorPublication {
+            lower,
+            upper: Arc::downgrade(upper),
+        })
+    }
+
+    pub(super) fn remember_ancestor_publication(
+        &self,
+        redirect: &str,
+        publication: AncestorPublication,
+    ) {
+        let mut cache = self.ancestor_publications.lock();
+        if cache.insertions_since_prune >= INODE_CACHE_PRUNE_INTERVAL {
+            cache
+                .entries
+                .retain(|_, publication| publication.upper.strong_count() != 0);
+            cache.insertions_since_prune = 0;
+        }
+        cache.entries.insert(String::from(redirect), publication);
+        cache.insertions_since_prune += 1;
+    }
+
+    pub(super) fn matches_ancestor_publication(
+        &self,
+        redirect: &str,
+        lowers: &[Arc<dyn IndexNode>],
+        upper: &Arc<dyn IndexNode>,
+    ) -> Result<bool, SystemError> {
+        let lower = lowers
+            .iter()
+            .map(RealInodeIdentity::from_inode)
+            .collect::<Result<Vec<_>, _>>()?;
+        let published = self
+            .ancestor_publications
+            .lock()
+            .entries
+            .get(redirect)
+            .and_then(|publication| {
+                (publication.lower == lower)
+                    .then(|| publication.upper.upgrade())
+                    .flatten()
+            });
+        Ok(published.is_some_and(|published| Arc::ptr_eq(&published, upper)))
     }
 
     pub(super) fn same_backing_inode(
@@ -593,6 +660,7 @@ impl MountableFileSystem for OverlayFS {
                 samefs,
                 inode_cache: Mutex::new(OvlInodeCache::default()),
                 dir_state_cache: Mutex::new(DirStateCache::default()),
+                ancestor_publications: Mutex::new(AncestorPublicationCache::default()),
                 copy_up_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),
                 ancestor_copy_up_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),
                 content_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -163,6 +163,7 @@ pub(super) struct OverlayFS {
     inode_cache: Mutex<OvlInodeCache>,
     dir_state_cache: Mutex<DirStateCache>,
     copy_up_locks: Vec<Mutex<()>>,
+    ancestor_copy_up_locks: Vec<Mutex<()>>,
     content_locks: Vec<Mutex<()>>,
 }
 
@@ -301,13 +302,21 @@ impl OverlayFS {
         Ok(self.dir_state_cache.lock().intern(identity))
     }
 
-    pub(super) fn copy_up_lock(&self, redirect: &str) -> &Mutex<()> {
+    fn redirect_lock_index(&self, redirect: &str) -> usize {
         let mut hash = 0xcbf29ce484222325u64;
         for byte in redirect.as_bytes() {
             hash ^= *byte as u64;
             hash = hash.wrapping_mul(0x100000001b3);
         }
-        &self.copy_up_locks[hash as usize % self.copy_up_locks.len()]
+        hash as usize % LOCK_STRIPE_COUNT
+    }
+
+    pub(super) fn copy_up_lock(&self, redirect: &str) -> &Mutex<()> {
+        &self.copy_up_locks[self.redirect_lock_index(redirect)]
+    }
+
+    pub(super) fn ancestor_copy_up_lock(&self, redirect: &str) -> &Mutex<()> {
+        &self.ancestor_copy_up_locks[self.redirect_lock_index(redirect)]
     }
 
     pub(super) fn content_lock(
@@ -557,6 +566,7 @@ impl MountableFileSystem for OverlayFS {
                 inode_cache: Mutex::new(OvlInodeCache::default()),
                 dir_state_cache: Mutex::new(DirStateCache::default()),
                 copy_up_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),
+                ancestor_copy_up_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),
                 content_locks: (0..LOCK_STRIPE_COUNT).map(|_| Mutex::new(())).collect(),
             }
         });

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -244,13 +244,14 @@ impl OverlayFS {
         Ok(inode)
     }
 
-    pub(super) fn intern_dir_state(
-        &self,
-        inode: &OvlInode,
-    ) -> Result<Arc<DirState>, SystemError> {
+    pub(super) fn intern_dir_state(&self, inode: &OvlInode) -> Result<Arc<DirState>, SystemError> {
         let identity = if inode.lower_inodes.is_empty() {
             DirIdentity::Upper(RealInodeIdentity::from_inode(
-                inode.upper_inode.lock().as_ref().ok_or(SystemError::ENOENT)?,
+                inode
+                    .upper_inode
+                    .lock()
+                    .as_ref()
+                    .ok_or(SystemError::ENOENT)?,
             )?)
         } else {
             DirIdentity::Lower(

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -98,26 +98,19 @@ const LOOKUP_RETENTION_SIZE: usize = 1024;
 const LOCK_STRIPE_COUNT: usize = 64;
 
 impl OvlInodeCache {
-    fn intern(
-        &mut self,
-        key: OvlInodeCacheKey,
-        retain_fallback_dir: bool,
-        create: impl FnOnce() -> Arc<OvlInode>,
-    ) -> Arc<OvlInode> {
-        let inode = if let Some(inode) = self.entries.get(&key).and_then(Weak::upgrade) {
-            inode
-        } else {
-            if self.insertions_since_prune >= INODE_CACHE_PRUNE_INTERVAL {
-                self.entries.retain(|_, inode| inode.strong_count() != 0);
-                self.insertions_since_prune = 0;
-            }
+    fn lookup(&self, key: &OvlInodeCacheKey) -> Option<Arc<OvlInode>> {
+        self.entries.get(key).and_then(Weak::upgrade)
+    }
 
-            let inode = create();
-            self.entries.insert(key, Arc::downgrade(&inode));
-            self.insertions_since_prune += 1;
-            inode
-        };
+    fn still_contains(&self, key: &OvlInodeCacheKey, expected: Option<&Arc<OvlInode>>) -> bool {
+        match (self.lookup(key), expected) {
+            (Some(current), Some(expected)) => Arc::ptr_eq(&current, expected),
+            (None, None) => true,
+            _ => false,
+        }
+    }
 
+    fn retain(&mut self, inode: Arc<OvlInode>, retain_fallback_dir: bool) {
         self.recent_lookups
             .retain(|cached| !Arc::ptr_eq(cached, &inode));
         self.recent_lookups.push_back(inode.clone());
@@ -133,7 +126,16 @@ impl OvlInodeCache {
                 self.recent_fallback_dirs.pop_front();
             }
         }
-        inode
+    }
+
+    fn replace(&mut self, key: OvlInodeCacheKey, inode: Arc<OvlInode>, retain_fallback_dir: bool) {
+        if self.insertions_since_prune >= INODE_CACHE_PRUNE_INTERVAL {
+            self.entries.retain(|_, inode| inode.strong_count() != 0);
+            self.insertions_since_prune = 0;
+        }
+        self.entries.insert(key, Arc::downgrade(&inode));
+        self.insertions_since_prune += 1;
+        self.retain(inode, retain_fallback_dir);
     }
 }
 
@@ -226,21 +228,40 @@ impl OverlayFS {
         };
 
         let retain_fallback_dir = !self.samefs && file_type == FileType::Dir;
-        let inode = self
-            .inode_cache
-            .lock()
-            .intern(key, retain_fallback_dir, || {
+        let expected_has_upper = upper_inode.is_some();
+        let inode = loop {
+            // Never inspect an inode while holding inode_cache: copy-up owns
+            // upper_inode before consulting this cache for ancestor objects.
+            let candidate = self.inode_cache.lock().lookup(&key);
+            if let Some(candidate) = candidate.as_ref() {
+                if candidate.has_upper() == expected_has_upper {
+                    let mut cache = self.inode_cache.lock();
+                    if cache.still_contains(&key, Some(candidate)) {
+                        cache.retain(candidate.clone(), retain_fallback_dir);
+                        break candidate.clone();
+                    }
+                    continue;
+                }
+            }
+
+            let replacement = {
                 let fallback_id = retain_fallback_dir.then(generate_inode_id);
                 let inode = Arc::new(OvlInode::new(
-                    redirect,
+                    redirect.clone(),
                     file_type,
-                    upper_inode,
-                    lower_inodes,
+                    upper_inode.clone(),
+                    lower_inodes.clone(),
                     fallback_id,
                 ));
                 inode.set_fs(Arc::downgrade(self));
                 inode
-            });
+            };
+            let mut cache = self.inode_cache.lock();
+            if cache.still_contains(&key, candidate.as_ref()) {
+                cache.replace(key.clone(), replacement.clone(), retain_fallback_dir);
+                break replacement;
+            }
+        };
         inode.load_origin_once()?;
         Ok(inode)
     }

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -84,10 +84,7 @@ impl DirState {
         data
     }
 
-    pub(super) fn cached_readdir(
-        &self,
-        version: &[DirVersion],
-    ) -> Option<Arc<Vec<String>>> {
+    pub(super) fn cached_readdir(&self, version: &[DirVersion]) -> Option<Arc<Vec<String>>> {
         let mut data = self.data.lock();
         let data = Self::revalidate(&mut data, version);
         data.readdir_cache

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -13,6 +13,8 @@ use crate::filesystem::vfs::{
 use crate::libs::casting::DowncastArc;
 use crate::libs::mutex::Mutex;
 use crate::mm::VmFlags;
+use crate::time::PosixTimeSpec;
+use alloc::collections::{BTreeMap, VecDeque};
 use alloc::string::{String, ToString};
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
@@ -29,9 +31,118 @@ pub struct OvlInode {
     pub(super) overlay_inode_id: Option<InodeId>,
     origin: Mutex<OriginState>,
     pub(super) content_privilege_lock: Mutex<()>,
+    dir_state: Mutex<Option<Arc<DirState>>>,
     #[allow(dead_code)]
     pub(super) oe: Arc<OvlEntry>,
     pub(super) fs: Mutex<Weak<OverlayFS>>,
+}
+
+const LOOKUP_CACHE_CAPACITY: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DirVersion {
+    dev_id: usize,
+    inode_id: InodeId,
+    size: i64,
+    mtime: PosixTimeSpec,
+    ctime: PosixTimeSpec,
+}
+
+#[derive(Debug, Default)]
+struct DirStateData {
+    generation: u64,
+    readdir_cache: Option<(u64, Arc<Vec<String>>)>,
+    lookup_cache: BTreeMap<String, Weak<OvlInode>>,
+    lookup_order: VecDeque<String>,
+    backing_version: Option<Vec<DirVersion>>,
+}
+
+#[derive(Debug)]
+pub(super) struct DirState {
+    pub(super) mutation_lock: Mutex<()>,
+    data: Mutex<DirStateData>,
+}
+
+impl Default for DirState {
+    fn default() -> Self {
+        Self {
+            mutation_lock: Mutex::new(()),
+            data: Mutex::new(DirStateData::default()),
+        }
+    }
+}
+
+impl DirState {
+    fn revalidate<'a>(data: &'a mut DirStateData, version: &[DirVersion]) -> &'a mut DirStateData {
+        if data.backing_version.as_deref() != Some(version) {
+            data.backing_version = Some(version.to_vec());
+            data.generation = data.generation.wrapping_add(1);
+            data.readdir_cache = None;
+            data.lookup_cache.clear();
+            data.lookup_order.clear();
+        }
+        data
+    }
+
+    pub(super) fn cached_readdir(
+        &self,
+        version: &[DirVersion],
+    ) -> Option<Arc<Vec<String>>> {
+        let mut data = self.data.lock();
+        let data = Self::revalidate(&mut data, version);
+        data.readdir_cache
+            .as_ref()
+            .filter(|(generation, _)| *generation == data.generation)
+            .map(|(_, entries)| entries.clone())
+    }
+
+    pub(super) fn cache_readdir(&self, version: &[DirVersion], entries: Arc<Vec<String>>) {
+        let mut data = self.data.lock();
+        let data = Self::revalidate(&mut data, version);
+        let generation = data.generation;
+        data.readdir_cache = Some((generation, entries));
+    }
+
+    pub(super) fn cached_lookup(
+        &self,
+        version: &[DirVersion],
+        name: &str,
+    ) -> Option<Arc<OvlInode>> {
+        let mut data = self.data.lock();
+        Self::revalidate(&mut data, version)
+            .lookup_cache
+            .get(name)
+            .and_then(Weak::upgrade)
+    }
+
+    pub(super) fn cache_lookup(&self, name: &str, inode: Arc<OvlInode>) {
+        if name == "." || name == ".." {
+            return;
+        }
+        let mut data = self.data.lock();
+        if data
+            .lookup_cache
+            .insert(name.to_string(), Arc::downgrade(&inode))
+            .is_none()
+        {
+            data.lookup_order.push_back(name.to_string());
+        }
+        while data.lookup_cache.len() > LOOKUP_CACHE_CAPACITY {
+            if let Some(oldest) = data.lookup_order.pop_front() {
+                data.lookup_cache.remove(&oldest);
+            }
+        }
+    }
+
+    pub(super) fn modified(&self, names: &[&str]) {
+        let mut data = self.data.lock();
+        data.generation = data.generation.wrapping_add(1);
+        data.readdir_cache = None;
+        for name in names {
+            data.lookup_cache.remove(*name);
+            data.lookup_order.retain(|cached| cached != name);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -57,6 +168,7 @@ impl OvlInode {
             overlay_inode_id,
             origin: Mutex::new(OriginState::Unchecked),
             content_privilege_lock: Mutex::new(()),
+            dir_state: Mutex::new(None),
             oe: Arc::new(OvlEntry::new()),
             fs: Mutex::new(Weak::default()),
         }
@@ -81,14 +193,48 @@ impl OvlInode {
         self.fs.lock().upgrade().ok_or(SystemError::EINVAL)
     }
 
+    pub(super) fn dir_state(&self) -> Result<Arc<DirState>, SystemError> {
+        if !self.is_dir() {
+            return Err(SystemError::ENOTDIR);
+        }
+        if let Some(state) = self.dir_state.lock().clone() {
+            return Ok(state);
+        }
+        let state = self.overlay_fs()?.intern_dir_state(self)?;
+        let mut slot = self.dir_state.lock();
+        Ok(slot.get_or_insert_with(|| state.clone()).clone())
+    }
+
+    pub(super) fn dir_version(&self) -> Result<Vec<DirVersion>, SystemError> {
+        let upper = self.upper_inode.lock().clone();
+        upper
+            .into_iter()
+            .chain(self.lower_inodes.iter().cloned())
+            .map(|inode| {
+                let metadata = inode.metadata()?;
+                Ok(DirVersion {
+                    dev_id: metadata.dev_id,
+                    inode_id: metadata.inode_id,
+                    size: metadata.size,
+                    mtime: metadata.mtime,
+                    ctime: metadata.ctime,
+                })
+            })
+            .collect()
+    }
+
     pub(super) fn downcast_overlay_inode(
         inode: Arc<dyn IndexNode>,
     ) -> Result<Arc<OvlInode>, SystemError> {
         inode.downcast_arc::<OvlInode>().ok_or(SystemError::EXDEV)
     }
 
-    pub(super) fn lookup_overlay_child(&self, name: &str) -> Result<Arc<OvlInode>, SystemError> {
-        Self::downcast_overlay_inode(self.find(name)?)
+    pub(super) fn lookup_overlay_child_locked(
+        &self,
+        name: &str,
+        state: &DirState,
+    ) -> Result<Arc<OvlInode>, SystemError> {
+        Self::downcast_overlay_inode(lookup::find_locked(self, name, state)?)
     }
 
     pub(super) fn has_upper(&self) -> bool {

--- a/kernel/src/filesystem/overlayfs/lookup.rs
+++ b/kernel/src/filesystem/overlayfs/lookup.rs
@@ -29,6 +29,19 @@ pub(super) fn find(
     inode: &OvlInode,
     name: &str,
 ) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
+    let state = inode.dir_state()?;
+    let _dir_guard = state.mutation_lock.lock();
+    find_locked(inode, name, &state)
+}
+
+pub(super) fn find_locked(
+    inode: &OvlInode,
+    name: &str,
+    state: &super::inode::DirState,
+) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
+    let version = inode.dir_version()?;
+    let cached = state.cached_lookup(&version, name);
+
     let mut upper_inode = None;
     let mut upper_file_type = None;
     if let Some(ref upper) = *inode.upper_inode.lock() {
@@ -93,6 +106,14 @@ pub(super) fn find(
         lower_inodes[0].metadata()?.file_type
     };
 
+    if let Some(cached) = cached {
+        if cached.file_type == file_type
+            && same_backing_set(&cached, upper_inode.as_ref(), &lower_inodes)?
+        {
+            return Ok(cached);
+        }
+    }
+
     let fs = inode.overlay_fs()?;
     let child = fs.intern_inode(
         inode.child_redirect(name),
@@ -101,5 +122,49 @@ pub(super) fn find(
         lower_inodes,
     )?;
 
+    state.cache_lookup(name, child.clone());
+
     Ok(child)
+}
+
+fn same_backing_set(
+    cached: &OvlInode,
+    upper: Option<&Arc<dyn IndexNode>>,
+    lowers: &[Arc<dyn IndexNode>],
+) -> Result<bool, SystemError> {
+    let cached_upper = cached.upper_inode.lock().clone();
+    if !same_optional_inode(cached_upper.as_ref(), upper)?
+        || cached.lower_inodes.len() != lowers.len()
+    {
+        return Ok(false);
+    }
+    for (cached, current) in cached.lower_inodes.iter().zip(lowers) {
+        if !same_inode(cached, current)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn same_optional_inode(
+    left: Option<&Arc<dyn IndexNode>>,
+    right: Option<&Arc<dyn IndexNode>>,
+) -> Result<bool, SystemError> {
+    match (left, right) {
+        (None, None) => Ok(true),
+        (Some(left), Some(right)) => same_inode(left, right),
+        _ => Ok(false),
+    }
+}
+
+fn same_inode(
+    left: &Arc<dyn IndexNode>,
+    right: &Arc<dyn IndexNode>,
+) -> Result<bool, SystemError> {
+    if !Arc::ptr_eq(&left.fs(), &right.fs()) {
+        return Ok(false);
+    }
+    let left = left.metadata()?;
+    let right = right.metadata()?;
+    Ok(left.dev_id == right.dev_id && left.inode_id == right.inode_id)
 }

--- a/kernel/src/filesystem/overlayfs/lookup.rs
+++ b/kernel/src/filesystem/overlayfs/lookup.rs
@@ -157,10 +157,7 @@ fn same_optional_inode(
     }
 }
 
-fn same_inode(
-    left: &Arc<dyn IndexNode>,
-    right: &Arc<dyn IndexNode>,
-) -> Result<bool, SystemError> {
+fn same_inode(left: &Arc<dyn IndexNode>, right: &Arc<dyn IndexNode>) -> Result<bool, SystemError> {
     if !Arc::ptr_eq(&left.fs(), &right.fs()) {
         return Ok(false);
     }

--- a/kernel/src/filesystem/overlayfs/lookup.rs
+++ b/kernel/src/filesystem/overlayfs/lookup.rs
@@ -39,6 +39,7 @@ pub(super) fn find_locked(
     name: &str,
     state: &super::inode::DirState,
 ) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
+    let child_redirect = inode.child_redirect(name);
     let version = inode.dir_version()?;
     let cached = state.cached_lookup(&version, name);
 
@@ -107,7 +108,8 @@ pub(super) fn find_locked(
     };
 
     if let Some(cached) = cached {
-        if cached.file_type == file_type
+        if cached.redirect == child_redirect
+            && cached.file_type == file_type
             && same_backing_set(&cached, upper_inode.as_ref(), &lower_inodes)?
         {
             return Ok(cached);
@@ -115,12 +117,7 @@ pub(super) fn find_locked(
     }
 
     let fs = inode.overlay_fs()?;
-    let child = fs.intern_inode(
-        inode.child_redirect(name),
-        file_type,
-        upper_inode,
-        lower_inodes,
-    )?;
+    let child = fs.intern_inode(child_redirect, file_type, upper_inode, lower_inodes)?;
 
     state.cache_lookup(name, child.clone());
 

--- a/kernel/src/filesystem/overlayfs/lookup.rs
+++ b/kernel/src/filesystem/overlayfs/lookup.rs
@@ -39,6 +39,15 @@ pub(super) fn find_locked(
     name: &str,
     state: &super::inode::DirState,
 ) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
+    find_locked_revalidated(inode, name, state, false)
+}
+
+fn find_locked_revalidated(
+    inode: &OvlInode,
+    name: &str,
+    state: &super::inode::DirState,
+    replace_stale: bool,
+) -> Result<Arc<dyn IndexNode>, system_error::SystemError> {
     let child_redirect = inode.child_redirect(name);
     let version = inode.dir_version()?;
     let cached = state.cached_lookup(&version, name);
@@ -117,7 +126,22 @@ pub(super) fn find_locked(
     }
 
     let fs = inode.overlay_fs()?;
-    let child = fs.intern_inode(child_redirect, file_type, upper_inode, lower_inodes)?;
+    let child = fs.intern_inode(
+        child_redirect.clone(),
+        file_type,
+        upper_inode,
+        lower_inodes,
+        replace_stale,
+    )?;
+    let Some(child) = child else {
+        // Serialize the refreshed backing lookup with both direct copy-up and
+        // publication of this object as an ancestor of another copy-up.
+        // Both lock domains are independent, and every dual acquisition uses
+        // leaf-before-ancestor order.
+        let _copy_up_guard = fs.copy_up_lock(&child_redirect).lock();
+        let _ancestor_guard = fs.ancestor_copy_up_lock(&child_redirect).lock();
+        return find_locked_revalidated(inode, name, state, true);
+    };
 
     state.cache_lookup(name, child.clone());
 

--- a/kernel/src/filesystem/overlayfs/metadata.rs
+++ b/kernel/src/filesystem/overlayfs/metadata.rs
@@ -414,10 +414,10 @@ pub(super) fn resize_with_lock_owner(
     lock_owner: u64,
 ) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
     let _privilege_guard = inode.content_privilege_lock.lock();
     inode.copy_up_locked_for_truncate(len)?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _content_guard = fs.content_lock(&upper)?.lock();
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     remove_security_capability(&upper)?;
     upper.resize_with_lock_owner(len, lock_owner)
@@ -432,12 +432,13 @@ pub(super) fn set_metadata_masked(
         return Ok(());
     }
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
     let kill_capability = metadata_change_kills_capability(mask);
-    let _privilege_guard = kill_capability.then(|| inode.content_privilege_lock.lock());
+    let _privilege_guard = inode.content_privilege_lock.lock();
     check_metadata_mutation_permission(inode, requested, mask)?;
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _content_guard = fs.content_lock(&upper)?.lock();
+    check_metadata_mutation_permission(inode, requested, mask)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     if kill_capability {
         remove_security_capability(&upper)?;
@@ -464,11 +465,12 @@ pub(super) fn resize_with_metadata(
     mask: SetMetadataMask,
 ) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
     let _privilege_guard = inode.content_privilege_lock.lock();
     check_metadata_mutation_permission(inode, requested, mask)?;
     inode.copy_up_locked_for_truncate(len)?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _content_guard = fs.content_lock(&upper)?.lock();
+    check_metadata_mutation_permission(inode, requested, mask)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     remove_security_capability(&upper)?;
     let mut upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
@@ -549,11 +551,12 @@ pub(super) fn resize_file_with_metadata(
     mask: SetMetadataMask,
 ) -> Result<(), SystemError> {
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
     let _privilege_guard = inode.content_privilege_lock.lock();
     check_metadata_mutation_permission(inode, requested, mask)?;
     inode.copy_up_locked_for_truncate(len)?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _content_guard = fs.content_lock(&upper)?.lock();
+    check_metadata_mutation_permission(inode, requested, mask)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     remove_security_capability(&upper)?;
     let mut upper_metadata = prepare_upper_metadata(&upper, requested, mask)?;
@@ -587,12 +590,12 @@ pub(super) fn setxattr(
         return Err(SystemError::EPERM);
     }
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
-    let _privilege_guard =
-        (name == XATTR_SECURITY_CAPABILITY).then(|| inode.content_privilege_lock.lock());
+    let _privilege_guard = inode.content_privilege_lock.lock();
     check_xattr_mutation_permission(inode, name)?;
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _content_guard = fs.content_lock(&upper)?.lock();
+    check_xattr_mutation_permission(inode, name)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     upper.setxattr(name, value, flags)
 }
@@ -633,9 +636,7 @@ pub(super) fn removexattr(inode: &OvlInode, name: &str) -> Result<usize, SystemE
         return Err(SystemError::EPERM);
     }
     let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
-    let _privilege_guard =
-        (name == XATTR_SECURITY_CAPABILITY).then(|| inode.content_privilege_lock.lock());
+    let _privilege_guard = inode.content_privilege_lock.lock();
     check_xattr_mutation_permission(inode, name)?;
     let copied_up_for_remove = !inode.has_upper();
     if copied_up_for_remove {
@@ -645,6 +646,8 @@ pub(super) fn removexattr(inode: &OvlInode, name: &str) -> Result<usize, SystemE
 
     inode.copy_up_locked()?;
     let upper = inode.upper_inode.lock().clone().ok_or(SystemError::EIO)?;
+    let _content_guard = fs.content_lock(&upper)?.lock();
+    check_xattr_mutation_permission(inode, name)?;
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     match upper.removexattr(name) {
         Ok(size) => Ok(size),

--- a/kernel/src/filesystem/overlayfs/readdir.rs
+++ b/kernel/src/filesystem/overlayfs/readdir.rs
@@ -1,52 +1,63 @@
 use super::inode::OvlInode;
+use crate::filesystem::vfs::IndexNode;
+use alloc::collections::BTreeSet;
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
-pub(super) fn list(inode: &OvlInode) -> Result<Vec<String>, system_error::SystemError> {
-    let mut entries: Vec<String> = Vec::new();
-    let mut hidden_entries: Vec<String> = Vec::new();
-    let upper_entries = if let Some(ref upper_inode) = *inode.upper_inode.lock() {
-        upper_inode.list()?
-    } else {
-        Vec::new()
-    };
-
-    for entry in upper_entries {
-        if !inode.has_whiteout(&entry) {
-            entries.push(entry);
+pub(super) fn list(inode: &OvlInode) -> Result<Vec<String>, SystemError> {
+    let state = inode.dir_state()?;
+    let _guard = state.mutation_lock.lock();
+    loop {
+        let version = inode.dir_version()?;
+        if let Some(entries) = state.cached_readdir(&version) {
+            return Ok((*entries).clone());
         }
-    }
 
-    for lower_inode in &inode.lower_inodes {
-        let lower_entries = lower_inode.list()?;
-        for entry in lower_entries {
-            if entries.contains(&entry) || hidden_entries.contains(&entry) {
-                continue;
-            }
-            if is_dot_entry(&entry) {
-                entries.push(entry);
-                continue;
-            }
-            if inode.has_whiteout(&entry) {
-                hidden_entries.push(entry);
-                continue;
-            }
-            match lower_inode.find(&entry) {
-                Ok(found) => {
-                    if OvlInode::is_whiteout_inode(&found) {
-                        hidden_entries.push(entry);
-                        continue;
-                    }
+        let mut entries = Vec::new();
+        let mut seen = BTreeSet::new();
+        if let Some(upper) = inode.upper_inode.lock().clone() {
+            merge_layer(&upper, &mut entries, &mut seen)?;
+        }
+        for lower in &inode.lower_inodes {
+            merge_layer(lower, &mut entries, &mut seen)?;
+        }
+
+        let current_version = inode.dir_version()?;
+        if current_version != version {
+            continue;
+        }
+        let entries = Arc::new(entries);
+        state.cache_readdir(&current_version, entries.clone());
+        return Ok((*entries).clone());
+    }
+}
+
+fn merge_layer(
+    layer: &Arc<dyn IndexNode>,
+    entries: &mut Vec<String>,
+    seen: &mut BTreeSet<String>,
+) -> Result<(), SystemError> {
+    for name in layer.list()? {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        if is_dot_entry(&name) {
+            entries.push(name);
+            continue;
+        }
+        match layer.find(&name) {
+            Ok(found) => {
+                if !OvlInode::is_whiteout_inode_checked(&found)? {
+                    entries.push(name);
                 }
-                Err(SystemError::ENOENT) => continue,
-                Err(err) => return Err(err),
             }
-            entries.push(entry);
+            Err(SystemError::ENOENT) => {}
+            Err(err) => return Err(err),
         }
     }
-
-    Ok(entries)
+    Ok(())
 }
 
 fn is_dot_entry(name: &str) -> bool {

--- a/kernel/src/filesystem/overlayfs/readdir.rs
+++ b/kernel/src/filesystem/overlayfs/readdir.rs
@@ -1,4 +1,4 @@
-use super::inode::OvlInode;
+use super::inode::{DirState, OvlInode};
 use crate::filesystem::vfs::IndexNode;
 use alloc::collections::BTreeSet;
 use alloc::string::String;
@@ -9,6 +9,10 @@ use system_error::SystemError;
 pub(super) fn list(inode: &OvlInode) -> Result<Vec<String>, SystemError> {
     let state = inode.dir_state()?;
     let _guard = state.mutation_lock.lock();
+    list_locked(inode, &state)
+}
+
+pub(super) fn list_locked(inode: &OvlInode, state: &DirState) -> Result<Vec<String>, SystemError> {
     loop {
         let version = inode.dir_version()?;
         if let Some(entries) = state.cached_readdir(&version) {

--- a/kernel/src/filesystem/overlayfs/rename.rs
+++ b/kernel/src/filesystem/overlayfs/rename.rs
@@ -21,10 +21,6 @@ pub(super) fn move_to(
         .downcast_arc::<OvlInode>()
         .ok_or(SystemError::EXDEV)?;
 
-    if inode.redirect == target_ovl.redirect && old_name == new_name {
-        return Ok(());
-    }
-
     let fs = inode.overlay_fs()?;
     let source_state = inode.dir_state()?;
     let target_state = target_ovl.dir_state()?;
@@ -93,6 +89,10 @@ fn move_to_locked(
 
     if flags.contains(RenameFlags::NOREPLACE) && target_child.is_some() {
         return Err(SystemError::EEXIST);
+    }
+
+    if inode.redirect == target_ovl.redirect && old_name == new_name {
+        return Ok(());
     }
 
     if flags.contains(RenameFlags::EXCHANGE) {

--- a/kernel/src/filesystem/overlayfs/rename.rs
+++ b/kernel/src/filesystem/overlayfs/rename.rs
@@ -83,7 +83,6 @@ fn move_to_locked(
     source_state: &DirState,
     target_state: &DirState,
 ) -> Result<(), SystemError> {
-
     let source = inode.lookup_overlay_child_locked(old_name, source_state)?;
     let target_had_whiteout = target_ovl.has_whiteout(new_name);
     let target_child = match target_ovl.lookup_overlay_child_locked(new_name, target_state) {

--- a/kernel/src/filesystem/overlayfs/rename.rs
+++ b/kernel/src/filesystem/overlayfs/rename.rs
@@ -1,5 +1,5 @@
 use super::dir;
-use super::inode::OvlInode;
+use super::inode::{DirState, OvlInode};
 use crate::filesystem::vfs::{syscall::RenameFlags, IndexNode};
 use crate::libs::casting::DowncastArc;
 use alloc::sync::Arc;
@@ -16,17 +16,77 @@ pub(super) fn move_to(
         return Err(SystemError::EINVAL);
     }
 
-    let fs = inode.overlay_fs()?;
-    let _mutation_guard = fs.mutation_lock.lock();
-
     let target_ovl = target
         .clone()
         .downcast_arc::<OvlInode>()
         .ok_or(SystemError::EXDEV)?;
 
-    let source = inode.lookup_overlay_child(old_name)?;
+    if inode.redirect == target_ovl.redirect && old_name == new_name {
+        return Ok(());
+    }
+
+    let fs = inode.overlay_fs()?;
+    let source_state = inode.dir_state()?;
+    let target_state = target_ovl.dir_state()?;
+    let _commit_guard = fs.mutation_lock.lock();
+    let result = if Arc::ptr_eq(&source_state, &target_state) {
+        let _guard = source_state.mutation_lock.lock();
+        move_to_locked(
+            inode,
+            old_name,
+            &target_ovl,
+            new_name,
+            flags,
+            &source_state,
+            &target_state,
+        )
+    } else if Arc::as_ptr(&source_state) < Arc::as_ptr(&target_state) {
+        let _source_guard = source_state.mutation_lock.lock();
+        let _target_guard = target_state.mutation_lock.lock();
+        move_to_locked(
+            inode,
+            old_name,
+            &target_ovl,
+            new_name,
+            flags,
+            &source_state,
+            &target_state,
+        )
+    } else {
+        let _target_guard = target_state.mutation_lock.lock();
+        let _source_guard = source_state.mutation_lock.lock();
+        move_to_locked(
+            inode,
+            old_name,
+            &target_ovl,
+            new_name,
+            flags,
+            &source_state,
+            &target_state,
+        )
+    };
+    if result.is_ok() {
+        source_state.modified(&[old_name, new_name]);
+        if !Arc::ptr_eq(&source_state, &target_state) {
+            target_state.modified(&[old_name, new_name]);
+        }
+    }
+    result
+}
+
+fn move_to_locked(
+    inode: &OvlInode,
+    old_name: &str,
+    target_ovl: &Arc<OvlInode>,
+    new_name: &str,
+    flags: RenameFlags,
+    source_state: &DirState,
+    target_state: &DirState,
+) -> Result<(), SystemError> {
+
+    let source = inode.lookup_overlay_child_locked(old_name, source_state)?;
     let target_had_whiteout = target_ovl.has_whiteout(new_name);
-    let target_child = match target_ovl.lookup_overlay_child(new_name) {
+    let target_child = match target_ovl.lookup_overlay_child_locked(new_name, target_state) {
         Ok(found) => Some(found),
         Err(SystemError::ENOENT) => None,
         Err(err) => return Err(err),
@@ -49,10 +109,6 @@ pub(super) fn move_to(
         let old_upper_dir = inode.writable_upper_inode_locked()?;
         let new_upper_dir = target_ovl.writable_upper_inode_locked()?;
         return old_upper_dir.move_to(old_name, &new_upper_dir, new_name, flags);
-    }
-
-    if inode.redirect == target_ovl.redirect && old_name == new_name {
-        return Ok(());
     }
 
     let source_needs_whiteout = inode.lower_positive(old_name);

--- a/kernel/src/filesystem/overlayfs/rename.rs
+++ b/kernel/src/filesystem/overlayfs/rename.rs
@@ -116,7 +116,7 @@ fn move_to_locked(
         return Err(SystemError::EXDEV);
     }
 
-    if let Some(target_child) = target_child {
+    let target_child_state = if let Some(target_child) = target_child.as_ref() {
         if source.is_dir() && !target_child.is_dir() {
             return Err(SystemError::ENOTDIR);
         }
@@ -124,10 +124,21 @@ fn move_to_locked(
             return Err(SystemError::EISDIR);
         }
         if source.is_dir() && target_child.is_dir() {
-            let target_node: Arc<dyn IndexNode> = target_child.clone();
-            if !dir::is_dir_empty(&target_node)? {
-                return Err(SystemError::ENOTEMPTY);
-            }
+            Some(target_child.dir_state()?)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    let _target_child_guard = target_child_state
+        .as_ref()
+        .map(|state| state.mutation_lock.lock());
+    if let (Some(target_child), Some(target_child_state)) =
+        (target_child.as_ref(), target_child_state.as_ref())
+    {
+        if !dir::is_dir_empty_locked(target_child, target_child_state)? {
+            return Err(SystemError::ENOTEMPTY);
         }
     }
 

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -94,9 +94,8 @@ fn tmpfs_move_entry_between_dirs(
     new_key: &DName,
     flags: RenameFlags,
 ) -> Result<(), SystemError> {
-    if src_dir.metadata.file_type != FileType::Dir || dst_dir.metadata.file_type != FileType::Dir {
-        return Err(SystemError::ENOTDIR);
-    }
+    tmpfs_require_live_dir(src_dir)?;
+    tmpfs_require_live_dir(dst_dir)?;
 
     let src_self = src_dir.self_ref.upgrade().ok_or(SystemError::EIO)?;
     let dst_self = dst_dir.self_ref.upgrade().ok_or(SystemError::EIO)?;
@@ -117,6 +116,7 @@ fn tmpfs_move_entry_between_dirs(
         if Arc::ptr_eq(&inode_to_move, &existing) {
             return Ok(());
         }
+        let now = PosixTimeSpec::now();
         let existing_type = existing.0.lock().metadata.file_type;
 
         src_dir.children.insert(old_key.clone(), existing.clone());
@@ -136,12 +136,16 @@ fn tmpfs_move_entry_between_dirs(
             let mut moved = inode_to_move.0.lock();
             moved.parent = Arc::downgrade(&dst_self);
             moved.name = new_key.clone();
+            moved.metadata.ctime = now;
         }
         {
             let mut replaced = existing.0.lock();
             replaced.parent = Arc::downgrade(&src_self);
             replaced.name = old_key.clone();
+            replaced.metadata.ctime = now;
         }
+        tmpfs_touch_dir(src_dir, now);
+        tmpfs_touch_dir(dst_dir, now);
         return Ok(());
     }
 
@@ -173,6 +177,9 @@ fn tmpfs_move_entry_between_dirs(
             // Destination already points to the same inode. For files this is
             // effectively removing the old entry.
             src_dir.children.remove(old_key);
+            let now = PosixTimeSpec::now();
+            tmpfs_touch_dir(src_dir, now);
+            inode_to_move.0.lock().metadata.ctime = now;
             return Ok(());
         }
 
@@ -195,6 +202,7 @@ fn tmpfs_move_entry_between_dirs(
         } else {
             existing_guard.metadata.nlinks = existing_guard.metadata.nlinks.saturating_sub(1);
         }
+        existing_guard.metadata.ctime = PosixTimeSpec::now();
     }
 
     // Remove from source directory.
@@ -214,7 +222,26 @@ fn tmpfs_move_entry_between_dirs(
     let mut moved = inode_to_move.0.lock();
     moved.parent = Arc::downgrade(&dst_self);
     moved.name = new_key.clone();
+    let now = PosixTimeSpec::now();
+    moved.metadata.ctime = now;
+    tmpfs_touch_dir(src_dir, now);
+    tmpfs_touch_dir(dst_dir, now);
 
+    Ok(())
+}
+
+fn tmpfs_touch_dir(dir: &mut TmpfsInode, now: PosixTimeSpec) {
+    dir.metadata.mtime = now;
+    dir.metadata.ctime = now;
+}
+
+fn tmpfs_require_live_dir(dir: &TmpfsInode) -> Result<(), SystemError> {
+    if dir.metadata.file_type != FileType::Dir {
+        return Err(SystemError::ENOTDIR);
+    }
+    if dir.metadata.nlinks == 0 {
+        return Err(SystemError::ENOENT);
+    }
     Ok(())
 }
 
@@ -223,6 +250,7 @@ fn tmpfs_insert_whiteout(dir: &mut TmpfsInode, name: &DName) -> Result<(), Syste
         return Err(SystemError::EEXIST);
     }
 
+    let now = PosixTimeSpec::now();
     let whiteout = Arc::new(LockedTmpfsInode::new(TmpfsInode {
         parent: dir.self_ref.clone(),
         self_ref: Weak::default(),
@@ -234,10 +262,10 @@ fn tmpfs_insert_whiteout(dir: &mut TmpfsInode, name: &DName) -> Result<(), Syste
             size: 0,
             blk_size: 0,
             blocks: 0,
-            atime: PosixTimeSpec::default(),
-            mtime: PosixTimeSpec::default(),
-            ctime: PosixTimeSpec::default(),
-            btime: PosixTimeSpec::default(),
+            atime: now,
+            mtime: now,
+            ctime: now,
+            btime: now,
             file_type: FileType::CharDevice,
             mode: InodeMode::S_IFCHR | InodeMode::from_bits_truncate(0o600),
             nlinks: 1,
@@ -1069,13 +1097,12 @@ impl IndexNode for LockedTmpfsInode {
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         let name = DName::from(name);
         let mut inode = self.0.lock();
-        if inode.metadata.file_type != FileType::Dir {
-            return Err(SystemError::ENOTDIR);
-        }
+        tmpfs_require_live_dir(&inode)?;
         if inode.children.contains_key(&name) {
             return Err(SystemError::EEXIST);
         }
 
+        let now = PosixTimeSpec::now();
         let result: Arc<LockedTmpfsInode> = Arc::new(LockedTmpfsInode::new(TmpfsInode {
             parent: inode.self_ref.clone(),
             self_ref: Weak::default(),
@@ -1087,10 +1114,10 @@ impl IndexNode for LockedTmpfsInode {
                 size: 0,
                 blk_size: 0,
                 blocks: 0,
-                atime: PosixTimeSpec::default(),
-                mtime: PosixTimeSpec::default(),
-                ctime: PosixTimeSpec::default(),
-                btime: PosixTimeSpec::default(),
+                atime: now,
+                mtime: now,
+                ctime: now,
+                btime: now,
                 file_type,
                 mode,
                 flags: InodeFlags::empty(),
@@ -1125,6 +1152,7 @@ impl IndexNode for LockedTmpfsInode {
         if file_type == FileType::Dir {
             inode.metadata.nlinks += 1;
         }
+        tmpfs_touch_dir(&mut inode, now);
         Ok(result)
     }
 
@@ -1137,9 +1165,7 @@ impl IndexNode for LockedTmpfsInode {
         let mut inode: MutexGuard<TmpfsInode> = self.0.lock();
         let mut other_locked: MutexGuard<TmpfsInode> = other.0.lock();
 
-        if inode.metadata.file_type != FileType::Dir {
-            return Err(SystemError::ENOTDIR);
-        }
+        tmpfs_require_live_dir(&inode)?;
         if other_locked.metadata.file_type == FileType::Dir {
             return Err(SystemError::EISDIR);
         }
@@ -1151,14 +1177,15 @@ impl IndexNode for LockedTmpfsInode {
             .children
             .insert(name, other_locked.self_ref.upgrade().unwrap());
         other_locked.metadata.nlinks += 1;
+        let now = PosixTimeSpec::now();
+        other_locked.metadata.ctime = now;
+        tmpfs_touch_dir(&mut inode, now);
         Ok(())
     }
 
     fn unlink(&self, name: &str) -> Result<(), SystemError> {
         let mut inode: MutexGuard<TmpfsInode> = self.0.lock();
-        if inode.metadata.file_type != FileType::Dir {
-            return Err(SystemError::ENOTDIR);
-        }
+        tmpfs_require_live_dir(&inode)?;
         if name == "." || name == ".." {
             return Err(SystemError::ENOTEMPTY);
         }
@@ -1188,9 +1215,12 @@ impl IndexNode for LockedTmpfsInode {
             .expect("tempfs nlinks underflow: filesystem corruption detected");
 
         let should_free = deleted_guard.metadata.nlinks == 0;
+        let now = PosixTimeSpec::now();
+        deleted_guard.metadata.ctime = now;
         drop(deleted_guard);
 
         inode.children.remove(&name);
+        tmpfs_touch_dir(&mut inode, now);
 
         if should_free {
             tmpfs.decrease_size(file_size);
@@ -1210,9 +1240,7 @@ impl IndexNode for LockedTmpfsInode {
 
         let name = DName::from(name);
         let mut inode: MutexGuard<TmpfsInode> = self.0.lock();
-        if inode.metadata.file_type != FileType::Dir {
-            return Err(SystemError::ENOTDIR);
-        }
+        tmpfs_require_live_dir(&inode)?;
         let to_delete = inode.children.get(&name).ok_or(SystemError::ENOENT)?;
         let deleted_inode = to_delete.0.lock();
         if deleted_inode.metadata.file_type != FileType::Dir {
@@ -1233,9 +1261,14 @@ impl IndexNode for LockedTmpfsInode {
             .ok_or(SystemError::EIO)?;
 
         drop(deleted_inode);
-        to_delete.0.lock().metadata.nlinks -= 1;
+        let now = PosixTimeSpec::now();
+        let mut deleted_inode = to_delete.0.lock();
+        deleted_inode.metadata.nlinks = 0;
+        deleted_inode.metadata.ctime = now;
+        drop(deleted_inode);
         inode.children.remove(&name);
         inode.metadata.nlinks -= 1;
+        tmpfs_touch_dir(&mut inode, now);
 
         // 减少文件系统使用的大小（目录通常大小为0）
         tmpfs.decrease_size(dir_size);
@@ -1263,16 +1296,6 @@ impl IndexNode for LockedTmpfsInode {
             .downcast_arc::<LockedTmpfsInode>()
             .ok_or(SystemError::EINVAL)?;
 
-        // Fast path: renaming to itself.
-        if Arc::ptr_eq(&(self.0.lock().self_ref.upgrade().unwrap()), &target_locked)
-            && old_key == new_key
-        {
-            if flags.contains(RenameFlags::NOREPLACE) {
-                return Err(SystemError::EEXIST);
-            }
-            return Ok(());
-        }
-
         // Lock ordering: lock by inode_id to avoid deadlocks.
         let self_id = self.0.lock().metadata.inode_id;
         let target_id = target_locked.0.lock().metadata.inode_id;
@@ -1280,6 +1303,7 @@ impl IndexNode for LockedTmpfsInode {
         if self_id == target_id {
             // Same directory rename.
             let mut dir = self.0.lock();
+            tmpfs_require_live_dir(&dir)?;
             let inode_to_move = dir
                 .children
                 .get(&old_key)
@@ -1299,10 +1323,16 @@ impl IndexNode for LockedTmpfsInode {
                     return Ok(());
                 }
 
+                let now = PosixTimeSpec::now();
                 dir.children.insert(old_key.clone(), existing.clone());
                 dir.children.insert(new_key.clone(), inode_to_move.clone());
-                existing.0.lock().name = old_key;
-                inode_to_move.0.lock().name = new_key;
+                let mut existing = existing.0.lock();
+                existing.name = old_key;
+                existing.metadata.ctime = now;
+                let mut moved = inode_to_move.0.lock();
+                moved.name = new_key;
+                moved.metadata.ctime = now;
+                tmpfs_touch_dir(&mut dir, now);
                 return Ok(());
             }
 
@@ -1340,6 +1370,7 @@ impl IndexNode for LockedTmpfsInode {
                     existing_guard.metadata.nlinks =
                         existing_guard.metadata.nlinks.saturating_sub(1);
                 }
+                existing_guard.metadata.ctime = PosixTimeSpec::now();
             }
 
             // Move entry within the same directory.
@@ -1348,7 +1379,11 @@ impl IndexNode for LockedTmpfsInode {
                 tmpfs_insert_whiteout(&mut dir, &old_key)?;
             }
             dir.children.insert(new_key.clone(), inode_to_move.clone());
-            inode_to_move.0.lock().name = new_key;
+            let now = PosixTimeSpec::now();
+            let mut moved = inode_to_move.0.lock();
+            moved.name = new_key;
+            moved.metadata.ctime = now;
+            tmpfs_touch_dir(&mut dir, now);
             return Ok(());
         }
 
@@ -1458,9 +1493,7 @@ impl IndexNode for LockedTmpfsInode {
         dev_t: DeviceNumber,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         let mut inode = self.0.lock();
-        if inode.metadata.file_type != FileType::Dir {
-            return Err(SystemError::ENOTDIR);
-        }
+        tmpfs_require_live_dir(&inode)?;
 
         let file_type = FileType::from(mode);
         if unlikely(file_type == FileType::File) {
@@ -1481,6 +1514,7 @@ impl IndexNode for LockedTmpfsInode {
             _ => return Err(SystemError::EINVAL),
         };
 
+        let now = PosixTimeSpec::now();
         let nod = Arc::new(LockedTmpfsInode::new(TmpfsInode {
             parent: inode.self_ref.clone(),
             self_ref: Weak::default(),
@@ -1492,10 +1526,10 @@ impl IndexNode for LockedTmpfsInode {
                 size: 0,
                 blk_size: 0,
                 blocks: 0,
-                atime: PosixTimeSpec::default(),
-                mtime: PosixTimeSpec::default(),
-                ctime: PosixTimeSpec::default(),
-                btime: PosixTimeSpec::default(),
+                atime: now,
+                mtime: now,
+                ctime: now,
+                btime: now,
                 file_type,
                 mode,
                 nlinks: 1,
@@ -1519,6 +1553,7 @@ impl IndexNode for LockedTmpfsInode {
         }
 
         inode.children.insert(filename, nod.clone());
+        tmpfs_touch_dir(&mut inode, now);
         Ok(nod)
     }
 

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -58,6 +58,22 @@ bool path_exists(const std::string& path) {
     return stat(path.c_str(), &st) == 0;
 }
 
+std::vector<std::string> directory_names(const std::string& path) {
+    std::vector<std::string> names;
+    DIR* dir = opendir(path.c_str());
+    if (dir == nullptr) {
+        return names;
+    }
+    while (dirent* ent = readdir(dir)) {
+        if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0) {
+            names.emplace_back(ent->d_name);
+        }
+    }
+    closedir(dir);
+    std::sort(names.begin(), names.end());
+    return names;
+}
+
 std::vector<std::string> xattr_names(const std::string& path) {
     ssize_t needed = listxattr(path.c_str(), nullptr, 0);
     EXPECT_GE(needed, 0) << path << ": " << strerror(errno);
@@ -3269,6 +3285,42 @@ TEST(OverlayFsSemantics, BindSharesDeviceAndIndependentOverlayGetsNewDevice) {
     EXPECT_NE(original.st_dev, independent.st_dev);
     ASSERT_EQ(0, umount(bind_path.c_str()));
     ASSERT_EQ(0, rmdir(bind_path.c_str()));
+}
+
+TEST(OverlayFsSemantics, LargeMergedDirectoryCacheInvalidatesAfterMutations) {
+    ScopedOverlayEnv scoped("overlayfs_large_readdir_cache");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+
+    constexpr int kEntryCount = 256;
+    for (int i = 0; i < kEntryCount; ++i) {
+        char name[32] = {};
+        snprintf(name, sizeof(name), "entry_%03d", i);
+        ASSERT_EQ(0, write_text(join_path(env.lower, name), "lower"));
+        if ((i % 2) == 0) {
+            ASSERT_EQ(0, write_text(join_path(env.upper, name), "upper"));
+        }
+    }
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    auto first = directory_names(env.merged);
+    ASSERT_EQ(static_cast<size_t>(kEntryCount), first.size());
+    EXPECT_EQ(first, directory_names(env.merged));
+
+    std::string created = join_path(env.merged, "created");
+    ASSERT_EQ(0, write_text(created, "new")) << strerror(errno);
+    auto after_create = directory_names(env.merged);
+    EXPECT_TRUE(std::binary_search(after_create.begin(), after_create.end(), "created"));
+
+    ASSERT_EQ(0, unlink(join_path(env.merged, "entry_003").c_str())) << strerror(errno);
+    auto after_unlink = directory_names(env.merged);
+    EXPECT_FALSE(std::binary_search(after_unlink.begin(), after_unlink.end(), "entry_003"));
+
+    std::string renamed = join_path(env.merged, "renamed");
+    ASSERT_EQ(0, rename(created.c_str(), renamed.c_str())) << strerror(errno);
+    auto after_rename = directory_names(env.merged);
+    EXPECT_FALSE(std::binary_search(after_rename.begin(), after_rename.end(), "created"));
+    EXPECT_TRUE(std::binary_search(after_rename.begin(), after_rename.end(), "renamed"));
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -1058,6 +1058,61 @@ TEST(OverlayFsSemantics, OldLowerFileDescriptorsSwitchToUpperAfterCopyUp) {
     EXPECT_EQ(0, close(old_fd1)) << strerror(errno);
 }
 
+TEST(OverlayFsSemantics, OldLowerDirectoryUsesAncestorCopyUp) {
+    ScopedOverlayEnv scoped("overlayfs_revalidate_old_dir");
+    const auto& env = scoped.env;
+    std::string lower_dir = join_path(env.lower, "dir");
+    std::string lower_file = join_path(lower_dir, "file");
+    std::string merged_dir = join_path(env.merged, "dir");
+    std::string merged_file = join_path(merged_dir, "file");
+    std::string upper_created = join_path(env.upper, "dir/created");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, mkdir(lower_dir.c_str(), 0755)) << strerror(errno);
+    ASSERT_EQ(0, write_text(lower_file, "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int old_dir_fd = open(merged_dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    ASSERT_GE(old_dir_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_file, "upper")) << strerror(errno);
+    ASSERT_EQ(0, mkdirat(old_dir_fd, "created", 0755)) << strerror(errno);
+
+    EXPECT_TRUE(path_exists(upper_created));
+    EXPECT_EQ(0, close(old_dir_fd)) << strerror(errno);
+}
+
+TEST(OverlayFsSemantics, DetachedOldDirectoryIsNotReusedForAncestorCopyUp) {
+    ScopedOverlayEnv scoped("overlayfs_detached_old_dir");
+    const auto& env = scoped.env;
+    std::string lower_dir = join_path(env.lower, "dir");
+    std::string lower_file = join_path(lower_dir, "file");
+    std::string upper_dir = join_path(env.upper, "dir");
+    std::string upper_file = join_path(upper_dir, "file");
+    std::string merged_dir = join_path(env.merged, "dir");
+    std::string merged_file = join_path(merged_dir, "file");
+
+    prepare_overlay_env(env);
+    ASSERT_EQ(0, mkdir(lower_dir.c_str(), 0755)) << strerror(errno);
+    ASSERT_EQ(0, write_text(lower_file, "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    int old_dir_fd = open(merged_dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    ASSERT_GE(old_dir_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_file, "upper")) << strerror(errno);
+    ASSERT_EQ(0, unlink(merged_file.c_str())) << strerror(errno);
+    ASSERT_EQ(0, rmdir(merged_dir.c_str())) << strerror(errno);
+    ASSERT_TRUE(is_whiteout(upper_dir));
+
+    // Simulate an upper-layer namespace change that reveals the lower path
+    // while old_dir_fd still retains the detached directory object.
+    ASSERT_EQ(0, unlink(upper_dir.c_str())) << strerror(errno);
+    ASSERT_EQ(0, write_text(merged_file, "new")) << strerror(errno);
+
+    EXPECT_EQ("new", read_text(merged_file));
+    EXPECT_EQ("new", read_text(upper_file));
+    EXPECT_EQ(0, close(old_dir_fd)) << strerror(errno);
+}
+
 TEST(OverlayFsSemantics, OldLowerFileDescriptorDoesNotFollowSameNameReplacement) {
     ScopedOverlayEnv scoped("overlayfs_revalidate_identity");
     const auto& env = scoped.env;

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -2697,6 +2697,60 @@ TEST(OverlayFsSemantics, RenameNoReplaceOverWhiteoutTargetTreatsTargetAsAbsent) 
     cleanup_overlay_env(env);
 }
 
+TEST(OverlayFsSemantics, CopyUpDoesNotAdoptConcurrentReplacement) {
+    constexpr size_t kCopySize = 64 * 1024 * 1024;
+    ScopedOverlayEnv scoped("overlayfs_copy_up_replace_race");
+    const auto& env = scoped.env;
+    std::string lower_file = join_path(env.lower, "entry");
+    std::string upper_file = join_path(env.upper, "entry");
+    std::string merged_file = join_path(env.merged, "entry");
+
+    prepare_overlay_env(env);
+    int lower_fd = open(lower_file.c_str(), O_CREAT | O_WRONLY | O_CLOEXEC, 0644);
+    ASSERT_GE(lower_fd, 0) << strerror(errno);
+    std::vector<char> block(1024 * 1024, 'l');
+    for (size_t offset = 0; offset < kCopySize; offset += block.size()) {
+        ASSERT_EQ(static_cast<ssize_t>(block.size()),
+            write(lower_fd, block.data(), block.size()))
+            << strerror(errno);
+    }
+    ASSERT_EQ(0, close(lower_fd)) << strerror(errno);
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        int fd = open(merged_file.c_str(), O_WRONLY | O_CLOEXEC);
+        if (fd < 0) {
+            _exit(errno == ESTALE ? 0 : 2);
+        }
+        if (write(fd, "stale", 5) != 5) {
+            close(fd);
+            _exit(4);
+        }
+        close(fd);
+        _exit(3);
+    }
+
+    bool copy_up_started = false;
+    for (int attempt = 0; attempt < 20000; ++attempt) {
+        if (overlay_temp_entry_count(env.work) > 0) {
+            copy_up_started = true;
+            break;
+        }
+        usleep(100);
+    }
+    ASSERT_TRUE(copy_up_started);
+    ASSERT_EQ(0, write_text(upper_file, "replacement")) << strerror(errno);
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    EXPECT_EQ("replacement", read_text(merged_file));
+    EXPECT_EQ(0, overlay_temp_entry_count(env.work));
+}
+
 TEST(OverlayFsSemantics, LowerFileRenameToDirectoryFailsWithoutCopyUp) {
     auto env = make_overlay_env("overlayfs_lower_file_to_dir_no_copyup");
     std::string lower_old = join_path(env.lower, "old");

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -2153,6 +2153,26 @@ TEST(OverlayFsSemantics, UpperOnlyRenameNoReplacePreservesState) {
     cleanup_overlay_env(env);
 }
 
+TEST(OverlayFsSemantics, RenameSamePathValidatesSourceAndNoReplace) {
+    ScopedOverlayEnv scoped("overlayfs_rename_same_path");
+    const auto& env = scoped.env;
+    prepare_overlay_env(env);
+    std::string merged_file = join_path(env.merged, "file");
+    ASSERT_EQ(0, write_text(join_path(env.lower, "file"), "lower"));
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    EXPECT_EQ(0, rename(merged_file.c_str(), merged_file.c_str())) << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, renameat2_call(merged_file, merged_file, RENAME_NOREPLACE));
+    EXPECT_EQ(EEXIST, errno);
+
+    std::string missing = join_path(env.merged, "missing");
+    errno = 0;
+    EXPECT_EQ(-1, rename(missing.c_str(), missing.c_str()));
+    EXPECT_EQ(ENOENT, errno);
+}
+
 TEST(OverlayFsSemantics, UserWhiteoutRenameIsRejected) {
     auto env = make_overlay_env("overlayfs_user_whiteout_reject");
     std::string upper_old = join_path(env.upper, "old");

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -1113,6 +1113,80 @@ TEST(OverlayFsSemantics, DetachedOldDirectoryIsNotReusedForAncestorCopyUp) {
     EXPECT_EQ(0, close(old_dir_fd)) << strerror(errno);
 }
 
+TEST(OverlayFsSemantics, ConcurrentChildrenShareAncestorPublication) {
+    constexpr int kParentCount = 32;
+    constexpr int kEvictionLookups = 1100;
+    ScopedOverlayEnv scoped("overlayfs_concurrent_ancestors");
+    const auto& env = scoped.env;
+    std::vector<int> left_fds;
+    std::vector<int> right_fds;
+
+    prepare_overlay_env(env);
+    for (int i = 0; i < kParentCount; ++i) {
+        std::string dir = join_path(env.lower, ("dir" + std::to_string(i)).c_str());
+        ASSERT_EQ(0, mkdir(dir.c_str(), 0755)) << strerror(errno);
+        ASSERT_EQ(0, write_text(join_path(dir, "left"), "left"));
+        ASSERT_EQ(0, write_text(join_path(dir, "right"), "right"));
+    }
+    for (int i = 0; i < kEvictionLookups; ++i) {
+        ASSERT_EQ(0, write_text(
+                         join_path(env.lower, ("evict" + std::to_string(i)).c_str()),
+                         "x"));
+    }
+    ASSERT_TRUE(setup_overlay_env(env)) << strerror(errno);
+
+    for (int i = 0; i < kParentCount; ++i) {
+        std::string dir = join_path(env.merged, ("dir" + std::to_string(i)).c_str());
+        left_fds.push_back(open(join_path(dir, "left").c_str(), O_RDONLY | O_CLOEXEC));
+        right_fds.push_back(open(join_path(dir, "right").c_str(), O_RDONLY | O_CLOEXEC));
+        ASSERT_GE(left_fds.back(), 0) << strerror(errno);
+        ASSERT_GE(right_fds.back(), 0) << strerror(errno);
+    }
+    for (int i = 0; i < kEvictionLookups; ++i) {
+        struct stat st = {};
+        std::string path = join_path(env.merged, ("evict" + std::to_string(i)).c_str());
+        ASSERT_EQ(0, stat(path.c_str(), &st)) << strerror(errno);
+    }
+
+    int start_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(start_pipe)) << strerror(errno);
+    std::vector<pid_t> children;
+    for (const auto* fds : {&left_fds, &right_fds}) {
+        pid_t child = fork();
+        ASSERT_GE(child, 0) << strerror(errno);
+        if (child == 0) {
+            close(start_pipe[1]);
+            char token = 0;
+            if (read(start_pipe[0], &token, 1) != 1) {
+                _exit(2);
+            }
+            for (int fd : *fds) {
+                if (fchmod(fd, 0600) != 0) {
+                    _exit(3);
+                }
+                sched_yield();
+            }
+            _exit(0);
+        }
+        children.push_back(child);
+    }
+    close(start_pipe[0]);
+    ASSERT_EQ(2, write(start_pipe[1], "xx", 2));
+    close(start_pipe[1]);
+    for (pid_t child : children) {
+        int status = 0;
+        ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+        ASSERT_TRUE(WIFEXITED(status));
+        EXPECT_EQ(0, WEXITSTATUS(status));
+    }
+    for (int fd : left_fds) {
+        close(fd);
+    }
+    for (int fd : right_fds) {
+        close(fd);
+    }
+}
+
 TEST(OverlayFsSemantics, OldLowerFileDescriptorDoesNotFollowSameNameReplacement) {
     ScopedOverlayEnv scoped("overlayfs_revalidate_identity");
     const auto& env = scoped.env;

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_semantics.cc
@@ -1113,6 +1113,28 @@ TEST(OverlayFsSemantics, DetachedOldDirectoryIsNotReusedForAncestorCopyUp) {
     EXPECT_EQ(0, close(old_dir_fd)) << strerror(errno);
 }
 
+TEST(TmpfsSemantics, RemovedDirectoryFdRejectsNamespaceMutations) {
+    std::string root = "/tmp/tmpfs_dead_dir_" + std::to_string(getpid());
+    std::string dir = join_path(root, "dir");
+
+    ASSERT_EQ(0, mkdir(root.c_str(), 0755)) << strerror(errno);
+    ASSERT_EQ(0, mkdir(dir.c_str(), 0755)) << strerror(errno);
+    int dir_fd = open(dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    ASSERT_GE(dir_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, rmdir(dir.c_str())) << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, mkdirat(dir_fd, "child", 0755));
+    EXPECT_EQ(ENOENT, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, renameat(dir_fd, "missing", dir_fd, "missing"));
+    EXPECT_EQ(ENOENT, errno);
+
+    EXPECT_EQ(0, close(dir_fd)) << strerror(errno);
+    EXPECT_EQ(0, rmdir(root.c_str())) << strerror(errno);
+}
+
 TEST(OverlayFsSemantics, ConcurrentChildrenShareAncestorPublication) {
     constexpr int kParentCount = 32;
     constexpr int kEvictionLookups = 1100;


### PR DESCRIPTION
## Summary

- cache merged overlayfs directory snapshots behind stable per-directory state
- replace quadratic vector deduplication with `BTreeSet` merging
- retain positive lookup objects in a mount-global bounded cache while revalidating backing identities
- replace filesystem-wide copy-up and content serialization with mount-local lock stripes
- keep rename and rmdir under a short namespace commit lock plus stable parent directory locks
- add large-directory regression coverage for duplicate merging and mutation invalidation

## Root cause

Overlayfs rebuilt merged directory listings on every call, used linear vector membership checks for every lower entry, and serialized unrelated copy-up and metadata operations through one filesystem-wide mutation lock. Existing weak inode interning also did not retain short-lived lookup results, while caching without backing revalidation could return stale objects after direct upper changes.

## Validation

- `make kernel`
- built `overlayfs_semantics_test`
- DragonOS QEMU guest: `overlayfs_semantics_test` — 68 passed, 8 skipped, 0 failed
- full dunitest run: 612 non-overlay tests passed or skipped; the one initial overlay cache failure was reproduced, fixed with backing revalidation, and the complete overlayfs suite was rerun successfully
- adversarial plan and code review covering lock ordering, cache lifetime, Linux semantics, whiteouts, copy-up, metadata, and memory bounds

Closes #2008
