### PR TITLE
feat(virtiofs): map shared memory cache windows safely

### DIFF
--- a/kernel/src/arch/loongarch64/mm/mod.rs
+++ b/kernel/src/arch/loongarch64/mm/mod.rs
@@ -57,6 +57,11 @@ impl MemoryManagementArch for LoongArch64MMArch {
 
     const ENTRY_FLAG_GLOBAL: usize = 0;
 
+    #[inline(always)]
+    fn entry_is_leaf(level: usize, _flags: usize) -> bool {
+        level == 0
+    }
+
     const PHYS_OFFSET: usize = 0x9000_0000_0000_0000;
 
     const KERNEL_LINK_OFFSET: usize = 0;

--- a/kernel/src/arch/riscv64/mm/mod.rs
+++ b/kernel/src/arch/riscv64/mm/mod.rs
@@ -149,6 +149,12 @@ impl MemoryManagementArch for RiscV64MMArch {
 
     const ENTRY_FLAG_HUGE_PAGE: usize = Self::ENTRY_FLAG_PRESENT | Self::ENTRY_FLAG_READWRITE;
 
+    #[inline(always)]
+    fn entry_is_leaf(_level: usize, flags: usize) -> bool {
+        flags & (Self::ENTRY_FLAG_READONLY | Self::ENTRY_FLAG_WRITEABLE | Self::ENTRY_FLAG_EXEC)
+            != 0
+    }
+
     #[inline(never)]
     unsafe fn init() {
         riscv_mm_init().expect("init kernel memory management architecture failed");

--- a/kernel/src/arch/x86_64/mm/mod.rs
+++ b/kernel/src/arch/x86_64/mm/mod.rs
@@ -116,6 +116,11 @@ impl MemoryManagementArch for X86_64MMArch {
     const ENTRY_FLAG_HUGE_PAGE: usize = 1 << 7;
     const ENTRY_FLAG_GLOBAL: usize = 1 << 8;
 
+    #[inline(always)]
+    fn entry_is_leaf(level: usize, flags: usize) -> bool {
+        level == 0 || flags & Self::ENTRY_FLAG_HUGE_PAGE != 0
+    }
+
     /// 物理地址与虚拟地址的偏移量
     /// 0xffff_8000_0000_0000
     const PHYS_OFFSET: usize = Self::PAGE_NEGATIVE_MASK + (Self::PAGE_ADDRESS_SIZE >> 1);

--- a/kernel/src/driver/pci/pci.rs
+++ b/kernel/src/driver/pci/pci.rs
@@ -10,6 +10,7 @@ use crate::arch::{MMArch, PciArch, TraitPciArch};
 use crate::driver::pci::subsys::pci_bus_subsys_init;
 use crate::exception::IrqNumber;
 use crate::libs::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use crate::libs::spinlock::SpinLock;
 
 use crate::mm::mmio_buddy::{mmio_pool, MMIOSpaceGuard};
 
@@ -1342,6 +1343,80 @@ pub struct PciBarMappingRequest {
     pub bar: u8,
     pub offset: u64,
     pub length: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PciBarSubresource {
+    bdf: BusDeviceFunction,
+    bar: u8,
+    offset: u64,
+    length: u64,
+    physical_start: u64,
+}
+
+lazy_static! {
+    static ref PCI_BAR_SUBRESOURCES: SpinLock<Vec<PciBarSubresource>> = SpinLock::new(Vec::new());
+}
+
+#[derive(Debug)]
+pub struct PciBarSubresourceGuard {
+    resource: PciBarSubresource,
+}
+
+impl PciBarSubresourceGuard {
+    pub fn reserve(
+        device: &PciDeviceStructureGeneralDevice,
+        bar: u8,
+        offset: u64,
+        length: u64,
+        physical_start: PhysAddr,
+    ) -> Result<Self, PciError> {
+        if length == 0 {
+            return Err(PciError::InvalidBarRange);
+        }
+        let end = offset
+            .checked_add(length)
+            .ok_or(PciError::InvalidBarRange)?;
+        let bar_info = device.standard_device_bar.read();
+        let (_, bar_size) = bar_info
+            .get_bar(bar)?
+            .memory_address_size()
+            .ok_or(PciError::InvalidBarType)?;
+        if end > bar_size {
+            return Err(PciError::InvalidBarRange);
+        }
+        drop(bar_info);
+
+        let resource = PciBarSubresource {
+            bdf: device.common_header.bus_device_function,
+            bar,
+            offset,
+            length,
+            physical_start: physical_start.data() as u64,
+        };
+        let physical_end = resource
+            .physical_start
+            .checked_add(length)
+            .ok_or(PciError::InvalidBarRange)?;
+        let mut resources = PCI_BAR_SUBRESOURCES.lock_irqsave();
+        if resources.iter().any(|existing| {
+            let existing_end = existing.physical_start.saturating_add(existing.length);
+            resource.physical_start < existing_end && existing.physical_start < physical_end
+        }) {
+            return Err(PciError::InvalidBarRange);
+        }
+        resources.push(resource);
+        Ok(Self { resource })
+    }
+}
+
+impl Drop for PciBarSubresourceGuard {
+    fn drop(&mut self) {
+        let mut resources = PCI_BAR_SUBRESOURCES.lock_irqsave();
+        if let Some(index) = resources.iter().position(|item| *item == self.resource) {
+            resources.remove(index);
+        }
+    }
 }
 
 fn unallocated_bar_has_required_mapping(

--- a/kernel/src/driver/virtio/transport.rs
+++ b/kernel/src/driver/virtio/transport.rs
@@ -7,7 +7,7 @@ use crate::{
         base::device::DeviceId,
         pci::pci_irq::IrqType,
         pci::{
-            pci::{PciDeviceStructure, PciError},
+            pci::{PciBarSubresourceGuard, PciDeviceStructure, PciError},
             pci_irq::{IrqCommonMsg, IrqSpecificMsg, PciInterrupt, PciIrqError, PciIrqMsg, IRQ},
         },
     },
@@ -27,13 +27,17 @@ use super::{
 pub struct VirtioSharedMemoryRegion {
     physical_address: PhysAddr,
     length: u64,
+    bar: u8,
+    offset: u64,
 }
 
 impl VirtioSharedMemoryRegion {
-    pub(crate) fn new(physical_address: PhysAddr, length: u64) -> Self {
+    pub(crate) fn new(physical_address: PhysAddr, length: u64, bar: u8, offset: u64) -> Self {
         Self {
             physical_address,
             length,
+            bar,
+            offset,
         }
     }
 
@@ -44,6 +48,14 @@ impl VirtioSharedMemoryRegion {
 
     pub fn length(&self) -> u64 {
         self.length
+    }
+
+    pub(crate) fn bar(&self) -> u8 {
+        self.bar
+    }
+
+    pub(crate) fn offset(&self) -> u64 {
+        self.offset
     }
 }
 
@@ -76,6 +88,16 @@ impl VirtIOTransport {
         match self {
             VirtIOTransport::Pci(transport) => transport.shared_memory_region(id),
             VirtIOTransport::Mmio(_) => None,
+        }
+    }
+
+    pub fn reserve_shared_memory_region(
+        &self,
+        region: VirtioSharedMemoryRegion,
+    ) -> Result<PciBarSubresourceGuard, PciError> {
+        match self {
+            VirtIOTransport::Pci(transport) => transport.reserve_shared_memory_region(region),
+            VirtIOTransport::Mmio(_) => Err(PciError::InvalidBarType),
         }
     }
 

--- a/kernel/src/driver/virtio/transport_pci.rs
+++ b/kernel/src/driver/virtio/transport_pci.rs
@@ -3,7 +3,7 @@
 use crate::arch::{PciArch, TraitPciArch};
 use crate::driver::base::device::DeviceId;
 use crate::driver::pci::pci::{
-    BusDeviceFunction, PciAddr, PciBarMappingRequest, PciDeviceStructure,
+    BusDeviceFunction, PciAddr, PciBarMappingRequest, PciBarSubresourceGuard, PciDeviceStructure,
     PciDeviceStructureGeneralDevice, PciError, PciStandardDeviceBar, PCI_CAP_ID_VNDR,
 };
 
@@ -12,7 +12,7 @@ use crate::driver::pci::root::pci_root_0;
 use crate::exception::IrqNumber;
 
 use crate::libs::volatile::{ReadOnly, Volatile, VolatileReadable, VolatileWritable, WriteOnly};
-use crate::mm::{PhysAddr, VirtAddr};
+use crate::mm::{MemoryManagementArch, PhysAddr, VirtAddr};
 
 use alloc::{sync::Arc, vec, vec::Vec};
 use core::{
@@ -305,7 +305,15 @@ impl PciTransport {
                         struct_info.bar,
                         offset,
                         length,
-                    );
+                    )
+                    .filter(|_| {
+                        !shared_memory_overlaps_mappings(
+                            struct_info.bar,
+                            offset,
+                            length,
+                            &transport_config_mappings,
+                        )
+                    });
                     if region.is_none() {
                         warn!(
                             "VirtIO PCI shared-memory capability id={} is outside its BAR or cannot be represented",
@@ -385,6 +393,19 @@ impl PciTransport {
             .iter()
             .find(|(region_id, _)| *region_id == id)
             .and_then(|(_, region)| *region)
+    }
+
+    pub fn reserve_shared_memory_region(
+        &self,
+        region: VirtioSharedMemoryRegion,
+    ) -> Result<PciBarSubresourceGuard, PciError> {
+        PciBarSubresourceGuard::reserve(
+            &self.device,
+            region.bar(),
+            region.offset(),
+            region.length(),
+            region.physical_address(),
+        )
     }
 
     fn cache_queue_notify_index(&mut self, queue: u16) -> Option<usize> {
@@ -805,12 +826,44 @@ fn validate_shared_memory_region(
 ) -> Option<VirtioSharedMemoryRegion> {
     let bar_info = device_bar.get_bar(bar).ok()?;
     let (bar_address, bar_size) = bar_info.memory_address_size()?;
-    validate_shared_memory_range(bar_address, bar_size, offset, length)
+    validate_shared_memory_range(bar_address, bar_size, bar, offset, length)
+}
+
+fn shared_memory_overlaps_mappings(
+    bar: u8,
+    offset: u64,
+    length: u64,
+    mappings: &[PciBarMappingRequest],
+) -> bool {
+    let Some(end) = offset.checked_add(length) else {
+        return true;
+    };
+    let page_mask = !((crate::arch::MMArch::PAGE_SIZE as u64) - 1);
+    let cache_start = offset & page_mask;
+    let Some(cache_end) = end
+        .checked_add(crate::arch::MMArch::PAGE_SIZE as u64 - 1)
+        .map(|value| value & page_mask)
+    else {
+        return true;
+    };
+    mappings.iter().any(|mapping| {
+        if mapping.bar != bar {
+            return false;
+        }
+        let Some(mapping_end) = mapping.offset.checked_add(mapping.length) else {
+            return true;
+        };
+        let mapping_start = mapping.offset & page_mask;
+        let mapping_end =
+            mapping_end.saturating_add(crate::arch::MMArch::PAGE_SIZE as u64 - 1) & page_mask;
+        cache_start < mapping_end && mapping_start < cache_end
+    })
 }
 
 fn validate_shared_memory_range(
     bar_address: u64,
     bar_size: u64,
+    bar: u8,
     offset: u64,
     length: u64,
 ) -> Option<VirtioSharedMemoryRegion> {
@@ -830,12 +883,18 @@ fn validate_shared_memory_range(
     Some(VirtioSharedMemoryRegion::new(
         PhysAddr::new(physical_address),
         length,
+        bar,
+        offset as u64,
     ))
 }
 
 #[cfg(test)]
 mod shared_memory_tests {
-    use super::{shared_memory_cap_len_supported, validate_shared_memory_range};
+    use super::{
+        shared_memory_cap_len_supported, shared_memory_overlaps_mappings,
+        validate_shared_memory_range,
+    };
+    use crate::driver::pci::pci::PciBarMappingRequest;
 
     #[test]
     fn accepts_padded_shared_memory_capability() {
@@ -846,30 +905,62 @@ mod shared_memory_tests {
 
     #[test]
     fn validates_shared_memory_range() {
-        let region = validate_shared_memory_range(0x1000, 0x4000, 0x1000, 0x2000).unwrap();
+        let region = validate_shared_memory_range(0x1000, 0x4000, 2, 0x1000, 0x2000).unwrap();
         assert_eq!(region.physical_address().data(), 0x2000);
         assert_eq!(region.length(), 0x2000);
     }
 
     #[test]
     fn rejects_unallocated_shared_memory_bar() {
-        assert!(validate_shared_memory_range(0, 0x4000, 0x1000, 0x2000).is_none());
+        assert!(validate_shared_memory_range(0, 0x4000, 2, 0x1000, 0x2000).is_none());
     }
 
     #[test]
     fn preserves_zero_length_region() {
-        let region = validate_shared_memory_range(0x1000, 0x4000, 0x4000, 0).unwrap();
+        let region = validate_shared_memory_range(0x1000, 0x4000, 2, 0x4000, 0).unwrap();
         assert_eq!(region.physical_address().data(), 0x5000);
         assert_eq!(region.length(), 0);
     }
 
     #[test]
     fn rejects_range_end_overflow() {
-        assert!(validate_shared_memory_range(0x1000, u64::MAX, u64::MAX, 1).is_none());
+        assert!(validate_shared_memory_range(0x1000, u64::MAX, 2, u64::MAX, 1).is_none());
     }
 
     #[test]
     fn rejects_range_outside_bar() {
-        assert!(validate_shared_memory_range(0x1000, 0x4000, 0x3000, 0x1001).is_none());
+        assert!(validate_shared_memory_range(0x1000, 0x4000, 2, 0x3000, 0x1001).is_none());
+    }
+
+    #[test]
+    fn rejects_shared_page_with_transport_mapping() {
+        let mappings = [PciBarMappingRequest {
+            bar: 2,
+            offset: 0x80,
+            length: 0x100,
+        }];
+        assert!(shared_memory_overlaps_mappings(2, 0x800, 0x800, &mappings));
+    }
+
+    #[test]
+    fn accepts_mapping_on_adjacent_page() {
+        let mappings = [PciBarMappingRequest {
+            bar: 2,
+            offset: 0,
+            length: 0x1000,
+        }];
+        assert!(!shared_memory_overlaps_mappings(
+            2, 0x1000, 0x1000, &mappings
+        ));
+    }
+
+    #[test]
+    fn ignores_mapping_in_different_bar() {
+        let mappings = [PciBarMappingRequest {
+            bar: 4,
+            offset: 0,
+            length: 0x2000,
+        }];
+        assert!(!shared_memory_overlaps_mappings(2, 0, 0x2000, &mappings));
     }
 }

--- a/kernel/src/driver/virtio/virtio_fs.rs
+++ b/kernel/src/driver/virtio/virtio_fs.rs
@@ -10,10 +10,16 @@ use system_error::SystemError;
 use virtio_drivers::transport::Transport;
 
 use crate::{
+    arch::MMArch,
     driver::base::device::{Device, DeviceId},
+    driver::pci::pci::PciBarSubresourceGuard,
     exception::{irqdesc::IrqReturn, IrqNumber},
     filesystem::fuse::{conn::FuseConn, stats},
     libs::{spinlock::SpinLock, wait_queue::WaitQueue},
+    mm::{
+        device_linear::DeviceLinearMapping, memblock::mem_block_manager, page::EntryFlags,
+        MemoryManagementArch,
+    },
 };
 
 use super::{
@@ -59,6 +65,54 @@ struct VirtioFsIrqConfig {
 }
 
 #[derive(Debug)]
+struct VirtioFsCacheWindow {
+    mapping: DeviceLinearMapping,
+    _reservation: PciBarSubresourceGuard,
+}
+
+impl VirtioFsCacheWindow {
+    fn new(
+        transport: &VirtIOTransport,
+        region: VirtioSharedMemoryRegion,
+    ) -> Result<Self, SystemError> {
+        let length = usize::try_from(region.length()).map_err(|_| SystemError::EOVERFLOW)?;
+        let start = region.physical_address();
+        if length == 0
+            || !start.check_aligned(MMArch::PAGE_SIZE)
+            || !length.is_multiple_of(MMArch::PAGE_SIZE)
+        {
+            return Err(SystemError::EINVAL);
+        }
+        let end = start
+            .data()
+            .checked_add(length)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if mem_block_manager().to_iter().any(|area| {
+            let area_end = area.base.data().saturating_add(area.size);
+            start.data() < area_end && area.base.data() < end
+        }) {
+            return Err(SystemError::EBUSY);
+        }
+
+        let reservation = transport
+            .reserve_shared_memory_region(region)
+            .map_err(|_| SystemError::EBUSY)?;
+        let flags = EntryFlags::new()
+            .set_user(false)
+            .set_write(true)
+            .set_execute(false)
+            .set_page_cache_disable(false)
+            .set_page_write_through(false)
+            .set_page_global(false);
+        let mapping = DeviceLinearMapping::new(start, length, flags)?;
+        Ok(Self {
+            mapping,
+            _reservation: reservation,
+        })
+    }
+}
+
+#[derive(Debug)]
 struct VirtioFsInstanceState {
     transport: Option<VirtioFsTransportHolder>,
     session_active: bool,
@@ -94,7 +148,7 @@ pub struct VirtioFsInstance {
     irq_wake_enabled: bool,
     irq_is_msix: bool,
     irq_ack: Option<PciInterruptAck>,
-    cache_region: Option<VirtioSharedMemoryRegion>,
+    cache_window: Option<VirtioFsCacheWindow>,
     state: SpinLock<VirtioFsInstanceState>,
     session_wait: WaitQueue,
 }
@@ -106,7 +160,7 @@ impl VirtioFsInstance {
         dev_id: Arc<DeviceId>,
         transport: VirtIOTransport,
         irq: VirtioFsIrqConfig,
-        cache_region: Option<VirtioSharedMemoryRegion>,
+        cache_window: Option<VirtioFsCacheWindow>,
     ) -> Self {
         Self {
             tag,
@@ -115,7 +169,7 @@ impl VirtioFsInstance {
             irq_wake_enabled: irq.wake_enabled,
             irq_is_msix: irq.is_msix,
             irq_ack: irq.ack,
-            cache_region,
+            cache_window,
             state: SpinLock::new(VirtioFsInstanceState {
                 transport: Some(VirtioFsTransportHolder(transport)),
                 session_active: false,
@@ -140,8 +194,10 @@ impl VirtioFsInstance {
         self.num_request_queues
     }
 
-    pub fn cache_region(&self) -> Option<VirtioSharedMemoryRegion> {
-        self.cache_region
+    pub fn cache_window_len(&self) -> Option<usize> {
+        self.cache_window
+            .as_ref()
+            .map(|window| window.mapping.len())
     }
 
     pub fn hiprio_queue_index(&self) -> u16 {
@@ -418,6 +474,16 @@ pub fn virtio_fs(
     let cache_region = transport
         .shared_memory_region(VIRTIO_FS_SHMCAP_ID_CACHE)
         .filter(|region| region.length() != 0);
+    let cache_window = cache_region.and_then(|region| match VirtioFsCacheWindow::new(&transport, region) {
+        Ok(window) => Some(window),
+        Err(error) => {
+            warn!(
+                "virtio-fs: cache window unavailable for tag='{}' dev={:?}: {:?}; continue without DAX",
+                tag, dev_id, error
+            );
+            None
+        }
+    });
     if matches!(transport, VirtIOTransport::Pci(_)) {
         if let Err(e) = transport.setup_irq(dev_id.clone()) {
             warn!(
@@ -448,10 +514,10 @@ pub fn virtio_fs(
             is_msix: irq_is_msix,
             ack: irq_ack,
         },
-        cache_region,
+        cache_window,
     ));
 
-    let cache_region_len = instance.cache_region().map(|region| region.length());
+    let cache_region_len = instance.cache_window_len();
     let mut map = VIRTIO_FS_INSTANCES.lock_irqsave();
     if map.contains_key(&tag) {
         warn!(

--- a/kernel/src/mm/device_linear.rs
+++ b/kernel/src/mm/device_linear.rs
@@ -1,0 +1,198 @@
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+use crate::{
+    arch::MMArch,
+    mm::{
+        kernel_mapper::KernelMapper,
+        page::{CreatedPageTable, EntryFlags},
+        tlb::flush_tlb_kernel_range,
+        MemoryManagementArch, PhysAddr, VirtAddr,
+    },
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MappingSegment {
+    vaddr: VirtAddr,
+    paddr: PhysAddr,
+    level: usize,
+    size: usize,
+}
+
+fn supported_levels() -> Vec<usize> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use raw_cpuid::CpuId;
+
+        let mut levels = Vec::with_capacity(3);
+        let has_1g = CpuId::new()
+            .get_extended_processor_and_feature_identifiers()
+            .is_some_and(|features| features.has_1gib_pages());
+        if has_1g && MMArch::PAGE_LEVELS > 2 {
+            levels.push(2);
+        }
+        if MMArch::PAGE_LEVELS > 1 {
+            levels.push(1);
+        }
+        levels.push(0);
+        levels
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        alloc::vec![0]
+    }
+}
+
+fn level_size(level: usize) -> Option<usize> {
+    let shift = level
+        .checked_mul(MMArch::PAGE_ENTRY_SHIFT)?
+        .checked_add(MMArch::PAGE_SHIFT)?;
+    1usize.checked_shl(shift as u32)
+}
+
+/// RAII owner for a write-back device-memory mapping in the kernel linear address space.
+#[derive(Debug)]
+pub struct DeviceLinearMapping {
+    start: VirtAddr,
+    end: VirtAddr,
+    segments: Vec<MappingSegment>,
+    created_tables: Vec<CreatedPageTable>,
+}
+
+impl DeviceLinearMapping {
+    pub fn new(
+        paddr: PhysAddr,
+        length: usize,
+        flags: EntryFlags<MMArch>,
+    ) -> Result<Self, SystemError> {
+        if length == 0
+            || !paddr.check_aligned(MMArch::PAGE_SIZE)
+            || !length.is_multiple_of(MMArch::PAGE_SIZE)
+        {
+            return Err(SystemError::EINVAL);
+        }
+        let vaddr = unsafe { MMArch::phys_2_virt(paddr) }.ok_or(SystemError::EOVERFLOW)?;
+        let end_data = vaddr
+            .data()
+            .checked_add(length)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let mut mapping = Self {
+            start: vaddr,
+            end: VirtAddr::new(end_data),
+            segments: Vec::new(),
+            created_tables: Vec::new(),
+        };
+
+        let levels = supported_levels();
+        let mut offset = 0usize;
+        let mut kernel_mapper = KernelMapper::lock();
+        let mapper = kernel_mapper
+            .as_mut()
+            .ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)?;
+        if !unsafe { mapper.has_existing_top_level_subtrees(vaddr, mapping.end) } {
+            return Err(SystemError::ERANGE);
+        }
+        while offset < length {
+            let current_vaddr = vaddr + offset;
+            let current_paddr = paddr + offset;
+            let remaining = length - offset;
+            let mut installed = None;
+            for level in levels.iter().copied() {
+                let Some(size) = level_size(level) else {
+                    continue;
+                };
+                if size > remaining
+                    || !current_vaddr.check_aligned(size)
+                    || !current_paddr.check_aligned(size)
+                {
+                    continue;
+                }
+                let result = unsafe {
+                    mapper.map_phys_at_level(
+                        current_vaddr,
+                        current_paddr,
+                        level,
+                        flags.set_page_global(false),
+                        &mut mapping.created_tables,
+                    )
+                };
+                if let Some(flush) = result {
+                    unsafe { flush.ignore() };
+                    installed = Some(MappingSegment {
+                        vaddr: current_vaddr,
+                        paddr: current_paddr,
+                        level,
+                        size,
+                    });
+                    break;
+                }
+            }
+            let Some(segment) = installed else {
+                drop(kernel_mapper);
+                mapping.reset();
+                return Err(SystemError::EBUSY);
+            };
+            offset += segment.size;
+            mapping.segments.push(segment);
+        }
+        drop(kernel_mapper);
+        Ok(mapping)
+    }
+
+    pub fn len(&self) -> usize {
+        self.end.data() - self.start.data()
+    }
+
+    pub fn reset(&mut self) {
+        if self.segments.is_empty() && self.created_tables.is_empty() {
+            return;
+        }
+        {
+            let mut kernel_mapper = KernelMapper::lock();
+            let mapper = kernel_mapper
+                .as_mut()
+                .expect("device mapping reset while KernelMapper is recursively locked");
+            for segment in self.segments.iter().rev() {
+                let cleared =
+                    unsafe { mapper.clear_mapping_at_level(segment.vaddr, segment.level) };
+                assert_eq!(
+                    cleared.map(|(paddr, _)| paddr),
+                    Some(segment.paddr),
+                    "device mapping ownership changed before reset"
+                );
+            }
+        }
+
+        // PTE writes are complete and the KernelMapper lock is no longer held. The synchronous
+        // shootdown must finish before any transaction-owned page-table page is reclaimed.
+        flush_tlb_kernel_range(self.start, self.end, !self.created_tables.is_empty());
+
+        {
+            let mut kernel_mapper = KernelMapper::lock();
+            let mapper = kernel_mapper
+                .as_mut()
+                .expect("device page-table reclaim while KernelMapper is recursively locked");
+            unsafe { mapper.reclaim_created_tables(&mut self.created_tables) };
+        }
+        self.segments.clear();
+    }
+}
+
+impl Drop for DeviceLinearMapping {
+    fn drop(&mut self) {
+        self.reset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::level_size;
+
+    #[test]
+    fn x86_page_table_levels_have_expected_sizes() {
+        assert_eq!(level_size(0), Some(4 * 1024));
+        assert_eq!(level_size(1), Some(2 * 1024 * 1024));
+        assert_eq!(level_size(2), Some(1024 * 1024 * 1024));
+    }
+}

--- a/kernel/src/mm/device_linear.rs
+++ b/kernel/src/mm/device_linear.rs
@@ -3,6 +3,7 @@ use system_error::SystemError;
 
 use crate::{
     arch::MMArch,
+    libs::mutex::Mutex,
     mm::{
         kernel_mapper::KernelMapper,
         page::{CreatedPageTable, EntryFlags},
@@ -10,6 +11,13 @@ use crate::{
         MemoryManagementArch, PhysAddr, VirtAddr,
     },
 };
+
+lazy_static! {
+    /// Transaction-owned page tables that could not be reclaimed because another device mapping
+    /// still used them. Every device-linear teardown retries these records after its synchronous
+    /// kernel TLB shootdown.
+    static ref DEVICE_MAPPING_TEARDOWN: Mutex<Vec<CreatedPageTable>> = Mutex::new(Vec::new());
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct MappingSegment {
@@ -148,6 +156,10 @@ impl DeviceLinearMapping {
         if self.segments.is_empty() && self.created_tables.is_empty() {
             return;
         }
+        // Serialize the complete clear -> shootdown -> reclaim transaction. Otherwise another
+        // teardown could observe a deferred table as empty and free it before this mapping's
+        // remote TLB entries have been invalidated.
+        let mut deferred = DEVICE_MAPPING_TEARDOWN.lock();
         {
             let mut kernel_mapper = KernelMapper::lock();
             let mapper = kernel_mapper
@@ -173,7 +185,8 @@ impl DeviceLinearMapping {
             let mapper = kernel_mapper
                 .as_mut()
                 .expect("device page-table reclaim while KernelMapper is recursively locked");
-            unsafe { mapper.reclaim_created_tables(&mut self.created_tables) };
+            deferred.append(&mut self.created_tables);
+            unsafe { mapper.reclaim_created_tables(&mut deferred) };
         }
         self.segments.clear();
     }

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -525,6 +525,11 @@ pub trait MemoryManagementArch: Clone + Copy + Debug {
     /// 当该位为1时，代表该页表项是全局的
     const ENTRY_FLAG_GLOBAL: usize;
 
+    /// Return whether a present entry at `level` is a leaf mapping rather than a pointer to the
+    /// next-level table. Architectures such as RISC-V encode this through permission bits instead
+    /// of a dedicated huge-page bit.
+    fn entry_is_leaf(level: usize, flags: usize) -> bool;
+
     /// 虚拟地址与物理地址的偏移量
     const PHYS_OFFSET: usize;
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -22,6 +22,7 @@ use self::{
 };
 
 pub mod allocator;
+pub mod device_linear;
 pub mod dma;
 pub mod early_ioremap;
 pub mod fault;

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -1566,6 +1566,11 @@ impl<Arch: MemoryManagementArch> EntryFlags<Arch> {
         return self.update_flags(Arch::ENTRY_FLAG_HUGE_PAGE, value);
     }
 
+    #[inline(always)]
+    pub fn has_huge_page(&self) -> bool {
+        self.has_flag(Arch::ENTRY_FLAG_HUGE_PAGE)
+    }
+
     /// MMIO内存的页表项标志
     #[inline(always)]
     pub fn mmio_flags() -> Self {
@@ -1618,6 +1623,15 @@ pub struct PageMapper<Arch, F> {
     /// 页分配器
     frame_allocator: F,
     phantom: PhantomData<fn() -> Arch>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CreatedPageTable {
+    parent_base: VirtAddr,
+    parent_phys: PhysAddr,
+    parent_level: usize,
+    index: usize,
+    child_phys: PhysAddr,
 }
 
 impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
@@ -1767,6 +1781,162 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
                     // 获取新分配的页表
                     table = table.next_level_table(i)?;
                 }
+            }
+        }
+    }
+
+    /// Map an existing physical range at a specific page-table leaf level.
+    ///
+    /// The target entry must be empty. Any intermediate tables allocated by this call are appended
+    /// to `created_tables`, allowing a higher-level transaction to reclaim only tables it owns.
+    pub unsafe fn map_phys_at_level(
+        &mut self,
+        virt: VirtAddr,
+        phys: PhysAddr,
+        level: usize,
+        flags: EntryFlags<Arch>,
+        created_tables: &mut Vec<CreatedPageTable>,
+    ) -> Option<PageFlush<Arch>> {
+        if level >= Arch::PAGE_LEVELS {
+            return None;
+        }
+        let shift = level
+            .checked_mul(Arch::PAGE_ENTRY_SHIFT)?
+            .checked_add(Arch::PAGE_SHIFT)?;
+        let size = 1usize.checked_shl(shift as u32)?;
+        if !virt.check_aligned(size) || !phys.check_aligned(size) {
+            return None;
+        }
+
+        let virt = VirtAddr::new(virt.data() & !Arch::PAGE_NEGATIVE_MASK);
+        let mut table = self.table();
+        while table.level() > level {
+            let index = table.index_of(virt)?;
+            let entry = table.entry(index)?;
+            if entry.present() {
+                if entry.flags().has_huge_page() {
+                    return None;
+                }
+                table = table.next_level_table(index)?;
+                continue;
+            }
+
+            let child_phys = self.frame_allocator.allocate_one()?;
+            Arch::write_bytes(Arch::phys_2_virt(child_phys)?, 0, Arch::PAGE_SIZE);
+            let child = PageTable::new(table.entry_base(index)?, child_phys, table.level() - 1);
+            table.set_entry(
+                index,
+                PageEntry::new(
+                    child_phys,
+                    EntryFlags::new_page_table(virt.kind() == PageTableKind::User),
+                ),
+            )?;
+            created_tables.push(CreatedPageTable {
+                parent_base: table.base(),
+                parent_phys: table.phys(),
+                parent_level: table.level(),
+                index,
+                child_phys,
+            });
+            table = child;
+        }
+
+        let index = table.index_of(virt)?;
+        if !table.entry(index)?.empty() {
+            return None;
+        }
+        let flags = if level == 0 {
+            flags
+        } else {
+            flags.set_huge_page(true)
+        };
+        table.set_entry(index, PageEntry::new(phys, flags))?;
+        Some(PageFlush::new(virt))
+    }
+
+    /// Return whether every top-level slot covering `[start, end)` already points at a shared
+    /// kernel page-table subtree. Device-linear mappings may add lower-level entries to an existing
+    /// shared subtree, but must not create a new top-level entry visible only in the current CR3.
+    pub unsafe fn has_existing_top_level_subtrees(&self, start: VirtAddr, end: VirtAddr) -> bool {
+        if start >= end {
+            return false;
+        }
+        let table = self.table();
+        let top_level_size_shift = (Arch::PAGE_LEVELS - 1)
+            .checked_mul(Arch::PAGE_ENTRY_SHIFT)
+            .and_then(|shift| shift.checked_add(Arch::PAGE_SHIFT));
+        let Some(top_level_size) =
+            top_level_size_shift.and_then(|shift| 1usize.checked_shl(shift as u32))
+        else {
+            return false;
+        };
+        let mut address = start.data();
+        while address < end.data() {
+            let vaddr = VirtAddr::new(address);
+            let Some(index) = table.index_of(vaddr) else {
+                return false;
+            };
+            let Some(entry) = table.entry(index) else {
+                return false;
+            };
+            if !entry.present() || entry.flags().has_huge_page() {
+                return false;
+            }
+            let next = (address & !(top_level_size - 1)).saturating_add(top_level_size);
+            if next <= address {
+                return false;
+            }
+            address = next.min(end.data());
+        }
+        true
+    }
+
+    /// Clear exactly the leaf entry at `level`, without descending through a huge mapping and
+    /// without freeing intermediate page tables.
+    pub unsafe fn clear_mapping_at_level(
+        &mut self,
+        virt: VirtAddr,
+        level: usize,
+    ) -> Option<(PhysAddr, EntryFlags<Arch>)> {
+        let mut table = self.table();
+        while table.level() > level {
+            let index = table.index_of(virt)?;
+            let entry = table.entry(index)?;
+            if !entry.present() || entry.flags().has_huge_page() {
+                return None;
+            }
+            table = table.next_level_table(index)?;
+        }
+        let index = table.index_of(virt)?;
+        let entry = table.entry(index)?;
+        if !entry.present() || (level != 0) != entry.flags().has_huge_page() {
+            return None;
+        }
+        table.set_entry(index, PageEntry::from_usize(0))?;
+        Some((entry.address().ok()?, entry.flags()))
+    }
+
+    /// Reclaim transaction-owned page tables after a synchronous kernel TLB shootdown.
+    pub unsafe fn reclaim_created_tables(&mut self, created_tables: &mut Vec<CreatedPageTable>) {
+        for owned in created_tables.drain(..).rev() {
+            let parent =
+                PageTable::<Arch>::new(owned.parent_base, owned.parent_phys, owned.parent_level);
+            let Some(entry) = parent.entry(owned.index) else {
+                continue;
+            };
+            if !entry.present() || entry.address().ok() != Some(owned.child_phys) {
+                continue;
+            }
+            let child = PageTable::<Arch>::new(
+                parent.entry_base(owned.index).unwrap(),
+                owned.child_phys,
+                owned.parent_level - 1,
+            );
+            let empty = (0..Arch::PAGE_ENTRY_NUM)
+                .all(|index| child.entry(index).is_some_and(|entry| entry.empty()));
+            if empty {
+                parent.set_entry(owned.index, PageEntry::from_usize(0));
+                self.frame_allocator.free_one(owned.child_phys);
             }
         }
     }

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -1566,11 +1566,6 @@ impl<Arch: MemoryManagementArch> EntryFlags<Arch> {
         return self.update_flags(Arch::ENTRY_FLAG_HUGE_PAGE, value);
     }
 
-    #[inline(always)]
-    pub fn has_huge_page(&self) -> bool {
-        self.has_flag(Arch::ENTRY_FLAG_HUGE_PAGE)
-    }
-
     /// MMIO内存的页表项标志
     #[inline(always)]
     pub fn mmio_flags() -> Self {
@@ -1814,7 +1809,7 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             let index = table.index_of(virt)?;
             let entry = table.entry(index)?;
             if entry.present() {
-                if entry.flags().has_huge_page() {
+                if Arch::entry_is_leaf(table.level(), entry.flags().data()) {
                     return None;
                 }
                 table = table.next_level_table(index)?;
@@ -1879,7 +1874,7 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             let Some(entry) = table.entry(index) else {
                 return false;
             };
-            if !entry.present() || entry.flags().has_huge_page() {
+            if !entry.present() || Arch::entry_is_leaf(table.level(), entry.flags().data()) {
                 return false;
             }
             let next = (address & !(top_level_size - 1)).saturating_add(top_level_size);
@@ -1902,14 +1897,14 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
         while table.level() > level {
             let index = table.index_of(virt)?;
             let entry = table.entry(index)?;
-            if !entry.present() || entry.flags().has_huge_page() {
+            if !entry.present() || Arch::entry_is_leaf(table.level(), entry.flags().data()) {
                 return None;
             }
             table = table.next_level_table(index)?;
         }
         let index = table.index_of(virt)?;
         let entry = table.entry(index)?;
-        if !entry.present() || (level != 0) != entry.flags().has_huge_page() {
+        if !entry.present() || !Arch::entry_is_leaf(level, entry.flags().data()) {
             return None;
         }
         table.set_entry(index, PageEntry::from_usize(0))?;
@@ -1925,6 +1920,9 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
                 continue;
             };
             if !entry.present() || entry.address().ok() != Some(owned.child_phys) {
+                continue;
+            }
+            if Arch::entry_is_leaf(owned.parent_level, entry.flags().data()) {
                 continue;
             }
             let child = PageTable::<Arch>::new(

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -1913,7 +1913,11 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
 
     /// Reclaim transaction-owned page tables after a synchronous kernel TLB shootdown.
     pub unsafe fn reclaim_created_tables(&mut self, created_tables: &mut Vec<CreatedPageTable>) {
-        for owned in created_tables.drain(..).rev() {
+        // A lower-level table must be reclaimed before the parent that points to it. Records that
+        // are still non-empty remain owned and are retried by a later device-mapping teardown.
+        created_tables.sort_unstable_by_key(|owned| owned.parent_level);
+        let pending = core::mem::take(created_tables);
+        for owned in pending {
             let parent =
                 PageTable::<Arch>::new(owned.parent_base, owned.parent_phys, owned.parent_level);
             let Some(entry) = parent.entry(owned.index) else {
@@ -1935,6 +1939,8 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             if empty {
                 parent.set_entry(owned.index, PageEntry::from_usize(0));
                 self.frame_allocator.free_one(owned.child_phys);
+            } else {
+                created_tables.push(owned);
             }
         }
     }

--- a/kernel/src/mm/tlb.rs
+++ b/kernel/src/mm/tlb.rs
@@ -52,7 +52,7 @@ pub const TLB_SINGLE_PAGE_FLUSH_CEILING: usize = 33;
 #[allow(dead_code)]
 pub struct FlushTlbInfo {
     /// Target address space
-    pub mm: Arc<AddressSpace>,
+    pub mm: Option<Arc<AddressSpace>>,
     /// Start virtual address (inclusive, aligned to stride)
     pub start: VirtAddr,
     /// End virtual address (exclusive). If `TLB_FLUSH_ALL`, invalidate the entire mm.
@@ -274,10 +274,10 @@ pub unsafe fn tlb_state_clear_loaded_mm() {
 ///
 /// Only updates `loaded_tlb_gen` when this CPU's loaded_mm matches `info.mm`.
 pub fn local_flush_tlb_func(info: &FlushTlbInfo) {
-    let loaded_matches = {
+    let loaded_matches = info.mm.as_ref().is_none_or(|mm| {
         let st = tlb_state_force(smp_get_processor_id());
-        st.loaded_is(&info.mm)
-    };
+        st.loaded_is(mm)
+    });
 
     if !loaded_matches {
         // This CPU has already switched to a different mm; the previous CR3 write implicitly
@@ -304,9 +304,11 @@ pub fn local_flush_tlb_func(info: &FlushTlbInfo) {
         }
     }
 
-    let st = tlb_state_local_mut();
-    if st.loaded_tlb_gen < info.new_tlb_gen {
-        st.loaded_tlb_gen = info.new_tlb_gen;
+    if info.mm.is_some() {
+        let st = tlb_state_local_mut();
+        if st.loaded_tlb_gen < info.new_tlb_gen {
+            st.loaded_tlb_gen = info.new_tlb_gen;
+        }
     }
 }
 
@@ -360,8 +362,13 @@ pub fn remote_flush_tlb_on_ipi() {
 /// Upon return, all CPUs in `target_cpus` have completed this shootdown (INV-4).
 fn flush_tlb_multi(target_cpus: &CpuMask, info: &FlushTlbInfo) {
     // Filter out offline CPUs to avoid sending IPIs to not-yet-started / offline APICs.
-    let online = smp_cpu_manager().present_cpus();
-    let active: CpuMask = target_cpus & online;
+    let mut online = CpuMask::new();
+    for cpu in smp_cpu_manager().present_cpus().iter_cpu() {
+        if smp_cpu_manager().is_online_cpu(cpu) {
+            online.set(cpu, true);
+        }
+    }
+    let active: CpuMask = target_cpus & &online;
 
     let my_cpu = smp_get_processor_id();
 
@@ -460,7 +467,7 @@ pub fn flush_tlb_mm_range(
     let this_cpu = smp_get_processor_id();
 
     let info = FlushTlbInfo {
-        mm: mm.clone(),
+        mm: Some(mm.clone()),
         start,
         end,
         new_tlb_gen: new_gen,
@@ -491,6 +498,53 @@ pub fn flush_tlb_mm_range(
         local_flush_tlb_func(&info);
     }
 
+    compiler_fence(Ordering::SeqCst);
+    drop(irq_guard);
+
+    #[cfg(target_arch = "x86_64")]
+    if !irq_was_enabled {
+        unsafe { CurrentIrqArch::interrupt_disable() };
+    }
+}
+
+/// Synchronously invalidate a kernel address-space range on every online CPU.
+///
+/// Kernel mappings are shared by all process page tables, so this request is deliberately
+/// independent from any user `AddressSpace` and its TLB generation. Callers must publish PTE
+/// changes before invoking this function and must not free intermediate page-table pages until it
+/// returns.
+pub fn flush_tlb_kernel_range(start: VirtAddr, end: VirtAddr, freed_tables: bool) {
+    #[cfg(target_arch = "x86_64")]
+    let irq_was_enabled = CurrentIrqArch::is_irq_enabled();
+    #[cfg(target_arch = "x86_64")]
+    if !irq_was_enabled {
+        unsafe { CurrentIrqArch::interrupt_enable() };
+    }
+    #[cfg(target_arch = "x86_64")]
+    let _flush_guard = FLUSH_TLB_GLOBAL_LOCK.lock();
+
+    let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+    compiler_fence(Ordering::SeqCst);
+    let this_cpu = smp_get_processor_id();
+    let info = FlushTlbInfo {
+        mm: None,
+        start,
+        end,
+        new_tlb_gen: 0,
+        stride_shift: MMArch::PAGE_SHIFT as u8,
+        freed_tables,
+        initiating_cpu: this_cpu,
+    };
+    let mut remote_mask = CpuMask::new();
+    for cpu in smp_cpu_manager().present_cpus().iter_cpu() {
+        if cpu != this_cpu && smp_cpu_manager().is_online_cpu(cpu) {
+            remote_mask.set(cpu, true);
+        }
+    }
+    if !remote_mask.is_empty() {
+        flush_tlb_multi(&remote_mask, &info);
+    }
+    local_flush_tlb_func(&info);
     compiler_fence(Ordering::SeqCst);
     drop(irq_guard);
 


### PR DESCRIPTION
## Summary

- promote validated virtiofs cache descriptors into explicitly owned PCI BAR subresources
- map cache windows into the kernel linear address space with write-back, writable, supervisor-only, non-executable, non-global attributes
- reject page-level overlap with VirtIO configuration and MSI-X mappings while preserving non-DAX fallback
- add level-aware transactional device mappings, synchronous kernel TLB shootdown, rollback, and RAII teardown

## Root cause

The transport discovered and retained the virtiofs shared-memory cache descriptor, but it remained address metadata only. No component reserved the PCI resource, established a correctly cached mapping, or owned deterministic reset and failure cleanup. Mapping the complete BAR through the MMIO pool was also unsafe for shared BAR layouts and could exhaust its virtual-address space.

## Design notes

- PCI configuration and MSI-X subranges remain independently mapped even when they share the cache BAR.
- Cache windows are rejected if their page-aligned extent aliases an existing uncached transport mapping.
- Existing shared kernel top-level page-table subtrees are required, preventing mappings that are visible only in the probing CR3.
- Mapping teardown clears recorded leaf entries, completes a synchronous all-online-CPU kernel TLB shootdown, then reclaims only transaction-owned empty page tables.
- DAX file I/O and `dax=always`/`dax=inode` remain disabled until allocator and FUSE mapping support land.

## Validation

- `make kernel`
- `git diff --check`
- QEMU x86_64, 2 vCPUs, virtiofs without a cache capability:
  - device registered with no cache window
  - non-DAX mount succeeded
  - guest read a host-created file and wrote a host-visible file
  - unmount succeeded
  - `dax=always` failed with `EOPNOTSUPP`

The available QEMU 8.2.2 `vhost-user-fs-pci` device does not expose a cache-window property, so a real cache capability could not be generated for dynamic validation. Static unit coverage was added for descriptor range and page-level alias boundaries, and the mapping lifecycle received adversarial implementation review.

Fixes #2077
