### PR TITLE
fix(process): preserve wait visibility across child exit

### DIFF
--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -505,18 +505,29 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
 
             // log::info!("de_thread: reparented current to old leader's parent");
 
-            // Complete the deferred PID/TGID/PGID/SID unhash that the old leader
-            // postponed during its exit phase.
-            leader.finish_deferred_unhash_for_exec();
-
             // The old leader should be reaped by the exec thread to prevent the
             // parent from reaping it prematurely before/after the swap.
+            let mut release_leader = false;
             if leader.is_zombie() {
                 if leader.try_mark_dead_from_zombie() {
-                    unsafe { ProcessManager::release(leader.raw_pid()) };
+                    release_leader = true;
                 }
             } else if leader.is_dead() {
+                release_leader = true;
+            }
+
+            if release_leader {
+                // Remove the old PCB from ALL_PROCESS before generic release can
+                // return its swapped-out TID to the PID allocator. Otherwise a
+                // concurrent fork can reuse that number and a late release would
+                // remove the newly published child under the same map key.
                 unsafe { ProcessManager::release(leader.raw_pid()) };
+
+                // Every DragonOS thread owns TGID/PGID/SID task links. The
+                // generic release path sees the migrated old leader as a
+                // non-leader and only detaches PID, so remove its remaining links
+                // explicitly. `leader` remains alive through this Arc.
+                leader.detach_exec_leader_non_pid_links();
             }
         } else {
             current

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -44,11 +44,8 @@ fn wstatus_to_waitid_exit_info(raw_wstatus: i32) -> (i32, i32) {
     }
 }
 
