### PR TITLE
fix(vfs): use caller fs root for pivot_root

### DIFF
--- a/kernel/src/filesystem/fs.rs
+++ b/kernel/src/filesystem/fs.rs
@@ -166,4 +166,31 @@ impl FsStruct {
     pub fn root_resolved(&self) -> Result<ResolvedPath, system_error::SystemError> {
         self.path_context.read().root.resolved()
     }
+
+    /// Linux `chroot_fs_refs()` equivalent for one fs_struct. Both comparisons
+    /// and replacements are performed under one path-context write lock.
+    pub fn replace_root_pwd(&self, old: &ResolvedPath, new: &ResolvedPath) -> bool {
+        let old_inode = old.inode();
+        let mut paths = self.path_context.write();
+        let root_hit = same_path_ref(&paths.root.inode, &old_inode);
+        let pwd_hit = same_path_ref(&paths.pwd.inode, &old_inode);
+
+        if root_hit {
+            paths.root = PinnedPath::from_resolved(new.derive_existing_owner());
+        }
+        if pwd_hit {
+            paths.pwd = PinnedPath::from_resolved(new.derive_existing_owner());
+        }
+        root_hit || pwd_hit
+    }
+}
+
+fn same_path_ref(left: &Arc<dyn IndexNode>, right: &Arc<dyn IndexNode>) -> bool {
+    let Some(left_mount) = left.clone().downcast_arc::<MountFSInode>() else {
+        return Arc::ptr_eq(left, right);
+    };
+    let Some(right_mount) = right.clone().downcast_arc::<MountFSInode>() else {
+        return false;
+    };
+    left_mount.same_path_ref(&right_mount)
 }

--- a/kernel/src/filesystem/vfs/inode_lifecycle.rs
+++ b/kernel/src/filesystem/vfs/inode_lifecycle.rs
@@ -132,6 +132,14 @@ impl InodeRetentionGuard {
         inode.retain(kind)?;
         Ok(Self { inode, kind })
     }
