### PR TITLE
fix(cubesandbox): support ext4 volumes and overlay appends

### DIFF
--- a/env.mk
+++ b/env.mk
@@ -18,4 +18,4 @@ export DADK?=$(shell which dadk)
 endif
 
 # RootFS manifest name under config/rootfs-manifests/
-export ROOTFS_MANIFEST?=default
+export ROOTFS_MANIFEST?=ubuntu2404

--- a/env.mk
+++ b/env.mk
@@ -18,4 +18,4 @@ export DADK?=$(shell which dadk)
 endif
 
 # RootFS manifest name under config/rootfs-manifests/
-export ROOTFS_MANIFEST?=ubuntu2404
+export ROOTFS_MANIFEST?=default

--- a/kernel/crates/another_ext4/ext4_test/src/main.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/main.rs
@@ -23,6 +23,66 @@ fn make_ext4() {
         .output();
 }
 
+fn nojournal_seeded_image_test() {
+    const IMAGE: &str = "ext4-nojournal-seeded.img";
+    let _ = std::fs::remove_file(IMAGE);
+    assert!(
+        std::process::Command::new("truncate")
+            .args(["-s", "1G", IMAGE])
+            .status()
+            .expect("truncate failed")
+            .success()
+    );
+    assert!(
+        std::process::Command::new("mkfs.ext4")
+            .args([
+                "-F",
+                "-b",
+                "4096",
+                "-I",
+                "256",
+                "-O",
+                "^has_journal,^orphan_file,metadata_csum_seed",
+                IMAGE,
+            ])
+            .status()
+            .expect("mkfs.ext4 failed")
+            .success()
+    );
+
+    let ext4 = Ext4::load_writable(Arc::new(BlockFile::new(IMAGE)))
+        .expect("Cube-equivalent nojournal image must mount writable");
+    let dir = ext4
+        .generic_create(
+            ROOT_INO,
+            "cube",
+            InodeMode::DIRECTORY | InodeMode::ALL_RWX,
+        )
+        .expect("create directory failed");
+    let file = ext4
+        .generic_create(dir, "payload", InodeMode::FILE | InodeMode::ALL_RWX)
+        .expect("create file failed");
+    ext4.write(file, 0, b"dragonos-on-cube")
+        .expect("write failed");
+    ext4.rename(dir, "payload", dir, "renamed")
+        .expect("rename failed");
+    ext4.generic_remove(dir, "renamed").expect("unlink failed");
+    ext4.shutdown_writable().expect("shutdown failed");
+    drop(ext4);
+
+    let output = std::process::Command::new("e2fsck")
+        .args(["-fn", IMAGE])
+        .output()
+        .expect("e2fsck failed");
+    assert!(
+        output.status.success(),
+        "nojournal seeded e2fsck failed:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    println!("nojournal metadata_csum_seed image test done");
+}
+
 fn open_ext4() -> Ext4 {
     let file = BlockFile::new("ext4.img");
     println!("creating ext4");
@@ -696,6 +756,7 @@ fn cross_parent_directory_replace_orphan_test() {
 fn main() {
     SimpleLogger::new().init().unwrap();
     log::set_max_level(log::LevelFilter::Off);
+    nojournal_seeded_image_test();
     make_ext4();
     println!("ext4.img created");
     let mut ext4 = open_ext4();

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -126,14 +126,15 @@ impl Ext4 {
             sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
         let checksum_bytes = (sb.clusters_per_group() as usize) / 8;
         if metadata_csum {
-            if !bg.verify_checksum(&sb.uuid()) {
+            if !bg.verify_checksum(sb.metadata_checksum_seed()) {
                 return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
             }
             let bitmap_image = transaction.read(self.block_device.as_ref(), bitmap_block_id)?;
-            if !bg
-                .desc
-                .verify_block_bitmap_csum(&sb.uuid(), &*bitmap_image, checksum_bytes)
-            {
+            if !bg.desc.verify_block_bitmap_csum(
+                sb.metadata_checksum_seed(),
+                &*bitmap_image,
+                checksum_bytes,
+            ) {
                 return_error!(ErrCode::EIO, "Corrupt block bitmap checksum");
             }
         }
@@ -160,16 +161,18 @@ impl Ext4 {
                 bitmap.clear_bit(index);
             }
             if metadata_csum
-                && !bg
-                    .desc
-                    .update_block_bitmap_csum(&sb.uuid(), image, checksum_bytes)
+                && !bg.desc.update_block_bitmap_csum(
+                    sb.metadata_checksum_seed(),
+                    image,
+                    checksum_bytes,
+                )
             {
                 return_error!(ErrCode::EIO, "Invalid block bitmap checksum length");
             }
         }
 
         bg.desc.set_free_blocks_count(new_bg_free);
-        self.transaction_stage_block_group_with_csum(transaction, &mut bg, &sb.uuid())?;
+        self.transaction_stage_block_group_with_csum(transaction, &mut bg)?;
         sb.set_free_blocks_count(new_sb_free);
         self.transaction_stage_super_block(transaction, &sb)
     }
@@ -202,14 +205,15 @@ impl Ext4 {
             sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
         let checksum_bytes = (sb.inodes_per_group() as usize) / 8;
         if metadata_csum {
-            if !bg.verify_checksum(&sb.uuid()) {
+            if !bg.verify_checksum(sb.metadata_checksum_seed()) {
                 return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
             }
             let bitmap_image = transaction.read(self.block_device.as_ref(), bitmap_block_id)?;
-            if !bg
-                .desc
-                .verify_inode_bitmap_csum(&sb.uuid(), &*bitmap_image, checksum_bytes)
-            {
+            if !bg.desc.verify_inode_bitmap_csum(
+                sb.metadata_checksum_seed(),
+                &*bitmap_image,
+                checksum_bytes,
+            ) {
                 return_error!(ErrCode::EIO, "Corrupt inode bitmap checksum");
             }
         }
@@ -240,9 +244,11 @@ impl Ext4 {
             }
             bitmap.clear_bit(idx);
             if metadata_csum
-                && !bg
-                    .desc
-                    .update_inode_bitmap_csum(&sb.uuid(), image, checksum_bytes)
+                && !bg.desc.update_inode_bitmap_csum(
+                    sb.metadata_checksum_seed(),
+                    image,
+                    checksum_bytes,
+                )
             {
                 return_error!(ErrCode::EIO, "Invalid inode bitmap checksum length");
             }
@@ -252,7 +258,7 @@ impl Ext4 {
         if let Some(used) = new_used_dirs {
             bg.desc.set_used_dirs_count(used);
         }
-        self.transaction_stage_block_group_with_csum(transaction, &mut bg, &sb.uuid())?;
+        self.transaction_stage_block_group_with_csum(transaction, &mut bg)?;
         sb.set_free_inodes_count(new_sb_free);
         self.transaction_stage_super_block(transaction, &sb)
     }
@@ -425,7 +431,7 @@ impl Ext4 {
         let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _mutation_guard =
             self.inode_mutation_locks[self.inode_mutation_lock_index(handle.inode_id)].lock();
-        self.reclaim_inode_lifetime(handle.inode_id, handle.generation)
+        self.reclaim_inode_lifetime(handle.inode_id, handle.generation, self.uses_journal())
     }
 
     /// Reclaim a mount-recovery orphan without manufacturing a VFS lifetime
@@ -436,7 +442,7 @@ impl Ext4 {
         let _mutation_guard =
             self.inode_mutation_locks[self.inode_mutation_lock_index(inode_id)].lock();
         let generation = self.read_inode_uncached(inode_id)?.inode.generation();
-        self.reclaim_inode_lifetime(inode_id, generation)
+        self.reclaim_inode_lifetime(inode_id, generation, true)
     }
 
     /// Complete a crash-interrupted truncate for an inode that still has names.
@@ -528,9 +534,14 @@ impl Ext4 {
         self.commit_reclaim_transaction(transaction)
     }
 
-    fn reclaim_inode_lifetime(&self, inode_id: InodeId, generation: u32) -> Result<()> {
+    fn reclaim_inode_lifetime(
+        &self,
+        inode_id: InodeId,
+        generation: u32,
+        require_orphan_membership: bool,
+    ) -> Result<()> {
         self.validate_reclaim_inode(inode_id, generation)?;
-        if !self.legacy_orphan_contains(inode_id)? {
+        if require_orphan_membership && !self.legacy_orphan_contains(inode_id)? {
             return_error!(ErrCode::EINVAL, "Inode {} is not orphaned", inode_id);
         }
         // Each iteration starts from the checkpointed inode-table entry.  The
@@ -629,8 +640,10 @@ impl Ext4 {
         }
         let is_dir = inode.inode.is_dir();
         let mut transaction = self.transaction_start(16)?;
-        let mut sb = self.transaction_read_super_block(&transaction)?;
-        self.transaction_orphan_del(&mut transaction, &inode, &mut sb)?;
+        if require_orphan_membership {
+            let mut sb = self.transaction_read_super_block(&transaction)?;
+            self.transaction_orphan_del(&mut transaction, &inode, &mut sb)?;
+        }
         self.transaction_dealloc_inode(&mut transaction, inode_id, is_dir)?;
         let mut cleared = InodeRef::new(inode_id, Box::default());
         cleared.inode.set_generation(generation);
@@ -765,7 +778,7 @@ impl Ext4 {
 
             // Set block group checksum
             if !bg.desc.update_block_bitmap_csum(
-                &sb.uuid(),
+                sb.metadata_checksum_seed(),
                 &*bitmap_block.data,
                 sb.clusters_per_group() as usize / 8,
             ) {
@@ -872,7 +885,7 @@ impl Ext4 {
         }
         // Set block group checksum
         if !bg.desc.update_block_bitmap_csum(
-            &sb.uuid(),
+            sb.metadata_checksum_seed(),
             &*bitmap_block.data,
             sb.clusters_per_group() as usize / 8,
         ) {
@@ -939,7 +952,7 @@ impl Ext4 {
             };
             // Update bitmap in disk
             if !bg.desc.update_inode_bitmap_csum(
-                &sb.uuid(),
+                sb.metadata_checksum_seed(),
                 &*bitmap_block.data,
                 sb.inodes_per_group() as usize / 8,
             ) {
@@ -1023,7 +1036,7 @@ impl Ext4 {
         }
         // Update bitmap in disk
         if !bg.desc.update_inode_bitmap_csum(
-            &sb.uuid(),
+            sb.metadata_checksum_seed(),
             &*bitmap_block.data,
             sb.inodes_per_group() as usize / 8,
         ) {

--- a/kernel/crates/another_ext4/src/ext4/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4/dir.rs
@@ -33,7 +33,7 @@ impl Ext4 {
     ) -> Result<DirBlockLayout> {
         let sb = self.read_super_block_cached();
         block.validate(
-            &sb.uuid(),
+            sb.metadata_checksum_seed(),
             dir.id,
             dir.inode.generation(),
             sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM),
@@ -59,12 +59,14 @@ impl Ext4 {
         }
         match layout {
             DirBlockLayout::Leaf => {
-                block.set_checksum(&sb.uuid(), dir.id, dir.inode.generation());
+                block.set_checksum(sb.metadata_checksum_seed(), dir.id, dir.inode.generation());
                 Ok(())
             }
-            DirBlockLayout::Htree => {
-                block.set_htree_checksum(&sb.uuid(), dir.id, dir.inode.generation())
-            }
+            DirBlockLayout::Htree => block.set_htree_checksum(
+                sb.metadata_checksum_seed(),
+                dir.id,
+                dir.inode.generation(),
+            ),
         }
     }
 

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -52,7 +52,7 @@ impl Ext4 {
                 .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
         );
         let calculated = extent_block_checksum(
-            &sb.uuid(),
+            sb.metadata_checksum_seed(),
             inode_ref.id,
             inode_ref.inode.generation(),
             image,
@@ -227,7 +227,7 @@ impl Ext4 {
             let mut leaf = ExtentNodeMut::from_bytes(&mut image[..]);
             Self::trim_leaf_tail(&mut leaf, remove)?;
             Self::set_extent_block_checksum(
-                &self.read_super_block_cached().uuid(),
+                self.read_super_block_cached().metadata_checksum_seed(),
                 inode_ref,
                 image,
             );
@@ -245,7 +245,7 @@ impl Ext4 {
             let mut leaf = ExtentNodeMut::from_bytes(&mut image[..]);
             leaf.remove_last_entry();
             Self::set_extent_block_checksum(
-                &self.read_super_block_cached().uuid(),
+                self.read_super_block_cached().metadata_checksum_seed(),
                 inode_ref,
                 image,
             );
@@ -279,7 +279,7 @@ impl Ext4 {
                 let mut node = ExtentNodeMut::from_bytes(&mut image[..]);
                 node.remove_last_entry();
                 Self::set_extent_block_checksum(
-                    &self.read_super_block_cached().uuid(),
+                    self.read_super_block_cached().metadata_checksum_seed(),
                     inode_ref,
                     image,
                 );
@@ -322,10 +322,14 @@ impl Ext4 {
         Ok(())
     }
 
-    fn set_extent_block_checksum(uuid: &[u8], inode_ref: &InodeRef, image: &mut [u8; BLOCK_SIZE]) {
+    fn set_extent_block_checksum(
+        seed: MetadataChecksumSeed,
+        inode_ref: &InodeRef,
+        image: &mut [u8; BLOCK_SIZE],
+    ) {
         let tail_offset = BLOCK_SIZE - core::mem::size_of::<crate::ext4_defs::ExtentTail>();
         let checksum =
-            extent_block_checksum(uuid, inode_ref.id, inode_ref.inode.generation(), image);
+            extent_block_checksum(seed, inode_ref.id, inode_ref.inode.generation(), image);
         image[tail_offset..tail_offset + 4].copy_from_slice(&checksum.to_le_bytes());
     }
 
@@ -333,7 +337,7 @@ impl Ext4 {
     fn write_extent_block(&self, block: &mut Block, inode_ref: &InodeRef) -> Result<()> {
         let tail_offset = BLOCK_SIZE - core::mem::size_of::<crate::ext4_defs::ExtentTail>();
         let csum = extent_block_checksum(
-            &self.read_super_block_cached().uuid(),
+            self.read_super_block_cached().metadata_checksum_seed(),
             inode_ref.id,
             inode_ref.inode.generation(),
             &*block.data,
@@ -990,7 +994,9 @@ mod tests {
             namespace_lock: spin::Mutex::new(()),
             metadata_mutation_barrier: crate::ext4::MetadataMutationGate::new(),
             poisoned: spin::Mutex::new(None),
-            journal: None,
+            metadata_mode: crate::ext4::MetadataMutationMode::ReadOnly,
+            write_barrier: true,
+            direct_restore_clean: false,
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),
@@ -1019,7 +1025,9 @@ mod tests {
             namespace_lock: spin::Mutex::new(()),
             metadata_mutation_barrier: crate::ext4::MetadataMutationGate::new(),
             poisoned: spin::Mutex::new(None),
-            journal: None,
+            metadata_mode: crate::ext4::MetadataMutationMode::ReadOnly,
+            write_barrier: true,
+            direct_restore_clean: false,
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),
@@ -1040,7 +1048,11 @@ mod tests {
         inode.inode.set_generation(23);
         let mut image = [0u8; BLOCK_SIZE];
         ExtentNodeMut::from_bytes(&mut image).init(0, 0);
-        Ext4::set_extent_block_checksum(&fs.read_super_block_cached().uuid(), &inode, &mut image);
+        Ext4::set_extent_block_checksum(
+            fs.read_super_block_cached().metadata_checksum_seed(),
+            &inode,
+            &mut image,
+        );
         fs.verify_extent_block_checksum(&inode, &image).unwrap();
 
         image[BLOCK_SIZE - 1] ^= 0x80;

--- a/kernel/crates/another_ext4/src/ext4/journal.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal.rs
@@ -1,4 +1,4 @@
-use super::{journal_recovery, journal_transaction, Ext4};
+use super::{journal_recovery, journal_transaction, Ext4, MetadataMutationMode};
 use crate::constants::BLOCK_SIZE;
 use crate::ext4_defs::{AsBytes, Block, BlockDevice, InodeRef, SuperBlock};
 use crate::jbd2::Superblock as JournalSuperblock;
@@ -8,7 +8,7 @@ fn validate_journal_inode(sb: &SuperBlock, inode: &InodeRef) -> Result<()> {
     if !inode.inode.is_file()
         || !inode.inode.uses_extents()
         || (sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM)
-            && !inode.verify_checksum(&sb.uuid()))
+            && !inode.verify_checksum(sb.metadata_checksum_seed()))
     {
         return Err(Ext4Error::new(ErrCode::EIO));
     }
@@ -121,12 +121,59 @@ impl Ext4 {
         self.block_device.flush()
     }
 
+    pub(super) fn initialize_direct(&mut self) -> Result<()> {
+        if !matches!(self.metadata_mode, MetadataMutationMode::ReadOnly) {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        let target_blocks = self.read_super_block_cached().block_count();
+        self.metadata_mode = MetadataMutationMode::Direct(
+            journal_transaction::DirectTransactionCore::new(target_blocks)?,
+        );
+        Ok(())
+    }
+
+    pub(super) fn mark_direct_mount_dirty(&mut self) -> Result<()> {
+        if self.write_barrier && !self.block_device.supports_reliable_flush() {
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
+        let mut sb = self.read_super_block_cached();
+        self.direct_restore_clean = sb.is_clean();
+        sb.set_clean(false);
+        self.write_super_block(&sb)?;
+        if self.write_barrier {
+            self.block_device.flush()?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn uses_journal(&self) -> bool {
+        matches!(self.metadata_mode, MetadataMutationMode::Journal(_))
+    }
+
     pub fn shutdown_writable(&self) -> Result<()> {
         // Clearing RECOVER is a metadata state transition and must not race a
         // direct writer even if the VFS normally excludes writers at umount.
         let _metadata_guard = self.lock_transactional_metadata_mutation()?;
-        let Some(journal) = self.journal.as_ref() else {
-            return Ok(());
+        let journal = match &self.metadata_mode {
+            MetadataMutationMode::ReadOnly => return Err(Ext4Error::new(ErrCode::EROFS)),
+            MetadataMutationMode::Direct(core) => {
+                if !core.can_shutdown() || self.poisoned.lock().is_some() {
+                    return Err(Ext4Error::new(ErrCode::EIO));
+                }
+                if self.write_barrier {
+                    self.block_device.flush()?;
+                }
+                if self.direct_restore_clean {
+                    let mut sb = self.read_super_block_cached();
+                    sb.set_clean(true);
+                    self.write_super_block(&sb)?;
+                    if self.write_barrier {
+                        self.block_device.flush()?;
+                    }
+                }
+                return Ok(());
+            }
+            MetadataMutationMode::Journal(core) => core,
         };
         if !journal.can_shutdown() {
             return Err(Ext4Error::new(ErrCode::EIO));
@@ -145,10 +192,11 @@ impl Ext4 {
         &self,
         credits: usize,
     ) -> Result<journal_transaction::Transaction<'_>> {
-        self.journal
-            .as_ref()
-            .ok_or_else(|| Ext4Error::new(ErrCode::ENOTSUP))?
-            .start(credits)
+        match &self.metadata_mode {
+            MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
+            MetadataMutationMode::Journal(core) => core.start(credits),
+            MetadataMutationMode::Direct(core) => core.start(credits),
+        }
     }
 
     pub(super) fn initialize_journal(&mut self) -> Result<()> {
@@ -254,16 +302,17 @@ impl Ext4 {
         } else {
             return Err(Ext4Error::new(ErrCode::EIO));
         };
-        self.journal = Some(journal_transaction::JournalTransactionCore::new(
-            journal_transaction::JournalContext {
-                superblock: journal_sb,
-                logical_blocks: mapping.into(),
-                journal_blocks: Arc::new(journal_blocks),
-                target_blocks: ext4_sb.block_count(),
-                head,
-                superblock_image: image,
-            },
-        )?);
+        self.metadata_mode =
+            MetadataMutationMode::Journal(journal_transaction::JournalTransactionCore::new(
+                journal_transaction::JournalContext {
+                    superblock: journal_sb,
+                    logical_blocks: mapping.into(),
+                    journal_blocks: Arc::new(journal_blocks),
+                    target_blocks: ext4_sb.block_count(),
+                    head,
+                    superblock_image: image,
+                },
+            )?);
 
         // Replay may itself publish a newer ext4 superblock.  Recheck the
         // recovered feature set before interpreting or mutating orphan state;
@@ -287,9 +336,10 @@ impl Ext4 {
     }
 
     pub(super) fn journal_owns_block_range(&self, start: PBlockId, end: PBlockId) -> bool {
-        self.journal
-            .as_ref()
-            .is_some_and(|journal| journal.owns_block_range(start, end))
+        match &self.metadata_mode {
+            MetadataMutationMode::Journal(journal) => journal.owns_block_range(start, end),
+            MetadataMutationMode::ReadOnly | MetadataMutationMode::Direct(_) => false,
+        }
     }
 }
 
@@ -348,7 +398,7 @@ mod tests {
         inode.inode.set_mode(InodeMode::FILE | InodeMode::ALL_RW);
         inode.inode.set_generation(9);
         inode.inode.extent_init();
-        inode.set_checksum(&sb.uuid());
+        inode.set_checksum(sb.metadata_checksum_seed());
         inode
     }
 
@@ -362,7 +412,7 @@ mod tests {
         bad_mode
             .inode
             .set_mode(InodeMode::DIRECTORY | InodeMode::ALL_RWX);
-        bad_mode.set_checksum(&sb.uuid());
+        bad_mode.set_checksum(sb.metadata_checksum_seed());
         assert_eq!(
             validate_journal_inode(&sb, &bad_mode).unwrap_err().code(),
             ErrCode::EIO
@@ -383,7 +433,7 @@ mod tests {
         let sb = metadata_csum_superblock();
         let mut before = valid_journal_inode(&sb);
         before.inode.set_size(8192);
-        before.set_checksum(&sb.uuid());
+        before.set_checksum(sb.metadata_checksum_seed());
         let after = before.clone();
         assert!(journal_replay_identity_matches(
             &before,

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -76,7 +76,9 @@ impl StagedBlock {
     }
 }
 
-/// Cache changes are published only after checkpoint data is durable.
+/// Publishes metadata images after the selected backend has completed its
+/// commit point. Journal commits publish after a durable checkpoint; direct
+/// commits publish after every synchronous home-block write has succeeded.
 pub trait CachePublisher: Send + Sync {
     /// Publish already-checkpointed images to in-memory caches.
     ///
@@ -111,6 +113,60 @@ pub struct JournalTransactionCore {
     writer: AtomicBool,
     poison: AtomicU8,
     context: spin::Mutex<JournalContext>,
+}
+
+/// Synchronous nojournal transaction backend.
+///
+/// The writer bit is deliberately separate from the filesystem-wide metadata
+/// mutation gate: the gate excludes legacy direct writers, while this token
+/// owns one staged transaction within this backend.
+pub struct DirectTransactionCore {
+    writer: AtomicBool,
+    poison: AtomicU8,
+    target_blocks: u64,
+}
+
+impl DirectTransactionCore {
+    pub fn new(target_blocks: u64) -> Result<Self> {
+        if target_blocks == 0 {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        Ok(Self {
+            writer: AtomicBool::new(false),
+            poison: AtomicU8::new(CLEAN),
+            target_blocks,
+        })
+    }
+
+    pub fn is_poisoned(&self) -> bool {
+        self.poison.load(Ordering::Acquire) != CLEAN
+    }
+
+    pub fn can_shutdown(&self) -> bool {
+        !self.writer.load(Ordering::Acquire) && !self.is_poisoned()
+    }
+
+    pub fn start(&self, credits: usize) -> Result<Transaction<'_>> {
+        if credits == 0 || self.is_poisoned() {
+            return Err(Ext4Error::new(if credits == 0 {
+                ErrCode::EINVAL
+            } else {
+                ErrCode::EROFS
+            }));
+        }
+        if self
+            .writer
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return Err(Ext4Error::new(ErrCode::EAGAIN));
+        }
+        Ok(Transaction::new(TransactionCoreRef::Direct(self), credits))
+    }
+
+    fn poison(&self) {
+        self.poison.store(POISONED, Ordering::Release);
+    }
 }
 
 impl JournalTransactionCore {
@@ -176,12 +232,7 @@ impl JournalTransactionCore {
             self.writer.store(false, Ordering::Release);
             return Err(Ext4Error::new(ErrCode::E2BIG));
         }
-        Ok(Transaction {
-            core: self,
-            credits,
-            staged: BTreeMap::new(),
-            owns_writer: true,
-        })
+        Ok(Transaction::new(TransactionCoreRef::Journal(self), credits))
     }
 
     fn poison(&self) {
@@ -189,14 +240,28 @@ impl JournalTransactionCore {
     }
 }
 
+#[derive(Clone, Copy)]
+enum TransactionCoreRef<'a> {
+    Journal(&'a JournalTransactionCore),
+    Direct(&'a DirectTransactionCore),
+}
+
 pub struct Transaction<'a> {
-    core: &'a JournalTransactionCore,
+    core: TransactionCoreRef<'a>,
     credits: usize,
     staged: BTreeMap<PBlockId, StagedBlock>,
     owns_writer: bool,
 }
 
 impl Transaction<'_> {
+    fn new(core: TransactionCoreRef<'_>, credits: usize) -> Transaction<'_> {
+        Transaction {
+            core,
+            credits,
+            staged: BTreeMap::new(),
+            owns_writer: true,
+        }
+    }
     /// Replace the final image for `home`.  Re-staging the same home block does
     /// not consume another credit and subsequent reads observe the replacement.
     pub fn stage(&mut self, home: PBlockId, image: Box<[u8; BLOCK_SIZE]>) -> Result<()> {
@@ -259,6 +324,51 @@ impl Transaction<'_> {
             self.release_writer();
             return Ok(());
         }
+        match self.core {
+            TransactionCoreRef::Journal(_) => self.commit_journal(device, publisher),
+            TransactionCoreRef::Direct(_) => self.commit_direct(device, publisher),
+        }
+    }
+
+    fn commit_direct(
+        mut self,
+        device: &dyn BlockDevice,
+        publisher: &dyn CachePublisher,
+    ) -> core::result::Result<(), CommitError> {
+        let TransactionCoreRef::Direct(core) = self.core else {
+            unreachable!()
+        };
+        if self
+            .staged
+            .values()
+            .any(|block| block.home >= core.target_blocks)
+        {
+            return self.fail(
+                Ext4Error::new(ErrCode::EINVAL),
+                CommitFailure::BeforeCommit,
+                false,
+            );
+        }
+        // BTreeMap iteration supplies a stable physical-block order without a
+        // second allocation. It is deterministic, not crash atomic.
+        for staged in self.staged.values() {
+            if let Err(error) = write_bytes(device, staged.home, staged.bytes()) {
+                return self.fail(error, CommitFailure::CheckpointFailed, true);
+            }
+        }
+        publisher.publish(&self.staged);
+        self.release_writer();
+        Ok(())
+    }
+
+    fn commit_journal(
+        mut self,
+        device: &dyn BlockDevice,
+        publisher: &dyn CachePublisher,
+    ) -> core::result::Result<(), CommitError> {
+        let TransactionCoreRef::Journal(core) = self.core else {
+            unreachable!()
+        };
         if !device.supports_reliable_flush() {
             return self.fail(
                 Ext4Error::new(ErrCode::ENOTSUP),
@@ -269,7 +379,7 @@ impl Transaction<'_> {
 
         // Copy the small allocation state, then release the spin guard before I/O.
         let (sb, mapping, journal_blocks, target_blocks, head, sb_image) = {
-            let context = self.core.context.lock();
+            let context = core.context.lock();
             (
                 context.superblock,
                 Arc::clone(&context.logical_blocks),
@@ -382,7 +492,7 @@ impl Transaction<'_> {
             return self.fail(error, CommitFailure::TailUpdateFailed, true);
         }
         {
-            let mut context = self.core.context.lock();
+            let mut context = core.context.lock();
             context.superblock.sequence = next_sequence;
             context.superblock.start = 0;
             context.head = ring_next(&sb, commit_logical);
@@ -399,7 +509,10 @@ impl Transaction<'_> {
         poison: bool,
     ) -> core::result::Result<T, CommitError> {
         if poison {
-            self.core.poison();
+            match self.core {
+                TransactionCoreRef::Journal(core) => core.poison(),
+                TransactionCoreRef::Direct(core) => core.poison(),
+            }
         }
         self.release_writer();
         Err(CommitError { error, failure })
@@ -408,7 +521,10 @@ impl Transaction<'_> {
     fn release_writer(&mut self) {
         if self.owns_writer {
             self.owns_writer = false;
-            self.core.writer.store(false, Ordering::Release);
+            match self.core {
+                TransactionCoreRef::Journal(core) => core.writer.store(false, Ordering::Release),
+                TransactionCoreRef::Direct(core) => core.writer.store(false, Ordering::Release),
+            }
         }
     }
 }
@@ -615,6 +731,7 @@ mod tests {
         stable: spin::Mutex<BTreeMap<PBlockId, Box<[u8; BLOCK_SIZE]>>>,
         operation: AtomicUsize,
         fail_at: AtomicUsize,
+        write_order: spin::Mutex<Vec<PBlockId>>,
     }
 
     impl MemoryDevice {
@@ -624,6 +741,7 @@ mod tests {
                 stable: spin::Mutex::new(BTreeMap::new()),
                 operation: AtomicUsize::new(0),
                 fail_at: AtomicUsize::new(usize::MAX),
+                write_order: spin::Mutex::new(Vec::new()),
             }
         }
 
@@ -660,6 +778,7 @@ mod tests {
 
         fn write_block(&self, block: &Block) -> Result<()> {
             self.step()?;
+            self.write_order.lock().push(block.id);
             self.volatile.lock().insert(block.id, block.data.clone());
             Ok(())
         }
@@ -680,6 +799,66 @@ mod tests {
         fn publish(&self, blocks: &BTreeMap<PBlockId, StagedBlock>) {
             self.0.fetch_add(blocks.len(), Ordering::SeqCst);
         }
+    }
+
+    #[test]
+    fn direct_commit_writes_home_blocks_in_order_then_publishes() {
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let mut transaction = core.start(3).unwrap();
+        transaction.stage(9, Box::new([9; BLOCK_SIZE])).unwrap();
+        transaction.stage(2, Box::new([2; BLOCK_SIZE])).unwrap();
+        transaction.stage(5, Box::new([5; BLOCK_SIZE])).unwrap();
+
+        transaction.commit(&device, &publisher).unwrap();
+
+        assert_eq!(&*device.write_order.lock(), &[2, 5, 9]);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 3);
+        assert!(!core.is_poisoned());
+        assert!(core.can_shutdown());
+    }
+
+    #[test]
+    fn direct_write_failure_never_publishes_and_poisons_backend() {
+        let device = MemoryDevice::new();
+        device.fail_at.store(1, Ordering::SeqCst);
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let mut transaction = core.start(2).unwrap();
+        transaction.stage(2, Box::new([2; BLOCK_SIZE])).unwrap();
+        transaction.stage(5, Box::new([5; BLOCK_SIZE])).unwrap();
+
+        let error = transaction.commit(&device, &publisher).unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::CheckpointFailed);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        assert!(core.is_poisoned());
+        assert_eq!(core.start(1).err().unwrap().code(), ErrCode::EROFS);
+    }
+
+    #[test]
+    fn direct_validation_failure_releases_writer_without_poison() {
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(8).unwrap();
+        let mut transaction = core.start(1).unwrap();
+        transaction.stage(8, Box::new([1; BLOCK_SIZE])).unwrap();
+
+        let error = transaction.commit(&device, &publisher).unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::BeforeCommit);
+        assert!(!core.is_poisoned());
+        assert!(core.start(1).is_ok());
+    }
+
+    #[test]
+    fn direct_backend_allows_only_one_transaction_owner() {
+        let core = DirectTransactionCore::new(8).unwrap();
+        let transaction = core.start(1).unwrap();
+        assert_eq!(core.start(1).err().unwrap().code(), ErrCode::EAGAIN);
+        transaction.abort();
+        assert!(core.start(1).is_ok());
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/link.rs
+++ b/kernel/crates/another_ext4/src/ext4/link.rs
@@ -103,8 +103,16 @@ impl Ext4 {
                 self.transaction_stage_inode_with_csum(&mut transaction, parent)?;
             }
             child.inode.set_link_count(0);
-            let mut sb = self.read_super_block_cached();
-            self.transaction_orphan_add(&mut transaction, child, &mut sb)?;
+            if self.uses_journal() {
+                let mut sb = self.read_super_block_cached();
+                self.transaction_orphan_add(&mut transaction, child, &mut sb)?;
+            } else {
+                // Linux nojournal mode does not enroll newly unlinked inodes in
+                // the persistent orphan chain. Lifetime reclaim starts only
+                // after this namespace transaction has published nlink == 0.
+                child.inode.set_next_orphan(0);
+                self.transaction_stage_inode_with_csum(&mut transaction, child)?;
+            }
 
             if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
                 // A commit-path failure may make journal state uncertain.  Do

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -40,19 +40,12 @@ impl SetAttr {
 }
 
 impl Ext4 {
-    fn xattr_checksum_seed(&self) -> Result<Option<u32>> {
+    fn xattr_checksum_seed(&self) -> Result<Option<MetadataChecksumSeed>> {
         let sb = self.read_super_block_cached();
         if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
             return Ok(None);
         }
-        // A seeded-checksum filesystem must use s_checksum_seed rather than
-        // CRC32C(UUID). Writable preflight rejects it, and direct xattr paths
-        // must fail closed as well instead of writing a mismatched checksum.
-        const FEATURE_INCOMPAT_CSUM_SEED: u32 = 0x2000;
-        if sb.has_incompatible_feature(FEATURE_INCOMPAT_CSUM_SEED) {
-            return Err(Ext4Error::new(ErrCode::ENOTSUP));
-        }
-        Ok(Some(crate::ext4_defs::crc::crc32(CRC32_INIT, &sb.uuid())))
+        Ok(Some(sb.metadata_checksum_seed()))
     }
 
     fn verify_xattr_block_checksum(&self, block_id: PBlockId, block: &XattrBlock) -> Result<()> {
@@ -920,7 +913,7 @@ impl Ext4 {
                 if existing_is_dir && !(child_is_dir && parent != new_parent) {
                     credits += 1; // target parent (new parent already counted above)
                 }
-                if final_target {
+                if final_target && self.uses_journal() {
                     credits += 1; // superblock orphan head
                 }
                 let mut transaction = self.transaction_start(credits)?;
@@ -974,8 +967,20 @@ impl Ext4 {
 
                 if final_target {
                     existing_inode.inode.set_link_count(0);
-                    let mut sb = self.read_super_block_cached();
-                    self.transaction_orphan_add(&mut transaction, &mut existing_inode, &mut sb)?;
+                    if self.uses_journal() {
+                        let mut sb = self.read_super_block_cached();
+                        self.transaction_orphan_add(
+                            &mut transaction,
+                            &mut existing_inode,
+                            &mut sb,
+                        )?;
+                    } else {
+                        existing_inode.inode.set_next_orphan(0);
+                        self.transaction_stage_inode_with_csum(
+                            &mut transaction,
+                            &mut existing_inode,
+                        )?;
+                    }
                 } else {
                     existing_inode.inode.set_link_count(existing_link_cnt - 1);
                     self.transaction_stage_inode_with_csum(&mut transaction, &mut existing_inode)?;
@@ -1542,7 +1547,12 @@ mod tests {
             namespace_lock: spin::Mutex::new(()),
             metadata_mutation_barrier: crate::ext4::MetadataMutationGate::new(),
             poisoned: spin::Mutex::new(None),
-            journal: None,
+            metadata_mode: crate::ext4::MetadataMutationMode::Direct(
+                crate::ext4::journal_transaction::DirectTransactionCore::new(block_count as u64)
+                    .unwrap(),
+            ),
+            write_barrier: true,
+            direct_restore_clean: false,
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),
@@ -1834,7 +1844,8 @@ mod tests {
 
     fn load_failing_test_fs() -> (Arc<FailingBlockDevice>, Ext4) {
         let block_device = Arc::new(FailingBlockDevice::new());
-        let fs = Ext4::load(block_device.clone()).unwrap();
+        let mut fs = Ext4::load(block_device.clone()).unwrap();
+        fs.initialize_direct().unwrap();
         (block_device, fs)
     }
 

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -90,9 +90,13 @@ pub struct Ext4 {
     metadata_mutation_barrier: MetadataMutationGate,
     /// First unrecoverable metadata error.  Once set, mutation must fail-stop.
     poisoned: spin::Mutex<Option<ErrCode>>,
-    /// Validated synchronous JBD2 engine. It is initialized only by
-    /// `load_writable`; read-only probing must not mutate or recover media.
-    journal: Option<journal_transaction::JournalTransactionCore>,
+    /// Explicit metadata mutation lifecycle. Read-only probing cannot acquire
+    /// either transaction backend and therefore cannot mutate or recover media.
+    metadata_mode: MetadataMutationMode,
+    /// Flush policy selected at mount. Journal mode currently requires this.
+    write_barrier: bool,
+    /// A Direct mount may restore VALID_FS only if it was set before mount.
+    direct_restore_clean: bool,
     /// Serializes inode metadata and extent-tree mutations per inode shard.
     ///
     /// another_ext4 stores inodes as value snapshots in a small cache. Without
@@ -101,6 +105,12 @@ pub struct Ext4 {
     /// sharding so unrelated apt download files do not serialize on one global
     /// filesystem-wide spin lock.
     inode_mutation_locks: Vec<spin::Mutex<()>>,
+}
+
+pub(super) enum MetadataMutationMode {
+    ReadOnly,
+    Journal(journal_transaction::JournalTransactionCore),
+    Direct(journal_transaction::DirectTransactionCore),
 }
 
 /// Non-blocking gate separating legacy direct writers from journal snapshots.
@@ -288,7 +298,8 @@ impl Ext4 {
     }
 
     fn validate_super_block(sb: &SuperBlock) -> Result<()> {
-        const SUPPORTED_INCOMPAT: u32 = 0x0002 | 0x0004 | 0x0040 | 0x0080 | 0x0200;
+        const SUPPORTED_INCOMPAT: u32 =
+            0x0002 | 0x0004 | 0x0040 | 0x0080 | 0x0200 | SuperBlock::FEATURE_INCOMPAT_CSUM_SEED;
         const SUPPORTED_RO_COMPAT: u32 = 0x0001
             | 0x0002
             | 0x0004
@@ -396,7 +407,7 @@ impl Ext4 {
         let block_bitmap = desc.block_bitmap_block();
         let inode_bitmap = desc.inode_bitmap_block();
         let inode_table = desc.inode_table_first_block();
-        if (metadata_csum && !group.verify_checksum(&sb.uuid()))
+        if (metadata_csum && !group.verify_checksum(sb.metadata_checksum_seed()))
             || block_bitmap == 0
             || block_bitmap >= sb.block_count()
             || inode_bitmap == 0
@@ -437,15 +448,55 @@ impl Ext4 {
             namespace_lock: spin::Mutex::new(()),
             metadata_mutation_barrier: MetadataMutationGate::new(),
             poisoned: spin::Mutex::new(None),
-            journal: None,
+            metadata_mode: MetadataMutationMode::ReadOnly,
+            write_barrier: true,
+            direct_restore_clean: false,
             inode_mutation_locks,
         })
     }
 
     /// Load, recover and activate a filesystem for metadata mutation.
     pub fn load_writable(block_device: Arc<dyn BlockDevice>) -> Result<Self> {
+        Self::load_writable_with_options(block_device, true)
+    }
+
+    pub fn load_read_only_checked(block_device: Arc<dyn BlockDevice>) -> Result<Self> {
+        let fs = Self::load(block_device)?;
+        let sb = fs.read_super_block_cached();
+        if sb.last_orphan() != 0
+            || sb.has_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER)
+        {
+            return_error!(
+                ErrCode::EROFS,
+                "Filesystem requires recovery before read-only mount"
+            );
+        }
+        Ok(fs)
+    }
+
+    pub fn load_writable_with_options(
+        block_device: Arc<dyn BlockDevice>,
+        write_barrier: bool,
+    ) -> Result<Self> {
         let mut fs = Self::load(block_device)?;
-        fs.initialize_journal()?;
+        fs.write_barrier = write_barrier;
+        fs.writable_orphan_preflight()?;
+        let has_journal = fs
+            .read_super_block_cached()
+            .has_compatible_feature(SuperBlock::FEATURE_COMPAT_HAS_JOURNAL);
+        if has_journal {
+            if !write_barrier {
+                return_error!(
+                    ErrCode::ENOTSUP,
+                    "barrier=0 is unsupported with the journal"
+                );
+            }
+            fs.initialize_journal()?;
+        } else {
+            fs.initialize_direct()?;
+            fs.mark_direct_mount_dirty()?;
+            fs.cleanup_legacy_orphan_chain()?;
+        }
         Ok(fs)
     }
 
@@ -466,6 +517,9 @@ impl Ext4 {
     }
 
     pub(super) fn ensure_mutable(&self) -> Result<()> {
+        if matches!(self.metadata_mode, MetadataMutationMode::ReadOnly) {
+            return_error!(ErrCode::EROFS, "Filesystem was opened read-only");
+        }
         if let Some(code) = *self.poisoned.lock() {
             return_error!(code, "Filesystem is fail-stopped after a metadata error");
         }
@@ -596,7 +650,7 @@ mod validation_tests {
         sb.set_checksum();
         let mut desc = BlockGroupDesc::validation_fixture();
         let mut group = BlockGroupRef::new(0, desc);
-        group.set_checksum(&sb.uuid());
+        group.set_checksum(sb.metadata_checksum_seed());
         desc = group.desc;
 
         let mut block0 = Block::new(0, Box::new([0; BLOCK_SIZE]));
@@ -663,7 +717,7 @@ mod validation_tests {
         let sb = SuperBlock::validation_fixture();
         let mut desc = BlockGroupDesc::validation_fixture();
         let mut group = BlockGroupRef::new(0, desc);
-        group.set_checksum(&sb.uuid());
+        group.set_checksum(sb.metadata_checksum_seed());
         desc = group.desc;
         assert!(Ext4::validate_block_group(&sb, 0, &desc, true, 16).is_ok());
 
@@ -675,7 +729,7 @@ mod validation_tests {
         bytes[0..4].copy_from_slice(&(sb.block_count() as u32).to_le_bytes());
         bad_address = BlockGroupDesc::from_bytes(&bytes);
         let mut group = BlockGroupRef::new(0, bad_address);
-        group.set_checksum(&sb.uuid());
+        group.set_checksum(sb.metadata_checksum_seed());
         assert!(Ext4::validate_block_group(&sb, 0, &group.desc, true, 16).is_err());
     }
 

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -464,6 +464,7 @@ impl Ext4 {
         let fs = Self::load(block_device)?;
         let sb = fs.read_super_block_cached();
         if sb.last_orphan() != 0
+            || sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT)
             || sb.has_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER)
         {
             return_error!(
@@ -645,8 +646,7 @@ mod validation_tests {
         }
     }
 
-    fn system_zone_test_fs() -> Ext4 {
-        let mut sb = SuperBlock::validation_fixture();
+    fn validation_device(mut sb: SuperBlock) -> Arc<ValidationDevice> {
         sb.set_checksum();
         let mut desc = BlockGroupDesc::validation_fixture();
         let mut group = BlockGroupRef::new(0, desc);
@@ -657,10 +657,13 @@ mod validation_tests {
         block0.write_offset_as(BASE_OFFSET, &sb);
         let mut block1 = Block::new(1, Box::new([0; BLOCK_SIZE]));
         block1.write_offset_as(0, &desc);
-        let device = ValidationDevice {
+        Arc::new(ValidationDevice {
             blocks: BTreeMap::from([(0, block0), (1, block1)]),
-        };
-        Ext4::load(Arc::new(device)).unwrap()
+        })
+    }
+
+    fn system_zone_test_fs() -> Ext4 {
+        Ext4::load(validation_device(SuperBlock::validation_fixture())).unwrap()
     }
 
     #[test]
@@ -684,12 +687,30 @@ mod validation_tests {
     }
 
     #[test]
-    fn orphan_present_is_recognized_for_read_only_loading() {
+    fn orphan_present_is_recognized_by_superblock_validation() {
         let mut sb = SuperBlock::validation_fixture();
         sb.set_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT, true);
         sb.set_checksum();
 
         assert!(Ext4::validate_super_block(&sb).is_ok());
+    }
+
+    #[test]
+    fn read_only_load_rejects_pending_orphan_file_recovery() {
+        let mut pending = SuperBlock::validation_fixture();
+        pending
+            .set_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT, true);
+        assert_eq!(
+            Ext4::load_read_only_checked(validation_device(pending))
+                .err()
+                .unwrap()
+                .code(),
+            ErrCode::EROFS
+        );
+
+        let mut clean = SuperBlock::validation_fixture();
+        clean.set_compatible_feature(SuperBlock::FEATURE_COMPAT_ORPHAN_FILE, true);
+        assert!(Ext4::load_read_only_checked(validation_device(clean)).is_ok());
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/orphan.rs
+++ b/kernel/crates/another_ext4/src/ext4/orphan.rs
@@ -37,7 +37,7 @@ fn corruption() -> Ext4Error {
 
 pub(super) fn inode_checksum_valid(sb: &SuperBlock, inode: &InodeRef) -> bool {
     !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM)
-        || inode.verify_checksum(&sb.uuid())
+        || inode.verify_checksum(sb.metadata_checksum_seed())
 }
 
 fn unsupported_orphan_format(sb: &SuperBlock) -> bool {
@@ -410,15 +410,15 @@ mod tests {
         let sb: SuperBlock = unsafe { core::mem::zeroed() };
         let mut inode = InodeRef::new(11, Box::default());
         inode.inode.set_generation(7);
-        inode.set_checksum(&sb.uuid());
+        inode.set_checksum(sb.metadata_checksum_seed());
         inode.inode.set_generation(8);
 
-        assert!(!inode.verify_checksum(&sb.uuid()));
+        assert!(!inode.verify_checksum(sb.metadata_checksum_seed()));
         assert!(inode_checksum_valid(&sb, &inode));
 
         let checked_sb = SuperBlock::validation_fixture();
         inode.inode.set_generation(9);
-        inode.set_checksum(&checked_sb.uuid());
+        inode.set_checksum(checked_sb.metadata_checksum_seed());
         inode.inode.set_generation(10);
         assert!(!inode_checksum_valid(&checked_sb, &inode));
     }

--- a/kernel/crates/another_ext4/src/ext4/rw.rs
+++ b/kernel/crates/another_ext4/src/ext4/rw.rs
@@ -62,9 +62,8 @@ impl Ext4 {
         &self,
         transaction: &mut super::journal_transaction::Transaction<'_>,
         bg_ref: &mut BlockGroupRef,
-        uuid: &[u8],
     ) -> Result<()> {
-        bg_ref.set_checksum(uuid);
+        bg_ref.set_checksum(self.read_super_block_cached().metadata_checksum_seed());
         let (block_id, offset) = self.block_group_disk_pos(bg_ref.id)?;
         let image = self.transaction_block_for_update(transaction, block_id)?;
         image[offset..offset + core::mem::size_of::<BlockGroupDesc>()]
@@ -83,7 +82,7 @@ impl Ext4 {
         transaction: &mut super::journal_transaction::Transaction<'_>,
         inode_ref: &mut InodeRef,
     ) -> Result<()> {
-        inode_ref.set_checksum(&self.read_super_block_cached().uuid());
+        inode_ref.set_checksum(self.read_super_block_cached().metadata_checksum_seed());
         let (block_id, offset) = self.inode_disk_pos(inode_ref.id)?;
         let image = self.transaction_block_for_update(transaction, block_id)?;
         let bytes = inode_ref.inode.to_bytes();
@@ -166,8 +165,8 @@ impl Ext4 {
 
     /// Write an inode to block device with checksum, and update cache.
     pub(super) fn write_inode_with_csum(&self, inode_ref: &mut InodeRef) -> Result<()> {
-        let uuid = self.read_super_block_cached().uuid();
-        inode_ref.set_checksum(&uuid);
+        let seed = self.read_super_block_cached().metadata_checksum_seed();
+        inode_ref.set_checksum(seed);
         self.write_inode_without_csum(inode_ref)
     }
 
@@ -197,8 +196,8 @@ impl Ext4 {
 
     /// Write a block group descriptor to disk and update cache, with checksum.
     pub(super) fn write_block_group_with_csum(&self, bg_ref: &mut BlockGroupRef) -> Result<()> {
-        let uuid = self.read_super_block_cached().uuid();
-        bg_ref.set_checksum(&uuid);
+        let seed = self.read_super_block_cached().metadata_checksum_seed();
+        bg_ref.set_checksum(seed);
         self.write_block_group_without_csum(bg_ref)
     }
 

--- a/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
+++ b/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
@@ -1,8 +1,7 @@
 use super::{journal_transaction::Transaction, Ext4};
-use crate::constants::*;
 use crate::ext4_defs::{
-    crc::crc32, validate_xattr_block_for_release, xattr_block_checksum, AsBytes, InodeRef,
-    SuperBlock, XattrHeader,
+    validate_xattr_block_for_release, xattr_block_checksum, AsBytes, InodeRef, SuperBlock,
+    XattrHeader,
 };
 use crate::prelude::*;
 
@@ -50,10 +49,12 @@ impl Ext4 {
         let bitmap = transaction.read(self.block_device.as_ref(), bitmap_block)?;
         if sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
             let checksum_bytes = sb.clusters_per_group() as usize / 8;
-            if !bg.verify_checksum(&sb.uuid())
-                || !bg
-                    .desc
-                    .verify_block_bitmap_csum(&sb.uuid(), &*bitmap, checksum_bytes)
+            if !bg.verify_checksum(sb.metadata_checksum_seed())
+                || !bg.desc.verify_block_bitmap_csum(
+                    sb.metadata_checksum_seed(),
+                    &*bitmap,
+                    checksum_bytes,
+                )
             {
                 return Err(Ext4Error::new(ErrCode::EIO));
             }
@@ -81,12 +82,6 @@ impl Ext4 {
             return Ok(None);
         }
         let sb = self.read_super_block_cached();
-        // EXT4_FEATURE_INCOMPAT_CSUM_SEED requires the explicit checksum-seed
-        // superblock field, which another_ext4 does not expose yet.
-        const FEATURE_INCOMPAT_CSUM_SEED: u32 = 0x2000;
-        if sb.has_incompatible_feature(FEATURE_INCOMPAT_CSUM_SEED) {
-            return Err(Ext4Error::new(ErrCode::ENOTSUP));
-        }
         self.validate_xattr_block_allocation(transaction, block_id)?;
         let image = transaction.read(self.block_device.as_ref(), block_id)?;
         let (mut header, has_ea_inode) = validate_xattr_block_for_release(&*image)
@@ -99,8 +94,7 @@ impl Ext4 {
         const FEATURE_RO_COMPAT_METADATA_CSUM: u32 = 0x0400;
         let checksum_seed = if sb.has_read_only_compatible_feature(FEATURE_RO_COMPAT_METADATA_CSUM)
         {
-            // Without metadata_csum_seed Linux derives the seed from UUID.
-            let seed = crc32(CRC32_INIT, &sb.uuid());
+            let seed = sb.metadata_checksum_seed();
             let expected = xattr_block_checksum(seed, block_id, &*image)
                 .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
             if header.checksum() != expected {

--- a/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
@@ -7,7 +7,7 @@
 
 use super::crc::*;
 use super::AsBytes;
-use crate::constants::*;
+use super::MetadataChecksumSeed;
 use crate::prelude::*;
 
 /// The Block Group Descriptor.
@@ -105,19 +105,29 @@ impl BlockGroupDesc {
         self.free_blocks_count_hi = (cnt >> 16) as u16;
     }
 
-    fn bitmap_csum(uuid: &[u8], bytes: &[u8], len: usize) -> Option<u32> {
+    fn bitmap_csum(seed: MetadataChecksumSeed, bytes: &[u8], len: usize) -> Option<u32> {
         let covered = bytes.get(..len)?;
-        Some(crc32(crc32(CRC32_INIT, uuid), covered))
+        Some(seed.crc32c(covered))
     }
 
-    pub fn verify_inode_bitmap_csum(&self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
-        Self::bitmap_csum(uuid, bytes, len).is_some_and(|csum| {
+    pub fn verify_inode_bitmap_csum(
+        &self,
+        seed: MetadataChecksumSeed,
+        bytes: &[u8],
+        len: usize,
+    ) -> bool {
+        Self::bitmap_csum(seed, bytes, len).is_some_and(|csum| {
             csum == (self.inode_bitmap_csum_lo as u32 | ((self.inode_bitmap_csum_hi as u32) << 16))
         })
     }
 
-    pub fn update_inode_bitmap_csum(&mut self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
-        let Some(csum) = Self::bitmap_csum(uuid, bytes, len) else {
+    pub fn update_inode_bitmap_csum(
+        &mut self,
+        seed: MetadataChecksumSeed,
+        bytes: &[u8],
+        len: usize,
+    ) -> bool {
+        let Some(csum) = Self::bitmap_csum(seed, bytes, len) else {
             return false;
         };
         self.inode_bitmap_csum_lo = csum as u16;
@@ -125,14 +135,24 @@ impl BlockGroupDesc {
         true
     }
 
-    pub fn verify_block_bitmap_csum(&self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
-        Self::bitmap_csum(uuid, bytes, len).is_some_and(|csum| {
+    pub fn verify_block_bitmap_csum(
+        &self,
+        seed: MetadataChecksumSeed,
+        bytes: &[u8],
+        len: usize,
+    ) -> bool {
+        Self::bitmap_csum(seed, bytes, len).is_some_and(|csum| {
             csum == (self.block_bitmap_csum_lo as u32 | ((self.block_bitmap_csum_hi as u32) << 16))
         })
     }
 
-    pub fn update_block_bitmap_csum(&mut self, uuid: &[u8], bytes: &[u8], len: usize) -> bool {
-        let Some(csum) = Self::bitmap_csum(uuid, bytes, len) else {
+    pub fn update_block_bitmap_csum(
+        &mut self,
+        seed: MetadataChecksumSeed,
+        bytes: &[u8],
+        len: usize,
+    ) -> bool {
+        let Some(csum) = Self::bitmap_csum(seed, bytes, len) else {
             return false;
         };
         self.block_bitmap_csum_lo = csum as u16;
@@ -164,20 +184,19 @@ impl BlockGroupRef {
         Self { id, desc }
     }
 
-    pub fn set_checksum(&mut self, uuid: &[u8]) {
+    pub fn set_checksum(&mut self, seed: MetadataChecksumSeed) {
         // Same as inode checksum: clear the checksum field before calculation to avoid
         // including old value causing checksum mismatch.
         self.desc.checksum = 0;
-        let mut checksum = crc32(CRC32_INIT, uuid);
-        checksum = crc32(checksum, &self.id.to_le_bytes());
+        let mut checksum = seed.crc32c(&self.id.to_le_bytes());
         checksum = crc32(checksum, self.desc.to_bytes());
         self.desc.checksum = checksum as u16;
     }
 
-    pub fn verify_checksum(&self, uuid: &[u8]) -> bool {
+    pub fn verify_checksum(&self, seed: MetadataChecksumSeed) -> bool {
         let expected = self.desc.checksum;
         let mut copy = BlockGroupRef::new(self.id, self.desc);
-        copy.set_checksum(uuid);
+        copy.set_checksum(seed);
         copy.desc.checksum == expected
     }
 }
@@ -198,6 +217,7 @@ mod tests {
     #[test]
     fn bitmap_checksum_covers_fixed_group_bytes_not_mutation_bounds() {
         let uuid = [0x5a; 16];
+        let seed = MetadataChecksumSeed::from_uuid(&uuid);
         let mut desc = BlockGroupDesc::default();
         let mut bytes = [0u8; 32];
         // Model a partial last inode group: direct mutation may touch only 65
@@ -207,33 +227,52 @@ mod tests {
             actual_inodes.set_bit(64);
         }
 
-        assert!(desc.update_block_bitmap_csum(&uuid, &bytes, 16));
-        assert!(desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
+        assert!(desc.update_block_bitmap_csum(seed, &bytes, 16));
+        assert!(desc.verify_block_bitmap_csum(seed, &bytes, 16));
 
         // This byte can be beyond the actual blocks in a partial final group,
         // but Linux still includes it in clusters_per_group / 8.
         bytes[15] ^= 1;
-        assert!(!desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
+        assert!(!desc.verify_block_bitmap_csum(seed, &bytes, 16));
         bytes[15] ^= 1;
 
         // Bytes beyond the fixed checksum length are outside the bitmap.
         bytes[16] ^= 1;
-        assert!(desc.verify_block_bitmap_csum(&uuid, &bytes, 16));
+        assert!(desc.verify_block_bitmap_csum(seed, &bytes, 16));
 
-        assert!(desc.update_inode_bitmap_csum(&uuid, &bytes, 16));
+        assert!(desc.update_inode_bitmap_csum(seed, &bytes, 16));
         bytes[15] ^= 1;
-        assert!(!desc.verify_inode_bitmap_csum(&uuid, &bytes, 16));
+        assert!(!desc.verify_inode_bitmap_csum(seed, &bytes, 16));
         bytes[15] ^= 1;
-        assert!(desc.verify_inode_bitmap_csum(&uuid, &bytes, 16));
+        assert!(desc.verify_inode_bitmap_csum(seed, &bytes, 16));
     }
 
     #[test]
     fn group_descriptor_checksum_detects_corruption() {
         let uuid = [0xa5; 16];
+        let seed = MetadataChecksumSeed::from_uuid(&uuid);
         let mut group = BlockGroupRef::new(7, BlockGroupDesc::default());
-        group.set_checksum(&uuid);
-        assert!(group.verify_checksum(&uuid));
+        group.set_checksum(seed);
+        assert!(group.verify_checksum(seed));
         group.desc.set_free_inodes_count(1);
-        assert!(!group.verify_checksum(&uuid));
+        assert!(!group.verify_checksum(seed));
+    }
+
+    #[test]
+    fn explicit_metadata_seed_is_not_rederived_from_uuid() {
+        let uuid_seed = MetadataChecksumSeed::from_uuid(&[0xa5; 16]);
+        let explicit_seed = MetadataChecksumSeed::from_raw(0x1234_5678);
+        let mut bytes = [0u8; 16];
+        bytes[7] = 0x5a;
+        let mut desc = BlockGroupDesc::default();
+
+        assert!(desc.update_block_bitmap_csum(explicit_seed, &bytes, bytes.len()));
+        assert!(desc.verify_block_bitmap_csum(explicit_seed, &bytes, bytes.len()));
+        assert!(!desc.verify_block_bitmap_csum(uuid_seed, &bytes, bytes.len()));
+
+        let mut group = BlockGroupRef::new(3, desc);
+        group.set_checksum(explicit_seed);
+        assert!(group.verify_checksum(explicit_seed));
+        assert!(!group.verify_checksum(uuid_seed));
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/dir.rs
@@ -4,6 +4,7 @@
 use super::crc::*;
 use super::AsBytes;
 use super::FileType;
+use super::MetadataChecksumSeed;
 use crate::constants::*;
 use crate::prelude::*;
 use crate::Block;
@@ -155,9 +156,14 @@ impl DirEntryTail {
         }
     }
 
-    pub fn set_checksum(&mut self, uuid: &[u8], ino: InodeId, ino_gen: u32, block: &Block) {
-        let mut csum = crc32(CRC32_INIT, uuid);
-        csum = crc32(csum, &ino.to_le_bytes());
+    pub fn set_checksum(
+        &mut self,
+        seed: MetadataChecksumSeed,
+        ino: InodeId,
+        ino_gen: u32,
+        block: &Block,
+    ) {
+        let mut csum = seed.crc32c(&ino.to_le_bytes());
         csum = crc32(csum, &ino_gen.to_le_bytes());
         // Hash all directory entries up to (but not including) this tail struct.
         // Linux: csum = ext4_chksum(sbi, i_csum_seed, dirent, (char*)tail - block_start)
@@ -191,7 +197,7 @@ impl DirBlock {
     /// record must end at or before that tail with a bounded name payload.
     pub fn validate(
         &self,
-        uuid: &[u8],
+        seed: MetadataChecksumSeed,
         ino: InodeId,
         ino_gen: u32,
         metadata_csum: bool,
@@ -199,17 +205,17 @@ impl DirBlock {
         htree_root: bool,
     ) -> Result<DirBlockLayout> {
         if indexed && htree_root {
-            self.validate_htree(uuid, ino, ino_gen, metadata_csum)?;
+            self.validate_htree(seed, ino, ino_gen, metadata_csum)?;
             return Ok(DirBlockLayout::Htree);
         }
         if indexed
             && self
-                .validate_htree(uuid, ino, ino_gen, metadata_csum)
+                .validate_htree(seed, ino, ino_gen, metadata_csum)
                 .is_ok()
         {
             return Ok(DirBlockLayout::Htree);
         }
-        if let Ok(()) = self.validate_leaf(uuid, ino, ino_gen, metadata_csum) {
+        if let Ok(()) = self.validate_leaf(seed, ino, ino_gen, metadata_csum) {
             return Ok(DirBlockLayout::Leaf);
         }
         Err(Ext4Error::new(ErrCode::EIO))
@@ -217,7 +223,7 @@ impl DirBlock {
 
     fn validate_leaf(
         &self,
-        uuid: &[u8],
+        seed: MetadataChecksumSeed,
         ino: InodeId,
         ino_gen: u32,
         metadata_csum: bool,
@@ -237,7 +243,7 @@ impl DirBlock {
                 return Err(Ext4Error::new(ErrCode::EIO));
             }
             let mut expected = tail;
-            expected.set_checksum(uuid, ino, ino_gen, &self.0);
+            expected.set_checksum(seed, ino, ino_gen, &self.0);
             if expected.checksum != tail.checksum {
                 return Err(Ext4Error::new(ErrCode::EIO));
             }
@@ -275,7 +281,7 @@ impl DirBlock {
     /// layout and checksum coverage as Linux `ext4_dx_csum_verify()`.
     fn validate_htree(
         &self,
-        uuid: &[u8],
+        seed: MetadataChecksumSeed,
         ino: InodeId,
         ino_gen: u32,
         metadata_csum: bool,
@@ -334,8 +340,7 @@ impl DirBlock {
         let used_end = count_offset
             .checked_add(count * 8)
             .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
-        let mut checksum = crc32(CRC32_INIT, uuid);
-        checksum = crc32(checksum, &ino.to_le_bytes());
+        let mut checksum = seed.crc32c(&ino.to_le_bytes());
         checksum = crc32(checksum, &ino_gen.to_le_bytes());
         checksum = crc32(checksum, &self.0.data[..used_end]);
         checksum = crc32(checksum, &self.0.data[tail_offset..tail_offset + 4]);
@@ -524,14 +529,19 @@ impl DirBlock {
     }
 
     /// Calc and set block checksum
-    pub fn set_checksum(&mut self, uuid: &[u8], ino: InodeId, ino_gen: u32) {
+    pub fn set_checksum(&mut self, seed: MetadataChecksumSeed, ino: InodeId, ino_gen: u32) {
         let tail_offset = BLOCK_SIZE - size_of::<DirEntryTail>();
         let mut tail: DirEntryTail = self.0.read_offset_as(tail_offset);
-        tail.set_checksum(uuid, ino, ino_gen, &self.0);
+        tail.set_checksum(seed, ino, ino_gen, &self.0);
         self.0.write_offset_as(tail_offset, &tail);
     }
 
-    pub fn set_htree_checksum(&mut self, uuid: &[u8], ino: InodeId, ino_gen: u32) -> Result<()> {
+    pub fn set_htree_checksum(
+        &mut self,
+        seed: MetadataChecksumSeed,
+        ino: InodeId,
+        ino_gen: u32,
+    ) -> Result<()> {
         let first_rec_len = u16::from_le_bytes([self.0.data[4], self.0.data[5]]) as usize;
         let count_offset = if first_rec_len == BLOCK_SIZE {
             8usize
@@ -561,8 +571,7 @@ impl DirBlock {
         let used_end = count_offset
             .checked_add(count * 8)
             .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
-        let mut checksum = crc32(CRC32_INIT, uuid);
-        checksum = crc32(checksum, &ino.to_le_bytes());
+        let mut checksum = seed.crc32c(&ino.to_le_bytes());
         checksum = crc32(checksum, &ino_gen.to_le_bytes());
         checksum = crc32(checksum, &self.0.data[..used_end]);
         checksum = crc32(checksum, &self.0.data[tail_offset..tail_offset + 4]);
@@ -576,11 +585,15 @@ impl DirBlock {
 mod tests {
     use super::*;
 
+    fn seed() -> MetadataChecksumSeed {
+        MetadataChecksumSeed::from_uuid(&[0x41; 16])
+    }
+
     fn valid_block() -> DirBlock {
         let mut block = DirBlock::new(Block::new(7, Box::new([0; BLOCK_SIZE])));
         block.init(true);
         assert!(block.insert("entry", 12, FileType::RegularFile, true));
-        block.set_checksum(&[0x41; 16], 2, 9);
+        block.set_checksum(seed(), 2, 9);
         block
     }
 
@@ -620,15 +633,13 @@ mod tests {
     #[test]
     fn validated_directory_rejects_zero_and_out_of_bounds_record_lengths() {
         let block = valid_block();
-        block
-            .validate(&[0x41; 16], 2, 9, true, false, false)
-            .unwrap();
+        block.validate(seed(), 2, 9, true, false, false).unwrap();
 
         let mut zero = block.0.clone();
         zero.data[4..6].copy_from_slice(&0u16.to_le_bytes());
         assert_eq!(
             DirBlock::new(zero)
-                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .validate(seed(), 2, 9, false, false, false)
                 .unwrap_err()
                 .code(),
             ErrCode::EIO
@@ -638,7 +649,7 @@ mod tests {
         oversized.data[4..6].copy_from_slice(&((BLOCK_SIZE - 4) as u16).to_le_bytes());
         assert_eq!(
             DirBlock::new(oversized)
-                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .validate(seed(), 2, 9, false, false, false)
                 .unwrap_err()
                 .code(),
             ErrCode::EIO
@@ -653,7 +664,7 @@ mod tests {
         bad_name.data[6] = 255;
         assert_eq!(
             DirBlock::new(bad_name)
-                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .validate(seed(), 2, 9, false, false, false)
                 .unwrap_err()
                 .code(),
             ErrCode::EIO
@@ -663,7 +674,7 @@ mod tests {
         bad_type.data[7] = 0xff;
         assert_eq!(
             DirBlock::new(bad_type)
-                .validate(&[0x41; 16], 2, 9, false, false, false)
+                .validate(seed(), 2, 9, false, false, false)
                 .unwrap_err()
                 .code(),
             ErrCode::EIO
@@ -673,7 +684,7 @@ mod tests {
         bad_checksum.data[BLOCK_SIZE - 1] ^= 0x80;
         assert_eq!(
             DirBlock::new(bad_checksum)
-                .validate(&[0x41; 16], 2, 9, true, false, false)
+                .validate(seed(), 2, 9, true, false, false)
                 .unwrap_err()
                 .code(),
             ErrCode::EIO
@@ -683,9 +694,7 @@ mod tests {
     #[test]
     fn missing_entry_scan_stops_before_checksum_tail() {
         let mut block = valid_block();
-        block
-            .validate(&[0x41; 16], 2, 9, true, false, false)
-            .unwrap();
+        block.validate(seed(), 2, 9, true, false, false).unwrap();
 
         assert_eq!(block.get("missing", true), None);
         let mut entries = Vec::new();
@@ -703,7 +712,7 @@ mod tests {
     fn indexed_directory_root_uses_dx_checksum_layout() {
         let block = valid_htree_root();
         assert_eq!(
-            block.validate(&[0x41; 16], 2, 9, true, true, true).unwrap(),
+            block.validate(seed(), 2, 9, true, true, true).unwrap(),
             DirBlockLayout::Htree
         );
         assert_eq!(block.get(".", true), Some(2));
@@ -712,7 +721,7 @@ mod tests {
         no_csum.data[32..34].copy_from_slice(&508u16.to_le_bytes());
         assert_eq!(
             DirBlock::new(no_csum)
-                .validate(&[0x41; 16], 2, 9, false, true, true)
+                .validate(seed(), 2, 9, false, true, true)
                 .unwrap(),
             DirBlockLayout::Htree
         );
@@ -721,7 +730,7 @@ mod tests {
         corrupted.data[BLOCK_SIZE - 1] ^= 0x80;
         assert_eq!(
             DirBlock::new(corrupted)
-                .validate(&[0x41; 16], 2, 9, true, true, true)
+                .validate(seed(), 2, 9, true, true, true)
                 .unwrap_err()
                 .code(),
             ErrCode::EIO
@@ -731,7 +740,7 @@ mod tests {
         invalid_type.data[7] = 0xff;
         assert_eq!(
             DirBlock::new(invalid_type)
-                .validate(&[0x41; 16], 2, 9, false, true, true)
+                .validate(seed(), 2, 9, false, true, true)
                 .unwrap_err()
                 .code(),
             ErrCode::EIO
@@ -744,9 +753,7 @@ mod tests {
         block.init(false);
         assert!(block.insert("entry", 12, FileType::RegularFile, false));
         assert_eq!(
-            block
-                .validate(&[0x41; 16], 2, 9, false, false, false)
-                .unwrap(),
+            block.validate(seed(), 2, 9, false, false, false).unwrap(),
             DirBlockLayout::Leaf
         );
     }

--- a/kernel/crates/another_ext4/src/ext4_defs/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/extent.rs
@@ -14,7 +14,8 @@
 //! the use of extra metadata blocks.
 
 use super::crc::crc32;
-use crate::constants::{BLOCK_SIZE, CRC32_INIT};
+use super::MetadataChecksumSeed;
+use crate::constants::BLOCK_SIZE;
 use crate::prelude::*;
 
 /// Compute the CRC32C checksum for an extent block (non-root node).
@@ -24,9 +25,13 @@ use crate::prelude::*;
 /// and `tail_offset = sizeof(header) + sizeof(extent) * eh_max`.
 ///
 /// For a 4096-byte block: tail is the last 4 bytes.
-pub fn extent_block_checksum(uuid: &[u8], ino: u32, ino_gen: u32, block: &[u8]) -> u32 {
-    let csum = crc32(CRC32_INIT, uuid);
-    let csum = crc32(csum, &ino.to_le_bytes());
+pub fn extent_block_checksum(
+    seed: MetadataChecksumSeed,
+    ino: u32,
+    ino_gen: u32,
+    block: &[u8],
+) -> u32 {
+    let csum = seed.crc32c(&ino.to_le_bytes());
     let csum = crc32(csum, &ino_gen.to_le_bytes());
 
     let tail_offset = BLOCK_SIZE - core::mem::size_of::<ExtentTail>();

--- a/kernel/crates/another_ext4/src/ext4_defs/inode.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/inode.rs
@@ -7,7 +7,7 @@
 
 use super::crc::*;
 use super::AsBytes;
-use super::{ExtentNode, ExtentNodeMut};
+use super::{ExtentNode, ExtentNodeMut, MetadataChecksumSeed};
 use crate::constants::*;
 use crate::prelude::*;
 use crate::FileType;
@@ -533,8 +533,8 @@ impl InodeRef {
         Self { id, inode }
     }
 
-    pub fn set_checksum(&mut self, uuid: &[u8]) {
-        let checksum = self.calculated_checksum(uuid);
+    pub fn set_checksum(&mut self, seed: MetadataChecksumSeed) {
+        let checksum = self.calculated_checksum(seed);
         self.inode.osd2.l_checksum_lo = checksum as u16;
         self.inode.checksum_hi = (checksum >> 16) as u16;
     }
@@ -545,20 +545,19 @@ impl InodeRef {
     }
 
     /// Compute the Linux ext4 inode checksum without modifying the inode.
-    pub fn calculated_checksum(&self, uuid: &[u8]) -> u32 {
+    pub fn calculated_checksum(&self, seed: MetadataChecksumSeed) -> u32 {
         // Linux treats both checksum fields as zero while calculating CRC32C.
         let mut inode = self.inode.as_ref().clone();
         inode.osd2.l_checksum_lo = 0;
         inode.checksum_hi = 0;
-        let mut checksum = crc32(CRC32_INIT, uuid);
-        checksum = crc32(checksum, &self.id.to_le_bytes());
+        let mut checksum = seed.crc32c(&self.id.to_le_bytes());
         checksum = crc32(checksum, &inode.generation.to_le_bytes());
         crc32(checksum, inode.to_bytes())
     }
 
     /// Verify the stored checksum against the inode identity and filesystem UUID.
-    pub fn verify_checksum(&self, uuid: &[u8]) -> bool {
-        self.checksum() == self.calculated_checksum(uuid)
+    pub fn verify_checksum(&self, seed: MetadataChecksumSeed) -> bool {
+        self.checksum() == self.calculated_checksum(seed)
     }
 }
 
@@ -654,17 +653,18 @@ mod tests {
     #[test]
     fn inode_checksum_can_be_verified_without_mutation() {
         let uuid = *b"0123456789abcdef";
+        let seed = MetadataChecksumSeed::from_uuid(&uuid);
         let mut inode = InodeRef::new(42, Box::new(Inode::default()));
         inode.inode.set_generation(7);
         inode.inode.set_next_orphan(11);
-        inode.set_checksum(&uuid);
+        inode.set_checksum(seed);
 
         let stored = inode.checksum();
-        assert!(inode.verify_checksum(&uuid));
+        assert!(inode.verify_checksum(seed));
         assert_eq!(inode.checksum(), stored);
 
         inode.inode.set_next_orphan(12);
-        assert!(!inode.verify_checksum(&uuid));
+        assert!(!inode.verify_checksum(seed));
         assert_eq!(inode.checksum(), stored);
     }
 

--- a/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/super_block.rs
@@ -6,6 +6,30 @@ use super::{crc::crc32, AsBytes};
 use crate::constants::CRC32_INIT;
 use crate::prelude::*;
 
+/// CRC32C seed shared by ext4 metadata checksums.
+///
+/// Linux stores this value in `s_csum_seed`: seeded filesystems read it from
+/// `s_checksum_seed`, while older metadata-checksum filesystems derive it from
+/// the filesystem UUID once at mount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MetadataChecksumSeed(u32);
+
+impl MetadataChecksumSeed {
+    pub fn crc32c(self, bytes: &[u8]) -> u32 {
+        crc32(self.0, bytes)
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn from_raw(seed: u32) -> Self {
+        Self(seed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_uuid(uuid: &[u8]) -> Self {
+        Self(crc32(CRC32_INIT, uuid))
+    }
+}
+
 // 结构体表示超级块
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,13 +129,22 @@ pub struct SuperBlock {
     encrypt_algos: [u8; 4],    // 使用的加密算法
     encrypt_pw_salt: [u8; 16], // 用于string2key算法的盐
     lpf_ino: u32,              // lost+found节点的位置
-    padding: [u32; 100],       // 块的末尾的填充
+    project_quota_inum: u32,   // 项目配额 inode
+    checksum_seed: u32,        // metadata_csum_seed 启用时的 s_csum_seed
+    padding: [u32; 98],        // 块的末尾的填充
     checksum: u32,             // crc32c(superblock)
 }
 
 unsafe impl AsBytes for SuperBlock {}
 
+// Linux `struct ext4_super_block` disk offsets. Keep the explicit seed out of
+// the reserved tail without changing the 1024-byte on-disk layout.
+const _: () = assert!(core::mem::offset_of!(SuperBlock, checksum_seed) == 0x270);
+const _: () = assert!(core::mem::offset_of!(SuperBlock, checksum) == 0x3fc);
+
 impl SuperBlock {
+    /// Filesystem was cleanly unmounted (`EXT4_VALID_FS`).
+    pub const STATE_VALID_FS: u16 = 0x0001;
     const SB_MAGIC: u16 = 0xEF53;
 
     pub const FEATURE_COMPAT_HAS_JOURNAL: u32 = 0x0004;
@@ -121,6 +154,7 @@ impl SuperBlock {
     pub const FEATURE_COMPAT_ORPHAN_FILE: u32 = 0x1000;
     pub const FEATURE_INCOMPAT_RECOVER: u32 = 0x0004;
     pub const FEATURE_INCOMPAT_JOURNAL_DEV: u32 = 0x0008;
+    pub const FEATURE_INCOMPAT_CSUM_SEED: u32 = 0x2000;
     /// The orphan file may contain orphaned inodes.
     pub const FEATURE_RO_COMPAT_ORPHAN_PRESENT: u32 = 0x0001_0000;
     pub const FEATURE_RO_COMPAT_SPARSE_SUPER: u32 = 0x0001;
@@ -145,6 +179,16 @@ impl SuperBlock {
 
     pub fn uuid(&self) -> [u8; 16] {
         self.uuid
+    }
+
+    /// Return Linux's `s_csum_seed` for every metadata checksum other than the
+    /// superblock checksum itself.
+    pub fn metadata_checksum_seed(&self) -> MetadataChecksumSeed {
+        if self.has_incompatible_feature(Self::FEATURE_INCOMPAT_CSUM_SEED) {
+            MetadataChecksumSeed(self.checksum_seed)
+        } else {
+            MetadataChecksumSeed(crc32(CRC32_INIT, &self.uuid))
+        }
     }
 
     pub fn compatible_features(&self) -> u32 {
@@ -202,6 +246,18 @@ impl SuperBlock {
     /// Head inode number of the legacy on-disk orphan list, or zero.
     pub fn last_orphan(&self) -> u32 {
         self.last_orphan
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.state & Self::STATE_VALID_FS != 0
+    }
+
+    pub fn set_clean(&mut self, clean: bool) {
+        if clean {
+            self.state |= Self::STATE_VALID_FS;
+        } else {
+            self.state &= !Self::STATE_VALID_FS;
+        }
     }
 
     /// Set the head inode number of the legacy on-disk orphan list.
@@ -372,6 +428,11 @@ impl SuperBlock {
     }
 
     #[cfg(test)]
+    pub(crate) fn set_checksum_seed(&mut self, seed: u32) {
+        self.checksum_seed = seed;
+    }
+
+    #[cfg(test)]
     pub(crate) fn set_backup_block_groups(&mut self, groups: [u32; 2]) {
         self.backup_bgs = groups;
     }
@@ -416,5 +477,19 @@ mod tests {
         assert_eq!(sb.inode_count_in_group(1), 8);
         assert_eq!(sb.inode_count_in_group(2), 4);
         assert_eq!(sb.inode_count_in_group(3), 0);
+    }
+
+    #[test]
+    fn metadata_seed_uses_disk_field_only_when_feature_is_set() {
+        let mut sb = SuperBlock::validation_fixture();
+        let uuid_seed = MetadataChecksumSeed::from_uuid(&sb.uuid());
+        sb.set_checksum_seed(0x1234_5678);
+        assert_eq!(sb.metadata_checksum_seed(), uuid_seed);
+
+        sb.set_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_CSUM_SEED, true);
+        assert_eq!(
+            sb.metadata_checksum_seed(),
+            MetadataChecksumSeed::from_raw(0x1234_5678)
+        );
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
@@ -8,7 +8,7 @@
 //!
 //! We only implement the seperate data block storage of extended attributes.
 
-use super::{crc::crc32, AsBytes, Block};
+use super::{crc::crc32, AsBytes, Block, MetadataChecksumSeed};
 use crate::constants::*;
 use crate::prelude::*;
 use core::cmp::Ordering;
@@ -74,12 +74,16 @@ impl XattrHeader {
 
 /// Compute an ext4 external-xattr block checksum using the Linux 6.6 layout.
 /// `seed` is the filesystem metadata checksum seed (normally CRC32C(uuid)).
-pub fn xattr_block_checksum(seed: u32, block_id: PBlockId, block: &[u8]) -> Option<u32> {
+pub fn xattr_block_checksum(
+    seed: MetadataChecksumSeed,
+    block_id: PBlockId,
+    block: &[u8],
+) -> Option<u32> {
     if block.len() != BLOCK_SIZE {
         return None;
     }
     let checksum_offset = core::mem::offset_of!(XattrHeader, checksum);
-    let mut checksum = crc32(seed, &block_id.to_le_bytes());
+    let mut checksum = seed.crc32c(&block_id.to_le_bytes());
     checksum = crc32(checksum, &block[..checksum_offset]);
     checksum = crc32(checksum, &[0; core::mem::size_of::<u32>()]);
     Some(crc32(
@@ -351,14 +355,14 @@ impl XattrBlock {
     }
 
     /// Verify the Linux ext4 external-xattr block checksum.
-    pub fn verify_checksum(&self, seed: u32, block_id: PBlockId) -> bool {
+    pub fn verify_checksum(&self, seed: MetadataChecksumSeed, block_id: PBlockId) -> bool {
         let header: XattrHeader = self.0.read_offset_as(0);
         xattr_block_checksum(seed, block_id, &*self.0.data)
             .is_some_and(|checksum| checksum == header.checksum())
     }
 
     /// Recompute the Linux ext4 external-xattr block checksum after mutation.
-    pub fn update_checksum(&mut self, seed: u32, block_id: PBlockId) -> bool {
+    pub fn update_checksum(&mut self, seed: MetadataChecksumSeed, block_id: PBlockId) -> bool {
         let mut header: XattrHeader = self.0.read_offset_as(0);
         header.set_checksum(0);
         self.0.write_offset_as(0, &header);
@@ -582,12 +586,15 @@ mod release_tests {
         start + (size_of::<FakeXattrEntry>() + name.len()).div_ceil(4) * 4
     }
 
-    fn checksummed_block(block_id: PBlockId, refcount: u32) -> ([u8; BLOCK_SIZE], u32) {
+    fn checksummed_block(
+        block_id: PBlockId,
+        refcount: u32,
+    ) -> ([u8; BLOCK_SIZE], MetadataChecksumSeed) {
         let mut bytes = [0; BLOCK_SIZE];
         let mut header = XattrHeader::new();
         header.set_refcount(refcount);
         bytes[..size_of::<XattrHeader>()].copy_from_slice(header.to_bytes());
-        let seed = 0x1234_5678;
+        let seed = MetadataChecksumSeed::from_raw(0x1234_5678);
         let checksum = xattr_block_checksum(seed, block_id, &bytes).unwrap();
         header.set_checksum(checksum);
         bytes[..size_of::<XattrHeader>()].copy_from_slice(header.to_bytes());
@@ -629,7 +636,7 @@ mod release_tests {
 
     #[test]
     fn xattr_block_mutation_recomputes_linux_checksum() {
-        let seed = 0x1234_5678;
+        let seed = MetadataChecksumSeed::from_raw(0x1234_5678);
         let block_id = 17;
         let mut block = XattrBlock::new(Block::new(block_id, Box::new([0; BLOCK_SIZE])));
         block.init();

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -134,6 +134,19 @@ impl Default for Ext4MountOptions {
 }
 
 impl Ext4MountOptions {
+    fn validate_error_behavior(&self) -> Result<(), SystemError> {
+        match self.errors {
+            Ext4ErrorsBehavior::Continue => Ok(()),
+            // A read-only mount already satisfies the externally observable
+            // result of errors=remount-ro. Dynamic writable-to-read-only
+            // transitions are not supported yet and must not be advertised.
+            Ext4ErrorsBehavior::RemountRo if self.read_only => Ok(()),
+            Ext4ErrorsBehavior::RemountRo | Ext4ErrorsBehavior::Panic => {
+                Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+            }
+        }
+    }
+
     fn parse(raw_data: Option<&str>) -> Result<Self, SystemError> {
         let mut options = Self::default();
         let Some(raw_data) = raw_data else {
@@ -149,9 +162,6 @@ impl Ext4MountOptions {
             match token {
                 "barrier" | "barrier=1" => options.write_barrier = true,
                 "nobarrier" | "barrier=0" => options.write_barrier = false,
-                "dax" | "dax=always" => options.dax = Some(Ext4DaxMode::Always),
-                "dax=never" => options.dax = Some(Ext4DaxMode::Never),
-                "dax=inode" => options.dax = Some(Ext4DaxMode::Inode),
                 "errors=continue" => options.errors = Ext4ErrorsBehavior::Continue,
                 "errors=remount-ro" => options.errors = Ext4ErrorsBehavior::RemountRo,
                 "errors=panic" => options.errors = Ext4ErrorsBehavior::Panic,
@@ -806,6 +816,8 @@ impl Ext4FileSystem {
         mount_data: Arc<GenDisk>,
         mount_options: Ext4MountOptions,
     ) -> Result<Arc<dyn FileSystem>, SystemError> {
+        mount_options.validate_error_behavior()?;
+
         // Worker creation may sleep and must never happen from final-release
         // publication while inode/eviction locks are held.
         lazy_static::initialize(&EXT4_EVICTION_WQ);
@@ -987,7 +999,8 @@ impl core::fmt::Debug for Ext4FileSystem {
 
 #[cfg(test)]
 mod mount_options_tests {
-    use super::{Ext4DaxMode, Ext4ErrorsBehavior, Ext4MountOptions};
+    use super::{Ext4ErrorsBehavior, Ext4MountOptions};
+    use system_error::SystemError;
 
     #[test]
     fn barrier_defaults_to_enabled() {
@@ -1019,25 +1032,44 @@ mod mount_options_tests {
         assert!(Ext4MountOptions::parse(Some("discard")).is_err());
         assert!(Ext4MountOptions::parse(Some("barrier=2")).is_err());
         assert!(Ext4MountOptions::parse(Some("barrier=")).is_err());
+        assert!(Ext4MountOptions::parse(Some("dax")).is_err());
         assert!(Ext4MountOptions::parse(Some("dax=invalid")).is_err());
         assert!(Ext4MountOptions::parse(Some("errors=invalid")).is_err());
     }
 
     #[test]
-    fn existing_rootflags_are_preserved() {
-        let options = Ext4MountOptions::parse(Some("dax,errors=remount-ro")).unwrap();
-        assert_eq!(options.dax, Some(Ext4DaxMode::Always));
+    fn existing_read_only_rootflags_are_supported() {
+        let options = Ext4MountOptions::parse(Some("errors=remount-ro")).unwrap();
         assert_eq!(options.errors, Ext4ErrorsBehavior::RemountRo);
         assert!(options.write_barrier);
+
+        let mut read_only = options;
+        read_only.read_only = true;
+        assert!(read_only.validate_error_behavior().is_ok());
+        assert_eq!(
+            options.validate_error_behavior(),
+            Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+        );
     }
 
     #[test]
-    fn dax_and_error_modes_are_last_value_wins() {
-        let options = Ext4MountOptions::parse(Some(
-            "dax=always,dax=never,dax=inode,errors=panic,errors=continue",
-        ))
-        .unwrap();
-        assert_eq!(options.dax, Some(Ext4DaxMode::Inode));
+    fn error_modes_are_last_value_wins() {
+        let options = Ext4MountOptions::parse(Some("errors=panic,errors=continue")).unwrap();
         assert_eq!(options.errors, Ext4ErrorsBehavior::Continue);
+        assert!(options.validate_error_behavior().is_ok());
+    }
+
+    #[test]
+    fn unsupported_panic_behavior_is_rejected() {
+        let mut options = Ext4MountOptions::parse(Some("errors=panic")).unwrap();
+        assert_eq!(
+            options.validate_error_behavior(),
+            Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+        );
+        options.read_only = true;
+        assert_eq!(
+            options.validate_error_behavior(),
+            Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+        );
     }
 }

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -118,6 +118,8 @@ pub struct Ext4MountOptions {
     pub dax: Option<Ext4DaxMode>,
     pub errors: Ext4ErrorsBehavior,
     pub read_only: bool,
+    /// Whether explicit durability boundaries issue a device cache flush.
+    pub write_barrier: bool,
 }
 
 impl Default for Ext4MountOptions {
@@ -126,7 +128,42 @@ impl Default for Ext4MountOptions {
             dax: None,
             errors: Ext4ErrorsBehavior::Continue,
             read_only: false,
+            write_barrier: true,
         }
+    }
+}
+
+impl Ext4MountOptions {
+    fn parse(raw_data: Option<&str>) -> Result<Self, SystemError> {
+        let mut options = Self::default();
+        let Some(raw_data) = raw_data else {
+            return Ok(options);
+        };
+
+        for raw_token in raw_data.split(',') {
+            let token = raw_token.trim();
+            if token.is_empty() {
+                continue;
+            }
+
+            match token {
+                "barrier" | "barrier=1" => options.write_barrier = true,
+                "nobarrier" | "barrier=0" => options.write_barrier = false,
+                "dax" | "dax=always" => options.dax = Some(Ext4DaxMode::Always),
+                "dax=never" => options.dax = Some(Ext4DaxMode::Never),
+                "dax=inode" => options.dax = Some(Ext4DaxMode::Inode),
+                "errors=continue" => options.errors = Ext4ErrorsBehavior::Continue,
+                "errors=remount-ro" => options.errors = Ext4ErrorsBehavior::RemountRo,
+                "errors=panic" => options.errors = Ext4ErrorsBehavior::Panic,
+                // Do not silently accept an option whose semantics ext4 does
+                // not implement. In particular, values other than 0/1 and
+                // journal-only options on a nojournal mount must fail here or
+                // in a future capability-aware parser.
+                _ => return Err(SystemError::EINVAL),
+            }
+        }
+
+        Ok(options)
     }
 }
 
@@ -220,7 +257,11 @@ impl FileSystem for Ext4FileSystem {
             flush_result
         };
         if wait {
-            result.and_then(|_| self.fs.flush_device().map_err(SystemError::from))
+            if self._mount_options.write_barrier {
+                result.and_then(|_| self.fs.flush_device().map_err(SystemError::from))
+            } else {
+                result
+            }
         } else {
             result
         }
@@ -761,10 +802,6 @@ impl Ext4FileSystem {
             .unwrap_or(false))
     }
 
-    pub fn from_gendisk(mount_data: Arc<GenDisk>) -> Result<Arc<dyn FileSystem>, SystemError> {
-        Self::from_gendisk_with_options(mount_data, Ext4MountOptions::default())
-    }
-
     pub fn from_gendisk_with_options(
         mount_data: Arc<GenDisk>,
         mount_options: Ext4MountOptions,
@@ -776,9 +813,12 @@ impl Ext4FileSystem {
         // Writable mounts recover the journal and the validated legacy orphan
         // chain before this filesystem is published to the VFS.
         let fs = if mount_options.read_only {
-            another_ext4::Ext4::load(mount_data.clone())?
+            another_ext4::Ext4::load_read_only_checked(mount_data.clone())?
         } else {
-            another_ext4::Ext4::load_writable(mount_data.clone())?
+            another_ext4::Ext4::load_writable_with_options(
+                mount_data.clone(),
+                mount_options.write_barrier,
+            )?
         };
         let root_inode: Arc<LockedExt4Inode> =
             Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| LockedExt4Inode {
@@ -877,10 +917,8 @@ impl MountableFileSystem for Ext4FileSystem {
         let mount_data = data
             .and_then(|d| d.as_any().downcast_ref::<Ext4MountData>())
             .ok_or(SystemError::EINVAL)?;
-        let options = Ext4MountOptions {
-            read_only: mount_flags.contains(MountFlags::RDONLY),
-            ..Ext4MountOptions::default()
-        };
+        let mut options = mount_data.options;
+        options.read_only = mount_flags.contains(MountFlags::RDONLY);
         Self::from_gendisk_with_options(mount_data.gendisk.clone(), options)
     }
 
@@ -891,13 +929,14 @@ impl MountableFileSystem for Ext4FileSystem {
             .and_then(|d| d.as_any().downcast_ref::<Ext4MountData>())
             .ok_or(SystemError::EINVAL)?;
 
-        Self::from_gendisk(mount_data.gendisk.clone())
+        Self::from_gendisk_with_options(mount_data.gendisk.clone(), mount_data.options)
     }
     fn make_mount_data(
-        _raw_data: Option<&str>,
+        raw_data: Option<&str>,
         source: &str,
     ) -> Result<Option<Arc<dyn FileSystemMakerData + 'static>>, SystemError> {
-        let mount_data = Ext4MountData::from_source(source).map_err(|e| {
+        let options = Ext4MountOptions::parse(raw_data)?;
+        let mount_data = Ext4MountData::from_source(source, options).map_err(|e| {
             log::error!(
                 "Failed to create Ext4 mount data from source '{}': {:?}",
                 source,
@@ -913,6 +952,7 @@ register_mountable_fs!(Ext4FileSystem, EXT4FSMAKER, "ext4");
 
 pub struct Ext4MountData {
     gendisk: Arc<GenDisk>,
+    options: Ext4MountOptions,
 }
 
 impl FileSystemMakerData for Ext4MountData {
@@ -922,7 +962,7 @@ impl FileSystemMakerData for Ext4MountData {
 }
 
 impl Ext4MountData {
-    fn from_source(path: &str) -> Result<Self, SystemError> {
+    fn from_source(path: &str, options: Ext4MountOptions) -> Result<Self, SystemError> {
         let pcb = ProcessManager::current_pcb();
         let (current_node, rest_path) = user_path_at(&pcb, AtFlags::AT_FDCWD.bits(), path)?;
         let inode = current_node.lookup_follow_symlink(&rest_path, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
@@ -933,7 +973,7 @@ impl Ext4MountData {
         let disk = inode.dname()?;
 
         if let Some(gendisk) = try_find_gendisk(disk.0.as_str()) {
-            return Ok(Self { gendisk });
+            return Ok(Self { gendisk, options });
         }
         Err(SystemError::ENOENT)
     }
@@ -942,5 +982,62 @@ impl Ext4MountData {
 impl core::fmt::Debug for Ext4FileSystem {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ext4")
+    }
+}
+
+#[cfg(test)]
+mod mount_options_tests {
+    use super::{Ext4DaxMode, Ext4ErrorsBehavior, Ext4MountOptions};
+
+    #[test]
+    fn barrier_defaults_to_enabled() {
+        assert!(Ext4MountOptions::parse(None).unwrap().write_barrier);
+        assert!(Ext4MountOptions::parse(Some("")).unwrap().write_barrier);
+    }
+
+    #[test]
+    fn barrier_aliases_and_last_value_win() {
+        assert!(
+            Ext4MountOptions::parse(Some("barrier=0,barrier"))
+                .unwrap()
+                .write_barrier
+        );
+        assert!(
+            !Ext4MountOptions::parse(Some("barrier=1,nobarrier"))
+                .unwrap()
+                .write_barrier
+        );
+        assert!(
+            !Ext4MountOptions::parse(Some("barrier, barrier=0,"))
+                .unwrap()
+                .write_barrier
+        );
+    }
+
+    #[test]
+    fn unknown_and_invalid_options_are_rejected() {
+        assert!(Ext4MountOptions::parse(Some("discard")).is_err());
+        assert!(Ext4MountOptions::parse(Some("barrier=2")).is_err());
+        assert!(Ext4MountOptions::parse(Some("barrier=")).is_err());
+        assert!(Ext4MountOptions::parse(Some("dax=invalid")).is_err());
+        assert!(Ext4MountOptions::parse(Some("errors=invalid")).is_err());
+    }
+
+    #[test]
+    fn existing_rootflags_are_preserved() {
+        let options = Ext4MountOptions::parse(Some("dax,errors=remount-ro")).unwrap();
+        assert_eq!(options.dax, Some(Ext4DaxMode::Always));
+        assert_eq!(options.errors, Ext4ErrorsBehavior::RemountRo);
+        assert!(options.write_barrier);
+    }
+
+    #[test]
+    fn dax_and_error_modes_are_last_value_wins() {
+        let options = Ext4MountOptions::parse(Some(
+            "dax=always,dax=never,dax=inode,errors=panic,errors=continue",
+        ))
+        .unwrap();
+        assert_eq!(options.dax, Some(Ext4DaxMode::Inode));
+        assert_eq!(options.errors, Ext4ErrorsBehavior::Continue);
     }
 }

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -303,6 +303,18 @@ impl FileSystem for Ext4FileSystem {
 }
 
 impl Ext4FileSystem {
+    /// Complete an explicit fsync/fdatasync/O_SYNC durability boundary.
+    ///
+    /// Linux ext4 performs the nojournal barrier after data and metadata
+    /// writeback, rather than flushing every ordinary metadata transaction.
+    /// Read-only and `nobarrier` mounts do not issue a device flush.
+    pub(super) fn finish_sync_durability_boundary(&self) -> Result<(), SystemError> {
+        if self._mount_options.read_only || !self._mount_options.write_barrier {
+            return Ok(());
+        }
+        self.fs.flush_device().map_err(SystemError::from)
+    }
+
     pub(super) fn schedule_inode_eviction(
         self: &Arc<Self>,
         inode: Arc<LockedExt4Inode>,

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -248,6 +248,10 @@ pub struct LockedExt4Inode {
 }
 
 impl IndexNode for LockedExt4Inode {
+    fn append_lock_fs(&self) -> Option<Arc<dyn vfs::FileSystem>> {
+        Some(self.fs())
+    }
+
     fn retention_state(&self) -> Option<&InodeRetentionState> {
         Some(&self.retention)
     }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -705,7 +705,9 @@ impl IndexNode for LockedExt4Inode {
         if let Some(page_cache) = self.page_cache() {
             page_cache.manager().sync()?;
         }
-        self.flush_metadata(false)
+        self.flush_metadata(false)?;
+        let fs = self.inner.lock().concret_fs();
+        fs.finish_sync_durability_boundary()
     }
 
     fn datasync(&self) -> Result<(), SystemError> {
@@ -713,7 +715,9 @@ impl IndexNode for LockedExt4Inode {
         if let Some(page_cache) = self.page_cache() {
             page_cache.manager().sync()?;
         }
-        self.flush_metadata(true)
+        self.flush_metadata(true)?;
+        let fs = self.inner.lock().concret_fs();
+        fs.finish_sync_durability_boundary()
     }
 
     fn sync_file(&self, datasync: bool, _data: PrivateData) -> Result<(), SystemError> {
@@ -739,7 +743,9 @@ impl IndexNode for LockedExt4Inode {
                 .manager()
                 .writeback_range(start_index, end_index)?;
         }
-        self.flush_metadata(datasync)
+        self.flush_metadata(datasync)?;
+        let fs = self.inner.lock().concret_fs();
+        fs.finish_sync_durability_boundary()
     }
 
     fn write_inode(&self, _wbc: &vfs::WritebackControl) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -1857,6 +1857,10 @@ impl LockedFATInode {
 }
 
 impl IndexNode for LockedFATInode {
+    fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        Some(self.fs())
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -38,6 +38,10 @@ use super::super::{
 use super::FuseNode;
 
 impl IndexNode for FuseNode {
+    fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        Some(self.fs())
+    }
+
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
     }

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -303,6 +303,10 @@ impl OvlInode {
 }
 
 impl IndexNode for OvlInode {
+    fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        Some(self.fs())
+    }
+
     fn open(
         &self,
         data: crate::libs::mutex::MutexGuard<FilePrivateData>,

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -344,6 +344,10 @@ impl MountableFileSystem for RamFS {
 register_mountable_fs!(RamFS, RAMFSMAKER, "ramfs");
 
 impl IndexNode for LockedRamFSInode {
+    fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        Some(self.fs())
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -734,6 +734,10 @@ impl MountableFileSystem for Tmpfs {
 register_mountable_fs!(Tmpfs, TMPFSMAKER, "tmpfs");
 
 impl IndexNode for LockedTmpfsInode {
+    fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        Some(self.fs())
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/vfs/append_lock.rs
+++ b/kernel/src/filesystem/vfs/append_lock.rs
@@ -8,17 +8,33 @@ use crate::libs::mutex::Mutex;
 
 use super::InodeId;
 
-/// Append lock key: uniquely identifies an inode across filesystems.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct AppendLockKey {
-    /// Device ID
+/// Internal append-lock identity for one inode in one filesystem instance.
+///
+/// `dev_id`/`inode_id` alone are not sufficient: stacked filesystems such as
+/// overlayfs may deliberately expose the backing inode's stat identity while
+/// still owning a distinct inode lock domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(super) struct AppendLockKey {
+    /// Allocation identity of the canonical filesystem instance.
+    fs_instance: usize,
+    /// Device namespace within that filesystem instance.
     dev_id: usize,
-    /// Inode ID
+    /// Inode identity within the device namespace.
     inode_id: InodeId,
 }
 
-/// 这里51个bucket是因为，AppendLockKey的大小加起来刚好小于2048字节，
-/// 内核会分配2K给这个结构体，所以51个bucket刚好合适，避免内部碎片
+impl AppendLockKey {
+    pub(super) const fn new(fs_instance: usize, dev_id: usize, inode_id: InodeId) -> Self {
+        Self {
+            fs_instance,
+            dev_id,
+            inode_id,
+        }
+    }
+}
+
+/// Keep enough shards to avoid a single append-lock map bottleneck without
+/// allocating a large fixed table. Each shard owns its entries dynamically.
 const APPEND_LOCK_SHARDS: usize = 51;
 
 struct AppendLockShard {
@@ -45,9 +61,12 @@ impl AppendLockManager {
     fn shard_index(key: &AppendLockKey) -> usize {
         // Use jhash to compute a stable hash for sharding.
         // Convert usize values to u32 arrays for jhash2.
+        let fs_instance = key.fs_instance as u64;
         let dev_id = key.dev_id as u64;
         let inode_id = key.inode_id.data() as u64;
         let key_array = [
+            (fs_instance >> 32) as u32,
+            fs_instance as u32,
             (dev_id >> 32) as u32,
             dev_id as u32,
             (inode_id >> 32) as u32,
@@ -60,11 +79,10 @@ impl AppendLockManager {
     /// Run `f` while holding the per-inode append lock.
     ///
     /// Notes:
-    /// - Map access is protected by a sharded spinlock to avoid a single global bottleneck.
+    /// - Map access is protected by sharded mutexes to avoid a single global bottleneck.
     /// - The per-inode lock is a sleeping `Mutex` since the critical section may schedule.
     /// - We opportunistically remove the map entry when it becomes unused.
-    pub fn with_lock<R>(&self, dev_id: usize, inode_id: InodeId, f: impl FnOnce() -> R) -> R {
-        let key = AppendLockKey { dev_id, inode_id };
+    fn with_lock<R>(&self, key: AppendLockKey, f: impl FnOnce() -> R) -> R {
         let shard_idx = Self::shard_index(&key);
         let shard = &self.shards[shard_idx];
 
@@ -109,6 +127,37 @@ pub fn init_append_lock_manager() {
 }
 
 #[inline]
-pub fn with_inode_append_lock<R>(dev_id: usize, inode_id: InodeId, f: impl FnOnce() -> R) -> R {
-    APPEND_LOCK_MANAGER.get().with_lock(dev_id, inode_id, f)
+pub(super) fn with_inode_append_lock<R>(key: AppendLockKey, f: impl FnOnce() -> R) -> R {
+    APPEND_LOCK_MANAGER.get().with_lock(key, f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_lock_key_keeps_stacked_filesystem_domains_distinct() {
+        let inode = InodeId::new(42);
+        let overlay = AppendLockKey::new(0x1000, 7, inode);
+        let backing = AppendLockKey::new(0x2000, 7, inode);
+
+        assert_ne!(overlay, backing);
+    }
+
+    #[test]
+    fn append_lock_key_keeps_device_namespaces_distinct() {
+        let inode = InodeId::new(42);
+        let first_origin = AppendLockKey::new(0x1000, 7, inode);
+        let second_origin = AppendLockKey::new(0x1000, 8, inode);
+
+        assert_ne!(first_origin, second_origin);
+    }
+
+    #[test]
+    fn append_lock_key_matches_same_canonical_inode() {
+        let first = AppendLockKey::new(0x1000, 7, InodeId::new(42));
+        let second = AppendLockKey::new(0x1000, 7, InodeId::new(42));
+
+        assert_eq!(first, second);
+    }
 }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -8,11 +8,11 @@ use log::error;
 use system_error::SystemError;
 
 use super::{
-    append_lock::with_inode_append_lock,
+    append_lock::{with_inode_append_lock, AppendLockKey},
     inode_lifecycle::{InodeRetentionGuard, InodeRetentionKind},
     mount::{MountExternalGuard, MountFSInode},
     utils::should_remove_sgid,
-    FileType, IndexNode, InodeId, Metadata, SetMetadataMask, SpecialNodeData,
+    FileSystem, FileType, IndexNode, InodeId, Metadata, SetMetadataMask, SpecialNodeData,
 };
 use crate::{arch::ipc::signal::Signal, filesystem::vfs::InodeFlags, process::pid::PidPrivateData};
 use crate::{
@@ -75,11 +75,30 @@ fn alloc_lock_owner_id() -> usize {
     NEXT_LOCK_OWNER_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-fn canonical_inode_for_posix_lock(mut inode: Arc<dyn IndexNode>) -> Arc<dyn IndexNode> {
+fn canonical_inode_for_file_lock(mut inode: Arc<dyn IndexNode>) -> Arc<dyn IndexNode> {
     loop {
         match inode.clone().downcast_arc::<MountFSInode>() {
             Some(mnt_inode) => inode = mnt_inode.underlying_inode(),
             None => return inode,
+        }
+    }
+}
+
+/// Cached append-lock identity and the owner that keeps its allocation
+/// identity alive. Keeping these fields together prevents callers from
+/// copying a raw filesystem address without also retaining the filesystem.
+#[derive(Clone, Debug)]
+struct AppendLockIdentity {
+    key: AppendLockKey,
+    _fs_owner: Arc<dyn FileSystem>,
+}
+
+impl AppendLockIdentity {
+    fn new(fs_owner: Arc<dyn FileSystem>, metadata: &Metadata) -> Self {
+        let fs_instance = Arc::as_ptr(&fs_owner) as *const () as usize;
+        Self {
+            key: AppendLockKey::new(fs_instance, metadata.dev_id, metadata.inode_id),
+            _fs_owner: fs_owner,
         }
     }
 }
@@ -519,6 +538,9 @@ pub struct File {
     /// Stable key for POSIX record locks. Cached at open time to avoid metadata fetch
     /// in close/drop_fd path (which can deadlock with user-space FUSE daemon).
     posix_lock_key: (usize, InodeId),
+    /// Stable internal identity for serializing atomic append operations.
+    /// Only regular, non-O_PATH files retain one.
+    append_lock_identity: Option<AppendLockIdentity>,
     /// 预读状态
     ra_state: Mutex<FileReadaheadState>,
     /// 当前 open file description 已观测到的 page cache 写回错误序列。
@@ -848,12 +870,19 @@ impl File {
             flags.insert(FileFlags::O_APPEND);
         }
 
-        let canonical_inode = canonical_inode_for_posix_lock(inode.clone());
-        let posix_lock_key = if Arc::ptr_eq(&canonical_inode, &inode) {
-            (metadata.dev_id, metadata.inode_id)
+        let canonical_inode = canonical_inode_for_file_lock(inode.clone());
+        let canonical_metadata = if Arc::ptr_eq(&canonical_inode, &inode) {
+            metadata.clone()
         } else {
-            let lock_md = canonical_inode.metadata()?;
-            (lock_md.dev_id, lock_md.inode_id)
+            canonical_inode.metadata()?
+        };
+        let posix_lock_key = (canonical_metadata.dev_id, canonical_metadata.inode_id);
+        let append_lock_identity = if file_type == FileType::File && !is_path {
+            canonical_inode
+                .append_lock_fs()
+                .map(|fs| AppendLockIdentity::new(fs, &canonical_metadata))
+        } else {
+            None
         };
 
         // O_CLOEXEC 是 per-fd 属性，由 alloc_fd/alloc_fd_arc 的 cloexec 参数控制，
@@ -930,6 +959,7 @@ impl File {
             cred: ProcessManager::current_pcb().cred(),
             owner: Mutex::new(FileOwner::new()),
             posix_lock_key,
+            append_lock_identity,
             ra_state: Mutex::new(FileReadaheadState::new()),
             wb_error_seq: Mutex::new(wb_error_seq),
             sb_error_seq: Mutex::new(sb_error_seq),
@@ -1227,15 +1257,18 @@ impl File {
         let md = self.inode.metadata()?;
         let file_type = md.file_type;
 
-        let is_append = (flags.contains(FileFlags::O_APPEND) || force_append)
-            && matches!(file_type, FileType::File);
+        let is_append = self.append_lock_identity.is_some()
+            && (flags.contains(FileFlags::O_APPEND) || force_append);
 
         // Linux 语义要求 O_APPEND（以及 RWF_APPEND）在并发下满足“取 EOF + 写入”的原子性，
         // 否则多个线程可能拿到相同 EOF 导致覆盖写，最终 size 比预期小。
         if is_append {
-            let dev_id = md.dev_id;
-            let inode_id = md.inode_id;
-            return with_inode_append_lock(dev_id, inode_id, || {
+            let key = self
+                .append_lock_identity
+                .as_ref()
+                .ok_or(SystemError::EIO)?
+                .key;
+            return with_inode_append_lock(key, || {
                 // 在锁内刷新元数据，确保 EOF 是最新的。
                 let md = self.inode.metadata()?;
                 let actual_offset = md.size.max(0) as usize;
@@ -1295,14 +1328,17 @@ impl File {
         let md = self.inode.metadata()?;
         let file_type = md.file_type;
 
-        let is_append = (flags.contains(FileFlags::O_APPEND) || force_append)
-            && matches!(file_type, FileType::File);
+        let is_append = self.append_lock_identity.is_some()
+            && (flags.contains(FileFlags::O_APPEND) || force_append);
 
         // Linux semantics require O_APPEND (and RWF_APPEND) to atomically fetch EOF and write under concurrency.
         if is_append {
-            let dev_id = md.dev_id;
-            let inode_id = md.inode_id;
-            return with_inode_append_lock(dev_id, inode_id, || {
+            let key = self
+                .append_lock_identity
+                .as_ref()
+                .ok_or(SystemError::EIO)?
+                .key;
+            return with_inode_append_lock(key, || {
                 let md = self.inode.metadata()?;
                 let actual_offset = md.size.max(0) as usize;
                 let actual_len = self.limit_write_len_by_fsize(file_type, actual_offset, len)?;
@@ -1571,6 +1607,7 @@ impl File {
             cred: self.cred.clone(),
             owner: Mutex::new(FileOwner::new()),
             posix_lock_key: self.posix_lock_key,
+            append_lock_identity: self.append_lock_identity.clone(),
             ra_state: Mutex::new(self.ra_state.lock().clone()),
             wb_error_seq: Mutex::new(*self.wb_error_seq.lock()),
             sb_error_seq: Mutex::new(*self.sb_error_seq.lock()),

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -84,22 +84,33 @@ fn canonical_inode_for_file_lock(mut inode: Arc<dyn IndexNode>) -> Arc<dyn Index
     }
 }
 
-/// Cached append-lock identity and the owner that keeps its allocation
-/// identity alive. Keeping these fields together prevents callers from
-/// copying a raw filesystem address without also retaining the filesystem.
+/// Append-lock domain and the owner that keeps its allocation identity alive.
+///
+/// The inode part of the key is deliberately derived from current metadata at
+/// write time. A stacked filesystem may change backing identity during open
+/// (for example, overlayfs copy-up), so caching the complete key here can split
+/// concurrent appenders across two locks.
 #[derive(Clone, Debug)]
-struct AppendLockIdentity {
-    key: AppendLockKey,
-    _fs_owner: Arc<dyn FileSystem>,
+struct AppendLockDomain {
+    fs_instance: usize,
+    fs_owner: Arc<dyn FileSystem>,
 }
 
-impl AppendLockIdentity {
-    fn new(fs_owner: Arc<dyn FileSystem>, metadata: &Metadata) -> Self {
+impl AppendLockDomain {
+    fn new(fs_owner: Arc<dyn FileSystem>) -> Self {
         let fs_instance = Arc::as_ptr(&fs_owner) as *const () as usize;
         Self {
-            key: AppendLockKey::new(fs_instance, metadata.dev_id, metadata.inode_id),
-            _fs_owner: fs_owner,
+            fs_instance,
+            fs_owner,
         }
+    }
+
+    fn key(&self, metadata: &Metadata) -> AppendLockKey {
+        debug_assert_eq!(
+            self.fs_instance,
+            Arc::as_ptr(&self.fs_owner) as *const () as usize
+        );
+        AppendLockKey::new(self.fs_instance, metadata.dev_id, metadata.inode_id)
     }
 }
 
@@ -538,9 +549,10 @@ pub struct File {
     /// Stable key for POSIX record locks. Cached at open time to avoid metadata fetch
     /// in close/drop_fd path (which can deadlock with user-space FUSE daemon).
     posix_lock_key: (usize, InodeId),
-    /// Stable internal identity for serializing atomic append operations.
-    /// Only regular, non-O_PATH files retain one.
-    append_lock_identity: Option<AppendLockIdentity>,
+    /// Internal filesystem domain for serializing atomic append operations.
+    /// Only regular, non-O_PATH files retain one; the inode key is resolved
+    /// from current metadata when an append starts.
+    append_lock_domain: Option<AppendLockDomain>,
     /// 预读状态
     ra_state: Mutex<FileReadaheadState>,
     /// 当前 open file description 已观测到的 page cache 写回错误序列。
@@ -877,10 +889,8 @@ impl File {
             canonical_inode.metadata()?
         };
         let posix_lock_key = (canonical_metadata.dev_id, canonical_metadata.inode_id);
-        let append_lock_identity = if file_type == FileType::File && !is_path {
-            canonical_inode
-                .append_lock_fs()
-                .map(|fs| AppendLockIdentity::new(fs, &canonical_metadata))
+        let append_lock_domain = if file_type == FileType::File && !is_path {
+            canonical_inode.append_lock_fs().map(AppendLockDomain::new)
         } else {
             None
         };
@@ -959,7 +969,7 @@ impl File {
             cred: ProcessManager::current_pcb().cred(),
             owner: Mutex::new(FileOwner::new()),
             posix_lock_key,
-            append_lock_identity,
+            append_lock_domain,
             ra_state: Mutex::new(FileReadaheadState::new()),
             wb_error_seq: Mutex::new(wb_error_seq),
             sb_error_seq: Mutex::new(sb_error_seq),
@@ -1281,8 +1291,8 @@ impl File {
                     },
                 )
             };
-            return match self.append_lock_identity.as_ref() {
-                Some(identity) => with_inode_append_lock(identity.key, append_write),
+            return match self.append_lock_domain.as_ref() {
+                Some(domain) => with_inode_append_lock(domain.key(&md), append_write),
                 None => append_write(),
             };
         }
@@ -1350,8 +1360,8 @@ impl File {
                     },
                 )
             };
-            return match self.append_lock_identity.as_ref() {
-                Some(identity) => with_inode_append_lock(identity.key, append_write),
+            return match self.append_lock_domain.as_ref() {
+                Some(domain) => with_inode_append_lock(domain.key(&md), append_write),
                 None => append_write(),
             };
         }
@@ -1606,7 +1616,7 @@ impl File {
             cred: self.cred.clone(),
             owner: Mutex::new(FileOwner::new()),
             posix_lock_key: self.posix_lock_key,
-            append_lock_identity: self.append_lock_identity.clone(),
+            append_lock_domain: self.append_lock_domain.clone(),
             ra_state: Mutex::new(self.ra_state.lock().clone()),
             wb_error_seq: Mutex::new(*self.wb_error_seq.lock()),
             sb_error_seq: Mutex::new(*self.sb_error_seq.lock()),

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1257,18 +1257,13 @@ impl File {
         let md = self.inode.metadata()?;
         let file_type = md.file_type;
 
-        let is_append = self.append_lock_identity.is_some()
+        let is_append = matches!(file_type, FileType::File)
             && (flags.contains(FileFlags::O_APPEND) || force_append);
 
-        // Linux 语义要求 O_APPEND（以及 RWF_APPEND）在并发下满足“取 EOF + 写入”的原子性，
-        // 否则多个线程可能拿到相同 EOF 导致覆盖写，最终 size 比预期小。
+        // 普通文件始终按 EOF 执行 O_APPEND/RWF_APPEND；提供稳定锁域的文件系统
+        // 还会在 VFS 层串行化“取 EOF + 写入”，避免并发追加互相覆盖。
         if is_append {
-            let key = self
-                .append_lock_identity
-                .as_ref()
-                .ok_or(SystemError::EIO)?
-                .key;
-            return with_inode_append_lock(key, || {
+            let append_write = || {
                 // 在锁内刷新元数据，确保 EOF 是最新的。
                 let md = self.inode.metadata()?;
                 let actual_offset = md.size.max(0) as usize;
@@ -1285,7 +1280,11 @@ impl File {
                         inode_flags,
                     },
                 )
-            });
+            };
+            return match self.append_lock_identity.as_ref() {
+                Some(identity) => with_inode_append_lock(identity.key, append_write),
+                None => append_write(),
+            };
         }
 
         let actual_offset = offset;
@@ -1328,17 +1327,13 @@ impl File {
         let md = self.inode.metadata()?;
         let file_type = md.file_type;
 
-        let is_append = self.append_lock_identity.is_some()
+        let is_append = matches!(file_type, FileType::File)
             && (flags.contains(FileFlags::O_APPEND) || force_append);
 
-        // Linux semantics require O_APPEND (and RWF_APPEND) to atomically fetch EOF and write under concurrency.
+        // Always select EOF for regular-file append semantics. Filesystems
+        // with a stable lock domain additionally serialize EOF lookup + write.
         if is_append {
-            let key = self
-                .append_lock_identity
-                .as_ref()
-                .ok_or(SystemError::EIO)?
-                .key;
-            return with_inode_append_lock(key, || {
+            let append_write = || {
                 let md = self.inode.metadata()?;
                 let actual_offset = md.size.max(0) as usize;
                 let actual_len = self.limit_write_len_by_fsize(file_type, actual_offset, len)?;
@@ -1354,7 +1349,11 @@ impl File {
                         inode_flags,
                     },
                 )
-            });
+            };
+            return match self.append_lock_identity.as_ref() {
+                Some(identity) => with_inode_append_lock(identity.key, append_write),
+                None => append_write(),
+            };
         }
 
         let actual_offset = offset;

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -423,6 +423,17 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         }
     }
 
+    /// Return the stable filesystem owner used to identify this inode's
+    /// atomic-append lock domain.
+    ///
+    /// Anonymous and protocol-style inodes default to no append lock: their
+    /// writes do not use regular-file offsets and some do not belong to a
+    /// mountable filesystem at all. Inodes implementing ordinary persistent
+    /// file semantics must opt in with their canonical filesystem instance.
+    fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        None
+    }
+
     /// 是否支持 seek（lseek）。
     ///
     /// 默认：普通文件/目录/块设备可 seek；Pipe/Socket/CharDevice 不可 seek；

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -3609,6 +3609,7 @@ static int ext_test_cached_short_read_updates_eof() {
     char buf[32];
     int f = -1;
     ssize_t n = -1;
+    uint32_t reads_after_short = 0;
 
     if (ensure_dir(mp) != 0) {
         printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
@@ -3679,12 +3680,6 @@ static int ext_test_cached_short_read_updates_eof() {
                read_count, errno);
         goto fail;
     }
-    memset(buf, 0x7f, sizeof(buf));
-    n = pread(f, buf, sizeof(buf), 5);
-    if (n != 0) {
-        printf("[FAIL] EOF cached pread got=%zd read=%u errno=%d\n", n, read_count, errno);
-        goto fail;
-    }
 
     // The second READ is speculative readahead, so the foreground pread must
     // not wait for the daemon to consume it. Wait here before inspecting the
@@ -3700,6 +3695,19 @@ static int ext_test_cached_short_read_updates_eof() {
         printf("[FAIL] short read trace count=%u off0=%llu size0=%u off1=%llu size1=%u\n",
                read_count, (unsigned long long)read_offsets[0], read_sizes[0],
                (unsigned long long)read_offsets[1], read_sizes[1]);
+        goto fail;
+    }
+    reads_after_short = read_count;
+
+    memset(buf, 0x7f, sizeof(buf));
+    n = pread(f, buf, sizeof(buf), 5);
+    if (n != 0) {
+        printf("[FAIL] EOF cached pread got=%zd read=%u errno=%d\n", n, read_count, errno);
+        goto fail;
+    }
+    if (read_count != reads_after_short) {
+        printf("[FAIL] cached EOF issued a new READ before=%u after=%u\n", reads_after_short,
+               read_count);
         goto fail;
     }
 

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_append_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_append_semantics.cc
@@ -1,0 +1,461 @@
+#include <gtest/gtest.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kWaitIterations = 1000;
+constexpr useconds_t kWaitIntervalUs = 10000;
+constexpr size_t kRecordSize = 32;
+
+std::string join_path(const std::string& dir, const char* name) {
+    return dir + "/" + name;
+}
+
+void remove_recursive(const std::string& path) {
+    struct stat st = {};
+    if (lstat(path.c_str(), &st) != 0) {
+        return;
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        unlink(path.c_str());
+        return;
+    }
+
+    DIR* dir = opendir(path.c_str());
+    if (dir != nullptr) {
+        while (dirent* ent = readdir(dir)) {
+            if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0) {
+                continue;
+            }
+            remove_recursive(join_path(path, ent->d_name));
+        }
+        closedir(dir);
+    }
+    rmdir(path.c_str());
+}
+
+bool write_all(int fd, const void* data, size_t len) {
+    const char* current = static_cast<const char*>(data);
+    while (len != 0) {
+        ssize_t written = write(fd, current, len);
+        if (written < 0 && errno == EINTR) {
+            continue;
+        }
+        if (written <= 0) {
+            return false;
+        }
+        current += written;
+        len -= static_cast<size_t>(written);
+    }
+    return true;
+}
+
+[[noreturn]] void exit_after_blocked_child(pid_t child) {
+    kill(child, SIGKILL);
+    fprintf(stderr, "append operation did not return within 10 seconds\n");
+    _exit(124);
+}
+
+template <typename Operation>
+bool run_child_bounded(Operation operation) {
+    pid_t child = fork();
+    if (child < 0) {
+        return false;
+    }
+    if (child == 0) {
+        _exit(operation() ? 0 : 1);
+    }
+
+    for (int attempt = 0; attempt < kWaitIterations; ++attempt) {
+        int status = 0;
+        pid_t result = waitpid(child, &status, WNOHANG);
+        if (result == child) {
+            return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+        }
+        if (result < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            kill(child, SIGKILL);
+            return false;
+        }
+        usleep(kWaitIntervalUs);
+    }
+    exit_after_blocked_child(child);
+}
+
+std::array<char, kRecordSize> make_record(int writer, int sequence) {
+    std::array<char, kRecordSize> record = {};
+    int prefix = snprintf(
+        record.data(), record.size(), "writer=%02d sequence=%03d", writer, sequence);
+    if (prefix < 0 || static_cast<size_t>(prefix) >= record.size()) {
+        return {};
+    }
+    for (size_t i = static_cast<size_t>(prefix); i < record.size(); ++i) {
+        record[i] = '#';
+    }
+    return record;
+}
+
+bool wait_for_children_bounded(const std::vector<pid_t>& children) {
+    std::set<pid_t> remaining(children.begin(), children.end());
+    bool success = true;
+    for (int attempt = 0; attempt < kWaitIterations && !remaining.empty(); ++attempt) {
+        for (auto it = remaining.begin(); it != remaining.end();) {
+            int status = 0;
+            pid_t result = waitpid(*it, &status, WNOHANG);
+            if (result == *it) {
+                if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+                    success = false;
+                }
+                it = remaining.erase(it);
+            } else if (result < 0) {
+                if (errno == EINTR) {
+                    ++it;
+                } else {
+                    success = false;
+                    it = remaining.erase(it);
+                }
+            } else {
+                ++it;
+            }
+        }
+        if (!remaining.empty()) {
+            usleep(kWaitIntervalUs);
+        }
+    }
+    if (!remaining.empty()) {
+        for (pid_t child : remaining) {
+            kill(child, SIGKILL);
+        }
+        fprintf(stderr, "concurrent append operations did not return within 10 seconds\n");
+        _exit(124);
+    }
+    return success;
+}
+
+std::set<std::string> expected_records(int writers, int records_per_writer) {
+    std::set<std::string> expected;
+    for (int writer = 0; writer < writers; ++writer) {
+        for (int sequence = 0; sequence < records_per_writer; ++sequence) {
+            const auto record = make_record(writer, sequence);
+            expected.emplace(record.data(), record.size());
+        }
+    }
+    return expected;
+}
+
+std::string read_file(const std::string& path) {
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        return {};
+    }
+
+    std::string result;
+    std::array<char, 4096> buffer = {};
+    for (;;) {
+        ssize_t count = read(fd, buffer.data(), buffer.size());
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        if (count <= 0) {
+            break;
+        }
+        result.append(buffer.data(), static_cast<size_t>(count));
+    }
+    close(fd);
+    return result;
+}
+
+class OverlayAppendEnv {
+public:
+    explicit OverlayAppendEnv(const char* name) {
+        root = std::string("/tmp/") + name + "_" + std::to_string(getpid());
+        upper = join_path(root, "upper");
+        lower = join_path(root, "lower");
+        work = join_path(root, "work");
+        merged = join_path(root, "merged");
+    }
+
+    ~OverlayAppendEnv() {
+        if (mounted) {
+            umount(merged.c_str());
+        }
+        remove_recursive(root);
+    }
+
+    bool setup() {
+        if (mkdir(root.c_str(), 0755) != 0 || mkdir(upper.c_str(), 0755) != 0
+            || mkdir(lower.c_str(), 0755) != 0 || mkdir(work.c_str(), 0755) != 0
+            || mkdir(merged.c_str(), 0755) != 0) {
+            return false;
+        }
+
+        std::string options =
+            "lowerdir=" + lower + ",upperdir=" + upper + ",workdir=" + work;
+        if (mount("overlay", merged.c_str(), "overlay", 0, options.c_str()) != 0) {
+            return false;
+        }
+        mounted = true;
+        return true;
+    }
+
+    std::string root;
+    std::string upper;
+    std::string lower;
+    std::string work;
+    std::string merged;
+    bool mounted = false;
+};
+
+TEST(OverlayFsAppend, ReopenPureUpperFileDoesNotDeadlock) {
+    OverlayAppendEnv env("overlay_append_reopen");
+    ASSERT_TRUE(env.setup()) << strerror(errno);
+    const std::string merged_file = join_path(env.merged, "history");
+    const std::string upper_file = join_path(env.upper, "history");
+
+    int fd = open(merged_file.c_str(), O_CREAT | O_WRONLY | O_APPEND, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_TRUE(write_all(fd, "first\n", 6)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+
+    ASSERT_TRUE(run_child_bounded([&]() {
+        int append_fd = open(merged_file.c_str(), O_WRONLY | O_APPEND);
+        if (append_fd < 0) {
+            return false;
+        }
+        bool ok = write_all(append_fd, "second\n", 7);
+        return close(append_fd) == 0 && ok;
+    }));
+
+    EXPECT_EQ("first\nsecond\n", read_file(merged_file));
+    EXPECT_EQ("first\nsecond\n", read_file(upper_file));
+}
+
+TEST(OverlayFsAppend, ZeroLengthWriteAfterReopenReturns) {
+    OverlayAppendEnv env("overlay_append_zero");
+    ASSERT_TRUE(env.setup()) << strerror(errno);
+    const std::string path = join_path(env.merged, "file");
+
+    int fd = open(path.c_str(), O_CREAT | O_WRONLY | O_APPEND, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_TRUE(write_all(fd, "data", 4));
+    ASSERT_EQ(0, close(fd));
+
+    ASSERT_TRUE(run_child_bounded([&]() {
+        int append_fd = open(path.c_str(), O_WRONLY | O_APPEND);
+        if (append_fd < 0 || write(append_fd, "", 0) != 0) {
+            return false;
+        }
+        bool ok = write_all(append_fd, "!", 1);
+        return close(append_fd) == 0 && ok;
+    }));
+    EXPECT_EQ("data!", read_file(path));
+}
+
+TEST(OverlayFsAppend, PwriteStillAppendsWithoutChangingFilePosition) {
+    OverlayAppendEnv env("overlay_append_pwrite");
+    ASSERT_TRUE(env.setup()) << strerror(errno);
+    const std::string path = join_path(env.merged, "file");
+
+    ASSERT_TRUE(run_child_bounded([&]() {
+        int fd = open(path.c_str(), O_CREAT | O_RDWR | O_APPEND, 0644);
+        if (fd < 0 || !write_all(fd, "abc", 3) || lseek(fd, 1, SEEK_SET) != 1
+            || pwrite(fd, "X", 1, 0) != 1 || lseek(fd, 0, SEEK_CUR) != 1) {
+            return false;
+        }
+        return close(fd) == 0;
+    }));
+
+    EXPECT_EQ("abcX", read_file(path));
+}
+
+TEST(OverlayFsAppend, FSetFlControlsAppendAtOverlayLayer) {
+    OverlayAppendEnv env("overlay_append_setfl");
+    ASSERT_TRUE(env.setup()) << strerror(errno);
+    const std::string path = join_path(env.merged, "file");
+
+    ASSERT_TRUE(run_child_bounded([&]() {
+        int fd = open(path.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+        if (fd < 0 || !write_all(fd, "abcd", 4)) {
+            return false;
+        }
+        int flags = fcntl(fd, F_GETFL);
+        if (flags < 0 || fcntl(fd, F_SETFL, flags | O_APPEND) != 0
+            || (fcntl(fd, F_GETFL) & O_APPEND) == 0 || lseek(fd, 1, SEEK_SET) != 1
+            || !write_all(fd, "X", 1)) {
+            return false;
+        }
+        flags = fcntl(fd, F_GETFL);
+        if (flags < 0 || fcntl(fd, F_SETFL, flags & ~O_APPEND) != 0
+            || (fcntl(fd, F_GETFL) & O_APPEND) != 0 || lseek(fd, 1, SEEK_SET) != 1
+            || !write_all(fd, "Y", 1)) {
+            return false;
+        }
+        return close(fd) == 0;
+    }));
+
+    EXPECT_EQ("aYcdX", read_file(path));
+}
+
+TEST(OverlayFsAppend, IndependentOpenFilesAppendWholeRecords) {
+    constexpr int kWriters = 4;
+    constexpr int kRecordsPerWriter = 24;
+
+    OverlayAppendEnv env("overlay_append_concurrent");
+    ASSERT_TRUE(env.setup()) << strerror(errno);
+    const std::string path = join_path(env.merged, "records");
+
+    int initial = open(path.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    ASSERT_GE(initial, 0) << strerror(errno);
+    ASSERT_EQ(0, close(initial));
+
+    int start_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(start_pipe)) << strerror(errno);
+    std::vector<pid_t> children;
+
+    for (int writer = 0; writer < kWriters; ++writer) {
+        pid_t child = fork();
+        ASSERT_GE(child, 0) << strerror(errno);
+        if (child == 0) {
+            close(start_pipe[1]);
+            char token = 0;
+            if (read(start_pipe[0], &token, 1) != 1) {
+                _exit(10);
+            }
+            close(start_pipe[0]);
+
+            int fd = open(path.c_str(), O_WRONLY | O_APPEND);
+            if (fd < 0) {
+                _exit(11);
+            }
+            for (int sequence = 0; sequence < kRecordsPerWriter; ++sequence) {
+                const auto record = make_record(writer, sequence);
+                if (write(fd, record.data(), record.size()) != static_cast<ssize_t>(record.size())) {
+                    _exit(13);
+                }
+            }
+            close(fd);
+            _exit(0);
+        }
+        children.push_back(child);
+    }
+
+    close(start_pipe[0]);
+    std::array<char, kWriters> tokens = {};
+    ASSERT_TRUE(write_all(start_pipe[1], tokens.data(), tokens.size()));
+    close(start_pipe[1]);
+
+    ASSERT_TRUE(wait_for_children_bounded(children));
+
+    const std::string content = read_file(path);
+    ASSERT_EQ(
+        static_cast<size_t>(kWriters * kRecordsPerWriter) * kRecordSize, content.size());
+    std::set<std::string> records;
+    for (size_t offset = 0; offset < content.size(); offset += kRecordSize) {
+        records.insert(content.substr(offset, kRecordSize));
+    }
+    EXPECT_EQ(expected_records(kWriters, kRecordsPerWriter), records);
+}
+
+TEST(OverlayFsAppend, HardlinksShareAtomicAppendDomain) {
+    constexpr int kWriters = 2;
+    constexpr int kRecordsPerWriter = 16;
+
+    OverlayAppendEnv env("overlay_append_hardlink");
+    ASSERT_TRUE(env.setup()) << strerror(errno);
+    const std::string first = join_path(env.merged, "records");
+    const std::string alias = join_path(env.merged, "records_alias");
+
+    int initial = open(first.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    ASSERT_GE(initial, 0) << strerror(errno);
+    ASSERT_EQ(0, close(initial));
+    ASSERT_EQ(0, link(first.c_str(), alias.c_str())) << strerror(errno);
+
+    int start_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(start_pipe)) << strerror(errno);
+    std::vector<pid_t> children;
+    const std::array<std::string, kWriters> paths = {first, alias};
+    for (int writer = 0; writer < kWriters; ++writer) {
+        pid_t child = fork();
+        ASSERT_GE(child, 0) << strerror(errno);
+        if (child == 0) {
+            close(start_pipe[1]);
+            char token = 0;
+            if (read(start_pipe[0], &token, 1) != 1) {
+                _exit(10);
+            }
+            close(start_pipe[0]);
+            int append_fd = open(paths[writer].c_str(), O_WRONLY | O_APPEND);
+            if (append_fd < 0) {
+                _exit(11);
+            }
+            for (int sequence = 0; sequence < kRecordsPerWriter; ++sequence) {
+                const auto record = make_record(writer, sequence);
+                if (write(append_fd, record.data(), record.size())
+                    != static_cast<ssize_t>(record.size())) {
+                    _exit(12);
+                }
+            }
+            close(append_fd);
+            _exit(0);
+        }
+        children.push_back(child);
+    }
+    close(start_pipe[0]);
+    std::array<char, kWriters> tokens = {};
+    ASSERT_TRUE(write_all(start_pipe[1], tokens.data(), tokens.size()));
+    close(start_pipe[1]);
+    ASSERT_TRUE(wait_for_children_bounded(children));
+
+    const std::string content = read_file(first);
+    ASSERT_EQ(static_cast<size_t>(kWriters * kRecordsPerWriter) * kRecordSize, content.size());
+    std::set<std::string> records;
+    for (size_t offset = 0; offset < content.size(); offset += kRecordSize) {
+        records.insert(content.substr(offset, kRecordSize));
+    }
+    EXPECT_EQ(expected_records(kWriters, kRecordsPerWriter), records);
+    EXPECT_EQ(content, read_file(alias));
+}
+
+TEST(AppendLockCapability, EventFdIgnoresAppendFilePosition) {
+    int fd = eventfd(0, 0);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    int flags = fcntl(fd, F_GETFL);
+    ASSERT_GE(flags, 0) << strerror(errno);
+    ASSERT_EQ(0, fcntl(fd, F_SETFL, flags | O_APPEND)) << strerror(errno);
+
+    uint64_t value = 1;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(value)), write(fd, &value, sizeof(value)))
+        << strerror(errno);
+    value = 0;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(value)), read(fd, &value, sizeof(value)))
+        << strerror(errno);
+    EXPECT_EQ(1U, value);
+    EXPECT_EQ(0, close(fd));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/overlayfs_append_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/overlayfs_append_semantics.cc
@@ -1,3 +1,7 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <gtest/gtest.h>
 
 #include <dirent.h>
@@ -11,6 +15,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -202,13 +207,17 @@ public:
         remove_recursive(root);
     }
 
-    bool setup() {
+    bool prepare() {
         if (mkdir(root.c_str(), 0755) != 0 || mkdir(upper.c_str(), 0755) != 0
             || mkdir(lower.c_str(), 0755) != 0 || mkdir(work.c_str(), 0755) != 0
             || mkdir(merged.c_str(), 0755) != 0) {
             return false;
         }
 
+        return true;
+    }
+
+    bool mount_overlay() {
         std::string options =
             "lowerdir=" + lower + ",upperdir=" + upper + ",workdir=" + work;
         if (mount("overlay", merged.c_str(), "overlay", 0, options.c_str()) != 0) {
@@ -216,6 +225,10 @@ public:
         }
         mounted = true;
         return true;
+    }
+
+    bool setup() {
+        return prepare() && mount_overlay();
     }
 
     std::string root;
@@ -434,6 +447,81 @@ TEST(OverlayFsAppend, HardlinksShareAtomicAppendDomain) {
     }
     EXPECT_EQ(expected_records(kWriters, kRecordsPerWriter), records);
     EXPECT_EQ(content, read_file(alias));
+}
+
+TEST(OverlayFsAppend, LowerHardlinkCopyUpKeepsRwfAppendAtomic) {
+    constexpr int kWriters = 4;
+    constexpr int kRecordsPerWriter = 64;
+
+    OverlayAppendEnv env("overlay_append_copyup_rwf");
+    ASSERT_TRUE(env.prepare()) << strerror(errno);
+    const std::string lower_file = join_path(env.lower, "records");
+    const std::string lower_alias = join_path(env.lower, "records_alias");
+    int initial = open(lower_file.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    ASSERT_GE(initial, 0) << strerror(errno);
+    ASSERT_EQ(0, close(initial)) << strerror(errno);
+    // A multiply-linked lower inode cannot use the origin xattr identity.
+    // The first writable open therefore changes stat identity during copy-up.
+    ASSERT_EQ(0, link(lower_file.c_str(), lower_alias.c_str())) << strerror(errno);
+    ASSERT_TRUE(env.mount_overlay()) << strerror(errno);
+
+    const std::string path = join_path(env.merged, "records");
+    std::array<int, kWriters> append_fds = {-1, -1};
+    // fd 0 opens the lower inode and triggers copy-up; later opens observe the
+    // resulting upper inode. None carries O_APPEND, so only RWF_APPEND supplies
+    // append semantics and no backing-file append lock can mask a split
+    // overlay lock domain.
+    for (int& fd : append_fds) {
+        fd = open(path.c_str(), O_WRONLY);
+        ASSERT_GE(fd, 0) << strerror(errno);
+    }
+
+    int start_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(start_pipe)) << strerror(errno);
+    std::vector<pid_t> children;
+    for (int writer = 0; writer < kWriters; ++writer) {
+        pid_t child = fork();
+        ASSERT_GE(child, 0) << strerror(errno);
+        if (child == 0) {
+            close(start_pipe[1]);
+            char token = 0;
+            if (read(start_pipe[0], &token, 1) != 1) {
+                _exit(10);
+            }
+            close(start_pipe[0]);
+            for (int sequence = 0; sequence < kRecordsPerWriter; ++sequence) {
+                sched_yield();
+                const auto record = make_record(writer, sequence);
+                iovec iov = {
+                    .iov_base = const_cast<char*>(record.data()),
+                    .iov_len = record.size(),
+                };
+                if (pwritev2(append_fds[writer], &iov, 1, 0, RWF_APPEND)
+                    != static_cast<ssize_t>(record.size())) {
+                    _exit(11);
+                }
+            }
+            _exit(0);
+        }
+        children.push_back(child);
+    }
+
+    close(start_pipe[0]);
+    std::array<char, kWriters> tokens = {};
+    ASSERT_TRUE(write_all(start_pipe[1], tokens.data(), tokens.size()));
+    close(start_pipe[1]);
+    ASSERT_TRUE(wait_for_children_bounded(children));
+    for (int fd : append_fds) {
+        ASSERT_EQ(0, close(fd)) << strerror(errno);
+    }
+
+    const std::string content = read_file(path);
+    ASSERT_EQ(static_cast<size_t>(kWriters * kRecordsPerWriter) * kRecordSize, content.size());
+    std::set<std::string> records;
+    for (size_t offset = 0; offset < content.size(); offset += kRecordSize) {
+        records.insert(content.substr(offset, kRecordSize));
+    }
+    EXPECT_EQ(expected_records(kWriters, kRecordsPerWriter), records);
 }
 
 TEST(AppendLockCapability, EventFdIgnoresAppendFilePosition) {

--- a/user/apps/tests/dunitest/suites/normal/sysfs_cgroup2_mount.cc
+++ b/user/apps/tests/dunitest/suites/normal/sysfs_cgroup2_mount.cc
@@ -332,6 +332,36 @@ TEST(SysfsCgroup2Mount, CubeAgentUnifiedCgroupSequenceSucceeds) {
     });
 }
 
+TEST(SysfsCgroup2Mount, AppendWritesKeepUsingPseudoFileEof) {
+    run_in_child("AppendWritesKeepUsingPseudoFileEof", [](int detail_fd) {
+        make_private_mount_namespace(detail_fd);
+        mount_sysfs_on_sys(detail_fd);
+
+        ensure_dir_recursive(detail_fd, "/sys/fs/cgroup");
+        if (mount("cgroup2",
+                  "/sys/fs/cgroup",
+                  "cgroup2",
+                  MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RELATIME,
+                  "nsdelegate") != 0) {
+            child_fail(detail_fd, "mount cgroup2 /sys/fs/cgroup");
+        }
+
+        int fd = open("/sys/fs/cgroup/cgroup.procs", O_WRONLY | O_APPEND);
+        if (fd < 0) {
+            child_fail(detail_fd, "open cgroup.procs O_APPEND");
+        }
+        static constexpr char kCurrentTask[] = "0\n";
+        for (int i = 0; i < 2; ++i) {
+            if (write(fd, kCurrentTask, sizeof(kCurrentTask) - 1) !=
+                static_cast<ssize_t>(sizeof(kCurrentTask) - 1)) {
+                close(fd);
+                child_fail(detail_fd, "write cgroup.procs O_APPEND");
+            }
+        }
+        close(fd);
+    });
+}
+
 TEST(SysfsCgroup2Mount, Cgroup2P1ControllerFilesFollowSubtreeControl) {
     run_in_child("Cgroup2P1ControllerFilesFollowSubtreeControl", [](int detail_fd) {
         make_private_mount_namespace(detail_fd);


### PR DESCRIPTION
## Summary

- support writable CubeSandbox ext4 volumes that use `metadata_csum_seed` without an internal journal
- keep the default rootfs manifest architecture-neutral so x86_64, riscv64, and loongarch64 CI use compatible inputs
- separate VFS append-lock domains across overlayfs and its backing filesystem while preserving atomic append semantics
- add bounded regression coverage for overlay reopen, `pwrite`, `F_SETFL`, concurrent append, hard links, and eventfd behavior

## Root causes

CubeSandbox exposed three related integration failures:

1. Data volumes use ext4 `metadata_csum_seed` and may omit `has_journal`. DragonOS rejected the checksum-seed incompat feature and initialized JBD2 unconditionally for writable mounts, so `/dev/vda` and `/dev/vdb` failed to mount with `EIO`.
2. Selecting the x86_64 Ubuntu rootfs manifest as the repository-wide default made riscv64 and loongarch64 validation fail before compilation and selected an unavailable Docker-backed path in CI.
3. Overlayfs may publish the backing inode's device and inode numbers while retaining a distinct internal lock domain. The VFS append mutex used only those user-visible numbers, so a reopened overlay append recursively acquired the same mutex when it reached the backing file. BusyBox then blocked while updating `.ash_history` before executing the next command.

## Design

- apply Linux-compatible checksum seed selection consistently across ext4 metadata
- select explicit read-only, journal-backed, and serialized direct-metadata transaction modes
- implement nojournal dirty/clean lifecycle, orphan handling, fail-stop behavior, and mount-option validation
- retain the architecture-neutral rootfs default while keeping Ubuntu 24.04 available through an explicit manifest override
- identify append locks by canonical filesystem allocation, device namespace, and inode identity
- retain the filesystem owner for the cached lock identity lifetime to prevent address reuse
- let persistent filesystem inodes opt in through `IndexNode::append_lock_fs`; anonymous protocol inodes retain their native write semantics

The append fix preserves backing `O_APPEND` and layered filesystem locking. It does not use recursive locks, retries, timeouts, polling, or path-specific exceptions.

## Impact

- CubeSandbox ext4 data volumes mount and mutate with the expected checksum and durability semantics
- all supported CI architectures retain a compatible default rootfs configuration
- BusyBox interactive shells no longer deadlock while appending overlay-backed command history
- direct upper-file writers and overlay writers still converge on the backing filesystem append lock

## Validation

- `cargo test --manifest-path kernel/crates/another_ext4/Cargo.toml` — 107 tests passed
- ext4 image integration suite, including remount and `e2fsck -fn`
- `make fmt`
- `ARCH={x86_64,riscv64,loongarch64} FMT_CHECK=1 make fmt`
- `ARCH={x86_64,riscv64,loongarch64} make all -j$(nproc)`
- kernel static tests for x86_64, riscv64, and loongarch64
- `overlayfs_append_semantics_test` — 7 tests passed
- deployed the resulting kernel to the CubeSandbox test machine
- repeated `cubecli multirun` smoke tests returned code 200
- interactive `ls`, `uname -a`, command-history append, and repeated overlay append completed successfully