-/// mt-exec: de_thread 正在等待旧 leader 完成 PID/TID 交换时，禁止提前回收
+/// mt-exec: de_thread 正在接管旧线程组时，禁止 wait 路径提前回收其他线程。
 fn reap_blocked_by_group_exec(child_pcb: &Arc<ProcessControlBlock>) -> bool {
-    if !child_pcb.is_thread_group_leader() {
-        return false;
-    }
     if !child_pcb.sighand().flags_contains(SignalFlags::GROUP_EXEC) {
         return false;
     }
@@ -61,24 +58,6 @@ fn reap_blocked_by_group_exec(child_pcb: &Arc<ProcessControlBlock>) -> bool {
 
 fn delay_group_leader(child_pcb: &Arc<ProcessControlBlock>) -> bool {
     child_pcb.is_thread_group_leader() && child_pcb.thread_group_has_live_nonleader_threads()
-}
-
-/// mt-exec: 非执行线程的组长在退出时，延迟 PID/TGID/PGID/SID 的 unhash
-/// 以避免 de_thread 交换 TID/raw_pid 时出现 ESRCH。
-fn should_defer_unhash_for_group_exec(pcb: &ProcessControlBlock, group_dead: bool) -> bool {
-    if !group_dead {
-        return false;
-    }
-    let sighand = pcb.sighand();
-    if !sighand.flags_contains(SignalFlags::GROUP_EXEC) {
-        return false;
-    }
-    let exec_task = sighand.group_exec_task();
-    let this = pcb.self_ref.upgrade();
-    match (exec_task, this) {
-        (Some(exec_task), Some(this)) => !Arc::ptr_eq(&exec_task, &this),
-        _ => false,
-    }
 }
 
 /// 检查子进程的 exit_signal 是否与等待选项匹配
@@ -490,15 +469,19 @@ fn report_wait_event(
         return CandidateDecision::Ineligible;
     }
 
+    // exit_notify publishes ProcessState::Exited before the release-store that
+    // makes ExitState::Zombie visible. Observe Zombie first (Acquire), then read
+    // the scheduler state so the wait status cannot come from an older snapshot.
+    let is_zombie = child_pcb.is_zombie();
     let state = child_pcb.sched_info().state();
 
     // Linux wait_consider_task() checks zombie before stopped/continued.
     // A zombie leader with live subthreads is still an eligible child even when
     // the caller did not request WEXITED; otherwise waitid(WSTOPPED|WNOHANG)
     // would incorrectly report ECHILD while the thread group can still change.
-    let delayed_zombie = child_pcb.is_zombie()
-        && (delay_group_leader(child_pcb) || reap_blocked_by_group_exec(child_pcb));
-    if child_pcb.is_zombie() && !delayed_zombie && kwo.options.contains(WaitOption::WEXITED) {
+    let delayed_zombie =
+        is_zombie && (delay_group_leader(child_pcb) || reap_blocked_by_group_exec(child_pcb));
+    if is_zombie && !delayed_zombie && kwo.options.contains(WaitOption::WEXITED) {
         let Some(raw_wstatus) = state.raw_wstatus().map(|status| status as i32) else {
             return CandidateDecision::Pending { can_change: false };
         };
@@ -560,7 +543,7 @@ fn report_wait_event(
         return CandidateDecision::Ready(Ok(wait_visible_pid(child_pcb).into()));
     }
 
-    let can_change = if child_pcb.is_zombie() {
+    let can_change = if is_zombie {
         delayed_zombie
             && (relation == WaitRelation::Natural
                 || kwo.options.contains(WaitOption::WEXITED)
@@ -867,16 +850,12 @@ impl ProcessControlBlock {
 
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/exit.c#123
     fn __unhash_process(&self, group_dead: bool) {
-        if should_defer_unhash_for_group_exec(self, group_dead) {
-            self.flags().insert(ProcessFlags::DEFER_UNHASH);
-        } else {
-            self.dec_visible_thread_count_if_accounted();
-            self.detach_pid(PidType::PID);
-            if group_dead {
-                self.detach_pid(PidType::TGID);
-                self.detach_pid(PidType::PGID);
-                self.detach_pid(PidType::SID);
-            }
+        self.dec_visible_thread_count_if_accounted();
+        self.detach_pid(PidType::PID);
+        if group_dead {
+            self.detach_pid(PidType::TGID);
+            self.detach_pid(PidType::PGID);
+            self.detach_pid(PidType::SID);
         }
 
         // 从线程组中移除。非组长线程离开 group_tasks 后，线程组 rusage 仍需保留其 CPU 时间。
@@ -895,18 +874,14 @@ impl ProcessControlBlock {
         }
     }
 
-    /// 在 de_thread 完成 PID/TID 交换后，补做延迟的 unhash。
-    pub(super) fn finish_deferred_unhash_for_exec(&self) {
-        if !self.flags().contains(ProcessFlags::DEFER_UNHASH) {
-            return;
-        }
-        self.flags().remove(ProcessFlags::DEFER_UNHASH);
-        self.dec_visible_thread_count_if_accounted();
-        self.detach_pid(PidType::PID);
-        if self.is_thread_group_leader() {
-            self.detach_pid(PidType::TGID);
-            self.detach_pid(PidType::PGID);
-            self.detach_pid(PidType::SID);
-        }
+    /// Remove the old leader's non-PID links after non-leader exec migration.
+    ///
+    /// DragonOS attaches TGID/PGID/SID links to every thread. The generic release
+    /// path observes the migrated old leader as a non-leader and therefore only
+    /// detaches PID; Linux instead transfers these leader links in de_thread().
+    pub(super) fn detach_exec_leader_non_pid_links(&self) {
+        self.detach_pid(PidType::TGID);
+        self.detach_pid(PidType::PGID);
+        self.detach_pid(PidType::SID);
     }
 }

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -482,18 +482,23 @@ impl ProcessManager {
                     .map(|vpid| (parent, vpid))
             });
 
-            pcb.__exit_signal();
-            {
-                let _cgroup_guard = crate::cgroup::cgroup_accounting_lock().lock();
-                pcb.task_cgroup_node().uncharge_pids(1);
-            }
             // Remove from the parent's children list.
             if let Some((parent, vpid)) = parent_child_vpid {
                 let mut children = parent.children.write();
                 children.retain(|&p| p != vpid);
             }
 
+            // Revoke the old PCB's global numeric lookup before __exit_signal()
+            // can detach the final PID link and return that number to the
+            // allocator. Otherwise a concurrent fork may publish a new task at
+            // the same key and this release would delete the new task instead.
             ALL_PROCESS.lock_irqsave().as_mut().unwrap().remove(&pid);
+
+            pcb.__exit_signal();
+            {
+                let _cgroup_guard = crate::cgroup::cgroup_accounting_lock().lock();
+                pcb.task_cgroup_node().uncharge_pids(1);
+            }
         }
     }
 

--- a/kernel/src/process/state.rs
+++ b/kernel/src/process/state.rs
@@ -193,8 +193,6 @@ bitflags! {
         /// Process is waiting for an I/O operation to complete (used for iowait
         /// accounting).
         const IN_IOWAIT = 1 << 13;
-        /// Delay unhash of PID/TGID/PGID/SID during thread-group exec.
-        const DEFER_UNHASH = 1 << 14;
         /// PID links and visible-thread accounting have already been released.
         const PID_UNHASHED = 1 << 15;
         /// Task is currently traced by another task.


### PR DESCRIPTION
## Summary

- make wait observe the published zombie state before reading the scheduler exit status
- keep non-leader exec retirement owned by the exec transaction across PID/TID migration
- revoke global PID lookup entries before PID numbers become reusable
- remove stale old-leader TGID/PGID/SID links after non-leader exec

## Root cause

The wait path could read a stale running scheduler state and then a freshly published zombie state. That mixed snapshot had no wait status and was incorrectly classified as a terminal non-waitable child, producing `ECHILD` for an unreaped direct child.

The non-leader exec cleanup path also allowed related PID lifecycle gaps: waiter ownership depended on a leader identity that changes during migration, PID numbers could become reusable before the old global lookup key was removed, and the migrated old leader retained non-PID task links.

## Fix

The wait path now performs the Acquire observation of zombie publication before reading the scheduler state and uses one exit-state snapshot for the decision. This pairs with the exit path's existing `Exited`-before-Zombie Release publication.

Process retirement now removes the parent/global numeric indices before detaching the final PID link, group-exec peers remain protected from wait-side reaping throughout migration, and the exec owner removes the old leader's remaining TGID/PGID/SID links.

## Validation

- `make kernel`
- pre-fix QEMU reproduction: failed on repetition 7 at iteration 37 with `ECHILD`
- post-fix QEMU: `spawn_exec_pipe_race_test` passed 10 consecutive repetitions
- post-fix QEMU: `proc_self_exec_cmdline_test` passed 2/2
- post-fix QEMU: `wait_rusage_test` passed 33/33
- post-fix QEMU: `process_signal_fork_test` passed 5/5

Closes #2067