+
+    /// Derive a new semantic owner while this owner keeps retention admission
+    /// open. `try_begin_freeing()` can close admission only when every kind has
+    /// a zero count, which is impossible while `self` is alive.
+    pub(crate) fn derive_existing(&self, kind: InodeRetentionKind) -> Self {
+        Self::new(self.inode.clone(), kind)
+            .expect("an existing inode retention owner must remain derivable")
+    }
 }
 
 impl Drop for InodeRetentionGuard {

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -57,8 +57,9 @@ use system_error::SystemError;
 /// detach, including propagation peers in other namespaces.
 ///
 /// Mount topology and propagation code acquires locks in this order:
-/// lifecycle -> namespace -> dentry mount gate -> parent mountpoints -> peer
-/// registry -> one mount's propagation state -> propagation group allocator.
+/// lifecycle -> namespace -> dentry mount gates (ordered by dentry ID) ->
+/// dentry topology snapshot -> parent mountpoints -> peer registry -> one
+/// mount's propagation state -> propagation group allocator.
 /// A lower layer must never acquire the lifecycle/topology layers in reverse.
 pub(crate) static MOUNT_LIFECYCLE_LOCK: Mutex<()> = Mutex::new(());
 
@@ -79,13 +80,116 @@ pub struct MountTopologyGuard {
     _mounts: MutexGuard<'static, ()>,
 }
 
+/// First stage of a mount-topology transaction.
+///
+/// Edge commits which also need dentry mount gates use this capability to
+/// acquire those gates before completing the dentry topology snapshot.
+pub(crate) struct MountLifecycleGuard {
+    mounts: MutexGuard<'static, ()>,
+}
+
+/// Proof that every dentry gate used by one mount-edge commit is held.
+/// The fields are private so only the gate-set helper can construct it.
+pub(crate) struct MountEdgeCommitToken {
+    dentries: [Option<DentryId>; 3],
+}
+
+impl MountEdgeCommitToken {
+    fn covers(&self, mountpoint: &MountFSInode) -> bool {
+        let id = mountpoint.dentry.id;
+        self.dentries.iter().flatten().any(|entry| *entry == id)
+    }
+}
+
+pub(crate) fn lock_mount_lifecycle() -> MountLifecycleGuard {
+    MountLifecycleGuard {
+        mounts: MOUNT_LIFECYCLE_LOCK.lock(),
+    }
+}
+
 /// Acquire the complete VFS topology snapshot in the canonical lock order.
 pub(crate) fn lock_mount_topology() -> MountTopologyGuard {
-    let mounts = MOUNT_LIFECYCLE_LOCK.lock();
-    let dentries = DENTRY_TOPOLOGY_LOCK.read();
-    MountTopologyGuard {
-        _dentries: dentries,
-        _mounts: mounts,
+    lock_mount_lifecycle().complete()
+}
+
+impl MountLifecycleGuard {
+    fn complete(self) -> MountTopologyGuard {
+        let dentries = DENTRY_TOPOLOGY_LOCK.read();
+        MountTopologyGuard {
+            _dentries: dentries,
+            _mounts: self.mounts,
+        }
+    }
+
+    /// Lock every dentry gate touched by an exact edge commit before taking
+    /// the dentry snapshot. Directory mutations hold the same gate while
+    /// acquiring the topology writer, so waiting for a gate under a read
+    /// snapshot would invert that order.
+    pub(crate) fn commit_mount_edges(
+        self,
+        mountpoints: [Option<Arc<MountFSInode>>; 3],
+        operation: impl FnOnce(&MountEdgeCommitToken) -> Result<(), SystemError>,
+    ) -> Result<MountTopologyGuard, SystemError> {
+        let mounts = self.mounts;
+        let dentries = mountpoints.map(|mountpoint| mountpoint.map(|inode| inode.dentry.clone()));
+        with_dentry_mount_gate_set(dentries, |token| {
+            let snapshot = DENTRY_TOPOLOGY_LOCK.read();
+            operation(token)?;
+            Ok(MountTopologyGuard {
+                _dentries: snapshot,
+                _mounts: mounts,
+            })
+        })
+    }
+}
+
+fn with_dentry_mount_gate_set<T>(
+    mut dentries: [Option<Arc<VfsDentry>>; 3],
+    operation: impl FnOnce(&MountEdgeCommitToken) -> T,
+) -> T {
+    dentries.sort_unstable_by_key(|entry| {
+        entry
+            .as_ref()
+            .map(|dentry| dentry.id.0)
+            .unwrap_or(usize::MAX)
+    });
+
+    let mut unique: [Option<Arc<VfsDentry>>; 3] = [None, None, None];
+    let mut count = 0;
+    for dentry in dentries.into_iter().flatten() {
+        if count == 0
+            || unique[count - 1]
+                .as_ref()
+                .is_none_or(|previous| previous.id != dentry.id)
+        {
+            unique[count] = Some(dentry);
+            count += 1;
+        }
+    }
+    let token = MountEdgeCommitToken {
+        dentries: unique
+            .each_ref()
+            .map(|entry| entry.as_ref().map(|dentry| dentry.id)),
+    };
+
+    match count {
+        0 => operation(&token),
+        1 => {
+            let _first = unique[0].as_ref().unwrap().mount_gate.lock();
+            operation(&token)
+        }
+        2 => {
+            let _first = unique[0].as_ref().unwrap().mount_gate.lock();
+            let _second = unique[1].as_ref().unwrap().mount_gate.lock();
+            operation(&token)
+        }
+        3 => {
+            let _first = unique[0].as_ref().unwrap().mount_gate.lock();
+            let _second = unique[1].as_ref().unwrap().mount_gate.lock();
+            let _third = unique[2].as_ref().unwrap().mount_gate.lock();
+            operation(&token)
+        }
+        _ => unreachable!(),
     }
 }
 
@@ -1290,11 +1394,35 @@ impl MountFS {
         self.attach_top_inner(mountpoint, mount_fs, true)
     }
 
+    pub(crate) fn attach_new_top_prelocked(
+        &self,
+        mountpoint: &Arc<MountFSInode>,
+        mount_fs: Arc<MountFS>,
+        gates: &MountEdgeCommitToken,
+    ) -> Result<(), SystemError> {
+        assert!(
+            gates.covers(mountpoint),
+            "mount-edge commit token must cover the attach dentry"
+        );
+        self.validate_attach_top(mountpoint, &mount_fs)?;
+        self.attach_top_prelocked(mountpoint, mount_fs, true)
+    }
+
     fn attach_top_inner(
         &self,
         mountpoint: &Arc<MountFSInode>,
         mount_fs: Arc<MountFS>,
         require_connected: bool,
+    ) -> Result<(), SystemError> {
+        self.validate_attach_top(mountpoint, &mount_fs)?;
+        let _gate = mountpoint.dentry.mount_gate.lock();
+        self.attach_top_prelocked(mountpoint, mount_fs, require_connected)
+    }
+
+    fn validate_attach_top(
+        &self,
+        mountpoint: &Arc<MountFSInode>,
+        mount_fs: &Arc<MountFS>,
     ) -> Result<(), SystemError> {
         if !Arc::ptr_eq(&mountpoint.mount_fs, &self.self_ref()) {
             return Err(SystemError::EINVAL);
@@ -1306,7 +1434,15 @@ impl MountFS {
         {
             return Err(SystemError::EINVAL);
         }
-        let _gate = mountpoint.dentry.mount_gate.lock();
+        Ok(())
+    }
+
+    fn attach_top_prelocked(
+        &self,
+        mountpoint: &Arc<MountFSInode>,
+        mount_fs: Arc<MountFS>,
+        require_connected: bool,
+    ) -> Result<(), SystemError> {
         if require_connected && mountpoint.is_disconnected() {
             return Err(SystemError::ENOENT);
         }
@@ -1596,6 +1732,30 @@ impl MountFS {
         replacement: Arc<MountFS>,
     ) -> Result<Arc<MountFS>, SystemError> {
         let mountpoint = old.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        let _gate = mountpoint.dentry.mount_gate.lock();
+        self.replace_exact_edge_prepared_prelocked(old, replacement, &mountpoint)
+    }
+
+    pub(crate) fn replace_exact_edge_prepared_with_token(
+        &self,
+        old: &Arc<MountFS>,
+        replacement: Arc<MountFS>,
+        gates: &MountEdgeCommitToken,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        let mountpoint = old.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        assert!(
+            gates.covers(&mountpoint),
+            "mount-edge commit token must cover the replace dentry"
+        );
+        self.replace_exact_edge_prepared_prelocked(old, replacement, &mountpoint)
+    }
+
+    fn replace_exact_edge_prepared_prelocked(
+        &self,
+        old: &Arc<MountFS>,
+        replacement: Arc<MountFS>,
+        mountpoint: &Arc<MountFSInode>,
+    ) -> Result<Arc<MountFS>, SystemError> {
         if !Arc::ptr_eq(&mountpoint.mount_fs, &self.self_ref())
             || replacement
                 .self_mountpoint()
@@ -1604,7 +1764,6 @@ impl MountFS {
         {
             return Err(SystemError::EINVAL);
         }
-        let _gate = mountpoint.dentry.mount_gate.lock();
         let mut mountpoints = self.mountpoints.lock();
         let stack = mountpoints
             .get_mut(&mountpoint.dentry.id)
@@ -1621,10 +1780,31 @@ impl MountFS {
         mount_fs: &Arc<MountFS>,
     ) -> Result<Arc<MountFS>, SystemError> {
         let mountpoint = mount_fs.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        let _gate = mountpoint.dentry.mount_gate.lock();
+        self.detach_exact_keep_slot_prelocked(mount_fs, &mountpoint)
+    }
+
+    pub(crate) fn detach_exact_keep_slot_with_token(
+        &self,
+        mount_fs: &Arc<MountFS>,
+        gates: &MountEdgeCommitToken,
+    ) -> Result<Arc<MountFS>, SystemError> {
+        let mountpoint = mount_fs.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        assert!(
+            gates.covers(&mountpoint),
+            "mount-edge commit token must cover the detach dentry"
+        );
+        self.detach_exact_keep_slot_prelocked(mount_fs, &mountpoint)
+    }
+
+    fn detach_exact_keep_slot_prelocked(
+        &self,
+        mount_fs: &Arc<MountFS>,
+        mountpoint: &Arc<MountFSInode>,
+    ) -> Result<Arc<MountFS>, SystemError> {
         if !Arc::ptr_eq(&mountpoint.mount_fs, &self.self_ref()) {
             return Err(SystemError::EINVAL);
         }
-        let _gate = mountpoint.dentry.mount_gate.lock();
         let key = mountpoint.dentry.id;
         let mut mountpoints = self.mountpoints.lock();
         let stack = mountpoints.get_mut(&key).ok_or(SystemError::ENOENT)?;

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         casting::DowncastArc,
         errseq::{ErrSeq, ErrSeqValue},
         mutex::{Mutex, MutexGuard},
-        rwsem::{RwSem, RwSemWriteGuard},
+        rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
         spinlock::SpinLock,
         wait_queue::WaitQueue,
     },
@@ -69,6 +69,26 @@ lazy_static! {
     static ref DENTRY_TOPOLOGY_LOCK: RwSem<()> = RwSem::new(());
 }
 
+/// Stable snapshot of both mount edges and dentry parent/name relationships.
+///
+/// Keep the field order in sync with the required release order: Rust drops
+/// fields in declaration order, so the dentry reader is released before the
+/// outer mount-lifecycle mutex.
+pub struct MountTopologyGuard {
+    _dentries: RwSemReadGuard<'static, ()>,
+    _mounts: MutexGuard<'static, ()>,
+}
+
+/// Acquire the complete VFS topology snapshot in the canonical lock order.
+pub(crate) fn lock_mount_topology() -> MountTopologyGuard {
+    let mounts = MOUNT_LIFECYCLE_LOCK.lock();
+    let dentries = DENTRY_TOPOLOGY_LOCK.read();
+    MountTopologyGuard {
+        _dentries: dentries,
+        _mounts: mounts,
+    }
+}
+
 /// Capability for one layered directory mutation to acquire the global dentry
 /// topology write lock exactly once.  Acquisition is deliberately lazy:
 /// layered filesystems may prepare a copy-up before the innermost backing
@@ -98,8 +118,7 @@ impl DentryMutationContext<'_> {
 }
 
 pub(crate) fn with_topology_snapshot<T>(f: impl FnOnce() -> T) -> T {
-    let _mounts = MOUNT_LIFECYCLE_LOCK.lock();
-    let _dentries = DENTRY_TOPOLOGY_LOCK.read();
+    let _topology = lock_mount_topology();
     f()
 }
 
@@ -1554,7 +1573,7 @@ impl MountFS {
         let _cover_reservation = mount_fs.reserve_mount_edge(cover_mountpoint, 0)?;
         mount_fs.detach_exact_keep_slot(covered)?;
         covered.relocate_mountpoint(Some(original_mountpoint.clone()));
-        let removed = match self.replace_exact_edge(mount_fs, covered.clone()) {
+        let removed = match self.replace_exact_edge_prepared(mount_fs, covered.clone()) {
             Ok(removed) => removed,
             Err(error) => {
                 // All objects remain owned; reconstruct the tuck-under
@@ -1571,7 +1590,7 @@ impl MountFS {
 
     /// Replace one exact edge in place, preserving the parent stack's key,
     /// capacity, ordering and mount-edge count.
-    fn replace_exact_edge(
+    pub(crate) fn replace_exact_edge_prepared(
         &self,
         old: &Arc<MountFS>,
         replacement: Arc<MountFS>,
@@ -2279,17 +2298,18 @@ impl MountFS {
     }
 
     fn derive_external_pin(&self) -> Result<MountExternalGuard, SystemError> {
-        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
         let mut lifecycle = self.lifecycle.lock();
         let component = match lifecycle.state {
-            MountLifecycleState::Constructing | MountLifecycleState::Detaching => {
+            MountLifecycleState::Constructing => {
                 return Err(SystemError::EBUSY);
             }
             MountLifecycleState::Detached if lifecycle.external_pins == 0 => {
                 return Err(SystemError::ESTALE);
             }
             MountLifecycleState::DetachedConnected => lifecycle.detached_component.clone(),
-            MountLifecycleState::Live | MountLifecycleState::Detached => None,
+            MountLifecycleState::Live
+            | MountLifecycleState::Detaching
+            | MountLifecycleState::Detached => None,
         };
         if component
             .as_ref()
@@ -2709,6 +2729,15 @@ impl MountExternalGuard {
     /// while lazy detach is in progress, matching Linux path_get semantics.
     pub fn derive(&self) -> Result<Self, SystemError> {
         self.mount.derive_external_pin()
+    }
+
+    /// Derive ownership from a guard that is known to remain alive for this
+    /// call. Final shutdown and detached-component cleanup both require the
+    /// existing owner count to reach zero, so failure indicates an internal
+    /// lifecycle-accounting bug rather than a recoverable pathname error.
+    pub(crate) fn derive_existing(&self) -> Self {
+        self.derive()
+            .expect("an existing mount pin must remain derivable")
     }
 }
 

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1760,7 +1760,7 @@ impl MountFS {
             || replacement
                 .self_mountpoint()
                 .as_ref()
-                .is_none_or(|replacement_mp| !Arc::ptr_eq(replacement_mp, &mountpoint))
+                .is_none_or(|replacement_mp| !Arc::ptr_eq(replacement_mp, mountpoint))
         {
             return Err(SystemError::EINVAL);
         }

--- a/kernel/src/filesystem/vfs/syscall/sys_pivot_root.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_pivot_root.rs
@@ -1,16 +1,19 @@
 //! System call handler for pivot_root(2).
 
 use alloc::{sync::Arc, vec::Vec};
+use hashbrown::HashMap;
 use system_error::SystemError;
 
 use crate::{
     arch::{interrupt::TrapFrame, syscall::nr::SYS_PIVOT_ROOT},
     filesystem::vfs::{
-        mount::MountFSInode, permission::PermissionMask, utils::user_path_at, FileSystem, FileType,
-        IndexNode, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
+        mount::MountFSInode,
+        permission::PermissionMask,
+        utils::{user_resolved_path_at, ResolvedPath},
+        FileType, IndexNode, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
     },
     libs::casting::DowncastArc,
-    process::{all_process, ProcessControlBlock, ProcessManager},
+    process::{all_process, lock_fs_refs_tasklist, ProcessControlBlock, ProcessManager},
     syscall::{
         table::{FormattedSyscallParam, Syscall},
         user_access::vfs_check_and_clone_cstr,
@@ -22,11 +25,10 @@ use super::sys_mount::may_mount;
 pub struct SysPivotRootHandle;
 
 struct PivotRootTargets {
-    current_pcb: Arc<ProcessControlBlock>,
     current_mntns: Arc<crate::process::namespace::mnt::MntNamespace>,
-    current_root_mntfs: Arc<crate::filesystem::vfs::MountFS>,
-    new_root_mntfs: Arc<crate::filesystem::vfs::MountFS>,
-    put_old_mountpoint: Arc<MountFSInode>,
+    current_root: ResolvedPath,
+    new_root: ResolvedPath,
+    put_old: ResolvedPath,
 }
 
 impl Syscall for SysPivotRootHandle {
@@ -36,19 +38,36 @@ impl Syscall for SysPivotRootHandle {
 
     fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
         let targets = resolve_pivot_root_targets(Self::new_root(args), Self::put_old(args))?;
-        let old_root_inode = targets.current_pcb.fs_struct().root();
+        let old_root = inode_as_mountpoint(&targets.current_root.inode())?;
+        let new_root = inode_as_mountpoint(&targets.new_root.inode())?;
+        let put_old = inode_as_mountpoint(&targets.put_old.inode())?;
 
-        targets.current_mntns.pivot_root(
-            targets.current_root_mntfs.clone(),
-            targets.new_root_mntfs.clone(),
-            targets.put_old_mountpoint.clone(),
-        )?;
-
-        // pivot_root operates on the caller's fs root, which may be a nested
-        // mount after chroot(2); it does not necessarily replace the mount
-        // namespace's global root.
-        let new_root_inode = targets.new_root_mntfs.root_inode();
-        repair_same_namespace_fs_refs(&targets.current_mntns, &old_root_inode, &new_root_inode);
+        // Match Linux's tasklist_lock boundary around chroot_fs_refs(): a
+        // newly copied fs_struct cannot become visible between this fixed
+        // published-task snapshot and the exact-reference migration.
+        let _fs_refs_tasklist = lock_fs_refs_tasklist();
+        let tasks = snapshot_all_processes()?;
+        let mut changed_fs = HashMap::new();
+        changed_fs
+            .try_reserve(tasks.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        let mut refresh_tasks = Vec::new();
+        refresh_tasks
+            .try_reserve(tasks.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        let topology = targets
+            .current_mntns
+            .pivot_root(old_root, new_root, put_old)?;
+        repair_fs_refs(
+            &tasks,
+            &targets.current_root,
+            &targets.new_root,
+            &mut changed_fs,
+            &mut refresh_tasks,
+        );
+        drop(topology);
+        drop(_fs_refs_tasklist);
+        refresh_cwd_caches(&refresh_tasks);
 
         Ok(0)
     }
@@ -98,85 +117,41 @@ fn resolve_pivot_root_targets(
 
     let current_pcb = ProcessManager::current_pcb();
     let current_mntns = ProcessManager::current_mntns();
-    let current_root_inode = current_pcb.fs_struct().root();
-
-    let (new_root_begin, new_root_rest) = user_path_at(
+    let (new_root_begin, new_root_rest) = user_resolved_path_at(
         &current_pcb,
         crate::filesystem::vfs::fcntl::AtFlags::AT_FDCWD.bits(),
         &new_root_path,
     )?;
-    let new_root_inode =
-        new_root_begin.lookup_follow_symlink(&new_root_rest, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+    let new_root = new_root_begin.inode().lookup_follow_symlink_owned(
+        &new_root_begin,
+        &new_root_rest,
+        VFS_MAX_FOLLOW_SYMLINK_TIMES,
+        true,
+    )?;
 
-    let (put_old_begin, put_old_rest) = user_path_at(
+    let (put_old_begin, put_old_rest) = user_resolved_path_at(
         &current_pcb,
         crate::filesystem::vfs::fcntl::AtFlags::AT_FDCWD.bits(),
         &put_old_path,
     )?;
-    let put_old_inode =
-        put_old_begin.lookup_follow_symlink(&put_old_rest, VFS_MAX_FOLLOW_SYMLINK_TIMES)?;
+    let put_old = put_old_begin.inode().lookup_follow_symlink_owned(
+        &put_old_begin,
+        &put_old_rest,
+        VFS_MAX_FOLLOW_SYMLINK_TIMES,
+        true,
+    )?;
+    // Match Linux get_fs_root(): one pinned caller-root snapshot is used for
+    // every check, topology mutation, and chroot_fs_refs-style replacement.
+    let current_root = current_pcb.fs_struct().root_resolved()?;
 
-    ensure_searchable_dir(&new_root_inode)?;
-    ensure_searchable_dir(&put_old_inode)?;
-
-    let current_root_mntfs = mount_fs_from_inode(&current_root_inode)?;
-    let new_root_mountpoint = inode_as_mountpoint(&new_root_inode)?;
-    let put_old_mountpoint = inode_as_mountpoint(&put_old_inode)?;
-    if new_root_mountpoint.is_disconnected() {
-        return Err(SystemError::ENOENT);
-    }
-    let new_root_mntfs = new_root_mountpoint.mount_fs();
-    let put_old_mntfs = put_old_mountpoint.mount_fs();
-
-    if same_path_ref(&new_root_inode, &current_root_inode)
-        || same_path_ref(&put_old_inode, &current_root_inode)
-    {
-        return Err(SystemError::EBUSY);
-    }
-
-    if !is_mount_root(&new_root_inode)? {
-        return Err(SystemError::EINVAL);
-    }
-
-    // Linux requires the caller's current fs root itself to be a mounted
-    // path. A chroot into an ordinary subdirectory must not rotate the whole
-    // containing mount.
-    if !is_mount_root(&current_root_inode)? {
-        return Err(SystemError::EINVAL);
-    }
-
-    if !is_path_reachable(&current_root_inode, &new_root_inode)? {
-        return Err(SystemError::EINVAL);
-    }
-
-    if !is_path_reachable(&new_root_inode, &put_old_inode)? {
-        return Err(SystemError::EINVAL);
-    }
-
-    let new_root_parent = new_root_mntfs
-        .self_mountpoint()
-        .ok_or(SystemError::EINVAL)?;
-    let new_root_parent_mntfs = new_root_parent.mount_fs();
-
-    let current_root_parent_mntfs = current_root_mntfs
-        .self_mountpoint()
-        .map(|mountpoint| mountpoint.mount_fs())
-        .unwrap_or_else(|| current_root_mntfs.clone());
-
-    if current_root_parent_mntfs.propagation().is_shared()
-        || new_root_parent_mntfs.propagation().is_shared()
-        || put_old_mntfs.propagation().is_shared()
-        || new_root_mntfs.is_locked()
-    {
-        return Err(SystemError::EINVAL);
-    }
+    ensure_searchable_dir(&new_root.inode())?;
+    ensure_searchable_dir(&put_old.inode())?;
 
     Ok(PivotRootTargets {
-        current_pcb,
         current_mntns,
-        current_root_mntfs,
-        new_root_mntfs,
-        put_old_mountpoint,
+        current_root,
+        new_root,
+        put_old,
     })
 }
 
@@ -193,15 +168,6 @@ fn ensure_searchable_dir(inode: &Arc<dyn IndexNode>) -> Result<(), SystemError> 
     )
 }
 
-fn mount_fs_from_inode(
-    inode: &Arc<dyn IndexNode>,
-) -> Result<Arc<crate::filesystem::vfs::MountFS>, SystemError> {
-    inode
-        .fs()
-        .downcast_arc::<crate::filesystem::vfs::MountFS>()
-        .ok_or(SystemError::EINVAL)
-}
-
 fn inode_as_mountpoint(inode: &Arc<dyn IndexNode>) -> Result<Arc<MountFSInode>, SystemError> {
     inode
         .clone()
@@ -209,75 +175,60 @@ fn inode_as_mountpoint(inode: &Arc<dyn IndexNode>) -> Result<Arc<MountFSInode>, 
         .ok_or(SystemError::EINVAL)
 }
 
-fn is_mount_root(inode: &Arc<dyn IndexNode>) -> Result<bool, SystemError> {
-    let mount_fs = mount_fs_from_inode(inode)?;
-    let mount_root = mount_fs.root_inode();
-    Ok(same_path_ref(inode, &mount_root))
-}
-
-fn same_path_ref(left: &Arc<dyn IndexNode>, right: &Arc<dyn IndexNode>) -> bool {
-    let Some(left) = left.clone().downcast_arc::<MountFSInode>() else {
-        return Arc::ptr_eq(left, right);
-    };
-    let Some(right) = right.clone().downcast_arc::<MountFSInode>() else {
-        return false;
-    };
-    Arc::ptr_eq(&left.mount_fs(), &right.mount_fs()) && left.dentry_id() == right.dentry_id()
-}
-
-fn is_path_reachable(
-    ancestor: &Arc<dyn IndexNode>,
-    descendant: &Arc<dyn IndexNode>,
-) -> Result<bool, SystemError> {
-    let mut current = descendant.clone();
-    for _ in 0..=MAX_PATHLEN {
-        if same_path_ref(ancestor, &current) {
-            return Ok(true);
-        }
-        let parent = current.parent()?;
-        if same_path_ref(&parent, &current) {
-            return Ok(false);
-        }
-        current = parent;
-    }
-    Err(SystemError::ELOOP)
-}
-
-fn repair_same_namespace_fs_refs(
-    target_mntns: &Arc<crate::process::namespace::mnt::MntNamespace>,
-    old_root_inode: &Arc<dyn IndexNode>,
-    new_root_inode: &Arc<dyn IndexNode>,
-) {
-    let tasks: Vec<Arc<ProcessControlBlock>> = {
+fn snapshot_all_processes() -> Result<Vec<Arc<ProcessControlBlock>>, SystemError> {
+    let mut tasks = Vec::new();
+    loop {
         let all = all_process().lock_irqsave();
-        all.as_ref()
-            .map(|map| map.values().cloned().collect())
-            .unwrap_or_default()
-    };
-
-    for task in tasks {
-        if !Arc::ptr_eq(task.nsproxy().mnt_namespace(), target_mntns) {
-            continue;
+        let required = all.as_ref().map(|map| map.len()).unwrap_or(0);
+        if tasks.capacity() >= required {
+            if let Some(map) = all.as_ref() {
+                // Capacity was reserved outside the IRQ-disabled section, so
+                // cloning the published PCB Arcs here cannot allocate.
+                tasks.extend(map.values().cloned());
+            }
+            return Ok(tasks);
         }
+        drop(all);
+        tasks
+            .try_reserve(required)
+            .map_err(|_| SystemError::ENOMEM)?;
+    }
+}
 
+fn repair_fs_refs(
+    tasks: &[Arc<ProcessControlBlock>],
+    old_root: &ResolvedPath,
+    new_root: &ResolvedPath,
+    changed_fs: &mut HashMap<usize, Arc<crate::filesystem::fs::FsStruct>>,
+    refresh_tasks: &mut Vec<Arc<ProcessControlBlock>>,
+) {
+    for task in tasks {
+        let _slot_update = task.lock_fs_slot_update();
         let Some(fs) = task.try_fs_struct() else {
             continue;
         };
-        let root_replaced = same_path_ref(&fs.root(), old_root_inode);
-        let pwd_replaced = same_path_ref(&fs.pwd(), old_root_inode);
-        if !root_replaced && !pwd_replaced {
-            continue;
+        let fs_id = Arc::as_ptr(&fs) as usize;
+        if fs.replace_root_pwd(old_root, new_root) {
+            // Retain the owner as well as indexing by address. This prevents
+            // allocator address reuse from turning the grouping key into an
+            // ABA match while another task concurrently replaces its slot.
+            changed_fs.insert(fs_id, fs.clone());
         }
+        // Every PCB sharing a changed FsStruct owns an independent display
+        // cache, even though only the first exact replacement reports a hit.
+        if changed_fs.contains_key(&fs_id) {
+            refresh_tasks.push(task.clone());
+        }
+    }
+}
 
-        if root_replaced {
-            fs.set_root(new_root_inode.clone());
-        }
-        if pwd_replaced {
-            fs.set_pwd(new_root_inode.clone());
-        }
-        // basic.cwd is only a display cache.  An unlinked cwd can make path
-        // rendering fail after the topology commit; Linux's chroot_fs_refs()
-        // is infallible, so cache refresh must not change syscall success.
+fn refresh_cwd_caches(tasks: &[Arc<ProcessControlBlock>]) {
+    for task in tasks {
+        let Some(fs) = task.try_fs_struct() else {
+            continue;
+        };
+        // basic.cwd is only a display cache. An unlinked cwd can make path
+        // rendering fail after commit; cache refresh must not change success.
         if let Ok(cwd) = visible_pwd(&fs) {
             task.basic_mut().set_cwd(cwd);
         }

--- a/kernel/src/filesystem/vfs/syscall/sys_pivot_root.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_pivot_root.rs
@@ -13,7 +13,7 @@ use crate::{
         FileType, IndexNode, MAX_PATHLEN, VFS_MAX_FOLLOW_SYMLINK_TIMES,
     },
     libs::casting::DowncastArc,
-    process::{all_process, lock_fs_refs_tasklist, ProcessControlBlock, ProcessManager},
+    process::{all_process, lock_fs_refs_pivot, ProcessControlBlock, ProcessManager},
     syscall::{
         table::{FormattedSyscallParam, Syscall},
         user_access::vfs_check_and_clone_cstr,
@@ -45,7 +45,7 @@ impl Syscall for SysPivotRootHandle {
         // Match Linux's tasklist_lock boundary around chroot_fs_refs(): a
         // newly copied fs_struct cannot become visible between this fixed
         // published-task snapshot and the exact-reference migration.
-        let _fs_refs_tasklist = lock_fs_refs_tasklist();
+        let fs_refs_pivot = lock_fs_refs_pivot();
         let tasks = snapshot_all_processes()?;
         let mut changed_fs = HashMap::new();
         changed_fs
@@ -66,7 +66,7 @@ impl Syscall for SysPivotRootHandle {
             &mut refresh_tasks,
         );
         drop(topology);
-        drop(_fs_refs_tasklist);
+        drop(fs_refs_pivot);
         refresh_cwd_caches(&refresh_tasks);
 
         Ok(0)

--- a/kernel/src/filesystem/vfs/utils.rs
+++ b/kernel/src/filesystem/vfs/utils.rs
@@ -67,6 +67,22 @@ impl ResolvedPath {
         Self::from_existing_mount(self.inode.clone(), mount_guard)
     }
 
+    /// Infallibly derive another operation owner from this live resolved path.
+    /// This does not perform initial mount-pin admission and therefore never
+    /// acquires the global mount topology lock.
+    pub(crate) fn derive_existing_owner(&self) -> Self {
+        Self {
+            inode: self.inode.clone(),
+            mount_guard: self
+                .mount_guard
+                .as_ref()
+                .map(MountExternalGuard::derive_existing),
+            _operation_guard: self
+                ._operation_guard
+                .derive_existing(InodeRetentionKind::Operation),
+        }
+    }
+
     pub fn into_parts(
         self,
     ) -> (

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -718,18 +718,6 @@ impl ProcessManager {
             )
         });
 
-        // Keep the fs_struct snapshot and child publication on the same side
-        // of pivot_root's exclusive migration barrier.
-        let fs_refs_copy = lock_fs_refs_copy();
-
-        // 拷贝文件系统信息
-        Self::copy_fs(&clone_flags, current_pcb, pcb, &fs_refs_copy).unwrap_or_else(|e| {
-            panic!(
-                "fork: Failed to copy fs from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
-                current_pcb.raw_pid(), pcb.raw_pid(), e
-            )
-        });
-
         // 拷贝信号相关数据
         Self::copy_sighand(&clone_flags, current_pcb, pcb).unwrap_or_else(|e| {
             panic!(
@@ -762,14 +750,6 @@ impl ProcessManager {
             )
         });
 
-        // 拷贝namespace
-        Self::copy_namespaces(&clone_flags, current_pcb, pcb, &fs_refs_copy).unwrap_or_else(|e| {
-            panic!(
-                "fork: Failed to copy namespaces from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
-                current_pcb.raw_pid(), pcb.raw_pid(), e
-            )
-        });
-
         // 拷贝线程
         Self::copy_thread(current_pcb, pcb, &clone_args, current_trapframe).unwrap_or_else(|e| {
             panic!(
@@ -788,6 +768,39 @@ impl ProcessManager {
 
         // 继承 cmdline（/proc/<pid>/cmdline 语义）
         pcb.set_cmdline_bytes(current_pcb.cmdline_bytes());
+
+        let current_leader = {
+            let ti = current_pcb.thread.read_irqsave();
+            ti.group_leader().unwrap_or_else(|| current_pcb.clone())
+        };
+        let clone_into_cgroup_target = Self::resolve_clone_into_cgroup_target(&clone_args)?;
+
+        // The default CPU is selected by wake_up_new_task(). Preserve only an
+        // explicit hint here, outside the fs publication barrier.
+        pcb.sched_info().mark_new_task(clone_args.target_cpu);
+
+        // Keep only the fs/namespace snapshot and the remaining child
+        // publication path on the same side of pivot_root's exclusive
+        // migration barrier. Potentially slow address-space, signal and
+        // architecture state copies above do not depend on this protocol.
+        let fs_refs_copy = lock_fs_refs_copy();
+
+        // 拷贝文件系统信息
+        Self::copy_fs(&clone_flags, current_pcb, pcb, &fs_refs_copy).unwrap_or_else(|e| {
+            panic!(
+                "fork: Failed to copy fs from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
+                current_pcb.raw_pid(), pcb.raw_pid(), e
+            )
+        });
+
+        // 拷贝namespace。CLONE_NEWNS 的 fs 路径投影依赖刚复制的 fs_struct，
+        // 因而这两步必须相邻且同处 publication barrier 内。
+        Self::copy_namespaces(&clone_flags, current_pcb, pcb, &fs_refs_copy).unwrap_or_else(|e| {
+            panic!(
+                "fork: Failed to copy namespaces from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
+                current_pcb.raw_pid(), pcb.raw_pid(), e
+            )
+        });
 
         // alloc_pid
         if pcb.raw_pid() == RawPid::UNASSIGNED {
@@ -829,12 +842,6 @@ impl ProcessManager {
             }
         }
 
-        let current_leader = {
-            let ti = current_pcb.thread.read_irqsave();
-            ti.group_leader().unwrap_or_else(|| current_pcb.clone())
-        };
-
-        let clone_into_cgroup_target = Self::resolve_clone_into_cgroup_target(&clone_args)?;
         let reserved_cgroup = if pcb.raw_pid() > RawPid(0) {
             let charge_node = clone_into_cgroup_target
                 .as_ref()
@@ -889,9 +896,6 @@ impl ProcessManager {
             pidfd_file = Some(prepared.file);
         }
 
-        // 新任务的默认落点 CPU 应在 wake_up_new_task() 时再选择；这里只保留显式 hint，
-        // 以避免 fork 长路径内父任务迁移导致的“过早采样当前 CPU”问题。
-        pcb.sched_info().mark_new_task(clone_args.target_cpu);
         sched_cgroup_fork(pcb);
 
         // 处理 rseq 状态。按 Linux copy_process() 顺序，应在任务对外可见前完成。
@@ -1046,7 +1050,7 @@ impl ProcessManager {
                 .install_reserved_fd(reservation, file)?;
         }
 
-        if pcb.raw_pid() > RawPid(0) {
+        let published_cgroup = if pcb.raw_pid() > RawPid(0) {
             let cgroup = pcb.task_cgroup_node();
             let needs_oom_score_adj_sync = Self::needs_oom_score_adj_clone_vm_sync(&clone_flags);
             let oom_score_adj_guard = if needs_oom_score_adj_sync {
@@ -1059,12 +1063,18 @@ impl ProcessManager {
             }
             ProcessManager::add_pcb(pcb.clone(), &fs_refs_copy);
             drop(oom_score_adj_guard);
+            Some(cgroup)
+        } else {
+            None
+        };
+        drop(fs_refs_copy);
+
+        if let Some(cgroup) = published_cgroup {
             cgroup.add_task(pcb.raw_pid());
             pcb.mark_visible_thread_accounted();
             inc_visible_thread_count();
             account_successful_fork();
         }
-        drop(fs_refs_copy);
 
         // 设置child_tid，意味着子线程能够知道自己的id。
         // 按 Linux schedule_tail 语义，在子任务首次运行时再 best-effort 写入。

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -29,8 +29,10 @@ use crate::{
 use super::{
     account_successful_fork, alloc_pid, inc_visible_thread_count,
     kthread::{KernelThreadPcbPrivate, WorkerPrivate},
+    lock_fs_refs_copy,
     pid::{Pid, PidType},
-    KernelStack, ProcessControlBlock, ProcessManager, RawPid, PTRACE_RELATION_LOCK,
+    FsRefsReadGuard, KernelStack, ProcessControlBlock, ProcessManager, RawPid,
+    PTRACE_RELATION_LOCK,
 };
 pub const MAX_PID_NS_LEVEL: usize = 32;
 
@@ -716,8 +718,12 @@ impl ProcessManager {
             )
         });
 
+        // Keep the fs_struct snapshot and child publication on the same side
+        // of pivot_root's exclusive migration barrier.
+        let fs_refs_copy = lock_fs_refs_copy();
+
         // 拷贝文件系统信息
-        Self::copy_fs(&clone_flags, current_pcb, pcb).unwrap_or_else(|e| {
+        Self::copy_fs(&clone_flags, current_pcb, pcb, &fs_refs_copy).unwrap_or_else(|e| {
             panic!(
                 "fork: Failed to copy fs from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.raw_pid(), pcb.raw_pid(), e
@@ -757,7 +763,7 @@ impl ProcessManager {
         });
 
         // 拷贝namespace
-        Self::copy_namespaces(&clone_flags, current_pcb, pcb).unwrap_or_else(|e| {
+        Self::copy_namespaces(&clone_flags, current_pcb, pcb, &fs_refs_copy).unwrap_or_else(|e| {
             panic!(
                 "fork: Failed to copy namespaces from current process, current pid: [{:?}], new pid: [{:?}]. Error: {:?}",
                 current_pcb.raw_pid(), pcb.raw_pid(), e
@@ -1051,13 +1057,14 @@ impl ProcessManager {
             if needs_oom_score_adj_sync {
                 Self::sync_oom_score_adj_for_clone_vm(current_pcb, pcb);
             }
-            ProcessManager::add_pcb(pcb.clone());
+            ProcessManager::add_pcb(pcb.clone(), &fs_refs_copy);
             drop(oom_score_adj_guard);
             cgroup.add_task(pcb.raw_pid());
             pcb.mark_visible_thread_accounted();
             inc_visible_thread_count();
             account_successful_fork();
         }
+        drop(fs_refs_copy);
 
         // 设置child_tid，意味着子线程能够知道自己的id。
         // 按 Linux schedule_tail 语义，在子任务首次运行时再 best-effort 写入。
@@ -1100,6 +1107,7 @@ impl ProcessManager {
         clone_flags: &CloneFlags,
         parent_pcb: &Arc<ProcessControlBlock>,
         child_pcb: &Arc<ProcessControlBlock>,
+        fs_refs: &FsRefsReadGuard,
     ) -> Result<(), SystemError> {
         let fs = parent_pcb.fs_struct();
         let child_fs = if clone_flags.contains(CloneFlags::CLONE_FS) {
@@ -1107,7 +1115,7 @@ impl ProcessManager {
         } else {
             Arc::new((*fs).clone())
         };
-        child_pcb.set_fs_struct(child_fs);
+        child_pcb.set_fs_struct(child_fs, fs_refs);
         Ok(())
     }
 

--- a/kernel/src/process/manager/mod.rs
+++ b/kernel/src/process/manager/mod.rs
@@ -12,6 +12,7 @@ use system_error::SystemError;
 use crate::{
     libs::{
         mutex::{Mutex, MutexGuard},
+        rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
         spinlock::SpinLock,
     },
     mm::{
@@ -113,12 +114,27 @@ pub(super) static mut __PROCESS_MANAGEMENT_INIT_DONE: bool = false;
 /// mm with another thread group must not miss a concurrent oom_score_adj update
 /// while it is becoming visible.
 static OOM_SCORE_ADJ_LOCK: Mutex<()> = Mutex::new(());
-/// Serializes publication of a task carrying a newly copied FsStruct with
-/// pivot_root's chroot_fs_refs-style scan of all published tasks.
-static FS_REFS_TASKLIST_LOCK: Mutex<()> = Mutex::new(());
+/// Allows concurrent fs_struct copy-and-publish operations while excluding
+/// pivot_root's topology commit and chroot_fs_refs-style migration.
+static FS_REFS_PUBLICATION_BARRIER: RwSem<()> = RwSem::new(());
 
-pub(crate) fn lock_fs_refs_tasklist() -> MutexGuard<'static, ()> {
-    FS_REFS_TASKLIST_LOCK.lock()
+pub(crate) struct FsRefsReadGuard {
+    _guard: RwSemReadGuard<'static, ()>,
+}
+pub(crate) struct FsRefsWriteGuard {
+    _guard: RwSemWriteGuard<'static, ()>,
+}
+
+pub(crate) fn lock_fs_refs_copy() -> FsRefsReadGuard {
+    FsRefsReadGuard {
+        _guard: FS_REFS_PUBLICATION_BARRIER.read(),
+    }
+}
+
+pub(crate) fn lock_fs_refs_pivot() -> FsRefsWriteGuard {
+    FsRefsWriteGuard {
+        _guard: FS_REFS_PUBLICATION_BARRIER.write(),
+    }
 }
 
 pub struct SwitchResult {
@@ -302,8 +318,7 @@ impl ProcessManager {
     /// ## Parameters
     ///
     /// - `pcb`: The PCB of the process.
-    pub fn add_pcb(pcb: Arc<ProcessControlBlock>) {
-        let _fs_refs_tasklist = lock_fs_refs_tasklist();
+    pub(crate) fn add_pcb(pcb: Arc<ProcessControlBlock>, _fs_refs: &FsRefsReadGuard) {
         ALL_PROCESS
             .lock_irqsave()
             .as_mut()

--- a/kernel/src/process/manager/mod.rs
+++ b/kernel/src/process/manager/mod.rs
@@ -113,6 +113,13 @@ pub(super) static mut __PROCESS_MANAGEMENT_INIT_DONE: bool = false;
 /// mm with another thread group must not miss a concurrent oom_score_adj update
 /// while it is becoming visible.
 static OOM_SCORE_ADJ_LOCK: Mutex<()> = Mutex::new(());
+/// Serializes publication of a task carrying a newly copied FsStruct with
+/// pivot_root's chroot_fs_refs-style scan of all published tasks.
+static FS_REFS_TASKLIST_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn lock_fs_refs_tasklist() -> MutexGuard<'static, ()> {
+    FS_REFS_TASKLIST_LOCK.lock()
+}
 
 pub struct SwitchResult {
     pub prev_pcb: Option<Arc<ProcessControlBlock>>,
@@ -296,6 +303,7 @@ impl ProcessManager {
     ///
     /// - `pcb`: The PCB of the process.
     pub fn add_pcb(pcb: Arc<ProcessControlBlock>) {
+        let _fs_refs_tasklist = lock_fs_refs_tasklist();
         ALL_PROCESS
             .lock_irqsave()
             .as_mut()

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -48,7 +48,7 @@ pub use info::{
 pub use kstack::{KernelStack, KernelStackType};
 pub(crate) use manager::{
     account_context_switch, account_successful_fork, all_process, dec_visible_thread_count,
-    inc_visible_thread_count, lock_fs_refs_tasklist,
+    inc_visible_thread_count, lock_fs_refs_copy, lock_fs_refs_pivot, FsRefsReadGuard,
 };
 #[allow(unused_imports)]
 pub use manager::{

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -48,7 +48,7 @@ pub use info::{
 pub use kstack::{KernelStack, KernelStackType};
 pub(crate) use manager::{
     account_context_switch, account_successful_fork, all_process, dec_visible_thread_count,
-    inc_visible_thread_count,
+    inc_visible_thread_count, lock_fs_refs_tasklist,
 };
 #[allow(unused_imports)]
 pub use manager::{

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -268,17 +268,19 @@ impl MntNamespace {
         let old_root = old_root_path.mount_fs();
         let new_root = new_root_path.mount_fs();
         let put_old_mnt = put_old_mountpoint.mount_fs();
+        let namespace_root = self.inner.read().root_mountfs.clone();
+        let old_is_namespace_root = Arc::ptr_eq(&old_root, &namespace_root);
         // lock_mount(&old) rejects a path whose containing mount was lazily
         // detached after pathname resolution before pivot validation.
         if !put_old_mnt.is_live() || !put_old_mnt.is_belongs_to_mntns(&namespace) {
             return Err(SystemError::ENOENT);
         }
-        // Linux keeps an unattached namespace root parented to itself. Mirror
-        // that identity for the checks which precede the explicit
-        // mnt_has_parent() rejection, so an old_mnt == root_mnt loop still
-        // reports EBUSY before the unattached-root EINVAL.
-        let root_parent = old_root
-            .self_mountpoint()
+        // DragonOS represents the namespace root without a visible parent
+        // edge. Attached caller roots use their exact parent below; the
+        // namespace-root branch instead publishes through root_mountfs.
+        let old_root_mountpoint = old_root.self_mountpoint();
+        let root_parent = old_root_mountpoint
+            .as_ref()
             .map(|mountpoint| mountpoint.mount_fs())
             .unwrap_or_else(|| old_root.clone());
         let new_root_parent = new_root
@@ -288,7 +290,7 @@ impl MntNamespace {
 
         if put_old_mnt.propagation().is_shared()
             || new_root_parent.propagation().is_shared()
-            || root_parent.propagation().is_shared()
+            || (!old_is_namespace_root && root_parent.propagation().is_shared())
             || !old_root.is_live()
             || !new_root.is_live()
             || !old_root.is_belongs_to_mntns(&namespace)
@@ -303,7 +305,9 @@ impl MntNamespace {
         if Arc::ptr_eq(&new_root, &old_root) || Arc::ptr_eq(&put_old_mnt, &old_root) {
             return Err(SystemError::EBUSY);
         }
-        let old_root_mountpoint = old_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        if !old_is_namespace_root && old_root_mountpoint.is_none() {
+            return Err(SystemError::EINVAL);
+        }
         let new_root_mountpoint = new_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
         if !old_root_path.same_path_ref(&old_root.mountpoint_root_inode())
             || !new_root_path.same_path_ref(&new_root.mountpoint_root_inode())
@@ -321,14 +325,30 @@ impl MntNamespace {
         // keep the original new-root key alive and guarantee one put-old slot.
         let _new_edge = new_root_parent.reserve_mount_edge(&new_root_mountpoint, 0)?;
         let _put_old_edge = put_old_mnt.reserve_mount_edge(&put_old_mountpoint, 1)?;
+        let mut namespace_inner = if old_is_namespace_root {
+            let inner = self.inner.write();
+            if !Arc::ptr_eq(&inner.root_mountfs, &old_root) {
+                return Err(SystemError::EINVAL);
+            }
+            Some(inner)
+        } else {
+            None
+        };
 
         new_root_parent
             .detach_exact_keep_slot(&new_root)
             .expect("validated pivot new-root edge must exist");
-        new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
-        root_parent
-            .replace_exact_edge_prepared(&old_root, new_root.clone())
-            .expect("validated pivot old-root edge must remain exact");
+        if old_is_namespace_root {
+            new_root.relocate_mountpoint(None);
+        } else {
+            let old_root_mountpoint = old_root_mountpoint
+                .as_ref()
+                .expect("validated attached caller root must keep its mountpoint");
+            new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
+            root_parent
+                .replace_exact_edge_prepared(&old_root, new_root.clone())
+                .expect("validated pivot old-root edge must remain exact");
+        }
         old_root.relocate_mountpoint(Some(put_old_mountpoint.clone()));
         put_old_mnt
             .attach_new_top(&put_old_mountpoint, old_root.clone())
@@ -340,6 +360,9 @@ impl MntNamespace {
         if old_root.is_locked() {
             old_root.unlock_mount();
             new_root.lock_mount();
+        }
+        if let Some(inner) = namespace_inner.as_mut() {
+            inner.root_mountfs = new_root;
         }
 
         Ok(topology)

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -1,7 +1,8 @@
 use crate::{
     filesystem::vfs::{
         mount::{
-            lock_mount_topology, MountFSInode, MountFlags, MountTopologyGuard, MOUNT_LIFECYCLE_LOCK,
+            lock_mount_lifecycle, MountFSInode, MountFlags, MountTopologyGuard,
+            MOUNT_LIFECYCLE_LOCK,
         },
         FileSystem, IndexNode, MountFS,
     },
@@ -255,26 +256,21 @@ impl MntNamespace {
         new_root_path: Arc<MountFSInode>,
         put_old_mountpoint: Arc<MountFSInode>,
     ) -> Result<MountTopologyGuard, SystemError> {
-        let topology = lock_mount_topology();
+        let lifecycle = lock_mount_lifecycle();
         let namespace = self.self_ref.upgrade().ok_or(SystemError::EINVAL)?;
 
         // Linux lock_mount(&old) follows any mount stacked on put_old while
         // holding namespace topology serialization.
         let put_old_mountpoint = put_old_mountpoint.overlaid_inode();
-        if put_old_mountpoint.is_disconnected() {
-            return Err(SystemError::ENOENT);
-        }
-
         let old_root = old_root_path.mount_fs();
         let new_root = new_root_path.mount_fs();
         let put_old_mnt = put_old_mountpoint.mount_fs();
-        let namespace_root = self.inner.read().root_mountfs.clone();
+        // Namespace publication precedes dentry gates in the canonical order.
+        // Keeping this writer across the commit also pins the namespace root
+        // identity until the final publication step.
+        let mut namespace_inner = self.inner.write();
+        let namespace_root = namespace_inner.root_mountfs.clone();
         let old_is_namespace_root = Arc::ptr_eq(&old_root, &namespace_root);
-        // lock_mount(&old) rejects a path whose containing mount was lazily
-        // detached after pathname resolution before pivot validation.
-        if !put_old_mnt.is_live() || !put_old_mnt.is_belongs_to_mntns(&namespace) {
-            return Err(SystemError::ENOENT);
-        }
         // DragonOS represents the namespace root without a visible parent
         // edge. Attached caller roots use their exact parent below; the
         // namespace-root branch instead publishes through root_mountfs.
@@ -283,89 +279,108 @@ impl MntNamespace {
             .as_ref()
             .map(|mountpoint| mountpoint.mount_fs())
             .unwrap_or_else(|| old_root.clone());
-        let new_root_parent = new_root
-            .self_mountpoint()
-            .map(|mountpoint| mountpoint.mount_fs())
-            .unwrap_or_else(|| new_root.clone());
-
-        if put_old_mnt.propagation().is_shared()
-            || new_root_parent.propagation().is_shared()
-            || (!old_is_namespace_root && root_parent.propagation().is_shared())
-            || !old_root.is_live()
-            || !new_root.is_live()
-            || !old_root.is_belongs_to_mntns(&namespace)
-            || !new_root.is_belongs_to_mntns(&namespace)
-            || new_root.is_locked()
-        {
-            return Err(SystemError::EINVAL);
-        }
-        if new_root_path.is_disconnected() {
-            return Err(SystemError::ENOENT);
-        }
-        if Arc::ptr_eq(&new_root, &old_root) || Arc::ptr_eq(&put_old_mnt, &old_root) {
-            return Err(SystemError::EBUSY);
-        }
         if !old_is_namespace_root && old_root_mountpoint.is_none() {
             return Err(SystemError::EINVAL);
         }
         let new_root_mountpoint = new_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
-        if !old_root_path.same_path_ref(&old_root.mountpoint_root_inode())
-            || !new_root_path.same_path_ref(&new_root.mountpoint_root_inode())
-            || put_old_mountpoint
-                .relative_path_from_snapshot(&new_root_path)?
-                .is_none()
-            || new_root_path
-                .relative_path_from_snapshot(&old_root_path)?
-                .is_none()
-        {
-            return Err(SystemError::EINVAL);
-        }
+        let new_root_parent = new_root_mountpoint.mount_fs();
+        let gates = [
+            Some(new_root_mountpoint.clone()),
+            if old_is_namespace_root {
+                None
+            } else {
+                old_root_mountpoint.clone()
+            },
+            Some(put_old_mountpoint.clone()),
+        ];
 
-        // Prepare every allocation before changing an edge. The reservations
-        // keep the original new-root key alive and guarantee one put-old slot.
-        let _new_edge = new_root_parent.reserve_mount_edge(&new_root_mountpoint, 0)?;
-        let _put_old_edge = put_old_mnt.reserve_mount_edge(&put_old_mountpoint, 1)?;
-        let mut namespace_inner = if old_is_namespace_root {
-            let inner = self.inner.write();
-            if !Arc::ptr_eq(&inner.root_mountfs, &old_root) {
+        lifecycle.commit_mount_edges(gates, |gate_token| {
+            // Repeat every admission check only after both dentry aliases and
+            // all affected edge gates have been frozen. This is the atomic
+            // validation point for the transaction.
+            if put_old_mountpoint.is_disconnected() {
+                return Err(SystemError::ENOENT);
+            }
+            // lock_mount(&old) rejects a path whose containing mount was
+            // lazily detached after pathname resolution.
+            if !put_old_mnt.is_live() || !put_old_mnt.is_belongs_to_mntns(&namespace) {
+                return Err(SystemError::ENOENT);
+            }
+            if put_old_mnt.propagation().is_shared()
+                || new_root_parent.propagation().is_shared()
+                || (!old_is_namespace_root && root_parent.propagation().is_shared())
+                || !old_root.is_live()
+                || !new_root.is_live()
+                || !old_root.is_belongs_to_mntns(&namespace)
+                || !new_root.is_belongs_to_mntns(&namespace)
+                || new_root.is_locked()
+                || !Arc::ptr_eq(&namespace_inner.root_mountfs, &namespace_root)
+                || new_root
+                    .self_mountpoint()
+                    .as_ref()
+                    .is_none_or(|mountpoint| !Arc::ptr_eq(mountpoint, &new_root_mountpoint))
+            {
                 return Err(SystemError::EINVAL);
             }
-            Some(inner)
-        } else {
-            None
-        };
+            if new_root_path.is_disconnected() {
+                return Err(SystemError::ENOENT);
+            }
+            if Arc::ptr_eq(&new_root, &old_root) || Arc::ptr_eq(&put_old_mnt, &old_root) {
+                return Err(SystemError::EBUSY);
+            }
+            if !old_root_path.same_path_ref(&old_root.mountpoint_root_inode())
+                || !new_root_path.same_path_ref(&new_root.mountpoint_root_inode())
+                || put_old_mountpoint
+                    .relative_path_from_snapshot(&new_root_path)?
+                    .is_none()
+                || new_root_path
+                    .relative_path_from_snapshot(&old_root_path)?
+                    .is_none()
+            {
+                return Err(SystemError::EINVAL);
+            }
 
-        new_root_parent
-            .detach_exact_keep_slot(&new_root)
-            .expect("validated pivot new-root edge must exist");
-        if old_is_namespace_root {
-            new_root.relocate_mountpoint(None);
-        } else {
-            let old_root_mountpoint = old_root_mountpoint
-                .as_ref()
-                .expect("validated attached caller root must keep its mountpoint");
-            new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
-            root_parent
-                .replace_exact_edge_prepared(&old_root, new_root.clone())
-                .expect("validated pivot old-root edge must remain exact");
-        }
-        old_root.relocate_mountpoint(Some(put_old_mountpoint.clone()));
-        put_old_mnt
-            .attach_new_top(&put_old_mountpoint, old_root.clone())
-            .expect("reserved pivot put-old edge must attach without allocation");
+            // Prepare every allocation before changing an edge. The
+            // reservations keep the original new-root key alive and
+            // guarantee one put-old slot.
+            let _new_edge = new_root_parent.reserve_mount_edge(&new_root_mountpoint, 0)?;
+            let _put_old_edge = put_old_mnt.reserve_mount_edge(&put_old_mountpoint, 1)?;
 
-        // Linux transfers MNT_LOCKED from the old root to the new root at
-        // commit. The old root now lives below put_old, outside the boundary
-        // that the lock protected before pivot_root.
-        if old_root.is_locked() {
-            old_root.unlock_mount();
-            new_root.lock_mount();
-        }
-        if let Some(inner) = namespace_inner.as_mut() {
-            inner.root_mountfs = new_root;
-        }
+            new_root_parent
+                .detach_exact_keep_slot_with_token(&new_root, gate_token)
+                .expect("validated pivot new-root edge must exist");
+            if old_is_namespace_root {
+                new_root.relocate_mountpoint(None);
+            } else {
+                let old_root_mountpoint = old_root_mountpoint
+                    .as_ref()
+                    .expect("validated attached caller root must keep its mountpoint");
+                new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
+                root_parent
+                    .replace_exact_edge_prepared_with_token(
+                        &old_root,
+                        new_root.clone(),
+                        gate_token,
+                    )
+                    .expect("validated pivot old-root edge must remain exact");
+            }
+            old_root.relocate_mountpoint(Some(put_old_mountpoint.clone()));
+            put_old_mnt
+                .attach_new_top_prelocked(&put_old_mountpoint, old_root.clone(), gate_token)
+                .expect("reserved pivot put-old edge must attach without allocation");
 
-        Ok(topology)
+            // Linux transfers MNT_LOCKED from the old root to the new root at
+            // commit. The old root now lives below put_old, outside the
+            // boundary that the lock protected before pivot_root.
+            if old_root.is_locked() {
+                old_root.unlock_mount();
+                new_root.lock_mount();
+            }
+            if old_is_namespace_root {
+                namespace_inner.root_mountfs = new_root.clone();
+            }
+            Ok(())
+        })
     }
 
     /// Move a complete mount subtree onto an exact shared dentry.

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -1,6 +1,8 @@
 use crate::{
     filesystem::vfs::{
-        mount::{MountFSInode, MountFlags, MOUNT_LIFECYCLE_LOCK},
+        mount::{
+            lock_mount_topology, MountFSInode, MountFlags, MountTopologyGuard, MOUNT_LIFECYCLE_LOCK,
+        },
         FileSystem, IndexNode, MountFS,
     },
     libs::{casting::DowncastArc, once::Once, rwsem::RwSem},
@@ -247,85 +249,90 @@ impl MntNamespace {
         old_root.deactivate();
     }
 
-    pub fn pivot_root(
+    pub(crate) fn pivot_root(
         &self,
-        old_root: Arc<MountFS>,
-        new_root: Arc<MountFS>,
+        old_root_path: Arc<MountFSInode>,
+        new_root_path: Arc<MountFSInode>,
         put_old_mountpoint: Arc<MountFSInode>,
-    ) -> Result<(), SystemError> {
-        let new_root_mountpoint = new_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
-        let new_root_parent = new_root_mountpoint.mount_fs();
-        let put_old_parent = put_old_mountpoint.mount_fs();
-        let _topology = MOUNT_LIFECYCLE_LOCK.lock();
-        let mut inner_guard = self.inner.write();
-        let old_root_mountpoint = old_root.self_mountpoint();
-        let old_root_tucked_under = old_root.is_tucked_under();
-        let new_root_tucked_under = new_root.is_tucked_under();
-        let namespace_root = Self::root_mntfs_locked(&inner_guard);
-        if !old_root.is_belongs_to_mntns(&self.self_ref.upgrade().ok_or(SystemError::EINVAL)?)
+    ) -> Result<MountTopologyGuard, SystemError> {
+        let topology = lock_mount_topology();
+        let namespace = self.self_ref.upgrade().ok_or(SystemError::EINVAL)?;
+
+        // Linux lock_mount(&old) follows any mount stacked on put_old while
+        // holding namespace topology serialization.
+        let put_old_mountpoint = put_old_mountpoint.overlaid_inode();
+        if put_old_mountpoint.is_disconnected() {
+            return Err(SystemError::ENOENT);
+        }
+
+        let old_root = old_root_path.mount_fs();
+        let new_root = new_root_path.mount_fs();
+        let put_old_mnt = put_old_mountpoint.mount_fs();
+        // lock_mount(&old) rejects a path whose containing mount was lazily
+        // detached after pathname resolution before pivot validation.
+        if !put_old_mnt.is_live() || !put_old_mnt.is_belongs_to_mntns(&namespace) {
+            return Err(SystemError::ENOENT);
+        }
+        // Linux keeps an unattached namespace root parented to itself. Mirror
+        // that identity for the checks which precede the explicit
+        // mnt_has_parent() rejection, so an old_mnt == root_mnt loop still
+        // reports EBUSY before the unattached-root EINVAL.
+        let root_parent = old_root
+            .self_mountpoint()
+            .map(|mountpoint| mountpoint.mount_fs())
+            .unwrap_or_else(|| old_root.clone());
+        let new_root_parent = new_root
+            .self_mountpoint()
+            .map(|mountpoint| mountpoint.mount_fs())
+            .unwrap_or_else(|| new_root.clone());
+
+        if put_old_mnt.propagation().is_shared()
+            || new_root_parent.propagation().is_shared()
+            || root_parent.propagation().is_shared()
+            || !old_root.is_live()
+            || !new_root.is_live()
+            || !old_root.is_belongs_to_mntns(&namespace)
+            || !new_root.is_belongs_to_mntns(&namespace)
             || new_root.is_locked()
         {
             return Err(SystemError::EINVAL);
         }
-
-        if put_old_parent.lookup_top(&put_old_mountpoint).is_some() {
+        if new_root_path.is_disconnected() {
+            return Err(SystemError::ENOENT);
+        }
+        if Arc::ptr_eq(&new_root, &old_root) || Arc::ptr_eq(&put_old_mnt, &old_root) {
             return Err(SystemError::EBUSY);
         }
-
-        new_root_parent.detach_exact(&new_root)?;
-
-        let old_parent = old_root_mountpoint
-            .as_ref()
-            .map(|mountpoint| mountpoint.mount_fs());
-        if let (Some(parent), Some(_)) = (&old_parent, &old_root_mountpoint) {
-            if let Err(error) = parent.detach_exact(&old_root) {
-                new_root_parent
-                    .attach_top(&new_root_mountpoint, new_root.clone())
-                    .expect("pivot_root rollback must restore the detached new root");
-                new_root.restore_tucked_under(new_root_tucked_under);
-                return Err(error);
-            }
+        let old_root_mountpoint = old_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        let new_root_mountpoint = new_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
+        if !old_root_path.same_path_ref(&old_root.mountpoint_root_inode())
+            || !new_root_path.same_path_ref(&new_root.mountpoint_root_inode())
+            || put_old_mountpoint
+                .relative_path_from_snapshot(&new_root_path)?
+                .is_none()
+            || new_root_path
+                .relative_path_from_snapshot(&old_root_path)?
+                .is_none()
+        {
+            return Err(SystemError::EINVAL);
         }
 
+        // Prepare every allocation before changing an edge. The reservations
+        // keep the original new-root key alive and guarantee one put-old slot.
+        let _new_edge = new_root_parent.reserve_mount_edge(&new_root_mountpoint, 0)?;
+        let _put_old_edge = put_old_mnt.reserve_mount_edge(&put_old_mountpoint, 1)?;
+
+        new_root_parent
+            .detach_exact_keep_slot(&new_root)
+            .expect("validated pivot new-root edge must exist");
+        new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
+        root_parent
+            .replace_exact_edge_prepared(&old_root, new_root.clone())
+            .expect("validated pivot old-root edge must remain exact");
         old_root.relocate_mountpoint(Some(put_old_mountpoint.clone()));
-        if let Err(error) = put_old_parent.attach_new_top(&put_old_mountpoint, old_root.clone()) {
-            old_root.relocate_mountpoint(old_root_mountpoint.clone());
-            if let (Some(parent), Some(mountpoint)) = (&old_parent, &old_root_mountpoint) {
-                parent
-                    .attach_top(mountpoint, old_root.clone())
-                    .expect("pivot_root rollback must restore the current root edge");
-                old_root.restore_tucked_under(old_root_tucked_under);
-            }
-            new_root_parent
-                .attach_top(&new_root_mountpoint, new_root.clone())
-                .expect("pivot_root rollback must restore the detached new root");
-            new_root.restore_tucked_under(new_root_tucked_under);
-            return Err(error);
-        }
-
-        if let (Some(parent), Some(mountpoint)) = (&old_parent, &old_root_mountpoint) {
-            new_root.relocate_mountpoint(Some(mountpoint.clone()));
-            if let Err(error) = parent.attach_top(mountpoint, new_root.clone()) {
-                put_old_parent
-                    .detach_exact(&old_root)
-                    .expect("pivot_root rollback must detach the temporary old root edge");
-                old_root.relocate_mountpoint(Some(mountpoint.clone()));
-                parent
-                    .attach_top(mountpoint, old_root.clone())
-                    .expect("pivot_root rollback must restore the current root edge");
-                old_root.restore_tucked_under(old_root_tucked_under);
-                new_root.relocate_mountpoint(Some(new_root_mountpoint.clone()));
-                new_root_parent
-                    .attach_top(&new_root_mountpoint, new_root.clone())
-                    .expect("pivot_root rollback must restore the new-root edge");
-                new_root.restore_tucked_under(new_root_tucked_under);
-                return Err(error);
-            }
-        } else {
-            debug_assert!(Arc::ptr_eq(&namespace_root, &old_root));
-            new_root.relocate_mountpoint(None);
-            inner_guard.root_mountfs = new_root.clone();
-        }
+        put_old_mnt
+            .attach_new_top(&put_old_mountpoint, old_root.clone())
+            .expect("reserved pivot put-old edge must attach without allocation");
 
         // Linux transfers MNT_LOCKED from the old root to the new root at
         // commit. The old root now lives below put_old, outside the boundary
@@ -335,7 +342,7 @@ impl MntNamespace {
             new_root.lock_mount();
         }
 
-        Ok(())
+        Ok(topology)
     }
 
     /// Move a complete mount subtree onto an exact shared dentry.

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -357,11 +357,7 @@ impl MntNamespace {
                     .expect("validated attached caller root must keep its mountpoint");
                 new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
                 root_parent
-                    .replace_exact_edge_prepared_with_token(
-                        &old_root,
-                        new_root.clone(),
-                        gate_token,
-                    )
+                    .replace_exact_edge_prepared_with_token(&old_root, new_root.clone(), gate_token)
                     .expect("validated pivot old-root edge must remain exact");
             }
             old_root.relocate_mountpoint(Some(put_old_mountpoint.clone()));

--- a/kernel/src/process/namespace/nsproxy.rs
+++ b/kernel/src/process/namespace/nsproxy.rs
@@ -13,7 +13,7 @@ use crate::{
             net_namespace::{NetNamespace, INIT_NET_NAMESPACE},
             uts_namespace::{UtsNamespace, INIT_UTS_NAMESPACE},
         },
-        ProcessControlBlock, ProcessManager,
+        FsRefsReadGuard, ProcessControlBlock, ProcessManager,
     },
 };
 use core::{fmt::Debug, intrinsics::likely};
@@ -122,10 +122,11 @@ impl ProcessManager {
     ///
     /// https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/nsproxy.c?r=&mo=3770&fi=151#151
     #[inline(never)]
-    pub fn copy_namespaces(
+    pub(crate) fn copy_namespaces(
         clone_flags: &CloneFlags,
         _parent_pcb: &Arc<ProcessControlBlock>,
         child_pcb: &Arc<ProcessControlBlock>,
+        _fs_refs: &FsRefsReadGuard,
     ) -> Result<(), SystemError> {
         // log::debug!(
         //     "copy_namespaces: clone_flags={:?}, parent pid={}, child pid={}, child name={}",
@@ -284,14 +285,16 @@ pub fn exec_task_namespaces() -> Result<(), SystemError> {
     let user_ns = tsk.cred().user_ns.clone();
     let new_nsproxy = create_new_namespaces(&CloneFlags::empty(), &tsk, user_ns)?;
     // todo: time_ns的逻辑
-    switch_task_namespaces(&tsk, new_nsproxy)?;
+    let fs_refs = crate::process::lock_fs_refs_copy();
+    switch_task_namespaces(&tsk, new_nsproxy, &fs_refs)?;
 
     return Ok(());
 }
 
-pub fn switch_task_namespaces(
+pub(crate) fn switch_task_namespaces(
     tsk: &Arc<ProcessControlBlock>,
     new_nsproxy: Arc<NsProxy>,
+    _fs_refs: &FsRefsReadGuard,
 ) -> Result<(), SystemError> {
     // Check sharing before taking our temporary Arc below.  Counting after
     // cloning the Arc would mistake this function's own reference for a
@@ -305,6 +308,7 @@ pub(crate) fn switch_task_namespaces_with_fs(
     tsk: &Arc<ProcessControlBlock>,
     fs: &Arc<FsStruct>,
     new_nsproxy: Arc<NsProxy>,
+    _fs_refs: &FsRefsReadGuard,
 ) -> Result<(), SystemError> {
     // unshare(CLONE_NEWNS) passes either a freshly copied fs_struct or the
     // task's proven-private one, so there is no CLONE_FS peer to reject.

--- a/kernel/src/process/namespace/setns.rs
+++ b/kernel/src/process/namespace/setns.rs
@@ -7,6 +7,7 @@ use crate::{
     process::{
         cred::{ns_capable, CAPFlags, Cred},
         fork::CloneFlags,
+        lock_fs_refs_copy,
         pid::PidType,
         ProcessManager,
     },
@@ -183,7 +184,8 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
         }
 
         let new_nsproxy = Arc::new(new_inner);
-        switch_task_namespaces(&current, new_nsproxy)?;
+        let fs_refs = lock_fs_refs_copy();
+        switch_task_namespaces(&current, new_nsproxy, &fs_refs)?;
         return Ok(());
     }
 
@@ -259,7 +261,8 @@ pub fn ksys_setns(fd: i32, nstype: i32) -> Result<(), SystemError> {
     let new_nsproxy = Arc::new(new_inner);
 
     // 5. 原子切换当前任务的 namespace 代理
-    switch_task_namespaces(&current, new_nsproxy)?;
+    let fs_refs = lock_fs_refs_copy();
+    switch_task_namespaces(&current, new_nsproxy, &fs_refs)?;
 
     Ok(())
 }

--- a/kernel/src/process/namespace/unshare.rs
+++ b/kernel/src/process/namespace/unshare.rs
@@ -7,6 +7,7 @@ use crate::{
     process::{
         cred::{ns_capable, CAPFlags, Cred},
         fork::CloneFlags,
+        lock_fs_refs_copy,
         namespace::nsproxy::{
             create_new_namespaces, switch_task_namespaces, switch_task_namespaces_with_fs, NsProxy,
         },
@@ -23,21 +24,23 @@ pub fn ksys_unshare(flags: CloneFlags) -> Result<(), SystemError> {
 
     let current_pcb = ProcessManager::current_pcb();
     let mut new_cred = unshare_user_cred(flags, &current_pcb)?;
-    let new_fs = unshare_fs_struct(flags, &current_pcb)?;
+    let fs_refs = lock_fs_refs_copy();
+    let new_fs = unshare_fs_struct(flags, &current_pcb, &fs_refs)?;
     let new_nsproxy =
         unshare_nsproxy_namespaces(flags, &current_pcb, new_cred.as_ref(), new_fs.as_ref())?;
 
     if let Some(new_nsproxy) = new_nsproxy {
         if let Some(new_fs) = new_fs.as_ref() {
-            switch_task_namespaces_with_fs(&current_pcb, new_fs, new_nsproxy)?;
+            switch_task_namespaces_with_fs(&current_pcb, new_fs, new_nsproxy, &fs_refs)?;
         } else {
-            switch_task_namespaces(&current_pcb, new_nsproxy)?;
+            switch_task_namespaces(&current_pcb, new_nsproxy, &fs_refs)?;
         }
     }
 
     if let Some(new_fs) = new_fs {
-        current_pcb.set_fs_struct(new_fs);
+        current_pcb.set_fs_struct(new_fs, &fs_refs);
     }
+    drop(fs_refs);
 
     if let Some(new_cred) = new_cred.take() {
         current_pcb.set_cred(Cred::new_arc(new_cred))?;
@@ -87,6 +90,7 @@ fn unshare_user_cred(
 fn unshare_fs_struct(
     unshare_flags: CloneFlags,
     current_pcb: &Arc<crate::process::ProcessControlBlock>,
+    _fs_refs: &crate::process::FsRefsReadGuard,
 ) -> Result<Option<Arc<FsStruct>>, SystemError> {
     if !unshare_flags.contains(CloneFlags::CLONE_FS) {
         return Ok(None);

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -26,6 +26,7 @@ use crate::{
     libs::{
         futex::futex::RobustListHead,
         lock_free_flags::LockFreeFlags,
+        mutex::{Mutex, MutexGuard},
         rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableGuard, RwLockWriteGuard},
         rwsem::RwSem,
         spinlock::{SpinLock, SpinLockGuard},
@@ -161,6 +162,9 @@ pub struct ProcessControlBlock {
 
     /// Process filesystem state.
     pub(super) fs: RwLock<Option<Arc<FsStruct>>>,
+    /// Serializes replacement/removal of `fs` with pivot_root's exact-path
+    /// migration. Ordinary readers intentionally stay off this cold-path lock.
+    fs_slot_update_lock: Mutex<()>,
 
     /// Alarm timer.
     pub(super) alarm_timer: SpinLock<Option<AlarmTimer>>,
@@ -332,6 +336,7 @@ impl ProcessControlBlock {
                 cputime_wait_queue: WaitQueue::default(),
                 thread: RwLock::new(ThreadInfo::new()),
                 fs: RwLock::new(Some(Arc::new(FsStruct::new()))),
+                fs_slot_update_lock: Mutex::new(()),
                 alarm_timer: SpinLock::new(None),
                 itimers: SpinLock::new(ProcessItimers::default()),
                 posix_timers: SpinLock::new(posix_timer::ProcessPosixTimers::default()),
@@ -763,6 +768,7 @@ impl ProcessControlBlock {
     }
 
     pub fn set_fs_struct(&self, fs: Arc<FsStruct>) -> Arc<FsStruct> {
+        let _slot_update = self.fs_slot_update_lock.lock();
         let mut guard = self.fs.write();
         let old = guard.replace(fs).expect("live task must have an fs_struct");
         old
@@ -773,7 +779,17 @@ impl ProcessControlBlock {
     /// This mirrors Linux `exit_fs()`: a zombie retains process metadata for
     /// wait(2), but must no longer pin its root or working-directory mounts.
     pub(super) fn exit_fs(&self) {
-        self.fs.write().take();
+        let _slot_update = self.fs_slot_update_lock.lock();
+        let fs = self.fs.write().take();
+        // Release the spin-based slot guard before dropping the final FsStruct
+        // owner, whose path-pin destructors may enqueue deferred cleanup work.
+        drop(fs);
+    }
+
+    /// Stabilize this task's fs slot across an operation that may sleep while
+    /// updating the referenced FsStruct.
+    pub(crate) fn lock_fs_slot_update(&self) -> MutexGuard<'_, ()> {
+        self.fs_slot_update_lock.lock()
     }
 
     pub fn pwd_inode(&self) -> Arc<dyn IndexNode> {

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -767,7 +767,11 @@ impl ProcessControlBlock {
         ) > 1
     }
 
-    pub fn set_fs_struct(&self, fs: Arc<FsStruct>) -> Arc<FsStruct> {
+    pub(crate) fn set_fs_struct(
+        &self,
+        fs: Arc<FsStruct>,
+        _fs_refs: &super::FsRefsReadGuard,
+    ) -> Arc<FsStruct> {
         let _slot_update = self.fs_slot_update_lock.lock();
         let mut guard = self.fs.write();
         let old = guard.replace(fs).expect("live task must have an fs_struct");

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -785,8 +785,9 @@ impl ProcessControlBlock {
     pub(super) fn exit_fs(&self) {
         let _slot_update = self.fs_slot_update_lock.lock();
         let fs = self.fs.write().take();
-        // Release the spin-based slot guard before dropping the final FsStruct
+        // Release the slot guard before dropping the final FsStruct
         // owner, whose path-pin destructors may enqueue deferred cleanup work.
+        drop(_slot_update);
         drop(fs);
     }
 

--- a/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
@@ -759,13 +759,21 @@ void case_namespace_root_pivot() {
     const char* base = "/tmp/test_pivot_root/namespace_root";
     const char* new_root = "/tmp/test_pivot_root/namespace_root/newroot";
     const char* put_old = "/tmp/test_pivot_root/namespace_root/newroot/oldroot";
-    const char* old_marker = "/tmp/test_pivot_root/namespace_root/old_marker";
+    const char* old_marker = "/tmp/test_pivot_root/namespace_root_old_marker";
     const char* new_marker = "/tmp/test_pivot_root/namespace_root/newroot/new_marker";
 
     ensure_parent_tree();
     ensure_dir(base);
-    ensure_dir(new_root);
     prepare_private_mount_namespace();
+    // Keep the new root's real parent private, then make only the caller's
+    // namespace root shared. Linux checks root_mnt->mnt_parent, not root_mnt
+    // itself, so this remains a valid namespace-root pivot.
+    if (mount("", base, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir namespace-root newroot failed");
+    }
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
@@ -774,12 +782,15 @@ void case_namespace_root_pivot() {
         (mkdir(new_marker, 0755) != 0 && errno != EEXIST)) {
         child_fail("prepare namespace-root markers failed");
     }
+    if (mount(nullptr, "/", nullptr, MS_SHARED, nullptr) != 0) {
+        child_skip("cannot make namespace root shared");
+    }
 
     if (do_pivot_root(new_root, put_old) != 0) {
         child_fail("pivot_root from namespace root failed");
     }
     if (access("/new_marker", F_OK) != 0 ||
-        access("/oldroot/tmp/test_pivot_root/namespace_root/old_marker", F_OK) != 0) {
+        access("/oldroot/tmp/test_pivot_root/namespace_root_old_marker", F_OK) != 0) {
         child_fail("namespace-root pivot published incomplete topology");
     }
     child_pass();

--- a/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
@@ -755,10 +755,12 @@ void case_chroot_ordinary_directory_rejected() {
     child_pass();
 }
 
-void case_namespace_root_rejected() {
+void case_namespace_root_pivot() {
     const char* base = "/tmp/test_pivot_root/namespace_root";
     const char* new_root = "/tmp/test_pivot_root/namespace_root/newroot";
     const char* put_old = "/tmp/test_pivot_root/namespace_root/newroot/oldroot";
+    const char* old_marker = "/tmp/test_pivot_root/namespace_root/old_marker";
+    const char* new_marker = "/tmp/test_pivot_root/namespace_root/newroot/new_marker";
 
     ensure_parent_tree();
     ensure_dir(base);
@@ -767,13 +769,18 @@ void case_namespace_root_rejected() {
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
-    if (mkdir(put_old, 0755) != 0 && errno != EEXIST) {
-        child_fail("mkdir(oldroot) failed");
+    if ((mkdir(put_old, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(old_marker, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(new_marker, 0755) != 0 && errno != EEXIST)) {
+        child_fail("prepare namespace-root markers failed");
     }
 
-    errno = 0;
-    if (do_pivot_root(new_root, put_old) != -1 || errno != EINVAL) {
-        child_fail("pivot_root from namespace root did not return EINVAL");
+    if (do_pivot_root(new_root, put_old) != 0) {
+        child_fail("pivot_root from namespace root failed");
+    }
+    if (access("/new_marker", F_OK) != 0 ||
+        access("/oldroot/tmp/test_pivot_root/namespace_root/old_marker", F_OK) != 0) {
+        child_fail("namespace-root pivot published incomplete topology");
     }
     child_pass();
 }
@@ -1185,8 +1192,8 @@ TEST(PivotRoot, ChrootOrdinaryDirectoryRejected) {
                              case_chroot_ordinary_directory_rejected);
 }
 
-TEST(PivotRoot, NamespaceRootRejected) {
-    expect_case_pass_or_skip("pivot_root_namespace_root_rejected", case_namespace_root_rejected);
+TEST(PivotRoot, NamespaceRootPivot) {
+    expect_case_pass_or_skip("pivot_root_namespace_root", case_namespace_root_pivot);
 }
 
 TEST(PivotRoot, NewRootOnRootMount) {

--- a/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
@@ -142,17 +142,24 @@ void expect_case_pass_or_skip(const char* case_name, PivotRootCaseFn fn) {
 }
 
 void case_success_path() {
-    const char* new_root = "/tmp/test_pivot_root/success/newroot";
+    const char* old_root = "/tmp/test_pivot_root/success/root";
+    const char* new_root = "/tmp/test_pivot_root/success/root/newroot";
     const char* put_old = "oldroot";
-    const char* oldroot_abs = "/tmp/test_pivot_root/success/newroot/oldroot";
-    const char* bin_dir = "/tmp/test_pivot_root/success/newroot/bin";
+    const char* oldroot_abs = "/tmp/test_pivot_root/success/root/newroot/oldroot";
+    const char* bin_dir = "/tmp/test_pivot_root/success/root/newroot/bin";
     char cwd[256] = {};
 
     ensure_parent_tree();
     ensure_dir("/tmp/test_pivot_root/success");
-    ensure_dir(new_root);
+    ensure_dir(old_root);
     prepare_private_mount_namespace();
 
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
@@ -167,9 +174,8 @@ void case_success_path() {
         child_fail("mkdir(bin) failed");
     }
 
-    if (chdir(new_root) != 0) {
-        cleanup_mount(new_root);
-        child_fail("chdir(new_root) failed");
+    if (chroot(old_root) != 0 || chdir("/newroot") != 0) {
+        child_fail("chroot/chdir(new_root) failed");
     }
 
     if (do_pivot_root(".", put_old) != 0) {
@@ -196,17 +202,24 @@ void case_success_path() {
 }
 
 void case_dot_dot_path() {
-    const char* new_root = "/tmp/test_pivot_root/dotdot/newroot";
-    const char* bin_dir = "/tmp/test_pivot_root/dotdot/newroot/bin";
+    const char* old_root = "/tmp/test_pivot_root/dotdot/root";
+    const char* new_root = "/tmp/test_pivot_root/dotdot/root/newroot";
+    const char* bin_dir = "/tmp/test_pivot_root/dotdot/root/newroot/bin";
     int oldroot_fd = -1;
     int newroot_fd = -1;
     char cwd[256] = {};
 
     ensure_parent_tree();
     ensure_dir("/tmp/test_pivot_root/dotdot");
-    ensure_dir(new_root);
+    ensure_dir(old_root);
     prepare_private_mount_namespace();
 
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
@@ -216,13 +229,17 @@ void case_dot_dot_path() {
         child_fail("mkdir(bin) failed");
     }
 
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+
     oldroot_fd = open("/", O_DIRECTORY | O_RDONLY);
     if (oldroot_fd < 0) {
         cleanup_mount(new_root);
         child_fail("open(oldroot) failed");
     }
 
-    newroot_fd = open(new_root, O_DIRECTORY | O_RDONLY);
+    newroot_fd = open("/newroot", O_DIRECTORY | O_RDONLY);
     if (newroot_fd < 0) {
         close(oldroot_fd);
         cleanup_mount(new_root);
@@ -278,16 +295,23 @@ void case_dot_dot_path() {
 }
 
 void case_dot_dot_rslave_detach() {
-    const char* new_root = "/tmp/test_pivot_root/dotdot_rslave/newroot";
-    const char* bin_dir = "/tmp/test_pivot_root/dotdot_rslave/newroot/bin";
+    const char* old_root = "/tmp/test_pivot_root/dotdot_rslave/root";
+    const char* new_root = "/tmp/test_pivot_root/dotdot_rslave/root/newroot";
+    const char* bin_dir = "/tmp/test_pivot_root/dotdot_rslave/root/newroot/bin";
     int oldroot_fd = -1;
     int newroot_fd = -1;
 
     ensure_parent_tree();
     ensure_dir("/tmp/test_pivot_root/dotdot_rslave");
-    ensure_dir(new_root);
+    ensure_dir(old_root);
     prepare_private_mount_namespace();
 
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
@@ -297,13 +321,17 @@ void case_dot_dot_rslave_detach() {
         child_fail("mkdir(bin) failed");
     }
 
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+
     oldroot_fd = open("/", O_DIRECTORY | O_RDONLY);
     if (oldroot_fd < 0) {
         cleanup_mount(new_root);
         child_fail("open(oldroot) failed");
     }
 
-    newroot_fd = open(new_root, O_DIRECTORY | O_RDONLY);
+    newroot_fd = open("/newroot", O_DIRECTORY | O_RDONLY);
     if (newroot_fd < 0) {
         close(oldroot_fd);
         cleanup_mount(new_root);
@@ -347,16 +375,35 @@ void case_dot_dot_rslave_detach() {
 }
 
 void case_new_root_not_mountpoint() {
-    const char* new_root = "/tmp/test_pivot_root/not_mountpoint/newroot";
-    const char* oldroot_abs = "/tmp/test_pivot_root/not_mountpoint/newroot/oldroot";
+    const char* old_root = "/tmp/test_pivot_root/not_mountpoint/root";
+    const char* containing_mount = "/tmp/test_pivot_root/not_mountpoint/root/mount";
+    const char* new_root = "/tmp/test_pivot_root/not_mountpoint/root/mount/newroot";
+    const char* oldroot_abs =
+        "/tmp/test_pivot_root/not_mountpoint/root/mount/newroot/oldroot";
 
     ensure_parent_tree();
     ensure_dir("/tmp/test_pivot_root/not_mountpoint");
-    ensure_dir(new_root);
-    ensure_dir(oldroot_abs);
+    ensure_dir(old_root);
     prepare_private_mount_namespace();
 
-    if (do_pivot_root(new_root, oldroot_abs) == -1 && errno == EINVAL) {
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(containing_mount, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(containing mount) failed");
+    }
+    if (mount("", containing_mount, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if ((mkdir(new_root, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(oldroot_abs, 0755) != 0 && errno != EEXIST)) {
+        child_fail("mkdir non-mount newroot layout failed");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+
+    if (do_pivot_root("/mount/newroot", "/mount/newroot/oldroot") == -1 && errno == EINVAL) {
         child_pass();
     }
 
@@ -364,31 +411,41 @@ void case_new_root_not_mountpoint() {
 }
 
 void case_put_old_outside_new_root() {
-    const char* new_root = "/tmp/test_pivot_root/put_old_outside/newroot";
-    const char* outside = "/tmp/test_pivot_root/put_old_outside/outside";
-    const char* inside = "/tmp/test_pivot_root/put_old_outside/newroot/inside";
+    const char* old_root = "/tmp/test_pivot_root/put_old_outside/root";
+    const char* new_root = "/tmp/test_pivot_root/put_old_outside/root/newroot";
+    const char* outside = "/tmp/test_pivot_root/put_old_outside/root/outside";
+    const char* inside = "/tmp/test_pivot_root/put_old_outside/root/newroot/inside";
 
     ensure_parent_tree();
     ensure_dir("/tmp/test_pivot_root/put_old_outside");
-    ensure_dir(new_root);
-    ensure_dir(outside);
+    ensure_dir(old_root);
     prepare_private_mount_namespace();
 
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if ((mkdir(new_root, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(outside, 0755) != 0 && errno != EEXIST)) {
+        child_fail("mkdir reachability layout failed");
+    }
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mount("", outside, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
 
     if (mkdir(inside, 0755) != 0 && errno != EEXIST) {
-        cleanup_mount(new_root);
         child_fail("mkdir(inside) failed");
     }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
 
-    if (do_pivot_root(new_root, outside) == -1 && errno == EINVAL) {
-        cleanup_mount(new_root);
+    if (do_pivot_root("/newroot", "/outside") == -1 && errno == EINVAL) {
         child_pass();
     }
 
-    cleanup_mount(new_root);
     child_fail("expected EINVAL");
 }
 
@@ -452,21 +509,19 @@ void case_permission_failure() {
 // ---- Tests for shared mount rejection ----
 
 void case_shared_mount_rejection() {
-    const char* new_root = "/tmp/test_pivot_root/shared/newroot";
-    const char* oldroot_abs = "/tmp/test_pivot_root/shared/newroot/oldroot";
+    const char* old_root = "/tmp/test_pivot_root/shared/root";
+    const char* new_root = "/tmp/test_pivot_root/shared/root/newroot";
+    const char* oldroot_abs = "/tmp/test_pivot_root/shared/root/newroot/oldroot";
 
     ensure_parent_tree();
     ensure_dir("/tmp/test_pivot_root/shared");
-    ensure_dir(new_root);
-
-    // Enter new mount namespace but DON'T make it private — keep shared
-    if (unshare(CLONE_NEWNS) != 0) {
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
-
-    // Explicitly make root shared
-    if (mount(nullptr, "/", nullptr, MS_REC | MS_SHARED, nullptr) != 0) {
-        child_skip("cannot make root shared");
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
     }
 
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
@@ -477,14 +532,19 @@ void case_shared_mount_rejection() {
         cleanup_mount(new_root);
         child_fail("mkdir(oldroot) failed");
     }
+    // put_old resolves on new_root, so making this mount shared exercises
+    // Linux's IS_MNT_SHARED(old_mnt) rejection without an unattached root.
+    if (mount(nullptr, new_root, nullptr, MS_SHARED, nullptr) != 0) {
+        child_skip("cannot make put_old mount shared");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
 
-    // pivot_root should fail with EINVAL because mounts are shared
-    if (do_pivot_root(new_root, oldroot_abs) == -1 && errno == EINVAL) {
-        cleanup_mount(new_root);
+    if (do_pivot_root("/newroot", "/newroot/oldroot") == -1 && errno == EINVAL) {
         child_pass();
     }
 
-    cleanup_mount(new_root);
     child_fail("expected EINVAL for shared mount");
 }
 
@@ -565,14 +625,21 @@ void case_mount_namespace_isolation() {
 // ---- Test for double pivot_root (pivot then pivot back) ----
 
 void case_double_pivot() {
-    const char* new_root = "/tmp/test_pivot_root/double/newroot";
-    const char* oldroot_abs = "/tmp/test_pivot_root/double/newroot/oldroot";
+    const char* old_root = "/tmp/test_pivot_root/double/root";
+    const char* new_root = "/tmp/test_pivot_root/double/root/newroot";
+    const char* oldroot_abs = "/tmp/test_pivot_root/double/root/newroot/oldroot";
 
     ensure_parent_tree();
     ensure_dir("/tmp/test_pivot_root/double");
-    ensure_dir(new_root);
+    ensure_dir(old_root);
     prepare_private_mount_namespace();
 
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
     if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
@@ -582,9 +649,8 @@ void case_double_pivot() {
         child_fail("mkdir(oldroot) failed");
     }
 
-    if (chdir(new_root) != 0) {
-        cleanup_mount(new_root);
-        child_fail("chdir(new_root) failed");
+    if (chroot(old_root) != 0 || chdir("/newroot") != 0) {
+        child_fail("chroot/chdir(new_root) failed");
     }
 
     // First pivot: make ramfs the new root
@@ -592,7 +658,9 @@ void case_double_pivot() {
         child_fail("first pivot_root failed");
     }
 
-    chdir("/");
+    if (chdir("/") != 0) {
+        child_fail("chdir(/) failed after first pivot");
+    }
 
     // Verify first pivot worked
     if (access("/oldroot", F_OK) != 0) {
@@ -609,7 +677,9 @@ void case_double_pivot() {
         child_fail(strerror(errno));
     }
 
-    chdir("/");
+    if (chdir("/") != 0) {
+        child_fail("chdir(/) failed after second pivot");
+    }
 
     // After pivoting back, /put_back should contain the ramfs
     if (access("/put_back", F_OK) != 0) {
@@ -685,6 +755,386 @@ void case_chroot_ordinary_directory_rejected() {
     child_pass();
 }
 
+void case_namespace_root_rejected() {
+    const char* base = "/tmp/test_pivot_root/namespace_root";
+    const char* new_root = "/tmp/test_pivot_root/namespace_root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/namespace_root/newroot/oldroot";
+
+    ensure_parent_tree();
+    ensure_dir(base);
+    ensure_dir(new_root);
+    prepare_private_mount_namespace();
+    if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(put_old, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(oldroot) failed");
+    }
+
+    errno = 0;
+    if (do_pivot_root(new_root, put_old) != -1 || errno != EINVAL) {
+        child_fail("pivot_root from namespace root did not return EINVAL");
+    }
+    child_pass();
+}
+
+void case_new_root_on_root_mount() {
+    const char* old_root = "/tmp/test_pivot_root/new_on_root/root";
+    const char* new_root = "/tmp/test_pivot_root/new_on_root/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/new_on_root/root/newroot/oldroot";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/new_on_root");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
+    if (mkdir(put_old, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(oldroot) failed");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+
+    errno = 0;
+    if (do_pivot_root("/newroot", "/newroot/oldroot") != -1 || errno != EBUSY) {
+        child_fail("new_root on current root mount did not return EBUSY");
+    }
+    child_pass();
+}
+
+void case_unreachable_new_root() {
+    const char* outside_root = "/tmp/test_pivot_root/unreachable/outside";
+    const char* old_root = "/tmp/test_pivot_root/unreachable/outside/root";
+    const char* new_root = "/tmp/test_pivot_root/unreachable/outside/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/unreachable/outside/root/newroot/oldroot";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/unreachable");
+    ensure_dir(outside_root);
+    prepare_private_mount_namespace();
+    if (mount("", outside_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(old_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(root) failed");
+    }
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_fail("mount(root) failed");
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
+    if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
+        child_fail("mount(newroot) failed");
+    }
+    if (mkdir(put_old, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(oldroot) failed");
+    }
+    if (chdir(outside_root) != 0 || chroot(old_root) != 0) {
+        child_fail("prepare cwd outside chroot failed");
+    }
+
+    errno = 0;
+    if (do_pivot_root(".", "/newroot/oldroot") != -1 || errno != EINVAL) {
+        child_fail("unreachable new_root did not return EINVAL");
+    }
+    child_pass();
+}
+
+void case_nested_pivot_preserves_upper_sibling() {
+    const char* base = "/tmp/test_pivot_root/nested_topology";
+    const char* old_root = "/tmp/test_pivot_root/nested_topology/root";
+    const char* new_root = "/tmp/test_pivot_root/nested_topology/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/nested_topology/root/newroot/oldroot";
+    const char* sibling = "/tmp/test_pivot_root/nested_topology/sibling";
+    const char* marker = "/tmp/test_pivot_root/nested_topology/sibling/marker";
+    struct stat before = {};
+    struct stat after = {};
+
+    ensure_parent_tree();
+    ensure_dir(base);
+    ensure_dir(old_root);
+    ensure_dir(sibling);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0 ||
+        mount("", sibling, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
+    if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
+        child_fail("mount(newroot) failed");
+    }
+    if ((mkdir(put_old, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(marker, 0755) != 0 && errno != EEXIST) || stat(marker, &before) != 0) {
+        child_fail("prepare topology marker failed");
+    }
+
+    pid_t pivot_child = fork();
+    if (pivot_child < 0) {
+        child_fail("fork pivot child failed");
+    }
+    if (pivot_child == 0) {
+        if (chroot(old_root) != 0 || chdir("/") != 0) {
+            _exit(2);
+        }
+        if (do_pivot_root("/newroot", "/newroot/oldroot") != 0) {
+            _exit(3);
+        }
+        if (access("/oldroot", F_OK) != 0) {
+            _exit(4);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    if (waitpid(pivot_child, &status, 0) != pivot_child || !WIFEXITED(status) ||
+        WEXITSTATUS(status) != 0) {
+        child_fail("nested pivot child failed");
+    }
+    if (stat(marker, &after) != 0 || before.st_dev != after.st_dev || before.st_ino != after.st_ino) {
+        child_fail("pivot moved or replaced an upper sibling mount");
+    }
+    child_pass();
+}
+
+void case_private_stacked_put_old() {
+    const char* old_root = "/tmp/test_pivot_root/stacked/root";
+    const char* new_root = "/tmp/test_pivot_root/stacked/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/stacked/root/newroot/oldroot";
+    const char* covered_marker = "/tmp/test_pivot_root/stacked/root/newroot/oldroot/marker";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/stacked");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
+    if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
+        child_fail("mount(newroot) failed");
+    }
+    if (mkdir(put_old, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(oldroot) failed");
+    }
+    if (mount("", put_old, "ramfs", 0, nullptr) != 0) {
+        child_skip("private put_old mount is unavailable");
+    }
+    if (mkdir(covered_marker, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir covered marker failed");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+    if (do_pivot_root("/newroot", "/newroot/oldroot") != 0) {
+        child_fail("pivot_root onto stacked put_old failed");
+    }
+    if (access("/oldroot/marker", F_OK) == 0) {
+        child_fail("old root did not cover the existing put_old mount");
+    }
+    if (umount("/oldroot") != 0 || access("/oldroot/marker", F_OK) != 0) {
+        child_fail("existing put_old mount was not revealed after umount");
+    }
+    child_pass();
+}
+
+void case_cross_process_exact_fs_refs() {
+    const char* base = "/tmp/test_pivot_root/fs_refs";
+    const char* old_root = "/tmp/test_pivot_root/fs_refs/root";
+    const char* new_root = "/tmp/test_pivot_root/fs_refs/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/fs_refs/root/newroot/oldroot";
+    const char* sibling = "/tmp/test_pivot_root/fs_refs/sibling";
+    const char* outside_marker = "/tmp/test_pivot_root/fs_refs/outside_marker";
+    struct stat expected_new = {};
+    struct stat sibling_before = {};
+    int ready[2] = {-1, -1};
+    int release[2] = {-1, -1};
+
+    ensure_parent_tree();
+    ensure_dir(base);
+    ensure_dir(old_root);
+    ensure_dir(sibling);
+    ensure_dir(outside_marker);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0 ||
+        mount("", sibling, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
+    if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
+        child_fail("mount(newroot) failed");
+    }
+    if (mkdir(put_old, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(oldroot) failed");
+    }
+    if (stat(new_root, &expected_new) != 0 || chdir(sibling) != 0 ||
+        stat(".", &sibling_before) != 0) {
+        child_fail("prepare fs-ref identities failed");
+    }
+    if (pipe(ready) != 0 || pipe(release) != 0) {
+        child_fail("pipe fs-ref barrier failed");
+    }
+
+    pid_t watcher = fork();
+    if (watcher < 0) {
+        child_fail("fork fs-ref watcher failed");
+    }
+    if (watcher == 0) {
+        close(ready[0]);
+        close(release[1]);
+        if (chroot(old_root) != 0 || chdir("/") != 0) {
+            _exit(2);
+        }
+        char token = 'R';
+        if (write(ready[1], &token, 1) != 1 || read(release[0], &token, 1) != 1) {
+            _exit(3);
+        }
+        struct stat root_after = {};
+        struct stat pwd_after = {};
+        if (stat("/", &root_after) != 0 || stat(".", &pwd_after) != 0) {
+            _exit(4);
+        }
+        if (root_after.st_dev != expected_new.st_dev || root_after.st_ino != expected_new.st_ino ||
+            pwd_after.st_dev != expected_new.st_dev || pwd_after.st_ino != expected_new.st_ino) {
+            _exit(5);
+        }
+        _exit(0);
+    }
+
+    close(ready[1]);
+    close(release[0]);
+    char token = 0;
+    if (read(ready[0], &token, 1) != 1 || token != 'R') {
+        child_fail("fs-ref watcher did not reach barrier");
+    }
+
+    pid_t pivot_child = fork();
+    if (pivot_child < 0) {
+        child_fail("fork fs-ref pivot child failed");
+    }
+    if (pivot_child == 0) {
+        close(ready[0]);
+        close(release[1]);
+        if (chroot(old_root) != 0 || chdir("/") != 0) {
+            _exit(6);
+        }
+        if (do_pivot_root("/newroot", "/newroot/oldroot") != 0) {
+            _exit(7);
+        }
+        _exit(0);
+    }
+
+    int pivot_status = 0;
+    if (waitpid(pivot_child, &pivot_status, 0) != pivot_child || !WIFEXITED(pivot_status) ||
+        WEXITSTATUS(pivot_status) != 0) {
+        child_fail("fs-ref pivot child failed");
+    }
+
+    struct stat sibling_after = {};
+    if (stat(".", &sibling_after) != 0 || sibling_before.st_dev != sibling_after.st_dev ||
+        sibling_before.st_ino != sibling_after.st_ino || access(outside_marker, F_OK) != 0) {
+        child_fail("non-matching fs root or pwd was replaced");
+    }
+
+    token = 'G';
+    if (write(release[1], &token, 1) != 1) {
+        child_fail("release fs-ref watcher failed");
+    }
+    int watcher_status = 0;
+    if (waitpid(watcher, &watcher_status, 0) != watcher || !WIFEXITED(watcher_status) ||
+        WEXITSTATUS(watcher_status) != 0) {
+        child_fail("matching fs root/pwd were not replaced");
+    }
+    child_pass();
+}
+
+void case_symlink_to_mounted_new_root() {
+    const char* old_root = "/tmp/test_pivot_root/symlink/root";
+    const char* new_root = "/tmp/test_pivot_root/symlink/root/newroot";
+    const char* new_root_link = "/tmp/test_pivot_root/symlink/root/newroot_link";
+    const char* put_old = "/tmp/test_pivot_root/symlink/root/newroot/oldroot";
+    const char* marker = "/tmp/test_pivot_root/symlink/root/newroot/marker";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/symlink");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) failed");
+    }
+    if (mount("", new_root, "ramfs", 0, nullptr) != 0) {
+        child_fail("mount(newroot) failed");
+    }
+    if ((mkdir(put_old, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(marker, 0755) != 0 && errno != EEXIST)) {
+        child_fail("prepare symlink new-root contents failed");
+    }
+    if (symlink("newroot", new_root_link) != 0) {
+        child_fail("symlink(newroot) failed");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+    if (do_pivot_root("/newroot_link", "/newroot_link/oldroot") != 0) {
+        child_fail("pivot_root through final symlink failed");
+    }
+    if (access("/oldroot", F_OK) != 0 || access("/marker", F_OK) != 0) {
+        child_fail("symlink pivot did not install new or old root");
+    }
+    child_pass();
+}
+
+void case_self_bind_alias_new_root() {
+    const char* old_root = "/tmp/test_pivot_root/bind_alias/root";
+    const char* candidate = "/tmp/test_pivot_root/bind_alias/root/candidate";
+    const char* put_old = "/tmp/test_pivot_root/bind_alias/root/candidate/oldroot";
+    const char* marker = "/tmp/test_pivot_root/bind_alias/root/candidate/marker";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/bind_alias");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(candidate, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(bind candidate) failed");
+    }
+    if ((mkdir(put_old, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(marker, 0755) != 0 && errno != EEXIST)) {
+        child_fail("prepare bind candidate contents failed");
+    }
+    // A self-bind gives the same backing dentry a distinct mount identity,
+    // making an ordinary directory a legal pivot_root new_root.
+    if (mount(candidate, candidate, nullptr, MS_BIND, nullptr) != 0) {
+        child_skip("self-bind mount is unavailable");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+    if (do_pivot_root("/candidate", "/candidate/oldroot") != 0) {
+        child_fail("pivot_root to self-bind alias failed");
+    }
+    if (access("/oldroot", F_OK) != 0 || access("/marker", F_OK) != 0) {
+        child_fail("bind-alias pivot did not install new or old root");
+    }
+    child_pass();
+}
+
 TEST(PivotRoot, SuccessPath) {
     expect_case_pass_or_skip("pivot_root_success", case_success_path);
 }
@@ -733,6 +1183,42 @@ TEST(PivotRoot, ChrootMountRoot) {
 TEST(PivotRoot, ChrootOrdinaryDirectoryRejected) {
     expect_case_pass_or_skip("pivot_root_chroot_ordinary_directory_rejected",
                              case_chroot_ordinary_directory_rejected);
+}
+
+TEST(PivotRoot, NamespaceRootRejected) {
+    expect_case_pass_or_skip("pivot_root_namespace_root_rejected", case_namespace_root_rejected);
+}
+
+TEST(PivotRoot, NewRootOnRootMount) {
+    expect_case_pass_or_skip("pivot_root_new_root_on_root_mount", case_new_root_on_root_mount);
+}
+
+TEST(PivotRoot, UnreachableNewRoot) {
+    expect_case_pass_or_skip("pivot_root_unreachable_new_root", case_unreachable_new_root);
+}
+
+TEST(PivotRoot, NestedPivotPreservesUpperSibling) {
+    expect_case_pass_or_skip("pivot_root_nested_preserves_upper_sibling",
+                             case_nested_pivot_preserves_upper_sibling);
+}
+
+TEST(PivotRoot, PrivateStackedPutOld) {
+    expect_case_pass_or_skip("pivot_root_private_stacked_put_old", case_private_stacked_put_old);
+}
+
+TEST(PivotRoot, CrossProcessExactFsRefs) {
+    expect_case_pass_or_skip("pivot_root_cross_process_exact_fs_refs",
+                             case_cross_process_exact_fs_refs);
+}
+
+TEST(PivotRoot, SymlinkToMountedNewRoot) {
+    expect_case_pass_or_skip("pivot_root_symlink_to_mounted_new_root",
+                             case_symlink_to_mounted_new_root);
+}
+
+TEST(PivotRoot, SelfBindAliasNewRoot) {
+    expect_case_pass_or_skip("pivot_root_self_bind_alias_new_root",
+                             case_self_bind_alias_new_root);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- resolve and pin the caller fs root, new_root, and put_old as mount-aware object paths
- rotate exact mount edges atomically and migrate matching root/pwd references across published tasks
- preserve Linux errno ordering, stacked mount semantics, and fork/fs-update synchronization
- add focused chroot, cross-process, symlink, bind-alias, and topology regression coverage

## Validation

- `make kernel`
- `test_pivot_root_test` (20/20)
- `mount_object_topology_test` (9/9)
- `mount_move_test` (11/11)
- `mount_propagation_test` (24/24)

Closes #2104