### PR TITLE
feat(tracepoint): add sched_process_exec tracepoint

### DIFF
--- a/kernel/src/perf/tracepoint.rs
+++ b/kernel/src/perf/tracepoint.rs
@@ -20,11 +20,24 @@ use core::sync::atomic::AtomicUsize;
 use rbpf::EbpfVmRaw;
 use system_error::SystemError;
 
-#[derive(Debug)]
 pub struct TracepointPerfEvent {
     _args: PerfProbeArgs,
     tp: &'static TracePoint,
-    ebpf_list: SpinLock<Vec<usize>>,
+    state: SpinLock<PerfTracepointState>,
+}
+
+struct PerfTracepointState {
+    enabled: bool,
+    callbacks: Vec<(usize, Arc<TracePointPerfCallBack>)>,
+}
+
+impl core::fmt::Debug for TracepointPerfEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TracepointPerfEvent")
+            .field("args", &self._args)
+            .field("tracepoint", &self.tp)
+            .finish()
+    }
 }
 
 impl TracepointPerfEvent {
@@ -32,7 +45,10 @@ impl TracepointPerfEvent {
         TracepointPerfEvent {
             _args: args,
             tp,
-            ebpf_list: SpinLock::new(Vec::new()),
+            state: SpinLock::new(PerfTracepointState {
+                enabled: false,
+                callbacks: Vec::new(),
+            }),
         }
     }
 }
@@ -87,10 +103,10 @@ pub struct TracePointPerfCallBack(BasicPerfEbpfCallBack);
 
 impl TracePointCallBackFunc for TracePointPerfCallBack {
     fn call(&self, entry: &[u8]) {
-        // ebpf needs a mutable slice
-        let entry =
-            unsafe { core::slice::from_raw_parts_mut(entry.as_ptr() as *mut u8, entry.len()) };
-        self.0.call(entry);
+        // rbpf requires an exclusive context. Never manufacture `&mut` from the
+        // shared canonical record: each BPF program gets an isolated copy.
+        let mut private_entry = entry.to_vec();
+        self.0.call(&mut private_entry);
     }
 }
 
@@ -127,17 +143,20 @@ impl PerfEventOps for TracepointPerfEvent {
             vm.set_jit_exec_memory(jit_mem).unwrap();
             vm.jit_compile().unwrap();
             let basic_callback = BasicPerfEbpfCallBack::new(file, vm, jit_mem_addr);
-            callback = Box::new(TracePointPerfCallBack(basic_callback));
+            callback = Arc::new(TracePointPerfCallBack(basic_callback));
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
             vm.register_allowed_memory(0..u64::MAX);
             let basic_callback = BasicPerfEbpfCallBack::new(file, vm);
-            callback = Box::new(TracePointPerfCallBack(basic_callback));
+            callback = Arc::new(TracePointPerfCallBack(basic_callback));
         }
 
         let id = CALLBACK_ID.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-        self.tp.register_raw_callback(id, callback);
+        let mut state = self.state.lock();
+        if state.enabled {
+            self.tp.register_raw_callback(id, callback.clone());
+        }
 
         log::info!(
             "Registered BPF program for tracepoint: {}:{} with ID: {}",
@@ -145,8 +164,7 @@ impl PerfEventOps for TracepointPerfEvent {
             self.tp.name(),
             id
         );
-        // Store the ID in the ebpf_list for later cleanup
-        self.ebpf_list.lock().push(id);
+        state.callbacks.push((id, callback));
         Ok(())
     }
 
@@ -156,12 +174,28 @@ impl PerfEventOps for TracepointPerfEvent {
             self.tp.system(),
             self.tp.name()
         );
-        self.tp.enable();
+        let mut state = self.state.lock();
+        if state.enabled {
+            return Ok(());
+        }
+        for (id, callback) in state.callbacks.iter() {
+            self.tp.register_raw_callback(*id, callback.clone());
+        }
+        self.tp.acquire_enable();
+        state.enabled = true;
         Ok(())
     }
 
     fn disable(&self) -> Result<()> {
-        self.tp.disable();
+        let mut state = self.state.lock();
+        if !state.enabled {
+            return Ok(());
+        }
+        for (id, _) in state.callbacks.iter() {
+            self.tp.unregister_raw_callback(*id);
+        }
+        self.tp.release_enable();
+        state.enabled = false;
         Ok(())
     }
 
