### PR TITLE
feat(ext4): recover zero-link orphan inodes

### DIFF
--- a/kernel/crates/another_ext4/ext4_test/src/cache_test.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/cache_test.rs
@@ -536,6 +536,79 @@ pub fn deferred_reclaim_lifecycle_test(ext4: &Ext4) {
     println!("  [PASS] deferred reclaim lifecycle and rename replacement");
 }
 
+pub fn full_directory_orphan_relink_test(ext4: &Ext4) {
+    let file_mode = InodeMode::FILE | InodeMode::ALL_RW;
+    let dir_mode = InodeMode::DIRECTORY | InodeMode::ALL_RWX;
+    let parent = ext4
+        .mkdir(ROOT_INO, "full_relink_dir", dir_mode)
+        .expect("create full relink directory failed");
+    assert_eq!(
+        ext4.create(parent, &"n".repeat(256), file_mode)
+            .expect_err("256-byte name must be rejected")
+            .code(),
+        another_ext4::ErrCode::ENAMETOOLONG
+    );
+    let victim = ext4
+        .create(parent, "v", file_mode)
+        .expect("create relink victim failed");
+    let spacer = ext4
+        .create(ROOT_INO, "full_relink_spacer", file_mode)
+        .expect("create allocation spacer failed");
+    let mut fillers = Vec::new();
+    for index in 0..75 {
+        let prefix = format!("f{index:02}");
+        let name = format!("{}{}", prefix, "x".repeat(255 - prefix.len()));
+        ext4.create(parent, &name, file_mode)
+            .expect("fill relink directory failed");
+        fillers.push(name);
+        if index % 15 == 14 {
+            let offset = (index / 15) * BLOCK_SIZE;
+            ext4.write(spacer, offset, &[0x5a])
+                .expect("fragment directory allocation failed");
+        }
+    }
+    let blocks_before = ext4.getattr(parent).unwrap().blocks;
+    assert!(
+        blocks_before / 8 > ext4.getattr(parent).unwrap().size / BLOCK_SIZE as u64,
+        "fixture must force external extent-tree metadata"
+    );
+    let handle = ext4
+        .unlink(parent, "v")
+        .expect("unlink full-directory victim failed")
+        .expect("victim unlink must return handle");
+    let relink_name = format!("r{}", "y".repeat(254));
+    ext4.link(victim, parent, &relink_name)
+        .expect("full-directory orphan relink failed");
+    assert!(
+        ext4.getattr(parent).unwrap().blocks > blocks_before,
+        "relink should prepare a new empty directory block"
+    );
+    drop(handle);
+
+    reclaim(
+        ext4,
+        ext4.unlink(parent, &relink_name)
+            .expect("unlink relink target failed"),
+    );
+    for name in fillers {
+        reclaim(
+            ext4,
+            ext4.unlink(parent, &name).expect("unlink filler failed"),
+        );
+    }
+    reclaim(
+        ext4,
+        ext4.rmdir(ROOT_INO, "full_relink_dir")
+            .expect("remove full relink directory failed"),
+    );
+    reclaim(
+        ext4,
+        ext4.unlink(ROOT_INO, "full_relink_spacer")
+            .expect("remove allocation spacer failed"),
+    );
+    println!("  [PASS] full-directory orphan relink preparation");
+}
+
 /// Run all cache correctness tests.
 pub fn run_all_cache_tests(ext4: &Ext4, _image_path: &str) {
     println!("=== Cache Correctness Tests ===");
@@ -546,6 +619,7 @@ pub fn run_all_cache_tests(ext4: &Ext4, _image_path: &str) {
     block_group_cache_test(ext4);
     metadata_consistency_after_lookup_test(ext4);
     deferred_reclaim_lifecycle_test(ext4);
+    full_directory_orphan_relink_test(ext4);
     cache_eviction_stress_test(ext4);
     // e2fsck is run after dropping ext4 to ensure all writes are flushed
     println!("  (e2fsck validation deferred to after drop)");

--- a/kernel/crates/another_ext4/ext4_test/src/main.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/main.rs
@@ -19,7 +19,7 @@ fn make_ext4() {
         .args(["if=/dev/zero", "of=ext4.img", "bs=1M", "count=512"])
         .status();
     let _ = std::process::Command::new("mkfs.ext4")
-        .args(["ext4.img"])
+        .args(["-O", "^orphan_file", "ext4.img"])
         .output();
 }
 
@@ -504,6 +504,156 @@ fn prepare_buffered_write_does_not_commit_size_test() {
     println!("prepare buffered write size boundary test done");
 }
 
+fn legacy_orphan_mount_cleanup_test() {
+    make_ext4();
+    let orphan = {
+        let ext4 = load_ext4();
+        let mode = InodeMode::FILE | InodeMode::ALL_RWX;
+        let inode = ext4
+            .generic_create(ROOT_INO, "crash_orphan", mode)
+            .expect("create crash orphan failed");
+        ext4.write(inode, 0, &vec![0x5a; 3 * 1024 * 1024])
+            .expect("write crash orphan failed");
+
+        // Model a crash after the final unlink transaction but before the VFS
+        // lifetime owner invokes reclaim_inode(): persist the one-shot handle
+        // only in volatile memory, then drop the mounted instance.
+        let handle = ext4
+            .unlink(ROOT_INO, "crash_orphan")
+            .expect("final unlink transaction failed")
+            .expect("final unlink did not produce reclaim handle");
+        drop(handle);
+        inode
+    };
+
+    let ext4 = load_ext4();
+    ext4
+        .generic_lookup(ROOT_INO, "crash_orphan")
+        .expect_err("orphaned name reappeared after recovery");
+    ext4
+        .getattr(orphan)
+        .expect_err("mount recovery did not reclaim orphan inode");
+    ext4.shutdown_writable()
+        .expect("clean writable shutdown failed");
+    drop(ext4);
+
+    let output = std::process::Command::new("e2fsck")
+        .args(["-fn", "ext4.img"])
+        .output()
+        .expect("e2fsck failed");
+    assert!(
+        output.status.success(),
+        "orphan recovery e2fsck FAILED:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    println!("legacy orphan mount cleanup test done");
+}
+
+fn rename_replace_orphan_mount_cleanup_test() {
+    make_ext4();
+    let replaced = {
+        let ext4 = load_ext4();
+        let mode = InodeMode::FILE | InodeMode::ALL_RWX;
+        ext4.generic_create(ROOT_INO, "rename_source", mode)
+            .expect("create rename source failed");
+        let replaced = ext4
+            .generic_create(ROOT_INO, "rename_target", mode)
+            .expect("create rename target failed");
+        ext4.write(replaced, 0, &vec![0xa5; 1024 * 1024])
+            .expect("write rename target failed");
+
+        // Model a crash after the atomic replace transaction and before the
+        // VFS lifetime owner consumes the reclaim capability.  The replaced
+        // inode must already be on the durable legacy orphan chain.
+        let handle = ext4
+            .rename(ROOT_INO, "rename_source", ROOT_INO, "rename_target")
+            .expect("rename replace transaction failed")
+            .expect("final target replacement did not return reclaim handle");
+        drop(handle);
+        replaced
+    };
+
+    let ext4 = load_ext4();
+    ext4.getattr(replaced)
+        .expect_err("mount recovery did not reclaim rename target orphan");
+    ext4.generic_lookup(ROOT_INO, "rename_source")
+        .expect_err("rename source name reappeared after recovery");
+    ext4.generic_lookup(ROOT_INO, "rename_target")
+        .expect("rename target disappeared after recovery");
+    ext4.shutdown_writable()
+        .expect("clean writable shutdown failed");
+    drop(ext4);
+
+    let output = std::process::Command::new("e2fsck")
+        .args(["-fn", "ext4.img"])
+        .output()
+        .expect("e2fsck failed");
+    assert!(
+        output.status.success(),
+        "rename orphan recovery e2fsck FAILED:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    println!("rename replace orphan mount cleanup test done");
+}
+
+fn cross_parent_directory_replace_orphan_test() {
+    make_ext4();
+    let replaced = {
+        let ext4 = load_ext4();
+        let mode = InodeMode::DIRECTORY | InodeMode::ALL_RWX;
+        let old_parent = ext4
+            .generic_create(ROOT_INO, "old_parent", mode)
+            .expect("create old parent failed");
+        let new_parent = ext4
+            .generic_create(ROOT_INO, "new_parent", mode)
+            .expect("create new parent failed");
+        let source = ext4
+            .generic_create(old_parent, "source_dir", mode)
+            .expect("create source directory failed");
+        let replaced = ext4
+            .generic_create(new_parent, "target_dir", mode)
+            .expect("create target directory failed");
+
+        let handle = ext4
+            .rename(old_parent, "source_dir", new_parent, "target_dir")
+            .expect("cross-parent directory replace transaction failed")
+            .expect("directory replacement did not return reclaim handle");
+        assert_eq!(
+            ext4.generic_lookup(new_parent, "target_dir")
+                .expect("new directory entry missing"),
+            source
+        );
+        ext4.generic_lookup(old_parent, "source_dir")
+            .expect_err("old directory entry survived replace");
+        assert_eq!(
+            ext4.generic_lookup(source, "..").expect("new '..' missing"),
+            new_parent
+        );
+        drop(handle);
+        replaced
+    };
+
+    let ext4 = load_ext4();
+    ext4.getattr(replaced)
+        .expect_err("mount recovery did not reclaim replaced directory");
+    ext4.shutdown_writable()
+        .expect("clean writable shutdown failed");
+    drop(ext4);
+    let output = std::process::Command::new("e2fsck")
+        .args(["-fn", "ext4.img"])
+        .output()
+        .expect("e2fsck failed");
+    assert!(
+        output.status.success(),
+        "cross-parent directory rename e2fsck FAILED:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    println!("cross-parent directory replace orphan test done");
+}
+
 fn main() {
     SimpleLogger::new().init().unwrap();
     log::set_max_level(log::LevelFilter::Off);
@@ -531,12 +681,17 @@ fn main() {
     extent_corruption_test();
     println!("extent corruption test done");
 
+    rename_replace_orphan_mount_cleanup_test();
+    cross_parent_directory_replace_orphan_test();
+
     // Interleaved setattr + writeback test
     interleaved_setattr_writeback_test();
 
     sparse_growth_and_range_writeback_test();
 
     prepare_buffered_write_does_not_commit_size_test();
+
+    legacy_orphan_mount_cleanup_test();
 
     // Cache correctness tests — run on a fresh image
     // Use load_ext4 (not open_ext4) to avoid init() corrupting mkfs.ext4 checksums

--- a/kernel/crates/another_ext4/src/error.rs
+++ b/kernel/crates/another_ext4/src/error.rs
@@ -45,6 +45,8 @@ pub enum ErrCode {
     EMLINK = 31,
     /// Math result not representable.
     ERANGE = 34,
+    /// File name too long.
+    ENAMETOOLONG = 36,
     /// Directory not empty.
     ENOTEMPTY = 39,
     /// No data available.

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -526,7 +526,7 @@ impl Ext4 {
         let mut sb = self.transaction_read_super_block(&transaction)?;
         self.transaction_orphan_del(&mut transaction, &inode, &mut sb)?;
         self.transaction_dealloc_inode(&mut transaction, inode_id, is_dir)?;
-        let mut cleared = InodeRef::new(inode_id, Box::new(Inode::default()));
+        let mut cleared = InodeRef::new(inode_id, Box::default());
         cleared.inode.set_generation(generation);
         self.transaction_stage_inode_with_csum(&mut transaction, &mut cleared)?;
         self.commit_reclaim_transaction(transaction)

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -541,10 +541,11 @@ impl Ext4 {
             );
         }
         let inode = self.read_inode_uncached(inode_id)?;
+        let sb = self.read_super_block_cached();
         if inode.inode.mode().bits() == 0
             || inode.inode.link_count() != 0
             || inode.inode.generation() != generation
-            || !inode.verify_checksum(&self.read_super_block_cached().uuid())
+            || !super::orphan::inode_checksum_valid(&sb, &inode)
         {
             return_error!(
                 ErrCode::EINVAL,

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -19,6 +19,23 @@ fn extent_tail_batch_limit(
     Some(core::cmp::min(count, in_last_group as u32))
 }
 
+fn linked_orphan_tail_remove_limit(
+    keep_blocks: u64,
+    tail_start: u32,
+    tail_blocks: u32,
+    group_limit: u32,
+) -> Option<u32> {
+    let tail_end = tail_start as u64 + tail_blocks as u64;
+    if tail_end <= keep_blocks {
+        return None;
+    }
+    let beyond_eof = tail_end - core::cmp::max(keep_blocks, tail_start as u64);
+    Some(core::cmp::min(
+        group_limit,
+        core::cmp::min(beyond_eof, u32::MAX as u64) as u32,
+    ))
+}
+
 impl Ext4 {
     fn restore_inode_allocation_state(
         &self,
@@ -420,6 +437,95 @@ impl Ext4 {
             self.inode_mutation_locks[self.inode_mutation_lock_index(inode_id)].lock();
         let generation = self.read_inode_uncached(inode_id)?.inode.generation();
         self.reclaim_inode_lifetime(inode_id, generation)
+    }
+
+    /// Complete a crash-interrupted truncate for an inode that still has names.
+    /// Blocks at or beyond ceil(i_size / block_size) are removed in restartable
+    /// transactions; the inode itself and its xattrs remain live.
+    pub(super) fn recover_linked_orphan_inode_by_id(&self, inode_id: InodeId) -> Result<()> {
+        self.ensure_mutable()?;
+        let _mutation_guard =
+            self.inode_mutation_locks[self.inode_mutation_lock_index(inode_id)].lock();
+        if !self.legacy_orphan_contains(inode_id)? {
+            return_error!(ErrCode::EINVAL, "Inode {} is not orphaned", inode_id);
+        }
+        loop {
+            let mut inode = self.read_inode_uncached(inode_id)?;
+            let sb = self.read_super_block_cached();
+            if !self.inode_is_allocated(inode_id)?
+                || inode.inode.mode().bits() == 0
+                || inode.inode.link_count() == 0
+                || !super::orphan::inode_checksum_valid(&sb, &inode)
+                || !inode.inode.is_file()
+                || !inode.inode.uses_extents()
+            {
+                return_error!(ErrCode::EIO, "Invalid linked truncate orphan {}", inode_id);
+            }
+            let keep_blocks = inode.inode.size().div_ceil(BLOCK_SIZE as u64);
+            let mut transaction = self.transaction_start(32)?;
+            let Some(tail) = self.extent_tail(&transaction, &inode)? else {
+                transaction.abort();
+                break;
+            };
+            let extent_end = tail
+                .start_pblock
+                .checked_add(tail.block_count as PBlockId)
+                .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent physical range"))?;
+            if tail.start_pblock == 0
+                || extent_end > sb.block_count()
+                || self.journal_owns_block_range(tail.start_pblock, extent_end)
+            {
+                return_error!(ErrCode::EIO, "Invalid linked orphan extent");
+            }
+            let group_limit = extent_tail_batch_limit(
+                sb.first_data_block() as PBlockId,
+                sb.blocks_per_group() as PBlockId,
+                tail.start_pblock,
+                tail.block_count,
+            )
+            .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent tail"))?;
+            let Some(remove_limit) = linked_orphan_tail_remove_limit(
+                keep_blocks,
+                tail.start_lblock,
+                tail.block_count,
+                group_limit,
+            ) else {
+                transaction.abort();
+                break;
+            };
+            let removed = self
+                .extent_remove_tail_in_transaction(&mut transaction, &mut inode, remove_limit)?
+                .ok_or_else(|| format_error!(ErrCode::EIO, "Extent tail disappeared"))?;
+            self.transaction_dealloc_block_range(
+                &mut transaction,
+                removed.start_pblock,
+                removed.block_count,
+            )?;
+            for metadata in removed.metadata_blocks.iter().copied() {
+                self.transaction_dealloc_block_range(&mut transaction, metadata, 1)?;
+            }
+            let released = removed.block_count as u64 + removed.metadata_blocks.len() as u64;
+            inode.inode.set_fs_block_count(
+                inode
+                    .inode
+                    .fs_block_count()
+                    .checked_sub(released)
+                    .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid inode block count"))?,
+            );
+            self.transaction_stage_inode_with_csum(&mut transaction, &mut inode)?;
+            self.commit_reclaim_transaction(transaction)?;
+        }
+
+        let mut inode = self.read_inode_uncached(inode_id)?;
+        if inode.inode.link_count() == 0 {
+            return_error!(ErrCode::EIO, "Linked truncate orphan lost all links");
+        }
+        let mut transaction = self.transaction_start(8)?;
+        let mut sb = self.transaction_read_super_block(&transaction)?;
+        self.transaction_orphan_del(&mut transaction, &inode, &mut sb)?;
+        inode.inode.set_next_orphan(0);
+        self.transaction_stage_inode_with_csum(&mut transaction, &mut inode)?;
+        self.commit_reclaim_transaction(transaction)
     }
 
     fn reclaim_inode_lifetime(&self, inode_id: InodeId, generation: u32) -> Result<()> {
@@ -967,7 +1073,7 @@ impl Ext4 {
 
 #[cfg(test)]
 mod reclaim_tests {
-    use super::extent_tail_batch_limit;
+    use super::{extent_tail_batch_limit, linked_orphan_tail_remove_limit};
 
     #[test]
     fn extent_reclaim_batch_never_crosses_a_block_group() {
@@ -982,5 +1088,13 @@ mod reclaim_tests {
         assert_eq!(extent_tail_batch_limit(1, 8, 0, 1), None);
         assert_eq!(extent_tail_batch_limit(0, 8, u64::MAX, 2), None);
         assert_eq!(extent_tail_batch_limit(0, 0, 1, 1), None);
+    }
+
+    #[test]
+    fn linked_orphan_trim_preserves_eof_block_and_honors_group_batch() {
+        assert_eq!(linked_orphan_tail_remove_limit(5, 3, 6, 6), Some(4));
+        assert_eq!(linked_orphan_tail_remove_limit(5, 3, 6, 2), Some(2));
+        assert_eq!(linked_orphan_tail_remove_limit(5, 8, 3, 3), Some(3));
+        assert_eq!(linked_orphan_tail_remove_limit(12, 8, 3, 3), None);
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -648,16 +648,23 @@ impl Ext4 {
             let old_bitmap_block = bitmap_block.clone();
             let old_bg = BlockGroupRef::new(bg.id, bg.desc);
             let old_sb = sb;
-            let mut bitmap = Bitmap::new(&mut *bitmap_block.data, blocks_in_group);
-
-            let bit = match bitmap.find_and_set_first_clear_bit(0, blocks_in_group) {
-                Some(bit) => bit,
-                None => continue,
+            let bit = {
+                let mut bitmap = Bitmap::new(&mut *bitmap_block.data, blocks_in_group);
+                match bitmap.find_and_set_first_clear_bit(0, blocks_in_group) {
+                    Some(bit) => bit,
+                    None => continue,
+                }
             };
             let fblock = Self::block_group_first_block(&sb, bgid) + bit as PBlockId;
 
             // Set block group checksum
-            bg.desc.set_block_bitmap_csum(&sb.uuid(), &bitmap);
+            if !bg.desc.update_block_bitmap_csum(
+                &sb.uuid(),
+                &*bitmap_block.data,
+                sb.clusters_per_group() as usize / 8,
+            ) {
+                return_error!(ErrCode::EIO, "Invalid block bitmap checksum length");
+            }
             self.write_block(&bitmap_block)?;
 
             // Update block group counters
@@ -749,15 +756,22 @@ impl Ext4 {
         let old_bitmap_block = bitmap_block.clone();
         let old_bg = BlockGroupRef::new(bg.id, bg.desc);
         let old_sb = sb;
-        let mut bitmap = Bitmap::new(&mut *bitmap_block.data, blocks_in_group);
-
-        // Free the block
-        if bitmap.is_bit_clear(bit) {
-            return_error!(ErrCode::EINVAL, "Block {} is already free", pblock);
+        {
+            let mut bitmap = Bitmap::new(&mut *bitmap_block.data, blocks_in_group);
+            // Free the block
+            if bitmap.is_bit_clear(bit) {
+                return_error!(ErrCode::EINVAL, "Block {} is already free", pblock);
+            }
+            bitmap.clear_bit(bit);
         }
-        bitmap.clear_bit(bit);
         // Set block group checksum
-        bg.desc.set_block_bitmap_csum(&sb.uuid(), &bitmap);
+        if !bg.desc.update_block_bitmap_csum(
+            &sb.uuid(),
+            &*bitmap_block.data,
+            sb.clusters_per_group() as usize / 8,
+        ) {
+            return_error!(ErrCode::EIO, "Invalid block bitmap checksum length");
+        }
         self.write_block(&bitmap_block)?;
 
         // Update block group counters
@@ -805,19 +819,26 @@ impl Ext4 {
             let old_bg = BlockGroupRef::new(bg.id, bg.desc);
             let old_sb = sb;
             let inode_count = sb.inode_count_in_group(bgid) as usize;
-            let mut bitmap = Bitmap::new(&mut *bitmap_block.data, inode_count);
-
-            // Find a free inode
-            let idx_in_bg =
+            // Find a free inode, limiting allocation to real inodes even though
+            // the checksum covers the fixed inodes_per_group bitmap length.
+            let idx_in_bg = {
+                let mut bitmap = Bitmap::new(&mut *bitmap_block.data, inode_count);
                 bitmap
                     .find_and_set_first_clear_bit(0, inode_count)
                     .ok_or(format_error!(
                         ErrCode::ENOSPC,
                         "No free inodes in block group {}",
                         bgid
-                    ))? as u32;
+                    ))? as u32
+            };
             // Update bitmap in disk
-            bg.desc.set_inode_bitmap_csum(&sb.uuid(), &bitmap);
+            if !bg.desc.update_inode_bitmap_csum(
+                &sb.uuid(),
+                &*bitmap_block.data,
+                sb.inodes_per_group() as usize / 8,
+            ) {
+                return_error!(ErrCode::EIO, "Invalid inode bitmap checksum length");
+            }
             self.write_block(&bitmap_block)?;
 
             // Modify block group counters
@@ -881,20 +902,27 @@ impl Ext4 {
         let old_bg = BlockGroupRef::new(bg.id, bg.desc);
         let old_sb = sb;
         let inode_count = sb.inode_count_in_group(bgid) as usize;
-        let mut bitmap = Bitmap::new(&mut *bitmap_block.data, inode_count);
-
-        // Free the inode
-        if bitmap.is_bit_clear(idx_in_bg as usize) {
-            return_error!(
-                ErrCode::EINVAL,
-                "Inode {} is already free in block group {}",
-                inode_ref.id,
-                bgid
-            );
+        {
+            let mut bitmap = Bitmap::new(&mut *bitmap_block.data, inode_count);
+            // Free the inode
+            if bitmap.is_bit_clear(idx_in_bg as usize) {
+                return_error!(
+                    ErrCode::EINVAL,
+                    "Inode {} is already free in block group {}",
+                    inode_ref.id,
+                    bgid
+                );
+            }
+            bitmap.clear_bit(idx_in_bg as usize);
         }
-        bitmap.clear_bit(idx_in_bg as usize);
         // Update bitmap in disk
-        bg.desc.set_inode_bitmap_csum(&sb.uuid(), &bitmap);
+        if !bg.desc.update_inode_bitmap_csum(
+            &sb.uuid(),
+            &*bitmap_block.data,
+            sb.inodes_per_group() as usize / 8,
+        ) {
+            return_error!(ErrCode::EIO, "Invalid inode bitmap checksum length");
+        }
         self.write_block(&bitmap_block)?;
 
         // Update block group counters

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -5,6 +5,20 @@ use crate::format_error;
 use crate::prelude::*;
 use crate::return_error;
 
+fn extent_tail_batch_limit(
+    first_data_block: PBlockId,
+    blocks_per_group: PBlockId,
+    start: PBlockId,
+    count: u32,
+) -> Option<u32> {
+    if blocks_per_group == 0 || count == 0 || start < first_data_block {
+        return None;
+    }
+    let last = start.checked_add(count as PBlockId)?.checked_sub(1)?;
+    let in_last_group = (last - first_data_block) % blocks_per_group + 1;
+    Some(core::cmp::min(count, in_last_group as u32))
+}
+
 impl Ext4 {
     fn restore_inode_allocation_state(
         &self,
@@ -28,7 +42,7 @@ impl Ext4 {
     }
 
     fn block_group_first_block(sb: &SuperBlock, bgid: BlockGroupId) -> PBlockId {
-        bgid as PBlockId * sb.blocks_per_group() as PBlockId
+        sb.first_data_block() as PBlockId + bgid as PBlockId * sb.blocks_per_group() as PBlockId
     }
 
     fn block_group_block_count(sb: &SuperBlock, bgid: BlockGroupId) -> usize {
@@ -38,6 +52,192 @@ impl Ext4 {
             return 0;
         }
         core::cmp::min(sb.blocks_per_group() as u64, total - first) as usize
+    }
+
+    /// Stage the release of one contiguous physical-block range.
+    ///
+    /// This changes allocation metadata only.  In particular, freed data is
+    /// not zeroed: after commit the blocks no longer belong to this inode and
+    /// clearing them would be both unnecessary I/O and a race with reuse.
+    pub(super) fn transaction_dealloc_block_range(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        first: PBlockId,
+        count: u32,
+    ) -> Result<()> {
+        let _alloc_guard = self.alloc_lock.lock();
+        if count == 0 {
+            return_error!(ErrCode::EINVAL, "Cannot free an empty block range");
+        }
+
+        let mut sb = self.transaction_read_super_block(transaction)?;
+        let last_exclusive = first
+            .checked_add(count as PBlockId)
+            .ok_or_else(|| format_error!(ErrCode::EINVAL, "Block range overflows"))?;
+        if first < sb.first_data_block() as PBlockId
+            || first >= sb.block_count()
+            || last_exclusive > sb.block_count()
+        {
+            return_error!(
+                ErrCode::EINVAL,
+                "Invalid block range {}..{}",
+                first,
+                last_exclusive
+            );
+        }
+        let blocks_per_group = sb.blocks_per_group() as PBlockId;
+        let data_first = sb.first_data_block() as PBlockId;
+        let bgid = ((first - data_first) / blocks_per_group) as BlockGroupId;
+        if ((last_exclusive - 1 - data_first) / blocks_per_group) as BlockGroupId != bgid {
+            return_error!(ErrCode::EINVAL, "Block range crosses a block group");
+        }
+        let group_first = Self::block_group_first_block(&sb, bgid);
+        let bit = (first - group_first) as usize;
+        let count = count as usize;
+        let blocks_in_group = Self::block_group_block_count(&sb, bgid);
+        if bit
+            .checked_add(count)
+            .is_none_or(|end| end > blocks_in_group)
+        {
+            return_error!(ErrCode::EINVAL, "Block range exceeds block group");
+        }
+        self.validate_data_blocks(first, count as u64)?;
+
+        let mut bg = self.transaction_read_block_group(transaction, bgid)?;
+        let bitmap_block_id = bg.desc.block_bitmap_block();
+        let metadata_csum =
+            sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
+        let checksum_bytes = (sb.clusters_per_group() as usize) / 8;
+        if metadata_csum {
+            if !bg.verify_checksum(&sb.uuid()) {
+                return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
+            }
+            let bitmap_image = transaction.read(self.block_device.as_ref(), bitmap_block_id)?;
+            if !bg
+                .desc
+                .verify_block_bitmap_csum(&sb.uuid(), &*bitmap_image, checksum_bytes)
+            {
+                return_error!(ErrCode::EIO, "Corrupt block bitmap checksum");
+            }
+        }
+        // Validate all accounting before mutating the transaction image.  A
+        // corrupt counter must not leave a half-applied bitmap update behind.
+        let new_bg_free = bg
+            .desc
+            .get_free_blocks_count()
+            .checked_add(count as u64)
+            .filter(|value| *value <= blocks_in_group as u64)
+            .ok_or_else(|| format_error!(ErrCode::EINVAL, "Invalid block-group free count"))?;
+        let new_sb_free = sb
+            .free_blocks_count()
+            .checked_add(count as u64)
+            .filter(|value| *value <= sb.block_count())
+            .ok_or_else(|| format_error!(ErrCode::EINVAL, "Invalid filesystem free count"))?;
+        {
+            let image = self.transaction_block_for_update(transaction, bitmap_block_id)?;
+            let mut bitmap = Bitmap::new(image, blocks_in_group);
+            if (bit..bit + count).any(|index| bitmap.is_bit_clear(index)) {
+                return_error!(ErrCode::EINVAL, "Block range contains a free block");
+            }
+            for index in bit..bit + count {
+                bitmap.clear_bit(index);
+            }
+            if metadata_csum
+                && !bg
+                    .desc
+                    .update_block_bitmap_csum(&sb.uuid(), image, checksum_bytes)
+            {
+                return_error!(ErrCode::EIO, "Invalid block bitmap checksum length");
+            }
+        }
+
+        bg.desc.set_free_blocks_count(new_bg_free);
+        self.transaction_stage_block_group_with_csum(transaction, &mut bg, &sb.uuid())?;
+        sb.set_free_blocks_count(new_sb_free);
+        self.transaction_stage_super_block(transaction, &sb)
+    }
+
+    /// Stage final inode-number release.  `itable_unused` describes the
+    /// never-initialized tail of the inode table, not reusable inode slots, so
+    /// freeing an inode must leave it unchanged (as Linux ext4 does).
+    pub(super) fn transaction_dealloc_inode(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode_id: InodeId,
+        is_dir: bool,
+    ) -> Result<()> {
+        let _alloc_guard = self.alloc_lock.lock();
+        let mut sb = self.transaction_read_super_block(transaction)?;
+        if inode_id == 0 || inode_id > sb.inode_count() {
+            return_error!(ErrCode::EINVAL, "Invalid inode {}", inode_id);
+        }
+        let inodes_per_group = sb.inodes_per_group();
+        let bgid = ((inode_id - 1) / inodes_per_group) as BlockGroupId;
+        let idx = ((inode_id - 1) % inodes_per_group) as usize;
+        let inode_count = sb.inode_count_in_group(bgid) as usize;
+        if idx >= inode_count {
+            return_error!(ErrCode::EINVAL, "Invalid inode index {}", idx);
+        }
+
+        let mut bg = self.transaction_read_block_group(transaction, bgid)?;
+        let bitmap_block_id = bg.desc.inode_bitmap_block();
+        let metadata_csum =
+            sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
+        let checksum_bytes = (sb.inodes_per_group() as usize) / 8;
+        if metadata_csum {
+            if !bg.verify_checksum(&sb.uuid()) {
+                return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
+            }
+            let bitmap_image = transaction.read(self.block_device.as_ref(), bitmap_block_id)?;
+            if !bg
+                .desc
+                .verify_inode_bitmap_csum(&sb.uuid(), &*bitmap_image, checksum_bytes)
+            {
+                return_error!(ErrCode::EIO, "Corrupt inode bitmap checksum");
+            }
+        }
+        let new_bg_free = bg
+            .desc
+            .free_inodes_count()
+            .checked_add(1)
+            .filter(|value| *value <= inode_count as u32)
+            .ok_or_else(|| format_error!(ErrCode::EINVAL, "Invalid block-group inode count"))?;
+        let new_sb_free = sb
+            .free_inodes_count()
+            .checked_add(1)
+            .filter(|value| *value <= sb.inode_count())
+            .ok_or_else(|| format_error!(ErrCode::EINVAL, "Invalid filesystem inode count"))?;
+        let new_used_dirs =
+            if is_dir {
+                Some(bg.desc.used_dirs_count().checked_sub(1).ok_or_else(|| {
+                    format_error!(ErrCode::EINVAL, "Invalid used-directory count")
+                })?)
+            } else {
+                None
+            };
+        {
+            let image = self.transaction_block_for_update(transaction, bitmap_block_id)?;
+            let mut bitmap = Bitmap::new(image, inode_count);
+            if bitmap.is_bit_clear(idx) {
+                return_error!(ErrCode::EINVAL, "Inode {} is already free", inode_id);
+            }
+            bitmap.clear_bit(idx);
+            if metadata_csum
+                && !bg
+                    .desc
+                    .update_inode_bitmap_csum(&sb.uuid(), image, checksum_bytes)
+            {
+                return_error!(ErrCode::EIO, "Invalid inode bitmap checksum length");
+            }
+        }
+
+        bg.desc.set_free_inodes_count(new_bg_free);
+        if let Some(used) = new_used_dirs {
+            bg.desc.set_used_dirs_count(used);
+        }
+        self.transaction_stage_block_group_with_csum(transaction, &mut bg, &sb.uuid())?;
+        sb.set_free_inodes_count(new_sb_free);
+        self.transaction_stage_super_block(transaction, &sb)
     }
 
     /// Create a new inode, returning the inode and its number
@@ -145,26 +345,17 @@ impl Ext4 {
         // Free the data blocks allocated for the inode
         let pblocks = self.extent_all_data_blocks(inode)?;
         for pblock in pblocks {
-            // Deallocate the block
             self.dealloc_block(inode, pblock)?;
-            // Clear the block content
-            self.write_block(&Block::new(pblock, Box::new([0; BLOCK_SIZE])))?;
         }
         // Free extent tree
         let pblocks = self.extent_all_tree_blocks(inode)?;
         for pblock in pblocks {
-            // Deallocate the block
             self.dealloc_block(inode, pblock)?;
-            // Clear the block content
-            self.write_block(&Block::new(pblock, Box::new([0; BLOCK_SIZE])))?;
         }
         // Free xattr block
         let xattr_block = inode.inode.xattr_block();
         if xattr_block != 0 {
-            // Deallocate the block
             self.dealloc_block(inode, xattr_block)?;
-            // Clear the block content
-            self.write_block(&Block::new(xattr_block, Box::new([0; BLOCK_SIZE])))?;
         }
         // Deallocate the inode
         self.dealloc_inode(inode)?;
@@ -211,34 +402,171 @@ impl Ext4 {
 
     fn reclaim_inode_inner(&self, handle: &InodeReclaimHandle) -> Result<()> {
         self.ensure_mutable()?;
+        // Delayed VFS eviction runs after the namespace operation released its
+        // guard. Re-enter the transactional domain for the complete multi-
+        // transaction reclaim so no legacy direct writer can race snapshots.
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _mutation_guard =
             self.inode_mutation_locks[self.inode_mutation_lock_index(handle.inode_id)].lock();
-        if !self.inode_is_allocated(handle.inode_id)? {
+        self.reclaim_inode_lifetime(handle.inode_id, handle.generation)
+    }
+
+    /// Reclaim a mount-recovery orphan without manufacturing a VFS lifetime
+    /// capability. The generation is read authoritatively before entering the
+    /// same validated orchestration used by delayed final close.
+    pub(super) fn reclaim_orphan_inode_by_id(&self, inode_id: InodeId) -> Result<()> {
+        self.ensure_mutable()?;
+        let _mutation_guard =
+            self.inode_mutation_locks[self.inode_mutation_lock_index(inode_id)].lock();
+        let generation = self.read_inode_uncached(inode_id)?.inode.generation();
+        self.reclaim_inode_lifetime(inode_id, generation)
+    }
+
+    fn reclaim_inode_lifetime(&self, inode_id: InodeId, generation: u32) -> Result<()> {
+        self.validate_reclaim_inode(inode_id, generation)?;
+        if !self.legacy_orphan_contains(inode_id)? {
+            return_error!(ErrCode::EINVAL, "Inode {} is not orphaned", inode_id);
+        }
+        // Each iteration starts from the checkpointed inode-table entry.  The
+        // on-disk extent root is therefore the restart cursor after any crash.
+        // Chain membership was fully validated once above. The metadata write
+        // barrier keeps the chain stable, avoiding O(extents * orphan_count)
+        // repeated walks; final orphan_del performs its own bounded walk.
+        loop {
+            let mut inode = self.validate_reclaim_inode(inode_id, generation)?;
+            if !inode.inode.uses_extents() {
+                if inode.inode.fs_block_count() != 0 {
+                    return_error!(ErrCode::EIO, "Non-extent orphan owns blocks");
+                }
+                break;
+            }
+
+            let mut transaction = self.transaction_start(32)?;
+            let Some(tail) = self.extent_tail(&transaction, &inode)? else {
+                break;
+            };
+            let extent_end = tail
+                .start_pblock
+                .checked_add(tail.block_count as PBlockId)
+                .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent physical range"))?;
+            if tail.start_pblock == 0
+                || extent_end > self.read_super_block_cached().block_count()
+                || self.journal_owns_block_range(tail.start_pblock, extent_end)
+            {
+                return_error!(
+                    ErrCode::EIO,
+                    "Orphan extent overlaps invalid or journal-owned blocks"
+                );
+            }
+            // transaction_dealloc_block_range deliberately accepts one block
+            // group only. Trim the right edge at that boundary so bitmap and
+            // counters stay a compact, independently restartable unit.
+            let sb = self.read_super_block_cached();
+            let blocks_per_group = sb.blocks_per_group() as PBlockId;
+            let remove_limit = extent_tail_batch_limit(
+                sb.first_data_block() as PBlockId,
+                blocks_per_group,
+                tail.start_pblock,
+                tail.block_count,
+            )
+            .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent tail"))?;
+            let removed = self
+                .extent_remove_tail_in_transaction(&mut transaction, &mut inode, remove_limit)?
+                .ok_or_else(|| format_error!(ErrCode::EIO, "Extent tail disappeared"))?;
+            self.transaction_dealloc_block_range(
+                &mut transaction,
+                removed.start_pblock,
+                removed.block_count,
+            )?;
+            for metadata in removed.metadata_blocks.iter().copied() {
+                self.transaction_dealloc_block_range(&mut transaction, metadata, 1)?;
+            }
+            let released = removed.block_count as u64 + removed.metadata_blocks.len() as u64;
+            let remaining = inode
+                .inode
+                .fs_block_count()
+                .checked_sub(released)
+                .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid inode block count"))?;
+            inode.inode.set_fs_block_count(remaining);
+            inode.inode.set_size(core::cmp::min(
+                inode.inode.size(),
+                removed.start_lblock as u64 * BLOCK_SIZE as u64,
+            ));
+            self.transaction_stage_inode_with_csum(&mut transaction, &mut inode)?;
+            self.commit_reclaim_transaction(transaction)?;
+        }
+
+        // External xattrs form their own restartable transaction. Shared
+        // blocks update h_refcount; exclusive blocks also release allocation.
+        let mut inode = self.validate_reclaim_inode(inode_id, generation)?;
+        if inode.inode.xattr_block() != 0 {
+            let mut transaction = self.transaction_start(16)?;
+            if let Some(block) = self.transaction_release_xattr(&mut transaction, &mut inode)? {
+                self.transaction_dealloc_block_range(&mut transaction, block, 1)?;
+            }
+            self.commit_reclaim_transaction(transaction)?;
+        }
+
+        // Only the final transaction makes the orphan undiscoverable. It also
+        // frees the inode number and installs a checksum-correct cleared table
+        // entry, preserving generation so reuse advances lifetime identity.
+        let inode = self.validate_reclaim_inode(inode_id, generation)?;
+        if inode.inode.uses_extents() {
+            let transaction = self.transaction_start(1)?;
+            if self.extent_tail(&transaction, &inode)?.is_some() {
+                return_error!(ErrCode::EIO, "Final reclaim with live extent");
+            }
+            transaction.abort();
+        }
+        if inode.inode.xattr_block() != 0 || inode.inode.fs_block_count() != 0 {
+            return_error!(ErrCode::EIO, "Final reclaim with owned blocks");
+        }
+        let is_dir = inode.inode.is_dir();
+        let mut transaction = self.transaction_start(16)?;
+        let mut sb = self.transaction_read_super_block(&transaction)?;
+        self.transaction_orphan_del(&mut transaction, &inode, &mut sb)?;
+        self.transaction_dealloc_inode(&mut transaction, inode_id, is_dir)?;
+        let mut cleared = InodeRef::new(inode_id, Box::new(Inode::default()));
+        cleared.inode.set_generation(generation);
+        self.transaction_stage_inode_with_csum(&mut transaction, &mut cleared)?;
+        self.commit_reclaim_transaction(transaction)
+    }
+
+    fn validate_reclaim_inode(&self, inode_id: InodeId, generation: u32) -> Result<InodeRef> {
+        if !self.inode_is_allocated(inode_id)? {
             return_error!(
                 ErrCode::EINVAL,
-                "Reclaim capability references free inode {}",
-                handle.inode_id
+                "Reclaim references free inode {}",
+                inode_id
             );
         }
-        let mut inode = self.read_inode_uncached(handle.inode_id)?;
+        let inode = self.read_inode_uncached(inode_id)?;
         if inode.inode.mode().bits() == 0
             || inode.inode.link_count() != 0
-            || inode.inode.generation() != handle.generation
+            || inode.inode.generation() != generation
+            || !inode.verify_checksum(&self.read_super_block_cached().uuid())
         {
             return_error!(
                 ErrCode::EINVAL,
-                "Invalid or stale reclaim capability for inode {}",
-                handle.inode_id
+                "Invalid or stale orphan inode {}",
+                inode_id
             );
         }
-        if let Err(error) = self.free_inode(&mut inode) {
+        Ok(inode)
+    }
+
+    fn commit_reclaim_transaction(
+        &self,
+        transaction: super::journal_transaction::Transaction<'_>,
+    ) -> Result<()> {
+        if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
             self.poison(ErrCode::EIO);
-            return Err(error);
+            return Err(error.error);
         }
         Ok(())
     }
 
-    fn inode_is_allocated(&self, inode_id: InodeId) -> Result<bool> {
+    pub(super) fn inode_is_allocated(&self, inode_id: InodeId) -> Result<bool> {
         let _alloc_guard = self.alloc_lock.lock();
         let sb = self.read_super_block_cached();
         if inode_id == 0 || inode_id > sb.inode_count() {
@@ -280,8 +608,12 @@ impl Ext4 {
         let iblock = self.extent_next_data_lblock(inode)?;
         // Check the extent tree to get the physical block id
         let fblock = self.extent_query_or_create(inode, iblock, 1)?;
-        // Update block count: data blocks only (tree blocks are added by setattr)
-        inode.inode.set_fs_block_count(iblock as u64 + 1);
+        let total_blocks = self
+            .extent_all_data_blocks(inode)?
+            .len()
+            .checked_add(self.extent_all_tree_blocks(inode)?.len())
+            .ok_or_else(|| format_error!(ErrCode::EFBIG, "Inode blocks overflow"))?;
+        inode.inode.set_fs_block_count(total_blocks as u64);
         self.write_inode_with_csum(inode)?;
 
         Ok((iblock, fblock))
@@ -361,6 +693,33 @@ impl Ext4 {
         return_error!(ErrCode::ENOSPC, "No free blocks in filesystem");
     }
 
+    /// Allocate and initialize a data block before any extent can publish it.
+    /// Extent-tree and xattr metadata allocations deliberately use
+    /// `alloc_block()` directly because their callers construct metadata
+    /// images rather than exposing zero-filled file data.
+    pub(super) fn alloc_zeroed_data_block(&self, inode: &mut InodeRef) -> Result<PBlockId> {
+        self.alloc_initialized_data_block(inode, Box::new([0; BLOCK_SIZE]))
+    }
+
+    pub(super) fn alloc_initialized_data_block(
+        &self,
+        inode: &mut InodeRef,
+        image: Box<[u8; BLOCK_SIZE]>,
+    ) -> Result<PBlockId> {
+        let pblock = self.alloc_block(inode)?;
+        if let Err(init_error) = self.write_block(&Block::new(pblock, image)) {
+            if let Err(rollback_error) = self.dealloc_block(inode, pblock) {
+                // The allocation bit may still be set and no extent owns the
+                // block.  Fail-stop instead of permitting silent leakage or a
+                // later stale-data mapping on this mount.
+                self.poison(ErrCode::EIO);
+                return Err(rollback_error);
+            }
+            return Err(init_error);
+        }
+        Ok(pblock)
+    }
+
     /// Deallocate a physical block allocated for an inode
     pub(super) fn dealloc_block(&self, _inode: &mut InodeRef, pblock: PBlockId) -> Result<()> {
         let _alloc_guard = self.alloc_lock.lock();
@@ -369,7 +728,11 @@ impl Ext4 {
             return_error!(ErrCode::EINVAL, "Invalid block {}", pblock);
         }
 
-        let bgid = (pblock / sb.blocks_per_group() as PBlockId) as BlockGroupId;
+        if pblock < sb.first_data_block() as PBlockId {
+            return_error!(ErrCode::EINVAL, "Invalid block {}", pblock);
+        }
+        let bgid = ((pblock - sb.first_data_block() as PBlockId)
+            / sb.blocks_per_group() as PBlockId) as BlockGroupId;
         let bit = (pblock - Self::block_group_first_block(&sb, bgid)) as usize;
         let blocks_in_group = Self::block_group_block_count(&sb, bgid);
         if bit >= blocks_in_group {
@@ -570,5 +933,25 @@ impl Ext4 {
         self.write_inode_with_csum(inode_ref)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod reclaim_tests {
+    use super::extent_tail_batch_limit;
+
+    #[test]
+    fn extent_reclaim_batch_never_crosses_a_block_group() {
+        // 1 KiB ext4 starts data at block 1. The tail spans groups 0 and 1;
+        // only the two right-most blocks in group 1 may be removed together.
+        assert_eq!(extent_tail_batch_limit(1, 8, 7, 4), Some(2));
+        assert_eq!(extent_tail_batch_limit(0, 8, 9, 3), Some(3));
+    }
+
+    #[test]
+    fn extent_reclaim_batch_rejects_invalid_or_overflowing_tails() {
+        assert_eq!(extent_tail_batch_limit(1, 8, 0, 1), None);
+        assert_eq!(extent_tail_batch_limit(0, 8, u64::MAX, 2), None);
+        assert_eq!(extent_tail_batch_limit(0, 0, 1, 1), None);
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4/dir.rs
@@ -18,18 +18,196 @@ impl DirAddFailure {
 }
 
 impl Ext4 {
+    fn validate_dir_name(name: &str) -> Result<()> {
+        if name.len() > 255 {
+            return_error!(ErrCode::ENAMETOOLONG, "Directory name exceeds 255 bytes");
+        }
+        Ok(())
+    }
+
+    fn validate_dir_block(
+        &self,
+        dir: &InodeRef,
+        iblock: LBlockId,
+        block: &DirBlock,
+    ) -> Result<DirBlockLayout> {
+        let sb = self.read_super_block_cached();
+        block.validate(
+            &sb.uuid(),
+            dir.id,
+            dir.inode.generation(),
+            sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM),
+            dir.inode.flags() & 0x1000 != 0,
+            iblock == 0,
+        )
+    }
+
+    fn metadata_csum_enabled(&self) -> bool {
+        self.read_super_block_cached()
+            .has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM)
+    }
+
+    fn set_dir_block_checksum(
+        &self,
+        dir: &InodeRef,
+        block: &mut DirBlock,
+        layout: DirBlockLayout,
+    ) -> Result<()> {
+        let sb = self.read_super_block_cached();
+        if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
+            return Ok(());
+        }
+        match layout {
+            DirBlockLayout::Leaf => {
+                block.set_checksum(&sb.uuid(), dir.id, dir.inode.generation());
+                Ok(())
+            }
+            DirBlockLayout::Htree => {
+                block.set_htree_checksum(&sb.uuid(), dir.id, dir.inode.generation())
+            }
+        }
+    }
+
+    fn dir_data_block_count(dir: &InodeRef) -> Result<u32> {
+        let size = dir.inode.size();
+        if size % BLOCK_SIZE as u64 != 0 {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        u32::try_from(size / BLOCK_SIZE as u64).map_err(|_| Ext4Error::new(ErrCode::EIO))
+    }
+
+    pub(super) fn dir_has_insert_space(
+        &self,
+        dir: &InodeRef,
+        child: &InodeRef,
+        name: &str,
+    ) -> Result<bool> {
+        Self::validate_dir_name(name)?;
+        for iblock in 0..Self::dir_data_block_count(dir)? {
+            let fblock = self.extent_query(dir, iblock)?;
+            let mut candidate = DirBlock::new(self.read_block(fblock)?);
+            if self.validate_dir_block(dir, iblock, &candidate)? == DirBlockLayout::Htree {
+                continue;
+            }
+            if candidate.insert(
+                name,
+                child.id,
+                child.inode.file_type(),
+                self.metadata_csum_enabled(),
+            ) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Prepare one checksum-valid empty directory block without publishing a
+    /// name.  If initialization fails, the allocation is rolled back before
+    /// any extent references it.  Once extent publication starts, failures are
+    /// indeterminate and the caller must poison the mount.
+    pub(super) fn prepare_empty_dir_slot(&self, dir: &mut InodeRef) -> Result<()> {
+        let mut empty = DirBlock::new(Block::new(0, Box::new([0; BLOCK_SIZE])));
+        let metadata_csum = self.metadata_csum_enabled();
+        empty.init(metadata_csum);
+        self.set_dir_block_checksum(dir, &mut empty, DirBlockLayout::Leaf)?;
+        let iblock = self.extent_next_data_lblock(dir)?;
+        let old_size = dir.inode.size();
+        let old_blocks = dir.inode.fs_block_count();
+        let new_size = old_size
+            .checked_add(BLOCK_SIZE as u64)
+            .ok_or_else(|| crate::format_error!(ErrCode::EFBIG, "Directory size overflow"))?;
+        let new_blocks = old_blocks.checked_add(1).ok_or_else(|| {
+            crate::format_error!(ErrCode::EFBIG, "Directory block count overflow")
+        })?;
+        dir.inode.set_size(new_size);
+        dir.inode.set_fs_block_count(new_blocks);
+        if let Err(error) = self.extent_query_or_create_initialized(
+            dir,
+            iblock,
+            1,
+            Some(empty.block().data.clone()),
+        ) {
+            dir.inode.set_size(old_size);
+            dir.inode.set_fs_block_count(old_blocks);
+            // Extent publication may have reached disk before reporting an
+            // error; freeing pblock could create a dangling mapping.
+            self.poison(ErrCode::EIO);
+            return Err(error);
+        }
+        let total_blocks = match self.extent_all_data_blocks(dir).and_then(|data| {
+            self.extent_all_tree_blocks(dir).and_then(|tree| {
+                data.len().checked_add(tree.len()).ok_or_else(|| {
+                    crate::format_error!(ErrCode::EFBIG, "Directory blocks overflow")
+                })
+            })
+        }) {
+            Ok(total) => total,
+            Err(error) => {
+                self.poison(ErrCode::EIO);
+                return Err(error);
+            }
+        };
+        dir.inode.set_fs_block_count(total_blocks as u64);
+        if let Err(error) = self.write_inode_with_csum(dir) {
+            self.poison(ErrCode::EIO);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    /// Stage insertion into an existing directory data block.  The read-only
+    /// scan consumes no journal credit; only the matching free-space block is
+    /// copied into the transaction image.  Directory growth requires extent
+    /// allocation and is intentionally rejected before any mutation until
+    /// that allocation path is fully journalled.
+    pub(super) fn transaction_dir_add_existing(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        dir: &InodeRef,
+        child: &InodeRef,
+        name: &str,
+    ) -> Result<()> {
+        Self::validate_dir_name(name)?;
+        for iblock in 0..Self::dir_data_block_count(dir)? {
+            let fblock = self.extent_query(dir, iblock)?;
+            let view = transaction.read(self.block_device.as_ref(), fblock)?;
+            let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
+            let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
+            if layout == DirBlockLayout::Htree {
+                continue;
+            }
+            if dir_block.insert(
+                name,
+                child.id,
+                child.inode.file_type(),
+                self.metadata_csum_enabled(),
+            ) {
+                self.set_dir_block_checksum(dir, &mut dir_block, layout)?;
+                transaction.stage(fblock, dir_block.block().data.clone())?;
+                return Ok(());
+            }
+        }
+        return_error!(
+            ErrCode::ENOSPC,
+            "Atomic relink requires free space in directory {}",
+            dir.id
+        );
+    }
+
     /// Find a directory entry that matches a given name under a parent directory
     pub(super) fn dir_find_entry(&self, dir: &InodeRef, name: &str) -> Result<InodeId> {
+        Self::validate_dir_name(name)?;
         trace!("Dir find entry: dir {}, name {}", dir.id, name);
-        let total_blocks = dir.inode.fs_block_count() as u32;
+        let total_blocks = Self::dir_data_block_count(dir)?;
         let mut iblock: LBlockId = 0;
         while iblock < total_blocks {
             // Get the fs block id
             let fblock = self.extent_query(dir, iblock)?;
             // Load block from disk
             let dir_block = DirBlock::new(self.read_block(fblock)?);
+            self.validate_dir_block(dir, iblock, &dir_block)?;
             // Find the entry in block
-            let res = dir_block.get(name);
+            let res = dir_block.get(name, self.metadata_csum_enabled());
             if let Some(r) = res {
                 return Ok(r);
             }
@@ -64,13 +242,14 @@ impl Ext4 {
         child: &InodeRef,
         name: &str,
     ) -> core::result::Result<(), DirAddFailure> {
+        Self::validate_dir_name(name).map_err(DirAddFailure::Unmodified)?;
         trace!(
             "Dir add entry: dir {}, child {}, name {}",
             dir.id,
             child.id,
             name
         );
-        let total_blocks = dir.inode.fs_block_count() as u32;
+        let total_blocks = Self::dir_data_block_count(dir).map_err(DirAddFailure::Unmodified)?;
         let mut iblock: LBlockId = 0;
         // Try finding a block with enough space
         while iblock < total_blocks {
@@ -81,14 +260,23 @@ impl Ext4 {
             // Load the parent block from disk
             let mut dir_block =
                 DirBlock::new(self.read_block(fblock).map_err(DirAddFailure::Unmodified)?);
+            let layout = self
+                .validate_dir_block(dir, iblock, &dir_block)
+                .map_err(DirAddFailure::Unmodified)?;
+            if layout == DirBlockLayout::Htree {
+                iblock += 1;
+                continue;
+            }
             // Try inserting the entry to parent block
-            if dir_block.insert(name, child.id, child.inode.file_type()) {
+            if dir_block.insert(
+                name,
+                child.id,
+                child.inode.file_type(),
+                self.metadata_csum_enabled(),
+            ) {
                 // Update checksum
-                dir_block.set_checksum(
-                    &self.read_super_block_cached().uuid(),
-                    dir.id,
-                    dir.inode.generation(),
-                );
+                self.set_dir_block_checksum(dir, &mut dir_block, layout)
+                    .map_err(DirAddFailure::Unmodified)?;
                 // Write the block back to disk
                 self.write_block(dir_block.block())
                     .map_err(DirAddFailure::Indeterminate)?;
@@ -121,15 +309,21 @@ impl Ext4 {
                 .map_err(DirAddFailure::Indeterminate)?,
         );
         // Write the entry to block
-        new_dir_block.init();
-        new_dir_block.insert(name, child.id, child.inode.file_type());
-        new_dir_block.set_checksum(
-            &self.read_super_block_cached().uuid(),
-            dir.id,
-            dir.inode.generation(),
+        new_dir_block.init(self.metadata_csum_enabled());
+        new_dir_block.insert(
+            name,
+            child.id,
+            child.inode.file_type(),
+            self.metadata_csum_enabled(),
         );
+        self.set_dir_block_checksum(dir, &mut new_dir_block, DirBlockLayout::Leaf)
+            .map_err(DirAddFailure::Indeterminate)?;
+        self.validate_dir_block(dir, iblock, &new_dir_block)
+            .map_err(DirAddFailure::Indeterminate)?;
         // Write the block back to disk
         self.write_block(new_dir_block.block())
+            .map_err(DirAddFailure::Indeterminate)?;
+        self.write_inode_with_csum(dir)
             .map_err(DirAddFailure::Indeterminate)?;
 
         Ok(())
@@ -137,8 +331,9 @@ impl Ext4 {
 
     /// Remove a entry from a directory
     pub(super) fn dir_remove_entry(&self, dir: &InodeRef, name: &str) -> Result<()> {
+        Self::validate_dir_name(name)?;
         trace!("Dir remove entry: dir {}, name {}", dir.id, name);
-        let total_blocks = dir.inode.fs_block_count() as u32;
+        let total_blocks = Self::dir_data_block_count(dir)?;
         // Check each block
         let mut iblock: LBlockId = 0;
         while iblock < total_blocks {
@@ -146,14 +341,15 @@ impl Ext4 {
             let fblock = self.extent_query(dir, iblock)?;
             // Load the block from disk
             let mut dir_block = DirBlock::new(self.read_block(fblock)?);
+            let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
+            if layout == DirBlockLayout::Htree {
+                iblock += 1;
+                continue;
+            }
             // Try removing the entry
-            if dir_block.remove(name) {
+            if dir_block.remove(name, self.metadata_csum_enabled()) {
                 // Update checksum
-                dir_block.set_checksum(
-                    &self.read_super_block_cached().uuid(),
-                    dir.id,
-                    dir.inode.generation(),
-                );
+                self.set_dir_block_checksum(dir, &mut dir_block, layout)?;
                 // Write the block back to disk
                 self.write_block(dir_block.block())?;
                 return Ok(());
@@ -170,9 +366,50 @@ impl Ext4 {
         );
     }
 
+    /// Stage removal of a directory entry in a transaction-private image.
+    /// No namespace change becomes visible on disk or through caches until the
+    /// caller commits the same transaction as its link-count updates.
+    pub(super) fn transaction_dir_remove_entry(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        dir: &InodeRef,
+        name: &str,
+    ) -> Result<()> {
+        Self::validate_dir_name(name)?;
+        trace!(
+            "Transaction dir remove entry: dir {}, name {}",
+            dir.id,
+            name
+        );
+        let total_blocks = Self::dir_data_block_count(dir)?;
+        for iblock in 0..total_blocks {
+            let fblock = self.extent_query(dir, iblock)?;
+            // Scanning must not consume a credit for every non-matching block
+            // in a large directory. `read` still observes an already-staged
+            // image if this helper is composed with another directory update.
+            let view = transaction.read(self.block_device.as_ref(), fblock)?;
+            let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
+            let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
+            if layout == DirBlockLayout::Htree {
+                continue;
+            }
+            if dir_block.remove(name, self.metadata_csum_enabled()) {
+                self.set_dir_block_checksum(dir, &mut dir_block, layout)?;
+                transaction.stage(fblock, dir_block.block().data.clone())?;
+                return Ok(());
+            }
+        }
+        return_error!(
+            ErrCode::ENOENT,
+            "Directory entry not found: dir {}, name {}",
+            dir.id,
+            name
+        );
+    }
+
     /// Get all entries under a directory
     pub(super) fn dir_list_entries(&self, dir: &InodeRef) -> Result<Vec<DirEntry>> {
-        let total_blocks = dir.inode.fs_block_count() as u32;
+        let total_blocks = Self::dir_data_block_count(dir)?;
         let mut entries: Vec<DirEntry> = Vec::new();
         let mut iblock: LBlockId = 0;
         while iblock < total_blocks {
@@ -180,8 +417,9 @@ impl Ext4 {
             let fblock = self.extent_query(dir, iblock)?;
             // Load block from disk
             let dir_block = DirBlock::new(self.read_block(fblock)?);
+            self.validate_dir_block(dir, iblock, &dir_block)?;
             // Get all entries from block
-            dir_block.list(&mut entries);
+            dir_block.list(&mut entries, self.metadata_csum_enabled());
             iblock += 1;
         }
         Ok(entries)
@@ -196,23 +434,21 @@ impl Ext4 {
         new_inode: InodeId,
         new_type: FileType,
     ) -> Result<()> {
+        Self::validate_dir_name(name)?;
         trace!(
             "Dir replace entry: dir {}, name {}, new_inode {}",
             dir.id,
             name,
             new_inode
         );
-        let total_blocks = dir.inode.fs_block_count() as u32;
+        let total_blocks = Self::dir_data_block_count(dir)?;
         let mut iblock: LBlockId = 0;
         while iblock < total_blocks {
             let fblock = self.extent_query(dir, iblock)?;
             let mut dir_block = DirBlock::new(self.read_block(fblock)?);
-            if dir_block.replace(name, new_inode, new_type) {
-                dir_block.set_checksum(
-                    &self.read_super_block_cached().uuid(),
-                    dir.id,
-                    dir.inode.generation(),
-                );
+            let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
+            if dir_block.replace(name, new_inode, new_type, self.metadata_csum_enabled()) {
+                self.set_dir_block_checksum(dir, &mut dir_block, layout)?;
                 self.write_block(dir_block.block())?;
                 return Ok(());
             }
@@ -221,6 +457,49 @@ impl Ext4 {
         return_error!(
             ErrCode::ENOENT,
             "Directory entry not found for replace: dir {}, name {}",
+            dir.id,
+            name
+        );
+    }
+
+    /// Stage an in-place directory-entry replacement in the caller's
+    /// transaction (the JBD2 equivalent of Linux `ext4_setent()`).
+    ///
+    /// The directory scan is read-only and therefore consumes no journal
+    /// credit for non-matching blocks.  Only the block containing `name` is
+    /// staged; if another rename operation already staged that same physical
+    /// block, `Transaction::stage` replaces the transaction-private image
+    /// without consuming a second credit.
+    pub(super) fn transaction_dir_replace_entry(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        dir: &InodeRef,
+        name: &str,
+        new_inode: InodeId,
+        new_type: FileType,
+    ) -> Result<()> {
+        Self::validate_dir_name(name)?;
+        trace!(
+            "Transaction dir replace entry: dir {}, name {}, new_inode {}",
+            dir.id,
+            name,
+            new_inode
+        );
+        let total_blocks = Self::dir_data_block_count(dir)?;
+        for iblock in 0..total_blocks {
+            let fblock = self.extent_query(dir, iblock)?;
+            let view = transaction.read(self.block_device.as_ref(), fblock)?;
+            let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
+            let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
+            if dir_block.replace(name, new_inode, new_type, self.metadata_csum_enabled()) {
+                self.set_dir_block_checksum(dir, &mut dir_block, layout)?;
+                transaction.stage(fblock, dir_block.block().data.clone())?;
+                return Ok(());
+            }
+        }
+        return_error!(
+            ErrCode::ENOENT,
+            "Directory entry not found for transactional replace: dir {}, name {}",
             dir.id,
             name
         );

--- a/kernel/crates/another_ext4/src/ext4/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4/dir.rs
@@ -70,7 +70,7 @@ impl Ext4 {
 
     fn dir_data_block_count(dir: &InodeRef) -> Result<u32> {
         let size = dir.inode.size();
-        if size % BLOCK_SIZE as u64 != 0 {
+        if !size.is_multiple_of(BLOCK_SIZE as u64) {
             return Err(Ext4Error::new(ErrCode::EIO));
         }
         u32::try_from(size / BLOCK_SIZE as u64).map_err(|_| Ext4Error::new(ErrCode::EIO))

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -5,10 +5,333 @@ use crate::format_error;
 use crate::prelude::*;
 use core::cmp::min;
 
+/// One contiguous tail of the right-most data extent removed from a tree.
+///
+/// The caller owns allocation accounting: `metadata_blocks` have already been
+/// disconnected from the staged tree and can therefore be freed atomically in
+/// the same transaction as `data` and the inode-table image.
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct ExtentTailRemoval {
+    pub start_lblock: LBlockId,
+    pub start_pblock: PBlockId,
+    pub block_count: u32,
+    pub metadata_blocks: Vec<PBlockId>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ExtentTail {
+    pub start_lblock: LBlockId,
+    pub start_pblock: PBlockId,
+    pub block_count: u32,
+    pub unwritten: bool,
+}
+
 impl Ext4 {
+    fn verify_extent_block_checksum(&self, inode_ref: &InodeRef, image: &[u8]) -> Result<()> {
+        let sb = self.read_super_block_cached();
+        if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
+            return Ok(());
+        }
+        if image.len() != BLOCK_SIZE {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let node = ExtentNode::from_bytes(image);
+        let expected_max =
+            (BLOCK_SIZE - core::mem::size_of::<ExtentHeader>()) / core::mem::size_of::<Extent>();
+        if node.header().max_entries_count() as usize != expected_max {
+            return Err(format_error!(
+                ErrCode::EIO,
+                "invalid extent block capacity on inode {}",
+                inode_ref.id
+            ));
+        }
+        let tail_offset = BLOCK_SIZE - core::mem::size_of::<crate::ext4_defs::ExtentTail>();
+        let stored = u32::from_le_bytes(
+            image[tail_offset..tail_offset + 4]
+                .try_into()
+                .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+        );
+        let calculated = extent_block_checksum(
+            &sb.uuid(),
+            inode_ref.id,
+            inode_ref.inode.generation(),
+            image,
+        );
+        if stored != calculated {
+            return Err(format_error!(
+                ErrCode::EIO,
+                "extent block checksum mismatch on inode {}",
+                inode_ref.id
+            ));
+        }
+        Ok(())
+    }
+
+    /// Read and authenticate a non-root extent node before interpreting any
+    /// header or entry.  Linux performs the equivalent check in
+    /// `ext4_extent_block_csum_verify()`.
+    fn read_extent_block(&self, inode_ref: &InodeRef, pblock: PBlockId) -> Result<Block> {
+        self.ensure_valid_pblock(inode_ref.id, pblock, "extent tree node")?;
+        self.validate_data_blocks(pblock, 1)?;
+        let block = self.read_block(pblock)?;
+        self.verify_extent_block_checksum(inode_ref, &block.data[..])?;
+        Ok(block)
+    }
+
+    fn verify_transaction_extent_block(&self, inode_ref: &InodeRef, image: &[u8]) -> Result<()> {
+        self.verify_extent_block_checksum(inode_ref, image)
+    }
+
+    /// Inspect the authoritative right-most extent without changing the tree.
+    /// This lets the allocator shorten a removal at a block-group boundary
+    /// before asking [`Self::extent_remove_tail_in_transaction`] to mutate it.
+    pub(super) fn extent_tail(
+        &self,
+        transaction: &super::journal_transaction::Transaction<'_>,
+        inode_ref: &InodeRef,
+    ) -> Result<Option<ExtentTail>> {
+        let root = inode_ref.inode.extent_root();
+        self.validate_extent_node(inode_ref.id, &root)?;
+        if root.header().entries_count() == 0 {
+            return Ok(None);
+        }
+
+        let mut depth = root.header().depth();
+        let mut next = {
+            let last = root.header().entries_count() as usize - 1;
+            (depth > 0).then(|| root.extent_index_at(last).leaf())
+        };
+        while let Some(pblock) = next {
+            self.ensure_valid_pblock(inode_ref.id, pblock, "extent tail node")?;
+            let image = transaction.read(self.block_device.as_ref(), pblock)?;
+            self.verify_transaction_extent_block(inode_ref, &*image)?;
+            let node = ExtentNode::from_bytes(&*image);
+            self.validate_extent_node(inode_ref.id, &node)?;
+            if node.header().depth() + 1 != depth {
+                return Err(format_error!(
+                    ErrCode::EIO,
+                    "extent depth mismatch on inode {} at block {}",
+                    inode_ref.id,
+                    pblock
+                ));
+            }
+            let entries = node.header().entries_count() as usize;
+            if entries == 0 {
+                return Err(format_error!(
+                    ErrCode::EIO,
+                    "empty reachable extent node on inode {} at block {}",
+                    inode_ref.id,
+                    pblock
+                ));
+            }
+            depth = node.header().depth();
+            if depth == 0 {
+                let extent = *node.extent_at(entries - 1);
+                return Ok(Some(Self::tail_description(&extent)));
+            }
+            next = Some(node.extent_index_at(entries - 1).leaf());
+        }
+
+        let extent = *root.extent_at(root.header().entries_count() as usize - 1);
+        Ok(Some(Self::tail_description(&extent)))
+    }
+
+    fn tail_description(extent: &Extent) -> ExtentTail {
+        ExtentTail {
+            start_lblock: extent.start_lblock(),
+            start_pblock: extent.start_pblock(),
+            block_count: extent.block_count(),
+            unwritten: extent.is_unwritten(),
+        }
+    }
+
+    /// Remove at most `max_blocks` from the right edge of exactly one extent.
+    ///
+    /// Every changed non-root extent block is transaction-private and receives
+    /// a checksum for its final image.  Empty right-edge nodes are recursively
+    /// detached from their parents and returned to the caller, but are not
+    /// themselves staged because their bitmap bits must be cleared in this same
+    /// transaction.  The inode's inline root is changed in memory only.
+    pub(super) fn extent_remove_tail_in_transaction(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode_ref: &mut InodeRef,
+        max_blocks: u32,
+    ) -> Result<Option<ExtentTailRemoval>> {
+        if max_blocks == 0 {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+
+        let root = inode_ref.inode.extent_root();
+        self.validate_extent_node(inode_ref.id, &root)?;
+        if root.header().entries_count() == 0 {
+            return Ok(None);
+        }
+
+        // Store the physical block of every non-root node on the right spine.
+        // The corresponding parent is root for path[0], otherwise path[i-1].
+        let mut path = Vec::new();
+        let mut expected_depth = root.header().depth();
+        if expected_depth > 0 {
+            let last = root.header().entries_count() as usize - 1;
+            let mut pblock = root.extent_index_at(last).leaf();
+            loop {
+                self.ensure_valid_pblock(inode_ref.id, pblock, "extent tail node")?;
+                let image = transaction.read(self.block_device.as_ref(), pblock)?;
+                self.verify_transaction_extent_block(inode_ref, &*image)?;
+                let node = ExtentNode::from_bytes(&*image);
+                self.validate_extent_node(inode_ref.id, &node)?;
+                if node.header().depth() + 1 != expected_depth || node.header().entries_count() == 0
+                {
+                    return Err(format_error!(
+                        ErrCode::EIO,
+                        "invalid right extent spine on inode {} at block {}",
+                        inode_ref.id,
+                        pblock
+                    ));
+                }
+                path.push(pblock);
+                expected_depth = node.header().depth();
+                if expected_depth == 0 {
+                    break;
+                }
+                let last = node.header().entries_count() as usize - 1;
+                pblock = node.extent_index_at(last).leaf();
+            }
+        }
+
+        let tail = self
+            .extent_tail(transaction, inode_ref)?
+            .ok_or(format_error!(
+                ErrCode::EIO,
+                "extent tail disappeared on inode {}",
+                inode_ref.id
+            ))?;
+        let remove = min(max_blocks, tail.block_count);
+        let result = ExtentTailRemoval {
+            start_lblock: tail.start_lblock + tail.block_count - remove,
+            start_pblock: tail.start_pblock + (tail.block_count - remove) as PBlockId,
+            block_count: remove,
+            metadata_blocks: Vec::new(),
+        };
+
+        if path.is_empty() {
+            let mut root = inode_ref.inode.extent_root_mut();
+            Self::trim_leaf_tail(&mut root, remove)?;
+            return Ok(Some(result));
+        }
+
+        let leaf_pblock = *path.last().unwrap();
+        if remove < tail.block_count {
+            let image = self.transaction_block_for_update(transaction, leaf_pblock)?;
+            let mut leaf = ExtentNodeMut::from_bytes(&mut image[..]);
+            Self::trim_leaf_tail(&mut leaf, remove)?;
+            Self::set_extent_block_checksum(
+                &self.read_super_block_cached().uuid(),
+                inode_ref,
+                image,
+            );
+            return Ok(Some(result));
+        }
+
+        // A full last extent leaves its leaf empty only when it was that leaf's
+        // sole entry.  Otherwise stage the shortened leaf and stop cascading.
+        let leaf_entries = {
+            let image = transaction.read(self.block_device.as_ref(), leaf_pblock)?;
+            ExtentNode::from_bytes(&*image).header().entries_count()
+        };
+        if leaf_entries > 1 {
+            let image = self.transaction_block_for_update(transaction, leaf_pblock)?;
+            let mut leaf = ExtentNodeMut::from_bytes(&mut image[..]);
+            leaf.remove_last_entry();
+            Self::set_extent_block_checksum(
+                &self.read_super_block_cached().uuid(),
+                inode_ref,
+                image,
+            );
+            return Ok(Some(result));
+        }
+
+        let mut result = result;
+        result.metadata_blocks.push(leaf_pblock);
+        let mut child_empty = true;
+        for level in (0..path.len() - 1).rev() {
+            if !child_empty {
+                break;
+            }
+            let pblock = path[level];
+            let entries = {
+                let image = transaction.read(self.block_device.as_ref(), pblock)?;
+                ExtentNode::from_bytes(&*image).header().entries_count()
+            };
+            if entries == 0 {
+                return Err(format_error!(
+                    ErrCode::EIO,
+                    "empty extent parent on inode {}",
+                    inode_ref.id
+                ));
+            }
+            child_empty = entries == 1;
+            if child_empty {
+                result.metadata_blocks.push(pblock);
+            } else {
+                let image = self.transaction_block_for_update(transaction, pblock)?;
+                let mut node = ExtentNodeMut::from_bytes(&mut image[..]);
+                node.remove_last_entry();
+                Self::set_extent_block_checksum(
+                    &self.read_super_block_cached().uuid(),
+                    inode_ref,
+                    image,
+                );
+            }
+        }
+
+        if child_empty {
+            let mut root = inode_ref.inode.extent_root_mut();
+            if !root.remove_last_entry() {
+                return Err(format_error!(
+                    ErrCode::EIO,
+                    "empty extent root on inode {}",
+                    inode_ref.id
+                ));
+            }
+            if root.header().entries_count() == 0 {
+                // Every node below the root was detached.  Restore the canonical
+                // empty inline leaf root; this also drops the obsolete depth.
+                root.init(0, 0);
+            }
+        }
+        Ok(Some(result))
+    }
+
+    fn trim_leaf_tail(node: &mut ExtentNodeMut<'_>, remove: u32) -> Result<()> {
+        let entries = node.header().entries_count() as usize;
+        if node.header().depth() != 0 || entries == 0 {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let last = node.extent_mut_at(entries - 1);
+        let old_len = last.block_count();
+        if remove == 0 || remove > old_len {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        if remove == old_len {
+            node.remove_last_entry();
+        } else {
+            last.set_block_count(old_len - remove);
+        }
+        Ok(())
+    }
+
+    fn set_extent_block_checksum(uuid: &[u8], inode_ref: &InodeRef, image: &mut [u8; BLOCK_SIZE]) {
+        let tail_offset = BLOCK_SIZE - core::mem::size_of::<crate::ext4_defs::ExtentTail>();
+        let checksum =
+            extent_block_checksum(uuid, inode_ref.id, inode_ref.inode.generation(), image);
+        image[tail_offset..tail_offset + 4].copy_from_slice(&checksum.to_le_bytes());
+    }
+
     /// Write an extent block to disk with checksum in the extent tail.
     fn write_extent_block(&self, block: &mut Block, inode_ref: &InodeRef) -> Result<()> {
-        let tail_offset = BLOCK_SIZE - core::mem::size_of::<ExtentTail>();
+        let tail_offset = BLOCK_SIZE - core::mem::size_of::<crate::ext4_defs::ExtentTail>();
         let csum = extent_block_checksum(
             &self.read_super_block_cached().uuid(),
             inode_ref.id,
@@ -54,7 +377,7 @@ impl Ext4 {
             let ex_node = if leaf.pblock != 0 {
                 // Load the extent node
                 self.ensure_valid_pblock(inode_ref.id, leaf.pblock, "extent leaf node")?;
-                block_data = self.read_block(leaf.pblock)?;
+                block_data = self.read_extent_block(inode_ref, leaf.pblock)?;
                 // Load the next extent header
                 ExtentNode::from_bytes(&*block_data.data)
             } else {
@@ -64,6 +387,7 @@ impl Ext4 {
             let ex = ex_node.extent_at(index);
             let pblock = ex.start_pblock() + (iblock - ex.start_lblock()) as PBlockId;
             self.ensure_valid_pblock(inode_ref.id, pblock, "extent data block")?;
+            self.validate_data_blocks(pblock, 1)?;
             Ok(pblock)
         } else {
             Err(format_error!(
@@ -83,6 +407,16 @@ impl Ext4 {
         iblock: LBlockId,
         block_count: u32,
     ) -> Result<PBlockId> {
+        self.extent_query_or_create_initialized(inode_ref, iblock, block_count, None)
+    }
+
+    pub(super) fn extent_query_or_create_initialized(
+        &self,
+        inode_ref: &mut InodeRef,
+        iblock: LBlockId,
+        block_count: u32,
+        initial_image: Option<Box<[u8; BLOCK_SIZE]>>,
+    ) -> Result<PBlockId> {
         let path = self.find_extent(inode_ref, iblock)?;
         // Leaf is the last element of the path
         let leaf = path.last().ok_or(format_error!(
@@ -93,7 +427,7 @@ impl Ext4 {
         // Note: block data must be defined here to keep it alive
         let mut block_data: Block;
         let ex_node = if leaf.pblock != 0 {
-            block_data = self.read_block(leaf.pblock)?;
+            block_data = self.read_extent_block(inode_ref, leaf.pblock)?;
             ExtentNodeMut::from_bytes(&mut *block_data.data)
         } else {
             // Root node
@@ -121,7 +455,15 @@ impl Ext4 {
 
                 let block_count = min(block_count, MAX_BLOCKS - iblock);
                 // Allocate physical block
-                let fblock = self.alloc_block(inode_ref)?;
+                // Data initialization must be durable before the new extent
+                // becomes reachable from either the inode root or an external
+                // extent node.  Metadata-node allocations below continue to
+                // use alloc_block directly.
+                let fblock = if let Some(image) = initial_image {
+                    self.alloc_initialized_data_block(inode_ref, image)?
+                } else {
+                    self.alloc_zeroed_data_block(inode_ref)?
+                };
                 let new_ext = Extent::new(iblock, fblock, block_count as u16);
 
                 // Try to merge with the previous extent
@@ -134,7 +476,7 @@ impl Ext4 {
                         let prev_idx = insert_pos - 1;
                         if leaf_pblock != 0 {
                             // Re-read the leaf block and update
-                            let mut leaf_block = self.read_block(leaf_pblock)?;
+                            let mut leaf_block = self.read_extent_block(inode_ref, leaf_pblock)?;
                             let mut leaf_node = ExtentNodeMut::from_bytes(&mut *leaf_block.data);
                             *leaf_node.extent_mut_at(prev_idx) = merged;
                             self.write_extent_block(&mut leaf_block, inode_ref)?;
@@ -163,10 +505,14 @@ impl Ext4 {
         if ex_node.header().entries_count() == 0 {
             return Ok(0);
         }
-        self.extent_last_lblock_recursive(&ex_node)
+        self.extent_last_lblock_recursive(inode_ref, &ex_node)
     }
 
-    fn extent_last_lblock_recursive(&self, ex_node: &ExtentNode) -> Result<LBlockId> {
+    fn extent_last_lblock_recursive(
+        &self,
+        inode_ref: &InodeRef,
+        ex_node: &ExtentNode,
+    ) -> Result<LBlockId> {
         let last = ex_node.header().entries_count() as usize - 1;
         if ex_node.header().depth() == 0 {
             // Leaf: return start_lblock + block_count of the last extent
@@ -175,9 +521,9 @@ impl Ext4 {
         } else {
             // Non-leaf: descend into the last child
             let ex_idx = ex_node.extent_index_at(last);
-            let child_block = self.read_block(ex_idx.leaf())?;
+            let child_block = self.read_extent_block(inode_ref, ex_idx.leaf())?;
             let child_node = ExtentNode::from_bytes(&*child_block.data);
-            self.extent_last_lblock_recursive(&child_node)
+            self.extent_last_lblock_recursive(inode_ref, &child_node)
         }
     }
 
@@ -185,7 +531,7 @@ impl Ext4 {
     pub(super) fn extent_all_data_blocks(&self, inode_ref: &InodeRef) -> Result<Vec<PBlockId>> {
         let mut pblocks = Vec::new();
         let ex_node = inode_ref.inode.extent_root();
-        self.get_all_pblocks_recursive(&ex_node, &mut pblocks)?;
+        self.get_all_pblocks_recursive(inode_ref, &ex_node, &mut pblocks)?;
         Ok(pblocks)
     }
 
@@ -193,12 +539,54 @@ impl Ext4 {
     pub(super) fn extent_all_tree_blocks(&self, inode_ref: &InodeRef) -> Result<Vec<PBlockId>> {
         let mut pblocks = Vec::new();
         let ex_node = inode_ref.inode.extent_root();
-        self.get_all_nodes_recursive(&ex_node, &mut pblocks)?;
+        self.get_all_nodes_recursive(inode_ref, &ex_node, &mut pblocks)?;
         Ok(pblocks)
+    }
+
+    pub(super) fn validate_complete_extent_tree(&self, inode_ref: &InodeRef) -> Result<()> {
+        let root = inode_ref.inode.extent_root();
+        self.validate_extent_node(inode_ref.id, &root)?;
+        let mut visited = BTreeSet::new();
+        self.validate_extent_subtree(inode_ref, &root, &mut visited)
+    }
+
+    fn validate_extent_subtree(
+        &self,
+        inode_ref: &InodeRef,
+        node: &ExtentNode<'_>,
+        visited: &mut BTreeSet<PBlockId>,
+    ) -> Result<()> {
+        if node.header().depth() == 0 {
+            return Ok(());
+        }
+        for index in 0..node.header().entries_count() as usize {
+            let pblock = node.extent_index_at(index).leaf();
+            if !visited.insert(pblock) {
+                return Err(format_error!(
+                    ErrCode::EIO,
+                    "duplicate or cyclic extent node on inode {}",
+                    inode_ref.id
+                ));
+            }
+            let child_block = self.read_extent_block(inode_ref, pblock)?;
+            let child = ExtentNode::from_bytes(&*child_block.data);
+            self.validate_extent_node(inode_ref.id, &child)?;
+            if child.header().depth() + 1 != node.header().depth() {
+                return Err(format_error!(
+                    ErrCode::EIO,
+                    "extent depth mismatch on inode {} at block {}",
+                    inode_ref.id,
+                    pblock
+                ));
+            }
+            self.validate_extent_subtree(inode_ref, &child, visited)?;
+        }
+        Ok(())
     }
 
     fn get_all_pblocks_recursive(
         &self,
+        inode_ref: &InodeRef,
         ex_node: &ExtentNode,
         pblocks: &mut Vec<PBlockId>,
     ) -> Result<()> {
@@ -214,9 +602,10 @@ impl Ext4 {
             // Non-leaf
             for i in 0..ex_node.header().entries_count() as usize {
                 let ex_idx = ex_node.extent_index_at(i);
-                let child_block = self.read_block(ex_idx.leaf())?;
+                let child_block = self.read_extent_block(inode_ref, ex_idx.leaf())?;
                 let child_node = ExtentNode::from_bytes(&*child_block.data);
-                self.get_all_pblocks_recursive(&child_node, pblocks)?;
+                self.validate_extent_node(inode_ref.id, &child_node)?;
+                self.get_all_pblocks_recursive(inode_ref, &child_node, pblocks)?;
             }
         }
         Ok(())
@@ -224,6 +613,7 @@ impl Ext4 {
 
     fn get_all_nodes_recursive(
         &self,
+        inode_ref: &InodeRef,
         ex_node: &ExtentNode,
         pblocks: &mut Vec<PBlockId>,
     ) -> Result<()> {
@@ -232,9 +622,10 @@ impl Ext4 {
             for i in 0..ex_node.header().entries_count() as usize {
                 let ex_idx = ex_node.extent_index_at(i);
                 pblocks.push(ex_idx.leaf());
-                let child_block = self.read_block(ex_idx.leaf())?;
+                let child_block = self.read_extent_block(inode_ref, ex_idx.leaf())?;
                 let child_node = ExtentNode::from_bytes(&*child_block.data);
-                self.get_all_nodes_recursive(&child_node, pblocks)?;
+                self.validate_extent_node(inode_ref.id, &child_node)?;
+                self.get_all_nodes_recursive(inode_ref, &child_node, pblocks)?;
             }
         }
         Ok(())
@@ -265,7 +656,7 @@ impl Ext4 {
             let next = ex_idx.leaf();
             self.ensure_valid_pblock(inode_ref.id, next, "extent index target")?;
             // Note: block data cannot be released until the next assigment
-            block_data = self.read_block(next)?;
+            block_data = self.read_extent_block(inode_ref, next)?;
             // Load the next extent header
             ex_node = ExtentNode::from_bytes(&*block_data.data);
             self.validate_extent_node(inode_ref.id, &ex_node)?;
@@ -304,7 +695,7 @@ impl Ext4 {
             };
         }
         // 2. Leaf is not root, load the leaf node
-        let mut leaf_block = self.read_block(leaf.pblock)?;
+        let mut leaf_block = self.read_extent_block(inode_ref, leaf.pblock)?;
         let mut leaf_node = ExtentNodeMut::from_bytes(&mut *leaf_block.data);
         // Insert the extent
         let res = leaf_node.insert_extent(new_ext, leaf.index.unwrap_err());
@@ -378,7 +769,7 @@ impl Ext4 {
             self.write_inode_with_csum(inode_ref)?;
         } else {
             // Parent is not root
-            let mut parent_block = self.read_block(parent_pblock)?;
+            let mut parent_block = self.read_extent_block(inode_ref, parent_pblock)?;
             let mut parent_node = ExtentNodeMut::from_bytes(&mut *parent_block.data);
             parent_depth = parent_node.header().depth();
             res = parent_node.insert_extent_index(&extent_index, child_pos + 1);
@@ -593,9 +984,40 @@ mod tests {
             block_device,
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups: Vec::new(),
+            system_metadata_ranges: Vec::new(),
             inode_cache: spin::Mutex::new(crate::ext4::InodeCache::new(16)),
             alloc_lock: spin::Mutex::new(()),
             namespace_lock: spin::Mutex::new(()),
+            metadata_mutation_barrier: crate::ext4::MetadataMutationGate::new(),
+            poisoned: spin::Mutex::new(None),
+            journal: None,
+            inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
+                .map(|_| spin::Mutex::new(()))
+                .collect(),
+        }
+    }
+
+    fn make_metadata_csum_test_fs(block_count: u32) -> Ext4 {
+        let mut device = StubBlockDevice::with_block_count(block_count);
+        // ext4_super_block: s_feature_ro_compat at byte 100, UUID at 104.
+        let base = BASE_OFFSET;
+        device.sb_block.data[base + 100..base + 104]
+            .copy_from_slice(&SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM.to_le_bytes());
+        device.sb_block.data[base + 104..base + 120].copy_from_slice(&[0x5a; 16]);
+        let block_device = Arc::new(device);
+        let sb = block_device
+            .read_block(0)
+            .unwrap()
+            .read_offset_as::<SuperBlock>(BASE_OFFSET);
+        Ext4 {
+            block_device,
+            cached_super_block: spin::Mutex::new(sb),
+            cached_block_groups: Vec::new(),
+            system_metadata_ranges: Vec::new(),
+            inode_cache: spin::Mutex::new(crate::ext4::InodeCache::new(16)),
+            alloc_lock: spin::Mutex::new(()),
+            namespace_lock: spin::Mutex::new(()),
+            metadata_mutation_barrier: crate::ext4::MetadataMutationGate::new(),
             poisoned: spin::Mutex::new(None),
             journal: None,
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
@@ -608,6 +1030,23 @@ mod tests {
     fn ensure_valid_pblock_rejects_out_of_range() {
         let fs = make_test_fs(16);
         let err = fs.ensure_valid_pblock(2, 16, "test").unwrap_err();
+        assert_eq!(err.code(), ErrCode::EIO);
+    }
+
+    #[test]
+    fn extent_block_tail_corruption_is_rejected_with_metadata_csum() {
+        let fs = make_metadata_csum_test_fs(1024);
+        let mut inode = InodeRef::new(17, Box::new(Inode::default()));
+        inode.inode.set_generation(23);
+        let mut image = [0u8; BLOCK_SIZE];
+        ExtentNodeMut::from_bytes(&mut image).init(0, 0);
+        Ext4::set_extent_block_checksum(&fs.read_super_block_cached().uuid(), &inode, &mut image);
+        fs.verify_extent_block_checksum(&inode, &image).unwrap();
+
+        image[BLOCK_SIZE - 1] ^= 0x80;
+        let err = fs
+            .verify_extent_block_checksum(&inode, &image)
+            .expect_err("damaged extent tail must fail authentication");
         assert_eq!(err.code(), ErrCode::EIO);
     }
 
@@ -639,5 +1078,84 @@ mod tests {
             .validate_extent_node(4, &node.as_immut())
             .expect_err("unsorted index must be rejected");
         assert_eq!(err.code(), ErrCode::EIO);
+    }
+
+    #[test]
+    fn trim_depth_zero_partial_extent_preserves_prefix() {
+        let mut raw = [0u8; 60];
+        let mut node = ExtentNodeMut::from_bytes(&mut raw);
+        node.init(0, 0);
+        node.header_mut().set_entries_count(1);
+        *node.extent_mut_at(0) = Extent::new(7, 100, 9);
+
+        Ext4::trim_leaf_tail(&mut node, 4).unwrap();
+
+        assert_eq!(node.header().entries_count(), 1);
+        assert_eq!(node.extent_at(0).start_lblock(), 7);
+        assert_eq!(node.extent_at(0).start_pblock(), 100);
+        assert_eq!(node.extent_at(0).block_count(), 5);
+    }
+
+    #[test]
+    fn trim_multi_extent_removes_only_rightmost_extent() {
+        let mut raw = [0u8; 60];
+        let mut node = ExtentNodeMut::from_bytes(&mut raw);
+        node.init(0, 0);
+        node.header_mut().set_entries_count(3);
+        *node.extent_mut_at(0) = Extent::new(0, 100, 2);
+        *node.extent_mut_at(1) = Extent::new(4, 200, 3);
+        *node.extent_mut_at(2) = Extent::new(20, 300, 1);
+
+        Ext4::trim_leaf_tail(&mut node, 1).unwrap();
+
+        assert_eq!(node.header().entries_count(), 2);
+        assert_eq!(node.extent_at(0).start_pblock(), 100);
+        assert_eq!(node.extent_at(1).start_pblock(), 200);
+        assert_eq!(node.extent_at(1).block_count(), 3);
+    }
+
+    #[test]
+    fn trim_partial_unwritten_extent_preserves_unwritten_state() {
+        let mut raw = [0u8; 60];
+        let mut node = ExtentNodeMut::from_bytes(&mut raw);
+        node.init(0, 0);
+        node.header_mut().set_entries_count(1);
+        *node.extent_mut_at(0) = Extent::new(0, 100, 8);
+        node.extent_mut_at(0).mark_unwritten();
+
+        Ext4::trim_leaf_tail(&mut node, 3).unwrap();
+
+        assert_eq!(node.extent_at(0).block_count(), 5);
+        assert!(node.extent_at(0).is_unwritten());
+    }
+
+    #[test]
+    fn depth_greater_than_zero_detaches_only_empty_right_spine() {
+        let mut root_raw = [0u8; 60];
+        let mut root = ExtentNodeMut::from_bytes(&mut root_raw);
+        root.init(2, 0);
+        root.header_mut().set_entries_count(2);
+        *root.extent_index_mut_at(0) = ExtentIndex::new(0, 10);
+        *root.extent_index_mut_at(1) = ExtentIndex::new(100, 20);
+
+        let mut parent_raw = [0u8; BLOCK_SIZE];
+        let mut parent = ExtentNodeMut::from_bytes(&mut parent_raw);
+        parent.init(1, 0);
+        parent.header_mut().set_entries_count(1);
+        *parent.extent_index_mut_at(0) = ExtentIndex::new(100, 30);
+
+        let mut leaf_raw = [0u8; BLOCK_SIZE];
+        let mut leaf = ExtentNodeMut::from_bytes(&mut leaf_raw);
+        leaf.init(0, 0);
+        leaf.header_mut().set_entries_count(1);
+        *leaf.extent_mut_at(0) = Extent::new(100, 500, 1);
+
+        Ext4::trim_leaf_tail(&mut leaf, 1).unwrap();
+        assert_eq!(leaf.header().entries_count(), 0);
+        assert!(parent.remove_last_entry());
+        assert_eq!(parent.header().entries_count(), 0);
+        assert!(root.remove_last_entry());
+        assert_eq!(root.header().entries_count(), 1);
+        assert_eq!(root.extent_index_at(0).leaf(), 10);
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/journal.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal.rs
@@ -1,8 +1,32 @@
 use super::{journal_recovery, journal_transaction, Ext4};
 use crate::constants::BLOCK_SIZE;
-use crate::ext4_defs::{Block, BlockDevice, SuperBlock};
+use crate::ext4_defs::{AsBytes, Block, BlockDevice, InodeRef, SuperBlock};
 use crate::jbd2::Superblock as JournalSuperblock;
 use crate::prelude::*;
+
+fn validate_journal_inode(sb: &SuperBlock, inode: &InodeRef) -> Result<()> {
+    if !inode.inode.is_file()
+        || !inode.inode.uses_extents()
+        || (sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM)
+            && !inode.verify_checksum(&sb.uuid()))
+    {
+        return Err(Ext4Error::new(ErrCode::EIO));
+    }
+    Ok(())
+}
+
+fn journal_replay_identity_matches(
+    before: &InodeRef,
+    after: &InodeRef,
+    before_mapping: &[PBlockId],
+    after_mapping: &[PBlockId],
+) -> bool {
+    after.id == before.id
+        && after.inode.generation() == before.inode.generation()
+        && after.inode.mode() == before.inode.mode()
+        && after.inode.size() == before.inode.size()
+        && after_mapping == before_mapping
+}
 
 struct RecoveryDevice<'a> {
     device: &'a dyn BlockDevice,
@@ -64,6 +88,31 @@ impl journal_recovery::JournalRecoveryIo for RecoveryDevice<'_> {
 }
 
 impl Ext4 {
+    fn map_validated_journal_inode(
+        &self,
+        inode: &InodeRef,
+        journal_len: usize,
+        filesystem_blocks: u64,
+    ) -> Result<(Vec<PBlockId>, BTreeSet<PBlockId>)> {
+        self.validate_complete_extent_tree(inode)?;
+        if self.extent_next_data_lblock(inode)? as usize != journal_len {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let mut mapping = Vec::new();
+        mapping
+            .try_reserve_exact(journal_len)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        let mut blocks = BTreeSet::new();
+        for logical in 0..journal_len {
+            let physical = self.extent_query(inode, logical as u32)?;
+            if physical == 0 || physical >= filesystem_blocks || !blocks.insert(physical) {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            mapping.push(physical);
+        }
+        Ok((mapping, blocks))
+    }
+
     pub fn supports_reliable_flush(&self) -> bool {
         self.block_device.supports_reliable_flush()
     }
@@ -73,6 +122,9 @@ impl Ext4 {
     }
 
     pub fn shutdown_writable(&self) -> Result<()> {
+        // Clearing RECOVER is a metadata state transition and must not race a
+        // direct writer even if the VFS normally excludes writers at umount.
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let Some(journal) = self.journal.as_ref() else {
             return Ok(());
         };
@@ -103,6 +155,9 @@ impl Ext4 {
         if !self.block_device.supports_reliable_flush() {
             return Err(Ext4Error::new(ErrCode::ENOTSUP));
         }
+        // Unsupported orphan-file states must be rejected before replay can
+        // write home blocks or this mount can set RECOVER.
+        self.writable_orphan_preflight()?;
         let mut ext4_sb = self.read_super_block_cached();
         if !ext4_sb.has_compatible_feature(SuperBlock::FEATURE_COMPAT_HAS_JOURNAL)
             || ext4_sb.has_compatible_feature(SuperBlock::FEATURE_COMPAT_FAST_COMMIT)
@@ -114,6 +169,7 @@ impl Ext4 {
         }
 
         let journal_inode = self.read_inode_uncached(ext4_sb.journal_inode_number())?;
+        validate_journal_inode(&ext4_sb, &journal_inode)?;
         let journal_size = journal_inode.inode.size();
         let journal_len_u64 = journal_size / BLOCK_SIZE as u64;
         if journal_size % BLOCK_SIZE as u64 != 0
@@ -137,21 +193,8 @@ impl Ext4 {
         }
 
         let journal_len = journal_sb.max_len as usize;
-        let mut mapping = Vec::new();
-        mapping
-            .try_reserve_exact(journal_len)
-            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
-        let mut journal_blocks = BTreeSet::new();
-        for logical in 0..journal_len {
-            let physical = self.extent_query(&journal_inode, logical as u32)?;
-            if physical == 0
-                || physical >= ext4_sb.block_count()
-                || !journal_blocks.insert(physical)
-            {
-                return Err(Ext4Error::new(ErrCode::EIO));
-            }
-            mapping.push(physical);
-        }
+        let (mapping, journal_blocks) =
+            self.map_validated_journal_inode(&journal_inode, journal_len, ext4_sb.block_count())?;
 
         let needs_recovery = ext4_sb.has_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER);
         if journal_sb.start != 0 && !needs_recovery {
@@ -168,32 +211,40 @@ impl Ext4 {
             let recovered_block0 = self.block_device.read_block(0)?;
             let recovered_sb: SuperBlock =
                 recovered_block0.read_offset_as(crate::constants::BASE_OFFSET);
-            if !recovered_sb.check_magic()
-                || recovered_sb.inode_size() != crate::constants::SB_GOOD_INODE_SIZE
-                || recovered_sb.desc_size() != crate::constants::SB_GOOD_DESC_SIZE
+            let recovered_groups =
+                Self::read_validated_block_groups(self.block_device.as_ref(), &recovered_sb)?;
+            let recovered_system_ranges =
+                Self::build_system_metadata_ranges(&recovered_sb, &recovered_groups)?;
+            if mapping
+                .iter()
+                .any(|physical| *physical >= recovered_sb.block_count())
             {
                 return Err(Ext4Error::new(ErrCode::EIO));
             }
             ext4_sb = recovered_sb;
             *self.cached_super_block.lock() = recovered_sb;
+            self.cached_block_groups = recovered_groups;
+            self.system_metadata_ranges = recovered_system_ranges;
+            let recovered_journal_inode =
+                self.read_inode_uncached(recovered_sb.journal_inode_number())?;
+            validate_journal_inode(&recovered_sb, &recovered_journal_inode)?;
+            let (recovered_mapping, recovered_journal_blocks) = self.map_validated_journal_inode(
+                &recovered_journal_inode,
+                journal_len,
+                recovered_sb.block_count(),
+            )?;
+            if !journal_replay_identity_matches(
+                &journal_inode,
+                &recovered_journal_inode,
+                &mapping,
+                &recovered_mapping,
+            ) || recovered_journal_blocks != journal_blocks
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
             let refreshed = self.block_device.read_block(mapping[0])?;
             journal_sb = JournalSuperblock::parse(&refreshed.data[..], BLOCK_SIZE as u32)?;
             self.inode_cache.lock().entries.clear();
-            for (index, cached) in self.cached_block_groups.iter().enumerate() {
-                let sb = self.read_super_block_cached();
-                let per_block = BLOCK_SIZE as u32 / sb.desc_size() as u32;
-                let block_id = sb.first_data_block() + index as u32 / per_block + 1;
-                let offset = (index as u32 % per_block) * sb.desc_size() as u32;
-                let block = self.block_device.read_block(block_id as PBlockId)?;
-                *cached.lock() = block.read_offset_as(offset as usize);
-            }
-        }
-
-        // Linux keeps RECOVER set for the complete read-write mount lifetime.
-        if !needs_recovery {
-            ext4_sb.set_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER, true);
-            self.write_super_block(&ext4_sb)?;
-            self.block_device.flush()?;
         }
 
         let mut image = Box::new([0u8; 1024]);
@@ -213,19 +264,146 @@ impl Ext4 {
                 superblock_image: image,
             },
         )?);
+
+        // Replay may itself publish a newer ext4 superblock.  Recheck the
+        // recovered feature set before interpreting or mutating orphan state;
+        // the earlier preflight is still required to prevent replay writes on
+        // a format that was already unsupported at mount entry.
+        self.writable_orphan_preflight()?;
+
+        // Linux keeps RECOVER set for the complete read-write mount lifetime.
+        // Publish it before the first new journal transaction. A later orphan
+        // validation or cleanup error deliberately leaves RECOVER set.
+        if !needs_recovery {
+            ext4_sb.set_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER, true);
+            self.write_super_block(&ext4_sb)?;
+            self.block_device.flush()?;
+        }
+
+        // Hold the transactional metadata barrier from the complete read-only
+        // orphan snapshot through every cleanup commit.
+        self.cleanup_legacy_orphan_chain()?;
         Ok(())
+    }
+
+    pub(super) fn journal_owns_block_range(&self, start: PBlockId, end: PBlockId) -> bool {
+        self.journal
+            .as_ref()
+            .is_some_and(|journal| journal.owns_block_range(start, end))
     }
 }
 
 impl journal_transaction::CachePublisher for Ext4 {
-    fn publish(&self, blocks: &[&journal_transaction::StagedBlock]) {
+    fn publish(&self, blocks: &BTreeMap<PBlockId, journal_transaction::StagedBlock>) {
+        // Normal transactions change descriptor counters/checksums, never the
+        // validated bitmap/table addresses. Therefore system_metadata_ranges
+        // remains immutable here; journal replay is the only path which can
+        // replace the complete SB/BGD snapshot and rebuilds it explicitly.
+        // Home blocks are durable at this point.  Decode cacheable value
+        // snapshots directly from the transaction-owned images; all updates
+        // below are infallible and allocation-free.
+        if let Some(block0) = blocks.get(&0) {
+            let sb = SuperBlock::from_bytes(&block0.bytes()[crate::constants::BASE_OFFSET..]);
+            *self.cached_super_block.lock() = sb;
+        }
+
+        let sb = self.read_super_block_cached();
+        let per_block = BLOCK_SIZE as u32 / sb.desc_size() as u32;
+        for (index, cached) in self.cached_block_groups.iter().enumerate() {
+            let block_id = sb.first_data_block() + index as u32 / per_block + 1;
+            let Some(image) = blocks.get(&(block_id as PBlockId)) else {
+                continue;
+            };
+            let offset = (index as u32 % per_block) * sb.desc_size() as u32;
+            *cached.lock() =
+                crate::ext4_defs::BlockGroupDesc::from_bytes(&image.bytes()[offset as usize..]);
+        }
+
         // Transactional inode and directory mutations must not leave value
         // snapshots from before the checkpoint visible after commit.
-        let changed = BTreeSet::from_iter(blocks.iter().map(|block| block.home()));
         self.inode_cache.lock().entries.retain(|inode_id, _| {
             self.inode_disk_pos(*inode_id)
-                .map(|(block, _)| !changed.contains(&block))
+                .map(|(block, _)| !blocks.contains_key(&block))
                 .unwrap_or(false)
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::BASE_OFFSET;
+    use crate::ext4_defs::{Inode, InodeMode};
+
+    fn metadata_csum_superblock() -> SuperBlock {
+        let mut raw = [0u8; 2048];
+        raw[BASE_OFFSET + 100..BASE_OFFSET + 104]
+            .copy_from_slice(&SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM.to_le_bytes());
+        raw[BASE_OFFSET + 104..BASE_OFFSET + 120].copy_from_slice(&[0x3c; 16]);
+        SuperBlock::from_bytes(&raw[BASE_OFFSET..])
+    }
+
+    fn valid_journal_inode(sb: &SuperBlock) -> InodeRef {
+        let mut inode = InodeRef::new(8, Box::new(Inode::default()));
+        inode.inode.set_mode(InodeMode::FILE | InodeMode::ALL_RW);
+        inode.inode.set_generation(9);
+        inode.inode.extent_init();
+        inode.set_checksum(&sb.uuid());
+        inode
+    }
+
+    #[test]
+    fn journal_inode_mode_and_checksum_are_authenticated() {
+        let sb = metadata_csum_superblock();
+        let inode = valid_journal_inode(&sb);
+        validate_journal_inode(&sb, &inode).unwrap();
+
+        let mut bad_mode = inode.clone();
+        bad_mode
+            .inode
+            .set_mode(InodeMode::DIRECTORY | InodeMode::ALL_RWX);
+        bad_mode.set_checksum(&sb.uuid());
+        assert_eq!(
+            validate_journal_inode(&sb, &bad_mode).unwrap_err().code(),
+            ErrCode::EIO
+        );
+
+        let mut bad_checksum = inode;
+        bad_checksum.inode.set_generation(10);
+        assert_eq!(
+            validate_journal_inode(&sb, &bad_checksum)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+    }
+
+    #[test]
+    fn replayed_journal_mapping_or_identity_change_is_rejected() {
+        let sb = metadata_csum_superblock();
+        let mut before = valid_journal_inode(&sb);
+        before.inode.set_size(8192);
+        before.set_checksum(&sb.uuid());
+        let after = before.clone();
+        assert!(journal_replay_identity_matches(
+            &before,
+            &after,
+            &[20, 21],
+            &[20, 21]
+        ));
+        assert!(!journal_replay_identity_matches(
+            &before,
+            &after,
+            &[20, 21],
+            &[20, 22]
+        ));
+        let mut changed = after;
+        changed.inode.set_generation(10);
+        assert!(!journal_replay_identity_matches(
+            &before,
+            &changed,
+            &[20, 21],
+            &[20, 21]
+        ));
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -78,7 +78,13 @@ impl StagedBlock {
 
 /// Cache changes are published only after checkpoint data is durable.
 pub trait CachePublisher: Send + Sync {
-    fn publish(&self, blocks: &[&StagedBlock]);
+    /// Publish already-checkpointed images to in-memory caches.
+    ///
+    /// This callback runs after the home-block flush, so it must not allocate,
+    /// perform I/O, or otherwise fail.  Borrowing the transaction's map also
+    /// lets publishers inspect the final image for a particular home block
+    /// without building a temporary collection.
+    fn publish(&self, blocks: &BTreeMap<PBlockId, StagedBlock>);
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -123,6 +129,17 @@ impl JournalTransactionCore {
 
     pub fn can_shutdown(&self) -> bool {
         !self.writer.load(Ordering::Acquire) && !self.is_poisoned()
+    }
+
+    pub fn owns_block_range(&self, start: PBlockId, end: PBlockId) -> bool {
+        start < end
+            && self
+                .context
+                .lock()
+                .journal_blocks
+                .range(start..end)
+                .next()
+                .is_some()
     }
 
     pub fn start(&self, credits: usize) -> Result<Transaction<'_>> {
@@ -188,6 +205,37 @@ impl Transaction<'_> {
         }
         self.staged.insert(home, StagedBlock { home, image });
         Ok(())
+    }
+
+    /// Return the transaction-private final image of `home` for mutation.
+    ///
+    /// The first access snapshots the device block and consumes one credit;
+    /// later accesses return the same image, providing read-your-writes and
+    /// naturally merging updates to shared metadata blocks.
+    pub fn read_for_update<'a>(
+        &'a mut self,
+        device: &dyn BlockDevice,
+        home: PBlockId,
+    ) -> Result<&'a mut [u8; BLOCK_SIZE]> {
+        if !self.staged.contains_key(&home) {
+            if self.staged.len() == self.credits {
+                return Err(Ext4Error::new(ErrCode::E2BIG));
+            }
+            let block = device.read_block(home)?;
+            self.staged.insert(
+                home,
+                StagedBlock {
+                    home,
+                    image: block.data,
+                },
+            );
+        }
+        Ok(self
+            .staged
+            .get_mut(&home)
+            .expect("staged block was just inserted")
+            .image
+            .as_mut())
     }
 
     pub fn read<'a>(&'a self, device: &dyn BlockDevice, home: PBlockId) -> Result<BlockView<'a>> {
@@ -326,7 +374,7 @@ impl Transaction<'_> {
         if let Err(error) = device.flush() {
             return self.fail(error, CommitFailure::CheckpointFailed, true);
         }
-        publisher.publish(&self.staged.values().collect::<Vec<_>>());
+        publisher.publish(&self.staged);
 
         if let Err(error) =
             write_journal_superblock(device, &mapping, &clean_sb_image).and_then(|_| device.flush())
@@ -629,9 +677,24 @@ mod tests {
 
     struct Publisher(AtomicUsize);
     impl CachePublisher for Publisher {
-        fn publish(&self, blocks: &[&StagedBlock]) {
+        fn publish(&self, blocks: &BTreeMap<PBlockId, StagedBlock>) {
             self.0.fetch_add(blocks.len(), Ordering::SeqCst);
         }
+    }
+
+    #[test]
+    fn read_for_update_merges_shared_block_and_charges_one_credit() {
+        let device = MemoryDevice::new();
+        let core = JournalTransactionCore::new(context()).unwrap();
+        let mut transaction = core.start(1).unwrap();
+
+        transaction.read_for_update(&device, 42).unwrap()[10] = 1;
+        transaction.read_for_update(&device, 42).unwrap()[11] = 2;
+        assert_eq!(transaction.read(&device, 42).unwrap()[10..12], [1, 2]);
+        assert_eq!(
+            transaction.read_for_update(&device, 43).unwrap_err().code(),
+            ErrCode::E2BIG
+        );
     }
 
     fn context() -> JournalContext {

--- a/kernel/crates/another_ext4/src/ext4/link.rs
+++ b/kernel/crates/another_ext4/src/ext4/link.rs
@@ -9,10 +9,38 @@ impl Ext4 {
         parent: &mut InodeRef,
         child: &mut InodeRef,
         name: &str,
+        allow_orphan_relink: bool,
     ) -> Result<()> {
         self.ensure_mutable()?;
         let child_link_count = child.inode.link_count();
         let parent_link_count = parent.inode.link_count();
+        if child_link_count == 0 && allow_orphan_relink {
+            if !self.legacy_orphan_contains(child.id)? {
+                return Err(Ext4Error::new(ErrCode::EINVAL));
+            }
+            if child.inode.is_dir() {
+                return Err(Ext4Error::new(ErrCode::EPERM));
+            }
+            if !self.dir_has_insert_space(parent, child, name)? {
+                self.prepare_empty_dir_slot(parent)?;
+            }
+            // A zero-link inode is discoverable through the durable orphan
+            // chain.  Linux removes it from that chain in the same handle that
+            // publishes the new name and link count; otherwise a crash could
+            // reclaim a newly reachable inode.
+            let mut transaction = self.transaction_start(3)?;
+            let mut sb = self.read_super_block_cached();
+            self.transaction_orphan_del(&mut transaction, child, &mut sb)?;
+            self.transaction_dir_add_existing(&mut transaction, parent, child, name)?;
+            child.inode.set_link_count(1);
+            child.inode.set_next_orphan(0);
+            self.transaction_stage_inode_with_csum(&mut transaction, child)?;
+            if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
+                self.poison(ErrCode::EIO);
+                return Err(error.error);
+            }
+            return Ok(());
+        }
         if child.inode.is_dir() {
             // Prepare all inode metadata before publishing parent/name.  A
             // failure before the final dir_add_entry cannot leave a namespace
@@ -47,10 +75,42 @@ impl Ext4 {
         child: &mut InodeRef,
         name: &str,
     ) -> Result<Option<InodeReclaimHandle>> {
-        // Remove entry from parent directory
-        self.dir_remove_entry(parent, name)?;
-
         let child_link_cnt = child.inode.link_count();
+        let final_link = (child.inode.is_dir() && child_link_cnt <= 2) || child_link_cnt <= 1;
+
+        if final_link {
+            // Linux journals deletion of the directory entry, the zero link
+            // count, and insertion into the orphan list in one handle.  Keep
+            // the same crash invariant here: after recovery the inode is
+            // either still named, or unreachable and discoverable from the
+            // on-disk orphan head.
+            let mut transaction =
+                self.transaction_start(if child.inode.is_dir() { 4 } else { 3 })?;
+            self.transaction_dir_remove_entry(&mut transaction, parent, name)?;
+
+            if child.inode.is_dir() {
+                parent.inode.set_link_count(parent.inode.link_count() - 1);
+                self.transaction_stage_inode_with_csum(&mut transaction, parent)?;
+            }
+            child.inode.set_link_count(0);
+            let mut sb = self.read_super_block_cached();
+            self.transaction_orphan_add(&mut transaction, child, &mut sb)?;
+
+            if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
+                // A commit-path failure may make journal state uncertain.  Do
+                // not let legacy direct writers continue after this boundary.
+                self.poison(ErrCode::EIO);
+                return Err(error.error);
+            }
+            return Ok(Some(InodeReclaimHandle::new(
+                child.id,
+                child.inode.generation(),
+            )));
+        }
+
+        // Non-final hard-link removal does not create an orphan.  Preserve the
+        // established path until all namespace writers move under JBD2.
+        self.dir_remove_entry(parent, name)?;
         if child.inode.is_dir() {
             parent.inode.set_link_count(parent.inode.link_count() - 1);
             if let Err(error) = self.write_inode_with_csum(parent) {
@@ -58,14 +118,11 @@ impl Ext4 {
                 return Err(error);
             }
         }
-        let final_link = (child.inode.is_dir() && child_link_cnt <= 2) || child_link_cnt <= 1;
-        child
-            .inode
-            .set_link_count(if final_link { 0 } else { child_link_cnt - 1 });
+        child.inode.set_link_count(child_link_cnt - 1);
         if let Err(error) = self.write_inode_with_csum(child) {
             self.poison(ErrCode::EIO);
             return Err(error);
         }
-        Ok(final_link.then(|| InodeReclaimHandle::new(child.id, child.inode.generation())))
+        Ok(None)
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -40,6 +40,43 @@ impl SetAttr {
 }
 
 impl Ext4 {
+    fn xattr_checksum_seed(&self) -> Result<Option<u32>> {
+        let sb = self.read_super_block_cached();
+        if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
+            return Ok(None);
+        }
+        // A seeded-checksum filesystem must use s_checksum_seed rather than
+        // CRC32C(UUID). Writable preflight rejects it, and direct xattr paths
+        // must fail closed as well instead of writing a mismatched checksum.
+        const FEATURE_INCOMPAT_CSUM_SEED: u32 = 0x2000;
+        if sb.has_incompatible_feature(FEATURE_INCOMPAT_CSUM_SEED) {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+        Ok(Some(crate::ext4_defs::crc::crc32(CRC32_INIT, &sb.uuid())))
+    }
+
+    fn verify_xattr_block_checksum(&self, block_id: PBlockId, block: &XattrBlock) -> Result<()> {
+        if let Some(seed) = self.xattr_checksum_seed()? {
+            if !block.verify_checksum(seed, block_id) {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+        }
+        Ok(())
+    }
+
+    fn update_xattr_block_checksum(
+        &self,
+        block_id: PBlockId,
+        block: &mut XattrBlock,
+    ) -> Result<()> {
+        if let Some(seed) = self.xattr_checksum_seed()? {
+            if !block.update_checksum(seed, block_id) {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+        }
+        Ok(())
+    }
+
     fn read_extent_or_hole(
         &self,
         file: &InodeRef,
@@ -1288,6 +1325,7 @@ impl Ext4 {
             return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
         }
         let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
         match xattr_block.get(name) {
             Some(value) => Ok(value.to_owned()),
             None => Err(format_error!(
@@ -1350,6 +1388,7 @@ impl Ext4 {
                         inode
                     );
                 }
+                self.update_xattr_block_checksum(pblock, &mut xattr_block)?;
                 self.write_block(&xattr_block.block())?;
                 inode_ref.inode.set_xattr_block(pblock);
                 self.write_inode_with_csum(&mut inode_ref)?;
@@ -1366,6 +1405,7 @@ impl Ext4 {
         }
 
         let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
         let exists = xattr_block.get(name).is_some();
         if exists && create {
             return_error!(ErrCode::EEXIST, "Xattr {} already exists", name);
@@ -1379,6 +1419,7 @@ impl Ext4 {
             let _ = new_xattr_block.remove(name);
         }
         if new_xattr_block.insert(name, value) {
+            self.update_xattr_block_checksum(xattr_block_id, &mut new_xattr_block)?;
             self.write_block(&new_xattr_block.block())?;
             Ok(())
         } else {
@@ -1411,7 +1452,9 @@ impl Ext4 {
             return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
         }
         let mut xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
         if xattr_block.remove(name) {
+            self.update_xattr_block_checksum(xattr_block_id, &mut xattr_block)?;
             self.write_block(&xattr_block.block())?;
             Ok(())
         } else {
@@ -1435,6 +1478,7 @@ impl Ext4 {
             return Ok(Vec::new());
         }
         let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
         Ok(xattr_block.list())
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -115,6 +115,7 @@ impl Ext4 {
     /// `EINVAL` if the inode is invalid (mode == 0).
     pub fn setattr(&self, id: InodeId, attr: SetAttr) -> Result<()> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
@@ -209,6 +210,8 @@ impl Ext4 {
         offset: usize,
         len: usize,
     ) -> Result<()> {
+        self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
@@ -231,6 +234,7 @@ impl Ext4 {
         _mtime: Option<u32>,
     ) -> Result<()> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
@@ -248,6 +252,7 @@ impl Ext4 {
         mtime: Option<u32>,
     ) -> Result<()> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
@@ -280,7 +285,7 @@ impl Ext4 {
         child: &mut InodeRef,
         name: &str,
     ) -> Result<()> {
-        if let Err(link_err) = self.link_inode(parent, child, name) {
+        if let Err(link_err) = self.link_inode(parent, child, name, false) {
             if let Err(cleanup_err) = self.free_inode(child) {
                 trace!(
                     "link failed for new inode {} (name {}), cleanup failed: {:?}; original link error: {:?}",
@@ -316,6 +321,7 @@ impl Ext4 {
     /// * `ENOSPC` - No space left on device
     pub fn create(&self, parent: InodeId, name: &str, mode: InodeMode) -> Result<InodeId> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent]);
         let mut parent = self.read_inode(parent)?;
@@ -361,6 +367,7 @@ impl Ext4 {
         minor: u32,
     ) -> Result<InodeId> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent]);
         let mut parent_ref = self.read_inode(parent)?;
@@ -520,6 +527,7 @@ impl Ext4 {
     /// * `ENOSPC` - no space left on device
     pub fn write(&self, file: InodeId, offset: usize, data: &[u8]) -> Result<usize> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let write_size = data.len();
         if write_size == 0 {
             return Ok(0);
@@ -578,6 +586,7 @@ impl Ext4 {
     /// operate on cloned `InodeRef` snapshots from the inode cache.
     pub fn write_data_only(&self, file: InodeId, offset: usize, data: &[u8]) -> Result<usize> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let write_size = data.len();
         let mut chunks = Vec::new();
         let _mutation_guard =
@@ -632,6 +641,10 @@ impl Ext4 {
     /// * `ENOSPC` - no space left on device
     pub fn link(&self, child: InodeId, parent: InodeId, name: &str) -> Result<()> {
         self.ensure_mutable()?;
+        // Relinking a zero-link inode must compose namespace publication with
+        // orphan removal in one journal transaction.  Use the exclusive
+        // metadata domain for both zero and nonzero link-count cases.
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent, child]);
         let mut parent = self.read_inode(parent)?;
@@ -644,7 +657,7 @@ impl Ext4 {
         if child.inode.is_dir() {
             return_error!(ErrCode::EISDIR, "Cannot link a directory");
         }
-        self.link_inode(&mut parent, &mut child, name)?;
+        self.link_inode(&mut parent, &mut child, name, true)?;
         Ok(())
     }
 
@@ -662,6 +675,7 @@ impl Ext4 {
     /// * `EISDIR` - `parent/name` is a directory
     pub fn unlink(&self, parent: InodeId, name: &str) -> Result<Option<InodeReclaimHandle>> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let mut parent_ref = self.read_inode(parent)?;
         // Can only unlink from a directory
@@ -774,6 +788,11 @@ impl Ext4 {
         new_name: &str,
     ) -> Result<Option<InodeReclaimHandle>> {
         self.ensure_mutable()?;
+        // Rename can remove the final name of an overwritten target. Keep the
+        // complete namespace transition in the exclusive domain so a follow-up
+        // transactional orphan/reclaim implementation cannot inherit a stale
+        // direct-writer snapshot window.
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let mut reclaim = None;
         // 1. 验证父目录
@@ -842,51 +861,66 @@ impl Ext4 {
                     }
                 }
 
-                // 4b-2. 原子替换：原地修改目标目录项，指向源 inode
-                // 这是原子操作的核心：目标目录项从未"消失"
+                let existing_link_cnt = existing_inode.inode.link_count();
+                let final_target =
+                    existing_link_cnt <= 1 || (existing_is_dir && existing_link_cnt <= 2);
+
+                // Upper bound of distinct home blocks in the replace set:
+                // destination dirent + source dirent + optional child "..";
+                // overwritten inode + each logically changed parent inode;
+                // and the superblock only for a final target.  The transaction
+                // map deduplicates entries which share a directory or inode-
+                // table block, so same-parent and same-block cases consume
+                // fewer credits without weakening the reservation bound.
+                let mut credits = 3; // two dirent blocks + overwritten inode
+                if child_is_dir && parent != new_parent {
+                    credits += 3; // child ".." + old parent + new parent
+                }
+                if existing_is_dir && !(child_is_dir && parent != new_parent) {
+                    credits += 1; // target parent (new parent already counted above)
+                }
+                if final_target {
+                    credits += 1; // superblock orphan head
+                }
+                let mut transaction = self.transaction_start(credits)?;
+
+                // Match Linux ext4_rename(): ext4_setent(new), delete(old),
+                // ext4_rename_dir_finish(), parent counts, target nlink, and
+                // ext4_orphan_add() all belong to this single handle.
                 {
                     let target_dir = new_parent_ref.as_mut().unwrap_or(&mut parent_ref);
-                    self.poison_on_error(self.dir_replace_entry(
+                    self.transaction_dir_replace_entry(
+                        &mut transaction,
                         target_dir,
                         new_name,
                         child_id,
                         child_file_type,
-                    ))?;
+                    )?;
 
-                    // 4b-3. 处理被替换目录的父目录 link count
-                    //
-                    // 被替换目录的 ".." 不主动删除（对齐 Linux ext4_rename）：
-                    // Linux 使用 clear_nlink(new.inode) 标记被替换目录待释放，
-                    // 从不触碰其内部的 ".." 条目。".." 随 free_inode 释放数据块自然消失。
-                    //
-                    // 父目录 link count 仍需递减：被替换目录的 ".." 引用逻辑上失效。
                     if existing_is_dir {
                         target_dir
                             .inode
                             .set_link_count(target_dir.inode.link_count() - 1);
-                        self.poison_on_error(self.write_inode_with_csum(target_dir))?;
+                        self.transaction_stage_inode_with_csum(&mut transaction, target_dir)?;
                     }
                 }
 
-                // 4b-4. 删除源目录项，避免 rename 覆盖后源路径仍可见
-                self.poison_on_error(self.dir_remove_entry(&parent_ref, name))?;
+                self.transaction_dir_remove_entry(&mut transaction, &parent_ref, name)?;
 
-                // 4b-5. 跨目录移动时，处理源目录的 ".." 指向
                 if child_is_dir && parent != new_parent {
-                    // 更新被移动目录的 ".." 指向新父目录
-                    self.poison_on_error(self.dir_replace_entry(
+                    self.transaction_dir_replace_entry(
+                        &mut transaction,
                         &child,
                         "..",
                         new_parent,
                         FileType::Directory,
-                    ))?;
+                    )?;
 
                     parent_ref
                         .inode
                         .set_link_count(parent_ref.inode.link_count() - 1);
-                    self.poison_on_error(self.write_inode_with_csum(&mut parent_ref))?;
+                    self.transaction_stage_inode_with_csum(&mut transaction, &mut parent_ref)?;
 
-                    // 注意：当 parent != new_parent 时，new_parent_ref 必定是 Some(...)
                     let new_parent_dir = new_parent_ref.as_mut().ok_or(format_error!(
                         ErrCode::EINVAL,
                         "rename: missing new parent reference for directory move"
@@ -894,28 +928,30 @@ impl Ext4 {
                     new_parent_dir
                         .inode
                         .set_link_count(new_parent_dir.inode.link_count() + 1);
-                    self.poison_on_error(self.write_inode_with_csum(new_parent_dir))?;
+                    self.transaction_stage_inode_with_csum(&mut transaction, new_parent_dir)?;
                 }
-                // 4b-6. The target link transition is the final fallible
-                // metadata step.  Once it reaches zero the returned capability
-                // cannot be lost behind later rename work.
-                let existing_link_cnt = existing_inode.inode.link_count();
-                if existing_link_cnt <= 1 || (existing_is_dir && existing_link_cnt <= 2) {
+
+                if final_target {
                     existing_inode.inode.set_link_count(0);
-                    if let Err(error) = self.write_inode_with_csum(&mut existing_inode) {
-                        self.poison(ErrCode::EIO);
-                        return Err(error);
-                    }
+                    let mut sb = self.read_super_block_cached();
+                    self.transaction_orphan_add(&mut transaction, &mut existing_inode, &mut sb)?;
+                } else {
+                    existing_inode.inode.set_link_count(existing_link_cnt - 1);
+                    self.transaction_stage_inode_with_csum(&mut transaction, &mut existing_inode)?;
+                }
+
+                if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
+                    // Once commit processing starts, failures can leave an
+                    // uncertain committed/checkpointed state.  Fail-stop every
+                    // subsequent metadata writer on this mount.
+                    self.poison(ErrCode::EIO);
+                    return Err(error.error);
+                }
+                if final_target {
                     reclaim = Some(InodeReclaimHandle::new(
                         existing_inode.id,
                         existing_inode.inode.generation(),
                     ));
-                } else {
-                    existing_inode.inode.set_link_count(existing_link_cnt - 1);
-                    if let Err(error) = self.write_inode_with_csum(&mut existing_inode) {
-                        self.poison(ErrCode::EIO);
-                        return Err(error);
-                    }
                 }
                 // 文件的 link count 不变（只是换了名字/位置）
             }
@@ -998,6 +1034,7 @@ impl Ext4 {
         new_name: &str,
     ) -> Result<()> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         // 1. 验证父目录
         let (mut parent_ref, mut new_parent_ref) = self.read_rename_dirs(parent, new_parent)?;
@@ -1115,6 +1152,7 @@ impl Ext4 {
     /// * `ENOSPC` - no space left on device
     pub fn mkdir(&self, parent: InodeId, name: &str, mode: InodeMode) -> Result<InodeId> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent]);
         let mut parent = self.read_inode(parent)?;
@@ -1199,6 +1237,7 @@ impl Ext4 {
     /// * `ENOTEMPTY` - `child` is not empty
     pub fn rmdir(&self, parent: InodeId, name: &str) -> Result<Option<InodeReclaimHandle>> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let mut parent_ref = self.read_inode(parent)?;
         // Can only remove a directory in a directory
@@ -1289,6 +1328,7 @@ impl Ext4 {
         replace: bool,
     ) -> Result<()> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _mutation_guard =
             self.inode_mutation_locks[self.inode_mutation_lock_index(inode)].lock();
         let mut inode_ref = self.read_inode(inode)?;
@@ -1362,6 +1402,7 @@ impl Ext4 {
     /// `ENODATA` - the attribute does not exist
     pub fn removexattr(&self, inode: InodeId, name: &str) -> Result<()> {
         self.ensure_mutable()?;
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _mutation_guard =
             self.inode_mutation_locks[self.inode_mutation_lock_index(inode)].lock();
         let inode_ref = self.read_inode(inode)?;
@@ -1447,9 +1488,11 @@ mod tests {
             block_device,
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups: Vec::new(),
+            system_metadata_ranges: Vec::new(),
             inode_cache: spin::Mutex::new(crate::ext4::InodeCache::new(16)),
             alloc_lock: spin::Mutex::new(()),
             namespace_lock: spin::Mutex::new(()),
+            metadata_mutation_barrier: crate::ext4::MetadataMutationGate::new(),
             poisoned: spin::Mutex::new(None),
             journal: None,
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
@@ -1469,6 +1512,92 @@ mod tests {
         fs.read_extent_or_hole(&inode, 0, 0, &mut buf).unwrap();
 
         assert_eq!(buf, [0; 16]);
+    }
+
+    #[test]
+    fn metadata_mutation_barrier_separates_direct_and_transactional_writers() {
+        let fs = make_test_fs(16);
+
+        let direct = fs.lock_direct_metadata_mutation().unwrap();
+        let second_direct = fs.lock_direct_metadata_mutation().unwrap();
+        assert_eq!(
+            fs.lock_transactional_metadata_mutation()
+                .expect_err("exclusive gate must not wait for direct owners")
+                .code(),
+            ErrCode::EAGAIN
+        );
+        drop(second_direct);
+        drop(direct);
+
+        let transaction = fs.lock_transactional_metadata_mutation().unwrap();
+        assert_eq!(
+            fs.lock_direct_metadata_mutation()
+                .expect_err("direct gate must not wait for exclusive owner")
+                .code(),
+            ErrCode::EAGAIN
+        );
+        assert_eq!(
+            fs.lock_transactional_metadata_mutation()
+                .expect_err("second exclusive owner must be rejected")
+                .code(),
+            ErrCode::EAGAIN
+        );
+        drop(transaction);
+        drop(fs.lock_transactional_metadata_mutation().unwrap());
+        drop(fs.lock_direct_metadata_mutation().unwrap());
+    }
+
+    #[test]
+    fn metadata_mutation_barrier_rejects_direct_count_overflow() {
+        let fs = make_test_fs(16);
+        fs.metadata_mutation_barrier.state.store(
+            crate::ext4::METADATA_GATE_DIRECT_MAX,
+            core::sync::atomic::Ordering::Relaxed,
+        );
+        assert_eq!(
+            fs.lock_direct_metadata_mutation()
+                .expect_err("direct count must not enter the exclusive bit")
+                .code(),
+            ErrCode::EAGAIN
+        );
+        fs.metadata_mutation_barrier
+            .state
+            .store(0, core::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[test]
+    fn metadata_mutation_barrier_allows_concurrent_direct_owners() {
+        let fs = make_test_fs(16);
+        let start = std::sync::Barrier::new(3);
+        let release = std::sync::Barrier::new(3);
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        std::thread::scope(|scope| {
+            for _ in 0..2 {
+                let sender = sender.clone();
+                let start = &start;
+                let release = &release;
+                let fs = &fs;
+                scope.spawn(move || {
+                    start.wait();
+                    let guard = fs.lock_direct_metadata_mutation();
+                    sender.send(guard.is_ok()).unwrap();
+                    release.wait();
+                    drop(guard);
+                });
+            }
+            start.wait();
+            assert!(receiver.recv().unwrap());
+            assert!(receiver.recv().unwrap());
+            assert_eq!(
+                fs.lock_transactional_metadata_mutation()
+                    .expect_err("both direct guards must remain live")
+                    .code(),
+                ErrCode::EAGAIN
+            );
+            release.wait();
+        });
+        drop(fs.lock_transactional_metadata_mutation().unwrap());
     }
 
     #[test]
@@ -1506,6 +1635,7 @@ mod tests {
             }
 
             let mut sb_block = blocks.remove(&0).unwrap();
+            Self::write_u32(&mut sb_block, BASE_OFFSET, 16);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 4, TEST_BLOCK_COUNT as u32);
             Self::write_u32(
                 &mut sb_block,
@@ -1516,6 +1646,7 @@ mod tests {
             Self::write_u32(&mut sb_block, BASE_OFFSET + 24, 2);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 28, 2);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 32, TEST_BLOCK_COUNT as u32);
+            Self::write_u32(&mut sb_block, BASE_OFFSET + 36, TEST_BLOCK_COUNT as u32);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 40, 16);
             Self::write_u16(&mut sb_block, BASE_OFFSET + 56, 0xef53);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 84, 1);
@@ -1603,6 +1734,25 @@ mod tests {
             let block = blocks.get(&TEST_INODE_TABLE).unwrap();
             let inode: Inode = block.read_offset_as(SB_GOOD_INODE_SIZE);
             inode.xattr_block()
+        }
+
+        fn fill_block(&self, block_id: PBlockId, byte: u8) {
+            self.blocks
+                .lock()
+                .get_mut(&block_id)
+                .unwrap()
+                .data
+                .fill(byte);
+        }
+
+        fn block_is_zero(&self, block_id: PBlockId) -> bool {
+            self.blocks
+                .lock()
+                .get(&block_id)
+                .unwrap()
+                .data
+                .iter()
+                .all(|byte| *byte == 0)
         }
     }
 
@@ -1768,6 +1918,33 @@ mod tests {
 
         assert_eq!(err.code(), ErrCode::EIO);
         assert_allocation_state(&fs, &block_device, false, TEST_INITIAL_FREE_BLOCKS);
+    }
+
+    #[test]
+    fn newly_reused_data_block_is_zeroed_before_mapping() {
+        let (block_device, fs) = load_failing_test_fs();
+        let mut inode = fs.read_inode(2).unwrap();
+        block_device.fill_block(TEST_XATTR_BLOCK, 0xa5);
+
+        let pblock = fs.alloc_zeroed_data_block(&mut inode).unwrap();
+
+        assert_eq!(pblock, TEST_XATTR_BLOCK);
+        assert!(block_device.block_is_zero(pblock));
+        assert_allocation_state(&fs, &block_device, true, TEST_INITIAL_FREE_BLOCKS - 1);
+    }
+
+    #[test]
+    fn data_block_zero_write_failure_rolls_back_allocation() {
+        let (block_device, fs) = load_failing_test_fs();
+        let mut inode = fs.read_inode(2).unwrap();
+        block_device.fill_block(TEST_XATTR_BLOCK, 0xa5);
+        block_device.fail_once_on_write(TEST_XATTR_BLOCK);
+
+        let err = fs.alloc_zeroed_data_block(&mut inode).unwrap_err();
+
+        assert_eq!(err.code(), ErrCode::EIO);
+        assert_allocation_state(&fs, &block_device, false, TEST_INITIAL_FREE_BLOCKS);
+        assert!(!block_device.block_is_zero(TEST_XATTR_BLOCK));
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -249,8 +249,14 @@ impl Ext4 {
 
     fn validate_super_block(sb: &SuperBlock) -> Result<()> {
         const SUPPORTED_INCOMPAT: u32 = 0x0002 | 0x0004 | 0x0040 | 0x0080 | 0x0200;
-        const SUPPORTED_RO_COMPAT: u32 =
-            0x0001 | 0x0002 | 0x0004 | 0x0008 | 0x0020 | 0x0040 | 0x0400;
+        const SUPPORTED_RO_COMPAT: u32 = 0x0001
+            | 0x0002
+            | 0x0004
+            | 0x0008
+            | 0x0020
+            | 0x0040
+            | 0x0400
+            | SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT;
 
         let metadata_csum =
             sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
@@ -562,6 +568,15 @@ mod validation_tests {
         assert!(Ext4::validate_super_block(&sb).is_ok());
         sb.set_free_inodes_count(1);
         assert!(Ext4::validate_super_block(&sb).is_err());
+    }
+
+    #[test]
+    fn orphan_present_is_recognized_for_read_only_loading() {
+        let mut sb = SuperBlock::validation_fixture();
+        sb.set_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT, true);
+        sb.set_checksum();
+
+        assert!(Ext4::validate_super_block(&sb).is_ok());
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -193,6 +193,31 @@ const INODE_CACHE_SIZE: usize = 512;
 pub(super) const INODE_MUTATION_LOCK_SHARDS: usize = 64;
 
 impl Ext4 {
+    fn is_power_of(mut value: u32, base: u32) -> bool {
+        while value > base && value.is_multiple_of(base) {
+            value /= base;
+        }
+        value == base
+    }
+
+    fn block_group_has_super(sb: &SuperBlock, group: BlockGroupId) -> bool {
+        if group == 0 {
+            return true;
+        }
+        if sb.has_compatible_feature(SuperBlock::FEATURE_COMPAT_SPARSE_SUPER2) {
+            return sb.backup_block_groups().contains(&group);
+        }
+        if group <= 1
+            || !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_SPARSE_SUPER)
+        {
+            return true;
+        }
+        group & 1 != 0
+            && (Self::is_power_of(group, 3)
+                || Self::is_power_of(group, 5)
+                || Self::is_power_of(group, 7))
+    }
+
     fn merge_metadata_ranges(mut ranges: Vec<(PBlockId, PBlockId)>) -> Vec<(PBlockId, PBlockId)> {
         ranges.sort_unstable();
         let mut merged: Vec<(PBlockId, PBlockId)> = Vec::new();
@@ -213,9 +238,7 @@ impl Ext4 {
         groups: &[spin::Mutex<BlockGroupDesc>],
     ) -> Result<Vec<(PBlockId, PBlockId)>> {
         let desc_per_block = BLOCK_SIZE as u64 / sb.desc_size() as u64;
-        let gdt_end = 1u64
-            .checked_add((sb.block_group_count() as u64).div_ceil(desc_per_block))
-            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let gdt_blocks = (sb.block_group_count() as u64).div_ceil(desc_per_block);
         let inode_table_blocks = (sb.inodes_per_group() as u64)
             .checked_mul(sb.inode_size() as u64)
             .and_then(|bytes| bytes.checked_add(BLOCK_SIZE as u64 - 1))
@@ -223,10 +246,27 @@ impl Ext4 {
             .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
         let mut ranges = Vec::new();
         ranges
-            .try_reserve_exact(2usize.saturating_add(groups.len().saturating_mul(3)))
+            .try_reserve_exact(groups.len().saturating_mul(4))
             .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
-        ranges.extend_from_slice(&[(0, 1), (1, gdt_end)]);
-        for group in groups {
+        for (bgid, group) in groups.iter().enumerate() {
+            let bgid = bgid as BlockGroupId;
+            if Self::block_group_has_super(sb, bgid) {
+                let start =
+                    sb.first_data_block() as u64 + bgid as u64 * sb.blocks_per_group() as u64;
+                let end = start
+                    .checked_add(1)
+                    .and_then(|value| value.checked_add(gdt_blocks))
+                    .and_then(|value| value.checked_add(sb.reserved_gdt_blocks() as u64))
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                let group_end = start
+                    .checked_add(sb.blocks_per_group() as u64)
+                    .map(|value| core::cmp::min(value, sb.block_count()))
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                if end > group_end {
+                    return Err(Ext4Error::new(ErrCode::EIO));
+                }
+                ranges.push((start, end));
+            }
             let desc = *group.lock();
             for start in [desc.block_bitmap_block(), desc.inode_bitmap_block()] {
                 ranges.push((
@@ -276,6 +316,7 @@ impl Ext4 {
             || sb.clusters_per_group() == 0
             || sb.clusters_per_group() as usize > BLOCK_SIZE * 8
             || sb.inodes_per_group() as usize > BLOCK_SIZE * 8
+            || sb.reserved_gdt_blocks() as usize > BLOCK_SIZE / 4
             || sb.clusters_per_group() != sb.blocks_per_group()
             || blocks <= sb.first_data_block() as u64
             || sb.inode_count() == 0
@@ -571,12 +612,44 @@ mod validation_tests {
     }
 
     #[test]
+    fn reserved_gdt_blocks_obey_linux_geometry_limit() {
+        let mut sb = SuperBlock::validation_fixture();
+        sb.set_reserved_gdt_blocks((BLOCK_SIZE / 4) as u16);
+        sb.set_checksum();
+        assert!(Ext4::validate_super_block(&sb).is_ok());
+
+        sb.set_reserved_gdt_blocks((BLOCK_SIZE / 4 + 1) as u16);
+        sb.set_checksum();
+        assert!(Ext4::validate_super_block(&sb).is_err());
+    }
+
+    #[test]
     fn orphan_present_is_recognized_for_read_only_loading() {
         let mut sb = SuperBlock::validation_fixture();
         sb.set_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT, true);
         sb.set_checksum();
 
         assert!(Ext4::validate_super_block(&sb).is_ok());
+    }
+
+    #[test]
+    fn backup_super_groups_follow_linux_sparse_rules() {
+        let mut sb = SuperBlock::validation_fixture();
+        sb.set_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_SPARSE_SUPER, true);
+        for group in [0, 1, 3, 5, 7, 9, 25, 49] {
+            assert!(Ext4::block_group_has_super(&sb, group));
+        }
+        for group in [2, 4, 11, 15, 21] {
+            assert!(!Ext4::block_group_has_super(&sb, group));
+        }
+
+        sb.set_compatible_feature(SuperBlock::FEATURE_COMPAT_SPARSE_SUPER2, true);
+        sb.set_backup_block_groups([4, 12]);
+        assert!(Ext4::block_group_has_super(&sb, 0));
+        assert!(Ext4::block_group_has_super(&sb, 4));
+        assert!(Ext4::block_group_has_super(&sb, 12));
+        assert!(!Ext4::block_group_has_super(&sb, 1));
+        assert!(!Ext4::block_group_has_super(&sb, 3));
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -2,6 +2,7 @@ use crate::constants::*;
 use crate::ext4_defs::*;
 use crate::prelude::*;
 use crate::return_error;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 mod alloc;
 mod dir;
@@ -12,7 +13,9 @@ mod journal_recovery;
 mod journal_transaction;
 mod link;
 mod low_level;
+mod orphan;
 mod rw;
+mod xattr_reclaim;
 
 pub use low_level::SetAttr;
 
@@ -65,6 +68,8 @@ pub struct Ext4 {
     /// Cached block group descriptors. Loaded at mount time.
     /// Index is block group id.
     cached_block_groups: Vec<spin::Mutex<BlockGroupDesc>>,
+    /// Sorted, merged half-open ranges occupied by primary ext4 metadata.
+    system_metadata_ranges: Vec<(PBlockId, PBlockId)>,
     /// LRU-ish inode cache. Avoids repeated disk reads for frequently accessed inodes.
     inode_cache: spin::Mutex<InodeCache>,
     /// Global allocation lock. Protects block/inode bitmap operations from
@@ -75,6 +80,14 @@ pub struct Ext4 {
     /// writeback remain sharded; namespace operations are comparatively cold
     /// and need a single ordering domain until journal transactions exist.
     namespace_lock: spin::Mutex<()>,
+    /// Separates legacy direct metadata writers from journal transactions.
+    ///
+    /// Direct writers hold a shared guard for their complete top-level
+    /// operation. A journal transaction holds the exclusive guard from its
+    /// first home-block snapshot until commit/cache publication. Taking this
+    /// lock only at `write_block` would be too late: a transaction could have
+    /// already captured an image which a direct writer subsequently changes.
+    metadata_mutation_barrier: MetadataMutationGate,
     /// First unrecoverable metadata error.  Once set, mutation must fail-stop.
     poisoned: spin::Mutex<Option<ErrCode>>,
     /// Validated synchronous JBD2 engine. It is initialized only by
@@ -90,11 +103,268 @@ pub struct Ext4 {
     inode_mutation_locks: Vec<spin::Mutex<()>>,
 }
 
+/// Non-blocking gate separating legacy direct writers from journal snapshots.
+///
+/// The top bit denotes an exclusive transactional owner; the remaining bits
+/// count direct writers.  Acquisition never waits for an existing owner, which
+/// is essential because guards intentionally span block-device I/O.
+#[derive(Debug)]
+struct MetadataMutationGate {
+    state: AtomicUsize,
+}
+
+const METADATA_GATE_EXCLUSIVE: usize = 1usize << (usize::BITS - 1);
+const METADATA_GATE_DIRECT_MAX: usize = METADATA_GATE_EXCLUSIVE - 1;
+
+impl MetadataMutationGate {
+    const fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+        }
+    }
+
+    fn try_direct(&self) -> Result<MetadataMutationGuard<'_>> {
+        const COMPATIBLE_CAS_RETRIES: usize = 64;
+        let mut state = self.state.load(Ordering::Relaxed);
+        for _ in 0..COMPATIBLE_CAS_RETRIES {
+            if state & METADATA_GATE_EXCLUSIVE != 0 || state == METADATA_GATE_DIRECT_MAX {
+                return Err(Ext4Error::new(ErrCode::EAGAIN));
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Ok(MetadataMutationGuard {
+                        gate: self,
+                        exclusive: false,
+                    });
+                }
+                // Retry only a compatible direct-count collision. Observing an
+                // exclusive owner is rejected at the top of the next iteration;
+                // no acquisition waits for an I/O-spanning owner to depart.
+                Err(observed) => state = observed,
+            }
+        }
+        Err(Ext4Error::new(ErrCode::EAGAIN))
+    }
+
+    fn try_transactional(&self) -> Result<MetadataMutationGuard<'_>> {
+        self.state
+            .compare_exchange(
+                0,
+                METADATA_GATE_EXCLUSIVE,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            )
+            .map_err(|_| Ext4Error::new(ErrCode::EAGAIN))?;
+        Ok(MetadataMutationGuard {
+            gate: self,
+            exclusive: true,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct MetadataMutationGuard<'a> {
+    gate: &'a MetadataMutationGate,
+    exclusive: bool,
+}
+
+impl Drop for MetadataMutationGuard<'_> {
+    fn drop(&mut self) {
+        if self.exclusive {
+            debug_assert_eq!(
+                self.gate.state.load(Ordering::Relaxed),
+                METADATA_GATE_EXCLUSIVE
+            );
+            self.gate.state.store(0, Ordering::Release);
+        } else {
+            let previous = self.gate.state.fetch_sub(1, Ordering::Release);
+            debug_assert!(previous > 0 && previous < METADATA_GATE_EXCLUSIVE);
+        }
+    }
+}
+
 /// Maximum number of inodes to cache in memory.
 const INODE_CACHE_SIZE: usize = 512;
 pub(super) const INODE_MUTATION_LOCK_SHARDS: usize = 64;
 
 impl Ext4 {
+    fn merge_metadata_ranges(mut ranges: Vec<(PBlockId, PBlockId)>) -> Vec<(PBlockId, PBlockId)> {
+        ranges.sort_unstable();
+        let mut merged: Vec<(PBlockId, PBlockId)> = Vec::new();
+        for (start, end) in ranges {
+            if let Some(last) = merged.last_mut() {
+                if start <= last.1 {
+                    last.1 = core::cmp::max(last.1, end);
+                    continue;
+                }
+            }
+            merged.push((start, end));
+        }
+        merged
+    }
+
+    fn build_system_metadata_ranges(
+        sb: &SuperBlock,
+        groups: &[spin::Mutex<BlockGroupDesc>],
+    ) -> Result<Vec<(PBlockId, PBlockId)>> {
+        let desc_per_block = BLOCK_SIZE as u64 / sb.desc_size() as u64;
+        let gdt_end = 1u64
+            .checked_add((sb.block_group_count() as u64).div_ceil(desc_per_block))
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let inode_table_blocks = (sb.inodes_per_group() as u64)
+            .checked_mul(sb.inode_size() as u64)
+            .and_then(|bytes| bytes.checked_add(BLOCK_SIZE as u64 - 1))
+            .map(|bytes| bytes / BLOCK_SIZE as u64)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(2usize.saturating_add(groups.len().saturating_mul(3)))
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        ranges.extend_from_slice(&[(0, 1), (1, gdt_end)]);
+        for group in groups {
+            let desc = *group.lock();
+            for start in [desc.block_bitmap_block(), desc.inode_bitmap_block()] {
+                ranges.push((
+                    start,
+                    start
+                        .checked_add(1)
+                        .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+                ));
+            }
+            let table = desc.inode_table_first_block();
+            ranges.push((
+                table,
+                table
+                    .checked_add(inode_table_blocks)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+            ));
+        }
+        Ok(Self::merge_metadata_ranges(ranges))
+    }
+
+    fn validate_super_block(sb: &SuperBlock) -> Result<()> {
+        const SUPPORTED_INCOMPAT: u32 = 0x0002 | 0x0004 | 0x0040 | 0x0080 | 0x0200;
+        const SUPPORTED_RO_COMPAT: u32 =
+            0x0001 | 0x0002 | 0x0004 | 0x0008 | 0x0020 | 0x0040 | 0x0400;
+
+        let metadata_csum =
+            sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
+        let blocks = sb.block_count();
+        let blocks_per_group = sb.blocks_per_group() as u64;
+        let inodes_per_group = sb.inodes_per_group() as u64;
+        if !sb.check_magic()
+            || (metadata_csum && (!sb.has_supported_checksum_type() || !sb.verify_checksum()))
+            || sb.block_size() != BLOCK_SIZE as u64
+            || sb.first_data_block() != 0
+            || sb.inode_size() != SB_GOOD_INODE_SIZE
+            || sb.desc_size() != SB_GOOD_DESC_SIZE
+            || sb.incompatible_features() & !SUPPORTED_INCOMPAT != 0
+            || sb.read_only_compatible_features() & !SUPPORTED_RO_COMPAT != 0
+            || blocks_per_group == 0
+            || inodes_per_group == 0
+            || sb.clusters_per_group() == 0
+            || sb.clusters_per_group() as usize > BLOCK_SIZE * 8
+            || sb.inodes_per_group() as usize > BLOCK_SIZE * 8
+            || sb.clusters_per_group() != sb.blocks_per_group()
+            || blocks <= sb.first_data_block() as u64
+            || sb.inode_count() == 0
+            || sb.first_inode() > sb.inode_count()
+            || sb.free_blocks_count() > blocks
+            || sb.free_inodes_count() > sb.inode_count()
+            || sb.reserved_blocks_count() > blocks
+        {
+            return_error!(
+                ErrCode::EIO,
+                "Invalid ext4 superblock geometry, feature set, or checksum"
+            );
+        }
+
+        let groups = (blocks - sb.first_data_block() as u64).div_ceil(blocks_per_group);
+        let inode_capacity = groups
+            .checked_mul(inodes_per_group)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let prior_capacity = groups
+            .saturating_sub(1)
+            .checked_mul(inodes_per_group)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        if groups == 0
+            || groups > u32::MAX as u64
+            || sb.inode_count() as u64 > inode_capacity
+            || sb.inode_count() as u64 <= prior_capacity
+        {
+            return_error!(ErrCode::EIO, "Invalid ext4 group-count or inode geometry");
+        }
+        Ok(())
+    }
+
+    fn read_validated_block_groups(
+        device: &dyn BlockDevice,
+        sb: &SuperBlock,
+    ) -> Result<Vec<spin::Mutex<BlockGroupDesc>>> {
+        Self::validate_super_block(sb)?;
+        let bg_count = sb.block_group_count();
+        let desc_per_block = BLOCK_SIZE as u32 / sb.desc_size() as u32;
+        let metadata_csum =
+            sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
+        let inode_table_blocks = (sb.inodes_per_group() as u64)
+            .checked_mul(sb.inode_size() as u64)
+            .and_then(|bytes| bytes.checked_add(BLOCK_SIZE as u64 - 1))
+            .map(|bytes| bytes / BLOCK_SIZE as u64)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let mut groups = Vec::new();
+        groups
+            .try_reserve_exact(bg_count as usize)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        for bgid in 0..bg_count {
+            let block_id = sb
+                .first_data_block()
+                .checked_add(bgid / desc_per_block)
+                .and_then(|id| id.checked_add(1))
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            if block_id as u64 >= sb.block_count() {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            let offset = (bgid % desc_per_block) * sb.desc_size() as u32;
+            let block = device.read_block(block_id as PBlockId)?;
+            let desc = block.read_offset_as::<BlockGroupDesc>(offset as usize);
+            Self::validate_block_group(sb, bgid, &desc, metadata_csum, inode_table_blocks)?;
+            groups.push(spin::Mutex::new(desc));
+        }
+        Ok(groups)
+    }
+
+    fn validate_block_group(
+        sb: &SuperBlock,
+        bgid: BlockGroupId,
+        desc: &BlockGroupDesc,
+        metadata_csum: bool,
+        inode_table_blocks: u64,
+    ) -> Result<()> {
+        let group = BlockGroupRef::new(bgid, *desc);
+        let block_bitmap = desc.block_bitmap_block();
+        let inode_bitmap = desc.inode_bitmap_block();
+        let inode_table = desc.inode_table_first_block();
+        if (metadata_csum && !group.verify_checksum(&sb.uuid()))
+            || block_bitmap == 0
+            || block_bitmap >= sb.block_count()
+            || inode_bitmap == 0
+            || inode_bitmap >= sb.block_count()
+            || inode_table == 0
+            || inode_table >= sb.block_count()
+            || inode_table
+                .checked_add(inode_table_blocks)
+                .is_none_or(|end| end > sb.block_count())
+        {
+            return_error!(ErrCode::EIO, "Invalid ext4 block-group descriptor");
+        }
+        Ok(())
+    }
+
     /// Opens and loads an Ext4 from the `block_device`.
     pub fn load(block_device: Arc<dyn BlockDevice>) -> Result<Self> {
         // Load the superblock
@@ -102,34 +372,8 @@ impl Ext4 {
         let block = block_device.read_block(0)?;
         let sb = block.read_offset_as::<SuperBlock>(BASE_OFFSET);
         log::debug!("Load Ext4 Superblock: {:?}", sb);
-        // Check magic number
-        if !sb.check_magic() {
-            return_error!(ErrCode::EINVAL, "Invalid magic number");
-        }
-        // Check inode size
-        if sb.inode_size() != SB_GOOD_INODE_SIZE {
-            return_error!(ErrCode::EINVAL, "Invalid inode size {}", sb.inode_size());
-        }
-        // Check block group desc size
-        if sb.desc_size() != SB_GOOD_DESC_SIZE {
-            return_error!(
-                ErrCode::EINVAL,
-                "Invalid block group desc size {}",
-                sb.desc_size()
-            );
-        }
-
-        // Load all block group descriptors into cache
-        let bg_count = sb.block_group_count();
-        let desc_per_block = BLOCK_SIZE as u32 / sb.desc_size() as u32;
-        let mut cached_block_groups = Vec::with_capacity(bg_count as usize);
-        for bgid in 0..bg_count {
-            let block_id = sb.first_data_block() + bgid / desc_per_block + 1;
-            let offset = (bgid % desc_per_block) * sb.desc_size() as u32;
-            let bg_block = block_device.read_block(block_id as PBlockId)?;
-            let desc = bg_block.read_offset_as::<BlockGroupDesc>(offset as usize);
-            cached_block_groups.push(spin::Mutex::new(desc));
-        }
+        let cached_block_groups = Self::read_validated_block_groups(block_device.as_ref(), &sb)?;
+        let system_metadata_ranges = Self::build_system_metadata_ranges(&sb, &cached_block_groups)?;
 
         // Create Ext4 instance
         let mut inode_mutation_locks = Vec::with_capacity(INODE_MUTATION_LOCK_SHARDS);
@@ -140,9 +384,11 @@ impl Ext4 {
             block_device,
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups,
+            system_metadata_ranges,
             inode_cache: spin::Mutex::new(InodeCache::new(INODE_CACHE_SIZE)),
             alloc_lock: spin::Mutex::new(()),
             namespace_lock: spin::Mutex::new(()),
+            metadata_mutation_barrier: MetadataMutationGate::new(),
             poisoned: spin::Mutex::new(None),
             journal: None,
             inode_mutation_locks,
@@ -179,6 +425,43 @@ impl Ext4 {
         Ok(())
     }
 
+    fn ranges_overlap(
+        start: PBlockId,
+        end: PBlockId,
+        reserved_start: PBlockId,
+        reserved_end: PBlockId,
+    ) -> bool {
+        start < reserved_end && reserved_start < end
+    }
+
+    /// Validate that a physical range is ordinary file-owned storage rather
+    /// than ext4 system metadata or the internal journal. All ranges are
+    /// half-open and every end is checked before comparison.
+    pub(super) fn validate_data_blocks(&self, start: PBlockId, count: u64) -> Result<()> {
+        let sb = self.read_super_block_cached();
+        let end = start
+            .checked_add(count)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        if count == 0 || start < sb.first_data_block() as u64 || end > sb.block_count() {
+            return_error!(ErrCode::EIO, "Invalid data block range {}..{}", start, end);
+        }
+
+        let candidate = self
+            .system_metadata_ranges
+            .partition_point(|(_, reserved_end)| *reserved_end <= start);
+        if self.system_metadata_ranges.get(candidate).is_some_and(
+            |(reserved_start, reserved_end)| {
+                Self::ranges_overlap(start, end, *reserved_start, *reserved_end)
+            },
+        ) {
+            return_error!(ErrCode::EIO, "Data range overlaps ext4 system metadata");
+        }
+        if self.journal_owns_block_range(start, end) {
+            return_error!(ErrCode::EIO, "Data range overlaps the internal journal");
+        }
+        Ok(())
+    }
+
     pub(super) fn poison(&self, code: ErrCode) {
         let mut poisoned = self.poisoned.lock();
         if poisoned.is_none() {
@@ -207,5 +490,118 @@ impl Ext4 {
             .into_iter()
             .map(|index| self.inode_mutation_locks[index].lock())
             .collect()
+    }
+
+    /// Enter a complete legacy/direct metadata mutation operation.
+    #[inline]
+    pub(super) fn lock_direct_metadata_mutation(&self) -> Result<MetadataMutationGuard<'_>> {
+        self.metadata_mutation_barrier.try_direct()
+    }
+
+    /// Enter a complete transaction-private snapshot/commit operation.
+    ///
+    /// Callers must not already hold a direct-mutation guard. Top-level
+    /// operations which can choose a transactional path acquire this guard
+    /// directly; contention is reported as `EAGAIN` rather than waited on.
+    #[inline]
+    pub(super) fn lock_transactional_metadata_mutation(&self) -> Result<MetadataMutationGuard<'_>> {
+        self.metadata_mutation_barrier.try_transactional()
+    }
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::*;
+
+    struct ValidationDevice {
+        blocks: BTreeMap<PBlockId, Block>,
+    }
+
+    impl BlockDevice for ValidationDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            self.blocks
+                .get(&block_id)
+                .cloned()
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))
+        }
+
+        fn write_block(&self, _block: &Block) -> Result<()> {
+            Err(Ext4Error::new(ErrCode::EIO))
+        }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
+    }
+
+    fn system_zone_test_fs() -> Ext4 {
+        let mut sb = SuperBlock::validation_fixture();
+        sb.set_checksum();
+        let mut desc = BlockGroupDesc::validation_fixture();
+        let mut group = BlockGroupRef::new(0, desc);
+        group.set_checksum(&sb.uuid());
+        desc = group.desc;
+
+        let mut block0 = Block::new(0, Box::new([0; BLOCK_SIZE]));
+        block0.write_offset_as(BASE_OFFSET, &sb);
+        let mut block1 = Block::new(1, Box::new([0; BLOCK_SIZE]));
+        block1.write_offset_as(0, &desc);
+        let device = ValidationDevice {
+            blocks: BTreeMap::from([(0, block0), (1, block1)]),
+        };
+        Ext4::load(Arc::new(device)).unwrap()
+    }
+
+    #[test]
+    fn replayed_superblock_checksum_damage_is_rejected() {
+        let mut sb = SuperBlock::validation_fixture();
+        assert!(Ext4::validate_super_block(&sb).is_ok());
+        sb.set_free_inodes_count(1);
+        assert!(Ext4::validate_super_block(&sb).is_err());
+    }
+
+    #[test]
+    fn replayed_group_descriptor_damage_and_bad_addresses_are_rejected() {
+        let sb = SuperBlock::validation_fixture();
+        let mut desc = BlockGroupDesc::validation_fixture();
+        let mut group = BlockGroupRef::new(0, desc);
+        group.set_checksum(&sb.uuid());
+        desc = group.desc;
+        assert!(Ext4::validate_block_group(&sb, 0, &desc, true, 16).is_ok());
+
+        desc.set_free_inodes_count(1);
+        assert!(Ext4::validate_block_group(&sb, 0, &desc, true, 16).is_err());
+
+        let mut bad_address = BlockGroupDesc::validation_fixture();
+        let mut bytes = bad_address.to_bytes().to_vec();
+        bytes[0..4].copy_from_slice(&(sb.block_count() as u32).to_le_bytes());
+        bad_address = BlockGroupDesc::from_bytes(&bytes);
+        let mut group = BlockGroupRef::new(0, bad_address);
+        group.set_checksum(&sb.uuid());
+        assert!(Ext4::validate_block_group(&sb, 0, &group.desc, true, 16).is_err());
+    }
+
+    #[test]
+    fn malicious_extent_or_xattr_cannot_claim_system_metadata() {
+        let fs = system_zone_test_fs();
+        assert!(fs.validate_data_blocks(0, 1).is_err());
+        assert!(fs.validate_data_blocks(1, 1).is_err());
+        assert!(fs.validate_data_blocks(2, 1).is_err());
+        assert!(fs.validate_data_blocks(3, 1).is_err());
+        assert!(fs.validate_data_blocks(4, 16).is_err());
+        assert!(fs.validate_data_blocks(20, 1).is_ok());
+    }
+
+    #[test]
+    fn system_metadata_ranges_merge_adjacency_and_preserve_boundaries() {
+        let merged = Ext4::merge_metadata_ranges(vec![(8, 10), (1, 3), (3, 5), (9, 12)]);
+        assert_eq!(merged, vec![(1, 5), (8, 12)]);
+        assert!(!Ext4::ranges_overlap(5, 8, 1, 5));
+        assert!(!Ext4::ranges_overlap(5, 8, 8, 12));
+        assert!(Ext4::ranges_overlap(4, 9, 1, 5));
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/orphan.rs
+++ b/kernel/crates/another_ext4/src/ext4/orphan.rs
@@ -75,7 +75,7 @@ fn validate_chain<R: LegacyOrphanReader>(reader: &R, head: InodeId) -> Result<Le
         }
 
         let node = reader.read_orphan_inode(current)?;
-        if !node.valid_checksum || !node.valid_mode || node.links != 0 {
+        if !node.valid_checksum || !node.valid_mode {
             return Err(corruption());
         }
         if node.next != 0 && !valid_orphan_number(reader, node.next) {
@@ -158,7 +158,6 @@ impl Ext4 {
             let current_inode = self.read_inode_uncached(current)?;
             if !inode_checksum_valid(sb, &current_inode)
                 || current_inode.inode.file_type() == FileType::Unknown
-                || current_inode.inode.link_count() != 0
             {
                 return Err(corruption());
             }
@@ -226,7 +225,6 @@ impl Ext4 {
 
             let node = self.read_orphan_inode(inode_id)?;
             if node.next != expected_next
-                || node.links != 0
                 || !node.valid_mode
                 || !node.valid_checksum
                 || !self.inode_allocated(inode_id)?
@@ -234,7 +232,11 @@ impl Ext4 {
                 return Err(corruption());
             }
 
-            self.reclaim_orphan_inode_by_id(inode_id)?;
+            if node.links == 0 {
+                self.reclaim_orphan_inode_by_id(inode_id)?;
+            } else {
+                self.recover_linked_orphan_inode_by_id(inode_id)?;
+            }
 
             if self.read_super_block_cached().last_orphan() != expected_next {
                 return Err(corruption());
@@ -355,12 +357,29 @@ mod tests {
     }
 
     #[test]
-    fn rejects_free_and_linked_inode() {
+    fn rejects_free_inode_and_accepts_linked_truncate_orphan() {
         let free = reader(&[(11, (false, MockReader::valid(0).1))]);
         assert!(validate_chain(&free, 11).is_err());
         let mut linked = MockReader::valid(0).1;
         linked.links = 1;
-        assert!(validate_chain(&reader(&[(11, (true, linked))]), 11).is_err());
+        assert_eq!(
+            validate_chain(&reader(&[(11, (true, linked))]), 11)
+                .unwrap()
+                .inodes,
+            vec![11]
+        );
+    }
+
+    #[test]
+    fn accepts_mixed_link_counts_in_complete_chain() {
+        let mut linked = MockReader::valid(12).1;
+        linked.links = 2;
+        let r = reader(&[
+            (11, MockReader::valid(13)),
+            (13, (true, linked)),
+            (12, MockReader::valid(0)),
+        ]);
+        assert_eq!(validate_chain(&r, 11).unwrap().inodes, vec![11, 13, 12]);
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/orphan.rs
+++ b/kernel/crates/another_ext4/src/ext4/orphan.rs
@@ -1,0 +1,383 @@
+//! Legacy ext4 orphan-list validation and mount-time cleanup.
+//!
+//! Validation of the complete list precedes the first cleanup transaction so
+//! a corrupt tail cannot turn a partially-cleaned list into an unrecoverable
+//! leak.  Cleanup then advances only from the current durable head and checks
+//! every link against that immutable snapshot.
+
+use super::Ext4;
+use crate::constants::EXT4_ROOT_INO;
+use crate::ext4_defs::{Bitmap, FileType, InodeRef, SuperBlock};
+use crate::prelude::*;
+
+#[derive(Debug)]
+pub(super) struct LegacyOrphanChain {
+    pub(super) inodes: Vec<InodeId>,
+}
+
+trait LegacyOrphanReader {
+    fn inode_count(&self) -> u32;
+    fn first_inode(&self) -> u32;
+    fn journal_inode(&self) -> u32;
+    fn inode_allocated(&self, inode: InodeId) -> Result<bool>;
+    fn read_orphan_inode(&self, inode: InodeId) -> Result<OrphanNode>;
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OrphanNode {
+    next: InodeId,
+    links: u16,
+    valid_mode: bool,
+    valid_checksum: bool,
+}
+
+fn corruption() -> Ext4Error {
+    Ext4Error::new(ErrCode::EIO)
+}
+
+fn unsupported_orphan_format(sb: &SuperBlock) -> bool {
+    unsupported_orphan_features(sb.compatible_features(), sb.read_only_compatible_features())
+}
+
+fn unsupported_orphan_features(compatible: u32, read_only_compatible: u32) -> bool {
+    compatible & SuperBlock::FEATURE_COMPAT_ORPHAN_FILE != 0
+        || read_only_compatible & SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT != 0
+}
+
+fn valid_orphan_number<R: LegacyOrphanReader>(reader: &R, inode: InodeId) -> bool {
+    inode >= reader.first_inode()
+        && inode <= reader.inode_count()
+        && inode != EXT4_ROOT_INO
+        && inode != reader.journal_inode()
+}
+
+fn validate_chain<R: LegacyOrphanReader>(reader: &R, head: InodeId) -> Result<LegacyOrphanChain> {
+    let mut current = head;
+    let mut visited = BTreeSet::new();
+    let mut inodes = Vec::new();
+
+    while current != 0 {
+        // Validate the inode number before calculating a block group or doing
+        // any inode-table / bitmap I/O.
+        if !valid_orphan_number(reader, current)
+            || inodes.len() >= reader.inode_count() as usize
+            || !visited.insert(current)
+        {
+            return Err(corruption());
+        }
+        if !reader.inode_allocated(current)? {
+            return Err(corruption());
+        }
+
+        let node = reader.read_orphan_inode(current)?;
+        if !node.valid_checksum || !node.valid_mode || node.links != 0 {
+            return Err(corruption());
+        }
+        if node.next != 0 && !valid_orphan_number(reader, node.next) {
+            return Err(corruption());
+        }
+
+        inodes.push(current);
+        current = node.next;
+    }
+
+    Ok(LegacyOrphanChain { inodes })
+}
+
+impl Ext4 {
+    /// Verify that `inode_id` is a member of the complete, valid legacy list.
+    ///
+    /// Reclaim calls this while holding the target inode's mutation shard.  A
+    /// complete bounded walk is intentional: accepting a locally plausible
+    /// node from a corrupt list could permanently lose the remainder at final
+    /// deletion.
+    pub(super) fn legacy_orphan_contains(&self, inode_id: InodeId) -> Result<bool> {
+        Ok(self
+            .validate_legacy_orphan_chain()?
+            .inodes
+            .contains(&inode_id))
+    }
+
+    /// Insert a zero-link inode at the head of the legacy orphan list in the
+    /// caller's transaction.  This helper only stages images; atomicity and
+    /// commit error handling remain the namespace operation's responsibility.
+    pub(super) fn transaction_orphan_add(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode: &mut InodeRef,
+        sb: &mut SuperBlock,
+    ) -> Result<()> {
+        if inode.inode.link_count() != 0
+            || inode.inode.file_type() == FileType::Unknown
+            || !valid_orphan_number(self, inode.id)
+        {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        let old_head = sb.last_orphan();
+        if old_head == inode.id || (old_head != 0 && !valid_orphan_number(self, old_head)) {
+            return Err(corruption());
+        }
+        inode.inode.set_next_orphan(old_head);
+        self.transaction_stage_inode_with_csum(transaction, inode)?;
+        sb.set_last_orphan(inode.id);
+        self.transaction_stage_super_block(transaction, sb)
+    }
+
+    /// Remove an inode from the legacy orphan chain in the caller's final
+    /// reclaim transaction. Both head and non-head deletion are supported.
+    /// The walk is bounded by `s_inodes_count` and validates every visited
+    /// inode before changing either the predecessor or superblock image.
+    pub(super) fn transaction_orphan_del(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode: &InodeRef,
+        sb: &mut SuperBlock,
+    ) -> Result<()> {
+        let target = inode.id;
+        let target_next = inode.inode.next_orphan();
+        if !valid_orphan_number(self, target) {
+            return Err(corruption());
+        }
+
+        let mut current = sb.last_orphan();
+        let mut predecessor: Option<InodeRef> = None;
+        let mut visited = BTreeSet::new();
+        while current != 0 {
+            if !valid_orphan_number(self, current)
+                || visited.len() >= sb.inode_count() as usize
+                || !visited.insert(current)
+                || !self.inode_is_allocated(current)?
+            {
+                return Err(corruption());
+            }
+            let current_inode = self.read_inode_uncached(current)?;
+            if !current_inode.verify_checksum(&sb.uuid())
+                || current_inode.inode.file_type() == FileType::Unknown
+                || current_inode.inode.link_count() != 0
+            {
+                return Err(corruption());
+            }
+            let next = current_inode.inode.next_orphan();
+            if next != 0 && !valid_orphan_number(self, next) {
+                return Err(corruption());
+            }
+            if current == target {
+                if current_inode.inode.generation() != inode.inode.generation()
+                    || next != target_next
+                {
+                    return Err(corruption());
+                }
+                if let Some(mut pred) = predecessor {
+                    pred.inode.set_next_orphan(target_next);
+                    self.transaction_stage_inode_with_csum(transaction, &mut pred)?;
+                } else {
+                    sb.set_last_orphan(target_next);
+                    self.transaction_stage_super_block(transaction, sb)?;
+                }
+                return Ok(());
+            }
+            predecessor = Some(current_inode);
+            current = next;
+        }
+        Err(corruption())
+    }
+
+    /// Reject formats whose orphan state this implementation cannot update.
+    /// This is called before journal replay or setting `RECOVER`.
+    pub(super) fn writable_orphan_preflight(&self) -> Result<()> {
+        let sb = self.read_super_block_cached();
+        if unsupported_orphan_format(&sb) {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+        Ok(())
+    }
+
+    /// First (read-only) phase of legacy orphan recovery.
+    pub(super) fn validate_legacy_orphan_chain(&self) -> Result<LegacyOrphanChain> {
+        let sb = self.read_super_block_cached();
+        validate_chain(self, sb.last_orphan())
+    }
+
+    /// Reclaim a previously validated legacy orphan chain, one durable
+    /// transaction at a time.
+    ///
+    /// The complete chain is validated under the metadata barrier before the
+    /// first transaction.  Before each transaction we re-read both links and
+    /// require them to still match that snapshot.  Thus a stale snapshot can
+    /// never detach or reclaim a different inode, and any error stops recovery
+    /// at the current durable head for the next mount to retry.
+    pub(super) fn cleanup_legacy_orphan_chain(&self) -> Result<()> {
+        // Keep every legacy direct metadata writer outside the complete
+        // validated-snapshot -> per-inode-commit recovery window.  The mount
+        // path is normally unpublished here, but the invariant belongs to
+        // this operation rather than to that calling convention.
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
+        let snapshot = self.validate_legacy_orphan_chain()?;
+        for (index, inode_id) in snapshot.inodes.iter().copied().enumerate() {
+            let expected_next = snapshot.inodes.get(index + 1).copied().unwrap_or(0);
+            if self.read_super_block_cached().last_orphan() != inode_id {
+                return Err(corruption());
+            }
+
+            let node = self.read_orphan_inode(inode_id)?;
+            if node.next != expected_next
+                || node.links != 0
+                || !node.valid_mode
+                || !node.valid_checksum
+                || !self.inode_allocated(inode_id)?
+            {
+                return Err(corruption());
+            }
+
+            self.reclaim_orphan_inode_by_id(inode_id)?;
+
+            if self.read_super_block_cached().last_orphan() != expected_next {
+                return Err(corruption());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl LegacyOrphanReader for Ext4 {
+    fn inode_count(&self) -> u32 {
+        self.read_super_block_cached().inode_count()
+    }
+
+    fn first_inode(&self) -> u32 {
+        self.read_super_block_cached().first_inode()
+    }
+
+    fn journal_inode(&self) -> u32 {
+        self.read_super_block_cached().journal_inode_number()
+    }
+
+    fn inode_allocated(&self, inode: InodeId) -> Result<bool> {
+        let sb = self.read_super_block_cached();
+        let group = (inode - 1) / sb.inodes_per_group();
+        let index = (inode - 1) % sb.inodes_per_group();
+        let bg = self.read_block_group(group)?;
+        let bitmap_block = self.read_block(bg.desc.inode_bitmap_block())?;
+        let count = sb.inode_count_in_group(group) as usize;
+        if index as usize >= count {
+            return Err(corruption());
+        }
+        let mut bytes = bitmap_block.data.clone();
+        let bitmap = Bitmap::new(&mut *bytes, count);
+        Ok(!bitmap.is_bit_clear(index as usize))
+    }
+
+    fn read_orphan_inode(&self, inode: InodeId) -> Result<OrphanNode> {
+        let inode_ref: InodeRef = self.read_inode_uncached(inode)?;
+        let sb = self.read_super_block_cached();
+        Ok(OrphanNode {
+            next: inode_ref.inode.next_orphan(),
+            links: inode_ref.inode.link_count(),
+            valid_mode: inode_ref.inode.file_type() != FileType::Unknown,
+            valid_checksum: inode_ref.verify_checksum(&sb.uuid()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockReader {
+        nodes: BTreeMap<InodeId, (bool, OrphanNode)>,
+    }
+
+    impl MockReader {
+        fn valid(next: InodeId) -> (bool, OrphanNode) {
+            (
+                true,
+                OrphanNode {
+                    next,
+                    links: 0,
+                    valid_mode: true,
+                    valid_checksum: true,
+                },
+            )
+        }
+    }
+
+    impl LegacyOrphanReader for MockReader {
+        fn inode_count(&self) -> u32 {
+            64
+        }
+        fn first_inode(&self) -> u32 {
+            11
+        }
+        fn journal_inode(&self) -> u32 {
+            8
+        }
+        fn inode_allocated(&self, inode: InodeId) -> Result<bool> {
+            Ok(self.nodes.get(&inode).map(|entry| entry.0).unwrap_or(false))
+        }
+        fn read_orphan_inode(&self, inode: InodeId) -> Result<OrphanNode> {
+            self.nodes
+                .get(&inode)
+                .map(|entry| entry.1)
+                .ok_or_else(corruption)
+        }
+    }
+
+    fn reader(entries: &[(InodeId, (bool, OrphanNode))]) -> MockReader {
+        MockReader {
+            nodes: entries.iter().copied().collect(),
+        }
+    }
+
+    #[test]
+    fn validates_complete_zero_link_chain() {
+        let r = reader(&[(11, MockReader::valid(12)), (12, MockReader::valid(0))]);
+        assert_eq!(validate_chain(&r, 11).unwrap().inodes, vec![11, 12]);
+    }
+
+    #[test]
+    fn rejects_self_and_two_node_cycles() {
+        let self_loop = reader(&[(11, MockReader::valid(11))]);
+        assert!(validate_chain(&self_loop, 11).is_err());
+        let two = reader(&[(11, MockReader::valid(12)), (12, MockReader::valid(11))]);
+        assert!(validate_chain(&two, 11).is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_head_and_next() {
+        assert!(validate_chain(&reader(&[]), 65).is_err());
+        let r = reader(&[(11, MockReader::valid(65))]);
+        assert!(validate_chain(&r, 11).is_err());
+    }
+
+    #[test]
+    fn rejects_free_and_linked_inode() {
+        let free = reader(&[(11, (false, MockReader::valid(0).1))]);
+        assert!(validate_chain(&free, 11).is_err());
+        let mut linked = MockReader::valid(0).1;
+        linked.links = 1;
+        assert!(validate_chain(&reader(&[(11, (true, linked))]), 11).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_checksum_and_mode() {
+        let mut checksum = MockReader::valid(0).1;
+        checksum.valid_checksum = false;
+        assert!(validate_chain(&reader(&[(11, (true, checksum))]), 11).is_err());
+        let mut mode = MockReader::valid(0).1;
+        mode.valid_mode = false;
+        assert!(validate_chain(&reader(&[(11, (true, mode))]), 11).is_err());
+    }
+
+    #[test]
+    fn preflight_rejects_each_orphan_file_feature() {
+        assert!(!unsupported_orphan_features(0, 0));
+        assert!(unsupported_orphan_features(
+            SuperBlock::FEATURE_COMPAT_ORPHAN_FILE,
+            0
+        ));
+        assert!(unsupported_orphan_features(
+            0,
+            SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT
+        ));
+    }
+}

--- a/kernel/crates/another_ext4/src/ext4/orphan.rs
+++ b/kernel/crates/another_ext4/src/ext4/orphan.rs
@@ -35,6 +35,11 @@ fn corruption() -> Ext4Error {
     Ext4Error::new(ErrCode::EIO)
 }
 
+pub(super) fn inode_checksum_valid(sb: &SuperBlock, inode: &InodeRef) -> bool {
+    !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM)
+        || inode.verify_checksum(&sb.uuid())
+}
+
 fn unsupported_orphan_format(sb: &SuperBlock) -> bool {
     unsupported_orphan_features(sb.compatible_features(), sb.read_only_compatible_features())
 }
@@ -151,7 +156,7 @@ impl Ext4 {
                 return Err(corruption());
             }
             let current_inode = self.read_inode_uncached(current)?;
-            if !current_inode.verify_checksum(&sb.uuid())
+            if !inode_checksum_valid(sb, &current_inode)
                 || current_inode.inode.file_type() == FileType::Unknown
                 || current_inode.inode.link_count() != 0
             {
@@ -274,7 +279,7 @@ impl LegacyOrphanReader for Ext4 {
             next: inode_ref.inode.next_orphan(),
             links: inode_ref.inode.link_count(),
             valid_mode: inode_ref.inode.file_type() != FileType::Unknown,
-            valid_checksum: inode_ref.verify_checksum(&sb.uuid()),
+            valid_checksum: inode_checksum_valid(&sb, &inode_ref),
         })
     }
 }
@@ -379,5 +384,23 @@ mod tests {
             0,
             SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT
         ));
+    }
+
+    #[test]
+    fn inode_checksum_is_optional_without_metadata_csum() {
+        let sb: SuperBlock = unsafe { core::mem::zeroed() };
+        let mut inode = InodeRef::new(11, Box::default());
+        inode.inode.set_generation(7);
+        inode.set_checksum(&sb.uuid());
+        inode.inode.set_generation(8);
+
+        assert!(!inode.verify_checksum(&sb.uuid()));
+        assert!(inode_checksum_valid(&sb, &inode));
+
+        let checked_sb = SuperBlock::validation_fixture();
+        inode.inode.set_generation(9);
+        inode.set_checksum(&checked_sb.uuid());
+        inode.inode.set_generation(10);
+        assert!(!inode_checksum_valid(&checked_sb, &inode));
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/rw.rs
+++ b/kernel/crates/another_ext4/src/ext4/rw.rs
@@ -4,6 +4,93 @@ use crate::ext4_defs::*;
 use crate::prelude::*;
 
 impl Ext4 {
+    /// Obtain a transaction-private metadata block image for mutation.
+    /// Repeated calls for the same block merge changes in one staged image.
+    pub(super) fn transaction_block_for_update<'tx>(
+        &self,
+        transaction: &'tx mut super::journal_transaction::Transaction<'_>,
+        block_id: PBlockId,
+    ) -> Result<&'tx mut [u8; BLOCK_SIZE]> {
+        transaction.read_for_update(self.block_device.as_ref(), block_id)
+    }
+
+    /// Stage block 0 with a checksum-correct ext4 superblock while preserving
+    /// boot-sector bytes and every unrelated field in the containing block.
+    pub(super) fn transaction_stage_super_block(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        sb: &SuperBlock,
+    ) -> Result<()> {
+        let image = self.transaction_block_for_update(transaction, 0)?;
+        let mut checksummed = *sb;
+        checksummed.set_checksum();
+        image[BASE_OFFSET..BASE_OFFSET + core::mem::size_of::<SuperBlock>()]
+            .copy_from_slice(checksummed.to_bytes());
+        Ok(())
+    }
+
+    /// Read the transaction's current superblock image.  This must be used by
+    /// operations which may update allocation counters more than once in one
+    /// transaction; the mounted cache is deliberately not published until the
+    /// checkpoint is durable.
+    pub(super) fn transaction_read_super_block(
+        &self,
+        transaction: &super::journal_transaction::Transaction<'_>,
+    ) -> Result<SuperBlock> {
+        let image = transaction.read(self.block_device.as_ref(), 0)?;
+        Ok(SuperBlock::from_bytes(&image[BASE_OFFSET..]))
+    }
+
+    /// Read a block-group descriptor from the transaction's current image.
+    pub(super) fn transaction_read_block_group(
+        &self,
+        transaction: &super::journal_transaction::Transaction<'_>,
+        block_group_id: BlockGroupId,
+    ) -> Result<BlockGroupRef> {
+        let (block_id, offset) = self.block_group_disk_pos(block_group_id)?;
+        let image = transaction.read(self.block_device.as_ref(), block_id)?;
+        Ok(BlockGroupRef::new(
+            block_group_id,
+            BlockGroupDesc::from_bytes(&image[offset..]),
+        ))
+    }
+
+    /// Merge a checksum-correct descriptor into its transaction-owned GDT
+    /// block.  Several groups may share that block, so staging a fresh block
+    /// for each descriptor would lose earlier changes.
+    pub(super) fn transaction_stage_block_group_with_csum(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        bg_ref: &mut BlockGroupRef,
+        uuid: &[u8],
+    ) -> Result<()> {
+        bg_ref.set_checksum(uuid);
+        let (block_id, offset) = self.block_group_disk_pos(bg_ref.id)?;
+        let image = self.transaction_block_for_update(transaction, block_id)?;
+        image[offset..offset + core::mem::size_of::<BlockGroupDesc>()]
+            .copy_from_slice(bg_ref.desc.to_bytes());
+        Ok(())
+    }
+
+    /// Stage a checksum-correct inode-table entry without publishing it to the
+    /// value cache before the surrounding journal transaction commits.
+    ///
+    /// Using the transaction-owned block image is important because several
+    /// inodes may share one inode-table block; repeated calls must merge rather
+    /// than overwrite an earlier staged entry.
+    pub(super) fn transaction_stage_inode_with_csum(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode_ref: &mut InodeRef,
+    ) -> Result<()> {
+        inode_ref.set_checksum(&self.read_super_block_cached().uuid());
+        let (block_id, offset) = self.inode_disk_pos(inode_ref.id)?;
+        let image = self.transaction_block_for_update(transaction, block_id)?;
+        let bytes = inode_ref.inode.to_bytes();
+        image[offset..offset + bytes.len()].copy_from_slice(bytes);
+        Ok(())
+    }
+
     /// Read a block from block device
     pub(super) fn read_block(&self, block_id: PBlockId) -> Result<Block> {
         self.block_device.read_block(block_id)
@@ -161,6 +248,13 @@ impl Ext4 {
     #[allow(unused)]
     fn block_group_disk_pos(&self, block_group_id: BlockGroupId) -> Result<(PBlockId, usize)> {
         let super_block = self.read_super_block_cached();
+        if block_group_id >= super_block.block_group_count() {
+            return Err(crate::format_error!(
+                ErrCode::EINVAL,
+                "Invalid block group id {}",
+                block_group_id
+            ));
+        }
         let desc_per_block = BLOCK_SIZE as u32 / super_block.desc_size() as u32;
 
         let block_id = super_block.first_data_block() + block_group_id / desc_per_block + 1;

--- a/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
+++ b/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
@@ -1,0 +1,154 @@
+use super::{journal_transaction::Transaction, Ext4};
+use crate::constants::*;
+use crate::ext4_defs::{
+    crc::crc32, validate_xattr_block_for_release, xattr_block_checksum, AsBytes, InodeRef,
+    SuperBlock, XattrHeader,
+};
+use crate::prelude::*;
+
+impl Ext4 {
+    fn validate_xattr_block_allocation(
+        &self,
+        transaction: &Transaction<'_>,
+        block_id: PBlockId,
+    ) -> Result<()> {
+        let sb = self.read_super_block_cached();
+        let first_data = sb.first_data_block() as PBlockId;
+        let blocks_per_group = sb.blocks_per_group() as PBlockId;
+        if blocks_per_group == 0 || block_id < first_data || block_id >= sb.block_count() {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        self.validate_data_blocks(block_id, 1)?;
+        let relative = block_id - first_data;
+        let group = relative / blocks_per_group;
+        if group >= sb.block_group_count() as PBlockId {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let group_first = first_data
+            .checked_add(
+                group
+                    .checked_mul(blocks_per_group)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+            )
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let valid_bits = core::cmp::min(
+            blocks_per_group,
+            sb.block_count()
+                .checked_sub(group_first)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+        ) as usize;
+        let bit = (block_id - group_first) as usize;
+        if bit >= valid_bits {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+
+        let bg = self.transaction_read_block_group(transaction, group as BlockGroupId)?;
+        let bitmap_block = bg.desc.block_bitmap_block();
+        if bitmap_block == 0 || bitmap_block >= sb.block_count() {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let bitmap = transaction.read(self.block_device.as_ref(), bitmap_block)?;
+        if sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
+            let checksum_bytes = sb.clusters_per_group() as usize / 8;
+            if !bg.verify_checksum(&sb.uuid())
+                || !bg
+                    .desc
+                    .verify_block_bitmap_csum(&sb.uuid(), &*bitmap, checksum_bytes)
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+        }
+        if !xattr_allocation_bit_is_set(&*bitmap, bit, valid_bits) {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        Ok(())
+    }
+
+    /// Release the external xattr reference owned by an inode as part of the
+    /// caller's final-reclaim transaction.
+    ///
+    /// A shared block is retained with a decremented reference count. An
+    /// exclusively owned block is detached from the inode and returned to the
+    /// caller, which must release it through the transaction allocator. This
+    /// method never commits and never changes allocation metadata directly.
+    pub(super) fn transaction_release_xattr(
+        &self,
+        transaction: &mut Transaction<'_>,
+        inode: &mut InodeRef,
+    ) -> Result<Option<PBlockId>> {
+        let block_id = inode.inode.xattr_block();
+        if block_id == 0 {
+            return Ok(None);
+        }
+        let sb = self.read_super_block_cached();
+        // EXT4_FEATURE_INCOMPAT_CSUM_SEED requires the explicit checksum-seed
+        // superblock field, which another_ext4 does not expose yet.
+        const FEATURE_INCOMPAT_CSUM_SEED: u32 = 0x2000;
+        if sb.has_incompatible_feature(FEATURE_INCOMPAT_CSUM_SEED) {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+        self.validate_xattr_block_allocation(transaction, block_id)?;
+        let image = transaction.read(self.block_device.as_ref(), block_id)?;
+        let (mut header, has_ea_inode) = validate_xattr_block_for_release(&*image)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        if has_ea_inode {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+
+        // Linux verifies and updates h_checksum only with metadata_csum.
+        const FEATURE_RO_COMPAT_METADATA_CSUM: u32 = 0x0400;
+        let checksum_seed = if sb.has_read_only_compatible_feature(FEATURE_RO_COMPAT_METADATA_CSUM)
+        {
+            // Without metadata_csum_seed Linux derives the seed from UUID.
+            let seed = crc32(CRC32_INIT, &sb.uuid());
+            let expected = xattr_block_checksum(seed, block_id, &*image)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            if header.checksum() != expected {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            Some(seed)
+        } else {
+            None
+        };
+
+        if header.refcount() > 1 {
+            header.set_refcount(header.refcount() - 1);
+            let image = self.transaction_block_for_update(transaction, block_id)?;
+            if let Some(seed) = checksum_seed {
+                header.set_checksum(0);
+                image[..core::mem::size_of::<XattrHeader>()].copy_from_slice(header.to_bytes());
+                let checksum = xattr_block_checksum(seed, block_id, image)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                header.set_checksum(checksum);
+            }
+            image[..core::mem::size_of::<XattrHeader>()].copy_from_slice(header.to_bytes());
+            // This inode no longer owns a reference.  Detach it in the same
+            // transaction as the shared reference-count decrement, otherwise
+            // a restartable reclaim would decrement the block repeatedly.
+            inode.inode.set_xattr_block(0);
+            self.transaction_stage_inode_with_csum(transaction, inode)?;
+            Ok(None)
+        } else {
+            inode.inode.set_xattr_block(0);
+            self.transaction_stage_inode_with_csum(transaction, inode)?;
+            Ok(Some(block_id))
+        }
+    }
+}
+
+fn xattr_allocation_bit_is_set(bitmap: &[u8], bit: usize, valid_bits: usize) -> bool {
+    bit < valid_bits && bit / 8 < bitmap.len() && bitmap[bit / 8] & (1 << (bit % 8)) != 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::xattr_allocation_bit_is_set;
+
+    #[test]
+    fn free_or_out_of_range_xattr_block_is_rejected() {
+        let bitmap = [0b0000_0100u8];
+        assert!(xattr_allocation_bit_is_set(&bitmap, 2, 8));
+        assert!(!xattr_allocation_bit_is_set(&bitmap, 3, 8));
+        assert!(!xattr_allocation_bit_is_set(&bitmap, 8, 8));
+    }
+}

--- a/kernel/crates/another_ext4/src/ext4_defs/bitmap.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/bitmap.rs
@@ -5,10 +5,6 @@ impl<'a> Bitmap<'a> {
         Self(&mut bmap[..nbits.div_ceil(8)])
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0
-    }
-
     pub fn is_bit_clear(&self, bit: usize) -> bool {
         self.0[bit / 8] & (1 << (bit % 8)) == 0
     }

--- a/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
@@ -7,7 +7,6 @@
 
 use super::crc::*;
 use super::AsBytes;
-use super::Bitmap;
 use crate::constants::*;
 use crate::prelude::*;
 
@@ -106,20 +105,6 @@ impl BlockGroupDesc {
         self.free_blocks_count_hi = (cnt >> 16) as u16;
     }
 
-    pub fn set_inode_bitmap_csum(&mut self, uuid: &[u8], bitmap: &Bitmap) {
-        let mut csum = crc32(CRC32_INIT, uuid);
-        csum = crc32(csum, bitmap.as_bytes());
-        self.inode_bitmap_csum_lo = csum as u16;
-        self.inode_bitmap_csum_hi = (csum >> 16) as u16;
-    }
-
-    pub fn set_block_bitmap_csum(&mut self, uuid: &[u8], bitmap: &Bitmap) {
-        let mut csum = crc32(CRC32_INIT, uuid);
-        csum = crc32(csum, bitmap.as_bytes());
-        self.block_bitmap_csum_lo = csum as u16;
-        self.block_bitmap_csum_hi = (csum >> 16) as u16;
-    }
-
     fn bitmap_csum(uuid: &[u8], bytes: &[u8], len: usize) -> Option<u32> {
         let covered = bytes.get(..len)?;
         Some(crc32(crc32(CRC32_INIT, uuid), covered))
@@ -215,6 +200,12 @@ mod tests {
         let uuid = [0x5a; 16];
         let mut desc = BlockGroupDesc::default();
         let mut bytes = [0u8; 32];
+        // Model a partial last inode group: direct mutation may touch only 65
+        // real inode bits, while Linux checksums the fixed 128-bit group bitmap.
+        {
+            let mut actual_inodes = crate::ext4_defs::Bitmap::new(&mut bytes, 65);
+            actual_inodes.set_bit(64);
+        }
 
         assert!(desc.update_block_bitmap_csum(&uuid, &bytes, 16));
         assert!(desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
@@ -228,6 +219,12 @@ mod tests {
         // Bytes beyond the fixed checksum length are outside the bitmap.
         bytes[16] ^= 1;
         assert!(desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
+
+        assert!(desc.update_inode_bitmap_csum(&uuid, &bytes, 16));
+        bytes[15] ^= 1;
+        assert!(!desc.verify_inode_bitmap_csum(&uuid, &bytes, 16));
+        bytes[15] ^= 1;
+        assert!(desc.verify_inode_bitmap_csum(&uuid, &bytes, 16));
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
@@ -98,12 +98,12 @@ impl BlockGroupDesc {
     }
 
     pub fn get_free_blocks_count(&self) -> u64 {
-        ((self.free_blocks_count_hi as u64) << 32) | self.free_blocks_count_lo as u64
+        ((self.free_blocks_count_hi as u64) << 16) | self.free_blocks_count_lo as u64
     }
 
     pub fn set_free_blocks_count(&mut self, cnt: u64) {
-        self.free_blocks_count_lo = ((cnt << 32) >> 32) as u16;
-        self.free_blocks_count_hi = (cnt >> 32) as u16;
+        self.free_blocks_count_lo = cnt as u16;
+        self.free_blocks_count_hi = (cnt >> 16) as u16;
     }
 
     pub fn set_inode_bitmap_csum(&mut self, uuid: &[u8], bitmap: &Bitmap) {
@@ -118,6 +118,50 @@ impl BlockGroupDesc {
         csum = crc32(csum, bitmap.as_bytes());
         self.block_bitmap_csum_lo = csum as u16;
         self.block_bitmap_csum_hi = (csum >> 16) as u16;
+    }
+
+    fn bitmap_csum(uuid: &[u8], bytes: &[u8], len: usize) -> Option<u32> {
+        let covered = bytes.get(..len)?;
+        Some(crc32(crc32(CRC32_INIT, uuid), covered))
+    }
+
+    pub fn verify_inode_bitmap_csum(&self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
+        Self::bitmap_csum(uuid, bytes, len).is_some_and(|csum| {
+            csum == (self.inode_bitmap_csum_lo as u32 | ((self.inode_bitmap_csum_hi as u32) << 16))
+        })
+    }
+
+    pub fn update_inode_bitmap_csum(&mut self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
+        let Some(csum) = Self::bitmap_csum(uuid, bytes, len) else {
+            return false;
+        };
+        self.inode_bitmap_csum_lo = csum as u16;
+        self.inode_bitmap_csum_hi = (csum >> 16) as u16;
+        true
+    }
+
+    pub fn verify_block_bitmap_csum(&self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
+        Self::bitmap_csum(uuid, bytes, len).is_some_and(|csum| {
+            csum == (self.block_bitmap_csum_lo as u32 | ((self.block_bitmap_csum_hi as u32) << 16))
+        })
+    }
+
+    pub fn update_block_bitmap_csum(&mut self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
+        let Some(csum) = Self::bitmap_csum(uuid, bytes, len) else {
+            return false;
+        };
+        self.block_bitmap_csum_lo = csum as u16;
+        self.block_bitmap_csum_hi = (csum >> 16) as u16;
+        true
+    }
+
+    #[cfg(test)]
+    pub(crate) fn validation_fixture() -> Self {
+        let mut desc = Self::default();
+        desc.block_bitmap_lo = 2;
+        desc.inode_bitmap_lo = 3;
+        desc.inode_table_first_block_lo = 4;
+        desc
     }
 }
 
@@ -143,5 +187,56 @@ impl BlockGroupRef {
         checksum = crc32(checksum, &self.id.to_le_bytes());
         checksum = crc32(checksum, self.desc.to_bytes());
         self.desc.checksum = checksum as u16;
+    }
+
+    pub fn verify_checksum(&self, uuid: &[u8]) -> bool {
+        let expected = self.desc.checksum;
+        let mut copy = BlockGroupRef::new(self.id, self.desc);
+        copy.set_checksum(uuid);
+        copy.desc.checksum == expected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn free_block_count_roundtrips_high_sixteen_bits() {
+        let mut desc = BlockGroupDesc::default();
+        for count in [0, 1, u16::MAX as u64, 0x1234_5678, u32::MAX as u64] {
+            desc.set_free_blocks_count(count);
+            assert_eq!(desc.get_free_blocks_count(), count);
+        }
+    }
+
+    #[test]
+    fn bitmap_checksum_covers_fixed_group_bytes_not_mutation_bounds() {
+        let uuid = [0x5a; 16];
+        let mut desc = BlockGroupDesc::default();
+        let mut bytes = [0u8; 32];
+
+        assert!(desc.update_block_bitmap_csum(&uuid, &bytes, 16));
+        assert!(desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
+
+        // This byte can be beyond the actual blocks in a partial final group,
+        // but Linux still includes it in clusters_per_group / 8.
+        bytes[15] ^= 1;
+        assert!(!desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
+        bytes[15] ^= 1;
+
+        // Bytes beyond the fixed checksum length are outside the bitmap.
+        bytes[16] ^= 1;
+        assert!(desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
+    }
+
+    #[test]
+    fn group_descriptor_checksum_detects_corruption() {
+        let uuid = [0xa5; 16];
+        let mut group = BlockGroupRef::new(7, BlockGroupDesc::default());
+        group.set_checksum(&uuid);
+        assert!(group.verify_checksum(&uuid));
+        group.desc.set_free_inodes_count(1);
+        assert!(!group.verify_checksum(&uuid));
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
@@ -32,8 +32,8 @@ pub struct BlockGroupDesc {
     used_dirs_count_lo: u16,         // 目录数
     flags: u16,                      // EXT4_BG_flags (INODE_UNINIT, etc)
     exclude_bitmap_lo: u32,          // 快照排除位图
-    block_bitmap_csum_lo: u16,       // crc32c(s_uuid+grp_num+bbitmap) LE
-    inode_bitmap_csum_lo: u16,       // crc32c(s_uuid+grp_num+ibitmap) LE
+    block_bitmap_csum_lo: u16,       // crc32c(s_csum_seed+bbitmap) LE
+    inode_bitmap_csum_lo: u16,       // crc32c(s_csum_seed+ibitmap) LE
     itable_unused_lo: u16,           // 未使用的节点数
     checksum: u16,                   // crc16(sb_uuid+group+desc)
 
@@ -45,8 +45,8 @@ pub struct BlockGroupDesc {
     used_dirs_count_hi: u16,         // 目录数 MSB
     itable_unused_hi: u16,           // 未使用的节点数 MSB
     exclude_bitmap_hi: u32,          // 快照排除位图 MSB
-    block_bitmap_csum_hi: u16,       // crc32c(s_uuid+grp_num+bbitmap) BE
-    inode_bitmap_csum_hi: u16,       // crc32c(s_uuid+grp_num+ibitmap) BE
+    block_bitmap_csum_hi: u16,       // crc32c(s_csum_seed+bbitmap) BE
+    inode_bitmap_csum_hi: u16,       // crc32c(s_csum_seed+ibitmap) BE
     reserved: u32,                   // 填充
 }
 

--- a/kernel/crates/another_ext4/src/ext4_defs/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/dir.rs
@@ -169,6 +169,12 @@ impl DirEntryTail {
 /// The block that stores an array of `DirEntry`.
 pub struct DirBlock(Block);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirBlockLayout {
+    Leaf,
+    Htree,
+}
+
 impl DirBlock {
     /// Wrap a data block to a directory block.
     pub fn new(block: Block) -> Self {
@@ -180,20 +186,191 @@ impl DirBlock {
         &self.0
     }
 
+    /// Validate the complete linear directory layout before any entry is
+    /// interpreted.  The checksum tail is not a directory entry and every
+    /// record must end at or before that tail with a bounded name payload.
+    pub fn validate(
+        &self,
+        uuid: &[u8],
+        ino: InodeId,
+        ino_gen: u32,
+        metadata_csum: bool,
+        indexed: bool,
+        htree_root: bool,
+    ) -> Result<DirBlockLayout> {
+        if indexed && htree_root {
+            self.validate_htree(uuid, ino, ino_gen, metadata_csum)?;
+            return Ok(DirBlockLayout::Htree);
+        }
+        if indexed
+            && self
+                .validate_htree(uuid, ino, ino_gen, metadata_csum)
+                .is_ok()
+        {
+            return Ok(DirBlockLayout::Htree);
+        }
+        if let Ok(()) = self.validate_leaf(uuid, ino, ino_gen, metadata_csum) {
+            return Ok(DirBlockLayout::Leaf);
+        }
+        Err(Ext4Error::new(ErrCode::EIO))
+    }
+
+    fn validate_leaf(
+        &self,
+        uuid: &[u8],
+        ino: InodeId,
+        ino_gen: u32,
+        metadata_csum: bool,
+    ) -> Result<()> {
+        let data_end = if metadata_csum {
+            BLOCK_SIZE - size_of::<DirEntryTail>()
+        } else {
+            BLOCK_SIZE
+        };
+        if metadata_csum {
+            let tail: DirEntryTail = self.0.read_offset_as(data_end);
+            if tail.reserved_zero1 != 0
+                || tail.rec_len as usize != size_of::<DirEntryTail>()
+                || tail.reserved_zero2 != 0
+                || tail.reserved_ft != 0xDE
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            let mut expected = tail;
+            expected.set_checksum(uuid, ino, ino_gen, &self.0);
+            if expected.checksum != tail.checksum {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+        }
+
+        let mut offset = 0usize;
+        while offset < data_end {
+            if data_end - offset < size_of::<FakeDirEntry>() {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            // Read primitive fields byte-wise.  Constructing FakeDirEntry
+            // before checking file_type would create an invalid Rust enum for
+            // malicious on-disk discriminants.
+            let rec_len =
+                u16::from_le_bytes([self.0.data[offset + 4], self.0.data[offset + 5]]) as usize;
+            let name_len = self.0.data[offset + 6] as usize;
+            let file_type = self.0.data[offset + 7];
+            if rec_len < size_of::<FakeDirEntry>()
+                || rec_len % 4 != 0
+                || offset.checked_add(rec_len).is_none_or(|end| end > data_end)
+                || name_len > rec_len - size_of::<FakeDirEntry>()
+                || file_type > FileType::SymLink as u8
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            offset += rec_len;
+        }
+        if offset != data_end {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        Ok(())
+    }
+
+    /// Validate an ext4 htree root or internal node using the same count/limit
+    /// layout and checksum coverage as Linux `ext4_dx_csum_verify()`.
+    fn validate_htree(
+        &self,
+        uuid: &[u8],
+        ino: InodeId,
+        ino_gen: u32,
+        metadata_csum: bool,
+    ) -> Result<()> {
+        let first_rec_len = u16::from_le_bytes([self.0.data[4], self.0.data[5]]) as usize;
+        if self.0.data[7] > FileType::SymLink as u8 {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let count_offset = if first_rec_len == BLOCK_SIZE {
+            8usize
+        } else if first_rec_len == 12 {
+            let second_rec_len = u16::from_le_bytes([self.0.data[16], self.0.data[17]]) as usize;
+            if second_rec_len != BLOCK_SIZE - 12
+                || self.0.data[24..28] != [0; 4]
+                || self.0.data[29] as usize != 8
+                || self.0.data[19] > FileType::SymLink as u8
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            32usize
+        } else {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        };
+
+        let limit =
+            u16::from_le_bytes([self.0.data[count_offset], self.0.data[count_offset + 1]]) as usize;
+        let count =
+            u16::from_le_bytes([self.0.data[count_offset + 2], self.0.data[count_offset + 3]])
+                as usize;
+        if count == 0 || count > limit {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let tail_offset = count_offset
+            .checked_add(
+                limit
+                    .checked_mul(8)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+            )
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let max_tail_offset = if metadata_csum {
+            BLOCK_SIZE - 8
+        } else {
+            BLOCK_SIZE
+        };
+        if tail_offset > max_tail_offset {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        if !metadata_csum {
+            return Ok(());
+        }
+        let stored = u32::from_le_bytes(
+            self.0.data[tail_offset + 4..tail_offset + 8]
+                .try_into()
+                .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+        );
+        let used_end = count_offset
+            .checked_add(count * 8)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let mut checksum = crc32(CRC32_INIT, uuid);
+        checksum = crc32(checksum, &ino.to_le_bytes());
+        checksum = crc32(checksum, &ino_gen.to_le_bytes());
+        checksum = crc32(checksum, &self.0.data[..used_end]);
+        checksum = crc32(checksum, &self.0.data[tail_offset..tail_offset + 4]);
+        checksum = crc32(checksum, &[0; 4]);
+        if checksum != stored {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        Ok(())
+    }
+
     /// Initialize a directory block, create an unused entry
     /// and the dir entry tail.
-    pub fn init(&mut self) {
-        let tail_offset = BLOCK_SIZE - size_of::<DirEntryTail>();
-        let entry = DirEntry::new(0, tail_offset as u16, "", FileType::Unknown);
+    pub fn init(&mut self, metadata_csum: bool) {
+        let data_end = if metadata_csum {
+            BLOCK_SIZE - size_of::<DirEntryTail>()
+        } else {
+            BLOCK_SIZE
+        };
+        let entry = DirEntry::new(0, data_end as u16, "", FileType::Unknown);
         self.0.write_offset_as(0, &entry);
-        let tail = DirEntryTail::new();
-        self.0.write_offset_as(tail_offset, &tail);
+        if metadata_csum {
+            let tail = DirEntryTail::new();
+            self.0.write_offset_as(data_end, &tail);
+        }
     }
 
     /// Get a directory entry by name, return the inode id of the entry.
-    pub fn get(&self, name: &str) -> Option<InodeId> {
+    pub fn get(&self, name: &str, metadata_csum: bool) -> Option<InodeId> {
+        let tail_offset = if metadata_csum {
+            BLOCK_SIZE - size_of::<DirEntryTail>()
+        } else {
+            BLOCK_SIZE
+        };
         let mut offset = 0;
-        while offset < BLOCK_SIZE {
+        while offset < tail_offset {
             let de: DirEntry = self.0.read_offset_as(offset);
             if !de.unused() && de.compare_name(name) {
                 return Some(de.inode);
@@ -204,9 +381,14 @@ impl DirBlock {
     }
 
     /// Get all directory entries in the block.
-    pub fn list(&self, entries: &mut Vec<DirEntry>) {
+    pub fn list(&self, entries: &mut Vec<DirEntry>, metadata_csum: bool) {
+        let tail_offset = if metadata_csum {
+            BLOCK_SIZE - size_of::<DirEntryTail>()
+        } else {
+            BLOCK_SIZE
+        };
         let mut offset = 0;
-        while offset < BLOCK_SIZE {
+        while offset < tail_offset {
             let de: DirEntry = self.0.read_offset_as(offset);
             offset += de.rec_len as usize;
             if !de.unused() {
@@ -218,13 +400,33 @@ impl DirBlock {
 
     /// Insert a directory entry to the block. Return true if success or false
     /// if the block doesn't have enough space.
-    pub fn insert(&mut self, name: &str, inode: InodeId, file_type: FileType) -> bool {
+    pub fn insert(
+        &mut self,
+        name: &str,
+        inode: InodeId,
+        file_type: FileType,
+        metadata_csum: bool,
+    ) -> bool {
         let required_size = DirEntry::required_size(name.len());
+        let tail_offset = if metadata_csum {
+            BLOCK_SIZE - size_of::<DirEntryTail>()
+        } else {
+            BLOCK_SIZE
+        };
         let mut offset = 0;
-        while offset < BLOCK_SIZE {
+        while offset < tail_offset {
             // Read a dir entry
             let mut de: DirEntry = self.0.read_offset_as(offset);
             let rec_len = de.rec_len as usize;
+            // An unused record is itself free space.  Reuse it in place
+            // instead of preserving an artificial 8-byte inode-zero prefix;
+            // ext4 directories must start with their first real entry, and
+            // e2fsck rejects the prefix once deletion makes a directory empty.
+            if de.unused() && rec_len >= required_size {
+                let new_entry = DirEntry::new(inode, rec_len as u16, name, file_type);
+                self.0.write_offset_as(offset, &new_entry);
+                return true;
+            }
             // The size that `de` actually uses
             let used_size = de.used_size();
             // The rest size
@@ -250,16 +452,33 @@ impl DirBlock {
 
     /// Remove a directory entry from the block. Return true if success or false
     /// if the entry doesn't exist.
-    pub fn remove(&mut self, name: &str) -> bool {
+    pub fn remove(&mut self, name: &str, metadata_csum: bool) -> bool {
+        let tail_offset = if metadata_csum {
+            BLOCK_SIZE - size_of::<DirEntryTail>()
+        } else {
+            BLOCK_SIZE
+        };
         let mut offset = 0;
-        while offset < BLOCK_SIZE {
+        let mut previous_offset = None;
+        while offset < tail_offset {
             let mut de: DirEntry = self.0.read_offset_as(offset);
             if !de.unused() && de.compare_name(name) {
-                // Mark the target entry as unused
-                de.set_unused();
-                self.0.write_offset_as(offset, &de);
+                // Match ext4_generic_delete_entry(): coalesce the deleted
+                // record into its predecessor when one exists.  Merely
+                // clearing i_ino leaves a typed, named hole which e2fsck
+                // rejects for directory entries on metadata_csum filesystems.
+                if let Some(previous_offset) = previous_offset {
+                    let mut previous: DirEntry = self.0.read_offset_as(previous_offset);
+                    previous.rec_len += de.rec_len;
+                    self.0.write_offset_as(previous_offset, &previous);
+                } else {
+                    de.set_unused();
+                    de.set_type(FileType::Unknown);
+                    self.0.write_offset_as(offset, &de);
+                }
                 return true;
             }
+            previous_offset = Some(offset);
             offset += de.rec_len as usize;
         }
         false
@@ -276,9 +495,20 @@ impl DirBlock {
     /// # Returns
     /// * `true` if entry found and replaced
     /// * `false` if entry not found
-    pub fn replace(&mut self, name: &str, new_inode: InodeId, new_type: FileType) -> bool {
+    pub fn replace(
+        &mut self,
+        name: &str,
+        new_inode: InodeId,
+        new_type: FileType,
+        metadata_csum: bool,
+    ) -> bool {
+        let tail_offset = if metadata_csum {
+            BLOCK_SIZE - size_of::<DirEntryTail>()
+        } else {
+            BLOCK_SIZE
+        };
         let mut offset = 0;
-        while offset < BLOCK_SIZE {
+        while offset < tail_offset {
             let mut de: DirEntry = self.0.read_offset_as(offset);
             if !de.unused() && de.compare_name(name) {
                 // In-place modification: only change inode and file_type
@@ -299,5 +529,225 @@ impl DirBlock {
         let mut tail: DirEntryTail = self.0.read_offset_as(tail_offset);
         tail.set_checksum(uuid, ino, ino_gen, &self.0);
         self.0.write_offset_as(tail_offset, &tail);
+    }
+
+    pub fn set_htree_checksum(&mut self, uuid: &[u8], ino: InodeId, ino_gen: u32) -> Result<()> {
+        let first_rec_len = u16::from_le_bytes([self.0.data[4], self.0.data[5]]) as usize;
+        let count_offset = if first_rec_len == BLOCK_SIZE {
+            8usize
+        } else if first_rec_len == 12 {
+            32usize
+        } else {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        };
+        let limit =
+            u16::from_le_bytes([self.0.data[count_offset], self.0.data[count_offset + 1]]) as usize;
+        let count =
+            u16::from_le_bytes([self.0.data[count_offset + 2], self.0.data[count_offset + 3]])
+                as usize;
+        if count == 0 || count > limit {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let tail_offset = count_offset
+            .checked_add(
+                limit
+                    .checked_mul(8)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+            )
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        if tail_offset > BLOCK_SIZE - 8 {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        let used_end = count_offset
+            .checked_add(count * 8)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        let mut checksum = crc32(CRC32_INIT, uuid);
+        checksum = crc32(checksum, &ino.to_le_bytes());
+        checksum = crc32(checksum, &ino_gen.to_le_bytes());
+        checksum = crc32(checksum, &self.0.data[..used_end]);
+        checksum = crc32(checksum, &self.0.data[tail_offset..tail_offset + 4]);
+        checksum = crc32(checksum, &[0; 4]);
+        self.0.data[tail_offset + 4..tail_offset + 8].copy_from_slice(&checksum.to_le_bytes());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_block() -> DirBlock {
+        let mut block = DirBlock::new(Block::new(7, Box::new([0; BLOCK_SIZE])));
+        block.init(true);
+        assert!(block.insert("entry", 12, FileType::RegularFile, true));
+        block.set_checksum(&[0x41; 16], 2, 9);
+        block
+    }
+
+    fn valid_htree_root() -> DirBlock {
+        let uuid = [0x41; 16];
+        let ino = 2u32;
+        let generation = 9u32;
+        let mut raw = Block::new(8, Box::new([0; BLOCK_SIZE]));
+        raw.write_offset_as(0, &DirEntry::new(ino, 12, ".", FileType::Directory));
+        raw.write_offset_as(
+            12,
+            &DirEntry::new(ino, (BLOCK_SIZE - 12) as u16, "..", FileType::Directory),
+        );
+        raw.data[28] = 1; // hash version
+        raw.data[29] = 8; // dx_root_info length
+        let count_offset = 32usize;
+        let limit = ((BLOCK_SIZE - count_offset - 8) / 8) as u16;
+        raw.data[count_offset..count_offset + 2].copy_from_slice(&limit.to_le_bytes());
+        raw.data[count_offset + 2..count_offset + 4].copy_from_slice(&2u16.to_le_bytes());
+        raw.data[count_offset + 4..count_offset + 8].copy_from_slice(&1u32.to_le_bytes());
+        raw.data[count_offset + 8..count_offset + 12]
+            .copy_from_slice(&0x8765_4321u32.to_le_bytes());
+        raw.data[count_offset + 12..count_offset + 16].copy_from_slice(&2u32.to_le_bytes());
+        let tail_offset = count_offset + limit as usize * 8;
+        raw.data[tail_offset..tail_offset + 4].copy_from_slice(&[12, 0, 0, 0xde]);
+        let used_end = count_offset + 2 * 8;
+        let mut checksum = crc32(CRC32_INIT, &uuid);
+        checksum = crc32(checksum, &ino.to_le_bytes());
+        checksum = crc32(checksum, &generation.to_le_bytes());
+        checksum = crc32(checksum, &raw.data[..used_end]);
+        checksum = crc32(checksum, &raw.data[tail_offset..tail_offset + 4]);
+        checksum = crc32(checksum, &[0; 4]);
+        raw.data[tail_offset + 4..tail_offset + 8].copy_from_slice(&checksum.to_le_bytes());
+        DirBlock::new(raw)
+    }
+
+    #[test]
+    fn validated_directory_rejects_zero_and_out_of_bounds_record_lengths() {
+        let block = valid_block();
+        block
+            .validate(&[0x41; 16], 2, 9, true, false, false)
+            .unwrap();
+
+        let mut zero = block.0.clone();
+        zero.data[4..6].copy_from_slice(&0u16.to_le_bytes());
+        assert_eq!(
+            DirBlock::new(zero)
+                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+
+        let mut oversized = block.0.clone();
+        oversized.data[4..6].copy_from_slice(&((BLOCK_SIZE - 4) as u16).to_le_bytes());
+        assert_eq!(
+            DirBlock::new(oversized)
+                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+    }
+
+    #[test]
+    fn validated_directory_rejects_name_overrun_and_bad_tail_checksum() {
+        let block = valid_block();
+        let mut bad_name = block.0.clone();
+        bad_name.data[4..6].copy_from_slice(&8u16.to_le_bytes());
+        bad_name.data[6] = 255;
+        assert_eq!(
+            DirBlock::new(bad_name)
+                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+
+        let mut bad_type = block.0.clone();
+        bad_type.data[7] = 0xff;
+        assert_eq!(
+            DirBlock::new(bad_type)
+                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+
+        let mut bad_checksum = block.0.clone();
+        bad_checksum.data[BLOCK_SIZE - 1] ^= 0x80;
+        assert_eq!(
+            DirBlock::new(bad_checksum)
+                .validate(&[0x41; 16], 2, 9, true, false, false)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+    }
+
+    #[test]
+    fn missing_entry_scan_stops_before_checksum_tail() {
+        let mut block = valid_block();
+        block
+            .validate(&[0x41; 16], 2, 9, true, false, false)
+            .unwrap();
+
+        assert_eq!(block.get("missing", true), None);
+        let mut entries = Vec::new();
+        block.list(&mut entries, true);
+        assert_eq!(entries.len(), 1);
+        assert!(!block.remove("missing", true));
+        assert!(!block.replace("missing", 99, FileType::RegularFile, true));
+        let long = "x".repeat(255);
+        while block.insert(&long, 99, FileType::RegularFile, true) {}
+        while block.insert("a", 99, FileType::RegularFile, true) {}
+        assert!(!block.insert("another", 99, FileType::RegularFile, true));
+    }
+
+    #[test]
+    fn indexed_directory_root_uses_dx_checksum_layout() {
+        let block = valid_htree_root();
+        assert_eq!(
+            block.validate(&[0x41; 16], 2, 9, true, true, true).unwrap(),
+            DirBlockLayout::Htree
+        );
+        assert_eq!(block.get(".", true), Some(2));
+
+        let mut no_csum = block.0.clone();
+        no_csum.data[32..34].copy_from_slice(&508u16.to_le_bytes());
+        assert_eq!(
+            DirBlock::new(no_csum)
+                .validate(&[0x41; 16], 2, 9, false, true, true)
+                .unwrap(),
+            DirBlockLayout::Htree
+        );
+
+        let mut corrupted = block.0.clone();
+        corrupted.data[BLOCK_SIZE - 1] ^= 0x80;
+        assert_eq!(
+            DirBlock::new(corrupted)
+                .validate(&[0x41; 16], 2, 9, true, true, true)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+
+        let mut invalid_type = block.0.clone();
+        invalid_type.data[7] = 0xff;
+        assert_eq!(
+            DirBlock::new(invalid_type)
+                .validate(&[0x41; 16], 2, 9, false, true, true)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+    }
+
+    #[test]
+    fn directory_without_metadata_checksum_uses_the_full_block() {
+        let mut block = DirBlock::new(Block::new(9, Box::new([0; BLOCK_SIZE])));
+        block.init(false);
+        assert!(block.insert("entry", 12, FileType::RegularFile, false));
+        assert_eq!(
+            block
+                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .unwrap(),
+            DirBlockLayout::Leaf
+        );
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/dir.rs
@@ -256,7 +256,7 @@ impl DirBlock {
             let name_len = self.0.data[offset + 6] as usize;
             let file_type = self.0.data[offset + 7];
             if rec_len < size_of::<FakeDirEntry>()
-                || rec_len % 4 != 0
+                || !rec_len.is_multiple_of(4)
                 || offset.checked_add(rec_len).is_none_or(|end| end > data_end)
                 || name_len > rec_len - size_of::<FakeDirEntry>()
                 || file_type > FileType::SymLink as u8

--- a/kernel/crates/another_ext4/src/ext4_defs/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/extent.rs
@@ -225,7 +225,11 @@ impl Extent {
 
     /// Set the number of blocks covered by this extent
     pub fn set_block_count(&mut self, block_count: LBlockId) {
+        let unwritten = self.is_unwritten();
         self.block_count = block_count as u16;
+        if unwritten {
+            self.block_count |= Self::INIT_MAX_LEN;
+        }
     }
 
     /// Check if the extent is unwritten
@@ -456,6 +460,20 @@ impl<'a> ExtentNodeMut<'a> {
         unsafe {
             &mut *((self.header_mut() as *mut ExtentHeader).add(1) as *mut FakeExtent).add(pos)
         }
+    }
+
+    /// Remove the last entry from this node.
+    ///
+    /// Extent nodes are packed arrays.  Decreasing `eh_entries` is sufficient:
+    /// bytes beyond the new entry count are not part of the tree and are
+    /// deliberately left untouched, matching ext4's on-disk convention.
+    pub fn remove_last_entry(&mut self) -> bool {
+        let entries = self.header().entries_count();
+        if entries == 0 {
+            return false;
+        }
+        self.header_mut().set_entries_count(entries - 1);
+        true
     }
 
     /// Initialize the extent node

--- a/kernel/crates/another_ext4/src/ext4_defs/inode.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/inode.rs
@@ -324,6 +324,21 @@ impl Inode {
         self.dtime = dtime;
     }
 
+    /// Next inode number in the legacy ext4 orphan list, or zero.
+    ///
+    /// Linux stores this pointer in `i_dtime` while an inode is orphaned.
+    pub fn next_orphan(&self) -> InodeId {
+        self.dtime
+    }
+
+    /// Set the next inode number in the legacy ext4 orphan list.
+    ///
+    /// This deliberately aliases `i_dtime`; callers must recompute the inode
+    /// checksum before persisting the inode.
+    pub fn set_next_orphan(&mut self, next: InodeId) {
+        self.dtime = next;
+    }
+
     pub fn crtime(&self) -> u32 {
         self.crtime
     }
@@ -367,6 +382,11 @@ impl Inode {
 
     pub fn flags(&self) -> u32 {
         self.flags
+    }
+
+    /// Whether `i_block` contains an extent root rather than inline/device data.
+    pub fn uses_extents(&self) -> bool {
+        self.flags & Self::FLAG_EXTENTS != 0
     }
 
     pub fn set_flags(&mut self, f: u32) {
@@ -514,16 +534,31 @@ impl InodeRef {
     }
 
     pub fn set_checksum(&mut self, uuid: &[u8]) {
-        // Must set checksum field to 0 before calculation to avoid including old value
-        // causing checksum to never match (Linux semantics).
-        self.inode.osd2.l_checksum_lo = 0;
-        self.inode.checksum_hi = 0;
-        let mut checksum = crc32(CRC32_INIT, uuid);
-        checksum = crc32(checksum, &self.id.to_le_bytes());
-        checksum = crc32(checksum, &self.inode.generation.to_le_bytes());
-        checksum = crc32(checksum, self.inode.to_bytes());
+        let checksum = self.calculated_checksum(uuid);
         self.inode.osd2.l_checksum_lo = checksum as u16;
         self.inode.checksum_hi = (checksum >> 16) as u16;
+    }
+
+    /// Return the checksum stored in the on-disk inode fields.
+    pub fn checksum(&self) -> u32 {
+        self.inode.osd2.l_checksum_lo as u32 | ((self.inode.checksum_hi as u32) << 16)
+    }
+
+    /// Compute the Linux ext4 inode checksum without modifying the inode.
+    pub fn calculated_checksum(&self, uuid: &[u8]) -> u32 {
+        // Linux treats both checksum fields as zero while calculating CRC32C.
+        let mut inode = self.inode.as_ref().clone();
+        inode.osd2.l_checksum_lo = 0;
+        inode.checksum_hi = 0;
+        let mut checksum = crc32(CRC32_INIT, uuid);
+        checksum = crc32(checksum, &self.id.to_le_bytes());
+        checksum = crc32(checksum, &inode.generation.to_le_bytes());
+        crc32(checksum, inode.to_bytes())
+    }
+
+    /// Verify the stored checksum against the inode identity and filesystem UUID.
+    pub fn verify_checksum(&self, uuid: &[u8]) -> bool {
+        self.checksum() == self.calculated_checksum(uuid)
     }
 }
 
@@ -592,6 +627,46 @@ pub mod device {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retryable_reclaim_error_returns_its_one_shot_handle() {
+        let failure = InodeReclaimError::new(
+            Ext4Error::new(ErrCode::EAGAIN),
+            InodeReclaimHandle::new(37, 91),
+        );
+        let (error, handle) = failure.into_parts();
+        assert_eq!(error.code(), ErrCode::EAGAIN);
+        assert_eq!(handle.inode_id, 37);
+        assert_eq!(handle.generation, 91);
+    }
+
+    #[test]
+    fn next_orphan_is_the_dtime_disk_field() {
+        let mut inode = Inode::default();
+        inode.set_next_orphan(123);
+        assert_eq!(inode.next_orphan(), 123);
+        assert_eq!(inode.dtime(), 123);
+
+        inode.set_dtime(456);
+        assert_eq!(inode.next_orphan(), 456);
+    }
+
+    #[test]
+    fn inode_checksum_can_be_verified_without_mutation() {
+        let uuid = *b"0123456789abcdef";
+        let mut inode = InodeRef::new(42, Box::new(Inode::default()));
+        inode.inode.set_generation(7);
+        inode.inode.set_next_orphan(11);
+        inode.set_checksum(&uuid);
+
+        let stored = inode.checksum();
+        assert!(inode.verify_checksum(&uuid));
+        assert_eq!(inode.checksum(), stored);
+
+        inode.inode.set_next_orphan(12);
+        assert!(!inode.verify_checksum(&uuid));
+        assert_eq!(inode.checksum(), stored);
+    }
 
     // ==================== device module tests ====================
 

--- a/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
@@ -115,12 +115,15 @@ impl SuperBlock {
     const SB_MAGIC: u16 = 0xEF53;
 
     pub const FEATURE_COMPAT_HAS_JOURNAL: u32 = 0x0004;
+    pub const FEATURE_COMPAT_RESIZE_INODE: u32 = 0x0010;
+    pub const FEATURE_COMPAT_SPARSE_SUPER2: u32 = 0x0200;
     pub const FEATURE_COMPAT_FAST_COMMIT: u32 = 0x0400;
     pub const FEATURE_COMPAT_ORPHAN_FILE: u32 = 0x1000;
     pub const FEATURE_INCOMPAT_RECOVER: u32 = 0x0004;
     pub const FEATURE_INCOMPAT_JOURNAL_DEV: u32 = 0x0008;
     /// The orphan file may contain orphaned inodes.
     pub const FEATURE_RO_COMPAT_ORPHAN_PRESENT: u32 = 0x0001_0000;
+    pub const FEATURE_RO_COMPAT_SPARSE_SUPER: u32 = 0x0001;
     pub const FEATURE_RO_COMPAT_METADATA_CSUM: u32 = 0x0400;
 
     pub fn check_magic(&self) -> bool {
@@ -178,6 +181,14 @@ impl SuperBlock {
 
     pub fn journal_inode_number(&self) -> u32 {
         self.journal_inode_number
+    }
+
+    pub fn reserved_gdt_blocks(&self) -> u16 {
+        self.s_reserved_gdt_blocks
+    }
+
+    pub fn backup_block_groups(&self) -> [u32; 2] {
+        self.backup_bgs
     }
 
     pub fn journal_device(&self) -> u32 {
@@ -349,6 +360,25 @@ impl SuperBlock {
         } else {
             self.features_read_only &= !feature;
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_compatible_feature(&mut self, feature: u32, enabled: bool) {
+        if enabled {
+            self.features_compatible |= feature;
+        } else {
+            self.features_compatible &= !feature;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_backup_block_groups(&mut self, groups: [u32; 2]) {
+        self.backup_bgs = groups;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_reserved_gdt_blocks(&mut self, blocks: u16) {
+        self.s_reserved_gdt_blocks = blocks;
     }
 }
 

--- a/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
@@ -119,6 +119,9 @@ impl SuperBlock {
     pub const FEATURE_COMPAT_ORPHAN_FILE: u32 = 0x1000;
     pub const FEATURE_INCOMPAT_RECOVER: u32 = 0x0004;
     pub const FEATURE_INCOMPAT_JOURNAL_DEV: u32 = 0x0008;
+    /// The orphan file may contain orphaned inodes.
+    pub const FEATURE_RO_COMPAT_ORPHAN_PRESENT: u32 = 0x0001_0000;
+    pub const FEATURE_RO_COMPAT_METADATA_CSUM: u32 = 0x0400;
 
     pub fn check_magic(&self) -> bool {
         self.magic == Self::SB_MAGIC
@@ -126,6 +129,11 @@ impl SuperBlock {
 
     pub fn first_data_block(&self) -> u32 {
         self.first_data_block
+    }
+
+    /// First inode number available for normal (non-reserved) allocation.
+    pub fn first_inode(&self) -> u32 {
+        self.first_inode
     }
 
     pub fn free_inodes_count(&self) -> u32 {
@@ -156,6 +164,10 @@ impl SuperBlock {
         self.features_incompatible & feature != 0
     }
 
+    pub fn has_read_only_compatible_feature(&self, feature: u32) -> bool {
+        self.features_read_only & feature != 0
+    }
+
     pub fn set_incompatible_feature(&mut self, feature: u32, enabled: bool) {
         if enabled {
             self.features_incompatible |= feature;
@@ -174,6 +186,18 @@ impl SuperBlock {
 
     pub fn journal_uuid(&self) -> [u8; 16] {
         self.journal_uuid
+    }
+
+    /// Head inode number of the legacy on-disk orphan list, or zero.
+    pub fn last_orphan(&self) -> u32 {
+        self.last_orphan
+    }
+
+    /// Set the head inode number of the legacy on-disk orphan list.
+    ///
+    /// The caller must recompute the superblock checksum before persisting it.
+    pub fn set_last_orphan(&mut self, inode: u32) {
+        self.last_orphan = inode;
     }
 
     /// Total number of inodes.
@@ -225,12 +249,21 @@ impl SuperBlock {
 
     pub fn inode_count_in_group(&self, bgid: u32) -> u32 {
         let bg_count = self.block_group_count();
-        if bgid < bg_count {
+        if bgid >= bg_count {
+            0
+        } else if bgid + 1 < bg_count {
             self.inodes_per_group
         } else {
-            // Last group
-            self.inode_count - (bg_count - 1) * self.inodes_per_group
+            self.inode_count
+                .saturating_sub((bg_count - 1).saturating_mul(self.inodes_per_group))
         }
+    }
+
+    /// Number of allocation clusters represented by a block bitmap.  The
+    /// on-disk field historically named fragments-per-group is
+    /// s_clusters_per_group in ext4.
+    pub fn clusters_per_group(&self) -> u32 {
+        self.frags_per_group
     }
 
     pub fn set_free_inodes_count(&mut self, count: u32) {
@@ -276,5 +309,73 @@ impl SuperBlock {
         let off = core::mem::offset_of!(SuperBlock, checksum);
         let bytes = self.to_bytes();
         self.checksum = crc32(CRC32_INIT, &bytes[..off]);
+    }
+
+    pub fn verify_checksum(&self) -> bool {
+        let expected = self.checksum;
+        let mut copy = *self;
+        copy.set_checksum();
+        copy.checksum == expected
+    }
+
+    pub fn has_supported_checksum_type(&self) -> bool {
+        self.checksum_type == 1
+    }
+
+    #[cfg(test)]
+    pub(crate) fn validation_fixture() -> Self {
+        let mut sb: Self = unsafe { core::mem::zeroed() };
+        sb.magic = Self::SB_MAGIC;
+        sb.block_count_lo = 1024;
+        sb.blocks_per_group = 1024;
+        sb.frags_per_group = 1024;
+        sb.inode_count = 256;
+        sb.inodes_per_group = 256;
+        sb.first_inode = 11;
+        sb.log_block_size = 2;
+        sb.log_cluster_size = 2;
+        sb.inode_size = 256;
+        sb.desc_size = 64;
+        sb.features_read_only = Self::FEATURE_RO_COMPAT_METADATA_CSUM;
+        sb.checksum_type = 1;
+        sb.set_checksum();
+        sb
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orphan_fields_and_feature_accessors_roundtrip() {
+        // Every bit pattern of SuperBlock's integer/byte fields is valid.
+        let mut sb: SuperBlock = unsafe { core::mem::zeroed() };
+        sb.first_inode = 11;
+        sb.features_read_only = SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT;
+
+        assert_eq!(sb.first_inode(), 11);
+        assert!(sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT));
+        assert_eq!(sb.last_orphan(), 0);
+
+        sb.set_last_orphan(42);
+        assert_eq!(sb.last_orphan(), 42);
+    }
+
+    #[test]
+    fn final_group_uses_actual_inode_mutation_bound() {
+        // Every bit pattern of SuperBlock's integer/byte fields is valid.
+        let mut sb: SuperBlock = unsafe { core::mem::zeroed() };
+        sb.block_count_lo = 24;
+        sb.first_data_block = 0;
+        sb.blocks_per_group = 8;
+        sb.inodes_per_group = 8;
+        sb.inode_count = 20;
+
+        assert_eq!(sb.block_group_count(), 3);
+        assert_eq!(sb.inode_count_in_group(0), 8);
+        assert_eq!(sb.inode_count_in_group(1), 8);
+        assert_eq!(sb.inode_count_in_group(2), 4);
+        assert_eq!(sb.inode_count_in_group(3), 0);
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
@@ -341,6 +341,15 @@ impl SuperBlock {
         sb.set_checksum();
         sb
     }
+
+    #[cfg(test)]
+    pub(crate) fn set_read_only_compatible_feature(&mut self, feature: u32, enabled: bool) {
+        if enabled {
+            self.features_read_only |= feature;
+        } else {
+            self.features_read_only &= !feature;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
@@ -8,7 +8,7 @@
 //!
 //! We only implement the seperate data block storage of extended attributes.
 
-use super::{AsBytes, Block};
+use super::{crc::crc32, AsBytes, Block};
 use crate::constants::*;
 use crate::prelude::*;
 use core::cmp::Ordering;
@@ -34,7 +34,7 @@ pub struct XattrHeader {
 unsafe impl AsBytes for XattrHeader {}
 
 impl XattrHeader {
-    const XATTR_MAGIC: u32 = 0xEA020000;
+    pub const XATTR_MAGIC: u32 = 0xEA020000;
 
     pub fn new() -> Self {
         XattrHeader {
@@ -46,6 +46,128 @@ impl XattrHeader {
             reserved: [0; 3],
         }
     }
+
+    pub fn magic(&self) -> u32 {
+        self.magic
+    }
+
+    pub fn refcount(&self) -> u32 {
+        self.refcount
+    }
+
+    pub fn set_refcount(&mut self, refcount: u32) {
+        self.refcount = refcount;
+    }
+
+    pub fn blocks(&self) -> u32 {
+        self.blocks
+    }
+
+    pub fn checksum(&self) -> u32 {
+        self.checksum
+    }
+
+    pub fn set_checksum(&mut self, checksum: u32) {
+        self.checksum = checksum;
+    }
+}
+
+/// Compute an ext4 external-xattr block checksum using the Linux 6.6 layout.
+/// `seed` is the filesystem metadata checksum seed (normally CRC32C(uuid)).
+pub fn xattr_block_checksum(seed: u32, block_id: PBlockId, block: &[u8]) -> Option<u32> {
+    if block.len() != BLOCK_SIZE {
+        return None;
+    }
+    let checksum_offset = core::mem::offset_of!(XattrHeader, checksum);
+    let mut checksum = crc32(seed, &block_id.to_le_bytes());
+    checksum = crc32(checksum, &block[..checksum_offset]);
+    checksum = crc32(checksum, &[0; core::mem::size_of::<u32>()]);
+    Some(crc32(
+        checksum,
+        &block[checksum_offset + core::mem::size_of::<u32>()..],
+    ))
+}
+
+/// Validate the fixed header and entry table needed before releasing a block.
+/// Returns whether any value is stored in an EA inode, which this crate cannot
+/// reclaim yet.
+pub fn validate_xattr_block_for_release(block: &[u8]) -> Option<(XattrHeader, bool)> {
+    if block.len() != BLOCK_SIZE || block.len() < size_of::<XattrHeader>() {
+        return None;
+    }
+    let header = XattrHeader::from_bytes(&block[..size_of::<XattrHeader>()]);
+    if header.magic() != XattrHeader::XATTR_MAGIC || header.refcount() == 0 || header.blocks() != 1
+    {
+        return None;
+    }
+
+    let mut entry_start = size_of::<XattrHeader>();
+    let mut has_ea_inode = false;
+    let mut inline_values = Vec::new();
+    loop {
+        let terminator_end = entry_start.checked_add(size_of::<u32>())?;
+        if terminator_end > BLOCK_SIZE {
+            return None;
+        }
+        if block[entry_start..terminator_end] == [0; 4] {
+            break;
+        }
+        let fixed_end = entry_start.checked_add(size_of::<FakeXattrEntry>())?;
+        if fixed_end > BLOCK_SIZE {
+            return None;
+        }
+        let entry = FakeXattrEntry::from_bytes(
+            &block[entry_start..entry_start + size_of::<FakeXattrEntry>()],
+        );
+        let name_end = fixed_end.checked_add(entry.name_len as usize)?;
+        if name_end > BLOCK_SIZE || block[fixed_end..name_end].contains(&0) {
+            return None;
+        }
+        let entry_size = size_of::<FakeXattrEntry>()
+            .checked_add(entry.name_len as usize)?
+            .checked_add(3)?
+            & !3;
+        let next_entry = entry_start.checked_add(entry_size)?;
+        // `next_entry == BLOCK_SIZE` cannot leave the mandatory four-byte
+        // terminator. This mirrors Linux's `EXT4_XATTR_NEXT(e) >= end` check.
+        if next_entry
+            .checked_add(size_of::<u32>())
+            .is_none_or(|end| end > BLOCK_SIZE)
+        {
+            return None;
+        }
+        has_ea_inode |= entry.value_inum != 0;
+        if entry.value_inum != 0 {
+            if entry.value_size == 0 {
+                return None;
+            }
+        } else if entry.value_size != 0 {
+            let value_start = entry.value_offset as usize;
+            let value_size = entry.value_size as usize;
+            let padded_size = value_size.checked_add(3)? & !3;
+            let value_end = value_start.checked_add(padded_size)?;
+            if value_start & 3 != 0 || value_end > BLOCK_SIZE {
+                return None;
+            }
+            inline_values.push((value_start, value_end));
+        }
+        entry_start = next_entry;
+    }
+
+    let names_end = entry_start.checked_add(size_of::<u32>())?;
+    for &(start, end) in &inline_values {
+        if start < names_end || end > BLOCK_SIZE {
+            return None;
+        }
+    }
+    inline_values.sort_unstable_by_key(|range| range.0);
+    if inline_values
+        .windows(2)
+        .any(|ranges| ranges[1].0 < ranges[0].1)
+    {
+        return None;
+    }
+    Some((header, has_ea_inode))
 }
 
 /// Following the struct `XattrHeader` is an array of `XattrEntry`.
@@ -412,5 +534,123 @@ impl XattrBlock {
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod release_tests {
+    use super::*;
+
+    fn add_inline_entry(
+        bytes: &mut [u8; BLOCK_SIZE],
+        start: usize,
+        name: &[u8],
+        value_offset: u16,
+        value_size: u32,
+    ) -> usize {
+        let entry = FakeXattrEntry {
+            name_len: name.len() as u8,
+            name_index: 1,
+            value_offset,
+            value_inum: 0,
+            value_size,
+            hash: 0,
+        };
+        bytes[start..start + size_of::<FakeXattrEntry>()].copy_from_slice(entry.to_bytes());
+        let name_start = start + size_of::<FakeXattrEntry>();
+        bytes[name_start..name_start + name.len()].copy_from_slice(name);
+        start + (size_of::<FakeXattrEntry>() + name.len()).div_ceil(4) * 4
+    }
+
+    fn checksummed_block(block_id: PBlockId, refcount: u32) -> ([u8; BLOCK_SIZE], u32) {
+        let mut bytes = [0; BLOCK_SIZE];
+        let mut header = XattrHeader::new();
+        header.set_refcount(refcount);
+        bytes[..size_of::<XattrHeader>()].copy_from_slice(header.to_bytes());
+        let seed = 0x1234_5678;
+        let checksum = xattr_block_checksum(seed, block_id, &bytes).unwrap();
+        header.set_checksum(checksum);
+        bytes[..size_of::<XattrHeader>()].copy_from_slice(header.to_bytes());
+        (bytes, seed)
+    }
+
+    #[test]
+    fn release_validation_checks_fixed_header_fields() {
+        let (mut bytes, _) = checksummed_block(17, 2);
+        let (header, has_ea_inode) = validate_xattr_block_for_release(&bytes).unwrap();
+        assert_eq!(header.refcount(), 2);
+        assert!(!has_ea_inode);
+
+        bytes[..4].copy_from_slice(&0u32.to_le_bytes());
+        assert!(validate_xattr_block_for_release(&bytes).is_none());
+        let (mut bytes, _) = checksummed_block(17, 1);
+        bytes[8..12].copy_from_slice(&2u32.to_le_bytes());
+        assert!(validate_xattr_block_for_release(&bytes).is_none());
+    }
+
+    #[test]
+    fn checksum_binds_block_number_and_detects_damage() {
+        let (mut bytes, seed) = checksummed_block(17, 2);
+        let header = XattrHeader::from_bytes(&bytes[..size_of::<XattrHeader>()]);
+        assert_eq!(
+            xattr_block_checksum(seed, 17, &bytes).unwrap(),
+            header.checksum()
+        );
+        assert_ne!(
+            xattr_block_checksum(seed, 18, &bytes).unwrap(),
+            header.checksum()
+        );
+        bytes[BLOCK_SIZE - 1] ^= 1;
+        assert_ne!(
+            xattr_block_checksum(seed, 17, &bytes).unwrap(),
+            header.checksum()
+        );
+    }
+
+    #[test]
+    fn release_validation_reports_ea_inode_entries() {
+        let (mut bytes, seed) = checksummed_block(17, 1);
+        bytes[size_of::<XattrHeader>()] = 1; // name_len
+        bytes[size_of::<XattrHeader>() + 4..size_of::<XattrHeader>() + 8]
+            .copy_from_slice(&42u32.to_le_bytes()); // value_inum
+        bytes[size_of::<XattrHeader>() + 8..size_of::<XattrHeader>() + 12]
+            .copy_from_slice(&1u32.to_le_bytes()); // value_size
+        bytes[size_of::<XattrHeader>() + size_of::<FakeXattrEntry>()] = b'x';
+        let checksum = xattr_block_checksum(seed, 17, &bytes).unwrap();
+        bytes[core::mem::offset_of!(XattrHeader, checksum)
+            ..core::mem::offset_of!(XattrHeader, checksum) + 4]
+            .copy_from_slice(&checksum.to_le_bytes());
+        assert_eq!(validate_xattr_block_for_release(&bytes).unwrap().1, true);
+    }
+
+    #[test]
+    fn release_validation_rejects_malformed_layout_without_checksum_help() {
+        let (template, _) = checksummed_block(17, 1);
+        let first = size_of::<XattrHeader>();
+
+        let mut bytes = template;
+        let next = add_inline_entry(&mut bytes, first, b"a\0b", 4088, 4);
+        bytes[next..next + 4].fill(0);
+        assert!(validate_xattr_block_for_release(&bytes).is_none());
+
+        let mut bytes = template;
+        let next = add_inline_entry(&mut bytes, first, b"a", 33, 4);
+        bytes[next..next + 4].fill(0);
+        assert!(validate_xattr_block_for_release(&bytes).is_none());
+
+        let mut bytes = template;
+        let next = add_inline_entry(&mut bytes, first, b"a", first as u16, 4);
+        bytes[next..next + 4].fill(0);
+        assert!(validate_xattr_block_for_release(&bytes).is_none());
+
+        let mut bytes = template;
+        let second = add_inline_entry(&mut bytes, first, b"a", 4088, 8);
+        let end = add_inline_entry(&mut bytes, second, b"b", 4092, 4);
+        bytes[end..end + 4].fill(0);
+        assert!(validate_xattr_block_for_release(&bytes).is_none());
+
+        let mut bytes = template;
+        bytes[first..].fill(0xff);
+        assert!(validate_xattr_block_for_release(&bytes).is_none());
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
@@ -350,6 +350,26 @@ impl XattrBlock {
         self.0.write_offset_as(0, &header);
     }
 
+    /// Verify the Linux ext4 external-xattr block checksum.
+    pub fn verify_checksum(&self, seed: u32, block_id: PBlockId) -> bool {
+        let header: XattrHeader = self.0.read_offset_as(0);
+        xattr_block_checksum(seed, block_id, &*self.0.data)
+            .is_some_and(|checksum| checksum == header.checksum())
+    }
+
+    /// Recompute the Linux ext4 external-xattr block checksum after mutation.
+    pub fn update_checksum(&mut self, seed: u32, block_id: PBlockId) -> bool {
+        let mut header: XattrHeader = self.0.read_offset_as(0);
+        header.set_checksum(0);
+        self.0.write_offset_as(0, &header);
+        let Some(checksum) = xattr_block_checksum(seed, block_id, &*self.0.data) else {
+            return false;
+        };
+        header.set_checksum(checksum);
+        self.0.write_offset_as(0, &header);
+        true
+    }
+
     /// Get a xattr by name, return the value.
     pub fn get(&self, name: &str) -> Option<&[u8]> {
         let mut entry_start = size_of::<XattrHeader>();
@@ -605,6 +625,23 @@ mod release_tests {
             xattr_block_checksum(seed, 17, &bytes).unwrap(),
             header.checksum()
         );
+    }
+
+    #[test]
+    fn xattr_block_mutation_recomputes_linux_checksum() {
+        let seed = 0x1234_5678;
+        let block_id = 17;
+        let mut block = XattrBlock::new(Block::new(block_id, Box::new([0; BLOCK_SIZE])));
+        block.init();
+        assert!(block.insert("user.test", b"value"));
+        assert!(block.update_checksum(seed, block_id));
+        assert!(block.verify_checksum(seed, block_id));
+
+        assert!(block.remove("user.test"));
+        assert!(!block.verify_checksum(seed, block_id));
+        assert!(block.update_checksum(seed, block_id));
+        assert!(block.verify_checksum(seed, block_id));
+        assert!(!block.verify_checksum(seed, block_id + 1));
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/lib.rs
+++ b/kernel/crates/another_ext4/src/lib.rs
@@ -2,6 +2,9 @@
 #![no_std]
 #![deny(clippy::all)]
 
+#[cfg(test)]
+extern crate std;
+
 mod constants;
 mod error;
 mod ext4;

--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -1119,7 +1119,7 @@ pub fn devfs_init() -> Result<(), SystemError> {
                 .or_else(|_| dev_inode.mkdir("shm", InodeMode::from_bits_truncate(0o1777)));
             if let Ok(shm_inode) = shm_inode {
                 let flags = MountFlags::NOSUID | MountFlags::NODEV | MountFlags::NOEXEC;
-                match produce_fs("tmpfs", Some("mode=1777"), "tmpfs") {
+                match produce_fs("tmpfs", Some("mode=1777"), "tmpfs", flags) {
                     Ok(fs) => {
                         if let Err(e) = shm_inode.mount(fs, flags) {
                             if e != SystemError::EBUSY {

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -626,9 +626,9 @@ impl Ext4FileSystem {
         mount_options: Ext4MountOptions,
     ) -> Result<Arc<dyn FileSystem>, SystemError> {
         let raw_dev = mount_data.device_num();
-        // The JBD2 writer is not activated for production mounts until every
-        // metadata mutation path has been converted to explicit handles.
-        let fs = another_ext4::Ext4::load(mount_data.clone())?;
+        // Writable mounts recover the journal and the validated legacy orphan
+        // chain before this filesystem is published to the VFS.
+        let fs = another_ext4::Ext4::load_writable(mount_data.clone())?;
         let root_inode: Arc<LockedExt4Inode> =
             Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| {
                 LockedExt4Inode(

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -6,10 +6,11 @@ use crate::{
         vfs::{
             self,
             fcntl::AtFlags,
+            mount::MountFlags,
             utils::{user_path_at, DName},
             vcore::{generate_inode_id, try_find_gendisk},
-            EvictionEpoch, FileSystem, FileSystemMakerData, IndexNode, Magic, MountableFileSystem,
-            FSMAKER, VFS_MAX_FOLLOW_SYMLINK_TIMES,
+            EvictionEpoch, FileSystem, FileSystemMakerData, FsReconfigureRequest, IndexNode, Magic,
+            MountableFileSystem, FSMAKER, VFS_MAX_FOLLOW_SYMLINK_TIMES,
         },
     },
     libs::{
@@ -120,6 +121,19 @@ impl Default for Ext4MountOptions {
 }
 
 impl FileSystem for Ext4FileSystem {
+    fn reconfigure(&self, request: FsReconfigureRequest<'_>) -> Result<MountFlags, SystemError> {
+        if request.raw_data.is_some_and(|raw| !raw.trim().is_empty()) {
+            return Err(SystemError::EINVAL);
+        }
+        let requested_read_only = request.sb_flags.contains(MountFlags::RDONLY);
+        if request.sb_flags_mask.contains(MountFlags::RDONLY)
+            && requested_read_only != self._mount_options.read_only
+        {
+            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        }
+        Ok(request.sb_flags & request.sb_flags_mask)
+    }
+
     fn supports_reliable_flush(&self) -> bool {
         self.fs.supports_reliable_flush()
     }
@@ -729,6 +743,20 @@ impl Drop for Ext4InodeTombstone {
 }
 
 impl MountableFileSystem for Ext4FileSystem {
+    fn make_fs_with_flags(
+        data: Option<&dyn FileSystemMakerData>,
+        mount_flags: MountFlags,
+    ) -> Result<Arc<dyn FileSystem + 'static>, SystemError> {
+        let mount_data = data
+            .and_then(|d| d.as_any().downcast_ref::<Ext4MountData>())
+            .ok_or(SystemError::EINVAL)?;
+        let options = Ext4MountOptions {
+            read_only: mount_flags.contains(MountFlags::RDONLY),
+            ..Ext4MountOptions::default()
+        };
+        Self::from_gendisk_with_options(mount_data.gendisk.clone(), options)
+    }
+
     fn make_fs(
         data: Option<&dyn FileSystemMakerData>,
     ) -> Result<Arc<dyn FileSystem + 'static>, SystemError> {

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -545,9 +545,9 @@ impl Ext4FileSystem {
                         } else {
                             None
                         };
-                        fs.fs
-                            .commit_inode_metadata(inode_num, size, mtime)
-                            .map_err(SystemError::from)
+                        LockedExt4Inode::retry_metadata_contention(|| {
+                            fs.fs.commit_inode_metadata(inode_num, size, mtime)
+                        })
                     })
                 } else {
                     Err(SystemError::EIO)

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -106,6 +106,7 @@ pub enum Ext4ErrorsBehavior {
 pub struct Ext4MountOptions {
     pub dax: Option<Ext4DaxMode>,
     pub errors: Ext4ErrorsBehavior,
+    pub read_only: bool,
 }
 
 impl Default for Ext4MountOptions {
@@ -113,6 +114,7 @@ impl Default for Ext4MountOptions {
         Self {
             dax: None,
             errors: Ext4ErrorsBehavior::Continue,
+            read_only: false,
         }
     }
 }
@@ -189,6 +191,9 @@ impl FileSystem for Ext4FileSystem {
     }
 
     fn on_umount(&self) {
+        if self._mount_options.read_only {
+            return;
+        }
         if let Err(error) = self.fs.shutdown_writable() {
             log::error!("ext4: failed to mark journal clean on unmount: {:?}", error);
         }
@@ -628,7 +633,11 @@ impl Ext4FileSystem {
         let raw_dev = mount_data.device_num();
         // Writable mounts recover the journal and the validated legacy orphan
         // chain before this filesystem is published to the VFS.
-        let fs = another_ext4::Ext4::load_writable(mount_data.clone())?;
+        let fs = if mount_options.read_only {
+            another_ext4::Ext4::load(mount_data.clone())?
+        } else {
+            another_ext4::Ext4::load_writable(mount_data.clone())?
+        };
         let root_inode: Arc<LockedExt4Inode> =
             Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| {
                 LockedExt4Inode(

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -19,6 +19,8 @@ use crate::{
     },
     mm::{truncate::truncate_inode_pages, MemoryManagementArch},
     process::{ProcessManager, RawPid},
+    sched::sched_yield,
+    time::sleep::nanosleep,
     time::PosixTimeSpec,
 };
 use alloc::{
@@ -1370,6 +1372,38 @@ impl IndexNode for LockedExt4Inode {
 }
 
 impl LockedExt4Inode {
+    fn metadata_contention_backoff(attempt: usize) {
+        const YIELDS_BEFORE_SLEEP: usize = 64;
+        if attempt % YIELDS_BEFORE_SLEEP == 0 {
+            // Keep the current eviction epoch pending, but avoid a workqueue
+            // hot loop while an I/O-spanning metadata owner is asleep.
+            let _ = nanosleep(PosixTimeSpec::new(0, 1_000_000));
+        } else {
+            sched_yield();
+        }
+    }
+
+    fn reclaim_with_metadata_contention_retry(
+        fs: &another_ext4::Ext4,
+        mut handle: another_ext4::InodeReclaimHandle,
+    ) -> Result<(), (another_ext4::Ext4Error, another_ext4::InodeReclaimHandle)> {
+        let mut attempt = 1usize;
+        loop {
+            match fs.reclaim_inode(handle) {
+                Ok(()) => return Ok(()),
+                Err(failure) => {
+                    let (error, returned_handle) = failure.into_parts();
+                    if error.code() != another_ext4::ErrCode::EAGAIN {
+                        return Err((error, returned_handle));
+                    }
+                    handle = returned_handle;
+                    Self::metadata_contention_backoff(attempt);
+                    attempt = attempt.saturating_add(1);
+                }
+            }
+        }
+    }
+
     fn reclaim_temporary_inode(
         fs: &Arc<Ext4FileSystem>,
         parent_inode_num: u32,
@@ -1380,21 +1414,27 @@ impl LockedExt4Inode {
         let _link_mutation = lifecycle.lock_link_mutation();
         let tombstone = fs.begin_freeing(&inode)?;
         let _reuse = fs.begin_reclaim();
-        let handle = match fs.fs.unlink(parent_inode_num, name) {
-            Ok(Some(handle)) => handle,
-            Ok(None) => {
-                let error = SystemError::EIO;
-                let _ = fs.poison_freeing(tombstone, error.clone());
-                return Err(error);
-            }
-            Err(error) => {
-                let error = SystemError::from(error);
-                let _ = fs.poison_freeing(tombstone, error.clone());
-                return Err(error);
+        let mut attempt = 1usize;
+        let handle = loop {
+            match fs.fs.unlink(parent_inode_num, name) {
+                Ok(Some(handle)) => break handle,
+                Ok(None) => {
+                    let error = SystemError::EIO;
+                    let _ = fs.poison_freeing(tombstone, error.clone());
+                    return Err(error);
+                }
+                Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
+                    Self::metadata_contention_backoff(attempt);
+                    attempt = attempt.saturating_add(1);
+                }
+                Err(error) => {
+                    let error = SystemError::from(error);
+                    let _ = fs.poison_freeing(tombstone, error.clone());
+                    return Err(error);
+                }
             }
         };
-        if let Err(error) = fs.fs.reclaim_inode(handle) {
-            let (error, handle) = error.into_parts();
+        if let Err((error, handle)) = Self::reclaim_with_metadata_contention_retry(&fs.fs, handle) {
             *inode.6.lock() = Some(handle);
             let error = SystemError::from(error);
             let _ = fs.poison_freeing(tombstone, error.clone());
@@ -1706,13 +1746,12 @@ impl LockedExt4Inode {
                 return Err(SystemError::EIO);
             }
         };
-        match fs.fs.reclaim_inode(handle) {
+        match Self::reclaim_with_metadata_contention_retry(&fs.fs, handle) {
             Ok(()) => {
                 fs.complete_freeing(tombstone)?;
                 Ok(())
             }
-            Err(failure) => {
-                let (error, handle) = failure.into_parts();
+            Err((error, handle)) => {
                 *self.6.lock() = Some(handle);
                 let error = SystemError::from(error);
                 let _ = fs.poison_freeing(tombstone, error.clone());

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1139,7 +1139,9 @@ impl IndexNode for LockedExt4Inode {
         // RENAME_EXCHANGE: 原子交换两个文件/目录
         if flags.contains(RenameFlags::EXCHANGE) {
             // VFS 层已验证目标存在，直接调用 exchange
-            ext4.rename_exchange(src_inode_num, old_name, target_inode_num, new_name)?;
+            Self::retry_metadata_contention(|| {
+                ext4.rename_exchange(src_inode_num, old_name, target_inode_num, new_name)
+            })?;
 
             // 更新缓存：交换两个条目
             self.update_exchange_cache(
@@ -1235,14 +1237,16 @@ impl IndexNode for LockedExt4Inode {
                     continue;
                 }
                 let allocation = ext4_fs.begin_allocation()?;
-                let whiteout_num = ext4.mknod(
-                    src_inode_num,
-                    &candidate,
-                    another_ext4::InodeMode::CHARDEV
-                        | another_ext4::InodeMode::from_bits_retain(0o600),
-                    WHITEOUT_DEV.major().data(),
-                    WHITEOUT_DEV.minor(),
-                )?;
+                let whiteout_num = Self::retry_metadata_contention(|| {
+                    ext4.mknod(
+                        src_inode_num,
+                        &candidate,
+                        another_ext4::InodeMode::CHARDEV
+                            | another_ext4::InodeMode::from_bits_retain(0o600),
+                        WHITEOUT_DEV.major().data(),
+                        WHITEOUT_DEV.minor(),
+                    )
+                })?;
                 whiteout_inode = match ext4_fs.publish_allocated_inode(
                     whiteout_num,
                     DName::from(candidate.as_str()),
@@ -1254,15 +1258,16 @@ impl IndexNode for LockedExt4Inode {
                     Err(error) => {
                         drop(allocation);
                         let _reclaim = ext4_fs.begin_reclaim();
-                        let cleanup =
-                            ext4.unlink(src_inode_num, &candidate).and_then(
-                                |handle| match handle {
-                                    Some(handle) => ext4
-                                        .reclaim_inode(handle)
-                                        .map_err(|failure| failure.into_parts().0),
-                                    None => Ok(()),
-                                },
-                            );
+                        let cleanup = Self::retry_metadata_contention(|| {
+                            ext4.unlink(src_inode_num, &candidate)
+                        })
+                        .and_then(|handle| match handle {
+                            Some(handle) => {
+                                Self::reclaim_with_metadata_contention_retry(ext4, handle)
+                                    .map_err(|failure| SystemError::from(failure.0))
+                            }
+                            None => Ok(()),
+                        });
                         if cleanup.is_err() {
                             ext4_fs.fail_stop_lifecycle();
                             return Err(SystemError::EIO);
@@ -1277,44 +1282,41 @@ impl IndexNode for LockedExt4Inode {
                 return Err(SystemError::EEXIST);
             }
 
-            if let Err(err) =
+            if let Err(err) = Self::retry_metadata_contention(|| {
                 ext4.rename_exchange(src_inode_num, old_name, src_inode_num, &temp_name)
-            {
+            }) {
                 Self::reclaim_temporary_inode(
                     &ext4_fs,
                     src_inode_num,
                     &temp_name,
                     whiteout_inode.take().unwrap(),
                 )?;
-                return Err(err.into());
+                return Err(err);
             }
-            let rename_handle =
-                match ext4.rename(src_inode_num, &temp_name, target_inode_num, new_name) {
-                    Ok(handle) => handle,
-                    Err(err) => {
-                        let rename_error = SystemError::from(err);
-                        let rollback = ext4.rename_exchange(
-                            src_inode_num,
-                            old_name,
-                            src_inode_num,
-                            &temp_name,
-                        );
-                        if rollback.is_err() {
-                            let whiteout_tombstone = ext4_fs.begin_freeing(
-                                whiteout_inode.as_ref().expect("whiteout was published"),
-                            )?;
-                            let _ = ext4_fs.poison_freeing(whiteout_tombstone, SystemError::EIO);
-                            return Err(SystemError::EIO);
-                        }
-                        Self::reclaim_temporary_inode(
-                            &ext4_fs,
-                            src_inode_num,
-                            &temp_name,
-                            whiteout_inode.take().unwrap(),
+            let rename_handle = match Self::retry_metadata_contention(|| {
+                ext4.rename(src_inode_num, &temp_name, target_inode_num, new_name)
+            }) {
+                Ok(handle) => handle,
+                Err(rename_error) => {
+                    let rollback = Self::retry_metadata_contention(|| {
+                        ext4.rename_exchange(src_inode_num, old_name, src_inode_num, &temp_name)
+                    });
+                    if rollback.is_err() {
+                        let whiteout_tombstone = ext4_fs.begin_freeing(
+                            whiteout_inode.as_ref().expect("whiteout was published"),
                         )?;
-                        return Err(rename_error);
+                        let _ = ext4_fs.poison_freeing(whiteout_tombstone, SystemError::EIO);
+                        return Err(SystemError::EIO);
                     }
-                };
+                    Self::reclaim_temporary_inode(
+                        &ext4_fs,
+                        src_inode_num,
+                        &temp_name,
+                        whiteout_inode.take().unwrap(),
+                    )?;
+                    return Err(rename_error);
+                }
+            };
             if will_free {
                 let handle = rename_handle.ok_or(SystemError::EIO)?;
                 dst_inode
@@ -1335,7 +1337,9 @@ impl IndexNode for LockedExt4Inode {
                     attr.links <= 1
                 };
                 if !will_free {
-                    let _ = ext4.rename(src_inode_num, old_name, target_inode_num, new_name)?;
+                    let _ = Self::retry_metadata_contention(|| {
+                        ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
+                    })?;
                 } else {
                     if ext4.lookup(target_inode_num, new_name).ok() != dst_inode_num {
                         return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -1348,17 +1352,20 @@ impl IndexNode for LockedExt4Inode {
                             Err(error) => return Err(error.into()),
                         }
                     }
-                    let handle =
-                        match ext4.rename(src_inode_num, old_name, target_inode_num, new_name) {
-                            Ok(Some(handle)) => handle,
-                            Ok(None) => return Err(SystemError::EIO),
-                            Err(err) => return Err(err.into()),
-                        };
+                    let handle = match Self::retry_metadata_contention(|| {
+                        ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
+                    }) {
+                        Ok(Some(handle)) => handle,
+                        Ok(None) => return Err(SystemError::EIO),
+                        Err(err) => return Err(err),
+                    };
                     dst_inode.defer_reclaim(handle)?;
                 }
             } else {
                 // ext4 library now correctly handles atomic replace
-                let _ = ext4.rename(src_inode_num, old_name, target_inode_num, new_name)?;
+                let _ = Self::retry_metadata_contention(|| {
+                    ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
+                })?;
             }
         }
 

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -281,9 +281,9 @@ impl IndexNode for LockedExt4Inode {
         let ext4 = &fs.fs;
 
         let id = if file_type == vfs::FileType::Dir {
-            ext4.mkdir(guard.inner_inode_num, name, file_mode)?
+            Self::retry_metadata_contention(|| ext4.mkdir(guard.inner_inode_num, name, file_mode))?
         } else {
-            ext4.create(guard.inner_inode_num, name, file_mode)?
+            Self::retry_metadata_contention(|| ext4.create(guard.inner_inode_num, name, file_mode))?
         };
 
         let dname = DName::from(name);
@@ -427,15 +427,15 @@ impl IndexNode for LockedExt4Inode {
                 log::warn!("Failed to get current time, using 0");
                 0
             });
-            fs.fs
-                .prepare_buffered_write(
+            Self::retry_metadata_contention(|| {
+                fs.fs.prepare_buffered_write(
                     inode_num,
                     alloc_start,
                     alloc_len,
                     new_end as u64,
                     Some(time),
                 )
-                .map_err(SystemError::from)?;
+            })?;
 
             // 写入范围的磁盘块已就绪，现在安全写入 page cache。
             let write_len = PageCache::write(&page_cache, offset, buf)?;
@@ -475,10 +475,9 @@ impl IndexNode for LockedExt4Inode {
             // which overwrites the inode's block_count/extent tree with a stale
             // snapshot, causing setattr to re-allocate blocks endlessly until
             // the extent tree overflows (entries > max_entries → EIO).
-            FileType::RegularFile => fs
-                .fs
-                .write_data_only(inode_num, offset, buf)
-                .map_err(From::from),
+            FileType::RegularFile => {
+                Self::retry_metadata_contention(|| fs.fs.write_data_only(inode_num, offset, buf))
+            }
             _ => Err(SystemError::EINVAL),
         }
     }
@@ -773,21 +772,23 @@ impl IndexNode for LockedExt4Inode {
             (guard.concret_fs(), guard.inner_inode_num)
         };
         let ext4 = &fs.fs;
-        ext4.setattr(
-            inode_num,
-            another_ext4::SetAttr {
-                mode: Some(another_ext4::InodeMode::from_bits_truncate(
-                    mode.bits() as u16
-                )),
-                uid: Some(metadata.uid as u32),
-                gid: Some(metadata.gid as u32),
-                size: Some(metadata.size as u64),
-                atime: Some(to_ext4_time(&metadata.atime)),
-                mtime: Some(to_ext4_time(&metadata.mtime)),
-                ctime: Some(to_ext4_time(&metadata.ctime)),
-                crtime: Some(to_ext4_time(&metadata.btime)),
-            },
-        )?;
+        Self::retry_metadata_contention(|| {
+            ext4.setattr(
+                inode_num,
+                another_ext4::SetAttr {
+                    mode: Some(another_ext4::InodeMode::from_bits_truncate(
+                        mode.bits() as u16
+                    )),
+                    uid: Some(metadata.uid as u32),
+                    gid: Some(metadata.gid as u32),
+                    size: Some(metadata.size as u64),
+                    atime: Some(to_ext4_time(&metadata.atime)),
+                    mtime: Some(to_ext4_time(&metadata.mtime)),
+                    ctime: Some(to_ext4_time(&metadata.ctime)),
+                    crtime: Some(to_ext4_time(&metadata.btime)),
+                },
+            )
+        })?;
         {
             let mut guard = self.0.lock();
             guard.cached_file_size = Some(metadata.size as u64);
@@ -820,20 +821,21 @@ impl IndexNode for LockedExt4Inode {
             let _io_guard = self.1.lock();
             let ext4 = &fs.fs;
             // 仅调整文件大小，其他属性保持不变
-            ext4.setattr(
-                inode_num,
-                another_ext4::SetAttr {
-                    mode: None,
-                    uid: None,
-                    gid: None,
-                    size: Some(len as u64),
-                    atime: None,
-                    mtime: None,
-                    ctime: None,
-                    crtime: None,
-                },
-            )
-            .map_err(SystemError::from)?;
+            Self::retry_metadata_contention(|| {
+                ext4.setattr(
+                    inode_num,
+                    another_ext4::SetAttr {
+                        mode: None,
+                        uid: None,
+                        gid: None,
+                        size: Some(len as u64),
+                        atime: None,
+                        mtime: None,
+                        ctime: None,
+                        crtime: None,
+                    },
+                )
+            })?;
             // 更新缓存的文件大小
             {
                 let mut guard = self.0.lock();
@@ -970,13 +972,15 @@ impl IndexNode for LockedExt4Inode {
             return Err(SystemError::EPERM);
         }
 
-        ext4.setxattr_with_flags(
-            inode_num,
-            name,
-            value,
-            flags.contains(XattrFlags::CREATE),
-            flags.contains(XattrFlags::REPLACE),
-        )?;
+        Self::retry_metadata_contention(|| {
+            ext4.setxattr_with_flags(
+                inode_num,
+                name,
+                value,
+                flags.contains(XattrFlags::CREATE),
+                flags.contains(XattrFlags::REPLACE),
+            )
+        })?;
 
         Ok(0)
     }
@@ -1023,7 +1027,7 @@ impl IndexNode for LockedExt4Inode {
             return Err(SystemError::EPERM);
         }
 
-        ext4.removexattr(inode_num, name)?;
+        Self::retry_metadata_contention(|| ext4.removexattr(inode_num, name))?;
         Ok(0)
     }
 
@@ -1059,16 +1063,18 @@ impl IndexNode for LockedExt4Inode {
             vfs::FileType::CharDevice | vfs::FileType::BlockDevice
         ) {
             // Character/block device: use mknod to store device number in i_block
-            ext4.mknod(
-                inode_num,
-                filename,
-                file_mode,
-                dev_t.major().data(),
-                dev_t.minor(),
-            )?
+            Self::retry_metadata_contention(|| {
+                ext4.mknod(
+                    inode_num,
+                    filename,
+                    file_mode,
+                    dev_t.major().data(),
+                    dev_t.minor(),
+                )
+            })?
         } else {
             // FIFO, Socket, etc.: use regular create (no device number needed)
-            ext4.create(inode_num, filename, file_mode)?
+            Self::retry_metadata_contention(|| ext4.create(inode_num, filename, file_mode))?
         };
 
         // Wrap as VFS inode and cache
@@ -1397,7 +1403,7 @@ impl LockedExt4Inode {
         }
     }
 
-    fn retry_metadata_contention<T>(
+    pub(super) fn retry_metadata_contention<T>(
         mut operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
     ) -> Result<T, SystemError> {
         let mut attempt = 1usize;
@@ -1835,9 +1841,7 @@ impl LockedExt4Inode {
         } else {
             None
         };
-        fs.fs
-            .commit_inode_metadata(inode_num, size, mtime)
-            .map_err(SystemError::from)?;
+        Self::retry_metadata_contention(|| fs.fs.commit_inode_metadata(inode_num, size, mtime))?;
 
         let mut guard = self.0.lock();
         if size_dirty && guard.cached_file_size == cached_size {

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -585,7 +585,13 @@ impl IndexNode for LockedExt4Inode {
             return Err(SystemError::EEXIST);
         }
 
-        ext4.link(other_inode_num, inode_num, name)?;
+        Self::retry_metadata_contention(|| ext4.link(other_inode_num, inode_num, name))?;
+        if other_attr.links == 0 {
+            // The orphan-del transaction made this inode live again. Discard
+            // the one-shot capability published by its previous final unlink
+            // before the fd retention that enabled AT_EMPTY_PATH can vanish.
+            other_arc.cancel_deferred_reclaim_after_relink();
+        }
 
         let dname = DName::from(name);
         guard.children.insert(dname, other_arc);
@@ -625,7 +631,8 @@ impl IndexNode for LockedExt4Inode {
             if ext4.lookup(inode_num, name)? != target_num {
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
-            if let Some(handle) = ext4.unlink(inode_num, name)? {
+            if let Some(handle) = Self::retry_metadata_contention(|| ext4.unlink(inode_num, name))?
+            {
                 fs.fs
                     .reclaim_inode(handle)
                     .map_err(|failure| SystemError::from(failure.into_parts().0))?;
@@ -639,7 +646,7 @@ impl IndexNode for LockedExt4Inode {
             Ok(_) => return Err(SystemError::EAGAIN_OR_EWOULDBLOCK),
             Err(error) => return Err(error.into()),
         }
-        let handle = match ext4.unlink(inode_num, name).map_err(SystemError::from) {
+        let handle = match Self::retry_metadata_contention(|| ext4.unlink(inode_num, name)) {
             Ok(Some(handle)) => handle,
             Ok(None) => return Err(SystemError::EIO),
             Err(error) => return Err(error),
@@ -907,7 +914,7 @@ impl IndexNode for LockedExt4Inode {
             Ok(_) => return Err(SystemError::ENOTEMPTY),
             Err(error) => return Err(error.into()),
         }
-        let handle = match concret_fs.rmdir(inode_num, name).map_err(SystemError::from) {
+        let handle = match Self::retry_metadata_contention(|| concret_fs.rmdir(inode_num, name)) {
             Ok(Some(handle)) => handle,
             Ok(None) => return Err(SystemError::EIO),
             Err(error) => return Err(error),
@@ -1383,6 +1390,22 @@ impl LockedExt4Inode {
         }
     }
 
+    fn retry_metadata_contention<T>(
+        mut operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
+    ) -> Result<T, SystemError> {
+        let mut attempt = 1usize;
+        loop {
+            match operation() {
+                Ok(value) => return Ok(value),
+                Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
+                    Self::metadata_contention_backoff(attempt);
+                    attempt = attempt.saturating_add(1);
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
     fn reclaim_with_metadata_contention_retry(
         fs: &another_ext4::Ext4,
         mut handle: another_ext4::InodeReclaimHandle,
@@ -1694,6 +1717,13 @@ impl LockedExt4Inode {
         self.try_schedule_deferred_eviction()
     }
 
+    fn cancel_deferred_reclaim_after_relink(&self) {
+        // Dropping the capability is the in-memory counterpart of the durable
+        // orphan-del transaction. A queued eviction, if any, observes None and
+        // cleanly aborts instead of treating cancellation as corruption.
+        let _ = self.6.lock().take();
+    }
+
     fn try_schedule_deferred_eviction(self: &Arc<Self>) -> Result<(), SystemError> {
         if self.6.lock().is_none() {
             return Ok(());
@@ -1732,20 +1762,24 @@ impl LockedExt4Inode {
                 return Err(error);
             }
         };
+        // Serialize the final capability decision with final unlink/relink.
+        // `begin_freeing` first closes operation admission and drains existing
+        // operations, so this ordering cannot deadlock a relink that already
+        // owns the link-mutation lock.
+        let _link_mutation = self.lifecycle().lock_link_mutation();
+        let handle = match self.6.lock().take() {
+            Some(handle) => handle,
+            None => {
+                fs.abort_freeing(tombstone)?;
+                *self.7.lock() = false;
+                self.5.abort_freeing();
+                return Ok(());
+            }
+        };
         let _reuse = fs.begin_reclaim();
         if let Some(page_cache) = self.page_cache() {
             truncate_inode_pages(page_cache, 0);
         }
-        let handle = match self.6.lock().take() {
-            Some(handle) => handle,
-            None => {
-                let _ = fs.abort_freeing(tombstone);
-                *self.7.lock() = false;
-                self.5.abort_freeing();
-                fs.fail_stop_lifecycle();
-                return Err(SystemError::EIO);
-            }
-        };
         match Self::reclaim_with_metadata_contention_retry(&fs.fs, handle) {
             Ok(()) => {
                 fs.complete_freeing(tombstone)?;
@@ -1862,6 +1896,20 @@ pub(crate) fn run_lifecycle_selftests() -> String {
     append(
         "poison_is_observable",
         lifecycle.begin_operation().err() == Some(SystemError::EIO),
+    );
+
+    let mut attempts = 0usize;
+    let retry_result = LockedExt4Inode::retry_metadata_contention(|| {
+        attempts += 1;
+        if attempts < 3 {
+            Err(another_ext4::Ext4Error::new(another_ext4::ErrCode::EAGAIN))
+        } else {
+            Ok(())
+        }
+    });
+    append(
+        "metadata_contention_is_internal",
+        retry_result.is_ok() && attempts == 3,
     );
 
     if failures == 0 {

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1374,7 +1374,7 @@ impl IndexNode for LockedExt4Inode {
 impl LockedExt4Inode {
     fn metadata_contention_backoff(attempt: usize) {
         const YIELDS_BEFORE_SLEEP: usize = 64;
-        if attempt % YIELDS_BEFORE_SLEEP == 0 {
+        if attempt.is_multiple_of(YIELDS_BEFORE_SLEEP) {
             // Keep the current eviction epoch pending, but avoid a workqueue
             // hot loop while an I/O-spanning metadata owner is asleep.
             let _ = nanosleep(PosixTimeSpec::new(0, 1_000_000));

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -1931,6 +1931,13 @@ pub trait MountableFileSystem: FileSystem {
         log::error!("This filesystem does not support make_fs");
         Err(SystemError::ENOSYS)
     }
+
+    fn make_fs_with_flags(
+        data: Option<&dyn FileSystemMakerData>,
+        _mount_flags: MountFlags,
+    ) -> Result<Arc<dyn FileSystem + 'static>, SystemError> {
+        Self::make_fs(data)
+    }
 }
 
 /// # 注册一个可以被挂载文件系统
@@ -1947,8 +1954,9 @@ macro_rules! register_mountable_fs {
         impl $fs {
             fn make_fs_bridge(
                 data: Option<&dyn FileSystemMakerData>,
+                mount_flags: $crate::filesystem::vfs::mount::MountFlags,
             ) -> Result<Arc<dyn FileSystem>, SystemError> {
-                <$fs as MountableFileSystem>::make_fs(data)
+                <$fs as MountableFileSystem>::make_fs_with_flags(data, mount_flags)
             }
 
             fn make_mount_data_bridge(
@@ -1966,6 +1974,7 @@ macro_rules! register_mountable_fs {
                 &($fs::make_fs_bridge
                     as fn(
                         Option<&dyn FileSystemMakerData>,
+                        $crate::filesystem::vfs::mount::MountFlags,
                     ) -> Result<Arc<dyn FileSystem + 'static>, SystemError>),
                 &($fs::make_mount_data_bridge
                     as fn(
@@ -2032,8 +2041,9 @@ impl FileSystemMaker {
     pub fn build(
         &self,
         data: Option<&dyn FileSystemMakerData>,
+        mount_flags: MountFlags,
     ) -> Result<Arc<dyn FileSystem>, SystemError> {
-        (self.maker)(data)
+        (self.maker)(data, mount_flags)
     }
 }
 
@@ -2041,8 +2051,10 @@ pub trait FileSystemMakerData: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 }
 
-pub type FSMakerFunction =
-    fn(data: Option<&dyn FileSystemMakerData>) -> Result<Arc<dyn FileSystem>, SystemError>;
+pub type FSMakerFunction = fn(
+    data: Option<&dyn FileSystemMakerData>,
+    mount_flags: MountFlags,
+) -> Result<Arc<dyn FileSystem>, SystemError>;
 pub type MountDataBuilder =
     fn(
         raw_data: Option<&str>,
@@ -2076,6 +2088,7 @@ pub fn produce_fs(
     filesystem: &str,
     data: Option<&str>,
     source: &str,
+    mount_flags: MountFlags,
 ) -> Result<Arc<dyn FileSystem>, SystemError> {
     let canonical_filesystem = if filesystem.starts_with("fuse.") {
         "fuse"
@@ -2087,7 +2100,7 @@ pub fn produce_fs(
         Some(maker) => {
             let mount_data = (maker.builder)(data, source)?;
             let mount_data_ref = mount_data.as_ref().map(|arc| arc.as_ref());
-            maker.build(mount_data_ref)
+            maker.build(mount_data_ref, mount_flags)
         }
         None => {
             log::error!("mismatch filesystem type : {}", filesystem);

--- a/kernel/src/filesystem/vfs/syscall/sys_mount.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mount.rs
@@ -511,7 +511,7 @@ fn do_new_mount(
 ) -> Result<Arc<MountFS>, SystemError> {
     let fs_type_str = filesystemtype.ok_or(SystemError::EINVAL)?;
     let source = source.ok_or(SystemError::EINVAL)?;
-    let fs = produce_fs(&fs_type_str, data.as_deref(), &source).inspect_err(|e| {
+    let fs = produce_fs(&fs_type_str, data.as_deref(), &source, mount_flags).inspect_err(|e| {
         log::warn!("Failed to produce filesystem: {:?}", e);
     })?;
 

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -397,10 +397,11 @@ pub fn mount_root_fs() -> Result<(), SystemError> {
 
     let init_rootfs = |kind: RootFsKind| -> Result<Arc<dyn FileSystem>, SystemError> {
         match kind {
-            RootFsKind::Ext4 => Ext4FileSystem::from_gendisk_with_options(
-                gendisk.clone(),
-                root_options.ext4_options,
-            ),
+            RootFsKind::Ext4 => {
+                let mut ext4_options = root_options.ext4_options;
+                ext4_options.read_only = root_options.mount_flags.contains(MountFlags::RDONLY);
+                Ext4FileSystem::from_gendisk_with_options(gendisk.clone(), ext4_options)
+            }
             RootFsKind::Fat => {
                 if root_options.has_ext4_specific_options() {
                     error!("rootfs: ext4-specific rootflags cannot be used with FAT rootfs");

--- a/user/apps/tests/dunitest/Makefile
+++ b/user/apps/tests/dunitest/Makefile
@@ -63,7 +63,15 @@ build-suites: $(TEST_BINS) $(EXT4_FIXTURE)
 $(EXT4_FIXTURE):
 	@mkdir -p "$(dir $@)"
 	@truncate -s 8M "$@"
-	@mke2fs -q -t ext4 -F -O ^orphan_file "$@"
+	@output=$$(mke2fs -q -t ext4 -F -O ^orphan_file "$@" 2>&1) || { \
+		case "$$output" in \
+			*"Invalid filesystem option set: ^orphan_file"*) \
+				rm -f "$@"; \
+				truncate -s 8M "$@"; \
+				mke2fs -q -t ext4 -F "$@" ;; \
+			*) printf '%s\n' "$$output" >&2; exit 1 ;; \
+		esac; \
+	}
 
 $(GTEST_OBJ): $(GTEST_SRC)
 	@mkdir -p "$(dir $@)"

--- a/user/apps/tests/dunitest/Makefile
+++ b/user/apps/tests/dunitest/Makefile
@@ -63,7 +63,7 @@ build-suites: $(TEST_BINS) $(EXT4_FIXTURE)
 $(EXT4_FIXTURE):
 	@mkdir -p "$(dir $@)"
 	@truncate -s 8M "$@"
-	@mke2fs -q -t ext4 -F "$@"
+	@mke2fs -q -t ext4 -F -O ^orphan_file "$@"
 
 $(GTEST_OBJ): $(GTEST_SRC)
 	@mkdir -p "$(dir $@)"

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -226,6 +226,34 @@ TEST(Ext4InodeIdentity, OpenFileSurvivesFinalUnlink) {
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
 }
 
+TEST(Ext4InodeIdentity, EmptyPathRelinkCancelsDeferredReclaim) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string old_path = fs.mount_point() + "/relink_source";
+    const std::string new_path = fs.mount_point() + "/relink_target";
+    int fd = open(old_path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    constexpr char kPayload[] = "relinked-data";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(fd, kPayload, sizeof(kPayload) - 1));
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(old_path.c_str())) << strerror(errno);
+
+    constexpr int kAtEmptyPath = 0x1000;
+    ASSERT_EQ(0, linkat(fd, "", AT_FDCWD, new_path.c_str(), kAtEmptyPath))
+        << strerror(errno);
+    struct stat linked = {};
+    ASSERT_EQ(0, stat(new_path.c_str(), &linked)) << strerror(errno);
+    EXPECT_EQ(1u, linked.st_nlink);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    EXPECT_EQ(std::string(kPayload, sizeof(kPayload) - 1),
+              ReadFile(new_path.c_str()));
+    ASSERT_EQ(0, unlink(new_path.c_str())) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
 TEST(Ext4InodeIdentity, CurrentDirectorySurvivesRmdir) {
     LoopExt4 fs;
     ASSERT_NO_FATAL_FAILURE(fs.SetUp());


### PR DESCRIPTION
## Summary

- implement Linux-compatible legacy ext4 zero-link orphan add/delete and writable-mount cleanup
- journal namespace/link-count/orphan updates and perform bounded restartable extent/xattr/inode reclaim
- validate replayed metadata, system block ownership, checksums, and indexed-directory layouts before mutation
- switch production ext4 mounts to the validated writable recovery path

Closes #2052

## Validation

- `cargo test -p another_ext4` (93 passed)
- full `another_ext4/ext4_test` suite, including crash-remount orphan cleanup, rename replacement, full-directory relink, 600-file stress, and final e2fsck
- `make kernel ROOTFS_MANIFEST=ubuntu2404`
- Ubuntu 24.04 ext4 rootfs boot/mount and `/bin/bash` ELF load
- forced-QEMU orphan crash/reboot recovery followed by clean `e2fsck -fn`
- final multi-agent adversarial review

## Scope

- writable mounts explicitly reject `orphan_file`/`ORPHAN_PRESENT` formats until supported
- interrupted linked truncate recovery remains out of scope and fails closed
- this change provides crash consistency for the zero-link orphan paths in #2052; it does not claim to transactionally convert every unrelated rename variant