### PR TITLE
feat(virtiofs): implement DAX I/O and mmap faults

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -330,7 +330,7 @@ impl X86_64MMArch {
 
         let mut tried_direct_reclaim = false;
 
-        loop {
+        'fault_retry: loop {
             let mut space_guard = current_address_space.write();
             let mut fault;
             loop {
@@ -487,7 +487,8 @@ impl X86_64MMArch {
                     current_address_space.clone(),
                 );
 
-                fault = PageFaultHandler::handle_mm_fault(message);
+                let outcome = PageFaultHandler::handle_mm_fault(message);
+                fault = outcome.reason;
 
                 if fault.contains(VmFaultReason::VM_FAULT_COMPLETED) {
                     return;
@@ -495,6 +496,15 @@ impl X86_64MMArch {
 
                 if unlikely(fault.contains(VmFaultReason::VM_FAULT_RETRY)) {
                     flags |= FaultFlags::FAULT_FLAG_TRIED;
+                    let wait = outcome.retry_wait;
+                    drop(space_guard);
+                    if let Some(wait) = wait {
+                        if wait.wait().is_err() {
+                            send_bus_adrerr();
+                            return;
+                        }
+                    }
+                    continue 'fault_retry;
                 } else {
                     break;
                 }

--- a/kernel/src/driver/virtio/virtio_fs.rs
+++ b/kernel/src/driver/virtio/virtio_fs.rs
@@ -65,7 +65,7 @@ struct VirtioFsIrqConfig {
 }
 
 #[derive(Debug)]
-struct VirtioFsCacheWindow {
+pub(crate) struct VirtioFsCacheWindow {
     mapping: DeviceLinearMapping,
     _reservation: PciBarSubresourceGuard,
 }
@@ -110,6 +110,26 @@ impl VirtioFsCacheWindow {
             _reservation: reservation,
         })
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.mapping.len()
+    }
+
+    pub(crate) fn checked_paddr(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Result<crate::mm::PhysAddr, SystemError> {
+        self.mapping.checked_paddr(offset, len)
+    }
+
+    pub(crate) fn checked_vaddr(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Result<crate::mm::VirtAddr, SystemError> {
+        self.mapping.checked_vaddr(offset, len)
+    }
 }
 
 #[derive(Debug)]
@@ -148,7 +168,7 @@ pub struct VirtioFsInstance {
     irq_wake_enabled: bool,
     irq_is_msix: bool,
     irq_ack: Option<PciInterruptAck>,
-    cache_window: Option<VirtioFsCacheWindow>,
+    cache_window: Option<Arc<VirtioFsCacheWindow>>,
     state: SpinLock<VirtioFsInstanceState>,
     session_wait: WaitQueue,
 }
@@ -160,7 +180,7 @@ impl VirtioFsInstance {
         dev_id: Arc<DeviceId>,
         transport: VirtIOTransport,
         irq: VirtioFsIrqConfig,
-        cache_window: Option<VirtioFsCacheWindow>,
+        cache_window: Option<Arc<VirtioFsCacheWindow>>,
     ) -> Self {
         Self {
             tag,
@@ -195,9 +215,11 @@ impl VirtioFsInstance {
     }
 
     pub fn cache_window_len(&self) -> Option<usize> {
-        self.cache_window
-            .as_ref()
-            .map(|window| window.mapping.len())
+        self.cache_window.as_ref().map(|window| window.len())
+    }
+
+    pub(crate) fn cache_window(&self) -> Option<Arc<VirtioFsCacheWindow>> {
+        self.cache_window.clone()
     }
 
     pub fn hiprio_queue_index(&self) -> u16 {
@@ -475,7 +497,7 @@ pub fn virtio_fs(
         .shared_memory_region(VIRTIO_FS_SHMCAP_ID_CACHE)
         .filter(|region| region.length() != 0);
     let cache_window = cache_region.and_then(|region| match VirtioFsCacheWindow::new(&transport, region) {
-        Ok(window) => Some(window),
+        Ok(window) => Some(Arc::new(window)),
         Err(error) => {
             warn!(
                 "virtio-fs: cache window unavailable for tag='{}' dev={:?}: {:?}; continue without DAX",

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -25,7 +25,12 @@ use crate::{
     process::ProcessManager,
 };
 
-use super::virtiofs::dax::{DaxMountMode, DaxRangeAllocator, DAX_RANGE_SIZE};
+use super::virtiofs::dax::{
+    DaxAdmission, DaxAdmissionGuard, DaxAdmissionState, DaxMappingOwner, DaxMountMode,
+    DaxRangeAllocator, DAX_RANGE_SIZE,
+};
+use crate::driver::virtio::virtio_fs::VirtioFsCacheWindow;
+use crate::mm::fault::FaultRetryWait;
 use crate::process::cred::CAPFlags;
 
 use super::protocol::{
@@ -39,6 +44,17 @@ use super::protocol::{
     FUSE_WRITEBACK_CACHE,
 };
 use super::reply::{FuseReadPagesReply, FuseReply};
+
+#[derive(Debug)]
+struct DaxRangeRetryWait {
+    conn: Arc<FuseConn>,
+}
+
+impl FaultRetryWait for DaxRangeRetryWait {
+    fn wait(&self) -> Result<(), SystemError> {
+        self.conn.reclaim_one_dax_range_for_fault()
+    }
+}
 use super::{stats, trace};
 
 mod daemon;
@@ -678,6 +694,9 @@ pub struct FuseConn {
     background: Arc<FuseBackgroundState>,
     filesystems: Mutex<Vec<Weak<super::fs::FuseFS>>>,
     dax_allocator: Option<Arc<DaxRangeAllocator>>,
+    dax_window: Mutex<Option<Arc<VirtioFsCacheWindow>>>,
+    dax_admission: Arc<DaxAdmission>,
+    dax_nodes: Mutex<BTreeMap<DaxMappingOwner, Weak<super::inode::FuseNode>>>,
 }
 
 impl FuseConn {
@@ -798,11 +817,182 @@ impl FuseConn {
             background: FuseBackgroundState::new(),
             filesystems: Mutex::new(Vec::new()),
             dax_allocator,
+            dax_window: Mutex::new(None),
+            dax_admission: DaxAdmission::new(),
+            dax_nodes: Mutex::new(BTreeMap::new()),
         })
+    }
+
+    pub(crate) fn new_for_virtiofs_with_dax_window(
+        max_request_size: usize,
+        max_reply_size: usize,
+        cache_window: Option<Arc<VirtioFsCacheWindow>>,
+        dax_mode: DaxMountMode,
+    ) -> Arc<Self> {
+        let len = cache_window.as_ref().map(|window| window.len());
+        let conn = Self::new_for_virtiofs_with_dax(max_request_size, max_reply_size, len, dax_mode);
+        if conn.dax_allocator.is_some() {
+            if let Some(window) = cache_window {
+                conn.install_dax_window(window)
+                    .expect("validated virtiofs DAX window must match its allocator");
+            }
+        }
+        conn
     }
 
     pub(crate) fn dax_allocator(&self) -> Option<&Arc<DaxRangeAllocator>> {
         self.dax_allocator.as_ref()
+    }
+
+    pub(crate) fn dax_enabled(&self) -> bool {
+        self.dax_allocator.is_some() && self.dax_window.lock().is_some()
+    }
+
+    pub(crate) fn install_dax_window(
+        &self,
+        window: Arc<VirtioFsCacheWindow>,
+    ) -> Result<(), SystemError> {
+        let allocator = self
+            .dax_allocator
+            .as_ref()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        if window.len() < DAX_RANGE_SIZE
+            || allocator.snapshot().total != window.len() / DAX_RANGE_SIZE
+        {
+            return Err(SystemError::EINVAL);
+        }
+        let mut slot = self.dax_window.lock();
+        if slot.is_some() {
+            return Err(SystemError::EBUSY);
+        }
+        *slot = Some(window);
+        Ok(())
+    }
+
+    pub(crate) fn dax_window(&self) -> Result<Arc<VirtioFsCacheWindow>, SystemError> {
+        self.dax_window
+            .lock()
+            .clone()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+    }
+
+    pub(crate) fn enter_dax(&self) -> Result<DaxAdmissionGuard, SystemError> {
+        self.dax_admission.enter()
+    }
+
+    pub(crate) fn dax_admission_state(&self) -> DaxAdmissionState {
+        self.dax_admission.state()
+    }
+
+    pub(crate) fn begin_dax_quiesce(&self) {
+        self.dax_admission.begin_quiesce();
+    }
+
+    pub(crate) fn wait_dax_drained(&self) {
+        self.dax_admission.wait_drained();
+    }
+
+    pub(crate) fn mark_dax_dead(&self) {
+        self.dax_admission.mark_dead();
+    }
+
+    pub(crate) fn register_dax_node(&self, node: &Arc<super::inode::FuseNode>) {
+        let owner = node.dax_mapping_owner();
+        let mut nodes = self.dax_nodes.lock();
+        nodes.retain(|_, node| node.strong_count() != 0);
+        nodes.insert(owner, Arc::downgrade(node));
+    }
+
+    pub(crate) fn unregister_dax_node(&self, owner: DaxMappingOwner) {
+        self.dax_nodes.lock().remove(&owner);
+    }
+
+    pub(crate) fn dax_node(&self, owner: DaxMappingOwner) -> Option<Arc<super::inode::FuseNode>> {
+        let mut nodes = self.dax_nodes.lock();
+        let node = nodes.get(&owner).and_then(Weak::upgrade);
+        if node.is_none() {
+            nodes.remove(&owner);
+        }
+        node
+    }
+
+    fn revoke_all_dax_ptes(&self) {
+        let nodes: Vec<_> = {
+            let mut registry = self.dax_nodes.lock();
+            let nodes = registry.values().filter_map(Weak::upgrade).collect();
+            registry.retain(|_, node| node.strong_count() != 0);
+            nodes
+        };
+        for node in nodes {
+            if let Err(error) = node.dax_disconnect_revoke() {
+                log::warn!(
+                    "fuse: failed to revoke DAX PTEs for node {} during disconnect: {:?}",
+                    node.nodeid(),
+                    error
+                );
+            }
+        }
+    }
+
+    pub(crate) fn dax_fault_retry_wait(self: &Arc<Self>) -> Arc<dyn FaultRetryWait> {
+        Arc::new(DaxRangeRetryWait { conn: self.clone() })
+    }
+
+    pub(crate) fn reclaim_one_dax_range_interruptible(&self) -> Result<(), SystemError> {
+        self.reclaim_one_dax_range(true)
+    }
+
+    fn reclaim_one_dax_range_for_fault(&self) -> Result<(), SystemError> {
+        self.reclaim_one_dax_range(false)
+    }
+
+    fn reclaim_one_dax_range(&self, interruptible: bool) -> Result<(), SystemError> {
+        let allocator = self
+            .dax_allocator
+            .as_ref()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        let mut candidates = Vec::with_capacity(16);
+        loop {
+            let snapshot = allocator.snapshot();
+            if snapshot.shutdown {
+                return Err(SystemError::ENODEV);
+            }
+            if snapshot.free > 0 {
+                return Ok(());
+            }
+            allocator.reclaim_candidates(&mut candidates, 16)?;
+            if candidates.is_empty() {
+                if interruptible {
+                    allocator.wait_available_interruptible()?;
+                } else {
+                    allocator.wait_available()?;
+                }
+                continue;
+            }
+            for candidate in &candidates {
+                let Some(node) = self.dax_node(candidate.owner()) else {
+                    // A Weak cannot be upgraded while FuseNode::drop() is
+                    // running. Do not race that teardown by changing the token
+                    // state behind its mapping tree.
+                    continue;
+                };
+                match node.dax_reclaim_candidate(candidate) {
+                    Ok(()) => return Ok(()),
+                    Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => continue,
+                    Err(error) => return Err(error),
+                }
+            }
+            if interruptible
+                && crate::arch::ipc::signal::Signal::signal_pending_state(
+                    true,
+                    false,
+                    &ProcessManager::current_pcb(),
+                )
+            {
+                return Err(SystemError::ERESTARTSYS);
+            }
+            crate::sched::sched_yield();
+        }
     }
 
     pub(crate) fn dax_map_alignment(&self) -> Option<u16> {
@@ -1096,9 +1286,13 @@ impl FuseConn {
     }
 
     pub fn abort(&self) {
+        self.begin_dax_quiesce();
         self.background.disconnect();
         let (processing, pending_noreply_count): (Vec<Arc<FusePendingState>>, usize) = {
             let mut g = self.inner.lock();
+            if !g.connected {
+                return;
+            }
             g.connected = false;
             g.mounted = false;
             // Close allocator acquisition before releasing the connection lock,
@@ -1121,7 +1315,13 @@ impl FuseConn {
         for p in processing {
             p.complete_disconnected(SystemError::ENOTCONN);
         }
+        // Admission was closed before requests were detached.  Wait until every
+        // DAX copy/fault/setup that was already admitted has released its guard
+        // before invalidating allocator tokens and the backing window.
+        self.wait_dax_drained();
+        self.revoke_all_dax_ptes();
         self.disconnect_cleanup_dax_allocator();
+        self.mark_dax_dead();
         self.read_wait.wakeup(None);
         self.wake_bridge(stats::VirtioFsBridgeWakeSource::Disconnect);
         self.init_wait.wakeup(None);
@@ -1136,7 +1336,7 @@ impl FuseConn {
     /// Keep the connection readable for daemon-side teardown; actual disconnect
     /// happens when /dev/fuse is closed or explicit abort path is triggered.
     pub fn on_umount(&self) {
-        self.begin_shutdown_dax_allocator();
+        self.begin_dax_quiesce();
         self.background.disconnect();
         let processing: Vec<Arc<FusePendingState>>;
         let dropped_processing: Vec<Arc<FusePendingState>>;
@@ -1186,6 +1386,8 @@ impl FuseConn {
         for p in dropped_processing {
             p.complete(Err(SystemError::ENOTCONN));
         }
+        self.wait_dax_drained();
+        self.begin_shutdown_dax_allocator();
         self.init_wait.wakeup(None);
 
         if !should_destroy {

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -101,7 +101,7 @@ impl FuseConn {
     }
 
     pub(crate) fn request_dax_mapping(
-        &self,
+        self: &Arc<Self>,
         opcode: u32,
         nodeid: u64,
         payload: &[u8],
@@ -120,14 +120,12 @@ impl FuseConn {
         let (result, kind) = match pending.wait_result_with_kind_uninterruptible() {
             Ok(result) => result,
             Err(_) => {
-                // A dead wait queue is an internal connection failure. Abort
-                // first so the request obtains a real terminal state before
-                // its allocator pin/reservation can be released.
-                self.abort();
-                match pending.wait_result_with_kind() {
-                    Ok(result) => result,
-                    Err(error) => return FuseDaxRequestOutcome::Disconnected(error),
-                }
+                // The DAX caller still owns an admission guard. Synchronous
+                // abort would wait for that same guard and self-deadlock, so
+                // defer connection teardown until this stack has unwound.
+                let conn = self.clone();
+                schedule_work(Work::new(move || conn.abort()));
+                return FuseDaxRequestOutcome::Disconnected(SystemError::ENOTCONN);
             }
         };
         match (result, kind) {

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -439,6 +439,15 @@ impl FuseFS {
             node.mark_stale();
         }
         for node in live_nodes.iter().chain(retired_nodes.iter()) {
+            if let Err(error) = node.dax_teardown() {
+                log::warn!(
+                    "fuse: failed to tear down DAX mappings for node {}: {:?}",
+                    node.nodeid(),
+                    error
+                );
+            }
+        }
+        for node in live_nodes.iter().chain(retired_nodes.iter()) {
             node.clear_lookup_cache_tree();
         }
         for node in live_nodes.iter().chain(retired_nodes.iter()) {
@@ -830,6 +839,10 @@ impl FileSystem for FuseFS {
     }
 
     fn on_umount(&self) {
+        if !self.is_submount {
+            self.conn.begin_dax_quiesce();
+            self.conn.wait_dax_drained();
+        }
         self.teardown_nodes();
         if !self.is_submount {
             self.conn.on_umount();

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -385,11 +385,10 @@ impl FuseNode {
                 writable: AtomicBool::new(writable),
                 token,
             });
-            if let Err(error) = allocator.get(&mapping.token) {
-                // The daemon mapping exists but cannot safely be published locally.
-                // Retain its allocator ownership; teardown will retire the connection range.
-                return Err(error);
-            }
+            // The daemon mapping exists but cannot safely be published locally
+            // without the access reference. Retain allocator ownership on error;
+            // teardown will retire the connection range.
+            allocator.get(&mapping.token)?;
             tree.bump_sequence()?;
             tree.mappings.insert(file_offset, mapping.clone());
             drop(tree);

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -21,7 +21,8 @@ use crate::{
         vfs::{FileType, InodeFlags, InodeId, InodeMode, Metadata},
     },
     libs::mutex::Mutex,
-    libs::rwsem::RwSem,
+    libs::rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
+    mm::MemoryManagementArch,
     time::PosixTimeSpec,
 };
 
@@ -32,11 +33,127 @@ use super::{
     private_data::FuseWritebackHandle,
     protocol::{
         fuse_pack_struct, fuse_read_struct, FuseAttr, FuseAttrOut, FuseEntryOut, FuseGetattrIn,
-        FUSE_GETATTR, FUSE_ROOT_ID,
+        FuseWriteIn, FuseWriteOut, FUSE_GETATTR, FUSE_ROOT_ID, FUSE_WRITE, FUSE_WRITE_LOCKOWNER,
+    },
+};
+
+use super::{
+    private_data::FuseOpenPrivateData,
+    virtiofs::dax::{
+        DaxAdmissionGuard, DaxMappingOwner, DaxRangeAllocator, OwnedToken, ReclaimCandidate,
+        ReclaimToken, DAX_RANGE_SIZE,
     },
 };
 
 static NEXT_DAX_OWNER_INCARNATION: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug)]
+pub(crate) struct DaxMapping {
+    file_offset: u64,
+    writable: AtomicBool,
+    token: OwnedToken,
+}
+
+#[derive(Debug, Default)]
+struct DaxMappingTree {
+    mappings: BTreeMap<u64, Arc<DaxMapping>>,
+    tombstones: BTreeMap<u64, Arc<DaxMapping>>,
+    sequence: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct DaxAccessGuard {
+    mapping: Arc<DaxMapping>,
+    allocator: Arc<DaxRangeAllocator>,
+    window: Arc<crate::driver::virtio::virtio_fs::VirtioFsCacheWindow>,
+    _admission: Option<DaxAdmissionGuard>,
+}
+
+#[derive(Debug)]
+pub(crate) struct DaxReclaimTombstone {
+    file_offset: u64,
+    mapping: Arc<DaxMapping>,
+    token: ReclaimToken,
+}
+
+impl DaxMappingTree {
+    fn bump_sequence(&mut self) -> Result<(), SystemError> {
+        self.sequence = self.sequence.checked_add(1).ok_or(SystemError::EOVERFLOW)?;
+        Ok(())
+    }
+}
+
+impl DaxMapping {
+    pub(crate) fn file_offset(&self) -> u64 {
+        self.file_offset
+    }
+
+    pub(crate) fn window_offset(&self) -> usize {
+        self.token.window_offset()
+    }
+
+    pub(crate) fn writable(&self) -> bool {
+        self.writable.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn owner(&self) -> DaxMappingOwner {
+        self.token.owner()
+    }
+}
+
+impl DaxAccessGuard {
+    pub(crate) fn mapping(&self) -> &Arc<DaxMapping> {
+        &self.mapping
+    }
+
+    fn checked_window_offset(&self, offset: usize, len: usize) -> Result<usize, SystemError> {
+        let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        if end > DAX_RANGE_SIZE {
+            return Err(SystemError::ERANGE);
+        }
+        self.mapping
+            .window_offset()
+            .checked_add(offset)
+            .ok_or(SystemError::EOVERFLOW)
+    }
+
+    pub(crate) fn checked_paddr(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Result<crate::mm::PhysAddr, SystemError> {
+        self.window
+            .checked_paddr(self.checked_window_offset(offset, len)?, len)
+    }
+
+    pub(crate) fn copy_to(&self, offset: usize, dst: &mut [u8]) -> Result<(), SystemError> {
+        let window_offset = self.checked_window_offset(offset, dst.len())?;
+        let src = self.window.checked_vaddr(window_offset, dst.len())?;
+        unsafe {
+            core::ptr::copy_nonoverlapping(src.data() as *const u8, dst.as_mut_ptr(), dst.len());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn copy_from(&self, offset: usize, src: &[u8]) -> Result<(), SystemError> {
+        if !self.mapping.writable() {
+            return Err(SystemError::EACCES);
+        }
+        let window_offset = self.checked_window_offset(offset, src.len())?;
+        let dst = self.window.checked_vaddr(window_offset, src.len())?;
+        unsafe {
+            core::ptr::copy_nonoverlapping(src.as_ptr(), dst.data() as *mut u8, src.len());
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DaxAccessGuard {
+    fn drop(&mut self) {
+        let result = self.allocator.put(&self.mapping.token);
+        debug_assert!(result.is_ok() || result == Err(SystemError::EINVAL));
+    }
+}
 
 #[derive(Debug)]
 pub struct FuseNode {
@@ -55,6 +172,8 @@ pub struct FuseNode {
     /// Serializes dirty-page admission against operations which must drain and
     /// invalidate the page cache (truncate and direct I/O).
     writeback_barrier: RwSem<()>,
+    dax_mappings: RwSem<DaxMappingTree>,
+    dax_pte_epoch: AtomicU64,
     cached_metadata_deadline_ns: AtomicU64,
     attr_version: AtomicU64,
     /// Version chain produced while short READ replies from one metadata
@@ -101,7 +220,7 @@ impl FuseNode {
             dax_owner_incarnation, 0,
             "FUSE DAX owner identity exhausted"
         );
-        Arc::new_cyclic(|self_ref| Self {
+        let node = Arc::new_cyclic(|self_ref| Self {
             fs,
             conn,
             self_ref: self_ref.clone(),
@@ -115,6 +234,8 @@ impl FuseNode {
             writeback_handles: Mutex::new(Vec::new()),
             lookup_cache: Mutex::new(BTreeMap::new()),
             writeback_barrier: RwSem::new(()),
+            dax_mappings: RwSem::new(DaxMappingTree::default()),
+            dax_pte_epoch: AtomicU64::new(0),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             attr_version: AtomicU64::new(initial_attr_epoch),
             short_read_source_attr_version: AtomicU64::new(0),
@@ -124,7 +245,9 @@ impl FuseNode {
             lookup_attr_flags: AtomicU32::new(0),
             generation: AtomicU64::new(0),
             stale: AtomicBool::new(false),
-        })
+        });
+        node.conn.register_dax_node(&node);
+        node
     }
 
     pub fn lookup_attr_flags(&self) -> u32 {
@@ -138,6 +261,619 @@ impl FuseNode {
     pub(crate) fn dax_mapping_owner(&self) -> super::virtiofs::dax::DaxMappingOwner {
         super::virtiofs::dax::DaxMappingOwner::from_inode(self.nodeid, self.dax_owner_incarnation)
             .expect("FuseNode has a valid DAX owner identity")
+    }
+
+    pub(crate) fn dax_layout_read(&self) -> RwSemReadGuard<'_, ()> {
+        self.writeback_barrier.read()
+    }
+
+    pub(crate) fn dax_layout_write(&self) -> RwSemWriteGuard<'_, ()> {
+        self.writeback_barrier.write()
+    }
+
+    pub(crate) fn dax_pte_epoch(&self) -> u64 {
+        self.dax_pte_epoch.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn dax_note_pte_published(&self) -> Result<u64, SystemError> {
+        self.dax_pte_epoch
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |epoch| {
+                epoch.checked_add(1)
+            })
+            .map(|old| old + 1)
+            .map_err(|_| SystemError::EOVERFLOW)
+    }
+
+    fn dax_aligned_offset(offset: u64) -> u64 {
+        offset & !(DAX_RANGE_SIZE as u64 - 1)
+    }
+
+    pub(crate) fn dax_access(
+        &self,
+        offset: u64,
+        writable: bool,
+    ) -> Result<DaxAccessGuard, SystemError> {
+        let admission = self.conn.enter_dax()?;
+        self.dax_access_inner(offset, writable, Some(admission))
+    }
+
+    fn dax_access_inner(
+        &self,
+        offset: u64,
+        writable: bool,
+        admission: Option<DaxAdmissionGuard>,
+    ) -> Result<DaxAccessGuard, SystemError> {
+        let file_offset = Self::dax_aligned_offset(offset);
+        let allocator = self
+            .conn
+            .dax_allocator()
+            .cloned()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        let window = self.conn.dax_window()?;
+
+        loop {
+            let mapping = {
+                let tree = self.dax_mappings.read();
+                if tree.tombstones.contains_key(&file_offset) {
+                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                }
+                let mapping = tree.mappings.get(&file_offset).cloned();
+                if let Some(mapping) = mapping.as_ref() {
+                    // Pin while the tree read lock still prevents reclaim from
+                    // transitioning this exact token to Reclaiming.
+                    allocator.get(&mapping.token)?;
+                }
+                mapping
+            };
+
+            if let Some(mapping) = mapping {
+                if !writable || mapping.writable() {
+                    return Ok(DaxAccessGuard {
+                        mapping,
+                        allocator,
+                        window,
+                        _admission: admission,
+                    });
+                }
+
+                let mut tree = self.dax_mappings.write();
+                let current = tree.mappings.get(&file_offset).cloned();
+                if !current
+                    .as_ref()
+                    .is_some_and(|current| Arc::ptr_eq(current, &mapping))
+                {
+                    drop(tree);
+                    allocator.put(&mapping.token)?;
+                    continue;
+                }
+                if !mapping.writable() {
+                    if let Err(error) = self.conn.setup_existing_dax_mapping(
+                        self.dax_mapping_owner(),
+                        &mapping.token,
+                        file_offset,
+                        true,
+                    ) {
+                        drop(tree);
+                        allocator.put(&mapping.token)?;
+                        return Err(error);
+                    }
+                    mapping.writable.store(true, Ordering::Release);
+                    tree.bump_sequence()?;
+                }
+                drop(tree);
+                return Ok(DaxAccessGuard {
+                    mapping,
+                    allocator,
+                    window,
+                    _admission: admission,
+                });
+            }
+
+            let mut tree = self.dax_mappings.write();
+            if tree.tombstones.contains_key(&file_offset) {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            if tree.mappings.contains_key(&file_offset) {
+                drop(tree);
+                continue;
+            }
+            let token =
+                self.conn
+                    .setup_dax_mapping(self.dax_mapping_owner(), file_offset, writable)?;
+            let mapping = Arc::new(DaxMapping {
+                file_offset,
+                writable: AtomicBool::new(writable),
+                token,
+            });
+            if let Err(error) = allocator.get(&mapping.token) {
+                // The daemon mapping exists but cannot safely be published locally.
+                // Retain its allocator ownership; teardown will retire the connection range.
+                return Err(error);
+            }
+            tree.bump_sequence()?;
+            tree.mappings.insert(file_offset, mapping.clone());
+            drop(tree);
+            return Ok(DaxAccessGuard {
+                mapping,
+                allocator,
+                window,
+                _admission: admission,
+            });
+        }
+    }
+
+    pub(crate) fn dax_isolate_reclaim(
+        &self,
+        candidate: &ReclaimCandidate,
+        expected_pte_epoch: u64,
+    ) -> Result<DaxReclaimTombstone, SystemError> {
+        let _layout = self.dax_layout_write();
+        self.dax_isolate_reclaim_locked(candidate, expected_pte_epoch)
+    }
+
+    fn dax_isolate_reclaim_locked(
+        &self,
+        candidate: &ReclaimCandidate,
+        expected_pte_epoch: u64,
+    ) -> Result<DaxReclaimTombstone, SystemError> {
+        if self.dax_pte_epoch() != expected_pte_epoch {
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        }
+        let allocator = self
+            .conn
+            .dax_allocator()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        let mut tree = self.dax_mappings.write();
+        let Some((file_offset, mapping)) = tree
+            .mappings
+            .iter()
+            .find(|(_, mapping)| mapping.token.matches_candidate(candidate))
+            .map(|(offset, mapping)| (*offset, mapping.clone()))
+        else {
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        };
+        let token = allocator.begin_reclaim(candidate)?;
+        tree.mappings.remove(&file_offset);
+        tree.tombstones.insert(file_offset, mapping.clone());
+        tree.bump_sequence()?;
+        Ok(DaxReclaimTombstone {
+            file_offset,
+            mapping,
+            token,
+        })
+    }
+
+    /// Acquire the inode layout exclusively after revoking and removing every
+    /// DAX range intersecting `[new_size, EOF)`.  Sequence and PTE epochs make
+    /// the rmap-walk-to-lock transition retryable instead of racy.
+    pub(crate) fn dax_layout_write_for_truncate(
+        &self,
+        new_size: usize,
+    ) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
+        if !self.conn.dax_enabled() {
+            return Ok(self.dax_layout_write());
+        }
+        'retry: loop {
+            let page_cache = self.cached_page_cache();
+            let (sequence, mappings) = {
+                let tree = self.dax_mappings.read();
+                let mappings = tree
+                    .mappings
+                    .values()
+                    .filter(|mapping| {
+                        (mapping.file_offset as usize).saturating_add(DAX_RANGE_SIZE) > new_size
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                (tree.sequence, mappings)
+            };
+            let epoch = self.dax_pte_epoch();
+            if let Some(cache) = page_cache.as_ref() {
+                for mapping in &mappings {
+                    let start = usize::try_from(mapping.file_offset)
+                        .map_err(|_| SystemError::EOVERFLOW)?
+                        >> crate::arch::MMArch::PAGE_SHIFT;
+                    let end = start
+                        .checked_add(DAX_RANGE_SIZE >> crate::arch::MMArch::PAGE_SHIFT)
+                        .ok_or(SystemError::EOVERFLOW)?;
+                    cache.unmap_mapping_pages(start, Some(end))?;
+                }
+            }
+            let layout = self.dax_layout_write();
+            if self.dax_pte_epoch() != epoch || self.dax_mappings.read().sequence != sequence {
+                drop(layout);
+                continue;
+            }
+            let allocator = self
+                .conn
+                .dax_allocator()
+                .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+            let total = allocator.snapshot().total;
+            let mut candidates = Vec::with_capacity(total);
+            allocator.reclaim_candidates(&mut candidates, total)?;
+            let mut tombstones = Vec::with_capacity(mappings.len());
+            for mapping in &mappings {
+                let Some(candidate) = candidates
+                    .iter()
+                    .find(|candidate| mapping.token.matches_candidate(candidate))
+                else {
+                    for tombstone in tombstones.drain(..) {
+                        let _ = self.dax_cancel_reclaim(tombstone);
+                    }
+                    drop(layout);
+                    continue 'retry;
+                };
+                match self.dax_isolate_reclaim_locked(candidate, epoch) {
+                    Ok(tombstone) => tombstones.push(tombstone),
+                    Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
+                        for tombstone in tombstones.drain(..) {
+                            let _ = self.dax_cancel_reclaim(tombstone);
+                        }
+                        drop(layout);
+                        continue 'retry;
+                    }
+                    Err(error) => {
+                        for tombstone in tombstones.drain(..) {
+                            let _ = self.dax_cancel_reclaim(tombstone);
+                        }
+                        return Err(error);
+                    }
+                }
+            }
+            drop(layout);
+            let second_zap = (|| {
+                for tombstone in &tombstones {
+                    if let Some(cache) = page_cache.as_ref() {
+                        let start = usize::try_from(tombstone.file_offset)
+                            .map_err(|_| SystemError::EOVERFLOW)?
+                            >> crate::arch::MMArch::PAGE_SHIFT;
+                        let end = start
+                            .checked_add(DAX_RANGE_SIZE >> crate::arch::MMArch::PAGE_SHIFT)
+                            .ok_or(SystemError::EOVERFLOW)?;
+                        // The tombstone blocks new DAX faults. A second rmap
+                        // pass drains fork/mremap publishers that raced the
+                        // first zap.
+                        cache.unmap_mapping_pages(start, Some(end))?;
+                    }
+                }
+                Ok::<(), SystemError>(())
+            })();
+            if let Err(error) = second_zap {
+                for tombstone in tombstones.drain(..) {
+                    let _ = self.dax_cancel_reclaim(tombstone);
+                }
+                return Err(error);
+            }
+            let layout = self.dax_layout_write();
+            let mut remaining = tombstones.into_iter();
+            while let Some(tombstone) = remaining.next() {
+                if let Err(error) = self.dax_finish_reclaim(tombstone) {
+                    for unsubmitted in remaining {
+                        let _ = self.dax_cancel_reclaim(unsubmitted);
+                    }
+                    return Err(error);
+                }
+            }
+            return Ok(layout);
+        }
+    }
+
+    pub(crate) fn dax_teardown(&self) -> Result<(), SystemError> {
+        if self.conn.dax_enabled() {
+            drop(self.dax_layout_write_for_truncate(0)?);
+        }
+        Ok(())
+    }
+
+    /// Disconnect-only local revocation. The daemon can no longer confirm
+    /// REMOVEMAPPING, so clear inode ownership after two PTE zaps and let the
+    /// connection retire every allocator entry globally.
+    pub(crate) fn dax_disconnect_revoke(&self) -> Result<(), SystemError> {
+        let page_cache = self.cached_page_cache();
+        let mappings = self
+            .dax_mappings
+            .read()
+            .mappings
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let zap = |mapping: &DaxMapping| -> Result<(), SystemError> {
+            let Some(cache) = page_cache.as_ref() else {
+                return Ok(());
+            };
+            let start = usize::try_from(mapping.file_offset).map_err(|_| SystemError::EOVERFLOW)?
+                >> crate::arch::MMArch::PAGE_SHIFT;
+            let end = start
+                .checked_add(DAX_RANGE_SIZE >> crate::arch::MMArch::PAGE_SHIFT)
+                .ok_or(SystemError::EOVERFLOW)?;
+            cache.unmap_mapping_pages(start, Some(end))
+        };
+        for mapping in &mappings {
+            zap(mapping)?;
+        }
+        {
+            let _layout = self.dax_layout_write();
+            let mut tree = self.dax_mappings.write();
+            tree.mappings.clear();
+            tree.tombstones.clear();
+            tree.bump_sequence()?;
+        }
+        for mapping in &mappings {
+            zap(mapping)?;
+        }
+        Ok(())
+    }
+
+    fn dax_abandon_mappings(&self) {
+        let mappings = self
+            .dax_mappings
+            .read()
+            .mappings
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let _ = self.dax_disconnect_revoke();
+        let Some(allocator) = self.conn.dax_allocator() else {
+            return;
+        };
+        let total = allocator.snapshot().total;
+        let mut candidates = Vec::with_capacity(total);
+        if allocator
+            .reclaim_candidates(&mut candidates, total)
+            .is_err()
+        {
+            return;
+        }
+        for mapping in mappings {
+            if let Some(candidate) = candidates
+                .iter()
+                .find(|candidate| mapping.token.matches_candidate(candidate))
+            {
+                if let Ok(token) = allocator.begin_reclaim(candidate) {
+                    let _ = allocator.retire_reclaim(&token);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn dax_cancel_reclaim(
+        &self,
+        tombstone: DaxReclaimTombstone,
+    ) -> Result<(), SystemError> {
+        let allocator = self
+            .conn
+            .dax_allocator()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        let mut tree = self.dax_mappings.write();
+        if !tree
+            .tombstones
+            .get(&tombstone.file_offset)
+            .is_some_and(|mapping| Arc::ptr_eq(mapping, &tombstone.mapping))
+        {
+            return Err(SystemError::EINVAL);
+        }
+        let restored = allocator.cancel_reclaim(&tombstone.token)?;
+        if !restored.same_identity(&tombstone.mapping.token) {
+            return Err(SystemError::EINVAL);
+        }
+        tree.tombstones.remove(&tombstone.file_offset);
+        tree.mappings
+            .insert(tombstone.file_offset, tombstone.mapping);
+        tree.bump_sequence()
+    }
+
+    pub(crate) fn dax_finish_reclaim(
+        &self,
+        tombstone: DaxReclaimTombstone,
+    ) -> Result<(), SystemError> {
+        let result = self.conn.remove_dax_mappings(
+            self.dax_mapping_owner(),
+            core::slice::from_ref(&tombstone.token),
+        );
+        let allocator = self
+            .conn
+            .dax_allocator()
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        let restore = result.is_err() && allocator.is_owned(&tombstone.mapping.token);
+        let mut tree = self.dax_mappings.write();
+        if tree
+            .tombstones
+            .get(&tombstone.file_offset)
+            .is_some_and(|mapping| Arc::ptr_eq(mapping, &tombstone.mapping))
+        {
+            tree.tombstones.remove(&tombstone.file_offset);
+            if restore {
+                tree.mappings
+                    .insert(tombstone.file_offset, tombstone.mapping);
+            }
+            tree.bump_sequence()?;
+        }
+        result
+    }
+
+    pub(crate) fn dax_mapping_for_offset(&self, offset: u64) -> Option<Arc<DaxMapping>> {
+        self.dax_mappings
+            .read()
+            .mappings
+            .get(&Self::dax_aligned_offset(offset))
+            .cloned()
+    }
+
+    pub(crate) fn dax_file_size(&self) -> Result<usize, SystemError> {
+        usize::try_from(self.cached_or_fetch_metadata()?.size.max(0))
+            .map_err(|_| SystemError::EOVERFLOW)
+    }
+
+    /// Reclaim one daemon mapping after first revoking every PTE that can
+    /// reference its 2 MiB cache-window range.  The epoch closes the race
+    /// between the rmap walk and taking the inode layout lock.
+    pub(crate) fn dax_reclaim_candidate(
+        &self,
+        candidate: &ReclaimCandidate,
+    ) -> Result<(), SystemError> {
+        let mapping = self
+            .dax_mappings
+            .read()
+            .mappings
+            .values()
+            .find(|mapping| mapping.token.matches_candidate(candidate))
+            .cloned()
+            .ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)?;
+        let expected_epoch = self.dax_pte_epoch();
+        let page_cache = self.cached_page_cache();
+        let start = usize::try_from(mapping.file_offset).map_err(|_| SystemError::EOVERFLOW)?
+            >> crate::arch::MMArch::PAGE_SHIFT;
+        let end = start
+            .checked_add(DAX_RANGE_SIZE >> crate::arch::MMArch::PAGE_SHIFT)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if let Some(cache) = page_cache.as_ref() {
+            cache.unmap_mapping_pages(start, Some(end))?;
+        }
+        let tombstone = self.dax_isolate_reclaim(candidate, expected_epoch)?;
+        if let Some(cache) = page_cache.as_ref() {
+            if let Err(error) = cache.unmap_mapping_pages(start, Some(end)) {
+                let _ = self.dax_cancel_reclaim(tombstone);
+                return Err(error);
+            }
+        }
+        self.dax_finish_reclaim(tombstone)
+    }
+
+    pub(crate) fn dax_read(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let _admission = self.conn.enter_dax()?;
+        let _layout = self.dax_layout_read();
+        let size = self.cached_or_fetch_metadata()?.size.max(0) as usize;
+        if offset >= size {
+            return Ok(0);
+        }
+        let requested = core::cmp::min(buf.len(), size - offset);
+        let mut done = 0usize;
+        while done < requested {
+            let current = offset.checked_add(done).ok_or(SystemError::EOVERFLOW)?;
+            let in_mapping = current & (DAX_RANGE_SIZE - 1);
+            let chunk = core::cmp::min(requested - done, DAX_RANGE_SIZE - in_mapping);
+            let access = match self.dax_access_inner(current as u64, false, None) {
+                Ok(access) => access,
+                Err(error) if done == 0 => return Err(error),
+                Err(_) => return Ok(done),
+            };
+            if let Err(error) = access.copy_to(in_mapping, &mut buf[done..done + chunk]) {
+                return if done == 0 { Err(error) } else { Ok(done) };
+            }
+            done += chunk;
+        }
+        Ok(done)
+    }
+
+    /// Send ordinary FUSE WRITE while the caller owns the inode layout write lock.
+    /// This helper deliberately does not acquire `writeback_barrier` again.
+    pub(crate) fn fuse_write_locked(
+        &self,
+        offset: usize,
+        buf: &[u8],
+        private: &FuseOpenPrivateData,
+        lock_owner: u64,
+    ) -> Result<usize, SystemError> {
+        let max_write = self.conn.max_write();
+        if max_write == 0 {
+            return Err(SystemError::EIO);
+        }
+        let mut done = 0usize;
+        while done < buf.len() {
+            let chunk = core::cmp::min(max_write, buf.len() - done);
+            let current = offset.checked_add(done).ok_or(SystemError::EOVERFLOW)?;
+            if current > i64::MAX as usize || chunk > u32::MAX as usize {
+                return if done == 0 {
+                    Err(SystemError::EFBIG)
+                } else {
+                    Ok(done)
+                };
+            }
+            let input = FuseWriteIn {
+                fh: private.fh,
+                offset: current as u64,
+                size: chunk as u32,
+                write_flags: if lock_owner != 0 {
+                    FUSE_WRITE_LOCKOWNER
+                } else {
+                    0
+                },
+                lock_owner,
+                flags: private.open_flags,
+                padding: 0,
+            };
+            let payload_len = core::mem::size_of::<FuseWriteIn>()
+                .checked_add(chunk)
+                .ok_or(SystemError::EOVERFLOW)?;
+            let mut request = Vec::new();
+            request
+                .try_reserve_exact(payload_len)
+                .map_err(|_| SystemError::ENOMEM)?;
+            request.extend_from_slice(fuse_pack_struct(&input));
+            request.extend_from_slice(&buf[done..done + chunk]);
+            let payload = match self.conn.request(FUSE_WRITE, self.nodeid, &request) {
+                Ok(payload) => payload,
+                Err(error) if done == 0 => return Err(error),
+                Err(_) => return Ok(done),
+            };
+            let output: FuseWriteOut = fuse_read_struct(&payload)?;
+            let wrote = output.size as usize;
+            if wrote > chunk {
+                return if done == 0 {
+                    Err(SystemError::EIO)
+                } else {
+                    Ok(done)
+                };
+            }
+            self.note_successful_write(current, wrote)?;
+            done += wrote;
+            if wrote < chunk {
+                break;
+            }
+        }
+        Ok(done)
+    }
+
+    pub(crate) fn dax_write_or_fuse_locked(
+        &self,
+        offset: usize,
+        buf: &[u8],
+        private: &FuseOpenPrivateData,
+        lock_owner: u64,
+    ) -> Result<usize, SystemError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let _admission = self.conn.enter_dax()?;
+        let _layout = self.dax_layout_write();
+        let end = offset
+            .checked_add(buf.len())
+            .ok_or(SystemError::EOVERFLOW)?;
+        let size = self.cached_or_fetch_metadata()?.size.max(0) as usize;
+        if offset >= size || end > size {
+            return self.fuse_write_locked(offset, buf, private, lock_owner);
+        }
+
+        let mut done = 0usize;
+        while done < buf.len() {
+            let current = offset.checked_add(done).ok_or(SystemError::EOVERFLOW)?;
+            let in_mapping = current & (DAX_RANGE_SIZE - 1);
+            let chunk = core::cmp::min(buf.len() - done, DAX_RANGE_SIZE - in_mapping);
+            let access = match self.dax_access_inner(current as u64, true, None) {
+                Ok(access) => access,
+                Err(error) if done == 0 => return Err(error),
+                Err(_) => return Ok(done),
+            };
+            if let Err(error) = access.copy_from(in_mapping, &buf[done..done + chunk]) {
+                return if done == 0 { Err(error) } else { Ok(done) };
+            }
+            self.note_successful_write(current, chunk)?;
+            done += chunk;
+        }
+        Ok(done)
     }
 
     pub(crate) fn set_generation(&self, gen: u64) {
@@ -472,6 +1208,17 @@ impl FuseNode {
 
 impl Drop for FuseNode {
     fn drop(&mut self) {
+        if let Err(error) = self.dax_teardown() {
+            log::warn!(
+                "fuse: inode {} dropped with DAX teardown error: {:?}",
+                self.nodeid,
+                error
+            );
+            // The daemon did not confirm removal. Revoke local PTEs/tree and
+            // retire the ranges so no future inode can observe an alias.
+            self.dax_abandon_mappings();
+        }
+        self.conn.unregister_dax_node(self.dax_mapping_owner());
         self.clear_lookup_cache_tree();
         self.flush_forget();
         self.clear_parent();

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -286,12 +286,17 @@ impl FuseNode {
         truncate_metadata: Option<(&Metadata, SetMetadataMask)>,
     ) -> Result<(), SystemError> {
         self.check_not_stale()?;
+        let old_size = self.cached_or_fetch_metadata()?.size.max(0) as usize;
         self.resolve_pending_short_read_truncate(len)?;
         // Drain once before taking the exclusive admission barrier to reduce
         // hold time, then drain again under the barrier to close the race with
         // buffered writes and page_mkwrite.
         self.sync_dirty_cached_pages()?;
-        let _barrier = self.writeback_barrier.write();
+        let _barrier = if self.conn().dax_enabled() && len < old_size {
+            self.dax_layout_write_for_truncate(len)?
+        } else {
+            self.writeback_barrier.write()
+        };
         self.sync_dirty_cached_pages()?;
         let mut valid = FATTR_SIZE;
         if lock_owner.is_some() {

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -86,12 +86,25 @@ impl IndexNode for FuseNode {
         };
 
         if (fopen_flags & FOPEN_DIRECT_IO) != 0
+            && !self.conn().dax_enabled()
             && vm_flags.contains(crate::mm::VmFlags::VM_MAYSHARE)
         {
             return Err(SystemError::ENODEV);
         }
 
         Ok(())
+    }
+
+    fn mmap_vm_flags(
+        &self,
+        _file: &Arc<crate::filesystem::vfs::file::File>,
+        vm_flags: crate::mm::VmFlags,
+    ) -> Result<crate::mm::VmFlags, SystemError> {
+        if self.conn().dax_enabled() {
+            Ok(vm_flags | crate::mm::VmFlags::VM_MIXEDMAP)
+        } else {
+            Ok(vm_flags)
+        }
     }
 
     fn mmap_file(
@@ -116,7 +129,7 @@ impl IndexNode for FuseNode {
             p.fopen_flags
         };
 
-        if (fopen_flags & FOPEN_DIRECT_IO) != 0 {
+        if (fopen_flags & FOPEN_DIRECT_IO) != 0 && !self.conn().dax_enabled() {
             if vm_flags.contains(crate::mm::VmFlags::VM_MAYSHARE) {
                 return Err(SystemError::ENODEV);
             }
@@ -354,6 +367,17 @@ impl IndexNode for FuseNode {
         let file_flags = private_data.open_flags;
         let fopen_flags = private_data.fopen_flags;
 
+        if self.conn().dax_enabled() {
+            loop {
+                match self.dax_read(offset, &mut buf[..len]) {
+                    Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
+                        self.conn().reclaim_one_dax_range_interruptible()?;
+                    }
+                    result => return result,
+                }
+            }
+        }
+
         if (fopen_flags & FOPEN_DIRECT_IO) != 0 || (file_flags & FileFlags::O_DIRECT.bits()) != 0 {
             let _barrier = self.writeback_barrier.write();
             self.prepare_direct_io_range(offset, len, &private_data, false)?;
@@ -385,6 +409,18 @@ impl IndexNode for FuseNode {
         let fh = private_data.fh;
         let file_flags = private_data.open_flags;
         let fopen_flags = private_data.fopen_flags;
+        if self.conn().dax_enabled() {
+            let lock_owner = crate::filesystem::vfs::vcore::current_file_lock_owner_id();
+            loop {
+                match self.dax_write_or_fuse_locked(offset, &buf[..len], &private_data, lock_owner)
+                {
+                    Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
+                        self.conn().reclaim_one_dax_range_interruptible()?;
+                    }
+                    result => return result,
+                }
+            }
+        }
         let max_write = core::cmp::min(self.conn().max_write(), self.max_pages_bytes());
         if max_write == 0 {
             return Err(SystemError::EIO);
@@ -523,15 +559,19 @@ impl IndexNode for FuseNode {
 
     fn set_metadata(&self, metadata: &Metadata) -> Result<(), SystemError> {
         self.check_not_stale()?;
+        let old = self.cached_or_fetch_metadata()?;
         let writeback_cache = self.conn().has_init_flag(FUSE_WRITEBACK_CACHE);
         if writeback_cache {
             self.sync_dirty_cached_pages()?;
         }
-        let _barrier = writeback_cache.then(|| self.writeback_barrier.write());
+        let _barrier = if self.conn().dax_enabled() && metadata.size < old.size {
+            Some(self.dax_layout_write_for_truncate(metadata.size.max(0) as usize)?)
+        } else {
+            writeback_cache.then(|| self.writeback_barrier.write())
+        };
         if writeback_cache {
             self.sync_dirty_cached_pages()?;
         }
-        let old = self.cached_or_fetch_metadata()?;
         if metadata.size > old.size {
             self.resolve_pending_short_read_truncate(metadata.size.max(0) as usize)?;
         }

--- a/kernel/src/filesystem/fuse/virtiofs/dax.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/dax.rs
@@ -1,5 +1,8 @@
 use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
-use core::mem::size_of;
+use core::{
+    mem::size_of,
+    sync::atomic::{AtomicU8, AtomicUsize, Ordering},
+};
 
 use log::error;
 use system_error::SystemError;
@@ -19,6 +22,92 @@ use crate::{
 };
 
 pub(crate) const DAX_RANGE_SIZE: usize = 2 * 1024 * 1024;
+const DAX_FH_INODE: u64 = u64::MAX;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum DaxAdmissionState {
+    Active = 0,
+    Quiescing = 1,
+    Dead = 2,
+}
+
+#[derive(Debug)]
+pub(crate) struct DaxAdmission {
+    state: AtomicU8,
+    active: AtomicUsize,
+    wait: WaitQueue,
+}
+
+#[derive(Debug)]
+pub(crate) struct DaxAdmissionGuard {
+    admission: Arc<DaxAdmission>,
+}
+
+impl DaxAdmission {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: AtomicU8::new(DaxAdmissionState::Active as u8),
+            active: AtomicUsize::new(0),
+            wait: WaitQueue::default(),
+        })
+    }
+
+    pub(crate) fn state(&self) -> DaxAdmissionState {
+        match self.state.load(Ordering::Acquire) {
+            0 => DaxAdmissionState::Active,
+            1 => DaxAdmissionState::Quiescing,
+            _ => DaxAdmissionState::Dead,
+        }
+    }
+
+    pub(crate) fn enter(self: &Arc<Self>) -> Result<DaxAdmissionGuard, SystemError> {
+        if self.state() != DaxAdmissionState::Active {
+            return Err(SystemError::ENODEV);
+        }
+        self.active.fetch_add(1, Ordering::AcqRel);
+        if self.state() != DaxAdmissionState::Active {
+            self.leave();
+            return Err(SystemError::ENODEV);
+        }
+        Ok(DaxAdmissionGuard {
+            admission: self.clone(),
+        })
+    }
+
+    pub(crate) fn begin_quiesce(&self) {
+        let _ = self.state.compare_exchange(
+            DaxAdmissionState::Active as u8,
+            DaxAdmissionState::Quiescing as u8,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+        self.wait.wakeup_all(None);
+    }
+
+    pub(crate) fn wait_drained(&self) {
+        self.wait
+            .wait_until(|| (self.active.load(Ordering::Acquire) == 0).then_some(()));
+    }
+
+    pub(crate) fn mark_dead(&self) {
+        self.state
+            .store(DaxAdmissionState::Dead as u8, Ordering::Release);
+        self.wait.wakeup_all(None);
+    }
+
+    fn leave(&self) {
+        if self.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.wait.wakeup_all(None);
+        }
+    }
+}
+
+impl Drop for DaxAdmissionGuard {
+    fn drop(&mut self) {
+        self.admission.leave();
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DaxMountMode {
@@ -150,6 +239,18 @@ impl OwnedToken {
     pub(crate) fn owner(&self) -> DaxMappingOwner {
         self.owner
     }
+
+    pub(crate) fn matches_candidate(&self, candidate: &ReclaimCandidate) -> bool {
+        self.index == candidate.index
+            && self.generation == candidate.generation
+            && self.owner == candidate.owner
+    }
+
+    pub(crate) fn same_identity(&self, other: &Self) -> bool {
+        self.index == other.index
+            && self.generation == other.generation
+            && self.owner == other.owner
+    }
 }
 
 impl ReclaimCandidate {
@@ -159,6 +260,10 @@ impl ReclaimCandidate {
 
     pub(crate) fn owner(&self) -> DaxMappingOwner {
         self.owner
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
     }
 }
 
@@ -330,6 +435,19 @@ impl DaxRangeAllocator {
                 None
             }
         })?
+    }
+
+    pub(crate) fn wait_available(&self) -> Result<(), SystemError> {
+        self.wait.wait_until(|| {
+            let state = self.state.lock_irqsave();
+            if state.shutdown {
+                Some(Err(SystemError::ENODEV))
+            } else if state.can_make_progress() {
+                Some(Ok(()))
+            } else {
+                None
+            }
+        })
     }
 
     pub(crate) fn assign_owner(
@@ -613,6 +731,14 @@ impl DaxRangeAllocator {
     pub(crate) fn snapshot(&self) -> DaxAllocatorSnapshot {
         self.state.lock_irqsave().snapshot()
     }
+
+    pub(crate) fn is_owned(&self, token: &OwnedToken) -> bool {
+        let state = self.state.lock_irqsave();
+        state.entries.get(token.index).is_some_and(|entry| {
+            entry.generation == token.generation
+                && matches!(entry.state, DaxRangeState::InodeOwned { owner, .. } if owner == token.owner)
+        })
+    }
 }
 
 impl FuseConn {
@@ -658,9 +784,8 @@ impl FuseConn {
     }
 
     fn send_setup_mapping(
-        &self,
+        self: &Arc<Self>,
         owner: DaxMappingOwner,
-        fh: u64,
         file_offset: u64,
         window_offset: usize,
         writable: bool,
@@ -670,7 +795,7 @@ impl FuseConn {
             return FuseDaxRequestOutcome::NeverSubmitted(error);
         }
         let input = FuseSetupMappingIn {
-            fh,
+            fh: DAX_FH_INODE,
             foffset: file_offset,
             len: DAX_RANGE_SIZE as u64,
             flags: FUSE_SETUPMAPPING_FLAG_READ
@@ -712,30 +837,23 @@ impl FuseConn {
     }
 
     pub(crate) fn setup_dax_mapping(
-        &self,
+        self: &Arc<Self>,
         owner: DaxMappingOwner,
-        fh: u64,
         file_offset: u64,
         writable: bool,
     ) -> Result<OwnedToken, SystemError> {
         let allocator = self.dax_allocator_clone()?;
         let reservation = allocator.try_allocate()?;
-        let result = self.send_setup_mapping(
-            owner,
-            fh,
-            file_offset,
-            reservation.window_offset(),
-            writable,
-        );
+        let result =
+            self.send_setup_mapping(owner, file_offset, reservation.window_offset(), writable);
         Self::apply_setup_outcome(&allocator, &reservation, owner, result)
     }
 
     /// Send SETUPMAPPING for an existing range (used by #2080 for access upgrades).
     pub(crate) fn setup_existing_dax_mapping(
-        &self,
+        self: &Arc<Self>,
         owner: DaxMappingOwner,
         token: &OwnedToken,
-        fh: u64,
         file_offset: u64,
         writable: bool,
     ) -> Result<(), SystemError> {
@@ -744,8 +862,7 @@ impl FuseConn {
         }
         let allocator = self.dax_allocator_clone()?;
         allocator.get(token)?;
-        let outcome =
-            self.send_setup_mapping(owner, fh, file_offset, token.window_offset(), writable);
+        let outcome = self.send_setup_mapping(owner, file_offset, token.window_offset(), writable);
         let put_result = allocator.put(token);
         match outcome {
             FuseDaxRequestOutcome::Success => {
@@ -767,7 +884,7 @@ impl FuseConn {
     }
 
     pub(crate) fn remove_dax_mappings(
-        &self,
+        self: &Arc<Self>,
         owner: DaxMappingOwner,
         tokens: &[ReclaimToken],
     ) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/fuse/virtiofs/mount.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/mount.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec};
 
 use linkme::distributed_slice;
 use system_error::SystemError;
@@ -6,10 +6,13 @@ use system_error::SystemError;
 use crate::{
     driver::virtio::virtio_fs::{virtio_fs_find_instance, VirtioFsInstance},
     filesystem::vfs::{
-        file::File, FileSystem, FileSystemMakerData, FsInfo, IndexNode, MountableFileSystem,
-        SuperBlock, FSMAKER,
+        file::File, FilePrivateData, FileSystem, FileSystemMakerData, FsInfo, IndexNode,
+        MountableFileSystem, SuperBlock, FSMAKER,
     },
-    mm::{fault::PageFaultMessage, VirtRegion, VmFaultReason, VmFlags},
+    mm::{
+        fault::{FaultFlags, PageFaultMessage},
+        MemoryManagementArch, VirtRegion, VmFaultReason, VmFlags,
+    },
     process::ProcessManager,
     register_mountable_fs,
 };
@@ -17,6 +20,7 @@ use crate::{
 use super::super::{
     conn::FuseConn,
     fs::{FuseFS, FuseMountData},
+    private_data::FuseFilePrivateData,
     protocol::FuseOutHeader,
 };
 use super::{
@@ -30,7 +34,6 @@ struct VirtioFsMountData {
     group_id: u32,
     allow_other: bool,
     default_permissions: bool,
-    dax_mode: DaxMountMode,
     conn: Arc<FuseConn>,
     instance: Arc<VirtioFsInstance>,
 }
@@ -49,6 +52,84 @@ struct VirtioFsFs {
 }
 
 impl VirtioFsFs {
+    unsafe fn dax_fault(&self, pfm: &mut PageFaultMessage) -> Option<VmFaultReason> {
+        let vma = pfm.vma();
+        let guard = vma.lock();
+        let vm_flags = *guard.vm_flags();
+        let file = guard.vm_file()?;
+        drop(guard);
+        let node = {
+            let private = file.private_data.lock();
+            let FilePrivateData::Fuse(FuseFilePrivateData::File(private)) = &*private else {
+                return Some(VmFaultReason::VM_FAULT_SIGBUS);
+            };
+            private.node.clone()
+        };
+        if !node.conn().dax_enabled() {
+            return None;
+        }
+
+        let page_index = match pfm.backing_pgoff() {
+            Some(index) => index,
+            None => return Some(VmFaultReason::VM_FAULT_SIGBUS),
+        };
+        let file_offset = match page_index.checked_mul(crate::arch::MMArch::PAGE_SIZE) {
+            Some(offset) => offset,
+            None => return Some(VmFaultReason::VM_FAULT_SIGBUS),
+        };
+        let _layout = node.dax_layout_read();
+        let file_size = match node.dax_file_size() {
+            Ok(size) => size,
+            Err(_) => return Some(VmFaultReason::VM_FAULT_SIGBUS),
+        };
+        if file_offset >= file_size {
+            return Some(VmFaultReason::VM_FAULT_SIGBUS);
+        }
+
+        let write = pfm.flags().contains(FaultFlags::FAULT_FLAG_WRITE);
+        let shared = vm_flags.contains(VmFlags::VM_SHARED);
+        let access = match node.dax_access(file_offset as u64, write && shared) {
+            Ok(access) => access,
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
+                pfm.set_retry_wait(node.conn().dax_fault_retry_wait());
+                return Some(VmFaultReason::VM_FAULT_RETRY);
+            }
+            Err(_) => return Some(VmFaultReason::VM_FAULT_SIGBUS),
+        };
+        let in_mapping = file_offset & (super::dax::DAX_RANGE_SIZE - 1);
+        let paddr = match access.checked_paddr(in_mapping, crate::arch::MMArch::PAGE_SIZE) {
+            Ok(paddr) => paddr,
+            Err(_) => return Some(VmFaultReason::VM_FAULT_SIGBUS),
+        };
+        let old_pfn = pfm.external_pfn();
+        let result = if write && !shared {
+            let mut source = vec![0; crate::arch::MMArch::PAGE_SIZE];
+            if access.copy_to(in_mapping, &mut source).is_err() {
+                return Some(VmFaultReason::VM_FAULT_SIGBUS);
+            }
+            pfm.cow_external_page(old_pfn, &source)
+        } else if let Some(old_pfn) = old_pfn {
+            if old_pfn != paddr {
+                VmFaultReason::VM_FAULT_SIGBUS
+            } else if write {
+                pfm.upgrade_external_pfn(paddr)
+            } else {
+                VmFaultReason::VM_FAULT_COMPLETED
+            }
+        } else {
+            pfm.map_external_pfn(paddr, write && shared)
+        };
+        if result.contains(VmFaultReason::VM_FAULT_COMPLETED) {
+            if write && shared {
+                node.note_mmap_write();
+            }
+            if node.dax_note_pte_published().is_err() {
+                return Some(VmFaultReason::VM_FAULT_SIGBUS);
+            }
+        }
+        Some(result)
+    }
+
     fn parse_opt_u32_decimal(v: &str) -> Result<u32, SystemError> {
         v.parse::<u32>().map_err(|_| SystemError::EINVAL)
     }
@@ -108,7 +189,9 @@ impl VirtioFsFs {
             }
         }
 
-        if dax_mode != DaxMountMode::Never {
+        // Per-inode DAX requires tracking FUSE_ATTR_DAX transitions.  Treating
+        // it as dax=always would violate the negotiated Linux ABI.
+        if dax_mode == DaxMountMode::Inode {
             return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
         }
 
@@ -157,11 +240,12 @@ impl FileSystem for VirtioFsFs {
     }
 
     unsafe fn fault(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
-        self.inner.fault(pfm)
+        self.dax_fault(pfm).unwrap_or_else(|| self.inner.fault(pfm))
     }
 
     unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
-        self.inner.page_mkwrite(pfm)
+        self.dax_fault(pfm)
+            .unwrap_or_else(|| self.inner.page_mkwrite(pfm))
     }
 
     fn mprotect(&self, old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {
@@ -199,10 +283,18 @@ impl MountableFileSystem for VirtioFsFs {
         let (rootmode, user_id, group_id, default_permissions, allow_other, dax_mode) =
             Self::parse_mount_options(raw_data)?;
         let instance = virtio_fs_find_instance(source).ok_or(SystemError::ENODEV)?;
-        let conn = FuseConn::new_for_virtiofs_with_dax(
+        let cache_window = instance.cache_window();
+        if dax_mode == DaxMountMode::Always
+            && cache_window
+                .as_ref()
+                .is_none_or(|window| window.len() < super::dax::DAX_RANGE_SIZE)
+        {
+            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        }
+        let conn = FuseConn::new_for_virtiofs_with_dax_window(
             VIRTIOFS_MAX_REQUEST_SIZE,
             VIRTIOFS_RSP_BUF_SIZE,
-            instance.cache_window_len(),
+            cache_window,
             dax_mode,
         );
 
@@ -212,7 +304,6 @@ impl MountableFileSystem for VirtioFsFs {
             group_id,
             allow_other,
             default_permissions,
-            dax_mode,
             conn,
             instance,
         })))
@@ -236,10 +327,6 @@ impl MountableFileSystem for VirtioFsFs {
             default_permissions: md.default_permissions,
             conn: md.conn.clone(),
         };
-
-        if md.dax_mode != DaxMountMode::Never {
-            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
-        }
 
         let inner = <FuseFS as MountableFileSystem>::make_fs(Some(
             &fuse_mount_data as &dyn FileSystemMakerData,

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -471,6 +471,12 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         Ok(())
     }
 
+    /// Allow a filesystem to add internal VMA flags after VFS permission
+    /// checks derived the user-visible protection and sharing flags.
+    fn mmap_vm_flags(&self, _file: &Arc<File>, vm_flags: VmFlags) -> Result<VmFlags, SystemError> {
+        Ok(vm_flags)
+    }
+
     fn mmap_effective_file(&self, file: &Arc<File>) -> Result<Arc<File>, SystemError> {
         Ok(file.clone())
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    file::{FileFlags, FileMode},
+    file::{File, FileFlags, FileMode},
     utils::DName,
     FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode, InodeRetentionKind,
     PollableInode, SetMetadataMask, SuperBlock, XattrFlags,
@@ -1990,6 +1990,10 @@ impl IndexNode for MountFSInode {
     ) -> Result<(), SystemError> {
         self.inner_inode
             .check_mmap_file(file, len, offset, vm_flags)
+    }
+
+    fn mmap_vm_flags(&self, file: &Arc<File>, vm_flags: VmFlags) -> Result<VmFlags, SystemError> {
+        self.inner_inode.mmap_vm_flags(file, vm_flags)
     }
 
     fn mmap_effective_file(

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -299,11 +299,16 @@ impl Futex {
                 PageFaultHandler::handle_mm_fault(message)
             };
 
-            if fault.contains(VmFaultReason::VM_FAULT_COMPLETED) {
+            if fault.reason.contains(VmFaultReason::VM_FAULT_COMPLETED) {
                 return Ok(());
             }
-            if fault.contains(VmFaultReason::VM_FAULT_RETRY) {
+            if fault.reason.contains(VmFaultReason::VM_FAULT_RETRY) {
                 flags |= FaultFlags::FAULT_FLAG_TRIED;
+                let wait = fault.retry_wait;
+                drop(space_guard);
+                if let Some(wait) = wait {
+                    wait.wait().map_err(|_| SystemError::EFAULT)?;
+                }
                 continue;
             }
             return Err(SystemError::EFAULT);

--- a/kernel/src/mm/device_linear.rs
+++ b/kernel/src/mm/device_linear.rs
@@ -62,6 +62,7 @@ fn level_size(level: usize) -> Option<usize> {
 /// RAII owner for a write-back device-memory mapping in the kernel linear address space.
 #[derive(Debug)]
 pub struct DeviceLinearMapping {
+    pstart: PhysAddr,
     start: VirtAddr,
     end: VirtAddr,
     segments: Vec<MappingSegment>,
@@ -86,6 +87,7 @@ impl DeviceLinearMapping {
             .checked_add(length)
             .ok_or(SystemError::EOVERFLOW)?;
         let mut mapping = Self {
+            pstart: paddr,
             start: vaddr,
             end: VirtAddr::new(end_data),
             segments: Vec::new(),
@@ -150,6 +152,30 @@ impl DeviceLinearMapping {
 
     pub fn len(&self) -> usize {
         self.end.data() - self.start.data()
+    }
+
+    pub fn checked_paddr(&self, offset: usize, len: usize) -> Result<PhysAddr, SystemError> {
+        let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        if end > self.len() {
+            return Err(SystemError::ERANGE);
+        }
+        self.pstart
+            .data()
+            .checked_add(offset)
+            .map(PhysAddr::new)
+            .ok_or(SystemError::EOVERFLOW)
+    }
+
+    pub fn checked_vaddr(&self, offset: usize, len: usize) -> Result<VirtAddr, SystemError> {
+        let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        if end > self.len() {
+            return Err(SystemError::ERANGE);
+        }
+        self.start
+            .data()
+            .checked_add(offset)
+            .map(VirtAddr::new)
+            .ok_or(SystemError::EOVERFLOW)
     }
 
     pub fn reset(&mut self) {

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -15,7 +15,7 @@ use crate::{
     mm::{
         page::{page_manager_lock, EntryFlags},
         ucontext::{AddressSpace, InnerAddressSpace, LockedVMA},
-        VirtAddr, VmFaultReason, VmFlags,
+        PhysAddr, VirtAddr, VmFaultReason, VmFlags,
     },
     process::{ProcessManager, ProcessState},
 };
@@ -23,6 +23,16 @@ use crate::{
 use crate::mm::MemoryManagementArch;
 
 use super::page::{Page, PageFlags, PageType};
+
+pub trait FaultRetryWait: core::fmt::Debug + Send + Sync {
+    fn wait(&self) -> Result<(), SystemError>;
+}
+
+#[derive(Debug)]
+pub struct VmFaultOutcome {
+    pub reason: VmFaultReason,
+    pub retry_wait: Option<Arc<dyn FaultRetryWait>>,
+}
 
 bitflags! {
     pub struct FaultFlags: u64{
@@ -66,6 +76,7 @@ pub struct PageFaultMessage<'a> {
     ///
     /// do_wp_page 等在修改 PTE 后需要走 mm-aware shootdown 的路径要依赖它（`AddressSpace::flush_tlb_range`）。
     mm: Arc<AddressSpace>,
+    retry_wait: Option<Arc<dyn FaultRetryWait>>,
 }
 
 impl<'a> PageFaultMessage<'a> {
@@ -91,6 +102,7 @@ impl<'a> PageFaultMessage<'a> {
             mapper,
             cow_page: None,
             mm,
+            retry_wait: None,
         }
     }
 
@@ -132,6 +144,179 @@ impl<'a> PageFaultMessage<'a> {
     #[inline(always)]
     pub fn mm(&self) -> &Arc<AddressSpace> {
         &self.mm
+    }
+
+    pub fn set_retry_wait(&mut self, wait: Arc<dyn FaultRetryWait>) {
+        self.retry_wait = Some(wait);
+    }
+
+    /// Return the currently installed raw PFN at the fault address.
+    ///
+    /// Managed pages deliberately return `None`; filesystem pfn_mkwrite/COW
+    /// implementations must not use this interface for page-cache pages.
+    pub fn external_pfn(&mut self) -> Option<PhysAddr> {
+        if !self.vma.lock().vm_flags().contains(VmFlags::VM_MIXEDMAP) {
+            return None;
+        }
+        let (paddr, _) = self.mapper.translate(self.address_aligned_down())?;
+        let mut page_manager = page_manager_lock();
+        page_manager.get(&paddr).is_none().then_some(paddr)
+    }
+
+    /// Install a validated external PFN in a VM_MIXEDMAP VMA.
+    ///
+    /// `writable` is accepted only for a writable shared VMA. Private mappings
+    /// must use `cow_external_page()` instead, so device memory can never be
+    /// exposed writable through MAP_PRIVATE.
+    pub unsafe fn map_external_pfn(&mut self, paddr: PhysAddr, writable: bool) -> VmFaultReason {
+        if !paddr.check_aligned(MMArch::PAGE_SIZE) {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        }
+        let (vm_flags, mut pte_flags) = {
+            let guard = self.vma.lock();
+            (*guard.vm_flags(), guard.flags())
+        };
+        if !vm_flags.contains(VmFlags::VM_MIXEDMAP)
+            || (writable
+                && (!vm_flags.contains(VmFlags::VM_SHARED)
+                    || !vm_flags.contains(VmFlags::VM_WRITE)))
+        {
+            return VmFaultReason::VM_FAULT_SIGSEGV;
+        }
+        pte_flags = pte_flags.set_write(writable);
+        let address = self.address_aligned_down();
+        let mm = self.mm.clone();
+        let _pt_edit = mm.page_table_edit();
+        if self.mapper.get_entry(address, 0).is_some() {
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        }
+        let Some(flush) = self.mapper.map_phys(address, paddr, pte_flags) else {
+            return VmFaultReason::VM_FAULT_OOM;
+        };
+        flush.flush();
+        self.vma.lock().set_mapped(true);
+        VmFaultReason::VM_FAULT_COMPLETED
+    }
+
+    /// Upgrade an already installed external PFN after the filesystem has
+    /// successfully completed its pfn_mkwrite/layout transaction.
+    pub unsafe fn upgrade_external_pfn(&mut self, expected: PhysAddr) -> VmFaultReason {
+        let vm_flags = *self.vma.lock().vm_flags();
+        if !vm_flags.contains(VmFlags::VM_MIXEDMAP | VmFlags::VM_SHARED | VmFlags::VM_WRITE) {
+            return VmFaultReason::VM_FAULT_SIGSEGV;
+        }
+        let address = self.address_aligned_down();
+        let mm = self.mm.clone();
+        let _pt_edit = mm.page_table_edit();
+        let Some(mut entry) = self.mapper.get_entry(address, 0) else {
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        };
+        if entry.address() != Ok(expected) || entry.write() {
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        }
+        let mut page_manager = page_manager_lock();
+        if page_manager.get(&expected).is_some() {
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        }
+        drop(page_manager);
+        let table = self.mapper.get_table(address, 0).unwrap();
+        let index = table.index_of(address).unwrap();
+        entry.set_flags(entry.flags().set_write(true).set_dirty(true));
+        table.set_entry(index, entry);
+        mm.flush_tlb_range(
+            address,
+            VirtAddr::new(address.data() + MMArch::PAGE_SIZE),
+            MMArch::PAGE_SHIFT as u8,
+            false,
+        );
+        VmFaultReason::VM_FAULT_COMPLETED
+    }
+
+    /// Replace an optional external PFN with a private anonymous COW page.
+    /// The source bytes must come from a filesystem-validated cache-window
+    /// virtual address and cover exactly one base page.
+    pub unsafe fn cow_external_page(
+        &mut self,
+        expected: Option<PhysAddr>,
+        source: &[u8],
+    ) -> VmFaultReason {
+        if source.len() != MMArch::PAGE_SIZE {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        }
+        let (vm_flags, pte_flags, mlocked) = {
+            let guard = self.vma.lock();
+            (
+                *guard.vm_flags(),
+                guard.flags().set_write(true).set_dirty(true),
+                guard.vm_flags().contains(VmFlags::VM_LOCKED),
+            )
+        };
+        if !vm_flags.contains(VmFlags::VM_MIXEDMAP)
+            || vm_flags.contains(VmFlags::VM_SHARED)
+            || !vm_flags.contains(VmFlags::VM_WRITE)
+        {
+            return VmFaultReason::VM_FAULT_SIGSEGV;
+        }
+
+        let page = {
+            let mut page_manager = page_manager_lock();
+            let mut allocator = crate::arch::mm::LockedFrameAllocator;
+            match page_manager.create_one_page(PageType::Normal, PageFlags::empty(), &mut allocator)
+            {
+                Ok(page) => page,
+                Err(_) => return VmFaultReason::VM_FAULT_OOM,
+            }
+        };
+        page.write().copy_from_slice(source);
+
+        let address = self.address_aligned_down();
+        let mm = self.mm.clone();
+        let _pt_edit = mm.page_table_edit();
+        let current = self.mapper.translate(address).map(|(paddr, _)| paddr);
+        if current != expected {
+            let mut page_manager = page_manager_lock();
+            page_manager.remove_page(&page.phys_address());
+            return VmFaultReason::VM_FAULT_NOPAGE;
+        }
+        if let Some(old) = current {
+            let mut page_manager = page_manager_lock();
+            if page_manager.get(&old).is_some() {
+                page_manager.remove_page(&page.phys_address());
+                return VmFaultReason::VM_FAULT_NOPAGE;
+            }
+        }
+
+        PageFaultHandler::attach_fault_mapped_page(&page, &self.vma, mlocked);
+        if current.is_some() {
+            let table = self.mapper.get_table(address, 0).unwrap();
+            let index = table.index_of(address).unwrap();
+            table.set_entry(
+                index,
+                super::page::PageEntry::new(page.phys_address(), pte_flags),
+            );
+            mm.flush_tlb_range(
+                address,
+                VirtAddr::new(address.data() + MMArch::PAGE_SIZE),
+                MMArch::PAGE_SHIFT as u8,
+                false,
+            );
+            // The replaced external PFN was not RSS-accounted; the new
+            // anonymous COW page is managed guest memory and must be.
+            mm.account_present_page_add();
+        } else if let Some(flush) = self
+            .mapper
+            .map_phys(address, page.phys_address(), pte_flags)
+        {
+            flush.flush();
+            mm.account_present_page_add();
+        } else {
+            PageFaultHandler::detach_fault_mapped_page(&page, &self.vma);
+            let mut page_manager = page_manager_lock();
+            page_manager.remove_page(&page.phys_address());
+            return VmFaultReason::VM_FAULT_OOM;
+        }
+        self.vma.lock().set_mapped(true);
+        VmFaultReason::VM_FAULT_COMPLETED | VmFaultReason::VM_FAULT_DONE_COW
     }
 }
 
@@ -183,7 +368,7 @@ impl PageFaultHandler {
     /// ## 返回值
     /// - VmFaultReason: 页面错误处理信息标志
     #[inline(never)]
-    pub unsafe fn handle_mm_fault(mut pfm: PageFaultMessage) -> VmFaultReason {
+    pub unsafe fn handle_mm_fault(mut pfm: PageFaultMessage) -> VmFaultOutcome {
         let flags = pfm.flags();
         let vma = pfm.vma();
         let current_pcb = ProcessManager::current_pcb();
@@ -197,7 +382,10 @@ impl PageFaultHandler {
             flags.contains(FaultFlags::FAULT_FLAG_INSTRUCTION),
             flags.contains(FaultFlags::FAULT_FLAG_REMOTE),
         ) {
-            return VmFaultReason::VM_FAULT_SIGSEGV;
+            return VmFaultOutcome {
+                reason: VmFaultReason::VM_FAULT_SIGSEGV,
+                retry_wait: None,
+            };
         }
 
         let guard = vma.lock();
@@ -206,10 +394,17 @@ impl PageFaultHandler {
         if unlikely(vm_flags.contains(VmFlags::VM_HUGETLB)) {
             //TODO: 添加handle_hugetlb_fault处理大页缺页异常
         } else {
-            return Self::handle_normal_fault(&mut pfm);
+            let reason = Self::handle_normal_fault(&mut pfm);
+            return VmFaultOutcome {
+                reason,
+                retry_wait: pfm.retry_wait.take(),
+            };
         }
 
-        VmFaultReason::VM_FAULT_COMPLETED
+        VmFaultOutcome {
+            reason: VmFaultReason::VM_FAULT_COMPLETED,
+            retry_wait: pfm.retry_wait.take(),
+        }
     }
 
     /// 处理普通页缺页异常
@@ -460,7 +655,13 @@ impl PageFaultHandler {
             .map(|page_cache| page_cache.invalidate_read());
         let fs = pfm.vma().lock().vm_file().unwrap().inode().fs();
 
-        let mut ret = Self::do_fault_around(pfm);
+        // VM_MIXEDMAP faults are owned by the filesystem: generic fault-around
+        // would populate page-cache pages and bypass DAX PFN validation.
+        let mut ret = if pfm.vma().lock().vm_flags().contains(VmFlags::VM_MIXEDMAP) {
+            VmFaultReason::empty()
+        } else {
+            Self::do_fault_around(pfm)
+        };
         if !ret.is_empty() {
             return ret;
         }
@@ -596,7 +797,26 @@ impl PageFaultHandler {
             return VmFaultReason::VM_FAULT_NOPAGE;
         };
         let mut page_manager = page_manager_lock();
-        let old_page = page_manager.get_unwrap(&old_paddr);
+        let old_page = page_manager.get(&old_paddr);
+        if old_page.is_none() {
+            drop(page_manager);
+            if !vma.lock().vm_flags().contains(VmFlags::VM_MIXEDMAP) {
+                panic!("unmanaged PFN {old_paddr:?} installed in a non-mixed VMA");
+            }
+            let file = vma.lock().vm_file();
+            let Some(file) = file else {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            };
+            // The filesystem owns validation of the DAX mapping identity and
+            // source window. Shared mappings complete pfn_mkwrite; private
+            // mappings complete COW through PageFaultMessage's guarded helper.
+            return if vma.lock().vm_flags().contains(VmFlags::VM_SHARED) {
+                file.inode().fs().page_mkwrite(pfm)
+            } else {
+                file.inode().fs().fault(pfm)
+            };
+        }
+        let old_page = old_page.unwrap();
         let map_count = old_page.read().map_count();
         drop(page_manager);
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -86,6 +86,12 @@ bitflags! {
         const VM_ARCH_1 = 0x01000000;
         const VM_WIPEONFORK = 0x02000000;
         const VM_DONTDUMP = 0x04000000;
+        /// The VMA may contain both ordinary managed pages and raw device PFNs.
+        ///
+        /// This matches Linux VM_MIXEDMAP: raw PFNs must never enter the
+        /// page-manager/rmap/LRU paths, while private COW pages in the same VMA
+        /// remain normal managed pages.
+        const VM_MIXEDMAP = 0x10000000;
 
         const VM_LOCKED_CLEAR_MASK = !(Self::VM_LOCKED.bits | Self::VM_LOCKONFAULT.bits);
     }
@@ -122,7 +128,13 @@ impl VmFlags {
     /// VMAs which Linux mlock_fixup() leaves unlocked and unaccounted.
     #[inline]
     pub fn is_mlock_flag_unsupported(self) -> bool {
-        self.intersects(Self::VM_IO | Self::VM_DONTEXPAND | Self::VM_PFNMAP | Self::VM_HUGETLB)
+        self.intersects(
+            Self::VM_IO
+                | Self::VM_DONTEXPAND
+                | Self::VM_PFNMAP
+                | Self::VM_MIXEDMAP
+                | Self::VM_HUGETLB,
+        )
     }
 
     /// VMAs which cannot be handled by DragonOS' ordinary prefault path.
@@ -132,7 +144,7 @@ impl VmFlags {
     /// skip hugetlb until its fault path is implemented.
     #[inline]
     pub fn is_mlock_population_unsupported(self) -> bool {
-        self.intersects(Self::VM_IO | Self::VM_PFNMAP | Self::VM_HUGETLB)
+        self.intersects(Self::VM_IO | Self::VM_PFNMAP | Self::VM_MIXEDMAP | Self::VM_HUGETLB)
     }
 }
 

--- a/kernel/src/mm/ucontext/address_space.rs
+++ b/kernel/src/mm/ucontext/address_space.rs
@@ -639,6 +639,11 @@ impl AddressSpace {
                 vm_flags |= VmFlags::VM_MAYWRITE;
             }
 
+            vm_flags = match vma_file.inode().mmap_vm_flags(&vma_file, vm_flags) {
+                Ok(flags) => flags,
+                Err(err) => map_fail!(err),
+            };
+
             if vm_flags.contains(VmFlags::VM_LOCKED) {
                 let error = if map_flags.contains(MapFlags::MAP_LOCKED)
                     && !InnerAddressSpace::has_mlock_quota()

--- a/kernel/src/mm/ucontext/inner.rs
+++ b/kernel/src/mm/ucontext/inner.rs
@@ -168,8 +168,19 @@ impl InnerAddressSpace {
                         if let Some((phys_addr, old_flags)) = old_mapper.translate(current_page) {
                             unsafe {
                                 if is_shared {
+                                    let child_flags =
+                                        if page_manager_guard.get(&phys_addr).is_none()
+                                            && vm_flags.contains(VmFlags::VM_MIXEDMAP)
+                                        {
+                                            // Preserve the actual external PTE permission. Using
+                                            // VMA page flags here could make a deliberately RO DAX
+                                            // PFN writable in the child without pfn_mkwrite.
+                                            old_flags
+                                        } else {
+                                            page_flags
+                                        };
                                     if new_mapper
-                                        .map_phys(current_page, phys_addr, page_flags)
+                                        .map_phys(current_page, phys_addr, child_flags)
                                         .is_none()
                                     {
                                         return Err(SystemError::ENOMEM);
@@ -197,7 +208,9 @@ impl InnerAddressSpace {
                                 if let Some(page) = page_manager_guard.get(&phys_addr) {
                                     page.write().insert_vma(new_vma.clone(), new_vma_mlocked);
                                 }
-                                child_present_pages += 1;
+                                if page_manager_guard.get(&phys_addr).is_some() {
+                                    child_present_pages += 1;
+                                }
                             }
                         }
                         current_page = VirtAddr::new(current_page.data() + MMArch::PAGE_SIZE);
@@ -396,9 +409,13 @@ impl InnerAddressSpace {
 
     fn add_present_page_mlock_ref(&mut self, addr: VirtAddr, vma: &Arc<LockedVMA>) {
         if let Some((paddr, _)) = self.user_mapper.utable.translate(addr) {
+            let vm_flags = *vma.lock().vm_flags();
             let mut page_manager_guard = page_manager_lock();
-            let page = page_manager_guard.get_unwrap(&paddr);
-            page.write().add_mlocked_vma_ref(vma);
+            if let PresentPfn::Managed(page) =
+                LockedVMA::classify_present_pfn(&mut page_manager_guard, paddr, vm_flags)
+            {
+                page.write().add_mlocked_vma_ref(vma);
+            }
         }
     }
 
@@ -418,9 +435,18 @@ impl InnerAddressSpace {
         let mut vaddr = start;
         while vaddr < end {
             if let Some((paddr, _)) = self.user_mapper.utable.translate(vaddr) {
+                let vm_flags = *vma.lock().vm_flags();
                 let page = {
                     let mut page_manager_guard = page_manager_lock();
-                    page_manager_guard.get_unwrap(&paddr)
+                    match LockedVMA::classify_present_pfn(&mut page_manager_guard, paddr, vm_flags)
+                    {
+                        PresentPfn::Managed(page) => Some(page),
+                        PresentPfn::External(_) => None,
+                    }
+                };
+                let Some(page) = page else {
+                    vaddr = VirtAddr::new(vaddr.data() + MMArch::PAGE_SIZE);
+                    continue;
                 };
                 {
                     let mut page_guard = page.write();
@@ -455,9 +481,9 @@ impl InnerAddressSpace {
             PageFaultHandler::handle_mm_fault(message)
         };
 
-        if fault.contains(VmFaultReason::VM_FAULT_COMPLETED) {
+        if fault.reason.contains(VmFaultReason::VM_FAULT_COMPLETED) {
             Ok(())
-        } else if fault.contains(VmFaultReason::VM_FAULT_OOM) {
+        } else if fault.reason.contains(VmFaultReason::VM_FAULT_OOM) {
             Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
         } else {
             Err(SystemError::ENOMEM)

--- a/kernel/src/mm/ucontext/mod.rs
+++ b/kernel/src/mm/ucontext/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     },
     mm::{
         mmu_gather::MmuGather,
-        page::{page_manager_lock, page_reclaimer_lock},
+        page::{page_manager_lock, page_reclaimer_lock, PageManager},
         PhysAddr,
     },
     process::{
@@ -117,4 +117,6 @@ pub use inner::InnerAddressSpace;
 pub use mapper::UserMapper;
 pub use stack::UserStack;
 #[allow(unused_imports)]
-pub use vma::{AnonSharedMapping, LockedVMA, PhysmapParams, Provider, VMASplitResult, VMA};
+pub use vma::{
+    AnonSharedMapping, LockedVMA, PhysmapParams, PresentPfn, Provider, VMASplitResult, VMA,
+};

--- a/kernel/src/mm/ucontext/mremap.rs
+++ b/kernel/src/mm/ucontext/mremap.rs
@@ -410,11 +410,12 @@ impl InnerAddressSpace {
                     unsafe { flush.ignore() };
                     tlb.accumulate_range(dst);
                     installed_target_pte = true;
-                    installed_target_present_pages += 1;
-                    page_manager_guard
-                        .get_unwrap(&paddr)
-                        .write()
-                        .insert_vma(new_vma.clone(), locked_source);
+                    if let PresentPfn::Managed(page) =
+                        LockedVMA::classify_present_pfn(&mut page_manager_guard, paddr, vm_flags)
+                    {
+                        installed_target_present_pages += 1;
+                        page.write().insert_vma(new_vma.clone(), locked_source);
+                    }
 
                     migrated.push((src, dst, paddr, src_flags));
                 }
@@ -453,14 +454,16 @@ impl InnerAddressSpace {
                     {
                         unsafe { flush.ignore() };
                         tlb.accumulate_range(src);
-                        removed_source_present_pages += 1;
                     } else {
                         panic!("mremap commit lost expected source PTE at {:?}", src);
                     }
 
-                    let page = page_manager_guard.get_unwrap(&paddr);
-                    let mut pg = page.write();
-                    pg.remove_vma(old_vma.as_ref());
+                    if let PresentPfn::Managed(page) =
+                        LockedVMA::classify_present_pfn(&mut page_manager_guard, paddr, vm_flags)
+                    {
+                        removed_source_present_pages += 1;
+                        page.write().remove_vma(old_vma.as_ref());
+                    }
                 }
             }
         }

--- a/kernel/src/mm/ucontext/vma.rs
+++ b/kernel/src/mm/ucontext/vma.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// Classification of a present user PTE in a VMA.
+///
+/// A missing `Page` is accepted only for VM_MIXEDMAP. Keeping this check in one
+/// place prevents device PFNs from accidentally reaching rmap, LRU, mlock, or
+/// the frame allocator.
+#[derive(Debug)]
+pub enum PresentPfn {
+    Managed(Arc<Page>),
+    External(PhysAddr),
+}
+
 /// A locked VMA (Virtual Memory Area)
 ///
 /// Note: benchmark to determine whether SpinLock or RwLock performs better.
@@ -27,6 +38,21 @@ impl Eq for LockedVMA {}
 
 #[allow(dead_code)]
 impl LockedVMA {
+    pub(crate) fn classify_present_pfn(
+        page_manager: &mut PageManager,
+        paddr: PhysAddr,
+        vm_flags: VmFlags,
+    ) -> PresentPfn {
+        if let Some(page) = page_manager.get(&paddr) {
+            return PresentPfn::Managed(page);
+        }
+        assert!(
+            vm_flags.contains(VmFlags::VM_MIXEDMAP),
+            "unmanaged PFN {paddr:?} installed in a non-mixed VMA"
+        );
+        PresentPfn::External(paddr)
+    }
+
     pub fn new(vma: VMA) -> Arc<Self> {
         let r = Arc::new(Self {
             id: LOCKEDVMA_ID_ALLOCATOR.lock().alloc().unwrap(),
@@ -103,11 +129,22 @@ impl LockedVMA {
         mut flusher: impl Flusher<MMArch>,
     ) -> Result<(), SystemError> {
         let mut guard = self.lock();
+        let mut page_manager = page_manager_lock();
         for page in guard.region.pages() {
-            if mapper.translate(page.virt_address()).is_some() {
+            if let Some((paddr, _)) = mapper.translate(page.virt_address()) {
+                let page_flags = if page_manager.get(&paddr).is_none()
+                    && guard.vm_flags().contains(VmFlags::VM_MIXEDMAP)
+                {
+                    // mprotect must not bypass the filesystem's pfn_mkwrite
+                    // transaction. A subsequent write fault performs the
+                    // external mapping upgrade and PTE identity revalidation.
+                    flags.set_write(false)
+                } else {
+                    flags
+                };
                 let r = unsafe {
                     mapper
-                        .remap(page.virt_address(), flags)
+                        .remap(page.virt_address(), page_flags)
                         .expect("Failed to remap")
                 };
                 flusher.consume(r);
@@ -123,7 +160,7 @@ impl LockedVMA {
     /// performs cross-core TLB shootdown first and then frees physical pages (INV-3).
     pub fn unmap(&self, mapper: &mut PageMapper, tlb: &mut MmuGather<'_>) {
         // todo: if the current VMA is associated with a file, complete the file-related logic
-        let (region, should_wakeup_writeback, mm) = {
+        let (region, should_wakeup_writeback, mm, vm_flags) = {
             let mut self_guard = self.lock();
             let region = *self_guard.region();
             let mm = self_guard.address_space().and_then(|mm| mm.upgrade());
@@ -132,7 +169,7 @@ impl LockedVMA {
                 && self_guard
                     .vm_flags()
                     .contains(VmFlags::VM_SHARED | VmFlags::VM_WRITE);
-            (region, should_wakeup_writeback, mm)
+            (region, should_wakeup_writeback, mm, *self_guard.vm_flags())
         };
 
         let mut pages_to_reclassify = Vec::new();
@@ -148,7 +185,16 @@ impl LockedVMA {
                         .expect("Failed to unmap, beacuse of some page is not mapped");
 
                 // Remove the current VMA from anon_vma
-                let page_arc = page_manager_guard.get_unwrap(&paddr);
+                let PresentPfn::Managed(page_arc) =
+                    Self::classify_present_pfn(&mut page_manager_guard, paddr, vm_flags)
+                else {
+                    unsafe { flush.ignore() };
+                    tlb.accumulate_range(page.virt_address());
+                    if freed_tables {
+                        tlb.note_pt_table_freed();
+                    }
+                    continue;
+                };
                 {
                     let mut page_guard = page_arc.write();
                     page_guard.remove_vma(self);
@@ -212,6 +258,7 @@ impl LockedVMA {
         let mm = self_guard.address_space().and_then(|mm| mm.upgrade());
         let vma_start = self_guard.region().start();
         let backing_pgoff = self_guard.backing_page_offset();
+        let vm_flags = *self_guard.vm_flags();
         let file_page_cache = self_guard
             .vm_file()
             .and_then(|file| file.inode().page_cache());
@@ -227,7 +274,21 @@ impl LockedVMA {
                     continue;
                 };
 
-                let page_arc = page_manager_guard.get_unwrap(&paddr);
+                let PresentPfn::Managed(page_arc) =
+                    Self::classify_present_pfn(&mut page_manager_guard, paddr, vm_flags)
+                else {
+                    // A raw mixed PFN belongs to this file VMA. CacheOnly and
+                    // EvenCow both zap it; private COW pages are managed and are
+                    // filtered below by PageType.
+                    let Some((_paddr, _, flush)) =
+                        (unsafe { mapper.unmap_phys_preserve_tables(virt) })
+                    else {
+                        continue;
+                    };
+                    unsafe { flush.ignore() };
+                    tlb.accumulate_range(virt);
+                    continue;
+                };
                 if let Some(page_cache) = file_page_cache.as_ref() {
                     let Some(base_pgoff) = backing_pgoff else {
                         continue;
@@ -389,10 +450,13 @@ impl LockedVMA {
             let virt_iter = before.lock().region.iter_pages();
             for frame in virt_iter {
                 if let Some((paddr, _)) = utable.translate(frame.virt_address()) {
-                    let page = page_manager_guard.get_unwrap(&paddr);
-                    let mut page_guard = page.write();
-                    page_guard.insert_vma(before.clone(), vma_mlocked);
-                    page_guard.remove_vma(self);
+                    if let Some(page) = page_manager_guard.get(&paddr) {
+                        let mut page_guard = page.write();
+                        page_guard.insert_vma(before.clone(), vma_mlocked);
+                        page_guard.remove_vma(self);
+                    } else {
+                        assert!(guard.vm_flags().contains(VmFlags::VM_MIXEDMAP));
+                    }
                     before.lock().mapped = true;
                 }
             }
@@ -401,10 +465,13 @@ impl LockedVMA {
             let virt_iter = after.lock().region.iter_pages();
             for frame in virt_iter {
                 if let Some((paddr, _)) = utable.translate(frame.virt_address()) {
-                    let page = page_manager_guard.get_unwrap(&paddr);
-                    let mut page_guard = page.write();
-                    page_guard.insert_vma(after.clone(), vma_mlocked);
-                    page_guard.remove_vma(self);
+                    if let Some(page) = page_manager_guard.get(&paddr) {
+                        let mut page_guard = page.write();
+                        page_guard.insert_vma(after.clone(), vma_mlocked);
+                        page_guard.remove_vma(self);
+                    } else {
+                        assert!(guard.vm_flags().contains(VmFlags::VM_MIXEDMAP));
+                    }
                     after.lock().mapped = true;
                 }
             }
@@ -784,12 +851,22 @@ impl VMA {
         } else {
             flags
         };
+        let mut page_manager = page_manager_lock();
         for page in self.region.pages() {
             // debug!("remap page {:?}", page.virt_address());
-            if mapper.translate(page.virt_address()).is_some() {
+            if let Some((paddr, _)) = mapper.translate(page.virt_address()) {
+                let external = self.vm_flags.contains(VmFlags::VM_MIXEDMAP)
+                    && page_manager.get(&paddr).is_none();
+                let page_flags = if external {
+                    // Adding PROT_WRITE must still fault through DAX
+                    // pfn_mkwrite/private COW and revalidate the PFN identity.
+                    pte_flags.set_write(false)
+                } else {
+                    pte_flags
+                };
                 let r = unsafe {
                     mapper
-                        .remap(page.virt_address(), pte_flags)
+                        .remap(page.virt_address(), page_flags)
                         .expect("Failed to remap")
                 };
                 unsafe { r.ignore() };

--- a/kernel/src/mm/ucontext/vma_ops.rs
+++ b/kernel/src/mm/ucontext/vma_ops.rs
@@ -834,9 +834,11 @@ impl InnerAddressSpace {
             if let Some((paddr, _)) = mapper.translate(vaddr) {
                 let page = {
                     let mut page_manager_guard = page_manager_lock();
-                    page_manager_guard.get_unwrap(&paddr)
+                    page_manager_guard.get(&paddr)
                 };
-                Self::remove_page_unevictable_if_unneeded(&page);
+                if let Some(page) = page {
+                    Self::remove_page_unevictable_if_unneeded(&page);
+                }
             }
             vaddr = VirtAddr::new(vaddr.data() + MMArch::PAGE_SIZE);
         }

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -121,16 +121,23 @@ fn prefault_user_range(addr: VirtAddr, len: usize, write: bool) -> Result<(), Sy
                 );
                 PageFaultHandler::handle_mm_fault(message)
             };
-            if fault.contains(VmFaultReason::VM_FAULT_OOM) {
+            if fault.reason.contains(VmFaultReason::VM_FAULT_OOM) {
                 return Err(SystemError::ENOMEM);
             }
-            if fault.intersects(
+            if fault.reason.contains(VmFaultReason::VM_FAULT_RETRY) {
+                let wait = fault.retry_wait;
+                drop(space_guard);
+                if let Some(wait) = wait {
+                    wait.wait().map_err(|_| SystemError::EFAULT)?;
+                }
+                continue;
+            }
+            if fault.reason.intersects(
                 VmFaultReason::VM_FAULT_SIGBUS
                     | VmFaultReason::VM_FAULT_SIGSEGV
                     | VmFaultReason::VM_FAULT_HWPOISON
                     | VmFaultReason::VM_FAULT_HWPOISON_LARGE
-                    | VmFaultReason::VM_FAULT_FALLBACK
-                    | VmFaultReason::VM_FAULT_RETRY,
+                    | VmFaultReason::VM_FAULT_FALLBACK,
             ) {
                 return Err(SystemError::EFAULT);
             }

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -89,71 +89,71 @@ fn prefault_user_range(addr: VirtAddr, len: usize, write: bool) -> Result<(), Sy
         let region = VirtRegion::new(start_page, region_len);
 
         let mm = AddressSpace::current()?;
-        let mut space_guard = mm.write_guard_no_reservation_conflict(region);
         let mut current = start_page;
-        loop {
-            let vma = space_guard
-                .mappings
-                .contains(current)
-                .ok_or(SystemError::EFAULT)?;
-            let vm_flags = *vma.lock().vm_flags();
-            let permitted = if write {
-                vm_flags.contains(VmFlags::VM_WRITE)
-            } else {
-                vm_flags.contains(VmFlags::VM_READ)
-            };
-            if !permitted {
-                return Err(SystemError::EFAULT);
-            }
-
-            let fault_flags = if write {
-                FaultFlags::FAULT_FLAG_WRITE
-            } else {
-                FaultFlags::empty()
-            };
-            let fault = unsafe {
-                let message = PageFaultMessage::new(
-                    vma,
-                    current,
-                    fault_flags,
-                    &mut space_guard.user_mapper.utable,
-                    mm.clone(),
-                );
-                PageFaultHandler::handle_mm_fault(message)
-            };
-            if fault.reason.contains(VmFaultReason::VM_FAULT_OOM) {
-                return Err(SystemError::ENOMEM);
-            }
-            if fault.reason.contains(VmFaultReason::VM_FAULT_RETRY) {
-                let wait = fault.retry_wait;
-                drop(space_guard);
-                if let Some(wait) = wait {
-                    wait.wait().map_err(|_| SystemError::EFAULT)?;
+        'retry: loop {
+            let mut space_guard = mm.write_guard_no_reservation_conflict(region);
+            loop {
+                let vma = space_guard
+                    .mappings
+                    .contains(current)
+                    .ok_or(SystemError::EFAULT)?;
+                let vm_flags = *vma.lock().vm_flags();
+                let permitted = if write {
+                    vm_flags.contains(VmFlags::VM_WRITE)
+                } else {
+                    vm_flags.contains(VmFlags::VM_READ)
+                };
+                if !permitted {
+                    return Err(SystemError::EFAULT);
                 }
-                continue;
-            }
-            if fault.reason.intersects(
-                VmFaultReason::VM_FAULT_SIGBUS
-                    | VmFaultReason::VM_FAULT_SIGSEGV
-                    | VmFaultReason::VM_FAULT_HWPOISON
-                    | VmFaultReason::VM_FAULT_HWPOISON_LARGE
-                    | VmFaultReason::VM_FAULT_FALLBACK,
-            ) {
-                return Err(SystemError::EFAULT);
-            }
 
-            if current == end_page {
-                break;
+                let fault_flags = if write {
+                    FaultFlags::FAULT_FLAG_WRITE
+                } else {
+                    FaultFlags::empty()
+                };
+                let fault = unsafe {
+                    let message = PageFaultMessage::new(
+                        vma,
+                        current,
+                        fault_flags,
+                        &mut space_guard.user_mapper.utable,
+                        mm.clone(),
+                    );
+                    PageFaultHandler::handle_mm_fault(message)
+                };
+                if fault.reason.contains(VmFaultReason::VM_FAULT_OOM) {
+                    return Err(SystemError::ENOMEM);
+                }
+                if fault.reason.contains(VmFaultReason::VM_FAULT_RETRY) {
+                    let wait = fault.retry_wait;
+                    drop(space_guard);
+                    if let Some(wait) = wait {
+                        wait.wait().map_err(|_| SystemError::EFAULT)?;
+                    }
+                    continue 'retry;
+                }
+                if fault.reason.intersects(
+                    VmFaultReason::VM_FAULT_SIGBUS
+                        | VmFaultReason::VM_FAULT_SIGSEGV
+                        | VmFaultReason::VM_FAULT_HWPOISON
+                        | VmFaultReason::VM_FAULT_HWPOISON_LARGE
+                        | VmFaultReason::VM_FAULT_FALLBACK,
+                ) {
+                    return Err(SystemError::EFAULT);
+                }
+
+                if current == end_page {
+                    return Ok(());
+                }
+                current = VirtAddr::new(
+                    current
+                        .data()
+                        .checked_add(MMArch::PAGE_SIZE)
+                        .ok_or(SystemError::EFAULT)?,
+                );
             }
-            current = VirtAddr::new(
-                current
-                    .data()
-                    .checked_add(MMArch::PAGE_SIZE)
-                    .ok_or(SystemError::EFAULT)?,
-            );
         }
-
-        Ok(())
     }
 }
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -3686,6 +3686,15 @@ static int ext_test_cached_short_read_updates_eof() {
         goto fail;
     }
 
+    // The second READ is speculative readahead, so the foreground pread must
+    // not wait for the daemon to consume it. Wait here before inspecting the
+    // asynchronous trace rather than depending on daemon scheduling.
+    for (int i = 0;
+         i < 200 &&
+         (read_count < 2 || read_offsets[1] != 4096 || read_sizes[1] != 4096);
+         ++i) {
+        usleep(5 * 1000);
+    }
     if (read_count < 2 || read_offsets[0] != 0 || read_sizes[0] != 4096 ||
         read_offsets[1] != 4096 || read_sizes[1] != 4096) {
         printf("[FAIL] short read trace count=%u off0=%llu size0=%u off1=%llu size1=%u\n",

--- a/user/apps/tests/dunitest/suites/normal/virtiofs_dax.cc
+++ b/user/apps/tests/dunitest/suites/normal/virtiofs_dax.cc
@@ -1,0 +1,588 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr size_t kPageSize = 4096;
+constexpr off_t kDaxRangeSize = 2 * 1024 * 1024;
+constexpr unsigned kWaitIterations = 150;
+
+bool dax_required() {
+    const char* value = getenv("DRAGONOS_VIRTIOFS_DAX_REQUIRED");
+    return value != nullptr && strcmp(value, "1") == 0;
+}
+
+int ensure_dir(const char* path) {
+    struct stat st = {};
+    if (stat(path, &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+    return mkdir(path, 0755);
+}
+
+std::string read_all(const char* path) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return {};
+    }
+
+    std::string result;
+    char buffer[1024];
+    for (;;) {
+        ssize_t n = read(fd, buffer, sizeof(buffer));
+        if (n == 0) {
+            break;
+        }
+        if (n < 0) {
+            result.clear();
+            break;
+        }
+        result.append(buffer, static_cast<size_t>(n));
+    }
+    close(fd);
+    return result;
+}
+
+long long parse_counter(const std::string& stats, unsigned opcode) {
+    std::string field = "opcode_" + std::to_string(opcode) + "_requests_total ";
+    size_t pos = stats.find(field);
+    if (pos == std::string::npos) {
+        return -1;
+    }
+    pos += field.size();
+    char* end = nullptr;
+    long long value = strtoll(stats.c_str() + pos, &end, 10);
+    return end == stats.c_str() + pos ? -1 : value;
+}
+
+struct OpcodeSnapshot {
+    long long read = -1;
+    long long write = -1;
+    long long setup_mapping = -1;
+    long long remove_mapping = -1;
+};
+
+OpcodeSnapshot snapshot(const char* stats_path) {
+    std::string contents = read_all(stats_path);
+    OpcodeSnapshot result;
+    result.read = parse_counter(contents, 15);
+    result.write = parse_counter(contents, 16);
+    result.setup_mapping = parse_counter(contents, 48);
+    result.remove_mapping = parse_counter(contents, 49);
+    return result;
+}
+
+void assert_valid_snapshot(const OpcodeSnapshot& value) {
+    ASSERT_GE(value.read, 0);
+    ASSERT_GE(value.write, 0);
+    ASSERT_GE(value.setup_mapping, 0);
+    ASSERT_GE(value.remove_mapping, 0);
+}
+
+void expect_dax_data_path(const OpcodeSnapshot& before, const OpcodeSnapshot& after,
+                          long long minimum_setups = 1) {
+    assert_valid_snapshot(before);
+    assert_valid_snapshot(after);
+    EXPECT_GE(after.setup_mapping - before.setup_mapping, minimum_setups);
+    EXPECT_EQ(before.read, after.read);
+    EXPECT_EQ(before.write, after.write);
+}
+
+uint8_t pattern_byte(off_t offset) {
+    return static_cast<uint8_t>((static_cast<uint64_t>(offset) * 131 + 17) % 251);
+}
+
+bool write_pattern_file(const char* path, off_t size) {
+    int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+    if (fd < 0) {
+        return false;
+    }
+
+    std::vector<uint8_t> buffer(64 * 1024);
+    for (off_t offset = 0; offset < size;) {
+        size_t length = static_cast<size_t>(size - offset);
+        if (length > buffer.size()) {
+            length = buffer.size();
+        }
+        for (size_t i = 0; i < length; ++i) {
+            buffer[i] = pattern_byte(offset + static_cast<off_t>(i));
+        }
+        ssize_t written = pwrite(fd, buffer.data(), length, offset);
+        if (written != static_cast<ssize_t>(length)) {
+            close(fd);
+            return false;
+        }
+        offset += written;
+    }
+    bool ok = fsync(fd) == 0 && close(fd) == 0;
+    return ok;
+}
+
+bool write_pressure_file(const char* path, off_t size, unsigned long ranges) {
+    int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+    if (fd < 0) {
+        return false;
+    }
+    bool ok = ftruncate(fd, size) == 0;
+    for (unsigned long i = 0; ok && i <= ranges; ++i) {
+        off_t offset = static_cast<off_t>(i) * kDaxRangeSize + 17;
+        uint8_t value = pattern_byte(offset);
+        ok = pwrite(fd, &value, 1, offset) == 1;
+    }
+    if (ok && fsync(fd) != 0) {
+        ok = false;
+    }
+    if (close(fd) != 0) {
+        ok = false;
+    }
+    return ok;
+}
+
+bool wait_for_child(pid_t child, int* status) {
+    for (unsigned i = 0; i < kWaitIterations; ++i) {
+        pid_t result = waitpid(child, status, WNOHANG);
+        if (result == child) {
+            return true;
+        }
+        if (result < 0) {
+            return false;
+        }
+        usleep(100000);
+    }
+    kill(child, SIGKILL);
+    waitpid(child, status, 0);
+    return false;
+}
+
+struct TestPaths {
+    char root[160] = {};
+    char mountpoint[192] = {};
+    char debugfs[192] = {};
+    char stats[224] = {};
+    char file[256] = {};
+
+    TestPaths(const char* suffix) {
+        snprintf(root, sizeof(root), "/tmp/virtiofs_dax_%s_%d", suffix, getpid());
+        snprintf(mountpoint, sizeof(mountpoint), "%s/mnt", root);
+        snprintf(debugfs, sizeof(debugfs), "%s/debug", root);
+        snprintf(stats, sizeof(stats), "%s/fuse/stats", debugfs);
+        snprintf(file, sizeof(file), "%s/dax_test.bin", mountpoint);
+    }
+
+    bool create() const {
+        return ensure_dir("/tmp") == 0 && ensure_dir(root) == 0 && ensure_dir(mountpoint) == 0 &&
+               ensure_dir(debugfs) == 0;
+    }
+
+    void cleanup() const {
+        umount(mountpoint);
+        umount(debugfs);
+        rmdir(mountpoint);
+        rmdir(debugfs);
+        rmdir(root);
+    }
+};
+
+bool mount_virtiofs(const char* mountpoint, const char* dax_mode, int* error);
+
+struct CleanupGuard {
+    const TestPaths& paths;
+
+    ~CleanupGuard() {
+        // Fatal gtest assertions return immediately. Keep those paths from
+        // leaking mounts or host-share fixtures into subsequent runs.
+        umount(paths.mountpoint);
+        int ignored_error = 0;
+        if (mount_virtiofs(paths.mountpoint, "never", &ignored_error)) {
+            unlink(paths.file);
+            umount(paths.mountpoint);
+        }
+        umount(paths.debugfs);
+        rmdir(paths.mountpoint);
+        rmdir(paths.debugfs);
+        rmdir(paths.root);
+    }
+};
+
+bool mount_virtiofs(const char* mountpoint, const char* dax_mode, int* error) {
+    char options[64] = {};
+    snprintf(options, sizeof(options), "dax=%s", dax_mode);
+    if (mount("hostshare", mountpoint, "virtiofs", 0, options) == 0) {
+        return true;
+    }
+    *error = errno;
+    return false;
+}
+
+bool prepare_non_dax_file(const TestPaths& paths, off_t size, int* error) {
+    if (!mount_virtiofs(paths.mountpoint, "never", error)) {
+        return false;
+    }
+    bool ok = write_pattern_file(paths.file, size);
+    if (!ok) {
+        *error = errno;
+    }
+    if (umount(paths.mountpoint) != 0) {
+        if (ok) {
+            *error = errno;
+        }
+        ok = false;
+    }
+    return ok;
+}
+
+bool prepare_non_dax_pressure_file(const TestPaths& paths, off_t size, unsigned long ranges,
+                                   int* error) {
+    if (!mount_virtiofs(paths.mountpoint, "never", error)) {
+        return false;
+    }
+    bool ok = write_pressure_file(paths.file, size, ranges);
+    if (!ok) {
+        *error = errno;
+    }
+    if (umount(paths.mountpoint) != 0) {
+        if (ok) {
+            *error = errno;
+        }
+        ok = false;
+    }
+    return ok;
+}
+
+void remove_non_dax_file(const TestPaths& paths) {
+    int error = 0;
+    if (mount_virtiofs(paths.mountpoint, "never", &error)) {
+        unlink(paths.file);
+        umount(paths.mountpoint);
+    }
+}
+
+bool mount_debugfs(const TestPaths& paths, int* error) {
+    if (mount("none", paths.debugfs, "debugfs", 0, nullptr) == 0) {
+        return true;
+    }
+    *error = errno;
+    return false;
+}
+
+void expect_child_signal(const char* path, off_t offset, int prot, int flags, int signal) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        int fd = open(path, O_RDONLY);
+        if (fd < 0) {
+            _exit(101);
+        }
+        void* mapping = mmap(nullptr, kPageSize, prot, flags, fd, offset);
+        if (mapping == MAP_FAILED) {
+            _exit(102);
+        }
+        volatile uint8_t* byte = static_cast<volatile uint8_t*>(mapping);
+        if (signal == SIGSEGV) {
+            *byte = static_cast<uint8_t>(*byte + 1);
+        } else {
+            (void)*byte;
+        }
+        _exit(103);
+    }
+
+    int status = 0;
+    ASSERT_TRUE(wait_for_child(child, &status)) << "child timed out";
+    ASSERT_TRUE(WIFSIGNALED(status)) << "child status=" << status;
+    EXPECT_EQ(signal, WTERMSIG(status));
+}
+
+void verify_zero_range(int fd, off_t offset, size_t length) {
+    std::vector<uint8_t> buffer(length, 0xff);
+    ASSERT_EQ(static_cast<ssize_t>(length), pread(fd, buffer.data(), length, offset));
+    for (size_t i = 0; i < length; ++i) {
+        ASSERT_EQ(0, buffer[i]) << "non-zero sparse byte at " << offset + i;
+    }
+}
+
+}  // namespace
+
+TEST(VirtioFsDax, IoMmapPermissionsEofAndTeardown) {
+    TestPaths paths("io");
+    ASSERT_TRUE(paths.create());
+    CleanupGuard cleanup{paths};
+
+    int error = 0;
+    constexpr off_t initial_size = 8 * kDaxRangeSize + 123;
+    if (!prepare_non_dax_file(paths, initial_size, &error)) {
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX is required but ordinary virtiofs preparation failed: errno=" << error
+                   << " (" << strerror(error) << ")";
+        }
+        GTEST_SKIP() << "ordinary virtiofs is unavailable: errno=" << error << " ("
+                     << strerror(error) << ")";
+    }
+    ASSERT_TRUE(mount_debugfs(paths, &error)) << strerror(error);
+
+    if (!mount_virtiofs(paths.mountpoint, "always", &error)) {
+        remove_non_dax_file(paths);
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX is required but dax=always mount failed: errno=" << error << " ("
+                   << strerror(error) << ")";
+        }
+        GTEST_SKIP() << "DAX window/backend is unavailable in optional mode: errno=" << error
+                     << " (" << strerror(error) << ")";
+    }
+
+    int fd = open(paths.file, O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+
+    OpcodeSnapshot before = snapshot(paths.stats);
+    ASSERT_EQ(0, lseek(fd, 64, SEEK_SET));
+    uint8_t read_buffer[64] = {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(read_buffer)), read(fd, read_buffer, sizeof(read_buffer)));
+    for (size_t i = 0; i < sizeof(read_buffer); ++i) {
+        EXPECT_EQ(pattern_byte(64 + static_cast<off_t>(i)), read_buffer[i]);
+    }
+    expect_dax_data_path(before, snapshot(paths.stats));
+
+    constexpr off_t cross_offset = 2 * kDaxRangeSize - 32;
+    before = snapshot(paths.stats);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(read_buffer)),
+              pread(fd, read_buffer, sizeof(read_buffer), cross_offset));
+    for (size_t i = 0; i < sizeof(read_buffer); ++i) {
+        EXPECT_EQ(pattern_byte(cross_offset + static_cast<off_t>(i)), read_buffer[i]);
+    }
+    expect_dax_data_path(before, snapshot(paths.stats), 2);
+
+    constexpr off_t mmap_offset = 3 * kDaxRangeSize;
+    before = snapshot(paths.stats);
+    void* read_mapping = mmap(nullptr, kPageSize, PROT_READ, MAP_PRIVATE, fd, mmap_offset);
+    ASSERT_NE(MAP_FAILED, read_mapping) << strerror(errno);
+    EXPECT_EQ(pattern_byte(mmap_offset + 37), static_cast<uint8_t*>(read_mapping)[37]);
+    ASSERT_EQ(0, munmap(read_mapping, kPageSize));
+    expect_dax_data_path(before, snapshot(paths.stats));
+
+    static const char inplace_data[] = "dax-in-place-write";
+    constexpr off_t inplace_offset = 4 * kDaxRangeSize + 100;
+    before = snapshot(paths.stats);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(inplace_data)),
+              pwrite(fd, inplace_data, sizeof(inplace_data), inplace_offset));
+    expect_dax_data_path(before, snapshot(paths.stats));
+
+    static const char shared_data[] = "dax-shared-mmap";
+    constexpr off_t shared_page = 5 * kDaxRangeSize;
+    before = snapshot(paths.stats);
+    void* shared_mapping = mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+                                shared_page);
+    ASSERT_NE(MAP_FAILED, shared_mapping) << strerror(errno);
+    memcpy(static_cast<uint8_t*>(shared_mapping) + 200, shared_data, sizeof(shared_data));
+    ASSERT_EQ(0, msync(shared_mapping, kPageSize, MS_SYNC)) << strerror(errno);
+    ASSERT_EQ(0, munmap(shared_mapping, kPageSize));
+    expect_dax_data_path(before, snapshot(paths.stats));
+
+    constexpr off_t private_page = 6 * kDaxRangeSize;
+    uint8_t private_original = pattern_byte(private_page + 300);
+    before = snapshot(paths.stats);
+    int readonly_fd = open(paths.file, O_RDONLY);
+    ASSERT_GE(readonly_fd, 0);
+    void* private_mapping = mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE,
+                                 readonly_fd, private_page);
+    ASSERT_NE(MAP_FAILED, private_mapping) << strerror(errno);
+    EXPECT_EQ(private_original, static_cast<uint8_t*>(private_mapping)[300]);
+    static_cast<uint8_t*>(private_mapping)[300] ^= 0x5a;
+    EXPECT_NE(private_original, static_cast<uint8_t*>(private_mapping)[300]);
+    ASSERT_EQ(0, munmap(private_mapping, kPageSize));
+    expect_dax_data_path(before, snapshot(paths.stats));
+
+    errno = 0;
+    void* denied = mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, readonly_fd, 0);
+    EXPECT_EQ(MAP_FAILED, denied);
+    EXPECT_EQ(EACCES, errno);
+
+    void* protected_mapping = mmap(nullptr, kPageSize, PROT_READ, MAP_SHARED, readonly_fd, 0);
+    ASSERT_NE(MAP_FAILED, protected_mapping);
+    errno = 0;
+    EXPECT_EQ(-1, mprotect(protected_mapping, kPageSize, PROT_READ | PROT_WRITE));
+    EXPECT_EQ(EACCES, errno);
+    ASSERT_EQ(0, munmap(protected_mapping, kPageSize));
+    ASSERT_EQ(0, close(readonly_fd));
+    expect_child_signal(paths.file, 0, PROT_READ, MAP_SHARED, SIGSEGV);
+
+    off_t final_page = initial_size & ~static_cast<off_t>(kPageSize - 1);
+    void* eof_tail = mmap(nullptr, kPageSize, PROT_READ, MAP_PRIVATE, fd, final_page);
+    ASSERT_NE(MAP_FAILED, eof_tail) << strerror(errno);
+    EXPECT_EQ(pattern_byte(initial_size - 1), static_cast<uint8_t*>(eof_tail)[122]);
+    for (size_t i = 123; i < kPageSize; ++i) {
+        ASSERT_EQ(0, static_cast<uint8_t*>(eof_tail)[i]) << "offset in EOF tail=" << i;
+    }
+    ASSERT_EQ(0, munmap(eof_tail, kPageSize));
+    expect_child_signal(paths.file, final_page + kPageSize, PROT_READ, MAP_PRIVATE, SIGBUS);
+
+    static const char extension[] = "regular-fuse-extension";
+    before = snapshot(paths.stats);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(extension)),
+              pwrite(fd, extension, sizeof(extension), initial_size));
+    OpcodeSnapshot after = snapshot(paths.stats);
+    assert_valid_snapshot(before);
+    assert_valid_snapshot(after);
+    EXPECT_GT(after.write, before.write);
+
+    constexpr off_t sparse_gap = 2 * kPageSize + 37;
+    off_t sparse_offset = initial_size + sizeof(extension) + sparse_gap;
+    static const char sparse_data[] = "regular-fuse-sparse-write";
+    before = snapshot(paths.stats);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(sparse_data)),
+              pwrite(fd, sparse_data, sizeof(sparse_data), sparse_offset));
+    after = snapshot(paths.stats);
+    EXPECT_GT(after.write, before.write);
+
+    ASSERT_EQ(0, fsync(fd));
+    ASSERT_EQ(0, close(fd));
+
+    // Create one last idle owned mapping so teardown, rather than an earlier
+    // pressure reclaim, must account for at least one REMOVEMAPPING request.
+    fd = open(paths.file, O_RDONLY);
+    ASSERT_GE(fd, 0);
+    uint8_t last_byte = 0;
+    ASSERT_EQ(1, pread(fd, &last_byte, 1, 7 * kDaxRangeSize + 19));
+    ASSERT_EQ(0, close(fd));
+    OpcodeSnapshot before_umount = snapshot(paths.stats);
+    ASSERT_EQ(0, umount(paths.mountpoint)) << strerror(errno);
+    OpcodeSnapshot after_umount = snapshot(paths.stats);
+    assert_valid_snapshot(before_umount);
+    assert_valid_snapshot(after_umount);
+    EXPECT_GT(after_umount.remove_mapping, before_umount.remove_mapping);
+
+    ASSERT_TRUE(mount_virtiofs(paths.mountpoint, "never", &error)) << strerror(error);
+    fd = open(paths.file, O_RDONLY);
+    ASSERT_GE(fd, 0);
+    char verify[64] = {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(inplace_data)),
+              pread(fd, verify, sizeof(inplace_data), inplace_offset));
+    EXPECT_EQ(0, memcmp(inplace_data, verify, sizeof(inplace_data)));
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(shared_data)),
+              pread(fd, verify, sizeof(shared_data), shared_page + 200));
+    EXPECT_EQ(0, memcmp(shared_data, verify, sizeof(shared_data)));
+    uint8_t private_verify = 0;
+    ASSERT_EQ(1, pread(fd, &private_verify, 1, private_page + 300));
+    EXPECT_EQ(private_original, private_verify);
+    struct stat st = {};
+    ASSERT_EQ(0, fstat(fd, &st));
+    EXPECT_EQ(sparse_offset + static_cast<off_t>(sizeof(sparse_data)), st.st_size);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(extension)),
+              pread(fd, verify, sizeof(extension), initial_size));
+    EXPECT_EQ(0, memcmp(extension, verify, sizeof(extension)));
+    verify_zero_range(fd, initial_size + sizeof(extension), sparse_gap);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(sparse_data)),
+              pread(fd, verify, sizeof(sparse_data), sparse_offset));
+    EXPECT_EQ(0, memcmp(sparse_data, verify, sizeof(sparse_data)));
+    ASSERT_EQ(0, close(fd));
+    ASSERT_EQ(0, unlink(paths.file));
+    ASSERT_EQ(0, umount(paths.mountpoint));
+    paths.cleanup();
+}
+
+TEST(VirtioFsDax, FaultRangePressureCompletesWithoutDeadlock) {
+    const char* ranges_text = getenv("DRAGONOS_VIRTIOFS_DAX_WINDOW_RANGES");
+    if (ranges_text == nullptr || *ranges_text == '\0') {
+        if (dax_required()) {
+            FAIL() << "required DAX pressure test needs DRAGONOS_VIRTIOFS_DAX_WINDOW_RANGES";
+        }
+        GTEST_SKIP() << "set DRAGONOS_VIRTIOFS_DAX_WINDOW_RANGES to the runner's DAX window size";
+    }
+    char* end = nullptr;
+    unsigned long ranges = strtoul(ranges_text, &end, 10);
+    ASSERT_NE(ranges_text, end);
+    ASSERT_EQ('\0', *end);
+    ASSERT_GE(ranges, 1UL);
+    ASSERT_LE(ranges, 128UL);
+
+    TestPaths paths("pressure");
+    ASSERT_TRUE(paths.create());
+    CleanupGuard cleanup{paths};
+    int error = 0;
+    off_t file_size = static_cast<off_t>(ranges + 1) * kDaxRangeSize + kPageSize;
+    if (!prepare_non_dax_pressure_file(paths, file_size, ranges, &error)) {
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX pressure environment is required but ordinary virtiofs preparation "
+                      "failed: "
+                   << strerror(error);
+        }
+        GTEST_SKIP() << "ordinary virtiofs is unavailable: " << strerror(error);
+    }
+    ASSERT_TRUE(mount_debugfs(paths, &error)) << strerror(error);
+    if (!mount_virtiofs(paths.mountpoint, "always", &error)) {
+        remove_non_dax_file(paths);
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX pressure environment is required: " << strerror(error);
+        }
+        GTEST_SKIP() << "DAX pressure environment is unavailable: " << strerror(error);
+    }
+
+    OpcodeSnapshot before = snapshot(paths.stats);
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        int fd = open(paths.file, O_RDONLY);
+        if (fd < 0) {
+            _exit(101);
+        }
+        volatile uint8_t sum = 0;
+        for (unsigned long i = 0; i <= ranges; ++i) {
+            off_t offset = static_cast<off_t>(i) * kDaxRangeSize + 17;
+            off_t page_offset = offset & ~static_cast<off_t>(kPageSize - 1);
+            size_t in_page = static_cast<size_t>(offset - page_offset);
+            void* mapping = mmap(nullptr, kPageSize, PROT_READ, MAP_PRIVATE, fd, page_offset);
+            if (mapping == MAP_FAILED) {
+                _exit(102);
+            }
+            volatile uint8_t value = static_cast<volatile uint8_t*>(mapping)[in_page];
+            if (value != pattern_byte(offset)) {
+                _exit(103);
+            }
+            sum ^= value;
+            if (munmap(mapping, kPageSize) != 0) {
+                _exit(104);
+            }
+        }
+        (void)sum;
+        close(fd);
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_TRUE(wait_for_child(child, &status)) << "DAX range-pressure fault path deadlocked";
+    ASSERT_TRUE(WIFEXITED(status)) << "pressure child status=" << status;
+    ASSERT_EQ(0, WEXITSTATUS(status));
+    OpcodeSnapshot after = snapshot(paths.stats);
+    assert_valid_snapshot(before);
+    assert_valid_snapshot(after);
+    EXPECT_GE(after.setup_mapping - before.setup_mapping, static_cast<long long>(ranges + 1));
+    EXPECT_GT(after.remove_mapping, before.remove_mapping);
+    EXPECT_EQ(before.read, after.read);
+
+    ASSERT_EQ(0, umount(paths.mountpoint));
+    remove_non_dax_file(paths);
+    paths.cleanup();
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -72,6 +72,7 @@ normal/tty_pty_hangup
 normal/cubesandbox_pty_exec_chain
 normal/eventfd_pending_signal
 normal/virtiofs_smoke
+normal/virtiofs_dax
 normal/af_packet_sockopt
 normal/af_packet_e2e
 normal/af_packet_mcast


### PR DESCRIPTION
## Summary

- wire the virtiofs shared-memory window into per-inode DAX mappings for read, non-extending write, mmap fault, shared write upgrade, and private COW
- add mixed-PFN MM support with safe mprotect, fork, mremap, unmap, RSS accounting, and lock-releasing fault retry
- implement pressure reclaim, truncate and disconnect revocation, admission draining, and two-pass PTE invalidation
- add virtiofs DAX dunitest coverage with FUSE opcode evidence for I/O, mmap, EOF, permissions, pressure, and teardown

## Linux semantics

The implementation follows Linux 6.6.139 fs/fuse/dax.c: fixed 2 MiB mappings, inode sentinel file handle, DAX precedence over direct I/O, ordinary FUSE for extending writes, shared write upgrades, private COW, and retry after releasing memory-management locks.

## Validation

- make kernel
- cargo fmt --all -- --check (kernel workspace)
- git diff --check
- built normal/virtiofs_dax_test
- optional local dunitest run: both cases explicitly skipped because this host has no DragonOS virtiofs/DAX device
- required-mode local dunitest run: failed as intended when the required DAX environment was absent

The available QEMU 10 vhost-user-fs device does not expose a DAX cache window, so true DAX end-to-end execution requires a DAX-capable runner. The required test mode treats a missing window/backend as failure rather than success.

Fixes #2080