### PR TITLE
fix(virtiofs): complete DAX teardown and mount modes

### DIFF
--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -1018,13 +1018,10 @@ impl FuseConn {
                 continue;
             }
 
-            wait_with_recheck(&self.dax_cleanup_wait, || {
+            self.dax_cleanup_wait.wait_until(|| {
                 let cleanup = self.dax_cleanup.lock();
-                if cleanup.nodes.is_empty() {
-                    return Ok(Some(()));
-                }
-                Ok(None)
-            })?;
+                cleanup.nodes.is_empty().then_some(())
+            });
             let cleanup = self.dax_cleanup.lock();
             if cleanup.nodes.is_empty() {
                 return if cleanup.revoke_failed {
@@ -1402,10 +1399,10 @@ impl FuseConn {
                 }
             };
             debug_assert_eq!(state, DaxCleanupState::InProgress);
-            wait_with_recheck(&self.dax_cleanup_wait, || {
+            self.dax_cleanup_wait.wait_until(|| {
                 let state = self.dax_cleanup.lock().state;
-                Ok((state != DaxCleanupState::InProgress).then_some(()))
-            })?;
+                (state != DaxCleanupState::InProgress).then_some(())
+            });
         }
     }
 

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -678,6 +678,21 @@ struct FuseConnInner {
     processing: BTreeMap<u64, Arc<FusePendingState>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DaxCleanupState {
+    Active,
+    InProgress,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug)]
+struct DaxCleanup {
+    state: DaxCleanupState,
+    nodes: BTreeMap<DaxMappingOwner, Weak<super::inode::FuseNode>>,
+    revoke_failed: bool,
+}
+
 /// FUSE connection object (roughly equivalent to Linux `struct fuse_conn`).
 #[derive(Debug)]
 pub struct FuseConn {
@@ -693,10 +708,12 @@ pub struct FuseConn {
     reply_layout_minor: AtomicU32,
     background: Arc<FuseBackgroundState>,
     filesystems: Mutex<Vec<Weak<super::fs::FuseFS>>>,
+    dax_mode: DaxMountMode,
     dax_allocator: Option<Arc<DaxRangeAllocator>>,
     dax_window: Mutex<Option<Arc<VirtioFsCacheWindow>>>,
     dax_admission: Arc<DaxAdmission>,
-    dax_nodes: Mutex<BTreeMap<DaxMappingOwner, Weak<super::inode::FuseNode>>>,
+    dax_cleanup: Mutex<DaxCleanup>,
+    dax_cleanup_wait: WaitQueue,
 }
 
 impl FuseConn {
@@ -722,6 +739,7 @@ impl FuseConn {
             false,
             None,
             None,
+            DaxMountMode::Never,
         )
     }
 
@@ -735,6 +753,21 @@ impl FuseConn {
         cache_window_len: Option<usize>,
         dax_mode: DaxMountMode,
     ) -> Arc<Self> {
+        Self::try_new_for_virtiofs_with_dax(
+            max_request_size,
+            max_reply_size,
+            cache_window_len,
+            dax_mode,
+        )
+        .expect("test DAX allocator construction must succeed")
+    }
+
+    pub(crate) fn try_new_for_virtiofs_with_dax(
+        max_request_size: usize,
+        max_reply_size: usize,
+        cache_window_len: Option<usize>,
+        dax_mode: DaxMountMode,
+    ) -> Result<Arc<Self>, SystemError> {
         let overhead = size_of::<FuseInHeader>() + size_of::<FuseWriteIn>();
         let cap = if max_request_size > overhead {
             core::cmp::max(Self::MIN_MAX_WRITE, max_request_size - overhead)
@@ -745,25 +778,24 @@ impl FuseConn {
             .then_some(cache_window_len)
             .flatten()
             .filter(|len| *len >= DAX_RANGE_SIZE)
-            .and_then(|len| match DaxRangeAllocator::new(len) {
-            Ok(allocator) => Some(Arc::new(allocator)),
-            Err(error) => {
-                log::warn!(
-                    "virtiofs: failed to create DAX range allocator for window length {}: {:?}; continue with DAX disabled",
-                    len,
-                    error
-                );
-                None
-            }
-        });
+            .map(DaxRangeAllocator::new)
+            .transpose()?
+            .map(Arc::new);
         let mut init_flags = Self::virtiofs_init_flags();
         if dax_allocator.is_some() {
             init_flags |= FUSE_MAP_ALIGNMENT;
         }
-        if dax_mode == DaxMountMode::Inode {
+        if dax_mode.is_inode_mode() {
             init_flags |= FUSE_HAS_INODE_DAX;
         }
-        Self::new_with_max_write_cap(cap, init_flags, true, Some(max_reply_size), dax_allocator)
+        Ok(Self::new_with_max_write_cap(
+            cap,
+            init_flags,
+            true,
+            Some(max_reply_size),
+            dax_allocator,
+            dax_mode,
+        ))
     }
 
     fn new_with_max_write_cap(
@@ -772,6 +804,7 @@ impl FuseConn {
         separate_hiprio_pending: bool,
         backend_reply_limit: Option<usize>,
         dax_allocator: Option<Arc<DaxRangeAllocator>>,
+        dax_mode: DaxMountMode,
     ) -> Arc<Self> {
         Arc::new(Self {
             inner: Mutex::new(FuseConnInner {
@@ -816,10 +849,16 @@ impl FuseConn {
             reply_layout_minor: AtomicU32::new(0),
             background: FuseBackgroundState::new(),
             filesystems: Mutex::new(Vec::new()),
+            dax_mode,
             dax_allocator,
             dax_window: Mutex::new(None),
             dax_admission: DaxAdmission::new(),
-            dax_nodes: Mutex::new(BTreeMap::new()),
+            dax_cleanup: Mutex::new(DaxCleanup {
+                state: DaxCleanupState::Active,
+                nodes: BTreeMap::new(),
+                revoke_failed: false,
+            }),
+            dax_cleanup_wait: WaitQueue::default(),
         })
     }
 
@@ -828,16 +867,37 @@ impl FuseConn {
         max_reply_size: usize,
         cache_window: Option<Arc<VirtioFsCacheWindow>>,
         dax_mode: DaxMountMode,
-    ) -> Arc<Self> {
+    ) -> Result<Arc<Self>, SystemError> {
         let len = cache_window.as_ref().map(|window| window.len());
-        let conn = Self::new_for_virtiofs_with_dax(max_request_size, max_reply_size, len, dax_mode);
+        let conn =
+            Self::try_new_for_virtiofs_with_dax(max_request_size, max_reply_size, len, dax_mode)?;
         if conn.dax_allocator.is_some() {
             if let Some(window) = cache_window {
                 conn.install_dax_window(window)
                     .expect("validated virtiofs DAX window must match its allocator");
             }
         }
-        conn
+        Ok(conn)
+    }
+
+    pub(crate) fn dax_mode(&self) -> DaxMountMode {
+        self.dax_mode
+    }
+
+    pub(crate) fn dax_inode_active(&self, attr_flags: u32, regular: bool) -> bool {
+        if !regular || self.dax_mode == DaxMountMode::Never {
+            return false;
+        }
+        let connection_capable = self.dax_enabled();
+        let inode_capability_negotiated = connection_capable
+            && self.dax_mode.is_inode_mode()
+            && self.has_init_flag(FUSE_HAS_INODE_DAX);
+        self.dax_mode.inode_enabled(
+            connection_capable,
+            inode_capability_negotiated,
+            (attr_flags & super::protocol::FUSE_ATTR_DAX) != 0,
+            true,
+        )
     }
 
     pub(crate) fn dax_allocator(&self) -> Option<&Arc<DaxRangeAllocator>> {
@@ -898,38 +958,80 @@ impl FuseConn {
 
     pub(crate) fn register_dax_node(&self, node: &Arc<super::inode::FuseNode>) {
         let owner = node.dax_mapping_owner();
-        let mut nodes = self.dax_nodes.lock();
-        nodes.retain(|_, node| node.strong_count() != 0);
-        nodes.insert(owner, Arc::downgrade(node));
+        let mut cleanup = self.dax_cleanup.lock();
+        if cleanup.state == DaxCleanupState::Active {
+            cleanup.nodes.insert(owner, Arc::downgrade(node));
+        }
     }
 
     pub(crate) fn unregister_dax_node(&self, owner: DaxMappingOwner) {
-        self.dax_nodes.lock().remove(&owner);
+        self.dax_cleanup.lock().nodes.remove(&owner);
+        self.dax_cleanup_wait.wakeup_all(None);
+    }
+
+    pub(crate) fn finish_dax_node_drop(
+        &self,
+        owner: DaxMappingOwner,
+        revoke: Result<(), SystemError>,
+    ) {
+        let mut cleanup = self.dax_cleanup.lock();
+        if revoke.is_err()
+            && matches!(
+                cleanup.state,
+                DaxCleanupState::Active | DaxCleanupState::InProgress
+            )
+        {
+            cleanup.revoke_failed = true;
+        }
+        cleanup.nodes.remove(&owner);
+        drop(cleanup);
+        self.dax_cleanup_wait.wakeup_all(None);
     }
 
     pub(crate) fn dax_node(&self, owner: DaxMappingOwner) -> Option<Arc<super::inode::FuseNode>> {
-        let mut nodes = self.dax_nodes.lock();
-        let node = nodes.get(&owner).and_then(Weak::upgrade);
-        if node.is_none() {
-            nodes.remove(&owner);
-        }
-        node
+        self.dax_cleanup
+            .lock()
+            .nodes
+            .get(&owner)
+            .and_then(Weak::upgrade)
     }
 
-    fn revoke_all_dax_ptes(&self) {
-        let nodes: Vec<_> = {
-            let mut registry = self.dax_nodes.lock();
-            let nodes = registry.values().filter_map(Weak::upgrade).collect();
-            registry.retain(|_, node| node.strong_count() != 0);
-            nodes
-        };
-        for node in nodes {
-            if let Err(error) = node.dax_disconnect_revoke() {
-                log::warn!(
-                    "fuse: failed to revoke DAX PTEs for node {} during disconnect: {:?}",
-                    node.nodeid(),
-                    error
-                );
+    fn revoke_registered_dax_nodes(&self) -> Result<(), SystemError> {
+        loop {
+            let node = {
+                let cleanup = self.dax_cleanup.lock();
+                cleanup
+                    .nodes
+                    .iter()
+                    .find_map(|(owner, node)| node.upgrade().map(|node| (*owner, node)))
+            };
+            if let Some((owner, node)) = node {
+                let result = node.dax_disconnect_revoke();
+                if let Err(ref error) = result {
+                    log::warn!(
+                        "fuse: failed to revoke DAX PTEs for node {} during disconnect: {:?}",
+                        node.nodeid(),
+                        error
+                    );
+                }
+                self.finish_dax_node_drop(owner, result);
+                continue;
+            }
+
+            wait_with_recheck(&self.dax_cleanup_wait, || {
+                let cleanup = self.dax_cleanup.lock();
+                if cleanup.nodes.is_empty() {
+                    return Ok(Some(()));
+                }
+                Ok(None)
+            })?;
+            let cleanup = self.dax_cleanup.lock();
+            if cleanup.nodes.is_empty() {
+                return if cleanup.revoke_failed {
+                    Err(SystemError::EIO)
+                } else {
+                    Ok(())
+                };
             }
         }
     }
@@ -1285,43 +1387,59 @@ impl FuseConn {
         })
     }
 
-    pub fn abort(&self) {
+    fn claim_dax_cleanup(&self) -> Result<bool, SystemError> {
+        loop {
+            let state = {
+                let mut cleanup = self.dax_cleanup.lock();
+                match cleanup.state {
+                    DaxCleanupState::Active => {
+                        cleanup.state = DaxCleanupState::InProgress;
+                        return Ok(true);
+                    }
+                    DaxCleanupState::Succeeded => return Ok(false),
+                    DaxCleanupState::Failed => return Err(SystemError::EIO),
+                    DaxCleanupState::InProgress => cleanup.state,
+                }
+            };
+            debug_assert_eq!(state, DaxCleanupState::InProgress);
+            wait_with_recheck(&self.dax_cleanup_wait, || {
+                let state = self.dax_cleanup.lock().state;
+                Ok((state != DaxCleanupState::InProgress).then_some(()))
+            })?;
+        }
+    }
+
+    fn disconnect_requests(&self) {
         self.begin_dax_quiesce();
         self.background.disconnect();
         let (processing, pending_noreply_count): (Vec<Arc<FusePendingState>>, usize) = {
             let mut g = self.inner.lock();
             if !g.connected {
-                return;
+                (Vec::new(), 0)
+            } else {
+                g.connected = false;
+                g.mounted = false;
+                // Close allocator acquisition before releasing the connection lock,
+                // so no observer can see a disconnected connection while DAX get()
+                // still accepts a new reference.
+                self.begin_shutdown_dax_allocator();
+                let pending_noreply_count = g
+                    .pending
+                    .iter()
+                    .chain(g.hiprio_pending.iter())
+                    .filter(|req| matches!(req.opcode, FUSE_FORGET | FUSE_INTERRUPT))
+                    .count();
+                g.hiprio_pending.clear();
+                g.pending.clear();
+                let processing = g.processing.values().cloned().collect();
+                g.processing.clear();
+                (processing, pending_noreply_count)
             }
-            g.connected = false;
-            g.mounted = false;
-            // Close allocator acquisition before releasing the connection lock,
-            // so no observer can see a disconnected connection while DAX get()
-            // still accepts a new reference.
-            self.begin_shutdown_dax_allocator();
-            let pending_noreply_count = g
-                .pending
-                .iter()
-                .chain(g.hiprio_pending.iter())
-                .filter(|req| matches!(req.opcode, FUSE_FORGET | FUSE_INTERRUPT))
-                .count();
-            g.hiprio_pending.clear();
-            g.pending.clear();
-            let processing = g.processing.values().cloned().collect();
-            g.processing.clear();
-            (processing, pending_noreply_count)
         };
         stats::on_fuse_requests_aborted(processing.len() + pending_noreply_count);
         for p in processing {
             p.complete_disconnected(SystemError::ENOTCONN);
         }
-        // Admission was closed before requests were detached.  Wait until every
-        // DAX copy/fault/setup that was already admitted has released its guard
-        // before invalidating allocator tokens and the backing window.
-        self.wait_dax_drained();
-        self.revoke_all_dax_ptes();
-        self.disconnect_cleanup_dax_allocator();
-        self.mark_dax_dead();
         self.read_wait.wakeup(None);
         self.wake_bridge(stats::VirtioFsBridgeWakeSource::Disconnect);
         self.init_wait.wakeup(None);
@@ -1329,6 +1447,50 @@ impl FuseConn {
             &self.epitems,
             EPollEventType::EPOLLERR | EPollEventType::EPOLLHUP,
         );
+    }
+
+    /// Disconnect the protocol and synchronously revoke every local DAX DMA
+    /// owner before a virtio transport reset may release its DMA resources.
+    pub(crate) fn abort_and_revoke_dax(&self) -> Result<(), SystemError> {
+        // Close admission before the cleanup-state lock rejects registrations.
+        // A node constructed before this point either registers while Active,
+        // or registers after InProgress but can no longer create a mapping.
+        self.begin_dax_quiesce();
+        self.begin_shutdown_dax_allocator();
+        if !self.claim_dax_cleanup()? {
+            return Ok(());
+        }
+
+        self.disconnect_requests();
+        // Pending SETUP/REMOVEMAPPING requests were completed above, so admitted
+        // callers can now drop their guards without depending on the daemon.
+        self.wait_dax_drained();
+        let revoke = self.revoke_registered_dax_nodes();
+        let result = {
+            let mut cleanup = self.dax_cleanup.lock();
+            let failed = revoke.is_err() || cleanup.revoke_failed || !cleanup.nodes.is_empty();
+            if failed {
+                cleanup.state = DaxCleanupState::Failed;
+                Err(SystemError::EIO)
+            } else {
+                self.disconnect_cleanup_dax_allocator();
+                self.dax_window.lock().take();
+                cleanup.state = DaxCleanupState::Succeeded;
+                Ok(())
+            }
+        };
+        self.mark_dax_dead();
+        self.dax_cleanup_wait.wakeup_all(None);
+        result
+    }
+
+    pub fn abort(&self) {
+        if let Err(error) = self.abort_and_revoke_dax() {
+            log::error!(
+                "fuse: disconnect DAX cleanup failed; transport resources must remain quarantined: {:?}",
+                error
+            );
+        }
     }
 
     /// Unmount path: fail in-flight requests and best-effort queue DESTROY.
@@ -1594,6 +1756,18 @@ mod tests {
         let flags = inode_without_window.inner.lock().init_flags;
         assert_eq!(flags & FUSE_MAP_ALIGNMENT, 0);
         assert_ne!(flags & FUSE_HAS_INODE_DAX, 0);
+    }
+
+    #[test]
+    fn empty_dax_cleanup_is_terminal_and_idempotent() {
+        let conn = FuseConn::new_for_virtiofs(8192, 8192);
+        assert_eq!(conn.abort_and_revoke_dax(), Ok(()));
+        assert_eq!(conn.dax_admission_state(), super::DaxAdmissionState::Dead);
+        assert_eq!(
+            conn.dax_cleanup.lock().state,
+            super::DaxCleanupState::Succeeded
+        );
+        assert_eq!(conn.abort_and_revoke_dax(), Ok(()));
     }
 
     #[test]

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -96,6 +96,21 @@ impl FuseFS {
         self.live_node(nodeid).map(|node| notify(&node))
     }
 
+    pub(crate) fn purge_lookup_aliases(&self, child: &Arc<FuseNode>) {
+        let mut parents = vec![self.root.clone()];
+        {
+            let nodes = self.nodes.lock();
+            parents.extend(nodes.values().filter_map(Weak::upgrade));
+        }
+        {
+            let retired = self.retired_nodes.lock();
+            parents.extend(retired.iter().filter_map(Weak::upgrade));
+        }
+        for parent in parents {
+            parent.purge_lookup_alias(child);
+        }
+    }
+
     fn should_retire_node(
         node: &Arc<FuseNode>,
         generation: Option<u64>,
@@ -212,7 +227,7 @@ impl FuseFS {
         parent: Option<Arc<FuseNode>>,
         cached: Option<Metadata>,
     ) -> Result<Arc<FuseNode>, SystemError> {
-        self.get_or_create_node_with_generation(nodeid, parent, cached, None, 0)
+        self.get_or_create_node_with_generation(nodeid, parent, cached, None, 0, 0)
     }
 
     pub fn get_or_create_node_with_generation(
@@ -222,6 +237,7 @@ impl FuseFS {
         cached: Option<Metadata>,
         generation: Option<u64>,
         lookup_refs: u64,
+        attr_flags: u32,
     ) -> Result<Arc<FuseNode>, SystemError> {
         if nodeid == self.root.nodeid() {
             if parent.is_some() || lookup_refs != 0 {
@@ -275,6 +291,7 @@ impl FuseFS {
                 parent_nodeid,
                 parent,
                 cached,
+                attr_flags,
             );
             if let Some(gen) = generation {
                 n.set_generation(gen);
@@ -296,6 +313,7 @@ impl FuseFS {
         cached: Option<Metadata>,
         generation: Option<u64>,
         lookup_refs: u64,
+        attr_flags: u32,
     ) -> Result<Arc<FuseNode>, SystemError> {
         if nodeid == self.root.nodeid() {
             if parent.is_some() || lookup_refs != 0 {
@@ -344,6 +362,7 @@ impl FuseFS {
                 parent_nodeid,
                 parent,
                 cached,
+                attr_flags,
             );
             if let Some(gen) = generation {
                 n.set_generation(gen);
@@ -364,6 +383,7 @@ impl FuseFS {
         root_parent: Arc<FuseNode>,
         root_nodeid: u64,
         root_md: Metadata,
+        attr_flags: u32,
     ) -> Arc<Self> {
         let conn = parent.conn.clone();
         let parent_nodeid = root_parent.nodeid();
@@ -375,6 +395,7 @@ impl FuseFS {
                 parent_nodeid,
                 Some(root_parent),
                 Some(root_md),
+                attr_flags,
             ),
             super_block: parent.super_block.clone(),
             conn,
@@ -504,7 +525,13 @@ pub fn fuse_try_automount_submount(
     }
 
     let parent_fs = fuse_node.fuse_fs().ok_or(SystemError::ENOENT)?;
-    let sub_fs = FuseFS::new_submount(&parent_fs, fuse_node.clone(), fuse_node.nodeid(), md);
+    let sub_fs = FuseFS::new_submount(
+        &parent_fs,
+        fuse_node.clone(),
+        fuse_node.nodeid(),
+        md,
+        attr_flags,
+    );
     let mount_path = match mount_path_override {
         Some(path) => path,
         None => {
@@ -611,6 +638,7 @@ impl MountableFileSystem for FuseFS {
                 FUSE_ROOT_ID,
                 None,
                 Some(root_md),
+                0,
             ),
             super_block,
             conn: conn.clone(),

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -43,8 +43,8 @@ use super::{
 use super::{
     private_data::FuseOpenPrivateData,
     virtiofs::dax::{
-        DaxAdmissionGuard, DaxMappingOwner, DaxRangeAllocator, OwnedToken, ReclaimCandidate,
-        ReclaimToken, DAX_RANGE_SIZE,
+        DaxAdmissionGuard, DaxAdmissionState, DaxMappingOwner, DaxRangeAllocator, OwnedToken,
+        ReclaimCandidate, ReclaimToken, DAX_RANGE_SIZE,
     },
 };
 
@@ -300,6 +300,10 @@ pub struct FuseNode {
     lookup_count: AtomicU64,
     /// 最近一次 LOOKUP 回复中的 fuse_attr.flags（用于 announce-submounts）。
     lookup_attr_flags: AtomicU32,
+    /// Fixed for this FuseNode incarnation, matching Linux inode S_DAX.
+    dax_active: bool,
+    /// Linux d_mark_dontcache equivalent for a per-inode DAX attribute change.
+    dax_dontcache: AtomicBool,
     /// LOOKUP 返回的 generation，用于检测 virtiofsd 复用 nodeid。
     generation: AtomicU64,
     stale: AtomicBool,
@@ -325,8 +329,20 @@ impl FuseNode {
         nodeid: u64,
         parent_nodeid: u64,
         parent: Option<Arc<FuseNode>>,
-        cached: Option<Metadata>,
+        mut cached: Option<Metadata>,
+        attr_flags: u32,
     ) -> Arc<Self> {
+        let regular = cached
+            .as_ref()
+            .is_some_and(|md| md.file_type == FileType::File);
+        let dax_active = conn.dax_inode_active(attr_flags, regular);
+        if let Some(md) = cached.as_mut() {
+            if dax_active {
+                md.flags.insert(InodeFlags::S_DAX);
+            } else {
+                md.flags.remove(InodeFlags::S_DAX);
+            }
+        }
         let has_cached = cached.is_some();
         let initial_attr_epoch = conn.sample_attr_epoch();
         let dax_owner_incarnation = NEXT_DAX_OWNER_INCARNATION.fetch_add(1, Ordering::Relaxed);
@@ -359,10 +375,14 @@ impl FuseNode {
             pending_short_read_eof: AtomicU64::new(u64::MAX),
             lookup_count: AtomicU64::new(0),
             lookup_attr_flags: AtomicU32::new(0),
+            dax_active,
+            dax_dontcache: AtomicBool::new(false),
             generation: AtomicU64::new(0),
             stale: AtomicBool::new(false),
         });
-        node.conn.register_dax_node(&node);
+        if node.dax_active {
+            node.conn.register_dax_node(&node);
+        }
         node
     }
 
@@ -377,6 +397,46 @@ impl FuseNode {
     pub(crate) fn dax_mapping_owner(&self) -> super::virtiofs::dax::DaxMappingOwner {
         super::virtiofs::dax::DaxMappingOwner::from_inode(self.nodeid, self.dax_owner_incarnation)
             .expect("FuseNode has a valid DAX owner identity")
+    }
+
+    pub(crate) fn dax_active(&self) -> bool {
+        self.dax_active
+    }
+
+    pub(crate) fn dax_dontcache(&self) -> bool {
+        self.dax_dontcache.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn set_lookup_attr_flags(&self, flags: u32) {
+        self.lookup_attr_flags.store(flags, Ordering::Relaxed);
+    }
+
+    fn metadata_with_dax_state(&self, mut md: Metadata) -> Metadata {
+        if self.dax_active {
+            md.flags.insert(InodeFlags::S_DAX);
+        } else {
+            md.flags.remove(InodeFlags::S_DAX);
+        }
+        md
+    }
+
+    fn note_dax_attr_change(&self, attr_flags: u32) {
+        if !self.conn.dax_mode().attr_change_requires_dontcache(
+            self.dax_active,
+            (attr_flags & super::protocol::FUSE_ATTR_DAX) != 0,
+        ) || self
+            .dax_dontcache
+            .compare_exchange(false, true, Ordering::Release, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let Some(node) = self.self_ref.upgrade() else {
+            return;
+        };
+        if let Some(fs) = self.fs.upgrade() {
+            fs.purge_lookup_aliases(&node);
+        }
     }
 
     pub(crate) fn dax_layout_read(&self) -> RwSemReadGuard<'_, ()> {
@@ -604,7 +664,7 @@ impl FuseNode {
         end_exclusive: Option<usize>,
         restore_on_failure: bool,
     ) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
-        if !self.conn.dax_enabled() {
+        if !self.dax_active() {
             return Ok(self.dax_layout_write());
         }
         let _reclaim_serial = self.dax_reclaim_serial.lock();
@@ -743,7 +803,7 @@ impl FuseNode {
     }
 
     pub(crate) fn dax_teardown(&self) -> Result<(), SystemError> {
-        if self.conn.dax_enabled() {
+        if self.dax_active() {
             drop(self.dax_layout_write_for_all()?);
         }
         Ok(())
@@ -788,7 +848,7 @@ impl FuseNode {
         Ok(())
     }
 
-    fn dax_abandon_mappings(&self) {
+    fn dax_abandon_mappings(&self) -> Result<(), SystemError> {
         let mappings = self
             .dax_mappings
             .read()
@@ -796,28 +856,23 @@ impl FuseNode {
             .values()
             .cloned()
             .collect::<Vec<_>>();
-        let _ = self.dax_disconnect_revoke();
+        self.dax_disconnect_revoke()?;
         let Some(allocator) = self.conn.dax_allocator() else {
-            return;
+            return Ok(());
         };
         let total = allocator.snapshot().total;
         let mut candidates = Vec::with_capacity(total);
-        if allocator
-            .reclaim_candidates(&mut candidates, total)
-            .is_err()
-        {
-            return;
-        }
+        allocator.reclaim_candidates(&mut candidates, total)?;
         for mapping in mappings {
             if let Some(candidate) = candidates
                 .iter()
                 .find(|candidate| mapping.token.matches_candidate(candidate))
             {
-                if let Ok(token) = allocator.begin_reclaim(candidate) {
-                    let _ = allocator.retire_reclaim(&token);
-                }
+                let token = allocator.begin_reclaim(candidate)?;
+                allocator.retire_reclaim(&token)?;
             }
         }
+        Ok(())
     }
 
     pub(crate) fn dax_cancel_reclaim(
@@ -1153,13 +1208,21 @@ impl FuseNode {
         self.cached_metadata.lock().as_ref().map(|md| md.file_type)
     }
 
-    pub fn set_cached_metadata_with_valid(&self, md: Metadata, valid: u64, valid_nsec: u32) {
+    pub fn set_cached_metadata_with_valid(
+        &self,
+        md: Metadata,
+        valid: u64,
+        valid_nsec: u32,
+        attr_flags: u32,
+    ) {
+        let md = self.metadata_with_dax_state(md);
         let mut metadata = self.cached_metadata.lock();
         *metadata = Some(md);
         self.bump_attr_version();
         drop(metadata);
         self.cached_metadata_deadline_ns
             .store(Self::cache_deadline(valid, valid_nsec), Ordering::Relaxed);
+        self.note_dax_attr_change(attr_flags);
     }
 
     /// Install an unsolicited/lookup/getattr daemon attribute snapshot.
@@ -1171,7 +1234,9 @@ impl FuseNode {
         valid: u64,
         valid_nsec: u32,
         request_epoch: u64,
+        attr_flags: u32,
     ) -> Metadata {
+        md = self.metadata_with_dax_state(md);
         let mut metadata = self.cached_metadata.lock();
         let stale_reply = self.attr_version() > request_epoch;
         if stale_reply {
@@ -1201,6 +1266,9 @@ impl FuseNode {
             },
             Ordering::Relaxed,
         );
+        if !stale_reply {
+            self.note_dax_attr_change(attr_flags);
+        }
         md
     }
 
@@ -1399,6 +1467,7 @@ impl FuseNode {
             out.attr_valid,
             out.attr_valid_nsec,
             request_epoch,
+            out.attr.flags,
         ))
     }
 
@@ -1416,17 +1485,38 @@ impl FuseNode {
 
 impl Drop for FuseNode {
     fn drop(&mut self) {
-        if let Err(error) = self.dax_teardown() {
-            log::warn!(
-                "fuse: inode {} dropped with DAX teardown error: {:?}",
-                self.nodeid,
-                error
-            );
-            // The daemon did not confirm removal. Revoke local PTEs/tree and
-            // retire the ranges so no future inode can observe an alias.
-            self.dax_abandon_mappings();
+        if self.dax_active() {
+            let revoke = if self.conn.dax_admission_state() == DaxAdmissionState::Active {
+                match self.dax_teardown() {
+                    Ok(()) => Ok(()),
+                    Err(error) => {
+                        log::warn!(
+                            "fuse: inode {} dropped with DAX teardown error: {:?}",
+                            self.nodeid,
+                            error
+                        );
+                        // The daemon did not confirm removal. Revoke local
+                        // PTEs/tree and retire the ranges before unregistering.
+                        self.dax_abandon_mappings()
+                    }
+                }
+            } else {
+                self.dax_disconnect_revoke()
+            };
+            if let Err(ref error) = revoke {
+                log::warn!(
+                    "fuse: inode {} dropped with local DAX revoke error: {:?}",
+                    self.nodeid,
+                    error
+                );
+            }
+            if self.conn.dax_admission_state() != DaxAdmissionState::Active || revoke.is_err() {
+                self.conn
+                    .finish_dax_node_drop(self.dax_mapping_owner(), revoke);
+            } else {
+                self.conn.unregister_dax_node(self.dax_mapping_owner());
+            }
         }
-        self.conn.unregister_dax_node(self.dax_mapping_owner());
         self.clear_lookup_cache_tree();
         self.flush_forget();
         self.clear_parent();

--- a/kernel/src/filesystem/fuse/inode/directory.rs
+++ b/kernel/src/filesystem/fuse/inode/directory.rs
@@ -44,13 +44,17 @@ impl FuseNode {
         if child.nodeid() == self.nodeid {
             return;
         }
+        if child.dax_dontcache() {
+            self.invalidate_lookup_cache(name);
+            return;
+        }
         let deadline_ns = Self::cache_deadline(valid, valid_nsec);
         self.prune_lookup_cache();
 
         let mut removed = Vec::new();
         {
             let mut cache = self.lookup_cache.lock();
-            if deadline_ns == 0 {
+            if deadline_ns == 0 || child.dax_dontcache() {
                 if let Some(entry) = cache.remove(name) {
                     removed.push(entry);
                 }
@@ -142,6 +146,22 @@ impl FuseNode {
         Some(entry.child)
     }
 
+    pub(crate) fn purge_lookup_alias(&self, child: &Arc<FuseNode>) {
+        let removed = {
+            let mut cache = self.lookup_cache.lock();
+            let aliases: Vec<String> = cache
+                .iter()
+                .filter(|(_, entry)| Arc::ptr_eq(&entry.child, child))
+                .map(|(name, _)| name.clone())
+                .collect();
+            aliases
+                .into_iter()
+                .filter_map(|name| cache.remove(&name))
+                .collect()
+        };
+        Self::clear_removed_lookup_entries(removed);
+    }
+
     fn remove_lookup_cache_entry(&self, name: &str) -> Option<FuseLookupCacheEntry> {
         self.lookup_cache.lock().remove(name)
     }
@@ -153,6 +173,7 @@ impl FuseNode {
         now: u64,
     ) -> bool {
         (entry.deadline_ns != u64::MAX && now >= entry.deadline_ns)
+            || entry.child.dax_dontcache()
             || entry.child.check_not_stale().is_err()
             || entry.child.generation() != entry.generation
             || entry.child.parent_fuse_nodeid() != parent_nodeid
@@ -219,14 +240,17 @@ impl FuseNode {
                 Some(md.clone()),
                 Some(entry.generation),
                 1,
+                entry.attr.flags,
             )?;
             consumed = true;
             child.set_dname(name);
+            child.set_lookup_attr_flags(entry.attr.flags);
             child.merge_cached_metadata_from_daemon(
                 md,
                 entry.attr_valid,
                 entry.attr_valid_nsec,
                 request_epoch,
+                entry.attr.flags,
             );
             self.cache_lookup_child(
                 name,
@@ -355,7 +379,9 @@ impl FuseNode {
                 Some(md.clone()),
                 Some(entry.generation),
                 1,
+                entry.attr.flags,
             )?;
+            child.set_lookup_attr_flags(entry.attr.flags);
             if let Some(name) = name {
                 child.set_dname(name);
                 self.cache_lookup_child(
@@ -372,6 +398,7 @@ impl FuseNode {
                 entry.attr_valid,
                 entry.attr_valid_nsec,
                 self.conn.sample_attr_epoch(),
+                entry.attr.flags,
             );
             Ok(child as Arc<dyn IndexNode>)
         })();

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -108,7 +108,7 @@ impl FuseNode {
         };
         let end_page_exclusive = end_index.checked_add(1);
         let page_cache = self.cached_page_cache();
-        let blocker = if self.conn().dax_enabled() {
+        let blocker = if self.dax_active() {
             Some(self.dax_begin_host_invalidation()?)
         } else {
             None
@@ -385,7 +385,7 @@ impl FuseNode {
         // hold time, then drain again under the barrier to close the race with
         // buffered writes and page_mkwrite.
         self.sync_dirty_cached_pages()?;
-        let _barrier = if self.conn().dax_enabled() && len != old_size {
+        let _barrier = if self.dax_active() && len != old_size {
             if len < old_size {
                 self.dax_layout_write_for_truncate(len)?
             } else {
@@ -477,7 +477,12 @@ impl FuseNode {
         let out: FuseAttrOut = fuse_read_struct(&payload)?;
         let md = Self::attr_to_metadata(&out.attr);
         let new_size = md.size.max(0) as usize;
-        self.set_cached_metadata_with_valid(md, out.attr_valid, out.attr_valid_nsec);
+        self.set_cached_metadata_with_valid(
+            md,
+            out.attr_valid,
+            out.attr_valid_nsec,
+            out.attr.flags,
+        );
         self.truncate_page_cache(new_size)?;
         Ok(())
     }
@@ -885,7 +890,7 @@ impl FuseNode {
             && self
                 .conn
                 .has_init_flag(super::super::protocol::FUSE_ATOMIC_O_TRUNC)
-            && self.conn.dax_enabled();
+            && self.dax_active();
         if atomic_dax_truncate {
             self.sync_dirty_cached_pages()?;
         }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -90,7 +90,7 @@ impl IndexNode for FuseNode {
         };
 
         if (fopen_flags & FOPEN_DIRECT_IO) != 0
-            && !self.conn().dax_enabled()
+            && !self.dax_active()
             && vm_flags.contains(crate::mm::VmFlags::VM_MAYSHARE)
         {
             return Err(SystemError::ENODEV);
@@ -104,7 +104,7 @@ impl IndexNode for FuseNode {
         _file: &Arc<crate::filesystem::vfs::file::File>,
         vm_flags: crate::mm::VmFlags,
     ) -> Result<crate::mm::VmFlags, SystemError> {
-        if self.conn().dax_enabled() {
+        if self.dax_active() {
             Ok(vm_flags | crate::mm::VmFlags::VM_MIXEDMAP)
         } else {
             Ok(vm_flags)
@@ -133,7 +133,7 @@ impl IndexNode for FuseNode {
             p.fopen_flags
         };
 
-        if (fopen_flags & FOPEN_DIRECT_IO) != 0 && !self.conn().dax_enabled() {
+        if (fopen_flags & FOPEN_DIRECT_IO) != 0 && !self.dax_active() {
             if vm_flags.contains(crate::mm::VmFlags::VM_MAYSHARE) {
                 return Err(SystemError::ENODEV);
             }
@@ -371,7 +371,7 @@ impl IndexNode for FuseNode {
         let file_flags = private_data.open_flags;
         let fopen_flags = private_data.fopen_flags;
 
-        if self.conn().dax_enabled() {
+        if self.dax_active() {
             loop {
                 match self.dax_read(offset, &mut buf[..len]) {
                     Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
@@ -417,7 +417,7 @@ impl IndexNode for FuseNode {
         let fh = private_data.fh;
         let file_flags = private_data.open_flags;
         let fopen_flags = private_data.fopen_flags;
-        if self.conn().dax_enabled() {
+        if self.dax_active() {
             let lock_owner = crate::filesystem::vfs::vcore::current_file_lock_owner_id();
             loop {
                 match self.dax_write_or_fuse_locked(offset, &buf[..len], &private_data, lock_owner)
@@ -576,7 +576,7 @@ impl IndexNode for FuseNode {
         if writeback_cache {
             self.sync_dirty_cached_pages()?;
         }
-        let _barrier = if self.conn().dax_enabled() && metadata.size != old.size {
+        let _barrier = if self.dax_active() && metadata.size != old.size {
             Some(if metadata.size < old.size {
                 self.dax_layout_write_for_truncate(metadata.size.max(0) as usize)?
             } else {
@@ -641,7 +641,12 @@ impl IndexNode for FuseNode {
         let out: FuseAttrOut = fuse_read_struct(&payload)?;
         let md = Self::attr_to_metadata(&out.attr);
         let new_size = md.size.max(0) as usize;
-        self.set_cached_metadata_with_valid(md, out.attr_valid, out.attr_valid_nsec);
+        self.set_cached_metadata_with_valid(
+            md,
+            out.attr_valid,
+            out.attr_valid_nsec,
+            out.attr.flags,
+        );
         if (valid & FATTR_SIZE) != 0 {
             self.truncate_page_cache(new_size)?;
         }
@@ -754,7 +759,7 @@ impl IndexNode for FuseNode {
         if changes_contents {
             self.sync_dirty_cached_pages()?;
         }
-        let block_faults = self.conn().dax_enabled() && (!keep_size || changes_contents);
+        let block_faults = self.dax_active() && (!keep_size || changes_contents);
         let _barrier = if block_faults {
             self.dax_layout_write_for_all()?
         } else {
@@ -1005,6 +1010,7 @@ impl IndexNode for FuseNode {
                 Some(md.clone()),
                 Some(entry.generation),
                 1,
+                entry.attr.flags,
             )?;
             consumed = true;
             Ok(child)
@@ -1019,14 +1025,13 @@ impl IndexNode for FuseNode {
             }
         };
         child.set_dname(name);
-        child
-            .lookup_attr_flags
-            .store(entry.attr.flags, Ordering::Relaxed);
+        child.set_lookup_attr_flags(entry.attr.flags);
         child.merge_cached_metadata_from_daemon(
             md,
             entry.attr_valid,
             entry.attr_valid_nsec,
             request_epoch,
+            entry.attr.flags,
         );
         self.cache_lookup_child(
             name,
@@ -1174,13 +1179,16 @@ impl IndexNode for FuseNode {
                 Some(md.clone()),
                 Some(entry.generation),
                 1,
+                entry.attr.flags,
             )?;
             consumed = true;
+            child.set_lookup_attr_flags(entry.attr.flags);
             child.merge_cached_metadata_from_daemon(
                 md,
                 entry.attr_valid,
                 entry.attr_valid_nsec,
                 request_epoch,
+                entry.attr.flags,
             );
             Ok(())
         })();

--- a/kernel/src/filesystem/fuse/protocol.rs
+++ b/kernel/src/filesystem/fuse/protocol.rs
@@ -87,6 +87,8 @@ pub const FUSE_DIRECT_IO_ALLOW_MMAP: u64 = 1 << 36;
 
 /// fuse_attr.flags (Linux 6.6): directory is a submount root announced by virtiofsd.
 pub const FUSE_ATTR_SUBMOUNT: u32 = 1 << 0;
+/// fuse_attr.flags (Linux 6.6): enable DAX for this regular file in inode mode.
+pub const FUSE_ATTR_DAX: u32 = 1 << 1;
 
 // fuse_open_out.open_flags (Linux 6.6 uapi subset)
 pub const FOPEN_DIRECT_IO: u32 = 1 << 0;

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -1791,11 +1791,32 @@ impl VirtioFsBridgeContext {
         self.clear_queue_full_blocked_stats();
         self.instance.clear_bridge_wake(self.session_id);
         self.response_pool.close();
+        if let Err(error) = self.conn.abort_and_revoke_dax() {
+            log::error!(
+                "virtiofs bridge: DAX cleanup failed before reset; quarantining session id={} tag='{}' dev={:?}: {:?}",
+                self.session_id,
+                self.instance.tag(),
+                self.instance.dev_id(),
+                error
+            );
+            self.fail_unfinished_preserving_inflight_dma(SystemError::ENOTCONN);
+            if !self
+                .instance
+                .release_session_without_transport(self.session_id)
+            {
+                warn!(
+                    "virtiofs bridge: failed to release DAX-quarantined session id={} tag='{}' dev={:?}",
+                    self.session_id,
+                    self.instance.tag(),
+                    self.instance.dev_id()
+                );
+            }
+            return false;
+        }
         if !self.reset_device_and_unset_queues() {
             // Idle pooled buffers are not visible to the device. Release them before the
             // reset-timeout quarantine keeps the transport, queues and inflight DMA buffers alive.
             self.fail_unfinished_preserving_inflight_dma(SystemError::ENOTCONN);
-            self.conn.abort();
             if !self
                 .instance
                 .release_session_without_transport(self.session_id)
@@ -1810,7 +1831,6 @@ impl VirtioFsBridgeContext {
             return false;
         }
         self.fail_all_unfinished(SystemError::ENOTCONN);
-        self.conn.abort();
 
         if let Some(transport) = self.transport.take() {
             self.instance.put_transport_after_session(transport);

--- a/kernel/src/filesystem/fuse/virtiofs/dax.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/dax.rs
@@ -111,9 +111,46 @@ impl Drop for DaxAdmissionGuard {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DaxMountMode {
+    InodeDefault,
     Never,
     Always,
     Inode,
+}
+
+impl DaxMountMode {
+    pub(crate) fn is_inode_mode(self) -> bool {
+        matches!(self, Self::InodeDefault | Self::Inode)
+    }
+
+    pub(crate) fn proc_option(self) -> Option<&'static str> {
+        match self {
+            Self::InodeDefault => None,
+            Self::Never => Some("dax=never"),
+            Self::Always => Some("dax=always"),
+            Self::Inode => Some("dax=inode"),
+        }
+    }
+
+    pub(crate) fn inode_enabled(
+        self,
+        connection_capable: bool,
+        inode_capability_negotiated: bool,
+        attr_dax: bool,
+        regular: bool,
+    ) -> bool {
+        if !regular || !connection_capable {
+            return false;
+        }
+        match self {
+            Self::Never => false,
+            Self::Always => true,
+            Self::InodeDefault | Self::Inode => inode_capability_negotiated && attr_dax,
+        }
+    }
+
+    pub(crate) fn attr_change_requires_dontcache(self, active: bool, attr_dax: bool) -> bool {
+        self.is_inode_mode() && active != attr_dax
+    }
 }
 
 #[derive(Debug)]
@@ -1041,6 +1078,26 @@ mod tests {
         let mut out = Vec::with_capacity(max);
         allocator.reclaim_candidates(&mut out, max).unwrap();
         out
+    }
+
+    #[test]
+    fn inode_policy_matches_linux_capability_matrix() {
+        assert!(DaxMountMode::Always.inode_enabled(true, false, false, true));
+        assert!(!DaxMountMode::Always.inode_enabled(false, true, true, true));
+        assert!(!DaxMountMode::Never.inode_enabled(true, true, true, true));
+        assert!(DaxMountMode::Inode.inode_enabled(true, true, true, true));
+        assert!(!DaxMountMode::Inode.inode_enabled(true, false, true, true));
+        assert!(!DaxMountMode::InodeDefault.inode_enabled(true, true, false, true));
+        assert!(!DaxMountMode::Inode.inode_enabled(true, true, true, false));
+    }
+
+    #[test]
+    fn dontcache_compares_fixed_state_with_raw_attr_only_in_inode_modes() {
+        assert!(DaxMountMode::Inode.attr_change_requires_dontcache(false, true));
+        assert!(DaxMountMode::InodeDefault.attr_change_requires_dontcache(true, false));
+        assert!(!DaxMountMode::Inode.attr_change_requires_dontcache(true, true));
+        assert!(!DaxMountMode::Always.attr_change_requires_dontcache(true, false));
+        assert!(!DaxMountMode::Never.attr_change_requires_dontcache(false, true));
     }
 
     #[test]

--- a/kernel/src/filesystem/fuse/virtiofs/mount.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/mount.rs
@@ -1,4 +1,5 @@
 use alloc::{sync::Arc, vec};
+use core::fmt::Write;
 
 use linkme::distributed_slice;
 use system_error::SystemError;
@@ -6,8 +7,8 @@ use system_error::SystemError;
 use crate::{
     driver::virtio::virtio_fs::{virtio_fs_find_instance, VirtioFsInstance},
     filesystem::vfs::{
-        file::File, FilePrivateData, FileSystem, FileSystemMakerData, FsInfo, IndexNode,
-        MountableFileSystem, SuperBlock, FSMAKER,
+        file::File, mount::MountFS, FilePrivateData, FileSystem, FileSystemMakerData, FsInfo,
+        IndexNode, MountableFileSystem, SuperBlock, FSMAKER,
     },
     mm::{
         fault::{FaultFlags, PageFaultMessage},
@@ -47,6 +48,7 @@ impl FileSystemMakerData for VirtioFsMountData {
 #[derive(Debug)]
 struct VirtioFsFs {
     inner: Arc<dyn FileSystem>,
+    conn: Arc<FuseConn>,
     instance: Arc<VirtioFsInstance>,
     session_id: u64,
 }
@@ -65,7 +67,7 @@ impl VirtioFsFs {
             };
             private.node.clone()
         };
-        if !node.conn().dax_enabled() {
+        if !node.dax_active() {
             return None;
         }
 
@@ -156,10 +158,10 @@ impl VirtioFsFs {
         v.is_empty() || v != "0"
     }
 
-    fn parse_dax_mode(v: &str) -> Result<DaxMountMode, SystemError> {
-        if v.is_empty() {
+    fn parse_dax_mode(v: Option<&str>) -> Result<DaxMountMode, SystemError> {
+        let Some(v) = v else {
             return Ok(DaxMountMode::Always);
-        }
+        };
 
         match v {
             "always" => Ok(DaxMountMode::Always),
@@ -180,17 +182,18 @@ impl VirtioFsFs {
         let mut group_id: Option<u32> = None;
         let mut default_permissions = true;
         let mut allow_other = true;
-        let mut dax_mode = DaxMountMode::Never;
+        let mut dax_mode = DaxMountMode::InodeDefault;
 
         for part in raw.unwrap_or("").split(',') {
             let part = part.trim();
             if part.is_empty() {
                 continue;
             }
-            let (k, v) = match part.split_once('=') {
-                Some((k, v)) => (k.trim(), v.trim()),
-                None => (part, ""),
+            let (k, value) = match part.split_once('=') {
+                Some((k, v)) => (k.trim(), Some(v.trim())),
+                None => (part, None),
             };
+            let v = value.unwrap_or("");
 
             match k {
                 "rootmode" => rootmode = Some(Self::parse_opt_u32_octal(v)?),
@@ -198,15 +201,9 @@ impl VirtioFsFs {
                 "group_id" => group_id = Some(Self::parse_opt_u32_decimal(v)?),
                 "default_permissions" => default_permissions = Self::parse_opt_bool_switch(v),
                 "allow_other" => allow_other = Self::parse_opt_bool_switch(v),
-                "dax" => dax_mode = Self::parse_dax_mode(v)?,
+                "dax" => dax_mode = Self::parse_dax_mode(value)?,
                 _ => return Err(SystemError::EINVAL),
             }
-        }
-
-        // Per-inode DAX requires tracking FUSE_ATTR_DAX transitions.  Treating
-        // it as dax=always would violate the negotiated Linux ABI.
-        if dax_mode == DaxMountMode::Inode {
-            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
         }
 
         Ok((
@@ -251,6 +248,17 @@ impl FileSystem for VirtioFsFs {
 
     fn permission_policy(&self) -> crate::filesystem::vfs::FsPermissionPolicy {
         self.inner.permission_policy()
+    }
+
+    fn proc_show_mount_options(
+        &self,
+        _mount: &MountFS,
+        out: &mut dyn Write,
+    ) -> Result<(), SystemError> {
+        if let Some(option) = self.conn.dax_mode().proc_option() {
+            out.write_str(option).map_err(|_| SystemError::EINVAL)?;
+        }
+        Ok(())
     }
 
     unsafe fn fault(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
@@ -303,14 +311,17 @@ impl MountableFileSystem for VirtioFsFs {
                 .as_ref()
                 .is_none_or(|window| window.len() < super::dax::DAX_RANGE_SIZE)
         {
-            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+            return Err(SystemError::EINVAL);
         }
         let conn = FuseConn::new_for_virtiofs_with_dax_window(
             VIRTIOFS_MAX_REQUEST_SIZE,
             VIRTIOFS_RSP_BUF_SIZE,
             cache_window,
             dax_mode,
-        );
+        )?;
+        if dax_mode == DaxMountMode::Always && !conn.dax_enabled() {
+            return Err(SystemError::EINVAL);
+        }
 
         Ok(Some(Arc::new(VirtioFsMountData {
             rootmode,
@@ -356,6 +367,7 @@ impl MountableFileSystem for VirtioFsFs {
 
         Ok(Arc::new(VirtioFsFs {
             inner,
+            conn: md.conn.clone(),
             instance: md.instance.clone(),
             session_id,
         }))
@@ -363,3 +375,43 @@ impl MountableFileSystem for VirtioFsFs {
 }
 
 register_mountable_fs!(VirtioFsFs, VIRTIOFSMAKER, "virtiofs");
+
+#[cfg(test)]
+mod tests {
+    use system_error::SystemError;
+
+    use super::{DaxMountMode, VirtioFsFs};
+
+    #[test]
+    fn dax_option_parser_matches_linux_modes() {
+        assert_eq!(VirtioFsFs::parse_dax_mode(None), Ok(DaxMountMode::Always));
+        assert_eq!(
+            VirtioFsFs::parse_dax_mode(Some("always")),
+            Ok(DaxMountMode::Always)
+        );
+        assert_eq!(
+            VirtioFsFs::parse_dax_mode(Some("never")),
+            Ok(DaxMountMode::Never)
+        );
+        assert_eq!(
+            VirtioFsFs::parse_dax_mode(Some("inode")),
+            Ok(DaxMountMode::Inode)
+        );
+        assert_eq!(
+            VirtioFsFs::parse_dax_mode(Some("")),
+            Err(SystemError::EINVAL)
+        );
+        assert_eq!(
+            VirtioFsFs::parse_dax_mode(Some("on")),
+            Err(SystemError::EINVAL)
+        );
+    }
+
+    #[test]
+    fn proc_option_distinguishes_default_and_explicit_inode_modes() {
+        assert_eq!(DaxMountMode::InodeDefault.proc_option(), None);
+        assert_eq!(DaxMountMode::Always.proc_option(), Some("dax=always"));
+        assert_eq!(DaxMountMode::Never.proc_option(), Some("dax=never"));
+        assert_eq!(DaxMountMode::Inode.proc_option(), Some("dax=inode"));
+    }
+}


### PR DESCRIPTION
Closes #2082

## Summary

- implement Linux 6.6-compatible default inode DAX policy plus explicit `dax=always`, `dax=never`, and `dax=inode` mount modes
- negotiate and honor `FUSE_HAS_INODE_DAX` / `FUSE_ATTR_DAX`, keep each live inode incarnation on a fixed buffered or DAX path, and drop lookup aliases when the host attribute changes
- synchronously drain DAX admission, complete pending requests, revoke inode PTEs/mappings, and release allocator/window state before virtio reset
- quarantine transport, queues, DMA owners, and the cache window when local revocation fails instead of resetting an unsafe device
- report explicit DAX modes through procfs and preserve Linux distinctions such as bare `dax` versus invalid `dax=`

## Design notes

The cleanup registry and its `Active -> InProgress -> Succeeded/Failed` state share one lock. Admission and allocator acquisition close before registration is rejected, so a node is either registered for revocation or cannot establish a new mapping. Inode Drop reports local revoke/allocator retirement failures through a persistent latch; reset is permitted only after the registry is empty and no failure was observed.

Per-inode DAX state is immutable for a live `FuseNode`. Attribute transitions use a node-wide dontcache flag and purge every hard-link lookup alias, matching Linux inode incarnation semantics without switching a live address-space model.

## Validation

- `make kernel`
- `cargo fmt --check` and `git diff --check`
- QEMU + virtiofsd 1.10.0: default mount succeeds and omits a DAX proc option
- QEMU: `dax=inode` and `dax=never` succeed on a device without a cache window, use buffered fallback, and report the explicit proc option
- QEMU: bare `dax` fails with `EINVAL` when no cache window exists; `dax=` is rejected as an invalid enum
- QEMU: five repeated `dax=inode` mount/unmount cycles pass

The available QEMU `vhost-user-fs-pci` device exposes no DAX cache-window property, so real-window PFN/reset behavior could not be exercised in this environment. The policy matrix and cleanup invariants are covered by focused unit tests and adversarial Linux/concurrency/lifecycle review; a cache-window-capable CI or machine should retain the existing DAX stress coverage.