### PR TITLE
feat(build): Support x86_64-pc-linux-gnu prefix and GCC15 in scripts

### DIFF
--- a/kernel/env.mk
+++ b/kernel/env.mk
@@ -4,9 +4,19 @@ include ../env.mk
 ifeq ($(USING_DRAGONOS_NIX_ENV),1) # Nix toolchain doesn't need to specify the prefix
 CCPREFIX=
 else ifeq ($(ARCH), x86_64)
+# Some distro like Gentoo use x86_64-pc-linux-gnu prefix
+ifneq ($(wildcard /usr/bin/x86_64-pc-linux-gnu-gcc),)
+CCPREFIX=x86_64-pc-linux-gnu-
+else
 CCPREFIX=x86_64-linux-gnu-
+endif
 else ifeq ($(ARCH), riscv64)
+# Some distro like Gentoo use riscv64-pc-linux-gnu prefix
+ifneq ($(wildcard /usr/bin/riscv64-pc-linux-gnu-gcc),)
+CCPREFIX=riscv64-pc-linux-gnu-
+else
 CCPREFIX=riscv64-linux-gnu-
+endif
 else ifeq ($(ARCH), loongarch64)
 CCPREFIX=loongarch64-unknown-linux-gnu-
 else

--- a/tools/grub_auto_install.sh
+++ b/tools/grub_auto_install.sh
@@ -32,6 +32,8 @@ export LD=ld
 export AS=as
 export NM=nm
 export OBJCOPY=objcopy
+# GCC 15 默认 C23，C23 将 bool/true/false 作为关键字，GRUB 2.06 不兼容，强制用 gnu11
+export CFLAGS="-std=gnu11"
 
 
 #检测grub是否已经安装
@@ -55,7 +57,7 @@ install_options=("install -y" \
                      "-S --needed --noconfirm" \
 		     "install -y" \
 		     "install -y" \
-		     ""
+		     "-v"
 		)
 found_pm=0
 pm_index=0


### PR DESCRIPTION
1. change the env.mk to support some distro use x86_64-pc-linux-gnu p…
2. add `-std=gnu11` for grub_auto_install.sh to support GCC15