### PR TITLE
feat(vfs): define inode retention lifecycle

### DIFF
--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -7,8 +7,8 @@ use crate::{
             fcntl::AtFlags,
             utils::{user_path_at, DName},
             vcore::{generate_inode_id, try_find_gendisk},
-            FileSystem, FileSystemMakerData, IndexNode, InodeRetentionKind, Magic,
-            MountableFileSystem, FSMAKER, VFS_MAX_FOLLOW_SYMLINK_TIMES,
+            FileSystem, FileSystemMakerData, IndexNode, Magic, MountableFileSystem, FSMAKER,
+            VFS_MAX_FOLLOW_SYMLINK_TIMES,
         },
     },
     libs::{
@@ -32,18 +32,11 @@ use linkme::distributed_slice;
 use system_error::SystemError;
 
 use super::inode::LockedExt4Inode;
-use crate::filesystem::vfs::inode_lifecycle::InodeRetentionGuard;
 
 #[derive(Debug)]
 struct CanonicalInodeEntry {
     inode: Weak<LockedExt4Inode>,
     lifecycle: Arc<Ext4InodeLifecycle>,
-}
-
-#[derive(Debug)]
-struct DirtyInodeEntry {
-    inode: Arc<LockedExt4Inode>,
-    _retention: InodeRetentionGuard,
 }
 
 #[must_use]
@@ -64,7 +57,7 @@ pub struct Ext4FileSystem {
     root_inode: Arc<LockedExt4Inode>,
 
     /// 元数据（size/mtime）脏但尚未刷盘的 inode 列表。
-    dirty_inodes: Mutex<Vec<DirtyInodeEntry>>,
+    dirty_inodes: Mutex<Vec<Arc<LockedExt4Inode>>>,
 
     /// Per-superblock canonical VFS inode identity, keyed by the on-disk inode number.
     inode_table: Mutex<BTreeMap<u32, CanonicalInodeEntry>>,
@@ -370,20 +363,14 @@ impl Ext4FileSystem {
 
         if should_queue {
             if let Some(fs) = fs {
-                fs.dirty_inodes.lock().push(DirtyInodeEntry {
-                    inode: inode.clone(),
-                    _retention: InodeRetentionGuard::new(
-                        inode.clone(),
-                        InodeRetentionKind::AsyncWork,
-                    )?,
-                });
+                fs.dirty_inodes.lock().push(inode.clone());
             }
         }
         Ok(())
     }
 
     fn flush_dirty_inodes(&self) -> Result<(), SystemError> {
-        let dirty: Vec<DirtyInodeEntry> = {
+        let dirty: Vec<Arc<LockedExt4Inode>> = {
             let mut guard = self.dirty_inodes.lock();
             if guard.is_empty() {
                 return Ok(());
@@ -392,10 +379,8 @@ impl Ext4FileSystem {
         };
 
         let mut last_err = Ok(());
-        let mut requeue: Vec<DirtyInodeEntry> = Vec::new();
-        for dirty_entry in dirty {
-            let inode = dirty_entry.inode.clone();
-            let mut dirty_entry = Some(dirty_entry);
+        let mut requeue: Vec<Arc<LockedExt4Inode>> = Vec::new();
+        for inode in dirty {
             let mut should_requeue = false;
             let result = {
                 let has_dirty_metadata = {
@@ -424,7 +409,7 @@ impl Ext4FileSystem {
                         continue;
                     }
                     Err(error) => {
-                        requeue.push(dirty_entry.take().unwrap());
+                        requeue.push(inode);
                         last_err = Err(error);
                         continue;
                     }
@@ -506,7 +491,7 @@ impl Ext4FileSystem {
                 last_err = Err(e);
             }
             if should_requeue {
-                requeue.push(dirty_entry.take().unwrap());
+                requeue.push(inode);
             }
         }
         if !requeue.is_empty() {

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -7,8 +7,8 @@ use crate::{
             fcntl::AtFlags,
             utils::{user_path_at, DName},
             vcore::{generate_inode_id, try_find_gendisk},
-            FileSystem, FileSystemMakerData, IndexNode, Magic, MountableFileSystem, FSMAKER,
-            VFS_MAX_FOLLOW_SYMLINK_TIMES,
+            FileSystem, FileSystemMakerData, IndexNode, InodeRetentionKind, Magic,
+            MountableFileSystem, FSMAKER, VFS_MAX_FOLLOW_SYMLINK_TIMES,
         },
     },
     libs::{
@@ -32,11 +32,18 @@ use linkme::distributed_slice;
 use system_error::SystemError;
 
 use super::inode::LockedExt4Inode;
+use crate::filesystem::vfs::inode_lifecycle::InodeRetentionGuard;
 
 #[derive(Debug)]
 struct CanonicalInodeEntry {
     inode: Weak<LockedExt4Inode>,
     lifecycle: Arc<Ext4InodeLifecycle>,
+}
+
+#[derive(Debug)]
+struct DirtyInodeEntry {
+    inode: Arc<LockedExt4Inode>,
+    _retention: InodeRetentionGuard,
 }
 
 #[must_use]
@@ -57,7 +64,7 @@ pub struct Ext4FileSystem {
     root_inode: Arc<LockedExt4Inode>,
 
     /// 元数据（size/mtime）脏但尚未刷盘的 inode 列表。
-    dirty_inodes: Mutex<Vec<Arc<LockedExt4Inode>>>,
+    dirty_inodes: Mutex<Vec<DirtyInodeEntry>>,
 
     /// Per-superblock canonical VFS inode identity, keyed by the on-disk inode number.
     inode_table: Mutex<BTreeMap<u32, CanonicalInodeEntry>>,
@@ -363,14 +370,20 @@ impl Ext4FileSystem {
 
         if should_queue {
             if let Some(fs) = fs {
-                fs.dirty_inodes.lock().push(inode.clone());
+                fs.dirty_inodes.lock().push(DirtyInodeEntry {
+                    inode: inode.clone(),
+                    _retention: InodeRetentionGuard::new(
+                        inode.clone(),
+                        InodeRetentionKind::AsyncWork,
+                    )?,
+                });
             }
         }
         Ok(())
     }
 
     fn flush_dirty_inodes(&self) -> Result<(), SystemError> {
-        let dirty: Vec<Arc<LockedExt4Inode>> = {
+        let dirty: Vec<DirtyInodeEntry> = {
             let mut guard = self.dirty_inodes.lock();
             if guard.is_empty() {
                 return Ok(());
@@ -379,8 +392,10 @@ impl Ext4FileSystem {
         };
 
         let mut last_err = Ok(());
-        let mut requeue: Vec<Arc<LockedExt4Inode>> = Vec::new();
-        for inode in dirty {
+        let mut requeue: Vec<DirtyInodeEntry> = Vec::new();
+        for dirty_entry in dirty {
+            let inode = dirty_entry.inode.clone();
+            let mut dirty_entry = Some(dirty_entry);
             let mut should_requeue = false;
             let result = {
                 let has_dirty_metadata = {
@@ -409,7 +424,7 @@ impl Ext4FileSystem {
                         continue;
                     }
                     Err(error) => {
-                        requeue.push(inode);
+                        requeue.push(dirty_entry.take().unwrap());
                         last_err = Err(error);
                         continue;
                     }
@@ -491,7 +506,7 @@ impl Ext4FileSystem {
                 last_err = Err(e);
             }
             if should_requeue {
-                requeue.push(inode);
+                requeue.push(dirty_entry.take().unwrap());
             }
         }
         if !requeue.is_empty() {

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -5,8 +5,7 @@ use crate::{
         page_cache::{AsyncPageCacheBackend, PageCache},
         vfs::{
             self, syscall::RenameFlags, utils::DName, vcore::generate_inode_id, FilePrivateData,
-            IndexNode, InodeFlags, InodeId, InodeMode, InodeRetentionState, SpecialNodeData,
-            XattrFlags,
+            IndexNode, InodeFlags, InodeId, InodeMode, SpecialNodeData, XattrFlags,
         },
     },
     ipc::pipe::LockedPipeInode,
@@ -73,7 +72,6 @@ pub(super) struct Ext4InodeLifecycle {
     inner: Mutex<Ext4InodeLifecycleInner>,
     link_mutation: Mutex<()>,
     wait_queue: WaitQueue,
-    retention: InodeRetentionState,
 }
 
 impl Ext4InodeLifecycle {
@@ -86,7 +84,6 @@ impl Ext4InodeLifecycle {
             }),
             link_mutation: Mutex::new(()),
             wait_queue: WaitQueue::default(),
-            retention: InodeRetentionState::new(),
         })
     }
 
@@ -235,16 +232,6 @@ pub struct LockedExt4Inode(
 );
 
 impl IndexNode for LockedExt4Inode {
-    fn retention_state(&self) -> Option<&InodeRetentionState> {
-        Some(&self.4.retention)
-    }
-
-    fn on_zero_retention(&self) {
-        // Wake lifecycle waiters so a zero-link inode implementation can
-        // re-evaluate eviction eligibility without doing I/O in this callback.
-        self.4.wait_queue.wake_all();
-    }
-
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -5,7 +5,8 @@ use crate::{
         page_cache::{AsyncPageCacheBackend, PageCache},
         vfs::{
             self, syscall::RenameFlags, utils::DName, vcore::generate_inode_id, FilePrivateData,
-            IndexNode, InodeFlags, InodeId, InodeMode, SpecialNodeData, XattrFlags,
+            IndexNode, InodeFlags, InodeId, InodeMode, InodeRetentionState, SpecialNodeData,
+            XattrFlags,
         },
     },
     ipc::pipe::LockedPipeInode,
@@ -72,6 +73,7 @@ pub(super) struct Ext4InodeLifecycle {
     inner: Mutex<Ext4InodeLifecycleInner>,
     link_mutation: Mutex<()>,
     wait_queue: WaitQueue,
+    retention: InodeRetentionState,
 }
 
 impl Ext4InodeLifecycle {
@@ -84,6 +86,7 @@ impl Ext4InodeLifecycle {
             }),
             link_mutation: Mutex::new(()),
             wait_queue: WaitQueue::default(),
+            retention: InodeRetentionState::new(),
         })
     }
 
@@ -232,6 +235,16 @@ pub struct LockedExt4Inode(
 );
 
 impl IndexNode for LockedExt4Inode {
+    fn retention_state(&self) -> Option<&InodeRetentionState> {
+        Some(&self.4.retention)
+    }
+
+    fn on_zero_retention(&self) {
+        // Wake lifecycle waiters so a zero-link inode implementation can
+        // re-evaluate eviction eligibility without doing I/O in this callback.
+        self.4.wait_queue.wake_all();
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/fs.rs
+++ b/kernel/src/filesystem/fs.rs
@@ -2,21 +2,75 @@ use core::sync::atomic::{AtomicU32, Ordering};
 
 use alloc::sync::Arc;
 
-use crate::filesystem::vfs::IndexNode;
 use crate::filesystem::vfs::InodeMode;
+use crate::filesystem::vfs::{mount::MountFSInode, utils::ResolvedPath, IndexNode};
+use crate::libs::casting::DowncastArc;
 use crate::libs::rwsem::RwSem;
 use crate::process::ProcessManager;
+
+#[derive(Debug)]
+struct PinnedPath {
+    inode: Arc<dyn IndexNode>,
+    _mount_guard: Option<crate::filesystem::vfs::mount::MountExternalGuard>,
+}
+
+impl PinnedPath {
+    fn new(inode: Arc<dyn IndexNode>) -> Self {
+        let mount_guard = inode.clone().downcast_arc::<MountFSInode>().map(|inode| {
+            inode
+                .mount_fs()
+                .try_pin_external()
+                .expect("live process path must pin its mount")
+        });
+        Self {
+            inode,
+            _mount_guard: mount_guard,
+        }
+    }
+
+    fn from_resolved(resolved: ResolvedPath) -> Self {
+        let (inode, mount_guard, operation_guard) = resolved.into_parts();
+        drop(operation_guard);
+        Self {
+            inode,
+            _mount_guard: mount_guard,
+        }
+    }
+
+    fn resolved(&self) -> Result<ResolvedPath, system_error::SystemError> {
+        let mount_guard = self
+            ._mount_guard
+            .as_ref()
+            .map(|guard| guard.derive())
+            .transpose()?;
+        ResolvedPath::from_existing_mount(self.inode.clone(), mount_guard)
+    }
+}
+
+impl Clone for PinnedPath {
+    fn clone(&self) -> Self {
+        Self {
+            inode: self.inode.clone(),
+            _mount_guard: self._mount_guard.as_ref().map(|guard| {
+                guard
+                    .derive()
+                    .expect("valid process path must remain derivable")
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct PathContext {
-    root: Arc<dyn IndexNode>,
-    pwd: Arc<dyn IndexNode>,
+    root: PinnedPath,
+    pwd: PinnedPath,
 }
 
 impl PathContext {
     pub fn new() -> Self {
         Self {
-            root: ProcessManager::current_mntns().root_inode(),
-            pwd: ProcessManager::current_mntns().root_inode(),
+            root: PinnedPath::new(ProcessManager::current_mntns().root_inode()),
+            pwd: PinnedPath::new(ProcessManager::current_mntns().root_inode()),
         }
     }
 }
@@ -66,18 +120,34 @@ impl FsStruct {
     }
 
     pub fn set_root(&self, inode: Arc<dyn IndexNode>) {
-        self.path_context.write().root = inode;
+        self.path_context.write().root = PinnedPath::new(inode);
+    }
+
+    pub fn set_root_resolved(&self, path: ResolvedPath) {
+        self.path_context.write().root = PinnedPath::from_resolved(path);
     }
 
     pub fn set_pwd(&self, inode: Arc<dyn IndexNode>) {
-        self.path_context.write().pwd = inode;
+        self.path_context.write().pwd = PinnedPath::new(inode);
+    }
+
+    pub fn set_pwd_resolved(&self, path: ResolvedPath) {
+        self.path_context.write().pwd = PinnedPath::from_resolved(path);
     }
 
     pub fn pwd(&self) -> Arc<dyn IndexNode> {
-        self.path_context.read().pwd.clone()
+        self.path_context.read().pwd.inode.clone()
     }
 
     pub fn root(&self) -> Arc<dyn IndexNode> {
-        self.path_context.read().root.clone()
+        self.path_context.read().root.inode.clone()
+    }
+
+    pub fn pwd_resolved(&self) -> Result<ResolvedPath, system_error::SystemError> {
+        self.path_context.read().pwd.resolved()
+    }
+
+    pub fn root_resolved(&self) -> Result<ResolvedPath, system_error::SystemError> {
+        self.path_context.read().root.resolved()
     }
 }

--- a/kernel/src/filesystem/procfs/mount/collect.rs
+++ b/kernel/src/filesystem/procfs/mount/collect.rs
@@ -17,7 +17,8 @@ pub(crate) fn collect_visible_mounts(
     let nsproxy = target.nsproxy();
     let mount_list = nsproxy.mnt_ns.mount_list();
     let root_path = target
-        .fs_struct()
+        .try_fs_struct()
+        .ok_or(SystemError::ESRCH)?
         .root()
         .absolute_path()
         .unwrap_or_else(|_| "/".to_string());

--- a/kernel/src/filesystem/procfs/pid/fd.rs
+++ b/kernel/src/filesystem/procfs/pid/fd.rs
@@ -144,7 +144,8 @@ impl SymOps for FdSymOps {
 
         // 获取进程的 chroot 根路径
         let root_prefix = process
-            .fs_struct()
+            .try_fs_struct()
+            .ok_or(SystemError::ESRCH)?
             .root()
             .absolute_path()
             .unwrap_or_default();

--- a/kernel/src/filesystem/procfs/pid/maps.rs
+++ b/kernel/src/filesystem/procfs/pid/maps.rs
@@ -118,11 +118,10 @@ fn generate_maps_content(target: &ProcPidTarget) -> Result<Vec<u8>, SystemError>
     let Some(vm) = vm else {
         return Ok(Vec::new());
     };
-    let root_prefix = target_pcb
-        .fs_struct()
-        .root()
-        .absolute_path()
-        .unwrap_or_default();
+    let Some(fs) = target_pcb.try_fs_struct() else {
+        return Ok(Vec::new());
+    };
+    let root_prefix = fs.root().absolute_path().unwrap_or_default();
 
     let as_guard = vm.read_guard_no_reservations();
 

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -8,8 +8,11 @@ use log::error;
 use system_error::SystemError;
 
 use super::{
-    append_lock::with_inode_append_lock, mount::MountFSInode, utils::should_remove_sgid, FileType,
-    IndexNode, InodeId, Metadata, SetMetadataMask, SpecialNodeData,
+    append_lock::with_inode_append_lock,
+    inode_lifecycle::{InodeRetentionGuard, InodeRetentionKind},
+    mount::{MountExternalGuard, MountFSInode},
+    utils::should_remove_sgid,
+    FileType, IndexNode, InodeId, Metadata, SetMetadataMask, SpecialNodeData,
 };
 use crate::{arch::ipc::signal::Signal, filesystem::vfs::InodeFlags, process::pid::PidPrivateData};
 use crate::{
@@ -528,9 +531,25 @@ pub struct File {
     /// via `eventpoll_release(file)`.  DragonOS keeps the same lifetime edge
     /// here so fd numbers can be safely reused after close.
     epitems: Arc<LockedEPItemLinkedList>,
+    /// One semantic inode pin per open file description. Duplicated file
+    /// descriptors and VMAs share this `File`, while `O_PATH` still owns it.
+    /// Declared last so the explicit `Drop` body runs `close()` before release.
+    _inode_retention: InodeRetentionGuard,
+    /// Pins the mount used to resolve this pathname independently from the
+    /// operation inode (which device/FIFO resolution may replace).
+    _mount_guard: Option<MountExternalGuard>,
 }
 
 impl File {
+    pub fn resolved_path(&self) -> Result<super::utils::ResolvedPath, SystemError> {
+        let mount_guard = self
+            ._mount_guard
+            .as_ref()
+            .map(MountExternalGuard::derive)
+            .transpose()?;
+        super::utils::ResolvedPath::from_existing_mount(self.inode.clone(), mount_guard)
+    }
+
     #[inline]
     pub fn cred(&self) -> Arc<Cred> {
         self.cred.clone()
@@ -763,8 +782,40 @@ impl File {
     /// semantics (e.g. sockets created by socket syscalls).
     pub fn new_with_private_data(
         inode: Arc<dyn IndexNode>,
+        flags: FileFlags,
+        private_data_init: FilePrivateData,
+    ) -> Result<Self, SystemError> {
+        let mount_guard = inode
+            .clone()
+            .downcast_arc::<MountFSInode>()
+            .map(|inode| inode.mount_fs().try_pin_external())
+            .transpose()?;
+        Self::new_with_private_data_and_mount_guard(inode, flags, private_data_init, mount_guard)
+    }
+
+    /// Construct a pathname-backed file by consuming the mount pin acquired
+    /// during path resolution. This closes the lookup-to-open umount window.
+    pub fn new_with_mount_guard(
+        inode: Arc<dyn IndexNode>,
+        flags: FileFlags,
+        mount_guard: Option<MountExternalGuard>,
+        operation_guard: InodeRetentionGuard,
+    ) -> Result<Self, SystemError> {
+        let file = Self::new_with_private_data_and_mount_guard(
+            inode,
+            flags,
+            FilePrivateData::default(),
+            mount_guard,
+        );
+        drop(operation_guard);
+        file
+    }
+
+    fn new_with_private_data_and_mount_guard(
+        inode: Arc<dyn IndexNode>,
         mut flags: FileFlags,
         private_data_init: FilePrivateData,
+        mount_guard: Option<MountExternalGuard>,
     ) -> Result<Self, SystemError> {
         let mut inode = inode;
         let mut file_type = inode.metadata()?.file_type;
@@ -810,6 +861,10 @@ impl File {
         flags.remove(FileFlags::O_CLOEXEC);
 
         let mut mode = FileMode::open_fmode(flags);
+        // Pin the final operation inode before invoking filesystem open. If
+        // open fails, the local guard releases exactly once on this error path.
+        let inode_retention =
+            InodeRetentionGuard::new(inode.clone(), InodeRetentionKind::OpenFileDescription)?;
 
         let private_data = Mutex::new(private_data_init);
         if is_path {
@@ -879,6 +934,8 @@ impl File {
             wb_error_seq: Mutex::new(wb_error_seq),
             sb_error_seq: Mutex::new(sb_error_seq),
             epitems: Arc::new(LockedEPItemLinkedList::default()),
+            _inode_retention: inode_retention,
+            _mount_guard: mount_guard,
         };
 
         return Ok(f);
@@ -1477,15 +1534,40 @@ impl File {
     ///
     /// @return Option<File> 克隆后的文件结构体。如果克隆失败，返回None
     pub fn try_clone(&self) -> Option<File> {
+        let inode_retention =
+            InodeRetentionGuard::new(self.inode.clone(), InodeRetentionKind::OpenFileDescription)
+                .ok()?;
+        let flags = self.flags();
+        let mode = self.mode();
+        let private_data = Mutex::new(self.private_data.lock().clone());
+        let mount_guard = self
+            ._mount_guard
+            .as_ref()
+            .map(MountExternalGuard::derive)
+            .transpose()
+            .ok()?;
+
+        if !mode.contains(FileMode::FMODE_PATH)
+            && self.inode.open(private_data.lock(), &flags).is_err()
+        {
+            return None;
+        }
+
+        if mode.contains(FileMode::FMODE_WRITER) {
+            if let Some(mnt_inode) = self.inode.clone().downcast_arc::<MountFSInode>() {
+                mnt_inode.mount_fs().inc_write_count();
+            }
+        }
+
         let res = Self {
             open_file_id: alloc_open_file_id(),
             inode: self.inode.clone(),
             offset: AtomicUsize::new(self.offset.load(Ordering::SeqCst)),
-            flags: RwSem::new(self.flags()),
-            mode: RwSem::new(self.mode()),
+            flags: RwSem::new(flags),
+            mode: RwSem::new(mode),
             file_type: self.file_type,
             readdir_subdirs_name: Mutex::new(self.readdir_subdirs_name.lock().clone()),
-            private_data: Mutex::new(self.private_data.lock().clone()),
+            private_data,
             cred: self.cred.clone(),
             owner: Mutex::new(FileOwner::new()),
             posix_lock_key: self.posix_lock_key,
@@ -1493,17 +1575,9 @@ impl File {
             wb_error_seq: Mutex::new(*self.wb_error_seq.lock()),
             sb_error_seq: Mutex::new(*self.sb_error_seq.lock()),
             epitems: Arc::new(LockedEPItemLinkedList::default()),
+            _inode_retention: inode_retention,
+            _mount_guard: mount_guard,
         };
-        // 调用inode的open方法，让inode知道有新的文件打开了这个inode
-        // TODO: reopen is not a good idea for some inodes, need a better design
-        if self
-            .inode
-            .open(res.private_data.lock(), &res.flags())
-            .is_err()
-        {
-            return None;
-        }
-
         return Some(res);
     }
 

--- a/kernel/src/filesystem/vfs/inode_lifecycle.rs
+++ b/kernel/src/filesystem/vfs/inode_lifecycle.rs
@@ -1,0 +1,207 @@
+use alloc::sync::Arc;
+use system_error::SystemError;
+
+use super::IndexNode;
+use crate::libs::spinlock::SpinLock;
+
+/// Monotonic completion boundary for filesystem eviction requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EvictionEpoch(u64);
+
+impl EvictionEpoch {
+    pub const EMPTY: Self = Self(0);
+
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(self) -> u64 {
+        self.0
+    }
+}
+
+/// The semantic owner of an inode lifetime pin.
+///
+/// Unlike an `Arc`, these pins describe references that filesystem eviction
+/// must wait for. They must be attached to the canonical inode lifetime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InodeRetentionKind {
+    OpenFileDescription,
+    Cache,
+    AsyncWork,
+    Operation,
+}
+
+impl InodeRetentionKind {
+    const COUNT: usize = 4;
+
+    const fn index(self) -> usize {
+        match self {
+            Self::OpenFileDescription => 0,
+            Self::Cache => 1,
+            Self::AsyncWork => 2,
+            Self::Operation => 3,
+        }
+    }
+}
+
+/// Filesystem-embeddable semantic retention accounting.
+///
+/// A single lock linearizes retain against the final release. This avoids the
+/// false-zero window that independent atomic kind/total counters would create
+/// when a new owner races the previous owner's release.
+#[derive(Debug)]
+pub struct InodeRetentionState {
+    inner: SpinLock<InodeRetentionInner>,
+}
+
+#[derive(Debug)]
+struct InodeRetentionInner {
+    counts: [usize; InodeRetentionKind::COUNT],
+    admitting: bool,
+}
+
+impl Default for InodeRetentionState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InodeRetentionState {
+    pub const fn new() -> Self {
+        Self {
+            inner: SpinLock::new(InodeRetentionInner {
+                counts: [0; InodeRetentionKind::COUNT],
+                admitting: true,
+            }),
+        }
+    }
+
+    pub fn retain(&self, kind: InodeRetentionKind) -> Result<(), SystemError> {
+        let mut inner = self.inner.lock();
+        if !inner.admitting {
+            return Err(SystemError::EBUSY);
+        }
+        inner.counts[kind.index()] = inner.counts[kind.index()]
+            .checked_add(1)
+            .expect("inode semantic retention overflow");
+        Ok(())
+    }
+
+    /// Release one owner and return whether all semantic owners are now gone.
+    ///
+    /// A `true` result is only an eviction notification edge. The filesystem
+    /// must still check link/cache state and publish a one-shot request.
+    pub fn release(&self, kind: InodeRetentionKind) -> bool {
+        let mut inner = self.inner.lock();
+        let count = &mut inner.counts[kind.index()];
+        assert!(*count != 0, "inode semantic retention underflow");
+        *count -= 1;
+        inner.counts.iter().all(|count| *count == 0)
+    }
+
+    /// Atomically stop new retention admission if no semantic owner remains.
+    pub fn try_begin_freeing(&self) -> Result<(), SystemError> {
+        let mut inner = self.inner.lock();
+        if !inner.admitting || inner.counts.iter().any(|count| *count != 0) {
+            return Err(SystemError::EBUSY);
+        }
+        inner.admitting = false;
+        Ok(())
+    }
+
+    /// Reopen admission after a filesystem freeing transaction is aborted.
+    pub fn abort_freeing(&self) {
+        self.inner.lock().admitting = true;
+    }
+}
+
+/// Exactly-once RAII pairing for `IndexNode::retain`/`release`.
+///
+/// Dropping this guard must never perform filesystem I/O. A filesystem may
+/// only publish a deferred eviction request from `release`; fallible work is
+/// completed through its explicit eviction drain path.
+#[derive(Debug)]
+pub struct InodeRetentionGuard {
+    inode: Arc<dyn IndexNode>,
+    kind: InodeRetentionKind,
+}
+
+impl InodeRetentionGuard {
+    pub fn new(inode: Arc<dyn IndexNode>, kind: InodeRetentionKind) -> Result<Self, SystemError> {
+        inode.retain(kind)?;
+        Ok(Self { inode, kind })
+    }
+}
+
+impl Drop for InodeRetentionGuard {
+    fn drop(&mut self) {
+        self.inode.release(self.kind);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    struct MockInode {
+        retention: InodeRetentionState,
+        eviction_notifications: AtomicUsize,
+    }
+
+    impl MockInode {
+        fn new() -> Self {
+            Self {
+                retention: InodeRetentionState::new(),
+                eviction_notifications: AtomicUsize::new(0),
+            }
+        }
+
+        fn retain(&self, kind: InodeRetentionKind) {
+            self.retention.retain(kind).unwrap();
+        }
+
+        fn release(&self, kind: InodeRetentionKind) {
+            if self.retention.release(kind) {
+                self.eviction_notifications.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    #[test]
+    fn retention_kinds_release_exactly_once_at_final_edge() {
+        let inode = MockInode::new();
+        inode.retain(InodeRetentionKind::OpenFileDescription);
+        inode.retain(InodeRetentionKind::AsyncWork);
+
+        inode.release(InodeRetentionKind::OpenFileDescription);
+        assert_eq!(inode.eviction_notifications.load(Ordering::Relaxed), 0);
+        inode.release(InodeRetentionKind::AsyncWork);
+        assert_eq!(inode.eviction_notifications.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "inode semantic retention underflow")]
+    fn retention_underflow_is_not_hidden() {
+        InodeRetentionState::new().release(InodeRetentionKind::Cache);
+    }
+
+    #[test]
+    fn freeing_admission_is_linearized_with_retention() {
+        let state = InodeRetentionState::new();
+        state
+            .retain(InodeRetentionKind::OpenFileDescription)
+            .unwrap();
+        assert_eq!(state.try_begin_freeing(), Err(SystemError::EBUSY));
+        assert!(state.release(InodeRetentionKind::OpenFileDescription));
+        state.try_begin_freeing().unwrap();
+        assert_eq!(
+            state.retain(InodeRetentionKind::Operation),
+            Err(SystemError::EBUSY)
+        );
+        state.abort_freeing();
+        state.retain(InodeRetentionKind::Operation).unwrap();
+        assert!(state.release(InodeRetentionKind::Operation));
+    }
+}

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -3,6 +3,7 @@ pub mod fasync;
 pub mod fcntl;
 pub mod file;
 pub mod flock;
+pub mod inode_lifecycle;
 pub mod iov;
 pub mod mount;
 pub mod open;
@@ -45,6 +46,7 @@ use crate::{
     time::PosixTimeSpec,
 };
 
+pub use self::inode_lifecycle::{EvictionEpoch, InodeRetentionKind, InodeRetentionState};
 pub use self::{file::FilePrivateData, mount::MountFS};
 use self::{
     file::{FileFlags, FileMode},
@@ -369,6 +371,43 @@ pub trait PollableInode: Any + Sync + Send + Debug + CastFromSync {
 }
 
 pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
+    /// Optional VFS accounting embedded by this canonical inode.
+    fn retention_state(&self) -> Option<&InodeRetentionState> {
+        None
+    }
+
+    /// Retain this canonical inode lifetime for a semantic VFS owner.
+    ///
+    /// This is deliberately distinct from `open()`: `O_PATH`, caches and
+    /// asynchronous work retain an inode without a filesystem open callback.
+    /// Admission of a new canonical lifetime must be resolved before this
+    /// infallible hook is called.
+    fn retain(&self, kind: InodeRetentionKind) -> Result<(), SystemError> {
+        if let Some(state) = self.retention_state() {
+            state.retain(kind)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Release one semantic inode lifetime owner.
+    ///
+    /// Implementations must not sleep or perform fallible I/O here. The final
+    /// release may publish a one-shot eviction request for an explicit worker
+    /// or shutdown drain.
+    fn release(&self, kind: InodeRetentionKind) {
+        if self
+            .retention_state()
+            .is_some_and(|state| state.release(kind))
+        {
+            self.on_zero_retention();
+        }
+    }
+
+    /// Non-blocking final-release notification. Implementations may enqueue,
+    /// but must not execute, fallible eviction work here.
+    fn on_zero_retention(&self) {}
+
     /// 是否为"流式"文件（不可 random access / 不可 seek）。
     ///
     /// 语义目标：把"pread/pwrite/lseek 应返回 ESPIPE"的判定收敛在 VFS 层，
@@ -1272,18 +1311,65 @@ impl dyn IndexNode {
         max_follow_times: usize,
         follow_final_symlink: bool,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        self.do_lookup_follow_symlink_owned(path, max_follow_times, follow_final_symlink, None)
+            .map(|(inode, _)| inode)
+    }
+
+    /// Path walk variant that transfers a mount/operation pin at every mount
+    /// transition before the newly found inode is inspected or used.
+    pub fn lookup_follow_symlink_owned(
+        &self,
+        start: &utils::ResolvedPath,
+        path: &str,
+        max_follow_times: usize,
+        follow_final_symlink: bool,
+    ) -> Result<utils::ResolvedPath, SystemError> {
+        self.do_lookup_follow_symlink_owned(
+            path,
+            max_follow_times,
+            follow_final_symlink,
+            Some(start.derive()?),
+        )?
+        .1
+        .ok_or(SystemError::ESTALE)
+    }
+
+    fn do_lookup_follow_symlink_owned(
+        &self,
+        path: &str,
+        max_follow_times: usize,
+        follow_final_symlink: bool,
+        mut ownership: Option<utils::ResolvedPath>,
+    ) -> Result<(Arc<dyn IndexNode>, Option<utils::ResolvedPath>), SystemError> {
         if self.metadata()?.file_type != FileType::Dir {
             return Err(SystemError::ENOTDIR);
         }
 
         // Linux 语义：绝对路径应当以"进程 fs root"（可被 chroot 改变）为起点
-        let process_root_inode = ProcessManager::current_pcb().fs_struct().root();
+        let fs_struct = ProcessManager::current_pcb().fs_struct();
+        let process_root_path = if ownership.is_some() {
+            Some(fs_struct.root_resolved()?)
+        } else {
+            None
+        };
+        let process_root_inode = process_root_path
+            .as_ref()
+            .map(|path| path.inode())
+            .unwrap_or_else(|| fs_struct.root());
         let trailing_slash = path.ends_with('/');
 
         // 处理绝对路径
         // result: 上一个被找到的inode
         // rest_path: 还没有查找的路径
         let (mut result, mut rest_path) = if let Some(rest) = path.strip_prefix('/') {
+            if ownership.is_some() {
+                ownership = Some(
+                    process_root_path
+                        .as_ref()
+                        .ok_or(SystemError::ESTALE)?
+                        .derive()?,
+                );
+            }
             (process_root_inode.clone(), String::from(rest))
         } else {
             // 是相对路径
@@ -1333,6 +1419,9 @@ impl dyn IndexNode {
             }
 
             let inode = result.find(&name)?;
+            if ownership.is_some() {
+                ownership = Some(utils::ResolvedPath::new(inode.clone())?);
+            }
             let file_type = inode.metadata()?.file_type;
             // 如果已经是路径的最后一个部分，并且不希望跟随最后的符号链接
             if rest_path.is_empty() && !follow_final_symlink && file_type == FileType::SymLink {
@@ -1340,7 +1429,7 @@ impl dyn IndexNode {
                 // 此时即使请求"不跟随最终 symlink"，也不能返回 symlink 本身。
                 if !trailing_slash {
                     // 返回符号链接本身
-                    return Ok(inode);
+                    return Ok((inode, ownership));
                 }
             }
 
@@ -1381,8 +1470,11 @@ impl dyn IndexNode {
                 // 这些链接的 readlink 返回的路径可能不可解析（如 pipe:[xxx]），
                 // 但它们有一个 special_node 指向真实的 inode
                 if let Some(SpecialNodeData::Reference(target_inode)) = inode.special_node() {
+                    if ownership.is_some() {
+                        ownership = Some(utils::ResolvedPath::new(target_inode.clone())?);
+                    }
                     if rest_path.is_empty() {
-                        return Ok(target_inode);
+                        return Ok((target_inode, ownership));
                     } else {
                         // 将 result 设为 magic link 的目标 inode，继续迭代
                         result = target_inode;
@@ -1417,6 +1509,14 @@ impl dyn IndexNode {
                 // 相对路径：从当前 result（symlink 所在目录）开始
                 if let Some(rest) = new_path.strip_prefix('/') {
                     result = process_root_inode.clone();
+                    if ownership.is_some() {
+                        ownership = Some(
+                            process_root_path
+                                .as_ref()
+                                .ok_or(SystemError::ESTALE)?
+                                .derive()?,
+                        );
+                    }
                     rest_path = String::from(rest);
                 } else {
                     rest_path = new_path;
@@ -1433,7 +1533,7 @@ impl dyn IndexNode {
             return Err(SystemError::ENOTDIR);
         }
 
-        return Ok(result);
+        return Ok((result, ownership));
     }
 }
 
@@ -1674,6 +1774,38 @@ pub trait FileSystem: Any + Sync + Send + Debug {
             return Err(SystemError::EINVAL);
         }
         Ok(request.sb_flags & request.sb_flags_mask)
+    }
+
+    /// Stop admitting new external inode lifetimes during final superblock
+    /// shutdown. Cache shrink and asynchronous cancellation may still publish
+    /// eviction requests after this point.
+    fn close_external_inode_admission(&self) {}
+
+    /// Release filesystem-owned dentry/inode cache retention during final
+    /// shutdown. Implementations may publish eviction requests here.
+    fn shrink_inode_cache_for_shutdown(&self) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    /// Stop or finish asynchronous retention producers before the eviction
+    /// queue is sealed.
+    fn quiesce_async_inode_work(&self) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    /// Seal the eviction producer queue after cache shrink and asynchronous
+    /// work have quiesced, returning the final request epoch to drain.
+    fn seal_eviction_queue(&self) -> EvictionEpoch {
+        EvictionEpoch::EMPTY
+    }
+
+    /// Wait for all eviction requests up to `epoch` and report their errors.
+    ///
+    /// Filesystems that implement deferred eviction must also retain errors in
+    /// their persistent writeback/error sequence; this call is not a
+    /// destructive single-consumer error channel.
+    fn drain_evictions_through(&self, _epoch: EvictionEpoch) -> Result<(), SystemError> {
+        Ok(())
     }
 
     /// VFS permission checking policy for this filesystem instance.

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -326,6 +326,15 @@ pub struct MountExternalGuard {
     mount: Arc<MountFS>,
 }
 
+// SAFETY: MountExternalGuard only owns an Arc<MountFS>. Every mutable MountFS
+// field reachable from the guard is protected by Mutex/RwSem/SpinLock or is
+// atomic. These explicit impls break the recursive auto-trait proof cycle
+// MountFS -> MountFSInode/File -> MountExternalGuard -> MountFS, which some
+// cross-target rustc builds cannot normalize within the default recursion
+// limit; they do not weaken the synchronization requirements of MountFS.
+unsafe impl Send for MountExternalGuard {}
+unsafe impl Sync for MountExternalGuard {}
+
 #[derive(Debug)]
 pub struct SuperBlockState {
     flags: RwSem<MountFlags>,

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -18,6 +18,7 @@ use crate::{
         mutex::{Mutex, MutexGuard},
         rwsem::RwSem,
         spinlock::SpinLock,
+        wait_queue::WaitQueue,
     },
     mm::{fault::PageFaultMessage, VirtRegion, VmFaultReason, VmFlags},
     process::{
@@ -336,6 +337,7 @@ pub struct SuperBlockState {
     dentry_namespace_lock: RwSem<()>,
     dentry_states: Mutex<BTreeMap<DentryKey, Weak<AtomicBool>>>,
     lifecycle: Mutex<SuperBlockLifecycle>,
+    shutdown_wait: WaitQueue,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -379,6 +381,7 @@ impl SuperBlockState {
                 external_pins: 0,
                 state: SuperBlockLifecycleState::Active,
             }),
+            shutdown_wait: WaitQueue::default(),
         }
     }
 
@@ -427,6 +430,17 @@ impl SuperBlockState {
         let mut lifecycle = self.lifecycle.lock();
         debug_assert_eq!(lifecycle.state, SuperBlockLifecycleState::Dying);
         lifecycle.state = SuperBlockLifecycleState::Dead;
+        drop(lifecycle);
+        self.shutdown_wait.wake_all();
+    }
+
+    /// Wait only when this unmount started the final superblock shutdown.
+    /// A still-active shared superblock needs no shutdown completion wait.
+    fn wait_for_shutdown_if_started(&self) {
+        self.shutdown_wait.wait_until(|| {
+            let state = self.lifecycle.lock().state;
+            (state != SuperBlockLifecycleState::Dying).then_some(())
+        });
     }
 
     fn dentry_state(&self, parent: InodeId, child: InodeId, name: DName) -> Arc<AtomicBool> {
@@ -996,6 +1010,16 @@ impl MountFS {
             let _topology = MOUNT_LIFECYCLE_LOCK.lock();
             collect(root)
         };
+        let mut super_blocks = Vec::new();
+        for mount in &mounts {
+            let state = mount.super_block_state();
+            if !super_blocks
+                .iter()
+                .any(|existing| Arc::ptr_eq(existing, &state))
+            {
+                super_blocks.push(state);
+            }
+        }
         let mut propagation_keys = Vec::with_capacity(mounts.len());
         for mount in &mounts {
             let mountpoint = mount.self_mountpoint().ok_or(SystemError::EINVAL)?;
@@ -1039,6 +1063,14 @@ impl MountFS {
             }
             if let Some(namespace) = namespace {
                 namespace.remove_mount_exact(&mount);
+            }
+        }
+        // Final filesystem shutdown may sleep and may itself need pathname
+        // operations. Never wait while holding the topology/admission lock.
+        drop(_topology);
+        if !lazy {
+            for super_block in super_blocks {
+                super_block.wait_for_shutdown_if_started();
             }
         }
         Ok(root.clone())

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1,11 +1,12 @@
 use super::{
     file::{FileFlags, FileMode},
     utils::DName,
-    FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode, PollableInode,
-    SetMetadataMask, SuperBlock, XattrFlags,
+    FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode, InodeRetentionKind,
+    PollableInode, SetMetadataMask, SuperBlock, XattrFlags,
 };
 use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
+    exception::workqueue::{schedule_work, Work},
     filesystem::{
         page_cache::list_page_caches,
         page_cache::PageCache,
@@ -23,8 +24,9 @@ use crate::{
         namespace::{
             mnt::MntNamespace,
             propagation::{
-                inherit_bind_mount_propagation, propagate_mount, propagate_umount, register_peer,
-                register_slave_with_master, unregister_peer, MountPropagation,
+                inherit_bind_mount_propagation, propagate_mount, propagate_umount,
+                propagation_umount_busy, register_peer, register_slave_with_master,
+                unregister_peer, MountPropagation,
             },
         },
         ProcessManager,
@@ -49,6 +51,10 @@ use lazy_static::lazy_static;
 use system_error::SystemError;
 
 mod subtree_move;
+
+/// Serializes mount pin admission against multi-mount busy preflight and
+/// detach, including propagation peers in other namespaces.
+pub(crate) static MOUNT_LIFECYCLE_LOCK: Mutex<()> = Mutex::new(());
 
 bitflags! {
     /// Mount flags for filesystem independent mount options
@@ -292,6 +298,31 @@ pub struct MountFS {
     mount_flags: RwSem<MountFlags>,
     super_block_state: Arc<SuperBlockState>,
     mount_source: RwSem<Option<String>>,
+    lifecycle: Mutex<MountLifecycle>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MountLifecycleState {
+    Constructing,
+    Live,
+    Detaching,
+    Detached,
+}
+
+#[derive(Debug)]
+struct MountLifecycle {
+    state: MountLifecycleState,
+    external_pins: usize,
+}
+
+/// A semantic reference to a path or open file description on one mount.
+///
+/// Unlike an `Arc<MountFS>`, this reference participates in ordinary umount's
+/// busy decision. It is intentionally not `Clone`: every independently owned
+/// path must explicitly acquire its own pin.
+#[derive(Debug)]
+pub struct MountExternalGuard {
+    mount: Arc<MountFS>,
 }
 
 #[derive(Debug)]
@@ -304,6 +335,21 @@ pub struct SuperBlockState {
     /// Shared by all mounts of this superblock, including bind mounts.
     dentry_namespace_lock: RwSem<()>,
     dentry_states: Mutex<BTreeMap<DentryKey, Weak<AtomicBool>>>,
+    lifecycle: Mutex<SuperBlockLifecycle>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SuperBlockLifecycleState {
+    Active,
+    Dying,
+    Dead,
+}
+
+#[derive(Debug)]
+struct SuperBlockLifecycle {
+    active_mounts: usize,
+    external_pins: usize,
+    state: SuperBlockLifecycleState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -328,7 +374,59 @@ impl SuperBlockState {
             unnamed_dev_minor: Mutex::new(None),
             dentry_namespace_lock: RwSem::new(()),
             dentry_states: Mutex::new(BTreeMap::new()),
+            lifecycle: Mutex::new(SuperBlockLifecycle {
+                active_mounts: 0,
+                external_pins: 0,
+                state: SuperBlockLifecycleState::Active,
+            }),
         }
+    }
+
+    fn add_mount(&self) {
+        let mut lifecycle = self.lifecycle.lock();
+        debug_assert_eq!(lifecycle.state, SuperBlockLifecycleState::Active);
+        lifecycle.active_mounts += 1;
+    }
+
+    fn try_add_external_pin(&self) -> bool {
+        let mut lifecycle = self.lifecycle.lock();
+        if lifecycle.state != SuperBlockLifecycleState::Active {
+            return false;
+        }
+        lifecycle.external_pins += 1;
+        true
+    }
+
+    fn remove_external_pin(&self) -> bool {
+        let mut lifecycle = self.lifecycle.lock();
+        debug_assert!(lifecycle.external_pins > 0);
+        lifecycle.external_pins -= 1;
+        Self::try_begin_shutdown(&mut lifecycle)
+    }
+
+    fn remove_mount(&self) -> bool {
+        let mut lifecycle = self.lifecycle.lock();
+        debug_assert!(lifecycle.active_mounts > 0);
+        lifecycle.active_mounts -= 1;
+        Self::try_begin_shutdown(&mut lifecycle)
+    }
+
+    fn try_begin_shutdown(lifecycle: &mut SuperBlockLifecycle) -> bool {
+        if lifecycle.state == SuperBlockLifecycleState::Active
+            && lifecycle.active_mounts == 0
+            && lifecycle.external_pins == 0
+        {
+            lifecycle.state = SuperBlockLifecycleState::Dying;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn finish_shutdown(&self) {
+        let mut lifecycle = self.lifecycle.lock();
+        debug_assert_eq!(lifecycle.state, SuperBlockLifecycleState::Dying);
+        lifecycle.state = SuperBlockLifecycleState::Dead;
     }
 
     fn dentry_state(&self, parent: InodeId, child: InodeId, name: DName) -> Arc<AtomicBool> {
@@ -528,6 +626,10 @@ impl MountFS {
             mount_flags: RwSem::new(mount_flags),
             super_block_state: state_init.super_block_state,
             mount_source: RwSem::new(state_init.mount_source),
+            lifecycle: Mutex::new(MountLifecycle {
+                state: MountLifecycleState::Constructing,
+                external_pins: 0,
+            }),
         });
 
         if let Some(mnt_ns) = mnt_ns {
@@ -556,6 +658,10 @@ impl MountFS {
             mount_flags: RwSem::new(self.mount_flags()),
             super_block_state: self.super_block_state.clone(),
             mount_source: RwSem::new(mount_source),
+            lifecycle: Mutex::new(MountLifecycle {
+                state: MountLifecycleState::Constructing,
+                external_pins: 0,
+            }),
         });
 
         register_mounted_superblock(&mountfs);
@@ -722,6 +828,137 @@ impl MountFS {
         self.self_ref.upgrade().unwrap()
     }
 
+    /// Publish a fully attached mount into the shared-superblock lifecycle.
+    /// Construction failures before this point require no counter rollback.
+    pub(crate) fn activate(&self) {
+        let mut lifecycle = self.lifecycle.lock();
+        if lifecycle.state == MountLifecycleState::Constructing {
+            self.super_block_state.add_mount();
+            lifecycle.state = MountLifecycleState::Live;
+        }
+    }
+
+    /// Remove one published mount from superblock activity exactly once.
+    /// This performs no filesystem I/O; final shutdown is delegated to workqueue.
+    pub(crate) fn deactivate(&self) {
+        let should_remove = {
+            let mut lifecycle = self.lifecycle.lock();
+            match lifecycle.state {
+                MountLifecycleState::Constructing => {
+                    lifecycle.state = MountLifecycleState::Detached;
+                    false
+                }
+                MountLifecycleState::Live | MountLifecycleState::Detaching => {
+                    lifecycle.state = MountLifecycleState::Detached;
+                    true
+                }
+                MountLifecycleState::Detached => false,
+            }
+        };
+        if should_remove && self.super_block_state.remove_mount() {
+            Self::schedule_final_shutdown(self.self_ref());
+        }
+    }
+
+    pub(crate) fn has_external_pins(&self) -> bool {
+        self.lifecycle.lock().external_pins != 0
+    }
+
+    pub(crate) fn subtree_has_external_pins(&self) -> bool {
+        if self.has_external_pins() {
+            return true;
+        }
+        self.mountpoints
+            .lock()
+            .values()
+            .any(|child| child.subtree_has_external_pins())
+    }
+
+    pub(crate) fn is_live(&self) -> bool {
+        self.lifecycle.lock().state == MountLifecycleState::Live
+    }
+
+    /// Finish lifecycle teardown for a subtree already disconnected from its
+    /// parent topology (propagation and namespace destruction paths).
+    pub(crate) fn deactivate_disconnected_subtree(root: &Arc<Self>) {
+        let children: Vec<_> = root.mountpoints.lock().values().cloned().collect();
+        for child in children {
+            Self::deactivate_disconnected_subtree(&child);
+        }
+        root.mountpoints.lock().clear();
+        if let Some(namespace) = root.namespace() {
+            namespace.remove_mount_exact(root);
+        }
+        root.set_self_mountpoint(None);
+        root.clear_namespace();
+        root.deactivate();
+    }
+
+    /// Acquire an external semantic reference used by ordinary umount's busy
+    /// check. Existing paths may derive another reference after lazy detach;
+    /// acquisition stops once final superblock shutdown has begun.
+    pub fn try_pin_external(&self) -> Result<MountExternalGuard, SystemError> {
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        let mut lifecycle = self.lifecycle.lock();
+        match lifecycle.state {
+            MountLifecycleState::Constructing | MountLifecycleState::Detaching => {
+                return Err(SystemError::EBUSY);
+            }
+            MountLifecycleState::Detached if lifecycle.external_pins == 0 => {
+                return Err(SystemError::ESTALE);
+            }
+            MountLifecycleState::Live | MountLifecycleState::Detached => {}
+        }
+        if !self.super_block_state.try_add_external_pin() {
+            return Err(SystemError::ESTALE);
+        }
+        lifecycle.external_pins += 1;
+        Ok(MountExternalGuard {
+            mount: self.self_ref(),
+        })
+    }
+
+    fn derive_external_pin(&self) -> Result<MountExternalGuard, SystemError> {
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        let mut lifecycle = self.lifecycle.lock();
+        if !self.super_block_state.try_add_external_pin() {
+            return Err(SystemError::ESTALE);
+        }
+        lifecycle.external_pins += 1;
+        Ok(MountExternalGuard {
+            mount: self.self_ref(),
+        })
+    }
+
+    fn schedule_final_shutdown(mount: Arc<Self>) {
+        schedule_work(Work::new(move || mount.finish_final_shutdown()));
+    }
+
+    fn finish_final_shutdown(&self) {
+        let sb_state = self.super_block_state();
+        let _umount_guard = sb_state.umount_write();
+        self.inner_filesystem.close_external_inode_admission();
+        if let Err(err) = self.sync_filesystem_locked() {
+            log::warn!("final superblock sync failed during umount: {:?}", err);
+            sb_state.record_wb_error(err);
+        }
+        if let Err(err) = self.inner_filesystem.shrink_inode_cache_for_shutdown() {
+            log::warn!("final inode cache shrink failed: {:?}", err);
+            sb_state.record_wb_error(err);
+        }
+        if let Err(err) = self.inner_filesystem.quiesce_async_inode_work() {
+            log::warn!("final asynchronous inode quiesce failed: {:?}", err);
+            sb_state.record_wb_error(err);
+        }
+        let epoch = self.inner_filesystem.seal_eviction_queue();
+        if let Err(err) = self.inner_filesystem.drain_evictions_through(epoch) {
+            log::warn!("final superblock eviction drain failed: {:?}", err);
+            sb_state.record_wb_error(err);
+        }
+        self.inner_filesystem.on_umount();
+        sb_state.finish_shutdown();
+    }
+
     /// Unmount the filesystem.
     ///
     /// Modeled after Linux `deactivate_super()` + `generic_shutdown_super()`:
@@ -733,26 +970,118 @@ impl MountFS {
     /// # Errors
     /// Returns `EINVAL` if this is the root filesystem.
     pub fn umount(&self) -> Result<Arc<MountFS>, SystemError> {
-        let mountpoint = self.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        Self::umount_subtree_with_mode(&self.self_ref(), false)
+    }
 
-        // Phase 1: Exclusive lock — excludes concurrent sync/IO during teardown.
-        let sb_state = self.super_block_state();
-        let _umount_guard = sb_state.umount_write();
-
-        // Phase 2: Sync while the superblock lock is already held.
-        // Errors during pre-umount sync are non-fatal (warn only).
-        if let Err(e) = self.sync_filesystem_locked() {
-            log::warn!("umount: pre-sync failed: {:?}, proceeding with umount", e);
+    /// Detach a complete mount subtree, deepest mounts first. Ordinary umount
+    /// performs one preflight busy check so it cannot partially detach merely
+    /// because a descendant owns an external path/file reference.
+    pub fn umount_subtree_with_mode(
+        root: &Arc<MountFS>,
+        lazy: bool,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        fn collect(root: &Arc<MountFS>) -> Vec<Arc<MountFS>> {
+            let mut mounts = Vec::new();
+            let mut stack = vec![root.clone()];
+            while let Some(mount) = stack.pop() {
+                stack.extend(mount.mountpoints().values().cloned());
+                mounts.push(mount);
+            }
+            mounts.reverse();
+            mounts
         }
 
-        // Phase 3: Detach and propagate (no syncing under the lock).
-        let result = mountpoint.do_umount();
+        // Potentially sleeping metadata reads happen without the topology lock.
+        let mounts = {
+            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+            collect(root)
+        };
+        let mut propagation_keys = Vec::with_capacity(mounts.len());
+        for mount in &mounts {
+            let mountpoint = mount.self_mountpoint().ok_or(SystemError::EINVAL)?;
+            propagation_keys.push((
+                mountpoint.mount_fs.clone(),
+                mountpoint.inner_inode.metadata()?.inode_id,
+            ));
+        }
+
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        let current = collect(root);
+        if current.len() != mounts.len()
+            || current
+                .iter()
+                .zip(mounts.iter())
+                .any(|(left, right)| left.mount_id() != right.mount_id())
+        {
+            return Err(SystemError::EBUSY);
+        }
+        if !lazy && root.subtree_has_external_pins() {
+            return Err(SystemError::EBUSY);
+        }
+        for (mount, (parent, mountpoint_id)) in mounts.iter().zip(propagation_keys.iter()) {
+            if !mount.is_live() {
+                return Err(SystemError::EINVAL);
+            }
+            if !lazy && propagation_umount_busy(parent, *mountpoint_id) {
+                return Err(SystemError::EBUSY);
+            }
+        }
+        for mount in &mounts {
+            mount.lifecycle.lock().state = MountLifecycleState::Detaching;
+        }
+
+        for (mount, (_, mountpoint_id)) in mounts.into_iter().zip(propagation_keys.into_iter()) {
+            let namespace = mount.namespace();
+            // All fallible admission checks completed above. A peer propagation
+            // may already have detached this node, which is an equivalent commit.
+            if mount.lifecycle.lock().state != MountLifecycleState::Detached {
+                mount.commit_umount_at(mountpoint_id)?;
+            }
+            if let Some(namespace) = namespace {
+                namespace.remove_mount_exact(&mount);
+            }
+        }
+        Ok(root.clone())
+    }
+
+    /// Detach this mount. Lazy detach skips the external-pin busy check and
+    /// pre-detach sync; final shared-superblock shutdown remains deferred until
+    /// every mount and external pin is gone.
+    pub fn umount_with_mode(&self, lazy: bool) -> Result<Arc<MountFS>, SystemError> {
+        let mountpoint = self.self_mountpoint().ok_or(SystemError::EINVAL)?;
+
+        if !lazy {
+            let mountpoint_id = mountpoint.inner_inode.metadata()?.inode_id;
+            if propagation_umount_busy(&mountpoint.mount_fs, mountpoint_id) {
+                return Err(SystemError::EBUSY);
+            }
+        }
+
+        {
+            let mut lifecycle = self.lifecycle.lock();
+            if lifecycle.state != MountLifecycleState::Live {
+                return Err(SystemError::EINVAL);
+            }
+            if !lazy && lifecycle.external_pins != 0 {
+                return Err(SystemError::EBUSY);
+            }
+            lifecycle.state = MountLifecycleState::Detaching;
+        }
+
+        let mountpoint_id = mountpoint.inner_inode.metadata()?.inode_id;
+        self.commit_umount_at(mountpoint_id)
+    }
+
+    fn commit_umount_at(&self, mountpoint_id: InodeId) -> Result<Arc<MountFS>, SystemError> {
+        let mountpoint = self.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        let result = mountpoint.do_umount_at(mountpoint_id);
 
         if result.is_ok() {
-            // Clear self_mountpoint to drop the back-reference to the old parent mountpoint.
             self.self_mountpoint.write().take();
-            self.inner_filesystem.on_umount();
             self.clear_namespace();
+            self.deactivate();
+        } else {
+            self.lifecycle.lock().state = MountLifecycleState::Live;
         }
 
         return result;
@@ -991,6 +1320,31 @@ impl Drop for MountFS {
     }
 }
 
+impl MountExternalGuard {
+    pub fn mount(&self) -> Arc<MountFS> {
+        self.mount.clone()
+    }
+
+    /// Derive another owner from an already valid path. This remains legal
+    /// while lazy detach is in progress, matching Linux path_get semantics.
+    pub fn derive(&self) -> Result<Self, SystemError> {
+        self.mount.derive_external_pin()
+    }
+}
+
+impl Drop for MountExternalGuard {
+    fn drop(&mut self) {
+        {
+            let mut lifecycle = self.mount.lifecycle.lock();
+            debug_assert!(lifecycle.external_pins > 0);
+            lifecycle.external_pins -= 1;
+        }
+        if self.mount.super_block_state.remove_external_pin() {
+            MountFS::schedule_final_shutdown(self.mount.clone());
+        }
+    }
+}
+
 impl MountFSInode {
     fn new_root(inner_inode: Arc<dyn IndexNode>, mount_fs: Arc<MountFS>) -> Arc<Self> {
         Arc::new_cyclic(|self_ref| Self {
@@ -1214,14 +1568,23 @@ impl MountFSInode {
             inherit_bind_mount_propagation(source, &new_mount_fs);
         }
 
-        self.mount_fs
-            .add_mount(metadata.inode_id, new_mount_fs.clone())?;
-
-        ProcessManager::current_mntns().add_mount(
-            Some(metadata.inode_id),
-            mount_path.clone(),
-            new_mount_fs.clone(),
-        )?;
+        {
+            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+            if !self.mount_fs.is_live() {
+                return Err(SystemError::EBUSY);
+            }
+            self.mount_fs
+                .add_mount(metadata.inode_id, new_mount_fs.clone())?;
+            if let Err(error) = ProcessManager::current_mntns().add_mount(
+                Some(metadata.inode_id),
+                mount_path.clone(),
+                new_mount_fs.clone(),
+            ) {
+                self.mount_fs.mountpoints().remove(&metadata.inode_id);
+                return Err(error);
+            }
+            new_mount_fs.activate();
+        }
 
         if parent_propagation.is_shared() {
             if let Err(e) = propagate_mount(
@@ -1388,10 +1751,7 @@ impl MountFSInode {
     }
 
     /// Remove the filesystem mounted at this mount point
-    fn do_umount(&self) -> Result<Arc<MountFS>, SystemError> {
-        // Allow umount for both directory and file bind mounts
-        let mountpoint_id = self.inner_inode.metadata()?.inode_id;
-
+    fn do_umount_at(&self, mountpoint_id: InodeId) -> Result<Arc<MountFS>, SystemError> {
         // Detach first. Follow-up bookkeeping (peer registry and propagation)
         // must not run if detach itself failed.
         let child_mount = self
@@ -1548,6 +1908,14 @@ impl MountFSInode {
 }
 
 impl IndexNode for MountFSInode {
+    fn retain(&self, kind: InodeRetentionKind) -> Result<(), SystemError> {
+        self.inner_inode.retain(kind)
+    }
+
+    fn release(&self, kind: InodeRetentionKind) {
+        self.inner_inode.release(kind);
+    }
+
     fn open(
         &self,
         data: MutexGuard<FilePrivateData>,

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -10,7 +10,7 @@ use super::{
     utils::{
         rsplit_path, should_remove_sgid_on_chown, user_path_at, user_resolved_path_at, ResolvedPath,
     },
-    vcore::{check_parent_dir_permission_inode, resolve_parent_inode, vfs_truncate},
+    vcore::{check_parent_dir_permission_inode, vfs_truncate},
     FileType, FsPermissionPolicy, IndexNode, InodeMode, SetMetadataMask, MAX_PATHLEN,
     VFS_MAX_FOLLOW_SYMLINK_TIMES,
 };
@@ -312,9 +312,16 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
                 if filename.len() > crate::filesystem::vfs::NAME_MAX {
                     return Err(SystemError::ENAMETOOLONG);
                 }
-                // 查找父目录
-                let parent_inode: Arc<dyn IndexNode> =
-                    resolve_parent_inode(inode_begin, parent_path)?;
+                // Resolve and retain the actual parent mount across permission
+                // checks and create. The original start_path alone is not
+                // sufficient when parent_path crosses a mount boundary.
+                let parent_resolved = inode_begin.lookup_follow_symlink_owned(
+                    &start_path,
+                    parent_path.unwrap_or(""),
+                    VFS_MAX_FOLLOW_SYMLINK_TIMES,
+                    true,
+                )?;
+                let parent_inode = parent_resolved.inode();
                 let parent_md = parent_inode.metadata()?;
                 // 父节点必须是目录
                 if parent_md.file_type != FileType::Dir {
@@ -331,7 +338,9 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
                 let inode: Arc<dyn IndexNode> =
                     parent_inode.create(filename, FileType::File, create_mode)?;
                 created = true;
-                ResolvedPath::new(inode)?
+                let created_path = ResolvedPath::new(inode)?;
+                drop(parent_resolved);
+                created_path
             } else {
                 // 不需要创建文件，因此返回错误码
                 return Err(errno);

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -7,7 +7,9 @@ use super::{
     mount::MountFlags,
     permission::PermissionMask,
     syscall::{OpenHow, OpenHowResolve},
-    utils::{rsplit_path, should_remove_sgid_on_chown, user_path_at},
+    utils::{
+        rsplit_path, should_remove_sgid_on_chown, user_path_at, user_resolved_path_at, ResolvedPath,
+    },
     vcore::{check_parent_dir_permission_inode, resolve_parent_inode, vfs_truncate},
     FileType, FsPermissionPolicy, IndexNode, InodeMode, SetMetadataMask, MAX_PATHLEN,
     VFS_MAX_FOLLOW_SYMLINK_TIMES,
@@ -85,6 +87,8 @@ pub(super) fn do_faccessat(
         mask |= PermissionMask::MAY_EXEC;
     }
 
+    let resolved = ResolvedPath::new(inode)?;
+    let inode = resolved.inode();
     let metadata = inode.metadata()?;
     match inode.fs().permission_policy() {
         FsPermissionPolicy::Dac => {
@@ -281,12 +285,17 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
     // 检查路径末尾斜杠 - 如果以斜杠结尾，目标必须是目录
     let path_ends_with_slash = path.ends_with('/');
 
-    let (inode_begin, path) = user_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
-    let inode =
-        inode_begin.lookup_follow_symlink2(&path, VFS_MAX_FOLLOW_SYMLINK_TIMES, follow_symlink);
+    let (start_path, path) = user_resolved_path_at(&ProcessManager::current_pcb(), dirfd, path)?;
+    let inode_begin = start_path.inode();
+    let resolved = inode_begin.lookup_follow_symlink_owned(
+        &start_path,
+        &path,
+        VFS_MAX_FOLLOW_SYMLINK_TIMES,
+        follow_symlink,
+    );
     let mut created = false;
-    let inode: Arc<dyn IndexNode> = match inode {
-        Ok(inode) => inode,
+    let resolved = match resolved {
+        Ok(resolved) => resolved,
         Err(errno) => {
             // 文件不存在，且需要创建
             if how.o_flags.contains(FileFlags::O_CREAT)
@@ -322,13 +331,15 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
                 let inode: Arc<dyn IndexNode> =
                     parent_inode.create(filename, FileType::File, create_mode)?;
                 created = true;
-                inode
+                ResolvedPath::new(inode)?
             } else {
                 // 不需要创建文件，因此返回错误码
                 return Err(errno);
             }
         }
     };
+    drop(start_path);
+    let inode = resolved.inode();
     let metadata = inode.metadata()?;
     let file_type: FileType = metadata.file_type;
 
@@ -414,7 +425,8 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
     if file_type == FileType::File && inode.truncate_before_open(&how.o_flags) {
         vfs_truncate(inode.clone(), 0)?;
     }
-    let file: File = File::new(inode, how.o_flags)?;
+    let (inode, mount_guard, operation_guard) = resolved.into_parts();
+    let file: File = File::new_with_mount_guard(inode, how.o_flags, mount_guard, operation_guard)?;
     let cloexec = how.o_flags.contains(FileFlags::O_CLOEXEC);
 
     // 把文件对象存入pcb

--- a/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
@@ -108,7 +108,7 @@ impl Syscall for SysChdirHandle {
         }
 
         proc.basic_mut().set_cwd(new_path);
-        proc.fs_struct_mut().set_pwd_resolved(resolved);
+        proc.fs_struct().set_pwd_resolved(resolved);
         Ok(0)
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chdir.rs
@@ -7,7 +7,7 @@ use alloc::{string::String, vec::Vec};
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_CHDIR;
 use crate::filesystem::vfs::permission::PermissionMask;
-use crate::filesystem::vfs::utils::user_path_at;
+use crate::filesystem::vfs::utils::{user_path_at, ResolvedPath};
 use crate::filesystem::vfs::{fcntl::AtFlags, FileType, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES};
 use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
@@ -68,6 +68,8 @@ impl Syscall for SysChdirHandle {
         let (inode_begin, remain_path) = user_path_at(&proc, AtFlags::AT_FDCWD.bits(), path)?;
         let inode =
             inode_begin.lookup_follow_symlink(&remain_path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+        let resolved = ResolvedPath::new(inode)?;
+        let inode = resolved.inode();
         let metadata = inode.metadata()?;
         if metadata.file_type != FileType::Dir {
             return Err(SystemError::ENOTDIR);
@@ -106,7 +108,7 @@ impl Syscall for SysChdirHandle {
         }
 
         proc.basic_mut().set_cwd(new_path);
-        proc.fs_struct_mut().set_pwd(inode);
+        proc.fs_struct_mut().set_pwd_resolved(resolved);
         Ok(0)
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_chroot.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chroot.rs
@@ -13,7 +13,8 @@ use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_CHROOT;
 use crate::filesystem::vfs::permission::PermissionMask;
 use crate::filesystem::vfs::{
-    utils::user_path_at, FileType, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
+    utils::{user_path_at, ResolvedPath},
+    FileType, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
 };
 use crate::process::cred::CAPFlags;
 use crate::process::ProcessManager;
@@ -58,6 +59,8 @@ impl Syscall for SysChrootHandle {
         let target =
             inode_begin.lookup_follow_symlink(&resolved_path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
 
+        let resolved = ResolvedPath::new(target)?;
+        let target = resolved.inode();
         let meta = target.metadata()?;
         if meta.file_type != FileType::Dir {
             return Err(SystemError::ENOTDIR);
@@ -70,7 +73,7 @@ impl Syscall for SysChrootHandle {
         )?;
 
         // 更新进程 fs root；不改变 cwd（Linux 行为）
-        pcb.fs_struct_mut().set_root(target);
+        pcb.fs_struct_mut().set_root_resolved(resolved);
         Ok(0)
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_chroot.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_chroot.rs
@@ -73,7 +73,7 @@ impl Syscall for SysChrootHandle {
         )?;
 
         // 更新进程 fs root；不改变 cwd（Linux 行为）
-        pcb.fs_struct_mut().set_root_resolved(resolved);
+        pcb.fs_struct().set_root_resolved(resolved);
         Ok(0)
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_fchdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchdir.rs
@@ -40,6 +40,8 @@ impl Syscall for SysFchdirHandle {
             .get_file_by_fd(fd)
             .ok_or(SystemError::EBADF)?;
         let inode = file.inode();
+        let resolved = crate::filesystem::vfs::utils::ResolvedPath::new(inode)?;
+        let inode = resolved.inode();
         let metadata = inode.metadata()?;
 
         if metadata.file_type != crate::filesystem::vfs::FileType::Dir {
@@ -53,7 +55,7 @@ impl Syscall for SysFchdirHandle {
 
         let path = inode.absolute_path()?;
         pcb.basic_mut().set_cwd(path);
-        pcb.fs_struct_mut().set_pwd(inode);
+        pcb.fs_struct_mut().set_pwd_resolved(resolved);
         return Ok(0);
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_fchdir.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fchdir.rs
@@ -55,7 +55,7 @@ impl Syscall for SysFchdirHandle {
 
         let path = inode.absolute_path()?;
         pcb.basic_mut().set_cwd(path);
-        pcb.fs_struct_mut().set_pwd_resolved(resolved);
+        pcb.fs_struct().set_pwd_resolved(resolved);
         return Ok(0);
     }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_pivot_root.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_pivot_root.rs
@@ -299,7 +299,9 @@ fn repair_same_namespace_fs_refs(
             continue;
         }
 
-        let fs = task.fs_struct();
+        let Some(fs) = task.try_fs_struct() else {
+            continue;
+        };
         let is_current_task = Arc::ptr_eq(&task, current_task);
         let root_replaced = same_path_ref(&fs.root(), old_root_inode);
         let pwd_replaced = same_path_ref(&fs.pwd(), old_root_inode);
@@ -311,13 +313,11 @@ fn repair_same_namespace_fs_refs(
 
         let old_cwd = task.basic().cwd();
         let mut basic = task.basic_mut();
-        let fs_guard = task.fs_struct_mut();
-
         if root_replaced || is_current_task {
-            fs_guard.set_root(new_root_inode.clone());
+            fs.set_root(new_root_inode.clone());
         }
         if pwd_replaced {
-            fs_guard.set_pwd(new_root_inode.clone());
+            fs.set_pwd(new_root_inode.clone());
         }
 
         if rewrite_cwd {

--- a/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
@@ -24,8 +24,7 @@ impl Syscall for SysStatfsHandle {
         let path = Self::path(args);
         let user_statfs = Self::statfs(args);
         let mut writer = UserBufferWriter::new(user_statfs, size_of::<PosixStatfs>(), true)?;
-        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))
-            .unwrap()
+        let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))?
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
         if path.is_empty() {

--- a/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_statfs.rs
@@ -1,11 +1,10 @@
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_STATFS;
-use crate::filesystem::vfs::file::FileFlags;
-use crate::filesystem::vfs::syscall::open_utils;
+use crate::filesystem::vfs::fcntl::AtFlags;
 use crate::filesystem::vfs::syscall::PosixStatfs;
-use crate::filesystem::vfs::utils::user_path_at;
-use crate::filesystem::vfs::InodeMode;
+use crate::filesystem::vfs::utils::user_resolved_path_at;
 use crate::filesystem::vfs::MAX_PATHLEN;
+use crate::filesystem::vfs::VFS_MAX_FOLLOW_SYMLINK_TIMES;
 use crate::process::ProcessManager;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
@@ -25,14 +24,24 @@ impl Syscall for SysStatfsHandle {
         let path = Self::path(args);
         let user_statfs = Self::statfs(args);
         let mut writer = UserBufferWriter::new(user_statfs, size_of::<PosixStatfs>(), true)?;
-        let fd = open_utils::do_open(path, FileFlags::O_RDONLY.bits(), InodeMode::empty().bits())?;
         let path = vfs_check_and_clone_cstr(path, Some(MAX_PATHLEN))
             .unwrap()
             .into_string()
             .map_err(|_| SystemError::EINVAL)?;
+        if path.is_empty() {
+            return Err(SystemError::ENOENT);
+        }
         let pcb = ProcessManager::current_pcb();
-        let (inode_begin, remain_path) = user_path_at(&pcb, fd as i32, &path)?;
-        let inode = inode_begin.lookup_follow_symlink(&remain_path, MAX_PATHLEN)?;
+        let (start_path, remain_path) =
+            user_resolved_path_at(&pcb, AtFlags::AT_FDCWD.bits(), &path)?;
+        let inode_begin = start_path.inode();
+        let resolved = inode_begin.lookup_follow_symlink_owned(
+            &start_path,
+            &remain_path,
+            VFS_MAX_FOLLOW_SYMLINK_TIMES,
+            true,
+        )?;
+        let inode = resolved.inode();
         let sb = inode.fs().statfs(&inode)?;
         let statfs = PosixStatfs::from(sb);
         writer.copy_one_to_user(&statfs, 0)?;

--- a/kernel/src/filesystem/vfs/syscall/sys_umount2.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_umount2.rs
@@ -75,7 +75,7 @@ syscall_table_macros::declare_syscall!(SYS_UMOUNT2, SysUmount2Handle);
 ///
 /// - dirfd: i32 - 目录文件描述符，用于指定要卸载的文件系统的根目录。
 /// - target: &str - 要卸载的文件系统的目标路径。
-/// - _flag: UmountFlag - 卸载标志，目前未使用。
+/// - flag: UmountFlag - 卸载模式；`MNT_DETACH` 执行 lazy detach。
 ///
 /// ## 返回值
 ///
@@ -85,18 +85,27 @@ syscall_table_macros::declare_syscall!(SYS_UMOUNT2, SysUmount2Handle);
 /// ## 错误处理
 ///
 /// 如果指定的路径没有对应的文件系统，或者在尝试卸载时发生错误，将返回错误。
-pub fn do_umount2(
-    dirfd: i32,
-    target: &str,
-    _flag: UmountFlag,
-) -> Result<Arc<MountFS>, SystemError> {
+pub fn do_umount2(dirfd: i32, target: &str, flag: UmountFlag) -> Result<Arc<MountFS>, SystemError> {
     let target = target.trim();
     if target.is_empty() {
         return Err(SystemError::ENOENT);
     }
 
+    if flag.contains(UmountFlag::MNT_EXPIRE)
+        && flag.intersects(UmountFlag::MNT_FORCE | UmountFlag::MNT_DETACH)
+    {
+        return Err(SystemError::EINVAL);
+    }
+    if flag.intersects(UmountFlag::MNT_EXPIRE | UmountFlag::MNT_FORCE) {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+
     let (work, rest) = user_path_at(&ProcessManager::current_pcb(), dirfd, target)?;
-    let target_inode = work.lookup_follow_symlink(&rest, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+    let target_inode = work.lookup_follow_symlink2(
+        &rest,
+        VFS_MAX_FOLLOW_SYMLINK_TIMES,
+        !flag.contains(UmountFlag::UMOUNT_NOFOLLOW),
+    )?;
     if !may_mount() {
         return Err(SystemError::EPERM);
     }
@@ -112,7 +121,11 @@ pub fn do_umount2(
         return Err(SystemError::EINVAL);
     }
 
-    if let Err(err) = fs.umount() {
+    // The target lookup above is not an external mount pin. This is deliberate:
+    // Linux discounts the syscall's own path reference from the busy check.
+    // File/path owners acquire explicit MountExternalGuard values instead.
+    let lazy = flag.contains(UmountFlag::MNT_DETACH);
+    if let Err(err) = MountFS::umount_subtree_with_mode(&fs, lazy) {
         log::warn!(
             "do_umount2: fs.umount failed for resolved='{}', fs='{}': {:?}",
             path,
@@ -120,13 +133,6 @@ pub fn do_umount2(
             err
         );
         return Err(err);
-    }
-    if current_mntns.remove_mount_exact(&fs).is_none() {
-        log::error!(
-            "do_umount2: mount_list exact remove miss for resolved='{}', fs='{}'",
-            path,
-            fs.name()
-        );
     }
     Ok(fs)
 }

--- a/kernel/src/filesystem/vfs/utils.rs
+++ b/kernel/src/filesystem/vfs/utils.rs
@@ -8,7 +8,75 @@ use system_error::SystemError;
 use crate::process::cred::{Cred, Kgid};
 use crate::process::ProcessControlBlock;
 
-use super::{fcntl::AtFlags, FileType, IndexNode, InodeMode};
+use super::{
+    fcntl::AtFlags,
+    inode_lifecycle::{InodeRetentionGuard, InodeRetentionKind},
+    mount::{MountExternalGuard, MountFSInode},
+    FileType, IndexNode, InodeMode,
+};
+use crate::libs::casting::DowncastArc;
+
+/// A resolved inode plus the mount and operation ownership required while a
+/// syscall performs permission, truncate, and open work on it.
+#[derive(Debug)]
+pub struct ResolvedPath {
+    inode: Arc<dyn IndexNode>,
+    mount_guard: Option<MountExternalGuard>,
+    _operation_guard: InodeRetentionGuard,
+}
+
+impl ResolvedPath {
+    pub fn new(inode: Arc<dyn IndexNode>) -> Result<Self, SystemError> {
+        let mount_guard = inode
+            .clone()
+            .downcast_arc::<MountFSInode>()
+            .map(|inode| inode.mount_fs().try_pin_external())
+            .transpose()?;
+        let operation_guard =
+            InodeRetentionGuard::new(inode.clone(), InodeRetentionKind::Operation)?;
+        Ok(Self {
+            inode,
+            mount_guard,
+            _operation_guard: operation_guard,
+        })
+    }
+
+    pub(crate) fn from_existing_mount(
+        inode: Arc<dyn IndexNode>,
+        mount_guard: Option<MountExternalGuard>,
+    ) -> Result<Self, SystemError> {
+        let operation_guard =
+            InodeRetentionGuard::new(inode.clone(), InodeRetentionKind::Operation)?;
+        Ok(Self {
+            inode,
+            mount_guard,
+            _operation_guard: operation_guard,
+        })
+    }
+
+    pub fn inode(&self) -> Arc<dyn IndexNode> {
+        self.inode.clone()
+    }
+
+    pub fn derive(&self) -> Result<Self, SystemError> {
+        let mount_guard = self
+            .mount_guard
+            .as_ref()
+            .map(MountExternalGuard::derive)
+            .transpose()?;
+        Self::from_existing_mount(self.inode.clone(), mount_guard)
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        Arc<dyn IndexNode>,
+        Option<MountExternalGuard>,
+        InodeRetentionGuard,
+    ) {
+        (self.inode.clone(), self.mount_guard, self._operation_guard)
+    }
+}
 
 /// @brief 切分路径字符串，返回最左侧那一级的目录名和剩余的部分。
 ///
@@ -79,6 +147,31 @@ pub fn user_path_at(
     }
 
     Ok((pcb.pwd_inode(), ret_path))
+}
+
+/// Resolve the starting point while retaining its mount for the complete path walk.
+pub fn user_resolved_path_at(
+    pcb: &Arc<ProcessControlBlock>,
+    dirfd: i32,
+    path: &str,
+) -> Result<(ResolvedPath, String), SystemError> {
+    let ret_path = String::from(path);
+    if path.is_empty() {
+        return Ok((pcb.fs_struct().pwd_resolved()?, ret_path));
+    }
+    if path.as_bytes()[0] == b'/' {
+        return Ok((pcb.fs_struct().root_resolved()?, ret_path));
+    }
+    if dirfd != AtFlags::AT_FDCWD.bits() {
+        let binding = pcb.fd_table();
+        let fd_table = binding.read();
+        let file = fd_table.get_file_by_fd(dirfd).ok_or(SystemError::EBADF)?;
+        if file.file_type() != FileType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+        return Ok((file.resolved_path()?, ret_path));
+    }
+    Ok((pcb.fs_struct().pwd_resolved()?, ret_path))
 }
 
 pub fn is_ancestor(ancestor: &Arc<dyn IndexNode>, node: &Arc<dyn IndexNode>) -> bool {

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -143,9 +143,9 @@ fn migrate_virtual_filesystem(
     // 以及 init stdio 的 /dev/hvc0 查找都会仍在旧 root 上执行，导致找不到设备节点。
     let new_root_inode = current_mntns.root_inode();
     let pcb = ProcessManager::current_pcb();
-    pcb.fs_struct_mut().set_root(new_root_inode.clone());
+    pcb.fs_struct().set_root(new_root_inode.clone());
     // init 通常 cwd 为 "/"，将 pwd 同步到新根，避免落在旧根造成后续语义混乱
-    pcb.fs_struct_mut().set_pwd(new_root_inode.clone());
+    pcb.fs_struct().set_pwd(new_root_inode.clone());
 
     // WARNING: mount devpts after devfs has been mounted,
     devpts_init().expect("Failed to initialize devpts");

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -17,7 +17,7 @@ use crate::{
         sysfs::sysfs_init,
         vfs::{
             file::{File, FileMode, FilePrivateData},
-            mount::MountFlags,
+            mount::{MountFlags, MOUNT_LIFECYCLE_LOCK},
             permission::PermissionMask,
             AtomicInodeId, FileSystem, FileType, InodeFlags, InodeMode, Metadata, MountFS,
             SetMetadataMask,
@@ -132,7 +132,11 @@ fn migrate_virtual_filesystem(
         .mount_from(old_root_inode.find("sys").expect("sys not mounted!"))
         .expect("Failed to migrate filesystem of sys");
 
-    current_mntns.force_change_root_mountfs(new_fs);
+    {
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        new_fs.activate();
+        current_mntns.force_change_root_mountfs(new_fs);
+    }
 
     // 换根后需要同步更新“当前进程”的 fs root/pwd。
     // 我们的路径解析（绝对路径）以进程 fs root 为起点；若不更新，后续诸如 /dev/pts 的挂载、

--- a/kernel/src/init/initram.rs
+++ b/kernel/src/init/initram.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use crate::filesystem::ramfs::RamFS;
-use crate::filesystem::vfs::mount::MountFlags;
+use crate::filesystem::vfs::mount::{MountFlags, MOUNT_LIFECYCLE_LOCK};
 use crate::filesystem::vfs::FilePrivateData;
 use crate::filesystem::vfs::FileSystem;
 use crate::filesystem::vfs::MountFS;
@@ -110,6 +110,10 @@ pub fn initramfs_init() -> Result<(), SystemError> {
     let root_inode = mount_fs.root_inode();
     unsafe {
         __INIT_ROOT_INODE = Some(root_inode.clone());
+    }
+    {
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        mount_fs.activate();
     }
 
     // Linux 中，内嵌的 initramfs 始终存在

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -1102,13 +1102,12 @@ impl ProcessManager {
         child_pcb: &Arc<ProcessControlBlock>,
     ) -> Result<(), SystemError> {
         let fs = parent_pcb.fs_struct();
-        let mut guard = child_pcb.fs_struct_mut();
-        if clone_flags.contains(CloneFlags::CLONE_FS) {
-            *guard = fs.clone();
+        let child_fs = if clone_flags.contains(CloneFlags::CLONE_FS) {
+            fs
         } else {
-            let new_fs = (*fs).clone();
-            *guard = Arc::new(new_fs);
-        }
+            Arc::new((*fs).clone())
+        };
+        child_pcb.set_fs_struct(child_fs);
         Ok(())
     }
 

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -278,6 +278,10 @@ impl ProcessManager {
             drop(old_user_vm);
 
             pcb.exit_files();
+            // Linux exit_fs() follows exit_files(). A zombie must not keep
+            // cwd/root path references alive, otherwise an already-reaped
+            // chrooted child can make an unrelated umount report EBUSY.
+            pcb.exit_fs();
             pcb.exit_timers();
 
             let (current_tty, is_session_leader, sid) = {

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -1,6 +1,6 @@
 use crate::{
     filesystem::vfs::{
-        mount::{MountFSInode, MountFlags, MountList, MountPath},
+        mount::{MountFSInode, MountFlags, MountList, MountPath, MOUNT_LIFECYCLE_LOCK},
         FileSystem, IndexNode, InodeId, MountFS,
     },
     libs::{once::Once, rwsem::RwSem},
@@ -85,10 +85,14 @@ impl MntNamespace {
             }),
         });
 
-        ramfs.set_namespace(Arc::downgrade(&result));
-        result
-            .add_mount(None, Arc::new(MountPath::from("/")), ramfs)
-            .expect("Failed to add root mount");
+        {
+            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+            ramfs.set_namespace(Arc::downgrade(&result));
+            result
+                .add_mount(None, Arc::new(MountPath::from("/")), ramfs)
+                .expect("Failed to add root mount");
+            result.root_mntfs().activate();
+        }
 
         return result;
     }
@@ -118,15 +122,16 @@ impl MntNamespace {
         old_put_old_path: &str,
         new_put_old_path: &str,
     ) -> Result<(), SystemError> {
-        let mut inner_guard = self.inner.write();
-        let old_root = Self::root_mntfs_locked(&inner_guard);
-        let old_root_mountpoint = old_root.self_mountpoint();
         let new_root_mountpoint = new_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
         let new_root_parent = new_root_mountpoint.mount_fs();
         let put_old_parent = put_old_mountpoint.mount_fs();
         let put_old_is_new_root = old_put_old_path == old_new_root_path;
         let new_root_mountpoint_id = new_root_mountpoint.inode_id()?;
         let put_old_mountpoint_id = put_old_mountpoint.inode_id()?;
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        let mut inner_guard = self.inner.write();
+        let old_root = Self::root_mntfs_locked(&inner_guard);
+        let old_root_mountpoint = old_root.self_mountpoint();
 
         {
             let put_old_mounts = put_old_parent.mountpoints();
@@ -225,14 +230,15 @@ impl MntNamespace {
         old_source_path: &str,
         new_target_path: &str,
     ) -> Result<(), SystemError> {
-        let inner = self.inner.write();
-        let moving_mounts = collect_mount_subtree(source_mfs);
         let old_mountpoint = source_mfs.self_mountpoint().ok_or(SystemError::EINVAL)?;
         let old_parent = old_mountpoint.mount_fs();
         let old_mp_id = old_mountpoint.inode_id()?;
 
         let target_parent = target_mountpoint.mount_fs();
         let target_mp_id = target_mountpoint.inode_id()?;
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        let inner = self.inner.write();
+        let moving_mounts = collect_mount_subtree(source_mfs);
 
         // 1. Detach from the old parent mount.
         let removed = old_parent
@@ -287,10 +293,14 @@ impl MntNamespace {
             }),
         });
 
-        new_root.set_namespace(Arc::downgrade(&result));
-        result
-            .add_mount(None, Arc::new(MountPath::from("/")), new_root)
-            .expect("Failed to add root mount");
+        {
+            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+            new_root.set_namespace(Arc::downgrade(&result));
+            result
+                .add_mount(None, Arc::new(MountPath::from("/")), new_root)
+                .expect("Failed to add root mount");
+            result.root_mntfs().activate();
+        }
 
         result
     }
@@ -394,16 +404,20 @@ impl MntNamespace {
                 register_slave_with_master(&new_mount_fs);
             }
 
-            data.parent_mount_fs
-                .add_mount(data.self_mp_inode_id, new_mount_fs.clone())
-                .expect("Failed to add mount");
-            new_mntns
-                .add_mount(
-                    Some(data.self_mp_inode_id),
-                    data.mount_path.clone(),
-                    new_mount_fs.clone(),
-                )
-                .expect("Failed to add mount to mount namespace");
+            {
+                let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+                data.parent_mount_fs
+                    .add_mount(data.self_mp_inode_id, new_mount_fs.clone())
+                    .expect("Failed to add mount");
+                new_mntns
+                    .add_mount(
+                        Some(data.self_mp_inode_id),
+                        data.mount_path.clone(),
+                        new_mount_fs.clone(),
+                    )
+                    .expect("Failed to add mount to mount namespace");
+                new_mount_fs.activate();
+            }
 
             // Add child mounts of the original mount point to the queue
 
@@ -562,8 +576,13 @@ fn join_pivot_paths(prefix: &str, suffix: &str) -> String {
     result
 }
 
-// impl Drop for MntNamespace {
-//     fn drop(&mut self) {
-//         log::warn!("mntns (level: {}) dropped", self.ns_common.level);
-//     }
-// }
+impl Drop for MntNamespace {
+    fn drop(&mut self) {
+        // Namespace destruction is a topology teardown, not filesystem I/O.
+        // Deactivation only updates explicit counters and schedules the final
+        // superblock worker when the last mount/path reference is gone.
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        let root = self.inner.read().root_mountfs.clone();
+        MountFS::deactivate_disconnected_subtree(&root);
+    }
+}

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -3,7 +3,7 @@ use crate::{
         mount::{MountFSInode, MountFlags, MountList, MountPath, MOUNT_LIFECYCLE_LOCK},
         FileSystem, IndexNode, InodeId, MountFS,
     },
-    libs::{once::Once, rwsem::RwSem},
+    libs::{mutex::MutexGuard, once::Once, rwsem::RwSem},
     process::{fork::CloneFlags, namespace::NamespaceType, ProcessManager},
 };
 use alloc::string::{String, ToString};
@@ -278,7 +278,12 @@ impl MntNamespace {
         Ok(())
     }
 
-    fn copy_with_mountfs(&self, new_root: Arc<MountFS>, _user_ns: Arc<UserNamespace>) -> Arc<Self> {
+    fn copy_with_mountfs(
+        &self,
+        new_root: Arc<MountFS>,
+        _user_ns: Arc<UserNamespace>,
+        _topology: &MutexGuard<'_, ()>,
+    ) -> Arc<Self> {
         let mut ns_common = self.ns_common.clone();
         ns_common.level += 1;
 
@@ -293,14 +298,13 @@ impl MntNamespace {
             }),
         });
 
-        {
-            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
-            new_root.set_namespace(Arc::downgrade(&result));
-            result
-                .add_mount(None, Arc::new(MountPath::from("/")), new_root)
-                .expect("Failed to add root mount");
-            result.root_mntfs().activate();
-        }
+        // The caller holds MOUNT_LIFECYCLE_LOCK, which serializes publication
+        // of every mount in the namespace copy with move/unmount/teardown.
+        new_root.set_namespace(Arc::downgrade(&result));
+        result
+            .add_mount(None, Arc::new(MountPath::from("/")), new_root)
+            .expect("Failed to add root mount");
+        result.root_mntfs().activate();
 
         result
     }
@@ -331,6 +335,10 @@ impl MntNamespace {
             // Return the current mount namespace if CLONE_NEWNS is not set
             return Ok(self.self_ref.upgrade().unwrap());
         }
+        // Keep the global topology lock outside the namespace lock. All other
+        // topology mutations use the same order, so namespace copy cannot
+        // deadlock with move_mount() or namespace teardown.
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
         let inner = self.inner.read();
 
         let old_root_mntfs = Self::root_mntfs_locked(&inner);
@@ -353,7 +361,7 @@ impl MntNamespace {
             register_slave_with_master(&new_root_mntfs);
         }
 
-        let new_mntns = self.copy_with_mountfs(new_root_mntfs, user_ns);
+        let new_mntns = self.copy_with_mountfs(new_root_mntfs, user_ns, &_topology);
         let new_mntns_root = new_mntns.root_mntfs();
 
         for x in inner.mount_list.clone_inner().values() {
@@ -404,20 +412,17 @@ impl MntNamespace {
                 register_slave_with_master(&new_mount_fs);
             }
 
-            {
-                let _topology = MOUNT_LIFECYCLE_LOCK.lock();
-                data.parent_mount_fs
-                    .add_mount(data.self_mp_inode_id, new_mount_fs.clone())
-                    .expect("Failed to add mount");
-                new_mntns
-                    .add_mount(
-                        Some(data.self_mp_inode_id),
-                        data.mount_path.clone(),
-                        new_mount_fs.clone(),
-                    )
-                    .expect("Failed to add mount to mount namespace");
-                new_mount_fs.activate();
-            }
+            data.parent_mount_fs
+                .add_mount(data.self_mp_inode_id, new_mount_fs.clone())
+                .expect("Failed to add mount");
+            new_mntns
+                .add_mount(
+                    Some(data.self_mp_inode_id),
+                    data.mount_path.clone(),
+                    new_mount_fs.clone(),
+                )
+                .expect("Failed to add mount to mount namespace");
+            new_mount_fs.activate();
 
             // Add child mounts of the original mount point to the queue
 

--- a/kernel/src/process/namespace/propagation.rs
+++ b/kernel/src/process/namespace/propagation.rs
@@ -1420,7 +1420,7 @@ mod tests {
     }
 
     fn new_test_mount(propagation: Arc<MountPropagation>) -> Arc<MountFS> {
-        MountFS::new(
+        let mount = MountFS::new(
             RamFS::new(),
             None,
             None,
@@ -1428,7 +1428,12 @@ mod tests {
             None,
             MountFlags::empty(),
             None,
-        )
+        );
+        // Test fixtures represent mounts that have already been published.
+        // Production constructors intentionally remain in Constructing until
+        // their topology/namespace insertion commits.
+        mount.activate();
+        mount
     }
 
     #[test]

--- a/kernel/src/process/namespace/propagation.rs
+++ b/kernel/src/process/namespace/propagation.rs
@@ -33,7 +33,10 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use hashbrown::HashSet;
 use system_error::SystemError;
 
-use crate::filesystem::vfs::{mount::MountFlags, mount::MountPath, MountFS};
+use crate::filesystem::vfs::{
+    mount::{MountFlags, MountPath, MOUNT_LIFECYCLE_LOCK},
+    MountFS,
+};
 use crate::libs::rwlock::RwLock;
 
 // ============================================================================
@@ -1133,18 +1136,25 @@ fn propagate_one(
             source_mountpoint.clone_with_new_mount_fs(target_mnt.clone()),
         ));
     }
-    target_mnt.add_mount(mountpoint_id, cloned_child.clone())?;
+    {
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+        if !target_mnt.is_live() {
+            return Err(SystemError::EBUSY);
+        }
+        target_mnt.add_mount(mountpoint_id, cloned_child.clone())?;
 
-    // Propagated child mounts must inherit the target mount's namespace,
-    // otherwise subsequent is_belongs_to_mntns() checks would incorrectly return EINVAL.
-    if let Some(ns) = target_mnt.namespace() {
-        cloned_child.set_namespace(Arc::downgrade(&ns));
-        let target_mount_path = propagated_mount_path(source_parent_path, mount_path, target_mnt);
-        ns.add_mount(Some(mountpoint_id), target_mount_path, cloned_child)
-            .inspect_err(|_e| {
-                // Roll back the cloned mount inserted into mountpoints.
-                target_mnt.mountpoints().remove(&mountpoint_id);
-            })?;
+        // Propagated child mounts must inherit the target mount's namespace,
+        // otherwise subsequent is_belongs_to_mntns() checks would incorrectly return EINVAL.
+        if let Some(ns) = target_mnt.namespace() {
+            cloned_child.set_namespace(Arc::downgrade(&ns));
+            let target_mount_path =
+                propagated_mount_path(source_parent_path, mount_path, target_mnt);
+            ns.add_mount(Some(mountpoint_id), target_mount_path, cloned_child.clone())
+                .inspect_err(|_e| {
+                    target_mnt.mountpoints().remove(&mountpoint_id);
+                })?;
+        }
+        cloned_child.activate();
     }
 
     Ok(())
@@ -1311,6 +1321,29 @@ pub fn propagate_umount(
     Ok(())
 }
 
+/// Preflight the propagation set before ordinary umount mutates topology.
+pub fn propagation_umount_busy(parent_mnt: &Arc<MountFS>, mountpoint_id: InodeId) -> bool {
+    let propagation = parent_mnt.propagation();
+    if !propagation.is_shared() {
+        return false;
+    }
+    let mut pending = get_all_peers(propagation.peer_group_id());
+    pending.extend(propagation.slaves());
+    let mut visited = HashSet::new();
+    while let Some(parent) = pending.pop() {
+        if !visited.insert(parent.mount_id().data()) {
+            continue;
+        }
+        if let Some(child) = parent.mountpoints().get(&mountpoint_id).cloned() {
+            if child.subtree_has_external_pins() {
+                return true;
+            }
+        }
+        pending.extend(parent.propagation().slaves());
+    }
+    false
+}
+
 /// Umount at a specific peer mount.
 ///
 /// Does NOT call `sync_filesystem()` here: all propagation clones share the same
@@ -1332,13 +1365,7 @@ fn umount_at_peer(peer_mnt: &Arc<MountFS>, mountpoint_id: InodeId) -> Result<(),
         child_prop.set_master(None);
     }
 
-    child.set_self_mountpoint(None);
-
-    // 先从 mount_list 移除，再清 namespace，避免 "namespace=None 但 mount_list 仍有记录" 的 TOCTOU 中间态。
-    if let Some(ns) = child.namespace() {
-        ns.remove_mount_exact(&child);
-    }
-    child.clear_namespace();
+    MountFS::deactivate_disconnected_subtree(&child);
 
     Ok(())
 }

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -160,7 +160,7 @@ pub struct ProcessControlBlock {
     pub(super) thread: RwLock<ThreadInfo>,
 
     /// Process filesystem state.
-    pub(super) fs: RwLock<Arc<FsStruct>>,
+    pub(super) fs: RwLock<Option<Arc<FsStruct>>>,
 
     /// Alarm timer.
     pub(super) alarm_timer: SpinLock<Option<AlarmTimer>>,
@@ -331,7 +331,7 @@ impl ProcessControlBlock {
                 wait_queue: WaitQueue::default(),
                 cputime_wait_queue: WaitQueue::default(),
                 thread: RwLock::new(ThreadInfo::new()),
-                fs: RwLock::new(Arc::new(FsStruct::new())),
+                fs: RwLock::new(Some(Arc::new(FsStruct::new()))),
                 alarm_timer: SpinLock::new(None),
                 itimers: SpinLock::new(ProcessItimers::default()),
                 posix_timers: SpinLock::new(posix_timer::ProcessPosixTimers::default()),
@@ -743,27 +743,41 @@ impl ProcessControlBlock {
 
     #[inline(always)]
     pub fn fs_struct(&self) -> Arc<FsStruct> {
-        self.fs.read().clone()
+        self.try_fs_struct()
+            .expect("live task must have an fs_struct")
     }
 
-    pub fn fs_struct_mut(&self) -> RwLockWriteGuard<'_, Arc<FsStruct>> {
-        self.fs.write()
+    /// Return the filesystem context when the task has not passed exit_fs().
+    pub fn try_fs_struct(&self) -> Option<Arc<FsStruct>> {
+        self.fs.read().clone()
     }
 
     #[inline(always)]
     pub fn fs_struct_is_shared(&self) -> bool {
-        Arc::strong_count(&*self.fs.read()) > 1
+        Arc::strong_count(
+            self.fs
+                .read()
+                .as_ref()
+                .expect("live task must have an fs_struct"),
+        ) > 1
     }
 
     pub fn set_fs_struct(&self, fs: Arc<FsStruct>) -> Arc<FsStruct> {
         let mut guard = self.fs.write();
-        let old = guard.clone();
-        *guard = fs;
+        let old = guard.replace(fs).expect("live task must have an fs_struct");
         old
     }
 
+    /// Drop this task's reference to its filesystem context during exit.
+    ///
+    /// This mirrors Linux `exit_fs()`: a zombie retains process metadata for
+    /// wait(2), but must no longer pin its root or working-directory mounts.
+    pub(super) fn exit_fs(&self) {
+        self.fs.write().take();
+    }
+
     pub fn pwd_inode(&self) -> Arc<dyn IndexNode> {
-        self.fs.read().pwd()
+        self.fs_struct().pwd()
     }
 
     /// Returns an `Arc` pointer to the file descriptor table.

--- a/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
@@ -7,6 +7,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/syscall.h>
 #include <sys/sysmacros.h>
 #include <unistd.h>
 
@@ -117,6 +118,13 @@ TEST(DevtmpfsSemantics, DevMountExportsLinuxTypeAndStatfs) {
 
     EXPECT_TRUE(ProcMountsHasDevtmpfsAt("/dev"));
     EXPECT_TRUE(MountInfoHasDevtmpfsAt("/dev"));
+}
+
+TEST(DevtmpfsSemantics, StatfsRejectsInvalidPathPointer) {
+    struct statfs st = {};
+    errno = 0;
+    EXPECT_EQ(-1, syscall(SYS_statfs, reinterpret_cast<const char*>(1), &st));
+    EXPECT_EQ(EFAULT, errno);
 }
 
 TEST(DevtmpfsSemantics, BuiltinDeviceNumbersAndLinks) {

--- a/user/apps/tests/dunitest/suites/normal/syncfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/syncfs_semantics.cc
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
+#include <sys/mman.h>
 #include <sys/eventfd.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -443,6 +444,93 @@ TEST(SyncUmountLifetime, SharedMountPropagationUmountNoDeadlock) {
         << "propagated child mount remained in peer namespace after umount";
 
     CleanupSharedUmountPaths(child, parent, root);
+}
+
+TEST(SyncUmountLifetime, OpenFileDescriptionPinsMountUntilLastOwner) {
+    const char* mountpoint = "/tmp/dunitest_mount_pin";
+    const char* file_path = "/tmp/dunitest_mount_pin/file";
+
+    ASSERT_EQ(0, EnsureDir("/tmp")) << strerror(errno);
+    ASSERT_EQ(0, EnsureDir(mountpoint)) << strerror(errno);
+    ASSERT_EQ(0, mount("", mountpoint, "ramfs", 0, nullptr)) << strerror(errno);
+
+    int fd = open(file_path, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(4, write(fd, "data", 4)) << strerror(errno);
+    int duplicate = dup(fd);
+    ASSERT_GE(duplicate, 0) << strerror(errno);
+    ASSERT_EQ(0, close(fd));
+
+    errno = 0;
+    ASSERT_EQ(-1, umount(mountpoint));
+    EXPECT_EQ(EBUSY, errno);
+
+    ASSERT_EQ(0, close(duplicate));
+    ASSERT_EQ(0, umount(mountpoint)) << strerror(errno);
+    ASSERT_EQ(0, rmdir(mountpoint)) << strerror(errno);
+}
+
+TEST(SyncUmountLifetime, VmaAndOPathPinMount) {
+    const char* mountpoint = "/tmp/dunitest_mount_vma_pin";
+    const char* file_path = "/tmp/dunitest_mount_vma_pin/file";
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+
+    ASSERT_EQ(0, EnsureDir("/tmp")) << strerror(errno);
+    ASSERT_EQ(0, EnsureDir(mountpoint)) << strerror(errno);
+    ASSERT_EQ(0, mount("", mountpoint, "ramfs", 0, nullptr)) << strerror(errno);
+
+    int fd = open(file_path, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, ftruncate(fd, static_cast<off_t>(page_size))) << strerror(errno);
+    void* mapping = mmap(nullptr, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    ASSERT_NE(MAP_FAILED, mapping) << strerror(errno);
+    ASSERT_EQ(0, close(fd));
+
+    int path_fd = open(file_path, O_PATH | O_CLOEXEC);
+    ASSERT_GE(path_fd, 0) << strerror(errno);
+    errno = 0;
+    ASSERT_EQ(-1, umount(mountpoint));
+    EXPECT_EQ(EBUSY, errno);
+
+    ASSERT_EQ(0, close(path_fd));
+    errno = 0;
+    ASSERT_EQ(-1, umount(mountpoint));
+    EXPECT_EQ(EBUSY, errno) << "the VMA must retain its effective File";
+
+    ASSERT_EQ(0, munmap(mapping, page_size)) << strerror(errno);
+    ASSERT_EQ(0, umount(mountpoint)) << strerror(errno);
+    ASSERT_EQ(0, rmdir(mountpoint)) << strerror(errno);
+}
+
+TEST(SyncUmountLifetime, LazyDetachKeepsExistingFileUsable) {
+    const char* mountpoint = "/tmp/dunitest_mount_lazy_pin";
+    const char* file_path = "/tmp/dunitest_mount_lazy_pin/file";
+
+    ASSERT_EQ(0, EnsureDir("/tmp")) << strerror(errno);
+    ASSERT_EQ(0, EnsureDir(mountpoint)) << strerror(errno);
+    ASSERT_EQ(0, mount("", mountpoint, "ramfs", 0, nullptr)) << strerror(errno);
+
+    int fd = open(file_path, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    int dirfd = open(mountpoint, O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(dirfd, 0) << strerror(errno);
+    ASSERT_EQ(0, umount2(mountpoint, MNT_DETACH)) << strerror(errno);
+    EXPECT_FALSE(MountInfoContains(mountpoint));
+
+    ASSERT_EQ(5, write(fd, "alive", 5)) << strerror(errno);
+    ASSERT_EQ(0, lseek(fd, 0, SEEK_SET)) << strerror(errno);
+    char buf[6] = {};
+    ASSERT_EQ(5, read(fd, buf, 5)) << strerror(errno);
+    EXPECT_STREQ("alive", buf);
+
+    int derived = openat(dirfd, "derived", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    ASSERT_GE(derived, 0) << "openat on a detached but pinned path: " << strerror(errno);
+    ASSERT_EQ(7, write(derived, "derived", 7)) << strerror(errno);
+
+    ASSERT_EQ(0, close(derived));
+    ASSERT_EQ(0, close(dirfd));
+    ASSERT_EQ(0, close(fd));
+    ASSERT_EQ(0, rmdir(mountpoint)) << strerror(errno);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- define semantic inode retention owners and explicit eviction completion hooks
- carry mount/inode ownership through open path walks, O_PATH, shared file descriptions, and VMAs
- linearize mount publication, busy checks, lazy detach, propagation, and namespace teardown without holding topology locks across filesystem I/O
- defer final superblock shutdown until active mounts and external owners are gone

## Linux semantics

The design follows Linux 6.6 separation of link count, inode reference ownership, freeing state, mount busy references, and deferred final eviction. It does not use Arc strong counts as semantic lifetime state and does not perform fallible filesystem I/O from Drop.

Changing another_ext4 disk reclamation remains out of scope, as specified by the issue; the new admission and drain contracts provide the integration point for that follow-up.

## Validation

- cargo fmt --manifest-path kernel/Cargo.toml --all -- --check
- git diff --check
- make kernel
- QEMU: syncfs_semantics_test (12/12)
- QEMU: fdatasync_test (7/7)
- QEMU: ext4_inode_identity_test (3/3)
- QEMU: mount_propagation_test (4/4)
- QEMU: mount_move_test (10/10)
- QEMU: test_pivot_root_test (10/10)

Closes #2050