### PR TITLE
feat(fuse): implement writeback cache semantics

### DIFF
--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -34,7 +34,7 @@ use super::protocol::{
     FUSE_FSYNCDIR, FUSE_GETXATTR, FUSE_HANDLE_KILLPRIV, FUSE_INIT_EXT, FUSE_INTERRUPT,
     FUSE_LISTXATTR, FUSE_MAX_PAGES, FUSE_NO_OPENDIR_SUPPORT, FUSE_NO_OPEN_SUPPORT,
     FUSE_PARALLEL_DIROPS, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO,
-    FUSE_REMOVEXATTR, FUSE_SETXATTR, FUSE_SUBMOUNTS,
+    FUSE_REMOVEXATTR, FUSE_SETXATTR, FUSE_SUBMOUNTS, FUSE_WRITEBACK_CACHE,
 };
 use super::reply::{FuseReadPagesReply, FuseReply};
 use super::{stats, trace};
@@ -573,6 +573,7 @@ struct FuseConnInner {
 pub struct FuseConn {
     inner: Mutex<FuseConnInner>,
     next_unique: AtomicU64,
+    attr_epoch: AtomicU64,
     dev_count: AtomicUsize,
     read_wait: WaitQueue,
     init_wait: WaitQueue,
@@ -657,6 +658,7 @@ impl FuseConn {
             }),
             // Use non-zero unique, keep even IDs for "ordinary" requests as Linux does.
             next_unique: AtomicU64::new(2),
+            attr_epoch: AtomicU64::new(1),
             dev_count: AtomicUsize::new(1),
             read_wait: WaitQueue::default(),
             init_wait: WaitQueue::default(),
@@ -675,6 +677,16 @@ impl FuseConn {
 
     pub fn is_connected(&self) -> bool {
         self.inner.lock().connected
+    }
+
+    pub(crate) fn sample_attr_epoch(&self) -> u64 {
+        self.attr_epoch.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn next_attr_epoch(&self) -> u64 {
+        self.attr_epoch
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1)
     }
 
     pub fn has_pending_requests(&self) -> bool {
@@ -1067,10 +1079,10 @@ impl FuseConn {
             | FUSE_MAX_PAGES
             | FUSE_EXPLICIT_INVAL_DATA
             | FUSE_INIT_EXT
+            | FUSE_WRITEBACK_CACHE
     }
 
     /// virtiofs uses the normal FUSE capability request plus Linux's submount bit.
-    /// WRITEBACK_CACHE is not requested until DragonOS has complete writeback-cache semantics.
     fn virtiofs_init_flags() -> u64 {
         Self::kernel_init_flags() | FUSE_SUBMOUNTS
     }

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -231,18 +231,17 @@ impl FuseFS {
                         n.set_generation(gen);
                         n.set_parent_nodeid(parent_nodeid);
                         n.set_parent_if_absent(parent);
-                        if let Some(md) = cached {
-                            n.set_cached_metadata(md);
-                        }
+                        // Attribute replies for an existing inode must be
+                        // installed by the caller through its daemon-attribute
+                        // merge path.  Installing `cached` here would roll
+                        // back locally authoritative writeback-cache fields
+                        // before the caller gets a chance to preserve them.
                         n.inc_lookup(lookup_refs);
                         return Ok(n);
                     }
                 } else {
                     n.set_parent_nodeid(parent_nodeid);
                     n.set_parent_if_absent(parent);
-                    if let Some(md) = cached {
-                        n.set_cached_metadata(md);
-                    }
                     n.inc_lookup(lookup_refs);
                     return Ok(n);
                 }
@@ -305,17 +304,13 @@ impl FuseFS {
                     } else {
                         n.set_generation(gen);
                         n.set_parent_if_absent(parent);
-                        if let Some(md) = cached {
-                            n.set_cached_metadata(md);
-                        }
+                        // See get_or_create_node_with_generation(): callers own
+                        // daemon-attribute merging for reused inode identities.
                         n.inc_lookup(lookup_refs);
                         return Ok(n);
                     }
                 } else {
                     n.set_parent_if_absent(parent);
-                    if let Some(md) = cached {
-                        n.set_cached_metadata(md);
-                    }
                     n.inc_lookup(lookup_refs);
                     return Ok(n);
                 }

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -757,10 +757,20 @@ impl FileSystem for FuseFS {
             p.node.clone()
         };
 
-        let Ok(_pin) = node.pin_writeback_handle() else {
-            return VmFaultReason::VM_FAULT_SIGBUS;
-        };
-        PageFaultHandler::filemap_page_mkwrite(pfm)
+        node.with_writeback_admission(|| {
+            let Ok(_pin) = node.pin_writeback_handle() else {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            };
+            let result = PageFaultHandler::filemap_page_mkwrite(pfm);
+            if !result.intersects(
+                VmFaultReason::VM_FAULT_SIGBUS
+                    | VmFaultReason::VM_FAULT_OOM
+                    | VmFaultReason::VM_FAULT_RETRY,
+            ) {
+                node.note_mmap_write();
+            }
+            result
+        })
     }
 
     fn mprotect(&self, _old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -230,7 +230,9 @@ impl FuseNode {
                 md = local.clone();
             }
         }
