### PR TITLE
fix(kernel): stabilize apt update under sustained I/O

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "bit_field",
  "bitfield-struct",
  "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "bitmap",
  "cfg-if",
  "cpio_reader",
@@ -493,6 +494,7 @@ dependencies = [
  "loongArch64",
  "lru",
  "multiboot2",
+ "napi-state",
  "num",
  "num-derive",
  "num-traits 0.2.15",
@@ -1018,6 +1020,10 @@ dependencies = [
  "derive_more",
  "ptr_meta",
 ]
+
+[[package]]
+name = "napi-state"
+version = "0.1.0"
 
 [[package]]
 name = "nom"
@@ -1873,7 +1879,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtio-drivers"
 version = "0.7.2"
-source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers?rev=89f6a402d494cf615cadfd851c9f017f31acac81#89f6a402d494cf615cadfd851c9f017f31acac81"
+source = "git+https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers?rev=82d783c935084a67c2e0a3bead0266a66aed80fd#82d783c935084a67c2e0a3bead0266a66aed80fd"
 dependencies = [
  "bitflags 2.9.1",
  "log",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,6 +43,7 @@ atomic_enum = "=0.2.0"
 bit_field = "=0.10"
 bitfield-struct = "=0.5.3"
 bitflags = "=1.3.2"
+bitflags2 = { package = "bitflags", version = "=2.9.1" }
 bitmap = { path = "crates/bitmap" }
 driver_base_macros = { "path" = "crates/driver_base_macros" }
 elf = { version = "=0.7.2", default-features = false }
@@ -55,6 +56,7 @@ intertrait = { path = "crates/intertrait" }
 kcmdline_macros = { path = "crates/kcmdline_macros" }
 kdepends = { path = "crates/kdepends" }
 klog_types = { path = "crates/klog_types" }
+napi-state = { path = "crates/napi-state" }
 linkme = "=0.3.27"
 num = { version = "=0.4.0", default-features = false }
 num-derive = "=0.3"
@@ -82,7 +84,7 @@ smoltcp = { version = "=0.12.0", git = "https://github.com/DragonOS-Community/sm
 syscall_table_macros = { path = "crates/syscall_table_macros" }
 system_error = { path = "crates/system_error" }
 unified-init = { path = "crates/unified-init" }
-virtio-drivers = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers", rev = "89f6a402d494cf615cadfd851c9f017f31acac81" }
+virtio-drivers = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/virtio-drivers", rev = "82d783c935084a67c2e0a3bead0266a66aed80fd" }
 wait_queue_macros = { path = "crates/wait_queue_macros" }
 paste = "=1.0.14"
 slabmalloc = { path = "crates/rust-slabmalloc" }

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -10,6 +10,23 @@ pub(super) struct RangeAllocation {
     pub allocation_homes: [PBlockId; 3],
 }
 
+// Range allocation runs under the transaction writer gate.  Keep the
+// speculative search short so a fragmented filesystem cannot turn a single
+// sequential write into a volume-wide metadata read.
+const TRANSACTION_RANGE_MAX_GROUP_PROBES: u32 = 4;
+
+fn transaction_range_probe_limit(block_group_count: u32, require_preferred: bool) -> u32 {
+    // An exact-adjacency request can only succeed in its preferred group.  A
+    // failed probe is therefore a fast-path miss, not a reason to scan other
+    // groups while holding the transaction gate.
+    let limit = if require_preferred {
+        1
+    } else {
+        TRANSACTION_RANGE_MAX_GROUP_PROBES
+    };
+    core::cmp::min(block_group_count, limit)
+}
+
 fn extent_tail_batch_limit(
     first_data_block: PBlockId,
     blocks_per_group: PBlockId,
@@ -105,12 +122,11 @@ impl Ext4 {
             .unwrap_or(preferred_inode_group);
         let count_usize = count as usize;
 
-        // A fragmented preferred group must not turn a perfectly valid
-        // multi-block allocation into the per-block legacy path.  Scan every
-        // group once, starting at the inode-local preference, exactly as the
-        // single-block allocator ultimately searches the whole filesystem.
-        // The free-block count rejects full groups before reading a bitmap.
-        for offset in 0..bg_count {
+        // This is a speculative fast path.  Bound its metadata I/O under the
+        // transaction writer gate; on a miss the caller aborts the
+        // transaction and uses the legacy allocator.  Exact-adjacency probes
+        // need only inspect the preferred group.
+        for offset in 0..transaction_range_probe_limit(bg_count, require_preferred) {
             let bgid = ((preferred_group as u64 + offset as u64) % bg_count as u64) as BlockGroupId;
             let blocks_in_group = Self::block_group_block_count(&sb, bgid);
             if blocks_in_group < count_usize {
@@ -1277,8 +1293,25 @@ impl Ext4 {
 }
 
 #[cfg(test)]
-mod reclaim_tests {
-    use super::{extent_tail_batch_limit, linked_orphan_tail_remove_limit};
+mod allocation_tests {
+    use super::{
+        extent_tail_batch_limit, linked_orphan_tail_remove_limit, transaction_range_probe_limit,
+        TRANSACTION_RANGE_MAX_GROUP_PROBES,
+    };
+
+    #[test]
+    fn transactional_range_probes_are_bounded_and_exact_requests_are_local() {
+        assert_eq!(transaction_range_probe_limit(0, false), 0);
+        assert_eq!(transaction_range_probe_limit(1, false), 1);
+        assert_eq!(
+            transaction_range_probe_limit(128, false),
+            TRANSACTION_RANGE_MAX_GROUP_PROBES
+        );
+
+        assert_eq!(transaction_range_probe_limit(0, true), 0);
+        assert_eq!(transaction_range_probe_limit(1, true), 1);
+        assert_eq!(transaction_range_probe_limit(128, true), 1);
+    }
 
     #[test]
     fn extent_reclaim_batch_never_crosses_a_block_group() {

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -4,14 +4,11 @@ use crate::ext4_defs::*;
 use crate::format_error;
 use crate::prelude::*;
 use crate::return_error;
-use core::cmp::min;
 
-pub(super) struct DirectRangeAllocation {
+pub(super) struct RangeAllocation {
     pub first: PBlockId,
     pub allocation_homes: [PBlockId; 3],
 }
-
-const DIRECT_RANGE_MAX_GROUP_PROBES: u32 = 4;
 
 fn extent_tail_batch_limit(
     first_data_block: PBlockId,
@@ -83,14 +80,14 @@ impl Ext4 {
     /// any cache or disk metadata.  The caller owns the filesystem-wide
     /// transactional metadata gate, so no direct allocator can race the
     /// transaction-private bitmap snapshot while zero I/O is in progress.
-    pub(super) fn transaction_alloc_direct_range(
+    pub(super) fn transaction_alloc_range(
         &self,
         transaction: &mut super::journal_transaction::Transaction<'_>,
         inode_id: InodeId,
         preferred_first: Option<PBlockId>,
         require_preferred: bool,
         count: u32,
-    ) -> Result<DirectRangeAllocation> {
+    ) -> Result<RangeAllocation> {
         if count == 0 {
             return_error!(ErrCode::EINVAL, "Cannot allocate an empty block range");
         }
@@ -108,7 +105,12 @@ impl Ext4 {
             .unwrap_or(preferred_inode_group);
         let count_usize = count as usize;
 
-        for offset in 0..min(bg_count, DIRECT_RANGE_MAX_GROUP_PROBES) {
+        // A fragmented preferred group must not turn a perfectly valid
+        // multi-block allocation into the per-block legacy path.  Scan every
+        // group once, starting at the inode-local preference, exactly as the
+        // single-block allocator ultimately searches the whole filesystem.
+        // The free-block count rejects full groups before reading a bitmap.
+        for offset in 0..bg_count {
             let bgid = ((preferred_group as u64 + offset as u64) % bg_count as u64) as BlockGroupId;
             let blocks_in_group = Self::block_group_block_count(&sb, bgid);
             if blocks_in_group < count_usize {
@@ -180,7 +182,7 @@ impl Ext4 {
                 self.prepare_stats.record_bitmap_io();
                 let mut bitmap = Bitmap::new(image, blocks_in_group);
                 if (bit..bit + count_usize).any(|index| !bitmap.is_bit_clear(index)) {
-                    return_error!(ErrCode::EIO, "Direct range changed during planning");
+                    return_error!(ErrCode::EIO, "Range allocation changed during planning");
                 }
                 for index in bit..bit + count_usize {
                     bitmap.set_bit(index);
@@ -200,7 +202,7 @@ impl Ext4 {
             self.transaction_stage_super_block(transaction, &sb)?;
             self.prepare_stats.record_superblock_io();
             let (gdt_home, _) = self.block_group_disk_pos(bgid)?;
-            return Ok(DirectRangeAllocation {
+            return Ok(RangeAllocation {
                 first,
                 allocation_homes: [bitmap_home, gdt_home, 0],
             });
@@ -706,57 +708,96 @@ impl Ext4 {
                 break;
             }
 
-            let mut transaction = self.transaction_start(32)?;
-            let Some(tail) = self.extent_tail(&transaction, &inode)? else {
-                break;
-            };
-            let extent_end = tail
-                .start_pblock
-                .checked_add(tail.block_count as PBlockId)
-                .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent physical range"))?;
-            if tail.start_pblock == 0
-                || extent_end > self.read_super_block_cached().block_count()
-                || self.journal_owns_block_range(tail.start_pblock, extent_end)
-            {
-                return_error!(
-                    ErrCode::EIO,
-                    "Orphan extent overlaps invalid or journal-owned blocks"
-                );
-            }
-            // transaction_dealloc_block_range deliberately accepts one block
-            // group only. Trim the right edge at that boundary so bitmap and
-            // counters stay a compact, independently restartable unit.
             let sb = self.read_super_block_cached();
             let blocks_per_group = sb.blocks_per_group() as PBlockId;
-            let remove_limit = extent_tail_batch_limit(
-                sb.first_data_block() as PBlockId,
-                blocks_per_group,
-                tail.start_pblock,
-                tail.block_count,
-            )
-            .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent tail"))?;
-            let removed = self
-                .extent_remove_tail_in_transaction(&mut transaction, &mut inode, remove_limit)?
-                .ok_or_else(|| format_error!(ErrCode::EIO, "Extent tail disappeared"))?;
-            self.transaction_dealloc_block_range(
-                &mut transaction,
-                removed.start_pblock,
-                removed.block_count,
-            )?;
-            for metadata in removed.metadata_blocks.iter().copied() {
-                self.transaction_dealloc_block_range(&mut transaction, metadata, 1)?;
+            let first_data_block = sb.first_data_block() as PBlockId;
+            let mut transaction = self.transaction_start(32)?;
+            let mut batch_group = None;
+            let mut removals = 0usize;
+
+            // Sequential range allocation can create hundreds of extents in
+            // one block group.  Committing each tail entry independently turns
+            // unlink/failed-download cleanup into hundreds of synchronous JBD2
+            // barriers.  Bitmap/GDT/superblock and the right-most extent leaf
+            // are read-your-writes transaction images, so remove all adjacent
+            // tail entries from the same allocation group in one commit.
+            while removals < 64 {
+                // One removal can detach an extent-tree right spine of at most
+                // five blocks. In the adversarial layout every detached
+                // metadata block belongs to a different allocation group:
+                // data bitmap/GDT (2), five metadata bitmap/GDT pairs (10),
+                // one surviving parent (1), the shared superblock (1), and
+                // the final inode-table image (1). Do not begin another
+                // mutation unless all 15 possible new homes still fit. This
+                // avoids a repeatable E2BIG orphan-reclaim failure while
+                // retaining large batches for the common shared-home case.
+                const NEXT_REMOVAL_CREDIT_RESERVE: usize = 15;
+                if removals != 0 && transaction.remaining_credits() < NEXT_REMOVAL_CREDIT_RESERVE {
+                    break;
+                }
+                let Some(tail) = self.extent_tail(&transaction, &inode)? else {
+                    break;
+                };
+                let extent_end = tail
+                    .start_pblock
+                    .checked_add(tail.block_count as PBlockId)
+                    .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent physical range"))?;
+                if tail.start_pblock == 0
+                    || extent_end > sb.block_count()
+                    || self.journal_owns_block_range(tail.start_pblock, extent_end)
+                {
+                    return_error!(
+                        ErrCode::EIO,
+                        "Orphan extent overlaps invalid or journal-owned blocks"
+                    );
+                }
+                let remove_limit = extent_tail_batch_limit(
+                    first_data_block,
+                    blocks_per_group,
+                    tail.start_pblock,
+                    tail.block_count,
+                )
+                .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent tail"))?;
+                let removed_first = extent_end
+                    .checked_sub(remove_limit as PBlockId)
+                    .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent tail range"))?;
+                let group = removed_first
+                    .checked_sub(first_data_block)
+                    .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid extent block group"))?
+                    / blocks_per_group;
+                if batch_group.is_some_and(|current| current != group) {
+                    break;
+                }
+                batch_group = Some(group);
+
+                let removed = self
+                    .extent_remove_tail_in_transaction(&mut transaction, &mut inode, remove_limit)?
+                    .ok_or_else(|| format_error!(ErrCode::EIO, "Extent tail disappeared"))?;
+                self.transaction_dealloc_block_range(
+                    &mut transaction,
+                    removed.start_pblock,
+                    removed.block_count,
+                )?;
+                for metadata in removed.metadata_blocks.iter().copied() {
+                    self.transaction_dealloc_block_range(&mut transaction, metadata, 1)?;
+                }
+                let released = removed.block_count as u64 + removed.metadata_blocks.len() as u64;
+                let remaining = inode
+                    .inode
+                    .fs_block_count()
+                    .checked_sub(released)
+                    .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid inode block count"))?;
+                inode.inode.set_fs_block_count(remaining);
+                inode.inode.set_size(core::cmp::min(
+                    inode.inode.size(),
+                    removed.start_lblock as u64 * BLOCK_SIZE as u64,
+                ));
+                removals += 1;
             }
-            let released = removed.block_count as u64 + removed.metadata_blocks.len() as u64;
-            let remaining = inode
-                .inode
-                .fs_block_count()
-                .checked_sub(released)
-                .ok_or_else(|| format_error!(ErrCode::EIO, "Invalid inode block count"))?;
-            inode.inode.set_fs_block_count(remaining);
-            inode.inode.set_size(core::cmp::min(
-                inode.inode.size(),
-                removed.start_lblock as u64 * BLOCK_SIZE as u64,
-            ));
+            if removals == 0 {
+                transaction.abort();
+                break;
+            }
             self.transaction_stage_inode_with_csum(&mut transaction, &mut inode)?;
             self.commit_reclaim_transaction(transaction)?;
         }

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -29,6 +29,9 @@ pub(super) struct ExtentTail {
 pub(super) struct DirectAppendShape {
     pub preferred_first: Option<PBlockId>,
     pub requires_merge: bool,
+    /// Physical home of the right-most extent leaf. `None` denotes the
+    /// inline extent root stored in the inode-table entry.
+    pub leaf_home: Option<PBlockId>,
 }
 
 impl Ext4 {
@@ -44,25 +47,74 @@ impl Ext4 {
         let root = inode.inode.extent_root();
         let header = root.header();
         self.validate_extent_node(inode.id, &root)?;
-        if header.depth() != 0
-            || header.max_entries_count() as usize != root.entry_capacity()
+        if header.max_entries_count() as usize != root.entry_capacity()
             || header.entries_count() as usize > root.entry_capacity()
         {
             return Ok(None);
         }
-        let entries = header.entries_count() as usize;
+        let mut entries = header.entries_count() as usize;
         if entries == 0 {
-            return Ok((start_lblock == 0).then_some(DirectAppendShape {
-                preferred_first: None,
-                requires_merge: false,
-            }));
+            return Ok(
+                (header.depth() == 0 && start_lblock == 0).then_some(DirectAppendShape {
+                    preferred_first: None,
+                    requires_merge: false,
+                    leaf_home: None,
+                }),
+            );
         }
-        let last = root.extent_at(entries - 1);
+
+        let mut leaf_block = None;
+        let leaf_home = if header.depth() == 0 {
+            None
+        } else {
+            // Range staging for an external leaf is journal-only.  The
+            // nojournal backend has a special publication order for an
+            // inline-root update and cannot safely publish another metadata
+            // home without a more general undo protocol.
+            if !self.uses_journal() {
+                return Ok(None);
+            }
+            let mut expected_depth = header.depth();
+            let mut home = root.extent_index_at(entries - 1).leaf();
+            loop {
+                let block = self.read_extent_block(inode, home)?;
+                let node = ExtentNode::from_bytes(&block.data[..]);
+                self.validate_extent_node(inode.id, &node)?;
+                if node.header().depth() + 1 != expected_depth {
+                    return Err(format_error!(
+                        ErrCode::EIO,
+                        "extent depth mismatch on inode {} at block {}",
+                        inode.id,
+                        home
+                    ));
+                }
+                entries = node.header().entries_count() as usize;
+                if entries == 0 {
+                    return Err(format_error!(
+                        ErrCode::EIO,
+                        "empty reachable extent node on inode {} at block {}",
+                        inode.id,
+                        home
+                    ));
+                }
+                expected_depth = node.header().depth();
+                if expected_depth == 0 {
+                    leaf_block = Some(block);
+                    break Some(home);
+                }
+                home = node.extent_index_at(entries - 1).leaf();
+            }
+        };
+        let leaf = leaf_block
+            .as_ref()
+            .map(|block| ExtentNode::from_bytes(&block.data[..]));
+        let node = leaf.as_ref().unwrap_or(&root);
+        let last = node.extent_at(entries - 1);
         if last.is_unwritten() {
             return Ok(None);
         }
         for index in 0..entries {
-            let extent = root.extent_at(index);
+            let extent = node.extent_at(index);
             self.validate_data_blocks(extent.start_pblock(), extent.block_count() as u64)?;
         }
         let next_lblock = last
@@ -78,13 +130,14 @@ impl Ext4 {
             .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
         let candidate = Extent::new(start_lblock, preferred_first, count as u16);
         let can_merge = Extent::can_append(last, &candidate);
-        let root_full = entries == header.max_entries_count() as usize;
-        if root_full && !can_merge {
+        let leaf_full = entries == node.header().max_entries_count() as usize;
+        if leaf_full && !can_merge {
             return Ok(None);
         }
         Ok(Some(DirectAppendShape {
             preferred_first: Some(preferred_first),
-            requires_merge: root_full,
+            requires_merge: leaf_full,
+            leaf_home,
         }))
     }
 
@@ -122,6 +175,67 @@ impl Ext4 {
             .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
         inode.inode.set_fs_block_count(blocks);
         Ok(())
+    }
+
+    /// Stage a contiguous append in either the inline extent root or the
+    /// existing right-most external leaf.
+    ///
+    /// This deliberately does not split a full leaf.  The general extent
+    /// insertion path already owns that operation; after it creates a new
+    /// right-most leaf, later sequential writes can re-enter this batched
+    /// transaction path.
+    pub(super) fn stage_journaled_append_extent(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode: &mut InodeRef,
+        leaf_home: Option<PBlockId>,
+        start_lblock: LBlockId,
+        start_pblock: PBlockId,
+        count: u32,
+    ) -> Result<()> {
+        if let Some(home) = leaf_home {
+            {
+                let image = transaction.read(self.block_device.as_ref(), home)?;
+                self.verify_transaction_extent_block(inode, &*image)?;
+                let node = ExtentNode::from_bytes(&*image);
+                self.validate_extent_node(inode.id, &node)?;
+                if node.header().depth() != 0 || node.header().entries_count() == 0 {
+                    return Err(format_error!(
+                        ErrCode::EIO,
+                        "invalid append leaf on inode {} at block {}",
+                        inode.id,
+                        home
+                    ));
+                }
+            }
+            let seed = self.read_super_block_cached().metadata_checksum_seed();
+            let image = self.transaction_block_for_update(transaction, home)?;
+            let new_extent = Extent::new(start_lblock, start_pblock, count as u16);
+            {
+                let mut node = ExtentNodeMut::from_bytes(image);
+                let entries = node.header().entries_count() as usize;
+                let last = *node.extent_at(entries - 1);
+                if Extent::can_append(&last, &new_extent) {
+                    node.extent_mut_at(entries - 1)
+                        .set_block_count(last.block_count() + count);
+                } else if node.insert_extent(&new_extent, entries).is_err() {
+                    return Err(format_error!(
+                        ErrCode::ENOTSUP,
+                        "External extent leaf requires a split"
+                    ));
+                }
+            }
+            Self::set_extent_block_checksum(seed, inode, image);
+            let blocks = inode
+                .inode
+                .fs_block_count()
+                .checked_add(count as u64)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+            inode.inode.set_fs_block_count(blocks);
+            Ok(())
+        } else {
+            self.stage_direct_append_extent(inode, start_lblock, start_pblock, count)
+        }
     }
 
     fn verify_extent_block_checksum(&self, inode_ref: &InodeRef, image: &[u8]) -> Result<()> {

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -306,6 +306,15 @@ impl Transaction<'_> {
         Ok(())
     }
 
+    /// Credits which are still available for previously untouched home blocks.
+    ///
+    /// Batched operations use this only to stop at a restartable boundary
+    /// before beginning their next logical mutation. Re-staging an existing
+    /// home remains free and the transaction is still the final authority.
+    pub(super) fn remaining_credits(&self) -> usize {
+        self.credits.saturating_sub(self.staged.len())
+    }
+
     /// Return the transaction-private final image of `home` for mutation.
     ///
     /// The first access snapshots the device block and consumes one credit;

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -11,20 +11,21 @@ use crate::prelude::*;
 use crate::return_error;
 use core::cmp::min;
 
-const DIRECT_RANGE_MIN_BLOCKS: usize = 16;
+const DIRECT_RANGE_MIN_BLOCKS: usize = 4;
 const DIRECT_RANGE_MAX_BLOCKS: usize = 256;
 const DIRECT_RANGE_ZERO_CHUNK_BLOCKS: usize = 8;
 
-enum DirectRangePrepare {
+enum TransactionalRangePrepare {
     Handled,
     Unsupported,
 }
 
-struct DirectRangePlan {
+struct TransactionalRangePlan {
     start_lblock: LBlockId,
     count: u32,
     preferred_first: Option<PBlockId>,
     requires_merge: bool,
+    leaf_home: Option<PBlockId>,
 }
 
 /// Attributes that can be set on an inode via `setattr`.
@@ -62,7 +63,12 @@ impl SetAttr {
 }
 
 impl Ext4 {
-    fn initialize_direct_range(&self, first: PBlockId, count: usize, zeros: &[u8]) -> Result<()> {
+    fn initialize_allocated_range(
+        &self,
+        first: PBlockId,
+        count: usize,
+        zeros: &[u8],
+    ) -> Result<()> {
         let mut done = 0usize;
         while done < count {
             let blocks = min(DIRECT_RANGE_ZERO_CHUNK_BLOCKS, count - done);
@@ -77,32 +83,52 @@ impl Ext4 {
         self.block_device.flush()
     }
 
-    fn direct_range_plan(
+    fn transactional_range_plan(
         &self,
         inode: &InodeRef,
         offset: usize,
         len: usize,
-    ) -> Result<Option<DirectRangePlan>> {
+    ) -> Result<Option<TransactionalRangePlan>> {
         if len == 0 {
             return Ok(None);
         }
         let end = offset
             .checked_add(len)
             .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
-        let start_lblock =
+        let mut start_lblock =
             u32::try_from(offset / BLOCK_SIZE).map_err(|_| Ext4Error::new(ErrCode::EFBIG))?;
         let end_lblock =
             u32::try_from((end - 1) / BLOCK_SIZE).map_err(|_| Ext4Error::new(ErrCode::EFBIG))?;
-        let count = end_lblock
+        let original_count = end_lblock
             .checked_sub(start_lblock)
             .and_then(|blocks| blocks.checked_add(1))
             .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
-        if start_lblock.checked_add(count).is_none()
-            || (count as usize) < DIRECT_RANGE_MIN_BLOCKS
-            || (count as usize) > DIRECT_RANGE_MAX_BLOCKS
+        if start_lblock.checked_add(original_count).is_none()
+            || (original_count as usize) > DIRECT_RANGE_MAX_BLOCKS
         {
             return Ok(None);
         }
+
+        // Sequential userspace writes need not be block aligned.  A 64 KiB
+        // circular buffer commonly starts the next write in the final block
+        // of the preceding write.  Trim that already-mapped prefix so the
+        // remaining append can still use one range transaction instead of
+        // falling back to one allocation transaction per 4 KiB block.
+        while start_lblock <= end_lblock {
+            match self.extent_query(inode, start_lblock) {
+                Ok(_) => start_lblock += 1,
+                Err(error) if error.code() == ErrCode::ENOENT => break,
+                Err(error) => return Err(error),
+            }
+        }
+        if start_lblock > end_lblock {
+            return Ok(None);
+        }
+        let count = end_lblock - start_lblock + 1;
+        if (count as usize) < DIRECT_RANGE_MIN_BLOCKS {
+            return Ok(None);
+        }
+
         let persistent_blocks = inode
             .inode
             .size()
@@ -115,36 +141,47 @@ impl Ext4 {
         let Some(shape) = self.direct_append_shape(inode, start_lblock, count)? else {
             return Ok(None);
         };
-        Ok(Some(DirectRangePlan {
+        Ok(Some(TransactionalRangePlan {
             start_lblock,
             count,
             preferred_first: shape.preferred_first,
             requires_merge: shape.requires_merge,
+            leaf_home: shape.leaf_home,
         }))
     }
 
-    fn try_prepare_direct_range(
+    fn try_prepare_transactional_range(
         &self,
         inode: &mut InodeRef,
         offset: usize,
         len: usize,
-    ) -> Result<DirectRangePrepare> {
+    ) -> Result<TransactionalRangePrepare> {
         if len == 0 {
-            return Ok(DirectRangePrepare::Handled);
+            return Ok(TransactionalRangePrepare::Handled);
         }
-        let Some(plan) = self.direct_range_plan(inode, offset, len)? else {
-            return Ok(DirectRangePrepare::Unsupported);
+        let Some(plan) = self.transactional_range_plan(inode, offset, len)? else {
+            return Ok(TransactionalRangePrepare::Unsupported);
         };
 
         let zero_bytes = DIRECT_RANGE_ZERO_CHUNK_BLOCKS * BLOCK_SIZE;
         let mut zeros = Vec::new();
         if zeros.try_reserve_exact(zero_bytes).is_err() {
-            return Ok(DirectRangePrepare::Unsupported);
+            return Ok(TransactionalRangePrepare::Unsupported);
         }
         zeros.resize(zero_bytes, 0);
 
-        let mut transaction = self.transaction_start_direct_range(4)?;
-        let allocation = match self.transaction_alloc_direct_range(
+        let journaled = self.uses_journal();
+        let credits = if journaled && plan.leaf_home.is_some() {
+            5
+        } else {
+            4
+        };
+        let mut transaction = if journaled {
+            self.transaction_start(credits)?
+        } else {
+            self.transaction_start_direct_range(credits)?
+        };
+        let allocation = match self.transaction_alloc_range(
             &mut transaction,
             inode.id,
             plan.preferred_first,
@@ -154,7 +191,7 @@ impl Ext4 {
             Ok(allocation) => allocation,
             Err(error) if error.code() == ErrCode::ENOSPC => {
                 transaction.abort();
-                return Ok(DirectRangePrepare::Unsupported);
+                return Ok(TransactionalRangePrepare::Unsupported);
             }
             Err(error) => return Err(error),
         };
@@ -163,20 +200,33 @@ impl Ext4 {
         self.prepare_stats.record_requested(plan.count as usize);
         self.prepare_stats
             .record_missing_blocks(plan.count as usize);
-        let initialized =
-            self.initialize_direct_range(allocation.first, plan.count as usize, zeros.as_slice());
+        let initialized = self.initialize_allocated_range(
+            allocation.first,
+            plan.count as usize,
+            zeros.as_slice(),
+        );
         if let Err(error) = initialized {
             self.prepare_stats.record_failure();
             transaction.abort();
             if error.code() == ErrCode::ENOMEM {
-                return Ok(DirectRangePrepare::Unsupported);
+                return Ok(TransactionalRangePrepare::Unsupported);
             }
             return Err(error);
         }
 
-        if let Err(error) =
+        let stage_result = if journaled {
+            self.stage_journaled_append_extent(
+                &mut transaction,
+                inode,
+                plan.leaf_home,
+                plan.start_lblock,
+                allocation.first,
+                plan.count,
+            )
+        } else {
             self.stage_direct_append_extent(inode, plan.start_lblock, allocation.first, plan.count)
-        {
+        };
+        if let Err(error) = stage_result {
             self.prepare_stats.record_failure();
             transaction.abort();
             return Err(error);
@@ -188,14 +238,23 @@ impl Ext4 {
             return Err(error);
         }
         self.prepare_stats.record_inode_io();
-        if let Err(error) = transaction.commit_direct_range(
-            self.block_device.as_ref(),
-            self,
-            &allocation.allocation_homes,
-            inode_home,
-        ) {
+        let commit_result = if journaled {
+            transaction.commit(self.block_device.as_ref(), self)
+        } else {
+            transaction.commit_direct_range(
+                self.block_device.as_ref(),
+                self,
+                &allocation.allocation_homes,
+                inode_home,
+            )
+        };
+        if let Err(error) = commit_result {
             self.prepare_stats.record_failure();
-            if error.failure != super::journal_transaction::CommitFailure::BeforeCommit {
+            // Both backends classify failures relative to their publication
+            // point.  A failed journal commit also poisons its private core;
+            // publish the same fail-stop state through the Ext4 facade.
+            if journaled || error.failure != super::journal_transaction::CommitFailure::BeforeCommit
+            {
                 self.poison(ErrCode::EIO);
             }
             return Err(error.error);
@@ -204,7 +263,7 @@ impl Ext4 {
         self.prepare_stats.record_gdt_io();
         self.prepare_stats.record_superblock_io();
         self.prepare_stats.record_inode_io();
-        Ok(DirectRangePrepare::Handled)
+        Ok(TransactionalRangePrepare::Handled)
     }
 
     fn xattr_checksum_seed(&self) -> Result<Option<MetadataChecksumSeed>> {
@@ -451,7 +510,7 @@ impl Ext4 {
         _mtime: Option<u32>,
     ) -> Result<()> {
         self.ensure_mutable()?;
-        if self.supports_direct_range_stage() {
+        if self.uses_journal() || self.supports_direct_range_stage() {
             // Classify the request under a compatible direct guard first.
             // Unsupported small, overwrite, sparse, and oversized writes can
             // continue through the legacy allocator without ever contending
@@ -464,7 +523,10 @@ impl Ext4 {
                 if inode.inode.mode().bits() == 0 {
                     return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
                 }
-                if self.direct_range_plan(&inode, offset, len)?.is_none() {
+                if self
+                    .transactional_range_plan(&inode, offset, len)?
+                    .is_none()
+                {
                     return self.ensure_blocks_for_write_range_locked(&mut inode, offset, len);
                 }
             }
@@ -476,9 +538,9 @@ impl Ext4 {
                 if inode.inode.mode().bits() == 0 {
                     return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
                 }
-                self.try_prepare_direct_range(&mut inode, offset, len)?
+                self.try_prepare_transactional_range(&mut inode, offset, len)?
             };
-            if matches!(outcome, DirectRangePrepare::Handled) {
+            if matches!(outcome, TransactionalRangePrepare::Handled) {
                 return Ok(());
             }
         }
@@ -928,9 +990,17 @@ impl Ext4 {
         }
 
         for (fblock, block_offset, cursor, write_len) in chunks {
-            let mut block = self.read_block(fblock)?;
-            block.write_offset(block_offset, &data[cursor..cursor + write_len]);
-            self.write_block(&block)?;
+            if block_offset == 0 && write_len == BLOCK_SIZE {
+                // Page-cache writeback supplies complete, block-aligned pages.
+                // Reading the old block before overwriting every byte doubles
+                // virtio I/O and serves no correctness purpose.
+                self.block_device
+                    .write_blocks(fblock, &data[cursor..cursor + write_len])?;
+            } else {
+                let mut block = self.read_block(fblock)?;
+                block.write_offset(block_offset, &data[cursor..cursor + write_len]);
+                self.write_block(&block)?;
+            }
         }
 
         Ok(write_size)
@@ -1841,7 +1911,7 @@ mod tests {
     impl StubBlockDevice {
         fn with_block_count(block_count: u32) -> Self {
             let mut data = [0u8; BLOCK_SIZE];
-            let off = BASE_OFFSET;
+            let off = BASE_OFFSET + core::mem::size_of::<u32>();
             data[off..off + 4].copy_from_slice(&block_count.to_le_bytes());
             Self {
                 sb_block: Block::new(0, Box::new(data)),
@@ -1959,14 +2029,14 @@ mod tests {
     }
 
     #[test]
-    fn direct_range_zero_failure_stops_before_flush() {
+    fn allocated_range_zero_failure_stops_before_flush() {
         let device = Arc::new(RangeInitDevice::new(128));
         device.fail_write_at.store(1, Ordering::SeqCst);
         let fs = make_test_fs_with_device(128, device.clone());
         let zeros = [0; DIRECT_RANGE_ZERO_CHUNK_BLOCKS * BLOCK_SIZE];
 
         let error = fs
-            .initialize_direct_range(32, DIRECT_RANGE_ZERO_CHUNK_BLOCKS * 2, &zeros)
+            .initialize_allocated_range(32, DIRECT_RANGE_ZERO_CHUNK_BLOCKS * 2, &zeros)
             .unwrap_err();
 
         assert_eq!(error.code(), ErrCode::ENOMEM);
@@ -1975,14 +2045,14 @@ mod tests {
     }
 
     #[test]
-    fn direct_range_flush_failure_is_reported_after_all_zero_chunks() {
+    fn allocated_range_flush_failure_is_reported_after_all_zero_chunks() {
         let device = Arc::new(RangeInitDevice::new(128));
         device.fail_flush.store(true, Ordering::SeqCst);
         let fs = make_test_fs_with_device(128, device.clone());
         let zeros = [0; DIRECT_RANGE_ZERO_CHUNK_BLOCKS * BLOCK_SIZE];
 
         let error = fs
-            .initialize_direct_range(32, DIRECT_RANGE_ZERO_CHUNK_BLOCKS * 2, &zeros)
+            .initialize_allocated_range(32, DIRECT_RANGE_ZERO_CHUNK_BLOCKS * 2, &zeros)
             .unwrap_err();
 
         assert_eq!(error.code(), ErrCode::EIO);
@@ -1991,22 +2061,22 @@ mod tests {
     }
 
     #[test]
-    fn direct_range_plan_filters_legacy_writes_before_transaction_gate() {
+    fn transactional_range_plan_filters_legacy_writes_before_transaction_gate() {
         let fs = make_test_fs(1024);
         let mut inode = Inode::default();
         inode.extent_init();
         let mut inode = InodeRef::new(2, Box::new(inode));
 
         assert!(fs
-            .direct_range_plan(&inode, 0, (DIRECT_RANGE_MIN_BLOCKS - 1) * BLOCK_SIZE)
+            .transactional_range_plan(&inode, 0, (DIRECT_RANGE_MIN_BLOCKS - 1) * BLOCK_SIZE)
             .unwrap()
             .is_none());
         assert!(fs
-            .direct_range_plan(&inode, 0, (DIRECT_RANGE_MAX_BLOCKS + 1) * BLOCK_SIZE)
+            .transactional_range_plan(&inode, 0, (DIRECT_RANGE_MAX_BLOCKS + 1) * BLOCK_SIZE)
             .unwrap()
             .is_none());
         assert!(fs
-            .direct_range_plan(&inode, 0, DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE)
+            .transactional_range_plan(&inode, 0, DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE)
             .unwrap()
             .is_some());
 
@@ -2014,9 +2084,28 @@ mod tests {
             .inode
             .set_size((DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE) as u64);
         assert!(fs
-            .direct_range_plan(&inode, 0, DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE)
+            .transactional_range_plan(&inode, 0, DIRECT_RANGE_MIN_BLOCKS * BLOCK_SIZE)
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn transactional_range_plan_trims_one_mapped_prefix_block() {
+        let fs = make_test_fs(1024);
+        let mut inode = Inode::default();
+        inode.extent_init();
+        let mut inode = InodeRef::new(2, Box::new(inode));
+        fs.stage_direct_append_extent(&mut inode, 0, 100, 16)
+            .unwrap();
+
+        let plan = fs
+            .transactional_range_plan(&inode, 15 * BLOCK_SIZE + 3360, 16 * BLOCK_SIZE)
+            .unwrap()
+            .expect("mapped prefix must not force per-block allocation");
+
+        assert_eq!(plan.start_lblock, 16);
+        assert_eq!(plan.count, 16);
+        assert_eq!(plan.preferred_first, Some(116));
     }
 
     #[test]

--- a/kernel/crates/napi-state/Cargo.toml
+++ b/kernel/crates/napi-state/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "napi-state"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"

--- a/kernel/crates/napi-state/src/lib.rs
+++ b/kernel/crates/napi-state/src/lib.rs
@@ -1,0 +1,141 @@
+#![no_std]
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+pub const SCHED: u32 = 1 << 0;
+pub const MISSED: u32 = 1 << 1;
+pub const DISABLE: u32 = 1 << 2;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CompleteState {
+    Completed,
+    Missed,
+}
+
+/// Try to acquire the single NAPI poll owner.
+///
+/// A caller which gets `true` owns the transition from idle to scheduled and
+/// must publish the NAPI instance exactly once. A caller which observes an
+/// existing owner only records `MISSED`.
+pub fn schedule_prep(state: &AtomicU32) -> bool {
+    let mut current = state.load(Ordering::Acquire);
+    loop {
+        if current & DISABLE != 0 {
+            return false;
+        }
+
+        let mut next = current | SCHED;
+        if current & SCHED != 0 {
+            next |= MISSED;
+        }
+
+        match state.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return current & SCHED == 0,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+/// Finish the current poll ownership transition.
+///
+/// If a scheduler recorded `MISSED`, ownership remains scheduled and the
+/// caller must publish the instance for one more poll after completing any
+/// device-specific callback handshake.
+pub fn complete(state: &AtomicU32) -> CompleteState {
+    let mut current = state.load(Ordering::Acquire);
+    loop {
+        debug_assert_ne!(current & SCHED, 0, "completing an unscheduled NAPI");
+
+        let mut next = current & !(SCHED | MISSED);
+        let result = if current & MISSED != 0 {
+            next |= SCHED;
+            CompleteState::Missed
+        } else {
+            CompleteState::Completed
+        };
+
+        match state.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return result,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+/// Permanently disable a NAPI instance and release any outstanding ownership.
+///
+/// This is reserved for a backing interface which can no longer be polled.
+/// Repeatedly calling `complete` is not equivalent: it creates an idle window
+/// in which a concurrent scheduler can acquire an owner that nobody publishes.
+pub fn disable(state: &AtomicU32) {
+    state.store(DISABLE, Ordering::Release);
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn first_schedule_acquires_owner() {
+        let state = AtomicU32::new(0);
+        assert!(schedule_prep(&state));
+        assert_eq!(state.load(Ordering::Relaxed), SCHED);
+    }
+
+    #[test]
+    fn repeated_schedule_only_records_missed() {
+        let state = AtomicU32::new(SCHED);
+        assert!(!schedule_prep(&state));
+        assert_eq!(state.load(Ordering::Relaxed), SCHED | MISSED);
+    }
+
+    #[test]
+    fn disable_rejects_schedule() {
+        let state = AtomicU32::new(DISABLE);
+        assert!(!schedule_prep(&state));
+        assert_eq!(state.load(Ordering::Relaxed), DISABLE);
+    }
+
+    #[test]
+    fn complete_releases_idle_owner() {
+        let state = AtomicU32::new(SCHED);
+        assert_eq!(complete(&state), CompleteState::Completed);
+        assert_eq!(state.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn complete_preserves_owner_after_missed() {
+        let state = AtomicU32::new(SCHED | MISSED);
+        assert_eq!(complete(&state), CompleteState::Missed);
+        assert_eq!(state.load(Ordering::Relaxed), SCHED);
+    }
+
+    #[test]
+    fn concurrent_schedule_is_not_lost_by_complete() {
+        let state = Arc::new(AtomicU32::new(SCHED));
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_state = state.clone();
+        let worker_barrier = barrier.clone();
+
+        let scheduler = thread::spawn(move || {
+            worker_barrier.wait();
+            assert!(!schedule_prep(&worker_state));
+        });
+
+        barrier.wait();
+        scheduler.join().unwrap();
+        assert_eq!(complete(&state), CompleteState::Missed);
+        assert_eq!(state.load(Ordering::Relaxed), SCHED);
+    }
+
+    #[test]
+    fn disable_releases_owner_and_rejects_future_schedule() {
+        let state = AtomicU32::new(SCHED | MISSED);
+        disable(&state);
+        assert_eq!(state.load(Ordering::Acquire), DISABLE);
+        assert!(!schedule_prep(&state));
+    }
+}

--- a/kernel/src/driver/base/block/gendisk/mod.rs
+++ b/kernel/src/driver/base/block/gendisk/mod.rs
@@ -179,8 +179,20 @@ impl GenDisk {
     }
 
     #[inline]
-    pub fn range(&self) -> &GeneralBlockRange {
-        &self.range
+    pub fn range(&self) -> GeneralBlockRange {
+        // A whole-disk node represents the current capacity of its backing
+        // block device.  This is especially important for loop devices: their
+        // GenDisk is registered while unbound and gains capacity only after
+        // LOOP_SET_FD.  Partitions, in contrast, keep the fixed range parsed
+        // from their partition table.
+        if self.idx.is_none() {
+            self.bdev
+                .upgrade()
+                .map(|bdev| bdev.disk_range())
+                .unwrap_or(self.range)
+        } else {
+            self.range
+        }
     }
 
     #[inline]
@@ -257,7 +269,8 @@ impl IndexNode for GenDisk {
 
     fn metadata(&self) -> Result<crate::filesystem::vfs::Metadata, SystemError> {
         let mut meta = self.metadata.clone();
-        let blocks = self.range.lba_end.saturating_sub(self.range.lba_start);
+        let range = self.range();
+        let blocks = range.lba_end.saturating_sub(range.lba_start);
         let size_in_bytes = blocks.saturating_mul(LBA_SIZE);
 
         meta.size = i64::try_from(size_in_bytes).unwrap_or(i64::MAX);
@@ -346,7 +359,7 @@ impl GenDiskMap {
 
     pub fn intersects(&self, range: &GeneralBlockRange) -> bool {
         for (_, v) in self.iter() {
-            if range.intersects_with(&v.range).is_some() {
+            if range.intersects_with(&v.range()).is_some() {
                 return true;
             }
         }

--- a/kernel/src/driver/base/block/manager.rs
+++ b/kernel/src/driver/base/block/manager.rs
@@ -183,7 +183,7 @@ impl BlockDevManager {
         {
             let mut meta_inner = blk_meta.inner();
             // 检查是否重复
-            if meta_inner.gendisks.intersects(gendisk.range()) {
+            if meta_inner.gendisks.intersects(&gendisk.range()) {
                 return Err(SystemError::EEXIST);
             }
 

--- a/kernel/src/driver/block/loop_device/loop_device.rs
+++ b/kernel/src/driver/block/loop_device/loop_device.rs
@@ -1218,11 +1218,7 @@ impl BlockDevice for LoopDevice {
 
     fn disk_range(&self) -> GeneralBlockRange {
         let inner = self.inner();
-        let blocks = if inner.file_size == 0 {
-            0
-        } else {
-            inner.file_size.saturating_add(LBA_SIZE - 1) / LBA_SIZE
-        };
+        let blocks = inner.file_size / LBA_SIZE;
         drop(inner);
         GeneralBlockRange::new(0, blocks).unwrap_or(GeneralBlockRange {
             lba_start: 0,

--- a/kernel/src/driver/net/e1000e/e1000e_driver.rs
+++ b/kernel/src/driver/net/e1000e/e1000e_driver.rs
@@ -431,7 +431,7 @@ impl Iface for E1000EInterface {
         self.common.poll(&mut driver)
     }
 
-    fn poll_napi(&self, budget: usize) -> bool {
+    fn poll_napi(&self, budget: usize) -> crate::driver::net::napi::NapiPollResult {
         let mut driver = self.driver.clone();
         self.common.poll_napi(&mut driver, budget)
     }

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -580,11 +580,12 @@ impl Iface for LoopbackInterface {
         progressed || self.driver.has_pending_rx()
     }
 
-    fn poll_napi(&self, budget: usize) -> bool {
+    fn poll_napi(&self, budget: usize) -> super::napi::NapiPollResult {
         // 与普通 poll 相同：若 egress 刚把包送回 lo 队列，则 NAPI 也必须继续自驱动。
         let mut driver = self.driver.clone();
-        let has_work_left = self.common.poll_napi(&mut driver, budget);
-        has_work_left || self.driver.has_pending_rx()
+        let mut result = self.common.poll_napi(&mut driver, budget);
+        result.poll_again |= self.driver.has_pending_rx();
+        result
     }
 
     fn raw_transmit(&self, frame: &[u8]) -> Result<(), SystemError> {

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -93,14 +93,19 @@ pub trait Iface: crate::driver::base::device::Device {
     /// # `poll_napi`
     /// NAPI（类似 Linux softirq/ksoftirqd）使用的 bounded poll。
     ///
-    /// ## 返回值语义（对齐 NAPI）
-    /// - `true`：还有工作没做完（例如 ingress backlog 超过 budget），应继续留在 poll_list
-    /// - `false`：本次已处理完，可 complete
-    ///
-    /// 默认实现退化为一次普通 poll（兼容旧驱动）；具体网卡应覆盖实现以保证 bounded work。
+    /// 返回本次实际处理量，以及是否需要立即再次 poll。
+    fn poll_napi(&self, budget: usize) -> napi::NapiPollResult;
+
+    /// Called after this NAPI instance acquires `SCHED`, before it is published.
+    /// Devices with interrupt mitigation may mask callbacks here.
     #[inline]
-    fn poll_napi(&self, _budget: usize) -> bool {
-        self.poll()
+    fn napi_poll_begin(&self) {}
+
+    /// Complete one NAPI ownership cycle. Devices may override this to pair
+    /// callback re-enabling with the `SCHED/MISSED` transition.
+    #[inline]
+    fn napi_complete(&self, napi: Arc<napi::NapiStruct>) {
+        napi::napi_complete(napi);
     }
 
     /// # `raw_transmit`
@@ -511,7 +516,7 @@ impl IfaceCommon {
     /// NAPI 使用的 bounded poll：最多处理 `budget` 个 ingress 包，然后推进一次 egress。
     ///
     /// 返回值语义：是否仍有 ingress backlog 需要继续 poll（即 budget 用尽且仍在处理包）。
-    pub fn poll_napi<D>(&self, device: &mut D, budget: usize) -> bool
+    pub fn poll_napi<D>(&self, device: &mut D, budget: usize) -> napi::NapiPollResult
     where
         D: smoltcp::phy::Device + ?Sized,
     {
@@ -570,8 +575,11 @@ impl IfaceCommon {
         // - 但仍有 ACK / window update / 后续 egress 需要立即发送；
         // - NAPI 线程却错误睡眠，直到下一次外部事件才继续推进，
         //   导致 send done 后 recv 端偶发卡住。
-        (had_packet && processed == budget)
-            || matches!(poll_at, Some(instant) if instant <= timestamp)
+        napi::NapiPollResult::new(
+            processed,
+            (had_packet && processed == budget)
+                || matches!(poll_at, Some(instant) if instant <= timestamp),
+        )
     }
 
     pub fn update_ip_addrs(&self, ip_addrs: &[smoltcp::wire::IpCidr]) -> Result<(), SystemError> {

--- a/kernel/src/driver/net/napi.rs
+++ b/kernel/src/driver/net/napi.rs
@@ -5,10 +5,11 @@ use crate::libs::wait_queue::WaitQueue;
 use crate::process::kthread::{KernelThreadClosure, KernelThreadMechanism};
 use crate::process::ProcessState;
 use alloc::boxed::Box;
+use alloc::collections::VecDeque;
 use alloc::string::ToString;
 use alloc::sync::{Arc, Weak};
-use alloc::vec::Vec;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::sync::atomic::AtomicU32;
+use napi_state::CompleteState;
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
@@ -42,28 +43,39 @@ impl NapiStruct {
         })
     }
 
-    pub fn poll(&self) -> bool {
-        // log::info!("NAPI instance {} polling", self.napi_id);
-        // 获取网卡的强引用
+    fn poll(&self, budget: usize) -> Option<(Arc<dyn Iface>, NapiPollResult)> {
         if let Some(iface) = self.net_device.upgrade() {
             if !iface.flags().contains(InterfaceFlags::UP) {
-                return false;
+                return Some((iface, NapiPollResult::idle()));
             }
-            // Linux NAPI 语义：每次 poll 处理有限工作量（budget/weight），避免无界处理导致 DoS/长时间关中断。
-            // smoltcp 的 Interface::poll() 会在一次调用内处理 device 队列中所有包，因此这里必须走 bounded poll。
-            //
-            // 返回值语义：
-            // - true：还有工作没做完（例如仍有 ingress 包未处理或需要立即继续 poll），保留在 poll_list 继续处理
-            // - false：本次已处理完，可 complete
-            return iface.poll_napi(self.weight);
+            let result = iface.poll_napi(budget);
+            return Some((iface, result));
         } else {
             log::error!(
                 "NAPI instance {}: associated net device is gone",
                 self.napi_id
             );
         }
+        None
+    }
+}
 
-        false
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct NapiPollResult {
+    pub work_done: usize,
+    pub poll_again: bool,
+}
+
+impl NapiPollResult {
+    pub const fn new(work_done: usize, poll_again: bool) -> Self {
+        Self {
+            work_done,
+            poll_again,
+        }
+    }
+
+    pub const fn idle() -> Self {
+        Self::new(0, false)
     }
 }
 
@@ -119,99 +131,122 @@ pub fn napi_init() -> Result<(), SystemError> {
 }
 
 fn net_rx_action() {
+    const NET_RX_PACKET_BUDGET: usize = 300;
+    const NET_RX_POLL_BUDGET: usize = 64;
+    const NET_RX_TIME_BUDGET_US: i64 = 2_000;
+
     loop {
-        // 这里直接将全局的NAPI管理器的napi_list取出，清空全局的列表，避免占用锁时间过长
         let mut inner = GLOBAL_NAPI_MANAGER.inner();
-        let mut poll_list = inner.napi_list.clone();
-        inner.napi_list.clear();
+        let mut active = core::mem::take(&mut inner.napi_list);
         drop(inner);
 
-        // log::info!("NAPI softirq processing {} instances", poll_list.len());
+        let started_at = crate::time::Instant::now().total_micros();
+        let mut packets_left = NET_RX_PACKET_BUDGET;
+        let mut polls_left = NET_RX_POLL_BUDGET;
+        let mut repoll = VecDeque::new();
 
-        while let Some(napi) = poll_list.pop() {
-            let has_work_left = napi.poll();
-            // log::info!("yes");
+        while let Some(napi) = active.pop_front() {
+            let elapsed = crate::time::Instant::now().total_micros() - started_at;
+            if polls_left == 0 || packets_left == 0 || elapsed >= NET_RX_TIME_BUDGET_US {
+                active.push_front(napi);
+                break;
+            }
 
-            if has_work_left {
-                poll_list.push(napi);
-            } else {
+            let budget = core::cmp::min(napi.weight, packets_left);
+            polls_left -= 1;
+
+            let Some((iface, result)) = napi.poll(budget) else {
+                // A registered NAPI must not outlive its interface. Clear the state to avoid
+                // retaining an owner forever; device teardown is responsible for stopping DMA.
                 napi_complete(napi);
+                continue;
+            };
+
+            debug_assert!(result.work_done <= budget);
+            packets_left = packets_left.saturating_sub(core::cmp::min(result.work_done, budget));
+
+            if result.poll_again || result.work_done >= budget {
+                repoll.push_back(napi);
+            } else {
+                iface.napi_complete(napi);
             }
         }
 
-        // log::info!("napi softirq iteration complete")
+        let mut inner = GLOBAL_NAPI_MANAGER.inner();
+        // Fair merge order: work which did not get a turn, newly scheduled work, then busy repolls.
+        active.append(&mut inner.napi_list);
+        active.append(&mut repoll);
+        inner.napi_list = active;
 
-        // 若 budget 用尽后仍有 backlog，必须继续自驱动处理，不能依赖新的外部唤醒。
-        // 否则 loopback/TCP 大流量场景下，发送端已经结束后不会再触发 napi_schedule()，
-        // 剩余包会永久滞留在 backlog 中，接收端 read()/recv() 就会偶发卡死。
-        if !poll_list.is_empty() {
-            let mut inner = GLOBAL_NAPI_MANAGER.inner();
-            inner.napi_list.extend(poll_list);
-            inner.has_pending_signal.store(true, Ordering::SeqCst);
-            drop(inner);
-            continue;
-        }
-
-        // 关键竞态：
-        // `poll()` / `poll_egress()` 期间，loopback Tx 可能再次调用 `napi_schedule()`，
-        // 把“新产生的 ingress 工作”塞回全局 `napi_list`。
-        //
-        // 由于本轮处理的是循环开始时快照出的 `poll_list`，如果这里不重新检查全局列表，
-        // 就可能出现：
-        // 1) 当前本地 `poll_list` 已空；
-        // 2) 但全局 `napi_list` 已被并发加入了新工作；
-        // 3) 当前线程仍把 `has_pending_signal` 清零并睡眠。
-        //
-        // 对 loopback/TCP 大包发送，这会把“send 过程中产生的后续本地收包”永久遗落，
-        // 直到下一次外部网络事件才被重新推进，从而表现为 recv() 偶发永久卡住。
-        let inner = GLOBAL_NAPI_MANAGER.inner();
         if !inner.napi_list.is_empty() {
-            inner.has_pending_signal.store(true, Ordering::SeqCst);
+            inner.has_pending_signal = true;
             drop(inner);
+            crate::sched::sched_yield();
             continue;
         }
 
-        // 只有确认全局队列也为空时，才真正进入睡眠。
-        inner.has_pending_signal.store(false, Ordering::SeqCst);
+        inner.has_pending_signal = false;
         drop(inner);
 
         let _ = wq_wait_event_interruptible!(
             GLOBAL_NAPI_MANAGER.wait_queue(),
-            GLOBAL_NAPI_MANAGER
-                .inner()
-                .has_pending_signal
-                .load(Ordering::SeqCst),
+            GLOBAL_NAPI_MANAGER.inner().has_pending_signal,
             {}
         );
     }
 }
 
-/// 标记这个napi任务已经完成
-pub fn napi_complete(napi: Arc<NapiStruct>) {
-    napi.state
-        .fetch_and(!NapiState::SCHED.bits(), Ordering::SeqCst);
+pub(crate) fn napi_complete_state(napi: &NapiStruct) -> CompleteState {
+    napi_state::complete(&napi.state)
 }
 
-/// 标记这个napi任务加入处理队列，已被调度
-pub fn napi_schedule(napi: Arc<NapiStruct>) {
-    let current_state = NapiState::from_bits_truncate(
-        napi.state
-            .fetch_or(NapiState::SCHED.bits(), Ordering::SeqCst),
-    );
-
-    if !current_state.contains(NapiState::SCHED) {
-        let new_state = current_state.union(NapiState::SCHED);
-        // log::info!("NAPI instance {} scheduled", napi.napi_id);
-        napi.state.store(new_state.bits(), Ordering::SeqCst);
+/// Complete a NAPI instance which has no device-specific callback handshake.
+pub fn napi_complete(napi: Arc<NapiStruct>) {
+    if napi_complete_state(&napi) == CompleteState::Missed {
+        __napi_schedule(napi);
     }
+}
 
+/// Permanently stop scheduling a NAPI instance whose device can no longer be
+/// polled. This must be a single atomic transition: completing twice can race
+/// a scheduler and orphan its newly acquired owner.
+pub(crate) fn napi_disable(napi: &NapiStruct) {
+    napi_state::disable(&napi.state);
+}
+
+pub(crate) fn napi_schedule_prep(napi: &NapiStruct) -> bool {
+    napi_state::schedule_prep(&napi.state)
+}
+
+pub(crate) fn __napi_schedule(napi: Arc<NapiStruct>) {
+    debug_assert_ne!(
+        napi.state.load(core::sync::atomic::Ordering::Relaxed) & napi_state::SCHED,
+        0
+    );
     let mut inner = GLOBAL_NAPI_MANAGER.inner();
-    inner.napi_list.push(napi);
-    inner.has_pending_signal.store(true, Ordering::SeqCst);
+    inner.napi_list.push_back(napi);
+    inner.has_pending_signal = true;
+    drop(inner);
 
     GLOBAL_NAPI_MANAGER.wakeup();
+}
 
-    // softirq_vectors().raise_softirq(SoftirqNumber::NetReceive);
+/// Acquire a NAPI owner, let the device mask callbacks, then publish it once.
+pub fn napi_schedule(napi: Arc<NapiStruct>) {
+    if !napi_schedule_prep(&napi) {
+        return;
+    }
+
+    let Some(iface) = napi.net_device.upgrade() else {
+        log::error!(
+            "NAPI instance {} scheduled after its interface was removed",
+            napi.napi_id
+        );
+        napi_disable(&napi);
+        return;
+    };
+    iface.napi_poll_begin();
+    __napi_schedule(napi);
 }
 
 pub struct NapiManager {
@@ -222,8 +257,8 @@ pub struct NapiManager {
 impl NapiManager {
     pub fn new() -> Arc<Self> {
         let inner = SpinLock::new(NapiManagerInner {
-            has_pending_signal: AtomicBool::new(false),
-            napi_list: Vec::new(),
+            has_pending_signal: false,
+            napi_list: VecDeque::new(),
         });
         Arc::new(Self {
             inner,
@@ -247,8 +282,8 @@ impl NapiManager {
 }
 
 pub struct NapiManagerInner {
-    has_pending_signal: AtomicBool,
-    napi_list: Vec<Arc<NapiStruct>>,
+    has_pending_signal: bool,
+    napi_list: VecDeque<Arc<NapiStruct>>,
 }
 
 // 下面的是软中断的做法，无法唤醒，做个记录

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -663,7 +663,7 @@ impl Iface for VethInterface {
         // self.clear_recv_buffer();
     }
 
-    fn poll_napi(&self, budget: usize) -> bool {
+    fn poll_napi(&self, budget: usize) -> super::napi::NapiPollResult {
         let mut driver = self.driver.clone();
         self.common.poll_napi(&mut driver, budget)
     }

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -1,8 +1,6 @@
 use core::{
     any::Any,
     fmt::{Debug, Formatter},
-    ops::{Deref, DerefMut},
-    sync::atomic::{AtomicBool, Ordering},
 };
 
 use alloc::{
@@ -11,9 +9,14 @@ use alloc::{
     vec::Vec,
 };
 use log::{debug, error};
+use napi_state::CompleteState;
 use smoltcp::{iface, phy, wire};
 use unified_init::macros::unified_init;
-use virtio_drivers::device::net::VirtIONet;
+use virtio_drivers::{
+    device::net::VirtIONetRaw,
+    transport::{DeviceStatus, DeviceType as VirtioDeviceType, Transport},
+    PhysAddr,
+};
 
 use super::{Iface, NetDeivceState, NetDeviceCommonData, Operstate};
 use crate::{
@@ -30,7 +33,10 @@ use crate::{
             kset::KSet,
         },
         net::{
-            napi::{napi_schedule, NapiStruct},
+            napi::{
+                __napi_schedule, napi_complete_state, napi_disable, napi_schedule,
+                napi_schedule_prep, NapiStruct,
+            },
             register_netdevice,
             types::InterfaceFlags,
         },
@@ -51,6 +57,7 @@ use crate::{
         rwsem::{RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
     },
+    mm::dma::{DmaAllocOptions, DmaBuffer, DmaDirection},
     net::generate_iface_id,
     process::namespace::net_namespace::INIT_NET_NAMESPACE,
     time::Instant,
@@ -60,11 +67,122 @@ use system_error::SystemError;
 static mut VIRTIO_NET_DRIVER: Option<Arc<VirtIONetDriver>> = None;
 
 const VIRTIO_NET_BASENAME: &str = "virtio_net";
+const VIRTIO_NET_QUEUE_SIZE: usize = 64;
+const VIRTIO_NET_BUFFER_SIZE: usize = 4096;
+// smoltcp expects the complete Ethernet frame size here. Without
+// VIRTIO_NET_F_MTU, Linux exposes the standard 1500-byte IP MTU.
+const VIRTIO_NET_MAX_FRAME_SIZE: usize = 1500 + 14;
+const VIRTIO_NET_RX_QUEUE: u16 = 0;
+const VIRTIO_NET_TX_QUEUE: u16 = 1;
 
 #[inline(always)]
 #[allow(dead_code)]
 fn virtio_net_driver() -> Arc<VirtIONetDriver> {
     unsafe { VIRTIO_NET_DRIVER.as_ref().unwrap().clone() }
+}
+
+/// Network-only transport wrapper which resets the device before its DMA
+/// buffers are released.
+struct VirtioNetTransport(VirtIOTransport, bool);
+
+impl VirtioNetTransport {
+    fn reset_device(&mut self) {
+        if self.1 {
+            return;
+        }
+        self.0.set_status(DeviceStatus::empty());
+        while self.0.get_status() != DeviceStatus::empty() {
+            core::hint::spin_loop();
+        }
+        self.1 = true;
+    }
+}
+
+impl Transport for VirtioNetTransport {
+    fn device_type(&self) -> VirtioDeviceType {
+        self.0.device_type()
+    }
+
+    fn read_device_features(&mut self) -> u64 {
+        self.0.read_device_features()
+    }
+
+    fn write_driver_features(&mut self, driver_features: u64) {
+        self.0.write_driver_features(driver_features)
+    }
+
+    fn max_queue_size(&mut self, queue: u16) -> u32 {
+        self.0.max_queue_size(queue)
+    }
+
+    fn notify(&mut self, queue: u16) {
+        self.0.notify(queue)
+    }
+
+    fn get_status(&self) -> DeviceStatus {
+        self.0.get_status()
+    }
+
+    fn set_status(&mut self, status: DeviceStatus) {
+        self.0.set_status(status)
+    }
+
+    fn set_guest_page_size(&mut self, guest_page_size: u32) {
+        self.0.set_guest_page_size(guest_page_size)
+    }
+
+    fn requires_legacy_layout(&self) -> bool {
+        self.0.requires_legacy_layout()
+    }
+
+    fn queue_set(
+        &mut self,
+        queue: u16,
+        size: u32,
+        descriptors: PhysAddr,
+        driver_area: PhysAddr,
+        device_area: PhysAddr,
+    ) {
+        self.0
+            .queue_set(queue, size, descriptors, driver_area, device_area)
+    }
+
+    fn queue_unset(&mut self, queue: u16) {
+        // VirtIONetRaw unsets queues from its Drop implementation. DragonOS's
+        // PCI transport cannot legally rewrite active queue configuration, so
+        // stop all device DMA before forwarding the first unset.
+        self.reset_device();
+        self.0.queue_unset(queue)
+    }
+
+    fn queue_used(&mut self, queue: u16) -> bool {
+        self.0.queue_used(queue)
+    }
+
+    fn ack_interrupt(&mut self) -> bool {
+        self.0.ack_interrupt()
+    }
+
+    fn begin_init<F>(&mut self, supported_features: F) -> F
+    where
+        F: bitflags2::Flags<Bits = u64> + core::ops::BitAnd<Output = F> + Debug,
+    {
+        self.0.begin_init(supported_features)
+    }
+
+    fn finish_init(&mut self) {
+        self.0.finish_init()
+    }
+
+    fn config_space<T: 'static>(&self) -> virtio_drivers::Result<core::ptr::NonNull<T>> {
+        self.0.config_space()
+    }
+}
+
+impl Drop for VirtioNetTransport {
+    fn drop(&mut self) {
+        self.reset_device();
+    }
 }
 
 /// virtio net device
@@ -122,18 +240,17 @@ impl VirtIONetDevice {
         };
 
         let irq_is_msix = transport.irq_is_msix();
-        let driver_net: VirtIONet<HalImpl, VirtIOTransport, 2> =
-            match VirtIONet::<HalImpl, VirtIOTransport, 2>::new(transport, 4096) {
-                Ok(net) => net,
-                Err(_) => {
-                    error!("VirtIONet init failed");
-                    return None;
-                }
-            };
+        let driver_net = match VirtIoNetImpl::new(VirtioNetTransport(transport, false)) {
+            Ok(net) => net,
+            Err(err) => {
+                error!("VirtIONet init failed: {err:?}");
+                return None;
+            }
+        };
         let mac = wire::EthernetAddress::from_bytes(&driver_net.mac_address());
         debug!("VirtIONetDevice mac: {:?}", mac);
         let device_inner = VirtIONicDeviceInner::new(driver_net);
-        device_inner.inner.lock_irqsave().enable_interrupts();
+        device_inner.inner.lock_irqsave().inner.enable_interrupts();
         let dev = Arc::new(Self {
             dev_id,
             inner: SpinLock::new(InnerVirtIONetDevice {
@@ -361,26 +478,284 @@ impl VirtIODevice for VirtIONetDevice {
     }
 }
 
+type RawVirtioNet = VirtIONetRaw<HalImpl, VirtioNetTransport, VIRTIO_NET_QUEUE_SIZE>;
+
+struct RxDmaBuffer {
+    dma: DmaBuffer,
+    packet_offset: usize,
+    packet_len: usize,
+}
+
+impl RxDmaBuffer {
+    fn packet(&self) -> &[u8] {
+        &self.dma.as_slice()[self.packet_offset..self.packet_offset + self.packet_len]
+    }
+}
+
+struct TxDmaBuffer {
+    dma: DmaBuffer,
+    used_len: usize,
+}
+
 pub struct VirtIoNetImpl {
-    inner: VirtIONet<HalImpl, VirtIOTransport, 2>,
+    // Keep the raw driver first: its transport reset must run before DMA slots are dropped.
+    inner: RawVirtioNet,
+    rx_slots: Vec<Option<RxDmaBuffer>>,
+    tx_inflight: Vec<Option<TxDmaBuffer>>,
+    tx_free: Vec<TxDmaBuffer>,
+    // Buffers submitted under a token that failed validation must stay alive
+    // until reset; returning them to the CPU would create a DMA use-after-free.
+    rx_quarantine: Vec<RxDmaBuffer>,
+    tx_quarantine: Vec<TxDmaBuffer>,
+    poisoned: bool,
 }
 
 impl VirtIoNetImpl {
-    const fn new(inner: VirtIONet<HalImpl, VirtIOTransport, 2>) -> Self {
-        Self { inner }
+    fn dma_buffer(direction: DmaDirection) -> Result<DmaBuffer, SystemError> {
+        DmaBuffer::try_alloc_bytes(
+            VIRTIO_NET_BUFFER_SIZE,
+            DmaAllocOptions {
+                direction,
+                use_pool: false,
+                ..Default::default()
+            },
+        )
     }
-}
 
-impl Deref for VirtIoNetImpl {
-    type Target = VirtIONet<HalImpl, VirtIOTransport, 2>;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
+    fn new(mut transport: VirtioNetTransport) -> Result<Self, SystemError> {
+        let rx_size = transport.max_queue_size(VIRTIO_NET_RX_QUEUE);
+        let tx_size = transport.max_queue_size(VIRTIO_NET_TX_QUEUE);
+        if rx_size < VIRTIO_NET_QUEUE_SIZE as u32 || tx_size < VIRTIO_NET_QUEUE_SIZE as u32 {
+            error!(
+                "virtio-net requires queue size {}, device offers rx={} tx={}",
+                VIRTIO_NET_QUEUE_SIZE, rx_size, tx_size
+            );
+            return Err(SystemError::ENODEV);
+        }
+
+        // Allocate every fallible payload buffer before the device starts consuming descriptors.
+        let mut rx_buffers = Vec::with_capacity(VIRTIO_NET_QUEUE_SIZE);
+        let mut tx_free = Vec::with_capacity(VIRTIO_NET_QUEUE_SIZE);
+        for _ in 0..VIRTIO_NET_QUEUE_SIZE {
+            rx_buffers.push(RxDmaBuffer {
+                dma: Self::dma_buffer(DmaDirection::FromDevice)?,
+                packet_offset: 0,
+                packet_len: 0,
+            });
+            tx_free.push(TxDmaBuffer {
+                dma: Self::dma_buffer(DmaDirection::ToDevice)?,
+                used_len: 0,
+            });
+        }
+
+        let mut rx_slots = (0..VIRTIO_NET_QUEUE_SIZE).map(|_| None).collect::<Vec<_>>();
+        let tx_inflight = (0..VIRTIO_NET_QUEUE_SIZE).map(|_| None).collect();
+        let mut rx_quarantine = Vec::new();
+        // Declared last so an initialization error drops/resets the raw device
+        // before any buffer already submitted to it is released.
+        let mut inner = RawVirtioNet::new(transport).map_err(|_| SystemError::EIO)?;
+
+        for mut buffer in rx_buffers {
+            // SAFETY: DmaBuffer is page-backed and stays owned by rx_slots until completion.
+            let token = unsafe { inner.receive_begin(buffer.dma.as_mut_slice()) }
+                .map_err(|_| SystemError::EIO)?;
+            let Some(slot) = rx_slots.get_mut(token as usize) else {
+                rx_quarantine.push(buffer);
+                return Err(SystemError::EIO);
+            };
+            if slot.is_some() {
+                rx_quarantine.push(buffer);
+                return Err(SystemError::EIO);
+            }
+            *slot = Some(buffer);
+        }
+
+        Ok(Self {
+            inner,
+            rx_slots,
+            tx_inflight,
+            tx_free,
+            rx_quarantine,
+            tx_quarantine: Vec::new(),
+            poisoned: false,
+        })
     }
-}
 
-impl DerefMut for VirtIoNetImpl {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+    fn mac_address(&self) -> [u8; 6] {
+        self.inner.mac_address()
+    }
+
+    fn poison(&mut self, reason: &'static str) {
+        if !self.poisoned {
+            error!("virtio-net queue poisoned: {reason}");
+            self.inner.disable_interrupts();
+            self.poisoned = true;
+        }
+    }
+
+    fn receive(&mut self) -> Result<Option<RxDmaBuffer>, SystemError> {
+        if self.poisoned {
+            return Err(SystemError::EIO);
+        }
+        let token = match self.inner.poll_receive_checked() {
+            Ok(Some(token)) => token,
+            Ok(None) => return Ok(None),
+            Err(_) => {
+                self.poison("RX completion token out of range");
+                return Err(SystemError::EIO);
+            }
+        };
+        let index = token as usize;
+        let Some(slot) = self.rx_slots.get_mut(index) else {
+            self.poison("RX token out of range");
+            return Err(SystemError::EIO);
+        };
+        let Some(mut buffer) = slot.take() else {
+            self.poison("RX token has no device-owned buffer");
+            return Err(SystemError::EIO);
+        };
+
+        // SAFETY: This is the same allocation submitted for this token and it remained stable.
+        let completed = unsafe {
+            self.inner
+                .receive_complete(token, buffer.dma.as_mut_slice())
+        };
+        let (header_len, packet_len) = match completed {
+            Ok(lengths) => lengths,
+            Err(_) => {
+                self.rx_slots[index] = Some(buffer);
+                self.poison("RX completion/token mismatch");
+                return Err(SystemError::EIO);
+            }
+        };
+        let Some(end) = header_len.checked_add(packet_len) else {
+            self.poison("RX completion length overflow");
+            return Err(SystemError::EIO);
+        };
+        if end > buffer.dma.len() {
+            // The descriptor is reclaimed and the allocation is CPU-owned,
+            // but an impossible used length is a device/queue integrity
+            // failure. Quarantine the buffer and fail-stop instead of
+            // silently returning it to an untrusted queue.
+            self.rx_quarantine.push(buffer);
+            self.poison("RX completion exceeds submitted DMA buffer");
+            return Err(SystemError::EIO);
+        }
+        buffer.packet_offset = header_len;
+        buffer.packet_len = packet_len;
+        Ok(Some(buffer))
+    }
+
+    fn recycle_rx(&mut self, mut buffer: RxDmaBuffer) -> Result<(), SystemError> {
+        if self.poisoned {
+            return Err(SystemError::EIO);
+        }
+        buffer.packet_offset = 0;
+        buffer.packet_len = 0;
+        // SAFETY: ownership returns to the queue and the allocation stays in rx_slots.
+        let token = unsafe { self.inner.receive_begin(buffer.dma.as_mut_slice()) }
+            .map_err(|_| SystemError::EIO)?;
+        let Some(slot) = self.rx_slots.get_mut(token as usize) else {
+            self.rx_quarantine.push(buffer);
+            self.poison("recycled RX token out of range");
+            return Err(SystemError::EIO);
+        };
+        if slot.is_some() {
+            self.rx_quarantine.push(buffer);
+            self.poison("recycled RX token already occupied");
+            return Err(SystemError::EIO);
+        }
+        *slot = Some(buffer);
+        Ok(())
+    }
+
+    fn reap_tx_completions(&mut self) -> Result<usize, SystemError> {
+        let mut completed = 0;
+        loop {
+            let token = match self.inner.poll_transmit_checked() {
+                Ok(Some(token)) => token,
+                Ok(None) => break,
+                Err(_) => {
+                    self.poison("TX completion token out of range");
+                    return Err(SystemError::EIO);
+                }
+            };
+            let index = token as usize;
+            let Some(slot) = self.tx_inflight.get_mut(index) else {
+                self.poison("TX completion token out of range");
+                return Err(SystemError::EIO);
+            };
+            let Some(buffer) = slot.take() else {
+                self.poison("TX completion token has no buffer");
+                return Err(SystemError::EIO);
+            };
+            let result = unsafe {
+                self.inner
+                    .transmit_complete(token, &buffer.dma.as_slice()[..buffer.used_len])
+            };
+            if result.is_err() {
+                self.tx_inflight[index] = Some(buffer);
+                self.poison("TX completion/token mismatch");
+                return Err(SystemError::EIO);
+            }
+            self.tx_free.push(buffer);
+            completed += 1;
+        }
+        Ok(completed)
+    }
+
+    fn has_rx_completion(&mut self) -> Result<bool, SystemError> {
+        match self.inner.poll_receive_checked() {
+            Ok(token) => Ok(token.is_some()),
+            Err(_) => {
+                self.poison("RX completion token out of range");
+                Err(SystemError::EIO)
+            }
+        }
+    }
+
+    fn reserve_tx(&mut self) -> Option<TxDmaBuffer> {
+        if self.poisoned || self.reap_tx_completions().is_err() || self.tx_free.len() < 2 {
+            return None;
+        }
+        self.tx_free.pop()
+    }
+
+    fn release_tx(&mut self, mut buffer: TxDmaBuffer) {
+        buffer.used_len = 0;
+        self.tx_free.push(buffer);
+    }
+
+    fn submit_tx(&mut self, buffer: TxDmaBuffer) -> Result<(), SystemError> {
+        if self.poisoned {
+            self.release_tx(buffer);
+            return Err(SystemError::EIO);
+        }
+        let used_len = buffer.used_len;
+        let submitted = unsafe {
+            self.inner
+                .transmit_begin(&buffer.dma.as_slice()[..used_len])
+        };
+        let token = match submitted {
+            Ok(token) => token,
+            Err(_) => {
+                self.poison("reserved TX descriptor could not be submitted");
+                self.release_tx(buffer);
+                return Err(SystemError::EIO);
+            }
+        };
+        let Some(slot) = self.tx_inflight.get_mut(token as usize) else {
+            self.tx_quarantine.push(buffer);
+            self.poison("submitted TX token out of range");
+            return Err(SystemError::EIO);
+        };
+        if slot.is_some() {
+            self.tx_quarantine.push(buffer);
+            self.poison("submitted TX token already occupied");
+            return Err(SystemError::EIO);
+        }
+        *slot = Some(buffer);
+        Ok(())
     }
 }
 
@@ -393,7 +768,6 @@ pub struct VirtIONicDeviceInner {
     pub inner: Arc<SpinLock<VirtIoNetImpl>>,
     /// 指向所属网络接口的弱引用，用于 packet socket 分发
     iface: Arc<SpinLock<Weak<dyn super::Iface>>>,
-    tx_reserved: Arc<AtomicBool>,
 }
 
 impl Debug for VirtIONicDeviceInner {
@@ -554,18 +928,16 @@ impl Device for VirtioInterface {
 }
 
 impl VirtIONicDeviceInner {
-    pub fn new(driver_net: VirtIONet<HalImpl, VirtIOTransport, 2>) -> Self {
-        let inner = Arc::new(SpinLock::new(VirtIoNetImpl::new(driver_net)));
-        let result = VirtIONicDeviceInner {
+    pub fn new(driver_net: VirtIoNetImpl) -> Self {
+        let inner = Arc::new(SpinLock::new(driver_net));
+        VirtIONicDeviceInner {
             inner,
             iface: Arc::new(SpinLock::new(Weak::<VirtioInterface>::new())),
-            tx_reserved: Arc::new(AtomicBool::new(false)),
-        };
-        return result;
+        }
     }
 
     pub fn ack_interrupt(&self) -> bool {
-        self.inner.lock_irqsave().ack_interrupt()
+        self.inner.lock_irqsave().inner.ack_interrupt()
     }
 
     /// 设置所属网络接口的引用
@@ -578,60 +950,77 @@ impl VirtIONicDeviceInner {
         self.iface.lock().upgrade()
     }
 
-    fn submit_frame<R, F>(&self, len: usize, fill: F) -> Result<R, SystemError>
+    fn submit_frame<R, F>(
+        &self,
+        mut buffer: TxDmaBuffer,
+        len: usize,
+        fill: F,
+    ) -> (R, Result<(), SystemError>)
     where
         F: FnOnce(&mut [u8]) -> R,
     {
-        if len > 2000 {
-            return Err(SystemError::EMSGSIZE);
-        }
-        let mut driver_net = self.inner.lock_irqsave();
-        if !driver_net.can_send() {
-            return Err(SystemError::ENOBUFS);
-        }
-        let mut tx_buf = driver_net.new_tx_buffer(len);
-        let result = fill(tx_buf.packet_mut());
-        driver_net.send(tx_buf).map_err(|_| SystemError::ENOBUFS)?;
-        Ok(result)
-    }
+        let tap_iface = self
+            .iface()
+            .filter(crate::net::socket::packet::packet_sockets_active);
+        let mut driver = self.inner.lock_irqsave();
+        let header_len = driver
+            .inner
+            .fill_buffer_header(buffer.dma.as_mut_slice())
+            .expect("preallocated virtio TX buffer is smaller than its header");
+        let frame_end = header_len
+            .checked_add(len)
+            .filter(|end| *end <= buffer.dma.len())
+            .expect("smoltcp exceeded advertised virtio-net MTU");
+        let result = fill(&mut buffer.dma.as_mut_slice()[header_len..frame_end]);
+        let tap_frame =
+            tap_iface.map(|iface| (iface, buffer.dma.as_slice()[header_len..frame_end].to_vec()));
+        buffer.used_len = frame_end;
+        let submit_result = driver.submit_tx(buffer);
+        drop(driver);
 
-    fn try_reserve_tx(&self) -> bool {
-        self.tx_reserved
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-    }
-
-    fn release_tx(&self) {
-        self.tx_reserved.store(false, Ordering::Release);
+        if submit_result.is_ok() {
+            if let Some((iface, frame)) = tap_frame {
+                crate::net::socket::packet::deliver_to_packet_sockets(
+                    &iface,
+                    &frame,
+                    crate::net::socket::packet::PacketType::Outgoing,
+                );
+            }
+        }
+        (result, submit_result)
     }
 
     pub fn try_raw_transmit(&self, frame: &[u8]) -> Result<(), SystemError> {
-        if !self.try_reserve_tx() {
-            return Err(SystemError::ENOBUFS);
+        if frame.len() > VIRTIO_NET_MAX_FRAME_SIZE {
+            return Err(SystemError::EMSGSIZE);
         }
-        let result = self.submit_frame(frame.len(), |buf| buf.copy_from_slice(frame));
-        self.release_tx();
+        let buffer = self
+            .inner
+            .lock_irqsave()
+            .reserve_tx()
+            .ok_or(SystemError::ENOBUFS)?;
+        let (_, result) = self.submit_frame(buffer, frame.len(), |buf| buf.copy_from_slice(frame));
         result
     }
 }
 
 pub struct VirtioNetToken {
     driver: VirtIONicDeviceInner,
-    rx_buffer: Option<virtio_drivers::device::net::RxBuffer>,
-    tx_reserved: bool,
+    rx_buffer: Option<RxDmaBuffer>,
+    tx_buffer: Option<TxDmaBuffer>,
 }
 
 impl VirtioNetToken {
-    pub fn new(
+    fn new(
         driver: VirtIONicDeviceInner,
-        rx_buffer: Option<virtio_drivers::device::net::RxBuffer>,
-        tx_reserved: bool,
+        rx_buffer: Option<RxDmaBuffer>,
+        tx_buffer: Option<TxDmaBuffer>,
     ) -> Self {
-        return Self {
+        Self {
             driver,
             rx_buffer,
-            tx_reserved,
-        };
+            tx_buffer,
+        }
     }
 }
 
@@ -649,35 +1038,34 @@ impl phy::Device for VirtIONicDeviceInner {
         &mut self,
         _timestamp: smoltcp::time::Instant,
     ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        match self.inner.lock_irqsave().receive() {
-            Ok(buf) => Some((
-                VirtioNetToken::new(self.clone(), Some(buf), false),
-                VirtioNetToken::new(self.clone(), None, false),
+        let mut driver = self.inner.lock_irqsave();
+        let tx_buffer = driver.reserve_tx()?;
+        match driver.receive() {
+            Ok(Some(rx_buffer)) => Some((
+                VirtioNetToken::new(self.clone(), Some(rx_buffer), None),
+                VirtioNetToken::new(self.clone(), None, Some(tx_buffer)),
             )),
-            Err(virtio_drivers::Error::NotReady) => None,
-            Err(err) => panic!("VirtIO receive failed: {}", err),
+            Ok(None) => {
+                driver.release_tx(tx_buffer);
+                None
+            }
+            Err(err) => {
+                driver.release_tx(tx_buffer);
+                error!("VirtIO receive failed: {err:?}");
+                None
+            }
         }
     }
 
     fn transmit(&mut self, _timestamp: smoltcp::time::Instant) -> Option<Self::TxToken<'_>> {
-        // debug!("VirtioNet: transmit");
-        if !self.try_reserve_tx() {
-            return None;
-        }
-        if self.inner.lock_irqsave().can_send() {
-            // debug!("VirtioNet: can send");
-            return Some(VirtioNetToken::new(self.clone(), None, true));
-        } else {
-            self.release_tx();
-            // debug!("VirtioNet: can not send");
-            return None;
-        }
+        let buffer = self.inner.lock_irqsave().reserve_tx()?;
+        Some(VirtioNetToken::new(self.clone(), None, Some(buffer)))
     }
 
     fn capabilities(&self) -> phy::DeviceCapabilities {
         let mut caps = phy::DeviceCapabilities::default();
         // 网卡的最大传输单元. 请与IP层的MTU进行区分。这个值应当是网卡的最大传输单元，而不是IP层的MTU。
-        caps.max_transmission_unit = 2000;
+        caps.max_transmission_unit = VIRTIO_NET_MAX_FRAME_SIZE;
         /*
            Maximum burst size, in terms of MTU.
            The network device is unable to send or receive bursts large than the value returned by this function.
@@ -693,39 +1081,11 @@ impl phy::TxToken for VirtioNetToken {
     where
         F: FnOnce(&mut [u8]) -> R,
     {
-        if !self.tx_reserved {
-            let mut frame = alloc::vec![0; len];
-            let result = f(&mut frame);
-            if self.driver.try_raw_transmit(&frame).is_ok() {
-                if let Some(iface) = self.driver.iface() {
-                    crate::net::socket::packet::deliver_to_packet_sockets(
-                        &iface,
-                        &frame,
-                        crate::net::socket::packet::PacketType::Outgoing,
-                    );
-                }
-            }
-            return result;
-        }
-        let mut driver = self.driver.inner.lock_irqsave();
-        let mut tx_buf = driver.new_tx_buffer(len);
-        let result = f(tx_buf.packet_mut());
-        let tap_frame = self
-            .driver
-            .iface()
-            .filter(crate::net::socket::packet::packet_sockets_active)
-            .map(|iface| (iface, tx_buf.packet().to_vec()));
-        let _ = driver.send(tx_buf);
-        drop(driver);
-        if let Some((iface, frame)) = tap_frame {
-            crate::net::socket::packet::deliver_to_packet_sockets(
-                &iface,
-                &frame,
-                crate::net::socket::packet::PacketType::Outgoing,
-            );
-        }
-        self.driver.release_tx();
-        self.tx_reserved = false;
+        let buffer = self
+            .tx_buffer
+            .take()
+            .expect("virtio TxToken consumed without a reserved DMA slot");
+        let (result, _) = self.driver.submit_frame(buffer, len, f);
         result
     }
 }
@@ -735,7 +1095,6 @@ impl phy::RxToken for VirtioNetToken {
     where
         F: FnOnce(&[u8]) -> R,
     {
-        // 为了线程安全，这里需要对VirtioNet进行加【写锁】，以保证对设备的互斥访问。
         let rx_buf = self.rx_buffer.take().unwrap();
         let packet = rx_buf.packet();
 
@@ -746,20 +1105,22 @@ impl phy::RxToken for VirtioNetToken {
         }
 
         let result = f(packet);
-        self.driver
-            .inner
-            .lock_irqsave()
-            .recycle_rx_buffer(rx_buf)
-            .expect("virtio_net recv failed");
+        if let Err(err) = self.driver.inner.lock_irqsave().recycle_rx(rx_buf) {
+            error!("virtio-net failed to recycle RX buffer: {err:?}");
+        }
         result
     }
 }
 
 impl Drop for VirtioNetToken {
     fn drop(&mut self) {
-        if self.tx_reserved {
-            self.driver.release_tx();
-            self.tx_reserved = false;
+        if let Some(buffer) = self.tx_buffer.take() {
+            self.driver.inner.lock_irqsave().release_tx(buffer);
+        }
+        if let Some(buffer) = self.rx_buffer.take() {
+            if let Err(err) = self.driver.inner.lock_irqsave().recycle_rx(buffer) {
+                error!("virtio-net failed to recycle dropped RX token: {err:?}");
+            }
         }
     }
 }
@@ -808,26 +1169,93 @@ impl Iface for VirtioInterface {
     }
 
     fn poll(&self) -> bool {
-        // log::debug!("VirtioInterface: poll");
-        let mut device = self.device_inner.clone();
-        self.iface_common.poll(&mut device)
+        // External virtio-net interfaces have one data-plane owner: NAPI.
+        // Socket syscalls and the namespace timer poller only request work;
+        // they must not enter smoltcp/device polling concurrently on another CPU.
+        if let Some(napi) = self.napi_struct() {
+            napi_schedule(napi);
+        }
+        false
     }
 
-    fn poll_napi(&self, budget: usize) -> bool {
+    fn poll_napi(&self, budget: usize) -> super::napi::NapiPollResult {
         let mut device = self.device_inner.clone();
+        {
+            let mut driver = device.inner.lock_irqsave();
+            if let Err(err) = driver.reap_tx_completions() {
+                error!("virtio-net TX completion failed before NAPI poll: {err:?}");
+            }
+            if driver.poisoned {
+                // Return through the normal completion hook once so it can
+                // atomically move this NAPI instance to DISABLE. Continuing
+                // into smoltcp can otherwise report poll_at=Now forever while
+                // the failed device refuses every transmit reservation.
+                return super::napi::NapiPollResult::idle();
+            }
+        }
         self.iface_common.poll_napi(&mut device, budget)
     }
 
-    fn raw_transmit(&self, frame: &[u8]) -> Result<(), SystemError> {
-        self.device_inner.try_raw_transmit(frame)?;
-        if let Some(iface) = self.device_inner.iface() {
-            crate::net::socket::packet::deliver_to_packet_sockets(
-                &iface,
-                frame,
-                crate::net::socket::packet::PacketType::Outgoing,
-            );
+    fn napi_poll_begin(&self) {
+        let mut driver = self.device_inner.inner.lock_irqsave();
+        if !driver.poisoned {
+            driver.inner.disable_interrupts();
         }
-        Ok(())
+    }
+
+    fn napi_complete(&self, napi: Arc<NapiStruct>) {
+        let interrupt_state = {
+            let mut driver = self.device_inner.inner.lock_irqsave();
+            if driver.poisoned {
+                drop(driver);
+                napi_disable(&napi);
+                return;
+            }
+            driver.inner.enable_interrupts_prepare()
+        };
+
+        match napi_complete_state(&napi) {
+            CompleteState::Missed => {
+                self.device_inner
+                    .inner
+                    .lock_irqsave()
+                    .inner
+                    .disable_interrupts();
+                __napi_schedule(napi);
+            }
+            CompleteState::Completed => {
+                let mut acquired = false;
+                {
+                    let mut driver = self.device_inner.inner.lock_irqsave();
+                    let tx_completed = driver.reap_tx_completions().unwrap_or_else(|err| {
+                        error!("virtio-net TX completion failed during NAPI complete: {err:?}");
+                        0
+                    });
+                    let has_rx = driver.has_rx_completion().unwrap_or_else(|err| {
+                        error!(
+                            "virtio-net RX completion check failed during NAPI complete: {err:?}"
+                        );
+                        false
+                    });
+                    let has_work = driver.inner.interrupt_pending(interrupt_state)
+                        || tx_completed != 0
+                        || has_rx;
+                    if has_work && napi_schedule_prep(&napi) {
+                        driver.inner.disable_interrupts();
+                        acquired = true;
+                    }
+                }
+                if acquired {
+                    __napi_schedule(napi);
+                }
+            }
+        }
+    }
+
+    fn raw_transmit(&self, frame: &[u8]) -> Result<(), SystemError> {
+        // submit_frame() owns the outgoing packet-socket tap for all virtio
+        // transmit paths, including raw frames.
+        self.device_inner.try_raw_transmit(frame)
     }
 
     // fn as_any_ref(&'static self) -> &'static dyn core::any::Any {

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -1004,33 +1004,48 @@ impl VirtIONicDeviceInner {
     }
 }
 
-pub struct VirtioNetToken {
+pub struct VirtioNetRxToken {
     driver: VirtIONicDeviceInner,
     rx_buffer: Option<RxDmaBuffer>,
+}
+
+pub struct VirtioNetTxToken {
+    driver: VirtIONicDeviceInner,
     tx_buffer: Option<TxDmaBuffer>,
 }
 
-impl VirtioNetToken {
-    fn new(
-        driver: VirtIONicDeviceInner,
-        rx_buffer: Option<RxDmaBuffer>,
-        tx_buffer: Option<TxDmaBuffer>,
-    ) -> Self {
+impl VirtioNetRxToken {
+    fn new(driver: VirtIONicDeviceInner, rx_buffer: RxDmaBuffer) -> Self {
         Self {
             driver,
-            rx_buffer,
-            tx_buffer,
+            rx_buffer: Some(rx_buffer),
+        }
+    }
+}
+
+impl VirtioNetTxToken {
+    fn deferred(driver: VirtIONicDeviceInner) -> Self {
+        Self {
+            driver,
+            tx_buffer: None,
+        }
+    }
+
+    fn reserved(driver: VirtIONicDeviceInner, tx_buffer: TxDmaBuffer) -> Self {
+        Self {
+            driver,
+            tx_buffer: Some(tx_buffer),
         }
     }
 }
 
 impl phy::Device for VirtIONicDeviceInner {
     type RxToken<'a>
-        = VirtioNetToken
+        = VirtioNetRxToken
     where
         Self: 'a;
     type TxToken<'a>
-        = VirtioNetToken
+        = VirtioNetTxToken
     where
         Self: 'a;
 
@@ -1039,18 +1054,13 @@ impl phy::Device for VirtIONicDeviceInner {
         _timestamp: smoltcp::time::Instant,
     ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         let mut driver = self.inner.lock_irqsave();
-        let tx_buffer = driver.reserve_tx()?;
         match driver.receive() {
             Ok(Some(rx_buffer)) => Some((
-                VirtioNetToken::new(self.clone(), Some(rx_buffer), None),
-                VirtioNetToken::new(self.clone(), None, Some(tx_buffer)),
+                VirtioNetRxToken::new(self.clone(), rx_buffer),
+                VirtioNetTxToken::deferred(self.clone()),
             )),
-            Ok(None) => {
-                driver.release_tx(tx_buffer);
-                None
-            }
+            Ok(None) => None,
             Err(err) => {
-                driver.release_tx(tx_buffer);
                 error!("VirtIO receive failed: {err:?}");
                 None
             }
@@ -1059,7 +1069,7 @@ impl phy::Device for VirtIONicDeviceInner {
 
     fn transmit(&mut self, _timestamp: smoltcp::time::Instant) -> Option<Self::TxToken<'_>> {
         let buffer = self.inner.lock_irqsave().reserve_tx()?;
-        Some(VirtioNetToken::new(self.clone(), None, Some(buffer)))
+        Some(VirtioNetTxToken::reserved(self.clone(), buffer))
     }
 
     fn capabilities(&self) -> phy::DeviceCapabilities {
@@ -1076,21 +1086,28 @@ impl phy::Device for VirtIONicDeviceInner {
     }
 }
 
-impl phy::TxToken for VirtioNetToken {
+impl phy::TxToken for VirtioNetTxToken {
     fn consume<R, F>(mut self, len: usize, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R,
     {
-        let buffer = self
-            .tx_buffer
-            .take()
-            .expect("virtio TxToken consumed without a reserved DMA slot");
-        let (result, _) = self.driver.submit_frame(buffer, len, f);
+        if let Some(buffer) = self.tx_buffer.take() {
+            let (result, _) = self.driver.submit_frame(buffer, len, f);
+            return result;
+        }
+
+        // The token paired with an RX packet is intentionally lazy: RX must
+        // continue to make progress even while the TX queue is saturated.
+        // Allocate response storage only if smoltcp actually emits a reply,
+        // then make a best-effort reservation after the RX packet is consumed.
+        let mut frame = alloc::vec![0; len];
+        let result = f(&mut frame);
+        let _ = self.driver.try_raw_transmit(&frame);
         result
     }
 }
 
-impl phy::RxToken for VirtioNetToken {
+impl phy::RxToken for VirtioNetRxToken {
     fn consume<R, F>(mut self, f: F) -> R
     where
         F: FnOnce(&[u8]) -> R,
@@ -1112,15 +1129,20 @@ impl phy::RxToken for VirtioNetToken {
     }
 }
 
-impl Drop for VirtioNetToken {
+impl Drop for VirtioNetRxToken {
     fn drop(&mut self) {
-        if let Some(buffer) = self.tx_buffer.take() {
-            self.driver.inner.lock_irqsave().release_tx(buffer);
-        }
         if let Some(buffer) = self.rx_buffer.take() {
             if let Err(err) = self.driver.inner.lock_irqsave().recycle_rx(buffer) {
                 error!("virtio-net failed to recycle dropped RX token: {err:?}");
             }
+        }
+    }
+}
+
+impl Drop for VirtioNetTxToken {
+    fn drop(&mut self) {
+        if let Some(buffer) = self.tx_buffer.take() {
+            self.driver.inner.lock_irqsave().release_tx(buffer);
         }
     }
 }

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -69,9 +69,10 @@ static mut VIRTIO_NET_DRIVER: Option<Arc<VirtIONetDriver>> = None;
 const VIRTIO_NET_BASENAME: &str = "virtio_net";
 const VIRTIO_NET_QUEUE_SIZE: usize = 64;
 const VIRTIO_NET_BUFFER_SIZE: usize = 4096;
+const VIRTIO_NET_IP_MTU: usize = 1500;
 // smoltcp expects the complete Ethernet frame size here. Without
 // VIRTIO_NET_F_MTU, Linux exposes the standard 1500-byte IP MTU.
-const VIRTIO_NET_MAX_FRAME_SIZE: usize = 1500 + 14;
+const VIRTIO_NET_MAX_FRAME_SIZE: usize = VIRTIO_NET_IP_MTU + 14;
 const VIRTIO_NET_RX_QUEUE: u16 = 0;
 const VIRTIO_NET_TX_QUEUE: u16 = 1;
 
@@ -795,8 +796,6 @@ struct InnerVirtIOInterface {
 
 impl VirtioInterface {
     pub fn new(mut device_inner: VirtIONicDeviceInner) -> Arc<Self> {
-        use smoltcp::phy::Device;
-
         let iface_id = generate_iface_id();
         let mut iface_config = iface::Config::new(wire::HardwareAddress::Ethernet(
             wire::EthernetAddress(device_inner.inner.lock_irqsave().mac_address()),
@@ -811,8 +810,6 @@ impl VirtioInterface {
             | InterfaceFlags::MULTICAST
             | InterfaceFlags::LOWER_UP;
         let iface_name = format!("eth{}", iface_id);
-        let mtu = device_inner.capabilities().max_transmission_unit;
-
         let iface = Arc::new(VirtioInterface {
             device_inner,
             locked_kobj_state: LockedKObjectState::default(),
@@ -820,7 +817,7 @@ impl VirtioInterface {
                 iface_id,
                 crate::driver::net::types::InterfaceType::ETHER,
                 iface_name,
-                mtu,
+                VIRTIO_NET_IP_MTU,
                 flags,
                 iface,
             ),

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -104,6 +104,13 @@ pub struct FATFileSystem {
     root_inode: Arc<LockedFATInode>,
     /// FAT表查询缓存（LRU）
     fat_cache: Mutex<LruCache<ClusterID, ClusterID>>,
+    /// Serialize FAT chain allocation and release.
+    ///
+    /// Selecting a free cluster and publishing it in the FAT must be one
+    /// filesystem-wide transaction.  Per-inode locking is insufficient
+    /// because writeback for different files can run concurrently and select
+    /// the same free entry.  This mirrors Linux's `msdos_sb_info::fat_lock`.
+    fat_lock: Mutex<()>,
     /// 目录项扇区读-改-写串行化锁。
     ///
     /// FAT 的 `ShortDirEntry`/`LongDirEntry` 只占 32 字节，而底层 gendisk 的写入粒度是
@@ -772,6 +779,7 @@ impl FATFileSystem {
             fat_cache: Mutex::new(LruCache::new(
                 NonZeroUsize::new(FAT_LRU_CACHE_SIZE).unwrap(),
             )),
+            fat_lock: Mutex::new(()),
             dirent_io_lock: Mutex::new(()),
         });
 
@@ -1044,6 +1052,7 @@ impl FATFileSystem {
     /// @return Ok(Cluster) 新获取的空闲簇
     /// @return Err(SystemError) 错误码
     pub fn allocate_cluster(&self, prev_cluster: Option<Cluster>) -> Result<Cluster, SystemError> {
+        let _fat_guard = self.fat_lock.lock();
         let end_cluster: Cluster = self.max_cluster_number();
         let start_cluster: Cluster = match self.bpb.fat_type {
             FATType::FAT32(_) => {
@@ -1080,6 +1089,11 @@ impl FATFileSystem {
             // debug!("set entry, prev ={prev_cluster:?}, next = {free_cluster:?}");
             self.set_entry(prev_cluster, FATEntry::Next(free_cluster))?;
         }
+        // The cluster is now reserved and linked, so another allocator cannot
+        // select it.  Do not serialize data-area zeroing behind the FAT
+        // metadata lock; callers already hold the owning inode lock until this
+        // initialization completes.
+        drop(_fat_guard);
         // 清空新获取的这个簇
         self.zero_cluster(free_cluster)?;
         return Ok(free_cluster);
@@ -1089,17 +1103,15 @@ impl FATFileSystem {
     ///
     /// @param start_cluster 簇链的第一个簇
     pub fn deallocate_cluster_chain(&self, start_cluster: Cluster) -> Result<(), SystemError> {
+        let _fat_guard = self.fat_lock.lock();
         let clusters: Vec<Cluster> = self.clusters(start_cluster);
         for c in clusters {
-            self.deallocate_cluster(c)?;
+            self.deallocate_cluster_locked(c)?;
         }
         return Ok(());
     }
 
-    /// @brief 释放簇
-    ///
-    /// @param 要释放的簇
-    pub fn deallocate_cluster(&self, cluster: Cluster) -> Result<(), SystemError> {
+    fn deallocate_cluster_locked(&self, cluster: Cluster) -> Result<(), SystemError> {
         let entry: FATEntry = self.get_fat_entry(cluster)?;
         // 如果不是坏簇
         if entry != FATEntry::Bad {

--- a/kernel/src/filesystem/procfs/pid/fd.rs
+++ b/kernel/src/filesystem/procfs/pid/fd.rs
@@ -52,7 +52,15 @@ impl DirOps for FdDirOps {
 
         // 检查文件描述符是否存在，并立即释放fd_table锁
         {
-            let fd_table = process.fd_table();
+            // A process can become a zombie after ProcPidTarget resolved it.
+            // exit_files() has already removed its descriptor table in that
+            // state, so /proc/<pid>/fd must report a disappearing entry rather
+            // than calling ProcessControlBlock::fd_table(), which unwraps.
+            let fd_table = process
+                .basic()
+                .try_fd_table()
+                .clone()
+                .ok_or(SystemError::ESRCH)?;
             let fd_table_guard = fd_table.read();
 
             if fd_table_guard.get_file_by_fd(fd).is_none() {
@@ -83,8 +91,10 @@ impl DirOps for FdDirOps {
         // 获取进程的所有文件描述符
         if let Some(process) = self.get_process() {
             // 先收集所有的fd，避免在持有锁时做复杂操作
+            let Some(fd_table) = process.basic().try_fd_table().clone() else {
+                return;
+            };
             let fds: Vec<i32> = {
-                let fd_table = process.fd_table();
                 let fd_table_guard = fd_table.read();
                 fd_table_guard.iter().map(|(fd, _)| fd).collect()
             };
@@ -134,7 +144,11 @@ impl SymOps for FdSymOps {
         // 先获取文件对象的 clone，然后立即释放 fd_table 锁
         // 避免在持有锁时调用可能获取其他锁的方法（如 absolute_path）
         let file = {
-            let fd_table = process.fd_table();
+            let fd_table = process
+                .basic()
+                .try_fd_table()
+                .clone()
+                .ok_or(SystemError::ESRCH)?;
             let fd_table_guard = fd_table.read();
 
             fd_table_guard
@@ -194,7 +208,7 @@ impl SymOps for FdSymOps {
 
         // 获取文件对象
         let file = {
-            let fd_table = process.fd_table();
+            let fd_table = process.basic().try_fd_table().clone()?;
             let fd_table_guard = fd_table.read();
             fd_table_guard.get_file_by_fd(self.fd)?
         };

--- a/kernel/src/filesystem/procfs/pid/fd.rs
+++ b/kernel/src/filesystem/procfs/pid/fd.rs
@@ -48,7 +48,7 @@ impl DirOps for FdDirOps {
         let fd = name.parse::<i32>().map_err(|_| SystemError::ENOENT)?;
 
         // 获取进程引用
-        let process = self.get_process().ok_or(SystemError::ESRCH)?;
+        let process = self.get_process().ok_or(SystemError::ENOENT)?;
 
         // 检查文件描述符是否存在，并立即释放fd_table锁
         {
@@ -60,7 +60,7 @@ impl DirOps for FdDirOps {
                 .basic()
                 .try_fd_table()
                 .clone()
-                .ok_or(SystemError::ESRCH)?;
+                .ok_or(SystemError::ENOENT)?;
             let fd_table_guard = fd_table.read();
 
             if fd_table_guard.get_file_by_fd(fd).is_none() {
@@ -111,6 +111,10 @@ impl DirOps for FdDirOps {
         }
         // 写锁在这里自动释放
     }
+
+    fn validate_child(&self, child: &dyn IndexNode) -> bool {
+        child.special_node().is_some()
+    }
 }
 
 /// /proc/[pid]/fd/[fd] 符号链接的 SymOps 实现
@@ -139,7 +143,7 @@ impl SymOps for FdSymOps {
         let process = self
             .target
             .thread_group_leader()
-            .ok_or(SystemError::ESRCH)?;
+            .ok_or(SystemError::ENOENT)?;
 
         // 先获取文件对象的 clone，然后立即释放 fd_table 锁
         // 避免在持有锁时调用可能获取其他锁的方法（如 absolute_path）
@@ -148,18 +152,18 @@ impl SymOps for FdSymOps {
                 .basic()
                 .try_fd_table()
                 .clone()
-                .ok_or(SystemError::ESRCH)?;
+                .ok_or(SystemError::ENOENT)?;
             let fd_table_guard = fd_table.read();
 
             fd_table_guard
                 .get_file_by_fd(self.fd)
-                .ok_or(SystemError::EBADF)?
+                .ok_or(SystemError::ENOENT)?
         }; // fd_table 锁在这里被释放
 
         // 获取进程的 chroot 根路径
         let root_prefix = process
             .try_fs_struct()
-            .ok_or(SystemError::ESRCH)?
+            .ok_or(SystemError::ENOENT)?
             .root()
             .absolute_path()
             .unwrap_or_default();

--- a/kernel/src/filesystem/procfs/pid/fdinfo.rs
+++ b/kernel/src/filesystem/procfs/pid/fdinfo.rs
@@ -5,7 +5,7 @@
 use crate::filesystem::{
     procfs::{
         pid::ProcPidTarget,
-        template::{Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder},
+        template::{Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFile, ProcFileBuilder},
     },
     vfs::{FilePrivateData, IndexNode, InodeMode},
 };
@@ -47,7 +47,7 @@ impl DirOps for FdInfoDirOps {
         let fd = name.parse::<i32>().map_err(|_| SystemError::ENOENT)?;
 
         // 获取进程引用
-        let process = self.get_process().ok_or(SystemError::ESRCH)?;
+        let process = self.get_process().ok_or(SystemError::ENOENT)?;
 
         // 检查文件描述符是否存在
         {
@@ -58,7 +58,7 @@ impl DirOps for FdInfoDirOps {
                 .basic()
                 .try_fd_table()
                 .clone()
-                .ok_or(SystemError::ESRCH)?;
+                .ok_or(SystemError::ENOENT)?;
             let fd_table_guard = fd_table.read();
 
             if fd_table_guard.get_file_by_fd(fd).is_none() {
@@ -104,37 +104,54 @@ impl DirOps for FdInfoDirOps {
             }
         }
     }
+
+    fn validate_child(&self, child: &dyn IndexNode) -> bool {
+        child
+            .downcast_ref::<ProcFile<FdInfoFileOps>>()
+            .is_some_and(|file| file.ops().is_current())
+    }
 }
 
 /// /proc/[pid]/fdinfo/[fd] 文件的 FileOps 实现
 #[derive(Debug)]
 pub struct FdInfoFileOps {
-    /// 存储 PID，在需要时动态查找进程
-    // pid: RawPid,
-    // fd: i32,
-    // 暂时不用参数
-    phantom: core::marker::PhantomData<()>,
+    target: ProcPidTarget,
+    fd: i32,
 }
 
 impl FdInfoFileOps {
     pub fn new_inode(
-        _target: ProcPidTarget,
-        _fd: i32,
+        target: ProcPidTarget,
+        fd: i32,
         parent: Weak<dyn IndexNode>,
     ) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(
-            Self {
-                phantom: core::marker::PhantomData,
-            },
-            InodeMode::S_IRUGO,
-        )
-        .parent(parent)
-        .build()
-        .unwrap()
+        ProcFileBuilder::new(Self { target, fd }, InodeMode::S_IRUGO)
+            .parent(parent)
+            .build()
+            .unwrap()
+    }
+
+    fn is_current(&self) -> bool {
+        let Some(process) = self.target.thread_group_leader() else {
+            return false;
+        };
+        let Some(fd_table) = process.basic().try_fd_table().clone() else {
+            return false;
+        };
+        let fd_table_guard = fd_table.read();
+        fd_table_guard.get_file_by_fd(self.fd).is_some()
     }
 }
 
 impl FileOps for FdInfoFileOps {
+    fn open(&self, _data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        if self.is_current() {
+            Ok(())
+        } else {
+            Err(SystemError::ENOENT)
+        }
+    }
+
     fn read_at(
         &self,
         _offset: usize,
@@ -142,6 +159,10 @@ impl FileOps for FdInfoFileOps {
         _buf: &mut [u8],
         _data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
-        Ok(0)
+        if self.is_current() {
+            Ok(0)
+        } else {
+            Err(SystemError::ENOENT)
+        }
     }
 }

--- a/kernel/src/filesystem/procfs/pid/fdinfo.rs
+++ b/kernel/src/filesystem/procfs/pid/fdinfo.rs
@@ -51,7 +51,14 @@ impl DirOps for FdInfoDirOps {
 
         // 检查文件描述符是否存在
         {
-            let fd_table = process.fd_table();
+            // The process may have reached exit_files() after the proc target
+            // was resolved. A disappearing fd table is normal procfs churn,
+            // not an invariant which may be unwrapped.
+            let fd_table = process
+                .basic()
+                .try_fd_table()
+                .clone()
+                .ok_or(SystemError::ESRCH)?;
             let fd_table_guard = fd_table.read();
 
             if fd_table_guard.get_file_by_fd(fd).is_none() {
@@ -81,8 +88,10 @@ impl DirOps for FdInfoDirOps {
 
         // 获取进程的所有文件描述符
         if let Some(process) = self.get_process() {
+            let Some(fd_table) = process.basic().try_fd_table().clone() else {
+                return;
+            };
             let fds: Vec<i32> = {
-                let fd_table = process.fd_table();
                 let fd_table_guard = fd_table.read();
                 fd_table_guard.iter().map(|(fd, _)| fd).collect()
             };

--- a/kernel/src/filesystem/procfs/template/file.rs
+++ b/kernel/src/filesystem/procfs/template/file.rs
@@ -62,6 +62,10 @@ impl<F: FileOps> ProcFile<F> {
             common,
         })
     }
+
+    pub(crate) fn ops(&self) -> &F {
+        &self.inner
+    }
 }
 
 /// FileOps trait 定义了 procfs 文件需要实现的操作

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -3,12 +3,27 @@ use system_error::SystemError;
 
 use crate::{
     driver::net::Operstate,
-    process::namespace::net_namespace::INIT_NET_NAMESPACE,
+    process::{
+        kthread::{KernelThreadClosure, KernelThreadMechanism},
+        namespace::net_namespace::INIT_NET_NAMESPACE,
+    },
     time::{sleep::nanosleep, PosixTimeSpec},
 };
 
 pub fn net_init() -> Result<(), SystemError> {
-    dhcp_query()
+    KernelThreadMechanism::create_and_run(
+        KernelThreadClosure::StaticEmptyClosure((&(dhcp_worker as fn() -> i32), ())),
+        "dhcpv4".into(),
+    )
+    .ok_or(SystemError::EAGAIN_OR_EWOULDBLOCK)?;
+    Ok(())
+}
+
+fn dhcp_worker() -> i32 {
+    if let Err(err) = dhcp_query() {
+        log::warn!("DHCP worker stopped without a lease: {err:?}");
+    }
+    0
 }
 
 fn dhcp_query() -> Result<(), SystemError> {

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -44,7 +44,8 @@ fn dhcp_query() -> Result<(), SystemError> {
         sockets().remove(dhcp_handle);
     });
 
-    const DHCP_TRY_ROUND: u8 = 10;
+    const DHCP_RETRY_INTERVAL_NS: i64 = 50_000_000;
+    const DHCP_TRY_ROUND: u16 = 200;
     for i in 0..DHCP_TRY_ROUND {
         log::debug!("DHCP try round: {}", i);
         net_face.poll();
@@ -119,7 +120,7 @@ fn dhcp_query() -> Result<(), SystemError> {
 
         let sleep_time = PosixTimeSpec {
             tv_sec: 0,
-            tv_nsec: 50,
+            tv_nsec: DHCP_RETRY_INTERVAL_NS,
         };
         nanosleep(sleep_time)?;
     }

--- a/kernel/src/process/idle.rs
+++ b/kernel/src/process/idle.rs
@@ -70,6 +70,10 @@ impl ProcessManager {
             // 在双锁保护下设置 cpus_allowed 和 task_cpu
             pi_guard.set_cpus_allowed(CpuMask::from_cpu(ProcessorId::new(i)));
             idle_pcb.sched_info().set_on_cpu(Some(ProcessorId::new(i)));
+            assert!(
+                idle_pcb.sched_info().try_mark_running(),
+                "idle task must acquire its initial CPU ownership exactly once"
+            );
 
             rq.set_current(Arc::downgrade(&idle_pcb));
             rq.set_idle(Arc::downgrade(&idle_pcb));

--- a/kernel/src/process/manager/mod.rs
+++ b/kernel/src/process/manager/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         ucontext::AddressSpace,
     },
     process::{ProcessControlBlock, RawPid},
-    sched::{cpu_rq, enqueue_task_on_cpu, WakeupFlags},
+    sched::{cpu_rq, enqueue_task_on_cpu, select_task_rq, OnRq, WakeupFlags},
     smp::{core::smp_get_processor_id, cpu::ProcessorId, kick_cpu},
     syscall::user_access::write_one_to_user_protected,
 };
@@ -399,6 +399,12 @@ impl ProcessManager {
         prev_pcb.arch_info.force_unlock();
         fence(Ordering::SeqCst);
 
+        // The old CPU no longer uses prev_pcb's architecture context or
+        // kernel stack. Publish that fact only after releasing arch_info so a
+        // remote ttwu may safely enqueue and run the task on another CPU.
+        prev_pcb.sched_info().finish_running();
+        fence(Ordering::SeqCst);
+
         next_pcb.arch_info.force_unlock();
         fence(Ordering::SeqCst);
 
@@ -411,8 +417,27 @@ impl ProcessManager {
 
         if let Some(dest_cpu) = migrate_prev_to {
             debug_assert!(!Arc::ptr_eq(&prev_pcb, &next_pcb));
-            prev_pcb.sched_info().set_on_cpu(None);
-            enqueue_task_on_cpu(&prev_pcb, dest_cpu, WakeupFlags::WF_MIGRATED, false);
+            // The pending target may have been consumed by schedule just
+            // before a concurrent sched_setaffinity publishes a newer mask.
+            // Revalidate placement after switch-out, under pi_lock, and keep
+            // that lock through enqueue. A later affinity update will then
+            // either observe this legal placement or migrate it again.
+            let pi_guard = prev_pcb.sched_info().pi_lock_irqsave();
+            // stop_task() can win after schedule dequeues prev but before this
+            // tail obtains pi_lock. Likewise, wakeup_stop() can enqueue it
+            // after finish_running() and before this check. Only a still
+            // runnable, still off-rq task belongs to this migration owner;
+            // otherwise leave the stopped or already-enqueued state intact.
+            let still_owns_migration = prev_pcb.sched_info().state().is_runnable()
+                && *prev_pcb.sched_info().on_rq.lock_irqsave() == OnRq::None;
+            if still_owns_migration {
+                let allowed = pi_guard.cpus_allowed.clone();
+                let dest_cpu =
+                    select_task_rq(&prev_pcb, dest_cpu, WakeupFlags::WF_MIGRATED, &allowed);
+                prev_pcb.sched_info().set_on_cpu(None);
+                enqueue_task_on_cpu(&prev_pcb, dest_cpu, WakeupFlags::WF_MIGRATED, false);
+            }
+            drop(pi_guard);
         }
 
         let set_child_tid = next_pcb.thread.write_irqsave().set_child_tid.take();

--- a/kernel/src/process/manager/sched.rs
+++ b/kernel/src/process/manager/sched.rs
@@ -44,7 +44,6 @@ impl ProcessManager {
 
         pcb.debug_assert_fork_cpu_binding();
 
-        let mut schedule_dequeue_race = false;
         if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
             if let Some(target_cpu) = pcb.sched_info().on_cpu() {
                 let rq = cpu_rq(target_cpu.data() as usize);
@@ -61,24 +60,19 @@ impl ProcessManager {
                     }
                     return Ok(());
                 }
-
-                // DragonOS currently tracks task_cpu, but not Linux's
-                // separate p->on_cpu "still switching out" flag. If schedule()
-                // won the race and just dequeued this task, keep the wakeup on
-                // the previous rq instead of migrating it to another CPU where
-                // the same PCB/kernel stack could run before the old CPU
-                // finishes switch_process().
-                schedule_dequeue_race = true;
             }
         }
 
         let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        // Linux ttwu waits for p->on_cpu after observing an off-rq task. The
+        // old CPU may already have dequeued this task but still be executing
+        // switch_process() on its kernel stack. Enqueuing it remotely before
+        // the switch tail completes lets two CPUs restore and overwrite the
+        // same saved stack/context.
+        pcb.sched_info().wait_until_not_running();
+
         let allowed = pi_guard.cpus_allowed.clone();
-        let target_cpu = if schedule_dequeue_race {
-            prev_cpu
-        } else {
-            select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed)
-        };
+        let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
 
         if was_uninterruptible || pcb.flags().contains(ProcessFlags::IN_IOWAIT) {
             let prev_rq = cpu_rq(prev_cpu.data() as usize);
@@ -247,7 +241,7 @@ impl ProcessManager {
             };
         }
 
-        let _pi_guard = pcb.sched_info().pi_lock_irqsave();
+        let pi_guard = pcb.sched_info().pi_lock_irqsave();
         let state = pcb.sched_info().state();
         if !state.is_stopped() {
             return if state.is_runnable() {
@@ -260,37 +254,38 @@ impl ProcessManager {
         pcb.sched_info().set_state(ProcessState::Runnable);
         fence(Ordering::SeqCst);
 
-        // TODO: select_task_rq load balancing.
-        // let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(smp_get_processor_id());
-        // let allowed = pi_guard.cpus_allowed.clone();
-        // let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
-        let target_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
-        let update_clock = target_cpu == smp_get_processor_id();
-        let rq = cpu_rq(target_cpu.data() as usize);
-
-        let should_enqueue = {
+        let prev_cpu = pcb.sched_info().on_cpu().unwrap_or(current_cpu_id());
+        // A current task may be marked stopped and then resumed before its
+        // remote CPU reaches schedule(). It is still queued on prev_cpu in
+        // that window, so inspect and wake it under that rq lock; selecting a
+        // different rq first would attempt to dequeue it from the wrong queue.
+        if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
+            let rq = cpu_rq(prev_cpu.data() as usize);
             let (rq, _rq_guard) = rq.self_lock();
-            match *pcb.sched_info().on_rq.lock_irqsave() {
-                OnRq::Queued => {
-                    let is_current = Arc::ptr_eq(&rq.current(), pcb);
-                    if !is_current {
-                        if update_clock {
-                            rq.update_rq_clock();
-                            rq.check_preempt_current(pcb, WakeupFlags::empty());
-                        } else {
-                            rq.check_preempt_remote(pcb, WakeupFlags::empty());
-                        }
-                    } else if !update_clock {
-                        kick_cpu(target_cpu).ok();
+            if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued {
+                let local = prev_cpu == smp_get_processor_id();
+                if !Arc::ptr_eq(&rq.current(), pcb) {
+                    if local {
+                        rq.update_rq_clock();
+                        rq.check_preempt_current(pcb, WakeupFlags::WF_TTWU);
+                    } else {
+                        rq.check_preempt_remote(pcb, WakeupFlags::WF_TTWU);
                     }
-                    false
+                } else if !local {
+                    kick_cpu(prev_cpu).ok();
                 }
-                OnRq::None => true,
-                OnRq::Migrating => false,
+                return Ok(());
             }
-        };
+        }
 
-        if should_enqueue {
+        if *pcb.sched_info().on_rq.lock_irqsave() == OnRq::None {
+            // An off-rq stopped task retains its previous task_cpu for
+            // accounting, but sched_setaffinity may have changed its legal
+            // placement while it slept. Select again under pi_lock exactly
+            // like ordinary ttwu.
+            pcb.sched_info().wait_until_not_running();
+            let allowed = pi_guard.cpus_allowed.clone();
+            let target_cpu = select_task_rq(pcb, prev_cpu, WakeupFlags::WF_TTWU, &allowed);
             enqueue_task_on_cpu(pcb, target_cpu, WakeupFlags::empty(), false);
         }
 

--- a/kernel/src/process/sched_info.rs
+++ b/kernel/src/process/sched_info.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicI32, AtomicU32, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU8, Ordering};
 
 use alloc::sync::Arc;
 use system_error::SystemError;
@@ -17,8 +17,18 @@ use crate::{
 
 #[derive(Debug)]
 pub struct ProcessSchedulerInfo {
-    /// The CPU the current process is on.
+    /// Runqueue CPU assigned to this task (`task_cpu` in Linux terminology).
+    ///
+    /// This is deliberately not the same thing as `running`: a sleeping task
+    /// keeps its last runqueue CPU, and a task being switched out remains
+    /// physically executing for a short interval after it has left the rq.
     on_cpu: AtomicProcessorId,
+    /// Whether this task is currently executing or is still in the
+    /// switch-out tail on some CPU (`p->on_cpu` in Linux terminology).
+    ///
+    /// A remote wakeup must not enqueue an off-rq task on another CPU until
+    /// this becomes false, otherwise both CPUs can use the same kernel stack.
+    running: AtomicBool,
     /// If the current process is waiting to be migrated to another CPU core
     /// (i.e. PF_NEED_MIGRATE is set in flags), this field stores the target
     /// processor core number.
@@ -105,6 +115,7 @@ impl ProcessSchedulerInfo {
         let cpus_allowed = Self::default_cpus_allowed();
         return Self {
             on_cpu: AtomicProcessorId::new(cpu_id),
+            running: AtomicBool::new(false),
             migrate_to: AtomicProcessorId::new(ProcessorId::INVALID),
             state_atomic: AtomicU32::new(ProcessState::Blocked(false).to_u32()),
             pi_lock: SpinLock::new(PiProtected::new(cpus_allowed)),
@@ -140,6 +151,38 @@ impl ProcessSchedulerInfo {
             self.on_cpu.store(cpu_id, Ordering::SeqCst);
         } else {
             self.on_cpu.store(ProcessorId::INVALID, Ordering::SeqCst);
+        }
+    }
+
+    /// Publish that this task is about to become the current task.
+    ///
+    /// Returns false if another CPU still owns the task. Callers hold the
+    /// destination rq lock, so a false result is a scheduler invariant
+    /// violation rather than ordinary contention.
+    pub fn try_mark_running(&self) -> bool {
+        self.running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+    }
+
+    /// Publish completion of the switch-out tail.
+    ///
+    /// Release pairs with `wait_until_not_running()` in the remote wakeup
+    /// path, after the old CPU has stopped using the task's kernel stack and
+    /// released its saved architecture context.
+    pub fn finish_running(&self) {
+        let was_running = self.running.swap(false, Ordering::Release);
+        debug_assert!(was_running, "finishing a task which was not running");
+    }
+
+    /// Wait until a task which has already left its rq has fully switched out.
+    pub fn wait_until_not_running(&self) {
+        while self.running.load(Ordering::Acquire) {
+            core::hint::spin_loop();
         }
     }
 

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1208,14 +1208,11 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
                 "current task migration target {:?} must be online",
                 dest_cpu
             );
-            debug_assert!(
-                prev.sched_info()
-                    .cpus_allowed()
-                    .get(dest_cpu)
-                    .unwrap_or(false),
-                "current task migration target {:?} must be allowed by affinity",
-                dest_cpu
-            );
+            // Do not read cpus_allowed under rq_lock: sched_setaffinity uses
+            // pi_lock -> rq_lock. The switch tail, after releasing this rq,
+            // revalidates the destination under pi_lock immediately before
+            // enqueue and therefore closes concurrent affinity changes
+            // without introducing rq_lock -> pi_lock inversion here.
 
             rq.deactivate_task(
                 prev.clone(),
@@ -1247,6 +1244,10 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
     if likely(!Arc::ptr_eq(&prev, &next)) {
         crate::process::rseq::Rseq::on_preempt(&prev);
 
+        assert!(
+            next.sched_info().try_mark_running(),
+            "scheduler selected a task which is still running on another CPU"
+        );
         rq.set_current(Arc::downgrade(&next));
         compiler_fence(Ordering::SeqCst);
         account_context_switch();
@@ -1354,6 +1355,10 @@ pub fn enqueue_task_on_cpu(
     wake_flags: WakeupFlags,
     was_uninterruptible: bool,
 ) {
+    assert!(
+        !pcb.sched_info().is_running(),
+        "cannot enqueue a task before its previous switch-out completes"
+    );
     __set_task_cpu(pcb, target_cpu);
     pcb.sched_info().set_on_cpu(Some(target_cpu));
 
@@ -1425,6 +1430,7 @@ pub fn request_task_migration(
         pcb.sched_info().set_on_cpu(None);
         drop(_guard);
 
+        pcb.sched_info().wait_until_not_running();
         enqueue_task_on_cpu(pcb, dest_cpu, WakeupFlags::WF_MIGRATED, false);
         return Ok(());
     }

--- a/kernel/src/smp/syscall/sys_sched_setaffinity.rs
+++ b/kernel/src/smp/syscall/sys_sched_setaffinity.rs
@@ -6,7 +6,7 @@ use system_error::SystemError;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_SCHED_SETAFFINITY;
 use crate::libs::cpumask::CpuMask;
-use crate::process::{ProcessManager, RawPid};
+use crate::process::{ProcessFlags, ProcessManager, RawPid};
 use crate::sched::{
     request_task_migration, select_task_rq, syscall::util::has_sched_setaffinity_permission,
 };
@@ -57,13 +57,27 @@ impl Syscall for SysSchedSetaffinity {
             }
         }
 
-        {
-            let mut pi_guard = target_pcb.sched_info().pi_lock_irqsave();
-            pi_guard.set_cpus_allowed(mask.clone());
-        }
+        // Keep affinity publication and the corresponding placement decision
+        // in one pi_lock critical section. Otherwise two concurrent callers
+        // can publish masks in one order but execute their migrations in the
+        // opposite order.
+        let mut pi_guard = target_pcb.sched_info().pi_lock_irqsave();
+        pi_guard.set_cpus_allowed(mask.clone());
 
         if target_pcb.sched_info().is_new_task() {
             return Ok(0);
+        }
+
+        // A previous affinity request may have left a migration for a running
+        // task to be consumed in schedule tail. Do not let a newer mask retain
+        // an now-illegal destination.
+        if target_pcb
+            .sched_info()
+            .migrate_to()
+            .is_some_and(|cpu| !mask.get(cpu).unwrap_or(false))
+        {
+            target_pcb.sched_info().set_migrate_to(None);
+            target_pcb.flags().remove(ProcessFlags::NEED_MIGRATE);
         }
 
         if let Some(cpu) = target_pcb.sched_info().on_cpu() {

--- a/user/apps/tests/dunitest/no_skip.txt
+++ b/user/apps/tests/dunitest/no_skip.txt
@@ -4,3 +4,4 @@ normal/mount_propagation
 normal/mount_object_topology
 normal/mount_limit
 normal/open_dangling_symlink
+normal/rtnetlink_link_semantics

--- a/user/apps/tests/dunitest/runner/src/executor.rs
+++ b/user/apps/tests/dunitest/runner/src/executor.rs
@@ -283,7 +283,8 @@ fn parse_gtest_counts(log_path: &Path) -> Result<(usize, usize, usize, usize)> {
     for line in content.lines() {
         let s = line.trim();
 
-        if s.starts_with("[==========]") && s.contains(" tests from ") && s.contains(" ran.") {
+        let has_test_count = s.contains(" tests from ") || s.contains(" test from ");
+        if s.starts_with("[==========]") && has_test_count && s.contains(" ran.") {
             if let Some(v) = first_usize_token(s) {
                 total = v;
             }
@@ -742,6 +743,15 @@ exit 0
         let result = run_test(&spec, &results, false).unwrap();
 
         assert!(matches!(result.status, CaseStatus::Passed));
+        assert_eq!(
+            (
+                result.gtest_total,
+                result.gtest_passed,
+                result.gtest_failed,
+                result.gtest_skipped
+            ),
+            (1, 1, 0, 0)
+        );
         assert!(
             started.elapsed() < Duration::from_secs(10),
             "success path did not clean descendant pipe holders"

--- a/user/apps/tests/dunitest/suites/normal/fat_concurrent_allocation.cc
+++ b/user/apps/tests/dunitest/suites/normal/fat_concurrent_allocation.cc
@@ -1,0 +1,170 @@
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/statvfs.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr size_t kWorkers = 8;
+constexpr size_t kBlockSize = 4096;
+constexpr size_t kBlocksPerFile = 64;
+constexpr long kMsdosSuperMagic = 0x4d44;
+
+std::string TestPath(size_t worker) {
+  return "/fat-concurrent-allocation-" + std::to_string(getpid()) + "-" +
+         std::to_string(worker);
+}
+
+bool WriteAll(int fd, const uint8_t* data, size_t len) {
+  while (len != 0) {
+    const ssize_t written = write(fd, data, len);
+    if (written < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (written == 0) {
+      return false;
+    }
+    data += written;
+    len -= static_cast<size_t>(written);
+  }
+  return true;
+}
+
+bool ReadAllAt(int fd, uint8_t* data, size_t len, off_t offset) {
+  while (len != 0) {
+    const ssize_t bytes_read = pread(fd, data, len, offset);
+    if (bytes_read < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (bytes_read == 0) {
+      errno = EIO;
+      return false;
+    }
+    data += bytes_read;
+    len -= static_cast<size_t>(bytes_read);
+    offset += bytes_read;
+  }
+  return true;
+}
+
+class TestFiles {
+ public:
+  TestFiles() { fds.fill(-1); }
+
+  ~TestFiles() {
+    for (size_t worker = 0; worker < kWorkers; ++worker) {
+      if (fds[worker] >= 0) {
+        close(fds[worker]);
+      }
+      unlink(TestPath(worker).c_str());
+    }
+  }
+
+  std::array<int, kWorkers> fds;
+};
+
+TEST(FatConcurrentAllocation, ParallelGrowthKeepsClusterChainsIndependent) {
+  struct statfs fs_type {};
+  ASSERT_EQ(0, statfs("/", &fs_type)) << strerror(errno);
+  if (fs_type.f_type != kMsdosSuperMagic) {
+    GTEST_SKIP() << "root filesystem is not FAT";
+  }
+
+  struct statvfs space {};
+  ASSERT_EQ(0, statvfs("/", &space)) << strerror(errno);
+  const uint64_t required =
+      kWorkers * kBlockSize * kBlocksPerFile + 1024 * 1024;
+  if (space.f_bavail * space.f_frsize < required) {
+    GTEST_SKIP() << "insufficient free FAT space for allocation stress";
+  }
+
+  TestFiles files;
+  for (size_t worker = 0; worker < kWorkers; ++worker) {
+    const std::string path = TestPath(worker);
+    unlink(path.c_str());
+    files.fds[worker] = open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
+    ASSERT_GE(files.fds[worker], 0) << path << ": " << strerror(errno);
+  }
+
+  std::atomic<size_t> ready{0};
+  std::atomic<bool> start{false};
+  std::array<int, kWorkers> worker_errno{};
+  std::vector<std::thread> threads;
+  threads.reserve(kWorkers);
+  for (size_t worker = 0; worker < kWorkers; ++worker) {
+    threads.emplace_back([&, worker] {
+      const uint8_t fill = static_cast<uint8_t>(0x31 + worker);
+      std::array<uint8_t, kBlockSize> block{};
+      block.fill(fill);
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      for (size_t block_index = 0; block_index < kBlocksPerFile;
+           ++block_index) {
+        if (!WriteAll(files.fds[worker], block.data(), block.size())) {
+          worker_errno[worker] = errno == 0 ? EIO : errno;
+          return;
+        }
+      }
+      if (fsync(files.fds[worker]) != 0) {
+        worker_errno[worker] = errno;
+      }
+    });
+  }
+
+  while (ready.load(std::memory_order_acquire) != kWorkers) {
+    std::this_thread::yield();
+  }
+  start.store(true, std::memory_order_release);
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  std::array<uint8_t, kBlockSize> block{};
+  for (size_t worker = 0; worker < kWorkers; ++worker) {
+    ASSERT_EQ(0, worker_errno[worker])
+        << TestPath(worker) << ": " << strerror(worker_errno[worker]);
+    const uint8_t expected = static_cast<uint8_t>(0x31 + worker);
+    for (size_t block_index = 0; block_index < kBlocksPerFile;
+         ++block_index) {
+      const off_t offset = static_cast<off_t>(block_index * kBlockSize);
+      ASSERT_TRUE(
+          ReadAllAt(files.fds[worker], block.data(), block.size(), offset))
+          << TestPath(worker) << " block " << block_index << ": "
+          << strerror(errno);
+      ASSERT_TRUE(std::all_of(block.begin(), block.end(),
+                              [expected](uint8_t value) {
+                                return value == expected;
+                              }))
+          << TestPath(worker) << " block " << block_index;
+    }
+    ASSERT_EQ(0, close(files.fds[worker])) << strerror(errno);
+    files.fds[worker] = -1;
+    ASSERT_EQ(0, unlink(TestPath(worker).c_str())) << strerror(errno);
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
@@ -31,6 +31,15 @@ bool read_text_file(const char* path, std::string* out) {
     return n >= 0;
 }
 
+bool wait_for_zombie(pid_t child) {
+    siginfo_t info = {};
+    int result = -1;
+    do {
+        result = waitid(P_PID, child, &info, WEXITED | WNOWAIT);
+    } while (result < 0 && errno == EINTR);
+    return result == 0 && info.si_pid == child;
+}
+
 pid_t fork_waiting_child(int* release_fd) {
     int pipefd[2] = {-1, -1};
     if (pipe(pipefd) != 0) {
@@ -114,6 +123,59 @@ TEST(ProcPidReuseCache, NumericProcDirRefreshesAfterPidReuse) {
     EXPECT_NE(std::string::npos, status.find(pid_line)) << status_path << " content:\n" << status;
 
     release_child(reused, reused_release);
+}
+
+TEST(ProcPidReuseCache, ZombieFdEntriesDisappearWithEnoent) {
+    int release_fd = -1;
+    const pid_t child = fork_waiting_child(&release_fd);
+    ASSERT_GT(child, 0);
+
+    char fd_path[64] = {};
+    snprintf(fd_path, sizeof(fd_path), "/proc/%d/fd/0", child);
+    char link_target[64] = {};
+    EXPECT_GE(readlink(fd_path, link_target, sizeof(link_target)), 0);
+
+    char fdinfo_path[64] = {};
+    snprintf(fdinfo_path, sizeof(fdinfo_path), "/proc/%d/fdinfo/0", child);
+    const int live_fdinfo = open(fdinfo_path, O_RDONLY);
+    EXPECT_GE(live_fdinfo, 0);
+
+    const char byte = 'x';
+    EXPECT_EQ(1, write(release_fd, &byte, 1));
+    close(release_fd);
+
+    const bool became_zombie = wait_for_zombie(child);
+    if (became_zombie) {
+        errno = 0;
+        EXPECT_EQ(-1, readlink(fd_path, link_target, sizeof(link_target)));
+        EXPECT_EQ(ENOENT, errno);
+
+        errno = 0;
+        const int fdinfo = open(fdinfo_path, O_RDONLY);
+        EXPECT_EQ(-1, fdinfo);
+        EXPECT_EQ(ENOENT, errno);
+        if (fdinfo >= 0) {
+            close(fdinfo);
+        }
+
+        if (live_fdinfo >= 0) {
+            char byte = {};
+            errno = 0;
+            EXPECT_EQ(-1, read(live_fdinfo, &byte, sizeof(byte)));
+            EXPECT_EQ(ENOENT, errno);
+        }
+    }
+    if (live_fdinfo >= 0) {
+        close(live_fdinfo);
+    }
+
+    int status = 0;
+    pid_t waited = -1;
+    do {
+        waited = waitpid(child, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    EXPECT_EQ(child, waited);
+    ASSERT_TRUE(became_zombie) << "child did not become observable as a zombie";
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <linux/if_link.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+
+namespace {
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    ~FdGuard() {
+        if (fd_ >= 0) close(fd_);
+    }
+
+    int Get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+std::optional<int> FindEthernetIfindex() {
+    FdGuard fd(socket(AF_INET, SOCK_DGRAM, 0));
+    if (fd.Get() < 0) return std::nullopt;
+
+    for (int i = 0; i <= 20; ++i) {
+        const std::string name = "eth" + std::to_string(i);
+        ifreq ifr{};
+        std::strncpy(ifr.ifr_name, name.c_str(), IFNAMSIZ - 1);
+        if (ioctl(fd.Get(), SIOCGIFINDEX, &ifr) == 0) return ifr.ifr_ifindex;
+    }
+    return std::nullopt;
+}
+
+std::optional<uint32_t> QueryLinkMtu(int ifindex) {
+    FdGuard fd(socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE));
+    if (fd.Get() < 0) return std::nullopt;
+
+    sockaddr_nl address{};
+    address.nl_family = AF_NETLINK;
+    if (bind(fd.Get(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) < 0) {
+        return std::nullopt;
+    }
+
+    struct {
+        nlmsghdr header;
+        ifinfomsg link;
+    } request{};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(ifinfomsg));
+    request.header.nlmsg_type = RTM_GETLINK;
+    request.header.nlmsg_flags = NLM_F_REQUEST;
+    request.header.nlmsg_seq = 1;
+    request.link.ifi_family = AF_UNSPEC;
+    request.link.ifi_index = ifindex;
+
+    if (send(fd.Get(), &request, request.header.nlmsg_len, 0) < 0) return std::nullopt;
+
+    char buffer[4096]{};
+    for (;;) {
+        ssize_t length = recv(fd.Get(), buffer, sizeof(buffer), 0);
+        if (length < 0) return std::nullopt;
+
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer); NLMSG_OK(header, length);
+             header = NLMSG_NEXT(header, length)) {
+            if (header->nlmsg_seq != request.header.nlmsg_seq) continue;
+            if (header->nlmsg_type == NLMSG_ERROR || header->nlmsg_type == NLMSG_DONE) {
+                return std::nullopt;
+            }
+            if (header->nlmsg_type != RTM_NEWLINK) continue;
+
+            const auto* link = reinterpret_cast<const ifinfomsg*>(NLMSG_DATA(header));
+            if (link->ifi_index != ifindex) continue;
+
+            int attr_length = IFLA_PAYLOAD(header);
+            for (auto* attr = IFLA_RTA(link); RTA_OK(attr, attr_length);
+                 attr = RTA_NEXT(attr, attr_length)) {
+                if (attr->rta_type != IFLA_MTU || RTA_PAYLOAD(attr) != sizeof(uint32_t)) {
+                    continue;
+                }
+                uint32_t mtu = 0;
+                std::memcpy(&mtu, RTA_DATA(attr), sizeof(mtu));
+                return mtu;
+            }
+            return std::nullopt;
+        }
+    }
+}
+
+TEST(RtnetlinkLinkSemantics, VirtioEthernetReportsStandardIpMtu) {
+    const auto ifindex = FindEthernetIfindex();
+    if (!ifindex.has_value()) GTEST_SKIP() << "No eth0-eth20 interface found";
+
+    const auto mtu = QueryLinkMtu(*ifindex);
+    ASSERT_TRUE(mtu.has_value()) << "RTM_GETLINK did not return IFLA_MTU: errno=" << errno
+                                << " (" << std::strerror(errno) << ")";
+    EXPECT_EQ(*mtu, 1500U);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -85,3 +85,4 @@ normal/virtiofs_dax
 normal/af_packet_sockopt
 normal/af_packet_e2e
 normal/af_packet_mcast
+normal/rtnetlink_link_semantics

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -7,6 +7,7 @@ normal/getrandom_bit_distribution
 normal/ext4_xattr
 normal/ext4_inode_identity
 normal/fat_statfs
+normal/fat_concurrent_allocation
 normal/fallocate_semantics
 normal/syncfs_semantics
 normal/fcntl_lock


### PR DESCRIPTION
## Summary

- replace duplicate-prone NAPI scheduling with an exact-once `SCHED`/`MISSED` state machine and bounded, fair polling
- move virtio-net to Q64 raw queues with preallocated DMA slots, asynchronous TX completion, and race-closing EVENT_IDX notification handling
- prevent the same task from running or being enqueued on two CPUs during remote wakeups, stop/resume, affinity changes, and migration tails
- batch ext4 sequential range allocation and orphan extent reclamation while preserving journal credits, checksums, and initialized-before-published block ordering
- avoid read-before-write I/O for complete ext4 blocks and handle disappearing proc fd tables without panicking
- pin the merged virtio-drivers queue fixes from the DragonOS mirror

## Root cause

The observed `apt update` stalls were produced by several interacting bottlenecks and correctness gaps:

- virtio-net used two-descriptor RX and TX rings, while each TX packet synchronously waited for completion
- NAPI could enqueue the same instance more than once and did not close the callback-enable race
- remote network wakeups could enqueue a task before its previous CPU completed switch-out
- apt package-store writes caused ext4 to allocate and journal missing blocks one at a time, and interrupted-download cleanup committed each tail extent separately
- proc fd traversal could race process exit and unwrap an already removed descriptor table

Together these issues amplified interrupt, scheduler, and synchronous metadata costs into low throughput, long cleanup delays, and occasional kernel instability.

## Implementation

### Network data path

- add a host-testable atomic NAPI transition crate
- use FIFO scheduling with packet, poll-call, and elapsed-time budgets
- keep RX/TX callback state paired with NAPI ownership
- preallocate page-backed RX/TX DMA slots and recycle completions asynchronously
- fail-stop on queue-accounting or malformed completion invariants

### Scheduler

- track actual CPU execution ownership independently from runqueue placement
- wait for switch-out completion before remote enqueue
- serialize stop wakeups and affinity placement under the scheduler placement locks
- revalidate pending migration state, affinity, and runqueue ownership in the switch tail

### Filesystem and procfs

- allocate contiguous append ranges in one ext4 transaction
- support journaled appends to the right-most external extent leaf
- reserve transaction credits before batched tail reclamation
- batch same-group orphan extent cleanup
- write complete blocks without a preceding read
- treat missing fd/fdinfo tables as normal process-exit races

## Validation

- `cargo test -p napi-state`: 7 passed
- `cargo test -p another_ext4`: 131 passed
- virtio-drivers: 27 unit tests and 8 doctests passed before pinning the merged revision
- `make kernel`: passed against the pinned mirror revision
- QEMU fresh `apt update`: completed a 31.6 MB refresh without a hash mismatch
- interrupted partial download: resumed from the previous offset
- fragmented partial-file cleanup: reduced from minutes to a fraction of a second

## Remaining scope

This change removes the confirmed correctness failures and synchronous-I/O amplification. Full Linux-style ext4 delayed allocation and writeback-time allocation remain separate future performance work.
