### PR TITLE
fix(ext4): prepare shared mmap writes

### DIFF
--- a/kernel/crates/another_ext4/ext4_test/src/main.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/main.rs
@@ -506,6 +506,14 @@ fn prepare_buffered_write_does_not_commit_size_test() {
 
 fn legacy_orphan_mount_cleanup_test() {
     make_ext4();
+    let (free_inodes_before, free_blocks_before) = {
+        let ext4 = load_ext4();
+        let sb = ext4.super_block().expect("read baseline superblock failed");
+        let counters = (sb.free_inodes_count(), sb.free_blocks_count());
+        ext4.shutdown_writable()
+            .expect("baseline clean writable shutdown failed");
+        counters
+    };
     let orphan = {
         let ext4 = load_ext4();
         let mode = InodeMode::FILE | InodeMode::ALL_RWX;
@@ -527,12 +535,43 @@ fn legacy_orphan_mount_cleanup_test() {
     };
 
     let ext4 = load_ext4();
-    ext4
-        .generic_lookup(ROOT_INO, "crash_orphan")
+    ext4.generic_lookup(ROOT_INO, "crash_orphan")
         .expect_err("orphaned name reappeared after recovery");
-    ext4
-        .getattr(orphan)
+    ext4.getattr(orphan)
         .expect_err("mount recovery did not reclaim orphan inode");
+
+    // Recovery must leave both allocation bitmaps reusable.  Repeated
+    // allocate/write/unlink/reclaim cycles catch a stale inode bit, leaked
+    // data blocks, or an orphan record that is consumed more than once.
+    let mode = InodeMode::FILE | InodeMode::ALL_RWX;
+    for iteration in 0..16 {
+        let name = format!("post_recovery_reuse_{iteration}");
+        let inode = ext4
+            .generic_create(ROOT_INO, &name, mode)
+            .expect("post-recovery create failed");
+        let payload = vec![iteration as u8; 2 * 1024 * 1024];
+        ext4.write(inode, 0, &payload)
+            .expect("post-recovery write failed");
+        let handle = ext4
+            .unlink(ROOT_INO, &name)
+            .expect("post-recovery unlink failed")
+            .expect("post-recovery final unlink returned no reclaim handle");
+        ext4.reclaim_inode(handle)
+            .expect("post-recovery reclaim failed");
+    }
+    let recovered = ext4
+        .super_block()
+        .expect("read recovered superblock failed");
+    assert_eq!(
+        recovered.free_inodes_count(),
+        free_inodes_before,
+        "orphan recovery leaked inode bitmap accounting"
+    );
+    assert_eq!(
+        recovered.free_blocks_count(),
+        free_blocks_before,
+        "orphan recovery leaked block bitmap accounting"
+    );
     ext4.shutdown_writable()
         .expect("clean writable shutdown failed");
     drop(ext4);

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -185,10 +185,7 @@ impl FileSystem for Ext4FileSystem {
             return VmFaultReason::VM_FAULT_SIGBUS;
         };
         let inode_ref = file.inode();
-        let Some(inode) = inode_ref
-            .as_any_ref()
-            .downcast_ref::<LockedExt4Inode>()
-        else {
+        let Some(inode) = inode_ref.as_any_ref().downcast_ref::<LockedExt4Inode>() else {
             return VmFaultReason::VM_FAULT_SIGBUS;
         };
         let Ok(_prepare_guard) = inode.prepare_mmap_write(page_index) else {

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -177,6 +177,23 @@ impl FileSystem for Ext4FileSystem {
     }
 
     unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
+        let file = pfm.vma().lock().vm_file();
+        let Some(file) = file else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        let Some(page_index) = pfm.backing_pgoff() else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        let inode_ref = file.inode();
+        let Some(inode) = inode_ref
+            .as_any_ref()
+            .downcast_ref::<LockedExt4Inode>()
+        else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        let Ok(_prepare_guard) = inode.prepare_mmap_write(page_index) else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
         PageFaultHandler::filemap_page_mkwrite(pfm)
     }
 

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -790,18 +790,13 @@ impl IndexNode for LockedExt4Inode {
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
-        let (fs, inode_num, page_cache, cached_size) = {
+        let (fs, inode_num, page_cache) = {
             let guard = self.inner.lock();
             (
                 guard.concret_fs(),
                 guard.inner_inode_num,
                 guard.page_cache.clone(),
-                guard.cached_file_size,
             )
-        };
-        let old_size = match cached_size {
-            Some(size) => size,
-            None => fs.fs.getattr(inode_num)?.size,
         };
         let apply_resize = || -> Result<(), SystemError> {
             let _io_guard = self.io_lock.lock();
@@ -834,28 +829,45 @@ impl IndexNode for LockedExt4Inode {
             Ok(())
         };
 
-        if len < old_size as usize {
-            if let Some(page_cache) = page_cache {
-                let hole_start_page = len
-                    .checked_add(MMArch::PAGE_SIZE - 1)
-                    .ok_or(SystemError::EFBIG)?
-                    >> MMArch::PAGE_SHIFT;
-                loop {
-                    // Match PageCache::truncate(), but acquire ext4's size lock
-                    // after invalidate_write so mmap faults and regular writes
-                    // use one global order: invalidate -> size -> inode I/O.
-                    page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
-                    let committed = {
-                        let _invalidate = page_cache.invalidate_write();
-                        let _size_guard = self.size_lock.write();
-                        apply_resize()?;
-                        page_cache.truncate_locked(len)?
+        if let Some(page_cache) = page_cache {
+            let hole_start_page = len
+                .checked_add(MMArch::PAGE_SIZE - 1)
+                .ok_or(SystemError::EFBIG)?
+                >> MMArch::PAGE_SHIFT;
+            let mut truncate_pending = false;
+            loop {
+                // Match PageCache::truncate(), but acquire ext4's size lock
+                // after invalidate_write so mmap faults and regular writes
+                // use one global order: invalidate -> size -> inode I/O.
+                page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
+                let (shrinking, committed) = {
+                    let _invalidate = page_cache.invalidate_write();
+                    let _size_guard = self.size_lock.write();
+                    // Classify against the authoritative size while holding the
+                    // same lock that serializes the update.  A function-entry
+                    // snapshot can become stale after a concurrent extension.
+                    let cached_size = self.inner.lock().cached_file_size;
+                    let current_size = match cached_size {
+                        Some(size) => size,
+                        None => fs.fs.getattr(inode_num)?.size,
                     };
-                    if committed {
+                    // After truncate_locked() asks for another unmap pass, the
+                    // inode size already equals len.  Preserve that pending
+                    // cache truncation unless a concurrent resize moved the
+                    // authoritative size below this request.
+                    let shrinking = len < current_size as usize
+                        || (truncate_pending && len == current_size as usize);
+                    apply_resize()?;
+                    let committed = !shrinking || page_cache.truncate_locked(len)?;
+                    (shrinking, committed)
+                };
+                if committed {
+                    if shrinking {
                         page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
-                        return Ok(());
                     }
+                    return Ok(());
                 }
+                truncate_pending = shrinking;
             }
         }
         let _size_guard = self.size_lock.write();

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -13,7 +13,7 @@ use crate::{
     libs::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
-        rwsem::RwSem,
+        rwsem::{RwSem, RwSemReadGuard},
         spinlock::SpinLock,
         wait_queue::WaitQueue,
     },
@@ -167,6 +167,13 @@ impl Ext4InodeLifecycle {
 pub(super) struct Ext4InodeOperation {
     lifecycle: Arc<Ext4InodeLifecycle>,
     owner: RawPid,
+}
+
+/// Keeps the ext4 mmap write-preparation critical section alive until the
+/// generic page-cache layer has made the page writable and dirty.
+pub(super) struct Ext4MmapWriteGuard<'a> {
+    _operation: Ext4InodeOperation,
+    _size_guard: RwSemReadGuard<'a, ()>,
 }
 
 impl Drop for Ext4InodeOperation {
@@ -1832,6 +1839,65 @@ impl LockedExt4Inode {
         drop(guard);
         self.release_clean_metadata_queue_owner(&fs);
         Ok(())
+    }
+
+    /// Prepare the on-disk extent before a shared file VMA becomes writable.
+    ///
+    /// This is the ext4 counterpart of Linux `ext4_page_mkwrite()`: page-cache
+    /// dirtying alone is insufficient for a sparse page because writeback uses
+    /// `write_data_only()` and therefore requires the backing block to exist.
+    pub(super) fn prepare_mmap_write(
+        &self,
+        page_index: usize,
+    ) -> Result<Ext4MmapWriteGuard<'_>, SystemError> {
+        let operation = self.begin_operation()?;
+        let size_guard = self.size_lock.read();
+        let io_guard = self.io_lock.lock();
+        let (fs, inode_num, file_size) = {
+            let mut guard = self.inner.lock();
+            let fs = guard.concret_fs();
+            let file_size = match guard.cached_file_size {
+                Some(size) => size,
+                None => {
+                    let size = fs.fs.getattr(guard.inner_inode_num)?.size;
+                    guard.cached_file_size = Some(size);
+                    size
+                }
+            };
+            (fs, guard.inner_inode_num, file_size)
+        };
+        let page_start = page_index
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EFBIG)?;
+        if page_start >= file_size as usize {
+            return Err(SystemError::EFBIG);
+        }
+        let time = PosixTimeSpec::now().tv_sec.to_u32().unwrap_or(0);
+        Self::retry_metadata_contention(|| {
+            fs.fs.prepare_buffered_write(
+                inode_num,
+                page_start,
+                MMArch::PAGE_SIZE,
+                file_size,
+                Some(time),
+            )
+        })?;
+        // The size read lock remains held through the generic page-cache
+        // handoff, so truncate cannot remove the prepared extent.  Release the
+        // inode I/O lock first: filemap_page_mkwrite may wait for an existing
+        // writeback, whose write_sync path needs this same lock.
+        drop(io_guard);
+
+        let self_arc = {
+            let mut guard = self.inner.lock();
+            guard.cached_mtime = Some(time);
+            guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?
+        };
+        Ext4FileSystem::mark_inode_dirty(&self_arc, InodeDirtyState::MTIME_DIRTY)?;
+        Ok(Ext4MmapWriteGuard {
+            _operation: operation,
+            _size_guard: size_guard,
+        })
     }
 }
 

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -391,7 +391,6 @@ impl IndexNode for LockedExt4Inode {
         if len == 0 {
             return Ok(0);
         }
-        let _size_guard = self.size_lock.read();
         let buf = &buf[0..len];
 
         let (fs, inode_num, page_cache) = {
@@ -405,6 +404,7 @@ impl IndexNode for LockedExt4Inode {
 
         if let Some(page_cache) = page_cache {
             let _invalidate = page_cache.invalidate_write();
+            let _size_guard = self.size_lock.read();
             let _io_guard = self.io_lock.lock();
 
             // 使用缓存的文件大小，避免 getattr 磁盘 I/O
@@ -463,6 +463,7 @@ impl IndexNode for LockedExt4Inode {
 
             Ok(write_len)
         } else {
+            let _size_guard = self.size_lock.read();
             self.write_direct(offset, len, buf, data)
         }
     }
@@ -789,7 +790,6 @@ impl IndexNode for LockedExt4Inode {
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
-        let _size_guard = self.size_lock.write();
         let (fs, inode_num, page_cache, cached_size) = {
             let guard = self.inner.lock();
             (
@@ -803,7 +803,7 @@ impl IndexNode for LockedExt4Inode {
             Some(size) => size,
             None => fs.fs.getattr(inode_num)?.size,
         };
-        {
+        let apply_resize = || -> Result<(), SystemError> {
             let _io_guard = self.io_lock.lock();
             let ext4 = &fs.fs;
             // 仅调整文件大小，其他属性保持不变
@@ -831,13 +831,35 @@ impl IndexNode for LockedExt4Inode {
                     .remove(InodeDirtyState::SIZE_DIRTY | InodeDirtyState::MTIME_DIRTY);
             }
             self.release_clean_metadata_queue_owner(&fs);
-        }
+            Ok(())
+        };
+
         if len < old_size as usize {
             if let Some(page_cache) = page_cache {
-                page_cache.truncate(len)?;
+                let hole_start_page = len
+                    .checked_add(MMArch::PAGE_SIZE - 1)
+                    .ok_or(SystemError::EFBIG)?
+                    >> MMArch::PAGE_SHIFT;
+                loop {
+                    // Match PageCache::truncate(), but acquire ext4's size lock
+                    // after invalidate_write so mmap faults and regular writes
+                    // use one global order: invalidate -> size -> inode I/O.
+                    page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
+                    let committed = {
+                        let _invalidate = page_cache.invalidate_write();
+                        let _size_guard = self.size_lock.write();
+                        apply_resize()?;
+                        page_cache.truncate_locked(len)?
+                    };
+                    if committed {
+                        page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
+                        return Ok(());
+                    }
+                }
             }
         }
-        Ok(())
+        let _size_guard = self.size_lock.write();
+        apply_resize()
     }
 
     fn fallocate_file(

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -2324,7 +2324,12 @@ impl PageCache {
         }
     }
 
-    fn truncate_locked(&self, new_size: usize) -> Result<bool, SystemError> {
+    /// Remove cached pages while the caller holds `invalidate_write()`.
+    ///
+    /// Filesystems that must serialize their on-disk size update with page
+    /// invalidation use this after unmapping PTEs.  Callers must repeat the
+    /// unmap-and-lock sequence when this returns `false`.
+    pub(crate) fn truncate_locked(&self, new_size: usize) -> Result<bool, SystemError> {
         let first_full_truncate_page = page_align_up(new_size) >> MMArch::PAGE_SHIFT;
         let truncate_indices: Vec<usize> = {
             let guard = self.inner.lock();

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -165,6 +165,40 @@ class LoopExt4 {
         mounted_ = false;
     }
 
+    void Detach() {
+        ASSERT_TRUE(mounted_);
+        ASSERT_EQ(0, umount2(mount_point_.c_str(), MNT_DETACH)) << strerror(errno);
+        mounted_ = false;
+        detached_ = true;
+    }
+
+    void FinishDetached() {
+        ASSERT_TRUE(detached_);
+        // MNT_DETACH drops the namespace edge immediately, while final
+        // superblock teardown runs after the last external owner is released.
+        // Do not detach the loop backing underneath that teardown.
+        usleep(50 * 1000);
+        bool cleared = false;
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            if (ioctl(loop_fd_, kLoopClrFd, 0) == 0) {
+                cleared = true;
+                break;
+            }
+            ASSERT_EQ(EBUSY, errno) << strerror(errno);
+            usleep(5 * 1000);
+        }
+        ASSERT_TRUE(cleared) << "detached ext4 mount retained the loop device";
+        detached_ = false;
+        close(loop_fd_);
+        loop_fd_ = -1;
+        close(backing_fd_);
+        backing_fd_ = -1;
+        ASSERT_EQ(0, rmdir(mount_point_.c_str())) << strerror(errno);
+        mount_point_.clear();
+        ASSERT_EQ(0, unlink(image_.c_str())) << strerror(errno);
+        image_.clear();
+    }
+
     const std::string& mount_point() const {
         return mount_point_;
     }
@@ -176,6 +210,7 @@ class LoopExt4 {
     int backing_fd_ = -1;
     int loop_fd_ = -1;
     bool mounted_ = false;
+    bool detached_ = false;
 };
 
 void WriteAll(int fd, const char* data, size_t len) {
@@ -257,6 +292,186 @@ TEST(Ext4InodeIdentity, OpenFileSurvivesFinalUnlink) {
     ASSERT_EQ(0, close(fd)) << strerror(errno);
 
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, DeletedFdSupportsTruncateAndFallocate) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string path = fs.mount_point() + "/deleted_fd_mutation";
+    int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    constexpr char kPrefix[] = "retained-prefix";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(fd, kPrefix, sizeof(kPrefix) - 1));
+    ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+    struct stat st = {};
+    ASSERT_EQ(0, fstat(fd, &st)) << strerror(errno);
+    EXPECT_EQ(0u, st.st_nlink);
+
+    ASSERT_EQ(0, ftruncate(fd, 8)) << strerror(errno);
+    ASSERT_EQ(0, fallocate(fd, 0, 0, 8192)) << strerror(errno);
+    ASSERT_EQ(0, fstat(fd, &st)) << strerror(errno);
+    EXPECT_EQ(8192, st.st_size);
+    char data[16] = {};
+    ASSERT_EQ(16, pread(fd, data, sizeof(data), 0)) << strerror(errno);
+    EXPECT_EQ(0, memcmp(data, kPrefix, 8));
+    for (size_t i = 8; i < sizeof(data); ++i) {
+        EXPECT_EQ(0, data[i]);
+    }
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, DirtySharedMappingSurvivesUnlinkAndFdClose) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string path = fs.mount_point() + "/dirty_mapping";
+    int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, ftruncate(fd, 8192)) << strerror(errno);
+    char* mapping = static_cast<char*>(
+        mmap(nullptr, 8192, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    ASSERT_NE(MAP_FAILED, mapping) << strerror(errno);
+    memcpy(mapping + 64, "first-page", 10);
+    memcpy(mapping + 4096 + 32, "second-page", 11);
+    ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+    ASSERT_EQ(0, msync(mapping, 8192, MS_SYNC)) << strerror(errno);
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    EXPECT_EQ(0, memcmp(mapping + 64, "first-page", 10));
+    memcpy(mapping + 4096 + 32, "after-close", 11);
+    ASSERT_EQ(0, msync(mapping + 4096, 4096, MS_SYNC)) << strerror(errno);
+    EXPECT_EQ(-1, umount(fs.mount_point().c_str()));
+    EXPECT_EQ(EBUSY, errno);
+    ASSERT_EQ(0, munmap(mapping, 8192)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, SharedMmapWriteSerializesWithTruncate) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string path = fs.mount_point() + "/mmap_truncate_race";
+    int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(0, ftruncate(fd, 8192)) << strerror(errno);
+    char* mapping = static_cast<char*>(
+        mmap(nullptr, 8192, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    ASSERT_NE(MAP_FAILED, mapping) << strerror(errno);
+
+    std::atomic<bool> start{false};
+    std::atomic<int> first_error{0};
+    auto record_error = [&](int error) {
+        int expected = 0;
+        first_error.compare_exchange_strong(expected, error);
+    };
+    std::thread writer([&] {
+        while (!start.load(std::memory_order_acquire)) {
+        }
+        for (int iteration = 0; iteration < 64; ++iteration) {
+            if (madvise(mapping, 4096, MADV_DONTNEED) != 0) {
+                record_error(errno);
+                return;
+            }
+            mapping[iteration % 64] = static_cast<char>(iteration);
+            if (msync(mapping, 4096, MS_SYNC) != 0) {
+                record_error(errno);
+                return;
+            }
+        }
+    });
+    std::thread truncater([&] {
+        while (!start.load(std::memory_order_acquire)) {
+        }
+        for (int iteration = 0; iteration < 64; ++iteration) {
+            if (ftruncate(fd, (iteration & 1) ? 8192 : 4096) != 0) {
+                record_error(errno);
+                return;
+            }
+        }
+    });
+    start.store(true, std::memory_order_release);
+    writer.join();
+    truncater.join();
+    EXPECT_EQ(0, first_error.load());
+    ASSERT_EQ(0, ftruncate(fd, 8192)) << strerror(errno);
+    ASSERT_EQ(0, msync(mapping, 4096, MS_SYNC)) << strerror(errno);
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, munmap(mapping, 8192)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, FinalAndNonFinalHardLinkRemoval) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string first = fs.mount_point() + "/hardlink_first";
+    const std::string second = fs.mount_point() + "/hardlink_second";
+    int fd = open(first.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    constexpr char kData[] = "hard-link-lifetime";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(fd, kData, sizeof(kData) - 1));
+    ASSERT_EQ(0, link(first.c_str(), second.c_str())) << strerror(errno);
+    ASSERT_EQ(0, unlink(first.c_str())) << strerror(errno);
+    struct stat fd_stat = {};
+    struct stat path_stat = {};
+    ASSERT_EQ(0, fstat(fd, &fd_stat)) << strerror(errno);
+    ASSERT_EQ(0, stat(second.c_str(), &path_stat)) << strerror(errno);
+    EXPECT_EQ(1u, fd_stat.st_nlink);
+    EXPECT_EQ(fd_stat.st_ino, path_stat.st_ino);
+
+    ASSERT_EQ(0, unlink(second.c_str())) << strerror(errno);
+    ASSERT_EQ(0, fstat(fd, &fd_stat)) << strerror(errno);
+    EXPECT_EQ(0u, fd_stat.st_nlink);
+    EXPECT_EQ(-1, access(second.c_str(), F_OK));
+    EXPECT_EQ(ENOENT, errno);
+    char data[sizeof(kData)] = {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(kData) - 1),
+              pread(fd, data, sizeof(kData) - 1, 0))
+        << strerror(errno);
+    EXPECT_EQ(0, memcmp(data, kData, sizeof(kData) - 1));
+    ASSERT_EQ(1, pwrite(fd, "!", 1, sizeof(kData) - 1)) << strerror(errno);
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, LazyUnmountPreservesLiveUnlinkedFd) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    const std::string path = fs.mount_point() + "/lazy_unmount";
+    int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    constexpr char kData[] = "before-detach";
+    ASSERT_NO_FATAL_FAILURE(WriteAll(fd, kData, sizeof(kData) - 1));
+    ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+    EXPECT_EQ(-1, umount(fs.mount_point().c_str()));
+    EXPECT_EQ(EBUSY, errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Detach());
+
+    struct stat st = {};
+    ASSERT_EQ(0, fstat(fd, &st)) << strerror(errno);
+    EXPECT_EQ(0u, st.st_nlink);
+    ASSERT_EQ(1, pwrite(fd, "!", 1, sizeof(kData) - 1)) << strerror(errno);
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    char data[sizeof(kData)] = {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(kData) - 1),
+              pread(fd, data, sizeof(kData) - 1, 0))
+        << strerror(errno);
+    EXPECT_EQ(0, memcmp(data, kData, sizeof(kData) - 1));
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.FinishDetached());
 }
 
 TEST(Ext4InodeIdentity, DirtyClosedUnlinkSyncfsCompletes) {


### PR DESCRIPTION
## Summary

- prepare ext4 backing extents before shared mmap pages become writable and dirty
- serialize mmap write preparation with truncate without blocking writeback on the inode I/O lock
- expand ext4 unlinked-inode coverage for deleted-fd operations, mmap/writeback, hard links, lazy unmount, and recovery accounting

## Root cause

DragonOS ext4 reused the generic `filemap_page_mkwrite` path, which marks a page-cache page dirty but does not allocate ext4 blocks for a sparse mapped page. After unlink, `msync(MS_SYNC)` reached `write_data_only` without a physical extent and returned `ENOENT`.

The fix adds ext4-specific mmap write preparation before the generic dirty handoff. The inode lifecycle operation and size read lock span the whole handoff so truncate cannot remove the prepared extent. The inode I/O lock is released before the generic layer can wait for writeback, avoiding a writeback lock cycle.

## Validation

- `ROOTFS_MANIFEST=ubuntu2404 make kernel`
- Ubuntu 24.04 DragonOS QEMU guest: `/opt/tests/dunitest/bin/normal/ext4_inode_identity_test` — 19/19 passed
- `cargo run --release` in `kernel/crates/another_ext4/ext4_test` — recovery reuse/accounting and `e2fsck` passed
- focused pre-fix reproducer: dirty shared mmap + unlink returned `ENOENT` from `msync`; the same test passes after the fix

Closes #2054
