### PR TITLE
fix(user/profile): add /usr/sbin and /sbin for profile

### DIFF
--- a/user/sysconfig/etc/profile
+++ b/user/sysconfig/etc/profile
@@ -1,5 +1,5 @@
 #!/bin/sh
-export PATH=/bin:/usr/bin:/usr/local/bin
+export PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin:/sbin
 # 设置 PS1 环境变量，定义彩色命令行提示符
 # \\e[32m 设置绿色，\\e[34m 设置蓝色，\\e[0m 重置颜色，不可见字符必须用 \[ ... \] 包裹
 # \\u 用户名，\\h 主机名，\\w 当前工作目录


### PR DESCRIPTION
some software  like `ldconfig` are in /sbin or /usr/sbin.
ldconfig is important for dpkg