@@ -172,12 +206,15 @@ impl PerfEventOps for TracepointPerfEvent {
 
 impl Drop for TracepointPerfEvent {
     fn drop(&mut self) {
-        // Unregister all callbacks associated with this tracepoint event
-        let mut ebpf_list = self.ebpf_list.lock();
-        for id in ebpf_list.iter() {
-            self.tp.unregister_raw_callback(*id);
+        let mut state = self.state.lock();
+        if state.enabled {
+            for (id, _) in state.callbacks.iter() {
+                self.tp.unregister_raw_callback(*id);
+            }
+            self.tp.release_enable();
+            state.enabled = false;
         }
-        ebpf_list.clear();
+        state.callbacks.clear();
     }
 }
 

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -1,3 +1,4 @@
+use super::trace::trace_sched_process_exec;
 use crate::arch::CurrentIrqArch;
 use crate::exception::InterruptArch;
 use crate::filesystem::vfs::fcntl::AtFlags;
@@ -128,6 +129,11 @@ fn do_execve_internal(
 
     let old_vm = do_execve_switch_user_vm(address_space.clone());
 
+    // 捕获 sched_process_exec 的 old_pid：必须在 load_binary_file_with_context 之前，
+    // 因为该函数内的 begin_new_exec → de_thread 会在「非 leader 线程 execve」时
+    // 交换 current 与旧 thread-group leader 的 raw_pid（对齐 Linux fs/exec.c:1770）。
+    let old_pid = ProcessManager::current_pcb().raw_pid().data() as i32;
+
     // 尝试加载二进制文件
     let load_result = load_binary_file_with_context(&mut param, &ctx);
 
@@ -214,6 +220,11 @@ fn do_execve_internal(
             let vfork_done = pcb.thread.write_irqsave().vfork_done.take();
             let exec_ret = Syscall::arch_do_execve(regs, &param, &result, user_sp, argv_ptr);
             if exec_ret.is_ok() {
+                // sched_process_exec：arch_do_execve 成功、用户态寄存器就绪后触发，
+                // 对齐 Linux fs/exec.c:1803（trace 在 start_thread 之后、所有失败点之后）。
+                let pid = pcb.raw_pid().data() as i32;
+                trace_sched_process_exec(pcb.basic().name(), pid, old_pid);
+
                 if let Some(completion) = vfork_done {
                     completion.complete_all();
                 }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -223,7 +223,18 @@ fn do_execve_internal(
                 // sched_process_exec：arch_do_execve 成功、用户态寄存器就绪后触发，
                 // 对齐 Linux fs/exec.c:1803（trace 在 start_thread 之后、所有失败点之后）。
                 let pid = pcb.raw_pid().data() as i32;
-                trace_sched_process_exec(pcb.basic().name(), pid, old_pid);
+                // 先把 comm 复制到栈缓冲并释放 basic 读锁：trace 默认回调内部的
+                // trace_cmdline_push 会再次获取 basic 读锁，持锁重入有 deadlock 风险。
+                let mut comm_buf = [0u8; 16];
+                let comm_len;
+                {
+                    let basic_guard = pcb.basic();
+                    let name = basic_guard.name();
+                    comm_len = name.as_bytes().len().min(15);
+                    comm_buf[..comm_len].copy_from_slice(&name.as_bytes()[..comm_len]);
+                }
+                let comm = core::str::from_utf8(&comm_buf[..comm_len]).unwrap_or("");
+                trace_sched_process_exec(comm, pid, old_pid);
 
                 if let Some(completion) = vfork_done {
                     completion.complete_all();

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -226,11 +226,15 @@ fn do_execve_internal(
                 // 先把 comm 复制到栈缓冲并释放 basic 读锁：trace 默认回调内部的
                 // trace_cmdline_push 会再次获取 basic 读锁，持锁重入有 deadlock 风险。
                 let mut comm_buf = [0u8; 16];
-                let comm_len;
+                let mut comm_len;
                 {
                     let basic_guard = pcb.basic();
                     let name = basic_guard.name();
                     comm_len = name.as_bytes().len().min(15);
+                    // 回退到 UTF-8 字符边界，避免在多字节字符中间截断导致 from_utf8 失败。
+                    while comm_len > 0 && !name.is_char_boundary(comm_len) {
+                        comm_len -= 1;
+                    }
                     comm_buf[..comm_len].copy_from_slice(&name.as_bytes()[..comm_len]);
                 }
                 let comm = core::str::from_utf8(&comm_buf[..comm_len]).unwrap_or("");

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -230,7 +230,7 @@ fn do_execve_internal(
                 {
                     let basic_guard = pcb.basic();
                     let name = basic_guard.name();
-                    comm_len = name.as_bytes().len().min(15);
+                    comm_len = name.len().min(15);
                     // 回退到 UTF-8 字符边界，避免在多字节字符中间截断导致 from_utf8 失败。
                     while comm_len > 0 && !name.is_char_boundary(comm_len) {
                         comm_len -= 1;

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -1,4 +1,4 @@
-use super::trace::{trace_sched_process_exec, trace_sched_process_exec_enabled};
+use super::trace::trace_sched_process_exec;
 use crate::arch::CurrentIrqArch;
 use crate::exception::InterruptArch;
 use crate::filesystem::vfs::fcntl::AtFlags;
@@ -229,33 +229,16 @@ fn do_execve_internal(
                     completion.complete_all();
                 }
 
-                // sched_process_exec：arch_do_execve 成功、用户态寄存器就绪后触发，
-                // 对齐 Linux fs/exec.c:1803（trace 在 start_thread 之后、所有失败点之后）。
-                //
-                // Thread5：disabled 路径零开销。Rust 在调用函数前即求值参数，因此即便
-                // trace_sched_process_exec() 内部有 static-key 检查，comm 的取锁 /
-                // UTF-8 扫描 / 拷贝在每个成功 exec 上仍会发生。这里用只读的 _enabled()
-                // 守卫：tracepoint 未启用时完全跳过字段构造与触发，不为禁用路径付出
-                // 取 irqsave basic 读锁、扫 UTF-8 边界、拷贝 name 的开销。
-                if trace_sched_process_exec_enabled() {
-                    let pid = pcb.raw_pid().data() as i32;
-                    // 先把 comm 复制到栈缓冲并释放 basic 读锁：trace 默认回调内部的
-                    // trace_cmdline_push 会再次获取 basic 读锁，持锁重入有 deadlock 风险。
-                    let mut comm_buf = [0u8; 16];
-                    let mut comm_len;
-                    {
-                        let basic_guard = pcb.basic();
-                        let name = basic_guard.name();
-                        comm_len = name.len().min(15);
-                        // 回退到 UTF-8 字符边界，避免在多字节字符中间截断导致 from_utf8 失败。
-                        while comm_len > 0 && !name.is_char_boundary(comm_len) {
-                            comm_len -= 1;
-                        }
-                        comm_buf[..comm_len].copy_from_slice(&name.as_bytes()[..comm_len]);
-                    }
-                    let comm = core::str::from_utf8(&comm_buf[..comm_len]).unwrap_or("");
-                    trace_sched_process_exec(comm, pid, old_pid);
-                }
+                // Linux keeps bprm->filename as the original exec-visible name
+                // across shebang/interpreter rewrites. DragonOS's execfn has the
+                // same lifetime and meaning; filename tracks the current loader.
+                // All dynamic sizing/allocation remains behind the macro's static
+                // branch, while these borrowed bytes and integers are O(1).
+                trace_sched_process_exec(
+                    param.execfn().as_bytes(),
+                    pcb.raw_pid().data() as i32,
+                    old_pid,
+                );
             }
             exec_ret
         }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -1,4 +1,4 @@
-use super::trace::trace_sched_process_exec;
+use super::trace::{trace_sched_process_exec, trace_sched_process_exec_enabled};
 use crate::arch::CurrentIrqArch;
 use crate::exception::InterruptArch;
 use crate::filesystem::vfs::fcntl::AtFlags;
@@ -220,28 +220,41 @@ fn do_execve_internal(
             let vfork_done = pcb.thread.write_irqsave().vfork_done.take();
             let exec_ret = Syscall::arch_do_execve(regs, &param, &result, user_sp, argv_ptr);
             if exec_ret.is_ok() {
-                // sched_process_exec：arch_do_execve 成功、用户态寄存器就绪后触发，
-                // 对齐 Linux fs/exec.c:1803（trace 在 start_thread 之后、所有失败点之后）。
-                let pid = pcb.raw_pid().data() as i32;
-                // 先把 comm 复制到栈缓冲并释放 basic 读锁：trace 默认回调内部的
-                // trace_cmdline_push 会再次获取 basic 读锁，持锁重入有 deadlock 风险。
-                let mut comm_buf = [0u8; 16];
-                let mut comm_len;
-                {
-                    let basic_guard = pcb.basic();
-                    let name = basic_guard.name();
-                    comm_len = name.len().min(15);
-                    // 回退到 UTF-8 字符边界，避免在多字节字符中间截断导致 from_utf8 失败。
-                    while comm_len > 0 && !name.is_char_boundary(comm_len) {
-                        comm_len -= 1;
-                    }
-                    comm_buf[..comm_len].copy_from_slice(&name.as_bytes()[..comm_len]);
-                }
-                let comm = core::str::from_utf8(&comm_buf[..comm_len]).unwrap_or("");
-                trace_sched_process_exec(comm, pid, old_pid);
-
+                // Thread4：先 complete vfork parent，再触发 trace。
+                // 对齐 Linux：exec_mmap()/exec_mm_release() 内更早完成 vfork_done，
+                // 而 trace_sched_process_exec() 在 exec 成功提交尾部才执行。若先 trace
+                // 再 complete，父进程会被所有 tracepoint 回调阻塞，违反“child 完成 exec
+                // commit 即恢复父进程”的语义，给 exec 热路径引入不必要的 trace 回调延迟。
                 if let Some(completion) = vfork_done {
                     completion.complete_all();
+                }
+
+                // sched_process_exec：arch_do_execve 成功、用户态寄存器就绪后触发，
+                // 对齐 Linux fs/exec.c:1803（trace 在 start_thread 之后、所有失败点之后）。
+                //
+                // Thread5：disabled 路径零开销。Rust 在调用函数前即求值参数，因此即便
+                // trace_sched_process_exec() 内部有 static-key 检查，comm 的取锁 /
+                // UTF-8 扫描 / 拷贝在每个成功 exec 上仍会发生。这里用只读的 _enabled()
+                // 守卫：tracepoint 未启用时完全跳过字段构造与触发，不为禁用路径付出
+                // 取 irqsave basic 读锁、扫 UTF-8 边界、拷贝 name 的开销。
+                if trace_sched_process_exec_enabled() {
+                    let pid = pcb.raw_pid().data() as i32;
+                    // 先把 comm 复制到栈缓冲并释放 basic 读锁：trace 默认回调内部的
+                    // trace_cmdline_push 会再次获取 basic 读锁，持锁重入有 deadlock 风险。
+                    let mut comm_buf = [0u8; 16];
+                    let mut comm_len;
+                    {
+                        let basic_guard = pcb.basic();
+                        let name = basic_guard.name();
+                        comm_len = name.len().min(15);
+                        // 回退到 UTF-8 字符边界，避免在多字节字符中间截断导致 from_utf8 失败。
+                        while comm_len > 0 && !name.is_char_boundary(comm_len) {
+                            comm_len -= 1;
+                        }
+                        comm_buf[..comm_len].copy_from_slice(&name.as_bytes()[..comm_len]);
+                    }
+                    let comm = core::str::from_utf8(&comm_buf[..comm_len]).unwrap_or("");
+                    trace_sched_process_exec(comm, pid, old_pid);
                 }
             }
             exec_ret

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -24,6 +24,7 @@ pub mod signal;
 pub mod stdio;
 pub mod syscall;
 pub mod timer;
+pub mod trace;
 pub mod utils;
 pub mod wait;
 

--- a/kernel/src/process/trace.rs
+++ b/kernel/src/process/trace.rs
@@ -1,0 +1,36 @@
+//! 进程/调度类 tracepoint 声明。
+//!
+//! 字段参考 Linux `include/trace/events/sched.h`。
+//! 注意：DragonOS 的 `define_event_trace!` 宏不支持 Linux 的 `__string` 动态字符串，
+//! 且当前未实现 `bpf_get_current_comm()` helper，故 `comm` 直接放入 payload。
+
+use crate::define_event_trace;
+
+define_event_trace!(
+    sched_process_exec,
+    TP_system(sched),
+    TP_PROTO(comm: &str, pid: i32, old_pid: i32),
+    TP_STRUCT__entry {
+        comm: [u8; 16],
+        pid: i32,
+        old_pid: i32,
+    },
+    TP_fast_assign {
+        comm: {
+            // 对齐 Linux TASK_COMM_LEN=16（15 字符 + NUL）。
+            let mut buf = [0u8; 16];
+            let bytes = comm.as_bytes();
+            let len = bytes.len().min(15);
+            buf[..len].copy_from_slice(&bytes[..len]);
+            buf
+        },
+        pid: pid,
+        old_pid: old_pid,
+    },
+    TP_ident(__entry),
+    TP_printk({
+        let nul = __entry.comm.iter().position(|&b| b == 0).unwrap_or(16);
+        let comm = core::str::from_utf8(&__entry.comm[..nul]).unwrap_or("invalid utf8");
+        format!("comm={} pid={} old_pid={}", comm, __entry.pid, __entry.old_pid)
+    })
+);

--- a/kernel/src/process/trace.rs
+++ b/kernel/src/process/trace.rs
@@ -1,36 +1,29 @@
 //! 进程/调度类 tracepoint 声明。
 //!
-//! 字段参考 Linux `include/trace/events/sched.h`。
-//! 注意：DragonOS 的 `define_event_trace!` 宏不支持 Linux 的 `__string` 动态字符串，
-//! 且当前未实现 `bpf_get_current_comm()` helper，故 `comm` 直接放入 payload。
+//! 字段与 raw ABI 对齐 Linux 6.6 `include/trace/events/sched.h`。
 
 use crate::define_event_trace;
 
 define_event_trace!(
     sched_process_exec,
     TP_system(sched),
-    TP_PROTO(comm: &str, pid: i32, old_pid: i32),
+    TP_PROTO(filename: &[u8], pid: i32, old_pid: i32),
     TP_STRUCT__entry {
-        comm: [u8; 16],
+        __string(filename, filename),
         pid: i32,
         old_pid: i32,
     },
     TP_fast_assign {
-        comm: {
-            // 对齐 Linux TASK_COMM_LEN=16（15 字符 + NUL）。
-            let mut buf = [0u8; 16];
-            let bytes = comm.as_bytes();
-            let len = bytes.len().min(15);
-            buf[..len].copy_from_slice(&bytes[..len]);
-            buf
-        },
         pid: pid,
         old_pid: old_pid,
     },
     TP_ident(__entry),
     TP_printk({
-        let nul = __entry.comm.iter().position(|&b| b == 0).unwrap_or(16);
-        let comm = core::str::from_utf8(&__entry.comm[..nul]).unwrap_or("invalid utf8");
-        format!("comm={} pid={} old_pid={}", comm, __entry.pid, __entry.old_pid)
-    })
+        let filename = alloc::string::String::from_utf8_lossy(__entry.filename);
+        format!(
+            "filename={} pid={} old_pid={}",
+            filename, __entry.pid, __entry.old_pid
+        )
+    }),
+    TP_print_fmt("\"filename=%s pid=%d old_pid=%d\", __get_str(filename), REC->pid, REC->old_pid")
 );

--- a/kernel/src/tracepoint/basic_macro.rs
+++ b/kernel/src/tracepoint/basic_macro.rs
@@ -64,6 +64,20 @@ macro_rules! define_event_trace{
                     trace_point.callback_list(&mut f);
                 }
             }
+            /// 该 tracepoint 当前是否已启用（只读检查，无副作用）。
+            ///
+            /// 用于在构造 trace 参数之前进行廉价的禁用路径守卫：tracepoint 未启用时，
+            /// 调用方可据此跳过取锁 / 拷贝 / UTF-8 扫描等参数构造开销，避免 Rust 在进入
+            /// `trace_<name>()` 之前即求值参数所引入的禁用路径开销。
+            ///
+            /// 实现只读取 static-key 的运行时状态（atomic Relaxed 读），不操作代码段、
+            /// 不注册新的 jump entry，与 `trace_<name>()` 内部 `static_branch_unlikely!`
+            /// 的语义一致——二者都返回 true 当且仅当该 key 已被启用。
+            #[inline(always)]
+            #[allow(unused,non_snake_case)]
+            pub fn [<trace_ $name _enabled>]() -> bool {
+                [<__ $name _KEY>].is_enabled()
+            }
             #[allow(unused,non_snake_case)]
             pub fn [<register_trace_ $name>](func: fn(& (dyn core::any::Any+Send+Sync), $($arg_type),*), data: alloc::boxed::Box<dyn core::any::Any+Send+Sync>){
                 let func = unsafe{core::mem::transmute::<fn(& (dyn core::any::Any+Send+Sync), $($arg_type),*), fn()>(func)};

--- a/kernel/src/tracepoint/basic_macro.rs
+++ b/kernel/src/tracepoint/basic_macro.rs
@@ -39,6 +39,260 @@ macro_rules! define_event_trace{
         $name:ident,
         TP_system($system:ident),
         TP_PROTO($($arg:ident:$arg_type:ty),*),
+        TP_STRUCT__entry{
+            __string($dynamic:ident, $dynamic_value:expr),
+            $($entry:ident:$entry_type:ty,)*
+        },
+        TP_fast_assign{$($assign:ident:$value:expr,)*},
+        TP_ident($tp_ident:ident),
+        TP_printk($fmt_expr: expr),
+        TP_print_fmt($print_fmt: expr)
+    ) => {
+        paste::paste!{
+            static_keys::define_static_key_false!([<__ $name _KEY>]);
+            #[allow(non_upper_case_globals)]
+            #[used]
+            static [<__ $name>]: $crate::tracepoint::TracePoint = $crate::tracepoint::TracePoint::new(
+                &[<__ $name _KEY>],
+                stringify!($name),
+                stringify!($system),
+                [<trace_fmt_ $name>],
+                [<trace_fmt_show $name>],
+            );
+
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            pub fn [<trace_ $name>]($($arg:$arg_type),*) {
+                if static_keys::static_branch_unlikely!([<__ $name _KEY>]) {
+                    let mut f = |trace_func: &$crate::tracepoint::TracePointFunc| {
+                        let func = trace_func.func;
+                        let data = trace_func.data.as_ref();
+                        let func = unsafe {
+                            core::mem::transmute::<
+                                fn(),
+                                fn(&(dyn core::any::Any + Send + Sync), $($arg_type),*)
+                            >(func)
+                        };
+                        func(data $(,$arg)*);
+                    };
+                    [<__ $name>].callback_list(&mut f);
+                }
+            }
+
+            #[allow(unused, non_snake_case)]
+            pub fn [<register_trace_ $name>](
+                func: fn(&(dyn core::any::Any + Send + Sync), $($arg_type),*),
+                data: alloc::boxed::Box<dyn core::any::Any + Send + Sync>,
+            ) {
+                let func = unsafe {
+                    core::mem::transmute::<
+                        fn(&(dyn core::any::Any + Send + Sync), $($arg_type),*),
+                        fn()
+                    >(func)
+                };
+                [<__ $name>].register(func, data);
+            }
+
+            #[allow(unused, non_snake_case)]
+            pub fn [<unregister_trace_ $name>](
+                func: fn(&(dyn core::any::Any + Send + Sync), $($arg_type),*)
+            ) {
+                let func = unsafe {
+                    core::mem::transmute::<
+                        fn(&(dyn core::any::Any + Send + Sync), $($arg_type),*),
+                        fn()
+                    >(func)
+                };
+                [<__ $name>].unregister(func);
+            }
+
+            #[derive(Debug)]
+            #[repr(C)]
+            #[allow(non_snake_case, non_camel_case_types)]
+            struct [<__ $name _TracePointMeta>] {
+                trace_point: &'static $crate::tracepoint::TracePoint,
+                print_func: fn(&(dyn core::any::Any + Send + Sync), $($arg_type),*),
+            }
+
+            #[allow(non_upper_case_globals)]
+            #[link_section = ".tracepoint"]
+            #[used]
+            static [<__ $name _meta>]: [<__ $name _TracePointMeta>] = [<__ $name _TracePointMeta>] {
+                trace_point: &[<__ $name>],
+                print_func: [<trace_default_ $name>],
+            };
+
+            #[allow(unused, non_snake_case, clippy::redundant_field_names)]
+            pub fn [<trace_default_ $name>](
+                _data: &(dyn core::any::Any + Send + Sync),
+                $($arg:$arg_type),*
+            ) {
+                fn align_up(value: usize, align: usize) -> Option<usize> {
+                    value.checked_add(align.checked_sub(1)?)?.checked_div(align)?.checked_mul(align)
+                }
+
+                $(let $assign: $entry_type = $value;)*
+                let dynamic_value: &[u8] = $dynamic_value;
+                let Some(dynamic_len) = dynamic_value.len().checked_add(1) else {
+                    return;
+                };
+
+                let mut fixed_len = core::mem::size_of::<$crate::tracepoint::TraceEntry>()
+                    + core::mem::size_of::<u32>();
+                let mut max_align = core::mem::align_of::<u32>();
+                $(
+                    let field_align = <$entry_type as $crate::tracepoint::TraceEventField>::ALIGN;
+                    let Some(aligned) = align_up(fixed_len, field_align) else { return; };
+                    let Some(next) = aligned.checked_add(
+                        <$entry_type as $crate::tracepoint::TraceEventField>::SIZE
+                    ) else { return; };
+                    fixed_len = next;
+                    max_align = max_align.max(field_align);
+                )*
+                let Some(fixed_len) = align_up(fixed_len, max_align) else { return; };
+                let Ok(dynamic_offset) = u16::try_from(fixed_len) else { return; };
+                let Ok(dynamic_len_u16) = u16::try_from(dynamic_len) else { return; };
+                let Some(record_len) = fixed_len.checked_add(dynamic_len) else { return; };
+                let data_loc = ((dynamic_len_u16 as u32) << 16) | dynamic_offset as u32;
+
+                let process = $crate::process::ProcessManager::current_pcb();
+                let common_pid = process.raw_pid().data() as i32;
+                let mut event_buf = alloc::vec![0u8; fixed_len];
+                event_buf[0..2].copy_from_slice(&([<__ $name>].id() as u16).to_ne_bytes());
+                event_buf[2] = [<__ $name>].flags();
+                event_buf[3] = 0;
+                event_buf[4..8].copy_from_slice(&common_pid.to_ne_bytes());
+                event_buf[8..12].copy_from_slice(&data_loc.to_ne_bytes());
+
+                let mut field_offset = 12usize;
+                $(
+                    field_offset = align_up(
+                        field_offset,
+                        <$entry_type as $crate::tracepoint::TraceEventField>::ALIGN,
+                    ).expect("validated trace field layout");
+                    let field_end = field_offset
+                        + <$entry_type as $crate::tracepoint::TraceEventField>::SIZE;
+                    assert!(<$entry_type as $crate::tracepoint::TraceEventField>::write_ne(
+                        $assign,
+                        &mut event_buf[field_offset..field_end],
+                    ));
+                    field_offset = field_end;
+                )*
+                debug_assert_eq!(event_buf.len(), fixed_len);
+                event_buf.reserve(record_len - fixed_len);
+                event_buf.extend_from_slice(dynamic_value);
+                event_buf.push(0);
+
+                for callback in [<__ $name>].raw_callbacks_snapshot() {
+                    callback.call(&event_buf);
+                }
+
+                if [<__ $name>].is_trace_pipe_enabled() {
+                    $crate::debug::tracing::trace_cmdline_push(common_pid as u32);
+                    $crate::debug::tracing::trace_pipe_push_raw_record(&event_buf);
+                }
+            }
+
+            #[allow(unused, non_snake_case)]
+            pub fn [<trace_fmt_ $name>](buf: &[u8]) -> alloc::string::String {
+                fn align_up(value: usize, align: usize) -> Option<usize> {
+                    value.checked_add(align.checked_sub(1)?)?.checked_div(align)?.checked_mul(align)
+                }
+                fn invalid() -> alloc::string::String {
+                    alloc::string::String::from("<invalid trace record>")
+                }
+
+                if buf.len() < core::mem::size_of::<u32>() {
+                    return invalid();
+                }
+                let data_loc = u32::from_ne_bytes(buf[0..4].try_into().unwrap());
+                let full_offset = (data_loc & 0xffff) as usize;
+                let dynamic_len = (data_loc >> 16) as usize;
+                let Some(dynamic_offset) = full_offset
+                    .checked_sub(core::mem::size_of::<$crate::tracepoint::TraceEntry>())
+                else {
+                    return invalid();
+                };
+                let Some(dynamic_end) = dynamic_offset.checked_add(dynamic_len) else {
+                    return invalid();
+                };
+                let Some(dynamic_with_nul) = buf.get(dynamic_offset..dynamic_end) else {
+                    return invalid();
+                };
+                if dynamic_with_nul.last() != Some(&0) {
+                    return invalid();
+                }
+                let $dynamic = &dynamic_with_nul[..dynamic_with_nul.len() - 1];
+
+                let mut field_offset = 4usize;
+                $(
+                    let Some(aligned) = align_up(
+                        field_offset,
+                        <$entry_type as $crate::tracepoint::TraceEventField>::ALIGN,
+                    ) else { return invalid(); };
+                    let Some(field_end) = aligned.checked_add(
+                        <$entry_type as $crate::tracepoint::TraceEventField>::SIZE,
+                    ) else { return invalid(); };
+                    let Some(field_bytes) = buf.get(aligned..field_end) else {
+                        return invalid();
+                    };
+                    let Some($entry) = <$entry_type as $crate::tracepoint::TraceEventField>::read_ne(field_bytes) else {
+                        return invalid();
+                    };
+                    field_offset = field_end;
+                )*
+
+                struct Entry<'a> {
+                    $dynamic: &'a [u8],
+                    $($entry: $entry_type,)*
+                }
+                let $tp_ident = Entry {
+                    $dynamic: $dynamic,
+                    $($entry: $entry,)*
+                };
+                format!("{}", $fmt_expr)
+            }
+
+            #[allow(unused, non_snake_case)]
+            pub fn [<trace_fmt_show $name>]() -> alloc::string::String {
+                fn align_up(value: usize, align: usize) -> usize {
+                    value.div_ceil(align) * align
+                }
+
+                let mut fmt = format!("format:
+\tfield: u16 common_type; offset: 0; size: 2; signed: 0;
+\tfield: u8 common_flags; offset: 2; size: 1; signed: 0;
+\tfield: u8 common_preempt_count; offset: 3; size: 1; signed: 0;
+\tfield: i32 common_pid; offset: 4; size: 4; signed: 1;
+
+\tfield:__data_loc char[] {};\toffset:8;\tsize:4;\tsigned:1;\n",
+                    stringify!($dynamic),
+                );
+                let mut offset = 12usize;
+                $(
+                    offset = align_up(
+                        offset,
+                        <$entry_type as $crate::tracepoint::TraceEventField>::ALIGN,
+                    );
+                    fmt.push_str(&format!(
+                        "\tfield:{} {};\toffset:{};\tsize:{};\tsigned:{};\n",
+                        <$entry_type as $crate::tracepoint::TraceEventField>::TYPE_NAME,
+                        stringify!($entry),
+                        offset,
+                        <$entry_type as $crate::tracepoint::TraceEventField>::SIZE,
+                        if <$entry_type as $crate::tracepoint::TraceEventField>::SIGNED { 1 } else { 0 },
+                    ));
+                    offset += <$entry_type as $crate::tracepoint::TraceEventField>::SIZE;
+                )*
+                fmt.push_str(&format!("\nprint fmt: {}", $print_fmt));
+                fmt
+            }
+        }
+    };
+    (
+        $name:ident,
+        TP_system($system:ident),
+        TP_PROTO($($arg:ident:$arg_type:ty),*),
         TP_STRUCT__entry{$($entry:ident:$entry_type:ty,)*},
         TP_fast_assign{$($assign:ident:$value:expr,)*},
         TP_ident($tp_ident:ident),
@@ -64,20 +318,6 @@ macro_rules! define_event_trace{
                     trace_point.callback_list(&mut f);
                 }
             }
-            /// 该 tracepoint 当前是否已启用（只读检查，无副作用）。
-            ///
-            /// 用于在构造 trace 参数之前进行廉价的禁用路径守卫：tracepoint 未启用时，
-            /// 调用方可据此跳过取锁 / 拷贝 / UTF-8 扫描等参数构造开销，避免 Rust 在进入
-            /// `trace_<name>()` 之前即求值参数所引入的禁用路径开销。
-            ///
-            /// 实现只读取 static-key 的运行时状态（atomic Relaxed 读），不操作代码段、
-            /// 不注册新的 jump entry，与 `trace_<name>()` 内部 `static_branch_unlikely!`
-            /// 的语义一致——二者都返回 true 当且仅当该 key 已被启用。
-            #[inline(always)]
-            #[allow(unused,non_snake_case)]
-            pub fn [<trace_ $name _enabled>]() -> bool {
-                [<__ $name _KEY>].is_enabled()
-            }
             #[allow(unused,non_snake_case)]
             pub fn [<register_trace_ $name>](func: fn(& (dyn core::any::Any+Send+Sync), $($arg_type),*), data: alloc::boxed::Box<dyn core::any::Any+Send+Sync>){
                 let func = unsafe{core::mem::transmute::<fn(& (dyn core::any::Any+Send+Sync), $($arg_type),*), fn()>(func)};
@@ -95,7 +335,7 @@ macro_rules! define_event_trace{
             #[allow(non_snake_case,non_camel_case_types)]
             struct [<__ $name _TracePointMeta>]{
                 trace_point: &'static $crate::tracepoint::TracePoint,
-                print_func: fn(&mut (dyn core::any::Any+Send+Sync), $($arg_type),*),
+                print_func: fn(&(dyn core::any::Any+Send+Sync), $($arg_type),*),
             }
 
             #[allow(non_upper_case_globals)]
@@ -108,7 +348,7 @@ macro_rules! define_event_trace{
 
             #[allow(unused,non_snake_case)]
             #[allow(clippy::redundant_field_names)]
-            pub fn [<trace_default_ $name>](_data:&mut (dyn core::any::Any+Send+Sync), $($arg:$arg_type),* ){
+            pub fn [<trace_default_ $name>](_data:&(dyn core::any::Any+Send+Sync), $($arg:$arg_type),* ){
                 #[repr(C, packed)]
                 struct Entry {
                     $($entry: $entry_type,)*
@@ -145,14 +385,14 @@ macro_rules! define_event_trace{
                     )
                 };
 
-                let func = |f:&alloc::boxed::Box<dyn $crate::tracepoint::TracePointCallBackFunc>|{
-                    f.call(event_buf);
-                };
+                for callback in [<__ $name>].raw_callbacks_snapshot() {
+                    callback.call(event_buf);
+                }
 
-                [<__ $name>].raw_callback_list(&func);
-
-                $crate::debug::tracing::trace_cmdline_push(pid as u32);
-                $crate::debug::tracing::trace_pipe_push_raw_record(event_buf);
+                if [<__ $name>].is_trace_pipe_enabled() {
+                    $crate::debug::tracing::trace_cmdline_push(pid as u32);
+                    $crate::debug::tracing::trace_pipe_push_raw_record(event_buf);
+                }
             }
 
             #[allow(unused,non_snake_case)]

--- a/kernel/src/tracepoint/mod.rs
+++ b/kernel/src/tracepoint/mod.rs
@@ -17,7 +17,8 @@ use core::{
     sync::atomic::AtomicUsize,
 };
 pub use point::{
-    CommonTracePointMeta, TraceEntry, TracePoint, TracePointCallBackFunc, TracePointFunc,
+    CommonTracePointMeta, TraceEntry, TraceEventField, TracePoint, TracePointCallBackFunc,
+    TracePointFunc,
 };
 use system_error::SystemError;
 pub use trace_pipe::{
@@ -216,7 +217,7 @@ impl TracePointEnableFile {
     ///
     /// Returns true if the tracepoint is enabled, false otherwise.
     pub fn read(&self) -> &'static str {
-        if self.tracepoint.is_enabled() {
+        if self.tracepoint.is_trace_pipe_enabled() {
             "1\n"
         } else {
             "0\n"
@@ -225,8 +226,8 @@ impl TracePointEnableFile {
     /// Enable or disable the tracepoint
     pub fn write(&self, enable: char) {
         match enable {
-            '1' => self.tracepoint.enable(),
-            '0' => self.tracepoint.disable(),
+            '1' => self.tracepoint.set_trace_pipe_enabled(true),
+            '0' => self.tracepoint.set_trace_pipe_enabled(false),
             _ => {
                 log::warn!("Invalid value for tracepoint enable: {}", enable);
             }

--- a/kernel/src/tracepoint/point.rs
+++ b/kernel/src/tracepoint/point.rs
@@ -1,6 +1,10 @@
 use crate::libs::spinlock::SpinLock;
-use alloc::{boxed::Box, collections::BTreeMap, format, string::String};
-use core::{any::Any, fmt::Debug, sync::atomic::AtomicU32};
+use alloc::{boxed::Box, collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
+use core::{
+    any::Any,
+    fmt::Debug,
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+};
 use static_keys::StaticFalseKey;
 
 #[derive(Debug)]
@@ -38,11 +42,19 @@ pub struct TracePoint {
     system: &'static str,
     key: &'static StaticFalseKey,
     id: AtomicU32,
-    callback: SpinLock<BTreeMap<usize, TracePointFunc>>,
-    raw_callback: SpinLock<BTreeMap<usize, Box<dyn TracePointCallBackFunc>>>,
+    callback: SpinLock<Option<Arc<[TracePointFunc]>>>,
+    raw_callback: SpinLock<BTreeMap<usize, Arc<dyn TracePointCallBackFunc>>>,
+    enable_state: SpinLock<TracePointEnableState>,
+    trace_pipe_enabled: AtomicBool,
     trace_entry_fmt_func: fn(&[u8]) -> String,
     trace_print_func: fn() -> String,
     flags: u8,
+}
+
+#[derive(Debug)]
+struct TracePointEnableState {
+    users: usize,
+    trace_pipe_enabled: bool,
 }
 
 impl core::fmt::Debug for TracePoint {
@@ -63,15 +75,57 @@ pub struct CommonTracePointMeta {
     pub print_func: fn(),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TracePointFunc {
     pub func: fn(),
-    pub data: Box<dyn Any + Send + Sync>,
+    pub data: Arc<dyn Any + Send + Sync>,
 }
 
 pub trait TracePointCallBackFunc: Send + Sync {
     fn call(&self, entry: &[u8]);
 }
+
+/// Scalar field types supported by dynamically-sized trace records.
+///
+/// The codec writes fields explicitly instead of copying a Rust structure's
+/// object representation, so padding bytes never become part of the ABI.
+pub trait TraceEventField: Copy {
+    const SIZE: usize;
+    const ALIGN: usize;
+    const SIGNED: bool;
+    const TYPE_NAME: &'static str;
+
+    fn write_ne(self, dst: &mut [u8]) -> bool;
+    fn read_ne(src: &[u8]) -> Option<Self>;
+}
+
+macro_rules! impl_trace_event_field {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl TraceEventField for $ty {
+                const SIZE: usize = core::mem::size_of::<Self>();
+                const ALIGN: usize = core::mem::align_of::<Self>();
+                const SIGNED: bool = <$ty>::MIN != 0;
+                const TYPE_NAME: &'static str = stringify!($ty);
+
+                fn write_ne(self, dst: &mut [u8]) -> bool {
+                    let bytes = self.to_ne_bytes();
+                    if dst.len() != bytes.len() {
+                        return false;
+                    }
+                    dst.copy_from_slice(&bytes);
+                    true
+                }
+
+                fn read_ne(src: &[u8]) -> Option<Self> {
+                    Some(<$ty>::from_ne_bytes(src.try_into().ok()?))
+                }
+            }
+        )*
+    };
+}
+
+impl_trace_event_field!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
 
 impl TracePoint {
     pub const fn new(
@@ -89,8 +143,13 @@ impl TracePoint {
             flags: 0,
             trace_entry_fmt_func: fmt_func,
             trace_print_func,
-            callback: SpinLock::new(BTreeMap::new()),
+            callback: SpinLock::new(None),
             raw_callback: SpinLock::new(BTreeMap::new()),
+            enable_state: SpinLock::new(TracePointEnableState {
+                users: 0,
+                trace_pipe_enabled: false,
+            }),
+            trace_pipe_enabled: AtomicBool::new(false),
         }
     }
 
@@ -135,22 +194,55 @@ impl TracePoint {
 
     /// Register a callback function to the tracepoint
     pub fn register(&self, func: fn(), data: Box<dyn Any + Sync + Send>) {
-        let trace_point_func = TracePointFunc { func, data };
         let ptr = func as usize;
-        self.callback.lock().entry(ptr).or_insert(trace_point_func);
+        let mut callbacks = self.callback.lock();
+        if callbacks
+            .as_deref()
+            .is_some_and(|current| current.iter().any(|item| item.func as usize == ptr))
+        {
+            return;
+        }
+
+        let mut updated = callbacks
+            .as_deref()
+            .map(<[TracePointFunc]>::to_vec)
+            .unwrap_or_default();
+        updated.push(TracePointFunc {
+            func,
+            data: data.into(),
+        });
+        *callbacks = Some(updated.into());
     }
 
     /// Unregister a callback function from the tracepoint
     pub fn unregister(&self, func: fn()) {
         let func_ptr = func as usize;
-        self.callback.lock().remove(&func_ptr);
+        let mut callbacks = self.callback.lock();
+        let Some(current) = callbacks.as_deref() else {
+            return;
+        };
+        let updated: Vec<_> = current
+            .iter()
+            .filter(|item| item.func as usize != func_ptr)
+            .cloned()
+            .collect();
+        if updated.len() == current.len() {
+            return;
+        }
+        *callbacks = if updated.is_empty() {
+            None
+        } else {
+            Some(updated.into())
+        };
     }
 
     /// Iterate over all registered callback functions
     pub fn callback_list(&self, f: &dyn Fn(&TracePointFunc)) {
-        let callback = self.callback.lock();
-        for trace_func in callback.values() {
-            f(trace_func);
+        let callbacks = self.callback.lock().clone();
+        if let Some(callbacks) = callbacks {
+            for trace_func in callbacks.iter() {
+                f(trace_func);
+            }
         }
     }
 
@@ -160,7 +252,7 @@ impl TracePoint {
     pub fn register_raw_callback(
         &self,
         callback_id: usize,
-        callback: Box<dyn TracePointCallBackFunc>,
+        callback: Arc<dyn TracePointCallBackFunc>,
     ) {
         self.raw_callback
             .lock()
@@ -173,30 +265,73 @@ impl TracePoint {
         self.raw_callback.lock().remove(&callback_id);
     }
 
-    /// Iterate over all registered raw callback functions
-    pub fn raw_callback_list(&self, f: &dyn Fn(&Box<dyn TracePointCallBackFunc>)) {
-        let raw_callback = self.raw_callback.lock();
-        for callback in raw_callback.values() {
-            f(callback);
+    /// Snapshot all registered raw callbacks.
+    ///
+    /// Callback execution may allocate and run arbitrary BPF code, so it must
+    /// not happen while the registry spin lock is held. `Arc` keeps callbacks
+    /// alive when an owner unregisters after this snapshot was taken.
+    pub fn raw_callbacks_snapshot(&self) -> Vec<Arc<dyn TracePointCallBackFunc>> {
+        self.raw_callback.lock().values().cloned().collect()
+    }
+
+    /// Acquire one active consumer reference.
+    pub fn acquire_enable(&self) {
+        let mut state = self.enable_state.lock();
+        let users = state
+            .users
+            .checked_add(1)
+            .expect("tracepoint enable reference overflow");
+        if state.users == 0 {
+            unsafe { self.key.enable() };
+        }
+        state.users = users;
+    }
+
+    /// Release one active consumer reference.
+    pub fn release_enable(&self) {
+        let mut state = self.enable_state.lock();
+        state.users = state
+            .users
+            .checked_sub(1)
+            .expect("tracepoint enable reference underflow");
+        if state.users == 0 {
+            unsafe { self.key.disable() };
         }
     }
 
-    /// Enable the tracepoint
-    pub fn enable(&self) {
-        unsafe {
-            self.key.enable();
+    /// Set the tracefs recording owner state. Repeated writes are idempotent.
+    pub fn set_trace_pipe_enabled(&self, enabled: bool) {
+        let mut state = self.enable_state.lock();
+        if state.trace_pipe_enabled == enabled {
+            return;
+        }
+
+        if enabled {
+            let users = state
+                .users
+                .checked_add(1)
+                .expect("tracepoint enable reference overflow");
+            if state.users == 0 {
+                unsafe { self.key.enable() };
+            }
+            state.users = users;
+            state.trace_pipe_enabled = true;
+            self.trace_pipe_enabled.store(true, Ordering::Release);
+        } else {
+            self.trace_pipe_enabled.store(false, Ordering::Release);
+            state.trace_pipe_enabled = false;
+            state.users = state
+                .users
+                .checked_sub(1)
+                .expect("tracepoint enable reference underflow");
+            if state.users == 0 {
+                unsafe { self.key.disable() };
+            }
         }
     }
 
-    /// Disable the tracepoint
-    pub fn disable(&self) {
-        unsafe {
-            self.key.disable();
-        }
-    }
-
-    /// Check if the tracepoint is enabled
-    pub fn is_enabled(&self) -> bool {
-        self.key.is_enabled()
+    /// Whether tracefs owns an active recording reference.
+    pub fn is_trace_pipe_enabled(&self) -> bool {
+        self.trace_pipe_enabled.load(Ordering::Acquire)
     }
 }

--- a/kernel/src/tracepoint/trace_pipe.rs
+++ b/kernel/src/tracepoint/trace_pipe.rs
@@ -146,18 +146,19 @@ impl TraceCmdLineCache {
     /// If the command line exceeds 16 bytes, it will be truncated.
     /// If the cache exceeds the maximum record limit, the oldest entry will be removed.
     pub fn insert(&mut self, id: u32, cmdline: String) {
+        if self.max_record == 0 {
+            return;
+        }
         if self.cmdline.len() >= self.max_record {
             // Remove the oldest entry if we exceed the max record limit
             self.cmdline.remove(0);
         }
         let mut cmdline_bytes = [0u8; 16];
-        if cmdline.len() > 16 {
-            // Truncate to fit the fixed size
-            cmdline_bytes.copy_from_slice(&cmdline.as_bytes()[..16]);
-        } else {
-            // Copy the command line bytes into the fixed size array
-            cmdline_bytes[..cmdline.len()].copy_from_slice(cmdline.as_bytes());
+        let mut len = cmdline.len().min(15);
+        while len > 0 && !cmdline.is_char_boundary(len) {
+            len -= 1;
         }
+        cmdline_bytes[..len].copy_from_slice(&cmdline.as_bytes()[..len]);
         self.cmdline.push((id, cmdline_bytes));
     }
 
@@ -165,7 +166,11 @@ impl TraceCmdLineCache {
     pub fn get(&self, id: u32) -> Option<&str> {
         self.cmdline.iter().find_map(|(key, value)| {
             if *key == id {
-                Some(core::str::from_utf8(value).unwrap().trim_end_matches('\0'))
+                let len = value
+                    .iter()
+                    .position(|byte| *byte == 0)
+                    .unwrap_or(value.len());
+                core::str::from_utf8(&value[..len]).ok()
             } else {
                 None
             }
@@ -176,7 +181,8 @@ impl TraceCmdLineCache {
     pub fn set_max_record(&mut self, max_len: usize) {
         self.max_record = max_len;
         if self.cmdline.len() > max_len {
-            self.cmdline.truncate(max_len); // Keep only the latest records
+            let remove = self.cmdline.len() - max_len;
+            self.cmdline.drain(..remove);
         }
     }
 
@@ -210,6 +216,48 @@ impl TraceCmdLineCacheSnapshot {
         } else {
             Some(self.0.remove(0))
         }
+    }
+}
+
+#[cfg(test)]
+mod cmdline_cache_tests {
+    use super::TraceCmdLineCache;
+    use alloc::string::ToString;
+
+    #[test]
+    fn truncates_at_utf8_boundary_and_keeps_nul_space() {
+        let mut cache = TraceCmdLineCache::new(4);
+        cache.insert(1, "abcdefghijklmnop".to_string());
+        assert_eq!(cache.get(1), Some("abcdefghijklmno"));
+
+        cache.insert(2, "abcdefghijklmn界".to_string());
+        assert_eq!(cache.get(2), Some("abcdefghijklmn"));
+    }
+
+    #[test]
+    fn invalid_cached_bytes_do_not_panic() {
+        let mut cache = TraceCmdLineCache::new(1);
+        let mut invalid = [0u8; 16];
+        invalid[0] = 0xff;
+        cache.cmdline.push((1, invalid));
+        assert_eq!(cache.get(1), None);
+    }
+
+    #[test]
+    fn zero_capacity_and_shrink_keep_cache_invariants() {
+        let mut disabled = TraceCmdLineCache::new(0);
+        disabled.insert(1, "ignored".to_string());
+        assert_eq!(disabled.get(1), None);
+
+        let mut cache = TraceCmdLineCache::new(4);
+        for id in 1..=4 {
+            cache.insert(id, id.to_string());
+        }
+        cache.set_max_record(2);
+        assert_eq!(cache.get(1), None);
+        assert_eq!(cache.get(2), None);
+        assert_eq!(cache.get(3), Some("3"));
+        assert_eq!(cache.get(4), Some("4"));
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
@@ -120,6 +120,10 @@ TEST(SchedProcessExecTp, EventFilesExist) {
     EXPECT_FALSE(id.empty());
     char* end = nullptr;
     long idval = strtol(id.c_str(), &end, 10);
+    // 确认整个字符串都是数字（允许尾部换行），而非仅前缀可解析。
+    ASSERT_NE(end, id.c_str()) << "id not numeric: " << id;
+    while (end != nullptr && (*end == '\n' || *end == '\r' || *end == ' ')) ++end;
+    EXPECT_EQ(end != nullptr && *end == '\0', true) << "id has trailing garbage: " << id;
     EXPECT_GE(idval, 0) << "invalid id: " << id;
 
     EXPECT_EQ(0, umount(root)) << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
@@ -114,13 +114,13 @@ TEST(SchedProcessExecTp, EventFilesExist) {
     std::string enable = read_all(file);
     EXPECT_NE(std::string::npos, enable.find("0")) << "enable not '0' by default: " << enable;
 
-    // id 应为数字。
+    // id 应为非负整数（DragonOS tracepoint id 从 0 开始递增分配）。
     snprintf(file, sizeof(file), "%s/id", base);
     std::string id = read_all(file);
     EXPECT_FALSE(id.empty());
     char* end = nullptr;
     long idval = strtol(id.c_str(), &end, 10);
-    EXPECT_GT(idval, 0) << "invalid id: " << id;
+    EXPECT_GE(idval, 0) << "invalid id: " << id;
 
     EXPECT_EQ(0, umount(root)) << strerror(errno);
     EXPECT_EQ(0, rmdir(root)) << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
@@ -1,0 +1,187 @@
+// sched_process_exec tracepoint 语义测试。
+//
+// 验证：
+//   1. sched_process_exec 事件在 debugfs 下正确导出（enable/format/id 文件 + format 字段）。
+//   2. enable 后执行 execve 会触发该 tracepoint，并在 trace 文件中留下记录。
+//
+// 对应 issue #2149。
+
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+constexpr char kHelperExec[] = "--sched-tp-helper-exit0";
+
+// 读 path 全部内容（非阻塞，读到 EOF 为止）。
+std::string read_all(const char* path) {
+    int fd = open(path, O_RDONLY);
+    EXPECT_GE(fd, 0) << "open(" << path << ") failed: errno=" << errno << " ("
+                     << strerror(errno) << ")";
+    if (fd < 0) {
+        return {};
+    }
+    std::string out;
+    char buf[256];
+    while (true) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n <= 0) {
+            break;
+        }
+        out.append(buf, static_cast<size_t>(n));
+    }
+    close(fd);
+    return out;
+}
+
+// 向 path 写 data，返回是否写成功。
+bool write_file(const char* path, const char* data) {
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        return false;
+    }
+    size_t len = strlen(data);
+    ssize_t n = write(fd, data, len);
+    close(fd);
+    return n == static_cast<ssize_t>(len);
+}
+
+// mount debugfs 到 root。
+void mount_debugfs(const char* root) {
+    ASSERT_EQ(0, mount("none", root, "debugfs", 0, nullptr))
+        << "mount debugfs failed: errno=" << errno << " (" << strerror(errno) << ")";
+}
+
+// 子模式：被 execve 进来后立即退出 0。
+[[noreturn]] void helper_exec_exit0() {
+    char arg0[] = "/proc/self/exe";
+    char arg1[] = "--sched-tp-helper-exit0";
+    char* const argv[] = {arg0, arg1, nullptr};
+    char* const envp[] = {nullptr};
+    execve("/proc/self/exe", argv, envp);
+    _exit(127);
+}
+
+}  // namespace
+
+// 事件文件存在且 format 含全部字段。
+TEST(SchedProcessExecTp, EventFilesExist) {
+    char root[128] = {};
+    snprintf(root, sizeof(root), "/tmp/sched_tp_events_%d", getpid());
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+
+    mount_debugfs(root);
+
+    const char* base_rel = "/tracing/events/sched/sched_process_exec";
+    char base[256] = {};
+    snprintf(base, sizeof(base), "%s%s", root, base_rel);
+
+    struct stat st = {};
+    ASSERT_EQ(0, stat(base, &st)) << "missing event dir " << base << ": " << strerror(errno);
+    EXPECT_TRUE(S_ISDIR(st.st_mode));
+
+    char file[320] = {};
+    for (const char* leaf : {"enable", "format", "id"}) {
+        snprintf(file, sizeof(file), "%s/%s", base, leaf);
+        ASSERT_EQ(0, stat(file, &st))
+            << "missing " << file << ": " << strerror(errno);
+    }
+
+    // format 文件应含事件名与全部字段。
+    snprintf(file, sizeof(file), "%s/format", base);
+    std::string fmt = read_all(file);
+    ASSERT_FALSE(fmt.empty());
+    for (const char* needle :
+         {"sched_process_exec", "common_pid", "comm", "pid", "old_pid"}) {
+        EXPECT_NE(std::string::npos, fmt.find(needle))
+            << "format missing \"" << needle << "\"\n"
+            << fmt;
+    }
+
+    // enable 默认为 "0"（未启用）。
+    snprintf(file, sizeof(file), "%s/enable", base);
+    std::string enable = read_all(file);
+    EXPECT_NE(std::string::npos, enable.find("0")) << "enable not '0' by default: " << enable;
+
+    // id 应为数字。
+    snprintf(file, sizeof(file), "%s/id", base);
+    std::string id = read_all(file);
+    EXPECT_FALSE(id.empty());
+    char* end = nullptr;
+    long idval = strtol(id.c_str(), &end, 10);
+    EXPECT_GT(idval, 0) << "invalid id: " << id;
+
+    EXPECT_EQ(0, umount(root)) << strerror(errno);
+    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+}
+
+// enable 后 execve 应触发事件，trace 文件留下记录。
+TEST(SchedProcessExecTp, FiresOnExecve) {
+    char root[128] = {};
+    snprintf(root, sizeof(root), "/tmp/sched_tp_fire_%d", getpid());
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+
+    mount_debugfs(root);
+
+    const char* base_rel = "/tracing/events/sched/sched_process_exec";
+    char base[256] = {};
+    snprintf(base, sizeof(base), "%s%s", root, base_rel);
+
+    // 启用事件。
+    char enable_path[320] = {};
+    snprintf(enable_path, sizeof(enable_path), "%s/enable", base);
+    ASSERT_TRUE(write_file(enable_path, "1")) << "enable write failed";
+
+    // 清空 ring buffer：向 trace 写任意字节触发 clear。
+    char trace_path[256] = {};
+    snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
+    ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
+
+    // fork + execve 自身触发 sched_process_exec。
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: " << strerror(errno);
+    if (child == 0) {
+        helper_exec_exit0();
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: " << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "helper exit code != 0";
+
+    // 读 trace 快照，断言含 sched_process_exec 记录。
+    std::string trace = read_all(trace_path);
+    ASSERT_FALSE(trace.empty()) << "trace empty after execve";
+    EXPECT_NE(std::string::npos, trace.find("sched_process_exec("))
+        << "no sched_process_exec record in trace:\n"
+        << trace;
+    // TP_printk 输出的字段。
+    EXPECT_NE(std::string::npos, trace.find("comm="))
+        << "trace missing comm= field:\n"
+        << trace;
+
+    // 关闭事件并清理。
+    write_file(enable_path, "0");
+    EXPECT_EQ(0, umount(root)) << strerror(errno);
+    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+}
+
+int main(int argc, char** argv) {
+    // 子模式：被 execve 进来后立即退出 0。
+    if (argc >= 2 && strcmp(argv[1], kHelperExec) == 0) {
+        _exit(0);
+    }
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
@@ -10,6 +10,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -71,6 +72,24 @@ void mount_debugfs(const char* root) {
     char* const envp[] = {nullptr};
     execve("/proc/self/exe", argv, envp);
     _exit(127);
+}
+
+// non-leader exec 辅助：sibling 线程（非 leader）执行 execve。
+void* sibling_exec_thread(void*) {
+    helper_exec_exit0();
+    return nullptr;
+}
+
+// 子模式：创建 sibling 线程（非 leader）执行 execve，主线程（leader）永久挂起。
+// 触发内核 de_thread 的 raw_pid 交换路径（old_pid ≠ pid）。
+[[noreturn]] void helper_sibling_exec_exit0() {
+    pthread_t thread;
+    if (pthread_create(&thread, nullptr, sibling_exec_thread, nullptr) != 0) {
+        _exit(1);
+    }
+    for (;;) {
+        pause();
+    }
 }
 
 }  // namespace
@@ -176,6 +195,174 @@ TEST(SchedProcessExecTp, FiresOnExecve) {
         << trace;
 
     // 关闭事件并清理。
+    write_file(enable_path, "0");
+    EXPECT_EQ(0, umount(root)) << strerror(errno);
+    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+}
+
+// 默认 disabled 时 execve 不应在 trace 留下 sched_process_exec 记录。
+// 验证 static-key 门控：未 enable 时 tracepoint 零记录（若门控坏了永远触发，此处可抓住）。
+TEST(SchedProcessExecTp, DefaultDisabledNoRecords) {
+    char root[128] = {};
+    snprintf(root, sizeof(root), "/tmp/sched_tp_disabled_%d", getpid());
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+
+    mount_debugfs(root);
+
+    char trace_path[256] = {};
+    snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
+
+    // 清空 ring buffer。
+    ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
+
+    // 不 enable（保持默认 disabled 状态），fork + execve 自身触发。
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: " << strerror(errno);
+    if (child == 0) {
+        helper_exec_exit0();
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: " << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "helper exit code != 0";
+
+    // 默认 disabled：trace 中不应出现 sched_process_exec 记录。
+    std::string trace = read_all(trace_path);
+    EXPECT_EQ(std::string::npos, trace.find("sched_process_exec("))
+        << "tracepoint fired while disabled (static-key gate broken):\n"
+        << trace;
+
+    EXPECT_EQ(0, umount(root)) << strerror(errno);
+    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+}
+
+// enable 后能触发，disable 后不再触发。验证 enable/disable 状态机真正翻转 static-key。
+TEST(SchedProcessExecTp, DisableStopsFiring) {
+    char root[128] = {};
+    snprintf(root, sizeof(root), "/tmp/sched_tp_disable_%d", getpid());
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+
+    mount_debugfs(root);
+
+    const char* base_rel = "/tracing/events/sched/sched_process_exec";
+    char base[256] = {};
+    snprintf(base, sizeof(base), "%s%s", root, base_rel);
+
+    char enable_path[320] = {};
+    snprintf(enable_path, sizeof(enable_path), "%s/enable", base);
+    char trace_path[256] = {};
+    snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
+
+    // 基线：enable 后触发。
+    ASSERT_TRUE(write_file(enable_path, "1")) << "enable write failed";
+    ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
+    {
+        pid_t child = fork();
+        ASSERT_GE(child, 0) << "fork failed: " << strerror(errno);
+        if (child == 0) {
+            helper_exec_exit0();
+        }
+        int status = 0;
+        ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: " << strerror(errno);
+        ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+        ASSERT_EQ(0, WEXITSTATUS(status)) << "helper exit code != 0";
+    }
+    {
+        std::string trace = read_all(trace_path);
+        ASSERT_FALSE(trace.empty()) << "trace empty after enabled execve";
+        ASSERT_NE(std::string::npos, trace.find("sched_process_exec("))
+            << "enabled state did not fire (baseline):\n"
+            << trace;
+    }
+
+    // disable 后清 buffer 再触发：不应再记录。
+    ASSERT_TRUE(write_file(enable_path, "0")) << "disable write failed";
+    ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
+    {
+        pid_t child = fork();
+        ASSERT_GE(child, 0) << "fork failed: " << strerror(errno);
+        if (child == 0) {
+            helper_exec_exit0();
+        }
+        int status = 0;
+        ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: " << strerror(errno);
+        ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+        ASSERT_EQ(0, WEXITSTATUS(status)) << "helper exit code != 0";
+    }
+    {
+        std::string trace = read_all(trace_path);
+        EXPECT_EQ(std::string::npos, trace.find("sched_process_exec("))
+            << "tracepoint still fired after disable:\n"
+            << trace;
+    }
+
+    EXPECT_EQ(0, umount(root)) << strerror(errno);
+    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+}
+
+// non-leader 线程 execve：触发 de_thread 的 raw_pid 交换，old_pid ≠ pid。
+// FiresOnExecve 走单线程 leader exec（old_pid == pid），此处覆盖非 leader 路径。
+TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
+    char root[128] = {};
+    snprintf(root, sizeof(root), "/tmp/sched_tp_nonleader_%d", getpid());
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+
+    mount_debugfs(root);
+
+    const char* base_rel = "/tracing/events/sched/sched_process_exec";
+    char base[256] = {};
+    snprintf(base, sizeof(base), "%s%s", root, base_rel);
+
+    char enable_path[320] = {};
+    snprintf(enable_path, sizeof(enable_path), "%s/enable", base);
+    char trace_path[256] = {};
+    snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
+
+    ASSERT_TRUE(write_file(enable_path, "1")) << "enable write failed";
+    ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
+
+    // fork child：child 创建 sibling 线程（非 leader）执行 execve，leader 永久挂起。
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: " << strerror(errno);
+    if (child == 0) {
+        helper_sibling_exec_exit0();
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: " << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "helper exit code != 0";
+
+    std::string trace = read_all(trace_path);
+    ASSERT_FALSE(trace.empty()) << "trace empty after non-leader execve";
+
+    // 找到包含 sched_process_exec 的记录行。
+    size_t rec = trace.find("sched_process_exec");
+    ASSERT_NE(std::string::npos, rec)
+        << "no sched_process_exec record after non-leader execve:\n"
+        << trace;
+    size_t line_end = trace.find('\n', rec);
+    if (line_end == std::string::npos) {
+        line_end = trace.size();
+    }
+    std::string record = trace.substr(rec, line_end - rec);
+
+    // 解析 old_pid=N。注意 "old_pid=" 含 "pid=" 子串，先取 old_pid。
+    size_t old_pos = record.find("old_pid=");
+    ASSERT_NE(std::string::npos, old_pos) << "record missing old_pid=:\n" << record;
+    long old_pid_val = strtol(record.c_str() + old_pos + strlen("old_pid="), nullptr, 10);
+
+    // 解析 pid=N：用 " pid="（带前导空格）避免命中 old_pid 内的 pid。
+    size_t pid_pos = record.find(" pid=");
+    ASSERT_NE(std::string::npos, pid_pos) << "record missing pid=:\n" << record;
+    long pid_val = strtol(record.c_str() + pid_pos + strlen(" pid="), nullptr, 10);
+
+    // non-leader exec 触发 de_thread 交换：old_pid（调用 execve 线程原 PID）≠ pid（交换后 leader PID）。
+    EXPECT_NE(old_pid_val, pid_val)
+        << "non-leader exec should produce distinct old_pid vs pid:\n"
+        << record;
+
     write_file(enable_path, "0");
     EXPECT_EQ(0, umount(root)) << strerror(errno);
     EXPECT_EQ(0, rmdir(root)) << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
@@ -58,11 +58,47 @@ bool write_file(const char* path, const char* data) {
     return n == static_cast<ssize_t>(len);
 }
 
-// mount debugfs 到 root。
-void mount_debugfs(const char* root) {
-    ASSERT_EQ(0, mount("none", root, "debugfs", 0, nullptr))
-        << "mount debugfs failed: errno=" << errno << " (" << strerror(errno) << ")";
+// mount debugfs 到 root。返回 AssertionResult，供调用处 ASSERT_TRUE 在 mount
+// 失败时终止当前 TEST（Thread7：避免 void helper 里的 fatal assertion 只 return helper
+// 而让测试继续对着普通目录跑、产生连锁失败）。
+::testing::AssertionResult mount_debugfs(const char* root) {
+    if (mount("none", root, "debugfs", 0, nullptr) != 0) {
+        return ::testing::AssertionFailure()
+               << "mount debugfs failed: errno=" << errno << " (" << strerror(errno)
+               << ")";
+    }
+    return ::testing::AssertionSuccess();
 }
+
+// RAII guard：持有 debugfs mount 点，保证任意 ASSERT 提前 return 时都恢复测试前
+// 状态（Thread8：否则中途 ASSERT 失败会泄漏 enabled 的 static key + mount 点，污染
+// 共享 buffer 并给后续无关 exec 永久加开销）。
+//
+// 构造前提：mount_debugfs 已成功（mount 已生效）。此时析构必须 umount + rmdir。
+// arm_enable()：在事件成功 enable 后调用，记录 enable 文件路径；析构时写回 "0"。
+// 析构顺序：disable（仅当 arm 过）→ umount → rmdir。不可拷贝/移动（持有路径所有权）。
+class DebugfsMount {
+ public:
+    explicit DebugfsMount(const char* root) : root_(root) {}
+
+    ~DebugfsMount() {
+        if (!enable_path_.empty()) {
+            write_file(enable_path_.c_str(), "0");
+        }
+        umount(root_.c_str());
+        rmdir(root_.c_str());
+    }
+
+    DebugfsMount(const DebugfsMount&) = delete;
+    DebugfsMount& operator=(const DebugfsMount&) = delete;
+
+    // 在事件成功 enable 后调用：析构时把该文件写回 "0"。
+    void arm_enable(const char* enable_path) { enable_path_ = enable_path; }
+
+ private:
+    std::string root_;
+    std::string enable_path_;
+};
 
 // 子模式：被 execve 进来后立即退出 0。
 [[noreturn]] void helper_exec_exit0() {
@@ -100,7 +136,8 @@ TEST(SchedProcessExecTp, EventFilesExist) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_events_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
-    mount_debugfs(root);
+    ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
+    DebugfsMount guard(root);          // Thread8：RAII，任意提前 return 都 umount + rmdir。
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -145,8 +182,7 @@ TEST(SchedProcessExecTp, EventFilesExist) {
     EXPECT_EQ(end != nullptr && *end == '\0', true) << "id has trailing garbage: " << id;
     EXPECT_GE(idval, 0) << "invalid id: " << id;
 
-    EXPECT_EQ(0, umount(root)) << strerror(errno);
-    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+    // 清理由 RAII guard 析构完成（umount + rmdir；本测例未 enable，无需 disable）。
 }
 
 // enable 后 execve 应触发事件，trace 文件留下记录。
@@ -155,7 +191,8 @@ TEST(SchedProcessExecTp, FiresOnExecve) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_fire_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
-    mount_debugfs(root);
+    ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
+    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir。
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -165,6 +202,7 @@ TEST(SchedProcessExecTp, FiresOnExecve) {
     char enable_path[320] = {};
     snprintf(enable_path, sizeof(enable_path), "%s/enable", base);
     ASSERT_TRUE(write_file(enable_path, "1")) << "enable write failed";
+    guard.arm_enable(enable_path);  // Thread8：任意提前 return 析构都会写回 "0"。
 
     // 清空 ring buffer：向 trace 写任意字节触发 clear。
     char trace_path[256] = {};
@@ -194,10 +232,7 @@ TEST(SchedProcessExecTp, FiresOnExecve) {
         << "trace missing comm= field:\n"
         << trace;
 
-    // 关闭事件并清理。
-    write_file(enable_path, "0");
-    EXPECT_EQ(0, umount(root)) << strerror(errno);
-    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+    // 清理由 RAII guard 析构完成（disable + umount + rmdir）。
 }
 
 // 默认 disabled 时 execve 不应在 trace 留下 sched_process_exec 记录。
@@ -207,7 +242,8 @@ TEST(SchedProcessExecTp, DefaultDisabledNoRecords) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_disabled_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
-    mount_debugfs(root);
+    ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
+    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir（本测例不 enable）。
 
     char trace_path[256] = {};
     snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
@@ -233,8 +269,7 @@ TEST(SchedProcessExecTp, DefaultDisabledNoRecords) {
         << "tracepoint fired while disabled (static-key gate broken):\n"
         << trace;
 
-    EXPECT_EQ(0, umount(root)) << strerror(errno);
-    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+    // 清理由 RAII guard 析构完成（umount + rmdir；本测例未 enable，无需 disable）。
 }
 
 // enable 后能触发，disable 后不再触发。验证 enable/disable 状态机真正翻转 static-key。
@@ -243,7 +278,8 @@ TEST(SchedProcessExecTp, DisableStopsFiring) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_disable_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
-    mount_debugfs(root);
+    ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
+    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir。
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -256,6 +292,7 @@ TEST(SchedProcessExecTp, DisableStopsFiring) {
 
     // 基线：enable 后触发。
     ASSERT_TRUE(write_file(enable_path, "1")) << "enable write failed";
+    guard.arm_enable(enable_path);  // Thread8：任意提前 return 析构都会写回 "0"。
     ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
     {
         pid_t child = fork();
@@ -297,8 +334,7 @@ TEST(SchedProcessExecTp, DisableStopsFiring) {
             << trace;
     }
 
-    EXPECT_EQ(0, umount(root)) << strerror(errno);
-    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+    // 清理由 RAII guard 析构完成（disable + umount + rmdir；析构再次写 "0" 对已 disable 状态幂等）。
 }
 
 // non-leader 线程 execve：触发 de_thread 的 raw_pid 交换，old_pid ≠ pid。
@@ -308,7 +344,8 @@ TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_nonleader_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
-    mount_debugfs(root);
+    ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
+    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir。
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -320,6 +357,7 @@ TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
     snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
 
     ASSERT_TRUE(write_file(enable_path, "1")) << "enable write failed";
+    guard.arm_enable(enable_path);  // Thread8：任意提前 return 析构都会写回 "0"。
     ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
 
     // fork child：child 创建 sibling 线程（非 leader）执行 execve，leader 永久挂起。
@@ -363,9 +401,7 @@ TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
         << "non-leader exec should produce distinct old_pid vs pid:\n"
         << record;
 
-    write_file(enable_path, "0");
-    EXPECT_EQ(0, umount(root)) << strerror(errno);
-    EXPECT_EQ(0, rmdir(root)) << strerror(errno);
+    // 清理由 RAII guard 析构完成（disable + umount + rmdir）。
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_tracepoint.cc
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -85,7 +86,9 @@ class DebugfsMount {
         if (!enable_path_.empty()) {
             write_file(enable_path_.c_str(), "0");
         }
-        umount(root_.c_str());
+        if (mounted_) {
+            umount(root_.c_str());
+        }
         rmdir(root_.c_str());
     }
 
@@ -94,11 +97,73 @@ class DebugfsMount {
 
     // 在事件成功 enable 后调用：析构时把该文件写回 "0"。
     void arm_enable(const char* enable_path) { enable_path_ = enable_path; }
+    void mark_mounted() { mounted_ = true; }
 
  private:
     std::string root_;
     std::string enable_path_;
+    bool mounted_ = false;
 };
+
+class TemporaryPath {
+ public:
+    explicit TemporaryPath(const char* path) : path_(path) {}
+    ~TemporaryPath() { unlink(path_.c_str()); }
+    TemporaryPath(const TemporaryPath&) = delete;
+    TemporaryPath& operator=(const TemporaryPath&) = delete;
+
+ private:
+    std::string path_;
+};
+
+std::string record_for_pid(const std::string& trace, pid_t pid) {
+    const std::string pid_field = " pid=" + std::to_string(pid) + " old_pid=";
+    size_t start = 0;
+    while (start < trace.size()) {
+        size_t end = trace.find('\n', start);
+        if (end == std::string::npos) end = trace.size();
+        std::string line = trace.substr(start, end - start);
+        if (line.find("sched_process_exec(") != std::string::npos &&
+            line.find(pid_field) != std::string::npos) {
+            return line;
+        }
+        start = end + 1;
+    }
+    return {};
+}
+
+bool copy_file(const char* source, const char* destination) {
+    int in = open(source, O_RDONLY);
+    if (in < 0) return false;
+    int out = open(destination, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+    if (out < 0) {
+        close(in);
+        return false;
+    }
+    bool ok = true;
+    char buf[4096];
+    while (true) {
+        ssize_t n = read(in, buf, sizeof(buf));
+        if (n == 0) break;
+        if (n < 0) {
+            ok = false;
+            break;
+        }
+        ssize_t written = 0;
+        while (written < n) {
+            ssize_t part = write(out, buf + written, static_cast<size_t>(n - written));
+            if (part <= 0) {
+                ok = false;
+                break;
+            }
+            written += part;
+        }
+        if (!ok) break;
+    }
+    close(in);
+    close(out);
+    return ok;
+}
 
 // 子模式：被 execve 进来后立即退出 0。
 [[noreturn]] void helper_exec_exit0() {
@@ -111,16 +176,22 @@ class DebugfsMount {
 }
 
 // non-leader exec 辅助：sibling 线程（非 leader）执行 execve。
-void* sibling_exec_thread(void*) {
+void* sibling_exec_thread(void* arg) {
+    int notify_fd = *static_cast<int*>(arg);
+    pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+    if (write(notify_fd, &tid, sizeof(tid)) != sizeof(tid)) {
+        _exit(2);
+    }
+    close(notify_fd);
     helper_exec_exit0();
     return nullptr;
 }
 
 // 子模式：创建 sibling 线程（非 leader）执行 execve，主线程（leader）永久挂起。
 // 触发内核 de_thread 的 raw_pid 交换路径（old_pid ≠ pid）。
-[[noreturn]] void helper_sibling_exec_exit0() {
+[[noreturn]] void helper_sibling_exec_exit0(int notify_fd) {
     pthread_t thread;
-    if (pthread_create(&thread, nullptr, sibling_exec_thread, nullptr) != 0) {
+    if (pthread_create(&thread, nullptr, sibling_exec_thread, &notify_fd) != 0) {
         _exit(1);
     }
     for (;;) {
@@ -136,8 +207,9 @@ TEST(SchedProcessExecTp, EventFilesExist) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_events_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
+    DebugfsMount guard(root);
     ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
-    DebugfsMount guard(root);          // Thread8：RAII，任意提前 return 都 umount + rmdir。
+    guard.mark_mounted();
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -158,8 +230,9 @@ TEST(SchedProcessExecTp, EventFilesExist) {
     snprintf(file, sizeof(file), "%s/format", base);
     std::string fmt = read_all(file);
     ASSERT_FALSE(fmt.empty());
-    for (const char* needle :
-         {"sched_process_exec", "common_pid", "comm", "pid", "old_pid"}) {
+    for (const char* needle : {"sched_process_exec", "common_pid", "__data_loc char[] filename",
+                               "offset:8", "i32 pid", "offset:12", "i32 old_pid",
+                               "offset:16", "filename=%s pid=%d old_pid=%d"}) {
         EXPECT_NE(std::string::npos, fmt.find(needle))
             << "format missing \"" << needle << "\"\n"
             << fmt;
@@ -191,8 +264,9 @@ TEST(SchedProcessExecTp, FiresOnExecve) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_fire_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
+    DebugfsMount guard(root);
     ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
-    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir。
+    guard.mark_mounted();
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -224,15 +298,111 @@ TEST(SchedProcessExecTp, FiresOnExecve) {
     // 读 trace 快照，断言含 sched_process_exec 记录。
     std::string trace = read_all(trace_path);
     ASSERT_FALSE(trace.empty()) << "trace empty after execve";
-    EXPECT_NE(std::string::npos, trace.find("sched_process_exec("))
-        << "no sched_process_exec record in trace:\n"
-        << trace;
-    // TP_printk 输出的字段。
-    EXPECT_NE(std::string::npos, trace.find("comm="))
-        << "trace missing comm= field:\n"
-        << trace;
+    std::string record = record_for_pid(trace, child);
+    ASSERT_FALSE(record.empty()) << "no sched_process_exec record for child:\n" << trace;
+    EXPECT_NE(std::string::npos, record.find("filename=/proc/self/exe")) << record;
+    EXPECT_EQ(std::string::npos, record.find("comm=")) << record;
 
     // 清理由 RAII guard 析构完成（disable + umount + rmdir）。
+}
+
+TEST(SchedProcessExecTp, ShebangReportsOriginalScriptFilename) {
+    char root[128] = {};
+    snprintf(root, sizeof(root), "/tmp/sched_tp_shebang_mount_%d", getpid());
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+    DebugfsMount guard(root);
+    ASSERT_TRUE(mount_debugfs(root));
+    guard.mark_mounted();
+
+    char base[256] = {};
+    snprintf(base, sizeof(base), "%s/tracing/events/sched/sched_process_exec", root);
+    char enable_path[320] = {};
+    snprintf(enable_path, sizeof(enable_path), "%s/enable", base);
+    ASSERT_TRUE(write_file(enable_path, "1"));
+    guard.arm_enable(enable_path);
+    char trace_path[256] = {};
+    snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
+    ASSERT_TRUE(write_file(trace_path, "1"));
+
+    char script_path[160] = {};
+    snprintf(script_path, sizeof(script_path), "/tmp/sched_tp_script_%d", getpid());
+    TemporaryPath script_cleanup(script_path);
+    int script = open(script_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+    ASSERT_GE(script, 0) << strerror(errno);
+    // Use this test binary as the interpreter. The optional shebang argument
+    // switches main() into the immediate-exit helper, so the test exercises
+    // shebang rewriting without depending on an unrelated shell implementation.
+    const char script_body[] = "#!/proc/self/exe --sched-tp-helper-exit0\n";
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(script_body) - 1),
+              write(script, script_body, sizeof(script_body) - 1));
+    close(script);
+    ASSERT_EQ(0, chmod(script_path, 0755));
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        char* const argv[] = {script_path, nullptr};
+        char* const envp[] = {nullptr};
+        execve(script_path, argv, envp);
+        _exit(127);
+    }
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    std::string trace = read_all(trace_path);
+    std::string record = record_for_pid(trace, child);
+    ASSERT_FALSE(record.empty()) << trace;
+    EXPECT_NE(std::string::npos, record.find("filename=" + std::string(script_path))) << record;
+    EXPECT_EQ(std::string::npos, record.find("filename=/proc/self/exe")) << record;
+}
+
+TEST(SchedProcessExecTp, LongUnicodeExecNameDoesNotCorruptCmdlineCache) {
+    char root[128] = {};
+    snprintf(root, sizeof(root), "/tmp/sched_tp_unicode_mount_%d", getpid());
+    ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
+    DebugfsMount guard(root);
+    ASSERT_TRUE(mount_debugfs(root));
+    guard.mark_mounted();
+
+    char base[256] = {};
+    snprintf(base, sizeof(base), "%s/tracing/events/sched/sched_process_exec", root);
+    char enable_path[320] = {};
+    snprintf(enable_path, sizeof(enable_path), "%s/enable", base);
+    ASSERT_TRUE(write_file(enable_path, "1"));
+    guard.arm_enable(enable_path);
+    char trace_path[256] = {};
+    snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
+    ASSERT_TRUE(write_file(trace_path, "1"));
+
+    // Fourteen ASCII bytes place the following three-byte UTF-8 character
+    // across the old arbitrary 16-byte cache truncation boundary.
+    char executable_path[192] = {};
+    snprintf(executable_path, sizeof(executable_path), "/tmp/abcdefghijklmn界_exec_%d", getpid());
+    TemporaryPath executable_cleanup(executable_path);
+    ASSERT_TRUE(copy_file("/proc/self/exe", executable_path)) << strerror(errno);
+    ASSERT_EQ(0, chmod(executable_path, 0755));
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        char arg1[] = "--sched-tp-helper-exit0";
+        char* const argv[] = {executable_path, arg1, nullptr};
+        char* const envp[] = {nullptr};
+        execve(executable_path, argv, envp);
+        _exit(127);
+    }
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(0, WEXITSTATUS(status));
+
+    // Reading trace exercises TraceCmdLineCache::get(), the former panic site.
+    std::string trace = read_all(trace_path);
+    std::string record = record_for_pid(trace, child);
+    ASSERT_FALSE(record.empty()) << trace;
+    EXPECT_NE(std::string::npos, record.find("filename=" + std::string(executable_path))) << record;
 }
 
 // 默认 disabled 时 execve 不应在 trace 留下 sched_process_exec 记录。
@@ -242,8 +412,9 @@ TEST(SchedProcessExecTp, DefaultDisabledNoRecords) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_disabled_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
+    DebugfsMount guard(root);
     ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
-    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir（本测例不 enable）。
+    guard.mark_mounted();
 
     char trace_path[256] = {};
     snprintf(trace_path, sizeof(trace_path), "%s/tracing/trace", root);
@@ -278,8 +449,9 @@ TEST(SchedProcessExecTp, DisableStopsFiring) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_disable_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
+    DebugfsMount guard(root);
     ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
-    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir。
+    guard.mark_mounted();
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -292,6 +464,7 @@ TEST(SchedProcessExecTp, DisableStopsFiring) {
 
     // 基线：enable 后触发。
     ASSERT_TRUE(write_file(enable_path, "1")) << "enable write failed";
+    ASSERT_TRUE(write_file(enable_path, "1")) << "repeated enable write failed";
     guard.arm_enable(enable_path);  // Thread8：任意提前 return 析构都会写回 "0"。
     ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
     {
@@ -315,6 +488,7 @@ TEST(SchedProcessExecTp, DisableStopsFiring) {
 
     // disable 后清 buffer 再触发：不应再记录。
     ASSERT_TRUE(write_file(enable_path, "0")) << "disable write failed";
+    ASSERT_TRUE(write_file(enable_path, "0")) << "repeated disable write failed";
     ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
     {
         pid_t child = fork();
@@ -344,8 +518,9 @@ TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
     snprintf(root, sizeof(root), "/tmp/sched_tp_nonleader_%d", getpid());
     ASSERT_EQ(0, mkdir(root, 0755)) << strerror(errno);
 
+    DebugfsMount guard(root);
     ASSERT_TRUE(mount_debugfs(root));  // Thread7：mount 失败终止测试。
-    DebugfsMount guard(root);          // Thread8：RAII，析构 umount + rmdir。
+    guard.mark_mounted();
 
     const char* base_rel = "/tracing/events/sched/sched_process_exec";
     char base[256] = {};
@@ -360,12 +535,22 @@ TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
     guard.arm_enable(enable_path);  // Thread8：任意提前 return 析构都会写回 "0"。
     ASSERT_TRUE(write_file(trace_path, "1")) << "trace clear write failed";
 
+    int tid_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(tid_pipe)) << "pipe failed: " << strerror(errno);
+
     // fork child：child 创建 sibling 线程（非 leader）执行 execve，leader 永久挂起。
     pid_t child = fork();
     ASSERT_GE(child, 0) << "fork failed: " << strerror(errno);
     if (child == 0) {
-        helper_sibling_exec_exit0();
+        close(tid_pipe[0]);
+        helper_sibling_exec_exit0(tid_pipe[1]);
     }
+    close(tid_pipe[1]);
+    pid_t sibling_tid = -1;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(sibling_tid)),
+              read(tid_pipe[0], &sibling_tid, sizeof(sibling_tid)))
+        << "failed to receive sibling tid";
+    close(tid_pipe[0]);
 
     int status = 0;
     ASSERT_EQ(child, waitpid(child, &status, 0)) << "waitpid failed: " << strerror(errno);
@@ -375,16 +560,10 @@ TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
     std::string trace = read_all(trace_path);
     ASSERT_FALSE(trace.empty()) << "trace empty after non-leader execve";
 
-    // 找到包含 sched_process_exec 的记录行。
-    size_t rec = trace.find("sched_process_exec");
-    ASSERT_NE(std::string::npos, rec)
-        << "no sched_process_exec record after non-leader execve:\n"
+    std::string record = record_for_pid(trace, child);
+    ASSERT_FALSE(record.empty())
+        << "no sched_process_exec record for non-leader child:\n"
         << trace;
-    size_t line_end = trace.find('\n', rec);
-    if (line_end == std::string::npos) {
-        line_end = trace.size();
-    }
-    std::string record = trace.substr(rec, line_end - rec);
 
     // 解析 old_pid=N。注意 "old_pid=" 含 "pid=" 子串，先取 old_pid。
     size_t old_pos = record.find("old_pid=");
@@ -397,9 +576,8 @@ TEST(SchedProcessExecTp, NonLeaderExecFiresWithDistinctOldPid) {
     long pid_val = strtol(record.c_str() + pid_pos + strlen(" pid="), nullptr, 10);
 
     // non-leader exec 触发 de_thread 交换：old_pid（调用 execve 线程原 PID）≠ pid（交换后 leader PID）。
-    EXPECT_NE(old_pid_val, pid_val)
-        << "non-leader exec should produce distinct old_pid vs pid:\n"
-        << record;
+    EXPECT_EQ(child, pid_val) << record;
+    EXPECT_EQ(sibling_tid, old_pid_val) << record;
 
     // 清理由 RAII guard 析构完成（disable + umount + rmdir）。
 }

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -90,3 +90,4 @@ normal/af_packet_e2e
 normal/af_packet_mcast
 normal/rtnetlink_link_semantics
 normal/tty_termios
+normal/sched_tracepoint


### PR DESCRIPTION
为 execve 成功路径添加 `sched_process_exec` tracepoint，供 ANOLISA agentsight 的 eBPF 程序追踪进程 exec 事件、构建 AI agent 进程树。

## 变更内容

- **新增 `kernel/src/process/trace.rs`**：声明 `sched_process_exec` tracepoint（`comm`/`pid`/`old_pid` 字段），`TP_system(sched)`。字段参考 Linux `include/trace/events/sched.h`。
- **`kernel/src/process/execve.rs`**：在 `load_binary_file_with_context` 之前捕获 `old_pid`（`de_thread` 会交换 pid）；trace 调用置于 `arch_do_execve` 成功后、`is_ok()` 分支内，对齐 Linux `fs/exec.c` `exec_binprm()` 中 `trace_sched_process_exec` 的调用位置。
- **`kernel/src/process/mod.rs`**：注册 `process::trace` 模块。

## 设计说明

- DragonOS 的 `define_event_trace!` 宏不支持 Linux 的 `__string` 动态字符串，且当前未实现 `bpf_get_current_comm()` helper，故 `comm` 直接放入 payload（`[u8; 16]`，对齐 `TASK_COMM_LEN`）。
- `TP_printk` 在首个 NUL 字节处截断 comm，使用 Display 格式输出，输出格式对齐 Linux 的 `comm=... pid=... old_pid=...`。
- tracepoint 注册、debugfs 导出、eBPF attach 全部由现有框架自动完成。static key 保证未启用时零开销。

Refs: #2149