### PR TITLE
fix(fs): align post-write sync with Linux generic_write_sync

### DIFF
--- a/kernel/src/driver/base/block/block_device.rs
+++ b/kernel/src/driver/base/block/block_device.rs
@@ -16,6 +16,12 @@ use log::error;
 use system_error::SystemError;
 
 use super::{disk_info::Partition, gendisk::GenDisk, manager::BlockDevMeta};
+use crate::{
+    filesystem::vfs::{
+        file::FileFlags, DelegatedWriteResult, FilePrivateData, InodeMode, WriteSyncIntent,
+    },
+    libs::mutex::MutexGuard,
+};
 
 // 该文件定义了 Device 和 BlockDevice 的接口
 // Notice 设备错误码使用 Posix 规定的 int32_t 的错误码表示，而不是自己定义错误enum
@@ -220,6 +226,32 @@ pub fn __lba_to_bytes(lba_id: usize, blk_size: usize) -> BlockId {
 
 /// @brief 块设备应该实现的操作
 pub trait BlockDevice: Device {
+    /// Permissions used for the published devfs block node.
+    fn devfs_mode(&self) -> InodeMode {
+        InodeMode::from_bits_truncate(0o755)
+    }
+
+    fn file_open(
+        &self,
+        _data: MutexGuard<FilePrivateData>,
+        _flags: &FileFlags,
+    ) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    /// Release per-open block-device state initialized by [`Self::file_open`].
+    fn file_close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    /// Pin this block device for the lifetime of a mounted filesystem.
+    fn mount_holder_acquire(&self) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    /// Release a mount pin previously acquired by [`Self::mount_holder_acquire`].
+    fn mount_holder_release(&self) {}
+
     /// # dev_name
     /// 返回块设备的名字
     fn dev_name(&self) -> &DevName;
@@ -257,6 +289,25 @@ pub trait BlockDevice: Device {
         count: usize,
         buf: &[u8],
     ) -> Result<usize, SystemError>;
+
+    /// Whether this device implements an atomic write plus optional flush
+    /// operation for a delegated VFS synchronous write.
+    fn uses_delegated_write_sync(&self) -> bool {
+        false
+    }
+
+    /// Execute a byte write and consume the requested sync intent in the same
+    /// device operation. The default must not emulate this as write-then-sync:
+    /// devices without a stable configuration snapshot use generic VFS sync.
+    fn write_at_bytes_with_sync(
+        &self,
+        _offset: usize,
+        _len: usize,
+        _buf: &[u8],
+        _sync_intent: WriteSyncIntent,
+    ) -> Result<DelegatedWriteResult, SystemError> {
+        Err(SystemError::ENOSYS)
+    }
 
     /// @brief: 同步磁盘信息，把所有的dirty数据写回硬盘 - 待实现
     fn sync(&self) -> Result<(), SystemError>;

--- a/kernel/src/driver/base/block/gendisk/mod.rs
+++ b/kernel/src/driver/base/block/gendisk/mod.rs
@@ -1,5 +1,6 @@
 use core::{
     convert::TryFrom,
+    fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
     sync::atomic::{AtomicU32, Ordering},
 };
@@ -16,7 +17,10 @@ use crate::{
     driver::{base::device::device_number::DeviceNumber, block::loop_device::LoopDevice},
     filesystem::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
-        vfs::{utils::DName, FilePrivateData, FileType, IndexNode, InodeMode, Metadata},
+        vfs::{
+            utils::DName, DelegatedWriteResult, FilePrivateData, IndexNode, Metadata,
+            OpenFileBehavior, PostWriteSyncPolicy, WriteSyncIntent,
+        },
     },
     libs::{mutex::MutexGuard, rwlock::RwLock},
 };
@@ -39,6 +43,24 @@ pub struct GenDisk {
     name: DName,
 }
 
+pub struct GenDiskMountGuard {
+    bdev: Arc<dyn BlockDevice>,
+}
+
+impl Debug for GenDiskMountGuard {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenDiskMountGuard")
+            .field("device", self.bdev.dev_name())
+            .finish()
+    }
+}
+
+impl Drop for GenDiskMountGuard {
+    fn drop(&mut self) {
+        self.bdev.mount_holder_release();
+    }
+}
+
 impl GenDisk {
     /// 如果gendisk是整个磁盘，则idx为u32::MAX
     pub const ENTIRE_DISK_IDX: u32 = u32::MAX;
@@ -49,14 +71,16 @@ impl GenDisk {
         idx: Option<u32>,
         dev_name: DName,
     ) -> Arc<Self> {
-        let bsizelog2 = bdev.upgrade().unwrap().blk_size_log2();
+        let ptr = bdev
+            .upgrade()
+            .expect("backing block device disappeared while creating GenDisk");
+        let bsizelog2 = ptr.blk_size_log2();
 
         // 对应整块硬盘的情况
         let id = idx.unwrap_or(0);
         if id >= MINORS_PER_DISK {
             panic!("GenDisk index out of range: {}", id);
         }
-        let ptr = bdev.upgrade().unwrap();
         let meta = ptr.blkdev_meta();
         let major = meta.major;
 
@@ -74,14 +98,20 @@ impl GenDisk {
             fs: RwLock::new(Weak::default()),
             metadata: Metadata::new(
                 crate::filesystem::vfs::FileType::BlockDevice,
-                InodeMode::from_bits_truncate(0o755),
+                ptr.devfs_mode(),
             ),
             name: dev_name,
         });
     }
 
