### PR TITLE
feat(fuse): implement virtiofs DAX mapping lifecycle

### DIFF
--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -25,17 +25,18 @@ use crate::{
     process::ProcessManager,
 };
 
-use super::virtiofs::dax::DaxRangeAllocator;
+use super::virtiofs::dax::{DaxMountMode, DaxRangeAllocator, DAX_RANGE_SIZE};
 use crate::process::cred::CAPFlags;
 
 use super::protocol::{
     FuseInHeader, FuseWriteIn, FUSE_ABORT_ERROR, FUSE_ASYNC_DIO, FUSE_ASYNC_READ,
     FUSE_ATOMIC_O_TRUNC, FUSE_AUTO_INVAL_DATA, FUSE_BIG_WRITES, FUSE_DESTROY, FUSE_DONT_MASK,
     FUSE_DO_READDIRPLUS, FUSE_EXPLICIT_INVAL_DATA, FUSE_EXPORT_SUPPORT, FUSE_FORGET, FUSE_FSYNC,
-    FUSE_FSYNCDIR, FUSE_GETXATTR, FUSE_HANDLE_KILLPRIV, FUSE_HAS_EXPIRE_ONLY, FUSE_INIT_EXT,
-    FUSE_INTERRUPT, FUSE_LISTXATTR, FUSE_MAX_PAGES, FUSE_NO_OPENDIR_SUPPORT, FUSE_NO_OPEN_SUPPORT,
-    FUSE_PARALLEL_DIROPS, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO,
-    FUSE_REMOVEXATTR, FUSE_SETXATTR, FUSE_SUBMOUNTS, FUSE_WRITEBACK_CACHE,
+    FUSE_FSYNCDIR, FUSE_GETXATTR, FUSE_HANDLE_KILLPRIV, FUSE_HAS_EXPIRE_ONLY, FUSE_HAS_INODE_DAX,
+    FUSE_INIT_EXT, FUSE_INTERRUPT, FUSE_LISTXATTR, FUSE_MAP_ALIGNMENT, FUSE_MAX_PAGES,
+    FUSE_NO_OPENDIR_SUPPORT, FUSE_NO_OPEN_SUPPORT, FUSE_PARALLEL_DIROPS, FUSE_POSIX_ACL,
+    FUSE_POSIX_LOCKS, FUSE_READDIRPLUS_AUTO, FUSE_REMOVEXATTR, FUSE_SETXATTR, FUSE_SUBMOUNTS,
+    FUSE_WRITEBACK_CACHE,
 };
 use super::reply::{FuseReadPagesReply, FuseReply};
 use super::{stats, trace};
@@ -43,6 +44,7 @@ use super::{stats, trace};
 mod daemon;
 mod request;
 pub(crate) use request::BackgroundReadPagesCtx;
+pub(crate) use request::FuseDaxRequestOutcome;
 
 fn wait_with_recheck<T, F>(waitq: &WaitQueue, mut check: F) -> Result<T, SystemError>
 where
@@ -209,6 +211,7 @@ pub struct FusePendingState {
     wait: WaitQueue,
     background_credit: Mutex<Option<FuseBackgroundCredit>>,
     read_completion: Option<FuseReadCompletion>,
+    outcome_unknown: AtomicBool,
 }
 
 #[derive(Debug)]
