### PR TITLE
fix(namespace): implement propagated unmount transactions

### DIFF
--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1596,18 +1596,6 @@ impl MountFS {
             .and_then(|stack| stack.last().cloned())
     }
 
-    /// Return the chronologically first direct child at this exact mountpoint.
-    ///
-    /// Linux `__lookup_mnt()` uses this ordering for propagation events.  It is
-    /// deliberately different from [`Self::lookup_top`], which follows the
-    /// currently visible mount while resolving a pathname through a stack.
-    pub(crate) fn lookup_first(&self, mountpoint: &Arc<MountFSInode>) -> Option<Arc<MountFS>> {
-        self.mountpoints
-            .lock()
-            .get(&mountpoint.dentry.id)
-            .and_then(|stack| stack.first().cloned())
-    }
-
     pub fn children_at(&self, mountpoint: &Arc<MountFSInode>) -> Vec<Arc<MountFS>> {
         self.mountpoints
             .lock()

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -27,8 +27,8 @@ use crate::{
             propagation::{
                 abort_mount_propagation, commit_mount_propagation_locked, detach_mount_propagation,
                 ensure_subtree_shared, inherit_bind_mount_propagation,
-                prepare_mount_propagation_locked, propagate_umount, propagation_umount_busy,
-                MountPropagation,
+                prepare_mount_propagation_locked, propagate_umount_sources,
+                propagation_umount_busy, MountPropagation,
             },
         },
         ProcessManager,
@@ -403,6 +403,7 @@ struct MountLifecycle {
     state: MountLifecycleState,
     external_pins: usize,
     construction_reserved: bool,
+    propagation_attached: bool,
     detached_component: Option<Arc<DetachedMountComponent>>,
 }
 
@@ -1115,6 +1116,7 @@ impl MountFS {
                 state: MountLifecycleState::Constructing,
                 external_pins: 0,
                 construction_reserved: state_init.construction_reserved,
+                propagation_attached: true,
                 detached_component: None,
             }),
         });
@@ -1159,6 +1161,7 @@ impl MountFS {
                 state: MountLifecycleState::Constructing,
                 external_pins: 0,
                 construction_reserved: true,
+                propagation_attached: true,
                 detached_component: None,
             }),
         });
@@ -1380,6 +1383,133 @@ impl MountFS {
         }
     }
 
