### PR TITLE
feat(net): implement AF_PACKET fanout

### DIFF
--- a/docs/kernel/net/af_packet_fanout_plan.md
+++ b/docs/kernel/net/af_packet_fanout_plan.md
@@ -1,0 +1,431 @@
+# AF_PACKET PACKET_FANOUT 实施方案
+
+> Issue #2032：为 AF_PACKET 实现 `PACKET_FANOUT`，支持多 socket 间分发数据包做负载均衡。
+> 参考：Linux 6.6 `net/packet/af_packet.c`、`include/uapi/linux/if_packet.h`、`packet(7)`。
+
+## 1. 背景与目标
+
+AF_PACKET 当前只有广播模式：`NetNamespace::deliver_to_packet_sockets()` 把每个入站帧的副本投递给**所有**已注册的 packet socket。多个 socket 绑定同一网卡时各自收到完整副本，无法并行分担负载。
+
+`PACKET_FANOUT`（option 18）让一组 socket 形成 fanout group：每个匹配帧只投递给组内**一个** socket，由分发算法决定选谁。
+
+**目标**：实现符合 Linux 6.6 语义的 `PACKET_FANOUT`，覆盖主流分发算法，不破坏现有广播语义。
+
+---
+
+## 2. Linux PACKET_FANOUT 语义（权威参考）
+
+### 2.1 option value 编码
+
+`setsockopt(fd, SOL_PACKET, PACKET_FANOUT, &val, sizeof(int))`，`val` 为 32 位 int：
+
+| 位段 | 含义 |
+|------|------|
+| 低 16 位 `val & 0xffff` | **group id**（u16，0 表示请求内核自动分配，需配合 `FLAG_UNIQUEID`） |
+| 高 16 位 `val >> 16` | **type_flags**：低 7 位是 mode，其余是 flags |
+
+mode = `type_flags & 0x7f`；flags = `type_flags & ~0x7f`。
+
+### 2.2 mode 常量（`type_flags & 0x7f`）
+
+| 常量 | 值 | 算法 |
+|------|----|------|
+| `PACKET_FANOUT_HASH` | 0 | flow hash（src/dst IP + ports 的 jhash）取模成员数 |
+| `PACKET_FANOUT_LB` | 1 | round-robin（原子计数器取模） |
+| `PACKET_FANOUT_CPU` | 2 | 收包 CPU id 取模成员数 |
+| `PACKET_FANOUT_ROLLOVER` | 3 | 固定从起始 socket，满了滚到下一个 |
+| `PACKET_FANOUT_RND` | 4 | 随机选取 |
+| `PACKET_FANOUT_QM` | 5 | 按 NIC RSS queue_mapping |
+| `PACKET_FANOUT_CBPF` | 6 | classic BPF 程序选择 |
+| `PACKET_FANOUT_EBPF` | 7 | eBPF 程序选择 |
+
+### 2.3 flag 常量（`type_flags & ~0x7f`）
+
+| 常量 | 值 | 含义 |
+|------|----|------|
+| `PACKET_FANOUT_FLAG_ROLLOVER` | 0x1000 | 其他 mode 的 backup：选中的 socket backlog 则滚到下一个 |
+| `PACKET_FANOUT_FLAG_UNIQUEID` | 0x2000 | 请求内核分配唯一 id（忽略 value 中的 id 字段） |
+| `PACKET_FANOUT_FLAG_IGNORE_OUTGOING` | 0x4000 | 忽略本机发送的包 |
+| `PACKET_FANOUT_FLAG_DEFRAG` | 0x8000 | 分片重组后再 fanout |
+
+### 2.4 group 生命周期与校验
+
+- 第一个 socket join 时**隐式创建** group（记录其 protocol、device、mode、flags）。
+- 后续 socket join **必须匹配**：相同 protocol、device(ifindex)、socket type、mode、flags，否则 `EINVAL`。
+- socket **只能**通过 close 离开 group（无显式 leave）。
+- 最后一个 socket close 时**删除** group。
+- 已在 group 中的 socket 再次 set `PACKET_FANOUT` → `EBUSY`。
+- `getsockopt(PACKET_FANOUT)` 返回当前 group 的 `(id | (type_flags << 16))`。
+
+### 2.5 分发机制（Linux）
+
+Linux 给每个 fanout group 注册一个**独立的** `packet_type` hook（`dev_add_pack`），hook 函数是 `packet_rcv_fanout`。收包时该 hook 调 `fanout_demux_*` 选一个 socket 投递。普通 socket 各有独立 hook，互不影响。
+
+---
+
+## 3. DragonOS 现有代码分析
+
+### 3.1 PacketSocket 结构（`kernel/src/net/socket/packet/mod.rs:72-94`）
+
+16 字段，关键：
+- `binding: PacketBinding`：lock-free `(ifindex, protocol)` 快照（AtomicU64）
+- `bound_iface: RwSem<Option<Arc<dyn Iface>>>`
+- `rx_buffer: Mutex<VecDeque<ReceivedPacket>>` + `rx_buffer_bytes: AtomicUsize` / `recv_buffer_bytes: AtomicUsize`
+- `self_ref: Weak<Self>`、`netns: Arc<NetNamespace>`
+- `sock_type: PacketSocketType`（Raw/Dgram）
+
+### 3.2 注册表（`net_namespace.rs:82-86, 108-111`）
+
+```rust
+packet_sockets: RcuArcSlot<PacketSocketRegistrySnapshot>,  // RCU 无锁读
+packet_sockets_writer: Mutex<()>,                           // COW 写串行化
+packet_sockets_need_cleanup: AtomicBool,
+
+struct PacketSocketRegistrySnapshot { sockets: Vec<Weak<PacketSocket>> }
+```
+
+`RcuArcSlot` API：`new(Arc)` / `load() -> Arc` / `store_deferred(Arc)`。
+
+### 3.3 分发路径
+
+```
+deliver_to_packet_sockets(iface, frame, pkt_type)   // mod.rs:174 — 公共入口
+  → netns.deliver_to_packet_sockets(ifindex, frame, pkt_type)   // net_namespace.rs:443
+      load snapshot → for each socket: socket.deliver(ifindex, frame, pkt_type)
+          → deliver_from_iface(ifindex, frame, pkt_type)   // rx.rs:53
+              binding 过滤(ifindex/protocol) → 缓冲区检查 → 拷贝帧入 rx_buffer
+```
+
+deliver 在 **NAPI poll（进程上下文）**执行，可持 Mutex/RwSem，但应避免无界遍历/分配。
+
+### 3.4 选项处理（`sockopt.rs`）
+
+`set_packet_option(PSOL::PACKET, name, val)`：当前 `PSOL::PACKET` 分支未知 name 默认 `Ok(())`（静默接受）。`PACKET_FANOUT`(18) 需新增显式分支。
+
+### 3.5 关闭路径
+
+`do_close()`（mod.rs:253）→ `close_binding()`（binding.rs:79）→ `unregister_packet_socket`。fanout 离开挂在此路径。
+
+### 3.6 可用基础设施
+
+| 需求 | DragonOS 设施 |
+|------|---------------|
+| RCU COW 表 | `RcuArcSlot<T>`（`rcu/mod.rs`） |
+| flow hash | `jhash::jhash2(&[u32], 0)`（UDP 已用，`udp_bindings.rs:212`） |
+| RNG | `crate::libs::rand::rand()` / `soft_rand()` |
+| CPU id | `crate::arch::current_cpu_id().data()`（三架构实现） |
+| id 分配 | `IdAllocator`（`kernel/crates/ida`，`&mut self`，需外部锁） |
+
+---
+
+## 4. 架构设计
+
+### 4.1 设计原则
+
+1. **不破坏广播语义**：普通（非 fanout）socket 行为零变化。
+2. **复用 RcuArcSlot**：fanout group 表用 RCU COW，与 `packet_sockets` 同构，deliver 路径保持无锁读。
+3. **复用 deliver_from_iface**：group 选出 socket 后调用现有 `deliver_from_iface`，binding 过滤逻辑不重复。
+4. **成员一致性校验**：join 时强制 (sock_type, ifindex, protocol) 一致，保证 demux 选任何成员过滤结果相同。
+
+### 4.2 deliver 路径改造（核心）
+
+```
+netns.deliver_to_packet_sockets(ifindex, frame, pkt_type):
+    socket_snapshot = packet_sockets.load()
+    group_snapshot  = fanout_groups.load()        // 新增，RCU 读
+    for weak in socket_snapshot.sockets:
+        if let Some(socket) = weak.upgrade():
+            if socket.fanout.read().is_some():    // fanout socket 跳过广播
+                continue
+            socket.deliver(ifindex, frame, pkt_type)
+        else: stale = true
+    for group in group_snapshot.groups:
+        group.deliver(ifindex, frame, pkt_type)   // 每个 group 投递一份
+```
+
+`group.deliver()` 内部：load 成员 → demux 选 index → `members[idx].upgrade()` → `socket.deliver()`。成员 upgrade 失败（stale）时跳过并标记清理。
+
+**为什么 fanout socket 从广播跳过**：贴合 Linux「group 有独立 hook」语义——一个 group 只收一份。从广播路径剔除后由独立 group 遍历统一分发，避免 per-call 去重状态。
+
+### 4.3 新增数据结构
+
+文件：`kernel/src/net/socket/packet/fanout.rs`（新模块）
+
+```rust
+/// 分发算法
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FanoutMode {
+    Hash,      // 0
+    Lb,        // 1 — round-robin
+    Cpu,       // 2
+    Rollover,  // 3
+    Rnd,       // 4
+}
+
+impl FanoutMode {
+    /// 从 type_flags 低 7 位解析，不支持 QM/CBPF/EBPF
+    pub fn from_raw(raw: u32) -> Result<Self, SystemError> { ... }
+    pub fn as_raw(self) -> u32 { ... }
+}
+
+/// fanout group
+pub struct FanoutGroup {
+    pub id: u16,
+    pub mode: FanoutMode,
+    pub flags: u16,                              // PACKET_FANOUT_FLAG_* 原始值
+    /// HASH 模式 flow hash 随机种子（创建时生成，避免 flow polarization）
+    hash_seed: u32,
+    /// 成员列表，RCU COW（与 packet_sockets 同构）
+    members: RcuArcSlot<FanoutMemberSnapshot>,
+    members_writer: Mutex<()>,
+    /// LB / ROLLOVER 模式 round-robin 计数器
+    rr_counter: AtomicU32,
+}
+
+#[derive(Default)]
+struct FanoutMemberSnapshot {
+    members: Vec<Weak<PacketSocket>>,
+}
+```
+
+### 4.4 netns 字段新增（`net_namespace.rs`）
+
+```rust
+/// fanout group 表，RCU 无锁读（deliver 路径）
+fanout_groups: RcuArcSlot<FanoutGroupRegistry>,
+/// COW 写串行化 + 保护 id 分配器
+fanout_groups_writer: Mutex<FanoutGroupWriter>,
+fanout_groups_need_cleanup: AtomicBool,
+
+#[derive(Default)]
+struct FanoutGroupRegistry {
+    groups: Vec<Arc<FanoutGroup>>,   // 读路径顺序扫描，成员少
+}
+
+struct FanoutGroupWriter {
+    /// group id → Arc<FanoutGroup> 的权威索引（写路径）
+    by_id: BTreeMap<u16, Arc<FanoutGroup>>,
+    /// UNIQUEID 自动分配器
+    id_alloc: IdAllocator,
+}
+```
+
+> 写路径重建 `FanoutGroupRegistry`（Vec）并 `store_deferred`，与 `packet_sockets` 完全同构。`by_id` 仅写路径持有，保证 id 唯一与 O(log n) 查找。
+
+### 4.5 PacketSocket 字段新增（`mod.rs`）
+
+```rust
+/// fanout group 成员关系，None=普通广播 socket
+pub(super) fanout: RwSem<Option<Arc<FanoutGroup>>>,
+```
+
+`new()` 初始化为 `RwSem::new(None)`。
+
+### 4.6 uapi 常量（`packet/uapi.rs`）
+
+```rust
+pub mod packet_option {
+    // ... 已有 ...
+    pub const PACKET_FANOUT: usize = 18;
+    pub const PACKET_FANOUT_DATA: usize = 22;
+}
+
+pub mod fanout_mode {
+    pub const PACKET_FANOUT_HASH: u32 = 0;
+    pub const PACKET_FANOUT_LB: u32 = 1;
+    pub const PACKET_FANOUT_CPU: u32 = 2;
+    pub const PACKET_FANOUT_ROLLOVER: u32 = 3;
+    pub const PACKET_FANOUT_RND: u32 = 4;
+    pub const PACKET_FANOUT_QM: u32 = 5;     // 不支持
+    pub const PACKET_FANOUT_CBPF: u32 = 6;   // 不支持
+    pub const PACKET_FANOUT_EBPF: u32 = 7;   // 不支持
+}
+
+pub mod fanout_flag {
+    pub const PACKET_FANOUT_FLAG_ROLLOVER: u16 = 0x1000;
+    pub const PACKET_FANOUT_FLAG_UNIQUEID: u16 = 0x2000;
+    pub const PACKET_FANOUT_FLAG_IGNORE_OUTGOING: u16 = 0x4000;  // 不支持
+    pub const PACKET_FANOUT_FLAG_DEFRAG: u16 = 0x8000;           // 不支持
+}
+```
+
+---
+
+## 5. 关键流程
+
+### 5.1 set_option(PACKET_FANOUT) — `fanout.rs:join_fanout`
+
+```
+1. 解析 val(i32): id = (val as u32) & 0xffff; type_flags = (val as u32) >> 16
+   mode = type_flags & 0x7f; flags = (type_flags & !0x7f) as u16
+2. mode = FanoutMode::from_raw(mode)?     // QM/CBPF/EBPF → EINVAL
+3. flags 校验：仅允许 ROLLOVER(0x1000) | UNIQUEID(0x2000)；其余 → EINVAL
+4. 若 self.fanout.read().is_some() → EBUSY   // 已在 group
+5. 取 netns fanout_groups_writer 锁（与 leave 互斥）：
+   a. 确定 group id：UNIQUEID → id_alloc.alloc()（满 → ENOMEM）
+                    否则用 val 中的 id（若已被占用且参数不匹配 → EINVAL）
+   b. 查 by_id[id]：
+      - 存在 → 校验 mode/flags/(sock_type,ifindex,protocol) 一致，不一致 → EINVAL
+      - 不存在 → 创建 FanoutGroup（生成随机 hash_seed），加入 by_id
+   c. group.add_member(socket.self_ref)   // 先加成员（RCU publish 新快照）
+   d. socket.fanout.write() = Some(Arc::clone(group))  // 后设字段
+   e. 重建 registry store_deferred
+6. 返回 Ok(())
+
+> **join 操作顺序**：先 add_member（RCU publish）再设 fanout 字段，使二者在 writer 锁内完成。deliver 读 group 快照与 fanout 字段之间的瞬态窗口最多丢一个 join 期帧（与 Linux hook 切换瞬态等价，可接受）。
+```
+
+**一致性校验项**：`self.sock_type`、`self.binding.load()` 的 `(ifindex, protocol)` 必须与 group 创建者相同。保证 demux 选任何成员，`deliver_from_iface` 过滤结果一致。
+
+### 5.2 close 路径 — `fanout.rs:leave_fanout`
+
+在 `close_binding()`（binding.rs）中，`unregister_packet_socket` 之后调用 `self.leave_fanout()`：
+
+```
+1. group = self.fanout.write().take()?  // 取出，None 则返回
+2. 取 netns fanout_groups_writer 锁（与 join 互斥，消除 TOCTOU）：
+   a. group.remove_member(&self.self_ref)     // RCU COW 移除
+   b. 在 writer 锁内 load group 成员数（join 无法插入）；
+      为空 → by_id.remove(group.id) → id_alloc.free(id)
+   c. 重建 registry store_deferred
+```
+
+> **TOCTOU 修复**：「检查成员为空」与「从 by_id 删除」必须同在 writer 锁内原子完成。否则并发 join 可在空窗内注入成员，导致其 socket 指向已删除的 group（zombie，永不为 deliver 所见）。
+
+### 5.3 group.deliver — 分发
+
+```
+1. members = self.members.load()
+2. live = 成员列表过滤 upgrade 成功的（惰性清理 stale）；stale → 标记 need_cleanup
+3. 若 live 为空 → 返回
+4. base = match mode {
+     Hash     → flow_hash(frame, self.hash_seed) % live.len()
+     Lb       → self.rr_counter.fetch_add(1, Relaxed) as usize % live.len()
+     Cpu      → current_cpu_id().data() as usize % live.len()
+     Rnd      → rand() as usize % live.len()
+     Rollover → self.rr_counter.fetch_add(1, Relaxed) as usize % live.len() // base 起点
+   }
+5. // ROLLOVER 语义：选中 socket backlog 则滚到下一个有空间的
+   let rollover = mode == Rollover || (self.flags & FLAG_ROLLOVER != 0)
+   for offset in 0..live.len() {
+       idx = (base + offset) % live.len()
+       if !rollover || live[idx].rx_has_room() {   // 非 rollover 直接投；rollover 找有空间的
+           live[idx].deliver(ifindex, frame, pkt_type)
+           return
+       }
+   }
+   // 全部满（仅 rollover 路径）：投给 base，由 deliver_from_iface 记 drop
+   live[base].deliver(ifindex, frame, pkt_type)
+```
+
+> rr_counter 用 fetch_add 保证多核并发递增无竞争；HASH/RND/CPU 无共享状态。
+> rx_has_room() 为 PacketSocket 新增的 pub(super) 方法：rx_buffer_bytes.load(Acquire) < recv_buffer_bytes.load(Relaxed)（复用 rx.rs:74 既有判断）。
+
+### 5.4 ROLLOVER 语义（mode 与 FLAG_ROLLOVER）
+
+- **mode=ROLLOVER**：从 rr_counter 推进的 base 起点顺序找第一个 rx_has_room() 的成员投递。
+- **FLAG_ROLLOVER（其他 mode）**：demux 选 base 后，若 backlog 则滚到下一个有空间的成员。两种语义在 5.3 步骤 5 统一实现。
+- 全部满时投给 base，由 deliver_from_iface 记 stats_drops（保丢包统计语义）。
+
+### 5.5 flow_hash（HASH 模式）
+
+解析以太网帧（复用 rx.rs:parse_frame 的 dst/src/protocol 解析，再下钻 L3/L4）：
+- Ethernet 14B 头后是 IP：若 IPv4 取 src/dst（各 4B），IPv6 取 src/dst（各 16B）。
+- L4：若 TCP/UDP 取 src/dst port（各 2B）。
+- 拼 [src_ip_words..., dst_ip_words..., src_port, dst_port] → jhash2(&words, self.hash_seed)。
+- 非 IP 帧 → hash=0（全部走 base socket，退化但不丢）。
+- hash_seed 在 group 创建时随机生成（rand()），避免固定 seed 导致 flow polarization。
+
+---
+
+## 6. getsockopt(PACKET_FANOUT)
+
+```
+未加入 group → 返回成功，写回 0（Linux packet_getsockopt：po->fanout 为空时 val=0）
+已加入 group → 写回 (group.id as u32) | ((mode.as_raw() as u32 | flags as u32) << 16)，返回 4 字节
+```
+
+---
+
+## 7. scope 与不支持项
+
+| 特性 | 处理 | 理由 |
+|------|------|------|
+| QM(5)/CBPF(6)/EBPF(7) | `EINVAL` | 需 NIC RSS queue_mapping / BPF 基础设施，DragonOS 暂无 |
+| FLAG_DEFRAG | `EINVAL` | 需 IP 分片重组，DragonOS 暂无 |
+| FLAG_IGNORE_OUTGOING | `EINVAL` | DragonOS 不向 packet socket 回送出站帧，语义空缺 |
+| `fanout_args`（struct）传参 | 不支持 | Linux 新接口，传统 int 编码已覆盖主流用例 |
+
+> 对不支持项返回 `EINVAL` 而非静默忽略：避免用户误以为已生效。
+
+---
+
+## 8. 并发与正确性
+
+| 场景 | 保证 |
+|------|------|
+| deliver 与 join/remove 并发 | deliver 持 RCU 读快照，join/remove 走 COW + store_deferred，读者看到一致快照 |
+| LB/ROLLOVER rr_counter 多核竞争 | fetch_add 原子，无丢失 |
+| group 空时删除与并发 deliver | deliver 持旧快照（Arc 存活），删除只重建 registry；旧 group Arc 在快照释放后回收 |
+| **leave TOCTOU** | 「检查成员空 + 删除 group」整体在 fanout_groups_writer 锁内，与 join 互斥，无 zombie |
+| socket close 与 deliver 竞争 | 与现有 packet_sockets 相同：Weak.upgrade 决定，失败标记惰性清理 |
+| join 一致性校验 | writer 锁内完成「查找/创建 + 加成员 + 设字段」原子序列 |
+| join 瞬态窗口 | add_member 先于设 fanout。**已有 group**：release-acquire 下仅可能重复一帧（广播路径见 fanout=None 仍投 + group 路径见成员也投），不可能丢失——重复比丢失友好，用户态去重即可。**新 group**：registry publish 前被广播跳过，最多丢一帧。两者均等价 Linux hook 切换瞬态，bounded、可接受。消除该窗口需两套状态（fanout 字段 + 成员列表）原子切换，成本不划算。 |
+
+---
+
+## 9. 文件改动清单
+
+| 文件 | 改动 |
+|------|------|
+| `kernel/src/net/socket/packet/uapi.rs` | 新增 fanout mode/flag 常量、PACKET_FANOUT/PACKET_FANOUT_DATA option 常量 |
+| `kernel/src/net/socket/packet/fanout.rs` | **新建**：FanoutMode、FanoutGroup、join/leave/deliver/demux/flow_hash |
+| `kernel/src/net/socket/packet/mod.rs` | PacketSocket 加 `fanout` 字段；mod 声明 fanout；new() 初始化；deliver_to_packet_sockets 不变（分发改造在 netns） |
+| `kernel/src/net/socket/packet/sockopt.rs` | set/get 的 `PSOL::PACKET` 分支加 `PACKET_FANOUT` 处理 |
+| `kernel/src/net/socket/packet/binding.rs` | `close_binding()` 末尾调 `leave_fanout()` |
+| `kernel/src/process/namespace/net_namespace.rs` | 加 fanout_groups 注册表字段；deliver_to_packet_sockets 增加 group 分发遍历；join/leave/remove 的 netns 方法 |
+
+---
+
+## 10. 实施步骤
+
+### Task 1: uapi 常量
+新增 `PACKET_FANOUT`(18)、`PACKET_FANOUT_DATA`(22) option，`fanout_mode::*`、`fanout_flag::*` 模块。
+验证：`make kernel` 编译通过。
+
+### Task 2: FanoutMode + FanoutGroup 骨架（fanout.rs）
+定义 `FanoutMode`（含 from_raw/as_raw）、`FanoutGroup`、`FanoutMemberSnapshot`。实现 `add_member`/`remove_member`（RCU COW）。
+验证：编译通过。
+
+### Task 3: netns 注册表
+netns 加 `fanout_groups`/`fanout_groups_writer`/`fanout_groups_need_cleanup`；初始化；`join_fanout_group`/`leave_fanout_group`/`cleanup_fanout_groups` 方法。
+验证：编译通过。
+
+### Task 4: PacketSocket 字段 + join/leave
+PacketSocket 加 `fanout` 字段，new() 初始化。实现 `join_fanout`（一致性校验）、`leave_fanout`。
+验证：编译通过。
+
+### Task 5: deliver 分发
+netns.deliver_to_packet_sockets 增加 group 遍历；FanoutGroup::deliver + 各 mode demux + flow_hash。
+验证：编译通过。
+
+### Task 6: sockopt 接入
+sockopt.rs 的 set/get 加 PACKET_FANOUT 分支；close_binding 加 leave_fanout。
+验证：`make kernel` 编译通过。
+
+### Task 7: 测试
+编写用户态测试程序（`user/apps/c_unitest` 或独立），验证：
+- LB 模式 round-robin 分发（多 socket 收到不同包）
+- HASH 模式同流到同 socket
+- group 一致性校验（错误 mode/protocol → EINVAL）
+- close 后 group 删除
+验证：QEMU 内运行测试通过。
+
+---
+
+## 11. 风险与回归检查
+
+- **广播回归**：普通 socket（fanout=None）deliver 路径仅多一次 `fanout.read()` 判断，逻辑不变。
+- **性能**：deliver 多一次 group_snapshot.load()（RCU 读，无锁）+ group 遍历；group 数量通常极少。
+- **内存**：FanoutGroup Arc 在 group 删除后随快照释放回收，无泄漏。
+- **EBUSY/EINVAL 语义**：严格对齐 Linux man page，用 gvisor/真实程序验证错误码。

