### PR TITLE
feat(ext4): add JBD2 durability foundation

### DIFF
--- a/kernel/crates/another_ext4/ext4_fuse/src/block_dev.rs
+++ b/kernel/crates/another_ext4/ext4_fuse/src/block_dev.rs
@@ -97,6 +97,12 @@ impl BlockDevice for BlockMem {
         *slot = *block.data;
         Ok(())
     }
+    fn flush(&self) -> core::result::Result<(), another_ext4::Ext4Error> {
+        Ok(())
+    }
+    fn supports_reliable_flush(&self) -> bool {
+        true
+    }
 }
 
 impl StateBlockDevice<Vec<[u8; BLOCK_SIZE]>> for BlockMem {

--- a/kernel/crates/another_ext4/ext4_test/src/block_file.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/block_file.rs
@@ -37,4 +37,14 @@ impl BlockDevice for BlockFile {
             .map_err(|_| another_ext4::Ext4Error::new(another_ext4::ErrCode::EIO))?;
         Ok(())
     }
+
+    fn flush(&self) -> core::result::Result<(), another_ext4::Ext4Error> {
+        self.0
+            .sync_all()
+            .map_err(|_| another_ext4::Ext4Error::new(another_ext4::ErrCode::EIO))
+    }
+
+    fn supports_reliable_flush(&self) -> bool {
+        true
+    }
 }