+    /// Remove one exact mount edge while moving every mount stacked on the
+    /// removed mount's root back to the removed edge in chronological order.
+    ///
+    /// This is the `umount_list()` restoration operation used by propagated
+    /// umount. Each tuple identifies whether that root child is restored to the
+    /// original parent (`true`) or retained below a lazy-detached parent
+    /// (`false`). Commit capacity is reserved during preflight.
+    pub(crate) fn detach_exact_restoring_root_children(
+        &self,
+        mount_fs: &Arc<MountFS>,
+        root_children: Vec<(Arc<MountFS>, bool)>,
+        reservation: &MountEdgeReservation,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        let original_mountpoint = mount_fs.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        if !Arc::ptr_eq(&original_mountpoint.mount_fs, &self.self_ref())
+            || !Arc::ptr_eq(&reservation.parent, &self.self_ref())
+            || !Arc::ptr_eq(reservation.mountpoint(), &original_mountpoint)
+            || Arc::ptr_eq(&self.self_ref(), mount_fs)
+        {
+            return Err(SystemError::EINVAL);
+        }
+        let root_mountpoint = mount_fs.mountpoint_root_inode();
+        let original_dentry = original_mountpoint.shared_dentry();
+        let root_dentry = root_mountpoint.shared_dentry();
+
+        with_dentry_mount_gates(Some(&original_dentry), Some(&root_dentry), || {
+            fn replace_edge(
+                parent_mountpoints: &mut HashMap<DentryId, Vec<Arc<MountFS>>>,
+                child_mountpoints: &mut HashMap<DentryId, Vec<Arc<MountFS>>>,
+                original_mountpoint: &Arc<MountFSInode>,
+                root_mountpoint: &Arc<MountFSInode>,
+                mount_fs: &Arc<MountFS>,
+                root_children: &[(Arc<MountFS>, bool)],
+            ) -> Result<(), SystemError> {
+                let parent_stack = parent_mountpoints
+                    .get(&original_mountpoint.dentry_id())
+                    .ok_or(SystemError::ENOENT)?;
+                let parent_index = parent_stack
+                    .iter()
+                    .position(|child| Arc::ptr_eq(child, mount_fs))
+                    .ok_or(SystemError::ENOENT)?;
+                let actual_root_children = child_mountpoints
+                    .get(&root_mountpoint.dentry_id())
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                if actual_root_children.len() != root_children.len()
+                    || actual_root_children
+                        .iter()
+                        .zip(root_children)
+                        .any(|(actual, (expected, _))| !Arc::ptr_eq(actual, expected))
+                {
+                    return Err(SystemError::EBUSY);
+                }
+
+                let parent_stack = parent_mountpoints
+                    .get_mut(&original_mountpoint.dentry_id())
+                    .expect("validated propagated-umount parent stack");
+                parent_stack.remove(parent_index);
+                let mut offset = 0;
+                for (child, restore) in root_children {
+                    if !restore {
+                        continue;
+                    }
+                    child.relocate_mountpoint(Some(original_mountpoint.clone()));
+                    child.tucked_under.store(false, Ordering::Release);
+                    parent_stack.insert(parent_index + offset, child.clone());
+                    offset += 1;
+                }
+                let remove_root_key = if root_children.is_empty() {
+                    false
+                } else {
+                    let root_stack = child_mountpoints
+                        .get_mut(&root_mountpoint.dentry_id())
+                        .expect("validated propagated-umount root stack");
+                    let mut index = 0;
+                    root_stack.retain(|_| {
+                        let retain = !root_children[index].1;
+                        index += 1;
+                        retain
+                    });
+                    root_stack.is_empty()
+                };
+                if remove_root_key {
+                    child_mountpoints.remove(&root_mountpoint.dentry_id());
+                }
+                Ok(())
+            }
+
+            if self.mount_id.data() < mount_fs.mount_id.data() {
+                let mut parent_mountpoints = self.mountpoints.lock();
+                let mut child_mountpoints = mount_fs.mountpoints.lock();
+                replace_edge(
+                    &mut parent_mountpoints,
+                    &mut child_mountpoints,
+                    &original_mountpoint,
+                    &root_mountpoint,
+                    mount_fs,
+                    &root_children,
+                )?;
+            } else {
+                let mut child_mountpoints = mount_fs.mountpoints.lock();
+                let mut parent_mountpoints = self.mountpoints.lock();
+                replace_edge(
+                    &mut parent_mountpoints,
+                    &mut child_mountpoints,
+                    &original_mountpoint,
+                    &root_mountpoint,
+                    mount_fs,
+                    &root_children,
+                )?;
+            }
+
+            let restored_count = root_children.iter().filter(|(_, restore)| *restore).count();
+            root_dentry
+                .mount_edges
+                .fetch_sub(restored_count, Ordering::Release);
+            if restored_count == 0 {
+                original_dentry.mount_edges.fetch_sub(1, Ordering::Release);
+            } else if restored_count > 1 {
+                original_dentry
+                    .mount_edges
+                    .fetch_add(restored_count - 1, Ordering::Release);
+            }
+            Ok(mount_fs.clone())
+        })
+    }
+
     fn restore_exact_cover(
         &self,
         mount_fs: &Arc<MountFS>,
@@ -1464,6 +1594,18 @@ impl MountFS {
             .lock()
             .get(&mountpoint.dentry.id)
             .and_then(|stack| stack.last().cloned())
+    }
+
+    /// Return the chronologically first direct child at this exact mountpoint.
+    ///
+    /// Linux `__lookup_mnt()` uses this ordering for propagation events.  It is
+    /// deliberately different from [`Self::lookup_top`], which follows the
+    /// currently visible mount while resolving a pathname through a stack.
+    pub(crate) fn lookup_first(&self, mountpoint: &Arc<MountFSInode>) -> Option<Arc<MountFS>> {
+        self.mountpoints
+            .lock()
+            .get(&mountpoint.dentry.id)
+            .and_then(|stack| stack.first().cloned())
     }
 
     pub fn children_at(&self, mountpoint: &Arc<MountFSInode>) -> Vec<Arc<MountFS>> {
@@ -1755,22 +1897,29 @@ impl MountFS {
     pub(crate) fn deactivate(&self) {
         let (should_remove, release_construction, should_leave_propagation) = {
             let mut lifecycle = self.lifecycle.lock();
-            match lifecycle.state {
+            let should_leave_propagation = lifecycle.propagation_attached;
+            lifecycle.propagation_attached = false;
+            let (should_remove, release_construction) = match lifecycle.state {
                 MountLifecycleState::Constructing => {
                     lifecycle.state = MountLifecycleState::Detached;
                     let reserved = lifecycle.construction_reserved;
                     lifecycle.construction_reserved = false;
-                    (false, reserved, true)
+                    (false, reserved)
                 }
                 MountLifecycleState::Live
                 | MountLifecycleState::Detaching
                 | MountLifecycleState::DetachedConnected => {
                     lifecycle.state = MountLifecycleState::Detached;
                     lifecycle.detached_component = None;
-                    (true, false, true)
+                    (true, false)
                 }
-                MountLifecycleState::Detached => (false, false, false),
-            }
+                MountLifecycleState::Detached => (false, false),
+            };
+            (
+                should_remove,
+                release_construction,
+                should_leave_propagation,
+            )
         };
         if should_leave_propagation {
             detach_mount_propagation(&self.self_ref());
@@ -1780,6 +1929,22 @@ impl MountFS {
         }
         if should_remove && self.super_block_state.remove_mount() {
             Self::schedule_final_shutdown(self.self_ref());
+        }
+    }
+
+    /// Record that a prepared batch graph commit already removed this mount's
+    /// propagation relationships. Later lifecycle teardown must not repeat it.
+    pub(crate) fn mark_propagation_detached(&self) {
+        self.lifecycle.lock().propagation_attached = false;
+    }
+
+    fn detach_propagation_once(&self) {
+        let should_detach = {
+            let mut lifecycle = self.lifecycle.lock();
+            core::mem::replace(&mut lifecycle.propagation_attached, false)
+        };
+        if should_detach {
+            detach_mount_propagation(&self.self_ref());
         }
     }
 
@@ -1895,7 +2060,7 @@ impl MountFS {
                 namespace.remove_mount_exact(mount);
             }
             mount.clear_namespace();
-            detach_mount_propagation(mount);
+            mount.detach_propagation_once();
         }
 
         let mut component_roots = vec![root.clone()];
@@ -2111,7 +2276,17 @@ impl MountFS {
         }
 
         let root_mountpoint = root.self_mountpoint().ok_or(SystemError::EINVAL)?;
-        root.commit_umount_at(&root_mountpoint, lazy)?;
+        if let Err(error) = propagate_umount_sources(&mounts, lazy) {
+            for mount in &mounts {
+                let mut lifecycle = mount.lifecycle.lock();
+                if lifecycle.state == MountLifecycleState::Detaching {
+                    lifecycle.state = MountLifecycleState::Live;
+                }
+            }
+            return Err(error);
+        }
+        root.commit_umount_at(&root_mountpoint, lazy)
+            .expect("prepared local umount edge commit cannot fail");
         // Final filesystem shutdown may sleep and may itself need pathname
         // operations. Never wait while holding the topology/admission lock.
         drop(_topology);
@@ -2127,6 +2302,7 @@ impl MountFS {
     /// pre-detach sync; final shared-superblock shutdown remains deferred until
     /// every mount and external pin is gone.
     pub fn umount_with_mode(&self, lazy: bool) -> Result<Arc<MountFS>, SystemError> {
+        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
         let mountpoint = self.self_mountpoint().ok_or(SystemError::EINVAL)?;
 
         if !lazy && propagation_umount_busy(&mountpoint.mount_fs, &mountpoint) {
@@ -2143,8 +2319,14 @@ impl MountFS {
             }
             lifecycle.state = MountLifecycleState::Detaching;
         }
-
-        self.commit_umount_at(&mountpoint, lazy)
+        if let Err(error) = propagate_umount_sources(core::slice::from_ref(&self.self_ref()), lazy)
+        {
+            self.lifecycle.lock().state = MountLifecycleState::Live;
+            return Err(error);
+        }
+        Ok(self
+            .commit_umount_at(&mountpoint, lazy)
+            .expect("prepared local umount edge commit cannot fail"))
     }
 
     fn commit_umount_at(
@@ -2155,12 +2337,6 @@ impl MountFS {
         let parent = mountpoint.mount_fs();
         let this_mount = self.self_ref();
 
-        // Propagation performs a full preflight and commits only peer/slave
-        // copies. Keep the local edge intact until that transaction succeeds,
-        // so failure needs no local topology rollback.
-        if parent.propagation().is_shared() {
-            propagate_umount(&parent, mountpoint, &this_mount, lazy)?;
-        }
         let result = parent.detach_exact(&this_mount);
 
         if result.is_ok() {

--- a/kernel/src/process/namespace/propagation/change.rs
+++ b/kernel/src/process/namespace/propagation/change.rs
@@ -87,6 +87,14 @@ struct PreparedMountStateUpdate {
     state: PreparedMountPropagationState,
 }
 
+/// Allocation-complete final propagation graph for mounts that are about to
+/// leave a namespace. The topology lock is owned by the caller.
+pub(super) struct PreparedPropagationRemoval {
+    mount_states: HashMap<GraphMountId, PreparedMountStateUpdate>,
+    peer_groups: Vec<PreparedPeerGroupState>,
+    removals: Vec<Arc<MountFS>>,
+}
+
 pub(super) struct PropagationChangeTransaction {
     _topology_guard: MutexGuard<'static, ()>,
     mount_states: HashMap<GraphMountId, PreparedMountStateUpdate>,
@@ -402,6 +410,100 @@ impl PropagationGraph {
             }
         }
         Ok(())
+    }
+}
+
+impl PreparedPropagationRemoval {
+    pub(super) fn prepare_locked(targets: &[Arc<MountFS>]) -> Result<Self, SystemError> {
+        let mut before_reserve = || Ok(());
+        let mut graph = PropagationGraph::new(targets.len(), &mut before_reserve)?;
+        let mut target_ids = Vec::new();
+        reserve_vec(&mut target_ids, targets.len(), &mut before_reserve)?;
+        let mut removals = Vec::new();
+        reserve_vec(&mut removals, targets.len(), &mut before_reserve)?;
+        for target in targets {
+            if target_ids.contains(&target.mount_id()) {
+                continue;
+            }
+            graph.capture_component(target.clone(), &mut before_reserve)?;
+            target_ids.push(target.mount_id());
+            removals.push(target.clone());
+        }
+        for target in &removals {
+            let propagation = target.propagation();
+            if propagation.is_shared() {
+                graph.capture_group(propagation.peer_group_id(), target, &mut before_reserve)?;
+            }
+        }
+        let mut alloc_group = PropagationGroup::alloc;
+        graph.simulate_change(
+            &target_ids,
+            PropagationType::Private,
+            &mut alloc_group,
+            &mut before_reserve,
+        )?;
+
+        let mut mount_states = HashMap::new();
+        reserve_map(&mut mount_states, graph.nodes.len(), &mut before_reserve)?;
+        for id in &graph.order {
+            let node = graph.nodes.get(id).unwrap();
+            let mut slaves = Vec::new();
+            reserve_vec(&mut slaves, node.slaves.len(), &mut before_reserve)?;
+            slaves.extend(
+                node.slaves
+                    .iter()
+                    .map(|slave| Arc::downgrade(&graph.nodes.get(slave).unwrap().mount)),
+            );
+            let master = node
+                .master
+                .map(|master| Arc::downgrade(&graph.nodes.get(&master).unwrap().mount));
+            mount_states.insert(
+                *id,
+                PreparedMountStateUpdate {
+                    mount: node.mount.clone(),
+                    state: PreparedMountPropagationState {
+                        flags: node.flags,
+                        peer_group: node.peer_group.clone(),
+                        master,
+                        slaves,
+                    },
+                },
+            );
+        }
+        let mut peer_groups = Vec::new();
+        reserve_vec(&mut peer_groups, graph.groups.len(), &mut before_reserve)?;
+        for (group_id, group) in graph.groups {
+            if group.members.is_empty() {
+                peer_groups.push(PreparedPeerGroupState::Remove(group_id));
+                continue;
+            }
+            let mut members = Vec::new();
+            reserve_vec(&mut members, group.members.len(), &mut before_reserve)?;
+            members.extend(
+                group
+                    .members
+                    .iter()
+                    .map(|member| Arc::downgrade(&graph.nodes.get(member).unwrap().mount)),
+            );
+            peer_groups.push(PreparedPeerGroupState::Replace(group_id, members));
+        }
+        try_reserve_peer_group_keys(count_new_peer_group_keys(&peer_groups), &mut before_reserve)?;
+        Ok(Self {
+            mount_states,
+            peer_groups,
+            removals,
+        })
+    }
+
+    pub(super) fn commit_locked(self) {
+        apply_prepared_peer_groups(self.peer_groups);
+        for (_, state) in self.mount_states {
+            let old_state = state.mount.propagation().replace_state(state.state);
+            drop(old_state);
+        }
+        for mount in self.removals {
+            mount.mark_propagation_detached();
+        }
     }
 }
 

--- a/kernel/src/process/namespace/propagation/event.rs
+++ b/kernel/src/process/namespace/propagation/event.rs
@@ -948,13 +948,13 @@ fn prepare_propagated_umount_targets(
         .try_reserve(result.len())
         .map_err(|_| SystemError::ENOMEM)?;
     children_by_parent.resize_with(result.len(), Vec::new);
-    for index in 0..result.len() {
+    for (index, target) in result.iter().enumerate() {
         if let Some(parent_index) = candidate_by_id
-            .get(&result[index].parent.mount_id().data())
+            .get(&target.parent.mount_id().data())
             .copied()
             .filter(|parent_index| {
                 !Arc::ptr_eq(
-                    &result[index].mountpoint.shared_dentry(),
+                    &target.mountpoint.shared_dentry(),
                     &result[*parent_index].child.root_dentry(),
                 )
             })
@@ -969,8 +969,8 @@ fn prepare_propagated_umount_targets(
     removed
         .try_reserve(result.len())
         .map_err(|_| SystemError::ENOMEM)?;
-    for index in 0..result.len() {
-        if result[index].remove {
+    for (index, target) in result.iter().enumerate() {
+        if target.remove {
             removed.push_back(index);
         }
     }

--- a/kernel/src/process/namespace/propagation/event.rs
+++ b/kernel/src/process/namespace/propagation/event.rs
@@ -741,7 +741,7 @@ pub(crate) fn propagate_umount_sources(
         if !target.parent.is_live()
             || target
                 .parent
-                .lookup_first(&target.mountpoint)
+                .lookup_top(&target.mountpoint)
                 .is_none_or(|candidate| !Arc::ptr_eq(&candidate, &target.child))
             || {
                 let actual = target
@@ -1039,7 +1039,11 @@ fn propagated_child_at(
     // Linux propagation is keyed only by `(parent mount, mountpoint dentry)`.
     // The child's propagation type may have changed independently after the
     // original mount event and therefore cannot be used as correspondence.
-    parent.lookup_first(mountpoint)
+    // Linux __lookup_mnt() returns the first mount-hash entry. New mounts are
+    // inserted at the hash head, so that entry is the visible topper. DragonOS
+    // stores stacks oldest-to-newest and therefore represents the same rule as
+    // Vec::last() through lookup_top().
+    parent.lookup_top(mountpoint)
 }
 
 /// Preflight the propagation set before ordinary umount mutates topology.

--- a/kernel/src/process/namespace/propagation/event.rs
+++ b/kernel/src/process/namespace/propagation/event.rs
@@ -1,10 +1,10 @@
 //! Mount, move, and unmount event propagation across peer/slave topology.
 
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, VecDeque};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use hashbrown::HashSet;
+use hashbrown::{HashMap, HashSet};
 use system_error::SystemError;
 
 use crate::filesystem::vfs::{
@@ -12,6 +12,7 @@ use crate::filesystem::vfs::{
     MountFS,
 };
 
+use super::change::PreparedPropagationRemoval;
 use super::group::{
     apply_prepared_peer_groups, get_peers, prepare_peer_registrations, PreparedPeerGroupState,
     PropagationGroup,
@@ -680,35 +681,78 @@ pub(crate) fn commit_moved_tree_propagation_locked(
 /// # Returns
 /// * `Ok(())` on success
 /// * `Err(SystemError)` on failure
-pub fn propagate_umount(
+#[cfg(test)]
+pub(super) fn propagate_umount(
     parent_mnt: &Arc<MountFS>,
     mountpoint: &Arc<MountFSInode>,
     source_child: &Arc<MountFS>,
     lazy: bool,
 ) -> Result<(), SystemError> {
-    let propagation = parent_mnt.propagation();
-
-    // Only propagate for shared mounts
-    if !propagation.is_shared() {
-        return Ok(());
+    if source_child
+        .self_mountpoint()
+        .as_ref()
+        .is_none_or(|source_mp| !Arc::ptr_eq(source_mp, mountpoint))
+        || !Arc::ptr_eq(&mountpoint.mount_fs(), parent_mnt)
+    {
+        return Err(SystemError::EINVAL);
     }
+    propagate_umount_sources(core::slice::from_ref(source_child), lazy)
+}
 
-    // log::debug!(
-    //     "propagate_umount: propagating umount from group {} to peers",
-    //     group_id.0
-    // );
-
-    let prepared = propagated_umount_targets(parent_mnt, mountpoint, source_child)?;
+/// Propagate removal of a complete local umount list. `sources` is ordered
+/// deepest-first, matching `MountFS::umount_subtree_with_mode()`.
+pub(crate) fn propagate_umount_sources(
+    sources: &[Arc<MountFS>],
+    lazy: bool,
+) -> Result<(), SystemError> {
+    for source in sources {
+        let mountpoint = source.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        if !mountpoint
+            .mount_fs()
+            .children_at(&mountpoint)
+            .iter()
+            .any(|child| Arc::ptr_eq(child, source))
+        {
+            return Err(SystemError::EBUSY);
+        }
+    }
+    let mut prepared = prepare_propagated_umount_targets(sources, lazy, true)?;
+    let mut graph_targets = Vec::new();
+    let graph_target_count = sources
+        .len()
+        .checked_add(prepared.len())
+        .ok_or(SystemError::ENOMEM)?;
+    graph_targets
+        .try_reserve(graph_target_count)
+        .map_err(|_| SystemError::ENOMEM)?;
+    graph_targets.extend(sources.iter().cloned());
+    graph_targets.extend(
+        prepared
+            .iter()
+            .filter(|target| target.remove)
+            .map(|target| target.child.clone()),
+    );
+    let graph = PreparedPropagationRemoval::prepare_locked(&graph_targets)?;
 
     // The caller serializes detach through MOUNT_LIFECYCLE_LOCK. Validate the
     // whole set before the first mutation, then every detach below is an
     // invariant-preserving exact-object operation.
-    for (target, target_mountpoint, child) in &prepared {
-        if !target.is_live()
-            || !target
-                .children_at(target_mountpoint)
-                .iter()
-                .any(|candidate| Arc::ptr_eq(candidate, child))
+    for target in &prepared {
+        if !target.parent.is_live()
+            || target
+                .parent
+                .lookup_first(&target.mountpoint)
+                .is_none_or(|candidate| !Arc::ptr_eq(&candidate, &target.child))
+            || {
+                let actual = target
+                    .child
+                    .children_at(&target.child.mountpoint_root_inode());
+                actual.len() != target.root_children_snapshot.len()
+                    || actual
+                        .iter()
+                        .zip(&target.root_children_snapshot)
+                        .any(|(actual, expected)| !Arc::ptr_eq(actual, expected))
+            }
         {
             return Err(SystemError::EBUSY);
         }
@@ -717,53 +761,273 @@ pub fn propagate_umount(
     // corresponding propagation roots before gathering them for umount.  The
     // protected descendants remain locked and, for lazy detach, connected to
     // their detached component.
-    for (_, _, child) in &prepared {
-        child.unlock_mount();
+    for target in &prepared {
+        if target.unlock_root {
+            target.child.unlock_mount();
+        }
     }
-    for (target, _, child) in &prepared {
-        target.detach_exact_restoring_cover(child)?;
+    let max_depth = prepared
+        .iter()
+        .map(|target| target.depth)
+        .max()
+        .unwrap_or(0);
+    for depth in (0..=max_depth).rev() {
+        for target in prepared
+            .iter_mut()
+            .filter(|target| target.disconnect && target.depth == depth)
+        {
+            let reservation = target
+                .reservation
+                .as_ref()
+                .expect("removable propagated umount target has a reservation");
+            target
+                .parent
+                .detach_exact_restoring_root_children(
+                    &target.child,
+                    core::mem::take(&mut target.root_children_commit),
+                    reservation,
+                )
+                .expect("validated propagated umount edge commit cannot fail");
+        }
     }
-    for (_, _, child) in prepared {
-        child.set_self_mountpoint(None);
-        MountFS::finish_disconnected_umount(&child, lazy)?;
+    graph.commit_locked();
+    for depth in (0..=max_depth).rev() {
+        for target in prepared
+            .iter()
+            .filter(|target| target.disconnect && target.depth == depth)
+        {
+            target.child.set_self_mountpoint(None);
+            MountFS::finish_disconnected_umount(&target.child, lazy)
+                .expect("detached prepared propagation root has valid teardown topology");
+        }
     }
     Ok(())
 }
 
-type PropagatedUmountTarget = (Arc<MountFS>, Arc<MountFSInode>, Arc<MountFS>);
+struct PropagatedUmountTarget {
+    parent: Arc<MountFS>,
+    mountpoint: Arc<MountFSInode>,
+    child: Arc<MountFS>,
+    root_children_snapshot: Vec<Arc<MountFS>>,
+    /// `(child, restore_to_original_parent)` after deeper commits complete.
+    root_children_commit: Vec<(Arc<MountFS>, bool)>,
+    nonroot_children: Vec<Arc<MountFS>>,
+    marked: bool,
+    remove: bool,
+    disconnect: bool,
+    unlock_root: bool,
+    depth: usize,
+    reservation: Option<MountEdgeReservation>,
+}
 
-fn propagated_umount_targets(
-    parent_mnt: &Arc<MountFS>,
-    mountpoint: &Arc<MountFSInode>,
-    source_child: &Arc<MountFS>,
+fn prepare_propagated_umount_targets(
+    sources: &[Arc<MountFS>],
+    lazy: bool,
+    reserve_commit_capacity: bool,
 ) -> Result<Vec<PropagatedUmountTarget>, SystemError> {
-    // A deep slave's child is mastered by the corresponding child in the
-    // immediately preceding layer, not by the original source child. Keep the
-    // same parent->child projection that mount propagation uses.
-    let mut corresponding = CorrespondingSources::new();
-    corresponding.insert(parent_mnt, source_child.clone());
-    let mut result = Vec::new();
-    for target in propagation_targets(parent_mnt) {
-        let reference_child = match target.kind {
-            PropagationTargetKind::Peer => source_child.clone(),
-            PropagationTargetKind::Slave => {
-                let Some(child) = corresponding.nearest(&target.mount)? else {
-                    continue;
-                };
-                child
-            }
-        };
-        let target_mountpoint = match target.mount.wrapper_for_dentry(mountpoint.shared_dentry()) {
-            Ok(mountpoint) => mountpoint,
-            Err(SystemError::EXDEV) => continue,
-            Err(error) => return Err(error),
-        };
-        let Some(child) = propagated_child_at(&target.mount, &target_mountpoint, &reference_child)
-        else {
+    let mut result: Vec<PropagatedUmountTarget> = Vec::new();
+    let mut candidate_by_id: HashMap<usize, usize> = HashMap::new();
+    result
+        .try_reserve(sources.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    for (depth, source) in sources.iter().rev().enumerate() {
+        let source_mountpoint = source.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        let parent = source_mountpoint.mount_fs();
+        if !parent.propagation().is_shared() {
             continue;
-        };
-        corresponding.insert(&target.mount, child.clone());
-        result.push((target.mount, target_mountpoint, child));
+        }
+        for target in propagation_targets(&parent) {
+            let target_mountpoint = target
+                .mount
+                .wrapper_for_existing_edge(source_mountpoint.shared_dentry());
+            let Some(child) = propagated_child_at(&target.mount, &target_mountpoint) else {
+                continue;
+            };
+            if let Some(index) = candidate_by_id.get(&child.mount_id().data()).copied() {
+                let existing = &mut result[index];
+                existing.unlock_root |= depth == 0;
+                existing.depth = existing.depth.min(depth);
+                continue;
+            }
+            let all_children = child.mount_children();
+            let root_children = child.children_at(&child.mountpoint_root_inode());
+            let mut nonroot_children = Vec::new();
+            nonroot_children
+                .try_reserve(all_children.len().saturating_sub(root_children.len()))
+                .map_err(|_| SystemError::ENOMEM)?;
+            for mounted_child in all_children {
+                if !root_children
+                    .iter()
+                    .any(|root_child| Arc::ptr_eq(root_child, &mounted_child))
+                {
+                    nonroot_children.push(mounted_child);
+                }
+            }
+            result.try_reserve(1).map_err(|_| SystemError::ENOMEM)?;
+            candidate_by_id
+                .try_reserve(1)
+                .map_err(|_| SystemError::ENOMEM)?;
+            let index = result.len();
+            candidate_by_id.insert(child.mount_id().data(), index);
+            result.push(PropagatedUmountTarget {
+                parent: target.mount,
+                mountpoint: target_mountpoint,
+                child,
+                root_children_snapshot: root_children,
+                root_children_commit: Vec::new(),
+                nonroot_children,
+                marked: false,
+                remove: false,
+                disconnect: false,
+                unlock_root: depth == 0,
+                depth,
+                reservation: None,
+            });
+        }
+    }
+
+    // Linux's repeated __propagate_umount(parent) walk is a fixed point. Use
+    // reverse dependencies so deep hostile trees remain O(V + E) while the
+    // global topology lock is held.
+    let mut dependents = Vec::new();
+    dependents
+        .try_reserve(result.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    dependents.resize_with(result.len(), Vec::new);
+    let mut remaining = Vec::new();
+    remaining
+        .try_reserve(result.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    remaining.resize(result.len(), 0usize);
+    let mut blocked = Vec::new();
+    blocked
+        .try_reserve(result.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    blocked.resize(result.len(), false);
+    for (index, target) in result.iter().enumerate() {
+        for child in &target.nonroot_children {
+            let Some(child_index) = candidate_by_id.get(&child.mount_id().data()).copied() else {
+                blocked[index] = true;
+                continue;
+            };
+            dependents[child_index]
+                .try_reserve(1)
+                .map_err(|_| SystemError::ENOMEM)?;
+            dependents[child_index].push(index);
+            remaining[index] += 1;
+        }
+    }
+    let mut ready = VecDeque::new();
+    ready
+        .try_reserve(result.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    for index in 0..result.len() {
+        if !blocked[index] && remaining[index] == 0 {
+            ready.push_back(index);
+        }
+    }
+    while let Some(index) = ready.pop_front() {
+        if result[index].marked {
+            continue;
+        }
+        result[index].marked = true;
+        for dependent in &dependents[index] {
+            remaining[*dependent] -= 1;
+            if !blocked[*dependent] && remaining[*dependent] == 0 {
+                ready.push_back(*dependent);
+            }
+        }
+    }
+    for target in &mut result {
+        target.remove = target.marked && (target.unlock_root || !target.child.is_locked());
+    }
+    // umount_list() includes marked locked children once a selected ancestor
+    // is removed, while a locked root without such an ancestor is restored.
+    let mut children_by_parent = Vec::new();
+    children_by_parent
+        .try_reserve(result.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    children_by_parent.resize_with(result.len(), Vec::new);
+    for index in 0..result.len() {
+        if let Some(parent_index) = candidate_by_id
+            .get(&result[index].parent.mount_id().data())
+            .copied()
+            .filter(|parent_index| {
+                !Arc::ptr_eq(
+                    &result[index].mountpoint.shared_dentry(),
+                    &result[*parent_index].child.root_dentry(),
+                )
+            })
+        {
+            children_by_parent[parent_index]
+                .try_reserve(1)
+                .map_err(|_| SystemError::ENOMEM)?;
+            children_by_parent[parent_index].push(index);
+        }
+    }
+    let mut removed = VecDeque::new();
+    removed
+        .try_reserve(result.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    for index in 0..result.len() {
+        if result[index].remove {
+            removed.push_back(index);
+        }
+    }
+    while let Some(parent_index) = removed.pop_front() {
+        for child_index in &children_by_parent[parent_index] {
+            if result[*child_index].marked && !result[*child_index].remove {
+                result[*child_index].remove = true;
+                removed.push_back(*child_index);
+            }
+        }
+    }
+
+    // Linux disconnect_mount() retains a locked selected child below a
+    // selected parent during lazy detach. It still leaves the namespace and
+    // propagation graph, but the highest disconnected ancestor owns teardown.
+    for index in 0..result.len() {
+        let parent_removed = candidate_by_id
+            .get(&result[index].parent.mount_id().data())
+            .is_some_and(|parent| result[*parent].remove);
+        result[index].disconnect = result[index].remove
+            && !(lazy
+                && !result[index].unlock_root
+                && result[index].child.is_locked()
+                && parent_removed);
+    }
+
+    // Once the closure is final, distinguish already-disconnected root
+    // children, lazy-locked retained children, and covers that must be restored.
+    for index in 0..result.len() {
+        let mut commit = Vec::new();
+        commit
+            .try_reserve(result[index].root_children_snapshot.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        for child in &result[index].root_children_snapshot {
+            match candidate_by_id.get(&child.mount_id().data()).copied() {
+                Some(child_index) if result[child_index].disconnect => {}
+                Some(child_index) if result[child_index].remove => {
+                    commit.push((child.clone(), false));
+                }
+                _ => commit.push((child.clone(), true)),
+            }
+        }
+        result[index].root_children_commit = commit;
+    }
+    if reserve_commit_capacity {
+        for target in result.iter_mut().filter(|target| target.disconnect) {
+            let restore_count = target
+                .root_children_commit
+                .iter()
+                .filter(|(_, restore)| *restore)
+                .count();
+            target.reservation = Some(
+                target
+                    .parent
+                    .reserve_mount_edge(&target.mountpoint, restore_count.saturating_sub(1))?,
+            );
+        }
     }
     Ok(result)
 }
@@ -771,22 +1035,11 @@ fn propagated_umount_targets(
 fn propagated_child_at(
     parent: &Arc<MountFS>,
     mountpoint: &Arc<MountFSInode>,
-    source_child: &Arc<MountFS>,
 ) -> Option<Arc<MountFS>> {
-    let source_prop = source_child.propagation();
-    parent
-        .children_at(mountpoint)
-        .into_iter()
-        .rev()
-        .find(|candidate| {
-            let candidate_prop = candidate.propagation();
-            (source_prop.is_shared()
-                && candidate_prop.is_shared()
-                && candidate_prop.peer_group_id() == source_prop.peer_group_id())
-                || candidate_prop
-                    .master()
-                    .is_some_and(|master| Arc::ptr_eq(&master, source_child))
-        })
+    // Linux propagation is keyed only by `(parent mount, mountpoint dentry)`.
+    // The child's propagation type may have changed independently after the
+    // original mount event and therefore cannot be used as correspondence.
+    parent.lookup_first(mountpoint)
 }
 
 /// Preflight the propagation set before ordinary umount mutates topology.
@@ -798,10 +1051,16 @@ pub fn propagation_umount_busy(parent_mnt: &Arc<MountFS>, mountpoint: &Arc<Mount
     let Some(source_child) = parent_mnt.lookup_top(mountpoint) else {
         return true;
     };
-    propagated_umount_targets(parent_mnt, mountpoint, &source_child)
+    prepare_propagated_umount_targets(core::slice::from_ref(&source_child), false, false)
         .map(|targets| {
-            targets.into_iter().any(|(_, _, child)| {
-                !child.mount_children().is_empty() || child.subtree_has_external_pins()
+            targets.into_iter().any(|target| {
+                // Linux checks the candidate refcount only when it has no
+                // children or one root topper. Other child layouts make
+                // the propagation branch non-busy (and either restore the
+                // candidate or restore its complete root stack later).
+                target.remove
+                    && target.root_children_snapshot.len() <= 1
+                    && target.child.has_external_pins()
             })
         })
         .unwrap_or(true)
@@ -817,14 +1076,14 @@ pub fn propagation_umount_busy(parent_mnt: &Arc<MountFS>, mountpoint: &Arc<Mount
 pub(super) fn umount_at_peer(
     peer_mnt: &Arc<MountFS>,
     source_mountpoint: &Arc<MountFSInode>,
-    source_child: &Arc<MountFS>,
+    _source_child: &Arc<MountFS>,
 ) -> Result<(), SystemError> {
     let peer_mountpoint = match peer_mnt.wrapper_for_dentry(source_mountpoint.shared_dentry()) {
         Ok(mountpoint) => mountpoint,
         Err(SystemError::EXDEV) => return Ok(()),
         Err(error) => return Err(error),
     };
-    let Some(child) = propagated_child_at(peer_mnt, &peer_mountpoint, source_child) else {
+    let Some(child) = propagated_child_at(peer_mnt, &peer_mountpoint) else {
         return Ok(());
     };
     peer_mnt.detach_exact(&child)?;

--- a/kernel/src/process/namespace/propagation/mod.rs
+++ b/kernel/src/process/namespace/propagation/mod.rs
@@ -15,13 +15,14 @@ mod tests;
 pub use change::{
     change_mnt_propagation_recursive, flags_to_propagation_type, is_propagation_change,
 };
+pub(crate) use event::propagate_umount_sources;
+pub use event::propagation_umount_busy;
 #[allow(unused_imports)]
 pub(crate) use event::{
     abort_mount_propagation, abort_moved_tree_propagation_locked, commit_mount_propagation_locked,
     commit_moved_tree_propagation_locked, ensure_subtree_shared, prepare_mount_propagation_locked,
     prepare_moved_tree_propagation_locked, PreparedPropagation,
 };
-pub use event::{propagate_umount, propagation_umount_busy};
 #[allow(unused_imports)]
 pub use group::{register_peer, PropagationGroupId};
 pub(crate) use state::detach_mount_propagation;

--- a/kernel/src/process/namespace/propagation/tests.rs
+++ b/kernel/src/process/namespace/propagation/tests.rs
@@ -492,6 +492,68 @@ fn test_propagated_umount_removes_visible_shadow_stack_top() {
 }
 
 #[test]
+fn test_propagated_umount_restores_tucked_lower_for_flat_source_stack() {
+    let (source_parent, peer_parent, source_mp, peer_mp, source_lower, peer_lower) =
+        shared_umount_fixture();
+    let source_top = new_test_mount(MountPropagation::new_private());
+    source_top.set_self_mountpoint(Some(source_mp.clone()));
+    source_parent
+        .attach_top(&source_mp, source_top.clone())
+        .unwrap();
+
+    let peer_top = new_test_mount(MountPropagation::new_private());
+    peer_top.set_self_mountpoint(Some(peer_mp.clone()));
+    peer_parent
+        .attach_beneath(&peer_mp, peer_top.clone())
+        .unwrap();
+
+    let source_stack = source_parent.children_at(&source_mp);
+    assert_eq!(source_stack.len(), 2);
+    assert!(Arc::ptr_eq(&source_stack[0], &source_lower));
+    assert!(Arc::ptr_eq(&source_stack[1], &source_top));
+    let peer_stack = peer_parent.children_at(&peer_mp);
+    assert_eq!(peer_stack.len(), 1);
+    assert!(Arc::ptr_eq(&peer_stack[0], &peer_top));
+    let peer_root = peer_top.mountpoint_root_inode();
+    let tucked_stack = peer_top.children_at(&peer_root);
+    assert_eq!(tucked_stack.len(), 1);
+    assert!(Arc::ptr_eq(&tucked_stack[0], &peer_lower));
+    assert!(Arc::ptr_eq(
+        &peer_lower.self_mountpoint().unwrap(),
+        &peer_root
+    ));
+    assert!(Arc::ptr_eq(&peer_lower.parent_mount().unwrap(), &peer_top));
+    assert!(peer_lower.is_tucked_under());
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount_sources(&[source_lower.clone(), source_top.clone()], true).unwrap();
+
+    // Linux umount_list() restores children mounted on a removed mount's
+    // root. The tucked lower copy therefore survives this flat-source race.
+    let source_stack = source_parent.children_at(&source_mp);
+    assert_eq!(source_stack.len(), 2);
+    assert!(Arc::ptr_eq(&source_stack[0], &source_lower));
+    assert!(Arc::ptr_eq(&source_stack[1], &source_top));
+    let restored = peer_parent.children_at(&peer_mp);
+    assert_eq!(restored.len(), 1);
+    assert!(Arc::ptr_eq(&restored[0], &peer_lower));
+    assert!(Arc::ptr_eq(
+        &peer_lower.self_mountpoint().unwrap(),
+        &peer_mp
+    ));
+    assert!(Arc::ptr_eq(
+        &peer_lower.parent_mount().unwrap(),
+        &peer_parent
+    ));
+    assert!(peer_lower.is_live());
+    assert!(!peer_lower.is_tucked_under());
+    assert!(peer_top.children_at(&peer_root).is_empty());
+    assert!(peer_top.self_mountpoint().is_none());
+    assert!(peer_top.parent_mount().is_none());
+    assert!(!peer_top.is_live());
+}
+
+#[test]
 fn test_propagated_umount_retains_target_with_nonroot_child() {
     let (source_parent, peer_parent, source_mp, peer_mp, source_child, peer_child) =
         shared_umount_fixture();

--- a/kernel/src/process/namespace/propagation/tests.rs
+++ b/kernel/src/process/namespace/propagation/tests.rs
@@ -6,9 +6,10 @@ use system_error::SystemError;
 
 use crate::filesystem::ramfs::RamFS;
 use crate::filesystem::vfs::{
-    mount::{MountFlags, MOUNT_LIFECYCLE_LOCK},
-    MountFS,
+    mount::{MountFSInode, MountFlags, MOUNT_LIFECYCLE_LOCK},
+    IndexNode, InodeMode, MountFS,
 };
+use crate::libs::casting::DowncastArc;
 
 use super::{change::*, event::*, group::*, state::*};
 
@@ -412,6 +413,282 @@ fn test_umount_at_peer_detaches_slave_from_master() {
     assert!(peer.lookup_top(&mountpoint).is_none());
     assert!(!child.propagation().is_slave());
     assert!(source_child.propagation().slaves().is_empty());
+}
+
+fn shared_umount_fixture() -> (
+    Arc<MountFS>,
+    Arc<MountFS>,
+    Arc<MountFSInode>,
+    Arc<MountFSInode>,
+    Arc<MountFS>,
+    Arc<MountFS>,
+) {
+    let source_parent = new_test_mount(MountPropagation::new_shared().unwrap());
+    let peer_parent = shared_copy(&source_parent);
+    let group = source_parent.propagation().peer_group_id();
+    register_peer(group, &source_parent);
+    register_peer(group, &peer_parent);
+
+    let source_mountpoint = source_parent.mountpoint_root_inode();
+    let peer_mountpoint = peer_parent
+        .wrapper_for_dentry(source_mountpoint.shared_dentry())
+        .unwrap();
+    let source_child = new_test_mount(MountPropagation::new_private());
+    let peer_child = new_test_mount(MountPropagation::new_private());
+    source_child.set_self_mountpoint(Some(source_mountpoint.clone()));
+    peer_child.set_self_mountpoint(Some(peer_mountpoint.clone()));
+    source_parent
+        .attach_top(&source_mountpoint, source_child.clone())
+        .unwrap();
+    peer_parent
+        .attach_top(&peer_mountpoint, peer_child.clone())
+        .unwrap();
+    (
+        source_parent,
+        peer_parent,
+        source_mountpoint,
+        peer_mountpoint,
+        source_child,
+        peer_child,
+    )
+}
+
+#[test]
+fn test_propagated_umount_uses_exact_edge_after_child_becomes_private() {
+    let (source_parent, peer_parent, source_mp, peer_mp, source_child, peer_child) =
+        shared_umount_fixture();
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount(&source_parent, &source_mp, &source_child, true).unwrap();
+
+    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(!peer_child.is_live());
+}
+
+#[test]
+fn test_propagated_umount_retains_target_with_nonroot_child() {
+    let (source_parent, peer_parent, source_mp, peer_mp, source_child, peer_child) =
+        shared_umount_fixture();
+    let nonroot = peer_child
+        .mountpoint_root_inode()
+        .mkdir("nested", InodeMode::S_IRWXU)
+        .unwrap()
+        .downcast_arc::<MountFSInode>()
+        .unwrap();
+    let blocker = new_test_mount(MountPropagation::new_private());
+    blocker.set_self_mountpoint(Some(nonroot.clone()));
+    peer_child.attach_top(&nonroot, blocker.clone()).unwrap();
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount(&source_parent, &source_mp, &source_child, false).unwrap();
+
+    assert!(peer_parent
+        .lookup_first(&peer_mp)
+        .is_some_and(|mount| Arc::ptr_eq(&mount, &peer_child)));
+    assert!(peer_child
+        .lookup_top(&nonroot)
+        .is_some_and(|mount| Arc::ptr_eq(&mount, &blocker)));
+}
+
+#[test]
+fn test_propagated_umount_restores_complete_root_stack_in_order() {
+    let (source_parent, peer_parent, source_mp, peer_mp, source_child, peer_child) =
+        shared_umount_fixture();
+    let root = peer_child.mountpoint_root_inode();
+    let first = new_test_mount(MountPropagation::new_private());
+    let second = new_test_mount(MountPropagation::new_private());
+    for child in [&first, &second] {
+        child.set_self_mountpoint(Some(root.clone()));
+        peer_child.attach_top(&root, child.clone()).unwrap();
+    }
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount(&source_parent, &source_mp, &source_child, false).unwrap();
+
+    let restored = peer_parent.children_at(&peer_mp);
+    assert_eq!(restored.len(), 2);
+    assert!(Arc::ptr_eq(&restored[0], &first));
+    assert!(Arc::ptr_eq(&restored[1], &second));
+    assert!(Arc::ptr_eq(
+        &restored[1].self_mountpoint().unwrap(),
+        &peer_mp
+    ));
+    assert!(peer_child.mount_children().is_empty());
+}
+
+#[test]
+fn test_propagated_lazy_umount_advances_from_descendant_to_parent() {
+    let source_parent = new_test_mount(MountPropagation::new_shared().unwrap());
+    let peer_parent = shared_copy(&source_parent);
+    let parent_group = source_parent.propagation().peer_group_id();
+    register_peer(parent_group, &source_parent);
+    register_peer(parent_group, &peer_parent);
+
+    let source_mp = source_parent.mountpoint_root_inode();
+    let peer_mp = peer_parent.wrapper_for_existing_edge(source_mp.shared_dentry());
+    let source_child = new_test_mount(MountPropagation::new_shared().unwrap());
+    let peer_child = shared_copy(&source_child);
+    let child_group = source_child.propagation().peer_group_id();
+    register_peer(child_group, &source_child);
+    register_peer(child_group, &peer_child);
+    source_child.set_self_mountpoint(Some(source_mp.clone()));
+    peer_child.set_self_mountpoint(Some(peer_mp.clone()));
+    source_parent
+        .attach_top(&source_mp, source_child.clone())
+        .unwrap();
+    peer_parent
+        .attach_top(&peer_mp, peer_child.clone())
+        .unwrap();
+
+    let source_nested = source_child
+        .mountpoint_root_inode()
+        .mkdir("nested", InodeMode::S_IRWXU)
+        .unwrap()
+        .downcast_arc::<MountFSInode>()
+        .unwrap();
+    let peer_nested = peer_child.wrapper_for_existing_edge(source_nested.shared_dentry());
+    let source_grandchild = new_test_mount(MountPropagation::new_private());
+    let peer_grandchild = new_test_mount(MountPropagation::new_private());
+    source_grandchild.set_self_mountpoint(Some(source_nested.clone()));
+    peer_grandchild.set_self_mountpoint(Some(peer_nested.clone()));
+    source_child
+        .attach_top(&source_nested, source_grandchild.clone())
+        .unwrap();
+    peer_child
+        .attach_top(&peer_nested, peer_grandchild.clone())
+        .unwrap();
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount_sources(&[source_grandchild, source_child], true).unwrap();
+
+    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(!peer_child.is_live());
+    assert!(!peer_grandchild.is_live());
+}
+
+#[test]
+fn test_propagated_umount_does_not_restore_selected_root_child() {
+    let (source_parent, peer_parent, source_mp, peer_mp, source_child, peer_child) =
+        shared_umount_fixture();
+    source_child
+        .propagation()
+        .set_shared_with_group(PropagationGroup::alloc().unwrap());
+    peer_child
+        .propagation()
+        .set_shared_with_group(source_child.propagation().peer_group().unwrap());
+    let child_group = source_child.propagation().peer_group_id();
+    register_peer(child_group, &source_child);
+    register_peer(child_group, &peer_child);
+
+    let source_root = source_child.mountpoint_root_inode();
+    let peer_root = peer_child.wrapper_for_existing_edge(source_root.shared_dentry());
+    let source_topper = new_test_mount(MountPropagation::new_private());
+    let peer_topper = new_test_mount(MountPropagation::new_private());
+    source_topper.set_self_mountpoint(Some(source_root.clone()));
+    peer_topper.set_self_mountpoint(Some(peer_root.clone()));
+    source_child
+        .attach_top(&source_root, source_topper.clone())
+        .unwrap();
+    peer_child
+        .attach_top(&peer_root, peer_topper.clone())
+        .unwrap();
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount_sources(&[source_topper, source_child], true).unwrap();
+
+    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(!peer_child.is_live());
+    assert!(!peer_topper.is_live());
+}
+
+#[test]
+fn test_propagated_umount_restores_locked_selected_root_child() {
+    let (_source_parent, peer_parent, _source_mp, peer_mp, source_child, peer_child) =
+        shared_umount_fixture();
+    source_child
+        .propagation()
+        .set_shared_with_group(PropagationGroup::alloc().unwrap());
+    peer_child
+        .propagation()
+        .set_shared_with_group(source_child.propagation().peer_group().unwrap());
+    let child_group = source_child.propagation().peer_group_id();
+    register_peer(child_group, &source_child);
+    register_peer(child_group, &peer_child);
+
+    let source_root = source_child.mountpoint_root_inode();
+    let peer_root = peer_child.wrapper_for_existing_edge(source_root.shared_dentry());
+    let source_topper = new_test_mount(MountPropagation::new_private());
+    let peer_topper = new_test_mount(MountPropagation::new_private());
+    source_topper.set_self_mountpoint(Some(source_root.clone()));
+    peer_topper.set_self_mountpoint(Some(peer_root.clone()));
+    source_child
+        .attach_top(&source_root, source_topper.clone())
+        .unwrap();
+    peer_child
+        .attach_top(&peer_root, peer_topper.clone())
+        .unwrap();
+    peer_topper.lock_mount();
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount_sources(&[source_topper, source_child], true).unwrap();
+
+    let restored = peer_parent.children_at(&peer_mp);
+    assert_eq!(restored.len(), 1);
+    assert!(Arc::ptr_eq(&restored[0], &peer_topper));
+    assert!(peer_topper.is_live());
+    assert!(Arc::ptr_eq(
+        &peer_topper.self_mountpoint().unwrap(),
+        &peer_mp
+    ));
+    assert!(!peer_child.is_live());
+}
+
+#[test]
+fn test_propagated_lazy_umount_keeps_locked_child_connected() {
+    let (source_parent, peer_parent, source_mp, peer_mp, source_child, peer_child) =
+        shared_umount_fixture();
+    source_child
+        .propagation()
+        .set_shared_with_group(PropagationGroup::alloc().unwrap());
+    peer_child
+        .propagation()
+        .set_shared_with_group(source_child.propagation().peer_group().unwrap());
+    let child_group = source_child.propagation().peer_group_id();
+    register_peer(child_group, &source_child);
+    register_peer(child_group, &peer_child);
+
+    let source_nested = source_child
+        .mountpoint_root_inode()
+        .mkdir("locked", InodeMode::S_IRWXU)
+        .unwrap()
+        .downcast_arc::<MountFSInode>()
+        .unwrap();
+    let peer_nested = peer_child.wrapper_for_existing_edge(source_nested.shared_dentry());
+    let source_grandchild = new_test_mount(MountPropagation::new_private());
+    let peer_grandchild = new_test_mount(MountPropagation::new_private());
+    source_grandchild.set_self_mountpoint(Some(source_nested.clone()));
+    peer_grandchild.set_self_mountpoint(Some(peer_nested.clone()));
+    source_child
+        .attach_top(&source_nested, source_grandchild.clone())
+        .unwrap();
+    peer_child
+        .attach_top(&peer_nested, peer_grandchild.clone())
+        .unwrap();
+    peer_grandchild.lock_mount();
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount_sources(&[source_grandchild, source_child], true).unwrap();
+
+    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(peer_child
+        .lookup_first(&peer_nested)
+        .is_some_and(|mount| Arc::ptr_eq(&mount, &peer_grandchild)));
+    assert!(Arc::ptr_eq(
+        &peer_grandchild.parent_mount().unwrap(),
+        &peer_child
+    ));
+    assert!(!peer_child.is_live());
+    assert!(!peer_grandchild.is_live());
 }
 
 #[test]

--- a/kernel/src/process/namespace/propagation/tests.rs
+++ b/kernel/src/process/namespace/propagation/tests.rs
@@ -461,8 +461,34 @@ fn test_propagated_umount_uses_exact_edge_after_child_becomes_private() {
     let _topology = MOUNT_LIFECYCLE_LOCK.lock();
     propagate_umount(&source_parent, &source_mp, &source_child, true).unwrap();
 
-    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(peer_parent.lookup_top(&peer_mp).is_none());
     assert!(!peer_child.is_live());
+}
+
+#[test]
+fn test_propagated_umount_removes_visible_shadow_stack_top() {
+    let (source_parent, peer_parent, source_mp, peer_mp, source_child, peer_lower) =
+        shared_umount_fixture();
+    let peer_top = new_test_mount(MountPropagation::new_private());
+    peer_top.set_self_mountpoint(Some(peer_mp.clone()));
+    peer_parent.attach_top(&peer_mp, peer_top.clone()).unwrap();
+
+    let initial_stack = peer_parent.children_at(&peer_mp);
+    assert_eq!(initial_stack.len(), 2);
+    assert!(Arc::ptr_eq(&initial_stack[0], &peer_lower));
+    assert!(Arc::ptr_eq(&initial_stack[1], &peer_top));
+
+    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+    propagate_umount(&source_parent, &source_mp, &source_child, false).unwrap();
+
+    let remaining_stack = peer_parent.children_at(&peer_mp);
+    assert_eq!(remaining_stack.len(), 1);
+    assert!(Arc::ptr_eq(&remaining_stack[0], &peer_lower));
+    assert!(peer_parent
+        .lookup_top(&peer_mp)
+        .is_some_and(|mount| Arc::ptr_eq(&mount, &peer_lower)));
+    assert!(peer_lower.is_live());
+    assert!(!peer_top.is_live());
 }
 
 #[test]
@@ -483,7 +509,7 @@ fn test_propagated_umount_retains_target_with_nonroot_child() {
     propagate_umount(&source_parent, &source_mp, &source_child, false).unwrap();
 
     assert!(peer_parent
-        .lookup_first(&peer_mp)
+        .lookup_top(&peer_mp)
         .is_some_and(|mount| Arc::ptr_eq(&mount, &peer_child)));
     assert!(peer_child
         .lookup_top(&nonroot)
@@ -561,7 +587,7 @@ fn test_propagated_lazy_umount_advances_from_descendant_to_parent() {
     let _topology = MOUNT_LIFECYCLE_LOCK.lock();
     propagate_umount_sources(&[source_grandchild, source_child], true).unwrap();
 
-    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(peer_parent.lookup_top(&peer_mp).is_none());
     assert!(!peer_child.is_live());
     assert!(!peer_grandchild.is_live());
 }
@@ -596,7 +622,7 @@ fn test_propagated_umount_does_not_restore_selected_root_child() {
     let _topology = MOUNT_LIFECYCLE_LOCK.lock();
     propagate_umount_sources(&[source_topper, source_child], true).unwrap();
 
-    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(peer_parent.lookup_top(&peer_mp).is_none());
     assert!(!peer_child.is_live());
     assert!(!peer_topper.is_live());
 }
@@ -679,9 +705,9 @@ fn test_propagated_lazy_umount_keeps_locked_child_connected() {
     let _topology = MOUNT_LIFECYCLE_LOCK.lock();
     propagate_umount_sources(&[source_grandchild, source_child], true).unwrap();
 
-    assert!(peer_parent.lookup_first(&peer_mp).is_none());
+    assert!(peer_parent.lookup_top(&peer_mp).is_none());
     assert!(peer_child
-        .lookup_first(&peer_nested)
+        .lookup_top(&peer_nested)
         .is_some_and(|mount| Arc::ptr_eq(&mount, &peer_grandchild)));
     assert!(Arc::ptr_eq(
         &peer_grandchild.parent_mount().unwrap(),

--- a/user/apps/tests/dunitest/suites/normal/mount_propagation.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_propagation.cc
@@ -491,6 +491,184 @@ TEST_F(MountPropagationTest, OrdinaryUmountRejectsMountedDescendant) {
     best_effort_rmdir(base);
 }
 
+TEST_F(MountPropagationTest, UmountUsesExactEdgeAfterChildBecomesPrivate) {
+    char base[160] = {};
+    char peer[160] = {};
+    char child[192] = {};
+    char peer_child[192] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(peer, sizeof(peer), "%s/slave", root_);
+    snprintf(child, sizeof(child), "%s/child", base);
+    snprintf(peer_child, sizeof(peer_child), "%s/child", peer);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(peer)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(base, peer, nullptr, MS_BIND, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(child)) << strerror(errno);
+    ASSERT_EQ(0, mount("", child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(child, "propagated")) << strerror(errno);
+    ASSERT_TRUE(marker_exists(peer_child, "propagated"));
+
+    ASSERT_EQ(0, mount(nullptr, child, nullptr, MS_PRIVATE, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, umount2(child, MNT_DETACH)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(peer_child, "after_umount")) << strerror(errno);
+    EXPECT_TRUE(marker_exists(child, "after_umount"));
+
+    best_effort_umount(peer_child);
+    best_effort_umount(peer);
+    best_effort_umount(base);
+    best_effort_rmdir(child);
+    best_effort_rmdir(peer);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, LazyUmountPropagatesCompleteSourceSubtree) {
+    char base[160] = {};
+    char peer[160] = {};
+    char child[192] = {};
+    char peer_child[192] = {};
+    char grandchild[224] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(peer, sizeof(peer), "%s/slave", root_);
+    snprintf(child, sizeof(child), "%s/child", base);
+    snprintf(peer_child, sizeof(peer_child), "%s/child", peer);
+    snprintf(grandchild, sizeof(grandchild), "%s/grandchild", child);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(peer)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(base, peer, nullptr, MS_BIND, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(child)) << strerror(errno);
+    ASSERT_EQ(0, mount("", child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(grandchild)) << strerror(errno);
+    ASSERT_EQ(0, mount("", grandchild, "ramfs", 0, nullptr)) << strerror(errno);
+
+    ASSERT_EQ(0, umount2(child, MNT_DETACH)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(peer_child, "subtree_removed")) << strerror(errno);
+    EXPECT_TRUE(marker_exists(child, "subtree_removed"));
+
+    best_effort_umount(peer_child);
+    best_effort_umount(peer);
+    best_effort_umount(base);
+    best_effort_rmdir(grandchild);
+    best_effort_rmdir(child);
+    best_effort_rmdir(peer);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, LazyUmountRemovesSelectedRootTopper) {
+    char base[160] = {};
+    char peer[160] = {};
+    char child[192] = {};
+    char peer_child[192] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(peer, sizeof(peer), "%s/slave", root_);
+    snprintf(child, sizeof(child), "%s/child", base);
+    snprintf(peer_child, sizeof(peer_child), "%s/child", peer);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(peer)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(base, peer, nullptr, MS_BIND, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(child)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(child, "underlay")) << strerror(errno);
+    ASSERT_EQ(0, mount("", child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(child, "lower")) << strerror(errno);
+    ASSERT_EQ(0, mount("", child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(child, "topper")) << strerror(errno);
+    ASSERT_TRUE(marker_exists(peer_child, "topper"));
+
+    ASSERT_EQ(0, umount2(base, MNT_DETACH)) << strerror(errno);
+    EXPECT_TRUE(marker_exists(peer_child, "underlay"));
+    EXPECT_FALSE(marker_exists(peer_child, "lower"));
+    EXPECT_FALSE(marker_exists(peer_child, "topper"));
+
+    best_effort_umount(peer_child);
+    best_effort_umount(peer);
+    best_effort_umount(base);
+    best_effort_rmdir(child);
+    best_effort_rmdir(peer);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, UmountRetainsPeerWithPrivateNonRootChild) {
+    char base[160] = {};
+    char peer[160] = {};
+    char child[192] = {};
+    char peer_child[192] = {};
+    char peer_grandchild[224] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(peer, sizeof(peer), "%s/slave", root_);
+    snprintf(child, sizeof(child), "%s/child", base);
+    snprintf(peer_child, sizeof(peer_child), "%s/child", peer);
+    snprintf(peer_grandchild, sizeof(peer_grandchild), "%s/grandchild", peer_child);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(peer)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(base, peer, nullptr, MS_BIND, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(child)) << strerror(errno);
+    ASSERT_EQ(0, mount("", child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, peer_child, nullptr, MS_PRIVATE, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(peer_grandchild)) << strerror(errno);
+    ASSERT_EQ(0, mount("", peer_grandchild, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(peer_grandchild, "retained")) << strerror(errno);
+
+    ASSERT_EQ(0, umount(child)) << strerror(errno);
+    EXPECT_TRUE(marker_exists(peer_grandchild, "retained"));
+    ASSERT_EQ(0, create_marker(peer_child, "peer_only")) << strerror(errno);
+    EXPECT_FALSE(marker_exists(child, "peer_only"));
+
+    best_effort_umount(peer_grandchild);
+    best_effort_umount(peer_child);
+    best_effort_umount(peer);
+    best_effort_umount(base);
+    best_effort_rmdir(peer_grandchild);
+    best_effort_rmdir(child);
+    best_effort_rmdir(peer);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, UmountRestoresPeerRootCover) {
+    char base[160] = {};
+    char peer[160] = {};
+    char child[192] = {};
+    char peer_child[192] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(peer, sizeof(peer), "%s/slave", root_);
+    snprintf(child, sizeof(child), "%s/child", base);
+    snprintf(peer_child, sizeof(peer_child), "%s/child", peer);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(peer)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(base, peer, nullptr, MS_BIND, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(child)) << strerror(errno);
+    ASSERT_EQ(0, mount("", child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, peer_child, nullptr, MS_PRIVATE, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount("", peer_child, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(peer_child, "cover")) << strerror(errno);
+
+    ASSERT_EQ(0, mount(nullptr, child, nullptr, MS_PRIVATE, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, umount2(child, MNT_DETACH)) << strerror(errno);
+    EXPECT_TRUE(marker_exists(peer_child, "cover"));
+    ASSERT_EQ(0, create_marker(peer_child, "cover_only")) << strerror(errno);
+    EXPECT_FALSE(marker_exists(child, "cover_only"));
+
+    best_effort_umount(peer_child);
+    best_effort_umount(peer);
+    best_effort_umount(base);
+    best_effort_rmdir(child);
+    best_effort_rmdir(peer);
+    best_effort_rmdir(base);
+}
+
 TEST_F(MountPropagationTest, ParentUmountRemovesLockedCrossUserNamespaceCopy) {
     char base[160] = {};
     char host[192] = {};


### PR DESCRIPTION
## Summary

- implement Linux-compatible propagated unmount planning for the complete local source subtree
- resolve corresponding mounts by exact parent/mountpoint identity and compute mark, remove, restore, locked, and lazy-retain decisions before topology mutation
- batch propagation-graph cleanup, preserve root-stack order, and make lifecycle cleanup exactly once under the topology lock
- add object-level topology tests and DragonOS dunitest regressions for private children, blockers, covers, selected toppers, locked descendants, and peer/slave chains

## Linux semantics

The implementation was checked against Linux 6.6.139 `fs/pnode.c` and `fs/namespace.c`, including `__lookup_mnt`, `propagate_mount_busy`, `__propagate_umount`, `umount_list`, `restore_mounts`, and lazy `disconnect_mount` behavior.

## Validation

- `make kernel`
- dunitest build for `normal/mount_propagation`
- DragonOS QEMU: `MountPropagationTest` 19/19 passed
- `git diff --check`
- multi-agent adversarial review of Linux semantics, architecture, concurrency, lifecycle safety, performance, and regression coverage

Host `cargo test --no-run` remains blocked by pre-existing no_std host-test infrastructure errors (`Box` imports and duplicate lang items), unrelated to this change.

Fixes #2100