### PR TITLE
fix(net): restore deadline-driven TCP progress

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "lru",
  "multiboot2",
  "napi-state",
+ "net-poll-state",
  "num",
  "num-derive",
  "num-traits 0.2.15",
@@ -1023,6 +1024,10 @@ dependencies = [
 
 [[package]]
 name = "napi-state"
+version = "0.1.0"
+
+[[package]]
+name = "net-poll-state"
 version = "0.1.0"
 
 [[package]]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -57,6 +57,7 @@ kcmdline_macros = { path = "crates/kcmdline_macros" }
 kdepends = { path = "crates/kdepends" }
 klog_types = { path = "crates/klog_types" }
 napi-state = { path = "crates/napi-state" }
+net-poll-state = { path = "crates/net-poll-state" }
 linkme = "=0.3.27"
 num = { version = "=0.4.0", default-features = false }
 num-derive = "=0.3"

--- a/kernel/crates/napi-state/src/lib.rs
+++ b/kernel/crates/napi-state/src/lib.rs
@@ -10,18 +10,25 @@ pub const DISABLE: u32 = 1 << 2;
 pub enum CompleteState {
     Completed,
     Missed,
+    Disabled,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScheduleState {
+    Acquired,
+    Missed,
+    Disabled,
 }
 
 /// Try to acquire the single NAPI poll owner.
 ///
-/// A caller which gets `true` owns the transition from idle to scheduled and
-/// must publish the NAPI instance exactly once. A caller which observes an
-/// existing owner only records `MISSED`.
-pub fn schedule_prep(state: &AtomicU32) -> bool {
+/// A caller which acquires ownership must publish the NAPI instance exactly
+/// once. A caller which observes an existing owner only records `MISSED`.
+pub fn schedule_prep(state: &AtomicU32) -> ScheduleState {
     let mut current = state.load(Ordering::Acquire);
     loop {
         if current & DISABLE != 0 {
-            return false;
+            return ScheduleState::Disabled;
         }
 
         let mut next = current | SCHED;
@@ -30,7 +37,8 @@ pub fn schedule_prep(state: &AtomicU32) -> bool {
         }
 
         match state.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
-            Ok(_) => return current & SCHED == 0,
+            Ok(_) if current & SCHED == 0 => return ScheduleState::Acquired,
+            Ok(_) => return ScheduleState::Missed,
             Err(observed) => current = observed,
         }
     }
@@ -44,6 +52,9 @@ pub fn schedule_prep(state: &AtomicU32) -> bool {
 pub fn complete(state: &AtomicU32) -> CompleteState {
     let mut current = state.load(Ordering::Acquire);
     loop {
+        if current & DISABLE != 0 {
+            return CompleteState::Disabled;
+        }
         debug_assert_ne!(current & SCHED, 0, "completing an unscheduled NAPI");
 
         let mut next = current & !(SCHED | MISSED);
@@ -81,21 +92,21 @@ mod tests {
     #[test]
     fn first_schedule_acquires_owner() {
         let state = AtomicU32::new(0);
-        assert!(schedule_prep(&state));
+        assert_eq!(schedule_prep(&state), ScheduleState::Acquired);
         assert_eq!(state.load(Ordering::Relaxed), SCHED);
     }
 
     #[test]
     fn repeated_schedule_only_records_missed() {
         let state = AtomicU32::new(SCHED);
-        assert!(!schedule_prep(&state));
+        assert_eq!(schedule_prep(&state), ScheduleState::Missed);
         assert_eq!(state.load(Ordering::Relaxed), SCHED | MISSED);
     }
 
     #[test]
     fn disable_rejects_schedule() {
         let state = AtomicU32::new(DISABLE);
-        assert!(!schedule_prep(&state));
+        assert_eq!(schedule_prep(&state), ScheduleState::Disabled);
         assert_eq!(state.load(Ordering::Relaxed), DISABLE);
     }
 
@@ -122,7 +133,7 @@ mod tests {
 
         let scheduler = thread::spawn(move || {
             worker_barrier.wait();
-            assert!(!schedule_prep(&worker_state));
+            assert_eq!(schedule_prep(&worker_state), ScheduleState::Missed);
         });
 
         barrier.wait();
@@ -136,6 +147,26 @@ mod tests {
         let state = AtomicU32::new(SCHED | MISSED);
         disable(&state);
         assert_eq!(state.load(Ordering::Acquire), DISABLE);
-        assert!(!schedule_prep(&state));
+        assert_eq!(schedule_prep(&state), ScheduleState::Disabled);
+        assert_eq!(complete(&state), CompleteState::Disabled);
+        assert_eq!(state.load(Ordering::Acquire), DISABLE);
+    }
+
+    #[test]
+    fn concurrent_disable_cannot_be_cleared_by_complete() {
+        let state = Arc::new(AtomicU32::new(SCHED));
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_state = state.clone();
+        let worker_barrier = barrier.clone();
+
+        let disabler = thread::spawn(move || {
+            worker_barrier.wait();
+            disable(&worker_state);
+        });
+
+        barrier.wait();
+        disabler.join().unwrap();
+        assert_eq!(complete(&state), CompleteState::Disabled);
+        assert_eq!(state.load(Ordering::Acquire), DISABLE);
     }
 }

--- a/kernel/crates/net-poll-state/Cargo.toml
+++ b/kernel/crates/net-poll-state/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "net-poll-state"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"

--- a/kernel/crates/net-poll-state/src/lib.rs
+++ b/kernel/crates/net-poll-state/src/lib.rs
@@ -1,0 +1,253 @@
+#![no_std]
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+const DISARMED: u64 = 0;
+
+/// Whether publishing a future protocol deadline requires the sleeping
+/// scheduler to recompute its timeout.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PublishResult {
+    Unchanged,
+    RearmRequired,
+}
+
+/// The result of atomically classifying a protocol deadline.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DueResult {
+    Disarmed,
+    Future(u64),
+    Claimed(u64),
+}
+
+/// The scheduler-owned future protocol deadline for one network interface.
+///
+/// Zero is reserved for the disarmed state. Immediate work is deliberately
+/// not stored here: it remains owned by the caller currently polling the
+/// protocol stack.
+#[derive(Debug)]
+pub struct PollDeadline(AtomicU64);
+
+impl PollDeadline {
+    pub const fn new() -> Self {
+        Self(AtomicU64::new(DISARMED))
+    }
+
+    /// Publish a deadline which is strictly in the future.
+    ///
+    /// The returned decision is derived from the same RMW which publishes the
+    /// value, so a concurrent claim cannot be hidden by a separate load/store
+    /// sequence.
+    pub fn publish_future(&self, now_us: u64, new_us: u64) -> PublishResult {
+        debug_assert!(new_us > now_us);
+        debug_assert_ne!(new_us, DISARMED);
+
+        let old_us = self.0.swap(new_us, Ordering::AcqRel);
+        if old_us == new_us {
+            return PublishResult::Unchanged;
+        }
+
+        if old_us == DISARMED || old_us <= now_us || new_us < old_us {
+            PublishResult::RearmRequired
+        } else {
+            PublishResult::Unchanged
+        }
+    }
+
+    /// Remove the scheduler-owned deadline.
+    ///
+    /// A poller which already armed the old timeout may wake once early; no
+    /// notification is needed because clearing cannot make work late.
+    pub fn disarm(&self) {
+        self.0.store(DISARMED, Ordering::Release);
+    }
+
+    /// Classify the current value and atomically claim it when due.
+    ///
+    /// CAS failure is handled internally so callers cannot accidentally sleep
+    /// without reclassifying a concurrently replaced deadline.
+    pub fn classify_and_claim(&self, now_us: u64) -> DueResult {
+        let mut observed = self.0.load(Ordering::Acquire);
+        loop {
+            if observed == DISARMED {
+                return DueResult::Disarmed;
+            }
+            if observed > now_us {
+                return DueResult::Future(observed);
+            }
+
+            match self.0.compare_exchange_weak(
+                observed,
+                DISARMED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return DueResult::Claimed(observed),
+                Err(current) => observed = current,
+            }
+        }
+    }
+
+    /// Restore a claimed deadline only if no publisher has replaced it.
+    pub fn restore_claimed_if_empty(&self, claimed_us: u64) -> bool {
+        debug_assert_ne!(claimed_us, DISARMED);
+        self.0
+            .compare_exchange(DISARMED, claimed_us, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    #[inline]
+    pub fn load(&self) -> Option<u64> {
+        match self.0.load(Ordering::Acquire) {
+            DISARMED => None,
+            deadline => Some(deadline),
+        }
+    }
+}
+
+impl Default for PollDeadline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn classifies_all_states_and_claims_due_once() {
+        let deadline = PollDeadline::new();
+        assert_eq!(deadline.classify_and_claim(100), DueResult::Disarmed);
+
+        assert_eq!(
+            deadline.publish_future(100, 200),
+            PublishResult::RearmRequired
+        );
+        assert_eq!(deadline.classify_and_claim(199), DueResult::Future(200));
+        assert_eq!(deadline.classify_and_claim(200), DueResult::Claimed(200));
+        assert_eq!(deadline.classify_and_claim(200), DueResult::Disarmed);
+    }
+
+    #[test]
+    fn only_new_or_earlier_deadlines_require_rearm() {
+        let deadline = PollDeadline::new();
+        assert_eq!(
+            deadline.publish_future(10, 100),
+            PublishResult::RearmRequired
+        );
+        assert_eq!(deadline.publish_future(10, 100), PublishResult::Unchanged);
+        assert_eq!(deadline.publish_future(10, 120), PublishResult::Unchanged);
+        assert_eq!(
+            deadline.publish_future(10, 80),
+            PublishResult::RearmRequired
+        );
+    }
+
+    #[test]
+    fn replacing_an_overdue_deadline_requires_reclassification() {
+        let deadline = PollDeadline::new();
+        assert_eq!(
+            deadline.publish_future(10, 20),
+            PublishResult::RearmRequired
+        );
+        assert_eq!(
+            deadline.publish_future(30, 50),
+            PublishResult::RearmRequired
+        );
+        assert_eq!(deadline.classify_and_claim(30), DueResult::Future(50));
+    }
+
+    #[test]
+    fn disarm_clears_future_work() {
+        let deadline = PollDeadline::new();
+        deadline.publish_future(10, 20);
+        deadline.disarm();
+        assert_eq!(deadline.load(), None);
+        assert_eq!(deadline.classify_and_claim(20), DueResult::Disarmed);
+    }
+
+    #[test]
+    fn claim_before_publish_preserves_the_new_deadline() {
+        let deadline = Arc::new(PollDeadline::new());
+        deadline.publish_future(10, 20);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_deadline = deadline.clone();
+        let worker_barrier = barrier.clone();
+        let publisher = thread::spawn(move || {
+            worker_barrier.wait();
+            worker_deadline.publish_future(20, 40)
+        });
+
+        assert_eq!(deadline.classify_and_claim(20), DueResult::Claimed(20));
+        barrier.wait();
+        assert_eq!(publisher.join().unwrap(), PublishResult::RearmRequired);
+        assert_eq!(deadline.classify_and_claim(20), DueResult::Future(40));
+    }
+
+    #[test]
+    fn publish_before_claim_reclassifies_the_replacement() {
+        let deadline = Arc::new(PollDeadline::new());
+        deadline.publish_future(10, 20);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_deadline = deadline.clone();
+        let worker_barrier = barrier.clone();
+        let publisher = thread::spawn(move || {
+            worker_deadline.publish_future(20, 40);
+            worker_barrier.wait();
+        });
+
+        barrier.wait();
+        assert_eq!(deadline.classify_and_claim(20), DueResult::Future(40));
+        publisher.join().unwrap();
+    }
+
+    #[test]
+    fn restore_never_overwrites_a_concurrent_publish() {
+        let deadline = PollDeadline::new();
+        deadline.publish_future(10, 20);
+        assert_eq!(deadline.classify_and_claim(20), DueResult::Claimed(20));
+        deadline.publish_future(20, 40);
+        assert!(!deadline.restore_claimed_if_empty(20));
+        assert_eq!(deadline.load(), Some(40));
+    }
+
+    #[test]
+    fn one_of_concurrent_claimers_owns_the_due_value() {
+        let deadline = Arc::new(PollDeadline::new());
+        deadline.publish_future(10, 20);
+        let barrier = Arc::new(Barrier::new(3));
+
+        let spawn_claimer = |deadline: Arc<PollDeadline>, barrier: Arc<Barrier>| {
+            thread::spawn(move || {
+                barrier.wait();
+                deadline.classify_and_claim(20)
+            })
+        };
+        let first = spawn_claimer(deadline.clone(), barrier.clone());
+        let second = spawn_claimer(deadline, barrier.clone());
+        barrier.wait();
+
+        let results = [first.join().unwrap(), second.join().unwrap()];
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| **result == DueResult::Claimed(20))
+                .count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| **result == DueResult::Disarmed)
+                .count(),
+            1
+        );
+    }
+}

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -3,6 +3,7 @@ use alloc::{fmt, vec::Vec};
 use alloc::{string::String, sync::Arc};
 use core::net::Ipv4Addr;
 use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use net_poll_state::{DueResult, PollDeadline, PublishResult};
 use sysfs::netdev_register_kobject;
 
 use crate::driver::net::napi::NapiStruct;
@@ -283,8 +284,9 @@ pub struct IfaceCommon {
     bounds: RwLock<Arc<Vec<Arc<dyn InetSocket>>>>,
     /// 端口管理器
     port_manager: PortManager,
-    /// 下次需要推进协议栈的时间点（单位：微秒时间戳，0 表示无定时事件）
-    poll_at_us: core::sync::atomic::AtomicU64,
+    /// Scheduler-owned future protocol deadline. Immediate work stays with
+    /// the current poll owner and is never armed here.
+    poll_deadline: PollDeadline,
     /// 网络命名空间
     net_namespace: RwLock<Weak<NetNamespace>>,
     /// 路由相关数据
@@ -306,7 +308,7 @@ impl fmt::Debug for IfaceCommon {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("IfaceCommon")
             .field("iface_id", &self.iface_id)
-            .field("poll_at_us", &self.poll_at_us)
+            .field("poll_deadline", &self.poll_deadline)
             .finish()
     }
 }
@@ -332,7 +334,7 @@ impl IfaceCommon {
             sockets: Mutex::new(smoltcp::iface::SocketSet::new(Vec::new())),
             bounds: RwLock::new(Arc::new(Vec::new())),
             port_manager: PortManager::default(),
-            poll_at_us: core::sync::atomic::AtomicU64::new(0),
+            poll_deadline: PollDeadline::new(),
             net_namespace: RwLock::new(Weak::new()),
             router_common_data,
             flags: AtomicU32::new(flags.bits()),
@@ -420,7 +422,7 @@ impl IfaceCommon {
         self.tcp_listener_backlog
             .refresh_listen_socket_present(&sockets);
 
-        let (has_events, poll_at) = {
+        let (has_events, poll_again, deadline_rearm) = {
             let poll_result = interface.poll(timestamp, device, &mut sockets);
 
             // Reclaim/advance orphaned TCP sockets after smoltcp has processed ingress.
@@ -428,46 +430,20 @@ impl IfaceCommon {
             // scheduled immediately instead of waiting for an unrelated future poll.
             self.tcp_close_defer.reap_closed(timestamp, &mut sockets);
 
+            let poll_at = interface.poll_at(timestamp, &sockets);
+            let (poll_again, deadline_rearm) = self.publish_poll_deadline(timestamp, poll_at);
             (
                 matches!(poll_result, smoltcp::iface::PollResult::SocketStateChanged),
-                {
-                    // `poll_at()` may legally return an instant that is <= `timestamp`
-                    // (e.g. "poll immediately"). The previous implementation retried
-                    // in a tight loop without updating `timestamp`, which can spin
-                    // forever and look like a deadlock.
-                    //
-                    // Clamp to `timestamp` to indicate "poll ASAP" without spinning.
-                    match interface.poll_at(timestamp, &sockets) {
-                        Some(instant) if instant <= timestamp => Some(timestamp),
-                        other => other,
-                    }
-                },
+                poll_again,
+                deadline_rearm,
             )
         };
 
-        // drop sockets here to avoid deadlock
+        // Publish the deadline while the smoltcp serialization locks are held,
+        // but notify the namespace only after dropping them.
         drop(interface);
         drop(sockets);
-        // log::info!(
-        //     "polling iface {}, has_events: {}, poll_at: {:?}",
-        //     self.iface_id,
-        //     has_events,
-        //     poll_at
-        // );
-
-        use core::sync::atomic::Ordering;
-        if let Some(instant) = poll_at {
-            let _old_instant = self.poll_at_us.load(Ordering::Relaxed);
-            let new_instant = instant.total_micros() as u64;
-            self.poll_at_us.store(new_instant, Ordering::Relaxed);
-
-            // TODO: poll at
-            // if old_instant == 0 || new_instant < old_instant {
-            //     self.polling_wait_queue.wake_all();
-            // }
-        } else {
-            self.poll_at_us.store(0, Ordering::Relaxed);
-        }
+        self.notify_deadline_rearm(deadline_rearm);
 
         // 注意：不要在持有 bounds 读锁(且 irqsave)期间调用 socket.notify()。
         // 否则会形成典型锁顺序反转死锁：
@@ -495,22 +471,21 @@ impl IfaceCommon {
         // （例如 loopback 二次往返、ACK/window update、仅 egress 前进等）。
         // 如果这里只返回 `has_events`，快路径会过早停止，剩余工作只能等下一次外部事件，
         // 在 blocking TCP 大包场景就会表现为 send/recv 偶发永久卡住。
-        has_events || matches!(poll_at, Some(instant) if instant <= timestamp)
+        has_events || poll_again
     }
 
-    /// 返回 smoltcp 计算的“下次需要 poll 的时间点”（微秒时间戳）。
-    ///
-    /// - `None` 表示当前没有定时事件需要驱动。
-    /// - `Some(us)` 表示应当在 `us` 到达时再次 poll，以推进 TCP 定时器等。
+    /// Atomically classify and, when due, claim this interface's future
+    /// protocol deadline.
     #[inline]
-    pub fn poll_at_us(&self) -> Option<u64> {
-        use core::sync::atomic::Ordering;
-        let v = self.poll_at_us.load(Ordering::Relaxed);
-        if v == 0 {
-            None
-        } else {
-            Some(v)
-        }
+    pub fn classify_poll_deadline(&self, now_us: u64) -> DueResult {
+        self.poll_deadline.classify_and_claim(now_us)
+    }
+
+    /// Restore a claimed deadline after a failed scheduler handoff, without
+    /// overwriting a concurrent publisher.
+    #[inline]
+    pub fn restore_poll_deadline(&self, claimed_us: u64) -> bool {
+        self.poll_deadline.restore_claimed_if_empty(claimed_us)
     }
 
     /// NAPI 使用的 bounded poll：最多处理 `budget` 个 ingress 包，然后推进一次 egress。
@@ -548,22 +523,13 @@ impl IfaceCommon {
         // 推进发送路径（smoltcp 保证 bounded work）。
         let _ = interface.poll_egress(timestamp, device, &mut sockets);
 
-        // 更新 poll_at（用于定时驱动 TCP）。
-        use core::sync::atomic::Ordering;
-        let poll_at = match interface.poll_at(timestamp, &sockets) {
-            Some(instant) if instant <= timestamp => Some(timestamp),
-            other => other,
-        };
-        if let Some(instant) = poll_at {
-            self.poll_at_us
-                .store(instant.total_micros() as u64, Ordering::Relaxed);
-        } else {
-            self.poll_at_us.store(0, Ordering::Relaxed);
-        }
+        let poll_at = interface.poll_at(timestamp, &sockets);
+        let (poll_again, deadline_rearm) = self.publish_poll_deadline(timestamp, poll_at);
 
         // 解锁后唤醒/通知 socket（沿用原 poll() 的 Linux-like 语义）。
         drop(interface);
         drop(sockets);
+        self.notify_deadline_rearm(deadline_rearm);
         self.notify_all_bound_sockets();
 
         // NAPI 语义：只要“还有立即可推进的工作”，就应继续留在 poll_list。
@@ -575,11 +541,44 @@ impl IfaceCommon {
         // - 但仍有 ACK / window update / 后续 egress 需要立即发送；
         // - NAPI 线程却错误睡眠，直到下一次外部事件才继续推进，
         //   导致 send done 后 recv 端偶发卡住。
-        napi::NapiPollResult::new(
-            processed,
-            (had_packet && processed == budget)
-                || matches!(poll_at, Some(instant) if instant <= timestamp),
-        )
+        napi::NapiPollResult::new(processed, (had_packet && processed == budget) || poll_again)
+    }
+
+    /// Publish smoltcp's next scheduling decision while both smoltcp
+    /// serialization locks are held.
+    ///
+    /// The returned boolean pair is `(poll_again, deadline_rearm)`.
+    fn publish_poll_deadline(
+        &self,
+        now: smoltcp::time::Instant,
+        poll_at: Option<smoltcp::time::Instant>,
+    ) -> (bool, bool) {
+        match poll_at {
+            Some(instant) if instant <= now => {
+                self.poll_deadline.disarm();
+                (true, false)
+            }
+            Some(instant) => {
+                let now_us = now.total_micros() as u64;
+                let deadline_us = instant.total_micros() as u64;
+                let rearm = self.poll_deadline.publish_future(now_us, deadline_us)
+                    == PublishResult::RearmRequired;
+                (false, rearm)
+            }
+            None => {
+                self.poll_deadline.disarm();
+                (false, false)
+            }
+        }
+    }
+
+    fn notify_deadline_rearm(&self, rearm: bool) {
+        if !rearm {
+            return;
+        }
+        if let Some(netns) = self.net_namespace() {
+            netns.notify_deadline_changed();
+        }
     }
 
     pub fn update_ip_addrs(&self, ip_addrs: &[smoltcp::wire::IpCidr]) -> Result<(), SystemError> {
@@ -674,8 +673,9 @@ impl IfaceCommon {
         &self,
         requested: InterfaceFlags,
         change_mask: InterfaceFlags,
-    ) -> Result<InterfaceFlags, SystemError> {
+    ) -> Result<(InterfaceFlags, InterfaceFlags), SystemError> {
         let mut state = self.receive_mode.lock();
+        let old = InterfaceFlags::from_bits_truncate(state.configured_flags);
         let configured = (state.configured_flags & !change_mask.bits())
             | (requested.bits() & change_mask.bits());
 
@@ -690,7 +690,7 @@ impl IfaceCommon {
 
         state.configured_flags = configured;
         self.publish_effective_flags(&state);
-        Ok(InterfaceFlags::from_bits_truncate(configured))
+        Ok((old, InterfaceFlags::from_bits_truncate(configured)))
     }
 
     pub fn link_flags_snapshot(&self) -> Result<LinkFlagsSnapshot, SystemError> {

--- a/kernel/src/driver/net/napi.rs
+++ b/kernel/src/driver/net/napi.rs
@@ -10,6 +10,7 @@ use alloc::string::ToString;
 use alloc::sync::{Arc, Weak};
 use core::sync::atomic::AtomicU32;
 use napi_state::CompleteState;
+pub(crate) use napi_state::ScheduleState;
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
@@ -155,6 +156,10 @@ fn net_rx_action() {
             let budget = core::cmp::min(napi.weight, packets_left);
             polls_left -= 1;
 
+            if napi_is_disabled(&napi) {
+                continue;
+            }
+
             let Some((iface, result)) = napi.poll(budget) else {
                 // A registered NAPI must not outlive its interface. Clear the state to avoid
                 // retaining an owner forever; device teardown is responsible for stopping DMA.
@@ -214,11 +219,14 @@ pub(crate) fn napi_disable(napi: &NapiStruct) {
     napi_state::disable(&napi.state);
 }
 
-pub(crate) fn napi_schedule_prep(napi: &NapiStruct) -> bool {
+pub(crate) fn napi_schedule_prep(napi: &NapiStruct) -> ScheduleState {
     napi_state::schedule_prep(&napi.state)
 }
 
 pub(crate) fn __napi_schedule(napi: Arc<NapiStruct>) {
+    if napi_is_disabled(&napi) {
+        return;
+    }
     debug_assert_ne!(
         napi.state.load(core::sync::atomic::Ordering::Relaxed) & napi_state::SCHED,
         0
@@ -231,10 +239,24 @@ pub(crate) fn __napi_schedule(napi: Arc<NapiStruct>) {
     GLOBAL_NAPI_MANAGER.wakeup();
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NapiScheduleResult {
+    Accepted,
+    Disabled,
+    Detached,
+}
+
+#[inline]
+pub fn napi_is_disabled(napi: &NapiStruct) -> bool {
+    napi.state.load(core::sync::atomic::Ordering::Acquire) & napi_state::DISABLE != 0
+}
+
 /// Acquire a NAPI owner, let the device mask callbacks, then publish it once.
-pub fn napi_schedule(napi: Arc<NapiStruct>) {
-    if !napi_schedule_prep(&napi) {
-        return;
+pub fn napi_schedule(napi: Arc<NapiStruct>) -> NapiScheduleResult {
+    match napi_schedule_prep(&napi) {
+        ScheduleState::Disabled => return NapiScheduleResult::Disabled,
+        ScheduleState::Missed => return NapiScheduleResult::Accepted,
+        ScheduleState::Acquired => {}
     }
 
     let Some(iface) = napi.net_device.upgrade() else {
@@ -243,10 +265,14 @@ pub fn napi_schedule(napi: Arc<NapiStruct>) {
             napi.napi_id
         );
         napi_disable(&napi);
-        return;
+        return NapiScheduleResult::Detached;
     };
     iface.napi_poll_begin();
+    if napi_is_disabled(&napi) {
+        return NapiScheduleResult::Disabled;
+    }
     __napi_schedule(napi);
+    NapiScheduleResult::Accepted
 }
 
 pub struct NapiManager {

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -35,7 +35,7 @@ use crate::{
         net::{
             napi::{
                 __napi_schedule, napi_complete_state, napi_disable, napi_schedule,
-                napi_schedule_prep, NapiStruct,
+                napi_schedule_prep, NapiStruct, ScheduleState,
             },
             register_netdevice,
             types::InterfaceFlags,
@@ -1234,6 +1234,7 @@ impl Iface for VirtioInterface {
         };
 
         match napi_complete_state(&napi) {
+            CompleteState::Disabled => {}
             CompleteState::Missed => {
                 self.device_inner
                     .inner
@@ -1259,7 +1260,7 @@ impl Iface for VirtioInterface {
                     let has_work = driver.inner.interrupt_pending(interrupt_state)
                         || tx_completed != 0
                         || has_rx;
-                    if has_work && napi_schedule_prep(&napi) {
+                    if has_work && napi_schedule_prep(&napi) == ScheduleState::Acquired {
                         driver.inner.disable_interrupts();
                         acquired = true;
                     }

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -1,8 +1,10 @@
 use crate::{
     driver::net::{
+        napi::napi_schedule,
         types::{InterfaceFlags, InterfaceType},
         Iface, Operstate,
     },
+    libs::mutex::Mutex,
     net::socket::{
         netlink::{
             message::segment::{
@@ -31,6 +33,16 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::num::NonZero;
 use system_error::SystemError;
+
+lazy_static! {
+    /// Serialize RTM_SETLINK transactions through flag publication, operstate,
+    /// timer rearm, rename/MTU updates, and notification.
+    ///
+    /// Linux provides this boundary with RTNL. DragonOS does not yet expose a
+    /// general RTNL lock, so link mutation owns the smallest equivalent
+    /// serialization point here.
+    static ref RTNL_LINK_LOCK: Mutex<()> = Mutex::new(());
+}
 
 pub(super) fn do_get_link(
     request_segment: &LinkSegment,
@@ -196,6 +208,7 @@ pub(super) fn do_set_link(
     request_segment: &LinkSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
+    let _rtnl_guard = RTNL_LINK_LOCK.lock();
     let iface = find_iface_for_setlink(request_segment, netns.clone())?;
     let updates = validate_setlink_request(request_segment, iface.as_ref())?;
 
@@ -211,17 +224,30 @@ pub(super) fn do_set_link(
 
     let change_mask = InterfaceFlags::from_bits_truncate(request_segment.body().change.bits());
     let requested_flags = InterfaceFlags::from_bits_truncate(request_segment.body().flags.bits());
-    let new_flags = iface
+    let (old_flags, new_flags) = iface
         .common()
         .update_configured_flags(requested_flags, change_mask)?;
 
     if change_mask.contains(InterfaceFlags::UP) {
-        let operstate = if new_flags.contains(InterfaceFlags::UP) {
+        let was_up = old_flags.contains(InterfaceFlags::UP);
+        let is_up = new_flags.contains(InterfaceFlags::UP);
+        let operstate = if is_up {
             Operstate::IF_OPER_UP
         } else {
             Operstate::IF_OPER_DOWN
         };
         iface.set_operstate(operstate);
+
+        if was_up != is_up {
+            if is_up {
+                if let Some(napi) = iface.napi_struct() {
+                    napi_schedule(napi);
+                } else {
+                    netns.wakeup_poll_thread();
+                }
+            }
+            netns.notify_deadline_changed();
+        }
     }
 
     if let Some(name) = updates.name {

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -1,5 +1,6 @@
 use crate::driver::net::bridge::BridgeDriver;
 use crate::driver::net::loopback::LoopbackInterface;
+use crate::driver::net::types::InterfaceFlags;
 use crate::init::initcall::INITCALL_SUBSYS;
 use crate::libs::mutex::Mutex;
 use crate::libs::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -21,7 +22,7 @@ use crate::process::ProcessManager;
 use crate::rcu::{RcuArcSlot, RcuOptionArcSlot};
 use crate::time::{Duration, Instant};
 use crate::{
-    driver::net::napi::napi_schedule,
+    driver::net::napi::{napi_is_disabled, napi_schedule, NapiScheduleResult},
     driver::net::Iface,
     process::namespace::{nsproxy::NsCommon, user_namespace::UserNamespace},
 };
@@ -31,9 +32,10 @@ use alloc::string::{String, ToString};
 use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use core::sync::atomic::AtomicU32;
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use hashbrown::HashMap;
 use ida::IdAllocator;
+use net_poll_state::DueResult;
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
@@ -181,6 +183,9 @@ struct NetnsPoller {
     poll_pending: AtomicBool,
     /// Topology cleanup wakes the poller without being treated as network I/O.
     cleanup_pending: AtomicBool,
+    /// Monotonic notification sequence for future protocol deadline changes.
+    /// Unlike `poll_pending`, this only requests a timeout rescan.
+    deadline_generation: AtomicU64,
     /// # 轮询线程的 PCB（用于 stop）
     thread: RwSem<Option<Arc<ProcessControlBlock>>>,
 }
@@ -192,6 +197,7 @@ impl NetnsPoller {
             wait_queue: WaitQueue::default(),
             poll_pending: AtomicBool::new(false),
             cleanup_pending: AtomicBool::new(false),
+            deadline_generation: AtomicU64::new(0),
             thread: RwSem::new(None),
         })
     }
@@ -239,6 +245,33 @@ impl NetnsPoller {
         self.wait_queue.wake_all();
     }
 
+    /// Notify the poller that its previously computed timeout may be stale.
+    ///
+    /// This path is NAPI-safe: it only touches atomics and the wait queue.
+    fn notify_deadline_changed(&self) {
+        self.deadline_generation.fetch_add(1, Ordering::AcqRel);
+        self.wait_queue.wake_all();
+    }
+
+    /// Run one bounded batch for an interface without NAPI.
+    ///
+    /// Returns `true` when the interface still reports immediate work. The
+    /// caller must publish another network wake instead of monopolizing this
+    /// netns worker until quiescence.
+    fn poll_direct_batch(iface: &Arc<dyn Iface>) -> bool {
+        const DIRECT_POLL_BATCH: usize = 64;
+
+        for _ in 0..DIRECT_POLL_BATCH {
+            if !iface.flags().contains(InterfaceFlags::UP) {
+                return false;
+            }
+            if !iface.poll() {
+                return false;
+            }
+        }
+        true
+    }
+
     fn polling(&self) {
         let mut cleanup_retry_delay = PACKET_SOCKET_CLEANUP_RETRY_MIN;
         let mut cleanup_retry_at = None;
@@ -256,8 +289,8 @@ impl NetnsPoller {
             };
 
             let nsid = netns.ns_common.nsid.data();
-            let now_us = Instant::now().total_micros() as u64;
-            if cleanup_retry_at.is_none_or(|deadline| now_us >= deadline) {
+            let cleanup_now_us = Instant::now().total_micros() as u64;
+            if cleanup_retry_at.is_none_or(|deadline| cleanup_now_us >= deadline) {
                 match netns.cleanup_packet_sockets() {
                     PacketSocketCleanupResult::Complete => {
                         cleanup_retry_delay = PACKET_SOCKET_CLEANUP_RETRY_MIN;
@@ -269,7 +302,7 @@ impl NetnsPoller {
                     }
                     PacketSocketCleanupResult::AllocationFailed => {
                         cleanup_retry_at =
-                            Some(now_us.saturating_add(cleanup_retry_delay.total_micros()));
+                            Some(cleanup_now_us.saturating_add(cleanup_retry_delay.total_micros()));
                         cleanup_retry_delay = Duration::from_micros(core::cmp::min(
                             cleanup_retry_delay.total_micros().saturating_mul(2),
                             PACKET_SOCKET_CLEANUP_RETRY_MAX.total_micros(),
@@ -278,42 +311,75 @@ impl NetnsPoller {
                 }
             }
 
-            // 处理“已到期的定时事件”：到期则 schedule NAPI 推进一次。
-            // 同时计算下一次最早到期时间点，用于设置 sleep 超时。
+            // Cleanup may wait on packet-socket ownership. Deadline
+            // classification and timeout calculation must use a fresh clock
+            // sample so time spent there cannot postpone an already-due TCP
+            // timer by one additional timeout interval.
+            let observed_generation = self.deadline_generation.load(Ordering::Acquire);
+            let deadline_now_us = Instant::now().total_micros() as u64;
+
+            // Classify and atomically claim due protocol deadlines. The
+            // device-list lock is only used for topology lookup; no direct
+            // protocol poll or yield is performed while it is held.
             let mut next_us = cleanup_retry_at;
-            let mut had_due = false;
-            for (_, iface) in netns.device_list.read().iter() {
-                if let Some(us) = iface.common().poll_at_us() {
-                    if us <= now_us {
-                        had_due = true;
-                        if let Some(napi) = iface.napi_struct() {
-                            napi_schedule(napi);
-                        } else {
-                            // 兜底：若未配置 NAPI，则仍调用一次 poll 推进（可能无界）。
-                            let _ = iface.poll();
-                        }
+            let mut direct_due = Vec::new();
+            {
+                let devices = netns.device_list.read();
+                for (_, iface) in devices.iter() {
+                    if !iface.flags().contains(InterfaceFlags::UP) {
                         continue;
                     }
 
-                    next_us = Some(match next_us {
-                        Some(cur) => core::cmp::min(cur, us),
-                        None => us,
-                    });
+                    let napi = iface.napi_struct();
+                    if napi.as_deref().is_some_and(napi_is_disabled) {
+                        continue;
+                    }
+
+                    match iface.common().classify_poll_deadline(deadline_now_us) {
+                        DueResult::Disarmed => {}
+                        DueResult::Future(us) => {
+                            next_us = Some(match next_us {
+                                Some(cur) => core::cmp::min(cur, us),
+                                None => us,
+                            });
+                        }
+                        DueResult::Claimed(claimed_us) => match napi {
+                            Some(napi) => match napi_schedule(napi) {
+                                NapiScheduleResult::Accepted => {}
+                                NapiScheduleResult::Disabled | NapiScheduleResult::Detached => {
+                                    iface.common().restore_poll_deadline(claimed_us);
+                                }
+                            },
+                            None => direct_due.push((iface.clone(), claimed_us)),
+                        },
+                    }
                 }
             }
 
-            // sleep 超时：
-            // - 若刚处理了 due timer：小睡一会儿，避免在 NAPI 尚未推进/更新时间戳前重复 schedule 形成忙等
-            // - 否则按最早 deadline 精确睡眠
-            let timeout = if had_due {
-                Some(Duration::from_micros(200))
-            } else {
-                next_us.map(|us| {
-                    let delta = us.saturating_sub(now_us);
-                    Duration::from_micros(core::cmp::max(1, delta))
-                })
-            };
+            if !direct_due.is_empty() {
+                drop(netns);
+                for (iface, claimed_us) in direct_due {
+                    if !iface.flags().contains(InterfaceFlags::UP) {
+                        iface.common().restore_poll_deadline(claimed_us);
+                        continue;
+                    }
+                    if Self::poll_direct_batch(&iface) {
+                        self.notify_network();
+                    }
+                }
+                // A direct poll may have published a new future deadline.
+                // Rescan from a fresh generation snapshot before sleeping.
+                continue;
+            }
 
+            // Scheduling due interfaces can contend on device-side locks and
+            // a namespace may contain many interfaces. Re-sample immediately
+            // before sleeping so scan time is not added to the next deadline.
+            let sleep_now_us = Instant::now().total_micros() as u64;
+            let timeout = next_us.map(|us| {
+                let delta = us.saturating_sub(sleep_now_us);
+                Duration::from_micros(core::cmp::max(1, delta))
+            });
             log::trace!(
                 "netns scheduler sleep: nsid={} timeout_us={:?}",
                 nsid,
@@ -326,44 +392,53 @@ impl NetnsPoller {
             // 等待事件唤醒（IRQ/lo Tx 等）或 timeout（smoltcp timer deadline）。
             // Keep cleanup and network wake reasons separate: only the latter
             // should schedule interface NAPI below.
-            let woke_by_event = match self.wait_queue.wait_event_uninterruptible_timeout(
+            match self.wait_queue.wait_event_uninterruptible_timeout(
                 || {
                     self.poll_pending.load(Ordering::Acquire)
                         || self.cleanup_pending.load(Ordering::Acquire)
+                        || self.deadline_generation.load(Ordering::Acquire) != observed_generation
                 },
                 timeout,
             ) {
-                Ok(()) => true,
-                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => false,
+                Ok(()) | Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {}
                 Err(e) => {
                     log::warn!("netns scheduler sleep error: {:?}", e);
-                    false
                 }
+            }
+
+            let network_pending = self.poll_pending.swap(false, Ordering::AcqRel);
+            self.cleanup_pending.swap(false, Ordering::AcqRel);
+            if KernelThreadMechanism::should_stop(&ProcessManager::current_pcb()) {
+                break;
+            }
+            if !network_pending {
+                continue;
+            }
+
+            let netns = match self.netns.upgrade() {
+                Some(netns) => netns,
+                None => break,
             };
-
-            if woke_by_event {
-                let network_pending = self.poll_pending.swap(false, Ordering::AcqRel);
-                self.cleanup_pending.store(false, Ordering::Release);
-                if KernelThreadMechanism::should_stop(&ProcessManager::current_pcb()) {
-                    break;
-                }
-                if !network_pending {
-                    continue;
-                }
-                let netns = match self.netns.upgrade() {
-                    Some(netns) => netns,
-                    None => {
-                        break;
+            let mut direct_poll = Vec::new();
+            {
+                let devices = netns.device_list.read();
+                // Event-driven work is scheduled once; NAPI performs bounded
+                // polling and records concurrent requests through MISSED.
+                for (_, iface) in devices.iter() {
+                    if !iface.flags().contains(InterfaceFlags::UP) {
+                        continue;
                     }
-                };
-
-                // 事件驱动：尽量只 schedule 一次即可，由 NAPI 线程以 bounded poll 推进。
-                for (_, iface) in netns.device_list.read().iter() {
                     if let Some(napi) = iface.napi_struct() {
                         napi_schedule(napi);
                     } else {
-                        let _ = iface.poll();
+                        direct_poll.push(iface.clone());
                     }
+                }
+            }
+            drop(netns);
+            for iface in direct_poll {
+                if Self::poll_direct_batch(&iface) {
+                    self.notify_network();
                 }
             }
         }
@@ -928,6 +1003,7 @@ impl NetNamespace {
         device.set_net_namespace(self.self_ref.upgrade().unwrap());
 
         self.device_list_mut().insert(device.nic_id(), device);
+        self.notify_deadline_changed();
 
         // log::info!(
         //     "Network device added to namespace count: {:?}",
@@ -936,6 +1012,9 @@ impl NetNamespace {
     }
 
     pub fn remove_device(&self, nic_id: &usize) {
+        // Teardown helper only: the caller must quiesce IRQ, DMA, and NAPI
+        // before removing an active device. Runtime hot-remove is not provided
+        // by this API.
         let removed = self.device_list_mut().remove(nic_id);
         if removed.is_none() {
             return;
@@ -945,6 +1024,7 @@ impl NetNamespace {
             .clear_if_deferred(|current| current.iface.nic_id() == *nic_id);
         self.loopback_iface
             .clear_if_deferred(|current| current.nic_id() == *nic_id);
+        self.notify_deadline_changed();
     }
 
     pub fn insert_bridge(&self, bridge: Arc<BridgeDriver>) {
@@ -967,6 +1047,12 @@ impl NetNamespace {
             }
             log::trace!("netns: wakeup_poll_thread: woken={}", woken);
         }
+    }
+
+    /// Request a deadline-only timeout rescan without treating it as immediate
+    /// network I/O. Safe to call after dropping smoltcp and topology locks.
+    pub fn notify_deadline_changed(&self) {
+        self.poller.notify_deadline_changed();
     }
 
     fn create_polling_thread(netns: Arc<Self>, name: String) {

--- a/user/apps/tests/dunitest/suites/normal/tcp_receive_window_reopen.cc
+++ b/user/apps/tests/dunitest/suites/normal/tcp_receive_window_reopen.cc
@@ -1,0 +1,230 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace {
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    FdGuard(FdGuard&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+    FdGuard& operator=(FdGuard&& other) noexcept {
+        if (this != &other) {
+            if (fd_ >= 0) {
+                close(fd_);
+            }
+            fd_ = other.fd_;
+            other.fd_ = -1;
+        }
+        return *this;
+    }
+    ~FdGuard() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    int Get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+std::string ErrnoString(int err) {
+    return std::to_string(err) + " (" + std::strerror(err) + ")";
+}
+
+struct TcpPair {
+    FdGuard listener;
+    FdGuard sender;
+    FdGuard receiver;
+};
+
+TcpPair MakeTcpPair() {
+    FdGuard listener(socket(AF_INET, SOCK_STREAM, 0));
+    EXPECT_GE(listener.Get(), 0) << ErrnoString(errno);
+
+    sockaddr_in address {};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = 0;
+    EXPECT_EQ(bind(listener.Get(), reinterpret_cast<sockaddr*>(&address), sizeof(address)), 0)
+            << ErrnoString(errno);
+    EXPECT_EQ(listen(listener.Get(), 1), 0) << ErrnoString(errno);
+
+    socklen_t address_len = sizeof(address);
+    EXPECT_EQ(getsockname(listener.Get(), reinterpret_cast<sockaddr*>(&address), &address_len), 0)
+            << ErrnoString(errno);
+
+    FdGuard sender(socket(AF_INET, SOCK_STREAM, 0));
+    EXPECT_GE(sender.Get(), 0) << ErrnoString(errno);
+    EXPECT_EQ(connect(sender.Get(), reinterpret_cast<sockaddr*>(&address), sizeof(address)), 0)
+            << ErrnoString(errno);
+
+    FdGuard receiver(accept(listener.Get(), nullptr, nullptr));
+    EXPECT_GE(receiver.Get(), 0) << ErrnoString(errno);
+
+    return {std::move(listener), std::move(sender), std::move(receiver)};
+}
+
+uint8_t PatternByte(size_t offset) {
+    return static_cast<uint8_t>((offset * 131u + 17u) & 0xffu);
+}
+
+void FillPattern(std::array<uint8_t, 4096>* buffer, size_t offset) {
+    for (size_t index = 0; index < buffer->size(); ++index) {
+        (*buffer)[index] = PatternByte(offset + index);
+    }
+}
+
+void VerifyPattern(const uint8_t* buffer, size_t length, size_t offset) {
+    for (size_t index = 0; index < length; ++index) {
+        ASSERT_EQ(buffer[index], PatternByte(offset + index))
+                << "data mismatch at stream offset " << offset + index;
+    }
+}
+
+}  // namespace
+
+TEST(TcpReceiveWindowReopen, ReceiverProgressMakesBlockedSenderWritable) {
+    for (int iteration = 0; iteration < 4; ++iteration) {
+        TcpPair pair = MakeTcpPair();
+        ASSERT_GE(pair.sender.Get(), 0);
+        ASSERT_GE(pair.receiver.Get(), 0);
+
+        const int flags = fcntl(pair.sender.Get(), F_GETFL, 0);
+        ASSERT_GE(flags, 0) << ErrnoString(errno);
+        ASSERT_EQ(fcntl(pair.sender.Get(), F_SETFL, flags | O_NONBLOCK), 0)
+                << ErrnoString(errno);
+
+        std::array<uint8_t, 4096> write_buffer {};
+        size_t bytes_sent = 0;
+        bool reached_backpressure = false;
+        constexpr size_t kSafetyLimit = 8 * 1024 * 1024;
+
+        while (bytes_sent < kSafetyLimit) {
+            FillPattern(&write_buffer, bytes_sent);
+            const ssize_t written =
+                    send(pair.sender.Get(), write_buffer.data(), write_buffer.size(), MSG_DONTWAIT);
+            if (written > 0) {
+                bytes_sent += static_cast<size_t>(written);
+                continue;
+            }
+            if (written < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                reached_backpressure = true;
+                break;
+            }
+            FAIL() << "send failed while filling the receive window: " << ErrnoString(errno);
+        }
+        ASSERT_TRUE(reached_backpressure)
+                << "sender did not observe backpressure before the safety limit";
+
+        pollfd blocked {.fd = pair.sender.Get(), .events = POLLOUT, .revents = 0};
+        ASSERT_EQ(poll(&blocked, 1, 50), 0)
+                << "sender did not remain backpressured while the receiver was idle, revents="
+                << blocked.revents;
+
+        const int receiver_flags = fcntl(pair.receiver.Get(), F_GETFL, 0);
+        ASSERT_GE(receiver_flags, 0) << ErrnoString(errno);
+        ASSERT_EQ(fcntl(pair.receiver.Get(), F_SETFL, receiver_flags | O_NONBLOCK), 0)
+                << ErrnoString(errno);
+
+        std::array<uint8_t, 32768> read_buffer {};
+        size_t bytes_consumed = 0;
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+
+        // Establish the causal boundary explicitly: drain only receiver data
+        // that is already available before observing sender writability again.
+        // A single fixed-size recv is insufficient on Linux because POLLOUT
+        // depends on the dynamically sized send-buffer low-water threshold.
+        while (std::chrono::steady_clock::now() < deadline) {
+            const ssize_t consumed = recv(
+                    pair.receiver.Get(), read_buffer.data(), read_buffer.size(), MSG_DONTWAIT);
+            if (consumed < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                if (bytes_consumed > 0) {
+                    break;
+                }
+                const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        deadline - std::chrono::steady_clock::now());
+                pollfd readable {.fd = pair.receiver.Get(), .events = POLLIN, .revents = 0};
+                const int ready = poll(
+                        &readable,
+                        1,
+                        static_cast<int>(std::max<int64_t>(1, remaining.count())));
+                ASSERT_GE(ready, 0) << ErrnoString(errno);
+                ASSERT_EQ(readable.revents & (POLLERR | POLLHUP | POLLNVAL), 0);
+                continue;
+            }
+            ASSERT_GT(consumed, 0) << ErrnoString(errno);
+            VerifyPattern(read_buffer.data(), static_cast<size_t>(consumed), bytes_consumed);
+            bytes_consumed += static_cast<size_t>(consumed);
+        }
+        ASSERT_GT(bytes_consumed, 0u) << "receiver did not consume data before the deadline";
+
+        const auto writable_deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        pollfd writable {.fd = pair.sender.Get(), .events = POLLOUT, .revents = 0};
+        const auto writable_remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                writable_deadline - std::chrono::steady_clock::now());
+        const int writable_ready = poll(
+                &writable,
+                1,
+                static_cast<int>(std::max<int64_t>(1, writable_remaining.count())));
+        ASSERT_GE(writable_ready, 0) << ErrnoString(errno);
+        ASSERT_EQ(writable.revents & (POLLERR | POLLHUP | POLLNVAL), 0);
+        EXPECT_NE(writable.revents & POLLOUT, 0)
+                << "sender did not become writable after receiver consumed "
+                << bytes_consumed << " bytes";
+
+        const auto drain_deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (bytes_consumed < bytes_sent &&
+               std::chrono::steady_clock::now() < drain_deadline) {
+            const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    drain_deadline - std::chrono::steady_clock::now());
+            pollfd readable {.fd = pair.receiver.Get(), .events = POLLIN, .revents = 0};
+            const int ready =
+                    poll(&readable, 1, static_cast<int>(std::max<int64_t>(1, remaining.count())));
+            ASSERT_GE(ready, 0) << ErrnoString(errno);
+            ASSERT_EQ(readable.revents & (POLLERR | POLLHUP | POLLNVAL), 0);
+            if ((readable.revents & POLLIN) == 0) {
+                continue;
+            }
+
+            const size_t wanted =
+                    std::min(read_buffer.size(), bytes_sent - bytes_consumed);
+            const ssize_t consumed =
+                    recv(pair.receiver.Get(), read_buffer.data(), wanted, MSG_DONTWAIT);
+            if (consumed < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                continue;
+            }
+            ASSERT_GT(consumed, 0) << ErrnoString(errno);
+            VerifyPattern(
+                    read_buffer.data(), static_cast<size_t>(consumed), bytes_consumed);
+            bytes_consumed += static_cast<size_t>(consumed);
+        }
+
+        EXPECT_EQ(bytes_consumed, bytes_sent)
+                << "receiver did not drain all bytes accepted before backpressure";
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- add a minimal per-interface atomic state for publishing, claiming, and restoring future smoltcp poll deadlines
- wake the network namespace poller when a new, earlier, or replacement deadline requires its timeout to be recomputed
- make NAPI schedule and completion outcomes explicit across scheduled, missed, disabled, and detached states
- serialize RTNETLINK link mutations so UP/DOWN transitions cannot lose NAPI scheduling or deadline rearming
- bound direct polling for interfaces without NAPI so cleanup, shutdown, and other interfaces cannot be starved
- add deterministic state-machine tests and a TCP receive-window regression test

## Root cause

The interface poll owner could publish a future smoltcp deadline after the network namespace poller had already scanned all interfaces and decided to sleep. The deadline value was stored, but there was no reliable handoff that forced the sleeping poller to recompute its timeout.

TCP work such as delayed ACKs, receive-window recovery, retransmission, and deferred close could consequently lose its executor until unrelated ingress or a higher-level timeout happened to drive the stack again. APT partial and pipelined HTTP traffic after cancellation made this visible as long `Waiting for headers` gaps.

## Design

Immediate `PollAt::Now` work remains owned by the caller currently polling smoltcp. Only future deadlines are published to the namespace scheduler.

`PollDeadline` provides the linearization point for deadline publication and due-time claiming. Publishers notify the namespace through a generation counter only when a sleeping poller must rearm. The poller atomically claims due deadlines before scheduling NAPI and restores a claim if the handoff fails without overwriting a concurrent publication.

The timeout clock is sampled again after cleanup and topology scanning, preventing time spent waiting on locks or scanning devices from being added to an already-due deadline. The non-NAPI fallback performs at most 64 direct polls per worker turn and republishes pending work before returning to the main loop.

This does not add periodic polling, per-socket workers, APT-specific behavior, forced connection resets, or HTTP pipeline workarounds.

## User impact

TCP timers and receive-window progress no longer depend on unrelated incoming packets. In controlled APT tests, the previous 30-second no-packet gaps were no longer reproduced across fresh downloads, partial `206` responses, complete-partial `416` responses, default pipelining, and immediate reruns after cancellation. Observed transfer rates returned from the failure range of roughly 96.8–468 kB/s to approximately 1.7–4.2 MB/s.

## Validation

- `make fmt`
- `make kernel`
- `cargo test -p net-poll-state` — 8 passed
- `cargo test -p napi-state` — 8 passed
- Linux host TCP receive-window regression — 4 iterations passed
- DragonOS guest TCP receive-window regression — passed
- DragonOS guest TCP close semantics — 6 passed
- DragonOS guest epoll timeout budget — passed
- DragonOS guest RTNETLINK link semantics — passed
- `git diff --check`

Temporary counters and packet-capture switches used for diagnosis were removed before this commit.
