### PR TITLE
fix(namespace): make mount propagation transactional

### DIFF
--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -28,7 +28,7 @@ use crate::{
                 abort_mount_propagation, commit_mount_propagation_locked, detach_mount_propagation,
                 ensure_subtree_shared, inherit_bind_mount_propagation,
                 prepare_mount_propagation_locked, propagate_umount, propagation_umount_busy,
-                register_peer, register_slave_with_master, MountPropagation,
+                MountPropagation,
             },
         },
         ProcessManager,
@@ -360,6 +360,33 @@ pub struct MountFS {
     /// Internal MNT_LOCKED equivalent; never exposed as a userspace MS_* bit.
     locked: AtomicBool,
     lifecycle: Mutex<MountLifecycle>,
+}
+
+/// Capacity reserved for one future mount edge. Creating an empty map entry is
+/// topology-neutral; if prepare aborts before the slot is consumed, Drop
+/// removes that entry so failed events leave no mountpoint residue.
+pub(crate) struct MountEdgeReservation {
+    parent: Arc<MountFS>,
+    mountpoint: Arc<MountFSInode>,
+}
+
+impl Drop for MountEdgeReservation {
+    fn drop(&mut self) {
+        let mut mountpoints = self.parent.mountpoints.lock();
+        let dentry_id = self.mountpoint.dentry.id;
+        if mountpoints
+            .get(&dentry_id)
+            .is_some_and(|stack| stack.is_empty())
+        {
+            mountpoints.remove(&dentry_id);
+        }
+    }
+}
+
+impl MountEdgeReservation {
+    pub(crate) fn mountpoint(&self) -> &Arc<MountFSInode> {
+        &self.mountpoint
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1249,7 +1276,19 @@ impl MountFS {
         mountpoint: &Arc<MountFSInode>,
         mount_fs: Arc<MountFS>,
     ) -> Result<(), SystemError> {
+        let cover_mountpoint = mount_fs.mountpoint_root_inode();
+        self.attach_beneath_prepared(mountpoint, mount_fs, &cover_mountpoint)
+    }
+
+    pub(crate) fn attach_beneath_prepared(
+        &self,
+        mountpoint: &Arc<MountFSInode>,
+        mount_fs: Arc<MountFS>,
+        cover_mountpoint: &Arc<MountFSInode>,
+    ) -> Result<(), SystemError> {
         if !Arc::ptr_eq(&mountpoint.mount_fs, &self.self_ref())
+            || !Arc::ptr_eq(&cover_mountpoint.mount_fs, &mount_fs)
+            || cover_mountpoint.dentry.id != mount_fs.root_dentry.id
             || mount_fs
                 .self_mountpoint()
                 .as_ref()
@@ -1276,7 +1315,6 @@ impl MountFS {
 
         // Linux mnt_set_mountpoint_beneath(): the propagated mount takes the
         // original edge and the previous topper is reparented onto its root.
-        let cover_mountpoint = mount_fs.mountpoint_root_inode();
         covered.relocate_mountpoint(Some(cover_mountpoint.clone()));
         if let Err(error) = mount_fs.attach_top(&cover_mountpoint, covered.clone()) {
             covered.relocate_mountpoint(Some(mountpoint.clone()));
@@ -1300,25 +1338,124 @@ impl MountFS {
         mount_fs: &Arc<MountFS>,
     ) -> Result<Arc<MountFS>, SystemError> {
         let cover_mountpoint = mount_fs.mountpoint_root_inode();
-        let Some(covered) = mount_fs
-            .children_at(&cover_mountpoint)
-            .into_iter()
-            .find(|child| child.tucked_under.load(Ordering::Acquire))
-        else {
+        let covered = mount_fs
+            .mountpoints
+            .lock()
+            .get(&cover_mountpoint.dentry.id)
+            .and_then(|stack| {
+                stack
+                    .iter()
+                    .find(|child| child.tucked_under.load(Ordering::Acquire))
+                    .cloned()
+            });
+        let Some(covered) = covered else {
             return self.detach_exact(mount_fs);
         };
-        let original_mountpoint = mount_fs.self_mountpoint().ok_or(SystemError::EINVAL)?;
-        mount_fs.detach_exact(&covered)?;
-        covered.relocate_mountpoint(Some(original_mountpoint.clone()));
-        let removed = self.detach_exact(mount_fs)?;
-        if let Err(error) = self.attach_top(&original_mountpoint, covered.clone()) {
-            // All objects remain owned; reconstruct the tuck-under topology.
-            self.attach_top(&original_mountpoint, mount_fs.clone())?;
-            covered.relocate_mountpoint(Some(cover_mountpoint.clone()));
-            mount_fs.attach_top(&cover_mountpoint, covered)?;
-            return Err(error);
+        self.restore_exact_cover(mount_fs, &cover_mountpoint, &covered)
+    }
+
+    /// Transaction rollback variant using the exact topper and root wrapper
+    /// captured during prepare. It performs no discovery or allocation.
+    pub(crate) fn detach_exact_restoring_prepared_cover(
+        &self,
+        mount_fs: &Arc<MountFS>,
+        cover_mountpoint: Option<&Arc<MountFSInode>>,
+        covered: Option<&Arc<MountFS>>,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        match (cover_mountpoint, covered) {
+            (None, None) => self.detach_exact(mount_fs),
+            (Some(cover_mountpoint), Some(covered)) => {
+                if !covered.tucked_under.load(Ordering::Acquire)
+                    || !mount_fs
+                        .mountpoints
+                        .lock()
+                        .get(&cover_mountpoint.dentry.id)
+                        .is_some_and(|stack| stack.iter().any(|child| Arc::ptr_eq(child, covered)))
+                {
+                    return Err(SystemError::ENOENT);
+                }
+                self.restore_exact_cover(mount_fs, cover_mountpoint, covered)
+            }
+            _ => Err(SystemError::EINVAL),
         }
+    }
+
+    fn restore_exact_cover(
+        &self,
+        mount_fs: &Arc<MountFS>,
+        cover_mountpoint: &Arc<MountFSInode>,
+        covered: &Arc<MountFS>,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        let original_mountpoint = mount_fs.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        // Preserve the clone-root Vec until restoration completes. This is
+        // the rollback counterpart of the prepare-time cover reservation.
+        let _cover_reservation = mount_fs.reserve_mount_edge(&cover_mountpoint, 0)?;
+        mount_fs.detach_exact_keep_slot(covered)?;
+        covered.relocate_mountpoint(Some(original_mountpoint.clone()));
+        let removed = match self.replace_exact_edge(mount_fs, covered.clone()) {
+            Ok(removed) => removed,
+            Err(error) => {
+                // All objects remain owned; reconstruct the tuck-under
+                // topology without allocating from the reserved cover slot.
+                covered.relocate_mountpoint(Some(cover_mountpoint.clone()));
+                mount_fs.attach_top(cover_mountpoint, covered.clone())?;
+                covered.restore_tucked_under(true);
+                return Err(error);
+            }
+        };
         covered.tucked_under.store(false, Ordering::Release);
+        Ok(removed)
+    }
+
+    /// Replace one exact edge in place, preserving the parent stack's key,
+    /// capacity, ordering and mount-edge count.
+    fn replace_exact_edge(
+        &self,
+        old: &Arc<MountFS>,
+        replacement: Arc<MountFS>,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        let mountpoint = old.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        if !Arc::ptr_eq(&mountpoint.mount_fs, &self.self_ref())
+            || replacement
+                .self_mountpoint()
+                .as_ref()
+                .is_none_or(|replacement_mp| !Arc::ptr_eq(replacement_mp, &mountpoint))
+        {
+            return Err(SystemError::EINVAL);
+        }
+        let _gate = mountpoint.dentry.mount_gate.lock();
+        let mut mountpoints = self.mountpoints.lock();
+        let stack = mountpoints
+            .get_mut(&mountpoint.dentry.id)
+            .ok_or(SystemError::ENOENT)?;
+        let index = stack
+            .iter()
+            .position(|child| Arc::ptr_eq(child, old))
+            .ok_or(SystemError::ENOENT)?;
+        Ok(core::mem::replace(&mut stack[index], replacement))
+    }
+
+    pub(crate) fn detach_exact_keep_slot(
+        &self,
+        mount_fs: &Arc<MountFS>,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        let mountpoint = mount_fs.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        if !Arc::ptr_eq(&mountpoint.mount_fs, &self.self_ref()) {
+            return Err(SystemError::EINVAL);
+        }
+        let _gate = mountpoint.dentry.mount_gate.lock();
+        let key = mountpoint.dentry.id;
+        let mut mountpoints = self.mountpoints.lock();
+        let stack = mountpoints.get_mut(&key).ok_or(SystemError::ENOENT)?;
+        let index = stack
+            .iter()
+            .position(|child| Arc::ptr_eq(child, mount_fs))
+            .ok_or(SystemError::ENOENT)?;
+        let removed = stack.remove(index);
+        mountpoint
+            .dentry
+            .mount_edges
+            .fetch_sub(1, Ordering::Release);
         Ok(removed)
     }
 
@@ -1375,6 +1512,39 @@ impl MountFS {
 
     pub fn propagation(&self) -> Arc<MountPropagation> {
         self.propagation.clone()
+    }
+
+    /// Reserve the HashMap key and stack capacity needed by a future exact
+    /// edge publication. Callers hold `MOUNT_LIFECYCLE_LOCK`, so no topology
+    /// writer can consume the reserved slot before commit.
+    pub(crate) fn reserve_mount_edge(
+        &self,
+        mountpoint: &Arc<MountFSInode>,
+        additional: usize,
+    ) -> Result<MountEdgeReservation, SystemError> {
+        if !Arc::ptr_eq(&mountpoint.mount_fs, &self.self_ref()) {
+            return Err(SystemError::EINVAL);
+        }
+        let key = mountpoint.dentry.id;
+        let mut mountpoints = self.mountpoints.lock();
+        if let Some(stack) = mountpoints.get_mut(&key) {
+            stack
+                .try_reserve(additional)
+                .map_err(|_| SystemError::ENOMEM)?;
+        } else {
+            mountpoints
+                .try_reserve(1)
+                .map_err(|_| SystemError::ENOMEM)?;
+            let mut stack = Vec::new();
+            stack
+                .try_reserve(additional)
+                .map_err(|_| SystemError::ENOMEM)?;
+            mountpoints.insert(key, stack);
+        }
+        Ok(MountEdgeReservation {
+            parent: self.self_ref(),
+            mountpoint: mountpoint.clone(),
+        })
     }
 
     /// Get the mount ID
@@ -2559,17 +2729,6 @@ impl MountFSInode {
             return Err(error);
         }
 
-        let mut pending = vec![new_mount_fs.clone()];
-        while let Some(mount) = pending.pop() {
-            pending.extend(mount.mount_children());
-            let propagation = mount.propagation();
-            if propagation.is_shared() {
-                register_peer(propagation.peer_group_id(), &mount);
-            }
-            if propagation.is_slave() {
-                register_slave_with_master(&mount);
-            }
-        }
         Ok(())
     }
 

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1316,7 +1316,7 @@ impl MountFS {
         // Linux mnt_set_mountpoint_beneath(): the propagated mount takes the
         // original edge and the previous topper is reparented onto its root.
         covered.relocate_mountpoint(Some(cover_mountpoint.clone()));
-        if let Err(error) = mount_fs.attach_top(&cover_mountpoint, covered.clone()) {
+        if let Err(error) = mount_fs.attach_top(cover_mountpoint, covered.clone()) {
             covered.relocate_mountpoint(Some(mountpoint.clone()));
             let mut mountpoints = self.mountpoints.lock();
             let stack = mountpoints
@@ -1389,7 +1389,7 @@ impl MountFS {
         let original_mountpoint = mount_fs.self_mountpoint().ok_or(SystemError::EINVAL)?;
         // Preserve the clone-root Vec until restoration completes. This is
         // the rollback counterpart of the prepare-time cover reservation.
-        let _cover_reservation = mount_fs.reserve_mount_edge(&cover_mountpoint, 0)?;
+        let _cover_reservation = mount_fs.reserve_mount_edge(cover_mountpoint, 0)?;
         mount_fs.detach_exact_keep_slot(covered)?;
         covered.relocate_mountpoint(Some(original_mountpoint.clone()));
         let removed = match self.replace_exact_edge(mount_fs, covered.clone()) {

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -15,7 +15,9 @@ use system_error::SystemError;
 use super::{
     nsproxy::NsCommon,
     propagation::{
-        propagate_moved_tree_locked, register_peer, register_slave_with_master, MountPropagation,
+        abort_moved_tree_propagation_locked, commit_moved_tree_propagation_locked,
+        prepare_moved_tree_propagation_locked, register_peer, register_slave_with_master,
+        MountPropagation,
     },
     user_namespace::UserNamespace,
     NamespaceOps,
@@ -280,7 +282,40 @@ impl MntNamespace {
             }
         }
 
-        old_parent.detach_exact(source_mfs)?;
+        // Keep the old stack allocation alive until the move either commits
+        // or restores this exact edge. Successful moves drop the token and
+        // remove the now-empty key; rollback reuses the original Vec.
+        let _old_edge_reservation = old_parent.reserve_mount_edge(&old_mountpoint, 0)?;
+
+        // Match Linux attach_recursive_mnt(MNT_TREE_MOVE): allocate group IDs
+        // and clone every propagation target while the source still occupies
+        // its old edge. Resource failure therefore cannot expose a transient
+        // move and needs no topology rollback.
+        let prepared_propagation = if target_parent.propagation().is_shared() {
+            Some(prepare_moved_tree_propagation_locked(
+                &target_parent,
+                source_mfs,
+                target_mountpoint,
+            )?)
+        } else {
+            None
+        };
+        // Shared destinations reserve this edge as part of propagation
+        // prepare. A private destination still needs the same guarantee:
+        // attaching the moved root after detaching its old edge must not be
+        // the first operation that tries to grow the target stack.
+        let _private_target_reservation = if prepared_propagation.is_none() {
+            Some(target_parent.reserve_mount_edge(target_mountpoint, 1)?)
+        } else {
+            None
+        };
+
+        if let Err(error) = old_parent.detach_exact_keep_slot(source_mfs) {
+            if let Some(prepared) = prepared_propagation {
+                abort_moved_tree_propagation_locked(prepared);
+            }
+            return Err(error);
+        }
         source_mfs.relocate_mountpoint(Some(target_mountpoint.clone()));
         if let Err(error) = target_parent.attach_new_top(target_mountpoint, source_mfs.clone()) {
             source_mfs.relocate_mountpoint(Some(old_mountpoint));
@@ -293,13 +328,14 @@ impl MntNamespace {
                     source_mfs.clone(),
                 )
                 .expect("move rollback must restore the exact detached edge");
+            if let Some(prepared) = prepared_propagation {
+                abort_moved_tree_propagation_locked(prepared);
+            }
             return Err(error);
         }
 
-        if target_parent.propagation().is_shared() {
-            if let Err(error) =
-                propagate_moved_tree_locked(&target_parent, source_mfs, target_mountpoint)
-            {
+        if let Some(prepared) = prepared_propagation {
+            if let Err(error) = commit_moved_tree_propagation_locked(prepared) {
                 target_parent
                     .detach_exact(source_mfs)
                     .expect("failed move propagation must detach the target edge");

--- a/kernel/src/process/namespace/propagation/event.rs
+++ b/kernel/src/process/namespace/propagation/event.rs
@@ -7,9 +7,15 @@ use alloc::vec::Vec;
 use hashbrown::HashSet;
 use system_error::SystemError;
 
-use crate::filesystem::vfs::{mount::MountFSInode, MountFS};
+use crate::filesystem::vfs::{
+    mount::{MountEdgeReservation, MountFSInode},
+    MountFS,
+};
 
-use super::group::{get_peers, register_peer, unregister_peer, PropagationGroup};
+use super::group::{
+    apply_prepared_peer_groups, get_peers, prepare_peer_registrations, PreparedPeerGroupState,
+    PropagationGroup,
+};
 use super::state::{register_slave_with_master, PropagationType};
 
 #[derive(Clone, Copy)]
@@ -21,7 +27,6 @@ enum PropagationTargetKind {
 struct PropagationTarget {
     mount: Arc<MountFS>,
     kind: PropagationTargetKind,
-    master_parent: Option<Arc<MountFS>>,
 }
 
 struct PreparedMount {
@@ -29,6 +34,8 @@ struct PreparedMount {
     mountpoint: Arc<MountFSInode>,
     expected_top: Option<Arc<MountFS>>,
     clone: Arc<MountFS>,
+    _target_reservation: Option<MountEdgeReservation>,
+    cover_reservation: Option<MountEdgeReservation>,
 }
 
 pub(crate) struct PreparedPropagation {
@@ -36,6 +43,117 @@ pub(crate) struct PreparedPropagation {
     mountpoint: Arc<MountFSInode>,
     new_child: Arc<MountFS>,
     mounts: Vec<PreparedMount>,
+    registrations: PreparedRegistrations,
+    _local_reservation: MountEdgeReservation,
+}
+
+pub(super) struct CorrespondingSources {
+    mounts: BTreeMap<usize, Arc<MountFS>>,
+    peer_groups: BTreeMap<usize, Arc<MountFS>>,
+}
+
+impl CorrespondingSources {
+    pub(super) fn new() -> Self {
+        Self {
+            mounts: BTreeMap::new(),
+            peer_groups: BTreeMap::new(),
+        }
+    }
+
+    pub(super) fn insert(&mut self, parent: &Arc<MountFS>, child: Arc<MountFS>) {
+        self.mounts.insert(parent.mount_id().data(), child.clone());
+        let propagation = parent.propagation();
+        let group_id = propagation.peer_group_id();
+        if propagation.is_shared() && group_id.is_valid() {
+            self.peer_groups.entry(group_id.data()).or_insert(child);
+        }
+    }
+
+    pub(super) fn nearest(
+        &self,
+        target: &Arc<MountFS>,
+    ) -> Result<Option<Arc<MountFS>>, SystemError> {
+        // Linux `propagate_one()` retains `last_source` when a narrow peer is
+        // uncovered. Match that layer before walking to the next master.
+        let mut visited = HashSet::new();
+        visited.insert(target.mount_id().data());
+        let mut master = target.propagation().master();
+        while let Some(candidate) = master {
+            if !visited.insert(candidate.mount_id().data()) {
+                return Err(SystemError::ELOOP);
+            }
+            if let Some(source) = self.mounts.get(&candidate.mount_id().data()) {
+                return Ok(Some(source.clone()));
+            }
+            let propagation = candidate.propagation();
+            let group_id = propagation.peer_group_id();
+            if propagation.is_shared() && group_id.is_valid() {
+                if let Some(source) = self.peer_groups.get(&group_id.data()) {
+                    return Ok(Some(source.clone()));
+                }
+            }
+            master = propagation.master();
+        }
+        Ok(None)
+    }
+}
+
+struct PreparedRegistrations {
+    peer_groups: Vec<PreparedPeerGroupState>,
+    slaves: Vec<Arc<MountFS>>,
+}
+
+impl PreparedRegistrations {
+    fn prepare(mounts: &[Arc<MountFS>]) -> Result<Self, SystemError> {
+        let peer_groups = prepare_peer_registrations(mounts)?;
+        let mut slaves = Vec::new();
+        slaves
+            .try_reserve(mounts.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        for mount in mounts {
+            // Live source mounts in a move already occupy their master's
+            // reverse list. Detached source/clone mounts need publication.
+            if !mount.is_live() && mount.propagation().master().is_some() {
+                slaves.push(mount.clone());
+            }
+        }
+
+        let mut masters = Vec::new();
+        masters
+            .try_reserve(slaves.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        for slave in &slaves {
+            let master = slave
+                .propagation()
+                .master()
+                .expect("prepared slave retained its master");
+            masters.push((master.mount_id().data(), master));
+        }
+        masters.sort_unstable_by_key(|(mount_id, _)| *mount_id);
+        let mut index = 0;
+        while index < masters.len() {
+            let start = index;
+            let master_id = masters[index].0;
+            while index < masters.len() && masters[index].0 == master_id {
+                index += 1;
+            }
+            masters[start]
+                .1
+                .propagation()
+                .try_reserve_slaves(index - start)?;
+        }
+        Ok(Self {
+            peer_groups,
+            slaves,
+        })
+    }
+
+    fn commit(self) {
+        apply_prepared_peer_groups(self.peer_groups);
+        for mount in self.slaves {
+            register_slave_with_master(&mount);
+        }
+    }
 }
 
 /// Return every peer/slave destination exactly once.  The registry is only a
@@ -53,45 +171,28 @@ fn propagation_targets(source: &Arc<MountFS>) -> Vec<PropagationTarget> {
             result.push(PropagationTarget {
                 mount: peer.clone(),
                 kind: PropagationTargetKind::Peer,
-                master_parent: None,
             });
         }
     }
 
-    let mut pending: Vec<(Arc<MountFS>, Arc<MountFS>)> = source
-        .propagation()
-        .slaves()
-        .into_iter()
-        .map(|slave| (slave, source.clone()))
-        .collect();
+    let mut pending = source.propagation().slaves();
     for peer in result.iter().map(|target| &target.mount) {
-        pending.extend(
-            peer.propagation()
-                .slaves()
-                .into_iter()
-                .map(|slave| (slave, peer.clone())),
-        );
+        pending.extend(peer.propagation().slaves());
     }
-    while let Some((slave, master_parent)) = pending.pop() {
+    while let Some(slave) = pending.pop() {
         if !visited.insert(slave.mount_id().data()) {
             continue;
         }
-        pending.extend(
-            slave
-                .propagation()
-                .slaves()
-                .into_iter()
-                .map(|child| (child, slave.clone())),
-        );
+        pending.extend(slave.propagation().slaves());
         result.push(PropagationTarget {
             mount: slave,
             kind: PropagationTargetKind::Slave,
-            master_parent: Some(master_parent),
         });
     }
     result
 }
 
+/// Apply Linux's peer/slave clone flags to one detached copy.
 fn configure_clone_propagation(
     source: &Arc<MountFS>,
     clone: &Arc<MountFS>,
@@ -252,44 +353,46 @@ fn activate_subtree(
     Ok(())
 }
 
-fn register_subtree(root: &Arc<MountFS>) {
-    for mount in collect_subtree(root) {
-        let prop = mount.propagation();
-        if prop.is_shared() {
-            register_peer(prop.peer_group_id(), &mount);
-        }
-        register_slave_with_master(&mount);
-    }
-}
-
 pub(crate) fn prepare_mount_propagation_locked(
     source_mnt: &Arc<MountFS>,
     mountpoint: &Arc<MountFSInode>,
     new_child: &Arc<MountFS>,
 ) -> Result<Option<PreparedPropagation>, SystemError> {
     let source_prop = source_mnt.propagation();
-    if !source_prop.is_shared() {
-        return Ok(None);
-    }
     let canonical_mountpoint = source_mnt.wrapper_for_dentry(mountpoint.shared_dentry())?;
     if canonical_mountpoint.dentry_id() != mountpoint.dentry_id() {
         return Err(SystemError::EINVAL);
     }
+    // New/bind and move both publish the local source as a new top edge.
+    // Reserve its parent key/stack before either path changes topology.
+    let local_reservation = source_mnt.reserve_mount_edge(&canonical_mountpoint, 1)?;
 
     let source_dentry = mountpoint.shared_dentry();
     let mut slave_groups = BTreeMap::new();
     let mut mounts = Vec::new();
-    let mut propagated_sources = BTreeMap::new();
-    propagated_sources.insert(source_mnt.mount_id().data(), new_child.clone());
-    for target in propagation_targets(source_mnt) {
+    let mut propagated_sources = CorrespondingSources::new();
+    propagated_sources.insert(source_mnt, new_child.clone());
+    let targets = if source_prop.is_shared() {
+        propagation_targets(source_mnt)
+    } else {
+        Vec::new()
+    };
+    for target in targets {
         let PropagationTarget {
             mount: target_parent,
             kind,
-            master_parent,
         } = target;
-        let master_source = master_parent
-            .as_ref()
-            .and_then(|master| propagated_sources.get(&master.mount_id().data()).cloned());
+        let master_source = if matches!(kind, PropagationTargetKind::Slave) {
+            match propagated_sources.nearest(&target_parent) {
+                Ok(source) => source,
+                Err(error) => {
+                    abandon_prepared(&mounts);
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
         if matches!(kind, PropagationTargetKind::Slave) && master_source.is_none() {
             continue;
         }
@@ -318,19 +421,59 @@ pub(crate) fn prepare_mount_propagation_locked(
                 return Err(error);
             }
         };
-        propagated_sources.insert(target_parent.mount_id().data(), clone.clone());
+        let target_reservation = if expected_top.is_none() {
+            match target_parent.reserve_mount_edge(&target_mp, 1) {
+                Ok(reservation) => Some(reservation),
+                Err(error) => {
+                    MountFS::deactivate_disconnected_subtree(&clone);
+                    abandon_prepared(&mounts);
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
+        let cover_reservation = if expected_top.is_some() {
+            let cover_mountpoint = clone.mountpoint_root_inode();
+            match clone.reserve_mount_edge(&cover_mountpoint, 1) {
+                Ok(reservation) => Some(reservation),
+                Err(error) => {
+                    MountFS::deactivate_disconnected_subtree(&clone);
+                    abandon_prepared(&mounts);
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
+        propagated_sources.insert(&target_parent, clone.clone());
         mounts.push(PreparedMount {
             target_parent,
             mountpoint: target_mp,
             expected_top,
             clone,
+            _target_reservation: target_reservation,
+            cover_reservation,
         });
     }
+    let mut registration_mounts = collect_subtree(new_child);
+    for item in &mounts {
+        registration_mounts.extend(collect_subtree(&item.clone));
+    }
+    let registrations = match PreparedRegistrations::prepare(&registration_mounts) {
+        Ok(registrations) => registrations,
+        Err(error) => {
+            abandon_prepared(&mounts);
+            return Err(error);
+        }
+    };
     Ok(Some(PreparedPropagation {
         source_mnt: source_mnt.clone(),
         mountpoint: canonical_mountpoint,
         new_child: new_child.clone(),
         mounts,
+        registrations,
+        _local_reservation: local_reservation,
     }))
 }
 
@@ -408,19 +551,34 @@ pub(crate) fn commit_mount_propagation_locked(
     }
 
     let mut attached: Vec<&PreparedMount> = Vec::new();
+    if attached.try_reserve(prepared.mounts.len()).is_err() {
+        abandon_prepared(&prepared.mounts);
+        return Err(SystemError::ENOMEM);
+    }
     for item in &prepared.mounts {
-        let result = if item.expected_top.is_some() {
-            item.target_parent
-                .attach_beneath(&item.mountpoint, item.clone.clone())
+        let result = if let Some(cover_reservation) = item.cover_reservation.as_ref() {
+            item.target_parent.attach_beneath_prepared(
+                &item.mountpoint,
+                item.clone.clone(),
+                cover_reservation.mountpoint(),
+            )
         } else {
             item.target_parent
                 .attach_top(&item.mountpoint, item.clone.clone())
         };
         if let Err(error) = result {
             for committed in attached.iter().rev() {
-                let _: Result<Arc<MountFS>, _> = committed
+                committed
                     .target_parent
-                    .detach_exact_restoring_cover(&committed.clone);
+                    .detach_exact_restoring_prepared_cover(
+                        &committed.clone,
+                        committed
+                            .cover_reservation
+                            .as_ref()
+                            .map(MountEdgeReservation::mountpoint),
+                        committed.expected_top.as_ref(),
+                    )
+                    .expect("propagation rollback must restore every exact mount edge");
             }
             abandon_prepared(&prepared.mounts);
             return Err(error);
@@ -428,20 +586,38 @@ pub(crate) fn commit_mount_propagation_locked(
         attached.push(item);
     }
 
-    for item in &prepared.mounts {
-        register_subtree(&item.clone);
-    }
+    prepared.registrations.commit();
     Ok(())
 }
 
 /// Linux makes every mount in a moved tree shared before propagating the tree
 /// into the destination parent's peers.  The complete tree is copied once per
 /// destination instead of the former path/BFS reconstruction.
-pub(crate) fn propagate_moved_tree_locked(
+pub(crate) struct PreparedMovePropagation {
+    propagation: Option<PreparedPropagation>,
+    invented: Vec<(Arc<MountFS>, PropagationType, Arc<PropagationGroup>)>,
+}
+
+fn restore_invented_groups(invented: Vec<(Arc<MountFS>, PropagationType, Arc<PropagationGroup>)>) {
+    for (mount, old_type, _) in invented.into_iter().rev() {
+        let prop = mount.propagation();
+        match old_type {
+            PropagationType::Private => prop.set_private(),
+            PropagationType::Slave => {
+                prop.clear_shared();
+                prop.clear_group_id();
+            }
+            PropagationType::Unbindable => prop.set_unbindable(),
+            PropagationType::Shared => unreachable!(),
+        }
+    }
+}
+
+pub(crate) fn prepare_moved_tree_propagation_locked(
     target_parent: &Arc<MountFS>,
     moved_root: &Arc<MountFS>,
     moved_root_mountpoint: &Arc<MountFSInode>,
-) -> Result<(), SystemError> {
+) -> Result<PreparedMovePropagation, SystemError> {
     let subtree = collect_subtree(moved_root);
     let mut invented = Vec::new();
     for mount in &subtree {
@@ -454,30 +630,37 @@ pub(crate) fn propagate_moved_tree_locked(
         let prop = mount.propagation();
         if !prop.is_shared() {
             prop.set_shared_with_group(group.clone());
-            register_peer(prop.peer_group_id(), mount);
         }
     }
     let propagation =
-        prepare_mount_propagation_locked(target_parent, moved_root_mountpoint, moved_root);
-    if let Err(error) = propagation.and_then(commit_mount_propagation_locked) {
-        // Linux discards invented group IDs when propagation preparation
-        // fails. Restore the pre-move state rather than leaking a semantic
-        // change from a failed move.
-        for (mount, old_type, _) in invented.into_iter().rev() {
-            let prop = mount.propagation();
-            unregister_peer(prop.peer_group_id(), &mount);
-            match old_type {
-                PropagationType::Private => prop.set_private(),
-                PropagationType::Slave => {
-                    prop.clear_shared();
-                    prop.clear_group_id();
-                }
-                PropagationType::Unbindable => prop.set_unbindable(),
-                PropagationType::Shared => unreachable!(),
+        match prepare_mount_propagation_locked(target_parent, moved_root_mountpoint, moved_root) {
+            Ok(propagation) => propagation,
+            Err(error) => {
+                restore_invented_groups(invented);
+                return Err(error);
             }
-        }
+        };
+    Ok(PreparedMovePropagation {
+        propagation,
+        invented,
+    })
+}
+
+pub(crate) fn abort_moved_tree_propagation_locked(prepared: PreparedMovePropagation) {
+    abort_mount_propagation(prepared.propagation);
+    restore_invented_groups(prepared.invented);
+}
+
+pub(crate) fn commit_moved_tree_propagation_locked(
+    prepared: PreparedMovePropagation,
+) -> Result<(), SystemError> {
+    if let Err(error) = commit_mount_propagation_locked(prepared.propagation) {
+        restore_invented_groups(prepared.invented);
         return Err(error);
     }
+    // The propagation registration plan includes invented source groups and
+    // publishes them together with clone membership after every edge commits.
+    drop(prepared.invented);
     Ok(())
 }
 
@@ -553,20 +736,17 @@ fn propagated_umount_targets(
     // A deep slave's child is mastered by the corresponding child in the
     // immediately preceding layer, not by the original source child. Keep the
     // same parent->child projection that mount propagation uses.
-    let mut corresponding = BTreeMap::new();
-    corresponding.insert(parent_mnt.mount_id().data(), source_child.clone());
+    let mut corresponding = CorrespondingSources::new();
+    corresponding.insert(parent_mnt, source_child.clone());
     let mut result = Vec::new();
     for target in propagation_targets(parent_mnt) {
         let reference_child = match target.kind {
             PropagationTargetKind::Peer => source_child.clone(),
             PropagationTargetKind::Slave => {
-                let Some(master_parent) = target.master_parent.as_ref() else {
+                let Some(child) = corresponding.nearest(&target.mount)? else {
                     continue;
                 };
-                let Some(child) = corresponding.get(&master_parent.mount_id().data()) else {
-                    continue;
-                };
-                child.clone()
+                child
             }
         };
         let target_mountpoint = match target.mount.wrapper_for_dentry(mountpoint.shared_dentry()) {
@@ -578,7 +758,7 @@ fn propagated_umount_targets(
         else {
             continue;
         };
-        corresponding.insert(target.mount.mount_id().data(), child.clone());
+        corresponding.insert(&target.mount, child.clone());
         result.push((target.mount, target_mountpoint, child));
     }
     Ok(result)

--- a/kernel/src/process/namespace/propagation/event.rs
+++ b/kernel/src/process/namespace/propagation/event.rs
@@ -65,7 +65,11 @@ impl CorrespondingSources {
         let propagation = parent.propagation();
         let group_id = propagation.peer_group_id();
         if propagation.is_shared() && group_id.is_valid() {
-            self.peer_groups.entry(group_id.data()).or_insert(child);
+            // Linux propagate_one() advances last_source after every
+            // successfully materialized peer. Keep the newest child for the
+            // group so a later covered slave of an uncovered peer inherits
+            // from that nearest source rather than the event root.
+            self.peer_groups.insert(group_id.data(), child);
         }
     }
 

--- a/kernel/src/process/namespace/propagation/group.rs
+++ b/kernel/src/process/namespace/propagation/group.rs
@@ -455,6 +455,64 @@ where
         .map_err(|_| SystemError::ENOMEM)
 }
 
+/// Build complete peer-group replacements for mounts that will become
+/// discoverable at an event commit. Every final member vector and every new
+/// registry key is reserved before the first topology edge is published.
+pub(super) fn prepare_peer_registrations(
+    mounts: &[Arc<MountFS>],
+) -> Result<Vec<PreparedPeerGroupState>, SystemError> {
+    let mut additions = Vec::new();
+    additions
+        .try_reserve(mounts.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    for mount in mounts {
+        let propagation = mount.propagation();
+        let group_id = propagation.peer_group_id();
+        if propagation.is_shared() && group_id.is_valid() {
+            additions.push((group_id, mount.clone()));
+        }
+    }
+    additions.sort_unstable_by_key(|(group_id, _)| group_id.data());
+
+    let mut prepared = Vec::new();
+    prepared
+        .try_reserve(additions.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    let mut index = 0;
+    while index < additions.len() {
+        let group_id = additions[index].0;
+        let start = index;
+        while index < additions.len() && additions[index].0 == group_id {
+            index += 1;
+        }
+
+        let mut before_reserve = || Ok(());
+        let current = try_snapshot_peer_group(group_id, &mut before_reserve)?;
+        let mut members = Vec::new();
+        members
+            .try_reserve(current.len() + index - start)
+            .map_err(|_| SystemError::ENOMEM)?;
+        for member in current
+            .iter()
+            .chain(additions[start..index].iter().map(|(_, mount)| mount))
+        {
+            if members.iter().any(|existing: &Weak<MountFS>| {
+                existing
+                    .upgrade()
+                    .is_some_and(|existing| Arc::ptr_eq(&existing, member))
+            }) {
+                continue;
+            }
+            members.push(Arc::downgrade(member));
+        }
+        prepared.push(PreparedPeerGroupState::Replace(group_id.data(), members));
+    }
+
+    let new_group_keys = count_new_peer_group_keys(&prepared);
+    try_reserve_peer_group_keys(new_group_keys, &mut || Ok(()))?;
+    Ok(prepared)
+}
+
 /// Publish prepared registry membership without fallible allocation.
 ///
 /// The lifecycle lock is held by `PropagationChangeTransaction`; keep this

--- a/kernel/src/process/namespace/propagation/mod.rs
+++ b/kernel/src/process/namespace/propagation/mod.rs
@@ -17,8 +17,9 @@ pub use change::{
 };
 #[allow(unused_imports)]
 pub(crate) use event::{
-    abort_mount_propagation, commit_mount_propagation_locked, ensure_subtree_shared,
-    prepare_mount_propagation_locked, propagate_moved_tree_locked, PreparedPropagation,
+    abort_mount_propagation, abort_moved_tree_propagation_locked, commit_mount_propagation_locked,
+    commit_moved_tree_propagation_locked, ensure_subtree_shared, prepare_mount_propagation_locked,
+    prepare_moved_tree_propagation_locked, PreparedPropagation,
 };
 pub use event::{propagate_umount, propagation_umount_busy};
 #[allow(unused_imports)]

--- a/kernel/src/process/namespace/propagation/state.rs
+++ b/kernel/src/process/namespace/propagation/state.rs
@@ -342,6 +342,17 @@ impl MountPropagation {
         inner.slaves.push(slave);
     }
 
+    /// Reserve reverse slave-list storage before publishing topology edges.
+    /// `MOUNT_LIFECYCLE_LOCK` keeps topology writers from consuming this
+    /// capacity before the prepared event commits.
+    pub(crate) fn try_reserve_slaves(&self, additional: usize) -> Result<(), SystemError> {
+        self.inner
+            .lock()
+            .slaves
+            .try_reserve(additional)
+            .map_err(|_| SystemError::ENOMEM)
+    }
+
     /// Remove a slave mount
     pub fn remove_slave(&self, slave: &Weak<MountFS>) {
         let mut inner = self.inner.lock();

--- a/kernel/src/process/namespace/propagation/tests.rs
+++ b/kernel/src/process/namespace/propagation/tests.rs
@@ -135,12 +135,10 @@ fn test_peer_ring_scan_starts_after_middle_target() {
     let ring = get_peers(group_id, &target_b);
     assert!(Arc::ptr_eq(&ring[0], &peer_c));
     change_mnt_propagation(&target_b, PropagationType::Slave).unwrap();
-    assert!(
-        target_b
-            .propagation()
-            .master()
-            .is_some_and(|master| Arc::ptr_eq(&master, &peer_c))
-    );
+    assert!(target_b
+        .propagation()
+        .master()
+        .is_some_and(|master| Arc::ptr_eq(&master, &peer_c)));
 }
 
 #[test]
@@ -171,12 +169,10 @@ fn test_recursive_prepare_group_failure_changes_nothing() {
     assert!(matches!(result, Err(SystemError::ENOSPC)));
     assert!(root.propagation().is_private());
     assert!(child.propagation().is_private());
-    assert!(
-        first_group
-            .borrow()
-            .as_ref()
-            .is_some_and(|group| group.upgrade().is_none())
-    );
+    assert!(first_group
+        .borrow()
+        .as_ref()
+        .is_some_and(|group| group.upgrade().is_none()));
 }
 
 #[test]
@@ -205,12 +201,10 @@ fn test_recursive_prepare_capacity_failure_changes_nothing() {
 
     assert!(matches!(result, Err(SystemError::ENOMEM)));
     assert!(root.propagation().is_private());
-    assert!(
-        group_weak
-            .borrow()
-            .as_ref()
-            .is_some_and(|group| group.upgrade().is_none())
-    );
+    assert!(group_weak
+        .borrow()
+        .as_ref()
+        .is_some_and(|group| group.upgrade().is_none()));
 }
 
 #[test]
@@ -251,12 +245,10 @@ fn test_recursive_slave_chain_materializes_each_final_edge_once() {
     assert_eq!(external_slaves.len(), 3);
     for mount in [&mount_a, &mount_b, &mount_c] {
         assert!(!mount.propagation().is_shared());
-        assert!(
-            mount
-                .propagation()
-                .master()
-                .is_some_and(|master| Arc::ptr_eq(&master, &external))
-        );
+        assert!(mount
+            .propagation()
+            .master()
+            .is_some_and(|master| Arc::ptr_eq(&master, &external)));
         assert_eq!(
             external_slaves
                 .iter()
@@ -283,12 +275,10 @@ fn test_make_slave_preserves_new_masters_unrelated_slave() {
     assert_eq!(slaves.len(), 2);
     assert!(Arc::ptr_eq(&slaves[0], &target));
     assert!(Arc::ptr_eq(&slaves[1], &unrelated));
-    assert!(
-        unrelated
-            .propagation()
-            .master()
-            .is_some_and(|master| Arc::ptr_eq(&master, &peer))
-    );
+    assert!(unrelated
+        .propagation()
+        .master()
+        .is_some_and(|master| Arc::ptr_eq(&master, &peer)));
 }
 
 #[test]
@@ -300,28 +290,22 @@ fn test_nonshared_change_reparents_existing_slave_subtree_like_linux() {
     target.propagation().add_slave(Arc::downgrade(&child));
 
     change_mnt_propagation(&target, PropagationType::Slave).unwrap();
-    assert!(
-        target
-            .propagation()
-            .master()
-            .is_some_and(|current| Arc::ptr_eq(&current, &master))
-    );
-    assert!(
-        child
-            .propagation()
-            .master()
-            .is_some_and(|current| Arc::ptr_eq(&current, &master))
-    );
+    assert!(target
+        .propagation()
+        .master()
+        .is_some_and(|current| Arc::ptr_eq(&current, &master)));
+    assert!(child
+        .propagation()
+        .master()
+        .is_some_and(|current| Arc::ptr_eq(&current, &master)));
     assert!(target.propagation().slaves().is_empty());
 
     change_mnt_propagation(&target, PropagationType::Private).unwrap();
     assert!(target.propagation().master().is_none());
-    assert!(
-        child
-            .propagation()
-            .master()
-            .is_some_and(|current| Arc::ptr_eq(&current, &master))
-    );
+    assert!(child
+        .propagation()
+        .master()
+        .is_some_and(|current| Arc::ptr_eq(&current, &master)));
     assert!(target.propagation().slaves().is_empty());
 }
 
@@ -340,12 +324,10 @@ fn test_make_slave_prefers_exact_root_dentry_peer() {
     assert!(Arc::ptr_eq(&target.root_dentry(), &exact.root_dentry()));
     change_mnt_propagation(&target, PropagationType::Slave).unwrap();
 
-    assert!(
-        target
-            .propagation()
-            .master()
-            .is_some_and(|master| Arc::ptr_eq(&master, &exact))
-    );
+    assert!(target
+        .propagation()
+        .master()
+        .is_some_and(|master| Arc::ptr_eq(&master, &exact)));
 }
 
 #[test]
@@ -364,18 +346,14 @@ fn test_make_slave_selects_peer_as_master() {
     let prop_a = mount_a.propagation();
     assert!(prop_a.is_slave());
     assert!(!prop_a.is_shared());
-    assert!(
-        prop_a
-            .master()
-            .is_some_and(|master| Arc::ptr_eq(&master, &mount_b))
-    );
-    assert!(
-        mount_b
-            .propagation()
-            .slaves()
-            .iter()
-            .any(|slave| Arc::ptr_eq(slave, &mount_a))
-    );
+    assert!(prop_a
+        .master()
+        .is_some_and(|master| Arc::ptr_eq(&master, &mount_b)));
+    assert!(mount_b
+        .propagation()
+        .slaves()
+        .iter()
+        .any(|slave| Arc::ptr_eq(slave, &mount_a)));
 }
 
 #[test]
@@ -522,6 +500,27 @@ fn test_nearest_propagated_source_skips_unmaterialized_master() {
 }
 
 #[test]
+fn test_nearest_propagated_source_uses_latest_materialized_peer() {
+    let source = new_test_mount(MountPropagation::new_shared().unwrap());
+    let group = source.propagation().peer_group().unwrap();
+    let materialized_peer = new_test_mount(MountPropagation::new_shared_with_group(group.clone()));
+    let skipped_peer = new_test_mount(MountPropagation::new_shared_with_group(group));
+    let deep_slave = new_test_mount(MountPropagation::new_slave(Arc::downgrade(&skipped_peer)));
+
+    let source_child = new_test_mount(MountPropagation::new_private());
+    let peer_child = new_test_mount(MountPropagation::new_private());
+    let mut propagated_sources = CorrespondingSources::new();
+    propagated_sources.insert(&source, source_child);
+    propagated_sources.insert(&materialized_peer, peer_child.clone());
+
+    let selected = propagated_sources
+        .nearest(&deep_slave)
+        .unwrap()
+        .expect("a slave of an uncovered peer must use the latest peer source");
+    assert!(Arc::ptr_eq(&selected, &peer_child));
+}
+
+#[test]
 fn test_uncovered_slave_does_not_prune_covered_deeper_slave() {
     let master = new_test_mount(MountPropagation::new_shared().unwrap());
     register_peer(master.propagation().peer_group_id(), &master);
@@ -558,12 +557,10 @@ fn test_uncovered_slave_does_not_prune_covered_deeper_slave() {
     let deep_child = deep
         .lookup_top(&deep_mountpoint)
         .expect("the covered deeper slave must receive the propagation event");
-    assert!(
-        deep_child
-            .propagation()
-            .master()
-            .is_some_and(|source| Arc::ptr_eq(&source, &source_child))
-    );
+    assert!(deep_child
+        .propagation()
+        .master()
+        .is_some_and(|source| Arc::ptr_eq(&source, &source_child)));
 }
 
 #[test]
@@ -584,32 +581,26 @@ fn test_move_propagation_is_prepared_before_source_edge_changes() {
     let prepared =
         prepare_moved_tree_propagation_locked(&target, &moved_root, &target_mountpoint).unwrap();
 
-    assert!(
-        old_parent
-            .children_at(&old_mountpoint)
-            .iter()
-            .any(|child| Arc::ptr_eq(child, &moved_root))
-    );
+    assert!(old_parent
+        .children_at(&old_mountpoint)
+        .iter()
+        .any(|child| Arc::ptr_eq(child, &moved_root)));
     assert!(moved_root.propagation().is_shared());
     assert!(target.lookup_top(&target_mountpoint).is_none());
-    assert!(
-        target_peer
-            .lookup_top(
-                &target_peer
-                    .wrapper_for_dentry(target_mountpoint.shared_dentry())
-                    .unwrap()
-            )
-            .is_none()
-    );
+    assert!(target_peer
+        .lookup_top(
+            &target_peer
+                .wrapper_for_dentry(target_mountpoint.shared_dentry())
+                .unwrap()
+        )
+        .is_none());
 
     abort_moved_tree_propagation_locked(prepared);
     assert!(moved_root.propagation().is_private());
-    assert!(
-        old_parent
-            .children_at(&old_mountpoint)
-            .iter()
-            .any(|child| Arc::ptr_eq(child, &moved_root))
-    );
+    assert!(old_parent
+        .children_at(&old_mountpoint)
+        .iter()
+        .any(|child| Arc::ptr_eq(child, &moved_root)));
 }
 
 #[test]

--- a/kernel/src/process/namespace/propagation/tests.rs
+++ b/kernel/src/process/namespace/propagation/tests.rs
@@ -135,10 +135,12 @@ fn test_peer_ring_scan_starts_after_middle_target() {
     let ring = get_peers(group_id, &target_b);
     assert!(Arc::ptr_eq(&ring[0], &peer_c));
     change_mnt_propagation(&target_b, PropagationType::Slave).unwrap();
-    assert!(target_b
-        .propagation()
-        .master()
-        .is_some_and(|master| Arc::ptr_eq(&master, &peer_c)));
+    assert!(
+        target_b
+            .propagation()
+            .master()
+            .is_some_and(|master| Arc::ptr_eq(&master, &peer_c))
+    );
 }
 
 #[test]
@@ -169,10 +171,12 @@ fn test_recursive_prepare_group_failure_changes_nothing() {
     assert!(matches!(result, Err(SystemError::ENOSPC)));
     assert!(root.propagation().is_private());
     assert!(child.propagation().is_private());
-    assert!(first_group
-        .borrow()
-        .as_ref()
-        .is_some_and(|group| group.upgrade().is_none()));
+    assert!(
+        first_group
+            .borrow()
+            .as_ref()
+            .is_some_and(|group| group.upgrade().is_none())
+    );
 }
 
 #[test]
@@ -201,10 +205,12 @@ fn test_recursive_prepare_capacity_failure_changes_nothing() {
 
     assert!(matches!(result, Err(SystemError::ENOMEM)));
     assert!(root.propagation().is_private());
-    assert!(group_weak
-        .borrow()
-        .as_ref()
-        .is_some_and(|group| group.upgrade().is_none()));
+    assert!(
+        group_weak
+            .borrow()
+            .as_ref()
+            .is_some_and(|group| group.upgrade().is_none())
+    );
 }
 
 #[test]
@@ -245,10 +251,12 @@ fn test_recursive_slave_chain_materializes_each_final_edge_once() {
     assert_eq!(external_slaves.len(), 3);
     for mount in [&mount_a, &mount_b, &mount_c] {
         assert!(!mount.propagation().is_shared());
-        assert!(mount
-            .propagation()
-            .master()
-            .is_some_and(|master| Arc::ptr_eq(&master, &external)));
+        assert!(
+            mount
+                .propagation()
+                .master()
+                .is_some_and(|master| Arc::ptr_eq(&master, &external))
+        );
         assert_eq!(
             external_slaves
                 .iter()
@@ -275,10 +283,12 @@ fn test_make_slave_preserves_new_masters_unrelated_slave() {
     assert_eq!(slaves.len(), 2);
     assert!(Arc::ptr_eq(&slaves[0], &target));
     assert!(Arc::ptr_eq(&slaves[1], &unrelated));
-    assert!(unrelated
-        .propagation()
-        .master()
-        .is_some_and(|master| Arc::ptr_eq(&master, &peer)));
+    assert!(
+        unrelated
+            .propagation()
+            .master()
+            .is_some_and(|master| Arc::ptr_eq(&master, &peer))
+    );
 }
 
 #[test]
@@ -290,22 +300,28 @@ fn test_nonshared_change_reparents_existing_slave_subtree_like_linux() {
     target.propagation().add_slave(Arc::downgrade(&child));
 
     change_mnt_propagation(&target, PropagationType::Slave).unwrap();
-    assert!(target
-        .propagation()
-        .master()
-        .is_some_and(|current| Arc::ptr_eq(&current, &master)));
-    assert!(child
-        .propagation()
-        .master()
-        .is_some_and(|current| Arc::ptr_eq(&current, &master)));
+    assert!(
+        target
+            .propagation()
+            .master()
+            .is_some_and(|current| Arc::ptr_eq(&current, &master))
+    );
+    assert!(
+        child
+            .propagation()
+            .master()
+            .is_some_and(|current| Arc::ptr_eq(&current, &master))
+    );
     assert!(target.propagation().slaves().is_empty());
 
     change_mnt_propagation(&target, PropagationType::Private).unwrap();
     assert!(target.propagation().master().is_none());
-    assert!(child
-        .propagation()
-        .master()
-        .is_some_and(|current| Arc::ptr_eq(&current, &master)));
+    assert!(
+        child
+            .propagation()
+            .master()
+            .is_some_and(|current| Arc::ptr_eq(&current, &master))
+    );
     assert!(target.propagation().slaves().is_empty());
 }
 
@@ -324,10 +340,12 @@ fn test_make_slave_prefers_exact_root_dentry_peer() {
     assert!(Arc::ptr_eq(&target.root_dentry(), &exact.root_dentry()));
     change_mnt_propagation(&target, PropagationType::Slave).unwrap();
 
-    assert!(target
-        .propagation()
-        .master()
-        .is_some_and(|master| Arc::ptr_eq(&master, &exact)));
+    assert!(
+        target
+            .propagation()
+            .master()
+            .is_some_and(|master| Arc::ptr_eq(&master, &exact))
+    );
 }
 
 #[test]
@@ -346,14 +364,18 @@ fn test_make_slave_selects_peer_as_master() {
     let prop_a = mount_a.propagation();
     assert!(prop_a.is_slave());
     assert!(!prop_a.is_shared());
-    assert!(prop_a
-        .master()
-        .is_some_and(|master| Arc::ptr_eq(&master, &mount_b)));
-    assert!(mount_b
-        .propagation()
-        .slaves()
-        .iter()
-        .any(|slave| Arc::ptr_eq(slave, &mount_a)));
+    assert!(
+        prop_a
+            .master()
+            .is_some_and(|master| Arc::ptr_eq(&master, &mount_b))
+    );
+    assert!(
+        mount_b
+            .propagation()
+            .slaves()
+            .iter()
+            .any(|slave| Arc::ptr_eq(slave, &mount_a))
+    );
 }
 
 #[test]
@@ -478,4 +500,146 @@ fn test_propagate_to_shared_slave_keeps_child_shared_slave() {
     assert!(child_b_prop.is_shared());
     assert_eq!(child_a_prop.peer_group_id(), child_b_prop.peer_group_id());
     assert_ne!(child_a_prop.peer_group_id(), source_child_group);
+}
+
+#[test]
+fn test_nearest_propagated_source_skips_unmaterialized_master() {
+    let master = new_test_mount(MountPropagation::new_shared().unwrap());
+    let skipped = new_test_mount(MountPropagation::new_slave(Arc::downgrade(&master)));
+    let deep = new_test_mount(MountPropagation::new_slave(Arc::downgrade(&skipped)));
+    master.propagation().add_slave(Arc::downgrade(&skipped));
+    skipped.propagation().add_slave(Arc::downgrade(&deep));
+
+    let source_child = new_test_mount(MountPropagation::new_private());
+    let mut propagated_sources = CorrespondingSources::new();
+    propagated_sources.insert(&master, source_child.clone());
+
+    let selected = propagated_sources
+        .nearest(&deep)
+        .unwrap()
+        .expect("a deeper slave must fall back to the nearest materialized master");
+    assert!(Arc::ptr_eq(&selected, &source_child));
+}
+
+#[test]
+fn test_uncovered_slave_does_not_prune_covered_deeper_slave() {
+    let master = new_test_mount(MountPropagation::new_shared().unwrap());
+    register_peer(master.propagation().peer_group_id(), &master);
+
+    // The uncovered peer models a narrow bind root in the source peer group.
+    // The deeper slave deliberately has the master's wider object view, so
+    // Linux keeps the peer layer's last source and still propagates to it.
+    let group = master.propagation().peer_group().unwrap();
+    let skipped = new_test_mount(MountPropagation::new_shared_with_group(group));
+    register_peer(master.propagation().peer_group_id(), &skipped);
+    let deep = master.deepcopy(None).unwrap();
+    deep.propagation().set_private();
+    deep.propagation().set_slave(Some(Arc::downgrade(&skipped)));
+    deep.activate().unwrap();
+    skipped.propagation().add_slave(Arc::downgrade(&deep));
+
+    let mountpoint = master.mountpoint_root_inode();
+    assert!(matches!(
+        skipped.wrapper_for_dentry(mountpoint.shared_dentry()),
+        Err(SystemError::EXDEV)
+    ));
+    let deep_mountpoint = deep.wrapper_for_dentry(mountpoint.shared_dentry()).unwrap();
+    let source_child = new_test_mount(MountPropagation::new_private());
+    source_child.set_self_mountpoint(Some(mountpoint.clone()));
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    let prepared = prepare_mount_propagation_locked(&master, &mountpoint, &source_child).unwrap();
+    master
+        .attach_top(&mountpoint, source_child.clone())
+        .unwrap();
+    commit_mount_propagation_locked(prepared).unwrap();
+
+    assert!(skipped.mount_children().is_empty());
+    let deep_child = deep
+        .lookup_top(&deep_mountpoint)
+        .expect("the covered deeper slave must receive the propagation event");
+    assert!(
+        deep_child
+            .propagation()
+            .master()
+            .is_some_and(|source| Arc::ptr_eq(&source, &source_child))
+    );
+}
+
+#[test]
+fn test_move_propagation_is_prepared_before_source_edge_changes() {
+    let old_parent = new_test_mount(MountPropagation::new_private());
+    let moved_root = new_test_mount(MountPropagation::new_private());
+    attach_test_child(&old_parent, &moved_root);
+    let old_mountpoint = moved_root.self_mountpoint().unwrap();
+
+    let target = new_test_mount(MountPropagation::new_shared().unwrap());
+    let target_peer = shared_copy(&target);
+    let target_group = target.propagation().peer_group_id();
+    register_peer(target_group, &target);
+    register_peer(target_group, &target_peer);
+    let target_mountpoint = target.mountpoint_root_inode();
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    let prepared =
+        prepare_moved_tree_propagation_locked(&target, &moved_root, &target_mountpoint).unwrap();
+
+    assert!(
+        old_parent
+            .children_at(&old_mountpoint)
+            .iter()
+            .any(|child| Arc::ptr_eq(child, &moved_root))
+    );
+    assert!(moved_root.propagation().is_shared());
+    assert!(target.lookup_top(&target_mountpoint).is_none());
+    assert!(
+        target_peer
+            .lookup_top(
+                &target_peer
+                    .wrapper_for_dentry(target_mountpoint.shared_dentry())
+                    .unwrap()
+            )
+            .is_none()
+    );
+
+    abort_moved_tree_propagation_locked(prepared);
+    assert!(moved_root.propagation().is_private());
+    assert!(
+        old_parent
+            .children_at(&old_mountpoint)
+            .iter()
+            .any(|child| Arc::ptr_eq(child, &moved_root))
+    );
+}
+
+#[test]
+fn test_tuck_under_rollback_restores_cover_in_place() {
+    let parent = new_test_mount(MountPropagation::new_private());
+    let mountpoint = parent.mountpoint_root_inode();
+    let covered = new_test_mount(MountPropagation::new_private());
+    covered.set_self_mountpoint(Some(mountpoint.clone()));
+    parent.attach_top(&mountpoint, covered.clone()).unwrap();
+
+    let propagated = new_test_mount(MountPropagation::new_private());
+    propagated.set_self_mountpoint(Some(mountpoint.clone()));
+    let cover_mountpoint = propagated.mountpoint_root_inode();
+    let _cover_reservation = propagated.reserve_mount_edge(&cover_mountpoint, 1).unwrap();
+
+    parent
+        .attach_beneath(&mountpoint, propagated.clone())
+        .unwrap();
+    assert!(Arc::ptr_eq(
+        &parent.lookup_top(&mountpoint).unwrap(),
+        &propagated
+    ));
+    assert!(covered.is_tucked_under());
+
+    let removed = parent.detach_exact_restoring_cover(&propagated).unwrap();
+    assert!(Arc::ptr_eq(&removed, &propagated));
+    assert!(Arc::ptr_eq(
+        &parent.lookup_top(&mountpoint).unwrap(),
+        &covered
+    ));
+    assert!(!covered.is_tucked_under());
+    assert!(propagated.mount_children().is_empty());
 }

--- a/user/apps/tests/dunitest/suites/normal/mount_move.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_move.cc
@@ -387,11 +387,17 @@ TEST_F(MountMoveTest, MoveIntoSharedDestPropagatesToPeer) {
     char dst_b[160] = {};
     char mp_a[224] = {};
     char mp_b[224] = {};
+    char src_child[224] = {};
+    char mp_a_child[256] = {};
+    char mp_b_child[256] = {};
     snprintf(src, sizeof(src), "%s/src", root_);
     snprintf(dst_a, sizeof(dst_a), "%s/dst_a", root_);
     snprintf(dst_b, sizeof(dst_b), "%s/dst_b", root_);
     snprintf(mp_a, sizeof(mp_a), "%s/mp", dst_a);
     snprintf(mp_b, sizeof(mp_b), "%s/mp", dst_b);
+    snprintf(src_child, sizeof(src_child), "%s/child", src);
+    snprintf(mp_a_child, sizeof(mp_a_child), "%s/child", mp_a);
+    snprintf(mp_b_child, sizeof(mp_b_child), "%s/child", mp_b);
 
     ASSERT_EQ(0, ensure_dir(src)) << strerror(errno);
     ASSERT_EQ(0, ensure_dir(dst_a)) << strerror(errno);
@@ -408,13 +414,20 @@ TEST_F(MountMoveTest, MoveIntoSharedDestPropagatesToPeer) {
     // The private mount to be moved.
     ASSERT_EQ(0, mount("", src, "ramfs", 0, nullptr)) << strerror(errno);
     ASSERT_EQ(0, create_marker(src, "moved_marker")) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(src_child)) << strerror(errno);
+    ASSERT_EQ(0, mount("", src_child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(src_child, "child_marker")) << strerror(errno);
 
     ASSERT_EQ(0, mount(src, mp_a, nullptr, MS_MOVE, nullptr)) << strerror(errno);
 
     // After moving to the shared target, clone propagates to peer dst_b/mp.
     EXPECT_TRUE(marker_exists(mp_a, "moved_marker"));
     EXPECT_TRUE(marker_exists(mp_b, "moved_marker"));
+    EXPECT_TRUE(marker_exists(mp_a_child, "child_marker"));
+    EXPECT_TRUE(marker_exists(mp_b_child, "child_marker"));
 
+    best_effort_umount(mp_b_child);
+    best_effort_umount(mp_a_child);
     best_effort_umount(mp_b);
     best_effort_umount(mp_a);
     best_effort_umount(dst_b);


### PR DESCRIPTION
## Summary

- prepare propagation clones, registry membership, and mount edge capacity before topology publication
- resolve skipped slave layers through exact mount and peer-group identities, matching Linux propagation semantics
- split move propagation into prepare/commit/abort and preserve exact edges for allocation-free rollback
- add kernel regression coverage and verify moved child subtrees in dunitest

Closes #2099

## Validation

- `make kernel`
- DragonOS QEMU: `mount_propagation_test` (14/14)
- DragonOS QEMU: `mount_move_test` (11/11)
- DragonOS QEMU: `mount_object_topology_test` (8/8)
- independent adversarial review: no unresolved P0/P1/P2 findings