### PR TITLE
fix(ext4): eliminate delayed allocation retry storms

### DIFF
--- a/kernel/crates/another_ext4/src/ext4/journal.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal.rs
@@ -206,11 +206,12 @@ impl Ext4 {
         &self,
         credits: usize,
     ) -> Result<journal_transaction::Transaction<'_>> {
-        match &self.metadata_mode {
+        let result = match &self.metadata_mode {
             MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
             MetadataMutationMode::Journal(core) => core.start(credits),
             MetadataMutationMode::Direct(core) => core.start(credits),
-        }
+        };
+        self.normalize_transaction_start(result)
     }
 
     pub(super) fn transaction_credits_fit(&self, credits: usize) -> Result<bool> {
@@ -225,10 +226,32 @@ impl Ext4 {
         &self,
         credits: usize,
     ) -> Result<journal_transaction::Transaction<'_>> {
-        match &self.metadata_mode {
+        let result = match &self.metadata_mode {
             MetadataMutationMode::Direct(core) => core.start_direct_range(credits),
             MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
             MetadataMutationMode::Journal(_) => Err(Ext4Error::new(ErrCode::ENOTSUP)),
+        };
+        self.normalize_transaction_start(result)
+    }
+
+    fn normalize_transaction_start<'a>(
+        &self,
+        result: Result<journal_transaction::Transaction<'a>>,
+    ) -> Result<journal_transaction::Transaction<'a>> {
+        match result {
+            // Every production transaction start is protected either by the
+            // exclusive metadata gate or by unpublished single-threaded mount
+            // recovery. A busy raw core therefore means the ownership
+            // invariant is already broken; retrying it through the upper
+            // generation bridge would create a self-waking hot loop.
+            Err(error) if error.code() == ErrCode::EAGAIN => {
+                log::error!(
+                    "ext4 transaction core is busy behind the metadata gate; fail-stopping"
+                );
+                self.poison(ErrCode::EIO);
+                Err(Ext4Error::new(ErrCode::EIO))
+            }
+            result => result,
         }
     }
 

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -18,6 +18,7 @@ use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 const CLEAN: u8 = 0;
 const POISONED: u8 = 1;
+const MAX_COALESCED_WRITE_BLOCKS: usize = 64;
 
 /// A fully validated journal mapping and its current allocation cursor.
 ///
@@ -48,11 +49,9 @@ impl JournalContext {
         {
             return Err(Ext4Error::new(ErrCode::ENOTSUP));
         }
-        if self
-            .logical_blocks
-            .iter()
-            .any(|block| *block == 0 || !self.journal_blocks.contains(block))
-        {
+        if self.logical_blocks.iter().any(|block| {
+            *block == 0 || *block >= self.target_blocks || !self.journal_blocks.contains(block)
+        }) {
             return Err(Ext4Error::new(ErrCode::EIO));
         }
         Ok(())
@@ -619,6 +618,26 @@ impl Transaction<'_> {
                 poisoned: false,
             }
         })?;
+        let scratch_blocks = encoded
+            .len()
+            .max(self.staged.len())
+            .min(MAX_COALESCED_WRITE_BLOCKS);
+        let scratch_capacity =
+            scratch_blocks
+                .checked_mul(BLOCK_SIZE)
+                .ok_or_else(|| CommitError {
+                    error: Ext4Error::new(ErrCode::E2BIG),
+                    failure: CommitFailure::BeforeCommit,
+                    poisoned: false,
+                })?;
+        let mut write_scratch = Vec::new();
+        write_scratch
+            .try_reserve_exact(scratch_capacity)
+            .map_err(|_| CommitError {
+                error: Ext4Error::new(ErrCode::ENOMEM),
+                failure: CommitFailure::BeforeCommit,
+                poisoned: false,
+            })?;
 
         // Publish an active tail before log payload.  Recovery may safely scan
         // an empty/uncommitted transaction after a crash at this point.
@@ -629,10 +648,31 @@ impl Transaction<'_> {
         }
 
         debug_assert_eq!(encoded.len() + 1, positions.len());
