### PR TITLE
fix(ext4/xattr): Implement full Xattr block write before header in Linux kernel style

### DIFF
--- a/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
@@ -350,6 +350,7 @@ impl XattrBlock {
     /// Initialize a xattr block, write a `XattrHeader` to the
     /// beginning of the block.
     pub fn init(&mut self) {
+        self.0.data.fill(0);
         let header = XattrHeader::new();
         self.0.write_offset_as(0, &header);
     }


### PR DESCRIPTION
when use some software who use xattr like sed, it will go in to kernel panic .
```
  sed -i 's/d/d/' /etc/apt/sources.list.d/ubuntu.sources
  [ ERROR ] (src/debug/panic/mod.rs:44)    Kernel Panic Occurred. raw_pid: 52
  Location:
          File: /home/donjuan/.rustup/toolchains/nightly-2026-02-24-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/libs
          Line: 1031, Column: 55
  Message:
          range start index 25907 out of range for slice of length 4096
  Rust Panic Backtrace:
  [1] function:_Unwind_Backtrace()        (+) 0051 address:0xffff8000007cebe3
  [2] function:dragonos_kernel::debug::panic::hook::print_stack_trace()   (+) 0215 address:0xffff8000003a8d27
  [3] function:__rustc::rust_begin_unwind()       (+) 0541 address:0xffff8000005a77fd
  [4] function:core::panicking::panic_fmt()       (+) 0044 address:0xffff8000008c6adc
  [5] function:core::slice::index::slice_index_fail()     (+) 0077 address:0xffff8000008ba51d
  [6] function:<another_ext4::ext4_defs::xattr::XattrBlock>::insert()     (+) 1703 address:0xffff8000008adc07
  [7] function:<another_ext4::ext4::Ext4>::setxattr_with_flags::{closure#0}()     (+) 0187 address:0xffff800000870c0b
  [8] function:<another_ext4::ext4::Ext4>::setxattr_with_flags()  (+) 1176 address:0xffff80000088fa48
  [9] function:<dragonos_kernel::filesystem::ext4::inode::LockedExt4Inode as dragonos_kernel::filesystem::vfs::IndexN7
  [10] function:<dragonos_kernel::filesystem::vfs::mount::MountFSInode as dragonos_kernel::filesystem::vfs::IndexNode5
  [11] function:dragonos_kernel::filesystem::vfs::syscall::xattr_utils::do_setxattr()     (+) 0084 address:0xffff80004
  [12] function:dragonos_kernel::filesystem::vfs::syscall::xattr_utils::fd_setxattr()     (+) 0682 address:0xffff8000a
  [13] function:<dragonos_kernel::filesystem::vfs::syscall::sys_fsetxattr::SysFsetxattrHandle as dragonos_kernel::sysc
  [14] function:<dragonos_kernel::syscall::Syscall>::handle()     (+) 0338 address:0xffff8000003fab12
  [15] function:dragonos_kernel::debug::panic::kernel_catch_unwind::<core::result::Result<usize, system_error::System2
  [16] function:syscall_handler()         (+) 0255 address:0xffff8000006cd7df
  [17] function:syscall_64()      (+) 0101 address:0xffff800000147790
  [ ERROR ] (src/debug/panic/mod.rs:109)   Catch Unwind Error: Any { .. }
  [ ERROR ] (src/debug/panic/mod.rs:44)    Kernel Panic Occurred. raw_pid: 52
```

thats because: the init() of XattrBlock not write 0 to xattrblock. 

in linux kernel source `fs/ext4/xattr.c` line 2019
```c
		/* Allocate a buffer where we construct the new block. */
		s->base = kzalloc(sb->s_blocksize, GFP_NOFS);
		error = -ENOMEM;
		if (s->base == NULL)
			goto cleanup;
		header(s->base)->h_magic = cpu_to_le32(EXT4_XATTR_MAGIC);
		header(s->base)->h_blocks = cpu_to_le32(1);
		header(s->base)->h_refcount = cpu_to_le32(1);
		s->first = ENTRY(header(s->base)+1);
		s->here = ENTRY(header(s->base)+1);
		s->end = s->base + sb->s_blocksize;
	
```
`kzalloc` get a buffer filled with 0.

so we need to write the xattr block 0 first then write the header. 