### PR TITLE
fix(net): align AF_PACKET classic BPF with Linux

### DIFF
--- a/kernel/src/bpf/classic.rs
+++ b/kernel/src/bpf/classic.rs
@@ -1,12 +1,7 @@
 //! Classic BPF (cBPF) 解释器与验证器。
 //!
-//! 本模块从 `process/seccomp.rs` 提取，泛化为接收 `&[u8]` 数据输入，
-//! 同时服务于 seccomp 系统调用过滤和 AF_PACKET 包过滤。
-//!
-//! 数据加载语义：BPF_W / BPF_H 使用 **大端（网络字节序）** 读取，
-//! 与 Linux `bpf_internal_load_pointer_positive_helper` 中的
-//! `get_unaligned_be16` / `get_unaligned_be32` 一致。
-//! seccomp 调用方需将 `SeccompData` 的每个字段以大端序写入字节缓冲区。
+//! 本模块只实现 cBPF 机器模型、结构验证和输入协议。packet 与 seccomp
+//! 的字节序、逻辑偏移和 ancillary 语义由各自的输入实现负责。
 
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -69,9 +64,6 @@ pub const BPF_K: u16 = 0x00;
 pub const BPF_X: u16 = 0x08;
 pub const BPF_A: u16 = 0x10;
 
-/// RET 返回值掩码
-pub const BPF_RVAL_MASK: u16 = 0x18;
-
 /// ALU 操作（code & 0xf0）
 pub const BPF_ADD: u16 = 0x00;
 pub const BPF_SUB: u16 = 0x10;
@@ -102,6 +94,69 @@ pub const BPF_MAXINSNS: usize = 4096;
 /// BPF 记忆体大小（16 个 u32 字）
 pub const BPF_MEMWORDS: usize = 16;
 
+/// Linux socket filter ancillary 偏移。
+pub const SKF_AD_OFF: u32 = (-0x1000i32) as u32;
+pub const SKF_AD_PROTOCOL: u32 = 0;
+pub const SKF_AD_PKTTYPE: u32 = 4;
+pub const SKF_AD_IFINDEX: u32 = 8;
+pub const SKF_AD_NLATTR: u32 = 12;
+pub const SKF_AD_NLATTR_NEST: u32 = 16;
+pub const SKF_AD_MARK: u32 = 20;
+pub const SKF_AD_QUEUE: u32 = 24;
+pub const SKF_AD_HATYPE: u32 = 28;
+pub const SKF_AD_RXHASH: u32 = 32;
+pub const SKF_AD_CPU: u32 = 36;
+pub const SKF_AD_ALU_XOR_X: u32 = 40;
+pub const SKF_AD_VLAN_TAG: u32 = 44;
+pub const SKF_AD_VLAN_TAG_PRESENT: u32 = 48;
+pub const SKF_AD_PAY_OFFSET: u32 = 52;
+pub const SKF_AD_RANDOM: u32 = 56;
+pub const SKF_AD_VLAN_TPID: u32 = 60;
+pub const SKF_NET_OFF: i32 = -0x100000;
+pub const SKF_LL_OFF: i32 = -0x200000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpfWidth {
+    Word,
+    Half,
+    Byte,
+}
+
+/// cBPF 的调用域输入。实现必须自行定义普通加载的字节序和负偏移语义。
+pub trait ClassicBpfInput {
+    fn len(&self) -> u32;
+
+    fn load(&self, offset: i32, width: BpfWidth) -> Option<u32>;
+
+    fn load_ancillary(&self, extension: u32, accumulator: u32, index: u32) -> Option<u32> {
+        let _ = (extension, accumulator, index);
+        None
+    }
+}
+
+impl ClassicBpfInput for [u8] {
+    #[inline]
+    fn len(&self) -> u32 {
+        self.len().min(u32::MAX as usize) as u32
+    }
+
+    #[inline]
+    fn load(&self, offset: i32, width: BpfWidth) -> Option<u32> {
+        let offset = usize::try_from(offset).ok()?;
+        match width {
+            BpfWidth::Word => {
+                let bytes = self.get(offset..offset.checked_add(4)?)?;
+                Some(u32::from_be_bytes(bytes.try_into().ok()?))
+            }
+            BpfWidth::Half => {
+                let bytes = self.get(offset..offset.checked_add(2)?)?;
+                Some(u16::from_be_bytes(bytes.try_into().ok()?) as u32)
+            }
+            BpfWidth::Byte => self.get(offset).copied().map(u32::from),
+        }
+    }
+}
+
 // ============ cBPF 解释器 ============
 
 /// 运行 classic BPF 程序。
@@ -113,18 +168,16 @@ pub const BPF_MEMWORDS: usize = 16;
 /// - mem\[16\]: 记忆体
 ///
 /// # 加载语义
-/// - `BPF_LD|BPF_W|BPF_ABS`: 读 `data[k..k+4]` → u32（**大端**）
-/// - `BPF_LD|BPF_H|BPF_ABS`: 读 `data[k..k+2]` → u16（**大端**）
-/// - `BPF_LD|BPF_B|BPF_ABS`: 读 `data[k..k+1]` → u8
+/// - `BPF_LD|BPF_W/H/B|BPF_ABS`: 由 input 按调用域语义加载
 /// - `BPF_LD|*|BPF_IND`: 同上，但 offset = X + k
-/// - 越界读取（offset + size > data.len()）：A = 0
+/// - 越界读取（offset + size > data.len()）：立即返回 0
 /// - `BPF_LEN`: A = data.len() as u32
 ///
 /// # 返回值
 /// - 正常返回 `RET` 指令的值（返回截断长度，0 = 丢弃）
-/// - `DIV`/`MOD` 除数为 0：A = 0（继续执行）
+/// - `DIV`/`MOD` 除数为 0：立即返回 0
 /// - fall-through（无 RET 结尾）：返回 0（丢弃）
-pub fn run_cbpf(insns: &[SockFilter], data: &[u8]) -> u32 {
+pub fn run_cbpf<I: ClassicBpfInput + ?Sized>(insns: &[SockFilter], input: &I) -> u32 {
     let mut a: u32 = 0;
     let mut x: u32 = 0;
     let mut pc: usize = 0;
@@ -132,159 +185,153 @@ pub fn run_cbpf(insns: &[SockFilter], data: &[u8]) -> u32 {
 
     while pc < insns.len() {
         let insn = &insns[pc];
-        let class = insn.code & 0x07;
-
-        match class {
-            BPF_LD => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM => a = insn.k,
-                    BPF_ABS | BPF_IND => {
-                        let base = if mode == BPF_ABS {
-                            insn.k as usize
-                        } else {
-                            (x as usize).wrapping_add(insn.k as usize)
-                        };
-                        a = load_packet(data, base, insn.code);
-                    }
-                    BPF_MEM => {
-                        if (insn.k as usize) < BPF_MEMWORDS {
-                            a = mem[insn.k as usize];
-                        }
-                    }
-                    BPF_LEN => a = data.len() as u32,
-                    _ => {}
-                }
-                pc += 1;
+        if is_ancillary(insn.k) && matches!(insn.code, 0x20 | 0x28 | 0x30) {
+            let extension = insn.k.wrapping_sub(SKF_AD_OFF);
+            if extension == SKF_AD_ALU_XOR_X {
+                a ^= x;
+            } else {
+                a = match input.load_ancillary(extension, a, x) {
+                    Some(value) => value,
+                    None => return 0,
+                };
             }
-            BPF_LDX => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM => x = insn.k,
-                    BPF_MEM => {
-                        if (insn.k as usize) < BPF_MEMWORDS {
-                            x = mem[insn.k as usize];
-                        }
-                    }
-                    BPF_LEN => x = data.len() as u32,
-                    // 提取 IP 头长度：x = (data[k] & 0xf) << 2；越界时 x = 0
-                    BPF_MSH => {
-                        x = data
-                            .get(insn.k as usize)
-                            .map(|&b| ((b & 0xf) as u32) << 2)
-                            .unwrap_or(0);
-                    }
-                    _ => {}
-                }
-                pc += 1;
-            }
-            BPF_ST => {
-                if (insn.k as usize) < BPF_MEMWORDS {
-                    mem[insn.k as usize] = a;
-                }
-                pc += 1;
-            }
-            BPF_STX => {
-                if (insn.k as usize) < BPF_MEMWORDS {
-                    mem[insn.k as usize] = x;
-                }
-                pc += 1;
-            }
-            BPF_ALU => {
-                let op = insn.code & 0xf0;
-                let src = insn.code & 0x08;
-                let val = if src == BPF_K { insn.k } else { x };
-                match op {
-                    BPF_ADD => a = a.wrapping_add(val),
-                    BPF_SUB => a = a.wrapping_sub(val),
-                    BPF_MUL => a = a.wrapping_mul(val),
-                    BPF_DIV => a = a.checked_div(val).unwrap_or(0),
-                    BPF_OR => a |= val,
-                    BPF_AND => a &= val,
-                    BPF_LSH => a = a.wrapping_shl(val),
-                    BPF_RSH => a = a.wrapping_shr(val),
-                    BPF_NEG => a = a.wrapping_neg(),
-                    BPF_MOD => a = a.checked_rem(val).unwrap_or(0),
-                    BPF_XOR => a ^= val,
-                    _ => {}
-                }
-                pc += 1;
-            }
-            BPF_JMP => {
-                let op = insn.code & 0xf0;
-                if op == BPF_JA {
-                    pc = match pc
-                        .checked_add(1)
-                        .and_then(|v| v.checked_add(insn.k as usize))
-                    {
-                        Some(target) => target,
-                        None => return 0,
-                    };
-                } else {
-                    let src = insn.code & 0x08;
-                    let val = if src == BPF_K { insn.k } else { x };
-                    let cond = match op {
-                        BPF_JEQ => a == val,
-                        BPF_JGT => a > val,
-                        BPF_JGE => a >= val,
-                        BPF_JSET => (a & val) != 0,
-                        _ => false,
-                    };
-                    if cond {
-                        pc += 1 + insn.jt as usize;
-                    } else {
-                        pc += 1 + insn.jf as usize;
-                    }
-                }
-            }
-            BPF_RET => {
-                let rval = insn.code & BPF_RVAL_MASK;
-                return if rval == BPF_K { insn.k } else { a };
-            }
-            BPF_MISC => {
-                let op = insn.code & 0xf8;
-                match op {
-                    BPF_TAX => x = a,
-                    BPF_TXA => a = x,
-                    _ => {}
-                }
-                pc += 1;
-            }
-            _ => {
-                pc += 1;
-            }
+            pc += 1;
+            continue;
         }
+
+        match insn.code {
+            0x00 => a = insn.k, // LD IMM
+            0x01 => x = insn.k, // LDX IMM
+            0x20 | 0x28 | 0x30 => {
+                a = match input.load(insn.k as i32, width(insn.code)) {
+                    Some(value) => value,
+                    None => return 0,
+                };
+            }
+            0x40 | 0x48 | 0x50 => {
+                let offset = x.wrapping_add(insn.k) as i32;
+                a = match input.load(offset, width(insn.code)) {
+                    Some(value) => value,
+                    None => return 0,
+                };
+            }
+            0x60 => {
+                a = match mem.get(insn.k as usize) {
+                    Some(value) => *value,
+                    None => return 0,
+                }
+            }
+            0x61 => {
+                x = match mem.get(insn.k as usize) {
+                    Some(value) => *value,
+                    None => return 0,
+                }
+            }
+            0x80 => a = input.len(),
+            0x81 => x = input.len(),
+            0xb1 => {
+                x = match input.load(insn.k as i32, BpfWidth::Byte) {
+                    Some(value) => (value & 0xf) << 2,
+                    None => return 0,
+                };
+            }
+            0x02 => match mem.get_mut(insn.k as usize) {
+                Some(slot) => *slot = a,
+                None => return 0,
+            },
+            0x03 => match mem.get_mut(insn.k as usize) {
+                Some(slot) => *slot = x,
+                None => return 0,
+            },
+            0x04 => a = a.wrapping_add(insn.k),
+            0x0c => a = a.wrapping_add(x),
+            0x14 => a = a.wrapping_sub(insn.k),
+            0x1c => a = a.wrapping_sub(x),
+            0x24 => a = a.wrapping_mul(insn.k),
+            0x2c => a = a.wrapping_mul(x),
+            0x34 => {
+                if insn.k == 0 {
+                    return 0;
+                }
+                a /= insn.k;
+            }
+            0x3c => {
+                if x == 0 {
+                    return 0;
+                }
+                a /= x;
+            }
+            0x44 => a |= insn.k,
+            0x4c => a |= x,
+            0x54 => a &= insn.k,
+            0x5c => a &= x,
+            0x64 => a = a.wrapping_shl(insn.k),
+            0x6c => a = a.wrapping_shl(x & 31),
+            0x74 => a = a.wrapping_shr(insn.k),
+            0x7c => a = a.wrapping_shr(x & 31),
+            0x84 => a = a.wrapping_neg(),
+            0x94 => {
+                if insn.k == 0 {
+                    return 0;
+                }
+                a %= insn.k;
+            }
+            0x9c => {
+                if x == 0 {
+                    return 0;
+                }
+                a %= x;
+            }
+            0xa4 => a ^= insn.k,
+            0xac => a ^= x,
+            0x05 => {
+                pc = match pc
+                    .checked_add(1)
+                    .and_then(|next| next.checked_add(insn.k as usize))
+                {
+                    Some(target) => target,
+                    None => return 0,
+                };
+                continue;
+            }
+            0x15 | 0x1d | 0x25 | 0x2d | 0x35 | 0x3d | 0x45 | 0x4d => {
+                let value = if insn.code & BPF_X == 0 { insn.k } else { x };
+                let branch = match insn.code & 0xf0 {
+                    BPF_JEQ => a == value,
+                    BPF_JGT => a > value,
+                    BPF_JGE => a >= value,
+                    BPF_JSET => a & value != 0,
+                    _ => return 0,
+                };
+                pc += 1 + usize::from(if branch { insn.jt } else { insn.jf });
+                continue;
+            }
+            0x06 => return insn.k,
+            0x16 => return a,
+            0x07 => x = a,
+            0x87 => a = x,
+            _ => return 0,
+        }
+        pc += 1;
     }
 
     // fall-through：返回 0（丢弃）
     0
 }
 
-/// 按 size 字段从 packet 数据加载一个 u32 值。
-///
-/// 越界时返回 0。大端读取，与 Linux
-/// `get_unaligned_be16` / `get_unaligned_be32` 一致。
 #[inline]
-fn load_packet(data: &[u8], offset: usize, code: u16) -> u32 {
-    let size_code = code & 0x18;
-    match size_code {
-        BPF_W => {
-            if let Some(slice) = data.get(offset..offset + 4) {
-                u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]])
-            } else {
-                0
-            }
-        }
-        BPF_H => {
-            if let Some(slice) = data.get(offset..offset + 2) {
-                u16::from_be_bytes([slice[0], slice[1]]) as u32
-            } else {
-                0
-            }
-        }
-        BPF_B => data.get(offset).map(|&b| b as u32).unwrap_or(0),
-        _ => 0,
+fn width(code: u16) -> BpfWidth {
+    match code & 0x18 {
+        BPF_W => BpfWidth::Word,
+        BPF_H => BpfWidth::Half,
+        BPF_B => BpfWidth::Byte,
+        _ => unreachable!(),
     }
+}
+
+#[inline]
+fn is_ancillary(offset: u32) -> bool {
+    offset >= SKF_AD_OFF
 }
 
 // ============ cBPF 验证器 ============