@@ -369,8 +372,17 @@ impl FuseBackgroundState {
 enum PendingCompletion {
     Waiting,
     Completing,
-    Ready(Result<FusePendingResult, SystemError>),
+    Ready(Result<FusePendingResult, SystemError>, FuseCompletionKind),
     Consumed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FuseCompletionKind {
+    Success,
+    NeverSubmitted,
+    DaemonError,
+    OutcomeUnknown,
+    Disconnected,
 }
 
 #[derive(Debug)]
@@ -402,6 +414,7 @@ impl FusePendingState {
             wait: WaitQueue::default(),
             background_credit: Mutex::new(background_credit),
             read_completion,
+            outcome_unknown: AtomicBool::new(false),
         }
     }
 
@@ -410,17 +423,50 @@ impl FusePendingState {
     }
 
     pub fn complete(&self, v: Result<FuseReply, SystemError>) -> bool {
-        self.complete_result(v.map(FusePendingResult::Reply))
+        let kind = if v.is_ok() {
+            FuseCompletionKind::Success
+        } else {
+            FuseCompletionKind::OutcomeUnknown
+        };
+        self.complete_result(v.map(FusePendingResult::Reply), kind)
+    }
+
+    pub(crate) fn complete_daemon_error(&self, error: SystemError) -> bool {
+        let kind = if self.outcome_unknown.load(Ordering::Acquire) {
+            FuseCompletionKind::OutcomeUnknown
+        } else {
+            FuseCompletionKind::DaemonError
+        };
+        self.complete_result(Err(error), kind)
+    }
+
+    pub(crate) fn complete_never_submitted(&self, error: SystemError) -> bool {
+        self.complete_result(Err(error), FuseCompletionKind::NeverSubmitted)
+    }
+
+    pub(crate) fn complete_disconnected(&self, error: SystemError) -> bool {
+        self.complete_result(Err(error), FuseCompletionKind::Disconnected)
+    }
+
+    pub(crate) fn mark_outcome_unknown(&self) {
+        self.outcome_unknown.store(true, Ordering::Release);
     }
 
     /// Complete a page-cache read whose payload was written into its owned
     /// destination.  This deliberately shares the ordinary pending state so
     /// duplicate replies, disconnect and teardown have one retirement point.
     pub(crate) fn complete_read_pages_direct(&self, bytes: usize) -> bool {
-        self.complete_result(Ok(FusePendingResult::ReadPagesDirect { bytes }))
+        self.complete_result(
+            Ok(FusePendingResult::ReadPagesDirect { bytes }),
+            FuseCompletionKind::Success,
+        )
     }
 
-    fn complete_result(&self, mut v: Result<FusePendingResult, SystemError>) -> bool {
+    fn complete_result(
+        &self,
+        mut v: Result<FusePendingResult, SystemError>,
+        mut kind: FuseCompletionKind,
+    ) -> bool {
         let mut guard = self.response.lock();
         if !matches!(*guard, PendingCompletion::Waiting) {
             // Duplicate replies are ignored (Linux does similarly).
@@ -431,11 +477,12 @@ impl FusePendingState {
         if let Some(completion) = &self.read_completion {
             if let Err(error) = completion.finish(&v) {
                 v = Err(error);
+                kind = FuseCompletionKind::OutcomeUnknown;
             }
             completion.release_open_pin();
         }
         let mut guard = self.response.lock();
-        *guard = PendingCompletion::Ready(v);
+        *guard = PendingCompletion::Ready(v, kind);
         drop(guard);
         // Linux releases a background slot at request completion, not when a
         // waiter later consumes the result.  Taking the token makes this
@@ -467,9 +514,9 @@ impl FusePendingState {
     fn wait_read_pages_once(&self) -> FuseReadWaitOutcome {
         let take_ready = || {
             let mut guard = self.response.lock();
-            if matches!(*guard, PendingCompletion::Ready(_)) {
+            if matches!(*guard, PendingCompletion::Ready(_, _)) {
                 let ready = core::mem::replace(&mut *guard, PendingCompletion::Consumed);
-                if let PendingCompletion::Ready(result) = ready {
+                if let PendingCompletion::Ready(result, _) = ready {
                     return Some(result.map(|result| match result {
                         FusePendingResult::Reply(reply) => FuseReadPagesReply::Contiguous(reply),
                         FusePendingResult::ReadPagesDirect { bytes } => {
@@ -502,14 +549,58 @@ impl FusePendingState {
     fn wait_result(&self) -> Result<FusePendingResult, SystemError> {
         wait_with_recheck(&self.wait, || {
             let mut guard = self.response.lock();
-            if matches!(*guard, PendingCompletion::Ready(_)) {
+            if matches!(*guard, PendingCompletion::Ready(_, _)) {
                 let ready = core::mem::replace(&mut *guard, PendingCompletion::Consumed);
-                if let PendingCompletion::Ready(res) = ready {
+                if let PendingCompletion::Ready(res, _) = ready {
                     return Ok(Some(res));
                 }
             }
             Ok(None)
         })?
+    }
+
+    pub(crate) fn wait_result_with_kind(
+        &self,
+    ) -> Result<(Result<FusePendingResult, SystemError>, FuseCompletionKind), SystemError> {
+        wait_with_recheck(&self.wait, || {
+            let mut guard = self.response.lock();
+            if matches!(*guard, PendingCompletion::Ready(_, _)) {
+                let ready = core::mem::replace(&mut *guard, PendingCompletion::Consumed);
+                if let PendingCompletion::Ready(result, kind) = ready {
+                    return Ok(Some((result, kind)));
+                }
+            }
+            Ok(None)
+        })
+    }
+
+    pub(crate) fn wait_result_with_kind_uninterruptible(
+        &self,
+    ) -> Result<(Result<FusePendingResult, SystemError>, FuseCompletionKind), SystemError> {
+        let take_ready = || {
+            let mut guard = self.response.lock();
+            if matches!(*guard, PendingCompletion::Ready(_, _)) {
+                let ready = core::mem::replace(&mut *guard, PendingCompletion::Consumed);
+                if let PendingCompletion::Ready(result, kind) = ready {
+                    return Some((result, kind));
+                }
+            }
+            None
+        };
+        if let Some(result) = take_ready() {
+            return Ok(result);
+        }
+        loop {
+            let (waiter, waker) = Waiter::new_pair();
+            self.wait.register_waker(waker.clone())?;
+            if let Some(result) = take_ready() {
+                self.wait.remove_waker(&waker);
+                return Ok(result);
+            }
+            // Mapping lifecycle state may not be released until the request has
+            // a terminal result. Signals are therefore deliberately ignored.
+            waiter.wait(false)?;
+        }
     }
 }
 
@@ -521,6 +612,7 @@ struct FuseInitNegotiated {
     time_gran: u32,
     max_pages: u16,
     flags: u64,
+    map_alignment: u16,
 }
 
 impl Default for FuseInitNegotiated {
@@ -533,6 +625,7 @@ impl Default for FuseInitNegotiated {
             time_gran: 0,
             max_pages: FuseConn::DEFAULT_MAX_PAGES as u16,
             flags: 0,
+            map_alignment: 0,
         }
     }
 }
@@ -614,13 +707,14 @@ impl FuseConn {
     }
 
     pub fn new_for_virtiofs(max_request_size: usize, max_reply_size: usize) -> Arc<Self> {
-        Self::new_for_virtiofs_with_dax(max_request_size, max_reply_size, None)
+        Self::new_for_virtiofs_with_dax(max_request_size, max_reply_size, None, DaxMountMode::Never)
     }
 
     pub(crate) fn new_for_virtiofs_with_dax(
         max_request_size: usize,
         max_reply_size: usize,
         cache_window_len: Option<usize>,
+        dax_mode: DaxMountMode,
     ) -> Arc<Self> {
         let overhead = size_of::<FuseInHeader>() + size_of::<FuseWriteIn>();
         let cap = if max_request_size > overhead {
@@ -628,7 +722,11 @@ impl FuseConn {
         } else {
             Self::MIN_MAX_WRITE
         };
-        let dax_allocator = cache_window_len.and_then(|len| match DaxRangeAllocator::new(len) {
+        let dax_allocator = (dax_mode != DaxMountMode::Never)
+            .then_some(cache_window_len)
+            .flatten()
+            .filter(|len| *len >= DAX_RANGE_SIZE)
+            .and_then(|len| match DaxRangeAllocator::new(len) {
             Ok(allocator) => Some(Arc::new(allocator)),
             Err(error) => {
                 log::warn!(
@@ -639,13 +737,14 @@ impl FuseConn {
                 None
             }
         });
-        Self::new_with_max_write_cap(
-            cap,
-            Self::virtiofs_init_flags(),
-            true,
-            Some(max_reply_size),
-            dax_allocator,
-        )
+        let mut init_flags = Self::virtiofs_init_flags();
+        if dax_allocator.is_some() {
+            init_flags |= FUSE_MAP_ALIGNMENT;
+        }
+        if dax_mode == DaxMountMode::Inode {
+            init_flags |= FUSE_HAS_INODE_DAX;
+        }
+        Self::new_with_max_write_cap(cap, init_flags, true, Some(max_reply_size), dax_allocator)
     }
 
     fn new_with_max_write_cap(
@@ -706,18 +805,28 @@ impl FuseConn {
         self.dax_allocator.as_ref()
     }
 
-    fn shutdown_dax_allocator(&self) {
+    pub(crate) fn dax_map_alignment(&self) -> Option<u16> {
+        self.dax_allocator.as_ref()?;
+        Some(self.inner.lock().init.map_alignment)
+    }
+
+    fn dax_map_alignment_valid(enabled_flags: u64, map_alignment: u16) -> bool {
+        (enabled_flags & FUSE_MAP_ALIGNMENT) == 0
+            || u32::from(map_alignment) <= super::virtiofs::dax::DAX_RANGE_SIZE.trailing_zeros()
+    }
+
+    fn begin_shutdown_dax_allocator(&self) {
         let Some(allocator) = self.dax_allocator.as_ref() else {
             return;
         };
         allocator.begin_shutdown();
-        if let Err(error) = allocator.finish_shutdown() {
-            log::error!(
-                "virtiofs: DAX allocator still owns ranges during connection teardown: {:?}, state={:?}",
-                error,
-                allocator.snapshot()
-            );
-        }
+    }
+
+    fn disconnect_cleanup_dax_allocator(&self) {
+        let Some(allocator) = self.dax_allocator.as_ref() else {
+            return;
+        };
+        allocator.disconnect_cleanup();
     }
 
     pub(crate) fn register_filesystem(&self, fs: Weak<super::fs::FuseFS>) {
@@ -987,12 +1096,15 @@ impl FuseConn {
     }
 
     pub fn abort(&self) {
-        self.shutdown_dax_allocator();
         self.background.disconnect();
         let (processing, pending_noreply_count): (Vec<Arc<FusePendingState>>, usize) = {
             let mut g = self.inner.lock();
             g.connected = false;
             g.mounted = false;
+            // Close allocator acquisition before releasing the connection lock,
+            // so no observer can see a disconnected connection while DAX get()
+            // still accepts a new reference.
+            self.begin_shutdown_dax_allocator();
             let pending_noreply_count = g
                 .pending
                 .iter()
@@ -1007,8 +1119,9 @@ impl FuseConn {
         };
         stats::on_fuse_requests_aborted(processing.len() + pending_noreply_count);
         for p in processing {
-            p.complete(Err(SystemError::ENOTCONN));
+            p.complete_disconnected(SystemError::ENOTCONN);
         }
+        self.disconnect_cleanup_dax_allocator();
         self.read_wait.wakeup(None);
         self.wake_bridge(stats::VirtioFsBridgeWakeSource::Disconnect);
         self.init_wait.wakeup(None);
@@ -1023,7 +1136,7 @@ impl FuseConn {
     /// Keep the connection readable for daemon-side teardown; actual disconnect
     /// happens when /dev/fuse is closed or explicit abort path is triggered.
     pub fn on_umount(&self) {
-        self.shutdown_dax_allocator();
+        self.begin_shutdown_dax_allocator();
         self.background.disconnect();
         let processing: Vec<Arc<FusePendingState>>;
         let dropped_processing: Vec<Arc<FusePendingState>>;
@@ -1218,9 +1331,14 @@ mod tests {
 
     use super::super::protocol::{
         FuseEntryOut, FuseOpenOut, FuseOutHeader, FuseStatfsOut, FUSE_CREATE, FUSE_DESTROY,
-        FUSE_GETATTR, FUSE_LOOKUP, FUSE_STATFS,
+        FUSE_GETATTR, FUSE_HAS_INODE_DAX, FUSE_LOOKUP, FUSE_MAP_ALIGNMENT, FUSE_REMOVEMAPPING,
+        FUSE_SETUPMAPPING, FUSE_STATFS,
     };
-    use super::{daemon, request, stats, FuseConn, FusePendingState, FuseReplyCapacitySource};
+    use super::super::virtiofs::dax::{DaxMountMode, DAX_RANGE_SIZE};
+    use super::{
+        daemon, request, stats, FuseCompletionKind, FuseConn, FusePendingState,
+        FuseReplyCapacitySource,
+    };
 
     fn set_minor(conn: &FuseConn, minor: u32) {
         conn.inner.lock().init.minor = minor;
@@ -1232,6 +1350,68 @@ mod tests {
             .unwrap()
             .unwrap();
         (capacity.bytes, capacity.source)
+    }
+
+    #[test]
+    fn dax_init_policy_is_internal_and_window_gated() {
+        let never = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE),
+            DaxMountMode::Never,
+        );
+        assert!(never.dax_allocator().is_none());
+        assert_eq!(never.inner.lock().init_flags & FUSE_MAP_ALIGNMENT, 0);
+
+        let always = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE),
+            DaxMountMode::Always,
+        );
+        assert!(always.dax_allocator().is_some());
+        assert_ne!(always.inner.lock().init_flags & FUSE_MAP_ALIGNMENT, 0);
+        assert_eq!(always.inner.lock().init_flags & FUSE_HAS_INODE_DAX, 0);
+
+        let inode = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE),
+            DaxMountMode::Inode,
+        );
+        let flags = inode.inner.lock().init_flags;
+        assert_ne!(flags & FUSE_MAP_ALIGNMENT, 0);
+        assert_ne!(flags & FUSE_HAS_INODE_DAX, 0);
+
+        let no_window = FuseConn::new_for_virtiofs_with_dax(8192, 8192, None, DaxMountMode::Always);
+        assert!(no_window.dax_allocator().is_none());
+        assert_eq!(no_window.inner.lock().init_flags & FUSE_MAP_ALIGNMENT, 0);
+
+        let inode_without_window =
+            FuseConn::new_for_virtiofs_with_dax(8192, 8192, None, DaxMountMode::Inode);
+        let flags = inode_without_window.inner.lock().init_flags;
+        assert_eq!(flags & FUSE_MAP_ALIGNMENT, 0);
+        assert_ne!(flags & FUSE_HAS_INODE_DAX, 0);
+    }
+
+    #[test]
+    fn mapping_requests_have_exact_empty_reply_contracts() {
+        let conn = FuseConn::new_for_virtiofs(8192, 8192);
+        assert_eq!(
+            capacity(&conn, FUSE_SETUPMAPPING, &[]).0,
+            size_of::<FuseOutHeader>()
+        );
+        assert_eq!(
+            capacity(&conn, FUSE_REMOVEMAPPING, &[]).0,
+            size_of::<FuseOutHeader>()
+        );
+    }
+
+    #[test]
+    fn dax_alignment_rejects_daemon_requirement_above_range_shift() {
+        assert!(FuseConn::dax_map_alignment_valid(FUSE_MAP_ALIGNMENT, 21));
+        assert!(!FuseConn::dax_map_alignment_valid(FUSE_MAP_ALIGNMENT, 22));
+        assert!(FuseConn::dax_map_alignment_valid(0, u16::MAX));
     }
 
     #[test]
@@ -1350,6 +1530,34 @@ mod tests {
             contiguous.wait_read_pages_complete().unwrap(),
             super::super::reply::FuseReadPagesReply::Contiguous(reply) if &*reply == [1, 2]
         ));
+    }
+
+    #[test]
+    fn dax_completion_distinguishes_daemon_reply_from_synthetic_error() {
+        let daemon = FusePendingState::new(2, FUSE_SETUPMAPPING);
+        assert!(daemon.complete_daemon_error(SystemError::EIO));
+        let (result, kind) = daemon.wait_result_with_kind().unwrap();
+        assert_eq!(result.unwrap_err(), SystemError::EIO);
+        assert_eq!(kind, FuseCompletionKind::DaemonError);
+
+        let synthetic = FusePendingState::new(4, FUSE_SETUPMAPPING);
+        synthetic.mark_outcome_unknown();
+        assert!(synthetic.complete_daemon_error(SystemError::EIO));
+        let (result, kind) = synthetic.wait_result_with_kind().unwrap();
+        assert_eq!(result.unwrap_err(), SystemError::EIO);
+        assert_eq!(kind, FuseCompletionKind::OutcomeUnknown);
+
+        let local = FusePendingState::new(5, FUSE_REMOVEMAPPING);
+        assert!(local.complete_never_submitted(SystemError::ENOMEM));
+        let (result, kind) = local.wait_result_with_kind().unwrap();
+        assert_eq!(result.unwrap_err(), SystemError::ENOMEM);
+        assert_eq!(kind, FuseCompletionKind::NeverSubmitted);
+
+        let disconnected = FusePendingState::new(6, FUSE_REMOVEMAPPING);
+        assert!(disconnected.complete_disconnected(SystemError::ENOTCONN));
+        let (result, kind) = disconnected.wait_result_with_kind().unwrap();
+        assert_eq!(result.unwrap_err(), SystemError::ENOTCONN);
+        assert_eq!(kind, FuseCompletionKind::Disconnected);
     }
 
     #[test]

--- a/kernel/src/filesystem/fuse/conn/daemon.rs
+++ b/kernel/src/filesystem/fuse/conn/daemon.rs
@@ -11,10 +11,11 @@ use super::super::protocol::{
     FuseNotifyInvalEntryOut, FuseNotifyInvalInodeOut, FuseOpenOut, FuseOutHeader, FuseStatfsOut,
     FuseWriteIn, FUSE_CREATE, FUSE_DESTROY, FUSE_EXPIRE_ONLY, FUSE_FLUSH, FUSE_GETATTR,
     FUSE_GETXATTR, FUSE_INIT, FUSE_INIT_EXT, FUSE_INTERRUPT, FUSE_KERNEL_MINOR_VERSION,
-    FUSE_KERNEL_VERSION, FUSE_LINK, FUSE_LISTXATTR, FUSE_LOOKUP, FUSE_MAX_PAGES,
-    FUSE_MIN_READ_BUFFER, FUSE_MKDIR, FUSE_MKNOD, FUSE_NOTIFY_DELETE, FUSE_NOTIFY_INVAL_ENTRY,
-    FUSE_NOTIFY_INVAL_INODE, FUSE_NOTIFY_POLL, FUSE_NOTIFY_RETRIEVE, FUSE_NOTIFY_STORE, FUSE_READ,
-    FUSE_REMOVEXATTR, FUSE_SETATTR, FUSE_SETXATTR, FUSE_STATFS, FUSE_SYMLINK,
+    FUSE_KERNEL_VERSION, FUSE_LINK, FUSE_LISTXATTR, FUSE_LOOKUP, FUSE_MAP_ALIGNMENT,
+    FUSE_MAX_PAGES, FUSE_MIN_READ_BUFFER, FUSE_MKDIR, FUSE_MKNOD, FUSE_NOTIFY_DELETE,
+    FUSE_NOTIFY_INVAL_ENTRY, FUSE_NOTIFY_INVAL_INODE, FUSE_NOTIFY_POLL, FUSE_NOTIFY_RETRIEVE,
+    FUSE_NOTIFY_STORE, FUSE_READ, FUSE_REMOVEXATTR, FUSE_SETATTR, FUSE_SETXATTR, FUSE_STATFS,
+    FUSE_SYMLINK,
 };
 use super::{
     stats, trace, wait_with_recheck, FuseConn, FuseConnInner, FuseInitNegotiated, FuseRequest,
@@ -54,6 +55,24 @@ impl FuseConn {
         payload_len: usize,
     ) {
         if pending.complete(Err(error)) {
+            stats::on_fuse_reply_complete(pending.opcode, reply_error, payload_len);
+            trace::trace_fuse_reply_complete(
+                unique,
+                pending.opcode,
+                reply_error,
+                payload_len as u64,
+            );
+        }
+    }
+
+    fn complete_claimed_daemon_error(
+        pending: &Arc<super::FusePendingState>,
+        unique: u64,
+        error: SystemError,
+        reply_error: i32,
+        payload_len: usize,
+    ) {
+        if pending.complete_daemon_error(error) {
             stats::on_fuse_reply_complete(pending.opcode, reply_error, payload_len);
             trace::trace_fuse_reply_complete(
                 unique,
@@ -462,13 +481,7 @@ impl FuseConn {
                 );
             }
             self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;
-            Self::complete_claimed_reply_with_error(
-                &pending,
-                out_hdr.unique,
-                e,
-                error,
-                payload_len,
-            );
+            Self::complete_claimed_daemon_error(&pending, out_hdr.unique, e, error, payload_len);
             if matches!(pending.opcode, FUSE_INIT | FUSE_DESTROY) {
                 self.abort();
             }
@@ -510,6 +523,21 @@ impl FuseConn {
             let mut negotiated_flags = init_out.flags as u64;
             if (negotiated_flags & FUSE_INIT_EXT) != 0 {
                 negotiated_flags |= (init_out.flags2 as u64) << 32;
+            }
+            let requested_flags = self.inner.lock().init_flags;
+            let enabled_flags = negotiated_flags & requested_flags;
+            if !Self::dax_map_alignment_valid(enabled_flags, init_out.map_alignment) {
+                let error = -SystemError::EINVAL.to_posix_errno();
+                self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;
+                Self::complete_claimed_reply_with_error(
+                    &pending,
+                    out_hdr.unique,
+                    SystemError::EINVAL,
+                    error,
+                    payload_len,
+                );
+                self.abort();
+                return Ok(data.len());
             }
             let negotiated_minor = core::cmp::min(init_out.minor, FUSE_KERNEL_MINOR_VERSION);
             let negotiated_max_pages_raw = if (negotiated_flags & FUSE_MAX_PAGES) != 0 {
@@ -566,7 +594,6 @@ impl FuseConn {
                 // daemon-supported and locally-requested flags. virtiofsd often sets
                 // DO_READDIRPLUS etc. in the INIT reply; if adopted directly, it would
                 // trigger READDIRPLUS + cache_child_from_entry, causing stale inode mappings.
-                let enabled_flags = negotiated_flags & g.init_flags;
                 g.initialized = true;
                 g.init = FuseInitNegotiated {
                     minor: negotiated_minor,
@@ -575,6 +602,11 @@ impl FuseConn {
                     time_gran: init_out.time_gran,
                     max_pages: negotiated_max_pages,
                     flags: enabled_flags,
+                    map_alignment: if (enabled_flags & FUSE_MAP_ALIGNMENT) != 0 {
+                        init_out.map_alignment
+                    } else {
+                        0
+                    },
                 };
                 self.reply_layout_minor
                     .store(negotiated_minor, Ordering::Release);

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -19,12 +19,12 @@ use super::super::protocol::{
     FUSE_GETXATTR, FUSE_INIT, FUSE_INTERRUPT, FUSE_KERNEL_MINOR_VERSION, FUSE_KERNEL_VERSION,
     FUSE_LINK, FUSE_LISTXATTR, FUSE_LOOKUP, FUSE_MKDIR, FUSE_MKNOD, FUSE_OPEN, FUSE_OPENDIR,
     FUSE_READ, FUSE_READDIR, FUSE_READDIRPLUS, FUSE_READLINK, FUSE_RELEASE, FUSE_RELEASEDIR,
-    FUSE_REMOVEXATTR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_SETATTR, FUSE_SETXATTR,
-    FUSE_STATFS, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE,
+    FUSE_REMOVEMAPPING, FUSE_REMOVEXATTR, FUSE_RENAME, FUSE_RENAME2, FUSE_RMDIR, FUSE_SETATTR,
+    FUSE_SETUPMAPPING, FUSE_SETXATTR, FUSE_STATFS, FUSE_SYMLINK, FUSE_UNLINK, FUSE_WRITE,
 };
 use super::{
-    stats, trace, FuseConn, FusePendingState, FuseReplyCapacity, FuseReplyCapacitySource,
-    FuseReplyContract, FuseRequest, FuseRequestCred,
+    stats, trace, FuseCompletionKind, FuseConn, FusePendingResult, FusePendingState,
+    FuseReplyCapacity, FuseReplyCapacitySource, FuseReplyContract, FuseRequest, FuseRequestCred,
 };
 use crate::filesystem::fuse::reply::FuseReply;
 use crate::filesystem::{fuse::reply::FuseReadPagesReply, page_cache::PageCacheReadDmaReservation};
@@ -44,6 +44,14 @@ enum FuseReplyRouting {
     ReadPages(Arc<PageCacheReadDmaReservation>),
 }
 
+pub(crate) enum FuseDaxRequestOutcome {
+    Success,
+    NeverSubmitted(SystemError),
+    DaemonError(SystemError),
+    OutcomeUnknown(SystemError),
+    Disconnected(SystemError),
+}
+
 /// Bundled context for a background read-pages request.
 pub(crate) struct BackgroundReadPagesCtx {
     pub destination: Arc<PageCacheReadDmaReservation>,
@@ -56,6 +64,92 @@ pub(crate) struct BackgroundReadPagesCtx {
 }
 
 impl FuseConn {
+    #[cfg(test)]
+    pub(crate) fn install_pending_for_test(
+        &self,
+        unique: u64,
+        opcode: u32,
+    ) -> Arc<FusePendingState> {
+        let pending = Arc::new(FusePendingState::new(unique, opcode));
+        self.inner.lock().processing.insert(unique, pending.clone());
+        pending
+    }
+
+    pub(crate) fn mark_pending_outcome_unknown(&self, unique: u64) {
+        if let Some(pending) = self.inner.lock().processing.get(&unique).cloned() {
+            pending.mark_outcome_unknown();
+        }
+    }
+
+    pub(crate) fn complete_pending_never_submitted(
+        &self,
+        unique: u64,
+        error: SystemError,
+    ) -> Result<(), SystemError> {
+        let pending = self
+            .inner
+            .lock()
+            .processing
+            .remove(&unique)
+            .ok_or(SystemError::ENOENT)?;
+        let reply_error = error.to_posix_errno();
+        if pending.complete_never_submitted(error) {
+            stats::on_fuse_reply_complete(pending.opcode, reply_error, 0);
+            trace::trace_fuse_reply_complete(unique, pending.opcode, reply_error, 0);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn request_dax_mapping(
+        &self,
+        opcode: u32,
+        nodeid: u64,
+        payload: &[u8],
+    ) -> FuseDaxRequestOutcome {
+        let cred = ProcessManager::current_pcb().cred();
+        if !self.allow_current_process(&cred) {
+            return FuseDaxRequestOutcome::NeverSubmitted(SystemError::EACCES);
+        }
+        if let Err(error) = self.wait_initialized() {
+            return FuseDaxRequestOutcome::NeverSubmitted(error);
+        }
+        let pending = match self.enqueue_request(opcode, nodeid, payload) {
+            Ok(pending) => pending,
+            Err(error) => return FuseDaxRequestOutcome::NeverSubmitted(error),
+        };
+        let (result, kind) = match pending.wait_result_with_kind_uninterruptible() {
+            Ok(result) => result,
+            Err(_) => {
+                // A dead wait queue is an internal connection failure. Abort
+                // first so the request obtains a real terminal state before
+                // its allocator pin/reservation can be released.
+                self.abort();
+                match pending.wait_result_with_kind() {
+                    Ok(result) => result,
+                    Err(error) => return FuseDaxRequestOutcome::Disconnected(error),
+                }
+            }
+        };
+        match (result, kind) {
+            (Ok(FusePendingResult::Reply(_)), FuseCompletionKind::Success) => {
+                FuseDaxRequestOutcome::Success
+            }
+            (Err(error), FuseCompletionKind::DaemonError) => {
+                FuseDaxRequestOutcome::DaemonError(error)
+            }
+            (Err(error), FuseCompletionKind::NeverSubmitted) => {
+                FuseDaxRequestOutcome::NeverSubmitted(error)
+            }
+            (Err(error), FuseCompletionKind::Disconnected) => {
+                FuseDaxRequestOutcome::Disconnected(error)
+            }
+            (Err(error), FuseCompletionKind::OutcomeUnknown) => {
+                FuseDaxRequestOutcome::OutcomeUnknown(error)
+            }
+            _ => FuseDaxRequestOutcome::OutcomeUnknown(SystemError::EIO),
+        }
+    }
+
     fn is_high_priority_opcode(opcode: u32) -> bool {
         matches!(opcode, FUSE_FORGET | FUSE_INTERRUPT)
     }
@@ -377,6 +471,7 @@ impl FuseConn {
             FUSE_UNLINK | FUSE_RMDIR | FUSE_RENAME | FUSE_RENAME2 | FUSE_RELEASE | FUSE_FSYNC
             | FUSE_SETXATTR | FUSE_REMOVEXATTR | FUSE_FLUSH | FUSE_RELEASEDIR | FUSE_FSYNCDIR
             | FUSE_ACCESS | FUSE_INTERRUPT | FUSE_DESTROY | FUSE_FALLOCATE => Some(0),
+            FUSE_SETUPMAPPING | FUSE_REMOVEMAPPING => Some(0),
             _ => None,
         };
         if let Some(payload_len) = fixed_payload {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -36,12 +36,15 @@ use super::{
     },
 };
 
+static NEXT_DAX_OWNER_INCARNATION: AtomicU64 = AtomicU64::new(1);
+
 #[derive(Debug)]
 pub struct FuseNode {
     fs: Weak<FuseFS>,
     conn: Arc<FuseConn>,
     self_ref: Weak<FuseNode>,
     nodeid: u64,
+    dax_owner_incarnation: u64,
     parent_nodeid: Mutex<u64>,
     parent: Mutex<Option<Arc<FuseNode>>>,
     name: Mutex<Option<String>>,
@@ -93,11 +96,17 @@ impl FuseNode {
     ) -> Arc<Self> {
         let has_cached = cached.is_some();
         let initial_attr_epoch = conn.sample_attr_epoch();
+        let dax_owner_incarnation = NEXT_DAX_OWNER_INCARNATION.fetch_add(1, Ordering::Relaxed);
+        assert_ne!(
+            dax_owner_incarnation, 0,
+            "FUSE DAX owner identity exhausted"
+        );
         Arc::new_cyclic(|self_ref| Self {
             fs,
             conn,
             self_ref: self_ref.clone(),
             nodeid,
+            dax_owner_incarnation,
             parent_nodeid: Mutex::new(parent_nodeid),
             parent: Mutex::new(parent),
             name: Mutex::new(None),
@@ -124,6 +133,11 @@ impl FuseNode {
 
     pub(crate) fn generation(&self) -> u64 {
         self.generation.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn dax_mapping_owner(&self) -> super::virtiofs::dax::DaxMappingOwner {
+        super::virtiofs::dax::DaxMappingOwner::from_inode(self.nodeid, self.dax_owner_incarnation)
+            .expect("FuseNode has a valid DAX owner identity")
     }
 
     pub(crate) fn set_generation(&self, gen: u64) {

--- a/kernel/src/filesystem/fuse/protocol.rs
+++ b/kernel/src/filesystem/fuse/protocol.rs
@@ -50,6 +50,8 @@ pub const FUSE_DESTROY: u32 = 38; // no reply
 pub const FUSE_FALLOCATE: u32 = 43;
 pub const FUSE_READDIRPLUS: u32 = 44;
 pub const FUSE_RENAME2: u32 = 45;
+pub const FUSE_SETUPMAPPING: u32 = 48;
+pub const FUSE_REMOVEMAPPING: u32 = 49;
 
 // INIT flags (subset)
 pub const FUSE_ASYNC_READ: u64 = 1 << 0;
@@ -72,9 +74,11 @@ pub const FUSE_ABORT_ERROR: u64 = 1 << 21;
 pub const FUSE_MAX_PAGES: u64 = 1 << 22;
 pub const FUSE_NO_OPENDIR_SUPPORT: u64 = 1 << 24;
 pub const FUSE_EXPLICIT_INVAL_DATA: u64 = 1 << 25;
+pub const FUSE_MAP_ALIGNMENT: u64 = 1 << 26;
 /// Guest auto-mounts directories marked FUSE_ATTR_SUBMOUNT (Linux fuse.h: init->flags bit 27).
 pub const FUSE_SUBMOUNTS: u64 = 1 << 27;
 pub const FUSE_INIT_EXT: u64 = 1 << 30;
+pub const FUSE_HAS_INODE_DAX: u64 = 1 << 33;
 /// Kernel supports expiry-only entry invalidation (Linux 6.6 fuse.h bit 35).
 pub const FUSE_HAS_EXPIRE_ONLY: u64 = 1 << 35;
 /// Allow shared mmap for FOPEN_DIRECT_IO files (Linux 6.6 fuse.h bit 36).
@@ -122,6 +126,9 @@ pub const FATTR_LOCKOWNER: u32 = 1 << 9;
 pub const FATTR_CTIME: u32 = 1 << 10;
 
 pub const FUSE_FSYNC_FDATASYNC: u32 = 1 << 0;
+
+pub const FUSE_SETUPMAPPING_FLAG_WRITE: u64 = 1 << 0;
+pub const FUSE_SETUPMAPPING_FLAG_READ: u64 = 1 << 1;
 pub const FUSE_NOTIFY_POLL: i32 = 1;
 pub const FUSE_NOTIFY_INVAL_INODE: i32 = 2;
 pub const FUSE_NOTIFY_INVAL_ENTRY: i32 = 3;
@@ -201,6 +208,33 @@ pub struct FuseInitOut {
     pub flags2: u32,
     pub unused: [u32; 7],
 }
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FuseSetupMappingIn {
+    pub fh: u64,
+    pub foffset: u64,
+    pub len: u64,
+    pub flags: u64,
+    pub moffset: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FuseRemoveMappingIn {
+    pub count: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FuseRemoveMappingOne {
+    pub moffset: u64,
+    pub len: u64,
+}
+
+const _: [(); 40] = [(); size_of::<FuseSetupMappingIn>()];
+const _: [(); 4] = [(); size_of::<FuseRemoveMappingIn>()];
+const _: [(); 16] = [(); size_of::<FuseRemoveMappingOne>()];
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -689,7 +689,19 @@ impl VirtioFsBridgeContext {
 
     fn terminate_pending_with_error(&self, pending: &PendingReq, err: SystemError) {
         if !pending.noreply {
+            self.conn.mark_pending_outcome_unknown(pending.unique);
             self.complete_request_with_error(pending.unique, err);
+        }
+        if pending.opcode == FUSE_DESTROY {
+            self.conn.abort();
+        }
+    }
+
+    fn terminate_pending_not_submitted(&self, pending: &PendingReq, err: SystemError) {
+        if !pending.noreply {
+            let _ = self
+                .conn
+                .complete_pending_never_submitted(pending.unique, err);
         }
         if pending.opcode == FUSE_DESTROY {
             self.conn.abort();
@@ -868,7 +880,7 @@ impl VirtioFsBridgeContext {
                 let capacity = match capacity {
                     Some(capacity) => capacity,
                     None => {
-                        self.terminate_pending_with_error(&pending, SystemError::EIO);
+                        self.terminate_pending_not_submitted(&pending, SystemError::EIO);
                         return Ok(true);
                     }
                 };
@@ -884,7 +896,7 @@ impl VirtioFsBridgeContext {
                 ) {
                     Ok(rsp) => rsp,
                     Err(e) => {
-                        self.terminate_pending_with_error(&pending, e);
+                        self.terminate_pending_not_submitted(&pending, e);
                         return Ok(true);
                     }
                 };
@@ -904,19 +916,31 @@ impl VirtioFsBridgeContext {
             }
         };
 
+        let mut dma_outputs = if let Some(output_ref) = output.as_mut() {
+            match unsafe { output_ref.dma_slices(true) } {
+                Ok(outputs) => Some(outputs),
+                Err(error) => {
+                    Self::release_unsubmitted_output(&self.response_pool, output.take());
+                    self.terminate_pending_not_submitted(&pending, error);
+                    return Ok(true);
+                }
+            }
+        } else {
+            None
+        };
+
         let (token, should_notify) = match kind {
             QueueKind::Hiprio => {
                 let queue = self.hiprio_vq.as_mut().ok_or(SystemError::EIO)?;
-                let token = if let Some(output) = output.as_mut() {
+                let token = if let Some(outputs) = dma_outputs.as_mut() {
                     let inputs = [pending.req.bytes()];
-                    let mut outputs = unsafe { output.dma_slices(true)? };
                     // SAFETY: The request contains a non-empty FuseInHeader, and the reply
                     // contract makes `rsp_buf` at least a non-empty FuseOutHeader. On success,
                     // only their owners and independent metadata are moved/read before notification;
                     // neither buffer's contents are accessed again until `pop_used` succeeds or
                     // reset completes and `detach_unused` succeeds. On error no descriptor was
                     // accepted.
-                    unsafe { queue.add(&inputs, &mut outputs) }
+                    unsafe { queue.add(&inputs, outputs) }
                 } else {
                     let inputs = [pending.req.bytes()];
                     let mut outputs: [&mut [u8]; 0] = [];
@@ -931,16 +955,15 @@ impl VirtioFsBridgeContext {
             }
             QueueKind::Request(slot) => {
                 let queue = self.request_vqs.get_mut(slot).ok_or(SystemError::EINVAL)?;
-                let token = if let Some(output) = output.as_mut() {
+                let token = if let Some(outputs) = dma_outputs.as_mut() {
                     let inputs = [pending.req.bytes()];
-                    let mut outputs = unsafe { output.dma_slices(true)? };
                     // SAFETY: The request contains a non-empty FuseInHeader, and the reply
                     // contract makes `rsp_buf` at least a non-empty FuseOutHeader. On success,
                     // only their owners and independent metadata are moved/read before notification;
                     // neither buffer's contents are accessed again until `pop_used` succeeds or
                     // reset completes and `detach_unused` succeeds. On error no descriptor was
                     // accepted.
-                    unsafe { queue.add(&inputs, &mut outputs) }
+                    unsafe { queue.add(&inputs, outputs) }
                 } else {
                     let inputs = [pending.req.bytes()];
                     let mut outputs: [&mut [u8]; 0] = [];
@@ -954,6 +977,7 @@ impl VirtioFsBridgeContext {
                 (token, queue.should_notify())
             }
         };
+        drop(dma_outputs);
 
         let token = match token {
             Ok(token) => token,
@@ -981,7 +1005,7 @@ impl VirtioFsBridgeContext {
                     "virtiofs bridge: queue not ready opcode={} unique={} queue={:?} err={:?}",
                     pending.opcode, pending.unique, kind, se
                 );
-                self.terminate_pending_with_error(&pending, se);
+                self.terminate_pending_not_submitted(&pending, se);
                 return Ok(true);
             }
             Err(e) => {
@@ -992,7 +1016,7 @@ impl VirtioFsBridgeContext {
                     "virtiofs bridge: submit failed opcode={} unique={} queue={:?} err={:?}",
                     pending.opcode, pending.unique, kind, se
                 );
-                self.terminate_pending_with_error(&pending, se);
+                self.terminate_pending_not_submitted(&pending, se);
                 return Ok(true);
             }
         };
@@ -1518,26 +1542,37 @@ impl VirtioFsBridgeContext {
         }
     }
 
-    fn complete_unfinished(&self, err: SystemError, need_reply: Vec<u64>) {
-        let failed = need_reply.len();
+    fn complete_unfinished(
+        conn: &Arc<FuseConn>,
+        err: SystemError,
+        never_submitted: Vec<u64>,
+        outcome_unknown: Vec<u64>,
+    ) {
+        let failed = never_submitted.len() + outcome_unknown.len();
         let errno = err.to_posix_errno();
-        for unique in need_reply {
-            Self::complete_request_with_negative_errno(&self.conn, unique, errno);
+        for unique in never_submitted {
+            let _ = conn.complete_pending_never_submitted(unique, err.clone());
+        }
+        for unique in outcome_unknown {
+            conn.mark_pending_outcome_unknown(unique);
+            Self::complete_request_with_negative_errno(conn, unique, errno);
         }
         stats::on_virtiofs_fail_unfinished(failed);
     }
 
     fn fail_unfinished_preserving_inflight_dma(&mut self, err: SystemError) {
-        let mut need_reply = Vec::new();
-        self.drain_pending_reply_uniques(&mut need_reply);
-        self.collect_inflight_reply_uniques(&mut need_reply);
-        self.complete_unfinished(err, need_reply);
+        let mut never_submitted = Vec::new();
+        let mut outcome_unknown = Vec::new();
+        self.drain_pending_reply_uniques(&mut never_submitted);
+        self.collect_inflight_reply_uniques(&mut outcome_unknown);
+        Self::complete_unfinished(&self.conn, err, never_submitted, outcome_unknown);
     }
 
     fn fail_all_unfinished(&mut self, err: SystemError) {
-        let mut need_reply = Vec::new();
-        self.drain_pending_reply_uniques(&mut need_reply);
-        self.collect_inflight_reply_uniques(&mut need_reply);
+        let mut never_submitted = Vec::new();
+        let mut outcome_unknown = Vec::new();
+        self.drain_pending_reply_uniques(&mut never_submitted);
+        self.collect_inflight_reply_uniques(&mut outcome_unknown);
 
         let hiprio_inflight_count = self.hiprio_inflight.len();
         self.hiprio_inflight.clear();
@@ -1552,7 +1587,7 @@ impl VirtioFsBridgeContext {
             stats::VirtioFsQueueKind::Request,
             request_inflight_count,
         );
-        self.complete_unfinished(err, need_reply);
+        Self::complete_unfinished(&self.conn, err, never_submitted, outcome_unknown);
     }
 
     fn clear_queue_full_blocked_stats(&mut self) {
@@ -1760,6 +1795,7 @@ impl VirtioFsBridgeContext {
             // Idle pooled buffers are not visible to the device. Release them before the
             // reset-timeout quarantine keeps the transport, queues and inflight DMA buffers alive.
             self.fail_unfinished_preserving_inflight_dma(SystemError::ENOTCONN);
+            self.conn.abort();
             if !self
                 .instance
                 .release_session_without_transport(self.session_id)
@@ -1774,6 +1810,7 @@ impl VirtioFsBridgeContext {
             return false;
         }
         self.fail_all_unfinished(SystemError::ENOTCONN);
+        self.conn.abort();
 
         if let Some(transport) = self.transport.take() {
             self.instance.put_transport_after_session(transport);
@@ -2039,6 +2076,11 @@ mod tests {
 
     use system_error::SystemError;
 
+    use crate::filesystem::fuse::{
+        conn::{FuseCompletionKind, FuseConn},
+        protocol::{FUSE_REMOVEMAPPING, FUSE_SETUPMAPPING},
+    };
+
     use super::{QueueBlockState, VirtioFsBridgeContext};
 
     fn block_state(blocked: bool, completion_seen: bool) -> QueueBlockState {
@@ -2046,6 +2088,22 @@ mod tests {
             blocked,
             completion_seen,
         }
+    }
+
+    #[test]
+    fn unfinished_completion_preserves_submission_provenance() {
+        let conn = FuseConn::new_for_virtiofs(8192, 8192);
+        let pending = conn.install_pending_for_test(2, FUSE_REMOVEMAPPING);
+        let inflight = conn.install_pending_for_test(4, FUSE_SETUPMAPPING);
+
+        VirtioFsBridgeContext::complete_unfinished(&conn, SystemError::ENOTCONN, vec![2], vec![4]);
+
+        let (result, kind) = pending.wait_result_with_kind().unwrap();
+        assert_eq!(result.unwrap_err(), SystemError::ENOTCONN);
+        assert_eq!(kind, FuseCompletionKind::NeverSubmitted);
+        let (result, kind) = inflight.wait_result_with_kind().unwrap();
+        assert_eq!(result.unwrap_err(), SystemError::ENOTCONN);
+        assert_eq!(kind, FuseCompletionKind::OutcomeUnknown);
     }
 
     #[test]

--- a/kernel/src/filesystem/fuse/virtiofs/dax.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/dax.rs
@@ -1,19 +1,45 @@
-use alloc::{collections::VecDeque, vec::Vec};
+use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
+use core::mem::size_of;
 
 use log::error;
 use system_error::SystemError;
 
-use crate::libs::{spinlock::SpinLock, wait_queue::WaitQueue};
+use crate::{
+    arch::MMArch,
+    filesystem::fuse::{
+        conn::{FuseConn, FuseDaxRequestOutcome},
+        protocol::{
+            fuse_pack_struct, FuseRemoveMappingIn, FuseRemoveMappingOne, FuseSetupMappingIn,
+            FUSE_REMOVEMAPPING, FUSE_SETUPMAPPING, FUSE_SETUPMAPPING_FLAG_READ,
+            FUSE_SETUPMAPPING_FLAG_WRITE,
+        },
+    },
+    libs::{spinlock::SpinLock, wait_queue::WaitQueue},
+    mm::MemoryManagementArch,
+};
 
 pub(crate) const DAX_RANGE_SIZE: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DaxMountMode {
+    Never,
+    Always,
+    Inode,
+}
 
 #[derive(Debug)]
 enum DaxRangeState {
     Free,
     Reserved { nonce: u64 },
-    InodeOwned { inode: u64, refs: u64 },
-    Reclaiming { inode: u64, nonce: u64 },
+    InodeOwned { owner: DaxMappingOwner, refs: u64 },
+    Reclaiming { owner: DaxMappingOwner, nonce: u64 },
     Retired,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct DaxMappingOwner {
+    nodeid: u64,
+    incarnation: u64,
 }
 
 #[derive(Debug)]
@@ -52,7 +78,7 @@ pub(crate) struct AllocationToken {
 pub(crate) struct OwnedToken {
     index: usize,
     generation: u64,
-    inode: u64,
+    owner: DaxMappingOwner,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -60,7 +86,7 @@ pub(crate) struct OwnedToken {
 pub(crate) struct ReclaimCandidate {
     index: usize,
     generation: u64,
-    inode: u64,
+    owner: DaxMappingOwner,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -68,7 +94,7 @@ pub(crate) struct ReclaimCandidate {
 pub(crate) struct ReclaimToken {
     index: usize,
     generation: u64,
-    inode: u64,
+    owner: DaxMappingOwner,
     nonce: u64,
 }
 
@@ -93,6 +119,25 @@ impl AllocationToken {
     }
 }
 
+impl DaxMappingOwner {
+    pub(in crate::filesystem::fuse) fn from_inode(
+        nodeid: u64,
+        incarnation: u64,
+    ) -> Result<Self, SystemError> {
+        if nodeid == 0 || incarnation == 0 {
+            return Err(SystemError::EINVAL);
+        }
+        Ok(Self {
+            nodeid,
+            incarnation,
+        })
+    }
+
+    pub(crate) fn nodeid(self) -> u64 {
+        self.nodeid
+    }
+}
+
 impl OwnedToken {
     pub(crate) fn window_offset(&self) -> usize {
         self.index * DAX_RANGE_SIZE
@@ -102,8 +147,8 @@ impl OwnedToken {
         DAX_RANGE_SIZE
     }
 
-    pub(crate) fn inode(&self) -> u64 {
-        self.inode
+    pub(crate) fn owner(&self) -> DaxMappingOwner {
+        self.owner
     }
 }
 
@@ -112,9 +157,36 @@ impl ReclaimCandidate {
         self.index * DAX_RANGE_SIZE
     }
 
-    pub(crate) fn inode(&self) -> u64 {
-        self.inode
+    pub(crate) fn owner(&self) -> DaxMappingOwner {
+        self.owner
     }
+}
+
+impl ReclaimToken {
+    pub(crate) fn window_offset(&self) -> usize {
+        self.index * DAX_RANGE_SIZE
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        DAX_RANGE_SIZE
+    }
+
+    pub(crate) fn owner(&self) -> DaxMappingOwner {
+        self.owner
+    }
+}
+
+fn validate_unique_reclaim_indexes(tokens: &[ReclaimToken]) -> Result<(), SystemError> {
+    let mut indexes = Vec::new();
+    indexes
+        .try_reserve_exact(tokens.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    indexes.extend(tokens.iter().map(|token| token.index));
+    indexes.sort_unstable();
+    if indexes.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(SystemError::EINVAL);
+    }
+    Ok(())
 }
 
 impl DaxRangeAllocatorState {
@@ -260,14 +332,11 @@ impl DaxRangeAllocator {
         })?
     }
 
-    pub(crate) fn assign_inode(
+    pub(crate) fn assign_owner(
         &self,
         token: &AllocationToken,
-        inode: u64,
+        owner: DaxMappingOwner,
     ) -> Result<OwnedToken, SystemError> {
-        if inode == 0 {
-            return Err(SystemError::EINVAL);
-        }
         let mut state = self.state.lock_irqsave();
         if state.shutdown {
             return Err(SystemError::ENODEV);
@@ -281,11 +350,11 @@ impl DaxRangeAllocator {
         {
             return Err(SystemError::EINVAL);
         }
-        entry.state = DaxRangeState::InodeOwned { inode, refs: 1 };
+        entry.state = DaxRangeState::InodeOwned { owner, refs: 1 };
         let owned = OwnedToken {
             index: token.index,
             generation: token.generation,
-            inode,
+            owner,
         };
         drop(state);
         self.wait.wakeup(None);
@@ -310,6 +379,21 @@ impl DaxRangeAllocator {
         Ok(())
     }
 
+    pub(crate) fn retire_reservation(&self, token: &AllocationToken) -> Result<(), SystemError> {
+        let mut state = self.state.lock_irqsave();
+        let entry = state
+            .entries
+            .get_mut(token.index)
+            .ok_or(SystemError::EINVAL)?;
+        if entry.generation != token.generation
+            || !matches!(entry.state, DaxRangeState::Reserved { nonce } if nonce == token.nonce)
+        {
+            return Err(SystemError::EINVAL);
+        }
+        entry.state = DaxRangeState::Retired;
+        Ok(())
+    }
+
     pub(crate) fn get(&self, token: &OwnedToken) -> Result<(), SystemError> {
         let mut state = self.state.lock_irqsave();
         if state.shutdown {
@@ -322,10 +406,10 @@ impl DaxRangeAllocator {
         if entry.generation != token.generation {
             return Err(SystemError::EINVAL);
         }
-        let DaxRangeState::InodeOwned { inode, refs } = &mut entry.state else {
+        let DaxRangeState::InodeOwned { owner, refs } = &mut entry.state else {
             return Err(SystemError::EINVAL);
         };
-        if *inode != token.inode {
+        if *owner != token.owner {
             return Err(SystemError::EINVAL);
         }
         *refs = refs.checked_add(1).ok_or(SystemError::EOVERFLOW)?;
@@ -341,10 +425,10 @@ impl DaxRangeAllocator {
         if entry.generation != token.generation {
             return Err(SystemError::EINVAL);
         }
-        let DaxRangeState::InodeOwned { inode, refs } = &mut entry.state else {
+        let DaxRangeState::InodeOwned { owner, refs } = &mut entry.state else {
             return Err(SystemError::EINVAL);
         };
-        if *inode != token.inode || *refs <= 1 {
+        if *owner != token.owner || *refs <= 1 {
             return Err(SystemError::EINVAL);
         }
         *refs -= 1;
@@ -377,11 +461,11 @@ impl DaxRangeAllocator {
         while scanned < total && candidates.len() < limit {
             let index = (start + scanned) % total;
             let entry = &state.entries[index];
-            if let DaxRangeState::InodeOwned { inode, refs: 1 } = entry.state {
+            if let DaxRangeState::InodeOwned { owner, refs: 1 } = entry.state {
                 candidates.push(ReclaimCandidate {
                     index,
                     generation: entry.generation,
-                    inode,
+                    owner,
                 });
             }
             scanned += 1;
@@ -400,7 +484,7 @@ impl DaxRangeAllocator {
             .get_mut(candidate.index)
             .ok_or(SystemError::EINVAL)?;
         if entry.generation != candidate.generation
-            || !matches!(entry.state, DaxRangeState::InodeOwned { inode, refs: 1 } if inode == candidate.inode)
+            || !matches!(entry.state, DaxRangeState::InodeOwned { owner, refs: 1 } if owner == candidate.owner)
         {
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
         }
@@ -410,13 +494,13 @@ impl DaxRangeAllocator {
             .ok_or(SystemError::EOVERFLOW)?;
         entry.transition_nonce = nonce;
         entry.state = DaxRangeState::Reclaiming {
-            inode: candidate.inode,
+            owner: candidate.owner,
             nonce,
         };
         Ok(ReclaimToken {
             index: candidate.index,
             generation: candidate.generation,
-            inode: candidate.inode,
+            owner: candidate.owner,
             nonce,
         })
     }
@@ -431,17 +515,24 @@ impl DaxRangeAllocator {
         Ok(())
     }
 
+    pub(crate) fn retire_reclaim(&self, token: &ReclaimToken) -> Result<(), SystemError> {
+        let mut state = self.state.lock_irqsave();
+        Self::validate_reclaim_token(&state, token)?;
+        state.entries[token.index].state = DaxRangeState::Retired;
+        Ok(())
+    }
+
     pub(crate) fn cancel_reclaim(&self, token: &ReclaimToken) -> Result<OwnedToken, SystemError> {
         let mut state = self.state.lock_irqsave();
         Self::validate_reclaim_token(&state, token)?;
         state.entries[token.index].state = DaxRangeState::InodeOwned {
-            inode: token.inode,
+            owner: token.owner,
             refs: 1,
         };
         let owned = OwnedToken {
             index: token.index,
             generation: token.generation,
-            inode: token.inode,
+            owner: token.owner,
         };
         drop(state);
         self.wait.wakeup(None);
@@ -454,9 +545,24 @@ impl DaxRangeAllocator {
     ) -> Result<(), SystemError> {
         let entry = state.entries.get(token.index).ok_or(SystemError::EINVAL)?;
         if entry.generation != token.generation
-            || !matches!(entry.state, DaxRangeState::Reclaiming { inode, nonce } if inode == token.inode && nonce == token.nonce)
+            || !matches!(entry.state, DaxRangeState::Reclaiming { owner, nonce } if owner == token.owner && nonce == token.nonce)
         {
             return Err(SystemError::EINVAL);
+        }
+        Ok(())
+    }
+
+    fn validate_reclaim_batch(
+        &self,
+        owner: DaxMappingOwner,
+        tokens: &[ReclaimToken],
+    ) -> Result<(), SystemError> {
+        let state = self.state.lock_irqsave();
+        for token in tokens {
+            if token.owner != owner {
+                return Err(SystemError::EINVAL);
+            }
+            Self::validate_reclaim_token(&state, token)?;
         }
         Ok(())
     }
@@ -469,6 +575,26 @@ impl DaxRangeAllocator {
         state.shutdown = true;
         drop(state);
         self.wait.wakeup_all(None);
+    }
+
+    /// Finish local accounting after the FUSE connection is confirmed dead.
+    ///
+    /// The cache window belongs to this connection and is never handed to a
+    /// replacement session, so no daemon can observe aliases after this point.
+    pub(crate) fn disconnect_cleanup(&self) -> usize {
+        let mut state = self.state.lock_irqsave();
+        state.shutdown = true;
+        state.free.clear();
+        let mut cleaned = 0;
+        for entry in &mut state.entries {
+            if !matches!(entry.state, DaxRangeState::Free | DaxRangeState::Retired) {
+                cleaned += 1;
+            }
+            entry.state = DaxRangeState::Retired;
+        }
+        drop(state);
+        self.wait.wakeup_all(None);
+        cleaned
     }
 
     pub(crate) fn finish_shutdown(&self) -> Result<(), SystemError> {
@@ -486,6 +612,261 @@ impl DaxRangeAllocator {
 
     pub(crate) fn snapshot(&self) -> DaxAllocatorSnapshot {
         self.state.lock_irqsave().snapshot()
+    }
+}
+
+impl FuseConn {
+    const REMOVE_MAPPING_MAX_ENTRIES: usize = MMArch::PAGE_SIZE / size_of::<FuseRemoveMappingOne>();
+
+    fn dax_allocator_clone(&self) -> Result<Arc<DaxRangeAllocator>, SystemError> {
+        self.dax_allocator()
+            .cloned()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+    }
+
+    fn validate_mapping_range(
+        &self,
+        window_offset: usize,
+        file_offset: u64,
+        len: usize,
+    ) -> Result<(), SystemError> {
+        let alignment_shift = self
+            .dax_map_alignment()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        let alignment = 1u64
+            .checked_shl(u32::from(alignment_shift))
+            .ok_or(SystemError::EINVAL)?;
+        let len_u64 = u64::try_from(len).map_err(|_| SystemError::EOVERFLOW)?;
+        let window_offset_u64 = u64::try_from(window_offset).map_err(|_| SystemError::EOVERFLOW)?;
+        file_offset
+            .checked_add(len_u64)
+            .ok_or(SystemError::EOVERFLOW)?;
+        window_offset_u64
+            .checked_add(len_u64)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if len == 0
+            || window_offset % DAX_RANGE_SIZE != 0
+            || len % DAX_RANGE_SIZE != 0
+            || file_offset % DAX_RANGE_SIZE as u64 != 0
+            || file_offset % alignment != 0
+            || window_offset_u64 % alignment != 0
+            || len_u64 % alignment != 0
+        {
+            return Err(SystemError::EINVAL);
+        }
+        Ok(())
+    }
+
+    fn send_setup_mapping(
+        &self,
+        owner: DaxMappingOwner,
+        fh: u64,
+        file_offset: u64,
+        window_offset: usize,
+        writable: bool,
+    ) -> FuseDaxRequestOutcome {
+        if let Err(error) = self.validate_mapping_range(window_offset, file_offset, DAX_RANGE_SIZE)
+        {
+            return FuseDaxRequestOutcome::NeverSubmitted(error);
+        }
+        let input = FuseSetupMappingIn {
+            fh,
+            foffset: file_offset,
+            len: DAX_RANGE_SIZE as u64,
+            flags: FUSE_SETUPMAPPING_FLAG_READ
+                | if writable {
+                    FUSE_SETUPMAPPING_FLAG_WRITE
+                } else {
+                    0
+                },
+            moffset: window_offset as u64,
+        };
+        self.request_dax_mapping(FUSE_SETUPMAPPING, owner.nodeid(), fuse_pack_struct(&input))
+    }
+
+    fn apply_setup_outcome(
+        allocator: &DaxRangeAllocator,
+        reservation: &AllocationToken,
+        owner: DaxMappingOwner,
+        outcome: FuseDaxRequestOutcome,
+    ) -> Result<OwnedToken, SystemError> {
+        match outcome {
+            FuseDaxRequestOutcome::Success => match allocator.assign_owner(reservation, owner) {
+                Ok(owned) => Ok(owned),
+                Err(error) => {
+                    let _ = allocator.retire_reservation(reservation);
+                    Err(error)
+                }
+            },
+            FuseDaxRequestOutcome::NeverSubmitted(error)
+            | FuseDaxRequestOutcome::DaemonError(error) => {
+                let _ = allocator.cancel_reservation(reservation);
+                Err(error)
+            }
+            FuseDaxRequestOutcome::OutcomeUnknown(error)
+            | FuseDaxRequestOutcome::Disconnected(error) => {
+                let _ = allocator.retire_reservation(reservation);
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) fn setup_dax_mapping(
+        &self,
+        owner: DaxMappingOwner,
+        fh: u64,
+        file_offset: u64,
+        writable: bool,
+    ) -> Result<OwnedToken, SystemError> {
+        let allocator = self.dax_allocator_clone()?;
+        let reservation = allocator.try_allocate()?;
+        let result = self.send_setup_mapping(
+            owner,
+            fh,
+            file_offset,
+            reservation.window_offset(),
+            writable,
+        );
+        Self::apply_setup_outcome(&allocator, &reservation, owner, result)
+    }
+
+    /// Send SETUPMAPPING for an existing range (used by #2080 for access upgrades).
+    pub(crate) fn setup_existing_dax_mapping(
+        &self,
+        owner: DaxMappingOwner,
+        token: &OwnedToken,
+        fh: u64,
+        file_offset: u64,
+        writable: bool,
+    ) -> Result<(), SystemError> {
+        if token.owner() != owner {
+            return Err(SystemError::EINVAL);
+        }
+        let allocator = self.dax_allocator_clone()?;
+        allocator.get(token)?;
+        let outcome =
+            self.send_setup_mapping(owner, fh, file_offset, token.window_offset(), writable);
+        let put_result = allocator.put(token);
+        match outcome {
+            FuseDaxRequestOutcome::Success => {
+                put_result?;
+                Ok(())
+            }
+            FuseDaxRequestOutcome::NeverSubmitted(error)
+            | FuseDaxRequestOutcome::DaemonError(error)
+            | FuseDaxRequestOutcome::OutcomeUnknown(error)
+            | FuseDaxRequestOutcome::Disconnected(error) => match put_result {
+                Ok(()) => Err(error),
+                // disconnect_cleanup invalidates every token after closing the
+                // allocator. Preserve the request's real terminal errno rather
+                // than replacing it with the expected local EINVAL from put().
+                Err(SystemError::EINVAL) if !self.is_connected() => Err(error),
+                Err(put_error) => Err(put_error),
+            },
+        }
+    }
+
+    pub(crate) fn remove_dax_mappings(
+        &self,
+        owner: DaxMappingOwner,
+        tokens: &[ReclaimToken],
+    ) -> Result<(), SystemError> {
+        self.remove_dax_mappings_with(owner, tokens, |payload| {
+            self.request_dax_mapping(FUSE_REMOVEMAPPING, owner.nodeid(), payload)
+        })
+    }
+
+    fn remove_dax_mappings_with<F>(
+        &self,
+        owner: DaxMappingOwner,
+        tokens: &[ReclaimToken],
+        mut request: F,
+    ) -> Result<(), SystemError>
+    where
+        F: FnMut(&[u8]) -> FuseDaxRequestOutcome,
+    {
+        if tokens.is_empty() {
+            return Ok(());
+        }
+        let allocator = self.dax_allocator_clone()?;
+        let rollback_all = |tokens: &[ReclaimToken]| {
+            for token in tokens {
+                let _ = allocator.cancel_reclaim(token);
+            }
+        };
+
+        if let Err(error) = validate_unique_reclaim_indexes(tokens) {
+            rollback_all(tokens);
+            return Err(error);
+        }
+        if let Err(error) = allocator.validate_reclaim_batch(owner, tokens) {
+            rollback_all(tokens);
+            return Err(error);
+        }
+
+        let max_entries = core::cmp::min(Self::REMOVE_MAPPING_MAX_ENTRIES, tokens.len());
+        let max_payload_len = match max_entries
+            .checked_mul(size_of::<FuseRemoveMappingOne>())
+            .and_then(|entries| size_of::<FuseRemoveMappingIn>().checked_add(entries))
+        {
+            Some(len) => len,
+            None => {
+                rollback_all(tokens);
+                return Err(SystemError::EOVERFLOW);
+            }
+        };
+        let mut payload = Vec::new();
+        if payload.try_reserve_exact(max_payload_len).is_err() {
+            rollback_all(tokens);
+            return Err(SystemError::ENOMEM);
+        }
+
+        let mut start = 0;
+        while start < tokens.len() {
+            let end = core::cmp::min(
+                start.saturating_add(Self::REMOVE_MAPPING_MAX_ENTRIES),
+                tokens.len(),
+            );
+            let batch = &tokens[start..end];
+            payload.clear();
+            let header = FuseRemoveMappingIn {
+                // A batch is capped at PAGE_SIZE / 16, far below u32::MAX.
+                count: batch.len() as u32,
+            };
+            payload.extend_from_slice(fuse_pack_struct(&header));
+            for token in batch {
+                let entry = FuseRemoveMappingOne {
+                    moffset: token.window_offset() as u64,
+                    len: token.len() as u64,
+                };
+                payload.extend_from_slice(fuse_pack_struct(&entry));
+            }
+
+            match request(&payload) {
+                FuseDaxRequestOutcome::Success => {
+                    for token in batch {
+                        allocator.finish_reclaim(token)?;
+                    }
+                }
+                FuseDaxRequestOutcome::NeverSubmitted(error) => {
+                    rollback_all(&tokens[start..]);
+                    return Err(error);
+                }
+                FuseDaxRequestOutcome::DaemonError(error)
+                | FuseDaxRequestOutcome::OutcomeUnknown(error) => {
+                    for token in batch {
+                        let _ = allocator.retire_reclaim(token);
+                    }
+                    rollback_all(&tokens[end..]);
+                    return Err(error);
+                }
+                FuseDaxRequestOutcome::Disconnected(error) => {
+                    return Err(error);
+                }
+            }
+            start = end;
+        }
+        Ok(())
     }
 }
 
@@ -510,9 +891,33 @@ impl Drop for DaxRangeAllocator {
 mod tests {
     use super::*;
 
-    fn assign(allocator: &DaxRangeAllocator, inode: u64) -> OwnedToken {
+    fn owner(nodeid: u64) -> DaxMappingOwner {
+        DaxMappingOwner::from_inode(nodeid, nodeid).unwrap()
+    }
+
+    fn assign(allocator: &DaxRangeAllocator, nodeid: u64) -> OwnedToken {
         let reservation = allocator.try_allocate().unwrap();
-        allocator.assign_inode(&reservation, inode).unwrap()
+        allocator.assign_owner(&reservation, owner(nodeid)).unwrap()
+    }
+
+    fn reclaim_tokens(
+        allocator: &DaxRangeAllocator,
+        mapping_owner: DaxMappingOwner,
+        count: usize,
+    ) -> Vec<ReclaimToken> {
+        for _ in 0..count {
+            let reservation = allocator.try_allocate().unwrap();
+            allocator.assign_owner(&reservation, mapping_owner).unwrap();
+        }
+        let mut candidates = Vec::with_capacity(count);
+        allocator
+            .reclaim_candidates(&mut candidates, count)
+            .unwrap();
+        assert_eq!(candidates.len(), count);
+        candidates
+            .iter()
+            .map(|candidate| allocator.begin_reclaim(candidate).unwrap())
+            .collect()
     }
 
     fn candidates(allocator: &DaxRangeAllocator, max: usize) -> Vec<ReclaimCandidate> {
@@ -539,10 +944,201 @@ mod tests {
     }
 
     #[test]
+    fn mapping_range_validation_enforces_chunk_alignment_and_overflow() {
+        let conn = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE),
+            DaxMountMode::Always,
+        );
+        assert_eq!(conn.validate_mapping_range(0, 0, DAX_RANGE_SIZE), Ok(()));
+        assert_eq!(
+            conn.validate_mapping_range(0, 4096, DAX_RANGE_SIZE),
+            Err(SystemError::EINVAL)
+        );
+        assert_eq!(
+            conn.validate_mapping_range(4096, 0, DAX_RANGE_SIZE),
+            Err(SystemError::EINVAL)
+        );
+        assert_eq!(
+            conn.validate_mapping_range(0, u64::MAX - 4095, DAX_RANGE_SIZE),
+            Err(SystemError::EOVERFLOW)
+        );
+    }
+
+    #[test]
+    fn setup_outcome_publishes_rolls_back_or_retires_by_provenance() {
+        let mapping_owner = owner(7);
+
+        let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE).unwrap();
+        let reservation = allocator.try_allocate().unwrap();
+        let owned = FuseConn::apply_setup_outcome(
+            &allocator,
+            &reservation,
+            mapping_owner,
+            FuseDaxRequestOutcome::Success,
+        )
+        .unwrap();
+        assert_eq!(allocator.snapshot().inode_owned, 1);
+        assert_eq!(owned.owner(), mapping_owner);
+        allocator.disconnect_cleanup();
+
+        for outcome in [
+            FuseDaxRequestOutcome::NeverSubmitted(SystemError::ENOMEM),
+            FuseDaxRequestOutcome::DaemonError(SystemError::EIO),
+        ] {
+            let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE).unwrap();
+            let reservation = allocator.try_allocate().unwrap();
+            assert!(FuseConn::apply_setup_outcome(
+                &allocator,
+                &reservation,
+                mapping_owner,
+                outcome,
+            )
+            .is_err());
+            let snapshot = allocator.snapshot();
+            assert_eq!(snapshot.free, 1);
+            assert_eq!(snapshot.retired, 0);
+        }
+
+        for outcome in [
+            FuseDaxRequestOutcome::OutcomeUnknown(SystemError::EIO),
+            FuseDaxRequestOutcome::Disconnected(SystemError::ENOTCONN),
+        ] {
+            let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE).unwrap();
+            let reservation = allocator.try_allocate().unwrap();
+            assert!(FuseConn::apply_setup_outcome(
+                &allocator,
+                &reservation,
+                mapping_owner,
+                outcome,
+            )
+            .is_err());
+            let snapshot = allocator.snapshot();
+            assert_eq!(snapshot.free, 0);
+            assert_eq!(snapshot.retired, 1);
+        }
+    }
+
+    #[test]
+    fn remove_success_frees_only_after_reply() {
+        let count = 2;
+        let conn = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE * count),
+            DaxMountMode::Always,
+        );
+        let allocator = conn.dax_allocator().unwrap();
+        let mapping_owner = owner(11);
+        let tokens = reclaim_tokens(allocator, mapping_owner, count);
+        conn.remove_dax_mappings_with(mapping_owner, &tokens, |_| {
+            assert_eq!(allocator.snapshot().reclaiming, count);
+            FuseDaxRequestOutcome::Success
+        })
+        .unwrap();
+        assert_eq!(allocator.snapshot().free, count);
+    }
+
+    #[test]
+    fn remove_failure_restores_unsent_and_isolates_submitted_batch() {
+        let batch = FuseConn::REMOVE_MAPPING_MAX_ENTRIES;
+        let count = batch + 1;
+        let conn = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE * count),
+            DaxMountMode::Always,
+        );
+        let allocator = conn.dax_allocator().unwrap();
+        let mapping_owner = owner(13);
+        let tokens = reclaim_tokens(allocator, mapping_owner, count);
+        let mut calls = 0;
+        assert_eq!(
+            conn.remove_dax_mappings_with(mapping_owner, &tokens, |_| {
+                calls += 1;
+                if calls == 1 {
+                    FuseDaxRequestOutcome::Success
+                } else {
+                    FuseDaxRequestOutcome::OutcomeUnknown(SystemError::EIO)
+                }
+            }),
+            Err(SystemError::EIO)
+        );
+        assert_eq!(calls, 2);
+        let snapshot = allocator.snapshot();
+        assert_eq!(snapshot.free, batch);
+        assert_eq!(snapshot.retired, 1);
+        assert_eq!(snapshot.inode_owned, 0);
+    }
+
+    #[test]
+    fn remove_never_submitted_restores_entire_batch() {
+        let conn = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE * 2),
+            DaxMountMode::Always,
+        );
+        let allocator = conn.dax_allocator().unwrap();
+        let mapping_owner = owner(17);
+        let tokens = reclaim_tokens(allocator, mapping_owner, 2);
+        assert_eq!(
+            conn.remove_dax_mappings_with(mapping_owner, &tokens, |_| {
+                FuseDaxRequestOutcome::NeverSubmitted(SystemError::ENOMEM)
+            }),
+            Err(SystemError::ENOMEM)
+        );
+        let snapshot = allocator.snapshot();
+        assert_eq!(snapshot.inode_owned, 2);
+        assert_eq!(snapshot.retired, 0);
+        allocator.disconnect_cleanup();
+    }
+
+    #[test]
+    fn remove_daemon_error_isolates_and_disconnect_cleans_up() {
+        let conn = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE),
+            DaxMountMode::Always,
+        );
+        let allocator = conn.dax_allocator().unwrap();
+        let mapping_owner = owner(19);
+        let tokens = reclaim_tokens(allocator, mapping_owner, 1);
+        assert_eq!(
+            conn.remove_dax_mappings_with(mapping_owner, &tokens, |_| {
+                FuseDaxRequestOutcome::DaemonError(SystemError::EBUSY)
+            }),
+            Err(SystemError::EBUSY)
+        );
+        assert_eq!(allocator.snapshot().retired, 1);
+
+        let disconnected = FuseConn::new_for_virtiofs_with_dax(
+            8192,
+            8192,
+            Some(DAX_RANGE_SIZE),
+            DaxMountMode::Always,
+        );
+        let disconnected_allocator = disconnected.dax_allocator().unwrap();
+        let tokens = reclaim_tokens(disconnected_allocator, mapping_owner, 1);
+        assert_eq!(
+            disconnected.remove_dax_mappings_with(mapping_owner, &tokens, |_| {
+                disconnected.abort();
+                FuseDaxRequestOutcome::Disconnected(SystemError::ENOTCONN)
+            }),
+            Err(SystemError::ENOTCONN)
+        );
+        let snapshot = disconnected_allocator.snapshot();
+        assert!(snapshot.shutdown);
+        assert_eq!(snapshot.retired, 1);
+    }
+
+    #[test]
     fn references_protect_mapping_from_reclaim() {
         let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE).unwrap();
         let owned = assign(&allocator, 7);
-        assert_eq!(owned.inode(), 7);
+        assert_eq!(owned.owner(), owner(7));
         assert_eq!(owned.window_offset(), 0);
         assert_eq!(owned.len(), DAX_RANGE_SIZE);
         assert!(allocator.state.lock_irqsave().can_make_progress());
@@ -563,7 +1159,7 @@ mod tests {
         let reservation = allocator.try_allocate().unwrap();
         assert!(!allocator.state.lock_irqsave().can_make_progress());
 
-        let owned = allocator.assign_inode(&reservation, 12).unwrap();
+        let owned = allocator.assign_owner(&reservation, owner(12)).unwrap();
         assert!(allocator.state.lock_irqsave().can_make_progress());
         allocator.get(&owned).unwrap();
         assert!(!allocator.state.lock_irqsave().can_make_progress());
@@ -588,7 +1184,7 @@ mod tests {
         let owned = assign(&allocator, 9);
         let stale = candidates(&allocator, 1).pop().unwrap();
         assert_eq!(stale.window_offset(), 0);
-        assert_eq!(stale.inode(), 9);
+        assert_eq!(stale.owner(), owner(9));
         allocator.get(&owned).unwrap();
         assert_eq!(
             allocator.begin_reclaim(&stale),
@@ -617,6 +1213,92 @@ mod tests {
     }
 
     #[test]
+    fn uncertain_setup_is_retired_until_disconnect() {
+        let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE).unwrap();
+        let reservation = allocator.try_allocate().unwrap();
+        allocator.retire_reservation(&reservation).unwrap();
+        assert_eq!(allocator.snapshot().retired, 1);
+        assert_eq!(
+            allocator.try_allocate(),
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        );
+        assert_eq!(allocator.disconnect_cleanup(), 0);
+        assert!(allocator.state.lock_irqsave().invariants_hold());
+    }
+
+    #[test]
+    fn disconnect_cleanup_invalidates_every_live_state() {
+        let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE * 3).unwrap();
+        let reserved = allocator.try_allocate().unwrap();
+        let owned = assign(&allocator, 2);
+        let reclaim_owned = assign(&allocator, 3);
+        let candidate = candidates(&allocator, 3)
+            .into_iter()
+            .find(|candidate| candidate.owner() == reclaim_owned.owner())
+            .unwrap();
+        let reclaim = allocator.begin_reclaim(&candidate).unwrap();
+
+        assert_eq!(allocator.disconnect_cleanup(), 3);
+        let snapshot = allocator.snapshot();
+        assert!(snapshot.shutdown);
+        assert_eq!(snapshot.retired, 3);
+        assert_eq!(
+            snapshot.free + snapshot.reserved + snapshot.inode_owned + snapshot.reclaiming,
+            0
+        );
+        assert_eq!(
+            allocator.cancel_reservation(&reserved),
+            Err(SystemError::EINVAL)
+        );
+        assert_eq!(allocator.get(&owned), Err(SystemError::EINVAL));
+        assert_eq!(allocator.finish_reclaim(&reclaim), Err(SystemError::EINVAL));
+    }
+
+    #[test]
+    fn reclaim_batch_rejects_cross_generation_owner_and_duplicates() {
+        let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE * 2).unwrap();
+        let first = assign(&allocator, 9);
+        let second_reservation = allocator.try_allocate().unwrap();
+        let second_owner = DaxMappingOwner::from_inode(9, 2).unwrap();
+        let second = allocator
+            .assign_owner(&second_reservation, second_owner)
+            .unwrap();
+        let mut all = candidates(&allocator, 2);
+        let first_candidate = all
+            .iter()
+            .position(|candidate| candidate.owner() == first.owner())
+            .map(|position| all.swap_remove(position))
+            .unwrap();
+        let second_candidate = all.pop().unwrap();
+        let first_reclaim = allocator.begin_reclaim(&first_candidate).unwrap();
+        let second_reclaim = allocator.begin_reclaim(&second_candidate).unwrap();
+        assert_eq!(
+            allocator.validate_reclaim_batch(first.owner(), &[first_reclaim, second_reclaim]),
+            Err(SystemError::EINVAL)
+        );
+        allocator.disconnect_cleanup();
+    }
+
+    #[test]
+    fn reclaim_batch_rejects_duplicate_range() {
+        let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE).unwrap();
+        let owned = assign(&allocator, 7);
+        let candidate = candidates(&allocator, 1).pop().unwrap();
+        let token = allocator.begin_reclaim(&candidate).unwrap();
+        let duplicate = ReclaimToken {
+            index: token.index,
+            generation: token.generation,
+            owner: token.owner,
+            nonce: token.nonce,
+        };
+        assert_eq!(
+            validate_unique_reclaim_indexes(&[token, duplicate]),
+            Err(SystemError::EINVAL)
+        );
+        allocator.disconnect_cleanup();
+    }
+
+    #[test]
     fn zero_range_window_is_valid() {
         let allocator = DaxRangeAllocator::new(DAX_RANGE_SIZE - 1).unwrap();
         assert_eq!(allocator.snapshot().total, 0);
@@ -632,7 +1314,7 @@ mod tests {
         let reservation = allocator.try_allocate().unwrap();
         allocator.begin_shutdown();
         assert_eq!(
-            allocator.assign_inode(&reservation, 11),
+            allocator.assign_owner(&reservation, owner(11)),
             Err(SystemError::ENODEV)
         );
         allocator.cancel_reservation(&reservation).unwrap();
@@ -687,8 +1369,8 @@ mod tests {
         let second = candidates(&allocator, 1);
         assert_eq!(first.len(), 1);
         assert_eq!(second.len(), 1);
-        assert_eq!(first[0].inode(), 1);
-        assert_eq!(second[0].inode(), 2);
+        assert_eq!(first[0].owner(), owner(1));
+        assert_eq!(second[0].owner(), owner(2));
 
         for candidate in first.into_iter().chain(second) {
             let reclaim = allocator.begin_reclaim(&candidate).unwrap();

--- a/kernel/src/filesystem/fuse/virtiofs/dax.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/dax.rs
@@ -645,12 +645,12 @@ impl FuseConn {
             .checked_add(len_u64)
             .ok_or(SystemError::EOVERFLOW)?;
         if len == 0
-            || window_offset % DAX_RANGE_SIZE != 0
-            || len % DAX_RANGE_SIZE != 0
-            || file_offset % DAX_RANGE_SIZE as u64 != 0
-            || file_offset % alignment != 0
-            || window_offset_u64 % alignment != 0
-            || len_u64 % alignment != 0
+            || !window_offset.is_multiple_of(DAX_RANGE_SIZE)
+            || !len.is_multiple_of(DAX_RANGE_SIZE)
+            || !file_offset.is_multiple_of(DAX_RANGE_SIZE as u64)
+            || !file_offset.is_multiple_of(alignment)
+            || !window_offset_u64.is_multiple_of(alignment)
+            || !len_u64.is_multiple_of(alignment)
         {
             return Err(SystemError::EINVAL);
         }

--- a/kernel/src/filesystem/fuse/virtiofs/mount.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/mount.rs
@@ -19,7 +19,9 @@ use super::super::{
     fs::{FuseFS, FuseMountData},
     protocol::FuseOutHeader,
 };
-use super::{bridge::start_bridge, VIRTIOFS_MAX_REQUEST_SIZE, VIRTIOFS_RSP_BUF_SIZE};
+use super::{
+    bridge::start_bridge, dax::DaxMountMode, VIRTIOFS_MAX_REQUEST_SIZE, VIRTIOFS_RSP_BUF_SIZE,
+};
 
 #[derive(Debug)]
 struct VirtioFsMountData {
@@ -28,7 +30,7 @@ struct VirtioFsMountData {
     group_id: u32,
     allow_other: bool,
     default_permissions: bool,
-    dax_mode: VirtioFsDaxMode,
+    dax_mode: DaxMountMode,
     conn: Arc<FuseConn>,
     instance: Arc<VirtioFsInstance>,
 }
@@ -46,13 +48,6 @@ struct VirtioFsFs {
     session_id: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum VirtioFsDaxMode {
-    Never,
-    Always,
-    Inode,
-}
-
 impl VirtioFsFs {
     fn parse_opt_u32_decimal(v: &str) -> Result<u32, SystemError> {
         v.parse::<u32>().map_err(|_| SystemError::EINVAL)
@@ -66,22 +61,22 @@ impl VirtioFsFs {
         v.is_empty() || v != "0"
     }
 
-    fn parse_dax_mode(v: &str) -> Result<VirtioFsDaxMode, SystemError> {
+    fn parse_dax_mode(v: &str) -> Result<DaxMountMode, SystemError> {
         if v.is_empty() {
-            return Ok(VirtioFsDaxMode::Always);
+            return Ok(DaxMountMode::Always);
         }
 
         match v {
-            "always" => Ok(VirtioFsDaxMode::Always),
-            "never" => Ok(VirtioFsDaxMode::Never),
-            "inode" => Ok(VirtioFsDaxMode::Inode),
+            "always" => Ok(DaxMountMode::Always),
+            "never" => Ok(DaxMountMode::Never),
+            "inode" => Ok(DaxMountMode::Inode),
             _ => Err(SystemError::EINVAL),
         }
     }
 
     fn parse_mount_options(
         raw: Option<&str>,
-    ) -> Result<(u32, u32, u32, bool, bool, VirtioFsDaxMode), SystemError> {
+    ) -> Result<(u32, u32, u32, bool, bool, DaxMountMode), SystemError> {
         let pcb = ProcessManager::current_pcb();
         let cred = pcb.cred();
 
@@ -90,7 +85,7 @@ impl VirtioFsFs {
         let mut group_id: Option<u32> = None;
         let mut default_permissions = true;
         let mut allow_other = true;
-        let mut dax_mode = VirtioFsDaxMode::Never;
+        let mut dax_mode = DaxMountMode::Never;
 
         for part in raw.unwrap_or("").split(',') {
             let part = part.trim();
@@ -113,7 +108,7 @@ impl VirtioFsFs {
             }
         }
 
-        if dax_mode != VirtioFsDaxMode::Never {
+        if dax_mode != DaxMountMode::Never {
             return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
         }
 
@@ -208,6 +203,7 @@ impl MountableFileSystem for VirtioFsFs {
             VIRTIOFS_MAX_REQUEST_SIZE,
             VIRTIOFS_RSP_BUF_SIZE,
             instance.cache_window_len(),
+            dax_mode,
         );
 
         Ok(Some(Arc::new(VirtioFsMountData {
@@ -241,7 +237,7 @@ impl MountableFileSystem for VirtioFsFs {
             conn: md.conn.clone(),
         };
 
-        if md.dax_mode != VirtioFsDaxMode::Never {
+        if md.dax_mode != DaxMountMode::Never {
             return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
         }
 


### PR DESCRIPTION
Closes #2079

## Summary

- add the FUSE SETUPMAPPING/REMOVEMAPPING ABI and negotiate MAP_ALIGNMENT/HAS_INODE_DAX capabilities
- implement stable inode-instance ownership and provenance-aware DAX setup/remove transactions
- batch removals with safe rollback/isolation and prevent range reuse after unknown or failed live removals
- distinguish never-submitted, daemon-error, unknown, and disconnected request outcomes across virtiofs bridge teardown
- keep dax=always and dax=inode rejected until the follow-up data-path and teardown issues are complete

## Safety and semantics

SETUPMAPPING publishes a range only after a successful daemon reply. Explicitly unsubmitted or rejected setup requests release their reservation, while uncertain outcomes retire it. REMOVEMAPPING frees ranges only after success; failed submitted batches are isolated and unsent batches are restored. Disconnect closes the allocator before waking pending requests and then performs connection-local cleanup.

The implementation follows Linux 6.6 FUSE ABI and batching semantics while retaining DragonOS fixed 2 MiB range allocation.

## Validation

- make kernel
- final QEMU nographic boot to the DragonOS console
- guest uname and baseline mount inspection
- transaction tests added for all setup outcomes, remove success/failure/disconnect, and a 257-range partial batch failure
- bridge provenance tests added for pending versus inflight teardown

The host cargo test --lib --no-run command remains blocked by pre-existing repository test-build failures (missing Box/Vec imports in unrelated modules and the existing duplicate eh_personality lang item); the production kernel build succeeds.