### PR TITLE
perf(virtiofs): isolate virtio PCI interrupt vectors

### DIFF
--- a/kernel/src/arch/loongarch64/msi.rs
+++ b/kernel/src/arch/loongarch64/msi.rs
@@ -1,4 +1,14 @@
 use crate::driver::pci::pci_irq::TriggerMode;
+use crate::exception::IrqNumber;
+use system_error::SystemError;
+
+pub fn arch_pci_msi_vector_alloc() -> Option<IrqNumber> {
+    None
+}
+
+pub fn arch_pci_msi_vector_setup(_vector: IrqNumber) -> Result<(), SystemError> {
+    Err(SystemError::ENOSYS)
+}
 
 /// 获得MSI Message Address
 ///

--- a/kernel/src/arch/riscv64/msi.rs
+++ b/kernel/src/arch/riscv64/msi.rs
@@ -1,4 +1,14 @@
 use crate::driver::pci::pci_irq::TriggerMode;
+use crate::exception::IrqNumber;
+use system_error::SystemError;
+
+pub fn arch_pci_msi_vector_alloc() -> Option<IrqNumber> {
+    None
+}
+
+pub fn arch_pci_msi_vector_setup(_vector: IrqNumber) -> Result<(), SystemError> {
+    Err(SystemError::ENOSYS)
+}
 
 /// @brief 获得MSI Message Address
 /// @param processor 目标CPU ID号

--- a/kernel/src/arch/x86_64/msi.rs
+++ b/kernel/src/arch/x86_64/msi.rs
@@ -1,4 +1,81 @@
-use crate::driver::pci::pci_irq::TriggerMode;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use system_error::SystemError;
+
+use crate::{
+    arch::driver::apic::lapic_vector::local_apic_chip,
+    driver::pci::pci_irq::TriggerMode,
+    exception::{
+        handle::edge_irq_handler, irqdata::IrqLineStatus, irqdesc::irq_desc_manager, IrqNumber,
+    },
+};
+
+const PCI_MSI_VECTOR_FIRST: u32 = 64;
+const PCI_MSI_VECTOR_INT80: u32 = 128;
+const PCI_MSI_VECTOR_LAST: u32 = 150;
+
+struct PciMsiVectorAllocator {
+    next: AtomicU32,
+}
+
+impl PciMsiVectorAllocator {
+    const fn new() -> Self {
+        Self {
+            next: AtomicU32::new(PCI_MSI_VECTOR_FIRST),
+        }
+    }
+
+    fn alloc(&self) -> Option<IrqNumber> {
+        loop {
+            let current = self.next.load(Ordering::Relaxed);
+            if current > PCI_MSI_VECTOR_LAST {
+                return None;
+            }
+            let next = if current == PCI_MSI_VECTOR_INT80 - 1 {
+                PCI_MSI_VECTOR_INT80 + 1
+            } else {
+                current + 1
+            };
+            if self
+                .next
+                .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                return Some(IrqNumber::new(current));
+            }
+        }
+    }
+}
+
+static PCI_MSI_VECTOR_ALLOCATOR: PciMsiVectorAllocator = PciMsiVectorAllocator::new();
+
+/// Reserves a CPU vector from the x86 range owned by PCI MSI/MSI-X.
+///
+/// Vectors are intentionally not reused. DragonOS does not yet have a safe PCI `free_irq`
+/// lifecycle, so reuse could route a live MSI action to a different device.
+pub fn arch_pci_msi_vector_alloc() -> Option<IrqNumber> {
+    PCI_MSI_VECTOR_ALLOCATOR.alloc()
+}
+
+/// Rebinds an allocated vector from the blanket IOAPIC setup to message-interrupt semantics.
+pub fn arch_pci_msi_vector_setup(vector: IrqNumber) -> Result<(), SystemError> {
+    if !(PCI_MSI_VECTOR_FIRST..=PCI_MSI_VECTOR_LAST).contains(&vector.data())
+        || vector.data() == PCI_MSI_VECTOR_INT80
+    {
+        return Err(SystemError::EINVAL);
+    }
+    let desc = irq_desc_manager()
+        .lookup(vector)
+        .ok_or(SystemError::EINVAL)?;
+    let irq_data = desc.irq_data();
+    let mut chip_info = irq_data.chip_info_write_irqsave();
+    chip_info.set_chip(Some(local_apic_chip().clone()));
+    chip_info.set_chip_data(None);
+    drop(chip_info);
+    desc.modify_status(IrqLineStatus::IRQ_LEVEL, IrqLineStatus::empty());
+    desc.set_handler(edge_irq_handler());
+    Ok(())
+}
 /// @brief 获得MSI Message Address
 /// @param processor 目标CPU ID号
 /// @return MSI Message Address
@@ -15,5 +92,27 @@ pub fn arch_msi_message_data(vector: u16, _processor: u16, trigger: TriggerMode)
         TriggerMode::EdgeTrigger => vector as u32,
         TriggerMode::AssertHigh => vector as u32 | 1 << 15 | 1 << 14,
         TriggerMode::AssertLow => vector as u32 | 1 << 15,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PciMsiVectorAllocator, PCI_MSI_VECTOR_LAST};
+
+    #[test]
+    fn pci_msi_vector_allocator_skips_int80_and_exhausts() {
+        let allocator = PciMsiVectorAllocator::new();
+        let mut vectors = alloc::vec::Vec::new();
+        while let Some(vector) = allocator.alloc() {
+            vectors.push(vector.data());
+        }
+
+        assert_eq!(vectors.first().copied(), Some(64));
+        assert!(vectors.contains(&127));
+        assert!(!vectors.contains(&128));
+        assert!(vectors.contains(&129));
+        assert_eq!(vectors.last().copied(), Some(PCI_MSI_VECTOR_LAST));
+        assert_eq!(vectors.len(), 86);
+        assert_eq!(allocator.alloc(), None);
     }
 }

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -42,7 +42,7 @@ use crate::{
         },
         virtio::{
             sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager},
-            transport::VirtIOTransport,
+            transport::{DeferredVirtioIrq, VirtIOTransport},
             virtio_impl::HalImpl,
             VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId,
             VIRTIO_VENDOR_ID,
