### PR TITLE
feat(namespace): enforce mount namespace limits

### DIFF
--- a/.github/workflows/test-x86.yml
+++ b/.github/workflows/test-x86.yml
@@ -10,6 +10,7 @@ on:
 env:
   ARCH: x86_64
   HOME: /root
+  DISK_SAVE_MODE: "1"
   RUSTUP_DIST_SERVER: "https://rsproxy.cn"
   RUSTUP_UPDATE_ROOT: "https://rsproxy.cn/rustup"
 
@@ -38,8 +39,6 @@ jobs:
       - name: Run syscall test
         id: test-syscall
         shell: bash -ileo pipefail {0}
-        env:
-          DISK_SAVE_MODE: "1"
         run: |
           make test-syscall
 

--- a/kernel/src/filesystem/procfs/sys/fs.rs
+++ b/kernel/src/filesystem/procfs/sys/fs.rs
@@ -9,7 +9,10 @@ use crate::{
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
     libs::mutex::MutexGuard,
-    process::namespace::mnt::{mount_max, set_mount_max},
+    process::{
+        namespace::mnt::{mount_max, set_mount_max},
+        ProcessManager,
+    },
 };
 use alloc::{
     format,
@@ -92,6 +95,12 @@ impl FileOps for MountMaxFileOps {
         buf: &[u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
+        // Linux rechecks a 0644 sysctl against the caller's global effective
+        // UID on every write. In particular, capabilities gained by entering
+        // a child user namespace must not authorize this global parameter.
+        if ProcessManager::current_pcb().cred().euid.data() != 0 {
+            return Err(SystemError::EPERM);
+        }
         // Linux strict numeric sysctls consume non-zero-offset writes without
         // changing the value.
         if offset != 0 {

--- a/kernel/src/filesystem/procfs/sys/fs.rs
+++ b/kernel/src/filesystem/procfs/sys/fs.rs
@@ -1,0 +1,171 @@
+//! /proc/sys/fs - filesystem-wide kernel parameters.
+
+use crate::{
+    filesystem::{
+        procfs::{
+            template::{Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder},
+            utils::proc_read,
+        },
+        vfs::{FilePrivateData, IndexNode, InodeMode},
+    },
+    libs::mutex::MutexGuard,
+    process::namespace::mnt::{mount_max, set_mount_max},
+};
+use alloc::{
+    format,
+    string::ToString,
+    sync::{Arc, Weak},
+};
+use system_error::SystemError;
+
+#[derive(Debug)]
+pub struct FsDirOps;
+
+impl FsDirOps {
+    pub fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcDirBuilder::new(Self, InodeMode::from_bits_truncate(0o555))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl DirOps for FsDirOps {
+    fn lookup_child(
+        &self,
+        dir: &ProcDir<Self>,
+        name: &str,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        if name != "mount-max" {
+            return Err(SystemError::ENOENT);
+        }
+        let mut cached_children = dir.cached_children().write();
+        if let Some(child) = cached_children.get(name) {
+            return Ok(child.clone());
+        }
+        let inode = MountMaxFileOps::new_inode(dir.self_ref_weak().clone());
+        cached_children.insert(name.to_string(), inode.clone());
+        Ok(inode)
+    }
+
+    fn populate_children(&self, dir: &ProcDir<Self>) {
+        let mut cached_children = dir.cached_children().write();
+        cached_children
+            .entry("mount-max".to_string())
+            .or_insert_with(|| MountMaxFileOps::new_inode(dir.self_ref_weak().clone()));
+    }
+}
+
+#[derive(Debug)]
+struct MountMaxFileOps;
+
+impl MountMaxFileOps {
+    fn new_inode(parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self, InodeMode::from_bits_truncate(0o644))
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+}
+
+impl FileOps for MountMaxFileOps {
+    fn read_at(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        // Numeric proc sysctls return EOF after the first read, regardless of
+        // where that non-zero offset falls in their textual representation.
+        if offset != 0 {
+            return Ok(0);
+        }
+        let content = format!("{}\n", mount_max());
+        proc_read(offset, len, buf, content.as_bytes())
+    }
+
+    fn write_at(
+        &self,
+        offset: usize,
+        _len: usize,
+        buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        // Linux strict numeric sysctls consume non-zero-offset writes without
+        // changing the value.
+        if offset != 0 {
+            return Ok(buf.len());
+        }
+        let (value, consumed) = parse_mount_max(buf)?;
+        if !(1..=i32::MAX as i64).contains(&value) {
+            return Err(SystemError::EINVAL);
+        }
+        set_mount_max(value as u32)?;
+        Ok(consumed)
+    }
+}
+
+/// Parse one Linux numeric-sysctl token. Linux consumes leading whitespace,
+/// one base-0 signed integer and the whitespace immediately following it. A
+/// later token is left for a short write rather than rejecting the first one.
+fn parse_mount_max(buf: &[u8]) -> Result<(i64, usize), SystemError> {
+    let mut cursor = 0;
+    while cursor < buf.len() && buf[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+
+    let token_start = cursor;
+    let negative = if buf.get(cursor) == Some(&b'-') {
+        cursor += 1;
+        true
+    } else {
+        false
+    };
+    let digits_start = cursor;
+    let (radix, prefix_len) = if buf.get(cursor) == Some(&b'0')
+        && matches!(buf.get(cursor + 1), Some(b'x' | b'X'))
+        && buf
+            .get(cursor + 2)
+            .is_some_and(|byte| byte.is_ascii_hexdigit())
+    {
+        (16u32, 2usize)
+    } else if buf.get(cursor) == Some(&b'0') {
+        (8u32, 0usize)
+    } else {
+        (10u32, 0usize)
+    };
+    cursor += prefix_len;
+    let number_start = cursor;
+    let mut magnitude = 0u64;
+    while let Some(byte) = buf.get(cursor) {
+        let Some(digit) = (*byte as char).to_digit(radix) else {
+            break;
+        };
+        magnitude = magnitude
+            .checked_mul(radix as u64)
+            .and_then(|value| value.checked_add(digit as u64))
+            .ok_or(SystemError::EINVAL)?;
+        cursor += 1;
+    }
+    if cursor == number_start || (prefix_len == 0 && cursor == digits_start) {
+        return Err(SystemError::EINVAL);
+    }
+    // Linux proc_get_long() uses TMPBUFLEN=22 and rejects a parsed token
+    // whose sign/prefix/digits reach TMPBUFLEN-1 bytes.
+    if cursor - token_start >= 21 {
+        return Err(SystemError::EINVAL);
+    }
+    if let Some(byte) = buf.get(cursor) {
+        if !matches!(byte, b' ' | b'\t' | b'\n') {
+            return Err(SystemError::EINVAL);
+        }
+    }
+
+    let magnitude = i64::try_from(magnitude).map_err(|_| SystemError::EINVAL)?;
+    let value = if negative { -magnitude } else { magnitude };
+    while cursor < buf.len() && buf[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    Ok((value, cursor))
+}

--- a/kernel/src/filesystem/procfs/sys/mod.rs
+++ b/kernel/src/filesystem/procfs/sys/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! 提供类似 Linux 的 /proc/sys 接口，支持动态配置内核参数
 
+mod fs;
 mod kernel;
 mod net;
 mod vm;
@@ -50,6 +51,16 @@ impl DirOps for SysDirOps {
             cached_children.insert(name.to_string(), inode.clone());
             return Ok(inode);
         }
+        if name == "fs" {
+            let mut cached_children = dir.cached_children().write();
+            if let Some(child) = cached_children.get(name) {
+                return Ok(child.clone());
+            }
+
+            let inode = FsDirOps::new_inode(dir.self_ref_weak().clone());
+            cached_children.insert(name.to_string(), inode.clone());
+            return Ok(inode);
+        }
         if name == "vm" {
             let mut cached_children = dir.cached_children().write();
             if let Some(child) = cached_children.get(name) {
@@ -80,6 +91,9 @@ impl DirOps for SysDirOps {
             .entry("kernel".to_string())
             .or_insert_with(|| KernelDirOps::new_inode(dir.self_ref_weak().clone()));
         cached_children
+            .entry("fs".to_string())
+            .or_insert_with(|| FsDirOps::new_inode(dir.self_ref_weak().clone()));
+        cached_children
             .entry("vm".to_string())
             .or_insert_with(|| VmDirOps::new_inode(dir.self_ref_weak().clone()));
         cached_children
@@ -87,3 +101,4 @@ impl DirOps for SysDirOps {
             .or_insert_with(|| NetDirOps::new_inode(dir.self_ref_weak().clone()));
     }
 }
+use fs::FsDirOps;

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -350,7 +350,7 @@ pub struct MountFS {
     /// Weak reference to this MountFS
     self_ref: Weak<MountFS>,
 
-    namespace: RwSem<Option<Weak<MntNamespace>>>,
+    namespace: RwSem<MountNamespaceMembership>,
     propagation: Arc<MountPropagation>,
     mount_id: MountId,
 
@@ -360,6 +360,12 @@ pub struct MountFS {
     /// Internal MNT_LOCKED equivalent; never exposed as a userspace MS_* bit.
     locked: AtomicBool,
     lifecycle: Mutex<MountLifecycle>,
+}
+
+#[derive(Debug, Default)]
+struct MountNamespaceMembership {
+    owner: Option<Weak<MntNamespace>>,
+    accounted: bool,
 }
 
 /// Capacity reserved for one future mount edge. Creating an empty map entry is
@@ -1105,7 +1111,7 @@ impl MountFS {
             tucked_under: AtomicBool::new(false),
             self_mountpoint: RwSem::new(self_mountpoint),
             self_ref: self_ref.clone(),
-            namespace: RwSem::new(None),
+            namespace: RwSem::new(MountNamespaceMembership::default()),
             propagation,
             mount_id: MountId::alloc(),
             mount_flags: RwSem::new(mount_flags),
@@ -1150,7 +1156,7 @@ impl MountFS {
             tucked_under: AtomicBool::new(self.tucked_under.load(Ordering::Acquire)),
             self_mountpoint: RwSem::new(self_mountpoint),
             self_ref: self_ref.clone(),
-            namespace: RwSem::new(None),
+            namespace: RwSem::new(MountNamespaceMembership::default()),
             propagation: new_propagation,
             mount_id: MountId::alloc(),
             mount_flags: RwSem::new(self.mount_flags()),
@@ -1636,6 +1642,21 @@ impl MountFS {
             .collect()
     }
 
+    pub(crate) fn try_mount_children(&self) -> Result<Vec<Arc<MountFS>>, SystemError> {
+        let mountpoints = self.mountpoints.lock();
+        let count = mountpoints.values().try_fold(0usize, |count, stack| {
+            count.checked_add(stack.len()).ok_or(SystemError::ENOMEM)
+        })?;
+        let mut children = Vec::new();
+        children
+            .try_reserve(count)
+            .map_err(|_| SystemError::ENOMEM)?;
+        for stack in mountpoints.values() {
+            children.extend(stack.iter().cloned());
+        }
+        Ok(children)
+    }
+
     pub fn mountpoints(&self) -> MutexGuard<'_, HashMap<DentryId, Vec<Arc<MountFS>>>> {
         self.mountpoints.lock()
     }
@@ -1683,15 +1704,75 @@ impl MountFS {
     }
 
     pub fn set_namespace(&self, namespace: Weak<MntNamespace>) {
-        *self.namespace.write() = Some(namespace);
+        let mut membership = self.namespace.write();
+        assert!(
+            !membership.accounted,
+            "an accounted mount cannot change namespace ownership"
+        );
+        if let Some(owner) = membership.owner.as_ref() {
+            assert!(
+                Weak::ptr_eq(owner, &namespace),
+                "a constructing mount cannot be rebound to another namespace"
+            );
+        }
+        membership.owner = Some(namespace);
     }
 
     pub fn namespace(&self) -> Option<Arc<MntNamespace>> {
-        self.namespace.read().as_ref().and_then(|ns| ns.upgrade())
+        self.namespace.read().owner.as_ref().and_then(Weak::upgrade)
     }
 
     pub fn clear_namespace(&self) {
-        *self.namespace.write() = None;
+        let mut membership = self.namespace.write();
+        assert!(
+            !membership.accounted,
+            "namespace accounting must be released before clearing ownership"
+        );
+        membership.owner = None;
+    }
+
+    pub(crate) fn can_mark_namespace_accounted(&self, namespace: &Arc<MntNamespace>) -> bool {
+        let expected = Arc::downgrade(namespace);
+        let membership = self.namespace.read();
+        !membership.accounted
+            && membership
+                .owner
+                .as_ref()
+                .is_some_and(|owner| Weak::ptr_eq(owner, &expected))
+    }
+
+    pub(crate) fn mark_namespace_accounted(&self, namespace: &Arc<MntNamespace>) {
+        self.mark_namespace_accounted_weak(&Arc::downgrade(namespace));
+    }
+
+    pub(crate) fn mark_namespace_accounted_weak(&self, namespace: &Weak<MntNamespace>) {
+        let mut membership = self.namespace.write();
+        assert!(
+            !membership.accounted
+                && membership
+                    .owner
+                    .as_ref()
+                    .is_some_and(|owner| Weak::ptr_eq(owner, namespace)),
+            "mount accounting must match its namespace owner"
+        );
+        membership.accounted = true;
+    }
+
+    pub(crate) fn take_namespace_accounted(&self, namespace: &Weak<MntNamespace>) -> bool {
+        let mut membership = self.namespace.write();
+        let owner_matches = membership
+            .owner
+            .as_ref()
+            .is_some_and(|owner| Weak::ptr_eq(owner, namespace));
+        assert!(
+            !membership.accounted || owner_matches,
+            "an accounted mount cannot be released by another namespace"
+        );
+        if !owner_matches || !membership.accounted {
+            return false;
+        }
+        membership.accounted = false;
+        true
     }
 
     /// check_mnt(): Check whether the current MountFS belongs to the specified mount namespace.
@@ -2043,23 +2124,29 @@ impl MountFS {
                 lifecycle.state = MountLifecycleState::Detaching;
             }
         }
+        let mut component_roots = vec![root.clone()];
+        for mount in mounts.iter().filter(|mount| !Arc::ptr_eq(mount, root)) {
+            if mount.is_locked() {
+                continue;
+            }
+            let parent = mount
+                .parent_mount()
+                .expect("validated lazy-detach descendant retains its parent edge");
+            parent
+                .detach_exact_restoring_cover(mount)
+                .expect("validated lazy-detach edge commit cannot fail");
+            mount.set_self_mountpoint(None);
+            component_roots.push(mount.clone());
+        }
+
+        // Every fallible topology decision is complete. Release namespace
+        // capacity only after the detached graph can no longer be rolled back.
         for mount in &mounts {
             if let Some(namespace) = mount.namespace() {
                 namespace.remove_mount_exact(mount);
             }
             mount.clear_namespace();
             mount.detach_propagation_once();
-        }
-
-        let mut component_roots = vec![root.clone()];
-        for mount in mounts.iter().filter(|mount| !Arc::ptr_eq(mount, root)) {
-            if mount.is_locked() {
-                continue;
-            }
-            let parent = mount.parent_mount().ok_or(SystemError::EINVAL)?;
-            parent.detach_exact_restoring_cover(mount)?;
-            mount.set_self_mountpoint(None);
-            component_roots.push(mount.clone());
         }
 
         for component_root in component_roots {
@@ -2335,40 +2422,6 @@ impl MountFS {
         }
 
         return result;
-    }
-
-    /// Recursively unmount a mount and all its child mounts, removing them from the namespace's mount_list.
-    ///
-    /// Used for atomic rollback on recursive bind mount failure, ensuring all-or-nothing semantics.
-    pub fn umount_tree(root: &Arc<MountFS>) {
-        let mntns = ProcessManager::current_mntns();
-
-        // 1. DFS collect all descendant MountFS
-        let mut all_descendants: Vec<Arc<MountFS>> = Vec::new();
-        let mut stack: Vec<Arc<MountFS>> = Vec::new();
-
-        for child_mfs in root.mount_children() {
-            stack.push(child_mfs);
-        }
-
-        while let Some(mfs) = stack.pop() {
-            for child_mfs in mfs.mount_children() {
-                stack.push(child_mfs);
-            }
-            all_descendants.push(mfs);
-        }
-
-        // 2. Process in reverse order (deepest child mounts first), ensuring child mounts are cleaned up before parent mounts
-        all_descendants.reverse();
-
-        for child_mfs in &all_descendants {
-            mntns.remove_mount_exact(child_mfs);
-            let _ = child_mfs.umount();
-        }
-
-        // 3. Finally unmount the root mount itself
-        mntns.remove_mount_exact(root);
-        let _ = root.umount();
     }
 
     /// Corresponds to Linux `sync_inodes_sb()`: write back all dirty page caches under the specified mount.

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -497,9 +497,6 @@ impl MntNamespace {
         if inner.mount_count.pending_mounts != 0 {
             return Err(SystemError::EBUSY);
         }
-        if inner.mount_count.mounts > mount_max() {
-            return Err(SystemError::ENOSPC);
-        }
 
         let old_root_mntfs = Self::root_mntfs_locked(&inner);
         let new_root_mntfs = old_root_mntfs.deepcopy(None)?;
@@ -546,13 +543,8 @@ impl MntNamespace {
         }
 
         let prepared_metadata = (|| {
-            let mut copied_for_accounting = Vec::new();
-            copied_for_accounting
-                .try_reserve(copied_mounts.len())
-                .map_err(|_| SystemError::ENOMEM)?;
-            copied_for_accounting.extend(copied_mounts.iter().map(|(_, new)| new.clone()));
             let copied_count =
-                u32::try_from(copied_for_accounting.len()).map_err(|_| SystemError::ENOSPC)?;
+                u32::try_from(copied_mounts.len()).map_err(|_| SystemError::ENOSPC)?;
             assert_eq!(
                 copied_count, inner.mount_count.mounts,
                 "namespace copy topology must match the source committed count"
@@ -567,9 +559,9 @@ impl MntNamespace {
                     .iter()
                     .map(|(old, new)| (Arc::downgrade(old), Arc::downgrade(new))),
             );
-            Ok::<_, SystemError>((copied_for_accounting, copy_sources))
+            Ok::<_, SystemError>((copied_count, copy_sources))
         })();
-        let (copied_for_accounting, copy_sources) = match prepared_metadata {
+        let (copied_count, copy_sources) = match prepared_metadata {
             Ok(metadata) => metadata,
             Err(error) => {
                 MountFS::deactivate_disconnected_subtree(&new_root_mntfs);
@@ -586,28 +578,22 @@ impl MntNamespace {
             inner: RwSem::new(InnerMntNamespace {
                 _dead: false,
                 root_mountfs: new_root_mntfs,
-                mount_count: MountCountState::default(),
+                // Linux copy_mnt_ns() initializes the copied namespace's
+                // existing mount count directly. mount-max only admits new
+                // mount trees; it must not reject cloning existing topology.
+                mount_count: MountCountState {
+                    mounts: copied_count,
+                    pending_mounts: 0,
+                },
                 copy_sources,
             }),
         });
-
-        let count_reservation = match new_mntns.reserve_mounts(copied_for_accounting) {
-            Ok(reservation) => reservation,
-            Err(error) => {
-                // MntNamespace::drop() takes the topology lock. Release the
-                // source snapshot and its outer lock before invoking the sole
-                // cleanup owner for this unpublished namespace.
-                drop(inner);
-                drop(_topology);
-                drop(new_mntns);
-                return Err(error);
-            }
-        };
 
         // Publication is infallible and occurs only after the detached copy is
         // complete, so observers can never see a partially copied namespace.
         for (_old_mount, new_mount) in copied_mounts {
             new_mount.set_namespace(Arc::downgrade(&new_mntns));
+            new_mount.mark_namespace_accounted(&new_mntns);
             let propagation = new_mount.propagation();
             if propagation.is_shared() {
                 register_peer(propagation.peer_group_id(), &new_mount);
@@ -619,7 +605,6 @@ impl MntNamespace {
                 .activate()
                 .expect("a detached namespace copy is published exactly once");
         }
-        count_reservation.commit();
 
         Ok(new_mntns)
     }

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -9,6 +9,7 @@ use crate::{
 use alloc::collections::VecDeque;
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use system_error::SystemError;
 
@@ -24,6 +25,70 @@ use super::{
 };
 
 static mut INIT_MNT_NAMESPACE: Option<Arc<MntNamespace>> = None;
+
+const DEFAULT_MOUNT_MAX: u32 = 100_000;
+static MOUNT_MAX: AtomicU32 = AtomicU32::new(DEFAULT_MOUNT_MAX);
+
+pub fn mount_max() -> u32 {
+    MOUNT_MAX.load(Ordering::Relaxed)
+}
+
+pub fn set_mount_max(value: u32) -> Result<(), SystemError> {
+    if value == 0 || value > i32::MAX as u32 {
+        return Err(SystemError::EINVAL);
+    }
+    MOUNT_MAX.store(value, Ordering::Relaxed);
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct MountCountState {
+    mounts: u32,
+    pending_mounts: u32,
+}
+
+impl MountCountState {
+    fn reserve(&mut self, amount: u32, limit: u32) -> Result<(), SystemError> {
+        let used = self
+            .mounts
+            .checked_add(self.pending_mounts)
+            .ok_or(SystemError::ENOSPC)?;
+        let remaining = limit.checked_sub(used).ok_or(SystemError::ENOSPC)?;
+        if amount > remaining {
+            return Err(SystemError::ENOSPC);
+        }
+        self.pending_mounts = self
+            .pending_mounts
+            .checked_add(amount)
+            .ok_or(SystemError::ENOSPC)?;
+        Ok(())
+    }
+
+    fn commit(&mut self, amount: u32) {
+        self.pending_mounts = self
+            .pending_mounts
+            .checked_sub(amount)
+            .expect("mount reservation commit exceeds pending count");
+        self.mounts = self
+            .mounts
+            .checked_add(amount)
+            .expect("committed mount count overflow after validated reservation");
+    }
+
+    fn abort(&mut self, amount: u32) {
+        self.pending_mounts = self
+            .pending_mounts
+            .checked_sub(amount)
+            .expect("mount reservation rollback exceeds pending count");
+    }
+
+    fn release(&mut self, amount: u32) {
+        self.mounts = self
+            .mounts
+            .checked_sub(amount)
+            .expect("mount teardown exceeds committed count");
+    }
+}
 
 /// Initialize the root mount namespace
 pub fn mnt_namespace_init() {
@@ -53,9 +118,46 @@ pub struct MntNamespace {
 pub struct InnerMntNamespace {
     _dead: bool,
     root_mountfs: Arc<MountFS>,
+    mount_count: MountCountState,
     /// Exact old-mount to copied-mount projection used to rebind fs_struct
     /// root/pwd after CLONE_NEWNS. This is object identity, never a pathname.
     copy_sources: Vec<(Weak<MountFS>, Weak<MountFS>)>,
+}
+
+pub(crate) struct MountCountReservation {
+    namespace: Arc<MntNamespace>,
+    mounts: Vec<Arc<MountFS>>,
+    pending: bool,
+}
+
+impl MountCountReservation {
+    pub(crate) fn commit(mut self) {
+        for mount in &self.mounts {
+            assert!(
+                mount.can_mark_namespace_accounted(&self.namespace),
+                "mount reservation ownership changed before commit"
+            );
+        }
+
+        let amount = u32::try_from(self.mounts.len())
+            .expect("validated mount reservation length remains representable");
+        self.namespace.inner.write().mount_count.commit(amount);
+        for mount in &self.mounts {
+            mount.mark_namespace_accounted(&self.namespace);
+        }
+        self.pending = false;
+    }
+}
+
+impl Drop for MountCountReservation {
+    fn drop(&mut self) {
+        if !self.pending {
+            return;
+        }
+        let amount = u32::try_from(self.mounts.len())
+            .expect("validated mount reservation length remains representable");
+        self.namespace.inner.write().mount_count.abort(amount);
+    }
 }
 
 fn tree_contains_unbindable(root: &Arc<MountFS>) -> bool {
@@ -98,6 +200,7 @@ impl MntNamespace {
             _user_ns: super::user_namespace::INIT_USER_NAMESPACE.clone(),
             inner: RwSem::new(InnerMntNamespace {
                 root_mountfs: ramfs.clone(),
+                mount_count: MountCountState::default(),
                 copy_sources: Vec::new(),
                 _dead: false,
             }),
@@ -124,6 +227,13 @@ impl MntNamespace {
         let mut inner_guard = self.inner.write();
         new_root.set_namespace(self.self_ref.clone());
         let old_root = core::mem::replace(&mut inner_guard.root_mountfs, new_root);
+        assert!(
+            old_root.take_namespace_accounted(&self.self_ref),
+            "the old namespace root must own one committed mount slot"
+        );
+        inner_guard
+            .root_mountfs
+            .mark_namespace_accounted_weak(&self.self_ref);
         drop(inner_guard);
 
         assert!(
@@ -384,6 +494,13 @@ impl MntNamespace {
         let inner = self.inner.read();
         let cross_user_namespace = !Arc::ptr_eq(&self._user_ns, &user_ns);
 
+        if inner.mount_count.pending_mounts != 0 {
+            return Err(SystemError::EBUSY);
+        }
+        if inner.mount_count.mounts > mount_max() {
+            return Err(SystemError::ENOSPC);
+        }
+
         let old_root_mntfs = Self::root_mntfs_locked(&inner);
         let new_root_mntfs = old_root_mntfs.deepcopy(None)?;
         restrict_cross_user_propagation(&old_root_mntfs, &new_root_mntfs, cross_user_namespace);
@@ -428,6 +545,38 @@ impl MntNamespace {
             return Err(error);
         }
 
+        let prepared_metadata = (|| {
+            let mut copied_for_accounting = Vec::new();
+            copied_for_accounting
+                .try_reserve(copied_mounts.len())
+                .map_err(|_| SystemError::ENOMEM)?;
+            copied_for_accounting.extend(copied_mounts.iter().map(|(_, new)| new.clone()));
+            let copied_count =
+                u32::try_from(copied_for_accounting.len()).map_err(|_| SystemError::ENOSPC)?;
+            assert_eq!(
+                copied_count, inner.mount_count.mounts,
+                "namespace copy topology must match the source committed count"
+            );
+
+            let mut copy_sources = Vec::new();
+            copy_sources
+                .try_reserve(copied_mounts.len())
+                .map_err(|_| SystemError::ENOMEM)?;
+            copy_sources.extend(
+                copied_mounts
+                    .iter()
+                    .map(|(old, new)| (Arc::downgrade(old), Arc::downgrade(new))),
+            );
+            Ok::<_, SystemError>((copied_for_accounting, copy_sources))
+        })();
+        let (copied_for_accounting, copy_sources) = match prepared_metadata {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                MountFS::deactivate_disconnected_subtree(&new_root_mntfs);
+                return Err(error);
+            }
+        };
+
         let mut ns_common = self.ns_common.clone();
         ns_common.level += 1;
         let new_mntns = Arc::new_cyclic(|self_ref| Self {
@@ -437,12 +586,23 @@ impl MntNamespace {
             inner: RwSem::new(InnerMntNamespace {
                 _dead: false,
                 root_mountfs: new_root_mntfs,
-                copy_sources: copied_mounts
-                    .iter()
-                    .map(|(old, new)| (Arc::downgrade(old), Arc::downgrade(new)))
-                    .collect(),
+                mount_count: MountCountState::default(),
+                copy_sources,
             }),
         });
+
+        let count_reservation = match new_mntns.reserve_mounts(copied_for_accounting) {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                // MntNamespace::drop() takes the topology lock. Release the
+                // source snapshot and its outer lock before invoking the sole
+                // cleanup owner for this unpublished namespace.
+                drop(inner);
+                drop(_topology);
+                drop(new_mntns);
+                return Err(error);
+            }
+        };
 
         // Publication is infallible and occurs only after the detached copy is
         // complete, so observers can never see a partially copied namespace.
@@ -459,6 +619,7 @@ impl MntNamespace {
                 .activate()
                 .expect("a detached namespace copy is published exactly once");
         }
+        count_reservation.commit();
 
         Ok(new_mntns)
     }
@@ -516,6 +677,7 @@ impl MntNamespace {
         if mntfs.is_live() {
             return Err(SystemError::EBUSY);
         }
+        let count_reservation = self.reserve_mounts(vec![mntfs.clone()])?;
         // Initialize namespace ownership before publishing the edge. Path
         // lookup reads mount edges without taking the global topology lock, so
         // it must never observe an attached mount with missing ownership.
@@ -559,6 +721,7 @@ impl MntNamespace {
             mntfs.clear_namespace();
             return Err(error);
         }
+        count_reservation.commit();
         Ok(())
     }
 
@@ -620,7 +783,37 @@ impl MntNamespace {
         if !mntfs.is_belongs_to_mntns(&self.self_ref.upgrade()?) {
             return None;
         }
+        if mntfs.take_namespace_accounted(&self.self_ref) {
+            self.inner.write().mount_count.release(1);
+        }
         Some(mntfs.clone())
+    }
+
+    pub(crate) fn reserve_mounts(
+        &self,
+        mut mounts: Vec<Arc<MountFS>>,
+    ) -> Result<MountCountReservation, SystemError> {
+        if mounts.is_empty() {
+            return Err(SystemError::EINVAL);
+        }
+        mounts.sort_unstable_by_key(|mount| mount.mount_id().data());
+        if mounts
+            .windows(2)
+            .any(|pair| pair[0].mount_id() == pair[1].mount_id())
+        {
+            return Err(SystemError::EINVAL);
+        }
+        let amount = u32::try_from(mounts.len()).map_err(|_| SystemError::ENOSPC)?;
+        let namespace = self.self_ref.upgrade().ok_or(SystemError::EINVAL)?;
+        self.inner
+            .write()
+            .mount_count
+            .reserve(amount, mount_max())?;
+        Ok(MountCountReservation {
+            namespace,
+            mounts,
+            pending: true,
+        })
     }
 }
 
@@ -659,6 +852,83 @@ impl Drop for MntNamespace {
         // superblock worker when the last mount/path reference is gone.
         let _topology = MOUNT_LIFECYCLE_LOCK.lock();
         let root = self.inner.read().root_mountfs.clone();
+        let mut pending = vec![root.clone()];
+        let mut released = 0u32;
+        while let Some(mount) = pending.pop() {
+            pending.extend(mount.mount_children());
+            if mount.take_namespace_accounted(&self.self_ref) {
+                released = released
+                    .checked_add(1)
+                    .expect("namespace teardown mount count overflow");
+            }
+        }
+        {
+            let mut inner = self.inner.write();
+            assert_eq!(
+                inner.mount_count.pending_mounts, 0,
+                "a mount namespace cannot drop with pending reservations"
+            );
+            assert_eq!(
+                inner.mount_count.mounts, released,
+                "namespace teardown must consume every committed mount exactly once"
+            );
+            inner.mount_count.mounts = 0;
+        }
         MountFS::deactivate_disconnected_subtree(&root);
+    }
+}
+
+#[cfg(test)]
+mod mount_count_tests {
+    use super::MountCountState;
+    use system_error::SystemError;
+
+    #[test]
+    fn exact_limit_succeeds_and_next_reservation_fails() {
+        let mut state = MountCountState {
+            mounts: 3,
+            pending_mounts: 2,
+        };
+        state.reserve(5, 10).unwrap();
+        assert_eq!(state.pending_mounts, 7);
+        assert_eq!(state.reserve(1, 10), Err(SystemError::ENOSPC));
+        assert_eq!(state.pending_mounts, 7);
+    }
+
+    #[test]
+    fn rollback_and_commit_transfer_only_their_own_pending_count() {
+        let mut state = MountCountState {
+            mounts: 4,
+            pending_mounts: 0,
+        };
+        state.reserve(3, 10).unwrap();
+        state.reserve(2, 10).unwrap();
+        state.abort(3);
+        assert_eq!(state.mounts, 4);
+        assert_eq!(state.pending_mounts, 2);
+        state.commit(2);
+        assert_eq!(state.mounts, 6);
+        assert_eq!(state.pending_mounts, 0);
+        state.release(2);
+        assert_eq!(state.mounts, 4);
+    }
+
+    #[test]
+    fn arithmetic_overflow_and_lowered_limit_leave_state_unchanged() {
+        let mut overflow = MountCountState {
+            mounts: u32::MAX,
+            pending_mounts: 1,
+        };
+        assert_eq!(overflow.reserve(1, u32::MAX), Err(SystemError::ENOSPC));
+        assert_eq!(overflow.mounts, u32::MAX);
+        assert_eq!(overflow.pending_mounts, 1);
+
+        let mut lowered = MountCountState {
+            mounts: 20,
+            pending_mounts: 0,
+        };
+        assert_eq!(lowered.reserve(1, 10), Err(SystemError::ENOSPC));
+        assert_eq!(lowered.mounts, 20);
+        assert_eq!(lowered.pending_mounts, 0);
     }
 }

--- a/kernel/src/process/namespace/propagation/event.rs
+++ b/kernel/src/process/namespace/propagation/event.rs
@@ -12,6 +12,7 @@ use crate::filesystem::vfs::{
     MountFS,
 };
 
+use super::super::mnt::MountCountReservation;
 use super::change::PreparedPropagationRemoval;
 use super::group::{
     apply_prepared_peer_groups, get_peers, prepare_peer_registrations, PreparedPeerGroupState,
@@ -45,7 +46,25 @@ pub(crate) struct PreparedPropagation {
     new_child: Arc<MountFS>,
     mounts: Vec<PreparedMount>,
     registrations: PreparedRegistrations,
+    count_reservations: Vec<MountCountReservation>,
     _local_reservation: MountEdgeReservation,
+}
+
+fn try_collect_subtree(root: &Arc<MountFS>) -> Result<Vec<Arc<MountFS>>, SystemError> {
+    let mut result = Vec::new();
+    let mut pending = Vec::new();
+    pending.try_reserve(1).map_err(|_| SystemError::ENOMEM)?;
+    pending.push(root.clone());
+    while let Some(mount) = pending.pop() {
+        let children = mount.try_mount_children()?;
+        pending
+            .try_reserve(children.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        pending.extend(children);
+        result.try_reserve(1).map_err(|_| SystemError::ENOMEM)?;
+        result.push(mount);
+    }
+    Ok(result)
 }
 
 pub(super) struct CorrespondingSources {
@@ -363,6 +382,15 @@ pub(crate) fn prepare_mount_propagation_locked(
     mountpoint: &Arc<MountFSInode>,
     new_child: &Arc<MountFS>,
 ) -> Result<Option<PreparedPropagation>, SystemError> {
+    prepare_mount_propagation_with_counting_locked(source_mnt, mountpoint, new_child, true)
+}
+
+fn prepare_mount_propagation_with_counting_locked(
+    source_mnt: &Arc<MountFS>,
+    mountpoint: &Arc<MountFSInode>,
+    new_child: &Arc<MountFS>,
+    count_local_tree: bool,
+) -> Result<Option<PreparedPropagation>, SystemError> {
     let source_prop = source_mnt.propagation();
     let canonical_mountpoint = source_mnt.wrapper_for_dentry(mountpoint.shared_dentry())?;
     if canonical_mountpoint.dentry_id() != mountpoint.dentry_id() {
@@ -375,6 +403,15 @@ pub(crate) fn prepare_mount_propagation_locked(
     let source_dentry = mountpoint.shared_dentry();
     let mut slave_groups = BTreeMap::new();
     let mut mounts = Vec::new();
+    let mut count_reservations = Vec::new();
+    if count_local_tree {
+        if let Some(namespace) = source_mnt.namespace() {
+            count_reservations
+                .try_reserve(1)
+                .map_err(|_| SystemError::ENOMEM)?;
+            count_reservations.push(namespace.reserve_mounts(try_collect_subtree(new_child)?)?);
+        }
+    }
     let mut propagated_sources = CorrespondingSources::new();
     propagated_sources.insert(source_mnt, new_child.clone());
     let targets = if source_prop.is_shared() {
@@ -401,6 +438,11 @@ pub(crate) fn prepare_mount_propagation_locked(
         if matches!(kind, PropagationTargetKind::Slave) && master_source.is_none() {
             continue;
         }
+        let target_namespace = target_parent.namespace();
+        if target_namespace.is_some() && count_reservations.try_reserve(1).is_err() {
+            abandon_prepared(&mounts);
+            return Err(SystemError::ENOMEM);
+        }
         let target_mp = match target_parent.wrapper_for_dentry(source_dentry.clone()) {
             Ok(mountpoint) => mountpoint,
             // Equivalent to Linux propagate_mnt skipping a peer whose bind
@@ -426,6 +468,18 @@ pub(crate) fn prepare_mount_propagation_locked(
                 return Err(error);
             }
         };
+        if let Some(namespace) = target_namespace {
+            let reservation =
+                match try_collect_subtree(&clone).and_then(|tree| namespace.reserve_mounts(tree)) {
+                    Ok(reservation) => reservation,
+                    Err(error) => {
+                        MountFS::deactivate_disconnected_subtree(&clone);
+                        abandon_prepared(&mounts);
+                        return Err(error);
+                    }
+                };
+            count_reservations.push(reservation);
+        }
         let target_reservation = if expected_top.is_none() {
             match target_parent.reserve_mount_edge(&target_mp, 1) {
                 Ok(reservation) => Some(reservation),
@@ -472,12 +526,14 @@ pub(crate) fn prepare_mount_propagation_locked(
             return Err(error);
         }
     };
+
     Ok(Some(PreparedPropagation {
         source_mnt: source_mnt.clone(),
         mountpoint: canonical_mountpoint,
         new_child: new_child.clone(),
         mounts,
         registrations,
+        count_reservations,
         _local_reservation: local_reservation,
     }))
 }
@@ -592,6 +648,9 @@ pub(crate) fn commit_mount_propagation_locked(
     }
 
     prepared.registrations.commit();
+    for reservation in prepared.count_reservations {
+        reservation.commit();
+    }
     Ok(())
 }
 
@@ -637,14 +696,18 @@ pub(crate) fn prepare_moved_tree_propagation_locked(
             prop.set_shared_with_group(group.clone());
         }
     }
-    let propagation =
-        match prepare_mount_propagation_locked(target_parent, moved_root_mountpoint, moved_root) {
-            Ok(propagation) => propagation,
-            Err(error) => {
-                restore_invented_groups(invented);
-                return Err(error);
-            }
-        };
+    let propagation = match prepare_mount_propagation_with_counting_locked(
+        target_parent,
+        moved_root_mountpoint,
+        moved_root,
+        false,
+    ) {
+        Ok(propagation) => propagation,
+        Err(error) => {
+            restore_invented_groups(invented);
+            return Err(error);
+        }
+    };
     Ok(PreparedMovePropagation {
         propagation,
         invented,

--- a/user/apps/tests/dunitest/suites/normal/mount_limit.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_limit.cc
@@ -273,20 +273,24 @@ TEST_F(MountLimitTest, PropagationAndSharedMoveReserveCompleteCopies) {
     EXPECT_EQ(before, mount_count());
 }
 
-TEST_F(MountLimitTest, NamespaceCopyAndConcurrentCreatorsCannotExceedLimit) {
+TEST_F(MountLimitTest, NamespaceCopyIgnoresLoweredLimitAndCreatorsRespectIt) {
     int before = mount_count();
     ASSERT_GT(before, 1);
     ASSERT_EQ(0, write_mount_max(before - 1)) << strerror(errno);
-    errno = 0;
-    EXPECT_EQ(-1, unshare(CLONE_NEWNS));
-    EXPECT_EQ(ENOSPC, errno);
-    EXPECT_EQ(before, mount_count());
-    ASSERT_EQ(0, write_mount_max(before)) << strerror(errno);
     ASSERT_EQ(0, unshare(CLONE_NEWNS)) << strerror(errno);
     EXPECT_EQ(before, mount_count());
 
     const std::string p1 = dir("/p1");
     const std::string p2 = dir("/p2");
+    errno = 0;
+    EXPECT_EQ(-1, mount("none", p1.c_str(), "ramfs", 0, nullptr));
+    EXPECT_EQ(ENOSPC, errno);
+    EXPECT_EQ(before, mount_count());
+
+    ASSERT_EQ(0, write_mount_max(before)) << strerror(errno);
+    ASSERT_EQ(0, unshare(CLONE_NEWNS)) << strerror(errno);
+    EXPECT_EQ(before, mount_count());
+
     ASSERT_EQ(0, write_mount_max(before + 1)) << strerror(errno);
     std::atomic<int> ready{0};
     std::atomic<bool> go{false};

--- a/user/apps/tests/dunitest/suites/normal/mount_limit.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_limit.cc
@@ -11,9 +11,13 @@
 #include <string>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
 
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER 0x10000000
+#endif
 #ifndef CLONE_NEWNS
 #define CLONE_NEWNS 0x00020000
 #endif
@@ -199,6 +203,83 @@ TEST_F(MountLimitTest, SysctlMatchesLinuxNumericSemantics) {
     EXPECT_EQ(12, read_mount_max());
     ASSERT_EQ(0, write_mount_max_text(" 12345 \n")) << strerror(errno);
     EXPECT_EQ(12345, read_mount_max());
+}
+
+TEST_F(MountLimitTest, SysctlWritePermissionUsesGlobalEffectiveUid) {
+    const int candidate = original_max_ - 1;
+    char text[32] = {};
+    const int text_len = snprintf(text, sizeof(text), "%d\n", candidate);
+    ASSERT_GT(text_len, 0);
+    ASSERT_LT(static_cast<size_t>(text_len), sizeof(text));
+
+    int inherited_fd = open(kMountMaxPath, O_WRONLY);
+    ASSERT_GE(inherited_fd, 0) << strerror(errno);
+    pid_t child = fork();
+    if (child < 0) {
+        const int saved_errno = errno;
+        close(inherited_fd);
+        errno = saved_errno;
+    }
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(1000) != 0) {
+            _exit(10);
+        }
+        if (setuid(1000) != 0) {
+            _exit(11);
+        }
+        if (unshare(CLONE_NEWUSER) != 0) {
+            _exit(12);
+        }
+
+        errno = 0;
+        if (pwrite(inherited_fd, text, static_cast<size_t>(text_len), 0) != -1 ||
+            errno != EPERM) {
+            _exit(13);
+        }
+        close(inherited_fd);
+
+        errno = 0;
+        int reopened_fd = open(kMountMaxPath, O_WRONLY);
+        if (reopened_fd < 0) {
+            _exit(errno == EACCES || errno == EPERM ? 0 : 14);
+        }
+        errno = 0;
+        const ssize_t written = write(reopened_fd, text, static_cast<size_t>(text_len));
+        const int write_errno = errno;
+        close(reopened_fd);
+        _exit(written == -1 && write_errno == EPERM ? 0 : 15);
+    }
+    close(inherited_fd);
+
+    int status = 0;
+    pid_t waited = -1;
+    do {
+        waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    ASSERT_EQ(child, waited) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+    EXPECT_EQ(original_max_, read_mount_max());
+    ASSERT_EQ(0, write_mount_max(original_max_)) << strerror(errno);
+
+    child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (unshare(CLONE_NEWUSER) != 0) {
+            _exit(20);
+        }
+        _exit(write_mount_max(candidate) == 0 ? 0 : 21);
+    }
+    status = 0;
+    do {
+        waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    ASSERT_EQ(child, waited) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+    EXPECT_EQ(candidate, read_mount_max());
+    ASSERT_EQ(0, write_mount_max(original_max_)) << strerror(errno);
 }
 
 TEST_F(MountLimitTest, SimpleBoundaryAndUnmountReleaseCapacity) {

--- a/user/apps/tests/dunitest/suites/normal/mount_limit.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_limit.cc
@@ -1,0 +1,323 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <sched.h>
+#include <string>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+
+#ifndef CLONE_NEWNS
+#define CLONE_NEWNS 0x00020000
+#endif
+#ifndef MS_REC
+#define MS_REC 16384
+#endif
+#ifndef MS_PRIVATE
+#define MS_PRIVATE (1UL << 18)
+#endif
+#ifndef MS_SHARED
+#define MS_SHARED (1UL << 20)
+#endif
+#ifndef MS_MOVE
+#define MS_MOVE 8192
+#endif
+
+namespace {
+
+constexpr char kMountMaxPath[] = "/proc/sys/fs/mount-max";
+
+int ensure_dir(const std::string& path) {
+    struct stat st = {};
+    if (stat(path.c_str(), &st) == 0) {
+        return S_ISDIR(st.st_mode) ? 0 : -1;
+    }
+    return mkdir(path.c_str(), 0755);
+}
+
+int read_mount_max() {
+    int fd = open(kMountMaxPath, O_RDONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    char buf[64] = {};
+    const ssize_t n = read(fd, buf, sizeof(buf) - 1);
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    if (n <= 0) {
+        return -1;
+    }
+    char* end = nullptr;
+    const long value = strtol(buf, &end, 10);
+    return end == buf || value < 1 || value > INT_MAX ? -1 : static_cast<int>(value);
+}
+
+int write_mount_max_text(const char* text) {
+    int fd = open(kMountMaxPath, O_WRONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    const size_t len = strlen(text);
+    const ssize_t written = write(fd, text, len);
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return written == static_cast<ssize_t>(len) ? 0 : -1;
+}
+
+ssize_t write_mount_max_text_raw(const char* text) {
+    int fd = open(kMountMaxPath, O_WRONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    const ssize_t written = write(fd, text, strlen(text));
+    const int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return written;
+}
+
+int write_mount_max(int value) {
+    char buf[32] = {};
+    snprintf(buf, sizeof(buf), "%d\n", value);
+    return write_mount_max_text(buf);
+}
+
+int mount_count() {
+    FILE* file = fopen("/proc/self/mountinfo", "r");
+    if (file == nullptr) {
+        return -1;
+    }
+    int count = 0;
+    char line[2048] = {};
+    while (fgets(line, sizeof(line), file) != nullptr) {
+        ++count;
+    }
+    fclose(file);
+    return count;
+}
+
+int mountpoint_count(const std::string& path) {
+    FILE* file = fopen("/proc/self/mountinfo", "r");
+    if (file == nullptr) {
+        return -1;
+    }
+    int count = 0;
+    char line[2048] = {};
+    while (fgets(line, sizeof(line), file) != nullptr) {
+        char mountpoint[1024] = {};
+        if (sscanf(line, "%*s %*s %*s %*s %1023s", mountpoint) == 1 &&
+            path == mountpoint) {
+            ++count;
+        }
+    }
+    fclose(file);
+    return count;
+}
+
+void detach_all(const std::string& path) {
+    for (int i = 0; i < 64; ++i) {
+        if (umount2(path.c_str(), MNT_DETACH) == 0) {
+            continue;
+        }
+        if (errno == EINVAL || errno == ENOENT) {
+            return;
+        }
+        return;
+    }
+}
+
+class MountLimitTest : public ::testing::Test {
+protected:
+    std::string root_;
+    int original_max_ = -1;
+
+    void SetUp() override {
+        original_max_ = read_mount_max();
+        ASSERT_EQ(100000, original_max_);
+        ASSERT_EQ(0, unshare(CLONE_NEWNS)) << strerror(errno);
+        ASSERT_EQ(0, mount(nullptr, "/", nullptr, MS_REC | MS_PRIVATE, nullptr))
+            << strerror(errno);
+        static std::atomic<unsigned int> sequence{0};
+        root_ = "/tmp/mount_limit_" + std::to_string(getpid()) + "_" +
+                std::to_string(sequence.fetch_add(1));
+        ASSERT_EQ(0, ensure_dir("/tmp")) << strerror(errno);
+        ASSERT_EQ(0, ensure_dir(root_)) << strerror(errno);
+    }
+
+    void TearDown() override {
+        if (original_max_ > 0) {
+            EXPECT_EQ(0, write_mount_max(original_max_)) << strerror(errno);
+        }
+        const char* suffixes[] = {
+            "/a/child", "/b/child", "/a/mp", "/b/mp", "/rec/a/b",
+            "/rec/a",   "/extra",   "/p1",   "/p2",   "/dst",
+            "/src",     "/b",       "/a",    "/c",
+        };
+        for (const char* suffix : suffixes) {
+            detach_all(root_ + suffix);
+        }
+    }
+
+    std::string dir(const char* suffix) {
+        const std::string path = root_ + suffix;
+        EXPECT_EQ(0, ensure_dir(path)) << path << ": " << strerror(errno);
+        return path;
+    }
+};
+
+TEST_F(MountLimitTest, SysctlMatchesLinuxNumericSemantics) {
+    int fd = open(kMountMaxPath, O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    char partial[4] = {};
+    ASSERT_EQ(0, pread(fd, partial, 3, 1)) << strerror(errno);
+    ASSERT_EQ(3, pwrite(fd, "123", 3, 1)) << strerror(errno);
+    EXPECT_EQ(original_max_, read_mount_max());
+    close(fd);
+
+    errno = 0;
+    EXPECT_EQ(-1, write_mount_max_text("0\n"));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, write_mount_max_text("-1\n"));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, write_mount_max_text("2147483648\n"));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, write_mount_max_text("000000000000000000001\n"));
+    EXPECT_EQ(EINVAL, errno);
+    ASSERT_EQ(3, write_mount_max_text_raw("12 garbage\n")) << strerror(errno);
+    EXPECT_EQ(12, read_mount_max());
+    ASSERT_EQ(0, write_mount_max_text(" 12345 \n")) << strerror(errno);
+    EXPECT_EQ(12345, read_mount_max());
+}
+
+TEST_F(MountLimitTest, SimpleBoundaryAndUnmountReleaseCapacity) {
+    const std::string p1 = dir("/p1");
+    const std::string p2 = dir("/p2");
+    const int before = mount_count();
+    ASSERT_GT(before, 0);
+    ASSERT_EQ(0, write_mount_max(before + 1)) << strerror(errno);
+    ASSERT_EQ(0, mount("none", p1.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(-1, mount("none", p2.c_str(), "ramfs", 0, nullptr));
+    EXPECT_EQ(ENOSPC, errno);
+    EXPECT_EQ(before + 1, mount_count());
+    ASSERT_EQ(0, umount(p1.c_str())) << strerror(errno);
+    ASSERT_EQ(0, mount("none", p2.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+}
+
+TEST_F(MountLimitTest, RecursiveBindFailureIsInvisibleAndReservationRollsBack) {
+    const std::string rec = dir("/rec");
+    const std::string a = dir("/rec/a");
+    const std::string b = dir("/rec/a/b");
+    const std::string c = dir("/c");
+    (void)rec;
+    ASSERT_EQ(0, mount(a.c_str(), a.c_str(), nullptr, MS_BIND, nullptr)) << strerror(errno);
+    const int before = mount_count();
+    ASSERT_EQ(0, write_mount_max(before + 3)) << strerror(errno);
+    ASSERT_EQ(0, mount(a.c_str(), b.c_str(), nullptr, MS_BIND | MS_REC, nullptr))
+        << strerror(errno);
+    ASSERT_EQ(0, mount(a.c_str(), b.c_str(), nullptr, MS_BIND | MS_REC, nullptr))
+        << strerror(errno);
+    const int at_limit = mount_count();
+    ASSERT_EQ(before + 3, at_limit);
+    errno = 0;
+    EXPECT_EQ(-1, mount(a.c_str(), b.c_str(), nullptr, MS_BIND | MS_REC, nullptr));
+    EXPECT_EQ(ENOSPC, errno);
+    EXPECT_EQ(at_limit, mount_count());
+    detach_all(b);
+    ASSERT_EQ(0, mount("none", c.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+}
+
+TEST_F(MountLimitTest, PropagationAndSharedMoveReserveCompleteCopies) {
+    const std::string a = dir("/a");
+    const std::string b = dir("/b");
+    const std::string src = dir("/src");
+    ASSERT_EQ(0, mount("none", a.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+    const std::string child = dir("/a/child");
+    const std::string move_point = dir("/a/mp");
+    ASSERT_EQ(0, mount(nullptr, a.c_str(), nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(a.c_str(), b.c_str(), nullptr, MS_BIND, nullptr)) << strerror(errno);
+    const std::string peer_child = root_ + "/b/child";
+    const std::string peer_move_point = root_ + "/b/mp";
+
+    int before = mount_count();
+    ASSERT_EQ(0, write_mount_max(before + 1)) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(-1, mount("none", child.c_str(), "ramfs", 0, nullptr));
+    EXPECT_EQ(ENOSPC, errno);
+    EXPECT_EQ(before, mount_count());
+    EXPECT_EQ(0, mountpoint_count(child));
+    EXPECT_EQ(0, mountpoint_count(peer_child));
+
+    ASSERT_EQ(0, write_mount_max(original_max_)) << strerror(errno);
+    ASSERT_EQ(0, mount("none", src.c_str(), "ramfs", 0, nullptr)) << strerror(errno);
+    before = mount_count();
+    ASSERT_EQ(0, write_mount_max(before)) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(-1, mount(src.c_str(), move_point.c_str(), nullptr, MS_MOVE, nullptr));
+    EXPECT_EQ(ENOSPC, errno);
+    EXPECT_EQ(1, mountpoint_count(src));
+    EXPECT_EQ(0, mountpoint_count(move_point));
+    EXPECT_EQ(0, mountpoint_count(peer_move_point));
+    EXPECT_EQ(before, mount_count());
+}
+
+TEST_F(MountLimitTest, NamespaceCopyAndConcurrentCreatorsCannotExceedLimit) {
+    int before = mount_count();
+    ASSERT_GT(before, 1);
+    ASSERT_EQ(0, write_mount_max(before - 1)) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(-1, unshare(CLONE_NEWNS));
+    EXPECT_EQ(ENOSPC, errno);
+    EXPECT_EQ(before, mount_count());
+    ASSERT_EQ(0, write_mount_max(before)) << strerror(errno);
+    ASSERT_EQ(0, unshare(CLONE_NEWNS)) << strerror(errno);
+    EXPECT_EQ(before, mount_count());
+
+    const std::string p1 = dir("/p1");
+    const std::string p2 = dir("/p2");
+    ASSERT_EQ(0, write_mount_max(before + 1)) << strerror(errno);
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    int results[2] = {};
+    int errors[2] = {};
+    auto creator = [&](int index, const std::string& path) {
+        ready.fetch_add(1);
+        while (!go.load()) {
+            std::this_thread::yield();
+        }
+        results[index] = mount("none", path.c_str(), "ramfs", 0, nullptr);
+        errors[index] = errno;
+    };
+    std::thread first(creator, 0, p1);
+    std::thread second(creator, 1, p2);
+    while (ready.load() != 2) {
+        std::this_thread::yield();
+    }
+    go.store(true);
+    first.join();
+    second.join();
+    const int successes = (results[0] == 0) + (results[1] == 0);
+    EXPECT_EQ(1, successes);
+    EXPECT_TRUE((results[0] == -1 && errors[0] == ENOSPC) ||
+                (results[1] == -1 && errors[1] == ENOSPC));
+    EXPECT_EQ(before + 1, mount_count());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -19,6 +19,7 @@ normal/test_pivot_root
 normal/mount_reconfigure
 normal/mount_propagation
 normal/mount_move
+normal/mount_limit
 normal/mount_object_topology
 normal/overlayfs_semantics
 normal/overlayfs_mount_validation


### PR DESCRIPTION
## Summary

- add Linux-compatible committed/pending mount accounting per mount namespace
- reserve complete recursive and propagated trees before publication and return `ENOSPC` atomically
- expose `/proc/sys/fs/mount-max` with Linux 6.6 numeric sysctl semantics and the 100,000 default
- release capacity exactly once across normal unmount, lazy detach, propagation teardown, and namespace destruction
- enforce limits for namespace copies, including concurrent `mount-max` changes without cleanup deadlocks

## Design

Mount admission uses RAII reservations tied to the exact `MountFS` objects that will be published. Local trees are reserved first; propagation then follows Linux's incremental model by reserving each cloned peer/slave tree immediately after construction. Failed operations stop constructing further copies, remain invisible to lookup, and roll back pending capacity automatically.

Each mount carries namespace membership plus a one-shot accounted bit. This makes successful teardown consume capacity exactly once while detached construction and rollback never decrement committed mounts. Namespace-copy failure paths have a single cleanup owner and release the topology lock before namespace destruction.

The new procfs handler matches Linux numeric sysctl behavior for nonzero offsets, base-0 parsing, range validation, token-length limits, and short writes.

## Validation

- `make kernel`
- `mount_limit_test`: 5/5 passed
- `mount_object_topology_test`: 9/9 passed
- `mount_propagation_test`: 19/19 passed
- `mount_move_test`: 11/11 passed
- gVisor `MountTest.MaxRecursiveBind` with `mount-max=1024`: passed

Fixes #2102
