### PR TITLE
fix(mm): align mlock population with Linux semantics

### DIFF
--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -117,6 +117,24 @@ bitflags! {
     }
 }
 
+impl VmFlags {
+    /// VMAs which Linux mlock_fixup() leaves unlocked and unaccounted.
+    #[inline]
+    pub fn is_mlock_flag_unsupported(self) -> bool {
+        self.intersects(Self::VM_IO | Self::VM_DONTEXPAND | Self::VM_PFNMAP | Self::VM_HUGETLB)
+    }
+
+    /// VMAs which cannot be handled by DragonOS' ordinary prefault path.
+    ///
+    /// This deliberately differs from `is_mlock_flag_unsupported`: Linux
+    /// __mm_populate() only skips VM_IO/VM_PFNMAP, while DragonOS must also
+    /// skip hugetlb until its fault path is implemented.
+    #[inline]
+    pub fn is_mlock_population_unsupported(self) -> bool {
+        self.intersects(Self::VM_IO | Self::VM_PFNMAP | Self::VM_HUGETLB)
+    }
+}
+
 impl core::ops::Index<VmFlags> for [usize] {
     type Output = usize;
 

--- a/kernel/src/mm/syscall/sys_mlock.rs
+++ b/kernel/src/mm/syscall/sys_mlock.rs
@@ -50,16 +50,16 @@ pub(super) fn do_mlock(
     len: usize,
     new_flags: VmFlags,
 ) -> Result<usize, SystemError> {
+    if !can_do_mlock() {
+        return Err(SystemError::EPERM);
+    }
+
     let (start, len) = normalize_mlock_range(start, len)?;
     if len == 0 {
         return Ok(0);
     }
     if access_ok(start, len).is_err() {
         return Err(SystemError::EINVAL);
-    }
-
-    if !can_do_mlock() {
-        return Err(SystemError::EPERM);
     }
 
     let vm = AddressSpace::current()?;
@@ -75,8 +75,12 @@ pub(super) fn do_mlock(
         let new_pages = guard.count_unlocked_pages_for_mlock(start, len)?;
         check_mlock_rlimit(guard.locked_vm, new_pages)?;
 
-        match guard.apply_vma_lock_flags_collect(start, len, new_flags, false) {
-            Ok(()) => return Ok(0),
+        match guard.apply_vma_lock_flags_collect(start, len, new_flags) {
+            Ok(()) => {
+                drop(guard);
+                vm.populate_mlock_range_post_commit(start, len)?;
+                return Ok(0);
+            }
             Err(failure) => {
                 drop(guard);
                 crate::mm::ucontext::InnerAddressSpace::notify_close_notifications(

--- a/kernel/src/mm/syscall/sys_mlock2.rs
+++ b/kernel/src/mm/syscall/sys_mlock2.rs
@@ -55,16 +55,16 @@ fn do_mlock2(start: VirtAddr, len: usize, flags: usize) -> Result<usize, SystemE
         return Err(SystemError::EINVAL);
     }
 
+    if !can_do_mlock() {
+        return Err(SystemError::EPERM);
+    }
+
     let (start, len) = normalize_mlock_range(start, len)?;
     if len == 0 {
         return Ok(0);
     }
     if access_ok(start, len).is_err() {
         return Err(SystemError::EINVAL);
-    }
-
-    if !can_do_mlock() {
-        return Err(SystemError::EPERM);
     }
 
     let vm = AddressSpace::current()?;
@@ -84,8 +84,12 @@ fn do_mlock2(start: VirtAddr, len: usize, flags: usize) -> Result<usize, SystemE
 
         let new_pages = guard.count_unlocked_pages_for_mlock(start, len)?;
         check_mlock_rlimit(guard.locked_vm, new_pages)?;
-        match guard.apply_vma_lock_flags_collect(start, len, new_flags, false) {
-            Ok(()) => return Ok(0),
+        match guard.apply_vma_lock_flags_collect(start, len, new_flags) {
+            Ok(()) => {
+                drop(guard);
+                vm.populate_mlock_range_post_commit(start, len)?;
+                return Ok(0);
+            }
             Err(failure) => {
                 drop(guard);
                 crate::mm::ucontext::InnerAddressSpace::notify_close_notifications(

--- a/kernel/src/mm/syscall/sys_mlockall.rs
+++ b/kernel/src/mm/syscall/sys_mlockall.rs
@@ -73,22 +73,23 @@ fn do_mlockall(flags: usize) -> Result<usize, SystemError> {
         }
         guard.set_mlock_future(VmFlags::VM_NONE);
 
-        if flags & MCL_CURRENT != 0 {
-            if let Err(failure) = guard.apply_mlockall_current_collect(lock_flags) {
-                drop(guard);
-                crate::mm::ucontext::InnerAddressSpace::notify_close_notifications(
-                    failure.notifications,
-                );
-                return Err(failure.err);
-            }
-        }
+        let notifications = if flags & MCL_CURRENT != 0 {
+            Some(guard.apply_mlockall_current_collect(lock_flags))
+        } else {
+            None
+        };
 
         if flags & MCL_FUTURE != 0 {
             guard.set_mlock_future(lock_flags);
         }
 
-        // TODO: when fault-time page locking is implemented, VM_LOCKONFAULT should
-        // mark pages unevictable on demand instead of relying only on VMA state.
+        drop(guard);
+        if let Some(notifications) = notifications {
+            crate::mm::ucontext::InnerAddressSpace::notify_close_notifications(notifications);
+        }
+        if flags & MCL_CURRENT != 0 {
+            vm.populate_mlockall_post_commit();
+        }
         return Ok(0);
     }
 }

--- a/kernel/src/mm/syscall/sys_munlock.rs
+++ b/kernel/src/mm/syscall/sys_munlock.rs
@@ -38,7 +38,7 @@ impl Syscall for SysMunlockHandle {
                 vm.wait_for_no_reservation_conflict_interruptible(region)?;
                 continue;
             }
-            match guard.apply_vma_lock_flags_collect(start, len, VmFlags::VM_NONE, false) {
+            match guard.apply_vma_lock_flags_collect(start, len, VmFlags::VM_NONE) {
                 Ok(()) => return Ok(0),
                 Err(failure) => {
                     drop(guard);

--- a/kernel/src/mm/syscall/sys_munlockall.rs
+++ b/kernel/src/mm/syscall/sys_munlockall.rs
@@ -25,16 +25,10 @@ impl Syscall for SysMunlockallHandle {
                 vm.wait_for_no_reservations_interruptible()?;
                 continue;
             }
-            match guard.clear_all_vma_lock_flags_collect() {
-                Ok(()) => return Ok(0),
-                Err(failure) => {
-                    drop(guard);
-                    crate::mm::ucontext::InnerAddressSpace::notify_close_notifications(
-                        failure.notifications,
-                    );
-                    return Err(failure.err);
-                }
-            }
+            let notifications = guard.clear_all_vma_lock_flags_collect();
+            drop(guard);
+            crate::mm::ucontext::InnerAddressSpace::notify_close_notifications(notifications);
+            return Ok(0);
         }
     }
 

--- a/kernel/src/mm/ucontext/address_space.rs
+++ b/kernel/src/mm/ucontext/address_space.rs
@@ -55,6 +55,27 @@ pub struct AddressSpace {
 }
 
 impl AddressSpace {
+    /// Populate a range after mlock flags have been committed and the commit
+    /// guard released.  Reservation waits happen without holding the mm guard.
+    pub fn populate_mlock_range_post_commit(
+        self: &Arc<Self>,
+        start: VirtAddr,
+        len: usize,
+    ) -> Result<(), SystemError> {
+        let region = VirtRegion::new(start, len);
+        let mut guard = self.write_guard_no_reservation_conflict(region);
+        guard.populate_mlock_range_post_commit(start, len)
+    }
+
+    /// Best-effort post-commit population for mlockall(MCL_CURRENT).
+    pub fn populate_mlockall_post_commit(self: &Arc<Self>) {
+        // Do not wait for reservations created after the mlockall commit.
+        // They are not part of MCL_CURRENT's committed VMA set and a blocking
+        // file mmap must not indefinitely delay this best-effort phase.
+        let mut guard = self.write();
+        guard.populate_mlockall_post_commit();
+    }
+
     pub fn new(create_stack: bool) -> Result<Arc<Self>, SystemError> {
         let inner = InnerAddressSpace::new(false)?;
         let table_paddr = inner.user_mapper.utable.table().phys();
@@ -629,6 +650,9 @@ impl AddressSpace {
                 if let Err(err) = guard.check_mlock_rlimit_for_pages(page_count.data(), error) {
                     map_fail!(err);
                 }
+            }
+            if vm_flags.is_mlock_flag_unsupported() {
+                vm_flags &= VmFlags::VM_LOCKED_CLEAR_MASK;
             }
             if let Err(err) = guard.check_rlimit_as_for_region(region, len, map_flags) {
                 map_fail!(err);

--- a/kernel/src/mm/ucontext/inner.rs
+++ b/kernel/src/mm/ucontext/inner.rs
@@ -464,6 +464,36 @@ impl InnerAddressSpace {
         }
     }
 
+    fn populate_vma_intersection(
+        &mut self,
+        vma: Arc<LockedVMA>,
+        intersection: VirtRegion,
+        vm_flags: VmFlags,
+        fault_in_missing: bool,
+    ) -> Result<(), SystemError> {
+        if vm_flags.is_mlock_population_unsupported() {
+            return Ok(());
+        }
+
+        let fault_flags = if fault_in_missing {
+            Some(Self::mlock_fault_flags(vm_flags).ok_or(SystemError::ENOMEM)?)
+        } else {
+            None
+        };
+        let mut addr = intersection.start();
+        while addr < intersection.end() {
+            if self.user_mapper.utable.translate(addr).is_some() {
+                if vm_flags.contains(VmFlags::VM_LOCKED) {
+                    self.add_present_page_mlock_ref(addr, &vma);
+                }
+            } else if fault_in_missing {
+                self.populate_vma_page(vma.clone(), addr, fault_flags.unwrap())?;
+            }
+            addr = VirtAddr::new(addr.data() + MMArch::PAGE_SIZE);
+        }
+        Ok(())
+    }
+
     pub(super) fn populate_vma_range(
         &mut self,
         start: VirtAddr,
@@ -490,18 +520,7 @@ impl InnerAddressSpace {
                 continue;
             }
 
-            let fault_flags = Self::mlock_fault_flags(vm_flags).ok_or(SystemError::ENOMEM)?;
-            let mut addr = intersection.start();
-            while addr < intersection.end() {
-                if self.user_mapper.utable.translate(addr).is_some() {
-                    if vm_flags.contains(VmFlags::VM_LOCKED) {
-                        self.add_present_page_mlock_ref(addr, &vma);
-                    }
-                } else if fault_in_missing {
-                    self.populate_vma_page(vma.clone(), addr, fault_flags)?;
-                }
-                addr = VirtAddr::new(addr.data() + MMArch::PAGE_SIZE);
-            }
+            self.populate_vma_intersection(vma, intersection, vm_flags, fault_in_missing)?;
 
             cursor = intersection.end();
             if cursor >= target.end() {
@@ -514,6 +533,46 @@ impl InnerAddressSpace {
         }
 
         Ok(())
+    }
+
+    /// Populate the current VMAs intersecting an already validated mlock
+    /// range.  Unlike the commit-time coverage check, holes created after the
+    /// mlock flags were committed are skipped, matching Linux __mm_populate().
+    pub(super) fn populate_mlock_range_post_commit(
+        &mut self,
+        start: VirtAddr,
+        len: usize,
+    ) -> Result<(), SystemError> {
+        let target = Self::checked_user_region(start, len)?;
+        let mut vmas = self.mappings.conflicts(target);
+        vmas.sort_by_key(|vma| vma.lock().region().start().data());
+
+        for vma in vmas {
+            let (region, vm_flags) = {
+                let guard = vma.lock();
+                (*guard.region(), *guard.vm_flags())
+            };
+            let Some(intersection) = region.intersect(&target) else {
+                continue;
+            };
+            let fault_in_missing = !vm_flags.contains(VmFlags::VM_LOCKONFAULT);
+            self.populate_vma_intersection(vma, intersection, vm_flags, fault_in_missing)?;
+        }
+        Ok(())
+    }
+
+    /// Best-effort population used after mlockall(MCL_CURRENT).  Address-space
+    /// holes and per-VMA failures do not prevent later VMAs from being visited.
+    pub(super) fn populate_mlockall_post_commit(&mut self) {
+        let vmas = self.mappings.iter_vmas().cloned().collect::<Vec<_>>();
+        for vma in vmas {
+            let (region, vm_flags) = {
+                let guard = vma.lock();
+                (*guard.region(), *guard.vm_flags())
+            };
+            let fault_in_missing = !vm_flags.contains(VmFlags::VM_LOCKONFAULT);
+            let _ = self.populate_vma_intersection(vma, region, vm_flags, fault_in_missing);
+        }
     }
 
     pub(super) fn best_effort_locked_population(

--- a/kernel/src/mm/ucontext/mmap.rs
+++ b/kernel/src/mm/ucontext/mmap.rs
@@ -159,7 +159,7 @@ impl InnerAddressSpace {
         }
         // debug!("mmap: addr: {addr:?}, page_count: {page_count:?}, prot_flags: {prot_flags:?}, map_flags: {map_flags:?}");
 
-        let vm_flags = VmFlags::from(prot_flags)
+        let mut vm_flags = VmFlags::from(prot_flags)
             | VmFlags::from(map_flags)
             | self.mlock_future
             | VmFlags::VM_MAYREAD
@@ -173,6 +173,9 @@ impl InnerAddressSpace {
                 SystemError::EAGAIN_OR_EWOULDBLOCK
             };
             self.check_mlock_rlimit_for_pages(page_count.data(), error)?;
+        }
+        if vm_flags.is_mlock_flag_unsupported() {
+            vm_flags &= VmFlags::VM_LOCKED_CLEAR_MASK;
         }
 
         let mut notifications = VmaCloseNotifications::default();

--- a/kernel/src/mm/ucontext/vma_ops.rs
+++ b/kernel/src/mm/ucontext/vma_ops.rs
@@ -611,7 +611,7 @@ impl InnerAddressSpace {
     pub(crate) fn apply_mlockall_current_collect(
         &mut self,
         new_flags: VmFlags,
-    ) -> Result<(), VmaOpFailure> {
+    ) -> VmaCloseNotifications {
         let ranges = self
             .mappings
             .iter_vmas()
@@ -621,28 +621,27 @@ impl InnerAddressSpace {
             })
             .collect::<Vec<_>>();
 
+        let mut notifications = VmaCloseNotifications::default();
         for (start, len) in ranges {
-            self.apply_vma_lock_flags_collect(start, len, new_flags, true)?;
+            if let Err(failure) = self.apply_vma_lock_flags_collect(start, len, new_flags) {
+                notifications.extend(failure.notifications);
+            }
         }
 
-        Ok(())
+        notifications
     }
 
     pub fn apply_mlockall_current(&mut self, new_flags: VmFlags) -> Result<(), SystemError> {
-        match self.apply_mlockall_current_collect(new_flags) {
-            Ok(()) => Ok(()),
-            Err(failure) => {
-                Self::notify_close_notifications(failure.notifications);
-                Err(failure.err)
-            }
-        }
+        let notifications = self.apply_mlockall_current_collect(new_flags);
+        Self::notify_close_notifications(notifications);
+        Ok(())
     }
 
     pub fn set_mlock_future(&mut self, flags: VmFlags) {
         self.mlock_future = flags;
     }
 
-    pub(crate) fn clear_all_vma_lock_flags_collect(&mut self) -> Result<(), VmaOpFailure> {
+    pub(crate) fn clear_all_vma_lock_flags_collect(&mut self) -> VmaCloseNotifications {
         self.mlock_future = VmFlags::VM_NONE;
         let ranges = self
             .mappings
@@ -660,21 +659,20 @@ impl InnerAddressSpace {
             })
             .collect::<Vec<_>>();
 
+        let mut notifications = VmaCloseNotifications::default();
         for (start, len) in ranges {
-            self.apply_vma_lock_flags_collect(start, len, VmFlags::VM_NONE, false)?;
+            if let Err(failure) = self.apply_vma_lock_flags_collect(start, len, VmFlags::VM_NONE) {
+                notifications.extend(failure.notifications);
+            }
         }
 
-        Ok(())
+        notifications
     }
 
     pub fn clear_all_vma_lock_flags(&mut self) -> Result<(), SystemError> {
-        match self.clear_all_vma_lock_flags_collect() {
-            Ok(()) => Ok(()),
-            Err(failure) => {
-                Self::notify_close_notifications(failure.notifications);
-                Err(failure.err)
-            }
-        }
+        let notifications = self.clear_all_vma_lock_flags_collect();
+        Self::notify_close_notifications(notifications);
+        Ok(())
     }
 
     pub(crate) fn apply_vma_lock_flags_collect(
@@ -682,7 +680,6 @@ impl InnerAddressSpace {
         start: VirtAddr,
         len: usize,
         new_flags: VmFlags,
-        ignore_populate_errors: bool,
     ) -> Result<(), VmaOpFailure> {
         let target = Self::checked_user_region(start, len)?;
         self.count_unlocked_pages_for_mlock(start, len)?;
@@ -703,6 +700,9 @@ impl InnerAddressSpace {
                     *guard.vm_flags(),
                 )
             };
+            if old_flags.is_mlock_flag_unsupported() {
+                continue;
+            }
             let old_locked = old_flags.contains(VmFlags::VM_LOCKED);
             let committed_flags = (old_flags & VmFlags::VM_LOCKED_CLEAR_MASK) | new_flags;
             if committed_flags == old_flags {
@@ -784,13 +784,7 @@ impl InnerAddressSpace {
             split_lifecycle.commit();
         }
 
-        if wants_locked {
-            let fault_in_missing = !new_flags.contains(VmFlags::VM_LOCKONFAULT);
-            let result = self.populate_vma_range(target.start(), target.size(), fault_in_missing);
-            if !ignore_populate_errors {
-                result?;
-            }
-        } else {
+        if !wants_locked {
             self.munlock_vma_pages_range(target.start(), target.end())?;
         }
 
@@ -802,9 +796,8 @@ impl InnerAddressSpace {
         start: VirtAddr,
         len: usize,
         new_flags: VmFlags,
-        ignore_populate_errors: bool,
     ) -> Result<(), SystemError> {
-        match self.apply_vma_lock_flags_collect(start, len, new_flags, ignore_populate_errors) {
+        match self.apply_vma_lock_flags_collect(start, len, new_flags) {
             Ok(()) => Ok(()),
             Err(failure) => {
                 Self::notify_close_notifications(failure.notifications);

--- a/user/apps/tests/dunitest/suites/normal/mlock_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/mlock_semantics.cc
@@ -256,6 +256,26 @@ TEST(Mlock, PopulatesFileMappingBeforeFault) {
     EXPECT_EQ(0, munmap(addr, ps));
 }
 
+TEST(Mlock, ProtNoneReturnsEnomemButKeepsVmaLocked) {
+    const size_t ps = PageSize();
+    ScopedMemlockLimit lim;
+    ASSERT_TRUE(lim.valid());
+    ASSERT_TRUE(lim.set_bytes(ps));
+
+    void* addr = mmap(nullptr, ps, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, addr);
+
+    errno = 0;
+    EXPECT_EQ(-1, mlock(addr, ps));
+    EXPECT_EQ(ENOMEM, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, msync(addr, ps, MS_INVALIDATE));
+    EXPECT_EQ(EBUSY, errno) << "mlock population failure must not roll back VM_LOCKED";
+
+    EXPECT_EQ(0, munmap(addr, ps));
+}
+
 TEST(Mlock2, OnFaultDoesNotPrefault) {
     const size_t ps = PageSize();
     const size_t len = ps * 2;
@@ -282,6 +302,26 @@ TEST(Mlock2, OnFaultDoesNotPrefault) {
 
     EXPECT_EQ(0, munlock(addr, len));
     EXPECT_EQ(0, munmap(addr, len));
+}
+
+TEST(Mlock2, OnFaultAcceptsProtNoneWithoutPrefault) {
+    const size_t ps = PageSize();
+    ScopedMemlockLimit lim;
+    ASSERT_TRUE(lim.valid());
+    ASSERT_TRUE(lim.set_bytes(ps));
+
+    void* addr = mmap(nullptr, ps, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, addr);
+
+    errno = 0;
+    ASSERT_EQ(0, static_cast<int>(syscall(SYS_mlock2, addr, ps, MLOCK_ONFAULT)))
+        << "errno=" << errno << " (" << strerror(errno) << ")";
+
+    unsigned char vec[1] = {0};
+    ASSERT_EQ(0, mincore(addr, ps, vec));
+    EXPECT_FALSE(IsResident(vec[0]));
+
+    EXPECT_EQ(0, munmap(addr, ps));
 }
 
 TEST(MlockAll, FutureAppliesToNewMappings) {
@@ -313,17 +353,26 @@ TEST(MlockAll, CurrentWithProtNoneClearsStaleFuture) {
         GTEST_SKIP() << "unable to raise RLIMIT_MEMLOCK to hard limit";
     }
 
-    void* guard = mmap(nullptr, ps, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    ASSERT_NE(MAP_FAILED, guard);
+    auto* range = static_cast<char*>(
+        mmap(nullptr, ps * 3, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(MAP_FAILED, range);
+    ASSERT_EQ(0, mprotect(range + ps, ps, PROT_NONE));
 
     ASSERT_EQ(0, mlockall(MCL_FUTURE)) << "errno=" << errno << " (" << strerror(errno) << ")";
 
     errno = 0;
-    if (mlockall(MCL_CURRENT) == -1 && errno == ENOMEM) {
+    int current_result = mlockall(MCL_CURRENT);
+    if (current_result == -1 && errno == ENOMEM) {
         munlockall();
-        munmap(guard, ps);
+        munmap(range, ps * 3);
         GTEST_SKIP() << "RLIMIT_MEMLOCK too small for mlockall(MCL_CURRENT)";
     }
+    ASSERT_EQ(0, current_result) << "errno=" << errno << " (" << strerror(errno) << ")";
+
+    unsigned char vec[1] = {0};
+    ASSERT_EQ(0, mincore(range + ps * 2, ps, vec));
+    EXPECT_TRUE(IsResident(vec[0]))
+        << "mlockall(MCL_CURRENT) must continue past PROT_NONE VMAs and prefault later VMAs";
 
     void* fresh = mmap(nullptr, ps, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     ASSERT_NE(MAP_FAILED, fresh);
@@ -334,7 +383,7 @@ TEST(MlockAll, CurrentWithProtNoneClearsStaleFuture) {
 
     EXPECT_EQ(0, munmap(fresh, ps));
     EXPECT_EQ(0, munlockall());
-    EXPECT_EQ(0, munmap(guard, ps));
+    EXPECT_EQ(0, munmap(range, ps * 3));
 }
 
 TEST(MlockAll, FutureAppliesToBrkGrowth) {


### PR DESCRIPTION
## Summary

- Separate mlock VMA flag commits from post-commit population.
- Align special-VMA filtering, RLIMIT ordering, `MLOCK_ONFAULT`, and `mlockall` best-effort behavior with Linux 6.6.
- Keep VMA lifecycle notifications outside the address-space lock.
- Add regression coverage for `PROT_NONE` and `MCL_CURRENT` population semantics.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `make kernel`
- DragonOS guest: `mlock_semantics_test` — 16 passed, 1 skipped due to the existing brk environment limitation.
- DragonOS guest: `sysv_shm_semantics_test` — 61 passed, 3 skipped due to existing environment limitations.

## Compatibility note

DragonOS still skips hugetlb population because its hugetlb fault path is not implemented. Ordinary `mlock`, `mlock2`, `mlockall`, `MAP_LOCKED`, VMA accounting, and reclaim-source behavior are covered by this change.


Close: https://github.com/DragonOS-Community/DragonOS/issues/1845
