### PR TITLE
perf(virtiofs): batch non-DAX writeback

### DIFF
--- a/kernel/src/arch/riscv64/process/kthread.rs
+++ b/kernel/src/arch/riscv64/process/kthread.rs
@@ -58,10 +58,6 @@ impl KernelThreadMechanism {
             e
         })?;
 
-        let pcb = ProcessManager::find(pid).unwrap();
-        pcb.set_name(info.name().clone());
-        info.setup_pcb(&pcb);
-
         return Ok(pid);
     }
 }

--- a/kernel/src/arch/x86_64/process/kthread.rs
+++ b/kernel/src/arch/x86_64/process/kthread.rs
@@ -59,10 +59,6 @@ impl KernelThreadMechanism {
             unsafe { KernelThreadCreateInfo::parse_unsafe_arc_ptr(create_info) };
         })?;
 
-        let pcb = ProcessManager::find_task_by_vpid(pid).unwrap();
-        pcb.set_name(info.name().clone());
-        info.setup_pcb(&pcb);
-
         return Ok(pid);
     }
 }

--- a/kernel/src/debug/kthread.rs
+++ b/kernel/src/debug/kthread.rs
@@ -1,0 +1,75 @@
+use alloc::{string::String, string::ToString};
+
+use system_error::SystemError;
+
+use crate::{
+    debug::sysfs::debugfs_kobj,
+    driver::base::kobject::KObject,
+    filesystem::{
+        kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData},
+        vfs::{InodeMode, PollStatus},
+    },
+};
+
+#[derive(Debug)]
+struct KthreadSelftestCallback;
+
+impl KernFSCallback for KthreadSelftestCallback {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        let report = crate::process::kthread::run_debug_selftests()?;
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(report));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report: &String = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+pub fn init_debugfs_kthread() -> Result<(), SystemError> {
+    let debugfs = debugfs_kobj();
+    let root = debugfs.inode().ok_or(SystemError::ENOENT)?;
+    let kthread = root.add_dir(
+        "kthread".to_string(),
+        InodeMode::from_bits_truncate(0o555),
+        None,
+        None,
+    )?;
+    kthread.add_file(
+        "selftest".to_string(),
+        InodeMode::S_IRUSR,
+        Some(4096),
+        None,
+        Some(&KthreadSelftestCallback),
+    )?;
+    Ok(())
+}

--- a/kernel/src/debug/mod.rs
+++ b/kernel/src/debug/mod.rs
@@ -4,6 +4,8 @@ pub mod fuse;
 pub mod jump_label;
 pub mod klog;
 pub mod kprobe;
+pub mod kthread;
+pub mod page_cache;
 pub mod panic;
 pub mod rcu;
 pub mod sysfs;

--- a/kernel/src/debug/page_cache.rs
+++ b/kernel/src/debug/page_cache.rs
@@ -1,0 +1,75 @@
+use alloc::{string::String, string::ToString};
+
+use system_error::SystemError;
+
+use crate::{
+    debug::sysfs::debugfs_kobj,
+    driver::base::kobject::KObject,
+    filesystem::{
+        kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData},
+        vfs::{InodeMode, PollStatus},
+    },
+};
+
+#[derive(Debug)]
+struct PageCacheCompletionSelftestCallback;
+
+impl KernFSCallback for PageCacheCompletionSelftestCallback {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        let report = crate::filesystem::page_cache::run_completion_domain_debug_selftest()?;
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(report));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report: &String = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+pub fn init_debugfs_page_cache() -> Result<(), SystemError> {
+    let debugfs = debugfs_kobj();
+    let root = debugfs.inode().ok_or(SystemError::ENOENT)?;
+    let page_cache = root.add_dir(
+        "page_cache".to_string(),
+        InodeMode::from_bits_truncate(0o555),
+        None,
+        None,
+    )?;
+    page_cache.add_file(
+        "completion_domain_selftest".to_string(),
+        InodeMode::S_IRUSR,
+        Some(4096),
+        None,
+        Some(&PageCacheCompletionSelftestCallback),
+    )?;
+    Ok(())
+}

--- a/kernel/src/debug/sysfs/mod.rs
+++ b/kernel/src/debug/sysfs/mod.rs
@@ -25,6 +25,8 @@ fn debugfs_init() -> Result<(), SystemError> {
     super::errseq::init_debugfs_errseq()?;
     super::ext4::init_debugfs_ext4()?;
     super::fuse::init_debugfs_fuse()?;
+    super::kthread::init_debugfs_kthread()?;
+    super::page_cache::init_debugfs_page_cache()?;
     return Ok(());
 }
 

--- a/kernel/src/filesystem/fuse/conn/daemon.rs
+++ b/kernel/src/filesystem/fuse/conn/daemon.rs
@@ -619,15 +619,15 @@ impl FuseConn {
             })?;
             self.background
                 .configure(max_background, congestion_threshold);
