### PR TITLE
fix(kernel): eliminate build warnings

### DIFF
--- a/kernel/src/Makefile
+++ b/kernel/src/Makefile
@@ -24,6 +24,8 @@ ifeq ($(UNWIND_ENABLE), yes)
 	RUSTFLAGS +=  -Cforce-unwind-tables -Clink-arg=-Wl,eh_frame.ld -Cpanic=unwind
 endif
 
+LDFLAGS_X86_64 = -z noexecstack
+
 CFLAGS = $(GLOBAL_CFLAGS) -fno-pie $(CFLAGS_UNWIND) -I $(shell pwd) -I $(shell pwd)/include
 
 ifeq ($(ARCH), x86_64)
@@ -104,7 +106,7 @@ endif
 
 __link_x86_64_kernel:
 	@echo "Linking kernel..."
-	$(LD) -b elf64-x86-64 -z muldefs $(LDFLAGS_UNWIND) -o kernel ../target/x86_64-unknown-none/release/libdragonos_kernel.a -T arch/x86_64/link.lds --no-relax
+	$(LD) -b elf64-x86-64 -z muldefs $(LDFLAGS_X86_64) $(LDFLAGS_UNWIND) -o kernel ../target/x86_64-unknown-none/release/libdragonos_kernel.a -T arch/x86_64/link.lds --no-relax
 # 生成kallsyms
 	current_dir=$(pwd)
 
@@ -117,7 +119,7 @@ __link_x86_64_kernel:
 # 重新链接
 	@echo "Re-Linking kernel..."
 	@echo $(shell find . -name "*.o")
-	$(LD) -b elf64-x86-64 -z muldefs $(LDFLAGS_UNWIND) -o kernel ../target/x86_64-unknown-none/release/libdragonos_kernel.a ./debug/kallsyms.o  -T arch/x86_64/link.lds --no-relax
+	$(LD) -b elf64-x86-64 -z muldefs $(LDFLAGS_X86_64) $(LDFLAGS_UNWIND) -o kernel ../target/x86_64-unknown-none/release/libdragonos_kernel.a ./debug/kallsyms.o  -T arch/x86_64/link.lds --no-relax
 	@echo "Generating kernel ELF file..."
 # 生成内核文件
 ifeq ($(UNWIND_ENABLE), yes)

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -648,6 +648,7 @@ impl FusePendingState {
         })?
     }
 