@@ -306,9 +306,20 @@ pub fn virtio_blk(
     dev_parent: Option<Arc<dyn Device>>,
 ) {
     let device = VirtIOBlkDevice::new(transport, dev_id);
-    if let Some(device) = device {
+    if let Some((device, deferred_irq)) = device {
         if let Some(dev_parent) = dev_parent {
             device.set_dev_parent(Some(Arc::downgrade(&dev_parent)));
+        }
+        if let Some(deferred_irq) = deferred_irq {
+            if let Err(err) = deferred_irq.install(device.dev_id().clone()) {
+                error!(
+                    "VirtIOBlkDevice '{:?}' setup_irq failed: {:?}",
+                    device.dev_id(),
+                    err
+                );
+                device.abort_initialization();
+                return;
+            }
         }
         virtio_device_manager()
             .device_add(device.clone() as Arc<dyn VirtIODevice>)
@@ -408,12 +419,18 @@ unsafe impl Send for VirtIOBlkDevice {}
 unsafe impl Sync for VirtIOBlkDevice {}
 
 impl VirtIOBlkDevice {
-    pub fn new(transport: VirtIOTransport, dev_id: Arc<DeviceId>) -> Option<Arc<Self>> {
+    pub(crate) fn new(
+        transport: VirtIOTransport,
+        dev_id: Arc<DeviceId>,
+    ) -> Option<(Arc<Self>, Option<DeferredVirtioIrq>)> {
         // 设置中断
-        if let Err(err) = transport.setup_irq(dev_id.clone()) {
-            error!("VirtIOBlkDevice '{dev_id:?}' setup_irq failed: {:?}", err);
-            return None;
-        }
+        let irq_setup = match transport.setup_irq(dev_id.clone()) {
+            Ok(setup) => setup,
+            Err(err) => {
+                error!("VirtIOBlkDevice '{dev_id:?}' setup_irq failed: {:?}", err);
+                return None;
+            }
+        };
 
         let devname = virtioblk_manager().alloc_id()?;
         let irq = Some(transport.irq());
@@ -490,11 +507,23 @@ impl VirtIOBlkDevice {
             return None;
         }
 
-        Some(dev)
+        Some((dev, irq_setup.into_deferred()))
     }
 
     fn inner(&self) -> SpinLockGuard<'_, InnerVirtIOBlkDevice> {
         self.inner.lock_irqsave()
+    }
+
+    fn abort_initialization(self: &Arc<Self>) {
+        let devname_id = self.blkdev_meta.devname.id();
+        if let Err(err) = self.shutdown() {
+            error!(
+                "VirtIOBlkDevice '{:?}' initialization cleanup failed: {:?}",
+                self.dev_id, err
+            );
+            return;
+        }
+        virtioblk_manager().free_id(devname_id);
     }
 
     fn shutdown(self: &Arc<Self>) -> Result<(), SystemError> {

--- a/kernel/src/driver/char/virtio_console.rs
+++ b/kernel/src/driver/char/virtio_console.rs
@@ -22,7 +22,7 @@ use crate::{
         video::console::dummycon::dummy_console,
         virtio::{
             sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager},
-            transport::VirtIOTransport,
+            transport::{DeferredVirtioIrq, VirtIOTransport},
             virtio_drivers_error_to_system_error,
             virtio_impl::HalImpl,
             VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId,
@@ -307,15 +307,22 @@ pub fn virtio_console(
         dev_id,
         dev_parent.as_ref().map(|x| x.name())
     );
-    let device = VirtIOConsoleDevice::new(transport, dev_id.clone());
-    if device.is_none() {
+    let Some((device, deferred_irq)) = VirtIOConsoleDevice::new(transport, dev_id.clone()) else {
         return;
-    }
-
-    let device = device.unwrap();
+    };
 
     if let Some(dev_parent) = dev_parent {
         device.set_dev_parent(Some(Arc::downgrade(&dev_parent)));
+    }
+    if let Some(deferred_irq) = deferred_irq {
+        if let Err(err) = deferred_irq.install(device.dev_id().clone()) {
+            log::error!(
+                "VirtIOConsoleDevice '{:?}' setup_irq failed: {:?}",
+                device.dev_id(),
+                err
+            );
+            return;
+        }
     }
     virtio_device_manager()
         .device_add(device.clone() as Arc<dyn VirtIODevice>)
@@ -353,15 +360,21 @@ impl Debug for VirtIOConsoleDevice {
 }
 
 impl VirtIOConsoleDevice {
-    pub fn new(transport: VirtIOTransport, dev_id: Arc<DeviceId>) -> Option<Arc<Self>> {
+    pub(crate) fn new(
+        transport: VirtIOTransport,
+        dev_id: Arc<DeviceId>,
+    ) -> Option<(Arc<Self>, Option<DeferredVirtioIrq>)> {
         // 设置中断
-        if let Err(err) = transport.setup_irq(dev_id.clone()) {
-            log::error!(
-                "VirtIOConsoleDevice '{dev_id:?}' setup_irq failed: {:?}",
-                err
-            );
-            return None;
-        }
+        let irq_setup = match transport.setup_irq(dev_id.clone()) {
+            Ok(setup) => setup,
+            Err(err) => {
+                log::error!(
+                    "VirtIOConsoleDevice '{dev_id:?}' setup_irq failed: {:?}",
+                    err
+                );
+                return None;
+            }
+        };
 
         let irq = Some(transport.irq());
         let device_inner = DragonVirtIOConsole::new(transport);
@@ -394,7 +407,7 @@ impl VirtIOConsoleDevice {
             }),
         });
 
-        Some(dev)
+        Some((dev, irq_setup.into_deferred()))
     }
 
     fn inner(&self) -> SpinLockGuard<'_, InnerVirtIOConsoleDevice> {

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -37,7 +37,7 @@ use crate::{
         virtio::{
             irq::virtio_irq_manager,
             sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager},
-            transport::VirtIOTransport,
+            transport::{DeferredVirtioIrq, VirtIOTransport},
             virtio_impl::HalImpl,
             VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId,
             VIRTIO_VENDOR_ID,
@@ -108,12 +108,18 @@ impl Debug for InnerVirtIONetDevice {
 }
 
 impl VirtIONetDevice {
-    pub fn new(transport: VirtIOTransport, dev_id: Arc<DeviceId>) -> Option<Arc<Self>> {
+    pub(crate) fn new(
+        transport: VirtIOTransport,
+        dev_id: Arc<DeviceId>,
+    ) -> Option<(Arc<Self>, Option<DeferredVirtioIrq>)> {
         // 设置中断
-        if let Err(err) = transport.setup_irq(dev_id.clone()) {
-            error!("VirtIONetDevice '{dev_id:?}' setup_irq failed: {:?}", err);
-            return None;
-        }
+        let irq_setup = match transport.setup_irq(dev_id.clone()) {
+            Ok(setup) => setup,
+            Err(err) => {
+                error!("VirtIONetDevice '{dev_id:?}' setup_irq failed: {:?}", err);
+                return None;
+            }
+        };
 
         let irq_is_msix = transport.irq_is_msix();
         let driver_net: VirtIONet<HalImpl, VirtIOTransport, 2> =
@@ -144,7 +150,7 @@ impl VirtIONetDevice {
 
         // dev.set_driver(Some(Arc::downgrade(&virtio_net_driver()) as Weak<dyn Driver>));
 
-        return Some(dev);
+        return Some((dev, irq_setup.into_deferred()));
     }
 
     fn inner(&self) -> SpinLockGuard<'_, InnerVirtIONetDevice> {
@@ -767,10 +773,20 @@ pub fn virtio_net(
     dev_parent: Option<Arc<dyn Device>>,
 ) {
     let virtio_net_deivce = VirtIONetDevice::new(transport, dev_id);
-    if let Some(virtio_net_deivce) = virtio_net_deivce {
+    if let Some((virtio_net_deivce, deferred_irq)) = virtio_net_deivce {
         debug!("VirtIONetDevice '{:?}' created", virtio_net_deivce.dev_id);
         if let Some(dev_parent) = dev_parent {
             virtio_net_deivce.set_dev_parent(Some(Arc::downgrade(&dev_parent)));
+        }
+        if let Some(deferred_irq) = deferred_irq {
+            if let Err(err) = deferred_irq.install(virtio_net_deivce.dev_id().clone()) {
+                error!(
+                    "VirtIONetDevice '{:?}' setup_irq failed: {:?}",
+                    virtio_net_deivce.dev_id(),
+                    err
+                );
+                return;
+            }
         }
         virtio_device_manager()
             .device_add(virtio_net_deivce.clone() as Arc<dyn VirtIODevice>)

--- a/kernel/src/driver/virtio/sysfs.rs
+++ b/kernel/src/driver/virtio/sysfs.rs
@@ -20,9 +20,8 @@ use crate::{
             kobject::KObject,
             subsys::SubSysPrivate,
         },
-        virtio::irq::{virtio_irq_manager, DefaultVirtioIrqHandler},
+        virtio::irq::virtio_irq_manager,
     },
-    exception::{irqdesc::IrqHandleFlags, manage::irq_manager},
     filesystem::{
         sysfs::{
             file::sysfs_emit_str, Attribute, AttributeGroup, SysFSOpsSupport, SYSFS_ATTR_MODE_RO,
@@ -265,22 +264,6 @@ impl VirtIODeviceManager {
             return Ok(());
         }
         let irq = irq.unwrap();
-        if let Err(e) = irq_manager().request_irq(
-            irq,
-            dev.device_name(),
-            &DefaultVirtioIrqHandler,
-            IrqHandleFlags::IRQF_SHARED,
-            Some(dev.dev_id().clone()),
-        ) {
-            error!(
-                "Failed to request irq for virtio device '{}': irq: {:?}, error {:?}",
-                dev.device_name(),
-                irq,
-                e
-            );
-            return Err(e);
-        }
-
         virtio_irq_manager()
             .register_device(dev.clone())
             .map_err(|e| {

--- a/kernel/src/driver/virtio/transport.rs
+++ b/kernel/src/driver/virtio/transport.rs
@@ -8,10 +8,10 @@ use crate::{
         pci::pci_irq::IrqType,
         pci::{
             pci::{PciBarSubresourceGuard, PciDeviceStructure, PciError},
-            pci_irq::{IrqCommonMsg, IrqSpecificMsg, PciInterrupt, PciIrqError, PciIrqMsg, IRQ},
+            pci_irq::{IrqCommonMsg, IrqSpecificMsg, PciInterrupt, PciIrqMsg, IRQ},
         },
     },
-    exception::IrqNumber,
+    exception::{irqdesc::IrqHandleFlags, manage::irq_manager, IrqNumber},
     mm::PhysAddr,
 };
 
@@ -102,27 +102,44 @@ impl VirtIOTransport {
     }
 
     /// 设置中断
-    pub fn setup_irq(&self, dev_id: Arc<DeviceId>) -> Result<(), PciError> {
-        if let VirtIOTransport::Pci(transport) = self {
-            let standard_device = transport.pci_device().as_standard_device().unwrap();
-            let _irq_type = standard_device
-                .irq_init(IRQ::PCI_IRQ_MSIX | IRQ::PCI_IRQ_MSI)
-                .ok_or(PciError::PciIrqError(PciIrqError::IrqNotInited))?;
+    pub fn setup_irq(&self, dev_id: Arc<DeviceId>) -> Result<(), system_error::SystemError> {
+        match self {
+            VirtIOTransport::Pci(transport) => {
+                let standard_device = transport.pci_device().as_standard_device().unwrap();
+                standard_device
+                    .irq_init(IRQ::PCI_IRQ_MSIX | IRQ::PCI_IRQ_MSI)
+                    .ok_or(system_error::SystemError::ENODEV)?;
+                transport
+                    .setup_irq_vector()
+                    .map_err(|_| system_error::SystemError::ENOSPC)?;
 
-            // 中断相关信息
-            let msg = PciIrqMsg {
-                irq_common_message: IrqCommonMsg::init_from(
-                    0,
+                let msg = PciIrqMsg {
+                    irq_common_message: IrqCommonMsg::init_from(
+                        0,
+                        "Virtio_IRQ".to_string(),
+                        &DefaultVirtioIrqHandler,
+                        dev_id,
+                    ),
+                    irq_specific_message: IrqSpecificMsg::msi_default(),
+                };
+                standard_device
+                    .irq_install(msg)
+                    .map_err(|_| system_error::SystemError::EIO)?;
+                standard_device
+                    .irq_enable(true)
+                    .map_err(|_| system_error::SystemError::EIO)?;
+            }
+            VirtIOTransport::Mmio(_) => {
+                irq_manager().request_irq(
+                    self.irq(),
                     "Virtio_IRQ".to_string(),
                     &DefaultVirtioIrqHandler,
-                    dev_id,
-                ),
-                irq_specific_message: IrqSpecificMsg::msi_default(),
-            };
-            standard_device.irq_install(msg)?;
-            standard_device.irq_enable(true)?;
+                    IrqHandleFlags::IRQF_SHARED,
+                    Some(dev_id),
+                )?;
+            }
         }
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/kernel/src/driver/virtio/transport.rs
+++ b/kernel/src/driver/virtio/transport.rs
@@ -19,6 +19,38 @@ use super::{
     irq::DefaultVirtioIrqHandler, transport_mmio::VirtIOMmioTransport, transport_pci::PciTransport,
 };
 
+/// An MMIO interrupt request which must not be installed until the concrete
+/// VirtIO device has been fully constructed.
+pub(crate) struct DeferredVirtioIrq {
+    irq: IrqNumber,
+}
+
+impl DeferredVirtioIrq {
+    pub(crate) fn install(self, dev_id: Arc<DeviceId>) -> Result<(), system_error::SystemError> {
+        irq_manager().request_irq(
+            self.irq,
+            "Virtio_IRQ".to_string(),
+            &DefaultVirtioIrqHandler,
+            IrqHandleFlags::IRQF_SHARED,
+            Some(dev_id),
+        )
+    }
+}
+
+pub(crate) enum VirtioIrqSetup {
+    Installed,
+    Deferred(DeferredVirtioIrq),
+}
+
+impl VirtioIrqSetup {
+    pub(crate) fn into_deferred(self) -> Option<DeferredVirtioIrq> {
+        match self {
+            Self::Installed => None,
+            Self::Deferred(irq) => Some(irq),
+        }
+    }
+}
+
 /// A validated VirtIO shared-memory region descriptor.
 ///
 /// This is address metadata only. It does not grant access to the region or describe a safe
@@ -102,7 +134,10 @@ impl VirtIOTransport {
     }
 
     /// 设置中断
-    pub fn setup_irq(&self, dev_id: Arc<DeviceId>) -> Result<(), system_error::SystemError> {
+    pub(crate) fn setup_irq(
+        &self,
+        dev_id: Arc<DeviceId>,
+    ) -> Result<VirtioIrqSetup, system_error::SystemError> {
         match self {
             VirtIOTransport::Pci(transport) => {
                 let standard_device = transport.pci_device().as_standard_device().unwrap();
@@ -130,16 +165,12 @@ impl VirtIOTransport {
                     .map_err(|_| system_error::SystemError::EIO)?;
             }
             VirtIOTransport::Mmio(_) => {
-                irq_manager().request_irq(
-                    self.irq(),
-                    "Virtio_IRQ".to_string(),
-                    &DefaultVirtioIrqHandler,
-                    IrqHandleFlags::IRQF_SHARED,
-                    Some(dev_id),
-                )?;
+                return Ok(VirtioIrqSetup::Deferred(DeferredVirtioIrq {
+                    irq: self.irq(),
+                }));
             }
         }
-        Ok(())
+        Ok(VirtioIrqSetup::Installed)
     }
 }
 

--- a/kernel/src/driver/virtio/transport_pci.rs
+++ b/kernel/src/driver/virtio/transport_pci.rs
@@ -1,6 +1,9 @@
 //! PCI transport for VirtIO.
 
-use crate::arch::{PciArch, TraitPciArch};
+use crate::arch::{
+    msi::{arch_pci_msi_vector_alloc, arch_pci_msi_vector_setup},
+    PciArch, TraitPciArch,
+};
 use crate::driver::base::device::DeviceId;
 use crate::driver::pci::pci::{
     BusDeviceFunction, PciAddr, PciBarMappingRequest, PciBarSubresourceGuard, PciDeviceStructure,
@@ -69,8 +72,6 @@ fn shared_memory_cap_len_supported(cap_len: u8) -> bool {
     cap_len >= VIRTIO_PCI_CAP64_LEN
 }
 
-/// The interrupt vector number for VirtIO device receive interrupts.
-const VIRTIO_RECV_VECTOR: IrqNumber = IrqNumber::new(56);
 /// The MSI-X table entry index for VirtIO device receive interrupts.
 const VIRTIO_RECV_VECTOR_INDEX: u16 = 0;
 // Receive queue number
@@ -94,7 +95,7 @@ fn device_type(pci_device_id: u16) -> DeviceType {
 ///
 /// Ref: 4.1 Virtio Over PCI Bus
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PciTransport {
     device_type: DeviceType,
     /// The bus, device and function identifier for the VirtIO device.
@@ -110,7 +111,6 @@ pub struct PciTransport {
     isr_status: NonNull<Volatile<u8>>,
     /// The VirtIO device-specific configuration within some BAR.
     config_space: Option<NonNull<[u32]>>,
-    irq: IrqNumber,
     dev_id: Arc<DeviceId>,
     device: Arc<PciDeviceStructureGeneralDevice>,
     shared_memory_regions: Vec<(u8, Option<VirtioSharedMemoryRegion>)>,
@@ -151,7 +151,6 @@ impl PciTransport {
         device: Arc<PciDeviceStructureGeneralDevice>,
         dev_id: Arc<DeviceId>,
     ) -> Result<Self, VirtioPciError> {
-        let irq = VIRTIO_RECV_VECTOR;
         let header = &device.common_header;
         let bus_device_function = header.bus_device_function;
         if header.vendor_id != VIRTIO_VENDOR_ID {
@@ -220,12 +219,6 @@ impl PciTransport {
             .bar_ioremap_with_mappings(&shared_memory_bars, &transport_config_mappings)
             .unwrap()?;
         device.enable_master();
-        let standard_device = device.as_standard_device().unwrap();
-        // Currently there is no unified management of PCI device interrupt numbers, so an
-        // interrupt number must be specified here. It must not conflict with other interrupts.
-        let irq_vector = standard_device.irq_vector_mut().unwrap();
-        irq_vector.write().push(irq);
-
         // panic!();
         // device_capability is an iterator; iterating over it traverses all capability space.
         for capability in device.capabilities().unwrap() {
@@ -363,7 +356,6 @@ impl PciTransport {
             queue_notify_indices,
             isr_status,
             config_space,
-            irq,
             dev_id,
             device,
             shared_memory_regions,
@@ -374,8 +366,31 @@ impl PciTransport {
         self.device.clone()
     }
 
+    /// Reserves the CPU vector when an interrupt-driven driver actually requests IRQ setup.
+    /// Polling-only users such as virtio-vsock do not consume an MSI vector.
+    pub(super) fn setup_irq_vector(&self) -> Result<IrqNumber, VirtioPciError> {
+        let standard_device = self.device.as_standard_device().unwrap();
+        let irq_vector = standard_device.irq_vector_mut().unwrap();
+        let mut irq_vector = irq_vector.write();
+        if !irq_vector.is_empty() {
+            return Err(VirtioPciError::IrqVectorAlreadyAssigned);
+        }
+        let irq = arch_pci_msi_vector_alloc().ok_or(VirtioPciError::IrqVectorUnavailable)?;
+        arch_pci_msi_vector_setup(irq).map_err(|_| VirtioPciError::IrqVectorUnavailable)?;
+        irq_vector.push(irq);
+        Ok(irq)
+    }
+
     pub fn irq(&self) -> IrqNumber {
-        self.irq
+        *self
+            .device
+            .as_standard_device()
+            .unwrap()
+            .irq_vector_mut()
+            .unwrap()
+            .read()
+            .first()
+            .expect("VirtIO PCI IRQ must be configured before it is queried")
     }
 
     pub fn interrupt_ack(&self) -> PciInterruptAck {
@@ -708,6 +723,10 @@ pub enum VirtioPciError {
     BarGetVaddrFailed,
     /// A generic PCI error,
     Pci(PciError),
+    /// No CPU vector is available from the architecture PCI MSI/MSI-X range.
+    IrqVectorUnavailable,
+    /// The same PCI function was already assigned an interrupt vector.
+    IrqVectorAlreadyAssigned,
 }
 
 impl Display for VirtioPciError {
@@ -746,6 +765,13 @@ impl Display for VirtioPciError {
             ),
             Self::BarGetVaddrFailed => write!(f, "Get bar virtaddress failed"),
             Self::Pci(pci_error) => pci_error.fmt(f),
+            Self::IrqVectorUnavailable => write!(f, "No PCI MSI/MSI-X CPU vector is available."),
+            Self::IrqVectorAlreadyAssigned => {
+                write!(
+                    f,
+                    "The PCI function already has an assigned interrupt vector."
+                )
+            }
         }
     }
 }

--- a/kernel/src/driver/virtio/virtio_pmem.rs
+++ b/kernel/src/driver/virtio/virtio_pmem.rs
@@ -32,7 +32,7 @@ use crate::{
         },
         virtio::{
             sysfs::{virtio_bus, virtio_device_manager, virtio_driver_manager},
-            transport::VirtIOTransport,
+            transport::{DeferredVirtioIrq, VirtIOTransport},
             virtio_drivers_error_to_system_error,
             virtio_impl::HalImpl,
             VirtIODevice, VirtIODeviceIndex, VirtIODriver, VirtIODriverCommonData, VirtioDeviceId,
@@ -126,15 +126,18 @@ unsafe impl Send for VirtIOPmemDevice {}
 unsafe impl Sync for VirtIOPmemDevice {}
 
 impl VirtIOPmemDevice {
-    pub fn new(mut transport: VirtIOTransport, dev_id: Arc<DeviceId>) -> Option<Arc<Self>> {
-        let irq_ready = match transport.setup_irq(dev_id.clone()) {
-            Ok(()) => true,
+    pub(crate) fn new(
+        mut transport: VirtIOTransport,
+        dev_id: Arc<DeviceId>,
+    ) -> Option<(Arc<Self>, Option<DeferredVirtioIrq>)> {
+        let (irq_ready, deferred_irq) = match transport.setup_irq(dev_id.clone()) {
+            Ok(setup) => (true, setup.into_deferred()),
             Err(err) => {
                 warn!(
                     "VirtIOPmemDevice '{dev_id:?}' setup_irq failed, falling back to polling: {:?}",
                     err
                 );
-                false
+                (false, None)
             }
         };
 
@@ -169,7 +172,7 @@ impl VirtIOPmemDevice {
 
         let irq = irq_ready.then(|| transport.irq());
         let irq_is_msix = irq_ready && transport.irq_is_msix();
-        Some(Arc::new(Self {
+        let device = Arc::new(Self {
             dev_id,
             inner: SpinLock::new(InnerVirtIOPmemDevice {
                 transport: Some(transport),
@@ -189,7 +192,14 @@ impl VirtIOPmemDevice {
             locked_kobj_state: LockedKObjectState::default(),
             flush_mutex: Mutex::new(()),
             flush_wait: WaitQueue::default(),
-        }))
+        });
+        Some((device, deferred_irq))
+    }
+
+    fn fallback_to_polling(&self) {
+        let mut inner = self.inner();
+        inner.irq = None;
+        inner.irq_is_msix = false;
     }
 
     fn inner(&self) -> SpinLockGuard<'_, InnerVirtIOPmemDevice> {
@@ -737,11 +747,21 @@ pub fn virtio_pmem(
     dev_id: Arc<DeviceId>,
     dev_parent: Option<Arc<dyn Device>>,
 ) {
-    let Some(device) = VirtIOPmemDevice::new(transport, dev_id) else {
+    let Some((device, deferred_irq)) = VirtIOPmemDevice::new(transport, dev_id) else {
         return;
     };
     if let Some(dev_parent) = dev_parent {
         device.set_dev_parent(Some(Arc::downgrade(&dev_parent)));
+    }
+    if let Some(deferred_irq) = deferred_irq {
+        if let Err(err) = deferred_irq.install(device.dev_id().clone()) {
+            warn!(
+                "VirtIOPmemDevice '{:?}' setup_irq failed, falling back to polling: {:?}",
+                device.dev_id(),
+                err
+            );
+            device.fallback_to_polling();
+        }
     }
     virtio_device_manager()
         .device_add(device as Arc<dyn VirtIODevice>)

--- a/kernel/src/exception/manage.rs
+++ b/kernel/src/exception/manage.rs
@@ -240,7 +240,7 @@ impl IrqManager {
         {
             error!(
                 "Flags mismatch for irq {} (name: {}, flags: {:?}). old action name: {}, old flags: {:?}",
-                desc.irq_data().irq().data(),
+                desc_guard.irq_data().irq().data(),
                 action_guard.name(),
                 action_guard.flags(),
                 old_action_guard.name(),

--- a/kernel/src/filesystem/fuse/virtiofs/bridge.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/bridge.rs
@@ -1827,9 +1827,11 @@ impl VirtioFsBridgeContext {
                 break;
             }
 
-            if let Some(transport) = self.transport.as_mut() {
-                if transport.ack_interrupt() {
-                    stats::on_virtiofs_ack_interrupt();
+            if !self.irq_wake_enabled {
+                if let Some(transport) = self.transport.as_mut() {
+                    if transport.ack_interrupt() {
+                        stats::on_virtiofs_ack_interrupt();
+                    }
                 }
             }
             let completed = self.drain_completions()?;

--- a/user/apps/virtiofs_bench/transcript_test.sh
+++ b/user/apps/virtiofs_bench/transcript_test.sh
@@ -416,4 +416,139 @@ VIRTIOFS_BENCH_RUN_ID=cleanup_again \
     "$BIN" --mount "$MOUNT" --workload cleanup --path schema_test \
     >"$WORK_DIR/cleanup-again.log" 2>&1
 check_transcript <"$WORK_DIR/cleanup-again.log"
+
+# The formal parallel-read phase uses one immutable file per worker and starts
+# only after every fd, buffer and worker thread is ready.
+VIRTIOFS_BENCH_RUN_ID=parallel_prepare \
+    "$BIN" --mount "$MOUNT" --workload parallel_read_prepare --path parallel_schema \
+    --file-size 16384 --block-size 4096 --workers 4 --iterations 1 \
+    >"$WORK_DIR/parallel-prepare.log" 2>&1
+check_result_only_transcript <"$WORK_DIR/parallel-prepare.log"
+awk '
+    function value(prefix,    i) {
+        for (i = 1; i <= NF; ++i) {
+            if (index($i, prefix "=") == 1) {
+                return substr($i, length(prefix) + 2)
+            }
+        }
+        return "__missing__"
+    }
+    $1 == "result" {
+        seen++
+        if (value("workload") != "parallel_read_prepare" || value("status") != "ok" ||
+            value("errno") != "0" || value("bytes") != "65536" || value("ops") != "4") {
+            bad = 1
+        }
+    }
+    END { exit bad || seen != 1 }
+' "$WORK_DIR/parallel-prepare.log"
+PARALLEL_DIR="$MOUNT/.virtiofs_bench_parallel_schema"
+if [ "$(find "$PARALLEL_DIR" -maxdepth 1 -type f -name 'parallel_read_worker_*.dat' | wc -l)" \
+    -ne 4 ]; then
+    echo "parallel prepare did not create one file per worker" >&2
+    exit 1
+fi
+find "$PARALLEL_DIR" -maxdepth 1 -type f -name 'parallel_read_worker_*.dat' -print0 \
+    | sort -z | xargs -0 sha256sum >"$WORK_DIR/parallel-before.sha256"
+
+for run in first second; do
+    VIRTIOFS_BENCH_RUN_ID="parallel_${run}" \
+        "$BIN" --mount "$MOUNT" --workload parallel_read --path parallel_schema \
+        --file-size 16384 --block-size 4096 --workers 4 --iterations 1 \
+        >"$WORK_DIR/parallel-${run}.log" 2>&1
+    check_result_only_transcript <"$WORK_DIR/parallel-${run}.log"
+    awk '
+        function value(prefix,    i) {
+            for (i = 1; i <= NF; ++i) {
+                if (index($i, prefix "=") == 1) {
+                    return substr($i, length(prefix) + 2)
+                }
+            }
+            return "__missing__"
+        }
+        $1 == "result" {
+            seen++
+            if (value("workload") != "parallel_read" || value("status") != "ok" ||
+                value("errno") != "0" || value("bytes") != "65536" ||
+                value("ops") != "16" || value("syscalls") != "20" ||
+                value("short_io") != "0" || value("eintr") != "0") {
+                bad = 1
+            }
+        }
+        END { exit bad || seen != 1 }
+    ' "$WORK_DIR/parallel-${run}.log"
+done
+first_checksum=$(sed -n 's/.* checksum=\([^ ]*\).*/\1/p' "$WORK_DIR/parallel-first.log")
+second_checksum=$(sed -n 's/.* checksum=\([^ ]*\).*/\1/p' "$WORK_DIR/parallel-second.log")
+if [ -z "$first_checksum" ] || [ "$first_checksum" != "$second_checksum" ] || \
+    ! grep -q ' bytes=65536 ' "$WORK_DIR/parallel-first.log"; then
+    echo "parallel read aggregate result is not deterministic" >&2
+    exit 1
+fi
+find "$PARALLEL_DIR" -maxdepth 1 -type f -name 'parallel_read_worker_*.dat' -print0 \
+    | sort -z | xargs -0 sha256sum >"$WORK_DIR/parallel-after.sha256"
+cmp -s "$WORK_DIR/parallel-before.sha256" "$WORK_DIR/parallel-after.sha256"
+
+mv "$PARALLEL_DIR/parallel_read_worker_2.dat" "$WORK_DIR/missing-worker.dat"
+set +e
+"$BIN" --mount "$MOUNT" --workload parallel_read --path parallel_schema \
+    --file-size 16384 --block-size 4096 --workers 4 --iterations 1 \
+    >"$WORK_DIR/parallel-missing.log" 2>&1
+parallel_missing_rc=$?
+set -e
+if [ "$parallel_missing_rc" -eq 0 ]; then
+    echo "parallel read unexpectedly accepted a missing worker file" >&2
+    exit 1
+fi
+check_result_only_transcript <"$WORK_DIR/parallel-missing.log"
+awk '
+    function value(prefix,    i) {
+        for (i = 1; i <= NF; ++i) {
+            if (index($i, prefix "=") == 1) {
+                return substr($i, length(prefix) + 2)
+            }
+        }
+        return "__missing__"
+    }
+    $1 == "result" {
+        seen++
+        if (value("workload") != "parallel_read" || value("status") != "fail" ||
+            value("errno") != "2" || value("bytes") != "0" || value("ops") != "0" ||
+            value("syscalls") != "0") {
+            bad = 1
+        }
+    }
+    END { exit bad || seen != 1 }
+' "$WORK_DIR/parallel-missing.log"
+mv "$WORK_DIR/missing-worker.dat" "$PARALLEL_DIR/parallel_read_worker_2.dat"
+
+set +e
+"$BIN" --mount "$MOUNT" --workload parallel_read --path parallel_schema \
+    --file-size 67108865 --block-size 4096 --workers 4 --iterations 1 \
+    >"$WORK_DIR/parallel-memory-limit.log" 2>&1
+parallel_memory_rc=$?
+set -e
+if [ "$parallel_memory_rc" -ne 2 ]; then
+    echo "parallel read memory limit returned $parallel_memory_rc, expected parse failure 2" >&2
+    exit 1
+fi
+set +e
+"$BIN" --mount "$MOUNT" --workload parallel_read --path parallel_schema \
+    --file-size 16384 --block-size 4096 --workers 0 --iterations 1 \
+    >"$WORK_DIR/parallel-zero-workers.log" 2>&1
+parallel_zero_workers_rc=$?
+set -e
+if [ "$parallel_zero_workers_rc" -ne 2 ]; then
+    echo "parallel read zero workers returned $parallel_zero_workers_rc, expected parse failure 2" >&2
+    exit 1
+fi
+
+VIRTIOFS_BENCH_RUN_ID=parallel_cleanup \
+    "$BIN" --mount "$MOUNT" --workload cleanup --path parallel_schema \
+    >"$WORK_DIR/parallel-cleanup.log" 2>&1
+check_transcript <"$WORK_DIR/parallel-cleanup.log"
+if [ -e "$PARALLEL_DIR" ]; then
+    echo "parallel cleanup left its dataset behind" >&2
+    exit 1
+fi
 echo "virtiofs benchmark transcript tests: PASS"

--- a/user/apps/virtiofs_bench/virtiofs_bench.cc
+++ b/user/apps/virtiofs_bench/virtiofs_bench.cc
@@ -71,6 +71,8 @@ enum class WorkloadSpec {
     RandomRead,
     Mmap,
     Concurrent,
+    ParallelReadPrepare,
+    ParallelRead,
 };
 
 const char* workload_name(WorkloadSpec workload) {
@@ -103,6 +105,10 @@ const char* workload_name(WorkloadSpec workload) {
             return "mmap";
         case WorkloadSpec::Concurrent:
             return "concurrent";
+        case WorkloadSpec::ParallelReadPrepare:
+            return "parallel_read_prepare";
+        case WorkloadSpec::ParallelRead:
+            return "parallel_read";
     }
     return "unknown";
 }
@@ -124,7 +130,9 @@ bool parse_workload(const std::string& value, WorkloadSpec* workload) {
                  {"cleanup", WorkloadSpec::Cleanup},
                  {"random_read", WorkloadSpec::RandomRead},
                  {"mmap", WorkloadSpec::Mmap},
-                 {"concurrent", WorkloadSpec::Concurrent}};
+                 {"concurrent", WorkloadSpec::Concurrent},
+                 {"parallel_read_prepare", WorkloadSpec::ParallelReadPrepare},
+                 {"parallel_read", WorkloadSpec::ParallelRead}};
     for (const auto& spec : specs) {
         if (value == spec.name) {
             *workload = spec.workload;
@@ -149,6 +157,8 @@ struct Options {
     size_t workers = 4;
     bool iterations_explicit = false;
 };
+
+constexpr size_t kParallelReadMemoryLimit = 256 * 1024 * 1024;
 
 using StatsMap = std::map<std::string, long long>;
 
@@ -1689,6 +1699,7 @@ int cleanup_workload(const Options& opt, const std::string&) {
                 }
                 const std::string name = entry->d_name;
                 const bool known = name == kDatasetFile || name == kManifestFile ||
+                                   name.rfind("parallel_read_worker_", 0) == 0 ||
                                    name.rfind(kSeqTempPrefix, 0) == 0 ||
                                    name.rfind(kManifestTempPrefix, 0) == 0 ||
                                    name.rfind(kSeqBackupPrefix, 0) == 0 ||
@@ -1927,11 +1938,275 @@ int concurrent_workload(const Options& opt, const std::string& root) {
     return rc;
 }
 
+constexpr const char* kParallelReadFilePrefix = "parallel_read_worker_";
+
+std::string parallel_read_file_path(const std::string& root, size_t worker) {
+    return path_join(root,
+                     std::string(kParallelReadFilePrefix) + std::to_string(worker) + ".dat");
+}
+
+int parallel_read_prepare_workload(const Options& opt, const std::string& root) {
+    const char* label = workload_name(WorkloadSpec::ParallelReadPrepare);
+    uint64_t start = now_us();
+    uint64_t bytes = 0;
+    uint64_t ops = 0;
+    int err = 0;
+    for (size_t i = 0; i < opt.workers; ++i) {
+        err = prepare_data_file(opt, parallel_read_file_path(root, i),
+                                static_cast<char>('A' + (i % 26)));
+        if (err != 0) {
+            break;
+        }
+        bytes += opt.file_size;
+        ++ops;
+    }
+    emit_result(label, opt, now_us() - start, bytes, ops, err);
+    return err == 0 ? 0 : -1;
+}
+
+struct ConcurrentStartGate {
+    std::atomic<size_t> ready{0};
+    std::atomic<size_t> read_done{0};
+    std::atomic<bool> released{false};
+    std::atomic<bool> verify_released{false};
+    std::atomic<bool> aborted{false};
+};
+
+constexpr uint64_t kConcurrentGateTimeoutUs = 10ULL * 1000 * 1000;
+
+void concurrent_gate_pause() {
+    // Keep pre-timing coordination from saturating small guests. The bounded
+    // wait uses a short nominal interval without consuming a runnable vCPU.
+    usleep(50);
+}
+
+bool wait_for_gate_count(const std::atomic<size_t>& count, size_t expected) {
+    const uint64_t start = now_us();
+    while (count.load(std::memory_order_acquire) != expected) {
+        const uint64_t now = now_us();
+        if (start == 0 || now == 0 || now - start >= kConcurrentGateTimeoutUs) {
+            return false;
+        }
+        concurrent_gate_pause();
+    }
+    return true;
+}
+
+void wait_for_read_completion(const std::atomic<size_t>& count, size_t expected) {
+    // I/O itself has no artificial benchmark timeout. External harnesses own
+    // workload timeouts.
+    while (count.load(std::memory_order_acquire) != expected) {
+        concurrent_gate_pause();
+    }
+}
+
+struct ConcurrentReadArg {
+    const Options* opt = nullptr;
+    ConcurrentStartGate* gate = nullptr;
+    size_t id = 0;
+    int fd = -1;
+    int err = 0;
+    uint64_t bytes = 0;
+    uint64_t ops = 0;
+    uint64_t checksum = 1469598103934665603ULL;
+    IoCounters io;
+    std::vector<unsigned char> buffer;
+    bool started = false;
+};
+
+void* concurrent_read_worker(void* raw) {
+    ConcurrentReadArg* arg = static_cast<ConcurrentReadArg*>(raw);
+    arg->gate->ready.fetch_add(1, std::memory_order_release);
+    while (!arg->gate->released.load(std::memory_order_acquire) &&
+           !arg->gate->aborted.load(std::memory_order_acquire)) {
+        concurrent_gate_pause();
+    }
+    if (arg->gate->aborted.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
+
+    size_t offset = 0;
+    while (offset < arg->opt->file_size) {
+        const size_t requested = std::min(arg->opt->block_size, arg->opt->file_size - offset);
+        ++arg->io.syscalls;
+        ssize_t n;
+        do {
+            n = pread(arg->fd, arg->buffer.data() + offset, requested,
+                      static_cast<off_t>(offset));
+            if (n < 0 && errno == EINTR) {
+                ++arg->io.eintr;
+                ++arg->io.syscalls;
+            }
+        } while (n < 0 && errno == EINTR);
+        if (n < 0) {
+            arg->err = errno_or_eio();
+            break;
+        }
+        if (static_cast<size_t>(n) != requested) {
+            ++arg->io.short_io;
+            arg->err = EIO;
+            break;
+        }
+        arg->bytes += static_cast<uint64_t>(n);
+        ++arg->ops;
+        offset += static_cast<size_t>(n);
+    }
+    if (arg->err == 0) {
+        unsigned char eof = 0;
+        ++arg->io.syscalls;
+        ssize_t n;
+        do {
+            n = pread(arg->fd, &eof, 1, static_cast<off_t>(arg->opt->file_size));
+            if (n < 0 && errno == EINTR) {
+                ++arg->io.eintr;
+                ++arg->io.syscalls;
+            }
+        } while (n < 0 && errno == EINTR);
+        if (n != 0) {
+            arg->err = n < 0 ? errno_or_eio() : EIO;
+        }
+    }
+    arg->gate->read_done.fetch_add(1, std::memory_order_release);
+    while (!arg->gate->verify_released.load(std::memory_order_acquire)) {
+        concurrent_gate_pause();
+    }
+
+    if (arg->err == 0) {
+        const unsigned char expected = static_cast<unsigned char>('A' + (arg->id % 26));
+        for (unsigned char value : arg->buffer) {
+            if (value != expected) {
+                arg->err = EILSEQ;
+                break;
+            }
+            arg->checksum ^= value;
+            arg->checksum *= 1099511628211ULL;
+        }
+    }
+    return nullptr;
+}
+
+int parallel_read_workload(const Options& opt, const std::string& root) {
+    const char* label = workload_name(WorkloadSpec::ParallelRead);
+    std::vector<pthread_t> threads(opt.workers);
+    std::vector<ConcurrentReadArg> args(opt.workers);
+    ConcurrentStartGate gate;
+    int err = 0;
+
+    for (size_t i = 0; i < opt.workers; ++i) {
+        args[i].opt = &opt;
+        args[i].gate = &gate;
+        args[i].id = i;
+        args[i].fd = open(parallel_read_file_path(root, i).c_str(),
+                          O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+        if (args[i].fd < 0) {
+            err = errno_or_eio();
+            break;
+        }
+        struct stat st = {};
+        if (fstat(args[i].fd, &st) != 0) {
+            err = errno_or_eio();
+            break;
+        }
+        if (!S_ISREG(st.st_mode) || st.st_size != static_cast<off_t>(opt.file_size)) {
+            err = EIO;
+            break;
+        }
+        try {
+            args[i].buffer.resize(opt.file_size);
+        } catch (const std::bad_alloc&) {
+            err = ENOMEM;
+            break;
+        }
+    }
+
+    if (err == 0) {
+        for (size_t i = 0; i < opt.workers; ++i) {
+            int rc = pthread_create(&threads[i], nullptr, concurrent_read_worker, &args[i]);
+            if (rc != 0) {
+                err = rc;
+                break;
+            }
+            args[i].started = true;
+        }
+    }
+
+    const bool verify_stats = !stats_path().empty();
+    StatsMap before;
+    if (err == 0 && !wait_for_quiescence(label, "before")) {
+        err = ETIMEDOUT;
+    }
+    if (err == 0) {
+        before = read_stats();
+        if (verify_stats && before.empty()) {
+            err = EIO;
+        }
+    }
+
+    uint64_t start = 0;
+    uint64_t elapsed = 0;
+    uint64_t cpu_start = 0;
+    uint64_t cpu_elapsed = 0;
+    if (err != 0) {
+        gate.aborted.store(true, std::memory_order_release);
+    } else {
+        if (!wait_for_gate_count(gate.ready, opt.workers)) {
+            err = ETIMEDOUT;
+            gate.aborted.store(true, std::memory_order_release);
+        } else {
+            cpu_start = process_cpu_us();
+            start = now_us();
+            gate.released.store(true, std::memory_order_release);
+            wait_for_read_completion(gate.read_done, opt.workers);
+            const uint64_t end = now_us();
+            const uint64_t cpu_end = process_cpu_us();
+            if (start != 0 && end >= start) {
+                elapsed = end - start;
+            }
+            if (cpu_start != 0 && cpu_end >= cpu_start) {
+                cpu_elapsed = cpu_end - cpu_start;
+            }
+            gate.verify_released.store(true, std::memory_order_release);
+        }
+    }
+
+    uint64_t bytes = 0;
+    uint64_t ops = 0;
+    uint64_t checksum = 0;
+    IoCounters io;
+    for (size_t i = 0; i < opt.workers; ++i) {
+        if (args[i].started) {
+            int rc = pthread_join(threads[i], nullptr);
+            record_first_error(&err, rc);
+        }
+        if (args[i].fd >= 0) {
+            close_preserve_error(args[i].fd, &err);
+        }
+        record_first_error(&err, args[i].err);
+        bytes += args[i].bytes;
+        ops += args[i].ops;
+        io.syscalls += args[i].io.syscalls;
+        io.short_io += args[i].io.short_io;
+        io.eintr += args[i].io.eintr;
+        checksum ^= mix64(args[i].checksum ^ i);
+    }
+    if (err == 0 && !wait_for_quiescence(label, "after")) {
+        err = ETIMEDOUT;
+    }
+    StatsMap after = read_stats();
+    emit_stats_delta(label, before, after);
+    if (err == 0 && verify_stats && after.empty()) {
+        err = EIO;
+    }
+    emit_result(label, opt, elapsed, bytes, ops, err, io, checksum, {}, cpu_elapsed);
+    return err == 0 ? 0 : -1;
+}
+
 void usage(const char* argv0) {
     fprintf(stderr,
             "usage: %s --mount PATH [--workload all|metadata|readdir|readdir_prepare|"
             "readdir_scan|readdir_cleanup|sequential|prepare|sequential_write|"
-            "sequential_read|cleanup|random_read|mmap|concurrent] "
+            "sequential_read|cleanup|random_read|mmap|concurrent|parallel_read_prepare|"
+            "parallel_read] "
             "[--path RELATIVE_DATASET] [--seed N] [--expect-dax always|never] [--files N] "
             "[--file-size N] [--block-size N] [--iterations N] [--workers N]\n",
             argv0);
@@ -2006,7 +2281,9 @@ bool is_dataset_lifecycle_workload(WorkloadSpec workload) {
     return workload == WorkloadSpec::Prepare || workload == WorkloadSpec::SequentialWrite ||
            workload == WorkloadSpec::SequentialRead || workload == WorkloadSpec::Cleanup ||
            workload == WorkloadSpec::ReaddirPrepare || workload == WorkloadSpec::ReaddirScan ||
-           workload == WorkloadSpec::ReaddirCleanup;
+           workload == WorkloadSpec::ReaddirCleanup ||
+           workload == WorkloadSpec::ParallelReadPrepare ||
+           workload == WorkloadSpec::ParallelRead;
 }
 
 bool mount_options_contain(const std::string& options, const std::string& expected) {
@@ -2090,12 +2367,27 @@ bool parse_args(int argc, char** argv, Options* opt) {
     if (opt->workload == WorkloadSpec::ReaddirScan && !opt->iterations_explicit) {
         opt->iterations = 1;
     }
+    if ((opt->workload == WorkloadSpec::ParallelReadPrepare ||
+         opt->workload == WorkloadSpec::ParallelRead) &&
+        !opt->iterations_explicit) {
+        opt->iterations = 1;
+    }
     if ((opt->workload == WorkloadSpec::ReaddirPrepare ||
          opt->workload == WorkloadSpec::ReaddirScan ||
          opt->workload == WorkloadSpec::ReaddirCleanup) &&
         (opt->files == 0 || opt->iterations == 0)) {
         fprintf(stderr, "%s requires non-zero --files and --iterations\n",
                 workload_name(opt->workload));
+        return false;
+    }
+    if ((opt->workload == WorkloadSpec::ParallelReadPrepare ||
+         opt->workload == WorkloadSpec::ParallelRead) &&
+        (opt->iterations != 1 || opt->workers == 0 || opt->file_size == 0 ||
+         opt->block_size == 0 || opt->file_size > kParallelReadMemoryLimit / opt->workers)) {
+        fprintf(stderr,
+                "%s requires --iterations 1, non-zero sizes/workers, and workers * file-size "
+                "no greater than %zu\n",
+                workload_name(opt->workload), kParallelReadMemoryLimit);
         return false;
     }
     if (opt->tag.empty()) {
@@ -2245,7 +2537,8 @@ int main(int argc, char** argv) {
     std::string root = path_join(opt.mount, ".virtiofs_bench_" + opt.path);
     if (opt.workload != WorkloadSpec::Cleanup &&
         opt.workload != WorkloadSpec::ReaddirCleanup &&
-        opt.workload != WorkloadSpec::ReaddirScan) {
+        opt.workload != WorkloadSpec::ReaddirScan &&
+        opt.workload != WorkloadSpec::ParallelRead) {
         int root_fd = open_dataset_dir(opt, true);
         if (root_fd < 0) {
             fprintf(stderr, "failed to create safe dataset %s: %s\n", root.c_str(),
@@ -2306,6 +2599,13 @@ int main(int argc, char** argv) {
     }
     if (opt.workload == WorkloadSpec::All || opt.workload == WorkloadSpec::Concurrent) {
         rc |= run_with_stats_delta(WorkloadSpec::Concurrent, concurrent_workload, opt, root);
+    }
+    if (opt.workload == WorkloadSpec::ParallelReadPrepare) {
+        rc |= run_with_stats_delta(WorkloadSpec::ParallelReadPrepare,
+                                   parallel_read_prepare_workload, opt, root);
+    }
+    if (opt.workload == WorkloadSpec::ParallelRead) {
+        rc |= parallel_read_workload(opt, root);
     }
 
     return rc == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

- allocate a unique x86 MSI/MSI-X CPU vector when an interrupt-driven VirtIO PCI transport sets up its IRQ
- bind allocated message-interrupt descriptors to the local APIC edge flow and skip reserved vectors
- centralize VirtIO PCI/MMIO IRQ registration and remove duplicate sysfs IRQ requests
- keep PCI ISR acknowledgement in the hard IRQ path while retaining bridge acknowledgement for polling fallback
- add a deterministic parallel-read benchmark with per-worker immutable files, bounded start coordination, aligned wall/CPU timing boundaries, checksum/EOF validation, and transcript tests

## Root cause

All VirtIO PCI devices previously used CPU vector 56 and registered shared actions on that descriptor. In MSI-X mode the ISR status cannot reliably identify which shared device raised the message, so block, network, or console interrupts could wake the VirtioFS completion path even when VirtioFS had no completed request. This caused sustained unrelated callback and wake activity.

The vector is allocated only after MSI/MSI-X capability selection succeeds. Polling-only transports therefore remain constructible on architectures without PCI MSI vector allocation. Vectors are intentionally not reused because the current PCI stack does not yet provide a complete disable, synchronize, free_irq, and hot-unplug lifecycle.

Generic PCI MSI/MSI-X requests remain shareable for compatibility with drivers that still use fixed vectors; VirtIO devices are isolated by their distinct descriptor vectors.

## Performance observations

The local 8-worker 4 KiB read study measured a pooled baseline median of approximately 52.8 ms and a candidate median of 50.124 ms, an improvement of about 5%.

The CubeSandbox two-way lower-layer read study measured A1/candidate/A2 medians of 742.219/666.031/722.417 ms. Compared with the pooled 729.463 ms baseline, the candidate improved elapsed time by 8.70%. This Cube result is exploratory because guest IRQ statistics and a complete provenance manifest were unavailable; it is not presented as a formal 10% performance-threshold result.

A final fresh-boot regression smoke test completed an 8-worker 16 MiB read with 4,096 data operations and 4,104 syscalls, with zero short I/O and zero EINTR, and a valid checksum.

## Validation

- `make fmt`
- `make kernel`
- `make test-host` in `user/apps/virtiofs_bench`
- fresh-boot non-DAX VirtioFS mount and read smoke test
- VirtIO filesystem, block, network, and console initialization
- adversarial architecture and benchmark review

Relates to #2019.