-            stats::on_fuse_io_limits_negotiated(
-                self.max_read(),
-                self.max_write(),
-                negotiated_max_pages as usize,
-                init_out.max_readahead as usize,
-                (enabled_flags & FUSE_ASYNC_READ) != 0,
-                (enabled_flags & FUSE_WRITEBACK_CACHE) != 0,
-                self.effective_read_payload_limit(),
-                core::cmp::min(
+            stats::on_fuse_io_limits_negotiated(stats::NegotiatedFuseIoLimits {
+                max_read: self.max_read(),
+                max_write: self.max_write(),
+                max_pages: negotiated_max_pages as usize,
+                max_readahead: init_out.max_readahead as usize,
+                async_read: (enabled_flags & FUSE_ASYNC_READ) != 0,
+                writeback_cache: (enabled_flags & FUSE_WRITEBACK_CACHE) != 0,
+                effective_read_payload_limit: self.effective_read_payload_limit(),
+                effective_write_payload_limit: core::cmp::min(
                     core::cmp::min(
                         negotiated_max_pages as usize,
                         self.max_write() / MMArch::PAGE_SIZE,
@@ -635,7 +635,7 @@ impl FuseConn {
                     64,
                 )
                 .saturating_mul(MMArch::PAGE_SIZE),
-            );
+            });
             self.init_wait.wakeup(None);
         } else {
             self.claim_pending_reply(out_hdr.unique, &pending, |_| {})?;

--- a/kernel/src/filesystem/fuse/conn/daemon.rs
+++ b/kernel/src/filesystem/fuse/conn/daemon.rs
@@ -4,7 +4,11 @@ use core::{mem::size_of, sync::atomic::Ordering};
 use num_traits::FromPrimitive;
 use system_error::SystemError;
 
-use crate::filesystem::epoll::{EPollEventType, EPollItem};
+use crate::{
+    arch::MMArch,
+    filesystem::epoll::{EPollEventType, EPollItem},
+    mm::MemoryManagementArch,
+};
 
 use super::super::protocol::{
     fuse_read_struct, FuseAttrOut, FuseEntryOut, FuseInHeader, FuseInitOut, FuseNotifyDeleteOut,
@@ -15,7 +19,7 @@ use super::super::protocol::{
     FUSE_MAP_ALIGNMENT, FUSE_MAX_PAGES, FUSE_MIN_READ_BUFFER, FUSE_MKDIR, FUSE_MKNOD,
     FUSE_NOTIFY_DELETE, FUSE_NOTIFY_INVAL_ENTRY, FUSE_NOTIFY_INVAL_INODE, FUSE_NOTIFY_POLL,
     FUSE_NOTIFY_RETRIEVE, FUSE_NOTIFY_STORE, FUSE_READ, FUSE_REMOVEXATTR, FUSE_SETATTR,
-    FUSE_SETXATTR, FUSE_STATFS, FUSE_SYMLINK,
+    FUSE_SETXATTR, FUSE_STATFS, FUSE_SYMLINK, FUSE_WRITEBACK_CACHE,
 };
 use super::{
     stats, trace, wait_with_recheck, FuseConn, FuseConnInner, FuseInitNegotiated, FuseRequest,
@@ -615,12 +619,22 @@ impl FuseConn {
             })?;
             self.background
                 .configure(max_background, congestion_threshold);
-            stats::on_fuse_read_limits_negotiated(
+            stats::on_fuse_io_limits_negotiated(
                 self.max_read(),
+                self.max_write(),
                 negotiated_max_pages as usize,
                 init_out.max_readahead as usize,
                 (enabled_flags & FUSE_ASYNC_READ) != 0,
+                (enabled_flags & FUSE_WRITEBACK_CACHE) != 0,
                 self.effective_read_payload_limit(),
+                core::cmp::min(
+                    core::cmp::min(
+                        negotiated_max_pages as usize,
+                        self.max_write() / MMArch::PAGE_SIZE,
+                    ),
+                    64,
+                )
+                .saturating_mul(MMArch::PAGE_SIZE),
             );
             self.init_wait.wakeup(None);
         } else {

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -31,6 +31,7 @@ use super::{
         fuse_read_struct, FuseStatfsOut, FOPEN_DIRECT_IO, FUSE_ATTR_SUBMOUNT, FUSE_ROOT_ID,
         FUSE_STATFS,
     },
+    stats,
 };
 
 #[derive(Debug)]
@@ -843,11 +844,18 @@ impl FileSystem for FuseFS {
             p.node.clone()
         };
 
-        node.with_writeback_admission(|| {
+        let mut result = VmFaultReason::VM_FAULT_SIGBUS;
+        let admitted = node.try_with_writeback_admission(&mut || {
             let Ok(_pin) = node.pin_writeback_handle() else {
-                return VmFaultReason::VM_FAULT_SIGBUS;
+                return Ok(());
             };
-            let result = PageFaultHandler::filemap_page_mkwrite(pfm);
+            let Some(metadata) = node.cached_metadata_snapshot() else {
+                return Ok(());
+            };
+            result = PageFaultHandler::filemap_page_mkwrite_with_stable_size(
+                pfm,
+                metadata.size.max(0) as usize,
+            );
             if !result.intersects(
                 VmFaultReason::VM_FAULT_SIGBUS
                     | VmFaultReason::VM_FAULT_OOM
@@ -855,8 +863,21 @@ impl FileSystem for FuseFS {
             ) {
                 node.note_mmap_write();
             }
-            result
-        })
+            Ok(())
+        });
+        match admitted {
+            Ok(true) => result,
+            Ok(false) => {
+                // Never block on a writer-preferred admission semaphore while
+                // the architecture fault path owns AddressSpace::write(). The
+                // retry waiter acquires/releases it only after the MM guard is
+                // dropped, closing the barrier<->mkclean cycle.
+                stats::on_mmap_writeback_admission_retry();
+                pfm.set_retry_wait(node.writeback_admission_retry_wait());
+                VmFaultReason::VM_FAULT_RETRY
+            }
+            Err(_) => VmFaultReason::VM_FAULT_SIGBUS,
+        }
     }
 
     fn mprotect(&self, _old_vm_flags: VmFlags, new_vm_flags: VmFlags) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -13,7 +13,6 @@ use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering
 
 use system_error::SystemError;
 
-use crate::time::timekeep::ktime_get_real_ns;
 use crate::{
     driver::base::device::device_number::DeviceNumber,
     filesystem::{
@@ -26,7 +25,7 @@ use crate::{
         wait_queue::WaitQueue,
     },
     mm::{fault::FaultRetryWait, MemoryManagementArch},
-    time::PosixTimeSpec,
+    time::{jiffies::NSEC_PER_JIFFY, timer::clock, PosixTimeSpec, NSEC_PER_SEC},
 };
 
 use super::reply::FuseReply;
@@ -300,7 +299,7 @@ pub struct FuseNode {
     dax_mappings: RwSem<DaxMappingTree>,
     dax_host_invalidation: Arc<DaxHostInvalidationGate>,
     dax_pte_epoch: AtomicU64,
-    cached_metadata_deadline_ns: AtomicU64,
+    cached_metadata_deadline_ticks: AtomicU64,
     attr_version: AtomicU64,
     /// Version chain produced while short READ replies from one metadata
     /// snapshot monotonically converge on the lowest observed EOF.
@@ -325,7 +324,7 @@ pub struct FuseNode {
 struct FuseLookupCacheEntry {
     child: Arc<FuseNode>,
     generation: u64,
-    deadline_ns: u64,
+    deadline_ticks: u64,
 }
 
 impl FuseNode {
@@ -377,7 +376,7 @@ impl FuseNode {
             dax_mappings: RwSem::new(DaxMappingTree::default()),
             dax_host_invalidation: DaxHostInvalidationGate::new(),
             dax_pte_epoch: AtomicU64::new(0),
-            cached_metadata_deadline_ns: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
+            cached_metadata_deadline_ticks: AtomicU64::new(if has_cached { u64::MAX } else { 0 }),
             attr_version: AtomicU64::new(initial_attr_epoch),
             short_read_source_attr_version: AtomicU64::new(0),
             short_read_chain_attr_version: AtomicU64::new(0),
@@ -1233,7 +1232,7 @@ impl FuseNode {
         *metadata = Some(md);
         self.bump_attr_version();
         drop(metadata);
-        self.cached_metadata_deadline_ns
+        self.cached_metadata_deadline_ticks
             .store(Self::cache_deadline(valid, valid_nsec), Ordering::Relaxed);
         self.note_dax_attr_change(attr_flags);
     }
@@ -1271,7 +1270,7 @@ impl FuseNode {
         *metadata = Some(md.clone());
         self.bump_attr_version();
         drop(metadata);
-        self.cached_metadata_deadline_ns.store(
+        self.cached_metadata_deadline_ticks.store(
             if stale_reply {
                 0
             } else {
@@ -1303,7 +1302,8 @@ impl FuseNode {
 
     pub(crate) fn invalidate_cached_metadata(&self) {
         self.bump_attr_version();
-        self.cached_metadata_deadline_ns.store(0, Ordering::Release);
+        self.cached_metadata_deadline_ticks
+            .store(0, Ordering::Release);
     }
 
     /// 累计该 inode 在 userspace daemon 侧持有的 LOOKUP 引用。
@@ -1329,18 +1329,41 @@ impl FuseNode {
         let _ = self.conn.queue_forget(self.nodeid, nlookup);
     }
 
-    fn now_ns() -> u64 {
-        ktime_get_real_ns().max(0) as u64
+    fn now_ticks() -> u64 {
+        // FUSE cache expiry is an elapsed-time deadline, not wall-clock time.
+        // Match Linux fuse_time_to_jiffies(): use the monotonic timer tick
+        // counter so each hot-path attr/entry-cache check is an in-memory read
+        // and settimeofday cannot extend or prematurely expire the cache.
+        clock()
     }
 
-    fn cache_deadline(valid: u64, valid_nsec: u32) -> u64 {
+    fn cache_timeout_ticks(valid: u64, valid_nsec: u32) -> u64 {
         if valid == 0 && valid_nsec == 0 {
             return 0;
         }
-        let delta_ns = valid
-            .saturating_mul(1_000_000_000)
-            .saturating_add(valid_nsec as u64);
-        Self::now_ns().saturating_add(delta_ns)
+
+        // Linux clamps the daemon-provided nanosecond component before
+        // converting the relative timeout to jiffies.  Calculate in u128 so a
+        // malformed, extremely large finite timeout cannot overflow into the
+        // u64::MAX sentinel reserved for kernel-owned permanent snapshots.
+        let nsec = valid_nsec.min(NSEC_PER_SEC - 1) as u128;
+        let delta_ns = (valid as u128)
+            .saturating_mul(NSEC_PER_SEC as u128)
+            .saturating_add(nsec);
+        delta_ns
+            .div_ceil(NSEC_PER_JIFFY as u128)
+            .min((u64::MAX - 1) as u128) as u64
+    }
+
+    fn cache_deadline(valid: u64, valid_nsec: u32) -> u64 {
+        let delta_ticks = Self::cache_timeout_ticks(valid, valid_nsec);
+        if delta_ticks == 0 {
+            return 0;
+        }
+        Self::now_ticks()
+            .checked_add(delta_ticks)
+            .filter(|deadline| *deadline < u64::MAX)
+            .unwrap_or(u64::MAX - 1)
     }
 
     pub(crate) fn conn(&self) -> &Arc<FuseConn> {
@@ -1494,8 +1517,8 @@ impl FuseNode {
         fh: Option<u64>,
     ) -> Result<Metadata, SystemError> {
         if let Some(m) = self.cached_metadata.lock().clone() {
-            let deadline = self.cached_metadata_deadline_ns.load(Ordering::Relaxed);
-            if deadline == u64::MAX || (deadline != 0 && Self::now_ns() < deadline) {
+            let deadline = self.cached_metadata_deadline_ticks.load(Ordering::Relaxed);
+            if deadline == u64::MAX || (deadline != 0 && Self::now_ticks() < deadline) {
                 return Ok(m);
             }
         }
@@ -1520,8 +1543,8 @@ impl FuseNode {
         // for every AUTO_INVAL_DATA read dominates 4 KiB cached I/O. The TTL is
         // independently published, so reuse that snapshot while it remains
         // valid and issue GETATTR_FH only after expiry.
-        let deadline = self.cached_metadata_deadline_ns.load(Ordering::Acquire);
-        if deadline == u64::MAX || (deadline != 0 && Self::now_ns() < deadline) {
+        let deadline = self.cached_metadata_deadline_ticks.load(Ordering::Acquire);
+        if deadline == u64::MAX || (deadline != 0 && Self::now_ticks() < deadline) {
             return Ok(cached);
         }
         self.fetch_attr_with_file_handle(Some(fh))
@@ -1581,6 +1604,28 @@ mod tests {
         let open_file_query = getattr_request_input(Some(0x1234_5678));
         assert_eq!(open_file_query.getattr_flags, FUSE_GETATTR_FH);
         assert_eq!(open_file_query.fh, 0x1234_5678);
+    }
+
+    #[test]
+    fn cache_timeout_matches_linux_jiffy_and_nsec_rules() {
+        assert_eq!(FuseNode::cache_timeout_ticks(0, 0), 0);
+        assert_eq!(FuseNode::cache_timeout_ticks(0, 1), 1);
+
+        let clamped = FuseNode::cache_timeout_ticks(0, NSEC_PER_SEC - 1);
+        assert_eq!(FuseNode::cache_timeout_ticks(0, u32::MAX), clamped);
+        assert_eq!(
+            FuseNode::cache_timeout_ticks(1, 0),
+            (NSEC_PER_SEC as u64).div_ceil(NSEC_PER_JIFFY as u64)
+        );
+    }
+
+    #[test]
+    fn finite_cache_timeout_never_becomes_permanent_sentinel() {
+        assert_eq!(
+            FuseNode::cache_timeout_ticks(u64::MAX, u32::MAX),
+            u64::MAX - 1
+        );
+        assert_ne!(FuseNode::cache_deadline(u64::MAX, u32::MAX), u64::MAX);
     }
 
     #[test]

--- a/kernel/src/filesystem/fuse/inode/directory.rs
+++ b/kernel/src/filesystem/fuse/inode/directory.rs
@@ -48,13 +48,13 @@ impl FuseNode {
             self.invalidate_lookup_cache(name);
             return;
         }
-        let deadline_ns = Self::cache_deadline(valid, valid_nsec);
+        let deadline_ticks = Self::cache_deadline(valid, valid_nsec);
         self.prune_lookup_cache();
 
         let mut removed = Vec::new();
         {
             let mut cache = self.lookup_cache.lock();
-            if deadline_ns == 0 || child.dax_dontcache() {
+            if deadline_ticks == 0 || child.dax_dontcache() {
                 if let Some(entry) = cache.remove(name) {
                     removed.push(entry);
                 }
@@ -69,14 +69,14 @@ impl FuseNode {
                 if let Some(entry) = cache.get_mut(name) {
                     if Arc::ptr_eq(&entry.child, child) {
                         entry.generation = generation;
-                        entry.deadline_ns = deadline_ns;
+                        entry.deadline_ticks = deadline_ticks;
                     } else {
                         let old_entry = replace(
                             entry,
                             FuseLookupCacheEntry {
                                 child: child.clone(),
                                 generation,
-                                deadline_ns,
+                                deadline_ticks,
                             },
                         );
                         removed.push(old_entry);
@@ -87,7 +87,7 @@ impl FuseNode {
                         FuseLookupCacheEntry {
                             child: child.clone(),
                             generation,
-                            deadline_ns,
+                            deadline_ticks,
                         },
                     );
                 }
@@ -134,7 +134,7 @@ impl FuseNode {
     pub(crate) fn notify_expire_child(&self, name: &str) -> Result<(), SystemError> {
         let mut cache = self.lookup_cache.lock();
         let entry = cache.get_mut(name).ok_or(SystemError::ENOENT)?;
-        entry.deadline_ns = 0;
+        entry.deadline_ticks = 0;
         self.invalidate_cached_metadata();
         Ok(())
     }
@@ -172,7 +172,7 @@ impl FuseNode {
         entry: &FuseLookupCacheEntry,
         now: u64,
     ) -> bool {
-        (entry.deadline_ns != u64::MAX && now >= entry.deadline_ns)
+        (entry.deadline_ticks != u64::MAX && now >= entry.deadline_ticks)
             || entry.child.dax_dontcache()
             || entry.child.check_not_stale().is_err()
             || entry.child.generation() != entry.generation
@@ -190,7 +190,7 @@ impl FuseNode {
     }
 
     fn prune_lookup_cache(&self) {
-        let now = Self::now_ns();
+        let now = Self::now_ticks();
         let removed = {
             let mut cache = self.lookup_cache.lock();
             let stale_keys: Vec<String> = cache

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -15,13 +15,26 @@ use crate::{
         },
         vfs::{file::FileFlags, FilePrivateData, FileType, IndexNode, Metadata, SetMetadataMask},
     },
-    libs::mutex::Mutex,
+    libs::{mutex::Mutex, rwsem::RwSemWriteGuard},
     mm::{
+        fault::FaultRetryWait,
         readahead::{FileReadaheadState, ReadaheadControl},
         MemoryManagementArch,
     },
     time::PosixTimeSpec,
 };
+
+#[derive(Debug)]
+struct FuseWritebackAdmissionRetryWait {
+    node: Arc<FuseNode>,
+}
+
+impl FaultRetryWait for FuseWritebackAdmissionRetryWait {
+    fn wait(&self) -> Result<(), SystemError> {
+        drop(self.node.writeback_barrier.read());
+        Ok(())
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum FuseReadaheadEvent {
@@ -210,6 +223,55 @@ impl PageCacheBackend for FusePageCacheBackend {
         node.writeback_page_with_handle(index, buf)
     }
 
+    fn write_batch_pages(&self) -> Result<usize, SystemError> {
+        let node = self.node.upgrade().ok_or(SystemError::EIO)?;
+        let max_pages = node.conn().max_pages();
+        let max_write = node.conn().max_write();
+        if max_pages == 0 || max_write < MMArch::PAGE_SIZE {
+            return Err(SystemError::EIO);
+        }
+        let _ = max_pages
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let pages = core::cmp::min(max_pages, max_write / MMArch::PAGE_SIZE);
+        if pages == 0 {
+            return Err(SystemError::EIO);
+        }
+        Ok(pages)
+    }
+
+    fn write_pages(&self, start_index: usize, data: &[u8]) -> Result<(), SystemError> {
+        let node = self.node.upgrade().ok_or(SystemError::EIO)?;
+        match node.writeback_pages_with_handle(start_index, data) {
+            Ok(written) if written == data.len() => Ok(()),
+            Ok(_) => Err(SystemError::EIO),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn with_write_admission(
+        &self,
+        claim: &mut dyn FnMut() -> Result<(), SystemError>,
+    ) -> Result<(), SystemError> {
+        let node = self.node.upgrade().ok_or(SystemError::EIO)?;
+        node.with_writeback_admission(claim)
+    }
+
+    fn try_with_write_admission(
+        &self,
+        claim: &mut dyn FnMut() -> Result<(), SystemError>,
+    ) -> Result<bool, SystemError> {
+        let node = self.node.upgrade().ok_or(SystemError::EIO)?;
+        node.try_with_writeback_admission(claim)
+    }
+
+    fn stable_writeback_size(&self, _inode: &Arc<dyn IndexNode>) -> Result<usize, SystemError> {
+        let node = self.node.upgrade().ok_or(SystemError::EIO)?;
+        node.cached_metadata_snapshot()
+            .ok_or(SystemError::EIO)
+            .map(|metadata| metadata.size.max(0) as usize)
+    }
+
     fn npages(&self) -> usize {
         let Some(node) = self.node.upgrade() else {
             return 0;
@@ -296,24 +358,38 @@ impl FuseNode {
                 // invalidating the ordinary page cache. The host-invalidation
                 // blocker independently prevents DAX window use/PTE publish.
                 let layout = node.dax_layout_write();
-                if let Some(cache) = page_cache.as_ref() {
+                let mut first_error = None;
+                if page_cache.is_some() {
                     // Match Linux invalidate_inode_pages2_range(): only the
                     // notified pages participate in laundering. An unrelated
                     // dirty-page error must not abort the FUSE connection.
-                    cache
-                        .manager()
-                        .launder_range_for_invalidate(start_index, end_index)?;
+                    if let Err(error) =
+                        node.launder_cached_range_admitted(start_index, end_index, &layout)
+                    {
+                        first_error = Some(error);
+                    }
                 }
-                node.invalidate_page_cache_range(
+                // Even when laundering retained an errored/dirty page, evict
+                // every page that was successfully cleaned. Otherwise a late
+                // batch error could leave earlier clean cache entries stale
+                // after the host notification has been acknowledged.
+                if let Err(error) = node.invalidate_page_cache_range(
                     start,
                     end_exclusive
                         .and_then(|end| end.checked_sub(start))
                         .unwrap_or(usize::MAX - start),
-                )?;
+                ) {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
                 drop(layout);
 
                 if blocker.lock().is_some() {
                     drop(node.dax_layout_write_for_host_invalidation(start, end_exclusive)?);
+                }
+                if let Some(error) = first_error {
+                    return Err(error);
                 }
                 Ok::<(), SystemError>(())
             })();
@@ -350,6 +426,26 @@ impl FuseNode {
     pub(crate) fn with_writeback_admission<T>(&self, f: impl FnOnce() -> T) -> T {
         let _guard = self.writeback_barrier.read();
         f()
+    }
+
+    pub(crate) fn try_with_writeback_admission(
+        &self,
+        f: &mut dyn FnMut() -> Result<(), SystemError>,
+    ) -> Result<bool, SystemError> {
+        let Some(_guard) = self.writeback_barrier.try_read() else {
+            return Ok(false);
+        };
+        f()?;
+        Ok(true)
+    }
+
+    pub(crate) fn writeback_admission_retry_wait(&self) -> Arc<dyn FaultRetryWait> {
+        Arc::new(FuseWritebackAdmissionRetryWait {
+            node: self
+                .self_ref
+                .upgrade()
+                .expect("live FuseNode must retain its self reference"),
+        })
     }
 
     pub(crate) fn note_mmap_write(&self) {
@@ -540,7 +636,7 @@ impl FuseNode {
         } else {
             self.writeback_barrier.write()
         };
-        self.sync_dirty_cached_pages()?;
+        self.sync_dirty_cached_pages_admitted(&_barrier)?;
         let mut valid = FATTR_SIZE;
         if lock_owner.is_some() {
             valid |= FATTR_LOCKOWNER;
@@ -582,8 +678,8 @@ impl FuseNode {
                 atime = metadata.atime.tv_sec as u64;
                 atimensec = metadata.atime.tv_nsec as u32;
             }
-            // DragonOS does not currently negotiate WRITEBACK_CACHE. Match
-            // Linux FUSE by accepting the daemon-returned cmtime for truncate
+            // Under WRITEBACK_CACHE, Linux trusts the locally maintained cmtime;
+            // otherwise accept the daemon-returned values for automatic truncate
             // instead of sending a second SETATTR without the file handle.
             if mask.contains(SetMetadataMask::MTIME) && (!automatic || trust_local_cmtime) {
                 valid |= FATTR_MTIME;
@@ -671,7 +767,7 @@ impl FuseNode {
                         .store(chain_version, Ordering::Release);
                     self.pending_short_read_eof
                         .fetch_min(eof as u64, Ordering::AcqRel);
-                    self.cached_metadata_deadline_ns
+                    self.cached_metadata_deadline_ticks
                         .store(u64::MAX, Ordering::Relaxed);
                     if let Some(cache) = self.cached_page_cache() {
                         let start_page = eof / MMArch::PAGE_SIZE;
@@ -797,6 +893,60 @@ impl FuseNode {
         page_cache.manager().sync()
     }
 
+    fn stable_writeback_size(&self) -> Result<usize, SystemError> {
+        Ok(self
+            .cached_metadata_snapshot()
+            .ok_or(SystemError::EIO)?
+            .size
+            .max(0) as usize)
+    }
+
+    pub(super) fn sync_dirty_cached_pages_admitted(
+        &self,
+        _guard: &RwSemWriteGuard<'_, ()>,
+    ) -> Result<(), SystemError> {
+        let Some(page_cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+        page_cache
+            .manager()
+            .sync_with_stable_size(self.stable_writeback_size()?)
+    }
+
+    pub(super) fn sync_cached_range_admitted(
+        &self,
+        start_index: usize,
+        end_index: usize,
+        _guard: &RwSemWriteGuard<'_, ()>,
+    ) -> Result<(), SystemError> {
+        let Some(page_cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+        page_cache.manager().sync_range_with_stable_size(
+            start_index,
+            end_index,
+            self.stable_writeback_size()?,
+        )
+    }
+
+    pub(super) fn launder_cached_range_admitted(
+        &self,
+        start_index: usize,
+        end_index: usize,
+        _guard: &RwSemWriteGuard<'_, ()>,
+    ) -> Result<(), SystemError> {
+        let Some(page_cache) = self.cached_page_cache() else {
+            return Ok(());
+        };
+        page_cache
+            .manager()
+            .launder_range_for_invalidate_with_stable_size(
+                start_index,
+                end_index,
+                self.stable_writeback_size()?,
+            )
+    }
+
     pub(super) fn check_and_advance_open_wb_error(
         &self,
         data: &FuseOpenPrivateData,
@@ -816,22 +966,33 @@ impl FuseNode {
         data: &FuseOpenPrivateData,
         lock_owner: u64,
     ) -> Result<(), SystemError> {
+        let writeback_cache = self.conn().has_init_flag(FUSE_WRITEBACK_CACHE);
+        // Linux skips both data-cache writeback and protocol FLUSH for
+        // FOPEN_NOFLUSH only when writeback-cache is disabled.
+        if !writeback_cache && (data.fopen_flags & FOPEN_NOFLUSH) != 0 {
+            return Ok(());
+        }
+
         // Linux fuse_flush() drains inode writeback even when this particular
         // descriptor is read-only: another writable open may have admitted
         // dirty data for the same inode.
-        let writeback_cache = self.conn().has_init_flag(FUSE_WRITEBACK_CACHE);
-        let _barrier = writeback_cache.then(|| self.writeback_barrier.write());
-        let writeback_result = if writeback_cache {
-            self.sync_dirty_cached_pages()
-        } else {
-            Ok(())
-        };
-        let wb_error_result = self.check_and_advance_open_wb_error(data);
-
+        let barrier = self.writeback_barrier.write();
+        // Linux fuse_flush() calls write_inode_now() in both cache modes. This
+        // matters when a shared mapping dirtied a cached page while the file
+        // descriptor is being closed, even without WRITEBACK_CACHE.
+        let writeback_result = self.sync_dirty_cached_pages_admitted(&barrier);
+        // Linux leaves NOWRITE after fuse_sync_writes(), before the blocking
+        // daemon FLUSH request. WRITE-before-FLUSH is already guaranteed by
+        // the synchronous drain, so retaining the barrier would only block new
+        // dirty admission and expose a notify/daemon reverse-wait cycle.
+        drop(barrier);
         writeback_result?;
-        wb_error_result?;
+        self.check_and_advance_open_wb_error(data)?;
 
-        if data.no_open || (data.fopen_flags & FOPEN_NOFLUSH) != 0 || self.conn().no_flush() {
+        // FOPEN_NOFLUSH only suppresses FLUSH when writeback-cache is disabled.
+        // With writeback-cache Linux must still send FLUSH after draining dirty
+        // pages so daemon-side flush/lock semantics and errors are preserved.
+        if self.conn().no_flush() {
             return Ok(());
         }
 
@@ -865,7 +1026,7 @@ impl FuseNode {
         Err(SystemError::EIO)
     }
 
-    fn writeback_page_with_handle(
+    fn writeback_pages_with_handle(
         &self,
         page_index: usize,
         buf: &[u8],
@@ -925,10 +1086,26 @@ impl FuseNode {
             if out.size as usize != chunk {
                 return Err(SystemError::EIO);
             }
+            self.check_not_stale()?;
+            let reply_generation = self.generation();
+            if handle.open_context.node_generation != 0
+                && reply_generation != 0
+                && handle.open_context.node_generation != reply_generation
+            {
+                return Err(SystemError::ESTALE);
+            }
             total += chunk;
         }
 
         Ok(total)
+    }
+
+    fn writeback_page_with_handle(
+        &self,
+        page_index: usize,
+        buf: &[u8],
+    ) -> Result<usize, SystemError> {
+        self.writeback_pages_with_handle(page_index, buf)
     }
 
     pub(super) fn set_open_private_data(
@@ -1044,7 +1221,7 @@ impl FuseNode {
         if atomic_dax_truncate {
             self.sync_dirty_cached_pages()?;
         }
-        let _dax_truncate_layout = if atomic_dax_truncate {
+        let dax_truncate_layout = if atomic_dax_truncate {
             Some(self.dax_layout_write_for_all()?)
         } else {
             None
@@ -1052,7 +1229,11 @@ impl FuseNode {
         if atomic_dax_truncate {
             // Close dirty admission between the optimistic drain and layout
             // exclusivity before OPEN can atomically change the host file.
-            self.sync_dirty_cached_pages()?;
+            self.sync_dirty_cached_pages_admitted(
+                dax_truncate_layout
+                    .as_ref()
+                    .expect("atomic DAX truncate guard"),
+            )?;
         }
         let file_flags = flags.bits();
         if self.conn.should_skip_open(opcode) {
@@ -1927,6 +2108,7 @@ impl FuseNode {
         len: usize,
         data: &FuseOpenPrivateData,
         discard_clean: bool,
+        _guard: &RwSemWriteGuard<'_, ()>,
     ) -> Result<(), SystemError> {
         let Some((start_page_index, end_page_index, end_page_exclusive)) =
             Self::direct_io_page_range(offset, len)?
@@ -1937,12 +2119,11 @@ impl FuseNode {
             return Ok(());
         };
 
-        page_cache
-            .manager()
-            .writeback_range(start_page_index, end_page_index)?;
-        page_cache
-            .manager()
-            .wait_writeback_range(start_page_index, end_page_index)?;
+        page_cache.manager().sync_range_with_stable_size(
+            start_page_index,
+            end_page_index,
+            self.stable_writeback_size()?,
+        )?;
         self.check_and_advance_open_wb_error(data)?;
 
         if discard_clean {

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -43,7 +43,7 @@ impl IndexNode for FuseNode {
     }
 
     fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
-        Some(self.fs())
+        self.try_fs()
     }
 
     fn as_any_ref(&self) -> &dyn core::any::Any {
@@ -400,7 +400,7 @@ impl IndexNode for FuseNode {
 
         if (fopen_flags & FOPEN_DIRECT_IO) != 0 || (file_flags & FileFlags::O_DIRECT.bits()) != 0 {
             let _barrier = self.writeback_barrier.write();
-            self.prepare_direct_io_range(offset, len, &private_data, false)?;
+            self.prepare_direct_io_range(offset, len, &private_data, false, &_barrier)?;
             let lock_owner = crate::filesystem::vfs::vcore::current_file_lock_owner_id();
             return self.read_direct_with_open(offset, len, buf, fh, file_flags, lock_owner);
         }
@@ -482,7 +482,15 @@ impl IndexNode for FuseNode {
         };
         let mut total_written = 0usize;
         if !cached_write {
-            self.prepare_direct_io_range(offset, len, &private_data, true)?;
+            self.prepare_direct_io_range(
+                offset,
+                len,
+                &private_data,
+                true,
+                _direct_write_guard
+                    .as_ref()
+                    .expect("direct writeback admission guard"),
+            )?;
         }
         if cached_write && self.conn().has_init_flag(FUSE_WRITEBACK_CACHE) {
             while total_written < len {
@@ -612,7 +620,9 @@ impl IndexNode for FuseNode {
             writeback_cache.then(|| self.writeback_barrier.write())
         };
         if writeback_cache {
-            self.sync_dirty_cached_pages()?;
+            self.sync_dirty_cached_pages_admitted(
+                _barrier.as_ref().expect("writeback admission guard"),
+            )?;
         }
         if metadata.size > old.size {
             self.resolve_pending_short_read_truncate(metadata.size.max(0) as usize)?;
@@ -793,7 +803,7 @@ impl IndexNode for FuseNode {
         };
         if changes_contents {
             // Close dirty admission between the first drain and exclusivity.
-            self.sync_dirty_cached_pages()?;
+            self.sync_dirty_cached_pages_admitted(&_barrier)?;
         }
 
         let in_arg = FuseFallocateIn {
@@ -822,7 +832,8 @@ impl IndexNode for FuseNode {
                     self.bump_attr_version();
                 }
                 drop(metadata);
-                self.cached_metadata_deadline_ns.store(0, Ordering::Relaxed);
+                self.cached_metadata_deadline_ticks
+                    .store(0, Ordering::Relaxed);
                 Ok(())
             }
             Err(SystemError::ENOSYS) => {
@@ -862,7 +873,7 @@ impl IndexNode for FuseNode {
         match fuse_data {
             FuseFilePrivateData::File(p) => {
                 let _barrier = self.writeback_barrier.write();
-                let sync_result = self.sync_cached_pages();
+                let sync_result = self.sync_dirty_cached_pages_admitted(&_barrier);
                 let wb_error_result = self.check_and_advance_open_wb_error(&p);
                 sync_result?;
                 wb_error_result?;
@@ -891,11 +902,9 @@ impl IndexNode for FuseNode {
 
         if let FuseFilePrivateData::File(_) = &fuse_data {
             let _barrier = self.writeback_barrier.write();
-            if let Some(page_cache) = self.cached_page_cache() {
-                let start_index = start >> MMArch::PAGE_SHIFT;
-                let end_index = end >> MMArch::PAGE_SHIFT;
-                page_cache.manager().sync_range(start_index, end_index)?;
-            }
+            let start_index = start >> MMArch::PAGE_SHIFT;
+            let end_index = end >> MMArch::PAGE_SHIFT;
+            self.sync_cached_range_admitted(start_index, end_index, &_barrier)?;
             if let FuseFilePrivateData::File(p) = fuse_data {
                 self.check_and_advance_open_wb_error(&p)?;
                 return self.fsync_with_fh(FUSE_FSYNC, p.fh, datasync);
@@ -912,6 +921,10 @@ impl IndexNode for FuseNode {
 
     fn fs(&self) -> Arc<dyn FileSystem> {
         self.fs.upgrade().unwrap()
+    }
+
+    fn try_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        self.fs.upgrade().map(|fs| fs as Arc<dyn FileSystem>)
     }
 
     fn list(&self) -> Result<Vec<String>, SystemError> {

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -278,16 +278,18 @@ static BACKGROUND_MAX_BLOCKED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BACKGROUND_CONGESTION_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static MMAP_WRITEBACK_ADMISSION_RETRIES_TOTAL: AtomicU64 = AtomicU64::new(0);
 
-pub fn on_fuse_io_limits_negotiated(
-    max_read: usize,
-    max_write: usize,
-    max_pages: usize,
-    max_readahead: usize,
-    async_read: bool,
-    writeback_cache: bool,
-    effective_read_payload_limit: usize,
-    effective_write_payload_limit: usize,
-) {
+pub struct NegotiatedFuseIoLimits {
+    pub max_read: usize,
+    pub max_write: usize,
+    pub max_pages: usize,
+    pub max_readahead: usize,
+    pub async_read: bool,
+    pub writeback_cache: bool,
+    pub effective_read_payload_limit: usize,
+    pub effective_write_payload_limit: usize,
+}
+
+pub fn on_fuse_io_limits_negotiated(limits: NegotiatedFuseIoLimits) {
     let sequence = loop {
         let current = INIT_LIMITS_SEQ.load(Ordering::Acquire);
         if current & 1 != 0 {
@@ -306,16 +308,20 @@ pub fn on_fuse_io_limits_negotiated(
             break current;
         }
     };
-    NEGOTIATED_MAX_READ_BYTES.store(max_read as u64, Ordering::Relaxed);
-    NEGOTIATED_MAX_WRITE_BYTES.store(max_write as u64, Ordering::Relaxed);
-    NEGOTIATED_MAX_PAGES.store(max_pages as u64, Ordering::Relaxed);
-    NEGOTIATED_MAX_READAHEAD_BYTES.store(max_readahead as u64, Ordering::Relaxed);
-    NEGOTIATED_ASYNC_READ.store(async_read as u64, Ordering::Relaxed);
-    NEGOTIATED_WRITEBACK_CACHE.store(writeback_cache as u64, Ordering::Relaxed);
-    EFFECTIVE_READ_PAYLOAD_LIMIT_BYTES
-        .store(effective_read_payload_limit as u64, Ordering::Relaxed);
-    EFFECTIVE_WRITE_PAYLOAD_LIMIT_BYTES
-        .store(effective_write_payload_limit as u64, Ordering::Relaxed);
+    NEGOTIATED_MAX_READ_BYTES.store(limits.max_read as u64, Ordering::Relaxed);
+    NEGOTIATED_MAX_WRITE_BYTES.store(limits.max_write as u64, Ordering::Relaxed);
+    NEGOTIATED_MAX_PAGES.store(limits.max_pages as u64, Ordering::Relaxed);
+    NEGOTIATED_MAX_READAHEAD_BYTES.store(limits.max_readahead as u64, Ordering::Relaxed);
+    NEGOTIATED_ASYNC_READ.store(limits.async_read as u64, Ordering::Relaxed);
+    NEGOTIATED_WRITEBACK_CACHE.store(limits.writeback_cache as u64, Ordering::Relaxed);
+    EFFECTIVE_READ_PAYLOAD_LIMIT_BYTES.store(
+        limits.effective_read_payload_limit as u64,
+        Ordering::Relaxed,
+    );
+    EFFECTIVE_WRITE_PAYLOAD_LIMIT_BYTES.store(
+        limits.effective_write_payload_limit as u64,
+        Ordering::Relaxed,
+    );
     INIT_EPOCH.fetch_add(1, Ordering::Relaxed);
     INIT_LIMITS_SEQ.store(sequence.wrapping_add(2), Ordering::Release);
 }

--- a/kernel/src/filesystem/fuse/stats.rs
+++ b/kernel/src/filesystem/fuse/stats.rs
@@ -46,10 +46,13 @@ static STATS_MODE: AtomicU8 = AtomicU8::new(FuseStatsMode::Off as u8);
 pub struct FuseStatsSnapshot {
     pub init_epoch: u64,
     pub negotiated_max_read_bytes: u64,
+    pub negotiated_max_write_bytes: u64,
     pub negotiated_max_pages: u64,
     pub negotiated_max_readahead_bytes: u64,
     pub negotiated_async_read: u64,
+    pub negotiated_writeback_cache: u64,
     pub effective_read_payload_limit_bytes: u64,
+    pub effective_write_payload_limit_bytes: u64,
     pub request_queue_current: u64,
     pub dispatch_current: u64,
     pub processing_current: u64,
@@ -79,8 +82,14 @@ pub struct FuseStatsSnapshot {
     pub readahead_saturated_single_page_extensions_total: u64,
     pub readahead_reservation_conflicts_total: u64,
     pub readahead_short_reads_total: u64,
+    pub write_requested_requests_total: u64,
+    pub write_requested_bytes_total: u64,
+    pub write_requested_bytes_max: u64,
     pub background_inflight_current: u64,
     pub read_reservation_current: u64,
+    pub invalidation_launder_batches_total: u64,
+    pub invalidation_launder_pages_total: u64,
+    pub mmap_writeback_admission_retries_total: u64,
     pub background_inflight_peak: u64,
     pub background_max_blocked_total: u64,
     pub background_congestion_skipped_total: u64,
@@ -228,10 +237,13 @@ static REQUESTS_QUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static INIT_EPOCH: AtomicU64 = AtomicU64::new(0);
 static INIT_LIMITS_SEQ: AtomicU64 = AtomicU64::new(0);
 static NEGOTIATED_MAX_READ_BYTES: AtomicU64 = AtomicU64::new(0);
+static NEGOTIATED_MAX_WRITE_BYTES: AtomicU64 = AtomicU64::new(0);
 static NEGOTIATED_MAX_PAGES: AtomicU64 = AtomicU64::new(0);
 static NEGOTIATED_MAX_READAHEAD_BYTES: AtomicU64 = AtomicU64::new(0);
 static NEGOTIATED_ASYNC_READ: AtomicU64 = AtomicU64::new(0);
+static NEGOTIATED_WRITEBACK_CACHE: AtomicU64 = AtomicU64::new(0);
 static EFFECTIVE_READ_PAYLOAD_LIMIT_BYTES: AtomicU64 = AtomicU64::new(0);
+static EFFECTIVE_WRITE_PAYLOAD_LIMIT_BYTES: AtomicU64 = AtomicU64::new(0);
 static REQUESTS_DEQUEUED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static REQUEST_QUEUE_CURRENT: AtomicU64 = AtomicU64::new(0);
 static DISPATCH_CURRENT: AtomicU64 = AtomicU64::new(0);
@@ -264,13 +276,17 @@ static BACKGROUND_INFLIGHT_CURRENT: AtomicU64 = AtomicU64::new(0);
 static BACKGROUND_INFLIGHT_PEAK: AtomicU64 = AtomicU64::new(0);
 static BACKGROUND_MAX_BLOCKED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BACKGROUND_CONGESTION_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static MMAP_WRITEBACK_ADMISSION_RETRIES_TOTAL: AtomicU64 = AtomicU64::new(0);
 
-pub fn on_fuse_read_limits_negotiated(
+pub fn on_fuse_io_limits_negotiated(
     max_read: usize,
+    max_write: usize,
     max_pages: usize,
     max_readahead: usize,
     async_read: bool,
+    writeback_cache: bool,
     effective_read_payload_limit: usize,
+    effective_write_payload_limit: usize,
 ) {
     let sequence = loop {
         let current = INIT_LIMITS_SEQ.load(Ordering::Acquire);
@@ -291,16 +307,20 @@ pub fn on_fuse_read_limits_negotiated(
         }
     };
     NEGOTIATED_MAX_READ_BYTES.store(max_read as u64, Ordering::Relaxed);
+    NEGOTIATED_MAX_WRITE_BYTES.store(max_write as u64, Ordering::Relaxed);
     NEGOTIATED_MAX_PAGES.store(max_pages as u64, Ordering::Relaxed);
     NEGOTIATED_MAX_READAHEAD_BYTES.store(max_readahead as u64, Ordering::Relaxed);
     NEGOTIATED_ASYNC_READ.store(async_read as u64, Ordering::Relaxed);
+    NEGOTIATED_WRITEBACK_CACHE.store(writeback_cache as u64, Ordering::Relaxed);
     EFFECTIVE_READ_PAYLOAD_LIMIT_BYTES
         .store(effective_read_payload_limit as u64, Ordering::Relaxed);
+    EFFECTIVE_WRITE_PAYLOAD_LIMIT_BYTES
+        .store(effective_write_payload_limit as u64, Ordering::Relaxed);
     INIT_EPOCH.fetch_add(1, Ordering::Relaxed);
     INIT_LIMITS_SEQ.store(sequence.wrapping_add(2), Ordering::Release);
 }
 
-fn fuse_init_limits_snapshot() -> (u64, u64, u64, u64, u64, u64) {
+fn fuse_init_limits_snapshot() -> (u64, u64, u64, u64, u64, u64, u64, u64, u64) {
     loop {
         let before = INIT_LIMITS_SEQ.load(Ordering::Acquire);
         if before & 1 != 0 {
@@ -310,10 +330,13 @@ fn fuse_init_limits_snapshot() -> (u64, u64, u64, u64, u64, u64) {
         let values = (
             INIT_EPOCH.load(Ordering::Relaxed),
             NEGOTIATED_MAX_READ_BYTES.load(Ordering::Relaxed),
+            NEGOTIATED_MAX_WRITE_BYTES.load(Ordering::Relaxed),
             NEGOTIATED_MAX_PAGES.load(Ordering::Relaxed),
             NEGOTIATED_MAX_READAHEAD_BYTES.load(Ordering::Relaxed),
             NEGOTIATED_ASYNC_READ.load(Ordering::Relaxed),
+            NEGOTIATED_WRITEBACK_CACHE.load(Ordering::Relaxed),
             EFFECTIVE_READ_PAYLOAD_LIMIT_BYTES.load(Ordering::Relaxed),
+            EFFECTIVE_WRITE_PAYLOAD_LIMIT_BYTES.load(Ordering::Relaxed),
         );
         if before == INIT_LIMITS_SEQ.load(Ordering::Acquire) {
             return values;
@@ -373,6 +396,14 @@ pub fn on_background_pressure(speculative: bool) {
     } else {
         inc(&BACKGROUND_MAX_BLOCKED_TOTAL);
     }
+}
+
+/// Count mmap write faults which must retry after dropping the address-space
+/// guard because an exclusive cached-writeback operation owns the inode gate.
+/// This is always-on: it is a correctness/lifecycle observation rather than
+/// optional hot-path detail, and the increment occurs only on contention.
+pub fn on_mmap_writeback_admission_retry() {
+    inc(&MMAP_WRITEBACK_ADMISSION_RETRIES_TOTAL);
 }
 
 static DEVICE_QUEUE_DEPTH_MAX: AtomicU64 = AtomicU64::new(0);
@@ -439,6 +470,13 @@ static READ_REQUESTED_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
 static READ_REQUESTED_BYTES_MAX: AtomicU64 = AtomicU64::new(0);
 static READ_REQUESTED_PAGES: [AtomicU64; READ_PAGE_BUCKETS] =
     [const { AtomicU64::new(0) }; READ_PAGE_BUCKETS];
+
+// WRITE request-size diagnostics use FuseWriteIn.size at the successful
+// virtqueue submission point. They are optional so normal benchmarks do not
+// pay atomic RMW costs or mistake protocol/header bytes for file data.
+static WRITE_REQUESTED_REQUESTS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static WRITE_REQUESTED_BYTES_TOTAL: AtomicU64 = AtomicU64::new(0);
+static WRITE_REQUESTED_BYTES_MAX: AtomicU64 = AtomicU64::new(0);
 
 static OPCODE_REQUESTS_TOTAL: [AtomicU64; OPCODE_BUCKETS] =
     [const { AtomicU64::new(0) }; OPCODE_BUCKETS];
@@ -1034,6 +1072,24 @@ pub fn on_virtiofs_read_requested(requested_bytes: usize, pages: usize) {
     inc(&READ_REQUESTED_PAGES[read_page_bucket(pages)]);
 }
 
+/// Record the file-data payload declared by a successfully submitted
+/// FUSE_WRITE. The caller obtains this value from `FuseWriteIn.size`.
+#[inline]
+pub fn on_virtiofs_write_requested(requested_bytes: usize) {
+    if !light_stats_enabled() || requested_bytes == 0 {
+        return;
+    }
+    inc(&WRITE_REQUESTED_REQUESTS_TOTAL);
+    add(&WRITE_REQUESTED_BYTES_TOTAL, requested_bytes as u64);
+    update_peak(&WRITE_REQUESTED_BYTES_MAX, requested_bytes as u64);
+}
+
+/// Whether callers should pay the cost of decoding WRITE request details.
+#[inline]
+pub fn write_request_stats_enabled() -> bool {
+    light_stats_enabled()
+}
+
 /// Queue acceptance is the DMA ownership commit point.
 #[inline]
 pub fn on_virtiofs_direct_read_requested(requested_bytes: usize) {
@@ -1141,15 +1197,28 @@ pub fn on_virtiofs_dax_device_reset() {
 }
 
 pub fn fuse_snapshot() -> FuseStatsSnapshot {
-    let (init_epoch, max_read, max_pages, max_readahead, async_read, effective_read) =
-        fuse_init_limits_snapshot();
+    let (
+        init_epoch,
+        max_read,
+        max_write,
+        max_pages,
+        max_readahead,
+        async_read,
+        writeback_cache,
+        effective_read,
+        effective_write,
+    ) = fuse_init_limits_snapshot();
+    let page_cache = page_cache_stats::snapshot();
     FuseStatsSnapshot {
         init_epoch,
         negotiated_max_read_bytes: max_read,
+        negotiated_max_write_bytes: max_write,
         negotiated_max_pages: max_pages,
         negotiated_max_readahead_bytes: max_readahead,
         negotiated_async_read: async_read,
+        negotiated_writeback_cache: writeback_cache,
         effective_read_payload_limit_bytes: effective_read,
+        effective_write_payload_limit_bytes: effective_write,
         request_queue_current: REQUEST_QUEUE_CURRENT.load(Ordering::Acquire),
         dispatch_current: DISPATCH_CURRENT.load(Ordering::Acquire),
         processing_current: PROCESSING_CURRENT.load(Ordering::Acquire),
@@ -1185,8 +1254,15 @@ pub fn fuse_snapshot() -> FuseStatsSnapshot {
         readahead_reservation_conflicts_total: READAHEAD_RESERVATION_CONFLICTS_TOTAL
             .load(Ordering::Relaxed),
         readahead_short_reads_total: READAHEAD_SHORT_READS_TOTAL.load(Ordering::Relaxed),
+        write_requested_requests_total: WRITE_REQUESTED_REQUESTS_TOTAL.load(Ordering::Relaxed),
+        write_requested_bytes_total: WRITE_REQUESTED_BYTES_TOTAL.load(Ordering::Relaxed),
+        write_requested_bytes_max: WRITE_REQUESTED_BYTES_MAX.load(Ordering::Relaxed),
         background_inflight_current: BACKGROUND_INFLIGHT_CURRENT.load(Ordering::Acquire),
-        read_reservation_current: page_cache_stats::snapshot().read_dma_reservations,
+        read_reservation_current: page_cache.read_dma_reservations,
+        invalidation_launder_batches_total: page_cache.invalidation_launder_batches,
+        invalidation_launder_pages_total: page_cache.invalidation_launder_pages,
+        mmap_writeback_admission_retries_total: MMAP_WRITEBACK_ADMISSION_RETRIES_TOTAL
+            .load(Ordering::Relaxed),
         background_inflight_peak: BACKGROUND_INFLIGHT_PEAK.load(Ordering::Relaxed),
         background_max_blocked_total: BACKGROUND_MAX_BLOCKED_TOTAL.load(Ordering::Relaxed),
         background_congestion_skipped_total: BACKGROUND_CONGESTION_SKIPPED_TOTAL
@@ -1302,10 +1378,13 @@ detailed opcode,copy,allocation\n\
 [fuse]\n\
 init_epoch {}\n\
 negotiated_max_read_bytes {}\n\
+negotiated_max_write_bytes {}\n\
 negotiated_max_pages {}\n\
 negotiated_max_readahead_bytes {}\n\
 negotiated_async_read {}\n\
+negotiated_writeback_cache {}\n\
 effective_read_payload_limit_bytes {}\n\
+effective_write_payload_limit_bytes {}\n\
 request_queue_current {}\n\
 dispatch_current {}\n\
 processing_current {}\n\
@@ -1335,8 +1414,14 @@ readahead_window_extension_pages_total {}\n\
 readahead_saturated_single_page_extensions_total {}\n\
 readahead_reservation_conflicts_total {}\n\
 readahead_short_reads_total {}\n\
+write_requested_requests_total {}\n\
+write_requested_bytes_total {}\n\
+write_requested_bytes_max {}\n\
 background_inflight_current {}\n\
 read_reservation_current {}\n\
+invalidation_launder_batches_total {}\n\
+invalidation_launder_pages_total {}\n\
+mmap_writeback_admission_retries_total {}\n\
 background_inflight_peak {}\n\
 background_max_blocked_total {}\n\
 background_congestion_skipped_total {}\n\
@@ -1434,10 +1519,13 @@ dax_device_resets_total {}\n",
         stats_mode().as_str(),
         fuse.init_epoch,
         fuse.negotiated_max_read_bytes,
+        fuse.negotiated_max_write_bytes,
         fuse.negotiated_max_pages,
         fuse.negotiated_max_readahead_bytes,
         fuse.negotiated_async_read,
+        fuse.negotiated_writeback_cache,
         fuse.effective_read_payload_limit_bytes,
+        fuse.effective_write_payload_limit_bytes,
         fuse.request_queue_current,
         fuse.dispatch_current,
         fuse.processing_current,
@@ -1467,8 +1555,14 @@ dax_device_resets_total {}\n",
         fuse.readahead_saturated_single_page_extensions_total,
         fuse.readahead_reservation_conflicts_total,
         fuse.readahead_short_reads_total,
+        fuse.write_requested_requests_total,
+        fuse.write_requested_bytes_total,
+        fuse.write_requested_bytes_max,
         fuse.background_inflight_current,
         fuse.read_reservation_current,
+        fuse.invalidation_launder_batches_total,
+        fuse.invalidation_launder_pages_total,
+        fuse.mmap_writeback_admission_retries_total,
         fuse.background_inflight_peak,
         fuse.background_max_blocked_total,
         fuse.background_congestion_skipped_total,

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -30,8 +30,8 @@ use crate::{
 use super::super::{
     conn::{FuseConn, FuseReplyCapacitySource, FuseReplyContract, FuseRequest},
     protocol::{
-        fuse_pack_struct, fuse_read_struct, FuseOutHeader, FUSE_DESTROY, FUSE_FORGET,
-        FUSE_INTERRUPT, FUSE_READ,
+        fuse_pack_struct, fuse_read_struct, FuseInHeader, FuseOutHeader, FuseWriteIn, FUSE_DESTROY,
+        FUSE_FORGET, FUSE_INTERRUPT, FUSE_READ, FUSE_WRITE,
     },
     stats, trace,
 };
@@ -906,6 +906,17 @@ impl VirtioFsBridgeContext {
         } else {
             None
         };
+        let write_requested_bytes =
+            if trace_opcode == FUSE_WRITE && stats::write_request_stats_enabled() {
+                pending
+                    .req
+                    .bytes()
+                    .get(core::mem::size_of::<FuseInHeader>()..)
+                    .and_then(|payload| fuse_read_struct::<FuseWriteIn>(payload).ok())
+                    .map(|input| input.size as usize)
+            } else {
+                None
+            };
         let queue_size = match kind {
             QueueKind::Hiprio => self.hiprio_vq.as_ref().ok_or(SystemError::EIO)?.size(),
             QueueKind::Request(slot) => self
@@ -1083,6 +1094,9 @@ impl VirtioFsBridgeContext {
         };
         debug_assert!(replaced.is_none());
         stats::on_virtiofs_submitted(trace_opcode, req_len);
+        if let Some(requested_bytes) = write_requested_bytes {
+            stats::on_virtiofs_write_requested(requested_bytes);
+        }
         if let Some(requested_bytes) = read_requested_bytes {
             stats::on_virtiofs_read_requested(
                 requested_bytes,

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -22,10 +22,12 @@ use crate::libs::mutex::MutexGuard;
 use crate::libs::rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard};
 use crate::libs::spinlock::SpinLock;
 use crate::libs::wait_queue::WaitQueue;
+use crate::mm::fault::FaultRetryWait;
 use crate::mm::page::FileMapInfo;
 use crate::mm::page_cache_stats as pc_stats;
 use crate::mm::ucontext::LockedVMA;
 use crate::sched::completion::Completion;
+use crate::time::Duration;
 use crate::{arch::mm::LockedFrameAllocator, libs::lazy_init::Lazy};
 use crate::{
     arch::MMArch,
@@ -42,9 +44,49 @@ use lazy_static::lazy_static;
 
 static PAGE_CACHE_ID: AtomicUsize = AtomicUsize::new(0);
 static PAGE_CACHE_DMA_RESERVATION_ID: AtomicU64 = AtomicU64::new(1);
+static PAGE_CACHE_WRITEBACK_TAG_EPOCH: AtomicU64 = AtomicU64::new(1);
 
 const PAGECACHE_IO_WORKERS: usize = 4;
+const MAX_ASYNC_WRITEBACK_BATCHES: usize = PAGECACHE_IO_WORKERS * 2;
 static PAGECACHE_IO_RR: AtomicUsize = AtomicUsize::new(0);
+static PAGECACHE_WRITEBACK_RR: AtomicUsize = AtomicUsize::new(0);
+static ASYNC_WRITEBACK_BATCHES: AtomicUsize = AtomicUsize::new(0);
+static ASYNC_WRITEBACK_COMPLETIONS: AtomicU64 = AtomicU64::new(0);
+static ASYNC_WRITEBACK_WAIT: WaitQueue = WaitQueue::default();
+static PAGECACHE_COMPLETION_SELFTEST_RUNNING: AtomicBool = AtomicBool::new(false);
+
+struct PageCacheCompletionSelftestGuard;
+
+impl Drop for PageCacheCompletionSelftestGuard {
+    fn drop(&mut self) {
+        PAGECACHE_COMPLETION_SELFTEST_RUNNING.store(false, Ordering::Release);
+    }
+}
+
+struct PageCacheCompletionSelftestState {
+    generic_started: AtomicUsize,
+    generic_released: AtomicUsize,
+    completion_done: AtomicBool,
+    abort: AtomicBool,
+    wait: WaitQueue,
+}
+
+impl PageCacheCompletionSelftestState {
+    fn new() -> Self {
+        Self {
+            generic_started: AtomicUsize::new(0),
+            generic_released: AtomicUsize::new(0),
+            completion_done: AtomicBool::new(false),
+            abort: AtomicBool::new(false),
+            wait: WaitQueue::default(),
+        }
+    }
+
+    fn release_waiters(&self) {
+        self.abort.store(true, Ordering::Release);
+        self.wait.wake_all();
+    }
+}
 
 #[derive(Debug, Default)]
 struct FileVmaIndex {
@@ -121,12 +163,216 @@ lazy_static! {
         }
         wqs
     };
+    // Keep completion of already-published Writeback pages independent from
+    // generic page-cache work. In particular, host invalidation runs on the
+    // generic pool and may hold the filesystem admission barrier while waiting
+    // for Writeback. Sharing a FIFO worker could strand the corresponding
+    // writeback work behind that waiter and deadlock permanently.
+    static ref PAGECACHE_WRITEBACK_WQS: Vec<Arc<WorkQueue>> = {
+        let mut wqs = Vec::new();
+        for i in 0..PAGECACHE_IO_WORKERS {
+            wqs.push(WorkQueue::new(&format!("pagecache-wb-{i}")));
+        }
+        wqs
+    };
     static ref PAGECACHE_REGISTRY: SpinLock<Vec<Weak<PageCache>>> = SpinLock::new(Vec::new());
 }
 
 pub(crate) fn schedule_pagecache_io(work: Arc<Work>) {
     let idx = PAGECACHE_IO_RR.fetch_add(1, Ordering::Relaxed) % PAGECACHE_IO_WQS.len();
     PAGECACHE_IO_WQS[idx].enqueue(work);
+}
+
+fn schedule_pagecache_writeback(work: Arc<Work>) {
+    let idx =
+        PAGECACHE_WRITEBACK_RR.fetch_add(1, Ordering::Relaxed) % PAGECACHE_WRITEBACK_WQS.len();
+    PAGECACHE_WRITEBACK_WQS[idx].enqueue(work);
+}
+
+/// Verify that terminal writeback completion cannot be stranded behind generic
+/// page-cache workers waiting for that completion.
+///
+/// This is only called from a root-readable debugfs selftest. It injects no
+/// delay or branch into normal page-cache operation.
+pub(crate) fn run_completion_domain_debug_selftest() -> Result<alloc::string::String, SystemError> {
+    if PAGECACHE_COMPLETION_SELFTEST_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Err(SystemError::EBUSY);
+    }
+    let _running = PageCacheCompletionSelftestGuard;
+    let state = Arc::new(PageCacheCompletionSelftestState::new());
+
+    // Place exactly one waiter on every generic page-cache worker. Direct queue
+    // selection keeps the test deterministic even if unrelated page-cache work
+    // advances the production round-robin counter concurrently. The waiters
+    // model host invalidation after it has observed a published Writeback page.
+    for workqueue in PAGECACHE_IO_WQS.iter() {
+        let waiter_state = state.clone();
+        workqueue.enqueue(Work::new(move || {
+            waiter_state.generic_started.fetch_add(1, Ordering::AcqRel);
+            waiter_state.wait.wake_all();
+            waiter_state.wait.wait_until(|| {
+                (waiter_state.completion_done.load(Ordering::Acquire)
+                    || waiter_state.abort.load(Ordering::Acquire))
+                .then_some(())
+            });
+            waiter_state.generic_released.fetch_add(1, Ordering::AcqRel);
+            waiter_state.wait.wake_all();
+        }));
+    }
+
+    const SELFTEST_TIMEOUT: Duration = Duration::from_secs(2);
+    if let Err(error) = state.wait.wait_until_timeout(
+        || (state.generic_started.load(Ordering::Acquire) == PAGECACHE_IO_WORKERS).then_some(()),
+        SELFTEST_TIMEOUT,
+    ) {
+        state.release_waiters();
+        return Ok(alloc::format!(
+            "status=fail stage=occupy_generic error={error:?} started={} expected={}\n",
+            state.generic_started.load(Ordering::Acquire),
+            PAGECACHE_IO_WORKERS
+        ));
+    }
+
+    let completion_state = state.clone();
+    PAGECACHE_WRITEBACK_WQS[0].enqueue(Work::new(move || {
+        completion_state
+            .completion_done
+            .store(true, Ordering::Release);
+        completion_state.wait.wake_all();
+    }));
+
+    let completion_result = state.wait.wait_until_timeout(
+        || state.completion_done.load(Ordering::Acquire).then_some(()),
+        SELFTEST_TIMEOUT,
+    );
+    if completion_result.is_err() {
+        state.release_waiters();
+    }
+    let released_result = state.wait.wait_until_timeout(
+        || (state.generic_released.load(Ordering::Acquire) == PAGECACHE_IO_WORKERS).then_some(()),
+        SELFTEST_TIMEOUT,
+    );
+    state.release_waiters();
+
+    if let Err(error) = completion_result {
+        return Ok(alloc::format!(
+            "status=fail stage=completion error={error:?} released={} expected={}\n",
+            state.generic_released.load(Ordering::Acquire),
+            PAGECACHE_IO_WORKERS
+        ));
+    }
+    if let Err(error) = released_result {
+        return Ok(alloc::format!(
+            "status=fail stage=release error={error:?} released={} expected={}\n",
+            state.generic_released.load(Ordering::Acquire),
+            PAGECACHE_IO_WORKERS
+        ));
+    }
+
+    Ok(alloc::format!(
+        "status=ok generic_waiters={} completion_domain=independent\n",
+        PAGECACHE_IO_WORKERS
+    ))
+}
+
+struct AsyncWritebackPermit;
+
+impl AsyncWritebackPermit {
+    fn try_acquire() -> Option<Self> {
+        let mut current = ASYNC_WRITEBACK_BATCHES.load(Ordering::Acquire);
+        loop {
+            if current >= MAX_ASYNC_WRITEBACK_BATCHES {
+                return None;
+            }
+            match ASYNC_WRITEBACK_BATCHES.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Some(Self),
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn acquire() -> Self {
+        ASYNC_WRITEBACK_WAIT.wait_until(Self::try_acquire)
+    }
+}
+
+impl Drop for AsyncWritebackPermit {
+    fn drop(&mut self) {
+        ASYNC_WRITEBACK_BATCHES.fetch_sub(1, Ordering::AcqRel);
+        ASYNC_WRITEBACK_COMPLETIONS.fetch_add(1, Ordering::AcqRel);
+        ASYNC_WRITEBACK_WAIT.wake_all();
+    }
+}
+
+/// Capture the completion generation before a reclaim scan schedules dirty
+/// writeback.  Pair this with [`wait_for_async_writeback_progress`] so a fast
+/// completion between the scan and the wait cannot be lost.
+pub(crate) fn async_writeback_progress_snapshot() -> u64 {
+    ASYNC_WRITEBACK_COMPLETIONS.load(Ordering::Acquire)
+}
+
+/// Throttle a no-progress reclaim pass until asynchronous writeback advances.
+///
+/// The wait is bounded: a stuck backend must not pin the global reclaimer
+/// forever, because another cache may become reclaimable meanwhile.  Returning
+/// `false` means no blocking wait was performed (the sampled generation had
+/// already advanced, no writeback remained in flight, or the wait was
+/// interrupted); callers should apply a short retry backoff instead of
+/// immediately rescanning the same LRU.
+pub(crate) fn wait_for_async_writeback_progress(observed: u64) -> bool {
+    if ASYNC_WRITEBACK_COMPLETIONS.load(Ordering::Acquire) != observed {
+        return false;
+    }
+    if ASYNC_WRITEBACK_BATCHES.load(Ordering::Acquire) == 0 {
+        return false;
+    }
+
+    const RECLAIM_WRITEBACK_WAIT: Duration = Duration::from_millis(10);
+    let result = ASYNC_WRITEBACK_WAIT.wait_until_timeout(
+        || {
+            if ASYNC_WRITEBACK_COMPLETIONS.load(Ordering::Acquire) != observed
+                || ASYNC_WRITEBACK_BATCHES.load(Ordering::Acquire) == 0
+            {
+                Some(())
+            } else {
+                None
+            }
+        },
+        RECLAIM_WRITEBACK_WAIT,
+    );
+    !matches!(result, Err(SystemError::ERESTARTSYS))
+}
+
+struct ReclaimerRunnerGuard {
+    cache: Arc<PageCache>,
+}
+
+impl ReclaimerRunnerGuard {
+    fn try_acquire(cache: &Arc<PageCache>) -> Option<Self> {
+        cache
+            .reclaimer_writeback_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| Self {
+                cache: cache.clone(),
+            })
+    }
+}
+
+impl Drop for ReclaimerRunnerGuard {
+    fn drop(&mut self) {
+        self.cache
+            .reclaimer_writeback_active
+            .store(false, Ordering::Release);
+    }
 }
 
 fn register_page_cache(cache: &Arc<PageCache>) {
@@ -153,6 +399,55 @@ pub trait PageCacheBackend: Send + Sync + core::fmt::Debug {
     fn read_page(&self, index: usize, buf: &mut [u8]) -> Result<usize, SystemError>;
     fn write_page(&self, index: usize, buf: &[u8]) -> Result<usize, SystemError>;
     fn npages(&self) -> usize;
+
+    /// Maximum number of consecutive pages which are useful in one backend
+    /// write request.  Backends are single-page by default.
+    fn write_batch_pages(&self) -> Result<usize, SystemError> {
+        Ok(1)
+    }
+
+    /// Write a stable, i_size-clipped snapshot beginning at `start_index`.
+    /// All chunks except the final one are full pages.
+    fn write_pages(&self, start_index: usize, data: &[u8]) -> Result<(), SystemError> {
+        for (page_offset, chunk) in data.chunks(MMArch::PAGE_SIZE).enumerate() {
+            let index = start_index
+                .checked_add(page_offset)
+                .ok_or(SystemError::EOVERFLOW)?;
+            match self.write_page(index, chunk) {
+                Ok(written) if written == chunk.len() => {}
+                Ok(_) => return Err(SystemError::EIO),
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    }
+
+    /// Run the page-cache claim while the filesystem's write admission is
+    /// held. Filesystems with an explicit writeback barrier override this
+    /// method. The page-cache manager samples i_size only after it has also
+    /// acquired the invalidate read lock.
+    fn with_write_admission(
+        &self,
+        claim: &mut dyn FnMut() -> Result<(), SystemError>,
+    ) -> Result<(), SystemError> {
+        claim()
+    }
+
+    /// Try-only admission used by reclaimer workers. Returning `false` means
+    /// no page state was changed and the candidate remains Dirty.
+    fn try_with_write_admission(
+        &self,
+        claim: &mut dyn FnMut() -> Result<(), SystemError>,
+    ) -> Result<bool, SystemError> {
+        claim()?;
+        Ok(true)
+    }
+
+    /// Read authoritative i_size while filesystem admission and the page
+    /// cache invalidate read lock are both held.
+    fn stable_writeback_size(&self, inode: &Arc<dyn IndexNode>) -> Result<usize, SystemError> {
+        Ok(inode.metadata()?.size.max(0) as usize)
+    }
 
     fn read_page_async(&self, index: usize, page: &Arc<Page>) -> Arc<PageIoWaiter> {
         let waiter = PageIoWaiter::new();
@@ -262,7 +557,7 @@ impl PageCacheBackend for AsyncPageCacheBackend {
             let res = inode.write_sync(index * MMArch::PAGE_SIZE, &data);
             waiter_cb.complete(res);
         });
-        schedule_pagecache_io(work);
+        schedule_pagecache_writeback(work);
         waiter
     }
 }
@@ -282,6 +577,8 @@ pub struct PageCache {
     unevictable: AtomicBool,
     is_shmem: AtomicBool,
     reclassify_lock: Mutex<()>,
+    tagged_writeback_lock: Mutex<()>,
+    reclaimer_writeback_active: AtomicBool,
     manager: PageCacheManager,
 }
 
@@ -307,6 +604,12 @@ pub struct InnerPageCache {
     pages: HashMap<usize, Arc<PageEntry>>,
     page_indices: BTreeSet<usize>,
     dirty_pages: BTreeSet<usize>,
+    /// Page indices whose entries are currently in `PageState::Writeback`.
+    ///
+    /// This is maintained under the same `inner` lock as the entry state so
+    /// range completion checks remain atomic without scanning every cached
+    /// page while holding the lock.
+    writeback_pages: BTreeSet<usize>,
     /// Aggregated semantic owner for all dirty and writeback pages in this mapping.
     dirty_retention: Option<InodeRetentionGuard>,
     dirty_preparations: usize,
@@ -372,9 +675,26 @@ impl PageState {
 struct PageEntry {
     page: Arc<Page>,
     state: AtomicU8,
+    writeback_tag: AtomicU64,
     accounted_unevictable: AtomicBool,
     active_users: AtomicUsize,
     wait_queue: WaitQueue,
+}
+
+struct PageWritebackRetryWait {
+    entry: Arc<PageEntry>,
+}
+
+impl core::fmt::Debug for PageWritebackRetryWait {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PageWritebackRetryWait").finish()
+    }
+}
+
+impl FaultRetryWait for PageWritebackRetryWait {
+    fn wait(&self) -> Result<(), SystemError> {
+        PageCacheManager::wait_writeback_entry(self.entry.clone())
+    }
 }
 
 impl core::fmt::Debug for PageEntry {
@@ -802,6 +1122,16 @@ impl Drop for WritebackGuard {
     }
 }
 
+struct ClaimedWritebackBatch {
+    cache: Arc<PageCache>,
+    backend: Option<Arc<dyn PageCacheBackend>>,
+    first_index: usize,
+    file_size: usize,
+    entries: Vec<(usize, Arc<PageEntry>, Arc<Page>)>,
+    guards: Vec<WritebackGuard>,
+    data: Vec<u8>,
+}
+
 impl PageCacheManager {
     fn new(owner: Weak<PageCache>) -> Self {
         Self { owner }
@@ -1125,6 +1455,562 @@ impl PageCacheManager {
         }
     }
 
+    pub fn page_mkwrite_retry_wait(
+        &self,
+        page_index: usize,
+        page: &Arc<Page>,
+    ) -> Option<Arc<dyn FaultRetryWait>> {
+        let cache = self.upgrade().ok()?;
+        let entry = cache.inner.lock().get_entry(page_index)?;
+        if !Arc::ptr_eq(&entry.page, page) || entry.state() != PageState::Writeback {
+            return None;
+        }
+        Some(Arc::new(PageWritebackRetryWait { entry }))
+    }
+
+    fn claim_next_writeback_batch(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+        required_first: Option<(usize, &Arc<PageEntry>, u64)>,
+    ) -> Result<Option<ClaimedWritebackBatch>, SystemError> {
+        if start_index > end_index {
+            return Ok(None);
+        }
+        let backend = cache.backend();
+        let reported_pages = match backend.as_ref() {
+            Some(backend) => backend.write_batch_pages()?,
+            None => 1,
+        };
+        if reported_pages == 0 {
+            return Err(SystemError::EIO);
+        }
+        let batch_pages = reported_pages.min(64);
+        let max_data_len = batch_pages
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+
+        let mut candidates = Vec::new();
+        candidates
+            .try_reserve_exact(batch_pages)
+            .map_err(|_| SystemError::ENOMEM)?;
+        let mut prepared = Vec::new();
+        let mut guards = Vec::new();
+        let mut data = Vec::new();
+        prepared
+            .try_reserve_exact(batch_pages)
+            .map_err(|_| SystemError::ENOMEM)?;
+        guards
+            .try_reserve_exact(batch_pages)
+            .map_err(|_| SystemError::ENOMEM)?;
+        data.try_reserve_exact(max_data_len)
+            .map_err(|_| SystemError::ENOMEM)?;
+
+        let first_index = {
+            let mut inner = cache.inner.lock();
+            if let Some((required_index, required_entry, epoch)) = required_first {
+                let Some(current) = inner.pages.get(&required_index) else {
+                    return Ok(None);
+                };
+                if required_index < start_index
+                    || required_index > end_index
+                    || !Arc::ptr_eq(current, required_entry)
+                    || !inner.dirty_pages.contains(&required_index)
+                    || current.writeback_tag() != epoch
+                    || !matches!(
+                        current.state(),
+                        PageState::UpToDate | PageState::Dirty | PageState::Error
+                    )
+                {
+                    return Ok(None);
+                }
+            }
+            let mut expected = None;
+            for index in inner.dirty_pages.range(start_index..=end_index) {
+                if candidates.len() == batch_pages {
+                    break;
+                }
+                let Some(entry) = inner.pages.get(index).cloned() else {
+                    if candidates.is_empty() {
+                        continue;
+                    }
+                    break;
+                };
+                let eligible = matches!(
+                    entry.state(),
+                    PageState::UpToDate | PageState::Dirty | PageState::Error
+                );
+                let tagged = required_first
+                    .map(|(_, _, epoch)| entry.writeback_tag() == epoch)
+                    .unwrap_or(true);
+                if !eligible || !tagged {
+                    if candidates.is_empty() {
+                        continue;
+                    }
+                    break;
+                }
+                if let Some(expected) = expected {
+                    if *index != expected {
+                        break;
+                    }
+                }
+                candidates.push((*index, entry));
+                expected = index.checked_add(1);
+            }
+            let Some((first_index, _)) = candidates.first() else {
+                return Ok(None);
+            };
+            let first_index = *first_index;
+
+            // Validate every fallible condition before publishing any member
+            // as Writeback.  The state/identity recheck and dirty-set removal
+            // below then happen under this same inner critical section.
+            for (page_index, entry) in candidates.iter() {
+                page_index
+                    .checked_mul(MMArch::PAGE_SIZE)
+                    .ok_or(SystemError::EOVERFLOW)?;
+                let Some(current) = inner.pages.get(page_index) else {
+                    return Ok(None);
+                };
+                if !Arc::ptr_eq(current, entry) {
+                    return Ok(None);
+                }
+                if current.state() == PageState::Error {
+                    return Err(SystemError::EIO);
+                }
+            }
+
+            for (page_index, entry) in candidates.drain(..) {
+                let old_state = entry.state();
+                if old_state == PageState::UpToDate {
+                    cache.account_state_transition(PageState::UpToDate, PageState::Dirty);
+                    entry.set_state(PageState::Dirty);
+                }
+                debug_assert_eq!(entry.state(), PageState::Dirty);
+                entry.set_state(PageState::Writeback);
+                if required_first.is_some() {
+                    entry.set_writeback_tag(0);
+                }
+                cache.account_state_transition(PageState::Dirty, PageState::Writeback);
+                inner.dirty_pages.remove(&page_index);
+                inner.writeback_pages.insert(page_index);
+                let page = entry.page.clone();
+                guards.push(WritebackGuard::new(
+                    cache.clone(),
+                    page_index,
+                    entry.clone(),
+                    page.clone(),
+                ));
+                prepared.push((page_index, entry, page));
+            }
+            first_index
+        };
+
+        Ok(Some(ClaimedWritebackBatch {
+            cache: cache.clone(),
+            backend,
+            first_index,
+            file_size,
+            entries: prepared,
+            guards,
+            data,
+        }))
+    }
+
+    fn complete_writeback_batch(
+        mut batch: ClaimedWritebackBatch,
+        result: Result<(), SystemError>,
+    ) -> Result<(), SystemError> {
+        if let Err(error) = result.as_ref() {
+            batch
+                .cache
+                .record_writeback_error_with_superblock(error.clone());
+        }
+        let mut first_error = result.as_ref().err().cloned();
+        for (guard, (page_index, entry, page)) in
+            batch.guards.iter_mut().zip(batch.entries.drain(..))
+        {
+            guard.disarm();
+            if let Err(error) = Self::finish_writeback_entry_state(
+                batch.cache.clone(),
+                page_index,
+                entry,
+                page,
+                result.clone(),
+                false,
+            ) {
+                first_error.get_or_insert(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+
+    fn snapshot_writeback_batch(batch: &mut ClaimedWritebackBatch) -> Result<(), SystemError> {
+        for (page_index, _entry, page) in batch.entries.iter() {
+            let page_start = page_index
+                .checked_mul(MMArch::PAGE_SIZE)
+                .ok_or(SystemError::EOVERFLOW)?;
+            let len = batch
+                .file_size
+                .saturating_sub(page_start)
+                .min(MMArch::PAGE_SIZE);
+            // Every entry in this batch has already transitioned from Dirty
+            // to Writeback.  Even when a concurrent size change leaves the
+            // page wholly beyond the stable EOF, complete the dirty snapshot
+            // transition so completion can retire it instead of observing
+            // PG_DIRTY and requeueing it forever.  A zero length only omits
+            // payload; it does not undo the claimed writeback state.
+            batch.cache.mkclean_page(*page_index, false)?;
+            let mut page_guard = page.write();
+            page_guard.remove_flags(PageFlags::PG_DIRTY);
+            if len == 0 {
+                continue;
+            }
+            let src = unsafe { page_guard.as_slice() };
+            batch.data.extend_from_slice(&src[..len]);
+        }
+        Ok(())
+    }
+
+    /// Submit an already snapshotted batch.  This function must never acquire
+    /// invalidate/admission locks: async callers may run after a truncate has
+    /// started waiting for the published Writeback entries.
+    fn submit_writeback_batch(batch: ClaimedWritebackBatch) -> Result<(), SystemError> {
+        let result = if batch.data.is_empty() {
+            Ok(())
+        } else if let Some(backend) = batch.backend.as_ref() {
+            backend.write_pages(batch.first_index, &batch.data)
+        } else {
+            let inode = batch
+                .cache
+                .inode()
+                .and_then(|inode| inode.upgrade())
+                .ok_or(SystemError::EIO);
+            let offset = batch
+                .first_index
+                .checked_mul(MMArch::PAGE_SIZE)
+                .ok_or(SystemError::EOVERFLOW);
+            match (inode, offset) {
+                (Ok(inode), Ok(offset)) => inode
+                    .write_direct(
+                        offset,
+                        batch.data.len(),
+                        &batch.data,
+                        Mutex::new(FilePrivateData::Unused).lock(),
+                    )
+                    .and_then(|written| {
+                        if written == batch.data.len() {
+                            Ok(())
+                        } else {
+                            Err(SystemError::EIO)
+                        }
+                    }),
+                (Err(error), _) | (_, Err(error)) => Err(error),
+            }
+        };
+        Self::complete_writeback_batch(batch, result)
+    }
+
+    fn claim_and_snapshot_with_stable_size(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+    ) -> Result<Option<ClaimedWritebackBatch>, SystemError> {
+        let _invalidate = cache.invalidate_read();
+        Self::claim_and_snapshot_locked(cache, start_index, end_index, file_size)
+    }
+
+    /// Claim and snapshot with the invalidate read lock already held.
+    fn claim_and_snapshot_locked(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+    ) -> Result<Option<ClaimedWritebackBatch>, SystemError> {
+        let Some(mut batch) =
+            Self::claim_next_writeback_batch(cache, start_index, end_index, file_size, None)?
+        else {
+            return Ok(None);
+        };
+        if let Err(error) = Self::snapshot_writeback_batch(&mut batch) {
+            return Self::complete_writeback_batch(batch, Err(error)).map(|_| None);
+        }
+        Ok(Some(batch))
+    }
+
+    fn claim_and_snapshot_tagged_locked(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+        required_entry: &Arc<PageEntry>,
+        epoch: u64,
+    ) -> Result<Option<ClaimedWritebackBatch>, SystemError> {
+        let Some(mut batch) = Self::claim_next_writeback_batch(
+            cache,
+            start_index,
+            end_index,
+            file_size,
+            Some((start_index, required_entry, epoch)),
+        )?
+        else {
+            return Ok(None);
+        };
+        if let Err(error) = Self::snapshot_writeback_batch(&mut batch) {
+            return Self::complete_writeback_batch(batch, Err(error)).map(|_| None);
+        }
+        Ok(Some(batch))
+    }
+
+    fn writeback_next_batch_with_stable_size(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+    ) -> Result<bool, SystemError> {
+        let Some(batch) =
+            Self::claim_and_snapshot_with_stable_size(cache, start_index, end_index, file_size)?
+        else {
+            return Ok(false);
+        };
+        Self::submit_writeback_batch(batch)?;
+        Ok(true)
+    }
+
+    fn claim_next_batch_with_admission(
+        &self,
+        cache: &Arc<PageCache>,
+        inode: &Arc<dyn IndexNode>,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<Option<ClaimedWritebackBatch>, SystemError> {
+        let Some(backend) = cache.backend() else {
+            let _invalidate = cache.invalidate_read();
+            let file_size = inode.metadata()?.size.max(0) as usize;
+            return Self::claim_and_snapshot_locked(cache, start_index, end_index, file_size);
+        };
+        let mut claimed = None;
+        backend.with_write_admission(&mut || {
+            let _invalidate = cache.invalidate_read();
+            let file_size = backend.stable_writeback_size(inode)?;
+            claimed = Self::claim_and_snapshot_locked(cache, start_index, end_index, file_size)?;
+            Ok(())
+        })?;
+        Ok(claimed)
+    }
+
+    fn claim_tagged_batch_with_admission(
+        &self,
+        cache: &Arc<PageCache>,
+        inode: &Arc<dyn IndexNode>,
+        start_index: usize,
+        end_index: usize,
+        required_entry: &Arc<PageEntry>,
+        epoch: u64,
+    ) -> Result<Option<ClaimedWritebackBatch>, SystemError> {
+        let Some(backend) = cache.backend() else {
+            let _invalidate = cache.invalidate_read();
+            let file_size = inode.metadata()?.size.max(0) as usize;
+            return Self::claim_and_snapshot_tagged_locked(
+                cache,
+                start_index,
+                end_index,
+                file_size,
+                required_entry,
+                epoch,
+            );
+        };
+        let mut claimed = None;
+        backend.with_write_admission(&mut || {
+            let _invalidate = cache.invalidate_read();
+            let file_size = backend.stable_writeback_size(inode)?;
+            claimed = Self::claim_and_snapshot_tagged_locked(
+                cache,
+                start_index,
+                end_index,
+                file_size,
+                required_entry,
+                epoch,
+            )?;
+            Ok(())
+        })?;
+        Ok(claimed)
+    }
+
+    fn try_claim_next_batch_with_admission(
+        &self,
+        cache: &Arc<PageCache>,
+        inode: &Arc<dyn IndexNode>,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<Option<ClaimedWritebackBatch>, SystemError> {
+        let Some(backend) = cache.backend() else {
+            let Some(_invalidate) = cache.try_invalidate_read() else {
+                return Ok(None);
+            };
+            let file_size = inode.metadata()?.size.max(0) as usize;
+            return Self::claim_and_snapshot_locked(cache, start_index, end_index, file_size);
+        };
+        let mut invalidate_acquired = false;
+        let mut claimed = None;
+        let admitted = backend.try_with_write_admission(&mut || {
+            let Some(_invalidate) = cache.try_invalidate_read() else {
+                return Ok(());
+            };
+            invalidate_acquired = true;
+            let file_size = backend.stable_writeback_size(inode)?;
+            claimed = Self::claim_and_snapshot_locked(cache, start_index, end_index, file_size)?;
+            Ok(())
+        })?;
+        if !admitted || !invalidate_acquired {
+            return Ok(None);
+        }
+        Ok(claimed)
+    }
+
+    fn writeback_next_batch(
+        &self,
+        cache: &Arc<PageCache>,
+        inode: &Arc<dyn IndexNode>,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<bool, SystemError> {
+        let Some(batch) =
+            self.claim_next_batch_with_admission(cache, inode, start_index, end_index)?
+        else {
+            return Ok(false);
+        };
+        Self::submit_writeback_batch(batch)?;
+        Ok(true)
+    }
+
+    fn wait_data_range_clean(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<bool, SystemError> {
+        if start_index > end_index {
+            return Ok(true);
+        }
+        Self::wait_writeback_range_bounded(cache, start_index, end_index)?;
+        let inner = cache.inner.lock();
+        let has_dirty = inner
+            .dirty_pages
+            .range(start_index..=end_index)
+            .next()
+            .is_some();
+        let has_writeback = inner
+            .writeback_pages
+            .range(start_index..=end_index)
+            .next()
+            .is_some();
+        Ok(!has_dirty && !has_writeback)
+    }
+
+    fn wait_writeback_range_bounded(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<(), SystemError> {
+        if start_index > end_index {
+            return Ok(());
+        }
+        const WAIT_BATCH_ENTRIES: usize = 64;
+        const WAIT_SCAN_INDICES: usize = 256;
+        let mut cursor = start_index;
+        let mut first_error = None;
+        loop {
+            if cursor > end_index {
+                break;
+            }
+            let (entries, last_scanned) = {
+                let inner = cache.inner.lock();
+                let mut entries = Vec::new();
+                entries
+                    .try_reserve_exact(WAIT_BATCH_ENTRIES)
+                    .map_err(|_| SystemError::ENOMEM)?;
+                let mut last_scanned = None;
+                let mut scanned = 0usize;
+                for index in inner.page_indices.range(cursor..=end_index) {
+                    last_scanned = Some(*index);
+                    scanned += 1;
+                    let Some(entry) = inner.pages.get(index) else {
+                        if scanned == WAIT_SCAN_INDICES {
+                            break;
+                        }
+                        continue;
+                    };
+                    if entry.state() == PageState::Writeback {
+                        entries.push(entry.clone());
+                    }
+                    if entries.len() == WAIT_BATCH_ENTRIES || scanned == WAIT_SCAN_INDICES {
+                        break;
+                    }
+                }
+                (entries, last_scanned)
+            };
+            let Some(last_scanned) = last_scanned else {
+                break;
+            };
+            for entry in entries {
+                if let Err(error) = Self::wait_writeback_entry(entry) {
+                    first_error.get_or_insert(error);
+                }
+            }
+            if last_scanned == usize::MAX {
+                break;
+            }
+            cursor = last_scanned + 1;
+            crate::sched::sched_yield();
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+
+    fn sync_data_with_stable_size(
+        &self,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+    ) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        loop {
+            while Self::writeback_next_batch_with_stable_size(
+                &cache,
+                start_index,
+                end_index,
+                file_size,
+            )? {}
+            if Self::wait_data_range_clean(&cache, start_index, end_index)? {
+                return Ok(());
+            }
+        }
+    }
+
+    fn sync_data_admitted(
+        &self,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+    ) -> Result<(), SystemError> {
+        self.sync_data_with_stable_size(start_index, end_index, file_size)
+    }
+
+    fn sync_data(&self, start_index: usize, end_index: usize) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        let inode = cache
+            .inode()
+            .and_then(|inode| inode.upgrade())
+            .ok_or(SystemError::EIO)?;
+        loop {
+            while self.writeback_next_batch(&cache, &inode, start_index, end_index)? {}
+            if Self::wait_data_range_clean(&cache, start_index, end_index)? {
+                return Ok(());
+            }
+        }
+    }
+
     pub fn sync(&self) -> Result<(), SystemError> {
         let cache = self.upgrade()?;
         // Keep the canonical inode alive across the boundary between the last
@@ -1137,41 +2023,7 @@ impl PageCacheManager {
             .ok_or(SystemError::EIO)?;
         let _sync_retention =
             InodeRetentionGuard::new(sync_inode.clone(), InodeRetentionKind::AsyncWork)?;
-        loop {
-            let (dirty_entries, writeback_entries): (Vec<_>, Vec<_>) = {
-                let inner = cache.inner.lock();
-                let dirty = inner
-                    .dirty_pages
-                    .iter()
-                    .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
-                    .collect();
-                let writeback = inner
-                    .pages
-                    .values()
-                    .filter(|entry| entry.state() == PageState::Writeback)
-                    .cloned()
-                    .collect();
-                (dirty, writeback)
-            };
-
-            for (page_index, entry) in dirty_entries {
-                Self::writeback_entry(&cache, page_index, entry)?;
-            }
-            for entry in writeback_entries {
-                Self::wait_writeback_entry(entry)?;
-            }
-
-            let inner = cache.inner.lock();
-            let done = inner.dirty_pages.is_empty()
-                && !inner
-                    .pages
-                    .values()
-                    .any(|entry| entry.state() == PageState::Writeback);
-            drop(inner);
-            if done {
-                break;
-            }
-        }
+        self.sync_data(0, usize::MAX)?;
 
         // 脏页写完后调 write_inode 回写元数据。
         let wbc = WritebackControl::sync_all_for_sync();
@@ -1184,36 +2036,130 @@ impl PageCacheManager {
         Ok(())
     }
 
+    /// Synchronize after the filesystem has already blocked new dirty-page
+    /// admission and supplied the authoritative i_size.  Callers must not use
+    /// this as a substitute for `PageCacheBackend::with_write_admission`.
+    pub(crate) fn sync_with_stable_size(&self, file_size: usize) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        let sync_inode = cache
+            .inode()
+            .and_then(|inode| inode.upgrade())
+            .ok_or(SystemError::EIO)?;
+        let _sync_retention =
+            InodeRetentionGuard::new(sync_inode.clone(), InodeRetentionKind::AsyncWork)?;
+        self.sync_data_admitted(0, usize::MAX, file_size)?;
+
+        let wbc = WritebackControl::sync_all_for_sync();
+        if let Err(error) = sync_inode.write_inode(&wbc) {
+            cache.record_writeback_error_with_superblock(error.clone());
+            return Err(error);
+        }
+        Ok(())
+    }
+
     /// Write and wait for every dirty or in-flight page in an inclusive range.
     ///
     /// Unlike `writeback_range`, this is a data-integrity operation: pages
     /// already under writeback when the call starts must complete before the
     /// caller may issue a backend fsync request.
     pub fn sync_range(&self, start_index: usize, end_index: usize) -> Result<(), SystemError> {
-        let cache = self.upgrade()?;
-        loop {
-            let (dirty_entries, writeback_entries): (Vec<_>, Vec<_>) = {
-                let inner = cache.inner.lock();
-                let dirty = inner
-                    .dirty_pages
-                    .range(start_index..=end_index)
-                    .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
-                    .collect();
-                let writeback = inner
-                    .page_indices
-                    .range(start_index..=end_index)
-                    .filter_map(|idx| inner.pages.get(idx))
-                    .filter(|entry| entry.state() == PageState::Writeback)
-                    .cloned()
-                    .collect();
-                (dirty, writeback)
-            };
+        self.sync_data(start_index, end_index)
+    }
 
-            for (page_index, entry) in dirty_entries {
-                Self::writeback_entry(&cache, page_index, entry)?;
+    /// Range counterpart of `sync_with_stable_size` for filesystem-private
+    /// wrappers which already hold their write admission barrier.
+    pub(crate) fn sync_range_with_stable_size(
+        &self,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+    ) -> Result<(), SystemError> {
+        self.sync_data_admitted(start_index, end_index, file_size)
+    }
+
+    pub fn resize(&self, len: usize) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        cache.truncate(len)
+    }
+
+    pub fn writeback_range(&self, start_index: usize, end_index: usize) -> Result<(), SystemError> {
+        self.sync_data(start_index, end_index)
+    }
+
+    pub fn wait_writeback_range(
+        &self,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<(), SystemError> {
+        let cache = self.upgrade()?;
+        Self::wait_writeback_range_bounded(&cache, start_index, end_index)
+    }
+
+    /// Launder a complete range for best-effort cache invalidation.
+    ///
+    /// Ordinary range writeback is fail-fast. Invalidation instead mirrors
+    /// Linux invalidate_inode_pages2_range(): retain the first error but keep
+    /// processing every later page in the range.
+    pub(crate) fn launder_range_for_invalidate_with_stable_size(
+        &self,
+        start_index: usize,
+        end_index: usize,
+        file_size: usize,
+    ) -> Result<(), SystemError> {
+        if start_index > end_index {
+            return Ok(());
+        }
+        let cache = self.upgrade()?;
+        let mut first_error = None;
+        loop {
+            let mut cursor = start_index;
+            while cursor <= end_index {
+                let prepared = {
+                    let _invalidate = cache.invalidate_read();
+                    match Self::claim_next_writeback_batch(
+                        &cache, cursor, end_index, file_size, None,
+                    ) {
+                        Ok(Some(mut batch)) => {
+                            pc_stats::record_invalidation_launder_batch(batch.entries.len());
+                            let last_index = batch
+                                .entries
+                                .last()
+                                .map(|(index, _, _)| *index)
+                                .unwrap_or(cursor);
+                            let snapshot_result = Self::snapshot_writeback_batch(&mut batch);
+                            Ok(Some((batch, last_index, snapshot_result)))
+                        }
+                        Ok(None) => Ok(None),
+                        Err(error) => Err(error),
+                    }
+                };
+                let Some((batch, last_index, snapshot_result)) = (match prepared {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        first_error.get_or_insert(error);
+                        break;
+                    }
+                }) else {
+                    break;
+                };
+                let result = match snapshot_result {
+                    Ok(()) => Self::submit_writeback_batch(batch),
+                    Err(error) => Self::complete_writeback_batch(batch, Err(error)),
+                };
+                if let Err(error) = result {
+                    first_error.get_or_insert(error);
+                }
+                if last_index == usize::MAX {
+                    break;
+                }
+                cursor = last_index + 1;
             }
-            for entry in writeback_entries {
-                Self::wait_writeback_entry(entry)?;
+
+            if let Err(error) = Self::wait_writeback_range_bounded(&cache, start_index, end_index) {
+                first_error.get_or_insert(error);
+            }
+            if let Some(error) = first_error.take() {
+                return Err(error);
             }
 
             let inner = cache.inner.lock();
@@ -1223,102 +2169,18 @@ impl PageCacheManager {
                 .next()
                 .is_some();
             let has_writeback = inner
-                .page_indices
+                .writeback_pages
                 .range(start_index..=end_index)
-                .filter_map(|idx| inner.pages.get(idx))
-                .any(|entry| entry.state() == PageState::Writeback);
+                .next()
+                .is_some();
             if !has_dirty && !has_writeback {
                 return Ok(());
             }
+            // A generation may have been redirtied behind an older Writeback
+            // before the filesystem barrier became exclusive. The old
+            // completion restores it to Dirty; restart from the range head so
+            // invalidation cannot report success with that generation left.
         }
-    }
-
-    pub fn resize(&self, len: usize) -> Result<(), SystemError> {
-        let cache = self.upgrade()?;
-        cache.truncate(len)
-    }
-
-    pub fn writeback_range(&self, start_index: usize, end_index: usize) -> Result<(), SystemError> {
-        let cache = self.upgrade()?;
-        let dirty_entries: Vec<(usize, Arc<PageEntry>)> = {
-            let inner = cache.inner.lock();
-            inner
-                .dirty_pages
-                .range(start_index..=end_index)
-                .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
-                .collect()
-        };
-
-        for (page_index, entry) in dirty_entries {
-            Self::writeback_entry(&cache, page_index, entry)?;
-        }
-
-        Ok(())
-    }
-
-    pub fn wait_writeback_range(
-        &self,
-        start_index: usize,
-        end_index: usize,
-    ) -> Result<(), SystemError> {
-        let cache = self.upgrade()?;
-        let entries: Vec<Arc<PageEntry>> = {
-            let inner = cache.inner.lock();
-            inner
-                .page_indices
-                .range(start_index..=end_index)
-                .filter_map(|idx| inner.pages.get(idx).cloned())
-                .collect()
-        };
-
-        for entry in entries {
-            Self::wait_writeback_entry(entry)?;
-        }
-
-        Ok(())
-    }
-
-    /// Launder a complete range for best-effort cache invalidation.
-    ///
-    /// Ordinary range writeback is fail-fast. Invalidation instead mirrors
-    /// Linux invalidate_inode_pages2_range(): retain the first error but keep
-    /// processing every later page in the range.
-    pub(crate) fn launder_range_for_invalidate(
-        &self,
-        start_index: usize,
-        end_index: usize,
-    ) -> Result<(), SystemError> {
-        let cache = self.upgrade()?;
-        let dirty_entries: Vec<(usize, Arc<PageEntry>)> = {
-            let inner = cache.inner.lock();
-            inner
-                .dirty_pages
-                .range(start_index..=end_index)
-                .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
-                .collect()
-        };
-        let mut first_error = None;
-        for (page_index, entry) in dirty_entries {
-            if let Err(error) = Self::writeback_entry(&cache, page_index, entry) {
-                first_error.get_or_insert(error);
-            }
-        }
-
-        let entries: Vec<Arc<PageEntry>> = {
-            let inner = cache.inner.lock();
-            inner
-                .page_indices
-                .range(start_index..=end_index)
-                .filter_map(|idx| inner.pages.get(idx).cloned())
-                .collect()
-        };
-        for entry in entries {
-            if let Err(error) = Self::wait_writeback_entry(entry) {
-                first_error.get_or_insert(error);
-            }
-        }
-
-        first_error.map_or(Ok(()), Err)
     }
 
     pub fn prepare_page_mkwrite(
@@ -1339,15 +2201,19 @@ impl PageCacheManager {
                 }
                 entry
             };
-
             match entry.state() {
                 PageState::Loading => {
                     let _ = entry.wait_ready()?;
                     continue;
                 }
                 PageState::Writeback => {
-                    Self::wait_writeback_entry(entry)?;
-                    continue;
+                    // The fault path holds AddressSpace::write(). Batch
+                    // writeback publishes this state before mkclean_page()
+                    // takes AddressSpace::read(), so waiting here would form
+                    // mm.write -> writeback -> mm.read. The fault handler
+                    // installs a wait token and retries after dropping the MM
+                    // guard.
+                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
                 }
                 PageState::Error => return Err(SystemError::EIO),
                 PageState::UpToDate | PageState::Dirty => {}
@@ -1383,22 +2249,243 @@ impl PageCacheManager {
         &self,
         start_index: usize,
         end_index: usize,
+        sync_all: bool,
     ) -> Result<(), SystemError> {
+        if start_index > end_index {
+            return Ok(());
+        }
         let cache = self.upgrade()?;
-        let dirty_entries: Vec<(usize, Arc<PageEntry>)> = {
+        let inode = cache
+            .inode()
+            .and_then(|inode| inode.upgrade())
+            .ok_or(SystemError::EIO)?;
+        let _tagged_writeback = cache.tagged_writeback_lock.lock();
+
+        // Freeze the caller-visible dirty set with an epoch tag, equivalent to
+        // Linux's PAGECACHE_TAG_TOWRITE pass but without materializing an
+        // unbounded Vec. A monotonic index walk bounds transient memory and
+        // prevents a low-index redirtier from starving later pages.
+        let mut epoch = PAGE_CACHE_WRITEBACK_TAG_EPOCH.fetch_add(1, Ordering::AcqRel);
+        if epoch == 0 {
+            epoch = PAGE_CACHE_WRITEBACK_TAG_EPOCH.fetch_add(1, Ordering::AcqRel);
+        }
+        const WRITEBACK_TAG_CHUNK: usize = 256;
+        let Some(frozen_end) = ({
             let inner = cache.inner.lock();
             inner
                 .dirty_pages
                 .range(start_index..=end_index)
-                .filter_map(|idx| inner.pages.get(idx).cloned().map(|entry| (*idx, entry)))
-                .collect()
+                .next_back()
+                .copied()
+        }) else {
+            return Ok(());
         };
-
-        for (page_index, entry) in dirty_entries {
-            Self::start_writeback_entry(&cache, page_index, entry)?;
+        let mut tag_cursor = start_index;
+        loop {
+            let last_tagged = {
+                let inner = cache.inner.lock();
+                let mut last = None;
+                for index in inner
+                    .dirty_pages
+                    .range(tag_cursor..=frozen_end)
+                    .take(WRITEBACK_TAG_CHUNK)
+                {
+                    if let Some(entry) = inner.pages.get(index) {
+                        entry.set_writeback_tag(epoch);
+                        last = Some(*index);
+                    }
+                }
+                last
+            };
+            let Some(last_tagged) = last_tagged else {
+                break;
+            };
+            if last_tagged >= frozen_end || last_tagged == usize::MAX {
+                break;
+            }
+            tag_cursor = last_tagged + 1;
+            // Mirror Linux tag_pages_for_writeback(): do not monopolize the
+            // page-cache index lock or CPU while tagging a very large range.
+            crate::sched::sched_yield();
         }
 
+        let mut cursor = start_index;
+        loop {
+            if cursor > frozen_end {
+                break;
+            }
+            let (target, last_scanned) = {
+                let inner = cache.inner.lock();
+                let mut target = None;
+                let mut last_scanned = None;
+                for index in inner
+                    .dirty_pages
+                    .range(cursor..=frozen_end)
+                    .take(WRITEBACK_TAG_CHUNK)
+                {
+                    last_scanned = Some(*index);
+                    let Some(entry) = inner.pages.get(index) else {
+                        continue;
+                    };
+                    if entry.writeback_tag() == epoch {
+                        let mut tagged_end = *index;
+                        for next in inner
+                            .dirty_pages
+                            .range(*index..=frozen_end)
+                            .skip(1)
+                            .take(WRITEBACK_TAG_CHUNK - 1)
+                        {
+                            if *next != tagged_end.saturating_add(1) {
+                                break;
+                            }
+                            let Some(next_entry) = inner.pages.get(next) else {
+                                break;
+                            };
+                            if next_entry.writeback_tag() != epoch {
+                                break;
+                            }
+                            tagged_end = *next;
+                        }
+                        target = Some((*index, entry.clone(), tagged_end));
+                        break;
+                    }
+                }
+                (target, last_scanned)
+            };
+            let Some((target_index, target_entry, tagged_end)) = target else {
+                let Some(last_scanned) = last_scanned else {
+                    break;
+                };
+                if last_scanned >= frozen_end || last_scanned == usize::MAX {
+                    break;
+                }
+                cursor = last_scanned + 1;
+                crate::sched::sched_yield();
+                continue;
+            };
+
+            if target_entry.state() == PageState::Writeback {
+                if sync_all {
+                    Self::wait_writeback_entry(target_entry.clone())?;
+                    continue;
+                } else {
+                    if target_index == usize::MAX {
+                        break;
+                    }
+                    cursor = target_index + 1;
+                    continue;
+                }
+            }
+
+            let permit = AsyncWritebackPermit::acquire();
+            let Some(batch) = self.claim_tagged_batch_with_admission(
+                &cache,
+                &inode,
+                target_index,
+                tagged_end,
+                &target_entry,
+                epoch,
+            )?
+            else {
+                drop(permit);
+                let (same_tagged_entry, state) = {
+                    let inner = cache.inner.lock();
+                    match inner.pages.get(&target_index) {
+                        Some(current)
+                            if Arc::ptr_eq(current, &target_entry)
+                                && inner.dirty_pages.contains(&target_index)
+                                && current.writeback_tag() == epoch =>
+                        {
+                            (true, current.state())
+                        }
+                        _ => (false, target_entry.state()),
+                    }
+                };
+                if sync_all && same_tagged_entry {
+                    if state == PageState::Writeback {
+                        Self::wait_writeback_entry(target_entry.clone())?;
+                    }
+                    // Dirty may have raced with another completion between
+                    // admission and claim. Retry the same tagged target; only
+                    // identity removal or loss of the epoch permits advance.
+                    continue;
+                }
+                if target_index == usize::MAX {
+                    break;
+                }
+                cursor = target_index + 1;
+                continue;
+            };
+            let last_index = batch
+                .entries
+                .last()
+                .map(|(index, _, _)| *index)
+                .unwrap_or(target_index);
+            let work_state = Mutex::new(Some((permit, batch)));
+            schedule_pagecache_writeback(Work::new(move || {
+                let Some((permit, batch)) = work_state.lock().take() else {
+                    return;
+                };
+                let _permit = permit;
+                let _ = Self::submit_writeback_batch(batch);
+            }));
+            if last_index == usize::MAX {
+                break;
+            }
+            cursor = last_index + 1;
+        }
         Ok(())
+    }
+
+    /// Schedule one bounded reclaimer batch without doing page/MM work on the
+    /// reclaim thread. A busy runner or global budget leaves pages Dirty for a
+    /// later round; lock-taking claim/snapshot work runs in the I/O worker.
+    pub(crate) fn try_start_reclaimer_writeback_range(
+        &self,
+        start_index: usize,
+        end_index: usize,
+    ) -> Result<bool, SystemError> {
+        let cache = self.upgrade()?;
+        let Some(runner) = ReclaimerRunnerGuard::try_acquire(&cache) else {
+            return Ok(false);
+        };
+        let Some(permit) = AsyncWritebackPermit::try_acquire() else {
+            return Ok(false);
+        };
+        let inode = cache
+            .inode()
+            .and_then(|inode| inode.upgrade())
+            .ok_or(SystemError::EIO)?;
+        let manager = self.clone();
+        let work_state = Mutex::new(Some((runner, permit, cache, inode)));
+        schedule_pagecache_io(Work::new(move || {
+            let Some((runner, permit, cache, inode)) = work_state.lock().take() else {
+                return;
+            };
+            let _runner = runner;
+            let _permit = permit;
+            // Drain the caller's bounded scan range in file-offset order.
+            // Keeping one runner per cache prevents overlapping reclaimer
+            // workers, while advancing after each submitted batch avoids the
+            // former one-batch-per-5-second throughput ceiling. A page dirtied
+            // again behind the cursor is intentionally left for a later scan.
+            let mut cursor = start_index;
+            while cursor <= end_index {
+                let Ok(Some(batch)) =
+                    manager.try_claim_next_batch_with_admission(&cache, &inode, cursor, end_index)
+                else {
+                    break;
+                };
+                let Some(last_index) = batch.entries.last().map(|(index, _, _)| *index) else {
+                    break;
+                };
+                if Self::submit_writeback_batch(batch).is_err() || last_index == usize::MAX {
+                    break;
+                }
+                cursor = last_index + 1;
+            }
+        }));
+        Ok(true)
     }
 
     pub fn invalidate_range(
@@ -1549,12 +2636,7 @@ impl PageCacheManager {
     }
 
     pub fn writeback_page(&self, page_index: usize) -> Result<(), SystemError> {
-        let cache = self.upgrade()?;
-        let entry = match cache.inner.lock().get_entry(page_index) {
-            Some(entry) => entry,
-            None => return Ok(()),
-        };
-        Self::writeback_entry(&cache, page_index, entry)
+        self.sync_data(page_index, page_index)
     }
 
     fn wait_writeback_entry(entry: Arc<PageEntry>) -> Result<(), SystemError> {
@@ -1565,98 +2647,6 @@ impl PageCacheManager {
         })
     }
 
-    fn prepare_writeback_entry(
-        cache: &Arc<PageCache>,
-        page_index: usize,
-        entry: &Arc<PageEntry>,
-    ) -> Result<bool, SystemError> {
-        loop {
-            match entry.state() {
-                PageState::Loading => {
-                    let _ = entry.wait_ready()?;
-                    continue;
-                }
-                PageState::Writeback => {
-                    Self::wait_writeback_entry(entry.clone())?;
-                    continue;
-                }
-                PageState::Error => return Err(SystemError::EIO),
-                PageState::UpToDate => {
-                    let guard = entry.page.read();
-                    if !guard.flags().contains(PageFlags::PG_DIRTY) {
-                        return Ok(false);
-                    }
-                    drop(guard);
-                    let mut inner = cache.inner.lock();
-                    cache.ensure_dirty_retention_locked(&mut inner)?;
-                    entry.set_state(PageState::Dirty);
-                    inner.dirty_pages.insert(page_index);
-                    continue;
-                }
-                PageState::Dirty => {
-                    let guard = entry.page.read();
-                    if !guard.flags().contains(PageFlags::PG_DIRTY) {
-                        return Ok(false);
-                    }
-                }
-            }
-            if entry
-                .compare_exchange_state(PageState::Dirty, PageState::Writeback)
-                .is_ok()
-            {
-                cache.account_state_transition(PageState::Dirty, PageState::Writeback);
-                let mut inner = cache.inner.lock();
-                inner.dirty_pages.remove(&page_index);
-                return Ok(true);
-            }
-        }
-    }
-
-    fn try_prepare_async_writeback_entry(
-        cache: &Arc<PageCache>,
-        page_index: usize,
-        entry: &Arc<PageEntry>,
-    ) -> Result<bool, SystemError> {
-        loop {
-            match entry.state() {
-                PageState::Loading => {
-                    let _ = entry.wait_ready()?;
-                    continue;
-                }
-                PageState::Writeback => return Ok(false),
-                PageState::Error => return Err(SystemError::EIO),
-                PageState::UpToDate => {
-                    let guard = entry.page.read();
-                    if !guard.flags().contains(PageFlags::PG_DIRTY) {
-                        return Ok(false);
-                    }
-                    drop(guard);
-                    let mut inner = cache.inner.lock();
-                    cache.ensure_dirty_retention_locked(&mut inner)?;
-                    entry.set_state(PageState::Dirty);
-                    inner.dirty_pages.insert(page_index);
-                    continue;
-                }
-                PageState::Dirty => {
-                    let guard = entry.page.read();
-                    if !guard.flags().contains(PageFlags::PG_DIRTY) {
-                        return Ok(false);
-                    }
-                }
-            }
-
-            if entry
-                .compare_exchange_state(PageState::Dirty, PageState::Writeback)
-                .is_ok()
-            {
-                cache.account_state_transition(PageState::Dirty, PageState::Writeback);
-                let mut inner = cache.inner.lock();
-                inner.dirty_pages.remove(&page_index);
-                return Ok(true);
-            }
-        }
-    }
-
     fn finish_writeback_entry(
         cache: Arc<PageCache>,
         page_index: usize,
@@ -1664,8 +2654,21 @@ impl PageCacheManager {
         page: Arc<Page>,
         result: Result<(), SystemError>,
     ) -> Result<(), SystemError> {
+        Self::finish_writeback_entry_state(cache, page_index, entry, page, result, true)
+    }
+
+    fn finish_writeback_entry_state(
+        cache: Arc<PageCache>,
+        page_index: usize,
+        entry: Arc<PageEntry>,
+        page: Arc<Page>,
+        result: Result<(), SystemError>,
+        record_error: bool,
+    ) -> Result<(), SystemError> {
         if let Err(e) = result {
-            cache.record_writeback_error_with_superblock(e.clone());
+            if record_error {
+                cache.record_writeback_error_with_superblock(e.clone());
+            }
             {
                 let mut guard = page.write();
                 guard.add_flags(PageFlags::PG_ERROR | PageFlags::PG_DIRTY);
@@ -1673,6 +2676,7 @@ impl PageCacheManager {
             {
                 let mut inner = cache.inner.lock();
                 cache.account_state_transition(PageState::Writeback, PageState::Dirty);
+                inner.writeback_pages.remove(&page_index);
                 inner.dirty_pages.insert(page_index);
                 entry.set_state(PageState::Dirty);
             }
@@ -1697,6 +2701,7 @@ impl PageCacheManager {
             // writeback paths acquire the page lock before updating the page
             // cache, so doing so would invert the established lock order.
             let redirtied = page_dirty || inner.dirty_pages.contains(&page_index);
+            inner.writeback_pages.remove(&page_index);
             if redirtied {
                 cache.account_state_transition(PageState::Writeback, PageState::Dirty);
                 inner.dirty_pages.insert(page_index);
@@ -1711,163 +2716,6 @@ impl PageCacheManager {
         drop(cache.detach_dirty_retention_if_idle());
         Ok(())
     }
-
-    fn start_writeback_entry(
-        cache: &Arc<PageCache>,
-        page_index: usize,
-        entry: Arc<PageEntry>,
-    ) -> Result<(), SystemError> {
-        let _invalidate = cache.invalidate_read();
-        if !Self::try_prepare_async_writeback_entry(cache, page_index, &entry)? {
-            return Ok(());
-        }
-
-        let page = entry.page.clone();
-
-        // If the inode has been freed, restore page state via finish_writeback_entry and return error.
-        let inode = match cache.inode().and_then(|inode| inode.upgrade()) {
-            Some(inode) => inode,
-            None => {
-                Self::finish_writeback_entry(
-                    cache.clone(),
-                    page_index,
-                    entry,
-                    page,
-                    Err(SystemError::EIO),
-                )?;
-                return Err(SystemError::EIO);
-            }
-        };
-        let backend = cache.backend();
-        let page_start = page_index * MMArch::PAGE_SIZE;
-        let len = if let Ok(metadata) = inode.metadata() {
-            let file_size = metadata.size.max(0) as usize;
-            if file_size <= page_start {
-                0
-            } else {
-                core::cmp::min(MMArch::PAGE_SIZE, file_size - page_start)
-            }
-        } else {
-            MMArch::PAGE_SIZE
-        };
-
-        let data = if len > 0 {
-            let _ = cache.mkclean_page(page_index, false);
-            let mut guard = page.write();
-            guard.remove_flags(PageFlags::PG_DIRTY);
-            let src = unsafe { guard.as_slice() };
-            Some(src[..len].to_vec())
-        } else {
-            None
-        };
-
-        let cache = cache.clone();
-        let work_page = page.clone();
-        let work_entry = entry.clone();
-        let work = Work::new(move || {
-            let result = match &data {
-                Some(data) => {
-                    if let Some(backend) = &backend {
-                        match backend.write_page(page_index, data) {
-                            Ok(written) if written == data.len() => Ok(()),
-                            Ok(_) => Err(SystemError::EIO),
-                            Err(e) => Err(e),
-                        }
-                    } else {
-                        inode
-                            .write_direct(
-                                page_start,
-                                data.len(),
-                                data,
-                                Mutex::new(FilePrivateData::Unused).lock(),
-                            )
-                            .map(|_| ())
-                    }
-                }
-                None => Ok(()),
-            };
-            let _ = Self::finish_writeback_entry(
-                cache.clone(),
-                page_index,
-                work_entry.clone(),
-                work_page.clone(),
-                result,
-            );
-        });
-        schedule_pagecache_io(work);
-        Ok(())
-    }
-
-    fn writeback_entry(
-        cache: &Arc<PageCache>,
-        page_index: usize,
-        entry: Arc<PageEntry>,
-    ) -> Result<(), SystemError> {
-        let _invalidate = cache.invalidate_read();
-        if !Self::prepare_writeback_entry(cache, page_index, &entry)? {
-            return Ok(());
-        }
-
-        let page = entry.page.clone();
-        // RAII: if any subsequent path exits early, WritebackGuard ensures the page reverts to Dirty.
-        let mut wb_guard =
-            WritebackGuard::new(cache.clone(), page_index, entry.clone(), page.clone());
-
-        let inode = cache
-            .inode()
-            .and_then(|inode| inode.upgrade())
-            .ok_or(SystemError::EIO)?;
-        let backend = cache.backend();
-        let page_start = page_index * MMArch::PAGE_SIZE;
-        let len = if let Ok(metadata) = inode.metadata() {
-            let file_size = metadata.size.max(0) as usize;
-            if file_size <= page_start {
-                0
-            } else {
-                core::cmp::min(MMArch::PAGE_SIZE, file_size - page_start)
-            }
-        } else {
-            MMArch::PAGE_SIZE
-        };
-
-        if len > 0 {
-            let _ = cache.mkclean_page(page_index, false);
-            {
-                let mut guard = page.write();
-                guard.remove_flags(PageFlags::PG_DIRTY);
-            }
-            let result = if let Some(backend) = backend {
-                let data = {
-                    let guard = page.read();
-                    let src = unsafe { guard.as_slice() };
-                    src[..len].to_vec()
-                };
-                match backend.write_page(page_index, &data) {
-                    Ok(written) if written == data.len() => Ok(len),
-                    Ok(_) => Err(SystemError::EIO),
-                    Err(e) => Err(e),
-                }
-            } else {
-                let data = unsafe {
-                    core::slice::from_raw_parts(
-                        MMArch::phys_2_virt(page.phys_address()).unwrap().data() as *const u8,
-                        len,
-                    )
-                };
-                inode.write_direct(
-                    page_start,
-                    len,
-                    data,
-                    Mutex::new(FilePrivateData::Unused).lock(),
-                )
-            };
-            wb_guard.disarm();
-            Self::finish_writeback_entry(cache.clone(), page_index, entry, page, result.map(|_| ()))
-        } else {
-            wb_guard.disarm();
-            Self::finish_writeback_entry(cache.clone(), page_index, entry, page, Ok(()))
-        }
-    }
 }
 
 impl core::fmt::Debug for PageCacheManager {
@@ -1881,6 +2729,7 @@ impl PageEntry {
         Self {
             page,
             state: AtomicU8::new(state as u8),
+            writeback_tag: AtomicU64::new(0),
             accounted_unevictable: AtomicBool::new(false),
             active_users: AtomicUsize::new(0),
             wait_queue: WaitQueue::default(),
@@ -1893,6 +2742,14 @@ impl PageEntry {
 
     fn set_state(&self, state: PageState) {
         self.state.store(state as u8, Ordering::Release);
+    }
+
+    fn writeback_tag(&self) -> u64 {
+        self.writeback_tag.load(Ordering::Acquire)
+    }
+
+    fn set_writeback_tag(&self, epoch: u64) {
+        self.writeback_tag.store(epoch, Ordering::Release);
     }
 
     fn account_unevictable_if_needed(&self) {
@@ -1926,22 +2783,6 @@ impl PageEntry {
         PageEntryPin {
             entry: self.clone(),
         }
-    }
-
-    fn compare_exchange_state(
-        &self,
-        current: PageState,
-        new: PageState,
-    ) -> Result<PageState, PageState> {
-        self.state
-            .compare_exchange(
-                current as u8,
-                new as u8,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .map(Self::decode_state)
-            .map_err(Self::decode_state)
     }
 
     fn wait_ready(&self) -> Result<Arc<Page>, SystemError> {
@@ -2007,6 +2848,7 @@ impl InnerPageCache {
             pages: HashMap::new(),
             page_indices: BTreeSet::new(),
             dirty_pages: BTreeSet::new(),
+            writeback_pages: BTreeSet::new(),
             dirty_retention: None,
             dirty_preparations: 0,
             page_cache_ref,
@@ -2021,6 +2863,7 @@ impl InnerPageCache {
         let entry = self.pages.remove(&offset)?;
         self.page_indices.remove(&offset);
         self.dirty_pages.remove(&offset);
+        self.writeback_pages.remove(&offset);
         if let Some(cache) = self.page_cache_ref.upgrade() {
             cache.account_entry_remove(&entry);
         }
@@ -2112,6 +2955,8 @@ impl PageCache {
             unevictable: AtomicBool::new(false),
             is_shmem: AtomicBool::new(false),
             reclassify_lock: Mutex::new(()),
+            tagged_writeback_lock: Mutex::new(()),
+            reclaimer_writeback_active: AtomicBool::new(false),
             manager: PageCacheManager::new(weak.clone()),
         });
         register_page_cache(&cache);
@@ -2137,12 +2982,16 @@ impl PageCache {
         self.writeback_error.set(error);
     }
 
-    /// Record a writeback error in both the page cache mapping and its
-    /// mounted superblock, matching Linux mapping_set_error() semantics.
+    /// Record a writeback error in the page cache mapping and, while it is
+    /// still alive, its mounted superblock, matching Linux mapping_set_error()
+    /// semantics without assuming that a weak filesystem owner survived an
+    /// asynchronous writeback completion.
     pub fn record_writeback_error_with_superblock(&self, error: SystemError) {
         self.record_writeback_error(error.clone());
         if let Some(inode) = self.inode().and_then(|w| w.upgrade()) {
-            record_writeback_error_for_fs(&inode.fs(), error);
+            if let Some(fs) = inode.try_fs() {
+                record_writeback_error_for_fs(&fs, error);
+            }
         }
     }
 
@@ -2200,6 +3049,10 @@ impl PageCache {
 
     pub fn invalidate_read(&self) -> RwSemReadGuard<'_, ()> {
         self.invalidate_lock.read()
+    }
+
+    pub fn try_invalidate_read(&self) -> Option<RwSemReadGuard<'_, ()>> {
+        self.invalidate_lock.try_read()
     }
 
     pub fn invalidate_write(&self) -> RwSemWriteGuard<'_, ()> {
@@ -2566,6 +3419,7 @@ impl PageCache {
     fn clean_evict_indices(&self, range: Option<(usize, usize)>) -> Vec<usize> {
         let guard = self.inner.lock();
         match range {
+            Some((start, end)) if start > end => Vec::new(),
             Some((start, end)) => guard.page_indices.range(start..=end).copied().collect(),
             None => guard.page_indices.iter().copied().collect(),
         }
@@ -3444,11 +4298,10 @@ impl PageCache {
 
     fn detach_dirty_retention_if_idle(&self) -> Option<InodeRetentionGuard> {
         let mut inner = self.inner.lock();
-        let has_writeback = inner
-            .pages
-            .values()
-            .any(|entry| entry.state() == PageState::Writeback);
-        if inner.dirty_preparations == 0 && inner.dirty_pages.is_empty() && !has_writeback {
+        if inner.dirty_preparations == 0
+            && inner.dirty_pages.is_empty()
+            && inner.writeback_pages.is_empty()
+        {
             inner.dirty_retention.take()
         } else {
             None
@@ -3504,6 +4357,7 @@ impl PageCache {
             self.account_state_transition(old_state, PageState::Writeback);
             entry.set_state(PageState::Writeback);
             guard.dirty_pages.remove(&page_index);
+            guard.writeback_pages.insert(page_index);
         }
     }
 
@@ -3514,6 +4368,7 @@ impl PageCache {
             self.account_state_transition(old_state, PageState::UpToDate);
             entry.set_state(PageState::UpToDate);
             guard.dirty_pages.remove(&page_index);
+            guard.writeback_pages.remove(&page_index);
         }
         drop(guard);
         drop(self.detach_dirty_retention_if_idle());
@@ -3526,6 +4381,7 @@ impl PageCache {
             let old_state = entry.state();
             self.account_state_transition(old_state, PageState::Dirty);
             guard.dirty_pages.insert(page_index);
+            guard.writeback_pages.remove(&page_index);
             entry.set_state(PageState::Dirty);
             entry.wait_queue.wake_all();
         }

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -976,6 +976,14 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     /// @brief 获取inode所在的文件系统的指针
     fn fs(&self) -> Arc<dyn FileSystem>;
 
+    /// 获取 inode 所在的文件系统；供异步回收等可能与卸载并发的路径使用。
+    ///
+    /// 默认实现适用于 inode 强持有文件系统的实现。仅当 inode 与文件系统之间
+    /// 使用弱引用、且调用方允许文件系统已完成销毁时才应覆盖此方法。
+    fn try_fs(&self) -> Option<Arc<dyn FileSystem>> {
+        Some(self.fs())
+    }
+
     /// @brief 获取当前 inode 所在挂载点的挂载标志
     fn mount_flags(&self) -> MountFlags {
         MountFlags::empty()

--- a/kernel/src/filesystem/vfs/syscall/sys_sync_file_range.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync_file_range.rs
@@ -113,7 +113,9 @@ fn sync_file_range(
         file.check_and_advance_wb_error(&page_cache)?;
     }
     if flags.contains(SyncFileRangeFlags::WRITE) {
-        manager.start_writeback_range(start_index, end_index)?;
+        let sync_all =
+            flags.contains(SyncFileRangeFlags::WAIT_BEFORE | SyncFileRangeFlags::WAIT_AFTER);
+        manager.start_writeback_range(start_index, end_index, sync_all)?;
     }
     if flags.contains(SyncFileRangeFlags::WAIT_AFTER) {
         manager.wait_writeback_range(start_index, end_index)?;

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -337,6 +337,11 @@ impl<'a> PageFaultMessage<'a> {
 /// 缺页中断处理结构体
 pub struct PageFaultHandler;
 
+enum FilemapMkwriteSize {
+    FetchFromInode,
+    Stable(usize),
+}
+
 impl PageFaultHandler {
     #[inline(always)]
     fn account_new_present_mapping(mm: &Arc<AddressSpace>) {
@@ -1185,6 +1190,24 @@ impl PageFaultHandler {
     }
 
     pub unsafe fn filemap_page_mkwrite(pfm: &mut PageFaultMessage) -> VmFaultReason {
+        Self::filemap_page_mkwrite_inner(pfm, FilemapMkwriteSize::FetchFromInode)
+    }
+
+    /// Prepare a shared writable file-backed page using an inode size which
+    /// the filesystem has already stabilized against truncate and dirty-page
+    /// admission.  Filesystems whose metadata operation can enter userspace
+    /// must use this entry point from a fault critical section.
+    pub unsafe fn filemap_page_mkwrite_with_stable_size(
+        pfm: &mut PageFaultMessage,
+        stable_size: usize,
+    ) -> VmFaultReason {
+        Self::filemap_page_mkwrite_inner(pfm, FilemapMkwriteSize::Stable(stable_size))
+    }
+
+    unsafe fn filemap_page_mkwrite_inner(
+        pfm: &mut PageFaultMessage,
+        size_source: FilemapMkwriteSize,
+    ) -> VmFaultReason {
         let vma = pfm.vma();
         let vma_guard = vma.lock();
         let file = vma_guard.vm_file().expect("no vm_file in vma");
@@ -1210,8 +1233,15 @@ impl PageFaultHandler {
             return VmFaultReason::VM_FAULT_RETRY;
         }
 
-        if let Ok(md) = file.inode().metadata() {
-            let size = md.size.max(0) as usize;
+        let size = match size_source {
+            FilemapMkwriteSize::FetchFromInode => file
+                .inode()
+                .metadata()
+                .ok()
+                .map(|metadata| metadata.size.max(0) as usize),
+            FilemapMkwriteSize::Stable(size) => Some(size),
+        };
+        if let Some(size) = size {
             if size == 0 || backing_pgoff.saturating_mul(MMArch::PAGE_SIZE) >= size {
                 return VmFaultReason::VM_FAULT_SIGBUS;
             }
@@ -1219,10 +1249,17 @@ impl PageFaultHandler {
 
         match page_cache.manager().prepare_page_mkwrite(page_index, &page) {
             Ok(()) => {}
-            Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => return VmFaultReason::VM_FAULT_RETRY,
+            Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
+                if let Some(wait) = page_cache
+                    .manager()
+                    .page_mkwrite_retry_wait(page_index, &page)
+                {
+                    pfm.set_retry_wait(wait);
+                }
+                return VmFaultReason::VM_FAULT_RETRY;
+            }
             Err(_) => return VmFaultReason::VM_FAULT_SIGBUS,
         }
-
         VmFaultReason::empty()
     }
 

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -17,7 +17,10 @@ use lru::LruCache;
 use crate::{
     arch::{mm::LockedFrameAllocator, MMArch},
     filesystem::{
-        page_cache::{list_page_caches, PageCache},
+        page_cache::{
+            async_writeback_progress_snapshot, list_page_caches, wait_for_async_writeback_progress,
+            PageCache,
+        },
         vfs::FilePrivateData,
     },
     init::initcall::INITCALL_CORE,
@@ -283,9 +286,22 @@ fn page_reclaim_thread() -> i32 {
         // 保留4096个页面，总计16MB的空闲空间
         if usage.free().data() < 4096 {
             let page_to_free = 4096;
+            let writeback_generation = async_writeback_progress_snapshot();
             // 分离选择和回收阶段，避免长时间持有页面回收器锁导致与
             // page_manager/page_cache 的锁顺序反转。
-            PageReclaimer::shrink_list(PageFrameCount::new(page_to_free));
+            let progress = PageReclaimer::shrink_list(PageFrameCount::new(page_to_free));
+            if progress.reclaimed == 0 {
+                // Any no-progress pass must yield: dirty pages may need an
+                // asynchronous writeback completion, while mapped,
+                // unevictable, or otherwise busy pages cannot be reclaimed by
+                // immediately draining the same LRU again.  If there is no
+                // writeback to wait for, use a bounded retry backoff.
+                if progress.dirty_seen == 0
+                    || !wait_for_async_writeback_progress(writeback_generation)
+                {
+                    let _ = nanosleep(PosixTimeSpec::new(0, 1_000_000));
+                }
+            }
         } else {
             //TODO Temporarily let page reclaim thread handle dirty page writeback; should be separated later.
             PageReclaimer::flush_dirty_pages();
@@ -306,12 +322,21 @@ pub fn page_reclaimer_lock() -> MutexGuard<'static, PageReclaimer> {
 /// 页面回收器
 pub struct PageReclaimer {
     lru: LruCache<PhysAddr, Arc<Page>>,
+    writeback_cursor: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReclaimProgress {
+    pub reclaimed: usize,
+    pub dirty_seen: usize,
+    pub writeback_scheduled: usize,
 }
 
 impl PageReclaimer {
     pub fn new() -> Self {
         Self {
             lru: LruCache::unbounded(),
+            writeback_cursor: 0,
         }
     }
 
@@ -331,7 +356,7 @@ impl PageReclaimer {
     /// 分两阶段：
     /// 1) 持有回收器锁，从 LRU 中摘下目标页面列表；
     /// 2) 释放回收器锁后，逐个执行写回与回收，避免锁顺序反转。
-    pub fn shrink_list(count: PageFrameCount) {
+    pub fn shrink_list(count: PageFrameCount) -> ReclaimProgress {
         // 阶段1：仅持有回收器锁，摘取受害者
         let victims = {
             let mut reclaimer = page_reclaimer_lock();
@@ -339,7 +364,7 @@ impl PageReclaimer {
         };
 
         // 阶段2：不持有回收器锁，安全地回收页面
-        Self::evict_pages(victims);
+        Self::evict_pages(victims)
     }
 
     /// 从 LRU 中批量弹出页面，不做任何回收操作。
@@ -355,9 +380,10 @@ impl PageReclaimer {
     }
 
     /// 在不持有回收器锁的情况下，完成页面写回与回收。
-    fn evict_pages(victims: Vec<Arc<Page>>) {
+    fn evict_pages(victims: Vec<Arc<Page>>) -> ReclaimProgress {
+        let mut progress = ReclaimProgress::default();
         for page in victims {
-            let mut guard = page.write();
+            let guard = page.write();
             if let PageType::File(info) = guard.page_type().clone() {
                 if guard.flags().contains(PageFlags::PG_UNEVICTABLE) {
                     continue;
@@ -376,6 +402,8 @@ impl PageReclaimer {
                 let paddr = guard.phys_address();
 
                 if guard.flags().contains(PageFlags::PG_DIRTY) {
+                    progress.dirty_seen += 1;
+                    const MAX_RECLAIMER_PAGES_PER_BATCH: usize = 64;
                     let writeback_target = match guard.page_type() {
                         PageType::File(info) => info
                             .page_cache
@@ -386,22 +414,28 @@ impl PageReclaimer {
                     drop(guard);
 
                     if let Some((page_cache, page_index)) = writeback_target {
-                        let _ = page_cache.manager().writeback_page(page_index);
+                        // Reclaim must never synchronously enter a filesystem
+                        // or FUSE daemon. Schedule the same bounded, try-only
+                        // worker used by background writeback and keep the
+                        // victim on the LRU until a later pass observes it
+                        // clean. This also lets adjacent victims coalesce.
+                        let end = page_index.saturating_add(MAX_RECLAIMER_PAGES_PER_BATCH - 1);
+                        if page_cache
+                            .manager()
+                            .try_start_reclaimer_writeback_range(page_index, end)
+                            .unwrap_or(false)
+                        {
+                            progress.writeback_scheduled += 1;
+                        }
+                        page_reclaimer_lock().insert_page(paddr, &page);
+                        continue;
                     } else {
                         let mut guard = page.write();
                         guard.remove_flags(PageFlags::PG_DIRTY | PageFlags::PG_WRITEBACK);
                         drop(guard);
-                        page_manager_lock().remove_page(&paddr);
-                        continue;
-                    }
-
-                    guard = page.write();
-                    if guard.flags().intersects(
-                        PageFlags::PG_DIRTY | PageFlags::PG_WRITEBACK | PageFlags::PG_UNEVICTABLE,
-                    ) || guard.map_count() != 0
-                    {
-                        drop(guard);
-                        page_reclaimer_lock().insert_page(paddr, &page);
+                        if page_manager_lock().remove_page(&paddr).is_some() {
+                            progress.reclaimed += 1;
+                        }
                         continue;
                     }
                 }
@@ -427,9 +461,12 @@ impl PageReclaimer {
                         continue;
                     }
                 }
-                page_manager_lock().remove_page(&paddr);
+                if page_manager_lock().remove_page(&paddr).is_some() {
+                    progress.reclaimed += 1;
+                }
             }
         }
+        progress
     }
 
     /// Drop clean pagecache pages only, matching Linux drop_caches semantics.
@@ -542,32 +579,64 @@ impl PageReclaimer {
         }
     }
 
-    /// lru脏页刷新
-    fn dirty_pages_snapshot(&self) -> Vec<Arc<Page>> {
-        self.lru
-            .iter()
-            .filter_map(|(_paddr, page)| {
-                let guard = page.read();
-                if guard.flags().contains(PageFlags::PG_DIRTY) {
-                    Some(page.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
+    /// Take a bounded, rotating LRU snapshot without acquiring any page lock
+    /// while the global reclaimer lock is held.
+    fn writeback_scan_snapshot(&mut self) -> Vec<Arc<Page>> {
+        const MAX_RECLAIMER_SCAN_PAGES: usize = 512;
+        const RECLAIMER_SCAN_STRIDE: usize = 8;
+        let total = self.lru.len();
+        if total == 0 {
+            self.writeback_cursor = 0;
+            return Vec::new();
+        }
+
+        let start = self.writeback_cursor % total;
+        let count = total.min(MAX_RECLAIMER_SCAN_PAGES);
+        let mut pages = Vec::new();
+        if pages.try_reserve_exact(count).is_err() {
+            return pages;
+        }
+        pages.extend(
+            self.lru
+                .iter()
+                .skip(start)
+                .chain(self.lru.iter().take(start))
+                .take(count)
+                .map(|(_paddr, page)| page.clone()),
+        );
+        // Large LRUs advance by the whole sampled window so every region is
+        // visited before windows overlap. When the entire LRU fits, retain a
+        // small stride to rotate which hot cache gets the first scheduling
+        // slots without skipping any page from the snapshot.
+        let advance = if total > count {
+            count
+        } else {
+            RECLAIMER_SCAN_STRIDE.min(total)
+        };
+        self.writeback_cursor = if advance >= total - start {
+            advance - (total - start)
+        } else {
+            start + advance
+        };
+        pages
     }
 
     pub fn flush_dirty_pages() {
         let pages = {
-            let reclaimer = page_reclaimer_lock();
-            reclaimer.dirty_pages_snapshot()
+            let mut reclaimer = page_reclaimer_lock();
+            reclaimer.writeback_scan_snapshot()
         };
         Self::flush_dirty_pages_snapshot(pages);
     }
 
     fn flush_dirty_pages_snapshot(pages: Vec<Arc<Page>>) {
+        const MAX_RECLAIMER_RUNNERS: usize = 8;
+        const MAX_RECLAIMER_PAGES_PER_RUN: usize = 512;
+        let mut scheduled_runners = 0;
         for page in pages {
-            let mut guard = page.write();
+            let Some(guard) = page.try_read() else {
+                continue;
+            };
             if guard.flags().contains(PageFlags::PG_DIRTY) {
                 let writeback_target = match guard.page_type() {
                     PageType::File(info) => info
@@ -578,9 +647,28 @@ impl PageReclaimer {
                 };
                 if let Some((page_cache, page_index)) = writeback_target {
                     drop(guard);
-                    let _ = page_cache.manager().writeback_page(page_index);
+                    if scheduled_runners < MAX_RECLAIMER_RUNNERS {
+                        // Anchor every attempt at a page from the LRU snapshot,
+                        // then let one cache runner drain the same bounded
+                        // 512-page window as multiple backend-sized batches.
+                        // A contended cache is skipped immediately and later
+                        // snapshot candidates are still considered.
+                        let end = page_index.saturating_add(MAX_RECLAIMER_PAGES_PER_RUN - 1);
+                        if page_cache
+                            .manager()
+                            .try_start_reclaimer_writeback_range(page_index, end)
+                            .unwrap_or(false)
+                        {
+                            scheduled_runners += 1;
+                        }
+                    }
                 } else {
-                    Self::page_writeback(&mut guard, false);
+                    drop(guard);
+                    if let Some(mut guard) = page.try_write() {
+                        if guard.flags().contains(PageFlags::PG_DIRTY) {
+                            Self::page_writeback(&mut guard, false);
+                        }
+                    }
                 }
             }
         }
@@ -682,12 +770,20 @@ impl Page {
         self.inner.read()
     }
 
+    pub fn try_read(&self) -> Option<RwSemReadGuard<'_, InnerPage>> {
+        self.inner.try_read()
+    }
+
     pub fn upread(&self) -> RwSemUpgradeableGuard<'_, InnerPage> {
         self.inner.upread()
     }
 
     pub fn write(&self) -> RwSemWriteGuard<'_, InnerPage> {
         self.inner.write()
+    }
+
+    pub fn try_write(&self) -> Option<RwSemWriteGuard<'_, InnerPage>> {
+        self.inner.try_write()
     }
 }
 

--- a/kernel/src/mm/page_cache_stats.rs
+++ b/kernel/src/mm/page_cache_stats.rs
@@ -10,6 +10,8 @@ pub struct PageCacheStatsSnapshot {
     pub unevictable: u64,
     pub drop_pagecache: u64,
     pub read_dma_reservations: u64,
+    pub invalidation_launder_batches: u64,
+    pub invalidation_launder_pages: u64,
 }
 
 static FILE_PAGES: AtomicU64 = AtomicU64::new(0);
@@ -20,6 +22,8 @@ static SHMEM_PAGES: AtomicU64 = AtomicU64::new(0);
 static UNEVICTABLE: AtomicU64 = AtomicU64::new(0);
 static DROP_PAGECACHE: AtomicU64 = AtomicU64::new(0);
 static READ_DMA_RESERVATIONS: AtomicU64 = AtomicU64::new(0);
+static INVALIDATION_LAUNDER_BATCHES: AtomicU64 = AtomicU64::new(0);
+static INVALIDATION_LAUNDER_PAGES: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
 pub fn inc_file_pages() {
@@ -97,6 +101,12 @@ pub fn end_read_dma_reservation() {
 }
 
 #[inline]
+pub fn record_invalidation_launder_batch(pages: usize) {
+    INVALIDATION_LAUNDER_BATCHES.fetch_add(1, Ordering::Relaxed);
+    INVALIDATION_LAUNDER_PAGES.fetch_add(pages as u64, Ordering::Relaxed);
+}
+
+#[inline]
 pub fn snapshot() -> PageCacheStatsSnapshot {
     PageCacheStatsSnapshot {
         file_pages: FILE_PAGES.load(Ordering::Relaxed),
@@ -107,5 +117,7 @@ pub fn snapshot() -> PageCacheStatsSnapshot {
         unevictable: UNEVICTABLE.load(Ordering::Relaxed),
         drop_pagecache: DROP_PAGECACHE.load(Ordering::Relaxed),
         read_dma_reservations: READ_DMA_RESERVATIONS.load(Ordering::Acquire),
+        invalidation_launder_batches: INVALIDATION_LAUNDER_BATCHES.load(Ordering::Relaxed),
+        invalidation_launder_pages: INVALIDATION_LAUNDER_PAGES.load(Ordering::Relaxed),
     }
 }

--- a/kernel/src/process/kthread.rs
+++ b/kernel/src/process/kthread.rs
@@ -1,6 +1,6 @@
 use core::{
     hint::spin_loop,
-    sync::atomic::{compiler_fence, AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use alloc::{
@@ -17,7 +17,7 @@ use crate::{
     arch::CurrentIrqArch,
     exception::{irqdesc::IrqAction, InterruptArch},
     init::initial_kthread::{initial_kernel_thread, set_system_state, SystemState},
-    libs::{cpumask::CpuMask, once::Once, spinlock::SpinLock},
+    libs::{once::Once, spinlock::SpinLock, wait_queue::WaitQueue},
     process::{ProcessManager, ProcessState},
     sched::{completion::Completion, schedule, SchedMode},
     smp::cpu::ProcessorId,
@@ -29,7 +29,21 @@ use super::{fork::CloneFlags, ProcessControlBlock, ProcessFlags, RawPid};
 static KTHREAD_CREATE_LIST: SpinLock<LinkedList<Arc<KernelThreadCreateInfo>>> =
     SpinLock::new(LinkedList::new());
 
-static mut KTHREAD_DAEMON_PCB: Option<Arc<ProcessControlBlock>> = None;
+/// All work that can make kthreadd useful must use this notification path.
+/// The pending bit coalesces events because each daemon pass drains the full
+/// create list and reaps every zombie child.
+static KTHREAD_DAEMON_WAIT: WaitQueue = WaitQueue::default();
+static KTHREAD_DAEMON_WORK_PENDING: AtomicBool = AtomicBool::new(false);
+static KTHREAD_DAEMON_READY: AtomicBool = AtomicBool::new(false);
+static KTHREAD_SELFTEST_RUNNING: AtomicBool = AtomicBool::new(false);
+
+struct KthreadSelftestGuard;
+
+impl Drop for KthreadSelftestGuard {
+    fn drop(&mut self) {
+        KTHREAD_SELFTEST_RUNNING.store(false, Ordering::Release);
+    }
+}
 
 #[derive(Debug)]
 pub enum WorkerPrivate {
@@ -146,8 +160,9 @@ pub struct KernelThreadCreateInfo {
     closure: SpinLock<Option<Box<KernelThreadClosure>>>,
     /// 内核线程的名字
     name: String,
-    /// 是否已经完成创建 todo:使用comletion机制优化这里
+    /// 是否已经完成创建
     created: AtomicKernelThreadCreateStatus,
+    created_completion: Completion,
     result_pcb: SpinLock<Option<Arc<ProcessControlBlock>>>,
     /// 不安全的Arc引用计数，当内核线程创建失败时，需要减少这个计数
     has_unsafe_arc_instance: AtomicBool,
@@ -173,6 +188,7 @@ impl KernelThreadCreateInfo {
             closure: SpinLock::new(Some(Box::new(func))),
             name,
             created: AtomicKernelThreadCreateStatus::new(KernelThreadCreateStatus::NotCreated),
+            created_completion: Completion::new(),
             result_pcb: SpinLock::new(None),
             has_unsafe_arc_instance: AtomicBool::new(false),
             self_ref: Weak::new(),
@@ -197,23 +213,23 @@ impl KernelThreadCreateInfo {
     /// - Some(Arc<ProcessControlBlock>) 创建成功，返回新创建的内核线程的PCB
     /// - None 创建失败
     pub fn poll_result(&self) -> Option<Arc<ProcessControlBlock>> {
-        loop {
-            match self.created.load(Ordering::SeqCst) {
-                KernelThreadCreateStatus::Created => {
-                    return self.result_pcb.lock().take();
+        self.created_completion
+            .wait_for_completion()
+            .expect("kthread create completion wait failed");
+
+        match self.created.load(Ordering::SeqCst) {
+            KernelThreadCreateStatus::Created => self.result_pcb.lock().take(),
+            KernelThreadCreateStatus::ErrorOccured => {
+                // 创建失败，减少不安全的Arc引用计数
+                let to_delete = self.has_unsafe_arc_instance.swap(false, Ordering::SeqCst);
+                if to_delete {
+                    let self_ref = self.self_ref.upgrade().unwrap();
+                    unsafe { Arc::decrement_strong_count(&self_ref) };
                 }
-                KernelThreadCreateStatus::NotCreated => {
-                    spin_loop();
-                }
-                KernelThreadCreateStatus::ErrorOccured => {
-                    // 创建失败，减少不安全的Arc引用计数
-                    let to_delete = self.has_unsafe_arc_instance.swap(false, Ordering::SeqCst);
-                    if to_delete {
-                        let self_ref = self.self_ref.upgrade().unwrap();
-                        unsafe { Arc::decrement_strong_count(&self_ref) };
-                    }
-                    return None;
-                }
+                None
+            }
+            KernelThreadCreateStatus::NotCreated => {
+                panic!("kthread create completion published without a result")
             }
         }
     }
@@ -227,10 +243,16 @@ impl KernelThreadCreateInfo {
     }
 
     pub unsafe fn set_create_ok(&self, pcb: Arc<ProcessControlBlock>) {
-        // todo: 使用completion机制优化这里
         self.result_pcb.lock().replace(pcb);
         self.created
             .store(KernelThreadCreateStatus::Created, Ordering::SeqCst);
+        self.created_completion.complete();
+    }
+
+    pub fn set_create_error(&self) {
+        self.created
+            .store(KernelThreadCreateStatus::ErrorOccured, Ordering::SeqCst);
+        self.created_completion.complete();
     }
 
     /// 生成一个不安全的Arc指针（用于创建内核线程时传递参数）
@@ -308,7 +330,11 @@ impl KernelThreadCreateInfo {
         if flags.contains(KernelThreadFlags::IS_PER_CPU) {
             let cpu = (*self.bound_cpu.lock())
                 .expect("kthread create: per-cpu thread missing target cpu");
-            pcb.sched_info().set_cpus_allowed(CpuMask::from_cpu(cpu));
+            let allowed = pcb.sched_info().cpus_allowed();
+            assert!(
+                allowed.get(cpu).unwrap_or(false) && allowed.iter_cpu().count() == 1,
+                "kthread create: per-cpu affinity was not installed before first run"
+            );
         }
     }
 
@@ -374,16 +400,12 @@ impl KernelThreadMechanism {
             let info = KernelThreadCreateInfo::new(closure, "kthreadd".to_string());
             info.set_to_mark_sleep(false)
                 .expect("kthreadadd should be run first");
-            let kthreadd_pid: RawPid = Self::__inner_create(
+            Self::__inner_create(
                 &info,
                 CloneFlags::CLONE_VM | CloneFlags::CLONE_FS | CloneFlags::CLONE_FILES,
             )
             .expect("Failed to create kthread daemon");
-            let pcb = ProcessManager::find_task_by_vpid(kthreadd_pid).unwrap();
-            ProcessManager::wakeup(&pcb).expect("Failed to wakeup kthread daemon");
-            unsafe {
-                KTHREAD_DAEMON_PCB.replace(pcb);
-            }
+            KTHREAD_DAEMON_READY.store(true, Ordering::Release);
             info!("Initialize kernel thread mechanism stage2 complete");
         });
     }
@@ -401,15 +423,19 @@ impl KernelThreadMechanism {
     #[allow(dead_code)]
     pub fn create(func: KernelThreadClosure, name: String) -> Option<Arc<ProcessControlBlock>> {
         let info = KernelThreadCreateInfo::new(func, name);
-        while unsafe { KTHREAD_DAEMON_PCB.is_none() } {
+        while !KTHREAD_DAEMON_READY.load(Ordering::Acquire) {
             // 等待kthreadd启动
             spin_loop()
         }
         KTHREAD_CREATE_LIST.lock().push_back(info.clone());
-        compiler_fence(Ordering::SeqCst);
-        ProcessManager::wakeup(unsafe { KTHREAD_DAEMON_PCB.as_ref().unwrap() })
-            .expect("Failed to wakeup kthread daemon");
+        Self::notify_daemon();
         return info.poll_result();
+    }
+
+    /// Notify kthreadd after publishing create or zombie-reap work.
+    pub(crate) fn notify_daemon() {
+        KTHREAD_DAEMON_WORK_PENDING.store(true, Ordering::Release);
+        KTHREAD_DAEMON_WAIT.wakeup(None);
     }
 
     /// 创建并运行一个新的内核线程
@@ -557,9 +583,17 @@ impl KernelThreadMechanism {
         drop(current_pcb);
 
         loop {
-            let mut list = KTHREAD_CREATE_LIST.lock();
-            while let Some(info) = list.pop_front() {
-                drop(list);
+            KTHREAD_DAEMON_WAIT
+                .wait_event_uninterruptible(
+                    || KTHREAD_DAEMON_WORK_PENDING.swap(false, Ordering::AcqRel),
+                    None::<fn()>,
+                )
+                .expect("kthreadd wait failed");
+
+            loop {
+                let Some(info) = KTHREAD_CREATE_LIST.lock().pop_front() else {
+                    break;
+                };
                 // create a new kernel thread
                 let result: Result<RawPid, SystemError> = Self::__inner_create(
                     &info,
@@ -567,19 +601,11 @@ impl KernelThreadMechanism {
                 );
                 if result.is_err() {
                     // 创建失败
-                    info.created
-                        .store(KernelThreadCreateStatus::ErrorOccured, Ordering::SeqCst);
+                    info.set_create_error();
                 };
-                list = KTHREAD_CREATE_LIST.lock();
             }
-            drop(list);
 
             Self::reap_zombie_kthreads(&kthreadd_pcb);
-
-            let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-            ProcessManager::mark_sleep(true).ok();
-            drop(irq_guard);
-            schedule(SchedMode::SM_NONE);
         }
     }
 
@@ -606,6 +632,153 @@ impl KernelThreadMechanism {
     }
 }
 
+/// Exercise the externally visible kthread create/run/stop handshakes in a
+/// real DragonOS guest. This is intentionally invoked only through debugfs;
+/// production paths do not pay the stress-test cost.
+pub(crate) fn run_debug_selftests() -> Result<String, SystemError> {
+    if KTHREAD_SELFTEST_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Err(SystemError::EBUSY);
+    }
+    let _guard = KthreadSelftestGuard;
+
+    let mut report = String::new();
+    let mut failures = 0usize;
+
+    append_kthread_selftest_case(
+        &mut report,
+        "create_stopped_stop",
+        selftest_create_stopped_stop(),
+        &mut failures,
+    );
+    append_kthread_selftest_case(
+        &mut report,
+        "create_and_run_stop",
+        selftest_create_and_run_stop(),
+        &mut failures,
+    );
+
+    let (quick_exit_ok, quick_exit_completed) = selftest_quick_exit(512);
+    append_kthread_selftest_case(&mut report, "quick_exit_512", quick_exit_ok, &mut failures);
+    report.push_str(&alloc::format!(
+        "quick_exit_completed={quick_exit_completed}\n"
+    ));
+
+    if failures == 0 {
+        report.insert_str(0, "status=ok\n");
+    } else {
+        report.insert_str(0, &alloc::format!("status=fail failures={failures}\n"));
+    }
+    Ok(report)
+}
+
+fn selftest_create_stopped_stop() -> bool {
+    let entered = Arc::new(AtomicUsize::new(0));
+    let entered_worker = entered.clone();
+    let name = "kthread-selftest-stopped".to_string();
+    let closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            entered_worker.fetch_add(1, Ordering::AcqRel);
+            0
+        }),
+        (),
+    ));
+    let Some(pcb) = KernelThreadMechanism::create(closure, name.clone()) else {
+        return false;
+    };
+
+    let worker_private_ready = pcb
+        .worker_private()
+        .as_ref()
+        .and_then(|private| private.kernel_thread())
+        .is_some();
+    let ready_ok = entered.load(Ordering::Acquire) == 0
+        && pcb.sched_info().state() == ProcessState::Blocked(false)
+        && pcb.flags().contains(ProcessFlags::KTHREAD)
+        && pcb.basic().name() == name
+        && worker_private_ready;
+    let stop_ok = KernelThreadMechanism::stop(&pcb).is_ok();
+
+    ready_ok && stop_ok && entered.load(Ordering::Acquire) == 0
+}
+
+fn selftest_create_and_run_stop() -> bool {
+    const RESULT: i32 = 73;
+
+    let entered = Arc::new(AtomicUsize::new(0));
+    let entered_worker = entered.clone();
+    let entered_completion = Arc::new(Completion::new());
+    let entered_completion_worker = entered_completion.clone();
+    let closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            entered_worker.fetch_add(1, Ordering::AcqRel);
+            entered_completion_worker.complete();
+            let current = ProcessManager::current_pcb();
+            while !KernelThreadMechanism::should_stop(&current) {
+                schedule(SchedMode::SM_NONE);
+            }
+            RESULT
+        }),
+        (),
+    ));
+    let Some(pcb) =
+        KernelThreadMechanism::create_and_run(closure, "kthread-selftest-running".to_string())
+    else {
+        return false;
+    };
+
+    if entered_completion.wait_for_completion().is_err() {
+        let _ = KernelThreadMechanism::stop(&pcb);
+        return false;
+    }
+    let result = KernelThreadMechanism::stop(&pcb);
+    entered.load(Ordering::Acquire) == 1 && result == Ok(RESULT as usize)
+}
+
+fn selftest_quick_exit(iterations: usize) -> (bool, usize) {
+    const RESULT: i32 = 91;
+
+    let completed = Arc::new(AtomicUsize::new(0));
+    for _ in 0..iterations {
+        let entered_completion = Arc::new(Completion::new());
+        let entered_completion_worker = entered_completion.clone();
+        let completed_worker = completed.clone();
+        let closure = KernelThreadClosure::EmptyClosure((
+            Box::new(move || {
+                completed_worker.fetch_add(1, Ordering::AcqRel);
+                entered_completion_worker.complete();
+                RESULT
+            }),
+            (),
+        ));
+        let Some(pcb) = KernelThreadMechanism::create_and_run(
+            closure,
+            "kthread-selftest-quick-exit".to_string(),
+        ) else {
+            return (false, completed.load(Ordering::Acquire));
+        };
+        if entered_completion.wait_for_completion().is_err()
+            || KernelThreadMechanism::stop(&pcb) != Ok(RESULT as usize)
+        {
+            return (false, completed.load(Ordering::Acquire));
+        }
+    }
+
+    let completed = completed.load(Ordering::Acquire);
+    (completed == iterations, completed)
+}
+
+fn append_kthread_selftest_case(report: &mut String, name: &str, ok: bool, failures: &mut usize) {
+    if ok {
+        report.push_str(&alloc::format!("{name}=ok\n"));
+    } else {
+        *failures += 1;
+        report.push_str(&alloc::format!("{name}=fail\n"));
+    }
+}
+
 /// 内核线程启动的第二阶段
 ///
 /// 该函数只能被`kernel_thread_bootstrap_stage1`调用（jmp到该函数）
@@ -615,19 +788,33 @@ impl KernelThreadMechanism {
 /// - ptr: 传入的参数，是一个指向`Arc<KernelThreadCreateInfo>`的指针
 pub unsafe extern "C" fn kernel_thread_bootstrap_stage2(ptr: *const KernelThreadCreateInfo) -> ! {
     let info = KernelThreadCreateInfo::parse_unsafe_arc_ptr(ptr);
+    let current = ProcessManager::current_pcb();
+
+    // Complete all thread-visible setup before publishing Created. The arch
+    // fork path may already have scheduled this child, so post-fork setup in
+    // the parent cannot provide this ordering guarantee.
+    current.set_name(info.name().clone());
+    info.setup_pcb(&current);
 
     let closure: Box<KernelThreadClosure> = info.take_closure().unwrap();
-    info.set_create_ok(ProcessManager::current_pcb());
     let to_mark_sleep = info.to_mark_sleep();
-    drop(info);
 
     if to_mark_sleep {
-        // 进入睡眠状态
+        // Match Linux kthread(): publish the stopped state before publishing
+        // the creation result. A create_and_run wake racing with schedule()
+        // then either keeps this current task runnable or re-enqueues it after
+        // schedule has dequeued it; it can no longer be lost.
         let irq_guard = CurrentIrqArch::save_and_disable_irq();
-        ProcessManager::mark_sleep(true).expect("Failed to mark sleep");
+        ProcessManager::mark_sleep(false).expect("Failed to mark sleep");
+        info.set_create_ok(current.clone());
+        drop(info);
         drop(irq_guard);
         schedule(SchedMode::SM_NONE);
+    } else {
+        info.set_create_ok(current.clone());
+        drop(info);
     }
+    drop(current);
 
     let mut retval = SystemError::EINTR.to_posix_errno();
 

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     mm::IDLE_PROCESS_ADDRESS_SPACE,
     process::{
+        kthread::KernelThreadMechanism,
         pid::{Pid, PidType},
         ptrace, ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState, RawPid,
     },
@@ -136,7 +137,7 @@ impl ProcessManager {
             // Explicitly wake kthreadd when a kthread exits so that it can
             // reap the zombie.
             if is_kthread {
-                let _ = ProcessManager::wakeup(&parent_pcb);
+                KernelThreadMechanism::notify_daemon();
             }
 
             // TODO: The signal delivery decision should also consider thread-group

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1,19 +1,262 @@
 #include <gtest/gtest.h>
 
 #include <signal.h>
+#include <sched.h>
 #include <setjmp.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 #include <sys/xattr.h>
+#include <time.h>
 
 #include "fuse_gtest_common.h"
+
+#ifndef MNT_DETACH
+#define MNT_DETACH 2
+#endif
 
 static sigjmp_buf g_fuse_sigbus_jmp;
 static volatile sig_atomic_t g_fuse_sigbus_seen = 0;
 static sigjmp_buf g_fuse_sigsegv_jmp;
 static volatile sig_atomic_t g_fuse_sigsegv_seen = 0;
+
+struct fuse_fsync_worker_args {
+    int fd;
+    volatile int done;
+    int result;
+    int saved_errno;
+};
+
+static void *fuse_fsync_worker(void *opaque) {
+    struct fuse_fsync_worker_args *args = (struct fuse_fsync_worker_args *)opaque;
+    args->result = fsync(args->fd);
+    args->saved_errno = errno;
+    __sync_synchronize();
+    args->done = 1;
+    return NULL;
+}
+
+struct fuse_mmap_single_write_args {
+    volatile char *address;
+    char value;
+    volatile int started;
+    volatile int done;
+};
+
+static void *fuse_mmap_single_write_worker(void *opaque) {
+    struct fuse_mmap_single_write_args *args =
+        (struct fuse_mmap_single_write_args *)opaque;
+    args->started = 1;
+    __sync_synchronize();
+    *args->address = args->value;
+    __sync_synchronize();
+    args->done = 1;
+    return NULL;
+}
+
+static int fuse_monotonic_ms(uint64_t *value) {
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0 || now.tv_sec < 0 || now.tv_nsec < 0) {
+        return -1;
+    }
+    *value = (uint64_t)now.tv_sec * 1000u + (uint64_t)now.tv_nsec / 1000000u;
+    return 0;
+}
+
+static int fuse_wait_flag(volatile int *flag, unsigned int timeout_ms) {
+    uint64_t started_ms = 0;
+    uint64_t now_ms = 0;
+    if (fuse_monotonic_ms(&started_ms) != 0) {
+        return -1;
+    }
+    while (1) {
+        if (*flag) {
+            return 0;
+        }
+        if (fuse_monotonic_ms(&now_ms) != 0 || now_ms - started_ms >= timeout_ms) {
+            break;
+        }
+        usleep(1000);
+    }
+    return -1;
+}
+
+static int fuse_parse_u64_counter(const char *report, const char *field, uint64_t *value) {
+    size_t field_len = strlen(field);
+    const char *line = report;
+    while (line && *line) {
+        if (strncmp(line, field, field_len) == 0 && line[field_len] == ' ') {
+            char *end = NULL;
+            errno = 0;
+            unsigned long long parsed = strtoull(line + field_len + 1, &end, 10);
+            if (errno == 0 && end != line + field_len + 1) {
+                *value = (uint64_t)parsed;
+                return 0;
+            }
+            break;
+        }
+        line = strchr(line, '\n');
+        if (line) {
+            ++line;
+        }
+    }
+    return -1;
+}
+
+static char *fuse_read_stats_report(const char *path) {
+    char *report = (char *)malloc(32768);
+    if (!report) {
+        return NULL;
+    }
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        free(report);
+        return NULL;
+    }
+    size_t used = 0;
+    while (used + 1 < 32768) {
+        ssize_t n = read(fd, report + used, 32767 - used);
+        if (n < 0) {
+            close(fd);
+            free(report);
+            return NULL;
+        }
+        if (n == 0) {
+            break;
+        }
+        used += (size_t)n;
+    }
+    close(fd);
+    report[used] = '\0';
+    return report;
+}
+
+static int fuse_read_u64_counter(const char *path, const char *field, uint64_t *value) {
+    char *report = fuse_read_stats_report(path);
+    if (!report) {
+        return -1;
+    }
+    int result = fuse_parse_u64_counter(report, field, value);
+    free(report);
+    return result;
+}
+
+static int fuse_wait_counter_increase(const char *path, const char *field, uint64_t before,
+                                      uint64_t *after, unsigned int timeout_ms) {
+    uint64_t started_ms = 0;
+    uint64_t now_ms = 0;
+    if (fuse_monotonic_ms(&started_ms) != 0) {
+        return -1;
+    }
+    while (1) {
+        if (fuse_read_u64_counter(path, field, after) == 0 && *after > before) {
+            return 0;
+        }
+        if (fuse_monotonic_ms(&now_ms) != 0 || now_ms - started_ms >= timeout_ms) {
+            break;
+        }
+        usleep(1000);
+    }
+    return -1;
+}
+
+static int fuse_read_launder_counters(const char *path, uint64_t *batches, uint64_t *pages) {
+    char *report = fuse_read_stats_report(path);
+    if (!report) {
+        return -1;
+    }
+    int result = fuse_parse_u64_counter(report, "invalidation_launder_batches_total", batches);
+    if (result == 0) {
+        result = fuse_parse_u64_counter(report, "invalidation_launder_pages_total", pages);
+    }
+    free(report);
+    return result;
+}
+
+static int fuse_count_mounted_filesystems() {
+    FILE *mounts = fopen("/proc/mounts", "r");
+    if (!mounts) {
+        return -1;
+    }
+    int count = 0;
+    char type[64];
+    while (fscanf(mounts, "%*s %*s %63s %*[^\n]\n", type) == 1) {
+        if (strcmp(type, "fuse") == 0 || strncmp(type, "fuse.", 5) == 0 ||
+            strcmp(type, "fuseblk") == 0 || strcmp(type, "virtiofs") == 0) {
+            ++count;
+        }
+    }
+    fclose(mounts);
+    return count;
+}
+
+static volatile int *fuse_alloc_child_done() {
+    void *mapping = mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (mapping == MAP_FAILED) {
+        return NULL;
+    }
+    memset(mapping, 0, sizeof(int));
+    return (volatile int *)mapping;
+}
+
+static void fuse_publish_child_done(volatile int *done) {
+    __sync_synchronize();
+    *done = 1;
+    __sync_synchronize();
+}
+
+// DragonOS wait4(WNOHANG) is not used as the deadline primitive here: if that
+// syscall regresses into a blocking wait, the watchdog itself becomes
+// unbounded. The shared flag is published immediately before _exit(), so a
+// blocking reap is safe only after the flag is visible or SIGKILL was sent.
+static int fuse_reap_child_bounded(pid_t child, volatile int *done, int *status,
+                                   unsigned int timeout_ms) {
+    if (fuse_wait_flag(done, timeout_ms) == 0) {
+        return waitpid(child, status, 0) == child ? 1 : -1;
+    }
+    if (kill(child, SIGKILL) != 0 && errno != ESRCH) {
+        return -1;
+    }
+    return waitpid(child, status, 0) == child ? 0 : -1;
+}
+
+static int fuse_cleanup_mounts_bounded(const char *mp, const char *debug_root) {
+    volatile int *done = fuse_alloc_child_done();
+    if (!done) {
+        return -1;
+    }
+    pid_t cleaner = fork();
+    if (cleaner < 0) {
+        munmap((void *)done, sizeof(int));
+        return -1;
+    }
+    if (cleaner == 0) {
+        int failed = 0;
+        if (umount2(mp, MNT_DETACH) != 0 && errno != EINVAL && errno != ENOENT) {
+            failed = 1;
+        }
+        if (umount2(debug_root, MNT_DETACH) != 0 && errno != EINVAL && errno != ENOENT) {
+            failed = 1;
+        }
+        if (rmdir(mp) != 0 && errno != ENOENT) {
+            failed = 1;
+        }
+        if (rmdir(debug_root) != 0 && errno != ENOENT) {
+            failed = 1;
+        }
+        fuse_publish_child_done(done);
+        _exit(failed ? 1 : 0);
+    }
+    int status = 0;
+    int waited = fuse_reap_child_bounded(cleaner, done, &status, 2000);
+    munmap((void *)done, sizeof(int));
+    if (waited == 1) {
+        return WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 0 : -1;
+    }
+    return -1;
+}
 
 static void fuse_sigbus_longjmp_handler(int sig) {
     (void)sig;
@@ -43,6 +286,22 @@ static void fuse_sigsegv_longjmp_handler(int sig) {
 #define XATTR_SIZE_MAX 65536
 #endif
 
+#ifndef __NR_sync_file_range
+#if defined(__x86_64__)
+#define __NR_sync_file_range 277
+#elif defined(__riscv) || defined(__loongarch64)
+#define __NR_sync_file_range 84
+#else
+#error "__NR_sync_file_range is not defined for this architecture"
+#endif
+#endif
+#ifndef SYNC_FILE_RANGE_WRITE
+#define SYNC_FILE_RANGE_WRITE 2
+#endif
+#ifndef SYNC_FILE_RANGE_WAIT_AFTER
+#define SYNC_FILE_RANGE_WAIT_AFTER 4
+#endif
+
 static void fill_user_xattr_name(char *buf, size_t len) {
     memset(buf, 'a', len);
     memcpy(buf, "user.", strlen("user."));
@@ -53,6 +312,7 @@ static int ext_test_p2_ops() {
     const char *mp = "/tmp/test_fuse_p2_ops";
     int f = -1;
     int dfd = -1;
+    int direct_fd = -1;
     ssize_t tn = -1;
     ssize_t rn = -1;
     char hello[256];
@@ -60,6 +320,9 @@ static int ext_test_p2_ops() {
     char symlink_path[256];
     char target_buf[256];
     char hard_path[256];
+    char batch_path[256];
+    char error_path[256];
+    char direct_path[256];
     char sparse_path[256];
     char rbuf[64];
     char dst_exist[256];
@@ -68,7 +331,9 @@ static int ext_test_p2_ops() {
     const char sparse_marker = 'S';
     const off_t sparse_offset = 5000;
     const size_t sparse_size = (size_t)sparse_offset + 1;
+    const size_t batch_size = 3 * 4096 + 17;
     unsigned char *sparse_contents = NULL;
+    unsigned char *batch_data = NULL;
     if (ensure_dir(mp) != 0) {
         printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
         return -1;
@@ -88,13 +353,26 @@ static int ext_test_p2_ops() {
     volatile uint32_t fsync_count = 0;
     volatile uint32_t fsyncdir_count = 0;
     volatile uint32_t create_count = 0;
+    volatile uint64_t last_create_nodeid = 0;
     volatile uint32_t rename2_count = 0;
     volatile uint32_t write_count = 0;
+    volatile uint32_t dynamic_open_out_flags = 0;
+    volatile uint64_t last_write_offset = 0;
     volatile uint32_t last_write_size = 0;
     volatile uint32_t last_write_flags = 0;
     volatile uint32_t write_count_at_fsync = 0;
     volatile uint32_t last_write_flags_at_fsync = 0;
     volatile unsigned char extension_write_byte = 0;
+    volatile uint64_t large_write_nodeid = 0;
+    volatile uint64_t write_offsets[4] = {0};
+    volatile uint32_t write_sizes[4] = {0};
+    volatile uint32_t write_flags[4] = {0};
+    volatile int forced_write_errno = 0;
+    volatile uint64_t forced_write_offset = UINT64_MAX;
+    volatile uint64_t forced_short_write_offset = UINT64_MAX;
+    volatile uint32_t forced_short_write_size = 0;
+    unsigned char batch_backend[16384];
+    memset(batch_backend, 0, sizeof(batch_backend));
 
     struct fuse_daemon_args args;
     memset(&args, 0, sizeof(args));
@@ -108,15 +386,30 @@ static int ext_test_p2_ops() {
     args.fsync_count = &fsync_count;
     args.fsyncdir_count = &fsyncdir_count;
     args.create_count = &create_count;
+    args.last_create_nodeid = &last_create_nodeid;
     args.rename2_count = &rename2_count;
     args.write_count = &write_count;
+    args.dynamic_open_out_flags = &dynamic_open_out_flags;
+    args.last_write_offset = &last_write_offset;
     args.last_write_size = &last_write_size;
     args.last_write_flags = &last_write_flags;
     args.write_count_at_fsync = &write_count_at_fsync;
     args.last_write_flags_at_fsync = &last_write_flags_at_fsync;
+    args.large_write_backing = batch_backend;
+    args.large_write_backing_capacity = sizeof(batch_backend);
+    args.large_write_nodeid = &large_write_nodeid;
+    args.write_offsets = write_offsets;
+    args.write_sizes = write_sizes;
+    args.write_flags = write_flags;
+    args.write_trace_capacity = 4;
+    args.forced_write_errno = &forced_write_errno;
+    args.forced_write_offset = &forced_write_offset;
+    args.forced_short_write_offset = &forced_short_write_offset;
+    args.forced_short_write_size = &forced_short_write_size;
     args.write_watch_offset = 200;
     args.last_write_watch_byte = &extension_write_byte;
     args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
+    args.init_out_max_write_override = 8192;
     args.link_reuse_old_nodeid = 1;
     args.access_deny_mask = 2;
 
@@ -201,6 +494,7 @@ static int ext_test_p2_ops() {
     // Exercise writeback of an extension in the original EOF page. The
     // writeback length must be calculated from the extended local size.
     write_count = 0;
+    last_write_offset = UINT64_MAX;
     last_write_size = 0;
     write_count_at_fsync = 0;
     if (pwrite(f, &extension, 1, 200) != 1) {
@@ -221,6 +515,190 @@ static int ext_test_p2_ops() {
         goto fail;
     }
     close(f);
+
+    // P3: four locally dirty pages (the last one partial) must be submitted in
+    // max_write-sized batches rather than one request per page.
+    batch_data = (unsigned char *)malloc(batch_size);
+    if (!batch_data) {
+        printf("[FAIL] allocate batched write payload\n");
+        goto fail;
+    }
+    for (size_t i = 0; i < batch_size; ++i) {
+        batch_data[i] = (unsigned char)(i * 17u + 3u);
+    }
+    snprintf(batch_path, sizeof(batch_path), "%s/p3_batch.txt", mp);
+    f = open(batch_path, O_CREAT | O_RDWR, 0644);
+    if (f < 0 || write(f, batch_data, batch_size) != (ssize_t)batch_size) {
+        printf("[FAIL] create batched write file: %s (errno=%d)\n", strerror(errno), errno);
+        free(batch_data);
+        if (f >= 0)
+            close(f);
+        goto fail;
+    }
+    large_write_nodeid = last_create_nodeid;
+    write_count = 0;
+    last_write_offset = UINT64_MAX;
+    last_write_size = 0;
+    last_write_flags = 0;
+    if (fsync(f) != 0) {
+        printf("[FAIL] fsync batched write: %s (errno=%d)\n", strerror(errno), errno);
+        free(batch_data);
+        close(f);
+        goto fail;
+    }
+    if (write_count != 2 || write_offsets[0] != 0 || write_sizes[0] != 8192 ||
+        write_offsets[1] != 8192 || write_sizes[1] != batch_size - 8192 ||
+        write_flags[0] != FUSE_WRITE_CACHE || write_flags[1] != FUSE_WRITE_CACHE ||
+        last_write_offset != 8192 || last_write_size != batch_size - 8192 ||
+        (last_write_flags & FUSE_WRITE_CACHE) == 0 || large_write_nodeid == 0 ||
+        memcmp(batch_backend, batch_data, batch_size) != 0) {
+        printf("[FAIL] batched write requests=%u first=(%llu,%u,0x%x) second=(%llu,%u,0x%x) node=%llu expected_size=%zu\n",
+               write_count, (unsigned long long)write_offsets[0], write_sizes[0],
+               write_flags[0], (unsigned long long)write_offsets[1], write_sizes[1],
+               write_flags[1], (unsigned long long)large_write_nodeid, batch_size);
+        free(batch_data);
+        close(f);
+        goto fail;
+    }
+    close(f);
+
+    // Exercise the asynchronous WRITE|WAIT_AFTER path. Failure of the second
+    // max_write batch must be reported, leave only that failed batch dirty,
+    // and permit a later call to retry it without resending the first batch.
+    memset(batch_backend, 0, sizeof(batch_backend));
+    large_write_nodeid = 0;
+    snprintf(error_path, sizeof(error_path), "%s/p3_error.txt", mp);
+    f = open(error_path, O_CREAT | O_RDWR, 0644);
+    if (f < 0 || write(f, batch_data, batch_size) != (ssize_t)batch_size) {
+        printf("[FAIL] create async error file: %s (errno=%d)\n", strerror(errno), errno);
+        free(batch_data);
+        if (f >= 0)
+            close(f);
+        goto fail;
+    }
+    large_write_nodeid = last_create_nodeid;
+    write_count = 0;
+    forced_write_offset = 8192;
+    forced_write_errno = EIO;
+    errno = 0;
+    if (syscall(__NR_sync_file_range, f, 0, batch_size,
+                SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER) != -1 ||
+        errno != EIO || write_count != 2 ||
+        !((write_offsets[0] == 0 && write_sizes[0] == 8192 &&
+           write_offsets[1] == 8192 && write_sizes[1] == batch_size - 8192) ||
+          (write_offsets[1] == 0 && write_sizes[1] == 8192 &&
+           write_offsets[0] == 8192 && write_sizes[0] == batch_size - 8192))) {
+        printf("[FAIL] async batched EIO rc/errno/count=%d/%d/%u first=(%llu,%u) second=(%llu,%u)\n",
+               errno == EIO ? -1 : 0, errno, write_count,
+               (unsigned long long)write_offsets[0], write_sizes[0],
+               (unsigned long long)write_offsets[1], write_sizes[1]);
+        forced_write_errno = 0;
+        free(batch_data);
+        close(f);
+        goto fail;
+    }
+    forced_write_errno = 0;
+    forced_write_offset = UINT64_MAX;
+    write_count = 0;
+    if (syscall(__NR_sync_file_range, f, 0, batch_size,
+                SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER) != 0 ||
+        write_count != 1 || write_offsets[0] != 8192 ||
+        write_sizes[0] != batch_size - 8192 ||
+        memcmp(batch_backend, batch_data, batch_size) != 0) {
+        printf("[FAIL] async EIO retry count=%u write=(%llu,%u) errno=%d\n", write_count,
+               (unsigned long long)write_offsets[0], write_sizes[0], errno);
+        free(batch_data);
+        close(f);
+        goto fail;
+    }
+
+    // A short successful reply is an EIO for the whole request. Both pages in
+    // that batch must return to Dirty and be resent together on retry.
+    if (pwrite(f, batch_data, batch_size, 0) != (ssize_t)batch_size) {
+        printf("[FAIL] redirty async short-write file: %s (errno=%d)\n", strerror(errno), errno);
+        free(batch_data);
+        close(f);
+        goto fail;
+    }
+    write_count = 0;
+    forced_short_write_offset = 0;
+    forced_short_write_size = 4096;
+    errno = 0;
+    if (syscall(__NR_sync_file_range, f, 0, batch_size,
+                SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER) != -1 ||
+        errno != EIO || write_count != 2) {
+        printf("[FAIL] async short reply errno/count=%d/%u\n", errno, write_count);
+        forced_short_write_offset = UINT64_MAX;
+        free(batch_data);
+        close(f);
+        goto fail;
+    }
+    forced_short_write_offset = UINT64_MAX;
+    forced_short_write_size = 0;
+    write_count = 0;
+    if (syscall(__NR_sync_file_range, f, 0, batch_size,
+                SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER) != 0 ||
+        write_count != 1 || write_offsets[0] != 0 || write_sizes[0] != 8192 ||
+        memcmp(batch_backend, batch_data, batch_size) != 0) {
+        printf("[FAIL] async short retry count=%u write=(%llu,%u) errno=%d\n", write_count,
+               (unsigned long long)write_offsets[0], write_sizes[0], errno);
+        free(batch_data);
+        close(f);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+
+    // A direct write must drain overlapping cached dirty pages through the
+    // same stable-size batch path before issuing direct FUSE_WRITE requests.
+    // With max_write=8192, both phases split as 8192 + 4113 and direct writes
+    // must not carry FUSE_WRITE_CACHE. Direct writes do carry the current
+    // file lock owner, matching the ordinary FUSE direct-I/O path.
+    memset(batch_backend, 0, sizeof(batch_backend));
+    large_write_nodeid = 0;
+    snprintf(direct_path, sizeof(direct_path), "%s/p3_direct_drain.txt", mp);
+    f = open(direct_path, O_CREAT | O_RDWR, 0644);
+    if (f < 0 || write(f, batch_data, batch_size) != (ssize_t)batch_size) {
+        printf("[FAIL] create dirty direct-drain file: %s (errno=%d)\n", strerror(errno),
+               errno);
+        free(batch_data);
+        goto fail;
+    }
+    large_write_nodeid = last_create_nodeid;
+    write_count = 0;
+    dynamic_open_out_flags = FOPEN_DIRECT_IO;
+    direct_fd = open(direct_path, O_WRONLY);
+    if (direct_fd < 0 || pwrite(direct_fd, batch_data, batch_size, 0) != (ssize_t)batch_size) {
+        printf("[FAIL] direct write after dirty batch: %s (errno=%d)\n", strerror(errno),
+               errno);
+        dynamic_open_out_flags = 0;
+        free(batch_data);
+        goto fail;
+    }
+    dynamic_open_out_flags = 0;
+    close(direct_fd);
+    direct_fd = -1;
+    if (write_count != 4 || write_offsets[0] != 0 || write_sizes[0] != 8192 ||
+        write_flags[0] != FUSE_WRITE_CACHE || write_offsets[1] != 8192 ||
+        write_sizes[1] != batch_size - 8192 || write_flags[1] != FUSE_WRITE_CACHE ||
+        write_offsets[2] != 0 || write_sizes[2] != 8192 ||
+        write_flags[2] != FUSE_WRITE_LOCKOWNER ||
+        write_offsets[3] != 8192 || write_sizes[3] != batch_size - 8192 ||
+        write_flags[3] != FUSE_WRITE_LOCKOWNER ||
+        memcmp(batch_backend, batch_data, batch_size) != 0) {
+        printf("[FAIL] direct drain trace count=%u cached=(%llu,%u,0x%x),(%llu,%u,0x%x) direct=(%llu,%u,0x%x),(%llu,%u,0x%x)\n",
+               write_count, (unsigned long long)write_offsets[0], write_sizes[0],
+               write_flags[0], (unsigned long long)write_offsets[1], write_sizes[1],
+               write_flags[1], (unsigned long long)write_offsets[2], write_sizes[2],
+               write_flags[2], (unsigned long long)write_offsets[3], write_sizes[3],
+               write_flags[3]);
+        free(batch_data);
+        goto fail;
+    }
+    close(f);
+    f = -1;
+    free(batch_data);
+    batch_data = NULL;
 
     // A short daemon READ inside a locally extended sparse file denotes a
     // hole under FUSE_WRITEBACK_CACHE. It must neither shrink local i_size nor
@@ -373,6 +851,9 @@ static int ext_test_p2_ops() {
     return 0;
 
 fail:
+    if (direct_fd >= 0) {
+        close(direct_fd);
+    }
     umount(mp);
 fail_no_umount:
     stop = 1;
@@ -380,6 +861,310 @@ fail_no_umount:
     pthread_join(th, NULL);
     rmdir(mp);
     return -1;
+}
+
+static int ext_test_dirty_multibatch_notify_invalidation_inner() {
+    char mp[128];
+    char debug_root[128];
+    const size_t payload_size = 3 * 4096 + 17;
+    char path[256];
+    char stats_path[256];
+    unsigned char payload[3 * 4096 + 17];
+    unsigned char backing[16384];
+    char first = 0;
+    char tail = 0;
+    int fd = -1;
+    int file = -1;
+    int mounted = 0;
+    int debug_mounted = 0;
+    int daemon_active = 0;
+    int fsync_active = 0;
+    uint32_t reads_before = 0;
+    uint64_t launder_batches_before = 0;
+    uint64_t launder_batches_after = 0;
+    uint64_t launder_pages_before = 0;
+    uint64_t launder_pages_after = 0;
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile int write_entered = 0;
+    volatile int release_write = 1;
+    volatile uint64_t block_write_offset = 0;
+    volatile uint32_t create_count = 0;
+    volatile uint64_t last_create_nodeid = 0;
+    volatile uint64_t large_write_nodeid = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint64_t write_offsets[4] = {0};
+    volatile uint32_t write_sizes[4] = {0};
+    volatile uint32_t write_flags[4] = {0};
+    pthread_t daemon_thread;
+    pthread_t fsync_thread;
+    struct fuse_fsync_worker_args fsync_args;
+    struct {
+        struct fuse_out_header out;
+        struct fuse_notify_inval_inode_out inval;
+    } notify;
+
+    memset(backing, 0, sizeof(backing));
+    for (size_t i = 0; i < payload_size; ++i) {
+        payload[i] = (unsigned char)(i * 29u + 7u);
+    }
+    memset(&fsync_args, 0, sizeof(fsync_args));
+    memset(&notify, 0, sizeof(notify));
+    snprintf(mp, sizeof(mp), "/tmp/test_fuse_p3_notify_dirty_%d", getpid());
+    snprintf(debug_root, sizeof(debug_root), "/tmp/test_fuse_p3_notify_debugfs_%d", getpid());
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+    if (ensure_dir(debug_root) != 0 || mount("none", debug_root, "debugfs", 0, NULL) != 0) {
+        printf("[FAIL] mount debugfs: %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(debug_root);
+        rmdir(mp);
+        return -1;
+    }
+    debug_mounted = 1;
+    snprintf(stats_path, sizeof(stats_path), "%s/fuse/stats", debug_root);
+    if (fuse_count_mounted_filesystems() != 0) {
+        printf("[FAIL] dirty notify test requires an isolated guest with no FUSE mount\n");
+        goto fail;
+    }
+    fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        umount(debug_root);
+        rmdir(debug_root);
+        rmdir(mp);
+        return -1;
+    }
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.create_count = &create_count;
+    args.last_create_nodeid = &last_create_nodeid;
+    args.read_count = &read_count;
+    args.write_count = &write_count;
+    args.write_offsets = write_offsets;
+    args.write_sizes = write_sizes;
+    args.write_flags = write_flags;
+    args.write_trace_capacity = 4;
+    args.large_write_backing = backing;
+    args.large_write_backing_capacity = sizeof(backing);
+    args.large_write_nodeid = &large_write_nodeid;
+    args.block_write_offset = &block_write_offset;
+    args.write_entered = &write_entered;
+    args.release_write = &release_write;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
+    args.init_out_max_write_override = 8192;
+
+    if (pthread_create(&daemon_thread, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create daemon\n");
+        close(fd);
+        umount(debug_root);
+        rmdir(debug_root);
+        rmdir(mp);
+        return -1;
+    }
+    daemon_active = 1;
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,allow_other",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 1;
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+    if (fuse_count_mounted_filesystems() != 1) {
+        printf("[FAIL] dirty notify test lost exclusive FUSE mount ownership\n");
+        goto fail;
+    }
+    if (fuse_read_launder_counters(stats_path, &launder_batches_before,
+                                   &launder_pages_before) != 0) {
+        printf("[FAIL] read invalidation laundering counters before notify\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/dirty-notify.bin", mp);
+    file = open(path, O_CREAT | O_RDWR, 0644);
+    if (file < 0 || write(file, payload, payload_size) != (ssize_t)payload_size) {
+        printf("[FAIL] create dirty notify file: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    large_write_nodeid = last_create_nodeid;
+    if (create_count != 1 || large_write_nodeid == 0 || write_count != 0) {
+        printf("[FAIL] dirty setup create=%u node=%llu writes=%u\n", create_count,
+               (unsigned long long)large_write_nodeid, write_count);
+        goto fail;
+    }
+
+    release_write = 0;
+    __sync_synchronize();
+    notify.out.len = sizeof(notify);
+    notify.out.error = FUSE_NOTIFY_INVAL_INODE;
+    notify.out.unique = 0;
+    notify.inval.ino = large_write_nodeid;
+    notify.inval.off = 0;
+    notify.inval.len = -1;
+    if (write(fd, &notify, sizeof(notify)) != (ssize_t)sizeof(notify)) {
+        printf("[FAIL] write dirty inode notify: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (fuse_wait_flag(&write_entered, 5000) != 0) {
+        printf("[FAIL] notify worker did not enter laundering WRITE\n");
+        goto fail;
+    }
+
+    fsync_args.fd = file;
+    if (pthread_create(&fsync_thread, NULL, fuse_fsync_worker, &fsync_args) != 0) {
+        printf("[FAIL] pthread_create fsync\n");
+        goto fail;
+    }
+    fsync_active = 1;
+    release_write = 1;
+    __sync_synchronize();
+    pthread_join(fsync_thread, NULL);
+    fsync_active = 0;
+    if (fsync_args.result != 0) {
+        errno = fsync_args.saved_errno;
+        printf("[FAIL] fsync after dirty notify: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (fuse_count_mounted_filesystems() != 1 ||
+        fuse_read_launder_counters(stats_path, &launder_batches_after,
+                                   &launder_pages_after) != 0 ||
+        launder_batches_after - launder_batches_before != 2 ||
+        launder_pages_after - launder_pages_before != 4) {
+        printf("[FAIL] notify laundering counter delta batches=%llu->%llu pages=%llu->%llu\n",
+               (unsigned long long)launder_batches_before,
+               (unsigned long long)launder_batches_after,
+               (unsigned long long)launder_pages_before,
+               (unsigned long long)launder_pages_after);
+        goto fail;
+    }
+
+    if (write_count != 2 || write_offsets[0] != 0 || write_sizes[0] != 8192 ||
+        write_flags[0] != FUSE_WRITE_CACHE || write_offsets[1] != 8192 ||
+        write_sizes[1] != payload_size - 8192 || write_flags[1] != FUSE_WRITE_CACHE ||
+        memcmp(backing, payload, payload_size) != 0) {
+        printf("[FAIL] notify laundering trace count=%u first=(%llu,%u,0x%x) second=(%llu,%u,0x%x)\n",
+               write_count, (unsigned long long)write_offsets[0], write_sizes[0],
+               write_flags[0], (unsigned long long)write_offsets[1], write_sizes[1],
+               write_flags[1]);
+        goto fail;
+    }
+
+    // The worker has released the exclusive writeback barrier before fsync
+    // can complete. Mutating daemon backing now makes a subsequent cache hit
+    // distinguishable from a fresh FUSE_READ after successful invalidation.
+    backing[0] = 'Q';
+    backing[9000] = 'R';
+    reads_before = read_count;
+    if (pread(file, &first, 1, 0) != 1 || pread(file, &tail, 1, 9000) != 1 ||
+        first != 'Q' || tail != 'R' || read_count <= reads_before) {
+        printf("[FAIL] notify did not invalidate cache first=%d tail=%d reads=%u->%u errno=%d\n",
+               first, tail, reads_before, read_count, errno);
+        goto fail;
+    }
+
+    close(file);
+    file = -1;
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 0;
+    stop = 1;
+    close(fd);
+    fd = -1;
+    pthread_join(daemon_thread, NULL);
+    daemon_active = 0;
+    umount(debug_root);
+    debug_mounted = 0;
+    rmdir(debug_root);
+    rmdir(mp);
+    return 0;
+
+fail:
+    release_write = 1;
+    __sync_synchronize();
+    if (fsync_active) {
+        pthread_join(fsync_thread, NULL);
+    }
+    if (file >= 0) {
+        close(file);
+    }
+    if (mounted) {
+        umount(mp);
+    }
+    stop = 1;
+    if (fd >= 0) {
+        close(fd);
+    }
+    if (daemon_active) {
+        pthread_join(daemon_thread, NULL);
+    }
+    if (debug_mounted) {
+        umount(debug_root);
+    }
+    rmdir(debug_root);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_dirty_multibatch_notify_invalidation() {
+    char mp[128];
+    char debug_root[128];
+    volatile int *done = fuse_alloc_child_done();
+    if (!done) {
+        printf("[FAIL] allocate dirty notify child status: %s (errno=%d)\n", strerror(errno),
+               errno);
+        return -1;
+    }
+    pid_t child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork dirty notify test: %s (errno=%d)\n", strerror(errno), errno);
+        munmap((void *)done, sizeof(int));
+        return -1;
+    }
+    if (child == 0) {
+        int result = ext_test_dirty_multibatch_notify_invalidation_inner();
+        fflush(NULL);
+        fuse_publish_child_done(done);
+        _exit(result == 0 ? 0 : 1);
+    }
+    snprintf(mp, sizeof(mp), "/tmp/test_fuse_p3_notify_dirty_%d", child);
+    snprintf(debug_root, sizeof(debug_root), "/tmp/test_fuse_p3_notify_debugfs_%d", child);
+
+    int status = 0;
+    int waited = fuse_reap_child_bounded(child, done, &status, 15000);
+    munmap((void *)done, sizeof(int));
+    int result = -1;
+    if (waited == 1) {
+        result = WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 0 : -1;
+    } else {
+        printf(waited == 0 ? "[FAIL] dirty notify test timed out\n"
+                           : "[FAIL] waitpid dirty notify child failed\n");
+    }
+
+    // The child shares the mount namespace. All potentially blocking cleanup
+    // runs in its own bounded child so even teardown regressions cannot hang
+    // the FuseExtended parent.
+    if (fuse_cleanup_mounts_bounded(mp, debug_root) != 0) {
+        printf("[FAIL] bounded cleanup of dirty notify mounts failed\n");
+        result = -1;
+    }
+    return result;
 }
 
 static int ext_test_positive_lookup_cache_respects_entry_ttl() {
@@ -1466,6 +2251,127 @@ fail_no_umount:
     return -1;
 }
 
+static int ext_test_noopen_close_flushes_dirty_data_with_zero_fh() {
+    const char *mp = "/tmp/test_fuse_noopen_close_flush";
+    const char marker = 'N';
+    int f = -1;
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+
+    int fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    volatile uint32_t flush_count = 0;
+    volatile uint32_t release_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint32_t write_count_at_flush = 0;
+    volatile uint32_t last_write_flags = 0;
+    volatile uint64_t last_flush_fh = UINT64_MAX;
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.open_count = &open_count;
+    args.flush_count = &flush_count;
+    args.release_count = &release_count;
+    args.write_count = &write_count;
+    args.write_count_at_flush = &write_count_at_flush;
+    args.last_write_flags = &last_write_flags;
+    args.last_flush_fh = &last_flush_fh;
+    args.force_open_enosys = 1;
+    args.init_out_flags_override =
+        FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_NO_OPEN_SUPPORT | FUSE_WRITEBACK_CACHE;
+
+    pthread_t th;
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        stop = 1;
+        close(fd);
+        pthread_join(th, NULL);
+        rmdir(mp);
+        return -1;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (pwrite(f, &marker, 1, 1) != 1) {
+        printf("[FAIL] pwrite(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (write_count != 0) {
+        printf("[FAIL] no-open WB write reached daemon before close: writes=%u\n", write_count);
+        goto fail;
+    }
+    if (close(f) != 0) {
+        printf("[FAIL] close(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        f = -1;
+        goto fail;
+    }
+    f = -1;
+
+    if (open_count != 1 || write_count_at_flush == 0 || flush_count != 1 ||
+        last_flush_fh != 0 || release_count != 0 ||
+        (last_write_flags & FUSE_WRITE_CACHE) == 0) {
+        printf("[FAIL] no-open close ordering open=%u writes=%u writes_at_flush=%u flush=%u flush_fh=%llu release=%u flags=0x%x\n",
+               open_count, write_count, write_count_at_flush, flush_count,
+               (unsigned long long)last_flush_fh, release_count, last_write_flags);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_fsync_enosys_cached_success() {
     const char *mp = "/tmp/test_fuse_fsync_enosys";
     int f = -1;
@@ -2222,6 +3128,257 @@ fail_no_umount:
     stop = 1;
     close(fd);
     pthread_join(th, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_writeback_cache_noflush_still_flushes() {
+    const char *mp = "/tmp/test_fuse_wb_noflush_flush";
+    char path[256];
+    int f = -1;
+    int fd = -1;
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t flush_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint32_t write_count_at_flush = 0;
+    volatile uint32_t last_write_flags = 0;
+    const char marker = 'W';
+    pthread_t th;
+    int thread_started = 0;
+    int mounted = 0;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+    fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.flush_count = &flush_count;
+    args.write_count = &write_count;
+    args.write_count_at_flush = &write_count_at_flush;
+    args.last_write_flags = &last_write_flags;
+    args.hello_open_out_flags = FOPEN_NOFLUSH;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
+
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+    thread_started = 1;
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 1;
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (pwrite(f, &marker, 1, 1) != 1) {
+        printf("[FAIL] pwrite(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (write_count != 0) {
+        printf("[FAIL] writeback-cache write reached daemon before close: writes=%u\n",
+               write_count);
+        goto fail;
+    }
+    if (close(f) != 0) {
+        printf("[FAIL] close(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        f = -1;
+        goto fail;
+    }
+    f = -1;
+
+    if (flush_count != 1 || write_count_at_flush == 0 ||
+        (last_write_flags & FUSE_WRITE_CACHE) == 0) {
+        printf("[FAIL] WB+NOFLUSH ordering writes=%u writes_at_flush=%u flush=%u flags=0x%x\n",
+               write_count, write_count_at_flush, flush_count, last_write_flags);
+        goto fail;
+    }
+
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 0;
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (f >= 0) {
+        close(f);
+    }
+    if (mounted) {
+        umount(mp);
+    }
+    stop = 1;
+    close(fd);
+    if (thread_started) {
+        pthread_join(th, NULL);
+    }
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_nonwriteback_mmap_close_flushes_dirty_mapping() {
+    const char *mp = "/tmp/test_fuse_nonwb_mmap_close";
+    char path[256];
+    int f = -1;
+    int fd = -1;
+    void *addr = MAP_FAILED;
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t flush_count = 0;
+    volatile uint32_t read_count = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint32_t write_count_at_flush = 0;
+    volatile uint32_t last_write_flags = 0;
+    pthread_t th;
+    int thread_started = 0;
+    int mounted = 0;
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+    fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.flush_count = &flush_count;
+    args.read_count = &read_count;
+    args.write_count = &write_count;
+    args.write_count_at_flush = &write_count_at_flush;
+    args.last_write_flags = &last_write_flags;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES;
+
+    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fd);
+        rmdir(mp);
+        return -1;
+    }
+    thread_started = 1;
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 1;
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    f = open(path, O_RDWR);
+    if (f < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED) {
+        printf("[FAIL] mmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    if (((volatile char *)addr)[0] != 'h') {
+        printf("[FAIL] non-WB shared mmap first byte got=%d\n",
+               ((volatile char *)addr)[0]);
+        goto fail;
+    }
+    ((volatile char *)addr)[3] = 'C';
+    if (write_count != 0) {
+        printf("[FAIL] dirty mmap reached daemon before close: writes=%u\n", write_count);
+        goto fail;
+    }
+    if (close(f) != 0) {
+        printf("[FAIL] close(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        f = -1;
+        goto fail;
+    }
+    f = -1;
+
+    if (((volatile char *)addr)[3] != 'C' || read_count != 1 || flush_count != 1 ||
+        write_count_at_flush == 0 || (last_write_flags & FUSE_WRITE_CACHE) == 0) {
+        printf("[FAIL] non-WB mmap close ordering reads=%u writes=%u writes_at_flush=%u flush=%u flags=0x%x mapped=%d\n",
+               read_count, write_count, write_count_at_flush, flush_count, last_write_flags,
+               ((volatile char *)addr)[3]);
+        goto fail;
+    }
+
+    if (munmap(addr, 4096) != 0) {
+        printf("[FAIL] munmap(%s): %s (errno=%d)\n", path, strerror(errno), errno);
+        goto fail;
+    }
+    addr = MAP_FAILED;
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 0;
+    stop = 1;
+    close(fd);
+    pthread_join(th, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (addr != MAP_FAILED) {
+        munmap(addr, 4096);
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    if (mounted) {
+        umount(mp);
+    }
+    stop = 1;
+    close(fd);
+    if (thread_started) {
+        pthread_join(th, NULL);
+    }
     rmdir(mp);
     return -1;
 }
@@ -5292,6 +6449,489 @@ fail:
     munmap(shared, sizeof(*shared));
     rmdir(mp);
     return -1;
+}
+
+static int ext_test_mmap_writeback_retry_outside_mm_guard_inner(volatile int *stage) {
+    char mp[128];
+    char debug_root[128];
+    char path[256];
+    char stats_path[256];
+    int fd = -1;
+    int f = -1;
+    void *addr = MAP_FAILED;
+    int mounted = 0;
+    int debug_mounted = 0;
+    pthread_t daemon_thread;
+    pthread_t fsync_thread;
+    pthread_t writer_thread;
+    int daemon_active = 0;
+    int fsync_active = 0;
+    int writer_active = 0;
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint64_t last_create_nodeid = 0;
+    volatile uint64_t large_write_nodeid = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint64_t write_offsets[8] = {0};
+    volatile uint32_t write_sizes[8] = {0};
+    volatile uint32_t write_flags[8] = {0};
+    volatile uint64_t block_write_offset = 0;
+    volatile int write_entered = 0;
+    volatile int release_write = 0;
+    uint64_t retry_count_before = 0;
+    uint64_t retry_count_after = 0;
+    unsigned char backing[8192];
+    unsigned char payload[8192];
+    struct fuse_fsync_worker_args fsync_args;
+    struct fuse_mmap_single_write_args writer_args;
+    memset(backing, 0, sizeof(backing));
+    for (size_t i = 0; i < sizeof(payload); ++i) {
+        payload[i] = (unsigned char)(i * 13u + 7u);
+    }
+    memset(&fsync_args, 0, sizeof(fsync_args));
+    memset(&writer_args, 0, sizeof(writer_args));
+    snprintf(mp, sizeof(mp), "/tmp/test_fuse_mmap_writeback_retry_%d", getpid());
+    snprintf(debug_root, sizeof(debug_root), "/tmp/test_fuse_mmap_writeback_debugfs_%d",
+             getpid());
+    snprintf(stats_path, sizeof(stats_path), "%s/fuse/stats", debug_root);
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+    if (ensure_dir(debug_root) != 0 || mount("none", debug_root, "debugfs", 0, NULL) != 0) {
+        printf("[FAIL] mount mmap retry debugfs: %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(debug_root);
+        rmdir(mp);
+        return -1;
+    }
+    debug_mounted = 1;
+    if (fuse_count_mounted_filesystems() != 0) {
+        printf("[FAIL] mmap retry test requires an isolated guest with no FUSE mount\n");
+        goto fail;
+    }
+    if (fuse_read_u64_counter(stats_path, "mmap_writeback_admission_retries_total",
+                              &retry_count_before) != 0) {
+        printf("[FAIL] read mmap admission retry counter before test\n");
+        goto fail;
+    }
+    fd = open("/dev/fuse", O_RDWR);
+    if (fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    struct fuse_daemon_args daemon_args;
+    memset(&daemon_args, 0, sizeof(daemon_args));
+    daemon_args.fd = fd;
+    daemon_args.stop = &stop;
+    daemon_args.init_done = &init_done;
+    daemon_args.enable_write_ops = 1;
+    daemon_args.stop_on_destroy = 1;
+    daemon_args.last_create_nodeid = &last_create_nodeid;
+    daemon_args.write_count = &write_count;
+    daemon_args.write_offsets = write_offsets;
+    daemon_args.write_sizes = write_sizes;
+    daemon_args.write_flags = write_flags;
+    daemon_args.write_trace_capacity = 8;
+    daemon_args.large_write_backing = backing;
+    daemon_args.large_write_backing_capacity = sizeof(backing);
+    daemon_args.large_write_nodeid = &large_write_nodeid;
+    daemon_args.block_write_offset = &block_write_offset;
+    daemon_args.write_entered = &write_entered;
+    daemon_args.release_write = &release_write;
+    daemon_args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
+    daemon_args.init_out_max_write_override = 4096;
+    if (pthread_create(&daemon_thread, NULL, fuse_daemon_thread, &daemon_args) != 0) {
+        printf("[FAIL] pthread_create fuse daemon\n");
+        goto fail;
+    }
+    daemon_active = 1;
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount/init mmap retry daemon: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 1;
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] mmap retry init handshake timeout\n");
+        goto fail;
+    }
+    if (fuse_count_mounted_filesystems() != 1) {
+        printf("[FAIL] mmap retry test lost exclusive FUSE mount ownership\n");
+        goto fail;
+    }
+    *stage = 1;
+    __sync_synchronize();
+    snprintf(path, sizeof(path), "%s/two_pages", mp);
+    f = open(path, O_CREAT | O_RDWR, 0644);
+    if (f < 0 || write(f, payload, sizeof(payload)) != (ssize_t)sizeof(payload)) {
+        printf("[FAIL] create two-page mmap retry file: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    large_write_nodeid = last_create_nodeid;
+    if (large_write_nodeid == 0 || write_count != 0) {
+        printf("[FAIL] writeback-cache setup node=%llu writes=%u\n",
+               (unsigned long long)large_write_nodeid, write_count);
+        goto fail;
+    }
+    addr = mmap(NULL, sizeof(payload), PROT_READ | PROT_WRITE, MAP_SHARED, f, 0);
+    if (addr == MAP_FAILED || ((volatile unsigned char *)addr)[4096] != payload[4096]) {
+        printf("[FAIL] prefault second mmap page: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    fsync_args.fd = f;
+    if (pthread_create(&fsync_thread, NULL, fuse_fsync_worker, &fsync_args) != 0) {
+        printf("[FAIL] pthread_create fsync worker\n");
+        goto fail;
+    }
+    fsync_active = 1;
+    if (fuse_wait_flag(&write_entered, 5000) != 0 || write_count != 0) {
+        printf("[FAIL] first split WRITE did not enter blocking daemon entered=%d count=%u\n",
+               write_entered, write_count);
+        goto fail;
+    }
+    *stage = 2;
+    __sync_synchronize();
+
+    writer_args.address = (volatile char *)addr + 4096;
+    writer_args.value = 'Z';
+    if (pthread_create(&writer_thread, NULL, fuse_mmap_single_write_worker, &writer_args) != 0) {
+        printf("[FAIL] pthread_create mmap writer\n");
+        goto fail;
+    }
+    writer_active = 1;
+    if (fuse_wait_flag(&writer_args.started, 1000) != 0) {
+        printf("[FAIL] mmap writer did not start\n");
+        goto fail;
+    }
+    *stage = 3;
+    __sync_synchronize();
+    if (fuse_wait_counter_increase(stats_path, "mmap_writeback_admission_retries_total",
+                                   retry_count_before, &retry_count_after, 5000) != 0 ||
+        writer_args.done) {
+        printf("[FAIL] mmap writer did not enter admission retry count=%llu->%llu done=%d\n",
+               (unsigned long long)retry_count_before,
+               (unsigned long long)retry_count_after, writer_args.done);
+        goto fail;
+    }
+    *stage = 4;
+    __sync_synchronize();
+
+    release_write = 1;
+    __sync_synchronize();
+    *stage = 5;
+    __sync_synchronize();
+    if (fuse_wait_flag(&fsync_args.done, 5000) != 0) {
+        *stage = 6;
+        __sync_synchronize();
+        printf("[FAIL] mmap/fsync retry did not complete fsync=%d writer=%d\n",
+               fsync_args.done, writer_args.done);
+        goto fail;
+    }
+    *stage = 7;
+    __sync_synchronize();
+    if (fuse_wait_flag(&writer_args.done, 5000) != 0) {
+        *stage = 8;
+        __sync_synchronize();
+        printf("[FAIL] mmap/fsync retry did not complete fsync=%d writer=%d\n",
+               fsync_args.done, writer_args.done);
+        goto fail;
+    }
+    *stage = 9;
+    __sync_synchronize();
+    pthread_join(fsync_thread, NULL);
+    fsync_active = 0;
+    pthread_join(writer_thread, NULL);
+    writer_active = 0;
+    if (fsync_args.result != 0 || fsync(f) != 0) {
+        printf("[FAIL] mmap retry fsync results first=%d/%d final=%d\n", fsync_args.result,
+               fsync_args.saved_errno, errno);
+        goto fail;
+    }
+    payload[4096] = 'Z';
+    if (write_count != 3 || write_offsets[0] != 0 || write_offsets[1] != 4096 ||
+        write_offsets[2] != 4096 || write_sizes[0] != 4096 || write_sizes[1] != 4096 ||
+        write_sizes[2] != 4096 || write_flags[0] != FUSE_WRITE_CACHE ||
+        write_flags[1] != FUSE_WRITE_CACHE || write_flags[2] != FUSE_WRITE_CACHE ||
+        memcmp(backing, payload, sizeof(payload)) != 0) {
+        printf("[FAIL] mmap retry trace count=%u writes=(%llu,%u,0x%x),(%llu,%u,0x%x),(%llu,%u,0x%x)\n",
+               write_count, (unsigned long long)write_offsets[0], write_sizes[0], write_flags[0],
+               (unsigned long long)write_offsets[1], write_sizes[1], write_flags[1],
+               (unsigned long long)write_offsets[2], write_sizes[2], write_flags[2]);
+        goto fail;
+    }
+
+    munmap(addr, sizeof(payload));
+    addr = MAP_FAILED;
+    close(f);
+    f = -1;
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount mmap retry mount: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 0;
+    stop = 1;
+    close(fd);
+    fd = -1;
+    pthread_join(daemon_thread, NULL);
+    daemon_active = 0;
+    if (umount(debug_root) != 0) {
+        printf("[FAIL] umount mmap retry debugfs: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    debug_mounted = 0;
+    rmdir(debug_root);
+    rmdir(mp);
+    return 0;
+
+fail:
+    release_write = 1;
+    __sync_synchronize();
+    if (fsync_active) {
+        pthread_join(fsync_thread, NULL);
+    }
+    if (writer_active) {
+        pthread_join(writer_thread, NULL);
+    }
+    if (addr != MAP_FAILED) {
+        munmap(addr, sizeof(payload));
+    }
+    if (f >= 0) {
+        close(f);
+    }
+    if (mounted) {
+        umount(mp);
+    }
+    stop = 1;
+    if (fd >= 0) {
+        close(fd);
+    }
+    if (daemon_active) {
+        pthread_join(daemon_thread, NULL);
+    }
+    if (debug_mounted) {
+        umount(debug_root);
+    }
+    rmdir(debug_root);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_mmap_writeback_retry_outside_mm_guard() {
+    char mp[128];
+    char debug_root[128];
+    volatile int *done = fuse_alloc_child_done();
+    if (!done) {
+        printf("[FAIL] allocate mmap retry child status: %s (errno=%d)\n", strerror(errno),
+               errno);
+        return -1;
+    }
+    volatile int *stage = fuse_alloc_child_done();
+    if (!stage) {
+        printf("[FAIL] allocate mmap retry stage: %s (errno=%d)\n", strerror(errno), errno);
+        munmap((void *)done, sizeof(int));
+        return -1;
+    }
+    pid_t child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork mmap retry test: %s (errno=%d)\n", strerror(errno), errno);
+        munmap((void *)stage, sizeof(int));
+        munmap((void *)done, sizeof(int));
+        return -1;
+    }
+    if (child == 0) {
+        int result = ext_test_mmap_writeback_retry_outside_mm_guard_inner(stage);
+        fflush(NULL);
+        fuse_publish_child_done(done);
+        _exit(result == 0 ? 0 : 1);
+    }
+    snprintf(mp, sizeof(mp), "/tmp/test_fuse_mmap_writeback_retry_%d", child);
+    snprintf(debug_root, sizeof(debug_root), "/tmp/test_fuse_mmap_writeback_debugfs_%d", child);
+
+    int status = 0;
+    int waited = fuse_reap_child_bounded(child, done, &status, 15000);
+    munmap((void *)done, sizeof(int));
+    int result = -1;
+    if (waited == 1) {
+        result = WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 0 : -1;
+    } else {
+        int failed_stage = *stage;
+        fprintf(stderr, waited == 0 ? "[FAIL] mmap retry test timed out at stage=%d\n"
+                                    : "[FAIL] waitpid mmap retry child failed at stage=%d\n",
+                failed_stage);
+        fflush(stderr);
+        munmap((void *)stage, sizeof(int));
+        // The timed-out child owned the daemon. Issuing mount cleanup after
+        // killing it can itself enqueue FUSE requests with no consumer, hiding
+        // the original stage behind a second hang. A failed isolated run is
+        // intentionally left for the fresh-guest harness to discard.
+        return -100 - failed_stage;
+    }
+    munmap((void *)stage, sizeof(int));
+    if (fuse_cleanup_mounts_bounded(mp, debug_root) != 0) {
+        printf("[FAIL] bounded cleanup of mmap retry mounts failed\n");
+        result = -1;
+    }
+    return result;
+}
+
+static int ext_test_beyond_eof_dirty_page_retires_inner() {
+    char mp[128];
+    char path[256];
+    int fuse_fd = -1;
+    int file_fd = -1;
+    int mounted = 0;
+    int daemon_active = 0;
+    int fsync_result = -1;
+    unsigned char original = 0;
+    volatile unsigned char *bytes = NULL;
+    void *mapping = MAP_FAILED;
+    pthread_t daemon_thread;
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t write_count = 0;
+    volatile uint64_t getattr_size_override = UINT64_MAX;
+    struct stat st;
+
+    snprintf(mp, sizeof(mp), "/tmp/test_fuse_beyond_eof_dirty_%d", getpid());
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+    fuse_fd = open("/dev/fuse", O_RDWR);
+    if (fuse_fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    struct fuse_daemon_args args;
+    memset(&args, 0, sizeof(args));
+    args.fd = fuse_fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.enable_write_ops = 1;
+    args.stop_on_destroy = 1;
+    args.write_count = &write_count;
+    args.getattr_size_override = &getattr_size_override;
+    args.hello_generated_size_override = 2 * 4096;
+    // Deliberately omit FUSE_WRITEBACK_CACHE: a fresh daemon GETATTR may then
+    // shrink i_size below an already dirtied mmap page.
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES;
+    args.init_out_max_write_override = 8192;
+    if (pthread_create(&daemon_thread, NULL, fuse_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create beyond-EOF daemon\n");
+        goto fail;
+    }
+    daemon_active = 1;
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fuse_fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0 || fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] mount/init beyond-EOF daemon: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 1;
+    snprintf(path, sizeof(path), "%s/hello.txt", mp);
+    file_fd = open(path, O_RDWR);
+    if (file_fd < 0) {
+        printf("[FAIL] open beyond-EOF file: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mapping = mmap(NULL, 2 * 4096, PROT_READ | PROT_WRITE, MAP_SHARED, file_fd, 0);
+    if (mapping == MAP_FAILED) {
+        printf("[FAIL] mmap beyond-EOF file: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    bytes = (volatile unsigned char *)mapping;
+    original = bytes[4096];
+    bytes[4096] = (unsigned char)(original ^ 0x5a);
+    __sync_synchronize();
+
+    getattr_size_override = 0;
+    __sync_synchronize();
+    if (fstat(file_fd, &st) != 0 || st.st_size != 0) {
+        printf("[FAIL] GETATTR did not publish daemon shrink size=%lld errno=%d\n",
+               (long long)st.st_size, errno);
+        goto fail;
+    }
+    fsync_result = fsync(file_fd);
+    if (fsync_result != 0 || write_count != 0) {
+        printf("[FAIL] beyond-EOF dirty retirement fsync/write_count=%d/%u errno=%d\n",
+               fsync_result, write_count, errno);
+        goto fail;
+    }
+
+    munmap(mapping, 2 * 4096);
+    mapping = MAP_FAILED;
+    close(file_fd);
+    file_fd = -1;
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount beyond-EOF mount: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 0;
+    stop = 1;
+    close(fuse_fd);
+    fuse_fd = -1;
+    pthread_join(daemon_thread, NULL);
+    daemon_active = 0;
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (mapping != MAP_FAILED)
+        munmap(mapping, 2 * 4096);
+    if (file_fd >= 0)
+        close(file_fd);
+    if (mounted)
+        umount(mp);
+    stop = 1;
+    if (fuse_fd >= 0)
+        close(fuse_fd);
+    if (daemon_active)
+        pthread_join(daemon_thread, NULL);
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_beyond_eof_dirty_page_retires() {
+    char mp[128];
+    volatile int *done = fuse_alloc_child_done();
+    if (!done) {
+        printf("[FAIL] allocate beyond-EOF child status: %s (errno=%d)\n", strerror(errno),
+               errno);
+        return -1;
+    }
+    pid_t child = fork();
+    if (child < 0) {
+        printf("[FAIL] fork beyond-EOF test: %s (errno=%d)\n", strerror(errno), errno);
+        munmap((void *)done, sizeof(int));
+        return -1;
+    }
+    if (child == 0) {
+        int result = ext_test_beyond_eof_dirty_page_retires_inner();
+        fflush(NULL);
+        fuse_publish_child_done(done);
+        _exit(result == 0 ? 0 : 1);
+    }
+    snprintf(mp, sizeof(mp), "/tmp/test_fuse_beyond_eof_dirty_%d", child);
+    int status = 0;
+    int waited = fuse_reap_child_bounded(child, done, &status, 10000);
+    munmap((void *)done, sizeof(int));
+    int result = waited == 1 && WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 0 : -1;
+    if (waited != 1) {
+        printf(waited == 0 ? "[FAIL] beyond-EOF dirty test timed out\n"
+                           : "[FAIL] waitpid beyond-EOF dirty child failed\n");
+    }
+    if (fuse_cleanup_mounts_bounded(mp, mp) != 0) {
+        printf("[FAIL] bounded cleanup of beyond-EOF dirty mount failed\n");
+        result = -1;
+    }
+    return result;
 }
 
 static int ext_test_shared_writable_mmap_msync_writeback() {
@@ -8434,6 +10074,10 @@ TEST(FuseExtended, OpsAccessCreateSymlinkLinkRename2FlushFsync) {
     ASSERT_EQ(0, ext_test_p2_ops());
 }
 
+TEST(FuseExtended, DirtyMultibatchNotifyInvalidation) {
+    ASSERT_EQ(0, ext_test_dirty_multibatch_notify_invalidation());
+}
+
 TEST(FuseExtended, PositiveLookupCacheRespectsEntryTtl) {
     ASSERT_EQ(0, ext_test_positive_lookup_cache_respects_entry_ttl());
 }
@@ -8504,6 +10148,14 @@ TEST(FuseExtended, DirectIoMmapPolicy) {
 
 TEST(FuseExtended, SharedWritableMmapMsyncWriteback) {
     ASSERT_EQ(0, ext_test_shared_writable_mmap_msync_writeback());
+}
+
+TEST(FuseExtended, MmapWritebackRetryWaitsOutsideMmGuard) {
+    ASSERT_EQ(0, ext_test_mmap_writeback_retry_outside_mm_guard());
+}
+
+TEST(FuseExtended, BeyondEofDirtyPageRetiresWithoutWrite) {
+    ASSERT_EQ(0, ext_test_beyond_eof_dirty_page_retires());
 }
 
 TEST(FuseExtended, SharedMmapDirtyThenPwriteKeepsLatestData) {
@@ -8594,6 +10246,10 @@ TEST(FuseExtended, NoOpenFsyncUsesZeroFh) {
     ASSERT_EQ(0, ext_test_noopen_fsync_uses_zero_fh());
 }
 
+TEST(FuseExtended, NoOpenCloseFlushesDirtyDataWithZeroFh) {
+    ASSERT_EQ(0, ext_test_noopen_close_flushes_dirty_data_with_zero_fh());
+}
+
 TEST(FuseExtended, FsyncEnosysCachedSuccess) {
     ASSERT_EQ(0, ext_test_fsync_enosys_cached_success());
 }
@@ -8624,6 +10280,14 @@ TEST(FuseExtended, FsetflUpdatesFuseDevNonblock) {
 
 TEST(FuseExtended, FopenNoFlushSkipsFlush) {
     ASSERT_EQ(0, ext_test_fopen_noflush_skips_flush());
+}
+
+TEST(FuseExtended, WritebackCacheNoFlushStillFlushes) {
+    ASSERT_EQ(0, ext_test_writeback_cache_noflush_still_flushes());
+}
+
+TEST(FuseExtended, NonWritebackMmapCloseFlushesDirtyMapping) {
+    ASSERT_EQ(0, ext_test_nonwriteback_mmap_close_flushes_dirty_mapping());
 }
 
 TEST(FuseExtended, CloseReturnsFlushErrorAndClosesFd) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -720,6 +720,7 @@ struct fuse_daemon_args {
     uint32_t root_open_out_flags;
     uint32_t hello_open_out_flags;
     volatile uint32_t *dynamic_hello_open_out_flags;
+    volatile uint32_t *dynamic_open_out_flags;
     volatile unsigned char *dynamic_hello_first_byte;
     volatile size_t *dynamic_hello_read_size;
     volatile size_t *dynamic_hello_byte_offset;
@@ -736,12 +737,14 @@ struct fuse_daemon_args {
     volatile uint32_t *access_count;
     volatile uint32_t *lookup_count;
     volatile uint32_t *flush_count;
+    volatile uint32_t *write_count_at_flush;
     volatile uint32_t *last_flush_uid;
     volatile uint32_t *last_flush_gid;
     volatile uint32_t *last_flush_pid;
     volatile uint32_t *fsync_count;
     volatile uint32_t *fsyncdir_count;
     volatile uint32_t *create_count;
+    volatile uint64_t *last_create_nodeid;
     volatile uint32_t *mknod_count;
     volatile uint32_t *rename2_count;
     volatile uint32_t *open_count;
@@ -757,6 +760,9 @@ struct fuse_daemon_args {
     volatile uint64_t *last_setattr_fh;
     volatile uint64_t *last_setattr_size;
     volatile uint64_t *last_setattr_lock_owner;
+    // UINT64_MAX means no override.  Tests use this to model a daemon-side
+    // size shrink observed by GETATTR without issuing a local SETATTR first.
+    volatile uint64_t *getattr_size_override;
     volatile uint64_t *last_fallocate_fh;
     volatile uint64_t *last_fallocate_offset;
     volatile uint64_t *last_fallocate_length;
@@ -790,7 +796,17 @@ struct fuse_daemon_args {
     volatile unsigned char *write_watch_bytes;
     volatile unsigned char *write_covers_watch;
     volatile unsigned char *backend_watch_byte;
+    unsigned char *large_write_backing;
+    size_t large_write_backing_capacity;
+    volatile uint64_t *large_write_nodeid;
     uint32_t write_trace_capacity;
+    volatile int *forced_write_errno;
+    volatile uint64_t *forced_write_offset;
+    volatile uint64_t *forced_short_write_offset;
+    volatile uint32_t *forced_short_write_size;
+    volatile uint64_t *block_write_offset;
+    volatile int *write_entered;
+    volatile int *release_write;
     volatile uint64_t *last_fsync_fh;
     volatile uint32_t *write_count_at_fsync;
     volatile uint32_t *last_write_flags_at_fsync;
@@ -1054,6 +1070,10 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         struct fuse_attr_out out;
         memset(&out, 0, sizeof(out));
         simplefs_fill_attr(node, &out.attr);
+        if (a->getattr_size_override && *a->getattr_size_override != UINT64_MAX) {
+            out.attr.size = *a->getattr_size_override;
+            out.attr.blocks = (out.attr.size + 511) / 512;
+        }
         return fuse_write_reply(a->fd, h->unique, 0, &out, sizeof(out));
     }
     case FUSE_OPENDIR:
@@ -1093,7 +1113,10 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (h->opcode == FUSE_OPEN && (in->flags & O_TRUNC)) {
             node->size = 0;
         }
-        if (h->opcode == FUSE_OPEN && h->nodeid == 2 && a->dynamic_hello_open_out_flags) {
+        if (h->opcode == FUSE_OPEN && a->dynamic_open_out_flags) {
+            node->open_out_flags = *a->dynamic_open_out_flags;
+        } else if (h->opcode == FUSE_OPEN && h->nodeid == 2 &&
+                   a->dynamic_hello_open_out_flags) {
             node->open_out_flags = *a->dynamic_hello_open_out_flags;
         }
         struct fuse_open_out out;
@@ -1167,6 +1190,14 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             return fuse_write_reply(a->fd, h->unique, -forced_errno, NULL, 0);
         }
         size_t effective_size = node->size;
+        const unsigned char *read_backing = node->data;
+        if (a->large_write_backing && a->large_write_nodeid &&
+            *a->large_write_nodeid == h->nodeid) {
+            effective_size = node->size < a->large_write_backing_capacity
+                                 ? node->size
+                                 : a->large_write_backing_capacity;
+            read_backing = a->large_write_backing;
+        }
         int generated_hello = h->nodeid == 2 && a->hello_generated_size_override > 0;
         if (generated_hello) {
             effective_size = a->hello_generated_size_override;
@@ -1253,7 +1284,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             free(generated);
             return ret;
         }
-        return fuse_write_reply(a->fd, h->unique, 0, node->data + in->offset, to_copy);
+        return fuse_write_reply(a->fd, h->unique, 0, read_backing + in->offset, to_copy);
     }
     case FUSE_READDIR:
     case FUSE_READDIRPLUS: {
@@ -1452,6 +1483,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             return -1;
         }
         const struct fuse_flush_in *in = (const struct fuse_flush_in *)payload;
+        if (a->write_count_at_flush && a->write_count) {
+            *a->write_count_at_flush = *a->write_count;
+        }
         if (a->flush_count) {
             (*a->flush_count)++;
         }
@@ -1541,7 +1575,25 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (!node || simplefs_node_is_dir(node) || simplefs_node_is_symlink(node)) {
             return fuse_write_reply(a->fd, h->unique, -EINVAL, NULL, 0);
         }
-        if (in->offset >= SIMPLEFS_DATA_MAX) {
+        unsigned char *write_backing = node->data;
+        size_t write_capacity = SIMPLEFS_DATA_MAX;
+        if (a->large_write_backing && a->large_write_nodeid &&
+            ((*a->large_write_nodeid == h->nodeid) ||
+             (*a->large_write_nodeid == 0 &&
+              in->offset + in->size > SIMPLEFS_DATA_MAX))) {
+            if (*a->large_write_nodeid == 0 && in->offset > 0) {
+                size_t prefix = (size_t)in->offset;
+                if (prefix > SIMPLEFS_DATA_MAX)
+                    prefix = SIMPLEFS_DATA_MAX;
+                if (prefix > a->large_write_backing_capacity)
+                    prefix = a->large_write_backing_capacity;
+                memcpy(a->large_write_backing, node->data, prefix);
+            }
+            *a->large_write_nodeid = h->nodeid;
+            write_backing = a->large_write_backing;
+            write_capacity = a->large_write_backing_capacity;
+        }
+        if (in->offset >= write_capacity) {
             return fuse_write_reply(a->fd, h->unique, -EFBIG, NULL, 0);
         }
         uint32_t write_index = 0;
@@ -1573,8 +1625,8 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
             *a->last_write_pid = h->pid;
         }
         size_t to_copy = in->size;
-        if (in->offset + to_copy > SIMPLEFS_DATA_MAX) {
-            to_copy = SIMPLEFS_DATA_MAX - (size_t)in->offset;
+        if (in->offset + to_copy > write_capacity) {
+            to_copy = write_capacity - (size_t)in->offset;
         }
         unsigned char watch_byte = 0;
         int covers_watch = 0;
@@ -1604,14 +1656,36 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 a->write_covers_watch[write_index] = covers_watch ? 1 : 0;
             }
         }
-        memcpy(node->data + in->offset, data, to_copy);
+        if (a->block_write_offset && a->write_entered && a->release_write &&
+            in->offset == *a->block_write_offset && !*a->release_write) {
+            __sync_synchronize();
+            *a->write_entered = 1;
+            __sync_synchronize();
+            while (!*a->release_write && (!a->stop || !*a->stop)) {
+                usleep(1000);
+            }
+        }
+        if (a->forced_write_errno && a->forced_write_offset &&
+            *a->forced_write_errno > 0 && in->offset == *a->forced_write_offset) {
+            if (a->write_count) {
+                __sync_synchronize();
+                (*a->write_count)++;
+            }
+            return fuse_write_reply(a->fd, h->unique, -*a->forced_write_errno, NULL, 0);
+        }
+        if (a->forced_short_write_offset && a->forced_short_write_size &&
+            in->offset == *a->forced_short_write_offset &&
+            *a->forced_short_write_size < to_copy) {
+            to_copy = *a->forced_short_write_size;
+        }
+        memcpy(write_backing + in->offset, data, to_copy);
         if (node->size < in->offset + to_copy) {
             node->size = (size_t)in->offset + to_copy;
         }
         if (a->backend_watch_byte) {
             uint64_t watch = a->write_watch_offset;
-            if (watch < node->size && watch < SIMPLEFS_DATA_MAX) {
-                *a->backend_watch_byte = node->data[watch];
+            if (watch < node->size && watch < write_capacity) {
+                *a->backend_watch_byte = write_backing[watch];
             }
         }
         if (a->write_count) {
@@ -1673,6 +1747,9 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         strncpy(nnode->name, name, sizeof(nnode->name) - 1);
         nnode->name[sizeof(nnode->name) - 1] = '\0';
         nnode->size = 0;
+        if (a->last_create_nodeid) {
+            *a->last_create_nodeid = nnode->nodeid;
+        }
 
         struct {
             struct fuse_entry_out entry;

--- a/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
+++ b/user/apps/tests/dunitest/suites/normal/fuse_stats_debugfs.cc
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <string>
 
 #include "../fuse/fuse_gtest_common.h"
@@ -163,14 +164,20 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     expect_field(whole, "light direct_read_dma,read_size_buckets\n");
     expect_field(whole, "init_epoch ");
     expect_field(whole, "negotiated_max_read_bytes ");
+    expect_field(whole, "negotiated_max_write_bytes ");
     expect_field(whole, "negotiated_max_pages ");
     expect_field(whole, "negotiated_max_readahead_bytes ");
     expect_field(whole, "negotiated_async_read ");
+    expect_field(whole, "negotiated_writeback_cache ");
     expect_field(whole, "effective_read_payload_limit_bytes ");
+    expect_field(whole, "effective_write_payload_limit_bytes ");
     expect_field(whole, "request_queue_current ");
     expect_field(whole, "dispatch_current ");
     expect_field(whole, "processing_current ");
     expect_field(whole, "read_reservation_current ");
+    expect_field(whole, "invalidation_launder_batches_total ");
+    expect_field(whole, "invalidation_launder_pages_total ");
+    expect_field(whole, "mmap_writeback_admission_retries_total ");
     expect_field(whole, "requests_queued_total ");
     expect_field(whole, "requests_dequeued_total ");
     expect_field(whole, "requests_replied_ok_total ");
@@ -191,6 +198,18 @@ TEST(FuseStatsDebugFs, StatsFileExistsAndSupportsOffsetReads) {
     EXPECT_EQ(0, parse_counter(after_fuse, "dispatch_current"));
     EXPECT_EQ(0, parse_counter(after_fuse, "processing_current"));
     EXPECT_EQ(0, parse_counter(after_fuse, "read_reservation_current"));
+    const long long negotiated_max_write =
+        parse_counter(after_fuse, "negotiated_max_write_bytes");
+    const long long negotiated_max_pages =
+        parse_counter(after_fuse, "negotiated_max_pages");
+    ASSERT_GE(negotiated_max_write, 4096);
+    ASSERT_GE(negotiated_max_pages, 1);
+    EXPECT_LE(negotiated_max_write, 1024 * 1024);
+    EXPECT_EQ(0, parse_counter(after_fuse, "negotiated_writeback_cache"));
+    const long long expected_write_pages =
+        std::min(64LL, std::min(negotiated_max_pages, negotiated_max_write / 4096));
+    EXPECT_EQ(expected_write_pages * 4096,
+              parse_counter(after_fuse, "effective_write_payload_limit_bytes"));
 
     expect_field(whole, "[virtiofs]\n");
     expect_field(whole, "device_queue_depth_max ");

--- a/user/apps/tests/dunitest/suites/normal/kthread_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/kthread_selftest.cc
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+constexpr const char* kKthreadSelftestPath = "/sys/kernel/debug/kthread/selftest";
+
+std::string ReadAll(const char* path) {
+    int fd = open(path, O_RDONLY);
+    EXPECT_GE(fd, 0) << "open(" << path << ") failed: errno=" << errno << " (" << strerror(errno)
+                     << ")";
+    if (fd < 0) {
+        return {};
+    }
+
+    std::string content;
+    char buf[256];
+    while (true) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n == 0) {
+            break;
+        }
+        EXPECT_GT(n, 0) << "read(" << path << ") failed: errno=" << errno << " ("
+                        << strerror(errno) << ")";
+        if (n <= 0) {
+            close(fd);
+            return {};
+        }
+        content.append(buf, static_cast<size_t>(n));
+    }
+
+    EXPECT_EQ(0, close(fd)) << "close(" << path << ") failed: errno=" << errno << " ("
+                            << strerror(errno) << ")";
+    return content;
+}
+
+}  // namespace
+
+TEST(KthreadSelftest, CreateRunStopAndReapHandshakes) {
+    const std::string report = ReadAll(kKthreadSelftestPath);
+    ASSERT_FALSE(report.empty());
+    EXPECT_NE(std::string::npos, report.find("status=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("create_stopped_stop=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("create_and_run_stop=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("quick_exit_512=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("quick_exit_completed=512\n")) << report;
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -32,6 +32,7 @@ normal/sched_affinity
 normal/sync_file_range
 normal/splice_concurrent_io
 normal/rcu_selftest
+normal/kthread_selftest
 normal/restart_syscall_semantics
 normal/errseq_selftest
 normal/errseq_writeback_reporting

--- a/user/apps/virtiofs_bench/transcript_test.sh
+++ b/user/apps/virtiofs_bench/transcript_test.sh
@@ -46,11 +46,43 @@ check_transcript() {
                 (value("status") != "ok" && value("status") != "fail") ||
                 !decimal("errno") || !decimal("elapsed_us") || !decimal("bytes") ||
                 !decimal("ops") || !decimal("syscalls") || !decimal("short_io") ||
-                !decimal("eintr") || checksum !~ /^[0-9a-f]+$/ || length(checksum) != 16) {
+                !decimal("eintr") || !decimal("data_loop_us") || !decimal("fsync_us") ||
+                !decimal("close_us") || !decimal("end_to_end_us") ||
+                checksum !~ /^[0-9a-f]+$/ || length(checksum) != 16) {
+                bad = 1
+            }
+            workload = value("workload")
+            data_loop = value("data_loop_us") + 0
+            fsync_time = value("fsync_us") + 0
+            close_time = value("close_us") + 0
+            end_to_end = value("end_to_end_us") + 0
+            elapsed = value("elapsed_us") + 0
+            if (workload == "sequential_write" || workload == "prepare") {
+                if (data_loop == 0 || end_to_end == 0 || elapsed != data_loop ||
+                    end_to_end < data_loop + fsync_time + close_time) {
+                    bad = 1
+                }
+            } else if (data_loop != 0 || fsync_time != 0 || close_time != 0 ||
+                       end_to_end != 0) {
                 bad = 1
             }
         }
         END { exit bad || phases == 0 || results != 1 }
+    '
+}
+
+check_result_only_transcript() {
+    awk '
+        $1 == "phase" { phases++ }
+        $1 == "result" {
+            results++
+            for (i = 1; i <= NF; ++i) {
+                if ($i ~ /^(data_loop_us|fsync_us|close_us|end_to_end_us)=[0-9]+$/) {
+                    timings++
+                }
+            }
+        }
+        END { exit phases != 0 || results != 1 || timings != 4 }
     '
 }
 
@@ -62,10 +94,34 @@ VIRTIOFS_BENCH_RUN_ID=host_prepare VIRTIOFS_BENCH_CACHE_MODE=warm \
     --file-size 16384 --block-size 4096 >"$WORK_DIR/prepare.log" 2>&1
 check_transcript <"$WORK_DIR/prepare.log"
 
+VIRTIOFS_BENCH_PHASE_MARKERS=0 VIRTIOFS_BENCH_RUN_ID=host_perf \
+    "$BIN" --mount "$MOUNT" --workload prepare --path perf_schema_test \
+    --file-size 16384 --block-size 4096 >"$WORK_DIR/perf.log" 2>&1
+check_result_only_transcript <"$WORK_DIR/perf.log"
+
 VIRTIOFS_BENCH_RUN_ID=host_read VIRTIOFS_BENCH_CACHE_MODE=warm \
     "$BIN" --mount "$MOUNT" --workload sequential_read --path schema_test \
     --file-size 16384 --block-size 4096 >"$WORK_DIR/read.log" 2>&1
 check_transcript <"$WORK_DIR/read.log"
+
+VIRTIOFS_BENCH_RUN_ID=host_write VIRTIOFS_BENCH_CACHE_MODE=warm \
+    "$BIN" --mount "$MOUNT" --workload sequential_write --path schema_test \
+    --file-size 16384 --block-size 4096 >"$WORK_DIR/write.log" 2>&1
+check_transcript <"$WORK_DIR/write.log"
+
+# Timing fields are a semantic schema, not just four decimal strings.
+sed 's/ data_loop_us=[^ ]*/ data_loop_us=1/' "$WORK_DIR/read.log" \
+    >"$WORK_DIR/malformed-read-timing.log"
+if check_transcript <"$WORK_DIR/malformed-read-timing.log"; then
+    echo "non-write timing unexpectedly accepted" >&2
+    exit 1
+fi
+sed 's/ elapsed_us=[^ ]*/ elapsed_us=0/' "$WORK_DIR/write.log" \
+    >"$WORK_DIR/malformed-write-timing.log"
+if check_transcript <"$WORK_DIR/malformed-write-timing.log"; then
+    echo "inconsistent write timing unexpectedly accepted" >&2
+    exit 1
+fi
 
 # A missing mandatory result field must be rejected by the host parser.
 sed 's/ syscalls=[^ ]*//' "$WORK_DIR/read.log" >"$WORK_DIR/malformed.log"

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -539,12 +539,21 @@ struct IoCounters {
     uint64_t eintr = 0;
 };
 
+struct WritePhaseTimings {
+    uint64_t data_loop_us = 0;
+    uint64_t fsync_us = 0;
+    uint64_t close_us = 0;
+    uint64_t end_to_end_us = 0;
+};
+
 void emit_result(const char* workload, const Options& opt, uint64_t elapsed_us, uint64_t bytes,
-                 uint64_t ops, int err, const IoCounters& io = {}, uint64_t checksum = 0) {
+                 uint64_t ops, int err, const IoCounters& io = {}, uint64_t checksum = 0,
+                 const WritePhaseTimings& write_timings = {}) {
     utsname uts = {};
     uname(&uts);
     printf("result workload=%s status=%s errno=%d elapsed_us=%llu bytes=%llu ops=%llu "
            "syscalls=%llu short_io=%llu eintr=%llu checksum=%016llx "
+           "data_loop_us=%llu fsync_us=%llu close_us=%llu end_to_end_us=%llu "
            "mount=%s dataset=%s seed=%llu files=%zu file_size=%zu block_size=%zu "
            "iterations=%zu workers=%zu run_id=%s "
            "cache_mode=%s mount_options=%s expect_dax=%s sysname=%s release=%s\n",
@@ -555,7 +564,11 @@ void emit_result(const char* workload, const Options& opt, uint64_t elapsed_us, 
            static_cast<unsigned long long>(io.syscalls),
            static_cast<unsigned long long>(io.short_io),
            static_cast<unsigned long long>(io.eintr),
-           static_cast<unsigned long long>(checksum), opt.mount.c_str(),
+           static_cast<unsigned long long>(checksum),
+           static_cast<unsigned long long>(write_timings.data_loop_us),
+           static_cast<unsigned long long>(write_timings.fsync_us),
+           static_cast<unsigned long long>(write_timings.close_us),
+           static_cast<unsigned long long>(write_timings.end_to_end_us), opt.mount.c_str(),
            opt.path.empty() ? "ephemeral" : opt.path.c_str(),
            static_cast<unsigned long long>(opt.seed), opt.files, opt.file_size, opt.block_size,
            opt.iterations, opt.workers, env_or_empty("VIRTIOFS_BENCH_RUN_ID"),
@@ -640,6 +653,10 @@ struct DatasetManifest {
 
 void phase_marker(const Options& opt, const char* workload, const char* phase, const char* event,
                   uint64_t offset, uint64_t requested, int64_t returned, int err) {
+    const char* enabled = getenv("VIRTIOFS_BENCH_PHASE_MARKERS");
+    if (enabled && strcmp(enabled, "0") == 0) {
+        return;
+    }
     // DragonOS's current stderr formatter truncates at 64-bit printf
     // conversions. Build the record from decimal strings so each phase remains
     // a single, shell-tokenizable line without losing timing or I/O context.
@@ -1089,9 +1106,11 @@ int sequential_write_phase(const Options& opt, WorkloadSpec workload) {
     uint64_t bytes = 0;
     IoCounters io;
     uint64_t elapsed_us = 0;
+    WritePhaseTimings write_timings;
     if (fd >= 0) {
         phase_marker(opt, label, "data_loop", "begin", 0, opt.file_size, 0, 0);
-        uint64_t start = now_us();
+        const uint64_t end_to_end_start = now_us();
+        uint64_t start = end_to_end_start;
         while (err == 0 && bytes < opt.file_size) {
             size_t requested = std::min(opt.block_size, opt.file_size - static_cast<size_t>(bytes));
             if (!write_all_counted(fd, data.data() + bytes, requested, &io)) {
@@ -1101,16 +1120,23 @@ int sequential_write_phase(const Options& opt, WorkloadSpec workload) {
             bytes += requested;
         }
         elapsed_us = now_us() - start;
+        write_timings.data_loop_us = elapsed_us;
         phase_marker(opt, label, "data_loop", "end", bytes, 0,
                      err == 0 ? static_cast<int64_t>(bytes) : -1, err);
 
         if (err == 0) {
             phase_marker(opt, label, "fsync", "begin", bytes, 0, 0, 0);
+            start = now_us();
             fsync_preserve_error(fd, &err);
+            write_timings.fsync_us = now_us() - start;
             phase_marker(opt, label, "fsync", "end", bytes, 0, err == 0 ? 0 : -1, err);
         }
         phase_marker(opt, label, "close", "begin", bytes, 0, 0, 0);
+        start = now_us();
         close_preserve_error(fd, &err);
+        const uint64_t close_end = now_us();
+        write_timings.close_us = close_end - start;
+        write_timings.end_to_end_us = close_end - end_to_end_start;
         phase_marker(opt, label, "close", "end", bytes, 0, err == 0 ? 0 : -1, err);
     }
 
@@ -1127,7 +1153,7 @@ int sequential_write_phase(const Options& opt, WorkloadSpec workload) {
         unlinkat(root_fd, manifest_temp.c_str(), 0);
     }
     close(root_fd);
-    emit_result(label, opt, elapsed_us, bytes, io.syscalls, err, io, checksum);
+    emit_result(label, opt, elapsed_us, bytes, io.syscalls, err, io, checksum, write_timings);
     emit_io_summary(label, io, checksum, 0);
     return err == 0 ? 0 : -1;
 }


### PR DESCRIPTION
## Summary

- batch contiguous non-DAX FUSE writes through the page cache when `FUSE_WRITEBACK_CACHE` is negotiated
- bound each writeback batch by the negotiated `max_write`, `max_pages`, and transport scatter-gather limits
- preserve Linux-compatible fsync, close, truncate, mmap, invalidation, stable EOF, redirty, short-write, and errseq behavior
- isolate terminal writeback completion from generic page-cache workers to prevent invalidation/completion deadlocks
- harden kernel-thread creation and wakeup ordering used by the new worker pools
- extend FUSE/page-cache statistics, benchmark phase reporting, dunitest coverage, and root-only debug selftests

## Root cause

The non-DAX write path submitted small synchronous FUSE writes instead of retaining dirty pages and flushing bounded contiguous batches. This amplified request count and daemon round trips, especially for workloads issuing 4 KiB writes followed by fsync.

Writeback also needed explicit ordering and lifetime rules around mmap dirties, truncate and invalidation barriers, close/flush error reporting, and worker startup. In particular, published Writeback pages could not safely share a FIFO completion domain with invalidation workers that may wait for those pages.

## Behavior

The buffered path is enabled only after the daemon negotiates `FUSE_WRITEBACK_CACHE`; the existing non-writeback path remains available when the capability is absent. Dirty pages are tagged and claimed in bounded scans, submitted in contiguous batches, and completed with generation-aware redirty and error handling.

Close and flush behavior follows Linux 6.6 semantics, including `FOPEN_NOFLUSH`, `NO_OPEN` with `fh=0`, write-before-flush ordering, and writeback error sequencing. Direct I/O, truncate, mmap faults, and host invalidation synchronize through explicit admission and invalidation barriers.

## Performance

The frozen A1/B/A2 campaign used 9 fresh mounts per point and covered 16/64 MiB files with 4 KiB/128 KiB/1 MiB syscall sizes. All 162 samples completed without short I/O and with correct host hashes. A1 and A2 are the unmodified `origin/master` baseline; B is this writeback implementation.

Raw 64 MiB/4 KiB medians:

| Layer | data loop | fsync | data + fsync | end to end | data-loop throughput |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline A1 | 13.569206 s | 8.168021 s | 21.719323 s | 21.721853 s | 4.717 MiB/s |
| candidate B | 0.479139 s | 0.275695 s | 0.745776 s | 0.751208 s | 133.573 MiB/s |
| baseline A2 | 13.916102 s | 8.592727 s | 22.527501 s | 22.528964 s | 4.599 MiB/s |

The corresponding `data + fsync` p90 values were 22.940337 s for A1, 0.908964 s for B, and 22.937194 s for A2. Using the faster baseline period conservatively, the candidate improves the median by 29.123x and p90 by 25.234x. The maximum A1/A2 median drift across the full matrix was 6.429%, below the frozen 10% rejection gate.

Raw aggregate CPU measurements over 2160 MiB per layer:

| Layer | CPU time | CPU seconds/MiB |
| --- | ---: | ---: |
| baseline A1 | 859.48 s | 0.397907 |
| candidate B | 126.41 s | 0.058523 |
| baseline A2 | 903.22 s | 0.418157 |

Compared with the faster baseline CPU rate, the candidate reduces CPU seconds per MiB by 85.292%.

The accepted WRITE diagnostic conservatively included the 64 MiB data file plus a 107-byte manifest. It observed 265 WRITE requests carrying 67,108,971 bytes, for an average payload of 253,241 bytes against the 258,048-byte effective limit (98.137%). Relative to 16,384 4 KiB data writes, the request count decreased by 98.383%.

The latest post-fix 64 MiB/4 KiB guest smoke measured:

| Phase | Latest value |
| --- | ---: |
| data loop | 0.591492 s (108.201 MiB/s) |
| fsync | 0.274880 s |
| close | 0.004728 s |
| end to end | 0.871445 s (73.441 MiB/s) |

The latest smoke completed with correct contents, `short_io=0`, and a successful result. The follow-up lint fix only groups the same negotiated statistics fields into a value object and does not alter runtime I/O behavior.

CubeSandbox deployment was also checked. Its current shared filesystem is read-only and has writeback disabled, so it does not exercise this P3 writeback path and no CubeSandbox P3 performance claim is made.

## Validation

- `make fmt`
- `make kernel -j2`
- `git diff --check`
- FuseExtended: 69/69 passed in a DragonOS guest
- writeback-cache, non-writeback mmap-close, and `NO_OPEN` close/flush regressions passed
- multibatch host invalidation regression passed
- page-cache completion-domain selftest passed with all generic workers occupied
- kthread create/stop/run and 512 quick-exit selftests passed
- 256 MiB guest stress completed ten 64 MiB write-and-fsync rounds without panic, OOM, deadlock, or pending requests

Related to #2019.
