### PR TITLE
perf(virtiofs): eliminate readdir per-entry lookups

### DIFF
--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -1362,6 +1362,13 @@ impl FuseConn {
         !g.no_readdirplus && (g.init.flags & FUSE_DO_READDIRPLUS) != 0
     }
 
+    pub fn readdirplus_auto(&self) -> bool {
+        let g = self.inner.lock();
+        !g.no_readdirplus
+            && (g.init.flags & (FUSE_DO_READDIRPLUS | FUSE_READDIRPLUS_AUTO))
+                == (FUSE_DO_READDIRPLUS | FUSE_READDIRPLUS_AUTO)
+    }
+
     pub fn disable_readdirplus(&self) {
         let mut g = self.inner.lock();
         g.no_readdirplus = true;

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -335,6 +335,7 @@ struct FuseLookupCacheEntry {
 impl FuseNode {
     const FUSE_DIRENT_ALIGN: usize = 8;
     const LOOKUP_CACHE_MAX_ENTRIES: usize = 1024;
+    const LOOKUP_CACHE_PRUNE_BUDGET: usize = 64;
     const READDIR_BUFFER_SIZE: usize = 64 * 1024;
     const XATTR_SIZE_MAX: usize = 65536;
     const XATTR_LIST_MAX: usize = 65536;
@@ -1380,16 +1381,20 @@ impl FuseNode {
     }
 
     fn request_name(&self, opcode: u32, nodeid: u64, name: &str) -> Result<FuseReply, SystemError> {
-        self.check_not_stale()?;
-        let payload = Self::pack_name_payload(name);
-        self.conn().request(opcode, nodeid, &payload)
+        self.request_name_bytes(opcode, nodeid, name.as_bytes())
     }
 
-    fn pack_name_payload(name: &str) -> Vec<u8> {
+    fn request_name_bytes(
+        &self,
+        opcode: u32,
+        nodeid: u64,
+        name: &[u8],
+    ) -> Result<FuseReply, SystemError> {
+        self.check_not_stale()?;
         let mut payload = Vec::with_capacity(name.len() + 1);
-        payload.extend_from_slice(name.as_bytes());
+        payload.extend_from_slice(name);
         payload.push(0);
-        payload
+        self.conn().request(opcode, nodeid, &payload)
     }
 
     fn pack_struct_and_name_payload<T: Copy>(inarg: &T, name: &str) -> Vec<u8> {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -8,8 +8,9 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use core::mem::size_of;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use core::{mem::size_of, num::NonZeroUsize};
+use lru::LruCache;
 
 use system_error::SystemError;
 
@@ -287,7 +288,11 @@ pub struct FuseNode {
     cached_metadata: Mutex<Option<Metadata>>,
     page_cache: Mutex<Option<Arc<PageCache>>>,
     writeback_handles: Mutex<Vec<Arc<FuseWritebackHandle>>>,
-    lookup_cache: Mutex<BTreeMap<String, FuseLookupCacheEntry>>,
+    lookup_cache: Mutex<LruCache<String, FuseLookupCacheEntry>>,
+    /// Linux FUSE_I_INIT_RDPLUS equivalent for the first cache use of a child.
+    readdirplus_init: AtomicBool,
+    /// Linux FUSE_I_ADVISE_RDPLUS equivalent for the next directory batch.
+    readdirplus_advised: AtomicBool,
     /// Serializes dirty-page admission against operations which must drain and
     /// invalidate the page cache (truncate and direct I/O).
     writeback_barrier: RwSem<()>,
@@ -370,7 +375,11 @@ impl FuseNode {
             cached_metadata: Mutex::new(cached),
             page_cache: Mutex::new(None),
             writeback_handles: Mutex::new(Vec::new()),
-            lookup_cache: Mutex::new(BTreeMap::new()),
+            lookup_cache: Mutex::new(LruCache::new(
+                NonZeroUsize::new(Self::LOOKUP_CACHE_MAX_ENTRIES).unwrap(),
+            )),
+            readdirplus_init: AtomicBool::new(false),
+            readdirplus_advised: AtomicBool::new(false),
             writeback_barrier: RwSem::new(()),
             dax_reclaim_serial: Mutex::new(()),
             dax_mappings: RwSem::new(DaxMappingTree::default()),
@@ -1174,10 +1183,6 @@ impl FuseNode {
         *self.name.lock() = Some(name.to_string());
     }
 
-    pub(crate) fn has_dname(&self, name: &str) -> bool {
-        self.name.lock().as_deref() == Some(name)
-    }
-
     pub(crate) fn clear_dname_if(&self, name: &str) {
         let mut dname = self.name.lock();
         if dname.as_deref() == Some(name) {
@@ -1372,10 +1377,6 @@ impl FuseNode {
 
     pub(crate) fn fuse_fs(&self) -> Option<Arc<FuseFS>> {
         self.fs.upgrade()
-    }
-
-    pub(crate) fn parent_fuse_nodeid(&self) -> u64 {
-        *self.parent_nodeid.lock()
     }
 
     fn request_name(&self, opcode: u32, nodeid: u64, name: &str) -> Result<FuseReply, SystemError> {

--- a/kernel/src/filesystem/fuse/inode/directory.rs
+++ b/kernel/src/filesystem/fuse/inode/directory.rs
@@ -86,6 +86,7 @@ impl FuseNode {
             return;
         }
         let deadline_ticks = Self::cache_deadline(valid, valid_nsec);
+        self.prune_expired_lookup_cache_lru();
 
         let mut removed = Vec::new();
         {
@@ -163,6 +164,7 @@ impl FuseNode {
     }
 
     pub(super) fn lookup_cached_child(&self, name: &str) -> Option<Arc<FuseNode>> {
+        self.prune_expired_lookup_cache_lru();
         let entry = self.lookup_cache.lock().get(name).cloned()?;
         let now = Self::now_ticks();
         if !Self::lookup_cache_entry_expired_or_stale(&entry, now) {
@@ -212,6 +214,30 @@ impl FuseNode {
             || entry.child.dax_dontcache()
             || entry.child.check_not_stale().is_err()
             || entry.child.generation() != entry.generation
+    }
+
+    /// Reclaim expired entries from the LRU edge without scanning the cache or
+    /// promoting live entries. A live oldest entry stops the best-effort pass;
+    /// every named lookup still validates its target lazily.
+    fn prune_expired_lookup_cache_lru(&self) {
+        let now = Self::now_ticks();
+        let removed = {
+            let mut cache = self.lookup_cache.lock();
+            let mut removed = Vec::new();
+            for _ in 0..Self::LOOKUP_CACHE_PRUNE_BUDGET {
+                let Some((_name, entry)) = cache.peek_lru() else {
+                    break;
+                };
+                if !Self::lookup_cache_entry_expired_or_stale(entry, now) {
+                    break;
+                }
+                if let Some((_name, entry)) = cache.pop_lru() {
+                    removed.push(entry);
+                }
+            }
+            removed
+        };
+        Self::clear_removed_lookup_entries(removed);
     }
 
     fn take_lookup_cache_entries(&self) -> Vec<FuseLookupCacheEntry> {
@@ -348,21 +374,18 @@ impl FuseNode {
                 self.forget_readdirplus_from(payload, pos);
                 return Err(SystemError::EIO);
             }
-            let name = match core::str::from_utf8(name_bytes) {
-                Ok(name) => name,
-                Err(_) => {
-                    self.forget_readdirplus_from(payload, pos);
-                    return Err(SystemError::EIO);
-                }
-            };
             entries.push(DirectoryEntry {
-                name: name.to_string(),
+                name: name_bytes.to_vec(),
                 ino: dirent.ino,
                 d_type: dirent.typ as u8,
                 next_cookie: dirent.off,
             });
-            if name != "." && name != ".." {
-                self.cache_child_from_entry(&plus.entry_out, name, request_epoch);
+            if name_bytes != b"." && name_bytes != b".." {
+                if let Ok(name) = core::str::from_utf8(name_bytes) {
+                    self.cache_child_from_entry(&plus.entry_out, name, request_epoch);
+                } else if plus.entry_out.nodeid != 0 {
+                    let _ = self.conn.queue_forget(plus.entry_out.nodeid, 1);
+                }
             }
 
             last_off = dirent.off;
@@ -397,9 +420,8 @@ impl FuseNode {
             {
                 return Err(SystemError::EIO);
             }
-            let name = core::str::from_utf8(name_bytes).map_err(|_| SystemError::EIO)?;
             entries.push(DirectoryEntry {
-                name: name.to_string(),
+                name: name_bytes.to_vec(),
                 ino: dirent.ino,
                 d_type: dirent.typ as u8,
                 next_cookie: dirent.off,
@@ -497,7 +519,7 @@ mod tests {
         mm::MemoryManagementArch,
     };
 
-    fn push_dirent(payload: &mut Vec<u8>, ino: u64, cookie: u64, typ: u32, name: &str) {
+    fn push_dirent(payload: &mut Vec<u8>, ino: u64, cookie: u64, typ: u32, name: &[u8]) {
         let dirent = FuseDirent {
             ino,
             off: cookie,
@@ -505,7 +527,7 @@ mod tests {
             typ,
         };
         payload.extend_from_slice(fuse_pack_struct(&dirent));
-        payload.extend_from_slice(name.as_bytes());
+        payload.extend_from_slice(name);
         payload.resize(FuseNode::align_dirent_record_len(payload.len()), 0);
     }
 
@@ -532,14 +554,14 @@ mod tests {
     #[test]
     fn readdir_parser_preserves_type_dot_entries_and_opaque_cookies() {
         let mut payload = Vec::new();
-        push_dirent(&mut payload, 10, 7, DT_DIR as u32, ".");
-        push_dirent(&mut payload, 11, 41, DT_REG as u32, "file");
+        push_dirent(&mut payload, 10, 7, DT_DIR as u32, b".");
+        push_dirent(&mut payload, 11, 41, DT_REG as u32, b"file");
 
         let mut entries = Vec::new();
         let last = FuseNode::parse_readdir_payload(&payload, &mut entries, 0).unwrap();
         assert_eq!(last, 41);
         assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0].name, ".");
+        assert_eq!(entries[0].name, b".");
         assert_eq!(entries[0].next_cookie, 7);
         assert_eq!(entries[1].ino, 11);
         assert_eq!(entries[1].d_type, DT_REG as u8);
@@ -549,7 +571,7 @@ mod tests {
     #[test]
     fn readdir_parser_rejects_names_with_slashes() {
         let mut payload = Vec::new();
-        push_dirent(&mut payload, 10, 1, DT_REG as u32, "bad/name");
+        push_dirent(&mut payload, 10, 1, DT_REG as u32, b"bad/name");
         let mut entries = Vec::new();
         assert_eq!(
             FuseNode::parse_readdir_payload(&payload, &mut entries, 0),
@@ -560,7 +582,7 @@ mod tests {
     #[test]
     fn readdir_parser_does_not_emit_record_with_truncated_padding() {
         let mut payload = Vec::new();
-        push_dirent(&mut payload, 10, 7, DT_REG as u32, "x");
+        push_dirent(&mut payload, 10, 7, DT_REG as u32, b"x");
         payload.pop();
         let mut entries = Vec::new();
         assert_eq!(
@@ -568,5 +590,39 @@ mod tests {
             Ok(0)
         );
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn readdir_parser_preserves_non_utf8_names() {
+        let mut payload = Vec::new();
+        push_dirent(&mut payload, 10, 7, DT_REG as u32, b"f\xffo");
+        let mut entries = Vec::new();
+        assert_eq!(
+            FuseNode::parse_readdir_payload(&payload, &mut entries, 0),
+            Ok(7)
+        );
+        assert_eq!(entries[0].name, b"f\xffo");
+    }
+
+    #[test]
+    fn readdir_parser_preserves_zero_and_repeated_cookies() {
+        let mut payload = Vec::new();
+        push_dirent(&mut payload, 10, 0, DT_REG as u32, b"zero");
+        let mut entries = Vec::new();
+        assert_eq!(
+            FuseNode::parse_readdir_payload(&payload, &mut entries, 0),
+            Ok(0)
+        );
+        assert_eq!(entries[0].next_cookie, 0);
+
+        payload.clear();
+        push_dirent(&mut payload, 10, 7, DT_REG as u32, b"first");
+        push_dirent(&mut payload, 11, 7, DT_REG as u32, b"second");
+        entries.clear();
+        assert_eq!(
+            FuseNode::parse_readdir_payload(&payload, &mut entries, 0),
+            Ok(7)
+        );
+        assert_eq!(entries.len(), 2);
     }
 }

--- a/kernel/src/filesystem/fuse/inode/directory.rs
+++ b/kernel/src/filesystem/fuse/inode/directory.rs
@@ -272,7 +272,7 @@ impl FuseNode {
             .map(|len| len & !(Self::FUSE_DIRENT_ALIGN - 1))
     }
 
-    fn forget_readdirplus_from(&self, payload: &[u8], mut pos: usize) {
+    fn visit_readdirplus_lookups(payload: &[u8], mut pos: usize, mut visit: impl FnMut(u64)) {
         while pos
             .checked_add(size_of::<FuseDirentPlus>())
             .is_some_and(|end| end <= payload.len())
@@ -280,6 +280,18 @@ impl FuseNode {
             let Ok(plus) = fuse_read_struct::<FuseDirentPlus>(&payload[pos..]) else {
                 break;
             };
+            let name_start = pos + size_of::<FuseDirentPlus>();
+            let Some(name_end) = name_start.checked_add(plus.dirent.namelen as usize) else {
+                break;
+            };
+            if name_end > payload.len() {
+                break;
+            }
+            let name = &payload[name_start..name_end];
+            let is_dot = name == b"." || name == b"..";
+            if !is_dot && plus.entry_out.nodeid != 0 {
+                visit(plus.entry_out.nodeid);
+            }
             let Some(rec_len) = Self::checked_dirent_record_len(
                 size_of::<FuseDirentPlus>(),
                 plus.dirent.namelen as usize,
@@ -289,15 +301,14 @@ impl FuseNode {
             if rec_len > payload.len() - pos {
                 break;
             }
-            let name_start = pos + size_of::<FuseDirentPlus>();
-            let name_end = name_start + plus.dirent.namelen as usize;
-            let name = &payload[name_start..name_end];
-            let is_dot = name == b"." || name == b"..";
-            if !is_dot && plus.entry_out.nodeid != 0 {
-                let _ = self.conn.queue_forget(plus.entry_out.nodeid, 1);
-            }
             pos += rec_len;
         }
+    }
+
+    fn forget_readdirplus_from(&self, payload: &[u8], pos: usize) {
+        Self::visit_readdirplus_lookups(payload, pos, |nodeid| {
+            let _ = self.conn.queue_forget(nodeid, 1);
+        });
     }
 
     fn cache_child_from_entry(&self, entry: &FuseEntryOut, name: &str, request_epoch: u64) {
@@ -362,6 +373,7 @@ impl FuseNode {
                 break;
             };
             if rec_len > payload.len() - pos {
+                self.forget_readdirplus_from(payload, pos);
                 break;
             }
             let name_end = name_start + dirent.namelen as usize;
@@ -508,12 +520,13 @@ impl FuseNode {
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
+    use core::mem::size_of;
 
     use super::FuseNode;
     use crate::{
         arch::MMArch,
         filesystem::{
-            fuse::protocol::{fuse_pack_struct, FuseDirent},
+            fuse::protocol::{fuse_pack_struct, FuseDirent, FuseDirentPlus},
             vfs::{DT_DIR, DT_REG},
         },
         mm::MemoryManagementArch,
@@ -624,5 +637,23 @@ mod tests {
             Ok(7)
         );
         assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn truncated_readdirplus_padding_still_visits_lookup() {
+        // FuseDirentPlus is an integer-only wire structure.
+        let mut plus: FuseDirentPlus = unsafe { core::mem::zeroed() };
+        plus.entry_out.nodeid = 42;
+        plus.dirent.namelen = 3;
+        let mut payload = fuse_pack_struct(&plus).to_vec();
+        payload.extend_from_slice(b"abc");
+        assert!(
+            FuseNode::checked_dirent_record_len(size_of::<FuseDirentPlus>(), 3).unwrap()
+                > payload.len()
+        );
+
+        let mut nodeids = Vec::new();
+        FuseNode::visit_readdirplus_lookups(&payload, 0, |nodeid| nodeids.push(nodeid));
+        assert_eq!(nodeids, [42]);
     }
 }

--- a/kernel/src/filesystem/fuse/inode/directory.rs
+++ b/kernel/src/filesystem/fuse/inode/directory.rs
@@ -3,13 +3,13 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::mem::{replace, size_of, take};
+use core::mem::size_of;
 
 use system_error::SystemError;
 
 use crate::{
     arch::MMArch,
-    filesystem::vfs::{FileType, IndexNode},
+    filesystem::vfs::{DirectoryEntry, FileType, IndexNode},
     mm::MemoryManagementArch,
 };
 
@@ -19,6 +19,43 @@ use super::super::protocol::{
 use super::{FuseLookupCacheEntry, FuseNode};
 
 impl FuseNode {
+    const FUSE_NAME_MAX: usize = 1024;
+
+    pub(super) fn use_readdirplus(&self, offset: u64) -> bool {
+        if !self.conn().use_readdirplus() {
+            return false;
+        }
+        if !self.conn().readdirplus_auto() {
+            return true;
+        }
+        if self
+            .readdirplus_advised
+            .swap(false, core::sync::atomic::Ordering::AcqRel)
+        {
+            return true;
+        }
+        offset == 0
+    }
+
+    pub(super) fn advise_readdirplus(&self) {
+        if self.conn().readdirplus_auto() {
+            self.readdirplus_advised
+                .store(true, core::sync::atomic::Ordering::Release);
+        }
+    }
+
+    fn mark_readdirplus_init(&self) {
+        if self.conn().readdirplus_auto() {
+            self.readdirplus_init
+                .store(true, core::sync::atomic::Ordering::Release);
+        }
+    }
+
+    fn consume_readdirplus_init(&self) -> bool {
+        self.readdirplus_init
+            .swap(false, core::sync::atomic::Ordering::AcqRel)
+    }
+
     fn readdir_request_size_for_limits(max_read: usize, max_pages: usize) -> u32 {
         let max_pages_bytes = core::cmp::max(1, max_pages).saturating_mul(MMArch::PAGE_SIZE);
         let size = core::cmp::min(
@@ -49,47 +86,33 @@ impl FuseNode {
             return;
         }
         let deadline_ticks = Self::cache_deadline(valid, valid_nsec);
-        self.prune_lookup_cache();
 
         let mut removed = Vec::new();
         {
             let mut cache = self.lookup_cache.lock();
             if deadline_ticks == 0 || child.dax_dontcache() {
-                if let Some(entry) = cache.remove(name) {
+                if let Some(entry) = cache.pop(name) {
                     removed.push(entry);
                 }
-            } else {
-                if !cache.contains_key(name) && cache.len() >= Self::LOOKUP_CACHE_MAX_ENTRIES {
-                    if let Some(victim) = cache.keys().next().cloned() {
-                        if let Some(entry) = cache.remove(&victim) {
-                            removed.push(entry);
-                        }
-                    }
-                }
-                if let Some(entry) = cache.get_mut(name) {
-                    if Arc::ptr_eq(&entry.child, child) {
-                        entry.generation = generation;
-                        entry.deadline_ticks = deadline_ticks;
-                    } else {
-                        let old_entry = replace(
-                            entry,
-                            FuseLookupCacheEntry {
-                                child: child.clone(),
-                                generation,
-                                deadline_ticks,
-                            },
-                        );
-                        removed.push(old_entry);
-                    }
-                } else {
-                    cache.insert(
-                        name.to_string(),
-                        FuseLookupCacheEntry {
-                            child: child.clone(),
-                            generation,
-                            deadline_ticks,
-                        },
-                    );
+            } else if cache
+                .peek(name)
+                .is_some_and(|entry| Arc::ptr_eq(&entry.child, child))
+            {
+                let entry = cache
+                    .get_mut(name)
+                    .expect("peeked lookup cache entry still exists");
+                entry.generation = generation;
+                entry.deadline_ticks = deadline_ticks;
+            } else if let Some((_key, entry)) = cache.push(
+                name.to_string(),
+                FuseLookupCacheEntry {
+                    child: child.clone(),
+                    generation,
+                    deadline_ticks,
+                },
+            ) {
+                if !Arc::ptr_eq(&entry.child, child) {
+                    removed.push(entry);
                 }
             }
         }
@@ -133,17 +156,35 @@ impl FuseNode {
 
     pub(crate) fn notify_expire_child(&self, name: &str) -> Result<(), SystemError> {
         let mut cache = self.lookup_cache.lock();
-        let entry = cache.get_mut(name).ok_or(SystemError::ENOENT)?;
+        let entry = cache.peek_mut(name).ok_or(SystemError::ENOENT)?;
         entry.deadline_ticks = 0;
         self.invalidate_cached_metadata();
         Ok(())
     }
 
     pub(super) fn lookup_cached_child(&self, name: &str) -> Option<Arc<FuseNode>> {
-        self.prune_lookup_cache();
-        let cache = self.lookup_cache.lock();
-        let entry = cache.get(name).cloned()?;
-        Some(entry.child)
+        let entry = self.lookup_cache.lock().get(name).cloned()?;
+        let now = Self::now_ticks();
+        if !Self::lookup_cache_entry_expired_or_stale(&entry, now) {
+            if entry.child.consume_readdirplus_init() {
+                self.advise_readdirplus();
+            }
+            return Some(entry.child);
+        }
+
+        let removed = {
+            let mut cache = self.lookup_cache.lock();
+            let same_entry = cache.peek(name).is_some_and(|current| {
+                Arc::ptr_eq(&current.child, &entry.child)
+                    && current.generation == entry.generation
+                    && current.deadline_ticks == entry.deadline_ticks
+            });
+            same_entry.then(|| cache.pop(name)).flatten()
+        };
+        if let Some(removed) = removed {
+            Self::clear_removed_lookup_entries(vec![removed]);
+        }
+        None
     }
 
     pub(crate) fn purge_lookup_alias(&self, child: &Arc<FuseNode>) {
@@ -156,62 +197,34 @@ impl FuseNode {
                 .collect();
             aliases
                 .into_iter()
-                .filter_map(|name| cache.remove(&name))
+                .filter_map(|name| cache.pop(&name))
                 .collect()
         };
         Self::clear_removed_lookup_entries(removed);
     }
 
     fn remove_lookup_cache_entry(&self, name: &str) -> Option<FuseLookupCacheEntry> {
-        self.lookup_cache.lock().remove(name)
+        self.lookup_cache.lock().pop(name)
     }
 
-    fn lookup_cache_entry_expired_or_stale(
-        parent_nodeid: u64,
-        name: &str,
-        entry: &FuseLookupCacheEntry,
-        now: u64,
-    ) -> bool {
+    fn lookup_cache_entry_expired_or_stale(entry: &FuseLookupCacheEntry, now: u64) -> bool {
         (entry.deadline_ticks != u64::MAX && now >= entry.deadline_ticks)
             || entry.child.dax_dontcache()
             || entry.child.check_not_stale().is_err()
             || entry.child.generation() != entry.generation
-            || entry.child.parent_fuse_nodeid() != parent_nodeid
-            || !entry.child.has_dname(name)
     }
 
     fn take_lookup_cache_entries(&self) -> Vec<FuseLookupCacheEntry> {
         let mut cache = self.lookup_cache.lock();
-        take(&mut *cache).into_values().collect()
+        let mut entries = Vec::with_capacity(cache.len());
+        while let Some((_name, entry)) = cache.pop_lru() {
+            entries.push(entry);
+        }
+        entries
     }
 
     pub(crate) fn clear_lookup_cache_tree(&self) {
         Self::clear_removed_lookup_entries(self.take_lookup_cache_entries());
-    }
-
-    fn prune_lookup_cache(&self) {
-        let now = Self::now_ticks();
-        let removed = {
-            let mut cache = self.lookup_cache.lock();
-            let stale_keys: Vec<String> = cache
-                .iter()
-                .filter_map(|(name, entry)| {
-                    if Self::lookup_cache_entry_expired_or_stale(self.nodeid, name, entry, now) {
-                        Some(name.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            let mut removed = Vec::new();
-            for key in stale_keys {
-                if let Some(entry) = cache.remove(&key) {
-                    removed.push(entry);
-                }
-            }
-            removed
-        };
-        Self::clear_removed_lookup_entries(removed);
     }
 
     fn clear_removed_lookup_entries(entries: Vec<FuseLookupCacheEntry>) {
@@ -221,8 +234,44 @@ impl FuseNode {
         }
     }
 
+    #[cfg(test)]
     fn align_dirent_record_len(base_len: usize) -> usize {
         (base_len + Self::FUSE_DIRENT_ALIGN - 1) & !(Self::FUSE_DIRENT_ALIGN - 1)
+    }
+
+    fn checked_dirent_record_len(header_len: usize, name_len: usize) -> Option<usize> {
+        header_len
+            .checked_add(name_len)?
+            .checked_add(Self::FUSE_DIRENT_ALIGN - 1)
+            .map(|len| len & !(Self::FUSE_DIRENT_ALIGN - 1))
+    }
+
+    fn forget_readdirplus_from(&self, payload: &[u8], mut pos: usize) {
+        while pos
+            .checked_add(size_of::<FuseDirentPlus>())
+            .is_some_and(|end| end <= payload.len())
+        {
+            let Ok(plus) = fuse_read_struct::<FuseDirentPlus>(&payload[pos..]) else {
+                break;
+            };
+            let Some(rec_len) = Self::checked_dirent_record_len(
+                size_of::<FuseDirentPlus>(),
+                plus.dirent.namelen as usize,
+            ) else {
+                break;
+            };
+            if rec_len > payload.len() - pos {
+                break;
+            }
+            let name_start = pos + size_of::<FuseDirentPlus>();
+            let name_end = name_start + plus.dirent.namelen as usize;
+            let name = &payload[name_start..name_end];
+            let is_dot = name == b"." || name == b"..";
+            if !is_dot && plus.entry_out.nodeid != 0 {
+                let _ = self.conn.queue_forget(plus.entry_out.nodeid, 1);
+            }
+            pos += rec_len;
+        }
     }
 
     fn cache_child_from_entry(&self, entry: &FuseEntryOut, name: &str, request_epoch: u64) {
@@ -245,6 +294,7 @@ impl FuseNode {
             consumed = true;
             child.set_dname(name);
             child.set_lookup_attr_flags(entry.attr.flags);
+            child.mark_readdirplus_init();
             child.merge_cached_metadata_from_daemon(
                 md,
                 entry.attr_valid,
@@ -269,7 +319,7 @@ impl FuseNode {
     pub(super) fn parse_readdirplus_payload(
         &self,
         payload: &[u8],
-        names: &mut Vec<String>,
+        entries: &mut Vec<DirectoryEntry>,
         mut last_off: u64,
         request_epoch: u64,
     ) -> Result<u64, SystemError> {
@@ -278,61 +328,85 @@ impl FuseNode {
             let plus: FuseDirentPlus = fuse_read_struct(&payload[pos..])?;
             let dirent = plus.dirent;
             let name_start = pos + size_of::<FuseDirentPlus>();
-            let name_end = name_start + dirent.namelen as usize;
-            if name_end > payload.len() {
+            let Some(rec_len) = Self::checked_dirent_record_len(
+                size_of::<FuseDirentPlus>(),
+                dirent.namelen as usize,
+            ) else {
+                self.forget_readdirplus_from(payload, pos);
+                break;
+            };
+            if rec_len > payload.len() - pos {
                 break;
             }
+            let name_end = name_start + dirent.namelen as usize;
 
             let name_bytes = &payload[name_start..name_end];
-            if let Ok(name) = core::str::from_utf8(name_bytes) {
-                if !name.is_empty() && name != "." && name != ".." {
-                    names.push(name.to_string());
-                    self.cache_child_from_entry(&plus.entry_out, name, request_epoch);
+            if name_bytes.is_empty()
+                || name_bytes.len() > Self::FUSE_NAME_MAX
+                || name_bytes.contains(&b'/')
+            {
+                self.forget_readdirplus_from(payload, pos);
+                return Err(SystemError::EIO);
+            }
+            let name = match core::str::from_utf8(name_bytes) {
+                Ok(name) => name,
+                Err(_) => {
+                    self.forget_readdirplus_from(payload, pos);
+                    return Err(SystemError::EIO);
                 }
-            } else if plus.entry_out.nodeid != 0 {
-                let _ = self.conn.queue_forget(plus.entry_out.nodeid, 1);
+            };
+            entries.push(DirectoryEntry {
+                name: name.to_string(),
+                ino: dirent.ino,
+                d_type: dirent.typ as u8,
+                next_cookie: dirent.off,
+            });
+            if name != "." && name != ".." {
+                self.cache_child_from_entry(&plus.entry_out, name, request_epoch);
             }
 
             last_off = dirent.off;
-            let rec_len = Self::align_dirent_record_len(
-                size_of::<FuseDirentPlus>() + dirent.namelen as usize,
-            );
-            if rec_len == 0 {
-                break;
-            }
-            pos = pos.saturating_add(rec_len);
+            pos += rec_len;
         }
         Ok(last_off)
     }
 
     pub(super) fn parse_readdir_payload(
         payload: &[u8],
-        names: &mut Vec<String>,
+        entries: &mut Vec<DirectoryEntry>,
         mut last_off: u64,
     ) -> Result<u64, SystemError> {
         let mut pos: usize = 0;
         while pos + size_of::<FuseDirent>() <= payload.len() {
             let dirent: FuseDirent = fuse_read_struct(&payload[pos..])?;
             let name_start = pos + size_of::<FuseDirent>();
-            let name_end = name_start + dirent.namelen as usize;
-            if name_end > payload.len() {
+            let Some(rec_len) =
+                Self::checked_dirent_record_len(size_of::<FuseDirent>(), dirent.namelen as usize)
+            else {
+                break;
+            };
+            if rec_len > payload.len() - pos {
                 break;
             }
+            let name_end = name_start + dirent.namelen as usize;
 
             let name_bytes = &payload[name_start..name_end];
-            if let Ok(name) = core::str::from_utf8(name_bytes) {
-                if !name.is_empty() && name != "." && name != ".." {
-                    names.push(name.to_string());
-                }
+            if name_bytes.is_empty()
+                || name_bytes.len() > Self::FUSE_NAME_MAX
+                || name_bytes.contains(&b'/')
+            {
+                return Err(SystemError::EIO);
             }
+            let name = core::str::from_utf8(name_bytes).map_err(|_| SystemError::EIO)?;
+            entries.push(DirectoryEntry {
+                name: name.to_string(),
+                ino: dirent.ino,
+                d_type: dirent.typ as u8,
+                next_cookie: dirent.off,
+            });
 
             last_off = dirent.off;
-            let rec_len =
-                Self::align_dirent_record_len(size_of::<FuseDirent>() + dirent.namelen as usize);
-            if rec_len == 0 {
-                break;
-            }
-            pos = pos.saturating_add(rec_len);
+            pos += rec_len;
         }
         Ok(last_off)
     }
@@ -411,8 +485,29 @@ impl FuseNode {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::FuseNode;
-    use crate::{arch::MMArch, mm::MemoryManagementArch};
+    use crate::{
+        arch::MMArch,
+        filesystem::{
+            fuse::protocol::{fuse_pack_struct, FuseDirent},
+            vfs::{DT_DIR, DT_REG},
+        },
+        mm::MemoryManagementArch,
+    };
+
+    fn push_dirent(payload: &mut Vec<u8>, ino: u64, cookie: u64, typ: u32, name: &str) {
+        let dirent = FuseDirent {
+            ino,
+            off: cookie,
+            namelen: name.len() as u32,
+            typ,
+        };
+        payload.extend_from_slice(fuse_pack_struct(&dirent));
+        payload.extend_from_slice(name.as_bytes());
+        payload.resize(FuseNode::align_dirent_record_len(payload.len()), 0);
+    }
 
     #[test]
     fn readdir_request_size_honors_read_and_page_limits() {
@@ -432,5 +527,46 @@ mod tests {
             FuseNode::readdir_request_size_for_limits(4 * 1024, 0),
             MMArch::PAGE_SIZE as u32
         );
+    }
+
+    #[test]
+    fn readdir_parser_preserves_type_dot_entries_and_opaque_cookies() {
+        let mut payload = Vec::new();
+        push_dirent(&mut payload, 10, 7, DT_DIR as u32, ".");
+        push_dirent(&mut payload, 11, 41, DT_REG as u32, "file");
+
+        let mut entries = Vec::new();
+        let last = FuseNode::parse_readdir_payload(&payload, &mut entries, 0).unwrap();
+        assert_eq!(last, 41);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, ".");
+        assert_eq!(entries[0].next_cookie, 7);
+        assert_eq!(entries[1].ino, 11);
+        assert_eq!(entries[1].d_type, DT_REG as u8);
+        assert_eq!(entries[1].next_cookie, 41);
+    }
+
+    #[test]
+    fn readdir_parser_rejects_names_with_slashes() {
+        let mut payload = Vec::new();
+        push_dirent(&mut payload, 10, 1, DT_REG as u32, "bad/name");
+        let mut entries = Vec::new();
+        assert_eq!(
+            FuseNode::parse_readdir_payload(&payload, &mut entries, 0),
+            Err(system_error::SystemError::EIO)
+        );
+    }
+
+    #[test]
+    fn readdir_parser_does_not_emit_record_with_truncated_padding() {
+        let mut payload = Vec::new();
+        push_dirent(&mut payload, 10, 7, DT_REG as u32, "x");
+        payload.pop();
+        let mut entries = Vec::new();
+        assert_eq!(
+            FuseNode::parse_readdir_payload(&payload, &mut entries, 0),
+            Ok(0)
+        );
+        assert!(entries.is_empty());
     }
 }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -12,8 +12,8 @@ use crate::{
             permission::PermissionMask,
             syscall::RenameFlags,
             utils::DName,
-            FilePrivateData, FileSystem, FileType, IndexNode, InodeMode, Metadata, SetMetadataMask,
-            XattrFlags,
+            DirectoryEntry, FilePrivateData, FileSystem, FileType, IndexNode, InodeMode, Metadata,
+            SetMetadataMask, XattrFlags,
         },
     },
     libs::{casting::DowncastArc, mutex::MutexGuard},
@@ -928,6 +928,14 @@ impl IndexNode for FuseNode {
     }
 
     fn list(&self) -> Result<Vec<String>, SystemError> {
+        Ok(self
+            .list_entries()?
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect())
+    }
+
+    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
         self.check_not_stale()?;
         self.ensure_dir()?;
 
@@ -940,16 +948,16 @@ impl IndexNode for FuseNode {
         };
         let fh = dir_p.fh;
         let open_flags = dir_p.open_flags;
-        let mut use_readdirplus = self.conn.use_readdirplus();
         // Linux issues uncached READDIR with a single PAGE_SIZE output page. DragonOS keeps the
         // existing larger batch when the connection supports it, but must not exceed either the
         // mount's max_read value or the negotiated max_pages descriptor bound.
         let readdir_size = self.readdir_request_size();
 
-        let mut names: Vec<String> = Vec::new();
+        let mut entries: Vec<DirectoryEntry> = Vec::new();
         let mut offset: u64 = 0;
 
         loop {
+            let mut use_readdirplus = self.use_readdirplus(offset);
             let read_in = FuseReadIn {
                 fh,
                 offset,
@@ -983,10 +991,14 @@ impl IndexNode for FuseNode {
 
             let mut last_off: u64 = offset;
             if use_readdirplus {
-                last_off =
-                    self.parse_readdirplus_payload(&payload, &mut names, last_off, request_epoch)?;
+                last_off = self.parse_readdirplus_payload(
+                    &payload,
+                    &mut entries,
+                    last_off,
+                    request_epoch,
+                )?;
             } else {
-                last_off = Self::parse_readdir_payload(&payload, &mut names, last_off)?;
+                last_off = Self::parse_readdir_payload(&payload, &mut entries, last_off)?;
             }
 
             if last_off == offset {
@@ -1000,7 +1012,7 @@ impl IndexNode for FuseNode {
         if !dir_p.no_open {
             self.release_common(FUSE_RELEASEDIR, fh, open_flags, 0);
         }
-        Ok(names)
+        Ok(entries)
     }
 
     fn find(&self, name: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
@@ -1079,6 +1091,7 @@ impl IndexNode for FuseNode {
             entry.entry_valid,
             entry.entry_valid_nsec,
         );
+        self.advise_readdirplus();
         Ok(child)
     }
 

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -930,12 +930,13 @@ impl IndexNode for FuseNode {
 
     fn list(&self) -> Result<Vec<String>, SystemError> {
         self.list_entries()?
+            .expect("FUSE provides native directory entries")
             .into_iter()
             .map(|entry| String::from_utf8(entry.name).map_err(|_| SystemError::EIO))
             .collect()
     }
 
-    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
+    fn list_entries(&self) -> Result<Option<Vec<DirectoryEntry>>, SystemError> {
         self.check_not_stale()?;
         self.ensure_dir()?;
 
@@ -1015,7 +1016,7 @@ impl IndexNode for FuseNode {
                 }
                 offset = last_off;
             }
-            Ok(entries)
+            Ok(Some(entries))
         })();
 
         // RELEASEDIR (best-effort)

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -1,6 +1,7 @@
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::{mem::size_of, sync::atomic::Ordering};
 
+use hashbrown::HashSet;
 use system_error::SystemError;
 
 use crate::{
@@ -928,11 +929,10 @@ impl IndexNode for FuseNode {
     }
 
     fn list(&self) -> Result<Vec<String>, SystemError> {
-        Ok(self
-            .list_entries()?
+        self.list_entries()?
             .into_iter()
-            .map(|entry| entry.name)
-            .collect())
+            .map(|entry| String::from_utf8(entry.name).map_err(|_| SystemError::EIO))
+            .collect()
     }
 
     fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
@@ -948,93 +948,112 @@ impl IndexNode for FuseNode {
         };
         let fh = dir_p.fh;
         let open_flags = dir_p.open_flags;
+        let no_open = dir_p.no_open;
         // Linux issues uncached READDIR with a single PAGE_SIZE output page. DragonOS keeps the
         // existing larger batch when the connection supports it, but must not exceed either the
         // mount's max_read value or the negotiated max_pages descriptor bound.
         let readdir_size = self.readdir_request_size();
 
         let mut entries: Vec<DirectoryEntry> = Vec::new();
+        let mut requested_offsets = HashSet::new();
         let mut offset: u64 = 0;
 
-        loop {
-            let mut use_readdirplus = self.use_readdirplus(offset);
-            let read_in = FuseReadIn {
-                fh,
-                offset,
-                size: readdir_size,
-                read_flags: 0,
-                lock_owner: 0,
-                flags: open_flags,
-                padding: 0,
-            };
-            let opcode = if use_readdirplus {
-                FUSE_READDIRPLUS
-            } else {
-                FUSE_READDIR
-            };
-            let request_epoch = self.conn.sample_attr_epoch();
-            let payload = match self
-                .conn()
-                .request(opcode, self.nodeid, fuse_pack_struct(&read_in))
-            {
-                Ok(v) => v,
-                Err(SystemError::ENOSYS) if use_readdirplus => {
-                    self.conn.disable_readdirplus();
-                    use_readdirplus = false;
-                    continue;
+        let result = (|| {
+            loop {
+                if !requested_offsets.insert(offset) {
+                    break;
                 }
-                Err(e) => return Err(e),
-            };
-            if payload.is_empty() {
-                break;
-            }
+                let mut use_readdirplus = self.use_readdirplus(offset);
+                let read_in = FuseReadIn {
+                    fh,
+                    offset,
+                    size: readdir_size,
+                    read_flags: 0,
+                    lock_owner: 0,
+                    flags: open_flags,
+                    padding: 0,
+                };
+                let opcode = if use_readdirplus {
+                    FUSE_READDIRPLUS
+                } else {
+                    FUSE_READDIR
+                };
+                let request_epoch = self.conn.sample_attr_epoch();
+                let payload =
+                    match self
+                        .conn()
+                        .request(opcode, self.nodeid, fuse_pack_struct(&read_in))
+                    {
+                        Ok(v) => v,
+                        Err(SystemError::ENOSYS) if use_readdirplus => {
+                            self.conn.disable_readdirplus();
+                            requested_offsets.remove(&offset);
+                            use_readdirplus = false;
+                            continue;
+                        }
+                        Err(e) => return Err(e),
+                    };
+                if payload.is_empty() {
+                    break;
+                }
 
-            let mut last_off: u64 = offset;
-            if use_readdirplus {
-                last_off = self.parse_readdirplus_payload(
-                    &payload,
-                    &mut entries,
-                    last_off,
-                    request_epoch,
-                )?;
-            } else {
-                last_off = Self::parse_readdir_payload(&payload, &mut entries, last_off)?;
-            }
+                let mut last_off: u64 = offset;
+                if use_readdirplus {
+                    last_off = self.parse_readdirplus_payload(
+                        &payload,
+                        &mut entries,
+                        last_off,
+                        request_epoch,
+                    )?;
+                } else {
+                    last_off = Self::parse_readdir_payload(&payload, &mut entries, last_off)?;
+                }
 
-            if last_off == offset {
-                // Avoid infinite loop if userspace doesn't advance offsets.
-                break;
+                if last_off == offset {
+                    // Avoid infinite loop if userspace doesn't advance offsets.
+                    break;
+                }
+                offset = last_off;
             }
-            offset = last_off;
-        }
+            Ok(entries)
+        })();
 
         // RELEASEDIR (best-effort)
-        if !dir_p.no_open {
+        if !no_open {
             self.release_common(FUSE_RELEASEDIR, fh, open_flags, 0);
         }
-        Ok(entries)
+        result
     }
 
     fn find(&self, name: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
+        self.find_bytes(name.as_bytes())
+    }
+
+    fn find_bytes(&self, name: &[u8]) -> Result<Arc<dyn IndexNode>, SystemError> {
         self.check_not_stale()?;
         self.ensure_dir()?;
-        if name == "." {
+        if name == b"." {
             let this = self.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
             return Ok(this);
         }
-        if name == ".." {
+        if name == b".." {
             return self.parent();
         }
 
-        if let Some(child) = self.lookup_cached_child(name) {
-            return Ok(child);
+        let utf8_name = core::str::from_utf8(name).ok();
+        if let Some(name) = utf8_name {
+            if let Some(child) = self.lookup_cached_child(name) {
+                return Ok(child);
+            }
         }
 
         let request_epoch = self.conn.sample_attr_epoch();
-        let payload = match self.request_name(FUSE_LOOKUP, self.nodeid, name) {
+        let payload = match self.request_name_bytes(FUSE_LOOKUP, self.nodeid, name) {
             Ok(payload) => payload,
             Err(err) => {
-                self.invalidate_lookup_cache(name);
+                if let Some(name) = utf8_name {
+                    self.invalidate_lookup_cache(name);
+                }
                 return Err(err);
             }
         };
@@ -1075,7 +1094,9 @@ impl IndexNode for FuseNode {
                 return Err(err);
             }
         };
-        child.set_dname(name);
+        if let Some(name) = utf8_name {
+            child.set_dname(name);
+        }
         child.set_lookup_attr_flags(entry.attr.flags);
         child.merge_cached_metadata_from_daemon(
             md,
@@ -1084,13 +1105,15 @@ impl IndexNode for FuseNode {
             request_epoch,
             entry.attr.flags,
         );
-        self.cache_lookup_child(
-            name,
-            &child,
-            entry.generation,
-            entry.entry_valid,
-            entry.entry_valid_nsec,
-        );
+        if let Some(name) = utf8_name {
+            self.cache_lookup_child(
+                name,
+                &child,
+                entry.generation,
+                entry.entry_valid,
+                entry.entry_valid_nsec,
+            );
+        }
         self.advise_readdirplus();
         Ok(child)
     }

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -8,8 +8,8 @@ use crate::filesystem::vfs::file::{File, FileFlags, FilePrivateData};
 use crate::filesystem::vfs::syscall::RenameFlags;
 use crate::filesystem::vfs::utils::DName;
 use crate::filesystem::vfs::{
-    self, inode_lifecycle::InodeRetentionGuard, FileSystem, FileType, IndexNode, InodeId,
-    InodeRetentionKind, Metadata, SetMetadataMask, XattrFlags,
+    self, inode_lifecycle::InodeRetentionGuard, DirectoryEntry, FileSystem, FileType, IndexNode,
+    InodeId, InodeRetentionKind, Metadata, SetMetadataMask, XattrFlags,
 };
 use crate::libs::casting::DowncastArc;
 use crate::libs::mutex::Mutex;
@@ -53,7 +53,7 @@ pub(super) struct DirVersion {
 #[derive(Debug, Default)]
 struct DirStateData {
     generation: u64,
-    readdir_cache: Option<(u64, Arc<Vec<String>>)>,
+    readdir_cache: Option<(u64, Arc<Vec<DirectoryEntry>>)>,
     lookup_cache: BTreeMap<String, Weak<OvlInode>>,
     lookup_order: VecDeque<String>,
     backing_version: Option<Vec<DirVersion>>,
@@ -86,7 +86,10 @@ impl DirState {
         data
     }
 
-    pub(super) fn cached_readdir(&self, version: &[DirVersion]) -> Option<Arc<Vec<String>>> {
+    pub(super) fn cached_readdir(
+        &self,
+        version: &[DirVersion],
+    ) -> Option<Arc<Vec<DirectoryEntry>>> {
         let mut data = self.data.lock();
         let data = Self::revalidate(&mut data, version);
         data.readdir_cache
@@ -95,7 +98,7 @@ impl DirState {
             .map(|(_, entries)| entries.clone())
     }
 
-    pub(super) fn cache_readdir(&self, version: &[DirVersion], entries: Arc<Vec<String>>) {
+    pub(super) fn cache_readdir(&self, version: &[DirVersion], entries: Arc<Vec<DirectoryEntry>>) {
         let mut data = self.data.lock();
         let data = Self::revalidate(&mut data, version);
         let generation = data.generation;
@@ -515,6 +518,10 @@ impl IndexNode for OvlInode {
 
     fn list(&self) -> Result<Vec<String>, system_error::SystemError> {
         readdir::list(self)
+    }
+
+    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
+        readdir::list_entries(self)
     }
 
     fn mkdir(

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -520,8 +520,8 @@ impl IndexNode for OvlInode {
         readdir::list(self)
     }
 
-    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
-        readdir::list_entries(self)
+    fn list_entries(&self) -> Result<Option<Vec<DirectoryEntry>>, SystemError> {
+        readdir::list_entries(self).map(Some)
     }
 
     fn mkdir(

--- a/kernel/src/filesystem/overlayfs/readdir.rs
+++ b/kernel/src/filesystem/overlayfs/readdir.rs
@@ -1,5 +1,5 @@
 use super::inode::{DirState, OvlInode};
-use crate::filesystem::vfs::IndexNode;
+use crate::filesystem::vfs::{DirectoryEntry, IndexNode, DT_CHR, DT_UNKNOWN};
 use alloc::collections::BTreeSet;
 use alloc::string::String;
 use alloc::sync::Arc;
@@ -7,12 +7,35 @@ use alloc::vec::Vec;
 use system_error::SystemError;
 
 pub(super) fn list(inode: &OvlInode) -> Result<Vec<String>, SystemError> {
+    Ok(list_entries(inode)?
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect())
+}
+
+pub(super) fn list_entries(inode: &OvlInode) -> Result<Vec<DirectoryEntry>, SystemError> {
+    // Resolve dot identities before taking the child directory lock. This
+    // preserves the parent -> child lock order used by overlay mutations.
+    let dot_ino = inode.metadata()?.inode_id.into() as u64;
+    let dotdot_ino = inode.parent()?.metadata()?.inode_id.into() as u64;
     let state = inode.dir_state()?;
     let _guard = state.mutation_lock.lock();
-    list_locked(inode, &state)
+    list_entries_locked(inode, &state, Some((dot_ino, dotdot_ino)), true)
 }
 
 pub(super) fn list_locked(inode: &OvlInode, state: &DirState) -> Result<Vec<String>, SystemError> {
+    Ok(list_entries_locked(inode, state, None, false)?
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect())
+}
+
+fn list_entries_locked(
+    inode: &OvlInode,
+    state: &DirState,
+    dot_inos: Option<(u64, u64)>,
+    cache_result: bool,
+) -> Result<Vec<DirectoryEntry>, SystemError> {
     loop {
         let version = inode.dir_version()?;
         if let Some(entries) = state.cached_readdir(&version) {
@@ -21,44 +44,96 @@ pub(super) fn list_locked(inode: &OvlInode, state: &DirState) -> Result<Vec<Stri
 
         let mut entries = Vec::new();
         let mut seen = BTreeSet::new();
+        let mut needs_overlay_metadata = BTreeSet::new();
         if let Some(upper) = inode.upper_inode.lock().clone() {
-            merge_layer(&upper, &mut entries, &mut seen)?;
+            merge_layer(
+                &upper,
+                &mut entries,
+                &mut seen,
+                &mut needs_overlay_metadata,
+                true,
+            )?;
         }
         for lower in &inode.lower_inodes {
-            merge_layer(lower, &mut entries, &mut seen)?;
+            merge_layer(
+                lower,
+                &mut entries,
+                &mut seen,
+                &mut needs_overlay_metadata,
+                false,
+            )?;
+        }
+
+        let mut mapped_entries = Vec::with_capacity(entries.len());
+        for mut entry in entries {
+            if needs_overlay_metadata.contains(&entry.name) {
+                let mapped_ino = if entry.name == "." {
+                    dot_inos.map(|(dot, _)| dot)
+                } else if entry.name == ".." {
+                    dot_inos.map(|(_, dotdot)| dotdot)
+                } else {
+                    let child = match super::lookup::find_locked(inode, &entry.name, state) {
+                        Ok(child) => child,
+                        Err(SystemError::ENOENT) => continue,
+                        Err(err) => return Err(err),
+                    };
+                    match child.metadata() {
+                        Ok(metadata) => Some(metadata.inode_id.into() as u64),
+                        Err(SystemError::ENOENT) => continue,
+                        Err(err) => return Err(err),
+                    }
+                };
+                if let Some(mapped_ino) = mapped_ino {
+                    entry.ino = mapped_ino;
+                }
+            }
+            entry.next_cookie = (mapped_entries.len() + 1) as u64;
+            mapped_entries.push(entry);
         }
 
         let current_version = inode.dir_version()?;
         if current_version != version {
             continue;
         }
-        let entries = Arc::new(entries);
-        state.cache_readdir(&current_version, entries.clone());
+        let entries = Arc::new(mapped_entries);
+        if cache_result {
+            state.cache_readdir(&current_version, entries.clone());
+        }
         return Ok((*entries).clone());
     }
 }
 
 fn merge_layer(
     layer: &Arc<dyn IndexNode>,
-    entries: &mut Vec<String>,
+    entries: &mut Vec<DirectoryEntry>,
     seen: &mut BTreeSet<String>,
+    needs_overlay_metadata: &mut BTreeSet<String>,
+    map_all_visible: bool,
 ) -> Result<(), SystemError> {
-    for name in layer.list()? {
-        if !seen.insert(name.clone()) {
+    for entry in layer.list_entries()? {
+        if !seen.insert(entry.name.clone()) {
             continue;
         }
-        if is_dot_entry(&name) {
-            entries.push(name);
-            continue;
-        }
-        match layer.find(&name) {
-            Ok(found) => {
-                if !OvlInode::is_whiteout_inode_checked(&found)? {
-                    entries.push(name);
-                }
+        let visible = if is_dot_entry(&entry.name) {
+            true
+        } else if entry.d_type as u16 == DT_CHR || entry.d_type as u16 == DT_UNKNOWN {
+            match layer.find(&entry.name) {
+                Ok(found) => !OvlInode::is_whiteout_inode_checked(&found)?,
+                Err(SystemError::ENOENT) => false,
+                Err(err) => return Err(err),
             }
-            Err(SystemError::ENOENT) => {}
-            Err(err) => return Err(err),
+        } else {
+            true
+        };
+        if visible {
+            if map_all_visible
+                || is_dot_entry(&entry.name)
+                || matches!(entry.d_type as u16, DT_CHR | DT_UNKNOWN)
+                || entry.d_type as u16 == crate::filesystem::vfs::DT_DIR
+            {
+                needs_overlay_metadata.insert(entry.name.clone());
+            }
+            entries.push(entry);
         }
     }
     Ok(())

--- a/kernel/src/filesystem/overlayfs/readdir.rs
+++ b/kernel/src/filesystem/overlayfs/readdir.rs
@@ -7,10 +7,10 @@ use alloc::vec::Vec;
 use system_error::SystemError;
 
 pub(super) fn list(inode: &OvlInode) -> Result<Vec<String>, SystemError> {
-    Ok(list_entries(inode)?
+    list_entries(inode)?
         .into_iter()
-        .map(|entry| entry.name)
-        .collect())
+        .map(|entry| String::from_utf8(entry.name).map_err(|_| SystemError::EIO))
+        .collect()
 }
 
 pub(super) fn list_entries(inode: &OvlInode) -> Result<Vec<DirectoryEntry>, SystemError> {
@@ -24,10 +24,10 @@ pub(super) fn list_entries(inode: &OvlInode) -> Result<Vec<DirectoryEntry>, Syst
 }
 
 pub(super) fn list_locked(inode: &OvlInode, state: &DirState) -> Result<Vec<String>, SystemError> {
-    Ok(list_entries_locked(inode, state, None, false)?
+    list_entries_locked(inode, state, None, false)?
         .into_iter()
-        .map(|entry| entry.name)
-        .collect())
+        .map(|entry| String::from_utf8(entry.name).map_err(|_| SystemError::EIO))
+        .collect()
 }
 
 fn list_entries_locked(
@@ -67,12 +67,12 @@ fn list_entries_locked(
         let mut mapped_entries = Vec::with_capacity(entries.len());
         for mut entry in entries {
             if needs_overlay_metadata.contains(&entry.name) {
-                let mapped_ino = if entry.name == "." {
+                let mapped_ino = if entry.name == b"." {
                     dot_inos.map(|(dot, _)| dot)
-                } else if entry.name == ".." {
+                } else if entry.name == b".." {
                     dot_inos.map(|(_, dotdot)| dotdot)
-                } else {
-                    let child = match super::lookup::find_locked(inode, &entry.name, state) {
+                } else if let Ok(name) = core::str::from_utf8(&entry.name) {
+                    let child = match super::lookup::find_locked(inode, name, state) {
                         Ok(child) => child,
                         Err(SystemError::ENOENT) => continue,
                         Err(err) => return Err(err),
@@ -82,6 +82,10 @@ fn list_entries_locked(
                         Err(SystemError::ENOENT) => continue,
                         Err(err) => return Err(err),
                     }
+                } else {
+                    // The current pathname lookup API is UTF-8-only. Preserve the
+                    // filesystem-supplied inode number for byte-only names.
+                    None
                 };
                 if let Some(mapped_ino) = mapped_ino {
                     entry.ino = mapped_ino;
@@ -106,8 +110,8 @@ fn list_entries_locked(
 fn merge_layer(
     layer: &Arc<dyn IndexNode>,
     entries: &mut Vec<DirectoryEntry>,
-    seen: &mut BTreeSet<String>,
-    needs_overlay_metadata: &mut BTreeSet<String>,
+    seen: &mut BTreeSet<Vec<u8>>,
+    needs_overlay_metadata: &mut BTreeSet<Vec<u8>>,
     map_all_visible: bool,
 ) -> Result<(), SystemError> {
     for entry in layer.list_entries()? {
@@ -117,7 +121,7 @@ fn merge_layer(
         let visible = if is_dot_entry(&entry.name) {
             true
         } else if entry.d_type as u16 == DT_CHR || entry.d_type as u16 == DT_UNKNOWN {
-            match layer.find(&entry.name) {
+            match layer.find_bytes(&entry.name) {
                 Ok(found) => !OvlInode::is_whiteout_inode_checked(&found)?,
                 Err(SystemError::ENOENT) => false,
                 Err(err) => return Err(err),
@@ -139,6 +143,6 @@ fn merge_layer(
     Ok(())
 }
 
-fn is_dot_entry(name: &str) -> bool {
-    name == "." || name == ".."
+fn is_dot_entry(name: &[u8]) -> bool {
+    name == b"." || name == b".."
 }

--- a/kernel/src/filesystem/overlayfs/readdir.rs
+++ b/kernel/src/filesystem/overlayfs/readdir.rs
@@ -114,7 +114,7 @@ fn merge_layer(
     needs_overlay_metadata: &mut BTreeSet<Vec<u8>>,
     map_all_visible: bool,
 ) -> Result<(), SystemError> {
-    for entry in layer.list_entries()? {
+    for entry in layer.materialize_list_entries()? {
         if !seen.insert(entry.name.clone()) {
             continue;
         }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -623,22 +623,74 @@ pub struct File {
     _mount_guard: Option<MountExternalGuard>,
 }
 
+#[derive(Debug, Clone)]
+enum ReaddirSnapshot {
+    Typed(Arc<[DirectoryEntry]>),
+    Names(Arc<[String]>),
+}
+
+impl ReaddirSnapshot {
+    fn len(&self) -> usize {
+        match self {
+            Self::Typed(entries) => entries.len(),
+            Self::Names(names) => names.len(),
+        }
+    }
+
+    fn cookie_after(&self, index: usize) -> Option<u64> {
+        match self {
+            Self::Typed(entries) => entries.get(index).map(|entry| entry.next_cookie),
+            Self::Names(names) => (index < names.len()).then(|| (index + 1) as u64),
+        }
+    }
+
+    fn index_after_cookie(&self, cookie: u64) -> usize {
+        match self {
+            Self::Typed(entries) => entries
+                .iter()
+                .position(|entry| entry.next_cookie == cookie)
+                .map_or(entries.len(), |index| index + 1),
+            Self::Names(names) => usize::try_from(cookie)
+                .ok()
+                .filter(|index| *index <= names.len())
+                .unwrap_or(names.len()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct ReaddirState {
-    entries: Option<Arc<[DirectoryEntry]>>,
+    snapshot: Option<ReaddirSnapshot>,
     next_index: usize,
 }
 
 impl ReaddirState {
     fn resume_after_cookie(&mut self, cookie: u64) {
-        let Some(entries) = self.entries.as_ref() else {
+        let Some(snapshot) = self.snapshot.as_ref() else {
             self.next_index = 0;
             return;
         };
-        self.next_index = entries
-            .iter()
-            .position(|entry| entry.next_cookie == cookie)
-            .map_or(entries.len(), |index| index + 1);
+        self.next_index = snapshot.index_after_cookie(cookie);
+    }
+}
+
+fn checked_dirent_cookie(cookie: u64) -> Result<usize, SystemError> {
+    let cookie = i64::try_from(cookie).map_err(|_| SystemError::EOVERFLOW)?;
+    usize::try_from(cookie).map_err(|_| SystemError::EOVERFLOW)
+}
+
+#[cfg(test)]
+mod readdir_tests {
+    use super::checked_dirent_cookie;
+    use system_error::SystemError;
+
+    #[test]
+    fn dirent_cookie_must_fit_signed_offset() {
+        assert_eq!(checked_dirent_cookie(1), Ok(1));
+        assert_eq!(
+            checked_dirent_cookie(i64::MAX as u64 + 1),
+            Err(SystemError::EOVERFLOW)
+        );
     }
 }
 
@@ -1549,6 +1601,7 @@ impl File {
             let mut state = self.readdir_state.lock();
             let pos = match origin {
                 SeekFrom::SeekSet(offset) => offset,
+                SeekFrom::SeekCurrent(0) => return Ok(self.offset.load(Ordering::SeqCst)),
                 SeekFrom::SeekCurrent(offset) => self.offset.load(Ordering::SeqCst) as i64 + offset,
                 SeekFrom::SeekEnd(_) => {
                     // Preserve the existing directory SEEK_END behavior.
@@ -1560,7 +1613,7 @@ impl File {
                 return Err(SystemError::EINVAL);
             }
             if pos == 0 {
-                state.entries = None;
+                state.snapshot = None;
                 state.next_index = 0;
             } else {
                 state.resume_after_cookie(pos as u64);
@@ -1655,39 +1708,76 @@ impl File {
         // 文件偏移被 seek 到 0 之前复用该缓存。
         let mut state = self.readdir_state.lock();
         let current_cookie = self.offset.load(Ordering::SeqCst) as u64;
-        if state.entries.is_none() {
-            state.entries = Some(Arc::from(inode.list_entries()?));
+        if state.snapshot.is_none() {
+            state.snapshot = Some(match inode.list_entries()? {
+                Some(entries) => ReaddirSnapshot::Typed(Arc::from(entries)),
+                None => ReaddirSnapshot::Names(Arc::from(inode.list()?)),
+            });
             if current_cookie == 0 {
                 state.next_index = 0;
             } else {
                 state.resume_after_cookie(current_cookie);
             }
         } else {
-            let expected_cookie = state.entries.as_ref().and_then(|entries| {
+            let expected_cookie = state.snapshot.as_ref().and_then(|snapshot| {
                 state
                     .next_index
                     .checked_sub(1)
-                    .and_then(|index| entries.get(index))
-                    .map(|entry| entry.next_cookie)
+                    .and_then(|index| snapshot.cookie_after(index))
             });
             if state.next_index > 0 && expected_cookie != Some(current_cookie) {
                 state.resume_after_cookie(current_cookie);
             }
         }
 
-        let entries = state
-            .entries
+        let snapshot = state
+            .snapshot
             .as_ref()
             .expect("readdir snapshot initialized")
             .clone();
-        if state.next_index > entries.len() {
+        if state.next_index > snapshot.len() {
             return Err(SystemError::EINVAL);
         }
-        while state.next_index < entries.len() {
-            let entry = &entries[state.next_index];
-            let next_cookie =
-                usize::try_from(entry.next_cookie).map_err(|_| SystemError::EOVERFLOW)?;
-            match ctx.fill_dir(&entry.name, next_cookie, entry.ino, entry.d_type) {
+        while state.next_index < snapshot.len() {
+            let index = state.next_index;
+            let (name, cookie, metadata) = match &snapshot {
+                ReaddirSnapshot::Typed(entries) => {
+                    let entry = &entries[index];
+                    (
+                        entry.name.as_slice(),
+                        entry.next_cookie,
+                        Some((entry.ino, entry.d_type)),
+                    )
+                }
+                ReaddirSnapshot::Names(names) => {
+                    let name = &names[index];
+                    (name.as_bytes(), (index + 1) as u64, None)
+                }
+            };
+            let next_cookie = checked_dirent_cookie(cookie)?;
+            let (ino, d_type) = if let Some(metadata) = metadata {
+                metadata
+            } else {
+                let metadata = match name {
+                    b"." => inode.metadata(),
+                    b".." => inode.parent().and_then(|parent| parent.metadata()),
+                    _ => inode.find_bytes(name).and_then(|child| child.metadata()),
+                };
+                let metadata = match metadata {
+                    Ok(metadata) => metadata,
+                    Err(SystemError::ENOENT) => {
+                        state.next_index += 1;
+                        self.offset.store(next_cookie, Ordering::SeqCst);
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
+                (
+                    metadata.inode_id.into() as u64,
+                    metadata.file_type.get_file_type_num() as u8,
+                )
+            };
+            match ctx.fill_dir(name, next_cookie, ino, d_type) {
                 Ok(_) => {
                     state.next_index += 1;
                     self.offset.store(next_cookie, Ordering::SeqCst);

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1645,13 +1645,10 @@ impl File {
         // 文件偏移被 seek 到 0 之前复用该缓存。
         let mut state = self.readdir_state.lock();
         let current_cookie = self.offset.load(Ordering::SeqCst) as u64;
-        if current_cookie == 0 {
+        if state.entries.is_none() {
             state.entries = Some(Arc::from(inode.list_entries()?));
             state.next_index = 0;
         } else {
-            if state.entries.is_none() {
-                state.entries = Some(Arc::from(inode.list_entries()?));
-            }
             let expected_cookie = state.entries.as_ref().and_then(|entries| {
                 state
                     .next_index
@@ -1659,7 +1656,7 @@ impl File {
                     .and_then(|index| entries.get(index))
                     .map(|entry| entry.next_cookie)
             });
-            if expected_cookie != Some(current_cookie) {
+            if state.next_index > 0 && expected_cookie != Some(current_cookie) {
                 let entries = state
                     .entries
                     .as_ref()

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -629,6 +629,19 @@ struct ReaddirState {
     next_index: usize,
 }
 
+impl ReaddirState {
+    fn resume_after_cookie(&mut self, cookie: u64) {
+        let Some(entries) = self.entries.as_ref() else {
+            self.next_index = 0;
+            return;
+        };
+        self.next_index = entries
+            .iter()
+            .position(|entry| entry.next_cookie == cookie)
+            .map_or(entries.len(), |index| index + 1);
+    }
+}
+
 impl File {
     pub fn resolved_path(&self) -> Result<super::utils::ResolvedPath, SystemError> {
         let mount_guard = self
@@ -1549,11 +1562,8 @@ impl File {
             if pos == 0 {
                 state.entries = None;
                 state.next_index = 0;
-            } else if let Some(entries) = state.entries.as_ref() {
-                state.next_index = entries
-                    .iter()
-                    .position(|entry| entry.next_cookie == pos as u64)
-                    .map_or(entries.len(), |index| index + 1);
+            } else {
+                state.resume_after_cookie(pos as u64);
             }
             self.offset.store(pos as usize, Ordering::SeqCst);
             return Ok(pos as usize);
@@ -1647,7 +1657,11 @@ impl File {
         let current_cookie = self.offset.load(Ordering::SeqCst) as u64;
         if state.entries.is_none() {
             state.entries = Some(Arc::from(inode.list_entries()?));
-            state.next_index = 0;
+            if current_cookie == 0 {
+                state.next_index = 0;
+            } else {
+                state.resume_after_cookie(current_cookie);
+            }
         } else {
             let expected_cookie = state.entries.as_ref().and_then(|entries| {
                 state
@@ -1657,14 +1671,7 @@ impl File {
                     .map(|entry| entry.next_cookie)
             });
             if state.next_index > 0 && expected_cookie != Some(current_cookie) {
-                let entries = state
-                    .entries
-                    .as_ref()
-                    .expect("readdir snapshot initialized");
-                state.next_index = entries
-                    .iter()
-                    .position(|entry| entry.next_cookie == current_cookie)
-                    .map_or(entries.len(), |index| index + 1);
+                state.resume_after_cookie(current_cookie);
             }
         }
 

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -12,7 +12,8 @@ use super::{
     inode_lifecycle::{InodeRetentionGuard, InodeRetentionKind},
     mount::{MountExternalGuard, MountFSInode},
     utils::should_remove_sgid,
-    FileSystem, FileType, IndexNode, InodeId, Metadata, SetMetadataMask, SpecialNodeData,
+    DirectoryEntry, FileSystem, FileType, IndexNode, InodeId, Metadata, SetMetadataMask,
+    SpecialNodeData,
 };
 use crate::{arch::ipc::signal::Signal, filesystem::vfs::InodeFlags, process::pid::PidPrivateData};
 use crate::{
@@ -587,8 +588,8 @@ pub struct File {
     mode: RwSem<FileMode>,
     /// 文件类型
     file_type: FileType,
-    /// readdir时候用的，暂存的本次循环中，所有子目录项的名字的数组
-    readdir_subdirs_name: Mutex<Vec<String>>,
+    /// Per-open immutable directory snapshot and its next record index.
+    readdir_state: Mutex<ReaddirState>,
     pub private_data: Mutex<FilePrivateData>,
     /// 文件的凭证
     cred: Arc<Cred>,
@@ -620,6 +621,12 @@ pub struct File {
     /// Pins the mount used to resolve this pathname independently from the
     /// operation inode (which device/FIFO resolution may replace).
     _mount_guard: Option<MountExternalGuard>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ReaddirState {
+    entries: Option<Arc<[DirectoryEntry]>>,
+    next_index: usize,
 }
 
 impl File {
@@ -1053,7 +1060,7 @@ impl File {
             flags: RwSem::new(flags),
             mode: RwSem::new(mode),
             file_type,
-            readdir_subdirs_name: Mutex::new(Vec::default()),
+            readdir_state: Mutex::new(ReaddirState::default()),
             private_data,
             cred: ProcessManager::current_pcb().cred(),
             owner: Mutex::new(FileOwner::new()),
@@ -1525,15 +1532,37 @@ impl File {
                 }
             }
         }
+        if file_type == FileType::Dir {
+            let mut state = self.readdir_state.lock();
+            let pos = match origin {
+                SeekFrom::SeekSet(offset) => offset,
+                SeekFrom::SeekCurrent(offset) => self.offset.load(Ordering::SeqCst) as i64 + offset,
+                SeekFrom::SeekEnd(_) => {
+                    // Preserve the existing directory SEEK_END behavior.
+                    return Ok(MAX_LFS_FILESIZE as usize);
+                }
+                SeekFrom::Invalid => return Err(SystemError::EINVAL),
+            };
+            if pos < 0 {
+                return Err(SystemError::EINVAL);
+            }
+            if pos == 0 {
+                state.entries = None;
+                state.next_index = 0;
+            } else if let Some(entries) = state.entries.as_ref() {
+                state.next_index = entries
+                    .iter()
+                    .position(|entry| entry.next_cookie == pos as u64)
+                    .map_or(entries.len(), |index| index + 1);
+            }
+            self.offset.store(pos as usize, Ordering::SeqCst);
+            return Ok(pos as usize);
+        }
+
         let pos: i64 = match origin {
             SeekFrom::SeekSet(offset) => offset,
             SeekFrom::SeekCurrent(offset) => self.offset.load(Ordering::SeqCst) as i64 + offset,
             SeekFrom::SeekEnd(offset) => {
-                if FileType::Dir == file_type {
-                    // 对目录，返回 Linux 常见语义：允许 SEEK_END 并返回 MAX_LFS_FILESIZE。
-                    // 测试接受 MAX_LFS_FILESIZE 或 EINVAL，但为通过当前测试选择返回 MAX_LFS_FILESIZE。
-                    return Ok(MAX_LFS_FILESIZE as usize);
-                }
                 let metadata = self.metadata()?;
                 metadata.size + offset
             }
@@ -1607,8 +1636,6 @@ impl File {
         }
 
         let inode: &Arc<dyn IndexNode> = &self.inode;
-        let mut current_pos = self.offset.load(Ordering::SeqCst);
-
         // POSIX 标准要求readdir应该返回. 和 ..
         // 但是观察到在现有的子目录中已经包含，不做处理也能正常返回. 和 .. 这里先不做处理
 
@@ -1616,37 +1643,50 @@ impl File {
         // 为了保证在目录内容动态变化（例如 /proc/self/fd）时不会因为重新
         // 创建列表而丢失尚未读取的目录项，这里缓存第一次生成的列表，在
         // 文件偏移被 seek 到 0 之前复用该缓存。
-        let mut cached_names = self.readdir_subdirs_name.lock();
-        if current_pos == 0 || cached_names.is_empty() {
-            *cached_names = inode.list()?;
+        let mut state = self.readdir_state.lock();
+        let current_cookie = self.offset.load(Ordering::SeqCst) as u64;
+        if current_cookie == 0 {
+            state.entries = Some(Arc::from(inode.list_entries()?));
+            state.next_index = 0;
+        } else {
+            if state.entries.is_none() {
+                state.entries = Some(Arc::from(inode.list_entries()?));
+            }
+            let expected_cookie = state.entries.as_ref().and_then(|entries| {
+                state
+                    .next_index
+                    .checked_sub(1)
+                    .and_then(|index| entries.get(index))
+                    .map(|entry| entry.next_cookie)
+            });
+            if expected_cookie != Some(current_cookie) {
+                let entries = state
+                    .entries
+                    .as_ref()
+                    .expect("readdir snapshot initialized");
+                state.next_index = entries
+                    .iter()
+                    .position(|entry| entry.next_cookie == current_cookie)
+                    .map_or(entries.len(), |index| index + 1);
+            }
         }
-        let readdir_subdirs_name = cached_names.clone();
-        drop(cached_names);
 
-        let subdirs_name_len = readdir_subdirs_name.len();
-        while current_pos < subdirs_name_len {
-            let name = &readdir_subdirs_name[current_pos];
-            let sub_inode: Arc<dyn IndexNode> = match inode.find(name) {
-                Ok(i) => i,
-                Err(e) => {
-                    if e == SystemError::ENOENT {
-                        // 目录项在本次读取过程中被移除，跳过它，继续读取后续条目
-                        self.offset.fetch_add(1, Ordering::SeqCst);
-                        current_pos += 1;
-                        continue;
-                    }
-                    error!("Readdir error: Failed to find sub inode");
-                    return Err(e);
-                }
-            };
-
-            let inode_metadata = sub_inode.metadata().unwrap();
-            let entry_ino = inode_metadata.inode_id.into() as u64;
-            let entry_d_type = inode_metadata.file_type.get_file_type_num() as u8;
-            match ctx.fill_dir(name, current_pos, entry_ino, entry_d_type) {
+        let entries = state
+            .entries
+            .as_ref()
+            .expect("readdir snapshot initialized")
+            .clone();
+        if state.next_index > entries.len() {
+            return Err(SystemError::EINVAL);
+        }
+        while state.next_index < entries.len() {
+            let entry = &entries[state.next_index];
+            let next_cookie =
+                usize::try_from(entry.next_cookie).map_err(|_| SystemError::EOVERFLOW)?;
+            match ctx.fill_dir(&entry.name, next_cookie, entry.ino, entry.d_type) {
                 Ok(_) => {
-                    self.offset.fetch_add(1, Ordering::SeqCst);
-                    current_pos += 1;
+                    state.next_index += 1;
+                    self.offset.store(next_cookie, Ordering::SeqCst);
                 }
                 Err(SystemError::EINVAL) => {
                     return Ok(());
@@ -1717,7 +1757,7 @@ impl File {
             flags: RwSem::new(flags),
             mode: RwSem::new(mode),
             file_type: self.file_type,
-            readdir_subdirs_name: Mutex::new(self.readdir_subdirs_name.lock().clone()),
+            readdir_state: Mutex::new(self.readdir_state.lock().clone()),
             private_data,
             cred: self.cred.clone(),
             owner: Mutex::new(FileOwner::new()),

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -1019,16 +1019,22 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         Err(SystemError::ENOTDIR)
     }
 
-    /// List directory records including the inode number, type and continuation
-    /// cookie already known by the filesystem.
-    ///
-    /// The default keeps existing filesystems source-compatible. Implementations
-    /// with a native directory record format should override this method to avoid
-    /// one lookup and metadata fetch per entry.
-    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
+    /// Return directory records already typed by the filesystem. `None` keeps
+    /// legacy filesystems on the lazy name lookup path so a small getdents
+    /// buffer does not force metadata lookup for the entire directory.
+    fn list_entries(&self) -> Result<Option<Vec<DirectoryEntry>>, SystemError> {
+        Ok(None)
+    }
+
+    /// Materialize typed records for callers, such as overlay merging, that
+    /// necessarily need metadata for the complete directory.
+    fn materialize_list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
+        if let Some(entries) = self.list_entries()? {
+            return Ok(entries);
+        }
         let names = self.list()?;
         let mut entries = Vec::with_capacity(names.len());
-        for name in names {
+        for (index, name) in names.into_iter().enumerate() {
             let metadata = match name.as_str() {
                 "." => self.metadata(),
                 ".." => self.parent().and_then(|parent| parent.metadata()),
@@ -1047,7 +1053,7 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
                 name: name.into_bytes(),
                 ino: metadata.inode_id.into() as u64,
                 d_type: metadata.file_type.get_file_type_num() as u8,
-                next_cookie: (entries.len() + 1) as u64,
+                next_cookie: (index + 1) as u64,
             });
         }
         Ok(entries)

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -302,7 +302,8 @@ pub const DT_MAX: u16 = 16;
 /// vector index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectoryEntry {
-    pub name: String,
+    /// Raw name bytes; Linux directory entries do not require UTF-8.
+    pub name: Vec<u8>,
     pub ino: u64,
     pub d_type: u8,
     pub next_cookie: u64,
@@ -945,6 +946,13 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         return Err(SystemError::ENOSYS);
     }
 
+    /// Look up a child by its raw directory-entry name. Filesystems whose
+    /// on-wire names are byte strings should override this method.
+    fn find_bytes(&self, name: &[u8]) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let name = core::str::from_utf8(name).map_err(|_| SystemError::EIO)?;
+        self.find(name)
+    }
+
     /// @brief 根据inode号，获取子目录项的名字
     ///
     /// @param ino inode号
@@ -1036,7 +1044,7 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
                 Err(error) => return Err(error),
             };
             entries.push(DirectoryEntry {
-                name,
+                name: name.into_bytes(),
                 ino: metadata.inode_id.into() as u64,
                 d_type: metadata.file_type.get_file_type_num() as u8,
                 next_cookie: (entries.len() + 1) as u64,
@@ -2287,13 +2295,13 @@ impl<'a> FilldirContext<'a> {
     /// - d_type 目录项的inode的file_type_num
     pub(crate) fn fill_dir(
         &mut self,
-        name: &str,
+        name: &[u8],
         offset: usize,
         ino: u64,
         d_type: u8,
     ) -> Result<(), SystemError> {
         let name_len = name.len();
-        let name_bytes = name.as_bytes();
+        let name_bytes = name;
 
         // 根据格式计算基础结构大小
         // linux_dirent (旧格式): d_ino(8) + d_off(8) + d_reclen(2) = 18 bytes

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -295,6 +295,19 @@ pub const DT_WHT: u16 = 14;
 #[allow(dead_code)]
 pub const DT_MAX: u16 = 16;
 
+/// Filesystem-supplied directory record used by `getdents(2)`.
+///
+/// `next_cookie` is an opaque continuation token. Filesystems backed by an
+/// external daemon must preserve that token instead of replacing it with a
+/// vector index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectoryEntry {
+    pub name: String,
+    pub ino: u64,
+    pub d_type: u8,
+    pub next_cookie: u64,
+}
+
 /// VFS 允许的最大符号链接跟随次数。
 ///
 /// Linux 6.6: MAXSYMLINKS = 40
@@ -996,6 +1009,40 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     /// @brief 列出当前inode下的所有目录项的名字
     fn list(&self) -> Result<Vec<String>, SystemError> {
         Err(SystemError::ENOTDIR)
+    }
+
+    /// List directory records including the inode number, type and continuation
+    /// cookie already known by the filesystem.
+    ///
+    /// The default keeps existing filesystems source-compatible. Implementations
+    /// with a native directory record format should override this method to avoid
+    /// one lookup and metadata fetch per entry.
+    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
+        let names = self.list()?;
+        let mut entries = Vec::with_capacity(names.len());
+        for name in names {
+            let metadata = match name.as_str() {
+                "." => self.metadata(),
+                ".." => self.parent().and_then(|parent| parent.metadata()),
+                _ => match self.find(&name) {
+                    Ok(child) => child.metadata(),
+                    Err(SystemError::ENOENT) => continue,
+                    Err(error) => return Err(error),
+                },
+            };
+            let metadata = match metadata {
+                Ok(metadata) => metadata,
+                Err(SystemError::ENOENT) => continue,
+                Err(error) => return Err(error),
+            };
+            entries.push(DirectoryEntry {
+                name,
+                ino: metadata.inode_id.into() as u64,
+                d_type: metadata.file_type.get_file_type_num() as u8,
+                next_cookie: (entries.len() + 1) as u64,
+            });
+        }
+        Ok(entries)
     }
 
     /// # mount - 挂载文件系统

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1,8 +1,8 @@
 use super::{
     file::{File, FileFlags, FileMode, PreopenedFile},
     utils::DName,
-    FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode, InodeRetentionKind,
-    PollableInode, SetMetadataMask, SuperBlock, XattrFlags,
+    DirectoryEntry, FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode,
+    InodeRetentionKind, PollableInode, SetMetadataMask, SuperBlock, XattrFlags,
 };
 use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
@@ -3787,6 +3787,11 @@ impl IndexNode for MountFSInode {
     #[inline]
     fn list(&self) -> Result<alloc::vec::Vec<alloc::string::String>, SystemError> {
         return self.dentry.inode.list();
+    }
+
+    #[inline]
+    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
+        self.dentry.inode.list_entries()
     }
 
     fn mount(

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -3761,6 +3761,16 @@ impl IndexNode for MountFSInode {
         }
     }
 
+    fn find_bytes(&self, name: &[u8]) -> Result<Arc<dyn IndexNode>, SystemError> {
+        if let Ok(name) = core::str::from_utf8(name) {
+            return self.find(name);
+        }
+        // Mount dentries are currently keyed by UTF-8 DName. Raw-name lookup is
+        // still required for metadata/whiteout checks during getdents, so pass
+        // byte-only names to the backing filesystem without inventing a lossy key.
+        self.dentry.inode.find_bytes(name)
+    }
+
     #[inline]
     fn get_entry_name(&self, ino: InodeId) -> Result<alloc::string::String, SystemError> {
         return self.dentry.inode.get_entry_name(ino);

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -3800,7 +3800,7 @@ impl IndexNode for MountFSInode {
     }
 
     #[inline]
-    fn list_entries(&self) -> Result<Vec<DirectoryEntry>, SystemError> {
+    fn list_entries(&self) -> Result<Option<Vec<DirectoryEntry>>, SystemError> {
         self.dentry.inode.list_entries()
     }
 

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -161,6 +161,257 @@ static int fuse_wait_counter_increase(const char *path, const char *field, uint6
     return -1;
 }
 
+struct p4_readdir_daemon_args {
+    struct fuse_daemon_args common;
+    volatile uint32_t lookup_count;
+    volatile uint32_t getattr_count;
+    volatile uint32_t forget_count;
+    volatile uint32_t readdir_count;
+    volatile uint32_t readdirplus_count;
+    volatile uint32_t dir_trace_count;
+    uint32_t dir_opcode_trace[16];
+    uint64_t dir_offset_trace[16];
+    int one_entry_per_reply;
+};
+
+struct p4_linux_dirent64 {
+    uint64_t d_ino;
+    int64_t d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[1];
+};
+
+struct p4_mock_dir_entry {
+    const char *name;
+    uint64_t nodeid;
+    uint64_t ino;
+    uint32_t type;
+    uint64_t next_cookie;
+};
+
+static const struct p4_mock_dir_entry p4_mock_dir_entries[] = {
+    {".", 1, 1, DT_DIR, 11},
+    {"..", 1, 1, DT_DIR, 29},
+    {"hello.txt", 2, 2, DT_REG, 101},
+    {"alpha.txt", 3, 3, DT_REG, 4099},
+    {"beta.txt", 4, 4, DT_REG, 65537},
+};
+
+struct p4_shared_readdir_args {
+    int fd;
+    volatile int *ready;
+    volatile int *go;
+    pthread_mutex_t *lock;
+    unsigned int *name_counts;
+    volatile int error;
+};
+
+struct p4_shared_seek_args {
+    int fd;
+    volatile int *go;
+    volatile int *stop;
+    volatile int error;
+};
+
+static int p4_mock_entry_index(const char *name) {
+    for (size_t i = 0; i < sizeof(p4_mock_dir_entries) / sizeof(p4_mock_dir_entries[0]); i++) {
+        if (strcmp(name, p4_mock_dir_entries[i].name) == 0) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+static void *p4_shared_readdir_thread(void *opaque) {
+    struct p4_shared_readdir_args *args = (struct p4_shared_readdir_args *)opaque;
+    __sync_fetch_and_add(args->ready, 1);
+    while (!*args->go) {
+        sched_yield();
+    }
+    for (;;) {
+        unsigned char buf[32];
+        ssize_t n = syscall(SYS_getdents64, args->fd, buf, sizeof(buf));
+        if (n < 0) {
+            args->error = errno;
+            return NULL;
+        }
+        if (n == 0) {
+            return NULL;
+        }
+        if ((size_t)n < offsetof(struct p4_linux_dirent64, d_name)) {
+            args->error = EIO;
+            return NULL;
+        }
+        struct p4_linux_dirent64 *entry = (struct p4_linux_dirent64 *)buf;
+        int index = p4_mock_entry_index(entry->d_name);
+        if (index < 0 || entry->d_reclen != (unsigned short)n ||
+            entry->d_off != (int64_t)p4_mock_dir_entries[index].next_cookie ||
+            entry->d_ino != p4_mock_dir_entries[index].ino ||
+            entry->d_type != p4_mock_dir_entries[index].type) {
+            args->error = EIO;
+            return NULL;
+        }
+        pthread_mutex_lock(args->lock);
+        args->name_counts[index]++;
+        pthread_mutex_unlock(args->lock);
+    }
+}
+
+static void *p4_shared_seek_thread(void *opaque) {
+    struct p4_shared_seek_args *args = (struct p4_shared_seek_args *)opaque;
+    while (!*args->go) {
+        sched_yield();
+    }
+    while (!*args->stop) {
+        if (lseek(args->fd, 0, SEEK_CUR) < 0) {
+            args->error = errno;
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+static void p4_add_mock_file(struct simplefs *fs, const char *name) {
+    struct simplefs_node *node = simplefs_alloc(fs);
+    if (!node) {
+        return;
+    }
+    node->parent = 1;
+    node->mode = S_IFREG | 0644;
+    node->is_dir = 0;
+    strncpy(node->name, name, sizeof(node->name) - 1);
+    node->name[sizeof(node->name) - 1] = '\0';
+}
+
+static int p4_handle_readdir(struct p4_readdir_daemon_args *args,
+                             const struct fuse_in_header *header, const unsigned char *payload,
+                             size_t payload_len) {
+    if (payload_len < sizeof(struct fuse_read_in)) {
+        return -1;
+    }
+    const struct fuse_read_in *in = (const struct fuse_read_in *)payload;
+    const bool plus = header->opcode == FUSE_READDIRPLUS;
+    size_t index = 0;
+    if (in->offset != 0) {
+        bool found = false;
+        for (size_t i = 0; i < sizeof(p4_mock_dir_entries) / sizeof(p4_mock_dir_entries[0]); i++) {
+            if (p4_mock_dir_entries[i].next_cookie == in->offset) {
+                index = i + 1;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return fuse_write_reply(args->common.fd, header->unique, -EINVAL, NULL, 0);
+        }
+    }
+
+    unsigned char outbuf[1024];
+    memset(outbuf, 0, sizeof(outbuf));
+    size_t outlen = 0;
+    size_t output_limit = in->size < sizeof(outbuf) ? in->size : sizeof(outbuf);
+    for (; index < sizeof(p4_mock_dir_entries) / sizeof(p4_mock_dir_entries[0]); index++) {
+        const struct p4_mock_dir_entry *entry = &p4_mock_dir_entries[index];
+        size_t name_len = strlen(entry->name);
+        size_t record_len =
+            plus ? fuse_direntplus_rec_len(name_len) : fuse_dirent_rec_len(name_len);
+        if (outlen + record_len > output_limit) {
+            break;
+        }
+        if (plus) {
+            struct fuse_direntplus dirent;
+            memset(&dirent, 0, sizeof(dirent));
+            struct simplefs_node *node = simplefs_find_node(&args->common.fs, entry->nodeid);
+            dirent.entry_out.nodeid = entry->nodeid;
+            dirent.entry_out.generation = node ? node->generation : 1;
+            dirent.entry_out.entry_valid = args->common.entry_valid_sec;
+            dirent.entry_out.attr_valid = args->common.attr_valid_sec;
+            if (node) {
+                simplefs_fill_attr(node, &dirent.entry_out.attr);
+            }
+            dirent.dirent.ino = entry->ino;
+            dirent.dirent.off = entry->next_cookie;
+            dirent.dirent.namelen = (uint32_t)name_len;
+            dirent.dirent.type = entry->type;
+            memcpy(outbuf + outlen, &dirent, sizeof(dirent));
+            memcpy(outbuf + outlen + sizeof(dirent), entry->name, name_len);
+        } else {
+            struct fuse_dirent dirent;
+            memset(&dirent, 0, sizeof(dirent));
+            dirent.ino = entry->ino;
+            dirent.off = entry->next_cookie;
+            dirent.namelen = (uint32_t)name_len;
+            dirent.type = entry->type;
+            memcpy(outbuf + outlen, &dirent, sizeof(dirent));
+            memcpy(outbuf + outlen + sizeof(dirent), entry->name, name_len);
+        }
+        outlen += record_len;
+        if (args->one_entry_per_reply) {
+            break;
+        }
+    }
+    return fuse_write_reply(args->common.fd, header->unique, 0, outbuf, outlen);
+}
+
+static void *p4_readdir_daemon_thread(void *opaque) {
+    struct p4_readdir_daemon_args *args = (struct p4_readdir_daemon_args *)opaque;
+    unsigned char *buf = (unsigned char *)malloc(FUSE_TEST_BUF_SIZE);
+    if (!buf) {
+        return NULL;
+    }
+    simplefs_init(&args->common.fs);
+    p4_add_mock_file(&args->common.fs, "alpha.txt");
+    p4_add_mock_file(&args->common.fs, "beta.txt");
+
+    while (!*args->common.stop) {
+        ssize_t n = read(args->common.fd, buf, FUSE_TEST_BUF_SIZE);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (fuse_daemon_read_should_stop(errno)) {
+                break;
+            }
+            continue;
+        }
+        if (n == 0) {
+            break;
+        }
+        const struct fuse_in_header *header = (const struct fuse_in_header *)buf;
+        if ((size_t)n != header->len || (size_t)n < sizeof(*header)) {
+            continue;
+        }
+        const unsigned char *payload = buf + sizeof(*header);
+        size_t payload_len = (size_t)n - sizeof(*header);
+        if (header->opcode == FUSE_LOOKUP) {
+            args->lookup_count++;
+        } else if (header->opcode == FUSE_GETATTR) {
+            args->getattr_count++;
+        } else if (header->opcode == FUSE_FORGET) {
+            args->forget_count++;
+        } else if (header->opcode == FUSE_READDIR) {
+            args->readdir_count++;
+        } else if (header->opcode == FUSE_READDIRPLUS) {
+            args->readdirplus_count++;
+        }
+        if (header->opcode == FUSE_READDIR || header->opcode == FUSE_READDIRPLUS) {
+            uint32_t trace_index = args->dir_trace_count++;
+            if (trace_index < sizeof(args->dir_opcode_trace) / sizeof(args->dir_opcode_trace[0]) &&
+                payload_len >= sizeof(struct fuse_read_in)) {
+                const struct fuse_read_in *read_in = (const struct fuse_read_in *)payload;
+                args->dir_opcode_trace[trace_index] = header->opcode;
+                args->dir_offset_trace[trace_index] = read_in->offset;
+            }
+            (void)p4_handle_readdir(args, header, payload, payload_len);
+        } else {
+            (void)fuse_handle_one(&args->common, buf, (size_t)n);
+        }
+    }
+    free(buf);
+    return NULL;
+}
+
 static int fuse_read_launder_counters(const char *path, uint64_t *batches, uint64_t *pages) {
     char *report = fuse_read_stats_report(path);
     if (!report) {
@@ -8977,18 +9228,6 @@ static bool forget_trace_contains(volatile uint64_t *nodeids, uint32_t count, ui
     return false;
 }
 
-static bool forget_trace_contains_pair(volatile uint64_t *nodeids,
-                                       volatile uint64_t *nlookups,
-                                       uint32_t count, uint64_t nodeid,
-                                       uint64_t nlookup) {
-    for (uint32_t i = 0; i < count && i < 32; i++) {
-        if (nodeids[i] == nodeid && nlookups[i] == nlookup) {
-            return true;
-        }
-    }
-    return false;
-}
-
 static int ext_test_positive_lookup_cache_expires_and_forgets_before_umount() {
     const char *mp = "/tmp/test_fuse_positive_lookup_lifetime";
     char parent_path[512];
@@ -9490,6 +9729,449 @@ fail:
     return -1;
 }
 
+static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies() {
+    const char *mp = "/tmp/test_fuse_readdir_typed_entries";
+    const char *overlay_root = "/tmp/test_fuse_readdir_typed_overlay";
+    char upper[256] = {};
+    char work[256] = {};
+    char merged[256] = {};
+    char overlay_options[1024] = {};
+    bool overlay_mounted = false;
+    int fuse_fd = -1;
+    int dir_fd = -1;
+    pthread_t daemon_thread;
+    bool daemon_started = false;
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    struct p4_readdir_daemon_args args;
+    const char *expected_names[] = {".", "..", "hello.txt", "alpha.txt", "beta.txt"};
+    const int64_t expected_cookies[] = {11, 29, 101, 4099, 65537};
+    uint64_t overlay_inos[5] = {0};
+    uint32_t lookup_before = 0;
+    uint32_t getattr_before = 0;
+    uint32_t forget_before = 0;
+    volatile int readers_ready = 0;
+    volatile int start_readers = 0;
+    pthread_mutex_t counts_lock = PTHREAD_MUTEX_INITIALIZER;
+    unsigned int concurrent_name_counts[5] = {0};
+    struct p4_shared_readdir_args reader_args[2];
+    pthread_t reader_threads[2];
+    size_t readers_started = 0;
+    volatile int stop_seeker = 0;
+    struct p4_shared_seek_args seeker_args;
+    pthread_t seeker_thread;
+    bool seeker_started = false;
+    size_t seen = 0;
+    unsigned char resume_buf[32];
+    ssize_t resume_n = -1;
+    struct p4_linux_dirent64 *resumed = NULL;
+    memset(&args, 0, sizeof(args));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+    fuse_fd = open("/dev/fuse", O_RDWR);
+    if (fuse_fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+    args.common.fd = fuse_fd;
+    args.common.stop = &stop;
+    args.common.init_done = &init_done;
+    args.common.stop_on_destroy = 1;
+    args.common.force_opendir_enosys = 1;
+    args.common.entry_valid_sec = 60;
+    args.common.attr_valid_sec = 60;
+    args.common.init_out_flags_override =
+        FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_NO_OPENDIR_SUPPORT;
+    if (pthread_create(&daemon_thread, NULL, p4_readdir_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fuse_fd);
+        rmdir(mp);
+        return -1;
+    }
+    daemon_started = true;
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fuse_fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+    dir_fd = open(mp, O_RDONLY | O_DIRECTORY);
+    if (dir_fd < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+
+    lookup_before = args.lookup_count;
+    getattr_before = args.getattr_count;
+    forget_before = args.forget_count;
+    memset(&seeker_args, 0, sizeof(seeker_args));
+    seeker_args.fd = dir_fd;
+    seeker_args.go = &start_readers;
+    seeker_args.stop = &stop_seeker;
+    if (pthread_create(&seeker_thread, NULL, p4_shared_seek_thread, &seeker_args) != 0) {
+        printf("[FAIL] pthread_create shared directory seeker\n");
+        goto fail;
+    }
+    seeker_started = true;
+    for (size_t i = 0; i < 2; i++) {
+        memset(&reader_args[i], 0, sizeof(reader_args[i]));
+        reader_args[i].fd = dir_fd;
+        reader_args[i].ready = &readers_ready;
+        reader_args[i].go = &start_readers;
+        reader_args[i].lock = &counts_lock;
+        reader_args[i].name_counts = concurrent_name_counts;
+        if (pthread_create(&reader_threads[i], NULL, p4_shared_readdir_thread,
+                           &reader_args[i]) != 0) {
+            printf("[FAIL] pthread_create shared readdir reader\n");
+            goto fail;
+        }
+        readers_started++;
+    }
+    while (readers_ready != 2) {
+        sched_yield();
+    }
+    start_readers = 1;
+    __sync_synchronize();
+    for (size_t i = 0; i < readers_started; i++) {
+        pthread_join(reader_threads[i], NULL);
+    }
+    readers_started = 0;
+    stop_seeker = 1;
+    __sync_synchronize();
+    pthread_join(seeker_thread, NULL);
+    seeker_started = false;
+    for (size_t i = 0; i < 5; i++) {
+        if (reader_args[0].error != 0 || reader_args[1].error != 0 ||
+            seeker_args.error != 0 || concurrent_name_counts[i] != 1) {
+            printf("[FAIL] shared readdir entry[%zu] count=%u errors=%d/%d seek=%d\n", i,
+                   concurrent_name_counts[i], reader_args[0].error, reader_args[1].error,
+                   seeker_args.error);
+            goto fail;
+        }
+    }
+    if (lseek(dir_fd, 0, SEEK_SET) != 0) {
+        printf("[FAIL] reset directory after shared readdir: %s (errno=%d)\n", strerror(errno),
+               errno);
+        goto fail;
+    }
+    for (;;) {
+        unsigned char buf[32];
+        ssize_t n = syscall(SYS_getdents64, dir_fd, buf, sizeof(buf));
+        if (n < 0) {
+            printf("[FAIL] getdents64 small buffer: %s (errno=%d)\n", strerror(errno), errno);
+            goto fail;
+        }
+        if (n == 0) {
+            break;
+        }
+        if ((size_t)n < offsetof(struct p4_linux_dirent64, d_name)) {
+            printf("[FAIL] short getdents64 record: n=%zd\n", n);
+            goto fail;
+        }
+        struct p4_linux_dirent64 *entry = (struct p4_linux_dirent64 *)buf;
+        if (entry->d_reclen != (unsigned short)n || seen >= 5 ||
+            strcmp(entry->d_name, expected_names[seen]) != 0 ||
+            entry->d_off != expected_cookies[seen] ||
+            entry->d_ino != p4_mock_dir_entries[seen].ino ||
+            entry->d_type != p4_mock_dir_entries[seen].type) {
+            printf("[FAIL] dirent[%zu] name=%s off=%lld reclen=%u n=%zd\n", seen,
+                   entry->d_name, (long long)entry->d_off, entry->d_reclen, n);
+            goto fail;
+        }
+        seen++;
+    }
+    if (seen != 5 || args.lookup_count != lookup_before || args.getattr_count != getattr_before ||
+        args.readdir_count == 0 || args.readdirplus_count != 0) {
+        printf("[FAIL] READDIR typed-entry counters seen=%zu lookup=%u/%u getattr=%u/%u "
+               "readdir=%u plus=%u\n",
+               seen, lookup_before, args.lookup_count, getattr_before, args.getattr_count,
+               args.readdir_count, args.readdirplus_count);
+        goto fail;
+    }
+
+    if (lseek(dir_fd, 29, SEEK_SET) != 29) {
+        printf("[FAIL] seekdir cookie 29: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    errno = 0;
+    if (syscall(SYS_getdents64, dir_fd, resume_buf, 24) >= 0 || errno != EINVAL) {
+        printf("[FAIL] undersized getdents expected EINVAL without advancing: errno=%d\n", errno);
+        goto fail;
+    }
+    resume_n = syscall(SYS_getdents64, dir_fd, resume_buf, sizeof(resume_buf));
+    if (resume_n <= 0) {
+        printf("[FAIL] getdents64 after undersized buffer: n=%zd errno=%d\n", resume_n, errno);
+        goto fail;
+    }
+    resumed = (struct p4_linux_dirent64 *)resume_buf;
+    if (strcmp(resumed->d_name, "hello.txt") != 0 || resumed->d_off != 101) {
+        printf("[FAIL] undersized buffer advanced name=%s off=%lld\n", resumed->d_name,
+               (long long)resumed->d_off);
+        goto fail;
+    }
+
+    if (lseek(dir_fd, 101, SEEK_SET) != 101) {
+        printf("[FAIL] seekdir cookie 101: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    resume_n = syscall(SYS_getdents64, dir_fd, resume_buf, sizeof(resume_buf));
+    if (resume_n <= 0) {
+        printf("[FAIL] getdents64 after cookie seek: n=%zd errno=%d\n", resume_n, errno);
+        goto fail;
+    }
+    resumed = (struct p4_linux_dirent64 *)resume_buf;
+    if (strcmp(resumed->d_name, "alpha.txt") != 0 || resumed->d_off != 4099) {
+        printf("[FAIL] cookie resume name=%s off=%lld\n", resumed->d_name,
+               (long long)resumed->d_off);
+        goto fail;
+    }
+
+    close(dir_fd);
+    dir_fd = -1;
+    snprintf(upper, sizeof(upper), "%s/upper", overlay_root);
+    snprintf(work, sizeof(work), "%s/work", overlay_root);
+    snprintf(merged, sizeof(merged), "%s/merged", overlay_root);
+    if (ensure_dir(overlay_root) != 0 || ensure_dir(upper) != 0 || ensure_dir(work) != 0 ||
+        ensure_dir(merged) != 0) {
+        printf("[FAIL] create typed overlay directories: %s (errno=%d)\n", strerror(errno),
+               errno);
+        goto fail;
+    }
+    snprintf(overlay_options, sizeof(overlay_options), "lowerdir=%s,upperdir=%s,workdir=%s", mp,
+             upper, work);
+    if (mount("overlay", merged, "overlay", 0, overlay_options) != 0) {
+        printf("[FAIL] mount typed overlay: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    overlay_mounted = true;
+    dir_fd = open(merged, O_RDONLY | O_DIRECTORY);
+    if (dir_fd < 0) {
+        printf("[FAIL] open typed overlay: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    lookup_before = args.lookup_count;
+    getattr_before = args.getattr_count;
+    forget_before = args.forget_count;
+    memset(concurrent_name_counts, 0, sizeof(concurrent_name_counts));
+    for (;;) {
+        unsigned char overlay_buf[512];
+        ssize_t overlay_n = syscall(SYS_getdents64, dir_fd, overlay_buf, sizeof(overlay_buf));
+        if (overlay_n < 0) {
+            printf("[FAIL] overlay getdents64: %s (errno=%d)\n", strerror(errno), errno);
+            goto fail;
+        }
+        if (overlay_n == 0) {
+            break;
+        }
+        size_t offset = 0;
+        while (offset < (size_t)overlay_n) {
+            struct p4_linux_dirent64 *entry =
+                (struct p4_linux_dirent64 *)(overlay_buf + offset);
+            int index = p4_mock_entry_index(entry->d_name);
+            if (index < 0 || entry->d_reclen == 0 ||
+                offset + entry->d_reclen > (size_t)overlay_n ||
+                entry->d_ino == 0 ||
+                entry->d_type != p4_mock_dir_entries[index].type) {
+                printf("[FAIL] overlay typed dirent name=%s ino=%llu type=%u\n", entry->d_name,
+                       (unsigned long long)entry->d_ino, entry->d_type);
+                goto fail;
+            }
+            concurrent_name_counts[index]++;
+            overlay_inos[index] = entry->d_ino;
+            offset += entry->d_reclen;
+        }
+    }
+    for (size_t i = 0; i < 5; i++) {
+        if (concurrent_name_counts[i] != 1) {
+            printf("[FAIL] overlay typed entry[%zu] count=%u\n", i,
+                   concurrent_name_counts[i]);
+            goto fail;
+        }
+    }
+    if (args.lookup_count != lookup_before || args.getattr_count != getattr_before ||
+        args.forget_count != forget_before) {
+        printf("[FAIL] overlay readdir issued N+1 lookup=%u/%u getattr=%u/%u forget=%u/%u\n",
+               lookup_before, args.lookup_count, getattr_before, args.getattr_count,
+               forget_before, args.forget_count);
+        goto fail;
+    }
+    for (size_t i = 2; i < 5; i++) {
+        struct stat overlay_stat;
+        if (fstatat(dir_fd, expected_names[i], &overlay_stat, AT_SYMLINK_NOFOLLOW) != 0 ||
+            (uint64_t)overlay_stat.st_ino != overlay_inos[i]) {
+            printf("[FAIL] overlay ino mismatch name=%s dirent=%llu stat=%llu errno=%d\n",
+                   expected_names[i], (unsigned long long)overlay_inos[i],
+                   (unsigned long long)overlay_stat.st_ino, errno);
+            goto fail;
+        }
+    }
+    close(dir_fd);
+    dir_fd = -1;
+    umount(merged);
+    overlay_mounted = false;
+    rmdir(merged);
+    rmdir(work);
+    rmdir(upper);
+    rmdir(overlay_root);
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fuse_fd);
+    pthread_join(daemon_thread, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    start_readers = 1;
+    __sync_synchronize();
+    for (size_t i = 0; i < readers_started; i++) {
+        pthread_join(reader_threads[i], NULL);
+    }
+    stop_seeker = 1;
+    __sync_synchronize();
+    if (seeker_started) {
+        pthread_join(seeker_thread, NULL);
+    }
+    if (dir_fd >= 0) {
+        close(dir_fd);
+    }
+    if (overlay_mounted) {
+        umount(merged);
+    }
+    rmdir(merged);
+    rmdir(work);
+    rmdir(upper);
+    rmdir(overlay_root);
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fuse_fd);
+    if (daemon_started) {
+        pthread_join(daemon_thread, NULL);
+    }
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_readdirplus_auto_uses_plus_only_for_initial_batch() {
+    const char *mp = "/tmp/test_fuse_readdirplus_auto";
+    int fuse_fd = -1;
+    int dir_fd = -1;
+    pthread_t daemon_thread;
+    bool daemon_started = false;
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    struct p4_readdir_daemon_args args;
+    unsigned char buf[512];
+    ssize_t n = -1;
+    int rounds = 0;
+    memset(&args, 0, sizeof(args));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        return -1;
+    }
+    fuse_fd = open("/dev/fuse", O_RDWR);
+    if (fuse_fd < 0) {
+        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        rmdir(mp);
+        return -1;
+    }
+    args.common.fd = fuse_fd;
+    args.common.stop = &stop;
+    args.common.init_done = &init_done;
+    args.common.stop_on_destroy = 1;
+    args.common.force_opendir_enosys = 1;
+    args.common.entry_valid_sec = 60;
+    args.common.attr_valid_sec = 60;
+    args.common.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES |
+                                          FUSE_NO_OPENDIR_SUPPORT | FUSE_DO_READDIRPLUS |
+                                          FUSE_READDIRPLUS_AUTO;
+    args.one_entry_per_reply = 1;
+    if (pthread_create(&daemon_thread, NULL, p4_readdir_daemon_thread, &args) != 0) {
+        printf("[FAIL] pthread_create\n");
+        close(fuse_fd);
+        rmdir(mp);
+        return -1;
+    }
+    daemon_started = true;
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fuse_fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    if (fuseg_wait_init(&init_done) != 0) {
+        printf("[FAIL] init handshake timeout\n");
+        goto fail;
+    }
+    dir_fd = open(mp, O_RDONLY | O_DIRECTORY);
+    if (dir_fd < 0) {
+        printf("[FAIL] open(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+    do {
+        n = syscall(SYS_getdents64, dir_fd, buf, sizeof(buf));
+        if (n < 0) {
+            printf("[FAIL] AUTO getdents64: n=%zd errno=%d\n", n, errno);
+            goto fail;
+        }
+        rounds++;
+    } while (n > 0 && rounds < 16);
+    if (n != 0) {
+        printf("[FAIL] AUTO getdents64 did not reach EOF after %d rounds\n", rounds);
+        goto fail;
+    }
+    if (args.readdirplus_count != 1 || args.readdir_count == 0 || args.dir_trace_count < 2 ||
+        args.dir_opcode_trace[0] != FUSE_READDIRPLUS || args.dir_offset_trace[0] != 0 ||
+        args.dir_opcode_trace[1] != FUSE_READDIR || args.dir_offset_trace[1] == 0) {
+        printf("[FAIL] AUTO sequence plus=%u readdir=%u trace=%u first=(%u,%llu) "
+               "second=(%u,%llu)\n",
+               args.readdirplus_count, args.readdir_count, args.dir_trace_count,
+               args.dir_opcode_trace[0], (unsigned long long)args.dir_offset_trace[0],
+               args.dir_opcode_trace[1], (unsigned long long)args.dir_offset_trace[1]);
+        goto fail;
+    }
+
+    close(dir_fd);
+    dir_fd = -1;
+    if (umount(mp) != 0) {
+        printf("[FAIL] umount(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail_no_umount;
+    }
+    stop = 1;
+    close(fuse_fd);
+    pthread_join(daemon_thread, NULL);
+    rmdir(mp);
+    return 0;
+
+fail:
+    if (dir_fd >= 0) {
+        close(dir_fd);
+    }
+    umount(mp);
+fail_no_umount:
+    stop = 1;
+    close(fuse_fd);
+    if (daemon_started) {
+        pthread_join(daemon_thread, NULL);
+    }
+    rmdir(mp);
+    return -1;
+}
+
 static int ext_test_readdirplus_generation_mismatch_stales_old_node() {
     const char *mp = "/tmp/test_fuse_readdirplus_generation";
     char file_path[512];
@@ -9616,124 +10298,6 @@ fail:
     }
     if (old_fd >= 0) {
         close(old_fd);
-    }
-    umount(mp);
-    stop = 1;
-    close(fd);
-    pthread_join(th, NULL);
-    rmdir(mp);
-    return -1;
-}
-
-static int ext_test_readdirplus_invalid_attr_forgets_unconsumed_entry() {
-    const char *mp = "/tmp/test_fuse_readdirplus_invalid_attr";
-    DIR *dir = NULL;
-    int saw = 0;
-
-    if (ensure_dir(mp) != 0) {
-        printf("[FAIL] ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
-        return -1;
-    }
-
-    int fd = open("/dev/fuse", O_RDWR);
-    if (fd < 0) {
-        printf("[FAIL] open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
-        rmdir(mp);
-        return -1;
-    }
-
-    volatile int stop = 0;
-    volatile int init_done = 0;
-    volatile uint32_t readdirplus_count = 0;
-    volatile uint32_t forget_count = 0;
-    volatile uint64_t forget_trace_nodeids[32] = {0};
-    volatile uint64_t forget_trace_nlookups[32] = {0};
-
-    struct fuse_daemon_args args;
-    memset(&args, 0, sizeof(args));
-    args.fd = fd;
-    args.stop = &stop;
-    args.init_done = &init_done;
-    args.stop_on_destroy = 1;
-    args.force_opendir_enosys = 1;
-    args.init_out_flags_override =
-        FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_NO_OPENDIR_SUPPORT | FUSE_DO_READDIRPLUS;
-    args.entry_valid_sec = 60;
-    args.attr_valid_sec = 60;
-    args.readdirplus_count = &readdirplus_count;
-    args.readdirplus_invalid_attr_name = "hello.txt";
-    args.readdirplus_invalid_attr_size = 0x8000000000000000ULL;
-    args.forget_count = &forget_count;
-    args.forget_trace_nodeids = forget_trace_nodeids;
-    args.forget_trace_nlookups = forget_trace_nlookups;
-    args.forget_trace_capacity = 32;
-
-    pthread_t th;
-    if (pthread_create(&th, NULL, fuse_daemon_thread, &args) != 0) {
-        printf("[FAIL] pthread_create\n");
-        close(fd);
-        rmdir(mp);
-        return -1;
-    }
-
-    char opts[256];
-    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0", fd);
-    if (mount("none", mp, "fuse", 0, opts) != 0) {
-        printf("[FAIL] mount(fuse): %s (errno=%d)\n", strerror(errno), errno);
-        stop = 1;
-        close(fd);
-        pthread_join(th, NULL);
-        rmdir(mp);
-        return -1;
-    }
-    if (fuseg_wait_init(&init_done) != 0) {
-        printf("[FAIL] init handshake timeout\n");
-        goto fail;
-    }
-
-    dir = opendir(mp);
-    if (!dir) {
-        printf("[FAIL] opendir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
-        goto fail;
-    }
-    struct dirent *de;
-    while ((de = readdir(dir)) != NULL) {
-        if (strcmp(de->d_name, "hello.txt") == 0) {
-            saw = 1;
-        }
-    }
-    closedir(dir);
-    dir = NULL;
-    if (!saw || readdirplus_count == 0) {
-        printf("[FAIL] expected hello.txt from READDIRPLUS, saw=%d count=%u\n", saw,
-               readdirplus_count);
-        goto fail;
-    }
-
-    for (int i = 0; i < 200; i++) {
-        if (forget_trace_contains_pair(forget_trace_nodeids, forget_trace_nlookups, forget_count, 2,
-                                       1)) {
-            break;
-        }
-        usleep(10 * 1000);
-    }
-    if (!forget_trace_contains_pair(forget_trace_nodeids, forget_trace_nlookups, forget_count, 2,
-                                    1)) {
-        printf("[FAIL] invalid READDIRPLUS entry was not forgotten before umount: count=%u\n",
-               forget_count);
-        goto fail;
-    }
-
-    umount(mp);
-    stop = 1;
-    close(fd);
-    pthread_join(th, NULL);
-    rmdir(mp);
-    return 0;
-
-fail:
-    if (dir) {
-        closedir(dir);
     }
     umount(mp);
     stop = 1;
@@ -10222,8 +10786,12 @@ TEST(FuseExtended, ReaddirplusGenerationMismatchStalesOldNode) {
     ASSERT_EQ(0, ext_test_readdirplus_generation_mismatch_stales_old_node());
 }
 
-TEST(FuseExtended, ReaddirplusInvalidAttrForgetsUnconsumedEntry) {
-    ASSERT_EQ(0, ext_test_readdirplus_invalid_attr_forgets_unconsumed_entry());
+TEST(FuseExtended, ReaddirTypedEntriesAvoidNPlusOneAndPreserveCookies) {
+    ASSERT_EQ(0, ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies());
+}
+
+TEST(FuseExtended, ReaddirplusAutoUsesPlusOnlyForInitialBatch) {
+    ASSERT_EQ(0, ext_test_readdirplus_auto_uses_plus_only_for_initial_batch());
 }
 
 TEST(FuseExtended, SameGenerationTypeMismatchStalesOldNode) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -9935,6 +9935,30 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
         goto fail;
     }
 
+    // Rewinding discards the cached snapshot. A subsequent seek to an opaque
+    // cookie must still resume after that cookie when getdents rebuilds it.
+    if (lseek(dir_fd, 0, SEEK_SET) != 0 || lseek(dir_fd, 101, SEEK_SET) != 101) {
+        printf("[FAIL] seekdir cookie after snapshot reset: %s (errno=%d)\n", strerror(errno),
+               errno);
+        goto fail;
+    }
+    errno = 0;
+    if (syscall(SYS_getdents64, dir_fd, resume_buf, 24) >= 0 || errno != EINVAL) {
+        printf("[FAIL] snapshot-reset seek advanced on undersized getdents: errno=%d\n", errno);
+        goto fail;
+    }
+    resume_n = syscall(SYS_getdents64, dir_fd, resume_buf, sizeof(resume_buf));
+    if (resume_n <= 0) {
+        printf("[FAIL] getdents64 after snapshot-reset seek: n=%zd errno=%d\n", resume_n, errno);
+        goto fail;
+    }
+    resumed = (struct p4_linux_dirent64 *)resume_buf;
+    if (strcmp(resumed->d_name, "alpha.txt") != 0 || resumed->d_off != 4099) {
+        printf("[FAIL] snapshot-reset cookie resume name=%s off=%lld\n", resumed->d_name,
+               (long long)resumed->d_off);
+        goto fail;
+    }
+
     close(dir_fd);
     dir_fd = -1;
     snprintf(upper, sizeof(upper), "%s/upper", overlay_root);

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <signal.h>
 #include <sched.h>
 #include <setjmp.h>
@@ -212,19 +213,19 @@ static uint64_t p4_mock_cookie(const struct p4_readdir_daemon_args *args, size_t
 
 struct p4_shared_readdir_args {
     int fd;
-    volatile int *ready;
-    volatile int *go;
+    std::atomic<int> *ready;
+    std::atomic<int> *go;
     pthread_mutex_t *lock;
     unsigned int *name_counts;
     const int64_t *expected_cookies;
-    volatile int error;
+    int error;
 };
 
 struct p4_shared_seek_args {
     int fd;
-    volatile int *go;
-    volatile int *stop;
-    volatile int error;
+    std::atomic<int> *go;
+    std::atomic<int> *stop;
+    int error;
 };
 
 static int p4_mock_entry_index(const char *name) {
@@ -238,8 +239,8 @@ static int p4_mock_entry_index(const char *name) {
 
 static void *p4_shared_readdir_thread(void *opaque) {
     struct p4_shared_readdir_args *args = (struct p4_shared_readdir_args *)opaque;
-    __sync_fetch_and_add(args->ready, 1);
-    while (!*args->go) {
+    args->ready->fetch_add(1, std::memory_order_release);
+    while (args->go->load(std::memory_order_acquire) == 0) {
         sched_yield();
     }
     for (;;) {
@@ -273,10 +274,10 @@ static void *p4_shared_readdir_thread(void *opaque) {
 
 static void *p4_shared_seek_thread(void *opaque) {
     struct p4_shared_seek_args *args = (struct p4_shared_seek_args *)opaque;
-    while (!*args->go) {
+    while (args->go->load(std::memory_order_acquire) == 0) {
         sched_yield();
     }
-    while (!*args->stop) {
+    while (args->stop->load(std::memory_order_acquire) == 0) {
         if (lseek(args->fd, 0, SEEK_CUR) < 0) {
             args->error = errno;
             return NULL;
@@ -9764,14 +9765,14 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
     uint32_t lookup_before = 0;
     uint32_t getattr_before = 0;
     uint32_t forget_before = 0;
-    volatile int readers_ready = 0;
-    volatile int start_readers = 0;
+    std::atomic<int> readers_ready{0};
+    std::atomic<int> start_readers{0};
     pthread_mutex_t counts_lock = PTHREAD_MUTEX_INITIALIZER;
     unsigned int concurrent_name_counts[5] = {0};
     struct p4_shared_readdir_args reader_args[2];
     pthread_t reader_threads[2];
     size_t readers_started = 0;
-    volatile int stop_seeker = 0;
+    std::atomic<int> stop_seeker{0};
     struct p4_shared_seek_args seeker_args;
     pthread_t seeker_thread;
     bool seeker_started = false;
@@ -9853,17 +9854,15 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
         }
         readers_started++;
     }
-    while (readers_ready != 2) {
+    while (readers_ready.load(std::memory_order_acquire) != 2) {
         sched_yield();
     }
-    start_readers = 1;
-    __sync_synchronize();
+    start_readers.store(1, std::memory_order_release);
     for (size_t i = 0; i < readers_started; i++) {
         pthread_join(reader_threads[i], NULL);
     }
     readers_started = 0;
-    stop_seeker = 1;
-    __sync_synchronize();
+    stop_seeker.store(1, std::memory_order_release);
     pthread_join(seeker_thread, NULL);
     seeker_started = false;
     for (size_t i = 0; i < 5; i++) {
@@ -10079,13 +10078,11 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
     return 0;
 
 fail:
-    start_readers = 1;
-    __sync_synchronize();
+    start_readers.store(1, std::memory_order_release);
     for (size_t i = 0; i < readers_started; i++) {
         pthread_join(reader_threads[i], NULL);
     }
-    stop_seeker = 1;
-    __sync_synchronize();
+    stop_seeker.store(1, std::memory_order_release);
     if (seeker_started) {
         pthread_join(seeker_thread, NULL);
     }

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -172,6 +172,8 @@ struct p4_readdir_daemon_args {
     uint32_t dir_opcode_trace[16];
     uint64_t dir_offset_trace[16];
     int one_entry_per_reply;
+    int zero_first_cookie;
+    int duplicate_middle_cookie;
 };
 
 struct p4_linux_dirent64 {
@@ -198,12 +200,23 @@ static const struct p4_mock_dir_entry p4_mock_dir_entries[] = {
     {"beta.txt", 4, 4, DT_REG, 65537},
 };
 
+static uint64_t p4_mock_cookie(const struct p4_readdir_daemon_args *args, size_t index) {
+    if (args->zero_first_cookie && index == 0) {
+        return 0;
+    }
+    if (args->duplicate_middle_cookie && index == 3) {
+        return p4_mock_dir_entries[2].next_cookie;
+    }
+    return p4_mock_dir_entries[index].next_cookie;
+}
+
 struct p4_shared_readdir_args {
     int fd;
     volatile int *ready;
     volatile int *go;
     pthread_mutex_t *lock;
     unsigned int *name_counts;
+    const int64_t *expected_cookies;
     volatile int error;
 };
 
@@ -246,7 +259,7 @@ static void *p4_shared_readdir_thread(void *opaque) {
         struct p4_linux_dirent64 *entry = (struct p4_linux_dirent64 *)buf;
         int index = p4_mock_entry_index(entry->d_name);
         if (index < 0 || entry->d_reclen != (unsigned short)n ||
-            entry->d_off != (int64_t)p4_mock_dir_entries[index].next_cookie ||
+            entry->d_off != args->expected_cookies[index] ||
             entry->d_ino != p4_mock_dir_entries[index].ino ||
             entry->d_type != p4_mock_dir_entries[index].type) {
             args->error = EIO;
@@ -296,7 +309,7 @@ static int p4_handle_readdir(struct p4_readdir_daemon_args *args,
     if (in->offset != 0) {
         bool found = false;
         for (size_t i = 0; i < sizeof(p4_mock_dir_entries) / sizeof(p4_mock_dir_entries[0]); i++) {
-            if (p4_mock_dir_entries[i].next_cookie == in->offset) {
+            if (p4_mock_cookie(args, i) == in->offset) {
                 index = i + 1;
                 found = true;
                 break;
@@ -313,6 +326,7 @@ static int p4_handle_readdir(struct p4_readdir_daemon_args *args,
     size_t output_limit = in->size < sizeof(outbuf) ? in->size : sizeof(outbuf);
     for (; index < sizeof(p4_mock_dir_entries) / sizeof(p4_mock_dir_entries[0]); index++) {
         const struct p4_mock_dir_entry *entry = &p4_mock_dir_entries[index];
+        uint64_t next_cookie = p4_mock_cookie(args, index);
         size_t name_len = strlen(entry->name);
         size_t record_len =
             plus ? fuse_direntplus_rec_len(name_len) : fuse_dirent_rec_len(name_len);
@@ -331,7 +345,7 @@ static int p4_handle_readdir(struct p4_readdir_daemon_args *args,
                 simplefs_fill_attr(node, &dirent.entry_out.attr);
             }
             dirent.dirent.ino = entry->ino;
-            dirent.dirent.off = entry->next_cookie;
+            dirent.dirent.off = next_cookie;
             dirent.dirent.namelen = (uint32_t)name_len;
             dirent.dirent.type = entry->type;
             memcpy(outbuf + outlen, &dirent, sizeof(dirent));
@@ -340,7 +354,7 @@ static int p4_handle_readdir(struct p4_readdir_daemon_args *args,
             struct fuse_dirent dirent;
             memset(&dirent, 0, sizeof(dirent));
             dirent.ino = entry->ino;
-            dirent.off = entry->next_cookie;
+            dirent.off = next_cookie;
             dirent.namelen = (uint32_t)name_len;
             dirent.type = entry->type;
             memcpy(outbuf + outlen, &dirent, sizeof(dirent));
@@ -9745,7 +9759,7 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
     volatile int init_done = 0;
     struct p4_readdir_daemon_args args;
     const char *expected_names[] = {".", "..", "hello.txt", "alpha.txt", "beta.txt"};
-    const int64_t expected_cookies[] = {11, 29, 101, 4099, 65537};
+    const int64_t expected_cookies[] = {0, 29, 101, 101, 65537};
     uint64_t overlay_inos[5] = {0};
     uint32_t lookup_before = 0;
     uint32_t getattr_before = 0;
@@ -9786,6 +9800,8 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
     args.common.attr_valid_sec = 60;
     args.common.init_out_flags_override =
         FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_NO_OPENDIR_SUPPORT;
+    args.zero_first_cookie = 1;
+    args.duplicate_middle_cookie = 1;
     if (pthread_create(&daemon_thread, NULL, p4_readdir_daemon_thread, &args) != 0) {
         printf("[FAIL] pthread_create\n");
         close(fuse_fd);
@@ -9829,6 +9845,7 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
         reader_args[i].go = &start_readers;
         reader_args[i].lock = &counts_lock;
         reader_args[i].name_counts = concurrent_name_counts;
+        reader_args[i].expected_cookies = expected_cookies;
         if (pthread_create(&reader_threads[i], NULL, p4_shared_readdir_thread,
                            &reader_args[i]) != 0) {
             printf("[FAIL] pthread_create shared readdir reader\n");
@@ -9887,6 +9904,11 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
                    entry->d_name, (long long)entry->d_off, entry->d_reclen, n);
             goto fail;
         }
+        if (lseek(dir_fd, 0, SEEK_CUR) != expected_cookies[seen]) {
+            printf("[FAIL] SEEK_CUR query changed opaque cookie at entry %zu: %s (errno=%d)\n",
+                   seen, strerror(errno), errno);
+            goto fail;
+        }
         seen++;
     }
     if (seen != 5 || args.lookup_count != lookup_before || args.getattr_count != getattr_before ||
@@ -9929,7 +9951,7 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
         goto fail;
     }
     resumed = (struct p4_linux_dirent64 *)resume_buf;
-    if (strcmp(resumed->d_name, "alpha.txt") != 0 || resumed->d_off != 4099) {
+    if (strcmp(resumed->d_name, "alpha.txt") != 0 || resumed->d_off != 101) {
         printf("[FAIL] cookie resume name=%s off=%lld\n", resumed->d_name,
                (long long)resumed->d_off);
         goto fail;
@@ -9953,7 +9975,7 @@ static int ext_test_readdir_typed_entries_avoid_n_plus_one_and_preserve_cookies(
         goto fail;
     }
     resumed = (struct p4_linux_dirent64 *)resume_buf;
-    if (strcmp(resumed->d_name, "alpha.txt") != 0 || resumed->d_off != 4099) {
+    if (strcmp(resumed->d_name, "alpha.txt") != 0 || resumed->d_off != 101) {
         printf("[FAIL] snapshot-reset cookie resume name=%s off=%lld\n", resumed->d_name,
                (long long)resumed->d_off);
         goto fail;

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -1322,6 +1322,8 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 memset(&dp, 0, sizeof(dp));
                 dp.entry_out.nodeid = 1;
                 dp.entry_out.generation = a->fs.nodes[0].generation;
+                dp.entry_out.entry_valid = a->entry_valid_sec;
+                dp.entry_out.attr_valid = a->attr_valid_sec;
                 simplefs_fill_attr(&a->fs.nodes[0], &dp.entry_out.attr);
                 dp.dirent.ino = 1;
                 dp.dirent.off = idx + 1;
@@ -1347,7 +1349,7 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         uint64_t cur = idx;
         for (int i = 0; i < SIMPLEFS_MAX_NODES; i++) {
             struct simplefs_node *c = &a->fs.nodes[i];
-            if (!c->used || c->parent != h->nodeid)
+            if (!c->used || c->nodeid == h->nodeid || c->parent != h->nodeid)
                 continue;
             if (cur < child_base) {
                 cur = child_base;
@@ -1367,6 +1369,8 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 memset(&dp, 0, sizeof(dp));
                 dp.entry_out.nodeid = c->nodeid;
                 dp.entry_out.generation = c->generation;
+                dp.entry_out.entry_valid = a->entry_valid_sec;
+                dp.entry_out.attr_valid = a->attr_valid_sec;
                 simplefs_fill_attr(c, &dp.entry_out.attr);
                 if (a->readdirplus_invalid_attr_name &&
                     strcmp(c->name, a->readdirplus_invalid_attr_name) == 0) {

--- a/user/apps/virtiofs_bench/transcript_test.sh
+++ b/user/apps/virtiofs_bench/transcript_test.sh
@@ -48,6 +48,7 @@ check_transcript() {
                 !decimal("ops") || !decimal("syscalls") || !decimal("short_io") ||
                 !decimal("eintr") || !decimal("data_loop_us") || !decimal("fsync_us") ||
                 !decimal("close_us") || !decimal("end_to_end_us") ||
+                !decimal("process_cpu_us") ||
                 checksum !~ /^[0-9a-f]+$/ || length(checksum) != 16) {
                 bad = 1
             }
@@ -88,6 +89,47 @@ check_result_only_transcript() {
 
 MOUNT="$WORK_DIR/mount"
 mkdir "$MOUNT"
+
+VIRTIOFS_BENCH_RUN_ID=readdir_prepare \
+    "$BIN" --mount "$MOUNT" --workload readdir_prepare --path readdir_schema \
+    --files 2048 >"$WORK_DIR/readdir-prepare.log" 2>&1
+check_transcript <"$WORK_DIR/readdir-prepare.log"
+
+VIRTIOFS_BENCH_RUN_ID=readdir_scan \
+    "$BIN" --mount "$MOUNT" --workload readdir_scan --path readdir_schema \
+    --files 2048 --iterations 3 >"$WORK_DIR/readdir-scan.log" 2>&1
+check_transcript <"$WORK_DIR/readdir-scan.log"
+awk '
+    function value(prefix,    i) {
+        for (i = 1; i <= NF; ++i) {
+            if (index($i, prefix "=") == 1) {
+                return substr($i, length(prefix) + 2)
+            }
+        }
+        return "__missing__"
+    }
+    $1 == "result" {
+        seen++
+        if (value("workload") != "readdir_scan" || value("status") != "ok" ||
+            value("files") != "2048" || value("iterations") != "3" ||
+            value("ops") != "6144" || value("syscalls") !~ /^[1-9][0-9]*$/ ||
+            value("syscalls") + 0 <= 6 ||
+            value("process_cpu_us") !~ /^[0-9]+$/ ||
+            value("checksum") !~ /^[0-9a-f]+$/ || length(value("checksum")) != 16) {
+            bad = 1
+        }
+    }
+    END { exit bad || seen != 1 }
+' "$WORK_DIR/readdir-scan.log"
+
+VIRTIOFS_BENCH_RUN_ID=readdir_cleanup \
+    "$BIN" --mount "$MOUNT" --workload readdir_cleanup --path readdir_schema \
+    --files 2048 >"$WORK_DIR/readdir-cleanup.log" 2>&1
+check_transcript <"$WORK_DIR/readdir-cleanup.log"
+if [ -e "$MOUNT/.virtiofs_bench_readdir_schema" ]; then
+    echo "readdir cleanup left its dataset directory" >&2
+    exit 1
+fi
 
 VIRTIOFS_BENCH_RUN_ID=host_prepare VIRTIOFS_BENCH_CACHE_MODE=warm \
     "$BIN" --mount "$MOUNT" --workload prepare --path schema_test \

--- a/user/apps/virtiofs_bench/transcript_test.sh
+++ b/user/apps/virtiofs_bench/transcript_test.sh
@@ -87,6 +87,29 @@ check_result_only_transcript() {
     '
 }
 
+check_readdir_failure_result() {
+    expected_errno=$1
+    awk -v expected_errno="$expected_errno" '
+        function value(prefix,    i) {
+            for (i = 1; i <= NF; ++i) {
+                if (index($i, prefix "=") == 1) {
+                    return substr($i, length(prefix) + 2)
+                }
+            }
+            return "__missing__"
+        }
+        $1 == "result" {
+            seen++
+            if (value("workload") != "readdir_scan" || value("status") != "fail" ||
+                value("errno") != expected_errno || value("bytes") != "0" ||
+                value("ops") != "0") {
+                bad = 1
+            }
+        }
+        END { exit bad || seen != 1 }
+    '
+}
+
 MOUNT="$WORK_DIR/mount"
 mkdir "$MOUNT"
 
@@ -121,6 +144,63 @@ awk '
     }
     END { exit bad || seen != 1 }
 ' "$WORK_DIR/readdir-scan.log"
+
+# A pre-scan quiescence timeout must still terminate the workload transcript
+# with one machine-readable failure result for benchmark parsers.
+: >"$WORK_DIR/non-quiescent.stats"
+set +e
+VIRTIOFS_BENCH_RUN_ID=readdir_timeout \
+    VIRTIOFS_STATS_PATH="$WORK_DIR/non-quiescent.stats" \
+    "$BIN" --mount "$MOUNT" --workload readdir_scan --path readdir_schema \
+    --files 2048 --iterations 3 >"$WORK_DIR/readdir-timeout.log" 2>&1
+readdir_timeout_rc=$?
+set -e
+if [ "$readdir_timeout_rc" -eq 0 ]; then
+    echo "readdir quiescence timeout unexpectedly succeeded" >&2
+    exit 1
+fi
+check_result_only_transcript <"$WORK_DIR/readdir-timeout.log"
+check_readdir_failure_result 110 <"$WORK_DIR/readdir-timeout.log"
+
+# Keep quiescence sampling independent from stats collection so that a stable
+# transport with an unavailable baseline exercises the adjacent EIO path.
+cat >"$WORK_DIR/quiescent.stats" <<'EOF'
+[fuse]
+request_queue_current 0
+dispatch_current 0
+processing_current 0
+background_inflight_current 0
+read_reservation_current 0
+requests_queued_total 0
+requests_dequeued_total 0
+requests_replied_ok_total 0
+requests_replied_err_total 0
+requests_aborted_total 0
+[virtiofs]
+inflight_current 0
+hiprio_inflight_current 0
+request_inflight_current 0
+queue_full_blocked_current 0
+reply_retained_current 0
+bridge_submitted_total 0
+bridge_completed_total 0
+direct_read_requested_bytes_total 0
+direct_read_completed_bytes_total 0
+EOF
+set +e
+VIRTIOFS_BENCH_RUN_ID=readdir_baseline_unavailable \
+    VIRTIOFS_QUIESCENCE_PATH="$WORK_DIR/quiescent.stats" \
+    VIRTIOFS_STATS_PATH="$WORK_DIR/missing.stats" \
+    "$BIN" --mount "$MOUNT" --workload readdir_scan --path readdir_schema \
+    --files 2048 --iterations 3 >"$WORK_DIR/readdir-baseline-unavailable.log" 2>&1
+readdir_baseline_rc=$?
+set -e
+if [ "$readdir_baseline_rc" -eq 0 ]; then
+    echo "readdir missing baseline unexpectedly succeeded" >&2
+    exit 1
+fi
+check_result_only_transcript <"$WORK_DIR/readdir-baseline-unavailable.log"
+check_readdir_failure_result 5 <"$WORK_DIR/readdir-baseline-unavailable.log"
 
 VIRTIOFS_BENCH_RUN_ID=readdir_cleanup \
     "$BIN" --mount "$MOUNT" --workload readdir_cleanup --path readdir_schema \

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -10,6 +10,7 @@
 #include <sys/mount.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <time.h>
@@ -59,6 +60,9 @@ enum class WorkloadSpec {
     All,
     Metadata,
     Readdir,
+    ReaddirPrepare,
+    ReaddirScan,
+    ReaddirCleanup,
     Sequential,
     Prepare,
     SequentialWrite,
@@ -77,6 +81,12 @@ const char* workload_name(WorkloadSpec workload) {
             return "metadata";
         case WorkloadSpec::Readdir:
             return "readdir";
+        case WorkloadSpec::ReaddirPrepare:
+            return "readdir_prepare";
+        case WorkloadSpec::ReaddirScan:
+            return "readdir_scan";
+        case WorkloadSpec::ReaddirCleanup:
+            return "readdir_cleanup";
         case WorkloadSpec::Sequential:
             return "sequential";
         case WorkloadSpec::Prepare:
@@ -104,6 +114,9 @@ bool parse_workload(const std::string& value, WorkloadSpec* workload) {
     } specs[] = {{"all", WorkloadSpec::All},
                  {"metadata", WorkloadSpec::Metadata},
                  {"readdir", WorkloadSpec::Readdir},
+                 {"readdir_prepare", WorkloadSpec::ReaddirPrepare},
+                 {"readdir_scan", WorkloadSpec::ReaddirScan},
+                 {"readdir_cleanup", WorkloadSpec::ReaddirCleanup},
                  {"sequential", WorkloadSpec::Sequential},
                  {"prepare", WorkloadSpec::Prepare},
                  {"sequential_write", WorkloadSpec::SequentialWrite},
@@ -134,6 +147,7 @@ struct Options {
     size_t block_size = 4096;
     size_t iterations = 4096;
     size_t workers = 4;
+    bool iterations_explicit = false;
 };
 
 using StatsMap = std::map<std::string, long long>;
@@ -141,6 +155,15 @@ using StatsMap = std::map<std::string, long long>;
 uint64_t now_us() {
     timespec ts = {};
     if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0;
+    }
+    return static_cast<uint64_t>(ts.tv_sec) * 1000000ULL +
+           static_cast<uint64_t>(ts.tv_nsec) / 1000ULL;
+}
+
+uint64_t process_cpu_us() {
+    timespec ts = {};
+    if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) != 0) {
         return 0;
     }
     return static_cast<uint64_t>(ts.tv_sec) * 1000000ULL +
@@ -329,6 +352,28 @@ bool stats_delta(const StatsMap& before, const StatsMap& after, const std::strin
     return true;
 }
 
+bool require_readdir_no_nplusone(const char* workload, const StatsMap& before,
+                                 const StatsMap& after) {
+    long long lookup = 0;
+    long long forget = 0;
+    long long getattr = 0;
+    long long readdir = 0;
+    long long readdirplus = 0;
+    bool present =
+        stats_delta(before, after, "virtiofs_opcode.opcode_1_requests_total", &lookup) &&
+        stats_delta(before, after, "virtiofs_opcode.opcode_2_requests_total", &forget) &&
+        stats_delta(before, after, "virtiofs_opcode.opcode_3_requests_total", &getattr) &&
+        stats_delta(before, after, "virtiofs_opcode.opcode_28_requests_total", &readdir) &&
+        stats_delta(before, after, "virtiofs_opcode.opcode_44_requests_total", &readdirplus);
+    bool passed = present && lookup == 0 && forget == 0 && getattr == 0 &&
+                  readdir + readdirplus > 0;
+    printf("stats_assert workload=%s check=readdir_nplusone status=%s present=%d "
+           "lookup=%lld forget=%lld getattr=%lld readdir=%lld readdirplus=%lld\n",
+           workload, passed ? "ok" : "fail", present ? 1 : 0, lookup, forget, getattr,
+           readdir, readdirplus);
+    return passed;
+}
+
 bool require_zero_copy_transfer(const char* workload, const StatsMap& before,
                                 const StatsMap& after, int opcode) {
     const std::string prefix =
@@ -454,7 +499,7 @@ bool validate_zero_copy_metrics(WorkloadSpec workload, const Options& opt,
     if (workload == WorkloadSpec::SequentialRead) {
         return require_cached_read_data_path(name, opt.file_size, before, after);
     }
-    if (workload == WorkloadSpec::Readdir) {
+    if (workload == WorkloadSpec::Readdir || workload == WorkloadSpec::ReaddirScan) {
         long long readdir_requests = 0;
         long long readdirplus_requests = 0;
         stats_delta(before, after, "virtiofs_opcode.opcode_28_requests_total",
@@ -548,12 +593,13 @@ struct WritePhaseTimings {
 
 void emit_result(const char* workload, const Options& opt, uint64_t elapsed_us, uint64_t bytes,
                  uint64_t ops, int err, const IoCounters& io = {}, uint64_t checksum = 0,
-                 const WritePhaseTimings& write_timings = {}) {
+                 const WritePhaseTimings& write_timings = {}, uint64_t cpu_us = 0) {
     utsname uts = {};
     uname(&uts);
     printf("result workload=%s status=%s errno=%d elapsed_us=%llu bytes=%llu ops=%llu "
            "syscalls=%llu short_io=%llu eintr=%llu checksum=%016llx "
            "data_loop_us=%llu fsync_us=%llu close_us=%llu end_to_end_us=%llu "
+           "process_cpu_us=%llu "
            "mount=%s dataset=%s seed=%llu files=%zu file_size=%zu block_size=%zu "
            "iterations=%zu workers=%zu run_id=%s "
            "cache_mode=%s mount_options=%s expect_dax=%s sysname=%s release=%s\n",
@@ -568,7 +614,8 @@ void emit_result(const char* workload, const Options& opt, uint64_t elapsed_us, 
            static_cast<unsigned long long>(write_timings.data_loop_us),
            static_cast<unsigned long long>(write_timings.fsync_us),
            static_cast<unsigned long long>(write_timings.close_us),
-           static_cast<unsigned long long>(write_timings.end_to_end_us), opt.mount.c_str(),
+           static_cast<unsigned long long>(write_timings.end_to_end_us),
+           static_cast<unsigned long long>(cpu_us), opt.mount.c_str(),
            opt.path.empty() ? "ephemeral" : opt.path.c_str(),
            static_cast<unsigned long long>(opt.seed), opt.files, opt.file_size, opt.block_size,
            opt.iterations, opt.workers, env_or_empty("VIRTIOFS_BENCH_RUN_ID"),
@@ -1070,6 +1117,317 @@ int readdir_workload(const Options& opt, const std::string& root) {
     return err == 0 ? 0 : -1;
 }
 
+constexpr const char* kReaddirEntryPrefix = "entry_";
+constexpr size_t kReaddirEntryDigits = 8;
+constexpr size_t kReaddirBufferSize = 64 * 1024;
+
+struct LinuxDirent64 {
+    uint64_t ino;
+    int64_t off;
+    uint16_t reclen;
+    uint8_t type;
+    char name[1];
+};
+
+std::string readdir_entry_name(size_t index) {
+    std::string name = kReaddirEntryPrefix;
+    name.resize(name.size() + kReaddirEntryDigits, '0');
+    for (size_t pos = name.size(); pos > sizeof("entry_") - 1; --pos) {
+        name[pos - 1] = static_cast<char>('0' + index % 10);
+        index /= 10;
+    }
+    return name;
+}
+
+bool readdir_entry_index(const char* name, size_t len, size_t files, size_t* index) {
+    constexpr size_t prefix_len = sizeof("entry_") - 1;
+    if (len != prefix_len + kReaddirEntryDigits ||
+        memcmp(name, kReaddirEntryPrefix, prefix_len) != 0) {
+        return false;
+    }
+    size_t value = 0;
+    for (size_t i = prefix_len; i < len; ++i) {
+        const unsigned char c = static_cast<unsigned char>(name[i]);
+        if (c < '0' || c > '9') {
+            return false;
+        }
+        value = value * 10 + static_cast<size_t>(c - '0');
+    }
+    if (value >= files) {
+        return false;
+    }
+    *index = value;
+    return true;
+}
+
+uint64_t readdir_dataset_checksum(size_t files) {
+    uint64_t hash = 1469598103934665603ULL;
+    for (size_t i = 0; i < files; ++i) {
+        const std::string name = readdir_entry_name(i);
+        for (unsigned char c : name) {
+            hash ^= c;
+            hash *= 1099511628211ULL;
+        }
+        hash ^= 0xff;
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+struct ReaddirScanCounters {
+    uint64_t bytes = 0;
+    uint64_t getdents_calls = 0;
+};
+
+struct ReaddirScanScratch {
+    explicit ReaddirScanScratch(size_t files)
+        : seen(files, false), buffer(kReaddirBufferSize) {}
+
+    void reset() {
+        std::fill(seen.begin(), seen.end(), false);
+    }
+
+    std::vector<bool> seen;
+    std::vector<unsigned char> buffer;
+};
+
+int scan_readdir_once(int fd, const Options& opt, ReaddirScanScratch* scratch,
+                      ReaddirScanCounters* counters) {
+    bool seen_dot = false;
+    bool seen_dotdot = false;
+    bool have_terminal_cookie = false;
+    int64_t terminal_cookie = 0;
+
+    for (;;) {
+        ++counters->getdents_calls;
+        long nread = syscall(SYS_getdents64, fd, scratch->buffer.data(), scratch->buffer.size());
+        if (nread < 0 && errno == EINTR) {
+            continue;
+        }
+        if (nread < 0) {
+            return errno_or_eio();
+        }
+        if (nread == 0) {
+            break;
+        }
+        counters->bytes += static_cast<uint64_t>(nread);
+        size_t offset = 0;
+        int64_t this_terminal_cookie = terminal_cookie;
+        while (offset < static_cast<size_t>(nread)) {
+            constexpr size_t header = offsetof(LinuxDirent64, name);
+            if (static_cast<size_t>(nread) - offset < header) {
+                return EIO;
+            }
+            const auto* entry =
+                reinterpret_cast<const LinuxDirent64*>(scratch->buffer.data() + offset);
+            if (entry->reclen < header + 1 || entry->reclen % sizeof(uint64_t) != 0 ||
+                entry->reclen > static_cast<size_t>(nread) - offset) {
+                return EIO;
+            }
+            const size_t name_capacity = entry->reclen - header;
+            const void* terminator = memchr(entry->name, '\0', name_capacity);
+            if (!terminator) {
+                return EIO;
+            }
+            const size_t name_len = static_cast<const char*>(terminator) - entry->name;
+            if (name_len == 0 || memchr(entry->name, '/', name_len)) {
+                return EIO;
+            }
+            if (name_len == 1 && entry->name[0] == '.') {
+                if (seen_dot) {
+                    return EIO;
+                }
+                seen_dot = true;
+            } else if (name_len == 2 && entry->name[0] == '.' && entry->name[1] == '.') {
+                if (seen_dotdot) {
+                    return EIO;
+                }
+                seen_dotdot = true;
+            } else {
+                size_t index = 0;
+                if (!readdir_entry_index(entry->name, name_len, opt.files, &index) ||
+                    scratch->seen[index] || entry->ino == 0 || entry->type != DT_REG) {
+                    return EIO;
+                }
+                scratch->seen[index] = true;
+            }
+            this_terminal_cookie = entry->off;
+            offset += entry->reclen;
+        }
+        if (offset != static_cast<size_t>(nread) ||
+            (have_terminal_cookie && this_terminal_cookie == terminal_cookie)) {
+            return EIO;
+        }
+        terminal_cookie = this_terminal_cookie;
+        have_terminal_cookie = true;
+    }
+    if (seen_dot != seen_dotdot ||
+        std::find(scratch->seen.begin(), scratch->seen.end(), false) != scratch->seen.end()) {
+        return EIO;
+    }
+    return 0;
+}
+
+int readdir_prepare_workload(const Options& opt, const std::string&) {
+    const char* label = workload_name(WorkloadSpec::ReaddirPrepare);
+    const uint64_t start = now_us();
+    int err = 0;
+    uint64_t ops = 0;
+    phase_marker(opt, label, "prepare", "begin", 0, opt.files, 0, 0);
+    DatasetWriteLock lock;
+    if (!lock.acquire(opt, &err)) {
+        phase_marker(opt, label, "prepare", "end", 0, opt.files, -1, err);
+        emit_result(label, opt, now_us() - start, 0, 0, err);
+        return -1;
+    }
+    int root_fd = open_dataset_dir(opt, true);
+    if (root_fd < 0) {
+        err = errno_or_eio();
+    }
+    for (size_t i = 0; err == 0 && i < opt.files; ++i) {
+        const std::string name = readdir_entry_name(i);
+        int fd = openat(root_fd, name.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC | O_NOFOLLOW,
+                        0644);
+        if (fd < 0 && errno == EEXIST) {
+            struct stat st = {};
+            if (fstatat(root_fd, name.c_str(), &st, AT_SYMLINK_NOFOLLOW) != 0) {
+                err = errno_or_eio();
+            } else if (!S_ISREG(st.st_mode) || st.st_size != 0) {
+                err = EINVAL;
+            }
+        } else if (fd < 0) {
+            err = errno_or_eio();
+        } else {
+            close_preserve_error(fd, &err);
+        }
+        if (err == 0) {
+            ++ops;
+        }
+    }
+    ReaddirScanCounters scan = {};
+    ReaddirScanScratch scratch(opt.files);
+    scratch.reset();
+    if (err == 0 && lseek(root_fd, 0, SEEK_SET) < 0) {
+        err = errno_or_eio();
+    }
+    if (err == 0) {
+        err = scan_readdir_once(root_fd, opt, &scratch, &scan);
+    }
+    if (root_fd >= 0) {
+        close_preserve_error(root_fd, &err);
+    }
+    phase_marker(opt, label, "prepare", "end", ops, opt.files, err == 0 ? 0 : -1, err);
+    emit_result(label, opt, now_us() - start, 0, ops, err, {},
+                err == 0 ? readdir_dataset_checksum(opt.files) : 0);
+    return err == 0 ? 0 : -1;
+}
+
+int readdir_scan_workload(const Options& opt, const std::string&) {
+    const char* label = workload_name(WorkloadSpec::ReaddirScan);
+    int err = 0;
+    int root_fd = open_dataset_dir(opt, false);
+    if (root_fd < 0) {
+        err = errno_or_eio();
+        emit_result(label, opt, 0, 0, 0, err);
+        return -1;
+    }
+    const bool verify_stats = !stats_path().empty();
+    if (!wait_for_quiescence(label, "before")) {
+        close(root_fd);
+        return -1;
+    }
+    StatsMap before = read_stats();
+    if (verify_stats && before.empty()) {
+        close(root_fd);
+        return -1;
+    }
+
+    phase_marker(opt, label, "scan", "begin", 0, opt.files, 0, 0);
+    ReaddirScanCounters scan = {};
+    ReaddirScanScratch scratch(opt.files);
+    uint64_t elapsed_us = 0;
+    uint64_t cpu_us = 0;
+    for (size_t iteration = 0; err == 0 && iteration < opt.iterations; ++iteration) {
+        if (iteration != 0 && lseek(root_fd, 0, SEEK_SET) < 0) {
+            err = errno_or_eio();
+            break;
+        }
+        scratch.reset();
+        const uint64_t cpu_start = process_cpu_us();
+        const uint64_t wall_start = now_us();
+        err = scan_readdir_once(root_fd, opt, &scratch, &scan);
+        elapsed_us += now_us() - wall_start;
+        const uint64_t cpu_end = process_cpu_us();
+        if (cpu_end >= cpu_start) {
+            cpu_us += cpu_end - cpu_start;
+        }
+    }
+    phase_marker(opt, label, "scan", "end", scan.bytes, opt.files,
+                 err == 0 ? static_cast<int64_t>(opt.files * opt.iterations) : -1, err);
+
+    if (!wait_for_quiescence(label, "after")) {
+        err = err == 0 ? ETIMEDOUT : err;
+    }
+    StatsMap after = read_stats();
+    emit_stats_delta(label, before, after);
+    if (err == 0 && verify_stats &&
+        (after.empty() ||
+         !validate_zero_copy_metrics(WorkloadSpec::ReaddirScan, opt, before, after) ||
+         !require_readdir_no_nplusone(label, before, after))) {
+        err = EIO;
+    }
+    close_preserve_error(root_fd, &err);
+
+    IoCounters io = {};
+    io.syscalls = scan.getdents_calls;
+    const uint64_t ops = opt.files * opt.iterations;
+    emit_result(label, opt, elapsed_us, scan.bytes, ops, err, io,
+                err == 0 ? readdir_dataset_checksum(opt.files) : 0, {}, cpu_us);
+    return err == 0 ? 0 : -1;
+}
+
+int readdir_cleanup_workload(const Options& opt, const std::string&) {
+    const char* label = workload_name(WorkloadSpec::ReaddirCleanup);
+    const uint64_t start = now_us();
+    int err = 0;
+    uint64_t ops = 0;
+    phase_marker(opt, label, "cleanup", "begin", 0, opt.files, 0, 0);
+    DatasetWriteLock lock;
+    if (!lock.acquire(opt, &err)) {
+        emit_result(label, opt, now_us() - start, 0, 0, err);
+        return -1;
+    }
+    int root_fd = open_dataset_dir(opt, false);
+    if (root_fd < 0) {
+        if (errno != ENOENT) {
+            err = errno_or_eio();
+        }
+    } else {
+        for (size_t i = 0; i < opt.files; ++i) {
+            const std::string name = readdir_entry_name(i);
+            if (unlinkat(root_fd, name.c_str(), 0) == 0) {
+                ++ops;
+            } else if (errno != ENOENT) {
+                record_first_error(&err, errno_or_eio());
+            }
+        }
+        close_preserve_error(root_fd, &err);
+    }
+    int mount_fd = open(opt.mount.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (mount_fd < 0) {
+        record_first_error(&err, errno_or_eio());
+    } else {
+        const std::string dirname = ".virtiofs_bench_" + opt.path;
+        if (unlinkat(mount_fd, dirname.c_str(), AT_REMOVEDIR) != 0 && errno != ENOENT) {
+            record_first_error(&err, errno_or_eio());
+        }
+        close_preserve_error(mount_fd, &err);
+    }
+    phase_marker(opt, label, "cleanup", "end", ops, opt.files, err == 0 ? 0 : -1, err);
+    emit_result(label, opt, now_us() - start, 0, ops, err);
+    return err == 0 ? 0 : -1;
+}
+
 int sequential_write_phase(const Options& opt, WorkloadSpec workload) {
     const char* label = workload_name(workload);
     std::vector<unsigned char> data;
@@ -1565,8 +1923,9 @@ int concurrent_workload(const Options& opt, const std::string& root) {
 
 void usage(const char* argv0) {
     fprintf(stderr,
-            "usage: %s --mount PATH [--workload all|metadata|readdir|sequential|prepare|"
-            "sequential_write|sequential_read|cleanup|random_read|mmap|concurrent] "
+            "usage: %s --mount PATH [--workload all|metadata|readdir|readdir_prepare|"
+            "readdir_scan|readdir_cleanup|sequential|prepare|sequential_write|"
+            "sequential_read|cleanup|random_read|mmap|concurrent] "
             "[--path RELATIVE_DATASET] [--seed N] [--expect-dax always|never] [--files N] "
             "[--file-size N] [--block-size N] [--iterations N] [--workers N]\n",
             argv0);
@@ -1639,7 +1998,9 @@ bool valid_dataset_component(const std::string& path) {
 
 bool is_dataset_lifecycle_workload(WorkloadSpec workload) {
     return workload == WorkloadSpec::Prepare || workload == WorkloadSpec::SequentialWrite ||
-           workload == WorkloadSpec::SequentialRead || workload == WorkloadSpec::Cleanup;
+           workload == WorkloadSpec::SequentialRead || workload == WorkloadSpec::Cleanup ||
+           workload == WorkloadSpec::ReaddirPrepare || workload == WorkloadSpec::ReaddirScan ||
+           workload == WorkloadSpec::ReaddirCleanup;
 }
 
 bool mount_options_contain(const std::string& options, const std::string& expected) {
@@ -1704,6 +2065,7 @@ bool parse_args(int argc, char** argv, Options* opt) {
         } else if (strcmp(argv[i], "--iterations") == 0) {
             const char* v = need(argv[i]);
             if (!v || !parse_size("--iterations", v, kMaxIterations, &opt->iterations)) return false;
+            opt->iterations_explicit = true;
         } else if (strcmp(argv[i], "--workers") == 0) {
             const char* v = need(argv[i]);
             if (!v || !parse_size("--workers", v, kMaxWorkers, &opt->workers)) return false;
@@ -1717,6 +2079,17 @@ bool parse_args(int argc, char** argv, Options* opt) {
     }
     if (is_dataset_lifecycle_workload(opt->workload) && opt->path.empty()) {
         fprintf(stderr, "%s requires --path RELATIVE_DATASET\n", workload_name(opt->workload));
+        return false;
+    }
+    if (opt->workload == WorkloadSpec::ReaddirScan && !opt->iterations_explicit) {
+        opt->iterations = 1;
+    }
+    if ((opt->workload == WorkloadSpec::ReaddirPrepare ||
+         opt->workload == WorkloadSpec::ReaddirScan ||
+         opt->workload == WorkloadSpec::ReaddirCleanup) &&
+        (opt->files == 0 || opt->iterations == 0)) {
+        fprintf(stderr, "%s requires non-zero --files and --iterations\n",
+                workload_name(opt->workload));
         return false;
     }
     if (opt->tag.empty()) {
@@ -1864,7 +2237,9 @@ int main(int argc, char** argv) {
         opt.path = std::to_string(getpid());
     }
     std::string root = path_join(opt.mount, ".virtiofs_bench_" + opt.path);
-    if (opt.workload != WorkloadSpec::Cleanup) {
+    if (opt.workload != WorkloadSpec::Cleanup &&
+        opt.workload != WorkloadSpec::ReaddirCleanup &&
+        opt.workload != WorkloadSpec::ReaddirScan) {
         int root_fd = open_dataset_dir(opt, true);
         if (root_fd < 0) {
             fprintf(stderr, "failed to create safe dataset %s: %s\n", root.c_str(),
@@ -1880,6 +2255,17 @@ int main(int argc, char** argv) {
     }
     if (opt.workload == WorkloadSpec::All || opt.workload == WorkloadSpec::Readdir) {
         rc |= run_with_stats_delta(WorkloadSpec::Readdir, readdir_workload, opt, root);
+    }
+    if (opt.workload == WorkloadSpec::ReaddirPrepare) {
+        rc |= run_with_stats_delta(WorkloadSpec::ReaddirPrepare, readdir_prepare_workload, opt,
+                                   root);
+    }
+    if (opt.workload == WorkloadSpec::ReaddirScan) {
+        rc |= readdir_scan_workload(opt, root);
+    }
+    if (opt.workload == WorkloadSpec::ReaddirCleanup) {
+        rc |= run_with_stats_delta(WorkloadSpec::ReaddirCleanup, readdir_cleanup_workload, opt,
+                                   root);
     }
     if (opt.workload == WorkloadSpec::All || opt.workload == WorkloadSpec::Sequential) {
         rc |= run_with_stats_delta(WorkloadSpec::Sequential, sequential_workload, opt, root);

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -1333,12 +1333,18 @@ int readdir_scan_workload(const Options& opt, const std::string&) {
     }
     const bool verify_stats = !stats_path().empty();
     if (!wait_for_quiescence(label, "before")) {
-        close(root_fd);
-        return -1;
+        err = ETIMEDOUT;
     }
-    StatsMap before = read_stats();
-    if (verify_stats && before.empty()) {
-        close(root_fd);
+    StatsMap before;
+    if (err == 0) {
+        before = read_stats();
+        if (verify_stats && before.empty()) {
+            err = EIO;
+        }
+    }
+    if (err != 0) {
+        close_preserve_error(root_fd, &err);
+        emit_result(label, opt, 0, 0, 0, err);
         return -1;
     }
 


### PR DESCRIPTION
## Summary

- preserve filesystem-provided inode numbers, file types, and opaque continuation cookies from FUSE through VFS and mount wrappers
- consume typed FUSE `READDIR`/`READDIRPLUS` records directly and implement negotiated `READDIRPLUS_AUTO` request selection
- keep one serialized per-open directory snapshot so concurrent `getdents64` and directory `lseek` share consistent progress
- merge typed overlayfs entries while preserving precedence, whiteout handling, overlay inode identity, and cache invalidation
- add deterministic readdir benchmark preparation/scanning plus request-count assertions and focused dunitest coverage

## Performance data

Environment: CubeSandbox with DragonOS `6.6.21-dragonos`, a directory containing 4,096 empty regular files pre-created in the virtiofs-backed lower layer, scanned through the container overlay mount.

Command:

```text
/p4bench --mount / --workload readdir_scan --path p4data --files 4096 --iterations 21
```

| Version | Commit | Total for 21 scans | Mean per scan | getdents64 calls | Result |
|---|---|---:|---:|---:|---|
| origin/master baseline | `72ebe13f64efedd0ffbc8626f30d7d3a7a7ecb53` | 64.894390 s | 3,090.209 ms | 84 | `status=ok` |
| optimized | `115163ce28f859159285f992912742644ed1e463` | 0.028097 s | 1.338 ms | 84 | `status=ok` |

The identical 86,016-entry workload is 2,309.66x faster, reducing measured scan time by 99.9567%. Both runs produced checksum `30d05c06b694f13d`.

A separate cold diagnostic scan with detailed FUSE statistics completed in 8.038 ms and reported:

```text
stats_assert workload=readdir_scan check=readdir_nplusone status=ok present=1 lookup=0 forget=0 getattr=0 readdir=4 readdirplus=0
```

CubeSandbox startup remained healthy after the change: the baseline instance was created in 2.507 s and the final candidate in 2.534 s.

## Validation

- `make fmt`
- `make kernel`
- `user/apps/virtiofs_bench/transcript_test.sh`
- `FuseExtended.ReaddirTypedEntriesAvoidNPlusOneAndPreserveCookies`
- `FuseExtended.ReaddirplusAutoUsesPlusOnlyForInitialBatch`
- CubeSandbox cold request-count validation: zero `LOOKUP`, `GETATTR`, and `FORGET` requests during the 4,096-entry scan
- CubeSandbox 21-iteration baseline/candidate comparison shown above

Refs #2019
