### PR TITLE
feat(virtiofs): discover shared memory cache regions

### DIFF
--- a/kernel/src/driver/net/e1000e/e1000e.rs
+++ b/kernel/src/driver/net/e1000e/e1000e.rs
@@ -205,7 +205,7 @@ impl E1000EDevice {
         if address == 0 {
             return Err(E1000EPciError::BarNotAllocated);
         }
-        if size != E1000E_BAR_REG_SIZE {
+        if size != u64::from(E1000E_BAR_REG_SIZE) {
             return Err(E1000EPciError::UnexpectedBarSize);
         }
         let vaddress = bar0

--- a/kernel/src/driver/pci/pci.rs
+++ b/kernel/src/driver/pci/pci.rs
@@ -6,14 +6,14 @@ use super::pci_irq::{IrqType, PciIrqError};
 use super::raw_device::PciGeneralDevice;
 use super::root::{pci_root_0, PciRoot};
 
-use crate::arch::{PciArch, TraitPciArch};
+use crate::arch::{MMArch, PciArch, TraitPciArch};
 use crate::driver::pci::subsys::pci_bus_subsys_init;
 use crate::exception::IrqNumber;
 use crate::libs::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::mm::mmio_buddy::{mmio_pool, MMIOSpaceGuard};
 
-use crate::mm::VirtAddr;
+use crate::mm::{MemoryManagementArch, PhysAddr, VirtAddr};
 
 use alloc::string::String;
 use alloc::sync::{Arc, Weak};
@@ -282,6 +282,7 @@ impl From<u8> for HeaderType {
 pub enum PciError {
     /// The device reported an invalid BAR type.
     InvalidBarType,
+    InvalidBarRange,
     CreateMmioError,
     InvalidBusDeviceFunction,
     SegmentNotFound,
@@ -296,6 +297,7 @@ impl Display for PciError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::InvalidBarType => write!(f, "Invalid PCI BAR type."),
+            Self::InvalidBarRange => write!(f, "Invalid PCI BAR range."),
             Self::CreateMmioError => write!(f, "Error occurred while creating mmio."),
             Self::InvalidBusDeviceFunction => write!(f, "Found invalid BusDeviceFunction."),
             Self::SegmentNotFound => write!(f, "Target segment not found"),
@@ -375,6 +377,16 @@ pub trait PciDeviceStructure: Send + Sync {
     fn bar_ioremap(&self) -> Option<Result<u8, PciError>> {
         None
     }
+    fn bar_ioremap_excluding(&self, _metadata_only_bars: &[u8]) -> Option<Result<u8, PciError>> {
+        self.bar_ioremap_with_mappings(_metadata_only_bars, &[])
+    }
+    fn bar_ioremap_with_mappings(
+        &self,
+        _metadata_only_bars: &[u8],
+        _required_mappings: &[PciBarMappingRequest],
+    ) -> Option<Result<u8, PciError>> {
+        self.bar_ioremap()
+    }
     /// @brief 获取PCI设备的bar寄存器的引用
     /// @return
     #[inline(always)]
@@ -393,6 +405,50 @@ pub trait PciDeviceStructure: Send + Sync {
             }
         }
         None
+    }
+    /// Return the BAR subranges required by the MSI-X table and pending-bit array.
+    fn msix_mapping_requests(&self) -> Result<Vec<PciBarMappingRequest>, PciError> {
+        let Some(capability) = self
+            .capabilities()
+            .and_then(|mut caps| caps.find(|cap| cap.id == PCI_CAP_ID_MSIX))
+        else {
+            return Ok(Vec::new());
+        };
+        let table_offset = capability
+            .offset
+            .checked_add(4)
+            .ok_or(PciError::InvalidBarRange)?;
+        let pba_offset = capability
+            .offset
+            .checked_add(8)
+            .ok_or(PciError::InvalidBarRange)?;
+        let bus_device_function = self.common_header().bus_device_function;
+        let table = pci_root_0().read_config(bus_device_function, table_offset.into());
+        let pba = pci_root_0().read_config(bus_device_function, pba_offset.into());
+        let table_bar = (table & 0x7) as u8;
+        let pba_bar = (pba & 0x7) as u8;
+        if table_bar >= 6 || pba_bar >= 6 {
+            return Err(PciError::InvalidBarType);
+        }
+        let vectors = u64::from(capability.private_header & 0x7ff) + 1;
+        let table_length = vectors.checked_mul(16).ok_or(PciError::InvalidBarRange)?;
+        let pba_length = vectors
+            .checked_add(63)
+            .and_then(|count| count.checked_div(64))
+            .and_then(|entries| entries.checked_mul(8))
+            .ok_or(PciError::InvalidBarRange)?;
+        Ok(vec![
+            PciBarMappingRequest {
+                bar: table_bar,
+                offset: u64::from(table & !0x7),
+                length: table_length,
+            },
+            PciBarMappingRequest {
+                bar: pba_bar,
+                offset: u64::from(pba & !0x7),
+                length: pba_length,
+            },
+        ])
     }
     /// @brief 寻找设备的msi空间的offset
     fn msi_capability_offset(&self) -> Option<u8> {
@@ -479,8 +535,22 @@ impl PciDeviceStructure for PciDeviceStructureGeneralDevice {
         })
     }
     fn bar_ioremap(&self) -> Option<Result<u8, PciError>> {
+        self.bar_ioremap_excluding(&[])
+    }
+    fn bar_ioremap_excluding(&self, metadata_only_bars: &[u8]) -> Option<Result<u8, PciError>> {
+        self.bar_ioremap_with_mappings(metadata_only_bars, &[])
+    }
+    fn bar_ioremap_with_mappings(
+        &self,
+        metadata_only_bars: &[u8],
+        required_mappings: &[PciBarMappingRequest],
+    ) -> Option<Result<u8, PciError>> {
         let common_header = &self.common_header;
-        match pci_bar_init(common_header.bus_device_function) {
+        match pci_bar_init(
+            common_header.bus_device_function,
+            metadata_only_bars,
+            required_mappings,
+        ) {
             Ok(bar) => {
                 *self.standard_device_bar.write() = bar;
                 Some(Ok(0))
@@ -1199,9 +1269,11 @@ pub enum BarInfo {
         /// The memory address, always 16-byte aligned.
         address: u64,
         /// The size of the BAR in bytes.
-        size: u32,
+        size: u64,
         /// The virtaddress for a memory bar(mapped).
-        mmio_guard: Arc<MMIOSpaceGuard>,
+        mmio_guard: Option<Arc<MMIOSpaceGuard>>,
+        /// Individually mapped subranges for metadata-only BARs.
+        mapped_ranges: Vec<PciBarMappedRange>,
     },
     /// The BAR is for an I/O region.
     IO {
@@ -1218,8 +1290,8 @@ impl BarInfo {
     /// BAR.
     ///@brief 得到某个bar的memory_address与size(前提是他的类型为Memory Bar)
     ///@param self
-    ///@return Option<(u64, u32) 是Memory Bar返回内存地址与大小，不是则返回None
-    pub fn memory_address_size(&self) -> Option<(u64, u32)> {
+    ///@return Option<(u64, u64) 是Memory Bar返回内存地址与大小，不是则返回None
+    pub fn memory_address_size(&self) -> Option<(u64, u64)> {
         if let Self::Memory { address, size, .. } = self {
             Some((*address, *size))
         } else {
@@ -1231,11 +1303,61 @@ impl BarInfo {
     ///@return Option<(u64) 是Memory Bar返回映射的虚拟地址，不是则返回None
     pub fn virtual_address(&self) -> Option<VirtAddr> {
         if let Self::Memory { mmio_guard, .. } = self {
-            Some(mmio_guard.vaddr())
+            mmio_guard.as_ref().map(|guard| guard.vaddr())
         } else {
             None
         }
     }
+
+    pub fn virtual_address_at(&self, offset: u64, length: usize) -> Option<VirtAddr> {
+        let Self::Memory {
+            size,
+            mmio_guard,
+            mapped_ranges,
+            ..
+        } = self
+        else {
+            return None;
+        };
+        let length = u64::try_from(length).ok()?;
+        let end = offset.checked_add(length)?;
+        if end > *size {
+            return None;
+        }
+        if let Some(guard) = mmio_guard {
+            return Some(guard.vaddr() + usize::try_from(offset).ok()?);
+        }
+        mapped_ranges.iter().find_map(|range| {
+            let range_end = range.offset.checked_add(range.length)?;
+            if offset < range.offset || end > range_end {
+                return None;
+            }
+            Some(range.vaddr + usize::try_from(offset - range.offset).ok()?)
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PciBarMappingRequest {
+    pub bar: u8,
+    pub offset: u64,
+    pub length: u64,
+}
+
+fn unallocated_bar_has_required_mapping(
+    address: u64,
+    bar: u8,
+    required_mappings: &[PciBarMappingRequest],
+) -> bool {
+    address == 0 && required_mappings.iter().any(|request| request.bar == bar)
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PciBarMappedRange {
+    offset: u64,
+    length: u64,
+    vaddr: VirtAddr,
+    _guard: Arc<MMIOSpaceGuard>,
 }
 ///实现BarInfo的Display trait，自定义输出
 impl Display for BarInfo {
@@ -1247,6 +1369,7 @@ impl Display for BarInfo {
                 address,
                 size,
                 mmio_guard,
+                ..
             } => write!(
                 f,
                 "Memory space at {:#010x}, size {}, type {:?}, prefetchable {}, mmio_guard: {:?}",
@@ -1320,38 +1443,55 @@ impl Default for PciStandardDeviceBar {
 ///@return Result<PciStandardDeviceBar, PciError> 成功则返回对应的PciStandardDeviceBar结构体，失败则返回错误类型
 pub fn pci_bar_init(
     bus_device_function: BusDeviceFunction,
+    metadata_only_bars: &[u8],
+    required_mappings: &[PciBarMappingRequest],
 ) -> Result<PciStandardDeviceBar, PciError> {
+    struct DecodeGuard {
+        bus_device_function: BusDeviceFunction,
+        command: u16,
+    }
+
+    impl Drop for DecodeGuard {
+        fn drop(&mut self) {
+            pci_root_0().write_config(
+                self.bus_device_function,
+                STATUS_COMMAND_OFFSET.into(),
+                u32::from(self.command),
+            );
+        }
+    }
+
+    let command_status =
+        pci_root_0().read_config(bus_device_function, STATUS_COMMAND_OFFSET.into());
+    let command = command_status as u16;
+    pci_root_0().write_config(
+        bus_device_function,
+        STATUS_COMMAND_OFFSET.into(),
+        u32::from(command & !(Command::IO_SPACE | Command::MEMORY_SPACE).bits()),
+    );
+    let _decode_guard = DecodeGuard {
+        bus_device_function,
+        command,
+    };
     let mut device_bar: PciStandardDeviceBar = PciStandardDeviceBar::default();
+    let mut consumed_mappings = vec![false; required_mappings.len()];
     let mut bar_index_ignore: u8 = 255;
     for bar_index in 0..6 {
         if bar_index == bar_index_ignore {
             continue;
         }
         let bar_info;
-        let bar_orig =
-            pci_root_0().read_config(bus_device_function, (BAR0_OFFSET + 4 * bar_index).into());
-        pci_root_0().write_config(
-            bus_device_function,
-            (BAR0_OFFSET + 4 * bar_index).into(),
-            0xffffffff,
-        );
-        let size_mask =
-            pci_root_0().read_config(bus_device_function, (BAR0_OFFSET + 4 * bar_index).into());
-        // A wrapping add is necessary to correctly handle the case of unused BARs, which read back
-        // as 0, and should be treated as size 0.
-        let size = (!(size_mask & 0xfffffff0)).wrapping_add(1);
-        //debug!("bar_orig:{:#x},size: {:#x}", bar_orig,size);
-        // Restore the original value.
-        pci_root_0().write_config(
-            bus_device_function,
-            (BAR0_OFFSET + 4 * bar_index).into(),
-            bar_orig,
-        );
-        if size == 0 {
-            continue;
-        }
+        let bar_offset = BAR0_OFFSET + 4 * bar_index;
+        let bar_orig = pci_root_0().read_config(bus_device_function, bar_offset.into());
         if bar_orig & 0x00000001 == 0x00000001 {
             // I/O space
+            pci_root_0().write_config(bus_device_function, bar_offset.into(), 0xffffffff);
+            let size_mask = pci_root_0().read_config(bus_device_function, bar_offset.into());
+            pci_root_0().write_config(bus_device_function, bar_offset.into(), bar_orig);
+            let size = (!(size_mask & 0xfffffffc)).wrapping_add(1);
+            if size == 0 {
+                continue;
+            }
             let address = bar_orig & 0xfffffffc;
             bar_info = BarInfo::IO { address, size };
         } else {
@@ -1359,39 +1499,146 @@ pub fn pci_bar_init(
             let mut address = u64::from(bar_orig & 0xfffffff0);
             let prefetchable = bar_orig & 0x00000008 != 0;
             let address_type = MemoryBarType::try_from(((bar_orig & 0x00000006) >> 1) as u8)?;
-            if address_type == MemoryBarType::Width64 {
+            let size = if address_type == MemoryBarType::Width64 {
                 if bar_index >= 5 {
                     return Err(PciError::InvalidBarType);
                 }
-                let address_top = pci_root_0().read_config(
-                    bus_device_function,
-                    (BAR0_OFFSET + 4 * (bar_index + 1)).into(),
-                );
+                let high_offset = BAR0_OFFSET + 4 * (bar_index + 1);
+                let address_top = pci_root_0().read_config(bus_device_function, high_offset.into());
                 address |= u64::from(address_top) << 32;
                 bar_index_ignore = bar_index + 1; //下个bar跳过，因为64位的memory bar覆盖了两个bar
+
+                pci_root_0().write_config(bus_device_function, bar_offset.into(), 0xffffffff);
+                pci_root_0().write_config(bus_device_function, high_offset.into(), 0xffffffff);
+                let size_mask_low =
+                    pci_root_0().read_config(bus_device_function, bar_offset.into());
+                let size_mask_high =
+                    pci_root_0().read_config(bus_device_function, high_offset.into());
+                pci_root_0().write_config(bus_device_function, bar_offset.into(), bar_orig);
+                pci_root_0().write_config(bus_device_function, high_offset.into(), address_top);
+                let size_mask =
+                    (u64::from(size_mask_high) << 32) | u64::from(size_mask_low & 0xfffffff0);
+                (!size_mask).wrapping_add(1)
+            } else {
+                pci_root_0().write_config(bus_device_function, bar_offset.into(), 0xffffffff);
+                let size_mask = pci_root_0().read_config(bus_device_function, bar_offset.into());
+                pci_root_0().write_config(bus_device_function, bar_offset.into(), bar_orig);
+                u64::from((!(size_mask & 0xfffffff0)).wrapping_add(1))
+            };
+            if size == 0 {
+                continue;
             }
+            if unallocated_bar_has_required_mapping(address, bar_index, required_mappings) {
+                return Err(PciError::InvalidBarRange);
+            }
+
             let pci_address = PciAddr::new(address as usize);
             let paddr = PciArch::address_pci_to_physical(pci_address); //PCI总线域物理地址转换为存储器域物理地址
 
-            let space_guard: Arc<MMIOSpaceGuard>;
-            unsafe {
-                let size_want = size as usize;
-                let tmp = mmio_pool()
+            // Keep resource discovery independent from virtual mapping. Very large 64-bit BARs,
+            // such as a virtiofs DAX window, must not consume an equally large MMIO VA range.
+            let (space_guard, mapped_ranges) = if address == 0 {
+                // Preserve the BAR metadata for resource discovery, but never map an
+                // unallocated BAR at physical address zero.
+                (None, Vec::new())
+            } else if metadata_only_bars.contains(&bar_index) {
+                let mut intervals = Vec::new();
+                for (index, request) in required_mappings.iter().enumerate() {
+                    if request.bar != bar_index {
+                        continue;
+                    }
+                    let end = request
+                        .offset
+                        .checked_add(request.length)
+                        .ok_or(PciError::InvalidBarRange)?;
+                    if request.length == 0 || end > size {
+                        return Err(PciError::InvalidBarRange);
+                    }
+                    consumed_mappings[index] = true;
+                    let start =
+                        usize::try_from(request.offset).map_err(|_| PciError::InvalidBarRange)?;
+                    let end = usize::try_from(end).map_err(|_| PciError::InvalidBarRange)?;
+                    let aligned_start = crate::libs::align::page_align_down(start);
+                    let aligned_end = end
+                        .checked_add(MMArch::PAGE_SIZE - 1)
+                        .map(crate::libs::align::page_align_down)
+                        .ok_or(PciError::InvalidBarRange)?;
+                    intervals.push((aligned_start, aligned_end));
+                }
+                intervals.sort_unstable_by_key(|interval| interval.0);
+                let mut merged: Vec<(usize, usize)> = Vec::new();
+                for (start, end) in intervals {
+                    if let Some(last) = merged.last_mut() {
+                        if start <= last.1 {
+                            last.1 = last.1.max(end);
+                            continue;
+                        }
+                    }
+                    merged.push((start, end));
+                }
+
+                let mut mapped_ranges = Vec::new();
+                for (start, end) in merged {
+                    let length = end.checked_sub(start).ok_or(PciError::InvalidBarRange)?;
+                    let request_paddr = paddr
+                        .data()
+                        .checked_add(start)
+                        .map(PhysAddr::new)
+                        .ok_or(PciError::InvalidBarRange)?;
+                    let page_offset = request_paddr.data() & (MMArch::PAGE_SIZE - 1);
+                    let mapped_length = crate::libs::align::page_align_up(
+                        length
+                            .checked_add(page_offset)
+                            .ok_or(PciError::InvalidBarRange)?,
+                    );
+                    let guard = mmio_pool()
+                        .create_mmio(mapped_length)
+                        .map_err(|_| PciError::CreateMmioError)?;
+                    let vaddr = unsafe {
+                        guard
+                            .map_any_phys(request_paddr, length)
+                            .map_err(|_| PciError::CreateMmioError)?
+                    };
+                    mapped_ranges.push(PciBarMappedRange {
+                        offset: start as u64,
+                        length: length as u64,
+                        vaddr,
+                        _guard: Arc::new(guard),
+                    });
+                }
+                (None, mapped_ranges)
+            } else {
+                for (index, request) in required_mappings.iter().enumerate() {
+                    if request.bar != bar_index {
+                        continue;
+                    }
+                    let end = request
+                        .offset
+                        .checked_add(request.length)
+                        .ok_or(PciError::InvalidBarRange)?;
+                    if request.length == 0 || end > size {
+                        return Err(PciError::InvalidBarRange);
+                    }
+                    consumed_mappings[index] = true;
+                }
+                let size_want = usize::try_from(size).map_err(|_| PciError::CreateMmioError)?;
+                let guard = mmio_pool()
                     .create_mmio(size_want)
                     .map_err(|_| PciError::CreateMmioError)?;
-                space_guard = Arc::new(tmp);
-                //debug!("Pci bar init: mmio space: {space_guard:?}, paddr={paddr:?}, size_want={size_want}");
-                assert!(
-                    space_guard.map_phys(paddr, size_want).is_ok(),
-                    "pci_bar_init: map_phys failed"
-                );
-            }
+                unsafe {
+                    guard
+                        .map_phys(paddr, size_want)
+                        .map_err(|_| PciError::CreateMmioError)?;
+                }
+                (Some(Arc::new(guard)), Vec::new())
+            };
             bar_info = BarInfo::Memory {
                 address_type,
                 prefetchable,
                 address,
                 size,
                 mmio_guard: space_guard,
+                mapped_ranges,
             };
         }
         match bar_index {
@@ -1416,8 +1663,29 @@ pub fn pci_bar_init(
             _ => {}
         }
     }
+    if consumed_mappings.iter().any(|consumed| !consumed) {
+        return Err(PciError::InvalidBarRange);
+    }
     //debug!("pci_device_bar:{}", device_bar);
     return Ok(device_bar);
+}
+
+#[cfg(test)]
+mod bar_mapping_tests {
+    use super::{unallocated_bar_has_required_mapping, PciBarMappingRequest};
+
+    #[test]
+    fn rejects_required_mapping_for_unallocated_bar() {
+        let mappings = [PciBarMappingRequest {
+            bar: 2,
+            offset: 0x1000,
+            length: 0x1000,
+        }];
+
+        assert!(unallocated_bar_has_required_mapping(0, 2, &mappings));
+        assert!(!unallocated_bar_has_required_mapping(0, 1, &mappings));
+        assert!(!unallocated_bar_has_required_mapping(0x1000, 2, &mappings));
+    }
 }
 
 /// Information about a PCI device capability.

--- a/kernel/src/driver/pci/pci_irq.rs
+++ b/kernel/src/driver/pci/pci_irq.rs
@@ -575,10 +575,13 @@ pub trait PciInterrupt: PciDeviceStructure {
                         .read();
                     let msix_bar = pcistandardbar.get_bar(msix_table_bar)?;
                     let vaddr: crate::mm::VirtAddr = msix_bar
-                        .virtual_address()
-                        .ok_or(PciError::PciIrqError(PciIrqError::BarGetVaddrFailed))?
-                        + msix_table_offset as usize
-                        + msg.irq_common_message.irq_index as usize * size_of::<MsixEntry>();
+                        .virtual_address_at(
+                            u64::from(msix_table_offset)
+                                + msg.irq_common_message.irq_index as u64
+                                    * size_of::<MsixEntry>() as u64,
+                            size_of::<MsixEntry>(),
+                        )
+                        .ok_or(PciError::PciIrqError(PciIrqError::BarGetVaddrFailed))?;
                     let msix_entry = NonNull::new(vaddr.data() as *mut MsixEntry).unwrap();
                     // 这里的操作并不适用于所有架构，需要再优化，msg_upper_data并不一定为0
                     unsafe {
@@ -698,11 +701,13 @@ pub trait PciInterrupt: PciDeviceStructure {
                     let msix_bar = pcistandardbar.get_bar(msix_table_bar).unwrap();
                     for index in 0..irq_max_num {
                         let vaddr = msix_bar
-                            .virtual_address()
+                            .virtual_address_at(
+                                u64::from(msix_table_offset)
+                                    + index as u64 * size_of::<MsixEntry>() as u64,
+                                size_of::<MsixEntry>(),
+                            )
                             .ok_or(PciError::PciIrqError(PciIrqError::BarGetVaddrFailed))
-                            .unwrap()
-                            + msix_table_offset as usize
-                            + index as usize * size_of::<MsixEntry>();
+                            .unwrap();
                         let msix_entry = NonNull::new(vaddr.data() as *mut MsixEntry).unwrap();
                         unsafe {
                             volwrite!(msix_entry, vector_control, 0);
@@ -826,9 +831,13 @@ pub trait PciInterrupt: PciDeviceStructure {
                         .unwrap()
                         .read();
                     let msix_bar = pcistandardbar.get_bar(msix_table_bar).unwrap();
-                    let vaddr = msix_bar.virtual_address().unwrap()
-                        + msix_table_offset as usize
-                        + irq_index as usize * size_of::<MsixEntry>();
+                    let vaddr = msix_bar
+                        .virtual_address_at(
+                            u64::from(msix_table_offset)
+                                + irq_index as u64 * size_of::<MsixEntry>() as u64,
+                            size_of::<MsixEntry>(),
+                        )
+                        .unwrap();
                     let msix_entry = NonNull::new(vaddr.data() as *mut MsixEntry).unwrap();
                     unsafe {
                         volwrite!(msix_entry, vector_control, 1);
@@ -947,9 +956,13 @@ pub trait PciInterrupt: PciDeviceStructure {
                         .unwrap()
                         .read();
                     let msix_bar = pcistandardbar.get_bar(msix_table_bar).unwrap();
-                    let vaddr = msix_bar.virtual_address().unwrap()
-                        + msix_table_offset as usize
-                        + irq_index as usize * size_of::<MsixEntry>();
+                    let vaddr = msix_bar
+                        .virtual_address_at(
+                            u64::from(msix_table_offset)
+                                + irq_index as u64 * size_of::<MsixEntry>() as u64,
+                            size_of::<MsixEntry>(),
+                        )
+                        .unwrap();
                     let msix_entry = NonNull::new(vaddr.data() as *mut MsixEntry).unwrap();
                     unsafe {
                         volwrite!(msix_entry, vector_control, 0);
@@ -1062,9 +1075,13 @@ pub trait PciInterrupt: PciDeviceStructure {
                         .unwrap()
                         .read();
                     let pending_bar = pcistandardbar.get_bar(pending_table_bar).unwrap();
-                    let vaddr = pending_bar.virtual_address().unwrap()
-                        + pending_table_offset as usize
-                        + (irq_index as usize / 64) * size_of::<PendingEntry>();
+                    let vaddr = pending_bar
+                        .virtual_address_at(
+                            u64::from(pending_table_offset)
+                                + (irq_index as u64 / 64) * size_of::<PendingEntry>() as u64,
+                            size_of::<PendingEntry>(),
+                        )
+                        .unwrap();
                     let pending_entry = NonNull::new(vaddr.data() as *mut PendingEntry).unwrap();
                     let pending_entry = unsafe { volread!(pending_entry, entry) };
                     return Ok(pending_entry & (1 << (irq_index as u64 % 64)) != 0);

--- a/kernel/src/driver/virtio/transport.rs
+++ b/kernel/src/driver/virtio/transport.rs
@@ -12,11 +12,40 @@ use crate::{
         },
     },
     exception::IrqNumber,
+    mm::PhysAddr,
 };
 
 use super::{
     irq::DefaultVirtioIrqHandler, transport_mmio::VirtIOMmioTransport, transport_pci::PciTransport,
 };
+
+/// A validated VirtIO shared-memory region descriptor.
+///
+/// This is address metadata only. It does not grant access to the region or describe a safe
+/// cache policy for normal memory accesses.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VirtioSharedMemoryRegion {
+    physical_address: PhysAddr,
+    length: u64,
+}
+
+impl VirtioSharedMemoryRegion {
+    pub(crate) fn new(physical_address: PhysAddr, length: u64) -> Self {
+        Self {
+            physical_address,
+            length,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn physical_address(&self) -> PhysAddr {
+        self.physical_address
+    }
+
+    pub fn length(&self) -> u64 {
+        self.length
+    }
+}
 
 pub enum VirtIOTransport {
     Pci(PciTransport),
@@ -40,6 +69,13 @@ impl VirtIOTransport {
                 )
             }
             VirtIOTransport::Mmio(_) => false,
+        }
+    }
+
+    pub fn shared_memory_region(&self, id: u8) -> Option<VirtioSharedMemoryRegion> {
+        match self {
+            VirtIOTransport::Pci(transport) => transport.shared_memory_region(id),
+            VirtIOTransport::Mmio(_) => None,
         }
     }
 

--- a/kernel/src/driver/virtio/transport_pci.rs
+++ b/kernel/src/driver/virtio/transport_pci.rs
@@ -1,9 +1,10 @@
 //! PCI transport for VirtIO.
 
+use crate::arch::{PciArch, TraitPciArch};
 use crate::driver::base::device::DeviceId;
 use crate::driver::pci::pci::{
-    BusDeviceFunction, PciDeviceStructure, PciDeviceStructureGeneralDevice, PciError,
-    PciStandardDeviceBar, PCI_CAP_ID_VNDR,
+    BusDeviceFunction, PciAddr, PciBarMappingRequest, PciDeviceStructure,
+    PciDeviceStructureGeneralDevice, PciError, PciStandardDeviceBar, PCI_CAP_ID_VNDR,
 };
 
 use crate::driver::pci::root::pci_root_0;
@@ -11,7 +12,7 @@ use crate::driver::pci::root::pci_root_0;
 use crate::exception::IrqNumber;
 
 use crate::libs::volatile::{ReadOnly, Volatile, VolatileReadable, VolatileWritable, WriteOnly};
-use crate::mm::VirtAddr;
+use crate::mm::{PhysAddr, VirtAddr};
 
 use alloc::{sync::Arc, vec, vec::Vec};
 use core::{
@@ -22,9 +23,10 @@ use core::{
 use log::warn;
 use virtio_drivers::{
     transport::{DeviceStatus, DeviceType, Transport},
-    Error, Hal, PhysAddr,
+    Error, Hal, PhysAddr as VirtioPhysAddr,
 };
 
+use super::transport::VirtioSharedMemoryRegion;
 use super::VIRTIO_VENDOR_ID;
 use crate::driver::pci::pci_irq::IrqType;
 
@@ -48,6 +50,9 @@ const CAP_BAR_OFFSET_OFFSET: u8 = 8;
 const CAP_LENGTH_OFFSET: u8 = 12;
 /// The offset of the`notify_off_multiplier` field within `virtio_pci_notify_cap`.
 const CAP_NOTIFY_OFF_MULTIPLIER_OFFSET: u8 = 16;
+const CAP_SHARED_MEMORY_OFFSET_HI_OFFSET: u8 = 16;
+const CAP_SHARED_MEMORY_LENGTH_HI_OFFSET: u8 = 20;
+const VIRTIO_PCI_CAP64_LEN: u8 = 24;
 
 /// Common configuration.
 const VIRTIO_PCI_CAP_COMMON_CFG: u8 = 1;
@@ -57,6 +62,12 @@ const VIRTIO_PCI_CAP_NOTIFY_CFG: u8 = 2;
 const VIRTIO_PCI_CAP_ISR_CFG: u8 = 3;
 /// Device specific configuration.
 const VIRTIO_PCI_CAP_DEVICE_CFG: u8 = 4;
+/// Additional shared memory capability.
+const VIRTIO_PCI_CAP_SHARED_MEMORY_CFG: u8 = 8;
+
+fn shared_memory_cap_len_supported(cap_len: u8) -> bool {
+    cap_len >= VIRTIO_PCI_CAP64_LEN
+}
 
 /// The interrupt vector number for VirtIO device receive interrupts.
 const VIRTIO_RECV_VECTOR: IrqNumber = IrqNumber::new(56);
@@ -102,6 +113,7 @@ pub struct PciTransport {
     irq: IrqNumber,
     dev_id: Arc<DeviceId>,
     device: Arc<PciDeviceStructureGeneralDevice>,
+    shared_memory_regions: Vec<(u8, Option<VirtioSharedMemoryRegion>)>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -152,7 +164,61 @@ impl PciTransport {
         let mut notify_off_multiplier = 0;
         let mut isr_cfg = None;
         let mut device_cfg = None;
-        device.bar_ioremap().unwrap()?;
+        let mut shared_memory_regions = Vec::new();
+        let mut shared_memory_bars = Vec::new();
+        let mut transport_config_mappings = Vec::new();
+        let mut mapped_config_types = Vec::new();
+        for capability in device.capabilities().unwrap() {
+            if capability.id != PCI_CAP_ID_VNDR {
+                continue;
+            }
+            let cap_len = capability.private_header as u8;
+            let cfg_type = (capability.private_header >> 8) as u8;
+            if cap_len < 16 || capability.offset.checked_add(cap_len - 1).is_none() {
+                continue;
+            }
+            let bar = pci_root_0().read_config(
+                bus_device_function,
+                (capability.offset + CAP_BAR_OFFSET).into(),
+            ) as u8;
+            let valid_transport_config = matches!(
+                cfg_type,
+                VIRTIO_PCI_CAP_COMMON_CFG
+                    | VIRTIO_PCI_CAP_NOTIFY_CFG
+                    | VIRTIO_PCI_CAP_ISR_CFG
+                    | VIRTIO_PCI_CAP_DEVICE_CFG
+            ) && (cfg_type != VIRTIO_PCI_CAP_NOTIFY_CFG
+                || cap_len >= 20);
+            if valid_transport_config && bar < 6 && !mapped_config_types.contains(&cfg_type) {
+                let offset = pci_root_0().read_config(
+                    bus_device_function,
+                    (capability.offset + CAP_BAR_OFFSET_OFFSET).into(),
+                );
+                let length = pci_root_0().read_config(
+                    bus_device_function,
+                    (capability.offset + CAP_LENGTH_OFFSET).into(),
+                );
+                transport_config_mappings.push(PciBarMappingRequest {
+                    bar,
+                    offset: u64::from(offset),
+                    length: u64::from(length),
+                });
+                mapped_config_types.push(cfg_type);
+            }
+            if cfg_type != VIRTIO_PCI_CAP_SHARED_MEMORY_CFG
+                || !shared_memory_cap_len_supported(cap_len)
+                || capability.offset.checked_add(cap_len - 1).is_none()
+            {
+                continue;
+            }
+            if bar < 6 && !shared_memory_bars.contains(&bar) {
+                shared_memory_bars.push(bar);
+            }
+        }
+        transport_config_mappings.extend(device.msix_mapping_requests()?);
+        device
+            .bar_ioremap_with_mappings(&shared_memory_bars, &transport_config_mappings)
+            .unwrap()?;
         device.enable_master();
         let standard_device = device.as_standard_device().unwrap();
         // Currently there is no unified management of PCI device interrupt numbers, so an
@@ -171,6 +237,9 @@ impl PciTransport {
             if cap_len < 16 {
                 continue;
             }
+            if capability.offset.checked_add(cap_len - 1).is_none() {
+                continue;
+            }
             let struct_info = VirtioCapabilityInfo {
                 bar: pci_root_0().read_config(
                     bus_device_function,
@@ -187,21 +256,63 @@ impl PciTransport {
             };
 
             match cfg_type {
-                VIRTIO_PCI_CAP_COMMON_CFG if common_cfg.is_none() => {
+                VIRTIO_PCI_CAP_COMMON_CFG if struct_info.bar < 6 && common_cfg.is_none() => {
                     common_cfg = Some(struct_info);
                 }
-                VIRTIO_PCI_CAP_NOTIFY_CFG if cap_len >= 20 && notify_cfg.is_none() => {
+                VIRTIO_PCI_CAP_NOTIFY_CFG
+                    if cap_len >= 20 && struct_info.bar < 6 && notify_cfg.is_none() =>
+                {
                     notify_cfg = Some(struct_info);
                     notify_off_multiplier = pci_root_0().read_config(
                         bus_device_function,
                         (capability.offset + CAP_NOTIFY_OFF_MULTIPLIER_OFFSET).into(),
                     );
                 }
-                VIRTIO_PCI_CAP_ISR_CFG if isr_cfg.is_none() => {
+                VIRTIO_PCI_CAP_ISR_CFG if struct_info.bar < 6 && isr_cfg.is_none() => {
                     isr_cfg = Some(struct_info);
                 }
-                VIRTIO_PCI_CAP_DEVICE_CFG if device_cfg.is_none() => {
+                VIRTIO_PCI_CAP_DEVICE_CFG if struct_info.bar < 6 && device_cfg.is_none() => {
                     device_cfg = Some(struct_info);
+                }
+                VIRTIO_PCI_CAP_SHARED_MEMORY_CFG if shared_memory_cap_len_supported(cap_len) => {
+                    if struct_info.bar >= 6 {
+                        continue;
+                    }
+                    let bar_and_id = pci_root_0().read_config(
+                        bus_device_function,
+                        (capability.offset + CAP_BAR_OFFSET).into(),
+                    );
+                    let id = (bar_and_id >> 8) as u8;
+                    if shared_memory_regions
+                        .iter()
+                        .any(|(seen_id, _)| *seen_id == id)
+                    {
+                        continue;
+                    }
+
+                    let offset_hi = pci_root_0().read_config(
+                        bus_device_function,
+                        (capability.offset + CAP_SHARED_MEMORY_OFFSET_HI_OFFSET).into(),
+                    );
+                    let length_hi = pci_root_0().read_config(
+                        bus_device_function,
+                        (capability.offset + CAP_SHARED_MEMORY_LENGTH_HI_OFFSET).into(),
+                    );
+                    let offset = u64::from(struct_info.offset) | (u64::from(offset_hi) << 32);
+                    let length = u64::from(struct_info.length) | (u64::from(length_hi) << 32);
+                    let region = validate_shared_memory_region(
+                        &device.standard_device_bar.read(),
+                        struct_info.bar,
+                        offset,
+                        length,
+                    );
+                    if region.is_none() {
+                        warn!(
+                            "VirtIO PCI shared-memory capability id={} is outside its BAR or cannot be represented",
+                            id
+                        );
+                    }
+                    shared_memory_regions.push((id, region));
                 }
                 _ => {}
             }
@@ -247,6 +358,7 @@ impl PciTransport {
             irq,
             dev_id,
             device,
+            shared_memory_regions,
         })
     }
 
@@ -266,6 +378,13 @@ impl PciTransport {
 
     pub fn ack_interrupt_ref(&self) -> bool {
         self.interrupt_ack().ack_interrupt()
+    }
+
+    pub fn shared_memory_region(&self, id: u8) -> Option<VirtioSharedMemoryRegion> {
+        self.shared_memory_regions
+            .iter()
+            .find(|(region_id, _)| *region_id == id)
+            .and_then(|(_, region)| *region)
     }
 
     fn cache_queue_notify_index(&mut self, queue: u16) -> Option<usize> {
@@ -404,9 +523,9 @@ impl Transport for PciTransport {
         &mut self,
         queue: u16,
         size: u32,
-        descriptors: PhysAddr,
-        driver_area: PhysAddr,
-        device_area: PhysAddr,
+        descriptors: VirtioPhysAddr,
+        driver_area: VirtioPhysAddr,
+        device_area: VirtioPhysAddr,
     ) {
         // Safe because the common config pointer is valid and we checked in get_bar_region that it
         // was aligned.
@@ -634,16 +753,17 @@ fn get_bar_region<T>(
     if bar_address == 0 {
         return Err(VirtioPciError::BarNotAllocated(struct_info.bar));
     }
-    if struct_info.offset + struct_info.length > bar_size
+    if u64::from(struct_info.offset)
+        .checked_add(u64::from(struct_info.length))
+        .is_none_or(|end| end > bar_size)
         || size_of::<T>() > struct_info.length as usize
     {
         return Err(VirtioPciError::BarOffsetOutOfRange);
     }
     //debug!("Chossed bar ={},used={}",struct_info.bar,struct_info.offset + struct_info.length);
-    let vaddr = (bar_info
-        .virtual_address()
-        .ok_or(VirtioPciError::BarGetVaddrFailed)?)
-        + struct_info.offset as usize;
+    let vaddr = bar_info
+        .virtual_address_at(u64::from(struct_info.offset), struct_info.length as usize)
+        .ok_or(VirtioPciError::BarGetVaddrFailed)?;
     if !vaddr.data().is_multiple_of(align_of::<T>()) {
         return Err(VirtioPciError::Misaligned {
             vaddr,
@@ -675,4 +795,81 @@ fn get_bar_region_slice<T>(
 
 fn nonnull_slice_from_raw_parts<T>(data: NonNull<T>, len: usize) -> NonNull<[T]> {
     NonNull::new(ptr::slice_from_raw_parts_mut(data.as_ptr(), len)).unwrap()
+}
+
+fn validate_shared_memory_region(
+    device_bar: &PciStandardDeviceBar,
+    bar: u8,
+    offset: u64,
+    length: u64,
+) -> Option<VirtioSharedMemoryRegion> {
+    let bar_info = device_bar.get_bar(bar).ok()?;
+    let (bar_address, bar_size) = bar_info.memory_address_size()?;
+    validate_shared_memory_range(bar_address, bar_size, offset, length)
+}
+
+fn validate_shared_memory_range(
+    bar_address: u64,
+    bar_size: u64,
+    offset: u64,
+    length: u64,
+) -> Option<VirtioSharedMemoryRegion> {
+    if bar_address == 0 {
+        return None;
+    }
+
+    let end = offset.checked_add(length)?;
+    if end > bar_size {
+        return None;
+    }
+
+    let bar_address = usize::try_from(bar_address).ok()?;
+    let offset = usize::try_from(offset).ok()?;
+    let physical_base = PciArch::address_pci_to_physical(PciAddr::new(bar_address));
+    let physical_address = physical_base.data().checked_add(offset)?;
+    Some(VirtioSharedMemoryRegion::new(
+        PhysAddr::new(physical_address),
+        length,
+    ))
+}
+
+#[cfg(test)]
+mod shared_memory_tests {
+    use super::{shared_memory_cap_len_supported, validate_shared_memory_range};
+
+    #[test]
+    fn accepts_padded_shared_memory_capability() {
+        assert!(!shared_memory_cap_len_supported(23));
+        assert!(shared_memory_cap_len_supported(24));
+        assert!(shared_memory_cap_len_supported(28));
+    }
+
+    #[test]
+    fn validates_shared_memory_range() {
+        let region = validate_shared_memory_range(0x1000, 0x4000, 0x1000, 0x2000).unwrap();
+        assert_eq!(region.physical_address().data(), 0x2000);
+        assert_eq!(region.length(), 0x2000);
+    }
+
+    #[test]
+    fn rejects_unallocated_shared_memory_bar() {
+        assert!(validate_shared_memory_range(0, 0x4000, 0x1000, 0x2000).is_none());
+    }
+
+    #[test]
+    fn preserves_zero_length_region() {
+        let region = validate_shared_memory_range(0x1000, 0x4000, 0x4000, 0).unwrap();
+        assert_eq!(region.physical_address().data(), 0x5000);
+        assert_eq!(region.length(), 0);
+    }
+
+    #[test]
+    fn rejects_range_end_overflow() {
+        assert!(validate_shared_memory_range(0x1000, u64::MAX, u64::MAX, 1).is_none());
+    }
+
+    #[test]
+    fn rejects_range_outside_bar() {
+        assert!(validate_shared_memory_range(0x1000, 0x4000, 0x3000, 0x1001).is_none());
+    }
 }

--- a/kernel/src/driver/virtio/virtio_fs.rs
+++ b/kernel/src/driver/virtio/virtio_fs.rs
@@ -18,13 +18,14 @@ use crate::{
 
 use super::{
     irq::{virtio_irq_manager, VirtioIrqCallback},
-    transport::VirtIOTransport,
+    transport::{VirtIOTransport, VirtioSharedMemoryRegion},
     transport_pci::PciInterruptAck,
 };
 
 const VIRTIO_FS_TAG_LEN: usize = 36;
 const VIRTIO_FS_REQUEST_QUEUE_BASE: u16 = 1;
 const VIRTIO_FS_MAX_REQUEST_QUEUES: u32 = 64;
+const VIRTIO_FS_SHMCAP_ID_CACHE: u8 = 0;
 
 #[repr(C, packed)]
 struct VirtioFsConfig {
@@ -48,6 +49,13 @@ unsafe impl Send for VirtioFsTransportHolder {}
 struct VirtioFsActiveBridge {
     session_id: u64,
     conn: Weak<FuseConn>,
+}
+
+#[derive(Debug)]
+struct VirtioFsIrqConfig {
+    wake_enabled: bool,
+    is_msix: bool,
+    ack: Option<PciInterruptAck>,
 }
 
 #[derive(Debug)]
@@ -86,6 +94,7 @@ pub struct VirtioFsInstance {
     irq_wake_enabled: bool,
     irq_is_msix: bool,
     irq_ack: Option<PciInterruptAck>,
+    cache_region: Option<VirtioSharedMemoryRegion>,
     state: SpinLock<VirtioFsInstanceState>,
     session_wait: WaitQueue,
 }
@@ -96,17 +105,17 @@ impl VirtioFsInstance {
         num_request_queues: u32,
         dev_id: Arc<DeviceId>,
         transport: VirtIOTransport,
-        irq_wake_enabled: bool,
-        irq_is_msix: bool,
-        irq_ack: Option<PciInterruptAck>,
+        irq: VirtioFsIrqConfig,
+        cache_region: Option<VirtioSharedMemoryRegion>,
     ) -> Self {
         Self {
             tag,
             num_request_queues,
             dev_id,
-            irq_wake_enabled,
-            irq_is_msix,
-            irq_ack,
+            irq_wake_enabled: irq.wake_enabled,
+            irq_is_msix: irq.is_msix,
+            irq_ack: irq.ack,
+            cache_region,
             state: SpinLock::new(VirtioFsInstanceState {
                 transport: Some(VirtioFsTransportHolder(transport)),
                 session_active: false,
@@ -129,6 +138,10 @@ impl VirtioFsInstance {
 
     pub fn num_request_queues(&self) -> u32 {
         self.num_request_queues
+    }
+
+    pub fn cache_region(&self) -> Option<VirtioSharedMemoryRegion> {
+        self.cache_region
     }
 
     pub fn hiprio_queue_index(&self) -> u16 {
@@ -402,6 +415,9 @@ pub fn virtio_fs(
     let mut irq_wake_enabled = false;
     let mut irq_is_msix = false;
     let mut irq_ack = None;
+    let cache_region = transport
+        .shared_memory_region(VIRTIO_FS_SHMCAP_ID_CACHE)
+        .filter(|region| region.length() != 0);
     if matches!(transport, VirtIOTransport::Pci(_)) {
         if let Err(e) = transport.setup_irq(dev_id.clone()) {
             warn!(
@@ -427,11 +443,15 @@ pub fn virtio_fs(
         nrqs,
         dev_id.clone(),
         transport,
-        irq_wake_enabled,
-        irq_is_msix,
-        irq_ack,
+        VirtioFsIrqConfig {
+            wake_enabled: irq_wake_enabled,
+            is_msix: irq_is_msix,
+            ack: irq_ack,
+        },
+        cache_region,
     ));
 
+    let cache_region_len = instance.cache_region().map(|region| region.length());
     let mut map = VIRTIO_FS_INSTANCES.lock_irqsave();
     if map.contains_key(&tag) {
         warn!(
@@ -443,8 +463,8 @@ pub fn virtio_fs(
 
     map.insert(tag.clone(), instance);
     info!(
-        "virtio-fs: registered instance tag='{}' dev={:?} request_queues={}",
-        tag, dev_id, nrqs
+        "virtio-fs: registered instance tag='{}' dev={:?} request_queues={} cache_region_len={:?}",
+        tag, dev_id, nrqs, cache_region_len
     );
 }
 


### PR DESCRIPTION
## Summary

- discover and validate VirtIO PCI shared-memory cap64 regions
- expose the virtiofs cache-region descriptor without enabling incomplete DAX I/O
- preserve full 64-bit PCI BAR resource sizes and avoid mapping dedicated shared-memory BARs into the MMIO VA pool
- map only VirtIO transport config, MSI-X table, and PBA subranges when they share a metadata-only cache BAR
- disable PCI address decoding safely while probing BAR sizes

## Root cause

DragonOS only parsed VirtIO PCI configuration capabilities 1 through 4, so virtiofs could not discover shared-memory cache capability ID 0. The PCI BAR model also truncated resource lengths to 32 bits and mapped every memory BAR wholesale, which is unsuitable for large DAX windows.

## Behavior

Virtiofs now records a validated cache-region descriptor when the host provides one. DAX data paths are intentionally not enabled by this stage: `dax=always` and `dax=inode` continue to fail explicitly until mapping allocation, FUSE mapping requests, fault handling, invalidation, and teardown are implemented.

## Validation

- `make fmt`
- `make kernel`
- QEMU nographic boot with vhost-user virtiofs
- verified device registration reports no cache region on the current non-DAX host
- mounted `hostshare` in the DragonOS guest and read back a file through the regular virtiofs path
- `git diff --cached --check`

Closes #2076

Refs #2019