--- a/kernel/src/net/socket/packet/binding.rs
+++ b/kernel/src/net/socket/packet/binding.rs
@@ -80,6 +80,9 @@ impl PacketSocket {
         let _guard = self.bind_lock.lock();
         self.revert_all_memberships();
         self.netns.unregister_packet_socket(&self.self_ref);
+        // Drop fanout membership after leaving the broadcast registry so the
+        // socket never receives both a broadcast and a group delivery.
+        self.leave_fanout();
         *self.bound_iface.write() = None;
         self.binding.store(0, 0);
         Ok(())

--- a/kernel/src/net/socket/packet/binding.rs
+++ b/kernel/src/net/socket/packet/binding.rs
@@ -49,6 +49,9 @@ impl PacketSocket {
             return Err(SystemError::ENODEV);
         }
         let _guard = self.bind_lock.lock();
+        if self.has_fanout_group() {
+            return Err(SystemError::EINVAL);
+        }
         let (old_index, old_protocol) = self.binding.load();
         let protocol = if requested_protocol == 0 {
             old_protocol
@@ -80,9 +83,6 @@ impl PacketSocket {
         let _guard = self.bind_lock.lock();
         self.revert_all_memberships();
         self.netns.unregister_packet_socket(&self.self_ref);
-        // Drop fanout membership after leaving the broadcast registry so the
-        // socket never receives both a broadcast and a group delivery.
-        self.leave_fanout();
         *self.bound_iface.write() = None;
         self.binding.store(0, 0);
         Ok(())

--- a/kernel/src/net/socket/packet/fanout.rs
+++ b/kernel/src/net/socket/packet/fanout.rs
@@ -1,49 +1,41 @@
 //! AF_PACKET `PACKET_FANOUT` group demultiplexing.
 //!
-//! A fanout group fans matching ingress frames out to exactly one of its member
-//! sockets, selected by the group's distribution algorithm (HASH/LB/CPU/RND/
-//! ROLLOVER). Members are registered with the owning `NetNamespace` and use the
-//! same RCU copy-on-write publication pattern as the broadcast packet-socket
-//! registry, so the NAPI deliver path stays lock-free on the read side.
+//! The owning network namespace publishes the complete plain-socket and
+//! fanout-group topology in one RCU snapshot.  Group snapshots are immutable;
+//! write-side membership changes create a replacement snapshot while sharing
+//! the small amount of algorithm runtime state.
 
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
-use core::sync::atomic::Ordering;
-use system_error::SystemError;
+use core::cmp::Ordering as CmpOrdering;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use jhash::jhash2;
+use system_error::SystemError;
 
-use crate::libs::mutex::Mutex;
-use crate::rcu::RcuArcSlot;
-
-use super::rx::l2_ethertype_l3_offset;
+use super::rx::packet_protocol;
 use super::uapi::{eth_protocol, fanout_flag, fanout_mode};
-use super::{PacketIngressMetadata, PacketSocket, PacketSocketType};
+use super::{PacketIngressMetadata, PacketSocket, PacketType};
 
 const IPPROTO_TCP: u8 = 6;
 const IPPROTO_UDP: u8 = 17;
+pub(crate) const LEGACY_FANOUT_MAX_MEMBERS: usize = 256;
+pub(crate) const FANOUT_MAX_MEMBERS: usize = 1 << 16;
 
-/// Supported fanout distribution algorithms.
-///
-/// QM(5)/CBPF(6)/EBPF(7) require NIC RSS queue mapping / BPF infrastructure
-/// that DragonOS does not yet provide, so `FanoutMode::from_raw` rejects them.
+/// One process-wide secret, matching Linux's use of a shared boot-random
+/// secret for `__skb_get_hash_symmetric()` rather than a per-group seed.
+static FLOW_HASH_SEED: AtomicU32 = AtomicU32::new(0);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FanoutMode {
-    /// 0 — flow hash of the L3/L4 4-tuple modulo the member count.
     Hash,
-    /// 1 — round-robin via an atomic counter.
     Lb,
-    /// 2 — receiving CPU id modulo the member count.
     Cpu,
-    /// 3 — start from the round-robin base and roll over filled members.
     Rollover,
-    /// 4 — uniformly random member selection.
     Rnd,
 }
 
 impl FanoutMode {
-    /// Parse the low 7 bits of `type_flags`. Returns `EINVAL` for unsupported
-    /// modes (QM/CBPF/EBPF).
     fn from_raw(raw: u32) -> Result<Self, SystemError> {
         match raw {
             fanout_mode::PACKET_FANOUT_HASH => Ok(Self::Hash),
@@ -51,7 +43,6 @@ impl FanoutMode {
             fanout_mode::PACKET_FANOUT_CPU => Ok(Self::Cpu),
             fanout_mode::PACKET_FANOUT_ROLLOVER => Ok(Self::Rollover),
             fanout_mode::PACKET_FANOUT_RND => Ok(Self::Rnd),
-            // PACKET_FANOUT_QM / CBPF / EBPF are unsupported.
             _ => Err(SystemError::EINVAL),
         }
     }
@@ -67,306 +58,553 @@ impl FanoutMode {
     }
 }
 
-/// Join-time parameter bundle for `NetNamespace::fanout_group_join`.
-///
-/// Grouping these values keeps that entry point under clippy's
-/// `too_many_arguments` threshold while letting the packet module hand the
-/// netns a single, self-describing value.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FanoutJoinParams {
-    /// Explicit group id requested by the socket (ignored when `unique`).
     pub id_req: u16,
-    /// `true` for `PACKET_FANOUT_FLAG_UNIQUEID`: allocate a fresh group.
     pub unique: bool,
-    /// Distribution algorithm for the group.
     pub mode: FanoutMode,
-    /// Raw `PACKET_FANOUT_FLAG_*` bits requested by the creator.
+    /// Persistent group flags. `UNIQUEID` is removed while parsing because it
+    /// is an allocation request, not group identity.
     pub flags: u16,
-    /// Joining socket's type / binding filter — enforced on every join.
-    pub sock_type: PacketSocketType,
     pub bound_ifindex: u32,
     pub bound_protocol: u16,
+    /// Zero selects the legacy 256-member limit. Non-zero values come from
+    /// Linux's 8-byte `fanout_args` ABI and are part of group identity.
+    pub max_num_members: u32,
 }
 
-/// RCU-published member list of a fanout group (mirrors the broadcast
-/// `PacketSocketRegistrySnapshot` COW pattern).
-#[derive(Debug, Default)]
-struct FanoutMemberSnapshot {
-    members: Vec<Weak<PacketSocket>>,
+#[derive(Debug)]
+struct FanoutRuntime {
+    rr_counter: AtomicU32,
 }
 
-/// A fanout group: an ordered set of sockets sharing a distribution algorithm.
-///
-/// All members are guaranteed (at join time) to share the same socket type and
-/// `(ifindex, protocol)` receive filter, so any demux choice yields identical
-/// `deliver_from_iface` filtering.
+impl FanoutRuntime {
+    fn try_new() -> Result<Arc<Self>, SystemError> {
+        Arc::try_new(Self {
+            rr_counter: AtomicU32::new(0),
+        })
+        .map_err(|_| SystemError::ENOMEM)
+    }
+}
+
+/// Linux associates rollover history with the initially selected packet
+/// socket. Keep a separate cursor per primary member so HASH/LB/CPU/RND flows
+/// do not perturb one another's fallback start.
+#[derive(Debug)]
+struct MemberRolloverState {
+    cursor: AtomicU32,
+}
+
+#[derive(Debug, Clone)]
+struct FanoutMember {
+    socket: Weak<PacketSocket>,
+    rollover: Option<Arc<MemberRolloverState>>,
+}
+
+impl FanoutMember {
+    fn try_new(socket: Weak<PacketSocket>, rollover: bool) -> Result<Self, SystemError> {
+        Ok(Self {
+            socket,
+            rollover: if rollover {
+                Some(
+                    Arc::try_new(MemberRolloverState {
+                        cursor: AtomicU32::new(0),
+                    })
+                    .map_err(|_| SystemError::ENOMEM)?,
+                )
+            } else {
+                None
+            },
+        })
+    }
+}
+
+/// Immutable group snapshot stored inside the netns delivery topology.
 #[derive(Debug)]
 pub(crate) struct FanoutGroup {
     pub id: u16,
     pub mode: FanoutMode,
-    /// Raw `PACKET_FANOUT_FLAG_*` bits requested by the creator.
     pub flags: u16,
-    /// Creator's socket type / binding filter — enforced on every join.
-    sock_type: PacketSocketType,
     bound_ifindex: u32,
     bound_protocol: u16,
-    /// Random HASH-mode seed to avoid flow polarization across groups.
-    hash_seed: u32,
-    /// Member list, RCU COW (mirrors `NetNamespace::packet_sockets`).
-    members: RcuArcSlot<FanoutMemberSnapshot>,
-    /// Serializes copy-on-write member-list updates.
-    members_writer: Mutex<()>,
-    /// LB / ROLLOVER round-robin counter (atomic, multi-core safe).
-    rr_counter: core::sync::atomic::AtomicU32,
+    max_num_members: usize,
+    runtime: Arc<FanoutRuntime>,
+    members: Vec<FanoutMember>,
 }
 
 impl FanoutGroup {
-    pub(crate) fn new(id: u16, params: FanoutJoinParams) -> Arc<Self> {
-        // A per-group random seed prevents flows from polarizing onto the same
-        // member across groups that happen to share a hash function.
-        let hash_seed = crate::arch::rand::rand() as u32;
-        Arc::new(Self {
+    pub(crate) fn try_new(
+        id: u16,
+        params: FanoutJoinParams,
+        socket: Weak<PacketSocket>,
+    ) -> Result<Arc<Self>, SystemError> {
+        let rollover = params.mode == FanoutMode::Rollover
+            || params.flags & fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER != 0;
+        let mut members = Vec::new();
+        members
+            .try_reserve_exact(1)
+            .map_err(|_| SystemError::ENOMEM)?;
+        members.push(FanoutMember::try_new(socket, rollover)?);
+        Arc::try_new(Self {
             id,
             mode: params.mode,
             flags: params.flags,
-            sock_type: params.sock_type,
             bound_ifindex: params.bound_ifindex,
             bound_protocol: params.bound_protocol,
-            hash_seed,
-            members: RcuArcSlot::new(Arc::new(FanoutMemberSnapshot::default())),
-            members_writer: Mutex::new(()),
-            rr_counter: core::sync::atomic::AtomicU32::new(0),
+            max_num_members: if params.max_num_members == 0 {
+                LEGACY_FANOUT_MAX_MEMBERS
+            } else {
+                params.max_num_members as usize
+            },
+            runtime: FanoutRuntime::try_new()?,
+            members,
         })
+        .map_err(|_| SystemError::ENOMEM)
     }
 
-    /// Whether a joining socket matches this group's creator profile.
-    pub(crate) fn matches(
+    pub(crate) fn matches(&self, params: FanoutJoinParams) -> bool {
+        self.mode == params.mode
+            && self.flags == params.flags
+            && self.bound_ifindex == params.bound_ifindex
+            && self.bound_protocol == params.bound_protocol
+            && (params.max_num_members == 0
+                || self.max_num_members == params.max_num_members as usize)
+    }
+
+    pub(crate) fn member_count(&self) -> usize {
+        self.members.len()
+    }
+
+    pub(crate) fn max_num_members(&self) -> usize {
+        self.max_num_members
+    }
+
+    pub(crate) fn try_with_member(
         &self,
-        sock_type: PacketSocketType,
-        bound_ifindex: u32,
-        bound_protocol: u16,
-    ) -> bool {
-        self.sock_type == sock_type
-            && self.bound_ifindex == bound_ifindex
-            && self.bound_protocol == bound_protocol
+        socket: Weak<PacketSocket>,
+    ) -> Result<Arc<Self>, SystemError> {
+        let mut members = Vec::new();
+        members
+            .try_reserve_exact(self.members.len().saturating_add(1))
+            .map_err(|_| SystemError::ENOMEM)?;
+        members.extend(self.members.iter().cloned());
+        let rollover = self.mode == FanoutMode::Rollover
+            || self.flags & fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER != 0;
+        members.push(FanoutMember::try_new(socket, rollover)?);
+        Arc::try_new(Self {
+            id: self.id,
+            mode: self.mode,
+            flags: self.flags,
+            bound_ifindex: self.bound_ifindex,
+            bound_protocol: self.bound_protocol,
+            max_num_members: self.max_num_members,
+            runtime: self.runtime.clone(),
+            members,
+        })
+        .map_err(|_| SystemError::ENOMEM)
     }
 
-    /// Publish a new member-list snapshot containing `socket` (RCU COW).
-    pub(crate) fn add_member(&self, socket: Weak<PacketSocket>) {
-        let _guard = self.members_writer.lock();
-        let current = self.members.load();
-        let mut members = current.members.clone();
-        // Drop already-dead weak refs while we hold the write-side clone.
-        members.retain(|entry| entry.strong_count() != 0);
-        if !members.iter().any(|entry| Weak::ptr_eq(entry, &socket)) {
-            members.push(socket);
-        }
-        self.members
-            .store_deferred(Arc::new(FanoutMemberSnapshot { members }));
-    }
-
-    /// Publish a new member-list snapshot without `socket` (RCU COW).
-    pub(crate) fn remove_member(&self, socket: &Weak<PacketSocket>) {
-        let _guard = self.members_writer.lock();
-        let current = self.members.load();
-        let mut members = current.members.clone();
-        members.retain(|entry| entry.strong_count() != 0 && !Weak::ptr_eq(entry, socket));
-        self.members
-            .store_deferred(Arc::new(FanoutMemberSnapshot { members }));
-    }
-
-    /// Count live members. Called only under the netns `fanout_groups_writer`
-    /// lock, which blocks concurrent `add_member`/`remove_member`, so the RCU
-    /// snapshot read here is stable for the empty-group teardown decision.
-    pub(crate) fn live_count(&self) -> usize {
-        let current = self.members.load();
-        current
-            .members
+    pub(crate) fn try_without_member(
+        &self,
+        socket: &Weak<PacketSocket>,
+    ) -> Result<Arc<Self>, SystemError> {
+        let mut members = Vec::new();
+        members
+            .try_reserve_exact(self.members.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        members.extend(self.members.iter().cloned());
+        if let Some(index) = members
             .iter()
-            .filter(|entry| entry.strong_count() != 0)
-            .count()
+            .position(|entry| Weak::ptr_eq(&entry.socket, socket))
+        {
+            // Linux also fills a removed slot with the final member.
+            members.swap_remove(index);
+        }
+        self.try_with_members(members)
     }
 
-    /// Deliver one copy of the frame to a single member selected by the
-    /// distribution algorithm. Returns `true` when the member list contained
-    /// dead weak refs (lazy cleanup hint for the netns).
+    /// Return a compacted replacement only when at least one dead Weak was
+    /// observed. Healthy groups keep their original Arc and member Vec.
+    pub(crate) fn try_without_dead_members(&self) -> Result<Option<Arc<Self>>, SystemError> {
+        if self.members.iter().all(|member| {
+            member
+                .socket
+                .upgrade()
+                .is_some_and(|socket| socket.is_packet_registry_active())
+        }) {
+            return Ok(None);
+        }
+        let mut members = Vec::new();
+        members
+            .try_reserve_exact(self.members.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        members.extend(self.members.iter().cloned());
+        let mut index = 0;
+        while index < members.len() {
+            if !members[index]
+                .socket
+                .upgrade()
+                .is_some_and(|socket| socket.is_packet_registry_active())
+            {
+                members.swap_remove(index);
+            } else {
+                index += 1;
+            }
+        }
+        self.try_with_members(members).map(Some)
+    }
+
+    fn try_with_members(&self, members: Vec<FanoutMember>) -> Result<Arc<Self>, SystemError> {
+        Arc::try_new(Self {
+            id: self.id,
+            mode: self.mode,
+            flags: self.flags,
+            bound_ifindex: self.bound_ifindex,
+            bound_protocol: self.bound_protocol,
+            max_num_members: self.max_num_members,
+            runtime: self.runtime.clone(),
+            members,
+        })
+        .map_err(|_| SystemError::ENOMEM)
+    }
+
+    /// Deliver to at most one member. Returns `true` when a dead weak member
+    /// was observed and the writer should compact the topology later.
     pub(crate) fn deliver(
         &self,
         ingress: PacketIngressMetadata,
         frame: &[u8],
+        protocol_cache: &mut Option<Option<u16>>,
+        flow_hash_cache: &mut Option<u32>,
     ) -> bool {
-        let snapshot = self.members.load();
-
-        // First pass: count live members without any heap allocation.
-        let mut stale = false;
-        let mut live_count = 0usize;
-        for entry in snapshot.members.iter() {
-            if entry.strong_count() != 0 {
-                live_count += 1;
-            } else {
-                stale = true;
-            }
-        }
-        if live_count == 0 {
-            return stale;
+        if self.members.is_empty()
+            || (self.bound_ifindex != 0 && self.bound_ifindex != ingress.ifindex)
+            || (self.flags & fanout_flag::PACKET_FANOUT_FLAG_IGNORE_OUTGOING != 0
+                && ingress.pkt_type == PacketType::Outgoing)
+        {
+            return false;
         }
 
-        let base = match self.mode {
-            FanoutMode::Hash => flow_hash(frame, self.hash_seed) as usize % live_count,
-            FanoutMode::Lb | FanoutMode::Rollover => {
-                self.rr_counter.fetch_add(1, Ordering::Relaxed) as usize % live_count
-            }
-            FanoutMode::Cpu => crate::arch::cpu::current_cpu_id().data() as usize % live_count,
-            FanoutMode::Rnd => crate::arch::rand::rand() % live_count,
-        };
-        // ROLLOVER semantics: mode == Rollover always rolls over filled
-        // backlogs; FLAG_ROLLOVER layers the same fallback onto other modes.
-        let rollover = self.mode == FanoutMode::Rollover
-            || (self.flags & fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER != 0);
-
-        // Second pass: find and deliver to the selected socket, rolling over
-        // filled backlogs. Each candidate is upgraded lazily —
-        // strong_count()!=0 guarantees upgrade() succeeds, so no heap
-        // allocation occurs.
-        for offset in 0..live_count {
-            let target = (base + offset) % live_count;
-            let Some(socket) = nth_live_member(&snapshot.members, target) else {
-                continue;
+        let needs_protocol =
+            self.bound_protocol != eth_protocol::ETH_P_ALL || self.mode == FanoutMode::Hash;
+        let protocol = if needs_protocol {
+            let Some(protocol) =
+                *protocol_cache.get_or_insert_with(|| packet_protocol(frame, ingress.pkt_type))
+            else {
+                return false;
             };
-            if !rollover || socket.rx_has_room() {
+            if self.bound_protocol != eth_protocol::ETH_P_ALL && self.bound_protocol != protocol {
+                return false;
+            }
+            protocol
+        } else {
+            eth_protocol::ETH_P_ALL
+        };
+
+        let count = self.members.len();
+        let base = match self.mode {
+            FanoutMode::Hash => {
+                let hash = *flow_hash_cache.get_or_insert_with(|| flow_hash(frame, protocol));
+                hash as usize % count
+            }
+            FanoutMode::Lb => {
+                self.runtime
+                    .rr_counter
+                    .fetch_add(1, Ordering::Relaxed)
+                    .wrapping_add(1) as usize
+                    % count
+            }
+            FanoutMode::Cpu => crate::smp::core::smp_get_processor_id().data() as usize % count,
+            FanoutMode::Rollover => 0,
+            FanoutMode::Rnd => random_below(count),
+        };
+
+        let rollover = self.mode == FanoutMode::Rollover
+            || self.flags & fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER != 0;
+        if !rollover {
+            return self.deliver_first_live_from(base, ingress, frame);
+        }
+
+        let mut stale = false;
+        if self.mode != FanoutMode::Rollover {
+            match self.members[base].socket.upgrade() {
+                Some(socket) if socket.rx_has_room() => {
+                    socket.deliver(ingress, frame);
+                    return false;
+                }
+                Some(_) => {}
+                None => stale = true,
+            }
+        }
+
+        let state = self.members[base]
+            .rollover
+            .as_ref()
+            .expect("rollover member state");
+        let start = state.cursor.load(Ordering::Relaxed) as usize % count;
+        for offset in 0..count {
+            let index = (start + offset) % count;
+            // Linux's FLAG_ROLLOVER path records the failed primary as
+            // `po_skip`; do not reselect it during the fallback scan.
+            if self.mode != FanoutMode::Rollover && index == base {
+                continue;
+            }
+            match self.members[index].socket.upgrade() {
+                Some(socket) if socket.rx_has_room() => {
+                    if index != start {
+                        state.cursor.store(index as u32, Ordering::Relaxed);
+                    }
+                    socket.deliver(ingress, frame);
+                    return stale;
+                }
+                Some(_) => {}
+                None => stale = true,
+            }
+        }
+
+        // Linux returns the initially selected member when every queue is
+        // full; the socket receive path then records the single final drop.
+        stale | self.deliver_first_live_from(base, ingress, frame)
+    }
+
+    fn deliver_first_live_from(
+        &self,
+        start: usize,
+        ingress: PacketIngressMetadata,
+        frame: &[u8],
+    ) -> bool {
+        let mut stale = false;
+        for offset in 0..self.members.len() {
+            let index = (start + offset) % self.members.len();
+            if let Some(socket) = self.members[index].socket.upgrade() {
                 socket.deliver(ingress, frame);
                 return stale;
             }
-        }
-        // All members full (only reachable on the rollover path): hand the
-        // frame to `base` so `deliver_from_iface` records the drop statistic.
-        if let Some(socket) = nth_live_member(&snapshot.members, base) {
-            socket.deliver(ingress, frame);
+            stale = true;
         }
         stale
     }
 }
 
-/// Upgrade the `target`-th live member (0-indexed among live entries) of a
-/// fanout snapshot. `strong_count()!=0` guarantees `upgrade()` succeeds, so
-/// this performs no heap allocation.
-fn nth_live_member(members: &[Weak<PacketSocket>], target: usize) -> Option<Arc<PacketSocket>> {
-    let mut seen = 0usize;
-    for entry in members {
-        if entry.strong_count() == 0 {
-            continue;
-        }
-        if seen == target {
-            return entry.upgrade();
-        }
-        seen += 1;
+fn hash_seed() -> u32 {
+    let current = FLOW_HASH_SEED.load(Ordering::Acquire);
+    if current != 0 {
+        return current;
     }
-    None
+    let generated = (crate::arch::rand::rand() as u32) | 1;
+    match FLOW_HASH_SEED.compare_exchange(0, generated, Ordering::AcqRel, Ordering::Acquire) {
+        Ok(_) => generated,
+        Err(installed) => installed,
+    }
 }
 
-/// Compute a flow hash over the L3/L4 4-tuple for HASH-mode demux.
-///
-/// Non-IP frames hash to 0 (all land on the base member — degraded but
-/// lossless). VLAN tags are skipped so tagged and untagged frames of the same
-/// flow hash identically.
-fn flow_hash(frame: &[u8], seed: u32) -> u32 {
-    let Some((ether, l3_off)) = l2_ethertype_l3_offset(frame) else {
-        return 0;
-    };
-    let l3 = if frame.len() > l3_off {
-        &frame[l3_off..]
-    } else {
-        return 0;
-    };
+fn random_below(upper: usize) -> usize {
+    debug_assert!(upper != 0);
+    let max_acceptable = usize::MAX - (usize::MAX % upper + 1) % upper;
+    loop {
+        let value = crate::arch::rand::rand();
+        if value <= max_acceptable {
+            return value % upper;
+        }
+    }
+}
 
-    if ether == eth_protocol::ETH_P_IP {
-        // IPv4
-        if l3.len() < 20 {
-            return 0;
+/// Linux-compatible symmetric flow-key subset: basic protocol, IP protocol,
+/// addresses and ports. Address and port pairs are canonicalized separately.
+fn flow_hash(frame: &[u8], protocol: u16) -> u32 {
+    let seed = hash_seed();
+    let Some((l3_protocol, l3_offset)) = l3_protocol_offset(frame) else {
+        return jhash2(&[protocol as u32], seed);
+    };
+    if l3_protocol == eth_protocol::ETH_P_IP {
+        return ipv4_flow_hash(
+            frame.get(l3_offset..).unwrap_or_default(),
+            l3_protocol,
+            seed,
+        );
+    }
+    if l3_protocol == eth_protocol::ETH_P_IPV6 {
+        return ipv6_flow_hash(
+            frame.get(l3_offset..).unwrap_or_default(),
+            l3_protocol,
+            seed,
+        );
+    }
+    jhash2(&[l3_protocol as u32], seed)
+}
+
+fn l3_protocol_offset(frame: &[u8]) -> Option<(u16, usize)> {
+    if frame.len() < 14 {
+        return None;
+    }
+    let mut protocol = u16::from_be_bytes([frame[12], frame[13]]);
+    let mut offset = 14usize;
+    // Linux's flow dissector walks stacked 802.1Q/802.1ad headers. Keep the
+    // same useful QinQ behavior with an explicit bound for hostile frames.
+    for _ in 0..8 {
+        if protocol != 0x8100 && protocol != 0x88a8 {
+            return Some((protocol, offset));
         }
-        if l3[0] >> 4 != 4 {
-            return 0;
-        }
-        let ihl = (l3[0] as usize & 0xf) * 4;
-        if ihl < 20 || l3.len() < ihl {
-            return 0;
-        }
-        let src = u32::from_be_bytes([l3[12], l3[13], l3[14], l3[15]]);
-        let dst = u32::from_be_bytes([l3[16], l3[17], l3[18], l3[19]]);
-        let proto = l3[9];
-        let (sp, dp) = l4_ports(&l3[ihl..], proto);
-        let words = [src, dst, sp as u32, dp as u32];
-        jhash2(&words, seed)
-    } else if ether == eth_protocol::ETH_P_IPV6 {
-        // IPv6
-        if l3.len() < 40 {
-            return 0;
-        }
-        let mut src = [0u32; 4];
-        let mut dst = [0u32; 4];
-        for i in 0..4 {
-            src[i] =
-                u32::from_be_bytes([l3[8 + i * 4], l3[9 + i * 4], l3[10 + i * 4], l3[11 + i * 4]]);
-            dst[i] = u32::from_be_bytes([
-                l3[24 + i * 4],
-                l3[25 + i * 4],
-                l3[26 + i * 4],
-                l3[27 + i * 4],
-            ]);
-        }
-        let next_header = l3[6];
-        let (sp, dp) = l4_ports(&l3[40..], next_header);
-        let words = [
-            src[0], src[1], src[2], src[3], dst[0], dst[1], dst[2], dst[3], sp as u32, dp as u32,
-        ];
-        jhash2(&words, seed)
+        let header = frame.get(offset..offset.checked_add(4)?)?;
+        protocol = u16::from_be_bytes([header[2], header[3]]);
+        offset += 4;
+    }
+    Some((protocol, offset))
+}
+
+fn ipv4_flow_hash(l3: &[u8], basic_protocol: u16, seed: u32) -> u32 {
+    if l3.len() < 20 || l3[0] >> 4 != 4 {
+        return jhash2(&[basic_protocol as u32], seed);
+    }
+    let ihl = usize::from(l3[0] & 0x0f) * 4;
+    if ihl < 20 || l3.len() < ihl {
+        return jhash2(&[basic_protocol as u32], seed);
+    }
+    let mut src = u32::from_be_bytes([l3[12], l3[13], l3[14], l3[15]]);
+    let mut dst = u32::from_be_bytes([l3[16], l3[17], l3[18], l3[19]]);
+    if dst < src {
+        core::mem::swap(&mut src, &mut dst);
+    }
+    let ip_protocol = l3[9];
+    let fragment = u16::from_be_bytes([l3[6], l3[7]]);
+    // Linux's symmetric dissector does not request first-fragment parsing:
+    // MF or a non-zero offset therefore suppresses L4 ports.
+    let ports = if fragment & 0x3fff == 0 {
+        canonical_ports(l3.get(ihl..).unwrap_or_default(), ip_protocol)
     } else {
         0
-    }
+    };
+    jhash2(
+        &[basic_protocol as u32, ip_protocol as u32, src, dst, ports],
+        seed,
+    )
 }
 
-/// Extract the source/destination ports from an L4 segment for TCP/UDP.
-fn l4_ports(l4: &[u8], proto: u8) -> (u16, u16) {
-    if (proto == IPPROTO_TCP || proto == IPPROTO_UDP) && l4.len() >= 4 {
-        let sp = u16::from_be_bytes([l4[0], l4[1]]);
-        let dp = u16::from_be_bytes([l4[2], l4[3]]);
-        (sp, dp)
-    } else {
-        (0, 0)
+fn ipv6_flow_hash(l3: &[u8], basic_protocol: u16, seed: u32) -> u32 {
+    if l3.len() < 40 || l3[0] >> 4 != 6 {
+        return jhash2(&[basic_protocol as u32], seed);
     }
+    let mut src = [0u32; 4];
+    let mut dst = [0u32; 4];
+    for index in 0..4 {
+        let src_off = 8 + index * 4;
+        let dst_off = 24 + index * 4;
+        src[index] = u32::from_be_bytes(l3[src_off..src_off + 4].try_into().unwrap());
+        dst[index] = u32::from_be_bytes(l3[dst_off..dst_off + 4].try_into().unwrap());
+    }
+    if compare_words(&dst, &src) == CmpOrdering::Less {
+        core::mem::swap(&mut src, &mut dst);
+    }
+    let (ip_protocol, transport_offset, has_ports) = ipv6_transport(l3);
+    let ports = if has_ports {
+        canonical_ports(l3.get(transport_offset..).unwrap_or_default(), ip_protocol)
+    } else {
+        0
+    };
+    let words = [
+        basic_protocol as u32,
+        ip_protocol as u32,
+        src[0],
+        src[1],
+        src[2],
+        src[3],
+        dst[0],
+        dst[1],
+        dst[2],
+        dst[3],
+        ports,
+    ];
+    jhash2(&words, seed)
+}
+
+fn ipv6_transport(l3: &[u8]) -> (u8, usize, bool) {
+    let mut next = l3[6];
+    let mut offset = 40usize;
+    for _ in 0..8 {
+        match next {
+            0 | 43 | 60 => {
+                let Some(header) = l3.get(offset..offset.saturating_add(2)) else {
+                    return (next, offset, false);
+                };
+                next = header[0];
+                offset = match offset.checked_add((usize::from(header[1]) + 1) * 8) {
+                    Some(value) if value <= l3.len() => value,
+                    _ => return (next, offset, false),
+                };
+            }
+            44 => {
+                let Some(header) = l3.get(offset..offset.saturating_add(8)) else {
+                    return (next, offset, false);
+                };
+                next = header[0];
+                offset += 8;
+                // Every IPv6 Fragment Header, including an atomic fragment,
+                // sets FLOW_DIS_IS_FRAGMENT and suppresses port extraction.
+                return (next, offset, false);
+            }
+            _ => return (next, offset, true),
+        }
+    }
+    (next, offset, false)
+}
+
+fn canonical_ports(l4: &[u8], protocol: u8) -> u32 {
+    if (protocol != IPPROTO_TCP && protocol != IPPROTO_UDP) || l4.len() < 4 {
+        return 0;
+    }
+    let mut src = u16::from_be_bytes([l4[0], l4[1]]);
+    let mut dst = u16::from_be_bytes([l4[2], l4[3]]);
+    if dst < src {
+        core::mem::swap(&mut src, &mut dst);
+    }
+    (u32::from(src) << 16) | u32::from(dst)
+}
+
+fn compare_words(left: &[u32; 4], right: &[u32; 4]) -> CmpOrdering {
+    for index in 0..4 {
+        match left[index].cmp(&right[index]) {
+            CmpOrdering::Equal => {}
+            ordering => return ordering,
+        }
+    }
+    CmpOrdering::Equal
 }
 
 impl PacketSocket {
-    /// `setsockopt(SOL_PACKET, PACKET_FANOUT, val)` entry point.
-    ///
-    /// Parses the option value, validates mode/flags, then delegates the
-    /// locked registry work — including the already-joined (`EBUSY`) check —
-    /// to the owning netns so that the check, "publish member", and "set
-    /// fanout field" all happen atomically under the netns writer lock.
-    pub(crate) fn join_fanout(&self, val: i32) -> Result<(), SystemError> {
-        let v = val as u32;
-        let id_req = (v & 0xffff) as u16;
-        let type_flags = v >> 16;
-        let mode = FanoutMode::from_raw(type_flags & 0x7f)?;
-        let flags = (type_flags & !0x7f) as u16;
+    pub(crate) fn join_fanout(&self, raw: u32, max_num_members: u32) -> Result<(), SystemError> {
+        let id_req = raw as u16;
+        let type_flags = raw >> 16;
+        let mode = FanoutMode::from_raw(type_flags & 0xff)?;
+        let mut flags = (type_flags & !0xff) as u16;
 
-        // Only ROLLOVER and UNIQUEID flags are supported. DEFRAG/IGNORE_OUTGOING
-        // need infrastructure DragonOS lacks; reject explicitly rather than
-        // silently ignoring them.
-        const ALLOWED_FLAGS: u16 =
-            fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER | fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID;
-        if flags & !ALLOWED_FLAGS != 0 {
+        const ALLOWED_FLAGS: u16 = fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER
+            | fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID
+            | fanout_flag::PACKET_FANOUT_FLAG_IGNORE_OUTGOING;
+        if flags & !ALLOWED_FLAGS != 0
+            || (mode == FanoutMode::Rollover
+                && flags & fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER != 0)
+        {
+            return Err(SystemError::EINVAL);
+        }
+        if max_num_members as usize > FANOUT_MAX_MEMBERS {
             return Err(SystemError::EINVAL);
         }
 
         let unique = flags & fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID != 0;
-        let Some(socket) = self.self_ref.upgrade() else {
+        if unique && id_req != 0 {
             return Err(SystemError::EINVAL);
-        };
-        // Extract the join profile here (inside the packet module, where the
-        // fields are visible) and hand the values to the netns.
-        let sock_type = self.sock_type;
+        }
+        flags &= !fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID;
+
+        let _guard = self.bind_lock.lock();
+        if self.has_fanout_group() {
+            return Err(SystemError::EALREADY);
+        }
         let (bound_ifindex, bound_protocol) = self.binding.load();
+        if bound_protocol == 0 {
+            return Err(SystemError::EINVAL);
+        }
+        let socket = self.self_ref.upgrade().ok_or(SystemError::EINVAL)?;
         self.netns.fanout_group_join(
             &socket,
             FanoutJoinParams {
@@ -374,71 +612,41 @@ impl PacketSocket {
                 unique,
                 mode,
                 flags,
-                sock_type,
                 bound_ifindex,
                 bound_protocol,
+                max_num_members,
             },
         )
     }
 
-    /// Leave the current fanout group (invoked from `close_binding`).
-    ///
-    /// Delegates entirely to the owning netns, which acquires
-    /// `fanout_groups_writer` *before* taking the socket's `fanout` write lock.
-    /// This keeps the lock order identical to the join path
-    /// (`fanout_groups_writer → fanout.write()`), avoiding the ABBA deadlock
-    /// that would arise if the leave path cleared `fanout` first.
-    pub(crate) fn leave_fanout(&self) {
-        self.netns.fanout_group_leave(&self.self_ref);
-    }
-
-    /// `true` if this socket currently belongs to a fanout group. Used by the
-    /// broadcast deliver path to skip sockets handled by their group.
-    pub(crate) fn is_fanout_member(&self) -> bool {
-        self.fanout_active.load(Ordering::Acquire)
-    }
-
-    /// Record group membership. Called by the netns join path while it holds
-    /// the `fanout_groups_writer` lock, so member publication and field update
-    /// are atomic from a concurrent join/leave viewpoint.
-    pub(crate) fn set_fanout_group(&self, group: Arc<FanoutGroup>) {
-        *self.fanout.write() = Some(group);
-        self.fanout_active.store(true, Ordering::Release);
-    }
-
-    /// Whether this socket currently holds a fanout group reference.
-    /// Checked by the netns join path under the `fanout_groups_writer` lock
-    /// for the already-joined (`EBUSY`) test.
     pub(crate) fn has_fanout_group(&self) -> bool {
-        self.fanout.read().is_some()
+        self.fanout_membership.load(Ordering::Acquire) >> 32 != 0
     }
 
-    /// Take and clear the fanout group membership, deactivating the socket.
-    /// Called by the netns leave path *after* acquiring `fanout_groups_writer`,
-    /// so the clear and the registry mutation share the same lock order as
-    /// the join path (`fanout_groups_writer → fanout.write()`).
-    pub(crate) fn clear_fanout_group(&self) -> Option<Arc<FanoutGroup>> {
-        let group = self.fanout.write().take();
-        if group.is_some() {
-            self.fanout_active.store(false, Ordering::Release);
-        }
-        group
+    pub(crate) fn set_fanout_membership(&self, value: u32) {
+        self.fanout_membership
+            .store((1u64 << 32) | u64::from(value), Ordering::Release);
     }
 
-    /// Current fanout membership encoded as `(id | (type_flags << 16))`, or
-    /// `None` if the socket has not joined a group.
+    pub(crate) fn clear_fanout_membership(&self) {
+        self.fanout_membership.store(0, Ordering::Release);
+    }
+
     pub(crate) fn fanout_getsockopt_value(&self) -> Option<u32> {
-        let group = self.fanout.read();
-        let group = group.as_ref()?;
-        let type_flags = group.mode.as_raw() | group.flags as u32;
-        Some(group.id as u32 | (type_flags << 16))
+        let membership = self.fanout_membership.load(Ordering::Acquire);
+        (membership >> 32 != 0).then_some(membership as u32)
     }
 
-    /// `true` when the receive buffer still has room for another frame. Mirrors
-    /// the admission check in `deliver_from_iface` (rx.rs) so the ROLLOVER
-    /// fallback can skip a backlogged member identically.
+    pub(crate) fn fanout_group_id(&self) -> Option<u16> {
+        self.fanout_getsockopt_value().map(|value| value as u16)
+    }
+
     pub(super) fn rx_has_room(&self) -> bool {
         self.rx_buffer_bytes.load(Ordering::Acquire)
             < self.recv_buffer_bytes.load(Ordering::Relaxed)
     }
+}
+
+pub(crate) fn membership_value(group: &FanoutGroup) -> u32 {
+    u32::from(group.id) | ((group.mode.as_raw() | u32::from(group.flags)) << 16)
 }

--- a/kernel/src/net/socket/packet/fanout.rs
+++ b/kernel/src/net/socket/packet/fanout.rs
@@ -121,24 +121,17 @@ pub(crate) struct FanoutGroup {
 }
 
 impl FanoutGroup {
-    pub(crate) fn new(
-        id: u16,
-        mode: FanoutMode,
-        flags: u16,
-        sock_type: PacketSocketType,
-        bound_ifindex: u32,
-        bound_protocol: u16,
-    ) -> Arc<Self> {
+    pub(crate) fn new(id: u16, params: FanoutJoinParams) -> Arc<Self> {
         // A per-group random seed prevents flows from polarizing onto the same
         // member across groups that happen to share a hash function.
         let hash_seed = crate::arch::rand::rand() as u32;
         Arc::new(Self {
             id,
-            mode,
-            flags,
-            sock_type,
-            bound_ifindex,
-            bound_protocol,
+            mode: params.mode,
+            flags: params.flags,
+            sock_type: params.sock_type,
+            bound_ifindex: params.bound_ifindex,
+            bound_protocol: params.bound_protocol,
             hash_seed,
             members: RcuArcSlot::new(Arc::new(FanoutMemberSnapshot::default())),
             members_writer: Mutex::new(()),

--- a/kernel/src/net/socket/packet/fanout.rs
+++ b/kernel/src/net/socket/packet/fanout.rs
@@ -16,9 +16,9 @@ use jhash::jhash2;
 use crate::libs::mutex::Mutex;
 use crate::rcu::RcuArcSlot;
 
-use super::uapi::{fanout_flag, fanout_mode, eth_protocol};
-use super::{PacketIngressMetadata, PacketSocket, PacketSocketType};
 use super::rx::l2_ethertype_l3_offset;
+use super::uapi::{eth_protocol, fanout_flag, fanout_mode};
+use super::{PacketIngressMetadata, PacketSocket, PacketSocketType};
 
 const IPPROTO_TCP: u8 = 6;
 const IPPROTO_UDP: u8 = 17;
@@ -236,10 +236,7 @@ impl FanoutGroup {
 /// Upgrade the `target`-th live member (0-indexed among live entries) of a
 /// fanout snapshot. `strong_count()!=0` guarantees `upgrade()` succeeds, so
 /// this performs no heap allocation.
-fn nth_live_member(
-    members: &[Weak<PacketSocket>],
-    target: usize,
-) -> Option<Arc<PacketSocket>> {
+fn nth_live_member(members: &[Weak<PacketSocket>], target: usize) -> Option<Arc<PacketSocket>> {
     let mut seen = 0usize;
     for entry in members {
         if entry.strong_count() == 0 {
@@ -294,12 +291,8 @@ fn flow_hash(frame: &[u8], seed: u32) -> u32 {
         let mut src = [0u32; 4];
         let mut dst = [0u32; 4];
         for i in 0..4 {
-            src[i] = u32::from_be_bytes([
-                l3[8 + i * 4],
-                l3[9 + i * 4],
-                l3[10 + i * 4],
-                l3[11 + i * 4],
-            ]);
+            src[i] =
+                u32::from_be_bytes([l3[8 + i * 4], l3[9 + i * 4], l3[10 + i * 4], l3[11 + i * 4]]);
             dst[i] = u32::from_be_bytes([
                 l3[24 + i * 4],
                 l3[25 + i * 4],
@@ -309,7 +302,9 @@ fn flow_hash(frame: &[u8], seed: u32) -> u32 {
         }
         let next_header = l3[6];
         let (sp, dp) = l4_ports(&l3[40..], next_header);
-        let words = [src[0], src[1], src[2], src[3], dst[0], dst[1], dst[2], dst[3], sp as u32, dp as u32];
+        let words = [
+            src[0], src[1], src[2], src[3], dst[0], dst[1], dst[2], dst[3], sp as u32, dp as u32,
+        ];
         jhash2(&words, seed)
     } else {
         0
@@ -330,10 +325,10 @@ fn l4_ports(l4: &[u8], proto: u8) -> (u16, u16) {
 impl PacketSocket {
     /// `setsockopt(SOL_PACKET, PACKET_FANOUT, val)` entry point.
     ///
-    /// Parses the option value, validates mode/flags, refuses an already-joined
-    /// socket with `EBUSY`, then delegates the locked registry work to the
-    /// owning netns so that "publish member" and "set fanout field" happen
-    /// atomically under the netns writer lock.
+    /// Parses the option value, validates mode/flags, then delegates the
+    /// locked registry work — including the already-joined (`EBUSY`) check —
+    /// to the owning netns so that the check, "publish member", and "set
+    /// fanout field" all happen atomically under the netns writer lock.
     pub(crate) fn join_fanout(&self, val: i32) -> Result<(), SystemError> {
         let v = val as u32;
         let id_req = (v & 0xffff) as u16;
@@ -348,11 +343,6 @@ impl PacketSocket {
             fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER | fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID;
         if flags & !ALLOWED_FLAGS != 0 {
             return Err(SystemError::EINVAL);
-        }
-
-        // Already a member of some group.
-        if self.fanout.read().is_some() {
-            return Err(SystemError::EBUSY);
         }
 
         let unique = flags & fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID != 0;
@@ -377,16 +367,13 @@ impl PacketSocket {
 
     /// Leave the current fanout group (invoked from `close_binding`).
     ///
-    /// The fanout field is cleared first; the owning netns then removes the
-    /// socket from the group member list and tears the group down if it becomes
-    /// empty — both under the netns writer lock to close the leave/join TOCTOU
-    /// window.
+    /// Delegates entirely to the owning netns, which acquires
+    /// `fanout_groups_writer` *before* taking the socket's `fanout` write lock.
+    /// This keeps the lock order identical to the join path
+    /// (`fanout_groups_writer → fanout.write()`), avoiding the ABBA deadlock
+    /// that would arise if the leave path cleared `fanout` first.
     pub(crate) fn leave_fanout(&self) {
-        let Some(group) = self.fanout.write().take() else {
-            return;
-        };
-        self.fanout_active.store(false, Ordering::Release);
-        self.netns.fanout_group_leave(&group, &self.self_ref);
+        self.netns.fanout_group_leave(&self.self_ref);
     }
 
     /// `true` if this socket currently belongs to a fanout group. Used by the
@@ -401,6 +388,25 @@ impl PacketSocket {
     pub(crate) fn set_fanout_group(&self, group: Arc<FanoutGroup>) {
         *self.fanout.write() = Some(group);
         self.fanout_active.store(true, Ordering::Release);
+    }
+
+    /// Whether this socket currently holds a fanout group reference.
+    /// Checked by the netns join path under the `fanout_groups_writer` lock
+    /// for the already-joined (`EBUSY`) test.
+    pub(crate) fn has_fanout_group(&self) -> bool {
+        self.fanout.read().is_some()
+    }
+
+    /// Take and clear the fanout group membership, deactivating the socket.
+    /// Called by the netns leave path *after* acquiring `fanout_groups_writer`,
+    /// so the clear and the registry mutation share the same lock order as
+    /// the join path (`fanout_groups_writer → fanout.write()`).
+    pub(crate) fn clear_fanout_group(&self) -> Option<Arc<FanoutGroup>> {
+        let group = self.fanout.write().take();
+        if group.is_some() {
+            self.fanout_active.store(false, Ordering::Release);
+        }
+        group
     }
 
     /// Current fanout membership encoded as `(id | (type_flags << 16))`, or

--- a/kernel/src/net/socket/packet/fanout.rs
+++ b/kernel/src/net/socket/packet/fanout.rs
@@ -117,6 +117,13 @@ impl FanoutMember {
             },
         })
     }
+
+    #[inline]
+    fn active_socket(&self) -> Option<Arc<PacketSocket>> {
+        self.socket
+            .upgrade()
+            .filter(|socket| socket.is_packet_registry_active())
+    }
 }
 
 /// Immutable group snapshot stored inside the netns delivery topology.
@@ -223,7 +230,7 @@ impl FanoutGroup {
         self.try_with_members(members)
     }
 
-    /// Return a compacted replacement only when at least one dead Weak was
+    /// Return a compacted replacement when a dead or inactive member is
     /// observed. Healthy groups keep their original Arc and member Vec.
     pub(crate) fn try_without_dead_members(&self) -> Result<Option<Arc<Self>>, SystemError> {
         if self.members.iter().all(|member| {
@@ -268,8 +275,8 @@ impl FanoutGroup {
         .map_err(|_| SystemError::ENOMEM)
     }
 
-    /// Deliver to at most one member. Returns `true` when a dead weak member
-    /// was observed and the writer should compact the topology later.
+    /// Deliver to at most one member. Returns `true` when a dead or inactive
+    /// member was observed and the writer should compact the topology later.
     pub(crate) fn deliver(
         &self,
         ingress: PacketIngressMetadata,
@@ -327,7 +334,7 @@ impl FanoutGroup {
 
         let mut stale = false;
         if self.mode != FanoutMode::Rollover {
-            match self.members[base].socket.upgrade() {
+            match self.members[base].active_socket() {
                 Some(socket) if socket.rx_has_room() => {
                     socket.deliver(ingress, frame);
                     return false;
@@ -349,7 +356,7 @@ impl FanoutGroup {
             if self.mode != FanoutMode::Rollover && index == base {
                 continue;
             }
-            match self.members[index].socket.upgrade() {
+            match self.members[index].active_socket() {
                 Some(socket) if socket.rx_has_room() => {
                     if index != start {
                         state.cursor.store(index as u32, Ordering::Relaxed);
@@ -376,7 +383,7 @@ impl FanoutGroup {
         let mut stale = false;
         for offset in 0..self.members.len() {
             let index = (start + offset) % self.members.len();
-            if let Some(socket) = self.members[index].socket.upgrade() {
+            if let Some(socket) = self.members[index].active_socket() {
                 socket.deliver(ingress, frame);
                 return stale;
             }

--- a/kernel/src/net/socket/packet/fanout.rs
+++ b/kernel/src/net/socket/packet/fanout.rs
@@ -67,6 +67,27 @@ impl FanoutMode {
     }
 }
 
+/// Join-time parameter bundle for `NetNamespace::fanout_group_join`.
+///
+/// Grouping these values keeps that entry point under clippy's
+/// `too_many_arguments` threshold while letting the packet module hand the
+/// netns a single, self-describing value.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FanoutJoinParams {
+    /// Explicit group id requested by the socket (ignored when `unique`).
+    pub id_req: u16,
+    /// `true` for `PACKET_FANOUT_FLAG_UNIQUEID`: allocate a fresh group.
+    pub unique: bool,
+    /// Distribution algorithm for the group.
+    pub mode: FanoutMode,
+    /// Raw `PACKET_FANOUT_FLAG_*` bits requested by the creator.
+    pub flags: u16,
+    /// Joining socket's type / binding filter — enforced on every join.
+    pub sock_type: PacketSocketType,
+    pub bound_ifindex: u32,
+    pub bound_protocol: u16,
+}
+
 /// RCU-published member list of a fanout group (mirrors the broadcast
 /// `PacketSocketRegistrySnapshot` COW pattern).
 #[derive(Debug, Default)]
@@ -355,13 +376,15 @@ impl PacketSocket {
         let (bound_ifindex, bound_protocol) = self.binding.load();
         self.netns.fanout_group_join(
             &socket,
-            id_req,
-            unique,
-            mode,
-            flags,
-            sock_type,
-            bound_ifindex,
-            bound_protocol,
+            FanoutJoinParams {
+                id_req,
+                unique,
+                mode,
+                flags,
+                sock_type,
+                bound_ifindex,
+                bound_protocol,
+            },
         )
     }
 

--- a/kernel/src/net/socket/packet/fanout.rs
+++ b/kernel/src/net/socket/packet/fanout.rs
@@ -1,0 +1,422 @@
+//! AF_PACKET `PACKET_FANOUT` group demultiplexing.
+//!
+//! A fanout group fans matching ingress frames out to exactly one of its member
+//! sockets, selected by the group's distribution algorithm (HASH/LB/CPU/RND/
+//! ROLLOVER). Members are registered with the owning `NetNamespace` and use the
+//! same RCU copy-on-write publication pattern as the broadcast packet-socket
+//! registry, so the NAPI deliver path stays lock-free on the read side.
+
+use alloc::sync::{Arc, Weak};
+use alloc::vec::Vec;
+use core::sync::atomic::Ordering;
+use system_error::SystemError;
+
+use jhash::jhash2;
+
+use crate::libs::mutex::Mutex;
+use crate::rcu::RcuArcSlot;
+
+use super::uapi::{fanout_flag, fanout_mode, eth_protocol};
+use super::{PacketIngressMetadata, PacketSocket, PacketSocketType};
+use super::rx::l2_ethertype_l3_offset;
+
+const IPPROTO_TCP: u8 = 6;
+const IPPROTO_UDP: u8 = 17;
+
+/// Supported fanout distribution algorithms.
+///
+/// QM(5)/CBPF(6)/EBPF(7) require NIC RSS queue mapping / BPF infrastructure
+/// that DragonOS does not yet provide, so `FanoutMode::from_raw` rejects them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FanoutMode {
+    /// 0 — flow hash of the L3/L4 4-tuple modulo the member count.
+    Hash,
+    /// 1 — round-robin via an atomic counter.
+    Lb,
+    /// 2 — receiving CPU id modulo the member count.
+    Cpu,
+    /// 3 — start from the round-robin base and roll over filled members.
+    Rollover,
+    /// 4 — uniformly random member selection.
+    Rnd,
+}
+
+impl FanoutMode {
+    /// Parse the low 7 bits of `type_flags`. Returns `EINVAL` for unsupported
+    /// modes (QM/CBPF/EBPF).
+    fn from_raw(raw: u32) -> Result<Self, SystemError> {
+        match raw {
+            fanout_mode::PACKET_FANOUT_HASH => Ok(Self::Hash),
+            fanout_mode::PACKET_FANOUT_LB => Ok(Self::Lb),
+            fanout_mode::PACKET_FANOUT_CPU => Ok(Self::Cpu),
+            fanout_mode::PACKET_FANOUT_ROLLOVER => Ok(Self::Rollover),
+            fanout_mode::PACKET_FANOUT_RND => Ok(Self::Rnd),
+            // PACKET_FANOUT_QM / CBPF / EBPF are unsupported.
+            _ => Err(SystemError::EINVAL),
+        }
+    }
+
+    fn as_raw(self) -> u32 {
+        match self {
+            Self::Hash => fanout_mode::PACKET_FANOUT_HASH,
+            Self::Lb => fanout_mode::PACKET_FANOUT_LB,
+            Self::Cpu => fanout_mode::PACKET_FANOUT_CPU,
+            Self::Rollover => fanout_mode::PACKET_FANOUT_ROLLOVER,
+            Self::Rnd => fanout_mode::PACKET_FANOUT_RND,
+        }
+    }
+}
+
+/// RCU-published member list of a fanout group (mirrors the broadcast
+/// `PacketSocketRegistrySnapshot` COW pattern).
+#[derive(Debug, Default)]
+struct FanoutMemberSnapshot {
+    members: Vec<Weak<PacketSocket>>,
+}
+
+/// A fanout group: an ordered set of sockets sharing a distribution algorithm.
+///
+/// All members are guaranteed (at join time) to share the same socket type and
+/// `(ifindex, protocol)` receive filter, so any demux choice yields identical
+/// `deliver_from_iface` filtering.
+#[derive(Debug)]
+pub(crate) struct FanoutGroup {
+    pub id: u16,
+    pub mode: FanoutMode,
+    /// Raw `PACKET_FANOUT_FLAG_*` bits requested by the creator.
+    pub flags: u16,
+    /// Creator's socket type / binding filter — enforced on every join.
+    sock_type: PacketSocketType,
+    bound_ifindex: u32,
+    bound_protocol: u16,
+    /// Random HASH-mode seed to avoid flow polarization across groups.
+    hash_seed: u32,
+    /// Member list, RCU COW (mirrors `NetNamespace::packet_sockets`).
+    members: RcuArcSlot<FanoutMemberSnapshot>,
+    /// Serializes copy-on-write member-list updates.
+    members_writer: Mutex<()>,
+    /// LB / ROLLOVER round-robin counter (atomic, multi-core safe).
+    rr_counter: core::sync::atomic::AtomicU32,
+}
+
+impl FanoutGroup {
+    pub(crate) fn new(
+        id: u16,
+        mode: FanoutMode,
+        flags: u16,
+        sock_type: PacketSocketType,
+        bound_ifindex: u32,
+        bound_protocol: u16,
+    ) -> Arc<Self> {
+        // A per-group random seed prevents flows from polarizing onto the same
+        // member across groups that happen to share a hash function.
+        let hash_seed = crate::arch::rand::rand() as u32;
+        Arc::new(Self {
+            id,
+            mode,
+            flags,
+            sock_type,
+            bound_ifindex,
+            bound_protocol,
+            hash_seed,
+            members: RcuArcSlot::new(Arc::new(FanoutMemberSnapshot::default())),
+            members_writer: Mutex::new(()),
+            rr_counter: core::sync::atomic::AtomicU32::new(0),
+        })
+    }
+
+    /// Whether a joining socket matches this group's creator profile.
+    pub(crate) fn matches(
+        &self,
+        sock_type: PacketSocketType,
+        bound_ifindex: u32,
+        bound_protocol: u16,
+    ) -> bool {
+        self.sock_type == sock_type
+            && self.bound_ifindex == bound_ifindex
+            && self.bound_protocol == bound_protocol
+    }
+
+    /// Publish a new member-list snapshot containing `socket` (RCU COW).
+    pub(crate) fn add_member(&self, socket: Weak<PacketSocket>) {
+        let _guard = self.members_writer.lock();
+        let current = self.members.load();
+        let mut members = current.members.clone();
+        // Drop already-dead weak refs while we hold the write-side clone.
+        members.retain(|entry| entry.strong_count() != 0);
+        if !members.iter().any(|entry| Weak::ptr_eq(entry, &socket)) {
+            members.push(socket);
+        }
+        self.members
+            .store_deferred(Arc::new(FanoutMemberSnapshot { members }));
+    }
+
+    /// Publish a new member-list snapshot without `socket` (RCU COW).
+    pub(crate) fn remove_member(&self, socket: &Weak<PacketSocket>) {
+        let _guard = self.members_writer.lock();
+        let current = self.members.load();
+        let mut members = current.members.clone();
+        members.retain(|entry| entry.strong_count() != 0 && !Weak::ptr_eq(entry, socket));
+        self.members
+            .store_deferred(Arc::new(FanoutMemberSnapshot { members }));
+    }
+
+    /// Count live members. Called only under the netns `fanout_groups_writer`
+    /// lock, which blocks concurrent `add_member`/`remove_member`, so the RCU
+    /// snapshot read here is stable for the empty-group teardown decision.
+    pub(crate) fn live_count(&self) -> usize {
+        let current = self.members.load();
+        current
+            .members
+            .iter()
+            .filter(|entry| entry.strong_count() != 0)
+            .count()
+    }
+
+    /// Deliver one copy of the frame to a single member selected by the
+    /// distribution algorithm. Returns `true` when the member list contained
+    /// dead weak refs (lazy cleanup hint for the netns).
+    pub(crate) fn deliver(
+        &self,
+        ingress: PacketIngressMetadata,
+        frame: &[u8],
+    ) -> bool {
+        let snapshot = self.members.load();
+
+        // First pass: count live members without any heap allocation.
+        let mut stale = false;
+        let mut live_count = 0usize;
+        for entry in snapshot.members.iter() {
+            if entry.strong_count() != 0 {
+                live_count += 1;
+            } else {
+                stale = true;
+            }
+        }
+        if live_count == 0 {
+            return stale;
+        }
+
+        let base = match self.mode {
+            FanoutMode::Hash => flow_hash(frame, self.hash_seed) as usize % live_count,
+            FanoutMode::Lb | FanoutMode::Rollover => {
+                self.rr_counter.fetch_add(1, Ordering::Relaxed) as usize % live_count
+            }
+            FanoutMode::Cpu => crate::arch::cpu::current_cpu_id().data() as usize % live_count,
+            FanoutMode::Rnd => crate::arch::rand::rand() % live_count,
+        };
+        // ROLLOVER semantics: mode == Rollover always rolls over filled
+        // backlogs; FLAG_ROLLOVER layers the same fallback onto other modes.
+        let rollover = self.mode == FanoutMode::Rollover
+            || (self.flags & fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER != 0);
+
+        // Second pass: find and deliver to the selected socket, rolling over
+        // filled backlogs. Each candidate is upgraded lazily —
+        // strong_count()!=0 guarantees upgrade() succeeds, so no heap
+        // allocation occurs.
+        for offset in 0..live_count {
+            let target = (base + offset) % live_count;
+            let Some(socket) = nth_live_member(&snapshot.members, target) else {
+                continue;
+            };
+            if !rollover || socket.rx_has_room() {
+                socket.deliver(ingress, frame);
+                return stale;
+            }
+        }
+        // All members full (only reachable on the rollover path): hand the
+        // frame to `base` so `deliver_from_iface` records the drop statistic.
+        if let Some(socket) = nth_live_member(&snapshot.members, base) {
+            socket.deliver(ingress, frame);
+        }
+        stale
+    }
+}
+
+/// Upgrade the `target`-th live member (0-indexed among live entries) of a
+/// fanout snapshot. `strong_count()!=0` guarantees `upgrade()` succeeds, so
+/// this performs no heap allocation.
+fn nth_live_member(
+    members: &[Weak<PacketSocket>],
+    target: usize,
+) -> Option<Arc<PacketSocket>> {
+    let mut seen = 0usize;
+    for entry in members {
+        if entry.strong_count() == 0 {
+            continue;
+        }
+        if seen == target {
+            return entry.upgrade();
+        }
+        seen += 1;
+    }
+    None
+}
+
+/// Compute a flow hash over the L3/L4 4-tuple for HASH-mode demux.
+///
+/// Non-IP frames hash to 0 (all land on the base member — degraded but
+/// lossless). VLAN tags are skipped so tagged and untagged frames of the same
+/// flow hash identically.
+fn flow_hash(frame: &[u8], seed: u32) -> u32 {
+    let Some((ether, l3_off)) = l2_ethertype_l3_offset(frame) else {
+        return 0;
+    };
+    let l3 = if frame.len() > l3_off {
+        &frame[l3_off..]
+    } else {
+        return 0;
+    };
+
+    if ether == eth_protocol::ETH_P_IP {
+        // IPv4
+        if l3.len() < 20 {
+            return 0;
+        }
+        if l3[0] >> 4 != 4 {
+            return 0;
+        }
+        let ihl = (l3[0] as usize & 0xf) * 4;
+        if ihl < 20 || l3.len() < ihl {
+            return 0;
+        }
+        let src = u32::from_be_bytes([l3[12], l3[13], l3[14], l3[15]]);
+        let dst = u32::from_be_bytes([l3[16], l3[17], l3[18], l3[19]]);
+        let proto = l3[9];
+        let (sp, dp) = l4_ports(&l3[ihl..], proto);
+        let words = [src, dst, sp as u32, dp as u32];
+        jhash2(&words, seed)
+    } else if ether == eth_protocol::ETH_P_IPV6 {
+        // IPv6
+        if l3.len() < 40 {
+            return 0;
+        }
+        let mut src = [0u32; 4];
+        let mut dst = [0u32; 4];
+        for i in 0..4 {
+            src[i] = u32::from_be_bytes([
+                l3[8 + i * 4],
+                l3[9 + i * 4],
+                l3[10 + i * 4],
+                l3[11 + i * 4],
+            ]);
+            dst[i] = u32::from_be_bytes([
+                l3[24 + i * 4],
+                l3[25 + i * 4],
+                l3[26 + i * 4],
+                l3[27 + i * 4],
+            ]);
+        }
+        let next_header = l3[6];
+        let (sp, dp) = l4_ports(&l3[40..], next_header);
+        let words = [src[0], src[1], src[2], src[3], dst[0], dst[1], dst[2], dst[3], sp as u32, dp as u32];
+        jhash2(&words, seed)
+    } else {
+        0
+    }
+}
+
+/// Extract the source/destination ports from an L4 segment for TCP/UDP.
+fn l4_ports(l4: &[u8], proto: u8) -> (u16, u16) {
+    if (proto == IPPROTO_TCP || proto == IPPROTO_UDP) && l4.len() >= 4 {
+        let sp = u16::from_be_bytes([l4[0], l4[1]]);
+        let dp = u16::from_be_bytes([l4[2], l4[3]]);
+        (sp, dp)
+    } else {
+        (0, 0)
+    }
+}
+
+impl PacketSocket {
+    /// `setsockopt(SOL_PACKET, PACKET_FANOUT, val)` entry point.
+    ///
+    /// Parses the option value, validates mode/flags, refuses an already-joined
+    /// socket with `EBUSY`, then delegates the locked registry work to the
+    /// owning netns so that "publish member" and "set fanout field" happen
+    /// atomically under the netns writer lock.
+    pub(crate) fn join_fanout(&self, val: i32) -> Result<(), SystemError> {
+        let v = val as u32;
+        let id_req = (v & 0xffff) as u16;
+        let type_flags = v >> 16;
+        let mode = FanoutMode::from_raw(type_flags & 0x7f)?;
+        let flags = (type_flags & !0x7f) as u16;
+
+        // Only ROLLOVER and UNIQUEID flags are supported. DEFRAG/IGNORE_OUTGOING
+        // need infrastructure DragonOS lacks; reject explicitly rather than
+        // silently ignoring them.
+        const ALLOWED_FLAGS: u16 =
+            fanout_flag::PACKET_FANOUT_FLAG_ROLLOVER | fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID;
+        if flags & !ALLOWED_FLAGS != 0 {
+            return Err(SystemError::EINVAL);
+        }
+
+        // Already a member of some group.
+        if self.fanout.read().is_some() {
+            return Err(SystemError::EBUSY);
+        }
+
+        let unique = flags & fanout_flag::PACKET_FANOUT_FLAG_UNIQUEID != 0;
+        let Some(socket) = self.self_ref.upgrade() else {
+            return Err(SystemError::EINVAL);
+        };
+        // Extract the join profile here (inside the packet module, where the
+        // fields are visible) and hand the values to the netns.
+        let sock_type = self.sock_type;
+        let (bound_ifindex, bound_protocol) = self.binding.load();
+        self.netns.fanout_group_join(
+            &socket,
+            id_req,
+            unique,
+            mode,
+            flags,
+            sock_type,
+            bound_ifindex,
+            bound_protocol,
+        )
+    }
+
+    /// Leave the current fanout group (invoked from `close_binding`).
+    ///
+    /// The fanout field is cleared first; the owning netns then removes the
+    /// socket from the group member list and tears the group down if it becomes
+    /// empty — both under the netns writer lock to close the leave/join TOCTOU
+    /// window.
+    pub(crate) fn leave_fanout(&self) {
+        let Some(group) = self.fanout.write().take() else {
+            return;
+        };
+        self.fanout_active.store(false, Ordering::Release);
+        self.netns.fanout_group_leave(&group, &self.self_ref);
+    }
+
+    /// `true` if this socket currently belongs to a fanout group. Used by the
+    /// broadcast deliver path to skip sockets handled by their group.
+    pub(crate) fn is_fanout_member(&self) -> bool {
+        self.fanout_active.load(Ordering::Acquire)
+    }
+
+    /// Record group membership. Called by the netns join path while it holds
+    /// the `fanout_groups_writer` lock, so member publication and field update
+    /// are atomic from a concurrent join/leave viewpoint.
+    pub(crate) fn set_fanout_group(&self, group: Arc<FanoutGroup>) {
+        *self.fanout.write() = Some(group);
+        self.fanout_active.store(true, Ordering::Release);
+    }
+
+    /// Current fanout membership encoded as `(id | (type_flags << 16))`, or
+    /// `None` if the socket has not joined a group.
+    pub(crate) fn fanout_getsockopt_value(&self) -> Option<u32> {
+        let group = self.fanout.read();
+        let group = group.as_ref()?;
+        let type_flags = group.mode.as_raw() | group.flags as u32;
+        Some(group.id as u32 | (type_flags << 16))
+    }
+
+    /// `true` when the receive buffer still has room for another frame. Mirrors
+    /// the admission check in `deliver_from_iface` (rx.rs) so the ROLLOVER
+    /// fallback can skip a backlogged member identically.
+    pub(super) fn rx_has_room(&self) -> bool {
+        self.rx_buffer_bytes.load(Ordering::Acquire)
+            < self.recv_buffer_bytes.load(Ordering::Relaxed)
+    }
+}

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -1,6 +1,6 @@
 //! AF_PACKET sockets.
-
 mod binding;
+mod fanout;
 mod mreq;
 mod rx;
 mod sockopt;
@@ -28,9 +28,10 @@ use crate::rcu::RcuOptionArcSlot;
 
 #[allow(unused_imports)]
 pub use uapi::{
-    eth_protocol, packet_mreq_type, packet_option, PacketMreq, PacketType, SockAddrLl,
-    TpacketAuxdata,
+    eth_protocol, fanout_flag, fanout_mode, packet_mreq_type, packet_option, PacketMreq,
+    PacketType, SockAddrLl, TpacketAuxdata,
 };
+pub(crate) use fanout::{FanoutGroup, FanoutMode};
 
 const DEFAULT_RX_BUFFER_SIZE: usize = 256 * 1024;
 const DEFAULT_TX_BUFFER_SIZE: usize = 256 * 1024;
@@ -119,6 +120,9 @@ pub struct PacketSocket {
     pub(super) filter: RcuOptionArcSlot<Vec<SockFilter>>,
     /// Serializes SO_ATTACH_FILTER, SO_DETACH_FILTER, and SO_LOCK_FILTER.
     pub(super) filter_locked: Mutex<bool>,
+    /// Fanout group membership (`None` for a plain broadcast socket).
+    pub(super) fanout: RwSem<Option<Arc<FanoutGroup>>>,
+    pub(super) fanout_active: AtomicBool,
     epoll_items: EPollItems,
     fasync_items: FAsyncItems,
 }
@@ -158,6 +162,8 @@ impl PacketSocket {
             open_files: AtomicUsize::new(0),
             self_ref: me.clone(),
             netns,
+            fanout: RwSem::new(None),
+            fanout_active: AtomicBool::new(false),
             epoll_items: EPollItems::default(),
             filter: RcuOptionArcSlot::new_none(),
             filter_locked: Mutex::new(false),

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -26,12 +26,12 @@ use crate::process::namespace::net_namespace::NetNamespace;
 use crate::process::ProcessManager;
 use crate::rcu::RcuOptionArcSlot;
 
+pub(crate) use fanout::{FanoutGroup, FanoutMode};
 #[allow(unused_imports)]
 pub use uapi::{
     eth_protocol, fanout_flag, fanout_mode, packet_mreq_type, packet_option, PacketMreq,
     PacketType, SockAddrLl, TpacketAuxdata,
 };
-pub(crate) use fanout::{FanoutGroup, FanoutMode};
 
 const DEFAULT_RX_BUFFER_SIZE: usize = 256 * 1024;
 const DEFAULT_TX_BUFFER_SIZE: usize = 256 * 1024;

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -26,7 +26,7 @@ use crate::process::namespace::net_namespace::NetNamespace;
 use crate::process::ProcessManager;
 use crate::rcu::RcuOptionArcSlot;
 
-pub(crate) use fanout::{FanoutGroup, FanoutMode};
+pub(crate) use fanout::{FanoutGroup, FanoutJoinParams};
 #[allow(unused_imports)]
 pub use uapi::{
     eth_protocol, fanout_flag, fanout_mode, packet_mreq_type, packet_option, PacketMreq,

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -26,7 +26,7 @@ use crate::process::namespace::net_namespace::NetNamespace;
 use crate::process::ProcessManager;
 use crate::rcu::RcuOptionArcSlot;
 
-pub(crate) use fanout::{FanoutGroup, FanoutJoinParams};
+pub(crate) use fanout::{membership_value, FanoutGroup, FanoutJoinParams};
 #[allow(unused_imports)]
 pub use uapi::{
     eth_protocol, fanout_flag, fanout_mode, packet_mreq_type, packet_option, PacketMreq,
@@ -120,9 +120,12 @@ pub struct PacketSocket {
     pub(super) filter: RcuOptionArcSlot<Vec<SockFilter>>,
     /// Serializes SO_ATTACH_FILTER, SO_DETACH_FILTER, and SO_LOCK_FILTER.
     pub(super) filter_locked: Mutex<bool>,
-    /// Fanout group membership (`None` for a plain broadcast socket).
-    pub(super) fanout: RwSem<Option<Arc<FanoutGroup>>>,
-    pub(super) fanout_active: AtomicBool,
+    /// Control-plane PACKET_FANOUT state: bit 32 marks active membership and
+    /// the low 32 bits are the Linux getsockopt encoding.
+    pub(super) fanout_membership: AtomicU64,
+    /// Writer/cleanup lifecycle marker. The NAPI delivery path relies solely
+    /// on the immutable topology and does not read this control-plane bit.
+    registry_active: AtomicBool,
     epoll_items: EPollItems,
     fasync_items: FAsyncItems,
 }
@@ -162,18 +165,28 @@ impl PacketSocket {
             open_files: AtomicUsize::new(0),
             self_ref: me.clone(),
             netns,
-            fanout: RwSem::new(None),
-            fanout_active: AtomicBool::new(false),
+            fanout_membership: AtomicU64::new(0),
+            registry_active: AtomicBool::new(true),
             epoll_items: EPollItems::default(),
             filter: RcuOptionArcSlot::new_none(),
             filter_locked: Mutex::new(false),
             fasync_items: FAsyncItems::default(),
         });
-        socket.netns.register_packet_socket(socket.self_ref.clone());
+        socket
+            .netns
+            .register_packet_socket(socket.self_ref.clone())?;
         Ok(socket)
     }
     pub fn is_nonblock(&self) -> bool {
         self.nonblock.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn is_packet_registry_active(&self) -> bool {
+        self.registry_active.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn deactivate_packet_registry(&self) {
+        self.registry_active.store(false, Ordering::Release);
     }
     /// Returns the configured receive timeout in scheduler ticks, or None for infinite wait.
     pub(super) fn recv_timeout_ticks(&self) -> Option<u64> {

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -123,8 +123,8 @@ pub struct PacketSocket {
     /// Control-plane PACKET_FANOUT state: bit 32 marks active membership and
     /// the low 32 bits are the Linux getsockopt encoding.
     pub(super) fanout_membership: AtomicU64,
-    /// Writer/cleanup lifecycle marker. The NAPI delivery path relies solely
-    /// on the immutable topology and does not read this control-plane bit.
+    /// Writer/cleanup lifecycle marker. The NAPI delivery path uses this bit
+    /// to reject inactive entries retained by an older topology snapshot.
     registry_active: AtomicBool,
     epoll_items: EPollItems,
     fasync_items: FAsyncItems,

--- a/kernel/src/net/socket/packet/rx.rs
+++ b/kernel/src/net/socket/packet/rx.rs
@@ -743,6 +743,20 @@ fn parse_frame(frame: &[u8]) -> Option<ParsedFrame> {
     })
 }
 
+/// Protocol as observed by the AF_PACKET hook. Incoming VLAN frames expose
+/// the inner protocol after VLAN normalization; outgoing taps retain the
+/// inline VLAN header and therefore expose the outer TPID.
+pub(crate) fn packet_protocol(frame: &[u8], pkt_type: PacketType) -> Option<u16> {
+    let parsed = parse_frame(frame)?;
+    Some(
+        if parsed.vlan.is_some() && pkt_type != PacketType::Outgoing {
+            parsed.protocol
+        } else {
+            parsed.vlan.map_or(parsed.protocol, |(_, tpid)| tpid)
+        },
+    )
+}
+
 impl PacketSocket {
     pub(super) fn deliver_from_iface(&self, ingress: PacketIngressMetadata, frame: &[u8]) {
         let (bound_ifindex, bound_protocol) = self.binding.load();

--- a/kernel/src/net/socket/packet/rx.rs
+++ b/kernel/src/net/socket/packet/rx.rs
@@ -701,33 +701,46 @@ impl ClassicBpfInput for PacketFilterInput<'_> {
     }
 }
 
+/// Parse the L3 ethertype and its byte offset within an Ethernet-II frame.
+///
+/// Handles 802.1Q (0x8100) and 802.1ad (0x88a8) VLAN tags by skipping the
+/// 4-byte tag to read the inner ethertype. Returns `None` if the frame is
+/// too short for a valid header.
+pub(super) fn l2_ethertype_l3_offset(frame: &[u8]) -> Option<(u16, usize)> {
+    if frame.len() < 14 {
+        return None;
+    }
+    let outer = u16::from_be_bytes([frame[12], frame[13]]);
+    if outer == 0x8100 || outer == 0x88a8 {
+        if frame.len() < 18 {
+            return None;
+        }
+        Some((u16::from_be_bytes([frame[16], frame[17]]), 18))
+    } else {
+        Some((outer, 14))
+    }
+}
+
 fn parse_frame(frame: &[u8]) -> Option<ParsedFrame> {
     if frame.len() < 14 {
         return None;
     }
     let dst = frame[0..6].try_into().ok()?;
     let src = frame[6..12].try_into().ok()?;
-    let outer = u16::from_be_bytes([frame[12], frame[13]]);
-    if outer == 0x8100 || outer == 0x88a8 {
-        if frame.len() < 18 {
-            return None;
-        }
+    let (protocol, l3_off) = l2_ethertype_l3_offset(frame)?;
+    let vlan = if l3_off == 18 {
         let tci = u16::from_be_bytes([frame[14], frame[15]]);
-        let protocol = u16::from_be_bytes([frame[16], frame[17]]);
-        Some(ParsedFrame {
-            dst,
-            src,
-            protocol,
-            vlan: Some((tci, outer)),
-        })
+        let tpid = u16::from_be_bytes([frame[12], frame[13]]);
+        Some((tci, tpid))
     } else {
-        Some(ParsedFrame {
-            dst,
-            src,
-            protocol: outer,
-            vlan: None,
-        })
-    }
+        None
+    };
+    Some(ParsedFrame {
+        dst,
+        src,
+        protocol,
+        vlan,
+    })
 }
 
 impl PacketSocket {

--- a/kernel/src/net/socket/packet/sockopt.rs
+++ b/kernel/src/net/socket/packet/sockopt.rs
@@ -51,6 +51,11 @@ impl PacketSocket {
                     value,
                     self.options.read().auxdata as i32,
                 )),
+                packet_option::PACKET_FANOUT => {
+                    // Linux packet_getsockopt: an unjoined socket reports 0.
+                    let val = self.fanout_getsockopt_value().unwrap_or(0) as i32;
+                    Ok(write_i32_getsockopt(value, val))
+                }
                 _ => Err(SystemError::ENOPROTOOPT),
             },
             _ => Err(SystemError::ENOPROTOOPT),
@@ -71,6 +76,7 @@ impl PacketSocket {
                     self.options.write().auxdata = Self::parse_i32(value)? != 0;
                     Ok(())
                 }
+                packet_option::PACKET_FANOUT => self.join_fanout(Self::parse_i32(value)?),
                 _ => Ok(()),
             },
             // Preserve backward compatibility: unknown levels are silently accepted.

--- a/kernel/src/net/socket/packet/sockopt.rs
+++ b/kernel/src/net/socket/packet/sockopt.rs
@@ -28,6 +28,23 @@ impl PacketSocket {
         }
         Ok(i32::from_ne_bytes(value[..4].try_into().unwrap()))
     }
+
+    fn parse_fanout(value: &[u8]) -> Result<(u32, u32), SystemError> {
+        if value.len() != core::mem::size_of::<u32>()
+            && value.len() != 2 * core::mem::size_of::<u32>()
+        {
+            return Err(SystemError::EINVAL);
+        }
+        // Linux lays out the first four bytes so that native u32 decoding is
+        // always `id | type_flags << 16`, including big-endian targets.
+        let raw = u32::from_ne_bytes(value[..4].try_into().unwrap());
+        let max_num_members = if value.len() == 8 {
+            u32::from_ne_bytes(value[4..8].try_into().unwrap())
+        } else {
+            0
+        };
+        Ok((raw, max_num_members))
+    }
     pub(super) fn packet_option(
         &self,
         level: PSOL,
@@ -76,7 +93,11 @@ impl PacketSocket {
                     self.options.write().auxdata = Self::parse_i32(value)? != 0;
                     Ok(())
                 }
-                packet_option::PACKET_FANOUT => self.join_fanout(Self::parse_i32(value)?),
+                packet_option::PACKET_FANOUT => {
+                    let (raw, max_num_members) = Self::parse_fanout(value)?;
+                    self.join_fanout(raw, max_num_members)
+                }
+                packet_option::PACKET_FANOUT_DATA => Err(SystemError::EINVAL),
                 _ => Ok(()),
             },
             // Preserve backward compatibility: unknown levels are silently accepted.

--- a/kernel/src/net/socket/packet/uapi.rs
+++ b/kernel/src/net/socket/packet/uapi.rs
@@ -17,8 +17,27 @@ pub mod packet_option {
     pub const PACKET_RESERVE: usize = 12;
     pub const PACKET_VNET_HDR: usize = 15;
     pub const PACKET_TX_TIMESTAMP: usize = 16;
-    pub const PACKET_TIMESTAMP: usize = 17;
     pub const PACKET_QDISC_BYPASS: usize = 20;
+    pub const PACKET_FANOUT: usize = 18;
+    pub const PACKET_FANOUT_DATA: usize = 22;
+}
+#[allow(dead_code)]
+pub mod fanout_mode {
+    pub const PACKET_FANOUT_HASH: u32 = 0;
+    pub const PACKET_FANOUT_LB: u32 = 1;
+    pub const PACKET_FANOUT_CPU: u32 = 2;
+    pub const PACKET_FANOUT_ROLLOVER: u32 = 3;
+    pub const PACKET_FANOUT_RND: u32 = 4;
+    pub const PACKET_FANOUT_QM: u32 = 5;
+    pub const PACKET_FANOUT_CBPF: u32 = 6;
+    pub const PACKET_FANOUT_EBPF: u32 = 7;
+}
+#[allow(dead_code)]
+pub mod fanout_flag {
+    pub const PACKET_FANOUT_FLAG_ROLLOVER: u16 = 0x1000;
+    pub const PACKET_FANOUT_FLAG_UNIQUEID: u16 = 0x2000;
+    pub const PACKET_FANOUT_FLAG_IGNORE_OUTGOING: u16 = 0x4000;
+    pub const PACKET_FANOUT_FLAG_DEFRAG: u16 = 0x8000;
 }
 #[allow(dead_code)]
 pub mod packet_mreq_type {

--- a/kernel/src/net/socket/packet/uapi.rs
+++ b/kernel/src/net/socket/packet/uapi.rs
@@ -17,6 +17,7 @@ pub mod packet_option {
     pub const PACKET_RESERVE: usize = 12;
     pub const PACKET_VNET_HDR: usize = 15;
     pub const PACKET_TX_TIMESTAMP: usize = 16;
+    pub const PACKET_TIMESTAMP: usize = 17;
     pub const PACKET_QDISC_BYPASS: usize = 20;
     pub const PACKET_FANOUT: usize = 18;
     pub const PACKET_FANOUT_DATA: usize = 22;

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -541,8 +541,10 @@ impl NetNamespace {
         bound_ifindex: u32,
         bound_protocol: u16,
     ) -> Result<(), SystemError> {
-
         let mut writer = self.fanout_groups_writer.lock();
+        if socket.has_fanout_group() {
+            return Err(SystemError::EBUSY);
+        }
         let group: Arc<FanoutGroup> = if unique {
             // UNIQUEID always creates a fresh group with a kernel-assigned id;
             // it cannot attach to an existing group.
@@ -571,11 +573,7 @@ impl NetNamespace {
                 None => {
                     // Reserve the explicit id in the allocator so a later
                     // UNIQUEID allocation cannot collide with it.
-                    if writer
-                        .id_alloc
-                        .alloc_specific(id_req as usize)
-                        .is_none()
-                    {
+                    if writer.id_alloc.alloc_specific(id_req as usize).is_none() {
                         return Err(SystemError::EINVAL);
                     }
                     let group = FanoutGroup::new(
@@ -606,15 +604,21 @@ impl NetNamespace {
     }
 
     /// Remove `socket` from its fanout group, tearing the group down if it
-    /// becomes empty. The empty-check and `by_id`/id-allocator removal run
-    /// together under `fanout_groups_writer` so a concurrent join cannot
-    /// resurrect a zombie group.
-    pub(crate) fn fanout_group_leave(
-        &self,
-        group: &Arc<FanoutGroup>,
-        socket: &Weak<PacketSocket>,
-    ) {
+    /// becomes empty. The socket's `fanout` field is cleared *after* acquiring
+    /// `fanout_groups_writer`, keeping the lock order identical to the join
+    /// path (`fanout_groups_writer → fanout.write()`) and avoiding the ABBA
+    /// deadlock. The empty-check and `by_id`/id-allocator removal also run
+    /// under the same lock so a concurrent join cannot resurrect a zombie group.
+    pub(crate) fn fanout_group_leave(&self, socket: &Weak<PacketSocket>) {
         let mut writer = self.fanout_groups_writer.lock();
+        // Clear the socket's fanout membership under the writer lock so the
+        // lock order is fanout_groups_writer → fanout.write() — matching join.
+        let Some(socket_arc) = socket.upgrade() else {
+            return;
+        };
+        let Some(group) = socket_arc.clear_fanout_group() else {
+            return;
+        };
         group.remove_member(socket);
         if group.live_count() == 0 {
             writer.by_id.remove(&group.id);

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -10,7 +10,7 @@ use crate::net::socket::netlink::table::{
     generate_supported_netlink_kernel_sockets, NetlinkKernelSocket, NetlinkSocketTable,
 };
 use crate::net::socket::packet::{
-    FanoutGroup, FanoutJoinParams, PacketIngressMetadata, PacketSocket,
+    membership_value, FanoutGroup, FanoutJoinParams, PacketIngressMetadata, PacketSocket,
 };
 use crate::net::socket::unix::ns::UnixAbstractTable;
 use crate::process::fork::CloneFlags;
@@ -84,14 +84,9 @@ pub struct NetNamespace {
     device_list: RwSem<BTreeMap<usize, Arc<dyn Iface>>>,
     /// Lock-free read-side snapshot for AF_PACKET delivery from NAPI context.
     packet_sockets: RcuArcSlot<PacketSocketRegistrySnapshot>,
-    /// Serializes copy-on-write registry updates in process context.
-    packet_sockets_writer: Mutex<()>,
+    /// Serializes all plain/fanout topology updates and owns group IDs.
+    packet_sockets_writer: Mutex<PacketSocketRegistryWriter>,
     packet_sockets_need_cleanup: AtomicBool,
-    /// Lock-free read-side snapshot of AF_PACKET fanout groups for delivery.
-    fanout_groups: RcuArcSlot<FanoutGroupRegistry>,
-    /// Serializes fanout group registry updates and protects the id allocator.
-    fanout_groups_writer: Mutex<FanoutGroupWriter>,
-    fanout_groups_need_cleanup: AtomicBool,
     ///当前网络命名空间下的桥接设备列表
     bridge_list: RwSem<BTreeMap<String, Arc<BridgeDriver>>>,
 
@@ -116,27 +111,24 @@ pub struct NetNamespace {
 #[derive(Debug, Default)]
 struct PacketSocketRegistrySnapshot {
     sockets: Vec<Weak<PacketSocket>>,
-}
-
-#[derive(Debug, Default)]
-struct FanoutGroupRegistry {
     groups: Vec<Arc<FanoutGroup>>,
+    live_receiver_count: usize,
 }
 
 #[derive(Debug)]
-struct FanoutGroupWriter {
+struct PacketSocketRegistryWriter {
     /// Authoritative `group id -> group` index used by the write path.
-    by_id: BTreeMap<u16, Arc<FanoutGroup>>,
+    by_id: HashMap<u16, Arc<FanoutGroup>>,
     /// Group id allocator. Reserves both UNIQUEID-allocated ids and explicit
     /// ids so the two namespaces can never collide.
     id_alloc: IdAllocator,
 }
 
-impl FanoutGroupWriter {
+impl PacketSocketRegistryWriter {
     fn new() -> Self {
         // Group ids occupy the full u16 range; 0 is a valid explicit id.
         Self {
-            by_id: BTreeMap::new(),
+            by_id: HashMap::new(),
             id_alloc: IdAllocator::new(0, u16::MAX as usize + 1)
                 .expect("fanout group id allocator"),
         }
@@ -237,7 +229,6 @@ impl NetnsPoller {
 
             let nsid = netns.ns_common.nsid.data();
             netns.cleanup_packet_sockets();
-            netns.cleanup_fanout_groups();
             let now_us = Instant::now().total_micros() as u64;
 
             // 处理“已到期的定时事件”：到期则 schedule NAPI 推进一次。
@@ -347,11 +338,8 @@ impl NetNamespace {
             poller: NetnsPoller::new(self_ref.clone()),
             device_list: RwSem::new(BTreeMap::new()),
             packet_sockets: RcuArcSlot::new(Arc::new(PacketSocketRegistrySnapshot::default())),
-            packet_sockets_writer: Mutex::new(()),
+            packet_sockets_writer: Mutex::new(PacketSocketRegistryWriter::new()),
             packet_sockets_need_cleanup: AtomicBool::new(false),
-            fanout_groups: RcuArcSlot::new(Arc::new(FanoutGroupRegistry::default())),
-            fanout_groups_writer: Mutex::new(FanoutGroupWriter::new()),
-            fanout_groups_need_cleanup: AtomicBool::new(false),
             bridge_list: RwSem::new(BTreeMap::new()),
             netlink_socket_table: NetlinkSocketTable::default(),
             netlink_kernel_socket: RwSem::new(generate_supported_netlink_kernel_sockets()),
@@ -389,11 +377,8 @@ impl NetNamespace {
             poller: NetnsPoller::new(self_ref.clone()),
             device_list: RwSem::new(BTreeMap::new()),
             packet_sockets: RcuArcSlot::new(Arc::new(PacketSocketRegistrySnapshot::default())),
-            packet_sockets_writer: Mutex::new(()),
+            packet_sockets_writer: Mutex::new(PacketSocketRegistryWriter::new()),
             packet_sockets_need_cleanup: AtomicBool::new(false),
-            fanout_groups: RcuArcSlot::new(Arc::new(FanoutGroupRegistry::default())),
-            fanout_groups_writer: Mutex::new(FanoutGroupWriter::new()),
-            fanout_groups_need_cleanup: AtomicBool::new(false),
             bridge_list: RwSem::new(BTreeMap::new()),
             netlink_socket_table: NetlinkSocketTable::default(),
             netlink_kernel_socket: RwSem::new(generate_supported_netlink_kernel_sockets()),
@@ -438,29 +423,71 @@ impl NetNamespace {
         self.device_list.read()
     }
 
-    pub fn register_packet_socket(&self, socket: Weak<PacketSocket>) {
-        let _guard = self.packet_sockets_writer.lock();
+    pub fn register_packet_socket(&self, socket: Weak<PacketSocket>) -> Result<(), SystemError> {
+        let writer = self.packet_sockets_writer.lock();
         let current = self.packet_sockets.load();
-        let mut sockets = current.sockets.clone();
-        sockets.retain(|entry| entry.strong_count() != 0);
+        let mut sockets = Vec::new();
+        sockets
+            .try_reserve_exact(current.sockets.len().saturating_add(1))
+            .map_err(|_| SystemError::ENOMEM)?;
+        sockets.extend(current.sockets.iter().cloned());
+        sockets.retain(|entry| entry.upgrade().is_some());
         if !sockets.iter().any(|entry| Weak::ptr_eq(entry, &socket)) {
             sockets.push(socket);
         }
-        self.packet_sockets
-            .store_deferred(Arc::new(PacketSocketRegistrySnapshot { sockets }));
-        self.packet_sockets_need_cleanup
-            .store(false, Ordering::Release);
+        let snapshot = self.prepare_packet_topology_update(&writer, sockets, None)?;
+        self.commit_packet_topology(snapshot);
+        Ok(())
     }
 
     pub fn unregister_packet_socket(&self, socket: &Weak<PacketSocket>) {
-        let _guard = self.packet_sockets_writer.lock();
+        if let Some(socket) = socket.upgrade() {
+            socket.deactivate_packet_registry();
+        }
+        if self.try_unregister_packet_socket(socket).is_err() {
+            // close(2) cannot be retried after the fd is detached. Keep the
+            // old RCU snapshot valid, mark this member orphaned, and let the
+            // fallible poller cleanup retry without failing the close path.
+            if let Some(socket) = socket.upgrade() {
+                socket.clear_fanout_membership();
+            }
+            self.packet_sockets_need_cleanup
+                .store(true, Ordering::Release);
+        }
+    }
+
+    fn try_unregister_packet_socket(&self, socket: &Weak<PacketSocket>) -> Result<(), SystemError> {
+        let socket_arc = socket.upgrade();
+        let group_id = socket_arc
+            .as_ref()
+            .and_then(|socket| socket.fanout_group_id());
+        let mut writer = self.packet_sockets_writer.lock();
         let current = self.packet_sockets.load();
-        let mut sockets = current.sockets.clone();
-        sockets.retain(|entry| entry.strong_count() != 0 && !Weak::ptr_eq(entry, socket));
-        self.packet_sockets
-            .store_deferred(Arc::new(PacketSocketRegistrySnapshot { sockets }));
-        self.packet_sockets_need_cleanup
-            .store(false, Ordering::Release);
+        let mut sockets = Vec::new();
+        sockets
+            .try_reserve_exact(current.sockets.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        sockets.extend(current.sockets.iter().cloned());
+        sockets.retain(|entry| entry.upgrade().is_some() && !Weak::ptr_eq(entry, socket));
+
+        let update = match group_id.and_then(|id| writer.by_id.get(&id).map(|group| (id, group))) {
+            Some((id, group)) => Some((id, group.try_without_member(socket)?)),
+            None => None,
+        };
+        let snapshot = self.prepare_packet_topology_update(&writer, sockets, update.as_ref())?;
+        self.commit_packet_topology(snapshot);
+        if let Some((id, replacement)) = update {
+            if replacement.member_count() == 0 {
+                writer.by_id.remove(&id);
+                writer.id_alloc.free(id as usize);
+            } else {
+                writer.by_id.insert(id, replacement);
+            }
+        }
+        if let Some(socket) = socket_arc {
+            socket.clear_fanout_membership();
+        }
+        Ok(())
     }
 
     fn cleanup_packet_sockets(&self) {
@@ -470,32 +497,82 @@ impl NetNamespace {
         {
             return;
         }
-        let _guard = self.packet_sockets_writer.lock();
+        let mut writer = self.packet_sockets_writer.lock();
         let current = self.packet_sockets.load();
-        let mut sockets = current.sockets.clone();
-        sockets.retain(|entry| entry.strong_count() != 0);
-        self.packet_sockets
-            .store_deferred(Arc::new(PacketSocketRegistrySnapshot { sockets }));
+        let mut sockets = Vec::new();
+        if sockets.try_reserve_exact(current.sockets.len()).is_err() {
+            self.packet_sockets_need_cleanup
+                .store(true, Ordering::Release);
+            return;
+        }
+        sockets.extend(current.sockets.iter().cloned());
+        sockets.retain(|entry| {
+            entry
+                .upgrade()
+                .is_some_and(|socket| socket.is_packet_registry_active())
+        });
+
+        let mut groups = Vec::new();
+        let mut updates = Vec::new();
+        if groups.try_reserve_exact(writer.by_id.len()).is_err()
+            || updates.try_reserve_exact(writer.by_id.len()).is_err()
+        {
+            self.packet_sockets_need_cleanup
+                .store(true, Ordering::Release);
+            return;
+        }
+        for (id, group) in writer.by_id.iter() {
+            match group.try_without_dead_members() {
+                Ok(Some(cleaned)) => {
+                    if cleaned.member_count() != 0 {
+                        groups.push(cleaned.clone());
+                    }
+                    updates.push((*id, cleaned));
+                }
+                Ok(None) => groups.push(group.clone()),
+                Err(_) => {
+                    self.packet_sockets_need_cleanup
+                        .store(true, Ordering::Release);
+                    return;
+                }
+            }
+        }
+        let Ok(snapshot) = Self::try_packet_topology(sockets, groups) else {
+            self.packet_sockets_need_cleanup
+                .store(true, Ordering::Release);
+            return;
+        };
+        self.commit_packet_topology(snapshot);
+        for (id, replacement) in updates {
+            if replacement.member_count() == 0 {
+                writer.by_id.remove(&id);
+                writer.id_alloc.free(id as usize);
+            } else {
+                writer.by_id.insert(id, replacement);
+            }
+        }
     }
 
     /// Deliver an ingress frame without taking a sleeping lock or allocating a
     /// temporary registry copy in the NAPI read-side path.
     ///
-    /// Plain (non-fanout) sockets each receive a copy as before; fanout group
-    /// members are skipped here and receive exactly one shared copy via their
-    /// group's distribution algorithm below.
+    /// The single snapshot contains both plain sockets and immutable fanout
+    /// groups, so a join/close transition cannot expose a socket in both (or
+    /// neither) topology to one reader.
     pub(crate) fn deliver_to_packet_sockets(&self, ingress: PacketIngressMetadata, frame: &[u8]) {
         let snapshot = self.packet_sockets.load();
         let mut stale = false;
         for socket in snapshot.sockets.iter() {
             if let Some(socket) = socket.upgrade() {
-                // Fanout members are delivered through their group below; skip
-                // them here so each frame is handed to a group exactly once.
-                if socket.is_fanout_member() {
-                    continue;
-                }
                 socket.deliver(ingress, frame);
             } else {
+                stale = true;
+            }
+        }
+        let mut protocol_cache = None;
+        let mut flow_hash_cache = None;
+        for group in snapshot.groups.iter() {
+            if group.deliver(ingress, frame, &mut protocol_cache, &mut flow_hash_cache) {
                 stale = true;
             }
         }
@@ -503,149 +580,205 @@ impl NetNamespace {
             self.packet_sockets_need_cleanup
                 .store(true, Ordering::Release);
         }
-
-        // Each fanout group receives a single copy and demuxes it internally.
-        let groups = self.fanout_groups.load();
-        let mut group_stale = false;
-        for group in groups.groups.iter() {
-            if group.deliver(ingress, frame) {
-                group_stale = true;
-            }
-        }
-        if group_stale {
-            self.fanout_groups_need_cleanup
-                .store(true, Ordering::Release);
-        }
     }
 
     pub fn has_packet_sockets(&self) -> bool {
-        self.packet_sockets
-            .load()
-            .sockets
-            .iter()
-            .any(|socket| socket.strong_count() != 0)
+        self.packet_sockets.load().live_receiver_count != 0
     }
 
     /// Join (creating if necessary) a fanout group.
     ///
-    /// All registry mutation — id allocation, consistency check, member
-    /// publication, the socket's `fanout` field update, and the registry Vec
-    /// rebuild — happens atomically under `fanout_groups_writer`, matching the
-    /// broadcast registry's COW pattern and closing the join/leave TOCTOU.
+    /// Move `socket` from the plain list into a group with one RCU publication.
+    /// The caller holds the socket bind lock, fixing the global lock order at
+    /// `bind_lock -> packet_sockets_writer`.
     pub(crate) fn fanout_group_join(
         &self,
         socket: &Arc<PacketSocket>,
         params: FanoutJoinParams,
     ) -> Result<(), SystemError> {
-        let FanoutJoinParams {
-            id_req,
-            unique,
-            mode,
-            flags,
-            sock_type,
-            bound_ifindex,
-            bound_protocol,
-        } = params;
-        let mut writer = self.fanout_groups_writer.lock();
+        let mut writer = self.packet_sockets_writer.lock();
         if socket.has_fanout_group() {
-            return Err(SystemError::EBUSY);
+            return Err(SystemError::EALREADY);
         }
-        let group: Arc<FanoutGroup> = if unique {
-            // UNIQUEID always creates a fresh group with a kernel-assigned id;
-            // it cannot attach to an existing group.
+        let socket_ref = socket.self_ref();
+        let current = self.packet_sockets.load();
+        if !current
+            .sockets
+            .iter()
+            .any(|entry| Weak::ptr_eq(entry, &socket_ref))
+        {
+            return Err(SystemError::EINVAL);
+        }
+
+        let mut reserved_new_id = None;
+        let group: Arc<FanoutGroup> = if params.unique {
+            writer
+                .by_id
+                .try_reserve(1)
+                .map_err(|_| SystemError::ENOMEM)?;
             let new_id = writer.id_alloc.alloc().ok_or(SystemError::ENOMEM)? as u16;
-            let group = FanoutGroup::new(new_id, params);
-            writer.by_id.insert(new_id, group.clone());
+            reserved_new_id = Some(new_id);
+            let group = match FanoutGroup::try_new(new_id, params, socket_ref.clone()) {
+                Ok(group) => group,
+                Err(err) => {
+                    writer.id_alloc.free(new_id as usize);
+                    return Err(err);
+                }
+            };
             group
         } else {
-            match writer.by_id.get(&id_req).cloned() {
-                Some(existing) => {
-                    if existing.mode != mode
-                        || existing.flags != flags
-                        || !existing.matches(sock_type, bound_ifindex, bound_protocol)
+            match writer.by_id.get(&params.id_req).cloned() {
+                Some(mut existing) => {
+                    if let Some(compacted) = existing.try_without_dead_members()? {
+                        existing = compacted;
+                    }
+                    if existing.member_count() == 0 {
+                        FanoutGroup::try_new(params.id_req, params, socket_ref.clone())?
+                    } else {
+                        if !existing.matches(params) {
+                            return Err(SystemError::EINVAL);
+                        }
+                        if existing.member_count() >= existing.max_num_members() {
+                            return Err(SystemError::ENOSPC);
+                        }
+                        existing.try_with_member(socket_ref.clone())?
+                    }
+                }
+                None => {
+                    writer
+                        .by_id
+                        .try_reserve(1)
+                        .map_err(|_| SystemError::ENOMEM)?;
+                    if writer
+                        .id_alloc
+                        .alloc_specific(params.id_req as usize)
+                        .is_none()
                     {
                         return Err(SystemError::EINVAL);
                     }
-                    existing
-                }
-                None => {
-                    // Reserve the explicit id in the allocator so a later
-                    // UNIQUEID allocation cannot collide with it.
-                    if writer.id_alloc.alloc_specific(id_req as usize).is_none() {
-                        return Err(SystemError::EINVAL);
+                    reserved_new_id = Some(params.id_req);
+                    match FanoutGroup::try_new(params.id_req, params, socket_ref.clone()) {
+                        Ok(group) => group,
+                        Err(err) => {
+                            writer.id_alloc.free(params.id_req as usize);
+                            return Err(err);
+                        }
                     }
-                    let group = FanoutGroup::new(id_req, params);
-                    writer.by_id.insert(id_req, group.clone());
-                    group
                 }
             }
         };
 
-        // Publish the new member list first, then set the socket's field, so a
-        // concurrent deliver that already sees the member also skips it in the
-        group.add_member(socket.self_ref().clone());
-        socket.set_fanout_group(group.clone());
-
-        self.publish_fanout_groups(&writer);
-        self.fanout_groups_need_cleanup
-            .store(false, Ordering::Release);
+        let prepared = match self.prepare_fanout_join_snapshot(
+            &writer,
+            &current,
+            &socket_ref,
+            group.clone(),
+        ) {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                if let Some(id) = reserved_new_id {
+                    writer.id_alloc.free(id as usize);
+                }
+                return Err(err);
+            }
+        };
+        self.commit_packet_topology(prepared);
+        writer.by_id.insert(group.id, group.clone());
+        socket.set_fanout_membership(membership_value(&group));
         Ok(())
     }
 
-    /// Remove `socket` from its fanout group, tearing the group down if it
-    /// becomes empty. The socket's `fanout` field is cleared *after* acquiring
-    /// `fanout_groups_writer`, keeping the lock order identical to the join
-    /// path (`fanout_groups_writer → fanout.write()`) and avoiding the ABBA
-    /// deadlock. The empty-check and `by_id`/id-allocator removal also run
-    /// under the same lock so a concurrent join cannot resurrect a zombie group.
-    pub(crate) fn fanout_group_leave(&self, socket: &Weak<PacketSocket>) {
-        let mut writer = self.fanout_groups_writer.lock();
-        // Clear the socket's fanout membership under the writer lock so the
-        // lock order is fanout_groups_writer → fanout.write() — matching join.
-        let Some(socket_arc) = socket.upgrade() else {
-            return;
-        };
-        let Some(group) = socket_arc.clear_fanout_group() else {
-            return;
-        };
-        group.remove_member(socket);
-        if group.live_count() == 0 {
-            writer.by_id.remove(&group.id);
-            writer.id_alloc.free(group.id as usize);
-            self.publish_fanout_groups(&writer);
+    fn prepare_fanout_join_snapshot(
+        &self,
+        writer: &PacketSocketRegistryWriter,
+        current: &PacketSocketRegistrySnapshot,
+        socket: &Weak<PacketSocket>,
+        replacement: Arc<FanoutGroup>,
+    ) -> Result<Arc<PacketSocketRegistrySnapshot>, SystemError> {
+        let mut sockets = Vec::new();
+        sockets
+            .try_reserve_exact(current.sockets.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        sockets.extend(
+            current
+                .sockets
+                .iter()
+                .filter(|entry| !Weak::ptr_eq(entry, socket))
+                .cloned(),
+        );
+
+        let additional = usize::from(!writer.by_id.contains_key(&replacement.id));
+        let mut groups = Vec::new();
+        groups
+            .try_reserve_exact(writer.by_id.len().saturating_add(additional))
+            .map_err(|_| SystemError::ENOMEM)?;
+        let mut replaced = false;
+        for (id, group) in writer.by_id.iter() {
+            if *id == replacement.id {
+                groups.push(replacement.clone());
+                replaced = true;
+            } else {
+                groups.push(group.clone());
+            }
         }
-        self.fanout_groups_need_cleanup
-            .store(false, Ordering::Release);
+        if !replaced {
+            groups.push(replacement);
+        }
+        let live_receiver_count = sockets.len()
+            + groups
+                .iter()
+                .map(|group| group.member_count())
+                .sum::<usize>();
+        Arc::try_new(PacketSocketRegistrySnapshot {
+            sockets,
+            groups,
+            live_receiver_count,
+        })
+        .map_err(|_| SystemError::ENOMEM)
     }
 
-    fn cleanup_fanout_groups(&self) {
-        if !self
-            .fanout_groups_need_cleanup
-            .swap(false, Ordering::AcqRel)
-        {
-            return;
+    fn prepare_packet_topology_update(
+        &self,
+        writer: &PacketSocketRegistryWriter,
+        sockets: Vec<Weak<PacketSocket>>,
+        update: Option<&(u16, Arc<FanoutGroup>)>,
+    ) -> Result<Arc<PacketSocketRegistrySnapshot>, SystemError> {
+        let mut groups = Vec::new();
+        groups
+            .try_reserve_exact(writer.by_id.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        for (id, group) in writer.by_id.iter() {
+            match update {
+                Some((update_id, replacement)) if id == update_id => {
+                    if replacement.member_count() != 0 {
+                        groups.push(replacement.clone());
+                    }
+                }
+                _ => groups.push(group.clone()),
+            }
         }
-        let mut writer = self.fanout_groups_writer.lock();
-        let dead: Vec<u16> = writer
-            .by_id
-            .iter()
-            .filter(|(_, g)| g.live_count() == 0)
-            .map(|(id, _)| *id)
-            .collect();
-        for id in &dead {
-            writer.by_id.remove(id);
-            writer.id_alloc.free(*id as usize);
-        }
-        if !dead.is_empty() {
-            self.publish_fanout_groups(&writer);
-        }
+        Self::try_packet_topology(sockets, groups)
     }
 
-    /// Rebuild the registry Vec from `writer` and publish a fresh RCU snapshot.
-    fn publish_fanout_groups(&self, writer: &FanoutGroupWriter) {
-        let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
-        self.fanout_groups
-            .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
+    fn try_packet_topology(
+        sockets: Vec<Weak<PacketSocket>>,
+        groups: Vec<Arc<FanoutGroup>>,
+    ) -> Result<Arc<PacketSocketRegistrySnapshot>, SystemError> {
+        let live_receiver_count = sockets.len()
+            + groups
+                .iter()
+                .map(|group| group.member_count())
+                .sum::<usize>();
+        Arc::try_new(PacketSocketRegistrySnapshot {
+            sockets,
+            groups,
+            live_receiver_count,
+        })
+        .map_err(|_| SystemError::ENOMEM)
+    }
+
+    fn commit_packet_topology(&self, snapshot: Arc<PacketSocketRegistrySnapshot>) {
+        self.packet_sockets.store_deferred(snapshot);
     }
 
     #[inline]

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -554,14 +554,7 @@ impl NetNamespace {
             // UNIQUEID always creates a fresh group with a kernel-assigned id;
             // it cannot attach to an existing group.
             let new_id = writer.id_alloc.alloc().ok_or(SystemError::ENOMEM)? as u16;
-            let group = FanoutGroup::new(
-                new_id,
-                mode,
-                flags,
-                sock_type,
-                bound_ifindex,
-                bound_protocol,
-            );
+            let group = FanoutGroup::new(new_id, params);
             writer.by_id.insert(new_id, group.clone());
             group
         } else {
@@ -581,14 +574,7 @@ impl NetNamespace {
                     if writer.id_alloc.alloc_specific(id_req as usize).is_none() {
                         return Err(SystemError::EINVAL);
                     }
-                    let group = FanoutGroup::new(
-                        id_req,
-                        mode,
-                        flags,
-                        sock_type,
-                        bound_ifindex,
-                        bound_protocol,
-                    );
+                    let group = FanoutGroup::new(id_req, params);
                     writer.by_id.insert(id_req, group.clone());
                     group
                 }
@@ -600,9 +586,7 @@ impl NetNamespace {
         group.add_member(socket.self_ref().clone());
         socket.set_fanout_group(group.clone());
 
-        let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
-        self.fanout_groups
-            .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
+        self.publish_fanout_groups(&writer);
         self.fanout_groups_need_cleanup
             .store(false, Ordering::Release);
         Ok(())
@@ -628,9 +612,7 @@ impl NetNamespace {
         if group.live_count() == 0 {
             writer.by_id.remove(&group.id);
             writer.id_alloc.free(group.id as usize);
-            let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
-            self.fanout_groups
-                .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
+            self.publish_fanout_groups(&writer);
         }
         self.fanout_groups_need_cleanup
             .store(false, Ordering::Release);
@@ -655,10 +637,15 @@ impl NetNamespace {
             writer.id_alloc.free(*id as usize);
         }
         if !dead.is_empty() {
-            let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
-            self.fanout_groups
-                .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
+            self.publish_fanout_groups(&writer);
         }
+    }
+
+    /// Rebuild the registry Vec from `writer` and publish a fresh RCU snapshot.
+    fn publish_fanout_groups(&self, writer: &FanoutGroupWriter) {
+        let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
+        self.fanout_groups
+            .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
     }
 
     #[inline]

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -9,7 +9,7 @@ use crate::net::routing::Router;
 use crate::net::socket::netlink::table::{
     generate_supported_netlink_kernel_sockets, NetlinkKernelSocket, NetlinkSocketTable,
 };
-use crate::net::socket::packet::{PacketIngressMetadata, PacketSocket};
+use crate::net::socket::packet::{FanoutGroup, FanoutMode, PacketIngressMetadata, PacketSocket};
 use crate::net::socket::unix::ns::UnixAbstractTable;
 use crate::process::fork::CloneFlags;
 use crate::process::kthread::{KernelThreadClosure, KernelThreadMechanism};
@@ -31,6 +31,7 @@ use alloc::vec::Vec;
 use core::sync::atomic::AtomicU32;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use hashbrown::HashMap;
+use ida::IdAllocator;
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
@@ -84,6 +85,11 @@ pub struct NetNamespace {
     /// Serializes copy-on-write registry updates in process context.
     packet_sockets_writer: Mutex<()>,
     packet_sockets_need_cleanup: AtomicBool,
+    /// Lock-free read-side snapshot of AF_PACKET fanout groups for delivery.
+    fanout_groups: RcuArcSlot<FanoutGroupRegistry>,
+    /// Serializes fanout group registry updates and protects the id allocator.
+    fanout_groups_writer: Mutex<FanoutGroupWriter>,
+    fanout_groups_need_cleanup: AtomicBool,
     ///当前网络命名空间下的桥接设备列表
     bridge_list: RwSem<BTreeMap<String, Arc<BridgeDriver>>>,
 
@@ -108,6 +114,31 @@ pub struct NetNamespace {
 #[derive(Debug, Default)]
 struct PacketSocketRegistrySnapshot {
     sockets: Vec<Weak<PacketSocket>>,
+}
+
+#[derive(Debug, Default)]
+struct FanoutGroupRegistry {
+    groups: Vec<Arc<FanoutGroup>>,
+}
+
+#[derive(Debug)]
+struct FanoutGroupWriter {
+    /// Authoritative `group id -> group` index used by the write path.
+    by_id: BTreeMap<u16, Arc<FanoutGroup>>,
+    /// Group id allocator. Reserves both UNIQUEID-allocated ids and explicit
+    /// ids so the two namespaces can never collide.
+    id_alloc: IdAllocator,
+}
+
+impl FanoutGroupWriter {
+    fn new() -> Self {
+        // Group ids occupy the full u16 range; 0 is a valid explicit id.
+        Self {
+            by_id: BTreeMap::new(),
+            id_alloc: IdAllocator::new(0, u16::MAX as usize + 1)
+                .expect("fanout group id allocator"),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -204,6 +235,7 @@ impl NetnsPoller {
 
             let nsid = netns.ns_common.nsid.data();
             netns.cleanup_packet_sockets();
+            netns.cleanup_fanout_groups();
             let now_us = Instant::now().total_micros() as u64;
 
             // 处理“已到期的定时事件”：到期则 schedule NAPI 推进一次。
@@ -315,6 +347,9 @@ impl NetNamespace {
             packet_sockets: RcuArcSlot::new(Arc::new(PacketSocketRegistrySnapshot::default())),
             packet_sockets_writer: Mutex::new(()),
             packet_sockets_need_cleanup: AtomicBool::new(false),
+            fanout_groups: RcuArcSlot::new(Arc::new(FanoutGroupRegistry::default())),
+            fanout_groups_writer: Mutex::new(FanoutGroupWriter::new()),
+            fanout_groups_need_cleanup: AtomicBool::new(false),
             bridge_list: RwSem::new(BTreeMap::new()),
             netlink_socket_table: NetlinkSocketTable::default(),
             netlink_kernel_socket: RwSem::new(generate_supported_netlink_kernel_sockets()),
@@ -354,6 +389,9 @@ impl NetNamespace {
             packet_sockets: RcuArcSlot::new(Arc::new(PacketSocketRegistrySnapshot::default())),
             packet_sockets_writer: Mutex::new(()),
             packet_sockets_need_cleanup: AtomicBool::new(false),
+            fanout_groups: RcuArcSlot::new(Arc::new(FanoutGroupRegistry::default())),
+            fanout_groups_writer: Mutex::new(FanoutGroupWriter::new()),
+            fanout_groups_need_cleanup: AtomicBool::new(false),
             bridge_list: RwSem::new(BTreeMap::new()),
             netlink_socket_table: NetlinkSocketTable::default(),
             netlink_kernel_socket: RwSem::new(generate_supported_netlink_kernel_sockets()),
@@ -440,11 +478,20 @@ impl NetNamespace {
 
     /// Deliver an ingress frame without taking a sleeping lock or allocating a
     /// temporary registry copy in the NAPI read-side path.
+    ///
+    /// Plain (non-fanout) sockets each receive a copy as before; fanout group
+    /// members are skipped here and receive exactly one shared copy via their
+    /// group's distribution algorithm below.
     pub(crate) fn deliver_to_packet_sockets(&self, ingress: PacketIngressMetadata, frame: &[u8]) {
         let snapshot = self.packet_sockets.load();
         let mut stale = false;
         for socket in snapshot.sockets.iter() {
             if let Some(socket) = socket.upgrade() {
+                // Fanout members are delivered through their group below; skip
+                // them here so each frame is handed to a group exactly once.
+                if socket.is_fanout_member() {
+                    continue;
+                }
                 socket.deliver(ingress, frame);
             } else {
                 stale = true;
@@ -452,6 +499,19 @@ impl NetNamespace {
         }
         if stale {
             self.packet_sockets_need_cleanup
+                .store(true, Ordering::Release);
+        }
+
+        // Each fanout group receives a single copy and demuxes it internally.
+        let groups = self.fanout_groups.load();
+        let mut group_stale = false;
+        for group in groups.groups.iter() {
+            if group.deliver(ingress, frame) {
+                group_stale = true;
+            }
+        }
+        if group_stale {
+            self.fanout_groups_need_cleanup
                 .store(true, Ordering::Release);
         }
     }
@@ -462,6 +522,134 @@ impl NetNamespace {
             .sockets
             .iter()
             .any(|socket| socket.strong_count() != 0)
+    }
+
+    /// Join (creating if necessary) a fanout group.
+    ///
+    /// All registry mutation — id allocation, consistency check, member
+    /// publication, the socket's `fanout` field update, and the registry Vec
+    /// rebuild — happens atomically under `fanout_groups_writer`, matching the
+    /// broadcast registry's COW pattern and closing the join/leave TOCTOU.
+    pub(crate) fn fanout_group_join(
+        &self,
+        socket: &Arc<PacketSocket>,
+        id_req: u16,
+        unique: bool,
+        mode: FanoutMode,
+        flags: u16,
+        sock_type: crate::net::socket::packet::PacketSocketType,
+        bound_ifindex: u32,
+        bound_protocol: u16,
+    ) -> Result<(), SystemError> {
+
+        let mut writer = self.fanout_groups_writer.lock();
+        let group: Arc<FanoutGroup> = if unique {
+            // UNIQUEID always creates a fresh group with a kernel-assigned id;
+            // it cannot attach to an existing group.
+            let new_id = writer.id_alloc.alloc().ok_or(SystemError::ENOMEM)? as u16;
+            let group = FanoutGroup::new(
+                new_id,
+                mode,
+                flags,
+                sock_type,
+                bound_ifindex,
+                bound_protocol,
+            );
+            writer.by_id.insert(new_id, group.clone());
+            group
+        } else {
+            match writer.by_id.get(&id_req).cloned() {
+                Some(existing) => {
+                    if existing.mode != mode
+                        || existing.flags != flags
+                        || !existing.matches(sock_type, bound_ifindex, bound_protocol)
+                    {
+                        return Err(SystemError::EINVAL);
+                    }
+                    existing
+                }
+                None => {
+                    // Reserve the explicit id in the allocator so a later
+                    // UNIQUEID allocation cannot collide with it.
+                    if writer
+                        .id_alloc
+                        .alloc_specific(id_req as usize)
+                        .is_none()
+                    {
+                        return Err(SystemError::EINVAL);
+                    }
+                    let group = FanoutGroup::new(
+                        id_req,
+                        mode,
+                        flags,
+                        sock_type,
+                        bound_ifindex,
+                        bound_protocol,
+                    );
+                    writer.by_id.insert(id_req, group.clone());
+                    group
+                }
+            }
+        };
+
+        // Publish the new member list first, then set the socket's field, so a
+        // concurrent deliver that already sees the member also skips it in the
+        group.add_member(socket.self_ref().clone());
+        socket.set_fanout_group(group.clone());
+
+        let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
+        self.fanout_groups
+            .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
+        self.fanout_groups_need_cleanup
+            .store(false, Ordering::Release);
+        Ok(())
+    }
+
+    /// Remove `socket` from its fanout group, tearing the group down if it
+    /// becomes empty. The empty-check and `by_id`/id-allocator removal run
+    /// together under `fanout_groups_writer` so a concurrent join cannot
+    /// resurrect a zombie group.
+    pub(crate) fn fanout_group_leave(
+        &self,
+        group: &Arc<FanoutGroup>,
+        socket: &Weak<PacketSocket>,
+    ) {
+        let mut writer = self.fanout_groups_writer.lock();
+        group.remove_member(socket);
+        if group.live_count() == 0 {
+            writer.by_id.remove(&group.id);
+            writer.id_alloc.free(group.id as usize);
+            let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
+            self.fanout_groups
+                .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
+        }
+        self.fanout_groups_need_cleanup
+            .store(false, Ordering::Release);
+    }
+
+    fn cleanup_fanout_groups(&self) {
+        if !self
+            .fanout_groups_need_cleanup
+            .swap(false, Ordering::AcqRel)
+        {
+            return;
+        }
+        let mut writer = self.fanout_groups_writer.lock();
+        let dead: Vec<u16> = writer
+            .by_id
+            .iter()
+            .filter(|(_, g)| g.live_count() == 0)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &dead {
+            writer.by_id.remove(id);
+            writer.id_alloc.free(*id as usize);
+        }
+        if !dead.is_empty() {
+            let groups: Vec<Arc<FanoutGroup>> = writer.by_id.values().cloned().collect();
+            self.fanout_groups
+                .store_deferred(Arc::new(FanoutGroupRegistry { groups }));
+        }
     }
 
     #[inline]

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -9,7 +9,9 @@ use crate::net::routing::Router;
 use crate::net::socket::netlink::table::{
     generate_supported_netlink_kernel_sockets, NetlinkKernelSocket, NetlinkSocketTable,
 };
-use crate::net::socket::packet::{FanoutGroup, FanoutMode, PacketIngressMetadata, PacketSocket};
+use crate::net::socket::packet::{
+    FanoutGroup, FanoutJoinParams, PacketIngressMetadata, PacketSocket,
+};
 use crate::net::socket::unix::ns::UnixAbstractTable;
 use crate::process::fork::CloneFlags;
 use crate::process::kthread::{KernelThreadClosure, KernelThreadMechanism};
@@ -533,14 +535,17 @@ impl NetNamespace {
     pub(crate) fn fanout_group_join(
         &self,
         socket: &Arc<PacketSocket>,
-        id_req: u16,
-        unique: bool,
-        mode: FanoutMode,
-        flags: u16,
-        sock_type: crate::net::socket::packet::PacketSocketType,
-        bound_ifindex: u32,
-        bound_protocol: u16,
+        params: FanoutJoinParams,
     ) -> Result<(), SystemError> {
+        let FanoutJoinParams {
+            id_req,
+            unique,
+            mode,
+            flags,
+            sock_type,
+            bound_ifindex,
+            bound_protocol,
+        } = params;
         let mut writer = self.fanout_groups_writer.lock();
         if socket.has_fanout_group() {
             return Err(SystemError::EBUSY);

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -47,6 +47,9 @@ lazy_static! {
 /// 每次创建新的网络命名空间时，都会增加这个计数器
 pub static mut NETNS_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+const PACKET_SOCKET_CLEANUP_RETRY_MIN: Duration = Duration::from_millis(100);
+const PACKET_SOCKET_CLEANUP_RETRY_MAX: Duration = Duration::from_secs(5);
+
 #[unified_init(INITCALL_SUBSYS)]
 pub fn root_net_namespace_init() -> Result<(), SystemError> {
     // 创建root网络命名空间的轮询线程
@@ -124,6 +127,13 @@ struct PacketSocketRegistryWriter {
     id_alloc: IdAllocator,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PacketSocketCleanupResult {
+    Complete,
+    Pending,
+    AllocationFailed,
+}
+
 impl PacketSocketRegistryWriter {
     fn new() -> Self {
         // Group ids occupy the full u16 range; 0 is a valid explicit id.
@@ -169,6 +179,8 @@ struct NetnsPoller {
     /// 用于避免唤醒丢失：当 poll 线程正在 poll 时收到的唤醒请求会设置此标志，
     /// poll 线程在进入等待前会检查此标志
     poll_pending: AtomicBool,
+    /// Topology cleanup wakes the poller without being treated as network I/O.
+    cleanup_pending: AtomicBool,
     /// # 轮询线程的 PCB（用于 stop）
     thread: RwSem<Option<Arc<ProcessControlBlock>>>,
 }
@@ -179,6 +191,7 @@ impl NetnsPoller {
             netns,
             wait_queue: WaitQueue::default(),
             poll_pending: AtomicBool::new(false),
+            cleanup_pending: AtomicBool::new(false),
             thread: RwSem::new(None),
         })
     }
@@ -213,7 +226,22 @@ impl NetnsPoller {
         }
     }
 
+    fn notify_network(&self) -> (bool, usize) {
+        let was_pending = self.poll_pending.swap(true, Ordering::AcqRel);
+        let woken = self.wait_queue.wake_all();
+        (!was_pending, woken)
+    }
+
+    /// Wake only the topology-cleanup worker. This is safe from the NAPI read
+    /// path and deliberately does not turn cleanup into an interface poll.
+    fn notify_cleanup(&self) {
+        self.cleanup_pending.store(true, Ordering::Release);
+        self.wait_queue.wake_all();
+    }
+
     fn polling(&self) {
+        let mut cleanup_retry_delay = PACKET_SOCKET_CLEANUP_RETRY_MIN;
+        let mut cleanup_retry_at = None;
         loop {
             if KernelThreadMechanism::should_stop(&ProcessManager::current_pcb()) {
                 break;
@@ -228,12 +256,31 @@ impl NetnsPoller {
             };
 
             let nsid = netns.ns_common.nsid.data();
-            netns.cleanup_packet_sockets();
             let now_us = Instant::now().total_micros() as u64;
+            if cleanup_retry_at.is_none_or(|deadline| now_us >= deadline) {
+                match netns.cleanup_packet_sockets() {
+                    PacketSocketCleanupResult::Complete => {
+                        cleanup_retry_delay = PACKET_SOCKET_CLEANUP_RETRY_MIN;
+                        cleanup_retry_at = None;
+                    }
+                    PacketSocketCleanupResult::Pending => {
+                        cleanup_retry_delay = PACKET_SOCKET_CLEANUP_RETRY_MIN;
+                        cleanup_retry_at = None;
+                    }
+                    PacketSocketCleanupResult::AllocationFailed => {
+                        cleanup_retry_at =
+                            Some(now_us.saturating_add(cleanup_retry_delay.total_micros()));
+                        cleanup_retry_delay = Duration::from_micros(core::cmp::min(
+                            cleanup_retry_delay.total_micros().saturating_mul(2),
+                            PACKET_SOCKET_CLEANUP_RETRY_MAX.total_micros(),
+                        ));
+                    }
+                }
+            }
 
             // 处理“已到期的定时事件”：到期则 schedule NAPI 推进一次。
             // 同时计算下一次最早到期时间点，用于设置 sleep 超时。
-            let mut next_us: Option<u64> = None;
+            let mut next_us = cleanup_retry_at;
             let mut had_due = false;
             for (_, iface) in netns.device_list.read().iter() {
                 if let Some(us) = iface.common().poll_at_us() {
@@ -277,9 +324,13 @@ impl NetnsPoller {
             drop(netns);
 
             // 等待事件唤醒（IRQ/lo Tx 等）或 timeout（smoltcp timer deadline）。
-            // cond 使用 swap(false) 原子消费一次 pending，避免丢唤醒。
+            // Keep cleanup and network wake reasons separate: only the latter
+            // should schedule interface NAPI below.
             let woke_by_event = match self.wait_queue.wait_event_uninterruptible_timeout(
-                || self.poll_pending.swap(false, Ordering::AcqRel),
+                || {
+                    self.poll_pending.load(Ordering::Acquire)
+                        || self.cleanup_pending.load(Ordering::Acquire)
+                },
                 timeout,
             ) {
                 Ok(()) => true,
@@ -291,8 +342,13 @@ impl NetnsPoller {
             };
 
             if woke_by_event {
+                let network_pending = self.poll_pending.swap(false, Ordering::AcqRel);
+                self.cleanup_pending.store(false, Ordering::Release);
                 if KernelThreadMechanism::should_stop(&ProcessManager::current_pcb()) {
                     break;
+                }
+                if !network_pending {
+                    continue;
                 }
                 let netns = match self.netns.upgrade() {
                     Some(netns) => netns,
@@ -451,8 +507,18 @@ impl NetNamespace {
             if let Some(socket) = socket.upgrade() {
                 socket.clear_fanout_membership();
             }
-            self.packet_sockets_need_cleanup
-                .store(true, Ordering::Release);
+            self.request_packet_socket_cleanup();
+        }
+    }
+
+    /// Coalesce stale-topology notifications and wake only the poller. Unlike
+    /// `wakeup_poll_thread`, this path never reads `device_list` from NAPI.
+    fn request_packet_socket_cleanup(&self) {
+        if !self
+            .packet_sockets_need_cleanup
+            .swap(true, Ordering::AcqRel)
+        {
+            self.poller.notify_cleanup();
         }
     }
 
@@ -490,12 +556,12 @@ impl NetNamespace {
         Ok(())
     }
 
-    fn cleanup_packet_sockets(&self) {
+    fn cleanup_packet_sockets(&self) -> PacketSocketCleanupResult {
         if !self
             .packet_sockets_need_cleanup
             .swap(false, Ordering::AcqRel)
         {
-            return;
+            return PacketSocketCleanupResult::Complete;
         }
         let mut writer = self.packet_sockets_writer.lock();
         let current = self.packet_sockets.load();
@@ -503,7 +569,7 @@ impl NetNamespace {
         if sockets.try_reserve_exact(current.sockets.len()).is_err() {
             self.packet_sockets_need_cleanup
                 .store(true, Ordering::Release);
-            return;
+            return PacketSocketCleanupResult::AllocationFailed;
         }
         sockets.extend(current.sockets.iter().cloned());
         sockets.retain(|entry| {
@@ -519,7 +585,7 @@ impl NetNamespace {
         {
             self.packet_sockets_need_cleanup
                 .store(true, Ordering::Release);
-            return;
+            return PacketSocketCleanupResult::AllocationFailed;
         }
         for (id, group) in writer.by_id.iter() {
             match group.try_without_dead_members() {
@@ -533,14 +599,14 @@ impl NetNamespace {
                 Err(_) => {
                     self.packet_sockets_need_cleanup
                         .store(true, Ordering::Release);
-                    return;
+                    return PacketSocketCleanupResult::AllocationFailed;
                 }
             }
         }
         let Ok(snapshot) = Self::try_packet_topology(sockets, groups) else {
             self.packet_sockets_need_cleanup
                 .store(true, Ordering::Release);
-            return;
+            return PacketSocketCleanupResult::AllocationFailed;
         };
         self.commit_packet_topology(snapshot);
         for (id, replacement) in updates {
@@ -550,6 +616,11 @@ impl NetNamespace {
             } else {
                 writer.by_id.insert(id, replacement);
             }
+        }
+        if self.packet_sockets_need_cleanup.load(Ordering::Acquire) {
+            PacketSocketCleanupResult::Pending
+        } else {
+            PacketSocketCleanupResult::Complete
         }
     }
 
@@ -563,10 +634,11 @@ impl NetNamespace {
         let snapshot = self.packet_sockets.load();
         let mut stale = false;
         for socket in snapshot.sockets.iter() {
-            if let Some(socket) = socket.upgrade() {
-                socket.deliver(ingress, frame);
-            } else {
-                stale = true;
+            match socket.upgrade() {
+                Some(socket) if socket.is_packet_registry_active() => {
+                    socket.deliver(ingress, frame);
+                }
+                Some(_) | None => stale = true,
             }
         }
         let mut protocol_cache = None;
@@ -577,8 +649,7 @@ impl NetNamespace {
             }
         }
         if stale {
-            self.packet_sockets_need_cleanup
-                .store(true, Ordering::Release);
+            self.request_packet_socket_cleanup();
         }
     }
 
@@ -885,11 +956,10 @@ impl NetNamespace {
     /// 使用原子标志确保即使 poll 线程正在执行也不会丢失唤醒请求
     pub fn wakeup_poll_thread(&self) {
         // 先设置 pending 标志，再唤醒：避免“先唤后睡/睡前漏信号”。
-        let was_pending = self.poller.poll_pending.swap(true, Ordering::AcqRel);
-        let woken = self.poller.wait_queue.wake_all();
+        let (newly_pending, woken) = self.poller.notify_network();
         // 事件驱动：对齐 Linux，尽量在事件发生后立刻 schedule NAPI（由 NAPI 线程 bounded poll 推进）。
         // 只在从“未 pending -> pending”这一跳触发一次，避免中断风暴下重复 schedule。
-        if !was_pending {
+        if newly_pending {
             for (_, iface) in self.device_list.read().iter() {
                 if let Some(napi) = iface.napi_struct() {
                     napi_schedule(napi);

--- a/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
@@ -54,6 +54,12 @@
 #ifndef PACKET_AUXDATA
 #define PACKET_AUXDATA 8
 #endif
+#ifndef PACKET_FANOUT
+#define PACKET_FANOUT 18
+#endif
+#ifndef PACKET_FANOUT_LB
+#define PACKET_FANOUT_LB 1
+#endif
 #ifndef TP_STATUS_USER
 #define TP_STATUS_USER 1
 #endif
@@ -1110,6 +1116,78 @@ TEST(AfPacketE2E, FilterReplacementPreservesReceiveState) {
     EXPECT_EQ(recv(receiver.Get(), buffer, sizeof(buffer), 0), static_cast<ssize_t>(sizeof(frame)))
         << "detached socket must continue receiving after the stress phase: "
         << ErrnoString(errno);
+}
+
+TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
+    const std::string ifname = "veth1";
+    int ifindex = ProbeIfindex(ifname);
+    ASSERT_GE(ifindex, 0) << "veth1 must exist for deterministic fanout testing";
+
+    auto make_receiver = [ifindex]() {
+        int fd = socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType));
+        if (fd < 0) return fd;
+        struct sockaddr_ll addr{};
+        addr.sll_family = AF_PACKET;
+        addr.sll_protocol = htons(kPrivateEtherType);
+        addr.sll_ifindex = ifindex;
+        if (bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+            close(fd);
+            return -1;
+        }
+        return fd;
+    };
+
+    FdGuard first(make_receiver());
+    FdGuard second(make_receiver());
+    FdGuard sender(socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType)));
+    ASSERT_GE(first.Get(), 0) << ErrnoString(errno);
+    ASSERT_GE(second.Get(), 0) << ErrnoString(errno);
+    ASSERT_GE(sender.Get(), 0) << ErrnoString(errno);
+
+    int fanout = (PACKET_FANOUT_LB << 16) | 0x5a31;
+    ASSERT_EQ(setsockopt(first.Get(), SOL_PACKET, PACKET_FANOUT, &fanout, sizeof(fanout)), 0)
+        << ErrnoString(errno);
+    ASSERT_EQ(setsockopt(second.Get(), SOL_PACKET, PACKET_FANOUT, &fanout, sizeof(fanout)), 0)
+        << ErrnoString(errno);
+
+    uint8_t local_mac[6];
+    GetIfHwaddr(sender.Get(), ifname, local_mac);
+    uint8_t frame[96]{};
+    std::memset(frame, 0xff, 6);
+    std::memcpy(frame + 6, local_mac, 6);
+    frame[12] = static_cast<uint8_t>(kPrivateEtherType >> 8);
+    frame[13] = static_cast<uint8_t>(kPrivateEtherType);
+
+    struct sockaddr_ll dst{};
+    dst.sll_family = AF_PACKET;
+    dst.sll_protocol = htons(kPrivateEtherType);
+    dst.sll_ifindex = ifindex;
+    dst.sll_hatype = ARPHRD_ETHER;
+    dst.sll_halen = ETH_ALEN;
+    std::memset(dst.sll_addr, 0xff, ETH_ALEN);
+
+    constexpr int kFrames = 16;
+    for (int sequence = 0; sequence < kFrames; ++sequence) {
+        std::memcpy(frame + kEthHdrLen, &sequence, sizeof(sequence));
+        ASSERT_EQ(sendto(sender.Get(), frame, sizeof(frame), 0,
+                         reinterpret_cast<sockaddr*>(&dst), sizeof(dst)),
+                  static_cast<ssize_t>(sizeof(frame)))
+            << ErrnoString(errno);
+    }
+
+    auto drain = [](int fd) {
+        uint8_t buffer[128];
+        int count = 0;
+        while (recv(fd, buffer, sizeof(buffer), MSG_DONTWAIT) > 0) ++count;
+        return count;
+    };
+    const int first_count = drain(first.Get());
+    const int second_count = drain(second.Get());
+    EXPECT_EQ(first_count + second_count, kFrames)
+        << "fanout must not broadcast or drop: first=" << first_count
+        << " second=" << second_count;
+    EXPECT_EQ(first_count, kFrames / 2);
+    EXPECT_EQ(second_count, kFrames / 2);
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/af_packet_mcast.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_mcast.cc
@@ -57,6 +57,12 @@ inline constexpr int kEthPAll = 0x0003;
 #ifndef PACKET_DROP_MEMBERSHIP
 #define PACKET_DROP_MEMBERSHIP 2
 #endif
+#ifndef PACKET_FANOUT
+#define PACKET_FANOUT 18
+#endif
+#ifndef PACKET_FANOUT_LB
+#define PACKET_FANOUT_LB 1
+#endif
 
 // mr_type constants for packet_mreq (corresponding to Linux if_packet.h)
 #ifndef PACKET_MR_PROMISC
@@ -547,6 +553,39 @@ TEST(AfPacketMcast, DuplicateMembershipAndCloseUseOneDeviceReference) {
     EXPECT_EQ(first_drop->promiscuity, first->promiscuity);
 
     fd.Reset();
+    auto closed = GetLinkSnapshot(route_fd.Get(), ifindex, ++seq);
+    ASSERT_TRUE(closed.has_value());
+    EXPECT_EQ(closed->promiscuity, baseline->promiscuity);
+}
+
+TEST(AfPacketMcast, FanoutCloseReleasesPromiscMembership) {
+    FdGuard packet_fd;
+    int ifindex = SetupMcastEnv(&packet_fd);
+    if (ifindex == -1) GTEST_SKIP() << "No usable NIC found";
+    ASSERT_NE(ifindex, -2) << ErrnoString(errno);
+    FdGuard route_fd(OpenRouteSocket());
+    ASSERT_GE(route_fd.Get(), 0) << ErrnoString(errno);
+    uint32_t seq = 150;
+    auto baseline = GetLinkSnapshot(route_fd.Get(), ifindex, ++seq);
+    ASSERT_TRUE(baseline.has_value());
+
+    PacketMreq mreq{};
+    mreq.mr_ifindex = ifindex;
+    mreq.mr_type = PACKET_MR_PROMISC;
+    ASSERT_EQ(setsockopt(packet_fd.Get(), SOL_PACKET, PACKET_ADD_MEMBERSHIP, &mreq,
+                         sizeof(mreq)),
+              0)
+        << ErrnoString(errno);
+
+    constexpr int kFanoutGroup = 0x5a30;
+    int fanout = (PACKET_FANOUT_LB << 16) | kFanoutGroup;
+    ASSERT_EQ(setsockopt(packet_fd.Get(), SOL_PACKET, PACKET_FANOUT, &fanout, sizeof(fanout)), 0)
+        << ErrnoString(errno);
+    auto active = GetLinkSnapshot(route_fd.Get(), ifindex, ++seq);
+    ASSERT_TRUE(active.has_value());
+    EXPECT_EQ(active->promiscuity, baseline->promiscuity + 1);
+
+    packet_fd.Reset();
     auto closed = GetLinkSnapshot(route_fd.Get(), ifindex, ++seq);
     ASSERT_TRUE(closed.has_value());
     EXPECT_EQ(closed->promiscuity, baseline->promiscuity);

--- a/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_sockopt.cc
@@ -77,6 +77,12 @@ struct TestSockAddrLl {
     uint8_t sll_addr[8];
 };
 
+struct TestFanoutArgs {
+    uint32_t id_type_flags;
+    uint32_t max_num_members;
+};
+static_assert(sizeof(TestFanoutArgs) == 8);
+
 // SOL_PACKET level socket options (matching Linux if_packet.h)
 #ifndef PACKET_ADD_MEMBERSHIP
 #define PACKET_ADD_MEMBERSHIP 1
@@ -110,6 +116,30 @@ struct TestSockAddrLl {
 #endif
 #ifndef PACKET_TIMESTAMP
 #define PACKET_TIMESTAMP 17
+#endif
+#ifndef PACKET_FANOUT
+#define PACKET_FANOUT 18
+#endif
+#ifndef PACKET_FANOUT_DATA
+#define PACKET_FANOUT_DATA 22
+#endif
+#ifndef PACKET_FANOUT_HASH
+#define PACKET_FANOUT_HASH 0
+#endif
+#ifndef PACKET_FANOUT_LB
+#define PACKET_FANOUT_LB 1
+#endif
+#ifndef PACKET_FANOUT_ROLLOVER
+#define PACKET_FANOUT_ROLLOVER 3
+#endif
+#ifndef PACKET_FANOUT_FLAG_ROLLOVER
+#define PACKET_FANOUT_FLAG_ROLLOVER 0x1000
+#endif
+#ifndef PACKET_FANOUT_FLAG_UNIQUEID
+#define PACKET_FANOUT_FLAG_UNIQUEID 0x2000
+#endif
+#ifndef PACKET_FANOUT_FLAG_IGNORE_OUTGOING
+#define PACKET_FANOUT_FLAG_IGNORE_OUTGOING 0x4000
 #endif
 #ifndef PACKET_QDISC_BYPASS
 #define PACKET_QDISC_BYPASS 20
@@ -906,6 +936,133 @@ TEST(AfPacketSockopt, RecvmsgDoesNotReturnEnosys) {
     }
     EXPECT_NE(errno, ENOSYS) << "recvmsg returned ENOSYS (feature not implemented)";
     // EAGAIN/EWOULDBLOCK is normal (no data)
+}
+
+TEST(AfPacketSockopt, FanoutRequiresExactLegacyIntegerLength) {
+    const uint8_t value[9]{};
+    for (socklen_t len : {0U, 1U, 3U, 5U, 7U, 9U}) {
+        FdGuard fd(MakeRawFd());
+        ASSERT_GE(fd.Get(), 0);
+        errno = 0;
+        EXPECT_EQ(setsockopt(fd.Get(), SOL_PACKET, PACKET_FANOUT, value, len), -1)
+            << "len=" << len;
+        EXPECT_EQ(errno, EINVAL) << "len=" << len << ": " << ErrnoString(errno);
+    }
+}
+
+TEST(AfPacketSockopt, FanoutArgsControlsGroupCapacity) {
+    constexpr uint32_t kRaw = (PACKET_FANOUT_LB << 16) | 0x5a20;
+    FdGuard first(MakeRawFd());
+    FdGuard second(MakeRawFd());
+    FdGuard third(MakeRawFd());
+    ASSERT_GE(first.Get(), 0);
+    ASSERT_GE(second.Get(), 0);
+    ASSERT_GE(third.Get(), 0);
+
+    TestFanoutArgs args{kRaw, 2};
+    ASSERT_EQ(setsockopt(first.Get(), SOL_PACKET, PACKET_FANOUT, &args, sizeof(args)), 0)
+        << ErrnoString(errno);
+    // Linux permits a legacy (max=0) join to a group created with an explicit
+    // capacity; a non-zero mismatch is rejected.
+    int legacy = static_cast<int>(kRaw);
+    ASSERT_EQ(setsockopt(second.Get(), SOL_PACKET, PACKET_FANOUT, &legacy, sizeof(legacy)), 0)
+        << ErrnoString(errno);
+
+    args.max_num_members = 3;
+    errno = 0;
+    EXPECT_EQ(setsockopt(third.Get(), SOL_PACKET, PACKET_FANOUT, &args, sizeof(args)), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+
+    args.max_num_members = 2;
+    errno = 0;
+    EXPECT_EQ(setsockopt(third.Get(), SOL_PACKET, PACKET_FANOUT, &args, sizeof(args)), -1);
+    EXPECT_EQ(errno, ENOSPC) << ErrnoString(errno);
+
+    args.id_type_flags = (PACKET_FANOUT_LB << 16) | 0x5a25;
+    args.max_num_members = 65537;
+    errno = 0;
+    EXPECT_EQ(setsockopt(third.Get(), SOL_PACKET, PACKET_FANOUT, &args, sizeof(args)), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+}
+
+TEST(AfPacketSockopt, FanoutControlSemanticsMatchLinux) {
+    constexpr int kGroup = 0x5a21;
+    FdGuard first(MakeRawFd());
+    FdGuard second(MakeRawFd());
+    ASSERT_GE(first.Get(), 0);
+    ASSERT_GE(second.Get(), 0);
+
+    int value = (PACKET_FANOUT_LB << 16) | kGroup;
+    ASSERT_EQ(SetIntOpt(first.Get(), PACKET_FANOUT, value), 0) << ErrnoString(errno);
+    int got = -1;
+    ASSERT_EQ(GetIntOpt(first.Get(), PACKET_FANOUT, &got), 0) << ErrnoString(errno);
+    EXPECT_EQ(got, value);
+
+    errno = 0;
+    EXPECT_EQ(SetIntOpt(first.Get(), PACKET_FANOUT, value), -1);
+    EXPECT_EQ(errno, EALREADY) << ErrnoString(errno);
+
+    int mismatched = (PACKET_FANOUT_HASH << 16) | kGroup;
+    errno = 0;
+    EXPECT_EQ(SetIntOpt(second.Get(), PACKET_FANOUT, mismatched), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+    ASSERT_EQ(SetIntOpt(second.Get(), PACKET_FANOUT, value), 0) << ErrnoString(errno);
+
+    TestSockAddrLl bind_addr{};
+    bind_addr.sll_family = AF_PACKET;
+    bind_addr.sll_protocol = htons(kEthPAll);
+    errno = 0;
+    EXPECT_EQ(bind(first.Get(), reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+}
+
+TEST(AfPacketSockopt, FanoutRejectsInactiveAndDualRollover) {
+    FdGuard inactive(socket(AF_PACKET, SOCK_RAW, 0));
+    ASSERT_GE(inactive.Get(), 0) << ErrnoString(errno);
+    int hash = (PACKET_FANOUT_HASH << 16) | 0x5a22;
+    errno = 0;
+    EXPECT_EQ(SetIntOpt(inactive.Get(), PACKET_FANOUT, hash), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+
+    FdGuard active(MakeRawFd());
+    ASSERT_GE(active.Get(), 0);
+    int dual = ((PACKET_FANOUT_ROLLOVER | PACKET_FANOUT_FLAG_ROLLOVER) << 16) | 0x5a23;
+    errno = 0;
+    EXPECT_EQ(SetIntOpt(active.Get(), PACKET_FANOUT, dual), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+}
+
+TEST(AfPacketSockopt, FanoutUniqueIdIsAllocationOnly) {
+    FdGuard first(MakeRawFd());
+    FdGuard second(MakeRawFd());
+    ASSERT_GE(first.Get(), 0);
+    ASSERT_GE(second.Get(), 0);
+
+    int request = (PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_UNIQUEID) << 16;
+    ASSERT_EQ(SetIntOpt(first.Get(), PACKET_FANOUT, request), 0) << ErrnoString(errno);
+    int assigned = -1;
+    ASSERT_EQ(GetIntOpt(first.Get(), PACKET_FANOUT, &assigned), 0) << ErrnoString(errno);
+    EXPECT_EQ((assigned >> 16) & PACKET_FANOUT_FLAG_UNIQUEID, 0);
+    ASSERT_EQ(SetIntOpt(second.Get(), PACKET_FANOUT, assigned), 0) << ErrnoString(errno);
+
+    FdGuard invalid(MakeRawFd());
+    int invalid_request = request | 7;
+    errno = 0;
+    EXPECT_EQ(SetIntOpt(invalid.Get(), PACKET_FANOUT, invalid_request), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
+}
+
+TEST(AfPacketSockopt, FanoutIgnoreOutgoingAndDataValidation) {
+    FdGuard fd(MakeRawFd());
+    ASSERT_GE(fd.Get(), 0);
+    int value = ((PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_IGNORE_OUTGOING) << 16) | 0x5a24;
+    ASSERT_EQ(SetIntOpt(fd.Get(), PACKET_FANOUT, value), 0) << ErrnoString(errno);
+    int got = 0;
+    ASSERT_EQ(GetIntOpt(fd.Get(), PACKET_FANOUT, &got), 0) << ErrnoString(errno);
+    EXPECT_EQ(got, value);
+    errno = 0;
+    EXPECT_EQ(SetIntOpt(fd.Get(), PACKET_FANOUT_DATA, 0), -1);
+    EXPECT_EQ(errno, EINVAL) << ErrnoString(errno);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Closes #2032.

Supersedes #2119 with the same AF_PACKET fanout implementation rebased onto the current `master`, including the merged PACKET_ADD_MEMBERSHIP / PACKET_DROP_MEMBERSHIP support.

## What changed

- implement Linux-compatible PACKET_FANOUT modes, flags, group lifecycle, and control-plane semantics;
- preserve PACKET_MR membership handling and its close-time device reference cleanup after the rebase;
- stop inactive sockets from receiving through stale immutable topology snapshots;
- wake the namespace poller for deferred AF_PACKET topology cleanup and retry allocation failures with bounded exponential backoff;
- keep cleanup-only and network wake reasons separate so cleanup does not spuriously schedule interface NAPI;
- add a regression test for closing a socket that combines PROMISC membership with fanout membership.

## Validation

- `make all -j 8`
- `make kernel`
- QEMU: `af_packet_sockopt_test` (38/38 passed)
- QEMU: `af_packet_e2e_test` (14/14 passed)
- QEMU: `af_packet_mcast_test` (14/14 passed)

The implementation and rebase were independently reviewed for concurrency, lifecycle safety, Linux semantics, performance, security, and regression risk.
