### PR TITLE
fix(ext4): defer rename and rmdir inode reclaim

### DIFF
--- a/kernel/crates/another_ext4/src/ext4/link.rs
+++ b/kernel/crates/another_ext4/src/ext4/link.rs
@@ -2,6 +2,13 @@ use super::Ext4;
 use crate::ext4_defs::*;
 use crate::prelude::*;
 
+/// Whether removing one published namespace entry makes the inode an orphan.
+/// Directories cannot have hard-link aliases: once rmdir/rename has verified
+/// that the directory is empty, Linux clears even an unexpectedly high nlink.
+pub(super) fn namespace_removal_is_final(is_dir: bool, link_count: u16) -> bool {
+    is_dir || link_count <= 1
+}
+
 impl Ext4 {
     /// Link a child inode to a parent directory.
     pub(super) fn link_inode(
@@ -76,7 +83,10 @@ impl Ext4 {
         name: &str,
     ) -> Result<Option<InodeReclaimHandle>> {
         let child_link_cnt = child.inode.link_count();
-        let final_link = (child.inode.is_dir() && child_link_cnt <= 2) || child_link_cnt <= 1;
+        // Linux clears an empty directory's link count unconditionally after
+        // removing its sole parent entry.  A stale/high directory nlink is a
+        // corruption warning, not evidence of another namespace alias.
+        let final_link = namespace_removal_is_final(child.inode.is_dir(), child_link_cnt);
 
         if final_link {
             // Linux journals deletion of the directory entry, the zero link
@@ -124,5 +134,18 @@ impl Ext4 {
             return Err(error);
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::namespace_removal_is_final;
+
+    #[test]
+    fn empty_directory_removal_is_final_despite_stale_high_nlink() {
+        assert!(namespace_removal_is_final(true, 7));
+        assert!(namespace_removal_is_final(true, u16::MAX));
+        assert!(namespace_removal_is_final(false, 1));
+        assert!(!namespace_removal_is_final(false, 2));
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -899,8 +899,12 @@ impl Ext4 {
                 }
 
                 let existing_link_cnt = existing_inode.inode.link_count();
+                // An empty replaced directory loses its only parent entry and
+                // Linux clear_nlink()s it even when an old/corrupt on-disk
+                // count is unexpectedly greater than two.  Regular files can
+                // still have independent hard links.
                 let final_target =
-                    existing_link_cnt <= 1 || (existing_is_dir && existing_link_cnt <= 2);
+                    super::link::namespace_removal_is_final(existing_is_dir, existing_link_cnt);
 
                 // Upper bound of distinct home blocks in the replace set:
                 // destination dirent + source dirent + optional child "..";

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -472,6 +472,12 @@ impl Ext4 {
         Ok(())
     }
 
+    /// Prevent every subsequent metadata mutation after an upper-layer
+    /// lifecycle invariant becomes indeterminate.
+    pub fn fail_stop_mutations(&self) {
+        self.poison(ErrCode::EIO);
+    }
+
     fn ranges_overlap(
         start: PBlockId,
         end: PBlockId,

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -87,6 +87,11 @@ pub struct Ext4FileSystem {
     /// Fail-stop allocation after an indeterminate physical reclaim.
     lifecycle_error: Mutex<Option<SystemError>>,
 
+    /// Own capabilities whose canonical handoff cannot be reconstructed after
+    /// an impossible namespace outcome. A fail-stopped mount keeps them alive;
+    /// mount recovery consumes the durable orphan chain after teardown.
+    pub(super) quarantined_reclaims: SpinLock<Vec<another_ext4::InodeReclaimHandle>>,
+
     eviction_queue: SpinLock<Ext4EvictionQueueState>,
     eviction_wait: WaitQueue,
 
@@ -278,6 +283,7 @@ impl Ext4FileSystem {
 
     pub(super) fn fail_stop_lifecycle(&self) {
         *self.lifecycle_error.lock() = Some(SystemError::EIO);
+        self.fs.fail_stop_mutations();
     }
 
     pub(super) fn get_or_create_inode(
@@ -795,6 +801,7 @@ impl Ext4FileSystem {
             inode_table: Mutex::new(BTreeMap::new()),
             inode_reuse_barrier: RwSem::new(()),
             lifecycle_error: Mutex::new(None),
+            quarantined_reclaims: SpinLock::new(Vec::new()),
             eviction_queue: SpinLock::new(Ext4EvictionQueueState::default()),
             eviction_wait: WaitQueue::default(),
             _mount_options: mount_options,

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -621,36 +621,14 @@ impl IndexNode for LockedExt4Inode {
         )?;
         let target_lifecycle = target.lifecycle().clone();
         let _link_mutation = target_lifecycle.lock_link_mutation();
-        let target_attr = ext4.getattr(target_num)?;
-
-        // Removing a non-final hard link must not enter the eviction lifecycle: the
-        // canonical inode and its shared page cache remain live for the other aliases.
-        if target_attr.links > 1 {
-            let _target_operation = target.begin_operation()?;
-            if ext4.lookup(inode_num, name)? != target_num {
-                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-            }
-            if let Some(handle) = Self::retry_metadata_contention(|| ext4.unlink(inode_num, name))?
-            {
-                fs.fs
-                    .reclaim_inode(handle)
-                    .map_err(|failure| SystemError::from(failure.into_parts().0))?;
-            }
-            let _ = guard.children.remove(&DName::from(name));
-            return Ok(());
-        }
-
+        let _target_operation = target.begin_operation()?;
         match ext4.lookup(inode_num, name) {
             Ok(current) if current == target_num => {}
             Ok(_) => return Err(SystemError::EAGAIN_OR_EWOULDBLOCK),
             Err(error) => return Err(error.into()),
         }
-        let handle = match Self::retry_metadata_contention(|| ext4.unlink(inode_num, name)) {
-            Ok(Some(handle)) => handle,
-            Ok(None) => return Err(SystemError::EIO),
-            Err(error) => return Err(error),
-        };
-        target.defer_reclaim(handle)?;
+        let reclaim = Self::retry_metadata_contention(|| ext4.unlink(inode_num, name))?;
+        target.handoff_namespace_reclaim(reclaim)?;
         // 清理 children 缓存
         let _ = guard.children.remove(&DName::from(name));
         Ok(())
@@ -918,12 +896,8 @@ impl IndexNode for LockedExt4Inode {
             Ok(_) => return Err(SystemError::ENOTEMPTY),
             Err(error) => return Err(error.into()),
         }
-        let handle = match Self::retry_metadata_contention(|| concret_fs.rmdir(inode_num, name)) {
-            Ok(Some(handle)) => handle,
-            Ok(None) => return Err(SystemError::EIO),
-            Err(error) => return Err(error),
-        };
-        target.defer_reclaim(handle)?;
+        let reclaim = Self::retry_metadata_contention(|| concret_fs.rmdir(inode_num, name))?;
+        target.handoff_namespace_reclaim(reclaim)?;
         // 清理 children 缓存
         let _ = guard.children.remove(&DName::from(name));
 
@@ -1212,31 +1186,6 @@ impl IndexNode for LockedExt4Inode {
 
         let mut resulting_whiteout = None;
         if flags.contains(RenameFlags::WHITEOUT) {
-            // Prepare and drain the replacement target before changing the source
-            // namespace. No fallible target preparation may occur after exchange.
-            let mut will_free = false;
-            if let (Some(_), Some(dst_inode_num)) = (&dst_inode, dst_inode_num) {
-                let attr = ext4.getattr(dst_inode_num)?;
-                will_free = if attr.ftype == FileType::Directory {
-                    attr.links <= 2
-                } else {
-                    attr.links <= 1
-                };
-                if will_free {
-                    if ext4.lookup(target_inode_num, new_name).ok() != Some(dst_inode_num) {
-                        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-                    }
-                    let fresh_attr = ext4.getattr(dst_inode_num)?;
-                    if fresh_attr.ftype == FileType::Directory {
-                        match ext4.listdir(dst_inode_num) {
-                            Ok(entries) if entries.len() <= 2 => {}
-                            Ok(_) => return Err(SystemError::ENOTEMPTY),
-                            Err(error) => return Err(error.into()),
-                        }
-                    }
-                }
-            }
-
             let mut temp_name = String::new();
             let mut whiteout_inode = None;
             let source_parent = self
@@ -1331,12 +1280,13 @@ impl IndexNode for LockedExt4Inode {
                     return Err(rename_error);
                 }
             };
-            if will_free {
-                let handle = rename_handle.ok_or(SystemError::EIO)?;
-                dst_inode
-                    .as_ref()
-                    .ok_or(SystemError::EIO)?
-                    .defer_reclaim(handle)?;
+            if let Some(dst_inode) = &dst_inode {
+                dst_inode.handoff_namespace_reclaim(rename_handle)?;
+            } else if let Some(handle) = rename_handle {
+                // The destination was absent while both namespace locks were
+                // held, so the backend must not report a replaced lifetime.
+                // If it does, retain that orphan capability and fail-stop.
+                return Self::quarantine_unexpected_rename_reclaim(&ext4_fs, handle);
             }
             if let Some(whiteout) = &whiteout_inode {
                 whiteout.inner.lock().dname = old_dname.clone();
@@ -1344,42 +1294,18 @@ impl IndexNode for LockedExt4Inode {
             resulting_whiteout = whiteout_inode;
         } else {
             if let Some(dst_inode) = &dst_inode {
-                let attr = ext4.getattr(dst_inode_num.unwrap())?;
-                let will_free = if attr.ftype == FileType::Directory {
-                    attr.links <= 2
-                } else {
-                    attr.links <= 1
-                };
-                if !will_free {
-                    let _ = Self::retry_metadata_contention(|| {
-                        ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
-                    })?;
-                } else {
-                    if ext4.lookup(target_inode_num, new_name).ok() != dst_inode_num {
-                        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-                    }
-                    let fresh_attr = ext4.getattr(dst_inode_num.unwrap())?;
-                    if fresh_attr.ftype == FileType::Directory {
-                        match ext4.listdir(dst_inode_num.unwrap()) {
-                            Ok(entries) if entries.len() <= 2 => {}
-                            Ok(_) => return Err(SystemError::ENOTEMPTY),
-                            Err(error) => return Err(error.into()),
-                        }
-                    }
-                    let handle = match Self::retry_metadata_contention(|| {
-                        ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
-                    }) {
-                        Ok(Some(handle)) => handle,
-                        Ok(None) => return Err(SystemError::EIO),
-                        Err(err) => return Err(err),
-                    };
-                    dst_inode.defer_reclaim(handle)?;
-                }
-            } else {
-                // ext4 library now correctly handles atomic replace
-                let _ = Self::retry_metadata_contention(|| {
+                let reclaim = Self::retry_metadata_contention(|| {
                     ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
                 })?;
+                dst_inode.handoff_namespace_reclaim(reclaim)?;
+            } else {
+                // ext4 library now correctly handles atomic replace
+                let reclaim = Self::retry_metadata_contention(|| {
+                    ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
+                })?;
+                if let Some(handle) = reclaim {
+                    return Self::quarantine_unexpected_rename_reclaim(&ext4_fs, handle);
+                }
             }
         }
 
@@ -1400,6 +1326,18 @@ impl IndexNode for LockedExt4Inode {
 }
 
 impl LockedExt4Inode {
+    fn quarantine_unexpected_rename_reclaim(
+        fs: &Arc<Ext4FileSystem>,
+        handle: another_ext4::InodeReclaimHandle,
+    ) -> Result<(), SystemError> {
+        fs.fail_stop_lifecycle();
+        // Never risk a second pending capability on a guessed canonical inode.
+        // The fail-stopped mount owns this handle until durable orphan recovery
+        // can complete after teardown.
+        fs.quarantined_reclaims.lock().push(handle);
+        Err(SystemError::EIO)
+    }
+
     fn release_clean_metadata_queue_owner(&self, fs: &Arc<Ext4FileSystem>) {
         if let Some(inode) = self.retention_callback_self.upgrade() {
             fs.release_clean_queued_inode(&inode);
@@ -1727,6 +1665,30 @@ impl Ext4Inode {
 }
 
 impl LockedExt4Inode {
+    /// Transfer the authoritative result of a namespace transaction to this
+    /// canonical inode lifetime. `None` means another hard link remains;
+    /// `Some` is the unique capability for the zero-link orphan.
+    fn handoff_namespace_reclaim(
+        self: &Arc<Self>,
+        reclaim: Option<another_ext4::InodeReclaimHandle>,
+    ) -> Result<(), SystemError> {
+        let Some(handle) = reclaim else {
+            return Ok(());
+        };
+        let (fs, inode_num) = {
+            let inner = self.inner.lock();
+            (inner.concret_fs(), inner.inner_inode_num)
+        };
+        if handle.inode_id() != inode_num {
+            // Never attach a capability to the wrong canonical lifetime. The
+            // fail-stopped mount retains it for durable orphan recovery.
+            fs.fail_stop_lifecycle();
+            fs.quarantined_reclaims.lock().push(handle);
+            return Err(SystemError::EIO);
+        }
+        self.defer_reclaim(handle)
+    }
+
     /// Publish the one-shot capability produced by the final unlink. Physical
     /// reclaim waits until every semantic VFS owner has released this inode.
     pub(super) fn defer_reclaim(

--- a/kernel/src/filesystem/vfs/stat.rs
+++ b/kernel/src/filesystem/vfs/stat.rs
@@ -225,8 +225,10 @@ pub fn vfs_getattr(
 
     // Derive directory link count dynamically only when metadata has no reliable value.
     if metadata.file_type == crate::filesystem::vfs::FileType::Dir {
-        // Many filesystems already maintain nlinks; use it when it looks valid (>=2 for dirs).
-        if metadata.nlinks < 2 {
+        // Zero is authoritative for an unlinked-but-live directory.  Only the
+        // legacy/default value one means the filesystem did not provide a
+        // usable directory link count and needs VFS derivation.
+        if metadata.nlinks == 1 {
             if let Ok(entries) = inode.list() {
                 let mut subdir_links = 0usize;
                 for name in entries {

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <errno.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -25,6 +26,24 @@
 #else
 #error "__NR_syncfs is not defined for this architecture"
 #endif
+#endif
+
+#ifndef __NR_renameat2
+#if defined(__x86_64__)
+#define __NR_renameat2 316
+#elif defined(__riscv) || defined(__loongarch64__)
+#define __NR_renameat2 276
+#else
+#error "__NR_renameat2 is not defined for this architecture"
+#endif
+#endif
+
+#ifndef RENAME_EXCHANGE
+#define RENAME_EXCHANGE (1U << 1)
+#endif
+
+#ifndef RENAME_WHITEOUT
+#define RENAME_WHITEOUT (1U << 2)
 #endif
 
 namespace {
@@ -455,14 +474,176 @@ TEST(Ext4InodeIdentity, CurrentDirectorySurvivesRmdir) {
 
     const std::string directory = fs.mount_point() + "/removed_cwd";
     ASSERT_EQ(0, mkdir(directory.c_str(), 0755)) << strerror(errno);
+    int directory_fd = open(directory.c_str(), O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(directory_fd, 0) << strerror(errno);
+    struct stat before = {};
+    ASSERT_EQ(0, fstat(directory_fd, &before)) << strerror(errno);
     ASSERT_EQ(0, chdir(directory.c_str())) << strerror(errno);
     ASSERT_EQ(0, rmdir(directory.c_str())) << strerror(errno);
 
     struct stat current = {};
     ASSERT_EQ(0, stat(".", &current)) << strerror(errno);
     EXPECT_TRUE(S_ISDIR(current.st_mode));
+    struct stat removed = {};
+    ASSERT_EQ(0, fstat(directory_fd, &removed)) << strerror(errno);
+    EXPECT_EQ(before.st_ino, removed.st_ino);
+    EXPECT_EQ(0u, removed.st_nlink);
 
     ASSERT_EQ(0, chdir("/")) << strerror(errno);
+    ASSERT_EQ(0, close(directory_fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, DirtyOpenRenameTargetSurvivesReplacement) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string source = fs.mount_point() + "/rename_source";
+    const std::string target = fs.mount_point() + "/rename_target";
+    int source_fd = open(source.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    int target_fd = open(target.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(source_fd, 0) << strerror(errno);
+    ASSERT_GE(target_fd, 0) << strerror(errno);
+    constexpr char kSource[] = "new-path-data";
+    constexpr char kTarget[] = "old-open-data";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(source_fd, kSource, sizeof(kSource) - 1));
+    ASSERT_NO_FATAL_FAILURE(WriteAll(target_fd, kTarget, sizeof(kTarget) - 1));
+    struct stat old_target = {};
+    ASSERT_EQ(0, fstat(target_fd, &old_target)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(source.c_str(), target.c_str())) << strerror(errno);
+    EXPECT_EQ(std::string(kSource, sizeof(kSource) - 1), ReadFile(target.c_str()));
+    struct stat replaced = {};
+    ASSERT_EQ(0, fstat(target_fd, &replaced)) << strerror(errno);
+    EXPECT_EQ(old_target.st_ino, replaced.st_ino);
+    EXPECT_EQ(0u, replaced.st_nlink);
+    ASSERT_EQ(0, lseek(target_fd, 0, SEEK_SET)) << strerror(errno);
+    char buffer[sizeof(kTarget)] = {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(kTarget) - 1),
+              read(target_fd, buffer, sizeof(buffer)))
+        << strerror(errno);
+    EXPECT_EQ(0, memcmp(buffer, kTarget, sizeof(kTarget) - 1));
+    constexpr char kSuffix[] = "-after-rename";
+    ASSERT_EQ(static_cast<off_t>(sizeof(kTarget) - 1),
+              lseek(target_fd, 0, SEEK_END));
+    ASSERT_NO_FATAL_FAILURE(WriteAll(target_fd, kSuffix, sizeof(kSuffix) - 1));
+    ASSERT_EQ(0, fdatasync(target_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(target_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(source_fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(target.c_str())) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, RenameReplacementPreservesRemainingHardLink) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string source = fs.mount_point() + "/hardlink_source";
+    const std::string target = fs.mount_point() + "/hardlink_target";
+    const std::string alias = fs.mount_point() + "/hardlink_alias";
+    int target_fd = open(target.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(target_fd, 0) << strerror(errno);
+    constexpr char kOld[] = "linked-target";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(target_fd, kOld, sizeof(kOld) - 1));
+    ASSERT_EQ(0, link(target.c_str(), alias.c_str())) << strerror(errno);
+    int source_fd = open(source.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0644);
+    ASSERT_GE(source_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(source_fd)) << strerror(errno);
+
+    ASSERT_EQ(0, rename(source.c_str(), target.c_str())) << strerror(errno);
+    EXPECT_EQ(std::string(kOld, sizeof(kOld) - 1), ReadFile(alias.c_str()));
+    struct stat remaining = {};
+    ASSERT_EQ(0, fstat(target_fd, &remaining)) << strerror(errno);
+    EXPECT_EQ(1u, remaining.st_nlink);
+    ASSERT_EQ(0, unlink(alias.c_str())) << strerror(errno);
+    ASSERT_EQ(0, fstat(target_fd, &remaining)) << strerror(errno);
+    EXPECT_EQ(0u, remaining.st_nlink);
+    ASSERT_EQ(0, fsync(target_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(target_fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(target.c_str())) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, RenameExchangeDoesNotUnlinkEitherInode) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string left = fs.mount_point() + "/exchange_left";
+    const std::string right = fs.mount_point() + "/exchange_right";
+    int left_fd = open(left.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    int right_fd = open(right.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(left_fd, 0) << strerror(errno);
+    ASSERT_GE(right_fd, 0) << strerror(errno);
+    constexpr char kLeft[] = "left";
+    constexpr char kRight[] = "right";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(left_fd, kLeft, sizeof(kLeft) - 1));
+    ASSERT_NO_FATAL_FAILURE(WriteAll(right_fd, kRight, sizeof(kRight) - 1));
+    ASSERT_EQ(0, syscall(__NR_renameat2, AT_FDCWD, left.c_str(), AT_FDCWD,
+                         right.c_str(), RENAME_EXCHANGE))
+        << strerror(errno);
+    EXPECT_EQ(std::string(kRight, sizeof(kRight) - 1), ReadFile(left.c_str()));
+    EXPECT_EQ(std::string(kLeft, sizeof(kLeft) - 1), ReadFile(right.c_str()));
+    struct stat left_stat = {};
+    struct stat right_stat = {};
+    ASSERT_EQ(0, fstat(left_fd, &left_stat)) << strerror(errno);
+    ASSERT_EQ(0, fstat(right_fd, &right_stat)) << strerror(errno);
+    EXPECT_EQ(1u, left_stat.st_nlink);
+    EXPECT_EQ(1u, right_stat.st_nlink);
+    ASSERT_EQ(0, close(left_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(right_fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(left.c_str())) << strerror(errno);
+    ASSERT_EQ(0, unlink(right.c_str())) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, RenameWhiteoutPreservesTargetAndLeaksNoTemporaryName) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string source = fs.mount_point() + "/whiteout_source";
+    const std::string target = fs.mount_point() + "/whiteout_target";
+    int source_fd = open(source.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    int target_fd = open(target.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(source_fd, 0) << strerror(errno);
+    ASSERT_GE(target_fd, 0) << strerror(errno);
+    constexpr char kSource[] = "whiteout-new";
+    constexpr char kTarget[] = "whiteout-old";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(source_fd, kSource, sizeof(kSource) - 1));
+    ASSERT_NO_FATAL_FAILURE(WriteAll(target_fd, kTarget, sizeof(kTarget) - 1));
+
+    ASSERT_EQ(0, syscall(__NR_renameat2, AT_FDCWD, source.c_str(), AT_FDCWD,
+                         target.c_str(), RENAME_WHITEOUT))
+        << strerror(errno);
+    EXPECT_EQ(std::string(kSource, sizeof(kSource) - 1), ReadFile(target.c_str()));
+    struct stat whiteout = {};
+    ASSERT_EQ(0, lstat(source.c_str(), &whiteout)) << strerror(errno);
+    EXPECT_TRUE(S_ISCHR(whiteout.st_mode));
+    struct stat replaced = {};
+    ASSERT_EQ(0, fstat(target_fd, &replaced)) << strerror(errno);
+    EXPECT_EQ(0u, replaced.st_nlink);
+
+    DIR* directory = opendir(fs.mount_point().c_str());
+    ASSERT_NE(nullptr, directory) << strerror(errno);
+    bool leaked_temporary = false;
+    constexpr char kTemporaryPrefix[] = ".dragonos-whiteout-";
+    while (dirent* entry = readdir(directory)) {
+        if (strncmp(entry->d_name, kTemporaryPrefix,
+                    sizeof(kTemporaryPrefix) - 1) == 0) {
+            leaked_temporary = true;
+        }
+    }
+    ASSERT_EQ(0, closedir(directory)) << strerror(errno);
+    EXPECT_FALSE(leaked_temporary);
+
+    ASSERT_EQ(0, fdatasync(target_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(target_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(source_fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(source.c_str())) << strerror(errno);
+    ASSERT_EQ(0, unlink(target.c_str())) << strerror(errno);
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
 }
 


### PR DESCRIPTION
## Summary

- use transaction-produced reclaim capabilities as the authoritative handoff for ext4 unlink, rename replacement, whiteout replacement, and rmdir
- match Linux directory `clear_nlink()` semantics and preserve `st_nlink == 0` for open removed directories
- quarantine impossible reclaim outcomes while fail-stopping both VFS allocation and backend metadata mutation
- add lifecycle regression coverage for dirty open rename targets, hard-link replacement, open rmdir, `RENAME_EXCHANGE`, and `RENAME_WHITEOUT`

## Root cause

The ext4 VFS adapter duplicated final-link decisions from pre-transaction link counts instead of consuming the authoritative result returned by the namespace transaction. Directory removal also treated a stale high link count as non-final, unlike Linux, and VFS stat reconstructed an unlinked directory's zero link count back to two.

## Validation

- `cargo test --manifest-path kernel/crates/another_ext4/Cargo.toml` (101 passed)
- `ROOTFS_MANIFEST=ubuntu2404 make kernel`
- Ubuntu 24.04 rootfs guest: `/opt/tests/dunitest/bin/normal/ext4_inode_identity_test` (14 passed)
- adversarial architecture, lifetime, locking, performance, safety, and workaround review completed with no remaining P1/P2 findings

The existing transaction fault-injection suite remains passing. The VFS whiteout state machine has no production-safe injectable I/O hook; its successful cleanup path is covered in the guest, while impossible post-transaction outcomes retain their one-shot capability in a backend-poisoned mount quarantine for durable orphan recovery.

Closes #2055
