### PR TITLE
feat(tty): Implement missing TTY termios ioctls (TCSETSF, TCSETA*)

### DIFF
--- a/kernel/src/driver/serial/mod.rs
+++ b/kernel/src/driver/serial/mod.rs
@@ -67,6 +67,7 @@ lazy_static! {
                 | LocalMode::IEXTEN,
             control_characters: INIT_CONTORL_CHARACTERS,
             line: LineDisciplineType::NTty,
+            c_line_abi: 0,
             input_speed: SERIAL_BAUDRATE.data(),
             output_speed: SERIAL_BAUDRATE.data(),
         }

--- a/kernel/src/driver/serial/mod.rs
+++ b/kernel/src/driver/serial/mod.rs
@@ -8,7 +8,7 @@ use crate::mm::VirtAddr;
 use self::serial8250::serial8250_manager;
 
 use super::tty::{
-    termios::{ControlMode, InputMode, LocalMode, OutputMode, Termios, INIT_CONTORL_CHARACTERS},
+    termios::{ControlMode, InputMode, LocalMode, OutputMode, Termios, INIT_C_LINE_ABI, INIT_CONTORL_CHARACTERS},
     tty_ldisc::LineDisciplineType,
 };
 
@@ -67,7 +67,7 @@ lazy_static! {
                 | LocalMode::IEXTEN,
             control_characters: INIT_CONTORL_CHARACTERS,
             line: LineDisciplineType::NTty,
-            c_line_abi: 0,
+            c_line_abi: INIT_C_LINE_ABI,
             input_speed: SERIAL_BAUDRATE.data(),
             output_speed: SERIAL_BAUDRATE.data(),
         }

--- a/kernel/src/driver/serial/mod.rs
+++ b/kernel/src/driver/serial/mod.rs
@@ -8,7 +8,10 @@ use crate::mm::VirtAddr;
 use self::serial8250::serial8250_manager;
 
 use super::tty::{
-    termios::{ControlMode, InputMode, LocalMode, OutputMode, Termios, INIT_C_LINE_ABI, INIT_CONTORL_CHARACTERS},
+    termios::{
+        ControlMode, InputMode, LocalMode, OutputMode, Termios, INIT_CONTORL_CHARACTERS,
+        INIT_C_LINE_ABI,
+    },
     tty_ldisc::LineDisciplineType,
 };
 

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -22,7 +22,7 @@ use crate::{
         tty::{
             console::ConsoleSwitch,
             kthread::{enqueue_tty_rx_byte_to_target_from_irq, TtyInputTarget},
-            termios::WindowSize,
+            termios::{ControlMode, Termios, WindowSize},
             tty_core::{TtyCore, TtyCoreData},
             tty_driver::{TtyDriver, TtyDriverManager, TtyOperation},
             tty_port::TtyInputByteResult,
@@ -39,6 +39,7 @@ use crate::{
     },
     libs::{rwsem::RwSem, spinlock::SpinLock},
     process::ProcessManager,
+    sched::sched_yield,
     time::{sleep::nanosleep, Duration, Instant, PosixTimeSpec},
 };
 use system_error::SystemError;
@@ -138,6 +139,8 @@ pub struct Serial8250PIOPort {
     rx_paused: AtomicBool,
     rx_state: SpinLock<Serial8250RxState>,
     tx_state: SpinLock<Serial8250TxState>,
+    /// Serializes the DLAB register-alias window against runtime UART I/O.
+    hw_lock: SpinLock<()>,
     console_owner: AtomicUsize,
     inner: RwSem<Serial8250PIOPortInner>,
 }
@@ -147,6 +150,7 @@ struct Serial8250RxState {
     input_target: Option<TtyInputTarget>,
     ier: u8,
     irq_registered: bool,
+    receiver_enabled: bool,
 }
 
 #[derive(Debug)]
@@ -174,6 +178,7 @@ impl Serial8250RxState {
             input_target: None,
             ier: 0,
             irq_registered: false,
+            receiver_enabled: true,
         }
     }
 }
@@ -189,6 +194,7 @@ impl Serial8250PIOPort {
             rx_paused: AtomicBool::new(false),
             rx_state: SpinLock::new(Serial8250RxState::new()),
             tx_state: SpinLock::new(Serial8250TxState::new()),
+            hw_lock: SpinLock::new(()),
             console_owner: AtomicUsize::new(SERIAL_8250_CONSOLE_OWNER_NONE),
             inner: RwSem::new(Serial8250PIOPortInner::new()),
         };
