### PR TITLE
fix(ext4): Remove undefined and unused error codes from Linux kernel

### DIFF
--- a/kernel/crates/another_ext4/src/error.rs
+++ b/kernel/crates/another_ext4/src/error.rs
@@ -53,10 +53,6 @@ pub enum ErrCode {
     ENODATA = 61,
     /// Not supported.
     ENOTSUP = 95,
-    /// Link failed.
-    ELINKFAIL = 97,
-    /// Inode alloc failed.
-    EALLOCFAIL = 98,
 }
 
 /// error used in this crate


### PR DESCRIPTION
delete error code which is not defined in linux kernel source and nerver use