### PR TITLE
fix(namespace): lock cross-user mount copies

### DIFF
--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -30,6 +30,7 @@ use crate::{
                 prepare_mount_propagation_locked, propagate_umount_sources,
                 propagation_umount_busy, MountPropagation,
             },
+            user_namespace::UserNamespace,
         },
         ProcessManager,
     },
@@ -45,7 +46,7 @@ use core::{
     cell::RefCell,
     fmt::Debug,
     hash::Hash,
-    sync::atomic::{compiler_fence, AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{compiler_fence, AtomicBool, AtomicU32, AtomicUsize, Ordering},
 };
 use hashbrown::HashMap;
 use ida::IdAllocator;
@@ -282,6 +283,23 @@ impl MountFlags {
     }
 }
 
+bitflags! {
+    /// Internal per-mount locks corresponding to Linux `MNT_LOCK_*` flags.
+    ///
+    /// These are deliberately separate from userspace-visible `MS_*` flags:
+    /// topology locking and attribute locking have different lifetimes. In
+    /// particular, a mount propagated across a user-namespace boundary may
+    /// have its topology lock cleared while retaining all attribute locks.
+    struct MountLockFlags: u32 {
+        const TOPOLOGY = 1 << 0;
+        const ATIME = 1 << 1;
+        const READONLY = 1 << 2;
+        const NODEV = 1 << 3;
+        const NOSUID = 1 << 4;
+        const NOEXEC = 1 << 5;
+    }
+}
+
 pub(crate) fn append_comma_options(base: &mut String, extra: String) {
     if extra.is_empty() {
         return;
@@ -357,8 +375,8 @@ pub struct MountFS {
     mount_flags: RwSem<MountFlags>,
     super_block_state: Arc<SuperBlockState>,
     mount_source: RwSem<Option<String>>,
-    /// Internal MNT_LOCKED equivalent; never exposed as a userspace MS_* bit.
-    locked: AtomicBool,
+    /// Internal `MNT_LOCK_*` state; never exposed as userspace `MS_*` bits.
+    mount_locks: AtomicU32,
     lifecycle: Mutex<MountLifecycle>,
 }
 
@@ -520,6 +538,9 @@ unsafe impl Sync for MountExternalGuard {}
 
 #[derive(Debug)]
 pub struct SuperBlockState {
+    /// User namespace that owns this superblock, matching Linux `s_user_ns`.
+    /// Bind mounts and mount-namespace copies retain the same owner.
+    owner_user_ns: Arc<UserNamespace>,
     flags: RwSem<MountFlags>,
     write_count: AtomicUsize,
     wb_error: ErrSeq,
@@ -696,6 +717,7 @@ struct MountStateInit {
 impl SuperBlockState {
     pub fn new(flags: MountFlags) -> Self {
         Self {
+            owner_user_ns: ProcessManager::current_user_ns(),
             flags: RwSem::new(flags & MountFlags::SB_SETTABLE_MASK),
             write_count: AtomicUsize::new(0),
             wb_error: ErrSeq::new(),
@@ -710,6 +732,10 @@ impl SuperBlockState {
             }),
             shutdown_wait: WaitQueue::default(),
         }
+    }
+
+    pub fn owner_user_ns(&self) -> &Arc<UserNamespace> {
+        &self.owner_user_ns
     }
 
     fn activate_mount(&self, construction_reserved: bool) -> Result<(), SystemError> {
@@ -1117,7 +1143,7 @@ impl MountFS {
             mount_flags: RwSem::new(mount_flags),
             super_block_state: state_init.super_block_state,
             mount_source: RwSem::new(state_init.mount_source),
-            locked: AtomicBool::new(false),
+            mount_locks: AtomicU32::new(0),
             lifecycle: Mutex::new(MountLifecycle {
                 state: MountLifecycleState::Constructing,
                 external_pins: 0,
@@ -1162,7 +1188,7 @@ impl MountFS {
             mount_flags: RwSem::new(self.mount_flags()),
             super_block_state: self.super_block_state.clone(),
             mount_source: RwSem::new(mount_source),
-            locked: AtomicBool::new(self.locked.load(Ordering::Acquire)),
+            mount_locks: AtomicU32::new(self.mount_locks.load(Ordering::Acquire)),
             lifecycle: Mutex::new(MountLifecycle {
                 state: MountLifecycleState::Constructing,
                 external_pins: 0,
@@ -1793,15 +1819,61 @@ impl MountFS {
     }
 
     pub(crate) fn lock_mount(&self) {
-        self.locked.store(true, Ordering::Release);
+        self.mount_locks
+            .fetch_or(MountLockFlags::TOPOLOGY.bits(), Ordering::Release);
     }
 
     pub(crate) fn unlock_mount(&self) {
-        self.locked.store(false, Ordering::Release);
+        self.mount_locks
+            .fetch_and(!MountLockFlags::TOPOLOGY.bits(), Ordering::Release);
     }
 
     pub(crate) fn is_locked(&self) -> bool {
-        self.locked.load(Ordering::Acquire)
+        self.mount_locks.load(Ordering::Acquire) & MountLockFlags::TOPOLOGY.bits() != 0
+    }
+
+    /// Linux `lock_mnt_tree()` semantics for mounts copied across a user
+    /// namespace boundary. Attribute locks snapshot per-mount flags only;
+    /// superblock flags have separate ownership and reconfiguration rules.
+    pub(crate) fn lock_cross_user_mount(&self) {
+        let mount_flags = self.mount_flags();
+        let mut locks = MountLockFlags::TOPOLOGY | MountLockFlags::ATIME;
+        if mount_flags.contains(MountFlags::RDONLY) {
+            locks.insert(MountLockFlags::READONLY);
+        }
+        if mount_flags.contains(MountFlags::NODEV) {
+            locks.insert(MountLockFlags::NODEV);
+        }
+        if mount_flags.contains(MountFlags::NOSUID) {
+            locks.insert(MountLockFlags::NOSUID);
+        }
+        if mount_flags.contains(MountFlags::NOEXEC) {
+            locks.insert(MountLockFlags::NOEXEC);
+        }
+        self.mount_locks.fetch_or(locks.bits(), Ordering::Release);
+    }
+
+    /// Linux `can_change_locked_flags()` equivalent for remount admission.
+    /// Locks prevent relaxing attributes that were present at lock time and
+    /// prevent changing the atime policy, while still allowing stricter flags
+    /// that were not locked to be added.
+    pub(crate) fn can_reconfigure_mount_flags(&self, requested: MountFlags) -> bool {
+        let locks = MountLockFlags::from_bits_truncate(self.mount_locks.load(Ordering::Acquire));
+        if locks.contains(MountLockFlags::READONLY) && !requested.contains(MountFlags::RDONLY) {
+            return false;
+        }
+        if locks.contains(MountLockFlags::NODEV) && !requested.contains(MountFlags::NODEV) {
+            return false;
+        }
+        if locks.contains(MountLockFlags::NOSUID) && !requested.contains(MountFlags::NOSUID) {
+            return false;
+        }
+        if locks.contains(MountLockFlags::NOEXEC) && !requested.contains(MountFlags::NOEXEC) {
+            return false;
+        }
+        !locks.contains(MountLockFlags::ATIME)
+            || (self.mount_flags() & MountFlags::MNT_ATIME_MASK)
+                == (requested & MountFlags::MNT_ATIME_MASK)
     }
 
     #[inline(never)]
@@ -2019,6 +2091,11 @@ impl MountFS {
 
     pub(crate) fn has_external_pins(&self) -> bool {
         self.lifecycle.lock().external_pins != 0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn superblock_external_pin_count(&self) -> usize {
+        self.super_block_state.lifecycle.lock().external_pins
     }
 
     pub(crate) fn subtree_has_external_pins(&self) -> bool {

--- a/kernel/src/filesystem/vfs/syscall/sys_mount.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mount.rs
@@ -324,6 +324,9 @@ fn do_reconfigure_bind_mount(
     if !target_mfs.is_live() || !target_mfs.is_belongs_to_mntns(&current_mntns) {
         return Err(SystemError::EINVAL);
     }
+    if !target_mfs.can_reconfigure_mount_flags(requested_flags) {
+        return Err(SystemError::EPERM);
+    }
     target_mfs.update_mount_flags(|mount_flags| {
         let preserved = *mount_flags & !MountFlags::MNT_USER_SETTABLE_MASK;
         let new_settable = requested_flags & MountFlags::MNT_USER_SETTABLE_MASK;
@@ -366,9 +369,17 @@ fn do_remount(
         if !target_mfs.is_live() || !target_mfs.is_belongs_to_mntns(&current_mntns) {
             return Err(SystemError::EINVAL);
         }
+        if !target_mfs.can_reconfigure_mount_flags(requested_mnt_flags) {
+            return Err(SystemError::EPERM);
+        }
     }
     let old_sb_flags = target_mfs.super_block_flags();
     let (data_sb_flags, data_sb_flags_mask, fs_private_data) = parse_remount_data(data.as_deref())?;
+    // Linux do_remount() requires CAP_SYS_ADMIN in sb->s_user_ns before a
+    // legacy remount may change shared superblock or filesystem-private state.
+    if !ns_capable(super_block_state.owner_user_ns(), CAPFlags::CAP_SYS_ADMIN) {
+        return Err(SystemError::EPERM);
+    }
     let sb_flags_mask = MountFlags::RMT_MASK | data_sb_flags_mask;
     let requested_sb_flags = (requested_sb_flags & !data_sb_flags_mask) | data_sb_flags;
     let new_sb_flags = (old_sb_flags & !sb_flags_mask) | (requested_sb_flags & sb_flags_mask);

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -17,8 +17,7 @@ use super::{
     nsproxy::NsCommon,
     propagation::{
         abort_moved_tree_propagation_locked, commit_moved_tree_propagation_locked,
-        prepare_moved_tree_propagation_locked, register_peer, register_slave_with_master,
-        MountPropagation,
+        prepare_moved_tree_propagation_locked, MountPropagation, PreparedRegistrations,
     },
     user_namespace::UserNamespace,
     NamespaceOps,
@@ -28,6 +27,10 @@ static mut INIT_MNT_NAMESPACE: Option<Arc<MntNamespace>> = None;
 
 const DEFAULT_MOUNT_MAX: u32 = 100_000;
 static MOUNT_MAX: AtomicU32 = AtomicU32::new(DEFAULT_MOUNT_MAX);
+
+#[cfg(test)]
+static FAIL_COPY_REGISTRATION_PREPARE: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 
 pub fn mount_max() -> u32 {
     MOUNT_MAX.load(Ordering::Relaxed)
@@ -569,6 +572,20 @@ impl MntNamespace {
             }
         };
 
+        #[cfg(test)]
+        if FAIL_COPY_REGISTRATION_PREPARE.swap(false, Ordering::AcqRel) {
+            MountFS::deactivate_disconnected_subtree(&new_root_mntfs);
+            return Err(SystemError::ENOMEM);
+        }
+        let prepared_registrations =
+            match PreparedRegistrations::prepare_iter(copied_mounts.iter().map(|(_, copy)| copy)) {
+                Ok(registrations) => registrations,
+                Err(error) => {
+                    MountFS::deactivate_disconnected_subtree(&new_root_mntfs);
+                    return Err(error);
+                }
+            };
+
         let mut ns_common = self.ns_common.clone();
         ns_common.level += 1;
         let new_mntns = Arc::new_cyclic(|self_ref| Self {
@@ -594,17 +611,11 @@ impl MntNamespace {
         for (_old_mount, new_mount) in copied_mounts {
             new_mount.set_namespace(Arc::downgrade(&new_mntns));
             new_mount.mark_namespace_accounted(&new_mntns);
-            let propagation = new_mount.propagation();
-            if propagation.is_shared() {
-                register_peer(propagation.peer_group_id(), &new_mount);
-            }
-            if propagation.is_slave() {
-                register_slave_with_master(&new_mount);
-            }
             new_mount
                 .activate()
                 .expect("a detached namespace copy is published exactly once");
         }
+        prepared_registrations.commit();
 
         Ok(new_mntns)
     }
@@ -810,7 +821,7 @@ fn restrict_cross_user_propagation(
     if !cross_user_namespace {
         return;
     }
-    copy.lock_mount();
+    copy.lock_cross_user_mount();
     if !source.propagation().is_shared() {
         return;
     }
@@ -827,6 +838,42 @@ impl ProcessManager {
         } else {
             root_mnt_namespace()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::process::namespace::{
+        propagation::{get_peers, register_peer},
+        user_namespace::INIT_USER_NAMESPACE,
+    };
+
+    #[test]
+    fn registration_prepare_failure_cleans_namespace_copy() {
+        let namespace = MntNamespace::new_root();
+        let root = namespace.root_mntfs();
+        root.propagation().set_shared().unwrap();
+        let group_id = root.propagation().peer_group_id();
+        register_peer(group_id, &root);
+        let peers_before = get_peers(group_id, &root).len();
+        let slaves_before = root.propagation().slaves().len();
+        let pins_before = root.superblock_external_pin_count();
+        let mount_count_before = namespace.inner.read().mount_count.mounts;
+
+        FAIL_COPY_REGISTRATION_PREPARE.store(true, Ordering::Release);
+        let result = namespace.copy_mnt_ns(&CloneFlags::CLONE_NEWNS, INIT_USER_NAMESPACE.clone());
+
+        assert!(matches!(result, Err(SystemError::ENOMEM)));
+        assert_eq!(root.superblock_external_pin_count(), pins_before);
+        assert_eq!(get_peers(group_id, &root).len(), peers_before);
+        assert_eq!(root.propagation().slaves().len(), slaves_before);
+        assert_eq!(
+            namespace.inner.read().mount_count.mounts,
+            mount_count_before
+        );
+        assert!(root.is_live());
+        assert!(root.is_belongs_to_mntns(&namespace));
     }
 }
 

--- a/kernel/src/process/namespace/propagation/event.rs
+++ b/kernel/src/process/namespace/propagation/event.rs
@@ -122,19 +122,64 @@ impl CorrespondingSources {
     }
 }
 
-struct PreparedRegistrations {
+pub(crate) struct PreparedRegistrations {
     peer_groups: Vec<PreparedPeerGroupState>,
     slaves: Vec<Arc<MountFS>>,
 }
 
 impl PreparedRegistrations {
-    fn prepare(mounts: &[Arc<MountFS>]) -> Result<Self, SystemError> {
-        let peer_groups = prepare_peer_registrations(mounts)?;
+    pub(crate) fn prepare(mounts: &[Arc<MountFS>]) -> Result<Self, SystemError> {
+        Self::prepare_iter(mounts.iter())
+    }
+
+    pub(crate) fn prepare_iter<'a>(
+        mounts: impl Iterator<Item = &'a Arc<MountFS>> + Clone,
+    ) -> Result<Self, SystemError> {
+        Self::prepare_iter_with(mounts, || Ok(()))
+    }
+
+    #[cfg(test)]
+    fn prepare_with(
+        mounts: &[Arc<MountFS>],
+        before_reserve: impl FnMut() -> Result<(), SystemError>,
+    ) -> Result<Self, SystemError> {
+        Self::prepare_iter_with(mounts.iter(), before_reserve)
+    }
+
+    fn prepare_iter_with<'a>(
+        mounts: impl Iterator<Item = &'a Arc<MountFS>> + Clone,
+        mut before_reserve: impl FnMut() -> Result<(), SystemError>,
+    ) -> Result<Self, SystemError> {
+        let relevant_count = mounts
+            .clone()
+            .filter(|mount| {
+                mount.propagation().is_shared() || mount.propagation().master().is_some()
+            })
+            .count();
+        let mut relevant = Vec::new();
+        if relevant_count != 0 {
+            before_reserve()?;
+            relevant
+                .try_reserve(relevant_count)
+                .map_err(|_| SystemError::ENOMEM)?;
+            relevant.extend(mounts.filter(|mount| {
+                mount.propagation().is_shared() || mount.propagation().master().is_some()
+            }));
+        }
+
+        let peer_groups = prepare_peer_registrations(&relevant)?;
         let mut slaves = Vec::new();
-        slaves
-            .try_reserve(mounts.len())
-            .map_err(|_| SystemError::ENOMEM)?;
-        for mount in mounts {
+        let slave_count = relevant
+            .iter()
+            .filter(|mount| !mount.is_live() && mount.propagation().master().is_some())
+            .count();
+        if slave_count != 0 {
+            before_reserve()?;
+            slaves
+                .try_reserve(slave_count)
+                .map_err(|_| SystemError::ENOMEM)?;
+        }
+        for mount in relevant {
             // Live source mounts in a move already occupy their master's
             // reverse list. Detached source/clone mounts need publication.
             if !mount.is_live() && mount.propagation().master().is_some() {
@@ -143,9 +188,12 @@ impl PreparedRegistrations {
         }
 
         let mut masters = Vec::new();
-        masters
-            .try_reserve(slaves.len())
-            .map_err(|_| SystemError::ENOMEM)?;
+        if !slaves.is_empty() {
+            before_reserve()?;
+            masters
+                .try_reserve(slaves.len())
+                .map_err(|_| SystemError::ENOMEM)?;
+        }
         for slave in &slaves {
             let master = slave
                 .propagation()
@@ -172,7 +220,7 @@ impl PreparedRegistrations {
         })
     }
 
-    fn commit(self) {
+    pub(crate) fn commit(self) {
         apply_prepared_peer_groups(self.peer_groups);
         for mount in self.slaves {
             register_slave_with_master(&mount);
@@ -600,7 +648,7 @@ pub(crate) fn commit_mount_propagation_locked(
                 // user-namespace boundary, while leaving the propagated root
                 // itself movable as the new visible boundary.
                 for mount in collect_subtree(&item.clone) {
-                    mount.lock_mount();
+                    mount.lock_cross_user_mount();
                 }
                 item.clone.unlock_mount();
             }

--- a/kernel/src/process/namespace/propagation/group.rs
+++ b/kernel/src/process/namespace/propagation/group.rs
@@ -371,6 +371,7 @@ impl PeerGroupRegistry {
 ///
 /// This is a convenience function that delegates to the global `PeerGroupRegistry`.
 #[inline]
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn register_peer(group_id: PropagationGroupId, mount: &Arc<MountFS>) {
     PEER_GROUP_REGISTRY.register(group_id, mount);
 }
@@ -459,7 +460,7 @@ where
 /// discoverable at an event commit. Every final member vector and every new
 /// registry key is reserved before the first topology edge is published.
 pub(super) fn prepare_peer_registrations(
-    mounts: &[Arc<MountFS>],
+    mounts: &[&Arc<MountFS>],
 ) -> Result<Vec<PreparedPeerGroupState>, SystemError> {
     let mut additions = Vec::new();
     additions
@@ -469,7 +470,7 @@ pub(super) fn prepare_peer_registrations(
         let propagation = mount.propagation();
         let group_id = propagation.peer_group_id();
         if propagation.is_shared() && group_id.is_valid() {
-            additions.push((group_id, mount.clone()));
+            additions.push((group_id, (*mount).clone()));
         }
     }
     additions.sort_unstable_by_key(|(group_id, _)| group_id.data());

--- a/kernel/src/process/namespace/propagation/mod.rs
+++ b/kernel/src/process/namespace/propagation/mod.rs
@@ -21,8 +21,10 @@ pub use event::propagation_umount_busy;
 pub(crate) use event::{
     abort_mount_propagation, abort_moved_tree_propagation_locked, commit_mount_propagation_locked,
     commit_moved_tree_propagation_locked, ensure_subtree_shared, prepare_mount_propagation_locked,
-    prepare_moved_tree_propagation_locked, PreparedPropagation,
+    prepare_moved_tree_propagation_locked, PreparedPropagation, PreparedRegistrations,
 };
+#[cfg(test)]
+pub(crate) use group::get_peers;
 #[allow(unused_imports)]
 pub use group::{register_peer, PropagationGroupId};
 pub(crate) use state::detach_mount_propagation;

--- a/kernel/src/process/namespace/propagation/tests.rs
+++ b/kernel/src/process/namespace/propagation/tests.rs
@@ -209,6 +209,38 @@ fn test_recursive_prepare_capacity_failure_changes_nothing() {
 }
 
 #[test]
+fn test_prepared_registration_failure_changes_no_reverse_indexes() {
+    let source = new_test_mount(MountPropagation::new_shared().unwrap());
+    let group_id = source.propagation().peer_group_id();
+    register_peer(group_id, &source);
+
+    let copy = source.deepcopy(None).unwrap();
+    copy.propagation().set_private();
+    copy.propagation().set_slave(Some(Arc::downgrade(&source)));
+    let peers_before = get_peers(group_id, &source);
+    let slaves_before = source.propagation().slaves();
+    let calls = Cell::new(0);
+
+    let result = PreparedRegistrations::prepare_with(&[copy.clone()], || {
+        let call = calls.get();
+        calls.set(call + 1);
+        if call == 1 {
+            Err(SystemError::ENOMEM)
+        } else {
+            Ok(())
+        }
+    });
+
+    assert!(matches!(result, Err(SystemError::ENOMEM)));
+    assert_eq!(get_peers(group_id, &source).len(), peers_before.len());
+    assert_eq!(source.propagation().slaves().len(), slaves_before.len());
+    assert!(copy.namespace().is_none());
+    assert!(!copy.is_live());
+    MountFS::deactivate_disconnected_subtree(&copy);
+    assert!(copy.propagation().is_private());
+}
+
+#[test]
 fn test_group_allocator_reuses_multiple_holes_in_minimum_order_without_free_storage() {
     let mut allocator = PropagationGroupIdAllocator::new();
     let ids: Vec<_> = (0..6).map(|_| allocator.alloc().unwrap()).collect();

--- a/user/apps/tests/dunitest/suites/normal/mount_propagation.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_propagation.cc
@@ -137,6 +137,35 @@ bool mount_source_at(const char* mount_point, const char* expected_source) {
     return found;
 }
 
+bool mount_has_option(const char* mount_point, const char* expected_option) {
+    FILE* fp = fopen("/proc/self/mountinfo", "r");
+    if (fp == nullptr) {
+        return false;
+    }
+
+    bool found = false;
+    char line[2048] = {};
+    while (fgets(line, sizeof(line), fp) != nullptr) {
+        char parsed_mount_point[256] = {};
+        char options[512] = {};
+        if (sscanf(line, "%*s %*s %*s %*s %255s %511s", parsed_mount_point, options) != 2 ||
+            strcmp(parsed_mount_point, mount_point) != 0) {
+            continue;
+        }
+        char* save = nullptr;
+        for (char* option = strtok_r(options, ",", &save); option != nullptr;
+             option = strtok_r(nullptr, ",", &save)) {
+            if (strcmp(option, expected_option) == 0) {
+                found = true;
+                break;
+            }
+        }
+        break;
+    }
+    fclose(fp);
+    return found;
+}
+
 struct PropagationTags {
     int shared = -1;
     int master = -1;
@@ -251,6 +280,34 @@ bool write_exact(int fd, const void* buffer, size_t length) {
     }
     return true;
 }
+
+class ChildProcessGuard {
+public:
+    explicit ChildProcessGuard(pid_t pid) : pid_(pid) {}
+
+    ~ChildProcessGuard() {
+        if (pid_ <= 0) {
+            return;
+        }
+        kill(pid_, SIGKILL);
+        while (waitpid(pid_, nullptr, 0) < 0 && errno == EINTR) {
+        }
+    }
+
+    pid_t wait(int* status) {
+        pid_t result;
+        do {
+            result = waitpid(pid_, status, 0);
+        } while (result < 0 && errno == EINTR);
+        if (result == pid_) {
+            pid_ = -1;
+        }
+        return result;
+    }
+
+private:
+    pid_t pid_;
+};
 
 void terminate_children(pid_t* children, size_t count) {
     for (size_t i = 0; i < count; ++i) {
@@ -466,6 +523,363 @@ TEST_F(MountPropagationTest, CrossUserNamespaceCanMakeLockedRootPrivate) {
     ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
     ASSERT_TRUE(WIFEXITED(status));
     EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
+TEST_F(MountPropagationTest, CrossUserCopyIsOneWayAndKeepsAttributeLocksAcrossCopy) {
+    char base[160] = {};
+    char host[192] = {};
+    char local[192] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(host, sizeof(host), "%s/host", base);
+    snprintf(local, sizeof(local), "%s/local", base);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(host)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(local)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr,
+                       MS_REMOUNT | MS_BIND | MS_NOSUID | MS_NODEV | MS_NOEXEC, nullptr))
+        << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    const int source_group = shared_group_id(base);
+    ASSERT_GT(source_group, 0);
+
+    int parent_to_child[2] = {-1, -1};
+    int child_to_parent[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(parent_to_child)) << strerror(errno);
+    ASSERT_EQ(0, pipe(child_to_parent)) << strerror(errno);
+
+    struct ChildReport {
+        PropagationTags initial_tags;
+        PropagationTags nested_tags;
+        int initial_remount_errno;
+        int add_readonly_errno;
+        int readonly_after_add;
+        int remove_readonly_errno;
+        int readonly_after_remove;
+        int atime_remount_errno;
+        int nested_unshare_errno;
+        int nested_remount_errno;
+        int ordinary_remount_errno;
+        int saw_parent_mount;
+        int local_mount_errno;
+        int saw_local_mount;
+    };
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    ChildProcessGuard child_guard(child);
+    if (child == 0) {
+        close(parent_to_child[1]);
+        close(child_to_parent[0]);
+        ChildReport report = {};
+        report.initial_tags = {};
+        report.nested_tags = {};
+
+        if (unshare(CLONE_NEWUSER | CLONE_NEWNS) != 0) {
+            _exit(1);
+        }
+        const char* points[] = {base};
+        if (!read_propagation_snapshot(points, 1, &report.initial_tags)) {
+            _exit(2);
+        }
+        errno = 0;
+        if (mount(nullptr, base, nullptr, MS_REMOUNT | MS_BIND, nullptr) == 0) {
+            report.initial_remount_errno = 0;
+        } else {
+            report.initial_remount_errno = errno;
+        }
+        errno = 0;
+        if (mount(nullptr, base, nullptr,
+                  MS_REMOUNT | MS_BIND | MS_RDONLY | MS_NOSUID | MS_NODEV | MS_NOEXEC,
+                  nullptr) != 0) {
+            report.add_readonly_errno = errno;
+        }
+        report.readonly_after_add = mount_has_option(base, "ro") ? 1 : 0;
+        errno = 0;
+        if (mount(nullptr, base, nullptr,
+                  MS_REMOUNT | MS_BIND | MS_NOSUID | MS_NODEV | MS_NOEXEC, nullptr) != 0) {
+            report.remove_readonly_errno = errno;
+        }
+        report.readonly_after_remove = mount_has_option(base, "ro") ? 1 : 0;
+        errno = 0;
+        if (mount(nullptr, base, nullptr,
+                  MS_REMOUNT | MS_BIND | MS_NOATIME | MS_NOSUID | MS_NODEV | MS_NOEXEC,
+                  nullptr) == 0) {
+            report.atime_remount_errno = 0;
+        } else {
+            report.atime_remount_errno = errno;
+        }
+
+        errno = 0;
+        if (unshare(CLONE_NEWNS) != 0) {
+            report.nested_unshare_errno = errno;
+        } else {
+            if (!read_propagation_snapshot(points, 1, &report.nested_tags)) {
+                _exit(3);
+            }
+            errno = 0;
+            if (mount(nullptr, base, nullptr, MS_REMOUNT | MS_BIND, nullptr) == 0) {
+                report.nested_remount_errno = 0;
+            } else {
+                report.nested_remount_errno = errno;
+            }
+            errno = 0;
+            if (mount(nullptr, base, nullptr, MS_REMOUNT, nullptr) == 0) {
+                report.ordinary_remount_errno = 0;
+            } else {
+                report.ordinary_remount_errno = errno;
+            }
+        }
+
+        const char ready = 'R';
+        if (!write_exact(child_to_parent[1], &ready, sizeof(ready))) {
+            _exit(4);
+        }
+        char release = 0;
+        if (!read_exact(parent_to_child[0], &release, sizeof(release))) {
+            _exit(5);
+        }
+        report.saw_parent_mount = marker_exists(host, "from_parent") ? 1 : 0;
+        errno = 0;
+        if (mount("issue2103-child", local, "ramfs", 0, nullptr) != 0) {
+            report.local_mount_errno = errno;
+        }
+        report.saw_local_mount = mount_source_at(local, "issue2103-child") ? 1 : 0;
+        if (!write_exact(child_to_parent[1], &report, sizeof(report))) {
+            _exit(6);
+        }
+        _exit(0);
+    }
+
+    close(parent_to_child[0]);
+    close(child_to_parent[1]);
+    char ready = 0;
+    ASSERT_TRUE(read_exact(child_to_parent[0], &ready, sizeof(ready)));
+    ASSERT_EQ('R', ready);
+    ASSERT_EQ(0, mount("", host, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, create_marker(host, "from_parent")) << strerror(errno);
+    const char release = 'G';
+    ASSERT_TRUE(write_exact(parent_to_child[1], &release, sizeof(release)));
+
+    ChildReport report = {};
+    ASSERT_TRUE(read_exact(child_to_parent[0], &report, sizeof(report)));
+    int status = 0;
+    ASSERT_EQ(child, child_guard.wait(&status)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    EXPECT_EQ(-1, report.initial_tags.shared);
+    EXPECT_EQ(source_group, report.initial_tags.master);
+    EXPECT_EQ(EPERM, report.initial_remount_errno);
+    EXPECT_EQ(0, report.add_readonly_errno);
+    EXPECT_EQ(1, report.readonly_after_add);
+    EXPECT_EQ(0, report.remove_readonly_errno);
+    EXPECT_EQ(0, report.readonly_after_remove);
+    EXPECT_EQ(EPERM, report.atime_remount_errno);
+    EXPECT_EQ(0, report.nested_unshare_errno);
+    EXPECT_EQ(-1, report.nested_tags.shared);
+    EXPECT_EQ(source_group, report.nested_tags.master);
+    EXPECT_EQ(EPERM, report.nested_remount_errno);
+    EXPECT_EQ(EPERM, report.ordinary_remount_errno);
+    EXPECT_EQ(1, report.saw_parent_mount);
+    EXPECT_EQ(0, report.local_mount_errno);
+    EXPECT_EQ(1, report.saw_local_mount);
+    EXPECT_FALSE(mount_source_at(local, "issue2103-child"));
+
+    close(parent_to_child[1]);
+    close(child_to_parent[0]);
+    best_effort_umount(host);
+    best_effort_umount(base);
+    best_effort_rmdir(host);
+    best_effort_rmdir(local);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, SameUserNamespaceCopyRemainsInSharedPeerGroup) {
+    char base[160] = {};
+    char local[192] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(local, sizeof(local), "%s/local", base);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(local)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    const int source_group = shared_group_id(base);
+    ASSERT_GT(source_group, 0);
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (unshare(CLONE_NEWNS) != 0) {
+            _exit(1);
+        }
+        const char* points[] = {base};
+        PropagationTags tags = {};
+        if (!read_propagation_snapshot(points, 1, &tags) || tags.shared != source_group ||
+            tags.master >= 0) {
+            _exit(2);
+        }
+        if (mount(nullptr, base, nullptr, MS_REMOUNT | MS_BIND | MS_NOATIME, nullptr) != 0 ||
+            !mount_has_option(base, "noatime")) {
+            _exit(3);
+        }
+        if (mount("", local, "ramfs", 0, nullptr) != 0 ||
+            create_marker(local, "same_user") != 0) {
+            _exit(4);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+    EXPECT_TRUE(marker_exists(local, "same_user"));
+
+    best_effort_umount(local);
+    best_effort_umount(base);
+    best_effort_rmdir(local);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, CrossUserCopyCannotReconfigureSourceSuperblock) {
+    char base[160] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (unshare(CLONE_NEWUSER | CLONE_NEWNS) != 0) {
+            _exit(1);
+        }
+        errno = 0;
+        if (mount(nullptr, base, nullptr, MS_REMOUNT | MS_RDONLY, nullptr) == 0 ||
+            errno != EPERM) {
+            _exit(2);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_REMOUNT | MS_RDONLY, nullptr))
+        << strerror(errno);
+    EXPECT_TRUE(mount_has_option(base, "ro"));
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_REMOUNT, nullptr)) << strerror(errno);
+    EXPECT_FALSE(mount_has_option(base, "ro"));
+
+    best_effort_umount(base);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, UserAndMountNamespaceCreationOrderMatchesLinux) {
+    char base[160] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    const int source_group = shared_group_id(base);
+    ASSERT_GT(source_group, 0);
+
+    pid_t sequential = fork();
+    ASSERT_GE(sequential, 0) << strerror(errno);
+    if (sequential == 0) {
+        if (unshare(CLONE_NEWUSER) != 0 || unshare(CLONE_NEWNS) != 0) {
+            _exit(1);
+        }
+        const char* points[] = {base};
+        PropagationTags tags = {};
+        if (!read_propagation_snapshot(points, 1, &tags) || tags.shared >= 0 ||
+            tags.master != source_group) {
+            _exit(2);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(sequential, waitpid(sequential, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+
+    pid_t reverse = fork();
+    ASSERT_GE(reverse, 0) << strerror(errno);
+    if (reverse == 0) {
+        if (unshare(CLONE_NEWNS) != 0 || unshare(CLONE_NEWUSER) != 0) {
+            _exit(1);
+        }
+        errno = 0;
+        if (mount(nullptr, base, nullptr, MS_PRIVATE, nullptr) == 0 || errno != EPERM) {
+            _exit(2);
+        }
+        if (unshare(CLONE_NEWNS) != 0) {
+            _exit(3);
+        }
+        const char* points[] = {base};
+        PropagationTags tags = {};
+        if (!read_propagation_snapshot(points, 1, &tags) || tags.shared >= 0 ||
+            tags.master != source_group) {
+            _exit(4);
+        }
+        if (mount(nullptr, base, nullptr, MS_PRIVATE, nullptr) != 0) {
+            _exit(5);
+        }
+        _exit(0);
+    }
+
+    ASSERT_EQ(reverse, waitpid(reverse, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+
+    best_effort_umount(base);
+    best_effort_rmdir(base);
+}
+
+TEST_F(MountPropagationTest, CrossUserSharedSlaveUsesSourceAsImmediateMaster) {
+    char base[160] = {};
+    char slave[160] = {};
+    snprintf(base, sizeof(base), "%s/base", root_);
+    snprintf(slave, sizeof(slave), "%s/slave", root_);
+
+    ASSERT_EQ(0, ensure_dir(base)) << strerror(errno);
+    ASSERT_EQ(0, ensure_dir(slave)) << strerror(errno);
+    ASSERT_EQ(0, mount("", base, "ramfs", 0, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, base, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(base, slave, nullptr, MS_BIND, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, slave, nullptr, MS_SLAVE, nullptr)) << strerror(errno);
+    ASSERT_EQ(0, mount(nullptr, slave, nullptr, MS_SHARED, nullptr)) << strerror(errno);
+    const int source_group = shared_group_id(slave);
+    ASSERT_GT(source_group, 0);
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (unshare(CLONE_NEWUSER | CLONE_NEWNS) != 0) {
+            _exit(1);
+        }
+        const char* points[] = {slave};
+        PropagationTags tags = {};
+        if (!read_propagation_snapshot(points, 1, &tags) || tags.shared >= 0 ||
+            tags.master != source_group) {
+            _exit(2);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+
+    best_effort_umount(slave);
+    best_effort_umount(base);
+    best_effort_rmdir(slave);
+    best_effort_rmdir(base);
 }
 
 TEST_F(MountPropagationTest, OrdinaryUmountRejectsMountedDescendant) {


### PR DESCRIPTION
## Summary

- downgrade shared mounts to one-way slaves when a mount namespace is copied into a different user namespace
- preserve Linux-style topology, security-attribute, and atime locks across namespace copies and propagated subtrees
- require `CAP_SYS_ADMIN` in the superblock owner user namespace for ordinary remounts
- prepare propagation registry capacity before publication so allocation failures cannot expose partial peer/slave state
- add focused coverage for namespace ordering, propagation direction, locked attributes, remount permissions, nested copies, and registration failure cleanup

Closes #2103

## Verification

- `cargo fmt --manifest-path kernel/Cargo.toml -- --check`
- `make kernel`
- DragonOS QEMU: `mount_propagation_test` — 24/24 passed
- DragonOS QEMU: `mount_reconfigure_test` — 16 passed, 1 skipped because xattr support is not implemented by the existing test filesystem
- DragonOS QEMU: `test_pivot_root_test` — 12/12 passed
- original gVisor `CloneTest.NewUserMountNamespace` passed

The remaining targeted gVisor mount/pivot cases enter the tests but block in the existing `InForkedUserMountNamespace` parent/child helper. Their semantics are covered by the focused DragonOS dunitests above; no gVisor source or default whitelist was changed.
