### PR TITLE
fix(vfs): complete pivot_root topology semantics

### DIFF
--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -27,7 +27,10 @@ use crate::{
     ipc::kill::send_signal_to_pid,
     libs::mutex::MutexGuard,
     process::{
-        cred::CAPFlags, namespace::mnt::mnt_namespace_init, resource::RLimitID, ProcessManager,
+        cred::CAPFlags,
+        namespace::mnt::{mnt_namespace_init, RootMountAttachment},
+        resource::RLimitID,
+        ProcessManager,
     },
 };
 
@@ -95,6 +98,7 @@ pub fn vfs_init() -> Result<(), SystemError> {
 fn migrate_virtual_filesystem(
     new_fs: Arc<dyn FileSystem>,
     root_mount_flags: MountFlags,
+    root_attachment: RootMountAttachment,
 ) -> Result<(), SystemError> {
     info!("VFS: Migrating filesystems...");
 
@@ -141,7 +145,7 @@ fn migrate_virtual_filesystem(
         new_fs
             .activate()
             .expect("the replacement root mount is published exactly once");
-        current_mntns.force_change_root_mountfs(new_fs);
+        current_mntns.force_change_root_mountfs(new_fs, root_attachment);
     }
 
     // 换根后需要同步更新“当前进程”的 fs root/pwd。
@@ -456,7 +460,11 @@ pub fn mount_root_fs() -> Result<(), SystemError> {
     };
 
     let fs_name = rootfs.name().to_string();
-    let r = migrate_virtual_filesystem(rootfs.clone(), root_options.mount_flags);
+    let r = migrate_virtual_filesystem(
+        rootfs.clone(),
+        root_options.mount_flags,
+        RootMountAttachment::Attached,
+    );
     if r.is_err() {
         error!(
             "Failed to migrate virtual filesystem to rootfs ({}).",
@@ -475,7 +483,11 @@ pub fn mount_root_fs() -> Result<(), SystemError> {
 pub fn change_root_fs() -> Result<(), SystemError> {
     info!("Try to change root fs to initramfs...");
     let initramfs = crate::init::initram::INIT_ROOT_INODE().fs();
-    let r = migrate_virtual_filesystem(initramfs, MountFlags::empty());
+    let r = migrate_virtual_filesystem(
+        initramfs,
+        MountFlags::empty(),
+        RootMountAttachment::Unattached,
+    );
 
     if r.is_err() {
         error!("Failed to migrate virtual filesystem to initramfs!");

--- a/kernel/src/net/socket/unix/ring_buffer.rs
+++ b/kernel/src/net/socket/unix/ring_buffer.rs
@@ -777,6 +777,14 @@ impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
         self.ring_buffer.is_send_shutdown()
     }
 
+    /// No more bytes can arrive after the receive queue is drained.
+    ///
+    /// The consumer observes this both after its owner calls `SHUT_RD` and
+    /// after the producer calls `SHUT_WR`.
+    pub fn is_read_shutdown(&self) -> bool {
+        self.is_recv_shutdown() || self.is_send_shutdown()
+    }
+
     pub fn set_recv_shutdown(&self) {
         self.ring_buffer.set_recv_shutdown()
     }

--- a/kernel/src/net/socket/unix/stream/inner.rs
+++ b/kernel/src/net/socket/unix/stream/inner.rs
@@ -531,11 +531,27 @@ impl Connected {
     pub(super) fn check_io_events(&self) -> EPollEventType {
         let mut events = EPollEventType::empty();
 
-        if !self.reader.lock().is_empty() {
-            events |= EPollEventType::EPOLLIN;
+        let reader = self.reader.lock();
+        let recv_shutdown = reader.is_recv_shutdown() || reader.is_send_shutdown();
+        if !reader.is_empty() || recv_shutdown {
+            events |= EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM;
         }
-        if !self.writer.lock().is_empty() {
-            events |= EPollEventType::EPOLLOUT;
+        if recv_shutdown {
+            events |= EPollEventType::EPOLLRDHUP;
+        }
+        drop(reader);
+
+        let writer = self.writer.lock();
+        let send_shutdown = writer.is_send_shutdown() || writer.is_recv_shutdown();
+        // Preserve the existing writable calculation for live sockets; this
+        // change only adds Linux's shutdown-is-writable escape from poll.
+        if !writer.is_empty() || send_shutdown {
+            events |= EPollEventType::EPOLLOUT
+                | EPollEventType::EPOLLWRNORM
+                | EPollEventType::EPOLLWRBAND;
+        }
+        if recv_shutdown && send_shutdown {
+            events |= EPollEventType::EPOLLHUP;
         }
 
         events

--- a/kernel/src/net/socket/unix/stream/inner.rs
+++ b/kernel/src/net/socket/unix/stream/inner.rs
@@ -288,8 +288,9 @@ impl Connected {
                 let guard = self.reader.lock();
                 let len = guard.len();
                 if len == 0 {
-                    // If peer has SHUT_WR and the receive queue is empty, return EOF.
-                    if guard.is_send_shutdown() {
+                    // SHUT_RD and peer SHUT_WR both become EOF once queued
+                    // bytes have been consumed.
+                    if guard.is_read_shutdown() {
                         return Ok(0);
                     }
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -310,7 +311,7 @@ impl Connected {
             let guard = self.reader.lock();
             let avail_len = guard.len();
             if avail_len == 0 {
-                if guard.is_send_shutdown() {
+                if guard.is_read_shutdown() {
                     return Ok(0);
                 }
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -338,8 +339,9 @@ impl Connected {
     ) -> Result<(usize, usize, bool), SystemError> {
         let mut guard = self.reader.lock();
         if guard.len() < size_of::<u32>() {
-            // If peer has SHUT_WR and the receive queue is empty, return EOF.
-            if guard.is_send_shutdown() {
+            // A complete record can never arrive after either read-side
+            // shutdown condition becomes final.
+            if guard.is_read_shutdown() {
                 return Ok((0, 0, false));
             }
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -439,8 +441,8 @@ impl Connected {
         guard.is_send_shutdown() || guard.is_recv_shutdown()
     }
 
-    pub(super) fn peer_send_shutdown(&self) -> bool {
-        self.reader.lock().is_send_shutdown()
+    pub(super) fn recv_closed(&self) -> bool {
+        self.reader.lock().is_read_shutdown()
     }
 
     pub(super) fn push_scm_at(
@@ -488,7 +490,7 @@ impl Connected {
 
         let avail_len = guard.len();
         if avail_len == 0 {
-            if guard.is_send_shutdown() {
+            if guard.is_read_shutdown() {
                 return Ok(StreamRecvmsgMeta {
                     copy_len: 0,
                     scm_cred: None,
@@ -532,7 +534,7 @@ impl Connected {
         let mut events = EPollEventType::empty();
 
         let reader = self.reader.lock();
-        let recv_shutdown = reader.is_recv_shutdown() || reader.is_send_shutdown();
+        let recv_shutdown = reader.is_read_shutdown();
         if !reader.is_empty() || recv_shutdown {
             events |= EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM;
         }

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -400,7 +400,7 @@ impl UnixStreamSocket {
             .expect("UnixStreamSocket inner is None")
         {
             Inner::Connected(connected) => {
-                connected.readable_len(self.is_seqpacket) != 0 || connected.peer_send_shutdown()
+                connected.readable_len(self.is_seqpacket) != 0 || connected.recv_closed()
             }
             _ => false,
         }
@@ -1606,8 +1606,11 @@ impl Socket for UnixStreamSocket {
         self.inner
             .read()
             .as_ref()
-            .expect("UnixStreamSocket inner is None")
-            .check_io_events()
+            .map(Inner::check_io_events)
+            // Concurrent close has already made the socket terminal and
+            // emitted its wakeups. Event queries racing with it must observe
+            // HUP rather than panic on the consumed Inner value.
+            .unwrap_or(EPollEventType::EPOLLHUP)
     }
 
     fn socket_inode_id(&self) -> InodeId {

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -1573,9 +1573,31 @@ impl Socket for UnixStreamSocket {
             connected.shutdown_send();
         }
 
-        // Wake any sleepers.
+        // Do not retain our inner lock while waking the peer. The peer can be
+        // shutting down the opposite endpoint concurrently and epoll wakeup
+        // may query its socket state.
+        drop(inner_guard);
+
+        // Local waiters may also need to observe a newly disabled direction.
         self.wait_queue
             .wakeup(Some(crate::process::ProcessState::Blocked(true)));
+        let _ = EventPoll::wakeup_epoll(self.epoll_items().as_ref(), self.check_io_event());
+
+        // The shutdown bits live in the rings shared with the peer, but a
+        // blocked peer sleeps on its own socket wait queue. Waking only this
+        // endpoint leaves a peer read/write asleep after the condition has
+        // become final (notably SOCK_SEQPACKET read after SHUT_WR).
+        let peer = self.peer.lock().as_ref().and_then(Weak::upgrade);
+        if let Some(peer) = peer {
+            peer.wait_queue
+                .wakeup(Some(crate::process::ProcessState::Blocked(true)));
+            let _ = EventPoll::wakeup_epoll(peer.epoll_items().as_ref(), peer.check_io_event());
+            if _how.is_both_shutdown() {
+                peer.fasync_items.send_sigio(FASYNC_POLL_HUP);
+            } else if _how.is_send_shutdown() {
+                peer.fasync_items.send_sigio(FASYNC_POLL_IN);
+            }
+        }
 
         Ok(())
     }

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -131,9 +131,25 @@ pub struct MntNamespace {
     inner: RwSem<InnerMntNamespace>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RootMountAttachment {
+    /// Linux's initial rootfs has no parent and cannot be pivoted.
+    Unattached,
+    /// The visible root is mounted on the hidden initial rootfs anchor.
+    Attached,
+}
+
 pub struct InnerMntNamespace {
     _dead: bool,
     root_mountfs: Arc<MountFS>,
+    /// Whether the current root has Linux's parent mount attachment.
+    ///
+    /// DragonOS removes the boot rootfs object when the real root is
+    /// installed, so that hidden parent edge cannot be represented by
+    /// `MountFS::self_mountpoint`. Keep its semantic state explicitly: the
+    /// initial rootfs is unattached and cannot be pivoted, while the real boot
+    /// root and namespace copies remain attached to that conceptual boundary.
+    root_attached: bool,
     mount_count: MountCountState,
     /// Exact old-mount to copied-mount projection used to rebind fs_struct
     /// root/pwd after CLONE_NEWNS. This is object identity, never a pathname.
@@ -216,6 +232,7 @@ impl MntNamespace {
             _user_ns: super::user_namespace::INIT_USER_NAMESPACE.clone(),
             inner: RwSem::new(InnerMntNamespace {
                 root_mountfs: ramfs.clone(),
+                root_attached: false,
                 mount_count: MountCountState::default(),
                 copy_sources: Vec::new(),
                 _dead: false,
@@ -239,10 +256,15 @@ impl MntNamespace {
     /// Forcibly replace the root mount filesystem of this MountNamespace.
     ///
     /// This method is only for use during DragonOS initialization.
-    pub fn force_change_root_mountfs(&self, new_root: Arc<MountFS>) {
+    pub(crate) fn force_change_root_mountfs(
+        &self,
+        new_root: Arc<MountFS>,
+        attachment: RootMountAttachment,
+    ) {
         let mut inner_guard = self.inner.write();
         new_root.set_namespace(self.self_ref.clone());
         let old_root = core::mem::replace(&mut inner_guard.root_mountfs, new_root);
+        inner_guard.root_attached = attachment == RootMountAttachment::Attached;
         assert!(
             old_root.take_namespace_accounted(&self.self_ref),
             "the old namespace root must own one committed mount slot"
@@ -278,7 +300,9 @@ impl MntNamespace {
         // The namespace writer precedes dentry gates in the canonical order.
         // Keeping it across the edge commit also pins the namespace root
         // identity throughout admission and mutation.
-        let _namespace_inner = self.inner.write();
+        let mut namespace_inner = self.inner.write();
+        let namespace_root = namespace_inner.root_mountfs.clone();
+        let old_is_namespace_root = Arc::ptr_eq(&old_root, &namespace_root);
         let old_root_mountpoint = old_root.self_mountpoint();
         let root_parent = old_root_mountpoint
             .as_ref()
@@ -291,7 +315,11 @@ impl MntNamespace {
             .unwrap_or_else(|| new_root.clone());
         let gates = [
             new_root_mountpoint.clone(),
-            old_root_mountpoint.clone(),
+            if old_is_namespace_root {
+                None
+            } else {
+                old_root_mountpoint.clone()
+            },
             Some(put_old_mountpoint.clone()),
         ];
 
@@ -309,12 +337,13 @@ impl MntNamespace {
             }
             if put_old_mnt.propagation().is_shared()
                 || new_root_parent.propagation().is_shared()
-                || root_parent.propagation().is_shared()
+                || (!old_is_namespace_root && root_parent.propagation().is_shared())
                 || !old_root.is_live()
                 || !new_root.is_live()
                 || !old_root.is_belongs_to_mntns(&namespace)
                 || !new_root.is_belongs_to_mntns(&namespace)
                 || new_root.is_locked()
+                || !Arc::ptr_eq(&namespace_inner.root_mountfs, &namespace_root)
             {
                 return Err(SystemError::EINVAL);
             }
@@ -324,18 +353,29 @@ impl MntNamespace {
             if Arc::ptr_eq(&new_root, &old_root) || Arc::ptr_eq(&put_old_mnt, &old_root) {
                 return Err(SystemError::EBUSY);
             }
-            let Some(old_root_mountpoint) = old_root_mountpoint.as_ref() else {
+            if old_is_namespace_root && !namespace_inner.root_attached {
                 return Err(SystemError::EINVAL);
-            };
+            }
+            let old_root_mountpoint = old_root_mountpoint.as_ref();
+            if !old_is_namespace_root && old_root_mountpoint.is_none() {
+                return Err(SystemError::EINVAL);
+            }
             let Some(new_root_mountpoint) = new_root_mountpoint.as_ref() else {
                 return Err(SystemError::EINVAL);
             };
             if !old_root_path.same_path_ref(&old_root.mountpoint_root_inode())
                 || !new_root_path.same_path_ref(&new_root.mountpoint_root_inode())
-                || old_root
-                    .self_mountpoint()
-                    .as_ref()
-                    .is_none_or(|mountpoint| !Arc::ptr_eq(mountpoint, old_root_mountpoint))
+                || (!old_is_namespace_root
+                    && old_root
+                        .self_mountpoint()
+                        .as_ref()
+                        .is_none_or(|mountpoint| {
+                            !Arc::ptr_eq(
+                                mountpoint,
+                                old_root_mountpoint
+                                    .expect("validated attached root must retain its mountpoint"),
+                            )
+                        }))
                 || new_root
                     .self_mountpoint()
                     .as_ref()
@@ -365,7 +405,7 @@ impl MntNamespace {
             {
                 return Err(SystemError::ENOMEM);
             }
-            let _new_edge = new_root_parent.reserve_mount_edge(&new_root_mountpoint, 0)?;
+            let _new_edge = new_root_parent.reserve_mount_edge(new_root_mountpoint, 0)?;
             #[cfg(test)]
             if FAIL_PIVOT_PREPARE
                 .compare_exchange(
@@ -383,10 +423,16 @@ impl MntNamespace {
             new_root_parent
                 .detach_exact_keep_slot_with_token(&new_root, gate_token)
                 .expect("validated pivot new-root edge must exist");
-            new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
-            root_parent
-                .replace_exact_edge_prepared_with_token(&old_root, new_root.clone(), gate_token)
-                .expect("validated pivot old-root edge must remain exact");
+            if old_is_namespace_root {
+                new_root.relocate_mountpoint(None);
+            } else {
+                let old_root_mountpoint = old_root_mountpoint
+                    .expect("validated attached root must retain its mountpoint");
+                new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
+                root_parent
+                    .replace_exact_edge_prepared_with_token(&old_root, new_root.clone(), gate_token)
+                    .expect("validated pivot old-root edge must remain exact");
+            }
             old_root.relocate_mountpoint(Some(put_old_mountpoint.clone()));
             put_old_mnt
                 .attach_new_top_prelocked(&put_old_mountpoint, old_root.clone(), gate_token)
@@ -398,6 +444,9 @@ impl MntNamespace {
             if old_root.is_locked() {
                 old_root.unlock_mount();
                 new_root.lock_mount();
+            }
+            if old_is_namespace_root {
+                namespace_inner.root_mountfs = new_root.clone();
             }
             Ok(())
         })
@@ -660,6 +709,7 @@ impl MntNamespace {
             inner: RwSem::new(InnerMntNamespace {
                 _dead: false,
                 root_mountfs: new_root_mntfs,
+                root_attached: inner.root_attached,
                 // Linux copy_mnt_ns() initializes the copied namespace's
                 // existing mount count directly. mount-max only admits new
                 // mount trees; it must not reject cloning existing topology.
@@ -927,6 +977,21 @@ mod tests {
         )
     }
 
+    fn install_attached_root(namespace: &Arc<MntNamespace>) -> Arc<MountFS> {
+        let root = MountFS::new(
+            RamFS::new(),
+            None,
+            None,
+            MountPropagation::new_private(),
+            Some(namespace),
+            MountFlags::empty(),
+            None,
+        );
+        root.activate().unwrap();
+        namespace.force_change_root_mountfs(root.clone(), RootMountAttachment::Attached);
+        root
+    }
+
     fn assert_failed_pivot_unchanged(
         namespace: &Arc<MntNamespace>,
         namespace_root: &Arc<MountFS>,
@@ -985,6 +1050,83 @@ mod tests {
         );
         assert!(root.is_live());
         assert!(root.is_belongs_to_mntns(&namespace));
+    }
+
+    #[test]
+    fn initial_rootfs_pivot_is_rejected() {
+        let namespace = MntNamespace::new_root();
+        let root = namespace.root_mntfs();
+        let new_root_mountpoint = root.mountpoint_root_inode();
+        let new_root = new_private_mount(new_root_mountpoint.clone());
+        {
+            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+            namespace
+                .add_mount(Some(&root), Some(&new_root_mountpoint), new_root.clone())
+                .unwrap();
+        }
+
+        let result = namespace.pivot_root(
+            root.mountpoint_root_inode(),
+            new_root.mountpoint_root_inode(),
+            new_root.mountpoint_root_inode(),
+        );
+
+        assert!(matches!(result, Err(SystemError::EINVAL)));
+        assert!(Arc::ptr_eq(&namespace.root_mntfs(), &root));
+        assert!(root
+            .children_at(&new_root_mountpoint)
+            .iter()
+            .any(|mount| Arc::ptr_eq(mount, &new_root)));
+    }
+
+    #[test]
+    fn attached_namespace_root_can_be_pivoted() {
+        let namespace = MntNamespace::new_root();
+        let old_root = install_attached_root(&namespace);
+        let new_root_mountpoint = old_root.mountpoint_root_inode();
+        let new_root = new_private_mount(new_root_mountpoint.clone());
+        {
+            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+            namespace
+                .add_mount(
+                    Some(&old_root),
+                    Some(&new_root_mountpoint),
+                    new_root.clone(),
+                )
+                .unwrap();
+        }
+
+        namespace
+            .pivot_root(
+                old_root.mountpoint_root_inode(),
+                new_root.mountpoint_root_inode(),
+                new_root.mountpoint_root_inode(),
+            )
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&namespace.root_mntfs(), &new_root));
+        assert!(new_root.self_mountpoint().is_none());
+        assert!(old_root
+            .self_mountpoint()
+            .as_ref()
+            .is_some_and(|mountpoint| Arc::ptr_eq(mountpoint, &new_root.mountpoint_root_inode())));
+        assert!(namespace.inner.read().root_attached);
+    }
+
+    #[test]
+    fn namespace_copy_preserves_root_attachment() {
+        let initial = MntNamespace::new_root();
+        let initial_copy = initial
+            .copy_mnt_ns(&CloneFlags::CLONE_NEWNS, INIT_USER_NAMESPACE.clone())
+            .unwrap();
+        assert!(!initial_copy.inner.read().root_attached);
+
+        let attached = MntNamespace::new_root();
+        install_attached_root(&attached);
+        let attached_copy = attached
+            .copy_mnt_ns(&CloneFlags::CLONE_NEWNS, INIT_USER_NAMESPACE.clone())
+            .unwrap();
+        assert!(attached_copy.inner.read().root_attached);
     }
 
     #[test]

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -35,6 +35,16 @@ static MOUNT_MAX: AtomicU32 = AtomicU32::new(DEFAULT_MOUNT_MAX);
 static FAIL_COPY_REGISTRATION_PREPARE: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
+#[cfg(test)]
+const FAIL_PIVOT_PREPARE_NONE: u8 = 0;
+#[cfg(test)]
+const FAIL_PIVOT_PREPARE_NEW_EDGE: u8 = 1;
+#[cfg(test)]
+const FAIL_PIVOT_PREPARE_PUT_OLD_EDGE: u8 = 2;
+#[cfg(test)]
+static FAIL_PIVOT_PREPARE: core::sync::atomic::AtomicU8 =
+    core::sync::atomic::AtomicU8::new(FAIL_PIVOT_PREPARE_NONE);
+
 pub fn mount_max() -> u32 {
     MOUNT_MAX.load(Ordering::Relaxed)
 }
@@ -265,32 +275,23 @@ impl MntNamespace {
         let old_root = old_root_path.mount_fs();
         let new_root = new_root_path.mount_fs();
         let put_old_mnt = put_old_mountpoint.mount_fs();
-        // Namespace publication precedes dentry gates in the canonical order.
-        // Keeping this writer across the commit also pins the namespace root
-        // identity until the final publication step.
-        let mut namespace_inner = self.inner.write();
-        let namespace_root = namespace_inner.root_mountfs.clone();
-        let old_is_namespace_root = Arc::ptr_eq(&old_root, &namespace_root);
-        // DragonOS represents the namespace root without a visible parent
-        // edge. Attached caller roots use their exact parent below; the
-        // namespace-root branch instead publishes through root_mountfs.
+        // The namespace writer precedes dentry gates in the canonical order.
+        // Keeping it across the edge commit also pins the namespace root
+        // identity throughout admission and mutation.
+        let _namespace_inner = self.inner.write();
         let old_root_mountpoint = old_root.self_mountpoint();
         let root_parent = old_root_mountpoint
             .as_ref()
             .map(|mountpoint| mountpoint.mount_fs())
             .unwrap_or_else(|| old_root.clone());
-        if !old_is_namespace_root && old_root_mountpoint.is_none() {
-            return Err(SystemError::EINVAL);
-        }
-        let new_root_mountpoint = new_root.self_mountpoint().ok_or(SystemError::EINVAL)?;
-        let new_root_parent = new_root_mountpoint.mount_fs();
+        let new_root_mountpoint = new_root.self_mountpoint();
+        let new_root_parent = new_root_mountpoint
+            .as_ref()
+            .map(|mountpoint| mountpoint.mount_fs())
+            .unwrap_or_else(|| new_root.clone());
         let gates = [
-            Some(new_root_mountpoint.clone()),
-            if old_is_namespace_root {
-                None
-            } else {
-                old_root_mountpoint.clone()
-            },
+            new_root_mountpoint.clone(),
+            old_root_mountpoint.clone(),
             Some(put_old_mountpoint.clone()),
         ];
 
@@ -308,17 +309,12 @@ impl MntNamespace {
             }
             if put_old_mnt.propagation().is_shared()
                 || new_root_parent.propagation().is_shared()
-                || (!old_is_namespace_root && root_parent.propagation().is_shared())
+                || root_parent.propagation().is_shared()
                 || !old_root.is_live()
                 || !new_root.is_live()
                 || !old_root.is_belongs_to_mntns(&namespace)
                 || !new_root.is_belongs_to_mntns(&namespace)
                 || new_root.is_locked()
-                || !Arc::ptr_eq(&namespace_inner.root_mountfs, &namespace_root)
-                || new_root
-                    .self_mountpoint()
-                    .as_ref()
-                    .is_none_or(|mountpoint| !Arc::ptr_eq(mountpoint, &new_root_mountpoint))
             {
                 return Err(SystemError::EINVAL);
             }
@@ -328,8 +324,22 @@ impl MntNamespace {
             if Arc::ptr_eq(&new_root, &old_root) || Arc::ptr_eq(&put_old_mnt, &old_root) {
                 return Err(SystemError::EBUSY);
             }
+            let Some(old_root_mountpoint) = old_root_mountpoint.as_ref() else {
+                return Err(SystemError::EINVAL);
+            };
+            let Some(new_root_mountpoint) = new_root_mountpoint.as_ref() else {
+                return Err(SystemError::EINVAL);
+            };
             if !old_root_path.same_path_ref(&old_root.mountpoint_root_inode())
                 || !new_root_path.same_path_ref(&new_root.mountpoint_root_inode())
+                || old_root
+                    .self_mountpoint()
+                    .as_ref()
+                    .is_none_or(|mountpoint| !Arc::ptr_eq(mountpoint, old_root_mountpoint))
+                || new_root
+                    .self_mountpoint()
+                    .as_ref()
+                    .is_none_or(|mountpoint| !Arc::ptr_eq(mountpoint, new_root_mountpoint))
                 || put_old_mountpoint
                     .relative_path_from_snapshot(&new_root_path)?
                     .is_none()
@@ -343,23 +353,40 @@ impl MntNamespace {
             // Prepare every allocation before changing an edge. The
             // reservations keep the original new-root key alive and
             // guarantee one put-old slot.
+            #[cfg(test)]
+            if FAIL_PIVOT_PREPARE
+                .compare_exchange(
+                    FAIL_PIVOT_PREPARE_NEW_EDGE,
+                    FAIL_PIVOT_PREPARE_NONE,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                return Err(SystemError::ENOMEM);
+            }
             let _new_edge = new_root_parent.reserve_mount_edge(&new_root_mountpoint, 0)?;
+            #[cfg(test)]
+            if FAIL_PIVOT_PREPARE
+                .compare_exchange(
+                    FAIL_PIVOT_PREPARE_PUT_OLD_EDGE,
+                    FAIL_PIVOT_PREPARE_NONE,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                return Err(SystemError::ENOMEM);
+            }
             let _put_old_edge = put_old_mnt.reserve_mount_edge(&put_old_mountpoint, 1)?;
 
             new_root_parent
                 .detach_exact_keep_slot_with_token(&new_root, gate_token)
                 .expect("validated pivot new-root edge must exist");
-            if old_is_namespace_root {
-                new_root.relocate_mountpoint(None);
-            } else {
-                let old_root_mountpoint = old_root_mountpoint
-                    .as_ref()
-                    .expect("validated attached caller root must keep its mountpoint");
-                new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
-                root_parent
-                    .replace_exact_edge_prepared_with_token(&old_root, new_root.clone(), gate_token)
-                    .expect("validated pivot old-root edge must remain exact");
-            }
+            new_root.relocate_mountpoint(Some(old_root_mountpoint.clone()));
+            root_parent
+                .replace_exact_edge_prepared_with_token(&old_root, new_root.clone(), gate_token)
+                .expect("validated pivot old-root edge must remain exact");
             old_root.relocate_mountpoint(Some(put_old_mountpoint.clone()));
             put_old_mnt
                 .attach_new_top_prelocked(&put_old_mountpoint, old_root.clone(), gate_token)
@@ -371,9 +398,6 @@ impl MntNamespace {
             if old_root.is_locked() {
                 old_root.unlock_mount();
                 new_root.lock_mount();
-            }
-            if old_is_namespace_root {
-                namespace_inner.root_mountfs = new_root.clone();
             }
             Ok(())
         })
@@ -885,10 +909,56 @@ impl ProcessManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::filesystem::ramfs::RamFS;
     use crate::process::namespace::{
         propagation::{get_peers, register_peer},
         user_namespace::INIT_USER_NAMESPACE,
     };
+
+    fn new_private_mount(mountpoint: Arc<MountFSInode>) -> Arc<MountFS> {
+        MountFS::new(
+            RamFS::new(),
+            None,
+            Some(mountpoint),
+            MountPropagation::new_private(),
+            None,
+            MountFlags::empty(),
+            None,
+        )
+    }
+
+    fn assert_failed_pivot_unchanged(
+        namespace: &Arc<MntNamespace>,
+        namespace_root: &Arc<MountFS>,
+        old_root: &Arc<MountFS>,
+        new_root: &Arc<MountFS>,
+        old_root_mountpoint: &Arc<MountFSInode>,
+        new_root_mountpoint: &Arc<MountFSInode>,
+    ) {
+        assert!(Arc::ptr_eq(&namespace.root_mntfs(), namespace_root));
+        assert_eq!(namespace.inner.read().mount_count.mounts, 3);
+        assert!(namespace_root
+            .children_at(old_root_mountpoint)
+            .iter()
+            .any(|mount| Arc::ptr_eq(mount, old_root)));
+        assert!(old_root
+            .children_at(new_root_mountpoint)
+            .iter()
+            .any(|mount| Arc::ptr_eq(mount, new_root)));
+        assert!(new_root
+            .children_at(&new_root.mountpoint_root_inode())
+            .is_empty());
+        assert!(old_root
+            .self_mountpoint()
+            .as_ref()
+            .is_some_and(|mountpoint| Arc::ptr_eq(mountpoint, old_root_mountpoint)));
+        assert!(new_root
+            .self_mountpoint()
+            .as_ref()
+            .is_some_and(|mountpoint| Arc::ptr_eq(mountpoint, new_root_mountpoint)));
+        assert!(old_root.is_locked());
+        assert!(!new_root.is_locked());
+    }
 
     #[test]
     fn registration_prepare_failure_cleans_namespace_copy() {
@@ -915,6 +985,56 @@ mod tests {
         );
         assert!(root.is_live());
         assert!(root.is_belongs_to_mntns(&namespace));
+    }
+
+    #[test]
+    fn pivot_prepare_failures_leave_topology_and_locks_unchanged() {
+        let namespace = MntNamespace::new_root();
+        let namespace_root = namespace.root_mntfs();
+        let old_root_mountpoint = namespace_root.mountpoint_root_inode();
+        let old_root = new_private_mount(old_root_mountpoint.clone());
+        let new_root_mountpoint = old_root.mountpoint_root_inode();
+        let new_root = new_private_mount(new_root_mountpoint.clone());
+        {
+            let _topology = MOUNT_LIFECYCLE_LOCK.lock();
+            namespace
+                .add_mount(
+                    Some(&namespace_root),
+                    Some(&old_root_mountpoint),
+                    old_root.clone(),
+                )
+                .unwrap();
+            namespace
+                .add_mount(
+                    Some(&old_root),
+                    Some(&new_root_mountpoint),
+                    new_root.clone(),
+                )
+                .unwrap();
+        }
+        old_root.lock_mount();
+
+        for failure_point in [FAIL_PIVOT_PREPARE_NEW_EDGE, FAIL_PIVOT_PREPARE_PUT_OLD_EDGE] {
+            FAIL_PIVOT_PREPARE.store(failure_point, Ordering::Release);
+            let result = namespace.pivot_root(
+                old_root.mountpoint_root_inode(),
+                new_root.mountpoint_root_inode(),
+                new_root.mountpoint_root_inode(),
+            );
+            assert!(matches!(result, Err(SystemError::ENOMEM)));
+            assert_eq!(
+                FAIL_PIVOT_PREPARE.load(Ordering::Acquire),
+                FAIL_PIVOT_PREPARE_NONE
+            );
+            assert_failed_pivot_unchanged(
+                &namespace,
+                &namespace_root,
+                &old_root,
+                &new_root,
+                &old_root_mountpoint,
+                &new_root_mountpoint,
+            );
+        }
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
@@ -29,6 +29,10 @@
 #define CLONE_NEWNS 0x00020000
 #endif
 
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER 0x10000000
+#endif
+
 #ifndef MS_REC
 #define MS_REC 16384
 #endif
@@ -506,6 +510,45 @@ void case_permission_failure() {
     child_fail("expected EPERM");
 }
 
+void case_not_dir() {
+    const char* base = "/tmp/test_pivot_root/not_dir";
+    const char* file = "/tmp/test_pivot_root/not_dir/file";
+
+    ensure_parent_tree();
+    ensure_dir(base);
+    int fd = open(file, O_CREAT | O_RDWR, 0600);
+    if (fd < 0) {
+        child_fail("create non-directory target failed");
+    }
+    close(fd);
+
+    errno = 0;
+    if (do_pivot_root(file, base) != -1 || errno != ENOTDIR) {
+        child_fail("non-directory new_root did not return ENOTDIR");
+    }
+    errno = 0;
+    if (do_pivot_root(base, file) != -1 || errno != ENOTDIR) {
+        child_fail("non-directory put_old did not return ENOTDIR");
+    }
+    child_pass();
+}
+
+void case_not_exist() {
+    ensure_parent_tree();
+    errno = 0;
+    if (do_pivot_root("/tmp/test_pivot_root/missing/newroot",
+                      "/tmp/test_pivot_root/missing/oldroot") != -1 ||
+        errno != ENOENT) {
+        child_fail("missing new_root did not preserve ENOENT");
+    }
+    errno = 0;
+    if (do_pivot_root("/tmp", "/tmp/test_pivot_root/missing/oldroot") != -1 ||
+        errno != ENOENT) {
+        child_fail("missing put_old did not preserve ENOENT");
+    }
+    child_pass();
+}
+
 // ---- Tests for shared mount rejection ----
 
 void case_shared_mount_rejection() {
@@ -546,6 +589,102 @@ void case_shared_mount_rejection() {
     }
 
     child_fail("expected EINVAL for shared mount");
+}
+
+void case_shared_root_parent_rejected() {
+    const char* outer = "/tmp/test_pivot_root/shared_root_parent/outer";
+    const char* old_root = "/tmp/test_pivot_root/shared_root_parent/outer/root";
+    const char* new_root = "/tmp/test_pivot_root/shared_root_parent/outer/root/newroot";
+    const char* put_old =
+        "/tmp/test_pivot_root/shared_root_parent/outer/root/newroot/oldroot";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/shared_root_parent");
+    ensure_dir(outer);
+    prepare_private_mount_namespace();
+    if (mount("", outer, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if ((mkdir(old_root, 0755) != 0 && errno != EEXIST) ||
+        mount("", old_root, "ramfs", 0, nullptr) != 0 ||
+        (mkdir(new_root, 0755) != 0 && errno != EEXIST) ||
+        mount("", new_root, "ramfs", 0, nullptr) != 0 ||
+        (mkdir(put_old, 0755) != 0 && errno != EEXIST)) {
+        child_fail("prepare shared root-parent layout failed");
+    }
+    // Use an explicit mount above the caller root, so this isolates Linux's
+    // root_mnt->mnt_parent check from the namespace-root representation.
+    if (mount(nullptr, outer, nullptr, MS_SHARED, nullptr) != 0) {
+        child_skip("cannot make caller-root parent shared");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+    errno = 0;
+    if (do_pivot_root("/newroot", "/newroot/oldroot") != -1 || errno != EINVAL) {
+        child_fail("shared root_mnt parent did not return EINVAL");
+    }
+    child_pass();
+}
+
+void case_shared_new_root_parent_rejected() {
+    const char* old_root = "/tmp/test_pivot_root/shared_new_parent/root";
+    const char* new_root = "/tmp/test_pivot_root/shared_new_parent/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/shared_new_parent/root/newroot/oldroot";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/shared_new_parent");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if ((mkdir(new_root, 0755) != 0 && errno != EEXIST) ||
+        mount("", new_root, "ramfs", 0, nullptr) != 0 ||
+        (mkdir(put_old, 0755) != 0 && errno != EEXIST)) {
+        child_fail("prepare shared new-root-parent layout failed");
+    }
+    // new_mnt->parent is the caller's old-root mount.
+    if (mount(nullptr, old_root, nullptr, MS_SHARED, nullptr) != 0) {
+        child_skip("cannot make new-root parent shared");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+    errno = 0;
+    if (do_pivot_root("/newroot", "/newroot/oldroot") != -1 || errno != EINVAL) {
+        child_fail("shared new_mnt parent did not return EINVAL");
+    }
+    child_pass();
+}
+
+void case_shared_mounted_put_old_rejected() {
+    const char* old_root = "/tmp/test_pivot_root/shared_put_old/root";
+    const char* new_root = "/tmp/test_pivot_root/shared_put_old/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/shared_put_old/root/newroot/oldroot";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/shared_put_old");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if ((mkdir(new_root, 0755) != 0 && errno != EEXIST) ||
+        mount("", new_root, "ramfs", 0, nullptr) != 0 ||
+        (mkdir(put_old, 0755) != 0 && errno != EEXIST) ||
+        mount("", put_old, "ramfs", 0, nullptr) != 0 ||
+        mount(nullptr, put_old, nullptr, MS_SHARED, nullptr) != 0) {
+        child_fail("prepare shared mounted-put-old layout failed");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+    errno = 0;
+    if (do_pivot_root("/newroot", "/newroot/oldroot") != -1 || errno != EINVAL) {
+        child_fail("shared top mount on put_old did not return EINVAL");
+    }
+    child_pass();
 }
 
 // ---- Test for mount namespace isolation (BUG-0a regression) ----
@@ -755,7 +894,7 @@ void case_chroot_ordinary_directory_rejected() {
     child_pass();
 }
 
-void case_namespace_root_pivot() {
+void case_rootfs_rejected() {
     const char* base = "/tmp/test_pivot_root/namespace_root";
     const char* new_root = "/tmp/test_pivot_root/namespace_root/newroot";
     const char* put_old = "/tmp/test_pivot_root/namespace_root/newroot/oldroot";
@@ -765,9 +904,6 @@ void case_namespace_root_pivot() {
     ensure_parent_tree();
     ensure_dir(base);
     prepare_private_mount_namespace();
-    // Keep the new root's real parent private, then make only the caller's
-    // namespace root shared. Linux checks root_mnt->mnt_parent, not root_mnt
-    // itself, so this remains a valid namespace-root pivot.
     if (mount("", base, "ramfs", 0, nullptr) != 0) {
         child_skip(strerror(errno));
     }
@@ -782,16 +918,97 @@ void case_namespace_root_pivot() {
         (mkdir(new_marker, 0755) != 0 && errno != EEXIST)) {
         child_fail("prepare namespace-root markers failed");
     }
-    if (mount(nullptr, "/", nullptr, MS_SHARED, nullptr) != 0) {
-        child_skip("cannot make namespace root shared");
+    errno = 0;
+    if (do_pivot_root(new_root, put_old) != -1 || errno != EINVAL) {
+        child_fail("pivot_root from unattached namespace root did not return EINVAL");
+    }
+    if (access(old_marker, F_OK) != 0 || access(new_marker, F_OK) != 0) {
+        child_fail("failed rootfs pivot changed the original topology");
+    }
+    child_pass();
+}
+
+void case_namespace_root_identity_busy() {
+    ensure_parent_tree();
+    prepare_private_mount_namespace();
+    errno = 0;
+    if (do_pivot_root("/", "/tmp") != -1 || errno != EBUSY) {
+        child_fail("namespace-root identity loop did not take EBUSY precedence");
+    }
+    child_pass();
+}
+
+void case_locked_new_root_rejected() {
+    const char* old_root = "/tmp/test_pivot_root/locked_new/root";
+    const char* new_root = "/tmp/test_pivot_root/locked_new/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/locked_new/root/newroot/oldroot";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/locked_new");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if ((mkdir(new_root, 0755) != 0 && errno != EEXIST) ||
+        mount("", new_root, "ramfs", 0, nullptr) != 0 ||
+        (mkdir(put_old, 0755) != 0 && errno != EEXIST)) {
+        child_fail("prepare locked-new-root layout failed");
+    }
+    // A mount namespace copied into a new user namespace locks every copied
+    // mount. The already-mounted new_root must therefore be rejected.
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNS) != 0) {
+        child_fail("unshare user+mount namespace failed");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot locked old root failed");
+    }
+    errno = 0;
+    if (do_pivot_root("/newroot", "/newroot/oldroot") != -1 || errno != EINVAL) {
+        child_fail("locked new_root did not return EINVAL");
+    }
+    child_pass();
+}
+
+void case_old_root_lock_transferred() {
+    const char* old_root = "/tmp/test_pivot_root/lock_transfer/root";
+    const char* new_root = "/tmp/test_pivot_root/lock_transfer/root/newroot";
+    const char* put_old = "/tmp/test_pivot_root/lock_transfer/root/newroot/oldroot";
+    const char* move_target = "/tmp/test_pivot_root/lock_transfer/root/newroot/move_target";
+
+    ensure_parent_tree();
+    ensure_dir("/tmp/test_pivot_root/lock_transfer");
+    ensure_dir(old_root);
+    prepare_private_mount_namespace();
+    if (mount("", old_root, "ramfs", 0, nullptr) != 0) {
+        child_skip(strerror(errno));
+    }
+    if (mkdir(new_root, 0755) != 0 && errno != EEXIST) {
+        child_fail("mkdir(newroot) before namespace copy failed");
+    }
+    // The copied old_root is locked, while mounts created after this point
+    // are owned by the new user namespace and remain movable.
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNS) != 0) {
+        child_fail("unshare user+mount namespace failed");
+    }
+    if (mount("", new_root, "ramfs", 0, nullptr) != 0 ||
+        (mkdir(put_old, 0755) != 0 && errno != EEXIST) ||
+        (mkdir(move_target, 0755) != 0 && errno != EEXIST)) {
+        child_fail("prepare unlocked pivot targets failed");
+    }
+    if (chroot(old_root) != 0 || chdir("/") != 0) {
+        child_fail("chroot(old_root) failed");
+    }
+    if (do_pivot_root("/newroot", "/newroot/oldroot") != 0) {
+        child_fail("pivot_root with locked old root failed");
     }
 
-    if (do_pivot_root(new_root, put_old) != 0) {
-        child_fail("pivot_root from namespace root failed");
+    errno = 0;
+    if (mount("/", "/move_target", nullptr, MS_MOVE, nullptr) != -1 || errno != EINVAL) {
+        child_fail("new root did not receive the topology lock");
     }
-    if (access("/new_marker", F_OK) != 0 ||
-        access("/oldroot/tmp/test_pivot_root/namespace_root_old_marker", F_OK) != 0) {
-        child_fail("namespace-root pivot published incomplete topology");
+    if (umount2("/oldroot", MNT_DETACH) != 0) {
+        child_fail("old root remained locked after pivot");
     }
     child_pass();
 }
@@ -1181,8 +1398,31 @@ TEST(PivotRoot, PermissionFailure) {
     expect_case_pass_or_skip("pivot_root_permission_failure", case_permission_failure);
 }
 
+TEST(PivotRoot, NotDir) {
+    expect_case_pass_or_skip("pivot_root_not_dir", case_not_dir);
+}
+
+TEST(PivotRoot, NotExist) {
+    expect_case_pass_or_skip("pivot_root_not_exist", case_not_exist);
+}
+
 TEST(PivotRoot, SharedMountRejection) {
     expect_case_pass_or_skip("pivot_root_shared_mount_rejection", case_shared_mount_rejection);
+}
+
+TEST(PivotRoot, SharedRootParentRejected) {
+    expect_case_pass_or_skip("pivot_root_shared_root_parent_rejected",
+                             case_shared_root_parent_rejected);
+}
+
+TEST(PivotRoot, SharedNewRootParentRejected) {
+    expect_case_pass_or_skip("pivot_root_shared_new_root_parent_rejected",
+                             case_shared_new_root_parent_rejected);
+}
+
+TEST(PivotRoot, SharedMountedPutOldRejected) {
+    expect_case_pass_or_skip("pivot_root_shared_mounted_put_old_rejected",
+                             case_shared_mounted_put_old_rejected);
 }
 
 TEST(PivotRoot, MountNamespaceIsolation) {
@@ -1203,8 +1443,22 @@ TEST(PivotRoot, ChrootOrdinaryDirectoryRejected) {
                              case_chroot_ordinary_directory_rejected);
 }
 
-TEST(PivotRoot, NamespaceRootPivot) {
-    expect_case_pass_or_skip("pivot_root_namespace_root", case_namespace_root_pivot);
+TEST(PivotRoot, RootFsRejected) {
+    expect_case_pass_or_skip("pivot_root_rootfs_rejected", case_rootfs_rejected);
+}
+
+TEST(PivotRoot, NamespaceRootIdentityBusy) {
+    expect_case_pass_or_skip("pivot_root_namespace_root_identity_busy",
+                             case_namespace_root_identity_busy);
+}
+
+TEST(PivotRoot, LockedNewRootRejected) {
+    expect_case_pass_or_skip("pivot_root_locked_new_root_rejected", case_locked_new_root_rejected);
+}
+
+TEST(PivotRoot, OldRootLockTransferred) {
+    expect_case_pass_or_skip("pivot_root_old_root_lock_transferred",
+                             case_old_root_lock_transferred);
 }
 
 TEST(PivotRoot, NewRootOnRootMount) {

--- a/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
+++ b/user/apps/tests/dunitest/suites/normal/test_pivot_root.cc
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/vfs.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -35,6 +36,10 @@
 
 #ifndef MS_REC
 #define MS_REC 16384
+#endif
+
+#ifndef RAMFS_MAGIC
+#define RAMFS_MAGIC 0x858458f6
 #endif
 
 namespace {
@@ -894,12 +899,20 @@ void case_chroot_ordinary_directory_rejected() {
     child_pass();
 }
 
-void case_rootfs_rejected() {
+void case_namespace_root_pivot() {
     const char* base = "/tmp/test_pivot_root/namespace_root";
     const char* new_root = "/tmp/test_pivot_root/namespace_root/newroot";
     const char* put_old = "/tmp/test_pivot_root/namespace_root/newroot/oldroot";
     const char* old_marker = "/tmp/test_pivot_root/namespace_root_old_marker";
     const char* new_marker = "/tmp/test_pivot_root/namespace_root/newroot/new_marker";
+
+    struct statfs current_root = {};
+    if (statfs("/", &current_root) != 0) {
+        child_fail("statfs current root failed");
+    }
+    if (current_root.f_type == RAMFS_MAGIC) {
+        child_skip("initial ramfs root is intentionally unattached");
+    }
 
     ensure_parent_tree();
     ensure_dir(base);
@@ -918,12 +931,12 @@ void case_rootfs_rejected() {
         (mkdir(new_marker, 0755) != 0 && errno != EEXIST)) {
         child_fail("prepare namespace-root markers failed");
     }
-    errno = 0;
-    if (do_pivot_root(new_root, put_old) != -1 || errno != EINVAL) {
-        child_fail("pivot_root from unattached namespace root did not return EINVAL");
+    if (do_pivot_root(new_root, put_old) != 0) {
+        child_fail("pivot_root from attached namespace root failed");
     }
-    if (access(old_marker, F_OK) != 0 || access(new_marker, F_OK) != 0) {
-        child_fail("failed rootfs pivot changed the original topology");
+    if (access("/new_marker", F_OK) != 0 ||
+        access("/oldroot/tmp/test_pivot_root/namespace_root_old_marker", F_OK) != 0) {
+        child_fail("namespace-root pivot did not preserve old and new roots");
     }
     child_pass();
 }
@@ -1443,8 +1456,8 @@ TEST(PivotRoot, ChrootOrdinaryDirectoryRejected) {
                              case_chroot_ordinary_directory_rejected);
 }
 
-TEST(PivotRoot, RootFsRejected) {
-    expect_case_pass_or_skip("pivot_root_rootfs_rejected", case_rootfs_rejected);
+TEST(PivotRoot, NamespaceRootPivot) {
+    expect_case_pass_or_skip("pivot_root_namespace_root", case_namespace_root_pivot);
 }
 
 TEST(PivotRoot, NamespaceRootIdentityBusy) {

--- a/user/apps/tests/dunitest/suites/normal/unix_socket_shutdown.cc
+++ b/user/apps/tests/dunitest/suites/normal/unix_socket_shutdown.cc
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+bool WaitForSleepingProcess(pid_t pid) {
+    char path[64] = {};
+    std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+    while (std::chrono::steady_clock::now() < deadline) {
+        FILE* stat = std::fopen(path, "r");
+        if (stat != nullptr) {
+            char line[512] = {};
+            const bool read = std::fgets(line, sizeof(line), stat) != nullptr;
+            std::fclose(stat);
+            if (read) {
+                const char* comm_end = std::strrchr(line, ')');
+                if (comm_end != nullptr && comm_end[1] == ' ' &&
+                    (comm_end[2] == 'S' || comm_end[2] == 'D')) {
+                    return true;
+                }
+            }
+        }
+        usleep(1'000);
+    }
+    return false;
+}
+
+void ExpectPeerReadWokenByShutdown(int socket_type) {
+    int sockets[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(socketpair(AF_UNIX, socket_type, 0, sockets), 0) << std::strerror(errno);
+    ASSERT_EQ(pipe(ready), 0) << std::strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << std::strerror(errno);
+    if (child == 0) {
+        close(sockets[0]);
+        close(ready[0]);
+
+        struct timeval timeout = {};
+        timeout.tv_sec = 1;
+        if (setsockopt(sockets[1], SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+            _exit(2);
+        }
+        char marker = 'R';
+        if (write(ready[1], &marker, sizeof(marker)) != sizeof(marker)) {
+            _exit(3);
+        }
+
+        const auto start = std::chrono::steady_clock::now();
+        char byte = 0;
+        const ssize_t nread = read(sockets[1], &byte, sizeof(byte));
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        if (nread != 0 || elapsed >= std::chrono::milliseconds(800)) {
+            _exit(4);
+        }
+        _exit(0);
+    }
+
+    close(sockets[1]);
+    close(ready[1]);
+    char marker = 0;
+    ASSERT_EQ(read(ready[0], &marker, sizeof(marker)), 1);
+    ASSERT_EQ(marker, 'R');
+    if (!WaitForSleepingProcess(child)) {
+        kill(child, SIGKILL);
+        waitpid(child, nullptr, 0);
+        FAIL() << "child did not block in read";
+    }
+    ASSERT_EQ(shutdown(sockets[0], SHUT_WR), 0) << std::strerror(errno);
+
+    int status = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    pid_t waited = 0;
+    while (std::chrono::steady_clock::now() < deadline) {
+        waited = waitpid(child, &status, WNOHANG);
+        if (waited != 0) {
+            break;
+        }
+        usleep(1'000);
+    }
+    if (waited == 0) {
+        kill(child, SIGKILL);
+        waitpid(child, &status, 0);
+        FAIL() << "peer read did not wake after shutdown(SHUT_WR)";
+    }
+    ASSERT_EQ(waited, child) << std::strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+
+    close(sockets[0]);
+    close(ready[0]);
+}
+
+}  // namespace
+
+TEST(UnixSocketShutdown, StreamPeerReadWakesForEof) {
+    ExpectPeerReadWokenByShutdown(SOCK_STREAM);
+}
+
+TEST(UnixSocketShutdown, SeqPacketPeerReadWakesForEof) {
+    ExpectPeerReadWokenByShutdown(SOCK_SEQPACKET);
+}
+
+TEST(UnixSocketShutdown, PollReportsDirectionalAndFullShutdown) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockets), 0) << std::strerror(errno);
+
+    ASSERT_EQ(shutdown(sockets[0], SHUT_WR), 0) << std::strerror(errno);
+    struct pollfd peer = {};
+    peer.fd = sockets[1];
+    peer.events = POLLIN | POLLRDHUP;
+    ASSERT_EQ(poll(&peer, 1, 0), 1) << std::strerror(errno);
+    EXPECT_NE(peer.revents & POLLIN, 0);
+    EXPECT_NE(peer.revents & POLLRDHUP, 0);
+
+    ASSERT_EQ(shutdown(sockets[0], SHUT_RD), 0) << std::strerror(errno);
+    peer.revents = 0;
+    ASSERT_EQ(poll(&peer, 1, 0), 1) << std::strerror(errno);
+    EXPECT_NE(peer.revents & POLLHUP, 0);
+
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/unix_socket_shutdown.cc
+++ b/user/apps/tests/dunitest/suites/normal/unix_socket_shutdown.cc
@@ -103,6 +103,115 @@ void ExpectPeerReadWokenByShutdown(int socket_type) {
     close(ready[0]);
 }
 
+void ExpectLocalReadShutdownDrainsThenReturnsEof(int socket_type) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(socketpair(AF_UNIX, socket_type, 0, sockets), 0) << std::strerror(errno);
+
+    constexpr char payload[] = "abc";
+    ASSERT_EQ(send(sockets[1], payload, sizeof(payload) - 1, 0),
+              static_cast<ssize_t>(sizeof(payload) - 1))
+        << std::strerror(errno);
+    ASSERT_EQ(shutdown(sockets[0], SHUT_RD), 0) << std::strerror(errno);
+
+    struct pollfd local = {};
+    local.fd = sockets[0];
+    local.events = POLLIN | POLLRDHUP;
+    ASSERT_EQ(poll(&local, 1, 0), 1) << std::strerror(errno);
+    EXPECT_NE(local.revents & POLLIN, 0);
+    EXPECT_NE(local.revents & POLLRDHUP, 0);
+
+    char received[sizeof(payload)] = {};
+    ASSERT_EQ(recv(sockets[0], received, sizeof(received), 0),
+              static_cast<ssize_t>(sizeof(payload) - 1))
+        << std::strerror(errno);
+    EXPECT_EQ(std::memcmp(received, payload, sizeof(payload) - 1), 0);
+
+    // Once pre-shutdown data is drained, SHUT_RD is an immediate EOF rather
+    // than EAGAIN or another blocking wait.
+    EXPECT_EQ(recv(sockets[0], received, sizeof(received), MSG_PEEK | MSG_DONTWAIT), 0)
+        << std::strerror(errno);
+
+    struct iovec iov = {};
+    iov.iov_base = received;
+    iov.iov_len = sizeof(received);
+    struct msghdr msg = {};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    EXPECT_EQ(recvmsg(sockets[0], &msg, MSG_DONTWAIT), 0) << std::strerror(errno);
+
+    EXPECT_EQ(recv(sockets[0], received, sizeof(received), MSG_DONTWAIT), 0)
+        << std::strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(send(sockets[1], payload, sizeof(payload) - 1, MSG_NOSIGNAL), -1);
+    EXPECT_EQ(errno, EPIPE);
+
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+void ExpectLocalReadWokenByShutdown(int socket_type) {
+    int sockets[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(socketpair(AF_UNIX, socket_type, 0, sockets), 0) << std::strerror(errno);
+    ASSERT_EQ(pipe(ready), 0) << std::strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << std::strerror(errno);
+    if (child == 0) {
+        close(sockets[1]);
+        close(ready[0]);
+        struct timeval timeout = {};
+        timeout.tv_sec = 1;
+        if (setsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+            _exit(2);
+        }
+        char marker = 'R';
+        if (write(ready[1], &marker, sizeof(marker)) != sizeof(marker)) {
+            _exit(3);
+        }
+        const auto start = std::chrono::steady_clock::now();
+        char byte = 0;
+        const ssize_t nread = read(sockets[0], &byte, sizeof(byte));
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        _exit(nread == 0 && elapsed < std::chrono::milliseconds(800) ? 0 : 4);
+    }
+
+    close(ready[1]);
+    char marker = 0;
+    ASSERT_EQ(read(ready[0], &marker, sizeof(marker)), 1);
+    ASSERT_EQ(marker, 'R');
+    if (!WaitForSleepingProcess(child)) {
+        kill(child, SIGKILL);
+        waitpid(child, nullptr, 0);
+        FAIL() << "child did not block in local read";
+    }
+
+    ASSERT_EQ(shutdown(sockets[0], SHUT_RD), 0) << std::strerror(errno);
+    int status = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    pid_t waited = 0;
+    while (std::chrono::steady_clock::now() < deadline) {
+        waited = waitpid(child, &status, WNOHANG);
+        if (waited != 0) {
+            break;
+        }
+        usleep(1'000);
+    }
+    if (waited == 0) {
+        kill(child, SIGKILL);
+        waitpid(child, &status, 0);
+        FAIL() << "local read did not wake after shutdown(SHUT_RD)";
+    }
+    ASSERT_EQ(waited, child) << std::strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+
+    close(sockets[0]);
+    close(sockets[1]);
+    close(ready[0]);
+}
+
 }  // namespace
 
 TEST(UnixSocketShutdown, StreamPeerReadWakesForEof) {
@@ -111,6 +220,22 @@ TEST(UnixSocketShutdown, StreamPeerReadWakesForEof) {
 
 TEST(UnixSocketShutdown, SeqPacketPeerReadWakesForEof) {
     ExpectPeerReadWokenByShutdown(SOCK_SEQPACKET);
+}
+
+TEST(UnixSocketShutdown, StreamLocalReadShutdownDrainsThenReturnsEof) {
+    ExpectLocalReadShutdownDrainsThenReturnsEof(SOCK_STREAM);
+}
+
+TEST(UnixSocketShutdown, SeqPacketLocalReadShutdownDrainsThenReturnsEof) {
+    ExpectLocalReadShutdownDrainsThenReturnsEof(SOCK_SEQPACKET);
+}
+
+TEST(UnixSocketShutdown, StreamLocalReadWakesForEof) {
+    ExpectLocalReadWokenByShutdown(SOCK_STREAM);
+}
+
+TEST(UnixSocketShutdown, SeqPacketLocalReadWakesForEof) {
+    ExpectLocalReadWokenByShutdown(SOCK_SEQPACKET);
 }
 
 TEST(UnixSocketShutdown, PollReportsDirectionalAndFullShutdown) {

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -44,6 +44,7 @@ normal/tcp_bind_semantics
 normal/tcp_close_semantics
 normal/udp_ipv6_send_semantics
 normal/socket_getsockopt_semantics
+normal/unix_socket_shutdown
 fuse/fuse_core
 fuse/fuse_extended
 normal/test_procfs_link


### PR DESCRIPTION
## Summary

- align `pivot_root(2)` admission and errno precedence with Linux 6.6, including unattached rootfs rejection, shared-parent checks, locked new-root rejection, and old-root lock transfer
- keep topology mutation allocation-free after the first edge change and add test-only reservation failure coverage
- fix Unix stream/seqpacket shutdown peer wakeups and level-triggered RDHUP/HUP state used by the gVisor user/mount namespace helper
- expand DragonOS pivot-root coverage and enable bounded Unix shutdown regressions in the default dunitest whitelist

## Validation

- `make kernel`
- `make -C user/apps/tests/dunitest all -j24`
- DragonOS guest `test_pivot_root_test`: 28/28 passed
- unchanged gVisor `PivotRootTest.*`: 19/19 passed
- DragonOS guest `unix_socket_shutdown_test`: 3/3 passed
- mount propagation: 24/24 passed
- mount object topology: 9/9 passed
- mount limit: 6/6 passed
- Linux host `unix_socket_shutdown_test`: 3/3 passed
- `cargo fmt --all -- --check`
- `git diff --check`

The targeted `cfg(test)` failure-injection test is present, but the repository's existing kernel host-test harness currently fails before test execution on unrelated baseline test-build errors. Production kernel and guest validation complete successfully.

Closes #2105
