### PR TITLE
fix(namespace): complete UTS namespace isolation

### DIFF
--- a/kernel/src/filesystem/procfs/sys/kernel.rs
+++ b/kernel/src/filesystem/procfs/sys/kernel.rs
@@ -12,6 +12,7 @@ use crate::{
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     libs::mutex::MutexGuard,
+    process::{namespace::uts_namespace::NewUtsName, ProcessManager},
 };
 use alloc::{
     format,
@@ -73,6 +74,21 @@ impl DirOps for KernelDirOps {
                 cached_children.insert(name.to_string(), inode.clone());
                 return Ok(inode);
             }
+            "hostname" | "domainname" => {
+                let mut cached_children = dir.cached_children().write();
+                if let Some(child) = cached_children.get(name) {
+                    return Ok(child.clone());
+                }
+
+                let kind = if name == "hostname" {
+                    UtsStringKind::Hostname
+                } else {
+                    UtsStringKind::Domainname
+                };
+                let inode = UtsStringFileOps::new_inode(dir.self_ref_weak().clone(), kind);
+                cached_children.insert(name.to_string(), inode.clone());
+                return Ok(inode);
+            }
             _ => Err(SystemError::ENOENT),
         }
     }
@@ -92,6 +108,100 @@ impl DirOps for KernelDirOps {
             .or_insert_with(|| {
                 OverflowIdFileOps::new_inode(dir.self_ref_weak().clone(), OverflowIdKind::Gid)
             });
+        cached_children
+            .entry("hostname".to_string())
+            .or_insert_with(|| {
+                UtsStringFileOps::new_inode(dir.self_ref_weak().clone(), UtsStringKind::Hostname)
+            });
+        cached_children
+            .entry("domainname".to_string())
+            .or_insert_with(|| {
+                UtsStringFileOps::new_inode(dir.self_ref_weak().clone(), UtsStringKind::Domainname)
+            });
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum UtsStringKind {
+    Hostname,
+    Domainname,
+}
+
+#[derive(Debug)]
+struct UtsStringFileOps {
+    kind: UtsStringKind,
+}
+
+impl UtsStringFileOps {
+    fn new_inode(parent: Weak<dyn IndexNode>, kind: UtsStringKind) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { kind }, InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    fn snapshot(&self) -> [u8; NewUtsName::MAXLEN] {
+        let uts_ns = ProcessManager::current_utsns();
+        match self.kind {
+            UtsStringKind::Hostname => uts_ns.hostname(),
+            UtsStringKind::Domainname => uts_ns.domainname(),
+        }
+    }
+}
+
+impl FileOps for UtsStringFileOps {
+    fn read_at(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        let value = self.snapshot();
+        let value_len = value
+            .iter()
+            .position(|byte| *byte == 0)
+            .unwrap_or(value.len());
+        let mut content = Vec::with_capacity(value_len + 1);
+        content.extend_from_slice(&value[..value_len]);
+        content.push(b'\n');
+        proc_read(offset, len, buf, &content)
+    }
+
+    fn write_at(
+        &self,
+        offset: usize,
+        _len: usize,
+        buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let uts_ns = ProcessManager::current_utsns();
+        let old = match self.kind {
+            UtsStringKind::Hostname => uts_ns.hostname(),
+            UtsStringKind::Domainname => uts_ns.domainname(),
+        };
+        let old_len = old.iter().position(|byte| *byte == 0).unwrap_or(old.len());
+        if offset > old_len {
+            return Ok(buf.len());
+        }
+
+        let input_len = buf
+            .iter()
+            .position(|byte| *byte == 0 || *byte == b'\n')
+            .unwrap_or(buf.len());
+        let copy_len = input_len.min((NewUtsName::MAXLEN - 1).saturating_sub(offset));
+        let mut value = [0u8; NewUtsName::MAXLEN];
+        value[..offset].copy_from_slice(&old[..offset]);
+        value[offset..offset + copy_len].copy_from_slice(&buf[..copy_len]);
+        match self.kind {
+            UtsStringKind::Hostname => uts_ns.set_hostname(&value[..offset + copy_len])?,
+            UtsStringKind::Domainname => uts_ns.set_domainname(&value[..offset + copy_len])?,
+        }
+        Ok(buf.len())
     }
 }
 

--- a/kernel/src/process/namespace/setns.rs
+++ b/kernel/src/process/namespace/setns.rs
@@ -38,6 +38,12 @@ fn can_setns_target_userns(
     cred.has_cap_sys_admin() && cred.user_ns.is_ancestor_of(target_user_ns)
 }
 
+fn can_setns_uts(target: &crate::process::namespace::uts_namespace::UtsNamespace) -> bool {
+    let current_user_ns = ProcessManager::current_pcb().cred().user_ns.clone();
+    ns_capable(target.user_ns(), CAPFlags::CAP_SYS_ADMIN)
+        && ns_capable(&current_user_ns, CAPFlags::CAP_SYS_ADMIN)
+}
+
 fn can_access_pidfd_setns_target(target: &Arc<crate::process::ProcessControlBlock>) -> bool {
     let current = ProcessManager::current_pcb();
     if Arc::ptr_eq(&current, target) {
@@ -135,11 +141,11 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
             return Err(SystemError::EINVAL);
         }
 
-        let target = target_pid.task(PidType::TGID).ok_or(SystemError::ESRCH)?;
+        let target = target_pid.task(PidType::PID).ok_or(SystemError::ESRCH)?;
         if !can_access_pidfd_setns_target(&target) {
             return Err(SystemError::EPERM);
         }
-        if !can_setns_target_userns(&target.cred().user_ns) {
+        if flags != CloneFlags::CLONE_NEWUTS && !can_setns_target_userns(&target.cred().user_ns) {
             return Err(SystemError::EPERM);
         }
 
@@ -148,6 +154,10 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
         let target_nsproxy = target.nsproxy();
 
         let mut new_inner: NsProxy = cur_nsproxy.clone_inner();
+
+        if flags.contains(CloneFlags::CLONE_NEWUTS) && !can_setns_uts(&target_nsproxy.uts_ns) {
+            return Err(SystemError::EPERM);
+        }
 
         if flags.contains(CloneFlags::CLONE_NEWNS) {
             new_inner.mnt_ns = target_nsproxy.mnt_ns.clone();
@@ -185,9 +195,11 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
 
     // 如果 flags 为空，则允许 “按 fd 类型推断”；否则必须与 fd 的 namespace 类型匹配。
     let mut new_inner: NsProxy = current.nsproxy().clone_inner();
-    if let Some(target_user_ns) = nsfd_target_userns(&ns_fd) {
-        if !can_setns_target_userns(&target_user_ns) {
-            return Err(SystemError::EPERM);
+    if !matches!(&ns_fd, NamespaceFilePrivateData::Uts(_)) {
+        if let Some(target_user_ns) = nsfd_target_userns(&ns_fd) {
+            if !can_setns_target_userns(&target_user_ns) {
+                return Err(SystemError::EPERM);
+            }
         }
     }
 
@@ -201,6 +213,9 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
         NamespaceFilePrivateData::Uts(ns) => {
             if !flags_match(flags, CloneFlags::CLONE_NEWUTS) {
                 return Err(SystemError::EINVAL);
+            }
+            if !can_setns_uts(&ns) {
+                return Err(SystemError::EPERM);
             }
             new_inner.uts_ns = ns;
         }

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -5,7 +5,7 @@ use system_error::SystemError;
 use crate::{
     filesystem::fs::FsStruct,
     process::{
-        cred::Cred,
+        cred::{ns_capable, CAPFlags, Cred},
         fork::CloneFlags,
         namespace::nsproxy::{
             create_new_namespaces, switch_task_namespaces, switch_task_namespaces_with_fs, NsProxy,
@@ -123,6 +123,10 @@ fn unshare_nsproxy_namespaces(
     let user_ns = new_cred
         .map(|cred| cred.user_ns.clone())
         .unwrap_or_else(ProcessManager::current_user_ns);
+
+    if !ns_capable(&user_ns, CAPFlags::CAP_SYS_ADMIN) {
+        return Err(SystemError::EPERM);
+    }
 
     let nsproxy = create_new_namespaces(&unshare_flags, current_pcb, user_ns)?;
 

--- a/kernel/src/process/namespace/uts_namespace.rs
+++ b/kernel/src/process/namespace/uts_namespace.rs
@@ -7,6 +7,7 @@ use system_error::SystemError;
 
 use crate::init::version_info::get_kernel_build_info;
 use crate::libs::spinlock::SpinLockGuard;
+use crate::process::cred::{ns_capable, CAPFlags};
 use crate::process::fork::CloneFlags;
 use crate::process::namespace::user_namespace::INIT_USER_NAMESPACE;
 use crate::process::namespace::{NamespaceOps, NamespaceType};
@@ -187,14 +188,21 @@ impl UtsNamespace {
         &self._user_ns
     }
 
+    pub fn hostname(&self) -> [u8; NewUtsName::MAXLEN] {
+        self.utsname.lock().node_name
+    }
+
+    pub fn domainname(&self) -> [u8; NewUtsName::MAXLEN] {
+        self.utsname.lock().domain_name
+    }
+
     pub fn set_hostname(&self, hostname: &[u8]) -> Result<(), SystemError> {
         // 验证长度
         if !NewUtsName::validate_len(hostname.len()) {
             return Err(SystemError::ENAMETOOLONG);
         }
 
-        // 检查权限（需要 CAP_SYS_ADMIN）
-        // TODO: 实现完整的 capability 检查
+        // 需要在该 UTS namespace 的 owning user namespace 中具有 CAP_SYS_ADMIN。
         if !self.check_uts_modify_permission() {
             return Err(SystemError::EPERM);
         }
@@ -209,8 +217,7 @@ impl UtsNamespace {
             return Err(SystemError::ENAMETOOLONG);
         }
 
-        // 检查权限（需要 CAP_SYS_ADMIN）
-        // TODO: 实现完整的 capability 检查
+        // 需要在该 UTS namespace 的 owning user namespace 中具有 CAP_SYS_ADMIN。
         if !self.check_uts_modify_permission() {
             return Err(SystemError::EPERM);
         }
@@ -221,10 +228,7 @@ impl UtsNamespace {
 
     /// 检查是否有权限修改 UTS 信息
     pub fn check_uts_modify_permission(&self) -> bool {
-        // 检查当前进程是否具有 CAP_SYS_ADMIN 权限
-        let pcb = ProcessManager::current_pcb();
-        let cred = pcb.cred();
-        cred.has_cap_sys_admin()
+        ns_capable(self.user_ns(), CAPFlags::CAP_SYS_ADMIN)
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/uts_namespace.cc
+++ b/user/apps/tests/dunitest/suites/normal/uts_namespace.cc
@@ -1,0 +1,164 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/capability.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+std::string hostname() {
+    struct utsname value {};
+    EXPECT_EQ(0, uname(&value)) << strerror(errno);
+    return value.nodename;
+}
+
+std::string domainname() {
+    struct utsname value {};
+    EXPECT_EQ(0, uname(&value)) << strerror(errno);
+    return value.domainname;
+}
+
+std::string read_file(const char* path) {
+    int fd = open(path, O_RDONLY);
+    EXPECT_GE(fd, 0) << strerror(errno);
+    if (fd < 0) return {};
+    char buf[128] = {};
+    ssize_t n = read(fd, buf, sizeof(buf));
+    EXPECT_GE(n, 0) << strerror(errno);
+    close(fd);
+    if (n < 0) return {};
+    return std::string(buf, static_cast<size_t>(n));
+}
+
+void write_all(int fd, const char* data, size_t len, off_t offset = 0) {
+    ssize_t n = pwrite(fd, data, len, offset);
+    ASSERT_EQ(static_cast<ssize_t>(len), n) << strerror(errno);
+}
+
+}  // namespace
+
+TEST(UtsNamespace, UnshareIsolatesHostnameAndSetnsRestoresNamespace) {
+    const std::string original = hostname();
+    int old_ns = open("/proc/self/ns/uts", O_RDONLY);
+    ASSERT_GE(old_ns, 0) << strerror(errno);
+
+    struct stat before {};
+    ASSERT_EQ(0, fstat(old_ns, &before)) << strerror(errno);
+    ASSERT_EQ(0, unshare(CLONE_NEWUTS)) << strerror(errno);
+
+    struct stat after {};
+    ASSERT_EQ(0, stat("/proc/self/ns/uts", &after)) << strerror(errno);
+    ASSERT_NE(before.st_ino, after.st_ino);
+
+    constexpr char changed[] = "dragonos-uts-child";
+    ASSERT_EQ(0, sethostname(changed, sizeof(changed) - 1)) << strerror(errno);
+    EXPECT_EQ(changed, hostname());
+
+    ASSERT_EQ(0, setns(old_ns, CLONE_NEWUTS)) << strerror(errno);
+    EXPECT_EQ(original, hostname());
+    struct stat restored {};
+    ASSERT_EQ(0, stat("/proc/self/ns/uts", &restored)) << strerror(errno);
+    EXPECT_EQ(before.st_ino, restored.st_ino);
+    close(old_ns);
+}
+
+TEST(UtsNamespace, ProcHostnameUsesCurrentNamespace) {
+    const std::string original = hostname();
+    const std::string original_domain = domainname();
+    int old_ns = open("/proc/self/ns/uts", O_RDONLY);
+    ASSERT_GE(old_ns, 0) << strerror(errno);
+    ASSERT_EQ(0, unshare(CLONE_NEWUTS)) << strerror(errno);
+
+    int fd = open("/proc/sys/kernel/hostname", O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    constexpr char first[] = "proc-uts-name\nignored";
+    write_all(fd, first, sizeof(first) - 1);
+    EXPECT_EQ("proc-uts-name", hostname());
+    EXPECT_EQ("proc-uts-name\n", read_file("/proc/sys/kernel/hostname"));
+
+    constexpr char suffix[] = "XYZ\n";
+    write_all(fd, suffix, sizeof(suffix) - 1, 5);
+    EXPECT_EQ("proc-XYZ", hostname());
+
+    constexpr char past_end[] = "ignored";
+    write_all(fd, past_end, sizeof(past_end) - 1, 32);
+    EXPECT_EQ("proc-XYZ", hostname());
+
+    std::string oversized(80, 'a');
+    write_all(fd, oversized.data(), oversized.size());
+    EXPECT_EQ(64u, hostname().size());
+    close(fd);
+
+    int domain_fd = open("/proc/sys/kernel/domainname", O_RDWR);
+    ASSERT_GE(domain_fd, 0) << strerror(errno);
+    constexpr char new_domain[] = "uts.example\n";
+    write_all(domain_fd, new_domain, sizeof(new_domain) - 1);
+    EXPECT_EQ("uts.example", domainname());
+    EXPECT_EQ("uts.example\n", read_file("/proc/sys/kernel/domainname"));
+    close(domain_fd);
+
+    ASSERT_EQ(0, setns(old_ns, CLONE_NEWUTS)) << strerror(errno);
+    EXPECT_EQ(original, hostname());
+    EXPECT_EQ(original_domain, domainname());
+    close(old_ns);
+}
+
+TEST(UtsNamespace, SethostnameLengthBoundaries) {
+    ASSERT_EQ(0, unshare(CLONE_NEWUTS)) << strerror(errno);
+    std::string max_name(64, 'h');
+    ASSERT_EQ(0, sethostname(max_name.data(), max_name.size())) << strerror(errno);
+    EXPECT_EQ(max_name, hostname());
+
+    std::string too_long(65, 'x');
+    errno = 0;
+    EXPECT_EQ(-1, sethostname(too_long.data(), too_long.size()));
+    EXPECT_EQ(EINVAL, errno);
+    EXPECT_EQ(max_name, hostname());
+
+    ASSERT_EQ(0, syscall(SYS_sethostname, nullptr, 0)) << strerror(errno);
+    EXPECT_EQ("", hostname());
+}
+
+TEST(UtsNamespace, OperationsRequireSysAdmin) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        __user_cap_header_struct header = {_LINUX_CAPABILITY_VERSION_3, 0};
+        __user_cap_data_struct caps[2] = {};
+        if (syscall(SYS_capget, &header, caps) != 0) _exit(10);
+        caps[0].effective &= ~(1u << CAP_SYS_ADMIN);
+        if (syscall(SYS_capset, &header, caps) != 0) _exit(11);
+
+        errno = 0;
+        if (sethostname("denied", 6) != -1 || errno != EPERM) _exit(12);
+        errno = 0;
+        if (unshare(CLONE_NEWUTS) != -1 || errno != EPERM) _exit(13);
+
+        int fd = open("/proc/sys/kernel/hostname", O_WRONLY);
+        if (fd < 0) _exit(14);
+        errno = 0;
+        ssize_t n = write(fd, "denied\n", 7);
+        close(fd);
+        if (n != -1 || errno != EPERM) _exit(15);
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -34,6 +34,7 @@ normal/errseq_selftest
 normal/errseq_writeback_reporting
 normal/test_tlb_shootdown
 normal/pid_namespace_fork
+normal/uts_namespace
 normal/tcp_bind_semantics
 normal/tcp_close_semantics
 normal/udp_ipv6_send_semantics


### PR DESCRIPTION
## Summary

- scope hostname and domainname sysctl reads and writes to the caller's current UTS namespace
- enforce Linux-compatible CAP_SYS_ADMIN checks for UTS mutation, unshare, namespace-fd setns, and pidfd setns
- resolve pidfd UTS targets to the exact task and preserve atomic namespace installation
- add dunitest regression coverage for isolation, setns restoration, procfs semantics, boundary handling, and capability failures

## Root cause

The UTS namespace data model and proc namespace inode support existed, but proc sysctl entries were missing and several permission paths checked the caller or target task user namespace instead of the UTS namespace's owning user namespace. The pidfd path also resolved the thread-group leader rather than the exact pidfd task.

## Validation

- make kernel
- make -C user/apps/tests/dunitest bin/normal/uts_namespace_test
- QEMU guest: /opt/tests/dunitest/bin/normal/uts_namespace_test (4 tests passed)
- git diff --cached --check

Closes #1846