### PR TITLE
fix(syscall): correct getrandom byte extraction

### DIFF
--- a/kernel/src/syscall/sys_getrandom.rs
+++ b/kernel/src/syscall/sys_getrandom.rs
@@ -1,7 +1,6 @@
 use crate::arch::interrupt::TrapFrame;
-use crate::arch::rand::rand;
 use crate::arch::syscall::nr::SYS_GETRANDOM;
-use crate::libs::rand::GRandFlags;
+use crate::libs::rand::{rand_bytes, GRandFlags};
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
 use crate::syscall::user_access::UserBufferWriter;
@@ -99,6 +98,10 @@ pub fn do_get_random(buf: *mut u8, len: usize, flags: GRandFlags) -> Result<usiz
         return Err(SystemError::EINVAL);
     }
 
+    if len == 0 {
+        return Ok(0);
+    }
+
     let mut writer = UserBufferWriter::new(buf, len, true)?;
     let mut buffer = writer.buffer_protected(0)?;
 
@@ -107,13 +110,7 @@ pub fn do_get_random(buf: *mut u8, len: usize, flags: GRandFlags) -> Result<usiz
         // 对 len - count 的长度进行判断，remain_len 小于4则循环次数和 remain_len 相等
         let remain_len = len - count;
         let step = cmp::min(remain_len, 4);
-        let rand_value = rand();
-
-        // 生成随机字节并直接写入用户缓冲区
-        let mut random_bytes = [0u8; 4];
-        for (offset, byte) in random_bytes.iter_mut().enumerate().take(step) {
-            *byte = (rand_value >> (offset * 2)) as u8;
-        }
+        let random_bytes = rand_bytes::<4>();
 
         // 使用异常表保护的方式写入用户缓冲区
         buffer.write_to_user(count, &random_bytes[..step])?;

--- a/user/apps/tests/dunitest/suites/normal/getrandom_bit_distribution.cc
+++ b/user/apps/tests/dunitest/suites/normal/getrandom_bit_distribution.cc
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+namespace {
+
+long RawGetrandom(void* buffer, size_t length, unsigned int flags) {
+    return syscall(SYS_getrandom, buffer, length, flags);
+}
+
+bool HasLegacyOverlappingBits(const std::array<uint8_t, 4>& sample) {
+    return (sample[0] >> 2) == (sample[1] & 0x3f) &&
+           (sample[1] >> 2) == (sample[2] & 0x3f) &&
+           (sample[2] >> 2) == (sample[3] & 0x3f);
+}
+
+TEST(GetrandomBitDistribution, DoesNotReuseOverlappingBitWindows) {
+    constexpr size_t kSampleCount = 32;
+    size_t overlapping_samples = 0;
+
+    for (size_t i = 0; i < kSampleCount; ++i) {
+        std::array<uint8_t, 4> sample = {};
+        errno = 0;
+        ASSERT_EQ(static_cast<long>(sample.size()),
+                  RawGetrandom(sample.data(), sample.size(), 0))
+            << "sample " << i << " failed with errno=" << errno << " ("
+            << strerror(errno) << ")";
+
+        if (HasLegacyOverlappingBits(sample)) {
+            ++overlapping_samples;
+        }
+    }
+
+    EXPECT_LT(overlapping_samples, kSampleCount)
+        << "all samples match the legacy offset*2 bit-overlap pattern";
+}
+
+TEST(GetrandomBitDistribution, NullBufferWithZeroLengthSucceeds) {
+    errno = 0;
+    EXPECT_EQ(0, RawGetrandom(nullptr, 0, 0));
+    EXPECT_EQ(0, errno);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -3,6 +3,7 @@
 demo/gtest_demo
 normal/capability
 normal/fdatasync
+normal/getrandom_bit_distribution
 normal/ext4_xattr
 normal/ext4_inode_identity
 normal/fallocate_semantics


### PR DESCRIPTION
## Summary

- replace the overlapping `offset * 2` extraction in `getrandom` with the shared `rand_bytes::<4>()` helper
- return zero-length requests before constructing a user buffer, preserving valid `getrandom(NULL, 0, 0)` behavior
- add dunitest coverage for the legacy overlapping-bit fingerprint and the zero-length NULL-buffer case

## Root cause

Each four-byte batch shifted one random value by 0, 2, 4, and 6 bits. Adjacent output bytes therefore shared six bits, and the batch consumed only 14 source bits instead of four distinct bytes.

The fix keeps the existing four-byte batching and protected user-copy path while reusing the repository's little-endian random-byte conversion helper.

## Validation

- reproduced the unfixed kernel in an x86_64 DragonOS guest: all 32/32 samples matched the legacy overlapping-bit relation
- built and ran `getrandom_bit_distribution_test` on the Linux host: 2 tests passed
- built the x86_64 kernel successfully
- built the loongarch64 kernel successfully
- compiled and linked the riscv64 kernel successfully; its final DragonStub packaging step is unavailable because the checked-out submodule has no `install` target
- booted the updated x86_64 kernel in QEMU and ran `/opt/tests/dunitest/bin/normal/getrandom_bit_distribution_test`: 2 tests passed

This change fixes byte extraction but does not claim to replace DragonOS's existing architecture random sources with Linux's ChaCha20 CRNG.

Closes #1743
