### PR TITLE
feat(fuse): pipeline cached readahead requests

### DIFF
--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -218,6 +218,7 @@ struct FuseReadCompletion {
     requested: usize,
     observed_size: usize,
     observed_attr_version: u64,
+    _open_pin: super::private_data::FuseOpenLifetimePin,
 }
 
 impl FuseReadCompletion {

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -1,4 +1,9 @@
-use alloc::{collections::BTreeMap, collections::VecDeque, sync::Arc, vec::Vec};
+use alloc::{
+    collections::BTreeMap,
+    collections::VecDeque,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
 use core::{
     mem::size_of,
     sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
@@ -200,11 +205,163 @@ pub struct FusePendingState {
     opcode: u32,
     response: Mutex<PendingCompletion>,
     wait: WaitQueue,
+    background_credit: Mutex<Option<FuseBackgroundCredit>>,
+    read_completion: Option<FuseReadCompletion>,
+}
+
+#[derive(Debug)]
+struct FuseReadCompletion {
+    target: Arc<PageCacheReadDmaReservation>,
+    node: Weak<super::inode::FuseNode>,
+    start_page: usize,
+    requested: usize,
+    observed_size: usize,
+    observed_attr_version: u64,
+}
+
+impl FuseReadCompletion {
+    fn finish(&self, result: &Result<FusePendingResult, SystemError>) -> Result<(), SystemError> {
+        let node = self.node.upgrade();
+        if let Some(node) = &node {
+            let start = self.start_page.saturating_mul(MMArch::PAGE_SIZE);
+            if node.attr_version() != self.observed_attr_version
+                && node
+                    .cached_metadata_snapshot()
+                    .is_some_and(|metadata| metadata.size.max(0) as usize <= start)
+            {
+                let _ = self.target.rollback(SystemError::EIO);
+                return Ok(());
+            }
+        }
+        let bytes = match result {
+            Ok(FusePendingResult::Reply(reply)) => {
+                if reply.len() > self.requested {
+                    self.target.rollback(SystemError::EIO)?;
+                    return Err(SystemError::EIO);
+                }
+                let bytes = reply.len();
+                self.target.publish_contiguous(reply)?;
+                bytes
+            }
+            Ok(FusePendingResult::ReadPagesDirect { bytes }) => {
+                if *bytes > self.requested {
+                    self.target.rollback(SystemError::EIO)?;
+                    return Err(SystemError::EIO);
+                }
+                self.target.publish_completed(*bytes)?;
+                *bytes
+            }
+            Err(error) => {
+                let _ = self.target.rollback(error.clone());
+                return Ok(());
+            }
+        };
+        if bytes < self.requested {
+            stats::on_readahead_short_read();
+            if let Some(node) = node {
+                let (eof, _) = node.note_short_read_eof(
+                    self.start_page,
+                    bytes,
+                    self.observed_size,
+                    self.observed_attr_version,
+                )?;
+                node.discard_completed_pages_beyond(&self.target, eof);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FuseBackgroundInner {
+    connected: bool,
+    max: usize,
+    congestion: usize,
+    inflight: usize,
+}
+
+#[derive(Debug)]
+struct FuseBackgroundState {
+    inner: Mutex<FuseBackgroundInner>,
+    wait: WaitQueue,
+}
+
+#[derive(Debug)]
+struct FuseBackgroundCredit {
+    state: Arc<FuseBackgroundState>,
+}
+
+impl Drop for FuseBackgroundCredit {
+    fn drop(&mut self) {
+        let mut inner = self.state.inner.lock();
+        inner.inflight = inner.inflight.saturating_sub(1);
+        drop(inner);
+        stats::on_background_released();
+        self.state.wait.wakeup(None);
+    }
+}
+
+impl FuseBackgroundState {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(FuseBackgroundInner {
+                connected: true,
+                max: FuseConn::DEFAULT_MAX_BACKGROUND,
+                congestion: FuseConn::DEFAULT_CONGESTION_THRESHOLD,
+                inflight: 0,
+            }),
+            wait: WaitQueue::default(),
+        })
+    }
+
+    fn configure(&self, max: usize, congestion: usize) {
+        let mut inner = self.inner.lock();
+        inner.max = core::cmp::max(1, max);
+        inner.congestion = core::cmp::min(core::cmp::max(1, congestion), inner.max);
+        drop(inner);
+        self.wait.wakeup(None);
+    }
+
+    fn disconnect(&self) {
+        self.inner.lock().connected = false;
+        self.wait.wakeup(None);
+    }
+
+    fn acquire(
+        self: &Arc<Self>,
+        speculative: bool,
+    ) -> Result<Option<FuseBackgroundCredit>, SystemError> {
+        wait_with_recheck(&self.wait, || {
+            let mut inner = self.inner.lock();
+            if !inner.connected {
+                return Err(SystemError::ENOTCONN);
+            }
+            let limit = if speculative {
+                inner.congestion
+            } else {
+                inner.max
+            };
+            if inner.inflight < limit {
+                inner.inflight += 1;
+                stats::on_background_acquired();
+                return Ok(Some(Some(FuseBackgroundCredit {
+                    state: self.clone(),
+                })));
+            }
+            if speculative {
+                stats::on_background_pressure(true);
+                return Ok(Some(None));
+            }
+            stats::on_background_pressure(false);
+            Ok(None)
+        })
+    }
 }
 
 #[derive(Debug)]
 enum PendingCompletion {
     Waiting,
+    Completing,
     Ready(Result<FusePendingResult, SystemError>),
     Consumed,
 }
@@ -215,13 +372,29 @@ pub(crate) enum FusePendingResult {
     ReadPagesDirect { bytes: usize },
 }
 
+enum FuseReadWaitOutcome {
+    Complete(Result<FuseReadPagesReply, SystemError>),
+    Interrupted,
+}
+
 impl FusePendingState {
     pub fn new(unique: u64, opcode: u32) -> Self {
+        Self::new_with_credit(unique, opcode, None, None)
+    }
+
+    fn new_with_credit(
+        unique: u64,
+        opcode: u32,
+        background_credit: Option<FuseBackgroundCredit>,
+        read_completion: Option<FuseReadCompletion>,
+    ) -> Self {
         Self {
             unique,
             opcode,
             response: Mutex::new(PendingCompletion::Waiting),
             wait: WaitQueue::default(),
+            background_credit: Mutex::new(background_credit),
+            read_completion,
         }
     }
 
@@ -240,14 +413,26 @@ impl FusePendingState {
         self.complete_result(Ok(FusePendingResult::ReadPagesDirect { bytes }))
     }
 
-    fn complete_result(&self, v: Result<FusePendingResult, SystemError>) -> bool {
+    fn complete_result(&self, mut v: Result<FusePendingResult, SystemError>) -> bool {
         let mut guard = self.response.lock();
         if !matches!(*guard, PendingCompletion::Waiting) {
             // Duplicate replies are ignored (Linux does similarly).
             return false;
         }
+        *guard = PendingCompletion::Completing;
+        drop(guard);
+        if let Some(completion) = &self.read_completion {
+            if let Err(error) = completion.finish(&v) {
+                v = Err(error);
+            }
+        }
+        let mut guard = self.response.lock();
         *guard = PendingCompletion::Ready(v);
         drop(guard);
+        // Linux releases a background slot at request completion, not when a
+        // waiter later consumes the result.  Taking the token makes this
+        // exactly-once across replies, abort and teardown.
+        self.background_credit.lock().take();
         self.wait.wakeup(None);
         true
     }
@@ -261,11 +446,47 @@ impl FusePendingState {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn wait_read_pages_complete(&self) -> Result<FuseReadPagesReply, SystemError> {
         match self.wait_result()? {
             FusePendingResult::Reply(reply) => Ok(FuseReadPagesReply::Contiguous(reply)),
             FusePendingResult::ReadPagesDirect { bytes } => {
                 Ok(FuseReadPagesReply::Direct { bytes })
+            }
+        }
+    }
+
+    fn wait_read_pages_once(&self) -> FuseReadWaitOutcome {
+        let take_ready = || {
+            let mut guard = self.response.lock();
+            if matches!(*guard, PendingCompletion::Ready(_)) {
+                let ready = core::mem::replace(&mut *guard, PendingCompletion::Consumed);
+                if let PendingCompletion::Ready(result) = ready {
+                    return Some(result.map(|result| match result {
+                        FusePendingResult::Reply(reply) => FuseReadPagesReply::Contiguous(reply),
+                        FusePendingResult::ReadPagesDirect { bytes } => {
+                            FuseReadPagesReply::Direct { bytes }
+                        }
+                    }));
+                }
+            }
+            None
+        };
+        if let Some(result) = take_ready() {
+            return FuseReadWaitOutcome::Complete(result);
+        }
+        loop {
+            let (waiter, waker) = Waiter::new_pair();
+            if let Err(error) = self.wait.register_waker(waker.clone()) {
+                return FuseReadWaitOutcome::Complete(Err(error));
+            }
+            if let Some(result) = take_ready() {
+                self.wait.remove_waker(&waker);
+                return FuseReadWaitOutcome::Complete(result);
+            }
+            if waiter.wait(true).is_err() {
+                self.wait.remove_waker(&waker);
+                return FuseReadWaitOutcome::Interrupted;
             }
         }
     }
@@ -352,6 +573,7 @@ pub struct FuseConn {
     epitems: LockedEPItemLinkedList,
     backend_reply_limit: Option<usize>,
     reply_layout_minor: AtomicU32,
+    background: Arc<FuseBackgroundState>,
 }
 
 impl FuseConn {
@@ -362,6 +584,8 @@ impl FuseConn {
     const DEFAULT_MAX_PAGES: usize = 32;
     const MAX_MAX_PAGES: usize = 256;
     const DEFAULT_MAX_READAHEAD: usize = 128 * MMArch::PAGE_SIZE;
+    const DEFAULT_MAX_BACKGROUND: usize = 12;
+    const DEFAULT_CONGESTION_THRESHOLD: usize = 9;
     const XATTR_SIZE_MAX: usize = 64 * 1024;
     const FUSE_COMPAT_ENTRY_OUT_SIZE: usize = 120;
     const FUSE_COMPAT_ATTR_OUT_SIZE: usize = 96;
@@ -433,6 +657,7 @@ impl FuseConn {
             epitems: LockedEPItemLinkedList::default(),
             backend_reply_limit,
             reply_layout_minor: AtomicU32::new(0),
+            background: FuseBackgroundState::new(),
         })
     }
 
@@ -680,6 +905,7 @@ impl FuseConn {
     }
 
     pub fn abort(&self) {
+        self.background.disconnect();
         let (processing, pending_noreply_count): (Vec<Arc<FusePendingState>>, usize) = {
             let mut g = self.inner.lock();
             g.connected = false;
@@ -714,6 +940,7 @@ impl FuseConn {
     /// Keep the connection readable for daemon-side teardown; actual disconnect
     /// happens when /dev/fuse is closed or explicit abort path is triggered.
     pub fn on_umount(&self) {
+        self.background.disconnect();
         let processing: Vec<Arc<FusePendingState>>;
         let dropped_processing: Vec<Arc<FusePendingState>>;
         let should_destroy: bool;
@@ -881,6 +1108,19 @@ impl FuseConn {
             g.init.max_readahead as usize
         };
         core::cmp::max(1, bytes >> MMArch::PAGE_SHIFT)
+    }
+
+    fn acquire_background_credit(
+        &self,
+        speculative: bool,
+    ) -> Result<Option<FuseBackgroundCredit>, SystemError> {
+        {
+            let inner = self.inner.lock();
+            if !inner.connected || inner.teardown_started {
+                return Err(SystemError::ENOTCONN);
+            }
+        }
+        self.background.acquire(speculative)
     }
 }
 

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -218,10 +218,14 @@ struct FuseReadCompletion {
     requested: usize,
     observed_size: usize,
     observed_attr_version: u64,
-    _open_pin: super::private_data::FuseOpenLifetimePin,
+    open_pin: Mutex<Option<super::private_data::FuseOpenLifetimePin>>,
 }
 
 impl FuseReadCompletion {
+    fn release_open_pin(&self) {
+        self.open_pin.lock().take();
+    }
+
     fn finish(&self, result: &Result<FusePendingResult, SystemError>) -> Result<(), SystemError> {
         let node = self.node.upgrade();
         if let Some(node) = &node {
@@ -427,6 +431,7 @@ impl FusePendingState {
             if let Err(error) = completion.finish(&v) {
                 v = Err(error);
             }
+            completion.release_open_pin();
         }
         let mut guard = self.response.lock();
         *guard = PendingCompletion::Ready(v);

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -41,6 +41,7 @@ use super::{stats, trace};
 
 mod daemon;
 mod request;
+pub(crate) use request::BackgroundReadPagesCtx;
 
 fn wait_with_recheck<T, F>(waitq: &WaitQueue, mut check: F) -> Result<T, SystemError>
 where

--- a/kernel/src/filesystem/fuse/conn/daemon.rs
+++ b/kernel/src/filesystem/fuse/conn/daemon.rs
@@ -535,6 +535,30 @@ impl FuseConn {
             }
             let negotiated_max_pages =
                 core::cmp::min(negotiated_max_pages_raw, max_pages_limit as u16);
+            let (max_background, congestion_threshold) = if negotiated_minor >= 13 {
+                let max_background = if init_out.max_background == 0 {
+                    Self::DEFAULT_MAX_BACKGROUND
+                } else {
+                    init_out.max_background as usize
+                };
+                let congestion = if init_out.congestion_threshold == 0 {
+                    Self::DEFAULT_CONGESTION_THRESHOLD
+                } else {
+                    init_out.congestion_threshold as usize
+                };
+                (
+                    core::cmp::max(1, max_background),
+                    core::cmp::min(
+                        core::cmp::max(1, congestion),
+                        core::cmp::max(1, max_background),
+                    ),
+                )
+            } else {
+                (
+                    Self::DEFAULT_MAX_BACKGROUND,
+                    Self::DEFAULT_CONGESTION_THRESHOLD,
+                )
+            };
 
             self.claim_pending_reply(out_hdr.unique, &pending, |g| {
                 // Align with Linux: only enable feature bits that are in the intersection of
@@ -554,6 +578,8 @@ impl FuseConn {
                 self.reply_layout_minor
                     .store(negotiated_minor, Ordering::Release);
             })?;
+            self.background
+                .configure(max_background, congestion_threshold);
             self.init_wait.wakeup(None);
         } else {
             self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -52,6 +52,7 @@ pub(crate) struct BackgroundReadPagesCtx {
     pub requested: usize,
     pub observed_size: usize,
     pub observed_attr_version: u64,
+    pub open_pin: super::super::private_data::FuseOpenLifetimePin,
 }
 
 impl FuseConn {
@@ -190,6 +191,7 @@ impl FuseConn {
                 requested: ctx.requested,
                 observed_size: ctx.observed_size,
                 observed_attr_version: ctx.observed_attr_version,
+                _open_pin: ctx.open_pin,
             }),
         ));
         let req = self.build_request(

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -191,7 +191,7 @@ impl FuseConn {
                 requested: ctx.requested,
                 observed_size: ctx.observed_size,
                 observed_attr_version: ctx.observed_attr_version,
-                _open_pin: ctx.open_pin,
+                open_pin: crate::libs::mutex::Mutex::new(Some(ctx.open_pin)),
             }),
         ));
         let req = self.build_request(

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -44,6 +44,16 @@ enum FuseReplyRouting {
     ReadPages(Arc<PageCacheReadDmaReservation>),
 }
 
+/// Bundled context for a background read-pages request.
+pub(crate) struct BackgroundReadPagesCtx {
+    pub destination: Arc<PageCacheReadDmaReservation>,
+    pub node: alloc::sync::Weak<super::super::inode::FuseNode>,
+    pub start_page: usize,
+    pub requested: usize,
+    pub observed_size: usize,
+    pub observed_attr_version: u64,
+}
+
 impl FuseConn {
     fn is_high_priority_opcode(opcode: u32) -> bool {
         matches!(opcode, FUSE_FORGET | FUSE_INTERRUPT)
@@ -160,14 +170,9 @@ impl FuseConn {
         &self,
         nodeid: u64,
         payload: &[u8],
-        destination: Arc<PageCacheReadDmaReservation>,
         req_cred: FuseRequestCred,
         speculative: bool,
-        node: alloc::sync::Weak<super::super::inode::FuseNode>,
-        start_page: usize,
-        requested: usize,
-        observed_size: usize,
-        observed_attr_version: u64,
+        ctx: BackgroundReadPagesCtx,
     ) -> Result<Option<Arc<FusePendingState>>, SystemError> {
         self.wait_initialized()?;
         let Some(credit) = self.acquire_background_credit(speculative)? else {
@@ -179,12 +184,12 @@ impl FuseConn {
             FUSE_READ,
             Some(credit),
             Some(super::FuseReadCompletion {
-                target: destination.clone(),
-                node,
-                start_page,
-                requested,
-                observed_size,
-                observed_attr_version,
+                target: ctx.destination.clone(),
+                node: ctx.node,
+                start_page: ctx.start_page,
+                requested: ctx.requested,
+                observed_size: ctx.observed_size,
+                observed_attr_version: ctx.observed_attr_version,
             }),
         ));
         let req = self.build_request(
@@ -193,7 +198,7 @@ impl FuseConn {
             nodeid,
             payload,
             req_cred,
-            FuseReplyRouting::ReadPages(destination),
+            FuseReplyRouting::ReadPages(ctx.destination),
         )?;
         self.push_request(req, Some(pending.clone()), unique)?;
         Ok(Some(pending))

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -153,23 +153,62 @@ impl FuseConn {
         self.wait_request_complete(opcode, pending)
     }
 
-    /// Submit one READ whose owned destination can be used directly by a
-    /// capable transport, while retaining the same-request contiguous fallback.
-    pub(crate) fn request_read_pages(
+    /// Enqueue a cache READ without waiting so one caller can build a bounded
+    /// pipeline. `Ok(None)` means a purely speculative request was suppressed
+    /// by the negotiated congestion threshold.
+    pub(crate) fn enqueue_background_read_pages(
         &self,
         nodeid: u64,
         payload: &[u8],
         destination: Arc<PageCacheReadDmaReservation>,
         req_cred: FuseRequestCred,
-    ) -> Result<FuseReadPagesReply, SystemError> {
+        speculative: bool,
+        node: alloc::sync::Weak<super::super::inode::FuseNode>,
+        start_page: usize,
+        requested: usize,
+        observed_size: usize,
+        observed_attr_version: u64,
+    ) -> Result<Option<Arc<FusePendingState>>, SystemError> {
         self.wait_initialized()?;
-        let pending = self.enqueue_read_pages(nodeid, payload, destination, req_cred)?;
-        match pending.wait_read_pages_complete() {
-            Err(SystemError::EINTR) | Err(SystemError::ERESTARTSYS) => {
+        let Some(credit) = self.acquire_background_credit(speculative)? else {
+            return Ok(None);
+        };
+        let unique = self.alloc_unique();
+        let pending = Arc::new(FusePendingState::new_with_credit(
+            unique,
+            FUSE_READ,
+            Some(credit),
+            Some(super::FuseReadCompletion {
+                target: destination.clone(),
+                node,
+                start_page,
+                requested,
+                observed_size,
+                observed_attr_version,
+            }),
+        ));
+        let req = self.build_request(
+            unique,
+            FUSE_READ,
+            nodeid,
+            payload,
+            req_cred,
+            FuseReplyRouting::ReadPages(destination),
+        )?;
+        self.push_request(req, Some(pending.clone()), unique)?;
+        Ok(Some(pending))
+    }
+
+    pub(crate) fn wait_background_read_pages(
+        &self,
+        pending: &Arc<FusePendingState>,
+    ) -> (Result<FuseReadPagesReply, SystemError>, bool) {
+        match pending.wait_read_pages_once() {
+            super::FuseReadWaitOutcome::Interrupted => {
                 let _ = self.queue_interrupt(pending.unique());
-                Err(SystemError::EINTR)
+                (Err(SystemError::EINTR), true)
             }
-            result => result,
+            super::FuseReadWaitOutcome::Complete(result) => (result, false),
         }
     }
 
@@ -276,27 +315,6 @@ impl FuseConn {
         )?;
         self.push_request(req, Some(pending_state.clone()), unique)?;
         Ok(pending_state)
-    }
-
-    fn enqueue_read_pages(
-        &self,
-        nodeid: u64,
-        payload: &[u8],
-        destination: Arc<PageCacheReadDmaReservation>,
-        req_cred: FuseRequestCred,
-    ) -> Result<Arc<FusePendingState>, SystemError> {
-        let unique = self.alloc_unique();
-        let pending = Arc::new(FusePendingState::new(unique, FUSE_READ));
-        let req = self.build_request(
-            unique,
-            FUSE_READ,
-            nodeid,
-            payload,
-            req_cred,
-            FuseReplyRouting::ReadPages(destination),
-        )?;
-        self.push_request(req, Some(pending.clone()), unique)?;
-        Ok(pending)
     }
 
     fn reply_capacity(

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -686,12 +686,18 @@ impl FileSystem for FuseFS {
         };
         drop(vma_guard);
 
-        let (node, fh, file_flags, fopen_flags) = {
+        let (node, fh, file_flags, fopen_flags, lifetime) = {
             let data = file.private_data.lock();
             let FilePrivateData::Fuse(FuseFilePrivateData::File(p)) = &*data else {
                 return VmFaultReason::VM_FAULT_SIGBUS;
             };
-            (p.node.clone(), p.fh, p.open_flags, p.fopen_flags)
+            (
+                p.node.clone(),
+                p.fh,
+                p.open_flags,
+                p.fopen_flags,
+                p.lifetime.clone(),
+            )
         };
         if (fopen_flags & FOPEN_DIRECT_IO) != 0 && vm_flags.contains(VmFlags::VM_MAYSHARE) {
             return VmFaultReason::VM_FAULT_SIGBUS;
@@ -707,7 +713,14 @@ impl FileSystem for FuseFS {
 
         if major {
             let mut ra_state = file.get_ra_state();
-            let _ = node.mmap_readahead_with_open(page_index, 1, &mut ra_state, fh, file_flags);
+            let _ = node.mmap_readahead_with_open(
+                page_index,
+                1,
+                &mut ra_state,
+                fh,
+                file_flags,
+                lifetime,
+            );
             let _ = file.set_ra_state(ra_state);
         }
 

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -50,6 +50,7 @@ pub struct FuseNode {
     lookup_cache: Mutex<BTreeMap<String, FuseLookupCacheEntry>>,
     direct_io_lock: Mutex<()>,
     cached_metadata_deadline_ns: AtomicU64,
+    attr_version: AtomicU64,
     lookup_count: AtomicU64,
     /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
     lookup_attr_flags: AtomicU32,
@@ -95,6 +96,7 @@ impl FuseNode {
             lookup_cache: Mutex::new(BTreeMap::new()),
             direct_io_lock: Mutex::new(()),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
+            attr_version: AtomicU64::new(1),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
             generation: AtomicU64::new(0),
@@ -180,15 +182,29 @@ impl FuseNode {
     }
 
     pub fn set_cached_metadata(&self, md: Metadata) {
-        *self.cached_metadata.lock() = Some(md);
+        let mut metadata = self.cached_metadata.lock();
+        *metadata = Some(md);
+        self.attr_version.fetch_add(1, Ordering::AcqRel);
+        drop(metadata);
         self.cached_metadata_deadline_ns
             .store(u64::MAX, Ordering::Relaxed);
     }
 
     pub fn set_cached_metadata_with_valid(&self, md: Metadata, valid: u64, valid_nsec: u32) {
-        *self.cached_metadata.lock() = Some(md);
+        let mut metadata = self.cached_metadata.lock();
+        *metadata = Some(md);
+        self.attr_version.fetch_add(1, Ordering::AcqRel);
+        drop(metadata);
         self.cached_metadata_deadline_ns
             .store(Self::cache_deadline(valid, valid_nsec), Ordering::Relaxed);
+    }
+
+    pub(crate) fn attr_version(&self) -> u64 {
+        self.attr_version.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn bump_attr_version(&self) {
+        self.attr_version.fetch_add(1, Ordering::AcqRel);
     }
 
     /// 累计该 inode 在 userspace daemon 侧持有的 LOOKUP 引用。

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -51,6 +51,10 @@ pub struct FuseNode {
     direct_io_lock: Mutex<()>,
     cached_metadata_deadline_ns: AtomicU64,
     attr_version: AtomicU64,
+    /// Version chain produced while short READ replies from one metadata
+    /// snapshot monotonically converge on the lowest observed EOF.
+    short_read_source_attr_version: AtomicU64,
+    short_read_chain_attr_version: AtomicU64,
     /// Lowest EOF established by a short READ whose inode-wide cache truncate
     /// is deferred out of the transport completion path.
     pending_short_read_eof: AtomicU64,
@@ -100,6 +104,8 @@ impl FuseNode {
             direct_io_lock: Mutex::new(()),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             attr_version: AtomicU64::new(1),
+            short_read_source_attr_version: AtomicU64::new(0),
+            short_read_chain_attr_version: AtomicU64::new(0),
             pending_short_read_eof: AtomicU64::new(u64::MAX),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
@@ -188,7 +194,7 @@ impl FuseNode {
     pub fn set_cached_metadata(&self, md: Metadata) {
         let mut metadata = self.cached_metadata.lock();
         *metadata = Some(md);
-        self.attr_version.fetch_add(1, Ordering::AcqRel);
+        self.bump_attr_version();
         drop(metadata);
         self.cached_metadata_deadline_ns
             .store(u64::MAX, Ordering::Relaxed);
@@ -197,7 +203,7 @@ impl FuseNode {
     pub fn set_cached_metadata_with_valid(&self, md: Metadata, valid: u64, valid_nsec: u32) {
         let mut metadata = self.cached_metadata.lock();
         *metadata = Some(md);
-        self.attr_version.fetch_add(1, Ordering::AcqRel);
+        self.bump_attr_version();
         drop(metadata);
         self.cached_metadata_deadline_ns
             .store(Self::cache_deadline(valid, valid_nsec), Ordering::Relaxed);
@@ -207,8 +213,18 @@ impl FuseNode {
         self.attr_version.load(Ordering::Acquire)
     }
 
-    pub(crate) fn bump_attr_version(&self) {
-        self.attr_version.fetch_add(1, Ordering::AcqRel);
+    pub(crate) fn bump_attr_version(&self) -> u64 {
+        let version = self
+            .attr_version
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1);
+        if version == 0 {
+            self.short_read_source_attr_version
+                .store(u64::MAX, Ordering::Release);
+            self.short_read_chain_attr_version
+                .store(u64::MAX, Ordering::Release);
+        }
+        version
     }
 
     /// 累计该 inode 在 userspace daemon 侧持有的 LOOKUP 引用。

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -51,6 +51,9 @@ pub struct FuseNode {
     direct_io_lock: Mutex<()>,
     cached_metadata_deadline_ns: AtomicU64,
     attr_version: AtomicU64,
+    /// Lowest EOF established by a short READ whose inode-wide cache truncate
+    /// is deferred out of the transport completion path.
+    pending_short_read_eof: AtomicU64,
     lookup_count: AtomicU64,
     /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
     lookup_attr_flags: AtomicU32,
@@ -97,6 +100,7 @@ impl FuseNode {
             direct_io_lock: Mutex::new(()),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             attr_version: AtomicU64::new(1),
+            pending_short_read_eof: AtomicU64::new(u64::MAX),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
             generation: AtomicU64::new(0),

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -243,12 +243,22 @@ impl FuseNode {
             let mut guard = self.cached_metadata.lock();
             if let Some(md) = guard.as_mut() {
                 let current_size = md.size.max(0) as usize;
-                if self.attr_version() == observed_attr_version
-                    && current_size == observed_size
-                    && eof < current_size
-                {
+                let current_version = self.attr_version();
+                let first_from_snapshot =
+                    current_version == observed_attr_version && current_size == observed_size;
+                let continues_short_read_chain =
+                    self.short_read_source_attr_version.load(Ordering::Acquire)
+                        == observed_attr_version
+                        && self.short_read_chain_attr_version.load(Ordering::Acquire)
+                            == current_version
+                        && current_size <= observed_size;
+                if (first_from_snapshot || continues_short_read_chain) && eof < current_size {
                     md.size = eof as i64;
-                    self.bump_attr_version();
+                    let chain_version = self.bump_attr_version();
+                    self.short_read_source_attr_version
+                        .store(observed_attr_version, Ordering::Release);
+                    self.short_read_chain_attr_version
+                        .store(chain_version, Ordering::Release);
                     self.pending_short_read_eof
                         .fetch_min(eof as u64, Ordering::AcqRel);
                     self.cached_metadata_deadline_ns
@@ -1307,9 +1317,11 @@ impl FuseNode {
         if let Some(md) = metadata.as_mut() {
             if end > md.size.max(0) as usize {
                 md.size = end as i64;
-                self.bump_attr_version();
             }
         }
+        // Every successful write is a mutation fence for READ replies issued
+        // from an older metadata snapshot, even when it does not extend size.
+        self.bump_attr_version();
         Ok(())
     }
 

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -897,12 +897,18 @@ impl FuseNode {
                 break;
             }
 
+            let speculative = run_start >= demand_end_page;
             let target = match page_cache
                 .manager()
                 .reserve_read_dma(run_start, run_end - run_start)
             {
                 Ok(target) => Arc::new(target),
                 Err(SystemError::EEXIST) => {
+                    if speculative {
+                        // The foreground read has no dependency on a conflicting
+                        // speculative window. Do not inherit its latency or error.
+                        break;
+                    }
                     // A concurrent reader won the reservation race. Wait for its first page to
                     // leave Loading, then rebuild the missing run from current cache state.
                     drop(page_cache.manager().commit_page(run_start)?);
@@ -919,7 +925,6 @@ impl FuseNode {
                 flags: file_ctx.file_flags,
                 padding: 0,
             };
-            let speculative = run_start >= demand_end_page;
             let Some(open_pin) = file_ctx.lifetime.try_pin() else {
                 let _ = target.rollback(SystemError::EIO);
                 if !speculative {
@@ -1009,11 +1014,11 @@ impl FuseNode {
         offset: usize,
         len: usize,
         buf: &mut [u8],
-        fh: u64,
-        file_flags: u32,
-        ra_state: &Arc<Mutex<FileReadaheadState>>,
-        lifetime: Arc<FuseOpenLifetime>,
+        open: &FuseOpenPrivateData,
     ) -> Result<usize, SystemError> {
+        let fh = open.fh;
+        let file_flags = open.open_flags;
+        let ra_state = &open.readahead_state;
         let md = self.cached_or_fetch_metadata()?;
         let file_size = md.size.max(0) as usize;
         self.resolve_pending_short_read_truncate(file_size)?;
@@ -1064,7 +1069,7 @@ impl FuseNode {
             file_size,
             fh,
             file_flags,
-            lifetime,
+            lifetime: open.lifetime.clone(),
         };
         let (_, mut truncate_eof) = self.fill_page_cache_range_with_open(
             &page_cache,

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -9,7 +9,7 @@ use system_error::SystemError;
 use crate::{
     arch::MMArch,
     filesystem::{
-        page_cache::{PageCache, PageCacheBackend},
+        page_cache::{PageCache, PageCacheBackend, PageCacheReadDmaReservation},
         vfs::{file::FileFlags, FilePrivateData, FileType, IndexNode, Metadata, SetMetadataMask},
     },
     libs::mutex::Mutex,
@@ -93,7 +93,7 @@ impl FuseNode {
         self.page_cache.lock().clone()
     }
 
-    fn cached_metadata_snapshot(&self) -> Option<Metadata> {
+    pub(crate) fn cached_metadata_snapshot(&self) -> Option<Metadata> {
         self.cached_metadata.lock().clone()
     }
 
@@ -105,11 +105,26 @@ impl FuseNode {
         Ok(())
     }
 
-    pub(super) fn truncate_page_cache(&self, new_size: usize) -> Result<(), SystemError> {
+    pub(crate) fn truncate_page_cache(&self, new_size: usize) -> Result<(), SystemError> {
         if let Some(cache) = self.cached_page_cache() {
             cache.truncate(new_size)?;
         }
         Ok(())
+    }
+
+    pub(crate) fn discard_completed_pages_beyond(
+        &self,
+        target: &PageCacheReadDmaReservation,
+        eof: usize,
+    ) {
+        let Some(cache) = self.cached_page_cache() else {
+            return;
+        };
+        for descriptor in target.descriptors() {
+            if descriptor.page_index().saturating_mul(MMArch::PAGE_SIZE) >= eof {
+                let _ = cache.manager().discard_clean_page(descriptor.page_index());
+            }
+        }
     }
 
     pub(super) fn setattr_size(
@@ -204,11 +219,12 @@ impl FuseNode {
         Ok(())
     }
 
-    fn note_short_read_eof(
+    pub(crate) fn note_short_read_eof(
         &self,
         page_index: usize,
         read_len: usize,
         observed_size: usize,
+        observed_attr_version: u64,
     ) -> Result<(usize, bool), SystemError> {
         let eof = page_index
             .checked_mul(MMArch::PAGE_SIZE)
@@ -219,8 +235,12 @@ impl FuseNode {
             let mut guard = self.cached_metadata.lock();
             if let Some(md) = guard.as_mut() {
                 let current_size = md.size.max(0) as usize;
-                if current_size == observed_size && eof < current_size {
+                if self.attr_version() == observed_attr_version
+                    && current_size == observed_size
+                    && eof < current_size
+                {
                     md.size = eof as i64;
+                    self.bump_attr_version();
                     self.cached_metadata_deadline_ns
                         .store(u64::MAX, Ordering::Relaxed);
                     should_truncate = true;
@@ -477,6 +497,7 @@ impl FuseNode {
                 no_open,
                 open_context,
                 writeback_handle,
+                readahead_state: Arc::new(Mutex::new(FileReadaheadState::new())),
             })),
             FUSE_OPENDIR => FilePrivateData::Fuse(FuseFilePrivateData::Dir(FuseOpenPrivateData {
                 conn: conn_any,
@@ -487,6 +508,7 @@ impl FuseNode {
                 no_open,
                 open_context,
                 writeback_handle: None,
+                readahead_state: Arc::new(Mutex::new(FileReadaheadState::new())),
             })),
             _ => return Err(SystemError::EINVAL),
         };
@@ -512,6 +534,7 @@ impl FuseNode {
             let mut guard = self.cached_metadata.lock();
             if let Some(md) = guard.as_mut() {
                 md.size = 0;
+                self.bump_attr_version();
             }
         } else if (fopen_flags & FOPEN_KEEP_CACHE) == 0 {
             self.invalidate_clean_page_cache()?;
@@ -754,6 +777,7 @@ impl FuseNode {
         file_size: usize,
         fh: u64,
         file_flags: u32,
+        demand_end_page: usize,
     ) -> Result<(usize, Option<usize>), SystemError> {
         if start_page >= end_page || file_size == 0 {
             return Ok((0, None));
@@ -766,7 +790,11 @@ impl FuseNode {
             core::cmp::min(max_pages_by_read, self.conn().max_pages()),
         );
         let mut total_read = 0usize;
-        let mut truncate_eof = None;
+        let truncate_eof = None;
+        let mut pending_reads = Vec::new();
+        let mut submission_error = None;
+        let observed_attr_version = self.attr_version();
+        let mut submitted_requests = 0usize;
 
         let mut idx = start_page;
         while idx < end_page {
@@ -824,41 +852,76 @@ impl FuseNode {
                 flags: file_flags,
                 padding: 0,
             };
-            let result = self.conn().request_read_pages(
+            let speculative = run_start >= demand_end_page;
+            let pending = self.conn().enqueue_background_read_pages(
                 self.nodeid,
-                fuse_pack_struct(&read_in),
+                &fuse_pack_struct(&read_in),
                 target.clone(),
                 FuseRequestCred::from_current(),
-            )?;
-            let bytes_read = match result {
-                FuseReadPagesReply::Direct { bytes } => {
-                    if bytes > read_len {
-                        let _ = target.rollback(SystemError::EIO);
-                        return Err(SystemError::EIO);
-                    }
-                    target.publish_completed(bytes)?;
-                    bytes
+                speculative,
+                self.self_ref.clone(),
+                run_start,
+                read_len,
+                file_size,
+                observed_attr_version,
+            );
+            let pending = match pending {
+                Ok(Some(pending)) => pending,
+                Ok(None) => {
+                    let _ = target.rollback(SystemError::EIO);
+                    break;
                 }
-                FuseReadPagesReply::Contiguous(reply) => {
-                    if reply.len() > read_len {
-                        return Err(SystemError::EIO);
+                Err(error) => {
+                    let _ = target.rollback(error.clone());
+                    if !speculative {
+                        submission_error = Some(error);
                     }
-                    let bytes = reply.len();
-                    target.publish_contiguous(&reply)?;
-                    bytes
+                    break;
                 }
             };
-            total_read += bytes_read.div_ceil(MMArch::PAGE_SIZE);
-
-            if bytes_read < read_len {
-                let (eof, should_truncate) =
-                    self.note_short_read_eof(run_start, bytes_read, file_size)?;
-                if should_truncate {
-                    truncate_eof = Some(eof);
-                }
-                break;
+            submitted_requests += 1;
+            if !speculative {
+                pending_reads.push((read_len, pending));
             }
             idx = run_end;
+        }
+
+        let mut first_error = submission_error;
+        let mut interrupted = false;
+        super::super::stats::on_readahead_batch(
+            end_page.saturating_sub(start_page),
+            submitted_requests,
+        );
+        for (read_len, pending) in pending_reads {
+            let (result, was_interrupted) = self.conn().wait_background_read_pages(&pending);
+            interrupted |= was_interrupted;
+            let result = match result {
+                Ok(result) => result,
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                    if interrupted {
+                        break;
+                    }
+                    continue;
+                }
+            };
+            let bytes_read = match result {
+                FuseReadPagesReply::Direct { bytes } => bytes,
+                FuseReadPagesReply::Contiguous(reply) => reply.len(),
+            };
+            if bytes_read > read_len {
+                return Err(SystemError::EIO);
+            }
+            total_read += bytes_read.div_ceil(MMArch::PAGE_SIZE);
+        }
+
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        if interrupted {
+            return Err(SystemError::EINTR);
         }
 
         Ok((total_read, truncate_eof))
@@ -871,6 +934,7 @@ impl FuseNode {
         buf: &mut [u8],
         fh: u64,
         file_flags: u32,
+        ra_state: &Arc<Mutex<FileReadaheadState>>,
     ) -> Result<usize, SystemError> {
         let md = self.cached_or_fetch_metadata()?;
         let file_size = md.size.max(0) as usize;
@@ -884,9 +948,32 @@ impl FuseNode {
         let page_cache = self.ensure_page_cache()?;
         let _invalidate = page_cache.invalidate_read();
         let last_file_page = (file_size - 1) >> MMArch::PAGE_SHIFT;
-        let max_pages_by_read = core::cmp::max(1, self.conn().max_read() >> MMArch::PAGE_SHIFT);
-        let max_pages_by_conn = core::cmp::min(max_pages_by_read, self.conn().max_pages());
-        let readaround_pages = core::cmp::min(max_pages_by_conn, 16);
+        let max_window = core::cmp::max(
+            1,
+            core::cmp::min(
+                self.conn().max_readahead_pages(),
+                FileReadaheadState::new().ra_pages,
+            ),
+        );
+        let demand_pages = end_page_index - start_page_index + 1;
+        let readaround_pages = {
+            let mut state = ra_state.lock();
+            let sequential = start_page_index == 0 || state.first_sequential(start_page_index);
+            let pages = if sequential {
+                let base = core::cmp::max(demand_pages, state.size.max(1));
+                core::cmp::min(
+                    max_window,
+                    core::cmp::max(demand_pages, base.saturating_mul(2)),
+                )
+            } else {
+                demand_pages
+            };
+            state.start = start_page_index;
+            state.size = pages;
+            state.async_size = pages.saturating_sub(demand_pages);
+            state.prev_index = end_page_index as i64;
+            pages
+        };
         let prefetch_end = core::cmp::min(
             last_file_page + 1,
             core::cmp::max(
@@ -901,7 +988,9 @@ impl FuseNode {
             file_size,
             fh,
             file_flags,
+            end_page_index + 1,
         )?;
+        let observed_attr_version = self.attr_version();
 
         let mut dst_offset = 0usize;
         for page_index in start_page_index..=end_page_index {
@@ -926,8 +1015,12 @@ impl FuseNode {
             let mut copy_end = copy_end;
             if let Some(read_len) = filled_len {
                 if read_len < MMArch::PAGE_SIZE {
-                    let (eof, should_truncate) =
-                        self.note_short_read_eof(page_index, read_len, file_size)?;
+                    let (eof, should_truncate) = self.note_short_read_eof(
+                        page_index,
+                        read_len,
+                        file_size,
+                        observed_attr_version,
+                    )?;
                     copy_end = core::cmp::min(copy_end, eof);
                     if should_truncate {
                         truncate_eof = Some(eof);
@@ -985,6 +1078,7 @@ impl FuseNode {
             return Err(SystemError::EINVAL);
         }
         let page_cache = self.ensure_page_cache()?;
+        let observed_attr_version = self.attr_version();
         let mut filled_len = None;
         let page = page_cache
             .manager()
@@ -995,7 +1089,12 @@ impl FuseNode {
             })?;
         if let Some(read_len) = filled_len {
             if read_len < MMArch::PAGE_SIZE {
-                let (eof, _) = self.note_short_read_eof(page_index, read_len, file_size)?;
+                let (eof, _) = self.note_short_read_eof(
+                    page_index,
+                    read_len,
+                    file_size,
+                    observed_attr_version,
+                )?;
                 if page_index.saturating_mul(MMArch::PAGE_SIZE) >= eof {
                     drop(page);
                     page_cache.manager().discard_clean_page(page_index)?;
@@ -1058,6 +1157,7 @@ impl FuseNode {
             file_size,
             fh,
             file_flags,
+            page_index.saturating_add(req_pages),
         )?;
 
         if let Some(eof) = truncate_eof {
@@ -1139,9 +1239,11 @@ impl FuseNode {
             return Ok(());
         }
         let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
-        if let Some(md) = self.cached_metadata.lock().as_mut() {
+        let mut metadata = self.cached_metadata.lock();
+        if let Some(md) = metadata.as_mut() {
             if end > md.size.max(0) as usize {
                 md.size = end as i64;
+                self.bump_attr_version();
             }
         }
         Ok(())

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -8,6 +8,7 @@ use system_error::SystemError;
 
 use crate::{
     arch::MMArch,
+    exception::workqueue::{schedule_work, Work},
     filesystem::{
         page_cache::{PageCache, PageCacheBackend, PageCacheReadDmaReservation},
         vfs::{file::FileFlags, FilePrivateData, FileType, IndexNode, Metadata, SetMetadataMask},
@@ -141,6 +142,7 @@ impl FuseNode {
         truncate_metadata: Option<(&Metadata, SetMetadataMask)>,
     ) -> Result<(), SystemError> {
         self.check_not_stale()?;
+        self.resolve_pending_short_read_truncate(len)?;
         let mut valid = FATTR_SIZE;
         if lock_owner.is_some() {
             valid |= FATTR_LOCKOWNER;
@@ -247,13 +249,60 @@ impl FuseNode {
                 {
                     md.size = eof as i64;
                     self.bump_attr_version();
+                    self.pending_short_read_eof
+                        .fetch_min(eof as u64, Ordering::AcqRel);
                     self.cached_metadata_deadline_ns
                         .store(u64::MAX, Ordering::Relaxed);
+                    if let Some(cache) = self.cached_page_cache() {
+                        let start_page = eof / MMArch::PAGE_SIZE;
+                        schedule_work(Work::new(move || {
+                            if let Err(error) = cache.unmap_mapping_pages_even_cow(start_page, None)
+                            {
+                                log::warn!(
+                                    "fuse: short-read mapping invalidation failed eof={} err={:?}",
+                                    eof,
+                                    error
+                                );
+                            }
+                        }));
+                    }
                     should_truncate = true;
                 }
             }
         }
         Ok((eof, should_truncate))
+    }
+
+    /// Finish an inode-wide page-cache truncate only when a later metadata
+    /// refresh grows the file past an EOF established by a short READ.
+    ///
+    /// Running `PageCache::truncate()` from the FUSE reply completion would
+    /// deadlock a single-threaded daemon when it waits for another outstanding
+    /// readahead page. Deferring it to the next operation that can expose or
+    /// create data past that EOF preserves coherence without blocking the
+    /// daemon's reply path.
+    pub(super) fn resolve_pending_short_read_truncate(
+        &self,
+        visible_size: usize,
+    ) -> Result<(), SystemError> {
+        let eof = self.pending_short_read_eof.load(Ordering::Acquire);
+        if eof == u64::MAX || visible_size <= eof as usize {
+            return Ok(());
+        }
+
+        self.truncate_pending_short_read_eof(eof)?;
+        Ok(())
+    }
+
+    fn truncate_pending_short_read_eof(&self, eof: u64) -> Result<(), SystemError> {
+        self.truncate_page_cache(eof as usize)?;
+        let _ = self.pending_short_read_eof.compare_exchange(
+            eof,
+            u64::MAX,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+        Ok(())
     }
 
     /// Linux `fuse_send_open()` forwards file flags except creation-only bits.
@@ -944,6 +993,7 @@ impl FuseNode {
     ) -> Result<usize, SystemError> {
         let md = self.cached_or_fetch_metadata()?;
         let file_size = md.size.max(0) as usize;
+        self.resolve_pending_short_read_truncate(file_size)?;
         if offset >= file_size || len == 0 {
             return Ok(0);
         }
@@ -1083,6 +1133,7 @@ impl FuseNode {
     ) -> Result<Arc<crate::mm::page::Page>, SystemError> {
         let md = self.cached_metadata_snapshot().ok_or(SystemError::EIO)?;
         let file_size = md.size.max(0) as usize;
+        self.resolve_pending_short_read_truncate(file_size)?;
         if file_size == 0 || page_index.saturating_mul(MMArch::PAGE_SIZE) >= file_size {
             return Err(SystemError::EINVAL);
         }
@@ -1137,6 +1188,7 @@ impl FuseNode {
 
         let md = self.cached_metadata_snapshot().ok_or(SystemError::EIO)?;
         let file_size = md.size.max(0) as usize;
+        self.resolve_pending_short_read_truncate(file_size)?;
         if file_size == 0 {
             return Ok(0);
         }

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 use super::super::{
-    conn::FuseRequestCred,
+    conn::{BackgroundReadPagesCtx, FuseRequestCred},
     private_data::{
         FuseFilePrivateData, FuseOpenContext, FuseOpenPrivateData, FuseWritebackHandle,
     },
@@ -37,6 +37,12 @@ use super::FuseNode;
 #[derive(Debug)]
 struct FusePageCacheBackend {
     node: Weak<FuseNode>,
+}
+
+struct FillPagesFileCtx {
+    file_size: usize,
+    fh: u64,
+    file_flags: u32,
 }
 
 impl FusePageCacheBackend {
@@ -774,12 +780,10 @@ impl FuseNode {
         page_cache: &Arc<PageCache>,
         start_page: usize,
         end_page: usize,
-        file_size: usize,
-        fh: u64,
-        file_flags: u32,
         demand_end_page: usize,
+        file_ctx: &FillPagesFileCtx,
     ) -> Result<(usize, Option<usize>), SystemError> {
-        if start_page >= end_page || file_size == 0 {
+        if start_page >= end_page || file_ctx.file_size == 0 {
             return Ok((0, None));
         }
 
@@ -815,7 +819,7 @@ impl FuseNode {
             let read_offset = run_start
                 .checked_mul(MMArch::PAGE_SIZE)
                 .ok_or(SystemError::EOVERFLOW)?;
-            if read_offset >= file_size {
+            if read_offset >= file_ctx.file_size {
                 break;
             }
 
@@ -824,7 +828,7 @@ impl FuseNode {
                 .ok_or(SystemError::EOVERFLOW)?;
             let read_len = core::cmp::min(
                 core::cmp::min(read_pages_len, max_read),
-                file_size - read_offset,
+                file_ctx.file_size - read_offset,
             );
             if read_len == 0 {
                 break;
@@ -844,26 +848,28 @@ impl FuseNode {
                 Err(error) => return Err(error),
             };
             let read_in = FuseReadIn {
-                fh,
+                fh: file_ctx.fh,
                 offset: read_offset as u64,
                 size: read_len as u32,
                 read_flags: 0,
                 lock_owner: 0,
-                flags: file_flags,
+                flags: file_ctx.file_flags,
                 padding: 0,
             };
             let speculative = run_start >= demand_end_page;
             let pending = self.conn().enqueue_background_read_pages(
                 self.nodeid,
-                &fuse_pack_struct(&read_in),
-                target.clone(),
+                fuse_pack_struct(&read_in),
                 FuseRequestCred::from_current(),
                 speculative,
-                self.self_ref.clone(),
-                run_start,
-                read_len,
-                file_size,
-                observed_attr_version,
+                BackgroundReadPagesCtx {
+                    destination: target.clone(),
+                    node: self.self_ref.clone(),
+                    start_page: run_start,
+                    requested: read_len,
+                    observed_size: file_ctx.file_size,
+                    observed_attr_version,
+                },
             );
             let pending = match pending {
                 Ok(Some(pending)) => pending,
@@ -981,14 +987,17 @@ impl FuseNode {
                 start_page_index.saturating_add(readaround_pages),
             ),
         );
+        let file_ctx = FillPagesFileCtx {
+            file_size,
+            fh,
+            file_flags,
+        };
         let (_, mut truncate_eof) = self.fill_page_cache_range_with_open(
             &page_cache,
             start_page_index,
             prefetch_end,
-            file_size,
-            fh,
-            file_flags,
             end_page_index + 1,
+            &file_ctx,
         )?;
         let observed_attr_version = self.attr_version();
 
@@ -1150,14 +1159,17 @@ impl FuseNode {
         let pages_to_read = core::cmp::min(max_pages, core::cmp::max(req_pages, 16));
         let end_page = core::cmp::min(last_file_page + 1, page_index.saturating_add(pages_to_read));
 
+        let file_ctx = FillPagesFileCtx {
+            file_size,
+            fh,
+            file_flags,
+        };
         let (total_read, truncate_eof) = self.fill_page_cache_range_with_open(
             &page_cache,
             page_index,
             end_page,
-            file_size,
-            fh,
-            file_flags,
             page_index.saturating_add(req_pages),
+            &file_ctx,
         )?;
 
         if let Some(eof) = truncate_eof {

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -20,7 +20,8 @@ use crate::{
 use super::super::{
     conn::{BackgroundReadPagesCtx, FuseRequestCred},
     private_data::{
-        FuseFilePrivateData, FuseOpenContext, FuseOpenPrivateData, FuseWritebackHandle,
+        FuseFilePrivateData, FuseOpenContext, FuseOpenLifetime, FuseOpenPrivateData,
+        FuseWritebackHandle,
     },
     protocol::{
         fuse_pack_struct, fuse_read_struct, FuseAttrOut, FuseFlushIn, FuseFsyncIn, FuseOpenIn,
@@ -44,6 +45,7 @@ struct FillPagesFileCtx {
     file_size: usize,
     fh: u64,
     file_flags: u32,
+    lifetime: Arc<FuseOpenLifetime>,
 }
 
 impl FusePageCacheBackend {
@@ -563,6 +565,7 @@ impl FuseNode {
                 open_context,
                 writeback_handle,
                 readahead_state: Arc::new(Mutex::new(FileReadaheadState::new())),
+                lifetime: Arc::new(FuseOpenLifetime::new()),
             })),
             FUSE_OPENDIR => FilePrivateData::Fuse(FuseFilePrivateData::Dir(FuseOpenPrivateData {
                 conn: conn_any,
@@ -574,6 +577,7 @@ impl FuseNode {
                 open_context,
                 writeback_handle: None,
                 readahead_state: Arc::new(Mutex::new(FileReadaheadState::new())),
+                lifetime: Arc::new(FuseOpenLifetime::new()),
             })),
             _ => return Err(SystemError::EINVAL),
         };
@@ -916,6 +920,13 @@ impl FuseNode {
                 padding: 0,
             };
             let speculative = run_start >= demand_end_page;
+            let Some(open_pin) = file_ctx.lifetime.try_pin() else {
+                let _ = target.rollback(SystemError::EIO);
+                if !speculative {
+                    submission_error = Some(SystemError::EIO);
+                }
+                break;
+            };
             let pending = self.conn().enqueue_background_read_pages(
                 self.nodeid,
                 fuse_pack_struct(&read_in),
@@ -928,6 +939,7 @@ impl FuseNode {
                     requested: read_len,
                     observed_size: file_ctx.file_size,
                     observed_attr_version,
+                    open_pin,
                 },
             );
             let pending = match pending {
@@ -1000,6 +1012,7 @@ impl FuseNode {
         fh: u64,
         file_flags: u32,
         ra_state: &Arc<Mutex<FileReadaheadState>>,
+        lifetime: Arc<FuseOpenLifetime>,
     ) -> Result<usize, SystemError> {
         let md = self.cached_or_fetch_metadata()?;
         let file_size = md.size.max(0) as usize;
@@ -1051,6 +1064,7 @@ impl FuseNode {
             file_size,
             fh,
             file_flags,
+            lifetime,
         };
         let (_, mut truncate_eof) = self.fill_page_cache_range_with_open(
             &page_cache,
@@ -1191,6 +1205,7 @@ impl FuseNode {
         ra_state: &mut FileReadaheadState,
         fh: u64,
         file_flags: u32,
+        lifetime: Arc<FuseOpenLifetime>,
     ) -> Result<usize, SystemError> {
         if req_pages == 0 {
             return Ok(0);
@@ -1225,6 +1240,7 @@ impl FuseNode {
             file_size,
             fh,
             file_flags,
+            lifetime,
         };
         let (total_read, truncate_eof) = self.fill_page_cache_range_with_open(
             &page_cache,

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -380,7 +380,8 @@ impl IndexNode for FuseNode {
             return Err(SystemError::EINVAL);
         }
         if len > 0 {
-            offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+            let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+            self.resolve_pending_short_read_truncate(end)?;
         }
         let private_data = Self::fuse_file_private_snapshot(&data)?;
         drop(data);
@@ -499,6 +500,9 @@ impl IndexNode for FuseNode {
     fn set_metadata(&self, metadata: &Metadata) -> Result<(), SystemError> {
         self.check_not_stale()?;
         let old = self.cached_or_fetch_metadata()?;
+        if metadata.size > old.size {
+            self.resolve_pending_short_read_truncate(metadata.size.max(0) as usize)?;
+        }
         let mut valid = 0u32;
         if metadata.mode != old.mode {
             valid |= FATTR_MODE;

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -357,7 +357,14 @@ impl IndexNode for FuseNode {
             return self.read_direct_with_open(offset, len, buf, fh, file_flags, lock_owner);
         }
 
-        self.read_cached_with_open(offset, len, buf, fh, file_flags)
+        self.read_cached_with_open(
+            offset,
+            len,
+            buf,
+            fh,
+            file_flags,
+            &private_data.readahead_state,
+        )
     }
 
     fn write_at(
@@ -655,11 +662,14 @@ impl IndexNode for FuseNode {
             .request(FUSE_FALLOCATE, self.nodeid, fuse_pack_struct(&in_arg))
         {
             Ok(_) => {
-                if let Some(md) = self.cached_metadata.lock().as_mut() {
+                let mut metadata = self.cached_metadata.lock();
+                if let Some(md) = metadata.as_mut() {
                     if new_size > md.size.max(0) as usize {
                         md.size = new_size as i64;
+                        self.bump_attr_version();
                     }
                 }
+                drop(metadata);
                 self.cached_metadata_deadline_ns.store(0, Ordering::Relaxed);
                 Ok(())
             }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -305,11 +305,13 @@ impl IndexNode for FuseNode {
                 if let Some(handle) = &p.writeback_handle {
                     self.unregister_writeback_handle(handle);
                 }
-                p.lifetime.close_and_wait();
                 if p.no_open {
                     return writeback_result;
                 }
-                self.release_common(FUSE_RELEASE, p.fh, p.open_flags, 0);
+                let node = self.self_ref.upgrade().ok_or(SystemError::EIO)?;
+                p.lifetime.close_or_defer(move || {
+                    node.release_common(FUSE_RELEASE, p.fh, p.open_flags, 0);
+                });
                 writeback_result
             }
             FuseFilePrivateData::Dir(p) => {
@@ -358,15 +360,7 @@ impl IndexNode for FuseNode {
             return self.read_direct_with_open(offset, len, buf, fh, file_flags, lock_owner);
         }
 
-        self.read_cached_with_open(
-            offset,
-            len,
-            buf,
-            fh,
-            file_flags,
-            &private_data.readahead_state,
-            private_data.lifetime.clone(),
-        )
+        self.read_cached_with_open(offset, len, buf, &private_data)
     }
 
     fn write_at(

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -305,6 +305,7 @@ impl IndexNode for FuseNode {
                 if let Some(handle) = &p.writeback_handle {
                     self.unregister_writeback_handle(handle);
                 }
+                p.lifetime.close_and_wait();
                 if p.no_open {
                     return writeback_result;
                 }
@@ -364,6 +365,7 @@ impl IndexNode for FuseNode {
             fh,
             file_flags,
             &private_data.readahead_state,
+            private_data.lifetime.clone(),
         )
     }
 

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -41,6 +41,58 @@ pub struct FuseOpenPrivateData {
     /// Per-open-file-description state. Cloning private data (dup/snapshots)
     /// keeps one shared sequential-read history.
     pub readahead_state: Arc<Mutex<FileReadaheadState>>,
+    pub lifetime: Arc<FuseOpenLifetime>,
+}
+
+#[derive(Debug)]
+pub struct FuseOpenLifetime {
+    closing: AtomicBool,
+    inflight: AtomicUsize,
+    wait_queue: WaitQueue,
+}
+
+impl FuseOpenLifetime {
+    pub fn new() -> Self {
+        Self {
+            closing: AtomicBool::new(false),
+            inflight: AtomicUsize::new(0),
+            wait_queue: WaitQueue::default(),
+        }
+    }
+
+    pub fn try_pin(self: &Arc<Self>) -> Option<FuseOpenLifetimePin> {
+        if self.closing.load(Ordering::Acquire) {
+            return None;
+        }
+        self.inflight.fetch_add(1, Ordering::AcqRel);
+        if self.closing.load(Ordering::Acquire) {
+            self.unpin();
+            return None;
+        }
+        Some(FuseOpenLifetimePin(self.clone()))
+    }
+
+    pub fn close_and_wait(&self) {
+        self.closing.store(true, Ordering::Release);
+        self.wait_queue.wait_until(|| {
+            (self.inflight.load(Ordering::Acquire) == 0).then_some(())
+        });
+    }
+
+    fn unpin(&self) {
+        if self.inflight.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.wait_queue.wake_all();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FuseOpenLifetimePin(Arc<FuseOpenLifetime>);
+
+impl Drop for FuseOpenLifetimePin {
+    fn drop(&mut self) {
+        self.0.unpin();
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
 use core::any::Any;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use system_error::SystemError;
@@ -44,11 +44,19 @@ pub struct FuseOpenPrivateData {
     pub lifetime: Arc<FuseOpenLifetime>,
 }
 
-#[derive(Debug)]
 pub struct FuseOpenLifetime {
     closing: AtomicBool,
     inflight: AtomicUsize,
-    wait_queue: WaitQueue,
+    deferred_release: Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>,
+}
+
+impl core::fmt::Debug for FuseOpenLifetime {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FuseOpenLifetime")
+            .field("closing", &self.closing.load(Ordering::Acquire))
+            .field("inflight", &self.inflight.load(Ordering::Acquire))
+            .finish()
+    }
 }
 
 impl FuseOpenLifetime {
@@ -56,7 +64,7 @@ impl FuseOpenLifetime {
         Self {
             closing: AtomicBool::new(false),
             inflight: AtomicUsize::new(0),
-            wait_queue: WaitQueue::default(),
+            deferred_release: Mutex::new(None),
         }
     }
 
@@ -72,16 +80,25 @@ impl FuseOpenLifetime {
         Some(FuseOpenLifetimePin(self.clone()))
     }
 
-    pub fn close_and_wait(&self) {
-        self.closing.store(true, Ordering::Release);
-        self.wait_queue.wait_until(|| {
-            (self.inflight.load(Ordering::Acquire) == 0).then_some(())
-        });
+    pub fn close_or_defer(&self, release: impl FnOnce() + Send + 'static) {
+        if self.closing.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let mut deferred = self.deferred_release.lock();
+        if self.inflight.load(Ordering::Acquire) == 0 {
+            drop(deferred);
+            release();
+        } else {
+            *deferred = Some(Box::new(release));
+        }
     }
 
     fn unpin(&self) {
         if self.inflight.fetch_sub(1, Ordering::AcqRel) == 1 {
-            self.wait_queue.wake_all();
+            let release = self.deferred_release.lock().take();
+            if let Some(release) = release {
+                release();
+            }
         }
     }
 }

--- a/kernel/src/filesystem/fuse/private_data.rs
+++ b/kernel/src/filesystem/fuse/private_data.rs
@@ -6,6 +6,7 @@ use system_error::SystemError;
 use crate::{
     filesystem::vfs::file::FileFlags,
     libs::{errseq::ErrSeqValue, mutex::Mutex, wait_queue::WaitQueue},
+    mm::readahead::FileReadaheadState,
 };
 
 use super::{
@@ -37,6 +38,9 @@ pub struct FuseOpenPrivateData {
     pub no_open: bool,
     pub open_context: FuseOpenContext,
     pub writeback_handle: Option<Arc<FuseWritebackHandle>>,
+    /// Per-open-file-description state. Cloning private data (dup/snapshots)
+    /// keeps one shared sequential-read history.
+    pub readahead_state: Arc<Mutex<FileReadaheadState>>,
 }
 
 #[derive(Debug, Clone)]

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -32,6 +32,15 @@ pub struct FuseStatsSnapshot {
     pub dev_fuse_input_copy_bytes_total: u64,
     pub virtiofs_compat_copy_count_total: u64,
     pub virtiofs_compat_copy_bytes_total: u64,
+    pub readahead_batches_total: u64,
+    pub readahead_requests_total: u64,
+    pub readahead_window_pages_total: u64,
+    pub readahead_window_pages_peak: u64,
+    pub readahead_short_reads_total: u64,
+    pub background_inflight_current: u64,
+    pub background_inflight_peak: u64,
+    pub background_max_blocked_total: u64,
+    pub background_congestion_skipped_total: u64,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -177,6 +186,43 @@ static DEV_FUSE_INPUT_COPY_COUNT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static DEV_FUSE_INPUT_COPY_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
 static VIRTIOFS_COMPAT_COPY_COUNT_TOTAL: AtomicU64 = AtomicU64::new(0);
 static VIRTIOFS_COMPAT_COPY_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static READAHEAD_BATCHES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static READAHEAD_REQUESTS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static READAHEAD_WINDOW_PAGES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static READAHEAD_WINDOW_PAGES_PEAK: AtomicU64 = AtomicU64::new(0);
+static READAHEAD_SHORT_READS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BACKGROUND_INFLIGHT_CURRENT: AtomicU64 = AtomicU64::new(0);
+static BACKGROUND_INFLIGHT_PEAK: AtomicU64 = AtomicU64::new(0);
+static BACKGROUND_MAX_BLOCKED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BACKGROUND_CONGESTION_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+pub fn on_readahead_batch(window_pages: usize, requests: usize) {
+    inc(&READAHEAD_BATCHES_TOTAL);
+    add(&READAHEAD_REQUESTS_TOTAL, requests as u64);
+    add(&READAHEAD_WINDOW_PAGES_TOTAL, window_pages as u64);
+    update_peak(&READAHEAD_WINDOW_PAGES_PEAK, window_pages as u64);
+}
+
+pub fn on_readahead_short_read() {
+    inc(&READAHEAD_SHORT_READS_TOTAL);
+}
+
+pub fn on_background_acquired() {
+    let current = BACKGROUND_INFLIGHT_CURRENT.fetch_add(1, Ordering::Relaxed) + 1;
+    update_peak(&BACKGROUND_INFLIGHT_PEAK, current);
+}
+
+pub fn on_background_released() {
+    saturating_sub(&BACKGROUND_INFLIGHT_CURRENT, 1);
+}
+
+pub fn on_background_pressure(speculative: bool) {
+    if speculative {
+        inc(&BACKGROUND_CONGESTION_SKIPPED_TOTAL);
+    } else {
+        inc(&BACKGROUND_MAX_BLOCKED_TOTAL);
+    }
+}
 
 static DEVICE_QUEUE_DEPTH_MAX: AtomicU64 = AtomicU64::new(0);
 static HIPRIO_VRING_SIZE_CONFIGURED: AtomicU64 = AtomicU64::new(0);
@@ -813,6 +859,16 @@ pub fn fuse_snapshot() -> FuseStatsSnapshot {
         dev_fuse_input_copy_bytes_total: DEV_FUSE_INPUT_COPY_BYTES_TOTAL.load(Ordering::Relaxed),
         virtiofs_compat_copy_count_total: VIRTIOFS_COMPAT_COPY_COUNT_TOTAL.load(Ordering::Relaxed),
         virtiofs_compat_copy_bytes_total: VIRTIOFS_COMPAT_COPY_BYTES_TOTAL.load(Ordering::Relaxed),
+        readahead_batches_total: READAHEAD_BATCHES_TOTAL.load(Ordering::Relaxed),
+        readahead_requests_total: READAHEAD_REQUESTS_TOTAL.load(Ordering::Relaxed),
+        readahead_window_pages_total: READAHEAD_WINDOW_PAGES_TOTAL.load(Ordering::Relaxed),
+        readahead_window_pages_peak: READAHEAD_WINDOW_PAGES_PEAK.load(Ordering::Relaxed),
+        readahead_short_reads_total: READAHEAD_SHORT_READS_TOTAL.load(Ordering::Relaxed),
+        background_inflight_current: BACKGROUND_INFLIGHT_CURRENT.load(Ordering::Relaxed),
+        background_inflight_peak: BACKGROUND_INFLIGHT_PEAK.load(Ordering::Relaxed),
+        background_max_blocked_total: BACKGROUND_MAX_BLOCKED_TOTAL.load(Ordering::Relaxed),
+        background_congestion_skipped_total: BACKGROUND_CONGESTION_SKIPPED_TOTAL
+            .load(Ordering::Relaxed),
     }
 }
 
@@ -920,6 +976,15 @@ dev_fuse_input_copy_count_total {}\n\
 dev_fuse_input_copy_bytes_total {}\n\
 virtiofs_compat_copy_count_total {}\n\
 virtiofs_compat_copy_bytes_total {}\n\
+readahead_batches_total {}\n\
+readahead_requests_total {}\n\
+readahead_window_pages_total {}\n\
+readahead_window_pages_peak {}\n\
+readahead_short_reads_total {}\n\
+background_inflight_current {}\n\
+background_inflight_peak {}\n\
+background_max_blocked_total {}\n\
+background_congestion_skipped_total {}\n\
 \n\
 [virtiofs]\n\
 device_queue_depth_max {}\n\
@@ -1011,6 +1076,15 @@ request_queue_full_total {}\n",
         fuse.dev_fuse_input_copy_bytes_total,
         fuse.virtiofs_compat_copy_count_total,
         fuse.virtiofs_compat_copy_bytes_total,
+        fuse.readahead_batches_total,
+        fuse.readahead_requests_total,
+        fuse.readahead_window_pages_total,
+        fuse.readahead_window_pages_peak,
+        fuse.readahead_short_reads_total,
+        fuse.background_inflight_current,
+        fuse.background_inflight_peak,
+        fuse.background_max_blocked_total,
+        fuse.background_congestion_skipped_total,
         virtiofs.device_queue_depth_max,
         virtiofs.hiprio_vring_size_configured,
         virtiofs.request_queue_count_configured,

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -3225,6 +3225,68 @@ fail:
     return -1;
 }
 
+static int ext_test_cached_read_pipelines_requests() {
+    const char *mp = "/tmp/test_fuse_read_pipeline";
+    const size_t data_size = 64 * 1024;
+    char *buf = NULL;
+    int n = -1;
+    int ok = 0;
+    if (ensure_dir(mp) != 0)
+        return -1;
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        rmdir(mp);
+        return -1;
+    }
+    volatile int stop = 0, init_done = 0, saw_pipeline = 0;
+    volatile uint32_t read_count = 0;
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.hello_generated_size_override = data_size;
+    args.read_count = &read_count;
+    args.defer_first_read_reply = 2;
+    args.saw_pipelined_read = &saw_pipeline;
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0)
+        goto fail_no_thread;
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0 || fuseg_wait_init(&init_done) != 0)
+        goto fail;
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    buf = (char *)malloc(data_size);
+    if (!buf)
+        goto fail;
+    n = fuseg_read_file(path, buf, 4096);
+    ok = n == 4096 && saw_pipeline && read_count >= 2;
+    for (size_t i = 0; ok && i < 4096; ++i)
+        ok = buf[i] == (char)('A' + (i % 26));
+    free(buf);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return ok ? 0 : -1;
+fail:
+    free(buf);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+fail_no_thread:
+    close(fd);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_cached_read_uses_open_fh_without_extra_open() {
     const char *mp = "/tmp/test_fuse_cached_read_fh";
     char path[256];
@@ -3416,9 +3478,11 @@ static int ext_test_cached_short_read_updates_eof() {
         goto fail;
     }
 
-    if (read_count != 1 || read_offsets[0] != 0 || read_sizes[0] != 4096) {
-        printf("[FAIL] short read trace count=%u off0=%llu size0=%u\n", read_count,
-               (unsigned long long)read_offsets[0], read_sizes[0]);
+    if (read_count < 2 || read_offsets[0] != 0 || read_sizes[0] != 4096 ||
+        read_offsets[1] != 4096 || read_sizes[1] != 4096) {
+        printf("[FAIL] short read trace count=%u off0=%llu size0=%u off1=%llu size1=%u\n",
+               read_count, (unsigned long long)read_offsets[0], read_sizes[0],
+               (unsigned long long)read_offsets[1], read_sizes[1]);
         goto fail;
     }
 
@@ -7745,6 +7809,10 @@ TEST(FuseExtended, PermissionModelAllowOtherDefaultPermissions) {
 
 TEST(FuseExtended, DevCloneAttachAndServe) {
     ASSERT_EQ(0, ext_test_clone());
+}
+
+TEST(FuseExtended, CachedReadPipelinesRequests) {
+    ASSERT_EQ(0, ext_test_cached_read_pipelines_requests());
 }
 
 int main(int argc, char **argv) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -3507,6 +3507,88 @@ fail:
     return -1;
 }
 
+static int ext_test_short_read_discards_old_pages_after_regrow() {
+    const char *mp = "/tmp/test_fuse_short_read_regrow";
+    char path[256];
+    int f = -1;
+    unsigned char byte = 0;
+    if (ensure_dir(mp) != 0)
+        return -1;
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0, init_done = 0;
+    volatile size_t visible_size = 8192;
+    volatile size_t watched_offset = 4096;
+    volatile unsigned char backend_byte = 'X';
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.hello_data_size_override = 8192;
+    args.dynamic_hello_read_size = &visible_size;
+    args.dynamic_hello_byte_offset = &watched_offset;
+    args.dynamic_hello_byte = &backend_byte;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0)
+        goto fail_no_thread;
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0 || fuseg_wait_init(&init_done) != 0)
+        goto fail;
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0)
+        goto fail;
+
+    if (pread(f, &byte, 1, 4096) != 1 || byte != 'X')
+        goto fail;
+
+    backend_byte = 'Y';
+    visible_size = 5;
+    if (pread(f, &byte, 1, 0) != 1 || byte != 'A')
+        goto fail;
+
+    visible_size = 8192;
+    if (ftruncate(f, 8192) != 0)
+        goto fail;
+    byte = 0;
+    if (pread(f, &byte, 1, 4096) != 1 || byte != 'Y') {
+        printf("[FAIL] regrown read returned stale byte=%u expected=%u errno=%d\n", byte, 'Y',
+               errno);
+        goto fail;
+    }
+
+    close(f);
+    f = -1;
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+fail:
+    if (f >= 0)
+        close(f);
+    umount(mp);
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+fail_no_thread:
+    close(fd);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_cached_read_sees_write_through_update() {
     const char *mp = "/tmp/test_fuse_cached_read_write";
     char path[256];
@@ -7620,6 +7702,10 @@ TEST(FuseExtended, CachedReadUsesOpenFhWithoutExtraOpen) {
 
 TEST(FuseExtended, CachedShortReadUpdatesEof) {
     ASSERT_EQ(0, ext_test_cached_short_read_updates_eof());
+}
+
+TEST(FuseExtended, ShortReadDiscardsOldPagesAfterRegrow) {
+    ASSERT_EQ(0, ext_test_short_read_discards_old_pages_after_regrow());
 }
 
 TEST(FuseExtended, CachedReadSeesWriteThroughUpdate) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -817,6 +817,11 @@ struct fuse_daemon_args {
     int force_getxattr_erange_at_max;
     int force_listxattr_erange_at_max;
     int block_read_until_interrupt;
+    int defer_first_read_reply;
+    volatile int *saw_pipelined_read;
+    uint64_t deferred_read_unique;
+    uint64_t deferred_read_offset;
+    uint32_t deferred_read_size;
     size_t hello_data_size_override;
     size_t hello_read_size_override;
     size_t hello_generated_size_override;
@@ -1142,6 +1147,42 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         size_t to_copy = in->size;
         if (to_copy > remain) {
             to_copy = remain;
+        }
+        if (generated_hello && a->defer_first_read_reply) {
+            if (a->deferred_read_unique == 0) {
+                a->deferred_read_unique = h->unique;
+                a->deferred_read_offset = in->offset;
+                a->deferred_read_size = (uint32_t)to_copy;
+                return 0;
+            }
+            if (a->saw_pipelined_read) {
+                *a->saw_pipelined_read = 1;
+            }
+            unsigned char *current = (unsigned char *)malloc(to_copy);
+            unsigned char *first = (unsigned char *)malloc(a->deferred_read_size);
+            if (!current || !first) {
+                free(current);
+                free(first);
+                return -1;
+            }
+            for (size_t i = 0; i < to_copy; i++)
+                current[i] = (unsigned char)('A' + ((in->offset + i) % 26));
+            for (size_t i = 0; i < a->deferred_read_size; i++)
+                first[i] = (unsigned char)('A' + ((a->deferred_read_offset + i) % 26));
+            int ret;
+            if (a->defer_first_read_reply == 2) {
+                ret = fuse_write_reply(a->fd, a->deferred_read_unique, 0, first,
+                                       a->deferred_read_size);
+            } else {
+                ret = fuse_write_reply(a->fd, h->unique, 0, current, to_copy);
+                if (ret == 0)
+                    ret = fuse_write_reply(a->fd, a->deferred_read_unique, 0, first,
+                                           a->deferred_read_size);
+            }
+            free(current);
+            free(first);
+            a->deferred_read_unique = 0;
+            return ret;
         }
         if (generated_hello) {
             unsigned char *generated = (unsigned char *)malloc(to_copy);

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -708,6 +708,9 @@ struct fuse_daemon_args {
     uint32_t hello_open_out_flags;
     volatile uint32_t *dynamic_hello_open_out_flags;
     volatile unsigned char *dynamic_hello_first_byte;
+    volatile size_t *dynamic_hello_read_size;
+    volatile size_t *dynamic_hello_byte_offset;
+    volatile unsigned char *dynamic_hello_byte;
     volatile uint32_t *forget_count;
     volatile uint64_t *forget_nlookup_sum;
     volatile uint64_t *forget_trace_nodeids;
@@ -1131,9 +1134,11 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (generated_hello) {
             effective_size = a->hello_generated_size_override;
         }
-        if (h->nodeid == 2 && a->hello_read_size_override > 0
-            && a->hello_read_size_override < effective_size) {
-            effective_size = a->hello_read_size_override;
+        size_t read_size_override = a->dynamic_hello_read_size
+                                        ? *a->dynamic_hello_read_size
+                                        : a->hello_read_size_override;
+        if (h->nodeid == 2 && read_size_override > 0 && read_size_override < effective_size) {
+            effective_size = read_size_override;
         }
         if (in->offset >= effective_size) {
             return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
@@ -1142,6 +1147,10 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             && *a->dynamic_hello_first_byte != 0
             && node->size > 0) {
             node->data[0] = *a->dynamic_hello_first_byte;
+        }
+        if (!generated_hello && h->nodeid == 2 && a->dynamic_hello_byte_offset
+            && a->dynamic_hello_byte && *a->dynamic_hello_byte_offset < node->size) {
+            node->data[*a->dynamic_hello_byte_offset] = *a->dynamic_hello_byte;
         }
         size_t remain = effective_size - (size_t)in->offset;
         size_t to_copy = in->size;

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -500,33 +500,48 @@ struct WorkerArg {
     uint64_t bytes;
     uint64_t ops;
     bool started;
+    bool read_only;
 };
 
 void* worker_main(void* raw) {
     WorkerArg* arg = static_cast<WorkerArg*>(raw);
     std::vector<char> buf(arg->opt.block_size, static_cast<char>('A' + (arg->id % 26)));
-    std::string p = path_join(arg->root, "worker_" + std::to_string(arg->id) + ".dat");
-    int fd = open(p.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0644);
+    std::string p = arg->read_only
+                        ? path_join(arg->root, "concurrent_read.dat")
+                        : path_join(arg->root, "worker_" + std::to_string(arg->id) + ".dat");
+    int fd = open(p.c_str(), arg->read_only ? O_RDONLY : (O_CREAT | O_TRUNC | O_RDWR), 0644);
     if (fd < 0) {
         arg->err = errno;
         return nullptr;
     }
     for (size_t i = 0; i < arg->opt.iterations; ++i) {
-        if (!write_full(fd, buf.data(), buf.size())) {
-            arg->err = errno_or_eio();
-            break;
+        if (arg->read_only) {
+            size_t span = arg->opt.file_size > buf.size() ? arg->opt.file_size - buf.size() : 0;
+            off_t off = span == 0 ? 0 : static_cast<off_t>((i * buf.size()) % span);
+            ssize_t n = pread(fd, buf.data(), buf.size(), off);
+            if (n < 0) {
+                arg->err = errno;
+                break;
+            }
+            arg->bytes += static_cast<uint64_t>(n);
+        } else {
+            if (!write_full(fd, buf.data(), buf.size())) {
+                arg->err = errno_or_eio();
+                break;
+            }
+            arg->bytes += buf.size();
         }
-        arg->bytes += buf.size();
         ++arg->ops;
     }
-    if (arg->err == 0) {
+    if (!arg->read_only && arg->err == 0) {
         fsync_preserve_error(fd, &arg->err);
     }
     close_preserve_error(fd, &arg->err);
     return nullptr;
 }
 
-int concurrent_workload(const Options& opt, const std::string& root) {
+static int run_concurrent_phase(const Options& opt, const std::string& root, bool read_only,
+                                const char* label) {
     std::vector<pthread_t> threads(opt.workers);
     std::vector<WorkerArg> args(opt.workers);
     uint64_t start = now_us();
@@ -538,6 +553,7 @@ int concurrent_workload(const Options& opt, const std::string& root) {
         args[i].bytes = 0;
         args[i].ops = 0;
         args[i].started = false;
+        args[i].read_only = read_only;
         int rc = pthread_create(&threads[i], nullptr, worker_main, &args[i]);
         if (rc != 0) {
             args[i].err = rc;
@@ -562,8 +578,29 @@ int concurrent_workload(const Options& opt, const std::string& root) {
             err = args[i].err;
         }
     }
-    emit_result("concurrent_write", opt, now_us() - start, bytes, ops, err);
+    emit_result(label, opt, now_us() - start, bytes, ops, err);
     return err == 0 ? 0 : -1;
+}
+
+int concurrent_workload(const Options& opt, const std::string& root) {
+    int rc = run_concurrent_phase(opt, root, false, "concurrent_write");
+    std::string path = path_join(root, "concurrent_read.dat");
+    std::vector<char> block(opt.block_size, 'R');
+    int fd = open(path.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0644);
+    if (fd < 0)
+        return -1;
+    for (size_t done = 0; done < opt.file_size;) {
+        size_t len = std::min(block.size(), opt.file_size - done);
+        if (!write_full(fd, block.data(), len)) {
+            close(fd);
+            return -1;
+        }
+        done += len;
+    }
+    fsync(fd);
+    close(fd);
+    rc |= run_concurrent_phase(opt, root, true, "concurrent_read");
+    return rc;
 }
 
 void usage(const char* argv0) {


### PR DESCRIPTION
## Summary

- negotiate and enforce FUSE `max_background` and congestion thresholds with completion-owned credits
- pipeline cached READ requests while allowing purely speculative readahead to complete independently of foreground demand
- preserve page-cache DMA, interrupt, abort, short-read EOF, attribute-generation, and direct-I/O invariants
- expose readahead/background pressure metrics and add sequential/concurrent read benchmark coverage
- add a controllable FUSE regression proving a demand read completes while a speculative request remains outstanding

## Root cause

Cached FUSE reads split ranges into bounded requests but waited for each request before submitting the next one. The fixed readaround window therefore produced at most one outstanding READ and did not honor negotiated background/congestion limits.

## Validation

- `make kernel`
- built `fuse_extended_test` and `virtiofs_bench`
- QEMU guest: `FuseExtended.CachedReadPipelinesRequests`
- QEMU guest: `FuseExtended.CachedShortReadUpdatesEof`
- QEMU guest: full `FuseExtended` suite, 56/56 passed
- QEMU guest: `FuseStatsDebugFs.StatsFileExistsAndSupportsOffsetReads`

Closes #2016
