### PR TITLE
fix(fs): stabilize epoll and namespace lifecycles

### DIFF
--- a/kernel/src/filesystem/epoll/event_poll.rs
+++ b/kernel/src/filesystem/epoll/event_poll.rs
@@ -15,10 +15,7 @@ use crate::{
         Duration, Instant, PosixTimeSpec,
     },
 };
-use core::{
-    fmt::Debug,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use core::fmt::Debug;
 
 use alloc::{
     collections::{BTreeSet, LinkedList},
@@ -77,8 +74,6 @@ pub struct EventPoll {
     ready_state: Arc<SpinLock<ReadyState>>,
     /// 监听本 epollfd 的 epitems（用于支持 epoll 嵌套：epollfd 被加入另一个 epoll）
     pub(super) poll_epitems: Arc<LockedEPItemLinkedList>,
-    /// 是否已经关闭
-    shutdown: AtomicBool,
     self_ref: Option<Weak<Mutex<EventPoll>>>,
 }
 
@@ -96,20 +91,12 @@ impl EventPoll {
                 epoll_wq: WaitQueue::default(),
             })),
             poll_epitems: Arc::new(LockedEPItemLinkedList::default()),
-            shutdown: AtomicBool::new(false),
             self_ref: None,
         }
     }
 
     /// 关闭epoll时，执行的逻辑
     pub(super) fn close(&mut self) -> Result<(), SystemError> {
-        // 唤醒epoll上面等待的所有进程
-        self.shutdown.store(true, Ordering::SeqCst);
-        {
-            let rs = self.ready_state.lock_irqsave();
-            rs.epoll_wq.wakeup_all(None);
-        }
-
         let fds: Vec<i32> = self.ep_items.keys().cloned().collect::<Vec<_>>();
         // 清理红黑树里面的epitems
         for fd in fds {
@@ -455,11 +442,6 @@ impl EventPoll {
                     continue;
                 }
 
-                if epoll.0.lock().shutdown.load(Ordering::SeqCst) {
-                    // 如果已经关闭
-                    return Err(SystemError::EBADF);
-                }
-
                 // 如果超时
                 if timeout {
                     return Ok(0);
@@ -524,9 +506,7 @@ impl EventPoll {
                 {
                     // 注册前再次检查，避免错过事件（仅需 SpinLock）
                     let rs = rs_arc.lock_irqsave();
-                    if Self::ready_state_has_events(&rs)
-                        || epoll.0.lock().shutdown.load(Ordering::SeqCst)
-                    {
+                    if Self::ready_state_has_events(&rs) {
                         available = true;
                         // 不注册，直接继续
                     } else {
@@ -555,10 +535,6 @@ impl EventPoll {
                     let rs = rs_arc.lock_irqsave();
                     rs.epoll_wq.remove_waker(&waker);
                     available = Self::ready_state_has_events(&rs);
-                    if epoll.0.lock().shutdown.load(Ordering::SeqCst) {
-                        // epoll 被关闭，直接退出
-                        return Err(SystemError::EINVAL);
-                    }
                 }
 
                 if let Some(timer) = timer {

--- a/kernel/src/filesystem/procfs/pid/ns.rs
+++ b/kernel/src/filesystem/procfs/pid/ns.rs
@@ -7,12 +7,15 @@ use crate::{
     filesystem::{
         procfs::{
             pid::ProcPidTarget,
-            template::{Builder, DirOps, ProcDir, ProcDirBuilder, ProcSymBuilder, SymOps},
+            template::{
+                Builder, DirOps, FileOps, ProcDir, ProcDirBuilder, ProcFileBuilder, ProcSymBuilder,
+                SymOps,
+            },
             thread_self::NsFileType,
         },
         vfs::{
             file::{FilePrivateData, NamespaceFilePrivateData},
-            IndexNode, InodeId, InodeMode,
+            FileSystem, IndexNode, InodeId, InodeMode, SpecialNodeData,
         },
     },
     process::namespace::{nsproxy::NamespaceId, NamespaceOps},
@@ -25,42 +28,27 @@ use alloc::{
 use core::convert::TryFrom;
 use system_error::SystemError;
 
-/// 获取指定进程的命名空间 ID
-fn get_ns_ino(target: &ProcPidTarget, ns_type: NsFileType) -> Result<usize, SystemError> {
-    let pcb = target.task().ok_or(SystemError::ESRCH)?;
-    let nsproxy = pcb.nsproxy();
-
-    let ino: NamespaceId = match ns_type {
-        NsFileType::Ipc => nsproxy.ipc_ns.ns_common().nsid,
-        NsFileType::Uts => nsproxy.uts_ns.ns_common().nsid,
-        NsFileType::Mnt => nsproxy.mnt_ns.ns_common().nsid,
-        NsFileType::Net => nsproxy.net_ns.ns_common().nsid,
-        NsFileType::Pid => pcb.active_pid_ns().ns_common().nsid,
-        NsFileType::PidForChildren => nsproxy.pid_ns_for_children.ns_common().nsid,
-        NsFileType::Time | NsFileType::TimeForChildren => {
-            // Time namespace 尚未实现
-            NamespaceId::new(0)
-        }
-        NsFileType::User => pcb.cred().user_ns.ns_common().nsid,
-        NsFileType::Cgroup => nsproxy.cgroup_ns.ns_common().nsid,
-    };
-
-    Ok(ino.data())
+#[derive(Debug)]
+struct NamespaceSnapshot {
+    data: NamespaceFilePrivateData,
+    nsid: NamespaceId,
 }
 
-fn namespace_private_data(
+fn namespace_snapshot(
     target: &ProcPidTarget,
     ns_type: NsFileType,
-) -> Result<NamespaceFilePrivateData, SystemError> {
+) -> Result<NamespaceSnapshot, SystemError> {
     let pcb = target.task().ok_or(SystemError::ESRCH)?;
     let nsproxy = pcb.nsproxy();
 
-    let ns_data = match ns_type {
+    let data = match ns_type {
         NsFileType::Ipc => NamespaceFilePrivateData::Ipc(nsproxy.ipc_ns.clone()),
         NsFileType::Uts => NamespaceFilePrivateData::Uts(nsproxy.uts_ns.clone()),
         NsFileType::Mnt => NamespaceFilePrivateData::Mnt(nsproxy.mnt_ns.clone()),
         NsFileType::Net => NamespaceFilePrivateData::Net(nsproxy.net_ns.clone()),
-        NsFileType::Pid => NamespaceFilePrivateData::Pid(pcb.active_pid_ns()),
+        NsFileType::Pid => {
+            NamespaceFilePrivateData::Pid(pcb.try_active_pid_ns().ok_or(SystemError::ESRCH)?)
+        }
         NsFileType::PidForChildren => {
             NamespaceFilePrivateData::PidForChildren(nsproxy.pid_ns_for_children.clone())
         }
@@ -71,7 +59,19 @@ fn namespace_private_data(
         NsFileType::Cgroup => NamespaceFilePrivateData::Cgroup(nsproxy.cgroup_ns.clone()),
     };
 
-    Ok(ns_data)
+    let nsid = match &data {
+        NamespaceFilePrivateData::Ipc(ns) => ns.ns_common().nsid,
+        NamespaceFilePrivateData::Uts(ns) => ns.ns_common().nsid,
+        NamespaceFilePrivateData::Mnt(ns) => ns.ns_common().nsid,
+        NamespaceFilePrivateData::Net(ns) => ns.ns_common().nsid,
+        NamespaceFilePrivateData::Pid(ns) | NamespaceFilePrivateData::PidForChildren(ns) => {
+            ns.ns_common().nsid
+        }
+        NamespaceFilePrivateData::User(ns) => ns.ns_common().nsid,
+        NamespaceFilePrivateData::Cgroup(ns) => ns.ns_common().nsid,
+    };
+
+    Ok(NamespaceSnapshot { data, nsid })
 }
 
 /// /proc/[pid]/ns 目录的 DirOps 实现
@@ -110,7 +110,12 @@ impl DirOps for NsDirOps {
         }
 
         // 创建命名空间符号链接
-        let inode = NsSymOps::new_inode(self.target.clone(), ns_type, dir.self_ref_weak().clone());
+        let inode = NsSymOps::new_inode(
+            self.target.clone(),
+            ns_type,
+            Arc::downgrade(&dir.fs()),
+            dir.self_ref_weak().clone(),
+        );
         cached_children.insert(name.to_string(), inode.clone());
         Ok(inode)
     }
@@ -125,7 +130,12 @@ impl DirOps for NsDirOps {
         for name in NsFileType::ALL_NAMES {
             if let Ok(ns_type) = NsFileType::try_from(name) {
                 cached_children.entry(name.to_string()).or_insert_with(|| {
-                    NsSymOps::new_inode(self.target.clone(), ns_type, dir.self_ref_weak().clone())
+                    NsSymOps::new_inode(
+                        self.target.clone(),
+                        ns_type,
+                        Arc::downgrade(&dir.fs()),
+                        dir.self_ref_weak().clone(),
+                    )
                 });
             }
         }
@@ -137,43 +147,82 @@ impl DirOps for NsDirOps {
 pub struct NsSymOps {
     target: ProcPidTarget,
     ns_type: NsFileType,
+    fs: Weak<dyn FileSystem>,
 }
 
 impl NsSymOps {
     pub fn new_inode(
         target: ProcPidTarget,
         ns_type: NsFileType,
+        fs: Weak<dyn FileSystem>,
         parent: Weak<dyn IndexNode>,
     ) -> Arc<dyn IndexNode> {
-        ProcSymBuilder::new(Self { target, ns_type }, InodeMode::S_IRWXUGO)
-            .parent(parent)
-            .build()
-            .unwrap()
+        ProcSymBuilder::new(
+            Self {
+                target,
+                ns_type,
+                fs,
+            },
+            InodeMode::S_IRWXUGO,
+        )
+        .parent(parent)
+        .build()
+        .unwrap()
+    }
+}
+
+#[derive(Debug)]
+struct NamespaceFileOps {
+    snapshot: NamespaceSnapshot,
+}
+
+impl FileOps for NamespaceFileOps {
+    fn read_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        _buf: &mut [u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EINVAL)
+    }
+
+    fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        **data = FilePrivateData::Namespace(self.snapshot.data.clone());
+        Ok(())
+    }
+
+    fn dynamic_inode_id(&self) -> Option<InodeId> {
+        Some(InodeId::new(self.snapshot.nsid.data()))
     }
 }
 
 impl SymOps for NsSymOps {
     fn read_link(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
-        let ino = get_ns_ino(&self.target, self.ns_type)?;
+        let ino = namespace_snapshot(&self.target, self.ns_type)?.nsid.data();
         let target = format!("{}:[{}]", self.ns_type.name(), ino);
         let len = target.len().min(buf.len());
         buf[..len].copy_from_slice(&target.as_bytes()[..len]);
         Ok(len)
     }
 
-    fn is_self_reference(&self) -> bool {
-        // 命名空间符号链接是自引用的魔法链接
-        true
+    fn special_node(&self) -> Option<SpecialNodeData> {
+        let snapshot = namespace_snapshot(&self.target, self.ns_type).ok()?;
+        let inode = ProcFileBuilder::new(NamespaceFileOps { snapshot }, InodeMode::S_IRUGO)
+            .fs(self.fs.clone())
+            .build()
+            .ok()?;
+        Some(SpecialNodeData::MountProjectedReference(inode))
     }
 
     fn dynamic_inode_id(&self) -> Option<InodeId> {
-        get_ns_ino(&self.target, self.ns_type)
+        namespace_snapshot(&self.target, self.ns_type)
             .ok()
-            .map(InodeId::new)
+            .map(|snapshot| InodeId::new(snapshot.nsid.data()))
     }
 
     fn open(&self, data: &mut MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
-        **data = FilePrivateData::Namespace(namespace_private_data(&self.target, self.ns_type)?);
+        **data = FilePrivateData::Namespace(namespace_snapshot(&self.target, self.ns_type)?.data);
         Ok(())
     }
 }

--- a/kernel/src/filesystem/procfs/pid/ns.rs
+++ b/kernel/src/filesystem/procfs/pid/ns.rs
@@ -15,6 +15,7 @@ use crate::{
         },
         vfs::{
             file::{FilePrivateData, NamespaceFilePrivateData},
+            utils::DName,
             FileSystem, IndexNode, InodeId, InodeMode, SpecialNodeData,
         },
     },
@@ -208,11 +209,19 @@ impl SymOps for NsSymOps {
 
     fn special_node(&self) -> Option<SpecialNodeData> {
         let snapshot = namespace_snapshot(&self.target, self.ns_type).ok()?;
+        let dname = DName::from(format!(
+            "{}:[{}]",
+            self.ns_type.name(),
+            snapshot.nsid.data()
+        ));
         let inode = ProcFileBuilder::new(NamespaceFileOps { snapshot }, InodeMode::S_IRUGO)
             .fs(self.fs.clone())
             .build()
             .ok()?;
-        Some(SpecialNodeData::MountProjectedReference(inode))
+        Some(SpecialNodeData::MountProjectedReference {
+            target: inode,
+            dname,
+        })
     }
 
     fn dynamic_inode_id(&self) -> Option<InodeId> {

--- a/kernel/src/filesystem/procfs/pid/task.rs
+++ b/kernel/src/filesystem/procfs/pid/task.rs
@@ -16,9 +16,10 @@ use crate::{
         },
         vfs::{IndexNode, InodeMode},
     },
-    process::ProcessControlBlock,
+    process::{pid::PidType, ProcessControlBlock, RawPid},
 };
 use alloc::{
+    collections::BTreeMap,
     string::ToString,
     sync::{Arc, Weak},
     vec::Vec,
@@ -42,6 +43,21 @@ impl TaskDirOps {
 
     fn thread_group_leader(&self) -> Option<Arc<ProcessControlBlock>> {
         self.target.thread_group_leader()
+    }
+
+    /// Resolve a live TID in this proc mount's PID namespace and verify that
+    /// it still belongs to the thread group represented by this task directory.
+    fn current_thread_target(&self, tid: RawPid) -> Option<ProcPidTarget> {
+        let leader = self.thread_group_leader()?;
+        let leader_tgid = leader.task_pid_ptr(PidType::TGID)?;
+        let pid = self.target.view_pid_ns().find_pid_in_ns(tid)?;
+        let task = pid.pid_task(PidType::PID)?;
+        let task_tgid = task.task_pid_ptr(PidType::TGID)?;
+        if !Arc::ptr_eq(&leader_tgid, &task_tgid) {
+            return None;
+        }
+
+        Some(ProcPidTarget::new(self.target.view_pid_ns().clone(), pid))
     }
 
     fn thread_targets(&self) -> Vec<ProcPidTarget> {
@@ -84,18 +100,21 @@ impl DirOps for TaskDirOps {
             return Err(SystemError::ESRCH);
         }
 
-        let tid = name.parse::<usize>().map_err(|_| SystemError::ENOENT)?;
-        let target = self
-            .thread_targets()
-            .into_iter()
-            .find(|target| target.vpid().data() == tid)
-            .ok_or(SystemError::ENOENT)?;
+        let tid = name.parse::<RawPid>().map_err(|_| SystemError::ENOENT)?;
 
         let mut cached_children = dir.cached_children().write();
+        let target = self.current_thread_target(tid).ok_or(SystemError::ENOENT)?;
         if let Some(child) = cached_children.get(name) {
-            return Ok(child.clone());
+            if let Some(tid_dir) = child.downcast_ref::<ProcDir<TidDirOps>>() {
+                if tid_dir.ops().represents(&target) {
+                    return Ok(child.clone());
+                }
+            }
         }
 
+        if target.task().is_none() {
+            return Err(SystemError::ENOENT);
+        }
         let inode = TidDirOps::new_inode(target, dir.self_ref_weak().clone());
         cached_children.insert(name.to_string(), inode.clone());
         Ok(inode)
@@ -106,13 +125,57 @@ impl DirOps for TaskDirOps {
             return;
         }
 
+        let targets = self
+            .thread_targets()
+            .into_iter()
+            .map(|target| (target.vpid().to_string(), target))
+            .collect::<BTreeMap<_, _>>();
+
         let mut cached_children = dir.cached_children().write();
-        for target in self.thread_targets() {
-            let tid_str = target.vpid().to_string();
-            cached_children.entry(tid_str).or_insert_with(|| {
-                TidDirOps::new_inode(target.clone(), dir.self_ref_weak().clone())
-            });
+        cached_children.retain(|name, child| {
+            let Some(target) = targets.get(name) else {
+                return false;
+            };
+            child
+                .downcast_ref::<ProcDir<TidDirOps>>()
+                .is_some_and(|tid_dir| tid_dir.ops().represents(target))
+        });
+
+        for (name, target) in targets {
+            let needs_refresh = cached_children
+                .get(&name)
+                .and_then(|child| child.downcast_ref::<ProcDir<TidDirOps>>())
+                .map(|tid_dir| !tid_dir.ops().represents(&target))
+                .unwrap_or(true);
+            if needs_refresh && target.task().is_some() {
+                cached_children.insert(
+                    name,
+                    TidDirOps::new_inode(target, dir.self_ref_weak().clone()),
+                );
+            }
         }
+    }
+
+    fn validate_child(&self, child: &dyn IndexNode) -> bool {
+        let Some(tid_dir) = child.downcast_ref::<ProcDir<TidDirOps>>() else {
+            return true;
+        };
+        let target = &tid_dir.ops().target;
+        let Some(task) = target.task() else {
+            return false;
+        };
+        let Some(task_tgid) = task.task_pid_ptr(PidType::TGID) else {
+            return false;
+        };
+        let Some(leader_tgid) = self
+            .thread_group_leader()
+            .and_then(|leader| leader.task_pid_ptr(PidType::TGID))
+        else {
+            return false;
+        };
+
+        Arc::ptr_eq(target.view_pid_ns(), self.target.view_pid_ns())
+            && Arc::ptr_eq(&task_tgid, &leader_tgid)
     }
 }
 
@@ -129,6 +192,10 @@ impl TidDirOps {
             .volatile()
             .build()
             .unwrap()
+    }
+
+    fn represents(&self, target: &ProcPidTarget) -> bool {
+        self.target.same_pid_object(target)
     }
 
     /// 静态条目表

--- a/kernel/src/filesystem/procfs/template/builder.rs
+++ b/kernel/src/filesystem/procfs/template/builder.rs
@@ -54,6 +54,11 @@ impl<F: FileOps> ProcFileBuilder<F> {
         self.common.set_parent(parent);
         self
     }
+
+    pub fn fs(mut self, fs: Weak<dyn FileSystem>) -> Self {
+        self.common.set_fs(fs);
+        self
+    }
 }
 
 impl<F> Builder<F> for ProcFileBuilder<F>

--- a/kernel/src/filesystem/procfs/template/file.rs
+++ b/kernel/src/filesystem/procfs/template/file.rs
@@ -119,6 +119,11 @@ pub trait FileOps: Sync + Send + Sized + Debug {
     fn owner(&self) -> Option<(usize, usize)> {
         None
     }
+
+    /// Override the generated inode ID for identity-bearing pseudo files.
+    fn dynamic_inode_id(&self) -> Option<crate::filesystem::vfs::InodeId> {
+        None
+    }
 }
 
 /// 为 ProcFile 实现 IndexNode trait
@@ -138,6 +143,9 @@ impl<F: FileOps + 'static> IndexNode for ProcFile<F> {
         if let Some((uid, gid)) = self.inner.owner() {
             metadata.uid = uid;
             metadata.gid = gid;
+        }
+        if let Some(inode_id) = self.inner.dynamic_inode_id() {
+            metadata.inode_id = inode_id;
         }
         Ok(metadata)
     }

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -323,7 +323,12 @@ pub enum SpecialNodeData {
     ///
     /// `MountFSInode` consumes this variant and wraps the raw target in an
     /// anonymous dentry. Raw filesystem walks follow it like `Reference`.
-    MountProjectedReference(Arc<dyn IndexNode>),
+    MountProjectedReference {
+        target: Arc<dyn IndexNode>,
+        /// Stable identity rendered by `/proc/<pid>/fd/<fd>` for the
+        /// anonymous target (for example, `uts:[4026531838]`).
+        dname: utils::DName,
+    },
 }
 
 /* these are defined by POSIX and also present in glibc's dirent.h */
@@ -1775,9 +1780,10 @@ impl dyn IndexNode {
                 // 但它们有一个 special_node 指向真实的 inode
                 let magic_target = match inode.special_node() {
                     Some(SpecialNodeData::Reference(target_inode))
-                    | Some(SpecialNodeData::MountProjectedReference(target_inode)) => {
-                        Some(target_inode)
-                    }
+                    | Some(SpecialNodeData::MountProjectedReference {
+                        target: target_inode,
+                        ..
+                    }) => Some(target_inode),
                     _ => None,
                 };
                 if let Some(target_inode) = magic_target {

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -318,6 +318,12 @@ pub enum SpecialNodeData {
     BlockDevice(Arc<dyn BlockDevice>),
     /// 指向其他 inode 的引用（用于 /proc/self/fd/N 这种魔法链接）
     Reference(Arc<dyn IndexNode>),
+    /// A magic-link target that belongs to the producer's inner filesystem
+    /// and must retain that filesystem's mount projection.
+    ///
+    /// `MountFSInode` consumes this variant and wraps the raw target in an
+    /// anonymous dentry. Raw filesystem walks follow it like `Reference`.
+    MountProjectedReference(Arc<dyn IndexNode>),
 }
 
 /* these are defined by POSIX and also present in glibc's dirent.h */
@@ -1767,7 +1773,14 @@ impl dyn IndexNode {
                 // 首先检查是否是"魔法链接"（如 /proc/self/fd/N）
                 // 这些链接的 readlink 返回的路径可能不可解析（如 pipe:[xxx]），
                 // 但它们有一个 special_node 指向真实的 inode
-                if let Some(SpecialNodeData::Reference(target_inode)) = inode.special_node() {
+                let magic_target = match inode.special_node() {
+                    Some(SpecialNodeData::Reference(target_inode))
+                    | Some(SpecialNodeData::MountProjectedReference(target_inode)) => {
+                        Some(target_inode)
+                    }
+                    _ => None,
+                };
+                if let Some(target_inode) = magic_target {
                     if ownership.is_some() {
                         ownership = Some(utils::ResolvedPath::new(target_inode.clone())?);
                     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -770,6 +770,31 @@ impl VfsDentry {
                     .is_some_and(|mountpoint| mountpoint.dentry.id == self.id)
         })
     }
+
+    /// Create a connected dentry without a directory edge.
+    ///
+    /// Magic-link targets use this to retain a mount projection for open and
+    /// bind mount. Anonymous dentries deliberately never enter the ordinary
+    /// dentry registry and therefore cannot participate in lookup or rename.
+    fn new_anonymous(inode: Arc<dyn IndexNode>) -> Result<Arc<Self>, SystemError> {
+        let metadata = inode.metadata()?;
+        let generation = inode.inode_generation();
+        Ok(Arc::new(Self {
+            id: DentryId::alloc(),
+            inode,
+            registry_child: metadata.inode_id,
+            registry_generation: generation,
+            mount_gate: Mutex::new(()),
+            children_gate: Mutex::new(()),
+            mount_edges: AtomicUsize::new(0),
+            automount_gate: Mutex::new(()),
+            state: Mutex::new(VfsDentryState {
+                name: None,
+                parent: None,
+                disconnected: false,
+            }),
+        }))
+    }
 }
 
 fn dentry_is_descendant_of(dentry: &Arc<VfsDentry>, ancestor: &Arc<VfsDentry>) -> bool {
@@ -3061,6 +3086,21 @@ impl MountFSInode {
         Ok(Self::from_dentry(dentry, mount_fs))
     }
 
+    fn new_anonymous(
+        inner_inode: Arc<dyn IndexNode>,
+        mount_fs: Arc<MountFS>,
+    ) -> Result<Arc<Self>, SystemError> {
+        let dentry = VfsDentry::new_anonymous(inner_inode)?;
+        // Anonymous magic-link targets have no directory edge and therefore
+        // cannot be rediscovered by dentry ID. Caching their wrappers would
+        // retain one stale Weak key for every namespace-link traversal.
+        Ok(Arc::new_cyclic(|self_ref| Self {
+            dentry,
+            mount_fs,
+            self_ref: self_ref.clone(),
+        }))
+    }
+
     fn update_move_dentries(
         source: &Arc<MountFSInode>,
         old_name: DName,
@@ -4402,6 +4442,25 @@ impl IndexNode for MountFSInode {
             {
                 self.self_ref
                     .upgrade()
+                    .map(|inode| super::SpecialNodeData::Reference(inode as Arc<dyn IndexNode>))
+            }
+            Some(super::SpecialNodeData::MountProjectedReference(target)) => {
+                if target.clone().downcast_arc::<MountFSInode>().is_some() {
+                    return Some(super::SpecialNodeData::Reference(target));
+                }
+
+                let target_fs = target.fs();
+                let inner_fs = self.mount_fs.inner_filesystem();
+                if !Arc::ptr_eq(&target_fs, &inner_fs) {
+                    debug_assert!(
+                        false,
+                        "mount-projected magic-link target changed filesystem"
+                    );
+                    return None;
+                }
+
+                Self::new_anonymous(target, self.mount_fs.clone())
+                    .ok()
                     .map(|inode| super::SpecialNodeData::Reference(inode as Arc<dyn IndexNode>))
             }
             other => other,

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -734,6 +734,8 @@ pub struct VfsDentry {
     /// Global fast-path hint; namespace-local checks still inspect topology.
     mount_edges: AtomicUsize,
     automount_gate: Mutex<()>,
+    /// True for a magic-link target that has identity but no directory edge.
+    anonymous: bool,
     state: Mutex<VfsDentryState>,
 }
 
@@ -776,7 +778,7 @@ impl VfsDentry {
     /// Magic-link targets use this to retain a mount projection for open and
     /// bind mount. Anonymous dentries deliberately never enter the ordinary
     /// dentry registry and therefore cannot participate in lookup or rename.
-    fn new_anonymous(inode: Arc<dyn IndexNode>) -> Result<Arc<Self>, SystemError> {
+    fn new_anonymous(inode: Arc<dyn IndexNode>, dname: DName) -> Result<Arc<Self>, SystemError> {
         let metadata = inode.metadata()?;
         let generation = inode.inode_generation();
         Ok(Arc::new(Self {
@@ -788,8 +790,9 @@ impl VfsDentry {
             children_gate: Mutex::new(()),
             mount_edges: AtomicUsize::new(0),
             automount_gate: Mutex::new(()),
+            anonymous: true,
             state: Mutex::new(VfsDentryState {
-                name: None,
+                name: Some(dname),
                 parent: None,
                 disconnected: false,
             }),
@@ -989,6 +992,7 @@ impl SuperBlockState {
             children_gate: Mutex::new(()),
             mount_edges: AtomicUsize::new(0),
             automount_gate: Mutex::new(()),
+            anonymous: false,
             state: Mutex::new(VfsDentryState {
                 name,
                 parent: parent.cloned(),
@@ -2222,6 +2226,18 @@ impl MountFS {
     /// Snapshot-only variant of [`Self::root_path`].  The caller must hold
     /// `DENTRY_TOPOLOGY_LOCK` and the mount lifecycle snapshot.
     pub(crate) fn root_path_from_snapshot(&self) -> Result<String, SystemError> {
+        // Linux nsfs reports an anonymous namespace bind root as
+        // `type:[ino]`, without the slash used by ordinary filesystem paths.
+        if self.root_dentry.anonymous {
+            return self
+                .root_dentry
+                .state
+                .lock()
+                .name
+                .clone()
+                .map(|name| name.to_string())
+                .ok_or(SystemError::EINVAL);
+        }
         let mut current = self.root_dentry.clone();
         let mut parts: Vec<Arc<String>> = Vec::new();
         let mut deleted = false;
@@ -3088,9 +3104,10 @@ impl MountFSInode {
 
     fn new_anonymous(
         inner_inode: Arc<dyn IndexNode>,
+        dname: DName,
         mount_fs: Arc<MountFS>,
     ) -> Result<Arc<Self>, SystemError> {
-        let dentry = VfsDentry::new_anonymous(inner_inode)?;
+        let dentry = VfsDentry::new_anonymous(inner_inode, dname)?;
         // Anonymous magic-link targets have no directory edge and therefore
         // cannot be rediscovered by dentry ID. Caching their wrappers would
         // retain one stale Weak key for every namespace-link traversal.
@@ -3529,6 +3546,19 @@ impl MountFSInode {
     }
 
     pub(crate) fn procfs_path(&self) -> Result<String, SystemError> {
+        // Anonymous magic-link targets have no namespace path. Render the
+        // stable identity captured when the target was resolved, mirroring
+        // Linux d_dname() handling for namespace file descriptors.
+        if self.dentry.anonymous && !self.is_mountpoint_root()? {
+            return self
+                .dentry
+                .state
+                .lock()
+                .name
+                .clone()
+                .map(|name| name.to_string())
+                .ok_or(SystemError::EINVAL);
+        }
         let mut path = self.do_absolute_path_impl(true)?;
         if self.dentry.is_disconnected() {
             path.push_str(" (deleted)");
@@ -4444,7 +4474,7 @@ impl IndexNode for MountFSInode {
                     .upgrade()
                     .map(|inode| super::SpecialNodeData::Reference(inode as Arc<dyn IndexNode>))
             }
-            Some(super::SpecialNodeData::MountProjectedReference(target)) => {
+            Some(super::SpecialNodeData::MountProjectedReference { target, dname }) => {
                 if target.clone().downcast_arc::<MountFSInode>().is_some() {
                     return Some(super::SpecialNodeData::Reference(target));
                 }
@@ -4459,7 +4489,7 @@ impl IndexNode for MountFSInode {
                     return None;
                 }
 
-                Self::new_anonymous(target, self.mount_fs.clone())
+                Self::new_anonymous(target, dname, self.mount_fs.clone())
                     .ok()
                     .map(|inode| super::SpecialNodeData::Reference(inode as Arc<dyn IndexNode>))
             }

--- a/user/apps/tests/dunitest/suites/normal/epoll_ctl_wait_concurrency.cc
+++ b/user/apps/tests/dunitest/suites/normal/epoll_ctl_wait_concurrency.cc
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <thread>
+
+namespace {
+
+constexpr int kEventRounds = 200;
+constexpr int kCtlRounds = 20000;
+constexpr int kMinimumCtlRounds = 100;
+constexpr int kWaitTimeoutMs = 1000;
+constexpr uint64_t kStableSource = 1;
+constexpr uint64_t kCtlSource = 2;
+
+void record_first_error(std::atomic<int>* first_error, int error) {
+    int expected = 0;
+    first_error->compare_exchange_strong(expected, error);
+}
+
+}  // namespace
+
+TEST(EpollCtlWaitConcurrency, StableSourceSurvivesConcurrentCtlUpdates) {
+    int stable_pipe[2] = {-1, -1};
+    int ctl_pipe[2] = {-1, -1};
+    ASSERT_EQ(0, pipe(stable_pipe)) << strerror(errno);
+    ASSERT_EQ(0, pipe(ctl_pipe)) << strerror(errno);
+
+    const int epfd = epoll_create1(EPOLL_CLOEXEC);
+    ASSERT_GE(epfd, 0) << strerror(errno);
+
+    epoll_event stable_event = {};
+    stable_event.events = EPOLLIN;
+    stable_event.data.u64 = kStableSource;
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, stable_pipe[0], &stable_event)) << strerror(errno);
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> event_phase_started{false};
+    std::atomic<bool> abort{false};
+    std::atomic<int> consumed{0};
+    std::atomic<int> completed_ctl_rounds{0};
+    std::atomic<int> first_error{0};
+
+    std::thread producer([&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        while (completed_ctl_rounds.load(std::memory_order_acquire) < kMinimumCtlRounds &&
+               !abort.load()) {
+            std::this_thread::yield();
+        }
+        event_phase_started.store(true, std::memory_order_release);
+        for (int round = 0; round < kEventRounds && !abort.load(); ++round) {
+            const char byte = 'x';
+            if (write(stable_pipe[1], &byte, sizeof(byte)) != 1) {
+                record_first_error(&first_error, errno != 0 ? errno : EIO);
+                return;
+            }
+            while (consumed.load(std::memory_order_acquire) <= round && !abort.load()) {
+                usleep(100);
+            }
+        }
+    });
+
+    std::thread controller([&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        epoll_event event = {};
+        event.events = EPOLLIN;
+        event.data.u64 = kCtlSource;
+        for (int round = 0; round < kCtlRounds && !abort.load(); ++round) {
+            if (epoll_ctl(epfd, EPOLL_CTL_ADD, ctl_pipe[0], &event) != 0) {
+                record_first_error(&first_error, errno);
+                return;
+            }
+            event.events = EPOLLIN | EPOLLET;
+            if (epoll_ctl(epfd, EPOLL_CTL_MOD, ctl_pipe[0], &event) != 0) {
+                record_first_error(&first_error, errno);
+                return;
+            }
+            if (epoll_ctl(epfd, EPOLL_CTL_DEL, ctl_pipe[0], nullptr) != 0) {
+                record_first_error(&first_error, errno);
+                return;
+            }
+            const int completed = completed_ctl_rounds.fetch_add(1, std::memory_order_release) + 1;
+            if (completed == kMinimumCtlRounds) {
+                while (!event_phase_started.load(std::memory_order_acquire) && !abort.load()) {
+                    std::this_thread::yield();
+                }
+            }
+            event.events = EPOLLIN;
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    int wait_error = 0;
+    for (int round = 0; round < kEventRounds; ++round) {
+        epoll_event event = {};
+        const int ready = epoll_wait(epfd, &event, 1, kWaitTimeoutMs);
+        if (ready != 1 || event.data.u64 != kStableSource) {
+            wait_error = ready < 0 ? errno : ETIMEDOUT;
+            break;
+        }
+
+        char byte = 0;
+        if (read(stable_pipe[0], &byte, sizeof(byte)) != 1) {
+            wait_error = errno != 0 ? errno : EIO;
+            break;
+        }
+        consumed.fetch_add(1, std::memory_order_release);
+    }
+
+    abort.store(true, std::memory_order_release);
+    producer.join();
+    controller.join();
+
+    EXPECT_EQ(0, wait_error) << "epoll_wait failed or lost the stable source: "
+                             << strerror(wait_error);
+    EXPECT_EQ(0, first_error.load())
+        << "producer or epoll_ctl failed: " << strerror(first_error.load());
+    EXPECT_EQ(kEventRounds, consumed.load());
+    EXPECT_GE(completed_ctl_rounds.load(), kMinimumCtlRounds);
+
+    close(epfd);
+    close(stable_pipe[0]);
+    close(stable_pipe[1]);
+    close(ctl_pipe[0]);
+    close(ctl_pipe[1]);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
@@ -7,6 +7,7 @@
 #include <pthread.h>
 #include <sched.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string>
 #include <string.h>
 #include <sys/mount.h>
@@ -15,6 +16,7 @@
 #include <sys/statfs.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <sys/wait.h>
 #include <sys/xattr.h>
 #include <time.h>
@@ -60,6 +62,33 @@ static bool path_exists(const char *path) {
     struct stat st;
     return stat(path, &st) == 0;
 }
+
+static bool running_on_dragonos() {
+    struct utsname value {};
+    return uname(&value) == 0 &&
+           (strstr(value.release, "dragonos") != nullptr ||
+            strstr(value.nodename, "dragonos") != nullptr);
+}
+
+struct NamespaceBindCleanup {
+    std::string target;
+    std::string directory;
+    int original_fd = -1;
+    int target_fd = -1;
+    bool switched = false;
+    bool mounted = false;
+
+    ~NamespaceBindCleanup() {
+        if (switched && original_fd >= 0) {
+            setns(original_fd, CLONE_NEWUTS);
+        }
+        if (target_fd >= 0) close(target_fd);
+        if (original_fd >= 0) close(original_fd);
+        if (mounted) umount2(target.c_str(), MNT_DETACH);
+        if (!target.empty()) unlink(target.c_str());
+        if (!directory.empty()) rmdir(directory.c_str());
+    }
+};
 
 static bool mount_has_option(const char *mountpoint, const char *option) {
     FILE *fp;
@@ -1406,6 +1435,98 @@ TEST(MountReconfigure, BindNamespaceOverOpenFileKeepsOpenFileIoFs) {
     unlink(target);
     ASSERT_EQ(0, umount(base)) << strerror(errno);
     rmdir(base);
+}
+
+TEST(MountReconfigure, BoundNamespaceSurvivesSourceTaskExit) {
+    if (unshare(CLONE_NEWNS) != 0) {
+        if (errno == EPERM && !running_on_dragonos()) {
+            GTEST_SKIP() << "mount namespace unavailable: " << strerror(errno);
+        }
+        FAIL() << "unshare(CLONE_NEWNS): " << strerror(errno);
+    }
+    ASSERT_EQ(0, mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL)) << strerror(errno);
+
+    char directory[] = "/tmp/dunitest-ns-pin-XXXXXX";
+    ASSERT_NE(nullptr, mkdtemp(directory)) << strerror(errno);
+
+    NamespaceBindCleanup cleanup;
+    cleanup.directory = directory;
+    cleanup.target = cleanup.directory + "/uts";
+    int placeholder = open(cleanup.target.c_str(), O_CREAT | O_RDONLY | O_CLOEXEC, 0600);
+    ASSERT_GE(placeholder, 0) << strerror(errno);
+    close(placeholder);
+    // Cleanup may always attempt umount; this also covers a worker failure
+    // after mount succeeds but before it reports completion.
+    cleanup.mounted = true;
+
+    cleanup.original_fd = open("/proc/self/ns/uts", O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(cleanup.original_fd, 0) << strerror(errno);
+    struct stat original_stat {};
+    ASSERT_EQ(0, fstat(cleanup.original_fd, &original_stat)) << strerror(errno);
+
+    int result_pipe[2];
+    ASSERT_EQ(0, pipe2(result_pipe, O_CLOEXEC)) << strerror(errno);
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        close(result_pipe[0]);
+        if (unshare(CLONE_NEWUTS) != 0) _exit(errno == EPERM ? 77 : 79);
+
+        int source_fd = open("/proc/self/ns/uts", O_RDONLY | O_CLOEXEC);
+        if (source_fd < 0) _exit(80);
+        struct stat source_stat {};
+        if (fstat(source_fd, &source_stat) != 0) _exit(81);
+        close(source_fd);
+
+        if (mount("/proc/self/ns/uts", cleanup.target.c_str(), NULL, MS_BIND, NULL) != 0) {
+            _exit(errno == EPERM ? 78 : 82);
+        }
+        if (write(result_pipe[1], &source_stat.st_ino, sizeof(source_stat.st_ino)) !=
+            static_cast<ssize_t>(sizeof(source_stat.st_ino))) {
+            _exit(83);
+        }
+        close(result_pipe[1]);
+        _exit(0);
+    }
+
+    close(result_pipe[1]);
+    ino_t source_ino = 0;
+    ssize_t result_size = read(result_pipe[0], &source_ino, sizeof(source_ino));
+    close(result_pipe[0]);
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    ASSERT_TRUE(WIFEXITED(status));
+    const int exit_code = WEXITSTATUS(status);
+    if ((exit_code == 77 || exit_code == 78) && !running_on_dragonos()) {
+        GTEST_SKIP() << "namespace bind unavailable";
+    }
+    ASSERT_EQ(0, exit_code) << "namespace worker failed with code " << exit_code;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(source_ino)), result_size);
+
+    const std::string stale_source = "/proc/" + std::to_string(child) + "/ns/uts";
+    errno = 0;
+    EXPECT_EQ(-1, access(stale_source.c_str(), F_OK));
+    EXPECT_EQ(ENOENT, errno);
+
+    struct stat persistent_stat {};
+    ASSERT_EQ(0, stat(cleanup.target.c_str(), &persistent_stat)) << strerror(errno);
+    EXPECT_EQ(source_ino, persistent_stat.st_ino);
+    EXPECT_NE(original_stat.st_ino, persistent_stat.st_ino);
+
+    cleanup.target_fd = open(cleanup.target.c_str(), O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(cleanup.target_fd, 0) << strerror(errno);
+    ASSERT_EQ(0, setns(cleanup.target_fd, CLONE_NEWUTS)) << strerror(errno);
+    cleanup.switched = true;
+
+    struct stat selected_stat {};
+    ASSERT_EQ(0, stat("/proc/self/ns/uts", &selected_stat)) << strerror(errno);
+    EXPECT_EQ(source_ino, selected_stat.st_ino);
+
+    ASSERT_EQ(0, setns(cleanup.original_fd, CLONE_NEWUTS)) << strerror(errno);
+    cleanup.switched = false;
+    struct stat restored_stat {};
+    ASSERT_EQ(0, stat("/proc/self/ns/uts", &restored_stat)) << strerror(errno);
+    EXPECT_EQ(original_stat.st_ino, restored_stat.st_ino);
 }
 
 TEST(MountReconfigure, ProcFdMagicLinkKeepsReferencedMountProjection) {

--- a/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
+++ b/user/apps/tests/dunitest/suites/normal/mount_reconfigure.cc
@@ -4,6 +4,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <pthread.h>
 #include <sched.h>
 #include <stdio.h>
@@ -135,6 +136,35 @@ static bool mount_has_option(const char *mountpoint, const char *option) {
         break;
     }
 
+    free(line);
+    fclose(fp);
+    return found;
+}
+
+static bool mountinfo_root_for(const std::string &mountpoint, std::string *root) {
+    FILE *fp = fopen("/proc/self/mountinfo", "r");
+    if (fp == nullptr) return false;
+
+    char *line = nullptr;
+    size_t cap = 0;
+    bool found = false;
+    while (getline(&line, &cap, fp) > 0) {
+        char *saveptr = nullptr;
+        char *field = strtok_r(line, " ", &saveptr);  // mount ID
+        if (field == nullptr) continue;
+        field = strtok_r(nullptr, " ", &saveptr);  // parent ID
+        if (field == nullptr) continue;
+        field = strtok_r(nullptr, " ", &saveptr);  // major:minor
+        if (field == nullptr) continue;
+        char *mount_root = strtok_r(nullptr, " ", &saveptr);
+        char *current_mountpoint = strtok_r(nullptr, " ", &saveptr);
+        if (mount_root != nullptr && current_mountpoint != nullptr &&
+            mountpoint == current_mountpoint) {
+            *root = mount_root;
+            found = true;
+            break;
+        }
+    }
     free(line);
     fclose(fp);
     return found;
@@ -1464,6 +1494,15 @@ TEST(MountReconfigure, BoundNamespaceSurvivesSourceTaskExit) {
     struct stat original_stat {};
     ASSERT_EQ(0, fstat(cleanup.original_fd, &original_stat)) << strerror(errno);
 
+    char proc_fd[64];
+    ASSERT_GT(snprintf(proc_fd, sizeof(proc_fd), "/proc/self/fd/%d", cleanup.original_fd), 0);
+    char namespace_identity[128] = {};
+    const ssize_t identity_len =
+        readlink(proc_fd, namespace_identity, sizeof(namespace_identity) - 1);
+    ASSERT_GT(identity_len, 0) << strerror(errno);
+    namespace_identity[identity_len] = '\0';
+    EXPECT_EQ("uts:[" + std::to_string(original_stat.st_ino) + "]", namespace_identity);
+
     int result_pipe[2];
     ASSERT_EQ(0, pipe2(result_pipe, O_CLOEXEC)) << strerror(errno);
     pid_t child = fork();
@@ -1512,9 +1551,18 @@ TEST(MountReconfigure, BoundNamespaceSurvivesSourceTaskExit) {
     ASSERT_EQ(0, stat(cleanup.target.c_str(), &persistent_stat)) << strerror(errno);
     EXPECT_EQ(source_ino, persistent_stat.st_ino);
     EXPECT_NE(original_stat.st_ino, persistent_stat.st_ino);
+    std::string mountinfo_root;
+    ASSERT_TRUE(mountinfo_root_for(cleanup.target, &mountinfo_root));
+    EXPECT_EQ("uts:[" + std::to_string(source_ino) + "]", mountinfo_root);
 
     cleanup.target_fd = open(cleanup.target.c_str(), O_RDONLY | O_CLOEXEC);
     ASSERT_GE(cleanup.target_fd, 0) << strerror(errno);
+    ASSERT_GT(snprintf(proc_fd, sizeof(proc_fd), "/proc/self/fd/%d", cleanup.target_fd), 0);
+    char bound_path[PATH_MAX] = {};
+    const ssize_t bound_path_len = readlink(proc_fd, bound_path, sizeof(bound_path) - 1);
+    ASSERT_GT(bound_path_len, 0) << strerror(errno);
+    bound_path[bound_path_len] = '\0';
+    EXPECT_EQ(cleanup.target, bound_path);
     ASSERT_EQ(0, setns(cleanup.target_fd, CLONE_NEWUTS)) << strerror(errno);
     cleanup.switched = true;
 

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -14,6 +14,7 @@ normal/syncfs_semantics
 normal/fcntl_lock
 normal/fcntl_signal
 normal/epoll_timeout_budget
+normal/epoll_ctl_wait_concurrency
 normal/devpts_dir_read
 normal/debugfs_mount
 normal/fuse_stats_debugfs


### PR DESCRIPTION
## Summary

- remove an epoll wait-path lock inversion that could schedule while an irqsave spin lock was held
- refresh `/proc/<tgid>/task/<tid>` entries by PID object identity and thread-group ownership
- make proc namespace magic links resolve to namespace-backed files whose bind mounts outlive the source task
- preserve mount ownership through an explicit anonymous magic-link projection without retaining registry or wrapper-cache entries
- add focused dunitest coverage for concurrent epoll control/wait and namespace bind lifetime

## Root cause

CubeSandbox container creation exposed three independent lifecycle failures in sequence:

1. `epoll_wait` read an outer sleeping mutex while holding the ready-state irqsave spin lock. Mutex contention could enter the scheduler with preemption disabled and panic.
2. `/proc/<tgid>/task/<tid>` cached numeric TID directories without revalidating the underlying PID object. A recycled TID could therefore resolve the directory for an exited thread and fail namespace lookup with `ESRCH`.
3. Namespace bind mounts retained the proc symlink inode, which still resolved namespace state through the source task. Once the short-lived source task exited, reopening the persistent namespace mount failed with `ESRCH`.

## Implementation

- remove the redundant epoll shutdown state; file reference ownership already prevents final close from racing an active wait
- keep the final ready check and waiter registration in one ready-state critical section without acquiring a sleeping mutex
- revalidate task-directory cache entries using PID object identity, the proc view PID namespace, and TGID ownership
- snapshot namespace data and inode identity from the same strong namespace reference, using the fallible PID namespace lookup during task exit
- introduce an explicit mount-projected magic-link reference for namespace targets
- create anonymous mount dentries that do not enter the normal dentry registry or wrapper cache, so persistent bind mounts pin the namespace without retaining the source task or accumulating stale weak entries

## Validation

- `make fmt`
- `make kernel`
- DragonOS proc PID/TID reuse suite: 3/3 passed
- DragonOS UTS namespace suite: 4/4 passed
- DragonOS mount reconfiguration suite: 27 passed, 1 unrelated existing xattr capability test skipped
- DragonOS epoll control/wait concurrency test passed
- Linux comparison smoke: namespace bind/proc-fd projection passed; epoll concurrency test passed repeatedly
- CubeSandbox final-kernel create/exec/destroy validation: 5/5 passed with no kernel panic, namespace `ESRCH`, preemption assertion, or request timeout
