### PR TITLE
fix(pipe): correct waitqueue wakeup semantics

### DIFF
--- a/kernel/src/filesystem/vfs/syscall/sys_splice.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_splice.rs
@@ -261,7 +261,7 @@ fn splice_file_to_pipe(
     }
     let wanted = trusted_read_limit.unwrap_or(limit);
 
-    let space = if flags.contains(SpliceFlags::SPLICE_F_NONBLOCK) {
+    let (space, wake_next_writer) = if flags.contains(SpliceFlags::SPLICE_F_NONBLOCK) {
         let space = pipe_inode.writable_len();
         if space == 0 && pipe_inode.has_readers() {
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -273,12 +273,16 @@ fn splice_file_to_pipe(
         {
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
         }
-        space
+        (space, false)
     } else if trusted_read_limit.is_some() {
         pipe_inode.wait_writable_for_splice(wanted)?
     } else {
         pipe_inode.wait_writable_any_for_splice()?
     };
+
+    // The returned space is an observation, not a reservation. Do not hold an
+    // exclusive writer wakeup baton across a potentially blocking input read.
+    pipe_inode.finish_writer_wait(wake_next_writer);
 
     let buf_size = if trusted_read_limit.is_some() && space == 0 {
         wanted
@@ -290,11 +294,14 @@ fn splice_file_to_pipe(
     // 从文件读取
     // 为了满足 Linux 语义：若后续写入 pipe 被信号中断且未写入任何字节，
     // 则不应推进输入文件的 file position。
-    let (read_len, advance_file_pos) = if let Some(off) = offset {
-        (file.pread(off, buf_size, &mut buffer)?, false)
+    let read_result = if let Some(off) = offset {
+        file.pread(off, buf_size, &mut buffer)
+            .map(|read_len| (read_len, false))
     } else {
-        (file.read_noadv(buf_size, &mut buffer)?, true)
+        file.read_noadv(buf_size, &mut buffer)
+            .map(|read_len| (read_len, true))
     };
+    let (read_len, advance_file_pos) = read_result?;
 
     if read_len == 0 {
         return Ok(0);
@@ -306,7 +313,7 @@ fn splice_file_to_pipe(
     let written = if flags.contains(SpliceFlags::SPLICE_F_NONBLOCK) {
         pipe_inode.write_from_splice_nonblock(&buffer)
     } else {
-        pipe.write(buffer.len(), &buffer)
+        pipe_inode.write_from_splice_blocking(&buffer)
     };
 
     match written {

--- a/kernel/src/filesystem/vfs/syscall/sys_splice.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_splice.rs
@@ -3,7 +3,7 @@ use crate::filesystem::vfs::file::FileMode;
 use crate::filesystem::vfs::FileFlags;
 use crate::filesystem::vfs::{file::File, syscall::SpliceFlags, FileType};
 use crate::ipc::kill::send_signal_to_pid;
-use crate::ipc::pipe::{LockedPipeInode, PIPE_BUF};
+use crate::ipc::pipe::LockedPipeInode;
 use crate::process::resource::RLimitID;
 use crate::process::ProcessManager;
 use crate::syscall::table::Syscall;
@@ -256,33 +256,20 @@ fn splice_file_to_pipe(
 
     let limit = len.min(4096);
     let trusted_read_limit = splice_trusted_file_read_limit(file, offset, limit);
+    let mut transaction = pipe_inode.begin_writer_transaction();
+    pipe_inode.ensure_splice_readers(&transaction)?;
     if trusted_read_limit == Some(0) {
         return Ok(0);
     }
     let wanted = trusted_read_limit.unwrap_or(limit);
 
-    let (space, wake_next_writer) = if flags.contains(SpliceFlags::SPLICE_F_NONBLOCK) {
-        let space = pipe_inode.writable_len();
-        if space == 0 && pipe_inode.has_readers() {
-            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-        }
-        if trusted_read_limit.is_some()
-            && wanted <= PIPE_BUF
-            && space < wanted
-            && pipe_inode.has_readers()
-        {
-            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-        }
-        (space, false)
+    let space = if flags.contains(SpliceFlags::SPLICE_F_NONBLOCK) {
+        pipe_inode.writable_for_splice_nonblock(&transaction, trusted_read_limit.map(|_| wanted))?
     } else if trusted_read_limit.is_some() {
-        pipe_inode.wait_writable_for_splice(wanted)?
+        pipe_inode.wait_writable_for_splice(&mut transaction, wanted)?
     } else {
-        pipe_inode.wait_writable_any_for_splice()?
+        pipe_inode.wait_writable_any_for_splice(&mut transaction)?
     };
-
-    // The returned space is an observation, not a reservation. Do not hold an
-    // exclusive writer wakeup baton across a potentially blocking input read.
-    pipe_inode.finish_writer_wait(wake_next_writer);
 
     let buf_size = if trusted_read_limit.is_some() && space == 0 {
         wanted
@@ -310,11 +297,7 @@ fn splice_file_to_pipe(
     buffer.truncate(read_len);
 
     // 写入 pipe
-    let written = if flags.contains(SpliceFlags::SPLICE_F_NONBLOCK) {
-        pipe_inode.write_from_splice_nonblock(&buffer)
-    } else {
-        pipe_inode.write_from_splice_blocking(&buffer)
-    };
+    let written = pipe_inode.write_from_splice_locked(&mut transaction, &buffer);
 
     match written {
         Ok(write_len) => {

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -43,6 +43,14 @@ pub const PIPE_BUF: usize = PIPE_MIN_SIZE;
 /// 管道缓冲区最大大小（Linux 默认为 1MB）
 pub const PIPE_MAX_SIZE: usize = 1024 * 1024;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum WakeMode {
+    #[default]
+    None,
+    One,
+    All,
+}
+
 // FIONREAD: 获取管道中可读的字节数
 const FIONREAD: u32 = 0x541B;
 
@@ -134,6 +142,11 @@ pub struct InnerPipeInode {
     metadata: Metadata,
     reader: u32,
     writer: u32,
+    /// Writers that have committed to sleeping for pipe space.
+    ///
+    /// This is protected by `LockedPipeInode::inner` and is used only to
+    /// choose between an exclusive wakeup and a broadcast after space grows.
+    write_wait_intents: usize,
     had_reader: bool,
     /// 是否为命名管道（FIFO）
     /// 只有 FIFO 才需要在 open 时阻塞等待另一端
@@ -286,6 +299,46 @@ impl InnerPipeInode {
 }
 
 impl LockedPipeInode {
+    #[inline]
+    fn writer_wake_mode(inner: &InnerPipeInode) -> WakeMode {
+        match inner.write_wait_intents {
+            0 => WakeMode::None,
+            1 => WakeMode::One,
+            _ => WakeMode::All,
+        }
+    }
+
+    #[inline]
+    fn wake_waiters(queue: &WaitQueue, mode: WakeMode) {
+        match mode {
+            WakeMode::None => {}
+            WakeMode::One => {
+                queue.wakeup(Some(ProcessState::Blocked(true)));
+            }
+            WakeMode::All => {
+                queue.wakeup_all(Some(ProcessState::Blocked(true)));
+            }
+        }
+    }
+
+    #[inline]
+    fn wake_pipe_waiters(&self, readers: WakeMode, writers: WakeMode) {
+        Self::wake_waiters(&self.read_wait_queue, readers);
+        Self::wake_waiters(&self.write_wait_queue, writers);
+    }
+
+    fn send_sigpipe() {
+        if let Err(err) = send_kernel_signal_to_current(Signal::SIGPIPE) {
+            log::error!("Failed to send SIGPIPE for pipe write: {:?}", err);
+        }
+    }
+
+    fn publish_write_progress(&self, reader_wake: WakeMode, pollflag: EPollEventType) {
+        Self::wake_waiters(&self.read_wait_queue, reader_wake);
+        let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
+        self.read_fasync_items.send_sigio(FASYNC_POLL_IN);
+    }
+
     /// 安全地锁定两个管道节点（避免死锁）
     /// 返回两个节点的锁保护对象
     /// 注意：p1 和 p2 必须不同，否则会发生死锁（如果尝试对同一个锁加锁两次）或返回不安全的别名引用
@@ -355,6 +408,7 @@ impl LockedPipeInode {
             },
             reader: 0,
             writer: 0,
+            write_wait_intents: 0,
             is_fifo: false, // 默认为匿名管道
             r_counter: 0,   // 初始化读端计数器
             w_counter: 0,   // 初始化写端计数器
@@ -412,6 +466,47 @@ impl LockedPipeInode {
         }
         let used = inode.valid_cnt.max(0) as usize;
         inode.buf_size.saturating_sub(used) >= need
+    }
+
+    /// Sleep for pipe space after publishing the writer's intent under the
+    /// pipe lock. Publishing before dropping the lock closes the gap where a
+    /// reader could create space without observing the waiter.
+    fn wait_for_write_space<'a, F>(
+        &'a self,
+        mut guard: crate::libs::spinlock::SpinLockGuard<'a, InnerPipeInode>,
+        required: Option<usize>,
+        before_wait: F,
+    ) -> (
+        crate::libs::spinlock::SpinLockGuard<'a, InnerPipeInode>,
+        Result<(), SystemError>,
+    )
+    where
+        F: FnOnce(),
+    {
+        guard.write_wait_intents = guard
+            .write_wait_intents
+            .checked_add(1)
+            .expect("pipe writer wait-intent count overflowed");
+        drop(guard);
+
+        before_wait();
+        let result = if let Some(need) = required {
+            wq_wait_event_interruptible!(
+                self.write_wait_queue,
+                self.writeable_len_at_least(need),
+                {}
+            )
+        } else {
+            wq_wait_event_interruptible!(self.write_wait_queue, self.writeable(), {})
+        };
+
+        let mut guard = self.inner.lock();
+        guard.write_wait_intents = guard
+            .write_wait_intents
+            .checked_sub(1)
+            .expect("pipe writer wait-intent count underflowed");
+        let result = result.map_err(|_| SystemError::ERESTARTSYS);
+        (guard, result)
     }
 
     /// 检查写端计数器是否已变化（用于 FIFO O_RDONLY 阻塞等待）
@@ -513,6 +608,13 @@ impl LockedPipeInode {
         inner.buf_size = new_size;
         inner.metadata.size = new_size as i64;
 
+        let writer_wake = Self::writer_wake_mode(&inner);
+        let pollflag = inner.poll_both_ends();
+        drop(inner);
+
+        Self::wake_waiters(&self.write_wait_queue, writer_wake);
+        let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
+
         Ok(new_size)
     }
 
@@ -561,9 +663,8 @@ impl LockedPipeInode {
         let mut inner_guard = self.inner.lock();
 
         if inner_guard.reader == 0 {
-            if !inner_guard.had_reader {
-                return Err(SystemError::ENXIO);
-            }
+            drop(inner_guard);
+            Self::send_sigpipe();
             return Err(SystemError::EPIPE);
         }
 
@@ -589,17 +690,17 @@ impl LockedPipeInode {
             len.min(available)
         };
 
+        let was_readable = inner_guard.valid_cnt > 0 && inner_guard.splice_hold == 0;
         Self::write_bytes(&mut inner_guard, buf, to_write);
-
-        if (inner_guard.valid_cnt as usize) < inner_guard.buf_size {
-            self.write_wait_queue
-                .wakeup(Some(ProcessState::Blocked(true)));
-        }
-        self.read_wait_queue
-            .wakeup(Some(ProcessState::Blocked(true)));
+        let reader_wake = if !was_readable && inner_guard.splice_hold == 0 {
+            WakeMode::One
+        } else {
+            WakeMode::None
+        };
 
         let pollflag = inner_guard.poll_both_ends();
         drop(inner_guard);
+        Self::wake_waiters(&self.read_wait_queue, reader_wake);
         let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
         self.read_fasync_items.send_sigio(FASYNC_POLL_IN);
 
@@ -618,11 +719,11 @@ impl LockedPipeInode {
         }
 
         let need_atomic = len <= PIPE_BUF;
+        let mut guard = self.inner.lock();
         loop {
-            let guard = self.inner.lock();
             if guard.reader == 0 {
                 drop(guard);
-                let _ = send_kernel_signal_to_current(Signal::SIGPIPE);
+                Self::send_sigpipe();
                 return Err(SystemError::EPIPE);
             }
 
@@ -632,19 +733,10 @@ impl LockedPipeInode {
                 return Ok(if need_atomic { len } else { len.min(space) });
             }
 
-            drop(guard);
-            let wait_result = if need_atomic {
-                wq_wait_event_interruptible!(
-                    self.write_wait_queue,
-                    self.writeable_len_at_least(len),
-                    {}
-                )
-            } else {
-                wq_wait_event_interruptible!(self.write_wait_queue, self.writeable(), {})
-            };
-            if wait_result.is_err() {
-                return Err(SystemError::ERESTARTSYS);
-            }
+            let required = need_atomic.then_some(len);
+            let (next_guard, wait_result) = self.wait_for_write_space(guard, required, || {});
+            guard = next_guard;
+            wait_result?;
         }
     }
 
@@ -654,11 +746,11 @@ impl LockedPipeInode {
     /// length is not known before calling into the file. The caller can then
     /// cap the read by the returned byte space.
     pub fn wait_writable_any_for_splice(&self) -> Result<usize, SystemError> {
+        let mut guard = self.inner.lock();
         loop {
-            let guard = self.inner.lock();
             if guard.reader == 0 {
                 drop(guard);
-                let _ = send_kernel_signal_to_current(Signal::SIGPIPE);
+                Self::send_sigpipe();
                 return Err(SystemError::EPIPE);
             }
 
@@ -668,10 +760,9 @@ impl LockedPipeInode {
                 return Ok(space);
             }
 
-            drop(guard);
-            if wq_wait_event_interruptible!(self.write_wait_queue, self.writeable(), {}).is_err() {
-                return Err(SystemError::ERESTARTSYS);
-            }
+            let (next_guard, wait_result) = self.wait_for_write_space(guard, None, || {});
+            guard = next_guard;
+            wait_result?;
         }
     }
 
@@ -725,6 +816,7 @@ impl LockedPipeInode {
         buf: &mut [u8],
         nonblock: bool,
     ) -> Result<usize, SystemError> {
+        let mut did_wait = false;
         loop {
             let mut guard = self.inner.lock();
             if guard.valid_cnt == 0 {
@@ -736,6 +828,7 @@ impl LockedPipeInode {
                 }
                 drop(guard);
                 wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+                did_wait = true;
                 continue;
             }
 
@@ -745,6 +838,7 @@ impl LockedPipeInode {
                 }
                 drop(guard);
                 wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+                did_wait = true;
                 continue;
             }
 
@@ -753,6 +847,11 @@ impl LockedPipeInode {
                 num = len;
             }
             if buf.len() < num {
+                let pass_baton = did_wait && guard.splice_hold == 0;
+                drop(guard);
+                if pass_baton {
+                    Self::wake_waiters(&self.read_wait_queue, WakeMode::One);
+                }
                 return Err(SystemError::EINVAL);
             }
 
@@ -784,17 +883,28 @@ impl LockedPipeInode {
             guard.valid_cnt -= consume as i32;
         }
         guard.splice_hold = 0;
-
-        if guard.valid_cnt > 0 || guard.writer == 0 {
-            self.read_wait_queue
-                .wakeup(Some(ProcessState::Blocked(true)));
-        }
-        self.write_wait_queue
-            .wakeup(Some(ProcessState::Blocked(true)));
+        let reader_wake = if guard.valid_cnt > 0 {
+            WakeMode::One
+        } else if guard.writer == 0 {
+            WakeMode::All
+        } else {
+            WakeMode::None
+        };
+        let writer_wake = if consume > 0 {
+            Self::writer_wake_mode(&guard)
+        } else {
+            WakeMode::None
+        };
         let pollflag = guard.poll_both_ends();
         drop(guard);
+        self.wake_pipe_waiters(reader_wake, writer_wake);
         let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
-        self.write_fasync_items.send_sigio(FASYNC_POLL_OUT);
+        if reader_wake != WakeMode::None {
+            self.read_fasync_items.send_sigio(FASYNC_POLL_IN);
+        }
+        if consume > 0 {
+            self.write_fasync_items.send_sigio(FASYNC_POLL_OUT);
+        }
     }
 
     /// Helper: Wait until the pipe is readable (has data).
@@ -803,6 +913,7 @@ impl LockedPipeInode {
     /// - Ok(false): EOF (no writers and no data).
     /// - Err(e): Interrupted or EAGAIN.
     fn wait_readable(&self, nonblock: bool) -> Result<bool, SystemError> {
+        let mut did_wait = false;
         loop {
             let (avail, has_writer, held) = {
                 let guard = self.inner.lock();
@@ -814,15 +925,22 @@ impl LockedPipeInode {
             };
 
             if avail > 0 && !held {
+                if did_wait {
+                    Self::wake_waiters(&self.read_wait_queue, WakeMode::One);
+                }
                 return Ok(true);
             }
             if avail == 0 && !has_writer {
+                if did_wait {
+                    Self::wake_waiters(&self.read_wait_queue, WakeMode::All);
+                }
                 return Ok(false);
             }
             if nonblock {
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
             wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+            did_wait = true;
         }
     }
 
@@ -831,19 +949,25 @@ impl LockedPipeInode {
     /// - Ok(()): Space is available.
     /// - Err(e): Interrupted, EAGAIN, or EPIPE (no readers).
     fn wait_writable(&self, nonblock: bool) -> Result<(), SystemError> {
+        let mut guard = self.inner.lock();
         loop {
-            let space = self.writable_len();
+            let space = guard
+                .buf_size
+                .saturating_sub(guard.valid_cnt.max(0) as usize);
             if space > 0 {
                 return Ok(());
             }
-            if !self.has_readers() {
-                let _ = send_kernel_signal_to_current(Signal::SIGPIPE);
+            if guard.reader == 0 {
+                drop(guard);
+                Self::send_sigpipe();
                 return Err(SystemError::EPIPE);
             }
             if nonblock {
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
-            wq_wait_event_interruptible!(self.write_wait_queue, self.writeable(), {})?;
+            let (next_guard, wait_result) = self.wait_for_write_space(guard, None, || {});
+            guard = next_guard;
+            wait_result?;
         }
     }
 
@@ -872,13 +996,15 @@ impl LockedPipeInode {
             .buf_size
             .saturating_sub(out_guard.valid_cnt.max(0) as usize);
 
-        if in_avail == 0 || out_space == 0 {
-            return Ok(0);
+        if out_guard.reader == 0 {
+            drop(in_guard);
+            drop(out_guard);
+            Self::send_sigpipe();
+            return Err(SystemError::EPIPE);
         }
 
-        if out_guard.reader == 0 {
-            let _ = send_kernel_signal_to_current(Signal::SIGPIPE);
-            return Err(SystemError::EPIPE);
+        if in_avail == 0 || in_guard.splice_hold > 0 || out_space == 0 {
+            return Ok(0);
         }
 
         let skip = skip_calculator(&in_guard);
@@ -896,6 +1022,8 @@ impl LockedPipeInode {
             return Ok(0);
         }
 
+        let out_was_readable = out_guard.valid_cnt > 0 && out_guard.splice_hold == 0;
+
         // Copy data directly
         let copied = out_guard.copy_from_other(&in_guard, chunk, skip);
 
@@ -905,29 +1033,32 @@ impl LockedPipeInode {
             in_guard.valid_cnt -= copied as i32;
         }
 
-        // Wakeups
-        if consume {
-            if in_guard.valid_cnt > 0 {
-                src.read_wait_queue
-                    .wakeup(Some(ProcessState::Blocked(true)));
-            }
-            src.write_wait_queue
-                .wakeup(Some(ProcessState::Blocked(true)));
-        }
+        let src_reader_wake = if consume && in_guard.valid_cnt == 0 && in_guard.writer == 0 {
+            WakeMode::All
+        } else {
+            WakeMode::None
+        };
+        let src_writer_wake = if consume {
+            Self::writer_wake_mode(&in_guard)
+        } else {
+            WakeMode::None
+        };
+        let dst_reader_wake = if !out_was_readable && out_guard.splice_hold == 0 {
+            WakeMode::One
+        } else {
+            WakeMode::None
+        };
 
-        dst.read_wait_queue
-            .wakeup(Some(ProcessState::Blocked(true)));
-        if (out_guard.valid_cnt as usize) < out_guard.buf_size {
-            dst.write_wait_queue
-                .wakeup(Some(ProcessState::Blocked(true)));
-        }
-
-        let in_poll = in_guard.poll_both_ends();
+        let in_poll = consume.then(|| in_guard.poll_both_ends());
         let out_poll = out_guard.poll_both_ends();
         drop(in_guard);
         drop(out_guard);
 
-        let _ = EventPoll::wakeup_epoll(&src.epitems, in_poll);
+        src.wake_pipe_waiters(src_reader_wake, src_writer_wake);
+        Self::wake_waiters(&dst.read_wait_queue, dst_reader_wake);
+        if let Some(in_poll) = in_poll {
+            let _ = EventPoll::wakeup_epoll(&src.epitems, in_poll);
+        }
         let _ = EventPoll::wakeup_epoll(&dst.epitems, out_poll);
         if consume {
             src.write_fasync_items.send_sigio(FASYNC_POLL_OUT);
@@ -1010,11 +1141,20 @@ impl LockedPipeInode {
 
             // Check output space
             // tee has special nonblock handling: return total if > 0
-            if out.writable_len() == 0 {
-                if !out.has_readers() {
-                    let _ = send_kernel_signal_to_current(Signal::SIGPIPE);
-                    return Err(SystemError::EPIPE);
-                }
+            let (out_space, out_has_readers) = {
+                let guard = out.inner.lock();
+                let used = guard.valid_cnt.max(0) as usize;
+                (guard.buf_size.saturating_sub(used), guard.reader > 0)
+            };
+            if !out_has_readers {
+                Self::send_sigpipe();
+                return if total > 0 {
+                    Ok(total)
+                } else {
+                    Err(SystemError::EPIPE)
+                };
+            }
+            if out_space == 0 {
                 if nonblock || total > 0 {
                     if total > 0 {
                         return Ok(total);
@@ -1025,7 +1165,7 @@ impl LockedPipeInode {
                 out.wait_writable(false)?;
             }
 
-            let copied = Self::transfer_chunk(self, out, len - total, false, |in_guard| {
+            let copied = match Self::transfer_chunk(self, out, len - total, false, |in_guard| {
                 if in_avail_snapshot.is_none() {
                     in_avail_snapshot = Some(in_guard.valid_cnt.max(0) as usize);
                     in_read_pos_snapshot = Some(in_guard.read_pos.max(0) as usize);
@@ -1053,7 +1193,11 @@ impl LockedPipeInode {
                     }
                 }
                 skip
-            })?;
+            }) {
+                Ok(copied) => copied,
+                Err(SystemError::EPIPE) if total > 0 => return Ok(total),
+                Err(err) => return Err(err),
+            };
 
             if copied == 0 {
                 // Snapshot may be stale if another reader drained the pipe; refresh on next loop.
@@ -1085,7 +1229,7 @@ impl LockedPipeInode {
 
 #[cfg(test)]
 mod tests {
-    use super::LockedPipeInode;
+    use super::{LockedPipeInode, PIPE_MIN_SIZE};
 
     #[test]
     fn tee_adjusted_skip_no_consumption() {
@@ -1105,6 +1249,49 @@ mod tests {
     #[test]
     fn tee_adjusted_skip_wraparound() {
         assert_eq!(LockedPipeInode::tee_adjusted_skip(90, 10, 100, 80, 50), 30);
+    }
+
+    #[test]
+    fn transfer_does_not_consume_splice_held_data() {
+        let src = LockedPipeInode::new();
+        let dst = LockedPipeInode::new();
+        {
+            let mut src_guard = src.inner.lock();
+            src_guard.reader = 1;
+            src_guard.writer = 1;
+            src_guard.data = alloc::vec![0u8; PIPE_MIN_SIZE];
+            src_guard.data[..4].copy_from_slice(b"held");
+            src_guard.valid_cnt = 4;
+            src_guard.write_pos = 4;
+        }
+        {
+            let mut dst_guard = dst.inner.lock();
+            dst_guard.reader = 1;
+            dst_guard.writer = 1;
+        }
+
+        let mut held = [0u8; 4];
+        assert_eq!(
+            src.splice_peek_hold_from_blocking(held.len(), &mut held, true),
+            Ok(4)
+        );
+        assert_eq!(&held, b"held");
+        assert_eq!(
+            LockedPipeInode::transfer_chunk(&src, &dst, 4, true, |_| 0),
+            Ok(0)
+        );
+        {
+            let src_guard = src.inner.lock();
+            assert_eq!(src_guard.valid_cnt, 4);
+            assert_eq!(src_guard.read_pos, 0);
+        }
+
+        src.splice_finish_hold(0);
+        assert_eq!(
+            LockedPipeInode::transfer_chunk(&src, &dst, 4, true, |_| 0),
+            Ok(4)
+        );
+        assert_eq!(src.inner.lock().valid_cnt, 0);
     }
 }
 
@@ -1197,18 +1384,17 @@ impl IndexNode for LockedPipeInode {
         if buf.len() < len {
             return Err(SystemError::EINVAL);
         }
+        if len == 0 {
+            return Ok(0);
+        }
         // log::debug!("pipe flags: {:?}", flags);
         // 加锁
         let mut inner_guard = self.inner.lock();
+        let mut did_wait = false;
 
         while inner_guard.valid_cnt == 0 || inner_guard.splice_hold > 0 {
             if inner_guard.valid_cnt == 0 && inner_guard.writer == 0 {
                 return Ok(0);
-            }
-
-            if inner_guard.valid_cnt == 0 {
-                self.write_wait_queue
-                    .wakeup(Some(ProcessState::Blocked(true)));
             }
 
             if flags.contains(FileFlags::O_NONBLOCK) {
@@ -1218,6 +1404,7 @@ impl IndexNode for LockedPipeInode {
 
             drop(inner_guard);
             wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+            did_wait = true;
 
             inner_guard = self.inner.lock();
         }
@@ -1244,17 +1431,17 @@ impl IndexNode for LockedPipeInode {
         inner_guard.read_pos = (inner_guard.read_pos + num as i32) % buf_size as i32;
         inner_guard.valid_cnt -= num as i32;
 
-        // 读完以后如果未读完，则唤醒下一个读者
-        if inner_guard.valid_cnt > 0 {
-            self.read_wait_queue
-                .wakeup(Some(ProcessState::Blocked(true)));
-        }
-
-        //读完后解锁并唤醒等待在写等待队列中的进程
-        self.write_wait_queue
-            .wakeup(Some(ProcessState::Blocked(true)));
+        let reader_wake = if inner_guard.valid_cnt == 0 && inner_guard.writer == 0 {
+            WakeMode::All
+        } else if did_wait && inner_guard.valid_cnt > 0 && inner_guard.splice_hold == 0 {
+            WakeMode::One
+        } else {
+            WakeMode::None
+        };
+        let writer_wake = Self::writer_wake_mode(&inner_guard);
         let pollflag = inner_guard.poll_both_ends();
         drop(inner_guard);
+        self.wake_pipe_waiters(reader_wake, writer_wake);
         // 唤醒epoll中等待的进程（忽略错误，因为状态已更新，这是尽力而为的通知）
         let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
         self.write_fasync_items.send_sigio(FASYNC_POLL_OUT);
@@ -1472,7 +1659,6 @@ impl IndexNode for LockedPipeInode {
         buf: &[u8],
         data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        // 获取flags
         let flags: FileFlags;
         if let FilePrivateData::Pipefs(pdata) = &*data {
             flags = pdata.flags;
@@ -1484,57 +1670,47 @@ impl IndexNode for LockedPipeInode {
             return Err(SystemError::EINVAL);
         }
 
-        // 提前释放 data 锁，因为后续可能需要睡眠
-        // 我们已经提取了需要的 mode 信息
         drop(data);
+        if len == 0 {
+            return Ok(0);
+        }
 
-        // 加锁
         let mut inner_guard = self.inner.lock();
-
-        // PIPE_BUF atomicity: if len <= PIPE_BUF, writes must be all-or-nothing.
-        // We implement this by waiting for enough room before writing the first byte.
         let atomic_write = len <= PIPE_BUF;
 
         if inner_guard.reader == 0 {
-            if !inner_guard.had_reader {
-                // 如果从未有读端，直接返回 ENXIO，无论是否阻塞模式
-                return Err(SystemError::ENXIO);
-            } else {
-                // 如果曾经有读端，现在已关闭
-                match flags.contains(FileFlags::O_NONBLOCK) {
-                    true => {
-                        // 非阻塞模式，直接返回 EPIPE
-                        return Err(SystemError::EPIPE);
-                    }
-                    false => {
-                        if let Err(e) = send_kernel_signal_to_current(Signal::SIGPIPE) {
-                            log::error!("Failed to send SIGPIPE for pipe write: {:?}", e);
-                        }
-                        return Err(SystemError::EPIPE);
-                    }
-                }
-            }
+            drop(inner_guard);
+            Self::send_sigpipe();
+            return Err(SystemError::EPIPE);
         }
 
-        // 延迟分配：如果缓冲区未分配，在第一次写入时分配
         if inner_guard.data.is_empty() {
-            // 分配缓冲区大小为 buf_size
             let buf_size = inner_guard.buf_size;
             inner_guard.data = vec![0u8; buf_size];
         }
 
         let mut total_written: usize = 0;
+        let mut reader_wake = WakeMode::None;
+        let mut progress_pending = false;
 
-        // 循环写入，直到写完所有数据
         while total_written < len {
-            // 计算本次要写入的字节数
+            if inner_guard.reader == 0 {
+                let pollflag = progress_pending.then(|| inner_guard.poll_both_ends());
+                drop(inner_guard);
+                if let Some(pollflag) = pollflag {
+                    self.publish_write_progress(reader_wake, pollflag);
+                }
+                Self::send_sigpipe();
+                return if total_written > 0 {
+                    Ok(total_written)
+                } else {
+                    Err(SystemError::EPIPE)
+                };
+            }
+
             let remaining = len - total_written;
             let buf_size = inner_guard.buf_size;
             let available_space = buf_size - inner_guard.valid_cnt as usize;
-
-            // 如果没有足够空间需要等待
-            // - non-atomic writes: only wait when pipe is full
-            // - atomic writes (<= PIPE_BUF): wait until we have room for the entire write
             let need_wait = if atomic_write && total_written == 0 {
                 available_space < len
             } else {
@@ -1542,90 +1718,61 @@ impl IndexNode for LockedPipeInode {
             };
 
             if need_wait {
-                // 唤醒读端
-                self.read_wait_queue
-                    .wakeup(Some(ProcessState::Blocked(true)));
+                let pending_poll = progress_pending.then(|| inner_guard.poll_both_ends());
+                let pending_reader_wake = reader_wake;
+                progress_pending = false;
+                reader_wake = WakeMode::None;
 
-                // 如果为非阻塞管道，返回已写入的字节数或 EAGAIN
                 if flags.contains(FileFlags::O_NONBLOCK) {
                     drop(inner_guard);
+                    if let Some(pollflag) = pending_poll {
+                        self.publish_write_progress(pending_reader_wake, pollflag);
+                    }
                     if total_written > 0 {
                         return Ok(total_written);
                     }
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
                 }
 
-                // 解锁并睡眠
-                drop(inner_guard);
-
-                let r = if atomic_write && total_written == 0 {
-                    wq_wait_event_interruptible!(
-                        self.write_wait_queue,
-                        self.writeable_len_at_least(len),
-                        {}
-                    )
-                } else {
-                    wq_wait_event_interruptible!(self.write_wait_queue, self.writeable(), {})
-                };
-
-                if r.is_err() {
-                    if total_written > 0 {
-                        return Ok(total_written);
+                let required = (atomic_write && total_written == 0).then_some(len);
+                let (guard, wait_result) = self.wait_for_write_space(inner_guard, required, || {
+                    if let Some(pollflag) = pending_poll {
+                        self.publish_write_progress(pending_reader_wake, pollflag);
                     }
-                    return Err(SystemError::ERESTARTSYS);
+                });
+                inner_guard = guard;
+
+                if let Err(err) = wait_result {
+                    return if total_written > 0 {
+                        Ok(total_written)
+                    } else {
+                        Err(err)
+                    };
                 }
-                inner_guard = self.inner.lock();
-
-                // 检查读端是否已关闭
-                if inner_guard.reader == 0 && inner_guard.had_reader {
-                    drop(inner_guard);
-
-                    // 发送 SIGPIPE 信号（阻塞模式下）
-                    if !flags.contains(FileFlags::O_NONBLOCK) {
-                        if let Err(e) = send_kernel_signal_to_current(Signal::SIGPIPE) {
-                            log::error!("Failed to send SIGPIPE for pipe write: {:?}", e);
-                        }
-                    }
-
-                    if total_written > 0 {
-                        return Ok(total_written);
-                    }
-                    return Err(SystemError::EPIPE);
-                }
-
                 continue;
             }
 
-            // 计算本次写入的字节数
             let to_write = core::cmp::min(remaining, available_space);
-
+            let was_readable = inner_guard.valid_cnt > 0 && inner_guard.splice_hold == 0;
             Self::write_bytes(
                 &mut inner_guard,
                 &buf[total_written..total_written + to_write],
                 to_write,
             );
             total_written += to_write;
+            progress_pending = true;
+            if !was_readable && inner_guard.splice_hold == 0 {
+                reader_wake = WakeMode::One;
+            }
         }
-
-        // 写完后还有位置，则唤醒下一个写者
-        if (inner_guard.valid_cnt as usize) < inner_guard.buf_size {
-            self.write_wait_queue
-                .wakeup(Some(ProcessState::Blocked(true)));
-        }
-
-        // 读完后解锁并唤醒等待在读等待队列中的进程
-        self.read_wait_queue
-            .wakeup(Some(ProcessState::Blocked(true)));
 
         let pollflag = inner_guard.poll_both_ends();
-
         drop(inner_guard);
-        // 唤醒epoll中等待的进程（忽略错误，因为数据已写入，这是尽力而为的通知）
-        let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
-        self.read_fasync_items.send_sigio(FASYNC_POLL_IN);
+        if progress_pending {
+            self.publish_write_progress(reader_wake, pollflag);
+        }
 
-        // 返回写入的字节数
-        return Ok(total_written);
+        Ok(total_written)
     }
 
     fn as_any_ref(&self) -> &dyn core::any::Any {

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -22,6 +22,7 @@ use crate::{
     syscall::user_access::UserBufferWriter,
     time::PosixTimeSpec,
 };
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -49,6 +50,118 @@ enum WakeMode {
     None,
     One,
     All,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PipeWriterWake {
+    None,
+    One(usize),
+    All,
+}
+
+#[derive(Debug, Default)]
+struct PipeWriteWaiters {
+    any_space: usize,
+    atomic: BTreeMap<usize, usize>,
+    /// Next class key considered for round-robin selection. Key 0 denotes
+    /// any-space writers; atomic classes use their required byte count.
+    next_class: usize,
+}
+
+impl PipeWriteWaiters {
+    fn register(&mut self, required: Option<usize>) -> usize {
+        match required {
+            Some(required) => {
+                debug_assert!((1..=PIPE_BUF).contains(&required));
+                let count = self.atomic.entry(required).or_insert(0);
+                *count = count
+                    .checked_add(1)
+                    .expect("pipe atomic writer wait-intent count overflowed");
+                required
+            }
+            None => {
+                self.any_space = self
+                    .any_space
+                    .checked_add(1)
+                    .expect("pipe writer wait-intent count overflowed");
+                0
+            }
+        }
+    }
+
+    fn unregister(&mut self, required: Option<usize>) {
+        match required {
+            Some(required) => {
+                let count = self
+                    .atomic
+                    .get_mut(&required)
+                    .expect("missing pipe atomic writer wait intent");
+                *count = count
+                    .checked_sub(1)
+                    .expect("pipe atomic writer wait-intent count underflowed");
+                if *count == 0 {
+                    self.atomic.remove(&required);
+                }
+            }
+            None => {
+                self.any_space = self
+                    .any_space
+                    .checked_sub(1)
+                    .expect("pipe writer wait-intent count underflowed");
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.any_space == 0 && self.atomic.is_empty()
+    }
+
+    fn class_count(&self) -> usize {
+        self.atomic.len() + usize::from(self.any_space > 0)
+    }
+
+    /// Select one currently eligible writer class. Tagged waiters let the
+    /// pipe-private policy skip writers whose free-space predicate is false.
+    fn wake_action(&mut self, available: usize, has_readers: bool) -> PipeWriterWake {
+        if self.is_empty() {
+            return PipeWriterWake::None;
+        }
+        if !has_readers {
+            return PipeWriterWake::All;
+        }
+        if available == 0 {
+            return PipeWriterWake::None;
+        }
+
+        let atomic_start = self.next_class.max(1);
+        let atomic_after_cursor = if atomic_start <= available {
+            self.atomic
+                .range(atomic_start..=available)
+                .next()
+                .map(|(required, _)| *required)
+        } else {
+            None
+        };
+        let selected = if self.next_class == 0 && self.any_space > 0 {
+            Some(0)
+        } else if let Some(atomic) = atomic_after_cursor {
+            Some(atomic)
+        } else if self.any_space > 0 {
+            Some(0)
+        } else {
+            self.atomic
+                .first_key_value()
+                .filter(|(required, _)| **required <= available)
+                .map(|(required, _)| *required)
+        };
+
+        if let Some(key) = selected {
+            self.next_class = if key >= PIPE_BUF { 0 } else { key + 1 };
+            PipeWriterWake::One(key)
+        } else {
+            PipeWriterWake::None
+        }
+    }
 }
 
 // FIONREAD: 获取管道中可读的字节数
@@ -142,11 +255,9 @@ pub struct InnerPipeInode {
     metadata: Metadata,
     reader: u32,
     writer: u32,
-    /// Writers that have committed to sleeping for pipe space.
-    ///
-    /// This is protected by `LockedPipeInode::inner` and is used only to
-    /// choose between an exclusive wakeup and a broadcast after space grows.
-    write_wait_intents: usize,
+    /// Pipe-space predicates published by writers before they sleep.
+    /// Protected by `LockedPipeInode::inner`.
+    write_waiters: PipeWriteWaiters,
     had_reader: bool,
     /// 是否为命名管道（FIFO）
     /// 只有 FIFO 才需要在 open 时阻塞等待另一端
@@ -300,12 +411,10 @@ impl InnerPipeInode {
 
 impl LockedPipeInode {
     #[inline]
-    fn writer_wake_mode(inner: &InnerPipeInode) -> WakeMode {
-        match inner.write_wait_intents {
-            0 => WakeMode::None,
-            1 => WakeMode::One,
-            _ => WakeMode::All,
-        }
+    fn writer_wake_action(inner: &mut InnerPipeInode) -> PipeWriterWake {
+        let used = inner.valid_cnt.max(0) as usize;
+        let available = inner.buf_size.saturating_sub(used);
+        inner.write_waiters.wake_action(available, inner.reader > 0)
     }
 
     #[inline]
@@ -322,9 +431,47 @@ impl LockedPipeInode {
     }
 
     #[inline]
-    fn wake_pipe_waiters(&self, readers: WakeMode, writers: WakeMode) {
+    fn wake_writers(&self, mut action: PipeWriterWake) {
+        match action {
+            PipeWriterWake::None => {}
+            PipeWriterWake::All => {
+                self.write_wait_queue
+                    .wakeup_all(Some(ProcessState::Blocked(true)));
+            }
+            PipeWriterWake::One(_) => {
+                // Include the already-selected action: its class can disappear
+                // between selection and the tagged wakeup.
+                let max_attempts = self.inner.lock().write_waiters.class_count() + 1;
+                for attempt in 0..max_attempts {
+                    match action {
+                        PipeWriterWake::None => return,
+                        PipeWriterWake::All => {
+                            self.write_wait_queue
+                                .wakeup_all(Some(ProcessState::Blocked(true)));
+                            return;
+                        }
+                        PipeWriterWake::One(class) => {
+                            if self.write_wait_queue.wake_one_tagged(class) {
+                                return;
+                            }
+                        }
+                    }
+                    if attempt + 1 == max_attempts {
+                        return;
+                    }
+                    action = {
+                        let mut inner = self.inner.lock();
+                        Self::writer_wake_action(&mut inner)
+                    };
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn wake_pipe_waiters(&self, readers: WakeMode, writers: PipeWriterWake) {
         Self::wake_waiters(&self.read_wait_queue, readers);
-        Self::wake_waiters(&self.write_wait_queue, writers);
+        self.wake_writers(writers);
     }
 
     fn send_sigpipe() {
@@ -408,7 +555,7 @@ impl LockedPipeInode {
             },
             reader: 0,
             writer: 0,
-            write_wait_intents: 0,
+            write_waiters: PipeWriteWaiters::default(),
             is_fifo: false, // 默认为匿名管道
             r_counter: 0,   // 初始化读端计数器
             w_counter: 0,   // 初始化写端计数器
@@ -483,28 +630,20 @@ impl LockedPipeInode {
     where
         F: FnOnce(),
     {
-        guard.write_wait_intents = guard
-            .write_wait_intents
-            .checked_add(1)
-            .expect("pipe writer wait-intent count overflowed");
+        let waiter_class = guard.write_waiters.register(required);
         drop(guard);
 
         before_wait();
         let result = if let Some(need) = required {
-            wq_wait_event_interruptible!(
-                self.write_wait_queue,
-                self.writeable_len_at_least(need),
-                {}
-            )
+            self.write_wait_queue
+                .wait_event_interruptible_tagged(waiter_class, || self.writeable_len_at_least(need))
         } else {
-            wq_wait_event_interruptible!(self.write_wait_queue, self.writeable(), {})
+            self.write_wait_queue
+                .wait_event_interruptible_tagged(waiter_class, || self.writeable())
         };
 
         let mut guard = self.inner.lock();
-        guard.write_wait_intents = guard
-            .write_wait_intents
-            .checked_sub(1)
-            .expect("pipe writer wait-intent count underflowed");
+        guard.write_waiters.unregister(required);
         let result = result.map_err(|_| SystemError::ERESTARTSYS);
         (guard, result)
     }
@@ -608,11 +747,11 @@ impl LockedPipeInode {
         inner.buf_size = new_size;
         inner.metadata.size = new_size as i64;
 
-        let writer_wake = Self::writer_wake_mode(&inner);
+        let writer_wake = Self::writer_wake_action(&mut inner);
         let pollflag = inner.poll_both_ends();
         drop(inner);
 
-        Self::wake_waiters(&self.write_wait_queue, writer_wake);
+        self.wake_writers(writer_wake);
         let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
 
         Ok(new_size)
@@ -650,6 +789,181 @@ impl LockedPipeInode {
         }
         inner_guard.write_pos = (inner_guard.write_pos + to_write as i32) % buf_size as i32;
         inner_guard.valid_cnt += to_write as i32;
+    }
+
+    pub(crate) fn finish_writer_wait(&self, wake_next_writer: bool) {
+        if !wake_next_writer {
+            return;
+        }
+
+        let writer_wake = {
+            let mut inner = self.inner.lock();
+            Self::writer_wake_action(&mut inner)
+        };
+        self.wake_writers(writer_wake);
+    }
+
+    /// Preserve exclusive reader-wakeup progress when a selected waiter exits
+    /// without consuming data (for example, because a signal interrupted it).
+    fn finish_interrupted_reader_wait(&self) {
+        let reader_wake = {
+            let inner = self.inner.lock();
+            if inner.valid_cnt > 0 && inner.splice_hold == 0 {
+                WakeMode::One
+            } else if inner.valid_cnt == 0 && inner.writer == 0 {
+                WakeMode::All
+            } else {
+                WakeMode::None
+            }
+        };
+        Self::wake_waiters(&self.read_wait_queue, reader_wake);
+    }
+
+    fn wait_for_readable_event(&self) -> Result<(), SystemError> {
+        let result = wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {});
+        if result.is_err() {
+            self.finish_interrupted_reader_wait();
+        }
+        result
+    }
+
+    fn write_with_flags(
+        &self,
+        len: usize,
+        buf: &[u8],
+        flags: FileFlags,
+    ) -> Result<usize, SystemError> {
+        if buf.len() < len {
+            return Err(SystemError::EINVAL);
+        }
+        if len == 0 {
+            return Ok(0);
+        }
+
+        let mut inner_guard = self.inner.lock();
+        let atomic_write = len <= PIPE_BUF;
+
+        if inner_guard.reader == 0 {
+            drop(inner_guard);
+            Self::send_sigpipe();
+            return Err(SystemError::EPIPE);
+        }
+
+        if inner_guard.data.is_empty() {
+            let buf_size = inner_guard.buf_size;
+            inner_guard.data = vec![0u8; buf_size];
+        }
+
+        let mut total_written: usize = 0;
+        let mut wake_next_writer = false;
+        let mut reader_wake = WakeMode::None;
+        let mut progress_pending = false;
+
+        while total_written < len {
+            if inner_guard.reader == 0 {
+                let pollflag = progress_pending.then(|| inner_guard.poll_both_ends());
+                let writer_wake =
+                    wake_next_writer.then(|| Self::writer_wake_action(&mut inner_guard));
+                drop(inner_guard);
+                if let Some(pollflag) = pollflag {
+                    self.publish_write_progress(reader_wake, pollflag);
+                }
+                if let Some(writer_wake) = writer_wake {
+                    self.wake_writers(writer_wake);
+                }
+                Self::send_sigpipe();
+                return if total_written > 0 {
+                    Ok(total_written)
+                } else {
+                    Err(SystemError::EPIPE)
+                };
+            }
+
+            let remaining = len - total_written;
+            let buf_size = inner_guard.buf_size;
+            let available_space = buf_size - inner_guard.valid_cnt as usize;
+            let need_wait = if atomic_write && total_written == 0 {
+                available_space < len
+            } else {
+                available_space == 0
+            };
+
+            if need_wait {
+                let pending_poll = progress_pending.then(|| inner_guard.poll_both_ends());
+                let pending_reader_wake = reader_wake;
+                progress_pending = false;
+                reader_wake = WakeMode::None;
+
+                if flags.contains(FileFlags::O_NONBLOCK) {
+                    let writer_wake =
+                        wake_next_writer.then(|| Self::writer_wake_action(&mut inner_guard));
+                    drop(inner_guard);
+                    if let Some(pollflag) = pending_poll {
+                        self.publish_write_progress(pending_reader_wake, pollflag);
+                    }
+                    if let Some(writer_wake) = writer_wake {
+                        self.wake_writers(writer_wake);
+                    }
+                    if total_written > 0 {
+                        return Ok(total_written);
+                    }
+                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                }
+
+                let required = (atomic_write && total_written == 0).then_some(len);
+                let (guard, wait_result) = self.wait_for_write_space(inner_guard, required, || {
+                    if let Some(pollflag) = pending_poll {
+                        self.publish_write_progress(pending_reader_wake, pollflag);
+                    }
+                });
+                inner_guard = guard;
+                wake_next_writer = true;
+
+                if let Err(err) = wait_result {
+                    let writer_wake = Self::writer_wake_action(&mut inner_guard);
+                    drop(inner_guard);
+                    self.wake_writers(writer_wake);
+                    return if total_written > 0 {
+                        Ok(total_written)
+                    } else {
+                        Err(err)
+                    };
+                }
+                continue;
+            }
+
+            let to_write = core::cmp::min(remaining, available_space);
+            let was_readable = inner_guard.valid_cnt > 0 && inner_guard.splice_hold == 0;
+            Self::write_bytes(
+                &mut inner_guard,
+                &buf[total_written..total_written + to_write],
+                to_write,
+            );
+            total_written += to_write;
+            progress_pending = true;
+            if !was_readable && inner_guard.splice_hold == 0 {
+                reader_wake = WakeMode::One;
+            }
+        }
+
+        let pollflag = inner_guard.poll_both_ends();
+        let writer_wake = wake_next_writer.then(|| Self::writer_wake_action(&mut inner_guard));
+        drop(inner_guard);
+        if progress_pending {
+            self.publish_write_progress(reader_wake, pollflag);
+        }
+        if let Some(writer_wake) = writer_wake {
+            self.wake_writers(writer_wake);
+        }
+
+        Ok(total_written)
+    }
+
+    pub(crate) fn write_from_splice_blocking(&self, buf: &[u8]) -> Result<usize, SystemError> {
+        // The syscall layer has already folded the output pipe's O_NONBLOCK
+        // state into SPLICE_F_NONBLOCK. Reaching this helper therefore means
+        // this particular splice operation is blocking.
+        self.write_with_flags(buf.len(), buf, FileFlags::empty())
     }
 
     /// Nonblocking write helper for splice(2) paths that must ignore the pipe FD's O_NONBLOCK flag.
@@ -712,14 +1026,17 @@ impl LockedPipeInode {
     /// The caller must pass the maximum number of bytes it can actually read
     /// from the input file for this splice attempt. DragonOS pipes are byte-ring
     /// based, so requests up to PIPE_BUF wait for the complete readable chunk;
-    /// larger requests wait for any space and may complete partially.
-    pub fn wait_writable_for_splice(&self, len: usize) -> Result<usize, SystemError> {
+    /// larger requests wait for any space and may complete partially. The
+    /// boolean return value tells the caller to pass the writer baton after it
+    /// has consumed the reserved space (or abandoned the operation).
+    pub fn wait_writable_for_splice(&self, len: usize) -> Result<(usize, bool), SystemError> {
         if len == 0 {
-            return Ok(0);
+            return Ok((0, false));
         }
 
         let need_atomic = len <= PIPE_BUF;
         let mut guard = self.inner.lock();
+        let mut wake_next_writer = false;
         loop {
             if guard.reader == 0 {
                 drop(guard);
@@ -730,13 +1047,20 @@ impl LockedPipeInode {
             let used = guard.valid_cnt.max(0) as usize;
             let space = guard.buf_size.saturating_sub(used);
             if (need_atomic && space >= len) || (!need_atomic && space > 0) {
-                return Ok(if need_atomic { len } else { len.min(space) });
+                let writable = if need_atomic { len } else { len.min(space) };
+                return Ok((writable, wake_next_writer));
             }
 
             let required = need_atomic.then_some(len);
             let (next_guard, wait_result) = self.wait_for_write_space(guard, required, || {});
             guard = next_guard;
-            wait_result?;
+            wake_next_writer = true;
+            if let Err(err) = wait_result {
+                let writer_wake = Self::writer_wake_action(&mut guard);
+                drop(guard);
+                self.wake_writers(writer_wake);
+                return Err(err);
+            }
         }
     }
 
@@ -744,9 +1068,12 @@ impl LockedPipeInode {
     ///
     /// This matches Linux `wait_for_space()` for inputs whose exact readable
     /// length is not known before calling into the file. The caller can then
-    /// cap the read by the returned byte space.
-    pub fn wait_writable_any_for_splice(&self) -> Result<usize, SystemError> {
+    /// cap the read by the returned byte space. The boolean return value tells
+    /// the caller to pass the writer baton after it has consumed the reserved
+    /// space (or abandoned the operation).
+    pub fn wait_writable_any_for_splice(&self) -> Result<(usize, bool), SystemError> {
         let mut guard = self.inner.lock();
+        let mut wake_next_writer = false;
         loop {
             if guard.reader == 0 {
                 drop(guard);
@@ -757,12 +1084,18 @@ impl LockedPipeInode {
             let used = guard.valid_cnt.max(0) as usize;
             let space = guard.buf_size.saturating_sub(used);
             if space > 0 {
-                return Ok(space);
+                return Ok((space, wake_next_writer));
             }
 
             let (next_guard, wait_result) = self.wait_for_write_space(guard, None, || {});
             guard = next_guard;
-            wait_result?;
+            wake_next_writer = true;
+            if let Err(err) = wait_result {
+                let writer_wake = Self::writer_wake_action(&mut guard);
+                drop(guard);
+                self.wake_writers(writer_wake);
+                return Err(err);
+            }
         }
     }
 
@@ -827,7 +1160,7 @@ impl LockedPipeInode {
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
                 }
                 drop(guard);
-                wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+                self.wait_for_readable_event()?;
                 did_wait = true;
                 continue;
             }
@@ -837,7 +1170,7 @@ impl LockedPipeInode {
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
                 }
                 drop(guard);
-                wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+                self.wait_for_readable_event()?;
                 did_wait = true;
                 continue;
             }
@@ -891,9 +1224,9 @@ impl LockedPipeInode {
             WakeMode::None
         };
         let writer_wake = if consume > 0 {
-            Self::writer_wake_mode(&guard)
+            Self::writer_wake_action(&mut guard)
         } else {
-            WakeMode::None
+            PipeWriterWake::None
         };
         let pollflag = guard.poll_both_ends();
         drop(guard);
@@ -939,23 +1272,25 @@ impl LockedPipeInode {
             if nonblock {
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
-            wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+            self.wait_for_readable_event()?;
             did_wait = true;
         }
     }
 
     /// Helper: Wait until the pipe is writable (has space).
     /// Returns:
-    /// - Ok(()): Space is available.
+    /// - Ok(waited): Space is available; `waited` requests a post-transfer
+    ///   writer-baton wakeup.
     /// - Err(e): Interrupted, EAGAIN, or EPIPE (no readers).
-    fn wait_writable(&self, nonblock: bool) -> Result<(), SystemError> {
+    fn wait_writable(&self, nonblock: bool) -> Result<bool, SystemError> {
         let mut guard = self.inner.lock();
+        let mut wake_next_writer = false;
         loop {
             let space = guard
                 .buf_size
                 .saturating_sub(guard.valid_cnt.max(0) as usize);
             if space > 0 {
-                return Ok(());
+                return Ok(wake_next_writer);
             }
             if guard.reader == 0 {
                 drop(guard);
@@ -967,7 +1302,13 @@ impl LockedPipeInode {
             }
             let (next_guard, wait_result) = self.wait_for_write_space(guard, None, || {});
             guard = next_guard;
-            wait_result?;
+            wake_next_writer = true;
+            if let Err(err) = wait_result {
+                let writer_wake = Self::writer_wake_action(&mut guard);
+                drop(guard);
+                self.wake_writers(writer_wake);
+                return Err(err);
+            }
         }
     }
 
@@ -1039,9 +1380,9 @@ impl LockedPipeInode {
             WakeMode::None
         };
         let src_writer_wake = if consume {
-            Self::writer_wake_mode(&in_guard)
+            Self::writer_wake_action(&mut in_guard)
         } else {
-            WakeMode::None
+            PipeWriterWake::None
         };
         let dst_reader_wake = if !out_was_readable && out_guard.splice_hold == 0 {
             WakeMode::One
@@ -1092,10 +1433,12 @@ impl LockedPipeInode {
             }
 
             // Wait for output space
-            out.wait_writable(nonblock)?;
+            let wake_next_writer = out.wait_writable(nonblock)?;
 
             // Try transfer
-            let copied = Self::transfer_chunk(self, out, len, true, |_| 0)?;
+            let transfer = Self::transfer_chunk(self, out, len, true, |_| 0);
+            out.finish_writer_wait(wake_next_writer);
+            let copied = transfer?;
             if copied > 0 {
                 return Ok(copied);
             }
@@ -1154,6 +1497,7 @@ impl LockedPipeInode {
                     Err(SystemError::EPIPE)
                 };
             }
+            let mut wake_next_writer = false;
             if out_space == 0 {
                 if nonblock || total > 0 {
                     if total > 0 {
@@ -1162,10 +1506,10 @@ impl LockedPipeInode {
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
                 }
                 // force blocking wait
-                out.wait_writable(false)?;
+                wake_next_writer = out.wait_writable(false)?;
             }
 
-            let copied = match Self::transfer_chunk(self, out, len - total, false, |in_guard| {
+            let transfer = Self::transfer_chunk(self, out, len - total, false, |in_guard| {
                 if in_avail_snapshot.is_none() {
                     in_avail_snapshot = Some(in_guard.valid_cnt.max(0) as usize);
                     in_read_pos_snapshot = Some(in_guard.read_pos.max(0) as usize);
@@ -1193,7 +1537,9 @@ impl LockedPipeInode {
                     }
                 }
                 skip
-            }) {
+            });
+            out.finish_writer_wait(wake_next_writer);
+            let copied = match transfer {
                 Ok(copied) => copied,
                 Err(SystemError::EPIPE) if total > 0 => return Ok(total),
                 Err(err) => return Err(err),
@@ -1229,7 +1575,46 @@ impl LockedPipeInode {
 
 #[cfg(test)]
 mod tests {
-    use super::{LockedPipeInode, PIPE_MIN_SIZE};
+    use super::{LockedPipeInode, PipeWriteWaiters, PipeWriterWake, PIPE_MIN_SIZE};
+
+    #[test]
+    fn writer_wake_action_targets_one_homogeneous_class() {
+        let mut waiters = PipeWriteWaiters::default();
+        let first_class = waiters.register(Some(4));
+        let second_class = waiters.register(Some(4));
+        assert_eq!(first_class, second_class);
+
+        assert!(matches!(waiters.wake_action(3, true), PipeWriterWake::None));
+        let PipeWriterWake::One(selected) = waiters.wake_action(4, true) else {
+            panic!("eligible writer class was not selected");
+        };
+        assert_eq!(selected, first_class);
+
+        waiters.unregister(Some(4));
+        waiters.unregister(Some(4));
+        assert!(waiters.is_empty());
+    }
+
+    #[test]
+    fn writer_wake_action_skips_ineligible_classes() {
+        let mut waiters = PipeWriteWaiters::default();
+        let any_class = waiters.register(None);
+        let atomic_class = waiters.register(Some(4));
+
+        let PipeWriterWake::One(selected) = waiters.wake_action(1, true) else {
+            panic!("any-space writer class was not selected");
+        };
+        assert_eq!(selected, any_class);
+        assert_ne!(selected, atomic_class);
+
+        assert_eq!(
+            waiters.wake_action(4, true),
+            PipeWriterWake::One(atomic_class)
+        );
+        assert_eq!(waiters.wake_action(1, true), PipeWriterWake::One(any_class));
+
+        assert_eq!(waiters.wake_action(0, false), PipeWriterWake::All);
+    }
 
     #[test]
     fn tee_adjusted_skip_no_consumption() {
@@ -1403,7 +1788,7 @@ impl IndexNode for LockedPipeInode {
             }
 
             drop(inner_guard);
-            wq_wait_event_interruptible!(self.read_wait_queue, self.readable(), {})?;
+            self.wait_for_readable_event()?;
             did_wait = true;
 
             inner_guard = self.inner.lock();
@@ -1438,7 +1823,7 @@ impl IndexNode for LockedPipeInode {
         } else {
             WakeMode::None
         };
-        let writer_wake = Self::writer_wake_mode(&inner_guard);
+        let writer_wake = Self::writer_wake_action(&mut inner_guard);
         let pollflag = inner_guard.poll_both_ends();
         drop(inner_guard);
         self.wake_pipe_waiters(reader_wake, writer_wake);
@@ -1639,11 +2024,16 @@ impl IndexNode for LockedPipeInode {
         } else {
             EPollEventType::empty()
         };
+        let writer_wake = if release_notify {
+            Self::writer_wake_action(&mut guard)
+        } else {
+            PipeWriterWake::None
+        };
         drop(guard);
 
         if release_notify {
             self.read_wait_queue.wakeup_all(None);
-            self.write_wait_queue.wakeup_all(None);
+            self.wake_writers(writer_wake);
             let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
             self.read_fasync_items.send_sigio(FASYNC_POLL_IN);
             self.write_fasync_items.send_sigio(FASYNC_POLL_OUT);
@@ -1665,114 +2055,8 @@ impl IndexNode for LockedPipeInode {
         } else {
             return Err(SystemError::EBADF);
         }
-
-        if buf.len() < len {
-            return Err(SystemError::EINVAL);
-        }
-
         drop(data);
-        if len == 0 {
-            return Ok(0);
-        }
-
-        let mut inner_guard = self.inner.lock();
-        let atomic_write = len <= PIPE_BUF;
-
-        if inner_guard.reader == 0 {
-            drop(inner_guard);
-            Self::send_sigpipe();
-            return Err(SystemError::EPIPE);
-        }
-
-        if inner_guard.data.is_empty() {
-            let buf_size = inner_guard.buf_size;
-            inner_guard.data = vec![0u8; buf_size];
-        }
-
-        let mut total_written: usize = 0;
-        let mut reader_wake = WakeMode::None;
-        let mut progress_pending = false;
-
-        while total_written < len {
-            if inner_guard.reader == 0 {
-                let pollflag = progress_pending.then(|| inner_guard.poll_both_ends());
-                drop(inner_guard);
-                if let Some(pollflag) = pollflag {
-                    self.publish_write_progress(reader_wake, pollflag);
-                }
-                Self::send_sigpipe();
-                return if total_written > 0 {
-                    Ok(total_written)
-                } else {
-                    Err(SystemError::EPIPE)
-                };
-            }
-
-            let remaining = len - total_written;
-            let buf_size = inner_guard.buf_size;
-            let available_space = buf_size - inner_guard.valid_cnt as usize;
-            let need_wait = if atomic_write && total_written == 0 {
-                available_space < len
-            } else {
-                available_space == 0
-            };
-
-            if need_wait {
-                let pending_poll = progress_pending.then(|| inner_guard.poll_both_ends());
-                let pending_reader_wake = reader_wake;
-                progress_pending = false;
-                reader_wake = WakeMode::None;
-
-                if flags.contains(FileFlags::O_NONBLOCK) {
-                    drop(inner_guard);
-                    if let Some(pollflag) = pending_poll {
-                        self.publish_write_progress(pending_reader_wake, pollflag);
-                    }
-                    if total_written > 0 {
-                        return Ok(total_written);
-                    }
-                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-                }
-
-                let required = (atomic_write && total_written == 0).then_some(len);
-                let (guard, wait_result) = self.wait_for_write_space(inner_guard, required, || {
-                    if let Some(pollflag) = pending_poll {
-                        self.publish_write_progress(pending_reader_wake, pollflag);
-                    }
-                });
-                inner_guard = guard;
-
-                if let Err(err) = wait_result {
-                    return if total_written > 0 {
-                        Ok(total_written)
-                    } else {
-                        Err(err)
-                    };
-                }
-                continue;
-            }
-
-            let to_write = core::cmp::min(remaining, available_space);
-            let was_readable = inner_guard.valid_cnt > 0 && inner_guard.splice_hold == 0;
-            Self::write_bytes(
-                &mut inner_guard,
-                &buf[total_written..total_written + to_write],
-                to_write,
-            );
-            total_written += to_write;
-            progress_pending = true;
-            if !was_readable && inner_guard.splice_hold == 0 {
-                reader_wake = WakeMode::One;
-            }
-        }
-
-        let pollflag = inner_guard.poll_both_ends();
-        drop(inner_guard);
-        if progress_pending {
-            self.publish_write_progress(reader_wake, pollflag);
-        }
-
-        Ok(total_written)
+        self.write_with_flags(len, buf, flags)
     }
 
     fn as_any_ref(&self) -> &dyn core::any::Any {

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -1,5 +1,5 @@
 use crate::filesystem::vfs::syscall::SpliceFlags;
-use crate::libs::mutex::MutexGuard;
+use crate::libs::mutex::{Mutex, MutexGuard};
 use crate::{
     arch::{ipc::signal::Signal, MMArch},
     filesystem::{
@@ -228,6 +228,12 @@ impl PipeFsPrivateData {
 /// @brief 管道文件i节点(锁)
 #[derive(Debug)]
 pub struct LockedPipeInode {
+    /// Serializes writes and output-side splice operations for this pipe.
+    ///
+    /// Lock order is `writer_transaction` -> `inner`. A blocking writer drops
+    /// this mutex only after publishing its wait predicate under `inner`, then
+    /// reacquires it before rechecking or committing data.
+    writer_transaction: Mutex<()>,
     inner: SpinLock<InnerPipeInode>,
     read_wait_queue: WaitQueue,
     write_wait_queue: WaitQueue,
@@ -236,6 +242,42 @@ pub struct LockedPipeInode {
     epitems: LockedEPItemLinkedList,
     read_fasync_items: FAsyncItems,
     write_fasync_items: FAsyncItems,
+}
+
+/// A serialized writer transaction. Dropping it releases the writer mutex
+/// before passing the exclusive writer-wakeup baton.
+pub(crate) struct PipeWriterTransaction<'a> {
+    pipe: &'a LockedPipeInode,
+    guard: Option<MutexGuard<'a, ()>>,
+    pass_baton: bool,
+}
+
+impl PipeWriterTransaction<'_> {
+    fn release_for_wait(&mut self) {
+        drop(self.guard.take());
+    }
+
+    fn reacquire_after_wait(&mut self) {
+        debug_assert!(self.guard.is_none());
+        self.guard = Some(self.pipe.writer_transaction.lock());
+    }
+
+    fn pass_baton_if_waiters_remain(&mut self, inner: &InnerPipeInode) {
+        self.pass_baton |= !inner.write_waiters.is_empty();
+    }
+}
+
+impl Drop for PipeWriterTransaction<'_> {
+    fn drop(&mut self) {
+        drop(self.guard.take());
+        if self.pass_baton {
+            let writer_wake = {
+                let mut inner = self.pipe.inner.lock();
+                LockedPipeInode::writer_wake_action(&mut inner)
+            };
+            self.pipe.wake_writers(writer_wake);
+        }
+    }
 }
 
 /// @brief 管道文件i节点(无锁)
@@ -411,6 +453,15 @@ impl InnerPipeInode {
 
 impl LockedPipeInode {
     #[inline]
+    pub(crate) fn begin_writer_transaction(&self) -> PipeWriterTransaction<'_> {
+        PipeWriterTransaction {
+            pipe: self,
+            guard: Some(self.writer_transaction.lock()),
+            pass_baton: false,
+        }
+    }
+
+    #[inline]
     fn writer_wake_action(inner: &mut InnerPipeInode) -> PipeWriterWake {
         let used = inner.valid_cnt.max(0) as usize;
         let available = inner.buf_size.saturating_sub(used);
@@ -561,6 +612,7 @@ impl LockedPipeInode {
             w_counter: 0,   // 初始化写端计数器
         };
         let result = Arc::new(Self {
+            writer_transaction: Mutex::new(()),
             inner: SpinLock::new(inner),
             read_wait_queue: WaitQueue::default(),
             write_wait_queue: WaitQueue::default(),
@@ -622,6 +674,7 @@ impl LockedPipeInode {
         &'a self,
         mut guard: crate::libs::spinlock::SpinLockGuard<'a, InnerPipeInode>,
         required: Option<usize>,
+        transaction: &mut PipeWriterTransaction<'a>,
         before_wait: F,
     ) -> (
         crate::libs::spinlock::SpinLockGuard<'a, InnerPipeInode>,
@@ -634,6 +687,7 @@ impl LockedPipeInode {
         drop(guard);
 
         before_wait();
+        transaction.release_for_wait();
         let result = if let Some(need) = required {
             self.write_wait_queue
                 .wait_event_interruptible_tagged(waiter_class, || self.writeable_len_at_least(need))
@@ -642,8 +696,10 @@ impl LockedPipeInode {
                 .wait_event_interruptible_tagged(waiter_class, || self.writeable())
         };
 
+        transaction.reacquire_after_wait();
         let mut guard = self.inner.lock();
         guard.write_waiters.unregister(required);
+        transaction.pass_baton_if_waiters_remain(&guard);
         let result = result.map_err(|_| SystemError::ERESTARTSYS);
         (guard, result)
     }
@@ -697,6 +753,7 @@ impl LockedPipeInode {
         // 确保不大于最大值
         let new_size = new_size.min(PIPE_MAX_SIZE);
 
+        let transaction = self.begin_writer_transaction();
         let mut inner = self.inner.lock();
 
         // 如果新大小小于当前数据量，返回 EBUSY
@@ -750,6 +807,7 @@ impl LockedPipeInode {
         let writer_wake = Self::writer_wake_action(&mut inner);
         let pollflag = inner.poll_both_ends();
         drop(inner);
+        drop(transaction);
 
         self.wake_writers(writer_wake);
         let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
@@ -791,18 +849,6 @@ impl LockedPipeInode {
         inner_guard.valid_cnt += to_write as i32;
     }
 
-    pub(crate) fn finish_writer_wait(&self, wake_next_writer: bool) {
-        if !wake_next_writer {
-            return;
-        }
-
-        let writer_wake = {
-            let mut inner = self.inner.lock();
-            Self::writer_wake_action(&mut inner)
-        };
-        self.wake_writers(writer_wake);
-    }
-
     /// Preserve exclusive reader-wakeup progress when a selected waiter exits
     /// without consuming data (for example, because a signal interrupted it).
     fn finish_interrupted_reader_wait(&self) {
@@ -840,6 +886,7 @@ impl LockedPipeInode {
             return Ok(0);
         }
 
+        let mut transaction = self.begin_writer_transaction();
         let mut inner_guard = self.inner.lock();
         let atomic_write = len <= PIPE_BUF;
 
@@ -855,21 +902,15 @@ impl LockedPipeInode {
         }
 
         let mut total_written: usize = 0;
-        let mut wake_next_writer = false;
         let mut reader_wake = WakeMode::None;
         let mut progress_pending = false;
 
         while total_written < len {
             if inner_guard.reader == 0 {
                 let pollflag = progress_pending.then(|| inner_guard.poll_both_ends());
-                let writer_wake =
-                    wake_next_writer.then(|| Self::writer_wake_action(&mut inner_guard));
                 drop(inner_guard);
                 if let Some(pollflag) = pollflag {
                     self.publish_write_progress(reader_wake, pollflag);
-                }
-                if let Some(writer_wake) = writer_wake {
-                    self.wake_writers(writer_wake);
                 }
                 Self::send_sigpipe();
                 return if total_written > 0 {
@@ -895,14 +936,9 @@ impl LockedPipeInode {
                 reader_wake = WakeMode::None;
 
                 if flags.contains(FileFlags::O_NONBLOCK) {
-                    let writer_wake =
-                        wake_next_writer.then(|| Self::writer_wake_action(&mut inner_guard));
                     drop(inner_guard);
                     if let Some(pollflag) = pending_poll {
                         self.publish_write_progress(pending_reader_wake, pollflag);
-                    }
-                    if let Some(writer_wake) = writer_wake {
-                        self.wake_writers(writer_wake);
                     }
                     if total_written > 0 {
                         return Ok(total_written);
@@ -911,18 +947,16 @@ impl LockedPipeInode {
                 }
 
                 let required = (atomic_write && total_written == 0).then_some(len);
-                let (guard, wait_result) = self.wait_for_write_space(inner_guard, required, || {
-                    if let Some(pollflag) = pending_poll {
-                        self.publish_write_progress(pending_reader_wake, pollflag);
-                    }
-                });
+                let (guard, wait_result) =
+                    self.wait_for_write_space(inner_guard, required, &mut transaction, || {
+                        if let Some(pollflag) = pending_poll {
+                            self.publish_write_progress(pending_reader_wake, pollflag);
+                        }
+                    });
                 inner_guard = guard;
-                wake_next_writer = true;
 
                 if let Err(err) = wait_result {
-                    let writer_wake = Self::writer_wake_action(&mut inner_guard);
                     drop(inner_guard);
-                    self.wake_writers(writer_wake);
                     return if total_written > 0 {
                         Ok(total_written)
                     } else {
@@ -940,6 +974,7 @@ impl LockedPipeInode {
                 to_write,
             );
             total_written += to_write;
+            transaction.pass_baton_if_waiters_remain(&inner_guard);
             progress_pending = true;
             if !was_readable && inner_guard.splice_hold == 0 {
                 reader_wake = WakeMode::One;
@@ -947,28 +982,24 @@ impl LockedPipeInode {
         }
 
         let pollflag = inner_guard.poll_both_ends();
-        let writer_wake = wake_next_writer.then(|| Self::writer_wake_action(&mut inner_guard));
         drop(inner_guard);
         if progress_pending {
             self.publish_write_progress(reader_wake, pollflag);
-        }
-        if let Some(writer_wake) = writer_wake {
-            self.wake_writers(writer_wake);
         }
 
         Ok(total_written)
     }
 
-    pub(crate) fn write_from_splice_blocking(&self, buf: &[u8]) -> Result<usize, SystemError> {
-        // The syscall layer has already folded the output pipe's O_NONBLOCK
-        // state into SPLICE_F_NONBLOCK. Reaching this helper therefore means
-        // this particular splice operation is blocking.
-        self.write_with_flags(buf.len(), buf, FileFlags::empty())
-    }
-
-    /// Nonblocking write helper for splice(2) paths that must ignore the pipe FD's O_NONBLOCK flag.
-    /// This never sleeps; it returns EAGAIN when no space is available.
-    pub fn write_from_splice_nonblock(&self, buf: &[u8]) -> Result<usize, SystemError> {
+    /// Commit file data to this pipe while holding its writer transaction.
+    /// Space and reader presence were checked before the input read; close,
+    /// resize, and competing writers take the same transaction mutex, so this
+    /// commit never needs to drop the transaction and wait.
+    pub(crate) fn write_from_splice_locked(
+        &self,
+        transaction: &mut PipeWriterTransaction<'_>,
+        buf: &[u8],
+    ) -> Result<usize, SystemError> {
+        debug_assert!(core::ptr::eq(transaction.pipe, self));
         let len = buf.len();
         if len == 0 {
             return Ok(0);
@@ -1013,6 +1044,7 @@ impl LockedPipeInode {
         };
 
         let pollflag = inner_guard.poll_both_ends();
+        transaction.pass_baton_if_waiters_remain(&inner_guard);
         drop(inner_guard);
         Self::wake_waiters(&self.read_wait_queue, reader_wake);
         let _ = EventPoll::wakeup_epoll(&self.epitems, pollflag);
@@ -1027,16 +1059,20 @@ impl LockedPipeInode {
     /// from the input file for this splice attempt. DragonOS pipes are byte-ring
     /// based, so requests up to PIPE_BUF wait for the complete readable chunk;
     /// larger requests wait for any space and may complete partially. The
-    /// boolean return value tells the caller to pass the writer baton after it
-    /// has consumed the reserved space (or abandoned the operation).
-    pub fn wait_writable_for_splice(&self, len: usize) -> Result<(usize, bool), SystemError> {
+    /// caller retains `transaction`, so the returned capacity remains valid
+    /// through the input read and non-waiting commit.
+    pub(crate) fn wait_writable_for_splice<'a>(
+        &'a self,
+        transaction: &mut PipeWriterTransaction<'a>,
+        len: usize,
+    ) -> Result<usize, SystemError> {
+        debug_assert!(core::ptr::eq(transaction.pipe, self));
         if len == 0 {
-            return Ok((0, false));
+            return Ok(0);
         }
 
         let need_atomic = len <= PIPE_BUF;
         let mut guard = self.inner.lock();
-        let mut wake_next_writer = false;
         loop {
             if guard.reader == 0 {
                 drop(guard);
@@ -1048,17 +1084,15 @@ impl LockedPipeInode {
             let space = guard.buf_size.saturating_sub(used);
             if (need_atomic && space >= len) || (!need_atomic && space > 0) {
                 let writable = if need_atomic { len } else { len.min(space) };
-                return Ok((writable, wake_next_writer));
+                return Ok(writable);
             }
 
             let required = need_atomic.then_some(len);
-            let (next_guard, wait_result) = self.wait_for_write_space(guard, required, || {});
+            let (next_guard, wait_result) =
+                self.wait_for_write_space(guard, required, transaction, || {});
             guard = next_guard;
-            wake_next_writer = true;
             if let Err(err) = wait_result {
-                let writer_wake = Self::writer_wake_action(&mut guard);
                 drop(guard);
-                self.wake_writers(writer_wake);
                 return Err(err);
             }
         }
@@ -1068,12 +1102,14 @@ impl LockedPipeInode {
     ///
     /// This matches Linux `wait_for_space()` for inputs whose exact readable
     /// length is not known before calling into the file. The caller can then
-    /// cap the read by the returned byte space. The boolean return value tells
-    /// the caller to pass the writer baton after it has consumed the reserved
-    /// space (or abandoned the operation).
-    pub fn wait_writable_any_for_splice(&self) -> Result<(usize, bool), SystemError> {
+    /// cap the read by the returned byte space while retaining the writer
+    /// transaction through the input read and non-waiting commit.
+    pub(crate) fn wait_writable_any_for_splice<'a>(
+        &'a self,
+        transaction: &mut PipeWriterTransaction<'a>,
+    ) -> Result<usize, SystemError> {
+        debug_assert!(core::ptr::eq(transaction.pipe, self));
         let mut guard = self.inner.lock();
-        let mut wake_next_writer = false;
         loop {
             if guard.reader == 0 {
                 drop(guard);
@@ -1084,19 +1120,53 @@ impl LockedPipeInode {
             let used = guard.valid_cnt.max(0) as usize;
             let space = guard.buf_size.saturating_sub(used);
             if space > 0 {
-                return Ok((space, wake_next_writer));
+                return Ok(space);
             }
 
-            let (next_guard, wait_result) = self.wait_for_write_space(guard, None, || {});
+            let (next_guard, wait_result) =
+                self.wait_for_write_space(guard, None, transaction, || {});
             guard = next_guard;
-            wake_next_writer = true;
             if let Err(err) = wait_result {
-                let writer_wake = Self::writer_wake_action(&mut guard);
                 drop(guard);
-                self.wake_writers(writer_wake);
                 return Err(err);
             }
         }
+    }
+
+    /// Check file->pipe splice output conditions without sleeping while the
+    /// writer transaction is held. This check happens before consuming input.
+    pub(crate) fn writable_for_splice_nonblock(
+        &self,
+        transaction: &PipeWriterTransaction<'_>,
+        wanted: Option<usize>,
+    ) -> Result<usize, SystemError> {
+        debug_assert!(core::ptr::eq(transaction.pipe, self));
+        let guard = self.inner.lock();
+        if guard.reader == 0 {
+            drop(guard);
+            Self::send_sigpipe();
+            return Err(SystemError::EPIPE);
+        }
+        let used = guard.valid_cnt.max(0) as usize;
+        let space = guard.buf_size.saturating_sub(used);
+        if space == 0 || wanted.is_some_and(|len| len <= PIPE_BUF && space < len) {
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        }
+        Ok(wanted.map_or(space, |len| len.min(space)))
+    }
+
+    /// Validate the output endpoint before file->pipe splice consumes input.
+    pub(crate) fn ensure_splice_readers(
+        &self,
+        transaction: &PipeWriterTransaction<'_>,
+    ) -> Result<(), SystemError> {
+        debug_assert!(core::ptr::eq(transaction.pipe, self));
+        let has_readers = self.inner.lock().reader > 0;
+        if !has_readers {
+            Self::send_sigpipe();
+            return Err(SystemError::EPIPE);
+        }
+        Ok(())
     }
 
     /// 从管道中“窥视”最多 `len` 字节数据到 `buf`，但不消耗管道数据。
@@ -1279,34 +1349,36 @@ impl LockedPipeInode {
 
     /// Helper: Wait until the pipe is writable (has space).
     /// Returns:
-    /// - Ok(waited): Space is available; `waited` requests a post-transfer
-    ///   writer-baton wakeup.
+    /// - Ok(()): Space is available while the destination writer transaction
+    ///   remains held.
     /// - Err(e): Interrupted, EAGAIN, or EPIPE (no readers).
-    fn wait_writable(&self, nonblock: bool) -> Result<bool, SystemError> {
+    fn wait_writable<'a>(
+        &'a self,
+        transaction: &mut PipeWriterTransaction<'a>,
+        nonblock: bool,
+    ) -> Result<(), SystemError> {
+        debug_assert!(core::ptr::eq(transaction.pipe, self));
         let mut guard = self.inner.lock();
-        let mut wake_next_writer = false;
         loop {
-            let space = guard
-                .buf_size
-                .saturating_sub(guard.valid_cnt.max(0) as usize);
-            if space > 0 {
-                return Ok(wake_next_writer);
-            }
             if guard.reader == 0 {
                 drop(guard);
                 Self::send_sigpipe();
                 return Err(SystemError::EPIPE);
             }
+            let space = guard
+                .buf_size
+                .saturating_sub(guard.valid_cnt.max(0) as usize);
+            if space > 0 {
+                return Ok(());
+            }
             if nonblock {
                 return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
             }
-            let (next_guard, wait_result) = self.wait_for_write_space(guard, None, || {});
+            let (next_guard, wait_result) =
+                self.wait_for_write_space(guard, None, transaction, || {});
             guard = next_guard;
-            wake_next_writer = true;
             if let Err(err) = wait_result {
-                let writer_wake = Self::writer_wake_action(&mut guard);
                 drop(guard);
-                self.wake_writers(writer_wake);
                 return Err(err);
             }
         }
@@ -1321,6 +1393,7 @@ impl LockedPipeInode {
     fn transfer_chunk<F>(
         src: &LockedPipeInode,
         dst: &LockedPipeInode,
+        transaction: &mut PipeWriterTransaction<'_>,
         len: usize,
         consume: bool,
         skip_calculator: F,
@@ -1328,6 +1401,7 @@ impl LockedPipeInode {
     where
         F: FnOnce(&InnerPipeInode) -> usize,
     {
+        debug_assert!(core::ptr::eq(transaction.pipe, dst));
         // Lock both pipes
         let (mut in_guard, mut out_guard) = Self::lock_two(src, dst);
 
@@ -1392,6 +1466,7 @@ impl LockedPipeInode {
 
         let in_poll = consume.then(|| in_guard.poll_both_ends());
         let out_poll = out_guard.poll_both_ends();
+        transaction.pass_baton_if_waiters_remain(&out_guard);
         drop(in_guard);
         drop(out_guard);
 
@@ -1432,13 +1507,14 @@ impl LockedPipeInode {
                 return Ok(0); // EOF
             }
 
-            // Wait for output space
-            let wake_next_writer = out.wait_writable(nonblock)?;
+            // Serialize only the destination writer side. The source pipe is
+            // protected by its inner lock during the actual transfer, avoiding
+            // writer-mutex ABBA between opposite-direction splices.
+            let mut transaction = out.begin_writer_transaction();
+            out.wait_writable(&mut transaction, nonblock)?;
 
             // Try transfer
-            let transfer = Self::transfer_chunk(self, out, len, true, |_| 0);
-            out.finish_writer_wait(wake_next_writer);
-            let copied = transfer?;
+            let copied = Self::transfer_chunk(self, out, &mut transaction, len, true, |_| 0)?;
             if copied > 0 {
                 return Ok(copied);
             }
@@ -1484,6 +1560,7 @@ impl LockedPipeInode {
 
             // Check output space
             // tee has special nonblock handling: return total if > 0
+            let mut transaction = out.begin_writer_transaction();
             let (out_space, out_has_readers) = {
                 let guard = out.inner.lock();
                 let used = guard.valid_cnt.max(0) as usize;
@@ -1497,7 +1574,6 @@ impl LockedPipeInode {
                     Err(SystemError::EPIPE)
                 };
             }
-            let mut wake_next_writer = false;
             if out_space == 0 {
                 if nonblock || total > 0 {
                     if total > 0 {
@@ -1506,39 +1582,45 @@ impl LockedPipeInode {
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
                 }
                 // force blocking wait
-                wake_next_writer = out.wait_writable(false)?;
+                out.wait_writable(&mut transaction, false)?;
             }
 
-            let transfer = Self::transfer_chunk(self, out, len - total, false, |in_guard| {
-                if in_avail_snapshot.is_none() {
-                    in_avail_snapshot = Some(in_guard.valid_cnt.max(0) as usize);
-                    in_read_pos_snapshot = Some(in_guard.read_pos.max(0) as usize);
-                    in_buf_size_snapshot = Some(in_guard.buf_size);
-                }
-
-                let snapshot = in_avail_snapshot.unwrap();
-                if total >= snapshot {
-                    return usize::MAX; // Signal to skip everything
-                }
-
-                let mut skip = total;
-                if let (Some(start_read_pos), Some(start_buf_size)) =
-                    (in_read_pos_snapshot, in_buf_size_snapshot)
-                {
-                    if start_buf_size == in_guard.buf_size {
-                        let cur_read_pos = in_guard.read_pos.max(0) as usize;
-                        skip = Self::tee_adjusted_skip(
-                            start_read_pos,
-                            cur_read_pos,
-                            start_buf_size,
-                            snapshot,
-                            total,
-                        );
+            let transfer = Self::transfer_chunk(
+                self,
+                out,
+                &mut transaction,
+                len - total,
+                false,
+                |in_guard| {
+                    if in_avail_snapshot.is_none() {
+                        in_avail_snapshot = Some(in_guard.valid_cnt.max(0) as usize);
+                        in_read_pos_snapshot = Some(in_guard.read_pos.max(0) as usize);
+                        in_buf_size_snapshot = Some(in_guard.buf_size);
                     }
-                }
-                skip
-            });
-            out.finish_writer_wait(wake_next_writer);
+
+                    let snapshot = in_avail_snapshot.unwrap();
+                    if total >= snapshot {
+                        return usize::MAX; // Signal to skip everything
+                    }
+
+                    let mut skip = total;
+                    if let (Some(start_read_pos), Some(start_buf_size)) =
+                        (in_read_pos_snapshot, in_buf_size_snapshot)
+                    {
+                        if start_buf_size == in_guard.buf_size {
+                            let cur_read_pos = in_guard.read_pos.max(0) as usize;
+                            skip = Self::tee_adjusted_skip(
+                                start_read_pos,
+                                cur_read_pos,
+                                start_buf_size,
+                                snapshot,
+                                total,
+                            );
+                        }
+                    }
+                    skip
+                },
+            );
             let copied = match transfer {
                 Ok(copied) => copied,
                 Err(SystemError::EPIPE) if total > 0 => return Ok(total),
@@ -1661,8 +1743,9 @@ mod tests {
             Ok(4)
         );
         assert_eq!(&held, b"held");
+        let mut transaction = dst.begin_writer_transaction();
         assert_eq!(
-            LockedPipeInode::transfer_chunk(&src, &dst, 4, true, |_| 0),
+            LockedPipeInode::transfer_chunk(&src, &dst, &mut transaction, 4, true, |_| 0),
             Ok(0)
         );
         {
@@ -1673,7 +1756,7 @@ mod tests {
 
         src.splice_finish_hold(0);
         assert_eq!(
-            LockedPipeInode::transfer_chunk(&src, &dst, 4, true, |_| 0),
+            LockedPipeInode::transfer_chunk(&src, &dst, &mut transaction, 4, true, |_| 0),
             Ok(4)
         );
         assert_eq!(src.inner.lock().valid_cnt, 0);
@@ -1997,6 +2080,7 @@ impl IndexNode for LockedPipeInode {
             return Ok(());
         }
 
+        let transaction = self.begin_writer_transaction();
         let mut guard = self.inner.lock();
         match accflags {
             FileFlags::O_RDONLY => {
@@ -2030,6 +2114,7 @@ impl IndexNode for LockedPipeInode {
             PipeWriterWake::None
         };
         drop(guard);
+        drop(transaction);
 
         if release_notify {
             self.read_wait_queue.wakeup_all(None);

--- a/kernel/src/libs/wait_queue.rs
+++ b/kernel/src/libs/wait_queue.rs
@@ -14,7 +14,7 @@ use core::{
 
 use alloc::{
     boxed::Box,
-    collections::VecDeque,
+    collections::{BTreeMap, VecDeque},
     rc::Rc,
     sync::{Arc, Weak},
     vec::Vec,
@@ -43,10 +43,14 @@ enum WaitSignalMode {
     Killable,
 }
 
+const DEFAULT_WAIT_TAG: usize = usize::MAX;
+const EMPTY_TAG_CACHE_LIMIT: usize = 8;
+
 #[derive(Debug)]
 struct InnerWaitQueue {
     dead: bool,
-    waiters: VecDeque<Arc<Waker>>,
+    waiters: BTreeMap<usize, VecDeque<Arc<Waker>>>,
+    empty_tag_count: usize,
 }
 
 /// 等待队列：基于一次性 Waiter/Waker，避免唤醒丢失
@@ -66,6 +70,7 @@ pub struct Waiter {
 #[derive(Debug)]
 pub struct Waker {
     state: AtomicU8,
+    tag: usize,
     target: Weak<ProcessControlBlock>,
 }
 
@@ -83,20 +88,38 @@ impl WaitQueue {
         if guard.dead {
             return Err(SystemError::ECHILD);
         }
-        guard.waiters.push_back(waker);
+        if waker.tag != DEFAULT_WAIT_TAG
+            && guard
+                .waiters
+                .get(&waker.tag)
+                .is_some_and(VecDeque::is_empty)
+        {
+            guard.empty_tag_count -= 1;
+        }
+        guard.waiters.entry(waker.tag).or_default().push_back(waker);
         self.num_waiters.fetch_add(1, Ordering::Release);
         Ok(())
     }
 
     pub fn remove_waker(&self, target: &Arc<Waker>) {
         let mut guard = self.inner.lock_irqsave();
-        let before = guard.waiters.len();
-        guard.waiters.retain(|w| !Arc::ptr_eq(w, target));
-        let removed = before - guard.waiters.len();
+        let (removed, became_empty) = if let Some(waiters) = guard.waiters.get_mut(&target.tag) {
+            let before = waiters.len();
+            waiters.retain(|w| !Arc::ptr_eq(w, target));
+            let removed = before - waiters.len();
+            (removed, removed > 0 && waiters.is_empty())
+        } else {
+            (0, false)
+        };
         if removed > 0 {
             self.num_waiters
                 .fetch_sub(removed as u32, Ordering::Release);
         }
+        let evicted = became_empty
+            .then(|| guard.cache_or_evict_empty_tag(target.tag))
+            .flatten();
+        drop(guard);
+        drop(evicted);
     }
 
     pub fn is_empty(&self) -> bool {
@@ -255,17 +278,41 @@ impl WaitQueue {
     /// - This ensures no wakeup is lost between check and sleep
     fn wait_until_impl<F, R, B>(
         &self,
-        mut cond: F,
+        cond: F,
         mode: WaitSignalMode,
         timeout: Option<Duration>,
         timeout_ticks: Option<u64>,
-        mut before_sleep: Option<B>,
+        before_sleep: Option<B>,
         is_io: bool,
     ) -> Result<R, SystemError>
     where
         F: FnMut() -> Option<R>,
         B: FnMut(),
     {
+        self.wait_until_impl_tagged(
+            cond,
+            mode,
+            timeout,
+            timeout_ticks,
+            before_sleep,
+            (is_io, DEFAULT_WAIT_TAG),
+        )
+    }
+
+    fn wait_until_impl_tagged<F, R, B>(
+        &self,
+        mut cond: F,
+        mode: WaitSignalMode,
+        timeout: Option<Duration>,
+        timeout_ticks: Option<u64>,
+        mut before_sleep: Option<B>,
+        wait_class: (bool, usize),
+    ) -> Result<R, SystemError>
+    where
+        F: FnMut() -> Option<R>,
+        B: FnMut(),
+    {
+        let (is_io, tag) = wait_class;
         // Fast path: check condition first
         if let Some(res) = cond() {
             return Ok(res);
@@ -278,7 +325,7 @@ impl WaitQueue {
             .or_else(|| timeout.map(|duration| next_n_us_timer_jiffies(duration.total_micros())));
 
         // Create only ONE waiter/waker pair (key difference from old implementation)
-        let (waiter, waker) = Waiter::new_pair();
+        let (waiter, waker) = Waiter::new_pair_tagged(tag);
 
         fn cancel_or_timeout<F, R>(
             cond: &mut F,
@@ -410,6 +457,30 @@ impl WaitQueue {
             None,
             before_sleep,
             false,
+        )
+    }
+
+    /// Wait interruptibly while publishing a caller-defined class tag on the
+    /// waiter. The tag lets a wakeup source select one eligible class without
+    /// disturbing unrelated waiters on the same queue.
+    pub fn wait_event_interruptible_tagged<F>(
+        &self,
+        tag: usize,
+        mut cond: F,
+    ) -> Result<(), SystemError>
+    where
+        F: FnMut() -> bool,
+    {
+        if tag == DEFAULT_WAIT_TAG {
+            return Err(SystemError::EINVAL);
+        }
+        self.wait_until_impl_tagged(
+            || if cond() { Some(()) } else { None },
+            WaitSignalMode::Interruptible,
+            None,
+            None,
+            None::<fn()>,
+            (false, tag),
         )
     }
 
@@ -578,15 +649,53 @@ impl WaitQueue {
         loop {
             let next = {
                 let mut guard = self.inner.lock_irqsave();
-                let waker = guard.waiters.pop_front();
+                let tagged_waker = guard
+                    .waiters
+                    .iter_mut()
+                    .find_map(|(tag, waiters)| waiters.pop_front().map(|waker| (*tag, waker)));
+                let waker = tagged_waker.as_ref().map(|(_, waker)| waker);
                 if waker.is_some() {
                     self.num_waiters.fetch_sub(1, Ordering::Release);
                 }
-                waker
+                let evicted = tagged_waker
+                    .as_ref()
+                    .filter(|(tag, _)| guard.waiters.get(tag).is_some_and(VecDeque::is_empty))
+                    .and_then(|(tag, _)| guard.cache_or_evict_empty_tag(*tag));
+                drop(guard);
+                drop(evicted);
+                tagged_waker.map(|(_, waker)| waker)
             };
 
             let Some(waker) = next else { return false };
             if waker.wake() {
+                return true;
+            }
+        }
+    }
+
+    /// Wake the first live waiter in an exact caller-defined class.
+    pub fn wake_one_tagged(&self, tag: usize) -> bool {
+        if tag == DEFAULT_WAIT_TAG {
+            return false;
+        }
+        loop {
+            let next = {
+                let mut guard = self.inner.lock_irqsave();
+                let waker = guard.waiters.get_mut(&tag).and_then(VecDeque::pop_front);
+                let Some(waker) = waker else { return false };
+                self.num_waiters.fetch_sub(1, Ordering::Release);
+                let evicted = guard
+                    .waiters
+                    .get(&tag)
+                    .is_some_and(VecDeque::is_empty)
+                    .then(|| guard.cache_or_evict_empty_tag(tag))
+                    .flatten();
+                drop(guard);
+                drop(evicted);
+                waker
+            };
+
+            if next.wake() {
                 return true;
             }
         }
@@ -602,18 +711,20 @@ impl WaitQueue {
             return 0;
         }
 
-        let mut drained = VecDeque::new();
+        let drained;
         {
             let mut guard = self.inner.lock_irqsave();
-            mem::swap(&mut guard.waiters, &mut drained);
+            drained = mem::take(&mut guard.waiters);
+            guard.empty_tag_count = 0;
             self.num_waiters.store(0, Ordering::Release);
         }
 
-        let wakers = drained;
         let mut woken = 0;
-        for w in wakers {
-            if w.wake() {
-                woken += 1;
+        for (_, wakers) in drained {
+            for waker in wakers {
+                if waker.wake() {
+                    woken += 1;
+                }
             }
         }
         woken
@@ -621,16 +732,19 @@ impl WaitQueue {
 
     /// 标记等待队列失效，清空并唤醒剩余等待者
     pub fn mark_dead(&self) {
-        let mut drained = VecDeque::new();
+        let drained;
         {
             let mut guard = self.inner.lock_irqsave();
             guard.dead = true;
-            mem::swap(&mut guard.waiters, &mut drained);
+            drained = mem::take(&mut guard.waiters);
+            guard.empty_tag_count = 0;
             self.num_waiters.store(0, Ordering::Release);
         }
-        for w in drained {
-            w.wake();
-            w.close();
+        for (_, wakers) in drained {
+            for waker in wakers {
+                waker.wake();
+                waker.close();
+            }
         }
     }
 
@@ -696,14 +810,32 @@ impl WaitQueue {
 impl InnerWaitQueue {
     pub const INIT: InnerWaitQueue = InnerWaitQueue {
         dead: false,
-        waiters: VecDeque::new(),
+        waiters: BTreeMap::new(),
+        empty_tag_count: 0,
     };
+
+    fn cache_or_evict_empty_tag(&mut self, tag: usize) -> Option<VecDeque<Arc<Waker>>> {
+        if tag == DEFAULT_WAIT_TAG {
+            return None;
+        }
+        if self.empty_tag_count < EMPTY_TAG_CACHE_LIMIT {
+            self.empty_tag_count += 1;
+            None
+        } else {
+            self.waiters.remove(&tag)
+        }
+    }
 }
 
 impl Waiter {
     pub fn new_pair() -> (Self, Arc<Waker>) {
+        Self::new_pair_tagged(DEFAULT_WAIT_TAG)
+    }
+
+    fn new_pair_tagged(tag: usize) -> (Self, Arc<Waker>) {
         let waker = Arc::new(Waker {
             state: AtomicU8::new(Waker::STATE_IDLE),
+            tag,
             target: Arc::downgrade(&ProcessManager::current_pcb()),
         });
         let waiter = Waiter {

--- a/user/apps/tests/dunitest/suites/normal/pipe_waitqueue_wakeup.cc
+++ b/user/apps/tests/dunitest/suites/normal/pipe_waitqueue_wakeup.cc
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
+#include <sys/socket.h>
 #include <string.h>
 #include <sys/epoll.h>
 #include <sys/wait.h>
@@ -198,6 +199,39 @@ bool ReadExactly(int fd, size_t len) {
     return true;
 }
 
+bool ReadAllInto(int fd, char* data, size_t len) {
+    size_t read_bytes = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (read_bytes < len) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+            return false;
+        }
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+        pollfd wait_fd {};
+        wait_fd.fd = fd;
+        wait_fd.events = POLLIN | POLLHUP;
+        const int ready = poll(&wait_fd, 1, static_cast<int>(std::max<int64_t>(1, remaining)));
+        if (ready < 0 && errno == EINTR) {
+            continue;
+        }
+        if (ready <= 0) {
+            return false;
+        }
+        const ssize_t n = read(fd, data + read_bytes, len - read_bytes);
+        if (n > 0) {
+            read_bytes += static_cast<size_t>(n);
+            continue;
+        }
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
 bool FillPipeExactly(int write_fd, size_t capacity) {
     const int old_flags = fcntl(write_fd, F_GETFL);
     if (old_flags < 0 || fcntl(write_fd, F_SETFL, old_flags | O_NONBLOCK) != 0) {
@@ -274,6 +308,40 @@ TEST(PipeWaitqueueWakeup, NonblockingWriteWithoutReaderRaisesSigpipe) {
     EXPECT_EQ(1, g_sigpipe_count);
 
     close(fds[1]);
+}
+
+TEST(PipeWaitqueueWakeup, NonblockingSocketSpliceWithoutReaderDoesNotConsumeInput) {
+    int source[2] = {-1, -1};
+    int destination[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, source)) << strerror(errno);
+    ASSERT_EQ(0, pipe(destination)) << strerror(errno);
+
+    const char payload[] = "splice-input";
+    ASSERT_TRUE(WriteAll(source[1], payload, sizeof(payload))) << strerror(errno);
+
+    struct sigaction action {};
+    action.sa_handler = SigpipeHandler;
+    sigemptyset(&action.sa_mask);
+    ScopedSignalAction sigpipe_guard(SIGPIPE);
+    ASSERT_TRUE(sigpipe_guard.Install(action)) << strerror(errno);
+    g_sigpipe_count = 0;
+
+    ASSERT_EQ(0, close(destination[0])) << strerror(errno);
+    destination[0] = -1;
+    errno = 0;
+    EXPECT_EQ(-1, splice(source[0], nullptr, destination[1], nullptr, sizeof(payload),
+                         SPLICE_F_NONBLOCK));
+    EXPECT_EQ(EPIPE, errno);
+    EXPECT_EQ(1, g_sigpipe_count);
+
+    char received[sizeof(payload)] = {};
+    ASSERT_TRUE(ReadAllInto(source[0], received, sizeof(received))) << strerror(errno);
+    EXPECT_EQ(0, memcmp(payload, received, sizeof(payload)))
+        << "failed splice consumed stream input before reporting EPIPE";
+
+    close(source[0]);
+    close(source[1]);
+    close(destination[1]);
 }
 
 TEST(PipeWaitqueueWakeup, EligibleWriterIsNotBlockedBehindLargerWriter) {
@@ -624,6 +692,114 @@ TEST(PipeWaitqueueWakeup, PipeToPipeSpliceWakesSourceWriterAndDestinationReader)
     EXPECT_EQ(0, WEXITSTATUS(writer_status));
     ASSERT_TRUE(WIFEXITED(reader_status));
     EXPECT_EQ(0, WEXITSTATUS(reader_status));
+
+    close(source[0]);
+    close(source[1]);
+    close(destination[0]);
+    close(destination[1]);
+}
+
+TEST(PipeWaitqueueWakeup, BlockingSocketSpliceKeepsObservedPipeSpace) {
+    int source[2] = {-1, -1};
+    int destination[2] = {-1, -1};
+    int splice_ready[2] = {-1, -1};
+    int writer_ready[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, source)) << strerror(errno);
+    ASSERT_EQ(0, pipe(destination)) << strerror(errno);
+    ASSERT_EQ(0, pipe(splice_ready)) << strerror(errno);
+    ASSERT_EQ(0, pipe(writer_ready)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(destination[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+    ASSERT_TRUE(FillPipeExactly(destination[1], 4096)) << strerror(errno);
+
+    pid_t splice_worker = fork();
+    ASSERT_GE(splice_worker, 0) << strerror(errno);
+    ChildProcessGuard splice_guard(splice_worker);
+    if (splice_worker == 0) {
+        close(source[1]);
+        close(destination[0]);
+        close(splice_ready[0]);
+        close(writer_ready[0]);
+        close(writer_ready[1]);
+        const char marker = 'S';
+        if (!WriteAll(splice_ready[1], &marker, 1)) {
+            _exit(2);
+        }
+        close(splice_ready[1]);
+        const ssize_t copied =
+            splice(source[0], nullptr, destination[1], nullptr, 4096, 0);
+        _exit(copied == 4096 ? 0 : 3);
+    }
+
+    close(splice_ready[1]);
+    char marker = 0;
+    ASSERT_EQ(1, read(splice_ready[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('S', marker);
+    close(splice_ready[0]);
+    if (!WaitForSleepingProcess(splice_worker)) {
+        FAIL() << "splice worker did not wait for destination space";
+    }
+
+    pid_t writer = fork();
+    ASSERT_GE(writer, 0) << strerror(errno);
+    ChildProcessGuard writer_guard(writer);
+    if (writer == 0) {
+        close(source[0]);
+        close(source[1]);
+        close(destination[0]);
+        close(splice_ready[0]);
+        close(splice_ready[1]);
+        close(writer_ready[0]);
+        const char ready = 'W';
+        if (!WriteAll(writer_ready[1], &ready, 1)) {
+            _exit(4);
+        }
+        close(writer_ready[1]);
+        const char byte = 'w';
+        _exit(write(destination[1], &byte, 1) == 1 ? 0 : 5);
+    }
+
+    close(writer_ready[1]);
+    marker = 0;
+    ASSERT_EQ(1, read(writer_ready[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('W', marker);
+    close(writer_ready[0]);
+    if (!WaitForSleepingProcess(writer)) {
+        FAIL() << "competing writer did not wait for destination space";
+    }
+
+    std::vector<char> drained(4096);
+    ASSERT_TRUE(ReadAllInto(destination[0], drained.data(), drained.size())) << strerror(errno);
+
+    int writer_status = 0;
+    if (WaitForChild(writer, &writer_status, 20)) {
+        writer_guard.Release();
+        FAIL() << "competing writer stole space owned by the blocked splice";
+    }
+
+    std::vector<char> payload(4096, 's');
+    ASSERT_TRUE(WriteAll(source[1], payload.data(), payload.size())) << strerror(errno);
+
+    int splice_status = 0;
+    if (!WaitForChild(splice_worker, &splice_status)) {
+        FAIL() << "splice did not commit after input became readable";
+    }
+    splice_guard.Release();
+    ASSERT_TRUE(WIFEXITED(splice_status));
+    ASSERT_EQ(0, WEXITSTATUS(splice_status));
+
+    std::vector<char> copied(4096);
+    ASSERT_TRUE(ReadAllInto(destination[0], copied.data(), copied.size())) << strerror(errno);
+    EXPECT_EQ(payload, copied);
+
+    if (!WaitForChild(writer, &writer_status)) {
+        FAIL() << "competing writer did not proceed after splice data was drained";
+    }
+    writer_guard.Release();
+    ASSERT_TRUE(WIFEXITED(writer_status));
+    ASSERT_EQ(0, WEXITSTATUS(writer_status));
+    char writer_byte = 0;
+    ASSERT_EQ(1, read(destination[0], &writer_byte, 1)) << strerror(errno);
+    EXPECT_EQ('w', writer_byte);
 
     close(source[0]);
     close(source[1]);

--- a/user/apps/tests/dunitest/suites/normal/pipe_waitqueue_wakeup.cc
+++ b/user/apps/tests/dunitest/suites/normal/pipe_waitqueue_wakeup.cc
@@ -124,6 +124,29 @@ private:
     pid_t child_ = -1;
 };
 
+class ScopedSignalAction {
+public:
+    explicit ScopedSignalAction(int signal) : signal_(signal) {}
+    ScopedSignalAction(const ScopedSignalAction&) = delete;
+    ScopedSignalAction& operator=(const ScopedSignalAction&) = delete;
+
+    ~ScopedSignalAction() {
+        if (installed_) {
+            sigaction(signal_, &old_action_, nullptr);
+        }
+    }
+
+    bool Install(const struct sigaction& action) {
+        installed_ = sigaction(signal_, &action, &old_action_) == 0;
+        return installed_;
+    }
+
+private:
+    int signal_;
+    bool installed_ = false;
+    struct sigaction old_action_ {};
+};
+
 bool WriteAll(int fd, const char* data, size_t len) {
     size_t written = 0;
     while (written < len) {
@@ -214,10 +237,10 @@ TEST(PipeWaitqueueWakeup, ZeroLengthIoHasNoEndpointSideEffects) {
     EXPECT_EQ(0, read(fds[0], &byte, 0)) << strerror(errno);
 
     struct sigaction action {};
-    struct sigaction old_action {};
     action.sa_handler = SigpipeHandler;
     sigemptyset(&action.sa_mask);
-    ASSERT_EQ(0, sigaction(SIGPIPE, &action, &old_action)) << strerror(errno);
+    ScopedSignalAction sigpipe_guard(SIGPIPE);
+    ASSERT_TRUE(sigpipe_guard.Install(action)) << strerror(errno);
     g_sigpipe_count = 0;
 
     ASSERT_EQ(0, close(fds[0])) << strerror(errno);
@@ -225,7 +248,6 @@ TEST(PipeWaitqueueWakeup, ZeroLengthIoHasNoEndpointSideEffects) {
     EXPECT_EQ(0, write(fds[1], &byte, 0)) << strerror(errno);
     EXPECT_EQ(0, g_sigpipe_count);
 
-    ASSERT_EQ(0, sigaction(SIGPIPE, &old_action, nullptr)) << strerror(errno);
     close(fds[1]);
 }
 
@@ -238,10 +260,10 @@ TEST(PipeWaitqueueWakeup, NonblockingWriteWithoutReaderRaisesSigpipe) {
     ASSERT_EQ(0, fcntl(fds[1], F_SETFL, flags | O_NONBLOCK)) << strerror(errno);
 
     struct sigaction action {};
-    struct sigaction old_action {};
     action.sa_handler = SigpipeHandler;
     sigemptyset(&action.sa_mask);
-    ASSERT_EQ(0, sigaction(SIGPIPE, &action, &old_action)) << strerror(errno);
+    ScopedSignalAction sigpipe_guard(SIGPIPE);
+    ASSERT_TRUE(sigpipe_guard.Install(action)) << strerror(errno);
     g_sigpipe_count = 0;
 
     ASSERT_EQ(0, close(fds[0])) << strerror(errno);
@@ -251,7 +273,6 @@ TEST(PipeWaitqueueWakeup, NonblockingWriteWithoutReaderRaisesSigpipe) {
     EXPECT_EQ(EPIPE, errno);
     EXPECT_EQ(1, g_sigpipe_count);
 
-    ASSERT_EQ(0, sigaction(SIGPIPE, &old_action, nullptr)) << strerror(errno);
     close(fds[1]);
 }
 
@@ -358,6 +379,61 @@ TEST(PipeWaitqueueWakeup, EligibleWriterIsNotBlockedBehindLargerWriter) {
     close(data[1]);
 }
 
+TEST(PipeWaitqueueWakeup, HomogeneousWritersPassBatonAfterPartialDrain) {
+    int data[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(data)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(data[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+    ASSERT_TRUE(FillPipeExactly(data[1], 4096)) << strerror(errno);
+
+    pid_t writers[2] = {-1, -1};
+    ChildProcessGuard writer_guards[2];
+    for (size_t i = 0; i < 2; ++i) {
+        writers[i] = fork();
+        ASSERT_GE(writers[i], 0) << strerror(errno);
+        writer_guards[i].Reset(writers[i]);
+        if (writers[i] == 0) {
+            close(data[0]);
+            close(ready[0]);
+            const char marker = static_cast<char>('0' + i);
+            if (!WriteAll(ready[1], &marker, 1)) {
+                _exit(2);
+            }
+            close(ready[1]);
+            const char byte = static_cast<char>('a' + i);
+            _exit(write(data[1], &byte, 1) == 1 ? 0 : 3);
+        }
+    }
+
+    close(ready[1]);
+    ASSERT_TRUE(ReadExactly(ready[0], 2)) << strerror(errno);
+    close(ready[0]);
+    for (pid_t writer : writers) {
+        if (!WaitForSleepingProcess(writer)) {
+            writer_guards[0].Cleanup();
+            writer_guards[1].Cleanup();
+            FAIL() << "homogeneous writer did not enter the pipe wait path";
+        }
+    }
+
+    char drained[2] = {};
+    ASSERT_EQ(2, read(data[0], drained, sizeof(drained))) << strerror(errno);
+
+    for (size_t i = 0; i < 2; ++i) {
+        int status = 0;
+        if (!WaitForChild(writers[i], &status)) {
+            FAIL() << "writer baton did not advance every eligible writer";
+        }
+        writer_guards[i].Release();
+        ASSERT_TRUE(WIFEXITED(status));
+        EXPECT_EQ(0, WEXITSTATUS(status));
+    }
+
+    close(data[0]);
+    close(data[1]);
+}
+
 TEST(PipeWaitqueueWakeup, PartialWriteNotifiesEpollBeforeWriterSleeps) {
     int data[2] = {-1, -1};
     int ready[2] = {-1, -1};
@@ -427,10 +503,10 @@ TEST(PipeWaitqueueWakeup, PartialWritePublishesSigioAndReturnsPartialAfterReader
     ASSERT_EQ(4096, fcntl(data[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
 
     struct sigaction sigio_action {};
-    struct sigaction old_sigio_action {};
     sigio_action.sa_handler = SigioHandler;
     sigemptyset(&sigio_action.sa_mask);
-    ASSERT_EQ(0, sigaction(SIGIO, &sigio_action, &old_sigio_action)) << strerror(errno);
+    ScopedSignalAction sigio_guard(SIGIO);
+    ASSERT_TRUE(sigio_guard.Install(sigio_action)) << strerror(errno);
     g_sigio_count = 0;
     ASSERT_EQ(0, fcntl(data[0], F_SETOWN, getpid())) << strerror(errno);
     const int read_flags = fcntl(data[0], F_GETFL);
@@ -482,7 +558,6 @@ TEST(PipeWaitqueueWakeup, PartialWritePublishesSigioAndReturnsPartialAfterReader
     writer_guard.Release();
     ASSERT_TRUE(WIFEXITED(status));
     EXPECT_EQ(0, WEXITSTATUS(status));
-    ASSERT_EQ(0, sigaction(SIGIO, &old_sigio_action, nullptr)) << strerror(errno);
 }
 
 TEST(PipeWaitqueueWakeup, PipeToPipeSpliceWakesSourceWriterAndDestinationReader) {
@@ -561,10 +636,12 @@ TEST(PipeWaitqueueWakeup, TeeReturnsPartialWithoutConsumingSource) {
     int destination[2] = {-1, -1};
     int ready[2] = {-1, -1};
     int release_reader[2] = {-1, -1};
+    int tee_result[2] = {-1, -1};
     ASSERT_EQ(0, pipe(source)) << strerror(errno);
     ASSERT_EQ(0, pipe(destination)) << strerror(errno);
     ASSERT_EQ(0, pipe(ready)) << strerror(errno);
     ASSERT_EQ(0, pipe(release_reader)) << strerror(errno);
+    ASSERT_EQ(0, pipe(tee_result)) << strerror(errno);
     ASSERT_EQ(8192, fcntl(source[1], F_SETPIPE_SZ, 8192)) << strerror(errno);
     ASSERT_EQ(4096, fcntl(destination[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
     std::vector<char> payload(8192, 't');
@@ -579,6 +656,8 @@ TEST(PipeWaitqueueWakeup, TeeReturnsPartialWithoutConsumingSource) {
         close(destination[1]);
         close(ready[0]);
         close(release_reader[1]);
+        close(tee_result[0]);
+        close(tee_result[1]);
         const char marker = 'T';
         if (!WriteAll(ready[1], &marker, 1)) {
             _exit(2);
@@ -603,7 +682,39 @@ TEST(PipeWaitqueueWakeup, TeeReturnsPartialWithoutConsumingSource) {
         FAIL() << "tee destination reader did not block";
     }
 
-    const ssize_t copied = tee(source[0], destination[1], payload.size(), 0);
+    struct TeeResult {
+        ssize_t copied;
+        int error;
+    };
+    pid_t tee_worker = fork();
+    ASSERT_GE(tee_worker, 0) << strerror(errno);
+    ChildProcessGuard tee_worker_guard(tee_worker);
+    if (tee_worker == 0) {
+        close(tee_result[0]);
+        errno = 0;
+        TeeResult result {};
+        result.copied = tee(source[0], destination[1], payload.size(), 0);
+        result.error = errno;
+        const bool reported = WriteAll(tee_result[1], reinterpret_cast<const char*>(&result),
+                                       sizeof(result));
+        _exit(reported ? 0 : 5);
+    }
+
+    close(tee_result[1]);
+    int tee_status = 0;
+    if (!WaitForChild(tee_worker, &tee_status)) {
+        FAIL() << "blocking tee did not return after making partial progress";
+    }
+    tee_worker_guard.Release();
+    ASSERT_TRUE(WIFEXITED(tee_status));
+    ASSERT_EQ(0, WEXITSTATUS(tee_status));
+    TeeResult result {};
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(result)),
+              read(tee_result[0], &result, sizeof(result)))
+        << strerror(errno);
+    close(tee_result[0]);
+    errno = result.error;
+    const ssize_t copied = result.copied;
     EXPECT_GT(copied, 0);
     EXPECT_LT(copied, static_cast<ssize_t>(payload.size()));
 

--- a/user/apps/tests/dunitest/suites/normal/pipe_waitqueue_wakeup.cc
+++ b/user/apps/tests/dunitest/suites/normal/pipe_waitqueue_wakeup.cc
@@ -1,13 +1,32 @@
 #include <gtest/gtest.h>
 
 #include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
 #include <signal.h>
 #include <string.h>
+#include <sys/epoll.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <vector>
+
 namespace {
+
+volatile sig_atomic_t g_sigpipe_count = 0;
+volatile sig_atomic_t g_sigio_count = 0;
+
+void SigpipeHandler(int) {
+    ++g_sigpipe_count;
+}
+
+void SigioHandler(int) {
+    ++g_sigio_count;
+}
 
 void SleepForMillis(long millis) {
     timespec ts {};
@@ -31,7 +50,681 @@ bool WaitForChild(pid_t child, int* status, int rounds = 300) {
     return false;
 }
 
+bool WaitForSleepingProcess(pid_t pid) {
+    char path[64] = {};
+    std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        FILE* stat = std::fopen(path, "r");
+        if (stat != nullptr) {
+            char line[512] = {};
+            const bool read = std::fgets(line, sizeof(line), stat) != nullptr;
+            std::fclose(stat);
+            if (read) {
+                const char* comm_end = strrchr(line, ')');
+                if (comm_end != nullptr && comm_end[1] == ' ' &&
+                    (comm_end[2] == 'S' || comm_end[2] == 'D')) {
+                    return true;
+                }
+            }
+        }
+        usleep(1'000);
+    }
+    return false;
+}
+
+bool WaitForSignalCount(volatile sig_atomic_t* count, sig_atomic_t expected) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (*count >= expected) {
+            return true;
+        }
+        usleep(1'000);
+    }
+    return *count >= expected;
+}
+
+void KillAndReap(pid_t child) {
+    if (child <= 0) {
+        return;
+    }
+    kill(child, SIGKILL);
+    while (waitpid(child, nullptr, 0) < 0 && errno == EINTR) {
+    }
+}
+
+class ChildProcessGuard {
+public:
+    ChildProcessGuard() = default;
+    explicit ChildProcessGuard(pid_t child) : child_(child) {}
+    ChildProcessGuard(const ChildProcessGuard&) = delete;
+    ChildProcessGuard& operator=(const ChildProcessGuard&) = delete;
+
+    ~ChildProcessGuard() {
+        Cleanup();
+    }
+
+    void Reset(pid_t child) {
+        Cleanup();
+        child_ = child;
+    }
+
+    void Release() {
+        child_ = -1;
+    }
+
+    void Cleanup() {
+        if (child_ > 0) {
+            KillAndReap(child_);
+            child_ = -1;
+        }
+    }
+
+private:
+    pid_t child_ = -1;
+};
+
+bool WriteAll(int fd, const char* data, size_t len) {
+    size_t written = 0;
+    while (written < len) {
+        const ssize_t n = write(fd, data + written, len - written);
+        if (n > 0) {
+            written += static_cast<size_t>(n);
+            continue;
+        }
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool ReadExactly(int fd, size_t len) {
+    std::vector<char> bytes(4096);
+    size_t read_bytes = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (read_bytes < len) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+            return false;
+        }
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+        pollfd wait_fd {};
+        wait_fd.fd = fd;
+        wait_fd.events = POLLIN;
+        const int ready = poll(&wait_fd, 1, static_cast<int>(std::max<int64_t>(1, remaining)));
+        if (ready < 0 && errno == EINTR) {
+            continue;
+        }
+        if (ready <= 0) {
+            return false;
+        }
+        const size_t chunk = std::min(bytes.size(), len - read_bytes);
+        const ssize_t n = read(fd, bytes.data(), chunk);
+        if (n > 0) {
+            read_bytes += static_cast<size_t>(n);
+            continue;
+        }
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool FillPipeExactly(int write_fd, size_t capacity) {
+    const int old_flags = fcntl(write_fd, F_GETFL);
+    if (old_flags < 0 || fcntl(write_fd, F_SETFL, old_flags | O_NONBLOCK) != 0) {
+        return false;
+    }
+
+    std::vector<char> bytes(4096, 'f');
+    size_t written = 0;
+    while (written < capacity) {
+        const size_t chunk = std::min(bytes.size(), capacity - written);
+        const ssize_t n = write(write_fd, bytes.data(), chunk);
+        if (n > 0) {
+            written += static_cast<size_t>(n);
+            continue;
+        }
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        fcntl(write_fd, F_SETFL, old_flags);
+        return false;
+    }
+    return fcntl(write_fd, F_SETFL, old_flags) == 0;
+}
+
 }  // namespace
+
+TEST(PipeWaitqueueWakeup, ZeroLengthIoHasNoEndpointSideEffects) {
+    int fds[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(fds)) << strerror(errno);
+
+    const int read_flags = fcntl(fds[0], F_GETFL);
+    ASSERT_GE(read_flags, 0) << strerror(errno);
+    ASSERT_EQ(0, fcntl(fds[0], F_SETFL, read_flags | O_NONBLOCK)) << strerror(errno);
+
+    char byte = 0;
+    errno = 0;
+    EXPECT_EQ(0, read(fds[0], &byte, 0)) << strerror(errno);
+
+    struct sigaction action {};
+    struct sigaction old_action {};
+    action.sa_handler = SigpipeHandler;
+    sigemptyset(&action.sa_mask);
+    ASSERT_EQ(0, sigaction(SIGPIPE, &action, &old_action)) << strerror(errno);
+    g_sigpipe_count = 0;
+
+    ASSERT_EQ(0, close(fds[0])) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(0, write(fds[1], &byte, 0)) << strerror(errno);
+    EXPECT_EQ(0, g_sigpipe_count);
+
+    ASSERT_EQ(0, sigaction(SIGPIPE, &old_action, nullptr)) << strerror(errno);
+    close(fds[1]);
+}
+
+TEST(PipeWaitqueueWakeup, NonblockingWriteWithoutReaderRaisesSigpipe) {
+    int fds[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(fds)) << strerror(errno);
+
+    const int flags = fcntl(fds[1], F_GETFL);
+    ASSERT_GE(flags, 0) << strerror(errno);
+    ASSERT_EQ(0, fcntl(fds[1], F_SETFL, flags | O_NONBLOCK)) << strerror(errno);
+
+    struct sigaction action {};
+    struct sigaction old_action {};
+    action.sa_handler = SigpipeHandler;
+    sigemptyset(&action.sa_mask);
+    ASSERT_EQ(0, sigaction(SIGPIPE, &action, &old_action)) << strerror(errno);
+    g_sigpipe_count = 0;
+
+    ASSERT_EQ(0, close(fds[0])) << strerror(errno);
+    char byte = 'x';
+    errno = 0;
+    EXPECT_EQ(-1, write(fds[1], &byte, 1));
+    EXPECT_EQ(EPIPE, errno);
+    EXPECT_EQ(1, g_sigpipe_count);
+
+    ASSERT_EQ(0, sigaction(SIGPIPE, &old_action, nullptr)) << strerror(errno);
+    close(fds[1]);
+}
+
+TEST(PipeWaitqueueWakeup, EligibleWriterIsNotBlockedBehindLargerWriter) {
+    int data[2] = {-1, -1};
+    int ready_large[2] = {-1, -1};
+    int ready_small[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(data)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready_large)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready_small)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(data[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+    const int capacity = fcntl(data[1], F_GETPIPE_SZ);
+    ASSERT_EQ(4096, capacity) << strerror(errno);
+    ASSERT_TRUE(FillPipeExactly(data[1], static_cast<size_t>(capacity))) << strerror(errno);
+
+    pid_t large = fork();
+    ASSERT_GE(large, 0) << strerror(errno);
+    ChildProcessGuard large_guard(large);
+    if (large == 0) {
+        close(data[0]);
+        close(ready_large[0]);
+        close(ready_small[0]);
+        close(ready_small[1]);
+        const char ready = 'L';
+        if (!WriteAll(ready_large[1], &ready, 1)) {
+            _exit(2);
+        }
+        close(ready_large[1]);
+        std::vector<char> payload(4096, 'L');
+        _exit(WriteAll(data[1], payload.data(), payload.size()) ? 0 : 3);
+    }
+
+    close(ready_large[1]);
+    char marker = 0;
+    ASSERT_EQ(1, read(ready_large[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('L', marker);
+    close(ready_large[0]);
+    if (!WaitForSleepingProcess(large)) {
+        large_guard.Cleanup();
+        FAIL() << "large writer did not enter the pipe wait path";
+    }
+
+    pid_t small = fork();
+    ASSERT_GE(small, 0) << strerror(errno);
+    ChildProcessGuard small_guard(small);
+    if (small == 0) {
+        close(data[0]);
+        close(ready_small[0]);
+        const char ready = 'S';
+        if (!WriteAll(ready_small[1], &ready, 1)) {
+            _exit(4);
+        }
+        close(ready_small[1]);
+        const char byte = 's';
+        _exit(WriteAll(data[1], &byte, 1) ? 0 : 5);
+    }
+
+    close(ready_small[1]);
+    marker = 0;
+    ASSERT_EQ(1, read(ready_small[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('S', marker);
+    close(ready_small[0]);
+    if (!WaitForSleepingProcess(small)) {
+        small_guard.Cleanup();
+        large_guard.Cleanup();
+        FAIL() << "small writer did not enter the pipe wait path";
+    }
+
+    char byte = 0;
+    ASSERT_EQ(1, read(data[0], &byte, 1)) << strerror(errno);
+
+    int small_status = 0;
+    const bool small_finished = WaitForChild(small, &small_status, 100);
+    if (!small_finished) {
+        small_guard.Cleanup();
+    } else {
+        small_guard.Release();
+    }
+
+    int large_status = 0;
+    const bool large_finished_early = waitpid(large, &large_status, WNOHANG) == large;
+    if (!large_finished_early) {
+        const size_t buffered = small_finished ? static_cast<size_t>(capacity)
+                                               : static_cast<size_t>(capacity - 1);
+        ASSERT_TRUE(ReadExactly(data[0], buffered)) << strerror(errno);
+        if (!WaitForChild(large, &large_status)) {
+            FAIL() << "large writer did not finish after sufficient space was released";
+        }
+        large_guard.Release();
+    } else {
+        large_guard.Release();
+    }
+
+    EXPECT_TRUE(small_finished) << "eligible 1-byte writer remained asleep behind 4096-byte writer";
+    if (small_finished) {
+        ASSERT_TRUE(WIFEXITED(small_status));
+        EXPECT_EQ(0, WEXITSTATUS(small_status));
+    }
+    EXPECT_FALSE(large_finished_early);
+    ASSERT_TRUE(WIFEXITED(large_status));
+    EXPECT_EQ(0, WEXITSTATUS(large_status));
+
+    close(data[0]);
+    close(data[1]);
+}
+
+TEST(PipeWaitqueueWakeup, PartialWriteNotifiesEpollBeforeWriterSleeps) {
+    int data[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(data)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(data[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+
+    const int epfd = epoll_create1(0);
+    ASSERT_GE(epfd, 0) << strerror(errno);
+    epoll_event interest {};
+    interest.events = EPOLLIN;
+    interest.data.fd = data[0];
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, data[0], &interest)) << strerror(errno);
+
+    pid_t writer = fork();
+    ASSERT_GE(writer, 0) << strerror(errno);
+    ChildProcessGuard writer_guard(writer);
+    if (writer == 0) {
+        close(data[0]);
+        close(ready[0]);
+        const char marker = 'W';
+        if (!WriteAll(ready[1], &marker, 1)) {
+            _exit(2);
+        }
+        close(ready[1]);
+        std::vector<char> payload(8192, 'w');
+        _exit(WriteAll(data[1], payload.data(), payload.size()) ? 0 : 3);
+    }
+
+    close(data[1]);
+    close(ready[1]);
+    char marker = 0;
+    ASSERT_EQ(1, read(ready[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('W', marker);
+    close(ready[0]);
+    if (!WaitForSleepingProcess(writer)) {
+        writer_guard.Cleanup();
+        FAIL() << "large writer did not block after publishing partial data";
+    }
+
+    epoll_event event {};
+    const int ready_count = epoll_wait(epfd, &event, 1, 200);
+
+    ASSERT_TRUE(ReadExactly(data[0], 4096)) << strerror(errno);
+    int status = 0;
+    if (!WaitForChild(writer, &status)) {
+        FAIL() << "large writer did not finish after reader drained the pipe";
+    }
+    writer_guard.Release();
+
+    EXPECT_EQ(1, ready_count) << strerror(errno);
+    if (ready_count == 1) {
+        EXPECT_NE(0U, event.events & EPOLLIN);
+    }
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+
+    close(epfd);
+    close(data[0]);
+}
+
+TEST(PipeWaitqueueWakeup, PartialWritePublishesSigioAndReturnsPartialAfterReaderClose) {
+    int data[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(data)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(data[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+
+    struct sigaction sigio_action {};
+    struct sigaction old_sigio_action {};
+    sigio_action.sa_handler = SigioHandler;
+    sigemptyset(&sigio_action.sa_mask);
+    ASSERT_EQ(0, sigaction(SIGIO, &sigio_action, &old_sigio_action)) << strerror(errno);
+    g_sigio_count = 0;
+    ASSERT_EQ(0, fcntl(data[0], F_SETOWN, getpid())) << strerror(errno);
+    const int read_flags = fcntl(data[0], F_GETFL);
+    ASSERT_GE(read_flags, 0) << strerror(errno);
+    ASSERT_EQ(0, fcntl(data[0], F_SETFL, read_flags | O_ASYNC)) << strerror(errno);
+
+    pid_t writer = fork();
+    ASSERT_GE(writer, 0) << strerror(errno);
+    ChildProcessGuard writer_guard(writer);
+    if (writer == 0) {
+        close(data[0]);
+        close(ready[0]);
+        struct sigaction sigpipe_action {};
+        sigpipe_action.sa_handler = SigpipeHandler;
+        sigemptyset(&sigpipe_action.sa_mask);
+        if (sigaction(SIGPIPE, &sigpipe_action, nullptr) != 0) {
+            _exit(2);
+        }
+        g_sigpipe_count = 0;
+        const char marker = 'P';
+        if (!WriteAll(ready[1], &marker, 1)) {
+            _exit(3);
+        }
+        close(ready[1]);
+        std::vector<char> payload(8192, 'p');
+        errno = 0;
+        const ssize_t written = write(data[1], payload.data(), payload.size());
+        _exit(written == 4096 && g_sigpipe_count == 1 ? 0 : 4);
+    }
+
+    close(data[1]);
+    close(ready[1]);
+    char marker = 0;
+    ASSERT_EQ(1, read(ready[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('P', marker);
+    close(ready[0]);
+    if (!WaitForSleepingProcess(writer)) {
+        writer_guard.Cleanup();
+        FAIL() << "large writer did not block after partial progress";
+    }
+    EXPECT_TRUE(WaitForSignalCount(&g_sigio_count, 1))
+        << "partial write did not publish read-side SIGIO before sleeping";
+
+    ASSERT_EQ(0, close(data[0])) << strerror(errno);
+    int status = 0;
+    if (!WaitForChild(writer, &status)) {
+        FAIL() << "writer did not return after the last reader closed";
+    }
+    writer_guard.Release();
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    ASSERT_EQ(0, sigaction(SIGIO, &old_sigio_action, nullptr)) << strerror(errno);
+}
+
+TEST(PipeWaitqueueWakeup, PipeToPipeSpliceWakesSourceWriterAndDestinationReader) {
+    int source[2] = {-1, -1};
+    int destination[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(source)) << strerror(errno);
+    ASSERT_EQ(0, pipe(destination)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(source[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(destination[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+    ASSERT_TRUE(FillPipeExactly(source[1], 4096)) << strerror(errno);
+
+    pid_t writer = fork();
+    ASSERT_GE(writer, 0) << strerror(errno);
+    ChildProcessGuard writer_guard(writer);
+    if (writer == 0) {
+        close(source[0]);
+        close(destination[0]);
+        close(destination[1]);
+        close(ready[0]);
+        const char marker = 'W';
+        if (!WriteAll(ready[1], &marker, 1)) {
+            _exit(2);
+        }
+        const char byte = 'w';
+        _exit(write(source[1], &byte, 1) == 1 ? 0 : 3);
+    }
+
+    pid_t reader = fork();
+    ASSERT_GE(reader, 0) << strerror(errno);
+    ChildProcessGuard reader_guard(reader);
+    if (reader == 0) {
+        close(destination[1]);
+        close(source[0]);
+        close(source[1]);
+        close(ready[0]);
+        const char marker = 'R';
+        if (!WriteAll(ready[1], &marker, 1)) {
+            _exit(4);
+        }
+        char byte = 0;
+        _exit(read(destination[0], &byte, 1) == 1 ? 0 : 5);
+    }
+
+    close(ready[1]);
+    ASSERT_TRUE(ReadExactly(ready[0], 2)) << strerror(errno);
+    close(ready[0]);
+    if (!WaitForSleepingProcess(writer) || !WaitForSleepingProcess(reader)) {
+        writer_guard.Cleanup();
+        reader_guard.Cleanup();
+        FAIL() << "splice participants did not enter their pipe wait paths";
+    }
+
+    ASSERT_EQ(4096, splice(source[0], nullptr, destination[1], nullptr, 4096, 0))
+        << strerror(errno);
+    int writer_status = 0;
+    int reader_status = 0;
+    ASSERT_TRUE(WaitForChild(writer, &writer_status));
+    writer_guard.Release();
+    ASSERT_TRUE(WaitForChild(reader, &reader_status));
+    reader_guard.Release();
+    ASSERT_TRUE(WIFEXITED(writer_status));
+    EXPECT_EQ(0, WEXITSTATUS(writer_status));
+    ASSERT_TRUE(WIFEXITED(reader_status));
+    EXPECT_EQ(0, WEXITSTATUS(reader_status));
+
+    close(source[0]);
+    close(source[1]);
+    close(destination[0]);
+    close(destination[1]);
+}
+
+TEST(PipeWaitqueueWakeup, TeeReturnsPartialWithoutConsumingSource) {
+    int source[2] = {-1, -1};
+    int destination[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    int release_reader[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(source)) << strerror(errno);
+    ASSERT_EQ(0, pipe(destination)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+    ASSERT_EQ(0, pipe(release_reader)) << strerror(errno);
+    ASSERT_EQ(8192, fcntl(source[1], F_SETPIPE_SZ, 8192)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(destination[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+    std::vector<char> payload(8192, 't');
+    ASSERT_TRUE(WriteAll(source[1], payload.data(), payload.size())) << strerror(errno);
+
+    pid_t reader = fork();
+    ASSERT_GE(reader, 0) << strerror(errno);
+    ChildProcessGuard reader_guard(reader);
+    if (reader == 0) {
+        close(source[0]);
+        close(source[1]);
+        close(destination[1]);
+        close(ready[0]);
+        close(release_reader[1]);
+        const char marker = 'T';
+        if (!WriteAll(ready[1], &marker, 1)) {
+            _exit(2);
+        }
+        close(ready[1]);
+        char byte = 0;
+        if (read(destination[0], &byte, 1) != 1) {
+            _exit(3);
+        }
+        _exit(read(release_reader[0], &byte, 1) == 1 ? 0 : 4);
+    }
+
+    close(destination[0]);
+    close(ready[1]);
+    close(release_reader[0]);
+    char marker = 0;
+    ASSERT_EQ(1, read(ready[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('T', marker);
+    close(ready[0]);
+    if (!WaitForSleepingProcess(reader)) {
+        reader_guard.Cleanup();
+        FAIL() << "tee destination reader did not block";
+    }
+
+    const ssize_t copied = tee(source[0], destination[1], payload.size(), 0);
+    EXPECT_GT(copied, 0);
+    EXPECT_LT(copied, static_cast<ssize_t>(payload.size()));
+
+    const char release = 'R';
+    ASSERT_TRUE(WriteAll(release_reader[1], &release, 1)) << strerror(errno);
+    close(release_reader[1]);
+    int reader_status = 0;
+    ASSERT_TRUE(WaitForChild(reader, &reader_status));
+    reader_guard.Release();
+    ASSERT_TRUE(WIFEXITED(reader_status));
+    EXPECT_EQ(0, WEXITSTATUS(reader_status));
+    ASSERT_TRUE(ReadExactly(source[0], payload.size()))
+        << "tee unexpectedly consumed source data";
+
+    close(source[0]);
+    close(source[1]);
+    close(destination[1]);
+}
+
+TEST(PipeWaitqueueWakeup, BlockedReadersPassBatonForRemainingData) {
+    int data[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(data)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+
+    pid_t readers[2] = {-1, -1};
+    ChildProcessGuard reader_guards[2];
+    for (size_t i = 0; i < 2; ++i) {
+        readers[i] = fork();
+        ASSERT_GE(readers[i], 0) << strerror(errno);
+        reader_guards[i].Reset(readers[i]);
+        if (readers[i] == 0) {
+            close(data[1]);
+            close(ready[0]);
+            const char marker = static_cast<char>('0' + i);
+            if (!WriteAll(ready[1], &marker, 1)) {
+                _exit(2);
+            }
+            close(ready[1]);
+            char byte = 0;
+            _exit(read(data[0], &byte, 1) == 1 ? 0 : 3);
+        }
+    }
+
+    close(ready[1]);
+    char markers[2] = {};
+    ASSERT_TRUE(ReadExactly(ready[0], sizeof(markers))) << strerror(errno);
+    close(ready[0]);
+
+    for (pid_t reader : readers) {
+        if (!WaitForSleepingProcess(reader)) {
+            reader_guards[0].Cleanup();
+            reader_guards[1].Cleanup();
+            FAIL() << "reader did not enter the pipe wait path";
+        }
+    }
+
+    const char tokens[2] = {'a', 'b'};
+    ASSERT_TRUE(WriteAll(data[1], tokens, sizeof(tokens))) << strerror(errno);
+
+    for (pid_t reader : readers) {
+        int status = 0;
+        if (!WaitForChild(reader, &status)) {
+            FAIL() << "reader baton did not make finite progress";
+        }
+        const size_t index = reader == readers[0] ? 0 : 1;
+        reader_guards[index].Release();
+        ASSERT_TRUE(WIFEXITED(status));
+        EXPECT_EQ(0, WEXITSTATUS(status));
+    }
+
+    close(data[0]);
+    close(data[1]);
+}
+
+TEST(PipeWaitqueueWakeup, ResizeWakesAtomicWriterAfterThresholdCrossing) {
+    int data[2] = {-1, -1};
+    int ready[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(data)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+    ASSERT_EQ(4096, fcntl(data[1], F_SETPIPE_SZ, 4096)) << strerror(errno);
+    const char occupied = 'x';
+    ASSERT_EQ(1, write(data[1], &occupied, 1)) << strerror(errno);
+
+    pid_t writer = fork();
+    ASSERT_GE(writer, 0) << strerror(errno);
+    ChildProcessGuard writer_guard(writer);
+    if (writer == 0) {
+        close(data[0]);
+        close(ready[0]);
+        const char marker = 'R';
+        if (!WriteAll(ready[1], &marker, 1)) {
+            _exit(2);
+        }
+        close(ready[1]);
+        std::vector<char> payload(4096, 'r');
+        _exit(WriteAll(data[1], payload.data(), payload.size()) ? 0 : 3);
+    }
+
+    close(ready[1]);
+    char marker = 0;
+    ASSERT_EQ(1, read(ready[0], &marker, 1)) << strerror(errno);
+    ASSERT_EQ('R', marker);
+    close(ready[0]);
+    if (!WaitForSleepingProcess(writer)) {
+        writer_guard.Cleanup();
+        FAIL() << "atomic writer did not enter the pipe wait path";
+    }
+
+    ASSERT_EQ(8192, fcntl(data[1], F_SETPIPE_SZ, 8192)) << strerror(errno);
+    int status = 0;
+    if (!WaitForChild(writer, &status)) {
+        FAIL() << "pipe resize did not wake the newly eligible writer";
+    }
+    writer_guard.Release();
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+
+    close(data[0]);
+    close(data[1]);
+}
 
 TEST(PipeWaitqueueWakeup, BlockingReadConsumesChildReadyByte) {
     int ready_pipe[2] = {-1, -1};


### PR DESCRIPTION
## Summary

- preserve blocked writer intent under the pipe state lock and select single or broadcast wakeups according to the set of possible write predicates
- publish waitqueue, epoll, async I/O, and SIGPIPE notifications after releasing pipe spinlocks
- correct partial-write, zero-length I/O, resize, splice, and tee semantics
- add deterministic regression coverage for endpoint side effects, writer eligibility, observer notification, splice/tee behavior, reader baton passing, and resize wakeups

## Root cause

Pipe wakeups were issued without enough information about heterogeneous blocked writers, while several observer notifications were performed under pipe spinlocks or omitted on partial-progress paths. The splice and tee paths also had inconsistent endpoint checks and could mishandle held or partially transferred data.

The fix keeps waiter intent and pipe state synchronized by the existing inner lock, performs external notifications only after unlocking, and preserves Linux-compatible return and signal behavior.

## Validation

- `make fmt`
- kernel build and Clippy checks
- `git diff --check`
- DragonOS dunitest:
  - `pipe_waitqueue_wakeup_test`: 10/10 passed
  - `pipe_release_wakeup_test`: 8/8 passed
  - `splice_concurrent_io_test`: 7/7 passed
  - `epoll_timeout_budget_test`: 1/1 passed

An exact A/B `lat_pipe` run did not cross the predefined performance significance threshold, so this change is intentionally presented as a correctness and wakeup-semantics fix rather than a claimed latency improvement.