### PR TITLE
fix(ext4.h): remove the rejection of FEATURE_COMPAT_ORPHAN_FILE

### DIFF
--- a/kernel/crates/another_ext4/src/ext4/orphan.rs
+++ b/kernel/crates/another_ext4/src/ext4/orphan.rs
@@ -44,9 +44,12 @@ fn unsupported_orphan_format(sb: &SuperBlock) -> bool {
     unsupported_orphan_features(sb.compatible_features(), sb.read_only_compatible_features())
 }
 
-fn unsupported_orphan_features(compatible: u32, read_only_compatible: u32) -> bool {
-    compatible & SuperBlock::FEATURE_COMPAT_ORPHAN_FILE != 0
-        || read_only_compatible & SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT != 0
+fn unsupported_orphan_features(_compatible: u32, read_only_compatible: u32) -> bool {
+    // FEATURE_COMPAT_ORPHAN_FILE is a *compat* feature: kernels without orphan-file
+    // support can still mount read-write and simply ignore the dedicated orphan inode.
+    // Reject only when ORPHAN_PRESENT is set, which means there are actual unrecovered
+    // orphans in the orphan file that this implementation cannot process.
+    read_only_compatible & SuperBlock::FEATURE_RO_COMPAT_ORPHAN_PRESENT != 0
 }
 
 fn valid_orphan_number<R: LegacyOrphanReader>(reader: &R, inode: InodeId) -> bool {
@@ -395,7 +398,7 @@ mod tests {
     #[test]
     fn preflight_rejects_each_orphan_file_feature() {
         assert!(!unsupported_orphan_features(0, 0));
-        assert!(unsupported_orphan_features(
+        assert!(!unsupported_orphan_features(
             SuperBlock::FEATURE_COMPAT_ORPHAN_FILE,
             0
         ));


### PR DESCRIPTION
compat features are safe to ignore and should not block rw mount.

In linux kernel `fs/ext4/ext4.h`

line 2086: 
```c
#define EXT4_FEATURE_COMPAT_ORPHAN_FILE		0x1000	/* Orphan file exists */
```

line 2107:
```c
#define EXT4_FEATURE_RO_COMPAT_ORPHAN_PRESENT	0x10000 /* Orphan file may be
							   non-empty */
```

line 2241:
```c
#define EXT4_FEATURE_COMPAT_SUPP	(EXT4_FEATURE_COMPAT_EXT_ATTR| \
					 EXT4_FEATURE_COMPAT_ORPHAN_FILE)
```

line 2256:
```c
#define EXT4_FEATURE_RO_COMPAT_SUPP	(EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER| \
					 EXT4_FEATURE_RO_COMPAT_LARGE_FILE| \
					 EXT4_FEATURE_RO_COMPAT_GDT_CSUM| \
					 EXT4_FEATURE_RO_COMPAT_DIR_NLINK | \
					 EXT4_FEATURE_RO_COMPAT_EXTRA_ISIZE | \
					 EXT4_FEATURE_RO_COMPAT_BTREE_DIR |\
					 EXT4_FEATURE_RO_COMPAT_HUGE_FILE |\
					 EXT4_FEATURE_RO_COMPAT_BIGALLOC |\
					 EXT4_FEATURE_RO_COMPAT_METADATA_CSUM|\
					 EXT4_FEATURE_RO_COMPAT_QUOTA |\
					 EXT4_FEATURE_RO_COMPAT_PROJECT |\
					 EXT4_FEATURE_RO_COMPAT_VERITY |\
					 EXT4_FEATURE_RO_COMPAT_ORPHAN_PRESENT)
```

these shows that:  `EXT4_FEATURE_COMPAT_ORPHAN_FILE` and `EXT4_FEATURE_RO_COMPAT_ORPHAN_PRESENT` are in `EXT4_FEATURE_COMPAT_SUPP` and `EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER`.

in `fs/ext4/super.c` line 3620
```c
if (ext4_has_unknown_ext4_incompat_features(sb)) {
		ext4_msg(sb, KERN_ERR,
			"Couldn't mount because of "
			"unsupported optional features (%x)",
			(le32_to_cpu(EXT4_SB(sb)->s_es->s_feature_incompat) &
			~EXT4_FEATURE_INCOMPAT_SUPP));
		return 0;
	}
```
```c
	/* Check that feature set is OK for a read-write mount */
	if (ext4_has_unknown_ext4_ro_compat_features(sb)) {
		ext4_msg(sb, KERN_ERR, "couldn't mount RDWR because of "
			 "unsupported optional features (%x)",
			 (le32_to_cpu(EXT4_SB(sb)->s_es->s_feature_ro_compat) &
				~EXT4_FEATURE_RO_COMPAT_SUPP));
		return 0;
	}
```
linux never check `COMPAT_SUPP`. if compat feature is not in SUPP, it will also not reject mount,only ignore them

Signed-off-by: Donjuanplatinum <donplat@barrensea.org>