-        if self.conn.has_init_flag(super::protocol::FUSE_WRITEBACK_CACHE)
+        if self
+            .conn
+            .has_init_flag(super::protocol::FUSE_WRITEBACK_CACHE)
             && md.file_type == FileType::File
         {
             if let Some(local) = metadata.as_ref() {
@@ -242,15 +244,14 @@ impl FuseNode {
         *metadata = Some(md.clone());
         self.bump_attr_version();
         drop(metadata);
-        self.cached_metadata_deadline_ns
-            .store(
-                if stale_reply {
-                    0
-                } else {
-                    Self::cache_deadline(valid, valid_nsec)
-                },
-                Ordering::Relaxed,
-            );
+        self.cached_metadata_deadline_ns.store(
+            if stale_reply {
+                0
+            } else {
+                Self::cache_deadline(valid, valid_nsec)
+            },
+            Ordering::Relaxed,
+        );
         md
     }
 

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -21,6 +21,7 @@ use crate::{
         vfs::{FileType, InodeFlags, InodeId, InodeMode, Metadata},
     },
     libs::mutex::Mutex,
+    libs::rwsem::RwSem,
     time::PosixTimeSpec,
 };
 
@@ -48,7 +49,9 @@ pub struct FuseNode {
     page_cache: Mutex<Option<Arc<PageCache>>>,
     writeback_handles: Mutex<Vec<Arc<FuseWritebackHandle>>>,
     lookup_cache: Mutex<BTreeMap<String, FuseLookupCacheEntry>>,
-    direct_io_lock: Mutex<()>,
+    /// Serializes dirty-page admission against operations which must drain and
+    /// invalidate the page cache (truncate and direct I/O).
+    writeback_barrier: RwSem<()>,
     cached_metadata_deadline_ns: AtomicU64,
     attr_version: AtomicU64,
     /// Version chain produced while short READ replies from one metadata
@@ -89,6 +92,7 @@ impl FuseNode {
         cached: Option<Metadata>,
     ) -> Arc<Self> {
         let has_cached = cached.is_some();
+        let initial_attr_epoch = conn.sample_attr_epoch();
         Arc::new_cyclic(|self_ref| Self {
             fs,
             conn,
@@ -101,9 +105,9 @@ impl FuseNode {
             page_cache: Mutex::new(None),
             writeback_handles: Mutex::new(Vec::new()),
             lookup_cache: Mutex::new(BTreeMap::new()),
-            direct_io_lock: Mutex::new(()),
+            writeback_barrier: RwSem::new(()),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
-            attr_version: AtomicU64::new(1),
+            attr_version: AtomicU64::new(initial_attr_epoch),
             short_read_source_attr_version: AtomicU64::new(0),
             short_read_chain_attr_version: AtomicU64::new(0),
             pending_short_read_eof: AtomicU64::new(u64::MAX),
@@ -209,15 +213,54 @@ impl FuseNode {
             .store(Self::cache_deadline(valid, valid_nsec), Ordering::Relaxed);
     }
 
+    /// Install an unsolicited/lookup/getattr daemon attribute snapshot.
+    /// With writeback cache negotiated, locally maintained size and cmtime are
+    /// authoritative and must not be rolled back by a stale daemon reply.
+    pub(crate) fn merge_cached_metadata_from_daemon(
+        &self,
+        mut md: Metadata,
+        valid: u64,
+        valid_nsec: u32,
+        request_epoch: u64,
+    ) -> Metadata {
+        let mut metadata = self.cached_metadata.lock();
+        let stale_reply = self.attr_version() > request_epoch;
+        if stale_reply {
+            if let Some(local) = metadata.as_ref() {
+                md = local.clone();
+            }
+        }
+        if self.conn.has_init_flag(super::protocol::FUSE_WRITEBACK_CACHE)
+            && md.file_type == FileType::File
+        {
+            if let Some(local) = metadata.as_ref() {
+                md.size = local.size;
+                md.mtime = local.mtime;
+                md.ctime = local.ctime;
+            }
+        }
+        *metadata = Some(md.clone());
+        self.bump_attr_version();
+        drop(metadata);
+        self.cached_metadata_deadline_ns
+            .store(
+                if stale_reply {
+                    0
+                } else {
+                    Self::cache_deadline(valid, valid_nsec)
+                },
+                Ordering::Relaxed,
+            );
+        md
+    }
+
     pub(crate) fn attr_version(&self) -> u64 {
         self.attr_version.load(Ordering::Acquire)
     }
 
     pub(crate) fn bump_attr_version(&self) -> u64 {
-        let version = self
-            .attr_version
-            .fetch_add(1, Ordering::AcqRel)
-            .wrapping_add(1);
+        let version = self.conn.next_attr_epoch();
+        self.attr_version.store(version, Ordering::Release);
         if version == 0 {
             self.short_read_source_attr_version
                 .store(u64::MAX, Ordering::Release);
@@ -385,6 +428,7 @@ impl FuseNode {
 
     fn fetch_attr(&self) -> Result<Metadata, SystemError> {
         self.check_not_stale()?;
+        let request_epoch = self.conn.sample_attr_epoch();
         let getattr_in = FuseGetattrIn {
             getattr_flags: 0,
             dummy: 0,
@@ -395,8 +439,12 @@ impl FuseNode {
                 .request(FUSE_GETATTR, self.nodeid, fuse_pack_struct(&getattr_in))?;
         let out: FuseAttrOut = fuse_read_struct(&payload)?;
         let md = Self::attr_to_metadata(&out.attr);
-        self.set_cached_metadata_with_valid(md.clone(), out.attr_valid, out.attr_valid_nsec);
-        Ok(md)
+        Ok(self.merge_cached_metadata_from_daemon(
+            md,
+            out.attr_valid,
+            out.attr_valid_nsec,
+            request_epoch,
+        ))
     }
 
     fn cached_or_fetch_metadata(&self) -> Result<Metadata, SystemError> {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -195,15 +195,6 @@ impl FuseNode {
         self.cached_metadata.lock().as_ref().map(|md| md.file_type)
     }
 
-    pub fn set_cached_metadata(&self, md: Metadata) {
-        let mut metadata = self.cached_metadata.lock();
-        *metadata = Some(md);
-        self.bump_attr_version();
-        drop(metadata);
-        self.cached_metadata_deadline_ns
-            .store(u64::MAX, Ordering::Relaxed);
-    }
-
     pub fn set_cached_metadata_with_valid(&self, md: Metadata, valid: u64, valid_nsec: u32) {
         let mut metadata = self.cached_metadata.lock();
         *metadata = Some(md);

--- a/kernel/src/filesystem/fuse/inode/directory.rs
+++ b/kernel/src/filesystem/fuse/inode/directory.rs
@@ -177,7 +177,7 @@ impl FuseNode {
         (base_len + Self::FUSE_DIRENT_ALIGN - 1) & !(Self::FUSE_DIRENT_ALIGN - 1)
     }
 
-    fn cache_child_from_entry(&self, entry: &FuseEntryOut, name: &str) {
+    fn cache_child_from_entry(&self, entry: &FuseEntryOut, name: &str, request_epoch: u64) {
         let mut consumed = false;
         let result = (|| {
             let md = Self::metadata_from_valid_entry(entry, SystemError::EIO, None)?;
@@ -195,7 +195,12 @@ impl FuseNode {
             )?;
             consumed = true;
             child.set_dname(name);
-            child.set_cached_metadata_with_valid(md, entry.attr_valid, entry.attr_valid_nsec);
+            child.merge_cached_metadata_from_daemon(
+                md,
+                entry.attr_valid,
+                entry.attr_valid_nsec,
+                request_epoch,
+            );
             self.cache_lookup_child(
                 name,
                 &child,
@@ -215,6 +220,7 @@ impl FuseNode {
         payload: &[u8],
         names: &mut Vec<String>,
         mut last_off: u64,
+        request_epoch: u64,
     ) -> Result<u64, SystemError> {
         let mut pos: usize = 0;
         while pos + size_of::<FuseDirentPlus>() <= payload.len() {
@@ -230,7 +236,7 @@ impl FuseNode {
             if let Ok(name) = core::str::from_utf8(name_bytes) {
                 if !name.is_empty() && name != "." && name != ".." {
                     names.push(name.to_string());
-                    self.cache_child_from_entry(&plus.entry_out, name);
+                    self.cache_child_from_entry(&plus.entry_out, name, request_epoch);
                 }
             } else if plus.entry_out.nodeid != 0 {
                 let _ = self.conn.queue_forget(plus.entry_out.nodeid, 1);
@@ -334,7 +340,12 @@ impl FuseNode {
                 );
             }
             consumed = true;
-            child.set_cached_metadata_with_valid(md, entry.attr_valid, entry.attr_valid_nsec);
+            child.merge_cached_metadata_from_daemon(
+                md,
+                entry.attr_valid,
+                entry.attr_valid_nsec,
+                self.conn.sample_attr_epoch(),
+            );
             Ok(child as Arc<dyn IndexNode>)
         })();
         if result.is_err() && entry.nodeid != 0 && !consumed {

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -112,10 +112,7 @@ impl FuseNode {
             .checked_add(data.len())
             .ok_or(SystemError::EOVERFLOW)?;
         let page_cache = self.ensure_page_cache()?;
-        let file_size = self
-            .cached_or_fetch_metadata()?
-            .size
-            .max(0) as usize;
+        let file_size = self.cached_or_fetch_metadata()?.size.max(0) as usize;
         let start_page = offset >> MMArch::PAGE_SHIFT;
         let end_page = (end - 1) >> MMArch::PAGE_SHIFT;
 
@@ -129,8 +126,8 @@ impl FuseNode {
             let page_start = page_index << MMArch::PAGE_SHIFT;
             let write_start = core::cmp::max(offset, page_start);
             let write_end = core::cmp::min(end, page_start + MMArch::PAGE_SIZE);
-            let full_overwrite = write_start == page_start
-                && write_end - write_start == MMArch::PAGE_SIZE;
+            let full_overwrite =
+                write_start == page_start && write_end - write_start == MMArch::PAGE_SIZE;
             if full_overwrite || page_cache.manager().peek_page(page_index).is_some() {
                 continue;
             }
@@ -148,9 +145,11 @@ impl FuseNode {
             {
                 return Err(SystemError::ESTALE);
             }
-            let _ = page_cache.manager().commit_page_with(page_index, |idx, dst| {
-                self.read_page_with_open(idx, dst, open.fh, open.open_flags)
-            })?;
+            let _ = page_cache
+                .manager()
+                .commit_page_with(page_index, |idx, dst| {
+                    self.read_page_with_open(idx, dst, open.fh, open.open_flags)
+                })?;
         }
 
         let written = page_cache.write(offset, data)?;

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -327,6 +327,13 @@ impl FuseNode {
         observed_size: usize,
         observed_attr_version: u64,
     ) -> Result<(usize, bool), SystemError> {
+        // Linux fuse_short_read() treats a short daemon read as a hole when
+        // writeback-cache is active. Local i_size may include dirty sparse
+        // extensions that the daemon has not observed yet, so shrinking it
+        // here could discard valid dirty pages beyond the hole.
+        if self.conn().has_init_flag(FUSE_WRITEBACK_CACHE) {
+            return Ok((observed_size, false));
+        }
         let eof = page_index
             .checked_mul(MMArch::PAGE_SIZE)
             .and_then(|start| start.checked_add(read_len))
@@ -1226,7 +1233,8 @@ impl FuseNode {
             }
             dst_offset += copy_len;
 
-            if filled_len.is_some_and(|read_len| read_len < MMArch::PAGE_SIZE)
+            if (!self.conn().has_init_flag(FUSE_WRITEBACK_CACHE)
+                && filled_len.is_some_and(|read_len| read_len < MMArch::PAGE_SIZE))
                 || current_size <= page_end
             {
                 break;

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     libs::mutex::Mutex,
     mm::{readahead::FileReadaheadState, MemoryManagementArch},
+    time::PosixTimeSpec,
 };
 
 use super::super::{
@@ -81,6 +82,82 @@ impl PageCacheBackend for FusePageCacheBackend {
 }
 
 impl FuseNode {
+    pub(crate) fn with_writeback_admission<T>(&self, f: impl FnOnce() -> T) -> T {
+        let _guard = self.writeback_barrier.read();
+        f()
+    }
+
+    pub(crate) fn note_mmap_write(&self) {
+        if !self.conn().has_init_flag(FUSE_WRITEBACK_CACHE) {
+            return;
+        }
+        let now = PosixTimeSpec::now();
+        if let Some(md) = self.cached_metadata.lock().as_mut() {
+            md.mtime = now;
+            md.ctime = now;
+            self.bump_attr_version();
+        }
+    }
+
+    pub(super) fn writeback_cache_write(
+        &self,
+        offset: usize,
+        data: &[u8],
+        open: &FuseOpenPrivateData,
+    ) -> Result<usize, SystemError> {
+        if data.is_empty() {
+            return Ok(0);
+        }
+        let end = offset
+            .checked_add(data.len())
+            .ok_or(SystemError::EOVERFLOW)?;
+        let page_cache = self.ensure_page_cache()?;
+        let file_size = self
+            .cached_or_fetch_metadata()?
+            .size
+            .max(0) as usize;
+        let start_page = offset >> MMArch::PAGE_SHIFT;
+        let end_page = (end - 1) >> MMArch::PAGE_SHIFT;
+
+        page_cache
+            .manager()
+            .wait_writeback_range(start_page, end_page)?;
+
+        // Keep the open request context alive while partial pages are filled.
+        let _lifetime = open.lifetime.clone();
+        for page_index in start_page..=end_page {
+            let page_start = page_index << MMArch::PAGE_SHIFT;
+            let write_start = core::cmp::max(offset, page_start);
+            let write_end = core::cmp::min(end, page_start + MMArch::PAGE_SIZE);
+            let full_overwrite = write_start == page_start
+                && write_end - write_start == MMArch::PAGE_SIZE;
+            if full_overwrite || page_cache.manager().peek_page(page_index).is_some() {
+                continue;
+            }
+
+            if page_start >= file_size {
+                let _ = page_cache.manager().commit_overwrite(page_index)?;
+                continue;
+            }
+
+            self.check_not_stale()?;
+            let generation = self.generation();
+            if open.open_context.node_generation != 0
+                && generation != 0
+                && open.open_context.node_generation != generation
+            {
+                return Err(SystemError::ESTALE);
+            }
+            let _ = page_cache.manager().commit_page_with(page_index, |idx, dst| {
+                self.read_page_with_open(idx, dst, open.fh, open.open_flags)
+            })?;
+        }
+
+        let written = page_cache.write(offset, data)?;
+        self.note_successful_write(offset, written)?;
+        Ok(written)
+    }
+
     pub(super) fn max_pages_bytes(&self) -> usize {
         core::cmp::max(1, self.conn().max_pages()).saturating_mul(MMArch::PAGE_SIZE)
     }
@@ -145,6 +222,12 @@ impl FuseNode {
     ) -> Result<(), SystemError> {
         self.check_not_stale()?;
         self.resolve_pending_short_read_truncate(len)?;
+        // Drain once before taking the exclusive admission barrier to reduce
+        // hold time, then drain again under the barrier to close the race with
+        // buffered writes and page_mkwrite.
+        self.sync_dirty_cached_pages()?;
+        let _barrier = self.writeback_barrier.write();
+        self.sync_dirty_cached_pages()?;
         let mut valid = FATTR_SIZE;
         if lock_owner.is_some() {
             valid |= FATTR_LOCKOWNER;
@@ -386,9 +469,6 @@ impl FuseNode {
         let Some(page_cache) = self.cached_page_cache() else {
             return Ok(());
         };
-        if !page_cache.has_dirty_pages() {
-            return Ok(());
-        }
         page_cache.manager().sync()
     }
 
@@ -515,7 +595,6 @@ impl FuseNode {
             if out.size as usize != chunk {
                 return Err(SystemError::EIO);
             }
-            self.note_successful_write(offset, chunk)?;
             total += chunk;
         }
 
@@ -1338,6 +1417,11 @@ impl FuseNode {
         if let Some(md) = metadata.as_mut() {
             if end > md.size.max(0) as usize {
                 md.size = end as i64;
+            }
+            if self.conn().has_init_flag(FUSE_WRITEBACK_CACHE) {
+                let now = PosixTimeSpec::now();
+                md.mtime = now;
+                md.ctime = now;
             }
         }
         // Every successful write is a mutation fence for READ replies issued

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -116,10 +116,6 @@ impl FuseNode {
         let start_page = offset >> MMArch::PAGE_SHIFT;
         let end_page = (end - 1) >> MMArch::PAGE_SHIFT;
 
-        page_cache
-            .manager()
-            .wait_writeback_range(start_page, end_page)?;
-
         // Keep the open request context alive while partial pages are filled.
         let _lifetime = open.lifetime.clone();
         for page_index in start_page..=end_page {
@@ -128,12 +124,20 @@ impl FuseNode {
             let write_end = core::cmp::min(end, page_start + MMArch::PAGE_SIZE);
             let full_overwrite =
                 write_start == page_start && write_end - write_start == MMArch::PAGE_SIZE;
-            if full_overwrite || page_cache.manager().peek_page(page_index).is_some() {
+            if full_overwrite {
+                let _ = page_cache
+                    .manager()
+                    .commit_overwrite_for_write(page_index)?;
+                continue;
+            }
+            if page_cache.manager().peek_page(page_index).is_some() {
                 continue;
             }
 
             if page_start >= file_size {
-                let _ = page_cache.manager().commit_overwrite(page_index)?;
+                let _ = page_cache
+                    .manager()
+                    .commit_overwrite_for_write(page_index)?;
                 continue;
             }
 
@@ -147,7 +151,7 @@ impl FuseNode {
             }
             let _ = page_cache
                 .manager()
-                .commit_page_with(page_index, |idx, dst| {
+                .commit_page_for_write_with(page_index, |idx, dst| {
                     self.read_page_with_open(idx, dst, open.fh, open.open_flags)
                 })?;
         }
@@ -495,7 +499,12 @@ impl FuseNode {
         data: &FuseOpenPrivateData,
         lock_owner: u64,
     ) -> Result<(), SystemError> {
-        let writeback_result = if data.writeback_handle.is_some() {
+        // Linux fuse_flush() drains inode writeback even when this particular
+        // descriptor is read-only: another writable open may have admitted
+        // dirty data for the same inode.
+        let writeback_cache = self.conn().has_init_flag(FUSE_WRITEBACK_CACHE);
+        let _barrier = writeback_cache.then(|| self.writeback_barrier.write());
+        let writeback_result = if writeback_cache {
             self.sync_dirty_cached_pages()
         } else {
             Ok(())

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -152,8 +152,13 @@ impl FuseNode {
                 })?;
         }
 
-        let written = page_cache.write(offset, data)?;
-        self.note_successful_write(offset, written)?;
+        // Linux fuse_write_end() publishes the extended i_size before marking
+        // the page dirty. Preserve the same invariant: writeback calculates
+        // the last-page length from cached metadata, so it must never observe
+        // dirty data while the old EOF is still visible.
+        let written = page_cache.write_with_before_dirty(offset, data, |written| {
+            self.note_successful_write(offset, written)
+        })?;
         Ok(written)
     }
 

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -749,6 +749,7 @@ impl IndexNode for FuseNode {
 
         match fuse_data {
             FuseFilePrivateData::File(p) => {
+                let _barrier = self.writeback_barrier.write();
                 let sync_result = self.sync_cached_pages();
                 let wb_error_result = self.check_and_advance_open_wb_error(&p);
                 sync_result?;
@@ -777,20 +778,21 @@ impl IndexNode for FuseNode {
         drop(data);
 
         if let FuseFilePrivateData::File(_) = &fuse_data {
+            let _barrier = self.writeback_barrier.write();
             if let Some(page_cache) = self.cached_page_cache() {
                 let start_index = start >> MMArch::PAGE_SHIFT;
                 let end_index = end >> MMArch::PAGE_SHIFT;
-                page_cache
-                    .manager()
-                    .writeback_range(start_index, end_index)?;
+                page_cache.manager().sync_range(start_index, end_index)?;
             }
+            if let FuseFilePrivateData::File(p) = fuse_data {
+                self.check_and_advance_open_wb_error(&p)?;
+                return self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync);
+            }
+            unreachable!();
         }
 
         match fuse_data {
-            FuseFilePrivateData::File(p) => {
-                self.check_and_advance_open_wb_error(&p)?;
-                self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync)
-            }
+            FuseFilePrivateData::File(_) => unreachable!(),
             FuseFilePrivateData::Dir(p) => self.fsync_with_fh(FUSE_FSYNCDIR, p.fh, datasync),
             FuseFilePrivateData::Dev(_) => self.fsync_common(datasync),
         }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -837,12 +837,8 @@ impl IndexNode for FuseNode {
 
             let mut last_off: u64 = offset;
             if use_readdirplus {
-                last_off = self.parse_readdirplus_payload(
-                    &payload,
-                    &mut names,
-                    last_off,
-                    request_epoch,
-                )?;
+                last_off =
+                    self.parse_readdirplus_payload(&payload, &mut names, last_off, request_epoch)?;
             } else {
                 last_off = Self::parse_readdir_payload(&payload, &mut names, last_off)?;
             }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -411,7 +411,26 @@ impl IndexNode for FuseNode {
             self.prepare_direct_io_range(offset, len, &private_data, true)?;
         }
         if cached_write && self.conn().has_init_flag(FUSE_WRITEBACK_CACHE) {
-            return self.writeback_cache_write(offset, &buf[..len], &private_data);
+            while total_written < len {
+                let chunk = core::cmp::min(max_write, len - total_written);
+                let chunk_offset = offset
+                    .checked_add(total_written)
+                    .ok_or(SystemError::EOVERFLOW)?;
+                let wrote = match self.writeback_cache_write(
+                    chunk_offset,
+                    &buf[total_written..total_written + chunk],
+                    &private_data,
+                ) {
+                    Ok(wrote) => wrote,
+                    Err(e) if total_written == 0 => return Err(e),
+                    Err(_) => return Ok(total_written),
+                };
+                total_written += wrote;
+                if wrote < chunk {
+                    break;
+                }
+            }
+            return Ok(total_written);
         }
         let cached_page_cache = if cached_write {
             self.cached_page_cache()

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -32,7 +32,7 @@ use super::super::{
         FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR, FUSE_READDIR,
         FUSE_READDIRPLUS, FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR, FUSE_REMOVEXATTR,
         FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_SETATTR, FUSE_SETXATTR, FUSE_SYMLINK,
-        FUSE_UNLINK, FUSE_WRITE, FUSE_WRITE_LOCKOWNER,
+        FUSE_UNLINK, FUSE_WRITE, FUSE_WRITEBACK_CACHE, FUSE_WRITE_LOCKOWNER,
     },
 };
 use super::FuseNode;
@@ -355,6 +355,7 @@ impl IndexNode for FuseNode {
         let fopen_flags = private_data.fopen_flags;
 
         if (fopen_flags & FOPEN_DIRECT_IO) != 0 || (file_flags & FileFlags::O_DIRECT.bits()) != 0 {
+            let _barrier = self.writeback_barrier.write();
             self.prepare_direct_io_range(offset, len, &private_data, false)?;
             let lock_owner = crate::filesystem::vfs::vcore::current_file_lock_owner_id();
             return self.read_direct_with_open(offset, len, buf, fh, file_flags, lock_owner);
@@ -395,14 +396,22 @@ impl IndexNode for FuseNode {
         } else {
             crate::filesystem::vfs::vcore::current_file_lock_owner_id()
         };
+        let _writeback_guard = if cached_write {
+            Some(self.writeback_barrier.read())
+        } else {
+            None
+        };
         let _direct_write_guard = if cached_write {
             None
         } else {
-            Some(self.direct_io_lock.lock())
+            Some(self.writeback_barrier.write())
         };
         let mut total_written = 0usize;
         if !cached_write {
             self.prepare_direct_io_range(offset, len, &private_data, true)?;
+        }
+        if cached_write && self.conn().has_init_flag(FUSE_WRITEBACK_CACHE) {
+            return self.writeback_cache_write(offset, &buf[..len], &private_data);
         }
         let cached_page_cache = if cached_write {
             self.cached_page_cache()
@@ -495,6 +504,14 @@ impl IndexNode for FuseNode {
 
     fn set_metadata(&self, metadata: &Metadata) -> Result<(), SystemError> {
         self.check_not_stale()?;
+        let writeback_cache = self.conn().has_init_flag(FUSE_WRITEBACK_CACHE);
+        if writeback_cache {
+            self.sync_dirty_cached_pages()?;
+        }
+        let _barrier = writeback_cache.then(|| self.writeback_barrier.write());
+        if writeback_cache {
+            self.sync_dirty_cached_pages()?;
+        }
         let old = self.cached_or_fetch_metadata()?;
         if metadata.size > old.size {
             self.resolve_pending_short_read_truncate(metadata.size.max(0) as usize)?;
@@ -649,6 +666,7 @@ impl IndexNode for FuseNode {
         if new_size > md.size.max(0) as usize {
             crate::filesystem::vfs::vcore::check_file_size_limit(new_size)?;
         }
+        let _barrier = self.writeback_barrier.write();
 
         let in_arg = FuseFallocateIn {
             fh: fuse_data.fh,
@@ -666,8 +684,11 @@ impl IndexNode for FuseNode {
                 if let Some(md) = metadata.as_mut() {
                     if new_size > md.size.max(0) as usize {
                         md.size = new_size as i64;
-                        self.bump_attr_version();
                     }
+                    let now = crate::time::PosixTimeSpec::now();
+                    md.mtime = now;
+                    md.ctime = now;
+                    self.bump_attr_version();
                 }
                 drop(metadata);
                 self.cached_metadata_deadline_ns.store(0, Ordering::Relaxed);
@@ -797,6 +818,7 @@ impl IndexNode for FuseNode {
             } else {
                 FUSE_READDIR
             };
+            let request_epoch = self.conn.sample_attr_epoch();
             let payload = match self
                 .conn()
                 .request(opcode, self.nodeid, fuse_pack_struct(&read_in))
@@ -815,7 +837,12 @@ impl IndexNode for FuseNode {
 
             let mut last_off: u64 = offset;
             if use_readdirplus {
-                last_off = self.parse_readdirplus_payload(&payload, &mut names, last_off)?;
+                last_off = self.parse_readdirplus_payload(
+                    &payload,
+                    &mut names,
+                    last_off,
+                    request_epoch,
+                )?;
             } else {
                 last_off = Self::parse_readdir_payload(&payload, &mut names, last_off)?;
             }
@@ -849,6 +876,7 @@ impl IndexNode for FuseNode {
             return Ok(child);
         }
 
+        let request_epoch = self.conn.sample_attr_epoch();
         let payload = match self.request_name(FUSE_LOOKUP, self.nodeid, name) {
             Ok(payload) => payload,
             Err(err) => {
@@ -896,7 +924,12 @@ impl IndexNode for FuseNode {
         child
             .lookup_attr_flags
             .store(entry.attr.flags, Ordering::Relaxed);
-        child.set_cached_metadata_with_valid(md, entry.attr_valid, entry.attr_valid_nsec);
+        child.merge_cached_metadata_from_daemon(
+            md,
+            entry.attr_valid,
+            entry.attr_valid_nsec,
+            request_epoch,
+        );
         self.cache_lookup_child(
             name,
             &child,
@@ -1028,6 +1061,7 @@ impl IndexNode for FuseNode {
             oldnodeid: target.nodeid,
         };
         let payload_in = Self::pack_struct_and_name_payload(&inarg, name);
+        let request_epoch = self.conn.sample_attr_epoch();
         let payload = self.conn().request(FUSE_LINK, self.nodeid, &payload_in)?;
         let entry: FuseEntryOut = fuse_read_struct(&payload)?;
         let mut consumed = false;
@@ -1044,7 +1078,12 @@ impl IndexNode for FuseNode {
                 1,
             )?;
             consumed = true;
-            child.set_cached_metadata_with_valid(md, entry.attr_valid, entry.attr_valid_nsec);
+            child.merge_cached_metadata_from_daemon(
+                md,
+                entry.attr_valid,
+                entry.attr_valid_nsec,
+                request_epoch,
+            );
             Ok(())
         })();
         if result.is_err() && entry.nodeid != 0 && !consumed {

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -1047,17 +1047,40 @@ impl PageCacheManager {
 
     pub fn sync(&self) -> Result<(), SystemError> {
         let cache = self.upgrade()?;
-        let dirty_entries: Vec<(usize, Arc<PageEntry>)> = {
-            let inner = cache.inner.lock();
-            inner
-                .dirty_pages
-                .iter()
-                .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
-                .collect()
-        };
+        loop {
+            let (dirty_entries, writeback_entries): (Vec<_>, Vec<_>) = {
+                let inner = cache.inner.lock();
+                let dirty = inner
+                    .dirty_pages
+                    .iter()
+                    .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
+                    .collect();
+                let writeback = inner
+                    .pages
+                    .values()
+                    .filter(|entry| entry.state() == PageState::Writeback)
+                    .cloned()
+                    .collect();
+                (dirty, writeback)
+            };
 
-        for (page_index, entry) in dirty_entries {
-            Self::writeback_entry(&cache, page_index, entry)?;
+            for (page_index, entry) in dirty_entries {
+                Self::writeback_entry(&cache, page_index, entry)?;
+            }
+            for entry in writeback_entries {
+                Self::wait_writeback_entry(entry)?;
+            }
+
+            let inner = cache.inner.lock();
+            let done = inner.dirty_pages.is_empty()
+                && !inner
+                    .pages
+                    .values()
+                    .any(|entry| entry.state() == PageState::Writeback);
+            drop(inner);
+            if done {
+                break;
+            }
         }
 
         // 脏页写完后调 write_inode 回写元数据。

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -3162,23 +3162,42 @@ impl PageCache {
         Ok(ret)
     }
 
-    /// 两阶段写入：持锁收集目标页，解锁后按页写入，避免用户缺页时持有page cache锁
     pub fn write(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
-        let len = buf.len();
+        let (copies, ret) = self.prepare_write_copies(offset, buf.len())?;
+        let mut src_offset = 0;
+        for item in copies {
+            // Prefault before taking the page lock.
+            let _ = volatile_read!(buf[src_offset]);
+            let mut page_guard = item.entry.page.write();
+            unsafe {
+                page_guard.as_slice_mut()[item.page_offset..item.page_offset + item.sub_len]
+                    .copy_from_slice(&buf[src_offset..src_offset + item.sub_len]);
+            }
+            page_guard.add_flags(PageFlags::PG_DIRTY);
+            src_offset += item.sub_len;
+            drop(page_guard);
+            self.mark_page_dirty(item.page_index);
+        }
+        Ok(ret)
+    }
+
+    fn prepare_write_copies(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Result<(Vec<CopyItem>, usize), SystemError> {
         if len == 0 {
-            return Ok(0);
+            return Ok((Vec::new(), 0));
         }
 
         let start_page_index = offset >> MMArch::PAGE_SHIFT;
         let end_page_index = (offset + len - 1) >> MMArch::PAGE_SHIFT;
-
         let mut copies: Vec<CopyItem> = Vec::new();
         let mut ret = 0usize;
 
         for page_index in start_page_index..=end_page_index {
             let page_start = page_index * MMArch::PAGE_SIZE;
             let page_end = page_start + MMArch::PAGE_SIZE;
-
             let write_start = core::cmp::max(offset, page_start);
             let write_end = core::cmp::min(offset + len, page_end);
             let page_write_len = write_end.saturating_sub(write_start);
@@ -3201,18 +3220,59 @@ impl PageCache {
             ret += page_write_len;
         }
 
+        Ok((copies, ret))
+    }
+
+    /// Two-phase write: prepare and pin every destination page before
+    /// committing metadata or exposing dirty data.
+    ///
+    /// `before_dirty` runs after all fallible page preparation has completed
+    /// and while every destination page is write-locked, but before any caller
+    /// data is copied or dirty state becomes visible. The locks remain held
+    /// through the copy and dirty transition, making the metadata, data, and
+    /// dirty state externally visible as one ordered commit.
+    pub(crate) fn write_with_before_dirty<F>(
+        &self,
+        offset: usize,
+        buf: &[u8],
+        before_dirty: F,
+    ) -> Result<usize, SystemError>
+    where
+        F: FnOnce(usize) -> Result<(), SystemError>,
+    {
+        let (copies, ret) = self.prepare_write_copies(offset, buf.len())?;
+        if ret == 0 {
+            return Ok(0);
+        }
+
         let mut src_offset = 0;
-        for item in copies {
-            // 预触发用户缓冲区当前段，避免后续在持页锁时缺页
+        for item in &copies {
+            // Prefault each source segment before the metadata commit so the
+            // remaining page-locked copy path cannot introduce a new failure
+            // point after the filesystem publishes the write.
             let _ = volatile_read!(buf[src_offset]);
-            let mut page_guard = item.entry.page.write();
+            src_offset += item.sub_len;
+        }
+
+        // Lock in ascending page-index order (the same order as `copies`) so
+        // readers and writeback cannot observe metadata for the new EOF until
+        // all copied bytes and PG_DIRTY transitions are ready to be exposed.
+        let mut page_guards: Vec<_> = copies.iter().map(|item| item.entry.page.write()).collect();
+
+        before_dirty(ret)?;
+
+        src_offset = 0;
+        for (item, page_guard) in copies.iter().zip(page_guards.iter_mut()) {
             unsafe {
                 page_guard.as_slice_mut()[item.page_offset..item.page_offset + item.sub_len]
                     .copy_from_slice(&buf[src_offset..src_offset + item.sub_len]);
             }
             page_guard.add_flags(PageFlags::PG_DIRTY);
             src_offset += item.sub_len;
-            drop(page_guard);
+        }
+        drop(page_guards);
+
+        for item in copies {
             self.mark_page_dirty(item.page_index);
         }
 

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -851,8 +851,28 @@ impl PageCacheManager {
         self.upgrade()?.get_or_create_page_with(page_index, fill)
     }
 
+    pub fn commit_page_for_write_with<F>(
+        &self,
+        page_index: usize,
+        fill: F,
+    ) -> Result<Arc<Page>, SystemError>
+    where
+        F: FnOnce(usize, &mut [u8]) -> Result<usize, SystemError>,
+    {
+        self.upgrade()?
+            .get_or_create_page_for_write_with(page_index, fill)
+    }
+
     pub fn commit_overwrite(&self, page_index: usize) -> Result<Arc<Page>, SystemError> {
         self.upgrade()?.get_or_create_page_zero(page_index)
+    }
+
+    pub fn commit_overwrite_for_write(&self, page_index: usize) -> Result<Arc<Page>, SystemError> {
+        self.upgrade()?
+            .get_or_create_page_for_write_with(page_index, |_idx, dst| {
+                dst.fill(0);
+                Ok(MMArch::PAGE_SIZE)
+            })
     }
 
     pub fn commit_overwrite_pinned(
@@ -1094,6 +1114,55 @@ impl PageCacheManager {
         }
 
         Ok(())
+    }
+
+    /// Write and wait for every dirty or in-flight page in an inclusive range.
+    ///
+    /// Unlike `writeback_range`, this is a data-integrity operation: pages
+    /// already under writeback when the call starts must complete before the
+    /// caller may issue a backend fsync request.
+    pub fn sync_range(&self, start_index: usize, end_index: usize) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        loop {
+            let (dirty_entries, writeback_entries): (Vec<_>, Vec<_>) = {
+                let inner = cache.inner.lock();
+                let dirty = inner
+                    .dirty_pages
+                    .range(start_index..=end_index)
+                    .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
+                    .collect();
+                let writeback = inner
+                    .page_indices
+                    .range(start_index..=end_index)
+                    .filter_map(|idx| inner.pages.get(idx))
+                    .filter(|entry| entry.state() == PageState::Writeback)
+                    .cloned()
+                    .collect();
+                (dirty, writeback)
+            };
+
+            for (page_index, entry) in dirty_entries {
+                Self::writeback_entry(&cache, page_index, entry)?;
+            }
+            for entry in writeback_entries {
+                Self::wait_writeback_entry(entry)?;
+            }
+
+            let inner = cache.inner.lock();
+            let has_dirty = inner
+                .dirty_pages
+                .range(start_index..=end_index)
+                .next()
+                .is_some();
+            let has_writeback = inner
+                .page_indices
+                .range(start_index..=end_index)
+                .filter_map(|idx| inner.pages.get(idx))
+                .any(|entry| entry.state() == PageState::Writeback);
+            if !has_dirty && !has_writeback {
+                return Ok(());
+            }
+        }
     }
 
     pub fn resize(&self, len: usize) -> Result<(), SystemError> {
@@ -2773,6 +2842,25 @@ impl PageCache {
         }
     }
 
+    fn discard_error_entry_if_same(&self, page_index: usize, expected: &Arc<PageEntry>) -> bool {
+        let removed = {
+            let mut guard = self.inner.lock();
+            let Some(entry) = guard.get_entry(page_index) else {
+                return false;
+            };
+            if !Arc::ptr_eq(&entry, expected) || entry.state() != PageState::Error {
+                return false;
+            }
+            guard.remove_page(page_index)
+        };
+        if let Some(page) = removed {
+            self.discard_unlinked_page(&page);
+            true
+        } else {
+            false
+        }
+    }
+
     fn discard_unlinked_page(&self, page: &Arc<Page>) {
         let paddr = page.phys_address();
         let can_remove_from_manager = {
@@ -2991,6 +3079,101 @@ impl PageCache {
                 entry.wait_queue.wake_all();
                 self.remove_failed_entry(page_index, &entry);
                 Err(e)
+            }
+        }
+    }
+
+    /// Populate a page for a write, replacing only a pre-existing Error entry.
+    /// Errors produced by this call's own fill operation are returned without
+    /// retry so persistent backend failures cannot turn into an infinite loop.
+    fn get_or_create_page_for_write_with<F>(
+        &self,
+        page_index: usize,
+        fill: F,
+    ) -> Result<Arc<Page>, SystemError>
+    where
+        F: FnOnce(usize, &mut [u8]) -> Result<usize, SystemError>,
+    {
+        let mut fill = Some(fill);
+        loop {
+            let mut page_cache_ref = None;
+            let existing_entry = {
+                let guard = self.inner.lock();
+                match guard.get_entry(page_index) {
+                    Some(entry) => Some(entry),
+                    None => {
+                        page_cache_ref = Some(guard.page_cache_ref.clone());
+                        None
+                    }
+                }
+            };
+
+            if let Some(entry) = existing_entry {
+                match entry.state() {
+                    state if state.is_ready() => return Ok(entry.page.clone()),
+                    PageState::Error => {
+                        self.discard_error_entry_if_same(page_index, &entry);
+                        continue;
+                    }
+                    PageState::Loading | PageState::Writeback => match entry.wait_ready() {
+                        Ok(page) => return Ok(page),
+                        Err(_e) if entry.state() == PageState::Error => {
+                            self.discard_error_entry_if_same(page_index, &entry);
+                            continue;
+                        }
+                        Err(e) => return Err(e),
+                    },
+                    PageState::UpToDate | PageState::Dirty => unreachable!(),
+                }
+            }
+
+            let page = self.allocate_page(
+                page_cache_ref.expect("page_cache_ref should exist"),
+                page_index,
+            )?;
+            let entry = Arc::new(PageEntry::new(page, PageState::Loading));
+            let inserted = {
+                let mut guard = self.inner.lock();
+                if guard.get_entry(page_index).is_some() {
+                    false
+                } else {
+                    guard.insert_entry(page_index, entry.clone());
+                    true
+                }
+            };
+            if !inserted {
+                self.discard_unlinked_page(&entry.page);
+                continue;
+            }
+            self.reconcile_entry_unevictable_for_insert(&entry);
+
+            let populate_result = {
+                let mut tmp = vec![0; MMArch::PAGE_SIZE];
+                match fill.take().expect("write page fill consumed once")(page_index, &mut tmp) {
+                    Ok(read_len) if read_len <= MMArch::PAGE_SIZE => {
+                        let mut page_guard = entry.page.write();
+                        let dst = unsafe { page_guard.as_slice_mut() };
+                        dst.copy_from_slice(&tmp);
+                        page_guard.add_flags(PageFlags::PG_UPTODATE);
+                        Ok(())
+                    }
+                    Ok(_) => Err(SystemError::EIO),
+                    Err(e) => Err(e),
+                }
+            };
+
+            match populate_result {
+                Ok(()) => {
+                    entry.set_state(PageState::UpToDate);
+                    entry.wait_queue.wake_all();
+                    return Ok(entry.page.clone());
+                }
+                Err(e) => {
+                    entry.set_state(PageState::Error);
+                    entry.wait_queue.wake_all();
+                    self.remove_failed_entry(page_index, &entry);
+                    return Err(e);
+                }
             }
         }
     }

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -84,6 +84,7 @@ static int ext_test_p2_ops() {
     volatile uint32_t create_count = 0;
     volatile uint32_t rename2_count = 0;
     volatile uint32_t write_count = 0;
+    volatile uint32_t last_write_size = 0;
     volatile uint32_t last_write_flags = 0;
     volatile uint32_t write_count_at_fsync = 0;
     volatile uint32_t last_write_flags_at_fsync = 0;
@@ -102,10 +103,12 @@ static int ext_test_p2_ops() {
     args.create_count = &create_count;
     args.rename2_count = &rename2_count;
     args.write_count = &write_count;
+    args.last_write_size = &last_write_size;
     args.last_write_flags = &last_write_flags;
     args.write_count_at_fsync = &write_count_at_fsync;
     args.last_write_flags_at_fsync = &last_write_flags_at_fsync;
     args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
+    args.link_reuse_old_nodeid = 1;
     args.access_deny_mask = 2;
 
     pthread_t th;
@@ -158,6 +161,15 @@ static int ext_test_p2_ops() {
         close(f);
         goto fail;
     }
+    // LINK returns an attribute snapshot for the same inode.  With
+    // writeback-cache negotiated, that daemon-side size is stale until fsync;
+    // processing the LINK reply must not roll back the local dirty size.
+    snprintf(hard_path, sizeof(hard_path), "%s/p2_hard.txt", mp);
+    if (link(created, hard_path) != 0) {
+        printf("[FAIL] link dirty writeback file: %s (errno=%d)\n", strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
     if (write_count != 0) {
         printf("[FAIL] writeback-cache write reached daemon before fsync: writes=%u\n",
                write_count);
@@ -169,14 +181,18 @@ static int ext_test_p2_ops() {
         close(f);
         goto fail;
     }
-    if (write_count_at_fsync == 0 ||
+    if (write_count_at_fsync == 0 || last_write_size != strlen("p2-data") ||
         (last_write_flags_at_fsync & FUSE_WRITE_CACHE) == 0) {
-        printf("[FAIL] fsync did not drain cached write first: writes=%u flags=0x%x\n",
-               write_count_at_fsync, last_write_flags_at_fsync);
+        printf("[FAIL] fsync did not drain full cached write first: writes=%u size=%u flags=0x%x\n",
+               write_count_at_fsync, last_write_size, last_write_flags_at_fsync);
         close(f);
         goto fail;
     }
     close(f);
+    if (unlink(hard_path) != 0) {
+        printf("[FAIL] unlink dirty-link probe: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
 
     snprintf(symlink_path, sizeof(symlink_path), "%s/p2_symlink.txt", mp);
     if (symlink("p2_create.txt", symlink_path) != 0) {
@@ -194,11 +210,11 @@ static int ext_test_p2_ops() {
         goto fail;
     }
 
-    snprintf(hard_path, sizeof(hard_path), "%s/p2_hard.txt", mp);
     if (link(created, hard_path) != 0) {
-        printf("[FAIL] link: %s (errno=%d)\n", strerror(errno), errno);
+        printf("[FAIL] link after fsync: %s (errno=%d)\n", strerror(errno), errno);
         goto fail;
     }
+
     if (unlink(created) != 0) {
         printf("[FAIL] unlink original: %s (errno=%d)\n", strerror(errno), errno);
         goto fail;

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -63,6 +63,7 @@ static int ext_test_p2_ops() {
     char rbuf[64];
     char dst_exist[256];
     char renamed[256];
+    const char extension = 'X';
     if (ensure_dir(mp) != 0) {
         printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
         return -1;
@@ -88,6 +89,7 @@ static int ext_test_p2_ops() {
     volatile uint32_t last_write_flags = 0;
     volatile uint32_t write_count_at_fsync = 0;
     volatile uint32_t last_write_flags_at_fsync = 0;
+    volatile unsigned char extension_write_byte = 0;
 
     struct fuse_daemon_args args;
     memset(&args, 0, sizeof(args));
@@ -107,6 +109,8 @@ static int ext_test_p2_ops() {
     args.last_write_flags = &last_write_flags;
     args.write_count_at_fsync = &write_count_at_fsync;
     args.last_write_flags_at_fsync = &last_write_flags_at_fsync;
+    args.write_watch_offset = 200;
+    args.last_write_watch_byte = &extension_write_byte;
     args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
     args.link_reuse_old_nodeid = 1;
     args.access_deny_mask = 2;
@@ -188,6 +192,29 @@ static int ext_test_p2_ops() {
         close(f);
         goto fail;
     }
+
+    // Exercise writeback of an extension in the original EOF page. The
+    // writeback length must be calculated from the extended local size.
+    write_count = 0;
+    last_write_size = 0;
+    write_count_at_fsync = 0;
+    if (pwrite(f, &extension, 1, 200) != 1) {
+        printf("[FAIL] extend dirty writeback file: %s (errno=%d)\n", strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    if (fsync(f) != 0) {
+        printf("[FAIL] fsync(extended file): %s (errno=%d)\n", strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    if (write_count_at_fsync == 0 || last_write_size != 201 ||
+        extension_write_byte != (unsigned char)extension) {
+        printf("[FAIL] fsync truncated extended cached page: writes=%u size=%u byte=%u\n",
+               write_count_at_fsync, last_write_size, extension_write_byte);
+        close(f);
+        goto fail;
+    }
     close(f);
     if (unlink(hard_path) != 0) {
         printf("[FAIL] unlink dirty-link probe: %s (errno=%d)\n", strerror(errno), errno);
@@ -226,13 +253,12 @@ static int ext_test_p2_ops() {
     }
     rn = read(f, rbuf, sizeof(rbuf) - 1);
     close(f);
-    if (rn <= 0) {
+    if (rn < (ssize_t)strlen("p2-data")) {
         printf("[FAIL] read hard link: %s (errno=%d)\n", strerror(errno), errno);
         goto fail;
     }
-    rbuf[rn] = '\0';
-    if (strcmp(rbuf, "p2-data") != 0) {
-        printf("[FAIL] hard link content mismatch: got=%s\n", rbuf);
+    if (memcmp(rbuf, "p2-data", strlen("p2-data")) != 0) {
+        printf("[FAIL] hard link content prefix mismatch\n");
         goto fail;
     }
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -83,6 +83,10 @@ static int ext_test_p2_ops() {
     volatile uint32_t fsyncdir_count = 0;
     volatile uint32_t create_count = 0;
     volatile uint32_t rename2_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint32_t last_write_flags = 0;
+    volatile uint32_t write_count_at_fsync = 0;
+    volatile uint32_t last_write_flags_at_fsync = 0;
 
     struct fuse_daemon_args args;
     memset(&args, 0, sizeof(args));
@@ -97,6 +101,11 @@ static int ext_test_p2_ops() {
     args.fsyncdir_count = &fsyncdir_count;
     args.create_count = &create_count;
     args.rename2_count = &rename2_count;
+    args.write_count = &write_count;
+    args.last_write_flags = &last_write_flags;
+    args.write_count_at_fsync = &write_count_at_fsync;
+    args.last_write_flags_at_fsync = &last_write_flags_at_fsync;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
     args.access_deny_mask = 2;
 
     pthread_t th;
@@ -149,8 +158,21 @@ static int ext_test_p2_ops() {
         close(f);
         goto fail;
     }
+    if (write_count != 0) {
+        printf("[FAIL] writeback-cache write reached daemon before fsync: writes=%u\n",
+               write_count);
+        close(f);
+        goto fail;
+    }
     if (fsync(f) != 0) {
         printf("[FAIL] fsync(file): %s (errno=%d)\n", strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    if (write_count_at_fsync == 0 ||
+        (last_write_flags_at_fsync & FUSE_WRITE_CACHE) == 0) {
+        printf("[FAIL] fsync did not drain cached write first: writes=%u flags=0x%x\n",
+               write_count_at_fsync, last_write_flags_at_fsync);
         close(f);
         goto fail;
     }
@@ -2652,8 +2674,10 @@ static int ext_test_init_requests_linux_no_open_support() {
     }
 
     if ((init_flags & FUSE_NO_OPEN_SUPPORT) == 0 ||
-        (init_flags & FUSE_NO_OPENDIR_SUPPORT) == 0) {
-        printf("[FAIL] INIT flags missing no-open support bits: flags=0x%x\n", init_flags);
+        (init_flags & FUSE_NO_OPENDIR_SUPPORT) == 0 ||
+        (init_flags & FUSE_WRITEBACK_CACHE) == 0) {
+        printf("[FAIL] INIT flags missing no-open/writeback support bits: flags=0x%x\n",
+               init_flags);
         goto fail;
     }
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -60,10 +60,15 @@ static int ext_test_p2_ops() {
     char symlink_path[256];
     char target_buf[256];
     char hard_path[256];
+    char sparse_path[256];
     char rbuf[64];
     char dst_exist[256];
     char renamed[256];
     const char extension = 'X';
+    const char sparse_marker = 'S';
+    const off_t sparse_offset = 5000;
+    const size_t sparse_size = (size_t)sparse_offset + 1;
+    unsigned char *sparse_contents = NULL;
     if (ensure_dir(mp) != 0) {
         printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
         return -1;
@@ -216,6 +221,58 @@ static int ext_test_p2_ops() {
         goto fail;
     }
     close(f);
+
+    // A short daemon READ inside a locally extended sparse file denotes a
+    // hole under FUSE_WRITEBACK_CACHE. It must neither shrink local i_size nor
+    // discard the dirty page beyond the hole before writeback reaches daemon.
+    snprintf(sparse_path, sizeof(sparse_path), "%s/p2_sparse.txt", mp);
+    f = open(sparse_path, O_CREAT | O_RDWR, 0644);
+    if (f < 0) {
+        printf("[FAIL] open sparse file: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (pwrite(f, &sparse_marker, 1, sparse_offset) != 1) {
+        printf("[FAIL] sparse cached extension: %s (errno=%d)\n", strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    sparse_contents = (unsigned char *)malloc(sparse_size);
+    if (!sparse_contents) {
+        printf("[FAIL] allocate sparse read buffer\n");
+        close(f);
+        goto fail;
+    }
+    memset(sparse_contents, 0xff, sparse_size);
+    if (pread(f, sparse_contents, sparse_size, 0) != (ssize_t)sparse_size) {
+        printf("[FAIL] read sparse extension before fsync: %s (errno=%d)\n", strerror(errno),
+               errno);
+        free(sparse_contents);
+        close(f);
+        goto fail;
+    }
+    for (size_t i = 0; i < sparse_size - 1; ++i) {
+        if (sparse_contents[i] != 0) {
+            printf("[FAIL] sparse hole byte %zu is %u\n", i, sparse_contents[i]);
+            free(sparse_contents);
+            close(f);
+            goto fail;
+        }
+    }
+    if (sparse_contents[sparse_size - 1] != (unsigned char)sparse_marker) {
+        printf("[FAIL] sparse dirty tail lost before fsync: got=%u\n",
+               sparse_contents[sparse_size - 1]);
+        free(sparse_contents);
+        close(f);
+        goto fail;
+    }
+    free(sparse_contents);
+    if (fsync(f) != 0) {
+        printf("[FAIL] fsync sparse file: %s (errno=%d)\n", strerror(errno), errno);
+        close(f);
+        goto fail;
+    }
+    close(f);
+
     if (unlink(hard_path) != 0) {
         printf("[FAIL] unlink dirty-link probe: %s (errno=%d)\n", strerror(errno), errno);
         goto fail;


### PR DESCRIPTION
## Summary

- negotiate `FUSE_WRITEBACK_CACHE` after routing buffered writes through the page cache
- serialize dirty admission with truncate, setattr, and direct I/O while preserving mmap and handle lifetime invariants
- keep local size/mtime/ctime authoritative and reject stale daemon attribute replies with a connection-wide epoch
- drain both dirty and already-in-flight writeback pages for sync operations
- add FUSE regression coverage for deferred writes, `FUSE_WRITE_CACHE`, fsync ordering, and capability negotiation

## Validation

- `make kernel`
- dunitest build
- DragonOS QEMU guest: `FuseExtended.OpsAccessCreateSymlinkLinkRename2FlushFsync`
- DragonOS QEMU guest: `FuseExtended.InitRequestsLinuxNoOpenSupport`
- DragonOS QEMU guest: `FuseExtended.SharedWritableMmapMsyncWriteback`
- DragonOS QEMU guest: `FuseExtended.SharedWritableMmapOSyncWriteback`
- DragonOS QEMU guest: `fdatasync_test`
- DragonOS QEMU guest: `syncfs_semantics_test`
- DragonOS QEMU guest: `errseq_writeback_reporting_test`
- DragonOS QEMU guest: `mmap_truncate_cow_test`

Fixes #2017