--- a/kernel/crates/another_ext4/ext4_test/src/main.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/main.rs
@@ -26,14 +26,14 @@ fn make_ext4() {
 fn open_ext4() -> Ext4 {
     let file = BlockFile::new("ext4.img");
     println!("creating ext4");
-    let mut ext4 = Ext4::load(Arc::new(file)).expect("open ext4 failed");
+    let mut ext4 = Ext4::load_writable(Arc::new(file)).expect("open writable ext4 failed");
     ext4.init().expect("init ext4 failed");
     ext4
 }
 
 fn load_ext4() -> Ext4 {
     let file = BlockFile::new("ext4.img");
-    Ext4::load(Arc::new(file)).expect("open ext4 failed")
+    Ext4::load_writable(Arc::new(file)).expect("open writable ext4 failed")
 }
 
 fn read_u16_le(buf: &[u8], off: usize) -> u16 {

--- a/kernel/crates/another_ext4/src/error.rs
+++ b/kernel/crates/another_ext4/src/error.rs
@@ -13,6 +13,8 @@ pub enum ErrCode {
     ENOENT = 2,
     /// I/O error.
     EIO = 5,
+    /// Resource temporarily unavailable.
+    EAGAIN = 11,
     /// No such device or address.
     ENXIO = 6,
     /// Argument list too long.

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -576,6 +576,13 @@ mod tests {
         fn write_block(&self, _block: &Block) -> Result<()> {
             Ok(())
         }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
     }
 
     fn make_test_fs(block_count: u32) -> Ext4 {
@@ -590,6 +597,7 @@ mod tests {
             alloc_lock: spin::Mutex::new(()),
             namespace_lock: spin::Mutex::new(()),
             poisoned: spin::Mutex::new(None),
+            journal: None,
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),

--- a/kernel/crates/another_ext4/src/ext4/journal.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal.rs
@@ -1,11 +1,231 @@
-use super::Ext4;
+use super::{journal_recovery, journal_transaction, Ext4};
+use crate::constants::BLOCK_SIZE;
+use crate::ext4_defs::{Block, BlockDevice, SuperBlock};
+use crate::jbd2::Superblock as JournalSuperblock;
+use crate::prelude::*;
+
+struct RecoveryDevice<'a> {
+    device: &'a dyn BlockDevice,
+    journal_blocks: &'a [PBlockId],
+    journal_block_set: &'a BTreeSet<PBlockId>,
+    filesystem_blocks: u64,
+}
+
+impl journal_recovery::JournalRecoveryIo for RecoveryDevice<'_> {
+    fn block_size(&self) -> usize {
+        BLOCK_SIZE
+    }
+
+    fn filesystem_blocks(&self) -> u64 {
+        self.filesystem_blocks
+    }
+
+    fn read_journal(&self, logical: u32) -> Result<Vec<u8>> {
+        let physical = *self
+            .journal_blocks
+            .get(logical as usize)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        Ok(self.device.read_block(physical)?.data.to_vec())
+    }
+
+    fn write_journal(&self, logical: u32, data: &[u8]) -> Result<()> {
+        let physical = *self
+            .journal_blocks
+            .get(logical as usize)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let image: Box<[u8; BLOCK_SIZE]> = data
+            .to_vec()
+            .into_boxed_slice()
+            .try_into()
+            .map_err(|_| Ext4Error::new(ErrCode::EIO))?;
+        self.device.write_block(&Block::new(physical, image))
+    }
+
+    fn write_home(&self, physical: u64, data: &[u8]) -> Result<()> {
+        let image: Box<[u8; BLOCK_SIZE]> = data
+            .to_vec()
+            .into_boxed_slice()
+            .try_into()
+            .map_err(|_| Ext4Error::new(ErrCode::EIO))?;
+        self.device.write_block(&Block::new(physical, image))
+    }
+
+    fn is_journal_physical(&self, physical: u64) -> bool {
+        self.journal_block_set.contains(&physical)
+    }
+
+    fn flush_home(&self) -> Result<()> {
+        self.device.flush()
+    }
+
+    fn flush_journal(&self) -> Result<()> {
+        self.device.flush()
+    }
+}
 
 impl Ext4 {
-    /// start transaction
-    #[allow(unused)]
-    pub(super) fn trans_start(&self) {}
+    pub fn supports_reliable_flush(&self) -> bool {
+        self.block_device.supports_reliable_flush()
+    }
 
-    /// stop transaction
-    #[allow(unused)]
-    pub(super) fn trans_abort(&self) {}
+    pub fn flush_device(&self) -> Result<()> {
+        self.block_device.flush()
+    }
+
+    pub fn shutdown_writable(&self) -> Result<()> {
+        let Some(journal) = self.journal.as_ref() else {
+            return Ok(());
+        };
+        if !journal.can_shutdown() {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        // Every synchronous transaction checkpoints and clears s_start before
+        // returning. With new writers excluded by VFS umount, it is now safe
+        // to clear RECOVER as Linux does at clean shutdown.
+        let mut sb = self.read_super_block_cached();
+        sb.set_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER, false);
+        self.write_super_block(&sb)?;
+        self.block_device.flush()
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn transaction_start(
+        &self,
+        credits: usize,
+    ) -> Result<journal_transaction::Transaction<'_>> {
+        self.journal
+            .as_ref()
+            .ok_or_else(|| Ext4Error::new(ErrCode::ENOTSUP))?
+            .start(credits)
+    }
+
+    pub(super) fn initialize_journal(&mut self) -> Result<()> {
+        if !self.block_device.supports_reliable_flush() {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+        let mut ext4_sb = self.read_super_block_cached();
+        if !ext4_sb.has_compatible_feature(SuperBlock::FEATURE_COMPAT_HAS_JOURNAL)
+            || ext4_sb.has_compatible_feature(SuperBlock::FEATURE_COMPAT_FAST_COMMIT)
+            || ext4_sb.has_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_JOURNAL_DEV)
+            || ext4_sb.journal_device() != 0
+            || ext4_sb.journal_inode_number() == 0
+        {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+
+        let journal_inode = self.read_inode_uncached(ext4_sb.journal_inode_number())?;
+        let journal_size = journal_inode.inode.size();
+        let journal_len_u64 = journal_size / BLOCK_SIZE as u64;
+        if journal_size % BLOCK_SIZE as u64 != 0
+            || journal_len_u64 == 0
+            || journal_len_u64 > u32::MAX as u64
+            || journal_len_u64 > ext4_sb.block_count()
+        {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let journal_zero = self.extent_query(&journal_inode, 0)?;
+        if journal_zero == 0 || journal_zero >= ext4_sb.block_count() {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let raw_journal_sb = self.block_device.read_block(journal_zero)?;
+        let mut journal_sb = JournalSuperblock::parse(&raw_journal_sb.data[..], BLOCK_SIZE as u32)?;
+        let ext4_journal_uuid = ext4_sb.journal_uuid();
+        if journal_sb.max_len as u64 != journal_len_u64
+            || (ext4_journal_uuid != [0; 16] && journal_sb.uuid != ext4_journal_uuid)
+        {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+
+        let journal_len = journal_sb.max_len as usize;
+        let mut mapping = Vec::new();
+        mapping
+            .try_reserve_exact(journal_len)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        let mut journal_blocks = BTreeSet::new();
+        for logical in 0..journal_len {
+            let physical = self.extent_query(&journal_inode, logical as u32)?;
+            if physical == 0
+                || physical >= ext4_sb.block_count()
+                || !journal_blocks.insert(physical)
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            mapping.push(physical);
+        }
+
+        let needs_recovery = ext4_sb.has_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER);
+        if journal_sb.start != 0 && !needs_recovery {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        if needs_recovery {
+            let io = RecoveryDevice {
+                device: self.block_device.as_ref(),
+                journal_blocks: &mapping,
+                journal_block_set: &journal_blocks,
+                filesystem_blocks: ext4_sb.block_count(),
+            };
+            journal_recovery::recover(&io)?;
+            let recovered_block0 = self.block_device.read_block(0)?;
+            let recovered_sb: SuperBlock =
+                recovered_block0.read_offset_as(crate::constants::BASE_OFFSET);
+            if !recovered_sb.check_magic()
+                || recovered_sb.inode_size() != crate::constants::SB_GOOD_INODE_SIZE
+                || recovered_sb.desc_size() != crate::constants::SB_GOOD_DESC_SIZE
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            ext4_sb = recovered_sb;
+            *self.cached_super_block.lock() = recovered_sb;
+            let refreshed = self.block_device.read_block(mapping[0])?;
+            journal_sb = JournalSuperblock::parse(&refreshed.data[..], BLOCK_SIZE as u32)?;
+            self.inode_cache.lock().entries.clear();
+            for (index, cached) in self.cached_block_groups.iter().enumerate() {
+                let sb = self.read_super_block_cached();
+                let per_block = BLOCK_SIZE as u32 / sb.desc_size() as u32;
+                let block_id = sb.first_data_block() + index as u32 / per_block + 1;
+                let offset = (index as u32 % per_block) * sb.desc_size() as u32;
+                let block = self.block_device.read_block(block_id as PBlockId)?;
+                *cached.lock() = block.read_offset_as(offset as usize);
+            }
+        }
+
+        // Linux keeps RECOVER set for the complete read-write mount lifetime.
+        if !needs_recovery {
+            ext4_sb.set_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER, true);
+            self.write_super_block(&ext4_sb)?;
+            self.block_device.flush()?;
+        }
+
+        let mut image = Box::new([0u8; 1024]);
+        image.copy_from_slice(&self.block_device.read_block(mapping[0])?.data[..1024]);
+        let head = if journal_sb.start == 0 {
+            journal_sb.first
+        } else {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        };
+        self.journal = Some(journal_transaction::JournalTransactionCore::new(
+            journal_transaction::JournalContext {
+                superblock: journal_sb,
+                logical_blocks: mapping.into(),
+                journal_blocks: Arc::new(journal_blocks),
+                target_blocks: ext4_sb.block_count(),
+                head,
+                superblock_image: image,
+            },
+        )?);
+        Ok(())
+    }
+}
+
+impl journal_transaction::CachePublisher for Ext4 {
+    fn publish(&self, blocks: &[&journal_transaction::StagedBlock]) {
+        // Transactional inode and directory mutations must not leave value
+        // snapshots from before the checkpoint visible after commit.
+        let changed = BTreeSet::from_iter(blocks.iter().map(|block| block.home()));
+        self.inode_cache.lock().entries.retain(|inode_id, _| {
+            self.inode_disk_pos(*inode_id)
+                .map(|(block, _)| !changed.contains(&block))
+                .unwrap_or(false)
+        });
+    }
 }

--- a/kernel/crates/another_ext4/src/ext4/journal_recovery.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_recovery.rs
@@ -1,0 +1,514 @@
+//! Recovery of an internal JBD2 journal.
+//!
+//! This module deliberately does not know how ext4 maps the journal inode.
+//! Mount code must first build an immutable logical-to-physical map from the
+//! journal inode's extent tree and expose it through [`JournalRecoveryIo`].
+
+use crate::jbd2::{
+    self, BlockType, ChecksumMode, Header, Superblock, FLAG_DELETED, FLAG_ESCAPE, FLAG_LAST_TAG,
+    FLAG_SAME_UUID, MAGIC,
+};
+use crate::prelude::*;
+
+/// I/O boundary used while the normal filesystem caches are not yet live.
+pub(super) trait JournalRecoveryIo {
+    fn block_size(&self) -> usize;
+    fn filesystem_blocks(&self) -> u64;
+    fn read_journal(&self, logical: u32) -> Result<Vec<u8>>;
+    fn write_journal(&self, logical: u32, data: &[u8]) -> Result<()>;
+    fn write_home(&self, physical: u64, data: &[u8]) -> Result<()>;
+    fn is_journal_physical(&self, physical: u64) -> bool;
+    fn flush_home(&self) -> Result<()>;
+    fn flush_journal(&self) -> Result<()>;
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct RecoveryStats {
+    pub transactions: u32,
+    pub replayed: u64,
+    pub revoke_hits: u64,
+}
+
+#[derive(Clone, Copy)]
+struct Tag {
+    block: u64,
+    flags: u32,
+    checksum: Option<u32>,
+}
+
+#[derive(Clone, Copy)]
+enum Pass {
+    Scan,
+    Revoke,
+    Replay,
+}
+
+/// Replay every complete transaction and make the journal clean.
+///
+/// An empty (`s_start == 0`) journal is left untouched. On any error the
+/// journal superblock is not changed, so a later mount can retry recovery.
+pub(super) fn recover<I: JournalRecoveryIo>(io: &I) -> Result<RecoveryStats> {
+    let mut raw_sb = io.read_journal(0)?;
+    if raw_sb.len() != io.block_size() {
+        return Err(Ext4Error::new(ErrCode::EIO));
+    }
+    let sb = Superblock::parse(&raw_sb, io.block_size() as u32)?;
+    if sb.max_len == 0 {
+        return Err(Ext4Error::new(ErrCode::EIO));
+    }
+    if sb.start == 0 {
+        return Ok(RecoveryStats::default());
+    }
+
+    let seed = jbd2::checksum_seed(&sb.uuid);
+    let end_sequence = walk(
+        io,
+        &sb,
+        seed,
+        Pass::Scan,
+        None,
+        None,
+        &mut RecoveryStats::default(),
+    )?;
+    let mut revokes = BTreeMap::<u64, u32>::new();
+    walk(
+        io,
+        &sb,
+        seed,
+        Pass::Revoke,
+        Some(end_sequence),
+        Some(&mut revokes),
+        &mut RecoveryStats::default(),
+    )?;
+    let mut stats = RecoveryStats::default();
+    walk(
+        io,
+        &sb,
+        seed,
+        Pass::Replay,
+        Some(end_sequence),
+        Some(&mut revokes),
+        &mut stats,
+    )?;
+
+    // Linux orders recovered home blocks before invalidating the log. Never
+    // advertise a clean journal if a home write or its durability barrier
+    // failed.
+    io.flush_home()?;
+    put_be32(&mut raw_sb, 24, end_sequence.wrapping_add(1))?;
+    put_be32(&mut raw_sb, 28, 0)?;
+    if sb.features.checksum == ChecksumMode::V3 {
+        put_be32(&mut raw_sb, 252, 0)?;
+        let checksum = jbd2::superblock_checksum(&raw_sb)?;
+        put_be32(&mut raw_sb, 252, checksum)?;
+    }
+    io.write_journal(0, &raw_sb)?;
+    io.flush_journal()?;
+    stats.transactions = end_sequence.wrapping_sub(sb.sequence);
+    Ok(stats)
+}
+
+fn walk<I: JournalRecoveryIo>(
+    io: &I,
+    sb: &Superblock,
+    seed: u32,
+    pass: Pass,
+    stop: Option<u32>,
+    mut revokes: Option<&mut BTreeMap<u64, u32>>,
+    stats: &mut RecoveryStats,
+) -> Result<u32> {
+    let mut pos = sb.start;
+    let mut sequence = sb.sequence;
+    let ring_len = sb.max_len - sb.first;
+    let mut consumed = 0u32;
+
+    loop {
+        if stop == Some(sequence) {
+            return Ok(sequence);
+        }
+        let tx_start = pos;
+        let mut committed = false;
+        let mut transaction_checksum_invalid = false;
+        while consumed < ring_len {
+            let raw = io.read_journal(pos)?;
+            check_size(io, &raw)?;
+            let header = match Header::parse(&raw) {
+                Ok(h) if h.sequence == sequence => h,
+                _ if matches!(pass, Pass::Scan) => return Ok(sequence),
+                _ => return Err(Ext4Error::new(ErrCode::EIO)),
+            };
+            pos = advance(sb, pos);
+            consumed += 1;
+            match header.block_type {
+                BlockType::Descriptor => {
+                    if sb.features.checksum == ChecksumMode::V3 {
+                        if let Err(error) = jbd2::verify_block_checksum(seed, &raw) {
+                            if matches!(pass, Pass::Scan) {
+                                transaction_checksum_invalid = true;
+                            } else {
+                                return Err(error);
+                            }
+                        }
+                    }
+                    let tags = parse_tags(&raw, sb, io.filesystem_blocks())?;
+                    for tag in tags {
+                        if consumed >= ring_len {
+                            return if matches!(pass, Pass::Scan) {
+                                Ok(sequence)
+                            } else {
+                                Err(Ext4Error::new(ErrCode::EIO))
+                            };
+                        }
+                        let mut data = io.read_journal(pos)?;
+                        check_size(io, &data)?;
+                        pos = advance(sb, pos);
+                        consumed += 1;
+                        if let Some(expected) = tag.checksum {
+                            if jbd2::tag_checksum(seed, sequence, &data) != expected {
+                                if matches!(pass, Pass::Scan) {
+                                    transaction_checksum_invalid = true;
+                                } else {
+                                    return Err(Ext4Error::new(ErrCode::EIO));
+                                }
+                            }
+                        }
+                        if matches!(pass, Pass::Replay) && tag.flags & FLAG_DELETED == 0 {
+                            if io.is_journal_physical(tag.block) {
+                                return Err(Ext4Error::new(ErrCode::EIO));
+                            }
+                            let revoked = revokes
+                                .as_deref()
+                                .and_then(|r| r.get(&tag.block))
+                                .map(|&tid| tid_geq(tid, sequence))
+                                .unwrap_or(false);
+                            if revoked {
+                                stats.revoke_hits += 1;
+                            } else {
+                                if tag.flags & FLAG_ESCAPE != 0 {
+                                    data[..4].copy_from_slice(&MAGIC.to_be_bytes());
+                                }
+                                io.write_home(tag.block, &data)?;
+                                stats.replayed += 1;
+                            }
+                        }
+                    }
+                }
+                BlockType::Revoke => {
+                    if sb.features.checksum == ChecksumMode::V3 {
+                        if let Err(error) = jbd2::verify_block_checksum(seed, &raw) {
+                            if matches!(pass, Pass::Scan) {
+                                transaction_checksum_invalid = true;
+                            } else {
+                                return Err(error);
+                            }
+                        }
+                    }
+                    if matches!(pass, Pass::Revoke) {
+                        for block in jbd2::parse_revoke_records(
+                            &raw,
+                            sb.features,
+                            sequence,
+                            io.filesystem_blocks(),
+                        )? {
+                            if io.is_journal_physical(block) {
+                                return Err(Ext4Error::new(ErrCode::EIO));
+                            }
+                            let table = revokes.as_deref_mut().ok_or_else(eio)?;
+                            match table.get(&block) {
+                                Some(&old) if tid_geq(old, sequence) => {}
+                                _ => {
+                                    table.insert(block, sequence);
+                                }
+                            }
+                        }
+                    }
+                }
+                BlockType::Commit => {
+                    if let Err(error) = jbd2::CommitHeader::parse(&raw, sb.features, sequence, seed)
+                    {
+                        if matches!(pass, Pass::Scan) {
+                            return Ok(sequence);
+                        }
+                        return Err(error);
+                    }
+                    if transaction_checksum_invalid {
+                        return Err(Ext4Error::new(ErrCode::EIO));
+                    }
+                    committed = true;
+                    break;
+                }
+                _ if matches!(pass, Pass::Scan) => return Ok(sequence),
+                _ => return Err(Ext4Error::new(ErrCode::EIO)),
+            }
+        }
+        if !committed {
+            return if matches!(pass, Pass::Scan) {
+                Ok(sequence)
+            } else {
+                Err(Ext4Error::new(ErrCode::EIO))
+            };
+        }
+        sequence = sequence.wrapping_add(1);
+        if pos == tx_start || consumed >= ring_len {
+            return Ok(sequence);
+        }
+    }
+}
+
+fn parse_tags(block: &[u8], sb: &Superblock, target_blocks: u64) -> Result<Vec<Tag>> {
+    let tail = if sb.features.checksum == ChecksumMode::V3 {
+        4
+    } else {
+        0
+    };
+    let mut off = 12usize;
+    let end = block.len().checked_sub(tail).ok_or_else(eio)?;
+    let mut tags = Vec::new();
+    loop {
+        let size = sb.features.tag_bytes();
+        if off.checked_add(size).ok_or_else(eio)? > end {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let low = be32(block, off)? as u64;
+        let (flags, high, checksum) = if sb.features.checksum == ChecksumMode::V3 {
+            let encoded_high = be32(block, off + 8)? as u64;
+            if !sb.features.has_64bit && encoded_high != 0 {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            let high = if sb.features.has_64bit {
+                encoded_high
+            } else {
+                0
+            };
+            (be32(block, off + 4)?, high, Some(be32(block, off + 12)?))
+        } else {
+            let flags = be16(block, off + 6)? as u32;
+            let high = if sb.features.has_64bit {
+                be32(block, off + 8)? as u64
+            } else {
+                0
+            };
+            (flags, high, None)
+        };
+        off += size;
+        if flags & FLAG_SAME_UUID == 0 {
+            let uuid = block.get(off..off + 16).ok_or_else(eio)?;
+            if uuid != sb.uuid {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            off += 16;
+        }
+        let target = low | (high << 32);
+        if target >= target_blocks {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        tags.push(Tag {
+            block: target,
+            flags,
+            checksum,
+        });
+        if flags & FLAG_LAST_TAG != 0 {
+            return Ok(tags);
+        }
+    }
+}
+
+fn advance(sb: &Superblock, pos: u32) -> u32 {
+    if pos + 1 == sb.max_len {
+        sb.first
+    } else {
+        pos + 1
+    }
+}
+
+fn tid_geq(a: u32, b: u32) -> bool {
+    (a.wrapping_sub(b) as i32) >= 0
+}
+
+fn check_size<I: JournalRecoveryIo>(io: &I, block: &[u8]) -> Result<()> {
+    if block.len() == io.block_size() {
+        Ok(())
+    } else {
+        Err(eio())
+    }
+}
+fn be16(bytes: &[u8], off: usize) -> Result<u16> {
+    let s = bytes.get(off..off + 2).ok_or_else(eio)?;
+    Ok(u16::from_be_bytes([s[0], s[1]]))
+}
+fn be32(bytes: &[u8], off: usize) -> Result<u32> {
+    let s = bytes.get(off..off + 4).ok_or_else(eio)?;
+    Ok(u32::from_be_bytes([s[0], s[1], s[2], s[3]]))
+}
+fn put_be32(bytes: &mut [u8], off: usize, value: u32) -> Result<()> {
+    bytes
+        .get_mut(off..off + 4)
+        .ok_or_else(eio)?
+        .copy_from_slice(&value.to_be_bytes());
+    Ok(())
+}
+fn eio() -> Ext4Error {
+    Ext4Error::new(ErrCode::EIO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+
+    struct MemoryIo {
+        journal: RefCell<Vec<Vec<u8>>>,
+        home: RefCell<BTreeMap<u64, Vec<u8>>>,
+        journal_physical: u64,
+        events: RefCell<Vec<&'static str>>,
+    }
+
+    impl JournalRecoveryIo for MemoryIo {
+        fn block_size(&self) -> usize {
+            1024
+        }
+        fn filesystem_blocks(&self) -> u64 {
+            1024
+        }
+        fn read_journal(&self, logical: u32) -> Result<Vec<u8>> {
+            self.journal
+                .borrow()
+                .get(logical as usize)
+                .cloned()
+                .ok_or_else(eio)
+        }
+        fn write_journal(&self, logical: u32, data: &[u8]) -> Result<()> {
+            self.events.borrow_mut().push("journal-write");
+            self.journal.borrow_mut()[logical as usize].copy_from_slice(data);
+            Ok(())
+        }
+        fn write_home(&self, physical: u64, data: &[u8]) -> Result<()> {
+            self.events.borrow_mut().push("home-write");
+            self.home.borrow_mut().insert(physical, data.to_vec());
+            Ok(())
+        }
+        fn is_journal_physical(&self, physical: u64) -> bool {
+            physical == self.journal_physical
+        }
+        fn flush_home(&self) -> Result<()> {
+            self.events.borrow_mut().push("home-flush");
+            Ok(())
+        }
+        fn flush_journal(&self) -> Result<()> {
+            self.events.borrow_mut().push("journal-flush");
+            Ok(())
+        }
+    }
+
+    fn put(block: &mut [u8], off: usize, value: u32) {
+        block[off..off + 4].copy_from_slice(&value.to_be_bytes());
+    }
+    fn hdr(block: &mut [u8], kind: BlockType, seq: u32) {
+        Header {
+            block_type: kind,
+            sequence: seq,
+        }
+        .encode_into(block)
+        .unwrap();
+    }
+    fn superblock(len: u32, start: u32, seq: u32) -> Vec<u8> {
+        let mut b = vec![0; 1024];
+        hdr(&mut b, BlockType::SuperblockV2, 0);
+        put(&mut b, 12, 1024);
+        put(&mut b, 16, len);
+        put(&mut b, 20, 1);
+        put(&mut b, 24, seq);
+        put(&mut b, 28, start);
+        b[48..64].copy_from_slice(&[0x5a; 16]);
+        b
+    }
+    fn descriptor(seq: u32, target: u32, escape: bool) -> Vec<u8> {
+        let mut b = vec![0; 1024];
+        hdr(&mut b, BlockType::Descriptor, seq);
+        put(&mut b, 12, target);
+        let flags = FLAG_LAST_TAG | if escape { FLAG_ESCAPE } else { 0 };
+        b[18..20].copy_from_slice(&(flags as u16).to_be_bytes());
+        b[20..36].copy_from_slice(&[0x5a; 16]);
+        b
+    }
+    fn commit(seq: u32) -> Vec<u8> {
+        let mut b = vec![0; 1024];
+        hdr(&mut b, BlockType::Commit, seq);
+        b
+    }
+    fn revoke(seq: u32, target: u32) -> Vec<u8> {
+        let mut b = vec![0; 1024];
+        hdr(&mut b, BlockType::Revoke, seq);
+        put(&mut b, 12, 20);
+        put(&mut b, 16, target);
+        b
+    }
+    fn memory(blocks: Vec<Vec<u8>>) -> MemoryIo {
+        MemoryIo {
+            journal: RefCell::new(blocks),
+            home: RefCell::new(BTreeMap::new()),
+            journal_physical: 900,
+            events: RefCell::new(Vec::new()),
+        }
+    }
+
+    #[test]
+    fn replays_committed_transaction_across_ring_wrap_and_orders_flushes() {
+        let mut blocks = vec![vec![0; 1024]; 8];
+        blocks[0] = superblock(8, 7, 42);
+        blocks[7] = descriptor(42, 77, true);
+        blocks[1] = vec![0x33; 1024];
+        blocks[2] = commit(42);
+        let io = memory(blocks);
+        let stats = recover(&io).unwrap();
+        assert_eq!(stats.transactions, 1);
+        assert_eq!(&io.home.borrow()[&77][..4], &MAGIC.to_be_bytes());
+        assert_eq!(
+            &*io.events.borrow(),
+            &["home-write", "home-flush", "journal-write", "journal-flush"]
+        );
+        assert_eq!(be32(&io.journal.borrow()[0], 28).unwrap(), 0);
+    }
+
+    #[test]
+    fn later_revoke_filters_earlier_committed_data() {
+        let mut blocks = vec![vec![0; 1024]; 9];
+        blocks[0] = superblock(9, 1, 10);
+        // Enable revoke in the journal superblock.
+        put(&mut blocks[0], 40, jbd2::FEATURE_INCOMPAT_REVOKE);
+        blocks[1] = descriptor(10, 55, false);
+        blocks[2] = vec![0xaa; 1024];
+        blocks[3] = commit(10);
+        blocks[4] = revoke(11, 55);
+        blocks[5] = commit(11);
+        let io = memory(blocks);
+        let stats = recover(&io).unwrap();
+        assert_eq!(stats.transactions, 2);
+        assert_eq!(stats.revoke_hits, 1);
+        assert!(io.home.borrow().is_empty());
+    }
+
+    #[test]
+    fn incomplete_transaction_is_not_replayed() {
+        let mut blocks = vec![vec![0; 1024]; 6];
+        blocks[0] = superblock(6, 1, 7);
+        blocks[1] = descriptor(7, 12, false);
+        blocks[2] = vec![0xcc; 1024];
+        let io = memory(blocks);
+        assert_eq!(recover(&io).unwrap().transactions, 0);
+        assert!(io.home.borrow().is_empty());
+    }
+
+    #[test]
+    fn rejects_replay_into_the_internal_journal() {
+        let mut blocks = vec![vec![0; 1024]; 6];
+        blocks[0] = superblock(6, 1, 3);
+        blocks[1] = descriptor(3, 900, false);
+        blocks[2] = vec![1; 1024];
+        blocks[3] = commit(3);
+        let io = memory(blocks);
+        assert!(recover(&io).is_err());
+        assert!(io.home.borrow().is_empty());
+        assert_ne!(be32(&io.journal.borrow()[0], 28).unwrap(), 0);
+    }
+}

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -1,0 +1,735 @@
+//! Synchronous, single-writer JBD2 transaction core.
+//!
+//! This module deliberately does not discover the journal inode.  Mount code
+//! must validate the journal superblock and provide the complete logical to
+//! physical block map.  Keeping mapping outside the commit path also ensures
+//! that no filesystem spin lock is held while block I/O is in flight.
+#![allow(dead_code)] // Activated only after every production metadata writer uses handles.
+
+use crate::constants::BLOCK_SIZE;
+use crate::ext4_defs::{Block, BlockDevice};
+use crate::jbd2::{
+    block_checksum, checksum_seed, commit_checksum, tag_checksum, BlockType, ChecksumMode,
+    Features, Header, Superblock, BLOCK_TAIL_BYTES, CRC32C_CHKSUM, FLAG_ESCAPE, FLAG_LAST_TAG,
+    FLAG_SAME_UUID, HEADER_BYTES, MAGIC,
+};
+use crate::prelude::*;
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+const CLEAN: u8 = 0;
+const POISONED: u8 = 1;
+
+/// A fully validated journal mapping and its current allocation cursor.
+///
+/// `logical_blocks[n]` is the filesystem physical block containing journal
+/// logical block `n`.  Entry zero is the JBD2 superblock.
+pub struct JournalContext {
+    pub superblock: Superblock,
+    pub logical_blocks: Arc<[PBlockId]>,
+    pub journal_blocks: Arc<BTreeSet<PBlockId>>,
+    /// Number of addressable blocks on the filesystem device.
+    pub target_blocks: u64,
+    /// Next journal logical block to allocate.  It must be in the data ring.
+    pub head: u32,
+    /// Exact 1024-byte JBD2 superblock image read at mount.
+    pub superblock_image: Box<[u8; 1024]>,
+}
+
+impl JournalContext {
+    pub fn validate(&self) -> Result<()> {
+        let sb = &self.superblock;
+        if sb.block_size as usize != BLOCK_SIZE
+            || (sb.features.checksum == ChecksumMode::V3 && sb.checksum_type != CRC32C_CHKSUM)
+            || self.logical_blocks.len() != sb.max_len as usize
+            || self.journal_blocks.len() != self.logical_blocks.len()
+            || self.head < sb.first
+            || self.head >= sb.max_len
+            || self.target_blocks == 0
+        {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+        if self
+            .logical_blocks
+            .iter()
+            .any(|block| *block == 0 || !self.journal_blocks.contains(block))
+        {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        Ok(())
+    }
+}
+
+/// A transaction-private metadata image.  It is intentionally not `Clone`:
+/// callers cannot retain a second publishable copy past commit/abort.
+pub struct StagedBlock {
+    home: PBlockId,
+    image: Box<[u8; BLOCK_SIZE]>,
+}
+
+impl StagedBlock {
+    pub fn home(&self) -> PBlockId {
+        self.home
+    }
+
+    pub fn bytes(&self) -> &[u8; BLOCK_SIZE] {
+        &self.image
+    }
+}
+
+/// Cache changes are published only after checkpoint data is durable.
+pub trait CachePublisher: Send + Sync {
+    fn publish(&self, blocks: &[&StagedBlock]);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitFailure {
+    /// No commit record was issued; recovery will ignore any log fragments.
+    BeforeCommit,
+    /// Commit write or its durability flush failed, so commit is uncertain.
+    CommitUncertain,
+    /// The transaction committed, but home blocks are not known durable.
+    CheckpointFailed,
+    /// Home blocks are durable, but the journal tail was not durably cleared.
+    TailUpdateFailed,
+}
+
+#[derive(Debug)]
+pub struct CommitError {
+    pub error: Ext4Error,
+    pub failure: CommitFailure,
+}
+
+/// Owns the single-writer token and poison state.  The token is held only as
+/// an atomic bit; no spin guard crosses a block-device operation.
+pub struct JournalTransactionCore {
+    writer: AtomicBool,
+    poison: AtomicU8,
+    context: spin::Mutex<JournalContext>,
+}
+
+impl JournalTransactionCore {
+    pub fn new(context: JournalContext) -> Result<Self> {
+        context.validate()?;
+        Ok(Self {
+            writer: AtomicBool::new(false),
+            poison: AtomicU8::new(CLEAN),
+            context: spin::Mutex::new(context),
+        })
+    }
+
+    pub fn is_poisoned(&self) -> bool {
+        self.poison.load(Ordering::Acquire) != CLEAN
+    }
+
+    pub fn can_shutdown(&self) -> bool {
+        !self.writer.load(Ordering::Acquire) && !self.is_poisoned()
+    }
+
+    pub fn start(&self, credits: usize) -> Result<Transaction<'_>> {
+        if credits == 0 || self.is_poisoned() {
+            return Err(Ext4Error::new(if credits == 0 {
+                ErrCode::EINVAL
+            } else {
+                ErrCode::EROFS
+            }));
+        }
+        if self
+            .writer
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return Err(Ext4Error::new(ErrCode::EAGAIN));
+        }
+
+        // Reserve against a strict upper bound before any mutation is staged.
+        let reservation = {
+            let context = self.context.lock();
+            required_log_blocks(credits, context.superblock.features).and_then(|needed| {
+                ring_len(&context.superblock).map(|available| needed <= available)
+            })
+        };
+        let fits = match reservation {
+            Ok(fits) => fits,
+            Err(error) => {
+                self.writer.store(false, Ordering::Release);
+                return Err(error);
+            }
+        };
+        if !fits {
+            self.writer.store(false, Ordering::Release);
+            return Err(Ext4Error::new(ErrCode::E2BIG));
+        }
+        Ok(Transaction {
+            core: self,
+            credits,
+            staged: BTreeMap::new(),
+            owns_writer: true,
+        })
+    }
+
+    fn poison(&self) {
+        self.poison.store(POISONED, Ordering::Release);
+    }
+}
+
+pub struct Transaction<'a> {
+    core: &'a JournalTransactionCore,
+    credits: usize,
+    staged: BTreeMap<PBlockId, StagedBlock>,
+    owns_writer: bool,
+}
+
+impl Transaction<'_> {
+    /// Replace the final image for `home`.  Re-staging the same home block does
+    /// not consume another credit and subsequent reads observe the replacement.
+    pub fn stage(&mut self, home: PBlockId, image: Box<[u8; BLOCK_SIZE]>) -> Result<()> {
+        if !self.staged.contains_key(&home) && self.staged.len() == self.credits {
+            return Err(Ext4Error::new(ErrCode::E2BIG));
+        }
+        self.staged.insert(home, StagedBlock { home, image });
+        Ok(())
+    }
+
+    pub fn read<'a>(&'a self, device: &dyn BlockDevice, home: PBlockId) -> Result<BlockView<'a>> {
+        if let Some(block) = self.staged.get(&home) {
+            Ok(BlockView::Staged(block.bytes()))
+        } else {
+            Ok(BlockView::Device(device.read_block(home)?))
+        }
+    }
+
+    pub fn abort(mut self) {
+        self.release_writer();
+    }
+
+    pub fn commit(
+        mut self,
+        device: &dyn BlockDevice,
+        publisher: &dyn CachePublisher,
+    ) -> core::result::Result<(), CommitError> {
+        if self.staged.is_empty() {
+            self.release_writer();
+            return Ok(());
+        }
+        if !device.supports_reliable_flush() {
+            return self.fail(
+                Ext4Error::new(ErrCode::ENOTSUP),
+                CommitFailure::BeforeCommit,
+                false,
+            );
+        }
+
+        // Copy the small allocation state, then release the spin guard before I/O.
+        let (sb, mapping, journal_blocks, target_blocks, head, sb_image) = {
+            let context = self.core.context.lock();
+            (
+                context.superblock,
+                Arc::clone(&context.logical_blocks),
+                Arc::clone(&context.journal_blocks),
+                context.target_blocks,
+                context.head,
+                context.superblock_image.clone(),
+            )
+        };
+        let needed =
+            required_log_blocks(self.staged.len(), sb.features).map_err(|error| CommitError {
+                error,
+                failure: CommitFailure::BeforeCommit,
+            })?;
+        if needed
+            > ring_len(&sb).map_err(|error| CommitError {
+                error,
+                failure: CommitFailure::BeforeCommit,
+            })?
+        {
+            return self.fail(
+                Ext4Error::new(ErrCode::E2BIG),
+                CommitFailure::BeforeCommit,
+                false,
+            );
+        }
+
+        let sequence = sb.sequence;
+        let positions = ring_positions(&sb, head, needed).map_err(|error| CommitError {
+            error,
+            failure: CommitFailure::BeforeCommit,
+        })?;
+        if self
+            .staged
+            .values()
+            .any(|block| block.home >= target_blocks || journal_blocks.contains(&block.home))
+        {
+            return self.fail(
+                Ext4Error::new(ErrCode::EINVAL),
+                CommitFailure::BeforeCommit,
+                false,
+            );
+        }
+        // Finish every fallible format operation before the first write.  Once
+        // the active tail reaches disk, all remaining failures are I/O failures
+        // which must poison the mount.
+        let encoded = encode_log(&sb, sequence, &self.staged).map_err(|error| CommitError {
+            error,
+            failure: CommitFailure::BeforeCommit,
+        })?;
+        let commit = encode_commit(&sb, sequence).map_err(|error| CommitError {
+            error,
+            failure: CommitFailure::BeforeCommit,
+        })?;
+        let mut active_sb_image = sb_image.clone();
+        update_superblock(&mut active_sb_image, sequence, head, &sb).map_err(|error| {
+            CommitError {
+                error,
+                failure: CommitFailure::BeforeCommit,
+            }
+        })?;
+        let next_sequence = sequence.wrapping_add(1);
+        let mut clean_sb_image = sb_image;
+        update_superblock(&mut clean_sb_image, next_sequence, 0, &sb).map_err(|error| {
+            CommitError {
+                error,
+                failure: CommitFailure::BeforeCommit,
+            }
+        })?;
+
+        // Publish an active tail before log payload.  Recovery may safely scan
+        // an empty/uncommitted transaction after a crash at this point.
+        if let Err(error) = write_journal_superblock(device, &mapping, &active_sb_image)
+            .and_then(|_| device.flush())
+        {
+            return self.fail(error, CommitFailure::BeforeCommit, true);
+        }
+
+        debug_assert_eq!(encoded.len() + 1, positions.len());
+        for (logical, bytes) in positions[..encoded.len()].iter().zip(encoded.iter()) {
+            if let Err(error) = write_bytes(device, mapping[*logical as usize], bytes) {
+                return self.fail(error, CommitFailure::BeforeCommit, true);
+            }
+        }
+        if let Err(error) = device.flush() {
+            return self.fail(error, CommitFailure::BeforeCommit, true);
+        }
+
+        let commit_logical = *positions.last().unwrap();
+        if let Err(error) = write_bytes(device, mapping[commit_logical as usize], &commit) {
+            return self.fail(error, CommitFailure::CommitUncertain, true);
+        }
+        if let Err(error) = device.flush() {
+            return self.fail(error, CommitFailure::CommitUncertain, true);
+        }
+
+        for staged in self.staged.values() {
+            if let Err(error) = write_bytes(device, staged.home, staged.bytes()) {
+                return self.fail(error, CommitFailure::CheckpointFailed, true);
+            }
+        }
+        if let Err(error) = device.flush() {
+            return self.fail(error, CommitFailure::CheckpointFailed, true);
+        }
+        publisher.publish(&self.staged.values().collect::<Vec<_>>());
+
+        if let Err(error) =
+            write_journal_superblock(device, &mapping, &clean_sb_image).and_then(|_| device.flush())
+        {
+            return self.fail(error, CommitFailure::TailUpdateFailed, true);
+        }
+        {
+            let mut context = self.core.context.lock();
+            context.superblock.sequence = next_sequence;
+            context.superblock.start = 0;
+            context.head = ring_next(&sb, commit_logical);
+            context.superblock_image = clean_sb_image;
+        }
+        self.release_writer();
+        Ok(())
+    }
+
+    fn fail<T>(
+        &mut self,
+        error: Ext4Error,
+        failure: CommitFailure,
+        poison: bool,
+    ) -> core::result::Result<T, CommitError> {
+        if poison {
+            self.core.poison();
+        }
+        self.release_writer();
+        Err(CommitError { error, failure })
+    }
+
+    fn release_writer(&mut self) {
+        if self.owns_writer {
+            self.owns_writer = false;
+            self.core.writer.store(false, Ordering::Release);
+        }
+    }
+}
+
+impl Drop for Transaction<'_> {
+    fn drop(&mut self) {
+        self.release_writer();
+    }
+}
+
+pub enum BlockView<'a> {
+    Staged(&'a [u8; BLOCK_SIZE]),
+    Device(Block),
+}
+
+impl core::ops::Deref for BlockView<'_> {
+    type Target = [u8; BLOCK_SIZE];
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Staged(bytes) => bytes,
+            Self::Device(block) => &block.data,
+        }
+    }
+}
+
+fn ring_len(sb: &Superblock) -> Result<usize> {
+    sb.max_len
+        .checked_sub(sb.first)
+        .map(|n| n as usize)
+        .ok_or_else(|| Ext4Error::new(ErrCode::EIO))
+}
+
+fn tags_per_descriptor(features: Features) -> Result<usize> {
+    let tail = if features.checksum == ChecksumMode::V3 {
+        BLOCK_TAIL_BYTES
+    } else {
+        0
+    };
+    let overhead = HEADER_BYTES + 16 + tail;
+    let available = BLOCK_SIZE
+        .checked_sub(overhead)
+        .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+    let tags = available / features.tag_bytes();
+    if tags == 0 {
+        Err(Ext4Error::new(ErrCode::EIO))
+    } else {
+        Ok(tags)
+    }
+}
+
+fn required_log_blocks(blocks: usize, features: Features) -> Result<usize> {
+    let descriptors = blocks
+        .checked_add(tags_per_descriptor(features)? - 1)
+        .ok_or_else(|| Ext4Error::new(ErrCode::E2BIG))?
+        / tags_per_descriptor(features)?;
+    blocks
+        .checked_add(descriptors)
+        .and_then(|n| n.checked_add(1))
+        .ok_or_else(|| Ext4Error::new(ErrCode::E2BIG))
+}
+
+fn ring_next(sb: &Superblock, current: u32) -> u32 {
+    if current + 1 == sb.max_len {
+        sb.first
+    } else {
+        current + 1
+    }
+}
+
+fn ring_positions(sb: &Superblock, head: u32, count: usize) -> Result<Vec<u32>> {
+    if count > ring_len(sb)? || head < sb.first || head >= sb.max_len {
+        return Err(Ext4Error::new(ErrCode::E2BIG));
+    }
+    let mut result = Vec::with_capacity(count);
+    let mut current = head;
+    for _ in 0..count {
+        result.push(current);
+        current = ring_next(sb, current);
+    }
+    Ok(result)
+}
+
+fn encode_log(
+    sb: &Superblock,
+    sequence: u32,
+    staged: &BTreeMap<PBlockId, StagedBlock>,
+) -> Result<Vec<Box<[u8; BLOCK_SIZE]>>> {
+    let seed = checksum_seed(&sb.uuid);
+    let per_descriptor = tags_per_descriptor(sb.features)?;
+    let all = staged.values().collect::<Vec<_>>();
+    let mut output = Vec::new();
+    for group in all.chunks(per_descriptor) {
+        let mut descriptor = Box::new([0; BLOCK_SIZE]);
+        Header {
+            block_type: BlockType::Descriptor,
+            sequence,
+        }
+        .encode_into(&mut descriptor[..])?;
+        let mut journal_data = Vec::with_capacity(group.len());
+        let mut offset = HEADER_BYTES;
+        for (index, staged) in group.iter().enumerate() {
+            let mut image = staged.image.clone();
+            let mut flags = if index != 0 { FLAG_SAME_UUID } else { 0 };
+            if u32::from_be_bytes(
+                image[..4]
+                    .try_into()
+                    .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+            ) == MAGIC
+            {
+                image[..4].fill(0);
+                flags |= FLAG_ESCAPE;
+            }
+            if index + 1 == group.len() {
+                flags |= FLAG_LAST_TAG;
+            }
+            descriptor[offset..offset + 4].copy_from_slice(&(staged.home as u32).to_be_bytes());
+            match sb.features.checksum {
+                ChecksumMode::V3 => {
+                    if !sb.features.has_64bit && staged.home > u32::MAX as u64 {
+                        return Err(Ext4Error::new(ErrCode::ENOTSUP));
+                    }
+                    descriptor[offset + 4..offset + 8].copy_from_slice(&flags.to_be_bytes());
+                    descriptor[offset + 8..offset + 12]
+                        .copy_from_slice(&((staged.home >> 32) as u32).to_be_bytes());
+                    descriptor[offset + 12..offset + 16]
+                        .copy_from_slice(&tag_checksum(seed, sequence, &image[..]).to_be_bytes());
+                }
+                ChecksumMode::None => {
+                    if staged.home > u32::MAX as u64 {
+                        return Err(Ext4Error::new(ErrCode::ENOTSUP));
+                    }
+                    descriptor[offset + 6..offset + 8]
+                        .copy_from_slice(&(flags as u16).to_be_bytes());
+                }
+            }
+            offset += sb.features.tag_bytes();
+            if index == 0 {
+                descriptor[offset..offset + 16].copy_from_slice(&sb.uuid);
+                offset += 16;
+            }
+            journal_data.push(image);
+        }
+        if sb.features.checksum == ChecksumMode::V3 {
+            let checksum = block_checksum(seed, &descriptor[..])?;
+            descriptor[BLOCK_SIZE - 4..].copy_from_slice(&checksum.to_be_bytes());
+        }
+        output.push(descriptor);
+        output.extend(journal_data);
+    }
+    Ok(output)
+}
+
+fn encode_commit(sb: &Superblock, sequence: u32) -> Result<Box<[u8; BLOCK_SIZE]>> {
+    let mut block = Box::new([0; BLOCK_SIZE]);
+    Header {
+        block_type: BlockType::Commit,
+        sequence,
+    }
+    .encode_into(&mut block[..])?;
+    if sb.features.checksum == ChecksumMode::V3 {
+        let checksum = commit_checksum(checksum_seed(&sb.uuid), &block[..])?;
+        block[16..20].copy_from_slice(&checksum.to_be_bytes());
+    }
+    Ok(block)
+}
+
+fn update_superblock(
+    image: &mut [u8; 1024],
+    sequence: u32,
+    start: u32,
+    sb: &Superblock,
+) -> Result<()> {
+    image[24..28].copy_from_slice(&sequence.to_be_bytes());
+    image[28..32].copy_from_slice(&start.to_be_bytes());
+    if sb.features.checksum == ChecksumMode::V3 {
+        image[252..256].fill(0);
+        let checksum = crate::jbd2::superblock_checksum(image)?;
+        image[252..256].copy_from_slice(&checksum.to_be_bytes());
+    }
+    Ok(())
+}
+
+fn write_journal_superblock(
+    device: &dyn BlockDevice,
+    mapping: &[PBlockId],
+    image: &[u8; 1024],
+) -> Result<()> {
+    let mut block = device.read_block(mapping[0])?;
+    block.data[..1024].copy_from_slice(image);
+    device.write_block(&block)
+}
+
+fn write_bytes(device: &dyn BlockDevice, id: PBlockId, bytes: &[u8; BLOCK_SIZE]) -> Result<()> {
+    device.write_block(&Block::new(id, Box::new(*bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    struct MemoryDevice {
+        volatile: spin::Mutex<BTreeMap<PBlockId, Box<[u8; BLOCK_SIZE]>>>,
+        stable: spin::Mutex<BTreeMap<PBlockId, Box<[u8; BLOCK_SIZE]>>>,
+        operation: AtomicUsize,
+        fail_at: AtomicUsize,
+    }
+
+    impl MemoryDevice {
+        fn new() -> Self {
+            Self {
+                volatile: spin::Mutex::new(BTreeMap::new()),
+                stable: spin::Mutex::new(BTreeMap::new()),
+                operation: AtomicUsize::new(0),
+                fail_at: AtomicUsize::new(usize::MAX),
+            }
+        }
+
+        fn step(&self) -> Result<()> {
+            let operation = self.operation.fetch_add(1, Ordering::SeqCst);
+            if operation == self.fail_at.load(Ordering::SeqCst) {
+                Err(Ext4Error::new(ErrCode::EIO))
+            } else {
+                Ok(())
+            }
+        }
+
+        /// Simulate power loss: only the last completed flush epoch survives.
+        fn crash(&self) {
+            *self.volatile.lock() = self.stable.lock().clone();
+        }
+
+        fn stable_block(&self, id: PBlockId) -> Option<Box<[u8; BLOCK_SIZE]>> {
+            self.stable.lock().get(&id).cloned()
+        }
+    }
+
+    impl BlockDevice for MemoryDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            Ok(Block::new(
+                block_id,
+                self.volatile
+                    .lock()
+                    .get(&block_id)
+                    .cloned()
+                    .unwrap_or_else(|| Box::new([0; BLOCK_SIZE])),
+            ))
+        }
+
+        fn write_block(&self, block: &Block) -> Result<()> {
+            self.step()?;
+            self.volatile.lock().insert(block.id, block.data.clone());
+            Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
+            self.step()?;
+            *self.stable.lock() = self.volatile.lock().clone();
+            Ok(())
+        }
+
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
+    }
+
+    struct Publisher(AtomicUsize);
+    impl CachePublisher for Publisher {
+        fn publish(&self, blocks: &[&StagedBlock]) {
+            self.0.fetch_add(blocks.len(), Ordering::SeqCst);
+        }
+    }
+
+    fn context() -> JournalContext {
+        let features = Features::validate(
+            0,
+            crate::jbd2::FEATURE_INCOMPAT_CSUM_V3 | crate::jbd2::FEATURE_INCOMPAT_64BIT,
+            0,
+        )
+        .unwrap();
+        let mut image = Box::new([0; 1024]);
+        Header {
+            block_type: BlockType::SuperblockV2,
+            sequence: 7,
+        }
+        .encode_into(&mut image[..])
+        .unwrap();
+        image[12..16].copy_from_slice(&(BLOCK_SIZE as u32).to_be_bytes());
+        image[16..20].copy_from_slice(&8u32.to_be_bytes());
+        image[20..24].copy_from_slice(&1u32.to_be_bytes());
+        image[24..28].copy_from_slice(&7u32.to_be_bytes());
+        image[40..44].copy_from_slice(
+            &(crate::jbd2::FEATURE_INCOMPAT_CSUM_V3 | crate::jbd2::FEATURE_INCOMPAT_64BIT)
+                .to_be_bytes(),
+        );
+        image[48..64].copy_from_slice(b"0123456789abcdef");
+        image[80] = CRC32C_CHKSUM;
+        update_superblock(
+            &mut image,
+            7,
+            0,
+            &Superblock {
+                block_size: BLOCK_SIZE as u32,
+                max_len: 8,
+                first: 1,
+                sequence: 7,
+                start: 0,
+                errno: 0,
+                features,
+                uuid: *b"0123456789abcdef",
+                checksum_type: CRC32C_CHKSUM,
+            },
+        )
+        .unwrap();
+        JournalContext {
+            superblock: Superblock::parse(&image[..], BLOCK_SIZE as u32).unwrap(),
+            logical_blocks: Vec::from_iter(100..108).into(),
+            journal_blocks: Arc::new(BTreeSet::from_iter(100..108)),
+            target_blocks: 1000,
+            head: 7,
+            superblock_image: image,
+        }
+    }
+
+    #[test]
+    fn encodes_escape_and_wraps_ring_without_losing_home_image() {
+        let device = MemoryDevice::new();
+        let core = JournalTransactionCore::new(context()).unwrap();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let mut transaction = core.start(1).unwrap();
+        let mut image = Box::new([0x5a; BLOCK_SIZE]);
+        image[..4].copy_from_slice(&MAGIC.to_be_bytes());
+        transaction.stage(42, image).unwrap();
+        transaction.commit(&device, &publisher).unwrap();
+
+        // head=7: descriptor at 7, escaped data wraps to 1, commit at 2.
+        assert_eq!(&device.stable_block(101).unwrap()[..4], &[0, 0, 0, 0]);
+        assert_eq!(&device.stable_block(42).unwrap()[..4], &MAGIC.to_be_bytes());
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 1);
+        assert!(!core.is_poisoned());
+    }
+
+    #[test]
+    fn commit_flush_failure_never_publishes_or_checkpoints() {
+        let device = MemoryDevice::new();
+        // active sb write+flush, descriptor+data writes+flush, commit write,
+        // then fail the commit-point flush (zero-based operation 6).
+        device.fail_at.store(6, Ordering::SeqCst);
+        let core = JournalTransactionCore::new(context()).unwrap();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let mut transaction = core.start(1).unwrap();
+        transaction.stage(42, Box::new([0x33; BLOCK_SIZE])).unwrap();
+        let error = transaction.commit(&device, &publisher).unwrap_err();
+        assert_eq!(error.failure, CommitFailure::CommitUncertain);
+        assert!(core.is_poisoned());
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        device.crash();
+        assert!(device.stable_block(42).is_none());
+    }
+
+    #[test]
+    fn staging_is_deduplicated_and_reads_its_latest_write() {
+        let device = MemoryDevice::new();
+        let core = JournalTransactionCore::new(context()).unwrap();
+        let mut transaction = core.start(1).unwrap();
+        transaction.stage(42, Box::new([1; BLOCK_SIZE])).unwrap();
+        transaction.stage(42, Box::new([2; BLOCK_SIZE])).unwrap();
+        assert_eq!(transaction.read(&device, 42).unwrap()[0], 2);
+        transaction.abort();
+        assert!(core.start(1).is_ok());
+    }
+}

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -1430,6 +1430,13 @@ mod tests {
         fn write_block(&self, _block: &Block) -> Result<()> {
             Ok(())
         }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
     }
 
     fn make_test_fs(block_count: u32) -> Ext4 {
@@ -1444,6 +1451,7 @@ mod tests {
             alloc_lock: spin::Mutex::new(()),
             namespace_lock: spin::Mutex::new(()),
             poisoned: spin::Mutex::new(None),
+            journal: None,
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),
@@ -1616,6 +1624,13 @@ mod tests {
             }
             self.blocks.lock().insert(block.id, block.clone());
             Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+        fn supports_reliable_flush(&self) -> bool {
+            true
         }
     }
 

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -8,6 +8,8 @@ mod dir;
 mod extent;
 mod high_level;
 mod journal;
+mod journal_recovery;
+mod journal_transaction;
 mod link;
 mod low_level;
 mod rw;
@@ -75,6 +77,9 @@ pub struct Ext4 {
     namespace_lock: spin::Mutex<()>,
     /// First unrecoverable metadata error.  Once set, mutation must fail-stop.
     poisoned: spin::Mutex<Option<ErrCode>>,
+    /// Validated synchronous JBD2 engine. It is initialized only by
+    /// `load_writable`; read-only probing must not mutate or recover media.
+    journal: Option<journal_transaction::JournalTransactionCore>,
     /// Serializes inode metadata and extent-tree mutations per inode shard.
     ///
     /// another_ext4 stores inodes as value snapshots in a small cache. Without
@@ -139,8 +144,16 @@ impl Ext4 {
             alloc_lock: spin::Mutex::new(()),
             namespace_lock: spin::Mutex::new(()),
             poisoned: spin::Mutex::new(None),
+            journal: None,
             inode_mutation_locks,
         })
+    }
+
+    /// Load, recover and activate a filesystem for metadata mutation.
+    pub fn load_writable(block_device: Arc<dyn BlockDevice>) -> Result<Self> {
+        let mut fs = Self::load(block_device)?;
+        fs.initialize_journal()?;
+        Ok(fs)
     }
 
     /// Initializes the root directory.

--- a/kernel/crates/another_ext4/src/ext4/rw.rs
+++ b/kernel/crates/another_ext4/src/ext4/rw.rs
@@ -142,7 +142,7 @@ impl Ext4 {
     /// inode table at `index = (inode_id - 1) % sb.inodes_per_group`.
     /// To get the byte address within the inode table, use
     /// `offset = index * sb.inode_size`.
-    fn inode_disk_pos(&self, inode_id: InodeId) -> Result<(PBlockId, usize)> {
+    pub(super) fn inode_disk_pos(&self, inode_id: InodeId) -> Result<(PBlockId, usize)> {
         let super_block = self.read_super_block_cached();
         let inodes_per_group = super_block.inodes_per_group();
 

--- a/kernel/crates/another_ext4/src/ext4_defs/block.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/block.rs
@@ -80,4 +80,59 @@ pub trait BlockDevice: Send + Sync + Any {
     fn read_block(&self, block_id: PBlockId) -> Result<Block>;
     /// Write a block to disk.
     fn write_block(&self, block: &Block) -> Result<()>;
+    /// Make all writes completed before this call durable on stable storage.
+    ///
+    /// A successful return must not be used for durability unless
+    /// [`Self::supports_reliable_flush`] is also true.
+    fn flush(&self) -> Result<()>;
+    /// Whether [`Self::flush`] provides a power-loss durability barrier.
+    fn supports_reliable_flush(&self) -> bool;
+}
+
+#[cfg(test)]
+mod block_device_tests {
+    use super::*;
+
+    struct FlushDevice {
+        reliable: bool,
+        error: Option<ErrCode>,
+    }
+
+    impl BlockDevice for FlushDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            Ok(Block::new(block_id, Box::new([0; BLOCK_SIZE])))
+        }
+
+        fn write_block(&self, _block: &Block) -> Result<()> {
+            Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
+            self.error.map_or(Ok(()), |code| Err(Ext4Error::new(code)))
+        }
+
+        fn supports_reliable_flush(&self) -> bool {
+            self.reliable
+        }
+    }
+
+    #[test]
+    fn flush_capability_is_independent_from_method_presence() {
+        let device: &dyn BlockDevice = &FlushDevice {
+            reliable: false,
+            error: None,
+        };
+        assert!(!device.supports_reliable_flush());
+        assert!(device.flush().is_ok());
+    }
+
+    #[test]
+    fn flush_error_is_preserved_through_trait_dispatch() {
+        let device: &dyn BlockDevice = &FlushDevice {
+            reliable: true,
+            error: Some(ErrCode::EIO),
+        };
+        assert!(device.supports_reliable_flush());
+        assert_eq!(device.flush().unwrap_err().code(), ErrCode::EIO);
+    }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/mod.rs
@@ -17,7 +17,7 @@
 mod bitmap;
 mod block;
 mod block_group;
-mod crc;
+pub(crate) mod crc;
 mod dir;
 mod extent;
 mod inode;

--- a/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
@@ -114,6 +114,12 @@ unsafe impl AsBytes for SuperBlock {}
 impl SuperBlock {
     const SB_MAGIC: u16 = 0xEF53;
 
+    pub const FEATURE_COMPAT_HAS_JOURNAL: u32 = 0x0004;
+    pub const FEATURE_COMPAT_FAST_COMMIT: u32 = 0x0400;
+    pub const FEATURE_COMPAT_ORPHAN_FILE: u32 = 0x1000;
+    pub const FEATURE_INCOMPAT_RECOVER: u32 = 0x0004;
+    pub const FEATURE_INCOMPAT_JOURNAL_DEV: u32 = 0x0008;
+
     pub fn check_magic(&self) -> bool {
         self.magic == Self::SB_MAGIC
     }
@@ -128,6 +134,46 @@ impl SuperBlock {
 
     pub fn uuid(&self) -> [u8; 16] {
         self.uuid
+    }
+
+    pub fn compatible_features(&self) -> u32 {
+        self.features_compatible
+    }
+
+    pub fn incompatible_features(&self) -> u32 {
+        self.features_incompatible
+    }
+
+    pub fn read_only_compatible_features(&self) -> u32 {
+        self.features_read_only
+    }
+
+    pub fn has_compatible_feature(&self, feature: u32) -> bool {
+        self.features_compatible & feature != 0
+    }
+
+    pub fn has_incompatible_feature(&self, feature: u32) -> bool {
+        self.features_incompatible & feature != 0
+    }
+
+    pub fn set_incompatible_feature(&mut self, feature: u32, enabled: bool) {
+        if enabled {
+            self.features_incompatible |= feature;
+        } else {
+            self.features_incompatible &= !feature;
+        }
+    }
+
+    pub fn journal_inode_number(&self) -> u32 {
+        self.journal_inode_number
+    }
+
+    pub fn journal_device(&self) -> u32 {
+        self.journal_dev
+    }
+
+    pub fn journal_uuid(&self) -> [u8; 16] {
+        self.journal_uuid
     }
 
     /// Total number of inodes.

--- a/kernel/crates/another_ext4/src/jbd2.rs
+++ b/kernel/crates/another_ext4/src/jbd2.rs
@@ -1,12 +1,599 @@
-use crate::prelude::*;
+//! JBD2 on-disk format primitives.
+//!
+//! JBD2 is deliberately kept separate from the ext4 transaction engine: this
+//! module only decodes, validates and checksums bytes written by Linux JBD2.
+//! All integer fields in the journal are big-endian (unlike ext4 metadata).
 
-#[allow(unused)]
-pub trait Jbd2: Send + Sync + Any + Debug {
-    fn load_journal(&mut self);
-    fn journal_start(&mut self);
-    fn transaction_start(&mut self);
-    fn write_transaction(&mut self, block_id: usize, block_data: Vec<u8>);
-    fn transaction_stop(&mut self);
-    fn journal_stop(&mut self);
-    fn recover(&mut self);
+use crate::{error::Ext4Error, ext4_defs::crc::crc32, prelude::Vec, ErrCode};
+
+pub const MAGIC: u32 = 0xc03b_3998;
+pub const SUPERBLOCK_BYTES: usize = 1024;
+pub const HEADER_BYTES: usize = 12;
+pub const BLOCK_TAIL_BYTES: usize = 4;
+
+pub const FEATURE_COMPAT_CHECKSUM: u32 = 0x0000_0001;
+pub const FEATURE_INCOMPAT_REVOKE: u32 = 0x0000_0001;
+pub const FEATURE_INCOMPAT_64BIT: u32 = 0x0000_0002;
+pub const FEATURE_INCOMPAT_ASYNC_COMMIT: u32 = 0x0000_0004;
+pub const FEATURE_INCOMPAT_CSUM_V2: u32 = 0x0000_0008;
+pub const FEATURE_INCOMPAT_CSUM_V3: u32 = 0x0000_0010;
+pub const FEATURE_INCOMPAT_FAST_COMMIT: u32 = 0x0000_0020;
+
+pub const FLAG_ESCAPE: u32 = 1;
+pub const FLAG_SAME_UUID: u32 = 2;
+pub const FLAG_DELETED: u32 = 4;
+pub const FLAG_LAST_TAG: u32 = 8;
+const KNOWN_TAG_FLAGS: u32 = FLAG_ESCAPE | FLAG_SAME_UUID | FLAG_DELETED | FLAG_LAST_TAG;
+pub const CRC32C_CHKSUM: u8 = 4;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum BlockType {
+    Descriptor = 1,
+    Commit = 2,
+    SuperblockV1 = 3,
+    SuperblockV2 = 4,
+    Revoke = 5,
+}
+
+impl BlockType {
+    fn from_raw(raw: u32) -> Result<Self, Ext4Error> {
+        match raw {
+            1 => Ok(Self::Descriptor),
+            2 => Ok(Self::Commit),
+            3 => Ok(Self::SuperblockV1),
+            4 => Ok(Self::SuperblockV2),
+            5 => Ok(Self::Revoke),
+            _ => malformed("unknown JBD2 block type"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Header {
+    pub block_type: BlockType,
+    pub sequence: u32,
+}
+
+impl Header {
+    pub fn parse(bytes: &[u8]) -> Result<Self, Ext4Error> {
+        need(bytes, HEADER_BYTES)?;
+        if be32(bytes, 0)? != MAGIC {
+            return malformed("invalid JBD2 magic");
+        }
+        Ok(Self {
+            block_type: BlockType::from_raw(be32(bytes, 4)?)?,
+            sequence: be32(bytes, 8)?,
+        })
+    }
+
+    pub fn encode_into(&self, bytes: &mut [u8]) -> Result<(), Ext4Error> {
+        need(bytes, HEADER_BYTES)?;
+        put32(bytes, 0, MAGIC)?;
+        put32(bytes, 4, self.block_type as u32)?;
+        put32(bytes, 8, self.sequence)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChecksumMode {
+    /// Old journals without any checksum feature.
+    None,
+    /// Linux checksum v3: full CRC32C tags and block tails.
+    V3,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Features {
+    pub checksum: ChecksumMode,
+    pub has_64bit: bool,
+    pub has_revoke: bool,
+}
+
+impl Features {
+    /// Validate the intentionally narrow feature matrix supported by the
+    /// synchronous writer/recovery design.  V1/V2 checksums, async commit and
+    /// fast commit are rejected rather than being silently misinterpreted.
+    pub fn validate(compat: u32, incompat: u32, ro_compat: u32) -> Result<Self, Ext4Error> {
+        if ro_compat != 0 {
+            return unsupported("JBD2 read-only-compatible features are unsupported");
+        }
+        if compat != 0 {
+            return unsupported("JBD2 checksum v1 or unknown compatible feature");
+        }
+        let allowed = FEATURE_INCOMPAT_REVOKE | FEATURE_INCOMPAT_64BIT | FEATURE_INCOMPAT_CSUM_V3;
+        if incompat & !allowed != 0 {
+            return unsupported("unsupported JBD2 incompatible feature");
+        }
+        let checksum = if incompat & FEATURE_INCOMPAT_CSUM_V3 != 0 {
+            ChecksumMode::V3
+        } else {
+            ChecksumMode::None
+        };
+        Ok(Self {
+            checksum,
+            has_64bit: incompat & FEATURE_INCOMPAT_64BIT != 0,
+            has_revoke: incompat & FEATURE_INCOMPAT_REVOKE != 0,
+        })
+    }
+
+    pub const fn tag_bytes(self) -> usize {
+        match (self.checksum, self.has_64bit) {
+            (ChecksumMode::V3, true) => 16,
+            // Feature validation makes this combination unreachable.  Keep
+            // the Linux on-disk size here so manually constructed values
+            // cannot cause a short parse.
+            (ChecksumMode::V3, false) => 16,
+            (ChecksumMode::None, true) => 12,
+            (ChecksumMode::None, false) => 8,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Superblock {
+    pub block_size: u32,
+    pub max_len: u32,
+    pub first: u32,
+    pub sequence: u32,
+    pub start: u32,
+    pub errno: u32,
+    pub features: Features,
+    pub uuid: [u8; 16],
+    pub checksum_type: u8,
+}
+
+impl Superblock {
+    pub fn parse(bytes: &[u8], expected_block_size: u32) -> Result<Self, Ext4Error> {
+        need(bytes, SUPERBLOCK_BYTES)?;
+        let header = Header::parse(bytes)?;
+        if header.block_type != BlockType::SuperblockV2 {
+            return unsupported("only JBD2 superblock v2 is supported");
+        }
+        let block_size = be32(bytes, 12)?;
+        let max_len = be32(bytes, 16)?;
+        let first = be32(bytes, 20)?;
+        let start = be32(bytes, 28)?;
+        if block_size != expected_block_size || block_size < SUPERBLOCK_BYTES as u32 {
+            return unsupported("unsupported JBD2 block size");
+        }
+        if max_len <= first || first == 0 || start >= max_len || (start != 0 && start < first) {
+            return malformed("JBD2 journal ring is out of range");
+        }
+        let features = Features::validate(be32(bytes, 36)?, be32(bytes, 40)?, be32(bytes, 44)?)?;
+        let checksum_type = bytes[80];
+        if features.checksum == ChecksumMode::V3 {
+            if checksum_type != CRC32C_CHKSUM {
+                return unsupported("JBD2 checksum v3 is not CRC32C");
+            }
+            if superblock_checksum(bytes)? != be32(bytes, 252)? {
+                return malformed("invalid JBD2 superblock checksum");
+            }
+        } else if checksum_type != 0 {
+            return unsupported("legacy JBD2 journal declares a checksum type");
+        }
+        let mut uuid = [0; 16];
+        uuid.copy_from_slice(&bytes[48..64]);
+        Ok(Self {
+            block_size,
+            max_len,
+            first,
+            sequence: be32(bytes, 24)?,
+            start,
+            errno: be32(bytes, 32)?,
+            features,
+            uuid,
+            checksum_type,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DescriptorTag {
+    pub block: u64,
+    pub flags: u32,
+    pub checksum: Option<u32>,
+}
+
+pub struct DescriptorTags<'a> {
+    bytes: &'a [u8],
+    features: Features,
+    offset: usize,
+    end: usize,
+    target_blocks: u64,
+    finished: bool,
+}
+
+impl<'a> DescriptorTags<'a> {
+    pub fn parse(
+        block: &'a [u8],
+        features: Features,
+        expected_sequence: u32,
+        target_blocks: u64,
+    ) -> Result<Self, Ext4Error> {
+        let header = Header::parse(block)?;
+        if header.block_type != BlockType::Descriptor || header.sequence != expected_sequence {
+            return malformed("unexpected JBD2 descriptor header");
+        }
+        let tail = if features.checksum == ChecksumMode::V3 {
+            BLOCK_TAIL_BYTES
+        } else {
+            0
+        };
+        if block.len() < HEADER_BYTES + features.tag_bytes() + tail {
+            return malformed("JBD2 descriptor has no complete tag");
+        }
+        Ok(Self {
+            bytes: block,
+            features,
+            offset: HEADER_BYTES,
+            end: block.len() - tail,
+            target_blocks,
+            finished: false,
+        })
+    }
+
+    pub fn next_tag(&mut self) -> Result<Option<DescriptorTag>, Ext4Error> {
+        if self.finished {
+            return Ok(None);
+        }
+        let size = self.features.tag_bytes();
+        let tag_end = self.offset.checked_add(size).ok_or_else(eio)?;
+        if tag_end > self.end {
+            return malformed("unterminated JBD2 descriptor tags");
+        }
+        let low = be32(self.bytes, self.offset)? as u64;
+        let (flags, high, checksum) = match self.features.checksum {
+            ChecksumMode::V3 => {
+                let flags = be32(self.bytes, self.offset + 4)?;
+                let encoded_high = be32(self.bytes, self.offset + 8)? as u64;
+                if !self.features.has_64bit && encoded_high != 0 {
+                    return malformed("32-bit JBD2 tag has a non-zero high block number");
+                }
+                let high = if self.features.has_64bit {
+                    encoded_high
+                } else {
+                    0
+                };
+                (flags, high, Some(be32(self.bytes, self.offset + 12)?))
+            }
+            ChecksumMode::None => {
+                let flags = be16(self.bytes, self.offset + 6)? as u32;
+                let high = if self.features.has_64bit {
+                    be32(self.bytes, self.offset + 8)? as u64
+                } else {
+                    0
+                };
+                (flags, high, None)
+            }
+        };
+        if flags & !KNOWN_TAG_FLAGS != 0 {
+            return malformed("unknown JBD2 descriptor tag flag");
+        }
+        self.offset = tag_end;
+        if flags & FLAG_SAME_UUID == 0 {
+            self.offset = self.offset.checked_add(16).ok_or_else(eio)?;
+            if self.offset > self.end {
+                return malformed("truncated JBD2 descriptor UUID");
+            }
+        }
+        let block = low | (high << 32);
+        if block >= self.target_blocks {
+            return malformed("JBD2 descriptor target block is out of range");
+        }
+        self.finished = flags & FLAG_LAST_TAG != 0;
+        Ok(Some(DescriptorTag {
+            block,
+            flags,
+            checksum,
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CommitHeader {
+    pub sequence: u32,
+    pub checksum: Option<u32>,
+    pub commit_sec: u64,
+    pub commit_nsec: u32,
+}
+
+impl CommitHeader {
+    pub fn parse(
+        block: &[u8],
+        features: Features,
+        expected_sequence: u32,
+        checksum_seed: u32,
+    ) -> Result<Self, Ext4Error> {
+        need(block, 60)?;
+        let header = Header::parse(block)?;
+        if header.block_type != BlockType::Commit || header.sequence != expected_sequence {
+            return malformed("unexpected JBD2 commit header");
+        }
+        let checksum = if features.checksum == ChecksumMode::V3 {
+            if commit_checksum(checksum_seed, block)? != be32(block, 16)? {
+                return malformed("invalid JBD2 commit checksum");
+            }
+            Some(be32(block, 16)?)
+        } else {
+            None
+        };
+        Ok(Self {
+            sequence: header.sequence,
+            checksum,
+            commit_sec: be64(block, 48)?,
+            commit_nsec: be32(block, 56)?,
+        })
+    }
+}
+
+/// Parse all revoke records after checking header, count, alignment and range.
+pub fn parse_revoke_records(
+    block: &[u8],
+    features: Features,
+    expected_sequence: u32,
+    target_blocks: u64,
+) -> Result<Vec<u64>, Ext4Error> {
+    if !features.has_revoke {
+        return unsupported("JBD2 revoke block without revoke feature");
+    }
+    let header = Header::parse(block)?;
+    if header.block_type != BlockType::Revoke || header.sequence != expected_sequence {
+        return malformed("unexpected JBD2 revoke header");
+    }
+    let count = be32(block, 12)? as usize;
+    let tail = if features.checksum == ChecksumMode::V3 {
+        BLOCK_TAIL_BYTES
+    } else {
+        0
+    };
+    if count < 16 || count > block.len().saturating_sub(tail) {
+        return malformed("JBD2 revoke byte count is out of range");
+    }
+    let width = if features.has_64bit { 8 } else { 4 };
+    if (count - 16) % width != 0 {
+        return malformed("misaligned JBD2 revoke records");
+    }
+    let mut records = Vec::with_capacity((count - 16) / width);
+    let mut offset = 16;
+    while offset < count {
+        let record = if width == 8 {
+            be64(block, offset)?
+        } else {
+            be32(block, offset)? as u64
+        };
+        if record >= target_blocks {
+            return malformed("JBD2 revoke target block is out of range");
+        }
+        records.push(record);
+        offset += width;
+    }
+    Ok(records)
+}
+
+pub fn superblock_checksum(bytes: &[u8]) -> Result<u32, Ext4Error> {
+    need(bytes, SUPERBLOCK_BYTES)?;
+    let mut checksum = crc32(u32::MAX, &bytes[..252]);
+    checksum = crc32(checksum, &[0; 4]);
+    Ok(crc32(checksum, &bytes[256..SUPERBLOCK_BYTES]))
+}
+
+pub fn block_checksum(seed: u32, block: &[u8]) -> Result<u32, Ext4Error> {
+    if block.len() < BLOCK_TAIL_BYTES {
+        return malformed("short JBD2 checksummed block");
+    }
+    let tail = block.len() - BLOCK_TAIL_BYTES;
+    let mut checksum = crc32(seed, &block[..tail]);
+    checksum = crc32(checksum, &[0; 4]);
+    Ok(checksum)
+}
+
+pub fn verify_block_checksum(seed: u32, block: &[u8]) -> Result<(), Ext4Error> {
+    let provided = be32(block, block.len().checked_sub(4).ok_or_else(eio)?)?;
+    if block_checksum(seed, block)? != provided {
+        return malformed("invalid JBD2 block checksum");
+    }
+    Ok(())
+}
+
+pub fn tag_checksum(seed: u32, sequence: u32, data_block: &[u8]) -> u32 {
+    let checksum = crc32(seed, &sequence.to_be_bytes());
+    crc32(checksum, data_block)
+}
+
+/// Linux initializes `journal->j_csum_seed` as crc32c(~0, journal UUID).
+pub fn checksum_seed(uuid: &[u8; 16]) -> u32 {
+    crc32(u32::MAX, uuid)
+}
+
+pub fn commit_checksum(seed: u32, block: &[u8]) -> Result<u32, Ext4Error> {
+    need(block, 20)?;
+    let mut checksum = crc32(seed, &block[..16]);
+    checksum = crc32(checksum, &[0; 4]);
+    Ok(crc32(checksum, &block[20..]))
+}
+
+fn need(bytes: &[u8], len: usize) -> Result<(), Ext4Error> {
+    if bytes.len() < len {
+        malformed("truncated JBD2 structure")
+    } else {
+        Ok(())
+    }
+}
+fn be16(bytes: &[u8], off: usize) -> Result<u16, Ext4Error> {
+    let value = bytes
+        .get(off..off.checked_add(2).ok_or_else(eio)?)
+        .ok_or_else(eio)?;
+    Ok(u16::from_be_bytes([value[0], value[1]]))
+}
+fn be32(bytes: &[u8], off: usize) -> Result<u32, Ext4Error> {
+    let value = bytes
+        .get(off..off.checked_add(4).ok_or_else(eio)?)
+        .ok_or_else(eio)?;
+    Ok(u32::from_be_bytes(value.try_into().map_err(|_| eio())?))
+}
+fn be64(bytes: &[u8], off: usize) -> Result<u64, Ext4Error> {
+    let value = bytes
+        .get(off..off.checked_add(8).ok_or_else(eio)?)
+        .ok_or_else(eio)?;
+    Ok(u64::from_be_bytes(value.try_into().map_err(|_| eio())?))
+}
+fn put32(bytes: &mut [u8], off: usize, value: u32) -> Result<(), Ext4Error> {
+    let dst = bytes
+        .get_mut(off..off.checked_add(4).ok_or_else(eio)?)
+        .ok_or_else(eio)?;
+    dst.copy_from_slice(&value.to_be_bytes());
+    Ok(())
+}
+fn eio() -> Ext4Error {
+    Ext4Error::new(ErrCode::EIO)
+}
+fn malformed<T>(_message: &'static str) -> Result<T, Ext4Error> {
+    Err(eio())
+}
+fn unsupported<T>(_message: &'static str) -> Result<T, Ext4Error> {
+    Err(Ext4Error::new(ErrCode::ENOTSUP))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header(block: &mut [u8], kind: BlockType, sequence: u32) {
+        Header {
+            block_type: kind,
+            sequence,
+        }
+        .encode_into(block)
+        .unwrap();
+    }
+
+    #[test]
+    fn header_uses_linux_big_endian_bytes() {
+        let mut bytes = [0; 12];
+        header(&mut bytes, BlockType::Descriptor, 0x0102_0304);
+        assert_eq!(bytes, [0xc0, 0x3b, 0x39, 0x98, 0, 0, 0, 1, 1, 2, 3, 4]);
+        assert_eq!(Header::parse(&bytes).unwrap().sequence, 0x0102_0304);
+    }
+
+    #[test]
+    fn feature_matrix_rejects_unsafe_formats() {
+        assert_eq!(
+            Features::validate(0, FEATURE_INCOMPAT_CSUM_V3 | FEATURE_INCOMPAT_64BIT, 0)
+                .unwrap()
+                .tag_bytes(),
+            16
+        );
+        assert_eq!(
+            Features::validate(0, FEATURE_INCOMPAT_CSUM_V3, 0)
+                .unwrap()
+                .tag_bytes(),
+            16
+        );
+        for (compat, incompat) in [
+            (FEATURE_COMPAT_CHECKSUM, 0),
+            (0, FEATURE_INCOMPAT_CSUM_V2),
+            (0, FEATURE_INCOMPAT_ASYNC_COMMIT),
+            (0, FEATURE_INCOMPAT_FAST_COMMIT),
+        ] {
+            assert_eq!(
+                Features::validate(compat, incompat, 0).unwrap_err().code(),
+                ErrCode::ENOTSUP
+            );
+        }
+    }
+
+    #[test]
+    fn parses_v3_64bit_tags_and_checks_bounds() {
+        let features =
+            Features::validate(0, FEATURE_INCOMPAT_CSUM_V3 | FEATURE_INCOMPAT_64BIT, 0).unwrap();
+        let mut block = [0; 64];
+        header(&mut block, BlockType::Descriptor, 7);
+        block[12..16].copy_from_slice(&2u32.to_be_bytes());
+        block[16..20].copy_from_slice(&(FLAG_SAME_UUID | FLAG_LAST_TAG).to_be_bytes());
+        block[20..24].copy_from_slice(&1u32.to_be_bytes());
+        block[24..28].copy_from_slice(&0x1122_3344u32.to_be_bytes());
+        let mut tags = DescriptorTags::parse(&block, features, 7, (1u64 << 32) + 3).unwrap();
+        assert_eq!(
+            tags.next_tag().unwrap().unwrap(),
+            DescriptorTag {
+                block: (1u64 << 32) + 2,
+                flags: FLAG_SAME_UUID | FLAG_LAST_TAG,
+                checksum: Some(0x1122_3344),
+            }
+        );
+        assert!(tags.next_tag().unwrap().is_none());
+        assert_eq!(
+            DescriptorTags::parse(&block, features, 7, 2)
+                .unwrap()
+                .next_tag()
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+    }
+
+    #[test]
+    fn v3_32bit_tag_rejects_nonzero_high_block_number() {
+        let features = Features::validate(0, FEATURE_INCOMPAT_CSUM_V3, 0).unwrap();
+        let mut block = [0; 64];
+        header(&mut block, BlockType::Descriptor, 7);
+        block[12..16].copy_from_slice(&2u32.to_be_bytes());
+        block[16..20].copy_from_slice(&(FLAG_SAME_UUID | FLAG_LAST_TAG).to_be_bytes());
+        block[20..24].copy_from_slice(&1u32.to_be_bytes());
+        let mut tags = DescriptorTags::parse(&block, features, 7, 16).unwrap();
+        assert_eq!(tags.next_tag().unwrap_err().code(), ErrCode::EIO);
+
+        block[20..24].fill(0);
+        let mut tags = DescriptorTags::parse(&block, features, 7, 16).unwrap();
+        assert_eq!(tags.next_tag().unwrap().unwrap().block, 2);
+    }
+
+    #[test]
+    fn checksum_helpers_have_stable_golden_values() {
+        assert_eq!(tag_checksum(u32::MAX, 0x0102_0304, b"jbd2"), 0x7d34_43ff);
+        let mut block = [0u8; 32];
+        header(&mut block, BlockType::Descriptor, 9);
+        assert_eq!(block_checksum(0x1234_5678, &block).unwrap(), 0xa454_bd12);
+    }
+
+    #[test]
+    fn parses_64bit_revoke_records_safely() {
+        let features =
+            Features::validate(0, FEATURE_INCOMPAT_REVOKE | FEATURE_INCOMPAT_64BIT, 0).unwrap();
+        let mut block = [0; 32];
+        header(&mut block, BlockType::Revoke, 3);
+        block[12..16].copy_from_slice(&24u32.to_be_bytes());
+        block[16..24].copy_from_slice(&0x0000_0001_0000_0002u64.to_be_bytes());
+        assert_eq!(
+            parse_revoke_records(&block, features, 3, 1u64 << 34).unwrap(),
+            [0x0000_0001_0000_0002]
+        );
+    }
+
+    #[test]
+    fn parses_v2_superblock_and_detects_checksum_damage() {
+        let mut bytes = [0u8; SUPERBLOCK_BYTES];
+        header(&mut bytes, BlockType::SuperblockV2, 11);
+        bytes[12..16].copy_from_slice(&4096u32.to_be_bytes());
+        bytes[16..20].copy_from_slice(&1024u32.to_be_bytes());
+        bytes[20..24].copy_from_slice(&1u32.to_be_bytes());
+        bytes[24..28].copy_from_slice(&11u32.to_be_bytes());
+        bytes[28..32].copy_from_slice(&1u32.to_be_bytes());
+        bytes[40..44]
+            .copy_from_slice(&(FEATURE_INCOMPAT_CSUM_V3 | FEATURE_INCOMPAT_64BIT).to_be_bytes());
+        bytes[48..64].copy_from_slice(b"0123456789abcdef");
+        bytes[80] = CRC32C_CHKSUM;
+        let checksum = superblock_checksum(&bytes).unwrap();
+        bytes[252..256].copy_from_slice(&checksum.to_be_bytes());
+        let sb = Superblock::parse(&bytes, 4096).unwrap();
+        assert_eq!(sb.sequence, 11);
+        assert_eq!(sb.features.checksum, ChecksumMode::V3);
+
+        bytes[100] ^= 1;
+        assert_eq!(
+            Superblock::parse(&bytes, 4096).unwrap_err().code(),
+            ErrCode::EIO
+        );
+    }
 }

--- a/kernel/crates/another_ext4/src/jbd2.rs
+++ b/kernel/crates/another_ext4/src/jbd2.rs
@@ -351,7 +351,7 @@ pub fn parse_revoke_records(
         return malformed("JBD2 revoke byte count is out of range");
     }
     let width = if features.has_64bit { 8 } else { 4 };
-    if (count - 16) % width != 0 {
+    if !(count - 16).is_multiple_of(width) {
         return malformed("misaligned JBD2 revoke records");
     }
     let mut records = Vec::with_capacity((count - 16) / width);

--- a/kernel/crates/another_ext4/src/lib.rs
+++ b/kernel/crates/another_ext4/src/lib.rs
@@ -6,7 +6,7 @@ mod constants;
 mod error;
 mod ext4;
 mod ext4_defs;
-mod jbd2;
+pub mod jbd2;
 mod prelude;
 
 pub use constants::{BLOCK_SIZE, EXT4_ROOT_INO, INODE_BLOCK_SIZE};

--- a/kernel/src/arch/riscv64/driver/vf2/dw_mshc/mmc.rs
+++ b/kernel/src/arch/riscv64/driver/vf2/dw_mshc/mmc.rs
@@ -850,6 +850,10 @@ impl BlockDevice for MMC {
         Ok(())
     }
 
+    fn supports_reliable_flush(&self) -> bool {
+        false
+    }
+
     fn blk_size_log2(&self) -> u8 {
         9
     }

--- a/kernel/src/driver/base/block/block_device.rs
+++ b/kernel/src/driver/base/block/block_device.rs
@@ -261,6 +261,9 @@ pub trait BlockDevice: Device {
     /// @brief: 同步磁盘信息，把所有的dirty数据写回硬盘 - 待实现
     fn sync(&self) -> Result<(), SystemError>;
 
+    /// Whether `sync()` issues a power-loss-safe cache flush/barrier.
+    fn supports_reliable_flush(&self) -> bool;
+
     /// @brief: 每个块设备都必须固定自己块大小，而且该块大小必须是2的幂次
     /// @return: 返回一个固定量，硬编码(编程的时候固定的常量).
     fn blk_size_log2(&self) -> u8;

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -1330,7 +1330,17 @@ impl BlockDevice for LoopDevice {
     }
 
     fn sync(&self) -> Result<(), SystemError> {
-        Ok(())
+        let inode = self.inner().file_inode.clone().ok_or(SystemError::ENODEV)?;
+        inode.sync()?;
+        inode.fs().sync_fs(true)
+    }
+
+    fn supports_reliable_flush(&self) -> bool {
+        self.inner()
+            .file_inode
+            .as_ref()
+            .map(|inode| inode.fs().supports_reliable_flush())
+            .unwrap_or(false)
     }
 
     fn blk_size_log2(&self) -> u8 {

--- a/kernel/src/driver/block/pmem/device.rs
+++ b/kernel/src/driver/block/pmem/device.rs
@@ -364,6 +364,10 @@ impl BlockDevice for PmemBlockDevice {
         Ok(())
     }
 
+    fn supports_reliable_flush(&self) -> bool {
+        self.flush.is_some()
+    }
+
     fn blk_size_log2(&self) -> u8 {
         9
     }

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -707,6 +707,13 @@ impl BlockDevice for VirtIOBlkDevice {
         Ok(())
     }
 
+    fn supports_reliable_flush(&self) -> bool {
+        self.inner()
+            .device_inner
+            .as_ref()
+            .is_some_and(|device| device.supports_flush())
+    }
+
     fn blk_size_log2(&self) -> u8 {
         9
     }

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -545,6 +545,10 @@ impl BlockDevice for LockedAhciDisk {
         return self.inner().sync();
     }
 
+    fn supports_reliable_flush(&self) -> bool {
+        false
+    }
+
     #[inline]
     fn device(&self) -> Arc<dyn Device> {
         return self.inner().self_ref.upgrade().unwrap();

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -118,6 +118,10 @@ impl Default for Ext4MountOptions {
 }
 
 impl FileSystem for Ext4FileSystem {
+    fn supports_reliable_flush(&self) -> bool {
+        self.fs.supports_reliable_flush()
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.root_inode.clone()
     }
@@ -168,7 +172,7 @@ impl FileSystem for Ext4FileSystem {
             EvictionEpoch::new(self.eviction_queue.lock().next_epoch)
         });
         let flush_result = self.flush_dirty_inodes();
-        if let Some(epoch) = eviction_epoch {
+        let result = if let Some(epoch) = eviction_epoch {
             // Finish the snapshotted asynchronous metadata work even if inode
             // writeback failed, while preserving that earlier error for the
             // caller and the superblock writeback error sequence.
@@ -176,6 +180,17 @@ impl FileSystem for Ext4FileSystem {
             flush_result.and(eviction_result)
         } else {
             flush_result
+        };
+        if wait {
+            result.and_then(|_| self.fs.flush_device().map_err(SystemError::from))
+        } else {
+            result
+        }
+    }
+
+    fn on_umount(&self) {
+        if let Err(error) = self.fs.shutdown_writable() {
+            log::error!("ext4: failed to mark journal clean on unmount: {:?}", error);
         }
     }
 
@@ -611,6 +626,8 @@ impl Ext4FileSystem {
         mount_options: Ext4MountOptions,
     ) -> Result<Arc<dyn FileSystem>, SystemError> {
         let raw_dev = mount_data.device_num();
+        // The JBD2 writer is not activated for production mounts until every
+        // metadata mutation path has been converted to explicit handles.
         let fs = another_ext4::Ext4::load(mount_data.clone())?;
         let root_inode: Arc<LockedExt4Inode> =
             Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| {

--- a/kernel/src/filesystem/ext4/gendisk.rs
+++ b/kernel/src/filesystem/ext4/gendisk.rs
@@ -82,4 +82,15 @@ impl another_ext4::BlockDevice for GenDisk {
             })?;
         Ok(())
     }
+
+    fn flush(&self) -> core::result::Result<(), another_ext4::Ext4Error> {
+        self.sync().map_err(|e| {
+            log::error!("Ext4BlkDevice flush failed: {:?}", e);
+            another_ext4::Ext4Error::new(Self::map_system_error_to_ext4(&e))
+        })
+    }
+
+    fn supports_reliable_flush(&self) -> bool {
+        self.block_device().supports_reliable_flush()
+    }
 }

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -425,6 +425,13 @@ impl FileSystemMakerData for TmpfsMountData {
 }
 
 impl FileSystem for Tmpfs {
+    fn supports_reliable_flush(&self) -> bool {
+        // tmpfs has no crash-surviving backing state. A loop image stored here
+        // disappears as a whole on power loss, so there is no partially
+        // durable post-crash image for JBD2 to recover.
+        true
+    }
+
     unsafe fn fault(
         &self,
         pfm: &mut crate::mm::fault::PageFaultMessage,

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -1740,6 +1740,10 @@ impl WritebackControl {
 
 /// @brief 所有文件系统都应该实现的trait
 pub trait FileSystem: Any + Sync + Send + Debug {
+    /// Whether `sync_fs(true)` reaches a power-loss-safe backing barrier.
+    fn supports_reliable_flush(&self) -> bool {
+        false
+    }
     /// @brief 获取当前文件系统的root inode的指针
     fn root_inode(&self) -> Arc<dyn IndexNode>;
 

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -2648,6 +2648,10 @@ impl IndexNode for MountFSInode {
 }
 
 impl FileSystem for MountFS {
+    fn supports_reliable_flush(&self) -> bool {
+        self.inner_filesystem.supports_reliable_flush()
+    }
+
     fn support_readahead(&self) -> bool {
         self.inner_filesystem.support_readahead()
     }


### PR DESCRIPTION
## Summary

- add strict JBD2 on-disk parsing and feature validation for legacy and checksum-v3 journals
- add bounded three-pass recovery with revoke processing, checksum verification, ring wrapping, replay ordering, and safe tail clearing
- add a synchronous metadata transaction foundation with credit accounting, staged-write deduplication, commit checksums, flush barriers, and poisoned-error propagation
- propagate reliable-flush capability through DragonOS block devices and filesystem wrappers, rejecting writable journal initialization when durability cannot be guaranteed

## Safety and scope

The implementation deliberately does not enable the new writer in the production unlink path yet. Doing so before every related metadata mutation is journaled, and before replacing spinlock-held mutation regions with a sleepable transaction boundary, would create a false atomicity guarantee and risk holding spinlocks across I/O. This PR establishes and validates the durability/recovery foundation required by the follow-up orphan persistence work.

Unsupported JBD2 feature combinations and storage without a reliable flush contract are rejected rather than silently degraded.

## Validation

- `cargo test --manifest-path kernel/crates/another_ext4/Cargo.toml` — 50/50 passed
- `ext4_test` release integration suite, including `e2fsck` validation — passed
- `ROOTFS_MANIFEST=ubuntu2404 make kernel` — passed
- Ubuntu 24.04 DragonOS QEMU boot smoke test — passed
- guest `ext4_inode_identity_test` — 5/5 passed
- guest `fdatasync_test` — 7/7 passed
- guest `syncfs_semantics_test` — 12/12 passed
- eight-role adversarial review and focused follow-up review completed; confirmed issues were corrected and re-tested

Closes #2049
