### PR TITLE
test(procfs): cover TID reuse refreshing task namespace directory

### DIFF
--- a/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
@@ -2,9 +2,12 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -74,6 +77,51 @@ void release_child(pid_t child, int release_fd) {
     int status = 0;
     while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
     }
+}
+
+bool is_dragonos() {
+    utsname uts = {};
+    if (uname(&uts) != 0) {
+        return false;
+    }
+    return strstr(uts.release, "dragonos") != nullptr ||
+           strstr(uts.nodename, "dragonos") != nullptr;
+}
+
+struct NamespaceThreadResult {
+    const char* ns_name = nullptr;
+    pid_t tid = -1;
+    int open_errno = 0;
+    bool opened = false;
+    bool link_read = false;
+};
+
+void* open_thread_namespace(void* opaque) {
+    auto* result = static_cast<NamespaceThreadResult*>(opaque);
+    result->tid = static_cast<pid_t>(syscall(SYS_gettid));
+
+    char path[128] = {};
+    snprintf(path, sizeof(path), "/proc/%d/task/%d/ns/%s", getpid(), result->tid,
+             result->ns_name);
+
+    const int fd = open(path, O_RDONLY);
+    result->open_errno = errno;
+    if (fd >= 0) {
+        result->opened = true;
+        close(fd);
+    }
+
+    char target[128] = {};
+    result->link_read = readlink(path, target, sizeof(target)) > 0;
+    return nullptr;
+}
+
+bool run_namespace_thread(NamespaceThreadResult* result) {
+    pthread_t thread = {};
+    if (pthread_create(&thread, nullptr, open_thread_namespace, result) != 0) {
+        return false;
+    }
+    return pthread_join(thread, nullptr) == 0;
 }
 
 }  // namespace
@@ -176,6 +224,51 @@ TEST(ProcPidReuseCache, ZombieFdEntriesDisappearWithEnoent) {
     } while (waited < 0 && errno == EINTR);
     EXPECT_EQ(child, waited);
     ASSERT_TRUE(became_zombie) << "child did not become observable as a zombie";
+}
+
+TEST(ProcPidReuseCache, ReusedTidRefreshesTaskNamespaceDirectory) {
+    NamespaceThreadResult first;
+    first.ns_name = "ipc";
+    ASSERT_TRUE(run_namespace_thread(&first));
+    ASSERT_GT(first.tid, 0);
+    ASSERT_TRUE(first.opened)
+        << "initial namespace open failed: errno=" << first.open_errno << " ("
+        << strerror(first.open_errno) << ")";
+    ASSERT_TRUE(first.link_read);
+
+    char stale_path[96] = {};
+    snprintf(stale_path, sizeof(stale_path), "/proc/%d/task/%d", getpid(), first.tid);
+    errno = 0;
+    const int stale_fd = open(stale_path, O_RDONLY | O_DIRECTORY);
+    EXPECT_EQ(-1, stale_fd);
+    EXPECT_EQ(ENOENT, errno);
+    if (stale_fd >= 0) {
+        close(stale_fd);
+    }
+
+    constexpr int kMaxReuseAttempts = 128;
+    bool observed_reuse = false;
+    for (int attempt = 0; attempt < kMaxReuseAttempts; ++attempt) {
+        NamespaceThreadResult replacement;
+        replacement.ns_name = "uts";
+        ASSERT_TRUE(run_namespace_thread(&replacement));
+        ASSERT_TRUE(replacement.opened)
+            << "replacement namespace open failed: tid=" << replacement.tid
+            << " errno=" << replacement.open_errno << " (" << strerror(replacement.open_errno)
+            << ")";
+        ASSERT_TRUE(replacement.link_read);
+
+        if (replacement.tid == first.tid) {
+            observed_reuse = true;
+            break;
+        }
+    }
+
+    if (!observed_reuse && !is_dragonos()) {
+        GTEST_SKIP() << "Linux does not guarantee TID reuse within a small fixed attempt budget";
+    }
+    EXPECT_TRUE(observed_reuse) << "DragonOS did not reuse the released TID within "
+                                << kMaxReuseAttempts << " attempts";
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- add a `ReusedTidRefreshesTaskNamespaceDirectory` dunitest to the `proc_pid_reuse_cache` suite
- verify `/proc/<pid>/task/<tid>/ns/<name>` entries follow TID reuse instead of resolving through a stale cached directory
- gate the reuse assertion to DragonOS, since Linux does not guarantee TID reuse within a small fixed attempt budget

## Implementation

- spawn a thread and open/readlink its IPC namespace file under `/proc/<pid>/task/<tid>/ns/`
- after the thread exits, confirm the per-TID task directory returns `ENOENT`
- reuse the released TID across up to 128 replacement threads and assert the task directory plus its UTS namespace links resolve to the new thread
- on kernels other than DragonOS, skip the reuse assertion with `GTEST_SKIP` when reuse is not observed

## Validation

- `normal/proc_pid_reuse_cache` is whitelisted, so the new test runs in DragonOS CI