-        for (logical, bytes) in positions[..encoded.len()].iter().zip(encoded.iter()) {
-            if let Err(error) = write_bytes(device, mapping[*logical as usize], bytes) {
+        // A logical ring wrap is a recovery boundary for run construction even
+        // when its physical mapping happens to be contiguous. Within each
+        // logical segment, coalesce only physically contiguous journal blocks.
+        let mut segment_start = 0;
+        for segment_end in 1..=encoded.len() {
+            let segment_complete = segment_end == encoded.len()
+                || positions[segment_end - 1].checked_add(1) != Some(positions[segment_end]);
+            if !segment_complete {
+                continue;
+            }
+            let blocks = positions[segment_start..segment_end]
+                .iter()
+                .zip(encoded[segment_start..segment_end].iter())
+                .map(|(logical, bytes)| {
+                    (
+                        mapping[*logical as usize],
+                        bytes.as_ref() as &[u8; BLOCK_SIZE],
+                    )
+                });
+            if let Err(error) =
+                write_contiguous_blocks(device, blocks, &mut write_scratch, scratch_blocks)
+            {
                 return self.fail(error, CommitFailure::BeforeCommit, true);
             }
+            segment_start = segment_end;
         }
         if let Err(error) = device.flush() {
             return self.fail(error, CommitFailure::BeforeCommit, true);
@@ -646,10 +686,14 @@ impl Transaction<'_> {
             return self.fail(error, CommitFailure::CommitUncertain, true);
         }
 
-        for staged in self.staged.values() {
-            if let Err(error) = write_bytes(device, staged.home, staged.bytes()) {
-                return self.fail(error, CommitFailure::CheckpointFailed, true);
-            }
+        let home_blocks = self
+            .staged
+            .values()
+            .map(|staged| (staged.home, staged.bytes()));
+        if let Err(error) =
+            write_contiguous_blocks(device, home_blocks, &mut write_scratch, scratch_blocks)
+        {
+            return self.fail(error, CommitFailure::CheckpointFailed, true);
         }
         if let Err(error) = device.flush() {
             return self.fail(error, CommitFailure::CheckpointFailed, true);
@@ -895,6 +939,43 @@ fn write_bytes(device: &dyn BlockDevice, id: PBlockId, bytes: &[u8; BLOCK_SIZE])
     device.write_block(&Block::new(id, Box::new(*bytes)))
 }
 
+fn write_contiguous_blocks<'a>(
+    device: &dyn BlockDevice,
+    blocks: impl IntoIterator<Item = (PBlockId, &'a [u8; BLOCK_SIZE])>,
+    scratch: &mut Vec<u8>,
+    max_blocks: usize,
+) -> Result<()> {
+    debug_assert!(
+        max_blocks <= MAX_COALESCED_WRITE_BLOCKS && scratch.capacity() >= max_blocks * BLOCK_SIZE,
+        "journal write scratch must be reserved before the active tail"
+    );
+    scratch.clear();
+    let mut first: Option<PBlockId> = None;
+    let mut previous: Option<PBlockId> = None;
+
+    for (physical, image) in blocks {
+        let at_capacity = scratch.len() == max_blocks * BLOCK_SIZE;
+        let contiguous = previous.and_then(|previous| previous.checked_add(1)) == Some(physical);
+        if !scratch.is_empty() && (at_capacity || !contiguous) {
+            device.write_blocks(first.expect("non-empty run has a first block"), scratch)?;
+            scratch.clear();
+            first = None;
+        }
+        if first.is_none() {
+            first = Some(physical);
+        }
+        debug_assert!(scratch.len() + BLOCK_SIZE <= scratch.capacity());
+        scratch.extend_from_slice(image);
+        previous = Some(physical);
+    }
+
+    if !scratch.is_empty() {
+        device.write_blocks(first.expect("non-empty run has a first block"), scratch)?;
+        scratch.clear();
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -910,6 +991,10 @@ mod tests {
         fail_at: AtomicUsize,
         fail_at_second: AtomicUsize,
         write_order: spin::Mutex<Vec<PBlockId>>,
+        bulk_writes: spin::Mutex<Vec<(PBlockId, usize)>>,
+        bulk_calls: AtomicUsize,
+        partial_bulk_call: AtomicUsize,
+        partial_bulk_prefix: AtomicUsize,
         reads: AtomicUsize,
         writes: AtomicUsize,
         flushes: AtomicUsize,
@@ -924,6 +1009,10 @@ mod tests {
                 fail_at: AtomicUsize::new(usize::MAX),
                 fail_at_second: AtomicUsize::new(usize::MAX),
                 write_order: spin::Mutex::new(Vec::new()),
+                bulk_writes: spin::Mutex::new(Vec::new()),
+                bulk_calls: AtomicUsize::new(0),
+                partial_bulk_call: AtomicUsize::new(usize::MAX),
+                partial_bulk_prefix: AtomicUsize::new(usize::MAX),
                 reads: AtomicUsize::new(0),
                 writes: AtomicUsize::new(0),
                 flushes: AtomicUsize::new(0),
@@ -969,6 +1058,41 @@ mod tests {
             self.step()?;
             self.write_order.lock().push(block.id);
             self.volatile.lock().insert(block.id, block.data.clone());
+            Ok(())
+        }
+
+        fn write_blocks(&self, start: PBlockId, data: &[u8]) -> Result<()> {
+            if data.is_empty() || !data.len().is_multiple_of(BLOCK_SIZE) {
+                return Err(Ext4Error::new(ErrCode::EINVAL));
+            }
+            let blocks = data.len() / BLOCK_SIZE;
+            let call = self.bulk_calls.fetch_add(1, Ordering::SeqCst);
+            self.bulk_writes.lock().push((start, blocks));
+            let partial = call == self.partial_bulk_call.load(Ordering::SeqCst);
+            let prefix = self.partial_bulk_prefix.load(Ordering::SeqCst);
+
+            for (index, bytes) in data.chunks_exact(BLOCK_SIZE).enumerate() {
+                if partial && index == prefix {
+                    return Err(Ext4Error::new(ErrCode::EIO));
+                }
+                let id = start
+                    .checked_add(index as PBlockId)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+                let mut image = Box::new([0; BLOCK_SIZE]);
+                image.copy_from_slice(bytes);
+                self.write_block(&Block::new(id, image))?;
+                if partial {
+                    // A failed multi-block request does not promise that its
+                    // completed prefix remained only in volatile cache.
+                    // Persist the prefix to model the conservative recovery
+                    // case required from a real block device after EIO.
+                    let stable_image = self.volatile.lock()[&id].clone();
+                    self.stable.lock().insert(id, stable_image);
+                }
+            }
+            if partial && prefix >= blocks {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
             Ok(())
         }
 
@@ -1340,7 +1464,23 @@ mod tests {
         }
     }
 
-    fn assert_counted_commit_shape(homes: usize, expected_reads: usize, expected_writes: usize) {
+    fn context_with_fragmented_log() -> JournalContext {
+        let mut context = context_with_ring(TEST_LARGE_JOURNAL_BLOCKS, 1);
+        let mut mapping = context.logical_blocks.to_vec();
+        for (logical, physical) in mapping.iter_mut().enumerate().skip(1) {
+            *physical = 200 + logical as PBlockId * 2;
+        }
+        context.journal_blocks = Arc::new(mapping.iter().copied().collect());
+        context.logical_blocks = mapping.into();
+        context
+    }
+
+    fn assert_counted_commit_shape(
+        homes: usize,
+        expected_reads: usize,
+        expected_writes: usize,
+        expected_bulk_writes: &[(PBlockId, usize)],
+    ) {
         let device = MemoryDevice::new();
         let publisher = Publisher(AtomicUsize::new(0));
         let core = JournalTransactionCore::new(context_with_ring(
@@ -1358,18 +1498,123 @@ mod tests {
         assert_eq!(device.reads.load(Ordering::SeqCst), expected_reads);
         assert_eq!(device.writes.load(Ordering::SeqCst), expected_writes);
         assert_eq!(device.flushes.load(Ordering::SeqCst), 5);
+        assert_eq!(&*device.bulk_writes.lock(), expected_bulk_writes);
         assert_eq!(publisher.0.load(Ordering::SeqCst), homes);
         assert!(!core.is_poisoned());
     }
 
     #[test]
     fn journal_commit_four_homes_has_expected_fixed_io_shape() {
-        assert_counted_commit_shape(4, 6, 12);
+        assert_counted_commit_shape(4, 6, 12, &[(163, 1), (101, 4), (42, 4)]);
     }
 
     #[test]
     fn journal_commit_max_fast_metadata_images_has_expected_fixed_io_shape() {
-        assert_counted_commit_shape(TEST_MAX_FAST_METADATA_IMAGES, 18, 36);
+        assert_counted_commit_shape(
+            TEST_MAX_FAST_METADATA_IMAGES,
+            18,
+            36,
+            &[(163, 1), (101, 16), (42, 16)],
+        );
+    }
+
+    #[test]
+    fn journal_commit_splits_physically_fragmented_log_runs() {
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let core = JournalTransactionCore::new(context_with_fragmented_log()).unwrap();
+
+        staged_journal_transaction(&core, 4)
+            .commit(&device, &publisher)
+            .unwrap();
+
+        assert_eq!(
+            &*device.bulk_writes.lock(),
+            &[(202, 1), (204, 1), (206, 1), (208, 1), (210, 1), (42, 4)]
+        );
+        assert_eq!(device.flushes.load(Ordering::SeqCst), 5);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn journal_core_rejects_out_of_range_mapping_at_construction() {
+        let mut context = context_with_ring(TEST_LARGE_JOURNAL_BLOCKS, 1);
+        let mut mapping = context.logical_blocks.to_vec();
+        mapping[2] = context.target_blocks;
+        context.journal_blocks = Arc::new(mapping.iter().copied().collect());
+        context.logical_blocks = mapping.into();
+
+        let error = JournalTransactionCore::new(context).err().unwrap();
+        assert_eq!(error.code(), ErrCode::EIO);
+    }
+
+    fn staged_journal_transaction<'a>(
+        core: &'a JournalTransactionCore,
+        homes: usize,
+    ) -> Transaction<'a> {
+        let mut transaction = core.start(homes).unwrap();
+        for home in 42..42 + homes as PBlockId {
+            transaction
+                .stage(home, Box::new([home as u8; BLOCK_SIZE]))
+                .unwrap();
+        }
+        transaction
+    }
+
+    #[test]
+    fn journal_bulk_log_partial_failure_never_publishes() {
+        for prefix in [0, 1, 2, 4] {
+            let device = MemoryDevice::new();
+            device.partial_bulk_call.store(0, Ordering::SeqCst);
+            device.partial_bulk_prefix.store(prefix, Ordering::SeqCst);
+            let core = JournalTransactionCore::new(context_with_ring(TEST_LARGE_JOURNAL_BLOCKS, 1))
+                .unwrap();
+            let publisher = Publisher(AtomicUsize::new(0));
+
+            let error = staged_journal_transaction(&core, 4)
+                .commit(&device, &publisher)
+                .unwrap_err();
+
+            assert_eq!(error.failure, CommitFailure::BeforeCommit);
+            assert!(core.is_poisoned());
+            assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+            assert_eq!(device.stable_block(101).is_some(), prefix != 0);
+            assert!(device.stable_block(42).is_none());
+            device.crash();
+            assert!(device.stable_block(42).is_none());
+        }
+    }
+
+    #[test]
+    fn journal_bulk_home_partial_failure_keeps_committed_log_for_recovery() {
+        for prefix in [0, 1, 2, 3, 4] {
+            let device = MemoryDevice::new();
+            device.partial_bulk_call.store(1, Ordering::SeqCst);
+            device.partial_bulk_prefix.store(prefix, Ordering::SeqCst);
+            let core = JournalTransactionCore::new(context_with_ring(TEST_LARGE_JOURNAL_BLOCKS, 1))
+                .unwrap();
+            let publisher = Publisher(AtomicUsize::new(0));
+
+            let error = staged_journal_transaction(&core, 4)
+                .commit(&device, &publisher)
+                .unwrap_err();
+
+            assert_eq!(error.failure, CommitFailure::CheckpointFailed);
+            assert!(core.is_poisoned());
+            assert_eq!(publisher.0.load(Ordering::SeqCst), 0);
+            for index in 0..4 {
+                assert_eq!(
+                    device.stable_block(42 + index as PBlockId).is_some(),
+                    index < prefix
+                );
+            }
+            // The commit block is stable before checkpoint starts, so mount
+            // recovery has the authoritative complete transaction even when
+            // an arbitrary home-block prefix reached stable media.
+            assert!(device.stable_block(106).is_some());
+            device.crash();
+            assert!(device.stable_block(106).is_some());
+        }
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -4288,8 +4288,19 @@ impl Ext4 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ext4::{MetadataMutationMode, MetadataMutationWaker};
     use crate::FileType;
     use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct CountingMetadataWaker {
+        wakes: AtomicUsize,
+    }
+
+    impl MetadataMutationWaker for CountingMetadataWaker {
+        fn wake_all(&self) {
+            self.wakes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
 
     #[test]
     fn production_credit_bound_violation_is_a_terminal_contract_error() {
@@ -4565,6 +4576,10 @@ mod tests {
     #[test]
     fn metadata_mutation_barrier_separates_direct_and_transactional_writers() {
         let fs = make_test_fs(16);
+        let waker = Arc::new(CountingMetadataWaker {
+            wakes: AtomicUsize::new(0),
+        });
+        fs.install_metadata_mutation_waker(waker.clone()).unwrap();
 
         let direct = fs.lock_direct_metadata_mutation().unwrap();
         let second_direct = fs.lock_direct_metadata_mutation().unwrap();
@@ -4575,7 +4590,11 @@ mod tests {
             ErrCode::EAGAIN
         );
         drop(second_direct);
+        assert_eq!(fs.metadata_mutation_generation(), 0);
+        assert_eq!(waker.wakes.load(Ordering::SeqCst), 0);
         drop(direct);
+        assert_eq!(fs.metadata_mutation_generation(), 1);
+        assert_eq!(waker.wakes.load(Ordering::SeqCst), 1);
 
         let transaction = fs.lock_transactional_metadata_mutation().unwrap();
         assert_eq!(
@@ -4591,8 +4610,12 @@ mod tests {
             ErrCode::EAGAIN
         );
         drop(transaction);
+        assert_eq!(fs.metadata_mutation_generation(), 2);
+        assert_eq!(waker.wakes.load(Ordering::SeqCst), 2);
         drop(fs.lock_transactional_metadata_mutation().unwrap());
         drop(fs.lock_direct_metadata_mutation().unwrap());
+        assert_eq!(fs.metadata_mutation_generation(), 4);
+        assert_eq!(waker.wakes.load(Ordering::SeqCst), 4);
     }
 
     #[test]
@@ -4606,11 +4629,93 @@ mod tests {
             fs.lock_direct_metadata_mutation()
                 .expect_err("direct count must not enter the exclusive bit")
                 .code(),
-            ErrCode::EAGAIN
+            ErrCode::EIO
         );
         fs.metadata_mutation_barrier
             .state
             .store(0, core::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[test]
+    fn metadata_mutation_generation_wrap_and_fail_stop_are_observable() {
+        let fs = make_test_fs(16);
+        let waker = Arc::new(CountingMetadataWaker {
+            wakes: AtomicUsize::new(0),
+        });
+        fs.install_metadata_mutation_waker(waker.clone()).unwrap();
+        fs.metadata_mutation_barrier
+            .generation
+            .store(u64::MAX, Ordering::Relaxed);
+
+        drop(fs.lock_transactional_metadata_mutation().unwrap());
+        assert_eq!(fs.metadata_mutation_generation(), 0);
+        assert_eq!(waker.wakes.load(Ordering::SeqCst), 1);
+
+        fs.fail_stop_mutations();
+        assert!(fs.metadata_mutations_terminal());
+        assert_eq!(fs.metadata_mutation_generation(), 1);
+        assert_eq!(waker.wakes.load(Ordering::SeqCst), 2);
+        fs.fail_stop_mutations();
+        assert_eq!(fs.metadata_mutation_generation(), 1);
+        assert_eq!(waker.wakes.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn metadata_mutation_waker_is_install_once() {
+        let fs = make_test_fs(16);
+        let first = Arc::new(CountingMetadataWaker {
+            wakes: AtomicUsize::new(0),
+        });
+        fs.install_metadata_mutation_waker(first.clone()).unwrap();
+        assert_eq!(
+            fs.install_metadata_mutation_waker(Arc::new(CountingMetadataWaker {
+                wakes: AtomicUsize::new(0),
+            }))
+            .unwrap_err()
+            .code(),
+            ErrCode::EINVAL
+        );
+        // Re-installing even the same object is a caller lifecycle error.
+        assert_eq!(
+            fs.install_metadata_mutation_waker(first)
+                .unwrap_err()
+                .code(),
+            ErrCode::EINVAL
+        );
+    }
+
+    #[test]
+    fn transaction_wrapper_fail_stops_raw_core_writer_collision() {
+        let fs = make_test_fs(16);
+        let MetadataMutationMode::Direct(core) = &fs.metadata_mode else {
+            panic!("fixture must use the direct transaction core");
+        };
+        let owner = core.start(1).unwrap();
+
+        let error = match fs.transaction_start(1) {
+            Err(error) => error,
+            Ok(_) => panic!("core-writer collision must fail-stop"),
+        };
+        assert_eq!(error.code(), ErrCode::EIO);
+        assert!(fs.metadata_mutations_terminal());
+        owner.abort();
+    }
+
+    #[test]
+    fn direct_range_wrapper_fail_stops_raw_core_writer_collision() {
+        let fs = make_test_fs(16);
+        let MetadataMutationMode::Direct(core) = &fs.metadata_mode else {
+            panic!("fixture must use the direct transaction core");
+        };
+        let owner = core.start(1).unwrap();
+
+        let error = match fs.transaction_start_direct_range(1) {
+            Err(error) => error,
+            Ok(_) => panic!("direct-range core-writer collision must fail-stop"),
+        };
+        assert_eq!(error.code(), ErrCode::EIO);
+        assert!(fs.metadata_mutations_terminal());
+        owner.abort();
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -548,9 +548,21 @@ pub(super) enum MetadataMutationMode {
 /// The top bit denotes an exclusive transactional owner; the remaining bits
 /// count direct writers.  Acquisition never waits for an existing owner, which
 /// is essential because guards intentionally span block-device I/O.
-#[derive(Debug)]
+pub trait MetadataMutationWaker: Send + Sync {
+    /// Wake every upper-layer waiter which may have observed the previous
+    /// metadata-mutation generation.
+    ///
+    /// This callback runs after a guard releases the atomic gate state or when
+    /// the filesystem first enters fail-stop. It must not block or call back
+    /// into this filesystem.
+    fn wake_all(&self);
+}
+
 struct MetadataMutationGate {
     state: AtomicUsize,
+    generation: AtomicU64,
+    waker_installed: AtomicBool,
+    waker: spin::Once<Arc<dyn MetadataMutationWaker>>,
 }
 
 const METADATA_GATE_EXCLUSIVE: usize = 1usize << (usize::BITS - 1);
@@ -562,15 +574,47 @@ impl MetadataMutationGate {
     const fn new() -> Self {
         Self {
             state: AtomicUsize::new(0),
+            generation: AtomicU64::new(0),
+            waker_installed: AtomicBool::new(false),
+            waker: spin::Once::new(),
+        }
+    }
+
+    fn install_waker(&self, waker: Arc<dyn MetadataMutationWaker>) -> Result<()> {
+        if self
+            .waker_installed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        self.waker.call_once(|| waker);
+        Ok(())
+    }
+
+    #[inline]
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    fn notify_progress(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+        if let Some(waker) = self.waker.get() {
+            waker.wake_all();
         }
     }
 
     fn try_direct(&self) -> Result<MetadataMutationGuard<'_>> {
-        const COMPATIBLE_CAS_RETRIES: usize = 64;
         let mut state = self.state.load(Ordering::Relaxed);
-        for _ in 0..COMPATIBLE_CAS_RETRIES {
-            if state & METADATA_GATE_EXCLUSIVE != 0 || state == METADATA_GATE_DIRECT_MAX {
+        loop {
+            if state & METADATA_GATE_EXCLUSIVE != 0 {
                 return Err(Ext4Error::new(ErrCode::EAGAIN));
+            }
+            if state == METADATA_GATE_DIRECT_MAX {
+                // This is a corrupted/impossible owner count, not contention:
+                // no finite gate-release event can make a fabricated maximum
+                // count a safe acquisition.
+                return Err(Ext4Error::new(ErrCode::EIO));
             }
             match self.state.compare_exchange_weak(
                 state,
@@ -590,7 +634,6 @@ impl MetadataMutationGate {
                 Err(observed) => state = observed,
             }
         }
-        Err(Ext4Error::new(ErrCode::EAGAIN))
     }
 
     fn try_transactional(&self) -> Result<MetadataMutationGuard<'_>> {
@@ -609,10 +652,17 @@ impl MetadataMutationGate {
     }
 }
 
-#[derive(Debug)]
 pub(super) struct MetadataMutationGuard<'a> {
     gate: &'a MetadataMutationGate,
     exclusive: bool,
+}
+
+impl core::fmt::Debug for MetadataMutationGuard<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MetadataMutationGuard")
+            .field("exclusive", &self.exclusive)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Drop for MetadataMutationGuard<'_> {
@@ -623,9 +673,13 @@ impl Drop for MetadataMutationGuard<'_> {
                 METADATA_GATE_EXCLUSIVE
             );
             self.gate.state.store(0, Ordering::Release);
+            self.gate.notify_progress();
         } else {
             let previous = self.gate.state.fetch_sub(1, Ordering::Release);
             debug_assert!(previous > 0 && previous < METADATA_GATE_EXCLUSIVE);
+            if previous == 1 {
+                self.gate.notify_progress();
+            }
         }
     }
 }
@@ -979,6 +1033,28 @@ impl Ext4 {
         self.poison(ErrCode::EIO);
     }
 
+    /// Install the scheduler-specific wake bridge before publishing this
+    /// filesystem to concurrent callers. Exactly one bridge may be installed
+    /// for a mounted lower filesystem.
+    pub fn install_metadata_mutation_waker(
+        &self,
+        waker: Arc<dyn MetadataMutationWaker>,
+    ) -> Result<()> {
+        self.metadata_mutation_barrier.install_waker(waker)
+    }
+
+    /// Snapshot the metadata gate progress generation before attempting an
+    /// operation which may return gate-contention `EAGAIN`.
+    #[inline]
+    pub fn metadata_mutation_generation(&self) -> u64 {
+        self.metadata_mutation_barrier.generation()
+    }
+
+    /// Whether all future metadata mutations are terminally rejected.
+    pub fn metadata_mutations_terminal(&self) -> bool {
+        self.poisoned.lock().is_some()
+    }
+
     /// Host-only synchronization point immediately before fail-stop tries to
     /// acquire the poison mutex. It is intentionally absent from normal and
     /// `test-api` builds; the low-level race test uses it only to establish a
@@ -1029,8 +1105,15 @@ impl Ext4 {
 
     pub(super) fn poison(&self, code: ErrCode) {
         let mut poisoned = self.poisoned.lock();
-        if poisoned.is_none() {
+        let first = poisoned.is_none();
+        if first {
             *poisoned = Some(code);
+        }
+        drop(poisoned);
+        if first {
+            // A fail-stop can occur without a live gate owner. Publish it as
+            // progress so upper waiters do not sleep forever awaiting Drop.
+            self.metadata_mutation_barrier.notify_progress();
         }
     }
 

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -546,8 +546,9 @@ pub(super) enum MetadataMutationMode {
 /// Non-blocking gate separating legacy direct writers from journal snapshots.
 ///
 /// The top bit denotes an exclusive transactional owner; the remaining bits
-/// count direct writers.  Acquisition never waits for an existing owner, which
-/// is essential because guards intentionally span block-device I/O.
+/// count direct writers. Acquisition is lock-free rather than per-caller
+/// wait-free: it never sleeps or waits for an incompatible owner, which is
+/// essential because guards intentionally span block-device I/O.
 pub trait MetadataMutationWaker: Send + Sync {
     /// Wake every upper-layer waiter which may have observed the previous
     /// metadata-mutation generation.
@@ -631,6 +632,12 @@ impl MetadataMutationGate {
                 // Retry only a compatible direct-count collision. Observing an
                 // exclusive owner is rejected at the top of the next iteration;
                 // no acquisition waits for an I/O-spanning owner to depart.
+                //
+                // Do not turn a retry limit into EAGAIN: generation advances
+                // only when the last direct owner exits, so compatible count
+                // churn has no matching progress event for an upper-layer
+                // waiter. Such a rejection could strand an otherwise
+                // compatible caller until the whole direct cohort drains.
                 Err(observed) => state = observed,
             }
         }

--- a/kernel/crates/another_ext4/src/lib.rs
+++ b/kernel/crates/another_ext4/src/lib.rs
@@ -17,7 +17,7 @@ pub use error::{ErrCode, Ext4Error};
 pub use ext4::{
     DelallocAppendBlockPublication, DelallocAppendBlockReservation,
     DelallocAppendBlockSubmitOutcome, DelallocAppendMapperAuthority, DelallocExtentNodePool,
-    DelallocLease, Ext4, InodeOwner, SetAttr,
+    DelallocLease, Ext4, InodeOwner, MetadataMutationWaker, SetAttr,
 };
 // The bounded append mapper implementation is compiled in normal builds, but
 // its raw facade remains test-only until the DragonOS VFS can supply the

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -166,6 +166,25 @@ pub(super) struct Ext4InodeTombstone {
     resolved: bool,
 }
 
+#[derive(Debug)]
+struct Ext4MetadataMutationWait {
+    wait_queue: WaitQueue,
+}
+
+impl Ext4MetadataMutationWait {
+    fn new() -> Self {
+        Self {
+            wait_queue: WaitQueue::default(),
+        }
+    }
+}
+
+impl another_ext4::MetadataMutationWaker for Ext4MetadataMutationWait {
+    fn wake_all(&self) {
+        self.wait_queue.wake_all();
+    }
+}
+
 pub struct Ext4FileSystem {
     /// 对应 another_ext4 中的实际文件系统
     pub(super) fs: another_ext4::Ext4,
@@ -194,6 +213,24 @@ pub struct Ext4FileSystem {
     delalloc_inodes: Mutex<BTreeMap<u32, Arc<LockedExt4Inode>>>,
     delalloc_wait: WaitQueue,
     delalloc_admission_open: AtomicBool,
+
+    /// Serializes only delayed-allocation transaction submission for this
+    /// mount. The lower transactional metadata gate has filesystem scope, so
+    /// per-inode producers must wait in the same ownership domain instead of
+    /// repeatedly restoring and reclaiming their PageCache batch on EAGAIN.
+    ///
+    /// Lock order:
+    /// delalloc_submit_lock -> inode.metadata_commit_lock
+    ///     -> inode.delalloc_pool -> lower transactional gate.
+    ///
+    /// PageCache, delalloc registry, and admission guards must never be held
+    /// while acquiring this sleeping lock.
+    pub(super) delalloc_submit_lock: Mutex<()>,
+
+    /// Scheduler-specific side of another_ext4's metadata-gate progress
+    /// bridge. It owns only a wait queue and deliberately has no filesystem
+    /// back-reference, so the lower install-once Arc cannot form a cycle.
+    metadata_mutation_wait: Arc<Ext4MetadataMutationWait>,
 
     /// Allocations hold a read guard through canonical publication. Physical reclaim
     /// holds a write guard through tombstone completion so an inode number cannot be
@@ -441,6 +478,41 @@ impl FileSystem for Ext4FileSystem {
 }
 
 impl Ext4FileSystem {
+    pub(super) fn wait_metadata_mutation_progress(&self, observed: u64) -> Result<(), SystemError> {
+        if self.fs.metadata_mutations_terminal() || self.lifecycle_error.lock().is_some() {
+            return Err(SystemError::EIO);
+        }
+        if self.fs.metadata_mutation_generation() != observed {
+            return Ok(());
+        }
+
+        self.metadata_mutation_wait.wait_queue.wait_until_io(|| {
+            if self.fs.metadata_mutations_terminal() || self.lifecycle_error.lock().is_some() {
+                Some(Err(SystemError::EIO))
+            } else if self.fs.metadata_mutation_generation() != observed {
+                Some(Ok(()))
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(super) fn retry_metadata_contention<T>(
+        &self,
+        mut operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
+    ) -> Result<T, SystemError> {
+        loop {
+            let observed = self.fs.metadata_mutation_generation();
+            match operation() {
+                Ok(value) => return Ok(value),
+                Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
+                    self.wait_metadata_mutation_progress(observed)?;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
     pub(super) fn delalloc_admission_open(&self) -> bool {
         self.delalloc_mapper_authority.is_some()
             && self.delalloc_admission_open.load(Ordering::Acquire)
@@ -575,6 +647,10 @@ impl Ext4FileSystem {
         self.fs.fail_stop_mutations();
         *self.lifecycle_error.lock() = Some(SystemError::EIO);
         self.close_delalloc_admission();
+        // lower fail-stop already broadcasts its generation. This second
+        // broadcast closes the upper lifecycle transition as well and is
+        // harmless because every waiter rechecks the predicate.
+        self.metadata_mutation_wait.wait_queue.wake_all();
     }
 
     pub(super) fn get_or_create_inode(
@@ -1084,7 +1160,7 @@ impl Ext4FileSystem {
                             } else {
                                 None
                             };
-                            LockedExt4Inode::retry_metadata_contention(|| {
+                            fs.retry_metadata_contention(|| {
                                 fs.fs
                                     .commit_inode_metadata(inode_num, size, atime, mtime, ctime)
                             })
@@ -1235,6 +1311,8 @@ impl Ext4FileSystem {
             Ok::<_, SystemError>((fs, root_attr))
         })();
         let (fs, root_attr) = prospective?;
+        let metadata_mutation_wait = Arc::new(Ext4MetadataMutationWait::new());
+        fs.install_metadata_mutation_waker(metadata_mutation_wait.clone())?;
         let delalloc_mapper_authority = if !delalloc_unique_writable {
             None
         } else {
@@ -1272,6 +1350,8 @@ impl Ext4FileSystem {
             delalloc_inodes: Mutex::new(BTreeMap::new()),
             delalloc_wait: WaitQueue::default(),
             delalloc_admission_open: AtomicBool::new(true),
+            delalloc_submit_lock: Mutex::new(()),
+            metadata_mutation_wait,
             inode_reuse_barrier: RwSem::new(()),
             lifecycle_error: Mutex::new(None),
             quarantined_reclaims: SpinLock::new(Vec::new()),

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -28,8 +28,6 @@ use crate::{
     },
     mm::MemoryManagementArch,
     process::{ProcessManager, RawPid},
-    sched::sched_yield,
-    time::sleep::nanosleep,
     time::{PosixTimeSpec, TimeArch},
 };
 use alloc::{
@@ -905,9 +903,6 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
         };
         let outcome =
             (|| -> Result<another_ext4::DelallocAppendBlockSubmitOutcome, SystemError> {
-                let _metadata_commit = self.inode.metadata_commit_lock.lock();
-                let mut pool_slot = self.inode.delalloc_pool.lock();
-                let pool = pool_slot.as_mut().ok_or(SystemError::EIO)?;
                 let mut publications = Vec::new();
                 let mut reservations = Vec::new();
                 publications
@@ -948,15 +943,41 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
                     });
                     reservations.push(&mut entry.pending.reservation);
                 }
-                let outcome = self
-                    .fs
-                    .fs
-                    .submit_delalloc_append_batch_authorized_with_pool(
-                        authority,
-                        &mut reservations,
-                        &publications,
-                        pool,
-                    );
+
+                // All fallible descriptor preparation is complete before this
+                // mount-scoped serialization point. The lower transaction
+                // gate has filesystem scope; waiting here aligns the upper
+                // ownership domain without exposing ext4 policy to PageCache.
+                let _delalloc_submit = self.fs.delalloc_submit_lock.lock();
+                let _metadata_commit = self.inode.metadata_commit_lock.lock();
+                let mut pool_slot = self.inode.delalloc_pool.lock();
+                let pool = pool_slot.as_mut().ok_or(SystemError::EIO)?;
+
+                let outcome = loop {
+                    let observed = self.fs.fs.metadata_mutation_generation();
+                    let outcome = self
+                        .fs
+                        .fs
+                        .submit_delalloc_append_batch_authorized_with_pool(
+                            authority,
+                            &mut reservations,
+                            &publications,
+                            pool,
+                        );
+                    if matches!(
+                        outcome,
+                        another_ext4::DelallocAppendBlockSubmitOutcome::RetryableNotPublished(
+                            another_ext4::ErrCode::EAGAIN
+                        )
+                    ) {
+                        // Preserve the exact claimed pages, reservations and
+                        // pool while sleeping on the filesystem-wide owner
+                        // which can actually make this transaction runnable.
+                        self.fs.wait_metadata_mutation_progress(observed)?;
+                        continue;
+                    }
+                    break outcome;
+                };
                 if matches!(
                     outcome,
                     another_ext4::DelallocAppendBlockSubmitOutcome::Completed
@@ -1341,7 +1362,7 @@ impl IndexNode for LockedExt4Inode {
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
 
         let attr = if file_type == vfs::FileType::Dir {
-            Self::retry_metadata_contention(|| {
+            fs.retry_metadata_contention(|| {
                 ext4.mkdir_with_owner_and_attr(
                     guard.inner_inode_num,
                     name,
@@ -1353,7 +1374,7 @@ impl IndexNode for LockedExt4Inode {
                 )
             })?
         } else {
-            Self::retry_metadata_contention(|| {
+            fs.retry_metadata_contention(|| {
                 ext4.create_with_owner_and_attr(
                     guard.inner_inode_num,
                     name,
@@ -1429,16 +1450,12 @@ impl IndexNode for LockedExt4Inode {
             let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
-        let file_type = Self::retry_metadata_contention(|| fs.fs.getattr(inode_num))?.ftype;
+        let file_type = fs.fs.getattr(inode_num)?.ftype;
         match file_type {
             FileType::Directory => Err(SystemError::EISDIR),
             FileType::Unknown => Err(SystemError::EROFS),
-            FileType::RegularFile => {
-                Self::retry_metadata_contention(|| fs.fs.read(inode_num, offset, buf))
-            }
-            FileType::SymLink => {
-                Self::retry_metadata_contention(|| fs.fs.readlink(inode_num, offset, buf))
-            }
+            FileType::RegularFile => fs.fs.read(inode_num, offset, buf).map_err(Into::into),
+            FileType::SymLink => fs.fs.readlink(inode_num, offset, buf).map_err(Into::into),
             _ => Err(SystemError::EINVAL),
         }
     }
@@ -1540,8 +1557,7 @@ impl IndexNode for LockedExt4Inode {
                 match cached_size {
                     Some(size) => size,
                     None => {
-                        let size =
-                            Self::retry_metadata_contention(|| fs.fs.getattr(inode_num))?.size;
+                        let size = fs.fs.getattr(inode_num)?.size;
                         self.inner.lock().cached_file_size = Some(size);
                         size
                     }
@@ -1583,7 +1599,7 @@ impl IndexNode for LockedExt4Inode {
                 .fs
                 .prepare_stats_enabled()
                 .then(CurrentTimeArch::get_cycles);
-            let prepare_result = Self::retry_metadata_contention(|| {
+            let prepare_result = fs.retry_metadata_contention(|| {
                 fs.fs.prepare_buffered_write(
                     inode_num,
                     alloc_start,
@@ -1638,7 +1654,7 @@ impl IndexNode for LockedExt4Inode {
             let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
-        let file_type = Self::retry_metadata_contention(|| fs.fs.getattr(inode_num))?.ftype;
+        let file_type = fs.fs.getattr(inode_num)?.ftype;
         match file_type {
             FileType::Directory => Err(SystemError::EISDIR),
             FileType::Unknown => Err(SystemError::EROFS),
@@ -1648,7 +1664,7 @@ impl IndexNode for LockedExt4Inode {
             // snapshot, causing setattr to re-allocate blocks endlessly until
             // the extent tree overflows (entries > max_entries → EIO).
             FileType::RegularFile => {
-                Self::retry_metadata_contention(|| fs.fs.write_data_only(inode_num, offset, buf))
+                fs.retry_metadata_contention(|| fs.fs.write_data_only(inode_num, offset, buf))
             }
             _ => Err(SystemError::EINVAL),
         }
@@ -1756,7 +1772,7 @@ impl IndexNode for LockedExt4Inode {
             return Err(SystemError::EEXIST);
         }
 
-        Self::retry_metadata_contention(|| ext4.link(other_inode_num, inode_num, name))?;
+        fs.retry_metadata_contention(|| ext4.link(other_inode_num, inode_num, name))?;
         if other_attr.links == 0 {
             // The orphan-del transaction made this inode live again. Discard
             // the one-shot capability published by its previous final unlink
@@ -1799,7 +1815,7 @@ impl IndexNode for LockedExt4Inode {
             Ok(_) => return Err(SystemError::EAGAIN_OR_EWOULDBLOCK),
             Err(error) => return Err(error.into()),
         }
-        let reclaim = Self::retry_metadata_contention(|| ext4.unlink(inode_num, name))?;
+        let reclaim = fs.retry_metadata_contention(|| ext4.unlink(inode_num, name))?;
         target.handoff_namespace_reclaim(reclaim)?;
         // 清理 children 缓存
         let _ = guard.children.remove(&DName::from(name));
@@ -1973,7 +1989,7 @@ impl IndexNode for LockedExt4Inode {
             .checked_add(1)
             .ok_or(SystemError::EOVERFLOW)?;
         let ext4 = &fs.fs;
-        Self::retry_metadata_contention(|| {
+        fs.retry_metadata_contention(|| {
             ext4.setattr(
                 inode_num,
                 another_ext4::SetAttr {
@@ -2076,7 +2092,7 @@ impl IndexNode for LockedExt4Inode {
             })
             .transpose()?;
 
-        Self::retry_metadata_contention(|| {
+        fs.retry_metadata_contention(|| {
             fs.fs.setattr(
                 inode_num,
                 another_ext4::SetAttr {
@@ -2167,7 +2183,7 @@ impl IndexNode for LockedExt4Inode {
             let _io_guard = self.io_lock.lock();
             let ext4 = &fs.fs;
             // 仅调整文件大小，其他属性保持不变
-            Self::retry_metadata_contention(|| {
+            fs.retry_metadata_contention(|| {
                 ext4.setattr(
                     inode_num,
                     another_ext4::SetAttr {
@@ -2300,7 +2316,7 @@ impl IndexNode for LockedExt4Inode {
             Ok(_) => return Err(SystemError::ENOTEMPTY),
             Err(error) => return Err(error.into()),
         }
-        let reclaim = Self::retry_metadata_contention(|| concret_fs.rmdir(inode_num, name))?;
+        let reclaim = fs.retry_metadata_contention(|| concret_fs.rmdir(inode_num, name))?;
         target.handoff_namespace_reclaim(reclaim)?;
         // 清理 children 缓存
         let _ = guard.children.remove(&DName::from(name));
@@ -2315,7 +2331,8 @@ impl IndexNode for LockedExt4Inode {
     fn getxattr(&self, name: &str, buf: &mut [u8]) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
         let guard = self.inner.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
         if ext4.getattr(inode_num)?.ftype == FileType::SymLink {
@@ -2345,14 +2362,15 @@ impl IndexNode for LockedExt4Inode {
     fn setxattr(&self, name: &str, value: &[u8], flags: XattrFlags) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
         let guard = self.inner.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
         if ext4.getattr(inode_num)?.ftype == FileType::SymLink {
             return Err(SystemError::EPERM);
         }
 
-        Self::retry_metadata_contention(|| {
+        fs.retry_metadata_contention(|| {
             ext4.setxattr_with_flags(
                 inode_num,
                 name,
@@ -2400,14 +2418,15 @@ impl IndexNode for LockedExt4Inode {
     fn removexattr(&self, name: &str) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
         let guard = self.inner.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
         if ext4.getattr(inode_num)?.ftype == FileType::SymLink {
             return Err(SystemError::EPERM);
         }
 
-        Self::retry_metadata_contention(|| ext4.removexattr(inode_num, name))?;
+        fs.retry_metadata_contention(|| ext4.removexattr(inode_num, name))?;
         Ok(0)
     }
 
@@ -2449,7 +2468,7 @@ impl IndexNode for LockedExt4Inode {
             vfs::FileType::CharDevice | vfs::FileType::BlockDevice
         ) {
             // Character/block device: use mknod to store device number in i_block
-            Self::retry_metadata_contention(|| {
+            fs.retry_metadata_contention(|| {
                 ext4.mknod_with_owner_and_attr(
                     inode_num,
                     filename,
@@ -2464,7 +2483,7 @@ impl IndexNode for LockedExt4Inode {
             })?
         } else {
             // FIFO, Socket, etc.: use regular create (no device number needed)
-            Self::retry_metadata_contention(|| {
+            fs.retry_metadata_contention(|| {
                 ext4.create_with_owner_and_attr(
                     inode_num,
                     filename,
@@ -2559,7 +2578,7 @@ impl IndexNode for LockedExt4Inode {
         // RENAME_EXCHANGE: 原子交换两个文件/目录
         if flags.contains(RenameFlags::EXCHANGE) {
             // VFS 层已验证目标存在，直接调用 exchange
-            Self::retry_metadata_contention(|| {
+            ext4_fs.retry_metadata_contention(|| {
                 ext4.rename_exchange(src_inode_num, old_name, target_inode_num, new_name)
             })?;
 
@@ -2633,7 +2652,7 @@ impl IndexNode for LockedExt4Inode {
                     continue;
                 }
                 let allocation = ext4_fs.begin_allocation()?;
-                let whiteout_attr = Self::retry_metadata_contention(|| {
+                let whiteout_attr = ext4_fs.retry_metadata_contention(|| {
                     ext4.mknod_with_owner_and_attr(
                         src_inode_num,
                         &candidate,
@@ -2657,16 +2676,15 @@ impl IndexNode for LockedExt4Inode {
                     Err(error) => {
                         drop(allocation);
                         let _reclaim = ext4_fs.begin_reclaim();
-                        let cleanup = Self::retry_metadata_contention(|| {
-                            ext4.unlink(src_inode_num, &candidate)
-                        })
-                        .and_then(|handle| match handle {
-                            Some(handle) => {
-                                Self::reclaim_with_metadata_contention_retry(ext4, handle)
-                                    .map_err(|failure| SystemError::from(failure.0))
-                            }
-                            None => Ok(()),
-                        });
+                        let cleanup = ext4_fs
+                            .retry_metadata_contention(|| ext4.unlink(src_inode_num, &candidate))
+                            .and_then(|handle| match handle {
+                                Some(handle) => {
+                                    Self::reclaim_with_metadata_contention_retry(&ext4_fs, handle)
+                                        .map_err(|failure| SystemError::from(failure.0))
+                                }
+                                None => Ok(()),
+                            });
                         if cleanup.is_err() {
                             ext4_fs.fail_stop_lifecycle();
                             return Err(SystemError::EIO);
@@ -2681,7 +2699,7 @@ impl IndexNode for LockedExt4Inode {
                 return Err(SystemError::EEXIST);
             }
 
-            if let Err(err) = Self::retry_metadata_contention(|| {
+            if let Err(err) = ext4_fs.retry_metadata_contention(|| {
                 ext4.rename_exchange(src_inode_num, old_name, src_inode_num, &temp_name)
             }) {
                 Self::reclaim_temporary_inode(
@@ -2692,12 +2710,12 @@ impl IndexNode for LockedExt4Inode {
                 )?;
                 return Err(err);
             }
-            let rename_handle = match Self::retry_metadata_contention(|| {
+            let rename_handle = match ext4_fs.retry_metadata_contention(|| {
                 ext4.rename(src_inode_num, &temp_name, target_inode_num, new_name)
             }) {
                 Ok(handle) => handle,
                 Err(rename_error) => {
-                    let rollback = Self::retry_metadata_contention(|| {
+                    let rollback = ext4_fs.retry_metadata_contention(|| {
                         ext4.rename_exchange(src_inode_num, old_name, src_inode_num, &temp_name)
                     });
                     if rollback.is_err() {
@@ -2730,13 +2748,13 @@ impl IndexNode for LockedExt4Inode {
             resulting_whiteout = whiteout_inode;
         } else {
             if let Some(dst_inode) = &dst_inode {
-                let reclaim = Self::retry_metadata_contention(|| {
+                let reclaim = ext4_fs.retry_metadata_contention(|| {
                     ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
                 })?;
                 dst_inode.handoff_namespace_reclaim(reclaim)?;
             } else {
                 // ext4 library now correctly handles atomic replace
-                let reclaim = Self::retry_metadata_contention(|| {
+                let reclaim = ext4_fs.retry_metadata_contention(|| {
                     ext4.rename(src_inode_num, old_name, target_inode_num, new_name)
                 })?;
                 if let Some(handle) = reclaim {
@@ -2935,8 +2953,6 @@ impl LockedExt4Inode {
         let page_start = offset & !(MMArch::PAGE_SIZE - 1);
         let new_eof = offset.checked_add(buf.len()).ok_or(SystemError::EFBIG)? as u64;
         let write_time = PosixTimeSpec::now().tv_sec.to_u32().unwrap_or(0);
-        let mut contention_attempt = 0usize;
-
         'admission: loop {
             let _invalidate = page_cache.invalidate_write();
             let _size = self.size_lock.read();
@@ -2978,7 +2994,8 @@ impl LockedExt4Inode {
                     drop(_io);
                     drop(_size);
                     drop(_invalidate);
-                    match progress.wait_for_progress_interruptible()? {
+                    let wait_outcome = progress.wait_for_progress_interruptible();
+                    match wait_outcome? {
                         PageCacheWritebackProgressOutcome::Failed(error) => return Err(error),
                         PageCacheWritebackProgressOutcome::Progress
                         | PageCacheWritebackProgressOutcome::Cancelled => {
@@ -3039,7 +3056,7 @@ impl LockedExt4Inode {
                 // this is internal metadata contention, not userspace
                 // nonblocking I/O, so keep the write admission pending until
                 // the owner releases the gate.
-                let pool = Self::retry_metadata_contention(|| {
+                let pool = fs.retry_metadata_contention(|| {
                     fs.fs
                         .create_delalloc_extent_node_pool_authorized(authority, inode_num)
                 })?;
@@ -3048,6 +3065,7 @@ impl LockedExt4Inode {
                     *slot = Some(pool);
                 }
             }
+            let observed = fs.fs.metadata_mutation_generation();
             let reservation_result = {
                 let mut slot = self.delalloc_pool.lock();
                 let pool = slot.as_mut().ok_or(SystemError::EIO)?;
@@ -3065,8 +3083,7 @@ impl LockedExt4Inode {
                     drop(_io);
                     drop(_size);
                     drop(_invalidate);
-                    contention_attempt = contention_attempt.saturating_add(1);
-                    Self::metadata_contention_backoff(contention_attempt);
+                    fs.wait_metadata_mutation_progress(observed)?;
                     continue 'admission;
                 }
                 Err(error)
@@ -3503,40 +3520,13 @@ impl LockedExt4Inode {
         }
     }
 
-    fn metadata_contention_backoff(attempt: usize) {
-        const YIELDS_BEFORE_SLEEP: usize = 64;
-        if attempt.is_multiple_of(YIELDS_BEFORE_SLEEP) {
-            // Keep the current eviction epoch pending, but avoid a workqueue
-            // hot loop while an I/O-spanning metadata owner is asleep.
-            let _ = nanosleep(PosixTimeSpec::new(0, 1_000_000));
-        } else {
-            sched_yield();
-        }
-    }
-
-    pub(super) fn retry_metadata_contention<T>(
-        mut operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
-    ) -> Result<T, SystemError> {
-        let mut attempt = 1usize;
-        loop {
-            match operation() {
-                Ok(value) => return Ok(value),
-                Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
-                    Self::metadata_contention_backoff(attempt);
-                    attempt = attempt.saturating_add(1);
-                }
-                Err(error) => return Err(error.into()),
-            }
-        }
-    }
-
     fn reclaim_with_metadata_contention_retry(
-        fs: &another_ext4::Ext4,
+        fs: &Arc<Ext4FileSystem>,
         mut handle: another_ext4::InodeReclaimHandle,
     ) -> Result<(), (another_ext4::Ext4Error, another_ext4::InodeReclaimHandle)> {
-        let mut attempt = 1usize;
         loop {
-            match fs.reclaim_inode(handle) {
+            let observed = fs.fs.metadata_mutation_generation();
+            match fs.fs.reclaim_inode(handle) {
                 Ok(()) => return Ok(()),
                 Err(failure) => {
                     let (error, returned_handle) = failure.into_parts();
@@ -3544,8 +3534,12 @@ impl LockedExt4Inode {
                         return Err((error, returned_handle));
                     }
                     handle = returned_handle;
-                    Self::metadata_contention_backoff(attempt);
-                    attempt = attempt.saturating_add(1);
+                    if fs.wait_metadata_mutation_progress(observed).is_err() {
+                        return Err((
+                            another_ext4::Ext4Error::new(another_ext4::ErrCode::EIO),
+                            handle,
+                        ));
+                    }
                 }
             }
         }
@@ -3561,8 +3555,8 @@ impl LockedExt4Inode {
         let _link_mutation = lifecycle.lock_link_mutation();
         let tombstone = fs.begin_freeing(&inode)?;
         let _reuse = fs.begin_reclaim();
-        let mut attempt = 1usize;
         let handle = loop {
+            let observed = fs.fs.metadata_mutation_generation();
             match fs.fs.unlink(parent_inode_num, name) {
                 Ok(Some(handle)) => break handle,
                 Ok(None) => {
@@ -3571,8 +3565,10 @@ impl LockedExt4Inode {
                     return Err(error);
                 }
                 Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
-                    Self::metadata_contention_backoff(attempt);
-                    attempt = attempt.saturating_add(1);
+                    if let Err(error) = fs.wait_metadata_mutation_progress(observed) {
+                        let _ = fs.poison_freeing(tombstone, error.clone());
+                        return Err(error);
+                    }
                 }
                 Err(error) => {
                     let error = SystemError::from(error);
@@ -3581,7 +3577,7 @@ impl LockedExt4Inode {
                 }
             }
         };
-        if let Err((error, handle)) = Self::reclaim_with_metadata_contention_retry(&fs.fs, handle) {
+        if let Err((error, handle)) = Self::reclaim_with_metadata_contention_retry(fs, handle) {
             *inode.pending_reclaim.lock() = Some(handle);
             let error = SystemError::from(error);
             let _ = fs.poison_freeing(tombstone, error.clone());
@@ -3980,7 +3976,7 @@ impl LockedExt4Inode {
                 return Err(error);
             }
         }
-        match Self::reclaim_with_metadata_contention_retry(&fs.fs, handle) {
+        match Self::reclaim_with_metadata_contention_retry(&fs, handle) {
             Ok(()) => {
                 fs.complete_freeing(tombstone)?;
                 Ok(())
@@ -4054,7 +4050,7 @@ impl LockedExt4Inode {
             .then_some(snapshot.cached_times.ctime);
 
         if size.is_some() || atime.is_some() || mtime.is_some() || ctime.is_some() {
-            Self::retry_metadata_contention(|| {
+            snapshot.fs.retry_metadata_contention(|| {
                 snapshot
                     .fs
                     .fs
@@ -4151,7 +4147,7 @@ impl LockedExt4Inode {
         } else {
             None
         };
-        Self::retry_metadata_contention(|| {
+        fs.retry_metadata_contention(|| {
             fs.fs
                 .commit_inode_metadata(inode_num, size, atime, mtime, ctime)
         })?;
@@ -4231,7 +4227,7 @@ impl LockedExt4Inode {
                     .ok_or(SystemError::EOVERFLOW)?,
             )
         };
-        Self::retry_metadata_contention(|| {
+        fs.retry_metadata_contention(|| {
             fs.fs.prepare_buffered_write(
                 inode_num,
                 page_start,
@@ -4317,20 +4313,6 @@ pub(crate) fn run_lifecycle_selftests() -> String {
     append(
         "poison_is_observable",
         lifecycle.begin_operation().err() == Some(SystemError::EIO),
-    );
-
-    let mut attempts = 0usize;
-    let retry_result = LockedExt4Inode::retry_metadata_contention(|| {
-        attempts += 1;
-        if attempts < 3 {
-            Err(another_ext4::Ext4Error::new(another_ext4::ErrCode::EAGAIN))
-        } else {
-            Ok(())
-        }
-    });
-    append(
-        "metadata_contention_is_internal",
-        retry_result.is_ok() && attempts == 3,
     );
 
     if failures == 0 {

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -644,6 +644,93 @@ TEST(Ext4InodeIdentity, DelallocQueuePublishesAndRecoversInOrder) {
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
 }
 
+TEST(Ext4InodeIdentity, ConcurrentDelallocInodesCompleteAndRecover) {
+    constexpr int kWriters = 4;
+    constexpr size_t kPageSize = 4096;
+    constexpr size_t kPagesPerWriter = 128;
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    std::atomic<int> ready{0};
+    std::atomic<bool> start{false};
+    std::atomic<int> first_error{0};
+    std::thread writers[kWriters];
+    for (int writer = 0; writer < kWriters; ++writer) {
+        writers[writer] = std::thread([&, writer] {
+            const std::string path =
+                fs.mount_point() + "/concurrent_delalloc_" + std::to_string(writer);
+            int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+            if (fd < 0) {
+                int expected = 0;
+                first_error.compare_exchange_strong(expected, errno);
+                return;
+            }
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            char page[kPageSize];
+            for (size_t index = 0; index < kPagesPerWriter; ++index) {
+                memset(page, 1 + (writer * 37 + index) % 251, sizeof(page));
+                size_t written = 0;
+                while (written != sizeof(page)) {
+                    ssize_t count = write(fd, page + written, sizeof(page) - written);
+                    if (count < 0 && errno == EINTR) {
+                        continue;
+                    }
+                    if (count <= 0) {
+                        int expected = 0;
+                        first_error.compare_exchange_strong(
+                            expected, count < 0 ? errno : EIO);
+                        close(fd);
+                        return;
+                    }
+                    written += static_cast<size_t>(count);
+                }
+            }
+            if (fsync(fd) != 0) {
+                int expected = 0;
+                first_error.compare_exchange_strong(expected, errno);
+            }
+            close(fd);
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) != kWriters
+           && first_error.load(std::memory_order_acquire) == 0) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& writer : writers) {
+        writer.join();
+    }
+    ASSERT_EQ(0, first_error.load()) << strerror(first_error.load());
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    std::string page(kPageSize, '\0');
+    for (int writer = 0; writer < kWriters; ++writer) {
+        const std::string path =
+            fs.mount_point() + "/concurrent_delalloc_" + std::to_string(writer);
+        int fd = open(path.c_str(), O_RDONLY);
+        ASSERT_GE(fd, 0) << strerror(errno);
+        for (size_t index = 0; index < kPagesPerWriter; ++index) {
+            ASSERT_EQ(static_cast<ssize_t>(page.size()),
+                      pread(fd, page.data(), page.size(), index * kPageSize))
+                << path << " page " << index << ": " << strerror(errno);
+            const char expected = 1 + (writer * 37 + index) % 251;
+            ASSERT_TRUE(std::all_of(page.begin(), page.end(),
+                                    [expected](char byte) {
+                                        return byte == expected;
+                                    }))
+                << path << " page " << index;
+        }
+        ASSERT_EQ(0, close(fd)) << strerror(errno);
+    }
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
 TEST(Ext4InodeIdentity, DelallocNonalignedThreePageAndSparseForwardAreZeroSafe) {
     constexpr size_t kPageSize = 4096;
     LoopExt4 fs;


### PR DESCRIPTION
## Summary

- replace fixed yield and sleep retries with a filesystem-scoped metadata mutation progress bridge
- serialize delayed-allocation transaction submissions per mount while preserving per-inode page-cache ownership
- coalesce contiguous journal log and checkpoint writes without changing durability boundaries
- fail-stop if the raw transaction core reports contention behind an already-acquired metadata gate
- add gate, wraparound, poison, partial bulk-I/O, and concurrent delayed-writeback recovery coverage

## Root cause

Delayed-allocation progress was owned per inode while the lower metadata transaction gate was owned per filesystem. Competing inode workers therefore restored and resubmitted the same page-cache batches when another metadata owner held the gate. Fixed yield and sleep retries reduced CPU pressure but could not wait for the owner that actually made progress.

The synchronous journal path also issued contiguous log and checkpoint blocks individually, amplifying block requests for each delayed-allocation transaction.

## Implementation

The lower ext4 crate now publishes a wrapping mutation generation and invokes an install-once scheduler-independent wake callback when the final direct owner, an exclusive owner, or the first fail-stop releases waiters. The DragonOS ext4 adapter installs a mount-local wait queue before publishing the filesystem and retries metadata operations only after generation progress or a terminal state.

Delayed submissions use a mount-scoped coordinator around the lower transaction window. Page-cache claims, reservations, reclaim handles, and publication ordering remain linear and are preserved across waits.

Journal descriptor, payload, and home blocks are grouped only when physically contiguous and within a bounded run. Scratch storage is reserved before the active journal tail is published. Commit records and all data, log, checkpoint, and clean-tail flush boundaries remain unchanged. Partial bulk-write failures retain their original recovery phase and never fall back to speculative per-block retries.

## User impact

Concurrent metadata and delayed-allocation workloads no longer rely on fixed backoff or repeatedly retry without filesystem-wide progress. This reduces retry storms and block-request amplification while preserving fsync, recovery, fail-stop, and unmount semantics.

## Validation

- `make fmt` including kernel Clippy
- `make kernel`
- `cargo test --lib` in `kernel/crates/another_ext4`: 161 passed
- complete `recovery_fault_injection` crash-recovery matrix
- DragonOS QEMU `ext4_inode_identity_test`: 33 passed
- final targeted concurrent delayed-writeback recovery test after cleanup: passed
- `git diff --check`
