### PR TITLE
perf(ext4): batch nojournal range allocation

### DIFF
--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -4,6 +4,14 @@ use crate::ext4_defs::*;
 use crate::format_error;
 use crate::prelude::*;
 use crate::return_error;
+use core::cmp::min;
+
+pub(super) struct DirectRangeAllocation {
+    pub first: PBlockId,
+    pub allocation_homes: [PBlockId; 3],
+}
+
+const DIRECT_RANGE_MAX_GROUP_PROBES: u32 = 4;
 
 fn extent_tail_batch_limit(
     first_data_block: PBlockId,
@@ -69,6 +77,135 @@ impl Ext4 {
             return 0;
         }
         core::cmp::min(sb.blocks_per_group() as u64, total - first) as usize
+    }
+
+    /// Stage one group-local contiguous data allocation without publishing
+    /// any cache or disk metadata.  The caller owns the filesystem-wide
+    /// transactional metadata gate, so no direct allocator can race the
+    /// transaction-private bitmap snapshot while zero I/O is in progress.
+    pub(super) fn transaction_alloc_direct_range(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode_id: InodeId,
+        preferred_first: Option<PBlockId>,
+        require_preferred: bool,
+        count: u32,
+    ) -> Result<DirectRangeAllocation> {
+        if count == 0 {
+            return_error!(ErrCode::EINVAL, "Cannot allocate an empty block range");
+        }
+        let mut sb = self.transaction_read_super_block(transaction)?;
+        self.prepare_stats.record_superblock_io();
+        let bg_count = sb.block_group_count();
+        let preferred_inode_group = ((inode_id - 1) / sb.inodes_per_group()) as BlockGroupId;
+        let preferred_group = preferred_first
+            .filter(|block| *block >= sb.first_data_block() as PBlockId)
+            .map(|block| {
+                ((block - sb.first_data_block() as PBlockId) / sb.blocks_per_group() as PBlockId)
+                    as BlockGroupId
+            })
+            .filter(|group| *group < bg_count)
+            .unwrap_or(preferred_inode_group);
+        let count_usize = count as usize;
+
+        for offset in 0..min(bg_count, DIRECT_RANGE_MAX_GROUP_PROBES) {
+            let bgid = ((preferred_group as u64 + offset as u64) % bg_count as u64) as BlockGroupId;
+            let blocks_in_group = Self::block_group_block_count(&sb, bgid);
+            if blocks_in_group < count_usize {
+                continue;
+            }
+            let mut bg = self.transaction_read_block_group(transaction, bgid)?;
+            self.prepare_stats.record_gdt_io();
+            if bg.desc.get_free_blocks_count() < count as u64 {
+                continue;
+            }
+            let bitmap_home = bg.desc.block_bitmap_block();
+            let bitmap_block = transaction.read(self.block_device.as_ref(), bitmap_home)?;
+            self.prepare_stats.record_bitmap_io();
+            let checksum_bytes = (sb.clusters_per_group() as usize) / 8;
+            if sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
+                if !bg.verify_checksum(sb.metadata_checksum_seed()) {
+                    return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
+                }
+                if !bg.desc.verify_block_bitmap_csum(
+                    sb.metadata_checksum_seed(),
+                    &*bitmap_block,
+                    checksum_bytes,
+                ) {
+                    return_error!(ErrCode::EIO, "Corrupt block bitmap checksum");
+                }
+            }
+
+            let group_first = Self::block_group_first_block(&sb, bgid);
+            let exact_hint = preferred_first
+                .filter(|_| offset == 0)
+                .and_then(|block| block.checked_sub(group_first))
+                .and_then(|bit| usize::try_from(bit).ok())
+                .filter(|bit| {
+                    bit.checked_add(count_usize)
+                        .is_some_and(|end| end <= blocks_in_group)
+                        && (*bit..*bit + count_usize)
+                            .all(|index| bitmap_block[index / 8] & (1 << (index % 8)) == 0)
+                });
+            let bit = exact_hint.or_else(|| {
+                (!require_preferred)
+                    .then(|| {
+                        Bitmap::first_clear_run_in(
+                            &*bitmap_block,
+                            blocks_in_group,
+                            0,
+                            blocks_in_group,
+                            count_usize,
+                        )
+                    })
+                    .flatten()
+            });
+            let Some(bit) = bit else { continue };
+            let first = group_first
+                .checked_add(bit as PBlockId)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+            self.validate_data_blocks(first, count as u64)?;
+            let new_bg_free = bg
+                .desc
+                .get_free_blocks_count()
+                .checked_sub(count as u64)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            let new_sb_free = sb
+                .free_blocks_count()
+                .checked_sub(count as u64)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+
+            {
+                let image = self.transaction_block_for_update(transaction, bitmap_home)?;
+                self.prepare_stats.record_bitmap_io();
+                let mut bitmap = Bitmap::new(image, blocks_in_group);
+                if (bit..bit + count_usize).any(|index| !bitmap.is_bit_clear(index)) {
+                    return_error!(ErrCode::EIO, "Direct range changed during planning");
+                }
+                for index in bit..bit + count_usize {
+                    bitmap.set_bit(index);
+                }
+                if !bg.desc.update_block_bitmap_csum(
+                    sb.metadata_checksum_seed(),
+                    image,
+                    checksum_bytes,
+                ) {
+                    return_error!(ErrCode::EIO, "Invalid block bitmap checksum length");
+                }
+            }
+            bg.desc.set_free_blocks_count(new_bg_free);
+            self.transaction_stage_block_group_with_csum(transaction, &mut bg)?;
+            self.prepare_stats.record_gdt_io();
+            sb.set_free_blocks_count(new_sb_free);
+            self.transaction_stage_super_block(transaction, &sb)?;
+            self.prepare_stats.record_superblock_io();
+            let (gdt_home, _) = self.block_group_disk_pos(bgid)?;
+            return Ok(DirectRangeAllocation {
+                first,
+                allocation_homes: [bitmap_home, gdt_home, 0],
+            });
+        }
+        return_error!(ErrCode::ENOSPC, "No contiguous direct range available");
     }
 
     /// Stage the release of one contiguous physical-block range.
@@ -764,6 +901,7 @@ impl Ext4 {
             // extent physical block numbers are absolute filesystem block numbers.
             let bitmap_block_id = bg.desc.block_bitmap_block();
             let mut bitmap_block = self.read_block(bitmap_block_id)?;
+            self.prepare_stats.record_bitmap_io();
             let old_bitmap_block = bitmap_block.clone();
             let old_bg = BlockGroupRef::new(bg.id, bg.desc);
             let old_sb = sb;
@@ -785,6 +923,7 @@ impl Ext4 {
                 return_error!(ErrCode::EIO, "Invalid block bitmap checksum length");
             }
             self.write_block(&bitmap_block)?;
+            self.prepare_stats.record_bitmap_io();
 
             // Update block group counters
             bg.desc
@@ -844,6 +983,7 @@ impl Ext4 {
             }
             return Err(init_error);
         }
+        self.prepare_stats.record_zero_io();
         Ok(pblock)
     }
 

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -26,7 +26,104 @@ pub(super) struct ExtentTail {
     pub unwritten: bool,
 }
 
+pub(super) struct DirectAppendShape {
+    pub preferred_first: Option<PBlockId>,
+    pub requires_merge: bool,
+}
+
 impl Ext4 {
+    pub(super) fn direct_append_shape(
+        &self,
+        inode: &InodeRef,
+        start_lblock: LBlockId,
+        count: u32,
+    ) -> Result<Option<DirectAppendShape>> {
+        if count == 0 || count > u16::MAX as u32 || !inode.inode.uses_extents() {
+            return Ok(None);
+        }
+        let root = inode.inode.extent_root();
+        let header = root.header();
+        self.validate_extent_node(inode.id, &root)?;
+        if header.depth() != 0
+            || header.max_entries_count() as usize != root.entry_capacity()
+            || header.entries_count() as usize > root.entry_capacity()
+        {
+            return Ok(None);
+        }
+        let entries = header.entries_count() as usize;
+        if entries == 0 {
+            return Ok((start_lblock == 0).then_some(DirectAppendShape {
+                preferred_first: None,
+                requires_merge: false,
+            }));
+        }
+        let last = root.extent_at(entries - 1);
+        if last.is_unwritten() {
+            return Ok(None);
+        }
+        for index in 0..entries {
+            let extent = root.extent_at(index);
+            self.validate_data_blocks(extent.start_pblock(), extent.block_count() as u64)?;
+        }
+        let next_lblock = last
+            .start_lblock()
+            .checked_add(last.block_count())
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        if next_lblock != start_lblock {
+            return Ok(None);
+        }
+        let preferred_first = last
+            .start_pblock()
+            .checked_add(last.block_count() as PBlockId)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        let candidate = Extent::new(start_lblock, preferred_first, count as u16);
+        let can_merge = Extent::can_append(last, &candidate);
+        let root_full = entries == header.max_entries_count() as usize;
+        if root_full && !can_merge {
+            return Ok(None);
+        }
+        Ok(Some(DirectAppendShape {
+            preferred_first: Some(preferred_first),
+            requires_merge: root_full,
+        }))
+    }
+
+    pub(super) fn stage_direct_append_extent(
+        &self,
+        inode: &mut InodeRef,
+        start_lblock: LBlockId,
+        start_pblock: PBlockId,
+        count: u32,
+    ) -> Result<()> {
+        let new_extent = Extent::new(start_lblock, start_pblock, count as u16);
+        let mut root = inode.inode.extent_root_mut();
+        let entries = root.header().entries_count() as usize;
+        if entries > 0 {
+            let last = *root.extent_at(entries - 1);
+            if Extent::can_append(&last, &new_extent) {
+                root.extent_mut_at(entries - 1)
+                    .set_block_count(last.block_count() + count);
+            } else if root.insert_extent(&new_extent, entries).is_err() {
+                return Err(format_error!(
+                    ErrCode::ENOTSUP,
+                    "Inline extent root requires a split"
+                ));
+            }
+        } else if root.insert_extent(&new_extent, 0).is_err() {
+            return Err(format_error!(
+                ErrCode::ENOTSUP,
+                "Inline extent root requires a split"
+            ));
+        }
+        let blocks = inode
+            .inode
+            .fs_block_count()
+            .checked_add(count as u64)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        inode.inode.set_fs_block_count(blocks);
+        Ok(())
+    }
+
     fn verify_extent_block_checksum(&self, inode_ref: &InodeRef, image: &[u8]) -> Result<()> {
         let sb = self.read_super_block_cached();
         if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
@@ -74,6 +171,7 @@ impl Ext4 {
         self.ensure_valid_pblock(inode_ref.id, pblock, "extent tree node")?;
         self.validate_data_blocks(pblock, 1)?;
         let block = self.read_block(pblock)?;
+        self.prepare_stats.record_extent_io();
         self.verify_extent_block_checksum(inode_ref, &block.data[..])?;
         Ok(block)
     }
@@ -345,6 +443,7 @@ impl Ext4 {
         // Write checksum into the tail
         block.data[tail_offset..tail_offset + 4].copy_from_slice(&csum.to_le_bytes());
         self.write_block(block)
+            .inspect(|_| self.prepare_stats.record_extent_io())
     }
 }
 
@@ -862,6 +961,15 @@ impl Ext4 {
                 inode_id
             ));
         }
+        if header.max_entries_count() as usize > ex_node.entry_capacity()
+            || header.entries_count() as usize > ex_node.entry_capacity()
+        {
+            return Err(format_error!(
+                ErrCode::EIO,
+                "extent header exceeds node capacity on inode {}",
+                inode_id
+            ));
+        }
         let entries = header.entries_count() as usize;
         if header.depth() > 0 {
             if entries == 0 {
@@ -1000,6 +1108,7 @@ mod tests {
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),
+            prepare_stats: crate::ext4::PrepareStats::new(),
         }
     }
 
@@ -1031,6 +1140,7 @@ mod tests {
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),
+            prepare_stats: crate::ext4::PrepareStats::new(),
         }
     }
 