@@ -306,117 +353,148 @@ pub fn validate_cbpf(insns: &[SockFilter]) -> Result<(), SystemError> {
     if insns.len() > BPF_MAXINSNS {
         return Err(SystemError::EINVAL);
     }
-    if (insns[insns.len() - 1].code & 0x07) != BPF_RET {
+    if !matches!(insns[insns.len() - 1].code, 0x06 | 0x16) {
         return Err(SystemError::EINVAL);
     }
 
     for (pc, insn) in insns.iter().enumerate() {
-        let class = insn.code & 0x07;
-        match class {
-            BPF_LD => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM | BPF_ABS | BPF_IND | BPF_LEN => {}
-                    BPF_MEM => {
-                        if insn.k as usize >= BPF_MEMWORDS {
-                            return Err(SystemError::EINVAL);
-                        }
-                    }
-                    _ => return Err(SystemError::EINVAL),
-                }
+        if !code_allowed(insn.code) {
+            return Err(SystemError::EINVAL);
+        }
+
+        match insn.code {
+            0x34 | 0x94 if insn.k == 0 => return Err(SystemError::EINVAL),
+            0x64 | 0x74 if insn.k >= 32 => return Err(SystemError::EINVAL),
+            0x60 | 0x61 | 0x02 | 0x03 if insn.k as usize >= BPF_MEMWORDS => {
+                return Err(SystemError::EINVAL);
             }
-            BPF_LDX => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM | BPF_LEN => {}
-                    BPF_MEM => {
-                        if insn.k as usize >= BPF_MEMWORDS {
-                            return Err(SystemError::EINVAL);
-                        }
-                    }
-                    // BPF_MSH 仅允许 BPF_B 宽度（提取 IP 头 IHL 字段）
-                    BPF_MSH => {
-                        if insn.code & 0x18 != BPF_B {
-                            return Err(SystemError::EINVAL);
-                        }
-                    }
-                    _ => return Err(SystemError::EINVAL),
-                }
-            }
-            BPF_ST | BPF_STX => {
-                if insn.k as usize >= BPF_MEMWORDS {
+            0x05 => {
+                if insn.k >= (insns.len() - pc - 1) as u32 {
                     return Err(SystemError::EINVAL);
                 }
             }
-            BPF_ALU => {
-                let op = insn.code & 0xf0;
-                let src = insn.code & 0x08;
-                match op {
-                    BPF_ADD | BPF_SUB | BPF_MUL | BPF_OR | BPF_AND | BPF_LSH | BPF_RSH
-                    | BPF_NEG | BPF_XOR => {}
-                    BPF_DIV | BPF_MOD => {
-                        if src == BPF_K && insn.k == 0 {
-                            return Err(SystemError::EINVAL);
-                        }
-                    }
-                    _ => return Err(SystemError::EINVAL),
-                }
-                // 源只允许 K 或 X
-                if src != BPF_K && src != BPF_X {
+            0x15 | 0x1d | 0x25 | 0x2d | 0x35 | 0x3d | 0x45 | 0x4d => {
+                if pc + insn.jt as usize + 1 >= insns.len()
+                    || pc + insn.jf as usize + 1 >= insns.len()
+                {
                     return Err(SystemError::EINVAL);
                 }
             }
-            BPF_JMP => {
-                let op = insn.code & 0xf0;
-                if op == BPF_JA {
-                    let Some(target) = pc
-                        .checked_add(1)
-                        .and_then(|v| v.checked_add(insn.k as usize))
-                    else {
-                        return Err(SystemError::EINVAL);
-                    };
-                    if target >= insns.len() {
-                        return Err(SystemError::EINVAL);
-                    }
-                } else {
-                    match op {
-                        BPF_JEQ | BPF_JGT | BPF_JGE | BPF_JSET => {}
-                        _ => return Err(SystemError::EINVAL),
-                    }
-                    let src = insn.code & 0x08;
-                    if src != BPF_K && src != BPF_X {
-                        return Err(SystemError::EINVAL);
-                    }
-                    let Some(jt_target) = pc
-                        .checked_add(1)
-                        .and_then(|v| v.checked_add(insn.jt as usize))
-                    else {
-                        return Err(SystemError::EINVAL);
-                    };
-                    let Some(jf_target) = pc
-                        .checked_add(1)
-                        .and_then(|v| v.checked_add(insn.jf as usize))
-                    else {
-                        return Err(SystemError::EINVAL);
-                    };
-                    if jt_target >= insns.len() || jf_target >= insns.len() {
-                        return Err(SystemError::EINVAL);
-                    }
-                }
+            0x20 | 0x28 | 0x30 if is_ancillary(insn.k) && !known_ancillary(insn.k) => {
+                return Err(SystemError::EINVAL);
             }
-            BPF_RET => {
-                let rval = insn.code & BPF_RVAL_MASK;
-                if rval != BPF_K && rval != BPF_A {
-                    return Err(SystemError::EINVAL);
-                }
+            _ => {}
+        }
+    }
+
+    check_loads_and_stores(insns)
+}
+
+#[inline]
+fn code_allowed(code: u16) -> bool {
+    const ALLOWED: &[u16] = &[
+        BPF_ALU | BPF_ADD | BPF_K,
+        BPF_ALU | BPF_ADD | BPF_X,
+        BPF_ALU | BPF_SUB | BPF_K,
+        BPF_ALU | BPF_SUB | BPF_X,
+        BPF_ALU | BPF_MUL | BPF_K,
+        BPF_ALU | BPF_MUL | BPF_X,
+        BPF_ALU | BPF_DIV | BPF_K,
+        BPF_ALU | BPF_DIV | BPF_X,
+        BPF_ALU | BPF_MOD | BPF_K,
+        BPF_ALU | BPF_MOD | BPF_X,
+        BPF_ALU | BPF_AND | BPF_K,
+        BPF_ALU | BPF_AND | BPF_X,
+        BPF_ALU | BPF_OR | BPF_K,
+        BPF_ALU | BPF_OR | BPF_X,
+        BPF_ALU | BPF_XOR | BPF_K,
+        BPF_ALU | BPF_XOR | BPF_X,
+        BPF_ALU | BPF_LSH | BPF_K,
+        BPF_ALU | BPF_LSH | BPF_X,
+        BPF_ALU | BPF_RSH | BPF_K,
+        BPF_ALU | BPF_RSH | BPF_X,
+        BPF_ALU | BPF_NEG,
+        BPF_LD | BPF_W | BPF_ABS,
+        BPF_LD | BPF_H | BPF_ABS,
+        BPF_LD | BPF_B | BPF_ABS,
+        BPF_LD | BPF_W | BPF_LEN,
+        BPF_LD | BPF_W | BPF_IND,
+        BPF_LD | BPF_H | BPF_IND,
+        BPF_LD | BPF_B | BPF_IND,
+        BPF_LD | BPF_IMM,
+        BPF_LD | BPF_MEM,
+        BPF_LDX | BPF_W | BPF_LEN,
+        BPF_LDX | BPF_B | BPF_MSH,
+        BPF_LDX | BPF_IMM,
+        BPF_LDX | BPF_MEM,
+        BPF_ST,
+        BPF_STX,
+        BPF_MISC | BPF_TAX,
+        BPF_MISC | BPF_TXA,
+        BPF_RET | BPF_K,
+        BPF_RET | BPF_A,
+        BPF_JMP | BPF_JA,
+        BPF_JMP | BPF_JEQ | BPF_K,
+        BPF_JMP | BPF_JEQ | BPF_X,
+        BPF_JMP | BPF_JGE | BPF_K,
+        BPF_JMP | BPF_JGE | BPF_X,
+        BPF_JMP | BPF_JGT | BPF_K,
+        BPF_JMP | BPF_JGT | BPF_X,
+        BPF_JMP | BPF_JSET | BPF_K,
+        BPF_JMP | BPF_JSET | BPF_X,
+    ];
+
+    ALLOWED.contains(&code)
+}
+
+#[inline]
+fn known_ancillary(offset: u32) -> bool {
+    matches!(
+        offset.wrapping_sub(SKF_AD_OFF),
+        SKF_AD_PROTOCOL
+            | SKF_AD_PKTTYPE
+            | SKF_AD_IFINDEX
+            | SKF_AD_NLATTR
+            | SKF_AD_NLATTR_NEST
+            | SKF_AD_MARK
+            | SKF_AD_QUEUE
+            | SKF_AD_HATYPE
+            | SKF_AD_RXHASH
+            | SKF_AD_CPU
+            | SKF_AD_ALU_XOR_X
+            | SKF_AD_VLAN_TAG
+            | SKF_AD_VLAN_TAG_PRESENT
+            | SKF_AD_PAY_OFFSET
+            | SKF_AD_RANDOM
+            | SKF_AD_VLAN_TPID
+    )
+}
+
+fn check_loads_and_stores(insns: &[SockFilter]) -> Result<(), SystemError> {
+    let mut masks = Vec::new();
+    masks
+        .try_reserve_exact(insns.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    masks.resize(insns.len(), u16::MAX);
+    let mut memvalid = 0u16;
+
+    for (pc, insn) in insns.iter().enumerate() {
+        memvalid &= masks[pc];
+        match insn.code {
+            0x02 | 0x03 => memvalid |= 1 << insn.k,
+            0x60 | 0x61 if memvalid & (1 << insn.k) == 0 => {
+                return Err(SystemError::EINVAL);
             }
-            BPF_MISC => {
-                let op = insn.code & 0xf8;
-                if op != BPF_TAX && op != BPF_TXA {
-                    return Err(SystemError::EINVAL);
-                }
+            0x05 => {
+                masks[pc + 1 + insn.k as usize] &= memvalid;
+                memvalid = u16::MAX;
             }
-            _ => return Err(SystemError::EINVAL),
+            0x15 | 0x1d | 0x25 | 0x2d | 0x35 | 0x3d | 0x45 | 0x4d => {
+                masks[pc + 1 + insn.jt as usize] &= memvalid;
+                masks[pc + 1 + insn.jf as usize] &= memvalid;
+                memvalid = u16::MAX;
+            }
+            _ => {}
         }
     }
 
@@ -427,13 +505,13 @@ pub fn validate_cbpf(insns: &[SockFilter]) -> Result<(), SystemError> {
 
 /// 从 optval 字节切片解析 `sock_fprog` 结构并读取 filter 指令。
 ///
-/// `optval` 应包含 `struct sock_fprog` 的原始字节（至少 16 字节）。
+/// `optval` 必须精确包含一个 native `struct sock_fprog`。
 /// 内部通过 `UserBufferReader` 安全地从用户空间读取 filter 指令数组。
 ///
 /// 返回已解析的 `Vec<SockFilter>`。
-pub(crate) fn read_sock_fprog(optval: &[u8]) -> Result<Vec<SockFilter>, SystemError> {
+pub(crate) fn parse_sock_fprog(optval: &[u8]) -> Result<SockFprog, SystemError> {
     let fprog_size = core::mem::size_of::<SockFprog>();
-    if optval.len() < fprog_size {
+    if optval.len() != fprog_size {
         return Err(SystemError::EINVAL);
     }
 
@@ -443,11 +521,24 @@ pub(crate) fn read_sock_fprog(optval: &[u8]) -> Result<Vec<SockFilter>, SystemEr
         optval[15],
     ]);
 
-    if len == 0 || len as usize > BPF_MAXINSNS {
+    Ok(SockFprog {
+        len,
+        _pad: [0; 6],
+        filter,
+    })
+}
+
+pub(crate) fn read_sock_fprog_insns(fprog: &SockFprog) -> Result<Vec<SockFilter>, SystemError> {
+    if fprog.len == 0 || fprog.len as usize > BPF_MAXINSNS {
         return Err(SystemError::EINVAL);
     }
 
-    read_filter_insns(filter, len as usize)
+    read_filter_insns(fprog.filter, fprog.len as usize)
+}
+
+pub(crate) fn read_sock_fprog(optval: &[u8]) -> Result<Vec<SockFilter>, SystemError> {
+    let fprog = parse_sock_fprog(optval)?;
+    read_sock_fprog_insns(&fprog)
 }
 
 /// 从用户空间读取 filter 指令数组。
@@ -455,11 +546,17 @@ fn read_filter_insns(ptr: u64, count: usize) -> Result<Vec<SockFilter>, SystemEr
     let insn_size = core::mem::size_of::<SockFilter>();
     let byte_len = count.checked_mul(insn_size).ok_or(SystemError::EINVAL)?;
 
-    let mut buf = alloc::vec![0u8; byte_len];
+    let mut buf = Vec::new();
+    buf.try_reserve_exact(byte_len)
+        .map_err(|_| SystemError::ENOMEM)?;
+    buf.resize(byte_len, 0);
     let reader = UserBufferReader::new(ptr as *const u8, byte_len, true)?;
     reader.copy_from_user_protected(&mut buf, 0)?;
 
-    let mut insns = Vec::with_capacity(count);
+    let mut insns = Vec::new();
+    insns
+        .try_reserve_exact(count)
+        .map_err(|_| SystemError::ENOMEM)?;
     for chunk in buf.chunks_exact(insn_size) {
         insns.push(SockFilter {
             code: u16::from_ne_bytes([chunk[0], chunk[1]]),

--- a/kernel/src/bpf/classic.rs
+++ b/kernel/src/bpf/classic.rs
@@ -1,0 +1,473 @@
+//! Classic BPF (cBPF) 解释器与验证器。
+//!
+//! 本模块从 `process/seccomp.rs` 提取，泛化为接收 `&[u8]` 数据输入，
+//! 同时服务于 seccomp 系统调用过滤和 AF_PACKET 包过滤。
+//!
+//! 数据加载语义：BPF_W / BPF_H 使用 **大端（网络字节序）** 读取，
+//! 与 Linux `bpf_internal_load_pointer_positive_helper` 中的
+//! `get_unaligned_be16` / `get_unaligned_be32` 一致。
+//! seccomp 调用方需将 `SeccompData` 的每个字段以大端序写入字节缓冲区。
+
+use alloc::vec::Vec;
+use system_error::SystemError;
+
+use crate::syscall::user_access::UserBufferReader;
+
+// ============ Sock Filter / Sock Fprog ============
+
+/// Classic BPF 指令（对应 Linux `struct sock_filter`，8 字节）
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SockFilter {
+    pub code: u16,
+    pub jt: u8,
+    pub jf: u8,
+    pub k: u32,
+}
+
+/// `struct sock_fprog` —— 用户空间传入的 filter 容器。
+///
+/// 布局：`{ u16 len; u8 _pad[6]; u64 filter; }`（共 16 字节）。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SockFprog {
+    pub len: u16,
+    pub _pad: [u8; 6],
+    pub filter: u64,
+}
+
+// ============ BPF 指令常量 ============
+// 参考 Linux include/uapi/linux/filter.h
+
+/// 指令类（code & 0x07）
+pub const BPF_LD: u16 = 0x00;
+pub const BPF_LDX: u16 = 0x01;
+pub const BPF_ST: u16 = 0x02;
+pub const BPF_STX: u16 = 0x03;
+pub const BPF_ALU: u16 = 0x04;
+pub const BPF_JMP: u16 = 0x05;
+pub const BPF_RET: u16 = 0x06;
+pub const BPF_MISC: u16 = 0x07;
+
+/// 加载宽度（code & 0x18，仅对 LD/LDX 有意义）
+pub const BPF_W: u16 = 0x00;
+pub const BPF_H: u16 = 0x08;
+pub const BPF_B: u16 = 0x10;
+
+/// 寻址模式（code & 0xe0，仅对 LD/LDX 有意义）
+pub const BPF_IMM: u16 = 0x00;
+pub const BPF_ABS: u16 = 0x20;
+pub const BPF_IND: u16 = 0x40;
+pub const BPF_MEM: u16 = 0x60;
+pub const BPF_LEN: u16 = 0x80;
+/// BPF_MSH：仅用于 `LDX|BPF_B|BPF_MSH`，提取 IP 头长度
+/// （`x = (data[k] & 0xf) << 2`）。
+pub const BPF_MSH: u16 = 0xa0;
+
+/// 数据源（code & 0x08，仅对 ALU/JMP 有意义）
+pub const BPF_K: u16 = 0x00;
+pub const BPF_X: u16 = 0x08;
+pub const BPF_A: u16 = 0x10;
+
+/// RET 返回值掩码
+pub const BPF_RVAL_MASK: u16 = 0x18;
+
+/// ALU 操作（code & 0xf0）
+pub const BPF_ADD: u16 = 0x00;
+pub const BPF_SUB: u16 = 0x10;
+pub const BPF_MUL: u16 = 0x20;
+pub const BPF_DIV: u16 = 0x30;
+pub const BPF_OR: u16 = 0x40;
+pub const BPF_AND: u16 = 0x50;
+pub const BPF_LSH: u16 = 0x60;
+pub const BPF_RSH: u16 = 0x70;
+pub const BPF_NEG: u16 = 0x80;
+pub const BPF_MOD: u16 = 0x90;
+pub const BPF_XOR: u16 = 0xa0;
+
+/// JMP 操作（code & 0xf0）
+pub const BPF_JA: u16 = 0x00;
+pub const BPF_JEQ: u16 = 0x10;
+pub const BPF_JGT: u16 = 0x20;
+pub const BPF_JGE: u16 = 0x30;
+pub const BPF_JSET: u16 = 0x40;
+
+/// MISC 操作（code & 0xf8）
+pub const BPF_TAX: u16 = 0x00;
+pub const BPF_TXA: u16 = 0x80;
+
+/// BPF 程序最大指令数（Linux 限制）
+pub const BPF_MAXINSNS: usize = 4096;
+
+/// BPF 记忆体大小（16 个 u32 字）
+pub const BPF_MEMWORDS: usize = 16;
+
+// ============ cBPF 解释器 ============
+
+/// 运行 classic BPF 程序。
+///
+/// cBPF 寄存器模型：
+/// - A (u32): 累加器
+/// - X (u32): 索引寄存器
+/// - pc: 程序计数器
+/// - mem\[16\]: 记忆体
+///
+/// # 加载语义
+/// - `BPF_LD|BPF_W|BPF_ABS`: 读 `data[k..k+4]` → u32（**大端**）
+/// - `BPF_LD|BPF_H|BPF_ABS`: 读 `data[k..k+2]` → u16（**大端**）
+/// - `BPF_LD|BPF_B|BPF_ABS`: 读 `data[k..k+1]` → u8
+/// - `BPF_LD|*|BPF_IND`: 同上，但 offset = X + k
+/// - 越界读取（offset + size > data.len()）：A = 0
+/// - `BPF_LEN`: A = data.len() as u32
+///
+/// # 返回值
+/// - 正常返回 `RET` 指令的值（返回截断长度，0 = 丢弃）
+/// - `DIV`/`MOD` 除数为 0：A = 0（继续执行）
+/// - fall-through（无 RET 结尾）：返回 0（丢弃）
+pub fn run_cbpf(insns: &[SockFilter], data: &[u8]) -> u32 {
+    let mut a: u32 = 0;
+    let mut x: u32 = 0;
+    let mut pc: usize = 0;
+    let mut mem = [0u32; BPF_MEMWORDS];
+
+    while pc < insns.len() {
+        let insn = &insns[pc];
+        let class = insn.code & 0x07;
+
+        match class {
+            BPF_LD => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM => a = insn.k,
+                    BPF_ABS | BPF_IND => {
+                        let base = if mode == BPF_ABS {
+                            insn.k as usize
+                        } else {
+                            (x as usize).wrapping_add(insn.k as usize)
+                        };
+                        a = load_packet(data, base, insn.code);
+                    }
+                    BPF_MEM => {
+                        if (insn.k as usize) < BPF_MEMWORDS {
+                            a = mem[insn.k as usize];
+                        }
+                    }
+                    BPF_LEN => a = data.len() as u32,
+                    _ => {}
+                }
+                pc += 1;
+            }
+            BPF_LDX => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM => x = insn.k,
+                    BPF_MEM => {
+                        if (insn.k as usize) < BPF_MEMWORDS {
+                            x = mem[insn.k as usize];
+                        }
+                    }
+                    BPF_LEN => x = data.len() as u32,
+                    // 提取 IP 头长度：x = (data[k] & 0xf) << 2；越界时 x = 0
+                    BPF_MSH => {
+                        x = data
+                            .get(insn.k as usize)
+                            .map(|&b| ((b & 0xf) as u32) << 2)
+                            .unwrap_or(0);
+                    }
+                    _ => {}
+                }
+                pc += 1;
+            }
+            BPF_ST => {
+                if (insn.k as usize) < BPF_MEMWORDS {
+                    mem[insn.k as usize] = a;
+                }
+                pc += 1;
+            }
+            BPF_STX => {
+                if (insn.k as usize) < BPF_MEMWORDS {
+                    mem[insn.k as usize] = x;
+                }
+                pc += 1;
+            }
+            BPF_ALU => {
+                let op = insn.code & 0xf0;
+                let src = insn.code & 0x08;
+                let val = if src == BPF_K { insn.k } else { x };
+                match op {
+                    BPF_ADD => a = a.wrapping_add(val),
+                    BPF_SUB => a = a.wrapping_sub(val),
+                    BPF_MUL => a = a.wrapping_mul(val),
+                    BPF_DIV => a = a.checked_div(val).unwrap_or(0),
+                    BPF_OR => a |= val,
+                    BPF_AND => a &= val,
+                    BPF_LSH => a = a.wrapping_shl(val),
+                    BPF_RSH => a = a.wrapping_shr(val),
+                    BPF_NEG => a = a.wrapping_neg(),
+                    BPF_MOD => a = a.checked_rem(val).unwrap_or(0),
+                    BPF_XOR => a ^= val,
+                    _ => {}
+                }
+                pc += 1;
+            }
+            BPF_JMP => {
+                let op = insn.code & 0xf0;
+                if op == BPF_JA {
+                    pc = match pc
+                        .checked_add(1)
+                        .and_then(|v| v.checked_add(insn.k as usize))
+                    {
+                        Some(target) => target,
+                        None => return 0,
+                    };
+                } else {
+                    let src = insn.code & 0x08;
+                    let val = if src == BPF_K { insn.k } else { x };
+                    let cond = match op {
+                        BPF_JEQ => a == val,
+                        BPF_JGT => a > val,
+                        BPF_JGE => a >= val,
+                        BPF_JSET => (a & val) != 0,
+                        _ => false,
+                    };
+                    if cond {
+                        pc += 1 + insn.jt as usize;
+                    } else {
+                        pc += 1 + insn.jf as usize;
+                    }
+                }
+            }
+            BPF_RET => {
+                let rval = insn.code & BPF_RVAL_MASK;
+                return if rval == BPF_K { insn.k } else { a };
+            }
+            BPF_MISC => {
+                let op = insn.code & 0xf8;
+                match op {
+                    BPF_TAX => x = a,
+                    BPF_TXA => a = x,
+                    _ => {}
+                }
+                pc += 1;
+            }
+            _ => {
+                pc += 1;
+            }
+        }
+    }
+
+    // fall-through：返回 0（丢弃）
+    0
+}
+
+/// 按 size 字段从 packet 数据加载一个 u32 值。
+///
+/// 越界时返回 0。大端读取，与 Linux
+/// `get_unaligned_be16` / `get_unaligned_be32` 一致。
+#[inline]
+fn load_packet(data: &[u8], offset: usize, code: u16) -> u32 {
+    let size_code = code & 0x18;
+    match size_code {
+        BPF_W => {
+            if let Some(slice) = data.get(offset..offset + 4) {
+                u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]])
+            } else {
+                0
+            }
+        }
+        BPF_H => {
+            if let Some(slice) = data.get(offset..offset + 2) {
+                u16::from_be_bytes([slice[0], slice[1]]) as u32
+            } else {
+                0
+            }
+        }
+        BPF_B => data.get(offset).map(|&b| b as u32).unwrap_or(0),
+        _ => 0,
+    }
+}
+
+// ============ cBPF 验证器 ============
+
+/// 验证 cBPF 程序的合法性（通用检查）。
+///
+/// 检查项：
+/// 1. 非空
+/// 2. len <= BPF_MAXINSNS (4096)
+/// 3. 末条指令 class == BPF_RET
+/// 4. 跳转目标 `checked_add`（溢出 → EINVAL），且 < insns.len()
+/// 5. ST/STX 的 k < BPF_MEMWORDS (16)
+/// 6. ALU|DIV|K 的 k != 0；ALU|MOD|K 的 k != 0（静态拒绝）
+/// 7. opcode class 在白名单内（LD 允许 IMM/ABS/IND/MEM/LEN；LDX 允许 IMM/MEM/LEN/MSH，其中 MSH 仅限 BPF_B 宽度）
+pub fn validate_cbpf(insns: &[SockFilter]) -> Result<(), SystemError> {
+    if insns.is_empty() {
+        return Err(SystemError::EINVAL);
+    }
+    if insns.len() > BPF_MAXINSNS {
+        return Err(SystemError::EINVAL);
+    }
+    if (insns[insns.len() - 1].code & 0x07) != BPF_RET {
+        return Err(SystemError::EINVAL);
+    }
+
+    for (pc, insn) in insns.iter().enumerate() {
+        let class = insn.code & 0x07;
+        match class {
+            BPF_LD => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM | BPF_ABS | BPF_IND | BPF_LEN => {}
+                    BPF_MEM => {
+                        if insn.k as usize >= BPF_MEMWORDS {
+                            return Err(SystemError::EINVAL);
+                        }
+                    }
+                    _ => return Err(SystemError::EINVAL),
+                }
+            }
+            BPF_LDX => {
+                let mode = insn.code & 0xe0;
+                match mode {
+                    BPF_IMM | BPF_LEN => {}
+                    BPF_MEM => {
+                        if insn.k as usize >= BPF_MEMWORDS {
+                            return Err(SystemError::EINVAL);
+                        }
+                    }
+                    // BPF_MSH 仅允许 BPF_B 宽度（提取 IP 头 IHL 字段）
+                    BPF_MSH => {
+                        if insn.code & 0x18 != BPF_B {
+                            return Err(SystemError::EINVAL);
+                        }
+                    }
+                    _ => return Err(SystemError::EINVAL),
+                }
+            }
+            BPF_ST | BPF_STX => {
+                if insn.k as usize >= BPF_MEMWORDS {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            BPF_ALU => {
+                let op = insn.code & 0xf0;
+                let src = insn.code & 0x08;
+                match op {
+                    BPF_ADD | BPF_SUB | BPF_MUL | BPF_OR | BPF_AND | BPF_LSH | BPF_RSH
+                    | BPF_NEG | BPF_XOR => {}
+                    BPF_DIV | BPF_MOD => {
+                        if src == BPF_K && insn.k == 0 {
+                            return Err(SystemError::EINVAL);
+                        }
+                    }
+                    _ => return Err(SystemError::EINVAL),
+                }
+                // 源只允许 K 或 X
+                if src != BPF_K && src != BPF_X {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            BPF_JMP => {
+                let op = insn.code & 0xf0;
+                if op == BPF_JA {
+                    let Some(target) = pc
+                        .checked_add(1)
+                        .and_then(|v| v.checked_add(insn.k as usize))
+                    else {
+                        return Err(SystemError::EINVAL);
+                    };
+                    if target >= insns.len() {
+                        return Err(SystemError::EINVAL);
+                    }
+                } else {
+                    match op {
+                        BPF_JEQ | BPF_JGT | BPF_JGE | BPF_JSET => {}
+                        _ => return Err(SystemError::EINVAL),
+                    }
+                    let src = insn.code & 0x08;
+                    if src != BPF_K && src != BPF_X {
+                        return Err(SystemError::EINVAL);
+                    }
+                    let Some(jt_target) = pc
+                        .checked_add(1)
+                        .and_then(|v| v.checked_add(insn.jt as usize))
+                    else {
+                        return Err(SystemError::EINVAL);
+                    };
+                    let Some(jf_target) = pc
+                        .checked_add(1)
+                        .and_then(|v| v.checked_add(insn.jf as usize))
+                    else {
+                        return Err(SystemError::EINVAL);
+                    };
+                    if jt_target >= insns.len() || jf_target >= insns.len() {
+                        return Err(SystemError::EINVAL);
+                    }
+                }
+            }
+            BPF_RET => {
+                let rval = insn.code & BPF_RVAL_MASK;
+                if rval != BPF_K && rval != BPF_A {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            BPF_MISC => {
+                let op = insn.code & 0xf8;
+                if op != BPF_TAX && op != BPF_TXA {
+                    return Err(SystemError::EINVAL);
+                }
+            }
+            _ => return Err(SystemError::EINVAL),
+        }
+    }
+
+    Ok(())
+}
+
+// ============ 用户空间解析 ============
+
+/// 从 optval 字节切片解析 `sock_fprog` 结构并读取 filter 指令。
+///
+/// `optval` 应包含 `struct sock_fprog` 的原始字节（至少 16 字节）。
+/// 内部通过 `UserBufferReader` 安全地从用户空间读取 filter 指令数组。
+///
+/// 返回已解析的 `Vec<SockFilter>`。
+pub(crate) fn read_sock_fprog(optval: &[u8]) -> Result<Vec<SockFilter>, SystemError> {
+    let fprog_size = core::mem::size_of::<SockFprog>();
+    if optval.len() < fprog_size {
+        return Err(SystemError::EINVAL);
+    }
+
+    let len = u16::from_ne_bytes([optval[0], optval[1]]);
+    let filter = u64::from_ne_bytes([
+        optval[8], optval[9], optval[10], optval[11], optval[12], optval[13], optval[14],
+        optval[15],
+    ]);
+
+    if len == 0 || len as usize > BPF_MAXINSNS {
+        return Err(SystemError::EINVAL);
+    }
+
+    read_filter_insns(filter, len as usize)
+}
+
+/// 从用户空间读取 filter 指令数组。
+fn read_filter_insns(ptr: u64, count: usize) -> Result<Vec<SockFilter>, SystemError> {
+    let insn_size = core::mem::size_of::<SockFilter>();
+    let byte_len = count.checked_mul(insn_size).ok_or(SystemError::EINVAL)?;
+
+    let mut buf = alloc::vec![0u8; byte_len];
+    let reader = UserBufferReader::new(ptr as *const u8, byte_len, true)?;
+    reader.copy_from_user_protected(&mut buf, 0)?;
+
+    let mut insns = Vec::with_capacity(count);
+    for chunk in buf.chunks_exact(insn_size) {
+        insns.push(SockFilter {
+            code: u16::from_ne_bytes([chunk[0], chunk[1]]),
+            jt: chunk[2],
+            jf: chunk[3],
+            k: u32::from_ne_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]),
+        });
+    }
+
+    Ok(insns)
+}

--- a/kernel/src/bpf/mod.rs
+++ b/kernel/src/bpf/mod.rs
@@ -1,3 +1,4 @@
+pub mod classic;
 pub mod helper;
 pub mod map;
 pub mod prog;

--- a/kernel/src/driver/net/e1000e/e1000e_driver.rs
+++ b/kernel/src/driver/net/e1000e/e1000e_driver.rs
@@ -90,9 +90,7 @@ impl phy::RxToken for E1000ERxToken {
         // 向注册的 packet socket 分发数据包
         if let Some(iface) = self.driver.iface() {
             let pkt_type = crate::net::socket::packet::classify_packet(packet, &iface);
-            if let Some(netns) = iface.net_namespace() {
-                netns.deliver_to_packet_sockets(iface.nic_id() as u32, packet, pkt_type);
-            }
+            crate::net::socket::packet::deliver_to_packet_sockets(&iface, packet, pkt_type);
         }
 
         let result = f(packet);
@@ -313,7 +311,7 @@ impl E1000EInterface {
             driver,
             common: IfaceCommon::new(
                 iface_id,
-                crate::driver::net::types::InterfaceType::EETHER,
+                crate::driver::net::types::InterfaceType::ETHER,
                 name,
                 mtu,
                 flags,

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -301,9 +301,7 @@ impl RxToken for VethRxToken {
         // 向注册的 packet socket 分发数据包
         if let Some(iface) = self.driver.iface() {
             let pkt_type = crate::net::socket::packet::classify_packet(packet, &iface);
-            if let Some(netns) = iface.net_namespace() {
-                netns.deliver_to_packet_sockets(iface.nic_id() as u32, packet, pkt_type);
-            }
+            crate::net::socket::packet::deliver_to_packet_sockets(&iface, packet, pkt_type);
         }
 
         f(packet)
@@ -405,7 +403,7 @@ impl VethInterface {
             driver: driver.clone(),
             common: IfaceCommon::new(
                 iface_id,
-                super::types::InterfaceType::EETHER,
+                super::types::InterfaceType::ETHER,
                 driver.name(),
                 mtu,
                 flags,

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -444,7 +444,7 @@ impl VirtioInterface {
             locked_kobj_state: LockedKObjectState::default(),
             iface_common: super::IfaceCommon::new(
                 iface_id,
-                crate::driver::net::types::InterfaceType::EETHER,
+                crate::driver::net::types::InterfaceType::ETHER,
                 iface_name,
                 mtu,
                 flags,
@@ -742,9 +742,7 @@ impl phy::RxToken for VirtioNetToken {
         // 向注册的 packet socket 分发数据包
         if let Some(iface) = self.driver.iface() {
             let pkt_type = crate::net::socket::packet::classify_packet(packet, &iface);
-            if let Some(netns) = iface.net_namespace() {
-                netns.deliver_to_packet_sockets(iface.nic_id() as u32, packet, pkt_type);
-            }
+            crate::net::socket::packet::deliver_to_packet_sockets(&iface, packet, pkt_type);
         }
 
         let result = f(packet);

--- a/kernel/src/net/socket/packet/binding.rs
+++ b/kernel/src/net/socket/packet/binding.rs
@@ -6,7 +6,7 @@ use crate::driver::net::Iface;
 use crate::filesystem::epoll::EPollEventType;
 use crate::net::socket::endpoint::{Endpoint, LinkLayerEndpoint};
 
-use super::{PacketSocket, PacketType};
+use super::{PacketIngressMetadata, PacketSocket};
 
 /// Lock-free, coherent `(ifindex, protocol)` receive-filter snapshot.
 #[derive(Debug)]
@@ -91,7 +91,7 @@ impl PacketSocket {
         ll.protocol = protocol;
         if let Some(iface) = self.bound_iface.read().as_ref() {
             ll.addr[..6].copy_from_slice(iface.mac().as_bytes());
-            ll.hatype = 1;
+            ll.hatype = iface.type_() as u16;
             ll.halen = 6;
         }
         Ok(Endpoint::LinkLayer(ll))
@@ -108,7 +108,7 @@ impl PacketSocket {
     }
 
     /// Registry delivery entry: the ingress interface is authoritative metadata.
-    pub(crate) fn deliver(&self, ingress_ifindex: u32, frame: &[u8], pkt_type: PacketType) {
-        self.deliver_from_iface(ingress_ifindex, frame, pkt_type);
+    pub(crate) fn deliver(&self, ingress: PacketIngressMetadata, frame: &[u8]) {
+        self.deliver_from_iface(ingress, frame);
     }
 }

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -23,7 +23,7 @@ use crate::net::socket::{Socket, PMSG, PSOCK, PSOL};
 use crate::process::cred::CAPFlags;
 use crate::process::namespace::net_namespace::NetNamespace;
 use crate::process::ProcessManager;
-use crate::rcu::RcuArcSlot;
+use crate::rcu::RcuOptionArcSlot;
 
 #[allow(unused_imports)]
 pub use uapi::{
@@ -41,6 +41,27 @@ pub enum PacketSocketType {
     Dgram,
 }
 
+/// Metadata captured at the packet-tap boundary. Keeping this structure
+/// `Copy` lets the NAPI receive path pass device information to every packet
+/// socket without consulting the sleepable netdevice registry.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PacketIngressMetadata {
+    pub ifindex: u32,
+    pub hatype: u16,
+    pub pkt_type: PacketType,
+}
+
+impl PacketIngressMetadata {
+    #[inline]
+    fn from_iface(iface: &Arc<dyn Iface>, pkt_type: PacketType) -> Self {
+        Self {
+            ifindex: iface.nic_id() as u32,
+            hatype: iface.type_() as u16,
+            pkt_type,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct PacketMetadata {
     pub src_mac: [u8; 6],
@@ -48,6 +69,7 @@ pub struct PacketMetadata {
     pub dst_mac: [u8; 6],
     pub protocol: u16,
     pub ifindex: u32,
+    pub hatype: u16,
     pub pkt_type: PacketType,
     pub wire_len: usize,
     #[allow(dead_code)]
@@ -91,12 +113,10 @@ pub struct PacketSocket {
     open_files: AtomicUsize,
     pub(super) self_ref: Weak<Self>,
     pub(super) netns: Arc<NetNamespace>,
-    /// BPF filter 快路径标记：false 时跳过 filter 评估（零开销）
-    pub(super) has_filter: AtomicBool,
-    /// cBPF filter 程序（RcuArcSlot 无锁读取，匹配 AF_PACKET 收包路径设计）
-    pub(super) filter: RcuArcSlot<Vec<SockFilter>>,
-    /// SO_LOCK_FILTER：一旦置 true 不可再修改 filter
-    pub(super) filter_locked: AtomicBool,
+    /// cBPF filter 程序；空指针是“未安装”的唯一事实来源。
+    pub(super) filter: RcuOptionArcSlot<Vec<SockFilter>>,
+    /// 串行化 SO_ATTACH_FILTER、SO_DETACH_FILTER 与 SO_LOCK_FILTER。
+    pub(super) filter_locked: Mutex<bool>,
     epoll_items: EPollItems,
     fasync_items: FAsyncItems,
 }
@@ -136,9 +156,8 @@ impl PacketSocket {
             self_ref: me.clone(),
             netns,
             epoll_items: EPollItems::default(),
-            has_filter: AtomicBool::new(false),
-            filter: RcuArcSlot::new(Arc::new(Vec::new())),
-            filter_locked: AtomicBool::new(false),
+            filter: RcuOptionArcSlot::new_none(),
+            filter_locked: Mutex::new(false),
             fasync_items: FAsyncItems::default(),
         });
         socket.netns.register_packet_socket(socket.self_ref.clone());
@@ -184,7 +203,7 @@ pub fn classify_packet(frame: &[u8], iface: &Arc<dyn Iface>) -> PacketType {
 /// Common AF_PACKET tap for Ethernet netdevices.
 pub fn deliver_to_packet_sockets(iface: &Arc<dyn Iface>, frame: &[u8], pkt_type: PacketType) {
     if let Some(netns) = iface.net_namespace() {
-        netns.deliver_to_packet_sockets(iface.nic_id() as u32, frame, pkt_type);
+        netns.deliver_to_packet_sockets(PacketIngressMetadata::from_iface(iface, pkt_type), frame);
     }
 }
 

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -12,6 +12,7 @@ use alloc::vec::Vec;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use system_error::SystemError;
 
+use crate::bpf::classic::SockFilter;
 use crate::driver::net::Iface;
 use crate::filesystem::epoll::EPollEventType;
 use crate::filesystem::vfs::{fasync::FAsyncItems, vcore::generate_inode_id, InodeId};
@@ -22,6 +23,7 @@ use crate::net::socket::{Socket, PMSG, PSOCK, PSOL};
 use crate::process::cred::CAPFlags;
 use crate::process::namespace::net_namespace::NetNamespace;
 use crate::process::ProcessManager;
+use crate::rcu::RcuArcSlot;
 
 #[allow(unused_imports)]
 pub use uapi::{
@@ -89,6 +91,12 @@ pub struct PacketSocket {
     open_files: AtomicUsize,
     pub(super) self_ref: Weak<Self>,
     pub(super) netns: Arc<NetNamespace>,
+    /// BPF filter 快路径标记：false 时跳过 filter 评估（零开销）
+    pub(super) has_filter: AtomicBool,
+    /// cBPF filter 程序（RcuArcSlot 无锁读取，匹配 AF_PACKET 收包路径设计）
+    pub(super) filter: RcuArcSlot<Vec<SockFilter>>,
+    /// SO_LOCK_FILTER：一旦置 true 不可再修改 filter
+    pub(super) filter_locked: AtomicBool,
     epoll_items: EPollItems,
     fasync_items: FAsyncItems,
 }
@@ -128,6 +136,9 @@ impl PacketSocket {
             self_ref: me.clone(),
             netns,
             epoll_items: EPollItems::default(),
+            has_filter: AtomicBool::new(false),
+            filter: RcuArcSlot::new(Arc::new(Vec::new())),
+            filter_locked: AtomicBool::new(false),
             fasync_items: FAsyncItems::default(),
         });
         socket.netns.register_packet_socket(socket.self_ref.clone());

--- a/kernel/src/net/socket/packet/rx.rs
+++ b/kernel/src/net/socket/packet/rx.rs
@@ -1,7 +1,14 @@
 use alloc::vec::Vec;
+use core::cell::Cell;
 use core::sync::atomic::Ordering;
 use system_error::SystemError;
 
+use crate::bpf::classic::{
+    BpfWidth, ClassicBpfInput, SKF_AD_CPU, SKF_AD_HATYPE, SKF_AD_IFINDEX, SKF_AD_MARK,
+    SKF_AD_NLATTR, SKF_AD_NLATTR_NEST, SKF_AD_PAY_OFFSET, SKF_AD_PKTTYPE, SKF_AD_PROTOCOL,
+    SKF_AD_QUEUE, SKF_AD_RANDOM, SKF_AD_RXHASH, SKF_AD_VLAN_TAG, SKF_AD_VLAN_TAG_PRESENT,
+    SKF_AD_VLAN_TPID, SKF_LL_OFF, SKF_NET_OFF,
+};
 use crate::filesystem::vfs::iov::IoVecs;
 use crate::net::socket::endpoint::{Endpoint, LinkLayerEndpoint};
 use crate::net::socket::unix::utils::CmsgBuffer;
@@ -9,15 +16,675 @@ use crate::net::socket::PMSG;
 
 use super::uapi::{SOL_PACKET, TP_STATUS_USER, TP_STATUS_VLAN_TPID_VALID, TP_STATUS_VLAN_VALID};
 use super::{
-    eth_protocol, packet_option, PacketMetadata, PacketSocket, PacketSocketType, PacketType,
-    ReceivedPacket, SockAddrLl, TpacketAuxdata,
+    eth_protocol, packet_option, PacketIngressMetadata, PacketMetadata, PacketSocket,
+    PacketSocketType, ReceivedPacket, SockAddrLl, TpacketAuxdata,
 };
+
+const ETHERNET_HEADER_LEN: usize = 14;
+const MAX_FLOW_DISSECT_HDRS: u8 = 15;
+
+#[derive(Clone, Copy)]
+enum FlowDissectRet {
+    StopGood,
+    Bad,
+    ProtoAgain,
+    IpProtoAgain,
+    Continue,
+}
+
+#[derive(Clone, Copy)]
+struct BasicFlowKeys {
+    thoff: usize,
+    ip_proto: u8,
+    is_fragment: bool,
+    is_first_fragment: bool,
+}
 
 struct ParsedFrame {
     dst: [u8; 6],
     src: [u8; 6],
     protocol: u16,
     vlan: Option<(u16, u16)>,
+}
+
+/// Linux runs AF_PACKET taps after the outer inline VLAN header has been
+/// moved into skb metadata. This view models that skb layout with at most two
+/// borrowed segments and is shared by cBPF loads and the eventual queue copy.
+struct PacketFilterInput<'a> {
+    first: &'a [u8],
+    second: &'a [u8],
+    data_offset: usize,
+    protocol: u16,
+    vlan: Option<(u16, u16)>,
+    ingress: PacketIngressMetadata,
+    payload_offset_cache: Cell<Option<u32>>,
+}
+
+impl<'a> PacketFilterInput<'a> {
+    fn new(
+        frame: &'a [u8],
+        parsed: &ParsedFrame,
+        sock_type: PacketSocketType,
+        ingress: PacketIngressMetadata,
+    ) -> Self {
+        let (first, second) = if parsed.vlan.is_some() {
+            (&frame[..12], &frame[16..])
+        } else {
+            (frame, &[][..])
+        };
+        Self {
+            first,
+            second,
+            data_offset: if sock_type == PacketSocketType::Raw {
+                0
+            } else {
+                ETHERNET_HEADER_LEN
+            },
+            protocol: parsed.protocol,
+            vlan: parsed.vlan,
+            ingress,
+            payload_offset_cache: Cell::new(None),
+        }
+    }
+
+    #[inline]
+    fn full_len(&self) -> usize {
+        self.first.len().saturating_add(self.second.len())
+    }
+
+    #[inline]
+    fn data_len(&self) -> usize {
+        self.full_len().saturating_sub(self.data_offset)
+    }
+
+    #[inline]
+    fn byte_at_full(&self, offset: usize) -> Option<u8> {
+        if offset < self.first.len() {
+            self.first.get(offset).copied()
+        } else {
+            self.second
+                .get(offset.checked_sub(self.first.len())?)
+                .copied()
+        }
+    }
+
+    fn load_full(&self, offset: usize, width: BpfWidth) -> Option<u32> {
+        let width = match width {
+            BpfWidth::Word => 4,
+            BpfWidth::Half => 2,
+            BpfWidth::Byte => 1,
+        };
+        offset
+            .checked_add(width)
+            .filter(|end| *end <= self.full_len())?;
+        let mut bytes = [0u8; 4];
+        for (index, byte) in bytes[..width].iter_mut().enumerate() {
+            *byte = self.byte_at_full(offset.checked_add(index)?)?;
+        }
+        Some(match width {
+            4 => u32::from_be_bytes(bytes),
+            2 => u16::from_be_bytes([bytes[0], bytes[1]]) as u32,
+            1 => bytes[0] as u32,
+            _ => unreachable!(),
+        })
+    }
+
+    fn resolve_offset(&self, offset: i32) -> Option<usize> {
+        let absolute = if offset >= 0 {
+            (self.data_offset as i64).checked_add(offset as i64)?
+        } else if offset >= SKF_NET_OFF {
+            (ETHERNET_HEADER_LEN as i64).checked_add((offset - SKF_NET_OFF) as i64)?
+        } else if offset >= SKF_LL_OFF {
+            (offset - SKF_LL_OFF) as i64
+        } else {
+            return None;
+        };
+        usize::try_from(absolute).ok()
+    }
+
+    fn copy_prefix_to(&self, output: &mut Vec<u8>, len: usize) {
+        let end = self.data_offset + len;
+        let first_start = self.data_offset.min(self.first.len());
+        let first_end = end.min(self.first.len());
+        if first_start < first_end {
+            output.extend_from_slice(&self.first[first_start..first_end]);
+        }
+        if end > self.first.len() {
+            let second_start = self.data_offset.saturating_sub(self.first.len());
+            let second_end = end - self.first.len();
+            output.extend_from_slice(&self.second[second_start..second_end]);
+        }
+    }
+
+    fn find_nlattr(&self, start: u32, attr_type: u32, nested: bool) -> u32 {
+        const NLA_HEADER_LEN: usize = 4;
+        const NLA_TYPE_MASK: u16 = 0x3fff;
+        let mut start = match usize::try_from(start) {
+            Ok(value) => value,
+            Err(_) => return 0,
+        };
+        if nested {
+            let Some(len) = self.load_native_u16(start) else {
+                return 0;
+            };
+            let len = len as usize;
+            if len < NLA_HEADER_LEN
+                || start
+                    .checked_add(len)
+                    .is_none_or(|end| end > self.data_len())
+            {
+                return 0;
+            }
+            start += NLA_HEADER_LEN;
+            return self.find_nlattr_in_range(
+                start,
+                len - NLA_HEADER_LEN,
+                attr_type,
+                NLA_TYPE_MASK,
+            );
+        }
+        self.find_nlattr_in_range(
+            start,
+            self.data_len().saturating_sub(start),
+            attr_type,
+            NLA_TYPE_MASK,
+        )
+    }
+
+    fn find_nlattr_in_range(
+        &self,
+        mut offset: usize,
+        length: usize,
+        attr_type: u32,
+        type_mask: u16,
+    ) -> u32 {
+        const NLA_HEADER_LEN: usize = 4;
+        let Some(end) = offset
+            .checked_add(length)
+            .filter(|end| *end <= self.data_len())
+        else {
+            return 0;
+        };
+        let mut remaining_iterations = length / NLA_HEADER_LEN;
+        while remaining_iterations != 0 && offset + NLA_HEADER_LEN <= end {
+            remaining_iterations -= 1;
+            let Some(nla_len) = self.load_native_u16(offset).map(usize::from) else {
+                return 0;
+            };
+            let Some(nla_type) = self.load_native_u16(offset + 2) else {
+                return 0;
+            };
+            if nla_len < NLA_HEADER_LEN || offset.checked_add(nla_len).is_none_or(|v| v > end) {
+                return 0;
+            }
+            if u32::from(nla_type & type_mask) == attr_type {
+                return offset.min(u32::MAX as usize) as u32;
+            }
+            let aligned = match nla_len.checked_add(3).map(|len| len & !3) {
+                Some(value) if value >= NLA_HEADER_LEN => value,
+                _ => return 0,
+            };
+            offset = match offset.checked_add(aligned) {
+                Some(value) => value,
+                None => return 0,
+            };
+        }
+        0
+    }
+
+    fn load_native_u16(&self, data_offset: usize) -> Option<u16> {
+        let first = self.byte_at_full(self.data_offset.checked_add(data_offset)?)?;
+        let second =
+            self.byte_at_full(self.data_offset.checked_add(data_offset)?.checked_add(1)?)?;
+        Some(u16::from_ne_bytes([first, second]))
+    }
+
+    fn payload_offset(&self) -> u32 {
+        if let Some(offset) = self.payload_offset_cache.get() {
+            return offset;
+        }
+        let offset = self.calculate_payload_offset();
+        self.payload_offset_cache.set(Some(offset));
+        offset
+    }
+
+    /// Mirrors Linux 6.6 `skb_get_poff()`: first run the basic flow
+    /// dissector, then advance over the small set of L4 headers it knows.
+    fn calculate_payload_offset(&self) -> u32 {
+        let Some(keys) = self.dissect_flow_keys_basic() else {
+            return 0;
+        };
+        let mut poff = keys
+            .thoff
+            .saturating_sub(self.data_offset)
+            .min(self.data_len())
+            .min(u16::MAX as usize)
+            .min(u32::MAX as usize) as u32;
+
+        if keys.is_fragment && !keys.is_first_fragment {
+            return poff;
+        }
+
+        let l4_len = match keys.ip_proto {
+            // TCP only needs the doff byte. A short TCP header leaves thoff
+            // unchanged, while a declared long header is deliberately not
+            // clamped to the packet length.
+            6 => {
+                let full_offset = self
+                    .data_offset
+                    .checked_add(poff as usize)
+                    .and_then(|offset| offset.checked_add(12));
+                let Some(doff) = full_offset.and_then(|offset| self.byte_at_full(offset)) else {
+                    return poff;
+                };
+                u32::from(((doff & 0xf0) >> 2).max(20))
+            }
+            // UDP, UDPLITE, ICMP, ICMPv6 and IGMP.
+            17 | 136 | 1 | 58 | 2 => 8,
+            // DCCP and SCTP.
+            33 | 132 => 12,
+            _ => 0,
+        };
+        poff = poff.wrapping_add(l4_len);
+        poff
+    }
+
+    fn dissect_flow_keys_basic(&self) -> Option<BasicFlowKeys> {
+        #[derive(Clone, Copy)]
+        enum Stage {
+            Protocol,
+            IpProtocol,
+        }
+
+        let mut protocol = self.vlan.map_or(self.protocol, |(_, tpid)| tpid);
+        let mut metadata_vlan_pending = self.vlan.is_some();
+        let mut ip_proto = 0;
+        let mut nhoff = ETHERNET_HEADER_LEN;
+        let mut is_fragment = false;
+        let mut is_first_fragment = false;
+        let mut num_headers = 0u8;
+        let mut stage = Stage::Protocol;
+
+        loop {
+            let result = match stage {
+                Stage::Protocol => self.dissect_protocol(
+                    &mut protocol,
+                    &mut ip_proto,
+                    &mut nhoff,
+                    &mut metadata_vlan_pending,
+                    &mut is_fragment,
+                    &mut is_first_fragment,
+                ),
+                Stage::IpProtocol => self.dissect_ip_protocol(
+                    &mut protocol,
+                    &mut ip_proto,
+                    &mut nhoff,
+                    &mut is_fragment,
+                    &mut is_first_fragment,
+                ),
+            };
+
+            match result {
+                FlowDissectRet::Bad => return None,
+                FlowDissectRet::StopGood => break,
+                FlowDissectRet::Continue => match stage {
+                    Stage::Protocol => stage = Stage::IpProtocol,
+                    Stage::IpProtocol => break,
+                },
+                FlowDissectRet::ProtoAgain | FlowDissectRet::IpProtoAgain => {
+                    num_headers = num_headers.saturating_add(1);
+                    if num_headers > MAX_FLOW_DISSECT_HDRS {
+                        break;
+                    }
+                    stage = if matches!(result, FlowDissectRet::ProtoAgain) {
+                        Stage::Protocol
+                    } else {
+                        Stage::IpProtocol
+                    };
+                }
+            }
+        }
+
+        Some(BasicFlowKeys {
+            thoff: nhoff.min(self.full_len()),
+            ip_proto,
+            is_fragment,
+            is_first_fragment,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn dissect_protocol(
+        &self,
+        protocol: &mut u16,
+        ip_proto: &mut u8,
+        nhoff: &mut usize,
+        metadata_vlan_pending: &mut bool,
+        is_fragment: &mut bool,
+        is_first_fragment: &mut bool,
+    ) -> FlowDissectRet {
+        const ETH_P_8021Q: u16 = 0x8100;
+        const ETH_P_8021AD: u16 = 0x88a8;
+        const ETH_P_PPP_SES: u16 = 0x8864;
+        const ETH_P_TIPC: u16 = 0x88ca;
+        const ETH_P_MPLS_UC: u16 = 0x8847;
+        const ETH_P_MPLS_MC: u16 = 0x8848;
+        const ETH_P_FCOE: u16 = 0x8906;
+        const ETH_P_ARP: u16 = 0x0806;
+        const ETH_P_RARP: u16 = 0x8035;
+        const ETH_P_BATMAN: u16 = 0x4305;
+        const ETH_P_1588: u16 = 0x88f7;
+        const ETH_P_PRP: u16 = 0x88fb;
+        const ETH_P_HSR: u16 = 0x892f;
+        const ETH_P_CFM: u16 = 0x8902;
+
+        match *protocol {
+            eth_protocol::ETH_P_IP => {
+                if !self.range_present(*nhoff, 20) {
+                    return FlowDissectRet::Bad;
+                }
+                let ihl = usize::from(self.byte_at_full(*nhoff).unwrap() & 0x0f) * 4;
+                if ihl < 20 {
+                    return FlowDissectRet::Bad;
+                }
+                *ip_proto = self.byte_at_full(*nhoff + 9).unwrap();
+                let frag = self.read_be_u16(*nhoff + 6).unwrap();
+                *nhoff = match nhoff.checked_add(ihl) {
+                    Some(offset) => offset,
+                    None => return FlowDissectRet::Bad,
+                };
+                if frag & 0x3fff != 0 {
+                    *is_fragment = true;
+                    *is_first_fragment = frag & 0x1fff == 0;
+                    FlowDissectRet::StopGood
+                } else {
+                    FlowDissectRet::Continue
+                }
+            }
+            eth_protocol::ETH_P_IPV6 => {
+                if !self.range_present(*nhoff, 40) {
+                    return FlowDissectRet::Bad;
+                }
+                *ip_proto = self.byte_at_full(*nhoff + 6).unwrap();
+                *nhoff = match nhoff.checked_add(40) {
+                    Some(offset) => offset,
+                    None => return FlowDissectRet::Bad,
+                };
+                FlowDissectRet::Continue
+            }
+            ETH_P_8021Q | ETH_P_8021AD => {
+                if *metadata_vlan_pending {
+                    *metadata_vlan_pending = false;
+                    *protocol = self.protocol;
+                } else {
+                    if !self.range_present(*nhoff, 4) {
+                        return FlowDissectRet::Bad;
+                    }
+                    *protocol = self.read_be_u16(*nhoff + 2).unwrap();
+                    *nhoff += 4;
+                }
+                FlowDissectRet::ProtoAgain
+            }
+            ETH_P_PPP_SES => self.dissect_pppoe(protocol, nhoff),
+            ETH_P_TIPC => {
+                if self.range_present(*nhoff, 16) {
+                    FlowDissectRet::StopGood
+                } else {
+                    FlowDissectRet::Bad
+                }
+            }
+            ETH_P_MPLS_UC | ETH_P_MPLS_MC => {
+                // The basic dissector does not request the MPLS key, so Linux
+                // does not read or validate the LSE and advances exactly one.
+                *nhoff = match nhoff.checked_add(4) {
+                    Some(offset) => offset,
+                    None => return FlowDissectRet::Bad,
+                };
+                FlowDissectRet::StopGood
+            }
+            ETH_P_FCOE => {
+                if !self.range_present(*nhoff, 38) {
+                    return FlowDissectRet::Bad;
+                }
+                *nhoff += 38;
+                FlowDissectRet::StopGood
+            }
+            ETH_P_ARP | ETH_P_RARP | ETH_P_CFM => FlowDissectRet::StopGood,
+            ETH_P_BATMAN => {
+                const BATADV_UNICAST_LEN: usize = 10;
+                const BATADV_AND_ETH_LEN: usize = BATADV_UNICAST_LEN + ETHERNET_HEADER_LEN;
+                if !self.range_present(*nhoff, BATADV_AND_ETH_LEN)
+                    || self.byte_at_full(*nhoff) != Some(0x40)
+                    || self.byte_at_full(*nhoff + 1) != Some(15)
+                {
+                    return FlowDissectRet::Bad;
+                }
+                *protocol = self.read_be_u16(*nhoff + BATADV_UNICAST_LEN + 12).unwrap();
+                *nhoff += BATADV_AND_ETH_LEN;
+                FlowDissectRet::ProtoAgain
+            }
+            ETH_P_1588 => {
+                const PTP_HEADER_LEN: usize = 34;
+                if !self.range_present(*nhoff, PTP_HEADER_LEN) {
+                    return FlowDissectRet::Bad;
+                }
+                *nhoff += PTP_HEADER_LEN;
+                FlowDissectRet::StopGood
+            }
+            ETH_P_PRP | ETH_P_HSR => {
+                const HSR_HEADER_LEN: usize = 6;
+                if !self.range_present(*nhoff, HSR_HEADER_LEN) {
+                    return FlowDissectRet::Bad;
+                }
+                *protocol = self.read_be_u16(*nhoff + 4).unwrap();
+                *nhoff += HSR_HEADER_LEN;
+                FlowDissectRet::ProtoAgain
+            }
+            _ => FlowDissectRet::Bad,
+        }
+    }
+
+    fn dissect_pppoe(&self, protocol: &mut u16, nhoff: &mut usize) -> FlowDissectRet {
+        const PPP_IP: u16 = 0x0021;
+        const PPP_IPV6: u16 = 0x0057;
+        const PPP_MPLS_UC: u16 = 0x0281;
+        const PPP_MPLS_MC: u16 = 0x0283;
+
+        if !self.range_present(*nhoff, 8)
+            || self.byte_at_full(*nhoff) != Some(0x11)
+            || self.byte_at_full(*nhoff + 1) != Some(0)
+        {
+            return FlowDissectRet::Bad;
+        }
+        let mut ppp_proto = self.read_be_u16(*nhoff + 6).unwrap();
+        let header_len = if ppp_proto & 0x0100 != 0 {
+            ppp_proto >>= 8;
+            7
+        } else {
+            8
+        };
+        *nhoff += header_len;
+        match ppp_proto {
+            PPP_IP => {
+                *protocol = eth_protocol::ETH_P_IP;
+                FlowDissectRet::ProtoAgain
+            }
+            PPP_IPV6 => {
+                *protocol = eth_protocol::ETH_P_IPV6;
+                FlowDissectRet::ProtoAgain
+            }
+            PPP_MPLS_UC => {
+                *protocol = 0x8847;
+                FlowDissectRet::ProtoAgain
+            }
+            PPP_MPLS_MC => {
+                *protocol = 0x8848;
+                FlowDissectRet::ProtoAgain
+            }
+            value if value & 0x0101 == 0x0001 => FlowDissectRet::StopGood,
+            _ => FlowDissectRet::Bad,
+        }
+    }
+
+    fn dissect_ip_protocol(
+        &self,
+        protocol: &mut u16,
+        ip_proto: &mut u8,
+        nhoff: &mut usize,
+        is_fragment: &mut bool,
+        is_first_fragment: &mut bool,
+    ) -> FlowDissectRet {
+        match *ip_proto {
+            47 => self.dissect_gre(protocol, nhoff),
+            0 | 43 | 60 if *protocol == eth_protocol::ETH_P_IPV6 => {
+                if !self.range_present(*nhoff, 2) {
+                    return FlowDissectRet::Bad;
+                }
+                *ip_proto = self.byte_at_full(*nhoff).unwrap();
+                let header_len = (usize::from(self.byte_at_full(*nhoff + 1).unwrap()) + 1) * 8;
+                *nhoff = match nhoff.checked_add(header_len) {
+                    Some(offset) => offset,
+                    None => return FlowDissectRet::Bad,
+                };
+                FlowDissectRet::IpProtoAgain
+            }
+            44 if *protocol == eth_protocol::ETH_P_IPV6 => {
+                if !self.range_present(*nhoff, 8) {
+                    return FlowDissectRet::Bad;
+                }
+                *ip_proto = self.byte_at_full(*nhoff).unwrap();
+                let frag = self.read_be_u16(*nhoff + 2).unwrap();
+                *nhoff += 8;
+                *is_fragment = true;
+                *is_first_fragment = frag & 0xfff8 == 0;
+                FlowDissectRet::StopGood
+            }
+            4 => {
+                *protocol = eth_protocol::ETH_P_IP;
+                FlowDissectRet::ProtoAgain
+            }
+            41 => {
+                *protocol = eth_protocol::ETH_P_IPV6;
+                FlowDissectRet::ProtoAgain
+            }
+            137 => {
+                *protocol = 0x8847;
+                FlowDissectRet::ProtoAgain
+            }
+            _ => FlowDissectRet::Continue,
+        }
+    }
+
+    fn dissect_gre(&self, protocol: &mut u16, nhoff: &mut usize) -> FlowDissectRet {
+        const GRE_CSUM: u16 = 0x8000;
+        const GRE_ROUTING: u16 = 0x4000;
+        const GRE_KEY: u16 = 0x2000;
+        const GRE_SEQ: u16 = 0x1000;
+        const GRE_ACK: u16 = 0x0080;
+        const GRE_VERSION: u16 = 0x0007;
+        const GRE_PROTO_PPP: u16 = 0x880b;
+        const ETH_P_TEB: u16 = 0x6558;
+
+        if !self.range_present(*nhoff, 4) {
+            return FlowDissectRet::Bad;
+        }
+        let flags = self.read_be_u16(*nhoff).unwrap();
+        let version = flags & GRE_VERSION;
+        if flags & GRE_ROUTING != 0 || version > 1 {
+            return FlowDissectRet::StopGood;
+        }
+        *protocol = self.read_be_u16(*nhoff + 2).unwrap();
+        if version == 1 && (*protocol != GRE_PROTO_PPP || flags & GRE_KEY == 0) {
+            return FlowDissectRet::StopGood;
+        }
+
+        let mut offset = 4usize;
+        if flags & GRE_CSUM != 0 {
+            offset += 4;
+        }
+        if flags & GRE_KEY != 0 {
+            if !self.range_present(*nhoff + offset, 4) {
+                return FlowDissectRet::Bad;
+            }
+            offset += 4;
+        }
+        if flags & GRE_SEQ != 0 {
+            offset += 4;
+        }
+
+        if version == 0 {
+            if *protocol == ETH_P_TEB {
+                if !self.range_present(*nhoff + offset, ETHERNET_HEADER_LEN) {
+                    return FlowDissectRet::Bad;
+                }
+                *protocol = self.read_be_u16(*nhoff + offset + 12).unwrap();
+                offset += ETHERNET_HEADER_LEN;
+            }
+        } else {
+            if flags & GRE_ACK != 0 {
+                offset += 4;
+            }
+            if !self.range_present(*nhoff + offset, 4) {
+                return FlowDissectRet::Bad;
+            }
+            match self.read_be_u16(*nhoff + offset + 2).unwrap() {
+                0x0021 => *protocol = eth_protocol::ETH_P_IP,
+                0x0057 => *protocol = eth_protocol::ETH_P_IPV6,
+                _ => {}
+            }
+            offset += 4;
+        }
+
+        *nhoff = match nhoff.checked_add(offset) {
+            Some(offset) => offset,
+            None => return FlowDissectRet::Bad,
+        };
+        FlowDissectRet::ProtoAgain
+    }
+
+    #[inline]
+    fn range_present(&self, offset: usize, len: usize) -> bool {
+        offset
+            .checked_add(len)
+            .is_some_and(|end| end <= self.full_len())
+    }
+
+    #[inline]
+    fn read_be_u16(&self, offset: usize) -> Option<u16> {
+        Some(u16::from_be_bytes([
+            self.byte_at_full(offset)?,
+            self.byte_at_full(offset.checked_add(1)?)?,
+        ]))
+    }
+}
+
+impl ClassicBpfInput for PacketFilterInput<'_> {
+    fn len(&self) -> u32 {
+        self.data_len().min(u32::MAX as usize) as u32
+    }
+
+    fn load(&self, offset: i32, width: BpfWidth) -> Option<u32> {
+        self.load_full(self.resolve_offset(offset)?, width)
+    }
+
+    fn load_ancillary(&self, extension: u32, accumulator: u32, index: u32) -> Option<u32> {
+        Some(match extension {
+            SKF_AD_PROTOCOL => self.protocol as u32,
+            SKF_AD_PKTTYPE => self.ingress.pkt_type as u32,
+            SKF_AD_IFINDEX => self.ingress.ifindex,
+            SKF_AD_NLATTR => self.find_nlattr(accumulator, index, false),
+            SKF_AD_NLATTR_NEST => self.find_nlattr(accumulator, index, true),
+            SKF_AD_MARK | SKF_AD_QUEUE | SKF_AD_RXHASH => 0,
+            SKF_AD_HATYPE => self.ingress.hatype as u32,
+            SKF_AD_CPU => crate::smp::core::smp_get_processor_id().data(),
+            SKF_AD_VLAN_TAG => self.vlan.map_or(0, |value| value.0 as u32),
+            SKF_AD_VLAN_TAG_PRESENT => u32::from(self.vlan.is_some()),
+            SKF_AD_PAY_OFFSET => self.payload_offset(),
+            SKF_AD_RANDOM => crate::arch::rand::rand() as u32,
+            SKF_AD_VLAN_TPID => self.vlan.map_or(0, |value| value.1 as u32),
+            _ => return None,
+        })
+    }
 }
 
 fn parse_frame(frame: &[u8]) -> Option<ParsedFrame> {
@@ -50,9 +717,9 @@ fn parse_frame(frame: &[u8]) -> Option<ParsedFrame> {
 }
 
 impl PacketSocket {
-    pub(super) fn deliver_from_iface(&self, ifindex: u32, frame: &[u8], pkt_type: PacketType) {
+    pub(super) fn deliver_from_iface(&self, ingress: PacketIngressMetadata, frame: &[u8]) {
         let (bound_ifindex, bound_protocol) = self.binding.load();
-        if bound_protocol == 0 || (bound_ifindex != 0 && bound_ifindex != ifindex) {
+        if bound_protocol == 0 || (bound_ifindex != 0 && bound_ifindex != ingress.ifindex) {
             return;
         }
         let Some(ParsedFrame {
@@ -67,48 +734,47 @@ impl PacketSocket {
         if bound_protocol != eth_protocol::ETH_P_ALL && bound_protocol != protocol {
             return;
         }
-        // Match Linux packet_rcv(): reject a socket whose receive memory is
-        // already full before allocating and copying a private frame. The
-        // atomic reservation below remains the final concurrent admission
-        // check and permits Linux's one-packet bounded overshoot.
+        let input = PacketFilterInput::new(
+            frame,
+            &ParsedFrame {
+                dst,
+                src,
+                protocol,
+                vlan,
+            },
+            self.sock_type,
+            ingress,
+        );
+        let wire_len = input.data_len();
+        let filter_result = self
+            .filter
+            .with_read_if_present(|prog| crate::bpf::classic::run_cbpf(prog, &input))
+            .unwrap_or_else(|| wire_len.min(u32::MAX as usize) as u32);
+        if filter_result == 0 {
+            return;
+        }
+        // Linux runs the socket filter before checking sk_rmem_alloc: a packet
+        // rejected by cBPF is not counted as a receive-buffer drop. Keep this
+        // cheap precheck after the filter and the atomic reservation below as
+        // the final concurrent admission check.
         if self.rx_buffer_bytes.load(Ordering::Acquire)
             >= self.recv_buffer_bytes.load(Ordering::Relaxed)
         {
             self.stats_drops.fetch_add(1, Ordering::Relaxed);
             return;
         }
-        let visible_len = frame
-            .len()
-            .saturating_sub(if vlan.is_some() { 4 } else { 0 });
-        let start = if self.sock_type == PacketSocketType::Raw {
-            0
-        } else {
-            14
-        };
-        let data_len = visible_len - start;
-        // AF_PACKET cBPF filter：has_filter 快路径（无 filter 时零开销）
-        if self.has_filter.load(Ordering::Acquire) {
-            let prog = self.filter.load();
-            if !prog.is_empty() {
-                // filter 运行在 socket 视角的数据上：
-                //   SOCK_RAW → frame[0..]（完整以太网帧）
-                //   SOCK_DGRAM → frame[14..]（L3 payload，MAC 头已剥）
-                let snaplen = crate::bpf::classic::run_cbpf(&prog, &frame[start..]) as usize;
-                if snaplen == 0 {
-                    return; // 包被 filter 丢弃
-                }
-            }
-        }
+        let data_len = wire_len.min(filter_result as usize);
         let metadata = PacketMetadata {
             src_mac: src,
             dst_mac: dst,
             protocol,
-            ifindex,
-            pkt_type,
+            ifindex: ingress.ifindex,
+            hatype: ingress.hatype,
+            pkt_type: ingress.pkt_type,
             // Linux stores origlen after SOCK_DGRAM has advanced data to the
             // network header; without a packet filter, origlen equals the
             // queued visible length for both RAW and DGRAM sockets.
-            wire_len: visible_len - start,
+            wire_len,
             mac_offset: 0,
             net_offset: 14,
             vlan_tci: vlan.map_or(0, |v| v.0),
@@ -136,16 +802,7 @@ impl PacketSocket {
             self.stats_drops.fetch_add(1, Ordering::Relaxed);
             return;
         }
-        if vlan.is_some() {
-            if self.sock_type == PacketSocketType::Raw {
-                data.extend_from_slice(&frame[..12]);
-                data.extend_from_slice(&frame[16..]);
-            } else {
-                data.extend_from_slice(&frame[18..]);
-            }
-        } else {
-            data.extend_from_slice(&frame[start..]);
-        }
+        input.copy_prefix_to(&mut data, data_len);
         let packet = ReceivedPacket {
             data,
             metadata,
@@ -218,7 +875,7 @@ impl PacketSocket {
         let mut ll = LinkLayerEndpoint::new(packet.metadata.ifindex as usize);
         ll.addr[..6].copy_from_slice(&packet.metadata.src_mac);
         ll.protocol = packet.metadata.protocol;
-        ll.hatype = 1;
+        ll.hatype = packet.metadata.hatype;
         ll.pkttype = packet.metadata.pkt_type as u8;
         ll.halen = 6;
         Ok((
@@ -255,7 +912,7 @@ impl PacketSocket {
                 sll_family: 17,
                 sll_protocol: packet.metadata.protocol.to_be(),
                 sll_ifindex: packet.metadata.ifindex as i32,
-                sll_hatype: 1,
+                sll_hatype: packet.metadata.hatype,
                 sll_pkttype: packet.metadata.pkt_type as u8,
                 sll_halen: 6,
                 sll_addr: addr,

--- a/kernel/src/net/socket/packet/rx.rs
+++ b/kernel/src/net/socket/packet/rx.rs
@@ -86,6 +86,19 @@ impl PacketSocket {
             14
         };
         let data_len = visible_len - start;
+        // AF_PACKET cBPF filter：has_filter 快路径（无 filter 时零开销）
+        if self.has_filter.load(Ordering::Acquire) {
+            let prog = self.filter.load();
+            if !prog.is_empty() {
+                // filter 运行在 socket 视角的数据上：
+                //   SOCK_RAW → frame[0..]（完整以太网帧）
+                //   SOCK_DGRAM → frame[14..]（L3 payload，MAC 头已剥）
+                let snaplen = crate::bpf::classic::run_cbpf(&prog, &frame[start..]) as usize;
+                if snaplen == 0 {
+                    return; // 包被 filter 丢弃
+                }
+            }
+        }
         let metadata = PacketMetadata {
             src_mac: src,
             dst_mac: dst,

--- a/kernel/src/net/socket/packet/sockopt.rs
+++ b/kernel/src/net/socket/packet/sockopt.rs
@@ -1,6 +1,8 @@
+use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU64, Ordering};
 use system_error::SystemError;
 
+use crate::bpf::classic::{self, validate_cbpf};
 use crate::net::socket::common::{
     parse_socket_buffer_size, parse_timeval_ticks, write_i32_getsockopt, write_timeval_ticks,
     write_u32_getsockopt, INFINITE_TIMEOUT_TICKS, SOCK_MIN_RCVBUF, SOCK_MIN_SNDBUF,
@@ -91,6 +93,36 @@ impl PacketSocket {
                 let timeout = self.socket_timeout_ticks(name)?;
                 let ticks = parse_timeval_ticks(val)?.unwrap_or(INFINITE_TIMEOUT_TICKS);
                 timeout.store(ticks, Ordering::Relaxed);
+                Ok(())
+            }
+            Ok(PSO::ATTACH_FILTER) => {
+                // SO_LOCK_FILTER 后不可修改
+                if self.filter_locked.load(Ordering::Acquire) {
+                    return Err(SystemError::EINVAL);
+                }
+                // 从 optval 解析 sock_fprog + 读取 filter 指令
+                let insns = classic::read_sock_fprog(val)?;
+                // 通用 cBPF 验证
+                validate_cbpf(&insns)?;
+                // 先 store filter，再置 has_filter=true（Release 序确保可见性）
+                self.filter.store_deferred(Arc::new(insns));
+                self.has_filter.store(true, Ordering::Release);
+                Ok(())
+            }
+            Ok(PSO::DETACH_FILTER) => {
+                if self.filter_locked.load(Ordering::Acquire) {
+                    return Err(SystemError::EINVAL);
+                }
+                // Linux：未安装 filter 时返回 ENOENT
+                if !self.has_filter.swap(false, Ordering::AcqRel) {
+                    return Err(SystemError::ENOENT);
+                }
+                self.filter.store_deferred(Arc::new(alloc::vec![]));
+                Ok(())
+            }
+            Ok(PSO::LOCK_FILTER) => {
+                // 不可逆：一旦锁定不可解锁（Linux 语义）
+                self.filter_locked.store(true, Ordering::Release);
                 Ok(())
             }
             _ => Err(SystemError::ENOPROTOOPT),

--- a/kernel/src/net/socket/packet/sockopt.rs
+++ b/kernel/src/net/socket/packet/sockopt.rs
@@ -9,6 +9,7 @@ use crate::net::socket::common::{
     SYSCTL_RMEM_MAX, SYSCTL_WMEM_MAX,
 };
 use crate::net::socket::{PSO, PSOL};
+use crate::rcu::rcu_defer_drop;
 
 use super::{packet_option, PacketSocket};
 
@@ -96,33 +97,51 @@ impl PacketSocket {
                 Ok(())
             }
             Ok(PSO::ATTACH_FILTER) => {
-                // SO_LOCK_FILTER 后不可修改
-                if self.filter_locked.load(Ordering::Acquire) {
-                    return Err(SystemError::EINVAL);
+                let fprog = classic::parse_sock_fprog(val)?;
+                // Linux checks SOCK_FILTER_LOCKED after copying the fprog
+                // header, but before validating or reading its instruction
+                // pointer. Keep the final check below to close the race with
+                // a concurrent SO_LOCK_FILTER.
+                if *self.filter_locked.lock() {
+                    return Err(SystemError::EPERM);
                 }
-                // 从 optval 解析 sock_fprog + 读取 filter 指令
-                let insns = classic::read_sock_fprog(val)?;
-                // 通用 cBPF 验证
+                let insns = classic::read_sock_fprog_insns(&fprog)?;
                 validate_cbpf(&insns)?;
-                // 先 store filter，再置 has_filter=true（Release 序确保可见性）
-                self.filter.store_deferred(Arc::new(insns));
-                self.has_filter.store(true, Ordering::Release);
+                let new_filter = Arc::try_new(insns).map_err(|_| SystemError::ENOMEM)?;
+
+                let old_filter = {
+                    let locked = self.filter_locked.lock();
+                    if *locked {
+                        return Err(SystemError::EPERM);
+                    }
+                    self.filter.swap(Some(new_filter))
+                };
+                if let Some(old_filter) = old_filter {
+                    rcu_defer_drop(old_filter);
+                }
                 Ok(())
             }
             Ok(PSO::DETACH_FILTER) => {
-                if self.filter_locked.load(Ordering::Acquire) {
-                    return Err(SystemError::EINVAL);
-                }
-                // Linux：未安装 filter 时返回 ENOENT
-                if !self.has_filter.swap(false, Ordering::AcqRel) {
-                    return Err(SystemError::ENOENT);
-                }
-                self.filter.store_deferred(Arc::new(alloc::vec![]));
+                // Linux's SOL_SOCKET path validates and reads an int even
+                // though SO_DETACH_FILTER does not use its value.
+                let _ = Self::parse_i32(val)?;
+                let old_filter = {
+                    let locked = self.filter_locked.lock();
+                    if *locked {
+                        return Err(SystemError::EPERM);
+                    }
+                    self.filter.swap(None).ok_or(SystemError::ENOENT)?
+                };
+                rcu_defer_drop(old_filter);
                 Ok(())
             }
             Ok(PSO::LOCK_FILTER) => {
-                // 不可逆：一旦锁定不可解锁（Linux 语义）
-                self.filter_locked.store(true, Ordering::Release);
+                let lock_filter = Self::parse_i32(val)? != 0;
+                let mut locked = self.filter_locked.lock();
+                if *locked && !lock_filter {
+                    return Err(SystemError::EPERM);
+                }
+                *locked = lock_filter;
                 Ok(())
             }
             _ => Err(SystemError::ENOPROTOOPT),
@@ -142,6 +161,10 @@ impl PacketSocket {
                 let ticks = self.socket_timeout_ticks(name)?.load(Ordering::Relaxed);
                 Ok(write_timeval_ticks(value, ticks))
             }
+            Ok(PSO::LOCK_FILTER) => Ok(write_i32_getsockopt(
+                value,
+                *self.filter_locked.lock() as i32,
+            )),
             _ => Err(SystemError::ENOPROTOOPT),
         }
     }

--- a/kernel/src/net/syscall/sys_setsockopt.rs
+++ b/kernel/src/net/syscall/sys_setsockopt.rs
@@ -4,7 +4,7 @@ use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_SETSOCKOPT;
 use crate::mm::VirtAddr;
 use crate::net::socket;
-use crate::net::socket::{PIPV6, PSOL};
+use crate::net::socket::{PIPV6, PSO, PSOL};
 use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::UserBufferReader;
@@ -50,6 +50,33 @@ impl Syscall for SysSetsockoptHandle {
         let mut optlen_to_read = optlen;
         if level == PSOL::IPV6 as usize && optname == PIPV6::CHECKSUM as usize {
             optlen_to_read = core::mem::size_of::<i32>();
+        }
+        // Linux validates the integer length before touching optval, then
+        // consumes only the leading int even when a longer buffer is supplied.
+        let filter_int_option = level == PSOL::SOCKET as usize
+            && matches!(
+                PSO::try_from(optname as u32),
+                Ok(PSO::DETACH_FILTER | PSO::LOCK_FILTER)
+            );
+        if filter_int_option {
+            if optlen < core::mem::size_of::<i32>() {
+                return Err(SystemError::EINVAL);
+            }
+            optlen_to_read = core::mem::size_of::<i32>();
+        }
+        // Linux's generic SOL_SOCKET path first reads an int. For a malformed
+        // SO_ATTACH_FILTER length, preserve that access/error ordering, then
+        // pass a four-byte slice so the fprog parser returns EINVAL. Only the
+        // exact native layout causes the full structure to be read.
+        let attach_filter = level == PSOL::SOCKET as usize
+            && matches!(PSO::try_from(optname as u32), Ok(PSO::ATTACH_FILTER));
+        if attach_filter {
+            if optlen < core::mem::size_of::<i32>() {
+                return Err(SystemError::EINVAL);
+            }
+            if optlen != core::mem::size_of::<crate::bpf::classic::SockFprog>() {
+                optlen_to_read = core::mem::size_of::<i32>();
+            }
         }
 
         // Verify optval address validity if from user space

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -9,7 +9,7 @@ use crate::net::routing::Router;
 use crate::net::socket::netlink::table::{
     generate_supported_netlink_kernel_sockets, NetlinkKernelSocket, NetlinkSocketTable,
 };
-use crate::net::socket::packet::{PacketSocket, PacketType};
+use crate::net::socket::packet::{PacketIngressMetadata, PacketSocket};
 use crate::net::socket::unix::ns::UnixAbstractTable;
 use crate::process::fork::CloneFlags;
 use crate::process::kthread::{KernelThreadClosure, KernelThreadMechanism};
@@ -440,17 +440,12 @@ impl NetNamespace {
 
     /// Deliver an ingress frame without taking a sleeping lock or allocating a
     /// temporary registry copy in the NAPI read-side path.
-    pub fn deliver_to_packet_sockets(
-        &self,
-        ingress_ifindex: u32,
-        frame: &[u8],
-        pkt_type: PacketType,
-    ) {
+    pub(crate) fn deliver_to_packet_sockets(&self, ingress: PacketIngressMetadata, frame: &[u8]) {
         let snapshot = self.packet_sockets.load();
         let mut stale = false;
         for socket in snapshot.sockets.iter() {
             if let Some(socket) = socket.upgrade() {
-                socket.deliver(ingress_ifindex, frame, pkt_type);
+                socket.deliver(ingress, frame);
             } else {
                 stale = true;
             }

--- a/kernel/src/process/seccomp.rs
+++ b/kernel/src/process/seccomp.rs
@@ -11,9 +11,7 @@ use core::sync::atomic::Ordering;
 use log::warn;
 use system_error::SystemError;
 
-use crate::bpf::classic::{
-    self, validate_cbpf, SockFilter, BPF_ABS, BPF_IND, BPF_LD, BPF_LDX, BPF_W,
-};
+use crate::bpf::classic::{self, BpfWidth, ClassicBpfInput, SockFilter};
 use crate::{
     arch::{interrupt::TrapFrame, ipc::signal::Signal},
     ipc::signal_types::{SaHandlerType, SigCode, SigInfo, SigType, SigactionType, SignalFlags},
@@ -173,8 +171,8 @@ impl SeccompFilter {
 
     /// 执行此过滤器
     fn run(&self, data: &SeccompData) -> u32 {
-        let data_bytes = seccomp_data_to_bytes(data);
-        let result = classic::run_cbpf(&self.insns, &data_bytes);
+        let input = SeccompBpfInput(data);
+        let result = classic::run_cbpf(&self.insns, &input);
 
         // 如果启用了 log 且结果不是 ALLOW，记录日志
         if self.log && (result & SECCOMP_RET_ACTION_FULL) != SECCOMP_RET_ALLOW {
@@ -185,33 +183,44 @@ impl SeccompFilter {
     }
 }
 
-// ============ Seccomp Data 序列化 ============
+struct SeccompBpfInput<'a>(&'a SeccompData);
 
-/// 将 `SeccompData` 序列化为 cBPF 解释器期望的大端字节缓冲区。
-///
-/// `bpf::classic::run_cbpf` 使用 `from_be_bytes` 加载数据（与 Linux
-/// `get_unaligned_be32` 一致），因此将每个字段以大端序写入。
-/// 对于 u64 字段，按主机结构体中的 u32 字顺序拆分后各自转大端，
-/// 确保从任意偏移加载 u32 的结果与原 `from_ne_bytes` 语义一致。
-fn seccomp_data_to_bytes(data: &SeccompData) -> [u8; SECCOMP_DATA_SIZE] {
-    let mut buf = [0u8; SECCOMP_DATA_SIZE];
-    buf[0..4].copy_from_slice(&(data.nr as u32).to_be_bytes());
-    buf[4..8].copy_from_slice(&data.arch.to_be_bytes());
-    write_u64_words(&mut buf[8..16], data.instruction_pointer);
-    for i in 0..6 {
-        write_u64_words(&mut buf[16 + i * 8..24 + i * 8], data.args[i]);
+impl ClassicBpfInput for SeccompBpfInput<'_> {
+    #[inline]
+    fn len(&self) -> u32 {
+        SECCOMP_DATA_SIZE as u32
     }
-    buf
+
+    fn load(&self, offset: i32, width: BpfWidth) -> Option<u32> {
+        if width != BpfWidth::Word || offset < 0 || offset & 3 != 0 {
+            return None;
+        }
+
+        let offset = offset as usize;
+        match offset {
+            0 => Some(self.0.nr as u32),
+            4 => Some(self.0.arch),
+            8 | 12 => Some(native_u64_word(
+                self.0.instruction_pointer,
+                (offset - 8) / 4,
+            )),
+            16..SECCOMP_DATA_SIZE => {
+                let relative = offset - 16;
+                let arg = *self.0.args.get(relative / 8)?;
+                Some(native_u64_word(arg, (relative % 8) / 4))
+            }
+            _ => None,
+        }
+    }
 }
 
-/// 将 u64 按主机原生字顺序拆分为两个 u32 字，各自以大端写入。
 #[inline]
-fn write_u64_words(buf: &mut [u8], val: u64) {
-    let raw = val.to_ne_bytes();
-    let w0 = u32::from_ne_bytes([raw[0], raw[1], raw[2], raw[3]]);
-    let w1 = u32::from_ne_bytes([raw[4], raw[5], raw[6], raw[7]]);
-    buf[0..4].copy_from_slice(&w0.to_be_bytes());
-    buf[4..8].copy_from_slice(&w1.to_be_bytes());
+fn native_u64_word(value: u64, index: usize) -> u32 {
+    #[cfg(target_endian = "little")]
+    let shift = index * 32;
+    #[cfg(target_endian = "big")]
+    let shift = (1 - index) * 32;
+    (value >> shift) as u32
 }
 
 // ============ BPF 验证器 ============
@@ -223,32 +232,23 @@ fn write_u64_words(buf: &mut [u8], val: u64) {
 /// 2. 不允许 BPF_IND 变址加载
 /// 3. BPF_ABS 偏移必须在 SeccompData 范围内且 4 字节对齐
 fn validate_seccomp_filter(insns: &[SockFilter]) -> Result<(), SystemError> {
-    // 通用检查：非空、长度上限、末条 RET、跳转目标、mem 边界、div/mod k!=0
-    validate_cbpf(insns)?;
+    classic::validate_cbpf(insns)?;
 
     for insn in insns {
-        let class = insn.code & 0x07;
-        if class == BPF_LD || class == BPF_LDX {
-            let mode = insn.code & 0xe0;
-            let size = insn.code & 0x18;
-
-            // seccomp 不允许 BPF_IND
-            if mode == BPF_IND {
-                return Err(SystemError::EINVAL);
-            }
-
-            // seccomp 只允许 BPF_W 加载（ABS 模式）
-            if mode == BPF_ABS && size != BPF_W {
-                return Err(SystemError::EINVAL);
-            }
-
-            // ABS 偏移必须在 SeccompData 范围内且 4 字节对齐
-            if mode == BPF_ABS {
+        match insn.code {
+            0x20 => {
                 let offset = insn.k as usize;
                 if !offset.is_multiple_of(4) || offset.saturating_add(4) > SECCOMP_DATA_SIZE {
                     return Err(SystemError::EINVAL);
                 }
             }
+            // 与 Linux seccomp_check_filter 的显式白名单一致。特别地，通用
+            // socket cBPF 接受 MOD，而 seccomp ABI 不接受 MOD K/X。
+            0x06 | 0x16 | 0x04 | 0x0c | 0x14 | 0x1c | 0x24 | 0x2c | 0x34 | 0x3c | 0x54 | 0x5c
+            | 0x44 | 0x4c | 0xa4 | 0xac | 0x64 | 0x6c | 0x74 | 0x7c | 0x84 | 0x00 | 0x01 | 0x80
+            | 0x81 | 0x60 | 0x61 | 0x02 | 0x03 | 0x07 | 0x87 | 0x05 | 0x15 | 0x1d | 0x35 | 0x3d
+            | 0x25 | 0x2d | 0x45 | 0x4d => {}
+            _ => return Err(SystemError::EINVAL),
         }
     }
 

--- a/kernel/src/process/seccomp.rs
+++ b/kernel/src/process/seccomp.rs
@@ -11,6 +11,9 @@ use core::sync::atomic::Ordering;
 use log::warn;
 use system_error::SystemError;
 
+use crate::bpf::classic::{
+    self, validate_cbpf, SockFilter, BPF_ABS, BPF_IND, BPF_LD, BPF_LDX, BPF_W,
+};
 use crate::{
     arch::{interrupt::TrapFrame, ipc::signal::Signal},
     ipc::signal_types::{SaHandlerType, SigCode, SigInfo, SigType, SigactionType, SignalFlags},
@@ -98,85 +101,6 @@ const AUDIT_ARCH_RISCV64: u32 = 243 | AUDIT_ARCH_64BIT | AUDIT_ARCH_LE;
 #[cfg(target_arch = "loongarch64")]
 const AUDIT_ARCH_LOONGARCH64: u32 = 258 | AUDIT_ARCH_64BIT | AUDIT_ARCH_LE;
 
-// ============ Sock Filter / Sock Fprog ============
-
-/// Classic BPF 指令（对应 Linux struct sock_filter，8 字节）
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct SockFilter {
-    pub code: u16,
-    pub jt: u8,
-    pub jf: u8,
-    pub k: u32,
-}
-
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct SockFprog {
-    pub len: u16,
-    _pad: [u8; 6],
-    pub filter: u64,
-}
-
-// ============ BPF 指令常量 ============
-// 参考 Linux include/uapi/linux/filter.h
-
-// 指令类型
-const BPF_LD: u16 = 0x00;
-const BPF_LDX: u16 = 0x01;
-const BPF_ST: u16 = 0x02;
-const BPF_STX: u16 = 0x03;
-const BPF_ALU: u16 = 0x04;
-const BPF_JMP: u16 = 0x05;
-const BPF_RET: u16 = 0x06;
-const BPF_MISC: u16 = 0x07;
-
-// 操作数宽度
-#[allow(dead_code)]
-const BPF_W: u16 = 0x00;
-
-// 寻址模式
-const BPF_IMM: u16 = 0x00;
-const BPF_ABS: u16 = 0x20;
-const BPF_MEM: u16 = 0x60;
-const BPF_LEN: u16 = 0x80;
-
-// 数据源
-const BPF_K: u16 = 0x00;
-const BPF_X: u16 = 0x08;
-const BPF_A: u16 = 0x10;
-const BPF_RVAL_MASK: u16 = 0x18;
-
-// ALU 操作
-const BPF_ADD: u16 = 0x00;
-const BPF_SUB: u16 = 0x10;
-const BPF_MUL: u16 = 0x20;
-const BPF_DIV: u16 = 0x30;
-const BPF_OR: u16 = 0x40;
-const BPF_AND: u16 = 0x50;
-const BPF_LSH: u16 = 0x60;
-const BPF_RSH: u16 = 0x70;
-const BPF_NEG: u16 = 0x80;
-const BPF_MOD: u16 = 0x90;
-const BPF_XOR: u16 = 0xa0;
-
-// JMP 操作
-const BPF_JA: u16 = 0x00;
-const BPF_JEQ: u16 = 0x10;
-const BPF_JGT: u16 = 0x20;
-const BPF_JGE: u16 = 0x30;
-const BPF_JSET: u16 = 0x40;
-
-// MISC 操作
-const BPF_TAX: u16 = 0x00;
-const BPF_TXA: u16 = 0x80;
-
-/// BPF 程序最大指令数（Linux 限制）
-const BPF_MAXINSNS: usize = 4096;
-
-/// BPF 记忆体大小（16 个 u32 字）
-const BPF_MEMWORDS: usize = 16;
-
 // ============ Strict 模式白名单 ============
 
 /// SECCOMP_MODE_STRICT 允许的系统调用白名单 (x86_64)
@@ -249,7 +173,8 @@ impl SeccompFilter {
 
     /// 执行此过滤器
     fn run(&self, data: &SeccompData) -> u32 {
-        let result = run_cbpf(&self.insns, data);
+        let data_bytes = seccomp_data_to_bytes(data);
+        let result = classic::run_cbpf(&self.insns, &data_bytes);
 
         // 如果启用了 log 且结果不是 ALLOW，记录日志
         if self.log && (result & SECCOMP_RET_ACTION_FULL) != SECCOMP_RET_ALLOW {
@@ -260,245 +185,69 @@ impl SeccompFilter {
     }
 }
 
-// ============ cBPF 解释器 ============
+// ============ Seccomp Data 序列化 ============
 
-/// 运行 classic BPF 程序
+/// 将 `SeccompData` 序列化为 cBPF 解释器期望的大端字节缓冲区。
 ///
-/// cBPF 寄存器模型：
-/// - A (u32): 累加器
-/// - X (u32): 索引寄存器
-/// - pc: 程序计数器
-/// - mem[16]: 记忆体
-fn run_cbpf(insns: &[SockFilter], data: &SeccompData) -> u32 {
-    let mut a: u32 = 0;
-    let mut x: u32 = 0;
-    let mut pc: usize = 0;
-    let mut mem = [0u32; BPF_MEMWORDS];
-
-    // 将 seccomp_data 转为字节切片以支持任意偏移读取
-    let data_bytes = unsafe {
-        core::slice::from_raw_parts(data as *const SeccompData as *const u8, SECCOMP_DATA_SIZE)
-    };
-
-    while pc < insns.len() {
-        let insn = &insns[pc];
-        let class = insn.code & 0x07;
-
-        match class {
-            BPF_LD => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM => a = insn.k,
-                    BPF_ABS => {
-                        let offset = insn.k as usize;
-                        if offset + 4 <= SECCOMP_DATA_SIZE {
-                            a = u32::from_ne_bytes([
-                                data_bytes[offset],
-                                data_bytes[offset + 1],
-                                data_bytes[offset + 2],
-                                data_bytes[offset + 3],
-                            ]);
-                        }
-                        // 越界读取：保持 A 不变（与 Linux 一致）
-                    }
-                    BPF_MEM => {
-                        if (insn.k as usize) < BPF_MEMWORDS {
-                            a = mem[insn.k as usize];
-                        }
-                    }
-                    BPF_LEN => a = SECCOMP_DATA_SIZE as u32,
-                    _ => {}
-                }
-                pc += 1;
-            }
-            BPF_LDX => {
-                let mode = insn.code & 0xe0;
-                match mode {
-                    BPF_IMM => x = insn.k,
-                    BPF_MEM => {
-                        if (insn.k as usize) < BPF_MEMWORDS {
-                            x = mem[insn.k as usize];
-                        }
-                    }
-                    BPF_LEN => x = SECCOMP_DATA_SIZE as u32,
-                    _ => {}
-                }
-                pc += 1;
-            }
-            BPF_ST => {
-                if (insn.k as usize) < BPF_MEMWORDS {
-                    mem[insn.k as usize] = a;
-                }
-                pc += 1;
-            }
-            BPF_STX => {
-                if (insn.k as usize) < BPF_MEMWORDS {
-                    mem[insn.k as usize] = x;
-                }
-                pc += 1;
-            }
-            BPF_ALU => {
-                let op = insn.code & 0xf0;
-                let src = insn.code & 0x08;
-                let val = if src == BPF_K { insn.k } else { x };
-                match op {
-                    BPF_ADD => a = a.wrapping_add(val),
-                    BPF_SUB => a = a.wrapping_sub(val),
-                    BPF_MUL => a = a.wrapping_mul(val),
-                    BPF_DIV => a = a.checked_div(val).unwrap_or(0),
-                    BPF_OR => a |= val,
-                    BPF_AND => a &= val,
-                    BPF_LSH => a = a.wrapping_shl(val),
-                    BPF_RSH => a = a.wrapping_shr(val),
-                    BPF_NEG => a = a.wrapping_neg(),
-                    BPF_MOD => a = a.checked_rem(val).unwrap_or(0),
-                    BPF_XOR => a ^= val,
-                    _ => {}
-                }
-                pc += 1;
-            }
-            BPF_JMP => {
-                let op = insn.code & 0xf0;
-                if op == BPF_JA {
-                    // 无条件跳转
-                    pc = pc.wrapping_add(1).wrapping_add(insn.k as usize);
-                } else {
-                    // 条件跳转
-                    let src = insn.code & 0x08;
-                    let val = if src == BPF_K { insn.k } else { x };
-                    let cond = match op {
-                        BPF_JEQ => a == val,
-                        BPF_JGT => a > val,
-                        BPF_JGE => a >= val,
-                        BPF_JSET => (a & val) != 0,
-                        _ => false,
-                    };
-                    if cond {
-                        pc += 1 + insn.jt as usize;
-                    } else {
-                        pc += 1 + insn.jf as usize;
-                    }
-                }
-            }
-            BPF_RET => {
-                let rval = insn.code & BPF_RVAL_MASK;
-                return if rval == BPF_K { insn.k } else { a };
-            }
-            BPF_MISC => {
-                let op = insn.code & 0xf8;
-                match op {
-                    BPF_TAX => x = a,
-                    BPF_TXA => a = x,
-                    _ => {}
-                }
-                pc += 1;
-            }
-            _ => {
-                pc += 1;
-            }
-        }
+/// `bpf::classic::run_cbpf` 使用 `from_be_bytes` 加载数据（与 Linux
+/// `get_unaligned_be32` 一致），因此将每个字段以大端序写入。
+/// 对于 u64 字段，按主机结构体中的 u32 字顺序拆分后各自转大端，
+/// 确保从任意偏移加载 u32 的结果与原 `from_ne_bytes` 语义一致。
+fn seccomp_data_to_bytes(data: &SeccompData) -> [u8; SECCOMP_DATA_SIZE] {
+    let mut buf = [0u8; SECCOMP_DATA_SIZE];
+    buf[0..4].copy_from_slice(&(data.nr as u32).to_be_bytes());
+    buf[4..8].copy_from_slice(&data.arch.to_be_bytes());
+    write_u64_words(&mut buf[8..16], data.instruction_pointer);
+    for i in 0..6 {
+        write_u64_words(&mut buf[16 + i * 8..24 + i * 8], data.args[i]);
     }
+    buf
+}
 
-    // 如果程序没有返回指令（不应该通过验证器），默认 KILL_THREAD
-    SECCOMP_RET_KILL_THREAD
+/// 将 u64 按主机原生字顺序拆分为两个 u32 字，各自以大端写入。
+#[inline]
+fn write_u64_words(buf: &mut [u8], val: u64) {
+    let raw = val.to_ne_bytes();
+    let w0 = u32::from_ne_bytes([raw[0], raw[1], raw[2], raw[3]]);
+    let w1 = u32::from_ne_bytes([raw[4], raw[5], raw[6], raw[7]]);
+    buf[0..4].copy_from_slice(&w0.to_be_bytes());
+    buf[4..8].copy_from_slice(&w1.to_be_bytes());
 }
 
 // ============ BPF 验证器 ============
 
-/// 验证 seccomp BPF 程序的合法性
+/// 验证 seccomp BPF 程序的合法性。
 ///
-/// 检查项：
-/// 1. 所有指令都在 seccomp 允许的子集内
-/// 2. 跳转目标不越界
-/// 3. BPF_LD|BPF_W|BPF_ABS 的偏移量在 seccomp_data 范围内且 4 字节对齐
-/// 4. 内存索引 < 16
+/// 先调用通用 `validate_cbpf` 进行结构性检查，再叠加 seccomp 专有限制：
+/// 1. LD/LDX 只允许 BPF_W 宽度（seccomp 不使用 H/B）
+/// 2. 不允许 BPF_IND 变址加载
+/// 3. BPF_ABS 偏移必须在 SeccompData 范围内且 4 字节对齐
 fn validate_seccomp_filter(insns: &[SockFilter]) -> Result<(), SystemError> {
-    if insns.is_empty() {
-        return Err(SystemError::EINVAL);
-    }
-    if insns.len() > BPF_MAXINSNS {
-        return Err(SystemError::EINVAL);
-    }
-    if (insns[insns.len() - 1].code & 0x07) != BPF_RET {
-        return Err(SystemError::EINVAL);
-    }
+    // 通用检查：非空、长度上限、末条 RET、跳转目标、mem 边界、div/mod k!=0
+    validate_cbpf(insns)?;
 
-    for (pc, insn) in insns.iter().enumerate() {
-        match insn.code {
-            code if code == (BPF_LD | BPF_W | BPF_ABS) => {
+    for insn in insns {
+        let class = insn.code & 0x07;
+        if class == BPF_LD || class == BPF_LDX {
+            let mode = insn.code & 0xe0;
+            let size = insn.code & 0x18;
+
+            // seccomp 不允许 BPF_IND
+            if mode == BPF_IND {
+                return Err(SystemError::EINVAL);
+            }
+
+            // seccomp 只允许 BPF_W 加载（ABS 模式）
+            if mode == BPF_ABS && size != BPF_W {
+                return Err(SystemError::EINVAL);
+            }
+
+            // ABS 偏移必须在 SeccompData 范围内且 4 字节对齐
+            if mode == BPF_ABS {
                 let offset = insn.k as usize;
                 if !offset.is_multiple_of(4) || offset.saturating_add(4) > SECCOMP_DATA_SIZE {
                     return Err(SystemError::EINVAL);
                 }
-            }
-            code if code == (BPF_LD | BPF_W | BPF_LEN) => {}
-            code if code == (BPF_LDX | BPF_W | BPF_LEN) => {}
-            code if code == (BPF_LD | BPF_IMM) => {}
-            code if code == (BPF_LDX | BPF_IMM) => {}
-            code if code == (BPF_LD | BPF_MEM) || code == (BPF_LDX | BPF_MEM) => {
-                if insn.k as usize >= BPF_MEMWORDS {
-                    return Err(SystemError::EINVAL);
-                }
-            }
-            code if code == BPF_ST || code == BPF_STX => {
-                if insn.k as usize >= BPF_MEMWORDS {
-                    return Err(SystemError::EINVAL);
-                }
-            }
-            code if code == (BPF_ALU | BPF_ADD | BPF_K)
-                || code == (BPF_ALU | BPF_ADD | BPF_X)
-                || code == (BPF_ALU | BPF_SUB | BPF_K)
-                || code == (BPF_ALU | BPF_SUB | BPF_X)
-                || code == (BPF_ALU | BPF_MUL | BPF_K)
-                || code == (BPF_ALU | BPF_MUL | BPF_X)
-                || code == (BPF_ALU | BPF_DIV | BPF_K)
-                || code == (BPF_ALU | BPF_DIV | BPF_X)
-                || code == (BPF_ALU | BPF_OR | BPF_K)
-                || code == (BPF_ALU | BPF_OR | BPF_X)
-                || code == (BPF_ALU | BPF_AND | BPF_K)
-                || code == (BPF_ALU | BPF_AND | BPF_X)
-                || code == (BPF_ALU | BPF_LSH | BPF_K)
-                || code == (BPF_ALU | BPF_LSH | BPF_X)
-                || code == (BPF_ALU | BPF_RSH | BPF_K)
-                || code == (BPF_ALU | BPF_RSH | BPF_X)
-                || code == (BPF_ALU | BPF_NEG)
-                || code == (BPF_ALU | BPF_XOR | BPF_K)
-                || code == (BPF_ALU | BPF_XOR | BPF_X) =>
-            {
-                if code == (BPF_ALU | BPF_DIV | BPF_K) && insn.k == 0 {
-                    return Err(SystemError::EINVAL);
-                }
-            }
-            code if code == (BPF_JMP | BPF_JA) => {
-                let Some(target) = pc
-                    .checked_add(1)
-                    .and_then(|x| x.checked_add(insn.k as usize))
-                else {
-                    return Err(SystemError::EINVAL);
-                };
-                if target >= insns.len() {
-                    return Err(SystemError::EINVAL);
-                }
-            }
-            code if code == (BPF_JMP | BPF_JEQ | BPF_K)
-                || code == (BPF_JMP | BPF_JEQ | BPF_X)
-                || code == (BPF_JMP | BPF_JGT | BPF_K)
-                || code == (BPF_JMP | BPF_JGT | BPF_X)
-                || code == (BPF_JMP | BPF_JGE | BPF_K)
-                || code == (BPF_JMP | BPF_JGE | BPF_X)
-                || code == (BPF_JMP | BPF_JSET | BPF_K)
-                || code == (BPF_JMP | BPF_JSET | BPF_X) =>
-            {
-                let jt_target = pc + 1 + insn.jt as usize;
-                let jf_target = pc + 1 + insn.jf as usize;
-                if jt_target >= insns.len() || jf_target >= insns.len() {
-                    return Err(SystemError::EINVAL);
-                }
-            }
-            code if code == (BPF_RET | BPF_K) || code == (BPF_RET | BPF_A) => {}
-            code if code == (BPF_MISC | BPF_TAX) || code == (BPF_MISC | BPF_TXA) => {}
-            _ => {
-                return Err(SystemError::EINVAL);
             }
         }
     }
@@ -854,15 +603,14 @@ pub fn seccomp_set_mode_filter(fprog_ptr: u64, flags: u32) -> Result<(), SystemE
     let log = (flags & SECCOMP_FILTER_FLAG_LOG) != 0;
     let tsync = (flags & SECCOMP_FILTER_FLAG_TSYNC) != 0;
 
-    // 从用户空间读取 sock_fprog
-    let fprog = read_sock_fprog(fprog_ptr)?;
+    // 从用户空间读取 sock_fprog 结构（16 字节）
+    let fprog_size = core::mem::size_of::<classic::SockFprog>();
+    let mut fprog_buf = [0u8; core::mem::size_of::<classic::SockFprog>()];
+    let reader = UserBufferReader::new(fprog_ptr as *const u8, fprog_size, true)?;
+    reader.copy_from_user_protected(&mut fprog_buf, 0)?;
 
-    if fprog.len == 0 || fprog.len as usize > BPF_MAXINSNS {
-        return Err(SystemError::EINVAL);
-    }
-
-    // 从用户空间读取 filter 指令
-    let insns = read_filter_insns(fprog.filter, fprog.len as usize)?;
+    // 解析并读取 filter 指令
+    let insns = classic::read_sock_fprog(&fprog_buf)?;
 
     // 获取当前 filter 链头作为 prev
     let prev = current.seccomp_filter.lock().clone();
@@ -984,49 +732,6 @@ fn is_filter_ancestor(
     }
 
     false
-}
-
-/// 从用户空间读取 sock_fprog 结构
-fn read_sock_fprog(ptr: u64) -> Result<SockFprog, SystemError> {
-    let size = core::mem::size_of::<SockFprog>();
-    let mut buf = [0u8; core::mem::size_of::<SockFprog>()];
-
-    let reader = UserBufferReader::new(ptr as *const u8, size, true)?;
-    reader.copy_from_user_protected(&mut buf, 0)?;
-
-    let len = u16::from_ne_bytes([buf[0], buf[1]]);
-    let filter = u64::from_ne_bytes([
-        buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15],
-    ]);
-
-    Ok(SockFprog {
-        len,
-        _pad: [0u8; 6],
-        filter,
-    })
-}
-
-/// 从用户空间读取 filter 指令数组
-fn read_filter_insns(ptr: u64, count: usize) -> Result<Vec<SockFilter>, SystemError> {
-    let insn_size = core::mem::size_of::<SockFilter>();
-    let byte_len = count.checked_mul(insn_size).ok_or(SystemError::EINVAL)?;
-
-    let mut buf = alloc::vec![0u8; byte_len];
-
-    let reader = UserBufferReader::new(ptr as *const u8, byte_len, true)?;
-    reader.copy_from_user_protected(&mut buf, 0)?;
-
-    let mut insns = Vec::with_capacity(count);
-    for chunk in buf.chunks_exact(insn_size) {
-        insns.push(SockFilter {
-            code: u16::from_ne_bytes([chunk[0], chunk[1]]),
-            jt: chunk[2],
-            jf: chunk[3],
-            k: u32::from_ne_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]),
-        });
-    }
-
-    Ok(insns)
 }
 
 /// fork 时复制 seccomp 状态

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -215,6 +215,39 @@ where
         }
     }
 
+    /// Borrows the currently published value for the duration of an RCU
+    /// read-side critical section without incrementing its `Arc` strong count.
+    ///
+    /// The initial null check keeps the common empty-slot path out of RCU
+    /// entirely. A writer may publish a value immediately after that check;
+    /// returning `None` is still a valid snapshot of the slot at the check's
+    /// linearization point. For a non-null observation, the pointer is loaded
+    /// again after entering RCU so a concurrently removed value is never
+    /// dereferenced without grace-period protection.
+    ///
+    /// The closure must not block or otherwise retain the borrowed reference.
+    #[inline]
+    pub fn with_read_if_present<R>(&self, f: impl FnOnce(&T) -> R) -> Option<R> {
+        if self.ptr.load(Ordering::Acquire).is_null() {
+            return None;
+        }
+
+        if !rcu_enabled() {
+            let pinned = self.load()?;
+            return Some(f(&pinned));
+        }
+
+        let _guard = rcu_read_lock();
+        let raw = rcu_dereference(&self.ptr);
+        let current = NonNull::new(raw)?;
+
+        // SAFETY: the pointer was reloaded after entering the RCU read-side
+        // section. A writer removing this slot-owned Arc must defer its drop
+        // until this section completes, and the reference cannot escape the
+        // closure's call.
+        Some(f(unsafe { current.as_ref() }))
+    }
+
     pub fn swap(&self, new: Option<Arc<T>>) -> Option<Arc<T>> {
         let new_raw = new
             .map(|value| Arc::into_raw(value) as *mut T)

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -508,10 +508,20 @@ fn run_pr3_selftest() -> Result<(), &'static str> {
     let option_race_old_drops = Arc::new(AtomicUsize::new(0));
     let option_race_new_drops = Arc::new(AtomicUsize::new(0));
     let option_drop_drops = Arc::new(AtomicUsize::new(0));
+    let option_borrow_old_drops = Arc::new(AtomicUsize::new(0));
+    let option_borrow_new_drops = Arc::new(AtomicUsize::new(0));
 
     let option_slot = RcuOptionArcSlot::new_none();
     if option_slot.load().is_some() {
         return Err("RcuOptionArcSlot::new_none did not start empty");
+    }
+    let empty_closure_called = AtomicBool::new(false);
+    if option_slot
+        .with_read_if_present(|_| empty_closure_called.store(true, Ordering::SeqCst))
+        .is_some()
+        || empty_closure_called.load(Ordering::SeqCst)
+    {
+        return Err("RcuOptionArcSlot::with_read_if_present called the closure for None");
     }
 
     option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {
@@ -549,6 +559,54 @@ fn run_pr3_selftest() -> Result<(), &'static str> {
     }
     if option_replacement_drops.load(Ordering::SeqCst) != 1 {
         return Err("RcuOptionArcSlot replacement object was not dropped after clear");
+    }
+
+    option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {
+        id: 11,
+        drops: option_borrow_old_drops.clone(),
+    })));
+    let borrowed_id = option_slot.with_read_if_present(|borrowed| {
+        let old = option_slot
+            .swap(Some(Arc::new(RcuSelftestDropProbe {
+                id: 12,
+                drops: option_borrow_new_drops.clone(),
+            })))
+            .expect("borrowed optional slot unexpectedly became empty");
+        rcu_defer_drop(old);
+
+        if option_borrow_old_drops.load(Ordering::SeqCst) != 0 {
+            return 0;
+        }
+        borrowed.id
+    });
+    if borrowed_id != Some(11) {
+        return Err("RcuOptionArcSlot::with_read_if_present did not pin the old snapshot");
+    }
+    if option_slot.with_read_if_present(|value| value.id) != Some(12) {
+        return Err("RcuOptionArcSlot::with_read_if_present did not observe the replacement");
+    }
+    rcu_barrier();
+    if option_borrow_old_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot borrowed old snapshot was not dropped after its reader");
+    }
+
+    let cleared_id = option_slot.with_read_if_present(|borrowed| {
+        let old = option_slot
+            .swap(None)
+            .expect("borrowed optional slot unexpectedly became empty before clear");
+        rcu_defer_drop(old);
+
+        if option_borrow_new_drops.load(Ordering::SeqCst) != 0 {
+            return 0;
+        }
+        borrowed.id
+    });
+    if cleared_id != Some(12) || option_slot.with_read_if_present(|_| ()).is_some() {
+        return Err("RcuOptionArcSlot::with_read_if_present clear transition was inconsistent");
+    }
+    rcu_barrier();
+    if option_borrow_new_drops.load(Ordering::SeqCst) != 1 {
+        return Err("RcuOptionArcSlot borrowed cleared snapshot was not dropped after its reader");
     }
 
     option_slot.store_deferred(Some(Arc::new(RcuSelftestDropProbe {

--- a/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
@@ -57,6 +57,20 @@
 #define TP_STATUS_USER 1
 #endif
 
+inline constexpr int kSoAttachFilter = 26;
+
+struct TestSockFilter {
+    uint16_t code;
+    uint8_t jt;
+    uint8_t jf;
+    uint32_t k;
+};
+
+struct TestSockFprog {
+    uint16_t len;
+    TestSockFilter* filter;
+};
+
 namespace {
 
 inline constexpr int kArpPktLen = 28;
@@ -303,6 +317,11 @@ int ProbeIfindex(const std::string& ifname) {
     int idx = GetIfIndex(ctrl, ifname);
     close(ctrl);
     return idx;
+}
+
+int AttachFilter(int fd, TestSockFilter* filter, uint16_t len) {
+    TestSockFprog program{len, filter};
+    return setsockopt(fd, SOL_SOCKET, kSoAttachFilter, &program, sizeof(program));
 }
 
 }  // namespace
@@ -783,6 +802,111 @@ TEST(AfPacketE2E, ReceiveBufferSizeControlsQueuedBytes) {
     EXPECT_GT(small_count, 0);
     EXPECT_GT(large_count, small_count)
         << "sent=" << sent << " small=" << small_count << " large=" << large_count;
+}
+
+TEST(AfPacketE2E, ClassicFilterSnaplenAndRuntimeErrorsAreFailClosed) {
+    const std::string ifname = "veth1";
+    int ifindex = ProbeIfindex(ifname);
+    ASSERT_GE(ifindex, 0) << "veth1 must exist for deterministic cBPF testing";
+
+    auto make_receiver = [ifindex]() {
+        int fd = socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType));
+        if (fd < 0) return fd;
+        struct sockaddr_ll bind_addr{};
+        bind_addr.sll_family = AF_PACKET;
+        bind_addr.sll_protocol = htons(kPrivateEtherType);
+        bind_addr.sll_ifindex = ifindex;
+        if (bind(fd, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
+            close(fd);
+            return -1;
+        }
+        struct timeval tv{1, 0};
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        return fd;
+    };
+
+    FdGuard receiver(make_receiver());
+    FdGuard sender(socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType)));
+    ASSERT_GE(receiver.Get(), 0) << ErrnoString(errno);
+    ASSERT_GE(sender.Get(), 0) << ErrnoString(errno);
+
+    uint8_t local_mac[6];
+    GetIfHwaddr(sender.Get(), ifname, local_mac);
+    uint8_t frame[96]{};
+    std::memset(frame, 0xff, 6);
+    std::memcpy(frame + 6, local_mac, 6);
+    frame[12] = static_cast<uint8_t>(kPrivateEtherType >> 8);
+    frame[13] = static_cast<uint8_t>(kPrivateEtherType);
+    struct sockaddr_ll dst{};
+    dst.sll_family = AF_PACKET;
+    dst.sll_protocol = htons(kPrivateEtherType);
+    dst.sll_ifindex = ifindex;
+    dst.sll_hatype = ARPHRD_ETHER;
+    dst.sll_halen = ETH_ALEN;
+    std::memset(dst.sll_addr, 0xff, ETH_ALEN);
+
+    auto send_one = [&]() {
+        ASSERT_EQ(sendto(sender.Get(), frame, sizeof(frame), 0,
+                         reinterpret_cast<sockaddr*>(&dst), sizeof(dst)),
+                  static_cast<ssize_t>(sizeof(frame)))
+            << ErrnoString(errno);
+    };
+
+    TestSockFilter snap_to_eight[] = {{0x06, 0, 0, 8}};  // RET #8
+    ASSERT_EQ(AttachFilter(receiver.Get(), snap_to_eight, 1), 0) << ErrnoString(errno);
+    send_one();
+    uint8_t buffer[128]{};
+    EXPECT_EQ(recv(receiver.Get(), buffer, sizeof(buffer), MSG_TRUNC), 8)
+        << "MSG_TRUNC must report filtered snaplen";
+
+    TestSockFilter oob_then_accept[] = {
+        {0x20, 0, 0, 0x7fffffffU},  // LD W ABS, runtime OOB
+        {0x06, 0, 0, 0xffffffffU},
+    };
+    ASSERT_EQ(AttachFilter(receiver.Get(), oob_then_accept, 2), 0) << ErrnoString(errno);
+    send_one();
+    errno = 0;
+    EXPECT_EQ(recv(receiver.Get(), buffer, sizeof(buffer), 0), -1);
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << ErrnoString(errno);
+
+    TestSockFilter divide_by_zero_then_accept[] = {
+        {0x01, 0, 0, 0},           // LDX IMM #0
+        {0x3c, 0, 0, 0},           // DIV X
+        {0x06, 0, 0, 0xffffffffU},
+    };
+    ASSERT_EQ(AttachFilter(receiver.Get(), divide_by_zero_then_accept, 3), 0)
+        << ErrnoString(errno);
+    send_one();
+    errno = 0;
+    EXPECT_EQ(recv(receiver.Get(), buffer, sizeof(buffer), 0), -1);
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << ErrnoString(errno);
+
+    FdGuard arp_receiver(socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ARP)));
+    ASSERT_GE(arp_receiver.Get(), 0) << ErrnoString(errno);
+    struct sockaddr_ll arp_bind{};
+    arp_bind.sll_family = AF_PACKET;
+    arp_bind.sll_protocol = htons(ETH_P_ARP);
+    arp_bind.sll_ifindex = ifindex;
+    ASSERT_EQ(bind(arp_receiver.Get(), reinterpret_cast<sockaddr*>(&arp_bind), sizeof(arp_bind)), 0)
+        << ErrnoString(errno);
+    struct timeval timeout{1, 0};
+    ASSERT_EQ(setsockopt(arp_receiver.Get(), SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                         sizeof(timeout)),
+              0);
+    TestSockFilter pay_offset[] = {
+        {0x20, 0, 0, 0xfffff034U},  // LD W ABS SKF_AD_OFF + SKF_AD_PAY_OFFSET
+        {0x16, 0, 0, 0},            // RET A
+    };
+    ASSERT_EQ(AttachFilter(arp_receiver.Get(), pay_offset, 2), 0) << ErrnoString(errno);
+    frame[12] = static_cast<uint8_t>(ETH_P_ARP >> 8);
+    frame[13] = static_cast<uint8_t>(ETH_P_ARP);
+    dst.sll_protocol = htons(ETH_P_ARP);
+    ASSERT_EQ(sendto(sender.Get(), frame, sizeof(frame), 0,
+                     reinterpret_cast<sockaddr*>(&dst), sizeof(dst)),
+              static_cast<ssize_t>(sizeof(frame)))
+        << ErrnoString(errno);
+    EXPECT_EQ(recv(arp_receiver.Get(), buffer, sizeof(buffer), MSG_TRUNC), kEthHdrLen)
+        << "Linux skb_get_poff returns the network offset for ARP";
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
@@ -43,6 +43,15 @@ inline constexpr int kSoRcvtimeoNew = 66;
 inline constexpr int kSoSndtimeoNew = 67;
 inline constexpr int kSoAttachFilter = 26;
 inline constexpr int kSoDetachFilter = 27;
+inline constexpr int kSoLockFilter = 44;
+
+// Classic BPF encodings used here are kept local because DragonOS musl may
+// not ship linux/filter.h in every test image.
+inline constexpr uint16_t kBpfLdWAbs = 0x20;
+inline constexpr uint16_t kBpfLdWInd = 0x40;
+inline constexpr uint16_t kBpfLdMem = 0x60;
+inline constexpr uint16_t kBpfLshK = 0x64;
+inline constexpr uint16_t kBpfRetK = 0x06;
 
 struct TestSockFilter {
     uint16_t code;
@@ -414,6 +423,139 @@ TEST(AfPacketSockopt, DetachFilterReturnsEnoentWhenNoFilter) {
     errno = 0;
     int dummy = 0;
     EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, &dummy, sizeof(dummy)), -1);
+    EXPECT_EQ(errno, ENOENT) << ErrnoString(errno);
+}
+
+TEST(AfPacketSockopt, ValidatorRejectsMalformedAndUnsafePrograms) {
+    FdGuard fd(MakeRawFd());
+    ASSERT_GE(fd.Get(), 0);
+
+    auto rejected = [&](TestSockFilter* insns, uint16_t len) {
+        TestSockFprog program{len, insns};
+        errno = 0;
+        EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &program,
+                             sizeof(program)),
+                  -1);
+        EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+    };
+
+    TestSockFilter unknown_size[] = {{static_cast<uint16_t>(kBpfRetK | 0x08), 0, 0, 1}};
+    rejected(unknown_size, 1);
+
+    TestSockFilter oversized_shift[] = {
+        {kBpfLshK, 0, 0, 32},
+        {kBpfRetK, 0, 0, 1},
+    };
+    rejected(oversized_shift, 2);
+
+    TestSockFilter uninitialized_mem[] = {
+        {kBpfLdMem, 0, 0, 0},
+        {kBpfRetK, 0, 0, 1},
+    };
+    rejected(uninitialized_mem, 2);
+
+    TestSockFilter runtime_negative_offset[] = {
+        {kBpfLdWInd, 0, 0, 0xffffffffU},
+        {kBpfRetK, 0, 0, 1},
+    };
+    // Linux reserves negative ABS offsets for known SKF_AD_* extensions, but
+    // an IND offset can still wrap negative at runtime and must fail closed.
+    TestSockFprog negative_program{2, runtime_negative_offset};
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &negative_program,
+                         sizeof(negative_program)),
+              0)
+        << ErrnoString(errno);
+}
+
+TEST(AfPacketSockopt, FilterLockUsesValboolAndIsIrreversible) {
+    FdGuard fd(MakeRawFd());
+    ASSERT_GE(fd.Get(), 0);
+    TestSockFilter accept_all{kBpfRetK, 0, 0, 0xffffffffU};
+    TestSockFprog program{1, &accept_all};
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &program,
+                         sizeof(program)),
+              0)
+        << ErrnoString(errno);
+
+    int zero = 0;
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoLockFilter, &zero, sizeof(zero)), 0)
+        << "LOCK_FILTER=0 must not lock: " << ErrnoString(errno);
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, &zero, sizeof(zero)), 0)
+        << ErrnoString(errno);
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &program,
+                         sizeof(program)),
+              0)
+        << ErrnoString(errno);
+
+    int one = 1;
+    ASSERT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoLockFilter, &one, sizeof(one)), 0)
+        << ErrnoString(errno);
+    errno = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, &zero, sizeof(zero)), -1);
+    EXPECT_EQ(errno, EPERM);
+    errno = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoLockFilter, &zero, sizeof(zero)), -1);
+    EXPECT_EQ(errno, EPERM);
+
+    TestSockFprog inaccessible_program{
+        1, reinterpret_cast<TestSockFilter*>(UINTPTR_MAX)};
+    errno = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &inaccessible_program,
+                         sizeof(inaccessible_program)),
+              -1);
+    EXPECT_EQ(errno, EPERM) << "filter lock must be checked before reading instructions";
+}
+
+TEST(AfPacketSockopt, AttachFilterFollowsFprogOptlenAndAccessOrdering) {
+    FdGuard fd(MakeRawFd());
+    ASSERT_GE(fd.Get(), 0);
+
+    for (socklen_t len = 0; len < sizeof(int); ++len) {
+        errno = 0;
+        EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter,
+                             reinterpret_cast<const void*>(UINTPTR_MAX), len),
+                  -1);
+        EXPECT_EQ(errno, EINVAL) << "short optlen must win over bad pointer, len=" << len;
+    }
+
+    errno = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter,
+                         reinterpret_cast<const void*>(UINTPTR_MAX), sizeof(TestSockFprog) + 1),
+              -1);
+    EXPECT_EQ(errno, EFAULT) << "SOL_SOCKET must read the leading int before rejecting size";
+
+    alignas(TestSockFprog) uint8_t oversized[sizeof(TestSockFprog) + 1]{};
+    errno = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, oversized,
+                         sizeof(oversized)),
+              -1);
+    EXPECT_EQ(errno, EINVAL);
+}
+
+TEST(AfPacketSockopt, DetachAndLockFollowIntegerOptlenAbi) {
+    FdGuard fd(MakeRawFd());
+    ASSERT_GE(fd.Get(), 0);
+    int value = 0;
+    for (socklen_t len = 0; len < sizeof(value); ++len) {
+        errno = 0;
+        EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, &value, len), -1);
+        EXPECT_EQ(errno, EINVAL) << "len=" << len;
+
+        errno = 0;
+        EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter,
+                             reinterpret_cast<const void*>(1), len),
+                  -1);
+        EXPECT_EQ(errno, EINVAL) << "short optlen must win over bad pointer, len=" << len;
+    }
+
+    struct {
+        int value;
+        int ignored;
+    } long_value{0, 0x12345678};
+    errno = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, &long_value,
+                         sizeof(long_value)),
+              -1);
     EXPECT_EQ(errno, ENOENT) << ErrnoString(errno);
 }
 

--- a/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
@@ -412,7 +412,8 @@ TEST(AfPacketSockopt, DetachFilterReturnsEnoentWhenNoFilter) {
     FdGuard fd(MakeRawFd());
     ASSERT_GE(fd.Get(), 0);
     errno = 0;
-    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, nullptr, 0), -1);
+    int dummy = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, &dummy, sizeof(dummy)), -1);
     EXPECT_EQ(errno, ENOENT) << ErrnoString(errno);
 }
 

--- a/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
@@ -402,7 +402,7 @@ TEST(AfPacketSockopt, AttachFilterAcceptsValidProgram) {
     FdGuard fd(MakeRawFd());
     ASSERT_GE(fd.Get(), 0);
     TestSockFilter accept_all{0x06, 0, 0, 0xffffffff};
-    TestSockFProg program{1, &accept_all};
+    TestSockFprog program{1, &accept_all};
     errno = 0;
     EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &program, sizeof(program)), 0)
         << ErrnoString(errno);

--- a/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
@@ -42,6 +42,7 @@ inline constexpr int kSoSndtimeoOld = 21;
 inline constexpr int kSoRcvtimeoNew = 66;
 inline constexpr int kSoSndtimeoNew = 67;
 inline constexpr int kSoAttachFilter = 26;
+inline constexpr int kSoDetachFilter = 27;
 
 struct TestSockFilter {
     uint16_t code;
@@ -397,14 +398,22 @@ TEST(AfPacketSockopt, SocketBufferOptionsAreIndependent) {
     EXPECT_EQ(actual, second_default_receive);
 }
 
-TEST(AfPacketSockopt, AttachFilterIsNotSilentlyAccepted) {
+TEST(AfPacketSockopt, AttachFilterAcceptsValidProgram) {
     FdGuard fd(MakeRawFd());
     ASSERT_GE(fd.Get(), 0);
     TestSockFilter accept_all{0x06, 0, 0, 0xffffffff};
-    TestSockFprog program{1, &accept_all};
+    TestSockFProg program{1, &accept_all};
     errno = 0;
-    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &program, sizeof(program)), -1);
-    EXPECT_EQ(errno, ENOPROTOOPT) << ErrnoString(errno);
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoAttachFilter, &program, sizeof(program)), 0)
+        << ErrnoString(errno);
+}
+
+TEST(AfPacketSockopt, DetachFilterReturnsEnoentWhenNoFilter) {
+    FdGuard fd(MakeRawFd());
+    ASSERT_GE(fd.Get(), 0);
+    errno = 0;
+    EXPECT_EQ(setsockopt(fd.Get(), SOL_SOCKET, kSoDetachFilter, nullptr, 0), -1);
+    EXPECT_EQ(errno, ENOENT) << ErrnoString(errno);
 }
 
 TEST(AfPacketSockopt, ReceiveTimeoutOldAndNewRoundTrip) {

--- a/user/apps/tests/dunitest/suites/normal/seccomp.cc
+++ b/user/apps/tests/dunitest/suites/normal/seccomp.cc
@@ -361,6 +361,51 @@ TEST(SeccompTest, UnalignedUserFilterPointerIsParsedSafely) {
   EXPECT_EQ(WEXITSTATUS(status), kOk);
 }
 
+TEST(SeccompTest, RejectsSocketOnlyAndModuloOpcodes) {
+  int status = ChildStatus([] {
+    RequireNoNewPrivs();
+
+    struct sock_filter mod_k[] = {
+        BPF_STMT(BPF_LD | BPF_IMM, 7),
+        BPF_STMT(BPF_ALU | BPF_MOD | BPF_K, 3),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    errno = 0;
+    if (InstallFilter(mod_k, sizeof(mod_k) / sizeof(mod_k[0])) != -1 ||
+        errno != EINVAL) {
+      _exit(3);
+    }
+
+    struct sock_filter mod_x[] = {
+        BPF_STMT(BPF_LDX | BPF_IMM, 3),
+        BPF_STMT(BPF_LD | BPF_IMM, 7),
+        BPF_STMT(BPF_ALU | BPF_MOD | BPF_X, 0),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    errno = 0;
+    if (InstallFilter(mod_x, sizeof(mod_x) / sizeof(mod_x[0])) != -1 ||
+        errno != EINVAL) {
+      _exit(4);
+    }
+
+    struct sock_filter packet_indirect[] = {
+        BPF_STMT(BPF_LDX | BPF_IMM, 0),
+        BPF_STMT(BPF_LD | BPF_W | BPF_IND, 0),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    errno = 0;
+    if (InstallFilter(packet_indirect,
+                      sizeof(packet_indirect) / sizeof(packet_indirect[0])) != -1 ||
+        errno != EINVAL) {
+      _exit(5);
+    }
+    _exit(kOk);
+  });
+
+  ASSERT_TRUE(WIFEXITED(status)) << "status=" << status;
+  EXPECT_EQ(WEXITSTATUS(status), kOk);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary

- align the shared classic BPF validator and interpreter with Linux 6.6 semantics, including exact opcode validation, initialized scratch-memory analysis, fail-closed runtime errors, and fallible allocations
- give seccomp and AF_PACKET dedicated zero-copy input semantics while keeping the common VM independent of packet metadata and seccomp layout details
- implement AF_PACKET ancillary loads, Linux-compatible payload-offset dissection, VLAN-aware logical packet views, and filter-controlled snaplen propagation
- serialize filter attach, detach, and lock operations around one control lock and an optional RCU publication point
- preserve Linux socket-option length, error-ordering, lock, and allocation-failure behavior

## Root cause

The original AF_PACKET filter path treated classic BPF failures as ordinary values, validated instruction encodings too loosely, and used a byte-slice input model that could not represent both socket packet metadata and seccomp data correctly. Filter publication also split state across independent atomics, while filter return values only controlled accept/drop instead of the complete snaplen lifecycle.

This change fixes those responsibilities at their source instead of special-casing the existing tests.

## Validation

- `cargo +nightly-2026-02-24 fmt --check --manifest-path kernel/Cargo.toml`
- `git diff --check`
- `make kernel`
- focused dunitest cross-compilation for AF_PACKET and seccomp
- QEMU nographic guest tests:
  - `af_packet_sockopt_test`: 28/28 passed
  - `af_packet_e2e_test`: 10/10 passed
  - `seccomp_test`: 12/12 passed
  - `rcu_selftest_test`: 2/2 passed

Closes #2031
