### PR TITLE
fix(virtiofs): serialize DAX layout invalidation

### DIFF
--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -9,7 +9,7 @@ use alloc::{
     vec::Vec,
 };
 use core::mem::size_of;
-use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 use system_error::SystemError;
 
@@ -20,9 +20,12 @@ use crate::{
         page_cache::PageCache,
         vfs::{FileType, InodeFlags, InodeId, InodeMode, Metadata},
     },
-    libs::mutex::Mutex,
-    libs::rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
-    mm::MemoryManagementArch,
+    libs::{
+        mutex::Mutex,
+        rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
+        wait_queue::WaitQueue,
+    },
+    mm::{fault::FaultRetryWait, MemoryManagementArch},
     time::PosixTimeSpec,
 };
 
@@ -74,6 +77,111 @@ pub(crate) struct DaxReclaimTombstone {
     file_offset: u64,
     mapping: Arc<DaxMapping>,
     token: ReclaimToken,
+}
+
+/// Blocks host-invalidated DAX contents from being consumed while keeping
+/// daemon requests outside the bounded active section.  A notification can
+/// therefore drain actual window users without waiting for a SETUPMAPPING
+/// request whose reply depends on that same notification returning.
+#[derive(Debug)]
+struct DaxHostInvalidationGate {
+    blockers: AtomicUsize,
+    active: AtomicUsize,
+    wait: WaitQueue,
+}
+
+#[derive(Debug)]
+pub(crate) struct DaxHostAccessGuard {
+    gate: Arc<DaxHostInvalidationGate>,
+}
+
+#[derive(Debug)]
+pub(crate) struct DaxHostInvalidationBlocker {
+    gate: Arc<DaxHostInvalidationGate>,
+}
+
+#[derive(Debug)]
+struct DaxHostInvalidationRetryWait {
+    gate: Arc<DaxHostInvalidationGate>,
+}
+
+impl DaxHostInvalidationGate {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            blockers: AtomicUsize::new(0),
+            active: AtomicUsize::new(0),
+            wait: WaitQueue::default(),
+        })
+    }
+
+    fn try_enter(self: &Arc<Self>) -> Result<DaxHostAccessGuard, SystemError> {
+        if self.blockers.load(Ordering::Acquire) != 0 {
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        }
+        self.active.fetch_add(1, Ordering::AcqRel);
+        if self.blockers.load(Ordering::Acquire) != 0 {
+            self.leave_active();
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        }
+        Ok(DaxHostAccessGuard { gate: self.clone() })
+    }
+
+    fn begin(self: &Arc<Self>) -> Result<DaxHostInvalidationBlocker, SystemError> {
+        self.blockers
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                count.checked_add(1)
+            })
+            .map_err(|_| SystemError::EOVERFLOW)?;
+        self.wait
+            .wait_until(|| (self.active.load(Ordering::Acquire) == 0).then_some(()));
+        Ok(DaxHostInvalidationBlocker { gate: self.clone() })
+    }
+
+    fn blocked(&self) -> bool {
+        self.blockers.load(Ordering::Acquire) != 0
+    }
+
+    fn wait_unblocked(&self) {
+        self.wait.wait_until(|| (!self.blocked()).then_some(()));
+    }
+
+    fn wait_unblocked_interruptible(&self) -> Result<(), SystemError> {
+        self.wait
+            .wait_until_interruptible(|| (!self.blocked()).then_some(()))
+    }
+
+    fn leave_active(&self) {
+        if self.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.wait.wakeup_all(None);
+        }
+    }
+
+    fn leave_blocker(&self) {
+        let previous = self.blockers.fetch_sub(1, Ordering::AcqRel);
+        debug_assert_ne!(previous, 0);
+        if previous == 1 {
+            self.wait.wakeup_all(None);
+        }
+    }
+}
+
+impl Drop for DaxHostAccessGuard {
+    fn drop(&mut self) {
+        self.gate.leave_active();
+    }
+}
+
+impl Drop for DaxHostInvalidationBlocker {
+    fn drop(&mut self) {
+        self.gate.leave_blocker();
+    }
+}
+
+impl FaultRetryWait for DaxHostInvalidationRetryWait {
+    fn wait(&self) -> Result<(), SystemError> {
+        self.gate.wait_unblocked();
+        Ok(())
+    }
 }
 
 impl DaxMappingTree {
@@ -172,7 +280,13 @@ pub struct FuseNode {
     /// Serializes dirty-page admission against operations which must drain and
     /// invalidate the page cache (truncate and direct I/O).
     writeback_barrier: RwSem<()>,
+    /// Serializes the complete two-zap/tombstone/REMOVEMAPPING transaction.
+    /// The layout semaphore is intentionally dropped between the two zaps, so
+    /// it cannot by itself prevent another layout breaker from observing and
+    /// passing a half-finished tombstone.
+    dax_reclaim_serial: Mutex<()>,
     dax_mappings: RwSem<DaxMappingTree>,
+    dax_host_invalidation: Arc<DaxHostInvalidationGate>,
     dax_pte_epoch: AtomicU64,
     cached_metadata_deadline_ns: AtomicU64,
     attr_version: AtomicU64,
@@ -234,7 +348,9 @@ impl FuseNode {
             writeback_handles: Mutex::new(Vec::new()),
             lookup_cache: Mutex::new(BTreeMap::new()),
             writeback_barrier: RwSem::new(()),
+            dax_reclaim_serial: Mutex::new(()),
             dax_mappings: RwSem::new(DaxMappingTree::default()),
+            dax_host_invalidation: DaxHostInvalidationGate::new(),
             dax_pte_epoch: AtomicU64::new(0),
             cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             attr_version: AtomicU64::new(initial_attr_epoch),
@@ -269,6 +385,30 @@ impl FuseNode {
 
     pub(crate) fn dax_layout_write(&self) -> RwSemWriteGuard<'_, ()> {
         self.writeback_barrier.write()
+    }
+
+    pub(crate) fn dax_try_host_access(&self) -> Result<DaxHostAccessGuard, SystemError> {
+        self.dax_host_invalidation.try_enter()
+    }
+
+    pub(crate) fn dax_begin_host_invalidation(
+        &self,
+    ) -> Result<DaxHostInvalidationBlocker, SystemError> {
+        self.dax_host_invalidation.begin()
+    }
+
+    pub(crate) fn dax_host_invalidation_blocked(&self) -> bool {
+        self.dax_host_invalidation.blocked()
+    }
+
+    pub(crate) fn dax_wait_host_invalidation_interruptible(&self) -> Result<(), SystemError> {
+        self.dax_host_invalidation.wait_unblocked_interruptible()
+    }
+
+    pub(crate) fn dax_host_invalidation_retry_wait(&self) -> Arc<dyn FaultRetryWait> {
+        Arc::new(DaxHostInvalidationRetryWait {
+            gate: self.dax_host_invalidation.clone(),
+        })
     }
 
     pub(crate) fn dax_pte_epoch(&self) -> u64 {
@@ -442,28 +582,42 @@ impl FuseNode {
         })
     }
 
+    fn dax_mapping_intersects(
+        mapping: &DaxMapping,
+        start: usize,
+        end_exclusive: Option<usize>,
+    ) -> Result<bool, SystemError> {
+        let mapping_start =
+            usize::try_from(mapping.file_offset).map_err(|_| SystemError::EOVERFLOW)?;
+        let mapping_end = mapping_start
+            .checked_add(DAX_RANGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        Ok(mapping_end > start && end_exclusive.is_none_or(|end| mapping_start < end))
+    }
+
     /// Acquire the inode layout exclusively after revoking and removing every
-    /// DAX range intersecting `[new_size, EOF)`.  Sequence and PTE epochs make
-    /// the rmap-walk-to-lock transition retryable instead of racy.
-    pub(crate) fn dax_layout_write_for_truncate(
+    /// DAX range intersecting `[start, end_exclusive)`. Sequence and PTE epochs
+    /// make the rmap-walk-to-lock transition retryable instead of racy.
+    fn dax_layout_write_for_range_with_restore(
         &self,
-        new_size: usize,
+        start: usize,
+        end_exclusive: Option<usize>,
+        restore_on_failure: bool,
     ) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
         if !self.conn.dax_enabled() {
             return Ok(self.dax_layout_write());
         }
+        let _reclaim_serial = self.dax_reclaim_serial.lock();
         'retry: loop {
             let page_cache = self.cached_page_cache();
             let (sequence, mappings) = {
                 let tree = self.dax_mappings.read();
-                let mappings = tree
-                    .mappings
-                    .values()
-                    .filter(|mapping| {
-                        (mapping.file_offset as usize).saturating_add(DAX_RANGE_SIZE) > new_size
-                    })
-                    .cloned()
-                    .collect::<Vec<_>>();
+                let mut mappings = Vec::new();
+                for mapping in tree.mappings.values() {
+                    if Self::dax_mapping_intersects(mapping, start, end_exclusive)? {
+                        mappings.push(mapping.clone());
+                    }
+                }
                 (tree.sequence, mappings)
             };
             let epoch = self.dax_pte_epoch();
@@ -546,9 +700,13 @@ impl FuseNode {
             let layout = self.dax_layout_write();
             let mut remaining = tombstones.into_iter();
             while let Some(tombstone) = remaining.next() {
-                if let Err(error) = self.dax_finish_reclaim(tombstone) {
+                if let Err(error) =
+                    self.dax_finish_reclaim_with_restore(tombstone, restore_on_failure)
+                {
                     for unsubmitted in remaining {
-                        let _ = self.dax_cancel_reclaim(unsubmitted);
+                        if restore_on_failure {
+                            let _ = self.dax_cancel_reclaim(unsubmitted);
+                        }
                     }
                     return Err(error);
                 }
@@ -557,9 +715,36 @@ impl FuseNode {
         }
     }
 
+    pub(crate) fn dax_layout_write_for_range(
+        &self,
+        start: usize,
+        end_exclusive: Option<usize>,
+    ) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
+        self.dax_layout_write_for_range_with_restore(start, end_exclusive, true)
+    }
+
+    pub(crate) fn dax_layout_write_for_truncate(
+        &self,
+        new_size: usize,
+    ) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
+        self.dax_layout_write_for_range(new_size, None)
+    }
+
+    pub(crate) fn dax_layout_write_for_all(&self) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
+        self.dax_layout_write_for_range(0, None)
+    }
+
+    pub(crate) fn dax_layout_write_for_host_invalidation(
+        &self,
+        start: usize,
+        end_exclusive: Option<usize>,
+    ) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
+        self.dax_layout_write_for_range_with_restore(start, end_exclusive, false)
+    }
+
     pub(crate) fn dax_teardown(&self) -> Result<(), SystemError> {
         if self.conn.dax_enabled() {
-            drop(self.dax_layout_write_for_truncate(0)?);
+            drop(self.dax_layout_write_for_all()?);
         }
         Ok(())
     }
@@ -665,6 +850,14 @@ impl FuseNode {
         &self,
         tombstone: DaxReclaimTombstone,
     ) -> Result<(), SystemError> {
+        self.dax_finish_reclaim_with_restore(tombstone, true)
+    }
+
+    fn dax_finish_reclaim_with_restore(
+        &self,
+        tombstone: DaxReclaimTombstone,
+        restore_on_failure: bool,
+    ) -> Result<(), SystemError> {
         let result = self.conn.remove_dax_mappings(
             self.dax_mapping_owner(),
             core::slice::from_ref(&tombstone.token),
@@ -673,19 +866,24 @@ impl FuseNode {
             .conn
             .dax_allocator()
             .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
-        let restore = result.is_err() && allocator.is_owned(&tombstone.mapping.token);
+        let restore =
+            restore_on_failure && result.is_err() && allocator.is_owned(&tombstone.mapping.token);
         let mut tree = self.dax_mappings.write();
         if tree
             .tombstones
             .get(&tombstone.file_offset)
             .is_some_and(|mapping| Arc::ptr_eq(mapping, &tombstone.mapping))
         {
-            tree.tombstones.remove(&tombstone.file_offset);
+            if result.is_ok() || restore_on_failure {
+                tree.tombstones.remove(&tombstone.file_offset);
+            }
             if restore {
                 tree.mappings
                     .insert(tombstone.file_offset, tombstone.mapping);
             }
-            tree.bump_sequence()?;
+            if result.is_ok() || restore_on_failure {
+                tree.bump_sequence()?;
+            }
         }
         result
     }
@@ -710,6 +908,7 @@ impl FuseNode {
         &self,
         candidate: &ReclaimCandidate,
     ) -> Result<(), SystemError> {
+        let _reclaim_serial = self.dax_reclaim_serial.lock();
         let mapping = self
             .dax_mappings
             .read()
@@ -756,6 +955,11 @@ impl FuseNode {
             let chunk = core::cmp::min(requested - done, DAX_RANGE_SIZE - in_mapping);
             let access = match self.dax_access_inner(current as u64, false, None) {
                 Ok(access) => access,
+                Err(error) if done == 0 => return Err(error),
+                Err(_) => return Ok(done),
+            };
+            let _host_access = match self.dax_try_host_access() {
+                Ok(guard) => guard,
                 Err(error) if done == 0 => return Err(error),
                 Err(_) => return Ok(done),
             };
@@ -863,6 +1067,11 @@ impl FuseNode {
             let chunk = core::cmp::min(buf.len() - done, DAX_RANGE_SIZE - in_mapping);
             let access = match self.dax_access_inner(current as u64, true, None) {
                 Ok(access) => access,
+                Err(error) if done == 0 => return Err(error),
+                Err(_) => return Ok(done),
+            };
+            let _host_access = match self.dax_try_host_access() {
+                Ok(guard) => guard,
                 Err(error) if done == 0 => return Err(error),
                 Err(_) => return Ok(done),
             };
@@ -1221,5 +1430,35 @@ impl Drop for FuseNode {
         self.clear_lookup_cache_tree();
         self.flush_forget();
         self.clear_parent();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dax_host_invalidation_gate_blocks_until_last_notification_finishes() {
+        let gate = DaxHostInvalidationGate::new();
+        let access = gate.try_enter().unwrap();
+        assert_eq!(gate.active.load(Ordering::Acquire), 1);
+        drop(access);
+
+        let first = gate.begin().unwrap();
+        let second = gate.begin().unwrap();
+        assert!(gate.blocked());
+        assert!(matches!(
+            gate.try_enter(),
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+        ));
+        drop(first);
+        assert!(gate.blocked());
+        drop(second);
+        assert!(!gate.blocked());
+
+        let access = gate.try_enter().unwrap();
+        assert_eq!(gate.active.load(Ordering::Acquire), 1);
+        drop(access);
+        assert_eq!(gate.active.load(Ordering::Acquire), 0);
     }
 }

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -145,6 +145,7 @@ impl FuseNode {
             return Ok(());
         }
         let node = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        let dax_fail_closed = blocker.is_some();
         let blocker = Mutex::new(blocker);
         schedule_pagecache_io(Work::new(move || {
             let result = (|| {
@@ -174,14 +175,29 @@ impl FuseNode {
                 Ok::<(), SystemError>(())
             })();
             if let Err(error) = result {
-                log::error!(
-                    "fuse: host inode invalidation failed closed node={} offset={} len={} err={:?}",
-                    node.nodeid(),
-                    offset,
-                    len,
-                    error
-                );
-                node.conn().abort();
+                if dax_fail_closed {
+                    log::error!(
+                        "fuse: host inode invalidation failed closed node={} offset={} len={} err={:?}",
+                        node.nodeid(),
+                        offset,
+                        len,
+                        error
+                    );
+                    node.conn().abort();
+                } else {
+                    // Linux treats reverse page-cache invalidation as
+                    // best-effort and ignores invalidate_inode_pages2_range()
+                    // failures. The page-cache writeback path retains the I/O
+                    // error for later fsync reporting; it must not disconnect
+                    // an otherwise healthy non-DAX FUSE session.
+                    log::warn!(
+                        "fuse: page-cache invalidation incomplete node={} offset={} len={} err={:?}",
+                        node.nodeid(),
+                        offset,
+                        len,
+                        error
+                    );
+                }
             }
             blocker.lock().take();
         }));

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -89,27 +89,47 @@ impl FuseNode {
         if offset < 0 {
             return Ok(());
         }
-        let Some(page_cache) = self.cached_page_cache() else {
-            return Ok(());
+        let start = offset as usize;
+        let end_exclusive = if len <= 0 {
+            None
+        } else {
+            Some(
+                (offset as u64)
+                    .saturating_add(len as u64)
+                    .min(usize::MAX as u64) as usize,
+            )
         };
-        let start_index = (offset as usize) >> MMArch::PAGE_SHIFT;
+        let start_index = start >> MMArch::PAGE_SHIFT;
         let end_index = if len <= 0 {
             usize::MAX
         } else {
             let last = (offset as u64).saturating_add(len as u64).saturating_sub(1);
             core::cmp::min(last, usize::MAX as u64) as usize >> MMArch::PAGE_SHIFT
         };
-        let end_exclusive = end_index.checked_add(1);
+        let end_page_exclusive = end_index.checked_add(1);
+        let page_cache = self.cached_page_cache();
+        let blocker = if self.conn().dax_enabled() {
+            Some(self.dax_begin_host_invalidation()?)
+        } else {
+            None
+        };
 
         // Linux unmap_mapping_pages(..., even_cows=false) preserves private
         // MAP_PRIVATE COW pages while zapping mappings backed by page cache.
-        let _ = page_cache.unmap_mapping_pages(start_index, end_exclusive);
+        if let Some(cache) = page_cache.as_ref() {
+            if let Err(error) = cache.unmap_mapping_pages(start_index, end_page_exclusive) {
+                if blocker.is_some() {
+                    self.conn().abort();
+                }
+                return Err(error);
+            }
+        }
         // Remove cache entries that need no daemon I/O before acknowledging the
         // notification. Dirty/loading/writeback entries remain pinned until the
         // deferred phase has made them safe to discard.
-        {
-            let _invalidate = page_cache.invalidate_write();
-            let _ = page_cache
+        if let Some(cache) = page_cache.as_ref() {
+            let _invalidate = cache.invalidate_write();
+            let _ = cache
                 .manager()
                 .discard_clean_range_nowait(start_index, end_index);
         }
@@ -121,20 +141,49 @@ impl FuseNode {
         // used while the work is pending.
         // This may block on userspace I/O, so use the dedicated page-cache I/O
         // pool rather than the single system workqueue.
+        if page_cache.is_none() && blocker.is_none() {
+            return Ok(());
+        }
+        let node = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+        let blocker = Mutex::new(blocker);
         schedule_pagecache_io(Work::new(move || {
-            // Linux invalidate_inode_pages2_range() launders dirty folios before
-            // removing clean cache pages.  Keep that ordering and best-effort
-            // behavior, but outside the unsolicited-notify call stack.
-            let _ = page_cache
-                .manager()
-                .launder_range_for_invalidate(start_index, end_index);
-            {
-                let _invalidate = page_cache.invalidate_write();
-                let _ = page_cache
-                    .manager()
-                    .discard_clean_range(start_index, end_index);
+            let result = (|| {
+                // Block buffered dirty admission while synchronizing and
+                // invalidating the ordinary page cache. The host-invalidation
+                // blocker independently prevents DAX window use/PTE publish.
+                let layout = node.dax_layout_write();
+                if let Some(cache) = page_cache.as_ref() {
+                    // Match Linux invalidate_inode_pages2_range(): only the
+                    // notified pages participate in laundering. An unrelated
+                    // dirty-page error must not abort the FUSE connection.
+                    cache
+                        .manager()
+                        .launder_range_for_invalidate(start_index, end_index)?;
+                }
+                node.invalidate_page_cache_range(
+                    start,
+                    end_exclusive
+                        .and_then(|end| end.checked_sub(start))
+                        .unwrap_or(usize::MAX - start),
+                )?;
+                drop(layout);
+
+                if blocker.lock().is_some() {
+                    drop(node.dax_layout_write_for_host_invalidation(start, end_exclusive)?);
+                }
+                Ok::<(), SystemError>(())
+            })();
+            if let Err(error) = result {
+                log::error!(
+                    "fuse: host inode invalidation failed closed node={} offset={} len={} err={:?}",
+                    node.nodeid(),
+                    offset,
+                    len,
+                    error
+                );
+                node.conn().abort();
             }
-            let _ = page_cache.unmap_mapping_pages(start_index, end_exclusive);
+            blocker.lock().take();
         }));
         Ok(())
     }
@@ -263,6 +312,34 @@ impl FuseNode {
         Ok(())
     }
 
+    /// Invalidate page-cache state after the daemon changed the contents of a
+    /// byte range (hole punch, zero range, or host notification). Dirty data
+    /// must have been drained before this helper is called.
+    pub(super) fn invalidate_page_cache_range(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Result<(), SystemError> {
+        if len == 0 {
+            return Ok(());
+        }
+        let Some(cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+        let end_byte = offset.checked_add(len - 1).ok_or(SystemError::EOVERFLOW)?;
+        let start_index = offset >> MMArch::PAGE_SHIFT;
+        let end_index = end_byte >> MMArch::PAGE_SHIFT;
+        let end_exclusive = end_index.checked_add(1);
+        cache.unmap_mapping_pages(start_index, end_exclusive)?;
+        {
+            let _invalidate = cache.invalidate_write();
+            cache
+                .manager()
+                .discard_clean_range(start_index, end_index)?;
+        }
+        cache.unmap_mapping_pages(start_index, end_exclusive)
+    }
+
     pub(crate) fn discard_completed_pages_beyond(
         &self,
         target: &PageCacheReadDmaReservation,
@@ -292,8 +369,15 @@ impl FuseNode {
         // hold time, then drain again under the barrier to close the race with
         // buffered writes and page_mkwrite.
         self.sync_dirty_cached_pages()?;
-        let _barrier = if self.conn().dax_enabled() && len < old_size {
-            self.dax_layout_write_for_truncate(len)?
+        let _barrier = if self.conn().dax_enabled() && len != old_size {
+            if len < old_size {
+                self.dax_layout_write_for_truncate(len)?
+            } else {
+                // SETUPMAPPING covers a full DAX range. Growth only needs to
+                // serialize the daemon size change with EOF validation; it
+                // does not need O(n) REMOVEMAPPING of reusable ranges.
+                self.dax_layout_write()
+            }
         } else {
             self.writeback_barrier.write()
         };
@@ -780,6 +864,25 @@ impl FuseNode {
         flags: &FileFlags,
     ) -> Result<(), SystemError> {
         self.check_not_stale()?;
+        let atomic_dax_truncate = opcode == FUSE_OPEN
+            && flags.contains(FileFlags::O_TRUNC)
+            && self
+                .conn
+                .has_init_flag(super::super::protocol::FUSE_ATOMIC_O_TRUNC)
+            && self.conn.dax_enabled();
+        if atomic_dax_truncate {
+            self.sync_dirty_cached_pages()?;
+        }
+        let _dax_truncate_layout = if atomic_dax_truncate {
+            Some(self.dax_layout_write_for_all()?)
+        } else {
+            None
+        };
+        if atomic_dax_truncate {
+            // Close dirty admission between the optimistic drain and layout
+            // exclusivity before OPEN can atomically change the host file.
+            self.sync_dirty_cached_pages()?;
+        }
         let file_flags = flags.bits();
         if self.conn.should_skip_open(opcode) {
             self.finish_open_cache_state(opcode, flags, FOPEN_KEEP_CACHE)?;

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -375,7 +375,11 @@ impl IndexNode for FuseNode {
             loop {
                 match self.dax_read(offset, &mut buf[..len]) {
                     Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                        self.conn().reclaim_one_dax_range_interruptible()?;
+                        if self.dax_host_invalidation_blocked() {
+                            self.dax_wait_host_invalidation_interruptible()?;
+                        } else {
+                            self.conn().reclaim_one_dax_range_interruptible()?;
+                        }
                     }
                     result => return result,
                 }
@@ -419,7 +423,11 @@ impl IndexNode for FuseNode {
                 match self.dax_write_or_fuse_locked(offset, &buf[..len], &private_data, lock_owner)
                 {
                     Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                        self.conn().reclaim_one_dax_range_interruptible()?;
+                        if self.dax_host_invalidation_blocked() {
+                            self.dax_wait_host_invalidation_interruptible()?;
+                        } else {
+                            self.conn().reclaim_one_dax_range_interruptible()?;
+                        }
                     }
                     result => return result,
                 }
@@ -568,8 +576,12 @@ impl IndexNode for FuseNode {
         if writeback_cache {
             self.sync_dirty_cached_pages()?;
         }
-        let _barrier = if self.conn().dax_enabled() && metadata.size < old.size {
-            Some(self.dax_layout_write_for_truncate(metadata.size.max(0) as usize)?)
+        let _barrier = if self.conn().dax_enabled() && metadata.size != old.size {
+            Some(if metadata.size < old.size {
+                self.dax_layout_write_for_truncate(metadata.size.max(0) as usize)?
+            } else {
+                self.dax_layout_write()
+            })
         } else {
             writeback_cache.then(|| self.writeback_barrier.write())
         };
@@ -710,7 +722,14 @@ impl IndexNode for FuseNode {
         _lock_owner: u64,
         data: MutexGuard<FilePrivateData>,
     ) -> Result<(), SystemError> {
-        if mode != 0 {
+        const FALLOC_FL_KEEP_SIZE: u32 = 0x01;
+        const FALLOC_FL_PUNCH_HOLE: u32 = 0x02;
+        const FALLOC_FL_ZERO_RANGE: u32 = 0x10;
+        const FUSE_FALLOC_SUPPORTED: u32 =
+            FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE | FALLOC_FL_ZERO_RANGE;
+
+        let mode_bits = mode as u32;
+        if mode < 0 || mode_bits & !FUSE_FALLOC_SUPPORTED != 0 {
             return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
         }
         self.check_not_stale()?;
@@ -726,10 +745,25 @@ impl IndexNode for FuseNode {
         drop(data);
 
         let md = self.metadata()?;
-        if new_size > md.size.max(0) as usize {
+        let old_size = md.size.max(0) as usize;
+        let keep_size = mode_bits & FALLOC_FL_KEEP_SIZE != 0;
+        let changes_contents = mode_bits & (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_ZERO_RANGE) != 0;
+        if !keep_size && new_size > old_size {
             crate::filesystem::vfs::vcore::check_file_size_limit(new_size)?;
         }
-        let _barrier = self.writeback_barrier.write();
+        if changes_contents {
+            self.sync_dirty_cached_pages()?;
+        }
+        let block_faults = self.conn().dax_enabled() && (!keep_size || changes_contents);
+        let _barrier = if block_faults {
+            self.dax_layout_write_for_all()?
+        } else {
+            self.writeback_barrier.write()
+        };
+        if changes_contents {
+            // Close dirty admission between the first drain and exclusivity.
+            self.sync_dirty_cached_pages()?;
+        }
 
         let in_arg = FuseFallocateIn {
             fh: fuse_data.fh,
@@ -743,9 +777,12 @@ impl IndexNode for FuseNode {
             .request(FUSE_FALLOCATE, self.nodeid, fuse_pack_struct(&in_arg))
         {
             Ok(_) => {
+                if changes_contents {
+                    self.invalidate_page_cache_range(offset, len)?;
+                }
                 let mut metadata = self.cached_metadata.lock();
                 if let Some(md) = metadata.as_mut() {
-                    if new_size > md.size.max(0) as usize {
+                    if !keep_size && new_size > md.size.max(0) as usize {
                         md.size = new_size as i64;
                     }
                     let now = crate::time::PosixTimeSpec::now();

--- a/kernel/src/filesystem/fuse/virtiofs/mount.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/mount.rs
@@ -91,7 +91,21 @@ impl VirtioFsFs {
         let access = match node.dax_access(file_offset as u64, write && shared) {
             Ok(access) => access,
             Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                pfm.set_retry_wait(node.conn().dax_fault_retry_wait());
+                pfm.set_retry_wait(if node.dax_host_invalidation_blocked() {
+                    node.dax_host_invalidation_retry_wait()
+                } else {
+                    node.conn().dax_fault_retry_wait()
+                });
+                return Some(VmFaultReason::VM_FAULT_RETRY);
+            }
+            Err(_) => return Some(VmFaultReason::VM_FAULT_SIGBUS),
+        };
+        let _host_access = match node.dax_try_host_access() {
+            Ok(guard) => guard,
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
+                drop(access);
+                drop(_layout);
+                pfm.set_retry_wait(node.dax_host_invalidation_retry_wait());
                 return Some(VmFaultReason::VM_FAULT_RETRY);
             }
             Err(_) => return Some(VmFaultReason::VM_FAULT_SIGBUS),

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -2543,6 +2543,7 @@ fail_no_umount:
 static int ext_test_ftruncate_setattr_uses_open_fh() {
     const char *mp = "/tmp/test_fuse_ftruncate_fh";
     int f = -1;
+    char fallocate_verify[17] = {};
     if (ensure_dir(mp) != 0) {
         printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
         return -1;
@@ -2732,6 +2733,70 @@ static int ext_test_ftruncate_setattr_uses_open_fh() {
                strerror(errno), (long long)st.st_size);
         goto fail;
     }
+
+    static const char fallocate_pattern[] = "abcdefghijklmnop";
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] reopen for fallocate modes: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (pwrite(f, fallocate_pattern, sizeof(fallocate_pattern) - 1, 0) !=
+        (ssize_t)(sizeof(fallocate_pattern) - 1)) {
+        printf("[FAIL] seed fallocate cache test: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (pread(f, fallocate_verify, sizeof(fallocate_pattern) - 1, 0) !=
+        (ssize_t)(sizeof(fallocate_pattern) - 1)) {
+        printf("[FAIL] prime fallocate cache: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    fallocate_count = 0;
+    if (syscall(SYS_fallocate, f, FALLOC_FL_KEEP_SIZE, 0, 64) != 0) {
+        printf("[FAIL] fallocate KEEP_SIZE: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (stat(path, &st) != 0 || st.st_size != 16 || fallocate_count != 1 ||
+        last_fallocate_mode != FALLOC_FL_KEEP_SIZE) {
+        printf("[FAIL] KEEP_SIZE semantics size=%lld count=%u mode=0x%x\n",
+               (long long)st.st_size, fallocate_count, last_fallocate_mode);
+        goto fail;
+    }
+
+    fallocate_count = 0;
+    if (syscall(SYS_fallocate, f, FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE, 4, 4) != 0) {
+        printf("[FAIL] fallocate ZERO_RANGE: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    memset(fallocate_verify, 0xff, sizeof(fallocate_verify));
+    if (pread(f, fallocate_verify, sizeof(fallocate_pattern) - 1, 0) !=
+        (ssize_t)(sizeof(fallocate_pattern) - 1) ||
+        memcmp(fallocate_verify, "abcd\0\0\0\0ijklmnop", sizeof(fallocate_pattern) - 1) != 0 ||
+        fallocate_count != 1 ||
+        last_fallocate_mode != (FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE)) {
+        printf("[FAIL] ZERO_RANGE cache/forwarding count=%u mode=0x%x\n", fallocate_count,
+               last_fallocate_mode);
+        goto fail;
+    }
+
+    fallocate_count = 0;
+    if (syscall(SYS_fallocate, f, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 8, 4) != 0) {
+        printf("[FAIL] fallocate PUNCH_HOLE: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    memset(fallocate_verify, 0xff, sizeof(fallocate_verify));
+    if (pread(f, fallocate_verify, sizeof(fallocate_pattern) - 1, 0) !=
+        (ssize_t)(sizeof(fallocate_pattern) - 1) ||
+        memcmp(fallocate_verify, "abcd\0\0\0\0\0\0\0\0mnop", sizeof(fallocate_pattern) - 1) !=
+            0 ||
+        fallocate_count != 1 ||
+        last_fallocate_mode != (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE)) {
+        printf("[FAIL] PUNCH_HOLE cache/forwarding count=%u mode=0x%x\n", fallocate_count,
+               last_fallocate_mode);
+        goto fail;
+    }
+    close(f);
+    f = -1;
 
     setattr_count = 0;
     fallocate_count = 0;

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -2011,14 +2011,22 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (!node || simplefs_node_is_dir(node) || simplefs_node_is_symlink(node)) {
             return fuse_write_reply(a->fd, h->unique, -EINVAL, NULL, 0);
         }
-        if (in->mode != 0) {
+        const uint32_t supported = FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE | FALLOC_FL_ZERO_RANGE;
+        if ((in->mode & ~supported) != 0 ||
+            ((in->mode & FALLOC_FL_PUNCH_HOLE) != 0 &&
+             (in->mode & FALLOC_FL_KEEP_SIZE) == 0) ||
+            ((in->mode & FALLOC_FL_PUNCH_HOLE) != 0 &&
+             (in->mode & FALLOC_FL_ZERO_RANGE) != 0)) {
             return fuse_write_reply(a->fd, h->unique, -EOPNOTSUPP, NULL, 0);
         }
         if (in->offset > SIMPLEFS_DATA_MAX || in->length > SIMPLEFS_DATA_MAX ||
             in->offset + in->length > SIMPLEFS_DATA_MAX) {
             return fuse_write_reply(a->fd, h->unique, -EFBIG, NULL, 0);
         }
-        if (node->size < in->offset + in->length) {
+        if ((in->mode & (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_ZERO_RANGE)) != 0) {
+            memset(node->data + in->offset, 0, in->length);
+        }
+        if ((in->mode & FALLOC_FL_KEEP_SIZE) == 0 && node->size < in->offset + in->length) {
             node->size = (size_t)(in->offset + in->length);
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);

--- a/user/apps/tests/dunitest/suites/normal/virtiofs_dax.cc
+++ b/user/apps/tests/dunitest/suites/normal/virtiofs_dax.cc
@@ -220,6 +220,17 @@ struct CleanupGuard {
     }
 };
 
+struct ExtraMountGuard {
+    const char* mountpoint;
+    bool mounted = false;
+
+    ~ExtraMountGuard() {
+        if (mounted) {
+            umount(mountpoint);
+        }
+    }
+};
+
 bool mount_virtiofs(const char* mountpoint, const char* dax_mode, int* error) {
     char options[64] = {};
     snprintf(options, sizeof(options), "dax=%s", dax_mode);
@@ -493,6 +504,313 @@ TEST(VirtioFsDax, IoMmapPermissionsEofAndTeardown) {
     ASSERT_EQ(0, close(fd));
     ASSERT_EQ(0, unlink(paths.file));
     ASSERT_EQ(0, umount(paths.mountpoint));
+    paths.cleanup();
+}
+
+TEST(VirtioFsDax, LayoutBreakingForTruncateFallocateAndAtomicOpen) {
+    TestPaths paths("layout");
+    ASSERT_TRUE(paths.create());
+    CleanupGuard cleanup{paths};
+
+    int error = 0;
+    constexpr off_t initial_size = 3 * kDaxRangeSize;
+    if (!prepare_non_dax_file(paths, initial_size, &error)) {
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX layout test preparation failed: " << strerror(error);
+        }
+        GTEST_SKIP() << "ordinary virtiofs is unavailable: " << strerror(error);
+    }
+    ASSERT_TRUE(mount_debugfs(paths, &error)) << strerror(error);
+    if (!mount_virtiofs(paths.mountpoint, "always", &error)) {
+        remove_non_dax_file(paths);
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX layout test requires dax=always: " << strerror(error);
+        }
+        GTEST_SKIP() << "DAX window/backend is unavailable: " << strerror(error);
+    }
+
+    int fd = open(paths.file, O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    void* inherited = mmap(nullptr, kPageSize, PROT_READ, MAP_SHARED, fd, kDaxRangeSize);
+    ASSERT_NE(MAP_FAILED, inherited) << strerror(errno);
+    EXPECT_EQ(pattern_byte(kDaxRangeSize), static_cast<uint8_t*>(inherited)[0]);
+
+    int ready[2] = {-1, -1};
+    int proceed[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(ready));
+    ASSERT_EQ(0, pipe(proceed));
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(ready[0]);
+        close(proceed[1]);
+        char byte = 'r';
+        if (write(ready[1], &byte, 1) != 1 || read(proceed[0], &byte, 1) != 1) {
+            _exit(101);
+        }
+        volatile uint8_t value = static_cast<volatile uint8_t*>(inherited)[0];
+        (void)value;
+        _exit(102);
+    }
+    close(ready[1]);
+    close(proceed[0]);
+    char byte = 0;
+    ASSERT_EQ(1, read(ready[0], &byte, 1));
+    OpcodeSnapshot before = snapshot(paths.stats);
+    ASSERT_EQ(0, ftruncate(fd, kPageSize)) << strerror(errno);
+    OpcodeSnapshot after = snapshot(paths.stats);
+    assert_valid_snapshot(before);
+    assert_valid_snapshot(after);
+    EXPECT_GT(after.remove_mapping, before.remove_mapping);
+    ASSERT_EQ(1, write(proceed[1], "x", 1));
+    close(ready[0]);
+    close(proceed[1]);
+    int status = 0;
+    ASSERT_TRUE(wait_for_child(child, &status)) << "inherited DAX PTE survived truncate timeout";
+    ASSERT_TRUE(WIFSIGNALED(status)) << "child status=" << status;
+    EXPECT_EQ(SIGBUS, WTERMSIG(status));
+    ASSERT_EQ(0, munmap(inherited, kPageSize));
+
+    ASSERT_EQ(0, ftruncate(fd, initial_size));
+    std::vector<uint8_t> nonzero(kPageSize, 0x5a);
+    ASSERT_EQ(static_cast<ssize_t>(nonzero.size()),
+              pwrite(fd, nonzero.data(), nonzero.size(), kDaxRangeSize));
+    inherited = mmap(nullptr, kPageSize, PROT_READ, MAP_SHARED, fd, kDaxRangeSize);
+    ASSERT_NE(MAP_FAILED, inherited);
+    EXPECT_EQ(0x5a, static_cast<uint8_t*>(inherited)[17]);
+    before = snapshot(paths.stats);
+    ASSERT_EQ(0, fallocate(fd, FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE, kDaxRangeSize,
+                           kPageSize))
+        << strerror(errno);
+    after = snapshot(paths.stats);
+    EXPECT_GT(after.remove_mapping, before.remove_mapping);
+    EXPECT_EQ(0, static_cast<uint8_t*>(inherited)[17]);
+    ASSERT_EQ(0, munmap(inherited, kPageSize));
+
+    ASSERT_EQ(static_cast<ssize_t>(nonzero.size()),
+              pwrite(fd, nonzero.data(), nonzero.size(), kDaxRangeSize));
+    inherited = mmap(nullptr, kPageSize, PROT_READ, MAP_SHARED, fd, kDaxRangeSize);
+    ASSERT_NE(MAP_FAILED, inherited);
+    EXPECT_EQ(0x5a, static_cast<uint8_t*>(inherited)[23]);
+    before = snapshot(paths.stats);
+    ASSERT_EQ(0, fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, kDaxRangeSize,
+                           kPageSize))
+        << strerror(errno);
+    after = snapshot(paths.stats);
+    EXPECT_GT(after.remove_mapping, before.remove_mapping);
+    EXPECT_EQ(0, static_cast<uint8_t*>(inherited)[23]);
+    ASSERT_EQ(0, munmap(inherited, kPageSize));
+
+    uint8_t mapped = 0;
+    ASSERT_EQ(1, pread(fd, &mapped, 1, 2 * kDaxRangeSize + 19));
+    before = snapshot(paths.stats);
+    int trunc_fd = open(paths.file, O_RDWR | O_TRUNC);
+    ASSERT_GE(trunc_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, close(trunc_fd));
+    after = snapshot(paths.stats);
+    EXPECT_GT(after.remove_mapping, before.remove_mapping);
+    struct stat st = {};
+    ASSERT_EQ(0, fstat(fd, &st));
+    EXPECT_EQ(0, st.st_size);
+
+    ASSERT_EQ(0, close(fd));
+    ASSERT_EQ(0, umount(paths.mountpoint));
+    remove_non_dax_file(paths);
+    paths.cleanup();
+}
+
+TEST(VirtioFsDax, ConcurrentFaultIoAndLayoutBreakingStress) {
+    TestPaths paths("layout_stress");
+    ASSERT_TRUE(paths.create());
+    CleanupGuard cleanup{paths};
+
+    int error = 0;
+    constexpr off_t initial_size = 3 * kDaxRangeSize;
+    if (!prepare_non_dax_file(paths, initial_size, &error)) {
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX layout stress preparation failed: " << strerror(error);
+        }
+        GTEST_SKIP() << "ordinary virtiofs is unavailable: " << strerror(error);
+    }
+    ASSERT_TRUE(mount_debugfs(paths, &error)) << strerror(error);
+    if (!mount_virtiofs(paths.mountpoint, "always", &error)) {
+        remove_non_dax_file(paths);
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "DAX layout stress requires dax=always: " << strerror(error);
+        }
+        GTEST_SKIP() << "DAX window/backend is unavailable: " << strerror(error);
+    }
+
+    int fd = open(paths.file, O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    struct SharedStressState {
+        unsigned start;
+        unsigned stop;
+        unsigned iterations;
+    };
+    auto* state = static_cast<SharedStressState*>(mmap(
+        nullptr, sizeof(SharedStressState), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(MAP_FAILED, state);
+    memset(state, 0, sizeof(*state));
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(ready));
+    OpcodeSnapshot before = snapshot(paths.stats);
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(ready[0]);
+        int child_fd = open(paths.file, O_RDWR);
+        if (child_fd < 0 || write(ready[1], "r", 1) != 1) {
+            _exit(101);
+        }
+        close(ready[1]);
+        while (__atomic_load_n(&state->start, __ATOMIC_ACQUIRE) == 0) {
+            usleep(1000);
+        }
+        for (unsigned i = 0; i < 100000; ++i) {
+            void* mapping = mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, child_fd, 0);
+            if (mapping == MAP_FAILED) {
+                _exit(102);
+            }
+            volatile uint8_t* bytes = static_cast<volatile uint8_t*>(mapping);
+            size_t index = i % kPageSize;
+            uint8_t value = bytes[index];
+            bytes[index] = static_cast<uint8_t>(value ^ 1);
+            if (munmap(mapping, kPageSize) != 0) {
+                _exit(103);
+            }
+            if (pread(child_fd, &value, 1, static_cast<off_t>(index)) != 1 ||
+                pwrite(child_fd, &value, 1, static_cast<off_t>(index)) != 1) {
+                _exit(104);
+            }
+            __atomic_store_n(&state->iterations, i + 1, __ATOMIC_RELEASE);
+            if (__atomic_load_n(&state->stop, __ATOMIC_ACQUIRE) != 0) {
+                _exit(close(child_fd) == 0 ? 0 : 105);
+            }
+        }
+        _exit(106);
+    }
+    close(ready[1]);
+    char byte = 0;
+    ASSERT_EQ(1, read(ready[0], &byte, 1));
+    close(ready[0]);
+    __atomic_store_n(&state->start, 1, __ATOMIC_RELEASE);
+    bool child_active = false;
+    for (unsigned i = 0; i < kWaitIterations; ++i) {
+        if (__atomic_load_n(&state->iterations, __ATOMIC_ACQUIRE) != 0) {
+            child_active = true;
+            break;
+        }
+        usleep(10000);
+    }
+
+    int operation_error = child_active ? 0 : ETIMEDOUT;
+    for (unsigned i = 0; i < 64; ++i) {
+        if (operation_error != 0 || ftruncate(fd, kPageSize) != 0 ||
+            ftruncate(fd, initial_size) != 0 ||
+            fallocate(fd, FALLOC_FL_ZERO_RANGE | FALLOC_FL_KEEP_SIZE, 0, kPageSize) != 0 ||
+            fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, kPageSize / 2,
+                      kPageSize / 2) != 0) {
+            operation_error = operation_error == 0 ? errno : operation_error;
+            break;
+        }
+    }
+
+    __atomic_store_n(&state->stop, 1, __ATOMIC_RELEASE);
+    int status = 0;
+    ASSERT_TRUE(wait_for_child(child, &status)) << "concurrent layout stress timed out";
+    ASSERT_EQ(0, operation_error) << strerror(operation_error);
+    ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    EXPECT_GT(__atomic_load_n(&state->iterations, __ATOMIC_ACQUIRE), 0U);
+    OpcodeSnapshot after = snapshot(paths.stats);
+    assert_valid_snapshot(before);
+    assert_valid_snapshot(after);
+    EXPECT_GT(after.remove_mapping, before.remove_mapping);
+    struct stat st = {};
+    ASSERT_EQ(0, fstat(fd, &st));
+    EXPECT_EQ(initial_size, st.st_size);
+
+    ASSERT_EQ(0, munmap(state, sizeof(*state)));
+    ASSERT_EQ(0, close(fd));
+    ASSERT_EQ(0, umount(paths.mountpoint));
+    remove_non_dax_file(paths);
+    paths.cleanup();
+}
+
+TEST(VirtioFsDax, HostInvalidationRevokesMappedWindow) {
+    TestPaths paths("notify");
+    ASSERT_TRUE(paths.create());
+    CleanupGuard cleanup{paths};
+    char ordinary_mount[224] = {};
+    char ordinary_file[288] = {};
+    snprintf(ordinary_mount, sizeof(ordinary_mount), "%s/ordinary", paths.root);
+    snprintf(ordinary_file, sizeof(ordinary_file), "%s/dax_test.bin", ordinary_mount);
+    ASSERT_EQ(0, ensure_dir(ordinary_mount));
+    ExtraMountGuard ordinary_cleanup{ordinary_mount};
+
+    int error = 0;
+    if (!prepare_non_dax_file(paths, 2 * kDaxRangeSize, &error)) {
+        rmdir(ordinary_mount);
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "host invalidation preparation failed: " << strerror(error);
+        }
+        GTEST_SKIP() << "ordinary virtiofs is unavailable: " << strerror(error);
+    }
+    ASSERT_TRUE(mount_debugfs(paths, &error)) << strerror(error);
+    if (!mount_virtiofs(paths.mountpoint, "always", &error)) {
+        remove_non_dax_file(paths);
+        rmdir(ordinary_mount);
+        paths.cleanup();
+        if (dax_required()) {
+            FAIL() << "host invalidation requires dax=always: " << strerror(error);
+        }
+        GTEST_SKIP() << "DAX window/backend is unavailable: " << strerror(error);
+    }
+    ASSERT_TRUE(mount_virtiofs(ordinary_mount, "never", &error)) << strerror(error);
+    ordinary_cleanup.mounted = true;
+
+    int dax_fd = open(paths.file, O_RDONLY);
+    ASSERT_GE(dax_fd, 0);
+    void* mapping = mmap(nullptr, kPageSize, PROT_READ, MAP_SHARED, dax_fd, 0);
+    ASSERT_NE(MAP_FAILED, mapping);
+    volatile uint8_t* mapped = static_cast<volatile uint8_t*>(mapping);
+    uint8_t original = mapped[37];
+    uint8_t replacement = static_cast<uint8_t>(original ^ 0x5a);
+    OpcodeSnapshot before = snapshot(paths.stats);
+
+    int ordinary_fd = open(ordinary_file, O_RDWR);
+    ASSERT_GE(ordinary_fd, 0) << strerror(errno);
+    ASSERT_EQ(1, pwrite(ordinary_fd, &replacement, 1, 37));
+    ASSERT_EQ(0, fsync(ordinary_fd));
+    ASSERT_EQ(0, close(ordinary_fd));
+
+    bool observed = false;
+    for (unsigned i = 0; i < kWaitIterations; ++i) {
+        if (mapped[37] == replacement) {
+            observed = true;
+            break;
+        }
+        usleep(100000);
+    }
+    EXPECT_TRUE(observed) << "host invalidation left stale DAX data";
+    OpcodeSnapshot after = snapshot(paths.stats);
+    assert_valid_snapshot(before);
+    assert_valid_snapshot(after);
+    EXPECT_GT(after.remove_mapping, before.remove_mapping);
+
+    ASSERT_EQ(0, munmap(mapping, kPageSize));
+    ASSERT_EQ(0, close(dax_fd));
+    ASSERT_EQ(0, umount(ordinary_mount));
+    ordinary_cleanup.mounted = false;
+    ASSERT_EQ(0, umount(paths.mountpoint));
+    remove_non_dax_file(paths);
+    rmdir(ordinary_mount);
     paths.cleanup();
 }
 


### PR DESCRIPTION
## Summary

- serialize complete DAX two-zap/tombstone/REMOVEMAPPING transactions so concurrent layout changes cannot pass a half-finished reclaim
- revoke DAX layouts for truncate, atomic `O_TRUNC`, size-changing/content-changing fallocate, and host invalidation while preserving grow mapping reuse
- gate cache-window access and PTE publication during host invalidation without waiting on pending FUSE requests
- support Linux FUSE `KEEP_SIZE`, `PUNCH_HOLE`, and `ZERO_RANGE` ordering and invalidate only the affected page-cache range
- add fake-daemon semantic coverage and DAX layout, notification, EOF, reclaim-pressure, and concurrent fault/I/O stress tests

## Linux 6.6 semantics

The locking and writeback order follows Linux 6.6 FUSE DAX behavior: layout breaking is serialized with file changes, dirty data is drained before destructive range operations, host reverse invalidation launders only the notified range, and a cache-window range is not reusable until `REMOVEMAPPING` succeeds. Revocation failures fail closed instead of restoring a mapping whose host validity cannot be proven.

## Testing

- `cargo fmt --manifest-path kernel/Cargo.toml --all -- --check`
- `make kernel`
- `make bin/normal/virtiofs_dax_test bin/fuse/fuse_extended_test`
- QEMU guest: `fuse_extended_test` — 57/57 passed
- QEMU guest: `virtiofs_dax_test` — 5 tests discovered; skipped because the default runner exposes no virtiofs device (`ENODEV`)

Closes #2081