@@ -248,9 +254,10 @@ impl Serial8250PIOPort {
     }
 
     const fn check_baudrate(&self, baudrate: &BaudRate) -> Result<(), SystemError> {
-        // 错误的比特率
-        if baudrate.data() > Self::SERIAL8250PIO_MAX_BAUD_RATE.data()
-            || Self::SERIAL8250PIO_MAX_BAUD_RATE.data() % baudrate.data() != 0
+        let baud = baudrate.data();
+        if baud == 0
+            || baud > Self::SERIAL8250PIO_MAX_BAUD_RATE.data()
+            || Self::SERIAL8250PIO_MAX_BAUD_RATE.data().div_ceil(baud) > u16::MAX as u32
         {
             return Err(SystemError::EINVAL);
         }
@@ -274,10 +281,11 @@ impl Serial8250PIOPort {
 
     /// 读取一个字节，如果没有数据则返回None
     fn read_one_byte(&self) -> Option<u8> {
-        if !self.serial_received() {
+        let _guard = self.hw_lock.lock_irqsave();
+        if self.serial_in_raw(5) & 1 == 0 {
             return None;
         }
-        return Some(self.serial_in(0) as u8);
+        Some(self.serial_in_raw(0) as u8)
     }
 
     fn set_input_target(&self, target: Option<TtyInputTarget>) {
@@ -351,15 +359,17 @@ impl Serial8250PIOPort {
             // THRE must be sampled after taking tx_state: both process and
             // IRQ contexts can pump this port, and a pre-lock sample becomes
             // stale as soon as another context fills the FIFO.
-            if self.is_transmit_empty() {
+            let _hw_guard = self.hw_lock.lock_irqsave();
+            if self.serial_in_raw(5) & 0x20 != 0 {
                 while sent < self.tx_fifo_size.load(Ordering::Acquire) {
                     let Some(byte) = queue.pop_front() else {
                         break;
                     };
-                    self.serial_out(0, byte.into());
+                    self.serial_out_raw(0, byte.into());
                     sent += 1;
                 }
             }
+            drop(_hw_guard);
             let pending = !queue.is_empty();
             let pending_after = queue.len();
             let should_wake = pending_before != 0
@@ -628,18 +638,29 @@ impl Serial8250PIOPort {
 
     fn pump_rx(&self) -> Result<(), SystemError> {
         let mut rx_state = self.rx_state.lock_irqsave();
-        let Some(target) = rx_state.input_target.as_ref() else {
+        let Some(target) = rx_state.input_target.clone() else {
             self.rx_paused.store(false, Ordering::Release);
             self.set_rx_interrupt_enabled_locked(&mut rx_state, false);
             return Ok(());
         };
+
+        if !rx_state.receiver_enabled {
+            for _ in 0..SERIAL_8250_RX_IRQ_LIMIT {
+                if self.read_one_byte().is_none() {
+                    break;
+                }
+            }
+            self.rx_paused.store(false, Ordering::Release);
+            self.set_rx_interrupt_enabled_locked(&mut rx_state, true);
+            return Ok(());
+        }
 
         // Linux serial8250_rx_chars also keeps a 256-byte bound to avoid
         // unbounded RX IRQ/softirq CPU occupation.
         let mut received = 0;
         for _ in 0..SERIAL_8250_RX_IRQ_LIMIT {
             let mut producer = || self.read_one_byte();
-            match enqueue_tty_rx_byte_to_target_from_irq(target, &mut producer) {
+            match enqueue_tty_rx_byte_to_target_from_irq(&target, &mut producer) {
                 TtyInputByteResult::Enqueued => {
                     received += 1;
                     self.rx_paused.store(false, Ordering::Release);
@@ -668,6 +689,152 @@ impl Serial8250PIOPort {
         }
         tx_state.tty = tty;
     }
+
+    fn line_control(control_mode: ControlMode) -> u8 {
+        let mut lcr = match control_mode.intersection(ControlMode::CSIZE) {
+            ControlMode::CS5 => 0,
+            ControlMode::CS6 => 1,
+            ControlMode::CS7 => 2,
+            _ => 3,
+        };
+        if control_mode.contains(ControlMode::CSTOPB) {
+            lcr |= 1 << 2;
+        }
+        if control_mode.contains(ControlMode::PARENB) {
+            lcr |= 1 << 3;
+            if !control_mode.contains(ControlMode::PARODD) {
+                lcr |= 1 << 4;
+            }
+        }
+        lcr
+    }
+
+    fn baud_control_mode(baud: u32) -> Option<ControlMode> {
+        Some(match baud {
+            0 => ControlMode::B0,
+            50 => ControlMode::B50,
+            75 => ControlMode::B75,
+            110 => ControlMode::B110,
+            134 => ControlMode::B134,
+            150 => ControlMode::B150,
+            200 => ControlMode::B200,
+            300 => ControlMode::B300,
+            600 => ControlMode::B600,
+            1200 => ControlMode::B1200,
+            1800 => ControlMode::B1800,
+            2400 => ControlMode::B2400,
+            4800 => ControlMode::B4800,
+            9600 => ControlMode::B9600,
+            19200 => ControlMode::B19200,
+            38400 => ControlMode::B38400,
+            57600 => ControlMode::B57600,
+            115200 => ControlMode::B115200,
+            _ => return None,
+        })
+    }
+
+    fn encode_baud_rate(termios: &mut Termios, baud: u32) {
+        let Some(flag) = Self::baud_control_mode(baud) else {
+            return;
+        };
+        let explicit_input_baud = termios.control_mode.intersects(ControlMode::CIBAUD);
+        termios
+            .control_mode
+            .remove(ControlMode::CBAUD | ControlMode::CIBAUD);
+        termios.control_mode.insert(flag);
+        if explicit_input_baud {
+            termios
+                .control_mode
+                .insert(ControlMode::from_bits_truncate(flag.bits() << 16));
+        }
+        termios.input_speed = baud;
+        termios.output_speed = baud;
+    }
+
+    /// Apply the 8250 line settings as one register transaction.
+    ///
+    /// DLAB aliases offsets 0/1 with THR/RBR/IER. The established lock order
+    /// is tx_state -> rx_state -> hw_lock, matching the TX and console paths.
+    fn apply_line_settings(
+        &self,
+        control_mode: ControlMode,
+        requested_baud: u32,
+        fallback_baud: u32,
+    ) -> Result<u32, SystemError> {
+        let visible_baud = if requested_baud == 0 {
+            0
+        } else if requested_baud <= Self::SERIAL8250PIO_MAX_BAUD_RATE.data() {
+            requested_baud
+        } else {
+            if fallback_baud <= Self::SERIAL8250PIO_MAX_BAUD_RATE.data() {
+                fallback_baud
+            } else {
+                Self::SERIAL8250PIO_MAX_BAUD_RATE.data()
+            }
+        };
+        // Linux programs a safe divisor while B0 controls hangup via MCR.
+        let hardware_baud = BaudRate::new(if visible_baud == 0 {
+            9600
+        } else {
+            visible_baud
+        });
+        self.check_baudrate(&hardware_baud)?;
+
+        // Runtime and emergency console paths release tx_state while polling
+        // the UART, but keep console_active set for their whole transaction.
+        let _tx_state = loop {
+            let guard = self.tx_state.lock_irqsave();
+            if !guard.console_active {
+                break guard;
+            }
+            drop(guard);
+            sched_yield();
+        };
+        let mut rx_state = self.rx_state.lock_irqsave();
+        rx_state.receiver_enabled = control_mode.contains(ControlMode::CREAD);
+        let _hw_guard = self.hw_lock.lock_irqsave();
+        let port = self.iobase as u16;
+        let lcr = Self::line_control(control_mode);
+
+        unsafe {
+            // Stop UART interrupts before offset 1 becomes DLM.
+            CurrentPortIOArch::out8(port + 1, 0);
+            let divisor = self.divisor(hardware_baud).0;
+            CurrentPortIOArch::out8(port + 3, lcr | 0x80);
+            CurrentPortIOArch::out8(port, (divisor & 0xff) as u8);
+            CurrentPortIOArch::out8(port + 1, ((divisor >> 8) & 0xff) as u8);
+            CurrentPortIOArch::out8(port + 3, lcr);
+
+            // Only B0 transitions change DTR/RTS; ordinary format changes
+            // preserve independently managed modem-control state.
+            let mcr = CurrentPortIOArch::in8(port + 4);
+            let mcr = if fallback_baud != 0 && visible_baud == 0 {
+                mcr & !0x03
+            } else if fallback_baud == 0 && visible_baud != 0 {
+                mcr | 0x03
+            } else {
+                mcr
+            };
+            CurrentPortIOArch::out8(port + 4, mcr);
+            let ier = if rx_state.irq_registered {
+                rx_state.ier
+            } else {
+                0
+            };
+            CurrentPortIOArch::out8(port + 1, ier);
+        }
+
+        self.baudrate.store(hardware_baud, Ordering::Release);
+        Ok(visible_baud)
+    }
+
+    fn serial_in_raw(&self, offset: u32) -> u32 {
+        unsafe { CurrentPortIOArch::in8(self.iobase as u16 + offset as u16).into() }
+    }
+
+    fn serial_out_raw(&self, offset: u32, value: u32) {
+        unsafe { CurrentPortIOArch::out8(self.iobase as u16 + offset as u16, value as u8) }
+    }
 }
 
 impl Serial8250Port for Serial8250PIOPort {
@@ -682,16 +849,18 @@ impl Serial8250Port for Serial8250PIOPort {
 
 impl UartPort for Serial8250PIOPort {
     fn serial_in(&self, offset: u32) -> u32 {
-        unsafe { CurrentPortIOArch::in8(self.iobase as u16 + offset as u16).into() }
+        let _guard = self.hw_lock.lock_irqsave();
+        self.serial_in_raw(offset)
     }
 
     fn serial_out(&self, offset: u32, value: u32) {
         // warning: pio的串口只能写入8位，因此这里丢弃高24位
-        unsafe { CurrentPortIOArch::out8(self.iobase as u16 + offset as u16, value as u8) }
+        let _guard = self.hw_lock.lock_irqsave();
+        self.serial_out_raw(offset, value)
     }
 
     fn divisor(&self, baud: BaudRate) -> (u32, DivisorFraction) {
-        let divisor = Self::SERIAL8250PIO_MAX_BAUD_RATE.data() / baud.data();
+        let divisor = (Self::SERIAL8250PIO_MAX_BAUD_RATE.data() + baud.data() / 2) / baud.data();
         return (divisor, DivisorFraction::new(0));
     }
 
@@ -856,6 +1025,33 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
 
         while !port.is_transmitter_idle() && Instant::now() < deadline {
             nanosleep(PosixTimeSpec::new(0, 1_000_000))?;
+        }
+        Ok(())
+    }
+
+    fn set_termios(&self, tty: Arc<TtyCore>, old_termios: Termios) -> Result<(), SystemError> {
+        let index = tty.core().index();
+        let port =
+            unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
+        let termios = *tty.core().termios();
+        let applied_baud = port.apply_line_settings(
+            termios.control_mode,
+            termios.output_speed,
+            old_termios.output_speed,
+        )?;
+        if !termios.control_mode.contains(ControlMode::CREAD) {
+            // A full TTY input queue may have paused RX and masked its IRQ.
+            // Drain already-received bytes now so CREAD-off data cannot be
+            // delivered after the receiver is enabled again.
+            port.pump_rx()?;
+        }
+
+        // Linux falls back to the previous supported baud when a request is
+        // outside the hardware range. Keep the cached hardware fields aligned
+        // with the divisor selected above. B0 intentionally remains zero.
+        if applied_baud != termios.output_speed {
+            let mut current = tty.core().termios_write();
+            Serial8250PIOPort::encode_baud_rate(&mut current, applied_baud);
         }
         Ok(())
     }

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -37,7 +37,7 @@ use crate::{
         tasklet::{tasklet_schedule, Tasklet, TaskletData},
         InterruptArch, IrqNumber,
     },
-    filesystem::epoll::EPollEventType,
+    filesystem::epoll::{event_poll::EventPoll, EPollEventType},
     libs::{rwsem::RwSem, spinlock::SpinLock},
     process::ProcessManager,
     sched::sched_yield,
@@ -1274,7 +1274,13 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         let port =
             unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
         port.clear_tx();
+        // Match Linux uart_flush_buffer(): releasing the software TX queue is
+        // a write-readiness transition. Do not call tty_wakeup() here because
+        // signal-character flush can enter with the N_TTY data lock held, and
+        // its synchronous write_wakeup callback would re-enter that lock.
         tty.write_wq().wakeup_all();
+        let events = EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM;
+        let _ = EventPoll::wakeup_epoll(tty.epitems(), events);
         Ok(())
     }
 }

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -37,6 +37,7 @@ use crate::{
         tasklet::{tasklet_schedule, Tasklet, TaskletData},
         InterruptArch, IrqNumber,
     },
+    filesystem::epoll::EPollEventType,
     libs::{rwsem::RwSem, spinlock::SpinLock},
     process::ProcessManager,
     sched::sched_yield,
@@ -57,6 +58,9 @@ const SERIAL_8250_TX_QUEUE_SIZE: usize = 4096;
 const SERIAL_8250_FIFO_SIZE: usize = 16;
 const SERIAL_8250_TX_WAKEUP_CHARS: usize = 256;
 const SERIAL_8250_CONSOLE_OWNER_NONE: usize = usize::MAX;
+/// Linux tty_port_init() defaults closing_wait to 30 seconds. The software
+/// queue and the physical transmitter share this single close-time budget.
+const SERIAL_8250_CLOSE_WAIT: Duration = Duration::from_secs(30);
 
 lazy_static! {
     static ref SERIAL_8250_RX_RETRY_TASKLET: Arc<Tasklet> =
@@ -134,6 +138,7 @@ pub(super) fn serial8250_pio_port_early_init() -> Result<(), SystemError> {
 pub struct Serial8250PIOPort {
     iobase: Serial8250PortBase,
     baudrate: AtomicBaudRate,
+    frame_time_us: AtomicUsize,
     initialized: AtomicBool,
     tx_fifo_size: AtomicUsize,
     rx_paused: AtomicBool,
@@ -189,6 +194,10 @@ impl Serial8250PIOPort {
         let r = Self {
             iobase,
             baudrate: AtomicBaudRate::new(baudrate),
+            // The early console starts in the conventional 8N1 format.
+            frame_time_us: AtomicUsize::new(
+                10_000_000usize.div_ceil(baudrate.data().max(1) as usize),
+            ),
             initialized: AtomicBool::new(false),
             tx_fifo_size: AtomicUsize::new(1),
             rx_paused: AtomicBool::new(false),
@@ -566,10 +575,9 @@ impl Serial8250PIOPort {
     }
 
     fn tx_batch_timeout(&self) -> Duration {
-        let baud = self.baudrate.load(Ordering::Acquire).data().max(1) as u64;
-        let char_time_us = 10_000_000u64.div_ceil(baud);
+        let frame_time_us = self.frame_time_us.load(Ordering::Acquire) as u64;
         Duration::from_micros(
-            (char_time_us * self.tx_fifo_size.load(Ordering::Acquire) as u64 * 2).max(2_000),
+            (frame_time_us * self.tx_fifo_size.load(Ordering::Acquire) as u64 * 2).max(2_000),
         )
     }
 
@@ -584,20 +592,31 @@ impl Serial8250PIOPort {
         true
     }
 
-    fn wait_for_tx_queue_empty(&self) -> Result<bool, SystemError> {
-        let pending = self.tx_pending();
-        if pending == 0 {
-            return Ok(true);
+    fn wait_for_tx_queue_empty_until(
+        &self,
+        tty: &TtyCoreData,
+        deadline: Instant,
+    ) -> Result<bool, SystemError> {
+        let remaining = deadline.saturating_sub(Instant::now());
+        if remaining == Duration::ZERO {
+            return Ok(self.tx_pending() == 0);
         }
-        let baud = self.baudrate.load(Ordering::Acquire).data().max(1) as u64;
-        let char_time_us = 10_000_000u64.div_ceil(baud);
-        let deadline =
-            Instant::now() + Duration::from_micros((char_time_us * pending as u64 * 2).max(2_000));
-        while self.tx_pending() != 0 {
-            if Instant::now() >= deadline {
+        let events = (EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM).bits() as u64;
+        tty.write_wq()
+            .wait_event_interruptible_timeout(events, || self.tx_pending() == 0, remaining)
+            .map(|_| true)
+    }
+
+    fn wait_for_transmitter_idle_until(&self, deadline: Instant) -> Result<bool, SystemError> {
+        let poll_interval_us =
+            (self.frame_time_us.load(Ordering::Acquire) as u64).clamp(1_000, 100_000);
+        while !self.is_transmitter_idle() {
+            let remaining_us = deadline.saturating_sub(Instant::now()).total_micros();
+            if remaining_us == 0 {
                 return Ok(false);
             }
-            nanosleep(PosixTimeSpec::new(0, 1_000_000))?;
+            let sleep_us = poll_interval_us.min(remaining_us);
+            nanosleep(PosixTimeSpec::new(0, sleep_us as i64 * 1_000))?;
         }
         Ok(true)
     }
@@ -707,6 +726,23 @@ impl Serial8250PIOPort {
             }
         }
         lcr
+    }
+
+    fn frame_time_us(control_mode: ControlMode, baudrate: BaudRate) -> usize {
+        let data_bits = match control_mode.intersection(ControlMode::CSIZE) {
+            ControlMode::CS5 => 5,
+            ControlMode::CS6 => 6,
+            ControlMode::CS7 => 7,
+            _ => 8,
+        };
+        let parity_bits = usize::from(control_mode.contains(ControlMode::PARENB));
+        let stop_bits = if control_mode.contains(ControlMode::CSTOPB) {
+            2
+        } else {
+            1
+        };
+        let frame_bits = 1 + data_bits + parity_bits + stop_bits;
+        (frame_bits * 1_000_000).div_ceil(baudrate.data().max(1) as usize)
     }
 
     fn baud_control_mode(baud: u32) -> Option<ControlMode> {
@@ -825,6 +861,10 @@ impl Serial8250PIOPort {
         }
 
         self.baudrate.store(hardware_baud, Ordering::Release);
+        self.frame_time_us.store(
+            Self::frame_time_us(control_mode, hardware_baud),
+            Ordering::Release,
+        );
         Ok(visible_baud)
     }
 
@@ -1013,19 +1053,10 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
             return Err(SystemError::ENODEV);
         }
         let port = unsafe { PIO_PORTS[index].as_ref() }.ok_or(SystemError::ENODEV)?;
-        let baud = port.baudrate.load(Ordering::Acquire).data().max(1) as u64;
-        // 8N1 is ten bits per character. Linux bounds uart_wait_until_sent
-        // to twice the FIFO transmission time when hardware flow control is
-        // disabled.
-        let char_time_us = 10_000_000u64.div_ceil(baud);
-        let timeout = Duration::from_micros(
-            (char_time_us * (port.tx_fifo_size.load(Ordering::Acquire) as u64) * 2).max(2_000),
-        );
-        let deadline = Instant::now() + timeout;
-
-        while !port.is_transmitter_idle() && Instant::now() < deadline {
-            nanosleep(PosixTimeSpec::new(0, 1_000_000))?;
-        }
+        // Linux bounds uart_wait_until_sent to twice the FIFO transmission
+        // time when hardware flow control is disabled.
+        let deadline = Instant::now() + port.tx_batch_timeout();
+        port.wait_for_transmitter_idle_until(deadline)?;
         Ok(())
     }
 
@@ -1068,13 +1099,19 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         let index = tty.core().index();
         let port =
             unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
-        if !port.wait_for_tx_queue_empty().unwrap_or(false) {
+        let close_deadline = Instant::now() + SERIAL_8250_CLOSE_WAIT;
+        let queue_drained = port
+            .wait_for_tx_queue_empty_until(tty.core(), close_deadline)
+            .unwrap_or(false);
+        let physical_deadline = close_deadline.min(Instant::now() + port.tx_batch_timeout());
+        let transmitter_idle = queue_drained
+            && port
+                .wait_for_transmitter_idle_until(physical_deadline)
+                .unwrap_or(false);
+        if !transmitter_idle {
             // A failed/stalled UART must not leak bytes into the next open.
             port.clear_tx();
         }
-        // Linux completes close cleanup even when a signal interrupts the
-        // best-effort physical drain.
-        let _ = self.wait_until_sent(tty.core());
         tty.ldisc().flush_buffer(tty.clone())?;
         Ok(())
     }

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -54,6 +54,9 @@ const SERIAL_8250_PIO_IRQ: IrqNumber = IrqNumber::new(IoApic::VECTOR_BASE as u32
 const SERIAL_8250_RX_IRQ_LIMIT: usize = 256;
 const SERIAL_8250_IER_RX_AVAILABLE: u8 = 0x01;
 const SERIAL_8250_IER_TX_EMPTY: u8 = 0x02;
+const SERIAL_8250_FCR_ENABLE_FIFO: u8 = 0x01;
+const SERIAL_8250_FCR_CLEAR_XMIT: u8 = 0x04;
+const SERIAL_8250_FCR_TRIGGER_14: u8 = 0xc0;
 const SERIAL_8250_TX_QUEUE_SIZE: usize = 4096;
 const SERIAL_8250_FIFO_SIZE: usize = 16;
 const SERIAL_8250_TX_WAKEUP_CHARS: usize = 256;
@@ -406,6 +409,42 @@ impl Serial8250PIOPort {
         self.set_tx_interrupt_enabled(false);
     }
 
+    fn abort_tx(&self) {
+        let mut tx_state = self.tx_state.lock_irqsave();
+        if let Some(queue) = tx_state.queue.as_mut() {
+            queue.clear();
+        }
+        self.set_tx_interrupt_enabled(false);
+
+        // Linux's ordinary uart_flush_buffer() leaves bytes already accepted
+        // by a PIO 8250 alone. A close-time abort is different: Linux follows
+        // it with 8250 shutdown, which resets the hardware FIFOs before a
+        // later open. DragonOS has no separate shutdown callback yet, so do
+        // the transmit-only reset here without discarding pending RX data.
+        if self.tx_fifo_size.load(Ordering::Acquire) > 1 {
+            let _hw_guard = self.hw_lock.lock_irqsave();
+            self.serial_out_raw(
+                2,
+                (SERIAL_8250_FCR_ENABLE_FIFO
+                    | SERIAL_8250_FCR_CLEAR_XMIT
+                    | SERIAL_8250_FCR_TRIGGER_14)
+                    .into(),
+            );
+        }
+    }
+
+    fn write_fifo_if_ready(&self, bytes: &[u8]) -> usize {
+        let _hw_guard = self.hw_lock.lock_irqsave();
+        if self.serial_in_raw(5) & 0x20 == 0 {
+            return 0;
+        }
+        let count = bytes.len().min(self.tx_fifo_size.load(Ordering::Acquire));
+        for byte in &bytes[..count] {
+            self.serial_out_raw(0, (*byte).into());
+        }
+        count
+    }
+
     fn submit_runtime_output(&self, s: &[u8]) {
         // This is the legacy, no-return-value console/debug interface: unlike
         // the TTY write callback it cannot report a short write.  Serialize it
@@ -491,12 +530,20 @@ impl Serial8250PIOPort {
             let count = older_remaining
                 .min(self.tx_fifo_size.load(Ordering::Acquire))
                 .min(queue.len());
-            for _ in 0..count {
-                self.serial_out(0, queue.pop_front().unwrap().into());
-            }
-            older_remaining -= count;
-            if count == 0 {
-                break;
+            let _hw_guard = self.hw_lock.lock_irqsave();
+            let sent = if self.serial_in_raw(5) & 0x20 == 0 {
+                0
+            } else {
+                for _ in 0..count {
+                    self.serial_out_raw(0, queue.pop_front().unwrap().into());
+                }
+                count
+            };
+            drop(_hw_guard);
+            older_remaining -= sent;
+            if sent == 0 {
+                drop(tx_state);
+                continue;
             }
         }
 
@@ -506,11 +553,11 @@ impl Serial8250PIOPort {
                 healthy = false;
                 break;
             }
-            let count = (s.len() - offset).min(self.tx_fifo_size.load(Ordering::Acquire));
-            for byte in &s[offset..offset + count] {
-                self.serial_out(0, (*byte).into());
+            let sent = self.write_fifo_if_ready(&s[offset..]);
+            if sent == 0 {
+                continue;
             }
-            offset += count;
+            offset += sent;
         }
 
         {
@@ -545,8 +592,7 @@ impl Serial8250PIOPort {
         self.set_tx_interrupt_enabled(false);
         drop(tx_state);
 
-        let timeout = self.tx_batch_timeout();
-        if !self.wait_for_thre(timeout) {
+        let Ok(_hw_guard) = self.hw_lock.try_lock_irqsave() else {
             let mut tx_state = self.tx_state.lock_irqsave();
             tx_state.console_active = inherited_console_active;
             let pending = tx_state
@@ -556,13 +602,30 @@ impl Serial8250PIOPort {
                 .unwrap_or(false);
             self.set_tx_interrupt_enabled(pending && !inherited_console_active);
             return;
+        };
+        let deadline = Instant::now() + self.tx_batch_timeout();
+        while self.serial_in_raw(5) & 0x20 == 0 {
+            if Instant::now() >= deadline {
+                drop(_hw_guard);
+                let mut tx_state = self.tx_state.lock_irqsave();
+                tx_state.console_active = inherited_console_active;
+                let pending = tx_state
+                    .queue
+                    .as_ref()
+                    .map(|queue| !queue.is_empty())
+                    .unwrap_or(false);
+                self.set_tx_interrupt_enabled(pending && !inherited_console_active);
+                return;
+            }
+            spin_loop();
         }
         // Atomic diagnostics get one bounded FIFO batch. Longer output is
         // intentionally truncated rather than extending IRQ/exception time.
         let count = s.len().min(self.tx_fifo_size.load(Ordering::Acquire));
         for byte in &s[..count] {
-            self.serial_out(0, (*byte).into());
+            self.serial_out_raw(0, (*byte).into());
         }
+        drop(_hw_guard);
 
         let mut tx_state = self.tx_state.lock_irqsave();
         tx_state.console_active = inherited_console_active;
@@ -1110,7 +1173,7 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
                 .unwrap_or(false);
         if !transmitter_idle {
             // A failed/stalled UART must not leak bytes into the next open.
-            port.clear_tx();
+            port.abort_tx();
         }
         tty.ldisc().flush_buffer(tty.clone())?;
         Ok(())

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -60,6 +60,7 @@ const SERIAL_8250_FCR_TRIGGER_14: u8 = 0xc0;
 const SERIAL_8250_TX_QUEUE_SIZE: usize = 4096;
 const SERIAL_8250_FIFO_SIZE: usize = 16;
 const SERIAL_8250_TX_WAKEUP_CHARS: usize = 256;
+const SERIAL_8250_EMERGENCY_TIMEOUT: Duration = Duration::from_millis(10);
 const SERIAL_8250_CONSOLE_OWNER_NONE: usize = usize::MAX;
 /// Linux tty_port_init() defaults closing_wait to 30 seconds. The software
 /// queue and the physical transmitter share this single close-time budget.
@@ -603,7 +604,11 @@ impl Serial8250PIOPort {
             self.set_tx_interrupt_enabled(pending && !inherited_console_active);
             return;
         };
-        let deadline = Instant::now() + self.tx_batch_timeout();
+        // Emergency output may run with interrupts or preemption disabled.
+        // Keep this independent of the configured baud rate: at B50 the
+        // ordinary FIFO-sized timeout would otherwise grow to several
+        // seconds. Linux's 8250 console likewise bounds an LSR wait to 10 ms.
+        let deadline = Instant::now() + SERIAL_8250_EMERGENCY_TIMEOUT;
         while self.serial_in_raw(5) & 0x20 == 0 {
             if Instant::now() >= deadline {
                 drop(_hw_guard);

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -167,6 +167,7 @@ struct Serial8250TxState {
     queue: Option<VecDeque<u8>>,
     tty: Weak<TtyCore>,
     console_active: bool,
+    flush_generation: usize,
 }
 
 impl Serial8250TxState {
@@ -177,6 +178,7 @@ impl Serial8250TxState {
             queue: None,
             tty: Weak::new(),
             console_active: false,
+            flush_generation: 0,
         }
     }
 }
@@ -407,6 +409,7 @@ impl Serial8250PIOPort {
         if let Some(queue) = tx_state.queue.as_mut() {
             queue.clear();
         }
+        tx_state.flush_generation = tx_state.flush_generation.wrapping_add(1);
         self.set_tx_interrupt_enabled(false);
     }
 
@@ -415,6 +418,7 @@ impl Serial8250PIOPort {
         if let Some(queue) = tx_state.queue.as_mut() {
             queue.clear();
         }
+        tx_state.flush_generation = tx_state.flush_generation.wrapping_add(1);
         self.set_tx_interrupt_enabled(false);
 
         // Linux's ordinary uart_flush_buffer() leaves bytes already accepted
@@ -507,13 +511,14 @@ impl Serial8250PIOPort {
                 }
             }
         }
-        let (mut older_remaining, tty) = {
+        let (mut older_remaining, flush_generation, tty) = {
             let mut tx_state = self.tx_state.lock_irqsave();
             tx_state.console_active = true;
             let pending = tx_state.queue.as_ref().map(VecDeque::len).unwrap_or(0);
+            let flush_generation = tx_state.flush_generation;
             let tty = tx_state.tty.upgrade();
             self.set_tx_interrupt_enabled(false);
-            (pending, tty)
+            (pending, flush_generation, tty)
         };
         let timeout = self.tx_batch_timeout();
         let mut healthy = true;
@@ -524,6 +529,10 @@ impl Serial8250PIOPort {
                 break;
             }
             let mut tx_state = self.tx_state.lock_irqsave();
+            if tx_state.flush_generation != flush_generation {
+                older_remaining = 0;
+                break;
+            }
             let Some(queue) = tx_state.queue.as_mut() else {
                 older_remaining = 0;
                 break;
@@ -531,6 +540,10 @@ impl Serial8250PIOPort {
             let count = older_remaining
                 .min(self.tx_fifo_size.load(Ordering::Acquire))
                 .min(queue.len());
+            if count == 0 {
+                older_remaining = 0;
+                break;
+            }
             let _hw_guard = self.hw_lock.lock_irqsave();
             let sent = if self.serial_in_raw(5) & 0x20 == 0 {
                 0
@@ -588,58 +601,52 @@ impl Serial8250PIOPort {
         let Ok(mut tx_state) = self.tx_state.try_lock_irqsave() else {
             return;
         };
-        let inherited_console_active = tx_state.console_active;
-        tx_state.console_active = true;
-        self.set_tx_interrupt_enabled(false);
-        drop(tx_state);
-
-        let Ok(_hw_guard) = self.hw_lock.try_lock_irqsave() else {
-            let mut tx_state = self.tx_state.lock_irqsave();
-            tx_state.console_active = inherited_console_active;
-            let pending = tx_state
-                .queue
-                .as_ref()
-                .map(|queue| !queue.is_empty())
-                .unwrap_or(false);
-            self.set_tx_interrupt_enabled(pending && !inherited_console_active);
+        let Ok(mut rx_state) = self.rx_state.try_lock_irqsave() else {
             return;
         };
+        let Ok(_hw_guard) = self.hw_lock.try_lock_irqsave() else {
+            return;
+        };
+
+        let inherited_console_active = tx_state.console_active;
+        tx_state.console_active = true;
+        rx_state.ier &= !SERIAL_8250_IER_TX_EMPTY;
+        self.sync_ier_hw_locked(&rx_state);
+
         // Emergency output may run with interrupts or preemption disabled.
         // Keep this independent of the configured baud rate: at B50 the
         // ordinary FIFO-sized timeout would otherwise grow to several
         // seconds. Linux's 8250 console likewise bounds an LSR wait to 10 ms.
         let deadline = Instant::now() + SERIAL_8250_EMERGENCY_TIMEOUT;
+        let mut ready = true;
         while self.serial_in_raw(5) & 0x20 == 0 {
             if Instant::now() >= deadline {
-                drop(_hw_guard);
-                let mut tx_state = self.tx_state.lock_irqsave();
-                tx_state.console_active = inherited_console_active;
-                let pending = tx_state
-                    .queue
-                    .as_ref()
-                    .map(|queue| !queue.is_empty())
-                    .unwrap_or(false);
-                self.set_tx_interrupt_enabled(pending && !inherited_console_active);
-                return;
+                ready = false;
+                break;
             }
             spin_loop();
         }
         // Atomic diagnostics get one bounded FIFO batch. Longer output is
         // intentionally truncated rather than extending IRQ/exception time.
-        let count = s.len().min(self.tx_fifo_size.load(Ordering::Acquire));
-        for byte in &s[..count] {
-            self.serial_out_raw(0, (*byte).into());
+        if ready {
+            let count = s.len().min(self.tx_fifo_size.load(Ordering::Acquire));
+            for byte in &s[..count] {
+                self.serial_out_raw(0, (*byte).into());
+            }
         }
-        drop(_hw_guard);
 
-        let mut tx_state = self.tx_state.lock_irqsave();
         tx_state.console_active = inherited_console_active;
         let pending = tx_state
             .queue
             .as_ref()
             .map(|queue| !queue.is_empty())
             .unwrap_or(false);
-        self.set_tx_interrupt_enabled(pending && !inherited_console_active);
+        if pending && !inherited_console_active {
+            rx_state.ier |= SERIAL_8250_IER_TX_EMPTY;
+        } else {
+            rx_state.ier &= !SERIAL_8250_IER_TX_EMPTY;
+        }
+        self.sync_ier_hw_locked(&rx_state);
     }
 
     fn tx_batch_timeout(&self) -> Duration {
@@ -699,12 +706,18 @@ impl Serial8250PIOPort {
     }
 
     fn sync_ier_locked(&self, rx_state: &Serial8250RxState) {
+        let _hw_guard = self.hw_lock.lock_irqsave();
+        self.sync_ier_hw_locked(rx_state);
+    }
+
+    /// Synchronize IER while the caller holds `hw_lock`.
+    fn sync_ier_hw_locked(&self, rx_state: &Serial8250RxState) {
         let ier = if rx_state.irq_registered {
             rx_state.ier
         } else {
             0
         };
-        self.serial_out(1, ier.into());
+        self.serial_out_raw(1, ier.into());
     }
 
     fn mark_rx_irq_registered(&self) {
@@ -884,8 +897,9 @@ impl Serial8250PIOPort {
         });
         self.check_baudrate(&hardware_baud)?;
 
-        // Runtime and emergency console paths release tx_state while polling
-        // the UART, but keep console_active set for their whole transaction.
+        // The runtime console releases tx_state while polling but keeps
+        // console_active set for the whole transaction. Emergency output
+        // holds a fully try-locked tx_state/rx_state/hw_lock tuple instead.
         let _tx_state = loop {
             let guard = self.tx_state.lock_irqsave();
             if !guard.console_active {

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -2,16 +2,17 @@
 
 use core::{
     hint::spin_loop,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use alloc::{
+    collections::VecDeque,
     string::ToString,
     sync::{Arc, Weak},
 };
 
 use crate::{
-    arch::{driver::apic::ioapic::IoApic, io::PortIOArch, CurrentPortIOArch},
+    arch::{driver::apic::ioapic::IoApic, io::PortIOArch, CurrentIrqArch, CurrentPortIOArch},
     driver::{
         base::device::{
             device_number::{DeviceNumber, Major},
@@ -34,9 +35,11 @@ use crate::{
         irqdesc::{IrqHandleFlags, IrqHandler, IrqReturn},
         manage::irq_manager,
         tasklet::{tasklet_schedule, Tasklet, TaskletData},
-        IrqNumber,
+        InterruptArch, IrqNumber,
     },
     libs::{rwsem::RwSem, spinlock::SpinLock},
+    process::ProcessManager,
+    time::{sleep::nanosleep, Duration, Instant, PosixTimeSpec},
 };
 use system_error::SystemError;
 
@@ -48,6 +51,11 @@ static mut PIO_PORTS: [Option<Serial8250PIOPort>; 8] =
 const SERIAL_8250_PIO_IRQ: IrqNumber = IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4);
 const SERIAL_8250_RX_IRQ_LIMIT: usize = 256;
 const SERIAL_8250_IER_RX_AVAILABLE: u8 = 0x01;
+const SERIAL_8250_IER_TX_EMPTY: u8 = 0x02;
+const SERIAL_8250_TX_QUEUE_SIZE: usize = 4096;
+const SERIAL_8250_FIFO_SIZE: usize = 16;
+const SERIAL_8250_TX_WAKEUP_CHARS: usize = 256;
+const SERIAL_8250_CONSOLE_OWNER_NONE: usize = usize::MAX;
 
 lazy_static! {
     static ref SERIAL_8250_RX_RETRY_TASKLET: Arc<Tasklet> =
@@ -126,8 +134,11 @@ pub struct Serial8250PIOPort {
     iobase: Serial8250PortBase,
     baudrate: AtomicBaudRate,
     initialized: AtomicBool,
+    tx_fifo_size: AtomicUsize,
     rx_paused: AtomicBool,
     rx_state: SpinLock<Serial8250RxState>,
+    tx_state: SpinLock<Serial8250TxState>,
+    console_owner: AtomicUsize,
     inner: RwSem<Serial8250PIOPortInner>,
 }
 
@@ -136,6 +147,25 @@ struct Serial8250RxState {
     input_target: Option<TtyInputTarget>,
     ier: u8,
     irq_registered: bool,
+}
+
+#[derive(Debug)]
+struct Serial8250TxState {
+    queue: Option<VecDeque<u8>>,
+    tty: Weak<TtyCore>,
+    console_active: bool,
+}
+
+impl Serial8250TxState {
+    fn new() -> Self {
+        Self {
+            // The PIO ports are constructed before the heap is available.
+            // Allocate the process-context TX queue later during TTY install.
+            queue: None,
+            tty: Weak::new(),
+            console_active: false,
+        }
+    }
 }
 
 impl Serial8250RxState {
@@ -155,8 +185,11 @@ impl Serial8250PIOPort {
             iobase,
             baudrate: AtomicBaudRate::new(baudrate),
             initialized: AtomicBool::new(false),
+            tx_fifo_size: AtomicUsize::new(1),
             rx_paused: AtomicBool::new(false),
             rx_state: SpinLock::new(Serial8250RxState::new()),
+            tx_state: SpinLock::new(Serial8250TxState::new()),
+            console_owner: AtomicUsize::new(SERIAL_8250_CONSOLE_OWNER_NONE),
             inner: RwSem::new(Serial8250PIOPortInner::new()),
         };
 
@@ -181,6 +214,14 @@ impl Serial8250PIOPort {
                 .unwrap(); // Set baud rate
 
             CurrentPortIOArch::out8(port + 2, 0xC7); // Enable FIFO, clear them, with 14-byte threshold
+                                                     // IIR[7:6] == 11b is the 16550A FIFO-enabled indication.  Older
+                                                     // 8250/16450-compatible hardware only guarantees one THR byte.
+            let fifo_size = if CurrentPortIOArch::in8(port + 2) & 0xC0 == 0xC0 {
+                SERIAL_8250_FIFO_SIZE
+            } else {
+                1
+            };
+            self.tx_fifo_size.store(fifo_size, Ordering::Release);
             CurrentPortIOArch::out8(port + 4, 0x08); // IRQs enabled, RTS/DSR clear (现代计算机上一般都不需要hardware flow control，因此不需要置位RTS/DSR)
             CurrentPortIOArch::out8(port + 4, 0x1E); // Set in loopback mode, test the serial chip
             CurrentPortIOArch::out8(port, 0xAE); // Test serial chip (send byte 0xAE and check if serial returns same byte)
@@ -226,19 +267,9 @@ impl Serial8250PIOPort {
         self.serial_in(5) & 0x20 != 0
     }
 
-    /// 发送字节
-    ///
-    /// ## 参数
-    ///
-    /// - `s`：待发送的字节
-    fn send_bytes(&self, s: &[u8]) {
-        while !self.is_transmit_empty() {
-            spin_loop();
-        }
-
-        for c in s {
-            self.serial_out(0, (*c).into());
-        }
+    /// Both the transmitter FIFO and shift register are empty.
+    fn is_transmitter_idle(&self) -> bool {
+        self.serial_in(5) & 0x40 != 0
     }
 
     /// 读取一个字节，如果没有数据则返回None
@@ -256,6 +287,309 @@ impl Serial8250PIOPort {
     fn set_rx_interrupt_enabled(&self, enabled: bool) {
         let mut rx_state = self.rx_state.lock_irqsave();
         self.set_rx_interrupt_enabled_locked(&mut rx_state, enabled);
+    }
+
+    fn set_tx_interrupt_enabled(&self, enabled: bool) {
+        let mut rx_state = self.rx_state.lock_irqsave();
+        if enabled {
+            rx_state.ier |= SERIAL_8250_IER_TX_EMPTY;
+        } else {
+            rx_state.ier &= !SERIAL_8250_IER_TX_EMPTY;
+        }
+        self.sync_ier_locked(&rx_state);
+    }
+
+    fn enqueue_tx(&self, buf: &[u8]) -> usize {
+        let accepted = {
+            let mut tx_state = self.tx_state.lock_irqsave();
+            let Some(queue) = tx_state.queue.as_mut() else {
+                return 0;
+            };
+            let room = SERIAL_8250_TX_QUEUE_SIZE.saturating_sub(queue.len());
+            let accepted = room.min(buf.len());
+            queue.extend(&buf[..accepted]);
+            accepted
+        };
+        if accepted != 0 {
+            self.pump_tx();
+        } else if self.tx_room() == 0 {
+            self.set_tx_interrupt_enabled(true);
+        }
+        accepted
+    }
+
+    fn tx_room(&self) -> usize {
+        self.tx_state
+            .lock_irqsave()
+            .queue
+            .as_ref()
+            .map(|queue| SERIAL_8250_TX_QUEUE_SIZE.saturating_sub(queue.len()))
+            .unwrap_or(0)
+    }
+
+    fn tx_pending(&self) -> usize {
+        self.tx_state
+            .lock_irqsave()
+            .queue
+            .as_ref()
+            .map(VecDeque::len)
+            .unwrap_or(0)
+    }
+
+    fn pump_tx(&self) {
+        let (sent, should_wake, tty) = {
+            let mut tx_state = self.tx_state.lock_irqsave();
+            if tx_state.console_active {
+                return;
+            }
+            let tty = tx_state.tty.upgrade();
+            let Some(queue) = tx_state.queue.as_mut() else {
+                return;
+            };
+            let pending_before = queue.len();
+            let mut sent = 0;
+            // THRE must be sampled after taking tx_state: both process and
+            // IRQ contexts can pump this port, and a pre-lock sample becomes
+            // stale as soon as another context fills the FIFO.
+            if self.is_transmit_empty() {
+                while sent < self.tx_fifo_size.load(Ordering::Acquire) {
+                    let Some(byte) = queue.pop_front() else {
+                        break;
+                    };
+                    self.serial_out(0, byte.into());
+                    sent += 1;
+                }
+            }
+            let pending = !queue.is_empty();
+            let pending_after = queue.len();
+            let should_wake = pending_before != 0
+                && (pending_after == 0
+                    || (pending_before >= SERIAL_8250_TX_WAKEUP_CHARS
+                        && pending_after < SERIAL_8250_TX_WAKEUP_CHARS));
+            // Commit IER from the same queue snapshot before enqueue/clear can
+            // mutate it, otherwise a stale disable can strand new bytes.
+            self.set_tx_interrupt_enabled(pending);
+            (sent, should_wake, tty)
+        };
+
+        if sent != 0 && should_wake {
+            if let Some(tty) = tty {
+                tty.tty_wakeup();
+            }
+        }
+    }
+
+    fn clear_tx(&self) {
+        let mut tx_state = self.tx_state.lock_irqsave();
+        if let Some(queue) = tx_state.queue.as_mut() {
+            queue.clear();
+        }
+        self.set_tx_interrupt_enabled(false);
+    }
+
+    fn submit_runtime_output(&self, s: &[u8]) {
+        // This is the legacy, no-return-value console/debug interface: unlike
+        // the TTY write callback it cannot report a short write.  Serialize it
+        // with the runtime queue, drain older TTY bytes first, then submit the
+        // whole message by polling.  Console output is intentionally
+        // synchronous; ordinary userspace TTY output remains IRQ-driven.
+        let early_guard = self.tx_state.lock_irqsave();
+        if early_guard.queue.is_none() {
+            // Timers and the interrupt pipeline are not available yet.
+            for byte in s {
+                while !self.is_transmit_empty() {
+                    spin_loop();
+                }
+                self.serial_out(0, (*byte).into());
+            }
+            return;
+        }
+        drop(early_guard);
+
+        // A PCB address is stable across migration and is also visible from a
+        // nested IRQ/exception on behalf of that task. Keep the Arc alive so
+        // the token cannot be reused while this submission owns the UART.
+        let current = ProcessManager::current_pcb();
+        let owner_token = Arc::as_ptr(&current) as usize;
+        if current.preempt_count() != 0 || !CurrentIrqArch::is_irq_enabled() {
+            match self.console_owner.compare_exchange(
+                SERIAL_8250_CONSOLE_OWNER_NONE,
+                owner_token,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.submit_emergency_output(s);
+                    self.console_owner
+                        .store(SERIAL_8250_CONSOLE_OWNER_NONE, Ordering::Release);
+                }
+                Err(owner) if owner == owner_token => self.submit_emergency_output(s),
+                Err(_) => {}
+            }
+            return;
+        }
+        loop {
+            match self.console_owner.compare_exchange(
+                SERIAL_8250_CONSOLE_OWNER_NONE,
+                owner_token,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(owner) if owner == owner_token => {
+                    self.submit_emergency_output(s);
+                    return;
+                }
+                Err(_) => {
+                    // Process-context callers may wait without pinning a CPU.
+                    if nanosleep(PosixTimeSpec::new(0, 1_000_000)).is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+        let (mut older_remaining, tty) = {
+            let mut tx_state = self.tx_state.lock_irqsave();
+            tx_state.console_active = true;
+            let pending = tx_state.queue.as_ref().map(VecDeque::len).unwrap_or(0);
+            let tty = tx_state.tty.upgrade();
+            self.set_tx_interrupt_enabled(false);
+            (pending, tty)
+        };
+        let timeout = self.tx_batch_timeout();
+        let mut healthy = true;
+
+        while older_remaining != 0 {
+            if !self.wait_for_thre(timeout) {
+                healthy = false;
+                break;
+            }
+            let mut tx_state = self.tx_state.lock_irqsave();
+            let Some(queue) = tx_state.queue.as_mut() else {
+                older_remaining = 0;
+                break;
+            };
+            let count = older_remaining
+                .min(self.tx_fifo_size.load(Ordering::Acquire))
+                .min(queue.len());
+            for _ in 0..count {
+                self.serial_out(0, queue.pop_front().unwrap().into());
+            }
+            older_remaining -= count;
+            if count == 0 {
+                break;
+            }
+        }
+
+        let mut offset = 0;
+        while healthy && offset < s.len() {
+            if !self.wait_for_thre(timeout) {
+                healthy = false;
+                break;
+            }
+            let count = (s.len() - offset).min(self.tx_fifo_size.load(Ordering::Acquire));
+            for byte in &s[offset..offset + count] {
+                self.serial_out(0, (*byte).into());
+            }
+            offset += count;
+        }
+
+        {
+            let mut tx_state = self.tx_state.lock_irqsave();
+            tx_state.console_active = false;
+            let pending = tx_state
+                .queue
+                .as_ref()
+                .map(|queue| !queue.is_empty())
+                .unwrap_or(false);
+            self.set_tx_interrupt_enabled(pending);
+        }
+        if older_remaining == 0 {
+            if let Some(tty) = tty {
+                tty.tty_wakeup();
+            }
+        }
+        if healthy {
+            self.pump_tx();
+        }
+        self.console_owner
+            .store(SERIAL_8250_CONSOLE_OWNER_NONE, Ordering::Release);
+        drop(current);
+    }
+
+    fn submit_emergency_output(&self, s: &[u8]) {
+        let Ok(mut tx_state) = self.tx_state.try_lock_irqsave() else {
+            return;
+        };
+        let inherited_console_active = tx_state.console_active;
+        tx_state.console_active = true;
+        self.set_tx_interrupt_enabled(false);
+        drop(tx_state);
+
+        let timeout = self.tx_batch_timeout();
+        if !self.wait_for_thre(timeout) {
+            let mut tx_state = self.tx_state.lock_irqsave();
+            tx_state.console_active = inherited_console_active;
+            let pending = tx_state
+                .queue
+                .as_ref()
+                .map(|queue| !queue.is_empty())
+                .unwrap_or(false);
+            self.set_tx_interrupt_enabled(pending && !inherited_console_active);
+            return;
+        }
+        // Atomic diagnostics get one bounded FIFO batch. Longer output is
+        // intentionally truncated rather than extending IRQ/exception time.
+        let count = s.len().min(self.tx_fifo_size.load(Ordering::Acquire));
+        for byte in &s[..count] {
+            self.serial_out(0, (*byte).into());
+        }
+
+        let mut tx_state = self.tx_state.lock_irqsave();
+        tx_state.console_active = inherited_console_active;
+        let pending = tx_state
+            .queue
+            .as_ref()
+            .map(|queue| !queue.is_empty())
+            .unwrap_or(false);
+        self.set_tx_interrupt_enabled(pending && !inherited_console_active);
+    }
+
+    fn tx_batch_timeout(&self) -> Duration {
+        let baud = self.baudrate.load(Ordering::Acquire).data().max(1) as u64;
+        let char_time_us = 10_000_000u64.div_ceil(baud);
+        Duration::from_micros(
+            (char_time_us * self.tx_fifo_size.load(Ordering::Acquire) as u64 * 2).max(2_000),
+        )
+    }
+
+    fn wait_for_thre(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while !self.is_transmit_empty() {
+            if Instant::now() >= deadline {
+                return false;
+            }
+            spin_loop();
+        }
+        true
+    }
+
+    fn wait_for_tx_queue_empty(&self) -> Result<bool, SystemError> {
+        let pending = self.tx_pending();
+        if pending == 0 {
+            return Ok(true);
+        }
+        let baud = self.baudrate.load(Ordering::Acquire).data().max(1) as u64;
+        let char_time_us = 10_000_000u64.div_ceil(baud);
+        let deadline =
+            Instant::now() + Duration::from_micros((char_time_us * pending as u64 * 2).max(2_000));
+        while self.tx_pending() != 0 {
+            if Instant::now() >= deadline {
+                return Ok(false);
+            }
+            nanosleep(PosixTimeSpec::new(0, 1_000_000))?;
+        }
+        Ok(true)
     }
 
     fn set_rx_interrupt_enabled_locked(&self, rx_state: &mut Serial8250RxState, enabled: bool) {
@@ -326,6 +660,14 @@ impl Serial8250PIOPort {
         }
         Ok(())
     }
+
+    fn set_tx_tty(&self, tty: Weak<TtyCore>) {
+        let mut tx_state = self.tx_state.lock_irqsave();
+        if tx_state.queue.is_none() {
+            tx_state.queue = Some(VecDeque::with_capacity(SERIAL_8250_TX_QUEUE_SIZE));
+        }
+        tx_state.tty = tty;
+    }
 }
 
 impl Serial8250Port for Serial8250PIOPort {
@@ -385,7 +727,9 @@ impl UartPort for Serial8250PIOPort {
     }
 
     fn handle_irq(&self) -> Result<(), SystemError> {
-        self.pump_rx()
+        self.pump_rx()?;
+        self.pump_tx();
+        Ok(())
     }
 
     fn iobase(&self) -> Option<usize> {
@@ -436,7 +780,7 @@ pub enum Serial8250PortBase {
 /// 临时函数，用于向COM1发送数据
 pub fn send_to_default_serial8250_pio_port(s: &[u8]) {
     if let Some(port) = unsafe { PIO_PORTS[0].as_ref() } {
-        port.send_bytes(s);
+        port.submit_runtime_output(s);
     }
 }
 
@@ -475,12 +819,46 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
             return Err(SystemError::ENODEV);
         }
         let pio_port = unsafe { PIO_PORTS[index].as_ref() }.ok_or(SystemError::ENODEV)?;
-        pio_port.send_bytes(&buf[..nr]);
+        Ok(pio_port.enqueue_tx(&buf[..nr]))
+    }
 
-        Ok(nr)
+    fn write_room(&self, tty: &TtyCoreData) -> usize {
+        let index = tty.index();
+        unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }
+            .map(Serial8250PIOPort::tx_room)
+            .unwrap_or(0)
+    }
+
+    fn chars_in_buffer(&self, tty: &TtyCoreData) -> usize {
+        let index = tty.index();
+        unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }
+            .map(Serial8250PIOPort::tx_pending)
+            .unwrap_or(0)
     }
 
     fn flush_chars(&self, _tty: &TtyCoreData) {}
+
+    fn wait_until_sent(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
+        let index = tty.index();
+        if index >= unsafe { PIO_PORTS.len() } {
+            return Err(SystemError::ENODEV);
+        }
+        let port = unsafe { PIO_PORTS[index].as_ref() }.ok_or(SystemError::ENODEV)?;
+        let baud = port.baudrate.load(Ordering::Acquire).data().max(1) as u64;
+        // 8N1 is ten bits per character. Linux bounds uart_wait_until_sent
+        // to twice the FIFO transmission time when hardware flow control is
+        // disabled.
+        let char_time_us = 10_000_000u64.div_ceil(baud);
+        let timeout = Duration::from_micros(
+            (char_time_us * (port.tx_fifo_size.load(Ordering::Acquire) as u64) * 2).max(2_000),
+        );
+        let deadline = Instant::now() + timeout;
+
+        while !port.is_transmitter_idle() && Instant::now() < deadline {
+            nanosleep(PosixTimeSpec::new(0, 1_000_000))?;
+        }
+        Ok(())
+    }
 
     fn put_char(&self, tty: &TtyCoreData, ch: u8) -> Result<(), SystemError> {
         self.write(tty, &[ch], 1).map(|_| ())
@@ -491,6 +869,16 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
     }
 
     fn close(&self, tty: Arc<TtyCore>) -> Result<(), SystemError> {
+        let index = tty.core().index();
+        let port =
+            unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
+        if !port.wait_for_tx_queue_empty().unwrap_or(false) {
+            // A failed/stalled UART must not leak bytes into the next open.
+            port.clear_tx();
+        }
+        // Linux completes close cleanup even when a signal interrupts the
+        // best-effort physical drain.
+        let _ = self.wait_until_sent(tty.core());
         tty.ldisc().flush_buffer(tty.clone())?;
         Ok(())
     }
@@ -519,12 +907,14 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         let vc = VirtConsole::new(Some(vc_data));
         let port = unsafe { PIO_PORTS[tty_index].as_ref() }.ok_or(SystemError::ENODEV)?;
         let vc_index = vc_manager().alloc(vc.clone()).ok_or(SystemError::EBUSY)?;
-        self.do_install(driver, tty, vc.clone()).inspect_err(|_| {
-            vc_manager().free(vc_index);
-            port.set_input_target(None);
-            port.rx_paused.store(false, Ordering::Release);
-            port.set_rx_interrupt_enabled(false);
-        })?;
+        self.do_install(driver, tty.clone(), vc.clone())
+            .inspect_err(|_| {
+                vc_manager().free(vc_index);
+                port.set_input_target(None);
+                port.rx_paused.store(false, Ordering::Release);
+                port.set_rx_interrupt_enabled(false);
+            })?;
+        port.set_tx_tty(Arc::downgrade(&tty));
         let irq_registered = {
             let mut rx_state = port.rx_state.lock_irqsave();
             rx_state.input_target = Some(TtyInputTarget::new(vc_index, vc.port()));
@@ -535,6 +925,15 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
             retry_serial8250_pio_input();
         }
 
+        Ok(())
+    }
+
+    fn flush_buffer(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
+        let index = tty.index();
+        let port =
+            unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
+        port.clear_tx();
+        tty.write_wq().wakeup_all();
         Ok(())
     }
 }

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -50,7 +50,11 @@ use super::{Serial8250ISADevices, Serial8250ISADriver, Serial8250Manager, Serial
 static mut PIO_PORTS: [Option<Serial8250PIOPort>; 8] =
     [None, None, None, None, None, None, None, None];
 
-const SERIAL_8250_PIO_IRQ: IrqNumber = IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4);
+const SERIAL_8250_PIO_IRQS: [IrqNumber; 2] = [
+    IrqNumber::new(IoApic::VECTOR_BASE as u32 + 3),
+    IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4),
+];
+const SERIAL_8250_IRQ_PASS_LIMIT: usize = 256;
 const SERIAL_8250_RX_IRQ_LIMIT: usize = 256;
 const SERIAL_8250_IER_RX_AVAILABLE: u8 = 0x01;
 const SERIAL_8250_IER_TX_EMPTY: u8 = 0x02;
@@ -292,6 +296,15 @@ impl Serial8250PIOPort {
     /// Both the transmitter FIFO and shift register are empty.
     fn is_transmitter_idle(&self) -> bool {
         self.serial_in(5) & 0x40 != 0
+    }
+
+    fn has_pending_interrupt(&self) -> bool {
+        let _guard = self.hw_lock.lock_irqsave();
+        self.serial_in_raw(2) & 0x01 == 0
+    }
+
+    fn irq(&self) -> Option<IrqNumber> {
+        self.iobase.legacy_irq()
     }
 
     /// 读取一个字节，如果没有数据则返回None
@@ -1068,6 +1081,19 @@ pub enum Serial8250PortBase {
     COM8 = 0x4e8,
 }
 
+impl Serial8250PortBase {
+    /// Linux's fixed x86 legacy table defines IRQ resources only for the
+    /// first four ISA UARTs. Additional base addresses require platform
+    /// firmware or explicit configuration and must not guess an IRQ.
+    const fn legacy_irq(self) -> Option<IrqNumber> {
+        match self {
+            Self::COM1 | Self::COM3 => Some(IrqNumber::new(IoApic::VECTOR_BASE as u32 + 4)),
+            Self::COM2 | Self::COM4 => Some(IrqNumber::new(IoApic::VECTOR_BASE as u32 + 3)),
+            Self::COM5 | Self::COM6 | Self::COM7 | Self::COM8 => None,
+        }
+    }
+}
+
 /// 临时函数，用于向COM1发送数据
 pub fn send_to_default_serial8250_pio_port(s: &[u8]) {
     if let Some(port) = unsafe { PIO_PORTS[0].as_ref() } {
@@ -1260,40 +1286,89 @@ pub(super) fn serial_8250_pio_register_tty_devices() -> Result<(), SystemError> 
     ))
     .ok_or(SystemError::ENODEV)?;
 
-    for (i, port) in unsafe { PIO_PORTS.iter() }.enumerate() {
-        if let Some(port) = port {
-            let core = driver.init_tty_device(Some(i)).inspect_err(|_| {
-                log::error!(
-                    "failed to init tty device for serial 8250 pio port {}, port iobase: {:?}",
-                    i,
-                    port.iobase
-                );
-            })?;
-            core.resize( core.clone(), WindowSize::DEFAULT)
-                .inspect_err(|_| {
-                    log::error!(
-                        "failed to resize tty device for serial 8250 pio port {}, port iobase: {:?}",
-                        i,
-                        port.iobase
-                    );
-                })?;
+    let mut registered_irqs = [false; SERIAL_8250_PIO_IRQS.len()];
+    for (slot, irq) in SERIAL_8250_PIO_IRQS.iter().copied().enumerate() {
+        let has_port = unsafe { PIO_PORTS.iter() }
+            .flatten()
+            .any(|port| port.irq() == Some(irq));
+        if !has_port {
+            continue;
         }
-    }
-
-    irq_manager()
-        .request_irq(
-            SERIAL_8250_PIO_IRQ,
+        match irq_manager().request_irq(
+            irq,
             "serial8250_pio".to_string(),
             &Serial8250IrqHandler,
             IrqHandleFlags::IRQF_SHARED | IrqHandleFlags::IRQF_TRIGGER_RISING,
-            Some(DeviceId::new(Some("serial8250_pio"), None).unwrap()),
-        )
-        .inspect_err(|e| {
-            log::error!("failed to request irq for serial 8250 pio: {:?}", e);
-        })?;
+            DeviceId::new(Some("serial8250_pio"), None),
+        ) {
+            Ok(()) => registered_irqs[slot] = true,
+            Err(err) => {
+                log::error!("failed to request serial 8250 PIO irq {:?}: {:?}", irq, err);
+            }
+        }
+    }
 
-    for port in unsafe { PIO_PORTS.iter() }.flatten() {
-        port.mark_rx_irq_registered();
+    let irq_is_registered = |irq: IrqNumber| {
+        SERIAL_8250_PIO_IRQS
+            .iter()
+            .position(|candidate| *candidate == irq)
+            .is_some_and(|slot| registered_irqs[slot])
+    };
+    let mut registered_ports = 0;
+    for (i, port) in unsafe { PIO_PORTS.iter() }.enumerate() {
+        if let Some(port) = port {
+            let Some(irq) = port.irq() else {
+                log::warn!(
+                    "serial 8250 PIO port {:?} has no enumerated IRQ resource; skipping tty registration",
+                    port.iobase
+                );
+                continue;
+            };
+            if !irq_is_registered(irq) {
+                log::error!(
+                    "serial 8250 PIO port {:?} cannot be registered without IRQ {:?}",
+                    port.iobase,
+                    irq
+                );
+                continue;
+            }
+            let core = match driver.init_tty_device(Some(i)) {
+                Ok(core) => core,
+                Err(err) => {
+                    log::error!(
+                        "failed to init tty device for serial 8250 pio port {}, port iobase: {:?}: {:?}",
+                        i,
+                        port.iobase,
+                        err
+                    );
+                    continue;
+                }
+            };
+            if let Err(err) = core.resize(core.clone(), WindowSize::DEFAULT) {
+                // The TTY already exists and cannot currently be rolled back.
+                // Keep its IRQ route usable and retain the driver's default
+                // size instead of abandoning this and every later port.
+                log::error!(
+                    "failed to resize tty device for serial 8250 pio port {}, port iobase: {:?}: {:?}",
+                    i,
+                    port.iobase,
+                    err
+                );
+            }
+            port.mark_rx_irq_registered();
+            registered_ports += 1;
+        }
+    }
+
+    if registered_ports == 0 && unsafe { PIO_PORTS.iter().any(Option::is_some) } {
+        // free_irq() is not implemented yet. Once any request succeeded,
+        // report this one-shot boot registration as complete instead of
+        // inviting a retry that would duplicate the installed IRQ action.
+        if registered_irqs.iter().any(|registered| *registered) {
+            log::error!("no serial 8250 PIO TTY could be initialized");
+            return Ok(());
+        }
+        return Err(SystemError::ENODEV);
     }
     retry_serial8250_pio_input();
 
@@ -1306,14 +1381,40 @@ struct Serial8250IrqHandler;
 impl IrqHandler for Serial8250IrqHandler {
     fn handle(
         &self,
-        _irq: IrqNumber,
+        irq: IrqNumber,
         _static_data: Option<&dyn IrqHandlerData>,
         _dynamic_data: Option<Arc<dyn IrqHandlerData>>,
     ) -> Result<IrqReturn, SystemError> {
-        for port in unsafe { PIO_PORTS.iter() }.flatten() {
-            port.handle_irq()?;
+        let mut handled = false;
+        for _ in 0..SERIAL_8250_IRQ_PASS_LIMIT {
+            let mut pending_in_pass = false;
+            for port in unsafe { PIO_PORTS.iter() }
+                .flatten()
+                .filter(|port| port.irq() == Some(irq))
+            {
+                if !port.has_pending_interrupt() {
+                    continue;
+                }
+                pending_in_pass = true;
+                handled = true;
+                if let Err(err) = port.handle_irq() {
+                    log::error!(
+                        "failed to service serial 8250 PIO port {:?} on irq {:?}: {:?}",
+                        port.iobase,
+                        irq,
+                        err
+                    );
+                }
+            }
+            if !pending_in_pass {
+                break;
+            }
         }
 
-        Ok(IrqReturn::Handled)
+        Ok(if handled {
+            IrqReturn::Handled
+        } else {
+            IrqReturn::NotHandled
+        })
     }
 }

--- a/kernel/src/driver/tty/pty/mod.rs
+++ b/kernel/src/driver/tty/pty/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     syscall::user_access::{UserBufferReader, UserBufferWriter},
 };
 
-use self::unix98pty::{Unix98PtyDriverInner, NR_UNIX98_PTY_MAX};
+use self::unix98pty::{pty_drain_workqueue_init, Unix98PtyDriverInner, NR_UNIX98_PTY_MAX};
 
 use super::{
     termios::{ControlMode, InputMode, LocalMode, OutputMode, TTY_STD_TERMIOS},
@@ -177,6 +177,7 @@ impl PtyCommon {
 #[unified_init(INITCALL_DEVICE)]
 #[inline(never)]
 pub fn pty_init() -> Result<(), SystemError> {
+    pty_drain_workqueue_init();
     let mut ptm_driver = TtyDriver::new(
         NR_UNIX98_PTY_MAX,
         "ptm",

--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -15,8 +15,11 @@ use crate::{
         termios::{ControlCharIndex, ControlMode, InputMode, LocalMode, Termios},
         tty_core::{TtyCore, TtyCoreData, TtyFlag, TtyIoctlCmd, TtyPacketStatus},
         tty_device::{TtyDevice, TtyFilePrivateData},
-        tty_driver::{TtyDriver, TtyDriverPrivateData, TtyDriverSubType, TtyOperation},
+        tty_driver::{
+            TtyCorePrivateField, TtyDriver, TtyDriverPrivateData, TtyDriverSubType, TtyOperation,
+        },
     },
+    exception::workqueue::{Work, WorkQueue},
     filesystem::{
         devpts::DevPtsFs,
         epoll::{event_poll::EventPoll, EPollEventType},
@@ -33,6 +36,14 @@ use crate::{
     process::ProcessManager,
     syscall::user_access::UserBufferWriter,
 };
+
+lazy_static! {
+    static ref PTY_DRAIN_WQ: Arc<WorkQueue> = WorkQueue::new("pty-drain");
+}
+
+pub(super) fn pty_drain_workqueue_init() {
+    lazy_static::initialize(&PTY_DRAIN_WQ);
+}
 
 use super::{ptm_driver, pts_driver, PtyCommon};
 
@@ -73,6 +84,8 @@ struct PtyDevPtsLink {
     slave_to_master_draining: AtomicBool,
     master_to_slave_drain_requested: AtomicBool,
     slave_to_master_drain_requested: AtomicBool,
+    master_to_slave_drain_scheduled: AtomicBool,
+    slave_to_master_drain_scheduled: AtomicBool,
     master_to_slave_discarding: AtomicBool,
     slave_to_master_discarding: AtomicBool,
     master_to_slave_flushing: AtomicBool,
@@ -98,6 +111,7 @@ struct DrainResult {
     delivered: usize,
     freed_backlog: usize,
     still_pending: bool,
+    yielded: bool,
 }
 
 #[derive(Debug)]
@@ -213,6 +227,8 @@ impl PtyDevPtsLink {
             slave_to_master_draining: AtomicBool::new(false),
             master_to_slave_drain_requested: AtomicBool::new(false),
             slave_to_master_drain_requested: AtomicBool::new(false),
+            master_to_slave_drain_scheduled: AtomicBool::new(false),
+            slave_to_master_drain_scheduled: AtomicBool::new(false),
             master_to_slave_discarding: AtomicBool::new(false),
             slave_to_master_discarding: AtomicBool::new(false),
             master_to_slave_flushing: AtomicBool::new(false),
@@ -224,6 +240,14 @@ impl PtyDevPtsLink {
         match subtype {
             TtyDriverSubType::PtyMaster => Some(&self.master_to_slave),
             TtyDriverSubType::PtySlave => Some(&self.slave_to_master),
+            _ => None,
+        }
+    }
+
+    fn drain_scheduled_for_source(&self, subtype: TtyDriverSubType) -> Option<&AtomicBool> {
+        match subtype {
+            TtyDriverSubType::PtyMaster => Some(&self.master_to_slave_drain_scheduled),
+            TtyDriverSubType::PtySlave => Some(&self.slave_to_master_drain_scheduled),
             _ => None,
         }
     }
@@ -372,6 +396,7 @@ impl PtyDevPtsLink {
 
     fn write_to_peer(
         &self,
+        owner: Arc<dyn TtyCorePrivateField>,
         subtype: TtyDriverSubType,
         to: Arc<TtyCore>,
         buf: &[u8],
@@ -398,10 +423,18 @@ impl PtyDevPtsLink {
             break queue_guard.push_slice(&buf[..nr]);
         };
 
+        // Preserve the existing in-order fast path when the peer termios state
+        // is stable. If a peer termios writer is active, never block while the
+        // source endpoint may hold its own termios/output locks: defer delivery
+        // to the workqueue and break the cross-endpoint ABBA dependency.
+        let Some(_peer_termios_guard) = to.core().termios_try_read_lock() else {
+            Self::schedule_peer_drain(owner, subtype, to);
+            return Ok(accepted);
+        };
+
         if accepted == 0 {
-            let result = self.drain_to_peer(subtype, to.clone())?;
+            let result = self.drain_to_peer_termios_locked(subtype, to.clone(), usize::MAX)?;
             if result.freed_backlog != 0 {
-                // Space became available in this PTY direction.
                 Self::wake_source_writer(&to);
             }
             accepted = loop {
@@ -420,7 +453,7 @@ impl PtyDevPtsLink {
         }
 
         if accepted != 0 {
-            let result = self.drain_to_peer(subtype, to.clone())?;
+            let result = self.drain_to_peer_termios_locked(subtype, to.clone(), usize::MAX)?;
             if result.freed_backlog != 0 {
                 Self::wake_source_writer(&to);
             }
@@ -428,10 +461,78 @@ impl PtyDevPtsLink {
         Ok(accepted)
     }
 
+    fn schedule_peer_drain(
+        owner: Arc<dyn TtyCorePrivateField>,
+        subtype: TtyDriverSubType,
+        to: Arc<TtyCore>,
+    ) {
+        let Some(hook) = owner.as_any().downcast_ref::<PtyDevPtsLink>() else {
+            return;
+        };
+        let Some(scheduled) = hook.drain_scheduled_for_source(subtype) else {
+            return;
+        };
+        if scheduled
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        PTY_DRAIN_WQ.enqueue(Work::new(move || {
+            let Some(hook) = owner.as_any().downcast_ref::<PtyDevPtsLink>() else {
+                return;
+            };
+            let Some(scheduled) = hook.drain_scheduled_for_source(subtype) else {
+                return;
+            };
+
+            let result = hook.drain_to_peer_budgeted(subtype, to.clone(), 16);
+            if let Ok(result) = result.as_ref() {
+                if result.freed_backlog != 0 {
+                    Self::wake_source_writer(&to);
+                }
+            }
+
+            scheduled.store(false, Ordering::Release);
+            let should_retry = result
+                .as_ref()
+                .map(|result| result.yielded || !result.still_pending)
+                .unwrap_or(false)
+                && hook
+                    .queue_for_source(subtype)
+                    .map(|queue| !queue.lock_irqsave().is_empty())
+                    .unwrap_or(false);
+            if should_retry {
+                Self::schedule_peer_drain(owner.clone(), subtype, to.clone());
+            }
+        }));
+    }
+
     fn drain_to_peer(
         &self,
         subtype: TtyDriverSubType,
         to: Arc<TtyCore>,
+    ) -> Result<DrainResult, SystemError> {
+        let _termios_guard = to.core().termios_read_lock();
+        self.drain_to_peer_termios_locked(subtype, to.clone(), usize::MAX)
+    }
+
+    fn drain_to_peer_budgeted(
+        &self,
+        subtype: TtyDriverSubType,
+        to: Arc<TtyCore>,
+        max_chunks: usize,
+    ) -> Result<DrainResult, SystemError> {
+        let _termios_guard = to.core().termios_read_lock();
+        self.drain_to_peer_termios_locked(subtype, to.clone(), max_chunks)
+    }
+
+    fn drain_to_peer_termios_locked(
+        &self,
+        subtype: TtyDriverSubType,
+        to: Arc<TtyCore>,
+        max_chunks: usize,
     ) -> Result<DrainResult, SystemError> {
         let Some(queue) = self.queue_for_source(subtype) else {
             return Err(SystemError::ENODEV);
@@ -456,6 +557,7 @@ impl PtyDevPtsLink {
             return Ok(result);
         }
 
+        let mut chunks = 0;
         loop {
             if flushing.load(Ordering::Acquire) {
                 let _ = self.discard_requested_prefix(queue);
@@ -512,20 +614,18 @@ impl PtyDevPtsLink {
                 continue;
             }
 
-            let delivered =
-                match to
-                    .core()
-                    .port()
-                    .unwrap()
-                    .receive_buf(&chunk[..chunk_len], &[], chunk_len)
-                {
-                    Ok(delivered) => delivered,
-                    Err(err) => {
-                        let _ = self.discard_requested_prefix(queue);
-                        draining.store(false, Ordering::Release);
-                        return Err(err);
-                    }
-                };
+            let delivered = match to.core().port().unwrap().receive_buf_termios_locked(
+                &chunk[..chunk_len],
+                &[],
+                chunk_len,
+            ) {
+                Ok(delivered) => delivered,
+                Err(err) => {
+                    let _ = self.discard_requested_prefix(queue);
+                    draining.store(false, Ordering::Release);
+                    return Err(err);
+                }
+            };
             queue.lock_irqsave().advance_front(delivered);
             result.delivered += delivered;
             result.freed_backlog += delivered;
@@ -547,6 +647,13 @@ impl PtyDevPtsLink {
             }
             if delivered < chunk_len {
                 result.still_pending = true;
+                draining.store(false, Ordering::Release);
+                break;
+            }
+            chunks += 1;
+            if chunks >= max_chunks && !queue.lock_irqsave().is_empty() {
+                result.still_pending = true;
+                result.yielded = true;
                 draining.store(false, Ordering::Release);
                 break;
             }
@@ -736,7 +843,13 @@ impl TtyOperation for Unix98PtyDriverInner {
 
         if let Some(hook_arc) = tty.private_fields() {
             if let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() {
-                return hook.write_to_peer(tty.driver().tty_driver_sub_type(), to, buf, nr);
+                return hook.write_to_peer(
+                    hook_arc.clone(),
+                    tty.driver().tty_driver_sub_type(),
+                    to,
+                    buf,
+                    nr,
+                );
             }
         }
 

--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -285,6 +285,12 @@ impl PtyDevPtsLink {
             .unwrap_or(0)
     }
 
+    fn pending_bytes_from(&self, subtype: TtyDriverSubType) -> usize {
+        self.queue_for_source(subtype)
+            .map(|queue| queue.lock_irqsave().len)
+            .unwrap_or(0)
+    }
+
     fn clear_pending_from(&self, subtype: TtyDriverSubType) -> Result<(), SystemError> {
         let Some(queue) = self.queue_for_source(subtype) else {
             return Err(SystemError::ENODEV);
@@ -868,6 +874,16 @@ impl TtyOperation for Unix98PtyDriverInner {
         }
 
         PTY_BUFFER_LIMIT
+    }
+
+    fn chars_in_buffer(&self, tty: &TtyCoreData) -> usize {
+        if let Some(hook_arc) = tty.private_fields() {
+            if let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() {
+                return hook.pending_bytes_from(tty.driver().tty_driver_sub_type());
+            }
+        }
+
+        0
     }
 
     fn flush_buffer(&self, tty: &TtyCoreData) -> Result<(), SystemError> {

--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -871,15 +871,25 @@ impl TtyOperation for Unix98PtyDriverInner {
     }
 
     fn flush_buffer(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
-        let Some(to) = tty.link() else {
-            return Ok(());
-        };
+        let to = tty.link();
 
         if let Some(hook_arc) = tty.private_fields() {
             if let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() {
                 hook.clear_pending_from(tty.driver().tty_driver_sub_type())?;
+                // clear_pending_from() can satisfy a concurrent drain wait in
+                // exactly the same way as normal queue delivery.  Wake the
+                // source endpoint after making the zero-backlog state visible.
+                if let Some(to) = to.as_ref() {
+                    PtyDevPtsLink::wake_source_writer(to);
+                } else {
+                    tty.write_wq().wakeup_all();
+                }
             }
         }
+
+        let Some(to) = to else {
+            return Ok(());
+        };
 
         if to.core().contorl_info_irqsave().packet {
             tty.contorl_info_irqsave()

--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -285,12 +285,6 @@ impl PtyDevPtsLink {
             .unwrap_or(0)
     }
 
-    fn pending_bytes_from(&self, subtype: TtyDriverSubType) -> usize {
-        self.queue_for_source(subtype)
-            .map(|queue| queue.lock_irqsave().len)
-            .unwrap_or(0)
-    }
-
     fn clear_pending_from(&self, subtype: TtyDriverSubType) -> Result<(), SystemError> {
         let Some(queue) = self.queue_for_source(subtype) else {
             return Err(SystemError::ENODEV);
@@ -876,25 +870,15 @@ impl TtyOperation for Unix98PtyDriverInner {
         PTY_BUFFER_LIMIT
     }
 
-    fn chars_in_buffer(&self, tty: &TtyCoreData) -> usize {
-        if let Some(hook_arc) = tty.private_fields() {
-            if let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() {
-                return hook.pending_bytes_from(tty.driver().tty_driver_sub_type());
-            }
-        }
-
-        0
-    }
-
     fn flush_buffer(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
         let to = tty.link();
 
         if let Some(hook_arc) = tty.private_fields() {
             if let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() {
                 hook.clear_pending_from(tty.driver().tty_driver_sub_type())?;
-                // clear_pending_from() can satisfy a concurrent drain wait in
-                // exactly the same way as normal queue delivery.  Wake the
-                // source endpoint after making the zero-backlog state visible.
+                // Releasing bridge capacity can satisfy blocked writers and
+                // POLLOUT waiters. Wake the source after making the new room
+                // visible.
                 if let Some(to) = to.as_ref() {
                     PtyDevPtsLink::wake_source_writer(to);
                 } else {
@@ -1180,6 +1164,7 @@ pub fn ptmx_open(
     *data = FilePrivateData::Tty(TtyFilePrivateData {
         tty: tty.clone(),
         flags: *flags,
+        hangup_generation: tty.core().file_open_hangup_generation(),
     });
 
     let core = tty.core();

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -474,7 +474,9 @@ impl PosixTermio {
         let ispeed = if ibaud == 0 {
             ospeed
         } else {
-            ControlMode::from_bits_truncate(ibaud).baud_rate().unwrap_or(ospeed)
+            ControlMode::from_bits_truncate(ibaud)
+                .baud_rate()
+                .unwrap_or(ospeed)
         };
         (ispeed, ospeed)
     }

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -55,7 +55,7 @@ pub struct PosixTermios {
 }
 
 impl PosixTermios {
-    pub fn from_kernel_termios(termios: Termios) -> Self {
+    pub fn from_kernel_termios(termios: &Termios) -> Self {
         Self {
             c_iflag: termios.input_mode.bits,
             c_oflag: termios.output_mode.bits,
@@ -82,17 +82,13 @@ impl PosixTermios {
     }
 
     fn output_speed(&self) -> Option<u32> {
-        let flag = ControlMode::from_bits_truncate(self.c_cflag & ControlMode::CBAUD.bits());
-        flag.baud_rate()
+        let cflag = ControlMode::from_bits_truncate(self.c_cflag & ControlMode::CBAUD.bits());
+        cflag.baud_rate()
     }
 
     fn input_speed(&self) -> Option<u32> {
-        let ibaud = (self.c_cflag & ControlMode::CIBAUD.bits()) >> 16;
-        if ibaud == 0 {
-            self.output_speed()
-        } else {
-            ControlMode::from_bits_truncate(ibaud).baud_rate()
-        }
+        let cflag = ControlMode::from_bits_truncate(self.c_cflag);
+        cflag.input_baud_rate()
     }
 }
 
@@ -152,7 +148,7 @@ lazy_static! {
                 | LocalMode::IEXTEN,
             control_characters: INIT_CONTORL_CHARACTERS,
             line: LineDisciplineType::NTty,
-            c_line_abi: 0,
+            c_line_abi: INIT_C_LINE_ABI,
             input_speed: 38400,
             output_speed: 38400,
         }
@@ -363,8 +359,12 @@ bitflags! {
         const TERMIOS_WAIT	=2;
         const TERMIOS_TERMIO	=4;
         const TERMIOS_OLD	=8;
-    }
 }
+}
+
+
+/// Shift to extract input baud rate bits from c_cflag (CIBAUD = 0x100f0000).
+pub const CIBAUD_SHIFT: u32 = 16;
 
 impl ControlMode {
     /// 获取波特率
@@ -400,15 +400,25 @@ impl ControlMode {
             Self::B2000000 => Some(2000000),
             Self::B2500000 => Some(2500000),
             Self::B3000000 => Some(3000000),
-            Self::B3500000 => Some(3500000),
-            Self::B4000000 => Some(4000000),
             _ => None,
+        }
+    }
+
+    /// Get input baud rate from CIBAUD bits, falling back to output baud rate.
+    pub fn input_baud_rate(&self) -> Option<u32> {
+        let ibaud = (self.bits() & Self::CIBAUD.bits()) >> CIBAUD_SHIFT;
+        if ibaud == 0 {
+            self.baud_rate()
+        } else {
+            ControlMode::from_bits_truncate(ibaud).baud_rate()
         }
     }
 }
 
-/// Number of control characters in legacy `struct termio`.
 pub const NCC: usize = 8;
+
+/// Default c_line ABI value (N_TTY = 0).
+pub const INIT_C_LINE_ABI: u8 = 0;
 
 /// Legacy SVR4 `struct termio` — the smaller predecessor of `struct termios`.
 /// Used by ioctl commands TCGETA / TCSETA / TCSETAW / TCSETAF.
@@ -424,7 +434,7 @@ pub struct PosixTermio {
     /// Explicit padding — eliminates the 1-byte implicit tail padding that
     /// repr(C) would otherwise insert, preventing kernel stack leak via
     /// TCGETA.  Default::default() zeros this field.
-    pub _pad: u8,
+    pub(crate) _pad: u8,
 }
 
 impl PosixTermio {
@@ -481,14 +491,7 @@ impl PosixTermio {
     /// after `user_termio_to_kernel_termios()`.
     pub fn speeds_from_cflag(cflag: ControlMode) -> (u32, u32) {
         let ospeed = cflag.baud_rate().unwrap_or(38400);
-        let ibaud = (cflag.bits() & ControlMode::CIBAUD.bits()) >> 16;
-        let ispeed = if ibaud == 0 {
-            ospeed
-        } else {
-            ControlMode::from_bits_truncate(ibaud)
-                .baud_rate()
-                .unwrap_or(ospeed)
-        };
+        let ispeed = cflag.input_baud_rate().unwrap_or(ospeed);
         (ispeed, ospeed)
     }
 }

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -362,8 +362,6 @@ bitflags! {
 }
 }
 
-
-
 impl ControlMode {
     /// 获取波特率
     pub fn baud_rate(&self) -> Option<u32> {

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -33,7 +33,12 @@ pub struct Termios {
     pub control_mode: ControlMode,
     pub local_mode: LocalMode,
     pub control_characters: [u8; CONTORL_CHARACTER_NUM],
+    /// Active line discipline (derived from c_line_abi).
     pub line: LineDisciplineType,
+    /// Raw ABI c_line value preserved across TCGETS/TCSETA round-trips.
+    /// Linux stores the c_line byte as-is; line discipline switching is
+    /// done via TIOCSETD, not by writing c_line in termios.
+    pub c_line_abi: u8,
     pub input_speed: u32,
     pub output_speed: u32,
 }
@@ -57,7 +62,7 @@ impl PosixTermios {
             c_cflag: termios.control_mode.bits,
             c_lflag: termios.local_mode.bits,
             c_cc: termios.control_characters,
-            c_line: termios.line as u8,
+            c_line: termios.c_line_abi,
         }
     }
 
@@ -70,6 +75,7 @@ impl PosixTermios {
             local_mode: LocalMode::from_bits_truncate(self.c_lflag),
             control_characters: self.c_cc,
             line: LineDisciplineType::from_line(self.c_line),
+            c_line_abi: self.c_line,
             input_speed: self.input_speed().unwrap_or(38400),
             output_speed: self.output_speed().unwrap_or(38400),
         }
@@ -146,6 +152,7 @@ lazy_static! {
                 | LocalMode::IEXTEN,
             control_characters: INIT_CONTORL_CHARACTERS,
             line: LineDisciplineType::NTty,
+            c_line_abi: 0,
             input_speed: 38400,
             output_speed: 38400,
         }
@@ -432,7 +439,7 @@ impl PosixTermio {
             c_oflag: termios.output_mode.bits as u16,
             c_cflag: termios.control_mode.bits as u16,
             c_lflag: termios.local_mode.bits as u16,
-            c_line: termios.line as u8,
+            c_line: termios.c_line_abi,
             c_cc: cc,
             _pad: 0,
         }
@@ -463,8 +470,7 @@ impl PosixTermio {
             ),
             control_characters: cc,
             line: LineDisciplineType::from_line(self.c_line),
-            // Speed is derived from the merged c_cflag by the caller via
-            // ControlMode::baud_rate(); termio carries no speed fields.
+            c_line_abi: self.c_line,
             input_speed: old.input_speed,
             output_speed: old.output_speed,
         }

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -414,6 +414,10 @@ pub struct PosixTermio {
     pub c_lflag: u16,
     pub c_line: u8,
     pub c_cc: [u8; NCC],
+    /// Explicit padding — eliminates the 1-byte implicit tail padding that
+    /// repr(C) would otherwise insert, preventing kernel stack leak via
+    /// TCGETA.  Default::default() zeros this field.
+    pub _pad: u8,
 }
 
 impl PosixTermio {
@@ -430,6 +434,7 @@ impl PosixTermio {
             c_lflag: termios.local_mode.bits as u16,
             c_line: termios.line as u8,
             c_cc: cc,
+            _pad: 0,
         }
     }
 

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -433,36 +433,50 @@ impl PosixTermio {
         }
     }
 
-    /// Convert user-space termio → kernel Termios.
-    /// u16 → u32 zero-extension; missing c_cc slots default to 0.
-    /// Speed is extracted from c_cflag CBAUD/CIBAUD bits, matching
-    /// the existing PosixTermios::to_kernel_termios() pattern.
-    pub fn to_kernel_termios(self) -> Termios {
-        let mut cc = [0u8; CONTORL_CHARACTER_NUM];
-        let copy_len = NCC.min(CONTORL_CHARACTER_NUM);
-        cc[..copy_len].copy_from_slice(&self.c_cc[..copy_len]);
-
-        let cflag = ControlMode::from_bits_truncate(self.c_cflag as u32);
-        let ospeed = cflag.baud_rate().unwrap_or(38400);
-        let ispeed = {
-            let ibaud = ((self.c_cflag as u32) & ControlMode::CIBAUD.bits()) >> 16;
-            if ibaud == 0 {
-                ospeed
-            } else {
-                ControlMode::from_bits_truncate(ibaud).baud_rate().unwrap_or(ospeed)
-            }
-        };
+    /// Convert user-space termio → kernel Termios, merging with `old`.
+    ///
+    /// Matches Linux 6.6 generic `user_termio_to_kernel_termios()`:
+    /// the low 16 bits of each flag word come from the termio, the high
+    /// 16 bits are preserved from `old`. Only the first NCC control
+    /// characters are overwritten; the rest are preserved from `old`.
+    pub fn to_kernel_termios(self, old: &Termios) -> Termios {
+        let mut cc = old.control_characters;
+        cc[..NCC].copy_from_slice(&self.c_cc);
 
         Termios {
-            input_mode: InputMode::from_bits_truncate(self.c_iflag as u32),
-            output_mode: OutputMode::from_bits_truncate(self.c_oflag as u32),
-            control_mode: cflag,
-            local_mode: LocalMode::from_bits_truncate(self.c_lflag as u32),
+            input_mode: InputMode::from_bits_truncate(
+                (old.input_mode.bits & 0xffff_0000) | self.c_iflag as u32,
+            ),
+            output_mode: OutputMode::from_bits_truncate(
+                (old.output_mode.bits & 0xffff_0000) | self.c_oflag as u32,
+            ),
+            control_mode: ControlMode::from_bits_truncate(
+                (old.control_mode.bits & 0xffff_0000) | self.c_cflag as u32,
+            ),
+            local_mode: LocalMode::from_bits_truncate(
+                (old.local_mode.bits & 0xffff_0000) | self.c_lflag as u32,
+            ),
             control_characters: cc,
             line: LineDisciplineType::from_line(self.c_line),
-            input_speed: ispeed,
-            output_speed: ospeed,
+            // Speed is derived from the merged c_cflag by the caller via
+            // ControlMode::baud_rate(); termio carries no speed fields.
+            input_speed: old.input_speed,
+            output_speed: old.output_speed,
         }
+    }
+
+    /// Extract input/output speeds from a merged kernel Termios c_cflag,
+    /// mirroring how Linux `set_termios()` calls `tty_termios_baud_rate()`
+    /// after `user_termio_to_kernel_termios()`.
+    pub fn speeds_from_cflag(cflag: ControlMode) -> (u32, u32) {
+        let ospeed = cflag.baud_rate().unwrap_or(38400);
+        let ibaud = (cflag.bits() & ControlMode::CIBAUD.bits()) >> 16;
+        let ispeed = if ibaud == 0 {
+            ospeed
+        } else {
+            ControlMode::from_bits_truncate(ibaud).baud_rate().unwrap_or(ospeed)
+        };
+        (ispeed, ospeed)
     }
 }
 

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -400,6 +400,72 @@ impl ControlMode {
     }
 }
 
+/// Number of control characters in legacy `struct termio`.
+pub const NCC: usize = 8;
+
+/// Legacy SVR4 `struct termio` — the smaller predecessor of `struct termios`.
+/// Used by ioctl commands TCGETA / TCSETA / TCSETAW / TCSETAF.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct PosixTermio {
+    pub c_iflag: u16,
+    pub c_oflag: u16,
+    pub c_cflag: u16,
+    pub c_lflag: u16,
+    pub c_line: u8,
+    pub c_cc: [u8; NCC],
+}
+
+impl PosixTermio {
+    /// Convert kernel Termios → user-space termio.
+    /// Fields wider than u16 are truncated; excess c_cc slots are dropped.
+    pub fn from_kernel_termios(termios: &Termios) -> Self {
+        let mut cc = [0u8; NCC];
+        let copy_len = NCC.min(termios.control_characters.len());
+        cc[..copy_len].copy_from_slice(&termios.control_characters[..copy_len]);
+        Self {
+            c_iflag: termios.input_mode.bits as u16,
+            c_oflag: termios.output_mode.bits as u16,
+            c_cflag: termios.control_mode.bits as u16,
+            c_lflag: termios.local_mode.bits as u16,
+            c_line: termios.line as u8,
+            c_cc: cc,
+        }
+    }
+
+    /// Convert user-space termio → kernel Termios.
+    /// u16 → u32 zero-extension; missing c_cc slots default to 0.
+    /// Speed is extracted from c_cflag CBAUD/CIBAUD bits, matching
+    /// the existing PosixTermios::to_kernel_termios() pattern.
+    pub fn to_kernel_termios(self) -> Termios {
+        let mut cc = [0u8; CONTORL_CHARACTER_NUM];
+        let copy_len = NCC.min(CONTORL_CHARACTER_NUM);
+        cc[..copy_len].copy_from_slice(&self.c_cc[..copy_len]);
+
+        let cflag = ControlMode::from_bits_truncate(self.c_cflag as u32);
+        let ospeed = cflag.baud_rate().unwrap_or(38400);
+        let ispeed = {
+            let ibaud = ((self.c_cflag as u32) & ControlMode::CIBAUD.bits()) >> 16;
+            if ibaud == 0 {
+                ospeed
+            } else {
+                ControlMode::from_bits_truncate(ibaud).baud_rate().unwrap_or(ospeed)
+            }
+        };
+
+        Termios {
+            input_mode: InputMode::from_bits_truncate(self.c_iflag as u32),
+            output_mode: OutputMode::from_bits_truncate(self.c_oflag as u32),
+            control_mode: cflag,
+            local_mode: LocalMode::from_bits_truncate(self.c_lflag as u32),
+            control_characters: cc,
+            line: LineDisciplineType::from_line(self.c_line),
+            input_speed: ispeed,
+            output_speed: ospeed,
+        }
+    }
+}
+
 /// 对应termios中控制字符的索引
 pub struct ControlCharIndex;
 #[allow(dead_code)]

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -363,8 +363,6 @@ bitflags! {
 }
 
 
-/// Shift to extract input baud rate bits from c_cflag (CIBAUD = 0x100f0000).
-pub const CIBAUD_SHIFT: u32 = 16;
 
 impl ControlMode {
     /// 获取波特率
@@ -400,6 +398,8 @@ impl ControlMode {
             Self::B2000000 => Some(2000000),
             Self::B2500000 => Some(2500000),
             Self::B3000000 => Some(3000000),
+            Self::B3500000 => Some(3500000),
+            Self::B4000000 => Some(4000000),
             _ => None,
         }
     }
@@ -416,6 +416,9 @@ impl ControlMode {
 }
 
 pub const NCC: usize = 8;
+
+/// Shift to extract input baud rate bits from c_cflag (CIBAUD = 0x100f0000).
+pub const CIBAUD_SHIFT: u32 = 16;
 
 /// Default c_line ABI value (N_TTY = 0).
 pub const INIT_C_LINE_ABI: u8 = 0;

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -404,7 +404,7 @@ impl ControlMode {
 
     /// Get input baud rate from CIBAUD bits, falling back to output baud rate.
     pub fn input_baud_rate(&self) -> Option<u32> {
-        let ibaud = (self.bits() & Self::CIBAUD.bits()) >> CIBAUD_SHIFT;
+        let ibaud = (self.bits() & Self::CIBAUD.bits()) >> 16;
         if ibaud == 0 {
             self.baud_rate()
         } else {
@@ -414,9 +414,6 @@ impl ControlMode {
 }
 
 pub const NCC: usize = 8;
-
-/// Shift to extract input baud rate bits from c_cflag (CIBAUD = 0x100f0000).
-pub const CIBAUD_SHIFT: u32 = 16;
 
 /// Default c_line ABI value (N_TTY = 0).
 pub const INIT_C_LINE_ABI: u8 = 0;
@@ -432,11 +429,16 @@ pub struct PosixTermio {
     pub c_lflag: u16,
     pub c_line: u8,
     pub c_cc: [u8; NCC],
-    /// Explicit padding — eliminates the 1-byte implicit tail padding that
-    /// repr(C) would otherwise insert, preventing kernel stack leak via
-    /// TCGETA.  Default::default() zeros this field.
+    /// Explicit padding in place of repr(C) implicit tail padding.
+    /// Essential: `Default::default()` zeros this field, preventing kernel
+    /// stack data leak to userspace via TCGETA.
     pub(crate) _pad: u8,
 }
+
+// Compile-time guard: sizeof(PosixTermio) must be 18 to match C struct
+// termio on all supported ABIs.  If this fails on a new architecture,
+// the _pad field and/or repr alignment need adjustment.
+const _: () = assert!(core::mem::size_of::<PosixTermio>() == 18);
 
 impl PosixTermio {
     /// Convert kernel Termios → user-space termio.
@@ -466,6 +468,11 @@ impl PosixTermio {
         let mut cc = old.control_characters;
         cc[..NCC].copy_from_slice(&self.c_cc);
 
+        let control_mode = ControlMode::from_bits_truncate(
+            (old.control_mode.bits & 0xffff_0000) | self.c_cflag as u32,
+        );
+        let (input_speed, output_speed) = Self::speeds_from_cflag(control_mode);
+
         Termios {
             input_mode: InputMode::from_bits_truncate(
                 (old.input_mode.bits & 0xffff_0000) | self.c_iflag as u32,
@@ -473,17 +480,15 @@ impl PosixTermio {
             output_mode: OutputMode::from_bits_truncate(
                 (old.output_mode.bits & 0xffff_0000) | self.c_oflag as u32,
             ),
-            control_mode: ControlMode::from_bits_truncate(
-                (old.control_mode.bits & 0xffff_0000) | self.c_cflag as u32,
-            ),
+            control_mode,
             local_mode: LocalMode::from_bits_truncate(
                 (old.local_mode.bits & 0xffff_0000) | self.c_lflag as u32,
             ),
             control_characters: cc,
             line: LineDisciplineType::from_line(self.c_line),
             c_line_abi: self.c_line,
-            input_speed: old.input_speed,
-            output_speed: old.output_speed,
+            input_speed,
+            output_speed,
         }
     }
 

--- a/kernel/src/driver/tty/termios.rs
+++ b/kernel/src/driver/tty/termios.rs
@@ -464,6 +464,10 @@ impl PosixTermio {
     /// the low 16 bits of each flag word come from the termio, the high
     /// 16 bits are preserved from `old`. Only the first NCC control
     /// characters are overwritten; the rest are preserved from `old`.
+    ///
+    /// `self._pad` is intentionally ignored — it exists solely to prevent
+    /// kernel stack data leaks to userspace via TCGETA reads.
+    /// User-supplied `_pad` values from TCGETA ioctl are harmless.
     pub fn to_kernel_termios(self, old: &Termios) -> Termios {
         let mut cc = old.control_characters;
         cc[..NCC].copy_from_slice(&self.c_cc);

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -440,8 +440,11 @@ impl TtyCore {
 
             // Retry drain_output while output_lock is held by a concurrent
             // writer.  Bounded to prevent indefinite stall.
+            // TODO: use wait_event on output_lock release instead of fixed retries
+            //       (tracked at issue/TERMIOS_WAIT_drain).
+            const DRAIN_RETRIES: u32 = 32;
             let mut ldisc_drained = false;
-            for _ in 0..8 {
+            for _ in 0..DRAIN_RETRIES {
                 match ld.drain_output(tty.clone()) {
                     Ok(true) => {
                         ldisc_drained = true;
@@ -453,11 +456,21 @@ impl TtyCore {
                     Err(e) => return Err(e),
                 }
             }
-            // Proceed even if ldisc_drained is false — documented limitation.
-            let _ = ldisc_drained;
+            if !ldisc_drained {
+                log::debug!(
+                    "TERMIOS_WAIT: output_lock held for {} retries, proceeding without full ldisc drain",
+                    DRAIN_RETRIES
+                );
+            }
 
             // Event-driven wait for hardware FIFO drain via write_wq.
             // On PTY, chars_in_buffer returns 0 immediately.
+            //
+            // Return value ignored intentionally: Linux tty_wait_until_sent()
+            // does not propagate errors to the tcsetattr caller either.
+            // A signal-interrupted wait still leaves the drain in a
+            // best-effort state; the caller gets the new termios regardless.
+            // TODO: add wait_event_interruptible_timeout for hung-hardware scenarios.
             let write_wq = tty.core().write_wq();
             let core_ref = tty.core();
             let _ = write_wq.wait_event_interruptible(

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -466,12 +466,25 @@ impl TtyCore {
             )?;
         }
 
+        // Known limitation: a TOCTOU window exists between the final drain
+        // wait above and set_termios_next below. A concurrent writer can
+        // submit new output to the ldisc opost queue during this window,
+        // and the subsequent TERMIOS_FLUSH only flushes the input side
+        // (flush_buffer), so that output escapes drain+flush and gets
+        // transmitted under the new termios settings. Linux mitigates
+        // this by holding termios_rwsem for write across the entire
+        // set_termios call, but concurrent write() faces the same race
+        // there. This is an accepted design trade-off in DragonOS's
+        // non-blocking architecture.
+
         // TCSAFLUSH semantics: flush must happen AFTER drain so that
         // any input arriving during the drain is also discarded.
         // See tty-termios-drain-bugs.md B4.
         if opt.contains(TtySetTermiosOpt::TERMIOS_FLUSH) {
             let ld = tty.ldisc();
-            let _ = ld.flush_buffer(tty.clone());
+            if let Err(e) = ld.flush_buffer(tty.clone()) {
+                log::warn!("flush_buffer failed during TCSAFLUSH: {:?}", e);
+            }
         }
 
         TtyCore::set_termios_next(tty, tmp_termios)?;

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -431,7 +431,23 @@ impl TtyCore {
         }
 
         if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) {
-            // TODO
+            let ld = tty.ldisc();
+            // Flush ldisc opost + echo buffers. The returned bool indicates
+            // whether opost_pending was fully drained; a `false` means the
+            // output lock was held by a concurrent writer and the opost
+            // state could not be inspected (see drain_output docs).
+            let _ldisc_drained = ld.drain_output(tty.clone())?;
+
+            // Poll the hardware buffer with scheduler yields between
+            // iterations so device IRQs get CPU time to drain the FIFO.
+            // On PTY, chars_in_buffer() returns 0 immediately.
+            const DRAIN_RETRIES: u32 = 100;
+            for _ in 0..DRAIN_RETRIES {
+                if tty.chars_in_buffer(tty.core()) == 0 {
+                    break;
+                }
+                crate::sched::sched_yield();
+            }
         }
 
         TtyCore::set_termios_next(tty, tmp_termios)?;

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -710,6 +710,11 @@ impl TtyCoreData {
         self.hangup_generation.load(Ordering::Acquire)
     }
 
+    #[inline]
+    pub fn file_hung_up(&self, file_hangup_generation: usize) -> bool {
+        self.hangup_generation() != file_hangup_generation
+    }
+
     /// Snapshot the generation assigned to a newly opening file.
     ///
     /// A file which races with an in-progress hangup belongs to the generation

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -145,6 +145,7 @@ impl TtyCore {
             vc_index: AtomicUsize::new(usize::MAX),
             ctrl: SpinLock::new(TtyControlInfo::default()),
             closing: AtomicBool::new(false),
+            hangup_generation: AtomicUsize::new(0),
             flow: SpinLock::new(TtyFlowState::default()),
             link: RwLock::default(),
             epitems: LockedEPItemLinkedList::default(),
@@ -245,10 +246,11 @@ impl TtyCore {
     pub fn tty_vhangup(tty: Arc<TtyCore>) {
         {
             let mut flags = tty.core().flags_write();
-            if flags.contains(TtyFlag::HUPPED) {
+            if flags.intersects(TtyFlag::HUPPED | TtyFlag::HUPPING) {
                 return;
             }
             flags.insert(TtyFlag::HUPPING);
+            tty.core().hangup_generation.fetch_add(1, Ordering::AcqRel);
         }
 
         let (sid, pgid) = {
@@ -647,6 +649,10 @@ pub struct TtyCoreData {
     ctrl: SpinLock<TtyControlInfo>,
     /// 是否正在关闭
     closing: AtomicBool,
+    /// Incremented when a hangup starts so file instances opened before that
+    /// point retain Linux's hung_up_tty_fops semantics independently of later
+    /// reopens.
+    hangup_generation: AtomicUsize,
     /// 流控状态
     flow: SpinLock<TtyFlowState>,
     /// 链接tty
@@ -697,6 +703,36 @@ impl TtyCoreData {
     #[inline]
     pub fn flags_write(&self) -> RwLockWriteGuard<'_, TtyFlag> {
         self.flags.write_irqsave()
+    }
+
+    #[inline]
+    pub fn hangup_generation(&self) -> usize {
+        self.hangup_generation.load(Ordering::Acquire)
+    }
+
+    /// Snapshot the generation assigned to a newly opening file.
+    ///
+    /// A file which races with an in-progress hangup belongs to the generation
+    /// being hung up. Holding the flags read lock pairs this decision with the
+    /// generation increment performed under the flags write lock.
+    pub fn file_open_hangup_generation(&self) -> usize {
+        let flags = self.flags.read_irqsave();
+        let generation = self.hangup_generation.load(Ordering::Acquire);
+        if flags.contains(TtyFlag::HUPPING) {
+            generation.wrapping_sub(1)
+        } else {
+            generation
+        }
+    }
+
+    /// Clear a completed pre-open hangup only if no newer hangup raced with
+    /// this open. The generation comparison and flag update share the same
+    /// critical section as tty_vhangup's generation increment.
+    pub fn finish_file_open(&self, file_hangup_generation: usize) {
+        let mut flags = self.flags.write_irqsave();
+        if self.hangup_generation.load(Ordering::Acquire) == file_hangup_generation {
+            flags.remove(TtyFlag::HUPPED);
+        }
     }
 
     pub fn private_fields(&self) -> Option<Arc<dyn TtyCorePrivateField>> {

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -409,7 +409,7 @@ impl TtyCore {
 
         #[allow(unused_assignments)]
         // TERMIOS_TERMIO下会用到
-        let mut tmp_termios = *tty.core().termios();
+        let mut tmp_termios = tty.core().committed_termios_snapshot();
 
         if opt.contains(TtySetTermiosOpt::TERMIOS_TERMIO) {
             let user_reader = UserBufferReader::new(

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -367,6 +367,9 @@ impl TtyCore {
     }
 
     pub fn tty_perform_flush(tty: Arc<TtyCore>, arg: usize) -> Result<usize, SystemError> {
+        // Job control check for TCFLSH ioctl.  This is a separate path
+        // from core_set_termios (termios ioctls); the two are never
+        // invoked concurrently for the same operation.
         TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTOU)?;
 
         match arg {
@@ -396,6 +399,8 @@ impl TtyCore {
         // Check job control: prevent background process groups from changing
         // terminal attributes without permission.  Matches Linux 6.6
         // set_termios() which calls tty_check_change() before any work.
+        // This path is separate from tty_perform_flush (TCFLSH ioctl);
+        // the two never overlap in a single operation.
         TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTOU)?;
 
         #[allow(unused_assignments)]
@@ -411,12 +416,6 @@ impl TtyCore {
             let mut termio = PosixTermio::default();
             user_reader.copy_one_from_user(&mut termio, 0)?;
             tmp_termios = termio.to_kernel_termios(&tmp_termios);
-            // termio carries no speed fields; derive speeds from the merged
-            // c_cflag exactly as Linux set_termios() does after
-            // user_termio_to_kernel_termios().
-            let (ispeed, ospeed) = PosixTermio::speeds_from_cflag(tmp_termios.control_mode);
-            tmp_termios.input_speed = ispeed;
-            tmp_termios.output_speed = ospeed;
         } else {
             let user_reader = UserBufferReader::new(
                 arg.as_ptr::<PosixTermios>(),
@@ -430,53 +429,49 @@ impl TtyCore {
             tmp_termios = term.to_kernel_termios();
         }
 
+        if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) {
+            let ld = tty.ldisc();
+            let write_wq = tty.core().write_wq();
+            let core_ref = tty.core();
+
+            // Drain N_TTY output-processing and echo backlog.
+            // drain_output blocks on output_lock; when the hardware FIFO
+            // is full, drain_output returns Ok(false) — loop until both
+            // ldisc queues are fully drained.
+            //
+            // On PTY, chars_in_buffer always returns 0, so the
+            // wait_event_interruptible below returns immediately.
+            // The loop still converges: drain_output serialises via
+            // output_lock, and the PTY master consumes data
+            // asynchronously so the next drain_output pass sees an
+            // empty FIFO.
+            loop {
+                if ld.drain_output(tty.clone())? {
+                    break;
+                }
+                // Hardware FIFO was full — wait for it to drain before
+                // re-draining ldisc.  Signal-interrupted waits propagate
+                // ERESTARTSYS so that Ctrl+C does not silently apply the
+                // new termios (matches Linux behaviour).
+                write_wq.wait_event_interruptible(
+                    (EPollEventType::EPOLLOUT.bits() | EPollEventType::EPOLLWRNORM.bits()) as u64,
+                    || tty.chars_in_buffer(core_ref) == 0,
+                )?;
+            }
+            // Final wait: ensure all hardware FIFOs are empty.
+            // Returns immediately on PTY (chars_in_buffer == 0).
+            write_wq.wait_event_interruptible(
+                (EPollEventType::EPOLLOUT.bits() | EPollEventType::EPOLLWRNORM.bits()) as u64,
+                || tty.chars_in_buffer(core_ref) == 0,
+            )?;
+        }
+
+        // TCSAFLUSH semantics: flush must happen AFTER drain so that
+        // any input arriving during the drain is also discarded.
+        // See tty-termios-drain-bugs.md B4.
         if opt.contains(TtySetTermiosOpt::TERMIOS_FLUSH) {
             let ld = tty.ldisc();
             let _ = ld.flush_buffer(tty.clone());
-        }
-
-        if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) {
-            let ld = tty.ldisc();
-
-            // Retry drain_output while output_lock is held by a concurrent
-            // writer.  Bounded to prevent indefinite stall.
-            // TODO: use wait_event on output_lock release instead of fixed retries
-            //       (tracked at issue/TERMIOS_WAIT_drain).
-            const DRAIN_RETRIES: u32 = 32;
-            let mut ldisc_drained = false;
-            for _ in 0..DRAIN_RETRIES {
-                match ld.drain_output(tty.clone()) {
-                    Ok(true) => {
-                        ldisc_drained = true;
-                        break;
-                    }
-                    Ok(false) => {
-                        crate::sched::sched_yield();
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-            if !ldisc_drained {
-                log::debug!(
-                    "TERMIOS_WAIT: output_lock held for {} retries, proceeding without full ldisc drain",
-                    DRAIN_RETRIES
-                );
-            }
-
-            // Event-driven wait for hardware FIFO drain via write_wq.
-            // On PTY, chars_in_buffer returns 0 immediately.
-            //
-            // Return value ignored intentionally: Linux tty_wait_until_sent()
-            // does not propagate errors to the tcsetattr caller either.
-            // A signal-interrupted wait still leaves the drain in a
-            // best-effort state; the caller gets the new termios regardless.
-            // TODO: add wait_event_interruptible_timeout for hung-hardware scenarios.
-            let write_wq = tty.core().write_wq();
-            let core_ref = tty.core();
-            let _ = write_wq.wait_event_interruptible(
-                (EPollEventType::EPOLLOUT.bits() | EPollEventType::EPOLLWRNORM.bits()) as u64,
-                || tty.chars_in_buffer(core_ref) == 0,
-            );
         }
 
         TtyCore::set_termios_next(tty, tmp_termios)?;

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -294,7 +294,7 @@ impl TtyCore {
         };
         match cmd {
             TtyIoctlCmd::TCGETS => {
-                let termios = PosixTermios::from_kernel_termios(*real_tty.core.termios());
+                let termios = PosixTermios::from_kernel_termios(&real_tty.core.termios());
                 let mut user_writer = UserBufferWriter::new(
                     VirtAddr::new(arg).as_ptr::<PosixTermios>(),
                     core::mem::size_of::<PosixTermios>(),

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -393,6 +393,11 @@ impl TtyCore {
         arg: VirtAddr,
         opt: TtySetTermiosOpt,
     ) -> Result<usize, SystemError> {
+        // Check job control: prevent background process groups from changing
+        // terminal attributes without permission.  Matches Linux 6.6
+        // set_termios() which calls tty_check_change() before any work.
+        TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTOU)?;
+
         #[allow(unused_assignments)]
         // TERMIOS_TERMIO下会用到
         let mut tmp_termios = *tty.core().termios();

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 use super::{
-    termios::{ControlMode, PosixTermios, Termios, TtySetTermiosOpt, WindowSize},
+    termios::{ControlMode, PosixTermio, PosixTermios, Termios, TtySetTermiosOpt, WindowSize},
     tty_driver::{TtyCorePrivateField, TtyDriver, TtyDriverSubType, TtyDriverType, TtyOperation},
     tty_job_control::TtyJobCtrlManager,
     tty_ldisc::{
@@ -365,7 +365,20 @@ impl TtyCore {
         let mut tmp_termios = *tty.core().termios();
 
         if opt.contains(TtySetTermiosOpt::TERMIOS_TERMIO) {
-            todo!()
+            let user_reader = UserBufferReader::new(
+                arg.as_ptr::<PosixTermio>(),
+                core::mem::size_of::<PosixTermio>(),
+                true,
+            )?;
+            let mut termio = PosixTermio::default();
+            user_reader.copy_one_from_user(&mut termio, 0)?;
+            tmp_termios = termio.to_kernel_termios(&tmp_termios);
+            // termio carries no speed fields; derive speeds from the merged
+            // c_cflag exactly as Linux set_termios() does after
+            // user_termio_to_kernel_termios().
+            let (ispeed, ospeed) = PosixTermio::speeds_from_cflag(tmp_termios.control_mode);
+            tmp_termios.input_speed = ispeed;
+            tmp_termios.output_speed = ospeed;
         } else {
             let user_reader = UserBufferReader::new(
                 arg.as_ptr::<PosixTermios>(),

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -287,9 +287,9 @@ impl TtyCore {
 
     pub fn tty_mode_ioctl(tty: Arc<TtyCore>, cmd: u32, arg: usize) -> Result<usize, SystemError> {
         let core = tty.core();
-        let real_tty = if core.driver().tty_driver_type() == TtyDriverType::Pty
-            && core.driver().tty_driver_sub_type() == TtyDriverSubType::PtyMaster
-        {
+        let redirected_from_pty_master = core.driver().tty_driver_type() == TtyDriverType::Pty
+            && core.driver().tty_driver_sub_type() == TtyDriverSubType::PtyMaster;
+        let real_tty = if redirected_from_pty_master {
             core.link().unwrap()
         } else {
             tty
@@ -323,6 +323,7 @@ impl TtyCore {
                     real_tty,
                     VirtAddr::new(arg),
                     TtySetTermiosOpt::TERMIOS_OLD,
+                    redirected_from_pty_master,
                 );
             }
             TtyIoctlCmd::TCSETSW => {
@@ -330,6 +331,7 @@ impl TtyCore {
                     real_tty,
                     VirtAddr::new(arg),
                     TtySetTermiosOpt::TERMIOS_WAIT | TtySetTermiosOpt::TERMIOS_OLD,
+                    redirected_from_pty_master,
                 );
             }
             TtyIoctlCmd::TCSETSF => {
@@ -339,6 +341,7 @@ impl TtyCore {
                     TtySetTermiosOpt::TERMIOS_FLUSH
                         | TtySetTermiosOpt::TERMIOS_WAIT
                         | TtySetTermiosOpt::TERMIOS_OLD,
+                    redirected_from_pty_master,
                 );
             }
             TtyIoctlCmd::TCSETA => {
@@ -346,6 +349,7 @@ impl TtyCore {
                     real_tty,
                     VirtAddr::new(arg),
                     TtySetTermiosOpt::TERMIOS_TERMIO,
+                    redirected_from_pty_master,
                 );
             }
             TtyIoctlCmd::TCSETAW => {
@@ -353,6 +357,7 @@ impl TtyCore {
                     real_tty,
                     VirtAddr::new(arg),
                     TtySetTermiosOpt::TERMIOS_WAIT | TtySetTermiosOpt::TERMIOS_TERMIO,
+                    redirected_from_pty_master,
                 );
             }
             TtyIoctlCmd::TCSETAF => {
@@ -362,6 +367,7 @@ impl TtyCore {
                     TtySetTermiosOpt::TERMIOS_FLUSH
                         | TtySetTermiosOpt::TERMIOS_WAIT
                         | TtySetTermiosOpt::TERMIOS_TERMIO,
+                    redirected_from_pty_master,
                 );
             }
             _ => {
@@ -399,6 +405,7 @@ impl TtyCore {
         tty: Arc<TtyCore>,
         arg: VirtAddr,
         opt: TtySetTermiosOpt,
+        redirected_from_pty_master: bool,
     ) -> Result<usize, SystemError> {
         // Check job control: prevent background process groups from changing
         // terminal attributes without permission.  Matches Linux 6.6
@@ -440,39 +447,44 @@ impl TtyCore {
                 let write_guard = tty.core().write_lock().lock_interruptible(false)?;
                 let termios_guard = tty.core().termios_write_lock_interruptible()?;
 
-                if Self::output_terminal_error(tty.core()) {
+                let output_closed = Self::output_terminal_closed(tty.core());
+                if output_closed && !redirected_from_pty_master {
                     return Err(SystemError::EIO);
                 }
 
-                match tty.ldisc().drain_output(tty.clone())? {
-                    TtyLdiscDrainResult::Drained => {}
-                    TtyLdiscDrainResult::NeedWriteRoom(required) => {
-                        let required = required.max(1);
+                if !output_closed {
+                    match tty.ldisc().drain_output(tty.clone())? {
+                        TtyLdiscDrainResult::Drained => {}
+                        TtyLdiscDrainResult::NeedWriteRoom(required) => {
+                            let required = required.max(1);
+                            drop(termios_guard);
+                            drop(write_guard);
+                            tty.core().write_wq().wait_event_interruptible(events, || {
+                                Self::output_terminal_closed(tty.core())
+                                    || tty.write_room(tty.core()) >= required
+                                    || !tty.ldisc().output_pending()
+                            })?;
+                            if Self::output_terminal_closed(tty.core())
+                                && !redirected_from_pty_master
+                            {
+                                return Err(SystemError::EIO);
+                            }
+                            continue;
+                        }
+                    }
+
+                    if tty.chars_in_buffer(tty.core()) != 0 {
                         drop(termios_guard);
                         drop(write_guard);
                         tty.core().write_wq().wait_event_interruptible(events, || {
-                            Self::output_terminal_error(tty.core())
-                                || tty.write_room(tty.core()) >= required
-                                || !tty.ldisc().output_pending()
+                            Self::output_terminal_closed(tty.core())
+                                || tty.chars_in_buffer(tty.core()) == 0
                         })?;
-                        if Self::output_terminal_error(tty.core()) {
+                        if Self::output_terminal_closed(tty.core()) && !redirected_from_pty_master {
                             return Err(SystemError::EIO);
                         }
                         continue;
                     }
-                }
-
-                if tty.chars_in_buffer(tty.core()) != 0 {
-                    drop(termios_guard);
-                    drop(write_guard);
-                    tty.core().write_wq().wait_event_interruptible(events, || {
-                        Self::output_terminal_error(tty.core())
-                            || tty.chars_in_buffer(tty.core()) == 0
-                    })?;
-                    if Self::output_terminal_error(tty.core()) {
-                        return Err(SystemError::EIO);
-                    }
-                    continue;
                 }
 
                 // Linux flushes input and waits for the physical transmitter
@@ -487,14 +499,14 @@ impl TtyCore {
                     tty.ldisc().flush_buffer(tty.clone())?;
                 }
 
-                if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) {
+                if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) && !output_closed {
                     tty.wait_until_sent(tty.core())?;
                     let current = ProcessManager::current_pcb();
                     if current.has_pending_signal_fast() && current.has_pending_not_masked_signal()
                     {
                         return Err(SystemError::ERESTARTSYS);
                     }
-                    if Self::output_terminal_error(tty.core()) {
+                    if Self::output_terminal_closed(tty.core()) && !redirected_from_pty_master {
                         return Err(SystemError::EIO);
                     }
                 }
@@ -548,7 +560,7 @@ impl TtyCore {
         Ok(())
     }
 
-    fn output_terminal_error(core: &TtyCoreData) -> bool {
+    fn output_terminal_closed(core: &TtyCoreData) -> bool {
         let flags = core.flags();
         flags.intersects(TtyFlag::IO_ERROR | TtyFlag::HUPPED | TtyFlag::HUPPING)
             || (flags.contains(TtyFlag::OTHER_CLOSED)

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -16,6 +16,7 @@ use crate::{
         event_poll::{EventPoll, LockedEPItemLinkedList},
         EPollEventType, EPollItem,
     },
+    filesystem::vfs::fasync::{FAsyncItem, FAsyncItems},
     libs::{
         rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableGuard, RwLockWriteGuard},
         rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
@@ -149,6 +150,7 @@ impl TtyCore {
             flow: SpinLock::new(TtyFlowState::default()),
             link: RwLock::default(),
             epitems: LockedEPItemLinkedList::default(),
+            fasync_items: FAsyncItems::new(),
             device_number,
             privete_fields: SpinLock::new(None),
         };
@@ -252,6 +254,10 @@ impl TtyCore {
             flags.insert(TtyFlag::HUPPING);
             tty.core().hangup_generation.fetch_add(1, Ordering::AcqRel);
         }
+        // Linux removes fasync registrations before replacing existing tty
+        // file operations with hung_up_tty_fops. This also clears O_ASYNC on
+        // every pre-hangup open file description.
+        tty.core().fasync_items.clear();
 
         let (sid, pgid) = {
             let ctrl = tty.core().contorl_info_irqsave();
@@ -659,6 +665,8 @@ pub struct TtyCoreData {
     link: RwLock<Weak<TtyCore>>,
     /// epitems
     epitems: LockedEPItemLinkedList,
+    /// Open file descriptions registered for asynchronous TTY notification.
+    fasync_items: FAsyncItems,
     /// 设备号
     device_number: DeviceNumber,
 
@@ -738,6 +746,29 @@ impl TtyCoreData {
         if self.hangup_generation.load(Ordering::Acquire) == file_hangup_generation {
             flags.remove(TtyFlag::HUPPED);
         }
+    }
+
+    pub fn add_fasync(
+        &self,
+        file_hangup_generation: usize,
+        item: FAsyncItem,
+    ) -> Result<(), SystemError> {
+        let flags = self.flags.read_irqsave();
+        if flags.contains(TtyFlag::HUPPING)
+            || self.hangup_generation.load(Ordering::Acquire) != file_hangup_generation
+        {
+            return Err(SystemError::ENOTTY);
+        }
+        self.fasync_items.add(item);
+        Ok(())
+    }
+
+    pub fn remove_fasync(&self, file: &Weak<crate::filesystem::vfs::file::File>) {
+        self.fasync_items.remove(file);
+    }
+
+    pub fn remove_fasync_file(&self, file: &crate::filesystem::vfs::file::File) {
+        self.fasync_items.remove_file(file);
     }
 
     pub fn private_fields(&self) -> Option<Arc<dyn TtyCorePrivateField>> {

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -432,22 +432,33 @@ impl TtyCore {
 
         if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) {
             let ld = tty.ldisc();
-            // Flush ldisc opost + echo buffers. The returned bool indicates
-            // whether opost_pending was fully drained; a `false` means the
-            // output lock was held by a concurrent writer and the opost
-            // state could not be inspected (see drain_output docs).
-            let _ldisc_drained = ld.drain_output(tty.clone())?;
 
-            // Poll the hardware buffer with scheduler yields between
-            // iterations so device IRQs get CPU time to drain the FIFO.
-            // On PTY, chars_in_buffer() returns 0 immediately.
-            const DRAIN_RETRIES: u32 = 100;
-            for _ in 0..DRAIN_RETRIES {
-                if tty.chars_in_buffer(tty.core()) == 0 {
-                    break;
+            // Retry drain_output while output_lock is held by a concurrent
+            // writer.  Bounded to prevent indefinite stall.
+            let mut ldisc_drained = false;
+            for _ in 0..8 {
+                match ld.drain_output(tty.clone()) {
+                    Ok(true) => {
+                        ldisc_drained = true;
+                        break;
+                    }
+                    Ok(false) => {
+                        crate::sched::sched_yield();
+                    }
+                    Err(e) => return Err(e),
                 }
-                crate::sched::sched_yield();
             }
+            // Proceed even if ldisc_drained is false — documented limitation.
+            let _ = ldisc_drained;
+
+            // Event-driven wait for hardware FIFO drain via write_wq.
+            // On PTY, chars_in_buffer returns 0 immediately.
+            let write_wq = tty.core().write_wq();
+            let core_ref = tty.core();
+            let _ = write_wq.wait_event_interruptible(
+                (EPollEventType::EPOLLOUT.bits() | EPollEventType::EPOLLWRNORM.bits()) as u64,
+                || tty.chars_in_buffer(core_ref) == 0,
+            );
         }
 
         TtyCore::set_termios_next(tty, tmp_termios)?;

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -304,6 +304,16 @@ impl TtyCore {
                 user_writer.copy_one_to_user(&termios, 0)?;
                 return Ok(0);
             }
+            TtyIoctlCmd::TCGETA => {
+                let termio = PosixTermio::from_kernel_termios(&real_tty.core.termios());
+                let mut user_writer = UserBufferWriter::new(
+                    VirtAddr::new(arg).as_ptr::<PosixTermio>(),
+                    core::mem::size_of::<PosixTermio>(),
+                    true,
+                )?;
+                user_writer.copy_one_to_user(&termio, 0)?;
+                return Ok(0);
+            }
             TtyIoctlCmd::TCSETS => {
                 return TtyCore::core_set_termios(
                     real_tty,
@@ -325,6 +335,29 @@ impl TtyCore {
                     TtySetTermiosOpt::TERMIOS_FLUSH
                         | TtySetTermiosOpt::TERMIOS_WAIT
                         | TtySetTermiosOpt::TERMIOS_OLD,
+                );
+            }
+            TtyIoctlCmd::TCSETA => {
+                return TtyCore::core_set_termios(
+                    real_tty,
+                    VirtAddr::new(arg),
+                    TtySetTermiosOpt::TERMIOS_TERMIO,
+                );
+            }
+            TtyIoctlCmd::TCSETAW => {
+                return TtyCore::core_set_termios(
+                    real_tty,
+                    VirtAddr::new(arg),
+                    TtySetTermiosOpt::TERMIOS_WAIT | TtySetTermiosOpt::TERMIOS_TERMIO,
+                );
+            }
+            TtyIoctlCmd::TCSETAF => {
+                return TtyCore::core_set_termios(
+                    real_tty,
+                    VirtAddr::new(arg),
+                    TtySetTermiosOpt::TERMIOS_FLUSH
+                        | TtySetTermiosOpt::TERMIOS_WAIT
+                        | TtySetTermiosOpt::TERMIOS_TERMIO,
                 );
             }
             _ => {

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -18,11 +18,12 @@ use crate::{
     },
     libs::{
         rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableGuard, RwLockWriteGuard},
+        rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
         wait_queue::{EventWaitQueue, WaitQueue},
     },
     mm::VirtAddr,
-    process::{pid::Pid, ProcessControlBlock},
+    process::{pid::Pid, ProcessControlBlock, ProcessManager},
     syscall::user_access::{UserBufferReader, UserBufferWriter},
 };
 
@@ -32,7 +33,7 @@ use super::{
     tty_job_control::TtyJobCtrlManager,
     tty_ldisc::{
         ntty::{NTtyData, NTtyLinediscipline},
-        TtyLineDiscipline,
+        TtyLdiscDrainResult, TtyLineDiscipline,
     },
     tty_port::TtyPort,
     virtual_terminal::{vc_manager, virtual_console::VirtualConsoleData, DrawRegion},
@@ -131,6 +132,7 @@ impl TtyCore {
         let core = TtyCoreData {
             tty_driver: driver,
             termios: RwLock::new(termios),
+            termios_rwsem: RwSem::new(()),
             name,
             flags: RwLock::new(TtyFlag::empty()),
             count: AtomicUsize::new(0),
@@ -294,7 +296,8 @@ impl TtyCore {
         };
         match cmd {
             TtyIoctlCmd::TCGETS => {
-                let termios = PosixTermios::from_kernel_termios(&real_tty.core.termios());
+                let snapshot = real_tty.core.committed_termios_snapshot();
+                let termios = PosixTermios::from_kernel_termios(&snapshot);
                 let mut user_writer = UserBufferWriter::new(
                     VirtAddr::new(arg).as_ptr::<PosixTermios>(),
                     core::mem::size_of::<PosixTermios>(),
@@ -305,7 +308,8 @@ impl TtyCore {
                 return Ok(0);
             }
             TtyIoctlCmd::TCGETA => {
-                let termio = PosixTermio::from_kernel_termios(&real_tty.core.termios());
+                let snapshot = real_tty.core.committed_termios_snapshot();
+                let termio = PosixTermio::from_kernel_termios(&snapshot);
                 let mut user_writer = UserBufferWriter::new(
                     VirtAddr::new(arg).as_ptr::<PosixTermio>(),
                     core::mem::size_of::<PosixTermio>(),
@@ -429,69 +433,96 @@ impl TtyCore {
             tmp_termios = term.to_kernel_termios();
         }
 
-        if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) {
-            let ld = tty.ldisc();
-            let write_wq = tty.core().write_wq();
-            let core_ref = tty.core();
+        if opt.intersects(TtySetTermiosOpt::TERMIOS_WAIT | TtySetTermiosOpt::TERMIOS_FLUSH) {
+            let events = (EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM).bits() as u64;
 
-            // Drain N_TTY output-processing and echo backlog.
-            // drain_output blocks on output_lock; when the hardware FIFO
-            // is full, drain_output returns Ok(false) — loop until both
-            // ldisc queues are fully drained.
-            //
-            // On PTY, chars_in_buffer always returns 0, so the
-            // wait_event_interruptible below returns immediately.
-            // The loop still converges: drain_output serialises via
-            // output_lock, and the PTY master consumes data
-            // asynchronously so the next drain_output pass sees an
-            // empty FIFO.
             loop {
-                if ld.drain_output(tty.clone())? {
-                    break;
+                let write_guard = tty.core().write_lock().lock_interruptible(false)?;
+                let termios_guard = tty.core().termios_write_lock_interruptible()?;
+
+                if Self::output_terminal_error(tty.core()) {
+                    return Err(SystemError::EIO);
                 }
-                // Hardware FIFO was full — wait for it to drain before
-                // re-draining ldisc.  Signal-interrupted waits propagate
-                // ERESTARTSYS so that Ctrl+C does not silently apply the
-                // new termios (matches Linux behaviour).
-                write_wq.wait_event_interruptible(
-                    (EPollEventType::EPOLLOUT.bits() | EPollEventType::EPOLLWRNORM.bits()) as u64,
-                    || tty.chars_in_buffer(core_ref) == 0,
-                )?;
+
+                match tty.ldisc().drain_output(tty.clone())? {
+                    TtyLdiscDrainResult::Drained => {}
+                    TtyLdiscDrainResult::NeedWriteRoom(required) => {
+                        let required = required.max(1);
+                        drop(termios_guard);
+                        drop(write_guard);
+                        tty.core().write_wq().wait_event_interruptible(events, || {
+                            Self::output_terminal_error(tty.core())
+                                || tty.write_room(tty.core()) >= required
+                                || !tty.ldisc().output_pending()
+                        })?;
+                        if Self::output_terminal_error(tty.core()) {
+                            return Err(SystemError::EIO);
+                        }
+                        continue;
+                    }
+                }
+
+                if tty.chars_in_buffer(tty.core()) != 0 {
+                    drop(termios_guard);
+                    drop(write_guard);
+                    tty.core().write_wq().wait_event_interruptible(events, || {
+                        Self::output_terminal_error(tty.core())
+                            || tty.chars_in_buffer(tty.core()) == 0
+                    })?;
+                    if Self::output_terminal_error(tty.core()) {
+                        return Err(SystemError::EIO);
+                    }
+                    continue;
+                }
+
+                // Linux flushes input and waits for the physical transmitter
+                // before tty_set_termios() takes termios_rwsem for the short
+                // attribute transaction. Keeping the write side of the
+                // semaphore across either operation can deadlock synchronous
+                // input producers and unnecessarily stalls RX at low baud.
+                drop(termios_guard);
+
+                // Linux performs input flush after the output-drain recheck.
+                if opt.contains(TtySetTermiosOpt::TERMIOS_FLUSH) {
+                    tty.ldisc().flush_buffer(tty.clone())?;
+                }
+
+                if opt.contains(TtySetTermiosOpt::TERMIOS_WAIT) {
+                    tty.wait_until_sent(tty.core())?;
+                    let current = ProcessManager::current_pcb();
+                    if current.has_pending_signal_fast() && current.has_pending_not_masked_signal()
+                    {
+                        return Err(SystemError::ERESTARTSYS);
+                    }
+                    if Self::output_terminal_error(tty.core()) {
+                        return Err(SystemError::EIO);
+                    }
+                }
+
+                let termios_guard = tty.core().termios_write_lock_interruptible()?;
+                let result = Self::set_termios_locked(tty.clone(), tmp_termios);
+                drop(termios_guard);
+                drop(write_guard);
+                Self::retry_deferred_output(&tty);
+                result?;
+                return Ok(0);
             }
-            // Final wait: ensure all hardware FIFOs are empty.
-            // Returns immediately on PTY (chars_in_buffer == 0).
-            write_wq.wait_event_interruptible(
-                (EPollEventType::EPOLLOUT.bits() | EPollEventType::EPOLLWRNORM.bits()) as u64,
-                || tty.chars_in_buffer(core_ref) == 0,
-            )?;
         }
 
-        // Known limitation: a TOCTOU window exists between the final drain
-        // wait above and set_termios_next below. A concurrent writer can
-        // submit new output to the ldisc opost queue during this window,
-        // and the subsequent TERMIOS_FLUSH only flushes the input side
-        // (flush_buffer), so that output escapes drain+flush and gets
-        // transmitted under the new termios settings. Linux mitigates
-        // this by holding termios_rwsem for write across the entire
-        // set_termios call, but concurrent write() faces the same race
-        // there. This is an accepted design trade-off in DragonOS's
-        // non-blocking architecture.
-
-        // TCSAFLUSH semantics: flush must happen AFTER drain so that
-        // any input arriving during the drain is also discarded.
-        // See tty-termios-drain-bugs.md B4.
-        if opt.contains(TtySetTermiosOpt::TERMIOS_FLUSH) {
-            let ld = tty.ldisc();
-            if let Err(e) = ld.flush_buffer(tty.clone()) {
-                log::warn!("flush_buffer failed during TCSAFLUSH: {:?}", e);
-            }
-        }
-
-        TtyCore::set_termios_next(tty, tmp_termios)?;
+        Self::set_termios_next(tty, tmp_termios)?;
         Ok(0)
     }
 
     fn set_termios_next(tty: Arc<TtyCore>, new_termios: Termios) -> Result<(), SystemError> {
+        let termios_guard = tty.core().termios_write_lock_interruptible()?;
+        let result = Self::set_termios_locked(tty.clone(), new_termios);
+        drop(termios_guard);
+        Self::retry_deferred_output(&tty);
+        result
+    }
+
+    /// Apply termios while the caller holds `termios_write_lock_interruptible()`.
+    fn set_termios_locked(tty: Arc<TtyCore>, new_termios: Termios) -> Result<(), SystemError> {
         let mut termios = tty.core().termios_write();
 
         let old_termios = *termios;
@@ -515,6 +546,19 @@ impl TtyCore {
         ld.set_termios(tty, Some(old_termios)).ok();
 
         Ok(())
+    }
+
+    fn output_terminal_error(core: &TtyCoreData) -> bool {
+        let flags = core.flags();
+        flags.intersects(TtyFlag::IO_ERROR | TtyFlag::HUPPED | TtyFlag::HUPPING)
+            || (flags.contains(TtyFlag::OTHER_CLOSED)
+                && core.driver().tty_driver_sub_type() != TtyDriverSubType::PtyMaster)
+    }
+
+    fn retry_deferred_output(tty: &Arc<TtyCore>) {
+        if tty.core().flags().contains(TtyFlag::DO_WRITE_WAKEUP) {
+            tty.tty_wakeup();
+        }
     }
 
     pub fn tty_do_resize(&self, windowsize: WindowSize) -> Result<(), SystemError> {
@@ -569,6 +613,8 @@ pub struct TtyFlowState {
 pub struct TtyCoreData {
     tty_driver: Arc<TtyDriver>,
     termios: RwLock<Termios>,
+    /// Serializes termios users with the update + driver/ldisc notification transaction.
+    termios_rwsem: RwSem<()>,
     name: String,
     flags: RwLock<TtyFlag>,
     /// 在初始化时即确定不会更改，所以这里不用加锁
@@ -653,6 +699,37 @@ impl TtyCoreData {
     #[inline]
     pub fn termios_write(&self) -> RwLockWriteGuard<'_, Termios> {
         self.termios.write_irqsave()
+    }
+
+    /// Snapshot only a fully committed termios transaction.
+    pub fn committed_termios_snapshot(&self) -> Termios {
+        let _guard = self.termios_read_lock();
+        *self.termios()
+    }
+
+    #[inline]
+    pub fn termios_read_lock(&self) -> RwSemReadGuard<'_, ()> {
+        self.termios_rwsem.read()
+    }
+
+    #[inline]
+    pub fn termios_read_lock_interruptible(&self) -> Result<RwSemReadGuard<'_, ()>, SystemError> {
+        self.termios_rwsem.read_interruptible()
+    }
+
+    #[inline]
+    pub fn termios_try_read_lock(&self) -> Option<RwSemReadGuard<'_, ()>> {
+        self.termios_rwsem.try_read()
+    }
+
+    #[inline]
+    pub fn termios_write_lock_interruptible(&self) -> Result<RwSemWriteGuard<'_, ()>, SystemError> {
+        self.termios_rwsem.write_interruptible()
+    }
+
+    #[inline]
+    pub fn termios_write_lock(&self) -> RwSemWriteGuard<'_, ()> {
+        self.termios_rwsem.write()
     }
 
     #[inline]
@@ -893,6 +970,11 @@ impl TtyOperation for TtyCore {
     #[inline]
     fn chars_in_buffer(&self, tty: &TtyCoreData) -> usize {
         return tty.tty_driver.driver_funcs().chars_in_buffer(tty);
+    }
+
+    #[inline]
+    fn wait_until_sent(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
+        tty.tty_driver.driver_funcs().wait_until_sent(tty)
     }
 
     #[inline]

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -31,6 +31,7 @@ use crate::{
         epoll::{EPollEventType, EPollItem},
         kernfs::KernFSInode,
         vfs::{
+            fasync::FAsyncItem,
             file::{File, FileFlags},
             utils::DName,
             FilePrivateData, FileType, IndexNode, InodeMode, Metadata, PollableInode,
@@ -150,13 +151,12 @@ impl TtyDevice {
         &self.name
     }
 
-    fn tty_core(private_data: &FilePrivateData) -> Result<Arc<TtyCore>, SystemError> {
-        let (tty, _) = if let FilePrivateData::Tty(tty_priv) = private_data {
-            (tty_priv.tty.clone(), tty_priv.flags)
+    fn tty_file(private_data: &FilePrivateData) -> Result<&TtyFilePrivateData, SystemError> {
+        if let FilePrivateData::Tty(tty_priv) = private_data {
+            Ok(tty_priv)
         } else {
-            return Err(SystemError::EIO);
-        };
-        Ok(tty)
+            Err(SystemError::EIO)
+        }
     }
 
     /// tty_open_current_tty - get locked tty of current task
@@ -193,7 +193,18 @@ impl Debug for TtyDevice {
 
 impl PollableInode for TtyDevice {
     fn poll(&self, private_data: &FilePrivateData) -> Result<usize, SystemError> {
-        let tty = TtyDevice::tty_core(private_data)?;
+        let tty_file = TtyDevice::tty_file(private_data)?;
+        if tty_file.is_hung_up() {
+            return Ok((EPollEventType::EPOLLIN
+                | EPollEventType::EPOLLOUT
+                | EPollEventType::EPOLLERR
+                | EPollEventType::EPOLLHUP
+                | EPollEventType::EPOLLRDNORM
+                | EPollEventType::EPOLLWRNORM)
+                .bits() as usize);
+        }
+
+        let tty = tty_file.tty();
         tty.ldisc().poll(tty)
     }
 
@@ -202,7 +213,15 @@ impl PollableInode for TtyDevice {
         epitem: Arc<EPollItem>,
         private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let tty = TtyDevice::tty_core(private_data)?;
+        let tty_file = TtyDevice::tty_file(private_data)?;
+        if tty_file.is_hung_up() {
+            // hung_up_tty_poll() is permanently ready and does not register
+            // a wait queue. epoll observes the fixed mask immediately after
+            // this callback.
+            return Ok(());
+        }
+
+        let tty = tty_file.tty();
         let core = tty.core();
         core.add_epitem(epitem);
         Ok(())
@@ -213,9 +232,40 @@ impl PollableInode for TtyDevice {
         epitem: &Arc<EPollItem>,
         private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let tty = TtyDevice::tty_core(private_data)?;
+        let tty_file = TtyDevice::tty_file(private_data)?;
+        let hung_up = tty_file.is_hung_up();
+        let tty = tty_file.tty();
         let core = tty.core();
-        core.remove_epitem(epitem)
+        match core.remove_epitem(epitem) {
+            Err(SystemError::ENOENT) if hung_up => Ok(()),
+            result => result,
+        }
+    }
+
+    fn add_fasync(
+        &self,
+        _fasync_item: FAsyncItem,
+        private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        if Self::tty_file(private_data)?.is_hung_up() {
+            Err(SystemError::ENOTTY)
+        } else {
+            // Preserve the existing TTY FIOASYNC behavior until TTY SIGIO
+            // delivery is implemented.
+            Ok(())
+        }
+    }
+
+    fn remove_fasync(
+        &self,
+        _file: &Weak<File>,
+        private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        if Self::tty_file(private_data)?.is_hung_up() {
+            Err(SystemError::ENOTTY)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -313,11 +363,11 @@ impl IndexNode for TtyDevice {
         buf: &mut [u8],
         data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
-        let (tty, flags) = if let FilePrivateData::Tty(tty_priv) = &*data {
-            (tty_priv.tty(), tty_priv.flags)
-        } else {
-            return Err(SystemError::EIO);
-        };
+        let tty_file = Self::tty_file(&data)?;
+        if tty_file.is_hung_up() {
+            return Ok(0);
+        }
+        let (tty, flags) = (tty_file.tty(), tty_file.flags);
 
         drop(data);
 
@@ -362,11 +412,11 @@ impl IndexNode for TtyDevice {
         data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, system_error::SystemError> {
         let mut count = len;
-        let (tty, flags) = if let FilePrivateData::Tty(tty_priv) = &*data {
-            (tty_priv.tty(), tty_priv.flags)
-        } else {
+        let tty_file = Self::tty_file(&data)?;
+        if tty_file.is_hung_up() {
             return Err(SystemError::EIO);
-        };
+        }
+        let (tty, flags) = (tty_file.tty(), tty_file.flags);
         drop(data);
         let ld = tty.ldisc();
         let core = tty.core();
@@ -492,11 +542,9 @@ impl IndexNode for TtyDevice {
         arg: usize,
         data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let (tty, file_hangup_generation) = if let FilePrivateData::Tty(tty_priv) = &*data {
-            (tty_priv.tty(), tty_priv.hangup_generation)
-        } else {
-            return Err(SystemError::EIO);
-        };
+        let tty_file = Self::tty_file(&data)?;
+        let hung_up = tty_file.is_hung_up();
+        let tty = tty_file.tty();
 
         // Drop the lock early: tty ioctl paths may block.
         drop(data);
@@ -505,7 +553,7 @@ impl IndexNode for TtyDevice {
         // with hung_up_tty_fops. A later successful reopen must remain usable.
         // Check the original file endpoint before PTY master mode ioctls
         // redirect to the slave.
-        if file_hangup_generation != tty.core().hangup_generation() {
+        if hung_up {
             return if cmd == TtyIoctlCmd::TIOCSPGRP {
                 Err(SystemError::ENOTTY)
             } else {
@@ -791,6 +839,10 @@ pub struct TtyFilePrivateData {
 impl TtyFilePrivateData {
     pub fn tty(&self) -> Arc<TtyCore> {
         self.tty.clone()
+    }
+
+    pub fn is_hung_up(&self) -> bool {
+        self.hangup_generation != self.tty.core().hangup_generation()
     }
 }
 

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -52,6 +52,7 @@ use super::{
     tty_core::{TtyCore, TtyFlag, TtyIoctlCmd},
     tty_driver::{TtyDriverManager, TtyDriverSubType, TtyDriverType, TtyOperation},
     tty_job_control::TtyJobCtrlManager,
+    tty_ldisc::TtyLdiscFileContext,
     virtual_terminal::vty_init,
 };
 
@@ -367,7 +368,11 @@ impl IndexNode for TtyDevice {
         if tty_file.is_hung_up() {
             return Ok(0);
         }
-        let (tty, flags) = (tty_file.tty(), tty_file.flags);
+        let tty = tty_file.tty();
+        let file_context = TtyLdiscFileContext {
+            flags: tty_file.flags,
+            hangup_generation: tty_file.hangup_generation,
+        };
 
         drop(data);
 
@@ -382,7 +387,14 @@ impl IndexNode for TtyDevice {
 
         loop {
             let mut size = (len - offset).min(buf.len() - offset);
-            size = ld.read(tty.clone(), &mut buf[offset..], size, &mut cookie, 0, flags)?;
+            size = ld.read(
+                tty.clone(),
+                &mut buf[offset..],
+                size,
+                &mut cookie,
+                0,
+                file_context,
+            )?;
             // 本次迭代未读取到数据，可能是EOF或暂时无数据可读
             if size == 0 {
                 break;
@@ -416,13 +428,17 @@ impl IndexNode for TtyDevice {
         if tty_file.is_hung_up() {
             return Err(SystemError::EIO);
         }
-        let (tty, flags) = (tty_file.tty(), tty_file.flags);
+        let tty = tty_file.tty();
+        let file_context = TtyLdiscFileContext {
+            flags: tty_file.flags,
+            hangup_generation: tty_file.hangup_generation,
+        };
         drop(data);
         let ld = tty.ldisc();
         let core = tty.core();
         let write_guard = core
             .write_lock()
-            .lock_interruptible(flags.contains(FileFlags::O_NONBLOCK))?;
+            .lock_interruptible(file_context.flags.contains(FileFlags::O_NONBLOCK))?;
         let mut chunk = 2048;
         if core.flags().contains(TtyFlag::NO_WRITE_SPLIT) {
             chunk = 65536;
@@ -437,7 +453,7 @@ impl IndexNode for TtyDevice {
 
             // 将数据从buf拷贝到writebuf
 
-            let ret = match ld.write(tty.clone(), &buf[written..], size, flags) {
+            let ret = match ld.write(tty.clone(), &buf[written..], size, file_context) {
                 Ok(ret) => ret,
                 Err(err) => {
                     if written != 0 {

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -256,11 +256,13 @@ impl IndexNode for TtyDevice {
         }
 
         let tty = tty.unwrap();
+        let hangup_generation = tty.core().file_open_hangup_generation();
 
         // 设置privdata
         *data = FilePrivateData::Tty(TtyFilePrivateData {
             tty: tty.clone(),
             flags: *mode,
+            hangup_generation,
         });
 
         tty.core().contorl_info_irqsave().clear_dead_session();
@@ -274,6 +276,11 @@ impl IndexNode for TtyDevice {
             }
             return Err(err);
         }
+
+        // A successful open after a completed hangup is a normal tty file in
+        // Linux. Do not clear a hangup which raced with this open: its
+        // generation change marks this file as one of the hung-up instances.
+        tty.core().finish_file_open(hangup_generation);
 
         let driver = tty.core().driver();
         // 考虑 O_NOCTTY：显式指定则不设置控制终端；pty master 也不会成为控制终端。
@@ -485,14 +492,26 @@ impl IndexNode for TtyDevice {
         arg: usize,
         data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let (tty, _) = if let FilePrivateData::Tty(tty_priv) = &*data {
-            (tty_priv.tty(), tty_priv.flags)
+        let (tty, file_hangup_generation) = if let FilePrivateData::Tty(tty_priv) = &*data {
+            (tty_priv.tty(), tty_priv.hangup_generation)
         } else {
             return Err(SystemError::EIO);
         };
 
         // Drop the lock early: tty ioctl paths may block.
         drop(data);
+
+        // Linux replaces only the file instances which existed at hangup
+        // with hung_up_tty_fops. A later successful reopen must remain usable.
+        // Check the original file endpoint before PTY master mode ioctls
+        // redirect to the slave.
+        if file_hangup_generation != tty.core().hangup_generation() {
+            return if cmd == TtyIoctlCmd::TIOCSPGRP {
+                Err(SystemError::ENOTTY)
+            } else {
+                Err(SystemError::EIO)
+            };
+        }
 
         match cmd {
             TtyIoctlCmd::TIOCSETD
@@ -766,6 +785,7 @@ impl CharDevice for TtyDevice {
 pub struct TtyFilePrivateData {
     pub tty: Arc<TtyCore>,
     pub flags: FileFlags,
+    pub hangup_generation: usize,
 }
 
 impl TtyFilePrivateData {

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -245,28 +245,38 @@ impl PollableInode for TtyDevice {
 
     fn add_fasync(
         &self,
-        _fasync_item: FAsyncItem,
+        fasync_item: FAsyncItem,
         private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        if Self::tty_file(private_data)?.is_hung_up() {
-            Err(SystemError::ENOTTY)
-        } else {
-            // Preserve the existing TTY FIOASYNC behavior until TTY SIGIO
-            // delivery is implemented.
-            Ok(())
-        }
+        let tty_file = Self::tty_file(private_data)?;
+        tty_file
+            .tty()
+            .core()
+            .add_fasync(tty_file.hangup_generation, fasync_item)
     }
 
     fn remove_fasync(
         &self,
-        _file: &Weak<File>,
+        file: &Weak<File>,
         private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        if Self::tty_file(private_data)?.is_hung_up() {
-            Err(SystemError::ENOTTY)
-        } else {
-            Ok(())
-        }
+        Self::tty_file(private_data)?
+            .tty()
+            .core()
+            .remove_fasync(file);
+        Ok(())
+    }
+
+    fn release_fasync(
+        &self,
+        file: &File,
+        private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        Self::tty_file(private_data)?
+            .tty()
+            .core()
+            .remove_fasync_file(file);
+        Ok(())
     }
 }
 

--- a/kernel/src/driver/tty/tty_driver.rs
+++ b/kernel/src/driver/tty/tty_driver.rs
@@ -529,6 +529,11 @@ pub trait TtyOperation: Sync + Send + Debug {
         0
     }
 
+    /// Wait until bytes accepted by the driver have physically left the device.
+    fn wait_until_sent(&self, _tty: &TtyCoreData) -> Result<(), SystemError> {
+        Ok(())
+    }
+
     fn set_termios(&self, _tty: Arc<TtyCore>, _old_termios: Termios) -> Result<(), SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -104,9 +104,9 @@ impl LineDisciplineType {
     pub fn from_line(line: u8) -> Self {
         match line {
             0 => Self::NTty,
-            _ => {
-                todo!()
-            }
+            // Unknown / unsupported line disciplines fall back to NTty,
+            // matching Linux behaviour (N_TTY is the default).
+            _ => Self::NTty,
         }
     }
 }

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -18,6 +18,12 @@ pub enum TtyLdiscDrainResult {
     NeedWriteRoom(usize),
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct TtyLdiscFileContext {
+    pub flags: FileFlags,
+    pub hangup_generation: usize,
+}
+
 pub trait TtyLineDiscipline: Sync + Send + Debug {
     fn open(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
     fn close(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
@@ -71,14 +77,14 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
         len: usize,
         cookie: &mut bool,
         offset: usize,
-        flags: FileFlags,
+        file_context: TtyLdiscFileContext,
     ) -> Result<usize, SystemError>;
     fn write(
         &self,
         tty: Arc<TtyCore>,
         buf: &[u8],
         len: usize,
-        flags: FileFlags,
+        file_context: TtyLdiscFileContext,
     ) -> Result<usize, SystemError>;
     fn ioctl(&self, tty: Arc<TtyCore>, cmd: u32, arg: usize) -> Result<usize, SystemError>;
 

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -106,7 +106,10 @@ impl LineDisciplineType {
             0 => Self::NTty,
             // Unknown / unsupported line disciplines fall back to NTty,
             // matching Linux behaviour (N_TTY is the default).
-            _ => Self::NTty,
+            _ => {
+                log::debug!("LineDisciplineType::from_line: unknown line discipline {}, falling back to NTty", line);
+                Self::NTty
+            }
         }
     }
 }

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -25,6 +25,14 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
         Ok(())
     }
 
+    /// Drain pending ldisc output (opost + echo) without blocking indefinitely.
+    /// Returns `Ok(true)` when everything was drained, `Ok(false)` when
+    /// the output lock was held by a concurrent writer and drain could not
+    /// be performed.
+    fn drain_output(&self, _tty: Arc<TtyCore>) -> Result<bool, SystemError> {
+        Ok(true)
+    }
+
     /// ## tty行规程循环读取函数
     ///
     /// ### 参数

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -25,10 +25,20 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
         Ok(())
     }
 
-    /// Drain pending ldisc output (opost + echo) without blocking indefinitely.
+    /// Drain pending ldisc output (opost + echo), blocking until complete.
+    ///
     /// Returns `Ok(true)` when everything was drained, `Ok(false)` when
-    /// the output lock was held by a concurrent writer and drain could not
-    /// be performed.
+    /// output could not be fully drained (e.g. hardware FIFO full).
+    ///
+    /// Callers MUST loop on `Ok(false)`: wait for hardware write readiness,
+    /// then call `drain_output` again until it returns `Ok(true)`.  See
+    /// `core_set_termios` for the canonical retry pattern.
+    ///
+    /// # Default implementation
+    ///
+    /// Returns `Ok(true)`.  **Line disciplines that have their own output
+    /// queues (opost / echo) MUST override this method.**  The default
+    /// causes TCSADRAIN to silently skip draining for undiscovered ldiscs.
     fn drain_output(&self, _tty: Arc<TtyCore>) -> Result<bool, SystemError> {
         Ok(true)
     }
@@ -101,13 +111,19 @@ pub enum LineDisciplineType {
 }
 
 impl LineDisciplineType {
+    /// Convert a raw c_line ABI byte to a LineDisciplineType.
+    ///
+    /// NOTE: this accepts u8 rather than LineDisciplineType, so adding
+    /// new enum variants (e.g. `Ppp = 1`) will NOT trigger a compiler
+    /// error here.  When extending the enum, update this match arm
+    /// to map the new variant(s).
     pub fn from_line(line: u8) -> Self {
         match line {
             0 => Self::NTty,
             // Unknown / unsupported line disciplines fall back to NTty,
             // matching Linux behaviour (N_TTY is the default).
             _ => {
-                log::debug!("LineDisciplineType::from_line: unknown line discipline {}, falling back to NTty", line);
+                log::warn!("LineDisciplineType::from_line: unknown line discipline {}, falling back to NTty", line);
                 Self::NTty
             }
         }

--- a/kernel/src/driver/tty/tty_ldisc/mod.rs
+++ b/kernel/src/driver/tty/tty_ldisc/mod.rs
@@ -12,6 +12,12 @@ use super::{
 
 pub mod ntty;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TtyLdiscDrainResult {
+    Drained,
+    NeedWriteRoom(usize),
+}
+
 pub trait TtyLineDiscipline: Sync + Send + Debug {
     fn open(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
     fn close(&self, tty: Arc<TtyCore>) -> Result<(), SystemError>;
@@ -27,20 +33,27 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
 
     /// Drain pending ldisc output (opost + echo), blocking until complete.
     ///
-    /// Returns `Ok(true)` when everything was drained, `Ok(false)` when
-    /// output could not be fully drained (e.g. hardware FIFO full).
+    /// Returns the exact minimum driver write room needed to make progress.
     ///
-    /// Callers MUST loop on `Ok(false)`: wait for hardware write readiness,
-    /// then call `drain_output` again until it returns `Ok(true)`.  See
+    /// Callers MUST loop on `NeedWriteRoom`: wait for the requested room,
+    /// then call `drain_output` again until it returns `Drained`.  See
     /// `core_set_termios` for the canonical retry pattern.
     ///
     /// # Default implementation
     ///
-    /// Returns `Ok(true)`.  **Line disciplines that have their own output
+    /// Returns `Drained`.  **Line disciplines that have their own output
     /// queues (opost / echo) MUST override this method.**  The default
     /// causes TCSADRAIN to silently skip draining for undiscovered ldiscs.
-    fn drain_output(&self, _tty: Arc<TtyCore>) -> Result<bool, SystemError> {
-        Ok(true)
+    fn drain_output(&self, _tty: Arc<TtyCore>) -> Result<TtyLdiscDrainResult, SystemError> {
+        Ok(TtyLdiscDrainResult::Drained)
+    }
+
+    /// Whether this line discipline still owns output that has not yet been
+    /// accepted by the driver. This must not sleep: wait-queue predicates use
+    /// it to notice progress made by `write_wakeup` even when that callback
+    /// consumes all newly available driver room.
+    fn output_pending(&self) -> bool {
+        false
     }
 
     /// ## tty行规程循环读取函数
@@ -99,6 +112,19 @@ pub trait TtyLineDiscipline: Sync + Send + Debug {
         count: usize,
     ) -> Result<usize, SystemError>;
 
+    /// Receive input while the caller already holds this TTY's termios read
+    /// semaphore. PTY uses this to lock the peer before marking a direction
+    /// as actively draining, avoiding nested reader acquisition.
+    fn receive_buf2_termios_locked(
+        &self,
+        tty: Arc<TtyCore>,
+        buf: &[u8],
+        flags: Option<&[u8]>,
+        count: usize,
+    ) -> Result<usize, SystemError> {
+        self.receive_buf2(tty, buf, flags, count)
+    }
+
     /// ## 唤醒线路写者
     fn write_wakeup(&self, _tty: &TtyCore) -> Result<(), SystemError> {
         Err(SystemError::ENOSYS)
@@ -122,10 +148,7 @@ impl LineDisciplineType {
             0 => Self::NTty,
             // Unknown / unsupported line disciplines fall back to NTty,
             // matching Linux behaviour (N_TTY is the default).
-            _ => {
-                log::warn!("LineDisciplineType::from_line: unknown line discipline {}, falling back to NTty", line);
-                Self::NTty
-            }
+            _ => Self::NTty,
         }
     }
 }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -35,7 +35,7 @@ use crate::{
     time::Duration,
 };
 
-use super::TtyLineDiscipline;
+use super::{TtyLdiscDrainResult, TtyLineDiscipline};
 pub const NTTY_BUFSIZE: usize = 4096;
 pub const ECHO_COMMIT_WATERMARK: usize = 256;
 pub const ECHO_BLOCK: usize = 256;
@@ -117,18 +117,20 @@ impl NTtyLinediscipline {
         }
     }
 
-    fn drain_opost_pending(&self, tty: &TtyCore) -> Result<bool, SystemError> {
+    fn drain_opost_pending(&self, tty: &TtyCore) -> Result<TtyLdiscDrainResult, SystemError> {
         let core = tty.core();
         loop {
             let pending = self.disc_data().opost_pending_bytes().to_vec();
             if pending.is_empty() {
-                return Ok(true);
+                return Ok(TtyLdiscDrainResult::Drained);
             }
 
-            let written = tty.write(core, &pending, pending.len())?;
+            let written = tty.write(core, &pending, pending.len()).inspect_err(|_| {
+                core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+            })?;
             if written == 0 {
                 core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
-                return Ok(false);
+                return Ok(TtyLdiscDrainResult::NeedWriteRoom(1));
             }
 
             self.disc_data().advance_opost_pending(written);
@@ -136,14 +138,16 @@ impl NTtyLinediscipline {
         }
     }
 
-    fn drain_echoes(&self, tty: &TtyCore) -> Result<bool, SystemError> {
+    fn drain_echoes(&self, tty: &TtyCore) -> Result<TtyLdiscDrainResult, SystemError> {
         let core = tty.core();
         loop {
             while let Some(bytes) = { self.disc_data().echo_pending_bytes() } {
-                let written = tty.write(core, &bytes, bytes.len())?;
+                let written = tty.write(core, &bytes, bytes.len()).inspect_err(|_| {
+                    core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+                })?;
                 if written == 0 {
                     core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
-                    return Ok(false);
+                    return Ok(TtyLdiscDrainResult::NeedWriteRoom(1));
                 }
                 {
                     let mut guard = self.disc_data();
@@ -160,20 +164,39 @@ impl NTtyLinediscipline {
             };
 
             let Some(step) = step else {
-                break;
+                let required = {
+                    let guard = self.disc_data();
+                    if !guard.has_echo_output_pending() {
+                        0
+                    } else {
+                        guard
+                            .next_echo_step(&termios, usize::MAX)
+                            .map(|step| step.bytes.len().max(1))
+                            .unwrap_or(1)
+                    }
+                };
+                if required == 0 {
+                    break;
+                }
+                core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+                return Ok(TtyLdiscDrainResult::NeedWriteRoom(required));
             };
 
             if !step.bytes.is_empty() {
                 let mut sent = 0;
                 while sent < step.bytes.len() {
-                    let written = tty.write(core, &step.bytes[sent..], step.bytes.len() - sent)?;
+                    let written = tty
+                        .write(core, &step.bytes[sent..], step.bytes.len() - sent)
+                        .inspect_err(|_| {
+                            core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
+                        })?;
                     if written == 0 {
                         if sent != 0 {
                             let mut guard = self.disc_data();
                             guard.set_echo_pending_step(step, sent);
                         }
                         core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
-                        return Ok(false);
+                        return Ok(TtyLdiscDrainResult::NeedWriteRoom(1));
                     }
                     sent += written;
                 }
@@ -189,7 +212,7 @@ impl NTtyLinediscipline {
         } else {
             core.flags_write().remove(TtyFlag::DO_WRITE_WAKEUP);
         }
-        Ok(true)
+        Ok(TtyLdiscDrainResult::Drained)
     }
 
     fn packet_status_pending(core: &TtyCoreData, packet: bool) -> bool {
@@ -1771,13 +1794,22 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     /// ## 重置缓冲区的基本信息
     fn flush_buffer(&self, tty: Arc<TtyCore>) -> Result<(), system_error::SystemError> {
         let core = tty.core();
-        if let Some(port) = core.port() {
-            if port.clear_input() != 0 {
-                retry_tty_input_producers();
-            }
+        // Stop queue-to-ldisc delivery before taking termios_rwsem.  A worker
+        // may already have marked a chunk as draining and then block on the
+        // read side, so waiting for it while holding the write side deadlocks.
+        let port = core.port();
+        if let Some(port) = port.as_ref() {
+            port.begin_input_flush();
         }
-        pty_flush_input_buffer(tty.clone(), || {
-            let _ = core.termios();
+
+        // Match n_tty_flush_buffer(): resetting the ring indices is a write
+        // transaction against concurrent read and receive paths.
+        let _termios_guard = core.termios_write_lock();
+        let cleared_port_input = port
+            .as_ref()
+            .map(|port| port.clear_input_during_flush())
+            .unwrap_or(0);
+        let result = pty_flush_input_buffer(tty.clone(), || {
             let mut ldata = self.disc_data();
             ldata.read_head = 0;
             ldata.canon_head = 0;
@@ -1793,7 +1825,19 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             if core.link().is_some() {
                 ldata.packet_mode_flush(core);
             }
-        })?;
+        });
+        drop(_termios_guard);
+
+        if let Some(port) = port.as_ref() {
+            port.finish_input_flush();
+            if port.has_input() {
+                tty_kick_input_worker(tty.clone());
+            }
+        }
+        if cleared_port_input != 0 {
+            retry_tty_input_producers();
+        }
+        result?;
 
         core.read_wq().wakeup_all();
         core.write_wq().wakeup_all();
@@ -1820,20 +1864,21 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         Ok(())
     }
 
-    fn drain_output(&self, tty: Arc<TtyCore>) -> Result<bool, SystemError> {
+    fn drain_output(&self, tty: Arc<TtyCore>) -> Result<TtyLdiscDrainResult, SystemError> {
         // Block on output_lock — a concurrent writer will release it once
         // its output is submitted to the hardware, at which point we can
         // drain the remaining opost/echo backlog.  Without blocking,
         // TCSADRAIN can silently switch termios while a writer is still
         // mid-flight (see tty-termios-drain-bugs.md B1).
         let _output_guard = self.output_lock.lock();
-        let drained = self.drain_opost_pending(&tty)?;
-        // drain_echoes manages DO_WRITE_WAKEUP via has_output_wakeup_pending(),
-        // which currently checks both opost and echo state.  If the check is
-        // ever decoupled (opost-only), DO_WRITE_WAKEUP set by drain_opost_pending
-        // above could be spuriously cleared — merge the flag management here.
-        let echo_drained = self.drain_echoes(&tty)?;
-        Ok(drained && echo_drained)
+        match self.drain_opost_pending(&tty)? {
+            TtyLdiscDrainResult::Drained => self.drain_echoes(&tty),
+            blocked => Ok(blocked),
+        }
+    }
+
+    fn output_pending(&self) -> bool {
+        self.disc_data().has_output_wakeup_pending()
     }
 
     #[inline(never)]
@@ -1846,6 +1891,11 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         _offset: usize,
         flags: FileFlags,
     ) -> Result<usize, system_error::SystemError> {
+        let core = tty.core();
+        if !*cookie {
+            TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTIN)?;
+        }
+        let mut termios_guard = Some(core.termios_read_lock());
         let mut ldata;
         if flags.contains(FileFlags::O_NONBLOCK) {
             let ret = self.disc_data_try_lock();
@@ -1856,7 +1906,6 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         } else {
             ldata = self.disc_data();
         }
-        let core = tty.core();
         let termios = core.termios();
         let mut nr = len;
 
@@ -1882,6 +1931,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             *cookie = false;
             let read_tail_moved = tail != ldata.read_tail;
             drop(ldata);
+            drop(termios_guard.take());
             if read_tail_moved {
                 tty_kick_input_worker(tty.clone());
                 Self::check_pty_unthrottle_after_read(&tty);
@@ -1890,8 +1940,6 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         }
 
         drop(termios);
-
-        TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTIN)?;
 
         let mut minimum: usize = 0;
         let mut current_wait = NTtyReadWait::Forever;
@@ -1944,7 +1992,9 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             let core = tty.core();
             if !ldata.input_available(core.termios(), false) {
                 drop(ldata);
+                drop(termios_guard.take());
                 let _ = pty_drain_pending_to(tty.clone());
+                termios_guard = Some(core.termios_read_lock());
                 ldata = self.disc_data();
             }
 
@@ -1986,6 +2036,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 }
 
                 drop(ldata);
+                drop(termios_guard.take());
                 let events = (EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM).bits() as u64;
                 let readiness = || {
                     let ldata = self.disc_data();
@@ -2012,14 +2063,18 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                     }
                     break;
                 }
+                termios_guard = Some(core.termios_read_lock());
                 continue;
             }
 
             if ldata.icanon && !core.termios().local_mode.contains(LocalMode::EXTPROC) {
                 let more = ldata.canon_copy_from_read_buf(buf, &mut nr, &mut offset)?;
                 if more {
-                    *cookie = true;
-                    break;
+                    // The current canonical record wrapped around the ring.
+                    // Finish it in this invocation while the termios read side
+                    // is still held; returning a cookie would let tcsetattr()
+                    // change ICANON/EXTPROC in the middle of one read syscall.
+                    continue;
                 }
             } else {
                 // 非标准模式
@@ -2033,8 +2088,10 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 if ldata.copy_from_read_buf(core.termios(), buf, &mut nr, &mut offset)?
                     && offset >= minimum
                 {
-                    *cookie = true;
-                    break;
+                    // A ring wrap is an implementation detail.  Continue the
+                    // same read under the same termios snapshot instead of
+                    // exposing a lock gap through tty_device's cookie loop.
+                    continue;
                 }
             }
 
@@ -2050,6 +2107,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let ldata = self.disc_data();
         let read_tail_moved = tail != ldata.read_tail;
         drop(ldata);
+        drop(termios_guard);
         if read_tail_moved {
             tty_kick_input_worker(tty.clone());
             Self::check_pty_unthrottle_after_read(&tty);
@@ -2075,10 +2133,11 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let pcb = ProcessManager::current_pcb();
         let binding = tty.clone();
         let core = binding.core();
-        let mut termios = *core.termios();
-        if termios.local_mode.contains(LocalMode::TOSTOP) {
+        if core.termios().local_mode.contains(LocalMode::TOSTOP) {
             TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTOU)?;
         }
+        let mut termios_guard = Some(core.termios_read_lock());
+        let mut termios = *core.termios();
 
         let mut output_guard = Some(self.output_lock.lock());
 
@@ -2089,11 +2148,9 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         // Known limitation: this can add latency to echo output during
         // heavy writes, but the alternative (retry loop here) risks
         // starving the write path.
-        match self.drain_echoes(&tty) {
-            Ok(false) => log::debug!("drain_echoes incomplete in write (FIFO full)"),
-            Err(e) => log::debug!("drain_echoes failed in write: {:?}", e),
-            Ok(true) => {}
-        }
+        // Echo output is best-effort. Pending state and DO_WRITE_WAKEUP are
+        // retained by drain_echoes so a later driver wakeup can retry it.
+        let _ = self.drain_echoes(&tty);
 
         let mut offset = 0;
         loop {
@@ -2240,6 +2297,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             // 休眠一段时间
             // 获取到termios读锁，避免termios被更改导致行为异常
             drop(output_guard.take());
+            drop(termios_guard.take());
             let wait_result = core.write_wq().wait_event_interruptible(
                 EPollEventType::EPOLLOUT.bits() as u64,
                 || {
@@ -2263,12 +2321,14 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 },
             );
             if let Err(err) = wait_result {
+                termios_guard = Some(core.termios_read_lock());
                 output_guard = Some(self.output_lock.lock());
                 if offset != 0 {
                     break;
                 }
                 return Err(err);
             }
+            termios_guard = Some(core.termios_read_lock());
             output_guard = Some(self.output_lock.lock());
             termios = *core.termios();
         }
@@ -2278,6 +2338,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         }
 
         drop(output_guard);
+        drop(termios_guard);
         Ok(offset)
     }
 
@@ -2558,11 +2619,12 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     /// this is a best-effort echo path; the caller at `tty_core.rs` already
     /// discards the `write_wakeup` return value with `let _ = …`.
     fn write_wakeup(&self, tty: &TtyCore) -> Result<(), SystemError> {
+        let Some(_termios_guard) = tty.core().termios_try_read_lock() else {
+            return Ok(());
+        };
         if let Some(_output_guard) = self.output_lock.try_lock() {
-            if self.drain_opost_pending(tty)? {
-                if let Err(e) = self.drain_echoes(tty) {
-                    log::debug!("drain_echoes failed in write_wakeup: {:?}", e);
-                }
+            if self.drain_opost_pending(tty)? == TtyLdiscDrainResult::Drained {
+                let _ = self.drain_echoes(tty)?;
             }
         }
         Ok(())
@@ -2606,13 +2668,12 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         flags: Option<&[u8]>,
         count: usize,
     ) -> Result<usize, SystemError> {
+        let _termios_guard = tty.core().termios_read_lock();
         let mut ldata = self.disc_data();
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, false);
         drop(ldata);
         if let Some(_output_guard) = self.output_lock.try_lock() {
-            if let Err(e) = self.drain_echoes(&tty) {
-                log::debug!("drain_echoes failed in receive_buf: {:?}", e);
-            }
+            let _ = self.drain_echoes(&tty);
         }
         ret
     }
@@ -2624,13 +2685,28 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         flags: Option<&[u8]>,
         count: usize,
     ) -> Result<usize, SystemError> {
+        let _termios_guard = tty.core().termios_read_lock();
         let mut ldata = self.disc_data();
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, true);
         drop(ldata);
         if let Some(_output_guard) = self.output_lock.try_lock() {
-            if let Err(e) = self.drain_echoes(&tty) {
-                log::debug!("drain_echoes failed in receive_buf2: {:?}", e);
-            }
+            let _ = self.drain_echoes(&tty);
+        }
+        ret
+    }
+
+    fn receive_buf2_termios_locked(
+        &self,
+        tty: Arc<TtyCore>,
+        buf: &[u8],
+        flags: Option<&[u8]>,
+        count: usize,
+    ) -> Result<usize, SystemError> {
+        let mut ldata = self.disc_data();
+        let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, true);
+        drop(ldata);
+        if let Some(_output_guard) = self.output_lock.try_lock() {
+            let _ = self.drain_echoes(&tty);
         }
         ret
     }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1889,15 +1889,18 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         len: usize,
         cookie: &mut bool,
         _offset: usize,
-        flags: FileFlags,
+        file_context: super::TtyLdiscFileContext,
     ) -> Result<usize, system_error::SystemError> {
         let core = tty.core();
+        if core.file_hung_up(file_context.hangup_generation) {
+            return Ok(0);
+        }
         if !*cookie {
             TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTIN)?;
         }
         let mut termios_guard = Some(core.termios_read_lock());
         let mut ldata;
-        if flags.contains(FileFlags::O_NONBLOCK) {
+        if file_context.flags.contains(FileFlags::O_NONBLOCK) {
             let ret = self.disc_data_try_lock();
             if ret.is_err() {
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -1968,6 +1971,10 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let tail = ldata.read_tail;
         drop(ldata);
         while nr != 0 {
+            if core.file_hung_up(file_context.hangup_generation) {
+                break;
+            }
+
             // todo: 处理packet模式
             if packet {
                 let link = core.link().unwrap();
@@ -2007,14 +2014,20 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 {
                     let flags = core.flags();
                     if flags.contains(TtyFlag::OTHER_CLOSED) {
-                        if flags.contains(TtyFlag::HUPPED) || flags.contains(TtyFlag::HUPPING) {
+                        if core.file_hung_up(file_context.hangup_generation)
+                            || flags.contains(TtyFlag::HUPPED)
+                            || flags.contains(TtyFlag::HUPPING)
+                        {
                             break;
                         }
                         ret = Err(SystemError::EIO);
                         break;
                     }
 
-                    if flags.contains(TtyFlag::HUPPED) || flags.contains(TtyFlag::HUPPING) {
+                    if core.file_hung_up(file_context.hangup_generation)
+                        || flags.contains(TtyFlag::HUPPED)
+                        || flags.contains(TtyFlag::HUPPING)
+                    {
                         break;
                     }
                 }
@@ -2023,7 +2036,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                     break;
                 }
 
-                if flags.contains(FileFlags::O_NONBLOCK)
+                if file_context.flags.contains(FileFlags::O_NONBLOCK)
                     || core.flags().contains(TtyFlag::LDISC_CHANGING)
                 {
                     ret = Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -2043,6 +2056,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                     ldata.input_available(core.termios(), false)
                         || Self::packet_status_pending(core, packet)
                         || core.flags().contains(TtyFlag::OTHER_CLOSED)
+                        || core.file_hung_up(file_context.hangup_generation)
                         || core.flags().contains(TtyFlag::HUPPED)
                         || core.flags().contains(TtyFlag::HUPPING)
                         || core.flags().contains(TtyFlag::LDISC_CHANGING)
@@ -2126,7 +2140,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         tty: Arc<TtyCore>,
         buf: &[u8],
         len: usize,
-        _flags: FileFlags,
+        file_context: super::TtyLdiscFileContext,
     ) -> Result<usize, system_error::SystemError> {
         let mut nr = len;
         let mut out_buf = Vec::with_capacity(NTTY_BUFSIZE);
@@ -2140,6 +2154,10 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let mut termios = *core.termios();
 
         let mut output_guard = Some(self.output_lock.lock());
+
+        if core.file_hung_up(file_context.hangup_generation) {
+            return Err(SystemError::EIO);
+        }
 
         self.disc_data().process_echoes(tty.clone());
         // Echo drain is best-effort in the write path; Ok(false) means
@@ -2160,7 +2178,8 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 }
                 return Err(SystemError::ERESTARTSYS);
             }
-            if core.flags().contains(TtyFlag::HUPPED)
+            if core.file_hung_up(file_context.hangup_generation)
+                || core.flags().contains(TtyFlag::HUPPED)
                 || (core.flags().contains(TtyFlag::OTHER_CLOSED)
                     && core.driver().tty_driver_sub_type() != TtyDriverSubType::PtyMaster)
                 || core.flags().contains(TtyFlag::HUPPING)
@@ -2281,7 +2300,7 @@ impl TtyLineDiscipline for NTtyLinediscipline {
                 break;
             }
 
-            if _flags.contains(FileFlags::O_NONBLOCK)
+            if file_context.flags.contains(FileFlags::O_NONBLOCK)
                 || core.flags().contains(TtyFlag::LDISC_CHANGING)
             {
                 if offset != 0 {
@@ -2301,7 +2320,8 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             let wait_result = core.write_wq().wait_event_interruptible(
                 EPollEventType::EPOLLOUT.bits() as u64,
                 || {
-                    if core.flags().contains(TtyFlag::HUPPED)
+                    if core.file_hung_up(file_context.hangup_generation)
+                        || core.flags().contains(TtyFlag::HUPPED)
                         || (core.flags().contains(TtyFlag::OTHER_CLOSED)
                             && core.driver().tty_driver_sub_type() != TtyDriverSubType::PtyMaster)
                         || core.flags().contains(TtyFlag::HUPPING)

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -2603,10 +2603,20 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             event.insert(EPollEventType::EPOLLHUP);
         }
 
-        if !core.write_lock().is_locked()
-            && core.driver().driver_funcs().chars_in_buffer(core) < 256
-            && core.driver().driver_funcs().write_room(core) > 0
-        {
+        let driver = core.driver();
+        let subtype = driver.tty_driver_sub_type();
+        let write_room = driver.driver_funcs().write_room(core);
+        // Linux PTYs have no driver-owned transmit queue, so their
+        // chars_in_buffer() is always zero and POLLOUT follows peer receive
+        // room. DragonOS has an asynchronous PTY bridge queue which must be
+        // counted for TCSADRAIN, but already queued bytes must not suppress
+        // writability after the peer frees actual queue room.
+        let below_wakeup_threshold = matches!(
+            subtype,
+            TtyDriverSubType::PtyMaster | TtyDriverSubType::PtySlave
+        ) || driver.driver_funcs().chars_in_buffer(core) < 256;
+
+        if !core.write_lock().is_locked() && below_wakeup_threshold && write_room > 0 {
             event.insert(EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM);
         }
 

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1828,6 +1828,10 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         // mid-flight (see tty-termios-drain-bugs.md B1).
         let _output_guard = self.output_lock.lock();
         let drained = self.drain_opost_pending(&tty)?;
+        // drain_echoes manages DO_WRITE_WAKEUP via has_output_wakeup_pending(),
+        // which currently checks both opost and echo state.  If the check is
+        // ever decoupled (opost-only), DO_WRITE_WAKEUP set by drain_opost_pending
+        // above could be spuriously cleared — merge the flag management here.
         let echo_drained = self.drain_echoes(&tty)?;
         Ok(drained && echo_drained)
     }
@@ -2548,6 +2552,11 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         Ok(event.bits() as usize)
     }
 
+    /// Write wakeup: drain pending opost/echo output when hardware FIFO has room.
+    ///
+    /// Echo drain errors are intentionally logged rather than propagated —
+    /// this is a best-effort echo path; the caller at `tty_core.rs` already
+    /// discards the `write_wakeup` return value with `let _ = …`.
     fn write_wakeup(&self, tty: &TtyCore) -> Result<(), SystemError> {
         if let Some(_output_guard) = self.output_lock.try_lock() {
             if self.drain_opost_pending(tty)? {

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1820,6 +1820,17 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         Ok(())
     }
 
+    fn drain_output(&self, tty: Arc<TtyCore>) -> Result<bool, SystemError> {
+        if let Some(_output_guard) = self.output_lock.try_lock() {
+            let drained = self.drain_opost_pending(&tty)?;
+            self.drain_echoes(&tty)?;
+            Ok(drained)
+        } else {
+            // output_lock held by a concurrent writer; cannot drain opost.
+            Ok(false)
+        }
+    }
+
     #[inline(never)]
     fn read(
         &self,

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -136,14 +136,14 @@ impl NTtyLinediscipline {
         }
     }
 
-    fn drain_echoes(&self, tty: &TtyCore) -> Result<(), SystemError> {
+    fn drain_echoes(&self, tty: &TtyCore) -> Result<bool, SystemError> {
         let core = tty.core();
         loop {
             while let Some(bytes) = { self.disc_data().echo_pending_bytes() } {
                 let written = tty.write(core, &bytes, bytes.len())?;
                 if written == 0 {
                     core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
-                    return Ok(());
+                    return Ok(false);
                 }
                 {
                     let mut guard = self.disc_data();
@@ -173,7 +173,7 @@ impl NTtyLinediscipline {
                             guard.set_echo_pending_step(step, sent);
                         }
                         core.flags_write().insert(TtyFlag::DO_WRITE_WAKEUP);
-                        return Ok(());
+                        return Ok(false);
                     }
                     sent += written;
                 }
@@ -189,7 +189,7 @@ impl NTtyLinediscipline {
         } else {
             core.flags_write().remove(TtyFlag::DO_WRITE_WAKEUP);
         }
-        Ok(())
+        Ok(true)
     }
 
     fn packet_status_pending(core: &TtyCoreData, packet: bool) -> bool {
@@ -1821,14 +1821,15 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     }
 
     fn drain_output(&self, tty: Arc<TtyCore>) -> Result<bool, SystemError> {
-        if let Some(_output_guard) = self.output_lock.try_lock() {
-            let drained = self.drain_opost_pending(&tty)?;
-            self.drain_echoes(&tty)?;
-            Ok(drained)
-        } else {
-            // output_lock held by a concurrent writer; cannot drain opost.
-            Ok(false)
-        }
+        // Block on output_lock — a concurrent writer will release it once
+        // its output is submitted to the hardware, at which point we can
+        // drain the remaining opost/echo backlog.  Without blocking,
+        // TCSADRAIN can silently switch termios while a writer is still
+        // mid-flight (see tty-termios-drain-bugs.md B1).
+        let _output_guard = self.output_lock.lock();
+        let drained = self.drain_opost_pending(&tty)?;
+        let echo_drained = self.drain_echoes(&tty)?;
+        Ok(drained && echo_drained)
     }
 
     #[inline(never)]
@@ -2078,7 +2079,17 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let mut output_guard = Some(self.output_lock.lock());
 
         self.disc_data().process_echoes(tty.clone());
-        self.drain_echoes(&tty)?;
+        // Echo drain is best-effort in the write path; Ok(false) means
+        // the hardware FIFO was full and draining will be retried by
+        // write_wakeup once the FIFO has room (DO_WRITE_WAKEUP is set).
+        // Known limitation: this can add latency to echo output during
+        // heavy writes, but the alternative (retry loop here) risks
+        // starving the write path.
+        match self.drain_echoes(&tty) {
+            Ok(false) => log::debug!("drain_echoes incomplete in write (FIFO full)"),
+            Err(e) => log::debug!("drain_echoes failed in write: {:?}", e),
+            Ok(true) => {}
+        }
 
         let mut offset = 0;
         loop {
@@ -2540,7 +2551,9 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     fn write_wakeup(&self, tty: &TtyCore) -> Result<(), SystemError> {
         if let Some(_output_guard) = self.output_lock.try_lock() {
             if self.drain_opost_pending(tty)? {
-                self.drain_echoes(tty)?;
+                if let Err(e) = self.drain_echoes(tty) {
+                    log::debug!("drain_echoes failed in write_wakeup: {:?}", e);
+                }
             }
         }
         Ok(())
@@ -2588,7 +2601,9 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, false);
         drop(ldata);
         if let Some(_output_guard) = self.output_lock.try_lock() {
-            self.drain_echoes(&tty)?;
+            if let Err(e) = self.drain_echoes(&tty) {
+                log::debug!("drain_echoes failed in receive_buf: {:?}", e);
+            }
         }
         ret
     }
@@ -2604,7 +2619,9 @@ impl TtyLineDiscipline for NTtyLinediscipline {
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, true);
         drop(ldata);
         if let Some(_output_guard) = self.output_lock.try_lock() {
-            self.drain_echoes(&tty)?;
+            if let Err(e) = self.drain_echoes(&tty) {
+                log::debug!("drain_echoes failed in receive_buf2: {:?}", e);
+            }
         }
         ret
     }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -2603,20 +2603,10 @@ impl TtyLineDiscipline for NTtyLinediscipline {
             event.insert(EPollEventType::EPOLLHUP);
         }
 
-        let driver = core.driver();
-        let subtype = driver.tty_driver_sub_type();
-        let write_room = driver.driver_funcs().write_room(core);
-        // Linux PTYs have no driver-owned transmit queue, so their
-        // chars_in_buffer() is always zero and POLLOUT follows peer receive
-        // room. DragonOS has an asynchronous PTY bridge queue which must be
-        // counted for TCSADRAIN, but already queued bytes must not suppress
-        // writability after the peer frees actual queue room.
-        let below_wakeup_threshold = matches!(
-            subtype,
-            TtyDriverSubType::PtyMaster | TtyDriverSubType::PtySlave
-        ) || driver.driver_funcs().chars_in_buffer(core) < 256;
-
-        if !core.write_lock().is_locked() && below_wakeup_threshold && write_room > 0 {
+        if !core.write_lock().is_locked()
+            && core.driver().driver_funcs().chars_in_buffer(core) < 256
+            && core.driver().driver_funcs().write_room(core) > 0
+        {
             event.insert(EPollEventType::EPOLLOUT | EPollEventType::EPOLLWRNORM);
         }
 

--- a/kernel/src/driver/tty/tty_port.rs
+++ b/kernel/src/driver/tty/tty_port.rs
@@ -42,6 +42,7 @@ struct TtyInputQueue {
     len: usize,
     generation: usize,
     draining: bool,
+    flushing: bool,
 }
 
 impl TtyInputQueue {
@@ -52,6 +53,7 @@ impl TtyInputQueue {
             len: 0,
             generation: 0,
             draining: false,
+            flushing: false,
         }
     }
 
@@ -183,6 +185,20 @@ pub trait TtyPort: Sync + Send + Debug {
         ret
     }
 
+    fn receive_buf_termios_locked(
+        &self,
+        buf: &[u8],
+        _flags: &[u8],
+        count: usize,
+    ) -> Result<usize, SystemError> {
+        let tty = self.port_data().internal_tty().ok_or(SystemError::ENODEV)?;
+        let ld = tty.ldisc();
+        // N_TTY wakes read waiters and epoll when it commits input. Avoid a
+        // nested poll here: poll may try to drain PTY input and reacquire the
+        // termios semaphore already held by the caller.
+        ld.receive_buf2_termios_locked(tty, buf, None, count)
+    }
+
     fn internal_tty(&self) -> Option<Arc<TtyCore>> {
         self.port_data().internal_tty()
     }
@@ -202,6 +218,15 @@ pub trait TtyPort: Sync + Send + Debug {
     fn has_input(&self) -> bool;
 
     fn clear_input(&self) -> usize;
+
+    /// Stop new queue-to-ldisc drains and wait for an in-flight drain to
+    /// finish. The caller must pair this with `finish_input_flush`.
+    fn begin_input_flush(&self);
+
+    /// Clear the queue while an input flush gate is held.
+    fn clear_input_during_flush(&self) -> usize;
+
+    fn finish_input_flush(&self);
 
     fn clear_input_from_receive(&self) -> usize;
 
@@ -300,6 +325,35 @@ impl TtyPort for DefaultTtyPort {
         })
     }
 
+    fn begin_input_flush(&self) {
+        self.input_drain_wq.wait_until(|| {
+            let mut queue = self.input_queue.lock_irqsave();
+            let Some(queue) = queue.as_mut() else {
+                return Some(());
+            };
+            if queue.draining || queue.flushing {
+                return None;
+            }
+            queue.flushing = true;
+            Some(())
+        });
+    }
+
+    fn clear_input_during_flush(&self) -> usize {
+        self.input_queue
+            .lock_irqsave()
+            .as_mut()
+            .map(TtyInputQueue::clear_buffer)
+            .unwrap_or(0)
+    }
+
+    fn finish_input_flush(&self) {
+        if let Some(queue) = self.input_queue.lock_irqsave().as_mut() {
+            queue.flushing = false;
+        }
+        self.input_drain_wq.wakeup_all(None);
+    }
+
     fn clear_input_from_receive(&self) -> usize {
         self.input_queue
             .lock_irqsave()
@@ -316,6 +370,13 @@ impl TtyPort for DefaultTtyPort {
             let Some(queue) = queue.as_mut() else {
                 return Ok(TtyInputDrain::default());
             };
+            if queue.flushing {
+                return Ok(TtyInputDrain {
+                    still_pending: !queue.is_empty(),
+                    blocked: true,
+                    ..TtyInputDrain::default()
+                });
+            }
             let (copied, generation) = queue.copy_front(&mut chunk[..max_count]);
             if copied != 0 {
                 queue.draining = true;

--- a/kernel/src/driver/tty/virtual_terminal/mod.rs
+++ b/kernel/src/driver/tty/virtual_terminal/mod.rs
@@ -10,12 +10,9 @@ use system_error::SystemError;
 use unified_init::macros::unified_init;
 
 use crate::{
-    driver::{
-        base::device::{
-            device_number::{DeviceNumber, Major},
-            device_register, IdTable,
-        },
-        serial::serial8250::send_to_default_serial8250_port,
+    driver::base::device::{
+        device_number::{DeviceNumber, Major},
+        device_register, IdTable,
     },
     filesystem::devfs::{devfs_register, devfs_unregister},
     init::initcall::INITCALL_LATE,
@@ -436,7 +433,6 @@ impl TtyOperation for TtyConsoleDriverInner {
         // if String::from_utf8_lossy(buf) == "Hello world!\n" {
         //     loop {}
         // }
-        send_to_default_serial8250_port(buf);
         let ret = tty.do_write(buf, nr);
         self.flush_chars(tty);
         ret

--- a/kernel/src/filesystem/vfs/fasync.rs
+++ b/kernel/src/filesystem/vfs/fasync.rs
@@ -218,25 +218,48 @@ impl FAsyncItems {
     }
 }
 
-pub fn set_file_fasync(file: &Arc<File>, fd: i32, enabled: bool) -> Result<(), SystemError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FAsyncHandlerPolicy {
+    Optional,
+    Required,
+}
+
+pub fn set_file_fasync(
+    file: &Arc<File>,
+    fd: i32,
+    enabled: bool,
+    handler_policy: FAsyncHandlerPolicy,
+) -> Result<(), SystemError> {
     let mut flags = file.flags();
+    if flags.contains(FileFlags::FASYNC) == enabled {
+        return Ok(());
+    }
+
+    let inode = file.inode();
+    if let Ok(pollable) = inode.as_pollable_inode() {
+        let private_data = file.private_data.lock();
+        let result = if enabled {
+            let item = FAsyncItem::new(Arc::downgrade(file), fd);
+            pollable.add_fasync(item, &private_data)
+        } else {
+            pollable.remove_fasync(&Arc::downgrade(file), &private_data)
+        };
+        if let Err(err) = result {
+            if err != SystemError::ENOSYS {
+                return Err(err);
+            }
+            if handler_policy == FAsyncHandlerPolicy::Required {
+                return Err(SystemError::ENOTTY);
+            }
+        }
+    } else if handler_policy == FAsyncHandlerPolicy::Required {
+        return Err(SystemError::ENOTTY);
+    }
+
     if enabled {
         flags.insert(FileFlags::FASYNC);
     } else {
         flags.remove(FileFlags::FASYNC);
     }
-
-    file.set_flags(flags)?;
-
-    if let Ok(pollable) = file.inode().as_pollable_inode() {
-        let private_data = file.private_data.lock();
-        if enabled {
-            let item = FAsyncItem::new(Arc::downgrade(file), fd);
-            let _ = pollable.add_fasync(item, &private_data);
-        } else {
-            let _ = pollable.remove_fasync(&Arc::downgrade(file), &private_data);
-        }
-    }
-
-    Ok(())
+    file.set_flags(flags)
 }

--- a/kernel/src/filesystem/vfs/fasync.rs
+++ b/kernel/src/filesystem/vfs/fasync.rs
@@ -230,13 +230,12 @@ pub fn set_file_fasync(
     enabled: bool,
     handler_policy: FAsyncHandlerPolicy,
 ) -> Result<(), SystemError> {
-    let mut flags = file.flags();
+    let flags = file.flags();
     if flags.contains(FileFlags::FASYNC) == enabled {
         return Ok(());
     }
 
-    let inode = file.inode();
-    if let Ok(pollable) = inode.as_pollable_inode() {
+    let handler_succeeded = if let Ok(pollable) = file.inode().as_pollable_inode() {
         let private_data = file.private_data.lock();
         let result = if enabled {
             let item = FAsyncItem::new(Arc::downgrade(file), fd);
@@ -251,15 +250,18 @@ pub fn set_file_fasync(
             if handler_policy == FAsyncHandlerPolicy::Required {
                 return Err(SystemError::ENOTTY);
             }
+            false
+        } else {
+            true
         }
     } else if handler_policy == FAsyncHandlerPolicy::Required {
         return Err(SystemError::ENOTTY);
-    }
-
-    if enabled {
-        flags.insert(FileFlags::FASYNC);
     } else {
-        flags.remove(FileFlags::FASYNC);
+        false
+    };
+
+    if handler_succeeded {
+        file.set_fasync_flag(enabled);
     }
-    file.set_flags(flags)
+    Ok(())
 }

--- a/kernel/src/filesystem/vfs/fasync.rs
+++ b/kernel/src/filesystem/vfs/fasync.rs
@@ -19,7 +19,7 @@ use crate::{
 use alloc::sync::Arc;
 use system_error::SystemError;
 
-use super::file::{File, FileFlags};
+use super::file::File;
 
 pub const FASYNC_POLL_IN: i64 = 0x00000001 | 0x00000040;
 pub const FASYNC_POLL_OUT: i64 = 0x00000004 | 0x00000100 | 0x00000200;
@@ -77,8 +77,11 @@ pub struct FAsyncItem {
 }
 
 impl FAsyncItem {
-    pub fn new(file: Weak<File>, fd: i32) -> Self {
-        Self { file, fd }
+    pub fn new(file: &Arc<File>, fd: i32) -> Self {
+        Self {
+            file: Arc::downgrade(file),
+            fd,
+        }
     }
 
     /// Get the file reference
@@ -132,6 +135,7 @@ impl FAsyncItems {
     /// Add a FAsyncItem
     pub fn add(&self, item: FAsyncItem) {
         let mut guard = self.items.lock();
+        guard.retain(FAsyncItem::is_alive);
         for old_item in guard.iter_mut() {
             if Weak::ptr_eq(old_item.file_weak(), item.file_weak()) {
                 old_item.set_fd(item.fd());
@@ -147,10 +151,28 @@ impl FAsyncItems {
         guard.retain(|item| !Weak::ptr_eq(item.file_weak(), file));
     }
 
-    /// Clear all items
-    #[allow(dead_code)]
+    /// Remove a registration while the last strong File reference is being
+    /// dropped and a new Weak cannot be constructed.
+    pub fn remove_file(&self, file: &File) {
+        let file_ptr = file as *const File;
+        self.items
+            .lock()
+            .retain(|item| item.file_weak().as_ptr() != file_ptr);
+    }
+
+    /// Remove every registration and clear FASYNC on each live open file
+    /// description. Drain the list before taking per-file fasync locks to
+    /// preserve the update path's fasync-lock -> item-list lock order.
     pub fn clear(&self) {
-        self.items.lock().clear();
+        let items = {
+            let mut guard = self.items.lock();
+            core::mem::take(&mut *guard)
+        };
+        for item in items {
+            if let Some(file) = item.file() {
+                file.clear_fasync_flag();
+            }
+        }
     }
 
     /// Send SIGIO to all registered file owners
@@ -230,38 +252,30 @@ pub fn set_file_fasync(
     enabled: bool,
     handler_policy: FAsyncHandlerPolicy,
 ) -> Result<(), SystemError> {
-    let flags = file.flags();
-    if flags.contains(FileFlags::FASYNC) == enabled {
-        return Ok(());
-    }
-
-    let handler_succeeded = if let Ok(pollable) = file.inode().as_pollable_inode() {
-        let private_data = file.private_data.lock();
-        let result = if enabled {
-            let item = FAsyncItem::new(Arc::downgrade(file), fd);
-            pollable.add_fasync(item, &private_data)
-        } else {
-            pollable.remove_fasync(&Arc::downgrade(file), &private_data)
-        };
-        if let Err(err) = result {
-            if err != SystemError::ENOSYS {
-                return Err(err);
+    file.update_fasync_flag(enabled, || {
+        if let Ok(pollable) = file.inode().as_pollable_inode() {
+            let private_data = file.private_data.lock();
+            let result = if enabled {
+                let item = FAsyncItem::new(file, fd);
+                pollable.add_fasync(item, &private_data)
+            } else {
+                pollable.remove_fasync(&Arc::downgrade(file), &private_data)
+            };
+            if let Err(err) = result {
+                if err != SystemError::ENOSYS {
+                    return Err(err);
+                }
+                if handler_policy == FAsyncHandlerPolicy::Required {
+                    return Err(SystemError::ENOTTY);
+                }
+                Ok(false)
+            } else {
+                Ok(true)
             }
-            if handler_policy == FAsyncHandlerPolicy::Required {
-                return Err(SystemError::ENOTTY);
-            }
-            false
+        } else if handler_policy == FAsyncHandlerPolicy::Required {
+            Err(SystemError::ENOTTY)
         } else {
-            true
+            Ok(false)
         }
-    } else if handler_policy == FAsyncHandlerPolicy::Required {
-        return Err(SystemError::ENOTTY);
-    } else {
-        false
-    };
-
-    if handler_succeeded {
-        file.set_fasync_flag(enabled);
-    }
-    Ok(())
+    })
 }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -584,6 +584,8 @@ pub struct File {
     offset: AtomicUsize,
     /// 文件的打开模式
     flags: RwSem<FileFlags>,
+    /// Serializes fasync registration with lifecycle-driven flag removal.
+    fasync_lock: Mutex<()>,
     /// 文件的访问模式
     mode: RwSem<FileMode>,
     /// 文件类型
@@ -1123,6 +1125,7 @@ impl File {
             io_fs,
             offset: AtomicUsize::new(0),
             flags: RwSem::new(flags),
+            fasync_lock: Mutex::new(()),
             mode: RwSem::new(mode),
             file_type,
             readdir_state: Mutex::new(ReaddirState::default()),
@@ -1849,6 +1852,7 @@ impl File {
             io_fs: self.io_fs.clone(),
             offset: AtomicUsize::new(self.offset.load(Ordering::SeqCst)),
             flags: RwSem::new(flags),
+            fasync_lock: Mutex::new(()),
             mode: RwSem::new(mode),
             file_type: self.file_type,
             readdir_state: Mutex::new(self.readdir_state.lock().clone()),
@@ -1935,6 +1939,11 @@ impl File {
         // todo: 是否需要调用inode的open方法，以更新private data（假如它与flags有关的话）?
         // 也许需要加个更好的设计，让inode知晓文件的打开模式发生了变化，让它自己决定是否需要更新private data
 
+        // Preserve lifecycle-driven FASYNC changes while merging the other
+        // status flags. This lock is also held by fasync registration and TTY
+        // hangup cleanup.
+        let _fasync_guard = self.fasync_lock.lock();
+
         // 访问模式不可修改
         let old_flags = self.flags();
         let old_accflags = old_flags.access_flags();
@@ -1959,17 +1968,37 @@ impl File {
         return Ok(());
     }
 
-    /// Commit the handler-owned FASYNC status bit.
+    /// Serialize a fasync registration update with the corresponding status
+    /// bit commit.
     ///
-    /// Linux excludes FASYNC from the generic SETFL mask: the fasync handler
-    /// owns this bit and updates it only after registration succeeds.
-    pub(crate) fn set_fasync_flag(&self, enabled: bool) {
-        let mut flags = self.flags.write();
-        if enabled {
-            flags.insert(FileFlags::FASYNC);
-        } else {
-            flags.remove(FileFlags::FASYNC);
+    /// Keeping the dedicated fasync lock across the inode callback lets inode
+    /// lifecycle paths (notably TTY hangup) clear a registered item and its
+    /// FASYNC bit without racing a delayed post-callback commit.
+    pub(crate) fn update_fasync_flag<F>(&self, enabled: bool, update: F) -> Result<(), SystemError>
+    where
+        F: FnOnce() -> Result<bool, SystemError>,
+    {
+        let _guard = self.fasync_lock.lock();
+        if self.flags().contains(FileFlags::FASYNC) == enabled {
+            return Ok(());
         }
+
+        if update()? {
+            let mut flags = self.flags.write();
+            if enabled {
+                flags.insert(FileFlags::FASYNC);
+            } else {
+                flags.remove(FileFlags::FASYNC);
+            }
+        }
+        Ok(())
+    }
+
+    /// Clear the handler-owned FASYNC status bit during inode teardown.
+    pub(crate) fn clear_fasync_flag(&self) {
+        let _guard = self.fasync_lock.lock();
+        let mut flags = self.flags.write();
+        flags.remove(FileFlags::FASYNC);
     }
 
     /// @brief 重新设置文件的大小
@@ -2126,6 +2155,13 @@ impl Drop for File {
         for epitem in epitems {
             EventPoll::release_file_epitem(&epitem);
             let _ = self.remove_epitem(&epitem);
+        }
+
+        if self.flags().contains(FileFlags::FASYNC) {
+            if let Ok(pollable) = self.inode.as_pollable_inode() {
+                let private_data = self.private_data.lock();
+                let _ = pollable.release_fasync(self, &private_data);
+            }
         }
 
         super::flock::release_all_for_file(self);

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1948,8 +1948,7 @@ impl File {
         const SETFL_MASK: u32 = FileFlags::O_APPEND.bits()
             | FileFlags::O_NONBLOCK.bits()
             | FileFlags::O_DIRECT.bits()
-            | FileFlags::O_NOATIME.bits()
-            | FileFlags::FASYNC.bits();
+            | FileFlags::O_NOATIME.bits();
 
         let new_bits = (new_flags.bits() & SETFL_MASK) | (old_flags.bits() & !SETFL_MASK);
         new_flags = FileFlags::from_bits_truncate(new_bits);
@@ -1958,6 +1957,19 @@ impl File {
         // 更新文件的打开模式
         *self.flags.write() = new_flags;
         return Ok(());
+    }
+
+    /// Commit the handler-owned FASYNC status bit.
+    ///
+    /// Linux excludes FASYNC from the generic SETFL mask: the fasync handler
+    /// owns this bit and updates it only after registration succeeds.
+    pub(crate) fn set_fasync_flag(&self, enabled: bool) {
+        let mut flags = self.flags.write();
+        if enabled {
+            flags.insert(FileFlags::FASYNC);
+        } else {
+            flags.remove(FileFlags::FASYNC);
+        }
     }
 
     /// @brief 重新设置文件的大小

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -382,6 +382,15 @@ pub trait PollableInode: Any + Sync + Send + Debug + CastFromSync {
         // Default implementation: not supported
         Err(SystemError::ENOSYS)
     }
+
+    /// Remove fasync state during final open-file-description release.
+    fn release_fasync(
+        &self,
+        _file: &file::File,
+        _private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        Err(SystemError::ENOSYS)
+    }
 }
 
 pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -990,8 +990,10 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         _data: usize,
         _private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        // 若文件系统没有实现此方法，则返回"不支持"
-        return Err(SystemError::ENOSYS);
+        // Match Linux vfs_ioctl(): a file without an ioctl handler does not
+        // support the command. sys_ioctl translates this internal error to
+        // the userspace-visible ENOTTY.
+        Err(SystemError::ENOIOCTLCMD)
     }
 
     /// @brief 获取inode所在的文件系统的指针

--- a/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
@@ -1,6 +1,6 @@
 use crate::arch::ipc::signal::Signal;
 use crate::arch::syscall::nr::SYS_FCNTL;
-use crate::filesystem::vfs::fasync::set_file_fasync;
+use crate::filesystem::vfs::fasync::{set_file_fasync, FAsyncHandlerPolicy};
 use crate::filesystem::vfs::FileType;
 use crate::filesystem::vfs::InodeFlags;
 use crate::ipc::pipe::LockedPipeInode;
@@ -189,10 +189,10 @@ impl SysFcntlHandle {
                     }
                     let old_fasync = current_flags.contains(FileFlags::FASYNC);
                     let new_fasync = new_flags.contains(FileFlags::FASYNC);
-                    file.set_flags(new_flags)?;
                     if old_fasync != new_fasync {
-                        set_file_fasync(&file, fd, new_fasync)?;
+                        set_file_fasync(&file, fd, new_fasync, FAsyncHandlerPolicy::Optional)?;
                     }
+                    file.set_flags(new_flags)?;
 
                     // Keep socket object nonblocking state in sync with file flags.
                     // Some socket implementations consult an internal AtomicBool rather than

--- a/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_fcntl.rs
@@ -189,10 +189,28 @@ impl SysFcntlHandle {
                     }
                     let old_fasync = current_flags.contains(FileFlags::FASYNC);
                     let new_fasync = new_flags.contains(FileFlags::FASYNC);
-                    if old_fasync != new_fasync {
-                        set_file_fasync(&file, fd, new_fasync, FAsyncHandlerPolicy::Optional)?;
+
+                    // Apply every potentially failing non-FASYNC flag update
+                    // before invoking the fasync handler. Linux likewise
+                    // validates flags first and lets the handler own FASYNC.
+                    let mut non_fasync_flags = new_flags;
+                    if old_fasync {
+                        non_fasync_flags.insert(FileFlags::FASYNC);
+                    } else {
+                        non_fasync_flags.remove(FileFlags::FASYNC);
                     }
-                    file.set_flags(new_flags)?;
+                    file.set_flags(non_fasync_flags)?;
+
+                    if old_fasync != new_fasync {
+                        if let Err(err) =
+                            set_file_fasync(&file, fd, new_fasync, FAsyncHandlerPolicy::Optional)
+                        {
+                            // A failed fasync transition must not commit the
+                            // other status flags from this F_SETFL request.
+                            file.set_flags(current_flags)?;
+                            return Err(err);
+                        }
+                    }
 
                     // Keep socket object nonblocking state in sync with file flags.
                     // Some socket implementations consult an internal AtomicBool rather than

--- a/kernel/src/filesystem/vfs/syscall/sys_ioctl.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_ioctl.rs
@@ -2,7 +2,7 @@
 
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_IOCTL;
-use crate::filesystem::vfs::fasync::set_file_fasync;
+use crate::filesystem::vfs::fasync::{set_file_fasync, FAsyncHandlerPolicy};
 use crate::filesystem::vfs::file::File;
 use crate::filesystem::vfs::file::FileFlags;
 use crate::syscall::table::FormattedSyscallParam;
@@ -168,7 +168,7 @@ impl SysIoctlHandle {
             UserBufferReader::new(data as *const i32, core::mem::size_of::<i32>(), true)?;
         let value = user_reader.buffer_protected(0)?.read_one::<i32>(0)?;
 
-        set_file_fasync(file, fd, value != 0)?;
+        set_file_fasync(file, fd, value != 0, FAsyncHandlerPolicy::Required)?;
         Ok(0)
     }
 

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -1174,6 +1174,26 @@ impl PollableInode for LockedPipeInode {
         }
         Ok(())
     }
+
+    fn release_fasync(
+        &self,
+        file: &crate::filesystem::vfs::file::File,
+        private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        if let FilePrivateData::Pipefs(pipe_data) = private_data {
+            let flags = pipe_data.flags;
+            if !flags.is_write_only() {
+                self.read_fasync_items.remove_file(file);
+            }
+            if !flags.is_read_only() {
+                self.write_fasync_items.remove_file(file);
+            }
+        } else {
+            self.read_fasync_items.remove_file(file);
+            self.write_fasync_items.remove_file(file);
+        }
+        Ok(())
+    }
 }
 
 impl IndexNode for LockedPipeInode {

--- a/kernel/src/net/socket/inode.rs
+++ b/kernel/src/net/socket/inode.rs
@@ -462,4 +462,9 @@ impl<T: Socket + 'static> PollableInode for T {
         self.fasync_items().remove(file);
         Ok(())
     }
+
+    fn release_fasync(&self, file: &File, _: &FilePrivateData) -> Result<(), SystemError> {
+        self.fasync_items().remove_file(file);
+        Ok(())
+    }
 }

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -1,0 +1,141 @@
+// test_tty_termios.c — verify TCSAFLUSH / TCSADRAIN and legacy termio ioctls
+// on a valid TTY fd (PTY slave).
+//
+// Regression coverage for: "tcsetattr(0, TCSAFLUSH, &t) fails with ENOTTY"
+// and TCSETA/TCSETAW/TCSETAF/TCGETA returning ENOIOCTLCMD.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pty.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+
+/* Legacy SVR4 struct termio — not exposed by glibc's <termios.h>. */
+#define NCC 8
+struct termio_compat {
+    unsigned short c_iflag;
+    unsigned short c_oflag;
+    unsigned short c_cflag;
+    unsigned short c_lflag;
+    unsigned char c_line;
+    unsigned char c_cc[NCC];
+};
+
+#ifndef TCGETA
+#define TCGETA 0x5405
+#endif
+#ifndef TCSETA
+#define TCSETA 0x5406
+#endif
+#ifndef TCSETAW
+#define TCSETAW 0x5407
+#endif
+#ifndef TCSETAF
+#define TCSETAF 0x5408
+#endif
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                                   \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "FAIL: %s (errno=%d: %s)\n", msg, errno,       \
+                    strerror(errno));                                      \
+            failures++;                                                    \
+        } else {                                                           \
+            printf("ok: %s\n", msg);                                       \
+        }                                                                  \
+    } while (0)
+
+int main(void) {
+    int ptm = -1, pts = -1;
+    char name[256];
+
+    if (openpty(&ptm, &pts, name, NULL, NULL) == -1) {
+        perror("openpty");
+        return EXIT_FAILURE;
+    }
+
+    struct termios t;
+
+    /* 1. tcgetattr + tcsetattr(TCSANOW) round-trip. */
+    CHECK(tcgetattr(pts, &t) == 0, "tcgetattr on PTY slave");
+    t.c_lflag &= ~(ICANON | ECHO);
+    CHECK(tcsetattr(pts, TCSANOW, &t) == 0, "tcsetattr TCSANOW");
+    struct termios back;
+    CHECK(tcgetattr(pts, &back) == 0, "tcgetattr after TCSANOW");
+    CHECK((back.c_lflag & (ICANON | ECHO)) == 0, "TCSANOW settings survive");
+
+    /* 2. tcsetattr TCSADRAIN — must not fail with ENOTTY. */
+    CHECK(tcsetattr(pts, TCSADRAIN, &t) == 0, "tcsetattr TCSADRAIN succeeds");
+
+    /* 3. tcsetattr TCSAFLUSH — the dpkg/apt regression. */
+    CHECK(tcsetattr(pts, TCSAFLUSH, &t) == 0, "tcsetattr TCSAFLUSH succeeds");
+    CHECK(tcgetattr(pts, &back) == 0, "tcgetattr after TCSAFLUSH");
+    CHECK((back.c_lflag & (ICANON | ECHO)) == 0, "TCSAFLUSH settings survive");
+
+    /* 4. Legacy termio ioctls — must not return ENOTTY. */
+    struct termio_compat tio;
+    memset(&tio, 0, sizeof(tio));
+
+    errno = 0;
+    CHECK(ioctl(pts, TCGETA, &tio) == 0, "ioctl TCGETA succeeds");
+    CHECK(errno != ENOTTY, "TCGETA does not return ENOTTY");
+
+    tio.c_lflag |= ISIG;
+    errno = 0;
+    CHECK(ioctl(pts, TCSETA, &tio) == 0, "ioctl TCSETA succeeds");
+    CHECK(errno != ENOTTY, "TCSETA does not return ENOTTY");
+
+    errno = 0;
+    CHECK(ioctl(pts, TCSETAW, &tio) == 0, "ioctl TCSETAW succeeds");
+    CHECK(errno != ENOTTY, "TCSETAW does not return ENOTTY");
+
+    errno = 0;
+    CHECK(ioctl(pts, TCSETAF, &tio) == 0, "ioctl TCSETAF succeeds");
+    CHECK(errno != ENOTTY, "TCSETAF does not return ENOTTY");
+
+    /* 5. Cross-check: TCGETA reports low 16 bits of what TCGETS reports. */
+    struct termios full;
+    memset(&tio, 0, sizeof(tio));
+    CHECK(tcgetattr(pts, &full) == 0, "tcgetattr for cross-check");
+    CHECK(ioctl(pts, TCGETA, &tio) == 0, "TCGETA for cross-check");
+    CHECK((full.c_lflag & 0xffff) == tio.c_lflag, "termio c_lflag is low 16 bits");
+    CHECK((full.c_iflag & 0xffff) == tio.c_iflag, "termio c_iflag is low 16 bits");
+
+    /* 6. termio round-trip preserves merge semantics: high bits of c_cflag
+     * (e.g. CIBAUD/ADDRB region) set via termios survive a TCSETA call. */
+    CHECK(tcgetattr(pts, &full) == 0, "tcgetattr before TCSETA merge check");
+    tcflag_t orig_cflag = full.c_cflag;
+    memset(&tio, 0, sizeof(tio));
+    CHECK(ioctl(pts, TCGETA, &tio) == 0, "TCGETA before TCSETA merge check");
+    tio.c_lflag &= ~(unsigned short)ECHO; /* flip a low-16-bit flag */
+    CHECK(ioctl(pts, TCSETA, &tio) == 0, "TCSETA merge apply");
+    CHECK(tcgetattr(pts, &full) == 0, "tcgetattr after TCSETA merge check");
+    CHECK((full.c_cflag & 0xffff0000u) == (orig_cflag & 0xffff0000u),
+          "TCSETA preserves high 16 bits of c_cflag");
+    CHECK((full.c_lflag & ECHO) == 0, "TCSETA applied low-16-bit change");
+
+    /* 7. tcsetattr on a non-TTY fd must fail with ENOTTY. */
+    int nullfd = open("/dev/null", O_RDWR);
+    if (nullfd >= 0) {
+        errno = 0;
+        int rc = tcsetattr(nullfd, TCSANOW, &t);
+        CHECK(rc == -1 && errno == ENOTTY, "tcsetattr on /dev/null → ENOTTY");
+        close(nullfd);
+    }
+
+    close(ptm);
+    close(pts);
+
+    if (failures) {
+        fprintf(stderr, "%d test(s) FAILED\n", failures);
+        return EXIT_FAILURE;
+    }
+    printf("all tty termios tests passed\n");
+    return EXIT_SUCCESS;
+}

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -84,20 +84,16 @@ int main(void) {
 
     errno = 0;
     CHECK(ioctl(pts, TCGETA, &tio) == 0, "ioctl TCGETA succeeds");
-    CHECK(errno != ENOTTY, "TCGETA does not return ENOTTY");
 
     tio.c_lflag |= ISIG;
     errno = 0;
     CHECK(ioctl(pts, TCSETA, &tio) == 0, "ioctl TCSETA succeeds");
-    CHECK(errno != ENOTTY, "TCSETA does not return ENOTTY");
 
     errno = 0;
     CHECK(ioctl(pts, TCSETAW, &tio) == 0, "ioctl TCSETAW succeeds");
-    CHECK(errno != ENOTTY, "TCSETAW does not return ENOTTY");
 
     errno = 0;
     CHECK(ioctl(pts, TCSETAF, &tio) == 0, "ioctl TCSETAF succeeds");
-    CHECK(errno != ENOTTY, "TCSETAF does not return ENOTTY");
 
     /* 5. Cross-check: TCGETA reports low 16 bits of what TCGETS reports. */
     struct termios full;

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -85,7 +85,7 @@ int main(void) {
     CHECK(tcsetattr(pts, TCSANOW, &t) == 0, "tcsetattr TCSANOW");
     struct termios back;
     CHECK(tcgetattr(pts, &back) == 0, "tcgetattr after TCSANOW");
-    CHECK((back.c_lflag & (ICANON | ECHO)) == 0, "TCSANOW settings survive");
+    CHECK_NOERR((back.c_lflag & (ICANON | ECHO)) == 0, "TCSANOW settings survive");
 
     /* 2. tcsetattr TCSADRAIN — must not fail with ENOTTY.
      * TODO: add a stress test where master writes data → slave TCSADRAIN
@@ -95,7 +95,7 @@ int main(void) {
     /* 3. tcsetattr TCSAFLUSH — the dpkg/apt regression. */
     CHECK(tcsetattr(pts, TCSAFLUSH, &t) == 0, "tcsetattr TCSAFLUSH succeeds");
     CHECK(tcgetattr(pts, &back) == 0, "tcgetattr after TCSAFLUSH");
-    CHECK((back.c_lflag & (ICANON | ECHO)) == 0, "TCSAFLUSH settings survive");
+    CHECK_NOERR((back.c_lflag & (ICANON | ECHO)) == 0, "TCSAFLUSH settings survive");
 
     /* 4. Legacy termio ioctls — must not return ENOTTY. */
     struct termio_compat tio;
@@ -107,13 +107,35 @@ int main(void) {
     tio.c_lflag |= ISIG;
     errno = 0;
     CHECK(ioctl(pts, TCSETA, &tio) == 0, "ioctl TCSETA succeeds");
+    /* Verify TCSETA was applied by reading back via TCGETA. */
+    {
+        struct termio_compat rdback;
+        memset(&rdback, 0, sizeof(rdback));
+        CHECK(ioctl(pts, TCGETA, &rdback) == 0, "TCGETA after TCSETA");
+        CHECK_NOERR((rdback.c_lflag & ISIG) != 0, "TCSETA ISIG flag applied");
+    }
 
+    tio.c_lflag &= ~(unsigned short)ISIG;
     errno = 0;
     CHECK(ioctl(pts, TCSETAW, &tio) == 0, "ioctl TCSETAW succeeds");
+    /* Verify TCSETAW was applied. */
+    {
+        struct termio_compat rdback;
+        memset(&rdback, 0, sizeof(rdback));
+        CHECK(ioctl(pts, TCGETA, &rdback) == 0, "TCGETA after TCSETAW");
+        CHECK_NOERR((rdback.c_lflag & ISIG) == 0, "TCSETAW cleared ISIG");
+    }
 
+    tio.c_lflag |= ISIG;
     errno = 0;
     CHECK(ioctl(pts, TCSETAF, &tio) == 0, "ioctl TCSETAF succeeds");
-
+    /* Verify TCSETAF was applied. */
+    {
+        struct termio_compat rdback;
+        memset(&rdback, 0, sizeof(rdback));
+        CHECK(ioctl(pts, TCGETA, &rdback) == 0, "TCGETA after TCSETAF");
+        CHECK_NOERR((rdback.c_lflag & ISIG) != 0, "TCSETAF ISIG flag applied");
+    }
     /* 5. Cross-check: TCGETA reports low 16 bits of what TCGETS reports. */
     struct termios full = {};
     memset(&tio, 0, sizeof(tio));
@@ -121,6 +143,8 @@ int main(void) {
     CHECK(ioctl(pts, TCGETA, &tio) == 0, "TCGETA for cross-check");
     CHECK_NOERR((full.c_lflag & 0xffff) == tio.c_lflag, "termio c_lflag is low 16 bits");
     CHECK_NOERR((full.c_iflag & 0xffff) == tio.c_iflag, "termio c_iflag is low 16 bits");
+    CHECK_NOERR((full.c_cflag & 0xffff) == tio.c_cflag, "termio c_cflag is low 16 bits");
+    CHECK_NOERR((full.c_oflag & 0xffff) == tio.c_oflag, "termio c_oflag is low 16 bits");
 
     /* c_line round-trip: verify that a non-zero c_line value set
      * through TCSETA is preserved when read back via TCGETA.  The

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -28,6 +28,7 @@ struct termio_compat {
     unsigned short c_lflag;
     unsigned char c_line;
     unsigned char c_cc[NCC];
+    unsigned char _pad;   /* match kernel PosixTermio layout */
 };
 
 #ifndef TCGETA
@@ -56,11 +57,22 @@ static int failures = 0;
         }                                                                  \
     } while (0)
 
+/* Like CHECK, but for assertions that don't follow a syscall —
+ * errno is irrelevant and printing it is misleading. */
+#define CHECK_NOERR(cond, msg)                                             \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            fprintf(stderr, "FAIL: %s\n", msg);                            \
+            failures++;                                                    \
+        } else {                                                           \
+            printf("ok: %s\n", msg);                                       \
+        }                                                                  \
+    } while (0)
+
 int main(void) {
     int ptm = -1, pts = -1;
-    char name[256];
 
-    if (openpty(&ptm, &pts, name, NULL, NULL) == -1) {
+    if (openpty(&ptm, &pts, NULL, NULL, NULL) == -1) {
         perror("openpty");
         return EXIT_FAILURE;
     }
@@ -103,12 +115,24 @@ int main(void) {
     CHECK(ioctl(pts, TCSETAF, &tio) == 0, "ioctl TCSETAF succeeds");
 
     /* 5. Cross-check: TCGETA reports low 16 bits of what TCGETS reports. */
-    struct termios full;
+    struct termios full = {};
     memset(&tio, 0, sizeof(tio));
     CHECK(tcgetattr(pts, &full) == 0, "tcgetattr for cross-check");
     CHECK(ioctl(pts, TCGETA, &tio) == 0, "TCGETA for cross-check");
-    CHECK((full.c_lflag & 0xffff) == tio.c_lflag, "termio c_lflag is low 16 bits");
-    CHECK((full.c_iflag & 0xffff) == tio.c_iflag, "termio c_iflag is low 16 bits");
+    CHECK_NOERR((full.c_lflag & 0xffff) == tio.c_lflag, "termio c_lflag is low 16 bits");
+    CHECK_NOERR((full.c_iflag & 0xffff) == tio.c_iflag, "termio c_iflag is low 16 bits");
+
+    /* c_line round-trip: verify that a non-zero c_line value set
+     * through TCSETA is preserved when read back via TCGETA.  The
+     * kernel's c_line_abi field retains the raw ABI byte even when
+     * LineDisciplineType::from_line falls back to N_TTY. */
+    memset(&tio, 0, sizeof(tio));
+    tio.c_line = 42;
+    CHECK(ioctl(pts, TCSETA, &tio) == 0, "TCSETA with c_line=42");
+    struct termio_compat tio2;
+    memset(&tio2, 0, sizeof(tio2));
+    CHECK(ioctl(pts, TCGETA, &tio2) == 0, "TCGETA after c_line=42");
+    CHECK_NOERR(tio2.c_line == 42, "c_line preserved through termio round-trip");
 
     /* 6. termio round-trip preserves merge semantics: high bits of c_cflag
      * (e.g. CIBAUD/ADDRB region) set via termios survive a TCSETA call. */
@@ -116,12 +140,16 @@ int main(void) {
     tcflag_t orig_cflag = full.c_cflag;
     memset(&tio, 0, sizeof(tio));
     CHECK(ioctl(pts, TCGETA, &tio) == 0, "TCGETA before TCSETA merge check");
+    /* Set a flag bit we know is currently clear so the subsequent
+     * clear of that bit is a real operation, not a no-op. */
+    tio.c_lflag |= ECHO;
+    CHECK(ioctl(pts, TCSETA, &tio) == 0, "TCSETA set ECHO before merge check");
     tio.c_lflag &= ~(unsigned short)ECHO; /* flip a low-16-bit flag */
     CHECK(ioctl(pts, TCSETA, &tio) == 0, "TCSETA merge apply");
     CHECK(tcgetattr(pts, &full) == 0, "tcgetattr after TCSETA merge check");
-    CHECK((full.c_cflag & 0xffff0000u) == (orig_cflag & 0xffff0000u),
+    CHECK_NOERR((full.c_cflag & 0xffff0000u) == (orig_cflag & 0xffff0000u),
           "TCSETA preserves high 16 bits of c_cflag");
-    CHECK((full.c_lflag & ECHO) == 0, "TCSETA applied low-16-bit change");
+    CHECK_NOERR((full.c_lflag & ECHO) == 0, "TCSETA applied low-16-bit change");
 
     /* 7. tcsetattr on a non-TTY fd must fail. The exact errno depends on
      * the underlying device (ENOTTY, ENOSYS, EINVAL are all valid). */
@@ -131,6 +159,8 @@ int main(void) {
         int rc = tcsetattr(nullfd, TCSANOW, &t);
         CHECK(rc == -1 && errno != 0, "tcsetattr on /dev/null fails");
         close(nullfd);
+    } else {
+        printf("skip: cannot open /dev/null (errno=%d: %s)\n", errno, strerror(errno));
     }
 
     close(ptm);

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -120,12 +120,13 @@ int main(void) {
           "TCSETA preserves high 16 bits of c_cflag");
     CHECK((full.c_lflag & ECHO) == 0, "TCSETA applied low-16-bit change");
 
-    /* 7. tcsetattr on a non-TTY fd must fail with ENOTTY. */
+    /* 7. tcsetattr on a non-TTY fd must fail. The exact errno depends on
+     * the underlying device (ENOTTY, ENOSYS, EINVAL are all valid). */
     int nullfd = open("/dev/null", O_RDWR);
     if (nullfd >= 0) {
         errno = 0;
         int rc = tcsetattr(nullfd, TCSANOW, &t);
-        CHECK(rc == -1 && errno == ENOTTY, "tcsetattr on /dev/null → ENOTTY");
+        CHECK(rc == -1 && errno != 0, "tcsetattr on /dev/null fails");
         close(nullfd);
     }
 

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -175,13 +175,13 @@ int main(void) {
           "TCSETA preserves high 16 bits of c_cflag");
     CHECK_NOERR((full.c_lflag & ECHO) == 0, "TCSETA applied low-16-bit change");
 
-    /* 7. tcsetattr on a non-TTY fd must fail. The exact errno depends on
-     * the underlying device (ENOTTY, ENOSYS, EINVAL are all valid). */
+    /* 7. Linux reports ENOTTY for a termios ioctl on a non-TTY fd. */
     int nullfd = open("/dev/null", O_RDWR);
     if (nullfd >= 0) {
         errno = 0;
         int rc = tcsetattr(nullfd, TCSANOW, &t);
-        CHECK(rc == -1 && errno != 0, "tcsetattr on /dev/null fails");
+        CHECK(rc == -1 && errno == ENOTTY,
+              "tcsetattr on /dev/null fails with ENOTTY");
         close(nullfd);
     } else {
         printf("skip: cannot open /dev/null (errno=%d: %s)\n", errno, strerror(errno));

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -1,3 +1,10 @@
+// test_tty_termios.c — quick smoke test for TTY termios/termio ioctls.
+//
+// This file intentionally overlaps with dunitest/suites/normal/tty_termios.cc.
+// The C version is a fast, self-contained static binary for QEMU serial-console
+// smoke testing.  The C++ gtest version is the full CI regression suite.
+// Keep both: the C test catches regressions in environments where dunitest
+// (which requires gtest, a runner, and a rootfs) cannot run.
 // test_tty_termios.c — verify TCSAFLUSH / TCSADRAIN and legacy termio ioctls
 // on a valid TTY fd (PTY slave).
 //
@@ -70,7 +77,9 @@ int main(void) {
     CHECK(tcgetattr(pts, &back) == 0, "tcgetattr after TCSANOW");
     CHECK((back.c_lflag & (ICANON | ECHO)) == 0, "TCSANOW settings survive");
 
-    /* 2. tcsetattr TCSADRAIN — must not fail with ENOTTY. */
+    /* 2. tcsetattr TCSADRAIN — must not fail with ENOTTY.
+     * TODO: add a stress test where master writes data → slave TCSADRAIN
+     * → verify drain actually waited for output to complete. */
     CHECK(tcsetattr(pts, TCSADRAIN, &t) == 0, "tcsetattr TCSADRAIN succeeds");
 
     /* 3. tcsetattr TCSAFLUSH — the dpkg/apt regression. */

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -77,7 +77,7 @@ int main(void) {
         return EXIT_FAILURE;
     }
 
-    struct termios t;
+    struct termios t = {};
 
     /* 1. tcgetattr + tcsetattr(TCSANOW) round-trip. */
     CHECK(tcgetattr(pts, &t) == 0, "tcgetattr on PTY slave");

--- a/user/apps/c_unitest/test_tty_termios.c
+++ b/user/apps/c_unitest/test_tty_termios.c
@@ -1,15 +1,13 @@
-// test_tty_termios.c — quick smoke test for TTY termios/termio ioctls.
-//
-// This file intentionally overlaps with dunitest/suites/normal/tty_termios.cc.
-// The C version is a fast, self-contained static binary for QEMU serial-console
-// smoke testing.  The C++ gtest version is the full CI regression suite.
-// Keep both: the C test catches regressions in environments where dunitest
-// (which requires gtest, a runner, and a rootfs) cannot run.
 // test_tty_termios.c — verify TCSAFLUSH / TCSADRAIN and legacy termio ioctls
 // on a valid TTY fd (PTY slave).
 //
 // Regression coverage for: "tcsetattr(0, TCSAFLUSH, &t) fails with ENOTTY"
 // and TCSETA/TCSETAW/TCSETAF/TCGETA returning ENOIOCTLCMD.
+//
+// This file intentionally overlaps with dunitest/suites/normal/tty_termios.cc.
+// The C version is a fast, self-contained static binary for QEMU smoke testing.
+// The C++ gtest version is the full CI regression suite.  Keep both: the C test
+// catches regressions in environments where dunitest cannot run.
 
 #include <errno.h>
 #include <fcntl.h>

--- a/user/apps/tests/dunitest/suites/normal/fcntl_signal.cc
+++ b/user/apps/tests/dunitest/suites/normal/fcntl_signal.cc
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <string.h>
 #include <sys/epoll.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -85,6 +86,26 @@ TEST(FcntlSignal, GetSigDefaultsToZero) {
 
     close(fds[0]);
     close(fds[1]);
+}
+
+TEST(FcntlSignal, UnsupportedFasyncDoesNotCommitFlag) {
+    int fd = open("/dev/null", O_RDONLY);
+    ASSERT_GE(fd, 0);
+
+    int before = fcntl(fd, F_GETFL);
+    ASSERT_GE(before, 0);
+    ASSERT_EQ(0, fcntl(fd, F_SETFL, before | O_ASYNC));
+
+    int after = fcntl(fd, F_GETFL);
+    ASSERT_GE(after, 0);
+    EXPECT_EQ(0, after & O_ASYNC);
+
+    int enabled = 1;
+    errno = 0;
+    EXPECT_EQ(-1, ioctl(fd, FIOASYNC, &enabled));
+    EXPECT_EQ(ENOTTY, errno);
+
+    close(fd);
 }
 
 TEST(FcntlSignal, SetSigRoundTripAndValidation) {

--- a/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
@@ -1114,7 +1114,8 @@ TEST(TtyPtyHangup, MasterCloseMakesSlaveObserveHangup) {
     pair.master.reset();
 
     short revents = PollEvents(pair.slave.get());
-    EXPECT_NE(0, revents & POLLHUP);
+    constexpr short kHungUpEvents = POLLIN | POLLOUT | POLLERR | POLLHUP;
+    EXPECT_EQ(kHungUpEvents, revents);
 
     char ch = 0;
     errno = 0;
@@ -1124,6 +1125,19 @@ TEST(TtyPtyHangup, MasterCloseMakesSlaveObserveHangup) {
     EXPECT_EQ(-1, write(pair.slave.get(), "x", 1));
     EXPECT_EQ(EIO, errno) << "slave write after master close errno=" << errno << " ("
                           << strerror(errno) << ")";
+
+    int async = 1;
+    errno = 0;
+    EXPECT_EQ(-1, ioctl(pair.slave.get(), FIOASYNC, &async));
+    EXPECT_EQ(ENOTTY, errno) << "slave FIOASYNC after master close errno=" << errno << " ("
+                            << strerror(errno) << ")";
+
+    int flags = fcntl(pair.slave.get(), F_GETFL);
+    ASSERT_GE(flags, 0);
+    errno = 0;
+    EXPECT_EQ(-1, fcntl(pair.slave.get(), F_SETFL, flags | O_ASYNC));
+    EXPECT_EQ(ENOTTY, errno) << "slave F_SETFL(O_ASYNC) after master close errno=" << errno << " ("
+                            << strerror(errno) << ")";
 }
 
 TEST(TtyPtyHangup, ChildExitDrainsSlaveOutputBeforeMasterEio) {

--- a/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -1138,6 +1139,77 @@ TEST(TtyPtyHangup, MasterCloseMakesSlaveObserveHangup) {
     EXPECT_EQ(-1, fcntl(pair.slave.get(), F_SETFL, flags | O_ASYNC));
     EXPECT_EQ(ENOTTY, errno) << "slave F_SETFL(O_ASYNC) after master close errno=" << errno << " ("
                             << strerror(errno) << ")";
+}
+
+TEST(TtyPtyHangup, HangupClearsAsyncState) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    int flags = fcntl(pair.slave.get(), F_GETFL);
+    ASSERT_GE(flags, 0);
+    ASSERT_EQ(0, fcntl(pair.slave.get(), F_SETFL, flags | O_ASYNC));
+    ASSERT_NE(0, fcntl(pair.slave.get(), F_GETFL) & O_ASYNC);
+
+    pair.master.reset();
+
+    flags = fcntl(pair.slave.get(), F_GETFL);
+    ASSERT_GE(flags, 0);
+    EXPECT_EQ(0, flags & O_ASYNC);
+
+    int async = 0;
+    EXPECT_EQ(0, ioctl(pair.slave.get(), FIOASYNC, &async));
+    EXPECT_EQ(0, fcntl(pair.slave.get(), F_SETFL, flags & ~O_ASYNC));
+}
+
+struct AsyncFlagRaceArgs {
+    int fd;
+    int async_flags;
+    std::atomic<bool> stop{false};
+    std::atomic<int> unexpected_errno{0};
+};
+
+void* ToggleNonblockAcrossHangup(void* opaque) {
+    auto* args = static_cast<AsyncFlagRaceArgs*>(opaque);
+    bool nonblock = false;
+    while (!args->stop.load(std::memory_order_acquire)) {
+        nonblock = !nonblock;
+        int flags = args->async_flags;
+        if (nonblock) {
+            flags |= O_NONBLOCK;
+        } else {
+            flags &= ~O_NONBLOCK;
+        }
+        if (fcntl(args->fd, F_SETFL, flags) < 0 && errno != ENOTTY) {
+            args->unexpected_errno.store(errno, std::memory_order_release);
+            break;
+        }
+    }
+    return nullptr;
+}
+
+TEST(TtyPtyHangup, ConcurrentStatusFlagUpdateCannotRestoreAsync) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    int flags = fcntl(pair.slave.get(), F_GETFL);
+    ASSERT_GE(flags, 0);
+    ASSERT_EQ(0, fcntl(pair.slave.get(), F_SETFL, flags | O_ASYNC));
+
+    AsyncFlagRaceArgs args{pair.slave.get(), flags | O_ASYNC};
+    pthread_t updater;
+    ASSERT_EQ(0, pthread_create(&updater, nullptr, ToggleNonblockAcrossHangup, &args));
+    usleep(1000);
+    pair.master.reset();
+    usleep(1000);
+    args.stop.store(true, std::memory_order_release);
+    ASSERT_EQ(0, pthread_join(updater, nullptr));
+
+    EXPECT_EQ(0, args.unexpected_errno.load(std::memory_order_acquire));
+    flags = fcntl(pair.slave.get(), F_GETFL);
+    ASSERT_GE(flags, 0);
+    EXPECT_EQ(0, flags & O_ASYNC);
 }
 
 TEST(TtyPtyHangup, ChildExitDrainsSlaveOutputBeforeMasterEio) {

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -130,7 +130,9 @@ TEST(TtyTermios, TcSanowRoundTrip) {
 }
 
 /* --------------------------------------------------------------------------
- * tcsetattr TCSADRAIN — must not fail with ENOTTY
+ * tcsetattr TCSADRAIN — must not fail with ENOTTY.
+ * TODO: add a stress test where master writes data → slave TCSADRAIN
+ * → verify drain actually waited for output to complete.
  * -------------------------------------------------------------------------- */
 TEST(TtyTermios, TcsadrainSucceeds) {
     auto pty = OpenRawPty();

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -187,6 +187,75 @@ TEST(TtyTermios, TcsadrainSucceeds) {
 }
 
 /*
+ * DragonOS keeps bytes that the peer N_TTY buffer cannot yet accept in a
+ * driver-owned PTY queue. TCSADRAIN must wait for that queue to empty, but it
+ * need not wait for the peer application to consume bytes already delivered
+ * to N_TTY.
+ */
+TEST(TtyTermios, TcsadrainWaitsForPtyDriverBacklog) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios t = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &t), 0) << strerror(errno);
+
+    int slave_flags = fcntl(pty.slave.get(), F_GETFL, 0);
+    ASSERT_GE(slave_flags, 0);
+    ASSERT_EQ(fcntl(pty.slave.get(), F_SETFL, slave_flags | O_NONBLOCK), 0);
+
+    char fill[1024];
+    memset(fill, 'q', sizeof(fill));
+    size_t accepted = 0;
+    for (;;) {
+        ssize_t n = write(pty.slave.get(), fill, sizeof(fill));
+        if (n > 0) {
+            accepted += static_cast<size_t>(n);
+            continue;
+        }
+        ASSERT_EQ(n, -1);
+        ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+        break;
+    }
+    ASSERT_GT(accepted, 0u);
+
+    int master_flags = fcntl(pty.master.get(), F_GETFL, 0);
+    ASSERT_GE(master_flags, 0);
+    ASSERT_EQ(fcntl(pty.master.get(), F_SETFL, master_flags | O_NONBLOCK), 0);
+
+    TcsetattrThreadArgs args;
+    args.fd = pty.slave.get();
+    args.action = TCSADRAIN;
+    args.term = t;
+    pthread_t waiter;
+    ASSERT_EQ(pthread_create(&waiter, nullptr, TcsetattrThread, &args), 0);
+    ASSERT_TRUE(WaitForFlag(args.started, 1000));
+
+    EXPECT_FALSE(WaitForFlag(args.done, 20))
+        << "TCSADRAIN completed with bytes still queued in the PTY driver";
+
+    char drain[1024];
+    for (int i = 0; i < 2000 && !args.done.load(std::memory_order_acquire); ++i) {
+        ssize_t n = read(pty.master.get(), drain, sizeof(drain));
+        if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                usleep(1000);
+            } else {
+                ADD_FAILURE() << "master read failed: " << strerror(errno);
+                break;
+            }
+        }
+    }
+
+    if (!args.done.load(std::memory_order_acquire)) {
+        pty.master.reset();
+    }
+    ASSERT_EQ(pthread_join(waiter, nullptr), 0);
+    ASSERT_TRUE(args.done.load(std::memory_order_acquire));
+    EXPECT_EQ(args.rc, 0) << "errno=" << args.saved_errno << " ("
+                          << strerror(args.saved_errno) << ")";
+}
+
+/*
  * DragonOS N_TTY can retain an echo step when the PTY bridge has no room.
  * TCSADRAIN must wait for that ldisc-owned output to be submitted, but it
  * must not wait for the master application to consume the entire PTY input.
@@ -206,20 +275,21 @@ TEST(TtyTermios, TcsadrainWaitsForRetainedEchoOnly) {
     ASSERT_GE(slave_flags, 0);
     ASSERT_EQ(fcntl(pty.slave.get(), F_SETFL, slave_flags | O_NONBLOCK), 0);
 
-    char fill[1024];
+    // Fill only the peer N_TTY buffer. Writing until EAGAIN would also fill
+    // the driver-owned PtyByteQueue and turn this into a duplicate of the
+    // dedicated PTY backlog test above.
+    char fill[4095];
     memset(fill, 'x', sizeof(fill));
     size_t accepted = 0;
-    for (;;) {
-        ssize_t n = write(pty.slave.get(), fill, sizeof(fill));
+    while (accepted < sizeof(fill)) {
+        ssize_t n = write(pty.slave.get(), &fill[accepted], sizeof(fill) - accepted);
         if (n > 0) {
             accepted += static_cast<size_t>(n);
             continue;
         }
-        ASSERT_EQ(n, -1);
-        ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
-        break;
+        ASSERT_GT(n, 0) << strerror(errno);
     }
-    ASSERT_GT(accepted, 0u);
+    ASSERT_EQ(accepted, sizeof(fill));
 
     const char control = 0x01;  // ECHOCTL renders this as "^A" (two bytes).
     ASSERT_EQ(write(pty.master.get(), &control, 1), 1) << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -92,7 +92,7 @@ PtyPair OpenRawPty() {
     struct termios term = {};
     if (tcgetattr(pair.slave.get(), &term) < 0) {
         ADD_FAILURE() << "tcgetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
-        return pair;
+        return {};
     }
 
     term.c_iflag = 0;
@@ -182,17 +182,38 @@ TEST(TtyTermios, LegacyTcsetaFamily) {
     ASSERT_GE(pty.slave.get(), 0);
 
     TermioCompat tio = {};
+    tio.c_lflag |= ISIG;
     errno = 0;
     EXPECT_EQ(ioctl(pty.slave.get(), TCSETA, &tio), 0)
         << "TCSETA: errno=" << errno << " (" << strerror(errno) << ")";
+    /* Verify TCSETA was applied. */
+    {
+        TermioCompat rdback = {};
+        ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &rdback), 0);
+        EXPECT_NE(rdback.c_lflag & ISIG, 0u) << "TCSETA ISIG flag applied";
+    }
 
+    tio.c_lflag &= ~static_cast<unsigned short>(ISIG);
     errno = 0;
     EXPECT_EQ(ioctl(pty.slave.get(), TCSETAW, &tio), 0)
         << "TCSETAW: errno=" << errno << " (" << strerror(errno) << ")";
+    /* Verify TCSETAW was applied. */
+    {
+        TermioCompat rdback = {};
+        ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &rdback), 0);
+        EXPECT_EQ(rdback.c_lflag & ISIG, 0u) << "TCSETAW cleared ISIG";
+    }
 
+    tio.c_lflag |= ISIG;
     errno = 0;
     EXPECT_EQ(ioctl(pty.slave.get(), TCSETAF, &tio), 0)
         << "TCSETAF: errno=" << errno << " (" << strerror(errno) << ")";
+    /* Verify TCSETAF was applied. */
+    {
+        TermioCompat rdback = {};
+        ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &rdback), 0);
+        EXPECT_NE(rdback.c_lflag & ISIG, 0u) << "TCSETAF ISIG flag applied";
+    }
 }
 
 /* --------------------------------------------------------------------------
@@ -212,12 +233,16 @@ TEST(TtyTermios, TermioLow16Bits) {
         << "termio c_lflag should be low 16 bits of termios c_lflag";
     EXPECT_EQ(full.c_iflag & 0xffff, tio.c_iflag)
         << "termio c_iflag should be low 16 bits of termios c_iflag";
+    EXPECT_EQ(full.c_cflag & 0xffff, tio.c_cflag)
+        << "termio c_cflag should be low 16 bits of termios c_cflag";
+    EXPECT_EQ(full.c_oflag & 0xffff, tio.c_oflag)
+        << "termio c_oflag should be low 16 bits of termios c_oflag";
 }
 
 /* --------------------------------------------------------------------------
  * c_line round-trip: non-zero c_line survives TCSETA → TCGETA
  * -------------------------------------------------------------------------- */
-TEST(TtyTermios, CLinelRoundtrip) {
+TEST(TtyTermios, CLineRoundtrip) {
     auto pty = OpenRawPty();
     ASSERT_GE(pty.slave.get(), 0);
 

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -170,7 +170,6 @@ TEST(TtyTermios, LegacyTcgeta) {
     errno = 0;
     ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &tio), 0)
         << "TCGETA should succeed: errno=" << errno << " (" << strerror(errno) << ")";
-    EXPECT_NE(errno, ENOTTY) << "TCGETA must not return ENOTTY";
 }
 
 /* --------------------------------------------------------------------------
@@ -184,17 +183,14 @@ TEST(TtyTermios, LegacyTcsetaFamily) {
     errno = 0;
     EXPECT_EQ(ioctl(pty.slave.get(), TCSETA, &tio), 0)
         << "TCSETA: errno=" << errno << " (" << strerror(errno) << ")";
-    EXPECT_NE(errno, ENOTTY);
 
     errno = 0;
     EXPECT_EQ(ioctl(pty.slave.get(), TCSETAW, &tio), 0)
         << "TCSETAW: errno=" << errno << " (" << strerror(errno) << ")";
-    EXPECT_NE(errno, ENOTTY);
 
     errno = 0;
     EXPECT_EQ(ioctl(pty.slave.get(), TCSETAF, &tio), 0)
         << "TCSETAF: errno=" << errno << " (" << strerror(errno) << ")";
-    EXPECT_NE(errno, ENOTTY);
 }
 
 /* --------------------------------------------------------------------------

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -76,6 +76,18 @@ private:
     int fd_ = -1;
 };
 
+class TermiosRestorer {
+public:
+    TermiosRestorer(int fd, const struct termios& term) : fd_(fd), term_(term) {}
+    TermiosRestorer(const TermiosRestorer&) = delete;
+    TermiosRestorer& operator=(const TermiosRestorer&) = delete;
+    ~TermiosRestorer() { tcsetattr(fd_, TCSANOW, &term_); }
+
+private:
+    int fd_;
+    struct termios term_;
+};
+
 struct PtyPair {
     UniqueFd master;
     UniqueFd slave;
@@ -435,6 +447,49 @@ TEST(TtyTermios, TermioMergeHighBits) {
         << "TCSETA should preserve high 16 bits of c_cflag";
     EXPECT_EQ(full.c_lflag & ECHO, 0u)
         << "TCSETA should apply low-16-bit change";
+}
+
+/* --------------------------------------------------------------------------
+ * Serial8250 termios must reach the UART hardware callback. Before the
+ * regression fix the default ENOSYS callback made the TTY core restore all
+ * hardware-related c_cflag bits even though tcsetattr/ioctl returned success.
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, Serial8250AppliesModernAndLegacySettings) {
+    UniqueFd serial(open("/dev/ttyS0", O_RDWR | O_NOCTTY));
+    if (serial.get() < 0) {
+        GTEST_SKIP() << "cannot open /dev/ttyS0: " << strerror(errno);
+        return;
+    }
+
+    struct termios original = {};
+    ASSERT_EQ(tcgetattr(serial.get(), &original), 0) << strerror(errno);
+    TermiosRestorer restore(serial.get(), original);
+
+    struct termios modern = original;
+    modern.c_cflag &= ~(CSIZE | CSTOPB | PARODD);
+    modern.c_cflag |= CS7 | PARENB;
+    ASSERT_EQ(cfsetispeed(&modern, B9600), 0);
+    ASSERT_EQ(cfsetospeed(&modern, B9600), 0);
+    ASSERT_EQ(tcsetattr(serial.get(), TCSANOW, &modern), 0) << strerror(errno);
+
+    struct termios modern_back = {};
+    ASSERT_EQ(tcgetattr(serial.get(), &modern_back), 0) << strerror(errno);
+    EXPECT_EQ(cfgetospeed(&modern_back), static_cast<speed_t>(B9600));
+    EXPECT_EQ(modern_back.c_cflag & CSIZE, static_cast<tcflag_t>(CS7));
+    EXPECT_NE(modern_back.c_cflag & PARENB, 0u);
+    EXPECT_EQ(modern_back.c_cflag & PARODD, 0u);
+
+    TermioCompat legacy = {};
+    ASSERT_EQ(ioctl(serial.get(), TCGETA, &legacy), 0) << strerror(errno);
+    legacy.c_cflag &= ~static_cast<unsigned short>(CBAUD | CSIZE | PARENB | PARODD);
+    legacy.c_cflag |= static_cast<unsigned short>(B19200 | CS8);
+    ASSERT_EQ(ioctl(serial.get(), TCSETA, &legacy), 0) << strerror(errno);
+
+    struct termios legacy_back = {};
+    ASSERT_EQ(tcgetattr(serial.get(), &legacy_back), 0) << strerror(errno);
+    EXPECT_EQ(cfgetospeed(&legacy_back), static_cast<speed_t>(B19200));
+    EXPECT_EQ(legacy_back.c_cflag & CSIZE, static_cast<tcflag_t>(CS8));
+    EXPECT_EQ(legacy_back.c_cflag & PARENB, 0u);
 }
 
 /* --------------------------------------------------------------------------

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -6,8 +6,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <pty.h>
 #include <string.h>
 #include <sys/ioctl.h>
@@ -109,6 +111,35 @@ PtyPair OpenRawPty() {
     return pair;
 }
 
+struct TcsetattrThreadArgs {
+    int fd = -1;
+    int action = TCSANOW;
+    struct termios term = {};
+    std::atomic<bool> started{false};
+    std::atomic<bool> done{false};
+    int rc = -1;
+    int saved_errno = 0;
+};
+
+void* TcsetattrThread(void* opaque) {
+    auto* args = static_cast<TcsetattrThreadArgs*>(opaque);
+    args->started.store(true, std::memory_order_release);
+    args->rc = tcsetattr(args->fd, args->action, &args->term);
+    args->saved_errno = errno;
+    args->done.store(true, std::memory_order_release);
+    return nullptr;
+}
+
+bool WaitForFlag(const std::atomic<bool>& flag, int timeout_ms) {
+    for (int elapsed = 0; elapsed < timeout_ms; ++elapsed) {
+        if (flag.load(std::memory_order_acquire)) {
+            return true;
+        }
+        usleep(1000);
+    }
+    return flag.load(std::memory_order_acquire);
+}
+
 /* --------------------------------------------------------------------------
  * tcgetattr + tcsetattr(TCSANOW) round-trip
  * -------------------------------------------------------------------------- */
@@ -141,6 +172,125 @@ TEST(TtyTermios, TcsadrainSucceeds) {
     struct termios t = {};
     ASSERT_EQ(tcgetattr(pty.slave.get(), &t), 0) << strerror(errno);
     EXPECT_EQ(tcsetattr(pty.slave.get(), TCSADRAIN, &t), 0) << strerror(errno);
+}
+
+/*
+ * DragonOS N_TTY can retain an echo step when the PTY bridge has no room.
+ * TCSADRAIN must wait for that ldisc-owned output to be submitted, but it
+ * must not wait for the master application to consume the entire PTY input.
+ */
+TEST(TtyTermios, TcsadrainWaitsForRetainedEchoOnly) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios t = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &t), 0) << strerror(errno);
+    t.c_iflag = 0;
+    t.c_oflag = 0;
+    t.c_lflag = ECHO | ECHOCTL;
+    ASSERT_EQ(tcsetattr(pty.slave.get(), TCSANOW, &t), 0) << strerror(errno);
+
+    int slave_flags = fcntl(pty.slave.get(), F_GETFL, 0);
+    ASSERT_GE(slave_flags, 0);
+    ASSERT_EQ(fcntl(pty.slave.get(), F_SETFL, slave_flags | O_NONBLOCK), 0);
+
+    char fill[1024];
+    memset(fill, 'x', sizeof(fill));
+    size_t accepted = 0;
+    for (;;) {
+        ssize_t n = write(pty.slave.get(), fill, sizeof(fill));
+        if (n > 0) {
+            accepted += static_cast<size_t>(n);
+            continue;
+        }
+        ASSERT_EQ(n, -1);
+        ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+        break;
+    }
+    ASSERT_GT(accepted, 0u);
+
+    const char control = 0x01;  // ECHOCTL renders this as "^A" (two bytes).
+    ASSERT_EQ(write(pty.master.get(), &control, 1), 1) << strerror(errno);
+
+    // RX delivery and echo generation run asynchronously. Observe the byte on
+    // the slave before starting tcsetattr so the test cannot pass merely
+    // because the drain raced ahead of the retained echo step.
+    char received = 0;
+    bool input_delivered = false;
+    for (int i = 0; i < 1000; ++i) {
+        ssize_t n = read(pty.slave.get(), &received, 1);
+        if (n == 1) {
+            input_delivered = true;
+            break;
+        }
+        ASSERT_EQ(n, -1);
+        ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+        usleep(1000);
+    }
+    ASSERT_TRUE(input_delivered) << "PTY input delivery timed out";
+    ASSERT_EQ(received, control);
+
+    int master_flags = fcntl(pty.master.get(), F_GETFL, 0);
+    ASSERT_GE(master_flags, 0);
+    ASSERT_EQ(fcntl(pty.master.get(), F_SETFL, master_flags | O_NONBLOCK), 0);
+
+    TcsetattrThreadArgs args;
+    args.fd = pty.slave.get();
+    args.action = TCSADRAIN;
+    args.term = t;
+    pthread_t waiter;
+    ASSERT_EQ(pthread_create(&waiter, nullptr, TcsetattrThread, &args), 0);
+    if (!WaitForFlag(args.started, 1000)) {
+        ADD_FAILURE() << "tcsetattr thread did not start";
+        pty.master.reset();
+        pthread_join(waiter, nullptr);
+        return;
+    }
+
+    // With no room for the retained two-byte echo step, the ioctl must not
+    // report completion. This catches the old bool drain / always-true wait.
+    EXPECT_FALSE(WaitForFlag(args.done, 20));
+
+    char echo_room[2];
+    for (size_t freed = 0; freed < sizeof(echo_room); ++freed) {
+        bool got_byte = false;
+        for (int i = 0; i < 1000; ++i) {
+            ssize_t n = read(pty.master.get(), &echo_room[freed], 1);
+            if (n == 1) {
+                got_byte = true;
+                break;
+            }
+            if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+                ADD_FAILURE() << "master read failed: " << strerror(errno);
+                break;
+            }
+            usleep(1000);
+        }
+        if (!got_byte) {
+            ADD_FAILURE() << "failed to free echo byte " << freed;
+            pty.master.reset();
+            pthread_join(waiter, nullptr);
+            return;
+        }
+        if (freed == 0) {
+            EXPECT_FALSE(WaitForFlag(args.done, 20));
+        }
+    }
+    EXPECT_TRUE(WaitForFlag(args.done, 1000));
+
+    if (!args.done.load(std::memory_order_acquire)) {
+        // Closing the peer guarantees a bounded cleanup path even on failure.
+        pty.master.reset();
+    }
+    ASSERT_EQ(pthread_join(waiter, nullptr), 0);
+    ASSERT_TRUE(args.done.load(std::memory_order_acquire));
+    EXPECT_EQ(args.rc, 0) << "errno=" << args.saved_errno << " ("
+                          << strerror(args.saved_errno) << ")";
+
+    // TCSADRAIN waits for the retained echo to be accepted by the PTY driver,
+    // not for the peer to consume the already accepted backlog.
+    char backlog = 0;
+    EXPECT_EQ(read(pty.master.get(), &backlog, 1), 1);
 }
 
 /* --------------------------------------------------------------------------

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -228,7 +228,12 @@ TEST(TtyTermios, TcsadrainWaitsForPtyDriverBacklog) {
     args.term = t;
     pthread_t waiter;
     ASSERT_EQ(pthread_create(&waiter, nullptr, TcsetattrThread, &args), 0);
-    ASSERT_TRUE(WaitForFlag(args.started, 1000));
+    if (!WaitForFlag(args.started, 1000)) {
+        ADD_FAILURE() << "tcsetattr thread did not start";
+        pty.master.reset();
+        pthread_join(waiter, nullptr);
+        return;
+    }
 
     EXPECT_FALSE(WaitForFlag(args.done, 20))
         << "TCSADRAIN completed with bytes still queued in the PTY driver";
@@ -253,6 +258,55 @@ TEST(TtyTermios, TcsadrainWaitsForPtyDriverBacklog) {
     ASSERT_TRUE(args.done.load(std::memory_order_acquire));
     EXPECT_EQ(args.rc, 0) << "errno=" << args.saved_errno << " ("
                           << strerror(args.saved_errno) << ")";
+}
+
+TEST(TtyTermios, PtyMasterDrainActionsSucceedAfterSlaveClose) {
+    for (int action : {TCSADRAIN, TCSAFLUSH}) {
+        auto pty = OpenRawPty();
+        ASSERT_GE(pty.master.get(), 0);
+        ASSERT_GE(pty.slave.get(), 0);
+
+        struct termios t = {};
+        ASSERT_EQ(tcgetattr(pty.master.get(), &t), 0) << strerror(errno);
+
+        int slave_flags = fcntl(pty.slave.get(), F_GETFL, 0);
+        ASSERT_GE(slave_flags, 0);
+        ASSERT_EQ(fcntl(pty.slave.get(), F_SETFL, slave_flags | O_NONBLOCK), 0);
+
+        char fill[1024];
+        memset(fill, 'z', sizeof(fill));
+        bool saturated = false;
+        for (int i = 0; i < 1024; ++i) {
+            ssize_t n = write(pty.slave.get(), fill, sizeof(fill));
+            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                saturated = true;
+                break;
+            }
+            ASSERT_GT(n, 0) << strerror(errno);
+        }
+        ASSERT_TRUE(saturated);
+        pty.slave.reset();
+
+        TcsetattrThreadArgs args;
+        args.fd = pty.master.get();
+        args.action = action;
+        args.term = t;
+        pthread_t waiter;
+        ASSERT_EQ(pthread_create(&waiter, nullptr, TcsetattrThread, &args), 0);
+        if (!WaitForFlag(args.started, 1000)) {
+            ADD_FAILURE() << "tcsetattr thread did not start";
+            pty.master.reset();
+            pthread_join(waiter, nullptr);
+            return;
+        }
+        if (!WaitForFlag(args.done, 1000)) {
+            ADD_FAILURE() << "PTY master drain action hung after slave close";
+            pty.master.reset();
+        }
+        ASSERT_EQ(pthread_join(waiter, nullptr), 0);
+        EXPECT_EQ(args.rc, 0) << "action=" << action << " errno=" << args.saved_errno
+                              << " (" << strerror(args.saved_errno) << ")";
+    }
 }
 
 /*

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -188,11 +188,10 @@ TEST(TtyTermios, TcsadrainSucceeds) {
 
 /*
  * DragonOS keeps bytes that the peer N_TTY buffer cannot yet accept in a
- * driver-owned PTY queue. TCSADRAIN must wait for that queue to empty, but it
- * need not wait for the peer application to consume bytes already delivered
- * to N_TTY.
+ * driver-owned PTY queue analogous to Linux's peer flip-buffer. TCSADRAIN must
+ * not wait for either layer of the peer input path to be consumed.
  */
-TEST(TtyTermios, TcsadrainWaitsForPtyDriverBacklog) {
+TEST(TtyTermios, TcsadrainDoesNotWaitForPtyInputBacklog) {
     auto pty = OpenRawPty();
     ASSERT_GE(pty.slave.get(), 0);
 
@@ -218,10 +217,6 @@ TEST(TtyTermios, TcsadrainWaitsForPtyDriverBacklog) {
     }
     ASSERT_GT(accepted, 0u);
 
-    int master_flags = fcntl(pty.master.get(), F_GETFL, 0);
-    ASSERT_GE(master_flags, 0);
-    ASSERT_EQ(fcntl(pty.master.get(), F_SETFL, master_flags | O_NONBLOCK), 0);
-
     TcsetattrThreadArgs args;
     args.fd = pty.slave.get();
     args.action = TCSADRAIN;
@@ -235,29 +230,44 @@ TEST(TtyTermios, TcsadrainWaitsForPtyDriverBacklog) {
         return;
     }
 
-    EXPECT_FALSE(WaitForFlag(args.done, 20))
-        << "TCSADRAIN completed with bytes still queued in the PTY driver";
-
-    char drain[1024];
-    for (int i = 0; i < 2000 && !args.done.load(std::memory_order_acquire); ++i) {
-        ssize_t n = read(pty.master.get(), drain, sizeof(drain));
-        if (n < 0) {
-            if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                usleep(1000);
-            } else {
-                ADD_FAILURE() << "master read failed: " << strerror(errno);
-                break;
-            }
-        }
-    }
-
-    if (!args.done.load(std::memory_order_acquire)) {
+    if (!WaitForFlag(args.done, 1000)) {
+        ADD_FAILURE() << "TCSADRAIN waited for unread PTY input";
         pty.master.reset();
     }
     ASSERT_EQ(pthread_join(waiter, nullptr), 0);
     ASSERT_TRUE(args.done.load(std::memory_order_acquire));
     EXPECT_EQ(args.rc, 0) << "errno=" << args.saved_errno << " ("
                           << strerror(args.saved_errno) << ")";
+}
+
+TEST(TtyTermios, HungUpSlaveModeIoctlsReturnLinuxErrors) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.master.get(), 0);
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios term = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &term), 0) << strerror(errno);
+    TermioCompat legacy = {};
+    ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &legacy), 0) << strerror(errno);
+
+    pty.master.reset();
+
+    errno = 0;
+    EXPECT_EQ(tcgetattr(pty.slave.get(), &term), -1);
+    EXPECT_EQ(errno, EIO);
+
+    errno = 0;
+    EXPECT_EQ(ioctl(pty.slave.get(), TCGETA, &legacy), -1);
+    EXPECT_EQ(errno, EIO);
+
+    errno = 0;
+    EXPECT_EQ(ioctl(pty.slave.get(), TCSETA, &legacy), -1);
+    EXPECT_EQ(errno, EIO);
+
+    pid_t pgrp = getpgrp();
+    errno = 0;
+    EXPECT_EQ(ioctl(pty.slave.get(), TIOCSPGRP, &pgrp), -1);
+    EXPECT_EQ(errno, ENOTTY);
 }
 
 TEST(TtyTermios, PtyMasterDrainActionsSucceedAfterSlaveClose) {
@@ -329,21 +339,24 @@ TEST(TtyTermios, TcsadrainWaitsForRetainedEchoOnly) {
     ASSERT_GE(slave_flags, 0);
     ASSERT_EQ(fcntl(pty.slave.get(), F_SETFL, slave_flags | O_NONBLOCK), 0);
 
-    // Fill only the peer N_TTY buffer. Writing until EAGAIN would also fill
-    // the driver-owned PtyByteQueue and turn this into a duplicate of the
-    // dedicated PTY backlog test above.
-    char fill[4095];
+    // Fill both the peer N_TTY buffer and the PTY bridge so the two-byte
+    // ECHOCTL rendering remains owned by this line discipline. The bridge
+    // backlog itself must not keep TCSADRAIN waiting after that echo is
+    // submitted.
+    char fill[1024];
     memset(fill, 'x', sizeof(fill));
     size_t accepted = 0;
-    while (accepted < sizeof(fill)) {
-        ssize_t n = write(pty.slave.get(), &fill[accepted], sizeof(fill) - accepted);
+    for (;;) {
+        ssize_t n = write(pty.slave.get(), fill, sizeof(fill));
         if (n > 0) {
             accepted += static_cast<size_t>(n);
             continue;
         }
-        ASSERT_GT(n, 0) << strerror(errno);
+        ASSERT_EQ(n, -1);
+        ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+        break;
     }
-    ASSERT_EQ(accepted, sizeof(fill));
+    ASSERT_GT(accepted, 0u);
 
     const char control = 0x01;  // ECHOCTL renders this as "^A" (two bytes).
     ASSERT_EQ(write(pty.master.get(), &control, 1), 1) << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -1,0 +1,266 @@
+// tty_termios.cc — verify TCSAFLUSH / TCSADRAIN and legacy termio ioctls
+// on a valid TTY fd (PTY slave).
+//
+// Regression coverage for: "tcsetattr(0, TCSAFLUSH, &t) fails with ENOTTY"
+// and TCSETA/TCSETAW/TCSETAF/TCGETA returning ENOIOCTLCMD.
+
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pty.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+
+namespace {
+
+/* Legacy SVR4 struct termio — not exposed by glibc's <termios.h>. */
+constexpr int kNcc = 8;
+struct TermioCompat {
+    unsigned short c_iflag;
+    unsigned short c_oflag;
+    unsigned short c_cflag;
+    unsigned short c_lflag;
+    unsigned char c_line;
+    unsigned char c_cc[kNcc];
+};
+
+#ifndef TCGETA
+#define TCGETA 0x5405
+#endif
+#ifndef TCSETA
+#define TCSETA 0x5406
+#endif
+#ifndef TCSETAW
+#define TCSETAW 0x5407
+#endif
+#ifndef TCSETAF
+#define TCSETAF 0x5408
+#endif
+
+class UniqueFd {
+public:
+    UniqueFd() = default;
+    explicit UniqueFd(int fd) : fd_(fd) {}
+    UniqueFd(const UniqueFd&) = delete;
+    UniqueFd& operator=(const UniqueFd&) = delete;
+
+    UniqueFd(UniqueFd&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+
+    UniqueFd& operator=(UniqueFd&& other) noexcept {
+        if (this != &other) {
+            reset();
+            fd_ = other.fd_;
+            other.fd_ = -1;
+        }
+        return *this;
+    }
+
+    ~UniqueFd() { reset(); }
+
+    int get() const { return fd_; }
+
+    void reset(int fd = -1) {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        fd_ = fd;
+    }
+
+private:
+    int fd_ = -1;
+};
+
+struct PtyPair {
+    UniqueFd master;
+    UniqueFd slave;
+};
+
+PtyPair OpenRawPty() {
+    int master = -1;
+    int slave = -1;
+    if (openpty(&master, &slave, nullptr, nullptr, nullptr) < 0) {
+        ADD_FAILURE() << "openpty failed: errno=" << errno << " (" << strerror(errno) << ")";
+        return {};
+    }
+
+    PtyPair pair{UniqueFd(master), UniqueFd(slave)};
+
+    struct termios term = {};
+    if (tcgetattr(pair.slave.get(), &term) < 0) {
+        ADD_FAILURE() << "tcgetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
+        return pair;
+    }
+
+    term.c_iflag = 0;
+    term.c_oflag = 0;
+    term.c_lflag = 0;
+    term.c_cflag |= CS8;
+    term.c_cc[VMIN] = 1;
+    term.c_cc[VTIME] = 0;
+
+    if (tcsetattr(pair.slave.get(), TCSANOW, &term) < 0) {
+        ADD_FAILURE() << "tcsetattr failed: errno=" << errno << " (" << strerror(errno) << ")";
+    }
+
+    return pair;
+}
+
+/* --------------------------------------------------------------------------
+ * tcgetattr + tcsetattr(TCSANOW) round-trip
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, TcSanowRoundTrip) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios t = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &t), 0) << strerror(errno);
+
+    tcflag_t orig = t.c_lflag;
+    t.c_lflag &= ~(ICANON | ECHO);
+    ASSERT_EQ(tcsetattr(pty.slave.get(), TCSANOW, &t), 0) << strerror(errno);
+
+    struct termios back = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &back), 0) << strerror(errno);
+    EXPECT_EQ(back.c_lflag & (ICANON | ECHO), 0u)
+        << "TCSANOW settings should survive";
+    t.c_lflag = orig;
+}
+
+/* --------------------------------------------------------------------------
+ * tcsetattr TCSADRAIN — must not fail with ENOTTY
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, TcsadrainSucceeds) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios t = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &t), 0) << strerror(errno);
+    EXPECT_EQ(tcsetattr(pty.slave.get(), TCSADRAIN, &t), 0) << strerror(errno);
+}
+
+/* --------------------------------------------------------------------------
+ * tcsetattr TCSAFLUSH — the dpkg/apt regression
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, TcsaflushSucceeds) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios t = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &t), 0) << strerror(errno);
+    t.c_lflag &= ~(ICANON | ECHO);
+    ASSERT_EQ(tcsetattr(pty.slave.get(), TCSAFLUSH, &t), 0) << strerror(errno);
+
+    struct termios back = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &back), 0) << strerror(errno);
+    EXPECT_EQ(back.c_lflag & (ICANON | ECHO), 0u)
+        << "TCSAFLUSH settings should survive";
+}
+
+/* --------------------------------------------------------------------------
+ * Legacy termio TCGETA — must not return ENOTTY
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, LegacyTcgeta) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    TermioCompat tio = {};
+    errno = 0;
+    ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &tio), 0)
+        << "TCGETA should succeed: errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_NE(errno, ENOTTY) << "TCGETA must not return ENOTTY";
+}
+
+/* --------------------------------------------------------------------------
+ * Legacy termio TCSETA / TCSETAW / TCSETAF
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, LegacyTcsetaFamily) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    TermioCompat tio = {};
+    errno = 0;
+    EXPECT_EQ(ioctl(pty.slave.get(), TCSETA, &tio), 0)
+        << "TCSETA: errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_NE(errno, ENOTTY);
+
+    errno = 0;
+    EXPECT_EQ(ioctl(pty.slave.get(), TCSETAW, &tio), 0)
+        << "TCSETAW: errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_NE(errno, ENOTTY);
+
+    errno = 0;
+    EXPECT_EQ(ioctl(pty.slave.get(), TCSETAF, &tio), 0)
+        << "TCSETAF: errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_NE(errno, ENOTTY);
+}
+
+/* --------------------------------------------------------------------------
+ * Cross-check: TCGETA low 16 bits match TCGETS
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, TermioLow16Bits) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios full = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &full), 0);
+
+    TermioCompat tio = {};
+    ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &tio), 0);
+
+    EXPECT_EQ(full.c_lflag & 0xffff, tio.c_lflag)
+        << "termio c_lflag should be low 16 bits of termios c_lflag";
+    EXPECT_EQ(full.c_iflag & 0xffff, tio.c_iflag)
+        << "termio c_iflag should be low 16 bits of termios c_iflag";
+}
+
+/* --------------------------------------------------------------------------
+ * Merge semantics: high 16 bits of c_cflag survive a TCSETA call
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, TermioMergeHighBits) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    struct termios full = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &full), 0);
+    tcflag_t orig_cflag = full.c_cflag;
+
+    TermioCompat tio = {};
+    ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &tio), 0);
+    tio.c_lflag &= ~static_cast<unsigned short>(ECHO); /* flip a low-16-bit flag */
+
+    ASSERT_EQ(ioctl(pty.slave.get(), TCSETA, &tio), 0)
+        << "TCSETA merge apply: errno=" << errno << " (" << strerror(errno) << ")";
+
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &full), 0);
+    EXPECT_EQ(full.c_cflag & 0xffff0000u, orig_cflag & 0xffff0000u)
+        << "TCSETA should preserve high 16 bits of c_cflag";
+    EXPECT_EQ(full.c_lflag & ECHO, 0u)
+        << "TCSETA should apply low-16-bit change";
+}
+
+/* --------------------------------------------------------------------------
+ * tcsetattr on non-TTY fd must fail (any error, not crash)
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, NonTtyFails) {
+    struct termios t = {};
+    int fd = open("/dev/null", O_RDWR);
+    if (fd < 0) {
+        GTEST_SKIP() << "cannot open /dev/null: " << strerror(errno);
+        return;
+    }
+    errno = 0;
+    int rc = tcsetattr(fd, TCSANOW, &t);
+    close(fd);
+    EXPECT_EQ(rc, -1) << "tcsetattr on non-TTY fd should fail";
+    EXPECT_NE(errno, 0) << "tcsetattr on non-TTY fd should set errno";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -25,6 +25,7 @@ struct TermioCompat {
     unsigned short c_lflag;
     unsigned char c_line;
     unsigned char c_cc[kNcc];
+    unsigned char _pad = 0;  /* match kernel PosixTermio layout */
 };
 
 #ifndef TCGETA
@@ -126,7 +127,6 @@ TEST(TtyTermios, TcSanowRoundTrip) {
     ASSERT_EQ(tcgetattr(pty.slave.get(), &back), 0) << strerror(errno);
     EXPECT_EQ(back.c_lflag & (ICANON | ECHO), 0u)
         << "TCSANOW settings should survive";
-    t.c_lflag = orig;
 }
 
 /* --------------------------------------------------------------------------
@@ -215,6 +215,24 @@ TEST(TtyTermios, TermioLow16Bits) {
 }
 
 /* --------------------------------------------------------------------------
+ * c_line round-trip: non-zero c_line survives TCSETA → TCGETA
+ * -------------------------------------------------------------------------- */
+TEST(TtyTermios, CLinelRoundtrip) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.slave.get(), 0);
+
+    TermioCompat tio = {};
+    tio.c_line = 42;
+    ASSERT_EQ(ioctl(pty.slave.get(), TCSETA, &tio), 0)
+        << "TCSETA with c_line=42";
+
+    TermioCompat tio2 = {};
+    ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &tio2), 0);
+    EXPECT_EQ(tio2.c_line, 42u)
+        << "c_line should survive termio round-trip";
+}
+
+/* --------------------------------------------------------------------------
  * Merge semantics: high 16 bits of c_cflag survive a TCSETA call
  * -------------------------------------------------------------------------- */
 TEST(TtyTermios, TermioMergeHighBits) {
@@ -227,6 +245,11 @@ TEST(TtyTermios, TermioMergeHighBits) {
 
     TermioCompat tio = {};
     ASSERT_EQ(ioctl(pty.slave.get(), TCGETA, &tio), 0);
+    /* Set a flag bit we know is currently clear so the subsequent
+     * clear of that bit is a real operation, not a no-op. */
+    tio.c_lflag |= ECHO;
+    ASSERT_EQ(ioctl(pty.slave.get(), TCSETA, &tio), 0)
+        << "TCSETA set ECHO before merge check";
     tio.c_lflag &= ~static_cast<unsigned short>(ECHO); /* flip a low-16-bit flag */
 
     ASSERT_EQ(ioctl(pty.slave.get(), TCSETA, &tio), 0)
@@ -251,9 +274,10 @@ TEST(TtyTermios, NonTtyFails) {
     }
     errno = 0;
     int rc = tcsetattr(fd, TCSANOW, &t);
+    int saved_errno = errno;
     close(fd);
     EXPECT_EQ(rc, -1) << "tcsetattr on non-TTY fd should fail";
-    EXPECT_NE(errno, 0) << "tcsetattr on non-TTY fd should set errno";
+    EXPECT_NE(saved_errno, 0) << "tcsetattr on non-TTY fd should set errno";
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -493,7 +493,7 @@ TEST(TtyTermios, Serial8250AppliesModernAndLegacySettings) {
 }
 
 /* --------------------------------------------------------------------------
- * tcsetattr on non-TTY fd must fail (any error, not crash)
+ * tcsetattr on a non-TTY fd must fail with Linux's ENOTTY.
  * -------------------------------------------------------------------------- */
 TEST(TtyTermios, NonTtyFails) {
     struct termios t = {};
@@ -507,7 +507,8 @@ TEST(TtyTermios, NonTtyFails) {
     int saved_errno = errno;
     close(fd);
     EXPECT_EQ(rc, -1) << "tcsetattr on non-TTY fd should fail";
-    EXPECT_NE(saved_errno, 0) << "tcsetattr on non-TTY fd should set errno";
+    EXPECT_EQ(saved_errno, ENOTTY)
+        << "tcsetattr on non-TTY fd should report ENOTTY";
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -82,3 +82,4 @@ normal/virtiofs_dax
 normal/af_packet_sockopt
 normal/af_packet_e2e
 normal/af_packet_mcast
+normal/tty_termios


### PR DESCRIPTION
## Summary

Complete the Linux-compatible TTY termios ioctl path and harden the surrounding TTY, PTY, serial8250, hangup, and asynchronous-notification lifecycles uncovered during review.

The original user-visible failure was `tcsetattr(..., TCSAFLUSH, ...)` returning `ENOTTY`, which caused package configuration tools such as `debconf` to fail:

```text
E: Setting in Start via TCSAFLUSH for stdin failed! - tcsetattr (25: Inappropriate ioctl for device)
```

This PR now provides the missing ioctl support and the drain, flush, synchronization, hardware-transmit, hangup, and wakeup semantics required for those operations to behave correctly under concurrency.

## User-visible behavior

- Implement `TCGETA`, `TCSETA`, `TCSETAW`, and `TCSETAF` using the legacy SVR4 `struct termio` ABI.
- Implement the wait semantics used by `TCSETSW`/`TCSETAW` (`TCSADRAIN`).
- Implement output drain followed by input flush for `TCSETSF`/`TCSETAF` (`TCSAFLUSH`).
- Return Linux-compatible errors for unsupported ioctls and hung-up file descriptions.
- Preserve the raw `c_line` ABI byte across termios/termio round trips without panicking on unsupported values.
- Apply serial baud rate, character size, parity, and stop-bit changes to the 8250 hardware.
- Make serial `tcdrain`, close-time drain, output flush, blocking writes, poll, and epoll observe the actual software queue and transmitter state.

## Implementation details

### Termios and legacy termio

- Add an ABI-sized `PosixTermio` representation with `NCC = 8`.
- Merge legacy 16-bit flag fields into the current kernel termios state, preserving the upper flag bits and untouched control characters as Linux does.
- Add explicit padding and initialize it on copy-out to avoid exposing kernel stack data through `TCGETA`.
- Decode both output and `CIBAUD` input speeds, including the extended baud-rate values.
- Run the Linux-style job-control check before changing terminal attributes.
- Serialize writes, drain rechecks, input flushing, and the final termios transaction without holding the termios write semaphore across long hardware waits.

### N_TTY drain and flush semantics

- Track retained OPOST and echo output that has not yet been accepted by the driver.
- Drain retained line-discipline output before checking the driver queue or physical transmitter.
- Use interruptible, event-driven write-room waits instead of unbounded polling.
- Recheck all drain predicates after wakeup and handle signals, hangup, peer teardown, and partial driver acceptance.
- Keep `TCSAFLUSH` input-only: pending output is drained, while unread input is discarded at the Linux-compatible point in the transaction.

### PTY behavior

- Add bounded, directional PTY staging queues with correct write-room and wakeup behavior.
- Defer peer delivery through a workqueue when taking the peer termios lock synchronously would create a cross-endpoint ABBA dependency.
- Preserve Linux PTY drain semantics: data already accepted into the peer-input staging layer is not reported as source-side `TIOCOUTQ` output, while N_TTY output not yet accepted by the driver is still drained.
- Correct PTY poll, packet-mode flush notification, input unthrottling, close, hangup, and peer-teardown behavior.
- Preserve per-open file-description hangup semantics across close and reopen races.

### serial8250 transmit and console path

- Replace direct multi-byte PIO writes with a bounded software TX queue driven by THRE interrupts.
- Detect the UART FIFO size and report real `write_room()` and `chars_in_buffer()` values.
- Implement physical-transmitter waits with an interruptible deadline shared by `tcdrain` and close.
- Route legacy x86 ports correctly: COM1/COM3 use IRQ4 and COM2/COM4 use IRQ3.
- Register only usable interrupt routes, filter shared IRQs by the asserted line and IIR state, bound IRQ rescans, and preserve `NotHandled` semantics.
- Serialize DLAB register programming against runtime RX/TX access.
- Coordinate runtime TTY output with console and emergency output without losing queued bytes, deadlocking in exception context, or waiting forever on broken hardware.
- Reset TX state on final close and notify both blocking writers and epoll waiters when output flush restores write readiness.

### Hangup and fasync lifecycle

- Track TTY hangup generations per open file description so pre-hangup descriptors retain Linux `hung_up_tty_fops` behavior independently of later reopens.
- Track TTY fasync registrations per open file description and remove them atomically when hangup starts.
- Serialize `F_SETFL` flag merging with fasync lifecycle updates so concurrent status-flag changes cannot restore stale `FASYNC` state.
- Unregister TTY, pipe, and socket fasync entries during final file release.
- Return `ENOTTY` for unsupported ioctl dispatch instead of leaking the internal `ENOIOCTLCMD` sentinel to userspace.

## Linux compatibility

The implementation was reviewed against Linux 6.6 behavior, including:

- `drivers/tty/tty_ioctl.c` for termios/termio conversion, job control, drain ordering, and input flush semantics;
- `drivers/tty/n_tty.c` for retained output and write-wakeup behavior;
- `drivers/tty/pty.c` for PTY write-room, drain, unthrottle, and hangup boundaries;
- `drivers/tty/serial/serial_core.c` and the 8250 driver for queued TX, `wait_until_sent`, flush wakeups, shutdown, and legacy IRQ routing;
- TTY/VFS hangup and fasync lifecycle behavior for per-file-description state.

## Validation

Completed locally:

- `make fmt` and kernel clippy checks;
- `make kernel`;
- QEMU dunitest suites:
  - `tty_termios`: 14/14 passed;
  - `tty_tcflush`: 6/6 passed;
  - `tty_pty_hangup`: 35/35 passed;
  - `fcntl_signal`: 7/7 passed;
- legacy `test_tty_termios.c` static build;
- independent COM2/IRQ3 transmission test: `/dev/ttyS1` transmitted 4096 bytes and the host received the complete payload without relying on COM1/IRQ4 traffic.

The latest full Dunitest run reached an unrelated intermittent FAT page-cache writeback panic in code not changed by this PR. The FAT concurrency issue and CI evidence are tracked separately in #2158.

## Change scope

- 24 files changed
- 3,006 insertions and 232 deletions
- Kernel TTY/PTY/serial/VFS lifecycle changes plus focused C and dunitest regression coverage