@@ -1090,6 +1200,36 @@ mod tests {
             .validate_extent_node(4, &node.as_immut())
             .expect_err("unsorted index must be rejected");
         assert_eq!(err.code(), ErrCode::EIO);
+    }
+
+    #[test]
+    fn validate_extent_node_rejects_header_larger_than_inline_storage() {
+        let fs = make_test_fs(1024);
+        let mut raw = [0u8; 60];
+        ExtentNodeMut::from_bytes(&mut raw).init(0, 0);
+        raw[2..4].copy_from_slice(&5u16.to_le_bytes());
+        raw[4..6].copy_from_slice(&5u16.to_le_bytes());
+        let node = ExtentNode::from_bytes(&raw);
+
+        let error = fs.validate_extent_node(5, &node).unwrap_err();
+
+        assert_eq!(error.code(), ErrCode::EIO);
+    }
+
+    #[test]
+    fn direct_append_rejects_unwritten_tail() {
+        let fs = make_test_fs(1024);
+        let mut inode = InodeRef::new(6, Box::new(Inode::default()));
+        inode.inode.extent_init();
+        let mut extent = Extent::new(0, 100, 16);
+        extent.mark_unwritten();
+        inode
+            .inode
+            .extent_root_mut()
+            .insert_extent(&extent, 0)
+            .unwrap();
+
+        assert!(fs.direct_append_shape(&inode, 16, 16).unwrap().is_none());
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/journal.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal.rs
@@ -146,8 +146,13 @@ impl Ext4 {
         Ok(())
     }
 
-    pub(super) fn uses_journal(&self) -> bool {
+    pub fn uses_journal(&self) -> bool {
         matches!(self.metadata_mode, MetadataMutationMode::Journal(_))
+    }
+
+    pub(super) fn supports_direct_range_stage(&self) -> bool {
+        matches!(self.metadata_mode, MetadataMutationMode::Direct(_))
+            && self.block_device.supports_reliable_flush()
     }
 
     pub fn shutdown_writable(&self) -> Result<()> {
@@ -196,6 +201,17 @@ impl Ext4 {
             MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
             MetadataMutationMode::Journal(core) => core.start(credits),
             MetadataMutationMode::Direct(core) => core.start(credits),
+        }
+    }
+
+    pub(super) fn transaction_start_direct_range(
+        &self,
+        credits: usize,
+    ) -> Result<journal_transaction::Transaction<'_>> {
+        match &self.metadata_mode {
+            MetadataMutationMode::Direct(core) => core.start_direct_range(credits),
+            MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
+            MetadataMutationMode::Journal(_) => Err(Ext4Error::new(ErrCode::ENOTSUP)),
         }
     }
 

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -63,6 +63,7 @@ impl JournalContext {
 /// callers cannot retain a second publishable copy past commit/abort.
 pub struct StagedBlock {
     home: PBlockId,
+    original: Option<Box<[u8; BLOCK_SIZE]>>,
     image: Box<[u8; BLOCK_SIZE]>,
 }
 
@@ -147,6 +148,18 @@ impl DirectTransactionCore {
     }
 
     pub fn start(&self, credits: usize) -> Result<Transaction<'_>> {
+        self.start_with_originals(credits, false)
+    }
+
+    pub(super) fn start_direct_range(&self, credits: usize) -> Result<Transaction<'_>> {
+        self.start_with_originals(credits, true)
+    }
+
+    fn start_with_originals(
+        &self,
+        credits: usize,
+        preserve_originals: bool,
+    ) -> Result<Transaction<'_>> {
         if credits == 0 || self.is_poisoned() {
             return Err(Ext4Error::new(if credits == 0 {
                 ErrCode::EINVAL
@@ -161,7 +174,11 @@ impl DirectTransactionCore {
         {
             return Err(Ext4Error::new(ErrCode::EAGAIN));
         }
-        Ok(Transaction::new(TransactionCoreRef::Direct(self), credits))
+        Ok(Transaction::new(
+            TransactionCoreRef::Direct(self),
+            credits,
+            preserve_originals,
+        ))
     }
 
     fn poison(&self) {
@@ -232,7 +249,11 @@ impl JournalTransactionCore {
             self.writer.store(false, Ordering::Release);
             return Err(Ext4Error::new(ErrCode::E2BIG));
         }
-        Ok(Transaction::new(TransactionCoreRef::Journal(self), credits))
+        Ok(Transaction::new(
+            TransactionCoreRef::Journal(self),
+            credits,
+            false,
+        ))
     }
 
     fn poison(&self) {
@@ -250,15 +271,21 @@ pub struct Transaction<'a> {
     core: TransactionCoreRef<'a>,
     credits: usize,
     staged: BTreeMap<PBlockId, StagedBlock>,
+    preserve_originals: bool,
     owns_writer: bool,
 }
 
 impl Transaction<'_> {
-    fn new(core: TransactionCoreRef<'_>, credits: usize) -> Transaction<'_> {
+    fn new(
+        core: TransactionCoreRef<'_>,
+        credits: usize,
+        preserve_originals: bool,
+    ) -> Transaction<'_> {
         Transaction {
             core,
             credits,
             staged: BTreeMap::new(),
+            preserve_originals,
             owns_writer: true,
         }
     }
@@ -268,7 +295,14 @@ impl Transaction<'_> {
         if !self.staged.contains_key(&home) && self.staged.len() == self.credits {
             return Err(Ext4Error::new(ErrCode::E2BIG));
         }
-        self.staged.insert(home, StagedBlock { home, image });
+        self.staged.insert(
+            home,
+            StagedBlock {
+                home,
+                original: None,
+                image,
+            },
+        );
         Ok(())
     }
 
@@ -287,10 +321,12 @@ impl Transaction<'_> {
                 return Err(Ext4Error::new(ErrCode::E2BIG));
             }
             let block = device.read_block(home)?;
+            let original = self.preserve_originals.then(|| block.data.clone());
             self.staged.insert(
                 home,
                 StagedBlock {
                     home,
+                    original,
                     image: block.data,
                 },
             );
@@ -328,6 +364,91 @@ impl Transaction<'_> {
             TransactionCoreRef::Journal(_) => self.commit_journal(device, publisher),
             TransactionCoreRef::Direct(_) => self.commit_direct(device, publisher),
         }
+    }
+
+    /// Commit a nojournal range allocation in semantic order.
+    ///
+    /// Allocation homes are written before the inode-table home which makes
+    /// the extent reachable.  A failure before the inode write rolls back the
+    /// completed allocation homes from their transaction-private snapshots.
+    /// Once the inode write is attempted its on-disk state is uncertain, so
+    /// the direct backend is poisoned instead of releasing possibly-owned
+    /// blocks for reuse.
+    pub(super) fn commit_direct_range(
+        mut self,
+        device: &dyn BlockDevice,
+        publisher: &dyn CachePublisher,
+        allocation_homes: &[PBlockId],
+        inode_home: PBlockId,
+    ) -> core::result::Result<(), CommitError> {
+        let TransactionCoreRef::Direct(core) = self.core else {
+            return self.fail(
+                Ext4Error::new(ErrCode::EINVAL),
+                CommitFailure::BeforeCommit,
+                false,
+            );
+        };
+        if !device.supports_reliable_flush()
+            || inode_home >= core.target_blocks
+            || allocation_homes.is_empty()
+            || allocation_homes.contains(&inode_home)
+            || self.staged.len() != allocation_homes.len() + 1
+            || !self.staged.contains_key(&inode_home)
+            || allocation_homes.iter().any(|home| {
+                *home >= core.target_blocks
+                    || !self.staged.contains_key(home)
+                    || self.staged[home].original.is_none()
+            })
+            || self.staged[&inode_home].original.is_none()
+        {
+            return self.fail(
+                Ext4Error::new(ErrCode::EINVAL),
+                CommitFailure::BeforeCommit,
+                false,
+            );
+        }
+
+        for (completed, home) in allocation_homes.iter().enumerate() {
+            let staged = &self.staged[home];
+            if let Err(error) = write_bytes(device, *home, staged.bytes()) {
+                // The failed write may have reached the device partially.
+                // Rewrite its old image as well as every earlier home before
+                // declaring the operation safely aborted.
+                let rollback = self.rollback_direct_range(device, &allocation_homes[..=completed]);
+                return match rollback {
+                    Ok(()) => self.fail(error, CommitFailure::BeforeCommit, false),
+                    Err(rollback_error) => {
+                        self.fail(rollback_error, CommitFailure::CheckpointFailed, true)
+                    }
+                };
+            }
+        }
+
+        let inode = &self.staged[&inode_home];
+        if let Err(error) = write_bytes(device, inode_home, inode.bytes()) {
+            return self.fail(error, CommitFailure::CommitUncertain, true);
+        }
+        publisher.publish(&self.staged);
+        self.release_writer();
+        Ok(())
+    }
+
+    fn rollback_direct_range(
+        &self,
+        device: &dyn BlockDevice,
+        completed_homes: &[PBlockId],
+    ) -> Result<()> {
+        for home in completed_homes.iter().rev() {
+            let original = self.staged[home]
+                .original
+                .as_ref()
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            write_bytes(device, *home, original)?;
+        }
+        if !completed_homes.is_empty() && device.supports_reliable_flush() {
+            device.flush()?;
+        }
+        Ok(())
     }
 
     fn commit_direct(
@@ -726,12 +847,19 @@ mod tests {
     use super::*;
     use core::sync::atomic::{AtomicUsize, Ordering};
 
+    const TEST_MAX_FAST_METADATA_IMAGES: usize = 16;
+    const TEST_LARGE_JOURNAL_BLOCKS: u32 = 64;
+
     struct MemoryDevice {
         volatile: spin::Mutex<BTreeMap<PBlockId, Box<[u8; BLOCK_SIZE]>>>,
         stable: spin::Mutex<BTreeMap<PBlockId, Box<[u8; BLOCK_SIZE]>>>,
         operation: AtomicUsize,
         fail_at: AtomicUsize,
+        fail_at_second: AtomicUsize,
         write_order: spin::Mutex<Vec<PBlockId>>,
+        reads: AtomicUsize,
+        writes: AtomicUsize,
+        flushes: AtomicUsize,
     }
 
     impl MemoryDevice {
@@ -741,13 +869,19 @@ mod tests {
                 stable: spin::Mutex::new(BTreeMap::new()),
                 operation: AtomicUsize::new(0),
                 fail_at: AtomicUsize::new(usize::MAX),
+                fail_at_second: AtomicUsize::new(usize::MAX),
                 write_order: spin::Mutex::new(Vec::new()),
+                reads: AtomicUsize::new(0),
+                writes: AtomicUsize::new(0),
+                flushes: AtomicUsize::new(0),
             }
         }
 
         fn step(&self) -> Result<()> {
             let operation = self.operation.fetch_add(1, Ordering::SeqCst);
-            if operation == self.fail_at.load(Ordering::SeqCst) {
+            if operation == self.fail_at.load(Ordering::SeqCst)
+                || operation == self.fail_at_second.load(Ordering::SeqCst)
+            {
                 Err(Ext4Error::new(ErrCode::EIO))
             } else {
                 Ok(())
@@ -766,6 +900,7 @@ mod tests {
 
     impl BlockDevice for MemoryDevice {
         fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
             Ok(Block::new(
                 block_id,
                 self.volatile
@@ -777,6 +912,7 @@ mod tests {
         }
 
         fn write_block(&self, block: &Block) -> Result<()> {
+            self.writes.fetch_add(1, Ordering::SeqCst);
             self.step()?;
             self.write_order.lock().push(block.id);
             self.volatile.lock().insert(block.id, block.data.clone());
@@ -784,6 +920,7 @@ mod tests {
         }
 
         fn flush(&self) -> Result<()> {
+            self.flushes.fetch_add(1, Ordering::SeqCst);
             self.step()?;
             *self.stable.lock() = self.volatile.lock().clone();
             Ok(())
@@ -862,6 +999,180 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_transactions_do_not_retain_rollback_images() {
+        let device = MemoryDevice::new();
+        let core = DirectTransactionCore::new(8).unwrap();
+        let mut transaction = core.start(1).unwrap();
+
+        transaction.read_for_update(&device, 1).unwrap()[0] = 1;
+
+        assert!(transaction.staged[&1].original.is_none());
+        transaction.abort();
+    }
+
+    #[test]
+    fn direct_range_transactions_retain_rollback_images() {
+        let device = MemoryDevice::new();
+        let core = DirectTransactionCore::new(8).unwrap();
+        let mut transaction = core.start_direct_range(1).unwrap();
+
+        transaction.read_for_update(&device, 1).unwrap()[0] = 1;
+
+        assert!(transaction.staged[&1].original.is_some());
+        transaction.abort();
+    }
+
+    fn staged_direct_range<'a>(
+        core: &'a DirectTransactionCore,
+        device: &MemoryDevice,
+    ) -> Transaction<'a> {
+        let mut transaction = core.start_direct_range(4).unwrap();
+        for (home, value) in [(9, 9), (2, 2), (5, 5), (7, 7)] {
+            transaction
+                .read_for_update(device, home)
+                .unwrap()
+                .fill(value);
+        }
+        transaction
+    }
+
+    #[test]
+    fn direct_range_uses_allocation_order_and_inode_last() {
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let transaction = staged_direct_range(&core, &device);
+
+        transaction
+            .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+            .unwrap();
+
+        assert_eq!(&*device.write_order.lock(), &[9, 2, 5, 7]);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 4);
+        assert!(!core.is_poisoned());
+    }
+
+    #[test]
+    fn direct_range_restores_failed_allocation_home_before_continuing() {
+        let device = MemoryDevice::new();
+        device.fail_at.store(1, Ordering::SeqCst);
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let transaction = staged_direct_range(&core, &device);
+
+        let error = transaction
+            .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+            .unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::BeforeCommit);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        assert_eq!(&*device.write_order.lock(), &[9, 2, 9]);
+        assert_eq!(device.volatile.lock()[&9].as_slice(), &[0; BLOCK_SIZE]);
+        assert_eq!(device.volatile.lock()[&2].as_slice(), &[0; BLOCK_SIZE]);
+        assert!(!core.is_poisoned());
+    }
+
+    #[test]
+    fn direct_range_restores_each_failed_allocation_home() {
+        for failed_home in 0..3 {
+            let device = MemoryDevice::new();
+            device.fail_at.store(failed_home, Ordering::SeqCst);
+            let publisher = Publisher(AtomicUsize::new(0));
+            let core = DirectTransactionCore::new(128).unwrap();
+            let transaction = staged_direct_range(&core, &device);
+
+            let error = transaction
+                .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+                .unwrap_err();
+
+            assert_eq!(error.failure, CommitFailure::BeforeCommit);
+            assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+            for home in [9, 2, 5] {
+                let image = device
+                    .volatile
+                    .lock()
+                    .get(&home)
+                    .cloned()
+                    .unwrap_or_else(|| Box::new([0; BLOCK_SIZE]));
+                assert_eq!(image.as_slice(), &[0; BLOCK_SIZE]);
+            }
+            assert!(!core.is_poisoned());
+        }
+    }
+
+    #[test]
+    fn direct_range_rollback_write_failure_poisons_backend() {
+        let device = MemoryDevice::new();
+        device.fail_at.store(1, Ordering::SeqCst);
+        device.fail_at_second.store(2, Ordering::SeqCst);
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let transaction = staged_direct_range(&core, &device);
+
+        let error = transaction
+            .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+            .unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::CheckpointFailed);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        assert!(core.is_poisoned());
+    }
+
+    #[test]
+    fn direct_range_rollback_flush_failure_poisons_backend() {
+        let device = MemoryDevice::new();
+        device.fail_at.store(1, Ordering::SeqCst);
+        device.fail_at_second.store(4, Ordering::SeqCst);
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let transaction = staged_direct_range(&core, &device);
+
+        let error = transaction
+            .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+            .unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::CheckpointFailed);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        assert!(core.is_poisoned());
+    }
+
+    #[test]
+    fn direct_range_inode_write_failure_is_uncertain_and_poisons() {
+        let device = MemoryDevice::new();
+        device.fail_at.store(3, Ordering::SeqCst);
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let transaction = staged_direct_range(&core, &device);
+
+        let error = transaction
+            .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+            .unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::CommitUncertain);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        assert!(core.is_poisoned());
+    }
+
+    #[test]
+    fn direct_range_rejects_out_of_range_inode_without_io() {
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(8).unwrap();
+        let mut transaction = core.start_direct_range(4).unwrap();
+        for home in [1, 2, 3, 8] {
+            transaction.read_for_update(&device, home).unwrap()[0] = 1;
+        }
+
+        let error = transaction
+            .commit_direct_range(&device, &publisher, &[1, 2, 3], 8)
+            .unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::BeforeCommit);
+        assert_eq!(device.writes.load(Ordering::SeqCst), 0);
+        assert!(!core.is_poisoned());
+    }
+
+    #[test]
     fn read_for_update_merges_shared_block_and_charges_one_credit() {
         let device = MemoryDevice::new();
         let core = JournalTransactionCore::new(context()).unwrap();
@@ -877,6 +1188,10 @@ mod tests {
     }
 
     fn context() -> JournalContext {
+        context_with_ring(8, 7)
+    }
+
+    fn context_with_ring(max_len: u32, head: u32) -> JournalContext {
         let features = Features::validate(
             0,
             crate::jbd2::FEATURE_INCOMPAT_CSUM_V3 | crate::jbd2::FEATURE_INCOMPAT_64BIT,
@@ -891,9 +1206,9 @@ mod tests {
         .encode_into(&mut image[..])
         .unwrap();
         image[12..16].copy_from_slice(&(BLOCK_SIZE as u32).to_be_bytes());
-        image[16..20].copy_from_slice(&8u32.to_be_bytes());
+        image[16..20].copy_from_slice(&max_len.to_be_bytes());
         image[20..24].copy_from_slice(&1u32.to_be_bytes());
-        image[24..28].copy_from_slice(&7u32.to_be_bytes());
+        image[24..28].copy_from_slice(&head.to_be_bytes());
         image[40..44].copy_from_slice(
             &(crate::jbd2::FEATURE_INCOMPAT_CSUM_V3 | crate::jbd2::FEATURE_INCOMPAT_64BIT)
                 .to_be_bytes(),
@@ -902,11 +1217,11 @@ mod tests {
         image[80] = CRC32C_CHKSUM;
         update_superblock(
             &mut image,
-            7,
+            head,
             0,
             &Superblock {
                 block_size: BLOCK_SIZE as u32,
-                max_len: 8,
+                max_len,
                 first: 1,
                 sequence: 7,
                 start: 0,
@@ -919,12 +1234,44 @@ mod tests {
         .unwrap();
         JournalContext {
             superblock: Superblock::parse(&image[..], BLOCK_SIZE as u32).unwrap(),
-            logical_blocks: Vec::from_iter(100..108).into(),
-            journal_blocks: Arc::new(BTreeSet::from_iter(100..108)),
+            logical_blocks: Vec::from_iter(100..100 + max_len as u64).into(),
+            journal_blocks: Arc::new(BTreeSet::from_iter(100..100 + max_len as u64)),
             target_blocks: 1000,
-            head: 7,
+            head,
             superblock_image: image,
         }
+    }
+
+    fn assert_counted_commit_shape(homes: usize, expected_reads: usize, expected_writes: usize) {
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = JournalTransactionCore::new(context_with_ring(
+            TEST_LARGE_JOURNAL_BLOCKS,
+            TEST_LARGE_JOURNAL_BLOCKS - 1,
+        ))
+        .unwrap();
+        let mut transaction = core.start(homes).unwrap();
+        for home in 42..42 + homes as u64 {
+            transaction.read_for_update(&device, home).unwrap()[0] = home as u8;
+        }
+
+        transaction.commit(&device, &publisher).unwrap();
+
+        assert_eq!(device.reads.load(Ordering::SeqCst), expected_reads);
+        assert_eq!(device.writes.load(Ordering::SeqCst), expected_writes);
+        assert_eq!(device.flushes.load(Ordering::SeqCst), 5);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), homes);
+        assert!(!core.is_poisoned());
+    }
+
+    #[test]
+    fn journal_commit_four_homes_has_expected_fixed_io_shape() {
+        assert_counted_commit_shape(4, 6, 12);
+    }
+
+    #[test]
+    fn journal_commit_max_fast_metadata_images_has_expected_fixed_io_shape() {
+        assert_counted_commit_shape(TEST_MAX_FAST_METADATA_IMAGES, 18, 36);
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -424,6 +424,21 @@ impl Transaction<'_> {
             }
         }
 
+        // The inode must never become durable before the allocation metadata
+        // that owns its blocks. Without this boundary a volatile device cache
+        // may persist the inode first and expose its blocks as free after a
+        // crash. A failed flush is still before publication, so restore every
+        // allocation home while the exclusive transaction owner is held.
+        if let Err(error) = device.flush() {
+            let rollback = self.rollback_direct_range(device, allocation_homes);
+            return match rollback {
+                Ok(()) => self.fail(error, CommitFailure::BeforeCommit, false),
+                Err(rollback_error) => {
+                    self.fail(rollback_error, CommitFailure::CheckpointFailed, true)
+                }
+            };
+        }
+
         let inode = &self.staged[&inode_home];
         if let Err(error) = write_bytes(device, inode_home, inode.bytes()) {
             return self.fail(error, CommitFailure::CommitUncertain, true);
@@ -1048,6 +1063,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(&*device.write_order.lock(), &[9, 2, 5, 7]);
+        assert_eq!(device.flushes.load(Ordering::SeqCst), 1);
+        assert_eq!(device.stable_block(9).unwrap().as_slice(), &[9; BLOCK_SIZE]);
+        assert!(device.stable_block(7).is_none());
         assert_eq!(publisher.0.load(Ordering::SeqCst), 4);
         assert!(!core.is_poisoned());
     }
@@ -1139,7 +1157,7 @@ mod tests {
     #[test]
     fn direct_range_inode_write_failure_is_uncertain_and_poisons() {
         let device = MemoryDevice::new();
-        device.fail_at.store(3, Ordering::SeqCst);
+        device.fail_at.store(4, Ordering::SeqCst);
         let publisher = Publisher(AtomicUsize::new(0));
         let core = DirectTransactionCore::new(128).unwrap();
         let transaction = staged_direct_range(&core, &device);
@@ -1149,6 +1167,48 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(error.failure, CommitFailure::CommitUncertain);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        assert!(core.is_poisoned());
+    }
+
+    #[test]
+    fn direct_range_allocation_flush_failure_restores_all_homes() {
+        let device = MemoryDevice::new();
+        device.fail_at.store(3, Ordering::SeqCst);
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let transaction = staged_direct_range(&core, &device);
+
+        let error = transaction
+            .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+            .unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::BeforeCommit);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+        for home in [9, 2, 5] {
+            assert_eq!(
+                device.stable_block(home).unwrap().as_slice(),
+                &[0; BLOCK_SIZE]
+            );
+        }
+        assert!(device.stable_block(7).is_none());
+        assert!(!core.is_poisoned());
+    }
+
+    #[test]
+    fn direct_range_allocation_flush_rollback_failure_poisons_backend() {
+        let device = MemoryDevice::new();
+        device.fail_at.store(3, Ordering::SeqCst);
+        device.fail_at_second.store(4, Ordering::SeqCst);
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = DirectTransactionCore::new(128).unwrap();
+        let transaction = staged_direct_range(&core, &device);
+
+        let error = transaction
+            .commit_direct_range(&device, &publisher, &[9, 2, 5], 7)
+            .unwrap_err();
+
+        assert_eq!(error.failure, CommitFailure::CheckpointFailed);
         assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
         assert!(core.is_poisoned());
     }

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -20,6 +20,13 @@ enum DirectRangePrepare {
     Unsupported,
 }
 
+struct DirectRangePlan {
+    start_lblock: LBlockId,
+    count: u32,
+    preferred_first: Option<PBlockId>,
+    requires_merge: bool,
+}
+
 /// Attributes that can be set on an inode via `setattr`.
 #[derive(Default)]
 pub struct SetAttr {
@@ -64,14 +71,14 @@ impl Ext4 {
         self.block_device.flush()
     }
 
-    fn try_prepare_direct_range(
+    fn direct_range_plan(
         &self,
-        inode: &mut InodeRef,
+        inode: &InodeRef,
         offset: usize,
         len: usize,
-    ) -> Result<DirectRangePrepare> {
+    ) -> Result<Option<DirectRangePlan>> {
         if len == 0 {
-            return Ok(DirectRangePrepare::Handled);
+            return Ok(None);
         }
         let end = offset
             .checked_add(len)
@@ -84,12 +91,11 @@ impl Ext4 {
             .checked_sub(start_lblock)
             .and_then(|blocks| blocks.checked_add(1))
             .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
-        if start_lblock.checked_add(count).is_none() {
-            return Ok(DirectRangePrepare::Unsupported);
-        }
-        if (count as usize) < DIRECT_RANGE_MIN_BLOCKS || (count as usize) > DIRECT_RANGE_MAX_BLOCKS
+        if start_lblock.checked_add(count).is_none()
+            || (count as usize) < DIRECT_RANGE_MIN_BLOCKS
+            || (count as usize) > DIRECT_RANGE_MAX_BLOCKS
         {
-            return Ok(DirectRangePrepare::Unsupported);
+            return Ok(None);
         }
         let persistent_blocks = inode
             .inode
@@ -98,9 +104,29 @@ impl Ext4 {
             .map(|size| size / BLOCK_SIZE as u64)
             .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
         if (start_lblock as u64) < persistent_blocks {
-            return Ok(DirectRangePrepare::Unsupported);
+            return Ok(None);
         }
         let Some(shape) = self.direct_append_shape(inode, start_lblock, count)? else {
+            return Ok(None);
+        };
+        Ok(Some(DirectRangePlan {
+            start_lblock,
+            count,
+            preferred_first: shape.preferred_first,
+            requires_merge: shape.requires_merge,
+        }))
+    }
+
+    fn try_prepare_direct_range(
+        &self,
+        inode: &mut InodeRef,
+        offset: usize,
+        len: usize,
+    ) -> Result<DirectRangePrepare> {
+        if len == 0 {
+            return Ok(DirectRangePrepare::Handled);
+        }
+        let Some(plan) = self.direct_range_plan(inode, offset, len)? else {
             return Ok(DirectRangePrepare::Unsupported);
         };
 
@@ -115,9 +141,9 @@ impl Ext4 {
         let allocation = match self.transaction_alloc_direct_range(
             &mut transaction,
             inode.id,
-            shape.preferred_first,
-            shape.requires_merge,
-            count,
+            plan.preferred_first,
+            plan.requires_merge,
+            plan.count,
         ) {
             Ok(allocation) => allocation,
             Err(error) if error.code() == ErrCode::ENOSPC => {
@@ -128,10 +154,11 @@ impl Ext4 {
         };
 
         self.prepare_stats.record_call();
-        self.prepare_stats.record_requested(count as usize);
-        self.prepare_stats.record_missing_blocks(count as usize);
+        self.prepare_stats.record_requested(plan.count as usize);
+        self.prepare_stats
+            .record_missing_blocks(plan.count as usize);
         let initialized =
-            self.initialize_direct_range(allocation.first, count as usize, zeros.as_slice());
+            self.initialize_direct_range(allocation.first, plan.count as usize, zeros.as_slice());
         if let Err(error) = initialized {
             self.prepare_stats.record_failure();
             transaction.abort();
@@ -142,7 +169,7 @@ impl Ext4 {
         }
 
         if let Err(error) =
-            self.stage_direct_append_extent(inode, start_lblock, allocation.first, count)
+            self.stage_direct_append_extent(inode, plan.start_lblock, allocation.first, plan.count)
         {
             self.prepare_stats.record_failure();
             transaction.abort();
@@ -415,6 +442,22 @@ impl Ext4 {
     ) -> Result<()> {
         self.ensure_mutable()?;
         if self.supports_direct_range_stage() {
+            // Classify the request under a compatible direct guard first.
+            // Unsupported small, overwrite, sparse, and oversized writes can
+            // continue through the legacy allocator without ever contending
+            // for the exclusive transaction snapshot gate.
+            {
+                let _metadata_guard = self.lock_direct_metadata_mutation()?;
+                let _mutation_guard =
+                    self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
+                let mut inode = self.read_inode(id)?;
+                if inode.inode.mode().bits() == 0 {
+                    return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
+                }
+                if self.direct_range_plan(&inode, offset, len)?.is_none() {
+                    return self.ensure_blocks_for_write_range_locked(&mut inode, offset, len);
+                }
+            }
             let outcome = {
                 let _metadata_guard = self.lock_transactional_metadata_mutation()?;
                 let _mutation_guard =
@@ -1816,6 +1859,35 @@ mod tests {
         assert_eq!(error.code(), ErrCode::EIO);
         assert_eq!(device.writes.load(Ordering::SeqCst), 2);
         assert_eq!(device.flushes.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn direct_range_plan_filters_legacy_writes_before_transaction_gate() {
+        let fs = make_test_fs(1024);
+        let mut inode = Inode::default();
+        inode.extent_init();
+        let mut inode = InodeRef::new(2, Box::new(inode));
+
+        assert!(fs
+            .direct_range_plan(&inode, 0, (DIRECT_RANGE_MIN_BLOCKS - 1) * BLOCK_SIZE)
+            .unwrap()
+            .is_none());
+        assert!(fs
+            .direct_range_plan(&inode, 0, (DIRECT_RANGE_MAX_BLOCKS + 1) * BLOCK_SIZE)
+            .unwrap()
+            .is_none());
+        assert!(fs
+            .direct_range_plan(&inode, 0, DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE)
+            .unwrap()
+            .is_some());
+
+        inode
+            .inode
+            .set_size((DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE) as u64);
+        assert!(fs
+            .direct_range_plan(&inode, 0, DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE)
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -11,6 +11,15 @@ use crate::prelude::*;
 use crate::return_error;
 use core::cmp::min;
 
+const DIRECT_RANGE_MIN_BLOCKS: usize = 16;
+const DIRECT_RANGE_MAX_BLOCKS: usize = 256;
+const DIRECT_RANGE_ZERO_CHUNK_BLOCKS: usize = 8;
+
+enum DirectRangePrepare {
+    Handled,
+    Unsupported,
+}
+
 /// Attributes that can be set on an inode via `setattr`.
 #[derive(Default)]
 pub struct SetAttr {
@@ -40,6 +49,131 @@ impl SetAttr {
 }
 
 impl Ext4 {
+    fn initialize_direct_range(&self, first: PBlockId, count: usize, zeros: &[u8]) -> Result<()> {
+        let mut done = 0usize;
+        while done < count {
+            let blocks = min(DIRECT_RANGE_ZERO_CHUNK_BLOCKS, count - done);
+            let pblock = first
+                .checked_add(done as PBlockId)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+            self.block_device
+                .write_blocks(pblock, &zeros[..blocks * BLOCK_SIZE])?;
+            self.prepare_stats.record_zero_io();
+            done += blocks;
+        }
+        self.block_device.flush()
+    }
+
+    fn try_prepare_direct_range(
+        &self,
+        inode: &mut InodeRef,
+        offset: usize,
+        len: usize,
+    ) -> Result<DirectRangePrepare> {
+        if len == 0 {
+            return Ok(DirectRangePrepare::Handled);
+        }
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        let start_lblock =
+            u32::try_from(offset / BLOCK_SIZE).map_err(|_| Ext4Error::new(ErrCode::EFBIG))?;
+        let end_lblock =
+            u32::try_from((end - 1) / BLOCK_SIZE).map_err(|_| Ext4Error::new(ErrCode::EFBIG))?;
+        let count = end_lblock
+            .checked_sub(start_lblock)
+            .and_then(|blocks| blocks.checked_add(1))
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        if start_lblock.checked_add(count).is_none() {
+            return Ok(DirectRangePrepare::Unsupported);
+        }
+        if (count as usize) < DIRECT_RANGE_MIN_BLOCKS || (count as usize) > DIRECT_RANGE_MAX_BLOCKS
+        {
+            return Ok(DirectRangePrepare::Unsupported);
+        }
+        let persistent_blocks = inode
+            .inode
+            .size()
+            .checked_add(BLOCK_SIZE as u64 - 1)
+            .map(|size| size / BLOCK_SIZE as u64)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        if (start_lblock as u64) < persistent_blocks {
+            return Ok(DirectRangePrepare::Unsupported);
+        }
+        let Some(shape) = self.direct_append_shape(inode, start_lblock, count)? else {
+            return Ok(DirectRangePrepare::Unsupported);
+        };
+
+        let zero_bytes = DIRECT_RANGE_ZERO_CHUNK_BLOCKS * BLOCK_SIZE;
+        let mut zeros = Vec::new();
+        if zeros.try_reserve_exact(zero_bytes).is_err() {
+            return Ok(DirectRangePrepare::Unsupported);
+        }
+        zeros.resize(zero_bytes, 0);
+
+        let mut transaction = self.transaction_start_direct_range(4)?;
+        let allocation = match self.transaction_alloc_direct_range(
+            &mut transaction,
+            inode.id,
+            shape.preferred_first,
+            shape.requires_merge,
+            count,
+        ) {
+            Ok(allocation) => allocation,
+            Err(error) if error.code() == ErrCode::ENOSPC => {
+                transaction.abort();
+                return Ok(DirectRangePrepare::Unsupported);
+            }
+            Err(error) => return Err(error),
+        };
+
+        self.prepare_stats.record_call();
+        self.prepare_stats.record_requested(count as usize);
+        self.prepare_stats.record_missing_blocks(count as usize);
+        let initialized =
+            self.initialize_direct_range(allocation.first, count as usize, zeros.as_slice());
+        if let Err(error) = initialized {
+            self.prepare_stats.record_failure();
+            transaction.abort();
+            if error.code() == ErrCode::ENOMEM {
+                return Ok(DirectRangePrepare::Unsupported);
+            }
+            return Err(error);
+        }
+
+        if let Err(error) =
+            self.stage_direct_append_extent(inode, start_lblock, allocation.first, count)
+        {
+            self.prepare_stats.record_failure();
+            transaction.abort();
+            return Err(error);
+        }
+        let (inode_home, _) = self.inode_disk_pos(inode.id)?;
+        if let Err(error) = self.transaction_stage_inode_with_csum(&mut transaction, inode) {
+            self.prepare_stats.record_failure();
+            transaction.abort();
+            return Err(error);
+        }
+        self.prepare_stats.record_inode_io();
+        if let Err(error) = transaction.commit_direct_range(
+            self.block_device.as_ref(),
+            self,
+            &allocation.allocation_homes,
+            inode_home,
+        ) {
+            self.prepare_stats.record_failure();
+            if error.failure != super::journal_transaction::CommitFailure::BeforeCommit {
+                self.poison(ErrCode::EIO);
+            }
+            return Err(error.error);
+        }
+        self.prepare_stats.record_bitmap_io();
+        self.prepare_stats.record_gdt_io();
+        self.prepare_stats.record_superblock_io();
+        self.prepare_stats.record_inode_io();
+        Ok(DirectRangePrepare::Handled)
+    }
+
     fn xattr_checksum_seed(&self) -> Result<Option<MetadataChecksumSeed>> {
         let sb = self.read_super_block_cached();
         if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
@@ -198,39 +332,55 @@ impl Ext4 {
         if len == 0 {
             return Ok(());
         }
-        let end = offset.checked_add(len).ok_or(format_error!(
-            ErrCode::EFBIG,
-            "write range overflow: offset={} len={}",
-            offset,
-            len
-        ))?;
-        let start_iblock = (offset / BLOCK_SIZE) as LBlockId;
-        let end_iblock = ((end - 1) / BLOCK_SIZE) as LBlockId;
-        let mut changed = false;
-        for iblock in start_iblock..=end_iblock {
-            match self.extent_query(inode, iblock) {
-                Ok(_) => {}
-                Err(err) if err.code() == ErrCode::ENOENT => {
-                    self.extent_query_or_create(inode, iblock, 1)?;
-                    self.extent_query(inode, iblock).map_err(|err| {
-                        format_error!(
-                            ErrCode::EIO,
-                            "extent allocation invariant failed: inode {} iblock {} missing after create: {:?}",
-                            inode.id,
-                            iblock,
-                            err
-                        )
-                    })?;
-                    changed = true;
+        self.prepare_stats.record_call();
+        let result = (|| {
+            let end = offset.checked_add(len).ok_or(format_error!(
+                ErrCode::EFBIG,
+                "write range overflow: offset={} len={}",
+                offset,
+                len
+            ))?;
+            let start_iblock = (offset / BLOCK_SIZE) as LBlockId;
+            let end_iblock = ((end - 1) / BLOCK_SIZE) as LBlockId;
+            let requested_blocks = end_iblock
+                .checked_sub(start_iblock)
+                .and_then(|blocks| blocks.checked_add(1))
+                .and_then(|blocks| usize::try_from(blocks).ok())
+                .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+            self.prepare_stats.record_requested(requested_blocks);
+            let mut changed = false;
+            for iblock in start_iblock..=end_iblock {
+                match self.extent_query(inode, iblock) {
+                    Ok(_) => {
+                        self.prepare_stats.record_mapped();
+                    }
+                    Err(err) if err.code() == ErrCode::ENOENT => {
+                        self.prepare_stats.record_missing();
+                        self.extent_query_or_create(inode, iblock, 1)?;
+                        self.extent_query(inode, iblock).map_err(|err| {
+                            format_error!(
+                                ErrCode::EIO,
+                                "extent allocation invariant failed: inode {} iblock {} missing after create: {:?}",
+                                inode.id,
+                                iblock,
+                                err
+                            )
+                        })?;
+                        changed = true;
+                    }
+                    Err(err) => return Err(err),
                 }
-                Err(err) => return Err(err),
             }
+            if changed {
+                self.recompute_inode_block_count(inode)?;
+                self.write_inode_with_csum(inode)?;
+            }
+            Ok(())
+        })();
+        if result.is_err() {
+            self.prepare_stats.record_failure();
         }
-        if changed {
-            self.recompute_inode_block_count(inode)?;
-            self.write_inode_with_csum(inode)?;
-        }
-        Ok(())
+        result
     }
 
     /// Ensure extents exist for the bytes that will actually be written.
@@ -264,14 +414,28 @@ impl Ext4 {
         _mtime: Option<u32>,
     ) -> Result<()> {
         self.ensure_mutable()?;
+        if self.supports_direct_range_stage() {
+            let outcome = {
+                let _metadata_guard = self.lock_transactional_metadata_mutation()?;
+                let _mutation_guard =
+                    self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
+                let mut inode = self.read_inode(id)?;
+                if inode.inode.mode().bits() == 0 {
+                    return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
+                }
+                self.try_prepare_direct_range(&mut inode, offset, len)?
+            };
+            if matches!(outcome, DirectRangePrepare::Handled) {
+                return Ok(());
+            }
+        }
         let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
             return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
         }
-        self.ensure_blocks_for_write_range_locked(&mut inode, offset, len)?;
-        Ok(())
+        self.ensure_blocks_for_write_range_locked(&mut inode, offset, len)
     }
 
     /// Commit cached inode metadata to disk without allocating data blocks.
@@ -1496,6 +1660,7 @@ impl Ext4 {
 mod tests {
     use super::*;
     use crate::FileType;
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     struct StubBlockDevice {
         sb_block: Block,
@@ -1535,6 +1700,10 @@ mod tests {
 
     fn make_test_fs(block_count: u32) -> Ext4 {
         let block_device = Arc::new(StubBlockDevice::with_block_count(block_count));
+        make_test_fs_with_device(block_count, block_device)
+    }
+
+    fn make_test_fs_with_device(block_count: u32, block_device: Arc<dyn BlockDevice>) -> Ext4 {
         let block = block_device.read_block(0).unwrap();
         let sb = block.read_offset_as::<SuperBlock>(BASE_OFFSET);
         Ext4 {
@@ -1556,7 +1725,97 @@ mod tests {
             inode_mutation_locks: (0..crate::ext4::INODE_MUTATION_LOCK_SHARDS)
                 .map(|_| spin::Mutex::new(()))
                 .collect(),
+            prepare_stats: crate::ext4::PrepareStats::new(),
         }
+    }
+
+    struct RangeInitDevice {
+        sb_block: Block,
+        writes: AtomicUsize,
+        flushes: AtomicUsize,
+        fail_write_at: AtomicUsize,
+        fail_flush: AtomicBool,
+    }
+
+    impl RangeInitDevice {
+        fn new(block_count: u32) -> Self {
+            let stub = StubBlockDevice::with_block_count(block_count);
+            Self {
+                sb_block: stub.sb_block,
+                writes: AtomicUsize::new(0),
+                flushes: AtomicUsize::new(0),
+                fail_write_at: AtomicUsize::new(usize::MAX),
+                fail_flush: AtomicBool::new(false),
+            }
+        }
+    }
+
+    impl BlockDevice for RangeInitDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            if block_id == 0 {
+                Ok(self.sb_block.clone())
+            } else {
+                Ok(Block::new(block_id, Box::new([0; BLOCK_SIZE])))
+            }
+        }
+
+        fn write_block(&self, _block: &Block) -> Result<()> {
+            Ok(())
+        }
+
+        fn write_blocks(&self, _start: PBlockId, _data: &[u8]) -> Result<()> {
+            let write = self.writes.fetch_add(1, Ordering::SeqCst);
+            if write == self.fail_write_at.load(Ordering::SeqCst) {
+                Err(Ext4Error::new(ErrCode::ENOMEM))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn flush(&self) -> Result<()> {
+            self.flushes.fetch_add(1, Ordering::SeqCst);
+            if self.fail_flush.load(Ordering::SeqCst) {
+                Err(Ext4Error::new(ErrCode::EIO))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn direct_range_zero_failure_stops_before_flush() {
+        let device = Arc::new(RangeInitDevice::new(128));
+        device.fail_write_at.store(1, Ordering::SeqCst);
+        let fs = make_test_fs_with_device(128, device.clone());
+        let zeros = [0; DIRECT_RANGE_ZERO_CHUNK_BLOCKS * BLOCK_SIZE];
+
+        let error = fs
+            .initialize_direct_range(32, DIRECT_RANGE_ZERO_CHUNK_BLOCKS * 2, &zeros)
+            .unwrap_err();
+
+        assert_eq!(error.code(), ErrCode::ENOMEM);
+        assert_eq!(device.writes.load(Ordering::SeqCst), 2);
+        assert_eq!(device.flushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn direct_range_flush_failure_is_reported_after_all_zero_chunks() {
+        let device = Arc::new(RangeInitDevice::new(128));
+        device.fail_flush.store(true, Ordering::SeqCst);
+        let fs = make_test_fs_with_device(128, device.clone());
+        let zeros = [0; DIRECT_RANGE_ZERO_CHUNK_BLOCKS * BLOCK_SIZE];
+
+        let error = fs
+            .initialize_direct_range(32, DIRECT_RANGE_ZERO_CHUNK_BLOCKS * 2, &zeros)
+            .unwrap_err();
+
+        assert_eq!(error.code(), ErrCode::EIO);
+        assert_eq!(device.writes.load(Ordering::SeqCst), 2);
+        assert_eq!(device.flushes.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -105,6 +105,158 @@ pub struct Ext4 {
     /// sharding so unrelated apt download files do not serialize on one global
     /// filesystem-wide spin lock.
     inode_mutation_locks: Vec<spin::Mutex<()>>,
+    prepare_stats: PrepareStats,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PrepareStatsSnapshot {
+    pub enabled: bool,
+    pub generation: usize,
+    pub calls: usize,
+    pub requested_blocks: usize,
+    pub mapped_blocks: usize,
+    pub missing_blocks: usize,
+    pub failures: usize,
+    pub elapsed_cycles: usize,
+    pub bitmap_io: usize,
+    pub gdt_io: usize,
+    pub superblock_io: usize,
+    pub inode_io: usize,
+    pub extent_io: usize,
+    pub zero_io: usize,
+}
+
+struct PrepareStats {
+    generation: usize,
+    calls: AtomicUsize,
+    requested_blocks: AtomicUsize,
+    mapped_blocks: AtomicUsize,
+    missing_blocks: AtomicUsize,
+    failures: AtomicUsize,
+    elapsed_cycles: AtomicUsize,
+    bitmap_io: AtomicUsize,
+    gdt_io: AtomicUsize,
+    superblock_io: AtomicUsize,
+    inode_io: AtomicUsize,
+    extent_io: AtomicUsize,
+    zero_io: AtomicUsize,
+}
+
+impl PrepareStats {
+    fn new() -> Self {
+        Self {
+            generation: NEXT_PREPARE_STATS_GENERATION.fetch_add(1, Ordering::Relaxed),
+            calls: AtomicUsize::new(0),
+            requested_blocks: AtomicUsize::new(0),
+            mapped_blocks: AtomicUsize::new(0),
+            missing_blocks: AtomicUsize::new(0),
+            failures: AtomicUsize::new(0),
+            elapsed_cycles: AtomicUsize::new(0),
+            bitmap_io: AtomicUsize::new(0),
+            gdt_io: AtomicUsize::new(0),
+            superblock_io: AtomicUsize::new(0),
+            inode_io: AtomicUsize::new(0),
+            extent_io: AtomicUsize::new(0),
+            zero_io: AtomicUsize::new(0),
+        }
+    }
+
+    fn record_call(&self) {
+        if P6_2_STATS_ENABLED {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_requested(&self, blocks: usize) {
+        if P6_2_STATS_ENABLED {
+            self.requested_blocks.fetch_add(blocks, Ordering::Relaxed);
+        }
+    }
+
+    fn record_mapped(&self) {
+        if P6_2_STATS_ENABLED {
+            self.mapped_blocks.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_missing(&self) {
+        if P6_2_STATS_ENABLED {
+            self.missing_blocks.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_missing_blocks(&self, blocks: usize) {
+        if P6_2_STATS_ENABLED {
+            self.missing_blocks.fetch_add(blocks, Ordering::Relaxed);
+        }
+    }
+
+    fn record_failure(&self) {
+        if P6_2_STATS_ENABLED {
+            self.failures.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_elapsed_cycles(&self, cycles: usize) {
+        if P6_2_STATS_ENABLED {
+            self.elapsed_cycles.fetch_add(cycles, Ordering::Relaxed);
+        }
+    }
+
+    fn record_bitmap_io(&self) {
+        if P6_2_STATS_ENABLED {
+            self.bitmap_io.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_gdt_io(&self) {
+        if P6_2_STATS_ENABLED {
+            self.gdt_io.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_superblock_io(&self) {
+        if P6_2_STATS_ENABLED {
+            self.superblock_io.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_inode_io(&self) {
+        if P6_2_STATS_ENABLED {
+            self.inode_io.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_extent_io(&self) {
+        if P6_2_STATS_ENABLED {
+            self.extent_io.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_zero_io(&self) {
+        if P6_2_STATS_ENABLED {
+            self.zero_io.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn snapshot(&self) -> PrepareStatsSnapshot {
+        PrepareStatsSnapshot {
+            enabled: P6_2_STATS_ENABLED,
+            generation: self.generation,
+            calls: self.calls.load(Ordering::Relaxed),
+            requested_blocks: self.requested_blocks.load(Ordering::Relaxed),
+            mapped_blocks: self.mapped_blocks.load(Ordering::Relaxed),
+            missing_blocks: self.missing_blocks.load(Ordering::Relaxed),
+            failures: self.failures.load(Ordering::Relaxed),
+            elapsed_cycles: self.elapsed_cycles.load(Ordering::Relaxed),
+            bitmap_io: self.bitmap_io.load(Ordering::Relaxed),
+            gdt_io: self.gdt_io.load(Ordering::Relaxed),
+            superblock_io: self.superblock_io.load(Ordering::Relaxed),
+            inode_io: self.inode_io.load(Ordering::Relaxed),
+            extent_io: self.extent_io.load(Ordering::Relaxed),
+            zero_io: self.zero_io.load(Ordering::Relaxed),
+        }
+    }
 }
 
 pub(super) enum MetadataMutationMode {
@@ -125,6 +277,8 @@ struct MetadataMutationGate {
 
 const METADATA_GATE_EXCLUSIVE: usize = 1usize << (usize::BITS - 1);
 const METADATA_GATE_DIRECT_MAX: usize = METADATA_GATE_EXCLUSIVE - 1;
+const P6_2_STATS_ENABLED: bool = option_env!("DRAGONOS_P6_2_STATS").is_some();
+static NEXT_PREPARE_STATS_GENERATION: AtomicUsize = AtomicUsize::new(1);
 
 impl MetadataMutationGate {
     const fn new() -> Self {
@@ -203,6 +357,18 @@ const INODE_CACHE_SIZE: usize = 512;
 pub(super) const INODE_MUTATION_LOCK_SHARDS: usize = 64;
 
 impl Ext4 {
+    pub fn prepare_stats_snapshot(&self) -> PrepareStatsSnapshot {
+        self.prepare_stats.snapshot()
+    }
+
+    pub const fn prepare_stats_enabled(&self) -> bool {
+        P6_2_STATS_ENABLED
+    }
+
+    pub fn record_prepare_elapsed_cycles(&self, cycles: usize) {
+        self.prepare_stats.record_elapsed_cycles(cycles);
+    }
+
     fn is_power_of(mut value: u32, base: u32) -> bool {
         while value > base && value.is_multiple_of(base) {
             value /= base;
@@ -452,6 +618,7 @@ impl Ext4 {
             write_barrier: true,
             direct_restore_clean: false,
             inode_mutation_locks,
+            prepare_stats: PrepareStats::new(),
         })
     }
 

--- a/kernel/crates/another_ext4/src/ext4/rw.rs
+++ b/kernel/crates/another_ext4/src/ext4/rw.rs
@@ -122,10 +122,12 @@ impl Ext4 {
         // cannot overwrite with all-zero block; also need to update superblock checksum,
         // otherwise Linux will consider the filesystem corrupted and require e2fsck.
         let mut block = self.read_block(0)?;
+        self.prepare_stats.record_superblock_io();
         let mut sb_with_csum = *sb;
         sb_with_csum.set_checksum();
         block.write_offset_as(BASE_OFFSET, &sb_with_csum);
         self.write_block(&block)?;
+        self.prepare_stats.record_superblock_io();
         // Disk write succeeded, now commit to cache.
         *self.cached_super_block.lock() = *sb;
         Ok(())
@@ -141,6 +143,7 @@ impl Ext4 {
         // Cache miss: read from disk
         let (block_id, offset) = self.inode_disk_pos(inode_id)?;
         let block = self.read_block(block_id)?;
+        self.prepare_stats.record_inode_io();
         let inode_ref = InodeRef::new(inode_id, Box::new(block.read_offset_as(offset)));
         // Populate cache
         self.inode_cache.lock().insert(inode_ref.clone());
@@ -151,6 +154,7 @@ impl Ext4 {
     pub(super) fn read_inode_uncached(&self, inode_id: InodeId) -> Result<InodeRef> {
         let (block_id, offset) = self.inode_disk_pos(inode_id)?;
         let block = self.read_block(block_id)?;
+        self.prepare_stats.record_inode_io();
         Ok(InodeRef::new(
             inode_id,
             Box::new(block.read_offset_as(offset)),
@@ -174,8 +178,10 @@ impl Ext4 {
     pub(super) fn write_inode_without_csum(&self, inode_ref: &InodeRef) -> Result<()> {
         let (block_id, offset) = self.inode_disk_pos(inode_ref.id)?;
         let mut block = self.read_block(block_id)?;
+        self.prepare_stats.record_inode_io();
         block.write_offset_as(offset, &*inode_ref.inode);
         self.write_block(&block)?;
+        self.prepare_stats.record_inode_io();
         // Update cache with the latest inode data
         self.inode_cache.lock().update(inode_ref);
         Ok(())
@@ -209,8 +215,10 @@ impl Ext4 {
         let block_id = sb.first_data_block() + bg_ref.id / desc_per_block + 1;
         let offset = (bg_ref.id % desc_per_block) * sb.desc_size() as u32;
         let mut block = self.read_block(block_id as PBlockId)?;
+        self.prepare_stats.record_gdt_io();
         block.write_offset_as(offset as usize, &bg_ref.desc);
         self.write_block(&block)?;
+        self.prepare_stats.record_gdt_io();
         if let Some(cached) = self.cached_block_groups.get(bg_ref.id as usize) {
             *cached.lock() = bg_ref.desc;
         }
@@ -245,7 +253,10 @@ impl Ext4 {
 
     /// Get disk position of a block group. Return block id and offset within the block.
     #[allow(unused)]
-    fn block_group_disk_pos(&self, block_group_id: BlockGroupId) -> Result<(PBlockId, usize)> {
+    pub(super) fn block_group_disk_pos(
+        &self,
+        block_group_id: BlockGroupId,
+    ) -> Result<(PBlockId, usize)> {
         let super_block = self.read_super_block_cached();
         if block_group_id >= super_block.block_group_count() {
             return Err(crate::format_error!(

--- a/kernel/crates/another_ext4/src/ext4_defs/bitmap.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/bitmap.rs
@@ -23,10 +23,56 @@ impl<'a> Bitmap<'a> {
         (start..end).find(|&i| self.is_bit_clear(i))
     }
 
+    /// Find the first contiguous clear run of exactly `count` bits in
+    /// `[start, end)`.  The bitmap is not modified.
+    pub fn first_clear_run_in(
+        bitmap: &[u8],
+        nbits: usize,
+        start: usize,
+        end: usize,
+        count: usize,
+    ) -> Option<usize> {
+        let end = core::cmp::min(end, core::cmp::min(nbits, bitmap.len() * 8));
+        if count == 0 || start > end || count > end.saturating_sub(start) {
+            return None;
+        }
+        let last_start = end - count;
+        let mut candidate = start;
+        while candidate <= last_start {
+            let mut offset = 0;
+            while offset < count {
+                let bit = candidate + offset;
+                if bitmap[bit / 8] & (1 << (bit % 8)) != 0 {
+                    break;
+                }
+                offset += 1;
+            }
+            if offset == count {
+                return Some(candidate);
+            }
+            candidate = candidate.checked_add(offset + 1)?;
+        }
+        None
+    }
+
     /// Find the first clear bit in the range `[start, end)` and set it if found
     pub fn find_and_set_first_clear_bit(&mut self, start: usize, end: usize) -> Option<usize> {
         self.first_clear_bit(start, end).inspect(|&bit| {
             self.set_bit(bit);
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Bitmap;
+
+    #[test]
+    fn clear_run_respects_fragmentation_and_bounds() {
+        let bitmap = [0b0010_1101, 0b1111_0000];
+        assert_eq!(Bitmap::first_clear_run_in(&bitmap, 16, 0, 16, 2), Some(6));
+        assert_eq!(Bitmap::first_clear_run_in(&bitmap, 16, 8, 16, 4), Some(8));
+        assert_eq!(Bitmap::first_clear_run_in(&bitmap, 10, 8, 16, 3), None);
+        assert_eq!(Bitmap::first_clear_run_in(&bitmap, 16, 0, 16, 0), None);
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/block.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/block.rs
@@ -80,6 +80,37 @@ pub trait BlockDevice: Send + Sync + Any {
     fn read_block(&self, block_id: PBlockId) -> Result<Block>;
     /// Write a block to disk.
     fn write_block(&self, block: &Block) -> Result<()>;
+    /// Read a contiguous physical block range into an exact-sized buffer.
+    /// Devices may override this to submit fewer, larger requests.
+    fn read_blocks(&self, start: PBlockId, data: &mut [u8]) -> Result<()> {
+        if data.is_empty() || !data.len().is_multiple_of(BLOCK_SIZE) {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        for (index, chunk) in data.chunks_exact_mut(BLOCK_SIZE).enumerate() {
+            let block_id = start
+                .checked_add(index as PBlockId)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+            let block = self.read_block(block_id)?;
+            chunk.copy_from_slice(&block.data[..]);
+        }
+        Ok(())
+    }
+    /// Write an exact-sized buffer to a contiguous physical block range.
+    /// The default preserves the existing one-block-at-a-time semantics.
+    fn write_blocks(&self, start: PBlockId, data: &[u8]) -> Result<()> {
+        if data.is_empty() || !data.len().is_multiple_of(BLOCK_SIZE) {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        for (index, chunk) in data.chunks_exact(BLOCK_SIZE).enumerate() {
+            let block_id = start
+                .checked_add(index as PBlockId)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+            let mut image = Box::new([0; BLOCK_SIZE]);
+            image.copy_from_slice(chunk);
+            self.write_block(&Block::new(block_id, image))?;
+        }
+        Ok(())
+    }
     /// Make all writes completed before this call durable on stable storage.
     ///
     /// A successful return must not be used for durability unless
@@ -92,6 +123,7 @@ pub trait BlockDevice: Send + Sync + Any {
 #[cfg(test)]
 mod block_device_tests {
     use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     struct FlushDevice {
         reliable: bool,
@@ -134,5 +166,66 @@ mod block_device_tests {
         };
         assert!(device.supports_reliable_flush());
         assert_eq!(device.flush().unwrap_err().code(), ErrCode::EIO);
+    }
+
+    struct CountingDevice {
+        reads: AtomicUsize,
+        writes: AtomicUsize,
+    }
+
+    impl BlockDevice for CountingDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            Ok(Block::new(block_id, Box::new([block_id as u8; BLOCK_SIZE])))
+        }
+
+        fn write_block(&self, _block: &Block) -> Result<()> {
+            self.writes.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn contiguous_defaults_preserve_block_semantics() {
+        let device = CountingDevice {
+            reads: AtomicUsize::new(0),
+            writes: AtomicUsize::new(0),
+        };
+        let mut read = [0u8; BLOCK_SIZE * 3];
+        device.read_blocks(7, &mut read).unwrap();
+        assert_eq!(device.reads.load(Ordering::Relaxed), 3);
+        assert!(read[..BLOCK_SIZE].iter().all(|byte| *byte == 7));
+        assert!(read[BLOCK_SIZE..BLOCK_SIZE * 2]
+            .iter()
+            .all(|byte| *byte == 8));
+        device.write_blocks(7, &read).unwrap();
+        assert_eq!(device.writes.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn contiguous_defaults_reject_invalid_lengths() {
+        let device = CountingDevice {
+            reads: AtomicUsize::new(0),
+            writes: AtomicUsize::new(0),
+        };
+        assert_eq!(
+            device.write_blocks(0, &[]).unwrap_err().code(),
+            ErrCode::EINVAL
+        );
+        assert_eq!(
+            device
+                .write_blocks(0, &[0; BLOCK_SIZE - 1])
+                .unwrap_err()
+                .code(),
+            ErrCode::EINVAL
+        );
     }
 }

--- a/kernel/crates/another_ext4/src/ext4_defs/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/extent.rs
@@ -309,6 +309,10 @@ impl<'a> ExtentNode<'a> {
         unsafe { &*(self.raw_data.as_ptr() as *const ExtentHeader) }
     }
 
+    pub fn entry_capacity(&self) -> usize {
+        (self.raw_data.len() - size_of::<ExtentHeader>()) / size_of::<Extent>()
+    }
+
     /// Get a immutable reference to the extent at a given position
     pub fn extent_at(&self, pos: usize) -> &Extent {
         unsafe { &*((self.header() as *const ExtentHeader).add(1) as *const Extent).add(pos) }

--- a/kernel/src/debug/block.rs
+++ b/kernel/src/debug/block.rs
@@ -1,0 +1,75 @@
+use alloc::{string::String, string::ToString};
+
+use system_error::SystemError;
+
+use crate::{
+    debug::sysfs::debugfs_kobj,
+    driver::base::kobject::KObject,
+    filesystem::{
+        kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData},
+        vfs::{InodeMode, PollStatus},
+    },
+};
+
+#[derive(Debug)]
+struct VirtIOBlkStatsCallback;
+
+impl KernFSCallback for VirtIOBlkStatsCallback {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        let report = crate::driver::block::virtio_blk::virtio_blk_stats_report();
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(report));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report: &String = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+pub fn init_debugfs_block() -> Result<(), SystemError> {
+    let debugfs = debugfs_kobj();
+    let root = debugfs.inode().ok_or(SystemError::ENOENT)?;
+    let block = root.add_dir(
+        "block".to_string(),
+        InodeMode::from_bits_truncate(0o555),
+        None,
+        None,
+    )?;
+    block.add_file(
+        "virtio_blk_stats".to_string(),
+        InodeMode::S_IRUSR,
+        Some(16384),
+        None,
+        Some(&VirtIOBlkStatsCallback),
+    )?;
+    Ok(())
+}

--- a/kernel/src/debug/ext4.rs
+++ b/kernel/src/debug/ext4.rs
@@ -13,9 +13,53 @@ use system_error::SystemError;
 #[derive(Debug)]
 struct Ext4LifecycleSelftestCallback;
 
+#[derive(Debug)]
+struct Ext4PrepareStatsCallback;
+
 impl KernFSCallback for Ext4LifecycleSelftestCallback {
     fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
         let report = crate::filesystem::ext4::inode::run_lifecycle_selftests();
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(report));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report: &String = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+impl KernFSCallback for Ext4PrepareStatsCallback {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        let report = crate::filesystem::ext4::filesystem::prepare_stats_report();
         data.file_private_data_mut()
             .replace(KernFilePrivateData::DebugTextSnapshot(report));
         Ok(())
@@ -69,6 +113,13 @@ pub fn init_debugfs_ext4() -> Result<(), SystemError> {
         Some(4096),
         None,
         Some(&Ext4LifecycleSelftestCallback),
+    )?;
+    ext4.add_file(
+        "prepare_stats".to_string(),
+        InodeMode::S_IRUSR,
+        Some(16384),
+        None,
+        Some(&Ext4PrepareStatsCallback),
     )?;
     Ok(())
 }

--- a/kernel/src/debug/mod.rs
+++ b/kernel/src/debug/mod.rs
@@ -1,3 +1,4 @@
+pub mod block;
 pub mod errseq;
 pub mod ext4;
 pub mod fuse;

--- a/kernel/src/debug/sysfs/mod.rs
+++ b/kernel/src/debug/sysfs/mod.rs
@@ -23,6 +23,7 @@ fn debugfs_init() -> Result<(), SystemError> {
     super::tracing::init_debugfs_tracing()?;
     super::rcu::init_debugfs_rcu()?;
     super::errseq::init_debugfs_errseq()?;
+    super::block::init_debugfs_block()?;
     super::ext4::init_debugfs_ext4()?;
     super::fuse::init_debugfs_fuse()?;
     super::kthread::init_debugfs_kthread()?;

--- a/kernel/src/driver/base/block/bio.rs
+++ b/kernel/src/driver/base/block/bio.rs
@@ -38,6 +38,7 @@ struct InnerBioRequest {
     complete_callbacks: Vec<BioCompleteCallback>,
     /// virtio-drivers返回的token，用于中断时匹配
     token: Option<u16>,
+    stats_submit_cycle: usize,
 }
 
 type BioCompleteCallback = Box<dyn Fn(Result<usize, SystemError>) + Send + Sync>;
@@ -45,8 +46,15 @@ type BioCompleteCallback = Box<dyn Fn(Result<usize, SystemError>) + Send + Sync>
 impl BioRequest {
     /// 创建一个读请求
     pub fn new_read(lba_start: BlockId, count: usize) -> Arc<Self> {
-        let buffer = DmaBuffer::alloc_bytes(count * LBA_SIZE, Default::default());
-        Arc::new(Self {
+        Self::try_new_read(lba_start, count).expect("bio read allocation failed")
+    }
+
+    /// Create a read request without panicking when the DMA buffer cannot be
+    /// allocated or the request size overflows.
+    pub fn try_new_read(lba_start: BlockId, count: usize) -> Result<Arc<Self>, SystemError> {
+        let len = Self::validate_request(lba_start, count)?;
+        let buffer = DmaBuffer::try_alloc_bytes(len, Default::default())?;
+        Ok(Arc::new(Self {
             inner: SpinLock::new(InnerBioRequest {
                 bio_type: BioType::Read,
                 lba_start,
@@ -57,17 +65,31 @@ impl BioRequest {
                 result: None,
                 complete_callbacks: Vec::new(),
                 token: None,
+                stats_submit_cycle: 0,
             }),
-        })
+        }))
     }
 
     /// 创建一个写请求
     pub fn new_write(lba_start: BlockId, count: usize, data: &[u8]) -> Arc<Self> {
-        let mut buffer = DmaBuffer::alloc_bytes(count * LBA_SIZE, Default::default());
-        let copy_len = data.len().min(buffer.len());
-        buffer.as_mut_slice()[..copy_len].copy_from_slice(&data[..copy_len]);
+        Self::try_new_write(lba_start, count, data).expect("bio write allocation failed")
+    }
 
-        Arc::new(Self {
+    /// Create a write request with exact-length validation and fallible DMA
+    /// allocation. A mismatched payload is never silently truncated or padded.
+    pub fn try_new_write(
+        lba_start: BlockId,
+        count: usize,
+        data: &[u8],
+    ) -> Result<Arc<Self>, SystemError> {
+        let len = Self::validate_request(lba_start, count)?;
+        if data.len() != len {
+            return Err(SystemError::EINVAL);
+        }
+        let mut buffer = DmaBuffer::try_alloc_bytes(len, Default::default())?;
+        buffer.as_mut_slice().copy_from_slice(data);
+
+        Ok(Arc::new(Self {
             inner: SpinLock::new(InnerBioRequest {
                 bio_type: BioType::Write,
                 lba_start,
@@ -78,8 +100,9 @@ impl BioRequest {
                 result: None,
                 complete_callbacks: Vec::new(),
                 token: None,
+                stats_submit_cycle: 0,
             }),
-        })
+        }))
     }
 
     /// Create a new flush request.
@@ -95,6 +118,7 @@ impl BioRequest {
                 result: None,
                 complete_callbacks: Vec::new(),
                 token: None,
+                stats_submit_cycle: 0,
             }),
         })
     }
@@ -142,6 +166,14 @@ impl BioRequest {
     /// 获取扇区数
     pub fn count(&self) -> usize {
         self.inner.lock_irqsave().count
+    }
+
+    pub fn set_stats_submit_cycle(&self, cycle: usize) {
+        self.inner.lock_irqsave().stats_submit_cycle = cycle;
+    }
+
+    pub fn stats_submit_cycle(&self) -> usize {
+        self.inner.lock_irqsave().stats_submit_cycle
     }
 
     /// 获取token
@@ -194,9 +226,42 @@ impl BioRequest {
         // 获取结果
         let inner = self.inner.lock_irqsave();
         match inner.result.as_ref() {
-            Some(Ok(_)) => Ok(inner.buffer.to_vec()),
+            Some(Ok(completed)) if *completed == Self::expected_len(&inner) => {
+                Ok(inner.buffer.to_vec())
+            }
+            Some(Ok(_)) => Err(SystemError::EIO),
             Some(Err(e)) => Err(e.clone()),
             None => Err(SystemError::EIO),
+        }
+    }
+
+    /// Wait for completion without copying the DMA payload. This is the
+    /// completion path for writes and flushes.
+    pub fn wait_status(&self) -> Result<usize, SystemError> {
+        let completion = self.inner.lock_irqsave().completion.clone();
+        completion.wait_for_completion()?;
+
+        let inner = self.inner.lock_irqsave();
+        match inner.result.as_ref() {
+            Some(Ok(completed)) if *completed == Self::expected_len(&inner) => Ok(*completed),
+            Some(Ok(_)) => Err(SystemError::EIO),
+            Some(Err(e)) => Err(e.clone()),
+            None => Err(SystemError::EIO),
+        }
+    }
+
+    fn validate_request(lba_start: BlockId, count: usize) -> Result<usize, SystemError> {
+        if count == 0 {
+            return Err(SystemError::EINVAL);
+        }
+        lba_start.checked_add(count).ok_or(SystemError::EOVERFLOW)?;
+        count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)
+    }
+
+    fn expected_len(inner: &InnerBioRequest) -> usize {
+        match inner.bio_type {
+            BioType::Read | BioType::Write => inner.count * LBA_SIZE,
+            BioType::Flush => 0,
         }
     }
 }

--- a/kernel/src/driver/base/block/block_device.rs
+++ b/kernel/src/driver/base/block/block_device.rs
@@ -293,11 +293,23 @@ pub trait BlockDevice: Device {
         count: usize,
         buf: &mut [u8],
     ) -> Result<usize, SystemError> {
+        if count == 0 {
+            return Ok(0);
+        }
+        let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
+        lba_id_start
+            .checked_add(count)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if buf.len() < expected {
+            return Err(SystemError::EINVAL);
+        }
         let bio = self.submit_bio_read(lba_id_start, count)?;
         let data = bio.wait()?;
-        let copy_len = core::cmp::min(buf.len(), data.len());
-        buf[..copy_len].copy_from_slice(&data[..copy_len]);
-        Ok(copy_len)
+        if data.len() != expected {
+            return Err(SystemError::EIO);
+        }
+        buf[..expected].copy_from_slice(&data);
+        Ok(expected)
     }
 
     /// # 函数的功能
@@ -308,9 +320,19 @@ pub trait BlockDevice: Device {
         count: usize,
         buf: &[u8],
     ) -> Result<usize, SystemError> {
+        if count == 0 {
+            return Ok(0);
+        }
+        let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
+        lba_id_start
+            .checked_add(count)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if buf.len() != expected {
+            return Err(SystemError::EINVAL);
+        }
         let bio = self.submit_bio_write(lba_id_start, count, buf)?;
-        let _ = bio.wait()?;
-        Ok(core::cmp::min(buf.len(), count * LBA_SIZE))
+        bio.wait_status()?;
+        Ok(expected)
     }
 
     fn write_at_bytes(&self, offset: usize, len: usize, buf: &[u8]) -> Result<usize, SystemError> {
@@ -403,15 +425,16 @@ pub trait BlockDevice: Device {
         lba_start: BlockId,
         count: usize,
     ) -> Result<Arc<super::bio::BioRequest>, SystemError> {
-        let bio = super::bio::BioRequest::new_read(lba_start, count);
+        let bio = super::bio::BioRequest::try_new_read(lba_start, count)?;
         match self.submit_bio(bio.clone()) {
             Ok(()) => Ok(bio),
             Err(SystemError::ENOSYS) => {
                 log::trace!("BlockDevice submit_bio_read ENOSYS, falling back to sync read");
                 let buf_ptr = bio.buffer_mut();
                 let buf = unsafe { &mut *buf_ptr };
-                self.read_at_sync(lba_start, count, &mut buf[..count * LBA_SIZE])?;
-                bio.complete(Ok(count * LBA_SIZE));
+                let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
+                let completed = self.read_at_sync(lba_start, count, &mut buf[..expected])?;
+                bio.complete(Ok(completed));
                 Ok(bio)
             }
             Err(e) => Err(e),
@@ -425,14 +448,15 @@ pub trait BlockDevice: Device {
         count: usize,
         data: &[u8],
     ) -> Result<Arc<super::bio::BioRequest>, SystemError> {
-        let bio = super::bio::BioRequest::new_write(lba_start, count, data);
+        let bio = super::bio::BioRequest::try_new_write(lba_start, count, data)?;
         match self.submit_bio(bio.clone()) {
             Ok(()) => Ok(bio),
             Err(SystemError::ENOSYS) => {
                 let buf_ptr = bio.buffer();
                 let buf = unsafe { &*buf_ptr };
-                self.write_at_sync(lba_start, count, &buf[..count * LBA_SIZE])?;
-                bio.complete(Ok(count * LBA_SIZE));
+                let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
+                let completed = self.write_at_sync(lba_start, count, &buf[..expected])?;
+                bio.complete(Ok(completed));
                 Ok(bio)
             }
             Err(e) => Err(e),

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -935,6 +935,9 @@ impl BlockDevice for VirtIOBlkDevice {
         count: usize,
         buf: &mut [u8],
     ) -> Result<usize, SystemError> {
+        if count == 0 {
+            return Ok(0);
+        }
         let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
         if buf.len() < expected {
             return Err(SystemError::EINVAL);
@@ -953,6 +956,9 @@ impl BlockDevice for VirtIOBlkDevice {
         count: usize,
         buf: &[u8],
     ) -> Result<usize, SystemError> {
+        if count == 0 {
+            return Ok(0);
+        }
         let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
         if buf.len() != expected {
             return Err(SystemError::EINVAL);

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -1,6 +1,7 @@
 use core::{
     any::Any,
-    fmt::{Debug, Formatter},
+    fmt::{Debug, Formatter, Write},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use alloc::{
@@ -20,7 +21,7 @@ use virtio_drivers::{
 };
 
 use crate::{
-    arch::CurrentIrqArch,
+    arch::{CurrentIrqArch, CurrentTimeArch},
     driver::{
         base::{
             block::{
@@ -71,7 +72,7 @@ use crate::{
         ProcessControlBlock, ProcessManager,
     },
     sched::prio::MAX_RT_PRIO,
-    time::{sleep::nanosleep, PosixTimeSpec},
+    time::{sleep::nanosleep, PosixTimeSpec, TimeArch},
 };
 
 const VIRTIO_BLK_BASENAME: &str = "virtio_blk";
@@ -81,6 +82,168 @@ const IO_BUDGET: usize = 32; // 每次最多处理32个请求
 const SLEEP_MS: usize = 20; // 达到budget后睡眠20ms
 const SHUTDOWN_DRAIN_RETRIES: usize = 32;
 const SHUTDOWN_DRAIN_INTERVAL_NS: i64 = 1_000_000;
+const P6_2_STATS_ENABLED: bool = option_env!("DRAGONOS_P6_2_STATS").is_some();
+const BIO_LATENCY_CYCLES_SHORT: usize = 10_000;
+const BIO_LATENCY_CYCLES_MEDIUM: usize = 100_000;
+const BIO_LATENCY_CYCLES_LONG: usize = 1_000_000;
+static NEXT_VIRTIO_BLK_STATS_GENERATION: AtomicUsize = AtomicUsize::new(1);
+
+#[derive(Default)]
+struct InflightTiming {
+    last_cycle: usize,
+    inflight: usize,
+    weighted_cycles: usize,
+    observed_cycles: usize,
+}
+
+struct VirtIOBlkStats {
+    generation: usize,
+    submits: AtomicUsize,
+    completes: AtomicUsize,
+    reads: AtomicUsize,
+    writes: AtomicUsize,
+    flushes: AtomicUsize,
+    bytes: AtomicUsize,
+    errors: AtomicUsize,
+    short: AtomicUsize,
+    inflight: AtomicUsize,
+    peak_inflight: AtomicUsize,
+    depth_1: AtomicUsize,
+    depth_2_4: AtomicUsize,
+    depth_5_16: AtomicUsize,
+    depth_17_plus: AtomicUsize,
+    size_4k: AtomicUsize,
+    size_16k: AtomicUsize,
+    size_32k: AtomicUsize,
+    size_64k: AtomicUsize,
+    size_large: AtomicUsize,
+    budget_hits: AtomicUsize,
+    latency_short: AtomicUsize,
+    latency_medium: AtomicUsize,
+    latency_long: AtomicUsize,
+    latency_very_long: AtomicUsize,
+    timing: SpinLock<InflightTiming>,
+}
+
+impl VirtIOBlkStats {
+    fn new() -> Self {
+        Self {
+            generation: NEXT_VIRTIO_BLK_STATS_GENERATION.fetch_add(1, Ordering::Relaxed),
+            submits: AtomicUsize::new(0),
+            completes: AtomicUsize::new(0),
+            reads: AtomicUsize::new(0),
+            writes: AtomicUsize::new(0),
+            flushes: AtomicUsize::new(0),
+            bytes: AtomicUsize::new(0),
+            errors: AtomicUsize::new(0),
+            short: AtomicUsize::new(0),
+            inflight: AtomicUsize::new(0),
+            peak_inflight: AtomicUsize::new(0),
+            depth_1: AtomicUsize::new(0),
+            depth_2_4: AtomicUsize::new(0),
+            depth_5_16: AtomicUsize::new(0),
+            depth_17_plus: AtomicUsize::new(0),
+            size_4k: AtomicUsize::new(0),
+            size_16k: AtomicUsize::new(0),
+            size_32k: AtomicUsize::new(0),
+            size_64k: AtomicUsize::new(0),
+            size_large: AtomicUsize::new(0),
+            budget_hits: AtomicUsize::new(0),
+            latency_short: AtomicUsize::new(0),
+            latency_medium: AtomicUsize::new(0),
+            latency_long: AtomicUsize::new(0),
+            latency_very_long: AtomicUsize::new(0),
+            timing: SpinLock::new(InflightTiming::default()),
+        }
+    }
+
+    fn account_time(&self, now: usize, inflight_delta: isize) {
+        let mut timing = self.timing.lock_irqsave();
+        if timing.last_cycle != 0 {
+            let elapsed = now.wrapping_sub(timing.last_cycle);
+            timing.observed_cycles = timing.observed_cycles.wrapping_add(elapsed);
+            timing.weighted_cycles = timing
+                .weighted_cycles
+                .wrapping_add(elapsed.wrapping_mul(timing.inflight));
+        }
+        timing.last_cycle = now;
+        if inflight_delta > 0 {
+            timing.inflight += inflight_delta as usize;
+        } else {
+            timing.inflight = timing.inflight.saturating_sub((-inflight_delta) as usize);
+        }
+    }
+
+    fn begin(&self, kind: BioType, bytes: usize, now: usize) {
+        if !P6_2_STATS_ENABLED {
+            return;
+        }
+        self.submits.fetch_add(1, Ordering::Relaxed);
+        self.bytes.fetch_add(bytes, Ordering::Relaxed);
+        match kind {
+            BioType::Read => &self.reads,
+            BioType::Write => &self.writes,
+            BioType::Flush => &self.flushes,
+        }
+        .fetch_add(1, Ordering::Relaxed);
+        if kind != BioType::Flush {
+            match bytes {
+                1..=4096 => &self.size_4k,
+                4097..=16384 => &self.size_16k,
+                16385..=32768 => &self.size_32k,
+                32769..=65536 => &self.size_64k,
+                _ => &self.size_large,
+            }
+            .fetch_add(1, Ordering::Relaxed);
+        }
+        let depth = self.inflight.fetch_add(1, Ordering::Relaxed) + 1;
+        self.peak_inflight.fetch_max(depth, Ordering::Relaxed);
+        match depth {
+            1 => &self.depth_1,
+            2..=4 => &self.depth_2_4,
+            5..=16 => &self.depth_5_16,
+            _ => &self.depth_17_plus,
+        }
+        .fetch_add(1, Ordering::Relaxed);
+        self.account_time(now, 1);
+    }
+
+    fn finish(
+        &self,
+        result: &Result<usize, SystemError>,
+        expected: usize,
+        start: usize,
+        now: usize,
+    ) {
+        if !P6_2_STATS_ENABLED {
+            return;
+        }
+        self.completes.fetch_add(1, Ordering::Relaxed);
+        let previous = self.inflight.fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(previous != 0);
+        match result {
+            Ok(completed) if *completed != expected => {
+                self.short.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(_) => {
+                self.errors.fetch_add(1, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+        let latency = now.wrapping_sub(start);
+        let bucket = if latency <= BIO_LATENCY_CYCLES_SHORT {
+            &self.latency_short
+        } else if latency <= BIO_LATENCY_CYCLES_MEDIUM {
+            &self.latency_medium
+        } else if latency <= BIO_LATENCY_CYCLES_LONG {
+            &self.latency_long
+        } else {
+            &self.latency_very_long
+        };
+        bucket.fetch_add(1, Ordering::Relaxed);
+        self.account_time(now, -1);
+    }
+}
 
 /// Token映射表：virtqueue token -> BioRequest
 /// BIO请求的完整上下文，包含virtio需要的req和resp
@@ -224,7 +387,7 @@ fn complete_used_requests(device: &Arc<VirtIOBlkDevice>, token_map: &Arc<BioToke
                     Err(VirtioError::NotReady) => {
                         if token_map.insert(token, ctx).is_err() {
                             error!("VirtIOBlk: token {} reinsert failed", token);
-                            bio.complete(Err(SystemError::EIO));
+                            device.complete_accounted_bio(&bio, Err(SystemError::EIO));
                         }
                         break;
                     }
@@ -249,7 +412,7 @@ fn complete_used_requests(device: &Arc<VirtIOBlkDevice>, token_map: &Arc<BioToke
                     Err(VirtioError::NotReady) => {
                         if token_map.insert(token, ctx).is_err() {
                             error!("VirtIOBlk: token {} reinsert failed", token);
-                            bio.complete(Err(SystemError::EIO));
+                            device.complete_accounted_bio(&bio, Err(SystemError::EIO));
                         }
                         break;
                     }
@@ -265,7 +428,7 @@ fn complete_used_requests(device: &Arc<VirtIOBlkDevice>, token_map: &Arc<BioToke
                     Err(VirtioError::NotReady) => {
                         if token_map.insert(token, ctx).is_err() {
                             error!("VirtIOBlk: token {} reinsert failed", token);
-                            bio.complete(Err(SystemError::EIO));
+                            device.complete_accounted_bio(&bio, Err(SystemError::EIO));
                         }
                         break;
                     }
@@ -277,7 +440,7 @@ fn complete_used_requests(device: &Arc<VirtIOBlkDevice>, token_map: &Arc<BioToke
             }
         };
         drop(inner);
-        bio.complete(result);
+        device.complete_accounted_bio(&bio, result);
         completed += 1;
     }
 
@@ -298,6 +461,51 @@ pub fn virtio_blk_0() -> Option<Arc<VirtIOBlkDevice>> {
         .first()
         .cloned()
         .map(|dev| dev.arc_any().downcast().unwrap())
+}
+
+pub fn virtio_blk_stats_report() -> String {
+    let mut report = String::new();
+    for device in virtio_blk_driver().devices() {
+        let Ok(device) = device.arc_any().downcast::<VirtIOBlkDevice>() else {
+            continue;
+        };
+        let stats = &device.stats;
+        let timing = stats.timing.lock_irqsave();
+        let _ = writeln!(
+            report,
+            "device={} generation={} enabled={} submits={} completes={} reads={} writes={} flushes={} bytes={} errors={} short={} inflight={} peak_inflight={} depth_1={} depth_2_4={} depth_5_16={} depth_17_plus={} size_4k={} size_16k={} size_32k={} size_64k={} size_large={} budget_hits={} latency_le_10k={} latency_le_100k={} latency_le_1m={} latency_gt_1m={} weighted_inflight_cycles={} observed_cycles={}",
+            device.blkdev_meta.devname.name(),
+            stats.generation,
+            P6_2_STATS_ENABLED as usize,
+            stats.submits.load(Ordering::Relaxed),
+            stats.completes.load(Ordering::Relaxed),
+            stats.reads.load(Ordering::Relaxed),
+            stats.writes.load(Ordering::Relaxed),
+            stats.flushes.load(Ordering::Relaxed),
+            stats.bytes.load(Ordering::Relaxed),
+            stats.errors.load(Ordering::Relaxed),
+            stats.short.load(Ordering::Relaxed),
+            stats.inflight.load(Ordering::Relaxed),
+            stats.peak_inflight.load(Ordering::Relaxed),
+            stats.depth_1.load(Ordering::Relaxed),
+            stats.depth_2_4.load(Ordering::Relaxed),
+            stats.depth_5_16.load(Ordering::Relaxed),
+            stats.depth_17_plus.load(Ordering::Relaxed),
+            stats.size_4k.load(Ordering::Relaxed),
+            stats.size_16k.load(Ordering::Relaxed),
+            stats.size_32k.load(Ordering::Relaxed),
+            stats.size_64k.load(Ordering::Relaxed),
+            stats.size_large.load(Ordering::Relaxed),
+            stats.budget_hits.load(Ordering::Relaxed),
+            stats.latency_short.load(Ordering::Relaxed),
+            stats.latency_medium.load(Ordering::Relaxed),
+            stats.latency_long.load(Ordering::Relaxed),
+            stats.latency_very_long.load(Ordering::Relaxed),
+            timing.weighted_cycles,
+            timing.observed_cycles,
+        );
+    }
+    report
 }
 
 pub fn virtio_blk(
@@ -404,6 +612,7 @@ pub struct VirtIOBlkDevice {
     parent: RwLock<Weak<LockedDevFSInode>>,
     fs: RwLock<Weak<DevFS>>,
     metadata: Metadata,
+    stats: VirtIOBlkStats,
 }
 
 impl Debug for VirtIOBlkDevice {
@@ -475,6 +684,7 @@ impl VirtIOBlkDevice {
                 crate::filesystem::vfs::FileType::BlockDevice,
                 InodeMode::from_bits_truncate(0o755),
             ),
+            stats: VirtIOBlkStats::new(),
         });
 
         let device_weak = Arc::downgrade(&dev);
@@ -514,6 +724,25 @@ impl VirtIOBlkDevice {
         self.inner.lock_irqsave()
     }
 
+    fn expected_bio_bytes(bio: &BioRequest) -> usize {
+        match bio.bio_type() {
+            BioType::Read | BioType::Write => bio.count() * LBA_SIZE,
+            BioType::Flush => 0,
+        }
+    }
+
+    fn complete_accounted_bio(&self, bio: &BioRequest, result: Result<usize, SystemError>) {
+        if P6_2_STATS_ENABLED {
+            self.stats.finish(
+                &result,
+                Self::expected_bio_bytes(bio),
+                bio.stats_submit_cycle(),
+                CurrentTimeArch::get_cycles(),
+            );
+        }
+        bio.complete(result);
+    }
+
     fn abort_initialization(self: &Arc<Self>) {
         let devname_id = self.blkdev_meta.devname.id();
         if let Err(err) = self.shutdown() {
@@ -551,7 +780,7 @@ impl VirtIOBlkDevice {
 
         if let Some(bio_queue) = &bio_queue {
             for bio in bio_queue.stop_and_drain() {
-                bio.complete(Err(SystemError::ESHUTDOWN));
+                self.complete_accounted_bio(&bio, Err(SystemError::ESHUTDOWN));
             }
         }
 
@@ -595,7 +824,7 @@ impl VirtIOBlkDevice {
                 );
             }
             for ctx in pending {
-                ctx.bio.complete(Err(SystemError::ESHUTDOWN));
+                self.complete_accounted_bio(&ctx.bio, Err(SystemError::ESHUTDOWN));
             }
         }
 
@@ -706,12 +935,16 @@ impl BlockDevice for VirtIOBlkDevice {
         count: usize,
         buf: &mut [u8],
     ) -> Result<usize, SystemError> {
+        let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
+        if buf.len() < expected {
+            return Err(SystemError::EINVAL);
+        }
         let bio = self.submit_bio_read(lba_id_start, count)?;
         let data = bio
             .wait()
             .inspect_err(|e| log::error!("VirtIOBlkDevice read_at_sync error: {:?}", e))?;
-        buf[..count * LBA_SIZE].copy_from_slice(&data[..count * LBA_SIZE]);
-        Ok(count)
+        buf[..expected].copy_from_slice(&data);
+        Ok(expected)
     }
 
     fn write_at_sync(
@@ -720,18 +953,20 @@ impl BlockDevice for VirtIOBlkDevice {
         count: usize,
         buf: &[u8],
     ) -> Result<usize, SystemError> {
-        let bio = self.submit_bio_write(lba_id_start, count, &buf[..count * LBA_SIZE])?;
-        let _ = bio
-            .wait()
+        let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
+        if buf.len() != expected {
+            return Err(SystemError::EINVAL);
+        }
+        let bio = self.submit_bio_write(lba_id_start, count, buf)?;
+        bio.wait_status()
             .inspect_err(|e| log::error!("VirtIOBlkDevice write_at_sync error: {:?}", e))?;
-        Ok(count)
+        Ok(expected)
     }
 
     fn sync(&self) -> Result<(), SystemError> {
         let bio = BioRequest::new_flush();
         self.submit_bio(bio.clone())?;
-        let _ = bio
-            .wait()
+        bio.wait_status()
             .inspect_err(|e| log::error!("VirtIOBlkDevice sync flush error: {:?}", e))?;
         Ok(())
     }
@@ -773,7 +1008,33 @@ impl BlockDevice for VirtIOBlkDevice {
             return Err(SystemError::ESHUTDOWN);
         }
         if let Some(bio_queue) = &inner.bio_queue {
-            bio_queue.submit(bio)
+            let (expected, now) = if P6_2_STATS_ENABLED {
+                let expected = match bio.bio_type() {
+                    BioType::Read | BioType::Write => bio
+                        .count()
+                        .checked_mul(LBA_SIZE)
+                        .ok_or(SystemError::EOVERFLOW)?,
+                    BioType::Flush => 0,
+                };
+                let now = CurrentTimeArch::get_cycles();
+                bio.set_stats_submit_cycle(now);
+                self.stats.begin(bio.bio_type(), expected, now);
+                (expected, now)
+            } else {
+                (0, 0)
+            };
+            if let Err(error) = bio_queue.submit(bio) {
+                if P6_2_STATS_ENABLED {
+                    self.stats.finish(
+                        &Err(error.clone()),
+                        expected,
+                        now,
+                        CurrentTimeArch::get_cycles(),
+                    );
+                }
+                return Err(error);
+            }
+            Ok(())
         } else {
             Err(SystemError::ENOSYS)
         }
@@ -1010,7 +1271,7 @@ impl Drop for VirtIOBlkDevice {
                     break;
                 }
                 for bio in batch {
-                    bio.complete(Err(SystemError::ENODEV));
+                    self.complete_accounted_bio(&bio, Err(SystemError::ENODEV));
                 }
             }
         }
@@ -1023,7 +1284,7 @@ impl Drop for VirtIOBlkDevice {
                 .map(|(_, v)| v)
                 .collect();
             for ctx in pending {
-                ctx.bio.complete(Err(SystemError::ENODEV));
+                self.complete_accounted_bio(&ctx.bio, Err(SystemError::ENODEV));
             }
         }
     }
@@ -1267,7 +1528,7 @@ fn bio_io_thread_loop(device_weak: Weak<VirtIOBlkDevice>) -> i32 {
                     if let Err(e) = submit_bio_to_virtio(&device, bio.clone()) {
                         log::error!("virtio submit_bio_to_virtio failed: {:?}", e);
                         // 失败时立即完成BIO
-                        bio.complete(Err(e));
+                        device.complete_accounted_bio(&bio, Err(e));
                     }
                     processed += 1;
 
@@ -1279,6 +1540,9 @@ fn bio_io_thread_loop(device_weak: Weak<VirtIOBlkDevice>) -> i32 {
 
             // 达到budget，主动睡眠20ms，避免独占CPU
             if processed >= IO_BUDGET {
+                if P6_2_STATS_ENABLED {
+                    device.stats.budget_hits.fetch_add(1, Ordering::Relaxed);
+                }
                 let sleep_time = PosixTimeSpec::new(0, (SLEEP_MS as i64) * 1_000_000); // 20ms
                 let _ = nanosleep(sleep_time);
             }
@@ -1381,7 +1645,7 @@ fn submit_bio_to_virtio(
     let token = match token {
         Some(token) => token,
         None => {
-            bio.complete(Ok(0));
+            device.complete_accounted_bio(&bio, Ok(0));
             drop(irq_guard);
             return Ok(());
         }

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -28,9 +28,11 @@ use crate::{
 };
 use alloc::{
     collections::BTreeMap,
+    string::String,
     sync::{Arc, Weak},
     vec::Vec,
 };
+use core::fmt::Write;
 use kdepends::another_ext4;
 use lazy_static::lazy_static;
 use linkme::distributed_slice;
@@ -54,6 +56,39 @@ struct Ext4EvictionQueueState {
 
 lazy_static! {
     static ref EXT4_EVICTION_WQ: Arc<WorkQueue> = WorkQueue::new("ext4_evict");
+    static ref EXT4_STATS_REGISTRY: SpinLock<Vec<Weak<Ext4FileSystem>>> = SpinLock::new(Vec::new());
+}
+
+pub(crate) fn prepare_stats_report() -> String {
+    let mut report = String::new();
+    let mut registry = EXT4_STATS_REGISTRY.lock();
+    registry.retain(|entry| entry.strong_count() != 0);
+    for entry in registry.iter().filter_map(Weak::upgrade) {
+        let snapshot = entry.fs.prepare_stats_snapshot();
+        let _ = writeln!(
+            report,
+            "device={} generation={} enabled={} journal={} reliable_flush={} write_barrier={} calls={} requested_blocks={} mapped_blocks={} missing_blocks={} failures={} elapsed_cycles={} bitmap_io={} gdt_io={} superblock_io={} inode_io={} extent_io={} zero_io={}",
+            entry.raw_dev.data(),
+            snapshot.generation,
+            snapshot.enabled as usize,
+            entry.fs.uses_journal() as usize,
+            entry.fs.supports_reliable_flush() as usize,
+            entry._mount_options.write_barrier as usize,
+            snapshot.calls,
+            snapshot.requested_blocks,
+            snapshot.mapped_blocks,
+            snapshot.missing_blocks,
+            snapshot.failures,
+            snapshot.elapsed_cycles,
+            snapshot.bitmap_io,
+            snapshot.gdt_io,
+            snapshot.superblock_io,
+            snapshot.inode_io,
+            snapshot.extent_io,
+            snapshot.zero_io,
+        );
+    }
+    report
 }
 
 #[must_use]
@@ -887,6 +922,7 @@ impl Ext4FileSystem {
             eviction_wait: WaitQueue::default(),
             _mount_options: mount_options,
         });
+        EXT4_STATS_REGISTRY.lock().push(Arc::downgrade(&fs));
 
         let mut guard = fs.root_inode.inner.lock();
         guard.fs_ptr = Arc::downgrade(&fs);

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -922,7 +922,10 @@ impl Ext4FileSystem {
             eviction_wait: WaitQueue::default(),
             _mount_options: mount_options,
         });
-        EXT4_STATS_REGISTRY.lock().push(Arc::downgrade(&fs));
+        let mut stats_registry = EXT4_STATS_REGISTRY.lock();
+        stats_registry.retain(|entry| entry.strong_count() != 0);
+        stats_registry.push(Arc::downgrade(&fs));
+        drop(stats_registry);
 
         let mut guard = fs.root_inode.inner.lock();
         guard.fs_ptr = Arc::downgrade(&fs);

--- a/kernel/src/filesystem/ext4/gendisk.rs
+++ b/kernel/src/filesystem/ext4/gendisk.rs
@@ -5,6 +5,8 @@ use system_error::SystemError;
 use crate::driver::base::block::block_device::LBA_SIZE;
 use crate::driver::base::block::gendisk::GenDisk;
 
+const EXT4_BLOCKS_PER_BULK_WRITE: usize = 16;
+
 impl GenDisk {
     fn convert_from_ext4_blkid(&self, ext4_blkid: u64) -> (usize, usize, usize) {
         // another_ext4 的逻辑块固定为 4096 字节（another_ext4::BLOCK_SIZE）。
@@ -23,6 +25,36 @@ impl GenDisk {
         (start_lba_offset, lba_id_start, block_count)
     }
 
+    fn checked_ext4_range(
+        &self,
+        ext4_blkid: u64,
+        ext4_block_count: usize,
+    ) -> Result<(usize, usize), SystemError> {
+        if ext4_block_count == 0 {
+            return Err(SystemError::EINVAL);
+        }
+        let blocks_per_ext4_block = another_ext4::BLOCK_SIZE / LBA_SIZE;
+        let ext4_blkid = usize::try_from(ext4_blkid).map_err(|_| SystemError::EOVERFLOW)?;
+        let relative_lba = ext4_blkid
+            .checked_mul(blocks_per_ext4_block)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let lba_count = ext4_block_count
+            .checked_mul(blocks_per_ext4_block)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let lba_start = self
+            .range()
+            .lba_start
+            .checked_add(relative_lba)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let lba_end = lba_start
+            .checked_add(lba_count)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if lba_end > self.range().lba_end {
+            return Err(SystemError::EFBIG);
+        }
+        Ok((lba_start, lba_count))
+    }
+
     fn map_system_error_to_ext4(e: &SystemError) -> another_ext4::ErrCode {
         match e {
             SystemError::EROFS => another_ext4::ErrCode::EROFS,
@@ -31,6 +63,8 @@ impl GenDisk {
             SystemError::ENOTDIR => another_ext4::ErrCode::ENOTDIR,
             SystemError::EISDIR => another_ext4::ErrCode::EISDIR,
             SystemError::EINVAL => another_ext4::ErrCode::EINVAL,
+            SystemError::ENOMEM => another_ext4::ErrCode::ENOMEM,
+            SystemError::EFBIG | SystemError::EOVERFLOW => another_ext4::ErrCode::EFBIG,
             SystemError::EIO => another_ext4::ErrCode::EIO,
             _ => another_ext4::ErrCode::EIO,
         }
@@ -80,6 +114,44 @@ impl another_ext4::BlockDevice for GenDisk {
                 }
                 another_ext4::Ext4Error::new(code)
             })?;
+        Ok(())
+    }
+
+    fn write_blocks(
+        &self,
+        start: u64,
+        data: &[u8],
+    ) -> core::result::Result<(), another_ext4::Ext4Error> {
+        if data.is_empty() || !data.len().is_multiple_of(another_ext4::BLOCK_SIZE) {
+            return Err(another_ext4::Ext4Error::new(another_ext4::ErrCode::EINVAL));
+        }
+
+        for (chunk_index, chunk) in data
+            .chunks(EXT4_BLOCKS_PER_BULK_WRITE * another_ext4::BLOCK_SIZE)
+            .enumerate()
+        {
+            let block_offset = chunk_index
+                .checked_mul(EXT4_BLOCKS_PER_BULK_WRITE)
+                .ok_or_else(|| another_ext4::Ext4Error::new(another_ext4::ErrCode::EFBIG))?;
+            let chunk_start = start
+                .checked_add(block_offset as u64)
+                .ok_or_else(|| another_ext4::Ext4Error::new(another_ext4::ErrCode::EFBIG))?;
+            let ext4_blocks = chunk.len() / another_ext4::BLOCK_SIZE;
+            let (lba_start, lba_count) = self
+                .checked_ext4_range(chunk_start, ext4_blocks)
+                .map_err(|error| {
+                    another_ext4::Ext4Error::new(Self::map_system_error_to_ext4(&error))
+                })?;
+            let completed = self
+                .block_device()
+                .write_at(lba_start, lba_count, chunk)
+                .map_err(|error| {
+                    another_ext4::Ext4Error::new(Self::map_system_error_to_ext4(&error))
+                })?;
+            if completed != chunk.len() {
+                return Err(another_ext4::Ext4Error::new(another_ext4::ErrCode::EIO));
+            }
+        }
         Ok(())
     }
 

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1,5 +1,5 @@
 use crate::{
-    arch::MMArch,
+    arch::{CurrentTimeArch, MMArch},
     driver::base::device::device_number::{DeviceNumber, Major},
     filesystem::{
         page_cache::{AsyncPageCacheBackend, PageCache},
@@ -21,7 +21,7 @@ use crate::{
     process::{ProcessManager, RawPid},
     sched::sched_yield,
     time::sleep::nanosleep,
-    time::PosixTimeSpec,
+    time::{PosixTimeSpec, TimeArch},
 };
 use alloc::{
     collections::BTreeMap,
@@ -438,7 +438,11 @@ impl IndexNode for LockedExt4Inode {
                 log::warn!("Failed to get current time, using 0");
                 0
             });
-            Self::retry_metadata_contention(|| {
+            let stats_start = fs
+                .fs
+                .prepare_stats_enabled()
+                .then(CurrentTimeArch::get_cycles);
+            let prepare_result = Self::retry_metadata_contention(|| {
                 fs.fs.prepare_buffered_write(
                     inode_num,
                     alloc_start,
@@ -446,7 +450,13 @@ impl IndexNode for LockedExt4Inode {
                     new_end as u64,
                     Some(time),
                 )
-            })?;
+            });
+            if let Some(start) = stats_start {
+                fs.fs.record_prepare_elapsed_cycles(
+                    CurrentTimeArch::get_cycles().wrapping_sub(start),
+                );
+            }
+            prepare_result?;
 
             // 写入范围的磁盘块已就绪，现在安全写入 page cache。
             let write_len = PageCache::write(&page_cache, offset, buf)?;

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -2,16 +2,13 @@ use alloc::vec::Vec;
 use core::ptr::NonNull;
 use system_error::SystemError;
 
-use crate::arch::mm::kernel_page_flags;
 use crate::arch::MMArch;
 use crate::libs::spinlock::SpinLock;
-use crate::mm::kernel_mapper::KernelMapper;
-use crate::mm::page::EntryFlags;
 use crate::mm::{
     allocator::page_frame::{
         allocate_page_frames, deallocate_page_frames, PageFrameCount, PhysPageFrame,
     },
-    MemoryManagementArch, PhysAddr, VirtAddr,
+    MemoryManagementArch, PhysAddr,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -43,7 +40,7 @@ impl Default for DmaAllocOptions {
     fn default() -> Self {
         Self {
             direction: DmaDirection::Bidirectional,
-            cache_policy: DmaCachePolicy::Uncached,
+            cache_policy: DmaCachePolicy::Cached,
             zeroed: true,
             dma_mask: None,
             use_pool: true,
@@ -64,8 +61,6 @@ pub struct DmaBuffer {
     vaddr: NonNull<u8>,
     len: usize,
     page_count: PageFrameCount,
-    #[allow(dead_code)]
-    cache_policy: DmaCachePolicy,
     pool_pages: Option<usize>,
 }
 
@@ -136,9 +131,7 @@ impl Drop for DmaBuffer {
         {
             return;
         }
-        unsafe {
-            dma_dealloc_pages_raw(self.paddr, self.vaddr, self.page_count.data());
-        }
+        unsafe { dma_dealloc_pages_raw(self.paddr, self.vaddr, self.page_count.data()) };
     }
 }
 
@@ -220,6 +213,11 @@ impl DmaAllocator {
         len: usize,
         options: DmaAllocOptions,
     ) -> Result<DmaBuffer, SystemError> {
+        // DragonOS currently supports coherent DMA mappings only. Keep RAM in
+        // its normal write-back direct mapping, as Linux does for coherent
+        // devices; changing PAT/cacheability requires architecture-specific
+        // cache maintenance and cannot be emulated by rewriting PTE flags.
+        validate_cache_policy(options.cache_policy)?;
         let pool_pages = self.pool_pages_for(page_count.data(), options.use_pool);
         let raw = if let Some(pages) = pool_pages {
             if let Some(raw) = self.take_from_pool(pages) {
@@ -238,7 +236,6 @@ impl DmaAllocator {
             vaddr: raw.vaddr,
             len,
             page_count: raw.page_count,
-            cache_policy: options.cache_policy,
             pool_pages,
         })
     }
@@ -248,6 +245,7 @@ impl DmaAllocator {
         page_count: PageFrameCount,
         options: &DmaAllocOptions,
     ) -> Result<DmaRawAllocation, SystemError> {
+        validate_cache_policy(options.cache_policy)?;
         let (paddr, count) =
             unsafe { allocate_page_frames(page_count) }.ok_or(SystemError::ENOMEM)?;
         let virt = match unsafe { MMArch::phys_2_virt(paddr) } {
@@ -264,25 +262,6 @@ impl DmaAllocator {
                 core::ptr::write_bytes(virt.data() as *mut u8, 0, count.data() * MMArch::PAGE_SIZE);
             }
         }
-        let dma_flags: EntryFlags<MMArch> = match options.cache_policy {
-            DmaCachePolicy::Uncached => EntryFlags::mmio_flags(),
-            DmaCachePolicy::WriteCombined => EntryFlags::mmio_flags(),
-            DmaCachePolicy::Cached => EntryFlags::mmio_flags(),
-        };
-        let mut kernel_mapper = KernelMapper::lock();
-        let Some(kernel_mapper) = kernel_mapper.as_mut() else {
-            unsafe {
-                deallocate_page_frames(PhysPageFrame::new(paddr), count);
-            }
-            return Err(SystemError::ENOMEM);
-        };
-        let Some(flusher) = (unsafe { kernel_mapper.remap(virt, dma_flags) }) else {
-            unsafe {
-                deallocate_page_frames(PhysPageFrame::new(paddr), count);
-            }
-            return Err(SystemError::ENOMEM);
-        };
-        flusher.flush();
         Ok(DmaRawAllocation {
             paddr,
             vaddr: NonNull::new(virt.data() as *mut u8).unwrap(),
@@ -344,17 +323,22 @@ pub fn dma_alloc_pages_raw(pages: usize, mut options: DmaAllocOptions) -> (usize
 
 pub unsafe fn dma_dealloc_pages_raw(paddr: usize, vaddr: NonNull<u8>, pages: usize) -> i32 {
     let page_count = page_count_from_pages(pages).expect("invalid dma deallocation page count");
-    let vaddr = VirtAddr::new(vaddr.as_ptr() as usize);
-    let mut kernel_mapper = KernelMapper::lock();
-    let kernel_mapper = kernel_mapper.as_mut().unwrap();
-    let flusher = kernel_mapper
-        .remap(vaddr, kernel_page_flags(vaddr))
-        .expect("dma remap failed");
-    flusher.flush();
+    debug_assert_eq!(
+        unsafe { MMArch::phys_2_virt(PhysAddr::new(paddr)) }.map(|addr| addr.data()),
+        Some(vaddr.as_ptr() as usize)
+    );
     unsafe {
         deallocate_page_frames(PhysPageFrame::new(PhysAddr::new(paddr)), page_count);
     }
     0
+}
+
+fn validate_cache_policy(cache_policy: DmaCachePolicy) -> Result<(), SystemError> {
+    if cache_policy == DmaCachePolicy::Cached {
+        Ok(())
+    } else {
+        Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+    }
 }
 
 fn page_count_from_pages(pages: usize) -> Option<PageFrameCount> {

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use core::ptr::NonNull;
+use system_error::SystemError;
 
 use crate::arch::mm::kernel_page_flags;
 use crate::arch::MMArch;
@@ -73,12 +74,23 @@ unsafe impl Sync for DmaBuffer {}
 
 impl DmaBuffer {
     pub fn alloc_bytes(size: usize, options: DmaAllocOptions) -> Self {
-        dma_allocator().alloc_bytes(size, options)
+        Self::try_alloc_bytes(size, options).expect("dma alloc bytes failed")
+    }
+
+    /// Allocate a physically contiguous DMA buffer without turning memory
+    /// pressure or invalid sizing into a kernel panic.
+    pub fn try_alloc_bytes(size: usize, options: DmaAllocOptions) -> Result<Self, SystemError> {
+        dma_allocator().try_alloc_bytes(size, options)
     }
 
     #[allow(dead_code)]
     pub fn alloc_pages(pages: usize, options: DmaAllocOptions) -> Self {
-        dma_allocator().alloc_pages(pages, options)
+        Self::try_alloc_pages(pages, options).expect("dma alloc pages failed")
+    }
+
+    #[allow(dead_code)]
+    pub fn try_alloc_pages(pages: usize, options: DmaAllocOptions) -> Result<Self, SystemError> {
+        dma_allocator().try_alloc_pages(pages, options)
     }
 
     #[allow(dead_code)]
@@ -180,24 +192,34 @@ impl DmaAllocator {
         Self { pools }
     }
 
-    pub fn alloc_bytes(&self, size: usize, options: DmaAllocOptions) -> DmaBuffer {
-        let page_count = page_count_from_bytes(size);
-        self.alloc_with_pages(page_count, size, options)
+    pub fn try_alloc_bytes(
+        &self,
+        size: usize,
+        options: DmaAllocOptions,
+    ) -> Result<DmaBuffer, SystemError> {
+        let page_count = page_count_from_bytes(size).ok_or(SystemError::ENOMEM)?;
+        self.try_alloc_with_pages(page_count, size, options)
     }
 
     #[allow(dead_code)]
-    pub fn alloc_pages(&self, pages: usize, options: DmaAllocOptions) -> DmaBuffer {
-        let page_count = page_count_from_pages(pages);
-        let size = pages * MMArch::PAGE_SIZE;
-        self.alloc_with_pages(page_count, size, options)
+    pub fn try_alloc_pages(
+        &self,
+        pages: usize,
+        options: DmaAllocOptions,
+    ) -> Result<DmaBuffer, SystemError> {
+        let page_count = page_count_from_pages(pages).ok_or(SystemError::ENOMEM)?;
+        let size = pages
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::ENOMEM)?;
+        self.try_alloc_with_pages(page_count, size, options)
     }
 
-    fn alloc_with_pages(
+    fn try_alloc_with_pages(
         &self,
         page_count: PageFrameCount,
         len: usize,
         options: DmaAllocOptions,
-    ) -> DmaBuffer {
+    ) -> Result<DmaBuffer, SystemError> {
         let pool_pages = self.pool_pages_for(page_count.data(), options.use_pool);
         let raw = if let Some(pages) = pool_pages {
             if let Some(raw) = self.take_from_pool(pages) {
@@ -206,25 +228,37 @@ impl DmaAllocator {
                 }
                 raw
             } else {
-                self.alloc_raw(page_count, &options)
+                self.try_alloc_raw(page_count, &options)?
             }
         } else {
-            self.alloc_raw(page_count, &options)
+            self.try_alloc_raw(page_count, &options)?
         };
-        DmaBuffer {
+        Ok(DmaBuffer {
             paddr: raw.paddr.data(),
             vaddr: raw.vaddr,
             len,
             page_count: raw.page_count,
             cache_policy: options.cache_policy,
             pool_pages,
-        }
+        })
     }
 
-    fn alloc_raw(&self, page_count: PageFrameCount, options: &DmaAllocOptions) -> DmaRawAllocation {
-        let (paddr, count) = unsafe { allocate_page_frames(page_count) }
-            .unwrap_or_else(|| panic!("dma alloc pages failed"));
-        let virt = unsafe { MMArch::phys_2_virt(paddr).unwrap() };
+    fn try_alloc_raw(
+        &self,
+        page_count: PageFrameCount,
+        options: &DmaAllocOptions,
+    ) -> Result<DmaRawAllocation, SystemError> {
+        let (paddr, count) =
+            unsafe { allocate_page_frames(page_count) }.ok_or(SystemError::ENOMEM)?;
+        let virt = match unsafe { MMArch::phys_2_virt(paddr) } {
+            Some(virt) => virt,
+            None => {
+                unsafe {
+                    deallocate_page_frames(PhysPageFrame::new(paddr), count);
+                }
+                return Err(SystemError::ENOMEM);
+            }
+        };
         if options.zeroed {
             unsafe {
                 core::ptr::write_bytes(virt.data() as *mut u8, 0, count.data() * MMArch::PAGE_SIZE);
@@ -236,18 +270,24 @@ impl DmaAllocator {
             DmaCachePolicy::Cached => EntryFlags::mmio_flags(),
         };
         let mut kernel_mapper = KernelMapper::lock();
-        let kernel_mapper = kernel_mapper.as_mut().unwrap();
-        let flusher = unsafe {
-            kernel_mapper
-                .remap(virt, dma_flags)
-                .expect("dma remap failed")
+        let Some(kernel_mapper) = kernel_mapper.as_mut() else {
+            unsafe {
+                deallocate_page_frames(PhysPageFrame::new(paddr), count);
+            }
+            return Err(SystemError::ENOMEM);
+        };
+        let Some(flusher) = (unsafe { kernel_mapper.remap(virt, dma_flags) }) else {
+            unsafe {
+                deallocate_page_frames(PhysPageFrame::new(paddr), count);
+            }
+            return Err(SystemError::ENOMEM);
         };
         flusher.flush();
-        DmaRawAllocation {
+        Ok(DmaRawAllocation {
             paddr,
             vaddr: NonNull::new(virt.data() as *mut u8).unwrap(),
             page_count: count,
-        }
+        })
     }
 
     fn zero_raw(&self, alloc: &DmaRawAllocation) {
@@ -295,13 +335,15 @@ impl DmaAllocator {
 
 pub fn dma_alloc_pages_raw(pages: usize, mut options: DmaAllocOptions) -> (usize, NonNull<u8>) {
     options.use_pool = false;
-    let page_count = page_count_from_pages(pages);
-    let raw = dma_allocator().alloc_raw(page_count, &options);
+    let page_count = page_count_from_pages(pages).expect("invalid dma page count");
+    let raw = dma_allocator()
+        .try_alloc_raw(page_count, &options)
+        .expect("dma alloc pages failed");
     (raw.paddr.data(), raw.vaddr)
 }
 
 pub unsafe fn dma_dealloc_pages_raw(paddr: usize, vaddr: NonNull<u8>, pages: usize) -> i32 {
-    let page_count = page_count_from_pages(pages);
+    let page_count = page_count_from_pages(pages).expect("invalid dma deallocation page count");
     let vaddr = VirtAddr::new(vaddr.as_ptr() as usize);
     let mut kernel_mapper = KernelMapper::lock();
     let kernel_mapper = kernel_mapper.as_mut().unwrap();
@@ -315,12 +357,12 @@ pub unsafe fn dma_dealloc_pages_raw(paddr: usize, vaddr: NonNull<u8>, pages: usi
     0
 }
 
-fn page_count_from_pages(pages: usize) -> PageFrameCount {
+fn page_count_from_pages(pages: usize) -> Option<PageFrameCount> {
     let pages = pages.max(1);
-    PageFrameCount::new(pages.next_power_of_two())
+    Some(PageFrameCount::new(pages.checked_next_power_of_two()?))
 }
 
-fn page_count_from_bytes(size: usize) -> PageFrameCount {
+fn page_count_from_bytes(size: usize) -> Option<PageFrameCount> {
     let pages = size.div_ceil(MMArch::PAGE_SIZE).max(1);
     page_count_from_pages(pages)
 }


### PR DESCRIPTION
## Summary

- batch nojournal ext4 allocation for bounded, contiguous depth-zero appends
- zero complete physical ranges before publishing initialized extents
- add bounded bulk block I/O, fallible DMA/BIO allocation, exact completion handling, and low-overhead diagnostic counters
- preserve the existing path for journaled filesystems, small writes, sparse or fragmented layouts, unsupported flush devices, and resource pressure

## Root cause

CubeSandbox `/tmp` uses a nojournal ext4 filesystem on virtio-blk. A first 8 MiB write allocated 2,048 missing 4 KiB blocks independently. Every block synchronously updated the bitmap, group descriptor, superblock, inode, and zeroed data, producing 18,470 queue-depth-one BIOs and amplifying fixed virtqueue latency.

## Implementation

The new `DirectRangeStage` plans a bounded contiguous allocation using transaction-private metadata images. It bulk-zeroes the entire range, performs a reliable pre-publication flush, then writes bitmap, group descriptor, superblock, and inode homes in semantic order.

Allocation-home failures restore the original images before returning. Rollback durability failures or uncertain inode-home writes poison the direct backend, preventing unsafe reuse. Only direct-range transactions retain rollback snapshots, so normal direct and JBD2 transactions do not pay an extra metadata-copy cost.

The block layer now supports fallible DMA/BIO construction, write completion without payload copies, exact short-I/O detection, and bounded contiguous transfers. Diagnostic counters are compiled out unless explicitly enabled.

The nojournal crash contract is unchanged: an abnormal power loss still requires `fsck`. New blocks are reliably zeroed before an initialized extent can become reachable.

## Performance

Fresh-volume CubeSandbox A1/B/A2 testing used 30 samples per phase with an 8 MiB file and 1 MiB write syscalls. All 90 hashes matched.

| Metric | master A1 | candidate | master A2 |
| --- | ---: | ---: | ---: |
| data median | 15.685 s | 0.500 s | 15.575 s |
| data p90 | 15.860 s | 0.520 s | 16.050 s |
| data + sync median | 18.550 s | 2.750 s | 18.415 s |
| data + sync p90 | 18.760 s | 2.900 s | 18.900 s |

The master median drift was approximately 0.7%. The candidate improves the data phase by approximately 31.3x and data plus sync by approximately 6.7x.

Final-artifact controls:

- 128 KiB syscalls, 8 MiB first write: 0.93 s data, 2.37 s sync
- 4 KiB syscalls, 2 MiB legacy path: 2.94 s data, 0.73 s sync
- 8 MiB overwrite of an allocated file: 0.31 s data, 2.29 s sync

## Validation

- `make fmt`
- `cargo test --manifest-path kernel/crates/another_ext4/Cargo.toml --lib` — 126 passed
- `RUST_MIN_STACK=33554432 make kernel`
- local nojournal ext4 full-file hash, clean unmount, and clean `e2fsck -fn`
- CubeSandbox fresh-volume A1/B/A2 hash and performance validation
- targeted fault tests for zeroing, the pre-publication flush, each allocation home, rollback writes and flushes, and uncertain inode publication

Refs #2019