-    pub fn block_device(&self) -> Arc<dyn BlockDevice> {
-        return self.bdev.upgrade().unwrap();
+    pub fn block_device(&self) -> Result<Arc<dyn BlockDevice>, SystemError> {
+        self.bdev.upgrade().ok_or(SystemError::ENODEV)
+    }
+
+    pub fn acquire_mount_holder(&self) -> Result<GenDiskMountGuard, SystemError> {
+        let bdev = self.block_device()?;
+        bdev.mount_holder_acquire()?;
+        Ok(GenDiskMountGuard { bdev })
     }
 
     /// # read_at
@@ -104,7 +134,7 @@ impl GenDisk {
         let blocks = buf.len() / (1 << self.block_size_log2 as usize);
         let lba = self.block_offset_2_disk_blkid(start_block_offset);
 
-        return self.block_device().read_at(lba, blocks, buf);
+        return self.block_device()?.read_at(lba, blocks, buf);
     }
 
     /// # read_at_bytes
@@ -119,7 +149,7 @@ impl GenDisk {
         let start_lba = self.range.lba_start;
         let bytes_offset = self.disk_blkid_2_bytes(start_lba) + bytes_offset;
         return self
-            .block_device()
+            .block_device()?
             .read_at_bytes(bytes_offset, buf.len(), buf);
     }
 
@@ -141,7 +171,7 @@ impl GenDisk {
         let start_lba = self.range.lba_start;
         let bytes_offset = self.disk_blkid_2_bytes(start_lba) + bytes_offset;
         return self
-            .block_device()
+            .block_device()?
             .write_at_bytes(bytes_offset, buf.len(), buf);
     }
 
@@ -160,7 +190,7 @@ impl GenDisk {
 
         let blocks = buf.len() / (1 << self.block_size_log2 as usize);
         let lba = self.block_offset_2_disk_blkid(start_block_offset);
-        return self.block_device().write_at(lba, blocks, buf);
+        return self.block_device()?.write_at(lba, blocks, buf);
     }
 
     #[inline]
@@ -208,7 +238,7 @@ impl GenDisk {
     /// # sync
     /// 同步磁盘
     pub fn sync(&self) -> Result<(), SystemError> {
-        self.block_device().sync()
+        self.block_device()?.sync()
     }
 
     pub fn symlink_name(&self) -> String {
@@ -231,8 +261,13 @@ impl IndexNode for GenDisk {
         self
     }
 
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::BlockDevice
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        if self
+            .block_device()
+            .is_ok_and(|bdev| bdev.uses_delegated_write_sync())
+        {
+            behavior.post_write_sync = PostWriteSyncPolicy::Delegated;
+        }
     }
 
     fn sync_file(
@@ -275,6 +310,25 @@ impl IndexNode for GenDisk {
         self.write_at_bytes(&buf[..len], offset)
     }
 
+    fn write_at_with_sync(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &[u8],
+        sync_intent: WriteSyncIntent,
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<DelegatedWriteResult, SystemError> {
+        if len > buf.len() {
+            return Err(SystemError::E2BIG);
+        }
+        let disk_offset = self
+            .disk_blkid_2_bytes(self.range().lba_start)
+            .checked_add(offset)
+            .ok_or(SystemError::EOVERFLOW)?;
+        self.block_device()?
+            .write_at_bytes_with_sync(disk_offset, len, &buf[..len], sync_intent)
+    }
+
     fn list(&self) -> Result<alloc::vec::Vec<alloc::string::String>, system_error::SystemError> {
         Err(SystemError::ENOSYS)
     }
@@ -306,17 +360,17 @@ impl IndexNode for GenDisk {
 
     fn close(
         &self,
-        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<(), SystemError> {
-        Ok(())
+        self.block_device()?.file_close(data)
     }
 
     fn open(
         &self,
-        _data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
-        _mode: &crate::filesystem::vfs::file::FileFlags,
+        data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
+        mode: &crate::filesystem::vfs::file::FileFlags,
     ) -> Result<(), SystemError> {
-        Ok(())
+        self.block_device()?.file_open(data, mode)
     }
 
     fn ioctl(
@@ -325,7 +379,7 @@ impl IndexNode for GenDisk {
         data: usize,
         private_data: MutexGuard<crate::filesystem::vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        let bdev = self.block_device();
+        let bdev = self.block_device()?;
         if let Some(loop_dev) = BlockDevice::as_any_ref(&*bdev).downcast_ref::<LoopDevice>() {
             loop_dev.ioctl(cmd, data, private_data)
         } else {

--- a/kernel/src/driver/base/block/gendisk/mod.rs
+++ b/kernel/src/driver/base/block/gendisk/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     driver::{base::device::device_number::DeviceNumber, block::loop_device::LoopDevice},
     filesystem::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
-        vfs::{utils::DName, IndexNode, InodeMode, Metadata},
+        vfs::{utils::DName, FilePrivateData, FileType, IndexNode, InodeMode, Metadata},
     },
     libs::{mutex::MutexGuard, rwlock::RwLock},
 };
@@ -229,6 +229,18 @@ impl IndexNode for GenDisk {
 
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
+    }
+
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::BlockDevice
+    }
+
+    fn sync_file(
+        &self,
+        _datasync: bool,
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        self.sync()
     }
 
     fn read_at(

--- a/kernel/src/driver/block/loop_device/constants.rs
+++ b/kernel/src/driver/block/loop_device/constants.rs
@@ -60,6 +60,8 @@ bitflags! {
     pub struct LoopFlags: u32 {
         /// 只读模式
         const READ_ONLY = 1 << 0;
+        /// Clear the backing file after the last opener and mount holder leave.
+        const AUTOCLEAR = 1 << 2;
     }
 }
 

--- a/kernel/src/driver/block/loop_device/constants.rs
+++ b/kernel/src/driver/block/loop_device/constants.rs
@@ -14,10 +14,6 @@ pub const LOOP_IO_DRAIN_TIMEOUT_MS: u32 = 30_000;
 /// I/O 排空检查间隔 (微秒)
 pub const LOOP_IO_DRAIN_CHECK_INTERVAL_US: u32 = 10_000;
 
-/// drain_active_io 最大重试次数
-/// 超过此次数后将强制进入 Deleting 状态，避免无限重试
-pub const LOOP_IO_DRAIN_MAX_RETRIES: u32 = 3;
-
 /// Loop 设备 ioctl 命令
 #[repr(u32)]
 #[derive(Debug, FromPrimitive)]

--- a/kernel/src/driver/block/loop_device/loop_control.rs
+++ b/kernel/src/driver/block/loop_device/loop_control.rs
@@ -176,7 +176,7 @@ impl IndexNode for LoopControlDevice {
                 log::info!("Starting LOOP_CTL_ADD ioctl");
                 let requested_index = data as u32;
                 let loop_dev = if requested_index == u32::MAX {
-                    self.loop_mgr.loop_add(None)?
+                    self.loop_mgr.loop_add_new()?
                 } else {
                     self.loop_mgr.loop_add(Some(requested_index))?
                 };
@@ -196,10 +196,7 @@ impl IndexNode for LoopControlDevice {
                 self.loop_mgr.loop_remove(minor_to_remove)?;
                 Ok(0)
             }
-            Some(LoopControlIoctl::GetFree) => match self.loop_mgr.find_free_minor() {
-                Some(minor) => Ok(minor as usize),
-                None => Err(SystemError::ENOSPC),
-            },
+            Some(LoopControlIoctl::GetFree) => Ok(self.loop_mgr.find_or_add_free_minor()? as usize),
             _ => Err(SystemError::ENOSYS),
         }
     }

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -1010,6 +1010,18 @@ impl IndexNode for LoopDevice {
         self
     }
 
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::BlockDevice
+    }
+
+    fn sync_file(
+        &self,
+        _datasync: bool,
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        <Self as BlockDevice>::sync(self)
+    }
+
     fn read_at(
         &self,
         offset: usize,

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -1338,6 +1338,8 @@ impl BlockDevice for LoopDevice {
     }
 
     fn sync(&self) -> Result<(), SystemError> {
+        let _io_guard = IoGuard::new(self)?;
+
         let inode = self.inner().file_inode.clone().ok_or(SystemError::ENODEV)?;
         inode.sync()?;
         inode.fs().sync_fs(true)

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -3,6 +3,7 @@ use crate::{
         block::{
             block_device::{BlockDevice, BlockId, GeneralBlockRange, LBA_SIZE},
             disk_info::Partition,
+            gendisk::GenDisk,
             manager::BlockDevMeta,
         },
         class::Class,
@@ -22,7 +23,11 @@ use crate::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
         kernfs::KernFSInode,
         sysfs::{AttributeGroup, SysFSOps},
-        vfs::{FilePrivateData, FileType, IndexNode, InodeFlags, InodeId, InodeMode, Metadata},
+        vfs::{
+            file::{File, FileFlags},
+            DelegatedWriteResult, FilePrivateData, FileType, IndexNode, InodeFlags, InodeId,
+            InodeMode, Metadata, WriteSyncIntent,
+        },
     },
     libs::{
         mutex::{Mutex, MutexGuard},
@@ -30,6 +35,7 @@ use crate::{
         rwsem::{RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
     },
+    process::cred::{capable, CAPFlags},
     process::ProcessManager,
     syscall::user_access::{UserBufferReader, UserBufferWriter},
     time::{sleep::nanosleep, PosixTimeSpec},
@@ -44,7 +50,7 @@ use core::{
     fmt::{Debug, Formatter},
     sync::atomic::{AtomicU32, Ordering},
 };
-use log::{error, info, warn};
+use log::{info, warn};
 use num_traits::FromPrimitive;
 use system_error::SystemError;
 
@@ -52,6 +58,12 @@ use super::constants::{
     LoopFlags, LoopIoctl, LoopState, LoopStatus, LoopStatus64, LOOP_BASENAME,
     LOOP_IO_DRAIN_CHECK_INTERVAL_US, LOOP_IO_DRAIN_TIMEOUT_MS,
 };
+
+/// Serializes loop backing topology validation and publication.
+///
+/// The fixed lock order is:
+/// `LOOP_BACKING_TOPOLOGY_LOCK -> LoopDevice::config_mutex -> inner`.
+static LOOP_BACKING_TOPOLOGY_LOCK: Mutex<()> = Mutex::new(());
 
 /// Loop 设备 KObject 类型
 #[derive(Debug)]
@@ -104,27 +116,50 @@ pub struct LoopDevice {
     self_ref: Weak<Self>,
     fs: RwLock<Weak<DevFS>>,
     parent: RwLock<Weak<LockedDevFSInode>>,
+    /// Serializes SET/CHANGE/CLEAR/DELETE configuration transactions.
+    config_mutex: Mutex<()>,
     /// 活跃的 I/O 操作计数
     active_io_count: AtomicU32,
+    /// Open file descriptions referring to this GenDisk.
+    open_count: AtomicU32,
+    /// Mounted filesystems using this GenDisk for their complete lifetime.
+    mount_holder_count: AtomicU32,
 }
 
-/// Loop 设备的私有数据（目前未使用）
+/// Per-open loop control state.
 #[derive(Debug, Clone, Default)]
-pub struct LoopPrivateData;
+pub struct LoopPrivateData {
+    /// Whether this open description of `/dev/loopN` has write access.
+    control_writable: bool,
+    /// Ensures the BlockDevice open count is released exactly once.
+    open_counted: bool,
+    /// Pins the BlockDevice while GenDisk itself intentionally stores only Weak.
+    _device_pin: Option<Arc<LoopDevice>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopQuiesceOwner {
+    Change,
+    Clear,
+    Reconfigure,
+}
 
 /// Loop 设备内部状态
 pub struct LoopDeviceInner {
     pub device_number: DeviceNumber,
     state: LoopState,
-    pub file_inode: Option<Arc<dyn IndexNode>>,
+    pub backing_file: Option<Arc<File>>,
     pub file_size: usize,
     pub offset: usize,
     pub size_limit: usize,
     pub flags: LoopFlags,
     pub kobject_common: KObjectCommonData,
     pub device_common: DeviceCommonData,
-    /// drain_active_io 重试计数，用于限制无限重试
-    drain_retry_count: u32,
+    /// Incremented whenever a backing/configuration generation is published.
+    generation: u64,
+    /// Monotonic owner token for quiesce transactions.
+    quiesce_epoch: u64,
+    quiesce_owner: Option<(u64, LoopQuiesceOwner)>,
 }
 
 impl LoopDeviceInner {
@@ -135,14 +170,15 @@ impl LoopDeviceInner {
         const VALID_TRANSITIONS: &[(LoopState, LoopState)] = &[
             (LoopState::Unbound, LoopState::Bound),
             (LoopState::Bound, LoopState::Unbound),
+            (LoopState::Bound, LoopState::Draining),
             (LoopState::Bound, LoopState::Rundown),
             (LoopState::Rundown, LoopState::Draining),
             (LoopState::Rundown, LoopState::Deleting),
             (LoopState::Rundown, LoopState::Unbound),
-            // 允许 Draining 回滚到 Rundown：当 I/O 排空超时/失败时保持拒绝新 I/O，
-            // 并允许后续重试 drain 或继续删除流程。
+            (LoopState::Draining, LoopState::Bound),
             (LoopState::Draining, LoopState::Rundown),
             (LoopState::Draining, LoopState::Deleting),
+            (LoopState::Draining, LoopState::Unbound),
             (LoopState::Unbound, LoopState::Deleting),
             // 允许 Deleting 回滚到 Rundown：当 unregister() 失败时，
             // 允许回滚状态以便后续重试删除操作，避免设备成为"僵尸"状态。
@@ -198,31 +234,23 @@ impl LoopDevice {
         Ok(effective)
     }
 
-    fn set_file_locked(
-        inner: &mut LoopDeviceInner,
-        file_inode: Arc<dyn IndexNode>,
-        file_size: usize,
-    ) {
-        inner.file_inode = Some(file_inode);
+    fn set_file_locked(inner: &mut LoopDeviceInner, backing_file: Arc<File>, file_size: usize) {
+        inner.backing_file = Some(backing_file);
         inner.file_size = file_size;
         inner.offset = 0;
         inner.size_limit = 0;
+        inner.generation = inner.generation.wrapping_add(1);
     }
 
     fn change_file_locked(
         inner: &mut LoopDeviceInner,
-        file_inode: Arc<dyn IndexNode>,
+        backing_file: Arc<File>,
         total_size: usize,
-        read_only: bool,
     ) -> Result<(), SystemError> {
         let effective = Self::calc_effective_size(total_size, inner.offset, inner.size_limit)?;
-        inner.file_inode = Some(file_inode);
-        inner.flags = if read_only {
-            LoopFlags::READ_ONLY
-        } else {
-            LoopFlags::empty()
-        };
+        inner.backing_file = Some(backing_file);
         inner.file_size = effective;
+        inner.generation = inner.generation.wrapping_add(1);
         Ok(())
     }
 
@@ -251,7 +279,7 @@ impl LoopDevice {
             id,
             minor,
             inner: SpinLock::new(LoopDeviceInner {
-                file_inode: None,
+                backing_file: None,
                 file_size: 0,
                 device_number: DeviceNumber::new(Major::LOOP_MAJOR, minor),
                 offset: 0,
@@ -260,14 +288,19 @@ impl LoopDevice {
                 kobject_common: KObjectCommonData::default(),
                 device_common: DeviceCommonData::default(),
                 state: LoopState::Unbound,
-                drain_retry_count: 0,
+                generation: 0,
+                quiesce_epoch: 0,
+                quiesce_owner: None,
             }),
             block_dev_meta: BlockDevMeta::new(devname, Major::LOOP_MAJOR),
             locked_kobj_state: LockedKObjectState::default(),
             self_ref: self_ref.clone(),
             fs: RwLock::new(Weak::default()),
             parent: RwLock::new(Weak::default()),
+            config_mutex: Mutex::new(()),
             active_io_count: AtomicU32::new(0),
+            open_count: AtomicU32::new(0),
+            mount_holder_count: AtomicU32::new(0),
         });
 
         // 设置 KObjType
@@ -277,11 +310,11 @@ impl LoopDevice {
     }
 
     fn compute_effective_size(
-        inode: &Arc<dyn IndexNode>,
+        file: &Arc<File>,
         offset: usize,
         size_limit: usize,
     ) -> Result<usize, SystemError> {
-        let metadata = inode.metadata()?;
+        let metadata = file.inode().metadata()?;
         if metadata.size < 0 {
             return Err(SystemError::EINVAL);
         }
@@ -289,65 +322,104 @@ impl LoopDevice {
         Self::calc_effective_size(total_size, offset, size_limit)
     }
 
-    fn recalc_effective_size(&self) -> Result<(), SystemError> {
-        // 通过“快照 -> 计算 -> CAS式提交”的方式避免：
-        // - 持锁期间调用 metadata() 导致阻塞
-        // - offset/limit/inode 并发变化时写入错误的 file_size
-        const MAX_RETRY: usize = 8;
-        for _ in 0..MAX_RETRY {
-            let (file_inode, offset, size_limit) = {
-                let inner = self.inner();
-                (inner.file_inode.clone(), inner.offset, inner.size_limit)
-            };
-
-            let inode = file_inode.ok_or(SystemError::ENODEV)?;
-            let effective = Self::compute_effective_size(&inode, offset, size_limit)?;
-
-            let mut inner = self.inner();
-            let still_same_inode = inner
-                .file_inode
-                .as_ref()
-                .map(|cur| Arc::ptr_eq(cur, &inode))
-                .unwrap_or(false);
-            if still_same_inode && inner.offset == offset && inner.size_limit == size_limit {
-                inner.file_size = effective;
-                return Ok(());
-            }
-        }
-        Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
-    }
-
     pub fn is_bound(&self) -> bool {
         matches!(self.inner().state(), LoopState::Bound)
     }
 
-    /// # 功能
-    ///
-    /// 将文件绑定到 loop 设备并设置访问权限。
-    ///
-    /// ## 参数
-    ///
-    /// - `file_inode`: 需要绑定的文件节点。
-    /// - `read_only`: 是否以只读方式绑定。
-    ///
-    /// ## 返回值
-    /// - `Ok(())`: 成功绑定。
-    /// - `Err(SystemError)`: 绑定失败的原因。
-    pub fn bind_file(
-        &self,
-        file_inode: Arc<dyn IndexNode>,
-        read_only: bool,
-    ) -> Result<(), SystemError> {
-        // 先在锁外拿到 metadata，避免在持锁期间做可能阻塞的操作
-        let metadata = file_inode.metadata()?;
+    /// Validate a candidate while the global backing-topology lock is held.
+    fn validate_backing_chain(&self, candidate: &Arc<File>) -> Result<(), SystemError> {
+        let mut current = candidate.clone();
+        let mut visited = Vec::new();
+
+        loop {
+            let inode = current.inode();
+            let block_device = inode
+                .as_any_ref()
+                .downcast_ref::<GenDisk>()
+                .map(GenDisk::block_device)
+                .transpose()?;
+
+            let loop_dev = if let Some(loop_dev) = inode.as_any_ref().downcast_ref::<LoopDevice>() {
+                loop_dev
+            } else if let Some(block_device) = block_device.as_ref() {
+                let Some(loop_dev) =
+                    BlockDevice::as_any_ref(block_device.as_ref()).downcast_ref::<LoopDevice>()
+                else {
+                    return Ok(());
+                };
+                loop_dev
+            } else {
+                return Ok(());
+            };
+
+            if core::ptr::eq(loop_dev, self) || visited.contains(&loop_dev.id()) {
+                return Err(SystemError::EBADF);
+            }
+            visited.push(loop_dev.id());
+
+            let inner = loop_dev.inner();
+            if !matches!(inner.state(), LoopState::Bound) {
+                return Err(SystemError::EINVAL);
+            }
+            current = inner.backing_file.clone().ok_or(SystemError::EINVAL)?;
+        }
+    }
+
+    fn wait_for_active_io(&self) -> Result<(), SystemError> {
+        let max_checks = LOOP_IO_DRAIN_TIMEOUT_MS * 1000 / LOOP_IO_DRAIN_CHECK_INTERVAL_US;
+        let sleep_ts = PosixTimeSpec::new(
+            0,
+            (LOOP_IO_DRAIN_CHECK_INTERVAL_US as i64).saturating_mul(1000),
+        );
+
+        for _ in 0..max_checks {
+            if self.active_io_count.load(Ordering::Acquire) == 0 {
+                return Ok(());
+            }
+            let _ = nanosleep(sleep_ts);
+        }
+        Err(SystemError::ETIMEDOUT)
+    }
+
+    fn install_quiesce_owner(inner: &mut LoopDeviceInner, owner: LoopQuiesceOwner) -> (u64, u64) {
+        inner.quiesce_epoch = inner.quiesce_epoch.wrapping_add(1);
+        let epoch = inner.quiesce_epoch;
+        let generation = inner.generation;
+        inner.quiesce_owner = Some((epoch, owner));
+        (epoch, generation)
+    }
+
+    fn quiesce_still_owned(
+        inner: &LoopDeviceInner,
+        epoch: u64,
+        generation: u64,
+        owner: LoopQuiesceOwner,
+    ) -> bool {
+        inner.generation == generation && inner.quiesce_owner == Some((epoch, owner))
+    }
+
+    fn rollback_bound_quiesce(&self, epoch: u64, generation: u64, owner: LoopQuiesceOwner) {
+        let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+        let _config = self.config_mutex.lock();
+        let mut inner = self.inner();
+        if Self::quiesce_still_owned(&inner, epoch, generation, owner) {
+            inner.quiesce_owner = None;
+            let _ = inner.set_state(LoopState::Bound);
+        }
+    }
+
+    pub fn bind_file(&self, backing_file: Arc<File>, read_only: bool) -> Result<(), SystemError> {
+        // Metadata can block; fetch it before taking loop configuration locks.
+        let metadata = backing_file.inode().metadata()?;
         if metadata.size < 0 {
             return Err(SystemError::EINVAL);
         }
-
         let total_size = metadata.size as usize;
 
-        // 在同一个临界区里完成状态检查 + 状态转换 + 写入 file_inode，
-        // 避免 set_file() 先修改数据、再 set_state() 失败造成"半更新"。
+        let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+        let _config = self.config_mutex.lock();
+        self.validate_backing_chain(&backing_file)?;
+
         let mut inner = self.inner();
         match inner.state() {
             LoopState::Unbound => {}
@@ -358,69 +430,66 @@ impl LoopDevice {
         }
 
         inner.set_state(LoopState::Bound)?;
-        Self::set_file_locked(&mut inner, file_inode.clone(), total_size);
+        Self::set_file_locked(&mut inner, backing_file, total_size);
         inner.flags = if read_only {
             LoopFlags::READ_ONLY
         } else {
             LoopFlags::empty()
         };
-        drop(inner);
-
-        // recalc_effective_size 失败时回滚状态，
-        // 避免调用者收到错误但设备实际已处于 Bound 状态的不一致情况。
-        if let Err(e) = self.recalc_effective_size() {
-            let mut inner = self.inner();
-            // 只有当前状态仍是 Bound 且 inode 未被并发修改时才回滚，
-            // 避免覆盖其他操作的结果
-            let should_rollback = matches!(inner.state(), LoopState::Bound)
-                && inner
-                    .file_inode
-                    .as_ref()
-                    .map(|cur| Arc::ptr_eq(cur, &file_inode))
-                    .unwrap_or(false);
-
-            if should_rollback {
-                inner.file_inode = None;
-                inner.file_size = 0;
-                inner.offset = 0;
-                inner.size_limit = 0;
-                inner.flags = LoopFlags::empty();
-                // Bound -> Unbound 是有效转换
-                let _ = inner.set_state(LoopState::Unbound);
-            }
-            return Err(e);
-        }
         Ok(())
     }
 
-    /// # 功能
-    ///
-    /// 清除 loop 设备的文件绑定并复位状态。
-    ///
-    /// ## 参数
-    ///
-    /// - 无。
-    ///
-    /// ## 返回值
-    /// - `Ok(())`: 成功清除。
-    /// - `Err(SystemError)`: 清除过程中的错误。
     pub fn clear_file(&self) -> Result<(), SystemError> {
-        let mut inner = self.inner();
-        match inner.state() {
-            LoopState::Bound | LoopState::Rundown => inner.set_state(LoopState::Unbound)?,
-            LoopState::Unbound => {}
-            LoopState::Draining => return Err(SystemError::EBUSY),
-            LoopState::Deleting => {
-                // 在删除流程中，允许清理文件
-                // 状态已经是Deleting，无需改变
+        let (epoch, generation) = {
+            let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+            let _config = self.config_mutex.lock();
+            let mut inner = self.inner();
+            match inner.state() {
+                LoopState::Unbound => return Ok(()),
+                LoopState::Bound => {
+                    // The ioctl file itself owns one open description. Any
+                    // additional open description includes nested-loop backing
+                    // Files; mounted filesystems are tracked separately.
+                    if self.open_count.load(Ordering::Acquire) > 1
+                        || self.mount_holder_count.load(Ordering::Acquire) != 0
+                    {
+                        return Err(SystemError::EBUSY);
+                    }
+                    inner.set_state(LoopState::Draining)?;
+                    Self::install_quiesce_owner(&mut inner, LoopQuiesceOwner::Clear)
+                }
+                LoopState::Rundown | LoopState::Draining | LoopState::Deleting => {
+                    return Err(SystemError::EBUSY);
+                }
             }
+        };
+
+        if let Err(error) = self.wait_for_active_io() {
+            self.rollback_bound_quiesce(epoch, generation, LoopQuiesceOwner::Clear);
+            return Err(error);
         }
 
-        inner.file_inode = None;
-        inner.file_size = 0;
-        inner.offset = 0;
-        inner.size_limit = 0;
-        inner.flags = LoopFlags::empty();
+        let topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+        let config = self.config_mutex.lock();
+        let old_file = {
+            let mut inner = self.inner();
+            if !Self::quiesce_still_owned(&inner, epoch, generation, LoopQuiesceOwner::Clear) {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            let old = inner.backing_file.take();
+            inner.file_size = 0;
+            inner.offset = 0;
+            inner.size_limit = 0;
+            inner.flags = LoopFlags::empty();
+            inner.generation = inner.generation.wrapping_add(1);
+            inner.quiesce_owner = None;
+            inner.set_state(LoopState::Unbound)?;
+            old
+        };
+
+        drop(config);
+        drop(topology);
+        drop(old_file);
         Ok(())
     }
 
@@ -460,6 +529,96 @@ impl LoopDevice {
         Ok(())
     }
 
+    /// Publish an offset/size-limit/capacity change only after all I/O using
+    /// the previous mapping has completed.
+    ///
+    /// Linux surrounds this transition with sync_blockdev/invalidate_bdev and
+    /// a queue freeze which waits, rather than failing new requests. DragonOS
+    /// currently has neither a blocking block-queue freeze nor a unified way
+    /// to quiesce FAT/ext4 page, metadata, and allocation caches. Consequently
+    /// a mounted mapping cannot be changed safely and is rejected with EBUSY.
+    /// For unmounted/raw users, the Draining interval waits for every request
+    /// using the old translated range before publishing the new mapping.
+    fn reconfigure_mapping(
+        &self,
+        requested_offset: Option<usize>,
+        requested_limit: Option<usize>,
+    ) -> Result<(), SystemError> {
+        const MAX_RETRY: usize = 16;
+
+        for _ in 0..MAX_RETRY {
+            let (backing_file, old_offset, old_limit, old_size, generation) = {
+                let inner = self.inner();
+                if !matches!(inner.state(), LoopState::Bound) {
+                    return Err(SystemError::ENXIO);
+                }
+                (
+                    inner.backing_file.clone().ok_or(SystemError::ENODEV)?,
+                    inner.offset,
+                    inner.size_limit,
+                    inner.file_size,
+                    inner.generation,
+                )
+            };
+            let new_offset = requested_offset.unwrap_or(old_offset);
+            let new_limit = requested_limit.unwrap_or(old_limit);
+            let effective = Self::compute_effective_size(&backing_file, new_offset, new_limit)?;
+
+            let owner = {
+                let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+                let _config = self.config_mutex.lock();
+                let mut inner = self.inner();
+                let unchanged_snapshot = inner
+                    .backing_file
+                    .as_ref()
+                    .is_some_and(|current| Arc::ptr_eq(current, &backing_file))
+                    && inner.generation == generation
+                    && matches!(inner.state(), LoopState::Bound);
+                if !unchanged_snapshot {
+                    continue;
+                }
+                if inner.offset == new_offset
+                    && inner.size_limit == new_limit
+                    && inner.file_size == effective
+                {
+                    return Ok(());
+                }
+                if self.mount_holder_count.load(Ordering::Acquire) != 0 {
+                    return Err(SystemError::EBUSY);
+                }
+                inner.set_state(LoopState::Draining)?;
+                Self::install_quiesce_owner(&mut inner, LoopQuiesceOwner::Reconfigure)
+            };
+
+            if let Err(error) = self.wait_for_active_io() {
+                self.rollback_bound_quiesce(owner.0, owner.1, LoopQuiesceOwner::Reconfigure);
+                return Err(error);
+            }
+
+            let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+            let _config = self.config_mutex.lock();
+            let mut inner = self.inner();
+            if !Self::quiesce_still_owned(&inner, owner.0, owner.1, LoopQuiesceOwner::Reconfigure) {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            debug_assert_eq!(inner.offset, old_offset);
+            debug_assert_eq!(inner.size_limit, old_limit);
+            debug_assert_eq!(inner.file_size, old_size);
+            inner.offset = new_offset;
+            inner.size_limit = new_limit;
+            inner.file_size = effective;
+            // READ_ONLY is fixed at bind time. DragonOS currently implements
+            // no runtime-settable loop flags.
+            inner.flags &= LoopFlags::READ_ONLY;
+            inner.generation = inner.generation.wrapping_add(1);
+            inner.quiesce_owner = None;
+            inner.set_state(LoopState::Bound)?;
+            return Ok(());
+        }
+
+        Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+    }
+
     /// 设置 loop 设备的状态（64 位版本）。
     ///
     /// ## 参数
@@ -490,68 +649,7 @@ impl LoopDevice {
             info.lo_sizelimit as usize
         };
 
-        // 关键修复：避免先更新 offset/size_limit 再单独更新 file_size 导致 I/O 看到不一致快照。
-        //
-        // 回归注释（不要移除）：
-        // - 不能在持有 SpinLock 时调用 inode.metadata()（可能阻塞），否则会导致不可接受的延迟/死锁风险；
-        // - 同时，I/O 边界检查会在同一把锁下读取 (offset, file_size) 来计算 limit_end = offset + file_size。
-        //   若把 offset/size_limit 与 file_size 分两次更新，中间窗口会出现"新 offset + 旧 file_size"的半更新快照，
-        //   从而放宽边界检查，造成越界读/写风险。
-        // 因此这里必须采用：锁内取 inode 快照 -> 锁外计算新 effective size -> 锁内一次性提交
-        // （offset/size_limit/flags/file_size 同一临界区写入，保证对 I/O 原子可见）。
-
-        const MAX_RETRY: usize = 16;
-        let new_flags = LoopFlags::from_bits_truncate(info.lo_flags);
-        let mut retry_count = 0;
-        let mut last_inode_changed = false;
-
-        for _ in 0..MAX_RETRY {
-            retry_count += 1;
-            let inode = {
-                let inner = self.inner();
-                if !matches!(inner.state(), LoopState::Bound | LoopState::Rundown) {
-                    return Err(SystemError::ENXIO);
-                }
-                inner.file_inode.clone().ok_or(SystemError::ENODEV)?
-            };
-
-            let effective = Self::compute_effective_size(&inode, new_offset, new_limit)?;
-
-            let mut inner = self.inner();
-            if !matches!(inner.state(), LoopState::Bound | LoopState::Rundown) {
-                return Err(SystemError::ENXIO);
-            }
-            match inner.file_inode.as_ref() {
-                Some(cur_inode) if Arc::ptr_eq(cur_inode, &inode) => {
-                    inner.offset = new_offset;
-                    inner.size_limit = new_limit;
-                    inner.flags = new_flags;
-                    inner.file_size = effective;
-                    return Ok(());
-                }
-                _ => {
-                    // backing file 在计算期间被切换/解绑，重试以拿到新的 inode 快照
-                    last_inode_changed = true;
-                    // 在多次重试后让出 CPU，减少竞争
-                    if retry_count > 4 {
-                        core::hint::spin_loop();
-                    }
-                    continue;
-                }
-            }
-        }
-
-        // 根据失败原因返回更精确的错误码
-        if last_inode_changed {
-            // inode 持续变化导致无法完成操作，建议调用者稍后重试
-            log::warn!(
-                "set_status64: failed after {} retries due to concurrent inode changes",
-                retry_count
-            );
-            Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
-        } else {
-            Err(SystemError::EBUSY)
-        }
+        self.reconfigure_mapping(Some(new_offset), Some(new_limit))
     }
 
     /// # 功能
@@ -609,41 +707,8 @@ impl LoopDevice {
         Self::validate_loop_status_params(&info)?;
 
         let new_offset = info.lo_offset as usize;
-        let new_flags = LoopFlags::from_bits_truncate(info.lo_flags as u32);
-
-        // legacy loop_info 不携带 sizelimit，这里保持现有的 size_limit 不变，只更新 offset/flags。
-        // 同时复用 set_status64 的“快照 -> 计算 -> 原子提交”模式，避免 file_size 与 offset 不一致。
-        const MAX_RETRY: usize = 8;
-        for _ in 0..MAX_RETRY {
-            let (inode, size_limit) = {
-                let inner = self.inner();
-                if !matches!(inner.state(), LoopState::Bound | LoopState::Rundown) {
-                    return Err(SystemError::ENXIO);
-                }
-                (
-                    inner.file_inode.clone().ok_or(SystemError::ENODEV)?,
-                    inner.size_limit,
-                )
-            };
-
-            let effective = Self::compute_effective_size(&inode, new_offset, size_limit)?;
-
-            let mut inner = self.inner();
-            if !matches!(inner.state(), LoopState::Bound | LoopState::Rundown) {
-                return Err(SystemError::ENXIO);
-            }
-            match inner.file_inode.as_ref() {
-                Some(cur_inode) if Arc::ptr_eq(cur_inode, &inode) => {
-                    inner.offset = new_offset;
-                    inner.flags = new_flags;
-                    inner.file_size = effective;
-                    return Ok(());
-                }
-                _ => continue,
-            }
-        }
-
-        Err(SystemError::EBUSY)
+        // legacy loop_info does not carry sizelimit.
+        self.reconfigure_mapping(Some(new_offset), None)
     }
 
     fn get_status(&self, user_ptr: usize) -> Result<(), SystemError> {
@@ -689,15 +754,13 @@ impl LoopDevice {
     /// - `Err(SystemError)`: 切换失败原因。
     fn change_fd(&self, new_file_fd: i32) -> Result<(), SystemError> {
         let fd_table = ProcessManager::current_pcb().fd_table();
-        let file = {
+        let new_file = {
             let guard = fd_table.read();
             guard.get_file_by_fd(new_file_fd)
         }
         .ok_or(SystemError::EBADF)?;
 
-        let read_only = file.flags().is_read_only();
-
-        let inode = file.inode();
+        let inode = new_file.inode();
         let metadata = inode.metadata()?;
         match metadata.file_type {
             FileType::File | FileType::BlockDevice => {}
@@ -709,22 +772,63 @@ impl LoopDevice {
         }
         let total_size = metadata.size as usize;
 
-        // 单次持锁完成校验+提交，避免“先读快照再提交”期间状态变化导致不一致
-        let mut inner = self.inner();
-        match inner.state() {
-            LoopState::Bound => {}
-            _ => return Err(SystemError::ENODEV),
+        let (epoch, generation) = {
+            let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+            let _config = self.config_mutex.lock();
+            self.validate_backing_chain(&new_file)?;
+            let mut inner = self.inner();
+            if !matches!(inner.state(), LoopState::Bound) {
+                return Err(SystemError::ENODEV);
+            }
+            if !inner.flags.contains(LoopFlags::READ_ONLY) {
+                return Err(SystemError::EINVAL);
+            }
+            if inner.backing_file.is_none() {
+                return Err(SystemError::ENODEV);
+            }
+
+            let effective = Self::calc_effective_size(total_size, inner.offset, inner.size_limit)?;
+            if effective != inner.file_size {
+                return Err(SystemError::EINVAL);
+            }
+
+            inner.set_state(LoopState::Draining)?;
+            Self::install_quiesce_owner(&mut inner, LoopQuiesceOwner::Change)
+        };
+
+        if let Err(error) = self.wait_for_active_io() {
+            self.rollback_bound_quiesce(epoch, generation, LoopQuiesceOwner::Change);
+            return Err(error);
         }
-        if inner.file_inode.is_none() {
-            return Err(SystemError::ENODEV);
+
+        let topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+        let config = self.config_mutex.lock();
+        if let Err(error) = self.validate_backing_chain(&new_file) {
+            drop(config);
+            drop(topology);
+            self.rollback_bound_quiesce(epoch, generation, LoopQuiesceOwner::Change);
+            return Err(error);
         }
-        Self::change_file_locked(&mut inner, inode, total_size, read_only)?;
+        let old_file = {
+            let mut inner = self.inner();
+            if !Self::quiesce_still_owned(&inner, epoch, generation, LoopQuiesceOwner::Change) {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            let old = inner.backing_file.take();
+            Self::change_file_locked(&mut inner, new_file, total_size)?;
+            inner.quiesce_owner = None;
+            inner.set_state(LoopState::Bound)?;
+            old
+        };
+
+        drop(config);
+        drop(topology);
+        drop(old_file);
         Ok(())
     }
 
     fn set_capacity(&self, _arg: usize) -> Result<(), SystemError> {
-        self.recalc_effective_size()?;
-        Ok(())
+        self.reconfigure_mapping(None, None)
     }
 
     /// # 功能
@@ -736,10 +840,7 @@ impl LoopDevice {
     /// - `Err(SystemError::ENODEV)`: 设备正在删除，拒绝新的 I/O
     fn io_start(&self) -> Result<(), SystemError> {
         let inner = self.inner();
-        if matches!(
-            inner.state(),
-            LoopState::Rundown | LoopState::Draining | LoopState::Deleting
-        ) {
+        if !matches!(inner.state(), LoopState::Bound) {
             return Err(SystemError::ENODEV);
         }
         self.active_io_count.fetch_add(1, Ordering::AcqRel);
@@ -756,138 +857,23 @@ impl LoopDevice {
         debug_assert!(prev > 0, "Loop device I/O count underflow");
     }
 
-    /// # 功能
-    ///
-    /// 进入 Rundown 状态，停止接受新的 I/O 请求
-    ///
-    /// ## 返回值
-    /// - `Ok(())`: 成功进入 Rundown 状态
-    /// - `Err(SystemError)`: 状态转换失败
-    pub(super) fn enter_rundown_state(&self) -> Result<(), SystemError> {
+    pub(super) fn prepare_delete(&self) -> Result<(), SystemError> {
+        let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+        let _config = self.config_mutex.lock();
         let mut inner = self.inner();
-        match inner.state() {
-            LoopState::Bound => {
-                // 开始新的删除流程时重置 drain 重试计数
-                inner.drain_retry_count = 0;
-                inner.set_state(LoopState::Rundown)?;
-                info!(
-                    "Loop device loop{} entering rundown state",
-                    inner.device_number.minor()
-                );
-            }
-            LoopState::Unbound => {
-                // 空设备可以直接删除
-                inner.set_state(LoopState::Deleting)?;
-                info!(
-                    "Loop device loop{} is unbound, skipping to deleting state",
-                    inner.device_number.minor()
-                );
-            }
-            LoopState::Rundown => {}
-            LoopState::Draining => {
-                // 处于 Draining 说明已经进入"停止接收新 I/O + 等待 I/O 排空"的删除流程中。
-                // 这里必须幂等返回 Ok：否则一旦 drain_active_io() 超时，设备会永久卡在 Draining，
-                // 后续任何删除重试都会被 EBUSY 拒绝，造成资源泄漏。
-            }
-            LoopState::Deleting => {
-                // 关键修复：Deleting 也必须幂等返回 Ok。
-                //
-                // 背景：loop_remove() 在 drain_active_io() 结束时会把状态推进到 Deleting，
-                // 但后续步骤（如 block_dev_manager().unregister()）仍可能失败。
-                // 若这里对 Deleting 返回 EBUSY，会导致删除失败后无法再次进入删除流程进行重试，
-                // 设备会永久卡死在 Deleting（"zombie"）。
-            }
-        }
-        Ok(())
-    }
-
-    /// # 功能
-    ///
-    /// 等待所有活跃的 I/O 操作完成
-    ///
-    /// ## 返回值
-    /// - `Ok(())`: 所有 I/O 已完成
-    /// - `Err(SystemError::ETIMEDOUT)`: 等待超时
-    pub(super) fn drain_active_io(&self) -> Result<(), SystemError> {
-        use super::constants::LOOP_IO_DRAIN_MAX_RETRIES;
-
-        let mut inner = self.inner();
-
-        // 关键修复：检查重试次数限制，避免无限重试
-        if inner.drain_retry_count >= LOOP_IO_DRAIN_MAX_RETRIES {
-            error!(
-                "Loop device loop{} exceeded max drain retries ({}), forcing cleanup",
-                inner.device_number.minor(),
-                LOOP_IO_DRAIN_MAX_RETRIES
-            );
-            // 强制转换到 Deleting 状态，即使还有活跃 I/O
-            // 这些 I/O 将在后续访问时收到 ENODEV 错误
-            if !matches!(inner.state(), LoopState::Deleting) {
-                inner.set_state(LoopState::Deleting)?;
-            }
+        if matches!(inner.state(), LoopState::Deleting) {
+            // BlockDevManager unregister can fail after the state is published;
+            // the serialized LOOP_CTL_REMOVE path must be able to retry it.
             return Ok(());
         }
-
-        if matches!(inner.state(), LoopState::Rundown) {
-            inner.drain_retry_count += 1;
-            inner.set_state(LoopState::Draining)?;
-            info!(
-                "Loop device loop{} entering draining state (attempt {}/{})",
-                inner.device_number.minor(),
-                inner.drain_retry_count,
-                LOOP_IO_DRAIN_MAX_RETRIES
-            );
+        if !matches!(inner.state(), LoopState::Unbound)
+            || inner.backing_file.is_some()
+            || self.open_count.load(Ordering::Acquire) != 0
+            || self.mount_holder_count.load(Ordering::Acquire) != 0
+        {
+            return Err(SystemError::EBUSY);
         }
-        drop(inner);
-        let max_checks = LOOP_IO_DRAIN_TIMEOUT_MS * 1000 / LOOP_IO_DRAIN_CHECK_INTERVAL_US;
-        let sleep_ts = PosixTimeSpec::new(
-            0,
-            (LOOP_IO_DRAIN_CHECK_INTERVAL_US as i64).saturating_mul(1000),
-        );
-
-        for _i in 0..max_checks {
-            let count = self.active_io_count.load(Ordering::Acquire);
-            if count == 0 {
-                break;
-            }
-
-            let _ = nanosleep(sleep_ts);
-        }
-
-        let final_count = self.active_io_count.load(Ordering::Acquire);
-        if final_count != 0 {
-            error!(
-                "Timeout waiting for I/O to drain on loop{}: {} operations still active",
-                self.minor(),
-                final_count
-            );
-            // 超时：从 Draining 回滚到 Rundown，保持拒绝新 I/O，并允许后续重试 drain。
-            // 注意：这里不能留在 Draining，否则删除流程会永久卡死（enter_rundown_state 返回 EBUSY）。
-            let mut inner = self.inner();
-            if matches!(inner.state(), LoopState::Draining) {
-                let _ = inner.set_state(LoopState::Rundown);
-            }
-            return Err(SystemError::ETIMEDOUT);
-        }
-
-        info!(
-            "All I/O operations drained for loop device loop{}",
-            self.minor()
-        );
-
-        let mut inner = self.inner();
-        // 成功排空后重置重试计数
-        inner.drain_retry_count = 0;
-
-        // 并发删除幂等性：
-        // 两个线程可能同时进入 drain_active_io()，并在 I/O 计数归零后几乎同时推进状态。
-        // 第一个线程把状态设置为 Deleting 后，第二个线程若再执行 set_state(Deleting)，
-        // 会因 (Deleting, Deleting) 不在 VALID_TRANSITIONS 而返回 EINVAL，导致 loop_remove() 失败。
-        // 因此这里需要对 Deleting 做幂等处理。
-        if !matches!(inner.state(), LoopState::Deleting) {
-            inner.set_state(LoopState::Deleting)?;
-        }
-
+        inner.set_state(LoopState::Deleting)?;
         Ok(())
     }
 
@@ -917,17 +903,25 @@ impl LoopDevice {
             self.minor(),
             self.id()
         );
-        let mut inner = self.inner();
-        if let Some(file_inode) = inner.file_inode.take() {
-            drop(file_inode);
+        let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+        let _config = self.config_mutex.lock();
+        let backing_file = {
+            let mut inner = self.inner();
+            let backing_file = inner.backing_file.take();
+            inner.file_size = 0;
+            inner.offset = 0;
+            inner.size_limit = 0;
+            backing_file
+        };
+        drop(_config);
+        drop(_topology);
+        if backing_file.is_some() {
             warn!(
-                "File inode was still present during final cleanup for loop{}",
+                "Backing file was still present during final cleanup for loop{}",
                 self.minor()
             );
         }
-        inner.file_size = 0;
-        inner.offset = 0;
-        inner.size_limit = 0;
+        drop(backing_file);
         info!("Loop device loop{} cleanup complete", self.minor());
     }
 }
@@ -1010,10 +1004,6 @@ impl IndexNode for LoopDevice {
         self
     }
 
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::BlockDevice
-    }
-
     fn sync_file(
         &self,
         _datasync: bool,
@@ -1032,7 +1022,7 @@ impl IndexNode for LoopDevice {
         if len > buf.len() {
             return Err(SystemError::ENOBUFS);
         }
-        BlockDevice::read_at_bytes(self, offset, len, buf)
+        self.read_bytes_operation(offset, len, buf)
     }
 
     fn write_at(
@@ -1045,7 +1035,8 @@ impl IndexNode for LoopDevice {
         if len > buf.len() {
             return Err(SystemError::E2BIG);
         }
-        BlockDevice::write_at_bytes(self, offset, len, &buf[..len])
+        self.write_bytes_operation(offset, len, &buf[..len], WriteSyncIntent::None)
+            .map(|result| result.written_len)
     }
 
     fn list(&self) -> Result<alloc::vec::Vec<alloc::string::String>, system_error::SystemError> {
@@ -1053,13 +1044,13 @@ impl IndexNode for LoopDevice {
     }
 
     fn metadata(&self) -> Result<crate::filesystem::vfs::Metadata, SystemError> {
-        let (inode, file_size, devnum) = {
+        let (backing_file, file_size, devnum) = {
             let inner = self.inner();
-            let inode = inner.file_inode.clone().ok_or(SystemError::EPERM)?;
-            (inode, inner.file_size, inner.device_number)
+            let backing_file = inner.backing_file.clone().ok_or(SystemError::EPERM)?;
+            (backing_file, inner.file_size, inner.device_number)
         };
 
-        let file_metadata = inode.metadata()?;
+        let file_metadata = backing_file.inode().metadata()?;
         let metadata = Metadata {
             dev_id: 0,
             inode_id: InodeId::new(0),
@@ -1085,9 +1076,15 @@ impl IndexNode for LoopDevice {
         &self,
         cmd: u32,
         data: usize,
-        _private_data: MutexGuard<FilePrivateData>,
+        private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         let ioctl_cmd = LoopIoctl::from_u32(cmd).ok_or(SystemError::ENOSYS)?;
+        let control_writable = matches!(
+            &*private_data,
+            FilePrivateData::Loop(data) if data.control_writable
+        );
+        let may_reconfigure = control_writable || capable(CAPFlags::CAP_SYS_ADMIN);
+        drop(private_data);
 
         match ioctl_cmd {
             LoopIoctl::LoopSetFd => {
@@ -1098,7 +1095,6 @@ impl IndexNode for LoopDevice {
                     guard.get_file_by_fd(file_fd)
                 }
                 .ok_or(SystemError::EBADF)?;
-                let read_only = file.flags().is_read_only();
                 let inode = file.inode();
                 let metadata = inode.metadata()?;
                 match metadata.file_type {
@@ -1106,14 +1102,21 @@ impl IndexNode for LoopDevice {
                     _ => return Err(SystemError::EINVAL),
                 }
 
-                self.bind_file(inode, read_only)?;
+                let read_only = file.flags().is_read_only() || !control_writable;
+                self.bind_file(file, read_only)?;
                 Ok(0)
             }
             LoopIoctl::LoopClrFd => {
+                if !may_reconfigure {
+                    return Err(SystemError::EPERM);
+                }
                 self.clear_file()?;
                 Ok(0)
             }
             LoopIoctl::LoopSetStatus => {
+                if !may_reconfigure {
+                    return Err(SystemError::EPERM);
+                }
                 self.set_status(data)?;
                 Ok(0)
             }
@@ -1122,6 +1125,9 @@ impl IndexNode for LoopDevice {
                 Ok(0)
             }
             LoopIoctl::LoopSetStatus64 => {
+                if !may_reconfigure {
+                    return Err(SystemError::EPERM);
+                }
                 self.set_status64(data)?;
                 Ok(0)
             }
@@ -1130,10 +1136,16 @@ impl IndexNode for LoopDevice {
                 Ok(0)
             }
             LoopIoctl::LoopChangeFd => {
+                if !may_reconfigure {
+                    return Err(SystemError::EPERM);
+                }
                 self.change_fd(data as i32)?;
                 Ok(0)
             }
             LoopIoctl::LoopSetCapacity => {
+                if !may_reconfigure {
+                    return Err(SystemError::EPERM);
+                }
                 self.set_capacity(data)?;
                 Ok(0)
             }
@@ -1219,7 +1231,166 @@ impl Device for LoopDevice {
     }
 }
 
+impl LoopDevice {
+    fn io_snapshot(&self, write: bool) -> Result<(Arc<File>, usize, usize), SystemError> {
+        let inner = self.inner();
+        if write && inner.is_read_only() {
+            return Err(SystemError::EROFS);
+        }
+        let backing_file = inner.backing_file.clone().ok_or(SystemError::ENODEV)?;
+        let limit_end = inner
+            .offset
+            .checked_add(inner.file_size)
+            .ok_or(SystemError::EOVERFLOW)?;
+        Ok((backing_file, inner.offset, limit_end))
+    }
+
+    fn translate_io_range(
+        base_offset: usize,
+        limit_end: usize,
+        offset: usize,
+        len: usize,
+    ) -> Result<usize, SystemError> {
+        let file_offset = base_offset
+            .checked_add(offset)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let end = file_offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        if end > limit_end {
+            return Err(SystemError::ENOSPC);
+        }
+        Ok(file_offset)
+    }
+
+    fn sync_backing_file(
+        backing_file: &Arc<File>,
+        start: usize,
+        end: usize,
+        datasync: bool,
+    ) -> Result<(), SystemError> {
+        Self::normalize_backing_sync_result(
+            backing_file.sync_range_and_check_wb_error(start, end, datasync),
+        )
+    }
+
+    fn normalize_backing_sync_result(result: Result<(), SystemError>) -> Result<(), SystemError> {
+        match result {
+            Ok(()) | Err(SystemError::EINVAL) => Ok(()),
+            Err(_) => Err(SystemError::EIO),
+        }
+    }
+
+    fn read_bytes_operation(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+    ) -> Result<usize, SystemError> {
+        if len > buf.len() {
+            return Err(SystemError::EINVAL);
+        }
+        if len == 0 {
+            return Ok(0);
+        }
+
+        let _io_guard = IoGuard::new(self)?;
+        let (backing_file, base_offset, limit_end) = self.io_snapshot(false)?;
+        let file_offset = Self::translate_io_range(base_offset, limit_end, offset, len)?;
+        let read = backing_file.pread(file_offset, len, &mut buf[..len])?;
+        if read < len {
+            // Linux loop zero-fills a short backing read inside the advertised
+            // device capacity rather than exposing stale destination bytes.
+            buf[read..len].fill(0);
+            return Ok(len);
+        }
+        Ok(read)
+    }
+
+    fn write_bytes_operation(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &[u8],
+        sync_intent: WriteSyncIntent,
+    ) -> Result<DelegatedWriteResult, SystemError> {
+        if len > buf.len() {
+            return Err(SystemError::EINVAL);
+        }
+        if len == 0 {
+            return Ok(DelegatedWriteResult {
+                written_len: 0,
+                sync_result: Ok(()),
+            });
+        }
+
+        // This guard and retained File snapshot cover both write and optional
+        // flush, so CLEAR/DELETE cannot release the file between them.
+        let _io_guard = IoGuard::new(self)?;
+        let (backing_file, base_offset, limit_end) = self.io_snapshot(true)?;
+        let file_offset = Self::translate_io_range(base_offset, limit_end, offset, len)?;
+        // Delegate the operation-level intent to the retained File itself.
+        // This merges it with backing O_SYNC/S_SYNC/SB_SYNCHRONOUS exactly
+        // once and preserves positive write progress if the following sync
+        // fails. Calling plain pwrite() here would collapse that failure into
+        // Err and make the outer loop file lose the completed byte count.
+        let mut result =
+            backing_file.pwrite_with_sync_intent(file_offset, len, &buf[..len], sync_intent)?;
+        result.sync_result = Self::normalize_backing_sync_result(result.sync_result);
+        Ok(result)
+    }
+}
+
 impl BlockDevice for LoopDevice {
+    fn devfs_mode(&self) -> InodeMode {
+        InodeMode::from_bits_truncate(0o600)
+    }
+
+    fn file_open(
+        &self,
+        mut data: MutexGuard<FilePrivateData>,
+        flags: &FileFlags,
+    ) -> Result<(), SystemError> {
+        let _config = self.config_mutex.lock();
+        if matches!(
+            self.inner().state(),
+            LoopState::Deleting | LoopState::Draining
+        ) {
+            return Err(SystemError::ENODEV);
+        }
+        let device_pin = self.self_ref.upgrade().ok_or(SystemError::ENODEV)?;
+        self.open_count.fetch_add(1, Ordering::AcqRel);
+        *data = FilePrivateData::Loop(LoopPrivateData {
+            control_writable: !flags.is_read_only(),
+            open_counted: true,
+            _device_pin: Some(device_pin),
+        });
+        Ok(())
+    }
+
+    fn file_close(&self, mut data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        if let FilePrivateData::Loop(loop_data) = &mut *data {
+            if loop_data.open_counted {
+                loop_data.open_counted = false;
+                let previous = self.open_count.fetch_sub(1, Ordering::AcqRel);
+                debug_assert!(previous > 0, "loop open count underflow");
+            }
+        }
+        Ok(())
+    }
+
+    fn mount_holder_acquire(&self) -> Result<(), SystemError> {
+        let _config = self.config_mutex.lock();
+        if !matches!(self.inner().state(), LoopState::Bound) {
+            return Err(SystemError::ENODEV);
+        }
+        self.mount_holder_count.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    fn mount_holder_release(&self) {
+        let previous = self.mount_holder_count.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "loop mount holder count underflow");
+    }
+
     fn dev_name(&self) -> &DevName {
         &self.block_dev_meta.devname
     }
@@ -1244,43 +1415,11 @@ impl BlockDevice for LoopDevice {
         count: usize,
         buf: &mut [u8],
     ) -> Result<usize, SystemError> {
-        // 使用 IoGuard 确保 I/O 计数正确管理
-        let _io_guard = IoGuard::new(self)?;
-
-        if count == 0 {
-            return Ok(0);
-        }
         let len = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
-        if len > buf.len() {
-            return Err(SystemError::EINVAL);
-        }
-
-        let (file_inode, base_offset, limit_end) = {
-            let inner = self.inner();
-            let inode = inner.file_inode.clone().ok_or(SystemError::ENODEV)?;
-            let limit = inner
-                .offset
-                .checked_add(inner.file_size)
-                .ok_or(SystemError::EOVERFLOW)?;
-            (inode, inner.offset, limit)
-        };
-
         let block_offset = lba_id_start
             .checked_mul(LBA_SIZE)
             .ok_or(SystemError::EOVERFLOW)?;
-        let file_offset = base_offset
-            .checked_add(block_offset)
-            .ok_or(SystemError::EOVERFLOW)?;
-
-        let end = file_offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
-        if end > limit_end {
-            return Err(SystemError::ENOSPC);
-        }
-
-        let data = Mutex::new(FilePrivateData::Unused);
-        let data_guard = data.lock();
-
-        file_inode.read_at(file_offset, len, &mut buf[..len], data_guard)
+        self.read_bytes_operation(block_offset, len, buf)
     }
 
     fn write_at_sync(
@@ -1289,67 +1428,51 @@ impl BlockDevice for LoopDevice {
         count: usize,
         buf: &[u8],
     ) -> Result<usize, SystemError> {
-        // 使用 IoGuard 确保 I/O 计数正确管理
-        let _io_guard = IoGuard::new(self)?;
-
-        if count == 0 {
-            return Ok(0);
-        }
         let len = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
-        if len > buf.len() {
-            return Err(SystemError::EINVAL);
-        }
-
-        let (file_inode, base_offset, limit_end) = {
-            let inner = self.inner();
-            if inner.is_read_only() {
-                return Err(SystemError::EROFS);
-            }
-            let inode = inner.file_inode.clone().ok_or(SystemError::ENODEV)?;
-            let limit = inner
-                .offset
-                .checked_add(inner.file_size)
-                .ok_or(SystemError::EOVERFLOW)?;
-            (inode, inner.offset, limit)
-        };
-
         let block_offset = lba_id_start
             .checked_mul(LBA_SIZE)
             .ok_or(SystemError::EOVERFLOW)?;
-        let file_offset = base_offset
-            .checked_add(block_offset)
-            .ok_or(SystemError::EOVERFLOW)?;
+        self.write_bytes_operation(block_offset, len, buf, WriteSyncIntent::None)
+            .map(|result| result.written_len)
+    }
 
-        let end = file_offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
-        if end > limit_end {
-            return Err(SystemError::ENOSPC);
-        }
+    fn read_at_bytes(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &mut [u8],
+    ) -> Result<usize, SystemError> {
+        self.read_bytes_operation(offset, len, buf)
+    }
 
-        let data = Mutex::new(FilePrivateData::Unused);
-        let data_guard = data.lock();
+    fn uses_delegated_write_sync(&self) -> bool {
+        true
+    }
 
-        let written = file_inode.write_at(file_offset, len, &buf[..len], data_guard)?;
-
-        if written > 0 {
-            let _ = self.recalc_effective_size();
-        }
-
-        Ok(written)
+    fn write_at_bytes_with_sync(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &[u8],
+        sync_intent: WriteSyncIntent,
+    ) -> Result<DelegatedWriteResult, SystemError> {
+        self.write_bytes_operation(offset, len, buf, sync_intent)
     }
 
     fn sync(&self) -> Result<(), SystemError> {
         let _io_guard = IoGuard::new(self)?;
-
-        let inode = self.inner().file_inode.clone().ok_or(SystemError::ENODEV)?;
-        inode.sync()?;
-        inode.fs().sync_fs(true)
+        let backing_file = self
+            .inner()
+            .backing_file
+            .clone()
+            .ok_or(SystemError::ENODEV)?;
+        Self::sync_backing_file(&backing_file, 0, usize::MAX, false)
     }
 
     fn supports_reliable_flush(&self) -> bool {
-        self.inner()
-            .file_inode
-            .as_ref()
-            .map(|inode| inode.fs().supports_reliable_flush())
+        let backing_file = self.inner().backing_file.clone();
+        backing_file
+            .map(|file| file.inode().fs().supports_reliable_flush())
             .unwrap_or(false)
     }
 

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -322,10 +322,6 @@ impl LoopDevice {
         Self::calc_effective_size(total_size, offset, size_limit)
     }
 
-    pub fn is_bound(&self) -> bool {
-        matches!(self.inner().state(), LoopState::Bound)
-    }
-
     /// Validate a candidate while the global backing-topology lock is held.
     fn validate_backing_chain(&self, candidate: &Arc<File>) -> Result<(), SystemError> {
         let mut current = candidate.clone();
@@ -445,7 +441,7 @@ impl LoopDevice {
             let _config = self.config_mutex.lock();
             let mut inner = self.inner();
             match inner.state() {
-                LoopState::Unbound => return Ok(()),
+                LoopState::Unbound => return Err(SystemError::ENXIO),
                 LoopState::Bound => {
                     // The ioctl file itself owns one open description. Any
                     // additional open description includes nested-loop backing
@@ -453,7 +449,15 @@ impl LoopDevice {
                     if self.open_count.load(Ordering::Acquire) > 1
                         || self.mount_holder_count.load(Ordering::Acquire) != 0
                     {
-                        return Err(SystemError::EBUSY);
+                        // Linux LOOP_CLR_FD succeeds for a busy loop device and
+                        // defers the actual detach until the final user leaves.
+                        if !inner.flags.contains(LoopFlags::AUTOCLEAR) {
+                            inner.flags.insert(LoopFlags::AUTOCLEAR);
+                            // Invalidate reconfiguration snapshots that would
+                            // otherwise republish the old flag value.
+                            inner.generation = inner.generation.wrapping_add(1);
+                        }
+                        return Ok(());
                     }
                     inner.set_state(LoopState::Draining)?;
                     Self::install_quiesce_owner(&mut inner, LoopQuiesceOwner::Clear)
@@ -464,6 +468,10 @@ impl LoopDevice {
             }
         };
 
+        self.finish_clear(epoch, generation)
+    }
+
+    fn finish_clear(&self, epoch: u64, generation: u64) -> Result<(), SystemError> {
         if let Err(error) = self.wait_for_active_io() {
             self.rollback_bound_quiesce(epoch, generation, LoopQuiesceOwner::Clear);
             return Err(error);
@@ -491,6 +499,37 @@ impl LoopDevice {
         drop(topology);
         drop(old_file);
         Ok(())
+    }
+
+    fn maybe_autoclear(&self) {
+        // file_open() and mount_holder_acquire() take config_mutex before
+        // incrementing their counters. Recheck both counters and publish
+        // Draining under that same mutex so a new user cannot race the final
+        // close and get detached after a successful open.
+        let owner = {
+            let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+            let _config = self.config_mutex.lock();
+            let mut inner = self.inner();
+            if !matches!(inner.state(), LoopState::Bound)
+                || !inner.flags.contains(LoopFlags::AUTOCLEAR)
+                || self.open_count.load(Ordering::Acquire) != 0
+                || self.mount_holder_count.load(Ordering::Acquire) != 0
+            {
+                return;
+            }
+            if let Err(error) = inner.set_state(LoopState::Draining) {
+                warn!(
+                    "loop{}: cannot begin deferred autoclear: {:?}",
+                    self.minor, error
+                );
+                return;
+            }
+            Self::install_quiesce_owner(&mut inner, LoopQuiesceOwner::Clear)
+        };
+
+        if let Err(error) = self.finish_clear(owner.0, owner.1) {
+            warn!("loop{}: deferred autoclear failed: {:?}", self.minor, error);
+        }
     }
 
     fn validate_loop_status64_params(info: &LoopStatus64) -> Result<(), SystemError> {
@@ -543,11 +582,12 @@ impl LoopDevice {
         &self,
         requested_offset: Option<usize>,
         requested_limit: Option<usize>,
+        requested_autoclear: Option<bool>,
     ) -> Result<(), SystemError> {
         const MAX_RETRY: usize = 16;
 
         for _ in 0..MAX_RETRY {
-            let (backing_file, old_offset, old_limit, old_size, generation) = {
+            let (backing_file, old_offset, old_limit, old_size, old_autoclear, generation) = {
                 let inner = self.inner();
                 if !matches!(inner.state(), LoopState::Bound) {
                     return Err(SystemError::ENXIO);
@@ -557,11 +597,38 @@ impl LoopDevice {
                     inner.offset,
                     inner.size_limit,
                     inner.file_size,
+                    inner.flags.contains(LoopFlags::AUTOCLEAR),
                     inner.generation,
                 )
             };
             let new_offset = requested_offset.unwrap_or(old_offset);
             let new_limit = requested_limit.unwrap_or(old_limit);
+            let new_autoclear = requested_autoclear.unwrap_or(old_autoclear);
+
+            // LOOP_SET_STATUS must not refresh capacity merely because the
+            // backing file changed size. Linux only does so when offset or
+            // sizelimit changes; LOOP_SET_CAPACITY is the explicit refresh.
+            let refresh_capacity = requested_offset.is_none() && requested_limit.is_none();
+            if !refresh_capacity && new_offset == old_offset && new_limit == old_limit {
+                let _topology = LOOP_BACKING_TOPOLOGY_LOCK.lock();
+                let _config = self.config_mutex.lock();
+                let mut inner = self.inner();
+                let unchanged_snapshot = inner
+                    .backing_file
+                    .as_ref()
+                    .is_some_and(|current| Arc::ptr_eq(current, &backing_file))
+                    && inner.generation == generation
+                    && matches!(inner.state(), LoopState::Bound);
+                if !unchanged_snapshot {
+                    continue;
+                }
+                if inner.flags.contains(LoopFlags::AUTOCLEAR) != new_autoclear {
+                    inner.flags.set(LoopFlags::AUTOCLEAR, new_autoclear);
+                    inner.generation = inner.generation.wrapping_add(1);
+                }
+                return Ok(());
+            }
+
             let effective = Self::compute_effective_size(&backing_file, new_offset, new_limit)?;
 
             let owner = {
@@ -581,6 +648,10 @@ impl LoopDevice {
                     && inner.size_limit == new_limit
                     && inner.file_size == effective
                 {
+                    if inner.flags.contains(LoopFlags::AUTOCLEAR) != new_autoclear {
+                        inner.flags.set(LoopFlags::AUTOCLEAR, new_autoclear);
+                        inner.generation = inner.generation.wrapping_add(1);
+                    }
                     return Ok(());
                 }
                 if self.mount_holder_count.load(Ordering::Acquire) != 0 {
@@ -607,9 +678,9 @@ impl LoopDevice {
             inner.offset = new_offset;
             inner.size_limit = new_limit;
             inner.file_size = effective;
-            // READ_ONLY is fixed at bind time. DragonOS currently implements
-            // no runtime-settable loop flags.
-            inner.flags &= LoopFlags::READ_ONLY;
+            // READ_ONLY is fixed at bind time; LOOP_SET_STATUS may update
+            // AUTOCLEAR together with the mapping.
+            inner.flags.set(LoopFlags::AUTOCLEAR, new_autoclear);
             inner.generation = inner.generation.wrapping_add(1);
             inner.quiesce_owner = None;
             inner.set_state(LoopState::Bound)?;
@@ -649,7 +720,11 @@ impl LoopDevice {
             info.lo_sizelimit as usize
         };
 
-        self.reconfigure_mapping(Some(new_offset), Some(new_limit))
+        self.reconfigure_mapping(
+            Some(new_offset),
+            Some(new_limit),
+            Some(info.lo_flags & LoopFlags::AUTOCLEAR.bits() != 0),
+        )
     }
 
     /// # 功能
@@ -708,7 +783,11 @@ impl LoopDevice {
 
         let new_offset = info.lo_offset as usize;
         // legacy loop_info does not carry sizelimit.
-        self.reconfigure_mapping(Some(new_offset), None)
+        self.reconfigure_mapping(
+            Some(new_offset),
+            None,
+            Some(info.lo_flags as u32 & LoopFlags::AUTOCLEAR.bits() != 0),
+        )
     }
 
     fn get_status(&self, user_ptr: usize) -> Result<(), SystemError> {
@@ -828,7 +907,7 @@ impl LoopDevice {
     }
 
     fn set_capacity(&self, _arg: usize) -> Result<(), SystemError> {
-        self.reconfigure_mapping(None, None)
+        self.reconfigure_mapping(None, None, None)
     }
 
     /// # 功能
@@ -1367,12 +1446,18 @@ impl BlockDevice for LoopDevice {
     }
 
     fn file_close(&self, mut data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        let mut became_last_opener = false;
         if let FilePrivateData::Loop(loop_data) = &mut *data {
             if loop_data.open_counted {
                 loop_data.open_counted = false;
                 let previous = self.open_count.fetch_sub(1, Ordering::AcqRel);
                 debug_assert!(previous > 0, "loop open count underflow");
+                became_last_opener = previous == 1;
             }
+        }
+        drop(data);
+        if became_last_opener {
+            self.maybe_autoclear();
         }
         Ok(())
     }
@@ -1389,6 +1474,9 @@ impl BlockDevice for LoopDevice {
     fn mount_holder_release(&self) {
         let previous = self.mount_holder_count.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(previous > 0, "loop mount holder count underflow");
+        if previous == 1 {
+            self.maybe_autoclear();
+        }
     }
 
     fn dev_name(&self) -> &DevName {

--- a/kernel/src/driver/block/loop_device/manager.rs
+++ b/kernel/src/driver/block/loop_device/manager.rs
@@ -111,6 +111,18 @@ impl LoopManager {
         }
     }
 
+    /// Allocate and register a new loop device with the first unused minor.
+    pub fn loop_add_new(&self) -> Result<Arc<LoopDevice>, SystemError> {
+        let _control = self.control_mutex.lock();
+        let mut inner = self.inner();
+        let id = Self::alloc_id_locked(&mut inner).ok_or(SystemError::ENOSPC)?;
+        let result = self.create_and_register_device_locked(&mut inner, id);
+        if result.is_err() {
+            Self::free_id_locked(&mut inner, id);
+        }
+        result
+    }
+
     /// # 功能
     ///
     /// 在锁作用域内分配指定次设备号的 loop 设备。
@@ -132,14 +144,10 @@ impl LoopManager {
             return Err(SystemError::EINVAL);
         }
 
-        if let Some(device) = Self::find_device_by_minor_locked(inner, minor) {
-            if device.is_bound() {
-                return Err(SystemError::EEXIST);
-            }
-            if Self::device_reusable(&device) {
-                return Ok(device);
-            }
-            return Err(SystemError::EBUSY);
+        if Self::find_device_by_minor_locked(inner, minor).is_some() {
+            // LOOP_CTL_ADD reserves a new minor. A registered device already
+            // owns this number even while Unbound; only GET_FREE may reuse it.
+            return Err(SystemError::EEXIST);
         }
 
         let id =
@@ -270,18 +278,13 @@ impl LoopManager {
         Ok(())
     }
 
-    pub fn find_free_minor(&self) -> Option<u32> {
+    /// Return a registered unbound loop device, creating one atomically when
+    /// no reusable device exists. This matches Linux LOOP_CTL_GET_FREE.
+    pub fn find_or_add_free_minor(&self) -> Result<u32, SystemError> {
         let _control = self.control_mutex.lock();
-        let inner = self.inner();
-        for minor in 0..Self::MAX_DEVICES as u32 {
-            match &inner.devices[minor as usize] {
-                // 只有 Unbound 才能视为可复用；删除流程中的设备不应返回给 loop_add
-                Some(dev) if Self::device_reusable(dev) => return Some(minor),
-                Some(_) => continue,
-                None => return Some(minor),
-            }
-        }
-        None
+        let mut inner = self.inner();
+        let device = self.loop_add_first_available_locked(&mut inner)?;
+        Ok(device.minor())
     }
 
     pub fn loop_init(&self, _driver: Arc<LoopDeviceDriver>) -> Result<(), SystemError> {

--- a/kernel/src/driver/block/loop_device/manager.rs
+++ b/kernel/src/driver/block/loop_device/manager.rs
@@ -3,7 +3,10 @@ use crate::{
         block::{block_device::BlockDevice, manager::block_dev_manager},
         device::DevName,
     },
-    libs::spinlock::{SpinLock, SpinLockGuard},
+    libs::{
+        mutex::Mutex,
+        spinlock::{SpinLock, SpinLockGuard},
+    },
 };
 use alloc::{format, sync::Arc};
 use ida::IdAllocator;
@@ -19,6 +22,8 @@ use super::{
 /// Loop 设备管理器
 pub struct LoopManager {
     inner: SpinLock<LoopManagerInner>,
+    /// Linux loop_ctl_mutex equivalent for device visibility and allocation.
+    control_mutex: Mutex<()>,
 }
 
 pub struct LoopManagerInner {
@@ -39,6 +44,7 @@ impl LoopManager {
                 id_alloc: IdAllocator::new(0, Self::MAX_DEVICES)
                     .expect("create IdAllocator failed"),
             }),
+            control_mutex: Mutex::new(()),
         }
     }
 
@@ -97,6 +103,7 @@ impl LoopManager {
     /// - `Ok(Arc<LoopDevice>)`: 成功获得的设备。
     /// - `Err(SystemError)`: 无可用设备或参数错误。
     pub fn loop_add(&self, requested_minor: Option<u32>) -> Result<Arc<LoopDevice>, SystemError> {
+        let _control = self.control_mutex.lock();
         let mut inner = self.inner();
         match requested_minor {
             Some(req_minor) => self.loop_add_specific_locked(&mut inner, req_minor),
@@ -218,6 +225,7 @@ impl LoopManager {
     /// - `Ok(())`: 成功删除设备
     /// - `Err(SystemError)`: 删除失败
     pub fn loop_remove(&self, minor: u32) -> Result<(), SystemError> {
+        let _control = self.control_mutex.lock();
         if minor >= Self::MAX_DEVICES as u32 {
             return Err(SystemError::EINVAL);
         }
@@ -228,17 +236,7 @@ impl LoopManager {
         .ok_or(SystemError::ENODEV)?;
         let id = device.id();
         info!("Starting removal of loop device loop{} (id {})", minor, id);
-        device.enter_rundown_state()?;
-        let needs_drain = {
-            let inner = device.inner();
-            !matches!(inner.state(), LoopState::Deleting)
-        };
-
-        if needs_drain {
-            device.drain_active_io()?;
-        }
-
-        device.clear_file()?;
+        device.prepare_delete()?;
 
         let block_dev: Arc<dyn BlockDevice> = device.clone();
         // 先尝试从 BlockDevManager 注销（会卸载 devfs gendisk 节点）。
@@ -252,17 +250,8 @@ impl LoopManager {
                 device.inner().state()
             );
 
-            // 回滚状态到 Rundown，允许后续重试删除操作。
-            // 这避免了设备卡在 Deleting 状态成为"僵尸"的问题。
-            let mut inner = device.inner();
-            if matches!(inner.state(), LoopState::Deleting) {
-                // Deleting -> Rundown 回滚
-                let _ = inner.set_state(LoopState::Rundown);
-                log::warn!(
-                    "Rolled back loop{} state from Deleting to Rundown for retry",
-                    minor
-                );
-            }
+            // Keep Deleting: new I/O/configuration must remain rejected. A
+            // later LOOP_CTL_REMOVE retry can safely retry unregister.
             return Err(e);
         }
 
@@ -282,6 +271,7 @@ impl LoopManager {
     }
 
     pub fn find_free_minor(&self) -> Option<u32> {
+        let _control = self.control_mutex.lock();
         let inner = self.inner();
         for minor in 0..Self::MAX_DEVICES as u32 {
             match &inner.devices[minor as usize] {

--- a/kernel/src/driver/block/pmem/device.rs
+++ b/kernel/src/driver/block/pmem/device.rs
@@ -30,7 +30,10 @@ use crate::{
     filesystem::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
         kernfs::KernFSInode,
-        vfs::{utils::DName, FilePrivateData, IndexNode, InodeFlags, InodeId, InodeMode, Metadata},
+        vfs::{
+            utils::DName, FilePrivateData, FileType, IndexNode, InodeFlags, InodeId, InodeMode,
+            Metadata,
+        },
     },
     libs::{
         align::{page_align_down, page_align_up},
@@ -220,6 +223,18 @@ impl IndexNode for PmemBlockDevice {
 
     fn as_any_ref(&self) -> &dyn Any {
         self
+    }
+
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::BlockDevice
+    }
+
+    fn sync_file(
+        &self,
+        _datasync: bool,
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        <Self as BlockDevice>::sync(self)
     }
 
     fn read_at(

--- a/kernel/src/driver/block/pmem/device.rs
+++ b/kernel/src/driver/block/pmem/device.rs
@@ -30,10 +30,7 @@ use crate::{
     filesystem::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
         kernfs::KernFSInode,
-        vfs::{
-            utils::DName, FilePrivateData, FileType, IndexNode, InodeFlags, InodeId, InodeMode,
-            Metadata,
-        },
+        vfs::{utils::DName, FilePrivateData, IndexNode, InodeFlags, InodeId, InodeMode, Metadata},
     },
     libs::{
         align::{page_align_down, page_align_up},
@@ -223,10 +220,6 @@ impl IndexNode for PmemBlockDevice {
 
     fn as_any_ref(&self) -> &dyn Any {
         self
-    }
-
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::BlockDevice
     }
 
     fn sync_file(

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -58,7 +58,7 @@ use crate::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
         kernfs::KernFSInode,
         mbr::MbrDiskPartionTable,
-        vfs::{utils::DName, IndexNode, InodeMode, Metadata},
+        vfs::{utils::DName, FilePrivateData, FileType, IndexNode, InodeMode, Metadata},
     },
     init::initcall::INITCALL_POSTCORE,
     libs::{
@@ -849,6 +849,19 @@ impl IndexNode for VirtIOBlkDevice {
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
     }
+
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::BlockDevice
+    }
+
+    fn sync_file(
+        &self,
+        _datasync: bool,
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<(), SystemError> {
+        <Self as BlockDevice>::sync(self)
+    }
+
     fn read_at(
         &self,
         _offset: usize,

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -58,7 +58,7 @@ use crate::{
         devfs::{DevFS, DeviceINode, LockedDevFSInode},
         kernfs::KernFSInode,
         mbr::MbrDiskPartionTable,
-        vfs::{utils::DName, FilePrivateData, FileType, IndexNode, InodeMode, Metadata},
+        vfs::{utils::DName, FilePrivateData, IndexNode, InodeMode, Metadata},
     },
     init::initcall::INITCALL_POSTCORE,
     libs::{
@@ -848,10 +848,6 @@ impl IndexNode for VirtIOBlkDevice {
     }
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
-    }
-
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::BlockDevice
     }
 
     fn sync_file(

--- a/kernel/src/filesystem/cgroup2/inode.rs
+++ b/kernel/src/filesystem/cgroup2/inode.rs
@@ -17,7 +17,8 @@ use crate::{
         file::{FileFlags, FilePrivateData},
         permission::PermissionMask,
         vcore::generate_inode_id,
-        FileSystem, FileType, IndexNode, InodeFlags, InodeMode, Metadata,
+        FileSystem, FileType, IndexNode, InodeFlags, InodeMode, Metadata, OpenFileBehavior,
+        PostWriteSyncPolicy,
     },
     libs::{mutex::MutexGuard, rwsem::RwSem, spinlock::SpinLock},
     process::ProcessManager,
@@ -556,6 +557,10 @@ impl Cgroup2Inode {
 }
 
 impl IndexNode for Cgroup2Inode {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        behavior.post_write_sync = PostWriteSyncPolicy::NotApplicable;
+    }
+
     fn open(
         &self,
         _data: MutexGuard<FilePrivateData>,

--- a/kernel/src/filesystem/epoll/fs.rs
+++ b/kernel/src/filesystem/epoll/fs.rs
@@ -3,7 +3,10 @@ use alloc::string::String;
 use crate::{
     filesystem::{
         epoll::EPollEventType,
-        vfs::{file::FileFlags, FilePrivateData, IndexNode, Metadata, PollableInode},
+        vfs::{
+            file::FileFlags, FilePrivateData, IndexNode, Metadata, OpenFileBehavior, PollableInode,
+            PostWriteSyncPolicy,
+        },
     },
     libs::mutex::MutexGuard,
 };
@@ -27,6 +30,10 @@ impl EPollInode {
 }
 
 impl IndexNode for EPollInode {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        behavior.post_write_sync = PostWriteSyncPolicy::NotApplicable;
+    }
+
     fn is_stream(&self) -> bool {
         // epollfd 不支持 seek/pread/pwrite，按流式对象处理，统一返回 ESPIPE。
         true

--- a/kernel/src/filesystem/eventfd.rs
+++ b/kernel/src/filesystem/eventfd.rs
@@ -2,7 +2,7 @@ use super::vfs::PollableInode;
 use crate::arch::MMArch;
 use crate::filesystem::epoll::event_poll::LockedEPItemLinkedList;
 use crate::filesystem::vfs::file::FileFlags;
-use crate::filesystem::vfs::InodeMode;
+use crate::filesystem::vfs::{InodeMode, OpenFileBehavior, PostWriteSyncPolicy};
 use crate::filesystem::{
     epoll::{event_poll::EventPoll, EPollEventType, EPollItem},
     vfs::{FilePrivateData, FileSystem, FileType, FsInfo, IndexNode, Magic, Metadata, SuperBlock},
@@ -167,6 +167,10 @@ impl PollableInode for EventFdInode {
 }
 
 impl IndexNode for EventFdInode {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        behavior.post_write_sync = PostWriteSyncPolicy::NotApplicable;
+    }
+
     fn is_stream(&self) -> bool {
         // eventfd 属于典型的不可 seek 的伪文件描述符：
         // - lseek/pread/pwrite 应返回 ESPIPE（Linux 语义）

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -1,5 +1,8 @@
 use crate::{
-    driver::base::{block::gendisk::GenDisk, device::device_number::DeviceNumber},
+    driver::base::{
+        block::gendisk::{GenDisk, GenDiskMountGuard},
+        device::device_number::DeviceNumber,
+    },
     exception::workqueue::{Work, WorkQueue},
     filesystem::{
         ext4::inode::{
@@ -168,6 +171,8 @@ pub struct Ext4FileSystem {
     pub(super) fs: another_ext4::Ext4,
     /// 当前文件系统对应的设备号
     pub(super) raw_dev: DeviceNumber,
+    /// Prevents loop clear/remove for the complete filesystem lifetime.
+    _device_mount_holder: GenDiskMountGuard,
 
     /// 根 inode
     root_inode: Arc<LockedExt4Inode>,
@@ -1185,6 +1190,7 @@ impl Ext4FileSystem {
         mount_options: Ext4MountOptions,
     ) -> Result<Arc<dyn FileSystem>, SystemError> {
         mount_options.validate_error_behavior()?;
+        let device_mount_holder = mount_data.acquire_mount_holder()?;
 
         // Worker creation may sleep and must never happen from final-release
         // publication while inode/eviction locks are held.
@@ -1257,6 +1263,7 @@ impl Ext4FileSystem {
         let fs = Arc::new(Ext4FileSystem {
             fs,
             raw_dev,
+            _device_mount_holder: device_mount_holder,
             root_inode,
             dirty_inodes: Mutex::new(Vec::new()),
             inode_table: Mutex::new(BTreeMap::new()),

--- a/kernel/src/filesystem/ext4/gendisk.rs
+++ b/kernel/src/filesystem/ext4/gendisk.rs
@@ -86,7 +86,7 @@ impl another_ext4::BlockDevice for GenDisk {
 
         let (_, lba_id_start, block_count) = self.convert_from_ext4_blkid(block_id);
         self.block_device()
-            .read_at(lba_id_start, block_count, &mut *buf)
+            .and_then(|bdev| bdev.read_at(lba_id_start, block_count, &mut *buf))
             .map_err(|e| {
                 log::error!("Ext4BlkDevice '{:?}' read_block failed: {:?}", block_id, e);
                 another_ext4::Ext4Error::new(Self::map_system_error_to_ext4(&e))
@@ -100,7 +100,7 @@ impl another_ext4::BlockDevice for GenDisk {
     ) -> core::result::Result<(), another_ext4::Ext4Error> {
         let (_, lba_id_start, block_count) = self.convert_from_ext4_blkid(block.id);
         self.block_device()
-            .write_at(lba_id_start, block_count, &*block.data)
+            .and_then(|bdev| bdev.write_at(lba_id_start, block_count, &*block.data))
             .map_err(|e| {
                 let code = Self::map_system_error_to_ext4(&e);
                 if code == another_ext4::ErrCode::EROFS {
@@ -144,7 +144,7 @@ impl another_ext4::BlockDevice for GenDisk {
                 })?;
             let completed = self
                 .block_device()
-                .write_at(lba_start, lba_count, chunk)
+                .and_then(|bdev| bdev.write_at(lba_start, lba_count, chunk))
                 .map_err(|error| {
                     another_ext4::Ext4Error::new(Self::map_system_error_to_ext4(&error))
                 })?;
@@ -163,6 +163,7 @@ impl another_ext4::BlockDevice for GenDisk {
     }
 
     fn supports_reliable_flush(&self) -> bool {
-        self.block_device().supports_reliable_flush()
+        self.block_device()
+            .is_ok_and(|bdev| bdev.supports_reliable_flush())
     }
 }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1295,6 +1295,10 @@ impl IndexNode for LockedExt4Inode {
         Some(self.fs())
     }
 
+    fn supports_post_write_sync(&self, file_type: vfs::FileType) -> bool {
+        file_type == vfs::FileType::File
+    }
+
     fn retention_state(&self) -> Option<&InodeRetentionState> {
         Some(&self.retention)
     }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1295,10 +1295,6 @@ impl IndexNode for LockedExt4Inode {
         Some(self.fs())
     }
 
-    fn supports_post_write_sync(&self, file_type: vfs::FileType) -> bool {
-        file_type == vfs::FileType::File
-    }
-
     fn retention_state(&self) -> Option<&InodeRetentionState> {
         Some(&self.retention)
     }

--- a/kernel/src/filesystem/fat/entry.rs
+++ b/kernel/src/filesystem/fat/entry.rs
@@ -306,8 +306,18 @@ impl FATFile {
         // 计算短目录项所在的位置，更新短目录项
         let short_entry_offset = fs.cluster_bytes_offset(self.loc.1 .0) + self.loc.1 .1;
         // todo: 更新时间信息
-        // 把短目录项写入磁盘
-        self.short_dir_entry.flush(fs, short_entry_offset)?;
+        //
+        // 这里只提交文件可达性所需的首簇和长度元数据，不提前发出设备
+        // barrier。调用者随后还要写入实际文件数据；若这里使用 flush()，
+        // O_SYNC 扩展写会在数据写入前后各做一次昂贵且顺序错误的 barrier。
+        //
+        // 当前 FAT 不延迟 FAT chain 或 short direntry 元数据：
+        // FATFile::write()/ensure_len() 返回前，这些写已经提交给底层设备。
+        // file-level fsync 会在数据页写回完成后执行最终 gendisk.sync()。
+        // 若未来引入延迟 metadata，必须同时扩展 FAT 的 sync_file_range()
+        // 以显式提交并等待这些 metadata。
+        self.short_dir_entry
+            .commit_without_barrier(fs, short_entry_offset)?;
         return Ok(());
     }
 
@@ -1149,16 +1159,13 @@ impl LongDirEntry {
         return Ok(());
     }
 
-    /// @brief 把当前长目录项写入磁盘
+    /// Submit the directory-sector RMW without issuing a device cache barrier.
     ///
-    /// @param fs 对应的文件系统
-    /// @param disk_bytes_offset 长目录项所在位置对应的在分区内的字节偏移量
-    ///
-    /// @return Ok(())
-    /// @return Err(SystemError) 错误码
-    pub fn flush(
+    /// The RMW remains serialized by `dirent_io_lock`; callers must establish
+    /// their own later durability boundary before promising persistence.
+    fn commit_without_barrier(
         &self,
-        fs: Arc<FATFileSystem>,
+        fs: &Arc<FATFileSystem>,
         gendisk_bytes_offset: u64,
     ) -> Result<(), SystemError> {
         // 目录项扇区 RMW 必须串行化，否则与并发的短/长目录项 flush 交错时，
@@ -1199,9 +1206,23 @@ impl LongDirEntry {
         // 把修改后的长目录项刷入磁盘
         fs.gendisk.write_at(cursor.as_slice(), lba)?;
 
-        fs.gendisk.sync()?;
+        Ok(())
+    }
 
-        return Ok(());
+    /// @brief 把当前长目录项写入磁盘，并建立设备持久化边界
+    ///
+    /// @param fs 对应的文件系统
+    /// @param disk_bytes_offset 长目录项所在位置对应的在分区内的字节偏移量
+    ///
+    /// @return Ok(())
+    /// @return Err(SystemError) 错误码
+    pub fn flush(
+        &self,
+        fs: Arc<FATFileSystem>,
+        gendisk_bytes_offset: u64,
+    ) -> Result<(), SystemError> {
+        self.commit_without_barrier(&fs, gendisk_bytes_offset)?;
+        fs.gendisk.sync()
     }
 }
 
@@ -1364,17 +1385,12 @@ impl ShortDirEntry {
         return result;
     }
 
-    /// # 把当前短目录项写入磁盘
+    /// Submit the directory-sector RMW without issuing a device cache barrier.
     ///
-    /// ## 参数
-    ///
-    /// - fs 对应的文件系统
-    /// - gendisk_bytes_offset 短目录项所在位置对应的在分区内的字节偏移量
-    ///
-    /// # 返回值
-    /// - Ok(())
-    /// - Err(SystemError) 错误码
-    pub fn flush(
+    /// This is intentionally private to the FAT implementation. The RMW is
+    /// complete when this function returns, but power-loss durability still
+    /// requires a later `gendisk.sync()`.
+    fn commit_without_barrier(
         &self,
         fs: &Arc<FATFileSystem>,
         gendisk_bytes_offset: u64,
@@ -1410,9 +1426,26 @@ impl ShortDirEntry {
         // 把修改后的长目录项刷入磁盘
         fs.gendisk.write_at(cursor.as_slice(), lba)?;
 
-        fs.gendisk.sync()?;
+        Ok(())
+    }
 
-        return Ok(());
+    /// # 把当前短目录项写入磁盘，并建立设备持久化边界
+    ///
+    /// ## 参数
+    ///
+    /// - fs 对应的文件系统
+    /// - gendisk_bytes_offset 短目录项所在位置对应的分区内字节偏移量
+    ///
+    /// # 返回值
+    /// - Ok(())
+    /// - Err(SystemError) 错误码
+    pub fn flush(
+        &self,
+        fs: &Arc<FATFileSystem>,
+        gendisk_bytes_offset: u64,
+    ) -> Result<(), SystemError> {
+        self.commit_without_barrier(fs, gendisk_bytes_offset)?;
+        fs.gendisk.sync()
     }
 
     /// @brief 设置短目录项的“第一个簇”字段的值

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -16,9 +16,10 @@ use log::error;
 use lru::LruCache;
 use system_error::SystemError;
 
-use crate::driver::base::block::gendisk::GenDisk;
+use crate::driver::base::block::gendisk::{GenDisk, GenDiskMountGuard};
 use crate::driver::base::device::device_number::DeviceNumber;
 use crate::filesystem::page_cache::{AsyncPageCacheBackend, PageCache};
+use crate::filesystem::vfs::mount::filesystem_is_synchronous;
 use crate::filesystem::vfs::utils::DName;
 use crate::filesystem::vfs::{Magic, SpecialNodeData, SuperBlock};
 use crate::ipc::pipe::LockedPipeInode;
@@ -94,6 +95,8 @@ impl Eq for Cluster {}
 pub struct FATFileSystem {
     /// 当前文件系统所在的分区
     pub gendisk: Arc<GenDisk>,
+    /// Prevents loop clear/remove for the complete filesystem lifetime.
+    _device_mount_holder: GenDiskMountGuard,
     /// 当前文件系统的BOPB
     pub bpb: BiosParameterBlock,
     /// 当前文件系统的第一个数据扇区（相对分区开始位置）
@@ -697,6 +700,7 @@ impl FATFileSystem {
     }
 
     pub fn new(gendisk: Arc<GenDisk>) -> Result<Arc<FATFileSystem>, SystemError> {
+        let device_mount_holder = gendisk.acquire_mount_holder()?;
         let bpb = BiosParameterBlock::new(&gendisk)?;
         // 从磁盘上读取FAT32文件系统的FsInfo结构体
         let fs_info: FATFsInfo = match bpb.fat_type {
@@ -772,6 +776,7 @@ impl FATFileSystem {
 
         let result: Arc<FATFileSystem> = Arc::new(FATFileSystem {
             gendisk,
+            _device_mount_holder: device_mount_holder,
             bpb,
             first_data_sector,
             fs_info: Arc::new(LockedFATFsInfo::new(fs_info)),
@@ -1883,18 +1888,9 @@ impl IndexNode for LockedFATInode {
     fn sync_file(
         &self,
         datasync: bool,
-        _data: MutexGuard<FilePrivateData>,
+        data: MutexGuard<FilePrivateData>,
     ) -> Result<(), SystemError> {
-        match self.metadata()?.file_type {
-            FileType::File | FileType::Dir => {
-                if datasync {
-                    self.datasync()
-                } else {
-                    self.sync()
-                }
-            }
-            _ => Err(SystemError::EINVAL),
-        }
+        self.sync_file_range(0, usize::MAX, datasync, data)
     }
 
     fn sync_file_range(
@@ -1904,19 +1900,38 @@ impl IndexNode for LockedFATInode {
         _datasync: bool,
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<(), SystemError> {
-        match self.metadata()?.file_type {
-            FileType::File | FileType::Dir => {
-                if let Some(page_cache) = self.page_cache() {
-                    let start_index = start >> MMArch::PAGE_SHIFT;
-                    let end_index = end >> MMArch::PAGE_SHIFT;
-                    page_cache
-                        .manager()
-                        .writeback_range(start_index, end_index)?;
-                }
-                Ok(())
-            }
-            _ => Err(SystemError::EINVAL),
+        let (file_type, page_cache, fs) = {
+            let inode = self.0.lock();
+            (
+                inode.metadata.file_type,
+                inode.page_cache.clone(),
+                inode.fs.upgrade().ok_or(SystemError::EIO)?,
+            )
+        };
+
+        if !matches!(file_type, FileType::File | FileType::Dir) {
+            return Err(SystemError::EINVAL);
         }
+
+        if let Some(page_cache) = page_cache {
+            let start_index = start >> MMArch::PAGE_SHIFT;
+            let end_index = end >> MMArch::PAGE_SHIFT;
+            // writeback_range() is synchronous: it submits and waits for the
+            // selected dirty pages, propagating submission/writeback errors.
+            // FATFile::write()/ensure_len() also submits the FAT chain and
+            // short direntry updates needed to make an extended file
+            // reachable before this call returns.
+            page_cache
+                .manager()
+                .writeback_range(start_index, end_index)?;
+        }
+
+        // FAT cannot safely omit size/cluster metadata for fdatasync, so both
+        // fsync and fdatasync share this final power-loss durability boundary.
+        // Do not move this barrier into page writeback: a single file-level
+        // sync must cover the related data, FAT chain, and directory entry,
+        // and the device flush error must be visible to the caller.
+        fs.gendisk.sync()
     }
 
     fn read_sync(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
@@ -2151,6 +2166,19 @@ impl IndexNode for LockedFATInode {
                             remain_size -= write_size;
                             offset += write_size;
                         }
+                        // Unlike ordinary/O_SYNC writes, resize and mode-0
+                        // fallocate do not pass through File post-write sync.
+                        // Match Linux fat_cont_expand() only for IS_SYNC.
+                        guard.synchronize_metadata();
+                        guard.metadata.size = len as i64;
+                        let inode_sync = guard.metadata.flags.contains(InodeFlags::S_SYNC);
+                        let fs = fs.clone();
+                        drop(guard);
+                        let mounted_fs: Arc<dyn FileSystem> = fs.clone();
+                        if inode_sync || filesystem_is_synchronous(&mounted_fs) {
+                            fs.gendisk.sync()?;
+                        }
+                        return Ok(());
                     }
                     Ordering::Less => {
                         guard.metadata.size = len as i64;
@@ -2175,10 +2203,6 @@ impl IndexNode for LockedFATInode {
                         }
                     }
                 }
-                // 同步元数据：从文件对象获取最新大小，并确保一致
-                guard.synchronize_metadata();
-                guard.metadata.size = len as i64;
-                return Ok(());
             }
             FATDirEntry::Dir(_) => return Err(SystemError::ENOSYS),
             FATDirEntry::UnInit => {

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -1876,6 +1876,10 @@ impl IndexNode for LockedFATInode {
         Some(self.fs())
     }
 
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::File
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -1876,10 +1876,6 @@ impl IndexNode for LockedFATInode {
         Some(self.fs())
     }
 
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::File
-    }
-
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -48,6 +48,10 @@ impl IndexNode for FuseNode {
         self.try_fs()
     }
 
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::File
+    }
+
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
     }

--- a/kernel/src/filesystem/fuse/inode/vfs.rs
+++ b/kernel/src/filesystem/fuse/inode/vfs.rs
@@ -14,7 +14,7 @@ use crate::{
             syscall::RenameFlags,
             utils::DName,
             DirectoryEntry, FilePrivateData, FileSystem, FileType, IndexNode, InodeMode, Metadata,
-            SetMetadataMask, XattrFlags,
+            OpenFileBehavior, SetMetadataMask, XattrFlags,
         },
     },
     libs::{casting::DowncastArc, mutex::MutexGuard},
@@ -46,10 +46,6 @@ impl IndexNode for FuseNode {
 
     fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
         self.try_fs()
-    }
-
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::File
     }
 
     fn as_any_ref(&self) -> &dyn core::any::Any {
@@ -274,7 +270,8 @@ impl IndexNode for FuseNode {
         }
     }
 
-    fn adjust_file_mode_after_open(&self, data: &FilePrivateData, mode: &mut FileMode) {
+    fn configure_open_file(&self, data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        let mode = &mut behavior.mode;
         let fopen_flags = match data {
             FilePrivateData::Fuse(FuseFilePrivateData::File(p))
             | FilePrivateData::Fuse(FuseFilePrivateData::Dir(p)) => p.fopen_flags,

--- a/kernel/src/filesystem/kernfs/mod.rs
+++ b/kernel/src/filesystem/kernfs/mod.rs
@@ -22,7 +22,8 @@ use self::callback::{KernCallbackData, KernFSCallback, KernInodePrivateData};
 
 use super::vfs::{
     file::FileFlags, utils::DName, vcore::generate_inode_id, FilePrivateData, FileSystem, FileType,
-    FsInfo, IndexNode, InodeFlags, InodeId, InodeMode, Magic, Metadata, SuperBlock,
+    FsInfo, IndexNode, InodeFlags, InodeId, InodeMode, Magic, Metadata, OpenFileBehavior,
+    PostWriteSyncPolicy, SuperBlock,
 };
 
 pub mod callback;
@@ -163,6 +164,10 @@ pub struct InnerKernFSInode {
 }
 
 impl IndexNode for KernFSInode {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        behavior.post_write_sync = PostWriteSyncPolicy::NotApplicable;
+    }
+
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
     }

--- a/kernel/src/filesystem/overlayfs/file.rs
+++ b/kernel/src/filesystem/overlayfs/file.rs
@@ -90,9 +90,22 @@ pub(super) fn write_at(
     buf: &[u8],
     data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
 ) -> Result<usize, SystemError> {
+    let result = write_at_with_sync(inode, offset, len, buf, vfs::WriteSyncIntent::None, data)?;
+    result.sync_result?;
+    Ok(result.written_len)
+}
+
+pub(super) fn write_at_with_sync(
+    inode: &OvlInode,
+    offset: usize,
+    len: usize,
+    buf: &[u8],
+    sync_intent: vfs::WriteSyncIntent,
+    data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
+) -> Result<vfs::DelegatedWriteResult, SystemError> {
     if len == 0 {
         let (backing_file, _) = backing_file_for_io(inode, data)?;
-        return backing_file.pwrite(offset, len, buf);
+        return backing_file.pwrite_with_sync_intent(offset, len, buf, sync_intent);
     }
 
     let _privilege_guard = inode.content_privilege_lock.lock();
@@ -101,7 +114,7 @@ pub(super) fn write_at(
     let _content_guard = fs.content_lock(&backing_file.inode())?.lock();
     let _cred_guard = CredOverrideGuard::new(fs.backing_cred.clone())?;
     super::metadata::remove_security_capability(&backing_file.inode())?;
-    backing_file.pwrite(offset, len, buf)
+    backing_file.pwrite_with_sync_intent(offset, len, buf, sync_intent)
 }
 
 pub(super) fn sync_file(
@@ -220,7 +233,14 @@ fn open_flags_need_copy_up(file_type: FileType, flags: &FileFlags) -> bool {
 }
 
 fn backing_open_flags(mut flags: FileFlags) -> FileFlags {
-    flags.remove(FileFlags::O_CREAT | FileFlags::O_EXCL | FileFlags::O_NOCTTY | FileFlags::O_TRUNC);
+    flags.remove(
+        FileFlags::O_CREAT
+            | FileFlags::O_EXCL
+            | FileFlags::O_NOCTTY
+            | FileFlags::O_TRUNC
+            | FileFlags::O_SYNC
+            | FileFlags::O_DSYNC,
+    );
     flags
 }
 

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -310,6 +310,10 @@ impl IndexNode for OvlInode {
         Some(self.fs())
     }
 
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::File
+    }
+
     fn open(
         &self,
         data: crate::libs::mutex::MutexGuard<FilePrivateData>,

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -310,10 +310,6 @@ impl IndexNode for OvlInode {
         Some(self.fs())
     }
 
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::File
-    }
-
     fn open(
         &self,
         data: crate::libs::mutex::MutexGuard<FilePrivateData>,

--- a/kernel/src/filesystem/overlayfs/inode.rs
+++ b/kernel/src/filesystem/overlayfs/inode.rs
@@ -9,7 +9,8 @@ use crate::filesystem::vfs::syscall::RenameFlags;
 use crate::filesystem::vfs::utils::DName;
 use crate::filesystem::vfs::{
     self, inode_lifecycle::InodeRetentionGuard, DirectoryEntry, FileSystem, FileType, IndexNode,
-    InodeId, InodeRetentionKind, Metadata, SetMetadataMask, XattrFlags,
+    InodeId, InodeRetentionKind, Metadata, OpenFileBehavior, PostWriteSyncPolicy, SetMetadataMask,
+    XattrFlags,
 };
 use crate::libs::casting::DowncastArc;
 use crate::libs::mutex::Mutex;
@@ -306,6 +307,12 @@ impl OvlInode {
 }
 
 impl IndexNode for OvlInode {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        if self.file_type == FileType::File {
+            behavior.post_write_sync = PostWriteSyncPolicy::Delegated;
+        }
+    }
+
     fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
         Some(self.fs())
     }
@@ -340,6 +347,17 @@ impl IndexNode for OvlInode {
         data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
     ) -> Result<usize, SystemError> {
         file::write_at(self, offset, len, buf, data)
+    }
+
+    fn write_at_with_sync(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &[u8],
+        sync_intent: vfs::WriteSyncIntent,
+        data: crate::libs::mutex::MutexGuard<vfs::FilePrivateData>,
+    ) -> Result<vfs::DelegatedWriteResult, SystemError> {
+        file::write_at_with_sync(self, offset, len, buf, sync_intent, data)
     }
 
     fn sync_file(

--- a/kernel/src/filesystem/procfs/template/file.rs
+++ b/kernel/src/filesystem/procfs/template/file.rs
@@ -5,7 +5,7 @@ use crate::{
         procfs::{template::Common, ProcfsFilePrivateData},
         vfs::{
             file::FileFlags, vcore::generate_inode_id, FilePrivateData, FileSystem, FileType,
-            IndexNode, InodeFlags, InodeMode, Metadata,
+            IndexNode, InodeFlags, InodeMode, Metadata, OpenFileBehavior, PostWriteSyncPolicy,
         },
     },
     time::PosixTimeSpec,
@@ -125,6 +125,10 @@ pub trait FileOps: Sync + Send + Sized + Debug {
 /// 使用 inherit_methods 宏从 common 继承通用方法
 #[inherit_methods(from = "self.common")]
 impl<F: FileOps + 'static> IndexNode for ProcFile<F> {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        behavior.post_write_sync = PostWriteSyncPolicy::NotApplicable;
+    }
+
     fn fs(&self) -> Arc<dyn FileSystem>;
     fn as_any_ref(&self) -> &dyn core::any::Any;
     fn set_metadata(&self, metadata: &Metadata) -> Result<(), SystemError>;

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -348,6 +348,10 @@ impl IndexNode for LockedRamFSInode {
         Some(self.fs())
     }
 
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::File
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -348,10 +348,6 @@ impl IndexNode for LockedRamFSInode {
         Some(self.fs())
     }
 
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::File
-    }
-
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -790,6 +790,10 @@ impl IndexNode for LockedTmpfsInode {
         Some(self.fs())
     }
 
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        file_type == FileType::File
+    }
+
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -35,7 +35,8 @@ use system_error::SystemError;
 
 use super::vfs::{
     file::FilePrivateData, mount::MountFlags, utils::DName, FileSystem, FsInfo,
-    FsReconfigureRequest, IndexNode, InodeFlags, InodeId, InodeMode, Metadata, SpecialNodeData,
+    FsReconfigureRequest, IndexNode, InodeFlags, InodeId, InodeMode, Metadata, OpenFileBehavior,
+    PostWriteSyncPolicy, SpecialNodeData,
 };
 
 use linkme::distributed_slice;
@@ -786,6 +787,10 @@ impl MountableFileSystem for Tmpfs {
 register_mountable_fs!(Tmpfs, TMPFSMAKER, "tmpfs");
 
 impl IndexNode for LockedTmpfsInode {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        behavior.post_write_sync = PostWriteSyncPolicy::NotApplicable;
+    }
+
     fn append_lock_fs(&self) -> Option<Arc<dyn FileSystem>> {
         Some(self.fs())
     }

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -790,10 +790,6 @@ impl IndexNode for LockedTmpfsInode {
         Some(self.fs())
     }
 
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        file_type == FileType::File
-    }
-
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         Ok(())
     }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -10,7 +10,7 @@ use system_error::SystemError;
 use super::{
     append_lock::{with_inode_append_lock, AppendLockKey},
     inode_lifecycle::{InodeRetentionGuard, InodeRetentionKind},
-    mount::{MountExternalGuard, MountFSInode},
+    mount::{MountExternalGuard, MountFSInode, MountFlags},
     utils::should_remove_sgid,
     DirectoryEntry, FileSystem, FileType, IndexNode, InodeId, Metadata, SetMetadataMask,
     SpecialNodeData,
@@ -824,6 +824,13 @@ impl File {
         Ok(len.min(limit.saturating_sub(offset)))
     }
 
+    fn combined_mount_flags(&self) -> MountFlags {
+        match self.inode.clone().downcast_arc::<MountFSInode>() {
+            Some(mnt_inode) => mnt_inode.mount_fs().combined_flags(),
+            None => self.inode.mount_flags(),
+        }
+    }
+
     fn maybe_sync_after_write(
         &self,
         file_type: FileType,
@@ -832,7 +839,7 @@ impl File {
         flags: FileFlags,
         inode_flags: InodeFlags,
     ) -> Result<(), SystemError> {
-        if written_len == 0 || !self.inode.supports_post_write_sync(file_type) {
+        if written_len == 0 {
             return Ok(());
         }
 
@@ -843,14 +850,23 @@ impl File {
 
         // inode 级别的 S_SYNC 标志
         let inode_sync = inode_flags.contains(InodeFlags::S_SYNC);
+        // Linux IS_SYNC(inode) 同时包含 inode S_SYNC 与 superblock/mount sync 语义。
+        let mount_sync = self
+            .combined_mount_flags()
+            .contains(MountFlags::SYNCHRONOUS);
 
-        if need_data_sync || inode_sync {
-            let end = start.saturating_add(written_len).saturating_sub(1);
-            // O_SYNC requests full metadata sync. O_DSYNC and inode S_SYNC
-            // use datasync, matching generic_write_sync().
-            self.sync_range_and_check_wb_error(start, end, !need_metadata_sync)?;
+        if !(need_data_sync || inode_sync || mount_sync) {
+            return Ok(());
         }
-        Ok(())
+
+        if !self.inode.supports_post_write_sync(file_type) {
+            return Ok(());
+        }
+
+        let end = start.saturating_add(written_len).saturating_sub(1);
+        // Linux generic_write_sync() 只有 IOCB_SYNC 才请求完整 metadata sync；
+        // O_DSYNC、S_SYNC 与 SB_SYNCHRONOUS 都按 datasync 处理。
+        self.sync_range_and_check_wb_error(start, end, !need_metadata_sync)
     }
 
     #[inline(never)]

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -205,10 +205,6 @@ struct WriteConfig {
     update_offset: bool,
     /// 偏移量更新方式
     offset_update: OffsetUpdate,
-    /// 文件标志
-    flags: FileFlags,
-    /// inode 标志
-    inode_flags: InodeFlags,
 }
 /// Namespace fd backing data, typically created from /proc/thread-self/ns/* files.
 #[derive(Clone)]
@@ -830,9 +826,16 @@ impl File {
 
     fn maybe_sync_after_write(
         &self,
+        file_type: FileType,
+        start: usize,
+        written_len: usize,
         flags: FileFlags,
         inode_flags: InodeFlags,
     ) -> Result<(), SystemError> {
+        if written_len == 0 || !self.inode.supports_post_write_sync(file_type) {
+            return Ok(());
+        }
+
         // O_SYNC 包含 O_DSYNC 位，所以只需检查 O_DSYNC 即可判断是否需要数据同步
         let need_data_sync = flags.contains(FileFlags::O_DSYNC);
         // 检查是否需要元数据同步（O_SYNC = __O_SYNC | O_DSYNC）
@@ -842,13 +845,10 @@ impl File {
         let inode_sync = inode_flags.contains(InodeFlags::S_SYNC);
 
         if need_data_sync || inode_sync {
-            if need_metadata_sync || inode_sync {
-                // O_SYNC 或 S_SYNC: 完整同步（数据 + 元数据）
-                self.sync_range_and_check_wb_error(0, usize::MAX, false)?;
-            } else {
-                // O_DSYNC: 仅数据同步
-                self.sync_range_and_check_wb_error(0, usize::MAX, true)?;
-            }
+            let end = start.saturating_add(written_len).saturating_sub(1);
+            // O_SYNC requests full metadata sync. O_DSYNC and inode S_SYNC
+            // use datasync, matching generic_write_sync().
+            self.sync_range_and_check_wb_error(start, end, !need_metadata_sync)?;
         }
         Ok(())
     }
@@ -921,7 +921,6 @@ impl File {
             }
         }
 
-        self.maybe_sync_after_write(config.flags, config.inode_flags)?;
         Ok(written_len)
     }
     /// @brief 创建一个新的文件对象
@@ -1487,31 +1486,32 @@ impl File {
                     WriteConfig {
                         update_offset,
                         offset_update: OffsetUpdate::StoreEnd,
-                        flags,
-                        inode_flags,
                     },
                 )
+                .map(|written_len| (actual_offset, written_len))
             };
-            return match self.append_lock_domain.as_ref() {
+            let (actual_offset, written_len) = match self.append_lock_domain.as_ref() {
                 Some(domain) => with_inode_append_lock(domain.key(&md), append_write),
                 None => append_write(),
-            };
+            }?;
+            self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
+            return Ok(written_len);
         }
 
         let actual_offset = offset;
         let actual_len = self.limit_write_len_by_fsize(file_type, actual_offset, len)?;
 
-        self.write_at_and_finalize(
+        let written_len = self.write_at_and_finalize(
             actual_offset,
             actual_len,
             buf,
             WriteConfig {
                 update_offset,
                 offset_update: OffsetUpdate::Add,
-                flags,
-                inode_flags,
             },
-        )
+        )?;
+        self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
+        Ok(written_len)
     }
 
     pub fn do_write_user(
@@ -1556,31 +1556,32 @@ impl File {
                     WriteConfig {
                         update_offset,
                         offset_update: OffsetUpdate::StoreEnd,
-                        flags,
-                        inode_flags,
                     },
                 )
+                .map(|written_len| (actual_offset, written_len))
             };
-            return match self.append_lock_domain.as_ref() {
+            let (actual_offset, written_len) = match self.append_lock_domain.as_ref() {
                 Some(domain) => with_inode_append_lock(domain.key(&md), append_write),
                 None => append_write(),
-            };
+            }?;
+            self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
+            return Ok(written_len);
         }
 
         let actual_offset = offset;
         let actual_len = self.limit_write_len_by_fsize(file_type, actual_offset, len)?;
 
-        self.write_user_at_and_finalize(
+        let written_len = self.write_user_at_and_finalize(
             actual_offset,
             actual_len,
             reader,
             WriteConfig {
                 update_offset,
                 offset_update: OffsetUpdate::Add,
-                flags,
-                inode_flags,
             },
-        )
+        )?;
+        self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
+        Ok(written_len)
     }
 
     /// Write to the file from a userspace buffer.

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -205,6 +205,68 @@ struct WriteConfig {
     update_offset: bool,
     /// 偏移量更新方式
     offset_update: OffsetUpdate,
+    /// Only consumed by a delegated write operation.
+    sync_intent: WriteSyncIntent,
+}
+
+/// Determines which write operation owns Linux post-write synchronous-I/O
+/// semantics for one open file description.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostWriteSyncPolicy {
+    /// The VFS calls the file-level range fsync operation after a positive write.
+    Generic,
+    /// The selected write operation consumes [`WriteSyncIntent`] itself.
+    Delegated,
+    /// The selected Linux write operation does not use `generic_write_sync()`.
+    NotApplicable,
+}
+
+/// Per-open behavior selected after the inode has initialized private data.
+#[derive(Debug, Clone, Copy)]
+pub struct OpenFileBehavior {
+    pub mode: FileMode,
+    pub post_write_sync: PostWriteSyncPolicy,
+}
+
+impl OpenFileBehavior {
+    fn new(mode: FileMode, file_type: FileType) -> Self {
+        let post_write_sync = match file_type {
+            FileType::File | FileType::BlockDevice => PostWriteSyncPolicy::Generic,
+            _ => PostWriteSyncPolicy::NotApplicable,
+        };
+        Self {
+            mode,
+            post_write_sync,
+        }
+    }
+}
+
+/// Synchronization requested as part of a delegated write operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteSyncIntent {
+    None,
+    Data,
+    Full,
+}
+
+impl WriteSyncIntent {
+    pub fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Full, _) | (_, Self::Full) => Self::Full,
+            (Self::Data, _) | (_, Self::Data) => Self::Data,
+            _ => Self::None,
+        }
+    }
+}
+
+/// A delegated write reports data progress separately from its sync result.
+///
+/// This preserves Linux's ordering: offset and write side effects are finalized
+/// after a positive write even when the following synchronous flush fails.
+#[derive(Debug)]
+pub struct DelegatedWriteResult {
+    pub written_len: usize,
+    pub sync_result: Result<(), SystemError>,
 }
 /// Namespace fd backing data, typically created from /proc/thread-self/ns/* files.
 #[derive(Clone)]
@@ -586,6 +648,8 @@ pub struct File {
     mode: RwSem<FileMode>,
     /// 文件类型
     file_type: FileType,
+    /// Immutable write-operation policy selected for this open file description.
+    post_write_sync: PostWriteSyncPolicy,
     /// Per-open immutable directory snapshot and its next record index.
     readdir_state: Mutex<ReaddirState>,
     pub private_data: Mutex<FilePrivateData>,
@@ -693,6 +757,30 @@ mod readdir_tests {
 }
 
 impl File {
+    fn configure_base_open_mode(inode: &Arc<dyn IndexNode>, mode: &mut FileMode) {
+        mode.remove(
+            FileMode::FMODE_STREAM
+                | FileMode::FMODE_LSEEK
+                | FileMode::FMODE_PREAD
+                | FileMode::FMODE_PWRITE
+                | FileMode::FMODE_ATOMIC_POS
+                | FileMode::FMODE_CAN_READ
+                | FileMode::FMODE_CAN_WRITE,
+        );
+        if inode.is_stream() {
+            mode.insert(FileMode::FMODE_STREAM);
+        }
+        if inode.supports_seek() {
+            mode.insert(FileMode::FMODE_LSEEK | FileMode::FMODE_ATOMIC_POS);
+        }
+        if inode.supports_pread() {
+            mode.insert(FileMode::FMODE_PREAD);
+        }
+        if inode.supports_pwrite() {
+            mode.insert(FileMode::FMODE_PWRITE);
+        }
+    }
+
     pub fn resolved_path(&self) -> Result<super::utils::ResolvedPath, SystemError> {
         let mount_guard = self
             ._mount_guard
@@ -824,64 +912,81 @@ impl File {
         Ok(len.min(limit.saturating_sub(offset)))
     }
 
-    fn combined_mount_flags(&self) -> MountFlags {
-        match self.inode.clone().downcast_arc::<MountFSInode>() {
-            Some(mnt_inode) => mnt_inode.mount_fs().combined_flags(),
-            None => self.inode.mount_flags(),
-        }
+    fn mount_is_synchronous(&self) -> bool {
+        self._mount_guard.as_ref().map_or_else(
+            || self.inode.mount_flags().contains(MountFlags::SYNCHRONOUS),
+            MountExternalGuard::is_synchronous,
+        )
     }
 
-    fn maybe_sync_after_write(
+    fn generic_sync_after_write(
         &self,
-        file_type: FileType,
         start: usize,
         written_len: usize,
-        flags: FileFlags,
-        inode_flags: InodeFlags,
+        sync_intent: WriteSyncIntent,
     ) -> Result<(), SystemError> {
-        if written_len == 0 {
+        if written_len == 0
+            || sync_intent == WriteSyncIntent::None
+            || self.post_write_sync != PostWriteSyncPolicy::Generic
+        {
             return Ok(());
         }
 
-        // O_SYNC 包含 O_DSYNC 位，所以只需检查 O_DSYNC 即可判断是否需要数据同步
-        let need_data_sync = flags.contains(FileFlags::O_DSYNC);
-        // 检查是否需要元数据同步（O_SYNC = __O_SYNC | O_DSYNC）
-        let need_metadata_sync = flags.contains(FileFlags::__O_SYNC);
-
-        // inode 级别的 S_SYNC 标志
-        let inode_sync = inode_flags.contains(InodeFlags::S_SYNC);
-        // Linux IS_SYNC(inode) 同时包含 inode S_SYNC 与 superblock/mount sync 语义。
-        let mount_sync = self
-            .combined_mount_flags()
-            .contains(MountFlags::SYNCHRONOUS);
-
-        if !(need_data_sync || inode_sync || mount_sync) {
-            return Ok(());
-        }
-
-        if !self.inode.supports_post_write_sync(file_type) {
-            return Ok(());
-        }
-
-        let end = start.saturating_add(written_len).saturating_sub(1);
+        let end = start
+            .checked_add(written_len - 1)
+            .ok_or(SystemError::EOVERFLOW)?;
         // Linux generic_write_sync() 只有 IOCB_SYNC 才请求完整 metadata sync；
         // O_DSYNC、S_SYNC 与 SB_SYNCHRONOUS 都按 datasync 处理。
-        self.sync_range_and_check_wb_error(start, end, !need_metadata_sync)
+        self.sync_range_and_check_wb_error(start, end, sync_intent != WriteSyncIntent::Full)
+    }
+
+    fn post_write_sync_intent(&self, flags: FileFlags, inode_flags: InodeFlags) -> WriteSyncIntent {
+        if self.post_write_sync == PostWriteSyncPolicy::NotApplicable {
+            return WriteSyncIntent::None;
+        }
+        if flags.contains(FileFlags::__O_SYNC) {
+            return WriteSyncIntent::Full;
+        }
+        if flags.contains(FileFlags::O_DSYNC)
+            || inode_flags.contains(InodeFlags::S_SYNC)
+            || self.mount_is_synchronous()
+        {
+            return WriteSyncIntent::Data;
+        }
+        WriteSyncIntent::None
     }
 
     #[inline(never)]
-    fn write_at_and_finalize(
+    fn write_at_and_finalize_split(
         &self,
         actual_offset: usize,
         actual_len: usize,
         buf: &[u8],
         config: WriteConfig,
-    ) -> Result<usize, SystemError> {
-        let written_len =
-            self.inode
-                .write_at(actual_offset, actual_len, buf, self.private_data.lock())?;
+    ) -> Result<DelegatedWriteResult, SystemError> {
+        let (written_len, sync_result) = match self.post_write_sync {
+            PostWriteSyncPolicy::Delegated => {
+                let result = self.inode.write_at_with_sync(
+                    actual_offset,
+                    actual_len,
+                    buf,
+                    config.sync_intent,
+                    self.private_data.lock(),
+                )?;
+                (result.written_len, Some(result.sync_result))
+            }
+            PostWriteSyncPolicy::Generic | PostWriteSyncPolicy::NotApplicable => (
+                self.inode
+                    .write_at(actual_offset, actual_len, buf, self.private_data.lock())?,
+                None,
+            ),
+        };
 
-        self.finalize_write(actual_offset, written_len, config)
+        let written_len = self.finalize_write(actual_offset, written_len, config)?;
+        Ok(DelegatedWriteResult {
+            written_len,
+            sync_result: sync_result.unwrap_or(Ok(())),
+        })
     }
 
     fn write_user_at_and_finalize(
@@ -891,25 +996,50 @@ impl File {
         reader: &UserBufferReader<'_>,
         config: WriteConfig,
     ) -> Result<usize, SystemError> {
-        let written_len = match self.inode.write_user_at(
-            actual_offset,
-            actual_len,
-            reader,
-            self.private_data.lock(),
-        )? {
-            Some(written_len) => written_len,
-            None => {
-                let mut buf = Vec::new();
-                buf.try_reserve(actual_len)
-                    .map_err(|_| SystemError::ENOMEM)?;
-                buf.resize(actual_len, 0);
-                reader.copy_from_user(&mut buf, 0)?;
-                self.inode
-                    .write_at(actual_offset, actual_len, &buf, self.private_data.lock())?
-            }
+        let (written_len, sync_result) = if self.post_write_sync == PostWriteSyncPolicy::Delegated {
+            let mut buf = Vec::new();
+            buf.try_reserve(actual_len)
+                .map_err(|_| SystemError::ENOMEM)?;
+            buf.resize(actual_len, 0);
+            reader.copy_from_user(&mut buf, 0)?;
+            let result = self.inode.write_at_with_sync(
+                actual_offset,
+                actual_len,
+                &buf,
+                config.sync_intent,
+                self.private_data.lock(),
+            )?;
+            (result.written_len, Some(result.sync_result))
+        } else {
+            let written_len = match self.inode.write_user_at(
+                actual_offset,
+                actual_len,
+                reader,
+                self.private_data.lock(),
+            )? {
+                Some(written_len) => written_len,
+                None => {
+                    let mut buf = Vec::new();
+                    buf.try_reserve(actual_len)
+                        .map_err(|_| SystemError::ENOMEM)?;
+                    buf.resize(actual_len, 0);
+                    reader.copy_from_user(&mut buf, 0)?;
+                    self.inode.write_at(
+                        actual_offset,
+                        actual_len,
+                        &buf,
+                        self.private_data.lock(),
+                    )?
+                }
+            };
+            (written_len, None)
         };
 
-        self.finalize_write(actual_offset, written_len, config)
+        let written_len = self.finalize_write(actual_offset, written_len, config)?;
+        if let Some(sync_result) = sync_result {
+            sync_result?;
+        }
+        Ok(written_len)
     }
 
     fn finalize_write(
@@ -1064,6 +1194,7 @@ impl File {
         flags.remove(FileFlags::O_CLOEXEC);
 
         let mut mode = FileMode::open_fmode(flags);
+        let mut post_write_sync = PostWriteSyncPolicy::NotApplicable;
         // Pin the final operation inode before invoking filesystem open. If
         // open fails, the local guard releases exactly once on this error path.
         let inode_retention =
@@ -1084,21 +1215,12 @@ impl File {
                 inode.open(private_data.lock(), &flags)?;
             }
 
-            // 设置默认能力（由 inode 能力接口统一决定；避免 syscall 层/字符串特判）
-            if inode.is_stream() {
-                mode.insert(FileMode::FMODE_STREAM);
-            }
-            if inode.supports_seek() {
-                mode.insert(FileMode::FMODE_LSEEK | FileMode::FMODE_ATOMIC_POS);
-            }
-            if inode.supports_pread() {
-                mode.insert(FileMode::FMODE_PREAD);
-            }
-            if inode.supports_pwrite() {
-                mode.insert(FileMode::FMODE_PWRITE);
-            }
-
-            inode.adjust_file_mode_after_open(&private_data.lock(), &mut mode);
+            // Select capabilities and behavior from this open's private data.
+            Self::configure_base_open_mode(&inode, &mut mode);
+            let mut behavior = OpenFileBehavior::new(mode, file_type);
+            inode.configure_open_file(&private_data.lock(), &mut behavior);
+            mode = behavior.mode;
+            post_write_sync = behavior.post_write_sync;
 
             // TODO: 检查inode是否有read/write方法,设置FMODE_CAN_READ/WRITE
             // 这需要在IndexNode trait中添加相应的检查方法
@@ -1143,6 +1265,7 @@ impl File {
             fasync_lock: Mutex::new(()),
             mode: RwSem::new(mode),
             file_type,
+            post_write_sync,
             readdir_state: Mutex::new(ReaddirState::default()),
             private_data,
             cred: ProcessManager::current_pcb().cred(),
@@ -1271,6 +1394,23 @@ impl File {
     /// ### 返回值
     /// - `Ok(usize)`: 成功写入的字节数
     pub fn pwrite(&self, offset: usize, len: usize, buf: &[u8]) -> Result<usize, SystemError> {
+        let result = self.pwrite_with_sync_intent(offset, len, buf, WriteSyncIntent::None)?;
+        result.sync_result?;
+        Ok(result.written_len)
+    }
+
+    /// Perform a positional write while merging an operation-level sync
+    /// request with this file's own O_SYNC/S_SYNC/SB_SYNCHRONOUS semantics.
+    ///
+    /// Data progress is returned separately from the synchronization result so
+    /// stacking filesystems can preserve write side effects when fsync fails.
+    pub fn pwrite_with_sync_intent(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &[u8],
+        requested_sync: WriteSyncIntent,
+    ) -> Result<DelegatedWriteResult, SystemError> {
         // Linux 语义：O_PATH fd 任何 I/O 都应返回 EBADF（优先于 ESPIPE）。
         let mode = *self.mode.read();
         if mode.contains(FileMode::FMODE_PATH) {
@@ -1292,7 +1432,7 @@ impl File {
             return Err(SystemError::EBADF);
         }
 
-        self.do_write(offset, len, buf, false, false)
+        self.do_write_split(offset, len, buf, false, false, requested_sync)
     }
 
     /// 强制追加写（Linux `RWF_APPEND`/`IOCB_APPEND` 语义）：
@@ -1464,6 +1604,27 @@ impl File {
         update_offset: bool,
         force_append: bool,
     ) -> Result<usize, SystemError> {
+        let result = self.do_write_split(
+            offset,
+            len,
+            buf,
+            update_offset,
+            force_append,
+            WriteSyncIntent::None,
+        )?;
+        result.sync_result?;
+        Ok(result.written_len)
+    }
+
+    fn do_write_split(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &[u8],
+        update_offset: bool,
+        force_append: bool,
+        requested_sync: WriteSyncIntent,
+    ) -> Result<DelegatedWriteResult, SystemError> {
         self.writeable()?;
 
         let inode_flags = self.get_inode_flags()?;
@@ -1482,6 +1643,12 @@ impl File {
         }
         let md = self.inode.metadata()?;
         let file_type = md.file_type;
+        let sync_intent = match self.post_write_sync {
+            PostWriteSyncPolicy::Generic | PostWriteSyncPolicy::Delegated => self
+                .post_write_sync_intent(flags, inode_flags)
+                .combine(requested_sync),
+            PostWriteSyncPolicy::NotApplicable => WriteSyncIntent::None,
+        };
 
         let is_append = matches!(file_type, FileType::File)
             && (flags.contains(FileFlags::O_APPEND) || force_append);
@@ -1495,39 +1662,62 @@ impl File {
                 let actual_offset = md.size.max(0) as usize;
                 let actual_len = self.limit_write_len_by_fsize(file_type, actual_offset, len)?;
 
-                self.write_at_and_finalize(
+                self.write_at_and_finalize_split(
                     actual_offset,
                     actual_len,
                     buf,
                     WriteConfig {
                         update_offset,
                         offset_update: OffsetUpdate::StoreEnd,
+                        sync_intent,
                     },
                 )
-                .map(|written_len| (actual_offset, written_len))
+                .map(|result| (actual_offset, result))
             };
-            let (actual_offset, written_len) = match self.append_lock_domain.as_ref() {
+            let (actual_offset, mut result) = match self.append_lock_domain.as_ref() {
                 Some(domain) => with_inode_append_lock(domain.key(&md), append_write),
                 None => append_write(),
             }?;
-            self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
-            return Ok(written_len);
+            if result.sync_result.is_ok() {
+                // generic_write_sync() observes IS_SYNC after the write.
+                // Re-sample the cheap mount atomic here while reusing the
+                // inode flags already fetched before I/O.
+                let current_sync_intent = self
+                    .post_write_sync_intent(flags, inode_flags)
+                    .combine(requested_sync);
+                result.sync_result = self.generic_sync_after_write(
+                    actual_offset,
+                    result.written_len,
+                    current_sync_intent,
+                );
+            }
+            return Ok(result);
         }
 
         let actual_offset = offset;
         let actual_len = self.limit_write_len_by_fsize(file_type, actual_offset, len)?;
 
-        let written_len = self.write_at_and_finalize(
+        let mut result = self.write_at_and_finalize_split(
             actual_offset,
             actual_len,
             buf,
             WriteConfig {
                 update_offset,
                 offset_update: OffsetUpdate::Add,
+                sync_intent,
             },
         )?;
-        self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
-        Ok(written_len)
+        if result.sync_result.is_ok() {
+            let current_sync_intent = self
+                .post_write_sync_intent(flags, inode_flags)
+                .combine(requested_sync);
+            result.sync_result = self.generic_sync_after_write(
+                actual_offset,
+                result.written_len,
+                current_sync_intent,
+            );
+        }
+        Ok(result)
     }
 
     pub fn do_write_user(
@@ -1553,6 +1743,7 @@ impl File {
 
         let md = self.inode.metadata()?;
         let file_type = md.file_type;
+        let sync_intent = self.post_write_sync_intent(flags, inode_flags);
 
         let is_append = matches!(file_type, FileType::File)
             && (flags.contains(FileFlags::O_APPEND) || force_append);
@@ -1572,6 +1763,7 @@ impl File {
                     WriteConfig {
                         update_offset,
                         offset_update: OffsetUpdate::StoreEnd,
+                        sync_intent,
                     },
                 )
                 .map(|written_len| (actual_offset, written_len))
@@ -1580,7 +1772,8 @@ impl File {
                 Some(domain) => with_inode_append_lock(domain.key(&md), append_write),
                 None => append_write(),
             }?;
-            self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
+            let current_sync_intent = self.post_write_sync_intent(flags, inode_flags);
+            self.generic_sync_after_write(actual_offset, written_len, current_sync_intent)?;
             return Ok(written_len);
         }
 
@@ -1594,9 +1787,11 @@ impl File {
             WriteConfig {
                 update_offset,
                 offset_update: OffsetUpdate::Add,
+                sync_intent,
             },
         )?;
-        self.maybe_sync_after_write(file_type, actual_offset, written_len, flags, inode_flags)?;
+        let current_sync_intent = self.post_write_sync_intent(flags, inode_flags);
+        self.generic_sync_after_write(actual_offset, written_len, current_sync_intent)?;
         Ok(written_len)
     }
 
@@ -1887,7 +2082,7 @@ impl File {
             InodeRetentionGuard::new(self.inode.clone(), InodeRetentionKind::OpenFileDescription)
                 .ok()?;
         let flags = self.flags();
-        let mode = self.mode();
+        let mut mode = self.mode();
         let private_data = Mutex::new(self.private_data.lock().clone());
         let mount_guard = self
             ._mount_guard
@@ -1901,6 +2096,23 @@ impl File {
         {
             return None;
         }
+
+        let post_write_sync = if mode.contains(FileMode::FMODE_PATH) {
+            PostWriteSyncPolicy::NotApplicable
+        } else {
+            Self::configure_base_open_mode(&self.inode, &mut mode);
+            let mut behavior = OpenFileBehavior::new(mode, self.file_type);
+            self.inode
+                .configure_open_file(&private_data.lock(), &mut behavior);
+            mode = behavior.mode;
+            if mode.contains(FileMode::FMODE_READ) {
+                mode.insert(FileMode::FMODE_CAN_READ);
+            }
+            if mode.contains(FileMode::FMODE_WRITE) {
+                mode.insert(FileMode::FMODE_CAN_WRITE);
+            }
+            behavior.post_write_sync
+        };
 
         if mode.contains(FileMode::FMODE_WRITER) {
             if let Some(mnt_inode) = self.inode.clone().downcast_arc::<MountFSInode>() {
@@ -1917,6 +2129,7 @@ impl File {
             fasync_lock: Mutex::new(()),
             mode: RwSem::new(mode),
             file_type: self.file_type,
+            post_write_sync,
             readdir_state: Mutex::new(self.readdir_state.lock().clone()),
             private_data,
             cred: self.cred.clone(),

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -47,9 +47,15 @@ use crate::{
 };
 
 pub use self::inode_lifecycle::{EvictionEpoch, InodeRetentionKind, InodeRetentionState};
-pub use self::{file::FilePrivateData, mount::MountFS};
+pub use self::{
+    file::{
+        DelegatedWriteResult, FilePrivateData, OpenFileBehavior, PostWriteSyncPolicy,
+        WriteSyncIntent,
+    },
+    mount::MountFS,
+};
 use self::{
-    file::{FileFlags, FileMode, PreopenedFile},
+    file::{FileFlags, PreopenedFile},
     utils::DName,
     vcore::generate_inode_id,
 };
@@ -589,21 +595,9 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         Ok(())
     }
 
-    /// Adjust per-open file mode bits after `open()` initialized private data.
-    ///
-    /// This models Linux helpers such as `nonseekable_open()` and
-    /// `stream_open()` without making VFS syscalls know filesystem-specific
-    /// protocol flags.
-    fn adjust_file_mode_after_open(&self, _data: &FilePrivateData, _mode: &mut FileMode) {}
-
-    /// Whether the VFS write path should apply Linux `generic_write_sync()`
-    /// semantics after a successful positive-length write.
-    ///
-    /// This is intentionally opt-in: many pseudo files are reported as regular
-    /// files but their Linux write paths do not perform generic write syncing.
-    fn supports_post_write_sync(&self, _file_type: FileType) -> bool {
-        false
-    }
+    /// Select per-open mode and write-operation behavior after `open()` has
+    /// initialized private data.
+    fn configure_open_file(&self, _data: &FilePrivateData, _behavior: &mut OpenFileBehavior) {}
 
     /// @brief 关闭文件
     ///
@@ -714,6 +708,20 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         return Err(SystemError::ENOSYS);
+    }
+
+    /// Execute a write whose selected operation owns any required post-write
+    /// synchronization. Only inodes selecting `PostWriteSyncPolicy::Delegated`
+    /// may use this entry point.
+    fn write_at_with_sync(
+        &self,
+        _offset: usize,
+        _len: usize,
+        _buf: &[u8],
+        _sync_intent: WriteSyncIntent,
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<DelegatedWriteResult, SystemError> {
+        Err(SystemError::ENOSYS)
     }
 
     /// # 在inode的指定偏移量开始，写入指定大小的数据，忽略PageCache

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -596,6 +596,15 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
     /// protocol flags.
     fn adjust_file_mode_after_open(&self, _data: &FilePrivateData, _mode: &mut FileMode) {}
 
+    /// Whether the VFS write path should apply Linux `generic_write_sync()`
+    /// semantics after a successful positive-length write.
+    ///
+    /// This is intentionally opt-in: many pseudo files are reported as regular
+    /// files but their Linux write paths do not perform generic write syncing.
+    fn supports_post_write_sync(&self, _file_type: FileType) -> bool {
+        false
+    }
+
     /// @brief 关闭文件
     ///
     /// @return 成功：Ok()

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -3611,6 +3611,10 @@ impl IndexNode for MountFSInode {
         self.dentry.inode.adjust_file_mode_after_open(data, mode)
     }
 
+    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
+        self.dentry.inode.supports_post_write_sync(file_type)
+    }
+
     fn mmap(&self, start: usize, len: usize, offset: usize) -> Result<(), SystemError> {
         return self.dentry.inode.mmap(start, len, offset);
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1,8 +1,9 @@
 use super::{
-    file::{File, FileFlags, FileMode, PreopenedFile},
+    file::{File, FileFlags, PreopenedFile},
     utils::DName,
-    DirectoryEntry, FilePrivateData, FileSystem, FileType, IndexNode, InodeId, InodeMode,
-    InodeRetentionKind, PollableInode, SetMetadataMask, SuperBlock, XattrFlags,
+    DelegatedWriteResult, DirectoryEntry, FilePrivateData, FileSystem, FileType, IndexNode,
+    InodeId, InodeMode, InodeRetentionKind, PollableInode, SetMetadataMask, SuperBlock,
+    WriteSyncIntent, XattrFlags,
 };
 use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
@@ -667,6 +668,7 @@ pub struct SuperBlockState {
     /// Bind mounts and mount-namespace copies retain the same owner.
     owner_user_ns: Arc<UserNamespace>,
     flags: RwSem<MountFlags>,
+    synchronous: AtomicBool,
     write_count: AtomicUsize,
     wb_error: ErrSeq,
     umount_lock: RwSem<()>,
@@ -841,9 +843,11 @@ struct MountStateInit {
 
 impl SuperBlockState {
     pub fn new(flags: MountFlags) -> Self {
+        let flags = flags & MountFlags::SB_SETTABLE_MASK;
         Self {
             owner_user_ns: ProcessManager::current_user_ns(),
-            flags: RwSem::new(flags & MountFlags::SB_SETTABLE_MASK),
+            flags: RwSem::new(flags),
+            synchronous: AtomicBool::new(flags.contains(MountFlags::SYNCHRONOUS)),
             write_count: AtomicUsize::new(0),
             wb_error: ErrSeq::new(),
             umount_lock: RwSem::new(()),
@@ -1103,7 +1107,15 @@ impl SuperBlockState {
     }
 
     pub fn set_flags(&self, flags: MountFlags) {
-        *self.flags.write() = flags & MountFlags::SB_SETTABLE_MASK;
+        let flags = flags & MountFlags::SB_SETTABLE_MASK;
+        let mut current = self.flags.write();
+        *current = flags;
+        self.synchronous
+            .store(flags.contains(MountFlags::SYNCHRONOUS), Ordering::Release);
+    }
+
+    pub fn is_synchronous(&self) -> bool {
+        self.synchronous.load(Ordering::Acquire)
     }
 
     pub fn inc_write_count(&self) {
@@ -2914,9 +2926,21 @@ pub fn record_writeback_error_for_fs(inner_fs: &Arc<dyn FileSystem>, error: Syst
     }
 }
 
+/// Query the canonical SB_SYNCHRONOUS state for a filesystem operation which
+/// runs on an unwrapped backing inode and therefore has no MountExternalGuard.
+pub fn filesystem_is_synchronous(inner_fs: &Arc<dyn FileSystem>) -> bool {
+    list_unique_mounted_superblocks().iter().any(|mount| {
+        Arc::ptr_eq(&mount.inner_filesystem(), inner_fs) && mount.super_block_state.is_synchronous()
+    })
+}
+
 impl MountExternalGuard {
     pub fn mount(&self) -> Arc<MountFS> {
         self.mount.clone()
+    }
+
+    pub fn is_synchronous(&self) -> bool {
+        self.mount.super_block_state.is_synchronous()
     }
 
     /// Derive another owner from an already valid path. This remains legal
@@ -3607,12 +3631,8 @@ impl IndexNode for MountFSInode {
         return self.dentry.inode.open(data, flags);
     }
 
-    fn adjust_file_mode_after_open(&self, data: &FilePrivateData, mode: &mut FileMode) {
-        self.dentry.inode.adjust_file_mode_after_open(data, mode)
-    }
-
-    fn supports_post_write_sync(&self, file_type: FileType) -> bool {
-        self.dentry.inode.supports_post_write_sync(file_type)
+    fn configure_open_file(&self, data: &FilePrivateData, behavior: &mut super::OpenFileBehavior) {
+        self.dentry.inode.configure_open_file(data, behavior)
     }
 
     fn mmap(&self, start: usize, len: usize, offset: usize) -> Result<(), SystemError> {
@@ -3760,6 +3780,20 @@ impl IndexNode for MountFSInode {
     ) -> Result<usize, SystemError> {
         self.ensure_mount_writable()?;
         return self.dentry.inode.write_at(offset, len, buf, data);
+    }
+
+    fn write_at_with_sync(
+        &self,
+        offset: usize,
+        len: usize,
+        buf: &[u8],
+        sync_intent: WriteSyncIntent,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<DelegatedWriteResult, SystemError> {
+        self.ensure_mount_writable()?;
+        self.dentry
+            .inode
+            .write_at_with_sync(offset, len, buf, sync_intent, data)
     }
 
     fn read_direct(

--- a/user/apps/c_unitest/test_loop.c
+++ b/user/apps/c_unitest/test_loop.c
@@ -149,31 +149,18 @@ static int create_test_file(const char *filename, int size) {
   return 0;
 }
 
-// 使用重试机制创建 loop 设备
+// Allocate a new registered loop device atomically. LOOP_CTL_GET_FREE returns
+// an already registered reusable device and must not be followed by ADD of
+// the same minor.
 static int create_loop_device(int control_fd, int *out_minor) {
-  for (int retry = 0; retry < 10; retry++) {
-    // LOOP_CTL_GET_FREE 通过返回值返回 free 的 minor 号
-    int free_minor = ioctl(control_fd, LOOP_CTL_GET_FREE, 0);
-    if (free_minor < 0) {
-      LOG_ERROR("Failed to get free loop device: %s", strerror(errno));
-      return -1;
-    }
-
-    int ret = ioctl(control_fd, LOOP_CTL_ADD, free_minor);
-    if (ret >= 0) {
-      *out_minor = ret;
-      return 0;
-    }
-
-    if (errno != EEXIST) {
-      LOG_ERROR("Failed to add loop device: %s", strerror(errno));
-      return -1;
-    }
-    // 设备已存在，重试
+  int minor = ioctl(control_fd, LOOP_CTL_ADD, UINT32_MAX);
+  if (minor < 0) {
+    LOG_ERROR("Failed to add loop device: %s", strerror(errno));
+    return -1;
   }
 
-  LOG_ERROR("Failed to create loop device after 10 retries");
-  return -1;
+  *out_minor = minor;
+  return 0;
 }
 
 // ===================================================================
@@ -916,6 +903,7 @@ static int test_device_inaccessible_after_deletion(void) {
   // 执行一次成功的 I/O
   char buf[512] = "Test data";
   if (write(fd, buf, sizeof(buf)) != sizeof(buf)) {
+    ioctl(fd, LOOP_CLR_FD, 0);
     close(fd);
     ioctl(g_control_fd, LOOP_CTL_REMOVE, minor);
     TEST_END_FAIL(test_name, "initial write failed");
@@ -923,6 +911,14 @@ static int test_device_inaccessible_after_deletion(void) {
   }
   LOG_STEP("Initial I/O successful");
 
+  // Linux rejects LOOP_CTL_REMOVE while the device is still bound. Detach the
+  // backing file first, then close the final opener before removing the node.
+  if (ioctl(fd, LOOP_CLR_FD, 0) < 0) {
+    close(fd);
+    ioctl(g_control_fd, LOOP_CTL_REMOVE, minor);
+    TEST_END_FAIL(test_name, "failed to clear loop backing");
+    return TEST_FAIL;
+  }
   close(fd);
 
   // 删除设备

--- a/user/apps/c_unitest/test_loop.c
+++ b/user/apps/c_unitest/test_loop.c
@@ -90,8 +90,9 @@ static void print_test_summary(void) {
 #define LO_FLAGS_READ_ONLY 0x1
 #define TEST_FILE_NAME "test_image.img"
 #define TEST_FILE_NAME_2 "test_image_2.img"
+#define TEST_SYNC_FILE_NAME "test_sync_image.img"
 #define TEST_FILE_SIZE (1024 * 1024)  // 1MB
-#define TEST_FILE_SIZE_2 (512 * 1024) // 512KB
+#define TEST_FILE_SIZE_2 (1024 * 1024) // 1MB
 
 // Loop 状态结构体
 // 必须与 Linux UAPI `include/uapi/linux/loop.h` 的 `struct loop_info64` 一致，
@@ -307,101 +308,119 @@ static int test_basic_read_write(int loop_fd, const char *loop_path,
   return TEST_PASS;
 }
 
-// 测试 2: 只读模式测试
-static int test_read_only_mode(int loop_fd, struct loop_status64 *status) {
-  const char *test_name = "Read-Only Mode";
+// 同步写和 fsync 必须使用 LOOP_SET_FD 时保留的 open file description；
+// 关闭用户传入的原始 backing fd 后仍应可用。
+static int test_sync_io_retains_backing_file(void) {
+  const char *test_name = "O_SYNC/O_DSYNC/fsync Retain Backing File";
   TEST_BEGIN(test_name);
 
-  char write_buf[512] = "Test data";
+  int minor = -1;
+  int backing_fd = -1;
+  int sync_fd = -1;
+  int dsync_fd = -1;
+  int verify_fd = -1;
+  char path[64];
+  char sync_data[512] = "loop O_SYNC retained backing";
+  char dsync_data[512] = "loop O_DSYNC retained backing";
+  char observed[1024] = {0};
 
-  // 设置只读标志
-  LOG_STEP("Setting read-only flag...");
+  if (create_test_file(TEST_SYNC_FILE_NAME, TEST_FILE_SIZE) < 0) {
+    goto fail;
+  }
+  backing_fd = open(TEST_SYNC_FILE_NAME, O_RDWR);
+  if (backing_fd < 0 || create_loop_device(g_control_fd, &minor) < 0) {
+    goto fail;
+  }
+  sprintf(path, "/dev/loop%d", minor);
+  sync_fd = open(path, O_RDWR | O_SYNC);
+  if (sync_fd < 0 || ioctl(sync_fd, LOOP_SET_FD, backing_fd) < 0) {
+    goto fail;
+  }
+
+  close(backing_fd);
+  backing_fd = -1;
+
+  dsync_fd = open(path, O_RDWR | O_DSYNC);
+  if (dsync_fd < 0 ||
+      pwrite(sync_fd, sync_data, sizeof(sync_data), 0) != sizeof(sync_data) ||
+      pwrite(dsync_fd, dsync_data, sizeof(dsync_data), 512) !=
+          sizeof(dsync_data) ||
+      fsync(sync_fd) != 0 || fdatasync(dsync_fd) != 0) {
+    goto fail;
+  }
+
+  verify_fd = open(TEST_SYNC_FILE_NAME, O_RDONLY);
+  if (verify_fd < 0 ||
+      pread(verify_fd, observed, sizeof(observed), 0) != sizeof(observed) ||
+      memcmp(observed, sync_data, sizeof(sync_data)) != 0 ||
+      memcmp(observed + 512, dsync_data, sizeof(dsync_data)) != 0) {
+    goto fail;
+  }
+
+  close(verify_fd);
+  close(dsync_fd);
+  ioctl(sync_fd, LOOP_CLR_FD, 0);
+  close(sync_fd);
+  ioctl(g_control_fd, LOOP_CTL_REMOVE, minor);
+  unlink(TEST_SYNC_FILE_NAME);
+  TEST_END_PASS(test_name);
+  return TEST_PASS;
+
+fail:
+  if (verify_fd >= 0)
+    close(verify_fd);
+  if (dsync_fd >= 0)
+    close(dsync_fd);
+  if (sync_fd >= 0) {
+    ioctl(sync_fd, LOOP_CLR_FD, 0);
+    close(sync_fd);
+  }
+  if (backing_fd >= 0)
+    close(backing_fd);
+  if (minor >= 0)
+    ioctl(g_control_fd, LOOP_CTL_REMOVE, minor);
+  unlink(TEST_SYNC_FILE_NAME);
+  TEST_END_FAIL(test_name, "retained backing synchronous I/O failed");
+  return TEST_FAIL;
+}
+
+// 测试 2: status ioctl 不得修改绑定时确定的 READ_ONLY
+static int test_status_preserves_read_only(int loop_fd,
+                                           struct loop_status64 *status) {
+  const char *test_name = "Status Preserves Bind-Time Read-Only";
+  TEST_BEGIN(test_name);
+
+  LOG_STEP("Attempting to set READ_ONLY through LOOP_SET_STATUS64...");
   status->lo_flags |= LO_FLAGS_READ_ONLY;
   if (ioctl(loop_fd, LOOP_SET_STATUS64, status) < 0) {
-    TEST_END_FAIL(test_name, "failed to set read-only flag");
+    TEST_END_FAIL(test_name, "LOOP_SET_STATUS64 failed");
     return TEST_FAIL;
   }
 
-  // 尝试写入（应该失败）
-  LOG_STEP("Attempting write in read-only mode (should fail)...");
-  errno = 0;
-  if (lseek(loop_fd, 0, SEEK_SET) < 0) {
-    // lseek 失败不影响测试
-  }
-
-  if (write(loop_fd, write_buf, sizeof(write_buf)) >= 0 || errno != EROFS) {
-    status->lo_flags &= ~LO_FLAGS_READ_ONLY;
-    ioctl(loop_fd, LOOP_SET_STATUS64, status);
-    TEST_END_FAIL(test_name, "write should have failed with EROFS");
+  struct loop_status64 observed = {0};
+  if (ioctl(loop_fd, LOOP_GET_STATUS64, &observed) < 0) {
+    TEST_END_FAIL(test_name, "LOOP_GET_STATUS64 failed");
     return TEST_FAIL;
   }
-  LOG_STEP("Write correctly rejected with EROFS");
-
-  // 恢复可写模式
-  LOG_STEP("Restoring writable mode...");
+  if (observed.lo_flags & LO_FLAGS_READ_ONLY) {
+    TEST_END_FAIL(test_name, "status ioctl changed bind-time READ_ONLY");
+    return TEST_FAIL;
+  }
   status->lo_flags &= ~LO_FLAGS_READ_ONLY;
-  if (ioctl(loop_fd, LOOP_SET_STATUS64, status) < 0) {
-    TEST_END_FAIL(test_name, "failed to restore writable mode");
-    return TEST_FAIL;
-  }
 
   TEST_END_PASS(test_name);
   return TEST_PASS;
 }
 
-// 测试 3: LOOP_CHANGE_FD
-static int test_change_fd(int loop_fd, struct loop_status64 *status) {
-  const char *test_name = "LOOP_CHANGE_FD";
+// 测试 3: writable loop 必须拒绝 LOOP_CHANGE_FD
+static int test_writable_change_fd_rejected(int loop_fd) {
+  const char *test_name = "Writable LOOP_CHANGE_FD Rejected";
   TEST_BEGIN(test_name);
 
-  char write_buf[512] = "New Backing File Data!";
-  char verify_buf[512] = {0};
-
-  // 切换后端文件
-  LOG_STEP("Changing backing file to %s...", TEST_FILE_NAME_2);
-  if (ioctl(loop_fd, LOOP_CHANGE_FD, g_backing_fd_2) < 0) {
-    TEST_END_FAIL(test_name, "LOOP_CHANGE_FD failed");
-    return TEST_FAIL;
-  }
-  LOG_STEP("Backing file changed successfully");
-
-  // 获取新状态
-  struct loop_status64 new_status = {0};
-  if (ioctl(loop_fd, LOOP_GET_STATUS64, &new_status) < 0) {
-    TEST_END_FAIL(test_name, "failed to get status after change");
-    return TEST_FAIL;
-  }
-  LOG_STEP("New status - offset: %llu, sizelimit: %llu, flags: 0x%x",
-           (unsigned long long)new_status.lo_offset,
-           (unsigned long long)new_status.lo_sizelimit, new_status.lo_flags);
-
-  // 写入新后端文件
-  LOG_STEP("Writing to new backing file...");
-  if (lseek(loop_fd, 0, SEEK_SET) < 0 ||
-      write(loop_fd, write_buf, sizeof(write_buf)) != sizeof(write_buf)) {
-    TEST_END_FAIL(test_name, "write to new backing file failed");
-    return TEST_FAIL;
-  }
-  LOG_STEP("Write successful: '%s'", write_buf);
-
-  // 验证新后端文件内容
-  LOG_STEP("Verifying new backing file content...");
-  int verify_fd = open(TEST_FILE_NAME_2, O_RDONLY);
-  if (verify_fd < 0) {
-    TEST_END_FAIL(test_name, "cannot open new backing file");
-    return TEST_FAIL;
-  }
-
-  if (lseek(verify_fd, (off_t)status->lo_offset, SEEK_SET) < 0 ||
-      read(verify_fd, verify_buf, sizeof(write_buf)) != sizeof(write_buf)) {
-    close(verify_fd);
-    TEST_END_FAIL(test_name, "cannot read new backing file");
-    return TEST_FAIL;
-  }
-  close(verify_fd);
-
-  if (memcmp(write_buf, verify_buf, sizeof(write_buf)) != 0) {
-    TEST_END_FAIL(test_name, "new backing file content mismatch");
+  errno = 0;
+  if (ioctl(loop_fd, LOOP_CHANGE_FD, g_backing_fd_2) >= 0 ||
+      errno != EINVAL) {
+    TEST_END_FAIL(test_name, "writable change did not fail with EINVAL");
     return TEST_FAIL;
   }
 
@@ -409,20 +428,93 @@ static int test_change_fd(int loop_fd, struct loop_status64 *status) {
   return TEST_PASS;
 }
 
-// 测试 4: LOOP_SET_CAPACITY
+// 测试 4: read-only、同容量 backing 可以 CHANGE_FD
+static int test_read_only_equal_size_change_fd(void) {
+  const char *test_name = "Read-Only Equal-Size LOOP_CHANGE_FD";
+  TEST_BEGIN(test_name);
+
+  int minor = -1;
+  int loop_fd = -1;
+  int rw_loop_fd = -1;
+  char path[64];
+  char expected[512] = "second backing generation";
+  char observed[512] = {0};
+
+  if (pwrite(g_backing_fd_2, expected, sizeof(expected), 0) !=
+      sizeof(expected)) {
+    TEST_END_FAIL(test_name, "cannot initialize second backing");
+    return TEST_FAIL;
+  }
+  if (create_loop_device(g_control_fd, &minor) < 0) {
+    TEST_END_FAIL(test_name, "cannot create loop device");
+    return TEST_FAIL;
+  }
+  sprintf(path, "/dev/loop%d", minor);
+  loop_fd = open(path, O_RDONLY);
+  if (loop_fd < 0 || ioctl(loop_fd, LOOP_SET_FD, g_backing_fd_1) < 0) {
+    goto fail;
+  }
+  if (ioctl(loop_fd, LOOP_CHANGE_FD, g_backing_fd_2) < 0) {
+    goto fail;
+  }
+  if (pread(loop_fd, observed, sizeof(observed), 0) != sizeof(observed) ||
+      memcmp(expected, observed, sizeof(expected)) != 0) {
+    goto fail;
+  }
+
+  struct loop_status64 status = {0};
+  if (ioctl(loop_fd, LOOP_GET_STATUS64, &status) < 0 ||
+      !(status.lo_flags & LO_FLAGS_READ_ONLY)) {
+    goto fail;
+  }
+  status.lo_flags = 0;
+  if (ioctl(loop_fd, LOOP_SET_STATUS64, &status) < 0 ||
+      ioctl(loop_fd, LOOP_GET_STATUS64, &status) < 0 ||
+      !(status.lo_flags & LO_FLAGS_READ_ONLY)) {
+    goto fail;
+  }
+
+  rw_loop_fd = open(path, O_RDWR);
+  errno = 0;
+  if (rw_loop_fd < 0 ||
+      write(rw_loop_fd, expected, sizeof(expected)) >= 0 || errno != EROFS) {
+    goto fail;
+  }
+
+  close(rw_loop_fd);
+  ioctl(loop_fd, LOOP_CLR_FD, 0);
+  close(loop_fd);
+  ioctl(g_control_fd, LOOP_CTL_REMOVE, minor);
+  TEST_END_PASS(test_name);
+  return TEST_PASS;
+
+fail:
+  if (rw_loop_fd >= 0)
+    close(rw_loop_fd);
+  if (loop_fd >= 0) {
+    ioctl(loop_fd, LOOP_CLR_FD, 0);
+    close(loop_fd);
+  }
+  if (minor >= 0)
+    ioctl(g_control_fd, LOOP_CTL_REMOVE, minor);
+  TEST_END_FAIL(test_name, "read-only equal-size change semantics failed");
+  return TEST_FAIL;
+}
+
+// 测试 5: LOOP_SET_CAPACITY
 static int test_set_capacity(int loop_fd, struct loop_status64 *status) {
   const char *test_name = "LOOP_SET_CAPACITY";
   TEST_BEGIN(test_name);
 
   // 扩大后端文件
-  LOG_STEP("Resizing backing file to %d bytes...", TEST_FILE_SIZE_2 * 2);
-  int resize_fd = open(TEST_FILE_NAME_2, O_RDWR);
+  LOG_STEP("Resizing backing file to %d bytes...", TEST_FILE_SIZE * 2);
+  int resize_fd = open(TEST_FILE_NAME, O_RDWR);
   if (resize_fd < 0) {
     TEST_END_FAIL(test_name, "cannot open backing file for resize");
     return TEST_FAIL;
   }
 
-  int new_size = TEST_FILE_SIZE_2 * 2;
+  int new_size = TEST_FILE_SIZE * 2;
   if (ftruncate(resize_fd, new_size) < 0) {
     close(resize_fd);
     TEST_END_FAIL(test_name, "ftruncate failed");
@@ -460,7 +552,7 @@ static int test_set_capacity(int loop_fd, struct loop_status64 *status) {
   // 尝试写入扩展区域
   LOG_STEP("Writing to extended region...");
   char extended_buf[512] = "Extended Data!";
-  if (lseek(loop_fd, TEST_FILE_SIZE_2, SEEK_SET) < 0 ||
+  if (lseek(loop_fd, TEST_FILE_SIZE, SEEK_SET) < 0 ||
       write(loop_fd, extended_buf, sizeof(extended_buf)) !=
           sizeof(extended_buf)) {
     TEST_END_FAIL(test_name, "write to extended region failed");
@@ -471,13 +563,13 @@ static int test_set_capacity(int loop_fd, struct loop_status64 *status) {
   // 验证扩展区域内容
   LOG_STEP("Verifying extended region content...");
   char verify_buf[512] = {0};
-  int verify_fd = open(TEST_FILE_NAME_2, O_RDONLY);
+  int verify_fd = open(TEST_FILE_NAME, O_RDONLY);
   if (verify_fd < 0) {
     TEST_END_FAIL(test_name, "cannot open backing file for verification");
     return TEST_FAIL;
   }
 
-  off_t verify_offset = (off_t)status->lo_offset + TEST_FILE_SIZE_2;
+  off_t verify_offset = (off_t)status->lo_offset + TEST_FILE_SIZE;
   if (lseek(verify_fd, verify_offset, SEEK_SET) < 0 ||
       read(verify_fd, verify_buf, sizeof(extended_buf)) !=
           sizeof(extended_buf)) {
@@ -496,9 +588,9 @@ static int test_set_capacity(int loop_fd, struct loop_status64 *status) {
   return TEST_PASS;
 }
 
-// 测试 5: 并发 I/O 期间删除设备
+// 已绑定且仍有 opener 的 loop 设备必须拒绝 LOOP_CTL_REMOVE。
 static int test_concurrent_io_deletion(void) {
-  const char *test_name = "Concurrent I/O During Deletion";
+  const char *test_name = "Bound Loop Removal During Concurrent I/O";
   TEST_BEGIN(test_name);
 
 #define NUM_IO_THREADS 4
@@ -547,6 +639,7 @@ static int test_concurrent_io_deletion(void) {
         io_args[j].should_stop = 1;
         pthread_join(io_threads[j], NULL);
       }
+      ioctl(test_fd, LOOP_CLR_FD, 0);
       close(test_fd);
       ioctl(g_control_fd, LOOP_CTL_REMOVE, test_minor);
       TEST_END_FAIL(test_name, "failed to create I/O thread");
@@ -554,10 +647,8 @@ static int test_concurrent_io_deletion(void) {
     }
   }
 
-  close(test_fd); // 关闭主 fd
-
-  // 启动删除线程
-  LOG_STEP("Starting deletion thread...");
+  // 保持主 fd 打开，并在其他 opener 正在执行 I/O 时尝试删除。
+  LOG_STEP("Starting removal attempt...");
   pthread_t delete_thread;
   struct delete_thread_args delete_args = {.control_fd = g_control_fd,
                                            .loop_minor = test_minor,
@@ -570,6 +661,8 @@ static int test_concurrent_io_deletion(void) {
       io_args[i].should_stop = 1;
       pthread_join(io_threads[i], NULL);
     }
+    ioctl(test_fd, LOOP_CLR_FD, 0);
+    close(test_fd);
     ioctl(g_control_fd, LOOP_CTL_REMOVE, test_minor);
     TEST_END_FAIL(test_name, "failed to create delete thread");
     return TEST_FAIL;
@@ -593,16 +686,40 @@ static int test_concurrent_io_deletion(void) {
   }
   LOG_STEP("I/O statistics: %d successful, %d errors", total_io, total_errors);
 
-  // 验证设备已删除
-  int verify_fd = open(test_path, O_RDWR);
-  if (verify_fd >= 0) {
-    close(verify_fd);
-    TEST_END_FAIL(test_name, "device still accessible after deletion");
+  if (delete_args.result >= 0 || delete_args.error_code != EBUSY) {
+    ioctl(test_fd, LOOP_CLR_FD, 0);
+    close(test_fd);
+    ioctl(g_control_fd, LOOP_CTL_REMOVE, test_minor);
+    TEST_END_FAIL(test_name, "bound device removal did not fail with EBUSY");
     return TEST_FAIL;
   }
 
-  if (delete_args.result != 0) {
-    TEST_END_FAIL(test_name, "deletion failed");
+  // 失败的删除不得影响已绑定设备；清除绑定后才能真正删除。
+  char verify_buf[512];
+  if (pread(test_fd, verify_buf, sizeof(verify_buf), 0) != sizeof(verify_buf) ||
+      ioctl(test_fd, LOOP_CLR_FD, 0) < 0) {
+    close(test_fd);
+    ioctl(g_control_fd, LOOP_CTL_REMOVE, test_minor);
+    TEST_END_FAIL(test_name, "failed removal damaged bound device");
+    return TEST_FAIL;
+  }
+  errno = 0;
+  if (ioctl(g_control_fd, LOOP_CTL_REMOVE, test_minor) >= 0 || errno != EBUSY) {
+    close(test_fd);
+    TEST_END_FAIL(test_name,
+                  "unbound device removal ignored the remaining opener");
+    return TEST_FAIL;
+  }
+  close(test_fd);
+  if (ioctl(g_control_fd, LOOP_CTL_REMOVE, test_minor) < 0) {
+    TEST_END_FAIL(test_name, "unbound device removal failed");
+    return TEST_FAIL;
+  }
+
+  int verify_fd = open(test_path, O_RDWR);
+  if (verify_fd >= 0) {
+    close(verify_fd);
+    TEST_END_FAIL(test_name, "device still accessible after successful removal");
     return TEST_FAIL;
   }
 
@@ -917,8 +1034,10 @@ int main(void) {
 
   // 基本功能测试
   test_basic_read_write(main_loop_fd, main_loop_path, &status);
-  test_read_only_mode(main_loop_fd, &status);
-  test_change_fd(main_loop_fd, &status);
+  test_status_preserves_read_only(main_loop_fd, &status);
+  test_writable_change_fd_rejected(main_loop_fd);
+  test_read_only_equal_size_change_fd();
+  test_sync_io_retains_backing_file();
   test_set_capacity(main_loop_fd, &status);
 
   // 资源回收测试

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -7593,6 +7593,11 @@ static int ext_test_shared_writable_mmap_osync_writeback() {
     volatile char c = 0;
     pid_t daemon = -1;
     const uint32_t expected_writeback_flags = FUSE_WRITE_CACHE;
+    // This mount does not negotiate FUSE_WRITEBACK_CACHE.  The pwrite request
+    // is therefore an ordinary cached write; only later page writeback carries
+    // FUSE_WRITE_CACHE.
+    const uint32_t expected_cached_write_flags = 0;
+    const uint32_t expected_cached_write_open_flags = O_RDWR | O_SYNC;
     const size_t page_size = 4096;
     const size_t map_len = page_size * 2;
     const char marker = 'Z';
@@ -7611,6 +7616,8 @@ static int ext_test_shared_writable_mmap_osync_writeback() {
         volatile uint64_t last_fsync_fh;
         volatile uint32_t write_count_at_fsync;
         volatile uint32_t last_write_flags_at_fsync;
+        volatile unsigned char mmap_dirty_byte;
+        volatile unsigned char pwrite_marker_byte;
     };
     struct mmap_shared_state *shared =
         (struct mmap_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
@@ -7663,6 +7670,10 @@ static int ext_test_shared_writable_mmap_osync_writeback() {
         child_args.last_fsync_fh = &shared->last_fsync_fh;
         child_args.write_count_at_fsync = &shared->write_count_at_fsync;
         child_args.last_write_flags_at_fsync = &shared->last_write_flags_at_fsync;
+        child_args.backend_watch_byte = &shared->mmap_dirty_byte;
+        child_args.backend_watch_byte2 = &shared->pwrite_marker_byte;
+        child_args.write_watch_offset = 2;
+        child_args.write_watch_offset2 = page_size;
         child_args.next_open_fh = 930;
         child_args.hello_data_size_override = map_len;
         fuse_daemon_thread(&child_args);
@@ -7711,19 +7722,44 @@ static int ext_test_shared_writable_mmap_osync_writeback() {
         goto fail;
     }
 
-    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 2 ||
+    // O_SYNC must synchronize only the range written by pwrite().  The dirty
+    // mmap page at offset zero is deliberately outside that range and must
+    // remain dirty until the explicit msync() below.
+    if (shared->open_count != 1 || shared->read_count != 1 || shared->write_count != 1 ||
         shared->fsync_count != 1 || shared->last_write_fh != 930 || shared->last_fsync_fh != 930 ||
-        shared->last_write_offset != 0 || shared->last_write_size != page_size ||
-        shared->last_write_flags != expected_writeback_flags || shared->last_write_open_flags != 0 ||
-        shared->write_count_at_fsync != 2 ||
-        shared->last_write_flags_at_fsync != expected_writeback_flags) {
-        printf("[FAIL] shared mmap osync counters open=%u read=%u write=%u fsync=%u wfh=%llu fsh=%llu off=%llu size=%u wflags=%u oflags=%u fsync_writes=%u fsync_wflags=%u\n",
+        shared->last_write_offset != page_size || shared->last_write_size != 1 ||
+        shared->last_write_flags != expected_cached_write_flags ||
+        shared->last_write_open_flags != expected_cached_write_open_flags ||
+        shared->write_count_at_fsync != 1 ||
+        shared->last_write_flags_at_fsync != expected_cached_write_flags) {
+        printf("[FAIL] shared mmap osync range counters open=%u read=%u write=%u fsync=%u wfh=%llu fsh=%llu off=%llu size=%u wflags=%u oflags=%u fsync_writes=%u fsync_wflags=%u\n",
                shared->open_count, shared->read_count, shared->write_count, shared->fsync_count,
                (unsigned long long)shared->last_write_fh,
                (unsigned long long)shared->last_fsync_fh,
                (unsigned long long)shared->last_write_offset, shared->last_write_size,
                shared->last_write_flags, shared->last_write_open_flags,
                shared->write_count_at_fsync, shared->last_write_flags_at_fsync);
+        goto fail;
+    }
+
+    if (msync(addr, page_size, MS_SYNC) != 0) {
+        printf("[FAIL] msync(dirty page outside O_SYNC range): %s (errno=%d)\n",
+               strerror(errno), errno);
+        goto fail;
+    }
+    if (shared->write_count != 2 || shared->fsync_count != 2 ||
+        shared->last_write_offset != 0 || shared->last_write_size != page_size ||
+        shared->last_write_flags != expected_writeback_flags ||
+        shared->last_write_open_flags != 0 || shared->last_fsync_fh != 930 ||
+        shared->write_count_at_fsync != 2 ||
+        shared->last_write_flags_at_fsync != expected_writeback_flags ||
+        shared->mmap_dirty_byte != 'F' ||
+        shared->pwrite_marker_byte != (unsigned char)marker) {
+        printf("[FAIL] shared mmap deferred writeback counters write=%u fsync=%u off=%llu size=%u wflags=%u oflags=%u mmap_byte=%u marker_byte=%u\n",
+               shared->write_count, shared->fsync_count,
+               (unsigned long long)shared->last_write_offset, shared->last_write_size,
+               shared->last_write_flags, shared->last_write_open_flags,
+               shared->mmap_dirty_byte, shared->pwrite_marker_byte);
         goto fail;
     }
 
@@ -7754,6 +7790,300 @@ fail:
         waitpid(daemon, NULL, 0);
     }
     munmap(shared, sizeof(*shared));
+    rmdir(mp);
+    return -1;
+}
+
+static int ext_test_loop_fuse_backing_sync_semantics() {
+    const char *mp = "/tmp/test_fuse_loop_sync";
+    const unsigned long loop_ctl_add = 0x4C80;
+    const unsigned long loop_ctl_remove = 0x4C81;
+    const unsigned long loop_ctl_get_free = 0x4C82;
+    const unsigned long loop_set_fd = 0x4C00;
+    const unsigned long loop_clr_fd = 0x4C01;
+    const uint64_t expected_fh = 950;
+    char backing_path[256];
+    char loop_path[64];
+    int fuse_fd = -1;
+    int backing_fd = -1;
+    int control_fd = -1;
+    int loop_sync_fd = -1;
+    int loop_dsync_fd = -1;
+    int minor = -1;
+    int mounted = 0;
+    int loop_added = 0;
+    int loop_bound = 0;
+    pid_t daemon = -1;
+    unsigned char block[512];
+    struct loop_fuse_shared_state {
+        volatile int stop;
+        volatile int init_done;
+        volatile int forced_fsync_errno;
+        volatile uint32_t open_count;
+        volatile uint32_t write_count;
+        volatile uint32_t fsync_count;
+        volatile uint64_t last_write_fh;
+        volatile uint64_t last_fsync_fh;
+        volatile uint32_t last_fsync_flags;
+        volatile uint32_t write_count_at_fsync;
+    };
+    struct loop_fuse_shared_state *shared =
+        (struct loop_fuse_shared_state *)mmap(NULL, sizeof(*shared), PROT_READ | PROT_WRITE,
+                                             MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared == MAP_FAILED) {
+        printf("[FAIL] loop+fuse mmap(shared): %s (errno=%d)\n", strerror(errno), errno);
+        return -1;
+    }
+    memset((void *)shared, 0, sizeof(*shared));
+    memset(block, 0x5a, sizeof(block));
+
+    if (ensure_dir(mp) != 0) {
+        printf("[FAIL] loop+fuse ensure_dir(%s): %s (errno=%d)\n", mp, strerror(errno), errno);
+        goto fail;
+    }
+    fuse_fd = open("/dev/fuse", O_RDWR);
+    if (fuse_fd < 0) {
+        printf("[FAIL] loop+fuse open(/dev/fuse): %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    daemon = fork();
+    if (daemon < 0) {
+        printf("[FAIL] loop+fuse fork daemon: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    if (daemon == 0) {
+        struct fuse_daemon_args child_args;
+        memset(&child_args, 0, sizeof(child_args));
+        child_args.fd = fuse_fd;
+        child_args.stop = &shared->stop;
+        child_args.init_done = &shared->init_done;
+        child_args.enable_write_ops = 1;
+        child_args.stop_on_destroy = 1;
+        child_args.open_count = &shared->open_count;
+        child_args.write_count = &shared->write_count;
+        child_args.fsync_count = &shared->fsync_count;
+        child_args.last_write_fh = &shared->last_write_fh;
+        child_args.last_fsync_fh = &shared->last_fsync_fh;
+        child_args.last_fsync_flags = &shared->last_fsync_flags;
+        child_args.write_count_at_fsync = &shared->write_count_at_fsync;
+        child_args.forced_fsync_errno = &shared->forced_fsync_errno;
+        child_args.next_open_fh = expected_fh;
+        child_args.hello_data_size_override = 8192;
+        child_args.init_out_flags_override =
+            FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_WRITEBACK_CACHE;
+        fuse_daemon_thread(&child_args);
+        _exit(0);
+    }
+
+    char opts[256];
+    snprintf(opts, sizeof(opts), "fd=%d,rootmode=040755,user_id=0,group_id=0,max_read=4096",
+             fuse_fd);
+    if (mount("none", mp, "fuse", 0, opts) != 0) {
+        printf("[FAIL] loop+fuse mount: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 1;
+    if (fuseg_wait_init(&shared->init_done) != 0) {
+        printf("[FAIL] loop+fuse init handshake timeout\n");
+        goto fail;
+    }
+
+    snprintf(backing_path, sizeof(backing_path), "%s/hello.txt", mp);
+    backing_fd = open(backing_path, O_RDWR);
+    if (backing_fd < 0) {
+        printf("[FAIL] loop+fuse open backing: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    control_fd = open("/dev/loop-control", O_RDWR);
+    if (control_fd < 0) {
+        printf("[FAIL] loop+fuse open loop-control: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    minor = ioctl(control_fd, loop_ctl_get_free, 0);
+    if (minor < 0 || ioctl(control_fd, loop_ctl_add, minor) < 0) {
+        printf("[FAIL] loop+fuse add loop device: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    loop_added = 1;
+    snprintf(loop_path, sizeof(loop_path), "/dev/loop%d", minor);
+    loop_sync_fd = open(loop_path, O_RDWR | O_SYNC);
+    if (loop_sync_fd < 0 || ioctl(loop_sync_fd, loop_set_fd, backing_fd) != 0) {
+        printf("[FAIL] loop+fuse bind backing: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    loop_bound = 1;
+
+    // The loop device must retain this exact FUSE open file description and fh.
+    if (close(backing_fd) != 0) {
+        printf("[FAIL] loop+fuse close setup backing fd: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    backing_fd = -1;
+    loop_dsync_fd = open(loop_path, O_RDWR | O_DSYNC);
+    if (loop_dsync_fd < 0) {
+        printf("[FAIL] loop+fuse open O_DSYNC loop fd: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+
+    // Stage 1: O_SYNC must complete backing WRITE then full FSYNC before return.
+    if (pwrite(loop_sync_fd, block, sizeof(block), 0) != (ssize_t)sizeof(block) ||
+        shared->write_count != 1 || shared->fsync_count != 1 ||
+        shared->last_write_fh != expected_fh || shared->last_fsync_fh != expected_fh ||
+        shared->last_fsync_flags != 0 || shared->write_count_at_fsync != 1) {
+        printf("[FAIL] loop+fuse O_SYNC write=%u fsync=%u wfh=%llu ffh=%llu flags=%u writes_at_fsync=%u errno=%d\n",
+               shared->write_count, shared->fsync_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_fsync_fh, shared->last_fsync_flags,
+               shared->write_count_at_fsync, errno);
+        goto fail;
+    }
+
+    // Stage 2: O_DSYNC has an independent write+fsync boundary and sets FDATASYNC.
+    memset(block, 0xa5, sizeof(block));
+    if (pwrite(loop_dsync_fd, block, sizeof(block), 512) != (ssize_t)sizeof(block) ||
+        shared->write_count != 2 || shared->fsync_count != 2 ||
+        shared->last_write_fh != expected_fh || shared->last_fsync_fh != expected_fh ||
+        shared->last_fsync_flags != FUSE_FSYNC_FDATASYNC ||
+        shared->write_count_at_fsync != 2) {
+        printf("[FAIL] loop+fuse O_DSYNC write=%u fsync=%u wfh=%llu ffh=%llu flags=%u writes_at_fsync=%u errno=%d\n",
+               shared->write_count, shared->fsync_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_fsync_fh, shared->last_fsync_flags,
+               shared->write_count_at_fsync, errno);
+        goto fail;
+    }
+
+    // Stage 3: explicit fsync/fdatasync must reach the same retained fh.
+    if (fsync(loop_sync_fd) != 0 || shared->fsync_count != 3 ||
+        shared->last_fsync_fh != expected_fh || shared->last_fsync_flags != 0 ||
+        shared->write_count_at_fsync != 2) {
+        printf("[FAIL] loop+fuse explicit fsync count=%u fh=%llu flags=%u writes=%u errno=%d\n",
+               shared->fsync_count, (unsigned long long)shared->last_fsync_fh,
+               shared->last_fsync_flags, shared->write_count_at_fsync, errno);
+        goto fail;
+    }
+    // Block-device fsync/fdatasync both use the device flush operation; unlike
+    // delegated O_DSYNC above, the explicit block-device operation is a full flush.
+    if (fdatasync(loop_dsync_fd) != 0 || shared->fsync_count != 4 ||
+        shared->last_fsync_fh != expected_fh || shared->last_fsync_flags != 0 ||
+        shared->write_count_at_fsync != 2) {
+        printf("[FAIL] loop+fuse explicit fdatasync count=%u fh=%llu flags=%u writes=%u errno=%d\n",
+               shared->fsync_count, (unsigned long long)shared->last_fsync_fh,
+               shared->last_fsync_flags, shared->write_count_at_fsync, errno);
+        goto fail;
+    }
+
+    // Stage 4: a backing FUSE_FSYNC EIO must be returned by the loop O_SYNC write.
+    shared->forced_fsync_errno = EIO;
+    errno = 0;
+    if (pwrite(loop_sync_fd, block, sizeof(block), 1024) >= 0 || errno != EIO ||
+        shared->write_count != 3 || shared->fsync_count != 5 ||
+        shared->last_write_fh != expected_fh || shared->last_fsync_fh != expected_fh ||
+        shared->last_fsync_flags != 0 || shared->write_count_at_fsync != 3) {
+        printf("[FAIL] loop+fuse injected EIO ret_errno=%d write=%u fsync=%u wfh=%llu ffh=%llu flags=%u writes_at_fsync=%u\n",
+               errno, shared->write_count, shared->fsync_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_fsync_fh, shared->last_fsync_flags,
+               shared->write_count_at_fsync);
+        goto fail;
+    }
+    shared->forced_fsync_errno = 0;
+
+    // Stage 5: Linux loop ignores EINVAL from a backing flush.
+    shared->forced_fsync_errno = EINVAL;
+    errno = 0;
+    if (pwrite(loop_sync_fd, block, sizeof(block), 1536) != (ssize_t)sizeof(block) ||
+        shared->write_count != 4 || shared->fsync_count != 6 ||
+        shared->last_write_fh != expected_fh || shared->last_fsync_fh != expected_fh ||
+        shared->last_fsync_flags != 0 || shared->write_count_at_fsync != 4) {
+        printf("[FAIL] loop+fuse injected EINVAL ret_errno=%d write=%u fsync=%u wfh=%llu ffh=%llu flags=%u writes_at_fsync=%u\n",
+               errno, shared->write_count, shared->fsync_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_fsync_fh, shared->last_fsync_flags,
+               shared->write_count_at_fsync);
+        goto fail;
+    }
+
+    // Stage 6: every other backing flush error is normalized to EIO.
+    shared->forced_fsync_errno = ENOSPC;
+    errno = 0;
+    if (pwrite(loop_sync_fd, block, sizeof(block), 2048) >= 0 || errno != EIO ||
+        shared->write_count != 5 || shared->fsync_count != 7 ||
+        shared->last_write_fh != expected_fh || shared->last_fsync_fh != expected_fh ||
+        shared->last_fsync_flags != 0 || shared->write_count_at_fsync != 5) {
+        printf("[FAIL] loop+fuse injected ENOSPC ret_errno=%d write=%u fsync=%u wfh=%llu ffh=%llu flags=%u writes_at_fsync=%u\n",
+               errno, shared->write_count, shared->fsync_count,
+               (unsigned long long)shared->last_write_fh,
+               (unsigned long long)shared->last_fsync_fh, shared->last_fsync_flags,
+               shared->write_count_at_fsync);
+        goto fail;
+    }
+    shared->forced_fsync_errno = 0;
+
+    close(loop_dsync_fd);
+    loop_dsync_fd = -1;
+    if (ioctl(loop_sync_fd, loop_clr_fd, 0) != 0) {
+        printf("[FAIL] loop+fuse LOOP_CLR_FD: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    loop_bound = 0;
+    close(loop_sync_fd);
+    loop_sync_fd = -1;
+    if (ioctl(control_fd, loop_ctl_remove, minor) != 0) {
+        printf("[FAIL] loop+fuse LOOP_CTL_REMOVE: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    loop_added = 0;
+    close(control_fd);
+    control_fd = -1;
+    if (umount(mp) != 0) {
+        printf("[FAIL] loop+fuse umount: %s (errno=%d)\n", strerror(errno), errno);
+        goto fail;
+    }
+    mounted = 0;
+    shared->stop = 1;
+    close(fuse_fd);
+    fuse_fd = -1;
+    waitpid(daemon, NULL, 0);
+    daemon = -1;
+    munmap((void *)shared, sizeof(*shared));
+    rmdir(mp);
+    return 0;
+
+fail:
+    shared->forced_fsync_errno = 0;
+    if (loop_dsync_fd >= 0) {
+        close(loop_dsync_fd);
+    }
+    if (loop_sync_fd >= 0) {
+        if (loop_bound) {
+            ioctl(loop_sync_fd, loop_clr_fd, 0);
+            loop_bound = 0;
+        }
+        close(loop_sync_fd);
+    }
+    if (backing_fd >= 0) {
+        close(backing_fd);
+    }
+    if (control_fd >= 0) {
+        if (loop_added) {
+            ioctl(control_fd, loop_ctl_remove, minor);
+        }
+        close(control_fd);
+    }
+    if (mounted) {
+        umount2(mp, MNT_DETACH);
+    }
+    shared->stop = 1;
+    if (fuse_fd >= 0) {
+        close(fuse_fd);
+    }
+    if (daemon > 0) {
+        kill(daemon, SIGTERM);
+        waitpid(daemon, NULL, 0);
+    }
+    munmap((void *)shared, sizeof(*shared));
     rmdir(mp);
     return -1;
 }
@@ -10771,6 +11101,10 @@ TEST(FuseExtended, SharedMmapDirtyThenPwriteKeepsLatestData) {
 
 TEST(FuseExtended, SharedWritableMmapOSyncWriteback) {
     ASSERT_EQ(0, ext_test_shared_writable_mmap_osync_writeback());
+}
+
+TEST(FuseExtended, LoopFuseBackingSyncSemantics) {
+    ASSERT_EQ(0, ext_test_loop_fuse_backing_sync_semantics());
 }
 
 TEST(FuseExtended, SharedMmapMprotectWriteback) {

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -7798,7 +7798,6 @@ static int ext_test_loop_fuse_backing_sync_semantics() {
     const char *mp = "/tmp/test_fuse_loop_sync";
     const unsigned long loop_ctl_add = 0x4C80;
     const unsigned long loop_ctl_remove = 0x4C81;
-    const unsigned long loop_ctl_get_free = 0x4C82;
     const unsigned long loop_set_fd = 0x4C00;
     const unsigned long loop_clr_fd = 0x4C01;
     const uint64_t expected_fh = 950;
@@ -7900,8 +7899,8 @@ static int ext_test_loop_fuse_backing_sync_semantics() {
         printf("[FAIL] loop+fuse open loop-control: %s (errno=%d)\n", strerror(errno), errno);
         goto fail;
     }
-    minor = ioctl(control_fd, loop_ctl_get_free, 0);
-    if (minor < 0 || ioctl(control_fd, loop_ctl_add, minor) < 0) {
+    minor = ioctl(control_fd, loop_ctl_add, UINT32_MAX);
+    if (minor < 0) {
         printf("[FAIL] loop+fuse add loop device: %s (errno=%d)\n", strerror(errno), errno);
         goto fail;
     }

--- a/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_test_simplefs_local.h
@@ -796,6 +796,7 @@ struct fuse_daemon_args {
     volatile unsigned char *write_watch_bytes;
     volatile unsigned char *write_covers_watch;
     volatile unsigned char *backend_watch_byte;
+    volatile unsigned char *backend_watch_byte2;
     unsigned char *large_write_backing;
     size_t large_write_backing_capacity;
     volatile uint64_t *large_write_nodeid;
@@ -808,6 +809,7 @@ struct fuse_daemon_args {
     volatile int *write_entered;
     volatile int *release_write;
     volatile uint64_t *last_fsync_fh;
+    volatile uint32_t *last_fsync_flags;
     volatile uint32_t *write_count_at_fsync;
     volatile uint32_t *last_write_flags_at_fsync;
     volatile uint64_t *last_release_fh;
@@ -831,6 +833,7 @@ struct fuse_daemon_args {
     uint32_t init_out_flags_override;
     uint32_t init_out_max_write_override;
     uint64_t write_watch_offset;
+    uint64_t write_watch_offset2;
     uint64_t hello_open_fh_override;
     uint64_t next_open_fh;
     uint64_t create_reuse_nodeid;
@@ -850,6 +853,7 @@ struct fuse_daemon_args {
     int force_opendir_enosys;
     int force_flush_errno;
     int force_fsync_errno;
+    volatile int *forced_fsync_errno;
     int force_fsyncdir_errno;
     int force_xattr_enosys;
     int force_getxattr_erange_at_max;
@@ -1521,14 +1525,19 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
         if (a->last_fsync_fh) {
             *a->last_fsync_fh = in->fh;
         }
+        if (a->last_fsync_flags) {
+            *a->last_fsync_flags = in->fsync_flags;
+        }
         if (a->write_count_at_fsync && a->write_count) {
             *a->write_count_at_fsync = *a->write_count;
         }
         if (a->last_write_flags_at_fsync && a->last_write_flags) {
             *a->last_write_flags_at_fsync = *a->last_write_flags;
         }
-        if (a->force_fsync_errno > 0) {
-            return fuse_write_reply(a->fd, h->unique, -a->force_fsync_errno, NULL, 0);
+        int fsync_errno =
+            a->forced_fsync_errno ? *a->forced_fsync_errno : a->force_fsync_errno;
+        if (fsync_errno > 0) {
+            return fuse_write_reply(a->fd, h->unique, -fsync_errno, NULL, 0);
         }
         return fuse_write_reply(a->fd, h->unique, 0, NULL, 0);
     }
@@ -1692,8 +1701,15 @@ static inline int fuse_handle_one(struct fuse_daemon_args *a, const unsigned cha
                 *a->backend_watch_byte = write_backing[watch];
             }
         }
+        if (a->backend_watch_byte2) {
+            uint64_t watch = a->write_watch_offset2;
+            if (watch < node->size && watch < write_capacity) {
+                *a->backend_watch_byte2 = write_backing[watch];
+            }
+        }
         if (a->write_count) {
-            if (a->write_trace_capacity > 0 || a->backend_watch_byte) {
+            if (a->write_trace_capacity > 0 || a->backend_watch_byte ||
+                a->backend_watch_byte2) {
                 __sync_synchronize();
             }
             (*a->write_count)++;

--- a/user/apps/tests/dunitest/suites/normal/errseq_writeback_reporting.cc
+++ b/user/apps/tests/dunitest/suites/normal/errseq_writeback_reporting.cc
@@ -140,25 +140,28 @@ int OpenSecondDescription(const TempFile& file) {
     return fd;
 }
 
-void ExpectSynchronousWriteReportsMappingError(const TempFile& file, int flags,
-                                               int expected_errno) {
+void ExpectTmpfsSynchronousWriteDefersMappingError(const TempFile& file, int flags,
+                                                   int expected_errno) {
     int fd = open(file.path(), O_RDWR | flags);
     ASSERT_GE(fd, 0) << "open synchronous fd failed: errno=" << errno << " ("
                      << strerror(errno) << ")";
 
     InjectError("mapping", fd, expected_errno == EIO ? "EIO" : "ENOSPC");
 
-    const char first = 's';
+    // Linux shmem_file_write_iter() does not call generic_write_sync(), and
+    // tmpfs uses noop_fsync. O_SYNC/O_DSYNC therefore do not consume the
+    // mapping errseq event. Use sync_file_range(WAIT_AFTER) as the explicit
+    // mapping-error observation point.
+    const char value = 's';
     errno = 0;
-    ExpectFailsWithErrno(write(fd, &first, sizeof(first)), expected_errno);
-
-    // The mapping error is consumed per open file description. A subsequent
-    // synchronous write must report its own byte count rather than replaying
-    // the old errseq event.
-    const char second = 't';
-    errno = 0;
-    EXPECT_EQ(static_cast<ssize_t>(sizeof(second)), write(fd, &second, sizeof(second)))
+    EXPECT_EQ(static_cast<ssize_t>(sizeof(value)), write(fd, &value, sizeof(value)))
         << "errno=" << errno << " (" << strerror(errno) << ")";
+
+    errno = 0;
+    ExpectFailsWithErrno(
+        RawSyncFileRange(fd, 0, 0, SYNC_FILE_RANGE_WAIT_AFTER), expected_errno);
+    errno = 0;
+    ExpectSucceeds(RawSyncFileRange(fd, 0, 0, SYNC_FILE_RANGE_WAIT_AFTER));
     EXPECT_EQ(0, close(fd));
 }
 
@@ -207,16 +210,16 @@ TEST(ErrSeqWritebackReporting, FdatasyncReportsMappingErrorOnce) {
     ExpectFailsWithErrno(RawSyncfs(file.fd()), ENOSPC);
 }
 
-TEST(ErrSeqWritebackReporting, SyncWriteReportsMappingErrorOnce) {
+TEST(ErrSeqWritebackReporting, TmpfsSyncWriteDoesNotConsumeMappingError) {
     TempFile file;
     ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
-    ExpectSynchronousWriteReportsMappingError(file, O_SYNC, EIO);
+    ExpectTmpfsSynchronousWriteDefersMappingError(file, O_SYNC, EIO);
 }
 
-TEST(ErrSeqWritebackReporting, DataSyncWriteReportsMappingErrorOnce) {
+TEST(ErrSeqWritebackReporting, TmpfsDataSyncWriteDoesNotConsumeMappingError) {
     TempFile file;
     ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
-    ExpectSynchronousWriteReportsMappingError(file, O_DSYNC, ENOSPC);
+    ExpectTmpfsSynchronousWriteDefersMappingError(file, O_DSYNC, ENOSPC);
 }
 
 TEST(ErrSeqWritebackReporting, CloseDoesNotConsumeMappingError) {

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -176,6 +176,23 @@ class LoopExt4 {
         mounted_ = false;
     }
 
+    void RequestAutoclearAndCloseLoop() {
+        ASSERT_GE(loop_fd_, 0);
+        ASSERT_EQ(0, ioctl(loop_fd_, kLoopClrFd, 0)) << strerror(errno);
+        ASSERT_EQ(0, close(loop_fd_)) << strerror(errno);
+        loop_fd_ = -1;
+    }
+
+    void ExpectLoopUnbound() const {
+        int probe = open(loop_path_.c_str(), O_RDWR);
+        ASSERT_GE(probe, 0) << strerror(errno);
+        unsigned char block[512] = {};
+        errno = 0;
+        EXPECT_EQ(-1, pread(probe, block, sizeof(block), 0));
+        EXPECT_EQ(ENODEV, errno);
+        EXPECT_EQ(0, close(probe));
+    }
+
     void MountSecond() {
         ASSERT_TRUE(mounted_);
         ASSERT_FALSE(second_mounted_);
@@ -525,6 +542,20 @@ TEST(Ext4InodeIdentity, StatfsReportsLinuxAbi) {
     EXPECT_LE(by_fd.f_bavail, by_fd.f_bfree);
 
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, AutoclearWaitsForFinalMountHolder) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    ASSERT_NO_FATAL_FAILURE(fs.RequestAutoclearAndCloseLoop());
+
+    struct statfs mounted = {};
+    ASSERT_EQ(0, statfs(fs.mount_point().c_str(), &mounted)) << strerror(errno);
+    EXPECT_EQ(0xEF53, mounted.f_type);
+
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+    ASSERT_NO_FATAL_FAILURE(fs.ExpectLoopUnbound());
 }
 
 std::string ReadFile(const char* path) {

--- a/user/apps/tests/dunitest/suites/normal/loop_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/loop_semantics.cc
@@ -2,6 +2,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
@@ -17,7 +18,26 @@ constexpr unsigned long kLoopCtlRemove = 0x4C81;
 constexpr unsigned long kLoopCtlGetFree = 0x4C82;
 constexpr unsigned long kLoopSetFd = 0x4C00;
 constexpr unsigned long kLoopClrFd = 0x4C01;
+constexpr unsigned long kLoopSetStatus64 = 0x4C04;
+constexpr unsigned long kLoopGetStatus64 = 0x4C05;
+constexpr uint32_t kLoopFlagAutoclear = 1U << 2;
 constexpr size_t kBackingSize = 1024 * 1024;
+
+struct LoopInfo64 {
+    uint64_t device;
+    uint64_t inode;
+    uint64_t rdevice;
+    uint64_t offset;
+    uint64_t size_limit;
+    uint32_t number;
+    uint32_t encrypt_type;
+    uint32_t encrypt_key_size;
+    uint32_t flags;
+    uint8_t file_name[64];
+    uint8_t crypt_name[64];
+    uint8_t encrypt_key[32];
+    uint64_t init[2];
+};
 
 class LoopDevice {
 public:
@@ -30,7 +50,7 @@ public:
             close(backing_fd_);
         }
         if (control_fd_ >= 0) {
-            if (minor_ >= 0) {
+            if (owns_registration_ && minor_ >= 0) {
                 ioctl(control_fd_, kLoopCtlRemove, minor_);
             }
             close(control_fd_);
@@ -40,7 +60,7 @@ public:
         }
     }
 
-    void SetUp(int loop_open_flags) {
+    void SetUp(int loop_open_flags, bool create_new = true) {
         backing_path_ =
             "/tmp/dunitest_loop_semantics_" + std::to_string(static_cast<long long>(getpid()));
         backing_fd_ = open(backing_path_.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
@@ -49,9 +69,14 @@ public:
 
         control_fd_ = open("/dev/loop-control", O_RDWR);
         ASSERT_GE(control_fd_, 0) << strerror(errno);
-        minor_ = ioctl(control_fd_, kLoopCtlGetFree, 0);
+
+        if (create_new) {
+            minor_ = ioctl(control_fd_, kLoopCtlAdd, UINT32_MAX);
+            owns_registration_ = true;
+        } else {
+            minor_ = ioctl(control_fd_, kLoopCtlGetFree, 0);
+        }
         ASSERT_GE(minor_, 0) << strerror(errno);
-        ASSERT_GE(ioctl(control_fd_, kLoopCtlAdd, minor_), 0) << strerror(errno);
 
         char path[64];
         snprintf(path, sizeof(path), "/dev/loop%d", minor_);
@@ -65,6 +90,12 @@ public:
         ASSERT_GE(backing_fd_, 0);
         ASSERT_EQ(close(backing_fd_), 0) << strerror(errno);
         backing_fd_ = -1;
+    }
+
+    void GrowBackingFile() {
+        ASSERT_GE(backing_fd_, 0);
+        ASSERT_EQ(ftruncate(backing_fd_, static_cast<off_t>(2 * kBackingSize)), 0)
+            << strerror(errno);
     }
 
     void ClearLoop() {
@@ -81,8 +112,10 @@ public:
     void RemoveLoop() {
         ASSERT_GE(control_fd_, 0);
         ASSERT_GE(minor_, 0);
+        ASSERT_TRUE(owns_registration_);
         ASSERT_EQ(ioctl(control_fd_, kLoopCtlRemove, minor_), 0) << strerror(errno);
         minor_ = -1;
+        owns_registration_ = false;
     }
 
     int loop_fd() const { return loop_fd_; }
@@ -96,9 +129,29 @@ private:
     int backing_fd_ = -1;
     int loop_fd_ = -1;
     int minor_ = -1;
+    bool owns_registration_ = false;
     std::string loop_path_;
     std::string backing_path_;
 };
+
+TEST(LoopSemantics, GetFreeReturnsRegisteredDevice) {
+    int control_fd = open("/dev/loop-control", O_RDWR);
+    ASSERT_GE(control_fd, 0) << strerror(errno);
+    int minor = ioctl(control_fd, kLoopCtlGetFree, 0);
+    ASSERT_GE(minor, 0) << strerror(errno);
+
+    char path[64];
+    snprintf(path, sizeof(path), "/dev/loop%d", minor);
+    int loop_fd = open(path, O_RDWR);
+    ASSERT_GE(loop_fd, 0) << "LOOP_CTL_GET_FREE returned an unregistered device: "
+                          << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(ioctl(control_fd, kLoopCtlAdd, minor), -1);
+    EXPECT_EQ(errno, EEXIST);
+    EXPECT_EQ(close(loop_fd), 0) << strerror(errno);
+    EXPECT_EQ(close(control_fd), 0) << strerror(errno);
+}
 
 TEST(LoopSemantics, SyncIoRetainsBackingOpenFileDescription) {
     LoopDevice device;
@@ -135,7 +188,7 @@ TEST(LoopSemantics, SyncIoRetainsBackingOpenFileDescription) {
 
 TEST(LoopSemantics, ControlRemoveRejectsBoundDeviceWithOpener) {
     LoopDevice device;
-    ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR));
+    ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR, true));
 
     errno = 0;
     EXPECT_EQ(ioctl(device.control_fd(), kLoopCtlRemove, device.minor()), -1);
@@ -148,12 +201,76 @@ TEST(LoopSemantics, ControlRemoveRejectsBoundDeviceWithOpener) {
 
     ASSERT_NO_FATAL_FAILURE(device.ClearLoop());
     errno = 0;
+    EXPECT_EQ(ioctl(device.loop_fd(), kLoopClrFd, 0), -1);
+    EXPECT_EQ(errno, ENXIO);
+
+    errno = 0;
     EXPECT_EQ(ioctl(device.control_fd(), kLoopCtlRemove, device.minor()), -1);
     EXPECT_EQ(errno, EBUSY)
         << "an unbound device must remain registered while its last opener exists";
 
     ASSERT_NO_FATAL_FAILURE(device.CloseLoopFd());
+}
+
+TEST(LoopSemantics, BusyClearDefersUntilLastOpener) {
+    LoopDevice device;
+    ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR));
+
+    int extra_fd = open(device.loop_path().c_str(), O_RDWR);
+    ASSERT_GE(extra_fd, 0) << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(device.ClearLoop());
+
+    unsigned char block[512] = {};
+    EXPECT_EQ(pread(device.loop_fd(), block, sizeof(block), 0),
+              static_cast<ssize_t>(sizeof(block)))
+        << "deferred clear detached a busy loop device: " << strerror(errno);
+
+    ASSERT_EQ(close(extra_fd), 0) << strerror(errno);
+    EXPECT_EQ(pread(device.loop_fd(), block, sizeof(block), 0),
+              static_cast<ssize_t>(sizeof(block)))
+        << "autoclear ran before the final opener closed: " << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(device.CloseLoopFd());
+
+    int probe_fd = open(device.loop_path().c_str(), O_RDWR);
+    ASSERT_GE(probe_fd, 0) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(pread(probe_fd, block, sizeof(block), 0), -1);
+    EXPECT_EQ(errno, ENODEV);
+    ASSERT_EQ(close(probe_fd), 0) << strerror(errno);
+
     ASSERT_NO_FATAL_FAILURE(device.RemoveLoop());
+}
+
+TEST(LoopSemantics, Status64UpdatesAutoclearFlag) {
+    LoopDevice device;
+    ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR));
+
+    LoopInfo64 status = {};
+    ASSERT_EQ(ioctl(device.loop_fd(), kLoopGetStatus64, &status), 0) << strerror(errno);
+    EXPECT_EQ(status.flags & kLoopFlagAutoclear, 0U);
+
+    ASSERT_NO_FATAL_FAILURE(device.GrowBackingFile());
+    unsigned char block[512] = {};
+    errno = 0;
+    EXPECT_EQ(pread(device.loop_fd(), block, sizeof(block), kBackingSize), -1)
+        << "backing growth changed loop capacity without LOOP_SET_CAPACITY";
+
+    status.flags |= kLoopFlagAutoclear;
+    ASSERT_EQ(ioctl(device.loop_fd(), kLoopSetStatus64, &status), 0) << strerror(errno);
+    memset(&status, 0, sizeof(status));
+    ASSERT_EQ(ioctl(device.loop_fd(), kLoopGetStatus64, &status), 0) << strerror(errno);
+    EXPECT_EQ(status.flags & kLoopFlagAutoclear, kLoopFlagAutoclear);
+    errno = 0;
+    EXPECT_EQ(pread(device.loop_fd(), block, sizeof(block), kBackingSize), -1)
+        << "flag-only LOOP_SET_STATUS64 unexpectedly refreshed loop capacity";
+
+    status.flags &= ~kLoopFlagAutoclear;
+    ASSERT_EQ(ioctl(device.loop_fd(), kLoopSetStatus64, &status), 0) << strerror(errno);
+    memset(&status, 0, sizeof(status));
+    ASSERT_EQ(ioctl(device.loop_fd(), kLoopGetStatus64, &status), 0) << strerror(errno);
+    EXPECT_EQ(status.flags & kLoopFlagAutoclear, 0U);
 }
 
 TEST(LoopSemantics, DeviceNodeRejectsUnprivilegedOpen) {

--- a/user/apps/tests/dunitest/suites/normal/loop_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/loop_semantics.cc
@@ -1,0 +1,189 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+constexpr unsigned long kLoopCtlAdd = 0x4C80;
+constexpr unsigned long kLoopCtlRemove = 0x4C81;
+constexpr unsigned long kLoopCtlGetFree = 0x4C82;
+constexpr unsigned long kLoopSetFd = 0x4C00;
+constexpr unsigned long kLoopClrFd = 0x4C01;
+constexpr size_t kBackingSize = 1024 * 1024;
+
+class LoopDevice {
+public:
+    ~LoopDevice() {
+        if (loop_fd_ >= 0) {
+            ioctl(loop_fd_, kLoopClrFd, 0);
+            close(loop_fd_);
+        }
+        if (backing_fd_ >= 0) {
+            close(backing_fd_);
+        }
+        if (control_fd_ >= 0) {
+            if (minor_ >= 0) {
+                ioctl(control_fd_, kLoopCtlRemove, minor_);
+            }
+            close(control_fd_);
+        }
+        if (!backing_path_.empty()) {
+            unlink(backing_path_.c_str());
+        }
+    }
+
+    void SetUp(int loop_open_flags) {
+        backing_path_ =
+            "/tmp/dunitest_loop_semantics_" + std::to_string(static_cast<long long>(getpid()));
+        backing_fd_ = open(backing_path_.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
+        ASSERT_GE(backing_fd_, 0) << strerror(errno);
+        ASSERT_EQ(ftruncate(backing_fd_, static_cast<off_t>(kBackingSize)), 0) << strerror(errno);
+
+        control_fd_ = open("/dev/loop-control", O_RDWR);
+        ASSERT_GE(control_fd_, 0) << strerror(errno);
+        minor_ = ioctl(control_fd_, kLoopCtlGetFree, 0);
+        ASSERT_GE(minor_, 0) << strerror(errno);
+        ASSERT_GE(ioctl(control_fd_, kLoopCtlAdd, minor_), 0) << strerror(errno);
+
+        char path[64];
+        snprintf(path, sizeof(path), "/dev/loop%d", minor_);
+        loop_path_ = path;
+        loop_fd_ = open(loop_path_.c_str(), loop_open_flags);
+        ASSERT_GE(loop_fd_, 0) << strerror(errno);
+        ASSERT_EQ(ioctl(loop_fd_, kLoopSetFd, backing_fd_), 0) << strerror(errno);
+    }
+
+    void CloseOriginalBackingFd() {
+        ASSERT_GE(backing_fd_, 0);
+        ASSERT_EQ(close(backing_fd_), 0) << strerror(errno);
+        backing_fd_ = -1;
+    }
+
+    void ClearLoop() {
+        ASSERT_GE(loop_fd_, 0);
+        ASSERT_EQ(ioctl(loop_fd_, kLoopClrFd, 0), 0) << strerror(errno);
+    }
+
+    void CloseLoopFd() {
+        ASSERT_GE(loop_fd_, 0);
+        ASSERT_EQ(close(loop_fd_), 0) << strerror(errno);
+        loop_fd_ = -1;
+    }
+
+    void RemoveLoop() {
+        ASSERT_GE(control_fd_, 0);
+        ASSERT_GE(minor_, 0);
+        ASSERT_EQ(ioctl(control_fd_, kLoopCtlRemove, minor_), 0) << strerror(errno);
+        minor_ = -1;
+    }
+
+    int loop_fd() const { return loop_fd_; }
+    int control_fd() const { return control_fd_; }
+    int minor() const { return minor_; }
+    const std::string& loop_path() const { return loop_path_; }
+    const std::string& backing_path() const { return backing_path_; }
+
+private:
+    int control_fd_ = -1;
+    int backing_fd_ = -1;
+    int loop_fd_ = -1;
+    int minor_ = -1;
+    std::string loop_path_;
+    std::string backing_path_;
+};
+
+TEST(LoopSemantics, SyncIoRetainsBackingOpenFileDescription) {
+    LoopDevice device;
+    ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR | O_SYNC));
+    ASSERT_NO_FATAL_FAILURE(device.CloseOriginalBackingFd());
+
+    int dsync_fd = open(device.loop_path().c_str(), O_RDWR | O_DSYNC);
+    ASSERT_GE(dsync_fd, 0) << strerror(errno);
+
+    unsigned char sync_data[512] = {};
+    unsigned char dsync_data[512] = {};
+    memset(sync_data, 0x5a, sizeof(sync_data));
+    memset(dsync_data, 0xa5, sizeof(dsync_data));
+    ASSERT_EQ(pwrite(device.loop_fd(), sync_data, sizeof(sync_data), 0),
+              static_cast<ssize_t>(sizeof(sync_data)))
+        << strerror(errno);
+    ASSERT_EQ(pwrite(dsync_fd, dsync_data, sizeof(dsync_data), 512),
+              static_cast<ssize_t>(sizeof(dsync_data)))
+        << strerror(errno);
+    ASSERT_EQ(fsync(device.loop_fd()), 0) << strerror(errno);
+    ASSERT_EQ(fdatasync(dsync_fd), 0) << strerror(errno);
+    ASSERT_EQ(close(dsync_fd), 0) << strerror(errno);
+
+    int verify_fd = open(device.backing_path().c_str(), O_RDONLY);
+    ASSERT_GE(verify_fd, 0) << strerror(errno);
+    unsigned char observed[1024] = {};
+    ASSERT_EQ(pread(verify_fd, observed, sizeof(observed), 0),
+              static_cast<ssize_t>(sizeof(observed)))
+        << strerror(errno);
+    EXPECT_EQ(memcmp(observed, sync_data, sizeof(sync_data)), 0);
+    EXPECT_EQ(memcmp(observed + 512, dsync_data, sizeof(dsync_data)), 0);
+    EXPECT_EQ(close(verify_fd), 0) << strerror(errno);
+}
+
+TEST(LoopSemantics, ControlRemoveRejectsBoundDeviceWithOpener) {
+    LoopDevice device;
+    ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR));
+
+    errno = 0;
+    EXPECT_EQ(ioctl(device.control_fd(), kLoopCtlRemove, device.minor()), -1);
+    EXPECT_EQ(errno, EBUSY);
+
+    unsigned char block[512] = {};
+    EXPECT_EQ(pread(device.loop_fd(), block, sizeof(block), 0),
+              static_cast<ssize_t>(sizeof(block)))
+        << "failed removal attempt damaged the bound device: " << strerror(errno);
+
+    ASSERT_NO_FATAL_FAILURE(device.ClearLoop());
+    errno = 0;
+    EXPECT_EQ(ioctl(device.control_fd(), kLoopCtlRemove, device.minor()), -1);
+    EXPECT_EQ(errno, EBUSY)
+        << "an unbound device must remain registered while its last opener exists";
+
+    ASSERT_NO_FATAL_FAILURE(device.CloseLoopFd());
+    ASSERT_NO_FATAL_FAILURE(device.RemoveLoop());
+}
+
+TEST(LoopSemantics, DeviceNodeRejectsUnprivilegedOpen) {
+    LoopDevice device;
+    ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR));
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        if (setgid(65534) != 0 || setuid(65534) != 0) {
+            _exit(2);
+        }
+        errno = 0;
+        const int fd = open(device.loop_path().c_str(), O_RDONLY);
+        if (fd >= 0) {
+            close(fd);
+            _exit(3);
+        }
+        _exit(errno == EACCES ? 0 : 4);
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -3,6 +3,7 @@
 demo/gtest_demo
 normal/capability
 normal/fdatasync
+normal/loop_semantics
 normal/getrandom_bit_distribution
 normal/ext4_xattr
 normal/ext4_inode_identity


### PR DESCRIPTION
## Summary

This PR aligns DragonOS synchronous-write behavior with Linux 6.6 semantics and makes synchronization a property of the selected open-file write operation rather than a default-false inode capability.

It also completes the durability and lifetime contracts needed by FAT, stacked files, block devices, and loop devices so `O_SYNC`, `O_DSYNC`, inode `S_SYNC`, and synchronous-superblock writes are neither silently skipped nor performed twice.

## Design

### Operation-owned post-write synchronization

- Replace the per-inode `supports_post_write_sync()` opt-in with a per-open `PostWriteSyncPolicy`:
  - `Generic`: VFS synchronizes the successfully written range.
  - `Delegated`: the selected write operation forwards the sync intent to the real backing `File` and completes it exactly once.
  - `NotApplicable`: the Linux write implementation does not run generic post-write sync, such as tmpfs/shmem.
- Determine the policy when the open file description is created and preserve it through the file operation path.
- Merge `O_SYNC`, `O_DSYNC`, inode `S_SYNC`, and current `SB_SYNCHRONOUS` state into one explicit sync intent.
- Synchronize only the positive-length range that was actually written, with checked range arithmetic.
- Preserve completed write progress and file-position updates when the following synchronous flush reports an error.
- Keep per-open writeback-error reporting through the existing errseq cursor.

### Stacked files and block devices

- Let OverlayFS and loop devices delegate sync intent to the retained backing `File` instead of issuing a second outer-layer flush.
- Forward delegated writes through mount wrappers and gendisk/block-device adapters without losing read-only checks or sync intent.
- Avoid extra policy dispatch and metadata queries on ordinary asynchronous writes.

### FAT durability

- Make file-level fsync/fdatasync wait for the requested page-cache range and then issue the final block-device durability barrier.
- Propagate data, FAT-chain, directory-entry, writeback, and device-flush errors.
- Separate directory-entry submission from the final barrier so an extending synchronous write does not perform redundant device flushes.
- Preserve required durability for synchronous resize/fallocate paths.

### Loop backing-file and lifecycle semantics

- Retain the original `Arc<File>` selected by `LOOP_SET_FD`, preserving its open-file private data, FUSE file handle, OverlayFS backing state, and errseq cursor.
- Use one backing/configuration snapshot and one `IoGuard` across delegated backing write plus flush.
- Serialize backing topology and configuration changes, reject recursive loop chains, drain active I/O before clear/change/reconfigure, and release replaced backing files outside configuration locks.
- Align `LOOP_CHANGE_FD` with Linux: only read-only loop devices may change to a backing file with the same effective capacity.
- Track open descriptions and mounted-filesystem holders independently so remove/clear cannot invalidate a live user.
- Implement Linux `LOOP_CLR_FD` autoclear behavior: a busy clear succeeds, marks the device for deferred detach, and detaches only after the final opener and mount holder leave.
- Prevent stale reconfiguration snapshots from overwriting runtime flag changes.
- Make `LOOP_SET_STATUS{,64}` update `AUTOCLEAR` without implicitly refreshing capacity; `LOOP_SET_CAPACITY` remains the explicit capacity refresh.
- Align loop-control allocation behavior: `GET_FREE` returns a registered reusable device, anonymous `ADD` creates a new device, and explicit `ADD` of an occupied minor returns `EEXIST`.
- Return `ENXIO` when clearing an unbound loop device and require safe unbound/no-holder state for removal.

## Linux compatibility notes

- tmpfs/shmem does not run `generic_write_sync()` and therefore uses `NotApplicable` rather than consuming mapping errseq errors from `O_SYNC`/`O_DSYNC` writes.
- Backing `EINVAL` from loop flush is ignored as Linux does; other backing flush failures are normalized to `EIO` while preserving completed write progress.
- Online mapping changes for a mounted loop filesystem currently return `EBUSY`. DragonOS does not yet have Linux-equivalent blocking queue freeze plus unified blockdev/cache quiescing, so accepting the change would allow one filesystem transaction to cross old and new mappings.
- This PR intentionally does not introduce a full Linux `file_operations`/`kiocb` framework.

## Test coverage

Added or extended coverage for:

- exact `O_SYNC`/`O_DSYNC` ranges, zero/partial writes, dynamic synchronous-mount state, and per-open errseq behavior;
- tmpfs/shmem non-applicable synchronous writes;
- OverlayFS single-owner synchronization;
- FAT data/metadata ordering and final device flush behavior;
- retained loop backing open-file descriptions and FUSE file handles;
- loop read-only change-fd rules, recursion, configuration draining, clear/remove/open/mount lifetimes, permissions, and flush error normalization;
- busy `LOOP_CLR_FD` autoclear, final mount-holder release, `AUTOCLEAR` set/clear, capacity stability, and loop-control allocation semantics;
- loop-to-FUSE `O_SYNC`, `O_DSYNC`, fsync/fdatasync, and injected `EIO`/`EINVAL`/`ENOSPC` paths.

## Validation

Local validation:

- `cargo fmt --all -- --check`
- `git diff --check`
- `make kernel`
- affected dunitest and c_unitest targets compile
- Ubuntu 24.04 DragonOS guest:
  - `loop_semantics_test`: 6/6 passed
  - `errseq_writeback_reporting_test`: 8/8 passed
  - `ext4_inode_identity_test`: 32/32 passed
  - `FuseExtended.LoopFuseBackingSyncSemantics`: passed
  - `FuseExtended.SharedWritableMmapOSyncWriteback`: passed

GitHub Actions:

- x86_64, riscv64, and loongarch64 builds: passed
- format and kernel static checks for all three architectures: passed
- Dunitest: passed
- Integration Test reports only `BasicPtyTest.OpenDevTTY`; the same assertion already fails on the current master baseline and this PR does not modify TTY, devpts, session, or controlling-terminal code.