+    #[cfg(test)]
     pub(crate) fn wait_result_with_kind(
         &self,
     ) -> Result<(Result<FusePendingResult, SystemError>, FuseCompletionKind), SystemError> {

--- a/kernel/src/filesystem/fuse/inode.rs
+++ b/kernel/src/filesystem/fuse/inode.rs
@@ -44,8 +44,8 @@ use super::{
 use super::{
     private_data::FuseOpenPrivateData,
     virtiofs::dax::{
-        DaxAdmissionGuard, DaxAdmissionState, DaxMappingOwner, DaxRangeAllocator, OwnedToken,
-        ReclaimCandidate, ReclaimToken, DAX_RANGE_SIZE,
+        DaxAdmissionGuard, DaxAdmissionState, DaxRangeAllocator, OwnedToken, ReclaimCandidate,
+        ReclaimToken, DAX_RANGE_SIZE,
     },
 };
 
@@ -201,10 +201,6 @@ impl DaxMappingTree {
 }
 
 impl DaxMapping {
-    pub(crate) fn file_offset(&self) -> u64 {
-        self.file_offset
-    }
-
     pub(crate) fn window_offset(&self) -> usize {
         self.token.window_offset()
     }
@@ -212,17 +208,9 @@ impl DaxMapping {
     pub(crate) fn writable(&self) -> bool {
         self.writable.load(Ordering::Acquire)
     }
-
-    pub(crate) fn owner(&self) -> DaxMappingOwner {
-        self.token.owner()
-    }
 }
 
 impl DaxAccessGuard {
-    pub(crate) fn mapping(&self) -> &Arc<DaxMapping> {
-        &self.mapping
-    }
-
     fn checked_window_offset(&self, offset: usize, len: usize) -> Result<usize, SystemError> {
         let end = offset.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
         if end > DAX_RANGE_SIZE {
@@ -968,14 +956,6 @@ impl FuseNode {
             }
         }
         result
-    }
-
-    pub(crate) fn dax_mapping_for_offset(&self, offset: u64) -> Option<Arc<DaxMapping>> {
-        self.dax_mappings
-            .read()
-            .mappings
-            .get(&Self::dax_aligned_offset(offset))
-            .cloned()
     }
 
     pub(crate) fn dax_file_size(&self) -> Result<usize, SystemError> {

--- a/kernel/src/filesystem/fuse/virtiofs/dax.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/dax.rs
@@ -241,6 +241,7 @@ impl AllocationToken {
         self.index * DAX_RANGE_SIZE
     }
 
+    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         DAX_RANGE_SIZE
     }
@@ -270,6 +271,7 @@ impl OwnedToken {
         self.index * DAX_RANGE_SIZE
     }
 
+    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         DAX_RANGE_SIZE
     }
@@ -292,16 +294,13 @@ impl OwnedToken {
 }
 
 impl ReclaimCandidate {
+    #[cfg(test)]
     pub(crate) fn window_offset(&self) -> usize {
         self.index * DAX_RANGE_SIZE
     }
 
     pub(crate) fn owner(&self) -> DaxMappingOwner {
         self.owner
-    }
-
-    pub(crate) fn generation(&self) -> u64 {
-        self.generation
     }
 }
 
@@ -314,6 +313,7 @@ impl ReclaimToken {
         DAX_RANGE_SIZE
     }
 
+    #[cfg(test)]
     pub(crate) fn owner(&self) -> DaxMappingOwner {
         self.owner
     }
@@ -753,6 +753,7 @@ impl DaxRangeAllocator {
         cleaned
     }
 
+    #[cfg(test)]
     pub(crate) fn finish_shutdown(&self) -> Result<(), SystemError> {
         let mut state = self.state.lock_irqsave();
         let snapshot = state.snapshot();

--- a/kernel/src/mm/ucontext/inner.rs
+++ b/kernel/src/mm/ucontext/inner.rs
@@ -441,7 +441,7 @@ impl InnerAddressSpace {
                     match LockedVMA::classify_present_pfn(&mut page_manager_guard, paddr, vm_flags)
                     {
                         PresentPfn::Managed(page) => Some(page),
-                        PresentPfn::External(_) => None,
+                        PresentPfn::External => None,
                     }
                 };
                 let Some(page) = page else {

--- a/kernel/src/mm/ucontext/vma.rs
+++ b/kernel/src/mm/ucontext/vma.rs
@@ -8,7 +8,7 @@ use super::*;
 #[derive(Debug)]
 pub enum PresentPfn {
     Managed(Arc<Page>),
-    External(PhysAddr),
+    External,
 }
 
 /// A locked VMA (Virtual Memory Area)
@@ -50,7 +50,7 @@ impl LockedVMA {
             vm_flags.contains(VmFlags::VM_MIXEDMAP),
             "unmanaged PFN {paddr:?} installed in a non-mixed VMA"
         );
-        PresentPfn::External(paddr)
+        PresentPfn::External
     }
 
     pub fn new(vma: VMA) -> Arc<Self> {

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -139,6 +139,7 @@ pub struct MntNamespace {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RootMountAttachment {
     /// Linux's initial rootfs has no parent and cannot be pivoted.
+    #[cfg(feature = "initram")]
     Unattached,
     /// The visible root is mounted on the hidden initial rootfs anchor.
     Attached,


### PR DESCRIPTION
## Summary

- restrict FUSE DAX inspection helpers to test builds and remove stale accessors
- preserve mixed-map PFN and initram root attachment semantics without unused production state
- apply the x86_64 noexecstack policy to both kernel link passes

## Root cause

Several test-only or obsolete helpers were compiled into the production kernel, while a mixed-map classification payload and a feature-specific mount variant retained state unused by the default build. The x86_64 link also relied on deprecated executable-stack inference when assembly inputs omitted GNU-stack notes.

## Impact

The production DAX state machine, locking, token validation, reclaim flow, and teardown ordering are unchanged. The final x86_64 kernel ELF now declares a non-executable GNU stack in both link passes.

## Validation

- make kernel
- make -C kernel fmt FMT_CHECK=--check
- initram feature compile check
- verified exactly one GNU_STACK program header with RW flags
- QEMU nographic boot and uname -a smoke test