### PR TITLE
fix(ext4): preserve dirty unlinked inode backing

### DIFF
--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -1,6 +1,6 @@
 use crate::{
     driver::base::{block::gendisk::GenDisk, device::device_number::DeviceNumber},
-    exception::workqueue::{schedule_work, Work},
+    exception::workqueue::{Work, WorkQueue},
     filesystem::{
         ext4::inode::{Ext4Inode, Ext4InodeLifecycle, Ext4InodeLifecycleState, InodeDirtyState},
         vfs::{
@@ -9,8 +9,8 @@ use crate::{
             mount::MountFlags,
             utils::{user_path_at, DName},
             vcore::{generate_inode_id, try_find_gendisk},
-            EvictionEpoch, FileSystem, FileSystemMakerData, FsReconfigureRequest, IndexNode, Magic,
-            MountableFileSystem, FSMAKER, VFS_MAX_FOLLOW_SYMLINK_TIMES,
+            EvictionEpoch, FileSystem, FileSystemMakerData, FsReconfigureRequest, IndexNode,
+            InodeRetentionKind, Magic, MountableFileSystem, FSMAKER, VFS_MAX_FOLLOW_SYMLINK_TIMES,
         },
     },
     libs::{
@@ -32,6 +32,7 @@ use alloc::{
     vec::Vec,
 };
 use kdepends::another_ext4;
+use lazy_static::lazy_static;
 use linkme::distributed_slice;
 use system_error::SystemError;
 
@@ -49,6 +50,10 @@ struct Ext4EvictionQueueState {
     completed_epoch: u64,
     sealed: bool,
     error: Option<SystemError>,
+}
+
+lazy_static! {
+    static ref EXT4_EVICTION_WQ: Arc<WorkQueue> = WorkQueue::new("ext4_evict");
 }
 
 #[must_use]
@@ -180,14 +185,12 @@ impl FileSystem for Ext4FileSystem {
     }
 
     fn sync_fs(&self, wait: bool) -> Result<(), SystemError> {
+        let flush_result = self.flush_dirty_inodes();
         let eviction_epoch = wait.then(|| {
-            // Like Linux ext4 flushing its filesystem workqueue before waiting
-            // for the target transaction, include every reclaim request that
-            // was published before this sync.  Do not seal the queue: requests
-            // published after this snapshot belong to a later sync boundary.
+            // Capture after dirty metadata flush: releasing the last AsyncWork
+            // owner can publish reclaim, and this sync boundary must include it.
             EvictionEpoch::new(self.eviction_queue.lock().next_epoch)
         });
-        let flush_result = self.flush_dirty_inodes();
         let result = if let Some(epoch) = eviction_epoch {
             // Finish the snapshotted asynchronous metadata work even if inode
             // writeback failed, while preserving that earlier error for the
@@ -247,7 +250,7 @@ impl Ext4FileSystem {
                 .checked_add(1)
                 .ok_or(SystemError::EOVERFLOW)?;
             let epoch = queue.next_epoch;
-            schedule_work(Work::new(move || {
+            EXT4_EVICTION_WQ.enqueue(Work::new(move || {
                 let result = inode.run_deferred_eviction();
                 let mut queue = fs.eviction_queue.lock();
                 if let Err(error) = result {
@@ -459,6 +462,10 @@ impl Ext4FileSystem {
         dirty: InodeDirtyState,
     ) -> Result<(), SystemError> {
         let _operation = inode.lifecycle().begin_operation()?;
+        // Acquire a prospective queue ownership before publishing dirty state.
+        // If the inode is already queued, the existing AsyncWork owner prevents
+        // this temporary retain/release pair from creating a false-zero edge.
+        inode.retain(InodeRetentionKind::AsyncWork)?;
         let (fs, should_queue) = {
             let mut guard = inode.0.lock();
             guard.dirty_state.insert(dirty);
@@ -474,7 +481,15 @@ impl Ext4FileSystem {
         if should_queue {
             if let Some(fs) = fs {
                 fs.dirty_inodes.lock().push(inode.clone());
+            } else {
+                let mut guard = inode.0.lock();
+                guard.dirty_state.remove(InodeDirtyState::QUEUED);
+                drop(guard);
+                inode.release(InodeRetentionKind::AsyncWork);
+                return Err(SystemError::EIO);
             }
+        } else {
+            inode.release(InodeRetentionKind::AsyncWork);
         }
         Ok(())
     }
@@ -492,38 +507,61 @@ impl Ext4FileSystem {
         let mut requeue: Vec<Arc<LockedExt4Inode>> = Vec::new();
         for inode in dirty {
             let mut should_requeue = false;
-            let result = {
-                let has_dirty_metadata = {
-                    let mut guard = inode.0.lock();
-                    let has_dirty = guard
+            let mut release_async_owner = false;
+            let has_dirty_metadata = {
+                let mut guard = inode.0.lock();
+                let has_dirty = guard
+                    .dirty_state
+                    .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
+                if !has_dirty {
+                    guard
                         .dirty_state
-                        .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
-                    if !has_dirty {
-                        guard.dirty_state.remove(InodeDirtyState::QUEUED);
+                        .remove(InodeDirtyState::QUEUED | InodeDirtyState::WRITEBACK);
+                    release_async_owner = true;
+                }
+                has_dirty
+            };
+
+            if !has_dirty_metadata {
+                if release_async_owner {
+                    inode.release(InodeRetentionKind::AsyncWork);
+                }
+                continue;
+            }
+
+            let operation = match inode.lifecycle().begin_operation() {
+                Ok(operation) => operation,
+                Err(error @ (SystemError::ESTALE | SystemError::EIO)) => {
+                    log::error!(
+                        "ext4: rejecting stale metadata writeback before disk access: {:?}",
+                        error
+                    );
+                    let page_cache = {
+                        let mut guard = inode.0.lock();
+                        guard.dirty_state.remove(
+                            InodeDirtyState::SIZE_DIRTY
+                                | InodeDirtyState::MTIME_DIRTY
+                                | InodeDirtyState::QUEUED
+                                | InodeDirtyState::WRITEBACK,
+                        );
+                        guard.page_cache.clone()
+                    };
+                    if let Some(page_cache) = page_cache {
+                        page_cache.record_writeback_error_with_superblock(error.clone());
                     }
-                    has_dirty
-                };
-                if !has_dirty_metadata {
+                    inode.release(InodeRetentionKind::AsyncWork);
+                    last_err = Err(error);
                     continue;
                 }
-                let _operation = match inode.lifecycle().begin_operation() {
-                    Ok(operation) => operation,
-                    Err(error @ (SystemError::ESTALE | SystemError::EIO)) => {
-                        log::error!(
-                            "ext4: rejecting stale metadata writeback before disk access: {:?}",
-                            error
-                        );
-                        if let Some(page_cache) = inode.0.lock().page_cache.clone() {
-                            page_cache.record_writeback_error_with_superblock(error);
-                        }
-                        continue;
-                    }
-                    Err(error) => {
-                        requeue.push(inode);
-                        last_err = Err(error);
-                        continue;
-                    }
-                };
+                Err(error) => {
+                    requeue.push(inode);
+                    last_err = Err(error);
+                    continue;
+                }
+            };
+
+            let result = {
+                let _operation = operation;
                 let _io_guard = inode.1.lock();
                 let (fs, inode_num, snapshot_dirty, cached_size, cached_mtime) = {
                     let mut guard = inode.0.lock();
@@ -533,9 +571,11 @@ impl Ext4FileSystem {
                         .intersection(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
                     if snapshot_dirty.is_empty() {
                         guard.dirty_state.remove(InodeDirtyState::WRITEBACK);
-                        continue;
+                        release_async_owner = true;
                     }
-                    guard.dirty_state.insert(InodeDirtyState::WRITEBACK);
+                    if !snapshot_dirty.is_empty() {
+                        guard.dirty_state.insert(InodeDirtyState::WRITEBACK);
+                    }
                     (
                         guard.fs_ptr.upgrade(),
                         guard.inner_inode_num,
@@ -545,55 +585,62 @@ impl Ext4FileSystem {
                     )
                 };
 
-                let result = if let Some(fs) = fs {
-                    let size = if snapshot_dirty.contains(InodeDirtyState::SIZE_DIRTY) {
-                        match cached_size {
-                            Some(size) => Ok(Some(size)),
-                            None => fs
-                                .fs
-                                .getattr(inode_num)
-                                .map(|attr| Some(attr.size))
-                                .map_err(SystemError::from),
-                        }
-                    } else {
-                        Ok(None)
-                    };
-                    size.and_then(|size| {
-                        let mtime = if snapshot_dirty.contains(InodeDirtyState::MTIME_DIRTY) {
-                            cached_mtime
-                        } else {
-                            None
-                        };
-                        LockedExt4Inode::retry_metadata_contention(|| {
-                            fs.fs.commit_inode_metadata(inode_num, size, mtime)
-                        })
-                    })
+                if snapshot_dirty.is_empty() {
+                    Ok(())
                 } else {
-                    Err(SystemError::EIO)
-                };
+                    let result = if let Some(fs) = fs {
+                        let size = if snapshot_dirty.contains(InodeDirtyState::SIZE_DIRTY) {
+                            match cached_size {
+                                Some(size) => Ok(Some(size)),
+                                None => fs
+                                    .fs
+                                    .getattr(inode_num)
+                                    .map(|attr| Some(attr.size))
+                                    .map_err(SystemError::from),
+                            }
+                        } else {
+                            Ok(None)
+                        };
+                        size.and_then(|size| {
+                            let mtime = if snapshot_dirty.contains(InodeDirtyState::MTIME_DIRTY) {
+                                cached_mtime
+                            } else {
+                                None
+                            };
+                            LockedExt4Inode::retry_metadata_contention(|| {
+                                fs.fs.commit_inode_metadata(inode_num, size, mtime)
+                            })
+                        })
+                    } else {
+                        Err(SystemError::EIO)
+                    };
 
-                let mut guard = inode.0.lock();
-                if result.is_ok() {
-                    if snapshot_dirty.contains(InodeDirtyState::SIZE_DIRTY)
-                        && guard.cached_file_size == cached_size
-                    {
-                        guard.dirty_state.remove(InodeDirtyState::SIZE_DIRTY);
+                    let mut guard = inode.0.lock();
+                    if result.is_ok() {
+                        if snapshot_dirty.contains(InodeDirtyState::SIZE_DIRTY)
+                            && guard.cached_file_size == cached_size
+                        {
+                            guard.dirty_state.remove(InodeDirtyState::SIZE_DIRTY);
+                        }
+                        if snapshot_dirty.contains(InodeDirtyState::MTIME_DIRTY)
+                            && guard.cached_mtime == cached_mtime
+                        {
+                            guard.dirty_state.remove(InodeDirtyState::MTIME_DIRTY);
+                        }
                     }
-                    if snapshot_dirty.contains(InodeDirtyState::MTIME_DIRTY)
-                        && guard.cached_mtime == cached_mtime
+                    guard.dirty_state.remove(InodeDirtyState::WRITEBACK);
+                    if guard
+                        .dirty_state
+                        .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY)
                     {
-                        guard.dirty_state.remove(InodeDirtyState::MTIME_DIRTY);
+                        guard.dirty_state.insert(InodeDirtyState::QUEUED);
+                        should_requeue = true;
+                    } else {
+                        guard.dirty_state.remove(InodeDirtyState::QUEUED);
+                        release_async_owner = true;
                     }
+                    result
                 }
-                guard.dirty_state.remove(InodeDirtyState::WRITEBACK);
-                if guard
-                    .dirty_state
-                    .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY)
-                {
-                    guard.dirty_state.insert(InodeDirtyState::QUEUED);
-                    should_requeue = true;
-                }
-                result
             };
 
             if let Err(e) = result {
@@ -602,6 +649,8 @@ impl Ext4FileSystem {
             }
             if should_requeue {
                 requeue.push(inode);
+            } else if release_async_owner {
+                inode.release(InodeRetentionKind::AsyncWork);
             }
         }
         if !requeue.is_empty() {
@@ -644,6 +693,9 @@ impl Ext4FileSystem {
         mount_data: Arc<GenDisk>,
         mount_options: Ext4MountOptions,
     ) -> Result<Arc<dyn FileSystem>, SystemError> {
+        // Worker creation may sleep and must never happen from final-release
+        // publication while inode/eviction locks are held.
+        lazy_static::initialize(&EXT4_EVICTION_WQ);
         let raw_dev = mount_data.device_num();
         // Writable mounts recover the journal and the validated legacy orphan
         // chain before this filesystem is published to the VFS.

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -494,6 +494,62 @@ impl Ext4FileSystem {
         Ok(())
     }
 
+    pub(super) fn release_clean_queued_inode(&self, inode: &Arc<LockedExt4Inode>) {
+        {
+            let mut dirty_inodes = self.dirty_inodes.lock();
+            let Some(position) = dirty_inodes
+                .iter()
+                .position(|queued| Arc::ptr_eq(queued, inode))
+            else {
+                // flush_dirty_inodes() already owns this queue entry and will
+                // release its AsyncWork retention after observing it clean.
+                return;
+            };
+
+            let mut guard = inode.inner.lock();
+            if !guard.dirty_state.contains(InodeDirtyState::QUEUED)
+                || guard.dirty_state.intersects(
+                    InodeDirtyState::SIZE_DIRTY
+                        | InodeDirtyState::MTIME_DIRTY
+                        | InodeDirtyState::WRITEBACK,
+                )
+            {
+                return;
+            }
+
+            dirty_inodes.swap_remove(position);
+            guard.dirty_state.remove(InodeDirtyState::QUEUED);
+        }
+
+        inode.release(InodeRetentionKind::AsyncWork);
+    }
+
+    fn publish_requeued_inodes(&self, requeue: Vec<Arc<LockedExt4Inode>>) {
+        let mut clean = Vec::new();
+        {
+            let mut dirty_inodes = self.dirty_inodes.lock();
+            for inode in requeue {
+                let mut guard = inode.inner.lock();
+                if guard
+                    .dirty_state
+                    .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY)
+                {
+                    guard.dirty_state.insert(InodeDirtyState::QUEUED);
+                    drop(guard);
+                    dirty_inodes.push(inode);
+                } else {
+                    guard.dirty_state.remove(InodeDirtyState::QUEUED);
+                    drop(guard);
+                    clean.push(inode);
+                }
+            }
+        }
+
+        for inode in clean {
+            inode.release(InodeRetentionKind::AsyncWork);
+        }
+    }
+
     fn flush_dirty_inodes(&self) -> Result<(), SystemError> {
         let dirty: Vec<Arc<LockedExt4Inode>> = {
             let mut guard = self.dirty_inodes.lock();
@@ -654,7 +710,7 @@ impl Ext4FileSystem {
             }
         }
         if !requeue.is_empty() {
-            self.dirty_inodes.lock().extend(requeue);
+            self.publish_requeued_inodes(requeue);
         }
         last_err
     }

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -375,7 +375,7 @@ impl Ext4FileSystem {
     }
 
     pub(super) fn validate_inode(&self, inode: &Arc<LockedExt4Inode>) -> Result<(), SystemError> {
-        let inode_num = inode.0.lock().inner_inode_num;
+        let inode_num = inode.inner.lock().inner_inode_num;
         let table = self.inode_table.lock();
         let entry = table.get(&inode_num).ok_or(SystemError::ESTALE)?;
         if !Weak::ptr_eq(&entry.inode, &Arc::downgrade(inode))
@@ -390,7 +390,7 @@ impl Ext4FileSystem {
         self: &Arc<Self>,
         inode: &Arc<LockedExt4Inode>,
     ) -> Result<Ext4InodeTombstone, SystemError> {
-        let inode_num = inode.0.lock().inner_inode_num;
+        let inode_num = inode.inner.lock().inner_inode_num;
         {
             let table = self.inode_table.lock();
             let entry = table.get(&inode_num).ok_or(SystemError::ESTALE)?;
@@ -467,7 +467,7 @@ impl Ext4FileSystem {
         // this temporary retain/release pair from creating a false-zero edge.
         inode.retain(InodeRetentionKind::AsyncWork)?;
         let (fs, should_queue) = {
-            let mut guard = inode.0.lock();
+            let mut guard = inode.inner.lock();
             guard.dirty_state.insert(dirty);
             let should_queue = !guard
                 .dirty_state
@@ -482,7 +482,7 @@ impl Ext4FileSystem {
             if let Some(fs) = fs {
                 fs.dirty_inodes.lock().push(inode.clone());
             } else {
-                let mut guard = inode.0.lock();
+                let mut guard = inode.inner.lock();
                 guard.dirty_state.remove(InodeDirtyState::QUEUED);
                 drop(guard);
                 inode.release(InodeRetentionKind::AsyncWork);
@@ -509,7 +509,7 @@ impl Ext4FileSystem {
             let mut should_requeue = false;
             let mut release_async_owner = false;
             let has_dirty_metadata = {
-                let mut guard = inode.0.lock();
+                let mut guard = inode.inner.lock();
                 let has_dirty = guard
                     .dirty_state
                     .intersects(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
@@ -537,7 +537,7 @@ impl Ext4FileSystem {
                         error
                     );
                     let page_cache = {
-                        let mut guard = inode.0.lock();
+                        let mut guard = inode.inner.lock();
                         guard.dirty_state.remove(
                             InodeDirtyState::SIZE_DIRTY
                                 | InodeDirtyState::MTIME_DIRTY
@@ -562,9 +562,9 @@ impl Ext4FileSystem {
 
             let result = {
                 let _operation = operation;
-                let _io_guard = inode.1.lock();
+                let _io_guard = inode.io_lock.lock();
                 let (fs, inode_num, snapshot_dirty, cached_size, cached_mtime) = {
-                    let mut guard = inode.0.lock();
+                    let mut guard = inode.inner.lock();
                     guard.dirty_state.remove(InodeDirtyState::QUEUED);
                     let snapshot_dirty = guard
                         .dirty_state
@@ -615,7 +615,7 @@ impl Ext4FileSystem {
                         Err(SystemError::EIO)
                     };
 
-                    let mut guard = inode.0.lock();
+                    let mut guard = inode.inner.lock();
                     if result.is_ok() {
                         if snapshot_dirty.contains(InodeDirtyState::SIZE_DIRTY)
                             && guard.cached_file_size == cached_size
@@ -705,32 +705,30 @@ impl Ext4FileSystem {
             another_ext4::Ext4::load_writable(mount_data.clone())?
         };
         let root_inode: Arc<LockedExt4Inode> =
-            Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| {
-                LockedExt4Inode(
-                    Mutex::new(Ext4Inode {
-                        inner_inode_num: another_ext4::EXT4_ROOT_INO,
-                        fs_ptr: Weak::default(),
-                        page_cache: None,
-                        children: BTreeMap::new(),
-                        dname: DName::from("/"),
-                        vfs_inode_id: generate_inode_id(),
-                        parent: self_ref.clone(),
-                        self_ref: self_ref.clone(),
-                        special_node: None,
-                        cached_file_size: None,
-                        cached_mtime: None,
-                        dirty_state: super::inode::InodeDirtyState::empty(),
-                    }),
-                    Mutex::new(()),
-                    RwSem::new(()),
-                    Mutex::new(()),
-                    Ext4InodeLifecycle::new(),
-                    vfs::InodeRetentionState::new(),
-                    SpinLock::new(None),
-                    SpinLock::new(false),
-                    self_ref.clone(),
-                    SpinLock::new(Weak::new()),
-                )
+            Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| LockedExt4Inode {
+                inner: Mutex::new(Ext4Inode {
+                    inner_inode_num: another_ext4::EXT4_ROOT_INO,
+                    fs_ptr: Weak::default(),
+                    page_cache: None,
+                    children: BTreeMap::new(),
+                    dname: DName::from("/"),
+                    vfs_inode_id: generate_inode_id(),
+                    parent: self_ref.clone(),
+                    self_ref: self_ref.clone(),
+                    special_node: None,
+                    cached_file_size: None,
+                    cached_mtime: None,
+                    dirty_state: super::inode::InodeDirtyState::empty(),
+                }),
+                io_lock: Mutex::new(()),
+                size_lock: RwSem::new(()),
+                namespace_lock: Mutex::new(()),
+                lifecycle: Ext4InodeLifecycle::new(),
+                retention: vfs::InodeRetentionState::new(),
+                pending_reclaim: SpinLock::new(None),
+                eviction_scheduled: SpinLock::new(false),
+                retention_callback_self: self_ref.clone(),
+                eviction_filesystem: SpinLock::new(Weak::new()),
             });
 
         let fs = Arc::new(Ext4FileSystem {
@@ -746,10 +744,10 @@ impl Ext4FileSystem {
             _mount_options: mount_options,
         });
 
-        let mut guard = fs.root_inode.0.lock();
+        let mut guard = fs.root_inode.inner.lock();
         guard.fs_ptr = Arc::downgrade(&fs);
         drop(guard);
-        *fs.root_inode.9.lock() = Arc::downgrade(&fs);
+        *fs.root_inode.eviction_filesystem.lock() = Arc::downgrade(&fs);
         fs.inode_table.lock().insert(
             another_ext4::EXT4_ROOT_INO,
             CanonicalInodeEntry {

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -227,26 +227,26 @@ pub struct Ext4Inode {
 }
 
 #[derive(Debug)]
-pub struct LockedExt4Inode(
-    pub(super) Mutex<Ext4Inode>,
-    pub(super) Mutex<()>,
-    pub(super) RwSem<()>,
-    pub(super) Mutex<()>,
-    pub(super) Arc<Ext4InodeLifecycle>,
-    pub(super) InodeRetentionState,
-    pub(super) SpinLock<Option<another_ext4::InodeReclaimHandle>>,
-    pub(super) SpinLock<bool>,
-    pub(super) Weak<LockedExt4Inode>,
-    pub(super) SpinLock<Weak<Ext4FileSystem>>,
-);
+pub struct LockedExt4Inode {
+    pub(super) inner: Mutex<Ext4Inode>,
+    pub(super) io_lock: Mutex<()>,
+    pub(super) size_lock: RwSem<()>,
+    pub(super) namespace_lock: Mutex<()>,
+    pub(super) lifecycle: Arc<Ext4InodeLifecycle>,
+    pub(super) retention: InodeRetentionState,
+    pub(super) pending_reclaim: SpinLock<Option<another_ext4::InodeReclaimHandle>>,
+    pub(super) eviction_scheduled: SpinLock<bool>,
+    pub(super) retention_callback_self: Weak<LockedExt4Inode>,
+    pub(super) eviction_filesystem: SpinLock<Weak<Ext4FileSystem>>,
+}
 
 impl IndexNode for LockedExt4Inode {
     fn retention_state(&self) -> Option<&InodeRetentionState> {
-        Some(&self.5)
+        Some(&self.retention)
     }
 
     fn on_zero_retention(&self) {
-        let inode = self.8.upgrade();
+        let inode = self.retention_callback_self.upgrade();
         if let Some(inode) = inode {
             let _ = inode.try_schedule_deferred_eviction();
         }
@@ -271,8 +271,8 @@ impl IndexNode for LockedExt4Inode {
         mode: vfs::InodeMode,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         let _operation = self.begin_operation()?;
-        let _namespace = self.3.lock();
-        let mut guard = self.0.lock();
+        let _namespace = self.namespace_lock.lock();
+        let mut guard = self.inner.lock();
         // another_ext4的高4位是文件类型，低12位是权限
         let file_mode = InodeMode::from(file_type).union(mode);
         let file_mode = another_ext4::InodeMode::from_bits_truncate(file_mode.bits() as u16);
@@ -332,7 +332,7 @@ impl IndexNode for LockedExt4Inode {
         // - prepare_read(): inode.metadata()
         // 若此处持有 inode 锁，则会在 metadata() 再次尝试获取同一把锁而自旋死锁。
         let page_cache = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             guard.page_cache.clone()
         };
 
@@ -349,7 +349,7 @@ impl IndexNode for LockedExt4Inode {
     fn read_sync(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
         let (fs, inode_num) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
         match fs.fs.getattr(inode_num)?.ftype {
@@ -384,11 +384,11 @@ impl IndexNode for LockedExt4Inode {
         if len == 0 {
             return Ok(0);
         }
-        let _size_guard = self.2.read();
+        let _size_guard = self.size_lock.read();
         let buf = &buf[0..len];
 
         let (fs, inode_num, page_cache) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
@@ -398,16 +398,16 @@ impl IndexNode for LockedExt4Inode {
 
         if let Some(page_cache) = page_cache {
             let _invalidate = page_cache.invalidate_write();
-            let _io_guard = self.1.lock();
+            let _io_guard = self.io_lock.lock();
 
             // 使用缓存的文件大小，避免 getattr 磁盘 I/O
             let old_file_size = {
-                let cached_size = self.0.lock().cached_file_size;
+                let cached_size = self.inner.lock().cached_file_size;
                 match cached_size {
                     Some(size) => size,
                     None => {
                         let size = fs.fs.getattr(inode_num)?.size;
-                        self.0.lock().cached_file_size = Some(size);
+                        self.inner.lock().cached_file_size = Some(size);
                         size
                     }
                 }
@@ -443,7 +443,7 @@ impl IndexNode for LockedExt4Inode {
                 let written_end = offset.checked_add(write_len).ok_or(SystemError::EFBIG)?;
                 let current_file_size = core::cmp::max(old_file_size, written_end as u64);
                 let self_arc = {
-                    let mut guard = self.0.lock();
+                    let mut guard = self.inner.lock();
                     guard.cached_file_size = Some(current_file_size);
                     guard.cached_mtime = Some(time);
                     guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?
@@ -462,9 +462,9 @@ impl IndexNode for LockedExt4Inode {
 
     fn write_sync(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
-        let _io_guard = self.1.lock();
+        let _io_guard = self.io_lock.lock();
         let (fs, inode_num) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
         match fs.fs.getattr(inode_num)?.ftype {
@@ -494,7 +494,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn fs(&self) -> Arc<dyn vfs::FileSystem> {
-        self.0.lock().concret_fs()
+        self.inner.lock().concret_fs()
     }
 
     fn as_any_ref(&self) -> &dyn core::any::Any {
@@ -503,8 +503,8 @@ impl IndexNode for LockedExt4Inode {
 
     fn find(&self, name: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
         let _operation = self.begin_operation()?;
-        let _namespace = self.3.lock();
-        let mut guard = self.0.lock();
+        let _namespace = self.namespace_lock.lock();
+        let mut guard = self.inner.lock();
         let dname = DName::from(name);
         if let Some(child) = guard.children.get(&dname) {
             let child = child.clone();
@@ -527,7 +527,7 @@ impl IndexNode for LockedExt4Inode {
     fn parent(&self) -> Result<Arc<dyn IndexNode>, SystemError> {
         // 只有目录才有父目录的概念
         // 先检查当前inode是否为目录
-        let guard = self.0.lock();
+        let guard = self.inner.lock();
 
         // 如果存储了父级指针，直接返回
         if let Some(parent) = guard.parent.upgrade() {
@@ -539,7 +539,7 @@ impl IndexNode for LockedExt4Inode {
 
     fn list(&self) -> Result<Vec<String>, SystemError> {
         let _operation = self.begin_operation()?;
-        let guard = self.0.lock();
+        let guard = self.inner.lock();
         let dentry = guard.concret_fs().fs.listdir(guard.inner_inode_num)?;
         let mut list = Vec::new();
         for entry in dentry {
@@ -550,8 +550,8 @@ impl IndexNode for LockedExt4Inode {
 
     fn link(&self, name: &str, other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
-        let _namespace = self.3.lock();
-        let mut guard = self.0.lock();
+        let _namespace = self.namespace_lock.lock();
+        let mut guard = self.inner.lock();
         let fs = guard.concret_fs();
         let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
@@ -560,14 +560,14 @@ impl IndexNode for LockedExt4Inode {
             .clone()
             .downcast_arc::<LockedExt4Inode>()
             .ok_or(SystemError::EINVAL)?;
-        let other_fs = other_arc.0.lock().concret_fs();
+        let other_fs = other_arc.inner.lock().concret_fs();
         if !Arc::ptr_eq(&fs, &other_fs) {
             return Err(SystemError::EXDEV);
         }
         let other_lifecycle = other_arc.lifecycle().clone();
         let _link_mutation = other_lifecycle.lock_link_mutation();
         let _other_operation = other_arc.begin_operation()?;
-        let other_inode_num = other_arc.0.lock().inner_inode_num;
+        let other_inode_num = other_arc.inner.lock().inner_inode_num;
 
         let my_attr = ext4.getattr(inode_num)?;
         let other_attr = ext4.getattr(other_inode_num)?;
@@ -600,8 +600,8 @@ impl IndexNode for LockedExt4Inode {
 
     fn unlink(&self, name: &str) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
-        let _namespace = self.3.lock();
-        let mut guard = self.0.lock();
+        let _namespace = self.namespace_lock.lock();
+        let mut guard = self.inner.lock();
         let fs = guard.concret_fs();
         let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
@@ -659,7 +659,7 @@ impl IndexNode for LockedExt4Inode {
     fn metadata(&self) -> Result<vfs::Metadata, SystemError> {
         let _operation = self.begin_operation()?;
         let (fs, inode_num, vfs_inode_id, cached_size, cached_mtime) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
@@ -757,7 +757,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn page_cache(&self) -> Option<Arc<PageCache>> {
-        self.0.lock().page_cache.clone()
+        self.inner.lock().page_cache.clone()
     }
 
     fn set_metadata(&self, metadata: &vfs::Metadata) -> Result<(), SystemError> {
@@ -768,7 +768,7 @@ impl IndexNode for LockedExt4Inode {
             |time: &PosixTimeSpec| -> u32 { time.tv_sec.max(0).min(u32::MAX as i64) as u32 };
 
         let (fs, inode_num) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
         let ext4 = &fs.fs;
@@ -790,7 +790,7 @@ impl IndexNode for LockedExt4Inode {
             )
         })?;
         {
-            let mut guard = self.0.lock();
+            let mut guard = self.inner.lock();
             guard.cached_file_size = Some(metadata.size as u64);
             guard.cached_mtime = Some(to_ext4_time(&metadata.mtime));
             guard
@@ -803,9 +803,9 @@ impl IndexNode for LockedExt4Inode {
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
-        let _size_guard = self.2.write();
+        let _size_guard = self.size_lock.write();
         let (fs, inode_num, page_cache, cached_size) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
@@ -818,7 +818,7 @@ impl IndexNode for LockedExt4Inode {
             None => fs.fs.getattr(inode_num)?.size,
         };
         {
-            let _io_guard = self.1.lock();
+            let _io_guard = self.io_lock.lock();
             let ext4 = &fs.fs;
             // 仅调整文件大小，其他属性保持不变
             Self::retry_metadata_contention(|| {
@@ -838,7 +838,7 @@ impl IndexNode for LockedExt4Inode {
             })?;
             // 更新缓存的文件大小
             {
-                let mut guard = self.0.lock();
+                let mut guard = self.inner.lock();
                 guard.cached_file_size = Some(len as u64);
                 guard
                     .dirty_state
@@ -872,8 +872,8 @@ impl IndexNode for LockedExt4Inode {
 
     fn rmdir(&self, name: &str) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
-        let _namespace = self.3.lock();
-        let mut guard = self.0.lock();
+        let _namespace = self.namespace_lock.lock();
+        let mut guard = self.inner.lock();
         let fs = guard.concret_fs();
         let concret_fs = &fs.fs;
         let inode_num = guard.inner_inode_num;
@@ -929,12 +929,12 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn dname(&self) -> Result<DName, SystemError> {
-        Ok(self.0.lock().dname.clone())
+        Ok(self.inner.lock().dname.clone())
     }
 
     fn getxattr(&self, name: &str, buf: &mut [u8]) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
-        let guard = self.0.lock();
+        let guard = self.inner.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
 
@@ -964,7 +964,7 @@ impl IndexNode for LockedExt4Inode {
 
     fn setxattr(&self, name: &str, value: &[u8], flags: XattrFlags) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
-        let guard = self.0.lock();
+        let guard = self.inner.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
 
@@ -987,7 +987,7 @@ impl IndexNode for LockedExt4Inode {
 
     fn listxattr(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
-        let guard = self.0.lock();
+        let guard = self.inner.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
 
@@ -1019,7 +1019,7 @@ impl IndexNode for LockedExt4Inode {
 
     fn removexattr(&self, name: &str) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
-        let guard = self.0.lock();
+        let guard = self.inner.lock();
         let ext4 = &guard.concret_fs().fs;
         let inode_num = guard.inner_inode_num;
 
@@ -1042,9 +1042,9 @@ impl IndexNode for LockedExt4Inode {
             return self.create(filename, vfs::FileType::File, mode);
         }
         let _operation = self.begin_operation()?;
-        let _namespace = self.3.lock();
+        let _namespace = self.namespace_lock.lock();
 
-        let mut guard = self.0.lock();
+        let mut guard = self.inner.lock();
         let fs = guard.concret_fs();
         let _reuse = fs.begin_allocation()?;
         let ext4 = &fs.fs;
@@ -1093,7 +1093,7 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn special_node(&self) -> Option<SpecialNodeData> {
-        self.0.lock().special_node.clone()
+        self.inner.lock().special_node.clone()
     }
 
     fn move_to(
@@ -1111,21 +1111,27 @@ impl IndexNode for LockedExt4Inode {
         let _target_operation = target_locked.begin_operation()?;
 
         let (ext4_fs, src_inode_num) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
         let ext4 = &ext4_fs.fs;
-        let target_inode_num = target_locked.0.lock().inner_inode_num;
-        if !Arc::ptr_eq(&ext4_fs, &target_locked.0.lock().concret_fs()) {
+        let target_inode_num = target_locked.inner.lock().inner_inode_num;
+        if !Arc::ptr_eq(&ext4_fs, &target_locked.inner.lock().concret_fs()) {
             return Err(SystemError::EXDEV);
         }
 
         let (_first_namespace, _second_namespace) = if src_inode_num == target_inode_num {
-            (self.3.lock(), None)
+            (self.namespace_lock.lock(), None)
         } else if src_inode_num < target_inode_num {
-            (self.3.lock(), Some(target_locked.3.lock()))
+            (
+                self.namespace_lock.lock(),
+                Some(target_locked.namespace_lock.lock()),
+            )
         } else {
-            (target_locked.3.lock(), Some(self.3.lock()))
+            (
+                target_locked.namespace_lock.lock(),
+                Some(self.namespace_lock.lock()),
+            )
         };
 
         let old_dname = DName::from(old_name);
@@ -1169,7 +1175,7 @@ impl IndexNode for LockedExt4Inode {
         let had_dst = dst_inode_num.is_some();
         let dst_inode = if let Some(dst_inode_num) = dst_inode_num {
             let target_parent = target_locked
-                .0
+                .inner
                 .lock()
                 .self_ref
                 .upgrade()
@@ -1232,7 +1238,7 @@ impl IndexNode for LockedExt4Inode {
             let mut temp_name = String::new();
             let mut whiteout_inode = None;
             let source_parent = self
-                .0
+                .inner
                 .lock()
                 .self_ref
                 .upgrade()
@@ -1331,7 +1337,7 @@ impl IndexNode for LockedExt4Inode {
                     .defer_reclaim(handle)?;
             }
             if let Some(whiteout) = &whiteout_inode {
-                whiteout.0.lock().dname = old_dname.clone();
+                whiteout.inner.lock().dname = old_dname.clone();
             }
             resulting_whiteout = whiteout_inode;
         } else {
@@ -1385,7 +1391,7 @@ impl IndexNode for LockedExt4Inode {
             had_dst,
         );
         if let Some(whiteout) = resulting_whiteout {
-            self.0.lock().children.insert(old_dname, whiteout);
+            self.inner.lock().children.insert(old_dname, whiteout);
         }
         Ok(())
     }
@@ -1471,7 +1477,7 @@ impl LockedExt4Inode {
             }
         };
         if let Err((error, handle)) = Self::reclaim_with_metadata_contention_retry(&fs.fs, handle) {
-            *inode.6.lock() = Some(handle);
+            *inode.pending_reclaim.lock() = Some(handle);
             let error = SystemError::from(error);
             let _ = fs.poison_freeing(tombstone, error.clone());
             return Err(error);
@@ -1495,11 +1501,11 @@ impl LockedExt4Inode {
 
     #[inline]
     fn begin_operation(&self) -> Result<Ext4InodeOperation, SystemError> {
-        self.4.begin_operation()
+        self.lifecycle.begin_operation()
     }
 
     pub(super) fn lifecycle(&self) -> &Arc<Ext4InodeLifecycle> {
-        &self.4
+        &self.lifecycle
     }
 
     /// 更新 rename 后的缓存
@@ -1513,20 +1519,20 @@ impl LockedExt4Inode {
         had_dst: bool,
     ) {
         if src_dir == dst_dir {
-            let mut guard = self.0.lock();
+            let mut guard = self.inner.lock();
             if had_dst {
                 guard.children.remove(new_dname);
             }
             if let Some(child) = guard.children.remove(old_dname) {
-                child.0.lock().dname = new_dname.clone();
+                child.inner.lock().dname = new_dname.clone();
                 guard.children.insert(new_dname.clone(), child);
             }
         } else {
             let (mut src_guard, mut dst_guard) = if src_dir < dst_dir {
-                (self.0.lock(), target.0.lock())
+                (self.inner.lock(), target.inner.lock())
             } else {
-                let d = target.0.lock();
-                let s = self.0.lock();
+                let d = target.inner.lock();
+                let s = self.inner.lock();
                 (s, d)
             };
 
@@ -1537,7 +1543,7 @@ impl LockedExt4Inode {
                 dst_guard.children.insert(new_dname.clone(), child.clone());
                 drop(src_guard);
                 drop(dst_guard);
-                let mut child_guard = child.0.lock();
+                let mut child_guard = child.inner.lock();
                 child_guard.dname = new_dname.clone();
                 child_guard.parent = Arc::downgrade(target);
             }
@@ -1555,25 +1561,25 @@ impl LockedExt4Inode {
     ) {
         if src_dir == dst_dir {
             // 同目录交换
-            let mut guard = self.0.lock();
+            let mut guard = self.inner.lock();
             let old_child = guard.children.remove(old_dname);
             let new_child = guard.children.remove(new_dname);
 
             if let Some(child) = old_child {
-                child.0.lock().dname = new_dname.clone();
+                child.inner.lock().dname = new_dname.clone();
                 guard.children.insert(new_dname.clone(), child);
             }
             if let Some(child) = new_child {
-                child.0.lock().dname = old_dname.clone();
+                child.inner.lock().dname = old_dname.clone();
                 guard.children.insert(old_dname.clone(), child);
             }
         } else {
             // 跨目录交换
             let (mut src_guard, mut dst_guard) = if src_dir < dst_dir {
-                (self.0.lock(), target.0.lock())
+                (self.inner.lock(), target.inner.lock())
             } else {
-                let d = target.0.lock();
-                let s = self.0.lock();
+                let d = target.inner.lock();
+                let s = self.inner.lock();
                 (s, d)
             };
 
@@ -1586,20 +1592,20 @@ impl LockedExt4Inode {
                 drop(src_guard);
                 drop(dst_guard);
 
-                let mut child_guard = child.0.lock();
+                let mut child_guard = child.inner.lock();
                 child_guard.dname = new_dname.clone();
                 child_guard.parent = Arc::downgrade(target);
                 drop(child_guard);
 
                 // 重新获取锁处理 new_child
                 if let Some(new_c) = new_child {
-                    let mut src_guard = self.0.lock();
+                    let mut src_guard = self.inner.lock();
                     src_guard.children.insert(old_dname.clone(), new_c.clone());
                     drop(src_guard);
 
-                    let mut new_c_guard = new_c.0.lock();
+                    let mut new_c_guard = new_c.inner.lock();
                     new_c_guard.dname = old_dname.clone();
-                    new_c_guard.parent = self.0.lock().self_ref.clone();
+                    new_c_guard.parent = self.inner.lock().self_ref.clone();
                 }
             } else if let Some(new_c) = new_child {
                 // 只有 new_child 在缓存中
@@ -1607,9 +1613,9 @@ impl LockedExt4Inode {
                 drop(src_guard);
                 drop(dst_guard);
 
-                let mut new_c_guard = new_c.0.lock();
+                let mut new_c_guard = new_c.inner.lock();
                 new_c_guard.dname = old_dname.clone();
-                new_c_guard.parent = self.0.lock().self_ref.clone();
+                new_c_guard.parent = self.inner.lock().self_ref.clone();
             }
         }
     }
@@ -1622,21 +1628,19 @@ impl LockedExt4Inode {
         known_file_type: Option<FileType>,
     ) -> Result<Arc<Self>, SystemError> {
         let lifecycle = Ext4InodeLifecycle::new();
-        let inode = Arc::new_cyclic(|self_ref| {
-            LockedExt4Inode(
-                Mutex::new(Ext4Inode::new(inode_num, fs_ptr.clone(), dname, parent)),
-                Mutex::new(()),
-                RwSem::new(()),
-                Mutex::new(()),
-                lifecycle,
-                InodeRetentionState::new(),
-                SpinLock::new(None),
-                SpinLock::new(false),
-                self_ref.clone(),
-                SpinLock::new(fs_ptr.clone()),
-            )
+        let inode = Arc::new_cyclic(|self_ref| LockedExt4Inode {
+            inner: Mutex::new(Ext4Inode::new(inode_num, fs_ptr.clone(), dname, parent)),
+            io_lock: Mutex::new(()),
+            size_lock: RwSem::new(()),
+            namespace_lock: Mutex::new(()),
+            lifecycle,
+            retention: InodeRetentionState::new(),
+            pending_reclaim: SpinLock::new(None),
+            eviction_scheduled: SpinLock::new(false),
+            retention_callback_self: self_ref.clone(),
+            eviction_filesystem: SpinLock::new(fs_ptr.clone()),
         });
-        let mut guard = inode.0.lock();
+        let mut guard = inode.inner.lock();
 
         // 设置self_ref
         guard.self_ref = Arc::downgrade(&inode);
@@ -1721,7 +1725,7 @@ impl LockedExt4Inode {
         self: &Arc<Self>,
         handle: another_ext4::InodeReclaimHandle,
     ) -> Result<(), SystemError> {
-        let mut pending = self.6.lock();
+        let mut pending = self.pending_reclaim.lock();
         if pending.is_some() {
             return Err(SystemError::EIO);
         }
@@ -1734,44 +1738,44 @@ impl LockedExt4Inode {
         // Dropping the capability is the in-memory counterpart of the durable
         // orphan-del transaction. A queued eviction, if any, observes None and
         // cleanly aborts instead of treating cancellation as corruption.
-        let _ = self.6.lock().take();
+        let _ = self.pending_reclaim.lock().take();
     }
 
     fn try_schedule_deferred_eviction(self: &Arc<Self>) -> Result<(), SystemError> {
-        if self.6.lock().is_none() {
+        if self.pending_reclaim.lock().is_none() {
             return Ok(());
         }
-        let mut scheduled = self.7.lock();
+        let mut scheduled = self.eviction_scheduled.lock();
         if *scheduled {
             return Ok(());
         }
-        if self.5.try_begin_freeing().is_err() {
+        if self.retention.try_begin_freeing().is_err() {
             return Ok(());
         }
         *scheduled = true;
-        let fs = match self.9.lock().upgrade() {
+        let fs = match self.eviction_filesystem.lock().upgrade() {
             Some(fs) => fs,
             None => {
                 *scheduled = false;
-                self.5.abort_freeing();
+                self.retention.abort_freeing();
                 return Err(SystemError::ESTALE);
             }
         };
         if let Err(error) = fs.schedule_inode_eviction(self.clone()) {
             *scheduled = false;
-            self.5.abort_freeing();
+            self.retention.abort_freeing();
             return Err(error);
         }
         Ok(())
     }
 
     pub(super) fn run_deferred_eviction(self: &Arc<Self>) -> Result<(), SystemError> {
-        let fs = self.0.lock().concret_fs();
+        let fs = self.inner.lock().concret_fs();
         let tombstone = match fs.begin_freeing(self) {
             Ok(tombstone) => tombstone,
             Err(error) => {
-                *self.7.lock() = false;
-                self.5.abort_freeing();
+                *self.eviction_scheduled.lock() = false;
+                self.retention.abort_freeing();
                 return Err(error);
             }
         };
@@ -1780,19 +1784,19 @@ impl LockedExt4Inode {
         // operations, so this ordering cannot deadlock a relink that already
         // owns the link-mutation lock.
         let _link_mutation = self.lifecycle().lock_link_mutation();
-        let handle = match self.6.lock().take() {
+        let handle = match self.pending_reclaim.lock().take() {
             Some(handle) => handle,
             None => {
                 fs.abort_freeing(tombstone)?;
-                *self.7.lock() = false;
-                self.5.abort_freeing();
+                *self.eviction_scheduled.lock() = false;
+                self.retention.abort_freeing();
                 return Ok(());
             }
         };
         let _reuse = fs.begin_reclaim();
         if let Some(page_cache) = self.page_cache() {
             if let Err(error) = page_cache.truncate(0) {
-                *self.6.lock() = Some(handle);
+                *self.pending_reclaim.lock() = Some(handle);
                 let _ = fs.poison_freeing(tombstone, error.clone());
                 return Err(error);
             }
@@ -1803,7 +1807,7 @@ impl LockedExt4Inode {
                 Ok(())
             }
             Err((error, handle)) => {
-                *self.6.lock() = Some(handle);
+                *self.pending_reclaim.lock() = Some(handle);
                 let error = SystemError::from(error);
                 let _ = fs.poison_freeing(tombstone, error.clone());
                 Err(error)
@@ -1813,9 +1817,9 @@ impl LockedExt4Inode {
 
     pub(super) fn flush_metadata(&self, datasync: bool) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
-        let _io_guard = self.1.lock();
+        let _io_guard = self.io_lock.lock();
         let (fs, inode_num, dirty, cached_size, cached_mtime) = {
-            let guard = self.0.lock();
+            let guard = self.inner.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
@@ -1847,7 +1851,7 @@ impl LockedExt4Inode {
         };
         Self::retry_metadata_contention(|| fs.fs.commit_inode_metadata(inode_num, size, mtime))?;
 
-        let mut guard = self.0.lock();
+        let mut guard = self.inner.lock();
         if size_dirty && guard.cached_file_size == cached_size {
             guard.dirty_state.remove(InodeDirtyState::SIZE_DIRTY);
         }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -797,6 +797,7 @@ impl IndexNode for LockedExt4Inode {
                 .dirty_state
                 .remove(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
         }
+        self.release_clean_metadata_queue_owner(&fs);
 
         Ok(())
     }
@@ -844,6 +845,7 @@ impl IndexNode for LockedExt4Inode {
                     .dirty_state
                     .remove(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
             }
+            self.release_clean_metadata_queue_owner(&fs);
         }
         if len < old_size as usize {
             if let Some(page_cache) = page_cache {
@@ -1398,6 +1400,12 @@ impl IndexNode for LockedExt4Inode {
 }
 
 impl LockedExt4Inode {
+    fn release_clean_metadata_queue_owner(&self, fs: &Arc<Ext4FileSystem>) {
+        if let Some(inode) = self.retention_callback_self.upgrade() {
+            fs.release_clean_queued_inode(&inode);
+        }
+    }
+
     fn metadata_contention_backoff(attempt: usize) {
         const YIELDS_BEFORE_SLEEP: usize = 64;
         if attempt.is_multiple_of(YIELDS_BEFORE_SLEEP) {
@@ -1833,6 +1841,7 @@ impl LockedExt4Inode {
         let mtime_dirty = dirty.contains(InodeDirtyState::MTIME_DIRTY);
 
         if !size_dirty && (!mtime_dirty || datasync) {
+            self.release_clean_metadata_queue_owner(&fs);
             return Ok(());
         }
 
@@ -1858,6 +1867,8 @@ impl LockedExt4Inode {
         if !datasync && mtime_dirty && guard.cached_mtime == cached_mtime {
             guard.dirty_state.remove(InodeDirtyState::MTIME_DIRTY);
         }
+        drop(guard);
+        self.release_clean_metadata_queue_owner(&fs);
         Ok(())
     }
 }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -17,7 +17,7 @@ use crate::{
         spinlock::SpinLock,
         wait_queue::WaitQueue,
     },
-    mm::{truncate::truncate_inode_pages, MemoryManagementArch},
+    mm::MemoryManagementArch,
     process::{ProcessManager, RawPid},
     sched::sched_yield,
     time::sleep::nanosleep,
@@ -1791,7 +1791,11 @@ impl LockedExt4Inode {
         };
         let _reuse = fs.begin_reclaim();
         if let Some(page_cache) = self.page_cache() {
-            truncate_inode_pages(page_cache, 0);
+            if let Err(error) = page_cache.truncate(0) {
+                *self.6.lock() = Some(handle);
+                let _ = fs.poison_freeing(tombstone, error.clone());
+                return Err(error);
+            }
         }
         match Self::reclaim_with_metadata_contention_retry(&fs.fs, handle) {
             Ok(()) => {

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -12,7 +12,9 @@ use hashbrown::HashMap;
 use system_error::SystemError;
 
 use super::vfs::{
-    mount::record_writeback_error_for_fs, FilePrivateData, IndexNode, WritebackControl,
+    inode_lifecycle::{InodeRetentionGuard, InodeRetentionKind},
+    mount::record_writeback_error_for_fs,
+    FilePrivateData, IndexNode, WritebackControl,
 };
 use crate::exception::workqueue::{schedule_work, Work, WorkQueue};
 use crate::libs::errseq::{ErrSeq, ErrSeqValue};
@@ -283,6 +285,21 @@ pub struct PageCache {
     manager: PageCacheManager,
 }
 
+pub struct PageDirtyReservation {
+    cache: Weak<PageCache>,
+    active: bool,
+}
+
+impl Drop for PageDirtyReservation {
+    fn drop(&mut self) {
+        if self.active {
+            if let Some(cache) = self.cache.upgrade() {
+                cache.cancel_page_dirty_reservation();
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct InnerPageCache {
     #[allow(unused)]
@@ -290,6 +307,9 @@ pub struct InnerPageCache {
     pages: HashMap<usize, Arc<PageEntry>>,
     page_indices: BTreeSet<usize>,
     dirty_pages: BTreeSet<usize>,
+    /// Aggregated semantic owner for all dirty and writeback pages in this mapping.
+    dirty_retention: Option<InodeRetentionGuard>,
+    dirty_preparations: usize,
     page_cache_ref: Weak<PageCache>,
 }
 
@@ -894,7 +914,7 @@ impl PageCacheManager {
                 let _ = entry.wait_ready()?;
             }
         }
-        cache.mark_page_dirty(page_index);
+        cache.mark_page_dirty(page_index)?;
         Ok(())
     }
 
@@ -1067,6 +1087,16 @@ impl PageCacheManager {
 
     pub fn sync(&self) -> Result<(), SystemError> {
         let cache = self.upgrade()?;
+        // Keep the canonical inode alive across the boundary between the last
+        // page completing writeback and write_inode(). The aggregated dirty
+        // owner may be released by finish_writeback_entry(), but eviction must
+        // not enter that false-zero window before metadata is committed.
+        let sync_inode = cache
+            .inode()
+            .and_then(|inode| inode.upgrade())
+            .ok_or(SystemError::EIO)?;
+        let _sync_retention =
+            InodeRetentionGuard::new(sync_inode.clone(), InodeRetentionKind::AsyncWork)?;
         loop {
             let (dirty_entries, writeback_entries): (Vec<_>, Vec<_>) = {
                 let inner = cache.inner.lock();
@@ -1104,13 +1134,11 @@ impl PageCacheManager {
         }
 
         // 脏页写完后调 write_inode 回写元数据。
-        if let Some(inode) = cache.inode().and_then(|w| w.upgrade()) {
-            let wbc = WritebackControl::sync_all_for_sync();
-            if let Err(e) = inode.write_inode(&wbc) {
-                log::warn!("write_inode failed: {:?}", e);
-                cache.record_writeback_error_with_superblock(e.clone());
-                return Err(e);
-            }
+        let wbc = WritebackControl::sync_all_for_sync();
+        if let Err(e) = sync_inode.write_inode(&wbc) {
+            log::warn!("write_inode failed: {:?}", e);
+            cache.record_writeback_error_with_superblock(e.clone());
+            return Err(e);
         }
 
         Ok(())
@@ -1422,7 +1450,10 @@ impl PageCacheManager {
     }
 
     pub fn remove_page(&self, page_index: usize) -> Result<Option<Arc<Page>>, SystemError> {
-        Ok(self.upgrade()?.lock().remove_page(page_index))
+        let cache = self.upgrade()?;
+        let removed = cache.lock().remove_page(page_index);
+        drop(cache.detach_dirty_retention_if_idle());
+        Ok(removed)
     }
 
     pub fn remove_clean_page_for_reclaim(
@@ -1516,8 +1547,9 @@ impl PageCacheManager {
                         return Ok(false);
                     }
                     drop(guard);
-                    entry.set_state(PageState::Dirty);
                     let mut inner = cache.inner.lock();
+                    cache.ensure_dirty_retention_locked(&mut inner)?;
+                    entry.set_state(PageState::Dirty);
                     inner.dirty_pages.insert(page_index);
                     continue;
                 }
@@ -1559,8 +1591,9 @@ impl PageCacheManager {
                         return Ok(false);
                     }
                     drop(guard);
-                    entry.set_state(PageState::Dirty);
                     let mut inner = cache.inner.lock();
+                    cache.ensure_dirty_retention_locked(&mut inner)?;
+                    entry.set_state(PageState::Dirty);
                     inner.dirty_pages.insert(page_index);
                     continue;
                 }
@@ -1597,10 +1630,12 @@ impl PageCacheManager {
                 let mut guard = page.write();
                 guard.add_flags(PageFlags::PG_ERROR | PageFlags::PG_DIRTY);
             }
-            cache.account_state_transition(PageState::Writeback, PageState::Dirty);
-            entry.set_state(PageState::Dirty);
-            let mut inner = cache.inner.lock();
-            inner.dirty_pages.insert(page_index);
+            {
+                let mut inner = cache.inner.lock();
+                cache.account_state_transition(PageState::Writeback, PageState::Dirty);
+                inner.dirty_pages.insert(page_index);
+                entry.set_state(PageState::Dirty);
+            }
             entry.wait_queue.wake_all();
             return Err(e);
         }
@@ -1611,18 +1646,20 @@ impl PageCacheManager {
         }
 
         let page_dirty = page.read().flags().contains(PageFlags::PG_DIRTY);
-        if page_dirty {
-            cache.account_state_transition(PageState::Writeback, PageState::Dirty);
-            entry.set_state(PageState::Dirty);
+        {
             let mut inner = cache.inner.lock();
-            inner.dirty_pages.insert(page_index);
-        } else {
-            cache.account_state_transition(PageState::Writeback, PageState::UpToDate);
-            entry.set_state(PageState::UpToDate);
-            let mut inner = cache.inner.lock();
-            inner.dirty_pages.remove(&page_index);
+            if page_dirty {
+                cache.account_state_transition(PageState::Writeback, PageState::Dirty);
+                inner.dirty_pages.insert(page_index);
+                entry.set_state(PageState::Dirty);
+            } else {
+                cache.account_state_transition(PageState::Writeback, PageState::UpToDate);
+                inner.dirty_pages.remove(&page_index);
+                entry.set_state(PageState::UpToDate);
+            }
         }
         entry.wait_queue.wake_all();
+        drop(cache.detach_dirty_retention_if_idle());
         Ok(())
     }
 
@@ -1921,6 +1958,8 @@ impl InnerPageCache {
             pages: HashMap::new(),
             page_indices: BTreeSet::new(),
             dirty_pages: BTreeSet::new(),
+            dirty_retention: None,
+            dirty_preparations: 0,
             page_cache_ref,
         }
     }
@@ -2358,6 +2397,7 @@ impl PageCache {
                 if let Some(page) = removed_page {
                     self.discard_unlinked_page(&page);
                 }
+                drop(self.detach_dirty_retention_if_idle());
                 break;
             }
         }
@@ -3279,17 +3319,96 @@ impl PageCache {
         }
     }
 
-    pub fn mark_page_dirty(&self, page_index: usize) {
+    fn ensure_dirty_retention_locked(&self, inner: &mut InnerPageCache) -> Result<(), SystemError> {
+        if inner.dirty_retention.is_some() {
+            return Ok(());
+        }
+        let inode = self
+            .inode()
+            .and_then(|inode| inode.upgrade())
+            .ok_or(SystemError::EIO)?;
+        inner.dirty_retention = Some(InodeRetentionGuard::new(
+            inode,
+            InodeRetentionKind::AsyncWork,
+        )?);
+        Ok(())
+    }
+
+    /// Establish dirty backing ownership before callers expose modified data.
+    pub fn prepare_page_dirty(&self) -> Result<PageDirtyReservation, SystemError> {
+        let mut inner = self.inner.lock();
+        self.ensure_dirty_retention_locked(&mut inner)?;
+        inner.dirty_preparations = inner
+            .dirty_preparations
+            .checked_add(1)
+            .expect("page-cache dirty preparation overflow");
+        Ok(PageDirtyReservation {
+            cache: self.manager.owner.clone(),
+            active: true,
+        })
+    }
+
+    fn cancel_page_dirty_reservation(&self) {
+        let mut inner = self.inner.lock();
+        assert!(inner.dirty_preparations != 0);
+        inner.dirty_preparations -= 1;
+        drop(inner);
+        drop(self.detach_dirty_retention_if_idle());
+    }
+
+    fn detach_dirty_retention_if_idle(&self) -> Option<InodeRetentionGuard> {
+        let mut inner = self.inner.lock();
+        let has_writeback = inner
+            .pages
+            .values()
+            .any(|entry| entry.state() == PageState::Writeback);
+        if inner.dirty_preparations == 0 && inner.dirty_pages.is_empty() && !has_writeback {
+            inner.dirty_retention.take()
+        } else {
+            None
+        }
+    }
+
+    pub fn mark_page_dirty(&self, page_index: usize) -> Result<(), SystemError> {
         let mut guard = self.inner.lock();
         if let Some(entry) = guard.get_entry(page_index) {
+            self.ensure_dirty_retention_locked(&mut guard)?;
             let old_state = entry.state();
             guard.dirty_pages.insert(page_index);
             if old_state == PageState::Writeback {
-                return;
+                return Ok(());
             }
             self.account_state_transition(old_state, PageState::Dirty);
             entry.set_state(PageState::Dirty);
+            return Ok(());
         }
+        drop(guard);
+        drop(self.detach_dirty_retention_if_idle());
+        Ok(())
+    }
+
+    pub fn mark_page_dirty_prepared(
+        &self,
+        page_index: usize,
+        reservation: &mut PageDirtyReservation,
+    ) -> Result<(), SystemError> {
+        assert!(reservation.active);
+        let mut guard = self.inner.lock();
+        assert!(guard.dirty_preparations != 0);
+        guard.dirty_preparations -= 1;
+        reservation.active = false;
+        if let Some(entry) = guard.get_entry(page_index) {
+            let old_state = entry.state();
+            guard.dirty_pages.insert(page_index);
+            if old_state != PageState::Writeback {
+                self.account_state_transition(old_state, PageState::Dirty);
+                entry.set_state(PageState::Dirty);
+            }
+            return Ok(());
+        }
+        drop(guard);
+        drop(self.detach_dirty_retention_if_idle());
+        Ok(())
     }
 
     pub fn mark_page_writeback(&self, page_index: usize) {
@@ -3310,6 +3429,8 @@ impl PageCache {
             entry.set_state(PageState::UpToDate);
             guard.dirty_pages.remove(&page_index);
         }
+        drop(guard);
+        drop(self.detach_dirty_retention_if_idle());
     }
 
     pub fn mark_page_error(&self, page_index: usize, error: SystemError) {
@@ -3317,10 +3438,10 @@ impl PageCache {
         let mut guard = self.inner.lock();
         if let Some(entry) = guard.get_entry(page_index) {
             let old_state = entry.state();
-            self.account_state_transition(old_state, PageState::Error);
-            entry.set_state(PageState::Error);
+            self.account_state_transition(old_state, PageState::Dirty);
+            guard.dirty_pages.insert(page_index);
+            entry.set_state(PageState::Dirty);
             entry.wait_queue.wake_all();
-            guard.dirty_pages.remove(&page_index);
         }
     }
 
@@ -3418,6 +3539,11 @@ impl PageCache {
 
     pub fn write(&self, offset: usize, buf: &[u8]) -> Result<usize, SystemError> {
         let (copies, ret) = self.prepare_write_copies(offset, buf.len())?;
+        let mut dirty_reservation = if ret != 0 {
+            Some(self.prepare_page_dirty()?)
+        } else {
+            None
+        };
         let mut src_offset = 0;
         for item in copies {
             // Prefault before taking the page lock.
@@ -3430,7 +3556,11 @@ impl PageCache {
             page_guard.add_flags(PageFlags::PG_DIRTY);
             src_offset += item.sub_len;
             drop(page_guard);
-            self.mark_page_dirty(item.page_index);
+            if let Some(mut reservation) = dirty_reservation.take() {
+                self.mark_page_dirty_prepared(item.page_index, &mut reservation)?;
+            } else {
+                self.mark_page_dirty(item.page_index)?;
+            }
         }
         Ok(ret)
     }
@@ -3513,6 +3643,7 @@ impl PageCache {
         // all copied bytes and PG_DIRTY transitions are ready to be exposed.
         let mut page_guards: Vec<_> = copies.iter().map(|item| item.entry.page.write()).collect();
 
+        let mut dirty_reservation = self.prepare_page_dirty()?;
         before_dirty(ret)?;
 
         src_offset = 0;
@@ -3526,8 +3657,12 @@ impl PageCache {
         }
         drop(page_guards);
 
-        for item in copies {
-            self.mark_page_dirty(item.page_index);
+        for (index, item) in copies.into_iter().enumerate() {
+            if index == 0 {
+                self.mark_page_dirty_prepared(item.page_index, &mut dirty_reservation)?;
+            } else {
+                self.mark_page_dirty(item.page_index)?;
+            }
         }
 
         Ok(ret)

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -1648,7 +1648,16 @@ impl PageCacheManager {
         let page_dirty = page.read().flags().contains(PageFlags::PG_DIRTY);
         {
             let mut inner = cache.inner.lock();
-            if page_dirty {
+            // `mark_page_dirty{,_prepared}()` publishes redirty through
+            // `dirty_pages` while holding `inner`.  The PG_DIRTY sample above
+            // must therefore be combined with that publication after taking
+            // the same lock; otherwise a redirty registered between the
+            // sample and this critical section would be overwritten as clean.
+            // Do not read the page flags while holding `inner`: legacy
+            // writeback paths acquire the page lock before updating the page
+            // cache, so doing so would invert the established lock order.
+            let redirtied = page_dirty || inner.dirty_pages.contains(&page_index);
+            if redirtied {
                 cache.account_state_transition(PageState::Writeback, PageState::Dirty);
                 inner.dirty_pages.insert(page_index);
                 entry.set_state(PageState::Dirty);

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -516,11 +516,21 @@ impl PageFaultHandler {
         let cache_page = pfm.page.clone().expect("no cache_page in PageFaultMessage");
 
         // 将pagecache页设为脏页，以便回收时能够回写
-        cache_page.write().add_flags(PageFlags::PG_DIRTY);
         let page_type = { cache_page.read().page_type().clone() };
         if let PageType::File(info) = page_type {
             if let Some(page_cache) = info.page_cache.upgrade() {
-                page_cache.mark_page_dirty(info.index);
+                let mut dirty_reservation = match page_cache.prepare_page_dirty() {
+                    Ok(reservation) => reservation,
+                    Err(_) => return VmFaultReason::VM_FAULT_SIGBUS,
+                };
+                cache_page.write().add_flags(PageFlags::PG_DIRTY);
+                if page_cache
+                    .mark_page_dirty_prepared(info.index, &mut dirty_reservation)
+                    .is_err()
+                {
+                    cache_page.write().remove_flags(PageFlags::PG_DIRTY);
+                    return VmFaultReason::VM_FAULT_SIGBUS;
+                }
             }
         }
         ret = ret.union(Self::finish_fault(pfm));
@@ -625,11 +635,21 @@ impl PageFaultHandler {
             // 共享映射：原地升级 PTE 为可写，并标记脏。
             let table = mapper.get_table(address, 0).unwrap();
             let i = table.index_of(address).unwrap();
-            old_page.write().add_flags(PageFlags::PG_DIRTY);
             let page_type = { old_page.read().page_type().clone() };
             if let PageType::File(info) = page_type {
                 if let Some(page_cache) = info.page_cache.upgrade() {
-                    page_cache.mark_page_dirty(info.index);
+                    let mut dirty_reservation = match page_cache.prepare_page_dirty() {
+                        Ok(reservation) => reservation,
+                        Err(_) => return VmFaultReason::VM_FAULT_SIGBUS,
+                    };
+                    old_page.write().add_flags(PageFlags::PG_DIRTY);
+                    if page_cache
+                        .mark_page_dirty_prepared(info.index, &mut dirty_reservation)
+                        .is_err()
+                    {
+                        old_page.write().remove_flags(PageFlags::PG_DIRTY);
+                        return VmFaultReason::VM_FAULT_SIGBUS;
+                    }
                 }
             }
             entry.set_flags(new_flags);

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -528,7 +528,7 @@ impl PageReclaimer {
                     len,
                     e
                 );
-                guard.add_flags(PageFlags::PG_ERROR);
+                guard.add_flags(PageFlags::PG_ERROR | PageFlags::PG_DIRTY);
                 page_cache.mark_page_error(page_index, e);
                 return;
             }
@@ -536,7 +536,7 @@ impl PageReclaimer {
 
         guard.remove_flags(PageFlags::PG_ERROR);
         if guard.flags().contains(PageFlags::PG_DIRTY) {
-            page_cache.mark_page_dirty(page_index);
+            let _ = page_cache.mark_page_dirty(page_index);
         } else {
             page_cache.mark_page_uptodate(page_index);
         }

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -9,9 +9,22 @@
 #include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <string>
+#include <thread>
+
+#ifndef __NR_syncfs
+#if defined(__x86_64__)
+#define __NR_syncfs 306
+#elif defined(__riscv) || defined(__loongarch64__)
+#define __NR_syncfs 267
+#else
+#error "__NR_syncfs is not defined for this architecture"
+#endif
+#endif
 
 namespace {
 
@@ -194,7 +207,6 @@ TEST(Ext4InodeIdentity, OpenFileSurvivesFinalUnlink) {
     ASSERT_GE(fd, 0) << strerror(errno);
     constexpr char kBefore[] = "before-unlink";
     ASSERT_NO_FATAL_FAILURE(WriteAll(fd, kBefore, sizeof(kBefore) - 1));
-    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
 
     struct stat before = {};
     ASSERT_EQ(0, fstat(fd, &before)) << strerror(errno);
@@ -214,6 +226,7 @@ TEST(Ext4InodeIdentity, OpenFileSurvivesFinalUnlink) {
               lseek(fd, 0, SEEK_END))
         << strerror(errno);
     ASSERT_NO_FATAL_FAILURE(WriteAll(fd, kAfter, sizeof(kAfter) - 1));
+    ASSERT_EQ(0, fdatasync(fd)) << strerror(errno);
     ASSERT_EQ(0, fsync(fd)) << strerror(errno);
     struct stat unlinked = {};
     ASSERT_EQ(0, fstat(fd, &unlinked)) << strerror(errno);
@@ -222,6 +235,146 @@ TEST(Ext4InodeIdentity, OpenFileSurvivesFinalUnlink) {
     EXPECT_EQ(static_cast<off_t>(sizeof(kBefore) + sizeof(kAfter) - 2),
               unlinked.st_size);
     ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, DirtyClosedUnlinkSyncfsCompletes) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string path = fs.mount_point() + "/dirty_closed_unlink";
+    int sync_fd = open(fs.mount_point().c_str(), O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(sync_fd, 0) << strerror(errno);
+    int fd = open(path.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    constexpr char kPayload[] = "dirty-without-pre-fsync";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(fd, kPayload, sizeof(kPayload) - 1));
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+    ASSERT_EQ(0, syscall(__NR_syncfs, sync_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(sync_fd)) << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, RecreatedPathIsIndependentFromLiveUnlinkedInode) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string path = fs.mount_point() + "/recreated";
+    int old_fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(old_fd, 0) << strerror(errno);
+    constexpr char kOld[] = "old-lifetime";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(old_fd, kOld, sizeof(kOld) - 1));
+    ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+
+    int new_fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(new_fd, 0) << strerror(errno);
+    constexpr char kNew[] = "new-lifetime-data";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(new_fd, kNew, sizeof(kNew) - 1));
+
+    struct stat old_stat = {};
+    struct stat new_stat = {};
+    ASSERT_EQ(0, fstat(old_fd, &old_stat)) << strerror(errno);
+    ASSERT_EQ(0, fstat(new_fd, &new_stat)) << strerror(errno);
+    EXPECT_NE(old_stat.st_ino, new_stat.st_ino);
+    EXPECT_EQ(0u, old_stat.st_nlink);
+    EXPECT_EQ(1u, new_stat.st_nlink);
+    ASSERT_EQ(0, lseek(old_fd, 0, SEEK_SET)) << strerror(errno);
+    char old_data[sizeof(kOld)] = {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(kOld) - 1),
+              read(old_fd, old_data, sizeof(old_data)))
+        << strerror(errno);
+    EXPECT_EQ(0, memcmp(old_data, kOld, sizeof(kOld) - 1));
+    ASSERT_EQ(0, fsync(old_fd)) << strerror(errno);
+    ASSERT_EQ(0, fsync(new_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(old_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(new_fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, ConcurrentWriteUnlinkSyncAndClose) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string path = fs.mount_point() + "/concurrent_unlink";
+    int owner_fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(owner_fd, 0) << strerror(errno);
+    int writer_fd = dup(owner_fd);
+    int sync_fd = dup(owner_fd);
+    int close_fd = dup(owner_fd);
+    int drain_fd = open(fs.mount_point().c_str(), O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(writer_fd, 0) << strerror(errno);
+    ASSERT_GE(sync_fd, 0) << strerror(errno);
+    ASSERT_GE(close_fd, 0) << strerror(errno);
+    ASSERT_GE(drain_fd, 0) << strerror(errno);
+
+    std::atomic<bool> start{false};
+    std::atomic<int> first_error{0};
+    auto record_error = [&](int error) {
+        int expected = 0;
+        first_error.compare_exchange_strong(expected, error);
+    };
+    std::thread writer([&] {
+        while (!start.load(std::memory_order_acquire)) {
+        }
+        constexpr char kChunk[] = "concurrent-data";
+        for (int i = 0; i < 64; ++i) {
+            if (pwrite(writer_fd, kChunk, sizeof(kChunk) - 1,
+                       static_cast<off_t>(i * (sizeof(kChunk) - 1))) !=
+                static_cast<ssize_t>(sizeof(kChunk) - 1)) {
+                record_error(errno);
+                break;
+            }
+            if ((i & 7) == 0 && fdatasync(writer_fd) != 0) {
+                record_error(errno);
+                break;
+            }
+        }
+        if (close(writer_fd) != 0) {
+            record_error(errno);
+        }
+    });
+    std::thread syncer([&] {
+        while (!start.load(std::memory_order_acquire)) {
+        }
+        for (int i = 0; i < 16; ++i) {
+            if (syscall(__NR_syncfs, sync_fd) != 0) {
+                record_error(errno);
+                break;
+            }
+        }
+        if (close(sync_fd) != 0) {
+            record_error(errno);
+        }
+    });
+    std::thread closer([&] {
+        while (!start.load(std::memory_order_acquire)) {
+        }
+        if (close(close_fd) != 0) {
+            record_error(errno);
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    int unlink_result = unlink(path.c_str());
+    int unlink_errno = errno;
+    int owner_close_result = close(owner_fd);
+    int owner_close_errno = errno;
+    writer.join();
+    syncer.join();
+    closer.join();
+    ASSERT_EQ(0, unlink_result) << strerror(unlink_errno);
+    ASSERT_EQ(0, owner_close_result) << strerror(owner_close_errno);
+    EXPECT_EQ(0, first_error.load());
+    ASSERT_EQ(0, syscall(__NR_syncfs, drain_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(drain_fd)) << strerror(errno);
 
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
 }

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -9,6 +9,7 @@
 #include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -255,6 +256,46 @@ TEST(Ext4InodeIdentity, DirtyClosedUnlinkSyncfsCompletes) {
     ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
     ASSERT_EQ(0, syscall(__NR_syncfs, sync_fd)) << strerror(errno);
     ASSERT_EQ(0, close(sync_fd)) << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, FsyncBeforeFinalCloseReclaimsUnlinkedBlocks) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    for (int iteration = 0; iteration < 3; ++iteration) {
+        struct statvfs before = {};
+        ASSERT_EQ(0, statvfs(fs.mount_point().c_str(), &before)) << strerror(errno);
+
+        const std::string path = fs.mount_point() + "/fsync_unlinked_reclaim_" +
+                                 std::to_string(iteration);
+        int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+        ASSERT_GE(fd, 0) << strerror(errno);
+        char block[64 * 1024];
+        memset(block, 0x5a, sizeof(block));
+        for (int i = 0; i < 8; ++i) {
+            ASSERT_NO_FATAL_FAILURE(WriteAll(fd, block, sizeof(block)));
+        }
+        ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+        ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+        ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+        struct statvfs after = {};
+        bool reclaimed = false;
+        for (int i = 0; i < 20; ++i) {
+            ASSERT_EQ(0, statvfs(fs.mount_point().c_str(), &after)) << strerror(errno);
+            if (after.f_bfree >= before.f_bfree) {
+                reclaimed = true;
+                break;
+            }
+            usleep(5 * 1000);
+        }
+        EXPECT_TRUE(reclaimed) << "iteration=" << iteration
+                               << " free blocks before=" << before.f_bfree
+                               << " after=" << after.f_bfree;
+    }
 
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
 }


### PR DESCRIPTION
## Summary

- retain canonical ext4 inodes while dirty metadata or page-cache writeback owns their backing
- keep dirty/writeback ownership continuous across redirty and writeback errors
- serialize synchronous eviction after metadata flush on a preinitialized ext4 workqueue
- fail stop final reclaim when page-cache truncation cannot complete
- cover dirty close/unlink/sync, live unlinked fd I/O, pathname recreation, and concurrent final release

## Root cause

The ext4 dirty-inode queue and dirty page cache held ordinary object references but did not participate in the VFS semantic retention lifecycle. After final unlink and close, eviction could reclaim the inode while metadata or page writeback remained queued. Later writeback observed stale backing, reported `ESTALE`/`EINVAL`, and could requeue indefinitely.

Final shutdown also shared the single system workqueue with deferred eviction. Waiting for an eviction epoch from that same worker could deadlock.

## Implementation

- acquire `AsyncWork` retention for ext4 metadata queue ownership and release it only after successful completion or a terminal error
- aggregate page-cache dirty/writeback retention per canonical mapping, including clean-to-dirty reservations, redirty, writeback errors, removal, and truncate paths
- hold full-sync retention through the final page writeback and inode metadata flush boundary
- run eviction on a shared ext4-specific workqueue initialized during mount setup
- snapshot the synchronous eviction epoch after dirty metadata flush, including reclaim published by that flush
- preserve reclaim capability and poison the filesystem if final page-cache truncation fails

## Validation

- `cargo fmt --manifest-path kernel/Cargo.toml --all -- --check`
- `git diff --check`
- `make kernel` with the Ubuntu 24.04 rootfs manifest
- Ubuntu 24.04 DragonOS QEMU guest: `ext4_inode_identity_test` (9/9 passed)
- Ubuntu 24.04 DragonOS QEMU guest: `errseq_writeback_reporting_test` (5/5 passed)

Fixes #2053
