### PR TITLE
fix(process): serialize non-leader exec handoff

### DIFF
--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -814,6 +814,13 @@ impl TtyOperation for Unix98PtyDriverInner {
         if subtype == TtyDriverSubType::PtySlave {
             if let Some(hook_arc) = tty.private_fields() {
                 if let Some(hook) = hook_arc.as_any().downcast_ref::<PtyDevPtsLink>() {
+                    // Pin the master before publishing this in-flight slave
+                    // open. The link is weak, so the last master file could
+                    // otherwise drop it between begin_slave_open() and
+                    // pty_common_open(), leaking ENODEV from the latter.
+                    // A concurrent master close is reported as EIO below,
+                    // matching Linux pts open semantics.
+                    let _master = tty.link().ok_or(SystemError::EIO)?;
                     hook.begin_slave_open()?;
                     return match PtyCommon::pty_common_open(tty) {
                         Ok(()) => {

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -141,6 +141,7 @@ impl TtyCore {
             read_wq: EventWaitQueue::new(),
             write_wq: EventWaitQueue::new(),
             write_lock: TtySleepLock::new(),
+            job_control_lock: TtySleepLock::new(),
             port: RwLock::new(None),
             index,
             vc_index: AtomicUsize::new(usize::MAX),
@@ -263,6 +264,7 @@ impl TtyCore {
     }
 
     pub fn tty_vhangup(tty: Arc<TtyCore>) {
+        let _job_control_guard = tty.core().job_control_lock().lock();
         {
             let mut flags = tty.core().flags_write();
             if flags.intersects(TtyFlag::HUPPED | TtyFlag::HUPPING) {
@@ -276,10 +278,7 @@ impl TtyCore {
         // every pre-hangup open file description.
         tty.core().fasync_items.clear();
 
-        let (sid, pgid) = {
-            let ctrl = tty.core().contorl_info_irqsave();
-            (ctrl.session.clone(), ctrl.pgid.clone())
-        };
+        let pgid = TtyJobCtrlManager::remove_session_tty_job_locked(&tty, None);
 
         if let Some(pgrp) = pgid {
             let _ = crate::ipc::kill::send_signal_to_pgid(&pgrp, Signal::SIGHUP);
@@ -290,12 +289,7 @@ impl TtyCore {
 
         {
             let mut ctrl = tty.core().contorl_info_irqsave();
-            ctrl.session = None;
-            ctrl.pgid = None;
             ctrl.pktstatus = TtyPacketStatus::empty();
-        }
-        if let Some(sid) = sid {
-            TtyJobCtrlManager::session_clear_tty(sid);
         }
 
         {
@@ -666,6 +660,8 @@ pub struct TtyCoreData {
     write_wq: EventWaitQueue,
     /// 串行化整个 tty write 调用，等价于 Linux tty->atomic_write_lock。
     write_lock: TtySleepLock,
+    /// Serializes controlling-session changes with hangup.
+    job_control_lock: TtySleepLock,
     /// 端口
     port: RwLock<Option<Arc<dyn TtyPort>>>,
     /// 前台进程
@@ -873,6 +869,11 @@ impl TtyCoreData {
 
     pub fn write_lock(&self) -> &TtySleepLock {
         &self.write_lock
+    }
+
+    #[inline]
+    pub fn job_control_lock(&self) -> &TtySleepLock {
+        &self.job_control_lock
     }
 
     #[inline]
@@ -1102,7 +1103,7 @@ impl TtyOperation for TtyCore {
             // );
             let r = self.core().tty_driver.driver_funcs().close(tty.clone());
             // 如果计数为0或者无效，表示tty已经关闭
-            TtyJobCtrlManager::remove_session_tty(&tty);
+            let _ = TtyJobCtrlManager::remove_session_tty(&tty);
             return r;
         }
         Ok(())

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -1095,15 +1095,21 @@ impl TtyOperation for TtyCore {
         let subtype = tty.core().driver().tty_driver_sub_type();
         let is_pty_slave_last = cnt == 1 && subtype == TtyDriverSubType::PtySlave;
         let is_pty_master_last = cnt == 1 && subtype == TtyDriverSubType::PtyMaster;
-        if !self.core().count_valid() || is_pty_slave_last || is_pty_master_last {
+        let final_release = !self.core().count_valid();
+        if final_release || is_pty_slave_last || is_pty_master_last {
             // log::debug!(
             //     "TtyCore close: ref count: {}, tty: {}",
             //     cnt,
             //     tty.core().name()
             // );
             let r = self.core().tty_driver.driver_funcs().close(tty.clone());
-            // 如果计数为0或者无效，表示tty已经关闭
-            let _ = TtyJobCtrlManager::remove_session_tty(&tty);
+            // Linux pty_close() runs when the last user fd closes even though
+            // the peer keeps the tty structure count at one. The controlling
+            // session remains attached in that case and may reopen /dev/tty;
+            // only a true final structure release clears it here.
+            if final_release {
+                let _ = TtyJobCtrlManager::remove_session_tty(&tty);
+            }
             return r;
         }
         Ok(())

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -347,22 +347,13 @@ impl IndexNode for TtyDevice {
         let driver = tty.core().driver();
         // 考虑 O_NOCTTY：显式指定则不设置控制终端；pty master 也不会成为控制终端。
         if !(mode.contains(FileFlags::O_NOCTTY)
+            || mode.is_write_only()
             || (driver.tty_driver_type() == TtyDriverType::Pty
                 && driver.tty_driver_sub_type() == TtyDriverSubType::PtyMaster))
         {
-            let pcb = ProcessManager::current_pcb();
-            let pcb_tty = pcb.sig_info_irqsave().tty();
-            let is_session_leader = pcb.sig_info_irqsave().is_session_leader;
-            let tty_session_is_none = tty.core().contorl_info_irqsave().session.is_none();
-            // Linux tty_open_proc_set_tty 语义：必须是会话首进程、尚无 controlling tty、
-            // tty 当前未被会话占用，且本次 open 具备读权限（不是 O_WRONLY）。
-            if is_session_leader
-                && pcb_tty.is_none()
-                && tty_session_is_none
-                && !mode.is_write_only()
-            {
-                TtyJobCtrlManager::proc_set_tty(tty);
-            }
+            // The helper revalidates and commits the controlling-tty state as
+            // one membership/tty/signal transaction.
+            TtyJobCtrlManager::proc_set_tty(tty);
         }
 
         Ok(())

--- a/kernel/src/driver/tty/tty_job_control.rs
+++ b/kernel/src/driver/tty/tty_job_control.rs
@@ -19,16 +19,23 @@ pub struct TtyJobCtrlManager;
 impl TtyJobCtrlManager {
     /// ### 设置当前进程的tty
     pub fn proc_set_tty(tty: Arc<TtyCore>) {
-        let core = tty.core();
         let pcb = ProcessManager::current_pcb();
-
-        let mut ctrl = core.contorl_info_irqsave();
+        let _job_control_guard = tty.core().job_control_lock().lock();
+        let _membership_guard = crate::process::pid::pid_membership_lock();
+        if tty
+            .core()
+            .flags()
+            .intersects(super::tty_core::TtyFlag::HUPPING | super::tty_core::TtyFlag::HUPPED)
+        {
+            return;
+        }
+        let mut ctrl = tty.core().contorl_info_irqsave();
+        let mut signal = pcb.sig_info_mut();
+        if !signal.is_session_leader || signal.tty().is_some() || ctrl.session.is_some() {
+            return;
+        }
         ctrl.set_info_by_pcb(pcb.clone());
-
-        drop(ctrl);
-
-        let mut singal = pcb.sig_info_mut();
-        singal.set_tty(Some(tty.clone()));
+        signal.set_tty(Some(tty.clone()));
     }
 
     /// ### 清除进程的tty
@@ -44,10 +51,47 @@ impl TtyJobCtrlManager {
         wguard.set_tty(None);
     }
 
-    pub fn remove_session_tty(tty: &Arc<TtyCore>) {
+    pub fn remove_session_tty(tty: &Arc<TtyCore>) -> Option<Arc<Pid>> {
+        let _job_control_guard = tty.core().job_control_lock().lock();
+        Self::remove_session_tty_job_locked(tty, None)
+    }
+
+    pub(crate) fn remove_session_tty_job_locked(
+        tty: &Arc<TtyCore>,
+        expected_sid: Option<&Arc<Pid>>,
+    ) -> Option<Arc<Pid>> {
+        let _membership_guard = crate::process::pid::pid_membership_lock();
+        Self::remove_session_tty_locked(tty, expected_sid)
+    }
+
+    pub fn remove_session_tty_if_owner(
+        tty: &Arc<TtyCore>,
+        expected_sid: &Arc<Pid>,
+    ) -> Option<Arc<Pid>> {
+        let _job_control_guard = tty.core().job_control_lock().lock();
+        Self::remove_session_tty_job_locked(tty, Some(expected_sid))
+    }
+
+    /// The caller must hold PID_MEMBERSHIP_LOCK.
+    fn remove_session_tty_locked(
+        tty: &Arc<TtyCore>,
+        expected_sid: Option<&Arc<Pid>>,
+    ) -> Option<Arc<Pid>> {
         let mut ctrl = tty.core().contorl_info_irqsave();
-        ctrl.session = None;
-        ctrl.pgid = None;
+        if expected_sid.is_some_and(|expected| {
+            ctrl.session
+                .as_ref()
+                .is_none_or(|owner| !Arc::ptr_eq(owner, expected))
+        }) {
+            return None;
+        }
+        let sid = ctrl.session.take();
+        let pgid = ctrl.pgid.take();
+        drop(ctrl);
+        if let Some(sid) = sid {
+            Self::session_clear_tty_locked(sid);
+        }
+        pgid
     }
 
     /// ### 检查tty
@@ -125,18 +169,31 @@ impl TtyJobCtrlManager {
     // https://code.dragonos.org.cn/xref/linux-6.6.21/drivers/tty/tty_jobctrl.c#tiocsctty
     fn tiocsctty(real_tty: Arc<TtyCore>, arg: usize) -> Result<usize, SystemError> {
         let current = ProcessManager::current_pcb();
-        let siginfo_guard = current.sig_info_irqsave();
+        let _job_control_guard = real_tty.core().job_control_lock().lock();
+        let _membership_guard = crate::process::pid::pid_membership_lock();
+        if real_tty
+            .core()
+            .flags()
+            .intersects(super::tty_core::TtyFlag::HUPPING | super::tty_core::TtyFlag::HUPPED)
+        {
+            return Err(SystemError::EIO);
+        }
+        let (is_session_leader, current_tty) = {
+            let siginfo = current.sig_info_irqsave();
+            (siginfo.is_session_leader, siginfo.tty())
+        };
 
         // 只有会话首进程才能设置控制终端
-        if !siginfo_guard.is_session_leader {
+        if !is_session_leader {
             return Err(SystemError::EPERM);
         }
 
+        let current_session = current.task_session();
+
         // 如果当前进程已经有控制终端，则返回错误（除非是同一个tty且会话相同）
-        if let Some(current_tty) = siginfo_guard.tty() {
-            if Arc::ptr_eq(&current_tty, &real_tty)
-                && current.task_session() == real_tty.core().contorl_info_irqsave().session
-            {
+        if let Some(current_tty) = current_tty {
+            let tty_session = real_tty.core().contorl_info_irqsave().session.clone();
+            if Arc::ptr_eq(&current_tty, &real_tty) && current_session == tty_session {
                 // 如果已经是当前tty且会话相同，直接返回成功
                 return Ok(0);
             } else {
@@ -145,13 +202,11 @@ impl TtyJobCtrlManager {
             }
         }
 
-        drop(siginfo_guard);
-
-        let tty_ctrl_guard = real_tty.core().contorl_info_irqsave();
+        let mut tty_ctrl_guard = real_tty.core().contorl_info_irqsave();
 
         if let Some(ref sid) = tty_ctrl_guard.session {
             // 如果当前进程是会话首进程，且tty的会话是当前进程的会话，则允许设置
-            if current.task_session() == Some(sid.clone()) {
+            if current_session == Some(sid.clone()) {
                 // 这是正常情况：会话首进程要设置自己会话的tty为控制终端
             } else {
                 // tty被其他会话占用
@@ -161,16 +216,16 @@ impl TtyJobCtrlManager {
                     if !cred.has_capability(CAPFlags::CAP_SYS_ADMIN) {
                         return Err(SystemError::EPERM);
                     }
-                    Self::session_clear_tty(sid.clone());
+                    Self::session_clear_tty_locked(sid.clone());
                 } else {
                     return Err(SystemError::EPERM);
                 }
             }
         }
 
+        tty_ctrl_guard.set_info_by_pcb(current.clone());
+        current.sig_info_mut().set_tty(Some(real_tty.clone()));
         drop(tty_ctrl_guard);
-
-        Self::proc_set_tty(real_tty);
         Ok(0)
     }
 
@@ -249,57 +304,31 @@ impl TtyJobCtrlManager {
         }
 
         let current = ProcessManager::current_pcb();
-
+        let _job_control_guard = real_tty.core().job_control_lock().lock();
+        let _membership_guard = crate::process::pid::pid_membership_lock();
+        let current_session = current.task_session();
+        let current_tty = current.sig_info_irqsave().tty();
         let mut ctrl = real_tty.core().contorl_info_irqsave();
-
+        if current_tty
+            .as_ref()
+            .is_none_or(|tty| !Arc::ptr_eq(tty, &real_tty))
+            || ctrl.session != current_session
         {
-            // if current.sig_info_irqsave().tty().is_none()
-            //     || !Arc::ptr_eq(
-            //         &current.sig_info_irqsave().tty().clone().unwrap(),
-            //         &real_tty,
-            //     )
-            //     || ctrl.session != current.task_session()
-            // {
-            //     log::debug!("sss-2");
-            //     return Err(SystemError::ENOTTY);
-            // }
-
-            // 拆分判断条件以便调试
-            let current_tty = current.sig_info_irqsave().tty();
-            let condition1 = current_tty.is_none();
-
-            let condition2 = if let Some(ref tty) = current_tty {
-                !Arc::ptr_eq(tty, &real_tty)
-            } else {
-                false // 如果 tty 为 None，这个条件就不用检查了
-            };
-
-            let condition3 = ctrl.session != current.task_session();
-
-            if condition1 || condition2 || condition3 {
-                if condition1 {
-                    log::debug!("sss-2: 失败原因 - 当前进程没有关联的 tty");
-                } else if condition2 {
-                    log::debug!("sss-2: 失败原因 - 当前进程的 tty 与目标 tty 不匹配");
-                } else if condition3 {
-                    log::debug!("sss-2: 失败原因 - 会话不匹配");
-                }
-                return Err(SystemError::ENOTTY);
-            }
+            return Err(SystemError::ENOTTY);
         }
+
         let pgrp =
             ProcessManager::find_vpid(RawPid::new(pgrp_nr as usize)).ok_or(SystemError::ESRCH)?;
-
-        if Self::session_of_pgrp(&pgrp) != current.task_session() {
+        if Self::session_of_pgrp_locked(&pgrp) != current_session {
             return Err(SystemError::EPERM);
         }
-
         ctrl.pgid = Some(pgrp);
 
         return Ok(0);
     }
 
-    fn session_of_pgrp(pgrp: &Arc<Pid>) -> Option<Arc<Pid>> {
+    /// The caller must hold PID_MEMBERSHIP_LOCK.
+    fn session_of_pgrp_locked(pgrp: &Arc<Pid>) -> Option<Arc<Pid>> {
         let mut p = pgrp.pid_task(PidType::PGID);
         if p.is_none() {
             // this should not be None
@@ -329,33 +358,28 @@ impl TtyJobCtrlManager {
             return Ok(0);
         }
 
-        let sid = pcb.task_session();
-        let tty_pgrp = real_tty.core().contorl_info_irqsave().pgid.clone();
+        let tty_pgrp = if let Some(sid) = pcb.task_session() {
+            Self::remove_session_tty_if_owner(&real_tty, &sid)
+        } else {
+            Self::proc_clear_tty(&pcb);
+            None
+        };
 
         if let Some(pgrp) = tty_pgrp {
             let _ = crate::ipc::kill::send_signal_to_pgid(&pgrp, Signal::SIGHUP);
             let _ = crate::ipc::kill::send_signal_to_pgid(&pgrp, Signal::SIGCONT);
         }
 
-        {
-            let mut ctrl = real_tty.core().contorl_info_irqsave();
-            ctrl.session = None;
-            ctrl.pgid = None;
-        }
-
-        if let Some(sid) = sid {
-            Self::session_clear_tty(sid);
-        } else {
-            Self::proc_clear_tty(&pcb);
-        }
-
         Ok(0)
     }
 
-    pub fn session_clear_tty(sid: Arc<Pid>) {
-        // 清除会话的tty
-        for task in sid.tasks_iter(PidType::SID) {
-            TtyJobCtrlManager::proc_clear_tty(&task);
+    /// The caller must hold PID_MEMBERSHIP_LOCK.
+    fn session_clear_tty_locked(sid: Arc<Pid>) {
+        let leaders: alloc::vec::Vec<_> = sid.tasks_iter(PidType::SID).collect();
+        for leader in leaders {
+            for task in ProcessManager::thread_group_tasks_snapshot(leader) {
+                TtyJobCtrlManager::proc_clear_tty(&task);
+            }
         }
     }
 

--- a/kernel/src/ipc/generic_signal.rs
+++ b/kernel/src/ipc/generic_signal.rs
@@ -407,14 +407,14 @@ fn sig_terminate(sig: Signal) {
 
     if sig == Signal::SIGKILL {
         let current = ProcessManager::current_pcb();
-        if !current.is_thread_group_leader() {
-            // 线程级 SIGKILL：仅终止当前线程，避免误杀整个线程组
-            ProcessManager::exit(sig as usize);
-        }
         let sighand = current.sighand();
         if sighand.flags_contains(SignalFlags::GROUP_EXEC) {
             if let Some(exec_task) = sighand.group_exec_task() {
                 if !Arc::ptr_eq(&exec_task, &current) {
+                    // de_thread() privately injects SIGKILL into the siblings
+                    // that the exec owner is replacing. Only those siblings
+                    // exit individually; an externally delivered SIGKILL
+                    // targeting the exec owner remains process-fatal.
                     ProcessManager::exit(sig as usize);
                 }
             }

--- a/kernel/src/ipc/kill.rs
+++ b/kernel/src/ipc/kill.rs
@@ -3,7 +3,6 @@ use crate::ipc::syscall::sys_kill::check_signal_permission_pcb_with_sig;
 use crate::process::pid::{Pid, PidType};
 use crate::process::{ProcessControlBlock, ProcessManager, RawPid};
 use crate::{arch::ipc::signal::Signal, ipc::signal_types::SigCode};
-use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::sync::atomic::compiler_fence;
@@ -74,27 +73,13 @@ pub fn send_signal_to_pcb(
 /// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/signal.c?fi=kill_pgrp#1921
 #[inline(never)]
 pub fn send_signal_to_pgid(pgid: &Arc<Pid>, sig: Signal) -> Result<usize, SystemError> {
-    // Linux only links thread-group leaders into PIDTYPE_PGID. DragonOS
-    // currently links every thread, so only use physical leader entries and
-    // group them by their stable TGID identity. TGID grouping also covers the
-    // brief old/new leader overlap during de_thread().
-    let mut thread_groups: BTreeMap<usize, Arc<ProcessControlBlock>> = BTreeMap::new();
-    let physical_tasks: Vec<Arc<ProcessControlBlock>> = pgid.tasks_iter(PidType::PGID).collect();
-    for task in physical_tasks {
-        if !task.is_thread_group_leader() {
-            continue;
-        }
-        let Some(tgid) = task.task_pid_ptr(PidType::TGID) else {
-            continue;
-        };
-        let representative = thread_groups
-            .entry(Arc::as_ptr(&tgid) as usize)
-            .or_insert_with(|| task.clone());
-        if !representative.is_live_thread_group_member() && task.is_live_thread_group_member() {
-            *representative = task;
-        }
-    }
-    let tasks: Vec<Arc<ProcessControlBlock>> = thread_groups.into_values().collect();
+    // As in Linux, PIDTYPE_PGID contains one physical link per thread group.
+    // CLONE_THREAD preserves the shared logical PGID without adding a link,
+    // while de_thread() transfers the old leader's link to the promoted leader.
+    let tasks: Vec<Arc<ProcessControlBlock>> = {
+        let _membership_guard = crate::process::pid::pid_membership_lock();
+        pgid.tasks_iter(PidType::PGID).collect()
+    };
 
     // 如果进程组中没有任何进程，返回 ESRCH
     if tasks.is_empty() {

--- a/kernel/src/ipc/kill.rs
+++ b/kernel/src/ipc/kill.rs
@@ -3,6 +3,7 @@ use crate::ipc::syscall::sys_kill::check_signal_permission_pcb_with_sig;
 use crate::process::pid::{Pid, PidType};
 use crate::process::{ProcessControlBlock, ProcessManager, RawPid};
 use crate::{arch::ipc::signal::Signal, ipc::signal_types::SigCode};
+use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::sync::atomic::compiler_fence;
@@ -73,8 +74,28 @@ pub fn send_signal_to_pcb(
 /// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/signal.c?fi=kill_pgrp#1921
 #[inline(never)]
 pub fn send_signal_to_pgid(pgid: &Arc<Pid>, sig: Signal) -> Result<usize, SystemError> {
-    // 先收集进程组中的所有进程，避免在持有锁时调用复杂操作
-    let tasks: Vec<Arc<ProcessControlBlock>> = pgid.tasks_iter(PidType::PGID).collect();
+    // Linux only links thread-group leaders into PIDTYPE_PGID. DragonOS
+    // currently links every thread, so only use physical leader entries and
+    // group them by their stable TGID identity. TGID grouping also covers the
+    // brief old/new leader overlap during de_thread().
+    let mut thread_groups: BTreeMap<usize, Arc<ProcessControlBlock>> = BTreeMap::new();
+    let physical_tasks: Vec<Arc<ProcessControlBlock>> =
+        pgid.tasks_iter(PidType::PGID).collect();
+    for task in physical_tasks {
+        if !task.is_thread_group_leader() {
+            continue;
+        }
+        let Some(tgid) = task.task_pid_ptr(PidType::TGID) else {
+            continue;
+        };
+        let representative = thread_groups
+            .entry(Arc::as_ptr(&tgid) as usize)
+            .or_insert_with(|| task.clone());
+        if !representative.is_live_thread_group_member() && task.is_live_thread_group_member() {
+            *representative = task;
+        }
+    }
+    let tasks: Vec<Arc<ProcessControlBlock>> = thread_groups.into_values().collect();
 
     // 如果进程组中没有任何进程，返回 ESRCH
     if tasks.is_empty() {

--- a/kernel/src/ipc/kill.rs
+++ b/kernel/src/ipc/kill.rs
@@ -79,8 +79,7 @@ pub fn send_signal_to_pgid(pgid: &Arc<Pid>, sig: Signal) -> Result<usize, System
     // group them by their stable TGID identity. TGID grouping also covers the
     // brief old/new leader overlap during de_thread().
     let mut thread_groups: BTreeMap<usize, Arc<ProcessControlBlock>> = BTreeMap::new();
-    let physical_tasks: Vec<Arc<ProcessControlBlock>> =
-        pgid.tasks_iter(PidType::PGID).collect();
+    let physical_tasks: Vec<Arc<ProcessControlBlock>> = pgid.tasks_iter(PidType::PGID).collect();
     for task in physical_tasks {
         if !task.is_thread_group_leader() {
             continue;

--- a/kernel/src/ipc/sighand.rs
+++ b/kernel/src/ipc/sighand.rs
@@ -20,6 +20,44 @@ use crate::{
 
 use super::signal_types::Sigaction;
 
+/// Producer state for the old leader of a non-leader exec transaction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GroupExecLeaderPhase {
+    Pending,
+    Exiting,
+    Ready,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GroupExecCancelResult {
+    Canceled,
+    Committed,
+    NotOwner,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NaturalParentNotifyPhase {
+    Idle,
+    Pending,
+    Done,
+}
+
+/// Non-copyable proof that a caller owns the one natural-parent notification
+/// transaction for a particular leader.
+#[derive(Debug)]
+pub struct NaturalParentNotifyToken {
+    owner: Weak<ProcessControlBlock>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReapTransition {
+    Blocked,
+    NotZombie,
+    Reportable,
+    Reaped,
+}
+
 pub struct SigHand {
     inner: RwLock<InnerSigHand>,
     group_exec_wait_queue: WaitQueue,
@@ -60,6 +98,12 @@ pub struct InnerSigHand {
     pub group_exec_task: Option<Weak<ProcessControlBlock>>,
     /// 线程组 exec（de-thread）等待计数（仿照 Linux 的 signal_struct::notify_count）
     pub group_exec_notify_count: isize,
+    /// Stable old leader and its producer state for non-leader exec.
+    group_exec_old_leader: Option<Weak<ProcessControlBlock>>,
+    group_exec_leader_phase: Option<GroupExecLeaderPhase>,
+    /// Monotonically increasing transaction generation. Zero is reserved for
+    /// the absence of a per-task token.
+    group_exec_generation: u64,
     /// The mm selected by the OOM killer for this thread group.
     ///
     /// The reserve entitlement is not decided by this metadata alone. Callers
@@ -153,6 +197,19 @@ impl SigHand {
             .wait_event_killable(cond, before_sleep)
     }
 
+    pub fn wait_group_exec_event_uninterruptible<F, B>(
+        &self,
+        cond: F,
+        before_sleep: Option<B>,
+    ) -> Result<(), SystemError>
+    where
+        F: FnMut() -> bool,
+        B: FnMut(),
+    {
+        self.group_exec_wait_queue()
+            .wait_event_uninterruptible(cond, before_sleep)
+    }
+
     pub fn reset_handlers(&self) {
         self.inner_mut().handlers = default_sighandlers();
     }
@@ -181,9 +238,11 @@ impl SigHand {
         let other_guard = other.inner();
         let mut self_guard = self.inner_mut();
         self_guard.flags = other_guard.flags;
+        // Group-exec is a transaction owned by the original shared sighand;
+        // copying only its flag would create an active state without owner,
+        // generation, phase, or pending tokens.
+        self_guard.flags.remove(SignalFlags::GROUP_EXEC);
         self_guard.group_exit_code = other_guard.group_exit_code;
-        self_guard.group_exec_task = other_guard.group_exec_task.clone();
-        self_guard.group_exec_notify_count = other_guard.group_exec_notify_count;
         self_guard.pids = other_guard.pids.clone();
     }
 
@@ -430,45 +489,213 @@ impl SigHand {
         g.stop_signal = sig;
     }
 
-    /// 尝试开始线程组 exec（去线程化）流程。
+    /// Start group exec and collect the transaction's ordinary sibling tokens
+    /// under the same lock that completion uses.
     ///
-    /// - 若已经有 GROUP_EXIT 或 GROUP_EXEC 在进行中，则返回 EAGAIN。
-    /// - 否则设置 GROUP_EXEC 并返回 Ok。
-    pub fn try_start_group_exec(&self) -> Result<(), SystemError> {
+    /// The callback may acquire thread-info locks, establishing the fixed
+    /// `SigHand -> thread-info` order. It must assign `generation` to every
+    /// identity-incomplete ordinary sibling and return that count.
+    pub fn start_group_exec_transaction<F, R>(
+        &self,
+        owner: &Arc<ProcessControlBlock>,
+        old_leader: Option<&Arc<ProcessControlBlock>>,
+        collect: F,
+    ) -> Result<R, SystemError>
+    where
+        F: FnOnce(u64) -> (R, usize),
+    {
         let mut g = self.inner_mut();
         if g.flags.contains(SignalFlags::GROUP_EXIT) || g.flags.contains(SignalFlags::GROUP_EXEC) {
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
         }
-        g.flags.insert(SignalFlags::GROUP_EXEC);
-        Ok(())
-    }
 
-    /// 在与 GROUP_EXEC/GROUP_EXIT 相同的锁下，设置 exec 标志并记录执行者。
-    pub fn start_group_exec(&self, task: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
-        let mut g = self.inner_mut();
-        if g.flags.contains(SignalFlags::GROUP_EXIT) || g.flags.contains(SignalFlags::GROUP_EXEC) {
+        debug_assert!(old_leader
+            .map(|leader| !Arc::ptr_eq(leader, owner))
+            .unwrap_or(true));
+        if old_leader
+            .map(|leader| {
+                leader.is_dead() || (leader.exit_notify_complete() && !leader.is_zombie())
+            })
+            .unwrap_or(false)
+        {
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
         }
+        let mut generation = g.group_exec_generation.wrapping_add(1);
+        if generation == 0 {
+            generation = 1;
+        }
+        let (result, pending) = collect(generation);
+
         g.flags.insert(SignalFlags::GROUP_EXEC);
-        g.group_exec_task = Some(Arc::downgrade(task));
-        g.group_exec_notify_count = 0;
-        Ok(())
+        g.group_exec_task = Some(Arc::downgrade(owner));
+        g.group_exec_old_leader = old_leader.map(Arc::downgrade);
+        g.group_exec_leader_phase = old_leader.map(|leader| {
+            if leader.exit_notify_complete() {
+                GroupExecLeaderPhase::Ready
+            } else {
+                GroupExecLeaderPhase::Pending
+            }
+        });
+        g.group_exec_generation = generation;
+        g.group_exec_notify_count = pending as isize;
+        let leader_ready = g.group_exec_leader_phase == Some(GroupExecLeaderPhase::Ready);
+        drop(g);
+
+        if leader_ready {
+            self.group_exec_wait_queue().wakeup_all(None);
+        }
+        Ok(result)
     }
 
-    /// 结束线程组 exec 状态。
-    pub fn finish_group_exec(&self) {
+    /// Finish only the caller's transaction. A non-leader exec can finish only
+    /// after the old-leader producer reached Ready.
+    pub fn finish_group_exec_owned(&self, owner: &Arc<ProcessControlBlock>) -> bool {
         let mut g = self.inner_mut();
-        g.flags.remove(SignalFlags::GROUP_EXEC);
-        g.group_exec_task = None;
-        g.group_exec_notify_count = 0;
+        if !Self::weak_matches(&g.group_exec_task, owner)
+            || g.group_exec_notify_count != 0
+            || matches!(
+                g.group_exec_leader_phase,
+                Some(GroupExecLeaderPhase::Pending | GroupExecLeaderPhase::Exiting)
+            )
+        {
+            return false;
+        }
+        Self::clear_group_exec_locked(&mut g);
         drop(g);
         self.group_exec_wait_queue().wakeup_all(None);
+        true
     }
 
-    /// 记录当前 exec 线程（去线程化执行者）。
-    pub fn set_group_exec_task(&self, task: &Arc<ProcessControlBlock>) {
+    /// Cancel before the old leader commits its dedicated exit. Once Exiting
+    /// has been claimed, the identity handoff must complete uninterruptibly.
+    pub fn try_cancel_group_exec(&self, owner: &Arc<ProcessControlBlock>) -> GroupExecCancelResult {
         let mut g = self.inner_mut();
-        g.group_exec_task = Some(Arc::downgrade(task));
+        if !g.flags.contains(SignalFlags::GROUP_EXEC)
+            || !Self::weak_matches(&g.group_exec_task, owner)
+        {
+            return GroupExecCancelResult::NotOwner;
+        }
+        if matches!(
+            g.group_exec_leader_phase,
+            Some(GroupExecLeaderPhase::Exiting | GroupExecLeaderPhase::Ready)
+        ) {
+            return GroupExecCancelResult::Committed;
+        }
+
+        Self::clear_group_exec_locked(&mut g);
+        drop(g);
+        self.group_exec_wait_queue().wakeup_all(None);
+        GroupExecCancelResult::Canceled
+    }
+
+    /// Atomically claim the old leader's dedicated producer path.
+    pub fn claim_group_exec_leader_exit(&self, candidate: &Arc<ProcessControlBlock>) -> bool {
+        let mut g = self.inner_mut();
+        if !g.flags.contains(SignalFlags::GROUP_EXEC)
+            || !Self::weak_matches(&g.group_exec_old_leader, candidate)
+            || g.group_exec_leader_phase != Some(GroupExecLeaderPhase::Pending)
+        {
+            return false;
+        }
+        g.group_exec_leader_phase = Some(GroupExecLeaderPhase::Exiting);
+        true
+    }
+
+    /// Publish producer completion before waking the exec waiter. This also
+    /// covers a leader that entered ordinary exit before group exec started.
+    pub fn complete_group_exec_leader_exit(&self, candidate: &Arc<ProcessControlBlock>) -> bool {
+        if !candidate.exit_notify_complete() {
+            return false;
+        }
+        let mut g = self.inner_mut();
+        if !g.flags.contains(SignalFlags::GROUP_EXEC)
+            || !Self::weak_matches(&g.group_exec_old_leader, candidate)
+            || !matches!(
+                g.group_exec_leader_phase,
+                Some(GroupExecLeaderPhase::Pending | GroupExecLeaderPhase::Exiting)
+            )
+        {
+            return false;
+        }
+        g.group_exec_leader_phase = Some(GroupExecLeaderPhase::Ready);
+        drop(g);
+        self.group_exec_wait_queue().wakeup_all(None);
+        true
+    }
+
+    pub fn group_exec_leader_phase(
+        &self,
+        owner: &Arc<ProcessControlBlock>,
+    ) -> Option<GroupExecLeaderPhase> {
+        let g = self.inner();
+        Self::weak_matches(&g.group_exec_task, owner).then_some(g.group_exec_leader_phase)?
+    }
+
+    pub fn group_exec_pending_complete(&self, owner: &Arc<ProcessControlBlock>) -> bool {
+        let g = self.inner();
+        Self::weak_matches(&g.group_exec_task, owner) && g.group_exec_notify_count == 0
+    }
+
+    pub fn group_exec_handoff_ready(&self, owner: &Arc<ProcessControlBlock>) -> bool {
+        let g = self.inner();
+        Self::weak_matches(&g.group_exec_task, owner)
+            && g.group_exec_notify_count == 0
+            && matches!(
+                g.group_exec_leader_phase,
+                None | Some(GroupExecLeaderPhase::Ready)
+            )
+    }
+
+    pub fn group_exec_committed(&self, owner: &Arc<ProcessControlBlock>) -> bool {
+        let g = self.inner();
+        Self::weak_matches(&g.group_exec_task, owner)
+            && matches!(
+                g.group_exec_leader_phase,
+                Some(GroupExecLeaderPhase::Exiting | GroupExecLeaderPhase::Ready)
+            )
+    }
+
+    /// Complete one ordinary sibling's identity-unhash token in O(1).
+    pub fn complete_group_exec_task(&self, candidate: &Arc<ProcessControlBlock>) -> bool {
+        if !candidate.identity_unhash_complete() {
+            return false;
+        }
+        let mut g = self.inner_mut();
+        let generation = candidate.take_group_exec_generation();
+        if generation == 0
+            || !g.flags.contains(SignalFlags::GROUP_EXEC)
+            || generation != g.group_exec_generation
+        {
+            return false;
+        }
+        assert!(
+            g.group_exec_notify_count > 0,
+            "group-exec pending count underflow"
+        );
+        g.group_exec_notify_count -= 1;
+        let ready = g.group_exec_notify_count == 0;
+        drop(g);
+        if ready {
+            self.group_exec_wait_queue().wakeup_all(None);
+        }
+        true
+    }
+
+    fn weak_matches(
+        weak: &Option<Weak<ProcessControlBlock>>,
+        task: &Arc<ProcessControlBlock>,
+    ) -> bool {
+        weak.as_ref()
+            .map(|candidate| Weak::ptr_eq(candidate, &Arc::downgrade(task)))
+            .unwrap_or(false)
+    }
+
+    fn clear_group_exec_locked(g: &mut InnerSigHand) {
+        g.flags.remove(SignalFlags::GROUP_EXEC);
+        g.group_exec_task = None;
+        g.group_exec_old_leader = None;
+        g.group_exec_leader_phase = None;
+        g.group_exec_notify_count = 0;
     }
 
     /// 在与 GROUP_EXEC/GROUP_EXIT 相同的锁下执行关键区，避免并发插入线程组。
@@ -490,29 +717,152 @@ impl SigHand {
         self.inner().group_exec_task.as_ref()?.upgrade()
     }
 
-    pub fn group_exec_notify_count(&self) -> isize {
-        self.inner().group_exec_notify_count
+    /// Claim the leader's natural-parent notification responsibility while
+    /// holding the same lock used by group-exec/reap arbitration. `eligible`
+    /// may acquire the leader thread-info lock (`SigHand -> thread-info`).
+    pub fn try_claim_natural_parent_notify<F>(
+        &self,
+        candidate: &Arc<ProcessControlBlock>,
+        eligible: F,
+    ) -> Option<NaturalParentNotifyToken>
+    where
+        F: FnOnce() -> bool,
+    {
+        self.try_claim_natural_parent_notify_with(candidate, || ((), eligible()))
+            .1
     }
 
-    pub fn set_group_exec_notify_count(&self, count: isize) {
-        let mut g = self.inner_mut();
-        g.group_exec_notify_count = count;
+    /// Variant for the last-sibling unhash path. `transition` always runs
+    /// while the sighand lock is held, so it can remove the sibling under the
+    /// nested leader thread-info lock and return whether that removal made a
+    /// Zombie leader eligible for natural-parent notification.
+    pub fn try_claim_natural_parent_notify_with<F, R>(
+        &self,
+        candidate: &Arc<ProcessControlBlock>,
+        transition: F,
+    ) -> (R, Option<NaturalParentNotifyToken>)
+    where
+        F: FnOnce() -> (R, bool),
+    {
+        let g = self.inner_mut();
+        let (result, eligible) = transition();
+        if !candidate.is_thread_group_leader()
+            || (g.flags.contains(SignalFlags::GROUP_EXEC)
+                && Self::weak_matches(&g.group_exec_old_leader, candidate))
+            || !eligible
+        {
+            return (result, None);
+        }
+        let owner = Arc::downgrade(candidate);
+        let token = candidate
+            .try_claim_natural_parent_notify()
+            .then_some(NaturalParentNotifyToken { owner });
+        (result, token)
     }
 
-    pub fn dec_group_exec_notify_count_and_wake(&self) {
-        let mut g = self.inner_mut();
-        if g.group_exec_notify_count > 0 {
-            g.group_exec_notify_count -= 1;
-            if g.group_exec_notify_count == 0 {
-                drop(g);
-                self.group_exec_wait_queue().wakeup_all(None);
-                return;
-            }
+    pub fn complete_natural_parent_notify(&self, token: NaturalParentNotifyToken) -> bool {
+        token
+            .owner
+            .upgrade()
+            .map(|owner| owner.complete_natural_parent_notify())
+            .unwrap_or(false)
+    }
+
+    /// Stable report/reap decision for natural-parent wait and autoreap.
+    pub fn try_reap_natural_child(
+        &self,
+        candidate: &Arc<ProcessControlBlock>,
+        consume: bool,
+    ) -> ReapTransition {
+        self.try_reap_natural_child_inner(candidate, consume, None)
+    }
+
+    /// Read-only fast probe used by wait scans before attempting a consuming
+    /// transition. The consuming helper rechecks these barriers under the
+    /// write lock, so a concurrent transaction cannot slip through a TOCTOU
+    /// window.
+    pub fn natural_reap_blocked(&self, candidate: &Arc<ProcessControlBlock>) -> bool {
+        let g = self.inner();
+        (g.flags.contains(SignalFlags::GROUP_EXEC)
+            && Self::weak_matches(&g.group_exec_old_leader, candidate))
+            || candidate.natural_parent_notify_phase() == NaturalParentNotifyPhase::Pending
+    }
+
+    /// Stable ptrace report/reap decision. Group-exec arbitration and the
+    /// optional Zombie -> Dead transition share one SigHand critical section.
+    pub fn try_reap_ptraced_child(
+        &self,
+        candidate: &Arc<ProcessControlBlock>,
+        consume: bool,
+    ) -> ReapTransition {
+        let g = self.inner_mut();
+        if g.flags.contains(SignalFlags::GROUP_EXEC)
+            && Self::weak_matches(&g.group_exec_old_leader, candidate)
+        {
+            return ReapTransition::Blocked;
+        }
+        if !candidate.is_zombie() {
+            return ReapTransition::NotZombie;
+        }
+        if !consume {
+            return ReapTransition::Reportable;
+        }
+        if candidate.try_mark_dead_from_zombie() {
+            ReapTransition::Reaped
+        } else {
+            ReapTransition::NotZombie
         }
     }
 
-    pub fn wake_group_exec_waiters(&self) {
-        self.group_exec_wait_queue().wakeup_all(None);
+    /// Autoreap used by the unique natural-parent notification owner. The
+    /// token bypasses only its own Pending barrier, never a group-exec barrier.
+    pub fn try_reap_natural_child_as_notify_owner(
+        &self,
+        candidate: &Arc<ProcessControlBlock>,
+        token: &NaturalParentNotifyToken,
+    ) -> ReapTransition {
+        self.try_reap_natural_child_inner(candidate, true, Some(token))
+    }
+
+    fn try_reap_natural_child_inner(
+        &self,
+        candidate: &Arc<ProcessControlBlock>,
+        consume: bool,
+        token: Option<&NaturalParentNotifyToken>,
+    ) -> ReapTransition {
+        let g = self.inner_mut();
+        if g.flags.contains(SignalFlags::GROUP_EXEC)
+            && Self::weak_matches(&g.group_exec_old_leader, candidate)
+        {
+            return ReapTransition::Blocked;
+        }
+
+        if candidate.natural_parent_notify_phase() == NaturalParentNotifyPhase::Pending {
+            let owns_notification = token
+                .map(|token| Weak::ptr_eq(&token.owner, &Arc::downgrade(candidate)))
+                .unwrap_or(false);
+            if !owns_notification {
+                return ReapTransition::Blocked;
+            }
+        }
+
+        if !candidate.is_zombie() {
+            return ReapTransition::NotZombie;
+        }
+        if !consume {
+            return ReapTransition::Reportable;
+        }
+        if candidate.try_mark_dead_from_zombie() {
+            ReapTransition::Reaped
+        } else {
+            ReapTransition::NotZombie
+        }
+    }
+
+    pub fn reap_blocked_by_group_exec(&self, candidate: &Arc<ProcessControlBlock>) -> bool {
+        let g = self.inner();
+        g.flags.contains(SignalFlags::GROUP_EXEC)
+            && Self::weak_matches(&g.group_exec_old_leader, candidate)
     }
 
     /// 若当前线程组已经处于 group-exit 状态，则返回统一的退出码；否则返回 None
@@ -597,6 +947,9 @@ impl Default for InnerSigHand {
             stop_signal: Signal::SIGSTOP,
             group_exec_task: None,
             group_exec_notify_count: 0,
+            group_exec_old_leader: None,
+            group_exec_leader_phase: None,
+            group_exec_generation: 0,
             oom_tgid: None,
             oom_mm_id: None,
             oom_mm: None,

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -466,9 +466,7 @@ impl Signal {
             return;
         };
 
-        if !is_thread_target
-            && self.start_fatal_group_exit_if_needed(pcb.clone(), target_pcb.clone())
-        {
+        if self.start_fatal_group_exit_if_needed(pcb.clone(), target_pcb.clone()) {
             return;
         }
 
@@ -495,7 +493,7 @@ impl Signal {
 
         let tasks = ProcessManager::thread_group_tasks_snapshot(target);
         for task in tasks {
-            Self::queue_group_kill_to_thread(&task);
+            Self::queue_private_sigkill_to_thread(&task);
         }
 
         true
@@ -525,7 +523,13 @@ impl Signal {
         true
     }
 
-    fn queue_group_kill_to_thread(task: &Arc<ProcessControlBlock>) {
+    /// Queue the private SIGKILL used after the kernel has already committed
+    /// to tearing down sibling threads for group-exit or de_thread().
+    ///
+    /// Unlike normal signal delivery, this must not run complete_signal()
+    /// again: during de_thread() the exec owner is intentionally preserved,
+    /// while during group-exit the shared exit state is already committed.
+    pub(crate) fn queue_private_sigkill_to_thread(task: &Arc<ProcessControlBlock>) {
         if task.flags().contains(ProcessFlags::EXITING) || task.is_zombie() || task.is_dead() {
             return;
         }

--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -431,6 +431,26 @@ impl Signal {
         compiler_fence(core::sync::atomic::Ordering::SeqCst);
         // 根据信号类型选择添加到线程级 pending 还是进程级 shared_pending
         let is_thread_target = matches!(pt, PidType::PID);
+        let target_pcb = if is_thread_target {
+            if self.wants_signal(pcb.clone()) {
+                Some(pcb.clone())
+            } else {
+                None
+            }
+        } else {
+            self.select_group_signal_target(pcb.clone())
+        };
+
+        // Linux commits SIGNAL_GROUP_EXIT and its shared exit code under the
+        // sighand lock before making a fatal signal observable to de_thread().
+        // Otherwise the exec owner can see private SIGKILL pending, cancel
+        // exec, and win the race to publish EAGAIN as the group exit status.
+        if let Some(target_pcb) = target_pcb.as_ref() {
+            if self.start_fatal_group_exit_if_needed(pcb.clone(), target_pcb.clone()) {
+                return;
+            }
+        }
+
         if is_thread_target {
             // 线程级信号：添加到线程的 sig_pending
             pcb.sig_info_mut()
@@ -449,26 +469,12 @@ impl Signal {
         // 若目标进程存在 signalfd 监听该信号，需要唤醒其等待者/epoll。
         crate::ipc::signalfd::notify_signalfd_for_pcb(&pcb, *self);
 
-        let target_pcb = if is_thread_target {
-            if self.wants_signal(pcb.clone()) {
-                Some(pcb.clone())
-            } else {
-                None
-            }
-        } else {
-            self.select_group_signal_target(pcb.clone())
-        };
-
         let Some(target_pcb) = target_pcb else {
             if is_thread_target {
                 pcb.recalc_sigpending();
             }
             return;
         };
-
-        if self.start_fatal_group_exit_if_needed(pcb.clone(), target_pcb.clone()) {
-            return;
-        }
 
         target_pcb.recalc_sigpending();
         compiler_fence(core::sync::atomic::Ordering::SeqCst);

--- a/kernel/src/ipc/signal_types.rs
+++ b/kernel/src/ipc/signal_types.rs
@@ -572,6 +572,26 @@ impl SigInfo {
                     },
                 },
             },
+            SigType::SigChild {
+                pid,
+                uid,
+                status,
+                utime,
+                stime,
+            } => PosixSigInfo {
+                si_signo: self.sig_no,
+                si_errno: self.errno,
+                si_code: self.sig_code.as_i32(),
+                _sifields: PosixSiginfoFields {
+                    _sigchld: PosixSiginfoSigchld {
+                        si_pid: pid.data() as i32,
+                        si_uid: uid,
+                        si_status: status,
+                        si_utime: utime,
+                        si_stime: stime,
+                    },
+                },
+            },
             SigType::Alarm(pid) => PosixSigInfo {
                 si_signo: self.sig_no,
                 si_errno: self.errno,
@@ -679,6 +699,14 @@ pub enum SigType {
         uid: u32,
         sigval: PosixSigval,
     },
+    /// Kernel-generated child state notification (CLD_*).
+    SigChild {
+        pid: RawPid,
+        uid: u32,
+        status: i32,
+        utime: i64,
+        stime: i64,
+    },
     Alarm(RawPid),
     /// POSIX interval timer 发送的信号（SI_TIMER）。
     /// - `timerid`: 对应用户态 `siginfo_t::si_timerid`
@@ -708,7 +736,6 @@ pub enum SigType {
     // 后续完善下列中的具体字段
     // Timer,
     // Rt,
-    // SigChild,
     // SigFault,
     // SigSys,
 }

--- a/kernel/src/process/cputime.rs
+++ b/kernel/src/process/cputime.rs
@@ -72,14 +72,35 @@ impl ProcessControlBlock {
             return self.thread_cputime_ns();
         }
 
-        let mut total = leader.thread_cputime_ns();
         let ti = leader.threads_read_irqsave();
+        // Exit accounts a thread under this same membership lock before
+        // removing it from group_tasks.  A reader therefore observes the
+        // thread either here or in the exited total, never in both/neither.
+        let mut total = *leader.exited_thread_group_cputime_ns.lock();
+        total = total.saturating_add(leader.thread_cputime_ns());
         for t in &ti.group_tasks {
             if let Some(p) = t.upgrade() {
                 total = total.saturating_add(p.thread_cputime_ns());
             }
         }
         total
+    }
+
+    pub(crate) fn add_exited_thread_group_cputime(&self, ns: u64) {
+        let mut total = self.exited_thread_group_cputime_ns.lock();
+        *total = total.saturating_add(ns);
+    }
+
+    /// Preserve signal_struct-like CPU history when non-leader exec promotes
+    /// this task to thread-group leader.  The group-exec handoff has already
+    /// quiesced every other member, so queries still select `old_leader` before
+    /// the identity swap and select `self` afterwards.
+    pub(crate) fn inherit_exited_thread_group_cputime_from(
+        &self,
+        old_leader: &ProcessControlBlock,
+    ) {
+        let inherited = *old_leader.exited_thread_group_cputime_ns.lock();
+        self.add_exited_thread_group_cputime(inherited);
     }
 
     #[inline(always)]

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -510,9 +510,12 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         }
         drop(membership_guard);
 
-        // Transfer the old leader's children list to the new leader.
-        let moved_children = {
-            let leader_pid_ns = leader.active_pid_ns();
+        // Transfer the old leader's children list and parent links as one
+        // tasklist-like transaction. A concurrent release must observe both
+        // the new owner and its index entry, or neither.
+        let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
+        let leader_pid_ns = leader.active_pid_ns();
+        let moved_child_pids = {
             let (first, second) =
                 if (Arc::as_ptr(&current) as usize) <= (Arc::as_ptr(leader) as usize) {
                     (current.clone(), leader.clone())
@@ -532,12 +535,13 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
                 first_children.extend(moved.iter().copied());
                 moved
             }
+        };
+        let moved_children = moved_child_pids
             .into_iter()
             .filter_map(|pid| ProcessManager::find_task_by_pid_ns(pid, &leader_pid_ns))
-            .collect::<Vec<_>>()
-        };
+            .collect::<Vec<_>>();
         for child in moved_children {
-            ProcessControlBlock::reparent_child_links_from_thread_group(
+            ProcessControlBlock::reparent_child_links_from_thread_group_locked(
                 &child,
                 current.tgid,
                 &current,
@@ -546,13 +550,13 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
 
         // Inherit parent process relationships from the old leader.
         {
-            let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
             let leader_parent = leader.real_parent_pcb.read_irqsave().clone();
             *current.parent_pcb.write_irqsave() = leader_parent.clone();
             *current.real_parent_pcb.write_irqsave() = leader_parent.clone();
             *current.wait_parent_pcb.write_irqsave() = leader_parent.clone();
             *current.fork_parent_pcb.write_irqsave() = leader_parent;
         }
+        drop(_relation_guard);
 
         // log::info!("de_thread: reparented current to old leader's parent");
 

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -463,12 +463,38 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         current.inherit_exited_thread_group_cputime_from(leader);
         current.inherit_thread_group_rusage_from(leader);
 
+        let membership_guard = crate::process::pid::pid_membership_lock();
         ProcessManager::exchange_tid_and_raw_pids(&current, leader);
 
         current
             .exit_signal
             .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
+
+        // PGID/SID physical indices contain leaders only. Transfer both links
+        // after promoting the new leader and before demoting the old one, so a
+        // concurrent group lookup always has a valid representative.
+        leader.transfer_pid_link_to_locked(&current, PidType::PGID);
+        leader.transfer_pid_link_to_locked(&current, PidType::SID);
         leader.exit_signal.store(-1, Ordering::SeqCst);
+
+        // Session-leader ownership is process-wide in Linux, but DragonOS
+        // currently stores the marker on the leader PCB. Move it together
+        // with the leader identity so job-control checks keep observing the
+        // same process after a non-leader exec.
+        let (leader_is_session_leader, leader_tty) = {
+            let mut leader_signal = leader.sig_info_mut();
+            let state = (leader_signal.is_session_leader, leader_signal.tty());
+            leader_signal.is_session_leader = false;
+            leader_signal.set_tty(None);
+            state
+        };
+        if leader_is_session_leader {
+            let mut current_signal = current.sig_info_mut();
+            current_signal.is_session_leader = true;
+            if current_signal.tty().is_none() {
+                current_signal.set_tty(leader_tty);
+            }
+        }
 
         // Promote the current thread to thread-group leader and clear
         // group_tasks (no other threads remain).
@@ -482,6 +508,7 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
             leader_ti.group_leader = Arc::downgrade(&current);
             leader_ti.group_tasks.clear();
         }
+        drop(membership_guard);
 
         // Transfer the old leader's children list to the new leader.
         let moved_children = {
@@ -547,11 +574,10 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
             // remove the newly published child under the same map key.
             unsafe { ProcessManager::release(leader.raw_pid()) };
 
-            // Every DragonOS thread owns TGID/PGID/SID task links. The
-            // generic release path sees the migrated old leader as a
-            // non-leader and only detaches PID, so remove its remaining links
-            // explicitly. `leader` remains alive through this Arc.
-            leader.detach_exec_leader_non_pid_links();
+            // DragonOS still indexes TGID by every thread. The generic release
+            // path sees the migrated old leader as a nonleader and only
+            // detaches PID, so remove its remaining TGID link explicitly.
+            leader.detach_pid(PidType::TGID);
         }
     } else {
         current

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -457,6 +457,12 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         );
         assert!(leader.is_zombie(), "old exec leader must be zombie");
 
+        // Linux keeps these values in the shared signal_struct, so de_thread()
+        // naturally preserves them. DragonOS stores them on the leader PCB and
+        // must transfer the accumulated history before changing leader identity.
+        current.inherit_exited_thread_group_cputime_from(leader);
+        current.inherit_thread_group_rusage_from(leader);
+
         ProcessManager::exchange_tid_and_raw_pids(&current, leader);
 
         current

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -7,6 +7,7 @@ use crate::{
     arch::ipc::signal::Signal,
     driver::base::block::SeekFrom,
     filesystem::vfs::{fcntl::AtFlags, file::File, open::do_open_execat},
+    ipc::sighand::GroupExecCancelResult,
     libs::elf::ELF_LOADER,
     mm::{
         ucontext::{AddressSpace, UserStack},
@@ -330,216 +331,233 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     }
 
     let sighand = current.sighand();
-    // Mutually exclusive with group-exit / concurrent exec.
-    sighand.start_group_exec(&current)?;
+    let leader = {
+        let ti = current.threads_read_irqsave();
+        ti.group_leader().unwrap_or_else(|| current.clone())
+    };
+    let old_leader = (!Arc::ptr_eq(&leader, &current)).then_some(leader.clone());
 
-    let result = (|| {
-        // log::info!(
-        //     "de_thread: start pid={:?} tgid={:?}",
-        //     current.raw_pid(),
-        //     current.raw_tgid()
-        // );
+    // Collection and per-task token assignment share SigHand::inner with the
+    // unhash-tail completion path. An already exiting/ptraced zombie sibling
+    // remains pending until it has stopped touching identity-bearing lists.
+    let (kill_list, invalid_old_leader) =
+        sighand.start_group_exec_transaction(&current, old_leader.as_ref(), |generation| {
+            let invalid_old_leader = old_leader
+                .as_ref()
+                .map(|old| old.is_dead())
+                .unwrap_or(false);
+            let mut kill_list = Vec::new();
+            let mut pending = 0;
 
-        if current.threads_read_irqsave().thread_group_empty() {
-            // log::info!(
-            //     "de_thread: single-thread fast path pid={:?}",
-            //     current.raw_pid()
-            // );
-            current
-                .exit_signal
-                .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
-            return Ok(());
-        }
+            if let Some(old) = old_leader.as_ref() {
+                if !old.flags().contains(ProcessFlags::EXITING)
+                    && !old.is_exited()
+                    && !old.is_zombie()
+                    && !old.is_dead()
+                {
+                    kill_list.push(old.clone());
+                }
+            }
 
-        let leader = {
-            let ti = current.threads_read_irqsave();
-            ti.group_leader().unwrap_or_else(|| current.clone())
-        };
-
-        // log::info!(
-        //     "de_thread: leader pid={:?}, current_is_leader={}",
-        //     leader.raw_pid(),
-        //     Arc::ptr_eq(&leader, &current)
-        // );
-
-        let mut kill_list: Vec<Arc<ProcessControlBlock>> = Vec::new();
-        let mut leader_in_kill_list = false;
-        if !Arc::ptr_eq(&leader, &current)
-            && !leader.flags().contains(ProcessFlags::EXITING)
-            && !leader.is_exited()
-            && !leader.is_zombie()
-            && !leader.is_dead()
-        {
-            kill_list.push(leader.clone());
-            leader_in_kill_list = true;
-        }
-        {
             let ti = leader.threads_read_irqsave();
             for weak in &ti.group_tasks {
-                if let Some(task) = weak.upgrade() {
-                    if Arc::ptr_eq(&task, &current) {
-                        continue;
-                    }
-                    if task.flags().contains(ProcessFlags::EXITING)
-                        || task.is_exited()
-                        || task.is_zombie()
-                        || task.is_dead()
-                    {
-                        continue;
-                    }
+                let Some(task) = weak.upgrade() else {
+                    continue;
+                };
+                if Arc::ptr_eq(&task, &current)
+                    || old_leader
+                        .as_ref()
+                        .map(|old| Arc::ptr_eq(old, &task))
+                        .unwrap_or(false)
+                {
+                    continue;
+                }
+                if !task.identity_unhash_complete() {
+                    task.assign_group_exec_generation(generation);
+                    pending += 1;
+                }
+                if !task.flags().contains(ProcessFlags::EXITING)
+                    && !task.is_exited()
+                    && !task.is_zombie()
+                    && !task.is_dead()
+                {
                     kill_list.push(task);
                 }
             }
-        }
+            ((kill_list, invalid_old_leader), pending)
+        })?;
 
-        let mut notify_count = kill_list.len() as isize;
-        // Non-leader exec: notify_count does not include the leader itself.
-        if !Arc::ptr_eq(&leader, &current) && leader_in_kill_list {
-            notify_count -= 1;
+    if invalid_old_leader {
+        match sighand.try_cancel_group_exec(&current) {
+            GroupExecCancelResult::Canceled => {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            GroupExecCancelResult::Committed => {
+                panic!("invalid old leader reached committed group-exec state");
+            }
+            GroupExecCancelResult::NotOwner => {
+                panic!("group-exec ownership disappeared during cleanup");
+            }
         }
-        sighand.set_group_exec_notify_count(notify_count);
+    }
 
-        for task in kill_list {
-            let _ = Signal::SIGKILL.send_signal_info_to_pcb(None, task, PidType::PID);
+    for task in kill_list {
+        let _ = Signal::SIGKILL.send_signal_info_to_pcb(None, task, PidType::PID);
+    }
+
+    let pending_wait = sighand.wait_group_exec_event_killable(
+        || Signal::fatal_signal_pending(&current) || sighand.group_exec_pending_complete(&current),
+        None::<fn()>,
+    );
+    if pending_wait.is_err() || Signal::fatal_signal_pending(&current) {
+        match sighand.try_cancel_group_exec(&current) {
+            GroupExecCancelResult::Canceled | GroupExecCancelResult::NotOwner => {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            GroupExecCancelResult::Committed => {
+                sighand
+                    .wait_group_exec_event_uninterruptible(
+                        || sighand.group_exec_handoff_ready(&current),
+                        None::<fn()>,
+                    )
+                    .expect("uninterruptible group-exec wait failed");
+            }
         }
+    }
 
-        // First wait for non-leader threads to exit (notify_count == 0).
-        let wait_res = sighand.wait_group_exec_event_killable(
-            || {
-                if Signal::fatal_signal_pending(&current) {
-                    return true;
-                }
-                sighand.group_exec_notify_count() == 0
-            },
-            None::<fn()>,
-        );
-        if wait_res.is_err() || Signal::fatal_signal_pending(&current) {
-            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-        }
-
-        // Non-leader exec: wait for the leader to become zombie before swapping
-        // tid/raw_pid.
-        if !Arc::ptr_eq(&leader, &current) {
-            // Mark that we are waiting for the leader to exit (notify_count < 0),
-            // to be woken by exit_notify. The wait state must be published before
-            // checking the leader, otherwise the leader might exit between the
-            // check and the write, causing exit_notify to miss notify_count < 0
-            // and lose the wakeup.
-            sighand.set_group_exec_notify_count(-1);
-            let wait_res = sighand.wait_group_exec_event_killable(
+    if let Some(leader) = old_leader.as_ref() {
+        if !sighand.group_exec_handoff_ready(&current) {
+            let leader_wait = sighand.wait_group_exec_event_killable(
                 || {
-                    if Signal::fatal_signal_pending(&current) {
-                        return true;
-                    }
-                    leader.is_zombie() || leader.is_dead()
+                    Signal::fatal_signal_pending(&current)
+                        || sighand.group_exec_handoff_ready(&current)
                 },
                 None::<fn()>,
             );
-            if wait_res.is_err() || Signal::fatal_signal_pending(&current) {
-                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-            }
-
-            ProcessManager::exchange_tid_and_raw_pids(&current, &leader)?;
-
-            current
-                .exit_signal
-                .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
-            leader.exit_signal.store(-1, Ordering::SeqCst);
-
-            // Promote the current thread to thread-group leader and clear
-            // group_tasks (no other threads remain).
-            {
-                let mut cur_ti = current.threads_write_irqsave();
-                cur_ti.group_leader = Arc::downgrade(&current);
-                cur_ti.group_tasks.clear();
-            }
-            {
-                let mut leader_ti = leader.threads_write_irqsave();
-                leader_ti.group_leader = Arc::downgrade(&current);
-                leader_ti.group_tasks.clear();
-            }
-
-            // Transfer the old leader's children list to the new leader.
-            let moved_children = {
-                let leader_pid_ns = leader.active_pid_ns();
-                let (first, second) =
-                    if (Arc::as_ptr(&current) as usize) <= (Arc::as_ptr(&leader) as usize) {
-                        (current.clone(), leader.clone())
-                    } else {
-                        (leader.clone(), current.clone())
-                    };
-
-                let mut first_children = first.children.write_irqsave();
-                let mut second_children = second.children.write_irqsave();
-
-                if Arc::ptr_eq(&leader, &first) {
-                    let moved = core::mem::take(&mut *first_children);
-                    second_children.extend(moved.iter().copied());
-                    moved
-                } else {
-                    let moved = core::mem::take(&mut *second_children);
-                    first_children.extend(moved.iter().copied());
-                    moved
+            if leader_wait.is_err() || Signal::fatal_signal_pending(&current) {
+                match sighand.try_cancel_group_exec(&current) {
+                    GroupExecCancelResult::Canceled | GroupExecCancelResult::NotOwner => {
+                        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                    }
+                    GroupExecCancelResult::Committed => {
+                        sighand
+                            .wait_group_exec_event_uninterruptible(
+                                || sighand.group_exec_handoff_ready(&current),
+                                None::<fn()>,
+                            )
+                            .expect("uninterruptible group-exec wait failed");
+                    }
                 }
-                .into_iter()
-                .filter_map(|pid| ProcessManager::find_task_by_pid_ns(pid, &leader_pid_ns))
-                .collect::<Vec<_>>()
-            };
-            for child in moved_children {
-                ProcessControlBlock::reparent_child_links_from_thread_group(
-                    &child,
-                    current.tgid,
-                    &current,
-                );
             }
-
-            // Inherit parent process relationships from the old leader.
-            {
-                let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
-                let leader_parent = leader.real_parent_pcb.read_irqsave().clone();
-                *current.parent_pcb.write_irqsave() = leader_parent.clone();
-                *current.real_parent_pcb.write_irqsave() = leader_parent.clone();
-                *current.wait_parent_pcb.write_irqsave() = leader_parent.clone();
-                *current.fork_parent_pcb.write_irqsave() = leader_parent;
-            }
-
-            // log::info!("de_thread: reparented current to old leader's parent");
-
-            // The old leader should be reaped by the exec thread to prevent the
-            // parent from reaping it prematurely before/after the swap.
-            let mut release_leader = false;
-            if leader.is_zombie() {
-                if leader.try_mark_dead_from_zombie() {
-                    release_leader = true;
-                }
-            } else if leader.is_dead() {
-                release_leader = true;
-            }
-
-            if release_leader {
-                // Remove the old PCB from ALL_PROCESS before generic release can
-                // return its swapped-out TID to the PID allocator. Otherwise a
-                // concurrent fork can reuse that number and a late release would
-                // remove the newly published child under the same map key.
-                unsafe { ProcessManager::release(leader.raw_pid()) };
-
-                // Every DragonOS thread owns TGID/PGID/SID task links. The
-                // generic release path sees the migrated old leader as a
-                // non-leader and only detaches PID, so remove its remaining links
-                // explicitly. `leader` remains alive through this Arc.
-                leader.detach_exec_leader_non_pid_links();
-            }
-        } else {
-            current
-                .exit_signal
-                .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
         }
 
-        Ok(())
-    })();
+        assert!(
+            sighand.group_exec_handoff_ready(&current),
+            "committed group-exec handoff is not ready"
+        );
+        assert!(leader.is_zombie(), "old exec leader must be zombie");
 
-    sighand.finish_group_exec();
-    result
+        ProcessManager::exchange_tid_and_raw_pids(&current, leader);
+
+        current
+            .exit_signal
+            .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
+        leader.exit_signal.store(-1, Ordering::SeqCst);
+
+        // Promote the current thread to thread-group leader and clear
+        // group_tasks (no other threads remain).
+        {
+            let mut cur_ti = current.threads_write_irqsave();
+            cur_ti.group_leader = Arc::downgrade(&current);
+            cur_ti.group_tasks.clear();
+        }
+        {
+            let mut leader_ti = leader.threads_write_irqsave();
+            leader_ti.group_leader = Arc::downgrade(&current);
+            leader_ti.group_tasks.clear();
+        }
+
+        // Transfer the old leader's children list to the new leader.
+        let moved_children = {
+            let leader_pid_ns = leader.active_pid_ns();
+            let (first, second) =
+                if (Arc::as_ptr(&current) as usize) <= (Arc::as_ptr(leader) as usize) {
+                    (current.clone(), leader.clone())
+                } else {
+                    (leader.clone(), current.clone())
+                };
+
+            let mut first_children = first.children.write_irqsave();
+            let mut second_children = second.children.write_irqsave();
+
+            if Arc::ptr_eq(leader, &first) {
+                let moved = core::mem::take(&mut *first_children);
+                second_children.extend(moved.iter().copied());
+                moved
+            } else {
+                let moved = core::mem::take(&mut *second_children);
+                first_children.extend(moved.iter().copied());
+                moved
+            }
+            .into_iter()
+            .filter_map(|pid| ProcessManager::find_task_by_pid_ns(pid, &leader_pid_ns))
+            .collect::<Vec<_>>()
+        };
+        for child in moved_children {
+            ProcessControlBlock::reparent_child_links_from_thread_group(
+                &child,
+                current.tgid,
+                &current,
+            );
+        }
+
+        // Inherit parent process relationships from the old leader.
+        {
+            let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
+            let leader_parent = leader.real_parent_pcb.read_irqsave().clone();
+            *current.parent_pcb.write_irqsave() = leader_parent.clone();
+            *current.real_parent_pcb.write_irqsave() = leader_parent.clone();
+            *current.wait_parent_pcb.write_irqsave() = leader_parent.clone();
+            *current.fork_parent_pcb.write_irqsave() = leader_parent;
+        }
+
+        // log::info!("de_thread: reparented current to old leader's parent");
+
+        // The old leader should be reaped by the exec thread to prevent the
+        // parent from reaping it prematurely before/after the swap.
+        let mut release_leader = false;
+        if leader.is_zombie() {
+            if leader.try_mark_dead_from_zombie() {
+                release_leader = true;
+            }
+        } else if leader.is_dead() {
+            release_leader = true;
+        }
+
+        if release_leader {
+            // Remove the old PCB from ALL_PROCESS before generic release can
+            // return its swapped-out TID to the PID allocator. Otherwise a
+            // concurrent fork can reuse that number and a late release would
+            // remove the newly published child under the same map key.
+            unsafe { ProcessManager::release(leader.raw_pid()) };
+
+            // Every DragonOS thread owns TGID/PGID/SID task links. The
+            // generic release path sees the migrated old leader as a
+            // non-leader and only detaches PID, so remove its remaining links
+            // explicitly. `leader` remains alive through this Arc.
+            leader.detach_exec_leader_non_pid_links();
+        }
+    } else {
+        current
+            .exit_signal
+            .store(Signal::SIGCHLD as i32, Ordering::SeqCst);
+    }
+
+    assert!(
+        sighand.finish_group_exec_owned(&current),
+        "group-exec owner could not finish a completed transaction"
+    );
+    Ok(())
 }
 
 /// ## Load a binary file.

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -402,7 +402,7 @@ fn de_thread(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     }
 
     for task in kill_list {
-        let _ = Signal::SIGKILL.send_signal_info_to_pcb(None, task, PidType::PID);
+        Signal::queue_private_sigkill_to_thread(&task);
     }
 
     let pending_wait = sighand.wait_group_exec_event_killable(

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -916,6 +916,7 @@ impl ProcessControlBlock {
                 let (wake_pidfd, token) =
                     sighand.try_claim_natural_parent_notify_with(&leader, || {
                         let mut leader_threads = leader.threads_write_irqsave();
+                        leader.add_exited_thread_group_cputime(self.thread_cputime_ns());
                         if let Some(rusage) = self.get_rusage(RUsageWho::RusageThread) {
                             leader.add_exited_thread_group_rusage(&rusage);
                         }

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -31,7 +31,7 @@ fn wstatus_to_waitid_status(raw_wstatus: i32) -> i32 {
 }
 
 #[inline(always)]
-fn wstatus_to_waitid_exit_info(raw_wstatus: i32) -> (i32, i32) {
+pub(crate) fn wstatus_to_waitid_exit_info(raw_wstatus: i32) -> (i32, i32) {
     let signal = raw_wstatus & 0x7f;
     if signal == 0 {
         (

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -8,6 +8,7 @@ use system_error::SystemError;
 use crate::{
     arch::ipc::signal::{SigChildCode, Signal},
     driver::tty::tty_core::TtyCore,
+    ipc::sighand::ReapTransition,
     ipc::signal_types::SignalFlags,
     process::{namespace::user_namespace::map_id_up, pid::PidType, ptrace, wait::WaitSelector},
     syscall::user_access::UserBufferWriter,
@@ -17,7 +18,7 @@ use super::{
     abi::WaitOption,
     dec_visible_thread_count,
     resource::{RUsage, RUsageWho},
-    ProcessControlBlock, ProcessFlags, ProcessManager, RawPid,
+    ProcessControlBlock, ProcessFlags, ProcessManager, RawPid, PTRACE_RELATION_LOCK,
 };
 
 const DEFAULT_OVERFLOW_UID: u32 = 65534;
@@ -46,14 +47,7 @@ fn wstatus_to_waitid_exit_info(raw_wstatus: i32) -> (i32, i32) {
 
 /// mt-exec: de_thread 正在接管旧线程组时，禁止 wait 路径提前回收其他线程。
 fn reap_blocked_by_group_exec(child_pcb: &Arc<ProcessControlBlock>) -> bool {
-    if !child_pcb.sighand().flags_contains(SignalFlags::GROUP_EXEC) {
-        return false;
-    }
-    let exec_task = child_pcb.sighand().group_exec_task();
-    exec_task
-        .as_ref()
-        .map(|t| !Arc::ptr_eq(t, child_pcb))
-        .unwrap_or(true)
+    child_pcb.sighand().reap_blocked_by_group_exec(child_pcb)
 }
 
 fn delay_group_leader(child_pcb: &Arc<ProcessControlBlock>) -> bool {
@@ -463,9 +457,27 @@ fn report_wait_event(
     relation: WaitRelation,
     kwo: &mut KernelWaitOption,
 ) -> CandidateDecision {
-    if !relation_is_eligible(child_pcb, relation, kwo.options)
-        || !child_matches_wait_options(child_pcb, kwo.options, relation)
-    {
+    if !relation_is_eligible(child_pcb, relation, kwo.options) {
+        return CandidateDecision::Ineligible;
+    }
+    // A TGID lookup can select the old leader immediately before de_thread
+    // publishes exit_signal = -1.  It is no longer the natural-child leader,
+    // but the same PID may already resolve to the promoted exec task.  Retry
+    // instead of turning this transient identity snapshot into ECHILD.
+    if relation == WaitRelation::Natural && !child_pcb.is_thread_group_leader() {
+        return CandidateDecision::Pending { can_change: true };
+    }
+    if !child_matches_wait_options(child_pcb, kwo.options, relation) {
+        // de_thread changes the old leader from a SIGCHLD child to a detached
+        // thread while transferring the visible TGID to the exec task.  The
+        // PID lookup and this exit_signal load are not covered by Linux's
+        // tasklist_lock in DragonOS, so a waiter can transiently select the
+        // old leader and then observe its post-handoff exit_signal.  Keep the
+        // candidate retryable until the explicit group-exec transaction is
+        // complete; the next scan will resolve the promoted leader.
+        if relation == WaitRelation::Natural && reap_blocked_by_group_exec(child_pcb) {
+            return CandidateDecision::Pending { can_change: true };
+        }
         return CandidateDecision::Ineligible;
     }
 
@@ -479,14 +491,50 @@ fn report_wait_event(
     // A zombie leader with live subthreads is still an eligible child even when
     // the caller did not request WEXITED; otherwise waitid(WSTOPPED|WNOHANG)
     // would incorrectly report ECHILD while the thread group can still change.
-    let delayed_zombie =
-        is_zombie && (delay_group_leader(child_pcb) || reap_blocked_by_group_exec(child_pcb));
+    let delayed_zombie = is_zombie
+        && (delay_group_leader(child_pcb)
+            || match relation {
+                WaitRelation::Natural => child_pcb.sighand().natural_reap_blocked(child_pcb),
+                WaitRelation::Ptraced => reap_blocked_by_group_exec(child_pcb),
+            });
     if is_zombie && !delayed_zombie && kwo.options.contains(WaitOption::WEXITED) {
         let Some(raw_wstatus) = state.raw_wstatus().map(|status| status as i32) else {
             return CandidateDecision::Pending { can_change: false };
         };
-        if !kwo.options.contains(WaitOption::WNOWAIT) && !child_pcb.try_mark_dead_from_zombie() {
-            return CandidateDecision::Ineligible;
+        let consume = !kwo.options.contains(WaitOption::WNOWAIT);
+        match relation {
+            WaitRelation::Natural => {
+                let transition = child_pcb
+                    .sighand()
+                    .try_reap_natural_child(child_pcb, consume);
+                let expected = if consume {
+                    ReapTransition::Reaped
+                } else {
+                    ReapTransition::Reportable
+                };
+                if transition == ReapTransition::Blocked {
+                    return CandidateDecision::Pending { can_change: true };
+                }
+                if transition != expected {
+                    return CandidateDecision::Ineligible;
+                }
+            }
+            WaitRelation::Ptraced => {
+                let transition = child_pcb
+                    .sighand()
+                    .try_reap_ptraced_child(child_pcb, consume);
+                let expected = if consume {
+                    ReapTransition::Reaped
+                } else {
+                    ReapTransition::Reportable
+                };
+                if transition == ReapTransition::Blocked {
+                    return CandidateDecision::Pending { can_change: true };
+                }
+                if transition != expected {
+                    return CandidateDecision::Ineligible;
+                }
+            }
         }
 
         let pid = wait_visible_pid(child_pcb);
@@ -496,7 +544,7 @@ fn report_wait_event(
         kwo.ret_status = raw_wstatus;
         kwo.ret_info = Some(waitid_info(child_pcb, status, cause));
 
-        if !kwo.options.contains(WaitOption::WNOWAIT) {
+        if consume {
             account_reaped_child_rusage(&child_rusage);
             unsafe { ProcessManager::release(child_pcb.raw_pid()) };
         }
@@ -631,7 +679,6 @@ fn do_wait(kwo: &mut KernelWaitOption) -> Result<usize, SystemError> {
             let check_child = |kwo: &mut KernelWaitOption| -> Result<Option<usize>, SystemError> {
                 let natural_child = pid.thread_group_leader_task();
                 let ptrace_child = pid.pid_task(PidType::PID);
-
                 let mut candidates = Vec::new();
                 if let Some(child_pcb) = natural_child {
                     push_wait_candidate(&mut candidates, child_pcb, WaitRelation::Natural);
@@ -818,16 +865,11 @@ impl ProcessControlBlock {
         self.flags().insert(ProcessFlags::PID_UNHASHED);
 
         let sighand = self.sighand();
-        if sighand.flags_contains(SignalFlags::GROUP_EXEC) {
-            let this = self.self_ref.upgrade();
-            let exec_task = sighand.group_exec_task();
-            let should_clear = exec_task
-                .as_ref()
-                .and_then(|t| this.as_ref().map(|me| Arc::ptr_eq(t, me)))
-                .unwrap_or(false);
-            if should_clear {
-                sighand.finish_group_exec();
-            }
+        if let Some(this) = self.self_ref.upgrade() {
+            // Pending transactions may be canceled by their owner. A committed
+            // old-leader handoff must never be cleared from an exit cleanup
+            // path; de_thread completes it uninterruptibly.
+            let _ = sighand.try_cancel_group_exec(&this);
         }
 
         let group_dead = self.is_thread_group_leader();
@@ -862,17 +904,48 @@ impl ProcessControlBlock {
 
         // 从线程组中移除。非组长线程离开 group_tasks 后，线程组 rusage 仍需保留其 CPU 时间。
         let thread_group_leader = self.threads_read_irqsave().group_leader();
+        let mut notify_leader = None;
         if let Some(leader) = thread_group_leader {
-            let mut leader_threads = leader.threads_write_irqsave();
             if !group_dead {
-                if let Some(rusage) = self.get_rusage(RUsageWho::RusageThread) {
-                    leader.add_exited_thread_group_rusage(&rusage);
+                let sighand = self.sighand();
+                // Match exit_notify's lock order. A ptrace attach/detach cannot
+                // race between the last-sibling observation and natural-parent
+                // notification ownership being claimed.
+                let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
+                let leader_is_ptraced = ptrace::ptracer_of_locked(&leader).is_some();
+                let (wake_pidfd, token) =
+                    sighand.try_claim_natural_parent_notify_with(&leader, || {
+                        let mut leader_threads = leader.threads_write_irqsave();
+                        if let Some(rusage) = self.get_rusage(RUsageWho::RusageThread) {
+                            leader.add_exited_thread_group_rusage(&rusage);
+                        }
+                        leader_threads.group_tasks.retain(|pcb| {
+                            pcb.upgrade().is_some() && !Weak::ptr_eq(pcb, &self.self_ref)
+                        });
+                        let empty = leader_threads.group_tasks.is_empty();
+                        (true, !leader_is_ptraced && empty && leader.is_zombie())
+                    });
+                drop(_relation_guard);
+
+                if wake_pidfd {
+                    if let Some(pid) = leader.task_pid_ptr(PidType::PID) {
+                        pid.wake_pidfd_pollers();
+                    }
                 }
+
+                notify_leader = token.map(|token| (leader.clone(), token));
             }
-            leader_threads
-                .group_tasks
-                .retain(|pcb| !Weak::ptr_eq(pcb, &self.self_ref));
-            leader.pid().wake_pidfd_pollers();
+        }
+
+        self.mark_identity_unhash_complete();
+        if !group_dead {
+            if let Some(me) = self.self_ref.upgrade() {
+                self.sighand().complete_group_exec_task(&me);
+            }
+        }
+
+        if let Some((leader, token)) = notify_leader {
+            ProcessManager::notify_natural_parent_owned(&leader, token);
         }
     }
 

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -498,9 +498,16 @@ fn report_wait_event(
                 WaitRelation::Ptraced => reap_blocked_by_group_exec(child_pcb),
             });
     if is_zombie && !delayed_zombie && kwo.options.contains(WaitOption::WEXITED) {
-        let Some(raw_wstatus) = state.raw_wstatus().map(|status| status as i32) else {
+        let Some(task_wstatus) = state.raw_wstatus().map(|status| status as i32) else {
             return CandidateDecision::Pending { can_change: false };
         };
+        // Linux wait_task_zombie() exposes signal->group_exit_code after
+        // SIGNAL_GROUP_EXIT for both natural and ptrace zombie waits.
+        let raw_wstatus = child_pcb
+            .sighand()
+            .group_exit_code_if_set()
+            .map(|status| status as i32)
+            .unwrap_or(task_wstatus);
         let consume = !kwo.options.contains(WaitOption::WNOWAIT);
         match relation {
             WaitRelation::Natural => {

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -887,6 +887,10 @@ impl ProcessControlBlock {
         } else {
             // todo: 通知那些等待当前线程组退出的进程
         }
+        // PGID/SID unhashing takes PID_MEMBERSHIP_LOCK. Release the per-PCB
+        // signal-info lock first to preserve the global membership -> sig_info
+        // lock order used by fork(), setpgid(), setsid(), and tty cleanup.
+        drop(sig_guard);
         self.__unhash_process(group_dead);
 
         drop(tty);
@@ -948,16 +952,5 @@ impl ProcessControlBlock {
         if let Some((leader, token)) = notify_leader {
             ProcessManager::notify_natural_parent_owned(&leader, token);
         }
-    }
-
-    /// Remove the old leader's non-PID links after non-leader exec migration.
-    ///
-    /// DragonOS attaches TGID/PGID/SID links to every thread. The generic release
-    /// path observes the migrated old leader as a non-leader and therefore only
-    /// detaches PID; Linux instead transfers these leader links in de_thread().
-    pub(super) fn detach_exec_leader_non_pid_links(&self) {
-        self.detach_pid(PidType::TGID);
-        self.detach_pid(PidType::PGID);
-        self.detach_pid(PidType::SID);
     }
 }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -902,6 +902,9 @@ impl ProcessManager {
         crate::process::rseq::rseq_fork(pcb, clone_flags.contains(CloneFlags::CLONE_VM));
 
         let publish_result: Result<(), SystemError> = {
+            // Keep PGID/SID publication ordered before the relation lock, the
+            // same order used by de_thread's membership transaction.
+            let _membership_guard = crate::process::pid::pid_membership_lock();
             let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
             if clone_flags.contains(CloneFlags::CLONE_THREAD) {
                 let inherited_parent = current_pcb.parent_pcb.read_irqsave().clone();
@@ -913,6 +916,11 @@ impl ProcessManager {
                 pcb.exit_signal.store(-1, Ordering::SeqCst);
 
                 let group_leader = pcb.threads_read_irqsave().group_leader().unwrap();
+                // PCB construction happens before the membership transaction.
+                // Refresh the per-thread tty here so session_clear_tty() and
+                // thread publication have a single linearization order.
+                let inherited_tty = current_pcb.sig_info_irqsave().tty();
+                pcb.sig_info_mut().set_tty(inherited_tty);
                 current_pcb.sighand().with_group_exec_check(|| {
                     pcb.attach_pid(PidType::PID);
                     pcb.task_join_group_stop();
@@ -924,11 +932,7 @@ impl ProcessManager {
 
                 let leader_tgid_pid = group_leader.pid();
                 pcb.init_task_pid(PidType::TGID, leader_tgid_pid.clone());
-                pcb.init_task_pid(PidType::PGID, leader_tgid_pid.clone());
-                pcb.init_task_pid(PidType::SID, leader_tgid_pid.clone());
                 pcb.attach_pid(PidType::TGID);
-                pcb.attach_pid(PidType::PGID);
-                pcb.attach_pid(PidType::SID);
                 Ok(())
             } else {
                 if clone_flags.contains(CloneFlags::CLONE_PARENT) {

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -826,8 +826,14 @@ impl ProcessManager {
         // log::debug!("fork: clone_flags: {:?}", clone_flags);
         // 设置线程组id、组长
         if clone_flags.contains(CloneFlags::CLONE_THREAD) {
-            pcb.thread.write_irqsave().group_leader =
-                current_pcb.thread.read_irqsave().group_leader.clone();
+            let current_thread = current_pcb.thread.read_irqsave();
+            let group_leader = current_thread.group_leader.clone();
+            let thread_group_live = current_thread.thread_group_live.clone();
+            drop(current_thread);
+            let mut child_thread = pcb.thread.write_irqsave();
+            child_thread.group_leader = group_leader;
+            child_thread.thread_group_live = thread_group_live;
+            drop(child_thread);
             unsafe {
                 let ptr = pcb.as_ref() as *const ProcessControlBlock as *mut ProcessControlBlock;
                 (*ptr).tgid = current_pcb.tgid;
@@ -922,6 +928,11 @@ impl ProcessManager {
                 let inherited_tty = current_pcb.sig_info_irqsave().tty();
                 pcb.sig_info_mut().set_tty(inherited_tty);
                 current_pcb.sighand().with_group_exec_check(|| {
+                    let live = pcb
+                        .threads_read_irqsave()
+                        .thread_group_live
+                        .fetch_add(1, Ordering::Relaxed);
+                    assert_ne!(live, 0, "cannot publish a thread into a dead group");
                     pcb.attach_pid(PidType::PID);
                     pcb.task_join_group_stop();
                     group_leader

--- a/kernel/src/process/info.rs
+++ b/kernel/src/process/info.rs
@@ -3,6 +3,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
+use core::sync::atomic::AtomicUsize;
 
 use crate::{
     arch::ipc::signal::{SigSet, Signal},
@@ -49,6 +50,12 @@ pub struct ThreadInfo {
     /// When the current thread is the group leader, this field stores the
     /// PCBs of all threads in the group.
     pub(super) group_tasks: Vec<Weak<ProcessControlBlock>>,
+    /// Number of published tasks that have not entered the exit path.
+    ///
+    /// This is shared by exactly one thread group. It must not live in
+    /// `SigHand`, because CLONE_SIGHAND may share that object across distinct
+    /// thread groups.
+    pub(super) thread_group_live: Arc<AtomicUsize>,
 }
 
 impl Default for ThreadInfo {
@@ -65,6 +72,7 @@ impl ThreadInfo {
             vfork_done: None,
             group_leader: Weak::default(),
             group_tasks: Vec::new(),
+            thread_group_live: Arc::new(AtomicUsize::new(1)),
         }
     }
 

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -14,23 +14,32 @@ use crate::{
     },
     driver::tty::tty_job_control::TtyJobCtrlManager,
     exception::InterruptArch,
-    ipc::sighand::{NaturalParentNotifyToken, ReapTransition},
+    ipc::{
+        sighand::{NaturalParentNotifyToken, ReapTransition},
+        signal_types::{SigCode, SigInfo, SigType},
+    },
     libs::futex::{
         constant::{FutexFlag, FUTEX_BITSET_MATCH_ANY},
         futex::{Futex, RobustListHead},
     },
     mm::IDLE_PROCESS_ADDRESS_SPACE,
     process::{
+        exit::wstatus_to_waitid_exit_info,
         kthread::KernelThreadMechanism,
+        namespace::user_namespace::map_id_up,
         pid::{Pid, PidType},
-        ptrace, ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState, RawPid,
+        ptrace,
+        resource::RUsageWho,
+        ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState, RawPid,
     },
-    sched::{SchedMode, __schedule_with_current},
+    sched::{cputime::ns_to_clock_t, SchedMode, __schedule_with_current},
     smp::core::smp_get_processor_id,
     syscall::user_access::clear_user_protected,
 };
 
 impl ProcessManager {
+    const DEFAULT_OVERFLOW_UID: u32 = 65534;
+
     /// Notify the parent process after a child process exits.
     #[inline(never)]
     fn exit_notify(current: &Arc<ProcessControlBlock>) {
@@ -169,6 +178,44 @@ impl ProcessManager {
         }
     }
 
+    fn child_exit_siginfo(
+        child: &Arc<ProcessControlBlock>,
+        parent: &Arc<ProcessControlBlock>,
+        signal: Signal,
+    ) -> SigInfo {
+        let raw_status = child
+            .sched_info()
+            .state()
+            .raw_wstatus()
+            .expect("natural-parent exit notification requires an exited child")
+            as i32;
+        let (status, code) = wstatus_to_waitid_exit_info(raw_status);
+        let pid = child
+            .task_pid_nr_ns(PidType::PID, Some(parent.active_pid_ns()))
+            .unwrap_or(RawPid::new(0));
+        let child_uid =
+            u32::try_from(child.cred().uid.data()).unwrap_or(Self::DEFAULT_OVERFLOW_UID);
+        let parent_user_ns = parent.cred().user_ns.clone();
+        let uid = map_id_up(&parent_user_ns.inner.lock().uid_map, child_uid)
+            .unwrap_or(Self::DEFAULT_OVERFLOW_UID);
+        let rusage = child.get_rusage(RUsageWho::RUsageSelf).unwrap_or_default();
+        let utime = i64::try_from(ns_to_clock_t(rusage.ru_utime.to_ns())).unwrap_or(i64::MAX);
+        let stime = i64::try_from(ns_to_clock_t(rusage.ru_stime.to_ns())).unwrap_or(i64::MAX);
+
+        SigInfo::new(
+            signal,
+            0,
+            SigCode::Raw(code),
+            SigType::SigChild {
+                pid,
+                uid,
+                status,
+                utime,
+                stime,
+            },
+        )
+    }
+
     /// Complete the unique natural-parent notification transaction. Signal
     /// delivery and an optional owner-authorized autoreap happen while the
     /// phase is Pending; Done is then published before the final parent wake.
@@ -193,8 +240,10 @@ impl ProcessManager {
         let autoreap = exit_signal == Signal::SIGCHLD as i32 && (ignored || no_cldwait);
 
         if exit_signal > 0 && !(autoreap && ignored) {
+            let signal = Signal::from(exit_signal);
+            let mut info = Self::child_exit_siginfo(child, &parent, signal);
             if let Err(e) =
-                crate::ipc::kill::send_signal_to_pcb(parent.clone(), Signal::from(exit_signal))
+                signal.send_signal_info_to_pcb(Some(&mut info), parent.clone(), PidType::TGID)
             {
                 warn!(
                     "failed to send exit signal for {:?} to parent {:?}: {:?}",

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -273,6 +273,15 @@ impl ProcessManager {
             child.sighand().complete_natural_parent_notify(token),
             "natural-parent notification ownership changed"
         );
+        // Reparenting is serialized by PTRACE_RELATION_LOCK. If it completed
+        // before this snapshot, wake the new wait owner after publishing Done;
+        // if it happens later, the reparent path wakes after Done is visible
+        // to the waiter. This closes the Pending -> reparent lost-wakeup
+        // window without holding the relation lock across signal delivery.
+        let completion_parent = {
+            let _relation_guard = crate::process::PTRACE_RELATION_LOCK.lock_irqsave();
+            child.real_parent_pcb()
+        };
 
         if let Some((signal, mut info)) = notification {
             if let Err(e) =
@@ -288,6 +297,11 @@ impl ProcessManager {
         }
 
         ProcessManager::wake_wait_parent(&parent);
+        if let Some(completion_parent) = completion_parent {
+            if !Arc::ptr_eq(&completion_parent, &parent) {
+                ProcessManager::wake_wait_parent(&completion_parent);
+            }
+        }
 
         if child.is_kthread() {
             KernelThreadMechanism::notify_daemon();

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -28,14 +28,38 @@ use crate::{
         kthread::KernelThreadMechanism,
         namespace::user_namespace::map_id_up,
         pid::{Pid, PidType},
-        ptrace,
-        resource::RUsageWho,
-        ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState, RawPid,
+        ptrace, ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState, RawPid,
     },
     sched::{cputime::ns_to_clock_t, SchedMode, __schedule_with_current},
     smp::core::smp_get_processor_id,
     syscall::user_access::clear_user_protected,
 };
+
+struct ChildExitSiginfoSnapshot {
+    code: i32,
+    pid: RawPid,
+    uid: u32,
+    status: i32,
+    utime: i64,
+    stime: i64,
+}
+
+impl ChildExitSiginfoSnapshot {
+    fn into_siginfo(self, signal: Signal) -> SigInfo {
+        SigInfo::new(
+            signal,
+            0,
+            SigCode::Raw(self.code),
+            SigType::SigChild {
+                pid: self.pid,
+                uid: self.uid,
+                status: self.status,
+                utime: self.utime,
+                stime: self.stime,
+            },
+        )
+    }
+}
 
 impl ProcessManager {
     const DEFAULT_OVERFLOW_UID: u32 = 65534;
@@ -49,11 +73,23 @@ impl ProcessManager {
         // A claimed old leader must retain all hashed identity until the exec
         // owner swaps it. In particular it is never autoreaped here.
         if claimed_exec_leader {
-            current.set_exit_state_zombie();
+            let ptrace_notification = {
+                let _relation_guard = crate::process::PTRACE_RELATION_LOCK.lock_irqsave();
+                let tracer = ptrace::ptracer_of_locked(current);
+                let snapshot = tracer
+                    .as_ref()
+                    .map(|tracer| Self::child_exit_siginfo_snapshot(current, tracer));
+                current.set_exit_state_zombie();
+                tracer.map(|tracer| {
+                    (
+                        tracer,
+                        Signal::SIGCHLD as i32,
+                        snapshot.expect("ptrace tracer requires an exit siginfo snapshot"),
+                    )
+                })
+            };
             Self::wake_pidfd_pollers_for_task_exit(current);
-            Self::notify_ptrace_parent(
-                ptrace::ptracer_of(current).map(|tracer| (tracer, Signal::SIGCHLD as i32)),
-            );
+            Self::notify_ptrace_parent(ptrace_notification);
             current.mark_exit_notify_complete();
             let completed = sighand.complete_group_exec_leader_exit(current);
             debug_assert!(completed);
@@ -75,6 +111,13 @@ impl ProcessManager {
                 // cannot lose the transition either.
                 let _relation_guard = crate::process::PTRACE_RELATION_LOCK.lock_irqsave();
                 let tracer = ptrace::ptracer_of_locked(current);
+                // A polling tracer may reap and unhash the child as soon as
+                // Zombie becomes visible. Freeze every child-derived field
+                // before publishing Zombie; signal delivery must consume only
+                // this immutable snapshot.
+                let ptrace_snapshot = tracer
+                    .as_ref()
+                    .map(|tracer| Self::child_exit_siginfo_snapshot(current, tracer));
                 let leader = current.is_thread_group_leader();
                 let (group_empty, natural_token) = if leader {
                     // Publish Zombie and inspect group emptiness under the same
@@ -107,7 +150,11 @@ impl ProcessManager {
                     } else {
                         Signal::SIGCHLD as i32
                     };
-                    (tracer, signal)
+                    (
+                        tracer,
+                        signal,
+                        ptrace_snapshot.expect("ptrace tracer requires an exit siginfo snapshot"),
+                    )
                 });
                 (ptrace_notification, natural_token, autoreap_nonleader)
             };
@@ -134,20 +181,31 @@ impl ProcessManager {
         sighand.complete_group_exec_leader_exit(current);
     }
 
-    fn notify_ptrace_parent(tracer: Option<(Arc<ProcessControlBlock>, i32)>) {
-        if let Some((tracer, signal)) = tracer {
+    fn notify_ptrace_parent(
+        tracer: Option<(Arc<ProcessControlBlock>, i32, ChildExitSiginfoSnapshot)>,
+    ) {
+        if let Some((tracer, signal, snapshot)) = tracer {
             if signal > 0 {
-                let _ = crate::ipc::kill::send_signal_to_pcb(tracer.clone(), Signal::from(signal));
+                let signal = Signal::from(signal);
+                let mut info = snapshot.into_siginfo(signal);
+                if let Err(e) =
+                    signal.send_signal_info_to_pcb(Some(&mut info), tracer.clone(), PidType::TGID)
+                {
+                    warn!(
+                        "failed to send ptrace exit signal to tracer {:?}: {:?}",
+                        tracer.raw_pid(),
+                        e
+                    );
+                }
             }
             ProcessManager::wake_wait_parent(&tracer);
         }
     }
 
-    fn child_exit_siginfo(
+    fn child_exit_siginfo_snapshot(
         child: &Arc<ProcessControlBlock>,
         parent: &Arc<ProcessControlBlock>,
-        signal: Signal,
-    ) -> SigInfo {
+    ) -> ChildExitSiginfoSnapshot {
         let raw_status = child
             .sched_info()
             .state()
@@ -171,22 +229,18 @@ impl ProcessManager {
         let parent_user_ns = parent.cred().user_ns.clone();
         let uid = map_id_up(&parent_user_ns.inner.lock().uid_map, child_uid)
             .unwrap_or(Self::DEFAULT_OVERFLOW_UID);
-        let rusage = child.get_rusage(RUsageWho::RUsageSelf).unwrap_or_default();
+        let rusage = child.exit_notification_rusage();
         let utime = i64::try_from(ns_to_clock_t(rusage.ru_utime.to_ns())).unwrap_or(i64::MAX);
         let stime = i64::try_from(ns_to_clock_t(rusage.ru_stime.to_ns())).unwrap_or(i64::MAX);
 
-        SigInfo::new(
-            signal,
-            0,
-            SigCode::Raw(code),
-            SigType::SigChild {
-                pid,
-                uid,
-                status,
-                utime,
-                stime,
-            },
-        )
+        ChildExitSiginfoSnapshot {
+            code,
+            pid,
+            uid,
+            status,
+            utime,
+            stime,
+        }
     }
 
     /// Complete the unique natural-parent notification transaction. Build the
@@ -217,7 +271,10 @@ impl ProcessManager {
         // Snapshot every field before autoreap can unhash the child's PID.
         let notification = if exit_signal > 0 && !(autoreap && ignored) {
             let signal = Signal::from(exit_signal);
-            Some((signal, Self::child_exit_siginfo(child, &parent, signal)))
+            Some((
+                signal,
+                Self::child_exit_siginfo_snapshot(child, &parent).into_siginfo(signal),
+            ))
         } else {
             None
         };

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -134,41 +134,6 @@ impl ProcessManager {
         sighand.complete_group_exec_leader_exit(current);
     }
 
-    /// Return the stable thread-group leader and whether `current`, which has
-    /// already published EXITING, is the last live task in the group.
-    ///
-    /// The caller must hold PID_MEMBERSHIP_LOCK across both mark_exiting() and
-    /// this scan, so concurrent exits cannot both miss the unique last task.
-    fn thread_group_last_live_task(
-        current: &Arc<ProcessControlBlock>,
-    ) -> (Arc<ProcessControlBlock>, bool) {
-        let leader = current
-            .threads_read_irqsave()
-            .group_leader()
-            .unwrap_or_else(|| current.clone());
-        let leader_threads = leader.threads_read_irqsave();
-        let is_live = |task: &Arc<ProcessControlBlock>| {
-            !task.flags().contains(ProcessFlags::EXITING)
-                && !task.is_exited()
-                && !task.is_zombie()
-                && !task.is_dead()
-        };
-
-        if !Arc::ptr_eq(&leader, current) && is_live(&leader) {
-            return (leader.clone(), false);
-        }
-        for weak in &leader_threads.group_tasks {
-            let Some(task) = weak.upgrade() else {
-                continue;
-            };
-            if !Arc::ptr_eq(&task, current) && is_live(&task) {
-                return (leader.clone(), false);
-            }
-        }
-        drop(leader_threads);
-        (leader, true)
-    }
-
     fn notify_ptrace_parent(tracer: Option<(Arc<ProcessControlBlock>, i32)>) {
         if let Some((tracer, signal)) = tracer {
             if signal > 0 {
@@ -364,7 +329,17 @@ impl ProcessManager {
             let (group_leader, group_dead) = {
                 let _membership_guard = crate::process::pid::pid_membership_lock();
                 pcb.mark_exiting();
-                Self::thread_group_last_live_task(&pcb)
+                let thread = pcb.threads_read_irqsave();
+                let group_leader = thread.group_leader().unwrap_or_else(|| pcb.clone());
+                let live = thread.thread_group_live.clone();
+                drop(thread);
+                // Match Linux signal_struct::live: every successfully
+                // published thread contributes once and consumes its token on
+                // first entering do_exit(). The unique 1 -> 0 transition owns
+                // thread-group finalization without scanning group_tasks.
+                let previous = live.fetch_sub(1, Ordering::AcqRel);
+                assert_ne!(previous, 0, "thread-group live count underflow");
+                (group_leader, previous == 1)
             };
             pid = pcb.pid();
             if pid.is_child_reaper() {

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -540,22 +540,28 @@ impl ProcessManager {
             ProcessManager::exit_ptrace(pcb);
             ProcessManager::ptrace_unlink_tracee(pcb);
 
-            let parent_child_vpid = pcb.real_parent_pcb().and_then(|parent| {
-                // A concurrently exiting parent may already have unhashed its
-                // PID before this nonleader is autoreaped. Its children list
-                // has then been consumed by the adoption transaction, so
-                // there is no attached namespace/list entry left to clean.
-                let parent_ns = parent
-                    .task_pid_ptr(PidType::PID)
-                    .and_then(|pid| pid.try_ns_of_pid())?;
-                pcb.task_pid_nr_ns(PidType::PID, Some(parent_ns))
-                    .map(|vpid| (parent, vpid))
-            });
+            {
+                // Pair parent discovery with children-index removal under the
+                // same tasklist-like transaction used by reparent/de_thread.
+                // Otherwise a concurrent identity handoff can move the list
+                // entry after this release selected the former parent.
+                let _relation_guard = crate::process::PTRACE_RELATION_LOCK.lock_irqsave();
+                let parent_child_vpid = pcb.real_parent_pcb().and_then(|parent| {
+                    // A concurrently exiting parent may already have unhashed
+                    // its PID before this nonleader is autoreaped. Its children
+                    // list has then been consumed by the adoption transaction,
+                    // so no attached namespace/list entry remains to clean.
+                    let parent_ns = parent
+                        .task_pid_ptr(PidType::PID)
+                        .and_then(|pid| pid.try_ns_of_pid())?;
+                    pcb.task_pid_nr_ns(PidType::PID, Some(parent_ns))
+                        .map(|vpid| (parent, vpid))
+                });
 
-            // Remove from the parent's children list.
-            if let Some((parent, vpid)) = parent_child_vpid {
-                let mut children = parent.children.write();
-                children.retain(|&p| p != vpid);
+                if let Some((parent, vpid)) = parent_child_vpid {
+                    let mut children = parent.children.write();
+                    children.retain(|&p| p != vpid);
+                }
             }
 
             // Revoke the old PCB's global numeric lookup before __exit_signal()

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -14,7 +14,8 @@ use crate::{
     },
     driver::tty::tty_job_control::TtyJobCtrlManager,
     exception::InterruptArch,
-    ipc::signal_types::{SigCode, SigInfo, SigType, SignalFlags},
+    ipc::sighand::{NaturalParentNotifyToken, ReapTransition},
+    ipc::signal_types::{SigCode, SigInfo, SigType},
     libs::futex::{
         constant::{FutexFlag, FUTEX_BITSET_MATCH_ANY},
         futex::{Futex, RobustListHead},
@@ -35,43 +36,22 @@ impl ProcessManager {
     #[inline(never)]
     fn exit_notify(current: &Arc<ProcessControlBlock>) {
         let sighand = current.sighand();
-        let exec_task = if sighand.flags_contains(SignalFlags::GROUP_EXEC) {
-            sighand.group_exec_task()
-        } else {
-            None
-        };
-        let is_mt_exec_leader = current.is_thread_group_leader()
-            && exec_task
-                .as_ref()
-                .map(|t| !Arc::ptr_eq(t, current))
-                .unwrap_or(false);
-        if sighand.flags_contains(SignalFlags::GROUP_EXEC) {
-            if let Some(exec_task) = exec_task.as_ref() {
-                if !Arc::ptr_eq(exec_task, current) {
-                    let notify_count = sighand.group_exec_notify_count();
-                    if notify_count < 0 {
-                        // mt-exec: the exec thread is waiting for the leader to exit
-                        sighand.wake_group_exec_waiters();
-                    } else if !current.is_thread_group_leader() {
-                        sighand.dec_group_exec_notify_count_and_wake();
-                    }
-                }
-            }
-            let should_clear = exec_task
-                .as_ref()
-                .map(|t| Arc::ptr_eq(t, current))
-                .unwrap_or(false);
-            if should_clear {
-                sighand.finish_group_exec();
-            }
-        }
-        // mt-exec: when the leader exits, only mark it zombie to avoid
-        // triggering the normal exit notification/adoption path.
-        if is_mt_exec_leader {
+        let claimed_exec_leader = sighand.claim_group_exec_leader_exit(current);
+
+        // A claimed old leader must retain all hashed identity until the exec
+        // owner swaps it. In particular it is never autoreaped here.
+        if claimed_exec_leader {
             current.set_exit_state_zombie();
             Self::wake_pidfd_pollers_for_task_exit(current);
+            Self::notify_ptrace_parent(
+                ptrace::ptracer_of(current).map(|tracer| (tracer, Signal::SIGCHLD as i32)),
+            );
+            current.mark_exit_notify_complete();
+            let completed = sighand.complete_group_exec_leader_exit(current);
+            debug_assert!(completed);
             return;
         }
+
         // Have the INIT process adopt all children.
         if current.raw_pid() != RawPid(1) {
             unsafe {
@@ -80,68 +60,134 @@ impl ProcessManager {
                     .unwrap_or_else(|e| panic!("adopte_childen failed: error: {e:?}"))
             };
             ProcessManager::exit_ptrace(current);
-            // Mark as Zombie before notifying the parent so that wait is
-            // guaranteed to see the state change.
-            current.set_exit_state_zombie();
+            let (ptrace_notification, natural_token, autoreap_nonleader) = {
+                // Keep ptrace classification stable until Zombie publication
+                // and natural-parent ownership are committed. Concurrent
+                // detach wakes the natural parent after this snapshot, so it
+                // cannot lose the transition either.
+                let _relation_guard = crate::process::PTRACE_RELATION_LOCK.lock_irqsave();
+                let tracer = ptrace::ptracer_of_locked(current);
+                let leader = current.is_thread_group_leader();
+                let (group_empty, natural_token) = if leader {
+                    // Publish Zombie and inspect group emptiness under the same
+                    // SigHand lock used by the last-sibling remove+claim path.
+                    // Whichever side observes the group become empty therefore
+                    // owns the one natural-parent notification transaction.
+                    let (empty, token) =
+                        sighand.try_claim_natural_parent_notify_with(current, || {
+                            current.set_exit_state_zombie();
+                            let empty = !current
+                                .threads_read_irqsave()
+                                .group_tasks
+                                .iter()
+                                .any(|task| task.upgrade().is_some());
+                            (empty, tracer.is_none() && empty)
+                        });
+                    (empty, token)
+                } else {
+                    current.set_exit_state_zombie();
+                    (false, None)
+                };
+                let autoreap_nonleader = tracer.is_none() && !leader;
+                let ptrace_notification = tracer.map(|tracer| {
+                    let natural_tracer = current
+                        .real_parent_pcb()
+                        .map(|parent| Arc::ptr_eq(&parent, &tracer))
+                        .unwrap_or(false);
+                    let signal = if leader && group_empty && natural_tracer {
+                        current.exit_signal.load(Ordering::Acquire)
+                    } else {
+                        Signal::SIGCHLD as i32
+                    };
+                    (tracer, signal)
+                });
+                (ptrace_notification, natural_token, autoreap_nonleader)
+            };
+            // Ordinary exit does not become wait-visible until adoption and
+            // ptrace teardown have stopped using the old identity. For a
+            // group-empty leader, notification Pending is claimed first so a
+            // polling parent cannot consume Zombie before the notifier owns
+            // the Done-before-wake transaction.
             Self::wake_pidfd_pollers_for_task_exit(current);
-            let r = current.parent_pcb.read_irqsave().upgrade();
-            if r.is_none() {
-                return;
-            }
-            let parent_pcb = r.unwrap();
+            Self::notify_ptrace_parent(ptrace_notification);
 
-            // Check the child's exit_signal; send a notification signal only when
-            // the signal number is positive.
-            // Linux semantics: exit_signal=0 means no signal sent but still waitable,
-            // -1 means a non-leader thread.
-            let exit_signal = current.exit_signal.load(Ordering::SeqCst);
-            let sigchld_disposition = parent_pcb.sighand().handler(Signal::SIGCHLD);
-            let sigchld_ignored = sigchld_disposition
-                .as_ref()
-                .map(|sa| sa.is_ignore())
-                .unwrap_or(false);
-            let sigchld_no_cldwait = sigchld_disposition
-                .as_ref()
-                .map(|sa| sa.flags().contains(SigFlags::SA_NOCLDWAIT))
-                .unwrap_or(false);
-            let autoreap = !current.is_ptraced()
-                && exit_signal == Signal::SIGCHLD as i32
-                && (sigchld_ignored || sigchld_no_cldwait);
-            let is_kthread = current.is_kthread();
-            if autoreap && current.try_mark_dead_from_zombie() {
-                unsafe { ProcessManager::release(current.raw_pid()) };
-            }
-
-            if exit_signal > 0 && !(autoreap && sigchld_ignored) {
-                let r = crate::ipc::kill::send_signal_to_pcb(
-                    parent_pcb.clone(),
-                    Signal::from(exit_signal),
-                );
-                if let Err(e) = r {
-                    warn!(
-                        "failed to send kill signal to {:?}'s parent pcb {:?}: {:?}",
-                        current.raw_pid(),
-                        parent_pcb.raw_pid(),
-                        e
-                    );
+            if autoreap_nonleader {
+                // Linux autoreaps ordinary nonleaders. release/__unhash_process
+                // completes the generation token only after identity teardown.
+                if current.try_mark_dead_from_zombie() {
+                    unsafe { ProcessManager::release(current.raw_pid()) };
                 }
+            } else if let Some(token) = natural_token {
+                Self::notify_natural_parent_owned(current, token);
             }
+        }
 
-            // Wake the wait parent regardless of exit_signal value.
-            // exit_signal only determines which signal to send, not whether to wake wait.
-            // DragonOS waiters sleep on per-task wait_queue, so we must also wake
-            // the parent's thread-group leader to compensate for Linux's shared
-            // signal->wait_chldexit queue semantics.
-            ProcessManager::wake_wait_parent(&parent_pcb);
+        current.mark_exit_notify_complete();
+        sighand.complete_group_exec_leader_exit(current);
+    }
 
-            // Explicitly wake kthreadd when a kthread exits so that it can
-            // reap the zombie.
-            if is_kthread {
-                KernelThreadMechanism::notify_daemon();
+    fn notify_ptrace_parent(tracer: Option<(Arc<ProcessControlBlock>, i32)>) {
+        if let Some((tracer, signal)) = tracer {
+            if signal > 0 {
+                let _ = crate::ipc::kill::send_signal_to_pcb(tracer.clone(), Signal::from(signal));
             }
+            ProcessManager::wake_wait_parent(&tracer);
+        }
+    }
 
-            // TODO: The signal delivery decision should also consider thread-group
-            // information.
+    /// Complete the unique natural-parent notification transaction. Signal
+    /// delivery and an optional owner-authorized autoreap happen while the
+    /// phase is Pending; Done is then published before the final parent wake.
+    pub(crate) fn notify_natural_parent_owned(
+        child: &Arc<ProcessControlBlock>,
+        token: NaturalParentNotifyToken,
+    ) {
+        let Some(parent) = child.real_parent_pcb() else {
+            child.sighand().complete_natural_parent_notify(token);
+            return;
+        };
+        let exit_signal = child.exit_signal.load(Ordering::SeqCst);
+        let disposition = parent.sighand().handler(Signal::SIGCHLD);
+        let ignored = disposition
+            .as_ref()
+            .map(|sa| sa.is_ignore())
+            .unwrap_or(false);
+        let no_cldwait = disposition
+            .as_ref()
+            .map(|sa| sa.flags().contains(SigFlags::SA_NOCLDWAIT))
+            .unwrap_or(false);
+        let autoreap = exit_signal == Signal::SIGCHLD as i32 && (ignored || no_cldwait);
+
+        if exit_signal > 0 && !(autoreap && ignored) {
+            if let Err(e) =
+                crate::ipc::kill::send_signal_to_pcb(parent.clone(), Signal::from(exit_signal))
+            {
+                warn!(
+                    "failed to send exit signal for {:?} to parent {:?}: {:?}",
+                    child.raw_pid(),
+                    parent.raw_pid(),
+                    e
+                );
+            }
+        }
+
+        if autoreap
+            && child
+                .sighand()
+                .try_reap_natural_child_as_notify_owner(child, &token)
+                == ReapTransition::Reaped
+        {
+            unsafe { ProcessManager::release(child.raw_pid()) };
+        }
+
+        assert!(
+            child.sighand().complete_natural_parent_notify(token),
+            "natural-parent notification ownership changed"
+        );
+        ProcessManager::wake_wait_parent(&parent);
+
+        if child.is_kthread() {
+            KernelThreadMechanism::notify_daemon();
         }
     }
 
@@ -478,7 +524,13 @@ impl ProcessManager {
             ProcessManager::ptrace_unlink_tracee(pcb);
 
             let parent_child_vpid = pcb.real_parent_pcb().and_then(|parent| {
-                let parent_ns = parent.active_pid_ns();
+                // A concurrently exiting parent may already have unhashed its
+                // PID before this nonleader is autoreaped. Its children list
+                // has then been consumed by the adoption transaction, so
+                // there is no attached namespace/list entry left to clean.
+                let parent_ns = parent
+                    .task_pid_ptr(PidType::PID)
+                    .and_then(|pid| pid.try_ns_of_pid())?;
                 pcb.task_pid_nr_ns(PidType::PID, Some(parent_ns))
                     .map(|vpid| (parent, vpid))
             });

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -216,9 +216,11 @@ impl ProcessManager {
         )
     }
 
-    /// Complete the unique natural-parent notification transaction. Signal
-    /// delivery and an optional owner-authorized autoreap happen while the
-    /// phase is Pending; Done is then published before the final parent wake.
+    /// Complete the unique natural-parent notification transaction. Build the
+    /// child snapshot while identity is stable, perform an optional
+    /// owner-authorized autoreap, and publish Done before signal delivery. A
+    /// SIGCHLD handler may call wait immediately, so the signal must never
+    /// expose the intermediate Pending phase.
     pub(crate) fn notify_natural_parent_owned(
         child: &Arc<ProcessControlBlock>,
         token: NaturalParentNotifyToken,
@@ -239,9 +241,32 @@ impl ProcessManager {
             .unwrap_or(false);
         let autoreap = exit_signal == Signal::SIGCHLD as i32 && (ignored || no_cldwait);
 
-        if exit_signal > 0 && !(autoreap && ignored) {
+        // Snapshot every field before autoreap can unhash the child's PID.
+        let notification = if exit_signal > 0 && !(autoreap && ignored) {
             let signal = Signal::from(exit_signal);
-            let mut info = Self::child_exit_siginfo(child, &parent, signal);
+            Some((signal, Self::child_exit_siginfo(child, &parent, signal)))
+        } else {
+            None
+        };
+
+        if autoreap {
+            let transition = child
+                .sighand()
+                .try_reap_natural_child_as_notify_owner(child, &token);
+            assert_eq!(
+                transition,
+                ReapTransition::Reaped,
+                "natural-parent notification owner failed to autoreap"
+            );
+            unsafe { ProcessManager::release(child.raw_pid()) };
+        }
+
+        assert!(
+            child.sighand().complete_natural_parent_notify(token),
+            "natural-parent notification ownership changed"
+        );
+
+        if let Some((signal, mut info)) = notification {
             if let Err(e) =
                 signal.send_signal_info_to_pcb(Some(&mut info), parent.clone(), PidType::TGID)
             {
@@ -254,19 +279,6 @@ impl ProcessManager {
             }
         }
 
-        if autoreap
-            && child
-                .sighand()
-                .try_reap_natural_child_as_notify_owner(child, &token)
-                == ReapTransition::Reaped
-        {
-            unsafe { ProcessManager::release(child.raw_pid()) };
-        }
-
-        assert!(
-            child.sighand().complete_natural_parent_notify(token),
-            "natural-parent notification ownership changed"
-        );
         ProcessManager::wake_wait_parent(&parent);
 
         if child.is_kthread() {

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -15,7 +15,6 @@ use crate::{
     driver::tty::tty_job_control::TtyJobCtrlManager,
     exception::InterruptArch,
     ipc::sighand::{NaturalParentNotifyToken, ReapTransition},
-    ipc::signal_types::{SigCode, SigInfo, SigType},
     libs::futex::{
         constant::{FutexFlag, FUTEX_BITSET_MATCH_ANY},
         futex::{Futex, RobustListHead},
@@ -476,20 +475,7 @@ impl ProcessManager {
                     if task.flags().contains(ProcessFlags::EXITING) {
                         return;
                     }
-                    let mut info = SigInfo::new(
-                        Signal::SIGKILL,
-                        0,
-                        SigCode::Kernel,
-                        SigType::Kill {
-                            pid: RawPid::new(0),
-                            uid: 0,
-                        },
-                    );
-                    let _ = Signal::SIGKILL.send_signal_info_to_pcb(
-                        Some(&mut info),
-                        task,
-                        PidType::PID,
-                    );
+                    Signal::queue_private_sigkill_to_thread(&task);
                 };
 
                 // Obtain the full thread list from the thread group leader's

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -189,6 +189,14 @@ impl ProcessManager {
             .raw_wstatus()
             .expect("natural-parent exit notification requires an exited child")
             as i32;
+        // Preserve Linux's observable group-exit status even though DragonOS
+        // stores the last task's local do_exit() argument separately (for
+        // example, de_thread() may return EAGAIN after SIGKILL committed).
+        let raw_status = child
+            .sighand()
+            .group_exit_code_if_set()
+            .map(|status| status as i32)
+            .unwrap_or(raw_status);
         let (status, code) = wstatus_to_waitid_exit_info(raw_status);
         let pid = child
             .task_pid_nr_ns(PidType::PID, Some(parent.active_pid_ns()))

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -126,6 +126,41 @@ impl ProcessManager {
         sighand.complete_group_exec_leader_exit(current);
     }
 
+    /// Return the stable thread-group leader and whether `current`, which has
+    /// already published EXITING, is the last live task in the group.
+    ///
+    /// The caller must hold PID_MEMBERSHIP_LOCK across both mark_exiting() and
+    /// this scan, so concurrent exits cannot both miss the unique last task.
+    fn thread_group_last_live_task(
+        current: &Arc<ProcessControlBlock>,
+    ) -> (Arc<ProcessControlBlock>, bool) {
+        let leader = current
+            .threads_read_irqsave()
+            .group_leader()
+            .unwrap_or_else(|| current.clone());
+        let leader_threads = leader.threads_read_irqsave();
+        let is_live = |task: &Arc<ProcessControlBlock>| {
+            !task.flags().contains(ProcessFlags::EXITING)
+                && !task.is_exited()
+                && !task.is_zombie()
+                && !task.is_dead()
+        };
+
+        if !Arc::ptr_eq(&leader, current) && is_live(&leader) {
+            return (leader.clone(), false);
+        }
+        for weak in &leader_threads.group_tasks {
+            let Some(task) = weak.upgrade() else {
+                continue;
+            };
+            if !Arc::ptr_eq(&task, current) && is_live(&task) {
+                return (leader.clone(), false);
+            }
+        }
+        drop(leader_threads);
+        (leader, true)
+    }
+
     fn notify_ptrace_parent(tracer: Option<(Arc<ProcessControlBlock>, i32)>) {
         if let Some((tracer, signal)) = tracer {
             if signal > 0 {
@@ -244,7 +279,11 @@ impl ProcessManager {
         // log::debug!("[exit: {}]", raw_pid.data());
         {
             let pcb = current_pcb.clone();
-            pcb.mark_exiting();
+            let (group_leader, group_dead) = {
+                let _membership_guard = crate::process::pid::pid_membership_lock();
+                pcb.mark_exiting();
+                Self::thread_group_last_live_task(&pcb)
+            };
             pid = pcb.pid();
             if pid.is_child_reaper() {
                 pid.ns_of_pid().disable_pid_allocation();
@@ -331,32 +370,25 @@ impl ProcessManager {
             pcb.exit_fs();
             pcb.exit_timers();
 
-            let (current_tty, is_session_leader, sid) = {
-                let siginfo = pcb.sig_info_irqsave();
-                (siginfo.tty(), siginfo.is_session_leader, pcb.task_session())
-            };
-            if let Some(tty) = current_tty {
-                if is_session_leader {
-                    let tty_pgrp = tty.core().contorl_info_irqsave().pgid.clone();
-                    if let Some(pgrp) = tty_pgrp {
-                        let _ = crate::ipc::kill::send_signal_to_pgid(&pgrp, Signal::SIGHUP);
-                    }
-                    TtyJobCtrlManager::remove_session_tty(&tty);
-                    if let Some(sid) = sid {
-                        TtyJobCtrlManager::session_clear_tty(sid);
+            if group_dead {
+                let (current_tty, is_session_leader, sid) = {
+                    let siginfo = group_leader.sig_info_irqsave();
+                    (siginfo.tty(), siginfo.is_session_leader, pcb.task_session())
+                };
+                if let Some(tty) = current_tty {
+                    if is_session_leader {
+                        let tty_pgrp = sid.as_ref().and_then(|sid| {
+                            TtyJobCtrlManager::remove_session_tty_if_owner(&tty, sid)
+                        });
+                        if let Some(pgrp) = tty_pgrp {
+                            let _ = crate::ipc::kill::send_signal_to_pgid(&pgrp, Signal::SIGHUP);
+                        }
                     } else {
-                        pcb.sig_info_mut().set_tty(None);
+                        group_leader.sig_info_mut().set_tty(None);
                     }
                 } else {
-                    let mut g = tty.core().contorl_info_irqsave();
-                    if g.pgid == Some(pid) {
-                        g.pgid = None;
-                    }
-                    drop(g);
-                    pcb.sig_info_mut().set_tty(None);
+                    group_leader.sig_info_mut().set_tty(None);
                 }
-            } else {
-                pcb.sig_info_mut().set_tty(None);
             }
 
             // Linux semantics: a zombie must not appear in cgroup.procs.
@@ -433,7 +465,6 @@ impl ProcessManager {
             //    shared sighand. If another thread has already set it, reuse
             //    the existing exit code.
             let sighand = current_pcb.sighand();
-            current_pcb.mark_exiting();
             final_exit_code = sighand.start_group_exit(exit_code);
 
             // 2. Send SIGKILL to other threads in the same thread group,

--- a/kernel/src/process/manager/mod.rs
+++ b/kernel/src/process/manager/mod.rs
@@ -7,7 +7,6 @@ use core::{
 use alloc::{sync::Arc, vec::Vec};
 use hashbrown::HashMap;
 use log::{debug, error, info};
-use system_error::SystemError;
 
 use crate::{
     libs::{
@@ -83,14 +82,15 @@ fn exchange_raw_pids_locked(
     map: &mut HashMap<RawPid, Arc<ProcessControlBlock>>,
     left: &Arc<ProcessControlBlock>,
     right: &Arc<ProcessControlBlock>,
-) -> Result<(), SystemError> {
+) {
     let left_pid = left.raw_pid();
     let right_pid = right.raw_pid();
-    if left_pid == right_pid {
-        return Err(SystemError::EINVAL);
-    }
-    let left_entry = map.remove(&left_pid).ok_or(SystemError::ESRCH)?;
-    let right_entry = map.remove(&right_pid).ok_or(SystemError::ESRCH)?;
+    let left_entry = map
+        .remove(&left_pid)
+        .expect("validated left PID disappeared during identity exchange");
+    let right_entry = map
+        .remove(&right_pid)
+        .expect("validated right PID disappeared during identity exchange");
 
     unsafe {
         left.force_set_raw_pid(right_pid);
@@ -99,7 +99,6 @@ fn exchange_raw_pids_locked(
 
     map.insert(right_pid, left_entry);
     map.insert(left_pid, right_entry);
-    Ok(())
 }
 
 pub static mut PROCESS_SWITCH_RESULT: Option<PerCpuVar<SwitchResult>> = None;
@@ -329,31 +328,55 @@ impl ProcessManager {
     pub(crate) fn exchange_tid_and_raw_pids(
         left: &Arc<ProcessControlBlock>,
         right: &Arc<ProcessControlBlock>,
-    ) -> Result<(), SystemError> {
-        let _cgroup_guard = crate::cgroup::cgroup_accounting_lock().lock();
-        let mut all_proc = all_process().lock_irqsave();
-        let map = all_proc.as_mut().ok_or(SystemError::EINVAL)?;
+    ) {
+        // Keep this order aligned with fork/release publication: ptrace
+        // relations, cgroup accounting, global raw-PID lookup, then the
+        // ordered per-task and struct-Pid locks acquired by exchange_tid_with.
+        let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
         let left_old_pid = left.raw_pid();
         let right_old_pid = right.raw_pid();
-        if left_old_pid == right_old_pid {
-            return Err(SystemError::EINVAL);
-        }
-        if !map.contains_key(&left_old_pid) || !map.contains_key(&right_old_pid) {
-            return Err(SystemError::ESRCH);
-        }
+        let ptrace_plan = crate::process::ptrace::prepare_tracee_pid_exchange_locked(
+            left,
+            right,
+            left_old_pid,
+            right_old_pid,
+        );
+        let _cgroup_guard = crate::cgroup::cgroup_accounting_lock().lock();
+        let mut all_proc = all_process().lock_irqsave();
+        let map = all_proc
+            .as_mut()
+            .expect("PID identity exchange requires initialized process map");
+        assert_ne!(
+            left_old_pid, right_old_pid,
+            "PID identity exchange requires distinct raw PIDs"
+        );
+        assert!(
+            map.get(&left_old_pid)
+                .map(|entry| Arc::ptr_eq(entry, left))
+                .unwrap_or(false),
+            "left raw PID does not resolve to the expected task"
+        );
+        assert!(
+            map.get(&right_old_pid)
+                .map(|entry| Arc::ptr_eq(entry, right))
+                .unwrap_or(false),
+            "right raw PID does not resolve to the expected task"
+        );
 
         let left_cgroup = left.task_cgroup_node();
         let right_cgroup = right.task_cgroup_node();
         let left_alive = !left.is_exited();
         let right_alive = !right.is_exited();
 
-        left.exchange_tid_with(right)?;
-        exchange_raw_pids_locked(map, left, right)?;
+        left.exchange_tid_with(right, || {
+            exchange_raw_pids_locked(map, left, right);
+            crate::process::ptrace::commit_tracee_pid_exchange_locked(ptrace_plan);
+        });
 
         // cgroup.procs only shows tasks that are still alive; when exec
         // detaches threads and swaps pids, only rename the visible members.
         if Arc::ptr_eq(&left_cgroup, &right_cgroup) && left_alive && right_alive {
-            return Ok(());
+            return;
         }
         if left_alive {
             left_cgroup.rename_task(left_old_pid, left.raw_pid());
@@ -361,8 +384,6 @@ impl ProcessManager {
         if right_alive {
             right_cgroup.rename_task(right_old_pid, right.raw_pid());
         }
-
-        Ok(())
     }
 
     /// ### Returns the PIDs of all processes.

--- a/kernel/src/process/pid.rs
+++ b/kernel/src/process/pid.rs
@@ -305,13 +305,17 @@ impl ProcessControlBlock {
         self.pid.store(pid, Ordering::Release);
     }
 
-    pub(super) fn exchange_tid_with(
+    pub(super) fn exchange_tid_with<F>(
         self: &Arc<Self>,
         other: &Arc<ProcessControlBlock>,
-    ) -> Result<(), SystemError> {
-        if Arc::ptr_eq(self, other) {
-            return Err(SystemError::EINVAL);
-        }
+        commit_outer_identity: F,
+    ) where
+        F: FnOnce(),
+    {
+        assert!(
+            !Arc::ptr_eq(self, other),
+            "cannot exchange one task's PID identity with itself"
+        );
 
         let (first_task, second_task) = order_pcbs(self, other);
         let mut first_link = first_task.pid_links[PidType::PID as usize].pid.write();
@@ -320,11 +324,30 @@ impl ProcessControlBlock {
         let mut first_thread_pid = first_task.thread_pid.write();
         let mut second_thread_pid = second_task.thread_pid.write();
 
-        let first_pid = first_thread_pid.clone().ok_or(SystemError::EINVAL)?;
-        let second_pid = second_thread_pid.clone().ok_or(SystemError::EINVAL)?;
-        if Arc::ptr_eq(&first_pid, &second_pid) {
-            return Err(SystemError::EINVAL);
-        }
+        let first_pid = first_thread_pid
+            .clone()
+            .expect("PID identity exchange requires first task thread_pid");
+        let second_pid = second_thread_pid
+            .clone()
+            .expect("PID identity exchange requires second task thread_pid");
+        assert!(
+            !Arc::ptr_eq(&first_pid, &second_pid),
+            "PID identity exchange requires distinct struct Pid objects"
+        );
+        assert!(
+            first_link
+                .as_ref()
+                .map(|pid| Arc::ptr_eq(pid, &first_pid))
+                .unwrap_or(false),
+            "first task's PID link does not match thread_pid"
+        );
+        assert!(
+            second_link
+                .as_ref()
+                .map(|pid| Arc::ptr_eq(pid, &second_pid))
+                .unwrap_or(false),
+            "second task's PID link does not match thread_pid"
+        );
 
         let (first_pid_lock, second_pid_lock) = order_pids(&first_pid, &second_pid);
         let mut first_tasks = first_pid_lock.tasks[PidType::PID as usize].lock();
@@ -336,13 +359,25 @@ impl ProcessControlBlock {
             (second_task, first_task)
         };
 
-        replace_task_in_pid_tasks(&mut first_tasks, first_task_for_pid, second_task_for_pid)?;
-        replace_task_in_pid_tasks(&mut second_tasks, second_task_for_pid, first_task_for_pid)?;
+        // Locate both entries before changing either list.  Once the first
+        // replacement is visible this operation is the committed half of an
+        // exec identity transaction and must no longer fail.
+        let first_index = find_task_in_pid_tasks(&first_tasks, first_task_for_pid)
+            .expect("first task missing from validated struct Pid task list");
+        let second_index = find_task_in_pid_tasks(&second_tasks, second_task_for_pid)
+            .expect("second task missing from validated struct Pid task list");
+
+        first_tasks[first_index] = Arc::downgrade(second_task_for_pid);
+        second_tasks[second_index] = Arc::downgrade(first_task_for_pid);
 
         core::mem::swap(&mut *first_link, &mut *second_link);
         core::mem::swap(&mut *first_thread_pid, &mut *second_thread_pid);
 
-        Ok(())
+        // Keep every PCB/Pid identity guard alive while the caller commits
+        // raw-PID lookup and ptrace indices. Readers can then observe either
+        // the complete old identity or the complete new identity, never a
+        // Pid.tasks-only half commit.
+        commit_outer_identity();
     }
 }
 
@@ -365,18 +400,13 @@ fn order_pids<'a>(left: &'a Arc<Pid>, right: &'a Arc<Pid>) -> (&'a Arc<Pid>, &'a
     }
 }
 
-fn replace_task_in_pid_tasks(
-    tasks: &mut [Weak<ProcessControlBlock>],
-    old_task: &Arc<ProcessControlBlock>,
-    new_task: &Arc<ProcessControlBlock>,
-) -> Result<(), SystemError> {
-    for weak in tasks.iter_mut() {
-        if Weak::ptr_eq(weak, &old_task.self_ref) {
-            *weak = Arc::downgrade(new_task);
-            return Ok(());
-        }
-    }
-    Err(SystemError::ESRCH)
+fn find_task_in_pid_tasks(
+    tasks: &[Weak<ProcessControlBlock>],
+    task: &Arc<ProcessControlBlock>,
+) -> Option<usize> {
+    tasks
+        .iter()
+        .position(|candidate| Weak::ptr_eq(candidate, &task.self_ref))
 }
 
 /// 连接任务和PID的桥梁结构体

--- a/kernel/src/process/pid.rs
+++ b/kernel/src/process/pid.rs
@@ -15,6 +15,16 @@ use system_error::SystemError;
 use super::namespace::pid_namespace::PidNamespace;
 use super::{ProcessControlBlock, RawPid};
 
+/// Serializes logical and physical PGID/SID membership transactions.
+///
+/// This is the DragonOS equivalent of the Linux tasklist lock coverage used by
+/// setpgid(), setsid(), de_thread(), exit unhashing, and process-group lookup.
+static PID_MEMBERSHIP_LOCK: SpinLock<()> = SpinLock::new(());
+
+pub(crate) fn pid_membership_lock() -> SpinLockGuard<'static, ()> {
+    PID_MEMBERSHIP_LOCK.lock_irqsave()
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -566,6 +576,56 @@ impl ProcessControlBlock {
         }
     }
 
+    /// Transfer one physical non-thread PID link without changing the logical
+    /// identity stored in the shared signal state.
+    ///
+    /// Linux uses transfer_pid() during de_thread() so PGID/SID indices keep
+    /// exactly one entry for the thread group while its leader PCB changes.
+    ///
+    /// The caller must hold PID_MEMBERSHIP_LOCK.
+    pub(super) fn transfer_pid_link_to_locked(
+        self: &Arc<Self>,
+        target: &Arc<ProcessControlBlock>,
+        pid_type: PidType,
+    ) {
+        assert!(
+            matches!(pid_type, PidType::PGID | PidType::SID),
+            "only leader-owned PGID/SID links may be transferred"
+        );
+        assert!(
+            !Arc::ptr_eq(self, target),
+            "cannot transfer a PID link to the same task"
+        );
+
+        let (first, second) = order_pcbs(self, target);
+        let mut first_link = first.pid_links[pid_type as usize].pid.write();
+        let mut second_link = second.pid_links[pid_type as usize].pid.write();
+        let (source_link, target_link) = if Arc::ptr_eq(first, self) {
+            (&mut first_link, &mut second_link)
+        } else {
+            (&mut second_link, &mut first_link)
+        };
+
+        let pid = source_link
+            .as_ref()
+            .cloned()
+            .expect("source task is missing its leader-owned PID link");
+        assert!(
+            target_link.is_none(),
+            "target task already owns the transferred PID link"
+        );
+
+        let mut tasks = pid.tasks[pid_type as usize].lock();
+        let source_index = find_task_in_pid_tasks(&tasks, self)
+            .expect("source task is missing from the struct Pid task list");
+        assert!(
+            find_task_in_pid_tasks(&tasks, target).is_none(),
+            "target task is already present in the struct Pid task list"
+        );
+        tasks[source_index] = Arc::downgrade(target);
+        **target_link = source_link.take();
+    }
+
     pub fn task_pid_ptr(&self, pid_type: PidType) -> Option<Arc<Pid>> {
         if pid_type == PidType::PID {
             return self.thread_pid.read().clone();
@@ -628,10 +688,18 @@ impl ProcessControlBlock {
     }
 
     pub(super) fn detach_pid(&self, pid_type: PidType) {
+        let _membership_guard =
+            matches!(pid_type, PidType::PGID | PidType::SID).then(pid_membership_lock);
         self.__change_pid(pid_type, None);
     }
 
-    pub(super) fn change_pid(&self, pid_type: PidType, new_pid: Arc<Pid>) {
+    /// Change a leader-owned PID identity while the caller holds
+    /// PID_MEMBERSHIP_LOCK across validation and commit.
+    pub(super) fn change_pid_locked(&self, pid_type: PidType, new_pid: Arc<Pid>) {
+        assert!(
+            matches!(pid_type, PidType::PGID | PidType::SID),
+            "only leader-owned PGID/SID identities use the membership transaction"
+        );
         self.__change_pid(pid_type, Some(new_pid));
         self.attach_pid(pid_type);
     }

--- a/kernel/src/process/process_group.rs
+++ b/kernel/src/process/process_group.rs
@@ -21,6 +21,7 @@ impl ProcessManager {
         pgrp: &Arc<Pid>,
         ignored_pcb: Option<&Arc<ProcessControlBlock>>,
     ) -> bool {
+        let _membership_guard = crate::process::pid::pid_membership_lock();
         for pcb in pgrp.tasks_iter(PidType::PGID) {
             let real_parent = pcb.real_parent_pcb().unwrap();
             if ignored_pcb.is_some() && Arc::ptr_eq(&pcb, ignored_pcb.unwrap()) {

--- a/kernel/src/process/ptrace.rs
+++ b/kernel/src/process/ptrace.rs
@@ -67,25 +67,110 @@ pub fn traceme_current() -> Result<(), SystemError> {
 }
 
 pub fn unlink_tracee(tracee: &Arc<ProcessControlBlock>) {
-    let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
     let tracer = {
-        let mut ptracer = tracee.ptracer_pcb.write_irqsave();
-        let tracer = ptracer.upgrade();
-        *ptracer = Weak::new();
-        tracee.flags().remove(ProcessFlags::PTRACED);
+        let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
+        let tracer = {
+            let mut ptracer = tracee.ptracer_pcb.write_irqsave();
+            let tracer = ptracer.upgrade();
+            *ptracer = Weak::new();
+            tracee.flags().remove(ProcessFlags::PTRACED);
+            tracer
+        };
+
+        if let Some(tracer) = tracer.as_ref() {
+            let raw_pid = tracee.raw_pid();
+            tracer.ptraced.write_irqsave().retain(|pid| *pid != raw_pid);
+        }
         tracer
     };
 
-    if let Some(tracer) = tracer {
-        let raw_pid = tracee.raw_pid();
-        tracer.ptraced.write_irqsave().retain(|pid| *pid != raw_pid);
+    // Linux wakes the ptrace parent before destroying the old leader in
+    // de_thread().  DragonOS keeps separate per-task wait queues, so both the
+    // tracer and natural parent must recheck their wait ownership after the
+    // relation and index update become visible.
+    if let Some(tracer) = tracer.as_ref() {
+        ProcessManager::wake_wait_parent(tracer);
     }
 
-    // Detaching can make a tracee observable by its natural parent again.
-    // Wake the DragonOS wait owner pair (parent task + group leader), matching
-    // Linux's shared signal->wait_chldexit visibility.
     if let Some(real_parent) = tracee.real_parent_pcb() {
-        ProcessManager::wake_wait_parent(&real_parent);
+        if !tracer
+            .as_ref()
+            .map(|tracer| Arc::ptr_eq(tracer, &real_parent))
+            .unwrap_or(false)
+        {
+            ProcessManager::wake_wait_parent(&real_parent);
+        }
+    }
+}
+
+pub(crate) struct TraceePidExchangePlan {
+    left: Option<TraceePidUpdate>,
+    right: Option<TraceePidUpdate>,
+}
+
+struct TraceePidUpdate {
+    tracer: Arc<ProcessControlBlock>,
+    index: usize,
+    old_pid: RawPid,
+    new_pid: RawPid,
+}
+
+/// Resolve tracer-side vector positions before entering the global process-map
+/// IRQ-off critical section. `PTRACE_RELATION_LOCK` keeps these indices stable
+/// until `commit_tracee_pid_exchange_locked()` applies the two O(1) writes.
+pub(crate) fn prepare_tracee_pid_exchange_locked(
+    left: &Arc<ProcessControlBlock>,
+    right: &Arc<ProcessControlBlock>,
+    left_old_pid: RawPid,
+    right_old_pid: RawPid,
+) -> TraceePidExchangePlan {
+    let left_tracer = left.ptracer_pcb.read_irqsave().upgrade();
+    let right_tracer = right.ptracer_pcb.read_irqsave().upgrade();
+    let left = left_tracer.as_ref().map(|tracer| {
+        let ptraced = tracer.ptraced.read_irqsave();
+        let index = ptraced
+            .iter()
+            .position(|pid| *pid == left_old_pid)
+            .expect("left tracee missing from tracer raw-PID index");
+        TraceePidUpdate {
+            tracer: tracer.clone(),
+            index,
+            old_pid: left_old_pid,
+            new_pid: right_old_pid,
+        }
+    });
+    let right = right_tracer.as_ref().map(|tracer| {
+        let ptraced = tracer.ptraced.read_irqsave();
+        let index = ptraced
+            .iter()
+            .position(|pid| *pid == right_old_pid)
+            .expect("right tracee missing from tracer raw-PID index");
+        TraceePidUpdate {
+            tracer: tracer.clone(),
+            index,
+            old_pid: right_old_pid,
+            new_pid: left_old_pid,
+        }
+    });
+
+    TraceePidExchangePlan { left, right }
+}
+
+/// Update tracer-side raw-PID indices after the corresponding task identities
+/// have been exchanged.  The caller must hold `PTRACE_RELATION_LOCK` and must
+/// call `prepare_tracee_pid_exchange_locked()` before beginning the identity
+/// transaction.
+pub(crate) fn commit_tracee_pid_exchange_locked(plan: TraceePidExchangePlan) {
+    for update in [plan.left, plan.right].into_iter().flatten() {
+        let mut ptraced = update.tracer.ptraced.write_irqsave();
+        let entry = ptraced
+            .get_mut(update.index)
+            .expect("tracee index changed during PID identity exchange");
+        assert_eq!(
+            *entry, update.old_pid,
+            "tracee PID changed during identity exchange"
+        );
+        *entry = update.new_pid;
     }
 }
 
@@ -135,7 +220,10 @@ pub fn ptracer_of(tracee: &Arc<ProcessControlBlock>) -> Option<Arc<ProcessContro
     ptracer_of_locked(tracee)
 }
 
-fn ptracer_of_locked(tracee: &Arc<ProcessControlBlock>) -> Option<Arc<ProcessControlBlock>> {
+/// Return the tracee's ptracer while the caller holds `PTRACE_RELATION_LOCK`.
+pub(crate) fn ptracer_of_locked(
+    tracee: &Arc<ProcessControlBlock>,
+) -> Option<Arc<ProcessControlBlock>> {
     tracee.ptracer_pcb.read_irqsave().upgrade()
 }
 

--- a/kernel/src/process/resource.rs
+++ b/kernel/src/process/resource.rs
@@ -229,6 +229,20 @@ impl ProcessControlBlock {
         usage
     }
 
+    /// CPU/resource usage reported with an exit notification.
+    ///
+    /// Match Linux's `task_cputime(tsk) + tsk->signal->{u,s}time`: include the
+    /// exiting task and already released siblings, but not siblings that are
+    /// still alive. `exit_notify()` runs before `__exit_signal()` accounts the
+    /// current task into `exited_thread_group_rusage`, so the current task is
+    /// not counted twice.
+    pub(crate) fn exit_notification_rusage(&self) -> RUsage {
+        let leader = self.leader_for_rusage();
+        let mut usage = *leader.exited_thread_group_rusage.lock();
+        usage.add_assign_saturating(&self.task_rusage());
+        usage
+    }
+
     pub fn add_exited_thread_group_rusage(&self, rusage: &RUsage) {
         let leader = self.leader_for_rusage();
         leader

--- a/kernel/src/process/resource.rs
+++ b/kernel/src/process/resource.rs
@@ -242,6 +242,18 @@ impl ProcessControlBlock {
         leader.children_rusage.lock().add_assign_saturating(rusage);
     }
 
+    /// Preserve signal_struct-like group statistics across a non-leader exec
+    /// leader handoff. All other group members are quiesced before this runs.
+    pub(crate) fn inherit_thread_group_rusage_from(&self, old_leader: &ProcessControlBlock) {
+        let exited = *old_leader.exited_thread_group_rusage.lock();
+        self.exited_thread_group_rusage
+            .lock()
+            .add_assign_saturating(&exited);
+
+        let children = *old_leader.children_rusage.lock();
+        self.children_rusage.lock().add_assign_saturating(&children);
+    }
+
     /// 获取进程资源使用情况
     pub fn get_rusage(&self, who: RUsageWho) -> Option<RUsage> {
         match who {

--- a/kernel/src/process/session.rs
+++ b/kernel/src/process/session.rs
@@ -1,10 +1,15 @@
-use super::{pid::Pid, ProcessControlBlock, ProcessManager, RawPid};
+use super::{
+    pid::{pid_membership_lock, Pid},
+    ProcessControlBlock, ProcessManager, RawPid,
+};
 use crate::{driver::tty::tty_job_control::TtyJobCtrlManager, process::pid::PidType};
 use alloc::sync::Arc;
 use system_error::SystemError;
 
 /// 参考 https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/sys.c#1225
 pub(super) fn ksys_setsid() -> Result<RawPid, SystemError> {
+    // Serialize leader validation and both membership changes with de_thread().
+    let _membership_guard = pid_membership_lock();
     let pcb = ProcessManager::current_pcb();
     let group_leader = pcb
         .threads_read_irqsave()
@@ -58,10 +63,10 @@ fn set_special_pids(current_session_group_leader: &Arc<ProcessControlBlock>, sid
     //     sid.pid_vnr().data()
     // );
     if change_sid {
-        current_session_group_leader.change_pid(PidType::SID, sid.clone());
+        current_session_group_leader.change_pid_locked(PidType::SID, sid.clone());
     }
     if change_pgrp {
-        current_session_group_leader.change_pid(PidType::PGID, sid.clone());
+        current_session_group_leader.change_pid_locked(PidType::PGID, sid.clone());
     }
 
     // log::debug!(

--- a/kernel/src/process/syscall/sys_setpgid.rs
+++ b/kernel/src/process/syscall/sys_setpgid.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_SETPGID;
-use crate::process::pid::PidType;
+use crate::process::pid::{pid_membership_lock, PidType};
 use crate::process::Pgid;
 use crate::process::ProcessFlags;
 use crate::process::ProcessManager;
@@ -54,6 +54,9 @@ impl Syscall for SysSetPgid {
             pgid = pid;
         }
 
+        // Match Linux tasklist-lock coverage: the selected leader and its
+        // physical PGID link must not change between validation and commit.
+        let _membership_guard = pid_membership_lock();
         let p = ProcessManager::find_task_by_vpid(pid).ok_or(SystemError::ESRCH)?;
         if !p.is_thread_group_leader() {
             return Err(SystemError::EINVAL);
@@ -102,7 +105,7 @@ impl Syscall for SysSetPgid {
         let pp = p.task_pgrp().unwrap();
 
         if !Arc::ptr_eq(&pp, &pgrp) {
-            p.change_pid(PidType::PGID, pgrp);
+            p.change_pid_locked(PidType::PGID, pgrp);
         }
 
         return Ok(0);

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -1013,14 +1013,6 @@ impl ProcessControlBlock {
         }
     }
 
-    pub(crate) fn reparent_child_to(
-        child: &Arc<ProcessControlBlock>,
-        new_parent: &Arc<ProcessControlBlock>,
-    ) {
-        let _relation_guard = PTRACE_RELATION_LOCK.lock_irqsave();
-        ProcessControlBlock::reparent_child_to_locked(child, new_parent);
-    }
-
     fn reparent_child_to_locked(
         child: &Arc<ProcessControlBlock>,
         new_parent: &Arc<ProcessControlBlock>,
@@ -1045,7 +1037,12 @@ impl ProcessControlBlock {
         }
     }
 
-    pub(crate) fn reparent_child_links_from_thread_group(
+    /// Update a child's parent links during a thread-group identity handoff.
+    ///
+    /// The caller must hold `PTRACE_RELATION_LOCK`, DragonOS's tasklist-like
+    /// relationship lock, so the parent pointers and the owning `children`
+    /// index change as one transaction with concurrent release/reparent.
+    pub(crate) fn reparent_child_links_from_thread_group_locked(
         child: &Arc<ProcessControlBlock>,
         old_tgid: RawPid,
         new_parent: &Arc<ProcessControlBlock>,
@@ -1067,7 +1064,7 @@ impl ProcessControlBlock {
                 .unwrap_or(false);
 
         if should_reparent {
-            ProcessControlBlock::reparent_child_to(child, new_parent);
+            ProcessControlBlock::reparent_child_to_locked(child, new_parent);
         }
     }
 

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -1,4 +1,6 @@
-use core::sync::atomic::{fence, AtomicBool, AtomicI32, AtomicU8, AtomicUsize, Ordering};
+use core::sync::atomic::{
+    fence, AtomicBool, AtomicI32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+};
 
 use alloc::{
     ffi::CString,
@@ -22,7 +24,10 @@ use crate::{
         fs::FsStruct,
         vfs::{file::FileDescriptorVec, FileType, IndexNode},
     },
-    ipc::{sighand::SigHand, signal::RestartBlock},
+    ipc::{
+        sighand::{NaturalParentNotifyPhase, SigHand},
+        signal::RestartBlock,
+    },
     libs::{
         futex::futex::RobustListHead,
         lock_free_flags::LockFreeFlags,
@@ -98,6 +103,20 @@ pub struct ProcessControlBlock {
     pub(super) sig_altstack: RwLock<SigStackArch>,
     /// Exit state (Running / Zombie / Dead).
     pub(super) exit_state: AtomicU8,
+    /// `exit_notify()` has finished all producer-side work for this task.
+    ///
+    /// This is separate from `exit_state`: publishing Zombie does not imply
+    /// that pidfd or parent/tracer notification work has completed.
+    exit_notify_complete: AtomicBool,
+    /// Release/unhash has finished all identity-sensitive operations.
+    identity_unhash_complete: AtomicBool,
+    /// Group-exec transaction generation that currently accounts this task.
+    /// Zero means that no transaction owns a completion token for the task.
+    group_exec_generation: AtomicU64,
+    /// Per-leader natural-parent exit notification state. `CLONE_SIGHAND`
+    /// may share SigHand between distinct thread groups, so this state cannot
+    /// live in SigHand's single shared slot.
+    natural_parent_notify_phase: AtomicU8,
 
     /// Linux task_struct::exit_signal semantics:
     /// - -1: Non-thread-group leader (CLONE_THREAD);
@@ -315,6 +334,10 @@ impl ProcessControlBlock {
                 sighand: RcuArcSlot::new(initial_sighand.clone()),
                 sig_altstack: RwLock::new(SigStackArch::new()),
                 exit_state: AtomicU8::new(ExitState::Running as u8),
+                exit_notify_complete: AtomicBool::new(false),
+                identity_unhash_complete: AtomicBool::new(false),
+                group_exec_generation: AtomicU64::new(0),
+                natural_parent_notify_phase: AtomicU8::new(NaturalParentNotifyPhase::Idle as u8),
                 exit_signal: AtomicI32::new(Signal::SIGCHLD as i32),
                 pdeath_signal: AtomicSignal::new(Signal::INVALID),
 
@@ -1049,6 +1072,10 @@ impl ProcessControlBlock {
         // reaper, and moving children form one tasklist-lock-like transaction.
         let mut result = Vec::new();
         let mut seen = Vec::new();
+        // All members of a thread group share the active PID namespace. A
+        // concurrently exiting sibling may already have detached its PID, so
+        // derive the namespace once from the still-attached exit notifier.
+        let owner_ns = exiting.active_pid_ns();
 
         let mut push_reparent_child =
             |child: Arc<ProcessControlBlock>, result: &mut Vec<Arc<ProcessControlBlock>>| {
@@ -1060,7 +1087,6 @@ impl ProcessControlBlock {
             };
 
         for owner in ProcessManager::thread_group_tasks_snapshot(exiting.clone()) {
-            let owner_ns = owner.active_pid_ns();
             let pids_to_rehome: Vec<RawPid> = if Arc::ptr_eq(&owner, exiting) {
                 let mut children = owner.children.write_irqsave();
                 core::mem::take(&mut *children)
@@ -1443,6 +1469,87 @@ impl ProcessControlBlock {
                 Ordering::Acquire,
             )
             .is_ok()
+    }
+
+    /// Publish completion of `exit_notify()` after all producer-side effects.
+    #[inline(always)]
+    pub fn mark_exit_notify_complete(&self) {
+        self.exit_notify_complete.store(true, Ordering::Release);
+    }
+
+    #[inline(always)]
+    pub fn exit_notify_complete(&self) -> bool {
+        self.exit_notify_complete.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn natural_parent_notify_phase(&self) -> NaturalParentNotifyPhase {
+        match self.natural_parent_notify_phase.load(Ordering::Acquire) {
+            value if value == NaturalParentNotifyPhase::Idle as u8 => {
+                NaturalParentNotifyPhase::Idle
+            }
+            value if value == NaturalParentNotifyPhase::Pending as u8 => {
+                NaturalParentNotifyPhase::Pending
+            }
+            value if value == NaturalParentNotifyPhase::Done as u8 => {
+                NaturalParentNotifyPhase::Done
+            }
+            _ => panic!("invalid natural-parent notification phase"),
+        }
+    }
+
+    pub(crate) fn try_claim_natural_parent_notify(&self) -> bool {
+        self.natural_parent_notify_phase
+            .compare_exchange(
+                NaturalParentNotifyPhase::Idle as u8,
+                NaturalParentNotifyPhase::Pending as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    pub(crate) fn complete_natural_parent_notify(&self) -> bool {
+        self.natural_parent_notify_phase
+            .compare_exchange(
+                NaturalParentNotifyPhase::Pending as u8,
+                NaturalParentNotifyPhase::Done as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Publish the tail of release/unhash after PID and thread-group identity
+    /// structures no longer reference this task as a live member.
+    #[inline(always)]
+    pub fn mark_identity_unhash_complete(&self) {
+        self.identity_unhash_complete.store(true, Ordering::Release);
+    }
+
+    #[inline(always)]
+    pub fn identity_unhash_complete(&self) -> bool {
+        self.identity_unhash_complete.load(Ordering::Acquire)
+    }
+
+    /// Assign this task to a group-exec transaction. The caller serializes
+    /// assignment with completion using `SigHand::inner`.
+    #[inline(always)]
+    pub fn assign_group_exec_generation(&self, generation: u64) {
+        debug_assert_ne!(generation, 0);
+        self.group_exec_generation
+            .store(generation, Ordering::Release);
+    }
+
+    #[inline(always)]
+    pub fn group_exec_generation(&self) -> u64 {
+        self.group_exec_generation.load(Ordering::Acquire)
+    }
+
+    /// Consume the task's single completion token. This must be called while
+    /// holding the associated `SigHand::inner` write lock.
+    #[inline(always)]
+    pub(crate) fn take_group_exec_generation(&self) -> u64 {
+        self.group_exec_generation.swap(0, Ordering::AcqRel)
     }
 
     pub fn mark_exiting(&self) {

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -193,6 +193,11 @@ pub struct ProcessControlBlock {
 
     /// CPU time accounting.
     pub(super) cpu_time: Arc<ProcessCpuTime>,
+    /// Raw CPU time accumulated from threads that have left this thread group.
+    ///
+    /// This remains in nanoseconds for CLOCK_PROCESS_CPUTIME_ID.  The separate
+    /// rusage accumulator uses timeval precision for the userspace ABI.
+    pub(super) exited_thread_group_cputime_ns: SpinLock<u64>,
     /// Thread-group-level resource accumulation for exited threads. Aligns with
     /// Linux signal_struct's exited thread statistics.
     pub(super) exited_thread_group_rusage: SpinLock<RUsage>,
@@ -364,6 +369,7 @@ impl ProcessControlBlock {
                 itimers: SpinLock::new(ProcessItimers::default()),
                 posix_timers: SpinLock::new(posix_timer::ProcessPosixTimers::default()),
                 cpu_time: Arc::new(ProcessCpuTime::default()),
+                exited_thread_group_cputime_ns: SpinLock::new(0),
                 exited_thread_group_rusage: SpinLock::new(RUsage::default()),
                 children_rusage: SpinLock::new(RUsage::default()),
                 robust_list: RwLock::new(None),

--- a/user/apps/tests/dunitest/suites/normal/proc_self_exec_cmdline.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_self_exec_cmdline.cc
@@ -18,6 +18,8 @@ namespace {
 constexpr char kExecExit42[] = "--proc-self-exec-cmdline-exit42";
 constexpr char kLeaderExec[] = "--proc-self-exec-cmdline-leader";
 constexpr char kSiblingExec[] = "--proc-self-exec-cmdline-sibling";
+constexpr char kSessionSiblingExec[] = "--proc-self-exec-session-sibling";
+constexpr char kSessionCheck[] = "--proc-self-exec-session-check";
 
 bool read_all(int fd, std::string* out) {
     out->clear();
@@ -102,6 +104,15 @@ void* sibling_exec_thread(void*) {
     return nullptr;
 }
 
+void* session_sibling_exec_thread(void*) {
+    char arg0[] = "/proc/self/exe";
+    char arg1[] = "--proc-self-exec-session-check";
+    char* const argv[] = {arg0, arg1, nullptr};
+    char* const envp[] = {nullptr};
+    execve("/proc/self/exe", argv, envp);
+    _exit(errno);
+}
+
 void run_sibling_exec_helper() {
     pthread_t thread;
     if (pthread_create(&thread, nullptr, sibling_exec_thread, nullptr) != 0) {
@@ -111,6 +122,33 @@ void run_sibling_exec_helper() {
     for (;;) {
         pause();
     }
+}
+
+void run_session_sibling_exec_helper() {
+    if (setsid() < 0) {
+        _exit(errno);
+    }
+
+    pthread_t thread;
+    if (pthread_create(&thread, nullptr, session_sibling_exec_thread, nullptr) != 0) {
+        _exit(1);
+    }
+
+    for (;;) {
+        pause();
+    }
+}
+
+int validate_session_leader_after_exec() {
+    if (getsid(0) != getpid()) {
+        return 1;
+    }
+
+    errno = 0;
+    if (setsid() != -1 || errno != EPERM) {
+        return 2;
+    }
+    return 43;
 }
 
 void expect_helper_exits_42(const char* mode) {
@@ -142,6 +180,25 @@ TEST(ProcSelfExecCmdline, SiblingThreadExecKeepsProcSelfCmdlineCurrent) {
     expect_helper_exits_42(kSiblingExec);
 }
 
+TEST(ProcSelfExecCmdline, SiblingThreadExecPreservesSessionLeadership) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (child == 0) {
+        char arg0[] = "/proc/self/exe";
+        char* const argv[] = {arg0, const_cast<char*>(kSessionSiblingExec), nullptr};
+        char* const envp[] = {nullptr};
+        execve("/proc/self/exe", argv, envp);
+        _exit(errno);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0))
+        << "waitpid failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
+    EXPECT_EQ(43, WEXITSTATUS(status));
+}
+
 int main(int argc, char** argv) {
     if (argc >= 2 && strcmp(argv[1], kExecExit42) == 0) {
         return validate_cmdline_and_exit42(argc, argv);
@@ -153,6 +210,13 @@ int main(int argc, char** argv) {
     if (argc >= 2 && strcmp(argv[1], kSiblingExec) == 0) {
         run_sibling_exec_helper();
         return 1;
+    }
+    if (argc >= 2 && strcmp(argv[1], kSessionSiblingExec) == 0) {
+        run_session_sibling_exec_helper();
+        return 1;
+    }
+    if (argc >= 2 && strcmp(argv[1], kSessionCheck) == 0) {
+        return validate_session_leader_after_exec();
     }
 
     ::testing::InitGoogleTest(&argc, argv);

--- a/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
@@ -233,6 +233,96 @@ TEST(ProcessSignalFork, ProcessGroupSignalIsDeliveredOncePerThreadGroup) {
     EXPECT_EQ(0, WEXITSTATUS(status));
 }
 
+TEST(ProcessSignalFork, ThreadCreationPreservesInheritedGroupAndSingleDelivery) {
+    int helper_ready[2] = {-1, -1};
+    int child_gate[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(helper_ready)) << "pipe failed: " << strerror(errno);
+    ASSERT_EQ(0, pipe(child_gate)) << "pipe failed: " << strerror(errno);
+
+    pid_t helper = fork();
+    ASSERT_GE(helper, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+    if (helper == 0) {
+        if (setpgid(0, 0) != 0) {
+            _exit(127);
+        }
+        sigset_t blocked;
+        sigemptyset(&blocked);
+        sigaddset(&blocked, SIGRTMIN);
+        if (sigprocmask(SIG_BLOCK, &blocked, nullptr) != 0) {
+            _exit(128);
+        }
+        WriteByteOrExit(helper_ready[1], 'R');
+        for (;;) {
+            pause();
+        }
+    }
+    ASSERT_TRUE(ReadByte(helper_ready[0])) << "helper did not become ready";
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+    if (child == 0) {
+        if (!ReadByte(child_gate[0])) {
+            _exit(129);
+        }
+        const pid_t process_group = getpgrp();
+        const pid_t session = getsid(0);
+        if (process_group != helper || session < 0) {
+            _exit(130);
+        }
+
+        const int signal = SIGRTMIN;
+        sigset_t blocked;
+        sigemptyset(&blocked);
+        sigaddset(&blocked, signal);
+        if (sigprocmask(SIG_BLOCK, &blocked, nullptr) != 0) {
+            _exit(131);
+        }
+
+        int ready_pipe[2] = {-1, -1};
+        if (pipe(ready_pipe) != 0) {
+            _exit(132);
+        }
+        pthread_t thread {};
+        if (pthread_create(&thread, nullptr, ReadyPauseThread, &ready_pipe[1]) != 0
+            || !ReadByte(ready_pipe[0])) {
+            _exit(133);
+        }
+
+        if (getpgrp() != process_group) {
+            _exit(134);
+        }
+        if (getsid(0) != session) {
+            _exit(135);
+        }
+        if (kill(0, signal) != 0) {
+            _exit(136);
+        }
+
+        timespec timeout {};
+        timeout.tv_nsec = 10 * 1000 * 1000;
+        if (sigtimedwait(&blocked, nullptr, &timeout) != signal) {
+            _exit(137);
+        }
+        errno = 0;
+        if (sigtimedwait(&blocked, nullptr, &timeout) != -1 || errno != EAGAIN) {
+            _exit(138);
+        }
+        _exit(0);
+    }
+
+    ASSERT_EQ(0, setpgid(child, helper))
+        << "setpgid failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_EQ(1, write(child_gate[1], "G", 1));
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_EQ(0, kill(helper, SIGKILL));
+    int helper_status = 0;
+    ASSERT_EQ(helper, waitpid(helper, &helper_status, 0));
+    ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
 TEST(ProcessSignalFork, ProcessDirectedSigkillKillsMultithreadedChild) {
     int ready_pipe[2] = {-1, -1};
     ASSERT_EQ(0, pipe(ready_pipe)) << "pipe failed: " << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
@@ -19,6 +19,10 @@ TEST(ProcessSignalFork, PosixForkAndJobControlUnavailableOnWindows) {
 #include <time.h>
 #include <unistd.h>
 
+#ifndef PTRACE_TRACEME
+#define PTRACE_TRACEME 0
+#endif
+
 namespace {
 
 void SleepForMillis(long millis) {
@@ -356,6 +360,44 @@ TEST(ProcessSignalFork, SigchldInfoUsesGroupLeaderWhenLastNonleaderExits) {
     child_guard.Release();
     ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
     EXPECT_EQ(0, WEXITSTATUS(status));
+}
+
+TEST(ProcessSignalFork, PtraceExitSignalCarriesChildSiginfo) {
+    const uid_t expected_uid = getuid();
+    sigset_t blocked;
+    sigemptyset(&blocked);
+    sigaddset(&blocked, SIGCHLD);
+    SignalMaskGuard mask_guard(blocked);
+    ASSERT_TRUE(mask_guard.valid()) << "sigprocmask failed: errno=" << errno << " ("
+                                    << strerror(errno) << ")";
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+    if (child == 0) {
+        if (syscall(SYS_ptrace, PTRACE_TRACEME, 0, 0, 0) != 0) {
+            _exit(120);
+        }
+        _exit(47);
+    }
+    ChildProcessGuard child_guard(child);
+
+    siginfo_t info {};
+    timespec timeout {};
+    timeout.tv_sec = 5;
+    ASSERT_EQ(SIGCHLD, sigtimedwait(&blocked, &info, &timeout))
+        << "sigtimedwait failed: errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_EQ(child, info.si_pid);
+    EXPECT_EQ(expected_uid, info.si_uid);
+    EXPECT_EQ(CLD_EXITED, info.si_code);
+    EXPECT_EQ(47, info.si_status);
+    EXPECT_GE(info.si_utime, 0);
+    EXPECT_GE(info.si_stime, 0);
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    child_guard.Release();
+    ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
+    EXPECT_EQ(47, WEXITSTATUS(status));
 }
 
 TEST(ProcessSignalFork, StopContinueRaceDoesNotLeaveChildStuck) {

--- a/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
@@ -66,6 +66,29 @@ bool ReadInt(int fd, int* value) {
     return n == static_cast<ssize_t>(sizeof(*value));
 }
 
+void KillAndReap(pid_t child) {
+    if (child <= 0) {
+        return;
+    }
+    kill(child, SIGKILL);
+    while (waitpid(child, nullptr, 0) < 0 && errno == EINTR) {
+    }
+}
+
+class ChildProcessGuard {
+public:
+    explicit ChildProcessGuard(pid_t child) : child_(child) {}
+    ChildProcessGuard(const ChildProcessGuard&) = delete;
+    ChildProcessGuard& operator=(const ChildProcessGuard&) = delete;
+
+    ~ChildProcessGuard() { KillAndReap(child_); }
+
+    void Release() { child_ = -1; }
+
+private:
+    pid_t child_;
+};
+
 void* PauseForeverThread(void*) {
     for (;;) {
         pause();
@@ -256,6 +279,7 @@ TEST(ProcessSignalFork, ThreadCreationPreservesInheritedGroupAndSingleDelivery) 
             pause();
         }
     }
+    ChildProcessGuard helper_guard(helper);
     ASSERT_TRUE(ReadByte(helper_ready[0])) << "helper did not become ready";
 
     pid_t child = fork();
@@ -309,6 +333,7 @@ TEST(ProcessSignalFork, ThreadCreationPreservesInheritedGroupAndSingleDelivery) 
         }
         _exit(0);
     }
+    ChildProcessGuard child_guard(child);
 
     ASSERT_EQ(0, setpgid(child, helper))
         << "setpgid failed: errno=" << errno << " (" << strerror(errno) << ")";
@@ -316,9 +341,11 @@ TEST(ProcessSignalFork, ThreadCreationPreservesInheritedGroupAndSingleDelivery) 
 
     int status = 0;
     ASSERT_EQ(child, waitpid(child, &status, 0));
+    child_guard.Release();
     ASSERT_EQ(0, kill(helper, SIGKILL));
     int helper_status = 0;
     ASSERT_EQ(helper, waitpid(helper, &helper_status, 0));
+    helper_guard.Release();
     ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
     EXPECT_EQ(0, WEXITSTATUS(status));
 }

--- a/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
@@ -12,7 +12,9 @@ TEST(ProcessSignalFork, PosixForkAndJobControlUnavailableOnWindows) {
 #include <pthread.h>
 #include <sched.h>
 #include <signal.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
@@ -89,6 +91,90 @@ private:
     pid_t child_;
 };
 
+class SignalMaskGuard {
+public:
+    explicit SignalMaskGuard(const sigset_t& blocked) : valid_(false) {
+        valid_ = sigprocmask(SIG_BLOCK, &blocked, &old_mask_) == 0;
+    }
+    SignalMaskGuard(const SignalMaskGuard&) = delete;
+    SignalMaskGuard& operator=(const SignalMaskGuard&) = delete;
+
+    ~SignalMaskGuard() {
+        if (valid_) {
+            sigprocmask(SIG_SETMASK, &old_mask_, nullptr);
+        }
+    }
+
+    bool valid() const { return valid_; }
+
+private:
+    sigset_t old_mask_ {};
+    bool valid_;
+};
+
+struct LastThreadExitArgs {
+    int ready_fd;
+    pid_t leader_tid;
+};
+
+bool PinCurrentTaskToOneAllowedCpu() {
+    cpu_set_t available;
+    CPU_ZERO(&available);
+    if (sched_getaffinity(0, sizeof(available), &available) != 0) {
+        return false;
+    }
+
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (!CPU_ISSET(cpu, &available)) {
+            continue;
+        }
+        cpu_set_t target;
+        CPU_ZERO(&target);
+        CPU_SET(cpu, &target);
+        return sched_setaffinity(0, sizeof(target), &target) == 0;
+    }
+    errno = EINVAL;
+    return false;
+}
+
+char ReadProcTaskState(pid_t tgid, pid_t tid) {
+    char path[128] {};
+    snprintf(path, sizeof(path), "/proc/%d/task/%d/stat", tgid, tid);
+    FILE* stat_file = fopen(path, "r");
+    if (stat_file == nullptr) {
+        return '\0';
+    }
+
+    char line[1024] {};
+    char state = '\0';
+    if (fgets(line, sizeof(line), stat_file) != nullptr) {
+        char* comm_end = strrchr(line, ')');
+        if (comm_end != nullptr && comm_end[1] == ' ') {
+            state = comm_end[2];
+        }
+    }
+    fclose(stat_file);
+    return state;
+}
+
+void* ExitAfterLeaderThread(void* raw_args) {
+    auto* args = static_cast<LastThreadExitArgs*>(raw_args);
+    const int ready_fd = args->ready_fd;
+    const pid_t leader_tid = args->leader_tid;
+    WriteIntOrExit(ready_fd, static_cast<int>(syscall(SYS_gettid)));
+
+    for (int i = 0; i < 5000; ++i) {
+        if (ReadProcTaskState(leader_tid, leader_tid) == 'Z') {
+            if (getuid() == 0 && syscall(SYS_setuid, 1234) != 0) {
+                _exit(124);
+            }
+            return nullptr;
+        }
+        SleepForMillis(1);
+    }
+    _exit(123);
+}
+
 void* PauseForeverThread(void*) {
     for (;;) {
         pause();
@@ -120,6 +206,60 @@ void RunMultithreadedSignalChild(int ready_fd) {
 }
 
 }  // namespace
+
+TEST(ProcessSignalFork, SigchldInfoUsesGroupLeaderWhenLastNonleaderExits) {
+    const uid_t leader_uid = getuid();
+    sigset_t blocked;
+    sigemptyset(&blocked);
+    sigaddset(&blocked, SIGCHLD);
+    SignalMaskGuard mask_guard(blocked);
+    ASSERT_TRUE(mask_guard.valid()) << "sigprocmask failed: errno=" << errno << " ("
+                                    << strerror(errno) << ")";
+
+    int ready_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(ready_pipe)) << "pipe failed: " << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+    if (child == 0) {
+        close(ready_pipe[0]);
+        if (!PinCurrentTaskToOneAllowedCpu()) {
+            _exit(120);
+        }
+        LastThreadExitArgs args {ready_pipe[1], getpid()};
+        pthread_t worker {};
+        if (pthread_create(&worker, nullptr, ExitAfterLeaderThread, &args) != 0) {
+            _exit(121);
+        }
+        syscall(SYS_exit, 0);
+        _exit(122);
+    }
+    ChildProcessGuard child_guard(child);
+
+    close(ready_pipe[1]);
+    int worker_tid = -1;
+    ASSERT_TRUE(ReadInt(ready_pipe[0], &worker_tid)) << "worker did not report its tid";
+    close(ready_pipe[0]);
+    ASSERT_GT(worker_tid, 0);
+    ASSERT_NE(worker_tid, child);
+
+    siginfo_t info {};
+    timespec timeout {};
+    timeout.tv_sec = 5;
+    ASSERT_EQ(SIGCHLD, sigtimedwait(&blocked, &info, &timeout))
+        << "sigtimedwait failed: errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_EQ(child, info.si_pid);
+    EXPECT_NE(worker_tid, info.si_pid);
+    EXPECT_EQ(leader_uid, info.si_uid);
+    EXPECT_EQ(CLD_EXITED, info.si_code);
+    EXPECT_EQ(0, info.si_status);
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    child_guard.Release();
+    ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
+}
 
 TEST(ProcessSignalFork, StopContinueRaceDoesNotLeaveChildStuck) {
     pid_t child = fork();

--- a/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
@@ -112,6 +112,45 @@ private:
     bool valid_;
 };
 
+class SignalActionGuard {
+public:
+    SignalActionGuard(int signal, const struct sigaction& action) : signal_(signal), valid_(false) {
+        valid_ = sigaction(signal_, &action, &old_action_) == 0;
+    }
+    SignalActionGuard(const SignalActionGuard&) = delete;
+    SignalActionGuard& operator=(const SignalActionGuard&) = delete;
+
+    ~SignalActionGuard() {
+        if (valid_) {
+            sigaction(signal_, &old_action_, nullptr);
+        }
+    }
+
+    bool valid() const { return valid_; }
+
+private:
+    struct sigaction old_action_ {};
+    int signal_;
+    bool valid_;
+};
+
+volatile sig_atomic_t sigchld_expected_pid = -1;
+volatile sig_atomic_t sigchld_wait_result = -2;
+volatile sig_atomic_t sigchld_wait_errno = 0;
+volatile sig_atomic_t sigchld_wait_status = 0;
+volatile sig_atomic_t sigchld_handler_calls = 0;
+
+void ReapExpectedChildFromSigchld(int) {
+    const int saved_errno = errno;
+    int status = 0;
+    const pid_t result = waitpid(static_cast<pid_t>(sigchld_expected_pid), &status, WNOHANG);
+    sigchld_wait_result = static_cast<sig_atomic_t>(result);
+    sigchld_wait_errno = result < 0 ? errno : 0;
+    sigchld_wait_status = status;
+    ++sigchld_handler_calls;
+    errno = saved_errno;
+}
+
 struct LastThreadExitArgs {
     int ready_fd;
     pid_t leader_tid;
@@ -206,6 +245,64 @@ void RunMultithreadedSignalChild(int ready_fd) {
 }
 
 }  // namespace
+
+TEST(ProcessSignalFork, SigchldHandlerCanImmediatelyReapExitedChild) {
+    struct sigaction action {};
+    action.sa_handler = ReapExpectedChildFromSigchld;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_RESTART;
+    SignalActionGuard action_guard(SIGCHLD, action);
+    ASSERT_TRUE(action_guard.valid()) << "sigaction failed: errno=" << errno << " ("
+                                     << strerror(errno) << ")";
+
+    int gate[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(gate)) << "pipe failed: " << strerror(errno);
+
+    const pid_t child = fork();
+    if (child < 0) {
+        const int fork_errno = errno;
+        close(gate[0]);
+        close(gate[1]);
+        FAIL() << "fork failed: errno=" << fork_errno << " (" << strerror(fork_errno) << ")";
+        return;
+    }
+    if (child == 0) {
+        close(gate[1]);
+        char value = 0;
+        if (read(gate[0], &value, sizeof(value)) != static_cast<ssize_t>(sizeof(value))) {
+            _exit(120);
+        }
+        _exit(42);
+    }
+    ChildProcessGuard child_guard(child);
+
+    close(gate[0]);
+    sigchld_expected_pid = child;
+    sigchld_wait_result = -2;
+    sigchld_wait_errno = 0;
+    sigchld_wait_status = 0;
+    sigchld_handler_calls = 0;
+    const char gate_value = 'X';
+    const ssize_t gate_write = write(gate[1], &gate_value, sizeof(gate_value));
+    const int gate_errno = errno;
+    close(gate[1]);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(gate_value)), gate_write)
+        << "write(gate) failed: errno=" << gate_errno << " (" << strerror(gate_errno) << ")";
+
+    for (int i = 0; i < 500 && sigchld_handler_calls == 0; ++i) {
+        SleepForMillis(1);
+    }
+
+    ASSERT_GT(sigchld_handler_calls, 0) << "SIGCHLD handler was not invoked";
+    EXPECT_EQ(child, static_cast<pid_t>(sigchld_wait_result))
+        << "waitpid(WNOHANG) in SIGCHLD handler did not observe the published exit; errno="
+        << sigchld_wait_errno;
+    if (sigchld_wait_result == child) {
+        child_guard.Release();
+        ASSERT_TRUE(WIFEXITED(sigchld_wait_status)) << "child status=" << sigchld_wait_status;
+        EXPECT_EQ(42, WEXITSTATUS(sigchld_wait_status));
+    }
+}
 
 TEST(ProcessSignalFork, SigchldInfoUsesGroupLeaderWhenLastNonleaderExits) {
     const uid_t leader_uid = getuid();

--- a/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
+++ b/user/apps/tests/dunitest/suites/normal/process_signal_fork.cc
@@ -73,6 +73,15 @@ void* PauseForeverThread(void*) {
     return nullptr;
 }
 
+void* ReadyPauseThread(void* arg) {
+    int ready_fd = *static_cast<int*>(arg);
+    WriteByteOrExit(ready_fd, 'R');
+    for (;;) {
+        pause();
+    }
+    return nullptr;
+}
+
 void RunMultithreadedSignalChild(int ready_fd) {
     pthread_t threads[3] {};
     for (pthread_t& thread : threads) {
@@ -173,6 +182,55 @@ TEST(ProcessSignalFork, ProcessDirectedSigkillKillsStoppedChildWithPendingStopEv
 
     ASSERT_TRUE(WIFSIGNALED(status)) << "child status=" << status;
     EXPECT_EQ(SIGKILL, WTERMSIG(status));
+}
+
+TEST(ProcessSignalFork, ProcessGroupSignalIsDeliveredOncePerThreadGroup) {
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    if (child == 0) {
+        if (setsid() < 0) {
+            _exit(120);
+        }
+
+        const int signal = SIGRTMIN;
+        sigset_t blocked;
+        sigemptyset(&blocked);
+        sigaddset(&blocked, signal);
+        if (sigprocmask(SIG_BLOCK, &blocked, nullptr) != 0) {
+            _exit(121);
+        }
+
+        int ready_pipe[2] = {-1, -1};
+        if (pipe(ready_pipe) != 0) {
+            _exit(122);
+        }
+        pthread_t thread {};
+        if (pthread_create(&thread, nullptr, ReadyPauseThread, &ready_pipe[1]) != 0
+            || !ReadByte(ready_pipe[0])) {
+            _exit(123);
+        }
+
+        if (kill(0, signal) != 0) {
+            _exit(124);
+        }
+
+        timespec timeout {};
+        timeout.tv_nsec = 10 * 1000 * 1000;
+        if (sigtimedwait(&blocked, nullptr, &timeout) != signal) {
+            _exit(125);
+        }
+        errno = 0;
+        if (sigtimedwait(&blocked, nullptr, &timeout) != -1 || errno != EAGAIN) {
+            _exit(126);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
+    EXPECT_EQ(0, WEXITSTATUS(status));
 }
 
 TEST(ProcessSignalFork, ProcessDirectedSigkillKillsMultithreadedChild) {

--- a/user/apps/tests/dunitest/suites/normal/spawn_exec_pipe_race.cc
+++ b/user/apps/tests/dunitest/suites/normal/spawn_exec_pipe_race.cc
@@ -15,6 +15,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -155,6 +156,7 @@ void* SiblingExecThread(void*) {
 
 struct FatalExecArgs {
   int tid_fd;
+  int release_fd;
 };
 
 void* FatalSiblingExecThread(void* opaque) {
@@ -163,7 +165,17 @@ void* FatalSiblingExecThread(void* opaque) {
   if (write(args->tid_fd, &tid, sizeof(tid)) != sizeof(tid)) {
     _exit(5);
   }
-  return SiblingExecThread(nullptr);
+
+  char ready_fd[16];
+  char release_fd[16];
+  snprintf(ready_fd, sizeof(ready_fd), "%d", args->tid_fd);
+  snprintf(release_fd, sizeof(release_fd), "%d", args->release_fd);
+  char arg0[] = "/proc/self/exe";
+  char* const argv[] = {arg0, const_cast<char*>(kExecBlockMode), ready_fd,
+                        release_fd, nullptr};
+  char* const envp[] = {nullptr};
+  execve("/proc/self/exe", argv, envp);
+  _exit(errno);
 }
 
 struct BlockingExecArgs {
@@ -434,15 +446,24 @@ TEST(SpawnExecPipeRace, FatalSignalDuringSiblingExecKeepsWaitOwnership) {
   for (int i = 0; i < kFatalIterations; ++i) {
     ChildCleanup cleanup;
     int tid_pipe[2] = {-1, -1};
+    int release_pipe[2] = {-1, -1};
     ASSERT_EQ(0, pipe(tid_pipe)) << "iter=" << i << ": " << strerror(errno);
     cleanup.ready_read = tid_pipe[0];
     cleanup.ready_write = tid_pipe[1];
+    ASSERT_EQ(0, pipe(release_pipe))
+        << "iter=" << i << ": " << strerror(errno);
+    cleanup.release_read = release_pipe[0];
+    cleanup.release_write = release_pipe[1];
 
     pid_t child = fork();
     ASSERT_GE(child, 0) << "iter=" << i << ": " << strerror(errno);
     if (child == 0) {
       close(tid_pipe[0]);
-      FatalExecArgs args = {.tid_fd = tid_pipe[1]};
+      close(release_pipe[1]);
+      FatalExecArgs args = {
+          .tid_fd = tid_pipe[1],
+          .release_fd = release_pipe[0],
+      };
       pthread_t thread;
       if (pthread_create(&thread, nullptr, FatalSiblingExecThread, &args) != 0) {
         _exit(6);
@@ -455,6 +476,8 @@ TEST(SpawnExecPipeRace, FatalSignalDuringSiblingExecKeepsWaitOwnership) {
 
     close(tid_pipe[1]);
     cleanup.ready_write = -1;
+    close(release_pipe[0]);
+    cleanup.release_read = -1;
     pid_t exec_tid = -1;
     ASSERT_EQ(static_cast<ssize_t>(sizeof(exec_tid)),
               read(tid_pipe[0], &exec_tid, sizeof(exec_tid)))
@@ -471,17 +494,60 @@ TEST(SpawnExecPipeRace, FatalSignalDuringSiblingExecKeepsWaitOwnership) {
     errno = 0;
     int kill_result = static_cast<int>(
         syscall(SYS_tgkill, child, exec_tid, SIGKILL));
-    ASSERT_TRUE(kill_result == 0 || errno == ESRCH)
-        << "iter=" << i << ": " << strerror(errno);
+    const int kill_errno = errno;
+    ASSERT_TRUE(kill_result == 0 ||
+                (kill_result == -1 && kill_errno == ESRCH))
+        << "iter=" << i << ": " << strerror(kill_errno);
+
+    bool target_retired = kill_result == -1;
+    if (target_retired) {
+      close(release_pipe[1]);
+      cleanup.release_write = -1;
+    }
 
     int status = 0;
-    ASSERT_TRUE(WaitForChildExit(child, &status, 5000))
+    bool child_exited = false;
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(5000);
+    while (std::chrono::steady_clock::now() < deadline) {
+      pid_t waited = waitpid(child, &status, WNOHANG);
+      if (waited == -1 && errno == EINTR) {
+        continue;
+      }
+      ASSERT_TRUE(waited == 0 || waited == child)
+          << "iter=" << i << ": " << strerror(errno);
+      if (waited == child) {
+        child_exited = true;
+        break;
+      }
+
+      if (!target_retired) {
+        errno = 0;
+        int probe_result = static_cast<int>(
+            syscall(SYS_tgkill, child, exec_tid, 0));
+        const int probe_errno = errno;
+        ASSERT_TRUE(probe_result == 0 ||
+                    (probe_result == -1 && probe_errno == ESRCH))
+            << "iter=" << i << ": " << strerror(probe_errno);
+        if (probe_result == -1) {
+          target_retired = true;
+          close(release_pipe[1]);
+          cleanup.release_write = -1;
+        }
+      }
+      SleepForMillis(10);
+    }
+
+    ASSERT_TRUE(child_exited)
         << "fatal sibling exec was not waitable at iter=" << i;
     cleanup.child = -1;
-    ASSERT_TRUE(WIFSIGNALED(status) ||
-                (WIFEXITED(status) &&
-                 (WEXITSTATUS(status) == 0 || WEXITSTATUS(status) == EAGAIN)))
-        << "unexpected child status=" << status << " at iter=" << i;
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL) {
+      continue;
+    }
+    ASSERT_TRUE(target_retired && WIFEXITED(status) &&
+                WEXITSTATUS(status) == 3)
+        << "thread-targeted SIGKILL was lost: child status=" << status
+        << " at iter=" << i;
   }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/spawn_exec_pipe_race.cc
+++ b/user/apps/tests/dunitest/suites/normal/spawn_exec_pipe_race.cc
@@ -4,10 +4,13 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <pthread.h>
+#include <sched.h>
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
@@ -21,7 +24,21 @@ namespace {
 
 constexpr char kSiblingExecMode[] = "--spawn-exec-pipe-race-sibling-exec";
 constexpr char kExecExitMode[] = "--spawn-exec-pipe-race-exec-exit";
+constexpr char kExecBlockMode[] = "--spawn-exec-pipe-race-exec-block";
 constexpr int kIterations = 512;
+constexpr int kFatalIterations = 128;
+
+#ifndef P_PIDFD
+#define P_PIDFD 3
+#endif
+
+#ifndef SYS_pidfd_open
+#ifdef __NR_pidfd_open
+#define SYS_pidfd_open __NR_pidfd_open
+#else
+#define SYS_pidfd_open 434
+#endif
+#endif
 
 void SleepForMillis(long millis) {
   timespec ts {};
@@ -105,10 +122,65 @@ bool WaitForChildExit(pid_t child, int* status, int timeout_ms) {
   return false;
 }
 
+struct ChildCleanup {
+  pid_t child = -1;
+  int ready_read = -1;
+  int ready_write = -1;
+  int release_read = -1;
+  int release_write = -1;
+  int pidfd = -1;
+
+  ~ChildCleanup() {
+    CloseIfOpen(&ready_read);
+    CloseIfOpen(&ready_write);
+    CloseIfOpen(&release_read);
+    CloseIfOpen(&release_write);
+    CloseIfOpen(&pidfd);
+    if (child > 0) {
+      kill(child, SIGKILL);
+      while (waitpid(child, nullptr, 0) < 0 && errno == EINTR) {
+      }
+    }
+  }
+};
+
 void* SiblingExecThread(void*) {
   char arg0[] = "/proc/self/exe";
   char arg1[] = "--spawn-exec-pipe-race-exec-exit";
   char* const argv[] = {arg0, arg1, nullptr};
+  char* const envp[] = {nullptr};
+  execve("/proc/self/exe", argv, envp);
+  _exit(errno);
+}
+
+struct FatalExecArgs {
+  int tid_fd;
+};
+
+void* FatalSiblingExecThread(void* opaque) {
+  auto* args = static_cast<FatalExecArgs*>(opaque);
+  pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+  if (write(args->tid_fd, &tid, sizeof(tid)) != sizeof(tid)) {
+    _exit(5);
+  }
+  return SiblingExecThread(nullptr);
+}
+
+struct BlockingExecArgs {
+  int ready_fd;
+  int release_fd;
+};
+
+void* BlockingSiblingExecThread(void* opaque) {
+  auto* args = static_cast<BlockingExecArgs*>(opaque);
+  char ready_fd[16];
+  char release_fd[16];
+  snprintf(ready_fd, sizeof(ready_fd), "%d", args->ready_fd);
+  snprintf(release_fd, sizeof(release_fd), "%d", args->release_fd);
+
+  char arg0[] = "/proc/self/exe";
+  char* const argv[] = {arg0, const_cast<char*>(kExecBlockMode), ready_fd,
+                        release_fd, nullptr};
   char* const envp[] = {nullptr};
   execve("/proc/self/exe", argv, envp);
   _exit(errno);
@@ -123,6 +195,32 @@ void RunSiblingExecHelper() {
   for (;;) {
     pause();
   }
+}
+
+void RunBlockingSiblingExecHelper(int ready_fd, int release_fd) {
+  BlockingExecArgs args = {.ready_fd = ready_fd, .release_fd = release_fd};
+  pthread_t thread;
+  if (pthread_create(&thread, nullptr, BlockingSiblingExecThread, &args) != 0) {
+    _exit(1);
+  }
+
+  for (;;) {
+    pause();
+  }
+}
+
+void RunBlockedExecImage(int ready_fd, int release_fd) {
+  char ready = 'R';
+  if (write(ready_fd, &ready, sizeof(ready)) != sizeof(ready)) {
+    _exit(2);
+  }
+
+  char release = 0;
+  ssize_t n;
+  do {
+    n = read(release_fd, &release, sizeof(release));
+  } while (n < 0 && errno == EINTR);
+  _exit(n == sizeof(release) ? 0 : 3);
 }
 
 void TriggerSiblingExecOnce() {
@@ -266,12 +364,137 @@ TEST(SpawnExecPipeRace, GtestHelpSpawnAfterSiblingExecStress) {
   }
 }
 
+TEST(SpawnExecPipeRace, NonLeaderExecKeepsOriginalPidAndPidfdAlive) {
+  ChildCleanup cleanup;
+  int ready_pipe[2] = {-1, -1};
+  int release_pipe[2] = {-1, -1};
+  ASSERT_EQ(0, pipe(ready_pipe)) << strerror(errno);
+  cleanup.ready_read = ready_pipe[0];
+  cleanup.ready_write = ready_pipe[1];
+  ASSERT_EQ(0, pipe(release_pipe)) << strerror(errno);
+  cleanup.release_read = release_pipe[0];
+  cleanup.release_write = release_pipe[1];
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    close(release_pipe[1]);
+    RunBlockingSiblingExecHelper(ready_pipe[1], release_pipe[0]);
+    _exit(4);
+  }
+  cleanup.child = child;
+
+  close(ready_pipe[1]);
+  cleanup.ready_write = -1;
+  close(release_pipe[0]);
+  cleanup.release_read = -1;
+  int pidfd = static_cast<int>(syscall(SYS_pidfd_open, child, 0));
+  ASSERT_GE(pidfd, 0) << strerror(errno);
+  cleanup.pidfd = pidfd;
+
+  pollfd ready_poll = {.fd = ready_pipe[0], .events = POLLIN, .revents = 0};
+  ASSERT_EQ(1, poll(&ready_poll, 1, 5000)) << "exec image did not become ready";
+  char ready = 0;
+  ASSERT_EQ(1, read(ready_pipe[0], &ready, sizeof(ready)));
+  ASSERT_EQ('R', ready);
+
+  int status = 0;
+  EXPECT_EQ(0, waitpid(child, &status, WNOHANG));
+
+  pollfd pidfd_poll = {.fd = pidfd, .events = POLLIN, .revents = 0};
+  EXPECT_EQ(0, poll(&pidfd_poll, 1, 0));
+
+  siginfo_t info {};
+  ASSERT_EQ(0, syscall(SYS_waitid, P_PIDFD, pidfd, &info,
+                       WEXITED | WNOHANG, nullptr))
+      << strerror(errno);
+  EXPECT_EQ(0, info.si_pid);
+
+  char release = 'X';
+  ASSERT_EQ(1, write(release_pipe[1], &release, sizeof(release)));
+  ASSERT_TRUE(WaitForChildExit(child, &status, 5000));
+  cleanup.child = -1;
+  ASSERT_TRUE(WIFEXITED(status));
+  ASSERT_EQ(0, WEXITSTATUS(status));
+
+  pidfd_poll.revents = 0;
+  EXPECT_EQ(1, poll(&pidfd_poll, 1, 1000));
+  EXPECT_NE(0, pidfd_poll.revents & POLLIN);
+
+  close(pidfd);
+  cleanup.pidfd = -1;
+  close(ready_pipe[0]);
+  cleanup.ready_read = -1;
+  close(release_pipe[1]);
+  cleanup.release_write = -1;
+}
+
+TEST(SpawnExecPipeRace, FatalSignalDuringSiblingExecKeepsWaitOwnership) {
+  for (int i = 0; i < kFatalIterations; ++i) {
+    ChildCleanup cleanup;
+    int tid_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(tid_pipe)) << "iter=" << i << ": " << strerror(errno);
+    cleanup.ready_read = tid_pipe[0];
+    cleanup.ready_write = tid_pipe[1];
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "iter=" << i << ": " << strerror(errno);
+    if (child == 0) {
+      close(tid_pipe[0]);
+      FatalExecArgs args = {.tid_fd = tid_pipe[1]};
+      pthread_t thread;
+      if (pthread_create(&thread, nullptr, FatalSiblingExecThread, &args) != 0) {
+        _exit(6);
+      }
+      for (;;) {
+        pause();
+      }
+    }
+    cleanup.child = child;
+
+    close(tid_pipe[1]);
+    cleanup.ready_write = -1;
+    pid_t exec_tid = -1;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(exec_tid)),
+              read(tid_pipe[0], &exec_tid, sizeof(exec_tid)))
+        << "iter=" << i << ": " << strerror(errno);
+    ASSERT_GT(exec_tid, 0) << "iter=" << i;
+
+    if ((i & 1) != 0) {
+      sched_yield();
+    }
+    if ((i & 3) == 3) {
+      SleepForMillis(1);
+    }
+
+    errno = 0;
+    int kill_result = static_cast<int>(
+        syscall(SYS_tgkill, child, exec_tid, SIGKILL));
+    ASSERT_TRUE(kill_result == 0 || errno == ESRCH)
+        << "iter=" << i << ": " << strerror(errno);
+
+    int status = 0;
+    ASSERT_TRUE(WaitForChildExit(child, &status, 5000))
+        << "fatal sibling exec was not waitable at iter=" << i;
+    cleanup.child = -1;
+    ASSERT_TRUE(WIFSIGNALED(status) ||
+                (WIFEXITED(status) &&
+                 (WEXITSTATUS(status) == 0 || WEXITSTATUS(status) == EAGAIN)))
+        << "unexpected child status=" << status << " at iter=" << i;
+  }
+}
+
 int main(int argc, char** argv) {
   if (argc >= 2 && strcmp(argv[1], kExecExitMode) == 0) {
     return 0;
   }
   if (argc >= 2 && strcmp(argv[1], kSiblingExecMode) == 0) {
     RunSiblingExecHelper();
+    return 1;
+  }
+  if (argc >= 4 && strcmp(argv[1], kExecBlockMode) == 0) {
+    RunBlockedExecImage(atoi(argv[2]), atoi(argv[3]));
     return 1;
   }
 

--- a/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_pty_hangup.cc
@@ -633,6 +633,65 @@ TEST(TtyPtyHangup, SlaveCanReopenWhileMasterAliveAfterLastSlaveClose) {
     EXPECT_EQ('r', ch);
 }
 
+TEST(TtyPtyHangup, ControllingSlaveCanReopenDevTtyAfterLastFdClose) {
+    PtyPair pair = OpenRawPty();
+    ASSERT_GE(pair.master.get(), 0);
+    ASSERT_GE(pair.slave.get(), 0);
+
+    int gate[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(gate)) << strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        close(gate[1]);
+        close(pair.master.release());
+        if (setsid() < 0) {
+            _exit(1);
+        }
+        if (ioctl(pair.slave.get(), TIOCSCTTY, 0) < 0) {
+            _exit(2);
+        }
+
+        char token = 0;
+        if (read(gate[0], &token, sizeof(token)) != sizeof(token)) {
+            _exit(3);
+        }
+        close(gate[0]);
+        pair.slave.reset();
+
+        int tty_fd = open("/dev/tty", O_RDWR | O_NOCTTY);
+        if (tty_fd < 0) {
+            _exit(4);
+        }
+        pid_t foreground = tcgetpgrp(tty_fd);
+        pid_t sid = -1;
+        if (foreground != getpgrp() || ioctl(tty_fd, TIOCGSID, &sid) < 0 ||
+            sid != getsid(0)) {
+            close(tty_fd);
+            _exit(5);
+        }
+        close(tty_fd);
+        _exit(0);
+    }
+
+    close(gate[0]);
+    pair.slave.reset();
+    char token = 'R';
+    ssize_t gate_write = -1;
+    do {
+        gate_write = write(gate[1], &token, sizeof(token));
+    } while (gate_write < 0 && errno == EINTR);
+    int gate_errno = errno;
+    close(gate[1]);
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(token)), gate_write) << strerror(gate_errno);
+
+    int status = 0;
+    ASSERT_TRUE(WaitForChild(child, &status));
+    ASSERT_TRUE(WIFEXITED(status)) << "child status=" << status;
+    ASSERT_EQ(0, WEXITSTATUS(status)) << "child status=" << status;
+}
+
 TEST(TtyPtyHangup, ReopenedSlaveKeepsIndexReservedAfterMasterClose) {
     char first_name[128] = {};
     PtyPair pair = OpenRawPty(first_name);

--- a/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
+++ b/user/apps/tests/dunitest/suites/normal/wait_rusage.cc
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <new>
+#include <memory>
 #include <poll.h>
 #include <pthread.h>
 #include <sched.h>
@@ -64,6 +65,24 @@ namespace {
 
 constexpr size_t kCloneStackSize = 1024 * 1024;
 constexpr uid_t kWaitidChildUid = 1234;
+
+volatile sig_atomic_t g_ptrace_clone_exit_signal = 0;
+
+void RecordPtraceCloneExitSignal(int) { ++g_ptrace_clone_exit_signal; }
+
+int PtraceCloneExit(void*) {
+  if (syscall(SYS_ptrace, PTRACE_TRACEME, 0, 0, 0) != 0) {
+    return 2;
+  }
+  return 0;
+}
+
+struct ScopedSignalAction {
+  int signal;
+  struct sigaction old_action;
+
+  ~ScopedSignalAction() { sigaction(signal, &old_action, nullptr); }
+};
 
 bool ReadExact(int fd, void* buf, size_t len) {
   char* cursor = static_cast<char*>(buf);
@@ -882,6 +901,31 @@ TEST(WaitRusage, PtraceTracemeChildIsWaitableWithWclone) {
   errno = 0;
   EXPECT_EQ(-1, wait4(child, nullptr, WNOHANG, nullptr));
   EXPECT_EQ(ECHILD, errno);
+}
+
+TEST(WaitRusage, PtraceTracemeClonePreservesExitSignal) {
+  struct sigaction action {};
+  action.sa_handler = RecordPtraceCloneExitSignal;
+  sigemptyset(&action.sa_mask);
+  struct sigaction old_action {};
+  ASSERT_EQ(0, sigaction(SIGUSR1, &action, &old_action)) << strerror(errno);
+  ScopedSignalAction restore = {.signal = SIGUSR1, .old_action = old_action};
+  g_ptrace_clone_exit_signal = 0;
+
+  auto stack = std::make_unique<char[]>(kCloneStackSize);
+  pid_t child = clone(PtraceCloneExit, stack.get() + kCloneStackSize, SIGUSR1,
+                      nullptr);
+  ASSERT_GT(child, 0) << strerror(errno);
+
+  int status = 0;
+  pid_t waited;
+  do {
+    waited = wait4(child, &status, __WCLONE, nullptr);
+  } while (waited < 0 && errno == EINTR);
+  ASSERT_EQ(child, waited) << strerror(errno);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(0, WEXITSTATUS(status));
+  EXPECT_EQ(1, g_ptrace_clone_exit_signal);
 }
 
 TEST(WaitRusage, RepeatedPtraceTracemeFailsWithEperm) {


### PR DESCRIPTION
## Summary

- model non-leader `exec`/`de_thread` as an owned, generation-based group-exec transaction that serializes sibling teardown, old-leader exit, fatal cancellation, identity exchange, and observer visibility
- atomically preserve and transfer PID/TGID/PGID/SID membership, raw-PID lookup, cgroup placement, parent/child ownership, ptrace relations, pidfd identity, session state, and accumulated resource usage across the leader handoff
- align exit, wait, signal, and controlling-TTY behavior with Linux 6.6 semantics, including fatal thread-group signals, one process-group signal delivery per thread group, SIGCHLD/ptrace child siginfo, notification-before-wake ordering, and PTY lifetime races
- add deterministic dunitest coverage for the original spawn/exec race and the follow-up concurrency, identity, accounting, notification, process-group, ptrace, and PTY regressions

Fixes #2153

## Design and implementation

### Non-leader exec handoff

- add explicit `Pending` / `Exiting` / `Ready` old-leader phases and per-task generation tokens to the shared group-exec transaction
- wait uninterruptibly once the old leader has committed its exit, while allowing only pre-commit cancellation
- delay wait/pidfd visibility until identity teardown is complete and prevent the old leader from being autoreaped before the exec owner can exchange identities
- exchange task PID links, global raw-PID entries, cgroup membership, ptrace-side indices, process-group/session links, and exec-visible identity under a validated lock order
- move every child parent pointer and the corresponding parent `children` index in the same tasklist-like relationship transaction

### Exit, wait, signal, and accounting semantics

- track live thread-group members with an O(1) shared counter so the unique `1 -> 0` transition owns finalization work without an exit-time group scan
- preserve exited-thread CPU time, rusage, and child-resource history across ordinary exits and the non-leader exec handoff
- commit fatal group-exit state before exposing private pending `SIGKILL`, and preserve Linux process-fatal semantics for externally delivered thread-directed fatal signals
- publish natural-parent notification completion before signal delivery, coordinate autoreap through an ownership token, and wake a concurrently reparented wait owner
- report the thread-group leader's namespace-visible identity, status, and accounting in natural-parent `SIGCHLD`
- deliver ptrace exit notifications with immutable child-layout siginfo snapshots taken before `Zombie` publication, avoiding reap/unhash races

### Process groups, sessions, and TTY/PTTY lifetime

- represent PGID and SID membership once per thread group, transfer leader-owned membership during `de_thread`, and serialize fork/setpgid/setsid/exit readers against membership updates
- deliver process-group signals once per thread group instead of once per thread
- serialize controlling-TTY publication, foreground-group updates, hangup, and session removal so stale owners cannot clear or signal a replacement session
- preserve a controlling terminal across the logical last PTY slave descriptor close while the master still owns the structure
- pin the PTY master across an in-flight slave open and return Linux-compatible `EIO` if the peer is already gone

## Regression coverage

The dunitest changes cover:

- the existing 512-iteration spawn/exec pipe race
- deterministic non-leader exec PID and pidfd identity preservation
- fatal-signal versus sibling-exec stress and wait ownership
- process CPU/rusage continuity after worker exit and leader handoff
- child ownership transfer, immediate `SIGCHLD` handler reap, and reparent wake ordering
- leader-based `SIGCHLD` metadata and ptrace exit signal/siginfo behavior
- single process-group signal delivery and PGID/SID inheritance across pthread creation
- `/proc/self` exec-visible identity
- controlling-TTY reopen and PTY master/slave close/open lifetime races

## Validation

- `cargo clippy` for the kernel with all features
- `make kernel`
- kernel formatting and diff checks
- targeted DragonOS/QEMU dunitest suites for spawn/exec, wait/rusage, process/signal/fork, `/proc/self` exec identity, and TTY/PTTY hangup
- GitHub CI passes all x86_64/riscv64/loongarch64 build, format, and kernel-static checks
- GitHub Dunitest passes

## Known CI limitations

- the Integration run still contains the known stale gVisor `BasicPtyTest.OpenDevTTY` cleanup expectation: closing the PTY master correctly produces Linux-compatible `SIGHUP`; the gVisor test artifact needs the upstream test fix rather than a DragonOS kernel workaround
- the latest Integration run also exhausted two binary-wide 300-second budgets in `pipe_test` and `socket_ip_tcp_generic_loopback_test`; the immediately preceding run used the identical source tree and did not reproduce those timeouts
- `claude-review` is rejected before checkout because its trusted `pull_request_target` workflow attempts to check out fork code; this is a workflow security-policy failure, not a source failure