### PR TITLE
fix(timekeeping): restore monotonic clock and clocksource semantics

### DIFF
--- a/kernel/src/arch/riscv64/interrupt/handle.rs
+++ b/kernel/src/arch/riscv64/interrupt/handle.rs
@@ -57,6 +57,7 @@ fn try_fixup_kernel_user_access(trap_frame: &mut TrapFrame) -> bool {
 #[no_mangle]
 unsafe extern "C" fn riscv64_do_irq(trap_frame: &mut TrapFrame) {
     if trap_frame.cause.is_interrupt() {
+        let hardirq_guard = crate::exception::enter_hardirq();
         crate::rcu::irq_enter();
         riscv64_do_interrupt(trap_frame);
         let irq_outermost = crate::rcu::irq_is_outermost();
@@ -69,6 +70,7 @@ unsafe extern "C" fn riscv64_do_irq(trap_frame: &mut TrapFrame) {
         let resume_idle_eqs = !should_schedule
             && ProcessManager::current_pcb().sched_info().policy() == SchedPolicy::IDLE;
         let irq_exited_outermost = crate::rcu::irq_exit(resume_idle_eqs);
+        drop(hardirq_guard);
 
         if should_schedule && irq_exited_outermost {
             __schedule(SchedMode::SM_PREEMPT);

--- a/kernel/src/arch/x86_64/driver/hpet.rs
+++ b/kernel/src/arch/x86_64/driver/hpet.rs
@@ -79,6 +79,8 @@ struct InnerHpet {
     timer_registers_ptr: NonNull<HpetTimerRegisters>,
     /// 定时器启动时配置
     timer_boot_cfg: Vec<u64>,
+    /// 定时器启动时比较器值
+    timer_boot_comparator: Vec<u64>,
 }
 
 impl Hpet {
@@ -127,10 +129,12 @@ impl Hpet {
         .unwrap();
         // 记录hpet定时器启动时配置
         let mut timer_boot_cfg = Vec::with_capacity(tm_num as usize);
+        let mut timer_boot_comparator = Vec::with_capacity(tm_num as usize);
         for i in 0..tm_num {
             let timer_reg = unsafe { timer_ptr.as_ptr().add(i).as_ref().unwrap() };
             let cfg = timer_reg.config();
             timer_boot_cfg.push(cfg);
+            timer_boot_comparator.push(timer_reg.comparator_value());
         }
 
         let hpet = Hpet {
@@ -140,6 +144,7 @@ impl Hpet {
                 registers_ptr: ptr,
                 timer_registers_ptr: timer_ptr,
                 timer_boot_cfg,
+                timer_boot_comparator,
             }),
             enabled: AtomicBool::new(false),
             boot_cfg,
@@ -156,6 +161,21 @@ impl Hpet {
     pub fn hpet_enable(&self) -> Result<(), SystemError> {
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
 
+        let result = self.try_hpet_enable();
+        if result.is_err() {
+            // Hpet::new() disables the device, and try_hpet_enable() may also
+            // restart the counter or program timer 0 before reporting an
+            // error. Restore the firmware state even though `enabled` was
+            // never published, so fallback clocks cannot inherit a partially
+            // configured HPET.
+            self.restore_boot_configuration();
+        }
+
+        drop(irq_guard);
+        return result;
+    }
+
+    fn try_hpet_enable(&self) -> Result<(), SystemError> {
         // ！！！这里是临时糊代码的，需要在apic重构的时候修改！！！
         let (inner_guard, regs) = unsafe { self.hpet_regs_mut() };
         let freq = regs.frequency();
@@ -204,8 +224,6 @@ impl Hpet {
         drop(inner_guard);
 
         info!("HPET enabled");
-
-        drop(irq_guard);
         return Ok(());
     }
 
@@ -350,13 +368,10 @@ impl Hpet {
         unsafe { regs.write_general_config(cfg) };
     }
 
-    /// 关闭hpet
-    pub fn hpet_disable(&self) {
-        debug!("HPET disable");
-        if !is_hpet_enabled() {
-            return;
-        }
-
+    /// Restore every HPET register modified during initialization or enable.
+    /// This intentionally does not consult `enabled`: failed enable attempts
+    /// must be rolled back before that flag is set.
+    fn restore_boot_configuration(&self) {
         // 恢复启动时的配置
         let mut cfg = self.boot_cfg;
         cfg &= !HPET_CFG_ENABLE;
@@ -368,17 +383,27 @@ impl Hpet {
             let (inner_guard, timer_reg) = unsafe { self.timer_mut(i).unwrap() };
             unsafe {
                 timer_reg.write_config(inner_guard.timer_boot_cfg[i as usize]);
+                timer_reg.write_comparator_value(inner_guard.timer_boot_comparator[i as usize]);
             }
             drop(inner_guard);
         }
 
-        // 如果HPET在启动时已经启用了，重新启用它
-        if (self.boot_cfg & HPET_CFG_ENABLE) != 0 {
-            let (_, regs) = unsafe { self.hpet_regs_mut() };
-            unsafe { regs.write_general_config(self.boot_cfg) };
-        }
+        // Restore the complete firmware configuration last. This also
+        // restarts a counter that firmware left enabled.
+        let (_, regs) = unsafe { self.hpet_regs_mut() };
+        unsafe { regs.write_general_config(self.boot_cfg) };
 
         self.enabled.store(false, Ordering::SeqCst);
+    }
+
+    /// 关闭hpet
+    pub fn hpet_disable(&self) {
+        debug!("HPET disable");
+        if !is_hpet_enabled() {
+            return;
+        }
+
+        self.restore_boot_configuration();
     }
 }
 

--- a/kernel/src/arch/x86_64/init/mod.rs
+++ b/kernel/src/arch/x86_64/init/mod.rs
@@ -3,7 +3,7 @@ use core::{
     sync::atomic::{compiler_fence, Ordering},
 };
 
-use log::debug;
+use log::{debug, warn};
 use system_error::SystemError;
 use x86::dtables::DescriptorTablePointer;
 
@@ -115,13 +115,45 @@ pub fn setup_arch_post() -> Result<(), SystemError> {
     // 3.如果 kvm-clock 和 HPET 都不可用，则回退到 ACPI PM Timer
     // 4.最后初始化 TSC 管理器 （既可以通过 kvm-clock 提供的 pvclock 确定 TSC 频率，也可以通过其他方法确定 TSC 频率）
     let kvmclock_ok = kvm_clock::kvmclock_init();
-    let ret = hpet_init();
-    if ret.is_ok() {
-        hpet_instance().hpet_enable().expect("hpet enable failed");
-    } else if !kvmclock_ok {
-        init_acpi_pm_clocksource().expect("acpi_pm_timer inits failed");
+    let hpet_ok = match hpet_init() {
+        Ok(()) => match hpet_instance().hpet_enable() {
+            Ok(_) => true,
+            Err(error) => {
+                warn!(
+                    "HPET enable failed, retaining fallback clocksource: {:?}",
+                    error
+                );
+                false
+            }
+        },
+        Err(error) => {
+            warn!(
+                "HPET init failed, retaining fallback clocksource: {:?}",
+                error
+            );
+            false
+        }
+    };
+    if !kvmclock_ok && !hpet_ok {
+        if let Err(error) = init_acpi_pm_clocksource() {
+            // jiffies is already registered and installed by timekeeping_init.
+            warn!(
+                "ACPI PM timer unavailable, continuing with jiffies: {:?}",
+                error
+            );
+        }
     }
-    TSCManager::init().expect("tsc init failed");
+    if let Err(error) = TSCManager::init() {
+        if TSCManager::cpu_khz() == 0 {
+            // The scheduler clock and APIC timer still require CPU_KHZ even
+            // when POSIX timekeeping can remain on jiffies.
+            return Err(error);
+        }
+        warn!(
+            "TSC clocksource unavailable, continuing with registered clocksource: {:?}",
+            error
+        );
+    }
 
     return Ok(());
 }

--- a/kernel/src/arch/x86_64/interrupt/handle.rs
+++ b/kernel/src/arch/x86_64/interrupt/handle.rs
@@ -17,6 +17,7 @@ unsafe extern "C" fn x86_64_do_irq(trap_frame: &mut TrapFrame, vector: u32) {
         x86_64::registers::segmentation::GS::swap();
     }
 
+    let hardirq_guard = crate::exception::enter_hardirq();
     crate::rcu::irq_enter();
 
     // 由于x86上面，虚拟中断号与物理中断号是一一对应的，所以这里直接使用vector作为中断号来查询irqdesc
@@ -46,6 +47,7 @@ unsafe extern "C" fn x86_64_do_irq(trap_frame: &mut TrapFrame, vector: u32) {
     let resume_idle_eqs = !should_schedule
         && ProcessManager::current_pcb().sched_info().policy() == SchedPolicy::IDLE;
     let irq_exited_outermost = crate::rcu::irq_exit(resume_idle_eqs);
+    drop(hardirq_guard);
 
     if should_schedule && irq_exited_outermost {
         __schedule(SchedMode::SM_PREEMPT);

--- a/kernel/src/debug/mod.rs
+++ b/kernel/src/debug/mod.rs
@@ -10,5 +10,6 @@ pub mod page_cache;
 pub mod panic;
 pub mod rcu;
 pub mod sysfs;
+pub mod timekeeping;
 pub mod traceback;
 pub mod tracing;

--- a/kernel/src/debug/sysfs/mod.rs
+++ b/kernel/src/debug/sysfs/mod.rs
@@ -28,6 +28,7 @@ fn debugfs_init() -> Result<(), SystemError> {
     super::fuse::init_debugfs_fuse()?;
     super::kthread::init_debugfs_kthread()?;
     super::page_cache::init_debugfs_page_cache()?;
+    super::timekeeping::init_debugfs_timekeeping()?;
     return Ok(());
 }
 

--- a/kernel/src/debug/timekeeping.rs
+++ b/kernel/src/debug/timekeeping.rs
@@ -10,7 +10,7 @@ use crate::{
         vfs::{InodeMode, PollStatus},
     },
     libs::rwlock::run_rwlock_selftests,
-    time::timekeeping::run_timekeeping_selftests,
+    time::{clocksource::run_clocksource_selftests, timekeeping::run_timekeeping_selftests},
 };
 
 #[cfg(target_arch = "x86_64")]
@@ -92,16 +92,17 @@ impl KernFSCallback for TimekeepingSelftestCallback {
 
 fn run_selftests() -> String {
     let (timekeeping_passed, timekeeping_failed, timekeeping_body) = run_timekeeping_selftests();
+    let (clocksource_passed, clocksource_failed, clocksource_body) = run_clocksource_selftests();
     let (rwlock_passed, rwlock_failed, rwlock_body) = run_rwlock_selftests();
     #[cfg(target_arch = "x86_64")]
     let (kvm_passed, kvm_failed, kvm_body) = run_kvm_clock_allocator_selftests();
     #[cfg(not(target_arch = "x86_64"))]
     let (kvm_passed, kvm_failed, kvm_body) = (0, 0, String::new());
-    let passed = timekeeping_passed + rwlock_passed + kvm_passed;
-    let failed = timekeeping_failed + rwlock_failed + kvm_failed;
+    let passed = timekeeping_passed + clocksource_passed + rwlock_passed + kvm_passed;
+    let failed = timekeeping_failed + clocksource_failed + rwlock_failed + kvm_failed;
     let status = if failed == 0 { "ok" } else { "fail" };
     format!(
-        "status={status}\n{timekeeping_body}{rwlock_body}{kvm_body}summary_pass={passed}\nsummary_fail={failed}\n"
+        "status={status}\n{timekeeping_body}{clocksource_body}{rwlock_body}{kvm_body}summary_pass={passed}\nsummary_fail={failed}\n"
     )
 }
 

--- a/kernel/src/debug/timekeeping.rs
+++ b/kernel/src/debug/timekeeping.rs
@@ -1,0 +1,125 @@
+use alloc::{format, string::String, string::ToString};
+
+use system_error::SystemError;
+
+use crate::{
+    debug::sysfs::debugfs_kobj,
+    driver::base::kobject::KObject,
+    filesystem::{
+        kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData},
+        vfs::{InodeMode, PollStatus},
+    },
+    libs::rwlock::run_rwlock_selftests,
+    time::timekeeping::run_timekeeping_selftests,
+};
+
+#[cfg(target_arch = "x86_64")]
+use crate::driver::clocksource::kvm_clock::run_kvm_clock_allocator_selftests;
+
+#[derive(Debug)]
+struct TimekeepingDirCallback;
+
+impl KernFSCallback for TimekeepingDirCallback {
+    fn open(&self, _data: KernCallbackData) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        _data: KernCallbackData,
+        _buf: &mut [u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EISDIR)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EISDIR)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Err(SystemError::EISDIR)
+    }
+}
+
+#[derive(Debug)]
+struct TimekeepingSelftestCallback;
+
+impl KernFSCallback for TimekeepingSelftestCallback {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(run_selftests()));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+fn run_selftests() -> String {
+    let (timekeeping_passed, timekeeping_failed, timekeeping_body) = run_timekeeping_selftests();
+    let (rwlock_passed, rwlock_failed, rwlock_body) = run_rwlock_selftests();
+    #[cfg(target_arch = "x86_64")]
+    let (kvm_passed, kvm_failed, kvm_body) = run_kvm_clock_allocator_selftests();
+    #[cfg(not(target_arch = "x86_64"))]
+    let (kvm_passed, kvm_failed, kvm_body) = (0, 0, String::new());
+    let passed = timekeeping_passed + rwlock_passed + kvm_passed;
+    let failed = timekeeping_failed + rwlock_failed + kvm_failed;
+    let status = if failed == 0 { "ok" } else { "fail" };
+    format!(
+        "status={status}\n{timekeeping_body}{rwlock_body}{kvm_body}summary_pass={passed}\nsummary_fail={failed}\n"
+    )
+}
+
+pub fn init_debugfs_timekeeping() -> Result<(), SystemError> {
+    let debugfs = debugfs_kobj();
+    let root_dir = debugfs.inode().ok_or(SystemError::ENOENT)?;
+    let timekeeping_root = root_dir.add_dir(
+        "timekeeping".to_string(),
+        InodeMode::from_bits_truncate(0o500),
+        None,
+        Some(&TimekeepingDirCallback),
+    )?;
+    timekeeping_root.add_file(
+        "selftest".to_string(),
+        InodeMode::S_IRUSR,
+        Some(16 * 1024),
+        None,
+        Some(&TimekeepingSelftestCallback),
+    )?;
+    Ok(())
+}

--- a/kernel/src/driver/clocksource/acpi_pm.rs
+++ b/kernel/src/driver/clocksource/acpi_pm.rs
@@ -7,7 +7,10 @@ use crate::{
     },
     libs::spinlock::SpinLock,
     time::{
-        clocksource::{Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, CycleNum},
+        clocksource::{
+            Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, ClocksourceUpdate,
+            CycleNum,
+        },
         PIT_TICK_RATE,
     },
 };
@@ -85,13 +88,13 @@ impl Acpipm {
             mask: ClocksourceMask::new(ACPI_PM_MASK),
             mult: 0,
             shift: 0,
+            max_cycles: Default::default(),
             max_idle_ns: Default::default(),
             flags: ClocksourceFlags::CLOCK_SOURCE_IS_CONTINUOUS,
             watchdog_last: CycleNum::new(0),
             cs_last: CycleNum::new(0),
             uncertainty_margin: 0,
             maxadj: 0,
-            cycle_last: CycleNum::new(0),
         };
         let acpi_pm = Arc::new(Acpipm(SpinLock::new(InnerAcpipm {
             data,
@@ -117,20 +120,8 @@ impl Clocksource for Acpipm {
         return self.0.lock_irqsave().self_reaf.upgrade().unwrap();
     }
 
-    fn update_clocksource_data(&self, data: ClocksourceData) -> Result<(), SystemError> {
-        let d = &mut self.0.lock_irqsave().data;
-        d.set_name(data.name);
-        d.set_rating(data.rating);
-        d.set_mask(data.mask);
-        d.set_mult(data.mult);
-        d.set_shift(data.shift);
-        d.set_max_idle_ns(data.max_idle_ns);
-        d.set_flags(data.flags);
-        d.watchdog_last = data.watchdog_last;
-        d.cs_last = data.cs_last;
-        d.set_uncertainty_margin(data.uncertainty_margin);
-        d.set_maxadj(data.maxadj);
-        d.cycle_last = data.cycle_last;
+    fn update_clocksource_data(&self, update: ClocksourceUpdate) -> Result<(), SystemError> {
+        update.apply(&mut self.0.lock_irqsave().data);
         return Ok(());
     }
 }

--- a/kernel/src/driver/clocksource/kvm_clock.rs
+++ b/kernel/src/driver/clocksource/kvm_clock.rs
@@ -19,8 +19,12 @@ use crate::{
         MemoryManagementArch, PhysAddr, VirtAddr,
     },
     smp::core::smp_get_processor_id,
+    smp::cpu::{smp_cpu_manager, ProcessorId},
     time::{
-        clocksource::{Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, CycleNum},
+        clocksource::{
+            Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, ClocksourceUpdate,
+            CycleNum,
+        },
         NSEC_PER_SEC,
     },
 };
@@ -49,8 +53,6 @@ impl KvmClockPage {
 }
 
 static mut KVM_CLOCK_PAGES: Option<PerCpuVar<KvmClockPage>> = None;
-static mut CLOCKSOURCE_KVM: Option<Arc<KvmClock>> = None;
-
 static MSR_KVM_SYSTEM_TIME: AtomicU32 = AtomicU32::new(0);
 static KVM_CLOCK_READY: AtomicBool = AtomicBool::new(false);
 
@@ -71,13 +73,13 @@ impl KvmClock {
             mask: ClocksourceMask::new(u64::MAX),
             mult: 0,
             shift: 0,
+            max_cycles: Default::default(),
             max_idle_ns: Default::default(),
             flags: ClocksourceFlags::CLOCK_SOURCE_IS_CONTINUOUS,
             watchdog_last: CycleNum::new(0),
             cs_last: CycleNum::new(0),
             uncertainty_margin: 0,
             maxadj: 0,
-            cycle_last: CycleNum::new(0),
         };
         let kvm = Arc::new(KvmClock(SpinLock::new(InnerKvmClock {
             data,
@@ -90,7 +92,7 @@ impl KvmClock {
 
 impl Clocksource for KvmClock {
     fn read(&self) -> CycleNum {
-        let now = kvm_clock_read().unwrap_or(0);
+        let now = kvm_clock_read().expect("active kvm-clock CPU has no pvclock page");
         CycleNum::new(now)
     }
 
@@ -106,20 +108,8 @@ impl Clocksource for KvmClock {
         self.0.lock_irqsave().self_ref.upgrade().unwrap()
     }
 
-    fn update_clocksource_data(&self, data: ClocksourceData) -> Result<(), SystemError> {
-        let d = &mut self.0.lock_irqsave().data;
-        d.set_name(data.name);
-        d.set_rating(data.rating);
-        d.set_mask(data.mask);
-        d.set_mult(data.mult);
-        d.set_shift(data.shift);
-        d.set_max_idle_ns(data.max_idle_ns);
-        d.set_flags(data.flags);
-        d.watchdog_last = data.watchdog_last;
-        d.cs_last = data.cs_last;
-        d.set_uncertainty_margin(data.uncertainty_margin);
-        d.set_maxadj(data.maxadj);
-        d.cycle_last = data.cycle_last;
+    fn update_clocksource_data(&self, update: ClocksourceUpdate) -> Result<(), SystemError> {
+        update.apply(&mut self.0.lock_irqsave().data);
         Ok(())
     }
 }
@@ -142,31 +132,122 @@ fn ensure_kvm_clock_pages() {
     }
 }
 
-fn alloc_clock_page() -> Result<KvmClockPage, SystemError> {
-    let phys = unsafe { crate::arch::mm::LockedFrameAllocator.allocate_one() }
-        .ok_or(SystemError::ENOMEM)?;
-    let virt = unsafe { MMArch::phys_2_virt(phys) }.ok_or(SystemError::EINVAL)?;
+trait ClockPageAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysAddr>;
+    fn map_frame(&mut self, phys: PhysAddr) -> Option<VirtAddr>;
+    fn clear_page(&mut self, virt: VirtAddr);
+    fn release_frame(&mut self, phys: PhysAddr);
+}
 
-    unsafe {
-        MMArch::write_bytes(virt, 0, MMArch::PAGE_SIZE);
+struct SystemClockPageAllocator;
+
+impl ClockPageAllocator for SystemClockPageAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysAddr> {
+        unsafe { crate::arch::mm::LockedFrameAllocator.allocate_one() }
     }
 
+    fn map_frame(&mut self, phys: PhysAddr) -> Option<VirtAddr> {
+        unsafe { MMArch::phys_2_virt(phys) }
+    }
+
+    fn clear_page(&mut self, virt: VirtAddr) {
+        unsafe { MMArch::write_bytes(virt, 0, MMArch::PAGE_SIZE) };
+    }
+
+    fn release_frame(&mut self, phys: PhysAddr) {
+        unsafe { crate::arch::mm::LockedFrameAllocator.free_one(phys) };
+    }
+}
+
+fn alloc_clock_page_with<A: ClockPageAllocator>(
+    allocator: &mut A,
+) -> Result<KvmClockPage, SystemError> {
+    let phys = allocator.allocate_frame().ok_or(SystemError::ENOMEM)?;
+    let Some(virt) = allocator.map_frame(phys) else {
+        allocator.release_frame(phys);
+        return Err(SystemError::EINVAL);
+    };
+    allocator.clear_page(virt);
     Ok(KvmClockPage { phys, virt })
 }
 
-fn ensure_clock_page_for_cpu() -> Result<KvmClockPage, SystemError> {
+fn release_clock_page_with<A: ClockPageAllocator>(allocator: &mut A, page: KvmClockPage) {
+    allocator.release_frame(page.phys);
+}
+
+fn allocate_missing_pages<A: ClockPageAllocator>(
+    missing_cpus: &[ProcessorId],
+    allocator: &mut A,
+) -> Result<Vec<(ProcessorId, KvmClockPage)>, SystemError> {
+    let mut staged = Vec::with_capacity(missing_cpus.len());
+    for &cpu_id in missing_cpus {
+        match alloc_clock_page_with(allocator) {
+            Ok(page) => staged.push((cpu_id, page)),
+            Err(error) => {
+                for (_, page) in staged.drain(..) {
+                    release_clock_page_with(allocator, page);
+                }
+                return Err(error);
+            }
+        }
+    }
+    Ok(staged)
+}
+
+fn alloc_clock_page() -> Result<KvmClockPage, SystemError> {
+    alloc_clock_page_with(&mut SystemClockPageAllocator)
+}
+
+fn ensure_clock_page_for_cpu() -> Result<(KvmClockPage, bool), SystemError> {
     ensure_kvm_clock_pages();
     let cpu_id = smp_get_processor_id();
     let pages = kvm_clock_pages();
 
     let page = unsafe { pages.force_get_mut(cpu_id) };
     if page.is_valid() {
-        return Ok(*page);
+        return Ok((*page, false));
     }
 
     let new_page = alloc_clock_page()?;
     *page = new_page;
-    Ok(new_page)
+    Ok((new_page, true))
+}
+
+fn prepare_clock_pages_for_present_cpus() -> Result<Vec<ProcessorId>, SystemError> {
+    ensure_kvm_clock_pages();
+    let pages = kvm_clock_pages();
+    let mut missing = Vec::new();
+    for cpu_id in smp_cpu_manager().present_cpus().iter_cpu() {
+        let slot = unsafe { pages.force_get_mut(cpu_id) };
+        if !slot.is_valid() {
+            missing.push(cpu_id);
+        }
+    }
+
+    // Allocate into local staging first. No real per-CPU slot is changed until
+    // every allocation and mapping has succeeded.
+    let staged = allocate_missing_pages(&missing, &mut SystemClockPageAllocator)?;
+    let mut committed = Vec::with_capacity(staged.len());
+    for (cpu_id, page) in staged {
+        let slot = unsafe { pages.force_get_mut(cpu_id) };
+        debug_assert!(!slot.is_valid());
+        *slot = page;
+        committed.push(cpu_id);
+    }
+    Ok(committed)
+}
+
+fn rollback_clock_pages(cpu_ids: &[ProcessorId]) {
+    let pages = kvm_clock_pages();
+    let mut allocator = SystemClockPageAllocator;
+    for &cpu_id in cpu_ids.iter().rev() {
+        let slot = unsafe { pages.force_get_mut(cpu_id) };
+        if slot.is_valid() {
+            let page = *slot;
+            *slot = KvmClockPage::empty();
+            release_clock_page_with(&mut allocator, page);
+        }
+    }
 }
 
 fn this_cpu_pvti() -> Option<&'static PvclockVcpuTimeInfo> {
@@ -188,6 +269,13 @@ fn write_system_time_msr(phys: PhysAddr) {
 
     let val = (phys.data() as u64) | 1u64;
     unsafe { wrmsr(msr, val) };
+}
+
+fn disable_system_time_msr() {
+    let msr = MSR_KVM_SYSTEM_TIME.load(Ordering::SeqCst);
+    if msr != 0 {
+        unsafe { wrmsr(msr, 0) };
+    }
 }
 
 fn kvm_clock_read() -> Option<u64> {
@@ -229,14 +317,24 @@ pub fn kvmclock_init() -> bool {
         return false;
     }
 
-    ensure_kvm_clock_pages();
-    let page = match ensure_clock_page_for_cpu() {
-        Ok(page) => page,
+    let mut committed_pages = match prepare_clock_pages_for_present_cpus() {
+        Ok(committed) => committed,
         Err(e) => {
-            warn!("kvm-clock: alloc clock page failed: {:?}", e);
+            warn!("kvm-clock: prealloc pvclock pages failed: {:?}", e);
             return false;
         }
     };
+    let (page, newly_allocated) = match ensure_clock_page_for_cpu() {
+        Ok(result) => result,
+        Err(e) => {
+            warn!("kvm-clock: alloc clock page failed: {:?}", e);
+            rollback_clock_pages(&committed_pages);
+            return false;
+        }
+    };
+    if newly_allocated {
+        committed_pages.push(smp_get_processor_id());
+    }
 
     if kvm_para::kvm_para_has_feature(kvm_para::KVM_FEATURE_CLOCKSOURCE_STABLE_BIT) {
         pvclock::pvclock_set_flags(PVCLOCK_TSC_STABLE_BIT);
@@ -248,12 +346,11 @@ pub fn kvmclock_init() -> bool {
     let clock = kvm_clock.clone() as Arc<dyn Clocksource>;
     if let Err(e) = clock.register(1, NSEC_PER_SEC) {
         warn!("kvm-clock: register failed: {:?}", e);
+        disable_system_time_msr();
+        rollback_clock_pages(&committed_pages);
         return false;
     }
 
-    unsafe {
-        CLOCKSOURCE_KVM = Some(kvm_clock);
-    }
     KVM_CLOCK_READY.store(true, Ordering::SeqCst);
 
     update_tsc_khz_from_pvclock();
@@ -262,15 +359,22 @@ pub fn kvmclock_init() -> bool {
     true
 }
 
-pub fn kvmclock_init_secondary() {
+pub fn kvmclock_init_secondary() -> Result<(), SystemError> {
     if !KVM_CLOCK_READY.load(Ordering::SeqCst) {
-        return;
+        return Ok(());
     }
 
-    let page = match ensure_clock_page_for_cpu() {
-        Ok(page) => page,
-        Err(_) => return,
-    };
+    let cpu_id = smp_get_processor_id();
+    let page = unsafe { *kvm_clock_pages().force_get(cpu_id) };
+    if !page.is_valid() {
+        return Err(SystemError::ENODEV);
+    }
 
     write_system_time_msr(page.phys);
+    Ok(())
 }
+
+#[path = "kvm_clock_selftest.rs"]
+mod selftest;
+
+pub(crate) use selftest::run_kvm_clock_allocator_selftests;

--- a/kernel/src/driver/clocksource/kvm_clock_selftest.rs
+++ b/kernel/src/driver/clocksource/kvm_clock_selftest.rs
@@ -1,0 +1,156 @@
+use alloc::{format, string::String, vec::Vec};
+
+use crate::smp::cpu::ProcessorId;
+
+use super::*;
+
+struct FakeAllocator {
+    allocate_calls: usize,
+    map_calls: usize,
+    clear_calls: usize,
+    fail_allocate_at: Option<usize>,
+    fail_map_at: Option<usize>,
+    released: Vec<usize>,
+}
+
+impl FakeAllocator {
+    fn new() -> Self {
+        Self {
+            allocate_calls: 0,
+            map_calls: 0,
+            clear_calls: 0,
+            fail_allocate_at: None,
+            fail_map_at: None,
+            released: Vec::new(),
+        }
+    }
+}
+
+impl ClockPageAllocator for FakeAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysAddr> {
+        self.allocate_calls += 1;
+        if self.fail_allocate_at == Some(self.allocate_calls) {
+            return None;
+        }
+        Some(PhysAddr::new(self.allocate_calls * 0x1000))
+    }
+
+    fn map_frame(&mut self, phys: PhysAddr) -> Option<VirtAddr> {
+        self.map_calls += 1;
+        if self.fail_map_at == Some(self.map_calls) {
+            return None;
+        }
+        Some(VirtAddr::new(0xffff_8000_0000_0000usize + phys.data()))
+    }
+
+    fn clear_page(&mut self, _virt: VirtAddr) {
+        self.clear_calls += 1;
+    }
+
+    fn release_frame(&mut self, phys: PhysAddr) {
+        self.released.push(phys.data());
+    }
+}
+
+struct Report {
+    text: String,
+    passed: usize,
+    failed: usize,
+}
+
+impl Report {
+    fn new() -> Self {
+        Self {
+            text: String::new(),
+            passed: 0,
+            failed: 0,
+        }
+    }
+
+    fn case(&mut self, name: &str, ok: bool) {
+        if ok {
+            self.passed += 1;
+            self.text.push_str(&format!("kvm_allocator.{name}=ok\n"));
+        } else {
+            self.failed += 1;
+            self.text.push_str(&format!("kvm_allocator.{name}=fail\n"));
+        }
+    }
+}
+
+pub(crate) fn run_kvm_clock_allocator_selftests() -> (usize, usize, String) {
+    let mut report = Report::new();
+    let cpus = [
+        ProcessorId::new(0),
+        ProcessorId::new(2),
+        ProcessorId::new(7),
+    ];
+
+    let mut empty_allocator = FakeAllocator::new();
+    let empty = allocate_missing_pages(&[], &mut empty_allocator);
+    report.case(
+        "empty",
+        empty.as_ref().is_ok_and(Vec::is_empty)
+            && empty_allocator.allocate_calls == 0
+            && empty_allocator.released.is_empty(),
+    );
+
+    let mut success_allocator = FakeAllocator::new();
+    let success = allocate_missing_pages(&cpus, &mut success_allocator);
+    let success_ok = success.as_ref().is_ok_and(|pages| {
+        pages.len() == cpus.len()
+            && pages
+                .iter()
+                .zip(cpus.iter())
+                .all(|((actual_cpu, page), expected_cpu)| {
+                    actual_cpu == expected_cpu && page.is_valid()
+                })
+    });
+    report.case(
+        "staged_success",
+        success_ok
+            && success_allocator.allocate_calls == cpus.len()
+            && success_allocator.map_calls == cpus.len()
+            && success_allocator.clear_calls == cpus.len()
+            && success_allocator.released.is_empty(),
+    );
+
+    let mut all_allocation_failures_ok = true;
+    for fail_at in 1..=cpus.len() {
+        let mut allocator = FakeAllocator::new();
+        allocator.fail_allocate_at = Some(fail_at);
+        let result = allocate_missing_pages(&cpus, &mut allocator);
+        all_allocation_failures_ok &= matches!(result, Err(SystemError::ENOMEM))
+            && allocator.released.len() == fail_at - 1
+            && allocator.clear_calls == fail_at - 1;
+    }
+    report.case("allocation_failure_rollback", all_allocation_failures_ok);
+
+    let mut all_mapping_failures_ok = true;
+    for fail_at in 1..=cpus.len() {
+        let mut allocator = FakeAllocator::new();
+        allocator.fail_map_at = Some(fail_at);
+        let result = allocate_missing_pages(&cpus, &mut allocator);
+        all_mapping_failures_ok &= matches!(result, Err(SystemError::EINVAL))
+            && allocator.released.len() == fail_at
+            && allocator.clear_calls == fail_at - 1;
+        allocator.released.sort_unstable();
+        allocator.released.dedup();
+        all_mapping_failures_ok &= allocator.released.len() == fail_at;
+    }
+    report.case("mapping_failure_releases_frame", all_mapping_failures_ok);
+
+    let mut retry_allocator = FakeAllocator::new();
+    retry_allocator.fail_allocate_at = Some(2);
+    let first = allocate_missing_pages(&cpus, &mut retry_allocator);
+    retry_allocator.fail_allocate_at = None;
+    let second = allocate_missing_pages(&cpus, &mut retry_allocator);
+    report.case(
+        "retry_after_rollback",
+        matches!(first, Err(SystemError::ENOMEM))
+            && second.as_ref().is_ok_and(|pages| pages.len() == cpus.len())
+            && retry_allocator.released.len() == 1,
+    );
+
+    (report.passed, report.failed, report.text)
+}

--- a/kernel/src/driver/clocksource/tsc.rs
+++ b/kernel/src/driver/clocksource/tsc.rs
@@ -9,7 +9,10 @@ use crate::{
     arch::{driver::tsc::TSCManager, CurrentTimeArch},
     libs::spinlock::SpinLock,
     time::{
-        clocksource::{Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, CycleNum},
+        clocksource::{
+            Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, ClocksourceUpdate,
+            CycleNum,
+        },
         TimeArch,
     },
 };
@@ -38,6 +41,7 @@ impl TscClocksource {
             mask: ClocksourceMask::new(u64::MAX),
             mult: 0,
             shift: 0,
+            max_cycles: Default::default(),
             max_idle_ns: Default::default(),
             flags: ClocksourceFlags::CLOCK_SOURCE_IS_CONTINUOUS
                 | ClocksourceFlags::CLOCK_SOURCE_MUST_VERIFY,
@@ -45,7 +49,6 @@ impl TscClocksource {
             cs_last: CycleNum::new(0),
             uncertainty_margin: 0,
             maxadj: 0,
-            cycle_last: CycleNum::new(0),
         };
         let tsc = Arc::new(TscClocksource(SpinLock::new(InnerTscClocksource {
             data,
@@ -71,20 +74,8 @@ impl Clocksource for TscClocksource {
         self.0.lock_irqsave().self_ref.upgrade().unwrap()
     }
 
-    fn update_clocksource_data(&self, data: ClocksourceData) -> Result<(), SystemError> {
-        let d = &mut self.0.lock_irqsave().data;
-        d.set_name(data.name);
-        d.set_rating(data.rating);
-        d.set_mask(data.mask);
-        d.set_mult(data.mult);
-        d.set_shift(data.shift);
-        d.set_max_idle_ns(data.max_idle_ns);
-        d.set_flags(data.flags);
-        d.watchdog_last = data.watchdog_last;
-        d.cs_last = data.cs_last;
-        d.set_uncertainty_margin(data.uncertainty_margin);
-        d.set_maxadj(data.maxadj);
-        d.cycle_last = data.cycle_last;
+    fn update_clocksource_data(&self, update: ClocksourceUpdate) -> Result<(), SystemError> {
+        update.apply(&mut self.0.lock_irqsave().data);
         Ok(())
     }
 }

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -474,24 +474,7 @@ impl IfaceCommon {
         // 等待的 socket。原因：smoltcp 在处理 ACK 后可能不返回 SocketStateChanged，但发送端的
         // can_send() 已经变为 true。如果只在 has_events 时唤醒，发送端会永远等待。
         // 唤醒后 socket 会重新检查条件，如果条件不满足会继续等待，所以不会造成忙等待。
-        {
-            // Avoid allocation here: take one Arc clone at a time, drop the lock, then notify.
-            let mut idx = 0usize;
-            loop {
-                let sock = {
-                    let guard = self.bounds.read_irqsave();
-                    if idx >= guard.len() {
-                        break;
-                    }
-                    let s = guard[idx].clone();
-                    s
-                };
-                // incase our inet socket missed the event, we manually notify it each time we poll
-                sock.notify();
-                let _woke = sock.wait_queue().wakeup(Some(ProcessState::Blocked(true)));
-                idx += 1;
-            }
-        }
+        self.notify_all_bound_sockets();
 
         // TODO: remove closed sockets
         // let closed_sockets = self
@@ -576,21 +559,7 @@ impl IfaceCommon {
         // 解锁后唤醒/通知 socket（沿用原 poll() 的 Linux-like 语义）。
         drop(interface);
         drop(sockets);
-        {
-            let mut idx = 0usize;
-            loop {
-                let sock = {
-                    let guard = self.bounds.read_irqsave();
-                    if idx >= guard.len() {
-                        break;
-                    }
-                    guard[idx].clone()
-                };
-                sock.notify();
-                let _ = sock.wait_queue().wakeup(Some(ProcessState::Blocked(true)));
-                idx += 1;
-            }
-        }
+        self.notify_all_bound_sockets();
 
         // NAPI 语义：只要“还有立即可推进的工作”，就应继续留在 poll_list。
         //
@@ -639,19 +608,16 @@ impl IfaceCommon {
     /// This is used after listener shutdown to ensure all client sockets
     /// are woken up even if the interface poll didn't detect any events.
     pub fn notify_all_bound_sockets(&self) {
-        // Avoid allocation and avoid holding bounds lock while notifying.
-        let mut idx = 0usize;
-        loop {
-            let sock = {
-                let guard = self.bounds.read_irqsave();
-                if idx >= guard.len() {
-                    break;
-                }
-                guard[idx].clone()
-            };
+        // Take one coherent snapshot before dropping the lock. Iterating by index while
+        // repeatedly releasing the lock can skip sockets when a concurrent close removes
+        // an earlier element and shifts the Vec to the left.
+        // Use a single read-side critical section. A size pass followed by a copy pass
+        // can be forced behind the stream of close-side writers between acquisitions,
+        // delaying network progress long enough for poll waiters to time out.
+        let sockets = self.bounds.read_irqsave().clone();
+        for sock in sockets {
             sock.notify();
             let _woke = sock.wait_queue().wakeup(Some(ProcessState::Blocked(true)));
-            idx += 1;
         }
     }
 

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -275,7 +275,7 @@ pub struct IfaceCommon {
     /// 存smoltcp网卡的套接字集
     sockets: Mutex<smoltcp::iface::SocketSet<'static>>,
     /// 存 kernel wrap smoltcp socket 的集合
-    bounds: RwLock<Vec<Arc<dyn InetSocket>>>,
+    bounds: RwLock<Arc<Vec<Arc<dyn InetSocket>>>>,
     /// 端口管理器
     port_manager: PortManager,
     /// 下次需要推进协议栈的时间点（单位：微秒时间戳，0 表示无定时事件）
@@ -325,7 +325,7 @@ impl IfaceCommon {
             name: RwLock::new(name),
             smol_iface: Mutex::new(iface),
             sockets: Mutex::new(smoltcp::iface::SocketSet::new(Vec::new())),
-            bounds: RwLock::new(Vec::new()),
+            bounds: RwLock::new(Arc::new(Vec::new())),
             port_manager: PortManager::default(),
             poll_at_us: core::sync::atomic::AtomicU64::new(0),
             net_namespace: RwLock::new(Weak::new()),
@@ -593,11 +593,12 @@ impl IfaceCommon {
 
     // 需要bounds储存具体的Inet Socket信息，以提供不同种类inet socket的事件分发
     pub fn bind_socket(&self, socket: Arc<dyn InetSocket>) {
-        self.bounds.write().push(socket);
+        Arc::make_mut(&mut *self.bounds.write()).push(socket);
     }
 
     pub fn unbind_socket(&self, socket: Arc<dyn InetSocket>) {
         let mut bounds = self.bounds.write();
+        let bounds = Arc::make_mut(&mut *bounds);
         if let Some(index) = bounds.iter().position(|s| Arc::ptr_eq(s, &socket)) {
             bounds.remove(index);
             // log::debug!("unbind socket success");
@@ -614,8 +615,11 @@ impl IfaceCommon {
         // Use a single read-side critical section. A size pass followed by a copy pass
         // can be forced behind the stream of close-side writers between acquisitions,
         // delaying network progress long enough for poll waiters to time out.
+        // Clone only the outer Arc while IRQs are disabled.  Mutations use
+        // Arc::make_mut(), so this remains a coherent snapshot without an
+        // O(n) allocation in the polling hot path.
         let sockets = self.bounds.read_irqsave().clone();
-        for sock in sockets {
+        for sock in sockets.iter() {
             sock.notify();
             let _woke = sock.wait_queue().wakeup(Some(ProcessState::Blocked(true)));
         }

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -209,15 +209,32 @@ impl TtyCore {
         *self.core.port.write() = Some(port);
     }
 
-    pub fn tty_start(&self) {
-        let mut flow = self.core.flow.lock_irqsave();
+    fn tty_start_locked(&self, flow: &mut TtyFlowState) -> bool {
         if !flow.stopped || flow.tco_stopped {
-            return;
+            return false;
         }
 
         flow.stopped = false;
         let _ = self.start(self.core());
+        true
+    }
+
+    pub fn tty_start(&self) {
+        let mut flow = self.core.flow.lock_irqsave();
+        if !self.tty_start_locked(&mut flow) {
+            return;
+        }
+
         self.tty_wakeup();
+    }
+
+    /// Starts output without waking writers or invoking the line discipline.
+    ///
+    /// A caller that observes `true` must call [`Self::tty_wakeup`] after
+    /// releasing any line-discipline locks it holds.
+    pub(crate) fn tty_start_without_wakeup(&self) -> bool {
+        let mut flow = self.core.flow.lock_irqsave();
+        self.tty_start_locked(&mut flow)
     }
 
     pub fn tty_stop(&self) {

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -504,14 +504,7 @@ impl NTtyData {
             todo!()
         } else {
             if look_ahead > 0 {
-                self.receive_buf_standard(
-                    tty.clone(),
-                    &termios,
-                    buf,
-                    flags,
-                    look_ahead,
-                    true,
-                );
+                self.receive_buf_standard(tty.clone(), &termios, buf, flags, look_ahead, true);
             }
 
             if count > look_ahead {
@@ -1027,13 +1020,7 @@ impl NTtyData {
     }
 
     /// ## 接收到信号字符时的处理
-    fn recv_sig_char(
-        &mut self,
-        tty: Arc<TtyCore>,
-        termios: &Termios,
-        signal: Signal,
-        c: u8,
-    ) {
+    fn recv_sig_char(&mut self, tty: Arc<TtyCore>, termios: &Termios, signal: Signal, c: u8) {
         self.input_signal(tty.clone(), termios, signal);
         if termios.input_mode.contains(InputMode::IXON) {
             tty.tty_start();
@@ -1048,12 +1035,7 @@ impl NTtyData {
     }
 
     /// ## 处理输入信号
-    pub fn input_signal(
-        &mut self,
-        tty: Arc<TtyCore>,
-        termios: &Termios,
-        signal: Signal,
-    ) {
+    pub fn input_signal(&mut self, tty: Arc<TtyCore>, termios: &Termios, signal: Signal) {
         // 先处理信号
         let ctrl_info = tty.core().contorl_info_irqsave();
         let pg = ctrl_info.pgid.clone();

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, vec::Vec};
-use core::{intrinsics::likely, ops::BitXor};
+use core::{intrinsics::likely, mem, ops::BitXor};
 
 use bitmap::{static_bitmap, traits::BitMapOps, StaticBitmap};
 
@@ -276,6 +276,7 @@ pub struct NTtyData {
     read_flags: static_bitmap!(NTTY_BUFSIZE),
     char_map: static_bitmap!(256),
 
+    deferred_tty_wakeup: bool,
     tty: Weak<TtyCore>,
 }
 
@@ -309,9 +310,14 @@ impl NTtyData {
             echo_buf: vec![0; NTTY_BUFSIZE].into_boxed_slice().try_into().unwrap(),
             read_flags: StaticBitmap::new(),
             char_map: StaticBitmap::new(),
+            deferred_tty_wakeup: false,
             tty: Weak::default(),
             no_room: false,
         }
+    }
+
+    fn take_deferred_tty_wakeup(&mut self) -> bool {
+        mem::take(&mut self.deferred_tty_wakeup)
     }
 
     fn opost_pending_bytes(&self) -> &[u8] {
@@ -458,9 +464,15 @@ impl NTtyData {
             }
 
             if let Some(flags) = flags {
-                self.receive_buf(tty.clone(), &buf[offset..], Some(&flags[offset..]), n);
+                self.receive_buf(
+                    tty.clone(),
+                    &*termios,
+                    &buf[offset..],
+                    Some(&flags[offset..]),
+                    n,
+                );
             } else {
-                self.receive_buf(tty.clone(), &buf[offset..], flags, n);
+                self.receive_buf(tty.clone(), &*termios, &buf[offset..], flags, n);
             }
 
             offset += n;
@@ -482,14 +494,11 @@ impl NTtyData {
     pub fn receive_buf(
         &mut self,
         tty: Arc<TtyCore>,
+        termios: &Termios,
         buf: &[u8],
         flags: Option<&[u8]>,
         count: usize,
     ) {
-        // Use one coherent snapshot for the whole receive batch. Reacquiring
-        // the RwLock in nested helpers can self-deadlock when a writer queues
-        // between recursive read acquisitions.
-        let termios = *tty.core().termios();
         let preops = termios.input_mode.contains(InputMode::ISTRIP)
             || termios.input_mode.contains(InputMode::IUCLC)
             || termios.local_mode.contains(LocalMode::IEXTEN);
@@ -504,7 +513,7 @@ impl NTtyData {
             todo!()
         } else {
             if look_ahead > 0 {
-                self.receive_buf_standard(tty.clone(), &termios, buf, flags, look_ahead, true);
+                self.receive_buf_standard(tty.clone(), termios, buf, flags, look_ahead, true);
             }
 
             if count > look_ahead {
@@ -512,7 +521,7 @@ impl NTtyData {
                 let remaining_flags = flags.map(|f| &f[look_ahead..]);
                 self.receive_buf_standard(
                     tty.clone(),
-                    &termios,
+                    termios,
                     remaining,
                     remaining_flags,
                     count - look_ahead,
@@ -521,7 +530,7 @@ impl NTtyData {
             }
 
             // 刷新echo
-            self.flush_echoes(tty.clone());
+            self.flush_echoes(termios);
 
             tty.flush_chars(tty.core());
         }
@@ -579,8 +588,7 @@ impl NTtyData {
         }
     }
 
-    pub fn flush_echoes(&mut self, tty: Arc<TtyCore>) {
-        let termios = tty.core().termios();
+    pub fn flush_echoes(&mut self, termios: &Termios) {
         if !termios.local_mode.contains(LocalMode::ECHO)
             && !termios.local_mode.contains(LocalMode::ECHONL)
             || self.echo_commit == self.echo_head
@@ -687,16 +695,15 @@ impl NTtyData {
             }
         }
 
-        let flow = tty.core().flow_irqsave();
-        if flow.stopped
-            && !flow.tco_stopped
-            && termios.input_mode.contains(InputMode::IXON)
+        if termios.input_mode.contains(InputMode::IXON)
             && termios.input_mode.contains(InputMode::IXANY)
         {
-            tty.tty_start();
-            self.process_echoes(tty.clone());
+            let started = tty.tty_start_without_wakeup();
+            self.deferred_tty_wakeup |= started;
+            if started {
+                self.process_echoes(tty.clone());
+            }
         }
-        drop(flow);
 
         if c == b'\r' {
             if termios.input_mode.contains(InputMode::IGNCR) {
@@ -1010,7 +1017,7 @@ impl NTtyData {
         }
 
         if termios.control_characters[ControlCharIndex::VSTART] == c {
-            tty.tty_start();
+            self.deferred_tty_wakeup |= tty.tty_start_without_wakeup();
             self.process_echoes(tty.clone());
             return true;
         } else {
@@ -1023,7 +1030,7 @@ impl NTtyData {
     fn recv_sig_char(&mut self, tty: Arc<TtyCore>, termios: &Termios, signal: Signal, c: u8) {
         self.input_signal(tty.clone(), termios, signal);
         if termios.input_mode.contains(InputMode::IXON) {
-            tty.tty_start();
+            self.deferred_tty_wakeup |= tty.tty_start_without_wakeup();
         }
 
         if termios.local_mode.contains(LocalMode::ECHO) {
@@ -2576,7 +2583,11 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     ) -> Result<usize, SystemError> {
         let mut ldata = self.disc_data();
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, false);
+        let deferred_tty_wakeup = ldata.take_deferred_tty_wakeup();
         drop(ldata);
+        if deferred_tty_wakeup {
+            tty.tty_wakeup();
+        }
         if let Some(_output_guard) = self.output_lock.try_lock() {
             self.drain_echoes(&tty)?;
         }
@@ -2592,7 +2603,11 @@ impl TtyLineDiscipline for NTtyLinediscipline {
     ) -> Result<usize, SystemError> {
         let mut ldata = self.disc_data();
         let ret = ldata.receive_buf_common(tty.clone(), buf, flags, count, true);
+        let deferred_tty_wakeup = ldata.take_deferred_tty_wakeup();
         drop(ldata);
+        if deferred_tty_wakeup {
+            tty.tty_wakeup();
+        }
         if let Some(_output_guard) = self.output_lock.try_lock() {
             self.drain_echoes(&tty)?;
         }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -466,13 +466,13 @@ impl NTtyData {
             if let Some(flags) = flags {
                 self.receive_buf(
                     tty.clone(),
-                    &*termios,
+                    &termios,
                     &buf[offset..],
                     Some(&flags[offset..]),
                     n,
                 );
             } else {
-                self.receive_buf(tty.clone(), &*termios, &buf[offset..], flags, n);
+                self.receive_buf(tty.clone(), &termios, &buf[offset..], flags, n);
             }
 
             offset += n;

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -486,21 +486,32 @@ impl NTtyData {
         flags: Option<&[u8]>,
         count: usize,
     ) {
-        let termios = tty.core().termios();
+        // Use one coherent snapshot for the whole receive batch. Reacquiring
+        // the RwLock in nested helpers can self-deadlock when a writer queues
+        // between recursive read acquisitions.
+        let termios = *tty.core().termios();
         let preops = termios.input_mode.contains(InputMode::ISTRIP)
             || termios.input_mode.contains(InputMode::IUCLC)
             || termios.local_mode.contains(LocalMode::IEXTEN);
+        let extproc = termios.local_mode.contains(LocalMode::EXTPROC);
 
         let look_ahead = self.lookahead_count.min(count);
         if self.real_raw {
             self.receive_buf_real_raw(buf, count);
-        } else if self.raw || (termios.local_mode.contains(LocalMode::EXTPROC) && !preops) {
+        } else if self.raw || (extproc && !preops) {
             self.receive_buf_raw(buf, flags, count);
-        } else if tty.core().is_closing() && !termios.local_mode.contains(LocalMode::EXTPROC) {
+        } else if tty.core().is_closing() && !extproc {
             todo!()
         } else {
             if look_ahead > 0 {
-                self.receive_buf_standard(tty.clone(), buf, flags, look_ahead, true);
+                self.receive_buf_standard(
+                    tty.clone(),
+                    &termios,
+                    buf,
+                    flags,
+                    look_ahead,
+                    true,
+                );
             }
 
             if count > look_ahead {
@@ -508,6 +519,7 @@ impl NTtyData {
                 let remaining_flags = flags.map(|f| &f[look_ahead..]);
                 self.receive_buf_standard(
                     tty.clone(),
+                    &termios,
                     remaining,
                     remaining_flags,
                     count - look_ahead,
@@ -523,7 +535,7 @@ impl NTtyData {
 
         self.lookahead_count -= look_ahead;
 
-        if self.icanon && !termios.local_mode.contains(LocalMode::EXTPROC) {
+        if self.icanon && !extproc {
             return;
         }
 
@@ -589,12 +601,12 @@ impl NTtyData {
     pub fn receive_buf_standard(
         &mut self,
         tty: Arc<TtyCore>,
+        termios: &Termios,
         buf: &[u8],
         flags: Option<&[u8]>,
         mut count: usize,
         lookahead_done: bool,
     ) {
-        let termios = tty.core().termios();
         if flags.is_some() {
             todo!("ntty recv buf flags todo");
         }
@@ -618,7 +630,7 @@ impl NTtyData {
                     && termios.local_mode.contains(LocalMode::IEXTEN)
                 {
                     c = (c as char).to_ascii_lowercase() as u8;
-                    self.receive_char(c, tty.clone())
+                    self.receive_char(c, tty.clone(), termios)
                 }
 
                 continue;
@@ -641,9 +653,9 @@ impl NTtyData {
 
             if ((c as usize) < self.char_map.len()) && self.char_map.get(c as usize).unwrap() {
                 // 特殊字符
-                self.receive_special_char(c, tty.clone(), lookahead_done);
+                self.receive_special_char(c, tty.clone(), termios, lookahead_done);
             } else {
-                self.receive_char(c, tty.clone());
+                self.receive_char(c, tty.clone(), termios);
             }
 
             count -= 1;
@@ -651,9 +663,14 @@ impl NTtyData {
     }
 
     #[inline(never)]
-    pub fn receive_special_char(&mut self, mut c: u8, tty: Arc<TtyCore>, lookahead_done: bool) {
-        let is_flow_ctrl = self.is_flow_ctrl_char(tty.clone(), c, lookahead_done);
-        let termios = tty.core().termios();
+    pub fn receive_special_char(
+        &mut self,
+        mut c: u8,
+        tty: Arc<TtyCore>,
+        termios: &Termios,
+        lookahead_done: bool,
+    ) {
+        let is_flow_ctrl = self.is_flow_ctrl_char(tty.clone(), termios, c, lookahead_done);
 
         // 启用软件流控，并且该字符已经当做软件流控字符处理
         if termios.input_mode.contains(InputMode::IXON) && is_flow_ctrl {
@@ -662,17 +679,17 @@ impl NTtyData {
 
         if termios.local_mode.contains(LocalMode::ISIG) {
             if c == termios.control_characters[ControlCharIndex::VINTR] {
-                self.recv_sig_char(tty.clone(), &termios, Signal::SIGINT, c);
+                self.recv_sig_char(tty.clone(), termios, Signal::SIGINT, c);
                 return;
             }
 
             if c == termios.control_characters[ControlCharIndex::VQUIT] {
-                self.recv_sig_char(tty.clone(), &termios, Signal::SIGQUIT, c);
+                self.recv_sig_char(tty.clone(), termios, Signal::SIGQUIT, c);
                 return;
             }
 
             if c == termios.control_characters[ControlCharIndex::VSUSP] {
-                self.recv_sig_char(tty.clone(), &termios, Signal::SIGTSTP, c);
+                self.recv_sig_char(tty.clone(), termios, Signal::SIGTSTP, c);
                 return;
             }
         }
@@ -708,7 +725,7 @@ impl NTtyData {
                 || (c == termios.control_characters[ControlCharIndex::VWERASE]
                     && termios.local_mode.contains(LocalMode::IEXTEN))
             {
-                self.eraser(c, &termios);
+                self.eraser(c, termios);
                 self.commit_echoes(tty.clone());
                 return;
             }
@@ -732,10 +749,10 @@ impl NTtyData {
             {
                 let mut tail = self.canon_head;
                 self.finish_erasing();
-                self.echo_char(c, &termios);
+                self.echo_char(c, termios);
                 self.echo_char_raw(b'\n');
                 while ntty_buf_mask(tail) != ntty_buf_mask(self.read_head) {
-                    self.echo_char(self.read_buf[ntty_buf_mask(tail)], &termios);
+                    self.echo_char(self.read_buf[ntty_buf_mask(tail)], termios);
                     tail += 1;
                 }
                 self.commit_echoes(tty.clone());
@@ -778,7 +795,7 @@ impl NTtyData {
                         self.add_echo_byte(EchoOperation::Start.to_u8());
                         self.add_echo_byte(EchoOperation::SetCanonCol.to_u8());
                     }
-                    self.echo_char(c, &termios);
+                    self.echo_char(c, termios);
                     self.commit_echoes(tty.clone());
                 }
 
@@ -805,7 +822,7 @@ impl NTtyData {
                     self.add_echo_byte(EchoOperation::Start.to_u8());
                     self.add_echo_byte(EchoOperation::SetCanonCol.to_u8());
                 }
-                self.echo_char(c, &termios);
+                self.echo_char(c, termios);
             }
 
             self.commit_echoes(tty.clone());
@@ -822,7 +839,7 @@ impl NTtyData {
 
     /// ## ntty默认eraser function
     #[inline(never)]
-    fn eraser(&mut self, mut c: u8, termios: &RwLockReadGuard<Termios>) {
+    fn eraser(&mut self, mut c: u8, termios: &Termios) {
         if self.read_head == self.canon_head {
             return;
         }
@@ -977,14 +994,18 @@ impl NTtyData {
 
     /// ## 多字节字符检测
     /// 检测是否为多字节字符的后续字节
-    fn is_continuation(c: u8, termios: &RwLockReadGuard<Termios>) -> bool {
+    fn is_continuation(c: u8, termios: &Termios) -> bool {
         return termios.input_mode.contains(InputMode::IUTF8) && (c & 0xc0) == 0x80;
     }
 
     /// ## 该字符是否已经当做流控字符处理
-    pub fn is_flow_ctrl_char(&mut self, tty: Arc<TtyCore>, c: u8, lookahead_done: bool) -> bool {
-        let termios = tty.core().termios();
-
+    pub fn is_flow_ctrl_char(
+        &mut self,
+        tty: Arc<TtyCore>,
+        termios: &Termios,
+        c: u8,
+        lookahead_done: bool,
+    ) -> bool {
         if !(termios.control_characters[ControlCharIndex::VSTART] == c
             || termios.control_characters[ControlCharIndex::VSTOP] == c)
         {
@@ -1009,7 +1030,7 @@ impl NTtyData {
     fn recv_sig_char(
         &mut self,
         tty: Arc<TtyCore>,
-        termios: &RwLockReadGuard<Termios>,
+        termios: &Termios,
         signal: Signal,
         c: u8,
     ) {
@@ -1030,7 +1051,7 @@ impl NTtyData {
     pub fn input_signal(
         &mut self,
         tty: Arc<TtyCore>,
-        termios: &RwLockReadGuard<Termios>,
+        termios: &Termios,
         signal: Signal,
     ) {
         // 先处理信号
@@ -1074,9 +1095,7 @@ impl NTtyData {
         }
     }
 
-    pub fn receive_char(&mut self, c: u8, tty: Arc<TtyCore>) {
-        let termios = tty.core().termios();
-
+    pub fn receive_char(&mut self, c: u8, tty: Arc<TtyCore>, termios: &Termios) {
         if termios.local_mode.contains(LocalMode::ECHO) {
             if self.erasing {
                 self.add_echo_byte(b'/');
@@ -1088,17 +1107,17 @@ impl NTtyData {
                 self.add_echo_byte(EchoOperation::SetCanonCol.to_u8());
             }
 
-            self.echo_char(c, &termios);
+            self.echo_char(c, termios);
             self.commit_echoes(tty.clone());
         }
 
-        if c == 0o377 && tty.core().termios().input_mode.contains(InputMode::PARMRK) {
+        if c == 0o377 && termios.input_mode.contains(InputMode::PARMRK) {
             self.add_read_byte(c);
         }
         self.add_read_byte(c);
     }
 
-    pub fn echo_char(&mut self, c: u8, termios: &RwLockReadGuard<Termios>) {
+    pub fn echo_char(&mut self, c: u8, termios: &Termios) {
         if c == EchoOperation::Start.to_u8() {
             self.add_echo_byte(EchoOperation::Start.to_u8());
             self.add_echo_byte(EchoOperation::Start.to_u8());

--- a/kernel/src/exception/bottom_half.rs
+++ b/kernel/src/exception/bottom_half.rs
@@ -13,9 +13,12 @@
 //! ## 重要边界
 //! - `lock_bh` 只解决"进程态 vs softirq/tasklet"并发。
 //! - 若同一把锁也会在 hardirq 中获取，仍必须使用 `*_irqsave`（`lock_bh` 不关硬中断）。
-//! - `local_bh_disable()` **不禁止抢占**，与 Linux 行为一致。`lock_bh()` 会额外禁用抢占。
+//! - `local_bh_disable()` 同 Linux 一样同时禁止抢占，确保 per-CPU BH 状态不会迁移。
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::{
+    marker::PhantomData,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use system_error::SystemError;
 
@@ -23,8 +26,9 @@ use alloc::vec::Vec;
 
 use crate::{
     arch::CurrentIrqArch,
-    exception::{softirq, tasklet, InterruptArch},
+    exception::{in_interrupt, softirq, tasklet, InterruptArch},
     mm::percpu::{PerCpu, PerCpuVar},
+    process::ProcessManager,
 };
 
 lazy_static! {
@@ -69,17 +73,21 @@ pub fn irq_bottom_half_init() -> Result<(), SystemError> {
 /// - Drop 时：`bh_disable_cnt--`；若归零且处于 task context（当前约束为：本地 IRQ enabled），则补跑 pending softirq。
 ///
 /// ## 注意
-/// 与 Linux 行为一致，`local_bh_disable()` **不禁止抢占**。如果需要同时禁用抢占，
-/// 应使用 `lock_bh()` 或显式调用 `preempt_disable()`。
-pub struct LocalBhDisableGuard;
+/// 与 Linux 一致，该 guard 同时禁止抢占，确保计数的 CPU 归属在整个作用域内稳定。
+pub struct LocalBhDisableGuard {
+    _not_send: PhantomData<*mut ()>,
+}
 
 /// 禁用本 CPU bottom half，返回 RAII 守卫。
 ///
-/// 注意：该接口只屏蔽本 CPU 的 softirq/tasklet 执行，不关硬中断，也不禁止抢占。
+/// 注意：该接口不关闭硬中断，但会禁止抢占以固定 per-CPU 状态的 CPU 归属。
 #[inline(always)]
 pub fn local_bh_disable() -> LocalBhDisableGuard {
+    ProcessManager::preempt_disable();
     local_cnt().fetch_add(1, Ordering::SeqCst);
-    LocalBhDisableGuard
+    LocalBhDisableGuard {
+        _not_send: PhantomData,
+    }
 }
 
 impl Drop for LocalBhDisableGuard {
@@ -92,21 +100,22 @@ impl Drop for LocalBhDisableGuard {
         // - 必须在 IRQ-off 区间完成“递减 + 是否归零”的判定，避免硬中断退出路径观察到中间态。
         // - 不能允许计数下溢；release 下也必须安全，因此用 checked decrement。
         let irq_was_enabled = CurrentIrqArch::is_irq_enabled();
+        let may_run_softirq = irq_was_enabled && !in_interrupt();
         let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
 
         let prev =
             local_cnt().fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| x.checked_sub(1));
 
         match prev {
-            Ok(1) if irq_was_enabled => {
+            Ok(1) if may_run_softirq => {
                 // 本次 drop 让计数归零，且来自 task context（IRQ was enabled）=> 补跑 softirq。
                 softirq::do_softirq();
             }
             Ok(_) => {}
-            Err(_old /* == 0 */) => {
-                // 发生了 enable 次数多于 disable 的逻辑错误；保持计数为 0，避免 wrap 下溢。
-                debug_assert!(false, "local_bh_enable underflow");
-            }
+            Err(_old /* == 0 */) => panic!("local_bh_enable underflow"),
         }
+
+        drop(_irq_guard);
+        ProcessManager::preempt_enable();
     }
 }

--- a/kernel/src/exception/interrupt_context.rs
+++ b/kernel/src/exception/interrupt_context.rs
@@ -8,8 +8,13 @@ use crate::{
     smp::{core::smp_get_processor_id, cpu::ProcessorId},
 };
 
-static HARDIRQ_DEPTH: [AtomicU32; PerCpu::MAX_CPU_NUM as usize] =
-    [const { AtomicU32::new(0) }; PerCpu::MAX_CPU_NUM as usize];
+/// Keep independently updated CPU counters on separate cache lines. Hardirq
+/// entry/exit is a hot path, so sharing one line would bounce it between CPUs.
+#[repr(align(64))]
+struct HardirqDepth(AtomicU32);
+
+static HARDIRQ_DEPTH: [HardirqDepth; PerCpu::MAX_CPU_NUM as usize] =
+    [const { HardirqDepth(AtomicU32::new(0)) }; PerCpu::MAX_CPU_NUM as usize];
 
 /// Marks the current CPU as executing a hard interrupt handler.
 ///
@@ -23,17 +28,14 @@ pub struct HardirqContextGuard {
 
 #[inline]
 fn depth(cpu_id: ProcessorId) -> &'static AtomicU32 {
-    &HARDIRQ_DEPTH[cpu_id.data() as usize]
+    &HARDIRQ_DEPTH[cpu_id.data() as usize].0
 }
 
 #[inline]
 pub(crate) fn enter_hardirq() -> HardirqContextGuard {
     let cpu_id = smp_get_processor_id();
-    depth(cpu_id)
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| {
-            old.checked_add(1)
-        })
-        .expect("hardirq nesting depth overflow");
+    let previous = depth(cpu_id).fetch_add(1, Ordering::Relaxed);
+    assert_ne!(previous, u32::MAX, "hardirq nesting depth overflow");
     HardirqContextGuard {
         cpu_id,
         _not_send: PhantomData,
@@ -53,10 +55,7 @@ pub fn in_interrupt() -> bool {
 impl Drop for HardirqContextGuard {
     fn drop(&mut self) {
         assert_eq!(smp_get_processor_id(), self.cpu_id);
-        depth(self.cpu_id)
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| {
-                old.checked_sub(1)
-            })
-            .expect("unbalanced hardirq context exit");
+        let previous = depth(self.cpu_id).fetch_sub(1, Ordering::Relaxed);
+        assert_ne!(previous, 0, "unbalanced hardirq context exit");
     }
 }

--- a/kernel/src/exception/interrupt_context.rs
+++ b/kernel/src/exception/interrupt_context.rs
@@ -1,0 +1,62 @@
+use core::{
+    marker::PhantomData,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use crate::{
+    mm::percpu::PerCpu,
+    smp::{core::smp_get_processor_id, cpu::ProcessorId},
+};
+
+static HARDIRQ_DEPTH: [AtomicU32; PerCpu::MAX_CPU_NUM as usize] =
+    [const { AtomicU32::new(0) }; PerCpu::MAX_CPU_NUM as usize];
+
+/// Marks the current CPU as executing a hard interrupt handler.
+///
+/// This accounting is deliberately lock-free: interrupt-context predicates
+/// must remain usable from lock slow paths and from nested IRQ handlers.
+#[must_use]
+pub struct HardirqContextGuard {
+    cpu_id: ProcessorId,
+    _not_send: PhantomData<*mut ()>,
+}
+
+#[inline]
+fn depth(cpu_id: ProcessorId) -> &'static AtomicU32 {
+    &HARDIRQ_DEPTH[cpu_id.data() as usize]
+}
+
+#[inline]
+pub(crate) fn enter_hardirq() -> HardirqContextGuard {
+    let cpu_id = smp_get_processor_id();
+    depth(cpu_id)
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| {
+            old.checked_add(1)
+        })
+        .expect("hardirq nesting depth overflow");
+    HardirqContextGuard {
+        cpu_id,
+        _not_send: PhantomData,
+    }
+}
+
+#[inline]
+pub fn in_hardirq() -> bool {
+    depth(smp_get_processor_id()).load(Ordering::Relaxed) != 0
+}
+
+#[inline]
+pub fn in_interrupt() -> bool {
+    in_hardirq() || super::softirq::in_softirq()
+}
+
+impl Drop for HardirqContextGuard {
+    fn drop(&mut self) {
+        assert_eq!(smp_get_processor_id(), self.cpu_id);
+        depth(self.cpu_id)
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| {
+                old.checked_sub(1)
+            })
+            .expect("unbalanced hardirq context exit");
+    }
+}

--- a/kernel/src/exception/mod.rs
+++ b/kernel/src/exception/mod.rs
@@ -12,6 +12,7 @@ pub mod entry;
 pub mod extable;
 pub mod handle;
 pub mod init;
+pub mod interrupt_context;
 pub mod ipi;
 pub mod irqchip;
 pub mod irqdata;
@@ -24,6 +25,9 @@ pub mod softirq;
 pub mod sysfs;
 pub mod tasklet;
 pub mod workqueue;
+
+pub(crate) use interrupt_context::enter_hardirq;
+pub use interrupt_context::{in_hardirq, in_interrupt};
 
 /// 中断的架构相关的trait
 pub trait InterruptArch: Send + Sync {

--- a/kernel/src/exception/softirq.rs
+++ b/kernel/src/exception/softirq.rs
@@ -3,7 +3,7 @@ use core::{
     intrinsics::unlikely,
     mem::{self, MaybeUninit},
     ptr::null_mut,
-    sync::atomic::{compiler_fence, fence, AtomicI16, Ordering},
+    sync::atomic::{compiler_fence, fence, AtomicI16, AtomicPtr, AtomicU64, Ordering},
 };
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
@@ -26,38 +26,43 @@ use crate::{
 const MAX_SOFTIRQ_NUM: u64 = 64;
 const MAX_SOFTIRQ_RESTART: i32 = 20;
 
-static mut __CPU_PENDING: Option<Box<[VecStatus; PerCpu::MAX_CPU_NUM as usize]>> = None;
-static mut __SORTIRQ_VECTORS: *mut Softirq = null_mut();
+static SOFTIRQ_VECTORS: AtomicPtr<Softirq> = AtomicPtr::new(null_mut());
 
 #[inline(never)]
 pub fn softirq_init() -> Result<(), SystemError> {
     info!("Initializing softirq...");
-    unsafe {
-        __SORTIRQ_VECTORS = Box::leak(Box::new(Softirq::new()));
-        __CPU_PENDING = Some(Box::new(
-            [VecStatus::default(); PerCpu::MAX_CPU_NUM as usize],
-        ));
-        let cpu_pending = __CPU_PENDING.as_mut().unwrap();
-        for i in 0..PerCpu::MAX_CPU_NUM {
-            cpu_pending[i as usize] = VecStatus::default();
-        }
+    let softirq = Box::into_raw(Box::new(Softirq::new()));
+    if SOFTIRQ_VECTORS
+        .compare_exchange(null_mut(), softirq, Ordering::Release, Ordering::Acquire)
+        .is_err()
+    {
+        unsafe { drop(Box::from_raw(softirq)) };
+        return Err(SystemError::EBUSY);
     }
     info!("Softirq initialized.");
     return Ok(());
 }
 
 #[inline(always)]
-pub fn softirq_vectors() -> &'static mut Softirq {
-    unsafe {
-        return __SORTIRQ_VECTORS.as_mut().unwrap();
-    }
+pub fn softirq_vectors() -> &'static Softirq {
+    let softirq = SOFTIRQ_VECTORS.load(Ordering::Acquire);
+    assert!(!softirq.is_null(), "softirq used before initialization");
+    unsafe { &*softirq }
 }
 
-#[inline(always)]
-fn cpu_pending(cpu_id: ProcessorId) -> &'static mut VecStatus {
-    unsafe {
-        return &mut __CPU_PENDING.as_mut().unwrap()[cpu_id.data() as usize];
-    }
+/// Returns whether the current CPU is executing a softirq callback.
+///
+/// Unlike `preempt_count`, this does not classify an arbitrary preempt-disabled
+/// task as interrupt context. It is also safe before softirq initialization.
+#[inline]
+pub fn in_softirq() -> bool {
+    let softirq = SOFTIRQ_VECTORS.load(Ordering::Acquire);
+    !softirq.is_null()
+        && unsafe { &*softirq }
+            .cpu_running_count()
+            .get()
+            .load(Ordering::Relaxed)
+            > 0
 }
 
 /// 软中断向量号码
@@ -99,6 +104,10 @@ pub trait SoftirqVec: Send + Sync + Debug {
 #[derive(Debug)]
 pub struct Softirq {
     table: RwLock<[Option<Arc<dyn SoftirqVec>>; MAX_SOFTIRQ_NUM as usize]>,
+    /// Per-CPU pending vector. IRQ exclusion gives the local read/clear
+    /// transaction its ordering; atomics avoid manufacturing aliased mutable
+    /// references to a global array across CPUs.
+    cpu_pending: PerCpuVar<AtomicU64>,
     /// 软中断嵌套层数（per cpu）
     cpu_running_count: PerCpuVar<AtomicI16>,
 }
@@ -121,14 +130,27 @@ impl Softirq {
         percpu_count.resize_with(PerCpu::MAX_CPU_NUM as usize, || AtomicI16::new(0));
         let cpu_running_count = PerCpuVar::new(percpu_count).unwrap();
 
+        let mut pending = Vec::with_capacity(PerCpu::MAX_CPU_NUM as usize);
+        pending.resize_with(PerCpu::MAX_CPU_NUM as usize, || AtomicU64::new(0));
+        let cpu_pending = PerCpuVar::new(pending).unwrap();
+
         return Softirq {
             table: RwLock::new(data),
+            cpu_pending,
             cpu_running_count,
         };
     }
 
     fn cpu_running_count(&self) -> &PerCpuVar<AtomicI16> {
         return &self.cpu_running_count;
+    }
+
+    #[inline]
+    fn pending_for(&self, cpu_id: ProcessorId) -> &AtomicU64 {
+        // `cpu_id` comes from the architecture CPU-id provider and PerCpuVar
+        // was initialized for the same CPU set.  The returned value is atomic,
+        // so exposing a shared reference across CPUs does not create aliases.
+        unsafe { self.cpu_pending.force_get(cpu_id) }
     }
 
     /// @brief 注册软中断向量
@@ -176,12 +198,15 @@ impl Softirq {
         // self.running.lock().set(VecStatus::from(softirq_num), false);
         // 将对应CPU的pending置0
         compiler_fence(Ordering::SeqCst);
-        cpu_pending(smp_get_processor_id()).set(VecStatus::from(softirq_num), false);
+        self.pending_for(smp_get_processor_id())
+            .fetch_and(!VecStatus::from(softirq_num).bits(), Ordering::SeqCst);
         compiler_fence(Ordering::SeqCst);
     }
 
     #[inline(never)]
-    pub fn do_softirq(&self) {
+    fn do_softirq(&self) {
+        ProcessManager::preempt_disable();
+        let _preempt_guard = SoftirqPreemptGuard;
         if self.cpu_running_count().get().load(Ordering::SeqCst) >= Self::MAX_RUNNING_PER_CPU {
             // 当前CPU的软中断嵌套层数已经达到最大值，不再执行
             return;
@@ -192,17 +217,13 @@ impl Softirq {
         // non-zero preempt count even though local IRQs may be enabled below.
         // This prevents a timer IRQ nested inside task-context softirq handling
         // from scheduling away before the softirq handler returns.
-        ProcessManager::preempt_disable();
-        let _preempt_guard = SoftirqPreemptGuard;
-
         // TODO pcb的flags未修改
         let end = clock() + 500 * 2;
         let cpu_id = smp_get_processor_id();
         let mut max_restart = MAX_SOFTIRQ_RESTART;
         loop {
             compiler_fence(Ordering::SeqCst);
-            let pending = cpu_pending(cpu_id).bits;
-            cpu_pending(cpu_id).bits = 0;
+            let pending = self.pending_for(cpu_id).swap(0, Ordering::SeqCst);
             compiler_fence(Ordering::SeqCst);
 
             unsafe { CurrentIrqArch::interrupt_enable() };
@@ -236,17 +257,14 @@ impl Softirq {
             unsafe { CurrentIrqArch::interrupt_disable() };
             max_restart -= 1;
             compiler_fence(Ordering::SeqCst);
-            if cpu_pending(cpu_id).is_empty() {
-                compiler_fence(Ordering::SeqCst);
-                if clock() < end && max_restart > 0 {
-                    continue;
-                } else {
-                    break;
-                }
-            } else {
-                // TODO：当有softirqd时 唤醒它
-                break;
+            let has_pending = self.pending_for(cpu_id).load(Ordering::SeqCst) != 0;
+            compiler_fence(Ordering::SeqCst);
+            if has_pending && clock() < end && max_restart > 0 {
+                continue;
             }
+            // Pending work left after the time/restart budget remains set for
+            // the next IRQ exit (or a future softirqd implementation).
+            break;
         }
     }
 
@@ -254,7 +272,8 @@ impl Softirq {
         let guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         let processor_id = smp_get_processor_id();
 
-        cpu_pending(processor_id).insert(VecStatus::from(softirq_num));
+        self.pending_for(processor_id)
+            .fetch_or(VecStatus::from(softirq_num).bits(), Ordering::SeqCst);
 
         compiler_fence(Ordering::SeqCst);
 
@@ -265,7 +284,8 @@ impl Softirq {
     #[allow(dead_code)]
     pub unsafe fn clear_softirq_pending(&self, softirq_num: SoftirqNumber) {
         compiler_fence(Ordering::SeqCst);
-        cpu_pending(smp_get_processor_id()).remove(VecStatus::from(softirq_num));
+        self.pending_for(smp_get_processor_id())
+            .fetch_and(!VecStatus::from(softirq_num).bits(), Ordering::SeqCst);
         compiler_fence(Ordering::SeqCst);
     }
 }
@@ -275,19 +295,22 @@ impl Softirq {
 /// 当进入作用域时，会自动将cpu_running_count加1，
 /// 当退出作用域时，会自动将cpu_running_count减1
 struct RunningCountGuard<'a> {
-    cpu_running_count: &'a PerCpuVar<AtomicI16>,
+    cpu_running_count: &'a AtomicI16,
 }
 
 impl<'a> RunningCountGuard<'a> {
     fn new(cpu_running_count: &'a PerCpuVar<AtomicI16>) -> RunningCountGuard<'a> {
-        cpu_running_count.get().fetch_add(1, Ordering::SeqCst);
-        return RunningCountGuard { cpu_running_count };
+        let local_count = cpu_running_count.get();
+        local_count.fetch_add(1, Ordering::SeqCst);
+        return RunningCountGuard {
+            cpu_running_count: local_count,
+        };
     }
 }
 
 impl Drop for RunningCountGuard<'_> {
     fn drop(&mut self) {
-        self.cpu_running_count.get().fetch_sub(1, Ordering::SeqCst);
+        self.cpu_running_count.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -304,7 +327,11 @@ impl Drop for SoftirqPreemptGuard {
 /// 如果本 CPU BH 被禁用，则直接返回，保留 pending 让 `LocalBhDisableGuard` 的 drop
 /// 或未来某次 IRQ 退出点补跑。
 #[inline(never)]
-pub fn do_softirq() {
+/// Run pending softirqs for the current CPU.
+///
+/// Callers must enter with local IRQs disabled.  Handlers may temporarily
+/// enable IRQs, but this function always returns with them disabled.
+pub(crate) fn do_softirq() {
     // BH disabled => 不执行 softirq（避免进程态持锁被打断后在 softirq 再取锁死锁）
     if bottom_half::is_local_bh_disabled() {
         return;

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -1285,6 +1285,9 @@ impl RestartFn for RestartFnNanosleep {
                 Ok(()) => return Ok(0),
                 Err(SystemError::ERESTARTSYS) => {
                     let remaining = calc_remaining(deadline, &ktime_now(*clockid));
+                    if remaining.is_empty() {
+                        return Ok(0);
+                    }
                     write_nanosleep_remaining(*rmtp, &remaining)?;
                 }
                 Err(e) => return Err(e),

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -20,9 +20,11 @@ use crate::{
     process::{
         pid::PidType, ProcessControlBlock, ProcessFlags, ProcessManager, ProcessSignalInfo, RawPid,
     },
+    syscall::user_access::UserBufferWriter,
     time::{
-        sleep::nanosleep, syscall::PosixClockID, timekeeping::getnstimeofday, Instant,
-        PosixTimeSpec,
+        sleep::nanosleep,
+        syscall::{posix_clock_now, PosixClockID},
+        Instant, PosixTimeSpec,
     },
 };
 
@@ -1171,6 +1173,7 @@ pub enum RestartBlockData {
     Nanosleep {
         deadline: crate::time::PosixTimeSpec,
         clockid: crate::time::syscall::PosixClockID,
+        rmtp: Option<VirtAddr>,
     },
     // todo: futex_wait
     FutexWait(),
@@ -1188,8 +1191,13 @@ impl RestartBlockData {
     pub fn new_nanosleep(
         deadline: crate::time::PosixTimeSpec,
         clockid: crate::time::syscall::PosixClockID,
+        rmtp: Option<VirtAddr>,
     ) -> Self {
-        Self::Nanosleep { deadline, clockid }
+        Self::Nanosleep {
+            deadline,
+            clockid,
+            rmtp,
+        }
     }
 }
 
@@ -1201,38 +1209,26 @@ pub struct PollRestartBlockData {
 }
 
 fn ktime_now(clockid: PosixClockID) -> PosixTimeSpec {
-    match clockid {
-        PosixClockID::Realtime => getnstimeofday(),
-        PosixClockID::Monotonic | PosixClockID::Boottime => getnstimeofday(),
-        PosixClockID::ProcessCPUTimeID => {
-            let pcb = ProcessManager::current_pcb();
-            PosixTimeSpec::from_ns(pcb.process_cputime_ns())
-        }
-        PosixClockID::ThreadCPUTimeID => {
-            let pcb = ProcessManager::current_pcb();
-            PosixTimeSpec::from_ns(pcb.thread_cputime_ns())
-        }
-        _ => getnstimeofday(),
-    }
+    posix_clock_now(clockid)
 }
 
 fn calc_remaining(deadline: &PosixTimeSpec, now: &PosixTimeSpec) -> PosixTimeSpec {
-    let mut sec = deadline.tv_sec - now.tv_sec;
-    let mut nsec = deadline.tv_nsec - now.tv_nsec;
-    if nsec < 0 {
-        sec -= 1;
-        nsec += 1_000_000_000;
+    deadline.saturating_sub_timespec(now)
+}
+
+fn write_nanosleep_remaining(
+    rmtp: Option<VirtAddr>,
+    remaining: &PosixTimeSpec,
+) -> Result<(), SystemError> {
+    if let Some(rmtp) = rmtp {
+        let mut writer = UserBufferWriter::new(
+            rmtp.as_ptr::<PosixTimeSpec>(),
+            core::mem::size_of::<PosixTimeSpec>(),
+            true,
+        )?;
+        writer.copy_one_to_user(remaining, 0)?;
     }
-    if sec < 0 {
-        return PosixTimeSpec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-    }
-    PosixTimeSpec {
-        tv_sec: sec,
-        tv_nsec: nsec,
-    }
+    Ok(())
 }
 
 /// Nanosleep 的重启函数：根据保存的 deadline/clockid 继续等待或重启
@@ -1241,8 +1237,13 @@ pub struct RestartFnNanosleep;
 
 impl RestartFn for RestartFnNanosleep {
     fn call(&self, data: &mut RestartBlockData) -> Result<usize, SystemError> {
-        if let RestartBlockData::Nanosleep { deadline, clockid } = data {
-            if deadline.tv_sec < 0 {
+        if let RestartBlockData::Nanosleep {
+            deadline,
+            clockid,
+            rmtp,
+        } = data
+        {
+            if !deadline.is_valid_timeout() || *clockid == PosixClockID::ThreadCPUTimeID {
                 return Err(SystemError::EINVAL);
             }
             let deadline_ns = (deadline.tv_sec as u64)
@@ -1268,31 +1269,24 @@ impl RestartFn for RestartFnNanosleep {
                         )
                     }
                 }
-                PosixClockID::ThreadCPUTimeID => {
-                    let pcb = ProcessManager::current_pcb();
-                    if pcb.thread_cputime_ns() >= deadline_ns {
-                        Ok(())
-                    } else {
-                        pcb.cputime_wait_queue().wait_event_interruptible(
-                            || pcb.thread_cputime_ns() >= deadline_ns,
-                            None::<fn()>,
-                        )
-                    }
-                }
+                PosixClockID::ThreadCPUTimeID => return Err(SystemError::EINVAL),
                 _ => {
                     let now = ktime_now(*clockid);
                     let remain = calc_remaining(deadline, &now);
                     if remain.tv_sec == 0 && remain.tv_nsec == 0 {
                         Ok(())
                     } else {
-                        nanosleep(remain).map(|_| ())
+                        nanosleep(remain)
                     }
                 }
             };
 
             match wait_res {
                 Ok(()) => return Ok(0),
-                Err(SystemError::ERESTARTSYS) => {}
+                Err(SystemError::ERESTARTSYS) => {
+                    let remaining = calc_remaining(deadline, &ktime_now(*clockid));
+                    write_nanosleep_remaining(*rmtp, &remaining)?;
+                }
                 Err(e) => return Err(e),
             }
             let rb = RestartBlock::new(&RestartFnNanosleep, data.clone());

--- a/kernel/src/ipc/syscall/sys_rt_sigtimedwait.rs
+++ b/kernel/src/ipc/syscall/sys_rt_sigtimedwait.rs
@@ -14,7 +14,9 @@ use crate::syscall::{
     table::{FormattedSyscallParam, Syscall},
     user_access::{UserBufferReader, UserBufferWriter},
 };
-use crate::time::{jiffies::NSEC_PER_JIFFY, timer::schedule_timeout, PosixTimeSpec};
+use crate::time::{
+    jiffies::NSEC_PER_JIFFY, timekeeping::monotonic_now, timer::schedule_timeout, PosixTimeSpec,
+};
 use alloc::vec::Vec;
 use core::mem::size_of;
 use syscall_table_macros::declare_syscall;
@@ -149,14 +151,14 @@ pub fn do_kernel_rt_sigtimedwait(
         // 第五步：释放中断，然后真正进入调度睡眠（窗口期内，线程保持可中断阻塞，发送侧会唤醒）
         // 计算剩余等待时间
         let remaining_time = if let Some(deadline) = deadline {
-            let now = PosixTimeSpec::now();
-            let remaining = deadline.total_nanos() - now.total_nanos();
-            if remaining <= 0 {
+            let now = monotonic_now();
+            let remaining = deadline.to_ktime_ns().saturating_sub(now.to_ktime_ns());
+            if remaining == 0 {
                 drop(preempt_guard);
                 restore_sigtimedwait_mask();
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
-            remaining / (NSEC_PER_JIFFY as i64)
+            (remaining / NSEC_PER_JIFFY as u64).min(i64::MAX as u64) as i64
         } else {
             i64::MAX
         };
@@ -238,21 +240,18 @@ fn has_pending_awaited_signal(awaited: &SigSet) -> bool {
 
 /// 计算超时截止时间
 fn compute_deadline(timeout: PosixTimeSpec) -> Result<PosixTimeSpec, SystemError> {
-    if timeout.tv_sec < 0 || timeout.tv_nsec < 0 || timeout.tv_nsec >= 1_000_000_000 {
+    if !timeout.is_valid_timeout() {
         return Err(SystemError::EINVAL);
     }
 
-    let now = PosixTimeSpec::now();
-    Ok(PosixTimeSpec {
-        tv_sec: now.tv_sec + timeout.tv_sec,
-        tv_nsec: now.tv_nsec + timeout.tv_nsec,
-    })
+    let now = monotonic_now();
+    Ok(now.saturating_add_ktime(&timeout))
 }
 
 /// 检查是否超时
 fn is_timeout_expired(deadline: PosixTimeSpec) -> bool {
-    let now = PosixTimeSpec::now();
-    now.total_nanos() >= deadline.total_nanos()
+    let now = monotonic_now();
+    now.to_ktime_ns() >= deadline.to_ktime_ns()
 }
 
 /// 将 PosixSigInfo 拷贝到用户空间

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -366,9 +366,10 @@ impl Futex {
         // 创建超时计时器任务
         let mut timer = None;
         if let Some(time) = abs_time {
-            let sec = time.tv_sec;
-            let nsec = time.tv_nsec;
-            let total_us = (nsec / 1000 + sec * 1_000_000) as u64;
+            if !time.is_valid_timeout() {
+                return Err(SystemError::EINVAL);
+            }
+            let total_us = time.to_ktime_ns().div_ceil(1000);
 
             // 如果超时时间为0，直接返回ETIMEDOUT
             if total_us == 0 {

--- a/kernel/src/libs/futex/syscall/sys_futex.rs
+++ b/kernel/src/libs/futex/syscall/sys_futex.rs
@@ -205,28 +205,23 @@ pub(super) fn do_futex(
             // 这里将绝对截止时间转换为相对剩余时间，past 则立即 ETIMEDOUT。
             let adjusted_timeout = if let Some(deadline) = timeout {
                 // 校验 timespec 合法性
-                if deadline.tv_nsec < 0 || deadline.tv_nsec >= 1_000_000_000 {
+                if !deadline.is_valid_timeout() {
                     return Err(SystemError::EINVAL);
                 }
 
-                // 选择时钟：若带 FUTEX_CLOCK_REALTIME 则使用 realtime；否则使用 monotonic（当前实现等价）
-                let now = crate::time::timekeeping::getnstimeofday();
+                let now = if flags.contains(FutexFlag::FLAGS_CLOCKRT) {
+                    crate::time::timekeeping::realtime_now()
+                } else {
+                    crate::time::timekeeping::monotonic_now()
+                };
 
                 // 计算剩余时间 = deadline - now，若 <=0 则立即超时
-                let mut sec = deadline.tv_sec - now.tv_sec;
-                let mut nsec = deadline.tv_nsec - now.tv_nsec;
-                if nsec < 0 {
-                    nsec += 1_000_000_000;
-                    sec -= 1;
-                }
-                if sec < 0 || (sec == 0 && nsec == 0) {
+                let remaining = deadline.saturating_sub_timespec(&now);
+                if remaining.is_empty() {
                     return Err(SystemError::ETIMEDOUT);
                 }
 
-                Some(PosixTimeSpec {
-                    tv_sec: sec,
-                    tv_nsec: nsec,
-                })
+                Some(remaining)
             } else {
                 None
             };

--- a/kernel/src/libs/rwlock.rs
+++ b/kernel/src/libs/rwlock.rs
@@ -4,7 +4,7 @@ use core::{
     hint::spin_loop,
     mem::{self, ManuallyDrop},
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicU32, Ordering},
+    sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
 
 use system_error::SystemError;
@@ -12,39 +12,78 @@ use system_error::SystemError;
 use crate::{
     arch::CurrentIrqArch,
     exception::bottom_half::{local_bh_disable, LocalBhDisableGuard},
-    exception::{InterruptArch, IrqFlagsGuard},
+    exception::{in_interrupt, InterruptArch, IrqFlagsGuard},
     process::ProcessManager,
 };
 
 ///RwLock读写锁
 /// @brief READER位占据从右往左数第三个比特位
-const READER: u32 = 1 << 2;
+const READER: u64 = 1 << 2;
 
 /// @brief UPGRADED位占据从右到左数第二个比特位
-const UPGRADED: u32 = 1 << 1;
+const UPGRADED: u64 = 1 << 1;
 
 /// @brief WRITER位占据最右边的比特位
-const WRITER: u32 = 1;
+const WRITER: u64 = 1;
 
-const READER_BIT: u32 = 2;
+const OWNER_MASK: u64 = WRITER | UPGRADED;
+const READER_MASK: u64 = (1u64 << 32) - READER;
+const ACTIVE_MASK: u64 = OWNER_MASK | READER_MASK;
+const PENDING_WRITER_ONE: u64 = 1u64 << 32;
+const PENDING_WRITER_MASK: u64 = !((1u64 << 32) - 1);
+const MAX_READERS: u64 = READER_MASK / READER;
 
 /// @brief 读写锁的基本数据结构
-/// @param lock 32位原子变量,最右边的两位从左到右分别是UPGRADED,WRITER (标志位)
-///             剩下的bit位存储READER数量(除了MSB)
+/// @param lock 64位原子变量。低32位保存所有者和读者状态，高32位保存等待写者数量。
 ///             对于标志位,0代表无, 1代表有
 ///             对于剩下的比特位表征READER的数量的多少
 ///             lock的MSB必须为0,否则溢出
 #[derive(Debug)]
 pub struct RwLock<T> {
-    lock: AtomicU32,
+    lock: AtomicU64,
+    writer_tickets: WriterTickets,
     data: UnsafeCell<T>,
+}
+
+/// FIFO admission state for blocking writers. Keeping ticket arithmetic in a
+/// small production helper makes wrap-around and pending semantics testable
+/// without exposing lock internals or creating a test-only control path.
+#[derive(Debug)]
+struct WriterTickets {
+    next: AtomicU32,
+    serving: AtomicU32,
+}
+
+impl WriterTickets {
+    const fn new() -> Self {
+        Self {
+            next: AtomicU32::new(0),
+            serving: AtomicU32::new(0),
+        }
+    }
+
+    #[inline]
+    fn issue(&self) -> u32 {
+        self.next.fetch_add(1, Ordering::AcqRel)
+    }
+
+    #[inline]
+    fn is_turn(&self, ticket: u32) -> bool {
+        self.serving.load(Ordering::Acquire) == ticket
+    }
+
+    #[inline]
+    fn finish(&self, ticket: u32) {
+        debug_assert_eq!(self.serving.load(Ordering::Relaxed), ticket);
+        self.serving.fetch_add(1, Ordering::Release);
+    }
 }
 
 /// @brief  READER守卫的数据结构
 /// @param lock 是对RwLock的lock属性值的只读引用
 pub struct RwLockReadGuard<'a, T: 'a> {
     data: *const T,
-    lock: &'a AtomicU32,
+    lock: &'a AtomicU64,
     irq_guard: Option<IrqFlagsGuard>,
 }
 
@@ -69,14 +108,14 @@ pub struct RwLockWriteGuard<'a, T: 'a> {
 
 /// `*_bh` 风格的读锁守卫：持锁期间屏蔽本 CPU 的 softirq/tasklet 执行（不关硬中断）。
 pub struct RwLockReadBhGuard<'a, T: 'a> {
-    bh: LocalBhDisableGuard,
     guard: RwLockReadGuard<'a, T>,
+    bh: LocalBhDisableGuard,
 }
 
 /// `*_bh` 风格的写锁守卫：持锁期间屏蔽本 CPU 的 softirq/tasklet 执行（不关硬中断）。
 pub struct RwLockWriteBhGuard<'a, T: 'a> {
-    bh: LocalBhDisableGuard,
     guard: RwLockWriteGuard<'a, T>,
+    bh: LocalBhDisableGuard,
 }
 
 unsafe impl<T: Send> Send for RwLock<T> {}
@@ -88,7 +127,8 @@ impl<T> RwLock<T> {
     /// @brief  RwLock的初始化
     pub const fn new(data: T) -> Self {
         return RwLock {
-            lock: AtomicU32::new(0),
+            lock: AtomicU64::new(0),
+            writer_tickets: WriterTickets::new(),
             data: UnsafeCell::new(data),
         };
     }
@@ -111,48 +151,86 @@ impl<T> RwLock<T> {
 
     #[allow(dead_code)]
     #[inline]
-    /// @brief 获取实时的读者数并尝试加1,如果增加值成功则返回增加1后的读者数,否则panic
-    fn current_reader(&self) -> Result<u32, SystemError> {
-        const MAX_READERS: u32 = u32::MAX >> READER_BIT >> 1; //右移3位
-
-        let value = self.lock.fetch_add(READER, Ordering::Acquire);
-        //value二进制形式的MSB不能为1, 否则导致溢出
-
-        if value > MAX_READERS << READER_BIT {
-            self.lock.fetch_sub(READER, Ordering::Release);
-            //panic!("Too many lock readers, cannot safely proceed");
-            return Err(SystemError::EOVERFLOW);
-        } else {
-            return Ok(value);
+    /// @brief 尝试原子注册读者；owner、reader 与 pending writer 使用同一状态快照判定。
+    fn current_reader(&self, bypass_waiting_writer: bool) -> Result<(), SystemError> {
+        let mut state = self.lock.load(Ordering::Relaxed);
+        loop {
+            if state & OWNER_MASK != 0
+                || (!bypass_waiting_writer && state & PENDING_WRITER_MASK != 0)
+            {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            if state & READER_MASK == MAX_READERS * READER {
+                return Err(SystemError::EOVERFLOW);
+            }
+            state = match self.lock.compare_exchange_weak(
+                state,
+                state + READER,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(actual) => actual,
+            };
         }
+    }
+
+    #[inline]
+    fn has_waiting_writer(&self) -> bool {
+        self.lock.load(Ordering::Acquire) & PENDING_WRITER_MASK != 0
+    }
+
+    /// Whether this reader executes in an actual hardirq or softirq callback.
+    #[inline]
+    fn interrupt_reader() -> bool {
+        in_interrupt()
+    }
+
+    #[inline]
+    fn register_waiting_writer(&self) -> Result<u32, SystemError> {
+        // Publish pending before issuing the FIFO ticket. A stalled registrant
+        // may conservatively block readers, but every issued ticket is backed
+        // by an already-visible pending count. This prevents the head writer
+        // from observing its turn before reader admission has been closed.
+        self.lock
+            .fetch_update(Ordering::AcqRel, Ordering::Relaxed, |state| {
+                (state & PENDING_WRITER_MASK != PENDING_WRITER_MASK)
+                    .then_some(state + PENDING_WRITER_ONE)
+            })
+            .map_err(|_| SystemError::EOVERFLOW)?;
+        Ok(self.writer_tickets.issue())
+    }
+
+    #[inline]
+    fn writer_turn(&self, ticket: u32) -> bool {
+        self.writer_tickets.is_turn(ticket)
+    }
+
+    #[inline]
+    fn finish_writer_turn(&self, ticket: u32) {
+        self.writer_tickets.finish(ticket)
     }
 
     #[allow(dead_code)]
     #[inline]
     /// @brief 尝试获取READER守卫
     pub fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
+        // Like Linux qrwlock's interrupt slowpath, an interrupt-context
+        // reader must not wait behind a queued writer: the interrupted outer
+        // reader may be the reader that writer is waiting for.  DragonOS uses
+        // an explicit hardirq/softirq predicate; merely disabling preemption
+        // does not qualify for this exception.
         ProcessManager::preempt_disable();
-        let r = self.inner_try_read();
+        let bypass_waiting_writer = Self::interrupt_reader();
+        let r = self.inner_try_read(bypass_waiting_writer);
         if r.is_none() {
             ProcessManager::preempt_enable();
         }
         return r;
     }
 
-    fn inner_try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
-        let reader_value = self.current_reader();
-        //得到自增后的reader_value, 包括了尝试获得READER守卫的进程
-
-        let value = if let Ok(rv) = reader_value {
-            rv
-        } else {
-            return None;
-        };
-
-        //判断有没有writer和upgrader
-        //注意, 若upgrader存在,已经存在的读者继续占有锁,但新读者不允许获得锁
-        if value & (WRITER | UPGRADED) != 0 {
-            self.lock.fetch_sub(READER, Ordering::Release);
+    fn inner_try_read(&self, bypass_waiting_writer: bool) -> Option<RwLockReadGuard<'_, T>> {
+        if self.current_reader(bypass_waiting_writer).is_err() {
             return None;
         } else {
             return Some(RwLockReadGuard {
@@ -181,8 +259,9 @@ impl<T> RwLock<T> {
     pub fn read_irqsave(&self) -> RwLockReadGuard<'_, T> {
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         ProcessManager::preempt_disable();
+        let bypass_waiting_writer = Self::interrupt_reader();
         loop {
-            match self.inner_try_read() {
+            match self.inner_try_read(bypass_waiting_writer) {
                 Some(mut guard) => {
                     guard.irq_guard = Some(irq_guard);
                     return guard;
@@ -204,10 +283,13 @@ impl<T> RwLock<T> {
     /// 尝试关闭中断并获取读者守卫
     pub fn try_read_irqsave(&self) -> Option<RwLockReadGuard<'_, T>> {
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-        if let Some(mut guard) = self.try_read() {
+        ProcessManager::preempt_disable();
+        let bypass_waiting_writer = Self::interrupt_reader();
+        if let Some(mut guard) = self.inner_try_read(bypass_waiting_writer) {
             guard.irq_guard = Some(irq_guard);
             return Some(guard);
         } else {
+            ProcessManager::preempt_enable();
             return None;
         }
     }
@@ -217,14 +299,14 @@ impl<T> RwLock<T> {
     /// @brief 获取读者+UPGRADER的数量, 不能保证能否获得同步值
     pub fn reader_count(&self) -> u32 {
         let state = self.lock.load(Ordering::Relaxed);
-        return state / READER + (state & UPGRADED) / UPGRADED;
+        return ((state & READER_MASK) / READER + u64::from(state & UPGRADED != 0)) as u32;
     }
 
     #[allow(dead_code)]
     #[inline]
     /// @brief 获取写者数量,不能保证能否获得同步值
     pub fn writer_count(&self) -> u32 {
-        return (self.lock.load(Ordering::Relaxed) & WRITER) / WRITER;
+        return u32::from(self.lock.load(Ordering::Relaxed) & WRITER != 0);
     }
 
     #[allow(dead_code)]
@@ -258,19 +340,39 @@ impl<T> RwLock<T> {
 
     #[allow(dead_code)]
     fn inner_try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
-        let res: bool = self
-            .lock
+        self.lock
             .compare_exchange(0, WRITER, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok();
-        //只有lock大小为0的时候能获得写者守卫
-        if res {
-            return Some(RwLockWriteGuard {
+            .ok()
+            .map(|_| RwLockWriteGuard {
                 data: unsafe { &mut *self.data.get() },
                 inner: self,
                 irq_guard: None,
-            });
-        } else {
-            return None;
+            })
+    }
+
+    #[inline]
+    fn inner_try_write_registered(&self) -> Option<RwLockWriteGuard<'_, T>> {
+        let mut state = self.lock.load(Ordering::Relaxed);
+        loop {
+            if state & ACTIVE_MASK != 0 || state & PENDING_WRITER_MASK == 0 {
+                return None;
+            }
+            let new_state = (state - PENDING_WRITER_ONE) | WRITER;
+            state = match self.lock.compare_exchange_weak(
+                state,
+                new_state,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Some(RwLockWriteGuard {
+                        data: unsafe { &mut *self.data.get() },
+                        inner: self,
+                        irq_guard: None,
+                    })
+                }
+                Err(actual) => actual,
+            };
         }
     }
 
@@ -278,9 +380,22 @@ impl<T> RwLock<T> {
     #[inline]
     /// @brief 获得WRITER守卫
     pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        ProcessManager::preempt_disable();
+        let ticket = self
+            .register_waiting_writer()
+            .expect("too many pending RwLock writers");
         loop {
-            match self.try_write() {
-                Some(guard) => return guard,
+            if !self.writer_turn(ticket) {
+                spin_loop();
+                continue;
+            }
+            match self.inner_try_write_registered() {
+                Some(guard) => {
+                    // Keep the writer announced until WRITER is visible, so
+                    // readers cannot enter through a zero-count window.
+                    self.finish_writer_turn(ticket);
+                    return guard;
+                }
                 None => spin_loop(),
             }
         }
@@ -294,9 +409,17 @@ impl<T> RwLock<T> {
     pub fn write_irqsave(&self) -> RwLockWriteGuard<'_, T> {
         let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
         ProcessManager::preempt_disable();
+        let ticket = self
+            .register_waiting_writer()
+            .expect("too many pending RwLock writers");
         loop {
-            match self.inner_try_write() {
+            if !self.writer_turn(ticket) {
+                spin_loop();
+                continue;
+            }
+            match self.inner_try_write_registered() {
                 Some(mut guard) => {
+                    self.finish_writer_turn(ticket);
                     guard.irq_guard = Some(irq_guard);
                     return guard;
                 }
@@ -333,17 +456,31 @@ impl<T> RwLock<T> {
     }
 
     fn inner_try_upgradeable_read(&self) -> Option<RwLockUpgradableGuard<'_, T>> {
-        // 获得UPGRADER守卫不需要查看读者位
-        // 如果获得读者锁失败,不需要撤回fetch_or的原子操作
-        if self.lock.fetch_or(UPGRADED, Ordering::Acquire) & (WRITER | UPGRADED) == 0 {
-            return Some(RwLockUpgradableGuard {
-                inner: self,
-                data: unsafe { &mut *self.data.get() },
-                irq_guard: None,
-            });
-        } else {
-            return None;
+        // 获得UPGRADER守卫不需要查看读者位。使用CAS避免失败的尝试污染
+        // WRITER状态中的UPGRADED位。
+        let mut state = self.lock.load(Ordering::Relaxed);
+        loop {
+            if state & (WRITER | UPGRADED | PENDING_WRITER_MASK) != 0
+                || state & READER_MASK == MAX_READERS * READER
+            {
+                return None;
+            }
+            state = match self.lock.compare_exchange_weak(
+                state,
+                state | UPGRADED,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => break,
+                Err(actual) => actual,
+            };
         }
+
+        return Some(RwLockUpgradableGuard {
+            inner: self,
+            data: self.data.get().cast_const(),
+            irq_guard: None,
+        });
     }
 
     #[allow(dead_code)]
@@ -381,7 +518,7 @@ impl<T> RwLock<T> {
     //extremely unsafe behavior
     /// @brief 强制减少READER数
     pub unsafe fn force_read_decrement(&self) {
-        debug_assert!(self.lock.load(Ordering::Relaxed) & !WRITER > 0);
+        debug_assert!(self.lock.load(Ordering::Relaxed) & READER_MASK > 0);
         self.lock.fetch_sub(READER, Ordering::Release);
     }
 
@@ -390,7 +527,7 @@ impl<T> RwLock<T> {
     //extremely unsafe behavior
     /// @brief 强制给WRITER解锁
     pub unsafe fn force_write_unlock(&self) {
-        debug_assert_eq!(self.lock.load(Ordering::Relaxed) & !(WRITER | UPGRADED), 0);
+        debug_assert_eq!(self.lock.load(Ordering::Relaxed) & ACTIVE_MASK, WRITER);
         self.lock.fetch_and(!(WRITER | UPGRADED), Ordering::Release);
     }
 
@@ -469,15 +606,25 @@ impl<'rwlock, T> RwLockUpgradableGuard<'rwlock, T> {
     #[inline]
     /// @brief 尝试将UPGRADER守卫升级为WRITER守卫
     pub fn try_upgrade(mut self) -> Result<RwLockWriteGuard<'rwlock, T>, Self> {
-        let res = self.inner.lock.compare_exchange(
-            UPGRADED,
-            WRITER,
-            Ordering::Acquire,
-            Ordering::Relaxed,
-        );
-        //当且仅当只有UPGRADED守卫时可以升级
+        let mut state = self.inner.lock.load(Ordering::Relaxed);
+        let res = loop {
+            if state & ACTIVE_MASK != UPGRADED {
+                break false;
+            }
+            let new_state = (state & PENDING_WRITER_MASK) | WRITER;
+            state = match self.inner.lock.compare_exchange_weak(
+                state,
+                new_state,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break true,
+                Err(actual) => actual,
+            };
+        };
+        // 当且仅当只有UPGRADED所有者（可另有pending writer）时可以升级。
 
-        if res.is_ok() {
+        if res {
             let inner = self.inner;
             let irq_guard = self.irq_guard.take();
             mem::forget(self);
@@ -510,15 +657,31 @@ impl<'rwlock, T> RwLockUpgradableGuard<'rwlock, T> {
     #[inline]
     /// @brief UPGRADER降级为READER
     pub fn downgrade(mut self) -> RwLockReadGuard<'rwlock, T> {
-        while self.inner.current_reader().is_err() {
-            spin_loop();
-        }
-
         let inner: &RwLock<T> = self.inner;
         let irq_guard = self.irq_guard.take();
 
-        // 手动清除 UPGRADED 位（UpgradableGuard::drop 会做这件事）
-        inner.lock.fetch_and(!UPGRADED, Ordering::Release);
+        // Convert the owned UPGRADED bit into a reader atomically.  This
+        // conversion is allowed even when another writer is pending because
+        // it does not admit a new lock owner.
+        let mut state = inner.lock.load(Ordering::Relaxed);
+        loop {
+            debug_assert_eq!(state & (WRITER | UPGRADED), UPGRADED);
+            assert_ne!(
+                state & READER_MASK,
+                MAX_READERS * READER,
+                "RwLock reader count overflow during upgrader downgrade"
+            );
+            let new_state = (state - UPGRADED) + READER;
+            state = match inner.lock.compare_exchange_weak(
+                state,
+                new_state,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => actual,
+            };
+        }
 
         // forget self 以跳过 UpgradableGuard::drop 中的 preempt_enable
         // 新的 ReadGuard 接管 preempt_count 所有权
@@ -569,17 +732,25 @@ impl<'rwlock, T> RwLockWriteGuard<'rwlock, T> {
     #[inline]
     /// @brief 将WRITER降级为READER
     pub fn downgrade(mut self) -> RwLockReadGuard<'rwlock, T> {
-        while self.inner.current_reader().is_err() {
-            spin_loop();
-        }
-
         let inner = self.inner;
         let irq_guard = self.irq_guard.take();
 
-        // 手动清除 WRITER | UPGRADED 位（WriteGuard::drop 会做这件事）
-        inner
-            .lock
-            .fetch_and(!(WRITER | UPGRADED), Ordering::Release);
+        // No reader can coexist with WRITER, so this is a single atomic state
+        // transition.  Pending writers remain announced in their own counter.
+        let mut state = inner.lock.load(Ordering::Relaxed);
+        loop {
+            assert_eq!(state & ACTIVE_MASK, WRITER, "invalid RwLock writer state");
+            let new_state = (state & PENDING_WRITER_MASK) | READER;
+            state = match inner.lock.compare_exchange_weak(
+                state,
+                new_state,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => actual,
+            };
+        }
 
         // forget self 以跳过 WriteGuard::drop 中的 preempt_enable
         // 新的 ReadGuard 接管 preempt_count 所有权
@@ -601,7 +772,20 @@ impl<'rwlock, T> RwLockWriteGuard<'rwlock, T> {
             WRITER
         );
 
-        self.inner.lock.store(UPGRADED, Ordering::Release);
+        let mut state = self.inner.lock.load(Ordering::Relaxed);
+        loop {
+            assert_eq!(state & ACTIVE_MASK, WRITER, "invalid RwLock writer state");
+            let new_state = (state & PENDING_WRITER_MASK) | UPGRADED;
+            state = match self.inner.lock.compare_exchange_weak(
+                state,
+                new_state,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => actual,
+            };
+        }
 
         let inner = self.inner;
 
@@ -648,7 +832,7 @@ impl<T> DerefMut for RwLockWriteGuard<'_, T> {
 
 impl<T> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
-        debug_assert!(self.lock.load(Ordering::Relaxed) & !(WRITER | UPGRADED) > 0);
+        debug_assert!(self.lock.load(Ordering::Relaxed) & READER_MASK > 0);
         self.lock.fetch_sub(READER, Ordering::Release);
         // 先恢复中断，再启用抢占
         self.irq_guard.take();
@@ -680,3 +864,8 @@ impl<T> Drop for RwLockWriteGuard<'_, T> {
         ProcessManager::preempt_enable();
     }
 }
+
+#[path = "rwlock_selftest.rs"]
+mod selftest;
+
+pub(crate) use selftest::run_rwlock_selftests;

--- a/kernel/src/libs/rwlock_selftest.rs
+++ b/kernel/src/libs/rwlock_selftest.rs
@@ -1,0 +1,335 @@
+use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+
+use crate::{
+    arch::CurrentIrqArch,
+    exception::{enter_hardirq, in_hardirq, in_interrupt, InterruptArch},
+    process::{
+        kthread::{KernelThreadClosure, KernelThreadMechanism},
+        ProcessManager,
+    },
+    sched::{completion::Completion, schedule, SchedMode},
+};
+
+use super::*;
+
+struct Report {
+    text: String,
+    passed: usize,
+    failed: usize,
+}
+
+impl Report {
+    fn new() -> Self {
+        Self {
+            text: String::new(),
+            passed: 0,
+            failed: 0,
+        }
+    }
+
+    fn case(&mut self, name: &str, ok: bool) {
+        if ok {
+            self.passed += 1;
+            self.text.push_str(&format!("rwlock.{name}=ok\n"));
+        } else {
+            self.failed += 1;
+            self.text.push_str(&format!("rwlock.{name}=fail\n"));
+        }
+    }
+}
+
+fn concurrent_reader_flood_writer_progress() -> bool {
+    const READER_THREADS: usize = 2;
+    const READS_PER_THREAD: usize = 16_384;
+
+    let lock = Arc::new(RwLock::new(0usize));
+    let ready = Arc::new(Completion::new());
+    let start = Arc::new(Completion::new());
+    let writer_acquired = Arc::new(AtomicBool::new(false));
+    let invalid_read = Arc::new(AtomicBool::new(false));
+    let read_count = Arc::new(AtomicUsize::new(0));
+    let mut readers = Vec::new();
+
+    for _ in 0..READER_THREADS {
+        let lock = lock.clone();
+        let ready = ready.clone();
+        let reader_start = start.clone();
+        let writer_acquired = writer_acquired.clone();
+        let invalid_read = invalid_read.clone();
+        let read_count = read_count.clone();
+        let closure = KernelThreadClosure::EmptyClosure((
+            Box::new(move || {
+                ready.complete();
+                if reader_start.wait_for_completion().is_err() {
+                    return 1;
+                }
+                for iteration in 0..READS_PER_THREAD {
+                    let value = *lock.read();
+                    if value > 1 {
+                        invalid_read.store(true, Ordering::Release);
+                    }
+                    read_count.fetch_add(1, Ordering::Relaxed);
+                    if writer_acquired.load(Ordering::Acquire) {
+                        break;
+                    }
+                    if iteration % 64 == 63 {
+                        schedule(SchedMode::SM_NONE);
+                    }
+                }
+                0
+            }),
+            (),
+        ));
+        let Some(reader) =
+            KernelThreadMechanism::create_and_run(closure, "rwlock-reader-flood-selftest".into())
+        else {
+            start.complete_all();
+            for reader in &readers {
+                let _ = KernelThreadMechanism::stop(reader);
+            }
+            return false;
+        };
+        readers.push(reader);
+    }
+
+    let writer_lock = lock.clone();
+    let writer_ready = ready.clone();
+    let writer_start = start.clone();
+    let writer_done = writer_acquired.clone();
+    let writer_closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            writer_ready.complete();
+            if writer_start.wait_for_completion().is_err() {
+                return 1;
+            }
+            let mut guard = writer_lock.write();
+            *guard = 1;
+            writer_done.store(true, Ordering::Release);
+            0
+        }),
+        (),
+    ));
+    let Some(writer) = KernelThreadMechanism::create_and_run(
+        writer_closure,
+        "rwlock-writer-progress-selftest".into(),
+    ) else {
+        start.complete_all();
+        for reader in &readers {
+            let _ = KernelThreadMechanism::stop(reader);
+        }
+        return false;
+    };
+
+    let mut all_ready = true;
+    for _ in 0..=READER_THREADS {
+        all_ready &= ready.wait_for_completion().is_ok();
+    }
+    start.complete_all();
+
+    let writer_stopped = KernelThreadMechanism::stop(&writer).is_ok();
+    let readers_stopped = readers
+        .iter()
+        .all(|reader| KernelThreadMechanism::stop(reader).is_ok());
+    let final_value = *lock.read();
+
+    all_ready
+        && writer_stopped
+        && readers_stopped
+        && writer_acquired.load(Ordering::Acquire)
+        && read_count.load(Ordering::Acquire) != 0
+        && read_count.load(Ordering::Acquire) < READER_THREADS * READS_PER_THREAD
+        && !invalid_read.load(Ordering::Acquire)
+        && final_value == 1
+}
+
+pub(crate) fn run_rwlock_selftests() -> (usize, usize, String) {
+    let mut report = Report::new();
+
+    let fifo = WriterTickets::new();
+    let first = fifo.issue();
+    let second = fifo.issue();
+    let first_turn = fifo.is_turn(first) && !fifo.is_turn(second);
+    fifo.finish(first);
+    let second_turn = fifo.is_turn(second);
+    fifo.finish(second);
+    report.case(
+        "ticket_fifo",
+        first == 0 && second == 1 && first_turn && second_turn,
+    );
+
+    let wrapping = WriterTickets {
+        next: AtomicU32::new(u32::MAX),
+        serving: AtomicU32::new(u32::MAX),
+    };
+    let last = wrapping.issue();
+    let wrap_pending = wrapping.is_turn(last);
+    wrapping.finish(last);
+    let zero = wrapping.issue();
+    let zero_turn = wrapping.is_turn(zero);
+    wrapping.finish(zero);
+    report.case(
+        "ticket_wrap",
+        last == u32::MAX
+            && zero == 0
+            && wrap_pending
+            && zero_turn
+            && wrapping.next.load(Ordering::SeqCst) == 1
+            && wrapping.serving.load(Ordering::SeqCst) == 1,
+    );
+
+    let overflow = RwLock::new(());
+    overflow.lock.store(PENDING_WRITER_MASK, Ordering::Relaxed);
+    let next_before = overflow.writer_tickets.next.load(Ordering::Relaxed);
+    let pending_overflow_rejected = overflow.register_waiting_writer().is_err()
+        && overflow.lock.load(Ordering::Relaxed) == PENDING_WRITER_MASK
+        && overflow.writer_tickets.next.load(Ordering::Relaxed) == next_before;
+    overflow.lock.store(0, Ordering::Relaxed);
+    report.case("pending_overflow", pending_overflow_rejected);
+
+    let reader_limit = RwLock::new(());
+    let full_reader_state = MAX_READERS * READER;
+    reader_limit
+        .lock
+        .store(full_reader_state, Ordering::Relaxed);
+    let upgrader_at_limit_rejected = reader_limit.try_upgradeable_read().is_none()
+        && reader_limit.lock.load(Ordering::Relaxed) == full_reader_state;
+    reader_limit.lock.store(0, Ordering::Relaxed);
+    report.case("upgrader_reader_limit", upgrader_at_limit_rejected);
+
+    let outside_interrupt = !in_hardirq() && !in_interrupt();
+    ProcessManager::preempt_disable();
+    let hardirq_outer = enter_hardirq();
+    let first_depth = in_hardirq() && in_interrupt();
+    let hardirq_inner = enter_hardirq();
+    let nested_depth = in_hardirq();
+    drop(hardirq_inner);
+    let outer_restored = in_hardirq();
+    drop(hardirq_outer);
+    ProcessManager::preempt_enable();
+    report.case(
+        "hardirq_context_depth",
+        outside_interrupt && first_depth && nested_depth && outer_restored && !in_hardirq(),
+    );
+
+    let lock = RwLock::new(7u32);
+    let ticket = lock.register_waiting_writer().unwrap();
+    let preempt_before = ProcessManager::current_pcb().preempt_count();
+    let irq_before = CurrentIrqArch::is_irq_enabled();
+    let reader_blocked = lock.try_read().is_none();
+    let upgradeable_blocked = lock.try_upgradeable_read().is_none();
+    let writer_barge_blocked = lock.try_write().is_none();
+    let irq_reader_blocked = lock.try_read_irqsave().is_none();
+    let state_restored = ProcessManager::current_pcb().preempt_count() == preempt_before
+        && CurrentIrqArch::is_irq_enabled() == irq_before;
+
+    // Merely disabling preemption must not masquerade as interrupt context.
+    ProcessManager::preempt_disable();
+    let nested_preempt = ProcessManager::current_pcb().preempt_count();
+    let nested_reader = lock.try_read();
+    let nested_reader_blocked = nested_reader.is_none();
+    drop(nested_reader);
+    let nested_state_restored = ProcessManager::current_pcb().preempt_count() == nested_preempt;
+    ProcessManager::preempt_enable();
+
+    // A real interrupt reader bypasses pending writers to avoid deadlocking
+    // against an interrupted outer reader.
+    ProcessManager::preempt_disable();
+    let hardirq = enter_hardirq();
+    let interrupt_reader = lock.try_read();
+    let interrupt_reader_ok = interrupt_reader.as_ref().is_some_and(|guard| **guard == 7);
+    drop(interrupt_reader);
+    drop(hardirq);
+    ProcessManager::preempt_enable();
+
+    ProcessManager::preempt_disable();
+    let writer = lock.inner_try_write_registered();
+    let writer_acquired = writer.is_some();
+    lock.finish_writer_turn(ticket);
+    drop(writer);
+    report.case(
+        "pending_blocks_new_owners",
+        reader_blocked
+            && upgradeable_blocked
+            && writer_barge_blocked
+            && irq_reader_blocked
+            && state_restored
+            && nested_reader_blocked
+            && nested_state_restored
+            && interrupt_reader_ok
+            && writer_acquired
+            && ProcessManager::current_pcb().preempt_count() == preempt_before
+            && !lock.has_waiting_writer(),
+    );
+
+    let transitions = RwLock::new(1u32);
+    let read_ok = transitions.try_read().is_some_and(|guard| *guard == 1);
+    let (upgrade_ok, downgrade_ok, pending_preserved) = match transitions.try_upgradeable_read() {
+        Some(upgradeable) => {
+            let queued = transitions.register_waiting_writer().unwrap();
+            match upgradeable.try_upgrade() {
+                Ok(mut writer) => {
+                    *writer = 2;
+                    let reader = writer.downgrade();
+                    let preserved = transitions.has_waiting_writer();
+                    let ok = *reader == 2 && transitions.writer_count() == 0;
+                    drop(reader);
+                    ProcessManager::preempt_disable();
+                    let queued_writer = transitions.inner_try_write_registered();
+                    let acquired = queued_writer.is_some();
+                    transitions.finish_writer_turn(queued);
+                    drop(queued_writer);
+                    (true, ok, preserved && acquired)
+                }
+                Err(upgradeable) => {
+                    drop(upgradeable);
+                    (false, false, false)
+                }
+            }
+        }
+        None => (false, false, false),
+    };
+    let downgrade_upgradeable_ok = match transitions.try_write() {
+        Some(writer) => {
+            let upgradeable = writer.downgrade_to_upgradeable();
+            let ok = *upgradeable == 2;
+            drop(upgradeable);
+            ok
+        }
+        None => false,
+    };
+    let downgrade_with_pending = RwLock::new(());
+    let downgrade_pending_ok = match downgrade_with_pending.try_write() {
+        Some(writer) => {
+            let queued = downgrade_with_pending.register_waiting_writer().unwrap();
+            let upgradeable = writer.downgrade_to_upgradeable();
+            let preserved = downgrade_with_pending.has_waiting_writer();
+            drop(upgradeable);
+            ProcessManager::preempt_disable();
+            let queued_writer = downgrade_with_pending.inner_try_write_registered();
+            let acquired = queued_writer.is_some();
+            downgrade_with_pending.finish_writer_turn(queued);
+            drop(queued_writer);
+            preserved && acquired && !downgrade_with_pending.has_waiting_writer()
+        }
+        None => false,
+    };
+    report.case(
+        "guard_transitions",
+        read_ok
+            && upgrade_ok
+            && downgrade_ok
+            && pending_preserved
+            && downgrade_upgradeable_ok
+            && downgrade_pending_ok
+            && transitions.reader_count() == 0
+            && transitions.writer_count() == 0,
+    );
+
+    report.case(
+        "concurrent_reader_flood_writer_progress",
+        concurrent_reader_flood_writer_progress(),
+    );
+
+    (report.passed, report.failed, report.text)
+}

--- a/kernel/src/libs/rwlock_selftest.rs
+++ b/kernel/src/libs/rwlock_selftest.rs
@@ -39,6 +39,20 @@ impl Report {
     }
 }
 
+/// Acquire a writer that has already registered its ticket.
+///
+/// This mirrors the preemption ownership contract of the public try-lock
+/// helpers: a successful guard owns the disable and restores it on drop,
+/// while a failed attempt must restore preemption before returning.
+fn try_write_registered<T>(lock: &RwLock<T>) -> Option<RwLockWriteGuard<'_, T>> {
+    ProcessManager::preempt_disable();
+    let writer = lock.inner_try_write_registered();
+    if writer.is_none() {
+        ProcessManager::preempt_enable();
+    }
+    writer
+}
+
 fn concurrent_reader_flood_writer_progress() -> bool {
     const READER_THREADS: usize = 2;
     const READS_PER_THREAD: usize = 16_384;
@@ -223,6 +237,16 @@ pub(crate) fn run_rwlock_selftests() -> (usize, usize, String) {
     let state_restored = ProcessManager::current_pcb().preempt_count() == preempt_before
         && CurrentIrqArch::is_irq_enabled() == irq_before;
 
+    let no_pending_writer = RwLock::new(());
+    let failed_registered_writer = try_write_registered(&no_pending_writer);
+    let registered_failure_restored = failed_registered_writer.is_none()
+        && ProcessManager::current_pcb().preempt_count() == preempt_before;
+    drop(failed_registered_writer);
+    report.case(
+        "registered_writer_failure_restores_preempt",
+        registered_failure_restored,
+    );
+
     // Merely disabling preemption must not masquerade as interrupt context.
     ProcessManager::preempt_disable();
     let nested_preempt = ProcessManager::current_pcb().preempt_count();
@@ -242,8 +266,7 @@ pub(crate) fn run_rwlock_selftests() -> (usize, usize, String) {
     drop(hardirq);
     ProcessManager::preempt_enable();
 
-    ProcessManager::preempt_disable();
-    let writer = lock.inner_try_write_registered();
+    let writer = try_write_registered(&lock);
     let writer_acquired = writer.is_some();
     lock.finish_writer_turn(ticket);
     drop(writer);
@@ -274,8 +297,7 @@ pub(crate) fn run_rwlock_selftests() -> (usize, usize, String) {
                     let preserved = transitions.has_waiting_writer();
                     let ok = *reader == 2 && transitions.writer_count() == 0;
                     drop(reader);
-                    ProcessManager::preempt_disable();
-                    let queued_writer = transitions.inner_try_write_registered();
+                    let queued_writer = try_write_registered(&transitions);
                     let acquired = queued_writer.is_some();
                     transitions.finish_writer_turn(queued);
                     drop(queued_writer);
@@ -305,8 +327,7 @@ pub(crate) fn run_rwlock_selftests() -> (usize, usize, String) {
             let upgradeable = writer.downgrade_to_upgradeable();
             let preserved = downgrade_with_pending.has_waiting_writer();
             drop(upgradeable);
-            ProcessManager::preempt_disable();
-            let queued_writer = downgrade_with_pending.inner_try_write_registered();
+            let queued_writer = try_write_registered(&downgrade_with_pending);
             let acquired = queued_writer.is_some();
             downgrade_with_pending.finish_writer_turn(queued);
             drop(queued_writer);

--- a/kernel/src/libs/spinlock.rs
+++ b/kernel/src/libs/spinlock.rs
@@ -95,7 +95,6 @@ impl<T> SpinLock<T> {
     /// 注意：该接口不关硬中断；若同一把锁也会在 hardirq 获取，则必须用 `lock_irqsave()`。
     pub fn lock_bh(&self) -> SpinLockBhGuard<'_, T> {
         let bh = local_bh_disable();
-        // `local_bh_disable()` 不禁用抢占，由 `lock()` 来禁用
         let guard = self.lock();
         SpinLockBhGuard { bh, guard }
     }

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -121,7 +121,7 @@ fn dhcp_query() -> Result<(), SystemError> {
             tv_sec: 0,
             tv_nsec: 50,
         };
-        let _ = nanosleep(sleep_time)?;
+        nanosleep(sleep_time)?;
     }
 
     return Err(SystemError::ETIMEDOUT);

--- a/kernel/src/process/kstack.rs
+++ b/kernel/src/process/kstack.rs
@@ -47,7 +47,7 @@ unsafe fn alloc_from_kernel_space() -> (VirtAddr, PhysAddr) {
     // | ..........  |
     // ---------------
 
-    let _guard = KSTACK_LOCK.try_lock_irqsave().unwrap();
+    let _guard = KSTACK_LOCK.lock_irqsave();
     let need_size = KernelStack::SIZE * 2;
     let page_num = PageFrameCount::new(need_size.div_ceil(MMArch::PAGE_SIZE).next_power_of_two());
 
@@ -95,7 +95,7 @@ unsafe fn dealloc_from_kernel_space(vaddr: VirtAddr, paddr: PhysAddr) {
     use crate::mm::kernel_mapper::KernelMapper;
     use crate::mm::MemoryManagementArch;
 
-    let _guard = KSTACK_LOCK.try_lock_irqsave().unwrap();
+    let _guard = KSTACK_LOCK.lock_irqsave();
 
     let need_size = KernelStack::SIZE * 2;
     let page_num = PageFrameCount::new(need_size.div_ceil(MMArch::PAGE_SIZE).next_power_of_two());

--- a/kernel/src/smp/cpu/mod.rs
+++ b/kernel/src/smp/cpu/mod.rs
@@ -116,13 +116,27 @@ impl CpuHpCpuState {
         self.state.store(state as u32, Ordering::Release);
     }
 
+    /// Update BSP-owned control state before publishing a bring-up request.
+    ///
     /// # Safety
     ///
-    /// Only the BSP/hotplug coordinator may access this object, and bring-up
+    /// Only the BSP/hotplug coordinator may call this method, and bring-up
     /// transactions for one CPU must remain serialized.
     #[inline]
-    unsafe fn bsp_control_mut(&self) -> &mut CpuHpControl {
-        unsafe { &mut *self.control.get() }
+    unsafe fn configure_bringup(&self, target_state: CpuHpState, bringup: bool) {
+        let control = unsafe { &mut *self.control.get() };
+        control.target_state = target_state;
+        control.bringup = bringup;
+    }
+
+    /// Read BSP-owned control state while the coordinator owns the transaction.
+    ///
+    /// # Safety
+    ///
+    /// Only the BSP/hotplug coordinator may call this method.
+    #[inline]
+    unsafe fn bringup(&self) -> bool {
+        unsafe { (*self.control.get()).bringup }
     }
 }
 
@@ -287,11 +301,7 @@ impl SmpCpuManager {
     ) -> Result<(), SystemError> {
         let cpu_state = self.cpuhp_state(cpu_id);
         let prev_state = cpu_state.state();
-        unsafe {
-            let control = cpu_state.bsp_control_mut();
-            control.target_state = target_state;
-            control.bringup = true;
-        }
+        unsafe { cpu_state.configure_bringup(target_state, true) };
         cpu_state.publish_state(CpuHpState::Starting);
 
         if let Err(e) = self.do_cpuhp_kick_ap(cpu_id) {
@@ -301,18 +311,12 @@ impl SmpCpuManager {
             } else {
                 prev_state
             });
-            unsafe {
-                let control = cpu_state.bsp_control_mut();
-                control.target_state = prev_state;
-                control.bringup = false;
-            }
+            unsafe { cpu_state.configure_bringup(prev_state, false) };
             return Err(e);
         }
 
         cpu_state.publish_state(target_state);
-        unsafe {
-            cpu_state.bsp_control_mut().bringup = false;
-        }
+        unsafe { cpu_state.configure_bringup(target_state, false) };
 
         Ok(())
     }
@@ -324,7 +328,7 @@ impl SmpCpuManager {
         if target_cpu_id != cpu_id {
             return Err(SystemError::EINVAL);
         }
-        let bringup = unsafe { cpu_state.bsp_control_mut().bringup };
+        let bringup = unsafe { cpu_state.bringup() };
         cpu_state
             .bringup_result
             .store(AP_BRINGUP_RESULT_PENDING, Ordering::Release);

--- a/kernel/src/smp/cpu/mod.rs
+++ b/kernel/src/smp/cpu/mod.rs
@@ -1,4 +1,7 @@
-use core::sync::atomic::AtomicU32;
+use core::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicI32, AtomicU32, Ordering},
+};
 
 use alloc::{sync::Arc, vec::Vec};
 use log::{debug, error, info};
@@ -16,6 +19,9 @@ use super::{core::smp_get_processor_id, SMPArch};
 
 int_like!(ProcessorId, AtomicProcessorId, u32, AtomicU32);
 
+const AP_BRINGUP_RESULT_PENDING: i32 = 0;
+const AP_BRINGUP_RESULT_SUCCESS: i32 = 1;
+
 impl ProcessorId {
     pub const INVALID: ProcessorId = ProcessorId::new(u32::MAX);
 }
@@ -32,41 +38,59 @@ pub fn smp_cpu_manager() -> &'static SmpCpuManager {
     unsafe { SMP_CPU_MANAGER.as_ref().unwrap() }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CpuHpState {
-    /// 启动阈值
-    ThresholdBringUp = 0,
-
     /// 该CPU是离线的
-    Offline,
+    Offline = 0,
+
+    /// BSP 已经发起启动，但 AP 尚未完成初始化。
+    Starting,
 
     /// 该CPU是在线的
     Online,
+
+    /// AP 已经运行并在初始化失败后进入终止 park，不能按 Offline 重试。
+    FailedParked,
+}
+
+struct CpuHpControl {
+    /// BSP 期望达到的目标状态。
+    target_state: CpuHpState,
+    /// 当前是否为启动流程。
+    bringup: bool,
 }
 
 /// Per-Cpu Cpu的热插拔状态
 pub struct CpuHpCpuState {
-    /// 当前状态
-    state: CpuHpState,
-    /// 目标状态
-    target_state: CpuHpState,
+    /// 跨 CPU 发布的生命周期状态。
+    state: AtomicU32,
     /// 指向热插拔的线程的PCB
     thread: Option<Arc<ProcessControlBlock>>,
-
-    /// 当前是否为启动流程
-    bringup: bool,
+    /// 仅由 BSP/hotplug coordinator 访问的普通控制字段。
+    control: UnsafeCell<CpuHpControl>,
     /// 启动完成的信号
     comp_done_up: Completion,
+    /// AP 初始化结果。AP 仅发布该原子消息，普通热插拔状态仍由 BSP 独占更新。
+    bringup_result: AtomicI32,
 }
+
+// SAFETY: `state`, `bringup_result` and `comp_done_up` provide their own
+// synchronization. `control` is private and is only accessed by the single
+// BSP hotplug coordinator; APs never read or write it.
+unsafe impl Sync for CpuHpCpuState {}
 
 impl CpuHpCpuState {
     const fn new() -> Self {
         Self {
-            state: CpuHpState::Offline,
-            target_state: CpuHpState::Offline,
+            state: AtomicU32::new(CpuHpState::Offline as u32),
             thread: None,
-            bringup: false,
+            control: UnsafeCell::new(CpuHpControl {
+                target_state: CpuHpState::Offline,
+                bringup: false,
+            }),
             comp_done_up: Completion::new(),
+            bringup_result: AtomicI32::new(AP_BRINGUP_RESULT_PENDING),
         }
     }
 
@@ -77,8 +101,28 @@ impl CpuHpCpuState {
 
     #[inline]
     #[allow(dead_code)]
-    pub const fn state(&self) -> CpuHpState {
-        self.state
+    pub fn state(&self) -> CpuHpState {
+        match self.state.load(Ordering::Acquire) {
+            value if value == CpuHpState::Offline as u32 => CpuHpState::Offline,
+            value if value == CpuHpState::Starting as u32 => CpuHpState::Starting,
+            value if value == CpuHpState::Online as u32 => CpuHpState::Online,
+            value if value == CpuHpState::FailedParked as u32 => CpuHpState::FailedParked,
+            _ => CpuHpState::FailedParked,
+        }
+    }
+
+    #[inline]
+    fn publish_state(&self, state: CpuHpState) {
+        self.state.store(state as u32, Ordering::Release);
+    }
+
+    /// # Safety
+    ///
+    /// Only the BSP/hotplug coordinator may access this object, and bring-up
+    /// transactions for one CPU must remain serialized.
+    #[inline]
+    unsafe fn bsp_control_mut(&self) -> &mut CpuHpControl {
+        unsafe { &mut *self.control.get() }
     }
 }
 
@@ -175,42 +219,19 @@ impl SmpCpuManager {
         unsafe { self.cpuhp_state.force_get(cpu_id) }
     }
 
-    #[allow(clippy::mut_from_ref)]
-    fn cpuhp_state_mut(&self, cpu_id: ProcessorId) -> &mut CpuHpCpuState {
-        unsafe { self.cpuhp_state.force_get_mut(cpu_id) }
-    }
-
-    /// 设置CPU的状态, 返回旧的状态
-    pub unsafe fn set_cpuhp_state(
-        &self,
-        cpu_id: ProcessorId,
-        target_state: CpuHpState,
-    ) -> CpuHpState {
-        let p = self.cpuhp_state.force_get_mut(cpu_id);
-        let old_state = p.state;
-
-        let bringup = target_state > p.state;
-        p.target_state = target_state;
-        p.bringup = bringup;
-
-        return old_state;
-    }
-
     pub fn set_online_cpu(&self, cpu_id: ProcessorId, is_online: bool) {
         let target_state = if is_online {
             CpuHpState::Online
         } else {
             CpuHpState::Offline
         };
-
-        unsafe { self.set_cpuhp_state(cpu_id, target_state) };
-        self.cpuhp_state_mut(cpu_id).state = target_state;
+        self.cpuhp_state(cpu_id).publish_state(target_state);
     }
 
     #[inline]
     #[allow(dead_code)]
     pub fn is_online_cpu(&self, cpu_id: ProcessorId) -> bool {
-        self.cpuhp_state(cpu_id).state == CpuHpState::Online
+        self.cpuhp_state(cpu_id).state.load(Ordering::Acquire) == CpuHpState::Online as u32
     }
 
     /// 获取出现在系统中的CPU
@@ -241,25 +262,22 @@ impl SmpCpuManager {
             return Err(SystemError::EINVAL);
         }
 
-        let cpu_state = self.cpuhp_state(cpu_id).state;
+        let cpu_state = self.cpuhp_state(cpu_id).state();
         debug!(
             "cpu_up: cpu_id: {}, cpu_state: {:?}, target_state: {:?}",
             cpu_id.data(),
             cpu_state,
             target_state
         );
-        // 如果CPU的状态已经达到或者超过目标状态，则直接返回
-        if cpu_state >= target_state {
-            return Ok(());
+        match cpu_state {
+            CpuHpState::Online if target_state == CpuHpState::Online => return Ok(()),
+            CpuHpState::Offline => {}
+            CpuHpState::Starting | CpuHpState::FailedParked | CpuHpState::Online => {
+                return Err(SystemError::EBUSY)
+            }
         }
 
-        unsafe { self.set_cpuhp_state(cpu_id, target_state) };
-        let cpu_state = self.cpuhp_state(cpu_id).state;
-        if cpu_state > CpuHpState::ThresholdBringUp {
-            self.cpuhp_kick_ap(cpu_id, target_state)?;
-        }
-
-        return Ok(());
+        self.cpuhp_kick_ap(cpu_id, target_state)
     }
 
     fn cpuhp_kick_ap(
@@ -267,61 +285,95 @@ impl SmpCpuManager {
         cpu_id: ProcessorId,
         target_state: CpuHpState,
     ) -> Result<(), SystemError> {
-        let prev_state = unsafe { self.set_cpuhp_state(cpu_id, target_state) };
-        let hpstate = self.cpuhp_state_mut(cpu_id);
-        if let Err(e) = self.do_cpuhp_kick_ap(hpstate) {
-            self.cpuhp_reset_state(hpstate, prev_state);
-            self.do_cpuhp_kick_ap(hpstate).ok();
+        let cpu_state = self.cpuhp_state(cpu_id);
+        let prev_state = cpu_state.state();
+        unsafe {
+            let control = cpu_state.bsp_control_mut();
+            control.target_state = target_state;
+            control.bringup = true;
+        }
+        cpu_state.publish_state(CpuHpState::Starting);
 
+        if let Err(e) = self.do_cpuhp_kick_ap(cpu_id) {
+            let ap_parked = cpu_state.bringup_result.load(Ordering::Acquire) < 0;
+            cpu_state.publish_state(if ap_parked {
+                CpuHpState::FailedParked
+            } else {
+                prev_state
+            });
+            unsafe {
+                let control = cpu_state.bsp_control_mut();
+                control.target_state = prev_state;
+                control.bringup = false;
+            }
             return Err(e);
         }
 
-        return Ok(());
+        cpu_state.publish_state(target_state);
+        unsafe {
+            cpu_state.bsp_control_mut().bringup = false;
+        }
+
+        Ok(())
     }
 
-    fn do_cpuhp_kick_ap(&self, cpu_state: &mut CpuHpCpuState) -> Result<(), SystemError> {
+    fn do_cpuhp_kick_ap(&self, cpu_id: ProcessorId) -> Result<(), SystemError> {
+        let cpu_state = self.cpuhp_state(cpu_id);
         let pcb = cpu_state.thread.as_ref().ok_or(SystemError::EINVAL)?;
-        let cpu_id = pcb.sched_info().on_cpu().ok_or(SystemError::EINVAL)?;
+        let target_cpu_id = pcb.sched_info().on_cpu().ok_or(SystemError::EINVAL)?;
+        if target_cpu_id != cpu_id {
+            return Err(SystemError::EINVAL);
+        }
+        let bringup = unsafe { cpu_state.bsp_control_mut().bringup };
+        cpu_state
+            .bringup_result
+            .store(AP_BRINGUP_RESULT_PENDING, Ordering::Release);
 
         // todo: 等待CPU启动完成
 
-        ProcessManager::wakeup(cpu_state.thread.as_ref().unwrap())?;
+        ProcessManager::wakeup(pcb)?;
 
         CurrentSMPArch::start_cpu(cpu_id, cpu_state)?;
         assert_eq!(ProcessManager::current_pcb().preempt_count(), 0);
-        self.wait_for_ap_thread(cpu_state, cpu_state.bringup);
+        self.wait_for_ap_thread(cpu_id, bringup)?;
 
         return Ok(());
     }
 
-    fn wait_for_ap_thread(&self, cpu_state: &mut CpuHpCpuState, bringup: bool) {
+    fn wait_for_ap_thread(&self, cpu_id: ProcessorId, bringup: bool) -> Result<(), SystemError> {
         if bringup {
-            cpu_state
-                .comp_done_up
-                .wait_for_completion()
-                .expect("failed to wait ap thread");
+            let cpu_state = self.cpuhp_state(cpu_id);
+            cpu_state.comp_done_up.wait_for_completion()?;
+            match cpu_state.bringup_result.load(Ordering::Acquire) {
+                AP_BRINGUP_RESULT_SUCCESS => {}
+                error if error < 0 => {
+                    return Err(match SystemError::from_posix_errno(error) {
+                        Some(error) => error,
+                        None => SystemError::EIO,
+                    });
+                }
+                _ => return Err(SystemError::EIO),
+            }
         } else {
             todo!("wait_for_ap_thread")
         }
+        Ok(())
     }
 
     /// 完成AP的启动
-    pub fn complete_ap_thread(&self, bringup: bool) {
+    pub fn complete_ap_thread(&self, bringup: bool, result: Result<(), SystemError>) {
         let cpu_id = smp_get_processor_id();
-        let cpu_state = self.cpuhp_state_mut(cpu_id);
+        let cpu_state = self.cpuhp_state(cpu_id);
         if bringup {
-            cpu_state.state = cpu_state.target_state;
+            let encoded = match result {
+                Ok(()) => AP_BRINGUP_RESULT_SUCCESS,
+                Err(error) => error.to_posix_errno(),
+            };
+            cpu_state.bringup_result.store(encoded, Ordering::Release);
             cpu_state.comp_done_up.complete();
         } else {
             todo!("complete_ap_thread")
         }
-    }
-
-    fn cpuhp_reset_state(&self, st: &mut CpuHpCpuState, prev_state: CpuHpState) {
-        let bringup = !st.bringup;
-        st.target_state = prev_state;
-
-        st.bringup = bringup;
     }
 }
 

--- a/kernel/src/smp/init.rs
+++ b/kernel/src/smp/init.rs
@@ -12,23 +12,48 @@ use crate::{
 pub fn smp_ap_start_stage2() -> ! {
     assert!(!CurrentIrqArch::is_irq_enabled());
 
-    smp_cpu_manager().complete_ap_thread(true);
-
-    do_ap_start_stage2();
+    if let Err(error) = do_ap_start_stage2() {
+        smp_cpu_manager().complete_ap_thread(true, Err(error));
+        park_failed_ap();
+    }
 
     CurrentSchedArch::initial_setup_sched_local();
-
     CurrentSchedArch::enable_sched_local();
+
+    // Publish Online only after every mandatory per-CPU facility, including
+    // the local scheduler, is ready to accept remote enqueue/wakeup work.
+    smp_cpu_manager().complete_ap_thread(true, Ok(()));
     ProcessManager::arch_idle_func();
 }
 
+/// Keep a failed AP offline without consuming a host CPU. Interrupts are
+/// still disabled here, so these instructions form a terminal park until a
+/// future hotplug protocol explicitly resets the CPU.
+fn park_failed_ap() -> ! {
+    #[cfg(target_arch = "x86_64")]
+    loop {
+        unsafe { x86::halt() };
+    }
+
+    #[cfg(target_arch = "riscv64")]
+    loop {
+        riscv::asm::wfi();
+    }
+
+    #[cfg(target_arch = "loongarch64")]
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
 #[inline(never)]
-fn do_ap_start_stage2() {
+fn do_ap_start_stage2() -> Result<(), system_error::SystemError> {
     info!("Successfully started AP {}", smp_get_processor_id().data());
     #[cfg(target_arch = "x86_64")]
     {
         crate::arch::x86_64::mm::X86_64MMArch::init_current_cpu_nxe();
-        crate::driver::clocksource::kvm_clock::kvmclock_init_secondary();
+        crate::driver::clocksource::kvm_clock::kvmclock_init_secondary()?;
     }
-    arch_syscall_init().expect("AP core failed to initialize syscall");
+    arch_syscall_init()?;
+    Ok(())
 }

--- a/kernel/src/time/clocksource.rs
+++ b/kernel/src/time/clocksource.rs
@@ -667,6 +667,10 @@ impl dyn Clocksource {
         // 将时钟源加入到监视队列中
         let previous_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave().watchdog.clone();
         if let Err(error) = self.clocksource_enqueue_watchdog() {
+            // enqueue_watchdog may have published list membership and a new
+            // reference before resetting every sample. Roll the complete
+            // watchdog transaction back, not only the main registry entry.
+            rollback_watchdog_registration(&this, previous_watchdog.clone());
             remove_clocksource_identity(&mut CLOCKSOURCE_LIST.lock(), &this);
             let _ = self.update_clocksource_data(ClocksourceUpdate::RestoreBeforeRegistration(
                 original_data.clone(),
@@ -873,21 +877,20 @@ impl dyn Clocksource {
     /// ## 参数
     ///
     /// * `rating` - 指定的时钟精度
-    fn clocksource_change_rating(&self, rating: i32) {
-        let _control_guard = CLOCKSOURCE_CONTROL_LOCK.lock_irqsave();
+    ///
+    /// Reorder a registered source while the caller holds
+    /// `CLOCKSOURCE_CONTROL_LOCK`.
+    fn clocksource_change_rating_locked(&self, rating: i32) -> Result<(), SystemError> {
         // 将时钟源从链表中弹出
         self.clocksource_dequeue();
-        self.update_clocksource_data(ClocksourceUpdate::SetRating(rating))
-            .expect("clocksource_change_rating:updata clocksource failed");
+        if let Err(error) = self.update_clocksource_data(ClocksourceUpdate::SetRating(rating)) {
+            // Preserve registry membership if a driver rejects the update.
+            self.clocksource_enqueue();
+            return Err(error);
+        }
         // 插入时钟源到时钟源链表中
         self.clocksource_enqueue();
-        // 检查是否有更好的时钟源
-        if let Err(error) = clocksource_select_locked() {
-            warn!(
-                "clocksource rating change could not switch source: {:?}",
-                error
-            );
-        }
+        Ok(())
     }
 }
 
@@ -1125,6 +1128,10 @@ pub fn clocksource_watchdog() -> Result<(), SystemError> {
 }
 
 fn __clocksource_watchdog_kthread() {
+    // Registration and removal use control -> watchdog -> list. Keep the
+    // unstable-source cleanup in the same transaction so unregister cannot
+    // remove a source after it leaves WATCHDOG_LIST and before it is rerated.
+    let _control_guard = CLOCKSOURCE_CONTROL_LOCK.lock_irqsave();
     let mut watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
     let mut wd_list = WATCHDOG_LIST.lock_irqsave();
     let del_clocks = remove_unstable_clocksources(&mut wd_list);
@@ -1151,7 +1158,15 @@ fn __clocksource_watchdog_kthread() {
     drop(watchdog);
     // 将不稳定的时钟源精度都设置为最低，然后删除unstable标记
     for clock in del_clocks.iter() {
-        clock.clocksource_change_rating(0);
+        if let Err(error) = clock.clocksource_change_rating_locked(0) {
+            warn!("clocksource unstable rating update failed: {:?}", error);
+        }
+    }
+    if let Err(error) = clocksource_select_locked() {
+        warn!(
+            "clocksource unstable cleanup could not switch source: {:?}",
+            error
+        );
     }
 }
 
@@ -1275,8 +1290,6 @@ pub fn init_watchdog_kthread() -> Result<(), SystemError> {
 }
 
 #[path = "clocksource_selftest.rs"]
-#[allow(dead_code)]
 mod selftest;
 
-#[allow(unused_imports)]
 pub(crate) use selftest::run_clocksource_selftests;

--- a/kernel/src/time/clocksource.rs
+++ b/kernel/src/time/clocksource.rs
@@ -28,7 +28,6 @@ use crate::{
 };
 
 use super::{
-    jiffies::clocksource_default_clock,
     timekeeping,
     timer::{clock, Timer, TimerFunction},
     NSEC_PER_SEC, NSEC_PER_USEC,
@@ -70,7 +69,7 @@ pub fn handle_clocksource_cmdline_param() {
 static mut WATCHDOG_KTHREAD: Option<Arc<ProcessControlBlock>> = None;
 
 /// 正在被使用时钟源
-pub static CUR_CLOCKSOURCE: SpinLock<Option<Arc<dyn Clocksource>>> = SpinLock::new(None);
+static CLOCKSOURCE_CONTROL_LOCK: SpinLock<()> = SpinLock::new(());
 /// 是否完成加载
 pub static FINISHED_BOOTING: AtomicBool = AtomicBool::new(false);
 static WATCHDOG_MAX_INTERVAL_NS_SEEN: AtomicU64 = AtomicU64::new(WATCHDOG_INTERVAL_MAX_NS);
@@ -88,6 +87,22 @@ pub const WATCHDOG_THRESHOLD: u32 = NSEC_PER_SEC >> 4;
 
 pub const MAX_SKEW_USEC: u64 = 125 * WATCHDOG_INTERVAL / HZ;
 pub const WATCHDOG_MAX_SKEW: u32 = MAX_SKEW_USEC as u32 * NSEC_PER_USEC;
+
+#[inline]
+fn watchdog_next_expiry(now: u64) -> u64 {
+    now.saturating_add(WATCHDOG_INTERVAL)
+}
+
+#[inline]
+fn watchdog_has_sources(
+    reference: &Option<Arc<dyn Clocksource>>,
+    list: &LinkedList<Arc<dyn Clocksource>>,
+) -> bool {
+    reference.as_ref().is_some_and(|watchdog| {
+        list.iter()
+            .any(|candidate| !Arc::ptr_eq(candidate, watchdog))
+    })
+}
 
 fn should_report_long_watchdog_interval(interval: u64) -> bool {
     loop {
@@ -187,37 +202,36 @@ impl ClocksourceWatchdog {
         }
     }
 
-    /// 获取watchdog
-    fn get_watchdog(&mut self) -> &mut Option<Arc<dyn Clocksource>> {
-        &mut self.watchdog
-    }
-
     /// 启用检查器
-    pub fn clocksource_start_watchdog(&mut self) {
+    pub fn clocksource_start_watchdog(&mut self, has_sources: bool) {
         // 如果watchdog未被设置或者已经启用了就退出
-        let watchdog_list = WATCHDOG_LIST.lock_irqsave();
-        if self.is_running || self.watchdog.is_none() || watchdog_list.is_empty() {
+        if self.is_running || self.watchdog.is_none() || !has_sources {
             return;
         }
         // 生成一个定时器
         let wd_timer_func: Box<WatchdogTimerFunc> = Box::new(WatchdogTimerFunc {});
-        self.timer_expires += clock() + WATCHDOG_INTERVAL;
-        let mut wd_data = self.watchdog.as_ref().unwrap().clone().clocksource_data();
-        wd_data.watchdog_last = self.watchdog.as_ref().unwrap().clone().read();
-        self.watchdog
-            .as_ref()
-            .unwrap()
-            .update_clocksource_data(wd_data)
-            .expect("clocksource_start_watchdog: failed to update watchdog data");
+        // `Timer` takes an absolute jiffies deadline.  A restart must be based
+        // on the current clock, not on a stale deadline left by the previous
+        // watchdog generation.
+        self.timer_expires = watchdog_next_expiry(clock());
+        let Some(watchdog) = self.watchdog.as_ref().cloned() else {
+            return;
+        };
+        let watchdog_last = watchdog.read();
+        if let Err(error) =
+            watchdog.update_clocksource_data(ClocksourceUpdate::SetWatchdogLast(watchdog_last))
+        {
+            warn!("clocksource watchdog could not initialize reference state: {error:?}");
+            return;
+        }
         let wd_timer = Timer::new(wd_timer_func, self.timer_expires);
         wd_timer.activate();
         self.is_running = true;
     }
 
     /// 停止检查器
-    /// list_len WATCHDOG_LIST长度
-    pub fn clocksource_stop_watchdog(&mut self, list_len: usize) {
-        if !self.is_running || (self.watchdog.is_some() && list_len != 0) {
+    pub fn clocksource_stop_watchdog(&mut self, has_sources: bool) {
+        if !self.is_running || (self.watchdog.is_some() && has_sources) {
             return;
         }
         // TODO 当实现了周期性的定时器后 需要将监视用的定时器删除
@@ -231,6 +245,114 @@ pub struct WatchdogTimerFunc;
 impl TimerFunction for WatchdogTimerFunc {
     fn run(&mut self) -> Result<(), SystemError> {
         return clocksource_watchdog();
+    }
+}
+
+/// Closed set of metadata transitions allowed after construction. This keeps
+/// watchdog/rating updates from accidentally overwriting immutable conversion
+/// parameters with a stale cloned `ClocksourceData`.
+#[derive(Debug, Clone)]
+pub enum ClocksourceUpdate {
+    RestoreBeforeRegistration(ClocksourceData),
+    SetConversion {
+        mult: u32,
+        shift: u32,
+    },
+    SetUncertaintyAndAdjustment {
+        uncertainty_margin: u32,
+        maxadj: u32,
+    },
+    SetMaxAdjustment(u32),
+    HalveConversion,
+    SetDeferment {
+        max_cycles: u64,
+        max_idle_ns: u64,
+    },
+    ResetWatchdog,
+    SetWatchdogLast(CycleNum),
+    BeginWatchdog {
+        watchdog_last: CycleNum,
+        cs_last: CycleNum,
+    },
+    UpdateWatchdogSamples {
+        watchdog_last: CycleNum,
+        cs_last: CycleNum,
+    },
+    MarkValidForHres,
+    MarkValidForHresIfStable,
+    MarkUnstable,
+    SetRating(i32),
+}
+
+impl ClocksourceUpdate {
+    pub fn apply(self, data: &mut ClocksourceData) {
+        match self {
+            Self::RestoreBeforeRegistration(original) => *data = original,
+            Self::SetConversion { mult, shift } => {
+                data.mult = mult;
+                data.shift = shift;
+            }
+            Self::SetUncertaintyAndAdjustment {
+                uncertainty_margin,
+                maxadj,
+            } => {
+                data.uncertainty_margin = uncertainty_margin;
+                data.maxadj = maxadj;
+            }
+            Self::SetMaxAdjustment(maxadj) => data.maxadj = maxadj,
+            Self::HalveConversion => {
+                data.mult >>= 1;
+                data.shift -= 1;
+            }
+            Self::SetDeferment {
+                max_cycles,
+                max_idle_ns,
+            } => {
+                data.max_cycles = max_cycles;
+                data.max_idle_ns = max_idle_ns;
+            }
+            Self::ResetWatchdog => {
+                data.flags.remove(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG);
+                data.watchdog_last = CycleNum::new(0);
+                data.cs_last = CycleNum::new(0);
+            }
+            Self::SetWatchdogLast(value) => data.watchdog_last = value,
+            Self::BeginWatchdog {
+                watchdog_last,
+                cs_last,
+            } => {
+                if !data.flags.contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE) {
+                    data.flags.insert(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG);
+                }
+                data.watchdog_last = watchdog_last;
+                data.cs_last = cs_last;
+            }
+            Self::UpdateWatchdogSamples {
+                watchdog_last,
+                cs_last,
+            } => {
+                data.watchdog_last = watchdog_last;
+                data.cs_last = cs_last;
+            }
+            Self::MarkValidForHres => {
+                data.flags
+                    .insert(ClocksourceFlags::CLOCK_SOURCE_VALID_FOR_HRES);
+            }
+            Self::MarkValidForHresIfStable => {
+                if !data.flags.contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE) {
+                    data.flags
+                        .insert(ClocksourceFlags::CLOCK_SOURCE_VALID_FOR_HRES);
+                }
+            }
+            Self::MarkUnstable => {
+                data.flags.remove(
+                    ClocksourceFlags::CLOCK_SOURCE_VALID_FOR_HRES
+                        | ClocksourceFlags::CLOCK_SOURCE_WATCHDOG,
+                );
+                data.flags.insert(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE);
+            }
+            Self::SetRating(rating) => data.rating = rating,
+        }
     }
 }
 
@@ -264,63 +386,140 @@ pub trait Clocksource: Send + Sync + Debug {
     // 获取时钟源数据
     fn clocksource_data(&self) -> ClocksourceData;
 
-    fn update_clocksource_data(&self, _data: ClocksourceData) -> Result<(), SystemError> {
+    fn update_clocksource_data(&self, _update: ClocksourceUpdate) -> Result<(), SystemError> {
         return Err(SystemError::ENOSYS);
     }
     // 获取时钟源
     fn clocksource(&self) -> Arc<dyn Clocksource>;
 }
 
-/// # 实现整数log2的运算
-///
-/// ## 参数
-///
-/// * `x` - 要计算的数字
-///
-/// ## 返回值
-///
-/// * `u32` - 返回\log_2(x)的值
-fn log2(x: u32) -> u32 {
-    let mut result = 0;
-    let mut x = x;
+fn validate_clocksource_conversion(
+    data: &ClocksourceData,
+    require_deferment: bool,
+) -> Result<(), SystemError> {
+    let mask = data.mask.bits();
+    let contiguous_mask = mask != 0 && (mask & mask.wrapping_add(1)) == 0;
+    if !contiguous_mask || data.mult == 0 || data.shift >= 64 {
+        return Err(SystemError::EINVAL);
+    }
+    if require_deferment
+        && (data.maxadj >= data.mult || data.max_cycles == 0 || data.max_cycles > mask)
+    {
+        return Err(SystemError::EINVAL);
+    }
+    Ok(())
+}
 
-    if x >= 1 << 16 {
-        x >>= 16;
-        result |= 16;
+fn remove_clocksource_identity(
+    list: &mut LinkedList<Arc<dyn Clocksource>>,
+    target: &Arc<dyn Clocksource>,
+) -> bool {
+    let mut retained = LinkedList::new();
+    let mut removed = false;
+    while let Some(candidate) = list.pop_front() {
+        if !removed && Arc::ptr_eq(&candidate, target) {
+            removed = true;
+        } else {
+            retained.push_back(candidate);
+        }
     }
-    if x >= 1 << 8 {
-        x >>= 8;
-        result |= 8;
-    }
-    if x >= 1 << 4 {
-        x >>= 4;
-        result |= 4;
-    }
-    if x >= 1 << 2 {
-        x >>= 2;
-        result |= 2;
-    }
-    if x >= 1 << 1 {
-        result |= 1;
+    *list = retained;
+    removed
+}
+
+fn watchdog_replacement_for(
+    target: &Arc<dyn Clocksource>,
+) -> Result<Option<Arc<dyn Clocksource>>, SystemError> {
+    let is_watchdog = CLOCKSOURCE_WATCHDOG
+        .lock_irqsave()
+        .watchdog
+        .as_ref()
+        .is_some_and(|watchdog| Arc::ptr_eq(watchdog, target));
+    if !is_watchdog {
+        return Ok(None);
     }
 
-    result
+    select_watchdog_replacement(&CLOCKSOURCE_LIST.lock(), target)
+        .map(Some)
+        .ok_or(SystemError::EBUSY)
+}
+
+fn select_watchdog_replacement(
+    list: &LinkedList<Arc<dyn Clocksource>>,
+    target: &Arc<dyn Clocksource>,
+) -> Option<Arc<dyn Clocksource>> {
+    list.iter()
+        .filter(|candidate| {
+            if Arc::ptr_eq(candidate, target) {
+                return false;
+            }
+            let flags = candidate.clocksource_data().flags;
+            !flags.intersects(
+                ClocksourceFlags::CLOCK_SOURCE_MUST_VERIFY
+                    | ClocksourceFlags::CLOCK_SOURCE_UNSTABLE,
+            )
+        })
+        .max_by_key(|candidate| candidate.clocksource_data().rating)
+        .cloned()
+}
+
+fn reset_watchdog_state(list: &LinkedList<Arc<dyn Clocksource>>) -> Result<(), SystemError> {
+    for clocksource in list {
+        clocksource.update_clocksource_data(ClocksourceUpdate::ResetWatchdog)?;
+    }
+    Ok(())
+}
+
+fn rollback_watchdog_registration(
+    target: &Arc<dyn Clocksource>,
+    previous_watchdog: Option<Arc<dyn Clocksource>>,
+) {
+    let mut watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
+    let mut list = WATCHDOG_LIST.lock_irqsave();
+    remove_clocksource_identity(&mut list, target);
+    watchdog.watchdog = previous_watchdog;
+    if let Err(error) = reset_watchdog_state(&list) {
+        warn!("clocksource registration rollback could not reset watchdog state: {error:?}");
+    }
+    if let Err(error) = target.update_clocksource_data(ClocksourceUpdate::ResetWatchdog) {
+        warn!("clocksource registration rollback could not reset source: {error:?}");
+    }
+    let has_sources = watchdog_has_sources(&watchdog.watchdog, &list);
+    watchdog.clocksource_stop_watchdog(has_sources);
+    watchdog.clocksource_start_watchdog(has_sources);
+}
+
+fn remove_unstable_clocksources(
+    list: &mut LinkedList<Arc<dyn Clocksource>>,
+) -> Vec<Arc<dyn Clocksource>> {
+    let mut stable = LinkedList::new();
+    let mut unstable = Vec::new();
+    while let Some(clocksource) = list.pop_front() {
+        if clocksource
+            .clocksource_data()
+            .flags
+            .contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE)
+        {
+            unstable.push(clocksource);
+        } else {
+            stable.push_back(clocksource);
+        }
+    }
+    *list = stable;
+    unstable
 }
 
 impl dyn Clocksource {
     /// # 计算时钟源能记录的最大时间跨度
-    pub fn clocksource_max_deferment(&self) -> u64 {
-        let cs_data_guard = self.clocksource_data();
-
-        let mut max_cycles: u64;
-        max_cycles = (1 << (63 - (log2(cs_data_guard.mult + cs_data_guard.maxadj) + 1))) as u64;
-        max_cycles = max_cycles.min(cs_data_guard.mask.bits);
-        let max_nsecs = clocksource_cyc2ns(
-            CycleNum(max_cycles),
-            cs_data_guard.mult - cs_data_guard.maxadj,
-            cs_data_guard.shift,
-        );
-        return max_nsecs - (max_nsecs >> 3);
+    pub fn clocksource_max_deferment(&self) -> (u64, u64) {
+        let data = self.clocksource_data();
+        let max_mult = data.mult.saturating_add(data.maxadj).max(1) as u64;
+        let max_cycles = (u64::MAX / max_mult).min(data.mask.bits());
+        let min_mult = data.mult.saturating_sub(data.maxadj).max(1) as u128;
+        let max_idle_ns = (((max_cycles as u128 * min_mult) >> data.shift) >> 1)
+            .try_into()
+            .unwrap_or(u64::MAX);
+        (max_cycles, max_idle_ns)
     }
 
     /// # 计算时钟源的mult和shift，以便将一个时钟源的频率转换为另一个时钟源的频率
@@ -359,8 +558,12 @@ impl dyn Clocksource {
 
     /// # 更新时钟源频率，初始化mult/shift 和 max_idle_ns
     fn clocksource_update_freq_scale(&self, scale: u32, freq: u32) -> Result<(), SystemError> {
+        if freq != 0 && scale == 0 {
+            return Err(SystemError::EINVAL);
+        }
+
         if freq != 0 {
-            let mut cs_data = self.clocksource_data();
+            let cs_data = self.clocksource_data();
             let mut sec: u64 = cs_data.mask.bits();
 
             sec /= freq as u64;
@@ -373,43 +576,52 @@ impl dyn Clocksource {
 
             let (mult, shift) =
                 self.clocks_calc_mult_shift(freq, NSEC_PER_SEC / scale, sec as u32 * scale);
-            cs_data.set_mult(mult);
-            cs_data.set_shift(shift);
-            self.update_clocksource_data(cs_data)?;
+            self.update_clocksource_data(ClocksourceUpdate::SetConversion { mult, shift })?;
         }
+
+        validate_clocksource_conversion(&self.clocksource_data(), false)?;
 
         let mut cs_data = self.clocksource_data();
         if scale != 0 && freq != 0 && cs_data.uncertainty_margin == 0 {
-            cs_data.set_uncertainty_margin(NSEC_PER_SEC / (scale * freq));
+            let scaled_frequency = (scale as u64).saturating_mul(freq as u64);
+            cs_data.uncertainty_margin = ((NSEC_PER_SEC as u64) / scaled_frequency)
+                .try_into()
+                .unwrap_or(u32::MAX);
             if cs_data.uncertainty_margin < 2 * WATCHDOG_MAX_SKEW {
-                cs_data.set_uncertainty_margin(2 * WATCHDOG_MAX_SKEW);
+                cs_data.uncertainty_margin = 2 * WATCHDOG_MAX_SKEW;
             }
         } else if cs_data.uncertainty_margin == 0 {
-            cs_data.set_uncertainty_margin(WATCHDOG_THRESHOLD);
+            cs_data.uncertainty_margin = WATCHDOG_THRESHOLD;
         }
 
         // 确保时钟源没有太大的mult值造成溢出
-        cs_data.set_maxadj(self.clocksource_max_adjustment());
-        self.update_clocksource_data(cs_data)?;
+        let uncertainty_margin = cs_data.uncertainty_margin;
+        let maxadj = self.clocksource_max_adjustment();
+        self.update_clocksource_data(ClocksourceUpdate::SetUncertaintyAndAdjustment {
+            uncertainty_margin,
+            maxadj,
+        })?;
         while freq != 0
             && (self.clocksource_data().mult + self.clocksource_data().maxadj
                 < self.clocksource_data().mult
                 || self.clocksource_data().mult - self.clocksource_data().maxadj
                     > self.clocksource_data().mult)
         {
-            let mut cs_data = self.clocksource_data();
-            cs_data.set_mult(cs_data.mult >> 1);
-            cs_data.set_shift(cs_data.shift - 1);
-            self.update_clocksource_data(cs_data)?;
-            let mut cs_data = self.clocksource_data();
-            cs_data.set_maxadj(self.clocksource_max_adjustment());
-            self.update_clocksource_data(cs_data)?;
+            self.update_clocksource_data(ClocksourceUpdate::HalveConversion)?;
+            let maxadj = self.clocksource_max_adjustment();
+            self.update_clocksource_data(ClocksourceUpdate::SetMaxAdjustment(maxadj))?;
         }
 
-        let mut cs_data = self.clocksource_data();
-        let ns = self.clocksource_max_deferment();
-        cs_data.set_max_idle_ns(ns as u32);
-        self.update_clocksource_data(cs_data)?;
+        let adjusted_data = self.clocksource_data();
+        if adjusted_data.maxadj >= adjusted_data.mult {
+            return Err(SystemError::EINVAL);
+        }
+
+        let (max_cycles, max_idle_ns) = self.clocksource_max_deferment();
+        self.update_clocksource_data(ClocksourceUpdate::SetDeferment {
+            max_cycles,
+            max_idle_ns,
+        })?;
 
         return Ok(());
     }
@@ -426,15 +638,50 @@ impl dyn Clocksource {
     /// * `Ok(0)` - 时钟源注册成功。
     /// * `Err(SystemError)` - 时钟源注册失败。
     pub fn register(&self, scale: u32, freq: u32) -> Result<(), SystemError> {
-        self.clocksource_update_freq_scale(scale, freq)?;
+        let _control_guard = CLOCKSOURCE_CONTROL_LOCK.lock_irqsave();
+        let this = self.clocksource();
+        let original_data = self.clocksource_data();
+        if CLOCKSOURCE_LIST
+            .lock()
+            .iter()
+            .any(|registered| Arc::ptr_eq(registered, &this))
+        {
+            return Err(SystemError::EEXIST);
+        }
+
+        if let Err(error) = self.clocksource_update_freq_scale(scale, freq) {
+            let _ = self.update_clocksource_data(ClocksourceUpdate::RestoreBeforeRegistration(
+                original_data.clone(),
+            ));
+            return Err(error);
+        }
+        if let Err(error) = validate_clocksource_conversion(&self.clocksource_data(), true) {
+            let _ = self.update_clocksource_data(ClocksourceUpdate::RestoreBeforeRegistration(
+                original_data.clone(),
+            ));
+            return Err(error);
+        }
 
         // 将时钟源加入到时钟源队列中
         self.clocksource_enqueue();
         // 将时钟源加入到监视队列中
-        self.clocksource_enqueue_watchdog()
-            .expect("register: failed to enqueue watchdog list");
+        let previous_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave().watchdog.clone();
+        if let Err(error) = self.clocksource_enqueue_watchdog() {
+            remove_clocksource_identity(&mut CLOCKSOURCE_LIST.lock(), &this);
+            let _ = self.update_clocksource_data(ClocksourceUpdate::RestoreBeforeRegistration(
+                original_data.clone(),
+            ));
+            return Err(error);
+        }
         // 选择一个最好的时钟源
-        clocksource_select();
+        if let Err(error) = clocksource_select_locked() {
+            rollback_watchdog_registration(&this, previous_watchdog);
+            remove_clocksource_identity(&mut CLOCKSOURCE_LIST.lock(), &this);
+            let _ = self.update_clocksource_data(ClocksourceUpdate::RestoreBeforeRegistration(
+                original_data.clone(),
+            ));
+            return Err(error);
+        }
         debug!("clocksource_register successfully");
         return Ok(());
     }
@@ -468,20 +715,21 @@ impl dyn Clocksource {
     /// * `Ok(0)` - 时间源插入监控队列成功
     /// * `Err(SystemError)` - 时间源插入监控队列失败
     pub fn clocksource_enqueue_watchdog(&self) -> Result<i32, SystemError> {
-        // BUG 可能需要lock irq
-        let mut cs_data = self.clocksource_data();
-
+        let cs_data = self.clocksource_data();
         let cs = self.clocksource();
+
+        // Reference publication, membership and sample reset are one
+        // watchdog transaction.  The watchdog callback holds the same lock
+        // while sampling, so it can never combine samples from two reference
+        // generations.
+        let mut cs_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
+        let mut list_guard = WATCHDOG_LIST.lock_irqsave();
         if cs_data
             .flags
             .contains(ClocksourceFlags::CLOCK_SOURCE_MUST_VERIFY)
         {
-            let mut list_guard = WATCHDOG_LIST.lock_irqsave();
             // cs是被监视的
-            cs_data
-                .flags
-                .remove(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG);
-            cs.update_clocksource_data(cs_data)?;
+            cs.update_clocksource_data(ClocksourceUpdate::ResetWatchdog)?;
             list_guard.push_back(cs);
         } else {
             // cs是监视器
@@ -490,57 +738,49 @@ impl dyn Clocksource {
                 .contains(ClocksourceFlags::CLOCK_SOURCE_IS_CONTINUOUS)
             {
                 // 如果时钟设备是连续的
-                cs_data
-                    .flags
-                    .insert(ClocksourceFlags::CLOCK_SOURCE_VALID_FOR_HRES);
-                cs.update_clocksource_data(cs_data.clone())?;
+                cs.update_clocksource_data(ClocksourceUpdate::MarkValidForHres)?;
             }
-
             // 将时钟源加入到监控队列中
-            let mut list_guard = WATCHDOG_LIST.lock_irqsave();
             list_guard.push_back(cs.clone());
-            drop(list_guard);
 
             // 对比当前注册的时间源的精度和监视器的精度
-            let mut cs_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
+            let mut replaced = false;
             if cs_watchdog.watchdog.is_none()
-                || cs_data.rating
-                    > cs_watchdog
-                        .watchdog
-                        .clone()
-                        .unwrap()
-                        .clocksource_data()
-                        .rating
+                || cs_watchdog
+                    .watchdog
+                    .as_ref()
+                    .is_some_and(|watchdog| cs_data.rating > watchdog.clocksource_data().rating)
             {
                 // 当前注册的时间源的精度更高或者没有监视器，替换监视器
                 cs_watchdog.watchdog.replace(cs);
-                clocksource_reset_watchdog();
+                replaced = true;
             }
-
-            // 启动监视器
-            cs_watchdog.clocksource_start_watchdog();
+            if replaced {
+                reset_watchdog_state(&list_guard)?;
+            }
         }
+
+        let has_sources = watchdog_has_sources(&cs_watchdog.watchdog, &list_guard);
+        drop(list_guard);
+        // This common tail is required when a MUST_VERIFY source is added
+        // after its reference (the normal jiffies -> TSC registration order).
+        cs_watchdog.clocksource_start_watchdog(has_sources);
         return Ok(0);
     }
 
-    /// # 将时钟源标记为unstable
-    ///
-    /// ## 参数
-    /// * `delta` - 时钟源误差
-    pub fn set_unstable(&self, delta: i64) -> Result<i32, SystemError> {
-        let mut cs_data = self.clocksource_data();
+    /// Mark a source unstable while the caller already serializes the
+    /// watchdog generation.  This deliberately does not acquire the control
+    /// lock: the watchdog timer holds `CLOCKSOURCE_WATCHDOG`, and taking
+    /// control here would invert the control -> watchdog order used by
+    /// registration and removal.
+    fn mark_unstable_from_watchdog(&self, delta: i64) -> Result<i32, SystemError> {
+        let cs_data = self.clocksource_data();
         // 打印出unstable的时钟源信息
         debug!(
             "clocksource :{:?} is unstable, its delta is {:?}",
             cs_data.name, delta
         );
-        cs_data.flags.remove(
-            ClocksourceFlags::CLOCK_SOURCE_VALID_FOR_HRES | ClocksourceFlags::CLOCK_SOURCE_WATCHDOG,
-        );
-        cs_data
-            .flags
-            .insert(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE);
-        self.update_clocksource_data(cs_data)?;
+        self.update_clocksource_data(ClocksourceUpdate::MarkUnstable)?;
 
         // 启动watchdog线程 进行后续处理
         if FINISHED_BOOTING.load(Ordering::Relaxed) {
@@ -551,131 +791,82 @@ impl dyn Clocksource {
     }
 
     /// # 将时间源从监视链表中弹出
-    fn clocksource_dequeue_watchdog(&self) {
-        let data = self.clocksource_data();
+    fn clocksource_dequeue_watchdog(
+        &self,
+        replacement: Option<Arc<dyn Clocksource>>,
+    ) -> Result<(), SystemError> {
+        let this = self.clocksource();
         let mut locked_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
-        let watchdog = locked_watchdog
-            .get_watchdog()
-            .clone()
-            .unwrap()
-            .clocksource_data();
+        let is_watchdog = locked_watchdog
+            .watchdog
+            .as_ref()
+            .is_some_and(|watchdog| Arc::ptr_eq(watchdog, &this));
+        if is_watchdog && replacement.is_none() {
+            return Err(SystemError::EBUSY);
+        }
 
         let mut list = WATCHDOG_LIST.lock_irqsave();
-        let mut size = list.len();
-
-        let mut del_pos: usize = size;
-        for (pos, ele) in list.iter().enumerate() {
-            let ele_data = ele.clocksource_data();
-            if ele_data.name.eq(&data.name) && ele_data.rating.eq(&data.rating) {
-                // 记录要删除的时钟源在监视链表中的下标
-                del_pos = pos;
-            }
+        if is_watchdog {
+            reset_watchdog_state(&list)?;
         }
-
-        if data
-            .flags
-            .contains(ClocksourceFlags::CLOCK_SOURCE_MUST_VERIFY)
-        {
-            // 如果时钟源是需要被检查的，直接删除时钟源
-            if del_pos != size {
-                let mut temp_list = list.split_off(del_pos);
-                temp_list.pop_front();
-                list.append(&mut temp_list);
-            }
-        } else if watchdog.name.eq(&data.name) && watchdog.rating.eq(&data.rating) {
-            // 如果要删除的时钟源是监视器，则需要找到一个新的监视器
-            // TODO 重新设置时钟源
-            // 将链表解锁防止reset中双重加锁 并释放保存的旧的watchdog的数据
-
-            // 代替了clocksource_reset_watchdog()的功能，将所有时钟源的watchdog标记清除
-            for ele in list.iter() {
-                ele.clocksource_data()
-                    .flags
-                    .remove(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG);
-            }
-
-            // 遍历所有时间源，寻找新的监视器
-            let mut clocksource_list = CLOCKSOURCE_LIST.lock();
-            let mut replace_pos: usize = clocksource_list.len();
-            for (pos, ele) in clocksource_list.iter().enumerate() {
-                let ele_data = ele.clocksource_data();
-
-                if ele_data.name.eq(&data.name) && ele_data.rating.eq(&data.rating)
-                    || ele_data
-                        .flags
-                        .contains(ClocksourceFlags::CLOCK_SOURCE_MUST_VERIFY)
-                {
-                    // 当前时钟源是要被删除的时钟源或没被检查过的时钟源
-                    // 不适合成为监视器
-                    continue;
-                }
-                let watchdog = locked_watchdog.get_watchdog().clone();
-                if watchdog.is_none()
-                    || ele_data.rating > watchdog.unwrap().clocksource_data().rating
-                {
-                    // 如果watchdog不存在或者当前时钟源的精度高于watchdog的精度，则记录当前时钟源的下标
-                    replace_pos = pos;
-                }
-            }
-            // 使用刚刚找到的更好的时钟源替换旧的watchdog
-            if replace_pos < clocksource_list.len() {
-                let mut temp_list = clocksource_list.split_off(replace_pos);
-                let new_wd = temp_list.front().unwrap().clone();
-                clocksource_list.append(&mut temp_list);
-                // 替换watchdog
-                locked_watchdog.watchdog.replace(new_wd);
-                // drop(locked_watchdog);
-            }
-            // 删除时钟源
-            if del_pos != size {
-                let mut temp_list = list.split_off(del_pos);
-                temp_list.pop_front();
-                list.append(&mut temp_list);
-            }
+        self.update_clocksource_data(ClocksourceUpdate::ResetWatchdog)?;
+        remove_clocksource_identity(&mut list, &this);
+        if is_watchdog {
+            locked_watchdog.watchdog = replacement;
         }
-
-        // 清除watchdog标记
-        let mut cs_data = self.clocksource_data();
-        cs_data
-            .flags
-            .remove(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG);
-        self.update_clocksource_data(cs_data)
-            .expect("clocksource_dequeue_watchdog: failed to update clocksource data");
-        size = list.len();
-        // 停止当前的watchdog
-        locked_watchdog.clocksource_stop_watchdog(size - 1);
+        let has_sources = watchdog_has_sources(&locked_watchdog.watchdog, &list);
+        locked_watchdog.clocksource_stop_watchdog(has_sources);
+        locked_watchdog.clocksource_start_watchdog(has_sources);
+        Ok(())
     }
 
     /// # 将时钟源从时钟源链表中弹出
     fn clocksource_dequeue(&self) {
         let mut list = CLOCKSOURCE_LIST.lock();
-        let data = self.clocksource_data();
-        let mut del_pos: usize = list.len();
-        for (pos, ele) in list.iter().enumerate() {
-            let ele_data = ele.clocksource_data();
-            if ele_data.name.eq(&data.name) && ele_data.rating.eq(&data.rating) {
-                // 记录时钟源在链表中的下标
-                del_pos = pos;
-            }
-        }
-
-        // 删除时钟源
-        if del_pos != list.len() {
-            let mut temp_list = list.split_off(del_pos);
-            temp_list.pop_front();
-            list.append(&mut temp_list);
-        }
+        remove_clocksource_identity(&mut list, &self.clocksource());
     }
 
     /// # 注销时钟源
     #[allow(dead_code)]
-    pub fn unregister(&self) {
+    pub fn unregister(&self) -> Result<(), SystemError> {
+        let _control_guard = CLOCKSOURCE_CONTROL_LOCK.lock_irqsave();
+        let this = self.clocksource();
+        let registered = CLOCKSOURCE_LIST
+            .lock()
+            .iter()
+            .any(|candidate| Arc::ptr_eq(candidate, &this));
+        if !registered {
+            return Err(SystemError::ENOENT);
+        }
+        let watchdog_replacement = watchdog_replacement_for(&this)?;
+        let is_active = timekeeping::timekeeping_is_initialized()
+            && timekeeping::timekeeper()
+                .current_clocksource()
+                .is_some_and(|current| Arc::ptr_eq(&current, &this));
+        if is_active {
+            let alternative = CLOCKSOURCE_LIST
+                .lock()
+                .iter()
+                .find(|candidate| {
+                    !Arc::ptr_eq(candidate, &this)
+                        && !candidate
+                            .clocksource_data()
+                            .flags
+                            .contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE)
+                })
+                .cloned()
+                .ok_or(SystemError::EBUSY)?;
+            // Switch while the old source is still registered and owned.  A
+            // failed validation leaves both registry and timekeeper intact.
+            timekeeping::timekeeper().timekeeper_setup_internals(alternative)?;
+        }
         // 将时钟源从监视链表中弹出
-        self.clocksource_dequeue_watchdog();
+        self.clocksource_dequeue_watchdog(watchdog_replacement)?;
         // 将时钟源从时钟源链表中弹出
         self.clocksource_dequeue();
         // 检查是否有更好的时钟源
-        clocksource_select();
+        clocksource_select_locked()?;
+        Ok(())
     }
     /// # 修改时钟源的精度
     ///
@@ -683,17 +874,20 @@ impl dyn Clocksource {
     ///
     /// * `rating` - 指定的时钟精度
     fn clocksource_change_rating(&self, rating: i32) {
+        let _control_guard = CLOCKSOURCE_CONTROL_LOCK.lock_irqsave();
         // 将时钟源从链表中弹出
         self.clocksource_dequeue();
-        let mut data = self.clocksource_data();
-        // 修改时钟源的精度
-        data.set_rating(rating);
-        self.update_clocksource_data(data)
+        self.update_clocksource_data(ClocksourceUpdate::SetRating(rating))
             .expect("clocksource_change_rating:updata clocksource failed");
         // 插入时钟源到时钟源链表中
         self.clocksource_enqueue();
         // 检查是否有更好的时钟源
-        clocksource_select();
+        if let Err(error) = clocksource_select_locked() {
+            warn!(
+                "clocksource rating change could not switch source: {:?}",
+                error
+            );
+        }
     }
 }
 
@@ -706,7 +900,8 @@ pub struct ClocksourceData {
     pub mask: ClocksourceMask,
     pub mult: u32,
     pub shift: u32,
-    pub max_idle_ns: u32,
+    pub max_cycles: u64,
+    pub max_idle_ns: u64,
     pub flags: ClocksourceFlags,
     pub watchdog_last: CycleNum,
     /// 用于watchdog机制中的字段，记录主时钟源上一次被读取的周期数
@@ -715,8 +910,6 @@ pub struct ClocksourceData {
     pub uncertainty_margin: u32,
     // 最大的时间调整量
     pub maxadj: u32,
-    /// 上一次读取时钟源时的周期数
-    pub cycle_last: CycleNum,
 }
 
 impl ClocksourceData {
@@ -728,7 +921,7 @@ impl ClocksourceData {
         mask: ClocksourceMask,
         mult: u32,
         shift: u32,
-        max_idle_ns: u32,
+        max_idle_ns: u64,
         flags: ClocksourceFlags,
         uncertainty_margin: u32,
         maxadj: u32,
@@ -739,61 +932,26 @@ impl ClocksourceData {
             mask,
             mult,
             shift,
+            max_cycles: 0,
             max_idle_ns,
             flags,
             watchdog_last: CycleNum(0),
             cs_last: CycleNum(0),
             uncertainty_margin,
             maxadj,
-            cycle_last: CycleNum(0),
         };
         return csd;
-    }
-
-    pub fn set_name(&mut self, name: String) {
-        self.name = name;
-    }
-    pub fn set_rating(&mut self, rating: i32) {
-        self.rating = rating;
-    }
-    pub fn set_mask(&mut self, mask: ClocksourceMask) {
-        self.mask = mask;
-    }
-    pub fn set_mult(&mut self, mult: u32) {
-        self.mult = mult;
-    }
-    pub fn set_shift(&mut self, shift: u32) {
-        self.shift = shift;
-    }
-    pub fn set_max_idle_ns(&mut self, max_idle_ns: u32) {
-        self.max_idle_ns = max_idle_ns;
-    }
-    pub fn set_flags(&mut self, flags: ClocksourceFlags) {
-        self.flags = flags;
-    }
-    #[allow(dead_code)]
-    pub fn remove_flags(&mut self, flags: ClocksourceFlags) {
-        self.flags.remove(flags)
-    }
-    #[allow(dead_code)]
-    pub fn insert_flags(&mut self, flags: ClocksourceFlags) {
-        self.flags.insert(flags)
-    }
-    pub fn set_uncertainty_margin(&mut self, uncertainty_margin: u32) {
-        self.uncertainty_margin = uncertainty_margin;
-    }
-    pub fn set_maxadj(&mut self, maxadj: u32) {
-        self.maxadj = maxadj;
     }
 }
 
 ///  converts clocksource cycles to nanoseconds
 ///
 pub fn clocksource_cyc2ns(cycles: CycleNum, mult: u32, shift: u32) -> u64 {
-    // info!("<clocksource_cyc2ns>");
-    // info!("cycles = {:?}, mult = {:?}, shift = {:?}", cycles, mult, shift);
-    // info!("ret = {:?}", (cycles.data() * mult as u64) >> shift);
-    return (cycles.data() * mult as u64) >> shift;
+    if shift >= 128 {
+        return 0;
+    }
+    let nanoseconds = ((cycles.data() as u128) * (mult as u128)) >> shift;
+    nanoseconds.min(u64::MAX as u128) as u64
 }
 
 /// # 重启所有的时间源
@@ -834,7 +992,7 @@ pub fn clocksource_suspend() {
 /// * `Ok()` - 检查完成
 /// * `Err(SystemError)` - 错误码
 pub fn clocksource_watchdog() -> Result<(), SystemError> {
-    let cs_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
+    let mut cs_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
     // debug!("clocksource_watchdog start");
 
     // watchdog没有在运行的话直接退出
@@ -843,10 +1001,17 @@ pub fn clocksource_watchdog() -> Result<(), SystemError> {
         return Ok(());
     }
 
-    drop(cs_watchdog);
-    let watchdog_list = WATCHDOG_LIST.lock_irqsave();
+    let watchdog = cs_watchdog.watchdog.as_ref().cloned().unwrap();
+    let watchdog_list: Vec<_> = {
+        let list = WATCHDOG_LIST.lock_irqsave();
+        list.iter().cloned().collect()
+    };
+    let wd_now_data = watchdog.clocksource_data();
     for cs in watchdog_list.iter() {
-        let mut cs_data = cs.clocksource_data();
+        if Arc::ptr_eq(cs, &watchdog) {
+            continue;
+        }
+        let cs_data = cs.clocksource_data();
         // 判断时钟源是否已经被标记为不稳定
         if cs_data
             .flags
@@ -864,10 +1029,7 @@ pub fn clocksource_watchdog() -> Result<(), SystemError> {
         // 读取时钟源现在的时间
         let cs_now_clock = cs.read();
         // 读取watchdog现在的时间
-        let wd = CLOCKSOURCE_WATCHDOG.lock_irqsave();
-        let wd_now = wd.watchdog.as_ref().unwrap().clone();
-        let wd_now_data = wd_now.as_ref().clocksource_data();
-        let wd_now_clock = wd_now.as_ref().read().data();
+        let wd_now_clock = watchdog.read().data();
 
         // info!("cs_name = {:?}", cs_data.name);
         // info!("cs_last = {:?}", cs_data.cs_last);
@@ -882,31 +1044,31 @@ pub fn clocksource_watchdog() -> Result<(), SystemError> {
             .contains(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG)
         {
             // debug!("clocksource_watchdog start watch");
-            cs_data
-                .flags
-                .insert(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG);
-            // 记录此次检查的时刻
-            cs_data.watchdog_last = CycleNum::new(wd_now_clock);
-            cs_data.cs_last = cs_now_clock;
-            cs.update_clocksource_data(cs_data.clone())?;
+            cs.update_clocksource_data(ClocksourceUpdate::BeginWatchdog {
+                watchdog_last: CycleNum::new(wd_now_clock),
+                cs_last: cs_now_clock,
+            })?;
             continue;
         }
 
         let wd_dev_nsec = clocksource_cyc2ns(
-            CycleNum((wd_now_clock - cs_data.watchdog_last.data()) & wd_now_data.mask.bits),
+            CycleNum(
+                wd_now_clock.wrapping_sub(cs_data.watchdog_last.data()) & wd_now_data.mask.bits,
+            ),
             wd_now_data.mult,
             wd_now_data.shift,
         );
 
         let cs_dev_nsec = clocksource_cyc2ns(
-            CycleNum(cs_now_clock.div(cs_data.cs_last).data() & cs_data.mask.bits),
+            CycleNum(cs_now_clock.data().wrapping_sub(cs_data.cs_last.data()) & cs_data.mask.bits),
             cs_data.mult,  // 2343484437
             cs_data.shift, // 23
         );
         // 记录此次检查的时刻
-        cs_data.watchdog_last = CycleNum::new(wd_now_clock);
-        cs_data.cs_last = cs_now_clock;
-        cs.update_clocksource_data(cs_data.clone())?;
+        cs.update_clocksource_data(ClocksourceUpdate::UpdateWatchdogSamples {
+            watchdog_last: CycleNum::new(wd_now_clock),
+            cs_last: cs_now_clock,
+        })?;
 
         // 判断是否有误差。长间隔判断只能基于可信 watchdog 的读数；
         // 被监视 clocksource 单侧跳变必须继续进入 skew 检测。
@@ -927,7 +1089,12 @@ pub fn clocksource_watchdog() -> Result<(), SystemError> {
             // 误差过大，标记为unstable
             info!("cs_dev_nsec = {}", cs_dev_nsec);
             info!("wd_dev_nsec = {}", wd_dev_nsec);
-            cs.set_unstable(cs_dev_nsec.abs_diff(wd_dev_nsec).try_into().unwrap())?;
+            cs.mark_unstable_from_watchdog(
+                cs_dev_nsec
+                    .abs_diff(wd_dev_nsec)
+                    .try_into()
+                    .unwrap_or(i64::MAX),
+            )?;
             continue;
         }
 
@@ -942,51 +1109,46 @@ pub fn clocksource_watchdog() -> Result<(), SystemError> {
                 .flags
                 .contains(ClocksourceFlags::CLOCK_SOURCE_IS_CONTINUOUS)
         {
-            cs_data
-                .flags
-                .insert(ClocksourceFlags::CLOCK_SOURCE_VALID_FOR_HRES);
-            cs.update_clocksource_data(cs_data)?;
+            cs.update_clocksource_data(ClocksourceUpdate::MarkValidForHresIfStable)?;
             // TODO 通知tick机制 切换为高精度模式
         }
     }
-    create_new_watchdog_timer_function();
+    // Rearm against the current absolute jiffies value.  Keep the watchdog
+    // generation locked until all samples and the next deadline are
+    // committed.
+    cs_watchdog.timer_expires = watchdog_next_expiry(clock());
+    let expires = cs_watchdog.timer_expires;
+    drop(cs_watchdog);
+    let watchdog_timer = Timer::new(Box::new(WatchdogTimerFunc {}), expires);
+    watchdog_timer.activate();
     return Ok(());
 }
 
-fn create_new_watchdog_timer_function() {
-    let mut cs_watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
-
-    cs_watchdog.timer_expires += WATCHDOG_INTERVAL;
-    //创建定时器执行watchdog
-    let watchdog_func = Box::new(WatchdogTimerFunc {});
-    let watchdog_timer = Timer::new(watchdog_func, cs_watchdog.timer_expires);
-    watchdog_timer.activate();
-}
-
 fn __clocksource_watchdog_kthread() {
-    let mut del_vec: Vec<usize> = Vec::new();
-    let mut del_clocks: Vec<Arc<dyn Clocksource>> = Vec::new();
+    let mut watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
     let mut wd_list = WATCHDOG_LIST.lock_irqsave();
+    let del_clocks = remove_unstable_clocksources(&mut wd_list);
 
-    // 将不稳定的时钟源弹出监视链表
-    for (pos, ele) in wd_list.iter().enumerate() {
-        let data = ele.clocksource_data();
-        if data.flags.contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE) {
-            del_vec.push(pos);
-            del_clocks.push(ele.clone());
+    let unstable_reference = watchdog.watchdog.as_ref().is_some_and(|reference| {
+        reference
+            .clocksource_data()
+            .flags
+            .contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE)
+    });
+    if unstable_reference {
+        if let Some(old_reference) = watchdog.watchdog.take() {
+            watchdog.watchdog = select_watchdog_replacement(&wd_list, &old_reference);
+            if let Err(error) = reset_watchdog_state(&wd_list) {
+                warn!("clocksource watchdog replacement could not reset state: {error:?}");
+            }
         }
-    }
-    for pos in del_vec {
-        let mut temp_list = wd_list.split_off(pos);
-        temp_list.pop_front();
-        wd_list.append(&mut temp_list);
     }
 
     // 检查是否需要停止watchdog
-    CLOCKSOURCE_WATCHDOG
-        .lock_irqsave()
-        .clocksource_stop_watchdog(wd_list.len());
+    let has_sources = watchdog_has_sources(&watchdog.watchdog, &wd_list);
     drop(wd_list);
+    watchdog.clocksource_stop_watchdog(has_sources);
+    drop(watchdog);
     // 将不稳定的时钟源精度都设置为最低，然后删除unstable标记
     for clock in del_clocks.iter() {
         clock.clocksource_change_rating(0);
@@ -1012,11 +1174,11 @@ pub fn clocksource_watchdog_kthread() -> i32 {
 
 /// # 清空所有时钟源的watchdog标志位
 pub fn clocksource_reset_watchdog() {
+    let _watchdog = CLOCKSOURCE_WATCHDOG.lock_irqsave();
     let list_guard = WATCHDOG_LIST.lock_irqsave();
     for ele in list_guard.iter() {
-        ele.clocksource_data()
-            .flags
-            .remove(ClocksourceFlags::CLOCK_SOURCE_WATCHDOG);
+        ele.update_clocksource_data(ClocksourceUpdate::ResetWatchdog)
+            .expect("clocksource_reset_watchdog: metadata update failed");
     }
 }
 
@@ -1027,55 +1189,63 @@ pub fn clocksource_resume_watchdog() {
 
 /// # 根据精度选择最优的时钟源，或者接受用户指定的时间源
 pub fn clocksource_select() {
-    let list_guard = CLOCKSOURCE_LIST.lock();
-    if !FINISHED_BOOTING.load(Ordering::Relaxed) || list_guard.is_empty() {
-        return;
+    let _control_guard = CLOCKSOURCE_CONTROL_LOCK.lock_irqsave();
+    if let Err(error) = clocksource_select_locked() {
+        warn!("clocksource selection failed: {:?}", error);
     }
-    let mut best = list_guard.front().unwrap().clone();
-    let override_name = OVERRIDE_NAME.lock();
-    // 判断是否有用户空间指定的时间源
-    for ele in list_guard.iter() {
-        if ele.clocksource_data().name.eq(override_name.deref()) {
-            // TODO 判断是否是高精度模式
-            // 暂时不支持高精度模式
-            // 如果是高精度模式，但是时钟源不支持高精度模式的话，就要退出循环
-            best = ele.clone();
-            break;
+}
+
+fn clocksource_select_locked() -> Result<(), SystemError> {
+    if !FINISHED_BOOTING.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+    let best = {
+        let list_guard = CLOCKSOURCE_LIST.lock();
+        if list_guard.is_empty() {
+            return Ok(());
         }
-    }
-    // 对比当前的时钟源和记录到最好的时钟源的精度
-    let mut should_update_timekeeper = false;
-    {
-        let mut cur_guard = CUR_CLOCKSOURCE.lock();
-        if cur_guard.as_ref().is_some() {
-            // 当前时钟源不为空
-            let cur_clocksource = cur_guard.as_ref().unwrap().clone();
-            let best_name = &best.clocksource_data().name;
-            if cur_clocksource.clocksource_data().name.ne(best_name) {
-                info!("Switching to the clocksource {:?}\n", best_name);
-                cur_guard.replace(best.clone());
-                should_update_timekeeper = true;
+        let Some(mut best) = list_guard
+            .iter()
+            .find(|candidate| {
+                !candidate
+                    .clocksource_data()
+                    .flags
+                    .contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE)
+            })
+            .cloned()
+        else {
+            return Ok(());
+        };
+        let override_name = OVERRIDE_NAME.lock();
+        for ele in list_guard.iter() {
+            let data = ele.clocksource_data();
+            if data.name.eq(override_name.deref())
+                && !data.flags.contains(ClocksourceFlags::CLOCK_SOURCE_UNSTABLE)
+            {
+                best = ele.clone();
+                break;
             }
-        } else {
-            // 当前时钟源为空
-            cur_guard.replace(best.clone());
-            should_update_timekeeper = true;
         }
+        best
+    };
+
+    let should_update = timekeeping::timekeeper()
+        .current_clocksource()
+        .is_none_or(|current| !Arc::ptr_eq(&current, &best));
+    if should_update && timekeeping::timekeeping_is_initialized() {
+        info!(
+            "Switching to the clocksource {:?}\n",
+            best.clocksource_data().name
+        );
+        timekeeping::timekeeper().timekeeper_setup_internals(best.clone())?;
     }
-    if should_update_timekeeper && timekeeping::timekeeping_is_initialized() {
-        timekeeping::timekeeper().timekeeper_setup_internals(best.clone());
-    }
-    debug!("clocksource_select finish, CUR_CLOCKSOURCE = {best:?}");
+    debug!("clocksource_select finish, current = {best:?}");
+    Ok(())
 }
 
 /// # clocksource模块加载完成
 pub fn clocksource_boot_finish() {
-    let mut cur_clocksource = CUR_CLOCKSOURCE.lock();
-    if cur_clocksource.is_none() {
-        cur_clocksource.replace(clocksource_default_clock());
-    }
     FINISHED_BOOTING.store(true, Ordering::Relaxed);
-    drop(cur_clocksource);
     clocksource_select();
     // 清除不稳定的时钟源
     __clocksource_watchdog_kthread();
@@ -1103,3 +1273,10 @@ pub fn init_watchdog_kthread() -> Result<(), SystemError> {
 
     return Ok(());
 }
+
+#[path = "clocksource_selftest.rs"]
+#[allow(dead_code)]
+mod selftest;
+
+#[allow(unused_imports)]
+pub(crate) use selftest::run_clocksource_selftests;

--- a/kernel/src/time/clocksource_selftest.rs
+++ b/kernel/src/time/clocksource_selftest.rs
@@ -1,0 +1,229 @@
+use alloc::{collections::LinkedList, format, string::String, string::ToString, sync::Arc};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use system_error::SystemError;
+
+use crate::libs::spinlock::SpinLock;
+
+use super::*;
+
+#[derive(Debug)]
+struct FakeClock {
+    data: SpinLock<ClocksourceData>,
+    cycle: AtomicU64,
+}
+
+impl FakeClock {
+    fn new(name: &str, rating: i32, flags: ClocksourceFlags) -> Arc<Self> {
+        let clock = Arc::new(Self {
+            data: SpinLock::new(ClocksourceData {
+                name: name.to_string(),
+                rating,
+                mask: ClocksourceMask::new(u64::MAX),
+                mult: 1,
+                shift: 0,
+                max_cycles: u64::MAX,
+                max_idle_ns: 0,
+                flags,
+                watchdog_last: CycleNum::new(0),
+                cs_last: CycleNum::new(0),
+                uncertainty_margin: 0,
+                maxadj: 0,
+            }),
+            cycle: AtomicU64::new(0),
+        });
+        clock
+    }
+}
+
+impl Clocksource for FakeClock {
+    fn read(&self) -> CycleNum {
+        CycleNum::new(self.cycle.load(Ordering::Relaxed))
+    }
+
+    fn clocksource_data(&self) -> ClocksourceData {
+        self.data.lock_irqsave().clone()
+    }
+
+    fn update_clocksource_data(&self, update: ClocksourceUpdate) -> Result<(), SystemError> {
+        update.apply(&mut self.data.lock_irqsave());
+        Ok(())
+    }
+
+    fn clocksource(&self) -> Arc<dyn Clocksource> {
+        let raw = self as *const FakeClock;
+        // SAFETY: `FakeClock` is private to this selftest and can only be
+        // constructed by `new()`, which immediately places it in an `Arc`.
+        // A trait call also holds a live reference, so incrementing the Arc
+        // strong count before rebuilding the handle is valid.
+        unsafe {
+            Arc::increment_strong_count(raw);
+            Arc::from_raw(raw)
+        }
+    }
+}
+
+struct Report {
+    body: String,
+    passed: usize,
+    failed: usize,
+}
+
+impl Report {
+    fn case(&mut self, name: &str, passed: bool) {
+        if passed {
+            self.passed += 1;
+            self.body.push_str(&format!("clocksource.{name}=ok\n"));
+        } else {
+            self.failed += 1;
+            self.body.push_str(&format!("clocksource.{name}=fail\n"));
+        }
+    }
+}
+
+pub(crate) fn run_clocksource_selftests() -> (usize, usize, String) {
+    let mut report = Report {
+        body: String::new(),
+        passed: 0,
+        failed: 0,
+    };
+
+    let valid = ClocksourceData {
+        name: "valid".to_string(),
+        rating: 100,
+        mask: ClocksourceMask::new(u64::MAX),
+        mult: 1_000,
+        shift: 10,
+        max_cycles: 10_000,
+        max_idle_ns: 0,
+        flags: ClocksourceFlags::empty(),
+        watchdog_last: CycleNum::new(0),
+        cs_last: CycleNum::new(0),
+        uncertainty_margin: 0,
+        maxadj: 100,
+    };
+    let mut invalid_mask = valid.clone();
+    invalid_mask.mask = ClocksourceMask::new(0b1011);
+    let mut invalid_deferment = valid.clone();
+    invalid_deferment.max_cycles = 0;
+    report.case(
+        "registration_validation",
+        validate_clocksource_conversion(&valid, true).is_ok()
+            && validate_clocksource_conversion(&invalid_mask, true) == Err(SystemError::EINVAL)
+            && validate_clocksource_conversion(&invalid_deferment, true)
+                == Err(SystemError::EINVAL),
+    );
+
+    let mut typed_metadata = valid.clone();
+    let immutable_before = (
+        typed_metadata.name.clone(),
+        typed_metadata.mask,
+        typed_metadata.mult,
+        typed_metadata.shift,
+        typed_metadata.max_cycles,
+        typed_metadata.max_idle_ns,
+    );
+    ClocksourceUpdate::SetRating(321).apply(&mut typed_metadata);
+    ClocksourceUpdate::MarkUnstable.apply(&mut typed_metadata);
+    ClocksourceUpdate::ResetWatchdog.apply(&mut typed_metadata);
+    report.case(
+        "runtime_update_preserves_conversion",
+        immutable_before
+            == (
+                typed_metadata.name.clone(),
+                typed_metadata.mask,
+                typed_metadata.mult,
+                typed_metadata.shift,
+                typed_metadata.max_cycles,
+                typed_metadata.max_idle_ns,
+            )
+            && typed_metadata.rating == 321,
+    );
+
+    let first: Arc<dyn Clocksource> = FakeClock::new("same", 100, ClocksourceFlags::empty());
+    let second: Arc<dyn Clocksource> = FakeClock::new("same", 100, ClocksourceFlags::empty());
+    let mut identity_list = LinkedList::from([first.clone(), second.clone()]);
+    let removed = remove_clocksource_identity(&mut identity_list, &first);
+    report.case(
+        "arc_identity_removal",
+        removed
+            && identity_list.len() == 1
+            && identity_list
+                .front()
+                .is_some_and(|remaining| Arc::ptr_eq(remaining, &second)),
+    );
+
+    let target: Arc<dyn Clocksource> = FakeClock::new("target", 300, ClocksourceFlags::empty());
+    let replacement: Arc<dyn Clocksource> =
+        FakeClock::new("replacement", 200, ClocksourceFlags::empty());
+    let must_verify: Arc<dyn Clocksource> = FakeClock::new(
+        "must-verify",
+        500,
+        ClocksourceFlags::CLOCK_SOURCE_MUST_VERIFY,
+    );
+    let unstable: Arc<dyn Clocksource> =
+        FakeClock::new("unstable", 600, ClocksourceFlags::CLOCK_SOURCE_UNSTABLE);
+    let candidates = LinkedList::from([target.clone(), must_verify, unstable, replacement.clone()]);
+    report.case(
+        "watchdog_replacement",
+        select_watchdog_replacement(&candidates, &target)
+            .is_some_and(|selected| Arc::ptr_eq(&selected, &replacement)),
+    );
+    let no_replacement = LinkedList::from([target.clone()]);
+    report.case(
+        "watchdog_replacement_required",
+        select_watchdog_replacement(&no_replacement, &target).is_none(),
+    );
+
+    let watched: Arc<dyn Clocksource> =
+        FakeClock::new("watched", 400, ClocksourceFlags::CLOCK_SOURCE_MUST_VERIFY);
+    let reference = Some(target.clone());
+    report.case(
+        "must_verify_starts_existing_reference",
+        !watchdog_has_sources(&reference, &LinkedList::from([target.clone()]))
+            && watchdog_has_sources(&reference, &LinkedList::from([target.clone(), watched])),
+    );
+    report.case(
+        "watchdog_restart_deadline",
+        watchdog_next_expiry(10_000) == 10_000 + WATCHDOG_INTERVAL
+            && watchdog_next_expiry(u64::MAX) == u64::MAX,
+    );
+
+    let stable_a: Arc<dyn Clocksource> = FakeClock::new("stable-a", 100, ClocksourceFlags::empty());
+    let unstable_a: Arc<dyn Clocksource> =
+        FakeClock::new("unstable-a", 100, ClocksourceFlags::CLOCK_SOURCE_UNSTABLE);
+    let unstable_b: Arc<dyn Clocksource> =
+        FakeClock::new("unstable-b", 100, ClocksourceFlags::CLOCK_SOURCE_UNSTABLE);
+    let stable_b: Arc<dyn Clocksource> = FakeClock::new("stable-b", 100, ClocksourceFlags::empty());
+    let mut mixed = LinkedList::from([
+        unstable_a.clone(),
+        stable_a.clone(),
+        unstable_b.clone(),
+        stable_b.clone(),
+    ]);
+    let removed = remove_unstable_clocksources(&mut mixed);
+    report.case(
+        "multiple_unstable_cleanup",
+        removed.len() == 2
+            && Arc::ptr_eq(&removed[0], &unstable_a)
+            && Arc::ptr_eq(&removed[1], &unstable_b)
+            && mixed.len() == 2
+            && mixed
+                .front()
+                .is_some_and(|source| Arc::ptr_eq(source, &stable_a))
+            && mixed
+                .back()
+                .is_some_and(|source| Arc::ptr_eq(source, &stable_b)),
+    );
+
+    let cycles = u64::MAX;
+    let mult = u32::MAX;
+    let shift = 32;
+    let expected = (((cycles as u128) * (mult as u128)) >> shift) as u64;
+    report.case(
+        "large_delta_u128_conversion",
+        clocksource_cyc2ns(CycleNum::new(cycles), mult, shift) == expected,
+    );
+
+    (report.passed, report.failed, report.body)
+}

--- a/kernel/src/time/jiffies.rs
+++ b/kernel/src/time/jiffies.rs
@@ -8,7 +8,10 @@ use system_error::SystemError;
 use crate::{arch::time::CLOCK_TICK_RATE, libs::spinlock::SpinLock};
 
 use super::{
-    clocksource::{Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, CycleNum, HZ},
+    clocksource::{
+        Clocksource, ClocksourceData, ClocksourceFlags, ClocksourceMask, ClocksourceUpdate,
+        CycleNum, HZ,
+    },
     timer::clock,
     NSEC_PER_SEC,
 };
@@ -48,20 +51,8 @@ impl Clocksource for ClocksourceJiffies {
     fn clocksource(&self) -> Arc<dyn Clocksource> {
         self.0.lock_irqsave().self_ref.upgrade().unwrap()
     }
-    fn update_clocksource_data(&self, data: ClocksourceData) -> Result<(), SystemError> {
-        let d = &mut self.0.lock_irqsave().data;
-        d.set_name(data.name);
-        d.set_rating(data.rating);
-        d.set_mask(data.mask);
-        d.set_mult(data.mult);
-        d.set_shift(data.shift);
-        d.set_max_idle_ns(data.max_idle_ns);
-        d.set_flags(data.flags);
-        d.watchdog_last = data.watchdog_last;
-        d.cs_last = data.cs_last;
-        d.set_uncertainty_margin(data.uncertainty_margin);
-        d.set_maxadj(data.maxadj);
-        d.cycle_last = data.cycle_last;
+    fn update_clocksource_data(&self, update: ClocksourceUpdate) -> Result<(), SystemError> {
+        update.apply(&mut self.0.lock_irqsave().data);
         return Ok(());
     }
 
@@ -77,13 +68,13 @@ impl ClocksourceJiffies {
             mask: ClocksourceMask::new(0xffffffff),
             mult: NSEC_PER_JIFFY << JIFFIES_SHIFT,
             shift: JIFFIES_SHIFT,
+            max_cycles: Default::default(),
             max_idle_ns: Default::default(),
             flags: ClocksourceFlags::new(0),
             watchdog_last: CycleNum::new(0),
             cs_last: CycleNum::new(0),
             uncertainty_margin: 0,
             maxadj: 0,
-            cycle_last: CycleNum::new(0),
         };
         let jiffies = Arc::new(ClocksourceJiffies(SpinLock::new(InnerJiffies {
             data,

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -7,7 +7,7 @@ use core::{
 use crate::arch::CurrentTimeArch;
 use crate::time::syscall::PosixTimeval;
 
-use self::timekeeping::getnstimeofday;
+use self::timekeeping::{getnstimeofday, monotonic_now};
 
 pub mod clocksource;
 pub mod jiffies;
@@ -57,6 +57,12 @@ pub struct PosixTimeSpec {
 }
 
 impl PosixTimeSpec {
+    /// Largest non-negative time representable by Linux's signed 64-bit ktime.
+    pub const KTIME_MAX: Self = Self {
+        tv_sec: i64::MAX / NSEC_PER_SEC as i64,
+        tv_nsec: i64::MAX % NSEC_PER_SEC as i64,
+    };
+
     #[allow(dead_code)]
     pub fn new(sec: i64, nsec: i64) -> PosixTimeSpec {
         return PosixTimeSpec {
@@ -98,7 +104,40 @@ impl PosixTimeSpec {
 
     /// 换算成纳秒
     pub fn total_nanos(&self) -> i64 {
-        self.tv_sec * NSEC_PER_SEC as i64 + self.tv_nsec
+        self.tv_sec
+            .saturating_mul(NSEC_PER_SEC as i64)
+            .saturating_add(self.tv_nsec)
+    }
+
+    /// Validate a non-negative POSIX timeout value.
+    #[inline]
+    pub fn is_valid_timeout(&self) -> bool {
+        self.tv_sec >= 0 && (0..NSEC_PER_SEC as i64).contains(&self.tv_nsec)
+    }
+
+    /// Convert a valid non-negative timespec to nanoseconds using Linux's
+    /// `ktime_set()` saturation boundary.
+    #[inline]
+    pub fn to_ktime_ns(&self) -> u64 {
+        (self.tv_sec.max(0) as u128)
+            .saturating_mul(NSEC_PER_SEC as u128)
+            .saturating_add(self.tv_nsec.max(0) as u128)
+            .min(i64::MAX as u128) as u64
+    }
+
+    /// Add two non-negative timespecs and saturate at `KTIME_MAX`.
+    #[inline]
+    pub fn saturating_add_ktime(&self, rhs: &Self) -> Self {
+        let total = (self.to_ktime_ns() as u128)
+            .saturating_add(rhs.to_ktime_ns() as u128)
+            .min(i64::MAX as u128) as u64;
+        Self::from_ns(total)
+    }
+
+    /// Return `self - rhs`, clamped to zero, without signed overflow.
+    #[inline]
+    pub fn saturating_sub_timespec(&self, rhs: &Self) -> Self {
+        Self::from_ns(self.to_ktime_ns().saturating_sub(rhs.to_ktime_ns()))
     }
 
     /// 从纳秒创建 PosixTimeSpec
@@ -266,7 +305,7 @@ impl Instant {
 
     /// Create a new `Instant` from the current time
     pub fn now() -> Instant {
-        let tm = getnstimeofday();
+        let tm = monotonic_now();
         Self::from_micros(tm.tv_sec * 1000000 + tm.tv_nsec / 1000)
     }
 

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -118,7 +118,7 @@ impl PosixTimeSpec {
     /// Convert a valid non-negative timespec to nanoseconds using Linux's
     /// `ktime_set()` saturation boundary.
     #[inline]
-    pub fn to_ktime_ns(&self) -> u64 {
+    pub fn to_ktime_ns(self) -> u64 {
         (self.tv_sec.max(0) as u128)
             .saturating_mul(NSEC_PER_SEC as u128)
             .saturating_add(self.tv_nsec.max(0) as u128)

--- a/kernel/src/time/sleep.rs
+++ b/kernel/src/time/sleep.rs
@@ -4,14 +4,13 @@ use alloc::{boxed::Box, sync::Arc};
 use system_error::SystemError;
 
 use crate::{
-    arch::{CurrentIrqArch, CurrentTimeArch},
-    exception::InterruptArch,
-    process::ProcessManager,
-    sched::{schedule, SchedMode},
+    arch::CurrentTimeArch,
+    libs::wait_queue::{TimeoutWaker, Waiter},
 };
 
 use super::{
-    timer::{next_n_us_timer_jiffies, Timer, WakeUpHelper},
+    timekeeping::monotonic_now,
+    timer::{next_n_us_timer_jiffies, Timer},
     PosixTimeSpec, TimeArch,
 };
 
@@ -35,35 +34,35 @@ pub fn nanosleep(sleep_time: PosixTimeSpec) -> Result<(), SystemError> {
         return Ok(());
     }
 
+    let sleep_deadline = monotonic_now().saturating_add_ktime(&sleep_time);
     let total_sleep_time_us = sleep_time.to_ktime_ns().div_ceil(1000);
-    // 创建定时器
-    let handler: Box<WakeUpHelper> = WakeUpHelper::new(ProcessManager::current_pcb());
-    let timer: Arc<Timer> = Timer::new(handler, next_n_us_timer_jiffies(total_sleep_time_us));
+    let (waiter, waker) = Waiter::new_pair();
+    let handler: Box<TimeoutWaker> = TimeoutWaker::new(waker);
+    let expiry_jiffies = next_n_us_timer_jiffies(total_sleep_time_us);
+    let timer: Arc<Timer> = Timer::new(handler, expiry_jiffies);
 
     timer.activate();
 
-    // Linux 语义：等待可能出现伪唤醒；只有在收到未被屏蔽的信号时才中断。
-    // 对于 job-control stop/continue 这类不应直接对用户态暴露的唤醒，应继续等待直到到期。
-    loop {
-        let irq_guard: crate::exception::IrqFlagsGuard =
-            unsafe { CurrentIrqArch::save_and_disable_irq() };
-        ProcessManager::mark_sleep(true).ok();
-        drop(irq_guard);
-        schedule(SchedMode::SM_NONE);
-
-        if timer.timeout() {
-            break;
+    match waiter.wait(true) {
+        Ok(()) => {
+            debug_assert!(timer.timeout());
+            Ok(())
         }
-
-        // 未到期而被唤醒：若存在未屏蔽待处理信号，则视为被信号打断；否则认为是伪唤醒，继续等待。
-        let current_pcb = ProcessManager::current_pcb();
-        let has_real_signal =
-            current_pcb.has_pending_signal_fast() && current_pcb.has_pending_not_masked_signal();
-        if has_real_signal {
+        Err(SystemError::ERESTARTSYS) => {
             timer.cancel();
-            return Err(SystemError::ERESTARTSYS);
+            if timer.timeout()
+                || sleep_deadline
+                    .saturating_sub_timespec(&monotonic_now())
+                    .is_empty()
+            {
+                Ok(())
+            } else {
+                Err(SystemError::ERESTARTSYS)
+            }
+        }
+        Err(err) => {
+            timer.cancel();
+            Err(err)
         }
     }
-
-    Ok(())
 }

--- a/kernel/src/time/sleep.rs
+++ b/kernel/src/time/sleep.rs
@@ -8,7 +8,6 @@ use crate::{
     exception::InterruptArch,
     process::ProcessManager,
     sched::{schedule, SchedMode},
-    time::timekeeping::getnstimeofday,
 };
 
 use super::{
@@ -20,11 +19,11 @@ use super::{
 ///
 /// @param sleep_time 指定休眠的时间
 ///
-/// @return Ok(TimeSpec) 剩余休眠时间
+/// @return Ok(()) 正常完成
 ///
 /// @return Err(SystemError) 错误码
-pub fn nanosleep(sleep_time: PosixTimeSpec) -> Result<PosixTimeSpec, SystemError> {
-    if sleep_time.tv_nsec < 0 || sleep_time.tv_nsec >= 1000000000 {
+pub fn nanosleep(sleep_time: PosixTimeSpec) -> Result<(), SystemError> {
+    if !sleep_time.is_valid_timeout() {
         return Err(SystemError::EINVAL);
     }
     // 对于小于500us的时间，使用spin/rdtsc来进行定时
@@ -33,19 +32,14 @@ pub fn nanosleep(sleep_time: PosixTimeSpec) -> Result<PosixTimeSpec, SystemError
         while CurrentTimeArch::get_cycles() < expired_tsc {
             spin_loop()
         }
-        return Ok(PosixTimeSpec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        });
+        return Ok(());
     }
 
-    let total_sleep_time_us: u64 =
-        sleep_time.tv_sec as u64 * 1000000 + sleep_time.tv_nsec as u64 / 1000;
+    let total_sleep_time_us = sleep_time.to_ktime_ns().div_ceil(1000);
     // 创建定时器
     let handler: Box<WakeUpHelper> = WakeUpHelper::new(ProcessManager::current_pcb());
     let timer: Arc<Timer> = Timer::new(handler, next_n_us_timer_jiffies(total_sleep_time_us));
 
-    let start_time = getnstimeofday();
     timer.activate();
 
     // Linux 语义：等待可能出现伪唤醒；只有在收到未被屏蔽的信号时才中断。
@@ -71,8 +65,5 @@ pub fn nanosleep(sleep_time: PosixTimeSpec) -> Result<PosixTimeSpec, SystemError
         }
     }
 
-    let end_time = getnstimeofday();
-    let real_sleep_time = end_time - start_time;
-    let rm_time: PosixTimeSpec = (sleep_time - real_sleep_time.into()).into();
-    Ok(rm_time)
+    Ok(())
 }

--- a/kernel/src/time/syscall/posix_clock.rs
+++ b/kernel/src/time/syscall/posix_clock.rs
@@ -1,20 +1,20 @@
 use crate::process::ProcessManager;
-use crate::time::timekeeping::getnstimeofday;
+use crate::time::jiffies::NSEC_PER_JIFFY;
+use crate::time::timekeeping::{
+    boottime_now, monotonic_coarse, monotonic_now, monotonic_raw_now, realtime_coarse, realtime_now,
+};
 use crate::time::PosixTimeSpec;
 
 use super::{PosixClockID, CPUCLOCK_PERTHREAD_MASK};
 
 pub(crate) fn posix_clock_now(clock_id: PosixClockID) -> PosixTimeSpec {
     match clock_id {
-        PosixClockID::Realtime => getnstimeofday(),
-        // 单调/boottime/raw/coarse/alarm 等目前仍复用 realtime（后续可补齐真正语义）。
-        PosixClockID::Monotonic
-        | PosixClockID::Boottime
-        | PosixClockID::MonotonicRaw
-        | PosixClockID::RealtimeCoarse
-        | PosixClockID::MonotonicCoarse
-        | PosixClockID::RealtimeAlarm
-        | PosixClockID::BoottimeAlarm => getnstimeofday(),
+        PosixClockID::Realtime | PosixClockID::RealtimeAlarm => realtime_now(),
+        PosixClockID::Monotonic => monotonic_now(),
+        PosixClockID::Boottime | PosixClockID::BoottimeAlarm => boottime_now(),
+        PosixClockID::MonotonicRaw => monotonic_raw_now(),
+        PosixClockID::RealtimeCoarse => realtime_coarse(),
+        PosixClockID::MonotonicCoarse => monotonic_coarse(),
 
         PosixClockID::ProcessCPUTimeID => {
             let pcb = ProcessManager::current_pcb();
@@ -39,11 +39,11 @@ pub(crate) fn posix_clock_now(clock_id: PosixClockID) -> PosixTimeSpec {
     }
 }
 
-pub(crate) fn posix_clock_res(_clock_id: PosixClockID) -> PosixTimeSpec {
-    // Linux 的 clock_getres 对大多数 POSIX clock 返回“该 clock 的分辨率”。
-    // DragonOS 目前对多数 clock 仍复用 realtime/getnstimeofday() 语义，
-    // 且内部时间统一用纳秒表示，因此先返回 1ns 作为分辨率。
-    //
-    // 后续若区分 coarse/raw 或引入 tick 粒度限制，可在这里统一收敛实现。
-    PosixTimeSpec::new(0, 1)
+pub(crate) fn posix_clock_res(clock_id: PosixClockID) -> PosixTimeSpec {
+    match clock_id {
+        PosixClockID::ProcessCPUTimeID
+        | PosixClockID::ThreadCPUTimeID
+        | PosixClockID::DynamicCpuClock(_) => PosixTimeSpec::new(0, 1),
+        _ => PosixTimeSpec::new(0, NSEC_PER_JIFFY as i64),
+    }
 }

--- a/kernel/src/time/syscall/sys_clock_nanosleep.rs
+++ b/kernel/src/time/syscall/sys_clock_nanosleep.rs
@@ -90,7 +90,18 @@ impl SysClockNanosleep {
                 if remain.tv_sec == 0 && remain.tv_nsec == 0 {
                     return Ok(());
                 }
-                nanosleep(remain).map(|_| ())
+                match nanosleep(remain) {
+                    Ok(()) => Ok(()),
+                    Err(SystemError::ERESTARTSYS) => {
+                        let remain = Self::calc_remaining(deadline, &Self::ktime_now(clockid));
+                        if remain.is_empty() {
+                            Ok(())
+                        } else {
+                            Err(SystemError::ERESTARTSYS)
+                        }
+                    }
+                    Err(err) => Err(err),
+                }
             }
         }
     }

--- a/kernel/src/time/syscall/sys_clock_nanosleep.rs
+++ b/kernel/src/time/syscall/sys_clock_nanosleep.rs
@@ -117,7 +117,10 @@ impl Syscall for SysClockNanosleep {
         let clockid = PosixClockID::try_from(Self::which_clock(args))?;
         match clockid {
             Realtime | Monotonic | Boottime | ProcessCPUTimeID => {}
-            ThreadCPUTimeID => return Err(SystemError::EINVAL),
+            // CLOCK_THREAD_CPUTIME_ID is a valid POSIX clock but Linux has no
+            // clock_nanosleep operation for it, so this is EOPNOTSUPP rather
+            // than EINVAL.
+            ThreadCPUTimeID => return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
             _ => return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
         }
         let flags = Self::flags(args);

--- a/kernel/src/time/syscall/sys_clock_nanosleep.rs
+++ b/kernel/src/time/syscall/sys_clock_nanosleep.rs
@@ -1,10 +1,10 @@
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_CLOCK_NANOSLEEP;
 use crate::ipc::signal::{RestartBlock, RestartBlockData};
+use crate::mm::VirtAddr;
 use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::{UserBufferReader, UserBufferWriter};
-use crate::time::timekeeping::getnstimeofday;
 use crate::time::{sleep::nanosleep, PosixTimeSpec};
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -29,27 +29,12 @@ impl SysClockNanosleep {
 
     #[inline]
     fn ktime_now(clockid: PosixClockID) -> PosixTimeSpec {
-        // 暂时使用 realtime 近似；后续区分 monotonic/boottime
-        // - Realtime：使用 getnstimeofday()
-        // - Monotonic/Boottime：暂与 Realtime 等价（后续引入真正单调/启动时钟）
-        match clockid {
-            Realtime => getnstimeofday(),
-            Monotonic | Boottime => getnstimeofday(),
-            ProcessCPUTimeID => {
-                let pcb = ProcessManager::current_pcb();
-                PosixTimeSpec::from_ns(pcb.process_cputime_ns())
-            }
-            ThreadCPUTimeID => {
-                let pcb = ProcessManager::current_pcb();
-                PosixTimeSpec::from_ns(pcb.thread_cputime_ns())
-            }
-            _ => getnstimeofday(),
-        }
+        super::posix_clock::posix_clock_now(clockid)
     }
 
     #[inline]
     fn is_valid_timespec(ts: &PosixTimeSpec) -> bool {
-        ts.tv_sec >= 0 && ts.tv_nsec >= 0 && ts.tv_nsec < 1_000_000_000
+        ts.is_valid_timeout()
     }
 
     #[inline]
@@ -62,36 +47,12 @@ impl SysClockNanosleep {
 
     #[inline]
     fn calc_remaining(deadline: &PosixTimeSpec, now: &PosixTimeSpec) -> PosixTimeSpec {
-        let mut sec = deadline.tv_sec - now.tv_sec;
-        let mut nsec = deadline.tv_nsec - now.tv_nsec;
-        if nsec < 0 {
-            sec -= 1;
-            nsec += 1_000_000_000;
-        }
-        if sec < 0 {
-            return PosixTimeSpec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-        }
-        PosixTimeSpec {
-            tv_sec: sec,
-            tv_nsec: nsec,
-        }
+        deadline.saturating_sub_timespec(now)
     }
 
     #[inline]
     fn add_timespec(a: &PosixTimeSpec, b: &PosixTimeSpec) -> PosixTimeSpec {
-        let mut sec = a.tv_sec + b.tv_sec;
-        let mut nsec = a.tv_nsec + b.tv_nsec;
-        if nsec >= 1_000_000_000 {
-            sec += 1;
-            nsec -= 1_000_000_000;
-        }
-        PosixTimeSpec {
-            tv_sec: sec,
-            tv_nsec: nsec,
-        }
+        a.saturating_add_ktime(b)
     }
 
     fn do_wait_until(deadline: &PosixTimeSpec, clockid: PosixClockID) -> Result<(), SystemError> {
@@ -144,10 +105,13 @@ impl Syscall for SysClockNanosleep {
         // 解析/校验参数
         let clockid = PosixClockID::try_from(Self::which_clock(args))?;
         match clockid {
-            Realtime | Monotonic | Boottime | ProcessCPUTimeID | ThreadCPUTimeID => {}
+            Realtime | Monotonic | Boottime | ProcessCPUTimeID => {}
+            ThreadCPUTimeID => return Err(SystemError::EINVAL),
             _ => return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
         }
         let flags = Self::flags(args);
+        // Linux 6.6 only interprets TIMER_ABSTIME here; unknown bits are
+        // ignored by the POSIX clock nanosleep implementations.
         let is_abstime = (flags & 0x01) != 0; // TIMER_ABSTIME = 1
 
         // 读取 rqtp
@@ -165,25 +129,25 @@ impl Syscall for SysClockNanosleep {
             tv_nsec: rq_user.tv_nsec,
         };
 
-        let rmtp_ptr = Self::rmtp(args);
-        let mut rmtp_writer = if !rmtp_ptr.is_null() && !is_abstime {
-            Some(UserBufferWriter::new(
-                rmtp_ptr,
-                core::mem::size_of::<PosixTimeSpec>(),
-                true,
-            )?)
+        let rmtp = if !Self::rmtp(args).is_null() && !is_abstime {
+            Some(VirtAddr::new(Self::rmtp(args) as usize))
         } else {
             None
         };
 
         // 计算 deadline
+        let deadline_clockid = if !is_abstime && matches!(clockid, Realtime) {
+            Monotonic
+        } else {
+            clockid
+        };
         let deadline: PosixTimeSpec = if is_abstime {
             PosixTimeSpec {
                 tv_sec: rq.tv_sec,
                 tv_nsec: rq.tv_nsec,
             }
         } else {
-            let now = Self::ktime_now(clockid);
+            let now = Self::ktime_now(deadline_clockid);
             Self::add_timespec(&now, &rq)
         };
 
@@ -197,7 +161,7 @@ impl Syscall for SysClockNanosleep {
         }
 
         // 等待
-        let wait_res = Self::do_wait_until(&deadline, clockid);
+        let wait_res = Self::do_wait_until(&deadline, deadline_clockid);
         match wait_res {
             Ok(()) => {
                 // log::debug!(
@@ -207,7 +171,7 @@ impl Syscall for SysClockNanosleep {
                 // );
                 return Ok(0);
             }
-            Err(_e) => {
+            Err(SystemError::ERESTARTSYS) => {
                 // 信号打断
                 if is_abstime {
                     // 绝对睡眠：返回 -ERESTARTNOHAND，不写 rmtp
@@ -215,18 +179,27 @@ impl Syscall for SysClockNanosleep {
                     return Err(SystemError::ERESTARTNOHAND);
                 } else {
                     // 相对睡眠：写回剩余时间，并设置restart block
-                    if let Some(ref mut w) = rmtp_writer {
-                        let now = Self::ktime_now(clockid);
+                    if let Some(rmtp) = rmtp {
+                        let now = Self::ktime_now(deadline_clockid);
                         let remain = Self::calc_remaining(&deadline, &now);
                         // log::debug!(
                         //     "clock_nanosleep: REL interrupted -> write rem {{sec={}, nsec={}}}",
                         //     remain.tv_sec,
                         //     remain.tv_nsec
                         // );
-                        w.copy_one_to_user(&remain, 0)?;
+                        let mut writer = UserBufferWriter::new(
+                            rmtp.as_ptr::<PosixTimeSpec>(),
+                            core::mem::size_of::<PosixTimeSpec>(),
+                            true,
+                        )?;
+                        writer.copy_one_to_user(&remain, 0)?;
                     }
                     // 设置重启函数
-                    let data = RestartBlockData::Nanosleep { deadline, clockid };
+                    let data = RestartBlockData::Nanosleep {
+                        deadline,
+                        clockid: deadline_clockid,
+                        rmtp,
+                    };
                     // log::debug!(
                     //     "clock_nanosleep: set restart block and return ERESTART_RESTARTBLOCK"
                     // );
@@ -234,6 +207,7 @@ impl Syscall for SysClockNanosleep {
                     return ProcessManager::current_pcb().set_restart_fn(Some(rb));
                 }
             }
+            Err(error) => return Err(error),
         }
     }
 

--- a/kernel/src/time/syscall/sys_nanosleep.rs
+++ b/kernel/src/time/syscall/sys_nanosleep.rs
@@ -54,12 +54,16 @@ impl Syscall for SysNanosleep {
             Err(error) => return Err(error),
         }
 
+        let remaining = deadline.saturating_sub_timespec(&monotonic_now());
+        if remaining.is_empty() {
+            return Ok(0);
+        }
+
         let rmtp = if Self::rm_time(args).is_null() {
             None
         } else {
             Some(VirtAddr::new(Self::rm_time(args) as usize))
         };
-        let remaining = deadline.saturating_sub_timespec(&monotonic_now());
         if let Some(rmtp) = rmtp {
             let mut writer = UserBufferWriter::new(
                 rmtp.as_ptr::<PosixTimeSpec>(),

--- a/kernel/src/time/syscall/sys_nanosleep.rs
+++ b/kernel/src/time/syscall/sys_nanosleep.rs
@@ -1,8 +1,13 @@
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_NANOSLEEP;
+use crate::ipc::signal::{RestartBlock, RestartBlockData, RestartFnNanosleep};
+use crate::mm::VirtAddr;
+use crate::process::ProcessManager;
 use crate::syscall::table::{FormattedSyscallParam, Syscall};
 use crate::syscall::user_access::{UserBufferReader, UserBufferWriter};
 use crate::time::sleep::nanosleep;
+use crate::time::syscall::PosixClockID;
+use crate::time::timekeeping::monotonic_now;
 use crate::time::PosixTimeSpec;
 use alloc::vec::Vec;
 use system_error::SystemError;
@@ -30,30 +35,43 @@ impl Syscall for SysNanosleep {
             core::mem::size_of::<PosixTimeSpec>(),
             true,
         )?;
-        let rm_time_ptr = Self::rm_time(args);
-        let mut rm_time_writer = if !rm_time_ptr.is_null() {
-            Some(UserBufferWriter::new(
-                rm_time_ptr,
-                core::mem::size_of::<PosixTimeSpec>(),
-                true,
-            )?)
-        } else {
-            None
-        };
-
         let sleep_time = sleep_time_reader.read_one_from_user::<PosixTimeSpec>(0)?;
 
         let slt_spec = PosixTimeSpec {
             tv_sec: sleep_time.tv_sec,
             tv_nsec: sleep_time.tv_nsec,
         };
-        let r = nanosleep(slt_spec)?;
-        if let Some(ref mut rm_time) = rm_time_writer {
-            // 如果rm_time不为null，则将剩余时间写入rm_time
-            rm_time.copy_one_to_user(&r, 0)?;
+        if !slt_spec.is_valid_timeout() {
+            return Err(SystemError::EINVAL);
         }
 
-        return Ok(0);
+        let deadline = monotonic_now().saturating_add_ktime(&slt_spec);
+        // Linux only writes `rem` when the sleep is interrupted. A successful
+        // nanosleep must leave the user buffer untouched.
+        match nanosleep(slt_spec) {
+            Ok(()) => return Ok(0),
+            Err(SystemError::ERESTARTSYS) => {}
+            Err(error) => return Err(error),
+        }
+
+        let rmtp = if Self::rm_time(args).is_null() {
+            None
+        } else {
+            Some(VirtAddr::new(Self::rm_time(args) as usize))
+        };
+        let remaining = deadline.saturating_sub_timespec(&monotonic_now());
+        if let Some(rmtp) = rmtp {
+            let mut writer = UserBufferWriter::new(
+                rmtp.as_ptr::<PosixTimeSpec>(),
+                core::mem::size_of::<PosixTimeSpec>(),
+                true,
+            )?;
+            writer.copy_one_to_user(&remaining, 0)?;
+        }
+
+        let data = RestartBlockData::new_nanosleep(deadline, PosixClockID::Monotonic, rmtp);
+        let restart = RestartBlock::new(&RestartFnNanosleep, data);
+        ProcessManager::current_pcb().set_restart_fn(Some(restart))
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/kernel/src/time/timekeeping.rs
+++ b/kernel/src/time/timekeeping.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
-use core::intrinsics::{likely, unlikely};
 use core::sync::atomic::{AtomicBool, Ordering};
-use log::{debug, info, warn};
+
+use log::{info, warn};
 use system_error::SystemError;
 
 use crate::{
@@ -15,298 +15,303 @@ use crate::{
     },
 };
 
-use super::timekeep::{ktime_t, timespec_to_ktime};
 use super::{
-    clocksource::{clocksource_cyc2ns, Clocksource, CycleNum, HZ},
+    clocksource::{Clocksource, ClocksourceMask},
     syscall::PosixTimeval,
     NSEC_PER_SEC,
 };
-/// NTP周期频率
-pub const NTP_INTERVAL_FREQ: u64 = HZ;
-/// NTP周期长度
-pub const NTP_INTERVAL_LENGTH: u64 = NSEC_PER_SEC as u64 / NTP_INTERVAL_FREQ;
-/// NTP转换比例
-pub const NTP_SCALE_SHIFT: u32 = 32;
 
-/// timekeeping休眠标志，false为未休眠
 pub static TIMEKEEPING_SUSPENDED: AtomicBool = AtomicBool::new(false);
-/// timekeeper全局变量，用于管理timekeeper模块
+
 static mut __TIMEKEEPER: Option<Timekeeper> = None;
+
+const TIME_SETTOD_SEC_MAX: i64 = i64::MAX / NSEC_PER_SEC as i64 - 30 * 365 * 24 * 60 * 60;
+
+#[derive(Debug, Clone)]
+struct TimekeeperReadBase {
+    clock: Arc<dyn Clocksource>,
+    mask: ClocksourceMask,
+    cycle_last: u64,
+    mult: u32,
+    shift: u32,
+    max_cycles: u64,
+    base_ns: u64,
+    fraction: u64,
+}
+
+impl TimekeeperReadBase {
+    fn new(
+        clock: Arc<dyn Clocksource>,
+        data: &super::clocksource::ClocksourceData,
+        cycle_last: u64,
+        base_ns: u64,
+    ) -> Option<Self> {
+        if data.mask.bits() == 0
+            || data.mult == 0
+            || data.shift >= u64::BITS
+            || data.max_cycles == 0
+            || data.max_cycles > data.mask.bits()
+            || !mask_is_contiguous(data.mask.bits())
+        {
+            return None;
+        }
+
+        Some(Self {
+            clock,
+            mask: data.mask,
+            cycle_last,
+            mult: data.mult,
+            shift: data.shift,
+            max_cycles: data.max_cycles,
+            base_ns,
+            fraction: 0,
+        })
+    }
+
+    #[inline]
+    fn delta(&self, cycle_now: u64) -> u64 {
+        clocksource_delta(
+            cycle_now,
+            self.cycle_last,
+            self.mask.bits(),
+            self.max_cycles,
+        )
+        .expect("installed timekeeper has invalid clocksource conversion bounds")
+    }
+
+    #[inline]
+    fn read_ns(&self, cycle_now: u64) -> u64 {
+        let (elapsed, _) = scale_delta(self.delta(cycle_now), self.mult, self.shift, self.fraction)
+            .expect("validated timekeeper conversion became invalid");
+        add_elapsed(self.base_ns, elapsed).expect("timekeeper read overflow")
+    }
+
+    fn forward(&mut self, cycle_now: u64) {
+        let (elapsed, fraction) =
+            scale_delta(self.delta(cycle_now), self.mult, self.shift, self.fraction)
+                .expect("validated timekeeper conversion became invalid");
+        self.base_ns = add_elapsed(self.base_ns, elapsed).expect("timekeeper forward overflow");
+        self.fraction = fraction;
+        self.cycle_last = cycle_now;
+    }
+}
+
+#[derive(Debug)]
+pub struct TimekeeperData {
+    mono: Option<TimekeeperReadBase>,
+    raw: Option<TimekeeperReadBase>,
+    realtime_offset_ns: i128,
+    boottime_offset_ns: u64,
+    clocksource_generation: u64,
+}
+
+impl TimekeeperData {
+    const fn new() -> Self {
+        Self {
+            mono: None,
+            raw: None,
+            realtime_offset_ns: 0,
+            boottime_offset_ns: 0,
+            clocksource_generation: 0,
+        }
+    }
+
+    fn forward(&mut self) {
+        let Some(mono) = self.mono.as_mut() else {
+            return;
+        };
+        let raw = self.raw.as_mut().expect("raw timekeeper base missing");
+        debug_assert!(Arc::ptr_eq(&mono.clock, &raw.clock));
+        debug_assert_eq!(mono.cycle_last, raw.cycle_last);
+        let cycle_now = mono.clock.read().data();
+        mono.forward(cycle_now);
+        raw.forward(cycle_now);
+        debug_assert_eq!(mono.cycle_last, raw.cycle_last);
+    }
+
+    fn monotonic_ns(&self) -> u64 {
+        let mono = self.mono.as_ref().expect("timekeeper not initialized");
+        mono.read_ns(mono.clock.read().data())
+    }
+
+    fn raw_ns(&self) -> u64 {
+        let raw = self.raw.as_ref().expect("raw timekeeper not initialized");
+        raw.read_ns(raw.clock.read().data())
+    }
+
+    fn boottime_ns(&self) -> u64 {
+        self.monotonic_ns()
+            .checked_add(self.boottime_offset_ns)
+            .expect("boottime overflow")
+    }
+
+    fn realtime_ns(&self) -> i128 {
+        self.monotonic_ns() as i128 + self.realtime_offset_ns
+    }
+}
 
 #[derive(Debug)]
 pub struct Timekeeper {
     inner: RwLock<TimekeeperData>,
 }
 
-#[allow(dead_code)]
-#[derive(Debug)]
-pub struct TimekeeperData {
-    /// 用于计时的当前时钟源。
-    clock: Option<Arc<dyn Clocksource>>,
-    /// 当前时钟源的移位值。
-    shift: i32,
-    /// 一个NTP间隔中的时钟周期数。
-    cycle_interval: CycleNum,
-    /// 一个NTP间隔中时钟移位的纳秒数。
-    xtime_interval: u64,
-    xtime_remainder: i64,
-    /// 每个NTP间隔累积的原始纳米秒
-    raw_interval: i64,
-    /// 时钟移位纳米秒余数
-    xtime_nsec: u64,
-    /// 积累时间和ntp时间在ntp位移纳秒量上的差距
-    ntp_error: i64,
-    /// 用于转换时钟偏移纳秒和ntp偏移纳秒的偏移量
-    ntp_error_shift: i32,
-    /// NTP调整时钟乘法器
-    mult: u32,
-    raw_time: PosixTimeSpec,
-    wall_to_monotonic: PosixTimeSpec,
-    total_sleep_time: PosixTimeSpec,
-    xtime: PosixTimeSpec,
-    /// 单调时间和实时时间的偏移量
-    real_time_offset: ktime_t,
-}
-impl TimekeeperData {
-    pub fn new() -> Self {
-        Self {
-            clock: None,
-            shift: Default::default(),
-            cycle_interval: CycleNum::new(0),
-            xtime_interval: Default::default(),
-            xtime_remainder: Default::default(),
-            raw_interval: Default::default(),
-            xtime_nsec: Default::default(),
-            ntp_error: Default::default(),
-            ntp_error_shift: Default::default(),
-            mult: Default::default(),
-            xtime: PosixTimeSpec {
-                tv_nsec: 0,
-                tv_sec: 0,
-            },
-            wall_to_monotonic: PosixTimeSpec {
-                tv_nsec: 0,
-                tv_sec: 0,
-            },
-            total_sleep_time: PosixTimeSpec {
-                tv_nsec: 0,
-                tv_sec: 0,
-            },
-            raw_time: PosixTimeSpec {
-                tv_nsec: 0,
-                tv_sec: 0,
-            },
-            real_time_offset: 0,
-        }
-    }
-}
 impl Timekeeper {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             inner: RwLock::new(TimekeeperData::new()),
         }
     }
 
-    /// # 设置timekeeper的参数
-    ///
-    /// ## 参数
-    ///
-    /// * 'clock' - 指定的时钟实际类型。初始为ClocksourceJiffies
-    pub fn timekeeper_setup_internals(&self, clock: Arc<dyn Clocksource>) {
-        let mut timekeeper = self.inner.write_irqsave();
-        // 更新clock
-        let mut clock_data = clock.clocksource_data();
-        clock_data.cycle_last = clock.read();
-        if clock.update_clocksource_data(clock_data).is_err() {
-            debug!("timekeeper_setup_internals:update_clocksource_data run failed");
-        }
-        timekeeper.clock.replace(clock.clone());
-
-        let clock_data = clock.clocksource_data();
-        let mut temp = NTP_INTERVAL_LENGTH << clock_data.shift;
-        let ntpinterval = temp;
-        temp += (clock_data.mult / 2) as u64;
-        // do div
-
-        timekeeper.cycle_interval = CycleNum::new(temp);
-        timekeeper.xtime_interval = temp * clock_data.mult as u64;
-        // 这里可能存在下界溢出问题，debug模式下会报错panic
-        timekeeper.xtime_remainder = (ntpinterval - timekeeper.xtime_interval) as i64;
-        timekeeper.raw_interval = (timekeeper.xtime_interval >> clock_data.shift) as i64;
-        timekeeper.xtime_nsec = 0;
-        timekeeper.shift = clock_data.shift as i32;
-
-        timekeeper.ntp_error = 0;
-        timekeeper.ntp_error_shift = (NTP_SCALE_SHIFT - clock_data.shift) as i32;
-
-        timekeeper.mult = clock_data.mult;
-    }
-
-    pub fn timekeeping_get_ns(&self) -> i64 {
-        let timekeeper = self.inner.read_irqsave();
-        let clock = timekeeper.clock.clone().unwrap();
-
-        let cycle_now = clock.read();
-        let clock_data = clock.clocksource_data();
-        let cycle_delta = (cycle_now.div(clock_data.cycle_last)).data() & clock_data.mask.bits();
-
-        return clocksource_cyc2ns(
-            CycleNum::new(cycle_delta),
-            timekeeper.mult,
-            timekeeper.shift as u32,
-        ) as i64;
-    }
-
-    /// # 处理大幅度调整
-    pub fn timekeeping_bigadjust(&self, error: i64, interval: i64, offset: i64) -> (i64, i64, i32) {
-        let mut error = error;
-        let mut interval = interval;
-        let mut offset = offset;
-
-        // TODO: 计算look_head并调整ntp误差
-
-        let tmp = interval;
-        let mut mult = 1;
-        let mut adj = 0;
-        if error < 0 {
-            error = -error;
-            interval = -interval;
-            offset = -offset;
-            mult = -1;
-        }
-        while error > tmp {
-            adj += 1;
-            error >>= 1;
-        }
-
-        interval <<= adj;
-        offset <<= adj;
-        mult <<= adj;
-
-        return (interval, offset, mult);
-    }
-
-    /// # 调整时钟的mult减少ntp_error
-    pub fn timekeeping_adjust(&self, offset: i64) -> i64 {
-        let mut timekeeper = self.inner.write_irqsave();
-        let mut interval = timekeeper.cycle_interval.data() as i64;
-        let mut offset = offset;
-        let adj: i32;
-
-        // 计算误差
-        let mut error = timekeeper.ntp_error >> (timekeeper.ntp_error_shift - 1);
-
-        // 误差超过一个interval，就要进行调整
-        if error >= 0 {
-            if error > interval {
-                error >>= 2;
-                if likely(error <= interval) {
-                    adj = 1;
-                } else {
-                    (interval, offset, adj) = self.timekeeping_bigadjust(error, interval, offset);
-                }
-            } else {
-                // 不需要校准
-                return offset;
-            }
-        } else if -error > interval {
-            if likely(-error <= interval) {
-                adj = -1;
-                interval = -interval;
-                offset = -offset;
-            } else {
-                (interval, offset, adj) = self.timekeeping_bigadjust(error, interval, offset);
-            }
-        } else {
-            // 不需要校准
-            return offset;
-        }
-
-        // 检查最大调整值，确保调整值不会超过时钟源允许的最大值
-        let clock_data = timekeeper.clock.clone().unwrap().clocksource_data();
-        if unlikely(
-            clock_data.maxadj != 0
-                && (timekeeper.mult as i32 + adj
-                    > clock_data.mult as i32 + clock_data.maxadj as i32),
-        ) {
+    pub fn timekeeper_setup_internals(
+        &self,
+        clock: Arc<dyn Clocksource>,
+    ) -> Result<(), SystemError> {
+        let data = clock.clocksource_data();
+        if data.mask.bits() == 0
+            || data.mult == 0
+            || data.shift >= u64::BITS
+            || data.max_cycles == 0
+            || data.max_cycles > data.mask.bits()
+            || !mask_is_contiguous(data.mask.bits())
+        {
             warn!(
-                "Adjusting {:?} more than ({} vs {})",
-                clock_data.name,
-                timekeeper.mult as i32 + adj,
-                clock_data.mult as i32 + clock_data.maxadj as i32
+                "refusing invalid clocksource {}: mask={:#x} mult={} shift={}",
+                data.name,
+                data.mask.bits(),
+                data.mult,
+                data.shift
             );
+            return Err(SystemError::EINVAL);
         }
 
-        if error > 0 {
-            timekeeper.mult += adj as u32;
-            timekeeper.xtime_interval += interval as u64;
-            timekeeper.xtime_nsec -= offset as u64;
-        } else {
-            timekeeper.mult -= adj as u32;
-            timekeeper.xtime_interval -= interval as u64;
-            timekeeper.xtime_nsec += offset as u64;
+        let mut tk = self.inner.write_irqsave();
+        if let Some(current) = tk.mono.as_ref() {
+            if Arc::ptr_eq(&current.clock, &clock) {
+                return Ok(());
+            }
+            tk.forward();
         }
-        timekeeper.ntp_error -= (interval - offset) << timekeeper.ntp_error_shift;
 
-        return offset;
+        let mono_base_ns = tk.mono.as_ref().map_or(0, |base| base.base_ns);
+        let raw_base_ns = tk.raw.as_ref().map_or(0, |base| base.base_ns);
+        let old_mono_fraction = tk.mono.as_ref().map_or(0, |base| base.fraction);
+        let old_raw_fraction = tk.raw.as_ref().map_or(0, |base| base.fraction);
+        let old_shift = tk.mono.as_ref().map(|base| base.shift);
+
+        let cycle_last = clock.read().data();
+        let mut mono = TimekeeperReadBase::new(clock.clone(), &data, cycle_last, mono_base_ns)
+            .expect("validated clocksource became invalid");
+        let mut raw = TimekeeperReadBase::new(clock, &data, cycle_last, raw_base_ns)
+            .expect("validated clocksource became invalid");
+        if let Some(old_shift) = old_shift {
+            mono.fraction = rescale_fraction(old_mono_fraction, old_shift, mono.shift);
+            raw.fraction = rescale_fraction(old_raw_fraction, old_shift, raw.shift);
+        }
+        tk.mono = Some(mono);
+        tk.raw = Some(raw);
+        tk.clocksource_generation = tk.clocksource_generation.wrapping_add(1);
+        Ok(())
     }
-    /// # 用于累积时间间隔，并将其转换为纳秒时间
-    pub fn logarithmic_accumulation(&self, offset: u64, shift: i32) -> u64 {
-        let mut timekeeper = self.inner.write_irqsave();
-        let clock = timekeeper.clock.clone().unwrap();
-        let clock_data = clock.clocksource_data();
-        let nsecps = (NSEC_PER_SEC as u64) << timekeeper.shift;
-        let mut offset = offset;
 
-        // 检查offset是否小于一个NTP周期间隔
-        if offset < timekeeper.cycle_interval.data() << shift {
-            return offset;
-        }
+    pub fn current_clocksource(&self) -> Option<Arc<dyn Clocksource>> {
+        self.inner
+            .read_irqsave()
+            .mono
+            .as_ref()
+            .map(|base| base.clock.clone())
+    }
+}
 
-        // 累积一个移位的interval
-        offset -= timekeeper.cycle_interval.data() << shift;
-        clock_data
-            .cycle_last
-            .add(CycleNum::new(timekeeper.cycle_interval.data() << shift));
-        if clock.update_clocksource_data(clock_data).is_err() {
-            debug!("logarithmic_accumulation:update_clocksource_data run failed");
-        }
-        timekeeper.clock.replace(clock.clone());
+#[inline]
+const fn mask_is_contiguous(mask: u64) -> bool {
+    mask != 0 && (mask & mask.wrapping_add(1)) == 0
+}
 
-        // 更新xime_nsec
-        timekeeper.xtime_nsec += timekeeper.xtime_interval << shift;
-        while timekeeper.xtime_nsec >= nsecps {
-            timekeeper.xtime_nsec -= nsecps;
-            timekeeper.xtime.tv_sec += 1;
-            // TODO: 处理闰秒
-        }
+#[inline]
+fn clocksource_delta(
+    cycle_now: u64,
+    cycle_last: u64,
+    mask: u64,
+    max_cycles: u64,
+) -> Result<u64, SystemError> {
+    if !mask_is_contiguous(mask) || max_cycles == 0 || max_cycles > mask {
+        return Err(SystemError::EINVAL);
+    }
+    let delta = cycle_now.wrapping_sub(cycle_last) & mask;
+    // Match Linux timekeeping_get_delta(): a delayed update beyond the
+    // conversion-safe window is capped, not allowed to overflow and not
+    // promoted into a kernel panic. The next writer advances cycle_last to
+    // the current sample, so the exceptional interval cannot repeat.
+    Ok(delta.min(max_cycles))
+}
 
-        // TODO：更新raw_time
+#[inline]
+const fn fraction_mask(shift: u32) -> u128 {
+    if shift == 0 {
+        0
+    } else {
+        (1u128 << shift) - 1
+    }
+}
 
-        // TODO：计算ntp_error
+#[inline]
+fn scale_delta(
+    delta: u64,
+    mult: u32,
+    shift: u32,
+    fraction: u64,
+) -> Result<(u64, u64), SystemError> {
+    if mult == 0 || shift >= u64::BITS || fraction as u128 > fraction_mask(shift) {
+        return Err(SystemError::EINVAL);
+    }
+    let scaled = delta as u128 * mult as u128 + fraction as u128;
+    let elapsed = (scaled >> shift)
+        .try_into()
+        .map_err(|_| SystemError::EOVERFLOW)?;
+    Ok((elapsed, (scaled & fraction_mask(shift)) as u64))
+}
 
-        return offset;
+#[inline]
+fn add_elapsed(base_ns: u64, elapsed_ns: u64) -> Result<u64, SystemError> {
+    base_ns
+        .checked_add(elapsed_ns)
+        .ok_or(SystemError::EOVERFLOW)
+}
+
+#[inline]
+fn rescale_fraction(fraction: u64, old_shift: u32, new_shift: u32) -> u64 {
+    if new_shift >= old_shift {
+        fraction
+            .checked_shl(new_shift - old_shift)
+            .expect("timekeeper fraction shift overflow")
+    } else {
+        fraction >> (old_shift - new_shift)
+    }
+}
+
+#[inline]
+fn ns_to_timespec(ns: i128) -> PosixTimeSpec {
+    let sec = ns.div_euclid(NSEC_PER_SEC as i128);
+    let nsec = ns.rem_euclid(NSEC_PER_SEC as i128);
+    PosixTimeSpec {
+        tv_sec: sec.try_into().expect("timekeeper seconds overflow"),
+        tv_nsec: nsec as i64,
     }
 }
 
 #[inline(always)]
 pub fn timekeeper() -> &'static Timekeeper {
-    let r = unsafe { __TIMEKEEPER.as_ref().unwrap() };
-
-    return r;
+    unsafe { __TIMEKEEPER.as_ref().unwrap() }
 }
 
 pub fn boottime_seconds() -> i64 {
     let tk = timekeeper().inner.read_irqsave();
-    let nsec_per_sec = NSEC_PER_SEC as i128;
-    let boottime_ns = (tk.xtime.tv_sec as i128) * nsec_per_sec
-        + (tk.xtime.tv_nsec as i128)
-        + (tk.wall_to_monotonic.tv_sec as i128) * nsec_per_sec
-        + (tk.wall_to_monotonic.tv_nsec as i128)
-        + (tk.total_sleep_time.tv_sec as i128) * nsec_per_sec
-        + (tk.total_sleep_time.tv_nsec as i128);
-
-    boottime_ns.div_euclid(nsec_per_sec) as i64
+    tk.realtime_offset_ns
+        .checked_sub(tk.boottime_offset_ns as i128)
+        .expect("boot epoch overflow")
+        .div_euclid(NSEC_PER_SEC as i128)
+        .try_into()
+        .expect("boot epoch seconds overflow")
 }
 
 pub fn timekeeping_is_initialized() -> bool {
@@ -317,165 +322,131 @@ pub fn timekeeper_init() {
     unsafe { __TIMEKEEPER = Some(Timekeeper::new()) };
 }
 
-/// # 获取1970.1.1至今的UTC时间戳(最小单位:nsec)
-///
-/// ## 返回值
-///
-/// * 'TimeSpec' - 时间戳
-pub fn getnstimeofday() -> PosixTimeSpec {
-    // debug!("enter getnstimeofday");
-
-    let nsecs;
-    let mut xtime: PosixTimeSpec;
-    loop {
-        match timekeeper().inner.try_read_irqsave() {
-            None => continue,
-            Some(tk) => {
-                xtime = tk.xtime;
-                drop(tk);
-
-                nsecs = timekeeper().timekeeping_get_ns();
-
-                // TODO 不同架构可能需要加上不同的偏移量
-                break;
-            }
-        }
-    }
-    xtime.tv_nsec += nsecs;
-    xtime.tv_sec += xtime.tv_nsec / NSEC_PER_SEC as i64;
-    xtime.tv_nsec %= NSEC_PER_SEC as i64;
-    // debug!("getnstimeofday: xtime = {:?}, nsecs = {:}", xtime, nsecs);
-
-    // TODO 将xtime和当前时间源的时间相加
-
-    return xtime;
+pub fn realtime_now() -> PosixTimeSpec {
+    let tk = timekeeper().inner.read_irqsave();
+    ns_to_timespec(tk.realtime_ns())
 }
 
-/// # 获取1970.1.1至今的UTC时间戳(最小单位:usec)
-///
-/// ## 返回值
-///
-/// * 'PosixTimeval' - 时间戳
+pub fn monotonic_now() -> PosixTimeSpec {
+    let tk = timekeeper().inner.read_irqsave();
+    ns_to_timespec(tk.monotonic_ns() as i128)
+}
+
+pub fn monotonic_raw_now() -> PosixTimeSpec {
+    let tk = timekeeper().inner.read_irqsave();
+    ns_to_timespec(tk.raw_ns() as i128)
+}
+
+pub fn boottime_now() -> PosixTimeSpec {
+    let tk = timekeeper().inner.read_irqsave();
+    ns_to_timespec(tk.boottime_ns() as i128)
+}
+
+pub fn realtime_coarse() -> PosixTimeSpec {
+    let tk = timekeeper().inner.read_irqsave();
+    let mono = tk.mono.as_ref().expect("timekeeper not initialized");
+    ns_to_timespec(mono.base_ns as i128 + tk.realtime_offset_ns)
+}
+
+pub fn monotonic_coarse() -> PosixTimeSpec {
+    let tk = timekeeper().inner.read_irqsave();
+    let mono = tk.mono.as_ref().expect("timekeeper not initialized");
+    ns_to_timespec(mono.base_ns as i128)
+}
+
+pub fn getnstimeofday() -> PosixTimeSpec {
+    realtime_now()
+}
+
 pub fn do_gettimeofday() -> PosixTimeval {
-    let tp = getnstimeofday();
-    return PosixTimeval {
+    let tp = realtime_now();
+    PosixTimeval {
         tv_sec: tp.tv_sec,
         tv_usec: (tp.tv_nsec / 1000) as i32,
-    };
+    }
 }
 
 pub fn do_settimeofday64(time: PosixTimeSpec) -> Result<(), SystemError> {
-    timekeeper().inner.write_irqsave().xtime = time;
-    // todo: 模仿linux，实现时间误差校准。
-    // https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/time/timekeeping.c?fi=do_settimeofday64#1312
-    return Ok(());
+    let requested = validate_settimeofday(time)?;
+    let mut tk = timekeeper().inner.write_irqsave();
+    settimeofday_locked(&mut tk, requested)
 }
 
-/// # 初始化timekeeping模块
+fn validate_settimeofday(time: PosixTimeSpec) -> Result<i128, SystemError> {
+    if time.tv_sec < 0
+        || time.tv_sec >= TIME_SETTOD_SEC_MAX
+        || time.tv_nsec < 0
+        || time.tv_nsec >= NSEC_PER_SEC as i64
+    {
+        return Err(SystemError::EINVAL);
+    }
+
+    Ok(time.tv_sec as i128 * NSEC_PER_SEC as i128 + time.tv_nsec as i128)
+}
+
+/// Apply a validated wall-clock value while the caller owns the timekeeper
+/// write side.  As in Linux, forwarding happens before rejecting a formatted
+/// value that would place realtime before monotonic; only the wall offset is
+/// transactional on that error path.
+fn settimeofday_locked(tk: &mut TimekeeperData, requested: i128) -> Result<(), SystemError> {
+    tk.forward();
+    let monotonic = tk
+        .mono
+        .as_ref()
+        .expect("timekeeper not initialized")
+        .base_ns as i128;
+    let realtime_offset = requested
+        .checked_sub(monotonic)
+        .ok_or(SystemError::EOVERFLOW)?;
+    if realtime_offset < tk.boottime_offset_ns as i128 {
+        return Err(SystemError::EINVAL);
+    }
+    // Prove all derived public values are representable before publishing the
+    // offset.  `requested` was already bounded by validate_settimeofday().
+    let _boot_epoch = realtime_offset
+        .checked_sub(tk.boottime_offset_ns as i128)
+        .ok_or(SystemError::EOVERFLOW)?;
+    tk.realtime_offset_ns = realtime_offset;
+    Ok(())
+}
+
 #[inline(never)]
 pub fn timekeeping_init() {
     info!("Initializing timekeeping module...");
     let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
     timekeeper_init();
 
-    // TODO 有ntp模块后 在此初始化ntp模块
+    // Registration computes max_cycles/max_idle_ns.  The default source must
+    // be fully registered before its conversion snapshot is installed, so
+    // non-KVM/TCG boots never depend on a later source replacing it.
+    jiffies_init();
 
     let clock = clocksource_default_clock();
     clock
         .enable()
         .expect("clocksource_default_clock enable failed");
-    timekeeper().timekeeper_setup_internals(clock);
-    // 暂时不支持其他架构平台对时间的设置 所以使用x86平台对应值初始化
-    let mut timekeeper = timekeeper().inner.write_irqsave();
-    timekeeper.xtime.tv_nsec = ktime_get_real_ns();
+    timekeeper()
+        .timekeeper_setup_internals(clock)
+        .expect("default clocksource has invalid conversion data");
 
-    //参考https://elixir.bootlin.com/linux/v4.4/source/kernel/time/timekeeping.c#L1251 对wtm进行初始化
-    (
-        timekeeper.wall_to_monotonic.tv_nsec,
-        timekeeper.wall_to_monotonic.tv_sec,
-    ) = (-timekeeper.xtime.tv_nsec, -timekeeper.xtime.tv_sec);
+    let initial_realtime = ktime_get_real_ns();
+    if initial_realtime > 0 {
+        do_settimeofday64(ns_to_timespec(initial_realtime as i128))
+            .expect("initial realtime is invalid");
+    }
 
     drop(irq_guard);
-    drop(timekeeper);
-    jiffies_init();
     info!("timekeeping_init successfully");
 }
 
-/// # 使用当前时钟源增加wall time
-/// 参考：https://code.dragonos.org.cn/xref/linux-3.4.99/kernel/time/timekeeping.c#1041
 pub fn update_wall_time() {
-    // debug!("enter update_wall_time, stack_use = {:}",stack_use);
-    let irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
-    // 如果在休眠那就不更新
-    if TIMEKEEPING_SUSPENDED.load(Ordering::SeqCst) {
+    if TIMEKEEPING_SUSPENDED.load(Ordering::Acquire) {
         return;
     }
-
-    let mut tk = timekeeper().inner.write_irqsave();
-    // 获取当前时钟源
-    let clock = tk.clock.clone().unwrap();
-    let clock_data = clock.clocksource_data();
-    // 计算从上一次更新周期以来经过的时钟周期数
-    let mut offset = (clock.read().div(clock_data.cycle_last).data()) & clock_data.mask.bits();
-    // 检查offset是否达到了一个NTP周期间隔
-    if offset < tk.cycle_interval.data() {
-        return;
-    }
-
-    // 将纳秒部分转换为更高精度的格式
-    tk.xtime_nsec = (tk.xtime.tv_nsec as u64) << tk.shift;
-
-    let mut shift = (offset.ilog2() - tk.cycle_interval.data().ilog2()) as i32;
-    shift = shift.max(0);
-    // let max_shift = (64 - (ntp_tick_length().ilog2()+1)) - 1;
-    // shift = min(shift, max_shift)
-    while offset >= tk.cycle_interval.data() {
-        offset = timekeeper().logarithmic_accumulation(offset, shift);
-        if offset < tk.cycle_interval.data() << shift {
-            shift -= 1;
-        }
-    }
-
-    timekeeper().timekeeping_adjust(offset as i64);
-
-    // 处理xtime_nsec下溢问题，并对NTP误差进行调整
-    if unlikely((tk.xtime_nsec as i64) < 0) {
-        let neg = -(tk.xtime_nsec as i64);
-        tk.xtime_nsec = 0;
-        tk.ntp_error += neg << tk.ntp_error_shift;
-    }
-
-    // 将纳秒部分舍入后存储在xtime.tv_nsec中
-    tk.xtime.tv_nsec = ((tk.xtime_nsec as i64) >> tk.shift) + 1;
-    tk.xtime_nsec -= (tk.xtime.tv_nsec as u64) << tk.shift;
-
-    // 确保经过舍入后的xtime.tv_nsec不会大于NSEC_PER_SEC，并在超过1秒的情况下进行适当的调整
-    if unlikely(tk.xtime.tv_nsec >= NSEC_PER_SEC.into()) {
-        tk.xtime.tv_nsec -= NSEC_PER_SEC as i64;
-        tk.xtime.tv_sec += 1;
-        // TODO: 处理闰秒
-    }
-
-    // 更新时间的相关信息
-    timekeeping_update(&mut tk);
-
-    drop(irq_guard);
-}
-// TODO wall_to_monotic
-
-/// 参考：https://code.dragonos.org.cn/xref/linux-3.4.99/kernel/time/timekeeping.c#190
-pub fn timekeeping_update(timekeeper: &mut TimekeeperData) {
-    // TODO：如果clearntp为true，则会清除NTP错误并调用ntp_clear()
-
-    // 更新实时时钟偏移量，用于跟踪硬件时钟与系统时间的差异，以便进行时间校正
-    update_rt_offset(timekeeper);
+    timekeeper().inner.write_irqsave().forward();
 }
 
-/// # 更新实时偏移量(墙上之间与单调时间的差值)
-pub fn update_rt_offset(timekeeper: &mut TimekeeperData) {
-    let ts = PosixTimeSpec::new(
-        -timekeeper.wall_to_monotonic.tv_sec,
-        -timekeeper.wall_to_monotonic.tv_nsec,
-    );
-    timekeeper.real_time_offset = timespec_to_ktime(ts);
-}
+#[path = "timekeeping_selftest.rs"]
+mod selftest;
+
+pub(crate) use selftest::run_timekeeping_selftests;

--- a/kernel/src/time/timekeeping.rs
+++ b/kernel/src/time/timekeeping.rs
@@ -398,7 +398,9 @@ fn settimeofday_locked(tk: &mut TimekeeperData, requested: i128) -> Result<(), S
     let realtime_offset = requested
         .checked_sub(monotonic)
         .ok_or(SystemError::EOVERFLOW)?;
-    if realtime_offset < tk.boottime_offset_ns as i128 {
+    // Linux rejects only wall-clock values earlier than CLOCK_MONOTONIC.
+    // CLOCK_BOOTTIME may legitimately be ahead after suspend.
+    if realtime_offset < 0 {
         return Err(SystemError::EINVAL);
     }
     // Prove all derived public values are representable before publishing the

--- a/kernel/src/time/timekeeping_selftest.rs
+++ b/kernel/src/time/timekeeping_selftest.rs
@@ -1,0 +1,407 @@
+use alloc::{
+    format,
+    string::{String, ToString},
+    sync::{Arc, Weak},
+};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use crate::{
+    libs::spinlock::SpinLock,
+    time::clocksource::{ClocksourceData, ClocksourceFlags, ClocksourceUpdate, CycleNum},
+};
+
+use super::*;
+
+#[derive(Debug)]
+struct FakeClock {
+    inner: SpinLock<FakeClockInner>,
+    cycle: AtomicU64,
+    reads: AtomicU64,
+}
+
+#[derive(Debug)]
+struct FakeClockInner {
+    data: ClocksourceData,
+    self_ref: Weak<FakeClock>,
+}
+
+impl FakeClock {
+    fn new(name: &str, mask: u64, mult: u32, shift: u32, max_cycles: u64) -> Arc<Self> {
+        let clock = Arc::new(Self {
+            inner: SpinLock::new(FakeClockInner {
+                data: ClocksourceData {
+                    name: name.to_string(),
+                    rating: 100,
+                    mask: ClocksourceMask::new(mask),
+                    mult,
+                    shift,
+                    max_cycles,
+                    max_idle_ns: 0,
+                    flags: ClocksourceFlags::CLOCK_SOURCE_IS_CONTINUOUS,
+                    watchdog_last: CycleNum::new(0),
+                    cs_last: CycleNum::new(0),
+                    uncertainty_margin: 0,
+                    maxadj: 0,
+                },
+                self_ref: Weak::new(),
+            }),
+            cycle: AtomicU64::new(0),
+            reads: AtomicU64::new(0),
+        });
+        clock.inner.lock().self_ref = Arc::downgrade(&clock);
+        clock
+    }
+
+    fn set_cycle(&self, cycle: u64) {
+        self.cycle.store(cycle, Ordering::SeqCst);
+    }
+
+    fn reads(&self) -> u64 {
+        self.reads.load(Ordering::SeqCst)
+    }
+}
+
+impl Clocksource for FakeClock {
+    fn read(&self) -> CycleNum {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        CycleNum::new(self.cycle.load(Ordering::SeqCst))
+    }
+
+    fn enable(&self) -> Result<i32, SystemError> {
+        Ok(0)
+    }
+
+    fn clocksource_data(&self) -> ClocksourceData {
+        self.inner.lock_irqsave().data.clone()
+    }
+
+    fn update_clocksource_data(&self, update: ClocksourceUpdate) -> Result<(), SystemError> {
+        update.apply(&mut self.inner.lock_irqsave().data);
+        Ok(())
+    }
+
+    fn clocksource(&self) -> Arc<dyn Clocksource> {
+        match self.inner.lock_irqsave().self_ref.upgrade() {
+            Some(clock) => clock,
+            None => FakeClock::new("detached", u64::MAX, 1, 0, u64::MAX),
+        }
+    }
+}
+
+struct Report {
+    text: String,
+    passed: usize,
+    failed: usize,
+}
+
+impl Report {
+    fn new() -> Self {
+        Self {
+            text: String::new(),
+            passed: 0,
+            failed: 0,
+        }
+    }
+
+    fn case(&mut self, name: &str, ok: bool) {
+        if ok {
+            self.passed += 1;
+            self.text.push_str(&format!("timekeeping.{name}=ok\n"));
+        } else {
+            self.failed += 1;
+            self.text.push_str(&format!("timekeeping.{name}=fail\n"));
+        }
+    }
+}
+
+pub(crate) fn run_timekeeping_selftests() -> (usize, usize, String) {
+    let mut report = Report::new();
+
+    report.case(
+        "contiguous_masks",
+        mask_is_contiguous(0x00ff_ffff)
+            && mask_is_contiguous(u32::MAX as u64)
+            && mask_is_contiguous(u64::MAX)
+            && !mask_is_contiguous(0)
+            && !mask_is_contiguous(0x00ff_fffe),
+    );
+
+    report.case(
+        "wrap_24",
+        clocksource_delta(0x5, 0x00ff_fff0, 0x00ff_ffff, 0x00ff_ffff) == Ok(0x15),
+    );
+    report.case(
+        "defer_boundary",
+        clocksource_delta(8, 0, 0xff, 8) == Ok(8)
+            && clocksource_delta(9, 0, 0xff, 8) == Ok(8)
+            && clocksource_delta(1, 0, 0xfe, 8) == Err(SystemError::EINVAL),
+    );
+
+    report.case(
+        "fraction_carry",
+        scale_delta(1, 3, 1, 1) == Ok((2, 0)) && scale_delta(7, 1, 3, 7) == Ok((1, 6)),
+    );
+    report.case(
+        "shift_boundaries",
+        scale_delta(3, 2, 0, 0) == Ok((6, 0))
+            && scale_delta(0, 1, 63, u64::MAX >> 1) == Ok((0, u64::MAX >> 1))
+            && scale_delta(1, 1, 63, u64::MAX >> 1) == Ok((1, 0))
+            && scale_delta(1, 1, 64, 0) == Err(SystemError::EINVAL)
+            && scale_delta(1, 1, 0, 1) == Err(SystemError::EINVAL),
+    );
+    report.case(
+        "fraction_rescale",
+        rescale_fraction(3, 2, 4) == 12 && rescale_fraction(12, 4, 2) == 3,
+    );
+    report.case(
+        "base_overflow",
+        add_elapsed(u64::MAX - 1, 1) == Ok(u64::MAX)
+            && add_elapsed(u64::MAX, 1) == Err(SystemError::EOVERFLOW),
+    );
+    report.case(
+        "timespec_normalization",
+        ns_to_timespec(-1)
+            == (PosixTimeSpec {
+                tv_sec: -1,
+                tv_nsec: 999_999_999,
+            })
+            && ns_to_timespec(1_000_000_001)
+                == (PosixTimeSpec {
+                    tv_sec: 1,
+                    tv_nsec: 1,
+                }),
+    );
+    report.case(
+        "timeout_extreme_saturation",
+        PosixTimeSpec {
+            tv_sec: i64::MAX,
+            tv_nsec: 0,
+        }
+        .to_ktime_ns()
+            == i64::MAX as u64
+            && PosixTimeSpec {
+                tv_sec: i64::MAX,
+                tv_nsec: 0,
+            }
+            .saturating_add_ktime(&PosixTimeSpec {
+                tv_sec: 1,
+                tv_nsec: 0,
+            }) == PosixTimeSpec::KTIME_MAX,
+    );
+    report.case(
+        "timeout_add_carry",
+        PosixTimeSpec {
+            tv_sec: 1,
+            tv_nsec: 900_000_000,
+        }
+        .saturating_add_ktime(&PosixTimeSpec {
+            tv_sec: 0,
+            tv_nsec: 200_000_000,
+        }) == (PosixTimeSpec {
+            tv_sec: 2,
+            tv_nsec: 100_000_000,
+        }),
+    );
+    report.case(
+        "timeout_reverse_sub_zero",
+        PosixTimeSpec {
+            tv_sec: 1,
+            tv_nsec: 0,
+        }
+        .saturating_sub_timespec(&PosixTimeSpec {
+            tv_sec: 2,
+            tv_nsec: 0,
+        }) == PosixTimeSpec::default(),
+    );
+    report.case(
+        "timeout_validation",
+        PosixTimeSpec {
+            tv_sec: 0,
+            tv_nsec: 999_999_999,
+        }
+        .is_valid_timeout()
+            && !PosixTimeSpec {
+                tv_sec: -1,
+                tv_nsec: 0,
+            }
+            .is_valid_timeout()
+            && !PosixTimeSpec {
+                tv_sec: 0,
+                tv_nsec: -1,
+            }
+            .is_valid_timeout()
+            && !PosixTimeSpec {
+                tv_sec: 0,
+                tv_nsec: NSEC_PER_SEC as i64,
+            }
+            .is_valid_timeout(),
+    );
+
+    let source_a = FakeClock::new("fake-a", u64::MAX, 2, 1, u64::MAX / 2);
+    source_a.set_cycle(100);
+    let source_a_dyn = source_a.clone() as Arc<dyn Clocksource>;
+    let local = Timekeeper::new();
+    let setup_a_ok = local
+        .timekeeper_setup_internals(source_a_dyn.clone())
+        .is_ok();
+    source_a.set_cycle(150);
+
+    let source_b = FakeClock::new("fake-b", u64::MAX, 1, 0, u64::MAX);
+    source_b.set_cycle(900);
+    let source_b_dyn = source_b.clone() as Arc<dyn Clocksource>;
+    let old_reads_before = source_a.reads();
+    let new_reads_before = source_b.reads();
+    let switch_ok = local
+        .timekeeper_setup_internals(source_b_dyn.clone())
+        .is_ok();
+    let switched = local.inner.read_irqsave();
+    let continuity_ok = switched.mono.as_ref().is_some_and(|base| {
+        Arc::ptr_eq(&base.clock, &source_b_dyn) && base.base_ns == 50 && base.cycle_last == 900
+    }) && switched.raw.as_ref().is_some_and(|base| {
+        Arc::ptr_eq(&base.clock, &source_b_dyn) && base.base_ns == 50 && base.cycle_last == 900
+    }) && switched.clocksource_generation == 2;
+    drop(switched);
+    report.case(
+        "switch_continuity",
+        setup_a_ok
+            && switch_ok
+            && continuity_ok
+            && source_a.reads() == old_reads_before + 1
+            && source_b.reads() == new_reads_before + 1,
+    );
+
+    let generation_before_noop = local.inner.read_irqsave().clocksource_generation;
+    let reads_before_noop = source_b.reads();
+    let noop_ok = local
+        .timekeeper_setup_internals(source_b_dyn.clone())
+        .is_ok();
+    report.case(
+        "same_source_noop",
+        noop_ok
+            && local.inner.read_irqsave().clocksource_generation == generation_before_noop
+            && source_b.reads() == reads_before_noop,
+    );
+
+    let invalid = FakeClock::new("invalid", u64::MAX, 0, 0, u64::MAX);
+    let generation_before_invalid = local.inner.read_irqsave().clocksource_generation;
+    let invalid_ok = local
+        .timekeeper_setup_internals(invalid.clone() as Arc<dyn Clocksource>)
+        .is_err();
+    report.case(
+        "switch_rollback_invalid_target",
+        invalid_ok
+            && invalid.reads() == 0
+            && local.inner.read_irqsave().clocksource_generation == generation_before_invalid
+            && local
+                .current_clocksource()
+                .is_some_and(|clock| Arc::ptr_eq(&clock, &source_b_dyn)),
+    );
+
+    let invalid_configs = [
+        FakeClock::new("mask-zero", 0, 1, 0, 1),
+        FakeClock::new("mask-gap", 0xfe, 1, 0, 1),
+        FakeClock::new("shift-64", u64::MAX, 1, 64, 1),
+        FakeClock::new("max-zero", u64::MAX, 1, 0, 0),
+        FakeClock::new("max-over-mask", 0xff, 1, 0, 0x100),
+    ];
+    report.case(
+        "source_validation",
+        invalid_configs.into_iter().all(|clock| {
+            local
+                .timekeeper_setup_internals(clock.clone() as Arc<dyn Clocksource>)
+                .is_err()
+                && clock.reads() == 0
+        }),
+    );
+
+    let wall_clock = FakeClock::new("wall", u64::MAX, 1, 0, u64::MAX);
+    wall_clock.set_cycle(100);
+    let wall_keeper = Timekeeper::new();
+    let wall_setup_ok = wall_keeper
+        .timekeeper_setup_internals(wall_clock.clone() as Arc<dyn Clocksource>)
+        .is_ok();
+    wall_clock.set_cycle(150);
+    let requested = validate_settimeofday(PosixTimeSpec {
+        tv_sec: 1,
+        tv_nsec: 0,
+    });
+    let wall_set_ok = requested
+        .and_then(|requested| {
+            settimeofday_locked(&mut wall_keeper.inner.write_irqsave(), requested)
+        })
+        .is_ok();
+    let wall_state = wall_keeper.inner.read_irqsave();
+    let offset_after_success = wall_state.realtime_offset_ns;
+    let wall_domains_ok = wall_state
+        .mono
+        .as_ref()
+        .is_some_and(|base| base.base_ns == 50)
+        && wall_state
+            .raw
+            .as_ref()
+            .is_some_and(|base| base.base_ns == 50)
+        && wall_state.boottime_offset_ns == 0
+        && wall_state.realtime_ns() == NSEC_PER_SEC as i128;
+    drop(wall_state);
+    report.case(
+        "settimeofday_domains",
+        wall_setup_ok && wall_set_ok && wall_domains_ok,
+    );
+
+    wall_clock.set_cycle(160);
+    let generation_before_early = wall_keeper.inner.read_irqsave().clocksource_generation;
+    let early_result = settimeofday_locked(&mut wall_keeper.inner.write_irqsave(), 0);
+    let early_state = wall_keeper.inner.read_irqsave();
+    let early_ok = early_result == Err(SystemError::EINVAL)
+        && early_state
+            .mono
+            .as_ref()
+            .is_some_and(|base| base.base_ns == 60)
+        && early_state
+            .raw
+            .as_ref()
+            .is_some_and(|base| base.base_ns == 60)
+        && early_state.realtime_offset_ns == offset_after_success
+        && early_state.clocksource_generation == generation_before_early;
+    drop(early_state);
+    report.case("settimeofday_early_forward_only", early_ok);
+
+    let reads_before_bad_format = wall_clock.reads();
+    let bad_format_ok = validate_settimeofday(PosixTimeSpec {
+        tv_sec: -1,
+        tv_nsec: 0,
+    }) == Err(SystemError::EINVAL)
+        && validate_settimeofday(PosixTimeSpec {
+            tv_sec: 0,
+            tv_nsec: -1,
+        }) == Err(SystemError::EINVAL)
+        && validate_settimeofday(PosixTimeSpec {
+            tv_sec: 0,
+            tv_nsec: NSEC_PER_SEC as i64,
+        }) == Err(SystemError::EINVAL)
+        && validate_settimeofday(PosixTimeSpec {
+            tv_sec: TIME_SETTOD_SEC_MAX - 1,
+            tv_nsec: NSEC_PER_SEC as i64 - 1,
+        })
+        .is_ok()
+        && validate_settimeofday(PosixTimeSpec {
+            tv_sec: TIME_SETTOD_SEC_MAX,
+            tv_nsec: 0,
+        }) == Err(SystemError::EINVAL)
+        && wall_clock.reads() == reads_before_bad_format;
+    report.case("settimeofday_format_boundaries", bad_format_ok);
+
+    let defer_source = FakeClock::new("defer", 0x00ff_ffff, 10, 2, 1);
+    let defer_update_ok = defer_source
+        .update_clocksource_data(ClocksourceUpdate::SetMaxAdjustment(1))
+        .is_ok();
+    let defer_dyn = defer_source as Arc<dyn Clocksource>;
+    let (max_cycles, max_idle_ns) = defer_dyn.clocksource_max_deferment();
+    let expected_idle = (((0x00ff_ffffu128 * 9) >> 2) >> 1) as u64;
+    report.case(
+        "max_deferment",
+        defer_update_ok && max_cycles == 0x00ff_ffff && max_idle_ns == expected_idle,
+    );
+
+    (report.passed, report.failed, report.text)
+}

--- a/kernel/src/time/timekeeping_selftest.rs
+++ b/kernel/src/time/timekeeping_selftest.rs
@@ -366,6 +366,33 @@ pub(crate) fn run_timekeeping_selftests() -> (usize, usize, String) {
     drop(early_state);
     report.case("settimeofday_early_forward_only", early_ok);
 
+    let suspended_clock = FakeClock::new("suspended-wall", u64::MAX, 1, 0, u64::MAX);
+    suspended_clock.set_cycle(100);
+    let suspended_keeper = Timekeeper::new();
+    let suspended_setup_ok = suspended_keeper
+        .timekeeper_setup_internals(suspended_clock.clone() as Arc<dyn Clocksource>)
+        .is_ok();
+    suspended_clock.set_cycle(150);
+    suspended_keeper.inner.write_irqsave().boottime_offset_ns = 100;
+    let realtime_before_boottime_ok = validate_settimeofday(PosixTimeSpec {
+        tv_sec: 0,
+        tv_nsec: 120,
+    })
+    .and_then(|requested| {
+        settimeofday_locked(&mut suspended_keeper.inner.write_irqsave(), requested)
+    })
+    .is_ok();
+    let suspended_state = suspended_keeper.inner.read_irqsave();
+    report.case(
+        "settimeofday_allows_realtime_before_boottime",
+        suspended_setup_ok
+            && realtime_before_boottime_ok
+            && suspended_state.realtime_ns() == 120
+            && suspended_state.monotonic_ns() == 50
+            && suspended_state.boottime_ns() == 150,
+    );
+    drop(suspended_state);
+
     let reads_before_bad_format = wall_clock.reads();
     let bad_format_ok = validate_settimeofday(PosixTimeSpec {
         tv_sec: -1,

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -908,7 +908,7 @@ if [ $flag_can_run -eq 1 ]; then
         echo "[错误] DRAGONOS_QEMU_ARGV_FILE 必须是父目录已存在且目标不存在的绝对路径"
         return 1
       fi
-      python3 - "${DRAGONOS_QEMU_ARGV_FILE}" "${cmd[@]}" <<'PY'
+      if ! python3 - "${DRAGONOS_QEMU_ARGV_FILE}" "${cmd[@]}" <<'PY'
 import json
 import pathlib
 import sys
@@ -918,6 +918,10 @@ with path.open("x", encoding="utf-8") as output:
     json.dump(sys.argv[2:], output, ensure_ascii=True, indent=2)
     output.write("\n")
 PY
+      then
+        echo "[错误] 无法可靠记录 QEMU argv，终止启动"
+        return 1
+      fi
     fi
     printf '[QEMU] 执行: sudo ' >&2
     printf '%q ' "${cmd[@]}" >&2

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -12,6 +12,13 @@
 #
 # - AUTO_TEST: 自动测试选项
 # - SYSCALL_TEST_DIR: 系统调用测试目录
+# - DUNITEST_PATTERN: dunitest runner pattern filter
+# - DRAGONOS_QEMU_SMP: 覆盖 vCPU 拓扑，例如 1,cores=1,threads=1,sockets=1
+# - DRAGONOS_QEMU_SERIAL_SOCKET: nographic 模式下使用独立 Unix socket 承载 guest virtconsole
+# - DRAGONOS_QEMU_ARGV_FILE: 以 JSON 数组记录实际执行的 QEMU argv（目标必须不存在）
+# - DRAGONOS_QEMU_DISK_IMAGE: 覆盖主磁盘镜像路径
+# - DRAGONOS_QEMU_SNAPSHOT: 设为1时以 QEMU snapshot 模式运行，避免修改基线镜像
+# - DRAGONOS_QEMU_TRACE: 覆盖传给 QEMU -d 的日志项；性能测试应设为 none
 # - DRAGONOS_VIRTIOFS_ENABLE: 是否启用 virtiofs（1启用，默认0）
 # - DRAGONOS_VIRTIOFS_SOCKET: virtiofsd socket路径
 # - DRAGONOS_VIRTIOFS_TAG: virtiofs 挂载tag
@@ -116,7 +123,7 @@ EXT4_DISK_NAME="ext4.img"
 FAT_DISK_NAME="fat.img"
 
 QEMU=$(which qemu-system-${ARCH})
-QEMU_DISK_IMAGE="../bin/${DISK_NAME}"
+QEMU_DISK_IMAGE="${DRAGONOS_QEMU_DISK_IMAGE:-../bin/${DISK_NAME}}"
 QEMU_EXT4_DISK_IMAGE="../bin/${EXT4_DISK_NAME}"
 QEMU_FAT_DISK_IMAGE="../bin/${FAT_DISK_NAME}"
 QEMU_MEMORY="2G"
@@ -379,14 +386,60 @@ GDB_PORT=$(find_free_port $((HOST_PORT + 1)))
 echo "${HOST_PORT}" > "${VMSTATE_DIR}/port"
 echo "${GDB_PORT}" > "${VMSTATE_DIR}/gdb"
 
-QEMU_SMP="2,cores=2,threads=1,sockets=1"
+QEMU_SMP="${DRAGONOS_QEMU_SMP:-2,cores=2,threads=1,sockets=1}"
+if ! [[ "${QEMU_SMP}" =~ ^[0-9]+(,(cores|threads|sockets|maxcpus)=[0-9]+)*$ ]]; then
+  echo "[错误] DRAGONOS_QEMU_SMP 格式无效: ${QEMU_SMP}"
+  exit 1
+fi
+IFS=',' read -r -a qemu_smp_fields <<< "${QEMU_SMP}"
+qemu_smp_cpus="${qemu_smp_fields[0]}"
+if [ "${qemu_smp_cpus}" -lt 1 ] || [ "${qemu_smp_cpus}" -gt 64 ]; then
+  echo "[错误] DRAGONOS_QEMU_SMP 的 vCPU 数必须位于 1..64: ${QEMU_SMP}"
+  exit 1
+fi
+declare -A qemu_smp_values=()
+for qemu_smp_field in "${qemu_smp_fields[@]:1}"; do
+  qemu_smp_key="${qemu_smp_field%%=*}"
+  qemu_smp_value="${qemu_smp_field#*=}"
+  if [ -n "${qemu_smp_values[${qemu_smp_key}]+set}" ] || \
+     [ "${qemu_smp_value}" -lt 1 ] || [ "${qemu_smp_value}" -gt 64 ]; then
+    echo "[错误] DRAGONOS_QEMU_SMP 含重复键或越界值: ${QEMU_SMP}"
+    exit 1
+  fi
+  qemu_smp_values["${qemu_smp_key}"]="${qemu_smp_value}"
+done
+if [ -n "${qemu_smp_values[maxcpus]+set}" ] && \
+   { [ "${qemu_smp_values[maxcpus]}" -lt "${qemu_smp_cpus}" ] || \
+     [ "${qemu_smp_values[maxcpus]}" -gt 64 ]; }; then
+  echo "[错误] DRAGONOS_QEMU_SMP 的 maxcpus 必须不小于当前 vCPU 数且不超过64: ${QEMU_SMP}"
+  exit 1
+fi
+if [ -n "${qemu_smp_values[cores]+set}" ] && \
+   [ -n "${qemu_smp_values[threads]+set}" ] && \
+   [ -n "${qemu_smp_values[sockets]+set}" ]; then
+  qemu_smp_product=$((qemu_smp_values[cores] * qemu_smp_values[threads] * qemu_smp_values[sockets]))
+  qemu_smp_expected_product="${qemu_smp_values[maxcpus]:-${qemu_smp_cpus}}"
+  if [ "${qemu_smp_product}" -ne "${qemu_smp_expected_product}" ]; then
+    echo "[错误] DRAGONOS_QEMU_SMP 的 cores*threads*sockets 必须等于 maxcpus（未指定时等于 vCPU 数）: ${QEMU_SMP}"
+    exit 1
+  fi
+fi
 QEMU_MONITOR_ARGS=(-monitor stdio)
-QEMU_TRACE="${qemu_trace_std}"
+QEMU_TRACE="${DRAGONOS_QEMU_TRACE:-${qemu_trace_std}}"
 QEMU_CPU_FEATURES=""
 QEMU_RTC_CLOCK=""
 QEMU_SERIAL_LOG_FILE="../serial_opt.txt"
 QEMU_SERIAL_ARGS=(-serial "file:${QEMU_SERIAL_LOG_FILE}")
-QEMU_DRIVE_ARGS=(-drive "id=disk,file=${QEMU_DISK_IMAGE},if=none,format=raw")
+QEMU_CONSOLE_CHARDEV_ID="mux"
+if [ "${DRAGONOS_QEMU_SNAPSHOT:-0}" != "0" ] && [ "${DRAGONOS_QEMU_SNAPSHOT:-0}" != "1" ]; then
+  echo "[错误] DRAGONOS_QEMU_SNAPSHOT 只能是0或1"
+  exit 1
+fi
+QEMU_DRIVE="id=disk,file=${QEMU_DISK_IMAGE},if=none,format=raw"
+if [ "${DRAGONOS_QEMU_SNAPSHOT:-0}" = "1" ]; then
+  QEMU_DRIVE+=",snapshot=on"
+fi
+QEMU_DRIVE_ARGS=(-drive "${QEMU_DRIVE}")
 QEMU_ACCEL_ARGS=()
 QEMU_DEVICE_ARGS=()
 QEMU_DISPLAY_ARGS=()
@@ -431,6 +484,8 @@ AUTO_TEST=${AUTO_TEST:=none}
 SYSCALL_TEST_DIR=${SYSCALL_TEST_DIR:=/opt/tests/gvisor}
 # dunitest测试目录
 DUNITEST_DIR=${DUNITEST_DIR:=/opt/tests/dunitest}
+# dunitest pattern过滤条件
+DUNITEST_PATTERN=${DUNITEST_PATTERN:=}
 
 BIOS_TYPE=""
 #这个变量为true则使用virtio磁盘
@@ -545,7 +600,8 @@ while true;do
 
 setup_kernel_init_program() {
     if [ ${ARCH} == "x86_64" ]; then
-        KERNEL_CMDLINE+=" init=/bin/busybox init AUTO_TEST=${AUTO_TEST} SYSCALL_TEST_DIR=${SYSCALL_TEST_DIR} DUNITEST_DIR=${DUNITEST_DIR} "
+        KERNEL_CMDLINE+=" init=/bin/busybox init AUTO_TEST=${AUTO_TEST} SYSCALL_TEST_DIR=${SYSCALL_TEST_DIR} DUNITEST_DIR=${DUNITEST_DIR} DUNITEST_PATTERN=${DUNITEST_PATTERN} "
+        # KERNEL_CMDLINE+=" init=/bin/dragonreach "
     elif [ ${ARCH} == "riscv64" ]; then
         KERNEL_CMDLINE+=" init=/bin/riscv_rust_init "
     fi
@@ -693,15 +749,36 @@ fi
 
 
 if [ ${QEMU_NOGRAPHIC} == true ]; then
-    QEMU_SERIAL_ARGS=(-serial chardev:mux -monitor chardev:mux -chardev "stdio,id=mux,mux=on,signal=off,logfile=${QEMU_SERIAL_LOG_FILE}")
+    if [ -n "${DRAGONOS_QEMU_SERIAL_SOCKET:-}" ]; then
+      qemu_serial_socket_dir="$(dirname "${DRAGONOS_QEMU_SERIAL_SOCKET}")"
+      qemu_serial_socket_real_dir="$(realpath -e -- "${qemu_serial_socket_dir}" 2>/dev/null || true)"
+      if [[ "${DRAGONOS_QEMU_SERIAL_SOCKET}" != /* ]] || \
+         [ ${#DRAGONOS_QEMU_SERIAL_SOCKET} -gt 100 ] || \
+         [ ! -d "${qemu_serial_socket_dir}" ] || \
+         [ -L "${qemu_serial_socket_dir}" ] || \
+         [ "${qemu_serial_socket_real_dir}" != "${qemu_serial_socket_dir}" ] || \
+         [ -e "${DRAGONOS_QEMU_SERIAL_SOCKET}" ]; then
+        echo "[错误] DRAGONOS_QEMU_SERIAL_SOCKET 必须位于已存在的非符号链接目录，长度不超过100且目标不存在"
+        exit 1
+      fi
+      if [ "$(stat -c '%u' "${qemu_serial_socket_dir}")" -ne "$(id -u)" ] || \
+         [ "$(stat -c '%a' "${qemu_serial_socket_dir}")" != "700" ]; then
+        echo "[错误] DRAGONOS_QEMU_SERIAL_SOCKET 父目录必须由当前用户拥有且权限严格为0700"
+        exit 1
+      fi
+      QEMU_CONSOLE_CHARDEV_ID="calib_console"
+      QEMU_SERIAL_ARGS=(-serial none -monitor none -chardev "socket,id=${QEMU_CONSOLE_CHARDEV_ID},path=${DRAGONOS_QEMU_SERIAL_SOCKET},server=on,wait=off,logfile=${QEMU_SERIAL_LOG_FILE}")
+    else
+      QEMU_SERIAL_ARGS=(-serial chardev:mux -monitor chardev:mux -chardev "stdio,id=mux,mux=on,signal=off,logfile=${QEMU_SERIAL_LOG_FILE}")
+    fi
 
     # 添加 virtio console 设备
     if [ ${ARCH} == "x86_64" ]; then
-      QEMU_DEVICE_ARGS+=(-device virtio-serial -device virtconsole,chardev=mux)
+      QEMU_DEVICE_ARGS+=(-device virtio-serial -device "virtconsole,chardev=${QEMU_CONSOLE_CHARDEV_ID}")
     elif [ ${ARCH} == "loongarch64" ]; then
-      QEMU_DEVICE_ARGS+=(-device virtio-serial -device virtconsole,chardev=mux)
+      QEMU_DEVICE_ARGS+=(-device virtio-serial -device "virtconsole,chardev=${QEMU_CONSOLE_CHARDEV_ID}")
     elif [ ${ARCH} == "riscv64" ]; then
-      QEMU_DEVICE_ARGS+=(-device virtio-serial-device -device virtconsole,chardev=mux)
+      QEMU_DEVICE_ARGS+=(-device virtio-serial-device -device "virtconsole,chardev=${QEMU_CONSOLE_CHARDEV_ID}")
     fi
 
     KERNEL_CMDLINE=" console=/dev/hvc0 ${KERNEL_CMDLINE}"
@@ -753,7 +830,9 @@ QEMU_ARGS+=(
 )
 QEMU_ARGS+=("${QEMU_MONITOR_ARGS[@]}")
 QEMU_ARGS+=("${QEMU_DISPLAY_ARGS[@]}")
-QEMU_ARGS+=(-d "${qemu_trace_std}")
+if [ "${QEMU_TRACE}" != "none" ]; then
+  QEMU_ARGS+=(-d "${QEMU_TRACE}")
+fi
 
 QEMU_ARGS+=(
   "${QEMU_MACHINE_ARGS[@]}"
@@ -822,6 +901,24 @@ if [ $flag_can_run -eq 1 ]; then
       echo "[QEMU] 等待GDB连接... (使用 'make gdb' 连接)"
     fi
     local -a cmd=("${QEMU}" "${bios_args[@]}" "${QEMU_ARGS[@]}")
+    if [ -n "${DRAGONOS_QEMU_ARGV_FILE:-}" ]; then
+      if [[ "${DRAGONOS_QEMU_ARGV_FILE}" != /* ]] || \
+         [ ! -d "$(dirname "${DRAGONOS_QEMU_ARGV_FILE}")" ] || \
+         [ -e "${DRAGONOS_QEMU_ARGV_FILE}" ]; then
+        echo "[错误] DRAGONOS_QEMU_ARGV_FILE 必须是父目录已存在且目标不存在的绝对路径"
+        return 1
+      fi
+      python3 - "${DRAGONOS_QEMU_ARGV_FILE}" "${cmd[@]}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+with path.open("x", encoding="utf-8") as output:
+    json.dump(sys.argv[2:], output, ensure_ascii=True, indent=2)
+    output.write("\n")
+PY
+    fi
     printf '[QEMU] 执行: sudo ' >&2
     printf '%q ' "${cmd[@]}" >&2
     printf '\n' >&2

--- a/tools/timekeeping/calibrate.py
+++ b/tools/timekeeping/calibrate.py
@@ -1,0 +1,1680 @@
+#!/usr/bin/env python3
+"""Bracketed host/guest timekeeping calibration for DragonOS.
+
+The runner never compares host and guest clock epochs.  It establishes causal
+host bounds around guest CLOCK_MONOTONIC_RAW samples and performs all verdict
+comparisons with integers.  A missing serial transport or incomplete protocol
+is recorded as ``incomplete`` and can never become a passing result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import fractions
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import select
+import secrets
+import selectors
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from typing import Any, Iterable
+
+
+SCHEMA = "dragonos.timekeeping-calibration.v3"
+PROTOCOL = "TKCAL/2"
+TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+HEX128 = re.compile(r"^[0-9a-f]{32}$")
+HEX256 = re.compile(r"^[0-9a-f]{64}$")
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+REQUIRED_VMS = {("kvm", 1), ("kvm", 2), ("tcg", 2)}
+READS_REQUIRED = 10_000_000
+MIGRATIONS_EXPECTED = (READS_REQUIRED - 1) // 4096
+MAX_SERIAL_LINE_BYTES = 64 * 1024
+MAX_SERIAL_BUFFER_BYTES = 128 * 1024
+MAX_TRANSCRIPT_BYTES = 16 * 1024 * 1024
+SOCKET_IO_TIMEOUT_NS = 10_000_000_000
+MAX_CPU_ID = 4095
+MAX_CPU_COUNT = 256
+SERIAL_FATAL_MARKERS = (
+    b"Kernel Panic Occurred.",
+    b"Panic Counter:",
+    b"fatal exception",
+    b"BUG: kernel NULL pointer dereference",
+    b"BUG: unable to handle page fault",
+)
+SERIAL_MEASUREMENT_FORBIDDEN_MARKERS = (
+    b"Switching to the clocksource",
+    b"clocksource :",  # prefix of the watchdog's exact "is unstable" diagnostic
+    b"cs_dev_nsec =",
+    b"clocksource watchdog could not initialize reference state",
+    b"clocksource registration rollback could not reset watchdog state",
+    b"clocksource registration rollback could not reset source",
+    b"clocksource rating change could not switch source",
+    b"clocksource watchdog: long readout interval, skip check",
+    b"clocksource watchdog replacement could not reset state",
+    b"clocksource selection failed",
+    b"refusing invalid clocksource",
+)
+
+
+class CalibrationError(Exception):
+    """Invalid evidence or a failed setup operation."""
+
+
+class ProtocolError(CalibrationError):
+    """Malformed, duplicated, or out-of-order guest protocol."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Event:
+    kind: str
+    fields: dict[str, str]
+    raw_line: str
+
+
+@dataclasses.dataclass(frozen=True)
+class TranscriptEvidence:
+    guest_events: tuple[Event, ...]
+    bytes_read: int
+
+
+@dataclasses.dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    starttime_ticks: int
+    exe: str
+    cwd: str
+    argv: tuple[str, ...]
+
+    def as_json(self) -> dict[str, Any]:
+        encoded = b"\0".join(os.fsencode(item) for item in self.argv) + b"\0"
+        return {
+            "pid": self.pid,
+            "starttime_ticks": self.starttime_ticks,
+            "exe": self.exe,
+            "cwd": self.cwd,
+            "cmdline_sha256": hashlib.sha256(encoded).hexdigest(),
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class Thresholds:
+    ratio_min_num: int
+    ratio_min_den: int
+    ratio_max_num: int
+    ratio_max_den: int
+    dispersion_num: int
+    dispersion_den: int
+    ratio_is_gate: bool
+    dispersion_is_gate: bool
+
+    @staticmethod
+    def for_accel(accel: str) -> "Thresholds":
+        if accel == "kvm":
+            return Thresholds(995, 1000, 1005, 1000, 2, 1000, True, True)
+        if accel == "tcg":
+            # TCG scheduling and translation overhead make rate brackets useful
+            # diagnostics, but not a stable performance gate.  Correctness and
+            # monotonicity remain mandatory for TCG runs.
+            return Thresholds(95, 100, 105, 100, 2, 100, False, False)
+        raise CalibrationError(f"unsupported accelerator: {accel}")
+
+    def as_json(self) -> dict[str, str]:
+        return {
+            "ratio_min": fraction_text(fractions.Fraction(self.ratio_min_num, self.ratio_min_den)),
+            "ratio_max": fraction_text(fractions.Fraction(self.ratio_max_num, self.ratio_max_den)),
+            "max_midpoint_dispersion": fraction_text(
+                fractions.Fraction(self.dispersion_num, self.dispersion_den)
+            ),
+            "ratio_is_gate": self.ratio_is_gate,
+            "dispersion_is_gate": self.dispersion_is_gate,
+        }
+
+
+def parse_event(line: str) -> Event | None:
+    """Parse one guest line; unrelated boot/shell output returns None."""
+    clean = line.rstrip("\r\n")
+    if not clean.startswith(PROTOCOL + " "):
+        return None
+    parts = clean.split(" ")
+    if len(parts) < 3 or parts[0] != PROTOCOL or not TOKEN.fullmatch(parts[1]):
+        raise ProtocolError(f"malformed protocol line: {clean!r}")
+    fields: dict[str, str] = {}
+    for token in parts[2:]:
+        if token.count("=") != 1:
+            raise ProtocolError(f"malformed field in protocol line: {token!r}")
+        key, value = token.split("=", 1)
+        if not TOKEN.fullmatch(key) or not value or len(value) > 256:
+            raise ProtocolError(f"invalid protocol field: {token!r}")
+        if key in fields:
+            raise ProtocolError(f"duplicate protocol field: {key}")
+        fields[key] = value
+    return Event(parts[1], fields, clean)
+
+
+def require_fields(event: Event, names: Iterable[str]) -> None:
+    missing = [name for name in names if name not in event.fields]
+    if missing:
+        raise ProtocolError(f"{event.kind} lacks fields: {','.join(missing)}")
+
+
+def uint_field(event: Event, name: str) -> int:
+    require_fields(event, [name])
+    value = event.fields[name]
+    if not value.isascii() or not value.isdecimal():
+        raise ProtocolError(f"{event.kind}.{name} is not an unsigned integer")
+    parsed = int(value)
+    if parsed < 0 or parsed > (1 << 64) - 1:
+        raise ProtocolError(f"{event.kind}.{name} is outside u64")
+    return parsed
+
+
+def validate_identity(event: Event, expected_kind: str, run_id: str, seq: int, case_id: str | None) -> None:
+    if event.kind != expected_kind:
+        raise ProtocolError(f"expected {expected_kind}, got {event.kind}")
+    require_fields(event, ["run", "seq"])
+    if event.fields["run"] != run_id or uint_field(event, "seq") != seq:
+        raise ProtocolError(f"{event.kind} has the wrong run or sequence")
+    if case_id is not None:
+        require_fields(event, ["case"])
+        if event.fields["case"] != case_id:
+            raise ProtocolError(f"{event.kind} has the wrong case")
+
+
+def validate_ack(event: Event, run_id: str, seq: int) -> None:
+    validate_identity(event, "ACK", run_id, seq, None)
+    if event.fields != {"run": run_id, "seq": str(seq), "status": "ok"}:
+        raise ProtocolError("ACK has invalid or extra fields")
+
+
+def validate_ready(event: Event, vcpus: int) -> None:
+    if set(event.fields) != {"run", "seq", "cpus"}:
+        raise ProtocolError("READY has invalid or extra fields")
+    cpu_items = [] if event.fields["cpus"] == "none" else event.fields["cpus"].split(",")
+    try:
+        cpu_set = set() if not cpu_items else parse_cpu_list(event.fields["cpus"])
+    except CalibrationError as error:
+        raise ProtocolError(f"READY CPU list is invalid: {error}") from error
+    if len(cpu_items) != vcpus or len(cpu_set) != vcpus:
+        raise ProtocolError(f"READY reports {event.fields['cpus']}, expected {vcpus} online CPUs")
+
+
+def compute_metrics(slo: int, shi: int, elo: int, ehi: int, guest_start: int, guest_end: int) -> dict[str, Any]:
+    values = (slo, shi, elo, ehi, guest_start, guest_end)
+    if any(value < 0 or value > (1 << 64) - 1 for value in values):
+        raise CalibrationError("timestamps must fit u64")
+    if not (slo <= shi < elo <= ehi):
+        raise CalibrationError("host brackets are not causally ordered")
+    if guest_end <= guest_start:
+        raise CalibrationError("guest raw clock did not advance")
+    guest_delta = guest_end - guest_start
+    host_min = elo - shi
+    host_max = ehi - slo
+    midpoint_twice = (elo + ehi) - (slo + shi)
+    if host_min <= 0 or host_max < host_min or midpoint_twice <= 0:
+        raise CalibrationError("invalid host interval bounds")
+
+    ratio_low = fractions.Fraction(guest_delta, host_max)
+    ratio_mid = fractions.Fraction(2 * guest_delta, midpoint_twice)
+    ratio_high = fractions.Fraction(guest_delta, host_min)
+    bracket_ppm = fractions.Fraction((host_max - host_min) * 2_000_000, midpoint_twice)
+    error_ppm = (ratio_mid - 1) * 1_000_000
+    return {
+        "guest_delta_ns": guest_delta,
+        "host_min_ns": host_min,
+        "host_max_ns": host_max,
+        "host_midpoint_twice_ns": midpoint_twice,
+        "ratio_low_fraction": ratio_low,
+        "ratio_mid_fraction": ratio_mid,
+        "ratio_high_fraction": ratio_high,
+        "ratio_low": fraction_text(ratio_low),
+        "ratio_mid": fraction_text(ratio_mid),
+        "ratio_high": fraction_text(ratio_high),
+        "ratio_numerator": ratio_mid.numerator,
+        "ratio_denominator": ratio_mid.denominator,
+        "error_ppm": fraction_text(error_ppm),
+        "bracket_ppm": fraction_text(bracket_ppm),
+    }
+
+
+def fraction_text(value: fractions.Fraction, digits: int = 9) -> str:
+    sign = "-" if value < 0 else ""
+    value = abs(value)
+    scale = 10**digits
+    rounded = (value.numerator * scale * 2 + value.denominator) // (2 * value.denominator)
+    return f"{sign}{rounded // scale}.{rounded % scale:0{digits}d}"
+
+
+def public_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in metrics.items() if not key.endswith("_fraction")}
+
+
+def evaluate_ratio(metrics: dict[str, Any], thresholds: Thresholds) -> tuple[str, list[str]]:
+    if not thresholds.ratio_is_gate:
+        return "pass", []
+    low: fractions.Fraction = metrics["ratio_low_fraction"]
+    high: fractions.Fraction = metrics["ratio_high_fraction"]
+    minimum = fractions.Fraction(thresholds.ratio_min_num, thresholds.ratio_min_den)
+    maximum = fractions.Fraction(thresholds.ratio_max_num, thresholds.ratio_max_den)
+    if low >= minimum and high <= maximum:
+        return "pass", []
+    if high < minimum:
+        return "fail", ["ratio_interval_below_threshold"]
+    if low > maximum:
+        return "fail", ["ratio_interval_above_threshold"]
+    reasons: list[str] = []
+    if low < minimum:
+        reasons.append("ratio_interval_overlaps_lower_threshold")
+    if high > maximum:
+        reasons.append("ratio_interval_overlaps_upper_threshold")
+    return "incomplete", reasons
+
+
+def evaluate_read_fields(work_done: Event, affinity: str, vcpus: int) -> list[str]:
+    required = [
+        "status", "raw_reads", "mono_reads", "raw_regressions", "mono_regressions",
+        "raw_max_backward_ns", "mono_max_backward_ns", "migrations_requested",
+        "migrations_observed", "cpu_mask_seen",
+    ]
+    require_fields(work_done, required)
+    reasons: list[str] = []
+    if work_done.fields["status"] != "ok":
+        reasons.append("guest_workload_failed")
+    for name in ("raw_reads", "mono_reads"):
+        if uint_field(work_done, name) != READS_REQUIRED:
+            reasons.append(f"{name}_does_not_match_required_count")
+    for name in ("raw_regressions", "mono_regressions", "raw_max_backward_ns", "mono_max_backward_ns"):
+        if uint_field(work_done, name) != 0:
+            reasons.append(f"{name}_nonzero")
+    if affinity == "migrate":
+        if vcpus < 2:
+            reasons.append("migration_requires_two_vcpus")
+        if uint_field(work_done, "migrations_requested") != MIGRATIONS_EXPECTED:
+            reasons.append("requested_migrations_do_not_match_expected_count")
+        if uint_field(work_done, "migrations_observed") != MIGRATIONS_EXPECTED:
+            reasons.append("observed_migrations_do_not_match_expected_count")
+        try:
+            cpu_mask = int(work_done.fields["cpu_mask_seen"], 16)
+        except ValueError as error:
+            raise ProtocolError("WORK_DONE.cpu_mask_seen is not hexadecimal") from error
+        if cpu_mask.bit_count() < 2:
+            reasons.append("fewer_than_two_cpus_observed")
+    elif (uint_field(work_done, "migrations_requested") != 0 or
+          uint_field(work_done, "migrations_observed") != 0):
+        reasons.append("fixed_case_reported_migrations")
+    return reasons
+
+
+def evaluate_case_evidence(spec: dict[str, Any], accel: str, vcpus: int, start: Event,
+                           work_done: Event, end: Event,
+                           bracket: dict[str, int]) -> tuple[str, list[str], dict[str, Any]]:
+    require_fields(start, ["guest_raw_ns", "status"])
+    require_fields(end, ["guest_raw_ns", "status"])
+    require_fields(work_done, ["work_end_raw_ns", "status", "reason"])
+    metrics = compute_metrics(
+        bracket["slo_ns"], bracket["shi_ns"], bracket["elo_ns"], bracket["ehi_ns"],
+        uint_field(start, "guest_raw_ns"), uint_field(end, "guest_raw_ns"),
+    )
+    fail_reasons: list[str] = []
+    incomplete_reasons: list[str] = []
+    if (start.fields["status"] != "ok" or end.fields["status"] != "ok" or
+            work_done.fields["status"] != "ok"):
+        fail_reasons.append("guest_reported_failure")
+    if spec["mode"] in ("sleep", "busy"):
+        work_end = uint_field(work_done, "work_end_raw_ns")
+        guest_start = uint_field(start, "guest_raw_ns")
+        if work_end < guest_start:
+            raise ProtocolError("WORK_DONE raw clock precedes START")
+        if work_end - guest_start < spec["target_ns"]:
+            fail_reasons.append("guest_workload_shorter_than_target")
+        ratio_status, ratio_reasons = evaluate_ratio(metrics, Thresholds.for_accel(accel))
+        if ratio_status == "fail":
+            fail_reasons.extend(ratio_reasons)
+        elif ratio_status == "incomplete":
+            incomplete_reasons.extend(ratio_reasons)
+    else:
+        fail_reasons.extend(evaluate_read_fields(work_done, spec["affinity"], vcpus))
+    if fail_reasons:
+        return "fail", sorted(set(fail_reasons)), metrics
+    if incomplete_reasons:
+        return "incomplete", sorted(set(incomplete_reasons)), metrics
+    return "pass", [], metrics
+
+
+def evaluate_dispersion(cases: list[dict[str, Any]], thresholds: Thresholds) -> list[str]:
+    if not thresholds.dispersion_is_gate:
+        return []
+    grouped: dict[tuple[str, int], list[fractions.Fraction]] = {}
+    for case in cases:
+        if case.get("mode") not in ("sleep", "busy") or case.get("status") != "pass":
+            continue
+        metrics = case["metrics"]
+        ratio = fractions.Fraction(metrics["ratio_numerator"], metrics["ratio_denominator"])
+        grouped.setdefault((case["mode"], case["target_ns"]), []).append(ratio)
+    reasons: list[str] = []
+    limit = fractions.Fraction(thresholds.dispersion_num, thresholds.dispersion_den)
+    for (mode, target), ratios in grouped.items():
+        if len(ratios) != 5:
+            reasons.append(f"{mode}_{target}_does_not_have_five_passing_rounds")
+        elif max(ratios) - min(ratios) > limit:
+            reasons.append(f"{mode}_{target}_midpoint_dispersion_exceeded")
+    for mode in ("sleep", "busy"):
+        for target in (10_000_000_000, 60_000_000_000):
+            if (mode, target) not in grouped:
+                reasons.append(f"{mode}_{target}_group_missing")
+    return sorted(set(reasons))
+
+
+def expected_cases(vcpus: int) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    for mode in ("sleep", "busy"):
+        for target in (10_000_000_000, 60_000_000_000):
+            for repetition in range(1, 6):
+                cases.append({
+                    "case_id": f"{mode}-{target // 1_000_000_000}s-r{repetition}",
+                    "mode": mode,
+                    "target_ns": target,
+                    "affinity": "fixed",
+                    "reads": 0,
+                    "repetition": repetition,
+                })
+    cases.append({
+        "case_id": "reads-fixed", "mode": "reads", "target_ns": 0,
+        "affinity": "fixed", "reads": READS_REQUIRED, "repetition": 1,
+    })
+    if vcpus == 1:
+        cases.append({
+            "case_id": "reads-migrate", "mode": "reads", "target_ns": 0,
+            "affinity": "migrate", "reads": READS_REQUIRED, "repetition": 1,
+            "predefined_skip": "requires_two_vcpus",
+        })
+    else:
+        cases.append({
+            "case_id": "reads-migrate", "mode": "reads", "target_ns": 0,
+            "affinity": "migrate", "reads": READS_REQUIRED, "repetition": 1,
+        })
+    return cases
+
+
+class SerialTransport:
+    def __init__(self, path: Path, transcript: Any):
+        self.path = path
+        self.transcript = transcript
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.settimeout(SOCKET_IO_TIMEOUT_NS / 1_000_000_000)
+        try:
+            self.sock.connect(str(path))
+        except OSError as error:
+            self.sock.close()
+            raise CalibrationError(
+                f"cannot connect to QEMU serial socket {path}; configure the general "
+                "DRAGONOS_QEMU_SERIAL_SOCKET interface before running calibration: {error}"
+            ) from error
+        self.sock.setblocking(False)
+        self.selector = selectors.DefaultSelector()
+        self.selector.register(self.sock, selectors.EVENT_READ)
+        self.buffer = bytearray()
+        self.transcript_bytes = 0
+
+    def write_transcript(self, data: bytes) -> None:
+        total = getattr(self, "transcript_bytes", 0) + len(data)
+        if total > MAX_TRANSCRIPT_BYTES:
+            raise CalibrationError("serial transcript exceeds the total byte limit")
+        self.transcript.write(data)
+        self.transcript.flush()
+        self.transcript_bytes = total
+
+    def close(self) -> None:
+        self.selector.close()
+        self.sock.close()
+
+    def send_line(self, line: str, timeout_ns: int = SOCKET_IO_TIMEOUT_NS) -> None:
+        try:
+            data = (line + "\n").encode("ascii")
+        except UnicodeEncodeError as error:
+            raise CalibrationError("serial command must be ASCII") from error
+        if len(data) > MAX_SERIAL_LINE_BYTES:
+            raise CalibrationError("serial command exceeds the line limit")
+        self.write_transcript(b">>> " + data)
+        view = memoryview(data)
+        deadline_ns = raw_now_ns() + timeout_ns
+        self.selector.modify(self.sock, selectors.EVENT_READ | selectors.EVENT_WRITE)
+        try:
+            while view:
+                remaining = deadline_ns - raw_now_ns()
+                if remaining <= 0:
+                    raise CalibrationError("timed out writing serial protocol")
+                events = self.selector.select(remaining / 1_000_000_000)
+                if not events:
+                    raise CalibrationError("timed out writing serial protocol")
+                if not any(mask & selectors.EVENT_WRITE for _, mask in events):
+                    continue
+                try:
+                    count = self.sock.send(view)
+                except BlockingIOError:
+                    continue
+                if count <= 0:
+                    raise CalibrationError("serial socket closed while writing")
+                view = view[count:]
+        finally:
+            self.selector.modify(self.sock, selectors.EVENT_READ)
+
+    def read_line(self, deadline_ns: int) -> str:
+        while True:
+            newline = self.buffer.find(b"\n")
+            if newline >= 0:
+                if newline + 1 > MAX_SERIAL_LINE_BYTES:
+                    raise ProtocolError("serial line exceeds the line limit")
+                raw = bytes(self.buffer[: newline + 1])
+                del self.buffer[: newline + 1]
+                self.write_transcript(raw)
+                return raw.decode("utf-8", errors="replace")
+            remaining = deadline_ns - raw_now_ns()
+            if remaining <= 0:
+                raise CalibrationError("timed out waiting for serial protocol")
+            events = self.selector.select(remaining / 1_000_000_000)
+            if not events:
+                raise CalibrationError("timed out waiting for serial protocol")
+            try:
+                data = self.sock.recv(65536)
+            except BlockingIOError:
+                continue
+            if not data:
+                raise CalibrationError("serial socket reached EOF")
+            self.buffer.extend(data)
+            if len(self.buffer) > MAX_SERIAL_BUFFER_BYTES:
+                raise ProtocolError("serial input exceeds the buffer limit")
+            if b"\n" not in self.buffer and len(self.buffer) > MAX_SERIAL_LINE_BYTES:
+                raise ProtocolError("serial line exceeds the line limit")
+
+    def wait_for_prompt(
+        self,
+        prompt: re.Pattern[str],
+        deadline_ns: int,
+        retry_ns: int = 2_000_000_000,
+    ) -> None:
+        """Wait for a possibly non-newline-terminated shell prompt.
+
+        BusyBox prints the activation prompt before opening hvc0 for input, so
+        a newline sent immediately after the socket connects can be lost.  A
+        bounded, low-frequency retry closes that boot race.  Prompt matching
+        strips terminal colour escapes but the transcript always retains the
+        exact bytes received from the guest.
+        """
+        next_retry_ns = 0
+        while True:
+            while True:
+                newline = self.buffer.find(b"\n")
+                end = newline + 1 if newline >= 0 else len(self.buffer)
+                if end == 0:
+                    break
+                raw = bytes(self.buffer[:end])
+                normalized = ANSI_ESCAPE_RE.sub("", raw.decode("utf-8", errors="replace"))
+                if prompt.search(normalized):
+                    del self.buffer[:end]
+                    self.write_transcript(raw)
+                    return
+                if newline < 0:
+                    break
+                del self.buffer[:end]
+                self.write_transcript(raw)
+
+            if len(self.buffer) > MAX_SERIAL_LINE_BYTES:
+                raise ProtocolError("serial line exceeds the line limit")
+            now_ns = raw_now_ns()
+            if now_ns >= deadline_ns:
+                raise CalibrationError("timed out waiting for guest shell prompt")
+            if now_ns >= next_retry_ns:
+                self.send_line("")
+                next_retry_ns = raw_now_ns() + retry_ns
+
+            wait_deadline_ns = min(deadline_ns, next_retry_ns)
+            remaining_ns = wait_deadline_ns - raw_now_ns()
+            if remaining_ns <= 0:
+                continue
+            events = self.selector.select(remaining_ns / 1_000_000_000)
+            if not events:
+                continue
+            try:
+                data = self.sock.recv(65536)
+            except BlockingIOError:
+                continue
+            if not data:
+                raise CalibrationError("serial socket reached EOF")
+            self.buffer.extend(data)
+            if len(self.buffer) > MAX_SERIAL_BUFFER_BYTES:
+                raise ProtocolError("serial input exceeds the buffer limit")
+
+    def read_event(self, kind: str, run_id: str, seq: int, case_id: str | None,
+                   timeout_ns: int) -> Event:
+        deadline = raw_now_ns() + timeout_ns
+        while True:
+            event = parse_event(self.read_line(deadline))
+            if event is None:
+                continue
+            if event.kind == "ERROR":
+                raise ProtocolError(f"guest protocol error: {event.raw_line}")
+            validate_identity(event, kind, run_id, seq, case_id)
+            return event
+
+
+def raw_now_ns() -> int:
+    return time.clock_gettime_ns(time.CLOCK_MONOTONIC_RAW)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def parse_transcript(path: Path) -> TranscriptEvidence:
+    events: list[Event] = []
+    total = 0
+    longest_fatal_marker = max(len(marker) for marker in SERIAL_FATAL_MARKERS)
+    longest_measurement_marker = max(
+        len(marker) for marker in SERIAL_MEASUREMENT_FORBIDDEN_MARKERS
+    )
+    fatal_marker_tail = b""
+    measurement_marker_tail = b""
+    measurement_active = False
+    try:
+        with path.open("rb") as source:
+            while True:
+                raw = source.readline(MAX_SERIAL_LINE_BYTES + 1)
+                if not raw:
+                    break
+                total += len(raw)
+                if total > MAX_TRANSCRIPT_BYTES:
+                    raise CalibrationError("serial transcript exceeds the total byte limit")
+                if len(raw) > MAX_SERIAL_LINE_BYTES:
+                    raise ProtocolError("serial transcript contains an overlong line")
+                line = raw.decode("utf-8", errors="replace")
+                event = parse_event(line)
+                if event is not None and event.kind == "READY" and not measurement_active:
+                    # The helper's initial READY is emitted only after boot and
+                    # establishes the start of the controlled measurement
+                    # session.  Boot-time source selection is expected; any
+                    # source change or watchdog anomaly after this boundary
+                    # invalidates the calibration run.
+                    measurement_active = True
+                    measurement_marker_tail = b""
+
+                lowered = fatal_marker_tail + raw.lower()
+                for marker in SERIAL_FATAL_MARKERS:
+                    if marker.lower() in lowered:
+                        raise CalibrationError(
+                            f"guest serial contains fatal kernel marker {marker.decode('ascii')!r}"
+                        )
+                fatal_marker_tail = lowered[-max(0, longest_fatal_marker - 1):]
+
+                if measurement_active:
+                    measured = measurement_marker_tail + raw.lower()
+                    for marker in SERIAL_MEASUREMENT_FORBIDDEN_MARKERS:
+                        if marker.lower() in measured:
+                            raise CalibrationError(
+                                "guest serial contains clocksource event during measurement "
+                                f"{marker.decode('ascii')!r}"
+                            )
+                    measurement_marker_tail = measured[
+                        -max(0, longest_measurement_marker - 1):
+                    ]
+
+                if event is not None:
+                    events.append(event)
+                    if event.kind == "ACK":
+                        measurement_active = False
+                        measurement_marker_tail = b""
+    except OSError as error:
+        raise CalibrationError(f"cannot read serial transcript {path}: {error}") from error
+    return TranscriptEvidence(tuple(events), total)
+
+
+def verify_transcript_session(value: dict[str, Any], transcript: TranscriptEvidence) -> None:
+    events = transcript.guest_events
+    cursor = 0
+
+    def take(expected_kind: str) -> Event:
+        nonlocal cursor
+        if cursor >= len(events):
+            raise CalibrationError(f"serial transcript is missing {expected_kind}")
+        event = events[cursor]
+        cursor += 1
+        if event.kind == "ERROR":
+            raise ProtocolError(f"serial transcript contains guest error: {event.raw_line}")
+        if event.kind != expected_kind:
+            raise ProtocolError(
+                f"serial transcript expected {expected_kind}, got {event.kind} at event {cursor}"
+            )
+        return event
+
+    run_id = value["run_id"]
+    vcpus = value["vcpus"]
+    initial = take("READY")
+    validate_identity(initial, "READY", run_id, 0, None)
+    validate_ready(initial, vcpus)
+    for case in value["cases"]:
+        if case["status"] == "skip":
+            continue
+        seq = case["seq"]
+        guest = case["guest"]
+        for kind, name in (("START", "start"), ("WORK_DONE", "work_done"), ("END", "end")):
+            event = take(kind)
+            validate_identity(event, kind, run_id, seq, case["case_id"])
+            if event.fields != guest[name]:
+                raise CalibrationError(
+                    f"serial {kind} differs from JSON evidence for {case['case_id']}"
+                )
+        ready = take("READY")
+        validate_identity(ready, "READY", run_id, seq, None)
+        validate_ready(ready, vcpus)
+    ack = take("ACK")
+    validate_ack(ack, run_id, int(value["shutdown_ack"]["seq"]))
+    if ack.fields != value["shutdown_ack"]:
+        raise CalibrationError("serial ACK differs from JSON shutdown evidence")
+    if cursor != len(events):
+        raise CalibrationError("serial transcript contains extra protocol events")
+
+
+def create_output_dir(path: Path) -> None:
+    try:
+        path.mkdir(parents=True, exist_ok=False)
+    except FileExistsError as error:
+        raise CalibrationError(f"refusing to overwrite artifact directory: {path}") from error
+
+
+def write_json_new(path: Path, value: Any) -> None:
+    if path.exists():
+        raise CalibrationError(f"refusing to overwrite artifact: {path}")
+    temporary = path.with_name(path.name + f".tmp-{os.getpid()}-{secrets.token_hex(4)}")
+    try:
+        with temporary.open("x", encoding="utf-8") as output:
+            json.dump(value, output, sort_keys=True, indent=2)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def artifact_record(path: Path) -> dict[str, Any]:
+    path = path.resolve()
+    return {"path": str(path), "sha256": sha256_file(path), "size": path.stat().st_size}
+
+
+def validate_artifact_store(path: Path) -> Path:
+    resolved = path.resolve()
+    if (not resolved.is_dir() or path.is_symlink() or resolved.stat().st_uid != os.getuid() or
+            resolved.stat().st_mode & 0o077 != 0):
+        raise CalibrationError("artifact store must be an existing private directory owned by the user")
+    return resolved
+
+
+def archive_artifact(source: Path, store: Path) -> dict[str, Any]:
+    if not source.is_file() or source.is_symlink():
+        raise CalibrationError(f"cannot archive missing/non-regular artifact: {source}")
+    source = source.resolve()
+    digest = sha256_file(source)
+    size = source.stat().st_size
+    destination = store / digest
+
+    def verify_destination() -> None:
+        if (not destination.is_file() or destination.is_symlink() or
+                destination.name != digest or destination.stat().st_size != size or
+                destination.stat().st_mode & 0o222 != 0 or sha256_file(destination) != digest):
+            raise CalibrationError(f"content-addressed artifact is invalid: {destination}")
+
+    if destination.exists():
+        verify_destination()
+    else:
+        temporary = store / f".{digest}.tmp-{os.getpid()}-{secrets.token_hex(4)}"
+        try:
+            completed = subprocess.run(
+                ["cp", "--reflink=auto", "--sparse=always", "--", str(source), str(temporary)],
+                check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+            )
+            if completed.returncode != 0:
+                raise CalibrationError(f"cannot archive {source}: {completed.stdout.strip()}")
+            if temporary.stat().st_size != size or sha256_file(temporary) != digest:
+                raise CalibrationError(f"archived copy differs from source: {source}")
+            temporary.chmod(0o444)
+            with temporary.open("rb") as archived:
+                os.fsync(archived.fileno())
+            try:
+                os.link(temporary, destination)
+            except FileExistsError:
+                pass
+            directory_fd = os.open(store, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+        verify_destination()
+    return {
+        "execution_path": str(source),
+        "archive_path": str(destination),
+        "sha256": digest,
+        "size": size,
+    }
+
+
+def command_output(argv: list[str]) -> str:
+    try:
+        completed = subprocess.run(argv, check=False, stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT, text=True, timeout=10)
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return f"unavailable:{type(error).__name__}"
+    return completed.stdout.splitlines()[0] if completed.stdout else f"exit:{completed.returncode}"
+
+
+def hash_untracked_content(repo: Path) -> str:
+    """Hash names, types, and contents of every non-ignored untracked path."""
+    try:
+        listed = subprocess.run(
+            ["git", "-C", str(repo), "ls-files", "--others", "--exclude-standard", "-z"],
+            check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError) as error:
+        raise CalibrationError(f"cannot enumerate untracked source content: {error}") from error
+    digest = hashlib.sha256()
+    for relative_raw in sorted(item for item in listed.split(b"\0") if item):
+        relative = os.fsdecode(relative_raw)
+        path = repo / relative
+        digest.update(relative_raw)
+        digest.update(b"\0")
+        if path.is_symlink():
+            digest.update(b"L\0")
+            digest.update(os.fsencode(os.readlink(path)))
+        elif path.is_file():
+            digest.update(b"F\0")
+            with path.open("rb") as source:
+                for block in iter(lambda: source.read(1024 * 1024), b""):
+                    digest.update(block)
+        else:
+            raise CalibrationError(f"unsupported untracked source path: {path}")
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def provenance(qemu_argv: list[str]) -> dict[str, Any]:
+    repo = Path(__file__).resolve().parents[2]
+    commit = command_output(["git", "-C", str(repo), "rev-parse", "HEAD"])
+    tree = command_output(["git", "-C", str(repo), "rev-parse", "HEAD^{tree}"])
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain=v1", "--untracked-files=all"],
+            check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=10,
+        ).stdout
+        tracked_diff = subprocess.run(
+            ["git", "-C", str(repo), "diff", "--binary", "HEAD"], check=False,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=10,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        status = b"unavailable"
+        tracked_diff = b"unavailable"
+    return {
+        "repo": {
+            "commit": commit,
+            "tree": tree,
+            "dirty": bool(status.strip()),
+            "status_sha256": hashlib.sha256(status).hexdigest(),
+            "tracked_diff_sha256": hashlib.sha256(tracked_diff).hexdigest(),
+            "untracked_content_sha256": hash_untracked_content(repo),
+        },
+        "host": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "affinity": sorted(os.sched_getaffinity(0)),
+            "clock_monotonic_raw_resolution_ns": round(
+                time.clock_getres(time.CLOCK_MONOTONIC_RAW) * 1_000_000_000
+            ),
+        },
+        "qemu_version": command_output([qemu_argv[0], "--version"]),
+    }
+
+
+def parse_cpu_list(text: str) -> set[int]:
+    cpus: set[int] = set()
+    if not text:
+        raise CalibrationError("CPU list must not be empty")
+    for item in text.split(","):
+        if "-" in item:
+            parts = item.split("-", 1)
+            if len(parts) != 2 or not all(part.isdecimal() for part in parts):
+                raise CalibrationError(f"invalid CPU range: {item}")
+            try:
+                start, end = map(int, parts)
+            except ValueError as error:
+                raise CalibrationError(f"invalid CPU range: {item}") from error
+            if start > end:
+                raise CalibrationError(f"descending CPU range: {item}")
+            if end > MAX_CPU_ID or end - start + 1 > MAX_CPU_COUNT:
+                raise CalibrationError(f"CPU range exceeds calibration limits: {item}")
+            cpus.update(range(start, end + 1))
+        elif item.isdecimal():
+            try:
+                cpu = int(item)
+            except ValueError as error:
+                raise CalibrationError(f"invalid CPU item: {item}") from error
+            if cpu > MAX_CPU_ID:
+                raise CalibrationError(f"CPU id exceeds calibration limit: {item}")
+            cpus.add(cpu)
+        else:
+            raise CalibrationError(f"invalid CPU item: {item}")
+        if len(cpus) > MAX_CPU_COUNT:
+            raise CalibrationError("CPU list exceeds calibration count limit")
+    return cpus
+
+
+def capture_process_identity(pid: int) -> ProcessIdentity:
+    proc = Path(f"/proc/{pid}")
+    try:
+        raw_cmdline = (proc / "cmdline").read_bytes()
+        raw_stat = (proc / "stat").read_text(encoding="ascii")
+        exe = str((proc / "exe").resolve(strict=True))
+        cwd = str((proc / "cwd").resolve(strict=True))
+    except (OSError, UnicodeError) as error:
+        raise CalibrationError(f"cannot capture process identity for pid {pid}: {error}") from error
+    if not raw_cmdline or not raw_cmdline.endswith(b"\0"):
+        raise CalibrationError(f"process {pid} has an invalid /proc cmdline")
+    raw_items = raw_cmdline[:-1].split(b"\0")
+    if not raw_items or any(not item for item in raw_items):
+        raise CalibrationError(f"process {pid} has empty argv entries")
+    argv = tuple(os.fsdecode(item) for item in raw_items)
+    closing = raw_stat.rfind(")")
+    if closing < 0:
+        raise CalibrationError(f"process {pid} has malformed /proc stat")
+    fields = raw_stat[closing + 2:].split()
+    if len(fields) <= 19 or not fields[19].isdecimal():
+        raise CalibrationError(f"process {pid} lacks a valid starttime")
+    return ProcessIdentity(pid, int(fields[19]), exe, cwd, argv)
+
+
+def validate_process_identity(identity: ProcessIdentity, expected_argv: list[str],
+                              qemu_binary: Path) -> None:
+    if identity.argv != tuple(expected_argv):
+        raise CalibrationError("live QEMU /proc cmdline differs from captured argv")
+    try:
+        same_binary = os.path.samefile(identity.exe, qemu_binary)
+    except OSError as error:
+        raise CalibrationError(f"cannot compare live QEMU executable: {error}") from error
+    if not same_binary:
+        raise CalibrationError("live QEMU executable differs from qemu_binary artifact")
+
+
+def require_pidfd_alive(pidfd: int) -> None:
+    readable, _, _ = select.select([pidfd], [], [], 0)
+    if readable:
+        raise CalibrationError("QEMU exited before calibration postflight")
+
+
+def option_values(argv: list[str] | tuple[str, ...], option: str) -> list[str]:
+    values: list[str] = []
+    for index, item in enumerate(argv):
+        if item == option:
+            if index + 1 >= len(argv) or argv[index + 1].startswith("-"):
+                raise CalibrationError(f"QEMU option {option} lacks a value")
+            values.append(argv[index + 1])
+    return values
+
+
+def unique_option(argv: list[str] | tuple[str, ...], option: str) -> str:
+    values = option_values(argv, option)
+    if len(values) != 1:
+        raise CalibrationError(f"QEMU calibration requires exactly one {option} option")
+    return values[0]
+
+
+def comma_fields(text: str, label: str) -> tuple[str, dict[str, str]]:
+    parts = text.split(",")
+    base = "" if "=" in parts[0] else parts[0]
+    fields: dict[str, str] = {}
+    for part in parts[0 if not base else 1:]:
+        if "=" not in part:
+            fields[part] = ""
+            continue
+        key, value = part.split("=", 1)
+        if not key or not value or key in fields:
+            raise CalibrationError(f"invalid or duplicate {label} field: {part}")
+        fields[key] = value
+    return base, fields
+
+
+def resolve_qemu_path(cwd: str, text: str, label: str) -> Path:
+    if "," in text:
+        raise CalibrationError(f"{label} path must not contain commas")
+    path = Path(text)
+    return (Path(cwd) / path).resolve() if not path.is_absolute() else path.resolve()
+
+
+def validate_qemu_policy(argv: list[str] | tuple[str, ...], cwd: str, accel: str, vcpus: int,
+                         kernel: Path, disk: Path, serial_socket: Path) -> None:
+    for forbidden in ("-S", "-d", "-trace", "-icount"):
+        if forbidden in argv:
+            raise CalibrationError(f"QEMU calibration forbids {forbidden}")
+    smp, smp_fields = comma_fields(unique_option(argv, "-smp"), "SMP")
+    if not smp.isdecimal() or int(smp) != vcpus:
+        raise CalibrationError("QEMU -smp does not match the claimed vCPU count")
+    if set(smp_fields) != {"cores", "threads", "sockets"} or any(
+            not value.isdecimal() or int(value) <= 0 for value in smp_fields.values()):
+        raise CalibrationError("QEMU calibration requires a complete positive SMP topology")
+    if int(smp_fields["cores"]) * int(smp_fields["threads"]) * int(smp_fields["sockets"]) != vcpus:
+        raise CalibrationError("QEMU SMP topology product differs from the vCPU count")
+    _, machine = comma_fields(unique_option(argv, "-machine"), "machine")
+    if machine.get("accel") != accel:
+        raise CalibrationError("QEMU machine accelerator differs from the claimed accelerator")
+    enable_kvm = sum(item == "-enable-kvm" for item in argv)
+    if (accel == "kvm" and enable_kvm != 1) or (accel != "kvm" and enable_kvm != 0):
+        raise CalibrationError("QEMU -enable-kvm does not match the claimed accelerator")
+    kernel_path = resolve_qemu_path(cwd, unique_option(argv, "-kernel"), "kernel")
+    if kernel_path != kernel.resolve():
+        raise CalibrationError("QEMU -kernel differs from the kernel artifact")
+    disk_matches = []
+    for drive in option_values(argv, "-drive"):
+        _, fields = comma_fields(drive, "drive")
+        if fields.get("id") == "disk":
+            disk_matches.append(fields)
+    if len(disk_matches) != 1:
+        raise CalibrationError("QEMU calibration requires exactly one id=disk drive")
+    disk_fields = disk_matches[0]
+    if disk_fields.get("snapshot") != "on" or "file" not in disk_fields:
+        raise CalibrationError("QEMU calibration disk must use snapshot=on")
+    disk_path = resolve_qemu_path(cwd, disk_fields["file"], "disk")
+    if disk_path != disk.resolve():
+        raise CalibrationError("QEMU disk differs from the disk artifact")
+    if unique_option(argv, "-serial") != "none" or unique_option(argv, "-monitor") != "none":
+        raise CalibrationError("QEMU calibration requires serial and monitor to be disabled")
+    _, rtc = comma_fields(unique_option(argv, "-rtc"), "RTC")
+    if rtc.get("clock") != "host":
+        raise CalibrationError("QEMU calibration requires an RTC driven by the host clock")
+    chardevs = option_values(argv, "-chardev")
+    if len(chardevs) != 1:
+        raise CalibrationError("QEMU calibration requires exactly one chardev")
+    backend, chardev = comma_fields(chardevs[0], "chardev")
+    if (backend != "socket" or chardev.get("server") != "on" or
+            chardev.get("wait") != "off" or "mux" in chardev or "path" not in chardev):
+        raise CalibrationError("QEMU calibration chardev policy is invalid")
+    if resolve_qemu_path(cwd, chardev["path"], "serial socket") != serial_socket.resolve():
+        raise CalibrationError("QEMU chardev path differs from the requested serial socket")
+    chardev_id = chardev.get("id")
+    devices = option_values(argv, "-device")
+    if sum(device.startswith("virtconsole,") and f"chardev={chardev_id}" in device.split(",")
+           for device in devices) != 1:
+        raise CalibrationError("QEMU virtconsole does not reference the calibration chardev")
+
+
+def qemu_affinity_snapshot(pid: int, allowed: set[int]) -> list[dict[str, Any]]:
+    task_root = Path(f"/proc/{pid}/task")
+    if not task_root.is_dir():
+        raise CalibrationError(f"QEMU pid is not running: {pid}")
+    snapshots: list[dict[str, Any]] = []
+    for task in sorted(task_root.iterdir(), key=lambda path: int(path.name)):
+        try:
+            comm = (task / "comm").read_text(encoding="utf-8").strip()
+            status = (task / "status").read_text(encoding="utf-8")
+        except OSError as error:
+            raise CalibrationError(f"cannot snapshot QEMU task {task.name}: {error}") from error
+        match = re.search(r"^Cpus_allowed_list:\s*(\S+)\s*$", status, re.MULTILINE)
+        if match is None:
+            raise CalibrationError(f"QEMU task {task.name} lacks Cpus_allowed_list")
+        actual = parse_cpu_list(match.group(1))
+        if not actual or not actual.issubset(allowed):
+            raise CalibrationError(
+                f"QEMU task {task.name} affinity {sorted(actual)} is outside expected {sorted(allowed)}"
+            )
+        snapshots.append({"tid": int(task.name), "comm": comm, "affinity": sorted(actual)})
+    if not snapshots:
+        raise CalibrationError("QEMU process has no observable tasks")
+    return snapshots
+
+
+def case_timeout_ns(case: dict[str, Any], accel: str) -> int:
+    target = int(case["target_ns"])
+    if case["mode"] == "reads":
+        # DragonOS currently services clock_gettime through a syscall rather
+        # than a vDSO.  Two domains x 10^7 reads take several minutes and must
+        # not be accidentally classified as a transport timeout.
+        return (600 if accel == "kvm" else 3600) * 1_000_000_000
+    if accel == "kvm":
+        return (30 if target <= 10_000_000_000 else 90) * 1_000_000_000
+    return max(180_000_000_000, target * 3)
+
+
+def run_case(transport: SerialTransport, run_id: str, seq: int, spec: dict[str, Any],
+             accel: str, vcpus: int) -> dict[str, Any]:
+    case_id = spec["case_id"]
+    timeout = case_timeout_ns(spec, accel)
+    command = (
+        f"START run={run_id} seq={seq} case={case_id} mode={spec['mode']} "
+        f"target_ns={spec['target_ns']} affinity={spec['affinity']} reads={spec['reads']}"
+    )
+    slo = raw_now_ns()
+    transport.send_line(command)
+    start = transport.read_event("START", run_id, seq, case_id, 10_000_000_000)
+    shi = raw_now_ns()
+    work_done = transport.read_event("WORK_DONE", run_id, seq, case_id, timeout)
+    elo = raw_now_ns()
+    transport.send_line(f"END run={run_id} seq={seq}")
+    end = transport.read_event("END", run_id, seq, case_id, 10_000_000_000)
+    ehi = raw_now_ns()
+    start = stored_event("START", start.fields, START_FIELDS)
+    work_done = stored_event("WORK_DONE", work_done.fields, WORK_DONE_FIELDS)
+    end = stored_event("END", end.fields, END_FIELDS)
+    ready = transport.read_event("READY", run_id, seq, None, 10_000_000_000)
+    validate_ready(ready, vcpus)
+
+    bracket = {"slo_ns": slo, "shi_ns": shi, "elo_ns": elo, "ehi_ns": ehi}
+    status, reasons, metrics = evaluate_case_evidence(
+        spec, accel, vcpus, start, work_done, end, bracket
+    )
+    return {
+        **spec,
+        "seq": seq,
+        "status": status,
+        "reasons": reasons,
+        "guest": {"start": start.fields, "work_done": work_done.fields, "end": end.fields},
+        "host_bracket": bracket,
+        "metrics": public_metrics(metrics),
+    }
+
+
+def finalize_vm_status(cases: list[dict[str, Any]], thresholds: Thresholds) -> tuple[str, list[str]]:
+    incomplete = [f"case_incomplete:{case['case_id']}" for case in cases
+                  if case["status"] == "incomplete"]
+    failed = [f"case_failed:{case['case_id']}" for case in cases if case["status"] == "fail"]
+    if incomplete:
+        return "incomplete", sorted(set(incomplete + failed))
+    if failed:
+        return "fail", sorted(set(failed))
+    dispersion = evaluate_dispersion(cases, thresholds)
+    return ("pass" if not dispersion else "fail", sorted(set(dispersion)))
+
+
+def load_qemu_argv(path: Path) -> list[str]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CalibrationError(f"cannot read QEMU argv JSON {path}: {error}") from error
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+        raise CalibrationError("QEMU argv JSON must be a non-empty string array")
+    return value
+
+
+def run_vm(args: argparse.Namespace) -> int:
+    run_id = args.run_id or secrets.token_hex(16)
+    if not HEX128.fullmatch(run_id):
+        raise CalibrationError("run-id must be exactly 32 lowercase hexadecimal characters")
+    if args.boot_timeout <= 0 or args.boot_timeout > 3600:
+        raise CalibrationError("boot-timeout must be in the range 1..3600 seconds")
+    if args.host_cpu < 0 or args.host_cpu > MAX_CPU_ID:
+        raise CalibrationError("host CPU is outside calibration limits")
+    if args.qemu_pid <= 0:
+        raise CalibrationError("QEMU pid must be positive")
+    artifact_store = validate_artifact_store(args.artifact_store)
+    output = args.output.resolve()
+    create_output_dir(output)
+    base: dict[str, Any] = {
+        "schema": SCHEMA,
+        "run_id": run_id,
+        "created_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "status": "incomplete",
+        "accel": args.accel,
+        "vcpus": args.vcpus,
+        "thresholds": Thresholds.for_accel(args.accel).as_json(),
+        "cases": [],
+        "reasons": [],
+    }
+    result_path = output / "result.json"
+    transcript_path = output / "serial.raw"
+    pidfd: int | None = None
+    try:
+        qemu_cpus = parse_cpu_list(args.qemu_cpus)
+        if args.host_cpu in qemu_cpus:
+            raise CalibrationError("host orchestrator CPU must not overlap QEMU CPUs")
+        try:
+            os.sched_setaffinity(0, {args.host_cpu})
+        except OSError as error:
+            raise CalibrationError(f"cannot pin host orchestrator to CPU {args.host_cpu}: {error}") from error
+        qemu_argv = load_qemu_argv(args.qemu_argv_json)
+        qemu_binary_text = shutil.which(qemu_argv[0]) or qemu_argv[0]
+        artifact_paths = {
+            "kernel": args.kernel_artifact,
+            "disk_image": args.disk_artifact,
+            "guest_helper": args.helper_artifact,
+            "host_runner": Path(__file__).resolve(),
+            "qemu_argv": args.qemu_argv_json,
+            "qemu_binary": Path(qemu_binary_text),
+        }
+        for artifact in artifact_paths.values():
+            if not artifact.is_file() or artifact.is_symlink():
+                raise CalibrationError(f"required regular non-symlink artifact is missing: {artifact}")
+        try:
+            pidfd = os.pidfd_open(args.qemu_pid, 0)
+        except OSError as error:
+            raise CalibrationError(f"cannot open QEMU pidfd: {error}") from error
+        process_identity = capture_process_identity(args.qemu_pid)
+        require_pidfd_alive(pidfd)
+        validate_process_identity(process_identity, qemu_argv, artifact_paths["qemu_binary"])
+        validate_qemu_policy(
+            qemu_argv, process_identity.cwd, args.accel, args.vcpus,
+            args.kernel_artifact, args.disk_artifact, args.serial_socket,
+        )
+        base["qemu"] = {
+            "argv": qemu_argv,
+            "argv_source": str(args.qemu_argv_json.resolve()),
+            "serial_socket": str(args.serial_socket.resolve()),
+        }
+        base.update(provenance(qemu_argv))
+        base["host"]["requested_cpu"] = args.host_cpu
+        base["qemu"]["pid"] = args.qemu_pid
+        base["qemu"]["requested_cpus"] = sorted(qemu_cpus)
+        base["qemu"]["task_affinity"] = qemu_affinity_snapshot(args.qemu_pid, qemu_cpus)
+        base["qemu"]["process_identity"] = process_identity.as_json()
+        base["build_artifacts"] = {
+            name: archive_artifact(path, artifact_store) for name, path in artifact_paths.items()
+        }
+        with transcript_path.open("xb") as transcript:
+            transport = SerialTransport(args.serial_socket, transcript)
+            try:
+                prompt_deadline = raw_now_ns() + args.boot_timeout * 1_000_000_000
+                prompt = re.compile(args.prompt)
+                transport.wait_for_prompt(prompt, prompt_deadline)
+                command = args.guest_command.format(run_id=run_id)
+                if "\n" in command or "\r" in command:
+                    raise CalibrationError("guest command must be one line")
+                transport.send_line(command)
+                ready = transport.read_event("READY", run_id, 0, None, 10_000_000_000)
+                validate_ready(ready, args.vcpus)
+                seq = 1
+                cases: list[dict[str, Any]] = []
+                base["cases"] = cases
+                for spec in expected_cases(args.vcpus):
+                    if "predefined_skip" in spec:
+                        cases.append({**spec, "seq": seq, "status": "skip", "reasons": [spec["predefined_skip"]]})
+                        continue
+                    cases.append(run_case(transport, run_id, seq, spec, args.accel, args.vcpus))
+                    seq += 1
+                transport.send_line(f"QUIT run={run_id} seq={seq}")
+                ack = transport.read_event("ACK", run_id, seq, None, SOCKET_IO_TIMEOUT_NS)
+                validate_ack(ack, run_id, seq)
+                base["shutdown_ack"] = ack.fields
+                base["status"], base["reasons"] = finalize_vm_status(
+                    cases, Thresholds.for_accel(args.accel)
+                )
+            finally:
+                transport.close()
+        for name, artifact in artifact_paths.items():
+            current = artifact_record(artifact)
+            archived = base["build_artifacts"][name]
+            if (current["sha256"] != archived["sha256"] or current["size"] != archived["size"] or
+                    str(artifact.resolve()) != archived["execution_path"]):
+                raise CalibrationError(f"build artifact changed during calibration: {artifact}")
+        require_pidfd_alive(pidfd)
+        process_identity_after = capture_process_identity(args.qemu_pid)
+        if process_identity_after != process_identity:
+            raise CalibrationError("QEMU process identity changed during calibration")
+        validate_process_identity(process_identity_after, qemu_argv, artifact_paths["qemu_binary"])
+        base["qemu"]["task_affinity_after"] = qemu_affinity_snapshot(args.qemu_pid, qemu_cpus)
+        base["qemu"]["lifecycle"] = {
+            "alive_after_calibration": True,
+            "termination_owner": "external_launcher",
+            "guest_helper_shutdown": "quit_ack",
+        }
+        verify_transcript_session(base, parse_transcript(transcript_path))
+    except (CalibrationError, OSError, ValueError) as error:
+        base["status"] = "incomplete"
+        base["reasons"] = [str(error)]
+    finally:
+        if pidfd is not None:
+            os.close(pidfd)
+        if transcript_path.exists():
+            base["serial"] = artifact_record(transcript_path)
+        write_json_new(result_path, base)
+        sums = [result_path]
+        if transcript_path.exists():
+            sums.append(transcript_path)
+        with (output / "sha256sums.txt").open("x", encoding="ascii") as index:
+            for path in sums:
+                index.write(f"{sha256_file(path)}  {path.name}\n")
+    return 0 if base["status"] == "pass" else 1 if base["status"] == "fail" else 2
+
+
+START_FIELDS = {"run", "seq", "case", "guest_raw_ns", "guest_mono_ns", "cpu", "status"}
+WORK_DONE_FIELDS = {
+    "run", "seq", "case", "status", "reason", "work_end_raw_ns", "work_end_mono_ns",
+    "checksum", "raw_reads", "mono_reads", "raw_regressions", "mono_regressions",
+    "raw_max_backward_ns", "mono_max_backward_ns", "migrations_requested",
+    "migrations_observed", "cpu_mask_seen",
+}
+END_FIELDS = START_FIELDS
+VM_TOP_LEVEL_FIELDS = {
+    "schema", "run_id", "created_utc", "status", "accel", "vcpus", "thresholds", "cases",
+    "reasons", "qemu", "repo", "host", "qemu_version", "build_artifacts", "serial",
+    "shutdown_ack",
+}
+
+
+def require_exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        missing = sorted(expected - set(value))
+        extra = sorted(set(value) - expected)
+        raise CalibrationError(f"{label} schema mismatch (missing={missing}, extra={extra})")
+
+
+def stored_event(kind: str, value: Any, expected_fields: set[str]) -> Event:
+    if not isinstance(value, dict) or not all(isinstance(key, str) and isinstance(item, str)
+                                               for key, item in value.items()):
+        raise CalibrationError(f"stored {kind} event must be a string map")
+    require_exact_keys(value, expected_fields, f"stored {kind}")
+    if value["status"] not in ("ok", "fail"):
+        raise CalibrationError(f"stored {kind} has invalid status")
+    event = Event(kind, value, "")
+    numeric = ({"seq", "guest_raw_ns", "guest_mono_ns"} if kind in ("START", "END") else {
+        "seq", "work_end_raw_ns", "work_end_mono_ns", "raw_reads", "mono_reads",
+        "raw_regressions", "mono_regressions", "raw_max_backward_ns", "mono_max_backward_ns",
+        "migrations_requested", "migrations_observed",
+    })
+    for name in numeric:
+        uint_field(event, name)
+    if kind in ("START", "END"):
+        cpu = value["cpu"]
+        if not cpu or (cpu[0] == "-" and not cpu[1:].isdecimal()) or (cpu[0] != "-" and not cpu.isdecimal()):
+            raise CalibrationError(f"stored {kind} CPU is not an integer")
+    else:
+        if not re.fullmatch(r"[0-9a-f]{16}", value["checksum"]):
+            raise CalibrationError("stored WORK_DONE checksum is not 64-bit hexadecimal")
+        if not re.fullmatch(r"[0-9a-f]{16}", value["cpu_mask_seen"]):
+            raise CalibrationError("stored WORK_DONE CPU mask is not 64-bit hexadecimal")
+    return event
+
+
+def stored_bracket(value: Any) -> dict[str, int]:
+    expected = {"slo_ns", "shi_ns", "elo_ns", "ehi_ns"}
+    if not isinstance(value, dict):
+        raise CalibrationError("stored host bracket must be an object")
+    require_exact_keys(value, expected, "stored host bracket")
+    for name in expected:
+        number = value[name]
+        if isinstance(number, bool) or not isinstance(number, int) or number < 0 or number > (1 << 64) - 1:
+            raise CalibrationError(f"stored host bracket field is not u64: {name}")
+    return value
+
+
+def verify_artifact_record(value: Any, label: str) -> tuple[str, str, int]:
+    if not isinstance(value, dict):
+        raise CalibrationError(f"{label} artifact record must be an object")
+    require_exact_keys(value, {"path", "sha256", "size"}, f"{label} artifact")
+    path_text, digest, size = value["path"], value["sha256"], value["size"]
+    if (not isinstance(path_text, str) or not path_text or not isinstance(digest, str) or
+            not HEX256.fullmatch(digest) or isinstance(size, bool) or not isinstance(size, int) or size < 0):
+        raise CalibrationError(f"{label} artifact record has invalid field types")
+    path = Path(path_text)
+    if not path.is_file() or path.is_symlink():
+        raise CalibrationError(f"{label} artifact is missing or not a regular file: {path}")
+    actual_size = path.stat().st_size
+    actual_digest = sha256_file(path)
+    if actual_size != size or actual_digest != digest:
+        raise CalibrationError(f"{label} artifact digest or size mismatch: {path}")
+    return path_text, digest, size
+
+
+def verify_archived_artifact(value: Any, label: str) -> tuple[str, str, str, int]:
+    if not isinstance(value, dict):
+        raise CalibrationError(f"{label} archived artifact must be an object")
+    require_exact_keys(
+        value, {"execution_path", "archive_path", "sha256", "size"},
+        f"{label} archived artifact",
+    )
+    execution, archive_text, digest, size = (
+        value["execution_path"], value["archive_path"], value["sha256"], value["size"]
+    )
+    if (not isinstance(execution, str) or not Path(execution).is_absolute() or
+            not isinstance(archive_text, str) or not Path(archive_text).is_absolute() or
+            not isinstance(digest, str) or not HEX256.fullmatch(digest) or
+            isinstance(size, bool) or not isinstance(size, int) or size < 0):
+        raise CalibrationError(f"{label} archived artifact has invalid fields")
+    archive = Path(archive_text)
+    if (archive.name != digest or not archive.is_file() or archive.is_symlink() or
+            archive.stat().st_mode & 0o222 != 0 or archive.stat().st_size != size or
+            sha256_file(archive) != digest):
+        raise CalibrationError(f"{label} content-addressed artifact is invalid: {archive}")
+    return execution, archive_text, digest, size
+
+
+def verify_task_snapshots(value: Any, allowed: set[int], label: str) -> None:
+    if not isinstance(value, list) or not value:
+        raise CalibrationError(f"{label} must be a non-empty array")
+    tids: set[int] = set()
+    for snapshot in value:
+        if not isinstance(snapshot, dict):
+            raise CalibrationError(f"{label} entry must be an object")
+        require_exact_keys(snapshot, {"tid", "comm", "affinity"}, f"{label} entry")
+        tid, comm, affinity = snapshot["tid"], snapshot["comm"], snapshot["affinity"]
+        if (isinstance(tid, bool) or not isinstance(tid, int) or tid <= 0 or tid in tids or
+                not isinstance(comm, str) or not comm or not isinstance(affinity, list) or
+                not affinity or any(isinstance(cpu, bool) or not isinstance(cpu, int)
+                                    for cpu in affinity) or not set(affinity).issubset(allowed)):
+            raise CalibrationError(f"{label} entry has invalid fields")
+        tids.add(tid)
+
+
+def verify_provenance_schema(value: dict[str, Any]) -> None:
+    qemu, repo, host = value["qemu"], value["repo"], value["host"]
+    require_exact_keys(qemu, {"argv", "argv_source", "serial_socket", "pid", "requested_cpus",
+                              "task_affinity", "task_affinity_after", "process_identity",
+                              "lifecycle"}, "QEMU provenance")
+    if (not isinstance(qemu["argv"], list) or not qemu["argv"] or
+            not all(isinstance(item, str) and item for item in qemu["argv"]) or
+            not isinstance(qemu["argv_source"], str) or not Path(qemu["argv_source"]).is_absolute() or
+            not isinstance(qemu["serial_socket"], str) or not Path(qemu["serial_socket"]).is_absolute() or
+            isinstance(qemu["pid"], bool) or not isinstance(qemu["pid"], int) or qemu["pid"] <= 0 or
+            not isinstance(qemu["requested_cpus"], list) or not qemu["requested_cpus"] or
+            any(isinstance(cpu, bool) or not isinstance(cpu, int) for cpu in qemu["requested_cpus"])):
+        raise CalibrationError("QEMU provenance has invalid field types")
+    requested = set(qemu["requested_cpus"])
+    if len(requested) != len(qemu["requested_cpus"]) or len(requested) > MAX_CPU_COUNT or \
+            min(requested) < 0 or max(requested) > MAX_CPU_ID:
+        raise CalibrationError("QEMU requested CPU evidence is invalid")
+    verify_task_snapshots(qemu["task_affinity"], requested, "QEMU pre-run task affinity")
+    verify_task_snapshots(qemu["task_affinity_after"], requested, "QEMU post-run task affinity")
+    process = qemu["process_identity"]
+    if not isinstance(process, dict):
+        raise CalibrationError("QEMU process identity must be an object")
+    require_exact_keys(process, {"pid", "starttime_ticks", "exe", "cwd", "cmdline_sha256"},
+                       "QEMU process identity")
+    encoded_argv = b"\0".join(os.fsencode(item) for item in qemu["argv"]) + b"\0"
+    if (process["pid"] != qemu["pid"] or isinstance(process["starttime_ticks"], bool) or
+            not isinstance(process["starttime_ticks"], int) or process["starttime_ticks"] <= 0 or
+            not isinstance(process["exe"], str) or not Path(process["exe"]).is_absolute() or
+            not isinstance(process["cwd"], str) or not Path(process["cwd"]).is_absolute() or
+            process["cmdline_sha256"] != hashlib.sha256(encoded_argv).hexdigest()):
+        raise CalibrationError("QEMU process identity evidence is invalid")
+    if qemu["lifecycle"] != {
+        "alive_after_calibration": True,
+        "termination_owner": "external_launcher",
+        "guest_helper_shutdown": "quit_ack",
+    }:
+        raise CalibrationError("QEMU lifecycle evidence is invalid")
+
+    require_exact_keys(repo, {"commit", "tree", "dirty", "status_sha256", "tracked_diff_sha256",
+                              "untracked_content_sha256"},
+                       "repository provenance")
+    if (not isinstance(repo["commit"], str) or not isinstance(repo["tree"], str) or
+            not isinstance(repo["dirty"], bool) or not isinstance(repo["status_sha256"], str) or
+            not HEX256.fullmatch(repo["status_sha256"]) or
+            not isinstance(repo["tracked_diff_sha256"], str) or
+            not HEX256.fullmatch(repo["tracked_diff_sha256"]) or
+            not isinstance(repo["untracked_content_sha256"], str) or
+            not HEX256.fullmatch(repo["untracked_content_sha256"])):
+        raise CalibrationError("repository provenance has invalid field types")
+
+    require_exact_keys(host, {"platform", "python", "affinity", "clock_monotonic_raw_resolution_ns",
+                              "requested_cpu"}, "host provenance")
+    if (not isinstance(host["platform"], str) or not isinstance(host["python"], str) or
+            not isinstance(host["affinity"], list) or not host["affinity"] or
+            any(isinstance(cpu, bool) or not isinstance(cpu, int) for cpu in host["affinity"]) or
+            isinstance(host["clock_monotonic_raw_resolution_ns"], bool) or
+            not isinstance(host["clock_monotonic_raw_resolution_ns"], int) or
+            host["clock_monotonic_raw_resolution_ns"] <= 0 or
+            isinstance(host["requested_cpu"], bool) or not isinstance(host["requested_cpu"], int) or
+            host["requested_cpu"] < 0 or host["requested_cpu"] > MAX_CPU_ID or
+            host["requested_cpu"] in requested):
+        raise CalibrationError("host provenance has invalid field types or CPU isolation")
+
+
+def verify_result_index(result_path: Path, serial_record: dict[str, Any]) -> None:
+    if result_path.name != "result.json":
+        raise CalibrationError(f"VM result must be named result.json: {result_path}")
+    serial_path = Path(serial_record["path"])
+    if serial_path.name != "serial.raw":
+        raise CalibrationError("serial artifact must be named serial.raw")
+    index_path = result_path.parent / "sha256sums.txt"
+    try:
+        lines = index_path.read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise CalibrationError(f"cannot read VM artifact index {index_path}: {error}") from error
+    expected = [
+        f"{sha256_file(result_path)}  result.json",
+        f"{serial_record['sha256']}  serial.raw",
+    ]
+    if lines != expected:
+        raise CalibrationError(f"VM artifact index does not match result and serial: {index_path}")
+
+
+def verify_case(case: Any, spec: dict[str, Any], accel: str, vcpus: int,
+                run_id: str, seq: int) -> dict[str, Any]:
+    if not isinstance(case, dict):
+        raise CalibrationError(f"case {spec['case_id']} must be an object")
+    metadata = {"case_id", "mode", "target_ns", "affinity", "reads", "repetition"}
+    if "predefined_skip" in spec:
+        require_exact_keys(case, metadata | {"predefined_skip", "seq", "status", "reasons"},
+                           f"case {spec['case_id']}")
+        if any(case.get(name) != value for name, value in spec.items()):
+            raise CalibrationError(f"case metadata differs from frozen matrix: {spec['case_id']}")
+        if (case["seq"] != seq or case["status"] != "skip" or
+                case["reasons"] != [spec["predefined_skip"]]):
+            raise CalibrationError(f"predefined skip evidence is invalid: {spec['case_id']}")
+        return case
+
+    require_exact_keys(case, metadata | {"seq", "status", "reasons", "guest", "host_bracket",
+                                         "metrics"}, f"case {spec['case_id']}")
+    if any(case.get(name) != value for name, value in spec.items()) or case["seq"] != seq:
+        raise CalibrationError(f"case metadata differs from frozen matrix: {spec['case_id']}")
+    guest = case["guest"]
+    if not isinstance(guest, dict):
+        raise CalibrationError(f"case guest evidence must be an object: {spec['case_id']}")
+    require_exact_keys(guest, {"start", "work_done", "end"}, f"case guest {spec['case_id']}")
+    start = stored_event("START", guest["start"], START_FIELDS)
+    work_done = stored_event("WORK_DONE", guest["work_done"], WORK_DONE_FIELDS)
+    end = stored_event("END", guest["end"], END_FIELDS)
+    for event in (start, work_done, end):
+        validate_identity(event, event.kind, run_id, seq, spec["case_id"])
+    if work_done.fields["status"] == "ok" and work_done.fields["reason"] != "ok":
+        raise CalibrationError(f"successful WORK_DONE has a non-ok reason: {spec['case_id']}")
+    bracket = stored_bracket(case["host_bracket"])
+    status, reasons, metrics = evaluate_case_evidence(
+        spec, accel, vcpus, start, work_done, end, bracket
+    )
+    if case["status"] != status or case["reasons"] != reasons:
+        raise CalibrationError(f"stored case verdict differs from raw evidence: {spec['case_id']}")
+    if case["metrics"] != public_metrics(metrics):
+        raise CalibrationError(f"stored case metrics differ from raw evidence: {spec['case_id']}")
+    return case
+
+
+ARTIFACT_NAMES = (
+    "kernel", "disk_image", "guest_helper", "host_runner", "qemu_argv", "qemu_binary",
+)
+SHARED_ARTIFACT_NAMES = (
+    "kernel", "disk_image", "guest_helper", "host_runner", "qemu_binary",
+)
+
+
+def verify_vm_result(value: Any, result_path: Path) -> tuple[tuple[str, int], tuple[str, ...]]:
+    if not isinstance(value, dict):
+        raise CalibrationError(f"VM result must be an object: {result_path}")
+    require_exact_keys(value, VM_TOP_LEVEL_FIELDS, "VM result")
+    if value["schema"] != SCHEMA:
+        raise CalibrationError(f"incompatible VM result schema: {result_path}")
+    run_id, accel, vcpus = value["run_id"], value["accel"], value["vcpus"]
+    if not isinstance(run_id, str) or not HEX128.fullmatch(run_id):
+        raise CalibrationError(f"VM result has invalid run ID: {result_path}")
+    if accel not in ("kvm", "tcg") or vcpus not in (1, 2):
+        raise CalibrationError(f"invalid VM result identity: {result_path}")
+    if (not isinstance(value["created_utc"], str) or not isinstance(value["qemu_version"], str) or
+            not isinstance(value["qemu"], dict) or not isinstance(value["repo"], dict) or
+            not isinstance(value["host"], dict) or not isinstance(value["reasons"], list) or
+            not all(isinstance(reason, str) for reason in value["reasons"])):
+        raise CalibrationError(f"VM result has invalid top-level field types: {result_path}")
+    try:
+        dt.datetime.fromisoformat(value["created_utc"])
+    except ValueError as error:
+        raise CalibrationError(f"VM result creation time is invalid: {result_path}") from error
+    verify_provenance_schema(value)
+    if value["thresholds"] != Thresholds.for_accel(accel).as_json():
+        raise CalibrationError(f"VM result thresholds differ from frozen policy: {result_path}")
+    if not isinstance(value["cases"], list):
+        raise CalibrationError(f"VM result cases must be an array: {result_path}")
+    expected = expected_cases(vcpus)
+    if len(value["cases"]) != len(expected):
+        raise CalibrationError(f"VM result has an incomplete case matrix: {result_path}")
+    seq = 1
+    verified_cases: list[dict[str, Any]] = []
+    for case, spec in zip(value["cases"], expected):
+        verified_cases.append(verify_case(case, spec, accel, vcpus, run_id, seq))
+        if "predefined_skip" not in spec:
+            seq += 1
+    recomputed_status, recomputed_reasons = finalize_vm_status(
+        verified_cases, Thresholds.for_accel(accel)
+    )
+    if value["status"] != recomputed_status or value["reasons"] != recomputed_reasons:
+        raise CalibrationError(f"stored VM verdict differs from raw evidence: {result_path}")
+    if value["shutdown_ack"] != {"run": run_id, "seq": str(seq), "status": "ok"}:
+        raise CalibrationError(f"VM result lacks a valid shutdown ACK: {result_path}")
+    build = value["build_artifacts"]
+    if not isinstance(build, dict):
+        raise CalibrationError(f"VM result build artifacts must be an object: {result_path}")
+    require_exact_keys(build, set(ARTIFACT_NAMES), "build artifacts")
+    verified_artifacts = {
+        name: verify_archived_artifact(build[name], name) for name in ARTIFACT_NAMES
+    }
+    identity_hashes = tuple(verified_artifacts[name][2] for name in SHARED_ARTIFACT_NAMES)
+    qemu_argv_execution = Path(verified_artifacts["qemu_argv"][0])
+    qemu_argv_archive = Path(verified_artifacts["qemu_argv"][1])
+    if qemu_argv_execution != Path(value["qemu"]["argv_source"]) or \
+            load_qemu_argv(qemu_argv_archive) != value["qemu"]["argv"]:
+        raise CalibrationError(f"QEMU argv provenance differs from its artifact: {result_path}")
+    if Path(value["qemu"]["process_identity"]["exe"]) != Path(
+            verified_artifacts["qemu_binary"][0]):
+        raise CalibrationError(f"QEMU executable identity differs from its artifact: {result_path}")
+    validate_qemu_policy(
+        value["qemu"]["argv"], value["qemu"]["process_identity"]["cwd"], accel, vcpus,
+        Path(verified_artifacts["kernel"][0]), Path(verified_artifacts["disk_image"][0]),
+        Path(value["qemu"]["serial_socket"]),
+    )
+    serial = value["serial"]
+    serial_path, _, _ = verify_artifact_record(serial, "serial")
+    verify_transcript_session(value, parse_transcript(Path(serial_path)))
+    verify_result_index(result_path, serial)
+    return (accel, vcpus), identity_hashes
+
+
+def aggregate(args: argparse.Namespace) -> int:
+    output = args.output.resolve()
+    create_output_dir(output)
+    loaded: list[dict[str, Any]] = []
+    reasons: list[str] = []
+    saw_fail = False
+    saw_incomplete = False
+    seen: set[tuple[str, int]] = set()
+    artifact_sets: set[tuple[str, ...]] = set()
+    for path in args.vm_result:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+            identity, identity_hashes = verify_vm_result(value, path)
+            if identity in seen:
+                raise CalibrationError(f"duplicate VM result identity: {identity}")
+            seen.add(identity)
+            loaded.append({"source": str(path), "sha256": sha256_file(path), "result": value})
+            vm_status = value["status"]
+            if vm_status == "fail":
+                saw_fail = True
+                reasons.append(f"vm_not_pass:{identity[0]}-{identity[1]}")
+            elif vm_status == "incomplete":
+                saw_incomplete = True
+                reasons.append(f"vm_incomplete:{identity[0]}-{identity[1]}")
+            elif vm_status != "pass":
+                raise CalibrationError(f"invalid VM status in {path}")
+            artifact_sets.add(identity_hashes)
+        except (OSError, json.JSONDecodeError, CalibrationError) as error:
+            saw_incomplete = True
+            reasons.append(str(error))
+    missing = REQUIRED_VMS - seen
+    reasons.extend(f"missing_vm:{accel}-{vcpus}" for accel, vcpus in sorted(missing))
+    if len(artifact_sets) > 1:
+        reasons.append("vm_results_use_different_build_artifacts")
+        saw_incomplete = True
+    status = "pass"
+    if missing or saw_incomplete:
+        status = "incomplete"
+    elif saw_fail or reasons:
+        status = "fail"
+    result = {
+        "schema": SCHEMA,
+        "kind": "matrix-summary",
+        "created_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "status": status,
+        "required_vms": [{"accel": accel, "vcpus": vcpus} for accel, vcpus in sorted(REQUIRED_VMS)],
+        "reasons": sorted(set(reasons)),
+        "vm_results": loaded,
+    }
+    result_path = output / "result.json"
+    write_json_new(result_path, result)
+    (output / "sha256sums.txt").write_text(f"{sha256_file(result_path)}  result.json\n", encoding="ascii")
+    return 0 if status == "pass" else 1 if status == "fail" else 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run = subparsers.add_parser("run-vm", help="drive one already-started VM through a Unix serial socket")
+    run.add_argument("--output", type=Path, required=True)
+    run.add_argument("--serial-socket", type=Path, required=True)
+    run.add_argument("--qemu-argv-json", type=Path, required=True)
+    run.add_argument("--kernel-artifact", type=Path, required=True)
+    run.add_argument("--disk-artifact", type=Path, required=True)
+    run.add_argument("--helper-artifact", type=Path, required=True)
+    run.add_argument("--artifact-store", type=Path, required=True,
+                     help="existing private content-addressed input archive")
+    run.add_argument("--accel", choices=("kvm", "tcg"), required=True)
+    run.add_argument("--vcpus", type=int, choices=(1, 2), required=True)
+    run.add_argument("--host-cpu", type=int, required=True,
+                     help="dedicated CPU for the host protocol/bracket process")
+    run.add_argument("--qemu-pid", type=int, required=True)
+    run.add_argument("--qemu-cpus", required=True,
+                     help="expected non-overlapping QEMU affinity, for example 4-5")
+    run.add_argument("--run-id")
+    run.add_argument("--boot-timeout", type=int, default=180)
+    run.add_argument("--prompt", default=r"root@dragonos:.*#\s*$")
+    run.add_argument(
+        "--guest-command",
+        default="exec /opt/tests/timekeeping-calibration/timekeeping_calibration --run-id {run_id}",
+    )
+    run.set_defaults(function=run_vm)
+
+    merge = subparsers.add_parser("aggregate", help="strictly aggregate KVM1/KVM2/TCG2 VM artifacts")
+    merge.add_argument("--output", type=Path, required=True)
+    merge.add_argument("--vm-result", type=Path, action="append", required=True)
+    merge.set_defaults(function=aggregate)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.function(args)
+    except CalibrationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/timekeeping/calibrate.py
+++ b/tools/timekeeping/calibrate.py
@@ -418,7 +418,7 @@ class SerialTransport:
             self.sock.close()
             raise CalibrationError(
                 f"cannot connect to QEMU serial socket {path}; configure the general "
-                "DRAGONOS_QEMU_SERIAL_SOCKET interface before running calibration: {error}"
+                f"DRAGONOS_QEMU_SERIAL_SOCKET interface before running calibration: {error}"
             ) from error
         selector = None
         try:

--- a/tools/timekeeping/calibrate.py
+++ b/tools/timekeeping/calibrate.py
@@ -420,9 +420,17 @@ class SerialTransport:
                 f"cannot connect to QEMU serial socket {path}; configure the general "
                 "DRAGONOS_QEMU_SERIAL_SOCKET interface before running calibration: {error}"
             ) from error
-        self.sock.setblocking(False)
-        self.selector = selectors.DefaultSelector()
-        self.selector.register(self.sock, selectors.EVENT_READ)
+        selector = None
+        try:
+            self.sock.setblocking(False)
+            selector = selectors.DefaultSelector()
+            selector.register(self.sock, selectors.EVENT_READ)
+        except Exception:
+            if selector is not None:
+                selector.close()
+            self.sock.close()
+            raise
+        self.selector = selector
         self.buffer = bytearray()
         self.transcript_bytes = 0
 

--- a/tools/timekeeping/test_calibrate.py
+++ b/tools/timekeeping/test_calibrate.py
@@ -265,6 +265,26 @@ class ProtocolTests(unittest.TestCase):
             transport.close()
             right.close()
 
+    def test_transport_init_failure_closes_partial_resources(self) -> None:
+        transcript = io.BytesIO()
+
+        sock = mock.Mock()
+        sock.setblocking.side_effect = RuntimeError("setblocking failed")
+        with mock.patch.object(calibrate.socket, "socket", return_value=sock):
+            with self.assertRaisesRegex(RuntimeError, "setblocking failed"):
+                calibrate.SerialTransport(Path("serial.sock"), transcript)
+        sock.close.assert_called_once_with()
+
+        sock = mock.Mock()
+        selector = mock.Mock()
+        selector.register.side_effect = RuntimeError("register failed")
+        with mock.patch.object(calibrate.socket, "socket", return_value=sock), \
+                mock.patch.object(calibrate.selectors, "DefaultSelector", return_value=selector):
+            with self.assertRaisesRegex(RuntimeError, "register failed"):
+                calibrate.SerialTransport(Path("serial.sock"), transcript)
+        selector.close.assert_called_once_with()
+        sock.close.assert_called_once_with()
+
     def test_prompt_wait_retries_and_accepts_ansi_prompt_without_newline(self) -> None:
         left, right = socket.socketpair()
         transport = calibrate.SerialTransport.__new__(calibrate.SerialTransport)

--- a/tools/timekeeping/test_calibrate.py
+++ b/tools/timekeeping/test_calibrate.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import io
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import selectors
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import calibrate
+
+
+RUN_ID = "0123456789abcdef0123456789abcdef"
+
+
+def event_fields(kind: str, case_id: str, seq: int, guest_raw_ns: int,
+                 *, mode: str, affinity: str) -> dict[str, str]:
+    common = {"run": RUN_ID, "seq": str(seq), "case": case_id, "status": "ok"}
+    if kind in ("START", "END"):
+        return {**common, "guest_raw_ns": str(guest_raw_ns),
+                "guest_mono_ns": str(guest_raw_ns), "cpu": "0"}
+    reads = calibrate.READS_REQUIRED if mode == "reads" else 0
+    migrations = calibrate.MIGRATIONS_EXPECTED if affinity == "migrate" else 0
+    return {
+        **common,
+        "reason": "ok",
+        "work_end_raw_ns": str(guest_raw_ns),
+        "work_end_mono_ns": str(guest_raw_ns),
+        "checksum": "0000000000000000",
+        "raw_reads": str(reads),
+        "mono_reads": str(reads),
+        "raw_regressions": "0",
+        "mono_regressions": "0",
+        "raw_max_backward_ns": "0",
+        "mono_max_backward_ns": "0",
+        "migrations_requested": str(migrations),
+        "migrations_observed": str(migrations),
+        "cpu_mask_seen": "0000000000000003" if affinity == "migrate" else "0000000000000001",
+    }
+
+
+def evidence_case(spec: dict, accel: str, vcpus: int, seq: int) -> dict:
+    guest_start = 1_000_000_000
+    elapsed = spec["target_ns"] if spec["mode"] != "reads" else 1_000_000
+    guest_end = guest_start + elapsed
+    start = calibrate.Event(
+        "START", event_fields("START", spec["case_id"], seq, guest_start,
+                              mode=spec["mode"], affinity=spec["affinity"]), ""
+    )
+    work_done = calibrate.Event(
+        "WORK_DONE", event_fields("WORK_DONE", spec["case_id"], seq, guest_end,
+                                  mode=spec["mode"], affinity=spec["affinity"]), ""
+    )
+    end = calibrate.Event(
+        "END", event_fields("END", spec["case_id"], seq, guest_end,
+                            mode=spec["mode"], affinity=spec["affinity"]), ""
+    )
+    bracket = {"slo_ns": 100, "shi_ns": 100, "elo_ns": 100 + elapsed,
+               "ehi_ns": 100 + elapsed}
+    status, reasons, metrics = calibrate.evaluate_case_evidence(
+        spec, accel, vcpus, start, work_done, end, bracket
+    )
+    return {
+        **spec, "seq": seq, "status": status, "reasons": reasons,
+        "guest": {"start": start.fields, "work_done": work_done.fields, "end": end.fields},
+        "host_bracket": bracket, "metrics": calibrate.public_metrics(metrics),
+    }
+
+
+def evidence_cases(accel: str, vcpus: int) -> tuple[list[dict], int]:
+    cases = []
+    seq = 1
+    for spec in calibrate.expected_cases(vcpus):
+        if "predefined_skip" in spec:
+            cases.append({**spec, "seq": seq, "status": "skip",
+                          "reasons": [spec["predefined_skip"]]})
+        else:
+            cases.append(evidence_case(spec, accel, vcpus, seq))
+            seq += 1
+    return cases, seq
+
+
+class EvidenceFactory:
+    def __init__(self, root: Path):
+        self.root = root
+        self.store = root / "store"
+        self.store.mkdir(mode=0o700)
+        self.paths = {
+            name: root / f"artifact-{name}" for name in calibrate.ARTIFACT_NAMES
+            if name != "qemu_argv"
+        }
+        for name, path in self.paths.items():
+            path.write_bytes((name + "\n").encode())
+        self.shared_artifacts = {
+            name: calibrate.archive_artifact(path, self.store)
+            for name, path in self.paths.items()
+        }
+
+    def qemu_argv(self, accel: str, vcpus: int, serial_socket: Path) -> list[str]:
+        argv = [
+            str(self.paths["qemu_binary"]),
+            "-kernel", str(self.paths["kernel"]),
+            "-smp", f"{vcpus},cores={vcpus},threads=1,sockets=1",
+            "-machine", f"q35,accel={accel}",
+            "-rtc", "clock=host,base=localtime",
+            "-serial", "none", "-monitor", "none",
+            "-chardev", f"socket,id=calib_console,path={serial_socket},server=on,wait=off",
+            "-drive", f"id=disk,file={self.paths['disk_image']},if=none,format=raw,snapshot=on",
+            "-device", "virtconsole,chardev=calib_console",
+        ]
+        if accel == "kvm":
+            argv.append("-enable-kvm")
+        return argv
+
+    @staticmethod
+    def transcript(cases: list[dict], vcpus: int, next_seq: int) -> bytes:
+        cpus = "0" if vcpus == 1 else "0,1"
+        lines = [f"{calibrate.PROTOCOL} READY run={RUN_ID} seq=0 cpus={cpus}"]
+        for case in cases:
+            if case["status"] == "skip":
+                continue
+            for kind, name in (("START", "start"), ("WORK_DONE", "work_done"),
+                               ("END", "end")):
+                fields = " ".join(f"{key}={value}" for key, value in case["guest"][name].items())
+                lines.append(f"{calibrate.PROTOCOL} {kind} {fields}")
+            lines.append(f"{calibrate.PROTOCOL} READY run={RUN_ID} seq={case['seq']} cpus={cpus}")
+        lines.append(f"{calibrate.PROTOCOL} ACK run={RUN_ID} seq={next_seq} status=ok")
+        return ("boot line\n" + "\n".join(lines) + "\n").encode()
+
+    def write_vm(self, accel: str, vcpus: int) -> Path:
+        directory = self.root / f"{accel}-{vcpus}"
+        directory.mkdir()
+        serial = directory / "serial.raw"
+        cases, next_seq = evidence_cases(accel, vcpus)
+        serial.write_bytes(self.transcript(cases, vcpus, next_seq))
+        serial_socket = self.root / f"console-{accel}-{vcpus}.sock"
+        argv = self.qemu_argv(accel, vcpus, serial_socket)
+        qemu_argv_source = self.root / f"qemu-argv-{accel}-{vcpus}.json"
+        qemu_argv_source.write_text(json.dumps(argv), encoding="utf-8")
+        artifacts = dict(self.shared_artifacts)
+        artifacts["qemu_argv"] = calibrate.archive_artifact(qemu_argv_source, self.store)
+        status, reasons = calibrate.finalize_vm_status(cases, calibrate.Thresholds.for_accel(accel))
+        encoded_argv = b"\0".join(item.encode() for item in argv) + b"\0"
+        value = {
+            "schema": calibrate.SCHEMA,
+            "run_id": RUN_ID,
+            "created_utc": "2026-01-01T00:00:00+00:00",
+            "status": status,
+            "accel": accel,
+            "vcpus": vcpus,
+            "thresholds": calibrate.Thresholds.for_accel(accel).as_json(),
+            "cases": cases,
+            "reasons": reasons,
+            "qemu": {
+                "argv": argv,
+                "argv_source": str(qemu_argv_source),
+                "serial_socket": str(serial_socket),
+                "pid": 123,
+                "requested_cpus": [2],
+                "task_affinity": [{"tid": 123, "comm": "qemu", "affinity": [2]}],
+                "task_affinity_after": [{"tid": 123, "comm": "qemu", "affinity": [2]}],
+                "process_identity": {
+                    "pid": 123, "starttime_ticks": 1,
+                    "exe": str(self.paths["qemu_binary"]), "cwd": str(self.root),
+                    "cmdline_sha256": hashlib.sha256(encoded_argv).hexdigest(),
+                },
+                "lifecycle": {"alive_after_calibration": True,
+                              "termination_owner": "external_launcher",
+                              "guest_helper_shutdown": "quit_ack"},
+            },
+            "repo": {"commit": "test", "tree": "test", "dirty": False,
+                     "status_sha256": "a" * 64, "tracked_diff_sha256": "b" * 64,
+                     "untracked_content_sha256": "c" * 64},
+            "host": {"platform": "test", "python": "test", "affinity": [1],
+                     "clock_monotonic_raw_resolution_ns": 1, "requested_cpu": 1},
+            "qemu_version": "test",
+            "build_artifacts": artifacts,
+            "serial": calibrate.artifact_record(serial),
+            "shutdown_ack": {"run": RUN_ID, "seq": str(next_seq), "status": "ok"},
+        }
+        result = directory / "result.json"
+        result.write_text(json.dumps(value), encoding="utf-8")
+        self.reindex(result)
+        return result
+
+    @staticmethod
+    def reindex(result: Path) -> None:
+        value = json.loads(result.read_text(encoding="utf-8"))
+        (result.parent / "sha256sums.txt").write_text(
+            f"{calibrate.sha256_file(result)}  result.json\n"
+            f"{value['serial']['sha256']}  serial.raw\n", encoding="ascii"
+        )
+
+
+def rewrite_serial(result: Path, transform) -> dict:
+    value = json.loads(result.read_text(encoding="utf-8"))
+    serial = Path(value["serial"]["path"])
+    serial.write_bytes(transform(serial.read_bytes()))
+    value["serial"] = calibrate.artifact_record(serial)
+    result.write_text(json.dumps(value), encoding="utf-8")
+    EvidenceFactory.reindex(result)
+    return value
+
+
+class ProtocolTests(unittest.TestCase):
+    def test_ignores_non_protocol_output(self) -> None:
+        self.assertIsNone(calibrate.parse_event("kernel: booting\n"))
+
+    def test_parses_valid_event(self) -> None:
+        event = calibrate.parse_event(
+            f"{calibrate.PROTOCOL} START run={RUN_ID} seq=7 case=busy-10s-r1 guest_raw_ns=123 status=ok\n"
+        )
+        self.assertIsNotNone(event)
+        assert event is not None
+        calibrate.validate_identity(event, "START", RUN_ID, 7, "busy-10s-r1")
+        self.assertEqual(calibrate.uint_field(event, "guest_raw_ns"), 123)
+
+    def test_rejects_duplicate_bad_sequence_and_bad_ack(self) -> None:
+        with self.assertRaises(calibrate.ProtocolError):
+            calibrate.parse_event(f"{calibrate.PROTOCOL} END run=a seq=1 seq=1\n")
+        event = calibrate.parse_event(f"{calibrate.PROTOCOL} ACK run=run seq=2 status=ok extra=x\n")
+        assert event is not None
+        with self.assertRaises(calibrate.ProtocolError):
+            calibrate.validate_ack(event, "run", 2)
+        wrong_status = calibrate.parse_event(f"{calibrate.PROTOCOL} ACK run=run seq=2 status=fail\n")
+        assert wrong_status is not None
+        with self.assertRaises(calibrate.ProtocolError):
+            calibrate.validate_ack(wrong_status, "run", 2)
+
+    def test_rejects_u64_overflow(self) -> None:
+        event = calibrate.parse_event(f"{calibrate.PROTOCOL} END run=run seq={1 << 64}\n")
+        assert event is not None
+        with self.assertRaises(calibrate.ProtocolError):
+            calibrate.uint_field(event, "seq")
+
+    def test_transport_has_line_and_deadline_limits(self) -> None:
+        left, right = socket.socketpair()
+        transport = calibrate.SerialTransport.__new__(calibrate.SerialTransport)
+        transport.path = Path("socketpair")
+        transport.transcript = io.BytesIO()
+        transport.sock = left
+        transport.sock.setblocking(False)
+        transport.selector = selectors.DefaultSelector()
+        transport.selector.register(left, selectors.EVENT_READ)
+        transport.buffer = bytearray()
+        try:
+            with self.assertRaises(calibrate.CalibrationError):
+                transport.send_line("x", timeout_ns=0)
+            right.sendall(b"x" * (calibrate.MAX_SERIAL_LINE_BYTES + 1) + b"\n")
+            with self.assertRaises(calibrate.ProtocolError):
+                transport.read_line(calibrate.raw_now_ns() + 1_000_000_000)
+        finally:
+            transport.close()
+            right.close()
+
+    def test_prompt_wait_retries_and_accepts_ansi_prompt_without_newline(self) -> None:
+        left, right = socket.socketpair()
+        transport = calibrate.SerialTransport.__new__(calibrate.SerialTransport)
+        transport.path = Path("socketpair")
+        transport.transcript = io.BytesIO()
+        transport.sock = left
+        transport.sock.setblocking(False)
+        transport.selector = selectors.DefaultSelector()
+        transport.selector.register(left, selectors.EVENT_READ)
+        transport.buffer = bytearray()
+
+        def delayed_console() -> None:
+            received = bytearray()
+            while received.count(b"\n") < 2:
+                received.extend(right.recv(64))
+            right.sendall(
+                b"\x1b[01;32mroot@dragonos\x1b[00m:"
+                b"\x1b[01;34m~\x1b[00m# "
+            )
+
+        responder = threading.Thread(target=delayed_console)
+        responder.start()
+        try:
+            transport.wait_for_prompt(
+                re.compile(r"root@dragonos:.*#\s*$"),
+                calibrate.raw_now_ns() + 1_000_000_000,
+                retry_ns=1_000_000,
+            )
+            transcript = transport.transcript.getvalue()
+            self.assertGreaterEqual(transcript.count(b">>> \n"), 2)
+            self.assertIn(b"root@dragonos", transcript)
+        finally:
+            transport.close()
+            right.close()
+            responder.join(timeout=1)
+
+    def test_transcript_total_limit_is_enforced_offline_and_live(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.object(calibrate, "MAX_TRANSCRIPT_BYTES", 32):
+            transcript = Path(directory) / "serial.raw"
+            transcript.write_bytes(b"ordinary console output\n" * 2)
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.parse_transcript(transcript)
+
+            transport = calibrate.SerialTransport.__new__(calibrate.SerialTransport)
+            transport.transcript = io.BytesIO()
+            transport.transcript_bytes = 32
+            with self.assertRaises(calibrate.CalibrationError):
+                transport.write_transcript(b"x")
+
+
+class MetricsTests(unittest.TestCase):
+    def test_exact_ratio_and_bounds(self) -> None:
+        metrics = calibrate.compute_metrics(100, 110, 1010, 1020, 5000, 5900)
+        self.assertEqual(metrics["guest_delta_ns"], 900)
+        self.assertEqual(metrics["host_min_ns"], 900)
+        self.assertEqual(metrics["host_max_ns"], 920)
+        self.assertEqual(metrics["ratio_mid"], "0.989010989")
+
+    def test_rejects_noncausal_bracket_and_regression(self) -> None:
+        with self.assertRaises(calibrate.CalibrationError):
+            calibrate.compute_metrics(100, 200, 150, 300, 1, 2)
+        with self.assertRaises(calibrate.CalibrationError):
+            calibrate.compute_metrics(100, 110, 200, 210, 2, 1)
+
+    def test_kvm_interval_has_pass_fail_and_incomplete_states(self) -> None:
+        thresholds = calibrate.Thresholds.for_accel("kvm")
+        passing = calibrate.compute_metrics(0, 0, 1_000_000, 1_000_000, 0, 1_000_000)
+        self.assertEqual(calibrate.evaluate_ratio(passing, thresholds), ("pass", []))
+        below = calibrate.compute_metrics(0, 0, 1_000_000, 1_000_000, 0, 994_999)
+        self.assertEqual(calibrate.evaluate_ratio(below, thresholds)[0], "fail")
+        overlap = calibrate.compute_metrics(0, 10_000, 1_000_000, 1_010_000, 0, 1_000_000)
+        self.assertEqual(calibrate.evaluate_ratio(overlap, thresholds)[0], "incomplete")
+
+    def test_tcg_ratio_is_informational(self) -> None:
+        metrics = calibrate.compute_metrics(0, 0, 1_000_000, 1_000_000, 0, 500_000)
+        self.assertEqual(calibrate.evaluate_ratio(metrics, calibrate.Thresholds.for_accel("tcg")),
+                         ("pass", []))
+
+
+class VerdictTests(unittest.TestCase):
+    def test_read_verdict_requires_exact_counts_and_migration_evidence(self) -> None:
+        fields = event_fields("WORK_DONE", "reads", 1, 100,
+                              mode="reads", affinity="migrate")
+        event = calibrate.Event("WORK_DONE", fields, "")
+        self.assertEqual(calibrate.evaluate_read_fields(event, "migrate", 2), [])
+        fields["raw_reads"] = str(calibrate.READS_REQUIRED + 1)
+        self.assertIn("raw_reads_does_not_match_required_count",
+                      calibrate.evaluate_read_fields(event, "migrate", 2))
+
+    def test_expected_matrix_has_strict_vm_set_and_only_one_skip(self) -> None:
+        one = calibrate.expected_cases(1)
+        two = calibrate.expected_cases(2)
+        self.assertEqual(len(one), 22)
+        self.assertEqual(len(two), 22)
+        self.assertEqual(sum("predefined_skip" in case for case in one), 1)
+        self.assertEqual(sum("predefined_skip" in case for case in two), 0)
+        self.assertEqual(calibrate.REQUIRED_VMS, {("kvm", 1), ("kvm", 2), ("tcg", 2)})
+
+
+class ProcessAndQemuPolicyTests(unittest.TestCase):
+    def test_process_identity_and_pidfd_bind_a_live_process(self) -> None:
+        sleep = shutil.which("sleep")
+        self.assertIsNotNone(sleep)
+        assert sleep is not None
+        process = subprocess.Popen([sleep, "30"])
+        pidfd = None
+        try:
+            # Popen returns after fork and the child can still expose the
+            # transient pre-exec empty cmdline.  Retry until execve has
+            # published the stable identity that the production runner sees
+            # for an already-started QEMU.
+            identity = None
+            for _ in range(100):
+                try:
+                    candidate = calibrate.capture_process_identity(process.pid)
+                    if os.path.samefile(candidate.exe, sleep):
+                        identity = candidate
+                        break
+                except (calibrate.CalibrationError, OSError):
+                    pass
+                threading.Event().wait(0.01)
+            self.assertIsNotNone(identity)
+            assert identity is not None
+            self.assertEqual(identity.pid, process.pid)
+            self.assertGreater(identity.starttime_ticks, 0)
+            calibrate.validate_process_identity(identity, list(identity.argv), Path(sleep))
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.validate_process_identity(identity, [*identity.argv, "changed"], Path(sleep))
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.validate_process_identity(identity, list(identity.argv), Path(sys.executable))
+            pidfd = os.pidfd_open(process.pid, 0)
+            calibrate.require_pidfd_alive(pidfd)
+            process.terminate()
+            process.wait(timeout=5)
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.require_pidfd_alive(pidfd)
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                process.wait(timeout=5)
+            if pidfd is not None:
+                os.close(pidfd)
+
+    def test_qemu_policy_rejects_calibration_affecting_argv_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            factory = EvidenceFactory(root)
+            serial = root / "serial.sock"
+            argv = factory.qemu_argv("kvm", 2, serial)
+            args = (str(root), "kvm", 2, factory.paths["kernel"],
+                    factory.paths["disk_image"], serial)
+            calibrate.validate_qemu_policy(argv, *args)
+
+            def replace_value(option: str, value: str) -> list[str]:
+                changed = list(argv)
+                changed[changed.index(option) + 1] = value
+                return changed
+
+            scenarios = {
+                "wrong_smp": replace_value("-smp", "1,cores=1,threads=1,sockets=1"),
+                "incomplete_topology": replace_value("-smp", "2"),
+                "wrong_accelerator": replace_value("-machine", "q35,accel=tcg"),
+                "wrong_kernel": replace_value("-kernel", str(root / "other-kernel")),
+                "mutable_disk": replace_value(
+                    "-drive", f"id=disk,file={factory.paths['disk_image']},if=none,format=raw"),
+                "wrong_disk": replace_value(
+                    "-drive", f"id=disk,file={root / 'other-disk'},snapshot=on"),
+                "monitor_enabled": replace_value("-monitor", "stdio"),
+                "wrong_rtc": replace_value("-rtc", "clock=vm"),
+                "wrong_socket": replace_value(
+                    "-chardev", "socket,id=calib_console,path=/tmp/wrong,server=on,wait=off"),
+                "debug_stop": [*argv, "-S"],
+                "duplicate_smp": [*argv, "-smp", "2,cores=2,threads=1,sockets=1"],
+            }
+            for name, changed in scenarios.items():
+                with self.subTest(name=name), self.assertRaises(calibrate.CalibrationError):
+                    calibrate.validate_qemu_policy(changed, *args)
+
+
+class ArtifactTests(unittest.TestCase):
+    def test_untracked_source_hash_covers_names_and_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            subprocess.run(["git", "init", "-q", str(repo)], check=True)
+            source = repo / "new-source.rs"
+            source.write_text("first\n", encoding="utf-8")
+            first = calibrate.hash_untracked_content(repo)
+            source.write_text("second\n", encoding="utf-8")
+            second = calibrate.hash_untracked_content(repo)
+            source.rename(repo / "renamed-source.rs")
+            renamed = calibrate.hash_untracked_content(repo)
+            self.assertNotEqual(first, second)
+            self.assertNotEqual(second, renamed)
+
+    def test_cpu_list_parser_has_strict_bounds(self) -> None:
+        self.assertEqual(calibrate.parse_cpu_list("1,3-5"), {1, 3, 4, 5})
+        for invalid in ("5-3", "0-1000000000", str(calibrate.MAX_CPU_ID + 1)):
+            with self.subTest(invalid=invalid), self.assertRaises(calibrate.CalibrationError):
+                calibrate.parse_cpu_list(invalid)
+
+    def test_output_directory_is_never_overwritten(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "run"
+            calibrate.create_output_dir(output)
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.create_output_dir(output)
+
+    def test_invalid_run_id_does_not_reserve_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "run"
+            args = type("Args", (), {"output": output, "run_id": "BAD"})()
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.run_vm(args)
+            self.assertFalse(output.exists())
+
+    def test_complete_raw_matrix_aggregates(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            factory = EvidenceFactory(root)
+            paths = [factory.write_vm(accel, vcpus)
+                     for accel, vcpus in sorted(calibrate.REQUIRED_VMS)]
+            args = type("Args", (), {"output": root / "aggregate", "vm_result": paths})()
+            self.assertEqual(calibrate.aggregate(args), 0)
+
+    def test_archived_inputs_survive_execution_tree_removal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            factory = EvidenceFactory(root)
+            result = factory.write_vm("kvm", 1)
+            value = json.loads(result.read_text(encoding="utf-8"))
+            for record in value["build_artifacts"].values():
+                Path(record["execution_path"]).unlink()
+            calibrate.verify_vm_result(value, result)
+
+    def test_archive_is_content_addressed_reused_and_read_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = root / "store"
+            store.mkdir(mode=0o700)
+            source = root / "source"
+            source.write_bytes(b"immutable input\n")
+            first = calibrate.archive_artifact(source, store)
+            second = calibrate.archive_artifact(source, store)
+            self.assertEqual(first, second)
+            archive = Path(first["archive_path"])
+            self.assertEqual(archive.name, first["sha256"])
+            self.assertEqual(archive.stat().st_mode & 0o222, 0)
+            source.unlink()
+            calibrate.verify_archived_artifact(first, "test")
+
+    def test_serial_protocol_and_json_are_strictly_bound(self) -> None:
+        def remove_first(data: bytes, prefix: bytes) -> bytes:
+            lines = data.splitlines(keepends=True)
+            index = next(i for i, line in enumerate(lines) if line.startswith(prefix))
+            del lines[index]
+            return b"".join(lines)
+
+        def duplicate_first(data: bytes, prefix: bytes) -> bytes:
+            lines = data.splitlines(keepends=True)
+            index = next(i for i, line in enumerate(lines) if line.startswith(prefix))
+            lines.insert(index, lines[index])
+            return b"".join(lines)
+
+        def reorder_first_case(data: bytes) -> bytes:
+            lines = data.splitlines(keepends=True)
+            start = next(i for i, line in enumerate(lines)
+                         if line.startswith(f"{calibrate.PROTOCOL} START ".encode()))
+            lines[start], lines[start + 1] = lines[start + 1], lines[start]
+            return b"".join(lines)
+
+        start_prefix = f"{calibrate.PROTOCOL} START ".encode()
+        ack_prefix = f"{calibrate.PROTOCOL} ACK ".encode()
+        scenarios = {
+            "guest_json_mismatch": lambda data: data.replace(
+                b"guest_raw_ns=1000000000", b"guest_raw_ns=1000000001", 1),
+            "missing_event": lambda data: remove_first(data, start_prefix),
+            "duplicate_event": lambda data: duplicate_first(data, start_prefix),
+            "reordered_event": reorder_first_case,
+            "guest_error": lambda data: data.replace(
+                start_prefix,
+                f"{calibrate.PROTOCOL} ERROR run={RUN_ID} seq=1 reason=test ".encode(), 1),
+            "wrong_ready_cpu_set": lambda data: data.replace(b"cpus=0\n", b"cpus=0,1\n", 1),
+            "missing_ack": lambda data: remove_first(data, ack_prefix),
+            "extra_event": lambda data: data +
+                f"{calibrate.PROTOCOL} READY run={RUN_ID} seq=999 cpus=0\n".encode(),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            for name, transform in scenarios.items():
+                with self.subTest(name=name):
+                    root = parent / name
+                    root.mkdir()
+                    result = EvidenceFactory(root).write_vm("kvm", 1)
+                    value = rewrite_serial(result, transform)
+                    with self.assertRaises(calibrate.CalibrationError):
+                        calibrate.verify_vm_result(value, result)
+
+    def test_schema_v2_result_cannot_pass_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            result = EvidenceFactory(root).write_vm("kvm", 1)
+            value = json.loads(result.read_text(encoding="utf-8"))
+            value["schema"] = "dragonos.timekeeping-calibration.v2"
+            result.write_text(json.dumps(value), encoding="utf-8")
+            EvidenceFactory.reindex(result)
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.verify_vm_result(value, result)
+
+    def test_skeletal_pass_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            result = EvidenceFactory(root).write_vm("kvm", 1)
+            value = json.loads(result.read_text(encoding="utf-8"))
+            value["cases"][0].pop("host_bracket")
+            result.write_text(json.dumps(value), encoding="utf-8")
+            EvidenceFactory.reindex(result)
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.verify_vm_result(value, result)
+
+    def test_tampered_ratio_status_and_artifact_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            factory = EvidenceFactory(root)
+            for field in ("ratio", "status"):
+                result = factory.write_vm("kvm", 1)
+                value = json.loads(result.read_text(encoding="utf-8"))
+                if field == "ratio":
+                    value["cases"][0]["metrics"]["ratio_numerator"] += 1
+                else:
+                    value["cases"][0]["status"] = "fail"
+                result.write_text(json.dumps(value), encoding="utf-8")
+                EvidenceFactory.reindex(result)
+                with self.subTest(field=field), self.assertRaises(calibrate.CalibrationError):
+                    calibrate.verify_vm_result(value, result)
+                for path in result.parent.iterdir():
+                    path.unlink()
+                result.parent.rmdir()
+            result = factory.write_vm("kvm", 1)
+            value = json.loads(result.read_text(encoding="utf-8"))
+            artifact = Path(value["build_artifacts"]["kernel"]["archive_path"])
+            artifact.chmod(0o644)
+            artifact.write_bytes(b"tampered\n")
+            with self.assertRaises(calibrate.CalibrationError):
+                calibrate.verify_vm_result(value, result)
+
+    def test_fatal_serial_marker_is_rejected_even_when_reindexed(self) -> None:
+        for marker in calibrate.SERIAL_FATAL_MARKERS:
+            with self.subTest(marker=marker), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                factory = EvidenceFactory(root)
+                result = factory.write_vm("kvm", 1)
+                value = json.loads(result.read_text(encoding="utf-8"))
+                serial = Path(value["serial"]["path"])
+                serial.write_bytes(serial.read_bytes() + marker + b"\n")
+                value["serial"] = calibrate.artifact_record(serial)
+                result.write_text(json.dumps(value), encoding="utf-8")
+                EvidenceFactory.reindex(result)
+                with self.assertRaises(calibrate.CalibrationError):
+                    calibrate.verify_vm_result(value, result)
+
+    def test_clocksource_event_during_measurement_is_rejected(self) -> None:
+        for marker in calibrate.SERIAL_MEASUREMENT_FORBIDDEN_MARKERS:
+            with self.subTest(marker=marker), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                factory = EvidenceFactory(root)
+                result = factory.write_vm("kvm", 1)
+
+                def inject_after_ready(serial: bytes) -> bytes:
+                    ready_end = serial.index(b"\n", serial.index(b" READY ")) + 1
+                    return serial[:ready_end] + marker + b"\n" + serial[ready_end:]
+
+                value = rewrite_serial(result, inject_after_ready)
+                with self.assertRaises(calibrate.CalibrationError):
+                    calibrate.verify_vm_result(value, result)
+
+    def test_boot_time_clocksource_events_are_outside_measurement_window(self) -> None:
+        for marker in calibrate.SERIAL_MEASUREMENT_FORBIDDEN_MARKERS:
+            with self.subTest(marker=marker), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                factory = EvidenceFactory(root)
+                result = factory.write_vm("kvm", 1)
+                value = rewrite_serial(result, lambda serial: marker + b"\n" + serial)
+                calibrate.verify_vm_result(value, result)
+
+    def test_missing_vm_makes_aggregate_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            factory = EvidenceFactory(root)
+            result = factory.write_vm("kvm", 1)
+            args = type("Args", (), {"output": root / "aggregate", "vm_result": [result]})()
+            self.assertEqual(calibrate.aggregate(args), 2)
+
+    def test_cli_parser_builds(self) -> None:
+        parser = calibrate.build_parser()
+        with self.assertRaises(SystemExit) as context:
+            parser.parse_args(["--help"])
+        self.assertEqual(context.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/timekeeping/test_calibrate.py
+++ b/tools/timekeeping/test_calibrate.py
@@ -269,6 +269,14 @@ class ProtocolTests(unittest.TestCase):
         transcript = io.BytesIO()
 
         sock = mock.Mock()
+        sock.connect.side_effect = OSError(111, "connection refused")
+        with mock.patch.object(calibrate.socket, "socket", return_value=sock):
+            with self.assertRaisesRegex(
+                    calibrate.CalibrationError, "connection refused"):
+                calibrate.SerialTransport(Path("serial.sock"), transcript)
+        sock.close.assert_called_once_with()
+
+        sock = mock.Mock()
         sock.setblocking.side_effect = RuntimeError("setblocking failed")
         with mock.patch.object(calibrate.socket, "socket", return_value=sock):
             with self.assertRaisesRegex(RuntimeError, "setblocking failed"):

--- a/user/apps/tests/dunitest/suites/normal/restart_syscall_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/restart_syscall_semantics.cc
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/syscall.h>
 #include <time.h>
@@ -110,6 +111,65 @@ TEST(RestartSyscallSemantics, RestartBlockDeliveredHandlerReturnsEintrEvenWithSa
     EXPECT_EQ(-1, restart_ret);
     EXPECT_EQ(EINTR, restart_errno)
         << "stale restart block was consumed after signal handler returned";
+
+    EXPECT_EQ(0, sigaction(SIGUSR1, &old_action, nullptr));
+}
+
+TEST(RestartSyscallSemantics, NanosleepInterruptionReportsRemainingFromOriginalDeadline) {
+    struct sigaction action {};
+    struct sigaction old_action {};
+    action.sa_handler = SignalHandler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_RESTART;
+    ASSERT_EQ(0, sigaction(SIGUSR1, &action, &old_action))
+        << "sigaction failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    g_signal_count = 0;
+    SignalAfterArgs args {};
+    args.target = pthread_self();
+    args.signo = SIGUSR1;
+    args.send_result = -1;
+
+    pthread_t sender;
+    ASSERT_EQ(0, pthread_create(&sender, nullptr, SendSignalAfterDelay, &args));
+
+    timespec started {};
+    timespec finished {};
+    ASSERT_EQ(0, clock_gettime(CLOCK_MONOTONIC, &started));
+
+    timespec request {};
+    request.tv_sec = 2;
+    timespec remain {};
+    remain.tv_sec = 123;
+    remain.tv_nsec = 456;
+    errno = 0;
+    int ret = nanosleep(&request, &remain);
+    int saved_errno = errno;
+
+    ASSERT_EQ(0, clock_gettime(CLOCK_MONOTONIC, &finished));
+    ASSERT_EQ(0, pthread_join(sender, nullptr));
+
+    const int64_t elapsed_ns =
+        (finished.tv_sec - started.tv_sec) * 1000000000LL +
+        (finished.tv_nsec - started.tv_nsec);
+    const int64_t remain_ns =
+        remain.tv_sec * 1000000000LL + remain.tv_nsec;
+
+    EXPECT_EQ(0, args.send_result);
+    EXPECT_EQ(1, g_signal_count);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(EINTR, saved_errno)
+        << "nanosleep returned errno=" << saved_errno << " ("
+        << strerror(saved_errno) << "), remain={" << remain.tv_sec << ", "
+        << remain.tv_nsec << "}";
+    EXPECT_GE(remain.tv_sec, 0);
+    EXPECT_GE(remain.tv_nsec, 0);
+    EXPECT_LT(remain.tv_nsec, 1000000000L);
+    EXPECT_GT(remain_ns, 0);
+    EXPECT_LT(remain_ns, 2000000000LL);
+    EXPECT_GE(elapsed_ns, 0);
+    EXPECT_LT(elapsed_ns, 1500000000LL)
+        << "interrupted nanosleep appears to have restarted the full duration";
 
     EXPECT_EQ(0, sigaction(SIGUSR1, &old_action, nullptr));
 }

--- a/user/apps/tests/dunitest/suites/normal/timekeeping_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/timekeeping_selftest.cc
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+constexpr const char* kSelftestPath = "/sys/kernel/debug/timekeeping/selftest";
+
+std::string ReadAll(int fd) {
+    std::string output;
+    char buffer[127];
+    for (;;) {
+        const ssize_t count = read(fd, buffer, sizeof(buffer));
+        if (count == 0) {
+            break;
+        }
+        if (count < 0) {
+            ADD_FAILURE() << "read(" << kSelftestPath << ") failed: errno=" << errno;
+            break;
+        }
+        output.append(buffer, static_cast<size_t>(count));
+    }
+    return output;
+}
+
+}  // namespace
+
+TEST(TimekeepingSelftest, KernelPureAndTransactionalChecksPass) {
+    const int fd = open(kSelftestPath, O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(fd, 0) << "open(" << kSelftestPath << ") failed: errno=" << errno;
+    const std::string report = ReadAll(fd);
+    ASSERT_EQ(0, close(fd));
+
+    ASSERT_FALSE(report.empty());
+    EXPECT_EQ(0u, report.find("status=ok\n")) << report;
+    EXPECT_EQ(std::string::npos, report.find("=fail\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("timekeeping.wrap_24=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("timekeeping.switch_continuity=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("timekeeping.settimeofday_domains=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("rwlock.ticket_fifo=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("rwlock.upgrader_reader_limit=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("rwlock.pending_blocks_new_owners=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("kvm_allocator.staged_success=ok\n")) << report;
+    EXPECT_NE(std::string::npos,
+              report.find("kvm_allocator.mapping_failure_releases_frame=ok\n"))
+        << report;
+    EXPECT_NE(std::string::npos, report.find("summary_fail=0\n")) << report;
+}
+
+TEST(TimekeepingSelftest, ReportIsPerOpenSnapshotAndReadOnly) {
+    const int first = open(kSelftestPath, O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(first, 0);
+    const std::string first_report = ReadAll(first);
+    ASSERT_EQ(0, close(first));
+
+    const int second = open(kSelftestPath, O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(second, 0);
+    const std::string second_report = ReadAll(second);
+    ASSERT_EQ(0, close(second));
+    EXPECT_EQ(first_report, second_report);
+
+    const int writable = open(kSelftestPath, O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(writable, 0) << "root open for callback test failed: errno=" << errno;
+    errno = 0;
+    EXPECT_EQ(-1, write(writable, "x", 1));
+    EXPECT_EQ(EPERM, errno);
+    EXPECT_EQ(0, close(writable));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/timekeeping_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/timekeeping_semantics.cc
@@ -1,0 +1,1094 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <time.h>
+#include <vector>
+
+namespace {
+
+constexpr int64_t kEpoch2020Seconds = 1577836800LL;
+constexpr int64_t kNanosecondsPerSecond = 1000000000LL;
+constexpr int64_t kShortWaitNanoseconds = 40000000LL;
+constexpr int64_t kMinimumObservedWaitNanoseconds = 20000000LL;
+constexpr int64_t kMaximumObservedWaitNanoseconds = 2000000000LL;
+constexpr uint64_t kStressReads = 10000000ULL;
+
+volatile sig_atomic_t g_nanosleep_signal_observed = 0;
+
+void RecordNanosleepSignal(int) {
+    g_nanosleep_signal_observed = 1;
+}
+
+timespec ReadClock(clockid_t clock_id) {
+    timespec value = {};
+    EXPECT_EQ(0, clock_gettime(clock_id, &value))
+        << "clock_gettime(" << clock_id << ") failed: errno=" << errno << " ("
+        << strerror(errno) << ")";
+    return value;
+}
+
+void ExpectNormalized(const timespec& value) {
+    EXPECT_GE(value.tv_sec, 0);
+    EXPECT_GE(value.tv_nsec, 0);
+    EXPECT_LT(value.tv_nsec, 1000000000L);
+}
+
+int Compare(const timespec& lhs, const timespec& rhs) {
+    if (lhs.tv_sec != rhs.tv_sec) {
+        return lhs.tv_sec < rhs.tv_sec ? -1 : 1;
+    }
+    if (lhs.tv_nsec != rhs.tv_nsec) {
+        return lhs.tv_nsec < rhs.tv_nsec ? -1 : 1;
+    }
+    return 0;
+}
+
+int64_t DiffNs(const timespec& start, const timespec& end) {
+    return (end.tv_sec - start.tv_sec) * kNanosecondsPerSecond +
+           (end.tv_nsec - start.tv_nsec);
+}
+
+timespec AddNs(const timespec& value, int64_t nanoseconds) {
+    const __int128 total = static_cast<__int128>(value.tv_sec) * kNanosecondsPerSecond +
+                           value.tv_nsec + nanoseconds;
+    timespec result = {};
+    result.tv_sec = static_cast<time_t>(total / kNanosecondsPerSecond);
+    result.tv_nsec = static_cast<long>(total % kNanosecondsPerSecond);
+    return result;
+}
+
+bool ReadClockRaw(clockid_t clock_id, timespec* value, int* error) {
+    if (clock_gettime(clock_id, value) == 0) {
+        return true;
+    }
+    if (error != nullptr) {
+        *error = errno;
+    }
+    return false;
+}
+
+std::vector<int> AllowedCpus() {
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    if (sched_getaffinity(0, sizeof(set), &set) != 0) {
+        return {};
+    }
+
+    std::vector<int> cpus;
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (CPU_ISSET(cpu, &set)) {
+            cpus.push_back(cpu);
+        }
+    }
+    return cpus;
+}
+
+bool SetCurrentCpu(int cpu) {
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(cpu, &set);
+    return sched_setaffinity(0, sizeof(set), &set) == 0;
+}
+
+int CurrentCpu() {
+    unsigned int cpu = 0;
+    if (syscall(SYS_getcpu, &cpu, nullptr, nullptr) != 0) {
+        return -1;
+    }
+    return static_cast<int>(cpu);
+}
+
+bool WaitUntilCurrentCpu(int target_cpu) {
+    timespec start = {};
+    if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+        return false;
+    }
+    for (int attempts = 0; attempts < 2000000; ++attempts) {
+        if (CurrentCpu() == target_cpu) {
+            return true;
+        }
+        timespec now = {};
+        if (clock_gettime(CLOCK_MONOTONIC, &now) != 0 ||
+            DiffNs(start, now) > kMaximumObservedWaitNanoseconds) {
+            return false;
+        }
+        sched_yield();
+    }
+    return false;
+}
+
+class ScopedAffinity {
+public:
+    bool Capture() {
+        CPU_ZERO(&saved_);
+        active_ = sched_getaffinity(0, sizeof(saved_), &saved_) == 0;
+        return active_;
+    }
+
+    ~ScopedAffinity() {
+        if (active_ && sched_setaffinity(0, sizeof(saved_), &saved_) != 0) {
+            ADD_FAILURE() << "failed to restore affinity: errno=" << errno << " ("
+                          << strerror(errno) << ")";
+        }
+    }
+
+    ScopedAffinity(const ScopedAffinity&) = delete;
+    ScopedAffinity& operator=(const ScopedAffinity&) = delete;
+    ScopedAffinity() = default;
+
+private:
+    cpu_set_t saved_ {};
+    bool active_ = false;
+};
+
+bool ReadWholeFile(const char* path, std::string* output, int* error) {
+    const int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        if (error != nullptr) {
+            *error = errno;
+        }
+        return false;
+    }
+
+    output->clear();
+    char buffer[4096];
+    for (;;) {
+        const ssize_t count = read(fd, buffer, sizeof(buffer));
+        if (count > 0) {
+            output->append(buffer, static_cast<size_t>(count));
+            continue;
+        }
+        if (count == 0) {
+            close(fd);
+            return true;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        if (error != nullptr) {
+            *error = errno;
+        }
+        close(fd);
+        return false;
+    }
+}
+
+bool ParseBtime(const std::string& contents, int64_t* btime, std::string* error) {
+    size_t offset = 0;
+    int matches = 0;
+    int64_t parsed = -1;
+    while (offset < contents.size()) {
+        const size_t end = contents.find('\n', offset);
+        const size_t length = (end == std::string::npos ? contents.size() : end) - offset;
+        if (length >= 6 && contents.compare(offset, 6, "btime ") == 0) {
+            const std::string value = contents.substr(offset + 6, length - 6);
+            char* parse_end = nullptr;
+            errno = 0;
+            const long long candidate = strtoll(value.c_str(), &parse_end, 10);
+            if (errno != 0 || parse_end == value.c_str() || *parse_end != '\0' || candidate < 0) {
+                *error = "malformed btime line: " + value;
+                return false;
+            }
+            parsed = static_cast<int64_t>(candidate);
+            ++matches;
+        }
+        if (end == std::string::npos) {
+            break;
+        }
+        offset = end + 1;
+    }
+    if (matches != 1) {
+        *error = "expected exactly one btime line, found " + std::to_string(matches);
+        return false;
+    }
+    *btime = parsed;
+    return true;
+}
+
+bool ReadBtime(int64_t* btime, std::string* error) {
+    std::string contents;
+    int read_error = 0;
+    if (!ReadWholeFile("/proc/stat", &contents, &read_error)) {
+        *error = "read /proc/stat failed: " + std::to_string(read_error) + " (" +
+                 strerror(read_error) + ")";
+        return false;
+    }
+    return ParseBtime(contents, btime, error);
+}
+
+struct NanosleepResult {
+    int return_code = -1;
+    int64_t elapsed_ns = -1;
+    timespec deadline = {};
+    timespec end_clock = {};
+};
+
+bool ReadExact(int fd, void* buffer, size_t length) {
+    auto* bytes = static_cast<char*>(buffer);
+    size_t done = 0;
+    while (done < length) {
+        const ssize_t count = read(fd, bytes + done, length - done);
+        if (count > 0) {
+            done += static_cast<size_t>(count);
+            continue;
+        }
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool WriteExact(int fd, const void* buffer, size_t length) {
+    const auto* bytes = static_cast<const char*>(buffer);
+    size_t done = 0;
+    while (done < length) {
+        const ssize_t count = write(fd, bytes + done, length - done);
+        if (count > 0) {
+            done += static_cast<size_t>(count);
+            continue;
+        }
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool RunClockNanosleepBounded(clockid_t clock_id, int flags, const timespec& request,
+                              NanosleepResult* result, std::string* error) {
+    int pipe_fds[2];
+    if (pipe(pipe_fds) != 0) {
+        *error = "pipe failed";
+        return false;
+    }
+    const pid_t child = fork();
+    if (child < 0) {
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        *error = "fork failed";
+        return false;
+    }
+    if (child == 0) {
+        close(pipe_fds[0]);
+        NanosleepResult child_result;
+        timespec start = {};
+        timespec end = {};
+        if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+            _exit(120);
+        }
+        timespec effective_request = request;
+        if ((flags & TIMER_ABSTIME) != 0) {
+            timespec clock_start = {};
+            if (clock_gettime(clock_id, &clock_start) != 0) {
+                _exit(127);
+            }
+            effective_request = AddNs(clock_start, DiffNs(timespec {}, request));
+            child_result.deadline = effective_request;
+        }
+        child_result.return_code =
+            clock_nanosleep(clock_id, flags, &effective_request, nullptr);
+        if (clock_gettime(CLOCK_MONOTONIC, &end) != 0 ||
+            clock_gettime(clock_id, &child_result.end_clock) != 0) {
+            _exit(121);
+        }
+        child_result.elapsed_ns = DiffNs(start, end);
+        const bool wrote = WriteExact(pipe_fds[1], &child_result, sizeof(child_result));
+        close(pipe_fds[1]);
+        _exit(wrote ? 0 : 122);
+    }
+
+    close(pipe_fds[1]);
+    timespec wait_start = {};
+    clock_gettime(CLOCK_MONOTONIC, &wait_start);
+    int status = 0;
+    for (int polls = 0;; ++polls) {
+        const pid_t waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) {
+            break;
+        }
+        if (waited < 0) {
+            kill(child, SIGKILL);
+            while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            close(pipe_fds[0]);
+            *error = "waitpid failed";
+            return false;
+        }
+        timespec now = {};
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        if (polls >= 2000 || DiffNs(wait_start, now) > kMaximumObservedWaitNanoseconds) {
+            kill(child, SIGKILL);
+            while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            close(pipe_fds[0]);
+            *error = "clock_nanosleep exceeded bounded wait (possible wrong clock domain)";
+            return false;
+        }
+        usleep(1000);
+    }
+
+    const bool read_ok = ReadExact(pipe_fds[0], result, sizeof(*result));
+    close(pipe_fds[0]);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0 || !read_ok) {
+        *error = "clock_nanosleep child failed, status=" + std::to_string(status);
+        return false;
+    }
+    return true;
+}
+
+struct ConcurrentReadResult {
+    int error = 0;
+    int clock_index = -1;
+    int iteration = -1;
+    timespec previous = {};
+    timespec current = {};
+};
+
+struct ConcurrentReadArgs {
+    std::atomic<bool>* start;
+    ConcurrentReadResult* result;
+};
+
+void* ConcurrentReader(void* opaque) {
+    auto* args = static_cast<ConcurrentReadArgs*>(opaque);
+    while (!args->start->load(std::memory_order_acquire)) {
+        sched_yield();
+    }
+    const clockid_t clocks[] = {CLOCK_MONOTONIC, CLOCK_MONOTONIC_RAW, CLOCK_BOOTTIME};
+    timespec previous[3] = {};
+    for (int clock_index = 0; clock_index < 3; ++clock_index) {
+        if (!ReadClockRaw(clocks[clock_index], &previous[clock_index], &args->result->error)) {
+            args->result->clock_index = clock_index;
+            return nullptr;
+        }
+    }
+    for (int iteration = 0; iteration < 100000; ++iteration) {
+        for (int clock_index = 0; clock_index < 3; ++clock_index) {
+            timespec current = {};
+            if (!ReadClockRaw(clocks[clock_index], &current, &args->result->error) ||
+                Compare(previous[clock_index], current) > 0) {
+                args->result->clock_index = clock_index;
+                args->result->iteration = iteration;
+                args->result->previous = previous[clock_index];
+                args->result->current = current;
+                return nullptr;
+            }
+            previous[clock_index] = current;
+        }
+    }
+    return nullptr;
+}
+
+class ScopedSignalMask {
+public:
+    bool CaptureAndBlock(int signal_number) {
+        if (pthread_sigmask(SIG_SETMASK, nullptr, &saved_) != 0) {
+            return false;
+        }
+        sigset_t one;
+        sigemptyset(&one);
+        sigaddset(&one, signal_number);
+        active_ = pthread_sigmask(SIG_BLOCK, &one, nullptr) == 0;
+        return active_;
+    }
+
+    ~ScopedSignalMask() {
+        if (active_) {
+            const int result = pthread_sigmask(SIG_SETMASK, &saved_, nullptr);
+            if (result != 0) {
+                ADD_FAILURE() << "failed to restore signal mask: " << strerror(result);
+            }
+        }
+    }
+
+private:
+    sigset_t saved_ {};
+    bool active_ = false;
+};
+
+struct SigtimedwaitResult {
+    int return_value = 0;
+    int error = 0;
+    int64_t elapsed_ns = 0;
+};
+
+bool RunSigtimedwaitBounded(int signal_number, const timespec& timeout,
+                            SigtimedwaitResult* result, std::string* error) {
+    int pipe_fds[2];
+    if (pipe(pipe_fds) != 0) {
+        *error = "pipe failed";
+        return false;
+    }
+    const pid_t child = fork();
+    if (child < 0) {
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        *error = "fork failed";
+        return false;
+    }
+    if (child == 0) {
+        close(pipe_fds[0]);
+        sigset_t awaited;
+        sigemptyset(&awaited);
+        sigaddset(&awaited, signal_number);
+        if (pthread_sigmask(SIG_BLOCK, &awaited, nullptr) != 0) {
+            _exit(123);
+        }
+        timespec start = {};
+        timespec end = {};
+        if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+            _exit(124);
+        }
+        siginfo_t info = {};
+        errno = 0;
+        SigtimedwaitResult child_result;
+        child_result.return_value = sigtimedwait(&awaited, &info, &timeout);
+        child_result.error = errno;
+        if (clock_gettime(CLOCK_MONOTONIC, &end) != 0) {
+            _exit(125);
+        }
+        child_result.elapsed_ns = DiffNs(start, end);
+        const bool wrote = WriteExact(pipe_fds[1], &child_result, sizeof(child_result));
+        close(pipe_fds[1]);
+        _exit(wrote ? 0 : 126);
+    }
+
+    close(pipe_fds[1]);
+    timespec wait_start = {};
+    clock_gettime(CLOCK_MONOTONIC, &wait_start);
+    int status = 0;
+    for (int polls = 0;; ++polls) {
+        const pid_t waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) {
+            break;
+        }
+        if (waited < 0) {
+            kill(child, SIGKILL);
+            while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            close(pipe_fds[0]);
+            *error = "waitpid failed";
+            return false;
+        }
+        timespec now = {};
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        if (polls >= 2000 || DiffNs(wait_start, now) > kMaximumObservedWaitNanoseconds) {
+            kill(child, SIGKILL);
+            while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            close(pipe_fds[0]);
+            *error = "sigtimedwait exceeded bounded wait";
+            return false;
+        }
+        usleep(1000);
+    }
+    const bool read_ok = ReadExact(pipe_fds[0], result, sizeof(*result));
+    close(pipe_fds[0]);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0 || !read_ok) {
+        *error = "sigtimedwait child failed, status=" + std::to_string(status);
+        return false;
+    }
+    return true;
+}
+
+struct FutexGuardArgs {
+    uint32_t* word;
+    std::atomic<bool>* done;
+    bool fired = false;
+};
+
+void* FutexGuard(void* opaque) {
+    auto* args = static_cast<FutexGuardArgs*>(opaque);
+    for (int i = 0; i < 500; ++i) {
+        if (args->done->load(std::memory_order_acquire)) {
+            return nullptr;
+        }
+        usleep(1000);
+    }
+    args->fired = true;
+    syscall(SYS_futex, args->word, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 1, nullptr, nullptr, 0);
+    return nullptr;
+}
+
+struct FutexWaitResult {
+    long return_value = 0;
+    int error = 0;
+    int64_t elapsed_ns = 0;
+    bool guard_fired = false;
+};
+
+FutexWaitResult RunFutexWaitBitsetInProcess(clockid_t clock_id, bool realtime) {
+    alignas(4) uint32_t word = 0;
+    std::atomic<bool> done {false};
+    FutexGuardArgs guard_args {&word, &done, false};
+    pthread_t guard {};
+    FutexWaitResult result;
+    if (pthread_create(&guard, nullptr, FutexGuard, &guard_args) != 0) {
+        result.error = EAGAIN;
+        return result;
+    }
+
+    timespec now = {};
+    timespec start = {};
+    timespec end = {};
+    if (clock_gettime(clock_id, &now) != 0 || clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+        result.error = errno;
+        done.store(true, std::memory_order_release);
+        pthread_join(guard, nullptr);
+        return result;
+    }
+    const timespec deadline = AddNs(now, kShortWaitNanoseconds);
+    const int operation = FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG |
+                          (realtime ? FUTEX_CLOCK_REALTIME : 0);
+    errno = 0;
+    result.return_value = syscall(SYS_futex, &word, operation, 0, &deadline, nullptr,
+                                  FUTEX_BITSET_MATCH_ANY);
+    result.error = errno;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    result.elapsed_ns = DiffNs(start, end);
+    done.store(true, std::memory_order_release);
+    pthread_join(guard, nullptr);
+    result.guard_fired = guard_args.fired;
+    return result;
+}
+
+bool RunFutexWaitBitsetBounded(clockid_t clock_id, bool realtime, FutexWaitResult* result,
+                               std::string* error) {
+    int pipe_fds[2];
+    if (pipe(pipe_fds) != 0) {
+        *error = "pipe failed";
+        return false;
+    }
+    const pid_t child = fork();
+    if (child < 0) {
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        *error = "fork failed";
+        return false;
+    }
+    if (child == 0) {
+        close(pipe_fds[0]);
+        const FutexWaitResult child_result = RunFutexWaitBitsetInProcess(clock_id, realtime);
+        const bool wrote = WriteExact(pipe_fds[1], &child_result, sizeof(child_result));
+        close(pipe_fds[1]);
+        _exit(wrote ? 0 : 128);
+    }
+
+    close(pipe_fds[1]);
+    timespec wait_start = {};
+    clock_gettime(CLOCK_MONOTONIC, &wait_start);
+    int status = 0;
+    for (int polls = 0;; ++polls) {
+        const pid_t waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) {
+            break;
+        }
+        if (waited < 0) {
+            kill(child, SIGKILL);
+            while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            close(pipe_fds[0]);
+            *error = "waitpid failed";
+            return false;
+        }
+        timespec now = {};
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        if (polls >= 2000 || DiffNs(wait_start, now) > kMaximumObservedWaitNanoseconds) {
+            kill(child, SIGKILL);
+            while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            close(pipe_fds[0]);
+            *error = "futex wait exceeded bounded wait (possible wrong clock domain)";
+            return false;
+        }
+        usleep(1000);
+    }
+    const bool read_ok = ReadExact(pipe_fds[0], result, sizeof(*result));
+    close(pipe_fds[0]);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0 || !read_ok) {
+        *error = "futex child failed, status=" + std::to_string(status);
+        return false;
+    }
+    return true;
+}
+
+struct ReadLoopResult {
+    bool ok = true;
+    int error = 0;
+    uint64_t iteration = 0;
+    timespec previous = {};
+    timespec current = {};
+};
+
+ReadLoopResult RunReadLoop(clockid_t clock_id, uint64_t reads) {
+    ReadLoopResult result;
+    if (!ReadClockRaw(clock_id, &result.previous, &result.error)) {
+        result.ok = false;
+        return result;
+    }
+    for (uint64_t i = 0; i < reads; ++i) {
+        if (!ReadClockRaw(clock_id, &result.current, &result.error) ||
+            Compare(result.previous, result.current) > 0) {
+            result.ok = false;
+            result.iteration = i;
+            return result;
+        }
+        result.previous = result.current;
+    }
+    return result;
+}
+
+void ExpectReadLoopSucceeded(clockid_t clock_id, const ReadLoopResult& result) {
+    EXPECT_TRUE(result.ok) << "clock=" << clock_id << " iteration=" << result.iteration
+                           << " errno=" << result.error << " previous="
+                           << result.previous.tv_sec << "." << result.previous.tv_nsec
+                           << " current=" << result.current.tv_sec << "."
+                           << result.current.tv_nsec;
+}
+
+}  // namespace
+
+TEST(TimekeepingSemantics, WallClockAndUptimeClocksUseDifferentDomains) {
+    const timespec realtime = ReadClock(CLOCK_REALTIME);
+    const timespec monotonic = ReadClock(CLOCK_MONOTONIC);
+    const timespec raw = ReadClock(CLOCK_MONOTONIC_RAW);
+    const timespec boottime = ReadClock(CLOCK_BOOTTIME);
+
+    ExpectNormalized(realtime);
+    ExpectNormalized(monotonic);
+    ExpectNormalized(raw);
+    ExpectNormalized(boottime);
+
+    ASSERT_GE(realtime.tv_sec, kEpoch2020Seconds)
+        << "RTC/realtime was not initialized to a plausible wall-clock epoch";
+    EXPECT_GE(realtime.tv_sec - monotonic.tv_sec, kEpoch2020Seconds)
+        << "CLOCK_MONOTONIC incorrectly shares CLOCK_REALTIME's epoch";
+    EXPECT_GE(realtime.tv_sec - raw.tv_sec, kEpoch2020Seconds)
+        << "CLOCK_MONOTONIC_RAW incorrectly shares CLOCK_REALTIME's epoch";
+    EXPECT_GE(realtime.tv_sec - boottime.tv_sec, kEpoch2020Seconds)
+        << "CLOCK_BOOTTIME incorrectly shares CLOCK_REALTIME's epoch";
+}
+
+TEST(TimekeepingSemantics, UptimeClocksNeverRegress) {
+    constexpr int kReadsPerClock = 100000;
+    const clockid_t clocks[] = {CLOCK_MONOTONIC, CLOCK_MONOTONIC_RAW, CLOCK_BOOTTIME};
+
+    for (clockid_t clock_id : clocks) {
+        timespec previous = ReadClock(clock_id);
+        for (int i = 0; i < kReadsPerClock; ++i) {
+            const timespec current = ReadClock(clock_id);
+            ASSERT_LE(Compare(previous, current), 0)
+                << "clock " << clock_id << " regressed at iteration " << i;
+            previous = current;
+        }
+    }
+}
+
+TEST(TimekeepingSemantics, SleepAdvancesMonotonicAndRawConsistently) {
+    const timespec mono_start = ReadClock(CLOCK_MONOTONIC);
+    const timespec raw_start = ReadClock(CLOCK_MONOTONIC_RAW);
+    ASSERT_EQ(0, usleep(200000));
+    const timespec mono_end = ReadClock(CLOCK_MONOTONIC);
+    const timespec raw_end = ReadClock(CLOCK_MONOTONIC_RAW);
+
+    const int64_t mono_elapsed = DiffNs(mono_start, mono_end);
+    const int64_t raw_elapsed = DiffNs(raw_start, raw_end);
+    EXPECT_GE(mono_elapsed, 150000000LL);
+    EXPECT_LE(mono_elapsed, 2000000000LL);
+    EXPECT_GE(raw_elapsed, 150000000LL);
+    EXPECT_LE(raw_elapsed, 2000000000LL);
+    EXPECT_LE(mono_elapsed > raw_elapsed ? mono_elapsed - raw_elapsed : raw_elapsed - mono_elapsed,
+              10000000LL);
+}
+
+TEST(TimekeepingSemantics, ReportedResolutionMatchesLowResolutionTimer) {
+    const clockid_t clocks[] = {CLOCK_REALTIME, CLOCK_MONOTONIC, CLOCK_MONOTONIC_RAW,
+                                CLOCK_BOOTTIME};
+    for (clockid_t clock_id : clocks) {
+        timespec resolution = {};
+        ASSERT_EQ(0, clock_getres(clock_id, &resolution));
+        ExpectNormalized(resolution);
+        const int64_t resolution_ns = DiffNs(timespec{}, resolution);
+        EXPECT_EQ(4000000LL, resolution_ns);
+    }
+
+    const clockid_t coarse_clocks[] = {CLOCK_REALTIME_COARSE, CLOCK_MONOTONIC_COARSE};
+    for (clockid_t clock_id : coarse_clocks) {
+        timespec resolution = {};
+        ASSERT_EQ(0, clock_getres(clock_id, &resolution));
+        const int64_t resolution_ns = DiffNs(timespec{}, resolution);
+        EXPECT_EQ(4000000LL, resolution_ns);
+    }
+}
+
+TEST(TimekeepingSemantics, ClockNanosleepRejectsUnsupportedClockDomains) {
+    const timespec request = {.tv_sec = 0, .tv_nsec = 1};
+    EXPECT_EQ(EINVAL, clock_nanosleep(CLOCK_THREAD_CPUTIME_ID, 0, &request, nullptr));
+    // Linux 6.6 interprets TIMER_ABSTIME and ignores other flag bits.
+    EXPECT_EQ(0, clock_nanosleep(CLOCK_MONOTONIC, 2, &request, nullptr));
+    EXPECT_EQ(EOPNOTSUPP, clock_nanosleep(CLOCK_MONOTONIC_RAW, 0, &request, nullptr));
+    EXPECT_EQ(EOPNOTSUPP, clock_nanosleep(CLOCK_REALTIME_COARSE, 0, &request, nullptr));
+    EXPECT_EQ(EOPNOTSUPP, clock_nanosleep(CLOCK_MONOTONIC_COARSE, 0, &request, nullptr));
+}
+
+TEST(TimekeepingSemantics, SuccessfulNanosleepLeavesRemainingUntouched) {
+    const timespec request = {.tv_sec = 0, .tv_nsec = 1000000};
+    timespec remaining = {.tv_sec = 123, .tv_nsec = 456};
+    ASSERT_EQ(0, nanosleep(&request, &remaining));
+    EXPECT_EQ(123, remaining.tv_sec);
+    EXPECT_EQ(456, remaining.tv_nsec);
+}
+
+TEST(TimekeepingSemantics, InterruptedNanosleepReportsNormalizedRemainingTime) {
+    struct sigaction action = {};
+    action.sa_handler = RecordNanosleepSignal;
+    sigemptyset(&action.sa_mask);
+
+    struct sigaction previous_action = {};
+    ASSERT_EQ(0, sigaction(SIGUSR1, &action, &previous_action));
+    g_nanosleep_signal_observed = 0;
+
+    const pid_t parent = getpid();
+    const pid_t sender = fork();
+    ASSERT_GE(sender, 0);
+    if (sender == 0) {
+        const timespec delay = {.tv_sec = 0, .tv_nsec = 50000000};
+        if (nanosleep(&delay, nullptr) != 0 || kill(parent, SIGUSR1) != 0) {
+            _exit(1);
+        }
+        _exit(0);
+    }
+
+    const timespec request = {.tv_sec = 1, .tv_nsec = 0};
+    timespec remaining = {.tv_sec = 123, .tv_nsec = 456};
+    const timespec start = ReadClock(CLOCK_MONOTONIC);
+    const int sleep_result = nanosleep(&request, &remaining);
+    const int sleep_errno = errno;
+    const timespec end = ReadClock(CLOCK_MONOTONIC);
+
+    int sender_status = 0;
+    const pid_t waited = waitpid(sender, &sender_status, 0);
+    const int restore_result = sigaction(SIGUSR1, &previous_action, nullptr);
+
+    ASSERT_EQ(sender, waited);
+    ASSERT_TRUE(WIFEXITED(sender_status));
+    ASSERT_EQ(0, WEXITSTATUS(sender_status));
+    ASSERT_EQ(0, restore_result);
+    EXPECT_EQ(1, g_nanosleep_signal_observed);
+    EXPECT_EQ(-1, sleep_result);
+    EXPECT_EQ(EINTR, sleep_errno);
+    ExpectNormalized(remaining);
+    EXPECT_GT(DiffNs(timespec{}, remaining), 0);
+    EXPECT_LT(DiffNs(timespec{}, remaining), DiffNs(timespec{}, request));
+    EXPECT_GE(DiffNs(start, end), 20000000LL);
+    EXPECT_LT(DiffNs(start, end), 500000000LL);
+}
+
+TEST(TimekeepingSemantics, RelativeBoottimeSleepIsAcceptedAndAdvances) {
+    const timespec start = ReadClock(CLOCK_BOOTTIME);
+    const timespec request = {.tv_sec = 0, .tv_nsec = 20000000};
+    ASSERT_EQ(0, clock_nanosleep(CLOCK_BOOTTIME, 0, &request, nullptr));
+    const timespec end = ReadClock(CLOCK_BOOTTIME);
+    EXPECT_GE(DiffNs(start, end), 15000000LL);
+    EXPECT_LE(DiffNs(start, end), 1000000000LL);
+}
+
+TEST(TimekeepingSemantics, ForcedTwoCpuMigrationNeverRegresses) {
+    ScopedAffinity affinity;
+    ASSERT_TRUE(affinity.Capture()) << "sched_getaffinity failed: errno=" << errno << " ("
+                                    << strerror(errno) << ")";
+    const std::vector<int> cpus = AllowedCpus();
+    ASSERT_FALSE(cpus.empty());
+    if (cpus.size() < 2) {
+        GTEST_SKIP() << "requires at least two allowed CPUs";
+    }
+
+    const clockid_t clocks[] = {CLOCK_MONOTONIC, CLOCK_MONOTONIC_RAW, CLOCK_BOOTTIME};
+    timespec previous[3] = {};
+    ASSERT_TRUE(SetCurrentCpu(cpus[0])) << "pin to first CPU failed: errno=" << errno;
+    ASSERT_TRUE(WaitUntilCurrentCpu(cpus[0])) << "did not reach first CPU";
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_EQ(0, clock_gettime(clocks[i], &previous[i]));
+    }
+
+    bool saw_first = false;
+    bool saw_second = false;
+    for (int iteration = 0; iteration < 5000; ++iteration) {
+        const int target = cpus[iteration & 1];
+        ASSERT_TRUE(SetCurrentCpu(target)) << "iteration=" << iteration << " errno=" << errno;
+        ASSERT_TRUE(WaitUntilCurrentCpu(target)) << "iteration=" << iteration
+                                                << " target_cpu=" << target;
+        saw_first |= CurrentCpu() == cpus[0];
+        saw_second |= CurrentCpu() == cpus[1];
+        for (int clock_index = 0; clock_index < 3; ++clock_index) {
+            timespec current = {};
+            ASSERT_EQ(0, clock_gettime(clocks[clock_index], &current));
+            ASSERT_LE(Compare(previous[clock_index], current), 0)
+                << "clock=" << clocks[clock_index] << " iteration=" << iteration
+                << " cpu=" << target;
+            previous[clock_index] = current;
+        }
+    }
+    EXPECT_TRUE(saw_first);
+    EXPECT_TRUE(saw_second);
+}
+
+TEST(TimekeepingSemantics, ConcurrentReadersAreMonotonicPerThread) {
+    constexpr int kThreadCount = 4;
+    std::atomic<bool> start {false};
+    pthread_t threads[kThreadCount] = {};
+    ConcurrentReadResult results[kThreadCount] = {};
+    ConcurrentReadArgs args[kThreadCount] = {};
+    int created = 0;
+    for (; created < kThreadCount; ++created) {
+        args[created] = ConcurrentReadArgs {&start, &results[created]};
+        const int error = pthread_create(&threads[created], nullptr, ConcurrentReader, &args[created]);
+        if (error != 0) {
+            start.store(true, std::memory_order_release);
+            for (int i = 0; i < created; ++i) {
+                pthread_join(threads[i], nullptr);
+            }
+            FAIL() << "pthread_create failed: " << strerror(error);
+        }
+    }
+    start.store(true, std::memory_order_release);
+    int first_join_error = 0;
+    for (int i = 0; i < kThreadCount; ++i) {
+        const int error = pthread_join(threads[i], nullptr);
+        if (first_join_error == 0 && error != 0) {
+            first_join_error = error;
+        }
+    }
+    ASSERT_EQ(0, first_join_error) << "pthread_join failed: " << strerror(first_join_error);
+    for (int i = 0; i < kThreadCount; ++i) {
+        EXPECT_EQ(-1, results[i].clock_index)
+            << "thread=" << i << " clock_index=" << results[i].clock_index
+            << " iteration=" << results[i].iteration << " errno=" << results[i].error
+            << " previous=" << results[i].previous.tv_sec << "."
+            << results[i].previous.tv_nsec << " current=" << results[i].current.tv_sec << "."
+            << results[i].current.tv_nsec;
+    }
+}
+
+TEST(TimekeepingSemantics, ProcStatBtimeIsStableBootEpoch) {
+    const timespec realtime_before = ReadClock(CLOCK_REALTIME);
+    const timespec boottime_after = ReadClock(CLOCK_BOOTTIME);
+
+    int64_t first_btime = -1;
+    std::string error;
+    ASSERT_TRUE(ReadBtime(&first_btime, &error)) << error;
+    ASSERT_EQ(0, usleep(50000));
+    int64_t second_btime = -1;
+    ASSERT_TRUE(ReadBtime(&second_btime, &error)) << error;
+
+    const timespec boottime_before = ReadClock(CLOCK_BOOTTIME);
+    const timespec realtime_after = ReadClock(CLOCK_REALTIME);
+    const __int128 lower_ns =
+        static_cast<__int128>(realtime_before.tv_sec) * kNanosecondsPerSecond +
+        realtime_before.tv_nsec -
+        (static_cast<__int128>(boottime_after.tv_sec) * kNanosecondsPerSecond +
+         boottime_after.tv_nsec);
+    const __int128 upper_ns =
+        static_cast<__int128>(realtime_after.tv_sec) * kNanosecondsPerSecond +
+        realtime_after.tv_nsec -
+        (static_cast<__int128>(boottime_before.tv_sec) * kNanosecondsPerSecond +
+         boottime_before.tv_nsec);
+    const int64_t lower_seconds = static_cast<int64_t>(lower_ns / kNanosecondsPerSecond) - 1;
+    const int64_t upper_seconds = static_cast<int64_t>(upper_ns / kNanosecondsPerSecond) + 1;
+
+    EXPECT_EQ(first_btime, second_btime);
+    EXPECT_GE(first_btime, kEpoch2020Seconds);
+    EXPECT_LE(first_btime, realtime_after.tv_sec);
+    EXPECT_GE(first_btime, lower_seconds);
+    EXPECT_LE(first_btime, upper_seconds);
+    EXPECT_GT(first_btime, boottime_before.tv_sec + 86400)
+        << "btime appears to contain uptime rather than the boot epoch";
+}
+
+TEST(TimekeepingSemantics, ClockNanosleepRelativeAndAbsoluteDomains) {
+    const clockid_t clocks[] = {CLOCK_REALTIME, CLOCK_MONOTONIC, CLOCK_BOOTTIME};
+    for (clockid_t clock_id : clocks) {
+        const timespec relative = AddNs(timespec {}, kShortWaitNanoseconds);
+        NanosleepResult relative_result;
+        std::string error;
+        ASSERT_TRUE(RunClockNanosleepBounded(clock_id, 0, relative, &relative_result, &error))
+            << "relative clock=" << clock_id << ": " << error;
+        EXPECT_EQ(0, relative_result.return_code) << "clock=" << clock_id;
+        EXPECT_GE(relative_result.elapsed_ns, kMinimumObservedWaitNanoseconds)
+            << "clock=" << clock_id;
+        EXPECT_LE(relative_result.elapsed_ns, kMaximumObservedWaitNanoseconds)
+            << "clock=" << clock_id;
+
+        // The bounded child constructs the absolute deadline from its own
+        // clock sample, so fork latency cannot consume the requested budget.
+        const timespec absolute_offset = AddNs(timespec {}, kShortWaitNanoseconds);
+        NanosleepResult absolute_result;
+        ASSERT_TRUE(RunClockNanosleepBounded(clock_id, TIMER_ABSTIME, absolute_offset,
+                                             &absolute_result, &error))
+            << "absolute clock=" << clock_id << ": " << error;
+        EXPECT_EQ(0, absolute_result.return_code) << "clock=" << clock_id;
+        EXPECT_GE(absolute_result.elapsed_ns, kMinimumObservedWaitNanoseconds)
+            << "clock=" << clock_id;
+        EXPECT_LE(absolute_result.elapsed_ns, kMaximumObservedWaitNanoseconds)
+            << "clock=" << clock_id;
+        EXPECT_LE(Compare(absolute_result.deadline, absolute_result.end_clock), 0)
+            << "clock=" << clock_id;
+    }
+}
+
+TEST(TimekeepingSemantics, RtSigtimedwaitRelativeTimeoutExpiresWithinBudget) {
+    ScopedSignalMask mask;
+    ASSERT_TRUE(mask.CaptureAndBlock(SIGUSR2));
+    sigset_t awaited;
+    sigemptyset(&awaited);
+    sigaddset(&awaited, SIGUSR2);
+
+    const timespec zero = {};
+    siginfo_t info = {};
+    errno = 0;
+    EXPECT_EQ(-1, sigtimedwait(&awaited, &info, &zero));
+    EXPECT_EQ(EAGAIN, errno);
+
+    const timespec invalid = {.tv_sec = 0, .tv_nsec = kNanosecondsPerSecond};
+    errno = 0;
+    EXPECT_EQ(-1, sigtimedwait(&awaited, &info, &invalid));
+    EXPECT_EQ(EINVAL, errno);
+
+    const timespec timeout = AddNs(timespec {}, kShortWaitNanoseconds);
+    SigtimedwaitResult result;
+    std::string error;
+    ASSERT_TRUE(RunSigtimedwaitBounded(SIGUSR2, timeout, &result, &error)) << error;
+    EXPECT_EQ(-1, result.return_value);
+    EXPECT_EQ(EAGAIN, result.error);
+    EXPECT_GE(result.elapsed_ns, kMinimumObservedWaitNanoseconds);
+    EXPECT_LE(result.elapsed_ns, kMaximumObservedWaitNanoseconds);
+}
+
+TEST(TimekeepingSemantics, FutexWaitBitsetUsesAbsoluteClockDomain) {
+    alignas(4) uint32_t invalid_word = 0;
+    const timespec negative_deadline = {.tv_sec = -1, .tv_nsec = 0};
+    errno = 0;
+    EXPECT_EQ(-1, syscall(SYS_futex, &invalid_word,
+                          FUTEX_WAIT_BITSET | FUTEX_PRIVATE_FLAG, 0, &negative_deadline,
+                          nullptr, FUTEX_BITSET_MATCH_ANY));
+    EXPECT_EQ(EINVAL, errno);
+
+    FutexWaitResult monotonic;
+    std::string error;
+    ASSERT_TRUE(RunFutexWaitBitsetBounded(CLOCK_MONOTONIC, false, &monotonic, &error))
+        << error;
+    EXPECT_EQ(-1, monotonic.return_value);
+    EXPECT_EQ(ETIMEDOUT, monotonic.error);
+    EXPECT_FALSE(monotonic.guard_fired) << "monotonic futex needed the bounded guard wake";
+    EXPECT_GE(monotonic.elapsed_ns, kMinimumObservedWaitNanoseconds);
+    EXPECT_LE(monotonic.elapsed_ns, kMaximumObservedWaitNanoseconds);
+
+    FutexWaitResult realtime;
+    ASSERT_TRUE(RunFutexWaitBitsetBounded(CLOCK_REALTIME, true, &realtime, &error)) << error;
+    EXPECT_EQ(-1, realtime.return_value);
+    EXPECT_EQ(ETIMEDOUT, realtime.error);
+    EXPECT_FALSE(realtime.guard_fired) << "realtime futex likely used the monotonic domain";
+    EXPECT_GE(realtime.elapsed_ns, kMinimumObservedWaitNanoseconds);
+    EXPECT_LE(realtime.elapsed_ns, kMaximumObservedWaitNanoseconds);
+}
+
+TEST(TimekeepingStress, TenMillionFixedCpuMonotonicAndRawReads) {
+    if (getenv("DUNITEST_TIMEKEEPING_STRESS") == nullptr ||
+        strcmp(getenv("DUNITEST_TIMEKEEPING_STRESS"), "1") != 0) {
+        GTEST_SKIP() << "set DUNITEST_TIMEKEEPING_STRESS=1 to run the strict gate";
+    }
+    ScopedAffinity affinity;
+    ASSERT_TRUE(affinity.Capture());
+    const std::vector<int> cpus = AllowedCpus();
+    ASSERT_FALSE(cpus.empty());
+    ASSERT_TRUE(SetCurrentCpu(cpus[0]));
+    ASSERT_TRUE(WaitUntilCurrentCpu(cpus[0]));
+
+    ExpectReadLoopSucceeded(CLOCK_MONOTONIC, RunReadLoop(CLOCK_MONOTONIC, kStressReads));
+    ExpectReadLoopSucceeded(CLOCK_MONOTONIC_RAW, RunReadLoop(CLOCK_MONOTONIC_RAW, kStressReads));
+}
+
+TEST(TimekeepingStress, TenMillionMigratingMonotonicAndRawReads) {
+    if (getenv("DUNITEST_TIMEKEEPING_STRESS") == nullptr ||
+        strcmp(getenv("DUNITEST_TIMEKEEPING_STRESS"), "1") != 0) {
+        GTEST_SKIP() << "set DUNITEST_TIMEKEEPING_STRESS=1 to run the strict gate";
+    }
+    ScopedAffinity affinity;
+    ASSERT_TRUE(affinity.Capture());
+    const std::vector<int> cpus = AllowedCpus();
+    ASSERT_FALSE(cpus.empty());
+    if (cpus.size() < 2) {
+        GTEST_SKIP() << "requires at least two allowed CPUs";
+    }
+
+    constexpr uint64_t kBatchReads = 65536;
+    const clockid_t clocks[] = {CLOCK_MONOTONIC, CLOCK_MONOTONIC_RAW};
+    timespec previous[2] = {};
+    for (int i = 0; i < 2; ++i) {
+        ASSERT_EQ(0, clock_gettime(clocks[i], &previous[i]));
+    }
+    bool visited[2] = {false, false};
+    uint64_t completed = 0;
+    while (completed < kStressReads) {
+        const int cpu_index = static_cast<int>((completed / kBatchReads) & 1);
+        ASSERT_TRUE(SetCurrentCpu(cpus[cpu_index]));
+        ASSERT_TRUE(WaitUntilCurrentCpu(cpus[cpu_index]));
+        visited[cpu_index] = true;
+        const uint64_t batch =
+            (kStressReads - completed < kBatchReads) ? kStressReads - completed : kBatchReads;
+        bool batch_ok = true;
+        int failure_errno = 0;
+        int failure_clock = -1;
+        uint64_t failure_iteration = 0;
+        timespec failure_previous = {};
+        timespec failure_current = {};
+        for (uint64_t i = 0; i < batch; ++i) {
+            for (int clock_index = 0; clock_index < 2; ++clock_index) {
+                timespec current = {};
+                if (!ReadClockRaw(clocks[clock_index], &current, &failure_errno) ||
+                    Compare(previous[clock_index], current) > 0) {
+                    batch_ok = false;
+                    failure_clock = clock_index;
+                    failure_iteration = completed + i;
+                    failure_previous = previous[clock_index];
+                    failure_current = current;
+                    break;
+                }
+                previous[clock_index] = current;
+            }
+            if (!batch_ok) {
+                break;
+            }
+        }
+        ASSERT_TRUE(batch_ok)
+            << "clock=" << (failure_clock >= 0 ? clocks[failure_clock] : -1)
+            << " iteration=" << failure_iteration << " cpu=" << cpus[cpu_index]
+            << " errno=" << failure_errno << " previous=" << failure_previous.tv_sec << "."
+            << failure_previous.tv_nsec << " current=" << failure_current.tv_sec << "."
+            << failure_current.tv_nsec;
+        completed += batch;
+    }
+    EXPECT_TRUE(visited[0]);
+    EXPECT_TRUE(visited[1]);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/timekeeping_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/timekeeping_semantics.cc
@@ -24,6 +24,7 @@ constexpr int64_t kNanosecondsPerSecond = 1000000000LL;
 constexpr int64_t kShortWaitNanoseconds = 40000000LL;
 constexpr int64_t kMinimumObservedWaitNanoseconds = 20000000LL;
 constexpr int64_t kMaximumObservedWaitNanoseconds = 2000000000LL;
+constexpr int kSemanticReadIterations = 10000;
 constexpr uint64_t kStressReads = 10000000ULL;
 
 volatile sig_atomic_t g_nanosleep_signal_observed = 0;
@@ -378,7 +379,7 @@ void* ConcurrentReader(void* opaque) {
             return nullptr;
         }
     }
-    for (int iteration = 0; iteration < 100000; ++iteration) {
+    for (int iteration = 0; iteration < kSemanticReadIterations; ++iteration) {
         for (int clock_index = 0; clock_index < 3; ++clock_index) {
             timespec current = {};
             if (!ReadClockRaw(clocks[clock_index], &current, &args->result->error) ||
@@ -686,12 +687,11 @@ TEST(TimekeepingSemantics, WallClockAndUptimeClocksUseDifferentDomains) {
 }
 
 TEST(TimekeepingSemantics, UptimeClocksNeverRegress) {
-    constexpr int kReadsPerClock = 100000;
     const clockid_t clocks[] = {CLOCK_MONOTONIC, CLOCK_MONOTONIC_RAW, CLOCK_BOOTTIME};
 
     for (clockid_t clock_id : clocks) {
         timespec previous = ReadClock(clock_id);
-        for (int i = 0; i < kReadsPerClock; ++i) {
+        for (int i = 0; i < kSemanticReadIterations; ++i) {
             const timespec current = ReadClock(clock_id);
             ASSERT_LE(Compare(previous, current), 0)
                 << "clock " << clock_id << " regressed at iteration " << i;
@@ -829,7 +829,7 @@ TEST(TimekeepingSemantics, ForcedTwoCpuMigrationNeverRegresses) {
 
     bool saw_first = false;
     bool saw_second = false;
-    for (int iteration = 0; iteration < 5000; ++iteration) {
+    for (int iteration = 0; iteration < 500; ++iteration) {
         const int target = cpus[iteration & 1];
         ASSERT_TRUE(SetCurrentCpu(target)) << "iteration=" << iteration << " errno=" << errno;
         ASSERT_TRUE(WaitUntilCurrentCpu(target)) << "iteration=" << iteration

--- a/user/apps/tests/dunitest/suites/normal/timekeeping_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/timekeeping_semantics.cc
@@ -747,6 +747,15 @@ TEST(TimekeepingSemantics, ClockNanosleepRejectsUnsupportedClockDomains) {
     EXPECT_EQ(EOPNOTSUPP, clock_nanosleep(CLOCK_MONOTONIC_COARSE, 0, &request, nullptr));
 }
 
+TEST(TimekeepingSemantics, RawClockNanosleepThreadCpuClockIsUnsupported) {
+    const timespec request = {.tv_sec = 0, .tv_nsec = 1};
+    errno = 0;
+    const long result = syscall(SYS_clock_nanosleep, CLOCK_THREAD_CPUTIME_ID, 0, &request,
+                                nullptr);
+    EXPECT_EQ(-1, result);
+    EXPECT_EQ(EOPNOTSUPP, errno);
+}
+
 TEST(TimekeepingSemantics, SuccessfulNanosleepLeavesRemainingUntouched) {
     const timespec request = {.tv_sec = 0, .tv_nsec = 1000000};
     timespec remaining = {.tv_sec = 123, .tv_nsec = 456};

--- a/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
+++ b/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
@@ -182,6 +182,7 @@ void* ForkChildFromThread(void* arg) {
 struct ThreadForkExitArgs {
   int ready_fd = -1;
   int release_fd = -1;
+  int release_write_fd = -1;
   pid_t child = -1;
   int fork_errno = 0;
 };
@@ -190,6 +191,8 @@ void* ForkChildAndExitThread(void* arg) {
   auto* args = reinterpret_cast<ThreadForkExitArgs*>(arg);
   pid_t child = fork();
   if (child == 0) {
+    close(args->ready_fd);
+    close(args->release_write_fd);
     char release = 0;
     if (read(args->release_fd, &release, 1) != 1) {
       _exit(22);
@@ -1061,6 +1064,7 @@ TEST(WaitRusage, WnothreadChildReparentedWhenForkingThreadExits) {
   ThreadForkExitArgs args;
   args.ready_fd = ready_pipe[1];
   args.release_fd = release_pipe[0];
+  args.release_write_fd = release_pipe[1];
   pthread_t thread {};
   ASSERT_EQ(0, pthread_create(&thread, nullptr, ForkChildAndExitThread, &args))
       << strerror(errno);
@@ -1075,8 +1079,76 @@ TEST(WaitRusage, WnothreadChildReparentedWhenForkingThreadExits) {
   ASSERT_EQ(0, args.fork_errno) << strerror(args.fork_errno);
   ASSERT_GT(args.child, 0);
 
-  ASSERT_EQ(1, write(release_pipe[1], "x", 1)) << strerror(errno);
-  close(release_pipe[1]);
+  auto close_release_pipe = [&release_pipe] {
+    if (release_pipe[1] >= 0) {
+      close(release_pipe[1]);
+      release_pipe[1] = -1;
+    }
+  };
+  auto cleanup_child = [&args, &close_release_pipe] {
+    close_release_pipe();
+    int cleanup_status = 0;
+    while (wait4(args.child, &cleanup_status, 0, nullptr) == -1 &&
+           errno == EINTR) {
+    }
+  };
+
+  struct timespec reparent_deadline {};
+  if (clock_gettime(CLOCK_MONOTONIC, &reparent_deadline) != 0) {
+    const int clock_errno = errno;
+    cleanup_child();
+    FAIL() << strerror(clock_errno);
+  }
+  ++reparent_deadline.tv_sec;
+  bool reparented = false;
+  while (true) {
+    struct timespec now {};
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+      const int clock_errno = errno;
+      cleanup_child();
+      FAIL() << strerror(clock_errno);
+    }
+    if (now.tv_sec > reparent_deadline.tv_sec ||
+        (now.tv_sec == reparent_deadline.tv_sec &&
+         now.tv_nsec >= reparent_deadline.tv_nsec)) {
+      break;
+    }
+
+    siginfo_t si {};
+    errno = 0;
+    long ret = syscall(SYS_waitid, P_PID, args.child, &si,
+                       WEXITED | WNOHANG | WNOWAIT | __WNOTHREAD, nullptr);
+    if (ret == 0 && si.si_pid == 0) {
+      reparented = true;
+      break;
+    }
+    if (ret == -1 && (errno == ECHILD || errno == EINTR)) {
+      usleep(1000);
+      continue;
+    }
+
+    const int wait_errno = errno;
+    cleanup_child();
+    if (ret == 0) {
+      FAIL() << "waitid observed child " << si.si_pid
+             << " before it was released";
+    }
+    FAIL() << "waitid before releasing child returned " << ret << ": "
+           << strerror(wait_errno);
+  }
+
+  if (!reparented) {
+    cleanup_child();
+    FAIL() << "child was not reparented to the waiting thread before timeout";
+  }
+
+  errno = 0;
+  if (write(release_pipe[1], "x", 1) != 1) {
+    const int write_errno = errno;
+    cleanup_child();
+    FAIL() << strerror(write_errno);
+  }
+  close_release_pipe();
 
   int status = 0;
   ASSERT_EQ(args.child, wait4(args.child, &status, __WNOTHREAD, nullptr))

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -37,6 +37,8 @@ normal/rcu_selftest
 normal/kthread_selftest
 normal/restart_syscall_semantics
 normal/errseq_selftest
+normal/timekeeping_semantics
+normal/timekeeping_selftest
 normal/errseq_writeback_reporting
 normal/test_tlb_shootdown
 normal/pid_namespace_fork

--- a/user/apps/timekeeping_calibration/.gitignore
+++ b/user/apps/timekeeping_calibration/.gitignore
@@ -1,0 +1,1 @@
+timekeeping_calibration

--- a/user/apps/timekeeping_calibration/Makefile
+++ b/user/apps/timekeeping_calibration/Makefile
@@ -1,0 +1,33 @@
+ARCH ?= x86_64
+
+ifeq ($(ARCH), x86_64)
+CROSS_COMPILE ?= x86_64-linux-musl-
+else ifeq ($(ARCH), riscv64)
+CROSS_COMPILE ?= riscv64-linux-musl-
+endif
+
+ifeq ($(origin CXX), default)
+CXX := $(CROSS_COMPILE)g++
+endif
+
+CXXFLAGS ?= -O2 -Wall -Wextra -Werror -std=c++17 -static
+BIN := timekeeping_calibration
+SRC := timekeeping_calibration.cc
+
+.PHONY: all install clean test-host
+
+all: $(BIN)
+
+$(BIN): $(SRC)
+	$(CXX) $(CXXFLAGS) $< -o $@
+
+install: all
+	@mkdir -p "$(DADK_CURRENT_BUILD_DIR)"
+	cp -f "$(BIN)" "$(DADK_CURRENT_BUILD_DIR)/$(BIN)"
+
+clean:
+	rm -f "$(BIN)"
+
+test-host:
+	$(MAKE) clean
+	$(MAKE) CROSS_COMPILE= CXX=c++

--- a/user/apps/timekeeping_calibration/timekeeping_calibration.cc
+++ b/user/apps/timekeeping_calibration/timekeeping_calibration.cc
@@ -1,0 +1,540 @@
+#include <errno.h>
+#include <inttypes.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <limits>
+#include <array>
+#include <initializer_list>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+constexpr const char* kProtocol = "TKCAL/2";
+constexpr uint64_t kMigrationStride = 4096;
+constexpr int kMigrationWaitRounds = 200000;
+constexpr size_t kMaxCommandLine = 1024;
+constexpr uint64_t kReadsRequired = 10000000;
+constexpr uint64_t kTarget10Seconds = 10000000000ULL;
+constexpr uint64_t kTarget60Seconds = 60000000000ULL;
+
+using Fields = std::unordered_map<std::string, std::string>;
+
+struct Command {
+    std::string verb;
+    Fields fields;
+};
+
+struct ReadStats {
+    uint64_t raw_reads = 0;
+    uint64_t mono_reads = 0;
+    uint64_t raw_regressions = 0;
+    uint64_t mono_regressions = 0;
+    uint64_t raw_max_backward_ns = 0;
+    uint64_t mono_max_backward_ns = 0;
+    uint64_t migrations_requested = 0;
+    uint64_t migrations_observed = 0;
+    uint64_t cpu_mask_seen = 0;
+};
+
+bool ToNs(clockid_t clock_id, uint64_t* value) {
+    timespec ts = {};
+    if (clock_gettime(clock_id, &ts) != 0 || ts.tv_sec < 0 || ts.tv_nsec < 0 ||
+        ts.tv_nsec >= 1000000000L) {
+        return false;
+    }
+    const auto seconds = static_cast<uint64_t>(ts.tv_sec);
+    if (seconds > (std::numeric_limits<uint64_t>::max() - static_cast<uint64_t>(ts.tv_nsec)) /
+                      1000000000ULL) {
+        errno = EOVERFLOW;
+        return false;
+    }
+    *value = seconds * 1000000000ULL + static_cast<uint64_t>(ts.tv_nsec);
+    return true;
+}
+
+int CurrentCpu() {
+    unsigned int cpu = 0;
+    if (syscall(SYS_getcpu, &cpu, nullptr, nullptr) != 0) {
+        return -1;
+    }
+    return static_cast<int>(cpu);
+}
+
+std::vector<int> AllowedCpus() {
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    std::vector<int> cpus;
+    if (sched_getaffinity(0, sizeof(set), &set) != 0) {
+        return cpus;
+    }
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (CPU_ISSET(cpu, &set)) {
+            cpus.push_back(cpu);
+        }
+    }
+    return cpus;
+}
+
+bool PinCpu(int cpu) {
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(cpu, &set);
+    return sched_setaffinity(0, sizeof(set), &set) == 0;
+}
+
+bool WaitForCpu(int cpu) {
+    for (int i = 0; i < kMigrationWaitRounds; ++i) {
+        if (CurrentCpu() == cpu) {
+            return true;
+        }
+        sched_yield();
+    }
+    errno = ETIMEDOUT;
+    return false;
+}
+
+bool ParseU64(const std::string& text, uint64_t* value) {
+    if (text.empty() || text[0] == '-') {
+        return false;
+    }
+    errno = 0;
+    char* end = nullptr;
+    const unsigned long long parsed = strtoull(text.c_str(), &end, 10);
+    if (errno != 0 || end == text.c_str() || *end != '\0') {
+        return false;
+    }
+    *value = static_cast<uint64_t>(parsed);
+    return true;
+}
+
+bool SafeToken(const std::string& text) {
+    if (text.empty() || text.size() > 128) {
+        return false;
+    }
+    for (unsigned char ch : text) {
+        if (!(ch == '_' || ch == '-' || ch == '.' ||
+              (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') ||
+              (ch >= 'a' && ch <= 'z'))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ValidRunId(const std::string& text) {
+    if (text.size() != 32) {
+        return false;
+    }
+    for (const unsigned char ch : text) {
+        if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ParseCommand(const char* line, Command* command) {
+    command->verb.clear();
+    command->fields.clear();
+    std::string input(line);
+    while (!input.empty() && (input.back() == '\n' || input.back() == '\r')) {
+        input.pop_back();
+    }
+    size_t cursor = 0;
+    while (cursor < input.size()) {
+        const size_t next = input.find(' ', cursor);
+        const std::string token = input.substr(cursor, next == std::string::npos
+                                                          ? std::string::npos
+                                                          : next - cursor);
+        if (!token.empty()) {
+            if (command->verb.empty()) {
+                command->verb = token;
+            } else {
+                const size_t equal = token.find('=');
+                if (equal == std::string::npos || equal == 0 || equal + 1 == token.size()) {
+                    return false;
+                }
+                const std::string key = token.substr(0, equal);
+                const std::string value = token.substr(equal + 1);
+                if (!SafeToken(key) || !SafeToken(value) || !command->fields.emplace(key, value).second) {
+                    return false;
+                }
+            }
+        }
+        if (next == std::string::npos) {
+            break;
+        }
+        cursor = next + 1;
+    }
+    return command->verb == "START" || command->verb == "END" || command->verb == "QUIT";
+}
+
+bool HasExactFields(const Command& command, std::initializer_list<const char*> names) {
+    if (command.fields.size() != names.size()) {
+        return false;
+    }
+    for (const char* name : names) {
+        if (command.fields.find(name) == command.fields.end()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+enum class LineResult { kOk, kEof, kTooLong };
+
+LineResult ReadBoundedLine(std::string* line) {
+    std::array<char, kMaxCommandLine + 2> buffer = {};
+    if (fgets(buffer.data(), buffer.size(), stdin) == nullptr) {
+        return LineResult::kEof;
+    }
+    const size_t length = strlen(buffer.data());
+    const bool has_newline = length > 0 && buffer[length - 1] == '\n';
+    if (!has_newline && !feof(stdin)) {
+        int ch = 0;
+        while ((ch = fgetc(stdin)) != '\n' && ch != EOF) {
+        }
+        return LineResult::kTooLong;
+    }
+    if (length > kMaxCommandLine + (has_newline ? 1U : 0U)) {
+        return LineResult::kTooLong;
+    }
+    line->assign(buffer.data(), length);
+    return LineResult::kOk;
+}
+
+bool ValidWorkload(const std::string& mode, const std::string& affinity, uint64_t target_ns,
+                   uint64_t reads) {
+    if ((mode == "sleep" || mode == "busy") && affinity == "fixed") {
+        return reads == 0 && (target_ns == kTarget10Seconds || target_ns == kTarget60Seconds);
+    }
+    if (mode == "reads" && (affinity == "fixed" || affinity == "migrate")) {
+        return target_ns == 0 && reads == kReadsRequired;
+    }
+    return false;
+}
+
+const std::string* Field(const Command& command, const char* name) {
+    const auto iterator = command.fields.find(name);
+    return iterator == command.fields.end() ? nullptr : &iterator->second;
+}
+
+void EmitReady(const std::string& run_id, uint64_t seq, const std::vector<int>& cpus) {
+    printf("%s READY run=%s seq=%" PRIu64 " cpus=", kProtocol, run_id.c_str(), seq);
+    if (cpus.empty()) {
+        printf("none");
+    }
+    for (size_t i = 0; i < cpus.size(); ++i) {
+        printf("%s%d", i == 0 ? "" : ",", cpus[i]);
+    }
+    printf("\n");
+}
+
+void EmitProtocolError(const std::string& run_id, uint64_t seq, const char* reason) {
+    printf("%s ERROR run=%s seq=%" PRIu64 " reason=%s\n", kProtocol, run_id.c_str(), seq,
+           reason);
+}
+
+bool SleepFor(uint64_t target_ns) {
+    timespec request = {static_cast<time_t>(target_ns / 1000000000ULL),
+                        static_cast<long>(target_ns % 1000000000ULL)};
+    while (true) {
+        timespec remaining = {};
+        const int result = clock_nanosleep(CLOCK_MONOTONIC, 0, &request, &remaining);
+        if (result == 0) {
+            return true;
+        }
+        if (result != EINTR) {
+            errno = result;
+            return false;
+        }
+        request = remaining;
+    }
+}
+
+bool BusyFor(uint64_t start_raw_ns, uint64_t target_ns, uint64_t* checksum) {
+    if (target_ns > std::numeric_limits<uint64_t>::max() - start_raw_ns) {
+        errno = EOVERFLOW;
+        return false;
+    }
+    const uint64_t deadline = start_raw_ns + target_ns;
+    uint64_t now = start_raw_ns;
+    uint64_t state = UINT64_C(0x9e3779b97f4a7c15);
+    while (now < deadline) {
+        for (int i = 0; i < 4096; ++i) {
+            state ^= state << 7;
+            state ^= state >> 9;
+            state *= UINT64_C(0xd6e8feb86659fd93);
+        }
+        if (!ToNs(CLOCK_MONOTONIC_RAW, &now)) {
+            return false;
+        }
+    }
+    *checksum = state;
+    return true;
+}
+
+void ObserveRead(uint64_t previous, uint64_t current, uint64_t* regressions,
+                 uint64_t* max_backward) {
+    if (current < previous) {
+        ++*regressions;
+        const uint64_t backward = previous - current;
+        if (backward > *max_backward) {
+            *max_backward = backward;
+        }
+    }
+}
+
+bool RunReads(uint64_t reads, bool migrate, const std::vector<int>& cpus, ReadStats* stats,
+              const char** reason) {
+    if (cpus.empty() || (migrate && cpus.size() < 2)) {
+        *reason = migrate ? "requires_two_cpus" : "no_allowed_cpu";
+        return false;
+    }
+    if (!PinCpu(cpus[0]) || !WaitForCpu(cpus[0])) {
+        *reason = "initial_affinity_failed";
+        return false;
+    }
+
+    uint64_t previous_raw = 0;
+    uint64_t previous_mono = 0;
+    if (!ToNs(CLOCK_MONOTONIC_RAW, &previous_raw) ||
+        !ToNs(CLOCK_MONOTONIC, &previous_mono)) {
+        *reason = "clock_read_failed";
+        return false;
+    }
+    const int initial_cpu = CurrentCpu();
+    if (initial_cpu >= 0 && initial_cpu < 64) {
+        stats->cpu_mask_seen |= UINT64_C(1) << initial_cpu;
+    }
+    int target_index = 0;
+    for (uint64_t i = 0; i < reads; ++i) {
+        if (migrate && i != 0 && i % kMigrationStride == 0) {
+            target_index ^= 1;
+            ++stats->migrations_requested;
+            if (!PinCpu(cpus[target_index]) || !WaitForCpu(cpus[target_index])) {
+                *reason = "migration_timeout";
+                return false;
+            }
+            ++stats->migrations_observed;
+            const int cpu = CurrentCpu();
+            if (cpu >= 0 && cpu < 64) {
+                stats->cpu_mask_seen |= UINT64_C(1) << cpu;
+            }
+        }
+        uint64_t current_raw = 0;
+        uint64_t current_mono = 0;
+        if (!ToNs(CLOCK_MONOTONIC_RAW, &current_raw) ||
+            !ToNs(CLOCK_MONOTONIC, &current_mono)) {
+            *reason = "clock_read_failed";
+            return false;
+        }
+        ObserveRead(previous_raw, current_raw, &stats->raw_regressions,
+                    &stats->raw_max_backward_ns);
+        ObserveRead(previous_mono, current_mono, &stats->mono_regressions,
+                    &stats->mono_max_backward_ns);
+        previous_raw = current_raw;
+        previous_mono = current_mono;
+        ++stats->raw_reads;
+        ++stats->mono_reads;
+    }
+    return true;
+}
+
+void DisableTerminalEcho(termios* saved, bool* valid) {
+    *valid = false;
+    if (!isatty(STDIN_FILENO) || tcgetattr(STDIN_FILENO, saved) != 0) {
+        return;
+    }
+    termios current = *saved;
+    current.c_lflag &= static_cast<tcflag_t>(~ECHO);
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &current) == 0) {
+        *valid = true;
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 3 || strcmp(argv[1], "--run-id") != 0 || !ValidRunId(argv[2])) {
+        fprintf(stderr, "usage: %s --run-id 32_LOWERCASE_HEX_DIGITS\n", argv[0]);
+        return 2;
+    }
+    const std::string run_id(argv[2]);
+    setvbuf(stdout, nullptr, _IONBF, 0);
+
+    termios saved = {};
+    bool restore_terminal = false;
+    DisableTerminalEcho(&saved, &restore_terminal);
+
+    const std::vector<int> cpus = AllowedCpus();
+    uint64_t expected_seq = 1;
+    bool completed = false;
+    EmitReady(run_id, 0, cpus);
+
+    std::string line;
+    while (true) {
+        const LineResult start_line = ReadBoundedLine(&line);
+        if (start_line == LineResult::kEof) {
+            break;
+        }
+        if (start_line == LineResult::kTooLong) {
+            EmitProtocolError(run_id, expected_seq, "line_too_long");
+            continue;
+        }
+        Command start;
+        if (!ParseCommand(line.c_str(), &start)) {
+            EmitProtocolError(run_id, expected_seq, "invalid_start");
+            continue;
+        }
+        if (start.verb == "QUIT") {
+            const std::string* command_run = Field(start, "run");
+            const std::string* seq_text = Field(start, "seq");
+            uint64_t seq = 0;
+            if (!HasExactFields(start, {"run", "seq"}) || command_run == nullptr ||
+                seq_text == nullptr || *command_run != run_id || !ParseU64(*seq_text, &seq) ||
+                seq != expected_seq) {
+                EmitProtocolError(run_id, expected_seq, "invalid_quit");
+                continue;
+            }
+            if (restore_terminal) {
+                tcsetattr(STDIN_FILENO, TCSANOW, &saved);
+                restore_terminal = false;
+            }
+            printf("%s ACK run=%s seq=%" PRIu64 " status=ok\n", kProtocol, run_id.c_str(), seq);
+            completed = true;
+            break;
+        }
+        if (start.verb != "START" ||
+            !HasExactFields(start, {"run", "seq", "case", "mode", "affinity", "target_ns",
+                                    "reads"})) {
+            EmitProtocolError(run_id, expected_seq, "invalid_start");
+            continue;
+        }
+        const std::string* command_run = Field(start, "run");
+        const std::string* seq_text = Field(start, "seq");
+        const std::string* case_id = Field(start, "case");
+        const std::string* mode = Field(start, "mode");
+        const std::string* affinity = Field(start, "affinity");
+        const std::string* target_text = Field(start, "target_ns");
+        const std::string* reads_text = Field(start, "reads");
+        uint64_t seq = 0;
+        uint64_t target_ns = 0;
+        uint64_t reads = 0;
+        if (command_run == nullptr || seq_text == nullptr || case_id == nullptr || mode == nullptr ||
+            affinity == nullptr || target_text == nullptr || reads_text == nullptr ||
+            *command_run != run_id || !SafeToken(*case_id) || !ParseU64(*seq_text, &seq) ||
+            !ParseU64(*target_text, &target_ns) || !ParseU64(*reads_text, &reads) ||
+            seq != expected_seq || !ValidWorkload(*mode, *affinity, target_ns, reads)) {
+            EmitProtocolError(run_id, expected_seq, "invalid_fields_or_sequence");
+            continue;
+        }
+
+        const bool migrate = *affinity == "migrate";
+        bool setup_ok = (*affinity == "fixed" || migrate) && !cpus.empty();
+        const char* reason = "ok";
+        if (!setup_ok) {
+            reason = cpus.empty() ? "no_allowed_cpu" : "invalid_affinity";
+        }
+        if (setup_ok && !migrate) {
+            setup_ok = PinCpu(cpus[0]) && WaitForCpu(cpus[0]);
+            if (!setup_ok) {
+                reason = "initial_affinity_failed";
+            }
+        }
+
+        uint64_t guest_start_raw = 0;
+        uint64_t guest_start_mono = 0;
+        setup_ok = setup_ok && ToNs(CLOCK_MONOTONIC_RAW, &guest_start_raw) &&
+                   ToNs(CLOCK_MONOTONIC, &guest_start_mono);
+        if (!setup_ok && strcmp(reason, "ok") == 0) {
+            reason = "start_clock_failed";
+        }
+        printf("%s START run=%s seq=%" PRIu64 " case=%s guest_raw_ns=%" PRIu64
+               " guest_mono_ns=%" PRIu64 " cpu=%d status=%s\n",
+               kProtocol, run_id.c_str(), seq, case_id->c_str(), guest_start_raw,
+               guest_start_mono, CurrentCpu(), setup_ok ? "ok" : "fail");
+
+        uint64_t checksum = 0;
+        ReadStats stats;
+        bool workload_ok = setup_ok;
+        if (workload_ok && *mode == "sleep") {
+            workload_ok = reads == 0 && SleepFor(target_ns);
+            if (!workload_ok) reason = "sleep_failed";
+        } else if (workload_ok && *mode == "busy") {
+            workload_ok = reads == 0 && BusyFor(guest_start_raw, target_ns, &checksum);
+            if (!workload_ok) reason = "busy_failed";
+        } else if (workload_ok && *mode == "reads") {
+            workload_ok = target_ns == 0 && reads > 0 &&
+                          RunReads(reads, migrate, cpus, &stats, &reason);
+        } else if (workload_ok) {
+            workload_ok = false;
+            reason = "unsupported_mode";
+        }
+
+        uint64_t work_end_raw = 0;
+        uint64_t work_end_mono = 0;
+        if (!ToNs(CLOCK_MONOTONIC_RAW, &work_end_raw) ||
+            !ToNs(CLOCK_MONOTONIC, &work_end_mono)) {
+            workload_ok = false;
+            reason = "work_end_clock_failed";
+        }
+        printf("%s WORK_DONE run=%s seq=%" PRIu64 " case=%s status=%s reason=%s"
+               " work_end_raw_ns=%" PRIu64 " work_end_mono_ns=%" PRIu64
+               " checksum=%016" PRIx64 " raw_reads=%" PRIu64 " mono_reads=%" PRIu64
+               " raw_regressions=%" PRIu64 " mono_regressions=%" PRIu64
+               " raw_max_backward_ns=%" PRIu64 " mono_max_backward_ns=%" PRIu64
+               " migrations_requested=%" PRIu64 " migrations_observed=%" PRIu64
+               " cpu_mask_seen=%016" PRIx64 "\n",
+               kProtocol, run_id.c_str(), seq, case_id->c_str(), workload_ok ? "ok" : "fail",
+               reason, work_end_raw, work_end_mono, checksum, stats.raw_reads, stats.mono_reads,
+               stats.raw_regressions, stats.mono_regressions, stats.raw_max_backward_ns,
+               stats.mono_max_backward_ns, stats.migrations_requested,
+               stats.migrations_observed, stats.cpu_mask_seen);
+
+        const LineResult end_line = ReadBoundedLine(&line);
+        if (end_line == LineResult::kEof) {
+            break;
+        }
+        if (end_line == LineResult::kTooLong) {
+            EmitProtocolError(run_id, expected_seq, "line_too_long");
+            break;
+        }
+        Command end;
+        uint64_t end_seq = 0;
+        const bool end_ok = ParseCommand(line.c_str(), &end) && end.verb == "END" &&
+                            HasExactFields(end, {"run", "seq"}) &&
+                            Field(end, "run") != nullptr && *Field(end, "run") == run_id &&
+                            Field(end, "seq") != nullptr && ParseU64(*Field(end, "seq"), &end_seq) &&
+                            end_seq == seq;
+        uint64_t guest_end_raw = 0;
+        uint64_t guest_end_mono = 0;
+        const bool end_clock_ok = ToNs(CLOCK_MONOTONIC_RAW, &guest_end_raw) &&
+                                  ToNs(CLOCK_MONOTONIC, &guest_end_mono);
+        printf("%s END run=%s seq=%" PRIu64 " case=%s guest_raw_ns=%" PRIu64
+               " guest_mono_ns=%" PRIu64 " cpu=%d status=%s\n",
+               kProtocol, run_id.c_str(), seq, case_id->c_str(), guest_end_raw, guest_end_mono,
+               CurrentCpu(), end_ok && end_clock_ok && workload_ok ? "ok" : "fail");
+        if (!end_ok) {
+            EmitProtocolError(run_id, expected_seq, "invalid_end");
+            break;
+        }
+        ++expected_seq;
+        EmitReady(run_id, expected_seq - 1, cpus);
+    }
+
+    if (restore_terminal) {
+        tcsetattr(STDIN_FILENO, TCSANOW, &saved);
+    }
+    return completed ? 0 : 1;
+}

--- a/user/dadk/config/all/timekeeping_calibration.toml
+++ b/user/dadk/config/all/timekeeping_calibration.toml
@@ -1,0 +1,20 @@
+name = "timekeeping_calibration"
+version = "0.1.0"
+description = "Guest helper for bracketed DragonOS timekeeping calibration"
+build-once = false
+install-once = false
+target-arch = ["x86_64"]
+
+[task-source]
+type = "build-from-source"
+source = "local"
+source-path = "user/apps/timekeeping_calibration"
+
+[build]
+build-command = "make install"
+
+[install]
+in-dragonos-path = "/opt/tests/timekeeping-calibration"
+
+[clean]
+clean-command = "make clean"

--- a/user/dadk/config/sets/ubuntu2404/timekeeping_calibration.toml
+++ b/user/dadk/config/sets/ubuntu2404/timekeeping_calibration.toml
@@ -1,0 +1,1 @@
+../../all/timekeeping_calibration.toml


### PR DESCRIPTION
## Summary

- separate realtime, monotonic, monotonic-raw, boottime, and coarse clock semantics
- make clocksource registration, selection, watchdog updates, switching, and rollback transactional
- preserve elapsed time and fractional state across clocksource changes
- initialize KVM clock state per CPU and roll back failed AP bring-up without publishing partial state
- guarantee timekeeper writer progress and track hardirq/softirq context explicitly
- align nanosleep restart, signal wait, and futex timeout consumers with Linux clock domains
- add kernel selftests, dunitest coverage, and fail-closed host/guest calibration tooling

## Root cause

The previous timekeeper used the realtime epoch for clocks that must remain independent of wall-clock changes. Clocksource cycle state also had multiple owners, so updates and source changes could lose elapsed time or recurse through the timekeeper lock. Continuous readers could starve writers, and KVM clock/AP initialization could expose partially initialized per-CPU state after a failure.

Timeout consumers inherited these clock-domain errors, making relative waits and restart handling sensitive to realtime behavior.

## Implementation

The timekeeper now owns independent monotonic and raw read bases. Realtime and boottime are derived through explicit offsets, while coarse clocks expose committed bases without performing a hardware read.

Clocksource control operations use a single serialized transaction with validation and rollback. A switch forwards the old source before installing the new source, retains fractional time, and publishes one coherent generation. KVM clock setup preallocates per-CPU state and only marks an AP online after initialization succeeds.

RwLock writer preference provides bounded writer progress. Explicit interrupt-context guards keep blocking lock paths out of hardirq and softirq execution. POSIX clock syscalls and timeout users now select the clock domain required by Linux semantics.

## User-visible impact

- `CLOCK_REALTIME` remains an epoch clock while monotonic/raw/boottime report uptime domains.
- Wall-clock changes no longer alter monotonic timeout behavior.
- Relative nanosleep, signal waits, and futex waits use stable monotonic deadlines.
- Clocksource changes no longer discard the elapsed interval before the switch.
- Failed KVM AP initialization no longer leaves partially published clock state.

This PR establishes the trustworthy Timekeeping baseline for later scheduler latency investigation; it does not claim to fix the separate `lat_ctx` scheduling/wakeup performance issue.

## Validation

- `make kernel` — x86_64 build and link passed
- `make -C kernel all ARCH=riscv64` — Rust build and kernel ELF links passed; final local packaging could not run because the optional DragonStub checkout was unavailable
- `python3 -m unittest tools.timekeeping.test_calibrate` — 31/31 passed
- `make -C user/apps/timekeeping_calibration test-host` — passed with static linking and warnings-as-errors
- Python syntax checks and `bash -n tools/run-qemu.sh` — passed
- KVM 2-vCPU Timekeeping/restart validation — 19/19 relevant tests passed
- fixed-CPU monotonic/raw stress — 10,000,000 reads without regression
- migrating monotonic/raw stress — 10,000,000 reads without regression
