### PR TITLE
fix(vfs): snapshot recursive bind topology

### DIFF
--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -2798,7 +2798,7 @@ impl MountFSInode {
         super_block_state: Option<Arc<SuperBlockState>>,
         bind_source: Option<&Arc<MountFS>>,
     ) -> Result<Arc<MountFS>, SystemError> {
-        // Linux do_add_mount: the parent mount point must belong to the current mount namespace.
+        // Preserve do_add_mount validation order before invoking a filesystem.
         let current_mntns = ProcessManager::current_mntns();
         if !self.mount_fs.is_belongs_to_mntns(&current_mntns) {
             return Err(SystemError::EINVAL);
@@ -2810,6 +2810,38 @@ impl MountFSInode {
         let root_is_dir = root_metadata.file_type == FileType::Dir;
         if is_dir != root_is_dir {
             return Err(SystemError::ENOTDIR);
+        }
+
+        self.prepare_subtree_with_root_dentry_prevalidated(
+            inner_fs,
+            root_inner_inode,
+            root_dentry,
+            mount_flags,
+            super_block_state,
+            bind_source,
+        )
+    }
+
+    /// Prepare a detached mount after the caller has validated that the source
+    /// root and destination mountpoint have compatible, immutable inode types.
+    ///
+    /// Unlike [`Self::prepare_subtree_with_root_dentry`], this entry point does
+    /// not call into the underlying filesystem. It is suitable for bind-mount
+    /// topology snapshot sections, where a FUSE `metadata()` request could
+    /// otherwise wait on a daemon that needs the dentry topology write lock.
+    pub(crate) fn prepare_subtree_with_root_dentry_prevalidated(
+        &self,
+        inner_fs: Arc<dyn FileSystem>,
+        root_inner_inode: Arc<dyn IndexNode>,
+        root_dentry: Option<Arc<VfsDentry>>,
+        mount_flags: MountFlags,
+        super_block_state: Option<Arc<SuperBlockState>>,
+        bind_source: Option<&Arc<MountFS>>,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        // Linux do_add_mount: the parent mount point must belong to the current mount namespace.
+        let current_mntns = ProcessManager::current_mntns();
+        if !self.mount_fs.is_belongs_to_mntns(&current_mntns) {
+            return Err(SystemError::EINVAL);
         }
 
         // Keep detached construction private. The destination parent's shared

--- a/kernel/src/filesystem/vfs/syscall/sys_mount.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mount.rs
@@ -593,92 +593,64 @@ fn do_bind_mount(
         .downcast_arc::<MountFSInode>()
         .ok_or(SystemError::EINVAL)?;
 
-    // Get the source's filesystem
-    let source_fs = source_inode.fs();
-
-    // Check if source is on a MountFS
-    let source_mfs = source_fs.clone().downcast_arc::<MountFS>();
-
-    // The source mount must belong to the current mount namespace.
-    if let Some(ref mfs) = source_mfs {
-        let current_mntns = ProcessManager::current_mntns();
-        if !mfs.is_belongs_to_mntns(&current_mntns) {
-            return Err(SystemError::EINVAL);
-        }
-    }
-
-    // Check if source is unbindable - if so, reject the bind mount
-    if let Some(ref mfs) = source_mfs {
-        if mfs.propagation().is_unbindable() {
-            return Err(SystemError::EINVAL);
-        }
-        if !flags.contains(MountFlags::REC)
-            && has_locked_children_in_view(mfs, &source_mount_inode)?
-        {
-            return Err(SystemError::EINVAL);
-        }
-    }
-
-    // Clone source_mfs for recursive bind mount (need to keep it for later use)
-    let source_mfs_for_recursive = source_mfs.clone();
-
-    let root_inner_inode = if is_mountpoint_root(&source_inode) {
-        source_mfs
-            .as_ref()
-            .map(|mfs| mfs.root_inner_inode())
-            .unwrap_or_else(|| source_inode.clone())
-    } else {
-        source_inode
-            .clone()
-            .downcast_arc::<MountFSInode>()
-            .map(|inode| inode.underlying_inode())
-            .unwrap_or_else(|| source_inode.clone())
-    };
-
-    // Get the inner filesystem for mounting while preserving the source subtree root.
-    let inner_fs = source_mfs
-        .map(|mfs| mfs.inner_filesystem())
-        .unwrap_or(source_fs);
-
-    // do_loopback: the target mount point must belong to the current mount namespace.
-    let current_mntns = ProcessManager::current_mntns();
-    let target_mount_fs = target_inode
+    let source_mfs = source_inode
         .fs()
         .downcast_arc::<MountFS>()
         .ok_or(SystemError::EINVAL)?;
-    if !target_mount_fs.is_belongs_to_mntns(&current_mntns) {
-        return Err(SystemError::EINVAL);
-    }
 
     let target_mountpoint = target_inode
         .clone()
         .downcast_arc::<crate::filesystem::vfs::mount::MountFSInode>()
         .ok_or(SystemError::EINVAL)?;
-    let target_mfs = target_mountpoint.prepare_subtree_with_root_dentry(
-        inner_fs,
-        root_inner_inode,
-        Some(source_mount_inode.shared_dentry()),
-        source_mfs_for_recursive
-            .as_ref()
-            .map(|mount| mount.mount_flags())
-            .unwrap_or_else(MountFlags::empty),
-        source_mfs_for_recursive
-            .as_ref()
-            .map(|mfs| mfs.super_block_state()),
-        source_mfs_for_recursive.as_ref(),
-    )?;
-    target_mfs.set_mount_source(Some(source_path.clone()));
+    let target_mount_fs = target_mountpoint.mount_fs();
+    let current_mntns = ProcessManager::current_mntns();
 
-    // Build the complete recursive clone while detached. The root edge is the
-    // publication point, so lookup never observes a half-copied bind tree.
-    if flags.contains(MountFlags::REC) {
-        if let Some(ref mfs) = source_mfs_for_recursive {
-            if let Err(e) = do_recursive_bind_mount(mfs, &target_mfs) {
+    // Linux holds namespace_lock across check_mnt(), clone_mnt(root), and
+    // copy_tree(children). Take one mount+dentry snapshot for the equivalent
+    // source validation and complete detached clone so root and descendants
+    // cannot observe different lifecycle or propagation states.
+    let target_mfs = with_topology_snapshot(|| {
+        if !source_mfs.is_live()
+            || !source_mfs.is_belongs_to_mntns(&current_mntns)
+            || !target_mount_fs.is_live()
+            || !target_mount_fs.is_belongs_to_mntns(&current_mntns)
+        {
+            return Err(SystemError::EINVAL);
+        }
+        if source_mfs.propagation().is_unbindable() {
+            return Err(SystemError::EINVAL);
+        }
+        if !flags.contains(MountFlags::REC)
+            && has_locked_children_in_view_locked(&source_mfs, &source_mount_inode)?
+        {
+            return Err(SystemError::EINVAL);
+        }
+
+        let root_inner_inode = if is_mountpoint_root(&source_inode) {
+            source_mfs.root_inner_inode()
+        } else {
+            source_mount_inode.underlying_inode()
+        };
+        let target_mfs = target_mountpoint.prepare_subtree_with_root_dentry_prevalidated(
+            source_mfs.inner_filesystem(),
+            root_inner_inode,
+            Some(source_mount_inode.shared_dentry()),
+            source_mfs.mount_flags(),
+            Some(source_mfs.super_block_state()),
+            Some(&source_mfs),
+        )?;
+        target_mfs.set_mount_source(Some(source_path.clone()));
+
+        // The root edge is the publication point, so lookup never observes a
+        // half-copied recursive bind tree.
+        if flags.contains(MountFlags::REC) {
+            if let Err(error) = do_recursive_bind_mount_locked(&source_mfs, &target_mfs) {
                 MountFS::deactivate_disconnected_subtree(&target_mfs);
-                return Err(e);
+                return Err(error);
             }
         }
-    }
+        Ok(target_mfs)
+    })?;
 
     if let Err(error) = target_mountpoint.publish_prepared_subtree(&target_mfs) {
         MountFS::deactivate_disconnected_subtree(&target_mfs);
@@ -690,26 +662,25 @@ fn do_bind_mount(
 
 /// Linux rejects a non-recursive bind when it would uncover locked child
 /// mounts below the selected source dentry (has_locked_children()).
-fn has_locked_children_in_view(
+/// Caller holds the mount+dentry topology snapshot.
+fn has_locked_children_in_view_locked(
     source_mount: &Arc<MountFS>,
     source_root: &Arc<MountFSInode>,
 ) -> Result<bool, SystemError> {
-    with_topology_snapshot(|| {
-        let mut pending = source_mount.mount_children();
-        while let Some(child) = pending.pop() {
-            let mountpoint = child.self_mountpoint().ok_or(SystemError::EINVAL)?;
-            if mountpoint
-                .relative_path_from_snapshot(source_root)?
-                .is_none()
-            {
-                continue;
-            }
-            if child.is_locked() {
-                return Ok(true);
-            }
+    let mut pending = source_mount.mount_children();
+    while let Some(child) = pending.pop() {
+        let mountpoint = child.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        if mountpoint
+            .relative_path_from_snapshot(source_root)?
+            .is_none()
+        {
+            continue;
         }
-        Ok(false)
-    })
+        if child.is_locked() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Change the propagation type of a mount point.
@@ -829,13 +800,12 @@ fn do_move_mount(
 /// # Returns
 /// * `Ok(())` on success
 /// * `Err(SystemError)` on failure
-fn do_recursive_bind_mount(
+///
+/// Caller holds the mount+dentry topology snapshot for the complete detached copy.
+fn do_recursive_bind_mount_locked(
     source_mfs: &Arc<MountFS>,
     target_mfs: &Arc<MountFS>,
 ) -> Result<(), SystemError> {
-    // Mount edge mutations use the same lock. Holding it for the complete
-    // detached copy gives MS_BIND|MS_REC one coherent source-tree snapshot.
-    let _topology = MOUNT_LIFECYCLE_LOCK.lock();
     let mut pending = vec![(source_mfs.clone(), target_mfs.clone())];
     while let Some((source_parent, target_parent)) = pending.pop() {
         for source_child in source_parent.mount_children() {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_core.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_core.cc
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <sched.h>
+#include <sys/wait.h>
+
 #include "fuse_gtest_common.h"
 
 static int core_test_nonblock_read_empty() {
@@ -547,6 +550,145 @@ static int core_test_lifecycle_forget_destroy() {
     return 0;
 }
 
+static int core_test_recursive_bind_cross_fs_mountpoint_collision() {
+    const char *base = "/tmp/test_fuse_recursive_bind_collision";
+    const char *source = "/tmp/test_fuse_recursive_bind_collision/source";
+    const char *source_a = "/tmp/test_fuse_recursive_bind_collision/source/a";
+    const char *source_b = "/tmp/test_fuse_recursive_bind_collision/source/b";
+    const char *source_a_file = "/tmp/test_fuse_recursive_bind_collision/source/a/hello.txt";
+    const char *source_b_file = "/tmp/test_fuse_recursive_bind_collision/source/b/hello.txt";
+    const char *dest = "/tmp/test_fuse_recursive_bind_collision/dest";
+    const char *dest_a = "/tmp/test_fuse_recursive_bind_collision/dest/a";
+    const char *dest_b = "/tmp/test_fuse_recursive_bind_collision/dest/b";
+    const char *dest_a_file = "/tmp/test_fuse_recursive_bind_collision/dest/a/hello.txt";
+    const char *dest_b_file = "/tmp/test_fuse_recursive_bind_collision/dest/b/hello.txt";
+    const char *payload_a = "/tmp/test_fuse_recursive_bind_collision/payload_a";
+    const char *payload_b = "/tmp/test_fuse_recursive_bind_collision/payload_b";
+    int fds[2] = {-1, -1};
+    volatile int stops[2] = {0, 0};
+    volatile int init_done[2] = {0, 0};
+    struct fuse_daemon_args args[2];
+    pthread_t threads[2] = {};
+    bool thread_started[2] = {false, false};
+    bool passed = false;
+
+    memset(args, 0, sizeof(args));
+    do {
+        if (unshare(CLONE_NEWNS) != 0 ||
+            mount(nullptr, "/", nullptr, MS_REC | MS_PRIVATE, nullptr) != 0) {
+            printf("[FAIL] isolate mount namespace: %s (errno=%d)\n", strerror(errno), errno);
+            break;
+        }
+        if (ensure_dir(base) != 0 || ensure_dir(source) != 0 || ensure_dir(dest) != 0 ||
+            mount("none", source, "ramfs", 0, nullptr) != 0 || ensure_dir(source_a) != 0 ||
+            ensure_dir(source_b) != 0 || fuseg_write_file(payload_a, "A") != 0 ||
+            fuseg_write_file(payload_b, "B") != 0) {
+            printf("[FAIL] prepare collision topology: %s (errno=%d)\n", strerror(errno), errno);
+            break;
+        }
+
+        for (int i = 0; i < 2; ++i) {
+            fds[i] = open("/dev/fuse", O_RDWR);
+            if (fds[i] < 0) {
+                printf("[FAIL] open(/dev/fuse)[%d]: %s (errno=%d)\n", i, strerror(errno), errno);
+                break;
+            }
+            args[i].fd = fds[i];
+            args[i].stop = &stops[i];
+            args[i].init_done = &init_done[i];
+            if (pthread_create(&threads[i], nullptr, fuse_daemon_thread, &args[i]) != 0) {
+                printf("[FAIL] pthread_create[%d]\n", i);
+                break;
+            }
+            thread_started[i] = true;
+        }
+        if (!thread_started[0] || !thread_started[1]) {
+            break;
+        }
+
+        char opts_a[256];
+        char opts_b[256];
+        snprintf(opts_a, sizeof(opts_a), "fd=%d,rootmode=040755,user_id=0,group_id=0", fds[0]);
+        snprintf(opts_b, sizeof(opts_b), "fd=%d,rootmode=040755,user_id=0,group_id=0", fds[1]);
+        if (mount("none", source_a, "fuse", 0, opts_a) != 0 ||
+            mount("none", source_b, "fuse", 0, opts_b) != 0 ||
+            fuseg_wait_init(&init_done[0]) != 0 || fuseg_wait_init(&init_done[1]) != 0) {
+            printf("[FAIL] mount/init FUSE pair: %s (errno=%d)\n", strerror(errno), errno);
+            break;
+        }
+
+        struct stat fuse_a = {};
+        struct stat fuse_b = {};
+        if (stat(source_a_file, &fuse_a) != 0 || stat(source_b_file, &fuse_b) != 0 ||
+            fuse_a.st_ino != fuse_b.st_ino || fuse_a.st_ino != 2 || fuse_a.st_dev == fuse_b.st_dev) {
+            printf("[FAIL] expected cross-filesystem FUSE mountpoint collision: "
+                   "a=(dev=%llu,ino=%llu) b=(dev=%llu,ino=%llu) errno=%d\n",
+                   (unsigned long long)fuse_a.st_dev, (unsigned long long)fuse_a.st_ino,
+                   (unsigned long long)fuse_b.st_dev, (unsigned long long)fuse_b.st_ino, errno);
+            break;
+        }
+
+        if (mount(payload_a, source_a_file, nullptr, MS_BIND, nullptr) != 0 ||
+            mount(payload_b, source_b_file, nullptr, MS_BIND, nullptr) != 0 ||
+            mount(source, dest, nullptr, MS_BIND | MS_REC, nullptr) != 0) {
+            printf("[FAIL] construct/clone nested collision edges: %s (errno=%d)\n",
+                   strerror(errno), errno);
+            break;
+        }
+
+        char content_a[8] = {};
+        char content_b[8] = {};
+        struct stat source_nested_a = {};
+        struct stat source_nested_b = {};
+        struct stat dest_nested_a = {};
+        struct stat dest_nested_b = {};
+        const int len_a = fuseg_read_file(dest_a_file, content_a, sizeof(content_a));
+        const int len_b = fuseg_read_file(dest_b_file, content_b, sizeof(content_b));
+        if (len_a != 1 || len_b != 1 || content_a[0] != 'A' || content_b[0] != 'B' ||
+            stat(source_a_file, &source_nested_a) != 0 ||
+            stat(source_b_file, &source_nested_b) != 0 || stat(dest_a_file, &dest_nested_a) != 0 ||
+            stat(dest_b_file, &dest_nested_b) != 0 ||
+            source_nested_a.st_dev != dest_nested_a.st_dev ||
+            source_nested_a.st_ino != dest_nested_a.st_ino ||
+            source_nested_b.st_dev != dest_nested_b.st_dev ||
+            source_nested_b.st_ino != dest_nested_b.st_ino ||
+            source_nested_a.st_ino == source_nested_b.st_ino) {
+            printf("[FAIL] recursive bind lost or swapped colliding nested edges\n");
+            break;
+        }
+        passed = true;
+    } while (false);
+
+    // Drop every clone before its source FUSE connection. MNT_DETACH keeps
+    // cleanup bounded even when the assertion path stopped mid-construction.
+    umount2(dest_a_file, MNT_DETACH);
+    umount2(dest_b_file, MNT_DETACH);
+    umount2(dest_a, MNT_DETACH);
+    umount2(dest_b, MNT_DETACH);
+    umount2(dest, MNT_DETACH);
+    umount2(source_a_file, MNT_DETACH);
+    umount2(source_b_file, MNT_DETACH);
+    umount2(source_a, MNT_DETACH);
+    umount2(source_b, MNT_DETACH);
+    umount2(source, MNT_DETACH);
+
+    for (int i = 0; i < 2; ++i) {
+        stops[i] = 1;
+        if (fds[i] >= 0) {
+            close(fds[i]);
+        }
+        if (thread_started[i]) {
+            pthread_join(threads[i], nullptr);
+        }
+    }
+    unlink(payload_a);
+    unlink(payload_b);
+    rmdir(dest);
+    rmdir(source);
+    rmdir(base);
+    return passed ? 0 : -1;
+}
+
 TEST(FuseCore, DevNonblockReadEmpty) {
     ASSERT_EQ(0, core_test_nonblock_read_empty());
 }
@@ -565,6 +707,18 @@ TEST(FuseCore, WritePathCreateTruncateRenameUnlinkMkdirRmdir) {
 
 TEST(FuseCore, LifecycleForgetAndDestroy) {
     ASSERT_EQ(0, core_test_lifecycle_forget_destroy());
+}
+
+TEST(FuseCore, RecursiveBindUsesCrossFilesystemMountpointIdentity) {
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        _exit(core_test_recursive_bind_cross_fs_mountpoint_collision() == 0 ? 0 : 1);
+    }
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
 }
 
 int main(int argc, char **argv) {

--- a/user/apps/tests/dunitest/suites/normal/mount_object_topology.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_object_topology.cc
@@ -171,7 +171,9 @@ protected:
         // A detached namespace is discarded when the test process exits, but
         // clean all paths because later cases clone this process's namespace.
         const char* mount_suffixes[] = {
-            "/dest/visible", "/dest/b/c", "/dest/c", "/dest",
+            "/dest/skipped/nested", "/dest/skipped", "/dest/visible",
+            "/dest/b/c", "/dest/c", "/dest",
+            "/source/skipped/nested", "/source/skipped", "/source/visible",
             "/source/selected/visible", "/source/selected/locked",
             "/source/outside", "/source/b/c", "/source/a/c",
             "/source/ab/c", "/source", "/alias_a", "/stack/proc",
@@ -184,6 +186,8 @@ protected:
         const char* files[] = {
             "/source_file", "/alias_a", "/alias_b", "/source/b/c/marker",
             "/source/a/c/a_marker", "/source/ab/c/ab_marker",
+            "/source/skipped/skipped_marker", "/source/skipped/nested/nested_marker",
+            "/source/visible/visible_marker",
             "/source/selected/visible/marker",
         };
         for (const char* suffix : files) {
@@ -191,7 +195,9 @@ protected:
         }
 
         const char* dirs[] = {
-            "/dest/visible", "/dest/b/c", "/dest/b", "/dest/c", "/dest",
+            "/dest/skipped/nested", "/dest/skipped", "/dest/visible",
+            "/dest/b/c", "/dest/b", "/dest/c", "/dest",
+            "/source/skipped/nested", "/source/skipped", "/source/visible",
             "/source/selected/visible", "/source/selected/locked",
             "/source/selected", "/source/outside", "/source/a/b/c",
             "/source/a/b", "/source/a/c", "/source/ab/c", "/source/b/c",
@@ -272,6 +278,45 @@ TEST_F(MountObjectTopologyTest, RecursiveBindFiltersSimilarPrefixSibling) {
     EXPECT_EQ("a", read_file(dest + "/c/a_marker"));
     EXPECT_FALSE(path_exists(dest + "/b/c/ab_marker"));
     EXPECT_FALSE(has_mountpoint(read_mountinfo(), dest + "/b/c"));
+}
+
+TEST_F(MountObjectTopologyTest, RecursiveBindSkipsUnlockedUnbindableSubtree) {
+    const std::string source = base_ + "/source";
+    const std::string skipped = source + "/skipped";
+    const std::string nested = skipped + "/nested";
+    const std::string visible = source + "/visible";
+    const std::string dest = base_ + "/dest";
+    const std::string dest_skipped = dest + "/skipped";
+    const std::string dest_nested = dest_skipped + "/nested";
+    const std::string dest_visible = dest + "/visible";
+
+    ASSERT_EQ(0, ensure_dir(source)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(dest)) << strerror(errno);
+    ASSERT_EQ(0, mount("none", source.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(skipped)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(visible)) << strerror(errno);
+
+    ASSERT_EQ(0, mount("none", skipped.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_file(skipped + "/skipped_marker", "skip")) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(nested)) << strerror(errno);
+    ASSERT_EQ(0, mount("none", nested.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_file(nested + "/nested_marker", "nested")) << strerror(errno);
+
+    ASSERT_EQ(0, mount("none", visible.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_file(visible + "/visible_marker", "visible")) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, skipped.c_str(), nullptr, MS_UNBINDABLE, nullptr))
+        << strerror(errno);
+
+    ASSERT_EQ(0, mount(source.c_str(), dest.c_str(), nullptr, MS_BIND | MS_REC, nullptr))
+        << strerror(errno);
+
+    const auto entries = read_mountinfo();
+    EXPECT_FALSE(has_mountpoint(entries, dest_skipped));
+    EXPECT_FALSE(has_mountpoint(entries, dest_nested));
+    EXPECT_FALSE(path_exists(dest_skipped + "/skipped_marker"));
+    EXPECT_FALSE(path_exists(dest_nested + "/nested_marker"));
+    EXPECT_TRUE(has_mountpoint(entries, dest_visible));
+    EXPECT_EQ("visible", read_file(dest_visible + "/visible_marker"));
 }
 
 TEST_F(MountObjectTopologyTest, RecursiveBindRejectsLockedUnbindableMountInView) {


### PR DESCRIPTION
## Summary

- keep source validation, bind-root cloning, and recursive descendant cloning in one mount/dentry topology snapshot
- keep potentially blocking filesystem metadata checks outside the global topology critical section
- preserve Linux `copy_tree()` handling for selected views, locked mounts, unbindable subtrees, propagation state, and detached-tree rollback
- add regressions for skipping a complete unbindable subtree and for parent-side inode collisions across independent FUSE filesystems

## Validation

- `make fmt -C kernel` (Clippy passes; existing dead-code warnings remain)
- `make kernel`
- targeted dunitest cross-compilation
- DragonOS QEMU: `mount_object_topology_test` (9/9)
- DragonOS QEMU: `fuse_core_test` (6/6)
- DragonOS QEMU: `mount_propagation_test` (19/19)
- DragonOS QEMU: `mount_move_test` (11/11)
- gVisor `MountTest.RecursiveBind`
- gVisor `MountTest.RecursiveBindPropagation`
- adversarial architecture/concurrency and test/cleanup reviews

Fixes #2101
