### PR TITLE
perf(virtiofs): reuse create handles for atomic open

### DIFF
--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -732,6 +732,7 @@ struct FuseConnInner {
     init: FuseInitNegotiated,
     no_open: bool,
     no_opendir: bool,
+    no_create: bool,
     no_readdirplus: bool,
     no_fallocate: bool,
     no_flush: bool,
@@ -892,6 +893,7 @@ impl FuseConn {
                 init: FuseInitNegotiated::default(),
                 no_open: false,
                 no_opendir: false,
+                no_create: false,
                 no_readdirplus: false,
                 no_fallocate: false,
                 no_flush: false,
@@ -1345,6 +1347,14 @@ impl FuseConn {
             super::protocol::FUSE_OPENDIR => g.no_opendir = true,
             _ => {}
         }
+    }
+
+    pub fn no_create(&self) -> bool {
+        self.inner.lock().no_create
+    }
+
+    pub fn mark_no_create(&self) {
+        self.inner.lock().no_create = true;
     }
 
     pub fn use_readdirplus(&self) -> bool {

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -931,7 +931,7 @@ impl FuseNode {
         Ok(total)
     }
 
-    fn set_open_private_data(
+    pub(super) fn set_open_private_data(
         &self,
         data: &mut FilePrivateData,
         opcode: u32,
@@ -1000,7 +1000,7 @@ impl FuseNode {
         Ok(())
     }
 
-    fn finish_open_cache_state(
+    pub(super) fn finish_open_cache_state(
         &self,
         opcode: u32,
         flags: &FileFlags,

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -8,7 +8,7 @@ use crate::{
     filesystem::{
         page_cache::PageCache,
         vfs::{
-            file::{FileFlags, FileMode},
+            file::{FileFlags, FileMode, PreopenedFile},
             permission::PermissionMask,
             syscall::RenameFlags,
             utils::DName,
@@ -1093,6 +1093,10 @@ impl IndexNode for FuseNode {
             return self.create_with_data(name, file_type, mode, 0);
         }
 
+        if self.conn().no_create() {
+            return self.create_with_data(name, file_type, mode, 0);
+        }
+
         let inarg = FuseCreateIn {
             flags: FileFlags::O_RDONLY.bits(),
             mode: (InodeMode::S_IFREG | mode).bits(),
@@ -1103,7 +1107,10 @@ impl IndexNode for FuseNode {
 
         let payload = match self.conn().request(FUSE_CREATE, self.nodeid, &payload_in) {
             Ok(v) => v,
-            Err(SystemError::ENOSYS) => return self.create_with_data(name, file_type, mode, 0),
+            Err(SystemError::ENOSYS) => {
+                self.conn().mark_no_create();
+                return self.create_with_data(name, file_type, mode, 0);
+            }
             Err(e) => return Err(e),
         };
         let (entry, open_out) = Self::parse_create_reply(&payload)?;
@@ -1117,6 +1124,86 @@ impl IndexNode for FuseNode {
             );
         }
         self.create_node_from_entry(&entry, Some(name), FileType::File)
+    }
+
+    fn create_and_open(
+        &self,
+        name: &str,
+        mode: InodeMode,
+        flags: &FileFlags,
+    ) -> Result<PreopenedFile, SystemError> {
+        self.check_not_stale()?;
+        self.ensure_dir()?;
+        if self.conn().no_create() {
+            return Err(SystemError::ENOSYS);
+        }
+
+        // Linux fuse_create_open() forwards creation flags, excluding the
+        // tty-only flag. O_CLOEXEC is per-fd state and must not reach FUSE.
+        let file_flags = flags.bits() & !FileFlags::O_CLOEXEC.bits();
+        let create_flags = file_flags & !FileFlags::O_NOCTTY.bits();
+        let inarg = FuseCreateIn {
+            flags: create_flags,
+            mode: (InodeMode::S_IFREG | mode).bits(),
+            umask: 0,
+            open_flags: 0,
+        };
+        let payload_in = Self::pack_struct_and_name_payload(&inarg, name);
+        let payload = match self.conn().request(FUSE_CREATE, self.nodeid, &payload_in) {
+            Ok(payload) => payload,
+            Err(SystemError::ENOSYS) => {
+                self.conn().mark_no_create();
+                return Err(SystemError::ENOSYS);
+            }
+            Err(err) => return Err(err),
+        };
+        let (entry, open_out) = Self::parse_create_reply(&payload)?;
+
+        let inode = match self.create_node_from_entry(&entry, Some(name), FileType::File) {
+            Ok(inode) => inode,
+            Err(err) => {
+                if entry.nodeid != 0 {
+                    self.release_common_for_node(
+                        FUSE_RELEASE,
+                        entry.nodeid,
+                        open_out.fh,
+                        file_flags,
+                        0,
+                    );
+                }
+                return Err(err);
+            }
+        };
+        let fuse_inode = match inode.clone().downcast_arc::<FuseNode>() {
+            Some(inode) => inode,
+            None => {
+                self.release_common_for_node(
+                    FUSE_RELEASE,
+                    entry.nodeid,
+                    open_out.fh,
+                    file_flags,
+                    0,
+                );
+                return Err(SystemError::EIO);
+            }
+        };
+
+        let mut private_data = FilePrivateData::default();
+        if let Err(err) = fuse_inode.set_open_private_data(
+            &mut private_data,
+            FUSE_OPEN,
+            open_out.fh,
+            file_flags,
+            open_out.open_flags,
+            false,
+        ) {
+            self.release_common_for_node(FUSE_RELEASE, entry.nodeid, open_out.fh, file_flags, 0);
+            return Err(err);
+        }
+
+        let preopened = PreopenedFile::new(inode, private_data);
+        fuse_inode.finish_open_cache_state(FUSE_OPEN, flags, open_out.open_flags)?;
+        Ok(preopened)
     }
 
     fn create_with_data(

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -284,6 +284,47 @@ impl Default for FilePrivateData {
     }
 }
 
+/// Owns filesystem private data for an inode that has already been opened.
+///
+/// The guard stays armed until a [`File`] takes ownership.  This closes the
+/// filesystem handle on every error path between an atomic create/open and
+/// construction of the open file description.
+pub struct PreopenedFile {
+    inode: Arc<dyn IndexNode>,
+    private_data: Option<FilePrivateData>,
+}
+
+impl PreopenedFile {
+    pub fn new(inode: Arc<dyn IndexNode>, private_data: FilePrivateData) -> Self {
+        Self {
+            inode,
+            private_data: Some(private_data),
+        }
+    }
+
+    pub fn inode(&self) -> Arc<dyn IndexNode> {
+        self.inode.clone()
+    }
+
+    pub fn replace_inode(&mut self, inode: Arc<dyn IndexNode>) {
+        self.inode = inode;
+    }
+
+    fn take_private_data(&mut self) -> FilePrivateData {
+        self.private_data
+            .take()
+            .expect("preopened file private data already consumed")
+    }
+}
+
+impl Drop for PreopenedFile {
+    fn drop(&mut self) {
+        if let Some(data) = self.private_data.take() {
+            let _ = self.inode.close(Mutex::new(data).lock());
+        }
+    }
+}
+
 impl FilePrivateData {
     pub fn update_flags(&mut self, flags: FileFlags) -> Result<(), SystemError> {
         match self {
@@ -831,7 +872,13 @@ impl File {
             .downcast_arc::<MountFSInode>()
             .map(|inode| inode.mount_fs().try_pin_external())
             .transpose()?;
-        Self::new_with_private_data_and_mount_guard(inode, flags, private_data_init, mount_guard)
+        Self::new_with_private_data_and_mount_guard(
+            inode,
+            flags,
+            private_data_init,
+            mount_guard,
+            None,
+        )
     }
 
     /// Construct a pathname-backed file by consuming the mount pin acquired
@@ -847,6 +894,26 @@ impl File {
             flags,
             FilePrivateData::default(),
             mount_guard,
+            None,
+        );
+        drop(operation_guard);
+        file
+    }
+
+    /// Construct a pathname-backed file from an already-opened inode.
+    pub fn new_preopened_with_mount_guard(
+        preopened: PreopenedFile,
+        flags: FileFlags,
+        mount_guard: Option<MountExternalGuard>,
+        operation_guard: InodeRetentionGuard,
+    ) -> Result<Self, SystemError> {
+        let inode = preopened.inode();
+        let file = Self::new_with_private_data_and_mount_guard(
+            inode,
+            flags,
+            FilePrivateData::default(),
+            mount_guard,
+            Some(preopened),
         );
         drop(operation_guard);
         file
@@ -857,6 +924,7 @@ impl File {
         mut flags: FileFlags,
         private_data_init: FilePrivateData,
         mount_guard: Option<MountExternalGuard>,
+        mut preopened: Option<PreopenedFile>,
     ) -> Result<Self, SystemError> {
         let mut inode = inode;
         let mut file_type = inode.metadata()?.file_type;
@@ -912,11 +980,20 @@ impl File {
         let inode_retention =
             InodeRetentionGuard::new(inode.clone(), InodeRetentionKind::OpenFileDescription)?;
 
-        let private_data = Mutex::new(private_data_init);
+        if is_path && preopened.is_some() {
+            return Err(SystemError::EINVAL);
+        }
+        let already_open = preopened.is_some();
+        let private_data = Mutex::new(match preopened.as_mut() {
+            Some(preopened) => preopened.take_private_data(),
+            None => private_data_init,
+        });
         if is_path {
             mode = FileMode::FMODE_PATH | FileMode::FMODE_OPENED;
         } else {
-            inode.open(private_data.lock(), &flags)?;
+            if !already_open {
+                inode.open(private_data.lock(), &flags)?;
+            }
 
             // 设置默认能力（由 inode 能力接口统一决定；避免 syscall 层/字符串特判）
             if inode.is_stream() {

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -49,7 +49,7 @@ use crate::{
 pub use self::inode_lifecycle::{EvictionEpoch, InodeRetentionKind, InodeRetentionState};
 pub use self::{file::FilePrivateData, mount::MountFS};
 use self::{
-    file::{FileFlags, FileMode},
+    file::{FileFlags, FileMode, PreopenedFile},
     utils::DName,
     vcore::generate_inode_id,
 };
@@ -792,6 +792,18 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
         // 若文件系统没有实现此方法，则默认调用其create_with_data方法。如果仍未实现，则会得到一个Err(-ENOSYS)的返回值
         return self.create_with_data(name, file_type, mode, 0);
+    }
+
+    /// Atomically create and open a regular file when supported by the
+    /// filesystem.  The returned guard owns the open handle until VFS builds
+    /// the corresponding open file description.
+    fn create_and_open(
+        &self,
+        _name: &str,
+        _mode: InodeMode,
+        _flags: &FileFlags,
+    ) -> Result<PreopenedFile, SystemError> {
+        Err(SystemError::ENOSYS)
     }
 
     /// @brief 在当前目录下创建一个新的inode，并传入一个简单的data字段，方便进行初始化。

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    file::{File, FileFlags, FileMode},
+    file::{File, FileFlags, FileMode, PreopenedFile},
     utils::DName,
     FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode, InodeRetentionKind,
     PollableInode, SetMetadataMask, SuperBlock, XattrFlags,
@@ -3299,6 +3299,38 @@ impl IndexNode for MountFSInode {
             &parent,
             DName::from(name),
         )?);
+    }
+
+    fn create_and_open(
+        &self,
+        name: &str,
+        mode: InodeMode,
+        flags: &FileFlags,
+    ) -> Result<PreopenedFile, SystemError> {
+        self.ensure_mount_writable()?;
+        let children_guard = self.dentry.children_gate.lock();
+        let mut preopened = self.dentry.inode.create_and_open(name, mode, flags)?;
+        let wrapped = {
+            let _namespace_guard = self
+                .mount_fs
+                .super_block_state
+                .dentry_namespace_lock
+                .write();
+            self.self_ref
+                .upgrade()
+                .ok_or(SystemError::ENOENT)
+                .and_then(|parent| {
+                    MountFSInode::new_child(
+                        preopened.inode(),
+                        self.mount_fs.clone(),
+                        &parent,
+                        DName::from(name),
+                    )
+                })
+        };
+        drop(children_guard);
+        preopened.replace_inode(wrapped?);
+        Ok(preopened)
     }
 
     fn link(&self, name: &str, other: &Arc<dyn IndexNode>) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -3,7 +3,7 @@ use system_error::SystemError;
 
 use super::{
     fcntl::AtFlags,
-    file::{File, FileFlags},
+    file::{File, FileFlags, PreopenedFile},
     mount::MountFlags,
     permission::PermissionMask,
     syscall::{OpenHow, OpenHowResolve},
@@ -294,6 +294,7 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
         follow_symlink,
     );
     let mut created = false;
+    let mut preopened: Option<PreopenedFile> = None;
     let resolved = match resolved {
         Ok(resolved) => resolved,
         Err(errno) => {
@@ -334,9 +335,25 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
                 let pcb = ProcessManager::current_pcb();
                 let umask = pcb.fs_struct().umask();
                 let create_mode = apply_umask_for_create(how.mode, umask);
-                // 创建文件
+                // Let filesystems with an atomic create/open operation carry
+                // the returned handle directly into the new File.  ENOSYS
+                // preserves the generic create-then-open fallback.
+                let mut create_flags = how.o_flags;
+                if create_flags.contains(FileFlags::O_EXCL) {
+                    create_flags.remove(FileFlags::O_TRUNC);
+                }
                 let inode: Arc<dyn IndexNode> =
-                    parent_inode.create(filename, FileType::File, create_mode)?;
+                    match parent_inode.create_and_open(filename, create_mode, &create_flags) {
+                        Ok(opened) => {
+                            let inode = opened.inode();
+                            preopened = Some(opened);
+                            inode
+                        }
+                        Err(SystemError::ENOSYS) => {
+                            parent_inode.create(filename, FileType::File, create_mode)?
+                        }
+                        Err(err) => return Err(err),
+                    };
                 created = true;
                 let created_path = ResolvedPath::new(inode)?;
                 drop(parent_resolved);
@@ -435,7 +452,12 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
         vfs_truncate(inode.clone(), 0)?;
     }
     let (inode, mount_guard, operation_guard) = resolved.into_parts();
-    let file: File = File::new_with_mount_guard(inode, how.o_flags, mount_guard, operation_guard)?;
+    let file: File = match preopened {
+        Some(opened) => {
+            File::new_preopened_with_mount_guard(opened, how.o_flags, mount_guard, operation_guard)?
+        }
+        None => File::new_with_mount_guard(inode, how.o_flags, mount_guard, operation_guard)?,
+    };
     let cloexec = how.o_flags.contains(FileFlags::O_CLOEXEC);
 
     // 把文件对象存入pcb

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1675,6 +1675,229 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_create_reuses_fuse_handle() {
+    const char *mp = "/tmp/test_fuse_create_handle";
+    const uint64_t create_fh = 0xcafe2019ULL;
+    int requested = O_CREAT | O_RDWR | O_TRUNC | O_APPEND | O_NONBLOCK | O_NOCTTY | O_CLOEXEC;
+    uint32_t expected_create = (uint32_t)(requested & ~(O_NOCTTY | O_CLOEXEC));
+    int f = -1;
+    if (ensure_dir(mp) != 0) return -1;
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0, init_done = 0;
+    volatile uint32_t create_count = 0, open_count = 0, write_count = 0;
+    volatile uint32_t flush_count = 0, release_count = 0, setattr_count = 0, create_flags = 0;
+    volatile uint64_t write_fh = 0, flush_fh = 0, release_fh = 0;
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.create_count = &create_count;
+    args.open_count = &open_count;
+    args.write_count = &write_count;
+    args.flush_count = &flush_count;
+    args.release_count = &release_count;
+    args.setattr_count = &setattr_count;
+    args.last_create_in_flags = &create_flags;
+    args.last_write_fh = &write_fh;
+    args.last_flush_fh = &flush_fh;
+    args.last_release_fh = &release_fh;
+    args.create_open_fh_override = create_fh;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_ATOMIC_O_TRUNC;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) goto fail_no_thread;
+    char opts[256], path[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) goto fail_thread;
+    if (fuseg_wait_init(&init_done) != 0) goto fail;
+    snprintf(path, sizeof(path), "%s/new.txt", mp);
+    f = open(path, requested, 0644);
+    if (f < 0 || write(f, "x", 1) != 1) goto fail;
+    close(f);
+    f = -1;
+    for (int i = 0; i < 200 && release_count < 1; i++) {
+        usleep(10 * 1000);
+    }
+
+    if (create_count != 1 || open_count != 0 || write_count != 1 || flush_count != 1 ||
+        release_count != 1 || setattr_count != 0 || create_flags != expected_create ||
+        write_fh != create_fh || flush_fh != create_fh || release_fh != create_fh) {
+        printf("[FAIL] create handle reuse create=%u open=%u write=%u flush=%u release=%u "
+               "flags=0%o expected=0%o fhs=%llx/%llx/%llx\n",
+               create_count, open_count, write_count, flush_count, release_count, create_flags,
+               expected_create, (unsigned long long)write_fh, (unsigned long long)flush_fh,
+               (unsigned long long)release_fh);
+        goto fail;
+    }
+    if (unlink(path) != 0) goto fail;
+    if (umount(mp) != 0) goto fail_no_umount;
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) close(f);
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+fail_thread:
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+fail_no_thread:
+    close(fd);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_create_enosys_falls_back_and_caches() {
+    const char *mp = "/tmp/test_fuse_create_enosys";
+    if (ensure_dir(mp) != 0) return -1;
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        rmdir(mp);
+        return -1;
+    }
+    volatile int stop = 0, init_done = 0;
+    volatile uint32_t create_count = 0, mknod_count = 0, open_count = 0, release_count = 0;
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.force_create_errno = ENOSYS;
+    args.create_count = &create_count;
+    args.mknod_count = &mknod_count;
+    args.open_count = &open_count;
+    args.release_count = &release_count;
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) goto fail_no_thread;
+    char opts[256], path[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) goto fail_thread;
+    if (fuseg_wait_init(&init_done) != 0) goto fail;
+    for (int i = 0; i < 2; i++) {
+        snprintf(path, sizeof(path), "%s/fallback-%d", mp, i);
+        int f = open(path, O_CREAT | O_RDWR, 0644);
+        if (f < 0) goto fail;
+        close(f);
+    }
+    for (int i = 0; i < 200 && release_count < 2; i++) {
+        usleep(10 * 1000);
+    }
+    if (create_count != 1 || mknod_count != 2 || open_count != 2 || release_count != 2) {
+        printf("[FAIL] create ENOSYS cache create=%u mknod=%u open=%u release=%u\n",
+               create_count, mknod_count, open_count, release_count);
+        goto fail;
+    }
+    if (umount(mp) != 0) goto fail_no_umount;
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+fail:
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+fail_thread:
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+fail_no_thread:
+    close(fd);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_invalid_create_reply_cleans_resources() {
+    const char *mp = "/tmp/test_fuse_create_cleanup";
+    const uint64_t create_fh = 0xbad2019ULL;
+    int bad_fd = -1;
+    if (ensure_dir(mp) != 0) return -1;
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        rmdir(mp);
+        return -1;
+    }
+    volatile int stop = 0, init_done = 0;
+    volatile uint32_t create_count = 0, open_count = 0, release_count = 0, forget_count = 0;
+    volatile uint64_t release_fh = 0, forget_nlookup = 0;
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.create_count = &create_count;
+    args.open_count = &open_count;
+    args.release_count = &release_count;
+    args.forget_count = &forget_count;
+    args.forget_nlookup_sum = &forget_nlookup;
+    args.last_release_fh = &release_fh;
+    args.create_open_fh_override = create_fh;
+    args.create_reply_mode_override = S_IFDIR | 0755;
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) goto fail_no_thread;
+    char opts[256], path[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) goto fail_thread;
+    if (fuseg_wait_init(&init_done) != 0) goto fail;
+    snprintf(path, sizeof(path), "%s/invalid", mp);
+    errno = 0;
+    bad_fd = open(path, O_CREAT | O_RDWR, 0644);
+    if (bad_fd >= 0) {
+        close(bad_fd);
+        goto fail;
+    }
+    if (errno != EIO) goto fail;
+    for (int i = 0; i < 200 && (release_count < 1 || forget_count < 1); i++) {
+        usleep(10 * 1000);
+    }
+    if (create_count != 1 || open_count != 0 || release_count != 1 || release_fh != create_fh ||
+        forget_count != 1 || forget_nlookup != 1) {
+        printf("[FAIL] invalid CREATE cleanup create=%u open=%u release=%u fh=%llx "
+               "forget=%u nlookup=%llu\n",
+               create_count, open_count, release_count, (unsigned long long)release_fh,
+               forget_count, (unsigned long long)forget_nlookup);
+        goto fail;
+    }
+    if (umount(mp) != 0) goto fail_no_umount;
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+fail:
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+fail_thread:
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+fail_no_thread:
+    close(fd);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_fsetfl_updates_fuse_io_flags() {
     const char *mp = "/tmp/test_fuse_fsetfl_flags";
     int requested = O_RDWR;
@@ -8377,6 +8600,18 @@ TEST(FuseExtended, FsyncEnosysCachedSuccess) {
 
 TEST(FuseExtended, OpenFlagsMatchLinuxMask) {
     ASSERT_EQ(0, ext_test_open_release_flags_match_linux());
+}
+
+TEST(FuseExtended, CreateReusesFuseHandleWithoutOpen) {
+    ASSERT_EQ(0, ext_test_create_reuses_fuse_handle());
+}
+
+TEST(FuseExtended, CreateEnosysFallsBackAndCaches) {
+    ASSERT_EQ(0, ext_test_create_enosys_falls_back_and_caches());
+}
+
+TEST(FuseExtended, InvalidCreateReplyCleansResources) {
+    ASSERT_EQ(0, ext_test_invalid_create_reply_cleans_resources());
 }
 
 TEST(FuseExtended, FsetflUpdatesFuseIoFlags) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -742,6 +742,7 @@ struct fuse_daemon_args {
     volatile uint32_t *fsync_count;
     volatile uint32_t *fsyncdir_count;
     volatile uint32_t *create_count;
+    volatile uint32_t *mknod_count;
     volatile uint32_t *rename2_count;
     volatile uint32_t *open_count;
     volatile uint32_t *opendir_count;
@@ -766,8 +767,10 @@ struct fuse_daemon_args {
     volatile uint32_t *read_count;
     volatile uint32_t *write_count;
     volatile uint32_t *last_open_in_flags;
+    volatile uint32_t *last_create_in_flags;
     volatile uint32_t *last_release_in_flags;
     volatile uint64_t *last_open_fh;
+    volatile uint64_t *last_flush_fh;
     volatile uint32_t *last_open_pid;
     volatile uint64_t *last_read_fh;
     volatile uint32_t *last_read_size;
@@ -816,6 +819,8 @@ struct fuse_daemon_args {
     uint64_t next_open_fh;
     uint64_t create_reuse_nodeid;
     uint64_t create_generation_override;
+    uint64_t create_open_fh_override;
+    uint32_t create_reply_mode_override;
     uint64_t link_generation_override;
     uint64_t hello_generation_override;
     const char *readdirplus_invalid_attr_name;
@@ -825,6 +830,7 @@ struct fuse_daemon_args {
     int allow_rename_replace;
     int has_hello_open_fh_override;
     int force_open_enosys;
+    int force_create_errno;
     int force_opendir_enosys;
     int force_flush_errno;
     int force_fsync_errno;
@@ -1441,9 +1447,16 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     }
-    case FUSE_FLUSH:
+    case FUSE_FLUSH: {
+        if (payload_len < sizeof(struct fuse_flush_in)) {
+            return -1;
+        }
+        const struct fuse_flush_in *in = (const struct fuse_flush_in *)payload;
         if (a->flush_count) {
             (*a->flush_count)++;
+        }
+        if (a->last_flush_fh) {
+            *a->last_flush_fh = in->fh;
         }
         if (a->last_flush_uid) {
             *a->last_flush_uid = h->uid;
@@ -1458,6 +1471,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             return fuse_write_reply(a->fd, h->unique, -a->force_flush_errno, NULL, 0);
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
+    }
     case FUSE_FSYNC: {
         if (payload_len < sizeof(struct fuse_fsync_in)) {
             return -1;
@@ -1626,6 +1640,12 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (a->create_count) {
             (*a->create_count)++;
         }
+        if (a->last_create_in_flags) {
+            *a->last_create_in_flags = in->flags;
+        }
+        if (a->force_create_errno > 0) {
+            return fuse_write_reply(a->fd, h->unique, -a->force_create_errno, NULL, 0);
+        }
         struct simplefs_node *p = simplefs_find_node(&a->fs, h->nodeid);
         if (!p || !simplefs_node_is_dir(p)) {
             return fuse_write_reply(a->fd, h->unique, -ENOTDIR, NULL, 0);
@@ -1648,7 +1668,8 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         nnode->is_dir = 0;
         nnode->is_symlink = 0;
         nnode->mode = in->mode;
-        nnode->open_fh = nnode->nodeid;
+        nnode->open_fh = a->create_open_fh_override != 0 ? a->create_open_fh_override
+                                                        : nnode->nodeid;
         strncpy(nnode->name, name, sizeof(nnode->name) - 1);
         nnode->name[sizeof(nnode->name) - 1] = '\0';
         nnode->size = 0;
@@ -1661,6 +1682,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         out.entry.nodeid = nnode->nodeid;
         out.entry.generation = nnode->generation;
         simplefs_fill_attr(nnode, &out.entry.attr);
+        if (a->create_reply_mode_override != 0) {
+            out.entry.attr.mode = a->create_reply_mode_override;
+        }
         out.open_out.fh = nnode->open_fh;
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
     }
@@ -1783,6 +1807,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         name = (const char *)(payload + name_off);
         if (name[payload_len - name_off - 1] != '\0')
             return -1;
+        if (!is_dir && a->mknod_count) {
+            (*a->mknod_count)++;
+        }
         if (simplefs_find_child(&a->fs, h->nodeid, name)) {
             return fuse_write_reply(a->fd, h->unique, -EEXIST, NULL, 0);
         }


### PR DESCRIPTION
## Summary

- reuse the file handle returned by `FUSE_CREATE` instead of issuing `FUSE_RELEASE` followed by `FUSE_OPEN`
- add a VFS preopened-file guard that safely transfers ownership through mount wrapping and closes handles on failure
- cache `FUSE_CREATE` `ENOSYS` and preserve the Linux-compatible `MKNOD + OPEN` fallback
- add FUSE regression coverage for handle reuse, flag filtering, fallback caching, and error cleanup

## Root cause

DragonOS discarded the handle returned by `FUSE_CREATE` and then opened the new inode again. This added two FUSE requests per created file and amplified metadata-heavy virtiofs workloads.

## Validation

- `make kernel`
- `make all`
- Rust formatting check
- FuseCore: 5/5 passed
- FuseExtended: 63/63 passed
- 64-file metadata workload: 8 to 6 FUSE requests per file; redundant `FUSE_OPEN` count reduced from 64 to 0
- CubeSandbox 64-file create workload: median 2.79s to 2.06s (about 26% faster)
- CubeSandbox command and file-read workloads improved materially; large-file write throughput remains a separate bottleneck

Fixes #2019
